### PR TITLE
refactor(Pronoun): route data, denotation, binding through the object

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -633,6 +633,7 @@ import Linglib.Fragments.English.Numerals
 import Linglib.Fragments.English.Plurals
 import Linglib.Fragments.English.Reference
 import Linglib.Fragments.English.Pronouns
+import Linglib.Fragments.English.NominalClassification
 import Linglib.Fragments.English.PropositionalLexemes
 import Linglib.Fragments.English.QuestionParticles
 import Linglib.Fragments.English.Scales

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1391,6 +1391,7 @@ import Linglib.Studies.Wellwood2015
 import Linglib.Studies.FoxHackl2006
 import Linglib.Studies.VonStechow1984
 import Linglib.Studies.Buring2007
+import Linglib.Studies.Buring2012
 import Linglib.Studies.Bobaljik2012
 import Linglib.Studies.BhattPancheva2004
 import Linglib.Studies.Lechner2004

--- a/Linglib/Features/CoreferenceStatus.lean
+++ b/Linglib/Features/CoreferenceStatus.lean
@@ -22,4 +22,20 @@ inductive CoreferenceStatus where
   | unspecified
   deriving Repr, DecidableEq
 
+/-- The binding-theoretic class of a nominal expression, shared across the
+    syntactic frameworks (HPSG, Dependency Grammar, Minimalism) so their
+    `classifyNominal` functions return the same type. The per-language
+    realization (which forms are which) lives in a Fragment helper (e.g.
+    `Fragments.English.NominalClassification`). -/
+inductive NominalType where
+  /-- Reflexive anaphor (*himself*, *herself*, *themselves*). -/
+  | reflexive
+  /-- Reciprocal anaphor (*each other*, *one another*). -/
+  | reciprocal
+  /-- Personal/other pronoun (*he*, *she*, *they*, …). -/
+  | pronoun
+  /-- Referring expression (proper name, full NP). -/
+  | rExpression
+  deriving Repr, DecidableEq
+
 end Features

--- a/Linglib/Fragments/English/NominalClassification.lean
+++ b/Linglib/Fragments/English/NominalClassification.lean
@@ -1,0 +1,75 @@
+import Linglib.Core.Word
+import Linglib.Features.CoreferenceStatus
+import Linglib.Fragments.English.Pronouns
+
+/-!
+# English nominal classification for binding
+
+Lexicon-driven classification of English nominals into `Features.NominalType`,
+plus φ-feature agreement, shared by the coreference/binding analyses in every
+syntactic framework (`Syntax.Minimalist.Coreference`, `Syntax.HPSG.Coreference`,
+`Syntax.DependencyGrammar`). Each previously re-stipulated these with hardcoded
+pronoun-form string lists; routing through `Fragments.English.Pronouns` makes
+the three frameworks classify against one lexicon.
+
+## Main definitions
+
+* `classifyNominal` — `Word → Option Features.NominalType`, via the pronoun
+  lexicon (`Fragments.English.Pronouns.lookup`) with a UPOS fallback for
+  R-expressions.
+* `phiAgree` — person/number/gender agreement between two nominals, as a `Prop`
+  with a `Decidable` instance.
+-/
+
+namespace Fragments.English.NominalClassification
+
+open Features (NominalType)
+
+/-- Is this a nominal category (proper noun, common noun, or pronoun)? -/
+def isNominalCat (c : UD.UPOS) : Bool :=
+  c == .PROPN || c == .NOUN || c == .PRON
+
+/-- Classify a word as a binding-theoretic nominal type.
+
+    Derives the classification from `Fragments.English.Pronouns` rather than a
+    hardcoded form list: a pronoun lexicon hit dispatches on its `pronounType`
+    (wh/relative/demonstrative count as pronominal), and any other nominal
+    category is an R-expression. -/
+def classifyNominal (w : Word) : Option NominalType :=
+  match Fragments.English.Pronouns.lookup w.form with
+  | some entry => match entry.pronounType with
+    | .reflexive  => some .reflexive
+    | .reciprocal => some .reciprocal
+    | _           => some .pronoun
+  | none =>
+    if isNominalCat w.cat then some .rExpression
+    else none
+
+/-- φ-feature agreement (person, number, gender) between two nominals.
+    Person and number compare the morphosyntactic features directly; gender
+    routes through the Fragment's `genderAgrees` (unspecified gender agrees
+    with anything). -/
+def phiAgree (w1 w2 : Word) : Prop :=
+  (match w1.features.person, w2.features.person with
+    | some p1, some p2 => p1 = p2
+    | _, _ => True) ∧
+  (match w1.features.number, w2.features.number with
+    | some n1, some n2 => n1 = n2
+    | _, _ => True) ∧
+  Fragments.English.Pronouns.genderAgrees w1.form w2.form = true
+
+instance (w1 w2 : Word) : Decidable (phiAgree w1 w2) := by
+  unfold phiAgree
+  have d1 : Decidable
+      (match w1.features.person, w2.features.person with
+       | some p1, some p2 => p1 = p2
+       | _, _ => True) := by
+    split <;> infer_instance
+  have d2 : Decidable
+      (match w1.features.number, w2.features.number with
+       | some n1, some n2 => n1 = n2
+       | _, _ => True) := by
+    split <;> infer_instance
+  exact inferInstance
+
+end Fragments.English.NominalClassification

