### PR TITLE
feat(Semantics/Dynamic/DRS): model-theoretic DRS core (K&R 1993)

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2064,6 +2064,10 @@ import Linglib.Semantics.Dynamic.UpdateSemantics.Basic
 import Linglib.Semantics.Dynamic.UpdateSemantics.Default
 import Linglib.Semantics.Dynamic.UpdateSemantics.Frames
 import Linglib.Semantics.Dynamic.DPL.Basic
+import Linglib.Semantics.Dynamic.DRS.Defs
+import Linglib.Semantics.Dynamic.DRS.Basic
+import Linglib.Semantics.Dynamic.DRS.Semantics
+import Linglib.Semantics.Dynamic.DRS.Reduction
 import Linglib.Semantics.Dynamic.DRT.Basic
 import Linglib.Semantics.Dynamic.Effects.Bilateral
 import Linglib.Semantics.Dynamic.Bilateral.BUS

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -2,48 +2,48 @@ import Linglib.Semantics.Dynamic.DRS.Defs
 import Mathlib.Data.Finset.Image
 
 /-!
-# DRS structural API: functorial renaming, merge algebra, properness
+# DRS structural API: functorial renaming and merge algebra
 @cite{kamp-reyle-1993}
 
 Structural operations and lemmas over the faithful `DRS` core (`DRS/Defs.lean`):
 
 * `DRS.map` / `Condition.map` — functorial renaming of discourse referents along
-  `f : V → W`. `map_id` makes "rename a referent to itself is the identity" a
-  free corollary, replacing the legacy bespoke `rename` + `rename_self`.
+  `f : V → W`. When `f` is a bijection this is Kamp & Reyle's *alphabetic
+  variant* (Def. 1.4.7); `map_id` makes "renaming to the identity is the
+  identity" a free corollary.
 * `merge` algebra — identity (`empty`) and associativity.
-* `IsProper` — the decidable, top-down "left and up" properness check (every
-  occurring referent is bound at its position), the faithful counterpart of the
-  legacy `allBound`.
 -/
+
+open FirstOrder
 
 namespace DRT
 
-universe u v w
+universe u v w x
 
-variable {R : Type u} {V : Type v} {W : Type w}
+variable {L : Language.{u, v}} {V : Type w} {W : Type x}
 
 /-! ### Functorial renaming -/
 
 mutual
 /-- Rename discourse referents along `f : V → W` throughout a DRS. -/
-def DRS.map [DecidableEq W] (f : V → W) : DRS R V → DRS R W
+def DRS.map [DecidableEq W] (f : V → W) : DRS L V → DRS L W
   | .mk refs conds => .mk (refs.image f) (Condition.mapList f conds)
 /-- Rename discourse referents along `f` throughout a condition. -/
-def Condition.map [DecidableEq W] (f : V → W) : Condition R V → Condition R W
-  | .rel r args => .rel r (args.map f)
+def Condition.map [DecidableEq W] (f : V → W) : Condition L V → Condition L W
+  | .rel R args => .rel R (fun i => f (args i))
   | .eq a b => .eq (f a) (f b)
   | .neg K => .neg (DRS.map f K)
   | .imp a c => .imp (DRS.map f a) (DRS.map f c)
   | .dis l r => .dis (DRS.map f l) (DRS.map f r)
 /-- Rename along `f` throughout a list of conditions (mutual helper). -/
-def Condition.mapList [DecidableEq W] (f : V → W) : List (Condition R V) → List (Condition R W)
+def Condition.mapList [DecidableEq W] (f : V → W) : List (Condition L V) → List (Condition L W)
   | [] => []
   | c :: cs => Condition.map f c :: Condition.mapList f cs
 end
 
 mutual
 /-- Renaming along the identity is the identity. -/
-@[simp] theorem DRS.map_id [DecidableEq V] (K : DRS R V) : DRS.map id K = K := by
+@[simp] theorem DRS.map_id [DecidableEq V] (K : DRS L V) : DRS.map id K = K := by
   match K with
   | .mk refs conds =>
       simp only [DRS.map, Condition.mapList_id]
@@ -51,15 +51,15 @@ mutual
       ext x
       simp
 /-- Renaming a condition along the identity is the identity. -/
-@[simp] theorem Condition.map_id [DecidableEq V] (c : Condition R V) :
+@[simp] theorem Condition.map_id [DecidableEq V] (c : Condition L V) :
     Condition.map id c = c := by
   match c with
-  | .rel r args => simp only [Condition.map, List.map_id]
-  | .eq a b => rfl
+  | .rel R args => simp only [Condition.map, id_eq]
+  | .eq a b => simp only [Condition.map, id_eq]
   | .neg K => simp only [Condition.map, DRS.map_id K]
   | .imp a c => simp only [Condition.map, DRS.map_id a, DRS.map_id c]
   | .dis l r => simp only [Condition.map, DRS.map_id l, DRS.map_id r]
-theorem Condition.mapList_id [DecidableEq V] (cs : List (Condition R V)) :
+theorem Condition.mapList_id [DecidableEq V] (cs : List (Condition L V)) :
     Condition.mapList id cs = cs := by
   match cs with
   | [] => rfl
@@ -72,15 +72,15 @@ namespace DRS
 
 variable [DecidableEq V]
 
-@[simp] theorem empty_merge (K : DRS R V) : (empty : DRS R V).merge K = K := by
+@[simp] theorem empty_merge (K : DRS L V) : (empty : DRS L V).merge K = K := by
   cases K with
   | mk r c => simp [merge, empty]
 
-@[simp] theorem merge_empty (K : DRS R V) : K.merge (empty : DRS R V) = K := by
+@[simp] theorem merge_empty (K : DRS L V) : K.merge (empty : DRS L V) = K := by
   cases K with
   | mk r c => simp [merge, empty]
 
