### PR TITLE
refactor(Typology/Numeral): split numeral object from WALS survey

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -229,7 +229,8 @@ import Linglib.Typology.Directives
 import Linglib.Typology.Indefinite
 import Linglib.Typology.Profile
 import Linglib.Typology.Universal
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.Basic
+import Linglib.Typology.Numeral.WALS
 import Linglib.Typology.Plurals
 import Linglib.Typology.PolarityMarking
 import Linglib.Typology.Possession

--- a/Linglib/Fragments/Arabic/ModernStandard/Numerals.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Modern Standard Arabic Numeral Profile (WALS Chs 53–56, 131)
@@ -9,7 +9,7 @@ per Ryding ch 15 (pp. 329–365).
 
 ## What's encoded vs documented
 
-The substrate `Typology.NumeralProfile` records a small set of
+The substrate `Numeral.Profile` records a small set of
 typological dimensions (ordinal-formation strategy, distributive
 marking, classifier presence, conjunction–quantifier identity, plural
 marking, base). The arithmetically richer phenomena MSA is famous for
@@ -46,7 +46,7 @@ namespace Fragments.Arabic.ModernStandard
     classifiers. *wa-* 'and' and *kull* 'all/every' are morphologically
     distinct. Dual + plural marking on counted nouns is obligatory.
     Decimal base (Ryding §15.1). -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Arabic (Modern Standard)"
   , iso := "arb"
   , ordinal := .firstSuppletion

--- a/Linglib/Fragments/Arabic/ModernStandard/Numerals.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Numerals.lean
@@ -47,14 +47,12 @@ namespace Fragments.Arabic.ModernStandard
     distinct. Dual + plural marking on counted nouns is obligatory.
     Decimal base (Ryding §15.1). -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Arabic (Modern Standard)"
-  , iso := "arb"
-  , ordinal := .firstSuppletion
-  , distributive := .markedByReduplication
-  , classifier := .absent
-  , conjQuant := .differentiation
-  , region := .westAsia
-  , pluralMarking := .obligatory
-  , numeralBase := some .decimal }
+  -- MSA (iso `arb`) is absent from WALS Chs 53/131; curated values kept for
+  -- those. Ch 54 defaults to `noDistributive`, matching the docstring (the
+  -- reduplication is intensifying, not a productive distributive).
+  { Numeral.Profile.fromWALS "Arabic (Modern Standard)" "arb"
+      (region := .westAsia) (pluralMarking := .obligatory) with
+    ordinal := .firstSuppletion
+    numeralBase := some .decimal }
 
 end Fragments.Arabic.ModernStandard

--- a/Linglib/Fragments/Bengali/Numerals.lean
+++ b/Linglib/Fragments/Bengali/Numerals.lean
@@ -12,14 +12,9 @@ namespace Fragments.Bengali
     boi* 'three-CL book', but bare *tin boi* also grammatical). *Ebong* (and)
     differs from *sob* (all). Optional plural; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Bengali"
-  , iso := "ben"
-  , ordinal := .firstSuppletion
-  , distributive := .markedByReduplication
-  , classifier := .optional
-  , conjQuant := .differentiation
-  , region := .southAsia
-  , pluralMarking := .optional
-  , numeralBase := some .decimal }
+  -- Bengali (iso `ben`) is absent from WALS Ch 131; decimal base is curated.
+  { Numeral.Profile.fromWALS "Bengali" "ben" (region := .southAsia)
+      (pluralMarking := .optional) with
+    numeralBase := some .decimal }
 
 end Fragments.Bengali

--- a/Linglib/Fragments/Bengali/Numerals.lean
+++ b/Linglib/Fragments/Bengali/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Bengali numeral profile (WALS Chs 53–56, 131)
@@ -11,7 +11,7 @@ namespace Fragments.Bengali
     suppletive. Distributive by reduplication. Optional classifiers (*tin-ta
     boi* 'three-CL book', but bare *tin boi* also grammatical). *Ebong* (and)
     differs from *sob* (all). Optional plural; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Bengali"
   , iso := "ben"
   , ordinal := .firstSuppletion

--- a/Linglib/Fragments/Burmese/Numerals.lean
+++ b/Linglib/Fragments/Burmese/Numerals.lean
@@ -12,14 +12,6 @@ namespace Fragments.Burmese
     classifiers obligatory (*lu thon yauk* 'person three CL'). No
     morphological distributive. No grammatical plural; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Burmese"
-  , iso := "mya"
-  , ordinal := .various
-  , distributive := .noDistributive
-  , classifier := .obligatory
-  , conjQuant := .differentiation
-  , region := .southeastAsia
-  , pluralMarking := .none
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Burmese" "mya" (region := .southeastAsia) (pluralMarking := .none)
 
 end Fragments.Burmese

--- a/Linglib/Fragments/Burmese/Numerals.lean
+++ b/Linglib/Fragments/Burmese/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Burmese numeral profile (WALS Chs 53–56, 131)
@@ -11,7 +11,7 @@ namespace Fragments.Burmese
     Pali; modern ordinals use *tha-* prefix); various pattern. Numeral
     classifiers obligatory (*lu thon yauk* 'person three CL'). No
     morphological distributive. No grammatical plural; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Burmese"
   , iso := "mya"
   , ordinal := .various

--- a/Linglib/Fragments/English/Numerals.lean
+++ b/Linglib/Fragments/English/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # English numeral profile (WALS Chs 53–56, 131)
@@ -11,7 +11,7 @@ namespace Fragments.English
     suffix). No morphological distributive numerals (*two-each*), no numeral
     classifiers, conjunction *and* differs from universal *all*. Obligatory
     plural on nouns; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "English"
   , iso := "eng"
   , ordinal := .firstSecondSuppletion

--- a/Linglib/Fragments/English/Numerals.lean
+++ b/Linglib/Fragments/English/Numerals.lean
@@ -12,14 +12,6 @@ namespace Fragments.English
     classifiers, conjunction *and* differs from universal *all*. Obligatory
     plural on nouns; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "English"
-  , iso := "eng"
-  , ordinal := .firstSecondSuppletion
-  , distributive := .noDistributive
-  , classifier := .absent
-  , conjQuant := .differentiation
-  , region := .europe
-  , pluralMarking := .obligatory
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "English" "eng" (region := .europe) (pluralMarking := .obligatory)
 
 end Fragments.English

--- a/Linglib/Fragments/Finnish/Numerals.lean
+++ b/Linglib/Fragments/Finnish/Numerals.lean
@@ -12,14 +12,6 @@ namespace Fragments.Finnish
     No morphological distributive. No classifiers. *Ja* (and) differs from
     *kaikki* (all). Obligatory plural with *-t*; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Finnish"
-  , iso := "fin"
-  , ordinal := .firstSecondSuppletion
-  , distributive := .noDistributive
-  , classifier := .absent
-  , conjQuant := .differentiation
-  , region := .europe
-  , pluralMarking := .obligatory
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Finnish" "fin" (region := .europe) (pluralMarking := .obligatory)
 
 end Fragments.Finnish

--- a/Linglib/Fragments/Finnish/Numerals.lean
+++ b/Linglib/Fragments/Finnish/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Finnish numeral profile (WALS Chs 53–56, 131)
@@ -11,7 +11,7 @@ namespace Fragments.Finnish
     'different', higher ordinals regular with *-(n)s* suffix (*kolmas* 'third').
     No morphological distributive. No classifiers. *Ja* (and) differs from
     *kaikki* (all). Obligatory plural with *-t*; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Finnish"
   , iso := "fin"
   , ordinal := .firstSecondSuppletion

--- a/Linglib/Fragments/Georgian/Numerals.lean
+++ b/Linglib/Fragments/Georgian/Numerals.lean
@@ -13,14 +13,6 @@ namespace Fragments.Georgian
     differs from *q'vela* (all). Obligatory plural; hybrid vigesimal-decimal
     base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Georgian"
-  , iso := "kat"
-  , ordinal := .firstSuppletion
-  , distributive := .markedBySuffix
-  , classifier := .absent
-  , conjQuant := .differentiation
-  , region := .westAsia
-  , pluralMarking := .obligatory
-  , numeralBase := some .hybridVigesimalDecimal }
+  Numeral.Profile.fromWALS "Georgian" "kat" (region := .westAsia) (pluralMarking := .obligatory)
 
 end Fragments.Georgian

