### PR TITLE
refactor(Core/Scales): hoist Comparison to shared scale primitive

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -290,6 +290,9 @@ import Linglib.Typology.Relativization.ExtractionBridge
 import Linglib.Core.Relativization.Hierarchy
 import Linglib.Typology.ClassifierSystem
 import Linglib.Core.Scales.Roundness
+import Linglib.Core.Scales.Predicate
+import Linglib.Core.Scales.Comparison
+import Linglib.Core.Scales.Scale
 import Linglib.Core.Scales.EpistemicScale.Defs
 import Linglib.Core.Scales.EpistemicScale.Entailments
 import Linglib.Core.Scales.EpistemicScale.FinsetBridge

--- a/Linglib/Core/Scales/Comparison.lean
+++ b/Linglib/Core/Scales/Comparison.lean
@@ -1,0 +1,98 @@
+import Mathlib.Order.Interval.Set.Basic
+
+/-!
+# Core/Scales/Comparison.lean — reified degree comparison
+
+`Comparison` reifies the five ways a measured value relates to a threshold —
+`=`, `≥`, `>`, `≤`, `<` — as data (cf. core `Ordering`, reified for `compare`).
+It is the shared, theory-neutral primitive behind numeral modifiers, measure
+phrases, and (the measure-derived case of) gradable comparatives, per the
+joint degree-semantic treatment of @cite{kennedy-2015} and @cite{rett-2014}.
+
+It interprets two ways, both bottoming out in mathlib's order API so downstream
+proofs reduce into `Set.mem_Ici` & friends rather than a bespoke lemma set:
+
+* `Comparison.rel`      — the order relation (`@cite{kennedy-2015}`'s `REL`).
+* `Comparison.interval` — the order-interval (`Set.Ici`/`Ioi`/`Iic`/`Iio`/`{·}`).
+* `Comparison.over μ n` — the predication `μ ⁻¹' (c.interval n)`: the entities
+  whose measure lands in the interval. Bare cardinals are `over .eq id`, measure
+  phrases `over c μ` for a `MeasureFn`, classifier counting `over .eq (atom-count)`.
+
+`Comparison` (a reified *relation choice*, data) is distinct from `HasComparison`
+(the lawless binary-comparative *typeclass*); the measure-derived instances of
+the latter factor through `Comparison.gt` (see `HasComparison.ofMeasure`).
+
+## Main declarations
+
+* `Core.Scale.Comparison` — the reified comparison.
+* `Comparison.isStrict` — Class A (`>`,`<`) vs. non-strict (`=`,`≥`,`≤`).
+* `Comparison.over` — preimage-of-interval predication.
+* `Comparison.boundary_mem` — Class A/B as interval-endpoint membership.
+-/
+
+namespace Core.Scale
+
+/-- @cite{kennedy-2015}'s `REL` reified: the relation a degree modifier draws
+    between a measured value and a threshold. -/
+inductive Comparison where
+  /-- Exact / bare: `μ x = n`. -/
+  | eq
+  /-- "At least `n`": `μ x ≥ n`. -/
+  | ge
+  /-- "More than `n`": `μ x > n`. -/
+  | gt
+  /-- "At most `n`": `μ x ≤ n`. -/
+  | le
+  /-- "Fewer than `n`": `μ x < n`. -/
+  | lt
+  deriving DecidableEq, Repr, Inhabited
+
+/-- Strict (Class A: `>`, `<`) vs. non-strict (bare `=`, Class B `≥`, `≤`). The
+    modifier-level Class A/B split (@cite{geurts-nouwen-2007}, @cite{nouwen-2010})
+    is `isStrict` restricted to the four modified forms. -/
+def Comparison.isStrict : Comparison → Prop
+  | .gt | .lt => True
+  | _         => False
+
+instance : DecidablePred Comparison.isStrict := fun c => by
+  cases c <;> unfold Comparison.isStrict <;> infer_instance
+
+/-- The order relation a `Comparison` stands for. -/
+def Comparison.rel {α : Type*} [Preorder α] : Comparison → α → α → Prop
+  | .eq => (· = ·) | .ge => (· ≥ ·) | .gt => (· > ·)
+  | .le => (· ≤ ·) | .lt => (· < ·)
+
+/-- The order-interval a comparison selects, in mathlib terms:
+    `{n}` / `[n,∞)` / `(n,∞)` / `(-∞,n]` / `(-∞,n)`. -/
+def Comparison.interval {α : Type*} [Preorder α] : Comparison → α → Set α
+  | .eq => fun n => {n}
+  | .ge => Set.Ici
+  | .gt => Set.Ioi
+  | .le => Set.Iic
+  | .lt => Set.Iio
+
+/-- **The unifying predication**: the entities whose measure `μ` lands in the
+    comparison's interval. The measure varies — `id` for bare cardinals, a
+    dimensional `MeasureFn` for measure phrases, an atom-count for classifiers. -/
+def Comparison.over {E α : Type*} [Preorder α]
+    (c : Comparison) (μ : E → α) (n : α) : Set E :=
+  μ ⁻¹' c.interval n
+
+@[simp] theorem Comparison.mem_interval {α : Type*} [Preorder α]
+    (c : Comparison) (a n : α) : a ∈ c.interval n ↔ c.rel a n := by
+  cases c <;> simp [Comparison.interval, Comparison.rel]
+
+@[simp] theorem Comparison.mem_over {E α : Type*} [Preorder α]
+    (c : Comparison) (μ : E → α) (n : α) (x : E) :
+    x ∈ c.over μ n ↔ c.rel (μ x) n := by
+  simp [Comparison.over]
+
+/-- **Class A/B is interval-endpoint membership.** A non-strict comparison
+    (bare `=`, Class B `≥`/`≤`) keeps the boundary `n`; a strict one (Class A
+    `>`/`<`) drops it — the whole Class A/B distinction
+    (@cite{geurts-nouwen-2007}, @cite{nouwen-2010}) in one lemma. -/
+@[simp] theorem Comparison.boundary_mem {α : Type*} [Preorder α]
+    (c : Comparison) (n : α) : n ∈ c.interval n ↔ ¬ c.isStrict := by
+  cases c <;> simp [Comparison.interval, Comparison.isStrict]
+
+end Core.Scale

--- a/Linglib/Core/Scales/HasComparison.lean
+++ b/Linglib/Core/Scales/HasComparison.lean
@@ -1,5 +1,6 @@
 import Mathlib.Order.Basic
 import Linglib.Core.Scales.HasMeasure
+import Linglib.Core.Scales.Comparison
 
 /-!
 # Core/Scales/HasComparison.lean — primitive comparison typeclass
@@ -43,6 +44,6 @@ class HasComparison (α : Type*) where
 @[reducible]
 def HasComparison.ofMeasure {α δ : Type} [Preorder δ] (m : HasMeasure α δ) :
     HasComparison α where
-  comparativeGreater a b := m.degree a > m.degree b
+  comparativeGreater a b := Comparison.gt.rel (m.degree a) (m.degree b)
 
 end Core.Scale

--- a/Linglib/Core/Scales/HasComparison.lean
+++ b/Linglib/Core/Scales/HasComparison.lean
@@ -42,7 +42,7 @@ class HasComparison (α : Type*) where
     `HasMeasure.measure`). `@[reducible]` is required for class-type
     `def`s (Lean elaboration hygiene). -/
 @[reducible]
-def HasComparison.ofMeasure {α δ : Type} [Preorder δ] (m : HasMeasure α δ) :
+def HasComparison.ofMeasure {α δ : Type*} [Preorder δ] (m : HasMeasure α δ) :
     HasComparison α where
   comparativeGreater a b := Comparison.gt.rel (m.degree a) (m.degree b)
 