-theorem merge_assoc (K₁ K₂ K₃ : DRS R V) :
+theorem merge_assoc (K₁ K₂ K₃ : DRS L V) :
     (K₁.merge K₂).merge K₃ = K₁.merge (K₂.merge K₃) := by
   cases K₁; cases K₂; cases K₃
   simp only [merge, referents_mk, conditions_mk]

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -1,0 +1,91 @@
+import Linglib.Semantics.Dynamic.DRS.Defs
+import Mathlib.Data.Finset.Image
+
+/-!
+# DRS structural API: functorial renaming, merge algebra, properness
+@cite{kamp-reyle-1993}
+
+Structural operations and lemmas over the faithful `DRS` core (`DRS/Defs.lean`):
+
+* `DRS.map` / `Condition.map` — functorial renaming of discourse referents along
+  `f : V → W`. `map_id` makes "rename a referent to itself is the identity" a
+  free corollary, replacing the legacy bespoke `rename` + `rename_self`.
+* `merge` algebra — identity (`empty`) and associativity.
+* `IsProper` — the decidable, top-down "left and up" properness check (every
+  occurring referent is bound at its position), the faithful counterpart of the
+  legacy `allBound`.
+-/
+
+namespace DRT
+
+universe u v w
+
+variable {R : Type u} {V : Type v} {W : Type w}
+
+/-! ### Functorial renaming -/
+
+mutual
+/-- Rename discourse referents along `f : V → W` throughout a DRS. -/
+def DRS.map [DecidableEq W] (f : V → W) : DRS R V → DRS R W
+  | .mk refs conds => .mk (refs.image f) (Condition.mapList f conds)
+/-- Rename discourse referents along `f` throughout a condition. -/
+def Condition.map [DecidableEq W] (f : V → W) : Condition R V → Condition R W
+  | .rel r args => .rel r (args.map f)
+  | .eq a b => .eq (f a) (f b)
+  | .neg K => .neg (DRS.map f K)
+  | .imp a c => .imp (DRS.map f a) (DRS.map f c)
+  | .dis l r => .dis (DRS.map f l) (DRS.map f r)
+/-- Rename along `f` throughout a list of conditions (mutual helper). -/
+def Condition.mapList [DecidableEq W] (f : V → W) : List (Condition R V) → List (Condition R W)
+  | [] => []
+  | c :: cs => Condition.map f c :: Condition.mapList f cs
+end
+
+mutual
+/-- Renaming along the identity is the identity. -/
+@[simp] theorem DRS.map_id [DecidableEq V] (K : DRS R V) : DRS.map id K = K := by
+  match K with
+  | .mk refs conds =>
+      simp only [DRS.map, Condition.mapList_id]
+      congr 1
+      ext x
+      simp
+/-- Renaming a condition along the identity is the identity. -/
+@[simp] theorem Condition.map_id [DecidableEq V] (c : Condition R V) :
+    Condition.map id c = c := by
+  match c with
+  | .rel r args => simp only [Condition.map, List.map_id]
+  | .eq a b => rfl
+  | .neg K => simp only [Condition.map, DRS.map_id K]
+  | .imp a c => simp only [Condition.map, DRS.map_id a, DRS.map_id c]
+  | .dis l r => simp only [Condition.map, DRS.map_id l, DRS.map_id r]
+theorem Condition.mapList_id [DecidableEq V] (cs : List (Condition R V)) :
+    Condition.mapList id cs = cs := by
+  match cs with
+  | [] => rfl
+  | c :: cs => simp only [Condition.mapList, Condition.map_id c, Condition.mapList_id cs]
+end
+
+/-! ### Merge algebra -/
+
+namespace DRS
+
+variable [DecidableEq V]
+
+@[simp] theorem empty_merge (K : DRS R V) : (empty : DRS R V).merge K = K := by
+  cases K with
+  | mk r c => simp [merge, empty]
+
+@[simp] theorem merge_empty (K : DRS R V) : K.merge (empty : DRS R V) = K := by
+  cases K with
+  | mk r c => simp [merge, empty]
+
+theorem merge_assoc (K₁ K₂ K₃ : DRS R V) :
+    (K₁.merge K₂).merge K₃ = K₁.merge (K₂.merge K₃) := by
+  cases K₁; cases K₂; cases K₃
+  simp only [merge, referents_mk, conditions_mk]
+  rw [Finset.union_assoc, List.append_assoc]
+
+end DRS
+
+end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -35,7 +35,9 @@ def Condition.map [DecidableEq W] (f : V → W) : Condition L V → Condition L 
   | .neg K => .neg (DRS.map f K)
   | .imp a c => .imp (DRS.map f a) (DRS.map f c)
   | .dis l r => .dis (DRS.map f l) (DRS.map f r)
-/-- Rename along `f` throughout a list of conditions (mutual helper). -/
+/-- Rename along `f` throughout a list of conditions. A `List` helper (not
+`conds.map (Condition.map f)`) because the higher-order form fails the
+nested-inductive structural-recursion checker. -/
 def Condition.mapList [DecidableEq W] (f : V → W) : List (Condition L V) → List (Condition L W)
   | [] => []
   | c :: cs => Condition.map f c :: Condition.mapList f cs
@@ -106,7 +108,9 @@ def Condition.Bound (b : Finset V) : Condition L V → Prop
   | .neg K => DRS.Bound b K
   | .imp a c => DRS.Bound b a ∧ DRS.Bound (b ∪ a.referents) c
   | .dis l r => DRS.Bound b l ∧ DRS.Bound b r
-/-- `b`-boundedness of a list of conditions (mutual helper). -/
+/-- `b`-boundedness of a list of conditions. A `List` helper (not
+`List.Forall (Condition.Bound b)`) — the higher-order form fails the
+nested-inductive structural-recursion checker. -/
 def Condition.BoundAll (b : Finset V) : List (Condition L V) → Prop
   | [] => True
   | c :: cs => Condition.Bound b c ∧ Condition.BoundAll b cs

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -88,4 +88,35 @@ theorem merge_assoc (K₁ K₂ K₃ : DRS L V) :
 
 end DRS
 
+/-! ### Properness (no free discourse referent) -/
+
+section Proper
+variable [DecidableEq V]
+
+mutual
+/-- `Bound b K`: every discourse referent occurring in `K` is bound — present in
+`b` or introduced by `K`'s universe or by an ancestor reachable "left and up"
+(the antecedent of a `⇒` threads its referents into the consequent). -/
+def DRS.Bound (b : Finset V) : DRS L V → Prop
+  | .mk U conds => Condition.BoundAll (b ∪ U) conds
+/-- `b`-boundedness of a condition. -/
+def Condition.Bound (b : Finset V) : Condition L V → Prop
+  | .rel _ args => ∀ i, args i ∈ b
+  | .eq u v => u ∈ b ∧ v ∈ b
+  | .neg K => DRS.Bound b K
+  | .imp a c => DRS.Bound b a ∧ DRS.Bound (b ∪ a.referents) c
+  | .dis l r => DRS.Bound b l ∧ DRS.Bound b r
+/-- `b`-boundedness of a list of conditions (mutual helper). -/
+def Condition.BoundAll (b : Finset V) : List (Condition L V) → Prop
+  | [] => True
+  | c :: cs => Condition.Bound b c ∧ Condition.BoundAll b cs
+end
+
+/-- A DRS is *proper* iff it has no free discourse referent
+(@cite{kamp-reyle-1993}, Def. 1.4.2–1.4.3): every occurring referent is bound at
+its position. -/
+def DRS.IsProper (K : DRS L V) : Prop := DRS.Bound ∅ K
+
+end Proper
+
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -1,135 +1,137 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Logic.Relation
+import Mathlib.ModelTheory.Basic
 
 /-!
-# Discourse Representation Structures (faithful core)
+# Discourse Representation Structures (faithful, model-theoretic core)
 @cite{kamp-reyle-1993}
 
-A faithful Lean model of the canonical DRS data type. Following Kamp & Reyle, a
-DRS is a pair `⟨referents, conditions⟩`: `referents` is the *universe* `U` — a
-finite set of discourse referents — and `conditions` a collection of
-DRS-conditions. Conditions are **atomic** (`rel`, `eq`) or **complex** (`neg`,
-`imp`, `dis`), and — crucially — sub-DRSs occur *only* inside complex conditions.
-Merge is an *operation*, not a constructor, and accessibility is the declarative
-"left and up" relation.
+A faithful Lean model of the canonical DRS data type, built on mathlib's
+`FirstOrder.Language` so its semantics can be given model-theoretically (via
+`FirstOrder.Language.Structure` / `Realize`), exactly as Kamp & Reyle define it
+(verifying embeddings into a model, Def. 1.4.4–1.4.5).
 
-This replaces the legacy flat encoding (`Boxes/Syntax.lean`), in which atoms were
-themselves DRSs, `box`/`seq` were constructors, and accessibility was a
-first-match `List` walk.
+A DRS is a pair `⟨referents, conditions⟩` (Def. 1.4.1): `referents` is the
+*universe* `U` — a finite set of discourse referents — and `conditions` a
+collection of DRS-conditions. Conditions are **atomic** (`rel`, `eq`) or
+**complex** (`neg`, `imp`, `dis`); sub-DRSs occur *only* inside complex
+conditions. Relation symbols come arity-indexed from a `FirstOrder.Language`.
 
 ## Main declarations
 
