### PR TITLE
feat(Syntax/HPSG): RSRL relations + quantification; Binding A/B

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2139,6 +2139,7 @@ import Linglib.Syntax.HPSG.HeadFiller
 import Linglib.Syntax.HPSG.LexicalRules
 import Linglib.Syntax.HPSG.RelativeClauses
 import Linglib.Syntax.HPSG.Coreference
+import Linglib.Syntax.HPSG.Binding
 -- Theories: Minimalism
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.Checking

--- a/Linglib/Syntax/HPSG/Binding.lean
+++ b/Linglib/Syntax/HPSG/Binding.lean
@@ -1,0 +1,217 @@
+import Linglib.Syntax.HPSG.Description
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# HPSG Binding Theory (Principles A & B) in RSRL
+@cite{pollard-sag-1994}, @cite{richter-2000}, @cite{richter-2024}
+
+The first *relational, quantified* HPSG principles in the RSRL substrate, exercising the
+`rel`/`ex`/`all` machinery of `Description.lean`. Following the HPSG Binding Theory
+(@cite{pollard-sag-1994}; @cite{muller-2024-binding}, Ch. 20):
+
+* **local o-command** ((11)): `Y` locally o-commands `Z` iff `Y` is less oblique than `Z` —
+  precedes it on the same ARG-ST list. Here it is the relation `locO` (interpreted per model).
+* **o-bind** ((13)): `Y` o-binds `Z` iff coindexed *and* o-commands. **Coindexation is token
+  identity** of the `INDEX` objects (`pathEq` on `INDEX`), the RSRL-faithful reading.
+* **Principle A** ((15)): a locally o-commanded anaphor must be locally o-bound.
+* **Principle B** ((15)): a personal pronoun must be locally o-free (not locally o-bound).
+
+## Implementation notes
+
+* **Simplification.** ARG-ST is modeled via `SUBJ`/`OBJ` attributes on the sign (its argument
+  synsems are components of the sign, so component quantification reaches them) and `locO` is
+  interpreted directly per model. Deriving `locO` from a `FIRST`/`REST` list and the obliqueness
+  order is a faithful refinement (the `list`/`nelist` machinery); `locO`-as-a-relation already
+  exercises the relational+quantified description language on real binding content.
+* The nom-obj hierarchy (`ana`/`ppro`/`npro` ⊑ `synsem`) keys the principles by sort.
+* **Computational bridge deferred.** A bridge to the project's computational binding
+  (`Syntax/HPSG/Coreference.lean`'s `computeCoreferenceStatus`) is future work: that layer
+  encodes coindexation as `index : Option Nat` *value* equality over `Word`-based clauses,
+  whereas the RSRL principles here use *token identity* (`pathEq` on `INDEX`) over abstract
+  entities — the same value-vs-token gap flagged for the HFP bridge. Aligning them needs the
+  computational layer to encode structure-sharing.
+-/
+
+namespace HPSG.RSRL.Binding
+
+/-! ### Signature: nom-obj hierarchy, INDEX, and the o-command relation -/
+
+/-- Sorts: a `sign`, `synsem` objects with the nom-obj species (`ana`/`ppro`/`npro`), and an
+atomic `idx` (referential index). -/
+inductive BSort | top | sign | synsem | ana | ppro | npro | idx
+  deriving DecidableEq, Fintype, Repr
+
+/-- Attributes: `SUBJ`/`OBJ` (a sign's arguments — a flattened ARG-ST) and `IDX` (a synsem's
+referential index). -/
+inductive BAttr | SUBJ | OBJ | IDX deriving DecidableEq, Fintype, Repr
+
+/-- One relation: local o-command, `locO` (arity 2). -/
+inductive BRel | locO deriving DecidableEq, Fintype, Repr
+
+/-- Subsumption: the nom-obj species are `≤ synsem`; everything `≤ top`. -/
+def bleB : BSort → BSort → Bool
+  | _, .top => true
+  | .ana, .synsem => true
+  | .ppro, .synsem => true
+  | .npro, .synsem => true
+  | a, b => decide (a = b)
+
+private theorem bleB_refl : ∀ a, bleB a a = true := by decide
+private theorem bleB_trans :
+    ∀ a b c, bleB a b = true → bleB b c = true → bleB a c = true := by decide
+private theorem bleB_antisymm : ∀ a b, bleB a b = true → bleB b a = true → a = b := by decide
+
+instance : PartialOrder BSort where
+  le a b := bleB a b = true
+  le_refl := bleB_refl
+  le_trans := bleB_trans
+  le_antisymm := bleB_antisymm
+
+instance : DecidableLE BSort := fun a b => inferInstanceAs (Decidable (bleB a b = true))
+
+def bapprop : BSort → BAttr → Option BSort
+  | .sign, .SUBJ => some .synsem
+  | .sign, .OBJ => some .synsem
+  | .synsem, .IDX => some .idx
+  | .ana, .IDX => some .idx
+  | .ppro, .IDX => some .idx
+  | .npro, .IDX => some .idx
+  | _, _ => none
+
+private theorem bapprop_inh : ∀ (σ₁ σ₂ : BSort) (α : BAttr) (τ₁ : BSort),
+    σ₂ ≤ σ₁ → bapprop σ₁ α = some τ₁ → ∃ τ₂, bapprop σ₂ α = some τ₂ ∧ τ₂ ≤ τ₁ := by decide
+
+@[reducible] def bindingSig : Signature BSort where
+  Attr := BAttr
+  Rel := BRel
+  arity := fun _ => 2
+  approp := bapprop
+  approp_inherits := fun {σ₁ σ₂ α τ₁} => bapprop_inh σ₁ σ₂ α τ₁
+
+/-! ### Principles A and B as descriptions
+
+Variables: `0` is the bound synsem `x`; `1` is the candidate binder `y`. `IDX(x) ≈ IDX(y)` is
+coindexation (token identity). -/
+
+/-- Coindexation of the entities at variables `x` and `y`: token identity of their `INDEX`. -/
+def coindexed (x y : Nat) : Desc bindingSig :=
+  .pathEq (.feat (.var x) .IDX) (.feat (.var y) .IDX)
+
+/-- `y` locally o-binds `x`: `locO(y, x)` and they are coindexed. -/
+def locallyOBinds (y x : Nat) : Desc bindingSig :=
+  .and (.rel .locO [.var y, .var x]) (coindexed x y)
+
+/-- **Principle A**: a locally o-commanded anaphor must be locally o-bound. For every
+component `x`: if `x` is an anaphor and some component `y` locally o-commands it, then some
+component `y` locally o-binds it. -/
+def principleA : Desc bindingSig :=
+  .all 0 (.imp
+    (.and (.sortAssign (.var 0) .ana) (.ex 1 (.rel .locO [.var 1, .var 0])))
+    (.ex 1 (locallyOBinds 1 0)))
+
+/-- **Principle B**: a personal pronoun must be locally o-free — no component locally o-binds
+it. -/
+def principleB : Desc bindingSig :=
+  .all 0 (.imp (.sortAssign (.var 0) .ppro)
+    (.neg (.ex 1 (locallyOBinds 1 0))))
+
+/-- The binding fragment's grammar. -/
+def bindingGrammar : Grammar bindingSig := [principleA, principleB]
+
+/-! ### Worked model: *Mary likes herself* (grammatical) -/
+
+/-- Entities of *Mary likes herself*: the verb sign, the subject (`mary`, an `npro`), the
+object (`herself`, an `ana`), and one shared index `i`. -/
+inductive GEnt | s | mary | herself | i deriving DecidableEq, Fintype, Repr
+
+/-- *Mary likes herself*: `mary` and `herself` share the index `i` (coindexed), and `mary`
+locally o-commands `herself` (it is less oblique). -/
+def maryLikesHerself : Interpretation bindingSig where
+  U := GEnt
+  S := fun
+    | .s => .sign
+    | .mary => .npro
+    | .herself => .ana
+    | .i => .idx
+  A := fun a u => match a, u with
+    | .SUBJ, .s => some .mary
+    | .OBJ, .s => some .herself
+    | .IDX, .mary => some .i
+    | .IDX, .herself => some .i
+    | _, _ => none
+  R := fun _ args => args = [GEnt.mary, GEnt.herself]
+
+instance : Fintype maryLikesHerself.U := inferInstanceAs (Fintype GEnt)
+instance : DecidableEq maryLikesHerself.U := inferInstanceAs (DecidableEq GEnt)
+instance (ρ : bindingSig.Rel) : DecidablePred (maryLikesHerself.R ρ) :=
+  fun args => inferInstanceAs (Decidable (args = [GEnt.mary, GEnt.herself]))
+
+/-- *Mary likes herself* satisfies Principle A: `herself` (an anaphor) is locally o-commanded
+by `mary`, and `mary` locally o-binds it (coindexed via the shared index `i`). -/
+example : maryLikesHerself.Models [principleA] := by decide
+
+/-- It also satisfies the whole binding grammar (Principle B is vacuous: no pronoun). -/
+example : maryLikesHerself.Models bindingGrammar := by decide
+
+/-! ### Worked model: *Mary likes himself* (gender clash — Principle A violated) -/
+
+/-- Entities with two *distinct* indices `iM`, `iH`: `mary` and `himself` are not coindexed. -/
+inductive HEnt | s | mary | himself | iM | iH deriving DecidableEq, Fintype, Repr
+
+/-- *Mary likes himself*: `mary` locally o-commands the anaphor `himself`, but their indices
+differ (gender clash), so `himself` is not locally o-bound — Principle A is violated. -/
+def maryLikesHimself : Interpretation bindingSig where
+  U := HEnt
+  S := fun
+    | .s => .sign
+    | .mary => .npro
+    | .himself => .ana
+    | .iM => .idx
+    | .iH => .idx
+  A := fun a u => match a, u with
+    | .SUBJ, .s => some .mary
+    | .OBJ, .s => some .himself
+    | .IDX, .mary => some .iM
+    | .IDX, .himself => some .iH
+    | _, _ => none
+  R := fun _ args => args = [HEnt.mary, HEnt.himself]
+
+instance : Fintype maryLikesHimself.U := inferInstanceAs (Fintype HEnt)
+instance : DecidableEq maryLikesHimself.U := inferInstanceAs (DecidableEq HEnt)
+instance (ρ : bindingSig.Rel) : DecidablePred (maryLikesHimself.R ρ) :=
+  fun args => inferInstanceAs (Decidable (args = [HEnt.mary, HEnt.himself]))
+
+/-- *Mary likes himself* violates Principle A — a genuine filter, not vacuously satisfied. -/
+example : ¬ maryLikesHimself.Models [principleA] := by decide
+
+/-! ### Worked model: *Mary likes her* coindexed (Principle B violated) -/
+
+/-- Entities with `her` a personal pronoun (`ppro`) sharing the index `i` with `mary`. -/
+inductive PEnt | s | mary | her | i deriving DecidableEq, Fintype, Repr
+
+/-- *Mary likes her_i* with `her` coindexed with `mary`: `mary` locally o-binds the pronoun
+`her`, so `her` is not locally o-free — Principle B is violated. -/
+def maryLikesHer : Interpretation bindingSig where
+  U := PEnt
+  S := fun
+    | .s => .sign
+    | .mary => .npro
+    | .her => .ppro
+    | .i => .idx
+  A := fun a u => match a, u with
+    | .SUBJ, .s => some .mary
+    | .OBJ, .s => some .her
+    | .IDX, .mary => some .i
+    | .IDX, .her => some .i
+    | _, _ => none
+  R := fun _ args => args = [PEnt.mary, PEnt.her]
+
+instance : Fintype maryLikesHer.U := inferInstanceAs (Fintype PEnt)
+instance : DecidableEq maryLikesHer.U := inferInstanceAs (DecidableEq PEnt)
+instance (ρ : bindingSig.Rel) : DecidablePred (maryLikesHer.R ρ) :=
+  fun args => inferInstanceAs (Decidable (args = [PEnt.mary, PEnt.her]))
+
+/-- A coindexed pronoun violates Principle B. -/
+example : ¬ maryLikesHer.Models [principleB] := by decide
+
+end HPSG.RSRL.Binding

--- a/Linglib/Syntax/HPSG/Description.lean
+++ b/Linglib/Syntax/HPSG/Description.lean
@@ -7,82 +7,113 @@ import Mathlib.Data.Fintype.Basic
 
 A native Lean rendering of the **description language** of RSRL — the formulae that state the
 principles of an HPSG grammar (@cite{richter-2000}, Def. 54; satisfaction is Def. 58;
-@cite{richter-2024}, Ch. 3 §2). This is the *relation-free, quantifier-free fragment*: sort
-assignments and path equations closed under the classical connectives. Relational formulae,
-component quantification, and chains (which make RSRL strictly richer than first-order logic)
-are deferred.
+@cite{richter-2024}, Ch. 3 §2). This now includes **relational formulae** and **component
+quantification** (∃/∀ over the components of the described entity), the features that make RSRL
+strictly richer than first-order logic. Chains (list-valued *relation arguments*, Def. 49–50)
+remain deferred.
 
 ## Main declarations
 
