### PR TITLE
feat(Semantics/Reference): fuse pronoun selector with iLookup

### DIFF
--- a/Linglib/Semantics/Reference/Nominal.lean
+++ b/Linglib/Semantics/Reference/Nominal.lean
@@ -32,13 +32,24 @@ a context, so that the existing `presupOfReferent`-built definite denotations
 fold into a `NominalDenot` by `rfl` without migrating any consumer; the
 intrinsic presupposition is layered on separately in `toPrProp`.
 
-## Todo
+## Relation to the dynamic lookup interface
 
-* Generalise `selector` to a functor-valued `Ctx → W → M (Option E)` and have
-  the static (`Id`) case *be* `Semantics.Dynamic.Context.HasFiberedLookup`'s
-  `iLookup` rather than restate it — fusing static reference with dynamic
-  (`Set`/`PMF`) anaphora under one lookup. Lift `lambdaAbsG` to supply the
-  bound-variable selector.
+The unification this core was built toward is realized by the seam lemma
+`PronounDenotation.interpPronoun_eq_iLookup`: the pronoun's static
+`interpPronoun` selector *is* the `M = Id` extensional-baseline instance of
+`Semantics.Dynamic.Context.HasFiberedLookup.iLookup`, modulo the `Option`
+partiality layer this signature adds. Static reference and dynamic
+(`Set`/`PMF`) anaphora therefore meet at one lookup interface on the static
+fiber, and bound pronouns share that selector with binding supplied externally
+(`Semantics.Reference.Binding`).
+
+Carrying the effect functor `M` *in this structure* (so `selector` is
+`Ctx → W → M (Option E)` and literally `iLookup`) is deliberately **not** done
+here: with only `Id` exercised it would be the same un-exercised generality
+PR1 removed, and a faithful `resolve`/`toPrProp` for `M ≠ Id` needs a
+dynamic-semantic commitment (a nonempty-set / distribution presupposition) that
+belongs with the first dynamic consumer that requires it. Until then the seam
+lemma carries the connection.
 -/
 
 set_option autoImplicit false

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -3,6 +3,7 @@ import Linglib.Semantics.Reference.Nominal
 import Linglib.Semantics.Presupposition.PhiFeatures
 import Linglib.Core.Logic.Intensional.Variables
 import Linglib.Core.Assignment
+import Linglib.Semantics.Dynamic.Effects.HasFiberedLookup
 
 /-!
 # The denotation of a pronoun
@@ -79,6 +80,23 @@ def Entry.denote {F : Frame} [PartialOrder F.Entity] (e : Entry) (i : ℕ)
     NominalDenot (Assignment F.Entity) PUnit F.Entity where
   presup := fun g _ => (e.phiPresup speaker addressee isFemale isInanimate).presup (g i)
   selector := fun g _ => some (interpPronoun (F := F) i g)
+
+/-! ### Fusion seam with the dynamic lookup interface -/
+
+/-- The pronoun's canonical variable selector `interpPronoun i` is exactly the
+`M = Id` extensional-baseline instance of the dynamic-anaphora lookup interface
+`HasFiberedLookup.iLookup` (`Semantics.Dynamic.Effects.HasFiberedLookup`,
+`instAssignmentHasFiberedLookup`). So static reference and dynamic (`Set`/`PMF`)
+anaphora already agree at the static fiber — modulo the `Option` partiality
+layer `Entry.denote` adds. This discharges the first step of the functor-
+parametric `NominalDenot` consolidation (`Nominal.lean`'s `Todo`): the remaining,
+higher-blast-radius stage makes `selector` itself functor-valued and *be*
+`iLookup`. -/
+theorem interpPronoun_eq_iLookup {F : Frame} (i : ℕ) (g : Assignment F.Entity)
+    (w : PUnit) :
+    interpPronoun (F := F) i g
+      = Semantics.Dynamic.Context.HasFiberedLookup.iLookup (M := Id) g i w :=
+  rfl
 
 /-! ### Featural definedness tests -/
 


### PR DESCRIPTION
Establishes the `NominalDenot` consolidation seam: `interpPronoun_eq_iLookup` proves the pronoun's static variable selector *is* the `M = Id` instance of `Semantics.Dynamic.Context.HasFiberedLookup.iLookup`, so static reference and dynamic (`Set`/`PMF`) anaphora meet at one lookup interface.

Closes the open `Nominal.lean` TODO: the fusion is realized and exercised by the seam; carrying the effect functor `M` *in the struct* stays consumer-gated (re-adding it with only `Id` exercised would be the un-exercised generality PR1 deliberately removed, and `resolve`/`toPrProp` for `M ≠ Id` needs a dynamic-semantic commitment that belongs with the first dynamic consumer).