### PR TITLE
ci(docs): nightly build + regenerate bibliography in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,8 @@
 name: Build and Deploy Docs
 
 on:
-  push:
-    branches: [main]
+  schedule:
+    - cron: '0 4 * * *'  # nightly at 04:00 UTC
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- **Cadence**: `docs.yml` ran a full doc-gen4 + Hugo + Pages deploy on every push to `main` (120-min cap). Switch to a **nightly cron (04:00 UTC)** + `workflow_dispatch`, mirroring mathlib keeping doc generation off the per-merge path.
- **Bibliography becomes a build artifact**: `blog/content/bibliography.md` (generated from `references.bib` by `gen_bibliography.py`) was tracked only so the deployed blog had it — a constant churn / merge-conflict source. Regenerate it in the workflow before the Hugo build; `git rm --cached` + gitignore the rendered output.

## Notes
- Scheduled workflows only run from the default branch, so the nightly cadence takes effect once merged to `main`.
- The required PR check (`ci.yml` `build`) is unaffected — it never built docs.
- `gen_bibliography.py` is stdlib-only (no pip step); `--check` validation remains available.

## Test plan
- [x] `python3 blog/scripts/gen_bibliography.py` runs clean (wrote 2387 entries).
- [x] YAML changes only; no Lean build logic touched.