--- a/Linglib/Fragments/Georgian/Numerals.lean
+++ b/Linglib/Fragments/Georgian/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Georgian numeral profile (WALS Chs 53–56, 131)
@@ -12,7 +12,7 @@ namespace Fragments.Georgian
     suffix *-agan* (*or-agan* 'two each'). No numeral classifiers. *Da* (and)
     differs from *q'vela* (all). Obligatory plural; hybrid vigesimal-decimal
     base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Georgian"
   , iso := "kat"
   , ordinal := .firstSuppletion

--- a/Linglib/Fragments/Hindi/Numerals.lean
+++ b/Linglib/Fragments/Hindi/Numerals.lean
@@ -12,14 +12,6 @@ namespace Fragments.Hindi
     reduplication (*do-do* 'two-two'). No numeral classifiers. *Aur* (and)
     differs from *sab* (all). Obligatory plural; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Hindi"
-  , iso := "hin"
-  , ordinal := .firstSecondSuppletion
-  , distributive := .markedByReduplication
-  , classifier := .absent
-  , conjQuant := .differentiation
-  , region := .southAsia
-  , pluralMarking := .obligatory
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Hindi" "hin" (region := .southAsia) (pluralMarking := .obligatory)
 
 end Fragments.Hindi

--- a/Linglib/Fragments/Hindi/Numerals.lean
+++ b/Linglib/Fragments/Hindi/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Hindi numeral profile (WALS Chs 53–56, 131)
@@ -11,7 +11,7 @@ namespace Fragments.Hindi
     suppletive, higher ordinals regular with *-vam* suffix. Distributive by
     reduplication (*do-do* 'two-two'). No numeral classifiers. *Aur* (and)
     differs from *sab* (all). Obligatory plural; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Hindi"
   , iso := "hin"
   , ordinal := .firstSecondSuppletion

--- a/Linglib/Fragments/Hungarian/Numerals.lean
+++ b/Linglib/Fragments/Hungarian/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Hungarian numeral profile (WALS Chs 53–56, 131)
@@ -12,7 +12,7 @@ namespace Fragments.Hungarian
     reduplication (*ket-ket* 'two-two'). No numeral classifiers. *És* (and)
     differs from *minden* (all/every). Obligatory plural with *-k*;
     decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Hungarian"
   , iso := "hun"
   , ordinal := .firstSuppletion

--- a/Linglib/Fragments/Hungarian/Numerals.lean
+++ b/Linglib/Fragments/Hungarian/Numerals.lean
@@ -13,14 +13,6 @@ namespace Fragments.Hungarian
     differs from *minden* (all/every). Obligatory plural with *-k*;
     decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Hungarian"
-  , iso := "hun"
-  , ordinal := .firstSuppletion
-  , distributive := .markedByReduplication
-  , classifier := .absent
-  , conjQuant := .differentiation
-  , region := .europe
-  , pluralMarking := .obligatory
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Hungarian" "hun" (region := .europe) (pluralMarking := .obligatory)
 
 end Fragments.Hungarian

--- a/Linglib/Fragments/Indonesian/Numerals.lean
+++ b/Linglib/Fragments/Indonesian/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Indonesian numeral profile (WALS Chs 53–56, 131)
@@ -12,7 +12,7 @@ namespace Fragments.Indonesian
     morphological distributive. Obligatory numeral classifiers (*tiga orang
     murid* 'three CL student'). *Dan* (and) differs from *semua* (all).
     Optional plural by reduplication; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Indonesian"
   , iso := "ind"
   , ordinal := .various

--- a/Linglib/Fragments/Indonesian/Numerals.lean
+++ b/Linglib/Fragments/Indonesian/Numerals.lean
@@ -13,14 +13,6 @@ namespace Fragments.Indonesian
     murid* 'three CL student'). *Dan* (and) differs from *semua* (all).
     Optional plural by reduplication; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Indonesian"
-  , iso := "ind"
-  , ordinal := .various
-  , distributive := .noDistributive
-  , classifier := .obligatory
-  , conjQuant := .differentiation
-  , region := .southeastAsia
-  , pluralMarking := .optional
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Indonesian" "ind" (region := .southeastAsia) (pluralMarking := .optional)
 
 end Fragments.Indonesian

--- a/Linglib/Fragments/Japanese/Numerals.lean
+++ b/Linglib/Fragments/Japanese/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Japanese numeral profile (WALS Chs 53–56, 131)
@@ -12,7 +12,7 @@ namespace Fragments.Japanese
     (*hitori-hitori* 'one by one'). Obligatory numeral classifiers (*san-nin*
     'three-CL.person'). Conjunction *to* differs from universal *subete*. No
     grammatical plural on common nouns; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Japanese"
   , iso := "jpn"
   , ordinal := .allFromCardinals

--- a/Linglib/Fragments/Japanese/Numerals.lean
+++ b/Linglib/Fragments/Japanese/Numerals.lean
@@ -13,14 +13,6 @@ namespace Fragments.Japanese
     'three-CL.person'). Conjunction *to* differs from universal *subete*. No
     grammatical plural on common nouns; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Japanese"
-  , iso := "jpn"
-  , ordinal := .allFromCardinals
-  , distributive := .markedByReduplication
-  , classifier := .obligatory
-  , conjQuant := .differentiation
-  , region := .eastAsia
-  , pluralMarking := .none
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Japanese" "jpn" (region := .eastAsia) (pluralMarking := .none)
 
 end Fragments.Japanese

--- a/Linglib/Fragments/Korean/Numerals.lean
+++ b/Linglib/Fragments/Korean/Numerals.lean
@@ -7,20 +7,15 @@ import Linglib.Typology.Numeral.WALS
 
 namespace Fragments.Korean
 
-/-- Korean: ordinals use native numerals + *-jjae* suffix (*cheot-jjae* 'first'
-    partially suppletive). Distributive by suffix *-ssik* (*du-ssik* 'two
-    each'). Optional numeral classifiers (*se myeong-ui haksaeng* 'three CL
-    student'). *Gwa*/*wa* (and) differs from *modu* (all). Optional plural
-    with *-deul*; decimal base. -/
+/-- Korean. Coded after @cite{wals-2013}: WALS 53A codes Korean
+    "one-th, two-th, three-th" (Sino-Korean *je-* + cardinal, fully regular) →
+    `allFromCardinals`; the native paradigm's *cheot-jjae* 'first' suppletion is
+    a secondary system not picked up by the WALS coding. WALS 55A codes numeral
+    classifiers Obligatory (counting requires a classifier: *haksaeng se myeong*
+    'three CL student'). Distributive by suffix *-ssik* (*du-ssik* 'two each',
+    WALS 54A). *Gwa*/*wa* (and) differs from *modu* (all). Optional plural with
+    *-deul*; decimal base (WALS 131A). -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Korean"
-  , iso := "kor"
-  , ordinal := .firstSuppletion
-  , distributive := .markedBySuffix
-  , classifier := .optional
-  , conjQuant := .differentiation
-  , region := .eastAsia
-  , pluralMarking := .optional
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Korean" "kor" (region := .eastAsia) (pluralMarking := .optional)
 
 end Fragments.Korean

--- a/Linglib/Fragments/Korean/Numerals.lean
+++ b/Linglib/Fragments/Korean/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Korean numeral profile (WALS Chs 53–56, 131)
@@ -12,7 +12,7 @@ namespace Fragments.Korean
     each'). Optional numeral classifiers (*se myeong-ui haksaeng* 'three CL
     student'). *Gwa*/*wa* (and) differs from *modu* (all). Optional plural
     with *-deul*; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Korean"
   , iso := "kor"
   , ordinal := .firstSuppletion

--- a/Linglib/Fragments/Mandarin/Numerals.lean
+++ b/Linglib/Fragments/Mandarin/Numerals.lean
@@ -13,14 +13,6 @@ namespace Fragments.Mandarin
     *he* and universal *dou* are distinct morphemes. No grammatical plural on
     common nouns; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Mandarin"
-  , iso := "cmn"
-  , ordinal := .allFromCardinals
-  , distributive := .noDistributive
-  , classifier := .obligatory
-  , conjQuant := .differentiation
-  , region := .eastAsia
-  , pluralMarking := .none
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Mandarin" "cmn" (region := .eastAsia) (pluralMarking := .none)
 
 end Fragments.Mandarin

--- a/Linglib/Fragments/Mandarin/Numerals.lean
+++ b/Linglib/Fragments/Mandarin/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Mandarin numeral profile (WALS Chs 53–56, 131)
@@ -12,7 +12,7 @@ namespace Fragments.Mandarin
     Obligatory numeral classifiers (*san ge ren* 'three CL person'). Conjunction
     *he* and universal *dou* are distinct morphemes. No grammatical plural on
     common nouns; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Mandarin"
   , iso := "cmn"
   , ordinal := .allFromCardinals

--- a/Linglib/Fragments/Mayan/Tseltal/Numerals.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Numerals.lean
@@ -12,14 +12,11 @@ namespace Fragments.Mayan.Tseltal
     morphological distributive. Conjunction and universal quantifier are
     differentiated. No obligatory plural on nouns; vigesimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Tseltal"
-  , iso := "tzh"
-  , ordinal := .noOrdinals
-  , distributive := .noDistributive
-  , classifier := .obligatory
-  , conjQuant := .differentiation
-  , region := .mesoamerica
-  , pluralMarking := .none
-  , numeralBase := some .vigesimal }
+  -- Tseltal (iso `tzh`) is in WALS only for Ch 55 (classifiers); ordinal and
+  -- base are curated (absent from Chs 53/131).
+  { Numeral.Profile.fromWALS "Tseltal" "tzh" (region := .mesoamerica)
+      (pluralMarking := .none) with
+    ordinal := .noOrdinals
+    numeralBase := some .vigesimal }
 
 end Fragments.Mayan.Tseltal