--- a/Linglib/Core/Scales/HasMeasure.lean
+++ b/Linglib/Core/Scales/HasMeasure.lean
@@ -129,21 +129,21 @@ abbrev thr (n : Nat) {max : Nat} (h : n < max := by omega) : Threshold max :=
     Renamed from `HasDegree` (legacy name) per master plan v4 Phase A.7.
     Field name kept as `degree` for one-version migration compatibility;
     `HasMeasure.measure` is provided as the v4-canonical alias. -/
-class HasMeasure (E : Type) (α : Type) where
+class HasMeasure (E : Type*) (α : Type*) where
   degree : E → α
 
 /-- v4-canonical name for the measurement function. Aliased to the
     legacy field name `degree` for one-version migration. -/
-abbrev HasMeasure.measure {E α : Type} [HasMeasure E α] : E → α :=
+abbrev HasMeasure.measure {E α : Type*} [HasMeasure E α] : E → α :=
   HasMeasure.degree
 
 /-- Deprecation alias: `HasDegree` is the legacy name for `HasMeasure`.
     One-version migration alias; will be removed in a follow-up refactor. -/
-abbrev HasDegree (E : Type) (α : Type) := HasMeasure E α
+abbrev HasDegree (E : Type*) (α : Type*) := HasMeasure E α
 
 /-- Explicit alias for the legacy field projection `HasDegree.degree`.
     Needed because Lean does not auto-derive projection names through abbrevs. -/
-abbrev HasDegree.degree {E α : Type} [HasDegree E α] : E → α :=
+abbrev HasDegree.degree {E α : Type*} [HasDegree E α] : E → α :=
   HasMeasure.degree
 
 end Core.Scale

--- a/Linglib/Core/Scales/Predicate.lean
+++ b/Linglib/Core/Scales/Predicate.lean
@@ -20,9 +20,9 @@ by a measure function `μ : W → α`:
 This file is part of the Phase A decomposition of the legacy
 `Core/Scales/Scale.lean` dumping ground (master plan v4).
 
-Per master plan v4, `relationalGQ` and its lemmas may move to
-`Semantics/Gradability/Kennedy.lean` in Phase B (it's a
-Kennedy-2015-framework operator, not a domain-general primitive).
+`relationalGQ` stays here as the canonical scale-comparison primitive: it is
+domain-general (numerals, measure phrases, and gradable comparatives all reduce
+to it), and the reified `Core.Scale.Comparison` interprets into it.
 -/
 
 namespace Core.Scale
@@ -247,8 +247,8 @@ the corresponding relation. The Class A vs Class B distinction
 (@cite{geurts-nouwen-2007}, @cite{nouwen-2010}) collapses to a structural
 property of `rel`: Class B ↔ `IsRefl α rel`; Class A ↔ `IsIrrefl α rel`.
 
-**Phase B note**: this Kennedy-framework operator is scheduled to move to
-`Semantics/Gradability/Kennedy.lean` per master plan v4. -/
+This is the canonical comparison primitive of the scale substrate; the reified
+`Core.Scale.Comparison` (in `Comparison.lean`) selects which `rel` to use. -/
 
 /-- Kennedy's unified GQ denotation: `(rel) (μ w) d`. The five named degree
     properties are definitionally equal to instantiations of this. -/

--- a/Linglib/Core/Scales/Scale.lean
+++ b/Linglib/Core/Scales/Scale.lean
@@ -3,6 +3,7 @@ import Linglib.Core.Scales.Rat01
 import Linglib.Core.Scales.Comparative
 import Linglib.Core.Scales.DirectedMeasure
 import Linglib.Core.Scales.Predicate
+import Linglib.Core.Scales.Comparison
 import Linglib.Core.Scales.Bounds
 import Linglib.Core.Scales.HasMeasure
 import Linglib.Core.Scales.HasComparison

--- a/Linglib/Semantics/Alternatives/Lexical.lean
+++ b/Linglib/Semantics/Alternatives/Lexical.lean
@@ -218,7 +218,7 @@ Numerals are NOT represented as a `HornScale` here because:
 Both cases are handled in `Semantics/Numerals/Basic.lean`:
 - The five Prop meaning functions (`bareMeaning`, `atLeastMeaning`, ...)
   expose theory disagreement directly via the choice of bare-numeral semantics
-- `kennedyAlternatives` (a single list of `Numeral.Comparison`) is Kennedy's
+- `kennedyAlternatives` (a single list of `Core.Scale.Comparison`) is Kennedy's
   anti-Horn-scale alternative set; Class A vs Class B emerges from
   asymmetric entailment, not from a pre-split sublist
 - `bare_not_upward_monotone` / `bare_not_downward_monotone` /

--- a/Linglib/Semantics/Classifier/Composition.lean
+++ b/Linglib/Semantics/Classifier/Composition.lean
@@ -58,7 +58,7 @@ variable {W : Type u} {E : Type v} [PartialOrder E]
     `⟨s,n⟩ → ⟨s,⟨e,t⟩⟩`. -/
 def upNum (atomic : Core.Intension W (E → Prop)) (n : NumeralIntens W) :
     Core.Intension W (E → Prop) :=
-  fun w x => {y : E | y ≤ x ∧ atomic w y}.ncard = n w
+  fun w x => atomCount atomic w x = n w
 
 @[simp] lemma upNum_apply (atomic : Core.Intension W (E → Prop))
     (n : NumeralIntens W) (w : W) (x : E) :
@@ -77,7 +77,7 @@ noncomputable def downNum (atomic P : Core.Intension W (E → Prop)) (w : W) :
     Option ℕ :=
   open Classical in
   if h : ∃ x, P w x then
-    some {y : E | y ≤ h.choose ∧ atomic w y}.ncard
+    some (atomCount atomic w h.choose)
   else none
 
 /-- Whether the silent ∪-shift on numerals is available in a language.

--- a/Linglib/Semantics/Classifier/Defs.lean
+++ b/Linglib/Semantics/Classifier/Defs.lean
@@ -52,6 +52,14 @@ structure ClassifierDenot (W : Type u) (E : Type v) [PartialOrder E] where
       For atomic-sortal classifiers, `counted = sortal` (see `ofSortal`). -/
   counted : Core.Intension W (E → Prop)
 
+/-- The atom-count measure: the number of ⊑-atomic `P`-parts of `x` in world
+    `w`. Noncomputable (`Set.ncard`); this is the `μ` over which classifier
+    counting is ordinary numeral comparison (`Comparison.eq.over`), and the same
+    set the Sudo ∪/∩ operators (`upNum`/`downNum`) count. -/
+noncomputable def atomCount {W : Type u} {E : Type v} [PartialOrder E]
+    (P : Core.Intension W (E → Prop)) (w : W) (x : E) : ℕ :=
+  {y : E | y ≤ x ∧ P w y}.ncard
+
 namespace ClassifierDenot
 
 variable {W : Type u} {E : Type v} [PartialOrder E]
@@ -74,8 +82,7 @@ def ofSortal (P : Core.Intension W (E → Prop)) : ClassifierDenot W E where
     measure phrases and bare cardinals use. (`Set.ncard` returns 0 on infinite
     sets; for natural-language counting the relevant sets are finite.) -/
 def apply (cl : ClassifierDenot W E) (w : W) (n : ℕ) (x : E) : Prop :=
-  cl.sortal w x ∧
-    x ∈ Core.Scale.Comparison.eq.over (fun y => {z : E | z ≤ y ∧ cl.counted w z}.ncard) n
+  cl.sortal w x ∧ x ∈ Core.Scale.Comparison.eq.over (atomCount cl.counted w) n
 
 @[simp] lemma ofSortal_sortal (P : Core.Intension W (E → Prop)) :
     (ofSortal P).sortal = P := rfl

