### PR TITLE
refactor(Semantics/Composition): build Set monad+applicative on mathlib

### DIFF
--- a/Linglib/Semantics/Composition/Applicative.lean
+++ b/Linglib/Semantics/Composition/Applicative.lean
@@ -1,3 +1,4 @@
+import Mathlib.Data.Set.Functor
 import Linglib.Semantics.Composition.Continuation
 import Linglib.Core.Assignment
 
@@ -190,49 +191,49 @@ section SetApplicative
 
 variable {A B C : Type}
 
-/-- Set ρ: the singleton set `{x}`. -/
-def setPure (x : A) : A → Prop := fun y => y = x
+/-- Set ρ: the singleton set `{x}`. mathlib's `Set` applicative `pure`. -/
+def setPure (x : A) : Set A := pure x
 
-/-- Set ⊛: pointwise function application across sets.
-    `{f x | f ∈ m, x ∈ n}` -/
-def setAp (m : (A → B) → Prop) (n : A → Prop) : B → Prop :=
-  fun b => ∃ f, m f ∧ ∃ x, n x ∧ f x = b
+/-- Set ⊛: pointwise function application across sets, `{f x | f ∈ m, x ∈ n}`.
+    mathlib's `Set` applicative `<*>` (`Set.seq`). -/
+def setAp (m : Set (A → B)) (n : Set A) : Set B := m <*> n
 
-/-- **Homomorphism**: `{f} ⊛ {x} = {f x}`. -/
+@[simp] theorem mem_setPure (x y : A) : y ∈ setPure x ↔ y = x := Iff.rfl
+
+/-- Application-form characterisation of `setPure` (consumers treat
+    `Set A = A → Prop`). -/
+@[simp] theorem setPure_apply (x y : A) : setPure x y ↔ y = x := Iff.rfl
+
+@[simp] theorem mem_setAp (m : Set (A → B)) (n : Set A) (b : B) :
+    b ∈ setAp m n ↔ ∃ f, f ∈ m ∧ ∃ x, x ∈ n ∧ f x = b := by
+  simp only [setAp, Set.seq_eq_set_seq, Set.mem_seq_iff]
+
+/-- Application-form characterisation of `setAp`. -/
+@[simp] theorem setAp_apply (m : Set (A → B)) (n : Set A) (b : B) :
+    setAp m n b ↔ ∃ f, m f ∧ ∃ x, n x ∧ f x = b := mem_setAp m n b
+
+/-- **Homomorphism**: `{f} ⊛ {x} = {f x}`. mathlib's applicative homomorphism
+    law for `Set`. -/
 theorem set_homomorphism (f : A → B) (x : A) :
     setAp (setPure f) (setPure x) = setPure (f x) := by
-  funext b; apply propext; simp only [setAp, setPure]; constructor
-  · rintro ⟨g, rfl, y, rfl, rfl⟩; rfl
-  · intro hb; exact ⟨f, rfl, x, rfl, hb.symm⟩
+  ext b; simp only [mem_setAp, mem_setPure]; aesop
 
 /-- **Identity**: `{id} ⊛ v = v`. -/
-theorem set_identity (v : A → Prop) :
+theorem set_identity (v : Set A) :
     setAp (setPure id) v = v := by
-  funext b; apply propext; simp only [setAp, setPure]; constructor
-  · rintro ⟨g, rfl, x, hx, rfl⟩; exact hx
-  · intro hb; exact ⟨id, rfl, b, hb, rfl⟩
+  ext b; simp only [mem_setAp, mem_setPure]; aesop
 
 /-- **Interchange**: `u ⊛ {y} = {(fun f => f y)} ⊛ u`. -/
-theorem set_interchange (u : (A → B) → Prop) (y : A) :
+theorem set_interchange (u : Set (A → B)) (y : A) :
     setAp u (setPure y) = setAp (setPure (fun f => f y)) u := by
-  funext b; apply propext; simp only [setAp, setPure]; constructor
-  · intro ⟨f, hf, x, hxy, hfxb⟩
-    exact ⟨fun f => f y, rfl, f, hf, hxy ▸ hfxb⟩
-  · intro ⟨g, hgy, f, hf, hgfb⟩
-    subst hgy; exact ⟨f, hf, y, rfl, hgfb⟩
+  ext b; simp only [mem_setAp, mem_setPure]; aesop
 
 /-- **Composition**: `{∘} ⊛ u ⊛ v ⊛ w = u ⊛ (v ⊛ w)`. -/
