### PR TITLE
refactor(Typology/Pronoun): split lexical core from WALS survey

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -14,6 +14,7 @@ import Linglib.Features.ClauseForm
 import Linglib.Features.Clusivity
 import Linglib.Syntax.Common.Inversion
 import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 import Linglib.Core.Logic.FactorsThroughOn
 import Linglib.Core.Logic.Truth3
 import Linglib.Core.Logic.Consequence

--- a/Linglib/Fragments/Arabic/Egyptian/Pronouns.lean
+++ b/Linglib/Fragments/Arabic/Egyptian/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # Arabic (Egyptian) pronoun profile (WALS Chs 39, 40, 44–48)

--- a/Linglib/Fragments/Arabic/ModernStandard/Pronouns.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # Modern Standard Arabic Pronoun Profile (WALS Chs 39, 40, 44–48; Chs 136–137)

--- a/Linglib/Fragments/English/Pronouns.lean
+++ b/Linglib/Fragments/English/Pronouns.lean
@@ -7,6 +7,7 @@ Lexical entries for English pronouns (personal, reflexive, wh-).
 import Linglib.Core.Word
 import Linglib.Features.Case
 import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 namespace Fragments.English.Pronouns
 

--- a/Linglib/Fragments/Finnish/Pronouns.lean
+++ b/Linglib/Fragments/Finnish/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # Finnish pronoun profile (WALS Chs 39, 40, 44–48)

--- a/Linglib/Fragments/French/Pronouns.lean
+++ b/Linglib/Fragments/French/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # French pronoun profile (WALS Chs 39, 40, 44–48)

--- a/Linglib/Fragments/German/Pronouns.lean
+++ b/Linglib/Fragments/German/Pronouns.lean
@@ -1,5 +1,5 @@
 import Linglib.Typology.Pronoun.Basic
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # German Pronoun Fragment

--- a/Linglib/Fragments/HindiUrdu/Pronouns.lean
+++ b/Linglib/Fragments/HindiUrdu/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # Hindi/Urdu pronoun profile (WALS Chs 39, 40, 44–48)

--- a/Linglib/Fragments/Hungarian/Pronouns.lean
+++ b/Linglib/Fragments/Hungarian/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # Hungarian pronoun profile (WALS Chs 39, 40, 44–48)

--- a/Linglib/Fragments/Japanese/Pronouns.lean
+++ b/Linglib/Fragments/Japanese/Pronouns.lean
@@ -11,6 +11,7 @@ traditional Japanese relies heavily on null reference.
 -/
 
 import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 import Linglib.Typology.Pronoun.Basic
 
 namespace Fragments.Japanese.Pronouns

--- a/Linglib/Fragments/Korean/Pronouns.lean
+++ b/Linglib/Fragments/Korean/Pronouns.lean
@@ -40,6 +40,7 @@ much of the linguistics literature) appear in docstrings only.
 -/
 
 import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 import Linglib.Typology.Pronoun.Basic
 
 namespace Fragments.Korean.Pronouns

--- a/Linglib/Fragments/Mandarin/Pronouns.lean
+++ b/Linglib/Fragments/Mandarin/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # Mandarin pronoun profile (WALS Chs 39, 40, 44–48)

--- a/Linglib/Fragments/Slavic/Russian/Pronouns.lean
+++ b/Linglib/Fragments/Slavic/Russian/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # Russian pronoun profile (WALS Chs 39, 40, 44–48)

--- a/Linglib/Fragments/Spanish/Pronouns.lean
+++ b/Linglib/Fragments/Spanish/Pronouns.lean
@@ -1,4 +1,5 @@
 import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 import Linglib.Typology.Pronoun.Basic
 
 /-!

--- a/Linglib/Fragments/Swahili/Pronouns.lean
+++ b/Linglib/Fragments/Swahili/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # Swahili pronoun profile (WALS Chs 39, 40, 44–48)

--- a/Linglib/Fragments/Tagalog/Pronouns.lean
+++ b/Linglib/Fragments/Tagalog/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 import Linglib.Features.Clusivity
 import Linglib.Features.Person
 

--- a/Linglib/Fragments/Turkish/Pronouns.lean
+++ b/Linglib/Fragments/Turkish/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 /-!
 # Turkish pronoun profile (WALS Chs 39, 40, 44–48)

--- a/Linglib/Typology/Pronoun/Basic.lean
+++ b/Linglib/Typology/Pronoun/Basic.lean
@@ -1,188 +1,42 @@
-import Linglib.Data.WALS.Features.F39A
-import Linglib.Data.WALS.Features.F39B
-import Linglib.Data.WALS.Features.F40A
-import Linglib.Data.WALS.Features.F44A
-import Linglib.Data.WALS.Features.F45A
-import Linglib.Data.WALS.Features.F46A
-import Linglib.Data.WALS.Features.F47A
-import Linglib.Data.WALS.Features.F48A
-import Linglib.Data.WALS.Features.F136A
-import Linglib.Data.WALS.Features.F136B
-import Linglib.Data.WALS.Features.F137A
-import Linglib.Data.WALS.Features.F137B
 import Linglib.Core.Word
 import Linglib.Features.Case
 import Linglib.Features.Register
 import Linglib.Features.Prominence
 import Linglib.Features.Gender
-import Linglib.Features.Clusivity
-import Mathlib.Order.Basic
 
 /-!
 # Pronoun
 
-Descriptive substrate for the pronoun as a grammatical object, gathering its
-facets: the lexical `Entry` schema fragments instantiate, the structural
-`Strength` (deficiency) classification, and the cross-linguistic typological
-survey (per-language `Profile` + phonological-shape patterns).
+Lexical core for the pronoun as a grammatical object: the `Entry` schema
+fragments instantiate, allocutive markers, the `Spec` referent-preference type,
+and @cite{cardinaletti-starke-1999}'s `Strength` deficiency classification.
 
 Cross-categorial features a pronoun carries — `Person`, `Number`, `Gender`,
 `Case` — are not redefined here; they live under `Features/` and are composed