-* `HPSG.RSRL.Desc` — descriptions: `sortAssign` (`τ ~ σ`), `pathEq` (`τ₁ ≈ τ₂`, token
-  identity), and `neg`/`and`/`or`/`imp`.
-* `HPSG.RSRL.Interpretation.satisfies` — the description-denotation: when a description is true
-  of an entity `u` in an interpretation (@cite{richter-2000}, Def. 58; `Desc` syntax is
-  Def. 54). Decidable on finite models, so worked examples reduce by `decide`.
-* `HPSG.RSRL.Grammar` / `Interpretation.Models` — a grammar is a set (here `List`) of
-  descriptions; an interpretation is a model iff every description holds of every entity.
+* `HPSG.RSRL.Desc` — descriptions over `Term`s (with variables): `sortAssign` (`τ ~ σ`),
+  `pathEq` (`τ₁ ≈ τ₂`, token identity), `rel` (relational formula `ρ(τ₁,…)`), `neg`/`and`/
+  `or`/`imp`, and `ex`/`all` (component quantification).
+* `HPSG.RSRL.Interpretation.satisfies` — satisfaction under a variable assignment
+  (@cite{richter-2000}, Def. 58). `ex`/`all` quantify over `IsComponentOf u` — RSRL's bounded
+  (component) quantification, *not* the whole universe. Decidable on finite models.
+* `HPSG.RSRL.Grammar` / `Interpretation.Models` — a grammar's principles; a model satisfies
+  every (variable-free) principle of every entity.
 
 ## Implementation notes
 