--- a/Linglib/Fragments/English/Pronouns.lean
+++ b/Linglib/Fragments/English/Pronouns.lean
@@ -1,13 +1,13 @@
-/-
-# English Pronoun Lexicon Fragment
-
-Lexical entries for English pronouns (personal, reflexive, wh-).
--/
-
 import Linglib.Core.Word
 import Linglib.Features.Case
 import Linglib.Typology.Pronoun.Basic
 import Linglib.Typology.Pronoun.WALS
+
+/-!
+# English Pronoun Lexicon Fragment
+
+Lexical entries for English pronouns (personal, reflexive, wh-).
+-/
 
 namespace Fragments.English.Pronouns
 
@@ -69,18 +69,20 @@ inductive PronounType where
 
 /--
 A lexical entry for a pronoun.
--/
-structure PronounEntry where
-  /-- Surface form -/
-  form : String
+
+Extends the cross-linguistic `Pronoun.Entry` core (`form`, `person`, `number`,
+`case_`, `gender`, …): the shared lexical fields are the object's fields *by
+construction*, not via a mapping. The three additional fields below are the
+English-specific extensions the `Pronoun.Entry` docstring anticipates
+(`pronounType`, `wh`) plus the epicene-aware `genderParadigm`, which is finer
+than the inherited `Pronoun.Entry.gender : Option SurfaceGender` (it
+distinguishes singular *they* from genuinely genderless forms). The inherited
+`gender` is left at its default in the literals; `PronounEntry.entry` fills it
+from `genderParadigm` so the object's denotation (`Pronoun.Entry.denote`,
+`Pronoun.Entry.phiPresup`) can be taken without storing gender twice. -/
+structure PronounEntry extends Pronoun.Entry where
   /-- Pronoun type -/
   pronounType : PronounType
-  /-- Person (for personal/reflexive) -/
-  person : Option Person := none
-  /-- Number -/
-  number : Option Number := none
-  /-- Case (for personal pronouns) -/
-  case_ : Option Features.Case := none
   /-- Gender paradigm class (3rd-person singular agreement).
       Epicene covers singular *they*; `none` for 1st/2nd person,
       reciprocals, and wh-pronouns. -/
@@ -88,6 +90,13 @@ structure PronounEntry where
   /-- Is this a wh-word? -/
   wh : Bool := false
   deriving Repr, BEq
+
+/-- The canonical `Pronoun.Entry` for this English entry: the inherited core
+with `gender` derived from the epicene-aware `genderParadigm` (epicene and
+unspecified contribute no `SurfaceGender`). Routes English pronouns into
+`Pronoun.Entry.denote`/`phiPresup`. -/
+def PronounEntry.entry (p : PronounEntry) : Pronoun.Entry :=
+  { p.toEntry with gender := p.genderParadigm.bind GenderParadigm.toSurfaceGender }
 
 -- ============================================================================
 -- Personal Pronouns

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -1,4 +1,5 @@
 import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 import Linglib.Core.Word
 
 /-! # Italian Pronoun and Clitic Fragment
@@ -220,3 +221,20 @@ theorem has_both_numbers :
     allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
 
 end Fragments.Italian.Pronouns
+
+namespace Fragments.Italian
+
+/-- Italian (Indo-European, Romance) pronoun typology profile, read off this
+    fragment's lexical inventory: no inclusive/exclusive distinction (*noi* is
+    a single 1pl), a binary T/V politeness distinction (*tu*/*Lei*), and gender
+    in the 3rd-person singular (*lui*/*lei*). Fields not evidenced by the
+    inventory are left unsurveyed (`.none`). -/
+def pronounProfile : Pronoun.Profile :=
+  { language := "Italian"
+  , family := "Indo-European"
+  , iso := "ita"
+  , inclusiveExclusive := some .noDistinction
+  , politeness := some .binary
+  , genderInPronouns := some .in3rdPersonSgOnly }
+
+end Fragments.Italian

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -220,6 +220,24 @@ theorem has_both_numbers :
     allPronouns.any (·.number == some .sg) = true ∧
     allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
 
+-- ============================================================================
+-- § 5: Cardinaletti–Starke deficiency classes
+-- ============================================================================
+
+/-- Italian's two pronoun series instantiate two Cardinaletti–Starke deficiency
+    classes (@cite{cardinaletti-starke-1999}): the strong forms (`allPronouns`)
+    are `.strong`; the object clitics (`paradigm`) are `.clitic`. -/
+def strongStrength : Strength := .strong
+
+/-- The object-clitic series is the maximally deficient `.clitic` class. -/
+def cliticStrength : Strength := .clitic
+
+/-- The clitic series is structurally more deficient than the strong series
+    (lower `Strength.rank`): the deficiency ordering behind their complementary
+    distribution (clitics host-adjacent and unfocusable, strong forms free). -/
+theorem clitics_more_deficient :
+    Strength.rank cliticStrength < Strength.rank strongStrength := by decide
+
 end Fragments.Italian.Pronouns
 
 namespace Fragments.Italian

--- a/Linglib/Fragments/Japanese/Pronouns.lean
+++ b/Linglib/Fragments/Japanese/Pronouns.lean
@@ -12,7 +12,6 @@ traditional Japanese relies heavily on null reference.
 
 import Linglib.Typology.Pronoun.Basic
 import Linglib.Typology.Pronoun.WALS