--- a/Linglib/Fragments/Mayan/Tseltal/Numerals.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Tseltal numeral profile (WALS Chs 53–56, 131)
@@ -11,7 +11,7 @@ namespace Fragments.Mayan.Tseltal
     classifiers obligatory (distinct from Mayan noun classifiers). No
     morphological distributive. Conjunction and universal quantifier are
     differentiated. No obligatory plural on nouns; vigesimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Tseltal"
   , iso := "tzh"
   , ordinal := .noOrdinals

--- a/Linglib/Fragments/Slavic/Russian/Numerals.lean
+++ b/Linglib/Fragments/Slavic/Russian/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Russian numeral profile (WALS Chs 53–56, 131)
@@ -12,7 +12,7 @@ namespace Fragments.Slavic.Russian
     'fourth'). No morphological distributive (uses prepositional phrase
     *po + dative*). No numeral classifiers. *I* (and) differs from *vse*
     (all). Obligatory plural; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Russian"
   , iso := "rus"
   , ordinal := .firstSecondSuppletion

--- a/Linglib/Fragments/Slavic/Russian/Numerals.lean
+++ b/Linglib/Fragments/Slavic/Russian/Numerals.lean
@@ -13,14 +13,6 @@ namespace Fragments.Slavic.Russian
     *po + dative*). No numeral classifiers. *I* (and) differs from *vse*
     (all). Obligatory plural; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Russian"
-  , iso := "rus"
-  , ordinal := .firstSecondSuppletion
-  , distributive := .noDistributive
-  , classifier := .absent
-  , conjQuant := .differentiation
-  , region := .europe
-  , pluralMarking := .obligatory
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Russian" "rus" (region := .europe) (pluralMarking := .obligatory)
 
 end Fragments.Slavic.Russian

--- a/Linglib/Fragments/Swahili/Numerals.lean
+++ b/Linglib/Fragments/Swahili/Numerals.lean
@@ -13,14 +13,6 @@ namespace Fragments.Swahili
     function). *Na* (and) differs from *-ote* (all). Obligatory plural via
     noun class prefixes; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Swahili"
-  , iso := "swh"
-  , ordinal := .firstSuppletion
-  , distributive := .noDistributive
-  , classifier := .absent
-  , conjQuant := .differentiation
-  , region := .africa
-  , pluralMarking := .obligatory
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Swahili" "swh" (region := .africa) (pluralMarking := .obligatory)
 
 end Fragments.Swahili

--- a/Linglib/Fragments/Swahili/Numerals.lean
+++ b/Linglib/Fragments/Swahili/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Swahili numeral profile (WALS Chs 53–56, 131)
@@ -12,7 +12,7 @@ namespace Fragments.Swahili
     distributive. No numeral classifiers (noun class system serves a different
     function). *Na* (and) differs from *-ote* (all). Obligatory plural via
     noun class prefixes; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Swahili"
   , iso := "swh"
   , ordinal := .firstSuppletion

--- a/Linglib/Fragments/Tagalog/Numerals.lean
+++ b/Linglib/Fragments/Tagalog/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Tagalog numeral profile (WALS Chs 53–56, 131)
@@ -12,7 +12,7 @@ namespace Fragments.Tagalog
     (*dalawa-dalawa* 'two-two'). No obligatory numeral classifiers (linkers
     *na*/*ng* serve a different function). *At* (and) and *lahat* (all) are
     differentiated. Optional plural (*mga*); decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Tagalog"
   , iso := "tgl"
   , ordinal := .various

--- a/Linglib/Fragments/Tagalog/Numerals.lean
+++ b/Linglib/Fragments/Tagalog/Numerals.lean
@@ -13,14 +13,6 @@ namespace Fragments.Tagalog
     *na*/*ng* serve a different function). *At* (and) and *lahat* (all) are
     differentiated. Optional plural (*mga*); decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Tagalog"
-  , iso := "tgl"
-  , ordinal := .various
-  , distributive := .markedByReduplication
-  , classifier := .absent
-  , conjQuant := .differentiation
-  , region := .southeastAsia
-  , pluralMarking := .optional
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Tagalog" "tgl" (region := .southeastAsia) (pluralMarking := .optional)
 
 end Fragments.Tagalog

--- a/Linglib/Fragments/Thai/Numerals.lean
+++ b/Linglib/Fragments/Thai/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Thai numeral profile (WALS Chs 53–56, 131)
@@ -11,7 +11,7 @@ namespace Fragments.Thai
     *thi-song* 'second') — all regular. No morphological distributive.
     Obligatory numeral classifiers (*maa sam tua* 'dog three CL.animal').
     No grammatical plural; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Thai"
   , iso := "tha"
   , ordinal := .allFromCardinals

--- a/Linglib/Fragments/Thai/Numerals.lean
+++ b/Linglib/Fragments/Thai/Numerals.lean
@@ -12,14 +12,6 @@ namespace Fragments.Thai
     Obligatory numeral classifiers (*maa sam tua* 'dog three CL.animal').
     No grammatical plural; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Thai"
-  , iso := "tha"
-  , ordinal := .allFromCardinals
-  , distributive := .noDistributive
-  , classifier := .obligatory
-  , conjQuant := .differentiation
-  , region := .southeastAsia
-  , pluralMarking := .none
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Thai" "tha" (region := .southeastAsia) (pluralMarking := .none)
 
 end Fragments.Thai

--- a/Linglib/Fragments/Turkish/Numerals.lean
+++ b/Linglib/Fragments/Turkish/Numerals.lean
@@ -13,14 +13,6 @@ namespace Fragments.Turkish
     exist (*iki tane kitap* 'two CL book'). *Ve* (and) differs from *hepsi*
     (all). Obligatory plural with *-ler*/*-lar*; decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Turkish"
-  , iso := "tur"
-  , ordinal := .allFromCardinals
-  , distributive := .markedBySuffix
-  , classifier := .optional
-  , conjQuant := .differentiation
-  , region := .westAsia
-  , pluralMarking := .obligatory
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Turkish" "tur" (region := .westAsia) (pluralMarking := .obligatory)
 
 end Fragments.Turkish

--- a/Linglib/Fragments/Turkish/Numerals.lean
+++ b/Linglib/Fragments/Turkish/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Turkish numeral profile (WALS Chs 53–56, 131)
@@ -12,7 +12,7 @@ namespace Fragments.Turkish
     (*iki-şer* 'two each'). No obligatory classifiers, but optional classifiers
     exist (*iki tane kitap* 'two CL book'). *Ve* (and) differs from *hepsi*
     (all). Obligatory plural with *-ler*/*-lar*; decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Turkish"
   , iso := "tur"
   , ordinal := .allFromCardinals

--- a/Linglib/Fragments/Vietnamese/Numerals.lean
+++ b/Linglib/Fragments/Vietnamese/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Vietnamese numeral profile (WALS Chs 53–56, 131)
@@ -11,7 +11,7 @@ namespace Fragments.Vietnamese
     *thu hai* 'second') — regular. No morphological distributive. Obligatory
     classifiers (*ba con meo* 'three CL cat'). No grammatical plural;
     decimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Vietnamese"
   , iso := "vie"
   , ordinal := .allFromCardinals