-* `pathEq` is **token identity** (@cite{richter-2024}, Ch. 3): two paths are equated iff both
-  are defined and denote the *same* entity — reentrancy is ordinary `=` in the model.
-* A grammar is a `List Desc` rather than `Set Desc` so that `Models` is decidable; the intended
-  reading is still set-like (order and duplication are irrelevant).
+* `ex`/`all` are **component-bounded** (`I.IsComponentOf u w`, i.e. `w` reachable from `u` by
+  attributes). On finite models this is decidable (`Interpretation.lean`), so `∃`-quantified
+  worked examples reduce by `decide`. Universal component quantification (`all`) is decidable
+  too, but `decide` on it can be kernel-heavy; such principles are better checked structurally.
+* `Models` evaluates principles under the assignment `fun _ => u`; grammar descriptions are
+  variable-free (Def. 54), so the choice of assignment is irrelevant.
 -/
 
 namespace HPSG.RSRL
 
 universe u
 
-/-- RSRL descriptions, relation-free quantifier-free fragment (@cite{richter-2000}, Def. 54). -/
+/-- RSRL descriptions over `Term`s (@cite{richter-2000}, Def. 54): atomic sort-assignments and
+path-equations, relational formulae, the classical connectives, and component quantification. -/
 inductive Desc {Srt : Type u} [PartialOrder Srt] (Sig : Signature Srt) where