--- a/Linglib/Semantics/Classifier/Defs.lean
+++ b/Linglib/Semantics/Classifier/Defs.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Set.Card
 import Linglib.Core.Logic.Intensional.Rigidity
+import Linglib.Core.Scales.Comparison
 
 /-!
 # Classifier Denotations à la Sudo (2016)
@@ -63,15 +64,18 @@ def ofSortal (P : Core.Intension W (E → Prop)) : ClassifierDenot W E where
   sortal := P
   counted := P
 
-/-- The body of Sudo's denotation (eq. 4):
-    `apply cl w n x` iff `sortal_w(x)` AND the cardinality of
-    `{y ⊑ x : counted_w(y)}` equals `n`.
+/-- The body of Sudo's denotation (eq. 4): `apply cl w n x` iff `sortal_w(x)`
+    AND the count of `x`'s ⊑-atomic `counted`-parts equals `n`.
 
-    Uses `Set.ncard` so the formalization works for infinite domains
-    (where `Set.ncard` returns 0 for infinite sets). For Sudo's analysis
-    of natural-language counting, the relevant sets are always finite. -/
+    The counting clause is the **exact (`=`) case of the shared
+    comparison-over-a-measure primitive** `Core.Scale.Comparison.over`, with the
+    measure being the atom-count `λx. |{y ⊑ x : counted_w(y)}|` — classifier
+    counting *is* numeral comparison with `μ = atom-count`, the same primitive
+    measure phrases and bare cardinals use. (`Set.ncard` returns 0 on infinite
+    sets; for natural-language counting the relevant sets are finite.) -/
 def apply (cl : ClassifierDenot W E) (w : W) (n : ℕ) (x : E) : Prop :=
-  cl.sortal w x ∧ {y : E | y ≤ x ∧ cl.counted w y}.ncard = n
+  cl.sortal w x ∧
+    x ∈ Core.Scale.Comparison.eq.over (fun y => {z : E | z ≤ y ∧ cl.counted w z}.ncard) n
 
 @[simp] lemma ofSortal_sortal (P : Core.Intension W (E → Prop)) :
     (ofSortal P).sortal = P := rfl

--- a/Linglib/Semantics/Measurement/Basic.lean
+++ b/Linglib/Semantics/Measurement/Basic.lean
@@ -116,16 +116,21 @@ instance {E : Type*} : CoeFun (MeasureFn E) (fun _ => E → ℚ) where
 
 @cite{scontras-2014}: measure terms are nouns that name specific measure
 functions. Their type is ⟨n, ⟨e,t⟩⟩ — they take a numeral and return a
-predicate. The exact-equality reading is the lexical meaning; pragmatic
-strengthening to lower-bound or at-most readings happens at the numeral
-level (see `bareMeaning` / `atLeastMeaning` / `atMostMeaning` in
-`Semantics.Numerals`), not on the measure term itself. -/
+predicate. This is the **exact (`=`) case of the shared comparison-over-a-
+measure primitive** `Core.Scale.Comparison.over`: `⟦kilo⟧(n)` is
+`Comparison.eq.over μ_kg n`. Modified readings (`> n`, `≥ n`, …) are the other
+`Comparison`s over the same `μ`. -/
 def MeasureFn.applyNumeral {E : Type*} (μ : MeasureFn E) (n : ℚ) (x : E) : Prop :=
-  μ.apply x = n
+  x ∈ Core.Scale.Comparison.eq.over μ.apply n
+
+/-- `applyNumeral` is exact measure predication: `μ(x) = n` (definitionally,
+    the `.eq` interval-membership). -/
+@[simp] theorem MeasureFn.applyNumeral_iff {E : Type*} (μ : MeasureFn E) (n : ℚ) (x : E) :
+    μ.applyNumeral n x ↔ μ.apply x = n := Iff.rfl
 
 instance {E : Type*} (μ : MeasureFn E) (n : ℚ) (x : E) :
-    Decidable (μ.applyNumeral n x) := by
-  unfold MeasureFn.applyNumeral; infer_instance
+    Decidable (μ.applyNumeral n x) :=
+  inferInstanceAs (Decidable (μ.apply x = n))
 
 -- ============================================================================
 -- § 3. CARD: Cardinality as a Measure Function
@@ -382,6 +387,6 @@ same condition `μ(x) = n` when QMOD's restrictor is taken to be trivial. -/
 theorem MeasureFn.applyNumeral_iff_qmod {E : Type*}
     (μ : MeasureFn E) (n : ℚ) (x : E) :
     μ.applyNumeral n x ↔ Mereology.QMOD (fun _ => True) μ.apply n x := by
-  simp [MeasureFn.applyNumeral, Mereology.QMOD]
+  simp [MeasureFn.applyNumeral_iff, Mereology.QMOD]
 
 end Semantics.Measurement

--- a/Linglib/Semantics/Measurement/Basic.lean
+++ b/Linglib/Semantics/Measurement/Basic.lean
@@ -186,7 +186,7 @@ per (entity, codomain) pair. For entities with multiple measurable dimensions,
 use `MeasureFn` directly — the typeclass projection is the specialization for
 when a single dimension is contextually salient. -/
 @[reducible]
-def MeasureFn.toHasDegree {E : Type} (μ : MeasureFn E) : Core.Scale.HasDegree E ℚ :=
+def MeasureFn.toHasDegree {E : Type*} (μ : MeasureFn E) : Core.Scale.HasDegree E ℚ :=
   { degree := μ.apply }
 
 -- ============================================================================

--- a/Linglib/Semantics/Numerals/Basic.lean
+++ b/Linglib/Semantics/Numerals/Basic.lean
@@ -159,30 +159,33 @@ instance : ToString BareNumeral where
     semantics: the order relation each comparison names, and the theory-choice
     meaning. -/
 
-/-- Meaning of a numeral form, parameterized by the bare-numeral semantics
-    (theory choice: Kennedy exact `bareMeaning` or Horn lower-bound
-    `atLeastMeaning`). Only the bare (`.eq`) form consults `bare`; the four
-    modified forms are theory-independent `relationalGQ` denotations. -/
-def _root_.Core.Scale.Comparison.meaning (c : Core.Scale.Comparison)
-    (bare : Nat → Nat → Prop) (m : Nat) : Nat → Prop :=
-  match c with
-  | .eq => bare m
-  | c   => Core.Scale.relationalGQ c.rel id m
+/-- Denotation of a numeral word `e`: the predicate over cardinalities it is true
+    of, under a choice of bare-numeral semantics (`bareMeaning` exact vs.
+    `atLeastMeaning` lower-bound — only the bare `.eq` form consults `bare`; the
+    four modified forms are theory-independent `relationalGQ` denotations). A
+    method on the numeral object, mirroring `Pronoun.Entry.denote`. -/
+def _root_.Numeral.Entry.meaning (e : Numeral.Entry) (bare : Nat → Nat → Prop) :
+    Nat → Prop :=
+  match e.comparison with
+  | .eq => bare e.argument
+  | c   => Core.Scale.relationalGQ c.rel id e.argument
 
-instance (c : Core.Scale.Comparison) (bare : Nat → Nat → Prop)
-    [∀ m n, Decidable (bare m n)] (m n : Nat) : Decidable (c.meaning bare m n) := by
+instance (e : Numeral.Entry) (bare : Nat → Nat → Prop)
+    [∀ m n, Decidable (bare m n)] (n : Nat) : Decidable (e.meaning bare n) := by
+  obtain ⟨_, c, _⟩ := e
   cases c <;>