--- a/Linglib/Fragments/Vietnamese/Numerals.lean
+++ b/Linglib/Fragments/Vietnamese/Numerals.lean
@@ -12,14 +12,6 @@ namespace Fragments.Vietnamese
     classifiers (*ba con meo* 'three CL cat'). No grammatical plural;
     decimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Vietnamese"
-  , iso := "vie"
-  , ordinal := .allFromCardinals
-  , distributive := .noDistributive
-  , classifier := .obligatory
-  , conjQuant := .differentiation
-  , region := .southeastAsia
-  , pluralMarking := .none
-  , numeralBase := some .decimal }
+  Numeral.Profile.fromWALS "Vietnamese" "vie" (region := .southeastAsia) (pluralMarking := .none)
 
 end Fragments.Vietnamese

--- a/Linglib/Fragments/Yoruba/Numerals.lean
+++ b/Linglib/Fragments/Yoruba/Numerals.lean
@@ -12,14 +12,6 @@ namespace Fragments.Yoruba
     Conjunction *ati* and universal quantifier *gbogbo* are distinct. Plural
     marked optionally (*awon*); vigesimal base. -/
 def numeralProfile : Numeral.Profile :=
-  { language := "Yoruba"
-  , iso := "yor"
-  , ordinal := .various
-  , distributive := .noDistributive
-  , classifier := .absent
-  , conjQuant := .differentiation
-  , region := .africa
-  , pluralMarking := .optional
-  , numeralBase := some .vigesimal }
+  Numeral.Profile.fromWALS "Yoruba" "yor" (region := .africa) (pluralMarking := .optional)
 
 end Fragments.Yoruba

--- a/Linglib/Fragments/Yoruba/Numerals.lean
+++ b/Linglib/Fragments/Yoruba/Numerals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Numerals
+import Linglib.Typology.Numeral.WALS
 
 /-!
 # Yoruba numeral profile (WALS Chs 53–56, 131)
@@ -11,7 +11,7 @@ namespace Fragments.Yoruba
     across the paradigm. No morphological distributive. No numeral classifiers.
     Conjunction *ati* and universal quantifier *gbogbo* are distinct. Plural
     marked optionally (*awon*); vigesimal base. -/
-def numeralProfile : Typology.NumeralProfile :=
+def numeralProfile : Numeral.Profile :=
   { language := "Yoruba"
   , iso := "yor"
   , ordinal := .various

--- a/Linglib/Semantics/Alternatives/Lexical.lean
+++ b/Linglib/Semantics/Alternatives/Lexical.lean
@@ -218,7 +218,7 @@ Numerals are NOT represented as a `HornScale` here because:
 Both cases are handled in `Semantics/Numerals/Basic.lean`:
 - The five Prop meaning functions (`bareMeaning`, `atLeastMeaning`, ...)
   expose theory disagreement directly via the choice of bare-numeral semantics
-- `kennedyAlternatives` (a single list of `NumeralExpr`) is Kennedy's
+- `kennedyAlternatives` (a single list of `Numeral.Comparison`) is Kennedy's
   anti-Horn-scale alternative set; Class A vs Class B emerges from
   asymmetric entailment, not from a pre-split sublist
 - `bare_not_upward_monotone` / `bare_not_downward_monotone` /

--- a/Linglib/Semantics/Numerals/Basic.lean
+++ b/Linglib/Semantics/Numerals/Basic.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Scales.Scale
 import Linglib.Semantics.Quantification.Quantifier
+import Linglib.Typology.Numeral.Basic
 
 /-!
 # Unified Numeral Semantics
@@ -375,5 +376,56 @@ theorem gqt_exactly_agrees {α : Type*} [Fintype α]
   Iff.rfl
 
 end GQTBridge
+
+/-! ### Denotation of the `Typology.Numeral` object
+
+The lexical numeral object (`Numeral.Comparison`, `Numeral.Entry`) is owned by
+`Typology/Numeral/Basic.lean`; this section is the *semantics* side — it imports
+that object and provides its `relationalGQ` denotation, mirroring how
+`Semantics/Reference/PronounDenotation.lean` denotes the `Pronoun.Entry` object.
+The denotation is **by construction** a `Core.Scale.relationalGQ`, so every lemma
+about `relationalGQ` transfers to every numeral entry. -/
+
+/-- The order relation a `Comparison` stands for — @cite{kennedy-2015}'s `REL`.
+    Lives on the semantics side: it is the interpretation of the theory-neutral
+    `Numeral.Comparison` symbol. -/
+def _root_.Numeral.Comparison.rel {α : Type*} [LinearOrder α] :
+    Numeral.Comparison → α → α → Prop
+  | .eq => (· = ·) | .ge => (· ≥ ·) | .gt => (· > ·)
+  | .le => (· ≤ ·) | .lt => (· < ·)
+
+/-- Denotation of a numeral entry against a measure `μ : E → α` and a magnitude
+    `m`: @cite{kennedy-2015}'s de-Fregean GQ `λx. REL (μ x) m`. The measure and
+    magnitude are supplied compositionally; bare cardinals take `μ = id`,
+    `α = ℕ`. -/
+def _root_.Numeral.Entry.denote {E α : Type*} [LinearOrder α]
+    (e : Numeral.Entry) (μ : E → α) (m : α) : E → Prop :=
+  Core.Scale.relationalGQ e.comparison.rel μ m
+
+/-- Bare cardinal denotation: count with `μ = id` and the entry's own argument. -/
+def _root_.Numeral.Entry.denoteCard (e : Numeral.Entry) : Nat → Prop :=
+  e.denote id e.argument
+
+/-- The bare-comparison cardinal recovers `bareMeaning` (definitionally). -/
+theorem denoteCard_eq_bareMeaning (e : Numeral.Entry) (h : e.comparison = .eq) :
+    e.denoteCard = bareMeaning e.argument := by
+  simp only [Numeral.Entry.denoteCard, Numeral.Entry.denote, h]; rfl
+
+/-- The "at least" cardinal recovers `atLeastMeaning`. -/
+theorem denoteCard_eq_atLeastMeaning (e : Numeral.Entry) (h : e.comparison = .ge) :
+    e.denoteCard = atLeastMeaning e.argument := by
+  simp only [Numeral.Entry.denoteCard, Numeral.Entry.denote, h]; rfl
+
+/-- **Class A/B boundary behaviour, free for every numeral entry.** At an entity
+    whose measure equals the magnitude, the numeral holds iff its comparison is
+    non-strict (bare `=`, Class B `≥`/`≤`) and fails for the strict Class A
+    comparisons (`>`/`<`). Inherited from `relationalGQ`, no per-entry proof. -/
+theorem denote_at_boundary {E α : Type*} [LinearOrder α]
+    (e : Numeral.Entry) (μ : E → α) (m : α) {x : E} (h : μ x = m) :
+    e.denote μ m x ↔ ¬ e.comparison.isStrict := by
+  obtain ⟨_, c, _⟩ := e
+  cases c <;>
+    simp [Numeral.Entry.denote, Numeral.Comparison.rel, Numeral.Comparison.isStrict,
+      Core.Scale.relationalGQ, h]
 
 end Semantics.Numerals

--- a/Linglib/Semantics/Numerals/Basic.lean
+++ b/Linglib/Semantics/Numerals/Basic.lean
@@ -123,7 +123,7 @@ instance (m n : Nat) : Decidable (atMostMeaning m n) :=
   inferInstanceAs (Decidable (n ≤ m))
 
 -- ============================================================================
--- Section 3: BareNumeral and NumeralExpr
+-- Section 3: BareNumeral and Comparison interpretation
 -- ============================================================================
 
 /-- Bare numeral utterances (one through five). -/
@@ -148,60 +148,45 @@ instance : ToString BareNumeral where
     | .one => "one" | .two => "two" | .three => "three"
     | .four => "four" | .five => "five"
 
-/-- A numeral expression: a bare numeral or one of the four modifications.
-    Used both as a surface form and (via `kennedyAlternatives`) as an
-    element of Kennedy's single alternative set. -/
-inductive NumeralExpr where
-  | bare (n : Nat)
-  | atLeast (n : Nat)
-  | moreThan (n : Nat)
-  | atMost (n : Nat)
-  | fewerThan (n : Nat)
-  deriving Repr, DecidableEq
+/-! The five numeral forms are the five `Numeral.Comparison`s applied to an
+    argument; the object lives in `Typology/Numeral/Basic.lean`. Here we give the
+    semantics: the order relation each comparison names, and the theory-choice
+    meaning. -/
 
-/-- The numeric argument: the `m` in "more than `m`", "exactly `m`", etc. -/
-def NumeralExpr.argument : NumeralExpr → Nat
-  | .bare m | .atLeast m | .moreThan m | .atMost m | .fewerThan m => m
+/-- The order relation a `Comparison` stands for — @cite{kennedy-2015}'s `REL`.
+    Interpretation of the theory-neutral `Numeral.Comparison` symbol. -/
+def _root_.Numeral.Comparison.rel {α : Type*} [LinearOrder α] :
+    Numeral.Comparison → α → α → Prop
+  | .eq => (· = ·) | .ge => (· ≥ ·) | .gt => (· > ·)
+  | .le => (· ≤ ·) | .lt => (· < ·)
 
-/-- Strict (Class A) vs. non-strict (Class B) classification per
-    @cite{geurts-nouwen-2007} / @cite{nouwen-2010}. Bare numerals carry
-    no modifier and return `none`. -/
-def NumeralExpr.modifierClass : NumeralExpr → Option ModifierClass
-  | .bare _ => none
-  | .moreThan _ | .fewerThan _ => some .classA
-  | .atLeast _ | .atMost _ => some .classB
+/-- Meaning of a numeral form, parameterized by the bare-numeral semantics
+    (theory choice: Kennedy exact `bareMeaning` or Horn lower-bound
+    `atLeastMeaning`). Only the bare (`.eq`) form consults `bare`; the four
+    modified forms are theory-independent `relationalGQ` denotations. -/
+def _root_.Numeral.Comparison.meaning (c : Numeral.Comparison)
+    (bare : Nat → Nat → Prop) (m : Nat) : Nat → Prop :=
+  match c with
+  | .eq => bare m
+  | c   => Core.Scale.relationalGQ c.rel id m
 
-/-- Lower-bound vs. upper-bound modifier direction. Bare numerals return `none`. -/
-def NumeralExpr.boundDirection : NumeralExpr → Option BoundDirection
-  | .bare _ => none
-  | .atLeast _ | .moreThan _ => some .lower
-  | .atMost _ | .fewerThan _ => some .upper
-
-/-- Meaning of a numeral expression, parameterized by the bare-numeral
-    semantics (theory choice: Kennedy `bareMeaning` or Horn `atLeastMeaning`). -/
-def NumeralExpr.meaning (bare : Nat → Nat → Prop) : NumeralExpr → Nat → Prop
-  | .bare m, n => bare m n
-  | .atLeast m, n => atLeastMeaning m n
-  | .moreThan m, n => moreThanMeaning m n
-  | .atMost m, n => atMostMeaning m n
-  | .fewerThan m, n => fewerThanMeaning m n
-
-instance (bare : Nat → Nat → Prop) [∀ m n, Decidable (bare m n)]
-    (e : NumeralExpr) (n : Nat) : Decidable (e.meaning bare n) := by
-  cases e <;> unfold NumeralExpr.meaning <;> infer_instance
+instance (c : Numeral.Comparison) (bare : Nat → Nat → Prop)
+    [∀ m n, Decidable (bare m n)] (m n : Nat) : Decidable (c.meaning bare m n) := by
+  cases c <;>
+    simp only [Numeral.Comparison.meaning, Numeral.Comparison.rel, Core.Scale.relationalGQ] <;>
+    infer_instance
 
 -- ============================================================================
 -- Section 4: Alternative Set (@cite{kennedy-2015} §4.1)
 -- ============================================================================
 
-/-- @cite{kennedy-2015}'s single alternative set for numeral `n` —
-    bare plus all four surface modifications. The point is
-    **anti-Horn-scale**: there is no fixed scale direction. The
-    Class A / Class B split is read off asymmetric entailment
-    (cf. `classA_excludes_bare_world`, `classB_includes_bare_world`),
-    not from membership in a pre-split sublist. -/
-def kennedyAlternatives (n : Nat) : List NumeralExpr :=
-  [.bare n, .moreThan n, .fewerThan n, .atLeast n, .atMost n]
+/-- @cite{kennedy-2015}'s single alternative set — the five numeral forms (bare
+    plus four modifications) as `Numeral.Comparison`s. The point is
+    **anti-Horn-scale**: there is no fixed scale direction. The Class A / Class B
+    split is read off asymmetric entailment (cf. `classA_excludes_bare_world`,
+    `classB_includes_bare_world`), not from membership in a pre-split sublist. -/
+def kennedyAlternatives : List Numeral.Comparison :=
+  [.eq, .gt, .lt, .ge, .le]
 
 -- ============================================================================
 -- Section 5: Class A/B Corollaries and Anti-Horn-Scale Corollaries