-  /-- Sort assignment `τ ~ σ`: the entity at path `p` has a sort at least as specific as `σ`. -/
-  | sortAssign (p : Path Sig) (σ : Srt)
-  /-- Path equation `τ₁ ≈ τ₂`: the entities at paths `p` and `q` are token-identical. -/
-  | pathEq (p q : Path Sig)
+  /-- Sort assignment `τ ~ σ`: the entity at `t` has a sort at least as specific as `σ`. -/
+  | sortAssign (t : Term Sig) (σ : Srt)
+  /-- Path equation `τ₁ ≈ τ₂`: the entities at `t₁` and `t₂` are token-identical. -/
+  | pathEq (t₁ t₂ : Term Sig)
+  /-- Relational formula `ρ(t₁,…,tₙ)`: the tuple of denoted terms stands in relation `ρ`. -/
+  | rel (ρ : Sig.Rel) (ts : List (Term Sig))
   /-- Negation. -/
   | neg (d : Desc Sig)
   /-- Conjunction. -/
   | and (d e : Desc Sig)
   /-- Disjunction. -/
   | or (d e : Desc Sig)
-  /-- Implication (classical; a non-antecedent entity satisfies it vacuously). -/
+  /-- Implication (classical; vacuously satisfied where the antecedent fails). -/
   | imp (d e : Desc Sig)
