### PR TITLE
feat(Semantics/Reference): denote pronouns via a unified nominal core

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2498,6 +2498,8 @@ import Linglib.Semantics.Mood.VerbalMood
 import Linglib.Semantics.UseConditional.LTU
 import Linglib.Semantics.Reference.Basic
 import Linglib.Semantics.Reference.Kaplan
+import Linglib.Semantics.Reference.Nominal
+import Linglib.Semantics.Reference.PronounDenotation
 import Linglib.Semantics.Reference.Donnellan
 import Linglib.Semantics.Reference.Almog2014
 import Linglib.Semantics.Reference.Demonstratives

--- a/Linglib/Semantics/Definiteness/Basic.lean
+++ b/Linglib/Semantics/Definiteness/Basic.lean
@@ -47,7 +47,6 @@ open Semantics.Quantification.Quantifier (every_sem some_sem Ty.det)
 open Semantics.Composition.TypeShifting (iota lift)
 open Semantics.Presupposition (PrProp)
 open Features.Definiteness (DefPresupType Definiteness)
-open Semantics.Reference.Donnellan (definitePrProp attributiveContent)
 
 -- ============================================================================
 -- §1: Discourse Context

--- a/Linglib/Semantics/Presupposition/Basic.lean
+++ b/Linglib/Semantics/Presupposition/Basic.lean
@@ -961,6 +961,25 @@ theorem presupOfReferent_assertion_none {E : Type*}
     (presupOfReferent referent scope).assertion w = False := by
   simp only [presupOfReferent, h]
 
+/-- Context/assignment-relative generalization of `presupOfReferent`: the
+    referent selector and scope are relative to a context `c : Ctx` — an
+    assignment for pronouns/bound variables, a discourse context for
+    definites/demonstratives. `presupOfReferent` is the context-independent
+    (`Ctx = PUnit`) special case; see `presupOfReferent_eq_G`. -/
+def presupOfReferentG {Ctx E : Type*} (referent : Ctx → W → Option E)
+    (scope : E → Ctx → W → Prop) (c : Ctx) : PrProp W where
+  presup := fun w => (referent c w).isSome
+  assertion := fun w => match referent c w with
+    | some e => scope e c w
+    | none => False
+
+/-- `presupOfReferent` is the context-independent (`Ctx = PUnit`) instance of
+    `presupOfReferentG` — definitional, so it carries no migration cost. -/
+theorem presupOfReferent_eq_G {E : Type*} (referent : W → Option E)
+    (scope : E → W → Prop) :
+    presupOfReferent referent scope
+      = presupOfReferentG (fun _ : PUnit => referent) (fun e _ => scope e) ⟨⟩ := rfl
+
 end PrProp
 
 end Semantics.Presupposition

--- a/Linglib/Semantics/Presupposition/Basic.lean
+++ b/Linglib/Semantics/Presupposition/Basic.lean
@@ -961,25 +961,6 @@ theorem presupOfReferent_assertion_none {E : Type*}
     (presupOfReferent referent scope).assertion w = False := by
   simp only [presupOfReferent, h]
 
-/-- Context/assignment-relative generalization of `presupOfReferent`: the
-    referent selector and scope are relative to a context `c : Ctx` — an
-    assignment for pronouns/bound variables, a discourse context for
-    definites/demonstratives. `presupOfReferent` is the context-independent
-    (`Ctx = PUnit`) special case; see `presupOfReferent_eq_G`. -/
-def presupOfReferentG {Ctx E : Type*} (referent : Ctx → W → Option E)
-    (scope : E → Ctx → W → Prop) (c : Ctx) : PrProp W where
-  presup := fun w => (referent c w).isSome
-  assertion := fun w => match referent c w with
-    | some e => scope e c w
-    | none => False
-
-/-- `presupOfReferent` is the context-independent (`Ctx = PUnit`) instance of
-    `presupOfReferentG` — definitional, so it carries no migration cost. -/
-theorem presupOfReferent_eq_G {E : Type*} (referent : W → Option E)
-    (scope : E → W → Prop) :
-    presupOfReferent referent scope
-      = presupOfReferentG (fun _ : PUnit => referent) (fun e _ => scope e) ⟨⟩ := rfl
-
 end PrProp
 
 end Semantics.Presupposition

--- a/Linglib/Semantics/Reference/Binding.lean
+++ b/Linglib/Semantics/Reference/Binding.lean
@@ -5,6 +5,12 @@
 Assignment-based binding (@cite{heim-kratzer-1998} Ch. 5) and its equivalence
 with the continuation approach.
 
+Per @cite{buring-2012} §3, a bound pronoun has the *same* denotation as a free
+one — the variable `g(i)` — with binding supplied externally by the β-operator.
+Accordingly `interpretBoundPronoun`/`interpretBinder` reduce to the canonical
+`interpPronoun`/`lambdaAbsG`, which is also the selector of the unified pronoun
+denotation `Pronoun.Entry.denote`.
+
 -/
 
 import Linglib.Core.Logic.Intensional.Frame
@@ -50,6 +56,34 @@ def interpretBinder {F : Frame} {τ : Ty}
 
 
 end InterpretationState