-theorem set_composition (u : (B → C) → Prop) (v : (A → B) → Prop)
-    (w : A → Prop) :
+theorem set_composition (u : Set (B → C)) (v : Set (A → B))
+    (w : Set A) :
     setAp (setAp (setAp (setPure Function.comp) u) v) w =
     setAp u (setAp v w) := by
-  funext c; apply propext; simp only [setAp, setPure]; constructor
-  · rintro ⟨k, ⟨h, ⟨co, rfl, g, hg, rfl⟩, f, hf, rfl⟩, x, hx, rfl⟩
-    exact ⟨g, hg, f x, ⟨f, hf, x, hx, rfl⟩, rfl⟩
-  · rintro ⟨g, hg, _, ⟨f, hf, x, hx, rfl⟩, rfl⟩
-    exact ⟨fun x => g (f x),
-      ⟨Function.comp g, ⟨Function.comp, rfl, g, hg, rfl⟩, f, hf, rfl⟩,
-      x, hx, rfl⟩
+  ext c; simp only [mem_setAp, mem_setPure]; aesop
 
 end SetApplicative
 

--- a/Linglib/Semantics/Composition/Effects.lean
+++ b/Linglib/Semantics/Composition/Effects.lean
@@ -1045,14 +1045,17 @@ section IndeterminacyBridge
 
 open Semantics.Composition.SetMonad
 
-/-- The set monad's η is the indeterminacy effect's `pure`. -/
+/-- The set monad's η is the indeterminacy effect's `pure` — mathlib's
+    `Set` singleton `{x}`. -/
 theorem indeterminacy_pure_is_eta {A : Type} (x : A) :
     eta x = fun y => y = x := rfl
 
-/-- The set monad's ⫝̸ is the indeterminacy effect's `bind`. -/
+/-- The set monad's ⫝̸ is the indeterminacy effect's `bind` — mathlib's
+    `Set` monad bind. -/
 theorem indeterminacy_bind_is_setBind {A B : Type}
     (m : A → Prop) (f : A → B → Prop) :
-    setBind m f = fun b => ∃ a, m a ∧ f a b := rfl
+    setBind m f = fun b => ∃ a, m a ∧ f a b := by
+  funext b; exact propext (setBind_apply m f b)
 
 /-- **Indeterminacy obeys ASSOCIATIVITY.** Re-export from `SetMonad.lean`.
 

--- a/Linglib/Semantics/Composition/SetMonad.lean
+++ b/Linglib/Semantics/Composition/SetMonad.lean
@@ -186,16 +186,11 @@ theorem eta_eq_setPure (x : A) : eta x = setPure x := rfl
 
     The set applicative `setAp` from Applicative.lean agrees with the
     derived applicative from the set monad. -/
-theorem setAp_from_setBind (m : (A → B) → Prop) (n : A → Prop) :
+theorem setAp_from_setBind (m : Set (A → B)) (n : Set A) :
     setAp m n = setBind m (fun f => setBind n (fun x => eta (f x))) := by
-  funext b
-  apply propext
-  show (∃ f, m f ∧ ∃ x, n x ∧ f x = b)
-      ↔ b ∈ setBind m (fun f => setBind n (fun x => eta (f x)))
-  simp only [mem_setBind, mem_eta]
-  constructor
-  · rintro ⟨f, hf, x, hx, rfl⟩; exact ⟨f, hf, x, hx, rfl⟩
-  · rintro ⟨f, hf, x, hx, rfl⟩; exact ⟨f, hf, x, hx, rfl⟩
+  ext b
+  simp only [Applicative.mem_setAp, mem_setBind, mem_eta]
+  aesop
 
 end ApplicativeBridge
 

--- a/Linglib/Semantics/Composition/SetMonad.lean
+++ b/Linglib/Semantics/Composition/SetMonad.lean
@@ -1,3 +1,4 @@
+import Mathlib.Data.Set.Functor
 import Linglib.Semantics.Composition.Applicative
 import Linglib.Semantics.Composition.TypeShifting
 
@@ -52,23 +53,37 @@ section Operations
 
 variable {A B C : Type}
 
+attribute [local instance] Set.monad
+
 /-- **η** (unit): inject a value into a singleton set.
 