+  /-- Existential component quantification: some component of the described entity. -/
+  | ex (v : Nat) (d : Desc Sig)
+  /-- Universal component quantification: every component of the described entity. -/
+  | all (v : Nat) (d : Desc Sig)
 
 namespace Interpretation
 
 variable {Srt : Type u} [PartialOrder Srt] {Sig : Signature Srt}
 
-/-- When a description is true of entity `u` in interpretation `I` (@cite{richter-2000},
-Def. 58). A path that is undefined makes an atomic description false. -/
-def satisfies (I : Interpretation Sig) (u : I.U) : Desc Sig → Prop
-  | .sortAssign p σ => match I.denot p u with
+/-- Satisfaction under a variable assignment (@cite{richter-2000}, Def. 58). `ex`/`all`
+quantify over the **components** of `u` (`IsComponentOf`), RSRL's bounded quantification. An
+undefined term makes an atomic description false. -/
+def satisfies (I : Interpretation Sig) (ass : Nat → I.U) (u : I.U) : Desc Sig → Prop
+  | .sortAssign t σ => match I.termDenot ass t u with
       | some v => I.S v ≤ σ
       | none => False
-  | .pathEq p q => match I.denot p u, I.denot q u with
+  | .pathEq t₁ t₂ => match I.termDenot ass t₁ u, I.termDenot ass t₂ u with
       | some a, some b => a = b
       | _, _ => False
-  | .neg d => ¬ I.satisfies u d
-  | .and d e => I.satisfies u d ∧ I.satisfies u e
-  | .or d e => I.satisfies u d ∨ I.satisfies u e
-  | .imp d e => I.satisfies u d → I.satisfies u e
+  | .rel ρ ts => match ts.mapM (fun t => I.termDenot ass t u) with
+      | some args => I.R ρ args
+      | none => False
+  | .neg d => ¬ I.satisfies ass u d
+  | .and d e => I.satisfies ass u d ∧ I.satisfies ass u e
+  | .or d e => I.satisfies ass u d ∨ I.satisfies ass u e
+  | .imp d e => I.satisfies ass u d → I.satisfies ass u e
+  | .ex v d => ∃ w, I.IsComponentOf u w ∧ I.satisfies (Function.update ass v w) u d
+  | .all v d => ∀ w, I.IsComponentOf u w → I.satisfies (Function.update ass v w) u d
 
-instance decSatisfies (I : Interpretation Sig) [DecidableEq I.U] [DecidableLE Srt] (u : I.U) :
-    (d : Desc Sig) → Decidable (I.satisfies u d)
-  | .sortAssign p σ => by unfold satisfies; split <;> infer_instance
-  | .pathEq p q => by unfold satisfies; split <;> infer_instance
-  | .neg d => by unfold satisfies; haveI := decSatisfies I u d; infer_instance
+instance decSatisfies (I : Interpretation Sig) [Fintype I.U] [DecidableEq I.U] [DecidableLE Srt]
+    [Fintype Sig.Attr] [∀ ρ, DecidablePred (I.R ρ)] (ass : Nat → I.U) (u : I.U) :
+    (d : Desc Sig) → Decidable (I.satisfies ass u d)
+  | .sortAssign t σ => by unfold satisfies; split <;> infer_instance
+  | .pathEq t₁ t₂ => by unfold satisfies; split <;> infer_instance
+  | .rel ρ ts => by unfold satisfies; split <;> infer_instance
+  | .neg d => by unfold satisfies; haveI := decSatisfies I ass u d; infer_instance
   | .and d e => by
-      unfold satisfies; haveI := decSatisfies I u d; haveI := decSatisfies I u e; infer_instance
+      unfold satisfies; haveI := decSatisfies I ass u d; haveI := decSatisfies I ass u e
+      infer_instance
   | .or d e => by
-      unfold satisfies; haveI := decSatisfies I u d; haveI := decSatisfies I u e; infer_instance
+      unfold satisfies; haveI := decSatisfies I ass u d; haveI := decSatisfies I ass u e
+      infer_instance
   | .imp d e => by