-    simp only [Core.Scale.Comparison.meaning, Core.Scale.Comparison.rel, Core.Scale.relationalGQ] <;>
+    simp only [Numeral.Entry.meaning, Core.Scale.Comparison.rel, Core.Scale.relationalGQ] <;>
     infer_instance
 
-/-- The bare-world meaning of a *modified* numeral (`c ≠ .eq`) is endpoint
-    membership in the comparison's interval — connecting `meaning` to the
-    interval form. -/
-theorem _root_.Core.Scale.Comparison.meaning_boundary (bare : Nat → Nat → Prop)
-    (c : Core.Scale.Comparison) (m : Nat) (h : c ≠ .eq) :
-    c.meaning bare m m ↔ m ∈ c.interval m := by
+/-- The bare-world meaning of a *modified* numeral word (`comparison ≠ .eq`) is
+    endpoint membership in the comparison's interval — connecting `meaning` to
+    the interval form. -/
+theorem _root_.Numeral.Entry.meaning_boundary (e : Numeral.Entry) (bare : Nat → Nat → Prop)
+    (h : e.comparison ≠ .eq) :
+    e.meaning bare e.argument ↔ e.argument ∈ e.comparison.interval e.argument := by
+  obtain ⟨_, c, _⟩ := e
   cases c <;>
-    simp_all [Core.Scale.Comparison.meaning, Core.Scale.Comparison.interval,
+    simp_all [Numeral.Entry.meaning, Core.Scale.Comparison.interval,
       Core.Scale.relationalGQ, Core.Scale.Comparison.rel]
 
 -- ============================================================================
@@ -210,20 +213,20 @@ def kennedyAlternatives : List Core.Scale.Comparison :=
 /-- **Class A excludes the bare-numeral world** (universal). A strict comparison
     (`>`, `<`) fails at the boundary `n = m`, regardless of which bare-numeral
     semantics is chosen. Corollary of `boundary_mem`. -/
-theorem classA_excludes_bare_world (bare : Nat → Nat → Prop) (c : Core.Scale.Comparison)
-    (m : Nat) (h : c.isStrict) :
-    ¬ c.meaning bare m m := by
-  have hne : c ≠ .eq := by cases c <;> simp_all [Core.Scale.Comparison.isStrict]
-  rw [Core.Scale.Comparison.meaning_boundary bare c m hne, Core.Scale.Comparison.boundary_mem]
+theorem classA_excludes_bare_world (e : Numeral.Entry) (bare : Nat → Nat → Prop)
+    (h : e.comparison.isStrict) :
+    ¬ e.meaning bare e.argument := by
+  have hne : e.comparison ≠ .eq := by intro heq; rw [heq] at h; exact h
+  rw [e.meaning_boundary bare hne, Core.Scale.Comparison.boundary_mem]
   exact not_not_intro h
 
 /-- **Class B includes the bare-numeral world** (universal). A non-strict
     *modifier* (`≥`, `≤`) holds at the boundary `n = m`, regardless of which
     bare-numeral semantics is chosen. Corollary of `boundary_mem`. -/
-theorem classB_includes_bare_world (bare : Nat → Nat → Prop) (c : Core.Scale.Comparison)
-    (m : Nat) (h : ¬ c.isStrict) (hne : c ≠ .eq) :
-    c.meaning bare m m := by
-  rw [Core.Scale.Comparison.meaning_boundary bare c m hne, Core.Scale.Comparison.boundary_mem]
+theorem classB_includes_bare_world (e : Numeral.Entry) (bare : Nat → Nat → Prop)
+    (h : ¬ e.comparison.isStrict) (hne : e.comparison ≠ .eq) :
+    e.meaning bare e.argument := by
+  rw [e.meaning_boundary bare hne, Core.Scale.Comparison.boundary_mem]
   exact h
 
 /-- Bare numeral pointwise entails "at least `m`" — the `id`-specialization

--- a/Linglib/Semantics/Numerals/Basic.lean
+++ b/Linglib/Semantics/Numerals/Basic.lean
@@ -34,7 +34,7 @@ underlying relation; see `Core.Scale.relationalGQ_refl_at_boundary` and
 
 1. Modifier classification (Class A/B, Bound direction)
 2. Numeral meaning functions (5 `def`s over `Core.Scale.{...}Deg id`)
-3. `BareNumeral` and `NumeralExpr`
+3. `BareNumeral`; `Comparison` interpretation (`Entry.denoteUnder`)
 4. Alternative sets (Kennedy §4.1)
 5. Class A/B corollaries, anti-Horn-scale corollaries
 6. Type-shifting (Kennedy §3.1)
@@ -164,28 +164,28 @@ instance : ToString BareNumeral where
     `atLeastMeaning` lower-bound — only the bare `.eq` form consults `bare`; the
     four modified forms are theory-independent `relationalGQ` denotations). A
     method on the numeral object, mirroring `Pronoun.Entry.denote`. -/
-def _root_.Numeral.Entry.meaning (e : Numeral.Entry) (bare : Nat → Nat → Prop) :
+def _root_.Numeral.Entry.denoteUnder (e : Numeral.Entry) (bare : Nat → Nat → Prop) :
     Nat → Prop :=
   match e.comparison with
   | .eq => bare e.argument
   | c   => Core.Scale.relationalGQ c.rel id e.argument
 
 instance (e : Numeral.Entry) (bare : Nat → Nat → Prop)
-    [∀ m n, Decidable (bare m n)] (n : Nat) : Decidable (e.meaning bare n) := by
+    [∀ m n, Decidable (bare m n)] (n : Nat) : Decidable (e.denoteUnder bare n) := by
   obtain ⟨_, c, _⟩ := e
   cases c <;>
-    simp only [Numeral.Entry.meaning, Core.Scale.Comparison.rel, Core.Scale.relationalGQ] <;>
+    simp only [Numeral.Entry.denoteUnder, Core.Scale.Comparison.rel, Core.Scale.relationalGQ] <;>
     infer_instance
 
 /-- The bare-world meaning of a *modified* numeral word (`comparison ≠ .eq`) is
     endpoint membership in the comparison's interval — connecting `meaning` to
     the interval form. -/
-theorem _root_.Numeral.Entry.meaning_boundary (e : Numeral.Entry) (bare : Nat → Nat → Prop)
+theorem _root_.Numeral.Entry.denoteUnder_boundary (e : Numeral.Entry) (bare : Nat → Nat → Prop)
     (h : e.comparison ≠ .eq) :
-    e.meaning bare e.argument ↔ e.argument ∈ e.comparison.interval e.argument := by
+    e.denoteUnder bare e.argument ↔ e.argument ∈ e.comparison.interval e.argument := by
   obtain ⟨_, c, _⟩ := e
   cases c <;>
