### PR TITLE
refactor(Core/Logic): cut RestrictedModality's import inversion into Semantics

### DIFF
--- a/Linglib/Core/Logic/Intensional/RestrictedModality.lean
+++ b/Linglib/Core/Logic/Intensional/RestrictedModality.lean
@@ -1,7 +1,6 @@
 import Linglib.Core.Logic.Intensional.Defs
 import Linglib.Core.Logic.Intensional.Quantification
 import Linglib.Core.Logic.Intensional.Algebra
-import Linglib.Semantics.Modality.ModalTypes
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.Lattice

--- a/Linglib/Semantics/Modality/EventRelativity.lean
+++ b/Linglib/Semantics/Modality/EventRelativity.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Logic.Intensional.RestrictedModality
+import Linglib.Semantics.Modality.ModalTypes
 
 /-!
 # Event-Relative Modality

--- a/Linglib/Semantics/Modality/Kratzer/Flavor.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Flavor.lean
@@ -8,6 +8,7 @@ modal base and ordering source for different types of modality.
 -/
 
 import Linglib.Semantics.Modality.Kratzer.Operators
+import Linglib.Semantics.Modality.ModalTypes
 
 namespace Semantics.Modality.Kratzer
 

--- a/Linglib/Studies/Tsiakmakis2025.lean
+++ b/Linglib/Studies/Tsiakmakis2025.lean
@@ -1,5 +1,6 @@
 import Linglib.Studies.JinKoenig2021
 import Linglib.Semantics.Modality.Kratzer.Operators
+import Linglib.Semantics.Modality.ModalTypes
 import Linglib.Fragments.Greek.StandardModern.Negation
 import Linglib.Fragments.Italian.Negation
 import Mathlib.Data.Fin.Basic


### PR DESCRIPTION
`RestrictedModality` imported `Semantics.Modality.ModalTypes` — a Core→Semantics layering inversion. Its body never used the symbols; the import only served as a transitive re-export. Cut the edge and gave the three files that actually use `ModalFlavor`/`BackgroundClass` (EventRelativity, Kratzer/Flavor, Tsiakmakis2025) a direct `ModalTypes` import. Restores 0 Core/Logic→Semantics violations.