-      unfold satisfies; haveI := decSatisfies I u d; haveI := decSatisfies I u e; infer_instance
+      unfold satisfies; haveI := decSatisfies I ass u d; haveI := decSatisfies I ass u e
+      infer_instance
+  | .ex v d => by
+      unfold satisfies
+      haveI : ∀ w, Decidable (I.satisfies (Function.update ass v w) u d) :=
+        fun w => decSatisfies I (Function.update ass v w) u d
+      infer_instance
+  | .all v d => by
+      unfold satisfies
+      haveI : ∀ w, Decidable (I.satisfies (Function.update ass v w) u d) :=
+        fun w => decSatisfies I (Function.update ass v w) u d
+      infer_instance
 
 end Interpretation
 
 /-- A **grammar** is a signature together with a set (here `List`) of descriptions, its
-principles (@cite{richter-2000}). The signature is implicit in the `Desc`s' type. -/
+principles (@cite{richter-2000}). -/
 abbrev Grammar {Srt : Type u} [PartialOrder Srt] (Sig : Signature Srt) := List (Desc Sig)
 
 namespace Interpretation
@@ -90,12 +121,14 @@ namespace Interpretation
 variable {Srt : Type u} [PartialOrder Srt] {Sig : Signature Srt}
 
 /-- An interpretation is a **model** of a grammar iff every principle holds of every entity in
-all its components (@cite{richter-2000}; @cite{richter-2024}, Ch. 3: component-wise). -/
+all its components (@cite{richter-2000}). Principles are variable-free, so they are evaluated
+under any assignment (here `fun _ => u`). -/
 def Models (I : Interpretation Sig) (G : Grammar Sig) : Prop :=
-  ∀ u : I.U, ∀ d ∈ G, I.satisfies u d
+  ∀ u : I.U, ∀ d ∈ G, I.satisfies (fun _ => u) u d
 
 instance (I : Interpretation Sig) [Fintype I.U] [DecidableEq I.U] [DecidableLE Srt]
-    (G : Grammar Sig) : Decidable (I.Models G) := by unfold Models; infer_instance
+    [Fintype Sig.Attr] [∀ ρ, DecidablePred (I.R ρ)] (G : Grammar Sig) :
+    Decidable (I.Models G) := by unfold Models; infer_instance
 
 end Interpretation
 

--- a/Linglib/Syntax/HPSG/Interpretation.lean
+++ b/Linglib/Syntax/HPSG/Interpretation.lean
@@ -1,5 +1,7 @@
 import Linglib.Syntax.HPSG.Signature
 import Mathlib.Data.Set.Basic
+import Mathlib.Data.Fintype.Basic
+import Linglib.Core.Relation.ReflTransGen
 
 /-!
 # RSRL interpretations
@@ -58,6 +60,32 @@ def denot (I : Interpretation Sig) : Path Sig → I.U → Option I.U
 
 @[simp] theorem denot_cons (I : Interpretation Sig) (a : Sig.Attr) (rest : Path Sig)
     (u : I.U) : I.denot (a :: rest) u = (I.A a u).bind (denot I rest) := rfl
+
+/-- Term denotation under a variable assignment (@cite{richter-2000}, Def. 53): `colon`
+denotes the described entity `u`, `var n` the assigned entity `ass n`, and `feat t α` follows
+attribute `α` (partially) from `t`'s denotation. -/
+def termDenot (I : Interpretation Sig) (ass : Nat → I.U) : Term Sig → I.U → Option I.U
+  | .colon, u => some u
+  | .var n, _ => some (ass n)
+  | .feat t a, u => (termDenot I ass t u).bind (I.A a)
+
+/-- The attribute-successor relation: `y` is an attribute value of `x`. Its
+reflexive-transitive closure is the *component-of* relation that bounds quantification. -/
+def attrSucc (I : Interpretation Sig) (x y : I.U) : Prop := ∃ α : Sig.Attr, I.A α x = some y
+
+instance (I : Interpretation Sig) [Fintype Sig.Attr] [DecidableEq I.U] :
+    DecidableRel I.attrSucc := fun _ _ => by unfold attrSucc; infer_instance
+
+/-- `v` is a **component of** `u` — reachable from `u` by following attributes (reflexively).
+RSRL component quantification ranges over exactly these (@cite{richter-2024}, Ch. 3). -/
+abbrev IsComponentOf (I : Interpretation Sig) (u v : I.U) : Prop :=
+  Relation.ReflTransGen I.attrSucc u v
+
+/-- Component-of is decidable on a finite interpretation (so `∃`-component quantification
+reduces by `decide`). Reuses the finite-carrier reachability decision procedure. -/
+instance (I : Interpretation Sig) [Fintype I.U] [DecidableEq I.U] [Fintype Sig.Attr]
+    (u v : I.U) : Decidable (I.IsComponentOf u v) :=
+  Relation.ReflTransGen.decidable_of_fintype u v
 
 /-- The totally-well-typed, sort-resolved condition on a model (@cite{richter-2000}, Def. 48):
 the species assignment lands in species, and every attribute is defined exactly on the