-in as `Entry` fields.
+in as `Entry` fields. The cross-linguistic WALS typological survey (per-language
+`Profile`, phonological-shape patterns) is a separately-importable facet in
+`Typology/Pronoun/Survey.lean`.
 
 ## Main declarations
 
 * `Pronoun.Entry` — cross-linguistic lexical pronoun entry (form + features).
 * `Pronoun.Strength` — @cite{cardinaletti-starke-1999} strong/weak/clitic
-  deficiency order. Orthogonal to @cite{dechaine-wiltschko-2002}'s categorial
-  pro-DP/φP/NP axis; a framework's structural account of the order stays in its
-  study file.
-* `Pronoun.Profile` — per-language pronoun-system survey across @cite{wals-2013}
-  Chs 39–48 (incl/excl, gender, politeness, indefinite strategy,
-  intensifier–reflexive, adpositional person marking).
+  deficiency order (via `Strength.rank`). Orthogonal to
+  @cite{dechaine-wiltschko-2002}'s categorial pro-DP/φP/NP axis; a framework's
+  structural account of the order stays in its study file.
 * `Pronoun.AllocutiveEntry` — speaker–addressee (allocutive) markers.
-
-## Implementation notes
-
-The typological survey is a *facet* of the pronoun object, hence `Pronoun.Profile`
-rather than a parent `Typology.` namespace. Phonological-shape patterns (M-T, N-M;
-@cite{nichols-peterson-2013}) and allocutive markers are likewise co-located facets.
+* `Pronoun.Spec` — which pronouns a referent uses (@cite{arnold-2026}); a social
+  fact about a referent, not a property of the pronoun system.
 -/
 
 set_option autoImplicit false
 
 namespace Pronoun
 
-/-- WALS Ch 39: inclusive/exclusive distinction in independent pronouns. -/
-inductive InclusiveExclusive where
-  /-- No first-person plural pronoun at all. -/
-  | noWe
-  /-- 'We' = 'I' (no number distinction in 1st person). -/
-  | weEqualsI
-  /-- 1st-pl exists but no incl/excl distinction. -/
-  | noDistinction
-  /-- Only inclusive form; no dedicated exclusive pronoun. -/
-  | onlyInclusive
-  /-- Full inclusive/exclusive distinction in 1st-pl. -/
-  | inclusiveExclusive
-  deriving DecidableEq, Repr
-
-/-- WALS Ch 39B: incl/excl forms in Pama-Nyungan languages
-    (areal sub-feature). -/
-inductive InclusiveExclusivePamaNyungan where
-  /-- No incl/excl opposition in 1st-pl. -/
-  | noOpposition
-  /-- Inclusive and exclusive forms differentiated. -/
-  | differentiated
-  deriving DecidableEq, Repr
-
-/-- WALS Ch 40: incl/excl distinction in verbal inflection. -/
-inductive InclusiveExclusiveVerbal where
-  /-- No person marking on verbs at all. -/
-  | noPersonMarking
-  /-- 'We' verbal form = 'I' form. -/
-  | weEqualsI
-  /-- Person marking exists but no incl/excl. -/
-  | noDistinction
-  /-- Only inclusive marking in verbal inflection. -/
-  | onlyInclusive
-  /-- Full incl/excl distinction in verbal inflection. -/
-  | inclusiveExclusive
-  deriving DecidableEq, Repr
-
-/-- WALS Ch 44: where gender distinctions appear in the pronoun paradigm. -/
-inductive GenderDistinction where
-  /-- Gender in 3rd person AND in 1st/2nd person (e.g., Arabic, Hebrew). -/
-  | in3rdAndOtherPersons
-  /-- Gender in 3rd person only, including non-singular forms
-      (e.g., Polish, Albanian). -/
-  | in3rdPersonIncludingNonSg
-  /-- Gender in 3rd person singular only (e.g., English he/she/it). -/
-  | in3rdPersonSgOnly
-  /-- Gender in 1st or 2nd person but not 3rd (rare; e.g., Iraqw). -/
-  | in1stOr2ndOnly
-  /-- Gender in 3rd person non-singular only (extremely rare). -/
-  | in3rdPersonNonSgOnly
-  /-- No gender distinctions in pronouns (e.g., Finnish, Turkish, Japanese). -/
-  | noGenderDistinctions
-  deriving DecidableEq, Repr
-
-/-- WALS Ch 45: politeness (honorific/formality) distinctions in pronouns. -/
-inductive PolitenessDistinction where
-  /-- No politeness distinction (e.g., English). -/
-  | none
-  /-- Binary T/V distinction (e.g., French tu/vous, German du/Sie). -/
-  | binary
-  /-- Multiple levels (e.g., Japanese, Hindi, Tagalog). -/
-  | multiple
-  /-- Pronouns avoided entirely for politeness; titles/kin terms used
-      instead (e.g., Korean, Thai). -/
-  | pronounsAvoided
-  deriving DecidableEq, Repr
-
-/-- WALS Ch 46: morphological source of indefinite pronouns. -/
-inductive IndefiniteType where
-  /-- Based on interrogative forms (e.g., Japanese dare-ka 'who-Q' = 'someone'). -/
-  | interrogativeBased
-  /-- Based on generic nouns (e.g., English 'somebody' = 'some' + 'body'). -/
-  | genericNounBased
-  /-- Special, dedicated forms unrelated to interrogatives or generic nouns. -/
-  | special
-  /-- Mixed: some interrogative-based, others generic-noun-based. -/
-  | mixed
-  /-- Existential construction used instead of indefinite pronouns. -/
-  | existentialConstruction
-  deriving DecidableEq, Repr
-
-/-- WALS Ch 47: relationship between intensifiers and reflexives. -/
-inductive IntensifierReflexive where
-  /-- Identical forms ('she herself did it' / 'she saw herself'). -/
-  | identical
-  /-- Different, morphologically unrelated forms. -/
-  | differentiated
-  deriving DecidableEq, Repr
-
-/-- WALS Ch 48: whether adpositions bear person-marking morphology. -/
-inductive PersonMarkingOnAdpositions where
-  /-- Language has no adpositions (head-marking or caseless). -/
-  | noAdpositions
-  /-- Adpositions exist but bear no person marking. -/
-  | noPersonMarking
-  /-- Only pronominal complements trigger person marking
-      (e.g., Hebrew be-xa 'in-you'). -/
-  | pronounsOnly
-  /-- Both pronominal and nominal complements trigger person marking. -/
-  | pronounsAndNouns
-  deriving DecidableEq, Repr
-
-/-- A language's pronoun-system profile across WALS Chs 39–40, 44–48.
-    Not all chapters have data for every language (sample varies by
-    chapter), so each field is `Option`. -/
-structure Profile where
-  language : String
-  family : String
-  iso : String := ""
-  /-- Ch 39: incl/excl in independent pronouns. -/
-  inclusiveExclusive : Option InclusiveExclusive := .none
-  /-- Ch 40: incl/excl in verbal inflection. -/
-  inclusiveExclusiveVerbal : Option InclusiveExclusiveVerbal := .none
-  /-- Ch 44: gender distinctions. -/
-  genderInPronouns : Option GenderDistinction := .none
-  /-- Ch 45: politeness distinctions. -/
-  politeness : Option PolitenessDistinction := .none
-  /-- Ch 46: indefinite pronoun strategy. -/
-  indefiniteType : Option IndefiniteType := .none
-  /-- Ch 47: intensifier-reflexive relationship. -/
-  intensifierReflexive : Option IntensifierReflexive := .none
-  /-- Ch 48: person marking on adpositions. -/
-  personMarkingAdpositions : Option PersonMarkingOnAdpositions := .none
-  deriving Repr, DecidableEq
-
-end Pronoun
+open Features.Register (Level)
+open Features (SurfaceGender)
 
 /-! ### Structural deficiency (@cite{cardinaletti-starke-1999}) -/
