### PR TITLE
refactor(Syntax/HPSG): dedup RSRL fixtures, terse docstrings

### DIFF
--- a/Linglib/Syntax/HPSG/Binding.lean
+++ b/Linglib/Syntax/HPSG/Binding.lean
@@ -3,33 +3,19 @@ import Mathlib.Tactic.DeriveFintype
 
 /-!
 # HPSG Binding Theory (Principles A & B) in RSRL
-@cite{pollard-sag-1994}, @cite{richter-2000}, @cite{richter-2024}
+@cite{pollard-sag-1994}, @cite{richter-2000}, @cite{muller-2024-binding}
 
 The first *relational, quantified* HPSG principles in the RSRL substrate, exercising the
-`rel`/`ex`/`all` machinery of `Description.lean`. Following the HPSG Binding Theory
-(@cite{pollard-sag-1994}; @cite{muller-2024-binding}, Ch. 20):
+`rel`/`ex`/`all` machinery of `Description.lean`. Following HPSG Binding Theory
+(@cite{muller-2024-binding}, Ch. 20): **local o-command** ("less oblique, same ARG-ST", the
+relation `locO`), **o-bind** (coindexed ∧ o-commands), **Principle A** (a locally o-commanded
+anaphor is locally o-bound), **Principle B** (a pronoun is locally o-free).
 
