### PR TITLE
refactor(Semantics/Verb): decompose VerbCore into facets, move to Verb/

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -151,7 +151,8 @@ import Linglib.Features.Causation
 import Linglib.Semantics.Lexical.LevinClass
 import Linglib.Semantics.Lexical.MeaningComponents
 import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Defs
+import Linglib.Semantics.Verb.Basic
 import Linglib.Core.Logic.NaturalLogic
 import Linglib.Core.Constraint.Profile
 import Linglib.Core.Constraint.Weighted

--- a/Linglib/Fragments/Buryat/Complementizers.lean
+++ b/Linglib/Fragments/Buryat/Complementizers.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Buryat Complementizers and Clause-Embedding Verbs
@@ -51,7 +51,6 @@ The verbs that anchor Bondarenko's bare-vs-nominalized arguments:
 
 namespace Buryat.Complementizers
 
-open Semantics.Lexical (VerbCore)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Clause-typing morpheme inventory

--- a/Linglib/Fragments/English/Predicates.lean
+++ b/Linglib/Fragments/English/Predicates.lean
@@ -11,8 +11,8 @@ Re-exports verbal and adjectival predicate entries.
 namespace English.Predicates
 
 export Verbal (
-  -- Types
-  PresupTriggerType ComplementType ControlType VerbEntry
+  -- Types (PresupTriggerType/ComplementType/ControlType are root-namespace now)
+  VerbEntry
   Preferential
   -- Functions
   allVerbs

--- a/Linglib/Fragments/English/Predicates/Copular.lean
+++ b/Linglib/Fragments/English/Predicates/Copular.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Gradability.ClauseEmbedding
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # English Copular Predicate Fragment

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Causation.Interpretation
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 import Linglib.Morphology.MorphRule
 
 /-! # Verbal Predicate Lexicon Fragment
@@ -15,12 +15,10 @@ and provides smart constructors for regular verbs.
 
 namespace English.Predicates.Verbal
 
--- Re-export verb-entry vocabulary so downstream files that open this
--- namespace (e.g., `open English.Predicates.Verbal (ComplementType ...)`)
--- continue to find them.
+-- Re-export Features verb-entry vocabulary so downstream files that open this
+-- namespace continue to find it. The `VerbCore`/`ComplementType`/… types now
+-- live at the root namespace (`Semantics/Verb/Defs`), so they need no re-export.
 export Features (Preferential Attitude Causative Implicative)
-export Semantics.Lexical (PresupTriggerType ProjectionBehavior ComplementType
-  ControlType VerbCore ImplicitInterp complementToValence)
 
 open Features
 open Semantics.Lexical

--- a/Linglib/Fragments/French/Predicates.lean
+++ b/Linglib/Fragments/French/Predicates.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # French Predicate Lexicon Fragment

--- a/Linglib/Fragments/German/Predicates.lean
+++ b/Linglib/Fragments/German/Predicates.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 import Linglib.Morphology.RootTypology
 
 /-!

--- a/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Modern Greek Complementizers @cite{christidis-1982} @cite{roussou-2010}
@@ -36,7 +36,6 @@ fragment schema.
 
 namespace Greek.StandardModern.Complementizers
 
-open Semantics.Lexical (VerbCore)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Complementizer Inventory

--- a/Linglib/Fragments/Greek/StandardModern/MoodChoice.lean
+++ b/Linglib/Fragments/Greek/StandardModern/MoodChoice.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Greek Mood-Choice Verb Entries @cite{grano-2024}

--- a/Linglib/Fragments/Hausa/VerbGrades.lean
+++ b/Linglib/Fragments/Hausa/VerbGrades.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 import Linglib.Phonology.Autosegmental.RegisterTier
 
 /-!
@@ -36,7 +36,6 @@ Per-cell verifications appear as `example`s.
 namespace Hausa.VerbGrades
 
 open Phonology.Autosegmental.RegisterTier (TRN)
-open Semantics.Lexical (VerbCore VoiceType ComplementType)
 
 -- ============================================================================
 -- § 1: Form Inventory (A/B/C/D — @cite{newman-2000} §74.2)

--- a/Linglib/Fragments/Hungarian/Predicates.lean
+++ b/Linglib/Fragments/Hungarian/Predicates.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Hungarian Predicate Lexicon Fragment

--- a/Linglib/Fragments/Indonesian/Predicates.lean
+++ b/Linglib/Fragments/Indonesian/Predicates.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 import Linglib.Typology.Voice
 import Linglib.Fragments.Indonesian.Morphophonology
 

--- a/Linglib/Fragments/Italian/Predicates.lean
+++ b/Linglib/Fragments/Italian/Predicates.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 import Linglib.Semantics.Attitudes.RationalAttitude
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 

--- a/Linglib/Fragments/Japanese/Predicates.lean
+++ b/Linglib/Fragments/Japanese/Predicates.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Attitudes.Preferential
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Japanese Predicate Lexicon Fragment

--- a/Linglib/Fragments/Korean/Complementizers.lean
+++ b/Linglib/Fragments/Korean/Complementizers.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Korean Complementizers and Clause-Embedding Verbs
@@ -49,7 +49,6 @@ lives in the `Bondarenko2022` Studies file.
 
 namespace Korean.Complementizers
 
-open Semantics.Lexical (VerbCore)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Clause-typing morpheme inventory

--- a/Linglib/Fragments/Korean/Predicates.lean
+++ b/Linglib/Fragments/Korean/Predicates.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Korean Predicate Lexicon Fragment

--- a/Linglib/Fragments/Mandarin/Predicates.lean
+++ b/Linglib/Fragments/Mandarin/Predicates.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Attitudes.Preferential
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Mandarin Predicate Lexicon Fragment

--- a/Linglib/Fragments/Portuguese/MoodChoice.lean
+++ b/Linglib/Fragments/Portuguese/MoodChoice.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Portuguese Mood-Choice Verb Entries @cite{grano-2024}

--- a/Linglib/Fragments/Romanian/MoodChoice.lean
+++ b/Linglib/Fragments/Romanian/MoodChoice.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Romanian Mood-Choice Verb Entries @cite{grano-2024}

--- a/Linglib/Fragments/Spanish/MoodChoice.lean
+++ b/Linglib/Fragments/Spanish/MoodChoice.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Spanish Mood-Choice Verb Entries @cite{grano-2024}

--- a/Linglib/Fragments/Spanish/Predicates.lean
+++ b/Linglib/Fragments/Spanish/Predicates.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 import Linglib.Syntax.Minimalist.Applicative
 
 /-!

--- a/Linglib/Fragments/Turkish/Predicates.lean
+++ b/Linglib/Fragments/Turkish/Predicates.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Attitudes.Preferential
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Turkish Predicate Lexicon Fragment

--- a/Linglib/Semantics/Attitudes/PreExistence.lean
+++ b/Linglib/Semantics/Attitudes/PreExistence.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Pre-Existence and Modal Insertion in Factive Complements
@@ -43,7 +43,6 @@ and is banned elsewhere.
 
 namespace Semantics.Attitudes.PreExistence
 
-open Semantics.Lexical (ComplementType)
 
 -- ============================================================================
 -- §1. Temporal Satisfaction of Pre-Existence

--- a/Linglib/Semantics/Composition/LexiconBuilder.lean
+++ b/Linglib/Semantics/Composition/LexiconBuilder.lean
@@ -1,6 +1,6 @@
 import Linglib.Core.Logic.Intensional.Frame
 import Linglib.Semantics.Composition.LexEntry
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Lexicon Builder
@@ -15,7 +15,7 @@ semantics. Provides:
    list of named entries, replacing the hand-written match-on-strings pattern
    that Studies currently use.
 
-3. **Entry construction** (`VerbCore.mkLexEntry`): given a VerbCore and a
+3. **Entry construction** (`mkLexEntry`): given a VerbCore and a
    denotation of the appropriate type, produce a `LexEntry F`.
 
 ## Design
@@ -50,8 +50,6 @@ open Semantics.Montague (LexEntry Lexicon)
 
 /-! ## Type Dispatch -/
 
-namespace Semantics.Lexical
-
 open Core.Logic.Intensional (Ty)
 
 /-- Map a verb's complement type to its Montague semantic type.
@@ -80,11 +78,8 @@ def ComplementType.toTy : ComplementType → Ty
 def VerbCore.semanticType (v : VerbCore) : Ty :=
   v.complementType.toTy
 
-end Semantics.Lexical
-
 namespace Semantics.Composition.LexiconBuilder
 
-open Semantics.Lexical (ComplementType VerbCore)
 
 /-! ## Lexicon Construction -/
 
@@ -121,7 +116,7 @@ def mergeLexicons {F : Frame} (lex1 lex2 : Lexicon F) : Lexicon F :=
 
     This ensures the entry's type tag matches the verb's argument structure
     by construction. -/
-def VerbCore.mkLexEntry (v : VerbCore) (F : Frame) (denot : F.Denot v.semanticType)
+def mkLexEntry (v : VerbCore) (F : Frame) (denot : F.Denot v.semanticType)
     : LexEntry F :=
   ⟨v.semanticType, denot⟩
 

--- a/Linglib/Semantics/Gradability/ClauseEmbedding.lean
+++ b/Linglib/Semantics/Gradability/ClauseEmbedding.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Clause-Embedding Adjectives
@@ -18,7 +18,6 @@ copula and its syntax belong in the Theory/Syntax layer, not here.
 
 namespace Semantics.Gradability
 
-open Semantics.Lexical (ComplementType PresupTriggerType)
 open Features (Attitude)
 open Core.NaturalLogic (EntailmentSig)
 

--- a/Linglib/Semantics/Lexical/VerbSmuggling.lean
+++ b/Linglib/Semantics/Lexical/VerbSmuggling.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 import Linglib.Syntax.Minimalist.Voice
 import Linglib.Syntax.Minimalist.Movement.Smuggling
 
@@ -26,63 +26,63 @@ deeper Voice-as-not-introducing-external-argument characterization rather
 than the surface `unaccusative : Bool` annotation.
 -/
 
-namespace Semantics.Lexical
+namespace VerbCore
 
 open Minimalist
 
 /-- A verb has a syntactic complement iff its `complementType` is anything
     other than `.none`. Used by smuggling derivations to check that there
     is something to smuggle. -/
-def VerbCore.hasComplement (v : VerbCore) : Bool := v.complementType != .none
+def hasComplement (v : VerbCore) : Bool := v.complementType != .none
 
 /-- The Voice head determined by a verb's derived unaccusativity:
     non-thematic (anticausative) for unaccusatives, agentive for unergatives.
     Reads `derivedUnaccusative`, which consults `voiceType.assignsTheta`
     when present, so the bridge is grounded in the Voice-as-not-introducing-
     external-argument characterization (@cite{kratzer-1996}). -/
-def VerbCore.voiceFor (v : VerbCore) : VoiceHead :=
+def voiceFor (v : VerbCore) : VoiceHead :=
   if v.derivedUnaccusative then voiceAnticausative else voiceAgent
 
 /-- Derived prediction: does the verb license quotative inversion?
     Composes `voiceFor` and `hasComplement` through `licensesQI`
     (@cite{storment-2026}, §4: smuggling requires non-phase Voice + a
     complement to smuggle). -/
-def VerbCore.derivedQI (v : VerbCore) : Bool :=
+def derivedQI (v : VerbCore) : Bool :=
   licensesQI v.voiceFor v.hasComplement
 
 /-- A verb licenses QI iff its derived Voice permits smuggling and it
     has a complement to smuggle. Direct unfolding from `licensesQI`'s
     definition. -/
-theorem VerbCore.derivedQI_iff (v : VerbCore) :
+theorem derivedQI_iff (v : VerbCore) :
     v.derivedQI = true ↔ v.voiceFor.permitsSmuggling = true ∧ v.hasComplement = true := by
-  unfold VerbCore.derivedQI licensesQI
+  unfold derivedQI licensesQI
   simp only [Bool.and_eq_true]
 
 /-- Unaccusative verbs project non-thematic (anticausative) Voice. -/
-theorem VerbCore.voiceFor_of_unaccusative (v : VerbCore)
+theorem voiceFor_of_unaccusative (v : VerbCore)
     (h : v.derivedUnaccusative = true) : v.voiceFor = voiceAnticausative := by
-  unfold VerbCore.voiceFor; simp [h]
+  unfold voiceFor; simp [h]
 
 /-- Unergative verbs project agentive Voice. -/
-theorem VerbCore.voiceFor_of_unergative (v : VerbCore)
+theorem voiceFor_of_unergative (v : VerbCore)
     (h : v.derivedUnaccusative = false) : v.voiceFor = voiceAgent := by
-  unfold VerbCore.voiceFor; simp [h]
+  unfold voiceFor; simp [h]
 
 /-- An unaccusative verb with a complement licenses QI. The two
     independent properties — non-phase Voice and complement availability —
     suffice. -/
-theorem VerbCore.derivedQI_of_unaccusative_with_complement (v : VerbCore)
+theorem derivedQI_of_unaccusative_with_complement (v : VerbCore)
     (hu : v.derivedUnaccusative = true) (hc : v.hasComplement = true) :
     v.derivedQI = true := by
-  rw [VerbCore.derivedQI_iff, VerbCore.voiceFor_of_unaccusative v hu]
+  rw [derivedQI_iff, voiceFor_of_unaccusative v hu]
   exact ⟨nonthematic_permits_smuggling, hc⟩
 
 /-- An unergative verb cannot license QI (regardless of complement),
     because agentive Voice blocks smuggling. -/
-theorem VerbCore.derivedQI_blocked_when_unergative (v : VerbCore)
+theorem derivedQI_blocked_when_unergative (v : VerbCore)
     (hu : v.derivedUnaccusative = false) : v.derivedQI = false := by
-  unfold VerbCore.derivedQI
-  rw [VerbCore.voiceFor_of_unergative v hu]
+  unfold derivedQI
+  rw [voiceFor_of_unergative v hu]
   exact agentive_blocks_qi _
 
-end Semantics.Lexical
+end VerbCore

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -1,0 +1,214 @@
+import Linglib.Semantics.Verb.Defs
+
+/-! # Verb entry — derived API
+
+Classification accessors DERIVED from the primitive `VerbCore` fields:
+unaccusativity from voice, veridicality from the attitude builder, presupposition
+status from event structure, theta-role linking, and so on. Verb classification
+is computed here, not stipulated as enum fields on `VerbCore`.
+-/
+
+open Semantics.Presupposition
+open Features
+open Semantics.Lexical
+open Semantics.Lexical.Roots
+open Features.ChangeOfState
+open Core.NaturalLogic (EntailmentSig)
+open Semantics.Causation.Psych (CausalSource)
+open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open Features.DegreeAchievement (DegreeAchievementScale)
+open Semantics.Aspect.Incremental (VerbIncClass)
+open Features.LevinClassProfiles
+
+/-- Derive unaccusativity from voice type when present, falling back
+    to the stored `unaccusative` field. A verb is unaccusative iff its
+    Voice does not introduce an external argument (@cite{kratzer-1996}). -/
+def VerbCore.derivedUnaccusative (v : VerbCore) : Bool :=
+  match v.voiceType with
+  | some vt => !vt.assignsTheta
+  | none => v.unaccusative
+
+/-- Derive vendlerClass from degreeAchievementScale if present.
+    Falls back to the stipulated vendlerClass field. -/
+def VerbCore.derivedVendlerClass (v : VerbCore) : Option VendlerClass :=
+  v.vendlerClass <|> v.degreeAchievementScale.map (·.defaultVendlerClass)
+
+/-- Effective subject entailment profile: verb-level override if present,
+    otherwise falls back to the Levin class–level profile
+    (@cite{levin-1993}, @cite{dowty-1991}). -/
+def VerbCore.effectiveSubjectEntailments (v : VerbCore) : Option EntailmentProfile :=
+  v.subjectEntailments <|> v.levinClass.bind (·.subjectProfile)
+
+/-- Effective object entailment profile: verb-level override if present,
+    otherwise falls back to the Levin class–level profile. -/
+def VerbCore.effectiveObjectEntailments (v : VerbCore) : Option EntailmentProfile :=
+  v.objectEntailments <|> v.levinClass.bind (·.objectProfile)
+
+/-- Veridicality is DERIVED from the attitude builder -/
+def VerbCore.veridicality (v : VerbCore) : Option Veridicality :=
+  v.attitude.map (·.veridicality)
+
+/-- Is this verb a doxastic attitude? -/
+def VerbCore.isDoxastic (v : VerbCore) : Bool :=
+  v.attitude.map (·.isDoxastic) |>.getD false
+
+/-- Is this verb a preferential attitude? -/
+def VerbCore.isPreferential (v : VerbCore) : Bool :=
+  v.attitude.map (·.isPreferential) |>.getD false
+
+/-- Does this attitude distribute over conjunction?
+    DERIVED from complementSig: any signature that refines `.mono`
+    (mono, additive, mult, addMult, all) distributes. -/
+def VerbCore.distribOverConj (v : VerbCore) : Bool :=
+  v.complementSig.map (fun s => decide (s ≤ .mono)) |>.getD false
+
+/-- Is the complement position upward-entailing?
+    DERIVED from complementSig. -/
+def VerbCore.isComplementUE (v : VerbCore) : Bool :=
+  v.complementSig.map (fun s => decide (s ≤ .mono)) |>.getD false
+
+/-- Valence is DERIVED from the attitude builder (for preferential attitudes) -/
+def VerbCore.preferentialValence (v : VerbCore) : Option AttitudeValence :=
+  v.attitude.bind (·.valence)
+
+-- Note: VerbCore.cDistributive, VerbCore.nvpClass, and VerbCore.takesQuestion
+-- are derived properties defined in Semantics.Intensional/Attitude/BuilderProperties.lean
+
+/--
+Get the CoS semantics for a verb (if it's a CoS verb).
+
+Returns `some (cosSemantics t P)` if the verb has a CoS type,
+where `P` is the activity predicate (complement denotation).
+-/
+def VerbCore.getCoSSemantics {W : Type*} (v : VerbCore) (P : W → Prop) :
+    Option (PrProp W) :=
+  v.cosType.map λ t => cosSemantics t P
+
+/-- Does this verb presuppose its complement via factivity?
+    DERIVED from attitude: true iff the verb is doxastic veridical. -/
+def VerbCore.factivePresup (v : VerbCore) : Bool :=
+  match v.attitude with
+  | some (.doxastic .veridical) => true
+  | _ => false
+
+/-- Does this verb presuppose its complement? -/
+def VerbCore.presupposesComplement (v : VerbCore) : Bool :=
+  v.factivePresup || v.cosType.isSome
+
+/-- Is this verb a presupposition trigger? -/
+def VerbCore.isPresupTrigger (v : VerbCore) : Bool :=
+  v.presupType.isSome
+
+/-- Presupposition trigger type DERIVED from event structure rather than
+    stipulated. @cite{roberts-simons-2024} argue that presupposition status
+    follows from a verb's event structure (factivity, CoS type), not from
+    a lexically specified trigger type. This accessor derives the prediction:
+    verbs with factive or CoS event structure are presupposition triggers.
+
+    Note: R&S (p. 705) argue that the soft/hard trigger distinction "has
+    never been clearly operationalized." We use `.softTrigger` here as a
+    placeholder, not as an endorsement of a binary soft/hard taxonomy. -/
+def VerbCore.derivedPresupType (v : VerbCore) : Option PresupTriggerType :=
+  if v.presupposesComplement then some .softTrigger else none
+
+/-- Is this verb a causative? DERIVED from causative field. -/
+def VerbCore.isCausative (v : VerbCore) : Bool :=
+  v.causative.isSome
+
+/-- Does this causative verb assert sufficiency (like "make")?
+
+    DERIVED: delegates to `Causative.assertsSufficiency`. -/
+def VerbCore.assertsSufficiency (v : VerbCore) : Bool :=
+  v.causative.map (·.assertsSufficiency) |>.getD false
+
+/-- Lexicalist prediction of the external argument's theta role
+    (@cite{levin-1993}, @cite{rappaport-hovav-levin-1998}), based solely
+    on verb-internal properties.
+
+    The cascade mirrors traditional linking rules:
+    - raising / weather → no external role
+    - external causal source → stimulus (Class II psych, @cite{kim-2024})
+    - attitude builder or factive presupposition → experiencer
+    - occasion sense (manage-to) → experiencer
+    - Levin class flinch / learn → experiencer
+    - unaccusative / measure → theme
+    - default → agent
+
+    Contrasts with the Kratzer severing prediction (`VoiceFlavor.thetaRole`),
+    which derives the role from Voice flavor rather than verb-internal
+    semantics. Studies comparing the two accounts can apply both to the
+    same `VerbCore` and inspect divergence. -/
+def VerbCore.predictedSubjectTheta (v : VerbCore) : Option ThetaRole :=
+  if v.controlType == .raising then none
+  else if v.levinClass == some .weather then none
+  else if v.causalSource.isSome then some .stimulus
+  else if v.attitude.isSome then some .experiencer
+  else if v.factivePresup && v.attitude.isNone then some .experiencer
+  else if v.senseTag == .occasion then some .experiencer
+  else if v.levinClass == some .flinch then some .experiencer
+  else if v.levinClass == some .learn then some .experiencer
+  else if v.unaccusative then some .theme
+  else if v.levinClass == some .measure then some .theme
+  else some .agent
+
+/-- Does this verb's semantics predict it is an expletive negation trigger?
+
+    DERIVED from attitude, implicative, and causative builders. Captures
+    the propositional attitude licensing condition from
+    @cite{jin-koenig-2021} §5.5, ex. 13a:
+
+    - **FEAR class**: negative-valence preferential attitudes activate
+      p (feared content) and ¬p (desired alternative).
+    - **FORGET class**: negative implicative verbs entail ¬p in w₀.
+    - **STOP/PREVENT**: causative preventatives entail ¬p in w₀.
+
+    DENY class triggers (doubt, question) are excluded — their
+    EN-triggering requires matrix negation/questioning (pragmatic,
+    via neg-raising), not purely lexical semantics. Temporal, logical,
+    and comparative triggers are operators/connectives, not verbs. -/
+def VerbCore.isENTrigger (v : VerbCore) : Bool :=
+  -- FEAR class: negative-valence preferential attitudes
+  (v.preferentialValence == some .negative) ||
+  -- FORGET class: negative implicative verbs
+  (v.implicative == some .negative) ||
+  -- STOP/PREVENT: causative prevent verbs
+  (v.causative == some .prevent)
+
+/-- Does this causative verb assert necessity (like "cause")?
+
+    DERIVED: delegates to `Causative.assertsNecessity`. -/
+def VerbCore.assertsNecessity (v : VerbCore) : Bool :=
+  v.causative.map (·.assertsNecessity) |>.getD false
+
+/-- Does success of this implicative verb entail the complement?
+
+    DERIVED: delegates to `Implicative.entailsComplement`.
+    Returns `some true` for positive implicatives (*manage*, *remember*),
+    `some false` for negative (*fail*, *forget*), `none` for non-implicatives. -/
+def VerbCore.entailsComplement (v : VerbCore) : Option Bool :=
+  v.implicative.map (·.entailsComplement)
+
+/-- Is this verb a preferential attitude predicate? -/
+def VerbCore.isPreferentialAttitude (v : VerbCore) : Bool :=
+  v.preferentialValence.isSome
+
+/-- Can this verb take a clausal (CP) complement?
+
+    Checks both primary and alternate complement frames. Used to classify
+    verbs as CP-selecting vs non-CP-selecting for coordination studies
+    (@cite{schwarzer-2026}). -/
+def VerbCore.canTakeClausalComplement (v : VerbCore) : Bool :=
+  v.complementType.isClausal ||
+  match v.altComplementType with | some ct => ct.isClausal | none => false
+
+/-- Can this verb take a nominal (DP) complement?
+
+    Checks both primary and alternate complement frames. -/
+def VerbCore.canTakeNominalComplement (v : VerbCore) : Bool :=
+  v.complementType.isNominal ||
+  match v.altComplementType with | some ct => ct.isNominal | none => false
+
+/-- Look up a verb core by citation form and sense tag. -/
+def lookupSense (verbs : List VerbCore) (form : String) (tag : SenseTag := .default) :
+    Option VerbCore :=
+  verbs.find? (λ v => v.form == form && v.senseTag == tag)

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -14,35 +14,30 @@ import Linglib.Semantics.Aspect.DegreeAchievement
 import Linglib.Semantics.Aspect.Incremental
 import Linglib.Semantics.Lexical.LevinClassProfiles
 
-/-! # Cross-Linguistic Verb Infrastructure
+/-! # Verb entry — core type
 
-Framework-agnostic types for verb semantics: complement type, control type,
-and the `VerbCore` structure that bundles all semantic fields shared across
-languages. Verb classification enums (`Causative`, `Implicative`, `Attitude`,
-etc.) are in `Core/Lexical/VerbClass.lean`.
+Framework-agnostic types for verb semantics: the selectional/inflectional enums
+(`ComplementType`, `VoiceType`, …) and the `VerbCore` structure that bundles the
+semantic fields shared across languages.
 
-English-specific morphology (3sg, past, participles) lives in
-`Fragments/English/Predicates/Verbal.lean`; other languages extend
-`VerbCore` with their own inflectional paradigms.
+`VerbCore` is the **semantic spine** of a verb entry. Its fields are organised
+into facet structures under the `Verb` namespace — `Verb.ArgStructure`,
+`Verb.Aspect`, `Verb.Presupposition`, `Verb.Causation`, `Verb.Attitude`,
+`Verb.Root` — which `VerbCore` composes via `extends`. Flat field access
+(`v.complementType`, `v.attitude`, …) is preserved by `extends`-flattening, and
+language fragments extend `VerbCore` with their own inflectional paradigms.
+
+Verb classification (factive, causative, attitude, …) is DERIVED from these
+primitive fields in `Semantics/Verb/Basic.lean`, not stipulated as an enum.
+
+## Main declarations
+* `VerbCore` — the composed verb entry spine
+* `Verb.ArgStructure`, `Verb.Aspect`, `Verb.Presupposition`, `Verb.Causation`,
+  `Verb.Attitude`, `Verb.Root` — the field facets
 
 ## Design
 @cite{bale-schwarz-2026} @cite{dayal-2025} @cite{heim-1992} @cite{icard-2012} @cite{kennedy-2007} @cite{maier-2015} @cite{qing-uegaki-2025} @cite{rappaport-hovav-levin-2024} @cite{solstad-bott-2024} @cite{rappaport-hovav-levin-1998}
-
-`VerbCore` is the **semantic spine** of a verb entry. It carries:
-- Argument structure (theta roles, complement type, control)
-- Primitive semantic features (factivity, opacity, speech-act status, …)
-- Links to compositional semantics (attitude builder, causative builder, …)
-
-Verb classification (factive, causative, attitude, etc.) is DERIVED from
-these primitive fields, not stipulated as an enum.
-
-Language-specific fragments extend `VerbCore` with morphological fields:
-- English: `form3sg`, `formPast`, `formPastPart`, `formPresPart`
-- Japanese: `form3sg` (nonpast), `formPast`, `formGerund`, `formProgressive`
-- Mandarin: (none — isolating language)
 -/
-
-namespace Semantics.Lexical
 
 open Semantics.Presupposition
 open Features
@@ -55,6 +50,8 @@ open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Semantics.Aspect.Incremental (VerbIncClass)
 open Features.LevinClassProfiles
+
+/-! ### Selectional and inflectional enums -/
 
 /-- Framework-neutral voice type for deriving argument structure properties.
 
@@ -114,7 +111,6 @@ inductive ProjectionBehavior where
   | hole    -- Passes complement presuppositions through
   | filter  -- Conditionally cancels complement presuppositions
   deriving DecidableEq, Repr
-
 
 /--
 Disambiguates polysemous verb entries that share a citation form.
@@ -207,19 +203,28 @@ inductive ImplicitInterp where
   | def     -- Pragmatically recoverable definite
   deriving DecidableEq, Repr
 
-/--
-Cross-linguistic verb core: all semantic fields shared across languages.
+/-- Map complement type to syntactic valence.
+    Clause-embedding types (.finiteClause,.infinitival,.gerund,.question,
+.smallClause) map to `.clausal` — they take xcomp/ccomp, not obj.
+    `checkVerbSubcat` skips `.clausal` verbs (their frames require
+    different validation than NP-argument counting). -/
+def complementToValence : ComplementType → Valence
+  | .none => .intransitive
+  | .np => .transitive
+  | .np_np => .ditransitive
+  | .np_pp => .locative
+  | _ => .clausal
 
-Bundles argument structure, semantic class, and links to compositional
-semantics. Language-specific fragments extend this with morphological
-fields appropriate to their inflectional system.
--/
-structure VerbCore where
-  -- === Citation Form ===
-  /-- Citation form (cross-linguistic) -/
-  form : String
+/-! ### Field facets
 
-  -- === Argument Structure ===
+Each facet groups a concern's fields; `VerbCore` composes them via `extends`,
+so flat access (`v.complementType`) is preserved. -/
+
+namespace Verb
+
+/-- Argument structure and realization: complement selection, control,
+    proto-role entailments, voice, and implicit arguments. -/
+structure ArgStructure where
   /-- What complement does the verb select? -/
   complementType : ComplementType
   /-- Proto-role entailment profile for the subject (external argument).
@@ -248,22 +253,19 @@ structure VerbCore where
   voiceType : Option VoiceType := none
   /-- Can the verb passivize? -/
   passivizable : Bool := true
-
-  -- === Implicit Arguments (@cite{bruening-2021}) ===
   /-- Can the direct object (theme/patient) be left unexpressed?
       Applies to monotransitives (*eat* vs *devour*) and the theme of
-      ditransitives. `none` = object always required. -/
+      ditransitives. `none` = object always required. @cite{bruening-2021} -/
   implicitObj : Option ImplicitInterp := none
   /-- Can the goal/recipient argument be left unexpressed?
       Applies to the IO of double object constructions and the PP
       of dative frames. `none` = goal always required. -/
   implicitGoal : Option ImplicitInterp := none
+  deriving Repr, BEq
 
-  -- === Semantic Class ===
-  /-- Does the verb denote the performance of an illocutionary act?
-      True for speech-act verbs (say, tell, claim, ask). This is a genuine
-      semantic primitive that cannot be derived from other fields. -/
-  speechActVerb : Bool := false
+/-- Aspectual class: Vendler class, degree-achievement scale, incrementality,
+    and change-of-state type. -/
+structure Aspect where
   /-- @cite{vendler-1957} aspectual class of the verb's base VP.
       For verbs whose class depends on the object NP (eat apples = activity,
       eat two apples = accomplishment), record the class with a quantized
@@ -279,15 +281,22 @@ structure VerbCore where
       with backups (read); `.cumOnly` = cumulative only (push, carry).
       `none` for intransitives and clause-embedding verbs. -/
   verbIncClass : Option VerbIncClass := none
+  /-- For CoS verbs: which type (cessation, inception, continuation)? -/
+  cosType : Option CoSType := none
+  deriving Repr, BEq
+
+/-- Presupposition profile: trigger type and complement-projection behavior. -/
+structure Presupposition where
   /-- Is the verb a presupposition trigger? -/
   presupType : Option PresupTriggerType := none
   /-- How does the verb treat presuppositions of its complement?
       Orthogonal to `presupType`. @cite{karttunen-1973} -/
   projectionBehavior : Option ProjectionBehavior := none
+  deriving Repr, BEq
 
-  -- === Class-Specific Features ===
-  /-- For CoS verbs: which type (cessation, inception, continuation)? -/
-  cosType : Option CoSType := none
+/-- Causal/implicative semantics: implicative polarity, causative mechanism,
+    and psych-causative source. -/
+structure Causation where
   /-- For implicative verbs: complement entailment polarity (links to compositional semantics). -/
   implicative : Option Implicative := none
   /-- For causative verbs: force-dynamic mechanism (links to compositional semantics). -/
@@ -295,15 +304,16 @@ structure VerbCore where
   /-- Source of causation for psych causatives (@cite{kim-2024} UPH).
       `.external` = mind-external percept, `.internal` = mind-internal representation. -/
   causalSource : Option CausalSource := none
+  deriving Repr, BEq
 
-  -- === Intensionality ===
+/-- Attitudinal and intensional properties: attitude classification, opacity,
+    question-embedding, and complement monotonicity. -/
+structure Attitude where
   /-- Does the verb create an opaque context for its complement? -/
   opaqueContext : Bool := false
-
-  -- === Attitude-Specific Properties ===
   /-- Unified attitude classification covering doxastic and preferential attitudes.
       Theoretical properties (C-distributivity, parasitic, etc.) are DERIVED. -/
-  attitude : Option Attitude := none
+  attitude : Option Features.Attitude := none
   /-- For non-preferential question-embedding verbs (know, wonder, ask) -/
   takesQuestionBase : Bool := false
   /-- Entailment signature of the complement position.
@@ -312,222 +322,37 @@ structure VerbCore where
       (be surprised). Used to derive conjunction distribution and neg-raising.
       See @cite{bondarenko-elliott-2026}. -/
   complementSig : Option EntailmentSig := none
+  deriving Repr, BEq
 
-  -- === Polysemy ===
-  /-- Disambiguates entries that share a citation form.
-      Most verbs use `.default`; polysemous entries use descriptive tags. -/
-  senseTag : SenseTag := .default
-
-  -- === Root Content (@cite{levin-1993}; @cite{spalek-mcnally-2026}) ===
+/-- Root content: Levin class and root-specific quality profile
+    (@cite{levin-1993}; @cite{spalek-mcnally-2026}). -/
+structure Root where
   /-- @cite{levin-1993} verb class (§§ 9–57). -/
   levinClass : Option LevinClass := none
   /-- Root-specific quality dimensions (within-class variation). -/
   rootProfile : Option RootProfile := none
   deriving Repr, BEq
 
-/-- Derive unaccusativity from voice type when present, falling back
-    to the stored `unaccusative` field. A verb is unaccusative iff its
-    Voice does not introduce an external argument (@cite{kratzer-1996}). -/
-def VerbCore.derivedUnaccusative (v : VerbCore) : Bool :=
-  match v.voiceType with
-  | some vt => !vt.assignsTheta
-  | none => v.unaccusative
-
-/-- Derive vendlerClass from degreeAchievementScale if present.
-    Falls back to the stipulated vendlerClass field. -/
-def VerbCore.derivedVendlerClass (v : VerbCore) : Option VendlerClass :=
-  v.vendlerClass <|> v.degreeAchievementScale.map (·.defaultVendlerClass)
-
-/-- Effective subject entailment profile: verb-level override if present,
-    otherwise falls back to the Levin class–level profile
-    (@cite{levin-1993}, @cite{dowty-1991}). -/
-def VerbCore.effectiveSubjectEntailments (v : VerbCore) : Option EntailmentProfile :=
-  v.subjectEntailments <|> v.levinClass.bind (·.subjectProfile)
-
-/-- Effective object entailment profile: verb-level override if present,
-    otherwise falls back to the Levin class–level profile. -/
-def VerbCore.effectiveObjectEntailments (v : VerbCore) : Option EntailmentProfile :=
-  v.objectEntailments <|> v.levinClass.bind (·.objectProfile)
-
-/-- Veridicality is DERIVED from the attitude builder -/
-def VerbCore.veridicality (v : VerbCore) : Option Veridicality :=
-  v.attitude.map (·.veridicality)
-
-/-- Is this verb a doxastic attitude? -/
-def VerbCore.isDoxastic (v : VerbCore) : Bool :=
-  v.attitude.map (·.isDoxastic) |>.getD false
-
-/-- Is this verb a preferential attitude? -/
-def VerbCore.isPreferential (v : VerbCore) : Bool :=
-  v.attitude.map (·.isPreferential) |>.getD false
-
-/-- Does this attitude distribute over conjunction?
-    DERIVED from complementSig: any signature that refines `.mono`
-    (mono, additive, mult, addMult, all) distributes. -/
-def VerbCore.distribOverConj (v : VerbCore) : Bool :=
-  v.complementSig.map (fun s => decide (s ≤ .mono)) |>.getD false
-
-/-- Is the complement position upward-entailing?
-    DERIVED from complementSig. -/
-def VerbCore.isComplementUE (v : VerbCore) : Bool :=
-  v.complementSig.map (fun s => decide (s ≤ .mono)) |>.getD false
-
-/-- Valence is DERIVED from the attitude builder (for preferential attitudes) -/
-def VerbCore.preferentialValence (v : VerbCore) : Option AttitudeValence :=
-  v.attitude.bind (·.valence)
-
--- Note: VerbCore.cDistributive, VerbCore.nvpClass, and VerbCore.takesQuestion
--- are derived properties defined in Semantics.Intensional/Attitude/BuilderProperties.lean
+end Verb
 
 /--
-Get the CoS semantics for a verb (if it's a CoS verb).
+Cross-linguistic verb core: all semantic fields shared across languages.
 
-Returns `some (cosSemantics t P)` if the verb has a CoS type,
-where `P` is the activity predicate (complement denotation).
+Composes the `Verb.*` facets (argument structure, aspect, presupposition,
+causation, attitude, root) plus the citation form, speech-act status, and a
+polysemy disambiguator. Language-specific fragments extend this with
+morphological fields appropriate to their inflectional system.
 -/
-def VerbCore.getCoSSemantics {W : Type*} (v : VerbCore) (P : W → Prop) :
-    Option (PrProp W) :=
-  v.cosType.map λ t => cosSemantics t P
-
-/-- Does this verb presuppose its complement via factivity?
-    DERIVED from attitude: true iff the verb is doxastic veridical. -/
-def VerbCore.factivePresup (v : VerbCore) : Bool :=
-  match v.attitude with
-  | some (.doxastic .veridical) => true
-  | _ => false
-
-/-- Does this verb presuppose its complement? -/
-def VerbCore.presupposesComplement (v : VerbCore) : Bool :=
-  v.factivePresup || v.cosType.isSome
-
-/-- Is this verb a presupposition trigger? -/
-def VerbCore.isPresupTrigger (v : VerbCore) : Bool :=
-  v.presupType.isSome
-
-/-- Presupposition trigger type DERIVED from event structure rather than
-    stipulated. @cite{roberts-simons-2024} argue that presupposition status
-    follows from a verb's event structure (factivity, CoS type), not from
-    a lexically specified trigger type. This accessor derives the prediction:
-    verbs with factive or CoS event structure are presupposition triggers.
-
-    Note: R&S (p. 705) argue that the soft/hard trigger distinction "has
-    never been clearly operationalized." We use `.softTrigger` here as a
-    placeholder, not as an endorsement of a binary soft/hard taxonomy. -/
-def VerbCore.derivedPresupType (v : VerbCore) : Option PresupTriggerType :=
-  if v.presupposesComplement then some .softTrigger else none
-
-/-- Is this verb a causative? DERIVED from causative field. -/
-def VerbCore.isCausative (v : VerbCore) : Bool :=
-  v.causative.isSome
-
-/-- Does this causative verb assert sufficiency (like "make")?
-
-    DERIVED: delegates to `Causative.assertsSufficiency`. -/
-def VerbCore.assertsSufficiency (v : VerbCore) : Bool :=
-  v.causative.map (·.assertsSufficiency) |>.getD false
-
-/-- Lexicalist prediction of the external argument's theta role
-    (@cite{levin-1993}, @cite{rappaport-hovav-levin-1998}), based solely
-    on verb-internal properties.
-
-    The cascade mirrors traditional linking rules:
-    - raising / weather → no external role
-    - external causal source → stimulus (Class II psych, @cite{kim-2024})
-    - attitude builder or factive presupposition → experiencer
-    - occasion sense (manage-to) → experiencer
-    - Levin class flinch / learn → experiencer
-    - unaccusative / measure → theme
-    - default → agent
-
-    Contrasts with the Kratzer severing prediction (`VoiceFlavor.thetaRole`),
-    which derives the role from Voice flavor rather than verb-internal
-    semantics. Studies comparing the two accounts can apply both to the
-    same `VerbCore` and inspect divergence. -/
-def VerbCore.predictedSubjectTheta (v : VerbCore) : Option ThetaRole :=
-  if v.controlType == .raising then none
-  else if v.levinClass == some .weather then none
-  else if v.causalSource.isSome then some .stimulus
-  else if v.attitude.isSome then some .experiencer
-  else if v.factivePresup && v.attitude.isNone then some .experiencer
-  else if v.senseTag == .occasion then some .experiencer
-  else if v.levinClass == some .flinch then some .experiencer
-  else if v.levinClass == some .learn then some .experiencer
-  else if v.unaccusative then some .theme
-  else if v.levinClass == some .measure then some .theme
-  else some .agent
-
-/-- Does this verb's semantics predict it is an expletive negation trigger?
-
-    DERIVED from attitude, implicative, and causative builders. Captures
-    the propositional attitude licensing condition from
-    @cite{jin-koenig-2021} §5.5, ex. 13a:
-
-    - **FEAR class**: negative-valence preferential attitudes activate
-      p (feared content) and ¬p (desired alternative).
-    - **FORGET class**: negative implicative verbs entail ¬p in w₀.
-    - **STOP/PREVENT**: causative preventatives entail ¬p in w₀.
-
-    DENY class triggers (doubt, question) are excluded — their
-    EN-triggering requires matrix negation/questioning (pragmatic,
-    via neg-raising), not purely lexical semantics. Temporal, logical,
-    and comparative triggers are operators/connectives, not verbs. -/
-def VerbCore.isENTrigger (v : VerbCore) : Bool :=
-  -- FEAR class: negative-valence preferential attitudes
-  (v.preferentialValence == some .negative) ||
-  -- FORGET class: negative implicative verbs
-  (v.implicative == some .negative) ||
-  -- STOP/PREVENT: causative prevent verbs
-  (v.causative == some .prevent)
-
-/-- Does this causative verb assert necessity (like "cause")?
-
-    DERIVED: delegates to `Causative.assertsNecessity`. -/
-def VerbCore.assertsNecessity (v : VerbCore) : Bool :=
-  v.causative.map (·.assertsNecessity) |>.getD false
-
-/-- Does success of this implicative verb entail the complement?
-
-    DERIVED: delegates to `Implicative.entailsComplement`.
-    Returns `some true` for positive implicatives (*manage*, *remember*),
-    `some false` for negative (*fail*, *forget*), `none` for non-implicatives. -/
-def VerbCore.entailsComplement (v : VerbCore) : Option Bool :=
-  v.implicative.map (·.entailsComplement)
-
-/-- Is this verb a preferential attitude predicate? -/
-def VerbCore.isPreferentialAttitude (v : VerbCore) : Bool :=
-  v.preferentialValence.isSome
-
-/-- Map complement type to syntactic valence.
-    Clause-embedding types (.finiteClause,.infinitival,.gerund,.question,
-.smallClause) map to `.clausal` — they take xcomp/ccomp, not obj.
-    `checkVerbSubcat` skips `.clausal` verbs (their frames require
-    different validation than NP-argument counting). -/
-def complementToValence : ComplementType → Valence
-  | .none => .intransitive
-  | .np => .transitive
-  | .np_np => .ditransitive
-  | .np_pp => .locative
-  | _ => .clausal
-
-/-- Can this verb take a clausal (CP) complement?
-
-    Checks both primary and alternate complement frames. Used to classify
-    verbs as CP-selecting vs non-CP-selecting for coordination studies
-    (@cite{schwarzer-2026}). -/
-def VerbCore.canTakeClausalComplement (v : VerbCore) : Bool :=
-  v.complementType.isClausal ||
-  match v.altComplementType with | some ct => ct.isClausal | none => false
-
-/-- Can this verb take a nominal (DP) complement?
-
-    Checks both primary and alternate complement frames. -/
-def VerbCore.canTakeNominalComplement (v : VerbCore) : Bool :=
-  v.complementType.isNominal ||
-  match v.altComplementType with | some ct => ct.isNominal | none => false
-
-/-- Look up a verb core by citation form and sense tag. -/
-def lookupSense (verbs : List VerbCore) (form : String) (tag : SenseTag := .default) :
-    Option VerbCore :=
-  verbs.find? (λ v => v.form == form && v.senseTag == tag)
-
-end Semantics.Lexical
+structure VerbCore extends
+    Verb.ArgStructure, Verb.Aspect, Verb.Presupposition,
+    Verb.Causation, Verb.Attitude, Verb.Root where
+  /-- Citation form (cross-linguistic) -/
+  form : String
+  /-- Does the verb denote the performance of an illocutionary act?
+      True for speech-act verbs (say, tell, claim, ask). This is a genuine
+      semantic primitive that cannot be derived from other fields. -/
+  speechActVerb : Bool := false
+  /-- Disambiguates entries that share a citation form.
+      Most verbs use `.default`; polysemous entries use descriptive tags. -/
+  senseTag : SenseTag := .default
+  deriving Repr, BEq

--- a/Linglib/Studies/AndersonJM2006.lean
+++ b/Linglib/Studies/AndersonJM2006.lean
@@ -318,14 +318,14 @@ theorem experiencer_agent_distinct_same_rank :
 -- § 3: VerbCore → Scenario (End-to-End Bridge)
 -- ============================================================================
 
-private def subjectRole (v : Semantics.Lexical.VerbCore) : Option ThetaRole :=
+private def subjectRole (v : VerbCore) : Option ThetaRole :=
   v.effectiveSubjectEntailments.bind (·.toRole)
 
-private def objectRole (v : Semantics.Lexical.VerbCore) : Option ThetaRole :=
+private def objectRole (v : VerbCore) : Option ThetaRole :=
   v.effectiveObjectEntailments.bind (·.toRole)
 
 /-- Derive Anderson's `Scenario` from a Fragment verb entry's derived roles. -/
-def toScenario (v : Semantics.Lexical.VerbCore) : Scenario :=
+def toScenario (v : VerbCore) : Scenario :=
   ⟨(subjectRole v |>.map thetaToCaseRelation).toList ++
    (objectRole v |>.map thetaToCaseRelation).toList⟩
 
@@ -345,7 +345,7 @@ def andersonLinking : LinkingTheory Scenario Unit where
     | _             => none
 
 /-- Anderson's predicted subject theta role for a verb entry. -/
-def andersonPredictedSubjectTheta (v : Semantics.Lexical.VerbCore) : Option ThetaRole :=
+def andersonPredictedSubjectTheta (v : VerbCore) : Option ThetaRole :=
   andersonLinking.predict (toScenario v) () .subject
 
 -- ============================================================================

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -2,7 +2,7 @@ import Linglib.Syntax.Minimalist.Selection
 import Linglib.Syntax.Minimalist.CategorialFeatures
 import Linglib.Semantics.Attitudes.ClauseDenotation.Content
 import Linglib.Semantics.Attitudes.ClauseDenotation.Situation
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 import Linglib.Studies.Bondarenko2022
 import Linglib.Fragments.Greek.StandardModern.Complementizers
 
@@ -111,7 +111,6 @@ complement *pu* from v_State.
 namespace Angelopoulos2026
 
 open Minimalist
-open Semantics.Lexical (VerbCore)
 open Semantics.Attitudes (ContentIndividual)
 open Semantics.Attitudes.ClauseDenotation.Content (compC ContentNoun)
 open Semantics.Attitudes.ClauseDenotation.Situation

--- a/Linglib/Studies/Chierchia1984.lean
+++ b/Linglib/Studies/Chierchia1984.lean
@@ -90,7 +90,6 @@ namespace Chierchia1984
 
 open Semantics.Modality.Kratzer
 open Semantics.Composition.TypeShifting (ComplSemLayer)
-open Semantics.Lexical (VerbCore ControlType ComplementType)
 
 abbrev World := Fin 4
 

--- a/Linglib/Studies/Glass2025.lean
+++ b/Linglib/Studies/Glass2025.lean
@@ -2,7 +2,7 @@ import Linglib.Semantics.Attitudes.Doxastic
 import Linglib.Semantics.Attitudes.NegRaising
 import Linglib.Semantics.Presupposition.Context
 import Linglib.Semantics.Dynamic.Postsupposition
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Fragments.Mandarin.Predicates
 

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -1272,7 +1272,6 @@ causative blocking) is *sufficient* for EN trigger status — the
 conclusion follows from the hypothesis, not by enumerating cases.
 -/
 
-open Semantics.Lexical (VerbCore)
 
 /-- Any verb with negative preferential valence is an EN trigger.
     This captures the FEAR class: negative valence activates both p

--- a/Linglib/Studies/Karttunen1973.lean
+++ b/Linglib/Studies/Karttunen1973.lean
@@ -31,7 +31,6 @@ Heim-1992-era hole consensus.
 namespace Karttunen1973
 
 open Semantics.Presupposition
-open Semantics.Lexical (ProjectionBehavior VerbCore)
 open CommonGround (ContextSet)
 open English.Predicates.Verbal
 

--- a/Linglib/Studies/Landau2015.lean
+++ b/Linglib/Studies/Landau2015.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Minimalist.MinimalPronoun
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 import Linglib.Typology.Complementation
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Studies.Noonan2007
@@ -44,7 +44,6 @@ OC in complement clauses divides into two subtypes:
 namespace Landau2015
 
 open Minimalist.MinimalPronoun
-open Semantics.Lexical (VerbCore ControlType ComplementType)
 open Features (Attitude)
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Schwarzer2026.lean
+++ b/Linglib/Studies/Schwarzer2026.lean
@@ -52,7 +52,6 @@ namespace Schwarzer2026
 
 open Features
 open Features.Coordination
-open Semantics.Lexical (ComplementType VerbCore)
 open German.Predicates
 open Typology.WordOrder
 open BrueningAlKhalaf2020

--- a/Linglib/Studies/White2014.lean
+++ b/Linglib/Studies/White2014.lean
@@ -30,7 +30,6 @@ a known overprediction of the original MCA.
 
 namespace White2014
 
-open Semantics.Lexical (ComplementType)
 open Williams2026
 open Semantics.Attitudes.PreExistence
 open English.Predicates.Verbal

--- a/Linglib/Studies/Williams2026.lean
+++ b/Linglib/Studies/Williams2026.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Lexical.VerbEntry
+import Linglib.Semantics.Verb.Basic
 
 /-!
 # Williams 2026: The Presuppositions of *forget*
@@ -51,7 +51,6 @@ The Fragment split is a practical separation of entailment patterns;
 
 namespace Williams2026
 
-open Semantics.Lexical (ComplementType)
 
 /-- Whether a factive presupposition has modal content.
 

--- a/Linglib/Syntax/Minimalist/FromFragments.lean
+++ b/Linglib/Syntax/Minimalist/FromFragments.lean
@@ -36,7 +36,7 @@ clauses use `.D` rather than a dedicated predicational head).
 namespace Minimalist.FromFragments
 
 open Minimalist
-open English.Predicates.Verbal (VerbEntry ComplementType)
+open English.Predicates.Verbal (VerbEntry)
 open English.Pronouns (PronounEntry PronounType)
 open English.Nouns (NounEntry)
 open Semantics.Quantification.Lexicon (QuantifierEntry)


### PR DESCRIPTION
Moves the verb-entry spine from `Semantics/Lexical/VerbEntry.lean` to `Semantics/Verb/{Defs,Basic}` (mathlib Defs/Basic layout) and decomposes the 28-field `VerbCore` god-record into six `Verb.*` facet structs (`ArgStructure`, `Aspect`, `Presupposition`, `Causation`, `Attitude`, `Root`) composed via `extends` — flat field access and all 260 construction sites are preserved.

Verb types move to the root namespace (explicit `open`/`export Semantics.Lexical (…)` of the moved names are dropped, since they're globally visible); VerbSmuggling/LexiconBuilder adopt `namespace VerbCore` rather than `_root_.`. `VerbCore` keeps its name — the rename to `Verb` is the follow-up PR.