### PR TITLE
fix(Typology/Phonology): attribute WALS Ch 10 to Hajek

### DIFF
--- a/Linglib/Typology/Phonology.lean
+++ b/Linglib/Typology/Phonology.lean
@@ -21,7 +21,7 @@ import Linglib.Data.WALS.Features.F19A
 
 /-!
 # Phonological typology — WALS substrate (Chapters 1–19)
-@cite{dryer-haspelmath-2013} @cite{maddieson-2013} @cite{goedemans-van-der-hulst-2013}
+@cite{dryer-haspelmath-2013} @cite{maddieson-2013} @cite{hajek-2013} @cite{goedemans-van-der-hulst-2013}
 
 Theory-neutral phonological-typology substrate distilled from WALS Chapters
 1–19, in the same `Linglib/Typology/{Domain}.lean` mould as `Case.lean`,
@@ -34,7 +34,8 @@ The 19 chapters are NOT all by Maddieson — the file's previous incarnation
 (`Phenomena/Phonology/Typology.lean`) cited only `@cite{maddieson-2013}`,
 which is an attribution error. Correct split:
 
-- **Chs 1–13, 18–19**: Maddieson 2013 (segmental inventory + tone)
+- **Chs 1–9, 11–13, 18–19**: Maddieson 2013 (segmental inventory + tone)
+- **Ch 10 (10A, 10B)**: Hajek 2013 (vowel nasalization, incl. West Africa)
 - **Chs 14–17**: Goedemans & van der Hulst 2013 (stress location, weight-
   sensitivity, weight factors, rhythm). Different framework: StressTyp
   database, presupposes a metrical-grid view where every word has a
@@ -162,7 +163,7 @@ inductive VelarNasalStatus where
   deriving DecidableEq, Repr
 
 /-- Nasal vowel contrast type in West Africa (WALS Ch 10B,
-    @cite{maddieson-2013}). Areal sub-feature of Ch 10A. -/
+    @cite{hajek-2013}). Areal sub-feature of Ch 10A. -/
 inductive NasalVowelWA where
   | noContrast
   | twoWayNoSpreading | twoWaySpreading

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -27018,13 +27018,45 @@
 @incollection{goedemans-van-der-hulst-2013,
   author    = {Goedemans, Rob and van der Hulst, Harry},
   year      = {2013},
-  title     = {Fixed Stress Locations / Weight-Sensitive Stress / Weight Factors / Rhythm Types},
+  title     = {Stress location, weight-sensitivity, and rhythm (WALS chapters 14–17)},
   editor    = {Dryer, Matthew S. and Haspelmath, Martin},
   booktitle = {The World Atlas of Language Structures Online (v2020.4)},
   publisher = {Max Planck Institute for Evolutionary Anthropology},
   address   = {Leipzig},
   url       = {https://wals.info/chapter/14},
   subfield  = {phonology/stress-typology},
+  role      = {data},
+  validated = {true},
+  sources   = {Linglib/Typology/Phonology.lean}
+}
+
+% WALS phonology chapters by Ian Maddieson (segmental inventory + tone) and
+% John Hajek (vowel nasalization). Anchor: Linglib/Typology/Phonology.lean.
+@incollection{maddieson-2013,
+  author    = {Maddieson, Ian},
+  year      = {2013},
+  title     = {Phonological inventory and tone features (WALS chapters 1–9, 11–13, 18–19)},
+  editor    = {Dryer, Matthew S. and Haspelmath, Martin},
+  booktitle = {The World Atlas of Language Structures Online (v2020.4)},
+  publisher = {Max Planck Institute for Evolutionary Anthropology},
+  address   = {Leipzig},
+  url       = {https://wals.info/chapter/1},
+  subfield  = {phonology/segmental-typology},
+  role      = {data},
+  validated = {true},
+  sources   = {Linglib/Typology/Phonology.lean}
+}
+
+@incollection{hajek-2013,
+  author    = {Hajek, John},
+  year      = {2013},
+  title     = {Vowel nasalization (WALS chapters 10A, 10B)},
+  editor    = {Dryer, Matthew S. and Haspelmath, Martin},
+  booktitle = {The World Atlas of Language Structures Online (v2020.4)},
+  publisher = {Max Planck Institute for Evolutionary Anthropology},
+  address   = {Leipzig},
+  url       = {https://wals.info/chapter/10},
+  subfield  = {phonology/nasalization},
   role      = {data},
   validated = {true},
   sources   = {Linglib/Typology/Phonology.lean}


### PR DESCRIPTION
WALS Ch 10 (Vowel Nasalization, features 10A/10B) is by Hajek, not Maddieson — corrects the attribution in `Typology/Phonology.lean` and adds the missing `maddieson-2013` and `hajek-2013` WALS bib entries (the 17 dangling `@cite{maddieson-2013}` references now resolve).