-* `DRS R V`, `Condition R V` — the mutual data type (drefs `V`, relations `R`).
+* `DRS L V`, `Condition L V` — the mutual data type over a language `L` (relation
+  signature) and discourse-referent type `V`.
 * `DRS.merge` — the `⊕` operation (set-union referents, concatenate conditions).
-* `DirectlySubordinate`, `Subordinate`, `WeakSubordinate` — the one-step
-  subordination relation and its `Relation.TransGen` / `ReflTransGen` closures.
-* `Accessible` — a dref is accessible at a sub-DRS iff it lies in the referents of
-  some weakly-superordinate DRS.
+* `DirectlySubordinate`, `Subordinate`, `WeakSubordinate` — immediate
+  subordination (Def. 1.4.10(i), extended to `⇒`/`∨` in Ch. 2) and its
+  `Relation.TransGen` / `ReflTransGen` closures (Def. 1.4.10(ii)).
+* `Accessible` — Def. 1.4.11: a referent is accessible at a sub-DRS iff it lies in
+  the universe of some weakly-superordinate DRS.
 
 ## Implementation notes
 
 * `referents` is the textbook "universe `U`"; named for its contents because
-  `universe` is a Lean keyword and `univ` collides with `Finset.univ` (the
-  complete set of a `Fintype` — the opposite of a DRS universe, which is a finite
-  *subset* of an arbitrary referent type, needing no `Fintype`).
+  `universe` is a Lean keyword and `univ` collides with `Finset.univ`.
 * The recursive `conditions` field is a `List`: Lean forbids nesting an inductive
-  through `Finset`/`Multiset`. Set semantics (order and duplication irrelevance)
-  are the responsibility of the interpretation, not the syntax.
-* The namespace is transitional `DRT` while the legacy `_root_.DRS`
-  (`Boxes/Syntax.lean`) is migrated out; it promotes to the root namespace once
-  the legacy type is retired.
+  through `Finset`/`Multiset`. Set semantics are imposed by the interpretation.
+* The namespace is transitional `DRT` while the legacy `_root_.DRS` is migrated
+  out; it promotes to the root namespace once the legacy type is retired.
 -/
+
+open FirstOrder
 
 namespace DRT
 
-universe u v
+universe u v w
 
 mutual
 /-- A discourse representation structure: the pair `⟨referents, conditions⟩`
-(@cite{kamp-reyle-1993}). `referents` is the universe `U` (a finite set of
-discourse referents); `conditions` the DRS-conditions. -/
-inductive DRS (R : Type u) (V : Type v) where
-  | mk (referents : Finset V) (conditions : List (Condition R V))
-/-- A DRS-condition: atomic (`rel`, `eq`) or complex (`neg`, `imp`, `dis`).
-Sub-DRSs occur only inside complex conditions. -/
-inductive Condition (R : Type u) (V : Type v) where
-  /-- Atomic condition: relation symbol `r` applied to `args`. -/
-  | rel (r : R) (args : List V)
+(@cite{kamp-reyle-1993}, Def. 1.4.1). `referents` is the universe `U` (a finite
+set of discourse referents); `conditions` the DRS-conditions. -/
+inductive DRS (L : Language.{u, v}) (V : Type w) where
+  | mk (referents : Finset V) (conditions : List (Condition L V))
+/-- A DRS-condition (@cite{kamp-reyle-1993}, Def. 1.4.1): atomic (`rel`, `eq`) or
+complex (`neg`, `imp`, `dis`). Sub-DRSs occur only inside complex conditions. -/
+inductive Condition (L : Language.{u, v}) (V : Type w) where
+  /-- Atomic condition: `n`-ary relation symbol `R` applied to referents `args`. -/
+  | rel {n : ℕ} (R : L.Relations n) (args : Fin n → V)
   /-- Atomic equality condition `u = v`. -/
   | eq (u v : V)
   /-- Complex condition `¬K`. -/
-  | neg (K : DRS R V)
+  | neg (K : DRS L V)
   /-- Complex condition `K₁ ⇒ K₂` (antecedent ⇒ consequent). -/
-  | imp (ante cons : DRS R V)
+  | imp (ante cons : DRS L V)
   /-- Complex condition `K₁ ∨ K₂`. -/
-  | dis (left right : DRS R V)
+  | dis (left right : DRS L V)
 end
 
 namespace DRS
 
-variable {R : Type u} {V : Type v}
+variable {L : Language.{u, v}} {V : Type w}
 
 /-- The referents (universe `U`) of a DRS — the discourse referents it introduces. -/
-def referents : DRS R V → Finset V
+def referents : DRS L V → Finset V
   | .mk u _ => u
 
 /-- The conditions of a DRS. -/
-def conditions : DRS R V → List (Condition R V)
+def conditions : DRS L V → List (Condition L V)
   | .mk _ c => c
 
-@[simp] theorem referents_mk (u : Finset V) (c : List (Condition R V)) :
+@[simp] theorem referents_mk (u : Finset V) (c : List (Condition L V)) :
     (DRS.mk u c).referents = u := rfl
 
-@[simp] theorem conditions_mk (u : Finset V) (c : List (Condition R V)) :
+@[simp] theorem conditions_mk (u : Finset V) (c : List (Condition L V)) :
     (DRS.mk u c).conditions = c := rfl
 
 /-- The empty DRS `⟨∅, []⟩`. -/
-def empty : DRS R V := .mk ∅ []
+def empty : DRS L V := .mk ∅ []
 
 /-- Merge (Kamp & Reyle's `⊕`): set-union the referents, concatenate the
 conditions. An *operation*, not a syntactic constructor. -/
-def merge [DecidableEq V] (K₁ K₂ : DRS R V) : DRS R V :=
+def merge [DecidableEq V] (K₁ K₂ : DRS L V) : DRS L V :=
   .mk (K₁.referents ∪ K₂.referents) (K₁.conditions ++ K₂.conditions)
 
-@[simp] theorem merge_referents [DecidableEq V] (K₁ K₂ : DRS R V) :
+@[simp] theorem merge_referents [DecidableEq V] (K₁ K₂ : DRS L V) :
     (K₁.merge K₂).referents = K₁.referents ∪ K₂.referents := rfl
 
-@[simp] theorem merge_conditions [DecidableEq V] (K₁ K₂ : DRS R V) :
+@[simp] theorem merge_conditions [DecidableEq V] (K₁ K₂ : DRS L V) :
     (K₁.merge K₂).conditions = K₁.conditions ++ K₂.conditions := rfl
 
 end DRS
 
 /-! ### Subordination and accessibility -/
 
-/-- One-step subordination ("`K'` is *directly subordinate* to `K`"), with
-exactly the canonical edges (@cite{kamp-reyle-1993}, Def. 2.1.2):
+/-- One-step subordination ("`K'` is *directly subordinate* to `K`"). The `neg`
+case is @cite{kamp-reyle-1993} Def. 1.4.10(i); the `⇒`/`∨` cases are its Chapter 2
+extension:
 
 * the body of a `¬` is subordinate to the containing DRS;
 * the antecedent of a `⇒` is subordinate to the containing DRS;
 * the consequent of a `⇒` is subordinate to its *antecedent* (the ⇒ asymmetry:
-  antecedent drefs are accessible in the consequent, not conversely);
+  antecedent referents are accessible in the consequent, not conversely);
 * each disjunct of a `∨` is subordinate to the containing DRS. -/
