### PR TITLE
refactor(Semantics/Lexical): evict postsupType, drop selectsDimension

### DIFF
--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -214,7 +214,6 @@ def weigh : VerbEntry := .mkRegular {
   form := "weigh"
   complementType := .np
   vendlerClass := some .state
-  selectsDimension := some .mass
   levinClass := some .measure }
 
 /-- "cover" — motion/extent predicate selecting for distance. -/
@@ -222,8 +221,7 @@ def cover : VerbEntry := .mkRegular {
   form := "cover"
   complementType := .np
   vendlerClass := some .accomplishment
-  verbIncClass := some .sinc
-  selectsDimension := some .distance }
+  verbIncClass := some .sinc }
 
 /-- "measure" — general measurement predicate. -/
 def measure : VerbEntry := .mkRegular {

--- a/Linglib/Fragments/Mandarin/Predicates.lean
+++ b/Linglib/Fragments/Mandarin/Predicates.lean
@@ -55,33 +55,17 @@ def haipa : MandarinVerbEntry := .mk' {
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .negative)) }
 
-/-!
-## yǐwéi: Postsupposition via `postsupType`
+/-- 以为 "yǐwéi" — be under the impression that.
 
-yǐwéi "be under the impression" has a POSTSUPPOSITION
-(output-context constraint) that ¬p is compatible with the Common Ground
-after the utterance. This is NOT a presupposition and cannot be derived
-from veridicality alone (@cite{glass-2025}, @cite{glass-2023}).
-
-Encoded structurally as `postsupType := some .weakContrafactive` in VerbCore,
-formalized as `Semantics.Dynamic.Postsupposition.weakContrafactive`, and exercised in
-`Glass2025`.
--/
-
-/-- 以为 "yǐwéi" — be under the impression that (weak contrafactive).
-
-Has postsupposition ◇¬p (CommonGround compatible with ¬p after utterance).
-This cannot be derived from veridicality; see @cite{glass-2025} and @cite{glass-2023}.
-The postsupposition is recorded structurally via `postsupType` and exercised
-in `Glass2025`.
--/
+A nonveridical doxastic attitude. @cite{glass-2025} analyzes its weak
+contrafactive postsupposition (◇¬p, not derivable from veridicality alone);
+that paper-specific apparatus lives in `Glass2025`, not on this entry. -/
 def yiwei : MandarinVerbEntry := .mk' {
   form := "yiwei"
   complementType := .finiteClause
   passivizable := false
   opaqueContext := true
-  attitude := some (.doxastic .nonVeridical)
-  postsupType := some .weakContrafactive }
+  attitude := some (.doxastic .nonVeridical) }
 
 /-! ## Liu & Yip 2026 complement-taking predicates
 

--- a/Linglib/Semantics/Lexical/VerbEntry.lean
+++ b/Linglib/Semantics/Lexical/VerbEntry.lean
@@ -7,7 +7,6 @@ import Linglib.Features.Causation
 import Linglib.Semantics.Lexical.LevinClass
 import Linglib.Core.Logic.NaturalLogic
 import Linglib.Semantics.Aspect.ChangeOfState
-import Linglib.Features.Dimension
 import Linglib.Semantics.Causation.Implicative
 import Linglib.Semantics.ArgumentStructure.Linking
 import Linglib.Semantics.Causation.Psych
@@ -50,7 +49,6 @@ open Features
 open Semantics.Lexical
 open Semantics.Lexical.Roots
 open Features.ChangeOfState
-open Features.Dimension (Dimension)
 open Core.NaturalLogic (EntailmentSig)
 open Semantics.Causation.Psych (CausalSource)
 open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
@@ -100,24 +98,6 @@ def PresupTriggerType.isSoft : PresupTriggerType → Bool
   | .hardTrigger => false
   | .softTrigger => true
   | .prerequisiteSoft => true
-
-/--
-Postsupposition type: output-context constraint distinct from presuppositions.
-
-@cite{glass-2025} argues that Mandarin yǐwéi has a postsupposition ◇¬p —
-after accepting "x yǐwéi p", the CommonGround must be compatible with ¬p.
-This cannot be derived from veridicality alone.
-
-The concrete `Semantics.Dynamic.Postsupposition.Postsupposition W` is parameterized
-by the world type; this enum is the world-type-independent tag stored
-in `VerbCore`.
--/
-inductive PostsupType where
-  /-- Output context must be compatible with ¬p: ◇¬p (@cite{glass-2025}). -/
-  | weakContrafactive
-  /-- Output context must entail ¬p: ⊨¬p (hypothetical, UNATTESTED). -/
-  | strongContrafactive
-  deriving DecidableEq, Repr
 
 /--
 Complement presupposition projection behavior (@cite{karttunen-1973}).