-    simp_all [Numeral.Entry.meaning, Core.Scale.Comparison.interval,
+    simp_all [Numeral.Entry.denoteUnder, Core.Scale.Comparison.interval,
       Core.Scale.relationalGQ, Core.Scale.Comparison.rel]
 
 -- ============================================================================
@@ -215,9 +215,9 @@ def kennedyAlternatives : List Core.Scale.Comparison :=
     semantics is chosen. Corollary of `boundary_mem`. -/
 theorem classA_excludes_bare_world (e : Numeral.Entry) (bare : Nat → Nat → Prop)
     (h : e.comparison.isStrict) :
-    ¬ e.meaning bare e.argument := by
+    ¬ e.denoteUnder bare e.argument := by
   have hne : e.comparison ≠ .eq := by intro heq; rw [heq] at h; exact h
-  rw [e.meaning_boundary bare hne, Core.Scale.Comparison.boundary_mem]
+  rw [e.denoteUnder_boundary bare hne, Core.Scale.Comparison.boundary_mem]
   exact not_not_intro h
 
 /-- **Class B includes the bare-numeral world** (universal). A non-strict
@@ -225,8 +225,8 @@ theorem classA_excludes_bare_world (e : Numeral.Entry) (bare : Nat → Nat → P
     bare-numeral semantics is chosen. Corollary of `boundary_mem`. -/
 theorem classB_includes_bare_world (e : Numeral.Entry) (bare : Nat → Nat → Prop)
     (h : ¬ e.comparison.isStrict) (hne : e.comparison ≠ .eq) :
-    e.meaning bare e.argument := by
-  rw [e.meaning_boundary bare hne, Core.Scale.Comparison.boundary_mem]
+    e.denoteUnder bare e.argument := by
+  rw [e.denoteUnder_boundary bare hne, Core.Scale.Comparison.boundary_mem]
   exact h
 
 /-- Bare numeral pointwise entails "at least `m`" — the `id`-specialization
@@ -366,8 +366,9 @@ The lexical numeral object (`Core.Scale.Comparison`, `Numeral.Entry`) is owned b
 that object and provides its `relationalGQ` denotation, mirroring how
 `Semantics/Reference/PronounDenotation.lean` denotes the `Pronoun.Entry` object.
 The denotation is **by construction** a `Core.Scale.relationalGQ`, so every lemma
-about `relationalGQ` transfers to every numeral entry. `Comparison.rel`/`.meaning`
-are defined in Section 3. -/
+about `relationalGQ` transfers to every numeral entry. `Comparison.rel` lives in
+`Core.Scale`; `Entry.denoteUnder` (the cardinal, theory-parameterized reading) is
+in Section 3. -/
 
 /-- Denotation of a numeral entry against a measure `μ : E → α` and a magnitude
     `m`: @cite{kennedy-2015}'s de-Fregean GQ `λx. REL (μ x) m`. The measure and

--- a/Linglib/Semantics/Numerals/Basic.lean
+++ b/Linglib/Semantics/Numerals/Basic.lean
@@ -52,15 +52,20 @@ namespace Semantics.Numerals
 -- Section 1: Modifier Classification
 -- ============================================================================
 
-/-- Class A (strict) vs Class B (non-strict) modified numerals.
+/-- Class A (strict `>`, `<`) vs Class B (non-strict `≥`, `≤`) modified
+numerals — a descriptive split due to @cite{nouwen-2010}.
 
-The distinction predicts ignorance implicature patterns:
-- Class A (>, <): EXCLUDE the bare-numeral world → no ignorance
-- Class B (≥, ≤): INCLUDE the bare-numeral world → ignorance
-
-Structurally: Class B iff the underlying relation is reflexive (`Std.Refl`),
-Class A iff irreflexive (`Std.Irrefl`); see
-`Core.Scale.relationalGQ_refl_at_boundary`. -/
+Truth-conditionally the split is the reflexive/irreflexive boundary behavior:
+Class A EXCLUDES the bare-numeral world, Class B INCLUDES it (Class B iff the
+underlying relation is reflexive; see `Core.Scale.relationalGQ_refl_at_boundary`
+and `Core.Scale.Comparison.boundary_mem`). The further claim that this predicts
+a *categorical* ignorance-implicature pattern (Class B carries ignorance, Class
+A not) is contested: @cite{schwarz-buccola-hamilton-2012} show *at most* and *up
+to* dissociate (so "Class B" is not one class), and
+@cite{cremers-coppock-dotlacil-roelofsen-2022} find the ignorance contrast
+graded and QUD-dependent rather than categorical; @cite{enguehard-2018} derives
+comparative-numeral inferences from granularity scales rather than from the
+strict/non-strict relation type. -/
 inductive ModifierClass where
   | classA  -- strict: >, <
   | classB  -- non-strict: ≥, ≤
@@ -149,101 +154,47 @@ instance : ToString BareNumeral where
     | .one => "one" | .two => "two" | .three => "three"
     | .four => "four" | .five => "five"
 
-/-! The five numeral forms are the five `Numeral.Comparison`s applied to an
+/-! The five numeral forms are the five `Core.Scale.Comparison`s applied to an
     argument; the object lives in `Typology/Numeral/Basic.lean`. Here we give the
     semantics: the order relation each comparison names, and the theory-choice
     meaning. -/
-
-/-- The order relation a `Comparison` stands for — @cite{kennedy-2015}'s `REL`.
-    Interpretation of the theory-neutral `Numeral.Comparison` symbol. -/
-def _root_.Numeral.Comparison.rel {α : Type*} [LinearOrder α] :
-    Numeral.Comparison → α → α → Prop
-  | .eq => (· = ·) | .ge => (· ≥ ·) | .gt => (· > ·)
-  | .le => (· ≤ ·) | .lt => (· < ·)
 
 /-- Meaning of a numeral form, parameterized by the bare-numeral semantics
     (theory choice: Kennedy exact `bareMeaning` or Horn lower-bound
     `atLeastMeaning`). Only the bare (`.eq`) form consults `bare`; the four
     modified forms are theory-independent `relationalGQ` denotations. -/
-def _root_.Numeral.Comparison.meaning (c : Numeral.Comparison)
+def _root_.Core.Scale.Comparison.meaning (c : Core.Scale.Comparison)
     (bare : Nat → Nat → Prop) (m : Nat) : Nat → Prop :=
   match c with
   | .eq => bare m
   | c   => Core.Scale.relationalGQ c.rel id m
 
-instance (c : Numeral.Comparison) (bare : Nat → Nat → Prop)
+instance (c : Core.Scale.Comparison) (bare : Nat → Nat → Prop)
     [∀ m n, Decidable (bare m n)] (m n : Nat) : Decidable (c.meaning bare m n) := by
   cases c <;>
-    simp only [Numeral.Comparison.meaning, Numeral.Comparison.rel, Core.Scale.relationalGQ] <;>
+    simp only [Core.Scale.Comparison.meaning, Core.Scale.Comparison.rel, Core.Scale.relationalGQ] <;>
     infer_instance
-
-/-! ### Interval / preimage form
-
-A numeral-modified predicate is, set-theoretically, the **preimage of an
-order-interval under a measure**: `μ ⁻¹' (c.interval n)`. The `Comparison`
-selects the interval; the measure `μ` selects what is counted or measured
-(`id` for bare cardinals, a `MeasureFn` for measure phrases, atom-cardinality
-for classifier counting). This is `relationalGQ` read through `Set`, and the
-Class A/B split becomes a one-liner about whether the interval is closed at its
-endpoint (`boundary_mem`). -/
-
-/-- The order-interval a comparison selects: `{n}`, `[n,∞)`, `(n,∞)`, `(-∞,n]`,
-    `(-∞,n)`. The set-theoretic interpretation of the comparison symbol. -/
-def _root_.Numeral.Comparison.interval {α : Type*} [Preorder α] :
-    Numeral.Comparison → α → Set α
-  | .eq => fun n => {n}
-  | .ge => Set.Ici
-  | .gt => Set.Ioi
-  | .le => Set.Iic
-  | .lt => Set.Iio
-
-/-- The interval form coincides with the relational form (`Comparison.rel`). -/
-theorem _root_.Numeral.Comparison.mem_interval {α : Type*} [LinearOrder α]
-    (c : Numeral.Comparison) (a n : α) : a ∈ c.interval n ↔ c.rel a n := by
-  cases c <;> simp [Numeral.Comparison.interval, Numeral.Comparison.rel]
-
-/-- **The unifying numeral-predication operation**: the set of entities whose
-    measure `μ` lands in the comparison's interval. Bare cardinals (`μ = id`),
-    measure phrases (`μ` a `MeasureFn`), and classifier counting (`μ` an
-    atom-cardinality) are all instances. -/
-def _root_.Numeral.over {E α : Type*} [Preorder α]
-    (c : Numeral.Comparison) (μ : E → α) (n : α) : Set E :=
-  μ ⁻¹' c.interval n
-
-/-- `Numeral.over` coincides with the `relationalGQ` denotation. -/
-theorem _root_.Numeral.mem_over {E α : Type*} [LinearOrder α]
-    (c : Numeral.Comparison) (μ : E → α) (n : α) (x : E) :
-    x ∈ Numeral.over c μ n ↔ Core.Scale.relationalGQ c.rel μ n x := by
-  simp [Numeral.over, Numeral.Comparison.mem_interval]; rfl
-
-/-- **Class A/B is interval-endpoint membership.** A non-strict comparison
-    (bare `=`, Class B `≥`/`≤`) keeps the boundary `n`; a strict one (Class A
-    `>`/`<`) drops it. This is the whole Class A/B generalization
-    (@cite{geurts-nouwen-2007}, @cite{nouwen-2010}) in one lemma. -/
-theorem _root_.Numeral.Comparison.boundary_mem {α : Type*} [Preorder α]
-    (c : Numeral.Comparison) (n : α) : n ∈ c.interval n ↔ ¬ c.isStrict := by
-  cases c <;> simp [Numeral.Comparison.interval, Numeral.Comparison.isStrict]
 
 /-- The bare-world meaning of a *modified* numeral (`c ≠ .eq`) is endpoint
     membership in the comparison's interval — connecting `meaning` to the
     interval form. -/
-theorem _root_.Numeral.Comparison.meaning_boundary (bare : Nat → Nat → Prop)
-    (c : Numeral.Comparison) (m : Nat) (h : c ≠ .eq) :
+theorem _root_.Core.Scale.Comparison.meaning_boundary (bare : Nat → Nat → Prop)
+    (c : Core.Scale.Comparison) (m : Nat) (h : c ≠ .eq) :
     c.meaning bare m m ↔ m ∈ c.interval m := by
   cases c <;>
-    simp_all [Numeral.Comparison.meaning, Numeral.Comparison.interval,
-      Core.Scale.relationalGQ, Numeral.Comparison.rel]
+    simp_all [Core.Scale.Comparison.meaning, Core.Scale.Comparison.interval,
+      Core.Scale.relationalGQ, Core.Scale.Comparison.rel]
 
 -- ============================================================================
 -- Section 4: Alternative Set (@cite{kennedy-2015} §4.1)
 -- ============================================================================
 
 /-- @cite{kennedy-2015}'s single alternative set — the five numeral forms (bare
-    plus four modifications) as `Numeral.Comparison`s. The point is
+    plus four modifications) as `Core.Scale.Comparison`s. The point is
     **anti-Horn-scale**: there is no fixed scale direction. The Class A / Class B
     split is read off asymmetric entailment (cf. `classA_excludes_bare_world`,
     `classB_includes_bare_world`), not from membership in a pre-split sublist. -/