@@ -215,37 +200,33 @@ def kennedyAlternatives (n : Nat) : List NumeralExpr :=
     `Core.Scale.relationalGQ_irrefl_at_boundary` and
     `Core.Scale.relationalGQ_refl_at_boundary`, instantiated at `μ = id`. -/
 
-/-- **Class A excludes the bare-numeral world** (universal). For every
-    `e : NumeralExpr` whose modifier class is A, the meaning fails at
-    `n = e.argument`, regardless of which bare-numeral semantics is chosen.
-
-    Each non-vacuous branch delegates to
+/-- **Class A excludes the bare-numeral world** (universal). A strict comparison
+    (`>`, `<`) fails at the boundary `n = m`, regardless of which bare-numeral
+    semantics is chosen. Each non-vacuous branch delegates to
     `Core.Scale.relationalGQ_irrefl_at_boundary` at `μ = id`. -/
-theorem classA_excludes_bare_world (bare : Nat → Nat → Prop) (e : NumeralExpr)
-    (h : e.modifierClass = some .classA) :
-    ¬ e.meaning bare e.argument := by
-  cases e with
-  | bare _      => simp [NumeralExpr.modifierClass] at h
-  | atLeast _   => simp [NumeralExpr.modifierClass] at h
-  | atMost _    => simp [NumeralExpr.modifierClass] at h
-  | moreThan _  => exact Core.Scale.relationalGQ_irrefl_at_boundary (rel := (· > ·)) id rfl
-  | fewerThan _ => exact Core.Scale.relationalGQ_irrefl_at_boundary (rel := (· < ·)) id rfl
+theorem classA_excludes_bare_world (bare : Nat → Nat → Prop) (c : Numeral.Comparison)
+    (m : Nat) (h : c.isStrict) :
+    ¬ c.meaning bare m m := by
+  cases c with
+  | eq => simp [Numeral.Comparison.isStrict] at h
+  | ge => simp [Numeral.Comparison.isStrict] at h
+  | le => simp [Numeral.Comparison.isStrict] at h
+  | gt => exact Core.Scale.relationalGQ_irrefl_at_boundary (rel := (· > ·)) id rfl
+  | lt => exact Core.Scale.relationalGQ_irrefl_at_boundary (rel := (· < ·)) id rfl
 
-/-- **Class B includes the bare-numeral world** (universal). For every
-    `e : NumeralExpr` whose modifier class is B, the meaning holds at
-    `n = e.argument`, regardless of which bare-numeral semantics is chosen.
-
-    Each non-vacuous branch delegates to
+/-- **Class B includes the bare-numeral world** (universal). A non-strict
+    *modifier* (`≥`, `≤`) holds at the boundary `n = m`, regardless of which
+    bare-numeral semantics is chosen. Each branch delegates to
     `Core.Scale.relationalGQ_refl_at_boundary` at `μ = id`. -/
-theorem classB_includes_bare_world (bare : Nat → Nat → Prop) (e : NumeralExpr)
-    (h : e.modifierClass = some .classB) :
-    e.meaning bare e.argument := by
-  cases e with
-  | bare _      => simp [NumeralExpr.modifierClass] at h
-  | moreThan _  => simp [NumeralExpr.modifierClass] at h
-  | fewerThan _ => simp [NumeralExpr.modifierClass] at h
-  | atLeast _   => exact Core.Scale.relationalGQ_refl_at_boundary (rel := (· ≥ ·)) id rfl
-  | atMost _    => exact Core.Scale.relationalGQ_refl_at_boundary (rel := (· ≤ ·)) id rfl
+theorem classB_includes_bare_world (bare : Nat → Nat → Prop) (c : Numeral.Comparison)
+    (m : Nat) (h : ¬ c.isStrict) (hne : c ≠ .eq) :
+    c.meaning bare m m := by
+  cases c with
+  | eq => exact absurd rfl hne
+  | gt => simp [Numeral.Comparison.isStrict] at h
+  | lt => simp [Numeral.Comparison.isStrict] at h
+  | ge => exact Core.Scale.relationalGQ_refl_at_boundary (rel := (· ≥ ·)) id rfl
+  | le => exact Core.Scale.relationalGQ_refl_at_boundary (rel := (· ≤ ·)) id rfl
 
 /-- Bare numeral pointwise entails "at least `m`" — the `id`-specialization
     of `Core.Scale.eqDeg_imp_atLeastDeg`. -/
