### PR TITLE
ci: cancel superseded runs and cap build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,14 @@ on:
 env:
   ELAN_NO_OVERRIDE_NOTICE: 1
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add a per-branch `concurrency` group with `cancel-in-progress` so a new push to a ref supersedes the still-running build on that ref (no zombie runs once main is protected and PRs see frequent fixup pushes).
- Add `timeout-minutes: 120` to the build job (matching `docs.yml`) to bound runaway proofs instead of the 6h default.

## Notes
- Pure scheduling/cost change — does not alter what CI checks.
- Mirrors the concurrency pattern already used in `docs.yml`.

## Test plan
- [ ] CI runs green on this PR.
- [ ] Push a second commit and confirm the first run is auto-cancelled.