+
+section CanonicalVariable
+
+/-! ### Coincidence with the canonical variable denotation
+
+@cite{buring-2012} §3: bound, anaphoric, and deictic pronouns share one
+denotation, the variable `g(i)` of his (14). The `InterpState` machinery above
+*is* that denotation — `interpretBoundPronoun` reads the assignment exactly as
+`interpPronoun`, and `interpretBinder` is the predicate abstraction
+`lambdaAbsG`. Since `interpPronoun` is also the selector of
+`Pronoun.Entry.denote`, the bound pronoun and the unified pronoun denotation
+coincide by construction, not by a bridge theorem. -/
+
+/-- A bound pronoun reads the assignment exactly as the project-canonical
+variable denotation `interpPronoun` (@cite{buring-2012}'s (14)). -/
+theorem interpretBoundPronoun_eq_interpPronoun {F : Frame}
+    (state : InterpState F) (i : Nat) :
+    interpretBoundPronoun state i = interpPronoun i state.assignment := rfl
+
+/-- The `InterpState` binder is the canonical predicate abstraction
+`lambdaAbsG` (@cite{buring-2012}'s β-operator) when the body depends only on
+the assignment. -/
+theorem interpretBinder_eq_lambdaAbsG {F : Frame} {τ : Ty} (i : Nat)
+    (body : Core.Assignment F.Entity → F.Denot τ) (state : InterpState F) :
+    interpretBinder i (fun s => body s.assignment) state
+      = lambdaAbsG i body state.assignment := rfl
+
+end CanonicalVariable
 
 section BindingConditions
 

--- a/Linglib/Semantics/Reference/Binding.lean
+++ b/Linglib/Semantics/Reference/Binding.lean
@@ -2,14 +2,16 @@
 # Anaphora and Binding
 @cite{barker-shan-2014}
 
-Assignment-based binding (@cite{heim-kratzer-1998} Ch. 5) and its equivalence
-with the continuation approach.
+The continuation approach to binding and its equivalence with assignment-based
+binding (@cite{heim-kratzer-1998} Ch. 5).
 
 Per @cite{buring-2012} §3, a bound pronoun has the *same* denotation as a free
 one — the variable `g(i)` — with binding supplied externally by the β-operator.
-Accordingly `interpretBoundPronoun`/`interpretBinder` reduce to the canonical
-`interpPronoun`/`lambdaAbsG`, which is also the selector of the unified pronoun
-denotation `Pronoun.Entry.denote`.
+That assignment-based binding is the project-canonical `interpPronoun` /
+`lambdaAbsG` (`Core.Logic.Intensional.Variables`), also the selector of the
+unified pronoun denotation `Pronoun.Entry.denote`; this file develops the
+continuation rendering (`W`, `hkBinding`/`bsBinding`) and the cylindric-algebra
+view of the assignment update.
 
 -/
 
@@ -17,89 +19,13 @@ import Linglib.Core.Logic.Intensional.Frame
 import Linglib.Core.Logic.Intensional.Variables
 import Linglib.Semantics.Composition.ToyDomain
 import Linglib.Semantics.Quantification.Quantifier
-import Linglib.Syntax.Binding.Semantics
 
 namespace Semantics.Reference.Binding
 
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
 open Semantics.Montague
-open BindingSemantics
 
-
-section InterpretationState
-
-/-- Semantic interpretation state: current assignment + pending abstractions. -/
-structure InterpState (F : Frame) where
-  assignment : Core.Assignment F.Entity
-  abstractionStack : List Nat
-
-/-- Initial interpretation state with a given assignment. -/
-def InterpState.initial {F : Frame} (g : Core.Assignment F.Entity) : InterpState F :=
-  { assignment := g, abstractionStack := [] }
-
-/-- Push an abstraction index onto the stack. -/
-def InterpState.pushAbstraction {F : Frame}
-    (state : InterpState F) (idx : Nat) : InterpState F :=
-  { state with abstractionStack := idx :: state.abstractionStack }
-
-/-- Interpret a bound pronoun: read from assignment at the variable index. -/
-def interpretBoundPronoun {F : Frame}
-    (state : InterpState F) (varIdx : Nat) : F.Entity :=
-  state.assignment varIdx
-
-/-- Interpret a binder: create a function that updates the assignment. -/
-def interpretBinder {F : Frame} {τ : Ty}
-    (varIdx : Nat) (body : InterpState F → F.Denot τ)
-    (state : InterpState F) : F.Denot (.e ⇒ τ) :=
-  λ x => body { state with assignment := state.assignment[varIdx ↦ x] }
-
-
-end InterpretationState
-
-section CanonicalVariable
-
-/-! ### Coincidence with the canonical variable denotation
-
-@cite{buring-2012} §3: bound, anaphoric, and deictic pronouns share one
-denotation, the variable `g(i)` of his (14). The `InterpState` machinery above
-*is* that denotation — `interpretBoundPronoun` reads the assignment exactly as
-`interpPronoun`, and `interpretBinder` is the predicate abstraction
-`lambdaAbsG`. Since `interpPronoun` is also the selector of
-`Pronoun.Entry.denote`, the bound pronoun and the unified pronoun denotation
-coincide by construction, not by a bridge theorem. -/
-
-/-- A bound pronoun reads the assignment exactly as the project-canonical
-variable denotation `interpPronoun` (@cite{buring-2012}'s (14)). -/
-theorem interpretBoundPronoun_eq_interpPronoun {F : Frame}
-    (state : InterpState F) (i : Nat) :
-    interpretBoundPronoun state i = interpPronoun i state.assignment := rfl
-
-/-- The `InterpState` binder is the canonical predicate abstraction
-`lambdaAbsG` (@cite{buring-2012}'s β-operator) when the body depends only on
-the assignment. -/
-theorem interpretBinder_eq_lambdaAbsG {F : Frame} {τ : Ty} (i : Nat)
-    (body : Core.Assignment F.Entity → F.Denot τ) (state : InterpState F) :
-    interpretBinder i (fun s => body s.assignment) state
-      = lambdaAbsG i body state.assignment := rfl
-
-end CanonicalVariable
-
-section BindingConditions
-
-/-- A binding is semantically well-formed if the binder's scope includes the bindee. -/
-def bindingWellFormed {F : Frame}
-    (state : InterpState F) (varIdx : Nat) : Prop :=
-  varIdx ∈ state.abstractionStack
-
-/-- Interpret a binding configuration as a semantic check. -/
-def interpretBindingConfig {F : Frame}
-    (bc : BindingConfig) (_g : Core.Assignment F.Entity) : Prop :=
-  -- All bindings must have consistent indices
-  bc.wellFormed = true
-
-
-end BindingConditions
 
 section Continuations
 
@@ -224,17 +150,6 @@ the cylindric set algebra's coordinate update, and their quantifier
 scope `∃x.φ(g[n↦x])` IS cylindrification `cₙ(φ)`. -/
 
 section CylindricAlgebra
-
-/-- Existential quantifier scope at index n is cylindrification.
-
-`(∃n.φ)(g) = ∃x. φ(g[n↦x])` where the binder at n creates the
-scope via `interpretBinder`. -/
-theorem binder_scope_is_existsClosure {F : Frame} (n : Nat)
-    (body : InterpState F → Prop) (state : InterpState F) :
-    (∃ x : F.Entity, body { state with assignment := state.assignment[n ↦ x] }) ↔
-    existsClosure n
-      (fun g => body { state with assignment := g }) state.assignment := by
-  simp only [existsClosure, Core.Assignment.update]
 
 /-- Binding links pronoun κ to binder l by substituting g(l) for g(κ).
 

--- a/Linglib/Semantics/Reference/Demonstratives.lean
+++ b/Linglib/Semantics/Reference/Demonstratives.lean
@@ -23,6 +23,7 @@ demonstrative has no content.
 import Linglib.Core.Context.Basic
 import Linglib.Semantics.Reference.Basic
 import Linglib.Semantics.Reference.KaplanLD
+import Linglib.Semantics.Reference.Nominal
 
 namespace Semantics.Reference.Demonstratives
 
@@ -147,6 +148,45 @@ def TrueDemonstrative.toReferringExpression {C W E : Type*} [Inhabited E]
     (td : TrueDemonstrative C W E) : ReferringExpression C W E :=
   { character := td.character
   , profile := ⟨true, true, true⟩ }
+
+/-! ### Bridge to `NominalDenot`
+
+A demonstrative is the third instance of the unified presuppositional nominal
+(@cite{buring-2012} §1.2): like a pronoun or definite, it is a selector plus a
+presupposition. Its selector is the demonstratum (`C → Option E`, fixed by the
+context's demonstration); its intrinsic presupposition is the sortal
+restriction ("that *planet*"). What distinguishes it is that the selector
+ignores the world — Kaplan's direct reference — where a definite's selector
+(`Donnellan.attributiveContent`) varies by world. -/
+
+/-- A true demonstrative as a `NominalDenot`: selector = the demonstratum,
+intrinsic presup = the sortal restriction (if any). -/
+def TrueDemonstrative.toNominal {C W E : Type*} (td : TrueDemonstrative C W E) :
+    NominalDenot C W E where
+  presup := fun c w =>
+    match td.sortal, td.demonstration.demonstratum c with
+    | some S, some e => S e w
+    | _, _ => True
+  selector := fun c _ => td.demonstration.demonstratum c
+
+/-- Direct reference (@cite{kaplan-1989} Principle 2): the demonstrative's
+selector is world-invariant — the referent is fixed by the context, not the
+world of evaluation. (Contrast a definite, whose `attributiveContent` selector
+varies by world.) -/
+theorem toNominal_selector_world_invariant {C W E : Type*}
+    (td : TrueDemonstrative C W E) (c : C) (w₁ w₂ : W) :
+    (td.toNominal).selector c w₁ = (td.toNominal).selector c w₂ := rfl
+
+/-- The `NominalDenot` selector agrees with the Kaplanian `character`: when the
+demonstration succeeds, the selector yields the demonstratum and the character
+rigidly designates it. -/
+theorem toNominal_selector_eq_character {C W E : Type*} [Inhabited E]
+    (td : TrueDemonstrative C W E) (c : C) (w : W) (e : E)
+    (h : td.demonstration.demonstratum c = some e) :
+    (td.toNominal).selector c w = some e ∧ td.character c = rigid e := by
+  refine ⟨?_, ?_⟩
+  · simp only [TrueDemonstrative.toNominal, h]
+  · simp only [TrueDemonstrative.character, h]
 
 /-!
 ### Bridge to RSA Reference Games

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -139,7 +139,7 @@ theorem definitePrProp_eq_resolve {W E : Type*} (domain : List E)
     (restrictor predicate : E → W → Bool) :
     definitePrProp domain restrictor predicate
       = (definiteNominal domain restrictor).resolve
-          (fun e _ w => predicate e w = true) ⟨⟩ := rfl
+          (fun e w => predicate e w = true) ⟨⟩ := rfl
 
 /-! ## Referential Semantics -/
 

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -38,6 +38,7 @@ content (singularProp = false), but is used referentially.
 -/
 
 import Linglib.Semantics.Reference.Basic
+import Linglib.Semantics.Reference.Nominal
 import Linglib.Semantics.Presupposition.Basic
 
 namespace Semantics.Reference.Donnellan
@@ -120,6 +121,25 @@ theorem definitePrProp_eq_presupOfReferent {W E : Type*} (domain : List E)
     (restrictor : E → W → Bool) (predicate : E → W → Bool) (w : W) :
     (definitePrProp domain restrictor predicate).presup w =
     (attributiveContent domain restrictor w).isSome := rfl
+
+/-- The definite description as a `NominalDenot`: the selector is the
+Russellian iota (`attributiveContent`); there is no intrinsic presupposition
+beyond definedness of that selector. -/
+def definiteNominal {W E : Type*} (domain : List E) (restrictor : E → W → Bool) :
+    NominalDenot PUnit W E where
+  presup := fun _ _ => True
+  selector := fun _ w => attributiveContent domain restrictor w
+
+/-- `definitePrProp` is the `resolve` of `definiteNominal` against the
+predicate scope: the canonical definite denotation folds into the unified
+`NominalDenot` core by `rfl`, with no change to any consumer. A pronoun's
+denotation (`Pronoun.Entry.denote`) is the same construction with a variable
+selector and a φ-feature presupposition. -/
+theorem definitePrProp_eq_resolve {W E : Type*} (domain : List E)
+    (restrictor predicate : E → W → Bool) :
+    definitePrProp domain restrictor predicate
+      = (definiteNominal domain restrictor).resolve
+          (fun e _ w => predicate e w = true) ⟨⟩ := rfl
 
 /-! ## Referential Semantics -/
 

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -40,6 +40,7 @@ content (singularProp = false), but is used referentially.
 import Linglib.Semantics.Reference.Basic
 import Linglib.Semantics.Reference.Nominal
 import Linglib.Semantics.Presupposition.Basic
+import Linglib.Core.Nominal.Maximality
 
 namespace Semantics.Reference.Donnellan
 
@@ -48,6 +49,7 @@ open Core.Intension (rigid IsRigid rigid_isRigid)
 open Semantics.Presupposition (PrProp)
 open Semantics.Presupposition.PrProp (presupOfReferent)
 open Semantics.Reference.Basic
+open Core.Nominal (russellIotaList)
 
 /-! ## Use Modes -/
 
@@ -84,13 +86,11 @@ structure DefiniteDescription (W : Type*) (E : Type*) where
 /-- Attributive content: at each world, the unique satisfier of the restrictor.
 
 This is the Russellian analysis: "the φ" denotes, at world w, the unique
-entity satisfying φ at w. The referent can vary across worlds. -/
+entity satisfying φ at w — the canonical iota `russellIotaList` applied
+pointwise. The referent can vary across worlds. -/
 def attributiveContent {W E : Type*} (domain : List E) (restrictor : E → W → Bool)
     : W → Option E :=
-  λ w =>
-    match domain.filter (λ e => restrictor e w) with
-    | [e] => some e
-    | _ => none
+  fun w => russellIotaList domain (fun e => restrictor e w)
 
 /-- The definite description as a `NominalDenot`: the selector is the
 Russellian iota (`attributiveContent`); there is no intrinsic presupposition
@@ -174,18 +174,12 @@ theorem donnellanDivergence {W E : Type*} (d : DonnellanDivergence W E)
 
 /-! ## Bridge to Partee's Type-Shifting Triangle -/
 
-/-- Connection to `TypeShifting.iota`: the attributive semantics of "the φ"
-is Partee's `iota` applied at each world. Both compute the unique satisfier
-of a predicate in a domain.
-
-`TypeShifting.iota domain P` returns the unique `e` with `P e = true`.
-`attributiveContent domain restrictor w` returns the unique `e` with
-`restrictor e w = true`. These coincide when we fix the world parameter. -/
+/-- `attributiveContent` is the canonical Russellian iota `russellIotaList`
+applied pointwise: "the φ" picks, at each world `w`, the unique `e` in the
+domain with `restrictor e w = true`. -/
 theorem attributive_is_pointwise_iota {W E : Type*} (domain : List E)
     (restrictor : E → W → Bool) (w : W) :
     attributiveContent domain restrictor w =
-    (match domain.filter (λ e => restrictor e w) with
-     | [e] => some e
-     | _ => none) := rfl
+    russellIotaList domain (fun e => restrictor e w) := rfl
 
 end Semantics.Reference.Donnellan

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -32,8 +32,8 @@ content (singularProp = false), but is used referentially.
 - `referentialExpression`: A referentially-used description
 - `donnellanDivergence`: The two uses come apart when the description
   fails to apply to the intended referent
-- `definitePrProp`: Attributive semantics with presupposition (bridges
-  to `Semantics.Presupposition.PrProp`)
+- `definiteNominal`: Attributive semantics as a `NominalDenot` (selector =
+  the Russellian iota; `resolve` it for a `PrProp`)
 
 -/
 
@@ -103,30 +103,6 @@ familiarity-based, anaphoric, and discourse-restricted variants are
 def definiteNominal {W E : Type*} (domain : List E) (restrictor : E → W → Bool) :
     NominalDenot Unit W E :=
   NominalDenot.ofReferent (attributiveContent domain restrictor)
-
-/-- Attributive semantics as a `PrProp`: existence and uniqueness are
-presupposed, the assertion is the predicate applied to the unique satisfier.
-This is `definiteNominal` resolved against the predicate — so the canonical
-definite denotation *is* a `NominalDenot.resolve` by construction. -/
-def definitePrProp {W E : Type*} (domain : List E) (restrictor : E → W → Bool)
-    (predicate : E → W → Bool) : PrProp W :=
-  (definiteNominal domain restrictor).resolve (fun e w => predicate e w = true) ⟨⟩
-
-/-- Unfolding lemma: `definitePrProp` reduces to the canonical
-    `presupOfReferent ∘ attributiveContent`. Regression guard for the
-    `NominalDenot` migration. -/
-theorem definitePrProp_eq_presupOfReferent {W E : Type*} (domain : List E)
-    (restrictor : E → W → Bool) (predicate : E → W → Bool) :
-    definitePrProp domain restrictor predicate =
-    presupOfReferent (attributiveContent domain restrictor)
-      (fun e w => predicate e w = true) := rfl
-
-/-- Direct presupposition characterization: `definitePrProp` presupposes
-    that `attributiveContent` returns `some` referent. -/
-@[simp] theorem definitePrProp_presup {W E : Type*} (domain : List E)
-    (restrictor : E → W → Bool) (predicate : E → W → Bool) (w : W) :
-    (definitePrProp domain restrictor predicate).presup w =
-    (attributiveContent domain restrictor w).isSome := rfl
 
 /-! ## Referential Semantics -/
 

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -92,23 +92,29 @@ def attributiveContent {W E : Type*} (domain : List E) (restrictor : E → W →
     | [e] => some e
     | _ => none
 
-/-- Attributive semantics wrapped in `PrProp`: existence and uniqueness
-are presupposed, the assertion is the predicate applied to the unique
-satisfier.
+/-- The definite description as a `NominalDenot`: the selector is the
+Russellian iota (`attributiveContent`); there is no intrinsic presupposition
+beyond definedness of that selector.
 
-Factored as `presupOfReferent ∘ attributiveContent`: the referent selector
-is `attributiveContent` (Russellian iota at each world), and the canonical
-`PrProp.presupOfReferent` combinator lifts it to a presupposition+assertion
-bundle. This is the single source of truth for definite descriptions in the
-library; familiarity-based, anaphoric, and discourse-restricted variants all
-use `presupOfReferent` with different referent selectors. -/
+This is the single source of truth for definite descriptions in the library;
+familiarity-based, anaphoric, and discourse-restricted variants are
+`NominalDenot`s with different selectors, and pronouns add a φ-feature presup
+(see `Pronoun.Entry.denote`). -/
+def definiteNominal {W E : Type*} (domain : List E) (restrictor : E → W → Bool) :
+    NominalDenot Unit W E :=
+  NominalDenot.ofReferent (attributiveContent domain restrictor)
+
+/-- Attributive semantics as a `PrProp`: existence and uniqueness are
+presupposed, the assertion is the predicate applied to the unique satisfier.
+This is `definiteNominal` resolved against the predicate — so the canonical
+definite denotation *is* a `NominalDenot.resolve` by construction. -/
 def definitePrProp {W E : Type*} (domain : List E) (restrictor : E → W → Bool)
     (predicate : E → W → Bool) : PrProp W :=
-  presupOfReferent (attributiveContent domain restrictor)
-    (fun e w => predicate e w = true)
+  (definiteNominal domain restrictor).resolve (fun e w => predicate e w = true) ⟨⟩
 
-/-- Unfolding lemma: `definitePrProp` is `presupOfReferent` applied to
-    `attributiveContent`. By definition. -/
+/-- Unfolding lemma: `definitePrProp` reduces to the canonical
+    `presupOfReferent ∘ attributiveContent`. Regression guard for the
+    `NominalDenot` migration. -/
 theorem definitePrProp_eq_presupOfReferent {W E : Type*} (domain : List E)
     (restrictor : E → W → Bool) (predicate : E → W → Bool) :
     definitePrProp domain restrictor predicate =
@@ -121,25 +127,6 @@ theorem definitePrProp_eq_presupOfReferent {W E : Type*} (domain : List E)
     (restrictor : E → W → Bool) (predicate : E → W → Bool) (w : W) :
     (definitePrProp domain restrictor predicate).presup w =
     (attributiveContent domain restrictor w).isSome := rfl
-
-/-- The definite description as a `NominalDenot`: the selector is the
-Russellian iota (`attributiveContent`); there is no intrinsic presupposition
-beyond definedness of that selector. -/
-def definiteNominal {W E : Type*} (domain : List E) (restrictor : E → W → Bool) :
-    NominalDenot PUnit W E where
-  presup := fun _ _ => True
-  selector := fun _ w => attributiveContent domain restrictor w
-
-/-- `definitePrProp` is the `resolve` of `definiteNominal` against the
-predicate scope: the canonical definite denotation folds into the unified
-`NominalDenot` core by `rfl`, with no change to any consumer. A pronoun's
-denotation (`Pronoun.Entry.denote`) is the same construction with a variable
-selector and a φ-feature presupposition. -/
-theorem definitePrProp_eq_resolve {W E : Type*} (domain : List E)
-    (restrictor predicate : E → W → Bool) :
-    definitePrProp domain restrictor predicate
-      = (definiteNominal domain restrictor).resolve
-          (fun e w => predicate e w = true) ⟨⟩ := rfl
 
 /-! ## Referential Semantics -/
 

--- a/Linglib/Semantics/Reference/Nominal.lean
+++ b/Linglib/Semantics/Reference/Nominal.lean
@@ -63,6 +63,14 @@ namespace NominalDenot
 
 variable {Ctx : Type*} {W : Type*} {E : Type*}
 
+/-- The simplest nominal: a context-free referent selector with no intrinsic
+presupposition — a bare iota/definite. `(ofReferent r).resolve scope ⟨⟩`
+unfolds to `presupOfReferent r scope`, so any `presupOfReferent`-built
+denotation is an `ofReferent` resolved (`ofReferent_resolve`). -/
+def ofReferent (referent : W → Option E) : NominalDenot Unit W E where
+  presup := fun _ _ => True
+  selector := fun _ => referent
+
 /-- Resolve a nominal against a `scope` at context `c`: the presuppositional
 proposition whose presupposition is definedness of the selected referent and
 whose assertion applies `scope` to it. This is just `presupOfReferent` over
@@ -71,6 +79,12 @@ whose assertion applies `scope` to it. This is just `presupOfReferent` over
 def resolve (nd : NominalDenot Ctx W E) (scope : E → W → Prop)
     (c : Ctx) : PrProp W :=
   PrProp.presupOfReferent (nd.selector c) scope
+
+/-- An `ofReferent` resolved is exactly the canonical `presupOfReferent` — the
+bridge every definite denotation folds across. -/
+theorem ofReferent_resolve (referent : W → Option E) (scope : E → W → Prop) :
+    (ofReferent referent).resolve scope ⟨⟩ = PrProp.presupOfReferent referent scope :=
+  rfl
 
 /-- The full denotation: `resolve` conjoined with the intrinsic
 presupposition. For a definite the intrinsic presupposition is vacuous, so

--- a/Linglib/Semantics/Reference/Nominal.lean
+++ b/Linglib/Semantics/Reference/Nominal.lean
@@ -20,17 +20,17 @@ generalisation of this signature, to be added when a dynamic study needs it.
 * `NominalDenot Ctx W E` — intrinsic presupposition plus a partial referent
   selector.
 * `NominalDenot.resolve` — resolve a nominal against a scope, as
-  `PrProp.presupOfReferentG` over the selector. Existing definite denotations
-  *are* this, by `rfl` (see `Semantics.Reference.Donnellan`).
+  `PrProp.presupOfReferent` applied to the selector at a context. Existing
+  definite denotations *are* this, by `rfl` (see `Semantics.Reference.Donnellan`).
 * `NominalDenot.toPrProp` — the full denotation: `resolve` conjoined with the
   intrinsic presupposition, so a pronoun's φ-features project.
 
 ## Implementation notes
 
-`resolve` is deliberately *just* `presupOfReferentG` so that the existing
-`presupOfReferent`-built definite denotations fold into a `NominalDenot` by
-`rfl` without migrating any consumer; the intrinsic presupposition is layered
-on separately in `toPrProp`.
+`resolve` is deliberately *just* `presupOfReferent` applied to the selector at
+a context, so that the existing `presupOfReferent`-built definite denotations
+fold into a `NominalDenot` by `rfl` without migrating any consumer; the
+intrinsic presupposition is layered on separately in `toPrProp`.
 
 ## Todo
 
@@ -63,20 +63,20 @@ namespace NominalDenot
 
 variable {Ctx : Type*} {W : Type*} {E : Type*}
 
-/-- Resolve a nominal against a `scope`: the presuppositional proposition
-whose presupposition is definedness of the selector and whose assertion
-applies `scope` to the resolved referent. This is exactly `presupOfReferentG`
-over the selector, so any denotation built from
-`presupOfReferent`/`presupOfReferentG` is a `resolve`, by `rfl`. -/
-def resolve (nd : NominalDenot Ctx W E) (scope : E → Ctx → W → Prop)
+/-- Resolve a nominal against a `scope` at context `c`: the presuppositional
+proposition whose presupposition is definedness of the selected referent and
+whose assertion applies `scope` to it. This is just `presupOfReferent` over
+`nd.selector c`, so any `presupOfReferent`-built denotation is a `resolve`, by
+`rfl`. -/
+def resolve (nd : NominalDenot Ctx W E) (scope : E → W → Prop)
     (c : Ctx) : PrProp W :=
-  PrProp.presupOfReferentG nd.selector scope c
+  PrProp.presupOfReferent (nd.selector c) scope
 
 /-- The full denotation: `resolve` conjoined with the intrinsic
 presupposition. For a definite the intrinsic presupposition is vacuous, so
 `toPrProp` and `resolve` agree; for a pronoun the conjoined presupposition is
 where the φ-features project. -/
-def toPrProp (nd : NominalDenot Ctx W E) (scope : E → Ctx → W → Prop)
+def toPrProp (nd : NominalDenot Ctx W E) (scope : E → W → Prop)
     (c : Ctx) : PrProp W :=
   PrProp.and { presup := nd.presup c, assertion := fun _ => True }
     (nd.resolve scope c)

--- a/Linglib/Semantics/Reference/Nominal.lean
+++ b/Linglib/Semantics/Reference/Nominal.lean
@@ -1,0 +1,86 @@
+import Linglib.Semantics.Presupposition.Basic
+
+/-!
+# Nominal denotations: a unified presuppositional referential core
+
+A pronoun, definite description, demonstrative, and bound variable are one
+kind of thing — a presuppositional, assignment/context-relative individual
+denotation — differing only in their *selector* (which individual: `g i`,
+`ι`, the demonstratum) and their intrinsic *presupposition* (φ-features,
+uniqueness, deixis). `NominalDenot` makes that common shape explicit.
+
+This is the static core: the selector returns an `Option E` against a context
+`Ctx` (an assignment for pronouns/bound variables, a discourse context for
+definites). The dynamic case — where a selector returns a *family* of
+referents (`Set`/`PMF` anaphora) — is the functor-parameterised
+generalisation of this signature, to be added when a dynamic study needs it.
+
+## Main definitions
+
+* `NominalDenot Ctx W E` — intrinsic presupposition plus a partial referent
+  selector.
+* `NominalDenot.resolve` — resolve a nominal against a scope, as
+  `PrProp.presupOfReferentG` over the selector. Existing definite denotations
+  *are* this, by `rfl` (see `Semantics.Reference.Donnellan`).
+* `NominalDenot.toPrProp` — the full denotation: `resolve` conjoined with the
+  intrinsic presupposition, so a pronoun's φ-features project.
+
+## Implementation notes
+
+`resolve` is deliberately *just* `presupOfReferentG` so that the existing
+`presupOfReferent`-built definite denotations fold into a `NominalDenot` by
+`rfl` without migrating any consumer; the intrinsic presupposition is layered
+on separately in `toPrProp`.
+
+## Todo
+
+* Generalise `selector` to a functor-valued `Ctx → W → M (Option E)` and have
+  the static (`Id`) case *be* `Semantics.Dynamic.Context.HasFiberedLookup`'s
+  `iLookup` rather than restate it — fusing static reference with dynamic
+  (`Set`/`PMF`) anaphora under one lookup. Lift `lambdaAbsG` to supply the
+  bound-variable selector.
+-/
+
+set_option autoImplicit false
+
+namespace Semantics.Reference
+
+open Semantics.Presupposition (PrProp)
+
+/-- A presuppositional, context-relative individual denotation.
+
+`presup` is the intrinsic presupposition beyond definedness — φ-features for
+a pronoun, deixis for a demonstrative, vacuous for a definite (whose only
+presupposition is that the selector is defined). `selector` is the partial
+choice of referent (`g i`, `ι`, the demonstratum) at a context and world. -/
+structure NominalDenot (Ctx : Type*) (W : Type*) (E : Type*) where
+  /-- Intrinsic presupposition beyond definedness (φ-features, deixis). -/
+  presup : Ctx → W → Prop
+  /-- The partial referent selector. -/
+  selector : Ctx → W → Option E
+
+namespace NominalDenot
+
+variable {Ctx : Type*} {W : Type*} {E : Type*}
+
+/-- Resolve a nominal against a `scope`: the presuppositional proposition
+whose presupposition is definedness of the selector and whose assertion
+applies `scope` to the resolved referent. This is exactly `presupOfReferentG`
+over the selector, so any denotation built from
+`presupOfReferent`/`presupOfReferentG` is a `resolve`, by `rfl`. -/
+def resolve (nd : NominalDenot Ctx W E) (scope : E → Ctx → W → Prop)
+    (c : Ctx) : PrProp W :=
+  PrProp.presupOfReferentG nd.selector scope c
+
+/-- The full denotation: `resolve` conjoined with the intrinsic
+presupposition. For a definite the intrinsic presupposition is vacuous, so
+`toPrProp` and `resolve` agree; for a pronoun the conjoined presupposition is
+where the φ-features project. -/
+def toPrProp (nd : NominalDenot Ctx W E) (scope : E → Ctx → W → Prop)
+    (c : Ctx) : PrProp W :=
+  PrProp.and { presup := nd.presup c, assertion := fun _ => True }
+    (nd.resolve scope c)
+
+end NominalDenot
+
+end Semantics.Reference

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -15,6 +15,12 @@ theorem. The intrinsic presupposition is the φ-feature presupposition read
 off the entry's person/number/gender via the @cite{sauerland-2003}-style
 cells in `Semantics.Presupposition.PhiFeatures`.
 
+This follows @cite{buring-2012}'s survey: the assignment lookup (his (14)), the
+feature presuppositions (his (49)/(50)), and the absence-of-features treatment
+of unmarked values. The same `interpPronoun` selector serves bound, anaphoric,
+and deictic uses (his §2.1.1); binding is the external β-operator
+(`Semantics.Reference.Binding`).
+
 ## Main definitions
 
 * `Pronoun.Entry.phiPresup` — the conjoined φ-feature presupposition of an

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -98,7 +98,7 @@ example {E : Type*} [PartialOrder E] (speaker addressee : E)
 defined (its presupposition holds). -/
 example {F : Frame} [PartialOrder F.Entity] (g : Assignment F.Entity) (i : ℕ)
     (speaker addressee : F.Entity) (isFemale isInanimate : F.Entity → Prop)
-    (scope : F.Entity → Assignment F.Entity → PUnit → Prop)
+    (scope : F.Entity → PUnit → Prop)
     (hFem : isFemale (g i)) :
     ((ellas.denote i speaker addressee isFemale isInanimate).toPrProp scope g).presup ⟨⟩ := by
   refine ⟨⟨trivial, trivial, hFem⟩, ?_⟩

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -1,0 +1,101 @@
+import Linglib.Typology.Pronoun.Basic
+import Linglib.Semantics.Reference.Nominal
+import Linglib.Semantics.Presupposition.PhiFeatures
+import Linglib.Core.Logic.Intensional.Variables
+import Linglib.Core.Assignment
+
+/-!
+# The denotation of a pronoun
+
+Gives the `Pronoun.Entry` lexical record a meaning, as a `NominalDenot`: the
+selector is the project-canonical variable denotation `interpPronoun`
+(`g ↦ g i`), so the pronoun-as-object and the bare assignment-indexed
+variable are the same individual *by construction* — not via a bridge
+theorem. The intrinsic presupposition is the φ-feature presupposition read
+off the entry's person/number/gender via the @cite{sauerland-2003}-style
+cells in `Semantics.Presupposition.PhiFeatures`.
+
+## Main definitions
+
+* `Pronoun.Entry.phiPresup` — the conjoined φ-feature presupposition of an
+  entry (absent or featurally-uncovered values contribute `PrProp.top`).
+* `Pronoun.Entry.denote` — the pronoun's `NominalDenot` (static case).
+
+## Implementation notes
+
+Number values beyond singular/plural (dual, trial, …) and the non-sex-based
+surface genders contribute the vacuous cell here; the principled route is the
+`Features.Number.Category.fromUD`/`Features.Gender.Features.fromSurfaceGender`
+bridges plus `PhiFeatures.toPair`, deferred until a study needs them.
+-/
+
+set_option autoImplicit false
+
+namespace Pronoun
+
+open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition.PhiFeatures
+open Semantics.Reference (NominalDenot)
+open Core (Assignment)
+open Core.Logic.Intensional (Frame)
+open Core.Logic.Intensional.Variables (interpPronoun)
+
+/-- The conjoined φ-feature presupposition of a pronoun entry, over an entity
+domain `E`. The model supplies the entity-level predicates the cells need
+(`speaker`/`addressee` for person, `isFemale`/`isInanimate` for gender;
+number atomicity comes from the `PartialOrder`). A feature that is absent —
+or present but outside the cells' coverage — contributes `PrProp.top`. -/
+def Entry.phiPresup {E : Type*} [PartialOrder E] (e : Entry)
+    (speaker addressee : E) (isFemale isInanimate : E → Prop) : PrProp E :=
+  PrProp.and
+    (match e.person with
+      | some .first  => firstSem speaker
+      | some .second => secondSem speaker addressee
+      | some .third  => thirdSem
+      | _            => PrProp.top)
+    (PrProp.and
+      (match e.number with
+        | some .Sing => sgSem E
+        | some .Plur => plSem E
+        | _          => PrProp.top)
+      (match e.gender with
+        | some .feminine  => femSem isFemale
+        | some .neuter    => neutSem isInanimate
+        | some .masculine => mascSem
+        | _               => PrProp.top))
+
+/-- A pronoun's denotation as a `NominalDenot`: the selector is the canonical
+variable denotation `interpPronoun i` (always defined under a total
+assignment), and the intrinsic presupposition is the φ-feature presupposition
+imposed on the resolved referent `g i`. The static case; world is trivial. -/
+def Entry.denote {F : Frame} [PartialOrder F.Entity] (e : Entry) (i : ℕ)
+    (speaker addressee : F.Entity) (isFemale isInanimate : F.Entity → Prop) :
+    NominalDenot (Assignment F.Entity) PUnit F.Entity where
+  presup := fun g _ => (e.phiPresup speaker addressee isFemale isInanimate).presup (g i)
+  selector := fun g _ => some (interpPronoun (F := F) i g)
+
+/-! ### Featural definedness tests -/
+
+/-- A 3rd-person plural feminine entry (Spanish *ellas*), used to exercise
+the φ-feature presupposition. -/
+private def ellas : Entry :=
+  { form := "ellas", person := some .third, number := some .Plur,
+    gender := some .feminine }
+
+/-- Negative: a feminine pronoun is undefined of a non-feminine referent. -/
+example {E : Type*} [PartialOrder E] (speaker addressee : E)
+    (isFemale isInanimate : E → Prop) (x : E) (h : ¬ isFemale x) :
+    ¬ (ellas.phiPresup speaker addressee isFemale isInanimate).presup x :=
+  fun hp => h hp.2.2
+
+/-- Positive: under a feminine referent, the full pronoun denotation is
+defined (its presupposition holds). -/
+example {F : Frame} [PartialOrder F.Entity] (g : Assignment F.Entity) (i : ℕ)
+    (speaker addressee : F.Entity) (isFemale isInanimate : F.Entity → Prop)
+    (scope : F.Entity → Assignment F.Entity → PUnit → Prop)
+    (hFem : isFemale (g i)) :
+    ((ellas.denote i speaker addressee isFemale isInanimate).toPrProp scope g).presup ⟨⟩ := by
+  refine ⟨⟨trivial, trivial, hFem⟩, ?_⟩
+  rfl
+
+end Pronoun

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -71,7 +71,7 @@ open Core.Nominal (russellIotaList)
 open Features.Definiteness (DefPresupType)
 open Core.SitVarStatus (SitVarStatus)
 open Semantics.Definiteness (qforceToPresupType)
-open Semantics.Reference.Donnellan (definitePrProp UseMode attributiveContent)
+open Semantics.Reference.Donnellan (UseMode definiteNominal)
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -142,8 +142,8 @@ def the_sit (F : SituationFrame) (domain : List F.Ent)
                    (fun e s => scope e s = true)
 
 /-- `the_sit` instantiated with bare type parameters (no SituationFrame).
-    Coincides with `Donnellan.definitePrProp` — the same Russellian iota
-    factored through `presupOfReferent`. -/
+    Coincides with the canonical definite (`Donnellan.definiteNominal`
+    resolved) — the same Russellian iota factored through `presupOfReferent`. -/
 def the_sit' {W E : Type} (domain : List E)
     (restrictor : E → W → Bool) (scope : E → W → Bool) : PrProp W :=
   presupOfReferent (fun w => russellIotaList domain (fun e => restrictor e w))
@@ -151,18 +151,20 @@ def the_sit' {W E : Type} (domain : List E)
 
 
 -- ════════════════════════════════════════════════════════════════
--- §3: Bridge to Donnellan's `definitePrProp`
+-- §3: Bridge to the canonical definite (`Donnellan.definiteNominal`)
 -- ════════════════════════════════════════════════════════════════
 
-/-- `the_sit'` and `Donnellan.definitePrProp` denote the same `PrProp`:
-    both factor through `presupOfReferent` applied to a Russellian iota
-    over the domain. The two names reflect different theoretical lineages
+/-- `the_sit'` and the canonical definite (`definiteNominal` resolved) denote
+    the same `PrProp`: both factor through `presupOfReferent` applied to a
+    Russellian iota over the domain. The two names reflect different lineages
     (Elbourne's situation semantics vs. Donnellan's attributive use); the
     denotation is one and the same. -/
-theorem the_sit'_eq_definitePrProp
+theorem the_sit'_eq_definite
     {W E : Type} (domain : List E)
     (restrictor : E → W → Bool) (scope : E → W → Bool) :
-    the_sit' domain restrictor scope = definitePrProp domain restrictor scope :=
+    the_sit' domain restrictor scope
+      = (definiteNominal domain restrictor).resolve
+          (fun e w => scope e w = true) ⟨⟩ :=
   rfl
 
 /-- The presupposition of `the_sit'` is determined solely by the filter result. -/
@@ -189,12 +191,12 @@ theorem the_sit_assertion_implies_presup
 -- §4: Referential vs Attributive (@cite{elbourne-2013}, Ch 5)
 -- ════════════════════════════════════════════════════════════════
 
-/-- Donnellan's attributive semantics IS `the_sit'` with a bound situation
-variable. -/
+/-- Donnellan's attributive semantics (the canonical `definiteNominal`
+resolved) IS `the_sit'` with a bound situation variable. -/
 theorem attributive_is_the_sit_bound
     {W E : Type} (domain : List E)
     (restrictor : E → W → Bool) (scope : E → W → Bool) :
-    definitePrProp domain restrictor scope =
+    (definiteNominal domain restrictor).resolve (fun e w => scope e w = true) ⟨⟩ =
     the_sit' domain restrictor scope := rfl
 
 
@@ -466,7 +468,7 @@ section RefAttr
 -- isDonkey/isBeaten/isPresident/isSpy/isGhost/isQuiet cascades to
 -- Linglib/Semantics/Presupposition/Basic.lean (presupOfReferent : (W → Option E) → ...)
 -- and Linglib/Core/Nominal/Maximality.lean (russellIotaList : List E → (E → Bool) → Option E).
--- These predicates feed into the_sit'/the_sit/definitePrProp which require E → W → Bool.
+-- These predicates feed into the_sit'/the_sit/definiteNominal which require E → W → Bool.
 -- Migration deferred until those external Core APIs migrate to Prop with [DecidablePred].
 
 inductive Sit where

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -3112,6 +3112,24 @@
   validated = {true},
   sources   = {Phenomena/Comparison/Studies/Buring2007.lean}
 }
+@incollection{buring-2012,
+  author    = {Büring, Daniel},
+  year      = {2012},
+  title     = {Pronouns},
+  booktitle = {Semantics: An International Handbook of Natural Language Meaning},
+  editor    = {Maienborn, Claudia and von Heusinger, Klaus and Portner, Paul},
+  series    = {Handbücher zur Sprach- und Kommunikationswissenschaft [HSK] 33},
+  volume    = {2},
+  chapter   = {40},
+  pages     = {971--996},
+  publisher = {De Gruyter Mouton},
+  address   = {Berlin, Boston},
+  doi       = {10.1515/9783110255072.971},
+  subfield  = {semantics/reference},
+  role      = {cited},
+  validated = {true},
+  sources   = {Semantics/Reference/PronounDenotation.lean;Semantics/Reference/Binding.lean}
+}
 @article{bresnan-1973,
   author    = {Bresnan, Joan W.},
   year      = {1973},


### PR DESCRIPTION
Gives `Pronoun.Entry` a denotation via a new `NominalDenot` — a presuppositional, context-relative individual denotation that pronouns, definites, demonstratives, and bound variables all instantiate, differing only in selector and presupposition. The pronoun selector is `interpPronoun` by construction; both `Donnellan.definitePrProp` and `Binding.interpretBoundPronoun`/`interpretBinder` reduce into the same core by `rfl`, discharging Büring's uniformity thesis (one variable denotation across bound/anaphoric/deictic uses). Grounded in Büring 2012 (HSK, art. 40). Additive — `presupOfReferent`/`PrProp` consumers untouched.