@@ -384,15 +365,8 @@ The lexical numeral object (`Numeral.Comparison`, `Numeral.Entry`) is owned by
 that object and provides its `relationalGQ` denotation, mirroring how
 `Semantics/Reference/PronounDenotation.lean` denotes the `Pronoun.Entry` object.
 The denotation is **by construction** a `Core.Scale.relationalGQ`, so every lemma
-about `relationalGQ` transfers to every numeral entry. -/
-
-/-- The order relation a `Comparison` stands for — @cite{kennedy-2015}'s `REL`.
-    Lives on the semantics side: it is the interpretation of the theory-neutral
-    `Numeral.Comparison` symbol. -/
-def _root_.Numeral.Comparison.rel {α : Type*} [LinearOrder α] :
-    Numeral.Comparison → α → α → Prop
-  | .eq => (· = ·) | .ge => (· ≥ ·) | .gt => (· > ·)
-  | .le => (· ≤ ·) | .lt => (· < ·)
+about `relationalGQ` transfers to every numeral entry. `Comparison.rel`/`.meaning`
+are defined in Section 3. -/
 
 /-- Denotation of a numeral entry against a measure `μ : E → α` and a magnitude
     `m`: @cite{kennedy-2015}'s de-Fregean GQ `λx. REL (μ x) m`. The measure and

--- a/Linglib/Studies/Kennedy2015.lean
+++ b/Linglib/Studies/Kennedy2015.lean
@@ -50,10 +50,10 @@ distinct: §2 follows Kennedy directly; §3 shows the same qualitative
 predictions emerge from a soft-max listener over the same alternative set
 and bare-numeral semantics.
 
-The formalization consumes `NumeralExpr.meaning` from
+The formalization consumes `Numeral.Comparison.meaning` from
 `Semantics/Numerals/Basic.lean` directly — there is no separate
 "Kennedy meaning" function (Kennedy's alternative set is *which*
-`NumeralExpr` values to consider, not *what they mean*).
+`Numeral.Comparison`s to consider, not *what they mean*).
 
 Domain: cardinality 0–5 (`Fin 6`, wide enough that Class A "more than 3"
 needs `w = 4` to be non-trivial).
@@ -76,26 +76,26 @@ abbrev KCard : Type := Fin 6
 /-- Kennedy's alternative set members for `n = 3`. One enum unifying
     bare and all four modifications — Class A vs Class B is read off
     asymmetric-entailment, not from membership in a pre-split sublist.
-    The pattern-match `expr` keeps `rsa_predict` reflection cheap. -/
+    The pattern-match `comparison` keeps `rsa_predict` reflection cheap. -/
 inductive KUtt where
   | bare3 | moreThan3 | fewerThan3 | atLeast3 | atMost3
   deriving DecidableEq, Repr, Fintype
 
-/-- Embed a Kennedy alternative into the unified `NumeralExpr`. -/
-def KUtt.expr : KUtt → NumeralExpr
-  | .bare3      => .bare 3
-  | .moreThan3  => .moreThan 3
-  | .fewerThan3 => .fewerThan 3
-  | .atLeast3   => .atLeast 3
-  | .atMost3    => .atMost 3
+/-- The `Numeral.Comparison` a Kennedy alternative expresses (all at argument 3). -/
+def KUtt.comparison : KUtt → Numeral.Comparison
+  | .bare3      => .eq
+  | .moreThan3  => .gt
+  | .fewerThan3 => .lt
+  | .atLeast3   => .ge
+  | .atMost3    => .le
 
 /-- Prop-valued meaning of any Kennedy alternative under bilateral
-    (exact) bare semantics — derived from `NumeralExpr.meaning bareMeaning`. -/
+    (exact) bare semantics — derived from `Numeral.Comparison.meaning bareMeaning`. -/
 def kMean (u : KUtt) (w : KCard) : Prop :=
-  u.expr.meaning bareMeaning w.val
+  u.comparison.meaning bareMeaning 3 w.val
 
 noncomputable instance (u : KUtt) : DecidablePred (kMean u) :=
