### PR TITLE
ci: auto-merge non-draft in-repo PRs once build passes

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,18 @@
+name: automerge
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - run: gh pr merge --squash --auto "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Adds a workflow that flags each non-draft, in-repo PR for GitHub native auto-merge (squash). The PR then merges itself once the required `build` check passes. Fork PRs and drafts are excluded. Needs the Actions token at read-write (already set).