-
-namespace Pronoun
 
 /-- @cite{cardinaletti-starke-1999}'s three pronoun classes, ordered by
     structural deficiency (strong > weak > clitic). Framework-neutral: only the
@@ -206,263 +60,16 @@ def Strength.rank : Strength → Nat
   | .weak   => 1
   | .clitic => 0
 
-theorem Strength.rank_injective : Function.Injective Strength.rank := by
-  intro a b h; cases a <;> cases b <;> simp_all [Strength.rank]
-
-/-- Total order via the rank pullback (clitic < weak < strong), mirroring
-    `LinearOrder AccessibilityLevel` in `Features/Accessibility.lean`. -/
-instance : LinearOrder Strength :=
-  LinearOrder.lift' Strength.rank Strength.rank_injective
-
-end Pronoun
-
--- ============================================================================
--- WALS converters (Chs 39, 39B, 40, 44–48)
--- ============================================================================
-
-namespace Pronoun
-
-def fromWALS39A : Data.WALS.F39A.InclusiveExclusiveDistinctionInIndependentPronouns →
-    InclusiveExclusive
-  | .noWe => .noWe
-  | .weTheSameAsI => .weEqualsI
-  | .noInclusiveExclusive => .noDistinction
-  | .onlyInclusive => .onlyInclusive
-  | .inclusiveExclusive => .inclusiveExclusive
-
-def fromWALS39B : Data.WALS.F39B.InclusiveExclusiveFormsInPamaNyungan →
-    InclusiveExclusivePamaNyungan
-  | .noInclusiveExclusiveOpposition => .noOpposition
-  | .inclusiveAndExclusiveDifferentiated => .differentiated
-
-def fromWALS40A : Data.WALS.F40A.InclusiveExclusiveDistinctionInVerbalInflection →
-    InclusiveExclusiveVerbal
-  | .noPersonMarking => .noPersonMarking
-  | .weTheSameAsI => .weEqualsI
-  | .noInclusiveExclusive => .noDistinction
-  | .onlyInclusive => .onlyInclusive
-  | .inclusiveExclusive => .inclusiveExclusive
-
-def fromWALS44A : Data.WALS.F44A.GenderDistinctionsInIndependentPersonalPronouns →
-    GenderDistinction
-  | .in3rdPerson1stAndOr2ndPerson => .in3rdAndOtherPersons
-  | .v3rdPersonOnlyButAlsoNonSingular => .in3rdPersonIncludingNonSg
-  | .v3rdPersonSingularOnly => .in3rdPersonSgOnly
-  | .v1stOr2ndPersonButNot3rd => .in1stOr2ndOnly
-  | .v3rdPersonNonSingularOnly => .in3rdPersonNonSgOnly
-  | .noGenderDistinctions => .noGenderDistinctions
-
-def fromWALS45A : Data.WALS.F45A.PolitenessDistinctionsInPronouns →
-    PolitenessDistinction
-  | .noPolitenessDistinction => .none
-  | .binaryPolitenessDistinction => .binary
-  | .multiplePolitenessDistinctions => .multiple
-  | .pronounsAvoidedForPoliteness => .pronounsAvoided
-
-def fromWALS46A : Data.WALS.F46A.IndefinitePronouns → IndefiniteType
-  | .interrogativeBased => .interrogativeBased
-  | .genericNounBased => .genericNounBased
-  | .special => .special
-  | .mixed => .mixed
-  | .existentialConstruction => .existentialConstruction
-
-def fromWALS47A : Data.WALS.F47A.IntensifierReflexive → IntensifierReflexive
-  | .identical => .identical
-  | .differentiated => .differentiated
-
-def fromWALS48A : Data.WALS.F48A.PersonMarkingOnAdpositions → PersonMarkingOnAdpositions
-  | .noAdpositions => .noAdpositions
-  | .noPersonMarking => .noPersonMarking
-  | .pronounsOnly => .pronounsOnly
-  | .pronounsAndNouns => .pronounsAndNouns
-
--- ============================================================================
--- WALS chapter abbrevs + size theorems + distribution + generalizations
--- ============================================================================
-
-private abbrev ch39 := Data.WALS.F39A.allData
-private abbrev ch39b := Data.WALS.F39B.allData
-private abbrev ch40 := Data.WALS.F40A.allData
-private abbrev ch44 := Data.WALS.F44A.allData
-private abbrev ch45 := Data.WALS.F45A.allData
-private abbrev ch46 := Data.WALS.F46A.allData
-private abbrev ch47 := Data.WALS.F47A.allData
-private abbrev ch48 := Data.WALS.F48A.allData
-
-set_option maxRecDepth 8192 in
-/-- Majority of languages (120/200) make no inclusive/exclusive
-    distinction in independent pronouns. -/
-theorem noDistinction_is_majority_ch39 :
-    (ch39.filter (·.value == .noInclusiveExclusive)).length >
-    (ch39.filter (·.value == .inclusiveExclusive)).length := by decide
-
-set_option maxRecDepth 8192 in
-/-- No gender distinctions in pronouns is the majority pattern (254/378 = 67.2%). -/
-theorem noGender_is_majority_ch44 :
-    (ch44.filter (·.value == .noGenderDistinctions)).length >
-    (ch44.filter (·.value == .v3rdPersonSingularOnly)).length +
-    (ch44.filter (·.value == .v3rdPersonOnlyButAlsoNonSingular)).length +
-    (ch44.filter (·.value == .in3rdPerson1stAndOr2ndPerson)).length := by decide
-
-set_option maxRecDepth 8192 in
-/-- Most languages lack politeness distinctions in pronouns (136/207 = 65.7%). -/
-theorem noPoliteness_is_majority_ch45 :
-    (ch45.filter (·.value == .noPolitenessDistinction)).length >
-    (ch45.filter (·.value == .binaryPolitenessDistinction)).length +
-    (ch45.filter (·.value == .multiplePolitenessDistinctions)).length +
-    (ch45.filter (·.value == .pronounsAvoidedForPoliteness)).length := by decide
-
-end Pronoun
-
--- ============================================================================
--- Pronoun phonological shape — WALS Chs 136, 137 @cite{nichols-peterson-2013}
--- ============================================================================
-
-namespace Pronoun
-
-/-- M-T pronoun pattern (WALS Ch 136A, @cite{nichols-peterson-2013}):
-    whether 1SG has /m/ and 2SG has /t/, a widespread cross-linguistic
-    pattern hypothesized to reflect deep genealogical signal. -/
-inductive MTPattern where
-  /-- No M-T pattern in the pronoun paradigm. -/
-  | absent
-  /-- M-T pattern is paradigmatic (systematic across forms). -/
-  | paradigmatic
-  /-- M-T pattern is non-paradigmatic (sporadic). -/
-  | nonParadigmatic
-  deriving DecidableEq, Repr
-
-/-- Whether 1SG has an m-initial or m-containing form (WALS Ch 136B). -/
-inductive MIn1SG where
-  | absent
-  | present
-  deriving DecidableEq, Repr
-
-/-- N-M pronoun pattern (WALS Ch 137A, @cite{nichols-peterson-2013}):
-    whether 1SG has /n/ and 2SG has /m/. -/
-inductive NMPattern where
-  | absent
-  | paradigmatic
-  | nonParadigmatic
-  deriving DecidableEq, Repr
-
-/-- Whether 2SG has an m-initial or m-containing form (WALS Ch 137B). -/
-inductive MIn2SG where
-  | absent
-  | present
-  deriving DecidableEq, Repr
-
-/-- A language's pronoun-shape profile across @cite{wals-2013} Chs 136–137.
-    Sister to `Profile` (Chs 39–48). Kept as a separate struct to
-    avoid contaminating the feature-system bundle with phonological-shape
-    fields. -/
-structure ShapeProfile where
-  language : String
-  iso : String := ""
-  /-- Ch 136A: M-T pronoun pattern. -/
-  mtPronouns : Option MTPattern := none
-  /-- Ch 136B: M in 1SG. -/
-  mIn1sg : Option MIn1SG := none
-  /-- Ch 137A: N-M pronoun pattern. -/
-  nmPronouns : Option NMPattern := none
-  /-- Ch 137B: M in 2SG. -/
-  mIn2sg : Option MIn2SG := none
-  deriving Repr
-
--- WALS converters for the four shape features.
-
-def fromWALS136A : Data.WALS.F136A.MTPronouns → MTPattern
-  | .noMTPronouns              => .absent
-  | .mTPronounsParadigmatic    => .paradigmatic
-  | .mTPronounsNonParadigmatic => .nonParadigmatic
-
-def fromWALS136B : Data.WALS.F136B.MInFirstPersonSingular → MIn1SG
-  | .noMInFirstPersonSingular => .absent
-  | .mInFirstPersonSingular   => .present
-
-def fromWALS137A : Data.WALS.F137A.NMPronouns → NMPattern
-  | .noNMPronouns              => .absent
-  | .nMPronounsParadigmatic    => .paradigmatic
-  | .nMPronounsNonParadigmatic => .nonParadigmatic
-
-def fromWALS137B : Data.WALS.F137B.MInSecondPersonSingular → MIn2SG
-  | .noMInSecondPersonSingular => .absent
-  | .mInSecondPersonSingular   => .present
-
-/-- WALS Ch 136A distribution: M-T pronoun patterns
-    (@cite{nichols-peterson-2013}, n = 230). -/
-structure MTCounts where
-  absent : Nat
-  paradigmatic : Nat
-  nonParadigmatic : Nat
-  deriving Repr
-
-def MTCounts.total (c : MTCounts) : Nat :=
-  c.absent + c.paradigmatic + c.nonParadigmatic
-
-/-- WALS Ch 136A counts (230 languages). -/
-def walsMT : MTCounts :=
-  { absent := 200
-  , paradigmatic := 27
-  , nonParadigmatic := 3 }
-
-/-- The M-T pronoun pattern is a clear minority cross-linguistically: only
-    30/230 languages (~13%) show any form of it; 200/230 lack it entirely.
-    Despite its visibility in Indo-European, it is not a typological default. -/
-theorem mt_pronouns_minority :
-    walsMT.absent > walsMT.paradigmatic + walsMT.nonParadigmatic := by decide
-
-end Pronoun
-
--- ════════════════════════════════════════════════════
--- § N. Cross-linguistic Pronoun Entry Schemas
--- ════════════════════════════════════════════════════
-
-/-! ## Cross-linguistic pronoun and allocutive entry schemas
-@cite{alok-bhalla-2026} @cite{arnold-2026}
-
-Cross-linguistic structures for pronoun inventories and allocutive markers,
-shared across all `Fragments/{Lang}/Pronouns.lean` files.
-
-Moved here from `Core/Lexical/Pronouns.lean` in the cleanup that
-dissolved `Core/Lexical/`. The 21-consumer footprint (20 Fragments + 1
-Phenomena study) is precisely the per-language entry-schema pattern
-this file already serves for WALS-anchored substrate enums.
-
-### Entry
-
-Covers the union of fields needed by all language fragments:
-- Core: form, person, number (all fragments)
-- Morphosyntactic: case_, gender (Galician, English, French, etc.)
-- Sociolinguistic: register (all SA-based fragments)
-- Orthographic: script (Korean hangul, Japanese kanji)
-
-### Spec
-
-Personal pronoun specification — which pronouns a person uses. A
-social-linguistic fact independent of grammatical gender.
-@cite{arnold-2026}'s pragmatic condition for *personal* singular *they*:
-referent's pronouns are known to be *they/them*.
-
-### AllocutiveEntry
-
-Verbal suffixes (Hindi, Magahi, Maithili, Punjabi, Tamil, Basque),
-particles (Korean, Japanese), or clitics (Galician) realising
-speaker-addressee agreement. -/
-
-namespace Pronoun
-
-open Features.Register (Level)
-open Features (SurfaceGender)
+/-! ### Lexical entry schemas (@cite{alok-bhalla-2026}, @cite{arnold-2026}) -/
 
 /-- Personal pronoun specification — which pronouns a person uses.
 
