### PR TITLE
refactor(Core): split Valence out of Word, off the Core.UD closure

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -7,6 +7,7 @@ and their interfaces. See README.md for documentation links.
 -- Core
 import Linglib.Features.Dimension
 import Linglib.Features.Gender
+import Linglib.Core.Valence
 import Linglib.Core.Word
 import Linglib.Typology.PolarityItem
 import Linglib.Typology.Negation

--- a/Linglib/Core/Valence.lean
+++ b/Linglib/Core/Valence.lean
@@ -1,0 +1,20 @@
+/-!
+# Valence
+
+Transitivity / argument structure of a predicate — the one `Core/Word`
+morphological type with no Universal Dependencies equivalent. Extracted to its
+own light module so verb lexical entries (`Semantics/Lexical/VerbEntry`) can
+type argument structure without pulling the heavier `Core.Word` / `Core.UD`
+import closure.
+-/
+
+/-- Transitivity / argument structure. No direct UD equivalent. -/
+inductive Valence where
+  | intransitive  -- sleep, arrive
+  | transitive    -- see, eat
+  | ditransitive  -- give, send (double object)
+  | dative        -- give X to Y (prepositional dative)
+  | locative      -- put X on Y
+  | copular       -- be (takes predicate)
+  | clausal       -- manage to VP, believe that S (xcomp/ccomp complement)
+  deriving Repr, DecidableEq, Inhabited

--- a/Linglib/Core/Word.lean
+++ b/Linglib/Core/Word.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.UD
+import Linglib.Core.Valence
 
 /-!
 # Word
@@ -106,17 +107,6 @@ inductive MassCount where
   | mass   -- mass nouns: *mold*, *pollen*, *milk*, *gold*
   | count  -- count nouns: *spider*, *pollen grain*, *dog*, *cup*
   deriving Repr, DecidableEq, Hashable
-
-/-- Transitivity / argument structure. No direct UD equivalent. -/
-inductive Valence where
-  | intransitive  -- sleep, arrive
-  | transitive    -- see, eat
-  | ditransitive  -- give, send (double object)
-  | dative        -- give X to Y (prepositional dative)
-  | locative      -- put X on Y
-  | copular       -- be (takes predicate)
-  | clausal       -- manage to VP, believe that S (xcomp/ccomp complement)
-  deriving Repr, DecidableEq, Inhabited
 
 /-- Head direction of a syntactic construction.
     Used for word-order typology and

--- a/Linglib/Semantics/Lexical/VerbEntry.lean
+++ b/Linglib/Semantics/Lexical/VerbEntry.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.Valence
 import Linglib.Semantics.ArgumentStructure.EntailmentProfile
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Features.Aktionsart


### PR DESCRIPTION
Extracts `Valence` from `Core/Word.lean` into a light, import-free `Core/Valence.lean`, so verb lexical entries can type argument structure without pulling the heavy `Core.Word` → `Core.UD` closure. `VerbEntry` now imports `Core.Valence`; `Core.Word` imports it for its `Features` bundle.

Verified: all 28 `VerbEntry` importers compile unchanged (1880-job build) — none relied on VerbEntry's transitive `Core.Word` re-export beyond `Valence` — so they shed `Core.Word`/`Core.UD` from their closure.

Interim home: `Valence` belongs in `Features/` once `Word` moves to `Morphology/` in the Core dissolution (blocked until then, since `Core.Word` can't import `Features`).