--- a/Linglib/Syntax/HPSG/Model.lean
+++ b/Linglib/Syntax/HPSG/Model.lean
@@ -106,13 +106,18 @@ instance search; the models below are plain `def`s. -/
   approp := happrop
   approp_inherits := fun {σ₁ σ₂ α τ₁} => happrop_inh σ₁ σ₂ α τ₁
 
+/-- `hpsgSig` has no relations, so relation membership is vacuously decidable — needed by the
+`satisfies`/`Models` decision procedure. -/
+instance (I : Interpretation hpsgSig) : ∀ ρ, DecidablePred (I.R ρ) := fun ρ => nomatch ρ
+
 /-! ### The Head Feature Principle -/
 
 /-- The **Head Feature Principle** (@cite{pollard-sag-1994}; @cite{richter-2024}, Ch. 3, (3a)),
 at CAT granularity: a headed phrase shares its category (path `CAT`) with its head daughter
-(path `HD CAT`), as token identity (`pathEq`). -/
+(path `HD CAT`), as token identity (`pathEq`). The mother is the described entity `:`; `CAT`
+and `HD CAT` are `:`-rooted paths (`Term.path`). -/
 def hfp : Desc hpsgSig :=
-  .imp (.sortAssign [] .headedPhrase) (.pathEq [.CAT] [.HD, .CAT])
+  .imp (.sortAssign .colon .headedPhrase) (.pathEq (.path [.CAT]) (.path [.HD, .CAT]))
 
 /-- The one-principle grammar of the worked fragment. -/
 def hpsgGrammar : Grammar hpsgSig := [hfp]
@@ -140,11 +145,17 @@ def posModel : Interpretation hpsgSig where
     | _, _ => none
   R := fun e => e.elim
 
+-- Explicit `Fintype`/`DecidableEq` on the carrier so `decide` resolves the decision instances
+-- *without* unfolding `posModel` (which would reduce `.R` and unmatch the empty-relation
+-- instance below). The kernel still unfolds `posModel` when evaluating `decide`.
+instance : Fintype posModel.U := inferInstanceAs (Fintype Ent)
+instance : DecidableEq posModel.U := inferInstanceAs (DecidableEq Ent)
+
 /-- The well-formed structure satisfies the Head Feature Principle. -/
-example : posModel.Models hpsgGrammar := by unfold posModel; decide
+example : posModel.Models hpsgGrammar := by decide
 
 /-- The well-formed structure is totally well-typed. -/
-example : posModel.WellTyped := by unfold posModel; decide
+example : posModel.WellTyped := by decide
 
 /-- An ill-formed structure: the head daughter's category differs from the mother's, so the
 HFP fails — the principle is a genuine filter, not vacuously satisfied. -/
@@ -162,11 +173,14 @@ def negModel : Interpretation hpsgSig where
     | _, _ => none
   R := fun e => e.elim
 
+instance : Fintype negModel.U := inferInstanceAs (Fintype Ent)
+instance : DecidableEq negModel.U := inferInstanceAs (DecidableEq Ent)
+
 /-- The ill-formed structure violates the Head Feature Principle. -/
-example : ¬ negModel.Models hpsgGrammar := by unfold negModel; decide
+example : ¬ negModel.Models hpsgGrammar := by decide
 
 /-- It is nonetheless well-typed: it only violates the *principle*, not the signature. -/
-example : negModel.WellTyped := by unfold negModel; decide
+example : negModel.WellTyped := by decide
 
 /-! ### A partial bridge to the computational HPSG core -/
 
@@ -203,9 +217,10 @@ so this does NOT establish `(toInterp r).Models hpsgGrammar`: `toInterp` gives t
 head daughter *distinct* category entities (`catM`/`catH`), which the grammar's `pathEq` HFP
 rejects even when their sorts agree. A faithful computational↔token-identity bridge (where the
 induced model structure-shares the category object) is future work. -/