-    A social-linguistic fact that may or may not be in common ground.
-    Independent of grammatical gender: a person with known feminine
-    gender may use she/her, they/them, or neopronouns.
-    @cite{arnold-2026}: the pragmatic condition for *personal*
-    singular *they* is knowing that the referent's personal pronouns
-    are *they/them*. -/
+    A social-linguistic fact about a *referent* (not a property of the pronoun
+    system) that may or may not be in common ground. Independent of grammatical
+    gender: a person with known feminine gender may use she/her, they/them, or
+    neopronouns. @cite{arnold-2026}: the pragmatic condition for *personal*
+    singular *they* is knowing that the referent's personal pronouns are
+    *they/them*. -/
 inductive Spec where
   | heHim      -- he/him/his
   | sheHer     -- she/her/hers
@@ -517,17 +124,4 @@ structure AllocutiveEntry where
   gloss : String
   deriving Repr, BEq
 
-/-- WALS Ch 39 image of a Cysouw clusivity system (`Features.Clusivity.System`):
-    WALS Ch 39 collapses Cysouw's `.inclExcl`, `.minimalAugmented`, and
-    `.unitAugmented` into the single value `.inclusiveExclusive`. The
-    function is therefore many-to-one: given a WALS Ch 39 value, the
-    Cysouw value is underdetermined. -/
-def InclusiveExclusive.fromClusivity : Features.Clusivity.System → InclusiveExclusive
-  | .noClusivity        => .noDistinction
-  | .inclExcl           => .inclusiveExclusive
-  | .minimalAugmented   => .inclusiveExclusive
-  | .unitAugmented      => .inclusiveExclusive
-  | .numberIndifferent  => .weEqualsI
-
 end Pronoun