-inductive DirectlySubordinate {R : Type u} {V : Type v} : DRS R V → DRS R V → Prop where
-  | neg {D K : DRS R V} : Condition.neg K ∈ D.conditions → DirectlySubordinate K D
-  | impAnte {D a c : DRS R V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate a D
-  | impCons {D a c : DRS R V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate c a
-  | disL {D l r : DRS R V} : Condition.dis l r ∈ D.conditions → DirectlySubordinate l D
-  | disR {D l r : DRS R V} : Condition.dis l r ∈ D.conditions → DirectlySubordinate r D
+inductive DirectlySubordinate {L : Language.{u, v}} {V : Type w} :
+    DRS L V → DRS L V → Prop where
+  | neg {D K : DRS L V} : Condition.neg K ∈ D.conditions → DirectlySubordinate K D
+  | impAnte {D a c : DRS L V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate a D
+  | impCons {D a c : DRS L V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate c a
+  | disL {D l r : DRS L V} : Condition.dis l r ∈ D.conditions → DirectlySubordinate l D
+  | disR {D l r : DRS L V} : Condition.dis l r ∈ D.conditions → DirectlySubordinate r D
 
-/-- `K₁ < K₂`: `K₁` is subordinate to `K₂` — the transitive closure of
-`DirectlySubordinate`. -/
-abbrev Subordinate {R : Type u} {V : Type v} : DRS R V → DRS R V → Prop :=
+/-- `K₁ < K₂`: subordinate — transitive closure of `DirectlySubordinate`
+(@cite{kamp-reyle-1993}, Def. 1.4.10(ii)). -/
+abbrev Subordinate {L : Language.{u, v}} {V : Type w} : DRS L V → DRS L V → Prop :=
   Relation.TransGen DirectlySubordinate
 
-/-- `K₁ ≤ K₂`: `K₁` is weakly subordinate to `K₂` — the reflexive-transitive
-closure of `DirectlySubordinate`. -/
-abbrev WeakSubordinate {R : Type u} {V : Type v} : DRS R V → DRS R V → Prop :=
+/-- `K₁ ≤ K₂`: weakly subordinate — reflexive-transitive closure
+(@cite{kamp-reyle-1993}; the `≤` of Def. 1.4.10). -/
+abbrev WeakSubordinate {L : Language.{u, v}} {V : Type w} : DRS L V → DRS L V → Prop :=
   Relation.ReflTransGen DirectlySubordinate
 
 /-- A discourse referent `u` is *accessible* at a sub-DRS `K` iff it lies in the
 referents of `K` itself or of some DRS weakly-superordinate to `K` — the "left
-and up" geometry. -/
-def Accessible {R : Type u} {V : Type v} (u : V) (K : DRS R V) : Prop :=
+and up" geometry (@cite{kamp-reyle-1993}, Def. 1.4.11). -/
+def Accessible {L : Language.{u, v}} {V : Type w} (u : V) (K : DRS L V) : Prop :=
   ∃ D, WeakSubordinate K D ∧ u ∈ D.referents
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -86,8 +86,10 @@ def conditions : DRS L V → List (Condition L V)
 /-- The empty DRS `⟨∅, []⟩`. -/
 def empty : DRS L V := .mk ∅ []
 
-/-- Merge (Kamp & Reyle's `⊕`): set-union the referents, concatenate the
-conditions. An *operation*, not a syntactic constructor. -/
+/-- Merge `⊕`: set-union the referents, concatenate the conditions. The binary
+DRS merge is @cite{muskens-1996}'s compositional operation — Kamp & Reyle
+themselves combine DRSs incrementally via the construction algorithm, not a
+symmetric binary `⊕`. An operation, not a syntactic constructor. -/
 def merge [DecidableEq V] (K₁ K₂ : DRS L V) : DRS L V :=
   .mk (K₁.referents ∪ K₂.referents) (K₁.conditions ++ K₂.conditions)
 

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -1,0 +1,135 @@
+import Mathlib.Data.Finset.Basic
+import Mathlib.Logic.Relation
+
+/-!
+# Discourse Representation Structures (faithful core)
+@cite{kamp-reyle-1993}
+
+A faithful Lean model of the canonical DRS data type. Following Kamp & Reyle, a
+DRS is a pair `⟨referents, conditions⟩`: `referents` is the *universe* `U` — a
+finite set of discourse referents — and `conditions` a collection of
+DRS-conditions. Conditions are **atomic** (`rel`, `eq`) or **complex** (`neg`,
+`imp`, `dis`), and — crucially — sub-DRSs occur *only* inside complex conditions.
+Merge is an *operation*, not a constructor, and accessibility is the declarative
+"left and up" relation.
+
+This replaces the legacy flat encoding (`Boxes/Syntax.lean`), in which atoms were
+themselves DRSs, `box`/`seq` were constructors, and accessibility was a
+first-match `List` walk.
+
+## Main declarations
+
+* `DRS R V`, `Condition R V` — the mutual data type (drefs `V`, relations `R`).
+* `DRS.merge` — the `⊕` operation (set-union referents, concatenate conditions).
+* `DirectlySubordinate`, `Subordinate`, `WeakSubordinate` — the one-step
+  subordination relation and its `Relation.TransGen` / `ReflTransGen` closures.
+* `Accessible` — a dref is accessible at a sub-DRS iff it lies in the referents of
+  some weakly-superordinate DRS.
+
+## Implementation notes
+
+* `referents` is the textbook "universe `U`"; named for its contents because
+  `universe` is a Lean keyword and `univ` collides with `Finset.univ` (the
+  complete set of a `Fintype` — the opposite of a DRS universe, which is a finite
+  *subset* of an arbitrary referent type, needing no `Fintype`).
+* The recursive `conditions` field is a `List`: Lean forbids nesting an inductive
+  through `Finset`/`Multiset`. Set semantics (order and duplication irrelevance)
+  are the responsibility of the interpretation, not the syntax.
+* The namespace is transitional `DRT` while the legacy `_root_.DRS`
+  (`Boxes/Syntax.lean`) is migrated out; it promotes to the root namespace once
+  the legacy type is retired.
+-/
+
+namespace DRT
+
+universe u v
+
+mutual
+/-- A discourse representation structure: the pair `⟨referents, conditions⟩`
+(@cite{kamp-reyle-1993}). `referents` is the universe `U` (a finite set of
+discourse referents); `conditions` the DRS-conditions. -/
+inductive DRS (R : Type u) (V : Type v) where
+  | mk (referents : Finset V) (conditions : List (Condition R V))
+/-- A DRS-condition: atomic (`rel`, `eq`) or complex (`neg`, `imp`, `dis`).
+Sub-DRSs occur only inside complex conditions. -/
+inductive Condition (R : Type u) (V : Type v) where
+  /-- Atomic condition: relation symbol `r` applied to `args`. -/
+  | rel (r : R) (args : List V)
+  /-- Atomic equality condition `u = v`. -/
+  | eq (u v : V)
+  /-- Complex condition `¬K`. -/
+  | neg (K : DRS R V)
+  /-- Complex condition `K₁ ⇒ K₂` (antecedent ⇒ consequent). -/
+  | imp (ante cons : DRS R V)
+  /-- Complex condition `K₁ ∨ K₂`. -/
+  | dis (left right : DRS R V)
+end
+
+namespace DRS
+
+variable {R : Type u} {V : Type v}
+
+/-- The referents (universe `U`) of a DRS — the discourse referents it introduces. -/
+def referents : DRS R V → Finset V
+  | .mk u _ => u
+
+/-- The conditions of a DRS. -/
+def conditions : DRS R V → List (Condition R V)
+  | .mk _ c => c
+
+@[simp] theorem referents_mk (u : Finset V) (c : List (Condition R V)) :
+    (DRS.mk u c).referents = u := rfl
+
+@[simp] theorem conditions_mk (u : Finset V) (c : List (Condition R V)) :
+    (DRS.mk u c).conditions = c := rfl
+
+/-- The empty DRS `⟨∅, []⟩`. -/
+def empty : DRS R V := .mk ∅ []
+
+/-- Merge (Kamp & Reyle's `⊕`): set-union the referents, concatenate the
+conditions. An *operation*, not a syntactic constructor. -/
+def merge [DecidableEq V] (K₁ K₂ : DRS R V) : DRS R V :=
+  .mk (K₁.referents ∪ K₂.referents) (K₁.conditions ++ K₂.conditions)
+
+@[simp] theorem merge_referents [DecidableEq V] (K₁ K₂ : DRS R V) :
+    (K₁.merge K₂).referents = K₁.referents ∪ K₂.referents := rfl
+
+@[simp] theorem merge_conditions [DecidableEq V] (K₁ K₂ : DRS R V) :
+    (K₁.merge K₂).conditions = K₁.conditions ++ K₂.conditions := rfl
+
+end DRS
+
+/-! ### Subordination and accessibility -/
+
+/-- One-step subordination ("`K'` is *directly subordinate* to `K`"), with
+exactly the canonical edges (@cite{kamp-reyle-1993}, Def. 2.1.2):
+
+* the body of a `¬` is subordinate to the containing DRS;
+* the antecedent of a `⇒` is subordinate to the containing DRS;
+* the consequent of a `⇒` is subordinate to its *antecedent* (the ⇒ asymmetry:
+  antecedent drefs are accessible in the consequent, not conversely);
+* each disjunct of a `∨` is subordinate to the containing DRS. -/
+inductive DirectlySubordinate {R : Type u} {V : Type v} : DRS R V → DRS R V → Prop where
+  | neg {D K : DRS R V} : Condition.neg K ∈ D.conditions → DirectlySubordinate K D
+  | impAnte {D a c : DRS R V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate a D
+  | impCons {D a c : DRS R V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate c a
+  | disL {D l r : DRS R V} : Condition.dis l r ∈ D.conditions → DirectlySubordinate l D
+  | disR {D l r : DRS R V} : Condition.dis l r ∈ D.conditions → DirectlySubordinate r D
+
+/-- `K₁ < K₂`: `K₁` is subordinate to `K₂` — the transitive closure of
+`DirectlySubordinate`. -/
+abbrev Subordinate {R : Type u} {V : Type v} : DRS R V → DRS R V → Prop :=
+  Relation.TransGen DirectlySubordinate
+
+/-- `K₁ ≤ K₂`: `K₁` is weakly subordinate to `K₂` — the reflexive-transitive
+closure of `DirectlySubordinate`. -/
+abbrev WeakSubordinate {R : Type u} {V : Type v} : DRS R V → DRS R V → Prop :=
+  Relation.ReflTransGen DirectlySubordinate
+
+/-- A discourse referent `u` is *accessible* at a sub-DRS `K` iff it lies in the
+referents of `K` itself or of some DRS weakly-superordinate to `K` — the "left
+and up" geometry. -/
+def Accessible {R : Type u} {V : Type v} (u : V) (K : DRS R V) : Prop :=
+  ∃ D, WeakSubordinate K D ∧ u ∈ D.referents
+
+end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -1,0 +1,83 @@
+import Linglib.Semantics.Dynamic.DRS.Semantics
+import Mathlib.ModelTheory.Syntax
+
+/-!
+# From DRT to predicate logic: the DRS → first-order reduction
+@cite{kamp-reyle-1993} (§1.5), @cite{muskens-1996}
+
+The "surprise" theorem of the whole development: the bespoke DRS box language is
+*equivalent to ordinary first-order logic*. We translate each DRS into a mathlib
+`FirstOrder.Language.Formula` and prove its `Realize` coincides with the bespoke
+`DRS.Realize` — Kamp & Reyle's §1.5 ("From DRT to Predicate Logic") and Muskens's
+"DRSs are already present in classical logic", now a Lean theorem rather than an
+assertion.
+
+The universe of a (sub-)DRS is *existentially closed* (`closeExists`, via
+mathlib's `Formula.iExs`); the antecedent of a `⇒` is *universally closed*
+(`closeForall`, via `Formula.iAlls`).
+
+## Main declarations
+
+* `DRS.toFormula` / `Condition.toFormula` — the translation into `L.Formula V`.
+* `DRS.realize_toFormula` — the agreement theorem (currently `sorry`; see TODO).
+-/
+
+open FirstOrder FirstOrder.Language
+
+namespace DRT
+
+universe u v w x
+
+variable {L : Language.{u, v}} {V : Type w}
+
+/-- Existentially close the referents in `U` within a formula over free
+referents `V` (relabel `U`-referents to the bound side, then `Formula.iExs`). -/
+noncomputable def closeExists [DecidableEq V] (U : Finset V) (φ : L.Formula V) : L.Formula V :=
+  (φ.relabel (fun x => if h : x ∈ U then Sum.inr ⟨x, h⟩ else Sum.inl x)).iExs {x // x ∈ U}
+
+/-- Universally close the referents in `U` (used for the antecedent of `⇒`). -/
+noncomputable def closeForall [DecidableEq V] (U : Finset V) (φ : L.Formula V) : L.Formula V :=
+  (φ.relabel (fun x => if h : x ∈ U then Sum.inr ⟨x, h⟩ else Sum.inl x)).iAlls {x // x ∈ U}
+
+mutual
+/-- Translate a DRS to a first-order formula: existentially close the universe
+over the conjunction of the (translated) conditions (@cite{kamp-reyle-1993} §1.5). -/
+noncomputable def DRS.toFormula [DecidableEq V] : DRS L V → L.Formula V
+  | .mk U conds => closeExists U (Condition.toFormulaAll conds)
+/-- The conjunction of a DRS's conditions, *without* closing its universe (used
+as the antecedent body of a `⇒`). -/
+noncomputable def DRS.bodyFormula [DecidableEq V] : DRS L V → L.Formula V
+  | .mk _ conds => Condition.toFormulaAll conds
+/-- Translate a single DRS-condition to a formula. -/
+noncomputable def Condition.toFormula [DecidableEq V] : Condition L V → L.Formula V
+  | .rel R args => Relations.formula R (fun i => Term.var (args i))
+  | .eq a b => Term.equal (Term.var a) (Term.var b)
+  | .neg K => (DRS.toFormula K).not
+  | .imp a c => closeForall a.referents ((DRS.bodyFormula a).imp (DRS.toFormula c))
+  | .dis l r => DRS.toFormula l ⊔ DRS.toFormula r
+/-- The conjunction of a list of (translated) conditions. -/
+noncomputable def Condition.toFormulaAll [DecidableEq V] : List (Condition L V) → L.Formula V
+  | [] => ⊤
+  | c :: cs => Condition.toFormula c ⊓ Condition.toFormulaAll cs
+end
+
+variable {M : Type x} [L.Structure M]
+
+/-- **DRT ⊆ FOL** (@cite{kamp-reyle-1993} §1.5; @cite{muskens-1996}): the
+translated formula's `Realize` coincides with the bespoke `DRS.Realize`. Because
+`toFormula` existentially closes the universe, the correspondence is with an
+embedding `v'` extending `v` over `K.referents`.
+
+TODO: mutual induction on `DRS`/`Condition`. Key lemmas:
+`Formula.realize_iExs`/`realize_iAlls` turn `closeExists`/`closeForall` into the
+`∃`/`∀` over an assignment to the universe-subtype `{x // x ∈ U}`;
+`Formula.realize_relabel` turns the split relabel into the agreement condition
+`∀ x ∉ U, v' x = v x` (the `∃ i : {x // x ∈ U} → M` of `realize_iExs` corresponds
+to `v' := fun x => if h : x ∈ U then i ⟨x, h⟩ else v x`); then `realize_rel`,
+`realize_inf`, `realize_sup`, `realize_not`, `realize_imp` discharge the
+condition cases against the matching clauses of `DRS.Realize`. -/
+theorem DRS.realize_toFormula [DecidableEq V] (K : DRS L V) (v : V → M) :
+    (K.toFormula).Realize v ↔ ∃ v', (∀ x, x ∉ K.referents → v' x = v x) ∧ K.Realize v' := by
+  sorry
+
+end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -7,11 +7,10 @@ import Mathlib.ModelTheory.Syntax
 
 The "surprise" theorem of the whole development: the bespoke DRS box language is
 *equivalent to ordinary first-order logic*. We translate each DRS into a mathlib
-`FirstOrder.Language.Formula` and state that its `Realize` coincides with the
-bespoke `DRS.Realize` — Kamp & Reyle's §1.5 ("From DRT to Predicate Logic") and
-Muskens's "DRSs are already present in classical logic". The translation is
-defined; the agreement theorem `DRS.realize_toFormula` is stated, with its proof
-in progress (`sorry`).
+`FirstOrder.Language.Formula` and prove its `Realize` coincides with the bespoke
+`DRS.Realize` — Kamp & Reyle's §1.5 ("From DRT to Predicate Logic") and Muskens's
+"DRSs are already present in classical logic", now a Lean theorem
+(`DRS.realize_toFormula`) rather than an assertion.
 
 The universe of a (sub-)DRS is *existentially closed* (`closeExists`, via
 mathlib's `Formula.iExs`); the antecedent of a `⇒` is *universally closed*
@@ -20,7 +19,10 @@ mathlib's `Formula.iExs`); the antecedent of a `⇒` is *universally closed*
 ## Main declarations
 
 * `DRS.toFormula` / `Condition.toFormula` — the translation into `L.Formula V`.
-* `DRS.realize_toFormula` — the agreement theorem (currently `sorry`; see TODO).
+* `DRS.realize_toFormula` — the agreement theorem: a DRS's bespoke truth matches
+  its first-order translation's `Realize`.
+* `realize_closeExists` / `realize_closeForall` — the universe-closure operators
+  realize as `∃`/`∀` over embeddings extending `v` on the closed referents.
 -/
 
 open FirstOrder FirstOrder.Language
@@ -31,15 +33,20 @@ universe u v w x
 
 variable {L : Language.{u, v}} {V : Type w}
 
+/-- Relabel the free referents `V` so that those in `U` move to the bound side
+`{x // x ∈ U}` (and the rest stay free) — the splitting `iExs`/`iAlls` quantify
+over. `DecidableEq V` is needed only for the `x ∈ U` test, not by `iExs`/`iAlls`. -/
+def splitOn [DecidableEq V] (U : Finset V) : V → V ⊕ {x // x ∈ U} :=
+  fun x => if h : x ∈ U then Sum.inr ⟨x, h⟩ else Sum.inl x
+
 /-- Existentially close the referents in `U` within a formula over free
-referents `V` (relabel `U`-referents to the bound side, then `Formula.iExs`).
-`DecidableEq V` is needed only for the `x ∈ U` test in the relabel, not by `iExs`. -/
+referents `V` (relabel via `splitOn`, then `Formula.iExs`). -/
 noncomputable def closeExists [DecidableEq V] (U : Finset V) (φ : L.Formula V) : L.Formula V :=
-  (φ.relabel (fun x => if h : x ∈ U then Sum.inr ⟨x, h⟩ else Sum.inl x)).iExs {x // x ∈ U}
+  (φ.relabel (splitOn U)).iExs {x // x ∈ U}
 
 /-- Universally close the referents in `U` (used for the antecedent of `⇒`). -/
 noncomputable def closeForall [DecidableEq V] (U : Finset V) (φ : L.Formula V) : L.Formula V :=
-  (φ.relabel (fun x => if h : x ∈ U then Sum.inr ⟨x, h⟩ else Sum.inl x)).iAlls {x // x ∈ U}
+  (φ.relabel (splitOn U)).iAlls {x // x ∈ U}
 
 mutual
 /-- Translate a DRS to a first-order formula: existentially close the universe
@@ -67,26 +74,117 @@ end
 
 variable {M : Type x} [L.Structure M]
 
-/-- **DRT ⊆ FOL** (@cite{kamp-reyle-1993} §1.5; @cite{muskens-1996}): the
-translated formula's `Realize` coincides with the bespoke `DRS.Realize`. Because
-`toFormula` existentially closes the universe, the correspondence is with an
-embedding `v'` extending `v` over `K.referents`.
+/-! ### Agreement of the translation with the bespoke semantics -/
 
-TODO: this needs a `mutual` theorem block paralleling the translation, with
-companion statements at the condition and list levels —
-`(Condition.toFormula c).Realize v ↔ Condition.Realize v c` and
-`(toFormulaAll cs).Realize v ↔ RealizeAll v cs` (the condition/list cases carry
-*no* extra closure; the universe `∃`/`∀` lives only in `DRS.toFormula`/the `imp`
-case). Key lemmas:
-`Formula.realize_iExs`/`realize_iAlls` turn `closeExists`/`closeForall` into the
-`∃`/`∀` over an assignment to the universe-subtype `{x // x ∈ U}`;
-`Formula.realize_relabel` turns the split relabel into the agreement condition
-`∀ x ∉ U, v' x = v x` (the `∃ i : {x // x ∈ U} → M` of `realize_iExs` corresponds
-to `v' := fun x => if h : x ∈ U then i ⟨x, h⟩ else v x`); then `realize_rel`,
-`realize_inf`, `realize_sup`, `realize_not`, `realize_imp` discharge the
-condition cases against the matching clauses of `DRS.Realize`. -/
+/-- The assignment that agrees with `v` off `U` and is given by `i` on `U`. -/
+private def extendOn [DecidableEq V] (U : Finset V) (v : V → M) (i : {x // x ∈ U} → M) : V → M :=
+  fun x => if h : x ∈ U then i ⟨x, h⟩ else v x
+
+private theorem elim_comp_splitOn [DecidableEq V] (U : Finset V) (v : V → M)
+    (i : {x // x ∈ U} → M) : (Sum.elim v i) ∘ (splitOn U) = extendOn U v i := by
+  funext x
+  simp only [splitOn, extendOn, Function.comp_apply]
+  by_cases h : x ∈ U <;> simp [h]
+
+private theorem extendOn_agrees [DecidableEq V] (U : Finset V) (v : V → M)
+    (i : {x // x ∈ U} → M) : ∀ x, x ∉ U → extendOn U v i x = v x := by
+  intro x hx; simp only [extendOn, dif_neg hx]
+
+private theorem extendOn_restrict [DecidableEq V] (U : Finset V) (v v' : V → M)
+    (h : ∀ x, x ∉ U → v' x = v x) : extendOn U v (fun s => v' s.val) = v' := by
+  funext x
+  simp only [extendOn]
+  by_cases hx : x ∈ U
+  · simp [hx]
+  · simp [hx, h x hx]
+
+/-- The `∃` over an assignment to the universe-subtype `{x // x ∈ U}` is the `∃`
+over embeddings extending `v` on `U`. -/
+private theorem exists_extend_iff [DecidableEq V] (U : Finset V) (v : V → M)
+    (P : (V → M) → Prop) :
+    (∃ i : {x // x ∈ U} → M, P (extendOn U v i)) ↔
+      ∃ v', (∀ x, x ∉ U → v' x = v x) ∧ P v' := by
+  constructor
+  · rintro ⟨i, hi⟩
+    exact ⟨extendOn U v i, extendOn_agrees U v i, hi⟩
+  · rintro ⟨v', hagree, hv'⟩
+    refine ⟨fun s => v' s.val, ?_⟩
+    rw [extendOn_restrict U v v' hagree]; exact hv'
+
+/-- The `∀` analogue of `exists_extend_iff`. -/
+private theorem forall_extend_iff [DecidableEq V] (U : Finset V) (v : V → M)
+    (P : (V → M) → Prop) :
+    (∀ i : {x // x ∈ U} → M, P (extendOn U v i)) ↔
+      ∀ v', (∀ x, x ∉ U → v' x = v x) → P v' := by
+  constructor
+  · intro hi v' hagree
+    have := hi (fun s => v' s.val)
+    rwa [extendOn_restrict U v v' hagree] at this
+  · intro hv' i
+    exact hv' (extendOn U v i) (extendOn_agrees U v i)
+
+/-- `closeExists` realizes as existential quantification over embeddings that
+extend `v` on `U`. -/
+theorem realize_closeExists [DecidableEq V] (U : Finset V) (φ : L.Formula V) (v : V → M) :
+    (closeExists U φ).Realize v ↔ ∃ v', (∀ x, x ∉ U → v' x = v x) ∧ φ.Realize v' := by
+  rw [closeExists, Formula.realize_iExs]
+  simp only [Formula.realize_relabel, elim_comp_splitOn]
+  exact exists_extend_iff U v (Formula.Realize φ)
+
+/-- `closeForall` realizes as universal quantification over embeddings that extend
+`v` on `U`. -/
+theorem realize_closeForall [DecidableEq V] (U : Finset V) (φ : L.Formula V) (v : V → M) :
+    (closeForall U φ).Realize v ↔ ∀ v', (∀ x, x ∉ U → v' x = v x) → φ.Realize v' := by
+  rw [closeForall, Formula.realize_iAlls]
+  simp only [Formula.realize_relabel, elim_comp_splitOn]
+  exact forall_extend_iff U v (Formula.Realize φ)
+
+mutual
+/-- **DRT ⊆ FOL** (@cite{kamp-reyle-1993} §1.5; @cite{muskens-1996}): the
+translated formula's `Realize` coincides with the bespoke `DRS.Realize`. As
+`toFormula` existentially closes the universe, the correspondence is with an
+embedding `v'` extending `v` over `K.referents`. -/
 theorem DRS.realize_toFormula [DecidableEq V] (K : DRS L V) (v : V → M) :
-    (K.toFormula).Realize v ↔ ∃ v', (∀ x, x ∉ K.referents → v' x = v x) ∧ K.Realize v' := by
-  sorry
+    (K.toFormula).Realize v ↔ ∃ v', (∀ x, x ∉ K.referents → v' x = v x) ∧ DRS.Realize v' K := by
+  match K with
+  | .mk U conds =>
+    rw [DRS.toFormula, realize_closeExists]
+    simp only [DRS.referents_mk, DRS.Realize]
+    exact exists_congr (fun v' => and_congr_right (fun _ => realize_toFormulaAll conds v'))
+/-- The open body of a DRS (its conditions, no universe closure) realizes as
+`DRS.Realize` (used for the antecedent of `⇒`). -/
+theorem DRS.realize_bodyFormula [DecidableEq V] (K : DRS L V) (v : V → M) :
+    (DRS.bodyFormula K).Realize v ↔ DRS.Realize v K := by
+  match K with
+  | .mk _ conds => exact realize_toFormulaAll conds v
+/-- A single condition's translation realizes as `Condition.Realize`. -/
+theorem Condition.realize_toFormula [DecidableEq V] (c : Condition L V) (v : V → M) :
+    (Condition.toFormula c).Realize v ↔ Condition.Realize v c := by
+  match c with
+  | .rel R args =>
+    simp [Condition.toFormula, Condition.Realize, Relations.formula, Formula.Realize,
+      BoundedFormula.realize_rel, Term.realize_var]
+  | .eq a b => simp [Condition.toFormula, Condition.Realize, Formula.realize_equal]
+  | .neg K =>
+    simp only [Condition.toFormula, Condition.Realize, Formula.realize_not]
+    rw [DRS.realize_toFormula K v]
+  | .imp a c =>
+    simp only [Condition.toFormula, Condition.Realize]
+    rw [realize_closeForall]
+    simp only [Formula.realize_imp]
+    refine forall_congr' (fun v' => imp_congr_right (fun _ => ?_))
+    rw [DRS.realize_bodyFormula a v', DRS.realize_toFormula c v']
+  | .dis l r =>
+    simp only [Condition.toFormula, Condition.Realize, Formula.realize_sup]
+    rw [DRS.realize_toFormula l v, DRS.realize_toFormula r v]
+/-- A list of conditions' conjoined translation realizes as `RealizeAll`. -/
+theorem realize_toFormulaAll [DecidableEq V] (cs : List (Condition L V)) (v : V → M) :
+    (Condition.toFormulaAll cs).Realize v ↔ Condition.RealizeAll v cs := by
+  match cs with
+  | [] => simp [Condition.toFormulaAll, Condition.RealizeAll, Formula.realize_top]
+  | c :: cs =>
+    rw [Condition.toFormulaAll, Condition.RealizeAll, Formula.realize_inf,
+      Condition.realize_toFormula c v, realize_toFormulaAll cs v]
+end
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -7,10 +7,11 @@ import Mathlib.ModelTheory.Syntax
 
 The "surprise" theorem of the whole development: the bespoke DRS box language is
 *equivalent to ordinary first-order logic*. We translate each DRS into a mathlib
-`FirstOrder.Language.Formula` and prove its `Realize` coincides with the bespoke
-`DRS.Realize` — Kamp & Reyle's §1.5 ("From DRT to Predicate Logic") and Muskens's
-"DRSs are already present in classical logic", now a Lean theorem rather than an
-assertion.
+`FirstOrder.Language.Formula` and state that its `Realize` coincides with the
+bespoke `DRS.Realize` — Kamp & Reyle's §1.5 ("From DRT to Predicate Logic") and
+Muskens's "DRSs are already present in classical logic". The translation is
+defined; the agreement theorem `DRS.realize_toFormula` is stated, with its proof
+in progress (`sorry`).
 
 The universe of a (sub-)DRS is *existentially closed* (`closeExists`, via
 mathlib's `Formula.iExs`); the antecedent of a `⇒` is *universally closed*
@@ -31,7 +32,8 @@ universe u v w x
 variable {L : Language.{u, v}} {V : Type w}
 
 /-- Existentially close the referents in `U` within a formula over free
-referents `V` (relabel `U`-referents to the bound side, then `Formula.iExs`). -/
+referents `V` (relabel `U`-referents to the bound side, then `Formula.iExs`).
+`DecidableEq V` is needed only for the `x ∈ U` test in the relabel, not by `iExs`. -/
 noncomputable def closeExists [DecidableEq V] (U : Finset V) (φ : L.Formula V) : L.Formula V :=
   (φ.relabel (fun x => if h : x ∈ U then Sum.inr ⟨x, h⟩ else Sum.inl x)).iExs {x // x ∈ U}
 
@@ -55,7 +57,9 @@ noncomputable def Condition.toFormula [DecidableEq V] : Condition L V → L.Form
   | .neg K => (DRS.toFormula K).not
   | .imp a c => closeForall a.referents ((DRS.bodyFormula a).imp (DRS.toFormula c))
   | .dis l r => DRS.toFormula l ⊔ DRS.toFormula r
-/-- The conjunction of a list of (translated) conditions. -/
+/-- The conjunction of a list of (translated) conditions. A `List` helper — the
+higher-order `(cs.map Condition.toFormula).foldr (· ⊓ ·) ⊤` form fails the
+nested-inductive structural-recursion checker. -/
 noncomputable def Condition.toFormulaAll [DecidableEq V] : List (Condition L V) → L.Formula V
   | [] => ⊤
   | c :: cs => Condition.toFormula c ⊓ Condition.toFormulaAll cs
@@ -68,7 +72,12 @@ translated formula's `Realize` coincides with the bespoke `DRS.Realize`. Because
 `toFormula` existentially closes the universe, the correspondence is with an
 embedding `v'` extending `v` over `K.referents`.
 
-TODO: mutual induction on `DRS`/`Condition`. Key lemmas:
+TODO: this needs a `mutual` theorem block paralleling the translation, with
+companion statements at the condition and list levels —
+`(Condition.toFormula c).Realize v ↔ Condition.Realize v c` and
+`(toFormulaAll cs).Realize v ↔ RealizeAll v cs` (the condition/list cases carry
+*no* extra closure; the universe `∃`/`∀` lives only in `DRS.toFormula`/the `imp`
+case). Key lemmas:
 `Formula.realize_iExs`/`realize_iAlls` turn `closeExists`/`closeForall` into the
 `∃`/`∀` over an assignment to the universe-subtype `{x // x ∈ U}`;
 `Formula.realize_relabel` turns the split relabel into the agreement condition

--- a/Linglib/Semantics/Dynamic/DRS/Semantics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Semantics.lean
@@ -34,7 +34,9 @@ def DRS.Realize (v : V → M) : DRS L V → Prop
   | .mk _ conds => Condition.RealizeAll v conds
 /-- `v` verifies a condition (Def. 1.4.4(ii)). A sub-DRS `K` is entered by
 existentially (re)assigning the referents of its universe (`v'` agrees with `v`
-off `K.referents`). -/
+off `K.referents`). For `imp`, the consequent witness `v''` extends the
+*antecedent* assignment `v'` (not the host `v`): antecedent referents are visible
+in the consequent — the `⇒` accessibility asymmetry. -/
 def Condition.Realize (v : V → M) : Condition L V → Prop
   | .rel R args => Structure.RelMap R (fun i => v (args i))
   | .eq a b => v a = v b
@@ -45,7 +47,9 @@ def Condition.Realize (v : V → M) : Condition L V → Prop
   | .dis l r =>
       (∃ v' : V → M, (∀ x, x ∉ l.referents → v' x = v x) ∧ DRS.Realize v' l) ∨
       (∃ v' : V → M, (∀ x, x ∉ r.referents → v' x = v x) ∧ DRS.Realize v' r)
-/-- Every condition in the list is verified by `v` (mutual helper). -/
+/-- Every condition in the list is verified by `v`. A `List` helper (not
+`List.Forall (Condition.Realize v)`) because Lean's structural-recursion checker
+for the nested `List (Condition …)` rejects the higher-order argument. -/
 def Condition.RealizeAll (v : V → M) : List (Condition L V) → Prop
   | [] => True
   | c :: cs => Condition.Realize v c ∧ Condition.RealizeAll v cs

--- a/Linglib/Semantics/Dynamic/DRS/Semantics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Semantics.lean
@@ -1,0 +1,59 @@
+import Linglib.Semantics.Dynamic.DRS.Defs
+import Mathlib.ModelTheory.Semantics
+
+/-!
+# Model-theoretic semantics of DRSs
+@cite{kamp-reyle-1993}
+
+DRS truth via *verifying embeddings* into a mathlib `FirstOrder.Language.Structure`
+— exactly Kamp & Reyle's Def. 1.4.4–1.4.5. An embedding is an assignment
+`v : V → M` of discourse referents to the model domain; the discourse referents
+introduced by a sub-DRS are existentially (re)assigned when that sub-DRS is
+entered, which is what `(∀ x ∉ K.referents, v' x = v x)` expresses (`v'` extends
+`v` on `K`'s universe).
+
+## Main declarations
+
+* `DRS.Realize` / `Condition.Realize` — the verifying-embedding relation
+  (Def. 1.4.4), reusing mathlib's `Structure.RelMap` for atomic conditions.
+* `DRS.trueIn` — `K` is true in `M` iff some embedding verifies it (Def. 1.4.5).
+-/
+
+open FirstOrder FirstOrder.Language
+
+namespace DRT
+
+universe u v w x
+
+variable {L : Language.{u, v}} {V : Type w} {M : Type x} [L.Structure M]
+
+mutual
+/-- `v` *verifies* `K` (@cite{kamp-reyle-1993}, Def. 1.4.4): every condition of `K`
+holds under the assignment `v`. -/
+def DRS.Realize (v : V → M) : DRS L V → Prop
+  | .mk _ conds => Condition.RealizeAll v conds
+/-- `v` verifies a condition (Def. 1.4.4(ii)). A sub-DRS `K` is entered by
+existentially (re)assigning the referents of its universe (`v'` agrees with `v`
+off `K.referents`). -/
+def Condition.Realize (v : V → M) : Condition L V → Prop
+  | .rel R args => Structure.RelMap R (fun i => v (args i))
+  | .eq a b => v a = v b
+  | .neg K => ¬ ∃ v' : V → M, (∀ x, x ∉ K.referents → v' x = v x) ∧ DRS.Realize v' K
+  | .imp a c =>
+      ∀ v' : V → M, (∀ x, x ∉ a.referents → v' x = v x) → DRS.Realize v' a →
+        ∃ v'' : V → M, (∀ x, x ∉ c.referents → v'' x = v' x) ∧ DRS.Realize v'' c
+  | .dis l r =>
+      (∃ v' : V → M, (∀ x, x ∉ l.referents → v' x = v x) ∧ DRS.Realize v' l) ∨
+      (∃ v' : V → M, (∀ x, x ∉ r.referents → v' x = v x) ∧ DRS.Realize v' r)
+/-- Every condition in the list is verified by `v` (mutual helper). -/
+def Condition.RealizeAll (v : V → M) : List (Condition L V) → Prop
+  | [] => True
+  | c :: cs => Condition.Realize v c ∧ Condition.RealizeAll v cs
+end
+
+/-- `K` is *true* in `M` iff some embedding verifies it (@cite{kamp-reyle-1993},
+Def. 1.4.5). -/
+def DRS.trueIn (M : Type x) [L.Structure M] (K : DRS L V) : Prop :=
+  ∃ v : V → M, K.Realize v
+
+end DRT


### PR DESCRIPTION
Faithful Lean model of Kamp & Reyle (1993) discourse representation structures, built on mathlib `FirstOrder.Language`, with the §1.5 DRT→FOL reduction proven.

- `Defs`/`Basic`/`Semantics`: the DRS data type, subordination/accessibility (`Relation.TransGen`), `IsProper`, functorial `map`, the merge monoid, and verifying-embedding truth (`Realize`/`trueIn`) over a `Structure`.
- `Reduction`: `toFormula` into `L.Formula`, and `realize_toFormula` proving a DRS's bespoke truth coincides with its first-order translation's `Realize`.