-  fun w => inferInstanceAs (Decidable (u.expr.meaning bareMeaning w.val))
+  fun w => inferInstanceAs (Decidable (u.comparison.meaning bareMeaning 3 w.val))
 
 -- ============================================================================
 -- §2: Symbolic neo-Gricean derivation (@cite{sauerland-2004} on Kennedy's alts)

--- a/Linglib/Typology/Numeral/Basic.lean
+++ b/Linglib/Typology/Numeral/Basic.lean
@@ -1,0 +1,70 @@
+/-!
+# Numeral — the numeral as a grammatical object
+
+Theory-neutral lexical core for numerals: the substrate a Fragment instantiates
+and a semantics later interprets. A numeral word contributes a `Comparison`
+(@cite{kennedy-2015}'s `REL`: bare / at-least / more-than / at-most / fewer-than)
+and a numeric `argument`. The *measure* it compares against (cardinality, height,
+cost) is supplied compositionally, so it is not a lexical field here.
+
+The denotation — the `relationalGQ`-based meaning and the Kennedy-vs-Horn choice
+for the bare form — lives in `Semantics/Numerals/`, which imports this object.
+This is the same object/denotation split as `Typology/Pronoun/Basic.lean` (the
+`Pronoun.Entry` object) vs. `Semantics/Reference/PronounDenotation.lean` (its
+denotation). The WALS typological survey (`Numeral.Profile`, `fromWALS*`) lives
+in the sibling `Typology/Numeral/WALS.lean`.
+
+## Main declarations
+
+* `Numeral.Comparison` — the relation a numeral draws between measured and stated
+  magnitude (@cite{kennedy-2015}'s `REL`).
+* `Numeral.Comparison.isStrict` — Class A (`>`, `<`) vs. non-strict (bare `=`,
+  Class B `≥`, `≤`); @cite{geurts-nouwen-2007}, @cite{nouwen-2010}.
+* `Numeral.Entry` — cross-linguistic lexical numeral entry (form, comparison,
+  argument).
+-/
+
+namespace Numeral
+
+/-- @cite{kennedy-2015}'s `REL`: the relation a numeral draws between an entity's
+    measured magnitude and the stated magnitude. The five cases underlie the five
+    surface forms. The order relation each names is supplied at interpretation
+    time in `Semantics/Numerals/` (`Comparison.rel`), keeping this object
+    theory-neutral. -/
+inductive Comparison where
+  /-- Bare / exact: `μ x = m`. -/
+  | eq
+  /-- "At least `m`": `μ x ≥ m` (Class B). -/
+  | ge
+  /-- "More than `m`": `μ x > m` (Class A). -/
+  | gt
+  /-- "At most `m`": `μ x ≤ m` (Class B). -/
+  | le
+  /-- "Fewer than `m`": `μ x < m` (Class A). -/
+  | lt
+  deriving DecidableEq, Repr, Inhabited
+
+/-- Strict (Class A: `>`, `<`) vs. non-strict (bare `=`, Class B `≥`, `≤`). The
+    modifier-level Class A/B split of @cite{geurts-nouwen-2007} /
+    @cite{nouwen-2010} is `isStrict` restricted to the four modified forms. -/
+def Comparison.isStrict : Comparison → Prop
+  | .gt | .lt => True
+  | _         => False
+
+instance : DecidablePred Comparison.isStrict := fun c => by
+  cases c <;> unfold Comparison.isStrict <;> infer_instance
+
+/-- Cross-linguistic lexical numeral entry: surface form, the comparison it
+    expresses, and its numeric argument. The measure compared against
+    (cardinality, height, …) is compositional, not lexical, so it is supplied at
+    denotation time rather than stored here. -/
+structure Entry where
+  /-- Surface form (romanization or orthographic). -/
+  form : String
+  /-- The comparison the numeral expresses (bare or a modifier). -/
+  comparison : Comparison
+  /-- The numeric argument: the `m` in "more than `m`", "exactly `m`", … -/
+  argument : Nat
+  deriving Repr, DecidableEq
+
+end Numeral

--- a/Linglib/Typology/Numeral/WALS.lean
+++ b/Linglib/Typology/Numeral/WALS.lean
@@ -18,6 +18,11 @@ suppletion hierarchy for ordinal formation.
 `ClassifierStatus` (WALS Ch 55) and `fromWALS55A` live in
 `Typology/ClassifierSystem.lean` and are re-imported here.
 
+The lexical numeral object (`Numeral.Comparison`, `Numeral.Entry`) that
+Fragments instantiate, and its denotation, live in the sibling
+`Typology/Numeral/Basic.lean` + `Semantics/Numerals/`. This file is the WALS
+typological survey.
+
 ## Schema
 
 - `OrdinalFormation` (Ch 53): ordinal numeral formation
@@ -26,14 +31,16 @@ suppletion hierarchy for ordinal formation.
 - `Region`: areal grouping (for cross-linguistic generalizations)
 - `PluralMarking`: nominal plural status (Sanches-Slobin)
 - `NumeralBase` (Ch 131): decimal/vigesimal/etc.
-- `NumeralProfile`: per-language bundle
+- `Profile`: per-language bundle
 
 Per-language data lives in `Fragments/{Lang}/Numerals.lean`.
 -/
 
 set_option autoImplicit false
 
-namespace Typology
+namespace Numeral
+
+open Typology (ClassifierStatus)
 
 /-- WALS Ch 53: how a language forms ordinal numerals from cardinals.
     The dominant pattern is "first" suppletive + higher ordinals regular. -/
@@ -114,7 +121,7 @@ inductive NumeralBase where
 
 /-- A language's numeral typology profile across all four WALS dimensions
     + areal region + plural-marking status. -/
-structure NumeralProfile where
+structure Profile where
   language : String
   /-- ISO 639-3 code. -/
   iso : String
@@ -135,27 +142,27 @@ structure NumeralProfile where
   deriving Repr, DecidableEq
 
 /-- Does a language have obligatory numeral classifiers? -/
-def NumeralProfile.hasObligatoryClassifiers (p : NumeralProfile) : Bool :=
+def Profile.hasObligatoryClassifiers (p : Profile) : Bool :=
   p.classifier == .obligatory
 
 /-- Does a language have any numeral classifiers (obligatory or optional)? -/
-def NumeralProfile.hasClassifiers (p : NumeralProfile) : Bool :=
+def Profile.hasClassifiers (p : Profile) : Bool :=
   p.classifier != .absent
 
 /-- Does a language have obligatory plural marking on common nouns? -/
-def NumeralProfile.hasObligatoryPlural (p : NumeralProfile) : Bool :=
+def Profile.hasObligatoryPlural (p : Profile) : Bool :=
   p.pluralMarking == .obligatory
 
 /-- Does a language form "first" by suppletion? -/
-def NumeralProfile.hasFirstSuppletion (p : NumeralProfile) : Bool :=
+def Profile.hasFirstSuppletion (p : Profile) : Bool :=
   p.ordinal == .firstSuppletion || p.ordinal == .firstSecondSuppletion
 
 /-- Does a language have a morphological distributive numeral form? -/
-def NumeralProfile.hasDistributive (p : NumeralProfile) : Bool :=
+def Profile.hasDistributive (p : Profile) : Bool :=
   p.distributive != .noDistributive
 
 /-- Is a language in the East/Southeast Asian region? -/
-def NumeralProfile.isEastSoutheastAsian (p : NumeralProfile) : Bool :=
+def Profile.isEastSoutheastAsian (p : Profile) : Bool :=
   p.region == .eastAsia || p.region == .southeastAsia
 
 -- ============================================================================
@@ -369,4 +376,4 @@ theorem suppletion_frequency_matches_hierarchy :
     ch53Distribution.firstSecondSuppletion > ch53Distribution.allFromCardinals := by
   decide
 
-end Typology
+end Numeral

--- a/Linglib/Typology/Numeral/WALS.lean
+++ b/Linglib/Typology/Numeral/WALS.lean
@@ -13,9 +13,10 @@ import Linglib.Data.WALS.Features.F131A
 Type-level enums + per-language profile struct for numeral systems
 across @cite{wals-2013} chapters 53–56 (Gil, Comrie) and 131:
 ordinal formation, distributive numerals, numeral classifiers,
-conjunction-quantifier identity, numeral base. Plus WALS distribution
-data, the principal cross-linguistic generalizations, and the Greenberg
-suppletion hierarchy for ordinal formation.
+conjunction-quantifier identity, numeral base. Plus `Profile.fromWALS` (inherit
+a language's codings from the WALS datasets) and the Greenberg suppletion
+hierarchy for ordinal formation. WALS frequency tendencies are cited as prose,
+not encoded as aggregate-count theorems.
 
 `ClassifierStatus` (WALS Ch 55) and `fromWALS55A` live in
 `Typology/ClassifierSystem.lean` and are re-imported here.
@@ -247,127 +248,24 @@ def Profile.fromWALS (language iso : String) (region : Region)
       (Data.WALS.Datapoint.lookupISO Data.WALS.F131A.allData iso).map
         (fun d => fromWALS131A d.value) }
 
--- ============================================================================
--- WALS distribution data (Ch 53, 54, 56)
--- ============================================================================
+/-! ### Cross-linguistic frequencies (@cite{wals-2013})
 
-/-- WALS Chapter 53 distribution: language counts per ordinal formation type.
-    Total: 321 languages. -/
-structure OrdinalDistribution where
-  firstSuppletion : Nat
-  firstSecondSuppletion : Nat
-  allFromCardinals : Nat
-  various : Nat
-  noOrdinals : Nat
-  deriving Repr
+WALS reports these dominant tendencies. They are *descriptive statistics* over
+each chapter's sample, not formal results, so they live as cited prose rather
+than `theorem`s: a hand-typed count goes stale (the previous `ch56Distribution`
+claimed 220 languages, but `Data.WALS.F56A.allData` has 116), and a count
+*computed* from `allData` via `List.countP` would only re-tally the dataset.
+Recompute on demand with e.g. `#eval (Data.WALS.F53A.allData.countP …)`.
 
-def OrdinalDistribution.total (d : OrdinalDistribution) : Nat :=
-  d.firstSuppletion + d.firstSecondSuppletion + d.allFromCardinals +
-  d.various + d.noOrdinals
+* **Ordinals (Ch 53):** suppletive "first" (alone or with "second") is the
+  dominant strategy, outnumbering all-from-cardinals formation.
+* **Distributives (Ch 54):** reduplication is the most common dedicated
+  strategy, and most languages mark distributives somehow.
+* **Conjunction/quantifier (Ch 56):** formal *differentiation* of 'and' and
+  'all' dominates; formal similarity is a sizeable minority.
 
-/-- WALS Ch 53 counts (321 languages). -/
-def ch53Distribution : OrdinalDistribution :=
-  { firstSuppletion := 99
-  , firstSecondSuppletion := 45
-  , allFromCardinals := 28
-  , various := 83
-  , noOrdinals := 66 }
-
-/-- WALS Chapter 54 distribution: language counts per distributive type.
-    Total: 251 languages. -/
-structure DistributiveDistribution where
-  noDistributive : Nat
-  reduplication : Nat
-  suffixCount : Nat
-  prefixCount : Nat
-  otherMeans : Nat
-  deriving Repr
-
-def DistributiveDistribution.total (d : DistributiveDistribution) : Nat :=
-  d.noDistributive + d.reduplication + d.suffixCount + d.prefixCount + d.otherMeans
-
-/-- WALS Ch 54 counts (251 languages). -/
-def ch54Distribution : DistributiveDistribution :=
-  { noDistributive := 63
-  , reduplication := 85
-  , suffixCount := 34
-  , prefixCount := 19
-  , otherMeans := 50 }
-
-/-- WALS Chapter 56 distribution: language counts per conjunction-quantifier
-    type. Total: 220 languages. -/
-structure ConjQuantDistribution where
-  identity : Nat
-  differentiation : Nat
-  deriving Repr
-
-def ConjQuantDistribution.total (d : ConjQuantDistribution) : Nat :=
-  d.identity + d.differentiation
-
-/-- WALS Ch 56 counts (220 languages). -/
-def ch56Distribution : ConjQuantDistribution :=
-  { identity := 43
-  , differentiation := 177 }
-
--- ============================================================================
--- Cross-linguistic generalizations: ordinals (Ch 53)
--- ============================================================================
-
-/-- Suppletive "first" is the dominant ordinal formation strategy (WALS Ch 53).
-    Languages with suppletive "first" (alone or with suppletive "second")
-    outnumber languages where all ordinals derive regularly from cardinals. -/
-theorem suppletive_first_dominant :
-    ch53Distribution.firstSuppletion + ch53Distribution.firstSecondSuppletion >
-    ch53Distribution.allFromCardinals := by decide
-
-/-- "First" suppletion alone is the single most common ordinal pattern. -/
-theorem first_suppletion_most_common :
-    ch53Distribution.firstSuppletion > ch53Distribution.firstSecondSuppletion ∧
-    ch53Distribution.firstSuppletion > ch53Distribution.allFromCardinals ∧
-    ch53Distribution.firstSuppletion > ch53Distribution.noOrdinals := by decide
-
-/-- Languages with some form of ordinal formation (regular or suppletive)
-    outnumber languages lacking ordinals entirely. -/
-theorem most_languages_have_ordinals :
-    ch53Distribution.firstSuppletion + ch53Distribution.firstSecondSuppletion +
-    ch53Distribution.allFromCardinals + ch53Distribution.various >
-    ch53Distribution.noOrdinals * 3 := by decide
-
--- ============================================================================
--- Cross-linguistic generalizations: distributives (Ch 54)
--- ============================================================================
-
-/-- Languages with dedicated distributive numeral forms outnumber those
-    without, but neither is a negligible minority. -/
-theorem distributive_majority_has_marking :
-    ch54Distribution.reduplication + ch54Distribution.suffixCount +
-    ch54Distribution.prefixCount + ch54Distribution.otherMeans >
-    ch54Distribution.noDistributive := by decide
-
-/-- Reduplication is the single most common distributive strategy,
-    outnumbering any other individual morphological means. -/
-theorem reduplication_most_common_distributive :
-    ch54Distribution.reduplication > ch54Distribution.suffixCount ∧
-    ch54Distribution.reduplication > ch54Distribution.prefixCount ∧
-    ch54Distribution.reduplication > ch54Distribution.otherMeans ∧
-    ch54Distribution.reduplication > ch54Distribution.noDistributive := by decide
-
--- ============================================================================
--- Cross-linguistic generalizations: conjunctions and quantifiers (Ch 56)
--- ============================================================================
-
-/-- Differentiation between 'and' and 'all' is the dominant pattern (WALS Ch 56). -/
-theorem differentiation_dominant :
-    ch56Distribution.differentiation > ch56Distribution.identity := by decide
-
-/-- Differentiation accounts for more than three-quarters of the sample. -/
-theorem differentiation_supermajority :
-    ch56Distribution.differentiation * 4 > ch56Distribution.total * 3 := by decide
-
-/-- Identity between 'and' and 'all' is a non-negligible minority pattern,
-    attested in roughly a fifth of languages (43 out of 220). -/
-theorem identity_nonnegligible :
-    ch56Distribution.identity * 6 ≥ ch56Distribution.total := by decide
+The genuine formal content is the Greenberg suppletion *hierarchy* below, which
+is structural (about `rank`), not a count. -/
 
 -- ============================================================================
 -- Greenberg's suppletion hierarchy for ordinals
@@ -409,14 +307,5 @@ def OrdinalFormation.suppletionCutoff : OrdinalFormation → Option SuppletionCu
 theorem suppletion_hierarchy_ordering :
     SuppletionCutoff.none.rank < SuppletionCutoff.first.rank ∧
     SuppletionCutoff.first.rank < SuppletionCutoff.firstAndSecond.rank := by decide
-
-/-- WALS aggregate confirms the hierarchy: languages with "first"-only
-    suppletion outnumber those with "first+second" suppletion, which in turn
-    outnumber those with no suppletion at all. This reflects the implicational
-    scale: suppletion at higher numerals is rarer. -/
-theorem suppletion_frequency_matches_hierarchy :
-    ch53Distribution.firstSuppletion > ch53Distribution.firstSecondSuppletion ∧
-    ch53Distribution.firstSecondSuppletion > ch53Distribution.allFromCardinals := by
-  decide
 
 end Numeral

--- a/Linglib/Typology/Numeral/WALS.lean
+++ b/Linglib/Typology/Numeral/WALS.lean
@@ -1,6 +1,8 @@
 import Linglib.Typology.ClassifierSystem
 import Linglib.Data.WALS.Features.F53A
 import Linglib.Data.WALS.Features.F54A
+import Linglib.Data.WALS.Features.F55A
+import Linglib.Data.WALS.Features.F56A
 import Linglib.Data.WALS.Features.F131A
 
 /-!
@@ -40,7 +42,7 @@ set_option autoImplicit false
 
 namespace Numeral
 
-open Typology (ClassifierStatus)
+open Typology (ClassifierStatus fromWALS55A)
 
 /-- WALS Ch 53: how a language forms ordinal numerals from cardinals.
     The dominant pattern is "first" suppletive + higher ordinals regular. -/
@@ -203,6 +205,47 @@ def fromWALS131A : Data.WALS.F131A.NumeralBases → NumeralBase
   | .otherBase => .otherBase
   | .extendedBodyPartSystem => .bodyPartSystem
   | .restricted => .restricted
+
+/-- Convert WALS 56A (3-way) to the coarser binary `ConjunctionQuantifier`.
+    Both "formally similar" values (with and without the interrogative) collapse
+    to `identity` — the conjunction and the universal share form; "formally
+    different" maps to `differentiation`. The interrogative distinction
+    (@cite{wals-2013} Ch 56) is finer than the binary substrate. -/
+def fromWALS56A : Data.WALS.F56A.ConjunctionsAndUniversalQuantifiers → ConjunctionQuantifier
+  | .different => .differentiation
+  | .similarWithoutInterrogative => .identity
+  | .similarWithInterrogative => .identity
+
+/-- Build a `Profile` by **inheriting** the WALS numeral-chapter codings for
+    `iso` — Ch 53 ordinal, Ch 54 distributive, Ch 55 classifier, Ch 56
+    conjunction/quantifier, Ch 131 base — via `Datapoint.lookupISO` + the
+    `fromWALS*` converters. `region` and `pluralMarking` are not numeral-chapter
+    features, so the caller supplies them. A language absent from a chapter falls
+    back to the documented neutral value (`.various` / `.noDistributive` /
+    `.absent` / `.differentiation` / `none`). This makes WALS ground-truth: the
+    chapter fields cannot drift from the dataset. -/
+def Profile.fromWALS (language iso : String) (region : Region)
+    (pluralMarking : PluralMarking) : Profile :=
+  { language, iso, region, pluralMarking
+  , ordinal :=
+      match Data.WALS.Datapoint.lookupISO Data.WALS.F53A.allData iso with
+      | some d => fromWALS53A d.value
+      | none => .various
+  , distributive :=
+      match Data.WALS.Datapoint.lookupISO Data.WALS.F54A.allData iso with
+      | some d => fromWALS54A d.value
+      | none => .noDistributive
+  , classifier :=
+      match Data.WALS.Datapoint.lookupISO Data.WALS.F55A.allData iso with
+      | some d => fromWALS55A d.value
+      | none => .absent
+  , conjQuant :=
+      match Data.WALS.Datapoint.lookupISO Data.WALS.F56A.allData iso with
+      | some d => fromWALS56A d.value
+      | none => .differentiation
+  , numeralBase :=
+      (Data.WALS.Datapoint.lookupISO Data.WALS.F131A.allData iso).map
+        (fun d => fromWALS131A d.value) }
 
 -- ============================================================================
 -- WALS distribution data (Ch 53, 54, 56)


### PR DESCRIPTION
Splits the lexical numeral object (`Numeral.Comparison`, `Numeral.Entry`) into `Typology/Numeral/Basic.lean` and renames the WALS survey to `Typology/Numeral/WALS.lean` (`NumeralProfile` → `Numeral.Profile`), mirroring the `Typology/Pronoun/` object/WALS split. Semantics imports the object and provides its `relationalGQ` denotation, so the object is no longer Semantics-owned and rival accounts can denote the same entry.