-

--- a/Linglib/Typology/Pronoun/WALS.lean
+++ b/Linglib/Typology/Pronoun/WALS.lean
@@ -1,0 +1,372 @@
+import Linglib.Data.WALS.Features.F39A
+import Linglib.Data.WALS.Features.F39B
+import Linglib.Data.WALS.Features.F40A
+import Linglib.Data.WALS.Features.F44A
+import Linglib.Data.WALS.Features.F45A
+import Linglib.Data.WALS.Features.F46A
+import Linglib.Data.WALS.Features.F47A
+import Linglib.Data.WALS.Features.F48A
+import Linglib.Data.WALS.Features.F136A
+import Linglib.Data.WALS.Features.F136B
+import Linglib.Data.WALS.Features.F137A
+import Linglib.Data.WALS.Features.F137B
+import Linglib.Features.Clusivity
+
+/-!
+# Pronoun — typological survey (WALS)
+@cite{wals-2013} @cite{nichols-peterson-2013}
+
+The cross-linguistic WALS-survey facet of the pronoun object: per-language
+feature-system `Profile` (Chs 39–48) and phonological `ShapeProfile`
+(Chs 136–137), with the WALS converters and distribution theorems.
+
+## Main declarations
+
+* `Pronoun.Profile` — per-language feature-system survey (incl/excl, gender,
+  politeness, indefinite strategy, intensifier–reflexive, adpositional person
+  marking), WALS Chs 39–48.
+* `Pronoun.ShapeProfile` — per-language M-T / N-M phonological-shape survey,
+  WALS Chs 136–137 (@cite{nichols-peterson-2013}).
+-/
+
+set_option autoImplicit false
+
+namespace Pronoun
+
+/-- WALS Ch 39: inclusive/exclusive distinction in independent pronouns. -/
+inductive InclusiveExclusive where
+  /-- No first-person plural pronoun at all. -/
+  | noWe
+  /-- 'We' = 'I' (no number distinction in 1st person). -/
+  | weEqualsI
+  /-- 1st-pl exists but no incl/excl distinction. -/
+  | noDistinction
+  /-- Only inclusive form; no dedicated exclusive pronoun. -/
+  | onlyInclusive
+  /-- Full inclusive/exclusive distinction in 1st-pl. -/
+  | inclusiveExclusive
+  deriving DecidableEq, Repr
+
+/-- WALS Ch 39B: incl/excl forms in Pama-Nyungan languages
+    (areal sub-feature). -/
+inductive InclusiveExclusivePamaNyungan where
+  /-- No incl/excl opposition in 1st-pl. -/
+  | noOpposition
+  /-- Inclusive and exclusive forms differentiated. -/
+  | differentiated
+  deriving DecidableEq, Repr
+
+/-- WALS Ch 40: incl/excl distinction in verbal inflection. -/
+inductive InclusiveExclusiveVerbal where
+  /-- No person marking on verbs at all. -/
+  | noPersonMarking
+  /-- 'We' verbal form = 'I' form. -/
+  | weEqualsI
+  /-- Person marking exists but no incl/excl. -/
+  | noDistinction
+  /-- Only inclusive marking in verbal inflection. -/
+  | onlyInclusive
+  /-- Full incl/excl distinction in verbal inflection. -/
+  | inclusiveExclusive
+  deriving DecidableEq, Repr
+
+/-- WALS Ch 44: where gender distinctions appear in the pronoun paradigm. -/
+inductive GenderDistinction where
+  /-- Gender in 3rd person AND in 1st/2nd person (e.g., Arabic, Hebrew). -/
+  | in3rdAndOtherPersons
+  /-- Gender in 3rd person only, including non-singular forms
+      (e.g., Polish, Albanian). -/
+  | in3rdPersonIncludingNonSg
+  /-- Gender in 3rd person singular only (e.g., English he/she/it). -/
+  | in3rdPersonSgOnly
+  /-- Gender in 1st or 2nd person but not 3rd (rare; e.g., Iraqw). -/
+  | in1stOr2ndOnly
+  /-- Gender in 3rd person non-singular only (extremely rare). -/
+  | in3rdPersonNonSgOnly
+  /-- No gender distinctions in pronouns (e.g., Finnish, Turkish, Japanese). -/
+  | noGenderDistinctions
+  deriving DecidableEq, Repr
+
+/-- WALS Ch 45: politeness (honorific/formality) distinctions in pronouns. -/
+inductive PolitenessDistinction where
+  /-- No politeness distinction (e.g., English). -/
+  | none
+  /-- Binary T/V distinction (e.g., French tu/vous, German du/Sie). -/
+  | binary
+  /-- Multiple levels (e.g., Japanese, Hindi, Tagalog). -/
+  | multiple
+  /-- Pronouns avoided entirely for politeness; titles/kin terms used
+      instead (e.g., Korean, Thai). -/
+  | pronounsAvoided
+  deriving DecidableEq, Repr
+
+/-- WALS Ch 46: morphological source of indefinite pronouns. -/
+inductive IndefiniteType where
+  /-- Based on interrogative forms (e.g., Japanese dare-ka 'who-Q' = 'someone'). -/
+  | interrogativeBased
+  /-- Based on generic nouns (e.g., English 'somebody' = 'some' + 'body'). -/
+  | genericNounBased
+  /-- Special, dedicated forms unrelated to interrogatives or generic nouns. -/
+  | special
+  /-- Mixed: some interrogative-based, others generic-noun-based. -/
+  | mixed
+  /-- Existential construction used instead of indefinite pronouns. -/
+  | existentialConstruction
+  deriving DecidableEq, Repr
+
+/-- WALS Ch 47: relationship between intensifiers and reflexives. -/
+inductive IntensifierReflexive where
+  /-- Identical forms ('she herself did it' / 'she saw herself'). -/
+  | identical
+  /-- Different, morphologically unrelated forms. -/
+  | differentiated
+  deriving DecidableEq, Repr
+
+/-- WALS Ch 48: whether adpositions bear person-marking morphology. -/
+inductive PersonMarkingOnAdpositions where
+  /-- Language has no adpositions (head-marking or caseless). -/
+  | noAdpositions
+  /-- Adpositions exist but bear no person marking. -/
+  | noPersonMarking
+  /-- Only pronominal complements trigger person marking
+      (e.g., Hebrew be-xa 'in-you'). -/
+  | pronounsOnly
+  /-- Both pronominal and nominal complements trigger person marking. -/
+  | pronounsAndNouns
+  deriving DecidableEq, Repr
+
+/-- A language's pronoun-system profile across WALS Chs 39–40, 44–48.
+    Not all chapters have data for every language (sample varies by
+    chapter), so each field is `Option`. -/
+structure Profile where
+  language : String
+  family : String
+  iso : String := ""
+  /-- Ch 39: incl/excl in independent pronouns. -/
+  inclusiveExclusive : Option InclusiveExclusive := .none
+  /-- Ch 40: incl/excl in verbal inflection. -/
+  inclusiveExclusiveVerbal : Option InclusiveExclusiveVerbal := .none
+  /-- Ch 44: gender distinctions. -/
+  genderInPronouns : Option GenderDistinction := .none
+  /-- Ch 45: politeness distinctions. -/
+  politeness : Option PolitenessDistinction := .none
+  /-- Ch 46: indefinite pronoun strategy. -/
+  indefiniteType : Option IndefiniteType := .none
+  /-- Ch 47: intensifier-reflexive relationship. -/
+  intensifierReflexive : Option IntensifierReflexive := .none
+  /-- Ch 48: person marking on adpositions. -/
+  personMarkingAdpositions : Option PersonMarkingOnAdpositions := .none
+  deriving Repr, DecidableEq
+
+end Pronoun
+
+/-! ### WALS converters (Chs 39, 39B, 40, 44–48) -/
+
+namespace Pronoun
+
+def fromWALS39A : Data.WALS.F39A.InclusiveExclusiveDistinctionInIndependentPronouns →
+    InclusiveExclusive
+  | .noWe => .noWe
+  | .weTheSameAsI => .weEqualsI
+  | .noInclusiveExclusive => .noDistinction
+  | .onlyInclusive => .onlyInclusive
+  | .inclusiveExclusive => .inclusiveExclusive
+
+def fromWALS39B : Data.WALS.F39B.InclusiveExclusiveFormsInPamaNyungan →
+    InclusiveExclusivePamaNyungan
+  | .noInclusiveExclusiveOpposition => .noOpposition
+  | .inclusiveAndExclusiveDifferentiated => .differentiated
+
+def fromWALS40A : Data.WALS.F40A.InclusiveExclusiveDistinctionInVerbalInflection →
+    InclusiveExclusiveVerbal
+  | .noPersonMarking => .noPersonMarking
+  | .weTheSameAsI => .weEqualsI
+  | .noInclusiveExclusive => .noDistinction
+  | .onlyInclusive => .onlyInclusive
+  | .inclusiveExclusive => .inclusiveExclusive
+
+def fromWALS44A : Data.WALS.F44A.GenderDistinctionsInIndependentPersonalPronouns →
+    GenderDistinction
+  | .in3rdPerson1stAndOr2ndPerson => .in3rdAndOtherPersons
+  | .v3rdPersonOnlyButAlsoNonSingular => .in3rdPersonIncludingNonSg
+  | .v3rdPersonSingularOnly => .in3rdPersonSgOnly
+  | .v1stOr2ndPersonButNot3rd => .in1stOr2ndOnly
+  | .v3rdPersonNonSingularOnly => .in3rdPersonNonSgOnly
+  | .noGenderDistinctions => .noGenderDistinctions
+
+def fromWALS45A : Data.WALS.F45A.PolitenessDistinctionsInPronouns →
+    PolitenessDistinction
+  | .noPolitenessDistinction => .none
+  | .binaryPolitenessDistinction => .binary
+  | .multiplePolitenessDistinctions => .multiple
+  | .pronounsAvoidedForPoliteness => .pronounsAvoided
+
+def fromWALS46A : Data.WALS.F46A.IndefinitePronouns → IndefiniteType
+  | .interrogativeBased => .interrogativeBased
+  | .genericNounBased => .genericNounBased
+  | .special => .special
+  | .mixed => .mixed
+  | .existentialConstruction => .existentialConstruction
+
+def fromWALS47A : Data.WALS.F47A.IntensifierReflexive → IntensifierReflexive
+  | .identical => .identical
+  | .differentiated => .differentiated
+
+def fromWALS48A : Data.WALS.F48A.PersonMarkingOnAdpositions → PersonMarkingOnAdpositions
+  | .noAdpositions => .noAdpositions
+  | .noPersonMarking => .noPersonMarking
+  | .pronounsOnly => .pronounsOnly
+  | .pronounsAndNouns => .pronounsAndNouns
+
+/-! ### Distribution theorems -/
+
+private abbrev ch39 := Data.WALS.F39A.allData
+private abbrev ch39b := Data.WALS.F39B.allData
+private abbrev ch40 := Data.WALS.F40A.allData
+private abbrev ch44 := Data.WALS.F44A.allData
+private abbrev ch45 := Data.WALS.F45A.allData
+private abbrev ch46 := Data.WALS.F46A.allData
+private abbrev ch47 := Data.WALS.F47A.allData
+private abbrev ch48 := Data.WALS.F48A.allData
+
+set_option maxRecDepth 8192 in
+/-- Majority of languages (120/200) make no inclusive/exclusive
+    distinction in independent pronouns. -/
+theorem noDistinction_is_majority_ch39 :
+    (ch39.filter (·.value == .noInclusiveExclusive)).length >
+    (ch39.filter (·.value == .inclusiveExclusive)).length := by decide
+
+set_option maxRecDepth 8192 in
+/-- No gender distinctions in pronouns is the majority pattern (254/378 = 67.2%). -/
+theorem noGender_is_majority_ch44 :
+    (ch44.filter (·.value == .noGenderDistinctions)).length >
+    (ch44.filter (·.value == .v3rdPersonSingularOnly)).length +
+    (ch44.filter (·.value == .v3rdPersonOnlyButAlsoNonSingular)).length +
+    (ch44.filter (·.value == .in3rdPerson1stAndOr2ndPerson)).length := by decide
+
+set_option maxRecDepth 8192 in
+/-- Most languages lack politeness distinctions in pronouns (136/207 = 65.7%). -/
+theorem noPoliteness_is_majority_ch45 :
+    (ch45.filter (·.value == .noPolitenessDistinction)).length >
+    (ch45.filter (·.value == .binaryPolitenessDistinction)).length +
+    (ch45.filter (·.value == .multiplePolitenessDistinctions)).length +
+    (ch45.filter (·.value == .pronounsAvoidedForPoliteness)).length := by decide
+
+end Pronoun
+
+/-! ### Phonological shape (WALS Chs 136–137, @cite{nichols-peterson-2013}) -/
+
+namespace Pronoun
+
+/-- M-T pronoun pattern (WALS Ch 136A, @cite{nichols-peterson-2013}):
+    whether 1SG has /m/ and 2SG has /t/, a widespread cross-linguistic
+    pattern hypothesized to reflect deep genealogical signal. -/
+inductive MTPattern where
+  /-- No M-T pattern in the pronoun paradigm. -/
+  | absent
+  /-- M-T pattern is paradigmatic (systematic across forms). -/
+  | paradigmatic
+  /-- M-T pattern is non-paradigmatic (sporadic). -/
+  | nonParadigmatic
+  deriving DecidableEq, Repr
+
+/-- Whether 1SG has an m-initial or m-containing form (WALS Ch 136B). -/
+inductive MIn1SG where
+  | absent
+  | present
+  deriving DecidableEq, Repr
+
+/-- N-M pronoun pattern (WALS Ch 137A, @cite{nichols-peterson-2013}):
+    whether 1SG has /n/ and 2SG has /m/. -/
+inductive NMPattern where
+  | absent
+  | paradigmatic
+  | nonParadigmatic
+  deriving DecidableEq, Repr
+
+/-- Whether 2SG has an m-initial or m-containing form (WALS Ch 137B). -/
+inductive MIn2SG where
+  | absent
+  | present
+  deriving DecidableEq, Repr
+
+/-- A language's pronoun-shape profile across @cite{wals-2013} Chs 136–137.
+    Sister to `Profile` (Chs 39–48). Kept as a separate struct to
+    avoid contaminating the feature-system bundle with phonological-shape
+    fields. -/
+structure ShapeProfile where
+  language : String
+  iso : String := ""
+  /-- Ch 136A: M-T pronoun pattern. -/
+  mtPronouns : Option MTPattern := none
+  /-- Ch 136B: M in 1SG. -/
+  mIn1sg : Option MIn1SG := none
+  /-- Ch 137A: N-M pronoun pattern. -/
+  nmPronouns : Option NMPattern := none
+  /-- Ch 137B: M in 2SG. -/
+  mIn2sg : Option MIn2SG := none
+  deriving Repr, DecidableEq
+
+-- WALS converters for the four shape features.
+
+def fromWALS136A : Data.WALS.F136A.MTPronouns → MTPattern
+  | .noMTPronouns              => .absent
+  | .mTPronounsParadigmatic    => .paradigmatic
+  | .mTPronounsNonParadigmatic => .nonParadigmatic
+
+def fromWALS136B : Data.WALS.F136B.MInFirstPersonSingular → MIn1SG
+  | .noMInFirstPersonSingular => .absent
+  | .mInFirstPersonSingular   => .present
+
+def fromWALS137A : Data.WALS.F137A.NMPronouns → NMPattern
+  | .noNMPronouns              => .absent
+  | .nMPronounsParadigmatic    => .paradigmatic
+  | .nMPronounsNonParadigmatic => .nonParadigmatic
+
+def fromWALS137B : Data.WALS.F137B.MInSecondPersonSingular → MIn2SG
+  | .noMInSecondPersonSingular => .absent
+  | .mInSecondPersonSingular   => .present
+
+/-- WALS Ch 136A distribution: M-T pronoun patterns
+    (@cite{nichols-peterson-2013}, n = 230). -/
+structure MTCounts where
+  absent : Nat
+  paradigmatic : Nat
+  nonParadigmatic : Nat
+  deriving Repr
+
+def MTCounts.total (c : MTCounts) : Nat :=
+  c.absent + c.paradigmatic + c.nonParadigmatic
+
+/-- WALS Ch 136A counts (230 languages). -/
+def walsMT : MTCounts :=
+  { absent := 200
+  , paradigmatic := 27
+  , nonParadigmatic := 3 }
+
+/-- The M-T pronoun pattern is a clear minority cross-linguistically: only
+    30/230 languages (~13%) show any form of it; 200/230 lack it entirely.
+    Despite its visibility in Indo-European, it is not a typological default. -/
+theorem mt_pronouns_minority :
+    walsMT.absent > walsMT.paradigmatic + walsMT.nonParadigmatic := by decide
+
+end Pronoun
+
+/-! ### Clusivity bridge -/
+
+namespace Pronoun
+
+/-- WALS Ch 39 image of a Cysouw clusivity system (`Features.Clusivity.System`):
+    WALS Ch 39 collapses Cysouw's `.inclExcl`, `.minimalAugmented`, and
+    `.unitAugmented` into the single value `.inclusiveExclusive`. The
+    function is therefore many-to-one: given a WALS Ch 39 value, the
+    Cysouw value is underdetermined. -/
+def InclusiveExclusive.fromClusivity : Features.Clusivity.System → InclusiveExclusive
+  | .noClusivity        => .noDistinction
+  | .inclExcl           => .inclusiveExclusive
+  | .minimalAugmented   => .inclusiveExclusive
+  | .unitAugmented      => .inclusiveExclusive
+  | .numberIndifferent  => .weEqualsI
+
+end Pronoun
+