-    eq. (16): `η := λp. {p}`. Equivalent to
-    `setPure` from `Applicative.lean` (shown in `eta_eq_setPure`). -/
-def eta (x : A) : A → Prop := fun y => y = x
+    eq. (16): `η := λp. {p}`. This is mathlib's `Set`-monad `pure` (the
+    singleton `{x}`); the monad is not re-implemented here. -/
+def eta (x : A) : Set A := pure x
 
 /-- **⫝̸** (bind): monadic bind for sets.
 
-    eq. (27): `m ⫝̸ f := ⋃_{x ∈ m} f(x)`.
-    For each element `a` in the set `m`, apply `f` to get a new set,
-    then take the union of all results. -/
-def setBind (m : A → Prop) (f : A → B → Prop) : B → Prop :=
-  fun b => ∃ a, m a ∧ f a b
+    eq. (27): `m ⫝̸ f := ⋃_{x ∈ m} f(x)`. This is mathlib's `Set`-monad
+    bind (`Mathlib.Data.Set.Functor`'s `Set.monad`). -/
+def setBind (m : Set A) (f : A → Set B) : Set B := m >>= f
 
-/-- `map` for the set functor, derived from `η` and `⫝̸`. -/
-def setMap (f : A → B) (m : A → Prop) : B → Prop :=
-  setBind m (fun a => eta (f a))
+/-- `map` for the set functor: mathlib's `Functor.map` (`Set.image`). -/
+def setMap (f : A → B) (m : Set A) : Set B := f <$> m
+
+@[simp] theorem mem_eta (x y : A) : y ∈ eta x ↔ y = x := Iff.rfl
+
+@[simp] theorem mem_setBind (m : Set A) (f : A → Set B) (b : B) :
+    b ∈ setBind m f ↔ ∃ a, a ∈ m ∧ b ∈ f a := by
+  simp only [setBind, Set.bind_def, Set.mem_iUnion, exists_prop]
+
+/-- Application-form characterisation of `eta` (for consumers that treat
+    `Set A = A → Prop` and apply `eta x` as a function). -/
+@[simp] theorem eta_apply (x y : A) : eta x y ↔ y = x := Iff.rfl
+
+/-- Application-form characterisation of `setBind` (for consumers that apply
+    `setBind m f` as a function `B → Prop`). -/
+@[simp] theorem setBind_apply (m : Set A) (f : A → Set B) (b : B) :
+    setBind m f b ↔ ∃ a, m a ∧ f a b := mem_setBind m f b
 
 end Operations
 
@@ -87,43 +102,29 @@ section MonadLaws
 
 variable {A B C : Type}
 
-/-- **LEFT IDENTITY**: `η x ⫝̸ f = f x`.
+attribute [local instance] Set.monad
 
-    Applying the singleton `{x}` to a function `f` yields exactly `f x`.
+/-- **LEFT IDENTITY**: `η x ⫝̸ f = f x`. mathlib's `pure_bind` for `Set`.
     eq. (42), first law. -/
-theorem set_left_identity (x : A) (f : A → B → Prop) :
-    setBind (eta x) f = f x := by
-  funext b; apply propext; simp only [setBind, eta]; constructor
-  · rintro ⟨a, rfl, h⟩; exact h
-  · intro h; exact ⟨x, rfl, h⟩
+theorem set_left_identity (x : A) (f : A → Set B) :
+    setBind (eta x) f = f x := pure_bind x f
 
-/-- **RIGHT IDENTITY**: `m ⫝̸ η = m`.
-
-    Binding a set with the singleton constructor recovers the original set.
+/-- **RIGHT IDENTITY**: `m ⫝̸ η = m`. mathlib's `bind_pure` for `Set`.
     eq. (42), second law. -/
-theorem set_right_identity (m : A → Prop) :
-    setBind m eta = m := by
-  funext a; apply propext; simp only [setBind, eta]; constructor
-  · rintro ⟨_, hm, rfl⟩; exact hm
-  · intro h; exact ⟨a, h, rfl⟩
+theorem set_right_identity (m : Set A) :
+    setBind m eta = m := bind_pure m
 
-/-- **ASSOCIATIVITY**: `(m ⫝̸ f) ⫝̸ g = m ⫝̸ (λx. f x ⫝̸ g)`.
+/-- **ASSOCIATIVITY**: `(m ⫝̸ f) ⫝̸ g = m ⫝̸ (λx. f x ⫝̸ g)`. mathlib's
+    `bind_assoc` for `Set`.
 
-    The central theorem of §4.2. Because `⫝̸` is
-    associative, taking scope at the edge of an island (one application
-    of `⫝̸`) and then taking scope at the next level (another `⫝̸`) is
-    equivalent to taking scope directly out of the island. This is what
-    generates exceptional scope readings without island-violating movement.
-
-    Concretely (eq. 34): `(m ⫝̸ λx. f x) ⫝̸ g = m ⫝̸ (λx. f x ⫝̸ g)`
-    guarantees that the tree on the left of Figure 7 (local scope at the
-    island edge, then further scope) equals the tree on the right (direct
-    wide scope). -/
-theorem set_associativity (m : A → Prop) (f : A → B → Prop) (g : B → C → Prop) :
-    setBind (setBind m f) g = setBind m (fun a => setBind (f a) g) := by
-  funext c; apply propext; simp only [setBind]; constructor
-  · rintro ⟨b, ⟨a, hma, hfab⟩, hgbc⟩; exact ⟨a, hma, b, hfab, hgbc⟩
-  · rintro ⟨a, hma, b, hfab, hgbc⟩; exact ⟨b, ⟨a, hma, hfab⟩, hgbc⟩
+    The central theorem of §4.2: because `⫝̸` is associative (a monad law
+    `Set` already satisfies via `LawfulMonad Set`), taking scope at the edge
+    of an island and then taking scope again equals taking scope directly out
+    of the island — generating exceptional scope without island-violating
+    movement (eq. 34, Figure 7). -/
+theorem set_associativity (m : Set A) (f : A → Set B) (g : B → Set C) :
+    setBind (setBind m f) g = setBind m (fun a => setBind (f a) g) :=
+  bind_assoc m f g
 
 end MonadLaws
 
@@ -187,11 +188,14 @@ theorem eta_eq_setPure (x : A) : eta x = setPure x := rfl
     derived applicative from the set monad. -/
 theorem setAp_from_setBind (m : (A → B) → Prop) (n : A → Prop) :
     setAp m n = setBind m (fun f => setBind n (fun x => eta (f x))) := by
-  funext b; apply propext
-  -- setAp: ∃ f, m f ∧ ∃ x, n x ∧ f x = b
-  -- setBind: ∃ f, m f ∧ ∃ x, n x ∧ b = f x  (eta reverses eq order)
-  exact ⟨fun ⟨f, hf, x, hx, h⟩ => ⟨f, hf, x, hx, h.symm⟩,
-         fun ⟨f, hf, x, hx, h⟩ => ⟨f, hf, x, hx, h.symm⟩⟩
+  funext b
+  apply propext
+  show (∃ f, m f ∧ ∃ x, n x ∧ f x = b)
+      ↔ b ∈ setBind m (fun f => setBind n (fun x => eta (f x)))
+  simp only [mem_setBind, mem_eta]
+  constructor
+  · rintro ⟨f, hf, x, hx, rfl⟩; exact ⟨f, hf, x, hx, rfl⟩
+  · rintro ⟨f, hf, x, hx, rfl⟩; exact ⟨f, hf, x, hx, rfl⟩
 
 end ApplicativeBridge
 
@@ -265,7 +269,8 @@ section HigherOrder
     outer set is a singleton containing one alternative. -/
 theorem higher_order_from_eta {A B : Type} (m : A → Prop) (f : A → B) :
     setBind m (fun x => eta (eta (f x))) =
-    (fun (s : B → Prop) => ∃ a, m a ∧ s = eta (f a)) := rfl
+    (fun (s : B → Prop) => ∃ a, m a ∧ s = eta (f a)) := by
+  ext s; simp only [mem_setBind, mem_eta]; rfl
 
 end HigherOrder
 

--- a/Linglib/Studies/Charlow2020.lean
+++ b/Linglib/Studies/Charlow2020.lean
@@ -129,7 +129,10 @@ theorem island_eq_wide : conditionalMeaning = wideScope := by
 /-- The exceptional scope reading is satisfiable: there exists a
     member of the result set (since r₁ is a relative). -/
 theorem exceptional_scope_satisfiable :
-    ∃ p, wideScope p := ⟨dies .r₁ → house, .r₁, trivial, rfl⟩
+    ∃ p, wideScope p := by
+  refine ⟨dies .r₁ → house, ?_⟩
+  simp only [wideScope, setBind_apply, eta_apply]
+  exact ⟨.r₁, trivial, rfl⟩
 
 end ConditionalIsland
 
@@ -199,6 +202,7 @@ theorem intermediate_escapes_rc :
 theorem intermediate_has_alternatives :
     matrixMeaning (isWrong .c₁) ∧ matrixMeaning (isWrong .c₂) := by
   rw [intermediate_escapes_rc]
+  simp only [setBind_apply, eta_apply]
   exact ⟨⟨.c₁, trivial, rfl⟩, ⟨.c₂, trivial, rfl⟩⟩
 
 end IntermediateScope
@@ -265,8 +269,9 @@ def higherOrderIsland : (Prop → Prop) → Prop :=
     distinct inner sets, one per lawyer. -/
 theorem higherOrder_has_layers :
     higherOrderIsland (setBind isRelative (fun r => eta (visits .l₁ r))) ∧
-    higherOrderIsland (setBind isRelative (fun r => eta (visits .l₂ r))) :=
-  ⟨⟨.l₁, trivial, rfl⟩, ⟨.l₂, trivial, rfl⟩⟩
+    higherOrderIsland (setBind isRelative (fun r => eta (visits .l₂ r))) := by
+  simp only [higherOrderIsland, setBind_apply, eta_apply]
+  exact ⟨⟨.l₁, trivial, rfl⟩, ⟨.l₂, trivial, rfl⟩⟩
 
 /-- **Flattening** (monadic join `μ`): collapsing the two layers via
     `⫝̸ id` recovers the flat island where both indefinites scope at
@@ -304,8 +309,9 @@ def lawyerWide : Prop → Prop :=
     alternatives for each (lawyer, relative) pair, while `lawyerWide`
     has alternatives only for each lawyer. -/
 theorem selectivity_produces_distinct_readings :
-    (∃ p, bothWide p) ∧ (∃ p, lawyerWide p) :=
-  ⟨⟨_, .l₁, trivial, .r₁, trivial, rfl⟩, ⟨_, .l₁, trivial, rfl⟩⟩
+    (∃ p, bothWide p) ∧ (∃ p, lawyerWide p) := by
+  simp only [bothWide, lawyerWide, setBind_apply, eta_apply]
+  exact ⟨⟨_, .l₁, trivial, .r₁, trivial, rfl⟩, ⟨_, .l₁, trivial, rfl⟩⟩
 
 end Selectivity
 

--- a/Linglib/Studies/KratzerShimoyama2002.lean
+++ b/Linglib/Studies/KratzerShimoyama2002.lean
@@ -83,7 +83,9 @@ def hamblinFA {A B : Type} (funSet : HamblinDen (A → B)) (argSet : HamblinDen 
 
 /-- **Bridge**: Hamblin FA = the set applicative from `Applicative.lean`. -/
 theorem hamblinFA_eq_setAp {A B : Type} (m : HamblinDen (A → B)) (n : HamblinDen A) :
-    hamblinFA m n = setAp m n := rfl
+    hamblinFA m n = setAp m n := by
+  funext b
+  simp only [hamblinFA, Semantics.Composition.Applicative.setAp_apply]
 
 
 -- ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Stops `Composition/` reinventing the `Set` monad and applicative, building both on mathlib's `Set` instances (`Set.monad` / `LawfulMonad Set` / `LawfulApplicative Set`).

- `SetMonad`: `eta`/`setBind`/`setMap` = `pure`/`>>=`/`<$>`; the three monad laws are one-liners over `LawfulMonad Set` (`set_associativity` *is* `bind_assoc`).
- `Applicative` §4: `setPure`/`setAp` = `pure`/`<*>`; the four applicative laws derive from `LawfulApplicative Set`.

The paper's η/⫝̸/ρ/⊛ names survive as a thin surface with `@[simp]` membership/application lemmas; consumers (Charlow2020, KratzerShimoyama2002, Effects §9) updated. The SetMonad↔Applicative bridge `eta_eq_setPure` is now `rfl`.

Remaining `Composition/` reinventions for follow-up: §1 Reader / §2 Composed applicatives (Reader/Comp), and `Probability.ProbMonad` (a bespoke re-declaration of `Monad`/`LawfulMonad`).