-import Linglib.Typology.Pronoun.Basic
 
 namespace Fragments.Japanese.Pronouns
 

--- a/Linglib/Fragments/Korean/Pronouns.lean
+++ b/Linglib/Fragments/Korean/Pronouns.lean
@@ -41,7 +41,6 @@ much of the linguistics literature) appear in docstrings only.
 
 import Linglib.Typology.Pronoun.Basic
 import Linglib.Typology.Pronoun.WALS
-import Linglib.Typology.Pronoun.Basic
 
 namespace Fragments.Korean.Pronouns
 

--- a/Linglib/Fragments/Mixtec/SMPM/Basic.lean
+++ b/Linglib/Fragments/Mixtec/SMPM/Basic.lean
@@ -1,5 +1,6 @@
 import Linglib.Features.Gender
 import Linglib.Core.Word
+import Linglib.Typology.Pronoun.Basic
 
 /-!
 # San Martín Peras Mixtec (SMPM) Fragment
@@ -82,11 +83,21 @@ def Gender.toSurfaceGender : Gender → Features.SurfaceGender
     SMPM distinguishes clitic and nonclitic pronouns
     (@cite{cardinaletti-starke-1999}). Clitics cannot be coordinated,
     cannot occur on their own, and may have impersonal readings.
-    Nonclitic forms can bear focus (e.g., with *íntàà* 'only'). -/
+    Nonclitic forms can bear focus (e.g., with *íntàà* 'only'). The two
+    variants instantiate two of Cardinaletti–Starke's deficiency classes,
+    routed through the shared `Pronoun.Strength` type below. -/
 structure PronounForm where
   clitic : String
   nonclitic : Option String  -- `none` if no distinct nonclitic form exists
   deriving Repr, DecidableEq
+
+/-- The Cardinaletti–Starke deficiency class of the `clitic` field: the
+    maximally deficient `.clitic` class. -/
+def PronounForm.cliticStrength : Pronoun.Strength := .clitic
+
+/-- The deficiency class of the `nonclitic` field, where present: the full
+    `.strong` form (focusable, coordinable). -/
+def PronounForm.noncliticStrength : Pronoun.Strength := .strong
 
 /-- Local person clitic pronouns (tables 4, 61). -/
 def pron1sg     : PronounForm := ⟨"=ì",    some "yù'u"⟩
@@ -107,9 +118,18 @@ def pron3sgAml     : String := "=rí"
 def pron3plNeutral : String := "=nà"
 def pron3plFem     : String := "=ná"
 
-/-- Controlled subjects in untensed subjunctives must be CLITIC pronouns.
-    Nonclitic forms are ungrammatical in this position (67). -/
-def controlledSubjectMustBeClitic : Bool := true
+/-- The Cardinaletti–Starke deficiency class required of a controlled subject
+    in an untensed subjunctive: the clitic (most deficient). Nonclitic (strong)
+    forms are ungrammatical in this position (67). -/
+def controlledSubjectStrength : Pronoun.Strength := PronounForm.cliticStrength
+
+/-- SMPM's ban on nonclitic controlled subjects (67) realizes the
+    Cardinaletti–Starke prediction: the required form is strictly more
+    deficient (lower `Strength.rank`) than the nonclitic strong alternative.
+    Derived from the shared deficiency ranking, not stipulated. -/
+theorem controlledSubject_is_most_deficient :
+    Pronoun.Strength.rank controlledSubjectStrength
+      < Pronoun.Strength.rank PronounForm.noncliticStrength := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 4: Embedded Clause Typology (table 26)

--- a/Linglib/Fragments/Spanish/Pronouns.lean
+++ b/Linglib/Fragments/Spanish/Pronouns.lean
@@ -1,6 +1,5 @@
 import Linglib.Typology.Pronoun.Basic
 import Linglib.Typology.Pronoun.WALS
-import Linglib.Typology.Pronoun.Basic
 
 /-!
 # Spanish Pronoun Fragment

--- a/Linglib/Fragments/Tamil/Pronouns.lean
+++ b/Linglib/Fragments/Tamil/Pronouns.lean
@@ -11,6 +11,7 @@ exclusive (*naangaL*). 3rd person distinguishes masculine (*avan*), feminine
 -/
 
 import Linglib.Typology.Pronoun.Basic
+import Linglib.Typology.Pronoun.WALS
 
 namespace Fragments.Tamil.Pronouns
 
@@ -120,3 +121,21 @@ theorem markers_match_2p :
     allAllocMarkers.map (·.register) = secondPersonPronouns.map (·.register) := rfl
 
 end Fragments.Tamil.Pronouns
+
+namespace Fragments.Tamil
+
+/-- Tamil (Dravidian) pronoun typology profile, read off this fragment's
+    lexical inventory rather than asserted from a WALS datapoint: full
+    inclusive/exclusive 1pl (*naam* vs *naangaL*), a two-level honorific
+    register split in 2nd person (*nii*/*niingaL*, a binary T/V-style
+    distinction), and gender in the 3rd-person singular (*avan*/*avaL*).
+    Fields not evidenced by the inventory are left unsurveyed (`.none`). -/
+def pronounProfile : Pronoun.Profile :=
+  { language := "Tamil"
+  , family := "Dravidian"
+  , iso := "tam"
+  , inclusiveExclusive := some .inclusiveExclusive
+  , politeness := some .binary
+  , genderInPronouns := some .in3rdPersonSgOnly }
+
+end Fragments.Tamil