-def kennedyAlternatives : List Numeral.Comparison :=
+def kennedyAlternatives : List Core.Scale.Comparison :=
   [.eq, .gt, .lt, .ge, .le]
 
 -- ============================================================================
@@ -253,26 +204,26 @@ def kennedyAlternatives : List Numeral.Comparison :=
 /-! Class A/B is the central typological generalization (@cite{geurts-nouwen-2007},
     @cite{nouwen-2010}): strict modifiers (`>`, `<`) exclude the bare-numeral
     world; non-strict modifiers (`≥`, `≤`) include it. Both theorems below are
-    now corollaries of `Numeral.Comparison.boundary_mem` (Class A/B = whether the
+    now corollaries of `Core.Scale.Comparison.boundary_mem` (Class A/B = whether the
     comparison's interval is closed at its endpoint) via `meaning_boundary`. -/
 
 /-- **Class A excludes the bare-numeral world** (universal). A strict comparison
     (`>`, `<`) fails at the boundary `n = m`, regardless of which bare-numeral
     semantics is chosen. Corollary of `boundary_mem`. -/
-theorem classA_excludes_bare_world (bare : Nat → Nat → Prop) (c : Numeral.Comparison)
+theorem classA_excludes_bare_world (bare : Nat → Nat → Prop) (c : Core.Scale.Comparison)
     (m : Nat) (h : c.isStrict) :
     ¬ c.meaning bare m m := by
-  have hne : c ≠ .eq := by cases c <;> simp_all [Numeral.Comparison.isStrict]
-  rw [Numeral.Comparison.meaning_boundary bare c m hne, Numeral.Comparison.boundary_mem]
+  have hne : c ≠ .eq := by cases c <;> simp_all [Core.Scale.Comparison.isStrict]
+  rw [Core.Scale.Comparison.meaning_boundary bare c m hne, Core.Scale.Comparison.boundary_mem]
   exact not_not_intro h
 
 /-- **Class B includes the bare-numeral world** (universal). A non-strict
     *modifier* (`≥`, `≤`) holds at the boundary `n = m`, regardless of which
     bare-numeral semantics is chosen. Corollary of `boundary_mem`. -/
-theorem classB_includes_bare_world (bare : Nat → Nat → Prop) (c : Numeral.Comparison)
+theorem classB_includes_bare_world (bare : Nat → Nat → Prop) (c : Core.Scale.Comparison)
     (m : Nat) (h : ¬ c.isStrict) (hne : c ≠ .eq) :
     c.meaning bare m m := by
-  rw [Numeral.Comparison.meaning_boundary bare c m hne, Numeral.Comparison.boundary_mem]
+  rw [Core.Scale.Comparison.meaning_boundary bare c m hne, Core.Scale.Comparison.boundary_mem]
   exact h
 
 /-- Bare numeral pointwise entails "at least `m`" — the `id`-specialization
@@ -407,7 +358,7 @@ end GQTBridge
 
 /-! ### Denotation of the `Typology.Numeral` object
 
-The lexical numeral object (`Numeral.Comparison`, `Numeral.Entry`) is owned by
+The lexical numeral object (`Core.Scale.Comparison`, `Numeral.Entry`) is owned by
 `Typology/Numeral/Basic.lean`; this section is the *semantics* side — it imports
 that object and provides its `relationalGQ` denotation, mirroring how
 `Semantics/Reference/PronounDenotation.lean` denotes the `Pronoun.Entry` object.
@@ -446,7 +397,7 @@ theorem denote_at_boundary {E α : Type*} [LinearOrder α]
     e.denote μ m x ↔ ¬ e.comparison.isStrict := by
   obtain ⟨_, c, _⟩ := e
   cases c <;>
-    simp [Numeral.Entry.denote, Numeral.Comparison.rel, Numeral.Comparison.isStrict,
+    simp [Numeral.Entry.denote, Core.Scale.Comparison.rel, Core.Scale.Comparison.isStrict,
       Core.Scale.relationalGQ, h]
 
 end Semantics.Numerals

--- a/Linglib/Semantics/Numerals/Degree.lean
+++ b/Linglib/Semantics/Numerals/Degree.lean
@@ -20,15 +20,9 @@ namespace Semantics.Numerals
 
 open Core.Scale
 
-/-- Cardinality (`Nat`) participates in the `HasDegree` framework via the
-    canonical embedding into ℚ. -/
+/-- Cardinality (`Nat`) participates in the `HasMeasure`/`HasDegree` framework
+    via the canonical embedding into ℚ. -/
 instance CardinalityDegree : HasDegree Nat ℚ where
   degree := λ n => (n : ℚ)
-
-/-- Literal/exact numeral semantics over `HasDegree`. "Six feet" is true of
-    `x` iff `μ_height(x) = 6`. -/
-def numeralExact {E α : Type} [HasDegree E α] [BEq α]
-    (stated : α) (entity : E) : Bool :=
-  HasDegree.degree entity == stated
 
 end Semantics.Numerals

--- a/Linglib/Studies/Kennedy2015.lean
+++ b/Linglib/Studies/Kennedy2015.lean
@@ -50,7 +50,7 @@ distinct: §2 follows Kennedy directly; §3 shows the same qualitative
 predictions emerge from a soft-max listener over the same alternative set
 and bare-numeral semantics.
 
-The formalization consumes `Numeral.Entry.meaning` from
+The formalization consumes `Numeral.Entry.denoteUnder` from
 `Semantics/Numerals/Basic.lean` directly — there is no separate
 "Kennedy meaning" function (Kennedy's alternative set is *which* numeral
 words to consider, not *what they mean*).
@@ -91,12 +91,12 @@ def KUtt.entry : KUtt → Numeral.Entry
   | .atMost3    => ⟨"at most three", .le, 3⟩
 
 /-- Prop-valued meaning of any Kennedy alternative under bilateral (exact) bare
-    semantics — `Numeral.Entry.meaning` with `bare := bareMeaning`. -/
+    semantics — `Numeral.Entry.denoteUnder` with `bare := bareMeaning`. -/
 def kMean (u : KUtt) (w : KCard) : Prop :=
-  u.entry.meaning bareMeaning w.val
+  u.entry.denoteUnder bareMeaning w.val
 
 noncomputable instance (u : KUtt) : DecidablePred (kMean u) :=
-  fun w => inferInstanceAs (Decidable (u.entry.meaning bareMeaning w.val))
+  fun w => inferInstanceAs (Decidable (u.entry.denoteUnder bareMeaning w.val))
 
 -- ============================================================================
 -- §2: Symbolic neo-Gricean derivation (@cite{sauerland-2004} on Kennedy's alts)

--- a/Linglib/Studies/Kennedy2015.lean
+++ b/Linglib/Studies/Kennedy2015.lean
@@ -50,10 +50,10 @@ distinct: §2 follows Kennedy directly; §3 shows the same qualitative
 predictions emerge from a soft-max listener over the same alternative set
 and bare-numeral semantics.
 
-The formalization consumes `Core.Scale.Comparison.meaning` from
+The formalization consumes `Numeral.Entry.meaning` from
 `Semantics/Numerals/Basic.lean` directly — there is no separate
-"Kennedy meaning" function (Kennedy's alternative set is *which*
-`Core.Scale.Comparison`s to consider, not *what they mean*).
+"Kennedy meaning" function (Kennedy's alternative set is *which* numeral
+words to consider, not *what they mean*).
 
 Domain: cardinality 0–5 (`Fin 6`, wide enough that Class A "more than 3"
 needs `w = 4` to be non-trivial).
@@ -81,21 +81,22 @@ inductive KUtt where
   | bare3 | moreThan3 | fewerThan3 | atLeast3 | atMost3
   deriving DecidableEq, Repr, Fintype
 
-/-- The `Core.Scale.Comparison` a Kennedy alternative expresses (all at argument 3). -/
-def KUtt.comparison : KUtt → Core.Scale.Comparison
-  | .bare3      => .eq
-  | .moreThan3  => .gt
-  | .fewerThan3 => .lt
-  | .atLeast3   => .ge
-  | .atMost3    => .le
+/-- The numeral word (`Numeral.Entry`) a Kennedy alternative is — all at
+    argument 3, with their surface forms. -/
+def KUtt.entry : KUtt → Numeral.Entry
+  | .bare3      => ⟨"three", .eq, 3⟩
+  | .moreThan3  => ⟨"more than three", .gt, 3⟩
+  | .fewerThan3 => ⟨"fewer than three", .lt, 3⟩
+  | .atLeast3   => ⟨"at least three", .ge, 3⟩
+  | .atMost3    => ⟨"at most three", .le, 3⟩
 
-/-- Prop-valued meaning of any Kennedy alternative under bilateral
-    (exact) bare semantics — derived from `Core.Scale.Comparison.meaning bareMeaning`. -/
+/-- Prop-valued meaning of any Kennedy alternative under bilateral (exact) bare
+    semantics — `Numeral.Entry.meaning` with `bare := bareMeaning`. -/
 def kMean (u : KUtt) (w : KCard) : Prop :=
-  u.comparison.meaning bareMeaning 3 w.val
+  u.entry.meaning bareMeaning w.val
 
 noncomputable instance (u : KUtt) : DecidablePred (kMean u) :=
-  fun w => inferInstanceAs (Decidable (u.comparison.meaning bareMeaning 3 w.val))
+  fun w => inferInstanceAs (Decidable (u.entry.meaning bareMeaning w.val))
 
 -- ============================================================================
 -- §2: Symbolic neo-Gricean derivation (@cite{sauerland-2004} on Kennedy's alts)

--- a/Linglib/Studies/Kennedy2015.lean
+++ b/Linglib/Studies/Kennedy2015.lean
@@ -50,10 +50,10 @@ distinct: §2 follows Kennedy directly; §3 shows the same qualitative
 predictions emerge from a soft-max listener over the same alternative set
 and bare-numeral semantics.
 
-The formalization consumes `Numeral.Comparison.meaning` from
+The formalization consumes `Core.Scale.Comparison.meaning` from
 `Semantics/Numerals/Basic.lean` directly — there is no separate
 "Kennedy meaning" function (Kennedy's alternative set is *which*
-`Numeral.Comparison`s to consider, not *what they mean*).
+`Core.Scale.Comparison`s to consider, not *what they mean*).
 
 Domain: cardinality 0–5 (`Fin 6`, wide enough that Class A "more than 3"
 needs `w = 4` to be non-trivial).
@@ -81,8 +81,8 @@ inductive KUtt where
   | bare3 | moreThan3 | fewerThan3 | atLeast3 | atMost3
   deriving DecidableEq, Repr, Fintype
 
-/-- The `Numeral.Comparison` a Kennedy alternative expresses (all at argument 3). -/
-def KUtt.comparison : KUtt → Numeral.Comparison
+/-- The `Core.Scale.Comparison` a Kennedy alternative expresses (all at argument 3). -/
+def KUtt.comparison : KUtt → Core.Scale.Comparison
   | .bare3      => .eq
   | .moreThan3  => .gt
   | .fewerThan3 => .lt
@@ -90,7 +90,7 @@ def KUtt.comparison : KUtt → Numeral.Comparison
   | .atMost3    => .le
 
 /-- Prop-valued meaning of any Kennedy alternative under bilateral
-    (exact) bare semantics — derived from `Numeral.Comparison.meaning bareMeaning`. -/
+    (exact) bare semantics — derived from `Core.Scale.Comparison.meaning bareMeaning`. -/
 def kMean (u : KUtt) (w : KCard) : Prop :=
   u.comparison.meaning bareMeaning 3 w.val
 

--- a/Linglib/Typology/Numeral/Basic.lean
+++ b/Linglib/Typology/Numeral/Basic.lean
@@ -1,63 +1,38 @@
+import Linglib.Core.Scales.Comparison
+
 /-!
-# Numeral — the numeral as a grammatical object
+# Numeral — the lexical numeral object
 
 Theory-neutral lexical core for numerals: the substrate a Fragment instantiates
 and a semantics later interprets. A numeral word contributes a `Comparison`
-(@cite{kennedy-2015}'s `REL`: bare / at-least / more-than / at-most / fewer-than)
-and a numeric `argument`. The *measure* it compares against (cardinality, height,
-cost) is supplied compositionally, so it is not a lexical field here.
+(the relation it draws — bare / at-least / more-than / …) and a numeric
+`argument`. The *measure* it compares against (cardinality, height, cost) is
+supplied compositionally, so it is not a lexical field here.
 
-The denotation — the `relationalGQ`-based meaning and the Kennedy-vs-Horn choice
-for the bare form — lives in `Semantics/Numerals/`, which imports this object.
-This is the same object/denotation split as `Typology/Pronoun/Basic.lean` (the
-`Pronoun.Entry` object) vs. `Semantics/Reference/PronounDenotation.lean` (its
-denotation). The WALS typological survey (`Numeral.Profile`, `fromWALS*`) lives
-in the sibling `Typology/Numeral/WALS.lean`.
+The comparison vocabulary itself is **not** numeral-specific — it is the shared
+degree-comparison primitive `Core.Scale.Comparison` (also used by measure
+phrases and gradable comparatives, per @cite{kennedy-2015}, @cite{rett-2014});
+this file just records that a numeral *entry* carries one. The denotation (the
+`relationalGQ`-based meaning, the Kennedy-vs-Horn bare-form choice) lives in
+`Semantics/Numerals/`, which imports this object — the same object/denotation
+split as `Typology/Pronoun/Basic.lean` vs.
+`Semantics/Reference/PronounDenotation.lean`. The WALS typological survey
+(`Numeral.Profile`, `fromWALS*`) lives in the sibling `Typology/Numeral/WALS.lean`.
 
 ## Main declarations
 
-* `Numeral.Comparison` — the relation a numeral draws between measured and stated
-  magnitude (@cite{kennedy-2015}'s `REL`).
-* `Numeral.Comparison.isStrict` — Class A (`>`, `<`) vs. non-strict (bare `=`,
-  Class B `≥`, `≤`); @cite{geurts-nouwen-2007}, @cite{nouwen-2010}.
 * `Numeral.Entry` — cross-linguistic lexical numeral entry (form, comparison,
   argument).
 -/
 
 namespace Numeral
 
-/-- @cite{kennedy-2015}'s `REL`: the relation a numeral draws between an entity's
-    measured magnitude and the stated magnitude. The five cases underlie the five
-    surface forms. The order relation each names is supplied at interpretation
-    time in `Semantics/Numerals/` (`Comparison.rel`), keeping this object
-    theory-neutral. -/
-inductive Comparison where
-  /-- Bare / exact: `μ x = m`. -/
-  | eq
-  /-- "At least `m`": `μ x ≥ m` (Class B). -/
-  | ge
-  /-- "More than `m`": `μ x > m` (Class A). -/
-  | gt
-  /-- "At most `m`": `μ x ≤ m` (Class B). -/
-  | le
-  /-- "Fewer than `m`": `μ x < m` (Class A). -/
-  | lt
-  deriving DecidableEq, Repr, Inhabited
+open Core.Scale (Comparison)
 
-/-- Strict (Class A: `>`, `<`) vs. non-strict (bare `=`, Class B `≥`, `≤`). The
-    modifier-level Class A/B split of @cite{geurts-nouwen-2007} /
-    @cite{nouwen-2010} is `isStrict` restricted to the four modified forms. -/
-def Comparison.isStrict : Comparison → Prop
-  | .gt | .lt => True
-  | _         => False
-
-instance : DecidablePred Comparison.isStrict := fun c => by
-  cases c <;> unfold Comparison.isStrict <;> infer_instance
-
-/-- Cross-linguistic lexical numeral entry: surface form, the comparison it
+/-- Cross-linguistic lexical numeral entry: surface form, the `Comparison` it
     expresses, and its numeric argument. The measure compared against
-    (cardinality, height, …) is compositional, not lexical, so it is supplied at
-    denotation time rather than stored here. -/
+    (cardinality, height, …) is compositional, supplied at denotation time
+    rather than stored here. -/
 structure Entry where
   /-- Surface form (romanization or orthographic). -/
   form : String

--- a/Linglib/Typology/Numeral/WALS.lean
+++ b/Linglib/Typology/Numeral/WALS.lean
@@ -21,7 +21,7 @@ not encoded as aggregate-count theorems.
 `ClassifierStatus` (WALS Ch 55) and `fromWALS55A` live in
 `Typology/ClassifierSystem.lean` and are re-imported here.
 
-The lexical numeral object (`Numeral.Comparison`, `Numeral.Entry`) that
+The lexical numeral object (`Core.Scale.Comparison`, `Numeral.Entry`) that
 Fragments instantiate, and its denotation, live in the sibling
 `Typology/Numeral/Basic.lean` + `Semantics/Numerals/`. This file is the WALS
 typological survey.

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -31453,3 +31453,42 @@
   subfield  = {syntax/argument-structure},
   role      = {cited}
 }
+
+@article{schwarz-buccola-hamilton-2012,
+  author    = {Schwarz, Bernhard and Buccola, Brian and Hamilton, Michael},
+  year      = {2012},
+  title     = {Two types of class B numeral modifiers: A reply to Nouwen 2010},
+  journal   = {Semantics and Pragmatics},
+  doi       = {10.3765/sp.5.1},
+  volume    = {5},
+  number    = {1},
+  pages     = {1--25},
+  subfield  = {semantics/numerals},
+  role      = {cited},
+  sources   = {Semantics/Numerals/Basic.lean}
+}
+
+@article{cremers-coppock-dotlacil-roelofsen-2022,
+  author    = {Cremers, Alexandre and Coppock, Liz and Dotlačil, Jakub and Roelofsen, Floris},
+  year      = {2022},
+  title     = {Ignorance implicatures of modified numerals},
+  journal   = {Linguistics and Philosophy},
+  doi       = {10.1007/s10988-021-09336-9},
+  volume    = {45},
+  number    = {3},
+  pages     = {683--740},
+  subfield  = {semantics/numerals},
+  role      = {cited},
+  sources   = {Semantics/Numerals/Basic.lean}
+}
+
+@inproceedings{enguehard-2018,
+  author    = {Enguehard, Émile},
+  year      = {2018},
+  title     = {Comparative modified numerals revisited: Scalar implicatures, granularity and blindness to context},
+  booktitle = {Proceedings of Semantics and Linguistic Theory (SALT) 28},
+  pages     = {21--39},
+  subfield  = {semantics/numerals},
+  role      = {cited},
+  sources   = {Semantics/Numerals/Basic.lean}
+}

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -31487,6 +31487,7 @@
   year      = {2018},
   title     = {Comparative modified numerals revisited: Scalar implicatures, granularity and blindness to context},
   booktitle = {Proceedings of Semantics and Linguistic Theory (SALT) 28},
+  doi       = {10.3765/salt.v28i0.4403},
   pages     = {21--39},
   subfield  = {semantics/numerals},
   role      = {cited},


### PR DESCRIPTION
Moves the reified five-way comparison (`eq/ge/gt/le/lt`) out of `Numeral` into `Core.Scale.Comparison`, the shared degree-comparison primitive behind numerals, measure phrases, and gradable comparatives. `Comparison.interval`/`over` bottom out in mathlib's order-interval + preimage API, and `mem_interval`/`mem_over`/`boundary_mem` are `@[simp]` so downstream proofs reduce into `Set.mem_Ici` & friends rather than a bespoke lemma set. `Numeral.Entry` now carries a `Core.Scale.Comparison`.

Also softens the Class A/B docstring (Nouwen 2010's strict/non-strict split is descriptive; the ignorance-implicature correlation is contested per Schwarz–Buccola–Hamilton 2012 and Cremers et al. 2022, granularity-based per Enguehard 2018) and adds those three references.