-* **local o-command** ((11)): `Y` locally o-commands `Z` iff `Y` is less oblique than `Z` —
-  precedes it on the same ARG-ST list. Here it is the relation `locO` (interpreted per model).
-* **o-bind** ((13)): `Y` o-binds `Z` iff coindexed *and* o-commands. **Coindexation is token
-  identity** of the `INDEX` objects (`pathEq` on `INDEX`), the RSRL-faithful reading.
-* **Principle A** ((15)): a locally o-commanded anaphor must be locally o-bound.
-* **Principle B** ((15)): a personal pronoun must be locally o-free (not locally o-bound).
-
-## Implementation notes
-
-* **Simplification.** ARG-ST is modeled via `SUBJ`/`OBJ` attributes on the sign (its argument
-  synsems are components of the sign, so component quantification reaches them) and `locO` is
-  interpreted directly per model. Deriving `locO` from a `FIRST`/`REST` list and the obliqueness
-  order is a faithful refinement (the `list`/`nelist` machinery); `locO`-as-a-relation already
-  exercises the relational+quantified description language on real binding content.
-* The nom-obj hierarchy (`ana`/`ppro`/`npro` ⊑ `synsem`) keys the principles by sort.
-* **Computational bridge deferred.** A bridge to the project's computational binding
-  (`Syntax/HPSG/Coreference.lean`'s `computeCoreferenceStatus`) is future work: that layer
-  encodes coindexation as `index : Option Nat` *value* equality over `Word`-based clauses,
-  whereas the RSRL principles here use *token identity* (`pathEq` on `INDEX`) over abstract
-  entities — the same value-vs-token gap flagged for the HFP bridge. Aligning them needs the
-  computational layer to encode structure-sharing.
+Coindexation is **token identity** of `INDEX` (`pathEq`), the RSRL-faithful reading. ARG-ST is
+modeled via `SUBJ`/`OBJ` attributes and `locO` interpreted per model (deriving `locO` from a
+`FIRST`/`REST` list is a refinement). A bridge to the computational binding
+(`Coreference.lean`, coindexation as `index : Option Nat` value equality) is deferred — the same
+value-vs-token gap as the HFP bridge.
 -/
 
 namespace HPSG.RSRL.Binding
@@ -56,19 +42,12 @@ def bleB : BSort → BSort → Bool
   | .npro, .synsem => true
   | a, b => decide (a = b)
 
-private theorem bleB_refl : ∀ a, bleB a a = true := by decide
-private theorem bleB_trans :
-    ∀ a b c, bleB a b = true → bleB b c = true → bleB a c = true := by decide
-private theorem bleB_antisymm : ∀ a b, bleB a b = true → bleB b a = true → a = b := by decide
-
-instance : PartialOrder BSort where
-  le a b := bleB a b = true
-  le_refl := bleB_refl
-  le_trans := bleB_trans
-  le_antisymm := bleB_antisymm
+instance : PartialOrder BSort :=
+  partialOrderOfBool bleB (by decide) (by decide) (by decide)
 
 instance : DecidableLE BSort := fun a b => inferInstanceAs (Decidable (bleB a b = true))
 
+/-- Appropriateness: a sign has `SUBJ`/`OBJ` synsems; every synsem species has an `IDX`. -/
 def bapprop : BSort → BAttr → Option BSort
   | .sign, .SUBJ => some .synsem
   | .sign, .OBJ => some .synsem
@@ -90,8 +69,7 @@ private theorem bapprop_inh : ∀ (σ₁ σ₂ : BSort) (α : BAttr) (τ₁ : BS
 
 /-! ### Principles A and B as descriptions
 
-Variables: `0` is the bound synsem `x`; `1` is the candidate binder `y`. `IDX(x) ≈ IDX(y)` is
-coindexation (token identity). -/
+Variable `0` is the bound synsem `x`; `1` is the candidate binder `y`. -/
 
 /-- Coindexation of the entities at variables `x` and `y`: token identity of their `INDEX`. -/
 def coindexed (x y : Nat) : Desc bindingSig :=
@@ -101,9 +79,7 @@ def coindexed (x y : Nat) : Desc bindingSig :=
 def locallyOBinds (y x : Nat) : Desc bindingSig :=
   .and (.rel .locO [.var y, .var x]) (coindexed x y)
 
-/-- **Principle A**: a locally o-commanded anaphor must be locally o-bound. For every
-component `x`: if `x` is an anaphor and some component `y` locally o-commands it, then some
-component `y` locally o-binds it. -/
+/-- **Principle A**: a locally o-commanded anaphor must be locally o-bound. -/
 def principleA : Desc bindingSig :=
   .all 0 (.imp
     (.and (.sortAssign (.var 0) .ana) (.ex 1 (.rel .locO [.var 1, .var 0])))
@@ -118,100 +94,47 @@ def principleB : Desc bindingSig :=
 /-- The binding fragment's grammar. -/
 def bindingGrammar : Grammar bindingSig := [principleA, principleB]
 
-/-! ### Worked model: *Mary likes herself* (grammatical) -/
+/-! ### Worked models
 
-/-- Entities of *Mary likes herself*: the verb sign, the subject (`mary`, an `npro`), the
-object (`herself`, an `ana`), and one shared index `i`. -/
-inductive GEnt | s | mary | herself | i deriving DecidableEq, Fintype, Repr
+One transitive-clause carrier and one builder `clause`; the three binding configurations are
+instantiations differing only in the object's sort and index. -/
 
-/-- *Mary likes herself*: `mary` and `herself` share the index `i` (coindexed), and `mary`
-locally o-commands `herself` (it is less oblique). -/
-def maryLikesHerself : Interpretation bindingSig where
-  U := GEnt
+/-- Entities of a transitive clause: the verb sign, subject, object, and two indices. -/
+inductive BindEnt | s | subj | obj | i1 | i2 deriving DecidableEq, Fintype, Repr
+
+/-- A transitive clause "`subj` V `obj`": the subject is an `npro` indexed `i1` and locally
+o-commands the object; the object has sort `objSort` and index `objIdx`. Coindexation is
+`objIdx = i1`. -/
+@[reducible] def clause (objSort : BSort) (objIdx : BindEnt) : Interpretation bindingSig where
+  U := BindEnt
   S := fun
     | .s => .sign
-    | .mary => .npro
-    | .herself => .ana
-    | .i => .idx
+    | .subj => .npro
+    | .obj => objSort
+    | .i1 => .idx
+    | .i2 => .idx
   A := fun a u => match a, u with
-    | .SUBJ, .s => some .mary
-    | .OBJ, .s => some .herself
-    | .IDX, .mary => some .i
-    | .IDX, .herself => some .i
+    | .SUBJ, .s => some .subj
+    | .OBJ, .s => some .obj
+    | .IDX, .subj => some .i1
+    | .IDX, .obj => some objIdx
     | _, _ => none
-  R := fun _ args => args = [GEnt.mary, GEnt.herself]
+  R := fun _ args => args = [BindEnt.subj, BindEnt.obj]
 
-instance : Fintype maryLikesHerself.U := inferInstanceAs (Fintype GEnt)
-instance : DecidableEq maryLikesHerself.U := inferInstanceAs (DecidableEq GEnt)
-instance (ρ : bindingSig.Rel) : DecidablePred (maryLikesHerself.R ρ) :=
-  fun args => inferInstanceAs (Decidable (args = [GEnt.mary, GEnt.herself]))
+instance (objSort : BSort) (objIdx : BindEnt) (ρ : bindingSig.Rel) :
+    DecidablePred ((clause objSort objIdx).R ρ) :=
+  fun args => inferInstanceAs (Decidable (args = [BindEnt.subj, BindEnt.obj]))
 
-/-- *Mary likes herself* satisfies Principle A: `herself` (an anaphor) is locally o-commanded
-by `mary`, and `mary` locally o-binds it (coindexed via the shared index `i`). -/
-example : maryLikesHerself.Models [principleA] := by decide
+/-- *Mary likes herself*: a coindexed anaphor object (`objIdx = i1`) is locally o-bound by the
+subject — Principle A satisfied, and the whole grammar (Principle B vacuous: no pronoun). -/
+example : (clause .ana .i1).Models bindingGrammar := by decide
 
-/-- It also satisfies the whole binding grammar (Principle B is vacuous: no pronoun). -/
-example : maryLikesHerself.Models bindingGrammar := by decide
+/-- *Mary likes himself* (gender clash): the anaphor object has a *distinct* index (`i2`), so it
+is locally o-commanded but not locally o-bound — Principle A violated (a genuine filter). -/
+example : ¬ (clause .ana .i2).Models [principleA] := by decide
 
-/-! ### Worked model: *Mary likes himself* (gender clash — Principle A violated) -/
-
-/-- Entities with two *distinct* indices `iM`, `iH`: `mary` and `himself` are not coindexed. -/
-inductive HEnt | s | mary | himself | iM | iH deriving DecidableEq, Fintype, Repr
-
-/-- *Mary likes himself*: `mary` locally o-commands the anaphor `himself`, but their indices
-differ (gender clash), so `himself` is not locally o-bound — Principle A is violated. -/
-def maryLikesHimself : Interpretation bindingSig where
-  U := HEnt
-  S := fun
-    | .s => .sign
-    | .mary => .npro
-    | .himself => .ana
-    | .iM => .idx
-    | .iH => .idx
-  A := fun a u => match a, u with
-    | .SUBJ, .s => some .mary
-    | .OBJ, .s => some .himself
-    | .IDX, .mary => some .iM
-    | .IDX, .himself => some .iH
-    | _, _ => none
-  R := fun _ args => args = [HEnt.mary, HEnt.himself]
-
-instance : Fintype maryLikesHimself.U := inferInstanceAs (Fintype HEnt)
-instance : DecidableEq maryLikesHimself.U := inferInstanceAs (DecidableEq HEnt)
-instance (ρ : bindingSig.Rel) : DecidablePred (maryLikesHimself.R ρ) :=
-  fun args => inferInstanceAs (Decidable (args = [HEnt.mary, HEnt.himself]))
-
-/-- *Mary likes himself* violates Principle A — a genuine filter, not vacuously satisfied. -/
-example : ¬ maryLikesHimself.Models [principleA] := by decide
-
-/-! ### Worked model: *Mary likes her* coindexed (Principle B violated) -/
-
-/-- Entities with `her` a personal pronoun (`ppro`) sharing the index `i` with `mary`. -/
-inductive PEnt | s | mary | her | i deriving DecidableEq, Fintype, Repr
-
-/-- *Mary likes her_i* with `her` coindexed with `mary`: `mary` locally o-binds the pronoun
-`her`, so `her` is not locally o-free — Principle B is violated. -/
-def maryLikesHer : Interpretation bindingSig where
-  U := PEnt
-  S := fun
-    | .s => .sign
-    | .mary => .npro
-    | .her => .ppro
-    | .i => .idx
-  A := fun a u => match a, u with
-    | .SUBJ, .s => some .mary
-    | .OBJ, .s => some .her
-    | .IDX, .mary => some .i
-    | .IDX, .her => some .i
-    | _, _ => none
-  R := fun _ args => args = [PEnt.mary, PEnt.her]
-
-instance : Fintype maryLikesHer.U := inferInstanceAs (Fintype PEnt)
-instance : DecidableEq maryLikesHer.U := inferInstanceAs (DecidableEq PEnt)
-instance (ρ : bindingSig.Rel) : DecidablePred (maryLikesHer.R ρ) :=
-  fun args => inferInstanceAs (Decidable (args = [PEnt.mary, PEnt.her]))
-
-/-- A coindexed pronoun violates Principle B. -/
-example : ¬ maryLikesHer.Models [principleB] := by decide
+/-- *Mary likes her_i* coindexed: a coindexed pronoun object is locally o-bound, so not locally
+o-free — Principle B violated. -/
+example : ¬ (clause .ppro .i1).Models [principleB] := by decide
 
 end HPSG.RSRL.Binding

--- a/Linglib/Syntax/HPSG/Description.lean
+++ b/Linglib/Syntax/HPSG/Description.lean
@@ -5,32 +5,14 @@ import Mathlib.Data.Fintype.Basic
 # RSRL descriptions
 @cite{richter-2000}, @cite{richter-2024}
 
-A native Lean rendering of the **description language** of RSRL — the formulae that state the
-principles of an HPSG grammar (@cite{richter-2000}, Def. 54; satisfaction is Def. 58;
-@cite{richter-2024}, Ch. 3 §2). This now includes **relational formulae** and **component
-quantification** (∃/∀ over the components of the described entity), the features that make RSRL
-strictly richer than first-order logic. Chains (list-valued *relation arguments*, Def. 49–50)
-remain deferred.
+The **description language** of RSRL — the formulae stating an HPSG grammar's principles (Def.
+54; satisfaction Def. 58). Includes relational formulae and **component quantification** (∃/∀
+over the components of the described entity), the features making RSRL richer than FOL. Chains
+(list-valued relation arguments, Def. 49–50) are deferred.
 
-## Main declarations
-
-* `HPSG.RSRL.Desc` — descriptions over `Term`s (with variables): `sortAssign` (`τ ~ σ`),
-  `pathEq` (`τ₁ ≈ τ₂`, token identity), `rel` (relational formula `ρ(τ₁,…)`), `neg`/`and`/
-  `or`/`imp`, and `ex`/`all` (component quantification).
-* `HPSG.RSRL.Interpretation.satisfies` — satisfaction under a variable assignment
-  (@cite{richter-2000}, Def. 58). `ex`/`all` quantify over `IsComponentOf u` — RSRL's bounded
-  (component) quantification, *not* the whole universe. Decidable on finite models.
-* `HPSG.RSRL.Grammar` / `Interpretation.Models` — a grammar's principles; a model satisfies
-  every (variable-free) principle of every entity.
-
-## Implementation notes
-
-* `ex`/`all` are **component-bounded** (`I.IsComponentOf u w`, i.e. `w` reachable from `u` by
-  attributes). On finite models this is decidable (`Interpretation.lean`), so `∃`-quantified
-  worked examples reduce by `decide`. Universal component quantification (`all`) is decidable
-  too, but `decide` on it can be kernel-heavy; such principles are better checked structurally.
-* `Models` evaluates principles under the assignment `fun _ => u`; grammar descriptions are
-  variable-free (Def. 54), so the choice of assignment is irrelevant.
+`ex`/`all` are bounded by `IsComponentOf` (reachability by attributes), decidable on finite
+models, so `∃`-worked examples reduce by `decide`. `Models` evaluates the (variable-free)
+principles under the assignment `fun _ => u`.
 -/
 
 namespace HPSG.RSRL

--- a/Linglib/Syntax/HPSG/Interpretation.lean
+++ b/Linglib/Syntax/HPSG/Interpretation.lean
@@ -7,95 +7,62 @@ import Linglib.Core.Relation.ReflTransGen
 # RSRL interpretations
 @cite{richter-2000}, @cite{richter-2024}
 
-A native Lean rendering of an RSRL **interpretation** of a `Signature`
-(@cite{richter-2000}, Def. 48): a universe of entities `U`, a species assignment `S`, an
-attribute interpretation `A` (each attribute a *partial* function on entities), and a
-relation interpretation `R`.
-
-## Main declarations
-
-* `HPSG.RSRL.Interpretation` — the structure `⟨U, S, A, R⟩` (Def. 48).
-* `HPSG.RSRL.Interpretation.denot` — term/path denotation (Def. 53): follow each attribute of
-  a path in turn, partially (`Option`-Kleisli composition).
-* `HPSG.RSRL.Interpretation.WellTyped` — the totally-well-typed, sort-resolved condition a
-  model must satisfy (Def. 48), as a `structure` with named fields.
-
-## Implementation notes
-
-* Attributes are interpreted as `A : Attr → U → Option U` (partial functions, Def. 48), via
-  `Option`, so denotation and well-typedness reduce by `decide` on finite models.
-* `WellTyped.appropSort` uses `Option` membership (`∀ τ ∈ Sig.approp …`) rather than a
-  `Fintype`-search over all sorts for the one appropriate value.
-* `R` is carried for faithfulness to Def. 48 but unused until the description language gains
-  relational formulae (RSRL is strictly richer than first-order logic).
-* `U` shares the signature's universe; full universe polymorphism is deferred.
+An RSRL **interpretation** of a `Signature` (Def. 48): a universe `U`, a species assignment
+`S`, partial attribute functions `A`, and a relation interpretation `R`. `WellTyped` is the
+totally-well-typed, sort-resolved condition a model must meet. `ex`/`all` quantification ranges
+over the components of an entity (`IsComponentOf`).
 -/
 
 namespace HPSG.RSRL
 
 universe u
 
+-- TODO: generalise `U : Type v` (currently tied to the signature's universe `u`).
 /-- An RSRL interpretation of a signature (@cite{richter-2000}, Def. 48). -/
 structure Interpretation {Srt : Type u} [PartialOrder Srt] (Sig : Signature Srt) where
-  /-- The universe of entities `U`. -/
+  /-- The universe of entities. -/
   U : Type u
-  /-- The species assignment `S` — every entity has a (maximally specific) sort. -/
+  /-- Species assignment — every entity has a (maximally specific) sort. -/
   S : U → Srt
-  /-- The attribute interpretation `A`: each attribute a partial function on entities. -/
+  /-- Attribute interpretation: each attribute a partial function on entities. -/
   A : Sig.Attr → U → Option U
-  /-- The relation interpretation `R` (unused until relational formulae are added). -/
+  /-- Relation interpretation. -/
   R : Sig.Rel → Set (List U)
 
 namespace Interpretation
 
 variable {Srt : Type u} [PartialOrder Srt] {Sig : Signature Srt}
 
-/-- Path denotation (@cite{richter-2000}, Def. 53): the empty path denotes the entity itself;
-`α :: rest` follows attribute `α` (partially) and then the rest of the path. -/
-def denot (I : Interpretation Sig) : Path Sig → I.U → Option I.U
-  | [], u => some u
-  | a :: rest, u => (I.A a u).bind (denot I rest)
-
-@[simp] theorem denot_nil (I : Interpretation Sig) (u : I.U) : I.denot [] u = some u := rfl
-
-@[simp] theorem denot_cons (I : Interpretation Sig) (a : Sig.Attr) (rest : Path Sig)
-    (u : I.U) : I.denot (a :: rest) u = (I.A a u).bind (denot I rest) := rfl
-
-/-- Term denotation under a variable assignment (@cite{richter-2000}, Def. 53): `colon`
-denotes the described entity `u`, `var n` the assigned entity `ass n`, and `feat t α` follows
-attribute `α` (partially) from `t`'s denotation. -/
+/-- Term denotation under an assignment (Def. 53): `colon ↦ u`, `var n ↦ ass n` (the anchor `u`
+is intentionally ignored for variables), `feat t α ↦` follow `α` from `t`. -/
 def termDenot (I : Interpretation Sig) (ass : Nat → I.U) : Term Sig → I.U → Option I.U
   | .colon, u => some u
   | .var n, _ => some (ass n)
   | .feat t a, u => (termDenot I ass t u).bind (I.A a)
 
-/-- The attribute-successor relation: `y` is an attribute value of `x`. Its
-reflexive-transitive closure is the *component-of* relation that bounds quantification. -/
+/-- `y` is an attribute value of `x`; its reflexive-transitive closure is `IsComponentOf`. -/
 def attrSucc (I : Interpretation Sig) (x y : I.U) : Prop := ∃ α : Sig.Attr, I.A α x = some y
 
 instance (I : Interpretation Sig) [Fintype Sig.Attr] [DecidableEq I.U] :
     DecidableRel I.attrSucc := fun _ _ => by unfold attrSucc; infer_instance
 
-/-- `v` is a **component of** `u` — reachable from `u` by following attributes (reflexively).
-RSRL component quantification ranges over exactly these (@cite{richter-2024}, Ch. 3). -/
+/-- `v` is a **component of** `u` — reachable from `u` by following attributes. RSRL bounds
+quantification to these (@cite{richter-2024}, Ch. 3). -/
 abbrev IsComponentOf (I : Interpretation Sig) (u v : I.U) : Prop :=
   Relation.ReflTransGen I.attrSucc u v
 
-/-- Component-of is decidable on a finite interpretation (so `∃`-component quantification
-reduces by `decide`). Reuses the finite-carrier reachability decision procedure. -/
 instance (I : Interpretation Sig) [Fintype I.U] [DecidableEq I.U] [Fintype Sig.Attr]
     (u v : I.U) : Decidable (I.IsComponentOf u v) :=
   Relation.ReflTransGen.decidable_of_fintype u v
 
-/-- The totally-well-typed, sort-resolved condition on a model (@cite{richter-2000}, Def. 48):
-the species assignment lands in species, and every attribute is defined exactly on the
-entities whose species licenses it, with an appropriately-specific value. -/
+/-- Totally-well-typed, sort-resolved (Def. 48): `S` species-valued, and `A` defined exactly
+where appropriate, with appropriate value sorts. -/
 structure WellTyped (I : Interpretation Sig) : Prop where
-  /-- Every entity's sort is a species (maximally specific). -/
+  /-- Every entity's sort is a species. -/
   species : ∀ u, IsSpecies (I.S u)
-  /-- An attribute is defined on an entity exactly when appropriate to its species. -/
+  /-- An attribute is defined exactly when appropriate to the entity's species. -/
   appropDefined : ∀ (α : Sig.Attr) (u : I.U), (I.A α u).isSome = (Sig.approp (I.S u) α).isSome
-  /-- A defined attribute value's sort is at least as specific as the appropriate value sort. -/
+  /-- A defined value's sort is at least as specific as the appropriate value sort. -/
   appropSort : ∀ (α : Sig.Attr) (u v : I.U), I.A α u = some v →
     ∀ τ ∈ Sig.approp (I.S u) α, I.S v ≤ τ
 

--- a/Linglib/Syntax/HPSG/Model.lean
+++ b/Linglib/Syntax/HPSG/Model.lean
@@ -5,41 +5,16 @@ import Linglib.Syntax.HPSG.Basic
 # A worked HPSG signature, the Head Feature Principle, and a computational bridge
 @cite{richter-2000}, @cite{richter-2024}, @cite{pollard-sag-1994}
 
-A small HPSG signature fragment in the RSRL substrate (`Signature.lean`, `Interpretation.lean`,
-`Description.lean`), the **Head Feature Principle** as a description, worked head-complement
-models showing the principle is a genuine constraint (one satisfying, one violating it), and a
-lemma relating the project's *computational* HPSG core (`HPSG.HeadCompRule.hfp`) to a sort-level
-description in the induced model — a deliberately partial bridge (the grammar's HFP is token
-identity, which value equality does not entail; see below).
+A minimal HPSG signature fragment over the RSRL substrate, the **Head Feature Principle** as a
+description, two worked head-complement models (one satisfying, one violating the HFP) showing
+the principle genuinely filters, and a deliberately partial bridge from the project's
+*computational* HPSG core (`HPSG.HeadCompRule.hfp`) to a sort-agreement description.
 
-## Main declarations
-
-* `HPSG.RSRL.hpsgSig` — a minimal HPSG signature over the sort hierarchy `HSort`, with
-  attributes `CAT`/`HD` and appropriateness `happrop`.
-* `HPSG.RSRL.hfp` / `hpsgGrammar` — the Head Feature Principle and the one-principle grammar.
-* `HPSG.RSRL.posModel` / `negModel` — head-complement structures that satisfy / violate the
-  HFP (both well-typed): the principle filters.
-* `HPSG.RSRL.toInterp_categoryAgreement_of_hfp` — from the computational `HeadCompRule.hfp`, the
-  induced model satisfies a category sort-agreement description (strictly weaker than the
-  grammar's token-identity HFP; see Implementation notes).
-
-## Implementation notes
-
-* **Granularity.** The canonical HFP (@cite{pollard-sag-1994}; @cite{richter-2024}, Ch. 3, (3a))
-  shares the **HEAD** value along `SYNSEM|LOC|CAT|HEAD` and is **token identity**. PR1 works at
-  the **CAT** granularity along a flattened `CAT`/`HD` path, because that is what the project's
-  computational `HPSG.HeadCompRule.hfp` (`result.synsem.cat = head.synsem.cat`) exposes; the
-  worked models still use token identity (`pathEq`). Note CAT-sharing is a valence-free
-  *fragment stand-in*, not a faithful coarsening: full CAT contains the valence features, so
-  sharing all of CAT mother-to-head would wrongly force valence identity (the Valence
-  Principle's job). The fragment has no valence attribute, so nothing breaks here; refining to
-  the HEAD value under the full feature geometry is later work.
-* **The computational bridge is partial.** `toInterp_categoryAgreement_of_hfp` reflects the
-  value-equality `HeadCompRule.hfp` only as a sort-agreement, not as the grammar's
-  token-identity `pathEq` HFP — value equality and token identity are genuinely different
-  notions. A faithful bridge is deferred (see that theorem's docstring).
-* Only `hpsgSig` is `@[reducible]` (so its projections resolve in instance search); the models
-  are plain `def`s, and the `decide`-checked examples expose their carriers with `unfold`.
+The HFP here works at **CAT** granularity (what `HeadCompRule.hfp` exposes), a valence-free
+stand-in for the canonical **HEAD**-value sharing (@cite{pollard-sag-1994}). The bridge is
+partial: `HeadCompRule.hfp` is value equality, the grammar's `pathEq` HFP is token identity —
+genuinely different notions, so the bridge proves only sort-agreement (see that theorem). Only
+`hpsgSig` is `@[reducible]`; the models are plain `def`s with explicit carrier instances.
 -/
 
 namespace HPSG.RSRL
@@ -70,17 +45,9 @@ def hleB : HSort → HSort → Bool
   | .otherCat, .category => true
   | a, b => decide (a = b)
 
-private theorem hleB_refl : ∀ a, hleB a a = true := by decide
-private theorem hleB_trans :
-    ∀ a b c, hleB a b = true → hleB b c = true → hleB a c = true := by decide
-private theorem hleB_antisymm : ∀ a b, hleB a b = true → hleB b a = true → a = b := by decide
-
 /-- The sort hierarchy as a `PartialOrder` (`a ≤ b` = "`a` at least as specific as `b`"). -/
-instance : PartialOrder HSort where
-  le a b := hleB a b = true
-  le_refl := hleB_refl
-  le_trans := hleB_trans
-  le_antisymm := hleB_antisymm
+instance : PartialOrder HSort :=
+  partialOrderOfBool hleB (by decide) (by decide) (by decide)
 
 instance : DecidableLE HSort := fun a b => inferInstanceAs (Decidable (hleB a b = true))
 

--- a/Linglib/Syntax/HPSG/Signature.lean
+++ b/Linglib/Syntax/HPSG/Signature.lean
@@ -5,91 +5,65 @@ import Mathlib.Order.Max
 # RSRL signatures
 @cite{richter-2000}, @cite{richter-2024}, @cite{pollard-sag-1994}
 
-A native Lean rendering of an RSRL **signature** — the sort hierarchy and appropriateness
-declarations that fix the space of possible feature structures of an HPSG grammar
-(@cite{richter-2000}, Def. 47; @cite{richter-2024}, Ch. 3 §2).
-
-HPSG since @cite{pollard-sag-1994} is **model-theoretic**: a grammar is a signature plus a
-set of descriptions (its principles), and its meaning is the class of total, sort-resolved
-objects satisfying every principle. This file provides the signature; `Interpretation.lean`
-the models, `Description.lean` the description language, `Model.lean` a worked instantiation.
-
-## Main declarations
-
-* `HPSG.RSRL.Signature` — over a sort hierarchy `Srt` (a mathlib `PartialOrder`; `a ≤ b` reads
-  "`a` is at least as specific as `b`", so species are the *minimal* sorts) it carries the
-  attributes, relation symbols with arities, and the appropriateness function with feature
-  inheritance.
-* `HPSG.RSRL.IsSpecies` — a maximally specific sort, i.e. `IsMin` in the specificity order.
-* `HPSG.RSRL.Signature.IsAtomicSort` — a species with no appropriate attributes.
-* `HPSG.RSRL.Path` — a `:`-rooted attribute path (the variable-free fragment of RSRL terms,
-  Def. 52).
-
-## Implementation notes
-
-* The sort hierarchy is a genuine `[PartialOrder Srt]` (RSRL's `⊑`); `IsSpecies := IsMin`.
-* The chain/relation/quantifier apparatus of full RSRL is not yet modelled (RSRL is strictly
-  richer than first-order logic — @cite{richter-2024}, Ch. 3); `Rel`/`arity` are carried for
-  signature completeness but unused until a principle needs relations.
+An RSRL **signature** (Def. 47): a sort hierarchy `[PartialOrder Srt]` (`a ≤ b` = "`a` at least
+as specific as `b`") with appropriateness declarations and relation symbols. The
+model-theoretic foundation of HPSG (Pollard & Sag 1994 onward); `Interpretation.lean` gives the
+models, `Description.lean` the description language.
 -/
 
 namespace HPSG.RSRL
 
 universe u
 
-/-- An RSRL signature (@cite{richter-2000}, Def. 47) over a sort hierarchy `Srt`: the sorts
-form a `PartialOrder` (subsumption `⊑`, here `≤`), and the signature adds attributes, relation
-symbols with arities, and an appropriateness function obeying feature inheritance. -/
+/-- Build a `PartialOrder` from a decidable boolean order whose laws hold (typically `by decide`
+on a finite type). Reducible so `≤` unfolds to `leB · · = true` in instance search. -/
+@[reducible] def partialOrderOfBool {α : Type u} (leB : α → α → Bool)
+    (le_refl : ∀ a, leB a a = true)
+    (le_trans : ∀ a b c, leB a b = true → leB b c = true → leB a c = true)
+    (le_antisymm : ∀ a b, leB a b = true → leB b a = true → a = b) : PartialOrder α where
+  le a b := leB a b = true
+  le_refl := le_refl
+  le_trans := le_trans
+  le_antisymm := le_antisymm
+
+/-- An RSRL signature (@cite{richter-2000}, Def. 47) over a sort hierarchy `Srt`. -/
 structure Signature (Srt : Type u) [PartialOrder Srt] where
-  /-- The attributes `𝒜` (feature names). -/
+  /-- Attributes (feature names). -/
   Attr : Type u
-  /-- The relation symbols `ℛ` (carried but unused until a principle needs relations). -/
+  /-- Relation symbols (unused until a principle needs relations). -/
   Rel : Type u
-  /-- Relation arities `𝒜ℛ`. -/
+  /-- Relation arities. -/
   arity : Rel → Nat
-  /-- Appropriateness `ℱ`: `approp σ α = some τ` means `α` is appropriate to `σ` with value
-  sort `τ`; `none` means `α` is not appropriate to `σ`. -/
+  /-- Appropriateness: `approp σ α = some τ` means `α` is appropriate to `σ` with value sort `τ`. -/
   approp : Srt → Attr → Option Srt
-  /-- Feature inheritance (@cite{richter-2000}, Def. 47): if `α` is appropriate to `σ₁` and
-  `σ₂` is at least as specific as `σ₁`, then `α` is appropriate to `σ₂` with an
-  at-least-as-specific value. -/
+  /-- Feature inheritance: a more specific sort inherits appropriateness with an at-least-as-
+  specific value. -/
   approp_inherits : ∀ {σ₁ σ₂ : Srt} {α : Attr} {τ₁ : Srt},
     σ₂ ≤ σ₁ → approp σ₁ α = some τ₁ → ∃ τ₂, approp σ₂ α = some τ₂ ∧ τ₂ ≤ τ₁
 
-/-- A **species** is a maximally specific sort (@cite{richter-2000}, Def. 47): a minimal
-element of the specificity order `≤`. -/
+/-- A **species** is a maximally specific sort — minimal in the specificity order. -/
 abbrev IsSpecies {Srt : Type u} [PartialOrder Srt] (σ : Srt) : Prop := IsMin σ
 
-namespace Signature
+/-- An **atomic** sort: a species with no appropriate attributes. (Distinct from `IsAtom`.) -/
+def Signature.IsAtomicSort {Srt : Type u} [PartialOrder Srt] (Sig : Signature Srt) (σ : Srt) :
+    Prop := IsMin σ ∧ ∀ α, Sig.approp σ α = none
 
-variable {Srt : Type u} [PartialOrder Srt] (Sig : Signature Srt)
-
-/-- An **atomic** sort: a species with no appropriate attributes. (Named `IsAtomicSort` to
-avoid colliding with mathlib's order-theoretic `IsAtom`.) -/
-def IsAtomicSort (σ : Srt) : Prop := IsMin σ ∧ ∀ α, Sig.approp σ α = none
-
-end Signature
-
-/-- A `:`-rooted attribute **path** (the variable-free fragment of RSRL terms,
-@cite{richter-2000}, Def. 52): `[]` denotes the described entity itself, and `α :: p` follows
-attribute `α` and then the rest of the path. -/
+/-- A `:`-rooted attribute **path** (Def. 52, variable-free fragment): `[]` is the described
+entity, `α :: p` follows `α` then the rest. -/
 abbrev Path {Srt : Type u} [PartialOrder Srt] (Sig : Signature Srt) := List Sig.Attr
 
-/-- An RSRL **term** (@cite{richter-2000}, Def. 52): rooted at either the described entity
-(`colon`, the reserved `:`) or a variable (`var n`), then extended by attributes (`feat t α`).
-Variables are needed for relational formulae and component quantification (Def. 54). -/
+/-- An RSRL **term** (Def. 52): rooted at the described entity (`colon`) or a variable (`var n`),
+extended by attributes (`feat t α`). Variables support relations and quantification. -/
 inductive Term {Srt : Type u} [PartialOrder Srt] (Sig : Signature Srt) where
-  /-- The described entity itself (RSRL `:`). -/
+  /-- The described entity (RSRL `:`). -/
   | colon : Term Sig
-  /-- A variable (de Bruijn-free; `n : ℕ` names it). -/
+  /-- A variable. -/
   | var : Nat → Term Sig
-  /-- Follow attribute `α` from the term `t` (RSRL `tα`). -/
+  /-- Follow attribute `α` from `t` (RSRL `tα`). -/
   | feat : Term Sig → Sig.Attr → Term Sig
 
-/-- The `:`-rooted term following a path of attributes — bridges the PR1 `Path` notation
-(`[α, β]`) into the term language: `Term.path [α, β] = (colon.feat α).feat β`. -/
-def Term.path {Srt : Type u} [PartialOrder Srt] {Sig : Signature Srt}
-    (p : Path Sig) : Term Sig :=
+/-- The `:`-rooted term following a path: `Term.path [α, β] = (colon.feat α).feat β`. -/
+def Term.path {Srt : Type u} [PartialOrder Srt] {Sig : Signature Srt} (p : Path Sig) : Term Sig :=
   p.foldl Term.feat Term.colon
 
 end HPSG.RSRL


### PR DESCRIPTION
Post-merge cleanup of the RSRL/HPSG slice (#49, #51): drop dead `denot`, dedup the three binding worked-models behind one `BindEnt` carrier + `clause` builder, factor the sort-order skeleton into a `partialOrderOfBool` combinator, and trim docstrings to mathlib brevity. No behavior change; net −187 lines.