-theorem toInterp_categoryAgreement_of_hfp (r : HPSG.HeadCompRule) :
-    (toInterp r).satisfies .mother
-      (.sortAssign [.HD, .CAT] (catSpecies r.result.synsem.cat)) := by
+theorem toInterp_categoryAgreement_of_hfp (r : HPSG.HeadCompRule)
+    (ass : Nat → (toInterp r).U) :
+    (toInterp r).satisfies ass .mother
+      (.sortAssign (.path [.HD, .CAT]) (catSpecies r.result.synsem.cat)) := by
   show catSpecies r.head.synsem.cat ≤ catSpecies r.result.synsem.cat
   rw [r.hfp]
 

--- a/Linglib/Syntax/HPSG/Signature.lean
+++ b/Linglib/Syntax/HPSG/Signature.lean
@@ -75,4 +75,21 @@ end Signature
 attribute `α` and then the rest of the path. -/
 abbrev Path {Srt : Type u} [PartialOrder Srt] (Sig : Signature Srt) := List Sig.Attr
 
+/-- An RSRL **term** (@cite{richter-2000}, Def. 52): rooted at either the described entity
+(`colon`, the reserved `:`) or a variable (`var n`), then extended by attributes (`feat t α`).
+Variables are needed for relational formulae and component quantification (Def. 54). -/
+inductive Term {Srt : Type u} [PartialOrder Srt] (Sig : Signature Srt) where
+  /-- The described entity itself (RSRL `:`). -/
+  | colon : Term Sig
+  /-- A variable (de Bruijn-free; `n : ℕ` names it). -/
+  | var : Nat → Term Sig
+  /-- Follow attribute `α` from the term `t` (RSRL `tα`). -/
+  | feat : Term Sig → Sig.Attr → Term Sig
+
+/-- The `:`-rooted term following a path of attributes — bridges the PR1 `Path` notation
+(`[α, β]`) into the term language: `Term.path [α, β] = (colon.feat α).feat β`. -/
+def Term.path {Srt : Type u} [PartialOrder Srt] {Sig : Signature Srt}
+    (p : Path Sig) : Term Sig :=
+  p.foldl Term.feat Term.colon
+
 end HPSG.RSRL

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -14176,6 +14176,23 @@
   role      = {foundational},
   sources   = {Syntax/HPSG/Signature.lean;Syntax/HPSG/Interpretation.lean;Syntax/HPSG/Description.lean;Syntax/HPSG/Model.lean}
 }
+@incollection{muller-2024-binding,
+  author    = {Müller, Stefan},
+  year      = {2024},
+  title     = {Anaphoric binding},
+  booktitle = {Head-Driven Phrase Structure Grammar: The Handbook},
+  edition   = {2},
+  editor    = {Müller, Stefan and Abeillé, Anne and Borsley, Robert D. and Koenig, Jean-Pierre},
+  publisher = {Language Science Press},
+  address   = {Berlin},
+  series    = {Empirically Oriented Theoretical Morphology and Syntax},
+  number    = {9},
+  pages     = {951--1009},
+  doi       = {10.5281/zenodo.13645097},
+  subfield  = {syntax},
+  role      = {foundational},
+  sources   = {Syntax/HPSG/Binding.lean}
+}
 @article{pollard-sag-1992,
   author    = {Pollard, Carl and Sag, Ivan A.},
   year      = {1992},


### PR DESCRIPTION
Extends the RSRL description language with **relational formulae** + **component quantification** (`Desc.rel`/`ex`/`all`, `Term`s with variables, assignment-threaded `satisfies`) — the features that make RSRL richer than FOL (Richter Def 54/58) — and uses them for the first real principle: **HPSG Binding Theory A & B** (`@cite{pollard-sag-1994}`; `@cite{muller-2024-binding}`).

- Component quantification is **bounded by reachability** (`IsComponentOf` via `Core/Relation/ReflTransGen`), decidable on finite models — so worked binding models `decide`: *Mary likes herself* ⊨ Principle A; gender-clash *Mary likes himself* ⊭ A; coindexed *her* ⊭ Principle B. **Coindexation = token identity** (`pathEq` on `INDEX`), the faithful RSRL reading.
- ARG-ST is a list-valued *attribute* (settled: not a chain — chains are for relation arguments, deferred). PR1's HFP worked-models ported to the `Term` form and still pass.
- Computational bridge to `Coreference.lean` deferred (value-vs-token coindexation gap, documented).