--- a/Linglib/Studies/Buring2012.lean
+++ b/Linglib/Studies/Buring2012.lean
@@ -1,0 +1,84 @@
+import Linglib.Fragments.English.Pronouns
+import Linglib.Semantics.Reference.PronounDenotation
+
+/-!
+# Büring 2012 — pronouns as φ-presupposing variables
+@cite{buring-2012}
+
+@cite{buring-2012}'s handbook survey of pronoun semantics makes several claims
+this file states as theorems about the *unified* pronoun denotation
+(`Pronoun.Entry.denote` / `Pronoun.Entry.phiPresup`) applied to the English
+Fragment's lexical entries (`Fragments.English.Pronouns`) — not about a local
+re-implementation. This is the "theory-hub denotation as study-file constraint":
+the object the rest of the codebase attributes to pronouns is the object these
+theorems are about.
+
+* A pronoun denotes the assignment value `g i` — the variable lookup
+  (`interpPronoun`). Free, anaphoric, and deictic uses share this selector.
+* Its φ-features are *presuppositions* on the resolved referent: a feminine
+  pronoun is undefined of a non-feminine referent (agreement-as-presupposition,
+  not assertion).
+* A *bound* pronoun has the *same* denotation as a free one — binding is
+  supplied externally by an assignment update, not by a distinct lexical entry
+  (Büring's §3 thesis; the continuation rendering is `Semantics.Reference.Binding`).
+
+A fourth theorem records the @cite{arnold-2026} contrast that motivates the
+English `epicene` paradigm: *they* carries no gender presupposition, so it is
+defined of a referent of any gender — exactly where *she* is undefined.
+
+## Main results
+
+* `she_denotes_assignment_value` — the selector is the variable lookup `g i`.
+* `she_undefined_of_non_female` — the φ-feature presupposition (negative test).
+* `she_bound_reading` — external binding (assignment update) returns the binder.
+* `they_defined_regardless_of_gender` — epicene *they* imposes no gender presup.
+-/
+
+set_option autoImplicit false
+
+namespace Buring2012
+
+open Fragments.English.Pronouns (she they)
+open Core (Assignment)
+open Core.Logic.Intensional (Frame)
+open Core.Logic.Intensional.Variables (interpPronoun)
+
+variable {F : Frame} [PartialOrder F.Entity]
+  (g : Assignment F.Entity) (i : ℕ) (spk adr : F.Entity)
+  (isFemale isInanimate : F.Entity → Prop)
+
+/-- A pronoun denotes the assignment value `g i`: its selector is the canonical
+variable lookup `interpPronoun i`, by construction. Büring's assignment-lookup
+denotation — the same selector for free, anaphoric, and deictic uses. -/
+theorem she_denotes_assignment_value :
+    (she.entry.denote i spk adr isFemale isInanimate).selector g ⟨⟩
+      = some (interpPronoun i g) := rfl
+
+/-- φ-features as presupposition: *she* is undefined of a non-female referent.
+The feminine feature does not *assert* femaleness of `g i` — it *presupposes*
+it, so the whole denotation lacks a defined value when the referent is not
+female. -/
+theorem she_undefined_of_non_female (scope : F.Entity → PUnit → Prop)
+    (h : ¬ isFemale (g i)) :
+    ¬ ((she.entry.denote i spk adr isFemale isInanimate).toPrProp scope g).presup ⟨⟩ :=
+  fun hp => h hp.1.2.2
+
+/-- A bound pronoun has the same denotation as a free one: binding is the
+external assignment update `g.update i b`, and the *unchanged* selector then
+returns the binder `b`. Büring §3 — there is no separate "bound pronoun"
+lexeme; the lexical entry is identical, binding lives in the assignment. -/
+theorem she_bound_reading (b : F.Entity) :
+    (she.entry.denote i spk adr isFemale isInanimate).selector (g.update i b) ⟨⟩
+      = some b := by
+  simp only [Pronoun.Entry.denote, interpPronoun, Assignment.update_at]
+
+/-- Epicene *they* (@cite{arnold-2026}) carries no gender presupposition: its
+denotation is defined of a referent regardless of gender — the structural
+correlate of *they*'s gender-neutrality, and the direct contrast with
+`she_undefined_of_non_female`. -/
+theorem they_defined_regardless_of_gender (scope : F.Entity → PUnit → Prop) :
+    ((they.entry.denote i spk adr isFemale isInanimate).toPrProp scope g).presup ⟨⟩ := by
+  refine ⟨⟨trivial, trivial, trivial⟩, ?_⟩
+  rfl
+
+end Buring2012

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -366,9 +366,14 @@ theorem smpm_no_scope_operator :
 theorem smpm_copy_cannot_bear_focus :
     (copyControlProfile smpmCopyControlType).copyCanBearFocus = false := rfl
 
-/-- The clitic requirement is derived from the fragment. -/
+/-- The clitic requirement, derived from the fragment and routed through the
+    Cardinaletti–Starke deficiency ranking: the required controlled-subject form
+    is strictly more deficient (lower `Strength.rank`) than the nonclitic strong
+    alternative. -/
 theorem smpm_controlled_must_be_clitic :
-    Fragments.Mixtec.SMPM.controlledSubjectMustBeClitic = true := rfl
+    Pronoun.Strength.rank Fragments.Mixtec.SMPM.controlledSubjectStrength
+      < Pronoun.Strength.rank Fragments.Mixtec.SMPM.PronounForm.noncliticStrength :=
+  Fragments.Mixtec.SMPM.controlledSubject_is_most_deficient
 
 -- ════════════════════════════════════════════════════════════════
 -- § 9: Exempt Anaphor Argument (§6)

--- a/Linglib/Syntax/DependencyGrammar/Core/Nominal.lean
+++ b/Linglib/Syntax/DependencyGrammar/Core/Nominal.lean
@@ -5,6 +5,8 @@ Used by d-command (Coreference.lean) binding analyses.
 -/
 
 import Linglib.Core.Word
+import Linglib.Features.CoreferenceStatus
+import Linglib.Fragments.English.NominalClassification
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Pronouns
 import Linglib.Fragments.English.Predicates.Verbal
@@ -12,56 +14,15 @@ import Linglib.Fragments.English.Predicates.Verbal
 namespace DepGrammar.Nominal
 
 -- ============================================================================
--- Nominal Classification
+-- Nominal Classification (shared helper)
 -- ============================================================================
 
-/-- Types of nominal expressions for coreference. -/
-inductive NominalType where
-  | reflexive   -- himself, herself, themselves
-  | reciprocal  -- each other, one another
-  | pronoun     -- he, she, they, him, her, them
-  | rExpression -- John, Mary, the cat
-  deriving Repr, DecidableEq
-
-/-- Is this a nominal category? -/
-def isNominalCat (c : UD.UPOS) : Bool :=
-  c == .PROPN || c == .NOUN || c == .PRON
-
-/-- Classify a word as a nominal type. -/
-def classifyNominal (w : Word) : Option NominalType :=
-  if w.form ∈ ["himself", "herself", "themselves", "myself", "yourself", "ourselves"] then
-    some .reflexive
-  else if w.form ∈ ["each other", "one another"] then
-    some .reciprocal
-  else if w.form ∈ ["he", "she", "they", "him", "her", "them", "it"] then
-    some .pronoun
-  else if isNominalCat w.cat then
-    some .rExpression
-  else
-    none
-
--- ============================================================================
--- Phi-Feature Agreement
--- ============================================================================
-
-/-- Check phi-feature agreement (person, number, gender) between two nominals. -/
-def phiAgree (w1 w2 : Word) : Bool :=
-  let personMatch := match w1.features.person, w2.features.person with
-    | some p1, some p2 => p1 == p2
-    | _, _ => true
-  let numberMatch := match w1.features.number, w2.features.number with
-    | some n1, some n2 => n1 == n2
-    | _, _ => true
-  let genderMatch :=
-    if w2.form == "himself" then
-      w1.form ∈ ["John", "he", "him"]
-    else if w2.form == "herself" then
-      w1.form ∈ ["Mary", "she", "her"]
-    else if w2.form ∈ ["themselves", "ourselves"] then
-      w1.features.number == some .pl
-    else
-      true
-  personMatch && numberMatch && genderMatch
+-- Nominal classification and φ-agreement are the shared, lexicon-driven
+-- `Fragments.English.NominalClassification` definitions, re-exported here so
+-- the d-command binding analyses (`Coreference.lean`) keep referring to them
+-- through `DepGrammar.Nominal`.
+export Features (NominalType)
+export Fragments.English.NominalClassification (isNominalCat classifyNominal phiAgree)
 
 -- ============================================================================
 -- Shared Test Words (from Fragments, used by Coreference.lean)

--- a/Linglib/Syntax/DependencyGrammar/Coreference.lean
+++ b/Linglib/Syntax/DependencyGrammar/Coreference.lean
@@ -116,7 +116,7 @@ def reflexiveLicensed (clause : SimpleClause) : Bool :=
     | some .reflexive =>
       subjectDCommandsObject clause &&
       sameLocalDomain clause &&
-      phiAgree clause.subject obj
+      decide (phiAgree clause.subject obj)
     | _ => true
 
 /-- Reciprocals must be d-commanded by a semantically plural antecedent.

--- a/Linglib/Syntax/HPSG/Coreference.lean
+++ b/Linglib/Syntax/HPSG/Coreference.lean
@@ -15,6 +15,7 @@ the Chomskyan Principle C. No separate "Principle C" is needed.
 import Linglib.Syntax.HPSG.Core.Basic
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Pronouns
+import Linglib.Fragments.English.NominalClassification
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Features.CoreferenceStatus
 import Linglib.Paradigms.AcceptabilityJudgment
@@ -36,30 +37,27 @@ private abbrev eachOther := Fragments.English.Pronouns.eachOther.toWord
 
 namespace HPSG.Coreference
 
+open Features (NominalType)
+open Fragments.English.NominalClassification (isNominalCat classifyNominal phiAgree)
+
 -- ============================================================================
 -- MODE Classification
 -- ============================================================================
 
 section ModeClassification
 
-/-- Is this a nominal category? -/
-def isNominalCat (c : UD.UPOS) : Bool :=
-  c == .PROPN || c == .NOUN || c == .PRON
-
-/-- Derive MODE feature from a word.
+/-- Derive MODE feature from a word, via the shared `classifyNominal`.
 
     Per @cite{sag-wasow-bender-2003} Ch. 7:
     - Reflexives and reciprocals → [MODE ana]
     - Personal pronouns and R-expressions → [MODE ref] -/
 def classifyMode (w : Word) : Option HPSG.Mode :=
-  if w.form ∈ ["himself", "herself", "themselves", "myself", "yourself", "ourselves"] then
-    some .ana
-  else if w.form ∈ ["each other", "one another"] then
-    some .ana
-  else if isNominalCat w.cat then
-    some .ref
-  else
-    none
+  match classifyNominal w with
+  | some .reflexive   => some .ana
+  | some .reciprocal  => some .ana
+  | some .pronoun     => some .ref
+  | some .rExpression => some .ref
+  | none              => none
 
 /-- Is this word an anaphor ([MODE ana])? -/
 def isAnaphor (w : Word) : Bool :=
@@ -67,42 +65,15 @@ def isAnaphor (w : Word) : Bool :=
 
 /-- Is this word a reflexive specifically? -/
 def isReflexive (w : Word) : Bool :=
-  w.form ∈ ["himself", "herself", "themselves", "myself", "yourself", "ourselves"]
+  match classifyNominal w with
+  | some .reflexive => true
+  | _               => false
 
 /-- Is this word a reciprocal? -/
 def isReciprocal (w : Word) : Bool :=
-  w.form ∈ ["each other", "one another"]
-
-/-- Types of nominal expressions for coreference.
-
-    Implementation convenience for dispatching agreement checks.
-    Both `pronoun` and `rExpression` map to [MODE ref] in SWB2003. -/
-inductive NominalType where
-  | reflexive   -- himself, herself, themselves
-  | reciprocal  -- each other, one another
-  | pronoun     -- he, she, they, him, her, them
-  | rExpression -- John, Mary, the cat
-  deriving Repr, DecidableEq
-
-/-- Classify a word as a nominal type.
-
-    This maps to MODE as follows:
-    - reflexive, reciprocal → [MODE ana]
-    - pronoun, rExpression → [MODE ref]
-
-    The pronoun/rExpression distinction is useful for implementation
-    (e.g., agreement checks) but both are [MODE ref] in SWB2003. -/
-def classifyNominal (w : Word) : Option NominalType :=
-  if w.form ∈ ["himself", "herself", "themselves", "myself", "yourself", "ourselves"] then
-    some .reflexive
-  else if w.form ∈ ["each other", "one another"] then
-    some .reciprocal
-  else if w.form ∈ ["he", "she", "they", "him", "her", "them", "it"] then
-    some .pronoun
-  else if isNominalCat w.cat then
-    some .rExpression
-  else
-    none
+  match classifyNominal w with
+  | some .reciprocal => true
+  | _                => false
 
 end ModeClassification
 
@@ -172,31 +143,6 @@ end ArgStOutranking
 -- Anaphoric Agreement Principle
 -- ============================================================================
 
-section Agreement
-
-/-- Anaphoric Agreement Principle (AAP): coindexed elements must agree.
-
-    Per @cite{sag-wasow-bender-2003} Ch. 7: "Coindexed NPs agree." -/
-def phiAgree (w1 w2 : Word) : Bool :=
-  let personMatch := match w1.features.person, w2.features.person with
-    | some p1, some p2 => p1 == p2
-    | _, _ => true  -- Compatible if unspecified
-  let numberMatch := match w1.features.number, w2.features.number with
-    | some n1, some n2 => n1 == n2
-    | _, _ => true
-  let genderMatch :=
-    if w2.form == "himself" then
-      w1.form ∈ ["John", "he", "him"]  -- masculine antecedents
-    else if w2.form == "herself" then
-      w1.form ∈ ["Mary", "she", "her"]  -- feminine antecedents
-    else if w2.form ∈ ["themselves", "ourselves"] then
-      w1.features.number == some .pl  -- plural
-    else
-      true
-  personMatch && numberMatch && genderMatch
-
-end Agreement
-
 -- ============================================================================
 -- Binding Principles
 -- ============================================================================
@@ -215,7 +161,7 @@ def reflexiveLicensed (clause : SimpleClause) : Bool :=
     | some .reflexive =>
       subjectOutranksObject clause &&
       sameArgSt clause &&
-      phiAgree clause.subject obj
+      decide (phiAgree clause.subject obj)
     | _ => true
 
 /-- Principle A for reciprocals: a reciprocal ([MODE ana]) must be outranked
@@ -385,7 +331,7 @@ def computeCoreferenceStatus (clause : SimpleClause) (i j : Nat) : Features.Core
       match classifyMode obj with
       | some .ana =>
         -- Principle A: anaphor must be outranked — check agreement
-        if subjectOutranksObject clause && sameArgSt clause && phiAgree clause.subject obj
+        if subjectOutranksObject clause && sameArgSt clause && decide (phiAgree clause.subject obj)
         then .obligatory
         else .blocked
       | some .ref =>

--- a/Linglib/Syntax/Minimalist/Coreference.lean
+++ b/Linglib/Syntax/Minimalist/Coreference.lean
@@ -1,5 +1,6 @@
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Pronouns
+import Linglib.Fragments.English.NominalClassification
 import Linglib.Syntax.Minimalist.Basic
 import Linglib.Features.CoreferenceStatus
 
@@ -17,31 +18,8 @@ Coreference constraints via c-command and locality following @cite{chomsky-1981}
 
 namespace Minimalist.Coreference
 
-/-- Types of nominal expressions for coreference -/
-inductive NominalType where
-  | reflexive
-  | reciprocal
-  | pronoun
-  | rExpression
-  deriving Repr, DecidableEq
-
-/-- Is this a nominal category? -/
-def isNominalCat (c : UD.UPOS) : Bool :=
-  c == .PROPN || c == .NOUN || c == .PRON
-
-/-- Classify a word as a nominal type.
-    Derives classification from `Fragments.English.Pronouns` rather than
-    hardcoding string lists. Falls back to UPOS for R-expressions. -/
-def classifyNominal (w : Word) : Option NominalType :=
-  match Fragments.English.Pronouns.lookup w.form with
-  | some entry => match entry.pronounType with
-    | .reflexive => some .reflexive
-    | .reciprocal => some .reciprocal
-    | .personal => some .pronoun
-    | _ => some .pronoun  -- wh, relative, demonstrative treated as pronominal
-  | none =>
-    if isNominalCat w.cat then some .rExpression
-    else none
+open Features (NominalType)
+open Fragments.English.NominalClassification (isNominalCat classifyNominal phiAgree)
 
 /-- Simple clause structure for coreference checking.
     `semanticPl` tracks whether the subject denotes a plurality,
@@ -146,34 +124,6 @@ def inSameBindingDomain (_clause : SimpleClause) (_pos1 _pos2 : String) : Prop :
 instance (clause : SimpleClause) (pos1 pos2 : String) :
     Decidable (inSameBindingDomain clause pos1 pos2) := by
   unfold inSameBindingDomain; infer_instance
-
-/-- Phi-feature agreement for coreference.
-    Checks person, number, and gender agreement between antecedent and
-    anaphor. Person and number come from `Word.Features`; gender uses
-    `Fragments.English.Pronouns.genderAgrees` since `Word` currently
-    lacks a gender field. -/
-def phiAgree (w1 w2 : Word) : Prop :=
-  (match w1.features.person, w2.features.person with
-    | some p1, some p2 => p1 = p2
-    | _, _ => True) ∧
-  (match w1.features.number, w2.features.number with
-    | some n1, some n2 => n1 = n2
-    | _, _ => True) ∧
-  Fragments.English.Pronouns.genderAgrees w1.form w2.form = true
-
-instance (w1 w2 : Word) : Decidable (phiAgree w1 w2) := by
-  unfold phiAgree
-  have d1 : Decidable
-      (match w1.features.person, w2.features.person with
-       | some p1, some p2 => p1 = p2
-       | _, _ => True) := by
-    split <;> infer_instance
-  have d2 : Decidable
-      (match w1.features.number, w2.features.number with
-       | some n1, some n2 => n1 = n2
-       | _, _ => True) := by
-    split <;> infer_instance
-  exact inferInstance
 
 /-- Principle A: Reflexives must be bound locally -/
 def reflexiveLicensed (clause : SimpleClause) : Prop :=

--- a/Linglib/Typology/Plurals.lean
+++ b/Linglib/Typology/Plurals.lean
@@ -1,3 +1,5 @@
+import Linglib.Typology.Pronoun.WALS
+
 /-!
 # Plural-marking typology — substrate types
 @cite{wals-2013} (Chs 33-36)
@@ -9,7 +11,8 @@ plurality across @cite{wals-2013} chapters 33–36.
 
 - `PluralCoding` (Ch 33): how plurality is morphologically realized
 - `PluralOccurrence` (Ch 34): when plural marking occurs (animacy + obligatoriness)
-- `PronounPlurality` (Ch 35): how independent pronouns encode number
+- `Pronoun.Plurality` (Ch 35): how independent pronouns encode number —
+  the canonical type lives in `Typology/Pronoun/WALS.lean`; this file bundles it
 - `AssociativePlural` (Ch 36): "X and associates" construction
 - `PluralityProfile`: per-language bundle of the four
 
@@ -73,26 +76,6 @@ inductive PluralOccurrence where
   | allNounsAlwaysObligatory
   deriving DecidableEq, Repr
 
-/-- WALS Ch 35: how independent personal pronouns encode number. -/
-inductive PronounPlurality where
-  /-- No independent subject pronouns (e.g., Acoma). -/
-  | noIndependentPronouns
-  /-- Same form for sg and pl (e.g., Pirahã ti 'I/we'). -/
-  | numberIndifferent
-  /-- Both person and number are affixal. -/
-  | personNumberAffixes
-  /-- Person+number fused in stem (e.g., Dogon mi/emme). -/
-  | personNumberStem
-  /-- Person-number stem + pronominal plural affix. -/
-  | pnStemPronominalAffix
-  /-- Person-number stem + nominal plural affix (e.g., Russian). -/
-  | pnStemNominalAffix
-  /-- Person stem + pronominal plural affix (e.g., Chuvash). -/
-  | personStemPronominalAffix
-  /-- Person stem + nominal plural affix (e.g., Mandarin -men). -/
-  | personStemNominalAffix
-  deriving DecidableEq, Repr
-
 /-- WALS Ch 36: associative plural marking ("X and associates").
     The typological split is between marker-overlap with additive
     plural vs dedicated associative form. -/
@@ -117,8 +100,8 @@ structure PluralityProfile where
   coding : PluralCoding
   /-- Ch 34: when plural marking occurs. -/
   occurrence : PluralOccurrence
-  /-- Ch 35: pronoun plurality type. -/
-  pronounPlurality : PronounPlurality
+  /-- Ch 35: pronoun plurality type (canonical type in `Typology/Pronoun/WALS.lean`). -/
+  pronounPlurality : Pronoun.Plurality
   /-- Ch 36: associative plural strategy. -/
   associativePlural : AssociativePlural
   deriving Repr, DecidableEq

--- a/Linglib/Typology/Pronoun/WALS.lean
+++ b/Linglib/Typology/Pronoun/WALS.lean
@@ -1,3 +1,4 @@
+import Linglib.Data.WALS.Features.F35A
 import Linglib.Data.WALS.Features.F39A
 import Linglib.Data.WALS.Features.F39B
 import Linglib.Data.WALS.Features.F40A
@@ -27,6 +28,10 @@ feature-system `Profile` (Chs 39–48) and phonological `ShapeProfile`
   marking), WALS Chs 39–48.
 * `Pronoun.ShapeProfile` — per-language M-T / N-M phonological-shape survey,
   WALS Chs 136–137 (@cite{nichols-peterson-2013}).