@@ -301,16 +281,9 @@ structure VerbCore where
   verbIncClass : Option VerbIncClass := none
   /-- Is the verb a presupposition trigger? -/
   presupType : Option PresupTriggerType := none
-  /-- Output-context constraint (postsupposition), distinct from
-      presuppositions. @cite{glass-2025}: yǐwéi has ◇¬p postsupposition. -/
-  postsupType : Option PostsupType := none
   /-- How does the verb treat presuppositions of its complement?
       Orthogonal to `presupType`. @cite{karttunen-1973} -/
   projectionBehavior : Option ProjectionBehavior := none
-  /-- For measure predicates: which dimension this verb selects for.
-      Determines *per*-phrase interpretation:
-      simplex dimension → compositional, quotient → math speak. -/
-  selectsDimension : Option Dimension := none
 
   -- === Class-Specific Features ===
   /-- For CoS verbs: which type (cessation, inception, continuation)? -/
@@ -430,11 +403,6 @@ def VerbCore.presupposesComplement (v : VerbCore) : Bool :=
 /-- Is this verb a presupposition trigger? -/
 def VerbCore.isPresupTrigger (v : VerbCore) : Bool :=
   v.presupType.isSome
-
-/-- Does this verb have a postsupposition (output-context constraint)?
-    DERIVED from `postsupType`. -/
-def VerbCore.hasPostsupposition (v : VerbCore) : Bool :=
-  v.postsupType.isSome
 
 /-- Presupposition trigger type DERIVED from event structure rather than
     stipulated. @cite{roberts-simons-2024} argue that presupposition status

--- a/Linglib/Studies/Glass2025.lean
+++ b/Linglib/Studies/Glass2025.lean
@@ -259,12 +259,25 @@ theorem yiwei_veridicality_nonfactive :
 /-!
 yǐwéi is classified as nonfactive by veridicality (§4), but it has an
 additional postsupposition ◇¬p that is NOT derivable from veridicality.
-This postsupposition is flagged in the Fragment layer and interpreted here.
+Veridicality is a derivable property of the canonical Mandarin entry; the
+postsupposition is @cite{glass-2025}'s paper-specific overlay, recorded here
+in the study rather than as a field on the Fragment entry.
 -/
 
-/-- yǐwéi carries a weak contrafactive postsupposition structurally. -/
-theorem yiwei_has_postsupposition :
-    yiwei.toVerbCore.postsupType = some .weakContrafactive := by native_decide
+/-- Postsupposition type: output-context constraint distinct from
+    presuppositions (@cite{glass-2025}). The world-type-independent tag; the
+    concrete construct is `Semantics.Dynamic.Postsupposition`. -/
+inductive PostsupType where
+  /-- Output context must be compatible with ¬p: ◇¬p (@cite{glass-2025}). -/
+  | weakContrafactive
+  /-- Output context must entail ¬p: ⊨¬p (hypothetical, UNATTESTED). -/
+  | strongContrafactive
+  deriving DecidableEq, Repr
+
+/-- @cite{glass-2025} classifies yǐwéi as carrying a weak contrafactive
+    postsupposition. This is the paper's analytical claim about the canonical
+    Mandarin `yiwei` entry — not a field on that entry. -/
+def yiweiPostsupType : PostsupType := .weakContrafactive
 
 /-- yǐwéi's veridicality gives nonfactive — no presupposition. -/
 theorem yiwei_derived_nonfactive :
@@ -272,11 +285,13 @@ theorem yiwei_derived_nonfactive :
 
 /-- The postsupposition IS necessary: veridicality alone gives .nonfactive
     (no presupposition), but yǐwéi actually has a weak contrafactive
-    postsupposition. Without `postsupType`, this would be invisible. -/
+    postsupposition. Pairing the canonical entry's derivable veridicality with
+    Glass's postsupposition classification shows the two diverge — veridicality
+    is blind to the postsupposition. -/
 theorem yiwei_postsup_not_from_veridicality :
     yiwei.toVerbCore.veridicality.map classifyVeridicality = some .nonfactive ∧
-    yiwei.toVerbCore.postsupType = some .weakContrafactive :=
-  ⟨by native_decide, by native_decide⟩
+    yiweiPostsupType = .weakContrafactive :=
+  ⟨by native_decide, rfl⟩
 
 -- ============================================================================
 -- §6. The Contrafactive Gap


### PR DESCRIPTION
Slims the `VerbCore` god-record of two paper-specific fields. `selectsDimension` is dead (zero readers) and is deleted, along with VerbEntry's now-unused `Features.Dimension` import. `postsupType` is read only by Glass2025, so its enum + the yǐwéi classification move into `Studies/Glass2025.lean` (keeping the Mandarin Fragment theory-light); the dead `hasPostsupposition` accessor goes with it, and the tautological `yiwei_has_postsupposition` is dropped in favour of the veridicality-vs-postsupposition divergence theorem.