### PR DESCRIPTION
## Summary
Follow-up to the ergonomics audit of the `Pronoun` object (#4). Splits the one ~530-line file (which imported 12 WALS-data modules every consumer paid for) into two facets:
- **`Basic.lean`** — lexical core (`Entry`, `Strength`+`rank`, `Spec`, `AllocutiveEntry`); imports only `Core.Word` + `Features.*`.
- **`WALS.lean`** — cross-linguistic survey (`Profile`, `ShapeProfile`, WALS converters, distribution theorems); holds the 12 WALS-data imports.

**Import-cost win** (verified facet map): 18 lexical-only consumers keep `Basic` and shed the WALS dependency entirely; 11 survey-only consumers import `WALS`; 5 dual import both.

Plus cheap cleanups: drop the unused `LinearOrder Strength` (consumers use `Strength.rank`), give `ShapeProfile` `DecidableEq`, normalize section dividers to `/-! ### -/`, delete stale migration meta-commentary, reword the `Spec` docstring.

## Notes
- Keeps `namespace Pronoun` (object-first). The lone-exception concern from the audit is to be resolved by migrating the other `Typology.<Domain>` siblings to object-first namespaces in follow-ups, not by reverting.
- Deferred: `genderInPronouns`→`genderDistinction` field rename (16-file churn); evicting `PersonMarkingOnAdpositions` to `Typology/Adposition.lean`.

## Test plan
- [x] `lake build` green (5993 jobs full library).