+* `Pronoun.Plurality` — how independent personal pronouns encode number,
+  WALS Ch 35. The canonical home for this pronoun-paradigm feature; the
+  per-language values are carried by `Typology.PluralityProfile` (which bundles
+  it with the nominal-plurality Chs 33/34/36).
 -/
 
 set_option autoImplicit false
@@ -367,6 +372,55 @@ def InclusiveExclusive.fromClusivity : Features.Clusivity.System → InclusiveEx
   | .minimalAugmented   => .inclusiveExclusive
   | .unitAugmented      => .inclusiveExclusive
   | .numberIndifferent  => .weEqualsI
+
+end Pronoun
+
+/-! ### Pronoun plurality (WALS Ch 35) -/
+
+namespace Pronoun
+
+/-- WALS Ch 35: how independent personal pronouns encode number. The canonical
+    home for this pronoun-paradigm feature; `Typology.PluralityProfile` carries
+    the per-language values alongside the nominal-plurality chapters (33/34/36). -/
+inductive Plurality where
+  /-- No independent subject pronouns (e.g., Acoma). -/
+  | noIndependentPronouns
+  /-- Same form for sg and pl (e.g., Pirahã ti 'I/we'). -/
+  | numberIndifferent
+  /-- Both person and number are affixal. -/
+  | personNumberAffixes
+  /-- Person+number fused in stem (e.g., Dogon mi/emme). -/
+  | personNumberStem
+  /-- Person-number stem + pronominal plural affix. -/
+  | pnStemPronominalAffix
+  /-- Person-number stem + nominal plural affix (e.g., Russian). -/
+  | pnStemNominalAffix
+  /-- Person stem + pronominal plural affix (e.g., Chuvash). -/
+  | personStemPronominalAffix
+  /-- Person stem + nominal plural affix (e.g., Mandarin -men). -/
+  | personStemNominalAffix
+  deriving DecidableEq, BEq, Repr
+
+/-- WALS Ch 35 raw values → the friendly `Plurality` labels. -/
+def fromWALS35A : Data.WALS.F35A.PronounPlurality → Plurality
+  | .noIndependentSubjectPronouns          => .noIndependentPronouns
+  | .numberIndifferentPronouns             => .numberIndifferent
+  | .personNumberAffixes                   => .personNumberAffixes
+  | .personNumberStem                      => .personNumberStem
+  | .personNumberStemPronominalPluralAffix => .pnStemPronominalAffix
+  | .personNumberStemNominalPluralAffix    => .pnStemNominalAffix
+  | .personStemPronominalPluralAffix       => .personStemPronominalAffix
+  | .personStemNominalPluralAffix          => .personStemNominalAffix
+
+private abbrev ch35 := Data.WALS.F35A.allData
+
+set_option maxRecDepth 8192 in
+/-- A fused person-number stem is the single most common pronoun-plurality
+    strategy cross-linguistically (114/261 languages in WALS Ch 35). -/
+theorem personNumberStem_is_plurality (other : Data.WALS.F35A.PronounPlurality) :
+    (ch35.filter (·.value == .personNumberStem)).length ≥
+    (ch35.filter (·.value == other)).length := by
+  cases other <;> decide
 
 end Pronoun
 


### PR DESCRIPTION
Routes pronoun data through the unified `Pronoun` object, gives its denotation its first real consumers, and removes the informal string-matching in the syntax layer.

- Fragments: English `PronounEntry extends Pronoun.Entry`; Tamil/Italian gain `Pronoun.Profile`s; Italian/Mixtec series classified via `Pronoun.Strength` (replacing a `Bool := true` stipulation).
- `Pronoun.Plurality`: folds in WALS Ch 35, retiring a duplicated enum and a dead WALS data file.
- `Studies/Buring2012`: first theorems stated about `Pronoun.Entry.denote`/`phiPresup`.
- `Syntax`: one lexicon-driven `classifyNominal`/`phiAgree` (Prop) shared across the Minimalist/HPSG/DG binding analyses, replacing three hardcoded copies.