### PR TITLE
refactor(Semantics/Verb): rename VerbCore to Verb

### DIFF
--- a/Linglib/Fragments/Buryat/Complementizers.lean
+++ b/Linglib/Fragments/Buryat/Complementizers.lean
@@ -111,7 +111,7 @@ theorem verbal_xor_participial (c : BuryatComplementizer) :
 
     Citation form is the eventive/cognition sense; the
     polysemy is tracked via `altComplementType`. -/
-def xanaxa : VerbCore where
+def xanaxa : Verb where
   form := "xanaxa"
   complementType := .finiteClause
   altComplementType := some .finiteClause
@@ -122,14 +122,14 @@ def xanaxa : VerbCore where
 /-- *boloxo* — 'happen / become'. Eventive change-of-state verb.
     Selects situation-typed argument; relevant to §4.3.3 cross-
     linguistic-occurrence-verb generalization. -/
-def boloxo : VerbCore where
+def boloxo : Verb where
   form := "boloxo"
   complementType := .finiteClause
   vendlerClass := some .achievement
   unaccusative := true
 
 /-- *medexe* — 'know'. Factive doxastic; stative. -/
-def medexe : VerbCore where
+def medexe : Verb where
   form := "medexe"
   complementType := .finiteClause
   attitude := some (.doxastic .veridical)
@@ -137,7 +137,7 @@ def medexe : VerbCore where
 
 /-- *xelexe* — 'say'. Speech-act verb; selects bare *gɔ*-marked
     complement per @cite{bondarenko-2022} §4.3.1. -/
-def xelexe : VerbCore where
+def xelexe : Verb where
   form := "xelexe"
   complementType := .finiteClause
   speechActVerb := true

--- a/Linglib/Fragments/English/Predicates/Copular.lean
+++ b/Linglib/Fragments/English/Predicates/Copular.lean
@@ -9,8 +9,8 @@ English clause-embedding adjectives that appear in copular constructions:
 
 The adjective entries use `ClauseEmbeddingAdj` (cross-linguistic type);
 the copular realization ("be" + adjective) is English-specific. The
-`toVerbCore` helper constructs the combined form for bridge theorems
-that need a uniform `VerbCore` interface.
+`toVerb` helper constructs the combined form for bridge theorems
+that need a uniform `Verb` interface.
 -/
 
 namespace English.Predicates.Copular
@@ -21,7 +21,7 @@ open Semantics.Lexical
 /-- "annoyed (that p)" — emotive factive clause-embedding adjective.
     @cite{degen-tonhauser-2021}, @cite{degen-tonhauser-2022}: canonically factive.
     Presupposes its complement via emotive semantics, not doxastic
-    veridicality — hence `factivePresup` on the derived `VerbCore` is
+    veridicality — hence `factivePresup` on the derived `Verb` is
     `false`, while `presupType = some .softTrigger`. -/
 def beAnnoyed : ClauseEmbeddingAdj where
   adjForm := "annoyed"
@@ -39,9 +39,9 @@ def beRight : ClauseEmbeddingAdj where
     entailment arises in perfective contexts, not from the lexicon. Therefore
     NO `implicative`: the entailment is not unconditional like *manage*.
 
-    Not modeled via `ClauseEmbeddingAdj` because `toVerbCore` doesn't transfer
-    `controlType`. Constructed as a direct `VerbCore` instead. -/
-def beAble : VerbCore where
+    Not modeled via `ClauseEmbeddingAdj` because `toVerb` doesn't transfer
+    `controlType`. Constructed as a direct `Verb` instead. -/
+def beAble : Verb where
   form := "be able"
   complementType := .infinitival
   controlType := .subjectControl
@@ -53,12 +53,12 @@ end English.Predicates.Copular
 -- ════════════════════════════════════════════════════
 
 open Semantics.Lexical in
-/-- Construct a `VerbCore` for an English copular predicate.
+/-- Construct a `Verb` for an English copular predicate.
     The copula contributes "be"; the adjective contributes the semantics.
     This is English-specific — other languages realize clause-embedding
     adjectives differently (zero copula, verbal adjectives, etc.). -/
-def Semantics.Gradability.ClauseEmbeddingAdj.toVerbCore
-    (a : Semantics.Gradability.ClauseEmbeddingAdj) : VerbCore where
+def Semantics.Gradability.ClauseEmbeddingAdj.toVerb
+    (a : Semantics.Gradability.ClauseEmbeddingAdj) : Verb where
   form := "be " ++ a.adjForm
   complementType := a.complementType
   presupType := a.presupType

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -8,15 +8,15 @@ English verb lexical entries with morphology, argument structure, semantic class
 and links to compositional semantics (CoS, attitudes, causatives).
 
 Semantic types (`ComplementType`, `Attitude`, etc.) and the
-cross-linguistic `VerbCore` structure live in `Core/Verbs.lean`. This file
-defines `VerbEntry extends VerbCore` with English-specific inflectional fields
+cross-linguistic `Verb` structure live in `Core/Verbs.lean`. This file
+defines `VerbEntry extends Verb` with English-specific inflectional fields
 and provides smart constructors for regular verbs.
 -/
 
 namespace English.Predicates.Verbal
 
 -- Re-export Features verb-entry vocabulary so downstream files that open this
--- namespace continue to find it. The `VerbCore`/`ComplementType`/… types now
+-- namespace continue to find it. The `Verb`/`ComplementType`/… types now
 -- live at the root namespace (`Semantics/Verb/Defs`), so they need no re-export.
 export Features (Preferential Attitude Causative Implicative)
 
@@ -64,16 +64,16 @@ def regularPresPart (stem : String) : String :=
   else stem ++ "ing"
 
 -- ════════════════════════════════════════════════════
--- § VerbEntry (extends VerbCore with English morphology)
+-- § VerbEntry (extends Verb with English morphology)
 -- ════════════════════════════════════════════════════
 
 /--
 A complete English lexical entry for a verb.
 
-Extends the cross-linguistic `VerbCore` (argument structure, semantic class,
+Extends the cross-linguistic `Verb` (argument structure, semantic class,
 compositional links) with English-specific inflectional morphology.
 -/
-structure VerbEntry extends VerbCore where
+structure VerbEntry extends Verb where
   /-- Third person singular present (for agreement) -/
   form3sg : String
   /-- Past tense form -/
@@ -94,8 +94,8 @@ structure VerbEntry extends VerbCore where
     def kick : VerbEntry :=.mkRegular {
       form := "kick", complementType :=.np }
     ``` -/
-def VerbEntry.mkRegular (core : VerbCore) : VerbEntry :=
-  { toVerbCore := core
+def VerbEntry.mkRegular (core : Verb) : VerbEntry :=
+  { toVerb := core
     form3sg := regular3sg core.form
     formPast := regularPast core.form
     formPastPart := regularPast core.form
@@ -3406,16 +3406,16 @@ referenced `Causative.toSemantics` over `CausalDynamics`) were removed
 in Phase D-G in favor of the polymorphic V2 versions. -/
 
 /-- "make" asserts sufficiency — derived from its builder. -/
-theorem make_asserts_sufficiency : make.toVerbCore.assertsSufficiency = true := by native_decide
+theorem make_asserts_sufficiency : make.toVerb.assertsSufficiency = true := by native_decide
 
 /-- "cause" asserts necessity — derived from its builder. -/
-theorem cause_asserts_necessity : cause.toVerbCore.assertsNecessity = true := by native_decide
+theorem cause_asserts_necessity : cause.toVerb.assertsNecessity = true := by native_decide
 
 /-- "make" does NOT assert necessity. -/
-theorem make_not_necessity : make.toVerbCore.assertsNecessity = false := by native_decide
+theorem make_not_necessity : make.toVerb.assertsNecessity = false := by native_decide
 
 /-- "cause" does NOT assert sufficiency. -/
-theorem cause_not_sufficiency : cause.toVerbCore.assertsSufficiency = false := by native_decide
+theorem cause_not_sufficiency : cause.toVerb.assertsSufficiency = false := by native_decide
 
 /-- make-type verbs (make, have, get) share the `.make` builder. -/
 theorem make_type_verbs_share_semantics :
@@ -3433,13 +3433,13 @@ theorem let_is_permissive :
 /-- "prevent" asserts neither sufficiency nor necessity —
     it uses the dual `preventSem` (blocking). -/
 theorem prevent_not_sufficiency :
-    prevent.toVerbCore.assertsSufficiency = false := by native_decide
+    prevent.toVerb.assertsSufficiency = false := by native_decide
 
 /-- "prevent" is an EN trigger — it entails ¬p in w₀ (complement
     falsity), satisfying the FORGET class licensing condition
     (@cite{jin-koenig-2021}, §6.1.4). -/
 theorem prevent_is_en_trigger :
-    prevent.toVerbCore.isENTrigger = true := rfl
+    prevent.toVerb.isENTrigger = true := rfl
 
 /-- make, force, and let have different builders despite shared truth conditions. -/
 theorem causative_builders_distinguished :
@@ -3460,11 +3460,11 @@ theorem lexical_causatives_use_make :
 
 /-- Lexical causatives all assert sufficiency — like periphrastic "make". -/
 theorem lexical_causatives_assert_sufficiency :
-    kill.toVerbCore.assertsSufficiency = true ∧
-    break_.toVerbCore.assertsSufficiency = true ∧
-    burn.toVerbCore.assertsSufficiency = true ∧
-    destroy.toVerbCore.assertsSufficiency = true ∧
-    melt.toVerbCore.assertsSufficiency = true := by
+    kill.toVerb.assertsSufficiency = true ∧
+    break_.toVerb.assertsSufficiency = true ∧
+    burn.toVerb.assertsSufficiency = true ∧
+    destroy.toVerb.assertsSufficiency = true ∧
+    melt.toVerb.assertsSufficiency = true := by
   refine ⟨by native_decide, by native_decide, by native_decide,
           by native_decide, by native_decide⟩
 
@@ -3485,19 +3485,19 @@ removed in Phase D-G. -/
 
 /-- "manage" entails the complement — derived from its builder. -/
 theorem manage_entails_complement_derived :
-    manage.toVerbCore.entailsComplement = some true := by native_decide
+    manage.toVerb.entailsComplement = some true := by native_decide
 
 /-- "fail" entails NOT the complement — derived from its builder. -/
 theorem fail_entails_not_complement_derived :
-    fail.toVerbCore.entailsComplement = some false := by native_decide
+    fail.toVerb.entailsComplement = some false := by native_decide
 
 /-- "remember" entails the complement — derived from its builder. -/
 theorem remember_entails_complement_derived :
-    remember.toVerbCore.entailsComplement = some true := by native_decide
+    remember.toVerb.entailsComplement = some true := by native_decide
 
 /-- "forget" entails NOT the complement — derived from its builder. -/
 theorem forget_entails_not_complement_derived :
-    forget.toVerbCore.entailsComplement = some false := by native_decide
+    forget.toVerb.entailsComplement = some false := by native_decide
 
 -- ════════════════════════════════════════════════════
 -- § Morphological Stem + Vacuity

--- a/Linglib/Fragments/French/Predicates.lean
+++ b/Linglib/Fragments/French/Predicates.lean
@@ -21,8 +21,8 @@ open Features (Causative)
 open Semantics.ArgumentStructure.EntailmentProfile
   (EntailmentProfile kickSubjectProfile seeSubjectProfile runSubjectProfile)
 
-/-- French verb entry: extends VerbCore with French inflectional paradigm. -/
-structure FrenchVerbEntry extends VerbCore where
+/-- French verb entry: extends Verb with French inflectional paradigm. -/
+structure FrenchVerbEntry extends Verb where
   /-- 3sg present -/
   form3sg : String
   /-- Passé simple -/

--- a/Linglib/Fragments/German/Predicates.lean
+++ b/Linglib/Fragments/German/Predicates.lean
@@ -5,7 +5,7 @@ import Linglib.Morphology.RootTypology
 # German Predicate Lexicon Fragment
 @cite{qing-uegaki-2025} @cite{song-1996} @cite{solstad-bott-2024}
 
-German causative and attitude verb entries, extending `VerbCore` with the
+German causative and attitude verb entries, extending `Verb` with the
 German inflectional paradigm (3sg present, Präteritum, Partizip II).
 
 ## Causative verbs
@@ -29,8 +29,8 @@ namespace German.Predicates
 open Semantics.Lexical
 open Features (Causative)
 
-/-- German verb entry: extends VerbCore with German inflectional paradigm. -/
-structure GermanVerbEntry extends VerbCore where
+/-- German verb entry: extends Verb with German inflectional paradigm. -/
+structure GermanVerbEntry extends Verb where
   /-- 3sg present (er/sie/es) -/
   form3sg : String
   /-- Past (Präteritum) -/
@@ -673,31 +673,31 @@ theorem sorgen_is_uncertainty :
 /-- Non-CP-selecting verbs cannot take clausal complements.
     Their `complementType` is `.np` with no `altComplementType`. -/
 theorem nonCPSelecting_profile :
-    beenden.toVerbCore.canTakeClausalComplement = false ∧
-    streichen.toVerbCore.canTakeClausalComplement = false ∧
-    uebereilen.toVerbCore.canTakeClausalComplement = false ∧
-    entwickeln.toVerbCore.canTakeClausalComplement = false :=
+    beenden.toVerb.canTakeClausalComplement = false ∧
+    streichen.toVerb.canTakeClausalComplement = false ∧
+    uebereilen.toVerb.canTakeClausalComplement = false ∧
+    entwickeln.toVerb.canTakeClausalComplement = false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 /-- CP-and-DP-selecting verbs can take clausal complements.
     They have `altComplementType := some .finiteClause`. -/
 theorem cpSelecting_profile :
-    veranlassen.toVerbCore.canTakeClausalComplement = true ∧
-    vergessen.toVerbCore.canTakeClausalComplement = true ∧
-    erwarten.toVerbCore.canTakeClausalComplement = true ∧
-    beschliessen.toVerbCore.canTakeClausalComplement = true :=
+    veranlassen.toVerb.canTakeClausalComplement = true ∧
+    vergessen.toVerb.canTakeClausalComplement = true ∧
+    erwarten.toVerb.canTakeClausalComplement = true ∧
+    beschliessen.toVerb.canTakeClausalComplement = true :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 /-- All 8 experimental verbs can take nominal (DP) complements. -/
 theorem all_experimental_select_dp :
-    beenden.toVerbCore.canTakeNominalComplement = true ∧
-    streichen.toVerbCore.canTakeNominalComplement = true ∧
-    uebereilen.toVerbCore.canTakeNominalComplement = true ∧
-    entwickeln.toVerbCore.canTakeNominalComplement = true ∧
-    veranlassen.toVerbCore.canTakeNominalComplement = true ∧
-    vergessen.toVerbCore.canTakeNominalComplement = true ∧
-    erwarten.toVerbCore.canTakeNominalComplement = true ∧
-    beschliessen.toVerbCore.canTakeNominalComplement = true :=
+    beenden.toVerb.canTakeNominalComplement = true ∧
+    streichen.toVerb.canTakeNominalComplement = true ∧
+    uebereilen.toVerb.canTakeNominalComplement = true ∧
+    entwickeln.toVerb.canTakeNominalComplement = true ∧
+    veranlassen.toVerb.canTakeNominalComplement = true ∧
+    vergessen.toVerb.canTakeNominalComplement = true ∧
+    erwarten.toVerb.canTakeNominalComplement = true ∧
+    beschliessen.toVerb.canTakeNominalComplement = true :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 -- ============================================================================

--- a/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
@@ -16,7 +16,7 @@ content/situation typing of the matrix-verb selection that
 @cite{angelopoulos-2026} introduces (following @cite{bondarenko-2022})
 is paper-specific apparatus and lives in
 `Studies/Angelopoulos2026.lean` as a
-projection over these `VerbCore` entries — it does not pollute the
+projection over these `Verb` entries — it does not pollute the
 fragment schema.
 
 ## Three complementizers
@@ -89,14 +89,14 @@ theorem n_bearing_complementizers :
 
 /-- *léo* (λέω) 'say' — past tense *ípe* in @cite{angelopoulos-2026}
     ex. 1a. Speech-act verb, eventive (activity). -/
-def leo : VerbCore where
+def leo : Verb where
   form := "léo"
   complementType := .finiteClause
   speechActVerb := true
   vendlerClass := some .activity
 
 /-- *pistévo* (πιστεύω) 'believe' — doxastic, stative. -/
-def pistevo : VerbCore where
+def pistevo : Verb where
   form := "pistévo"
   complementType := .finiteClause
   attitude := some (.doxastic .nonVeridical)
@@ -106,7 +106,7 @@ def pistevo : VerbCore where
 
 /-- *kséro* (ξέρω) 'know' (alongside *gnorízo*) — factive doxastic,
     stative. Rejects manner adverbs (@cite{angelopoulos-2026} ex. 21a). -/
-def ksero : VerbCore where
+def ksero : Verb where
   form := "kséro"
   complementType := .finiteClause
   attitude := some (.doxastic .veridical)
@@ -116,7 +116,7 @@ def ksero : VerbCore where
 /-- *katalavéno* (καταλαβαίνω) 'understand' — eventive (allows
     manner adverbs in @cite{angelopoulos-2026} ex. 21b, 22a),
     factive doxastic. -/
-def katalaveno : VerbCore where
+def katalaveno : Verb where
   form := "katalavéno"
   complementType := .finiteClause
   attitude := some (.doxastic .veridical)
@@ -124,7 +124,7 @@ def katalaveno : VerbCore where
 
 /-- *sinidhitopió* (συνειδητοποιώ) 'realize' — eventive (achievement),
     factive doxastic (@cite{angelopoulos-2026} ex. 21b). -/
-def sinidhitopio : VerbCore where
+def sinidhitopio : Verb where
   form := "sinidhitopió"
   complementType := .finiteClause
   attitude := some (.doxastic .veridical)
@@ -132,7 +132,7 @@ def sinidhitopio : VerbCore where
 
 /-- *eksigó* (εξηγώ) 'explain' — accomplishment, takes *oti*
     yielding *explanans* reading (@cite{angelopoulos-2026} ex. 4a). -/
-def eksigo : VerbCore where
+def eksigo : Verb where
   form := "eksigó"
   complementType := .finiteClause
   vendlerClass := some .accomplishment
@@ -146,7 +146,7 @@ def eksigo : VerbCore where
 
 /-- *metanióno* (μετανιώνω) 'regret' — preferential (negative
     valence), stative. @cite{angelopoulos-2026} ex. 1b, 20. -/
-def metaniono : VerbCore where
+def metaniono : Verb where
   form := "metanióno"
   complementType := .finiteClause
   attitude := some (.preferential (.degreeComparison .negative))
@@ -154,7 +154,7 @@ def metaniono : VerbCore where
 
 /-- *aréso* (αρέσω) 'appeal to / be liked by' — Class III experiencer,
     stative (@cite{angelopoulos-2026} ex. 13, 14; @cite{landau-2009}). -/
-def areso : VerbCore where
+def areso : Verb where
   form := "aréso"
   complementType := .finiteClause
   attitude := some (.preferential (.degreeComparison .positive))
@@ -163,7 +163,7 @@ def areso : VerbCore where
 
 /-- *xérome* (χαίρομαι) 'be happy/glad' — preferential positive,
     stative. -/
-def xerome : VerbCore where
+def xerome : Verb where
   form := "xérome"
   complementType := .finiteClause
   attitude := some (.preferential (.degreeComparison .positive))
@@ -184,7 +184,7 @@ def xerome : VerbCore where
     perception (eventive, with *oti*) and stative recollection
     (with *pu*). Citation form is the eventive one;
     @cite{angelopoulos-2026} ex. 22 contrasts the two. -/
-def thimame : VerbCore where
+def thimame : Verb where
   form := "thimáme"
   complementType := .finiteClause
   altComplementType := some .finiteClause  -- pu-complement available
@@ -194,7 +194,7 @@ def thimame : VerbCore where
 /-- *thimóno* (θυμώνω) 'get/be angry' — eventive (achievement)
     normally; stative when taking *pu* (@cite{angelopoulos-2026}
     ex. 19, 23). -/
-def thimono : VerbCore where
+def thimono : Verb where
   form := "thimóno"
   complementType := .finiteClause
   altComplementType := some .finiteClause

--- a/Linglib/Fragments/Greek/StandardModern/MoodChoice.lean
+++ b/Linglib/Fragments/Greek/StandardModern/MoodChoice.lean
@@ -26,7 +26,7 @@ open Semantics.Lexical
 /-- *thélo* (θέλω) 'want' — robustly subjunctive-selecting via *na*.
     @cite{grano-2024}, (5): *na* (SBJV) required, *oti* (IND) rejected.
     Cited from @cite{giannakidou-mari-2021}. -/
-def thelo : VerbCore where
+def thelo : Verb where
   form := "thélo"
   complementType := .finiteClause
   passivizable := false
@@ -37,7 +37,7 @@ def thelo : VerbCore where
 /-- *elpízo* (ελπίζω) 'hope' — accepts both *na* (SBJV) and *oti* (IND).
     @cite{grano-2024}, (13): both complementizers accepted.
     Cited from @cite{giannakidou-mari-2021}. -/
-def elpizo : VerbCore where
+def elpizo : Verb where
   form := "elpízo"
   complementType := .finiteClause
   passivizable := false
@@ -47,7 +47,7 @@ def elpizo : VerbCore where
 /-- *protíthete* (προτίθεται) 'intend' — robustly rejects indicative.
     @cite{grano-2024}, (22): *na* (SBJV) required, *oti* (IND) rejected.
     Cited from @cite{giannakidou-mari-2021}. -/
-def protithete : VerbCore where
+def protithete : Verb where
   form := "protíthete"
   complementType := .finiteClause
   passivizable := false
@@ -58,7 +58,7 @@ def protithete : VerbCore where
 /-- *vázo* (βάζω) 'put/make' — causative, subjunctive-selecting via *na*.
     @cite{grano-2024}, (45): *na* (SBJV) required, *oti* (IND) rejected.
     Past tense form *évala* used in the paper's examples. -/
-def vazo : VerbCore where
+def vazo : Verb where
   form := "vázo"
   complementType := .finiteClause
   controlType := .objectControl

--- a/Linglib/Fragments/Hausa/VerbGrades.lean
+++ b/Linglib/Fragments/Hausa/VerbGrades.lean
@@ -16,8 +16,8 @@ derivational stem-templates (gr0–gr7) defined by a fixed pairing of
 This file is the *interpretation* of two existing Theory interfaces in
 Hausa, not a parallel hierarchy:
 
-- `Semantics/Lexical/VerbEntry.VerbCore` carries argument
-  structure, voice, and Vendler class. A Hausa verb is a `VerbCore`
+- `Semantics/Lexical/VerbEntry.Verb` carries argument
+  structure, voice, and Vendler class. A Hausa verb is a `Verb`
   *plus* a Parsons grade.
 - `Phonology/Autosegmental/RegisterTier.TRN` carries
   the autosegmental tone primitives. A grade's tone melody is a list
@@ -25,7 +25,7 @@ Hausa, not a parallel hierarchy:
 
 The grade itself is a **record of predictions** (`StemTemplate`): tone,
 final-vowel template, derivational function, and the argument-structure
-defaults the grade entails. Concrete verbs derive their `VerbCore`
+defaults the grade entails. Concrete verbs derive their `Verb`
 fields from their grade by default; per-verb overrides are explicit.
 
 The named theorems below are **universal claims about the grade system
@@ -84,7 +84,7 @@ instance (t : FVTemplate) : Decidable t.threeWayChanging :=
   inferInstanceAs (Decidable (_ ∧ _ ∧ _))
 
 -- ============================================================================
--- § 3: Stem Templates (tone × vowel × function × VerbCore defaults)
+-- § 3: Stem Templates (tone × vowel × function × Verb defaults)
 -- ============================================================================
 
 /-- Coarse derivational function of a grade (@cite{newman-2000}
@@ -96,13 +96,13 @@ inductive GradeFunction where
   | efferential | ventive | sustentative
   deriving DecidableEq, Repr
 
-/-- Default `VerbCore.complementType` predicted by the grade's primary
+/-- Default `Verb.complementType` predicted by the grade's primary
     function. -/
 def GradeFunction.defaultCT : GradeFunction → ComplementType
   | .intransitive | .sustentative => .none
   | _                              => .np
 
-/-- Default `VerbCore.voiceType` predicted by the grade's primary
+/-- Default `Verb.voiceType` predicted by the grade's primary
     function. The sustentative (passive-like) gr7 selects nonThematic
     Voice; everything else introduces an external argument. -/
 def GradeFunction.defaultVoice : GradeFunction → VoiceType
@@ -188,13 +188,13 @@ def parsons : List StemTemplate :=
   [gr0, gr1, gr2, gr3, gr4, gr5, gr6, gr7]
 
 -- ============================================================================
--- § 5: Hausa Verb Entries (extending VerbCore)
+-- § 5: Hausa Verb Entries (extending Verb)
 -- ============================================================================
 
-/-- A Hausa verb extends `VerbCore` with its Parsons grade and its
+/-- A Hausa verb extends `Verb` with its Parsons grade and its
     A-form citation tones (which may be lexical for gr0). All other
     morphological data is **derived** from the grade. -/
-structure HausaVerb extends VerbCore where
+structure HausaVerb extends Verb where
   /-- The Parsons grade fixing tone, final vowel, and argument-structure
       defaults. -/
   grade    : StemTemplate
@@ -213,7 +213,7 @@ def HausaVerb.tones (v : HausaVerb) : List TRN :=
 def HausaVerb.fv (v : HausaVerb) (f : SynForm) : FinalVowel :=
   v.grade.fv f
 
-/-- A verb is **canonical** iff its `VerbCore` argument-structure
+/-- A verb is **canonical** iff its `Verb` argument-structure
     fields agree with the defaults predicted by its grade. Per-verb
     overrides break canonicity (and become explicit empirical claims). -/
 def HausaVerb.canonical (v : HausaVerb) : Prop :=
@@ -224,7 +224,7 @@ instance (v : HausaVerb) : Decidable v.canonical :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-- Smart constructor: builds a canonical `HausaVerb` from form and
-    grade by filling `VerbCore` from the grade's defaults. Concrete
+    grade by filling `Verb` from the grade's defaults. Concrete
     verb definitions use this; per-verb overrides spell out which
     field departs from the default. -/
 def mkVerb (form : String) (g : StemTemplate)
@@ -333,7 +333,7 @@ theorem mkVerb_is_canonical (form : String) (g : StemTemplate)
   ⟨rfl, rfl⟩
 
 /-- **Grades 5 and 6 introduce an external argument.** The two H–H
-    grades are both agentive at the `VerbCore` level. -/
+    grades are both agentive at the `Verb` level. -/
 theorem hh_grades_agentive :
     gr5.defaultVoice = .agentive ∧ gr6.defaultVoice = .agentive :=
   ⟨rfl, rfl⟩

--- a/Linglib/Fragments/Hungarian/Predicates.lean
+++ b/Linglib/Fragments/Hungarian/Predicates.lean
@@ -4,7 +4,7 @@ import Linglib.Semantics.Verb.Basic
 # Hungarian Predicate Lexicon Fragment
 @cite{egressy-2026}
 
-Hungarian attitude verb entries, extending `VerbCore` with the
+Hungarian attitude verb entries, extending `Verb` with the
 Hungarian inflectional paradigm. Hungarian has a distinctive
 **definite/indefinite conjugation** split: verbs agree not just with
 the subject but also with the definiteness of the object.
@@ -34,9 +34,9 @@ namespace Hungarian.Predicates
 
 open Semantics.Lexical
 
-/-- Hungarian verb entry: extends VerbCore with the definite/indefinite
+/-- Hungarian verb entry: extends Verb with the definite/indefinite
     conjugation paradigm. -/
-structure HungarianVerbEntry extends VerbCore where
+structure HungarianVerbEntry extends Verb where
   /-- English gloss -/
   gloss : String
   /-- 3sg present definite conjugation -/

--- a/Linglib/Fragments/Indonesian/Predicates.lean
+++ b/Linglib/Fragments/Indonesian/Predicates.lean
@@ -145,7 +145,7 @@ def TerClass.retainsSuffix : TerClass → Bool
 -- § 2: Indonesian Verb Entry
 -- ============================================================================
 
-/-- An Indonesian verb entry extending VerbCore with voice paradigm forms.
+/-- An Indonesian verb entry extending Verb with voice paradigm forms.
 
     Voice prefixes follow @cite{sneddon-1996} (§1.167–177 for *ber-*,
     §1.265–275 for *ter-*, §3.26–40 for active/passive voice):
@@ -156,7 +156,7 @@ def TerClass.retainsSuffix : TerClass → Bool
     - *ter-*: stative / accidental / abilitative (@cite{sneddon-1996} §1.265–275);
       analyzed as anticausative for causer-unspecified roots by
       @cite{beavers-udayana-2022} -/
-structure IndonesianVerbEntry extends VerbCore where
+structure IndonesianVerbEntry extends Verb where
   /-- Active voice *meN-* form (with allomorph selection). -/
   formMeN : Option String := none
   /-- Middle voice *ber-* form. -/
@@ -466,7 +466,7 @@ theorem cukur_predicted_reading :
 /-- *pecah* is a break-class verb → participates in middle alternation
     (change-of-state) and causative/inchoative alternation. -/
 theorem pecah_levin_class :
-    pecah.toVerbCore.levinClass = some .break_ := rfl
+    pecah.toVerb.levinClass = some .break_ := rfl
 
 -- § 5f: ter- class verification (@cite{sneddon-1996} §1.265–1.275)
 

--- a/Linglib/Fragments/Italian/Predicates.lean
+++ b/Linglib/Fragments/Italian/Predicates.lean
@@ -57,9 +57,9 @@ def InfComplementizer.reading : InfComplementizer → Reading :=
 -- § 2. Italian Verb Entry
 -- ════════════════════════════════════════════════════════════════
 
-/-- An Italian verb entry extending `VerbCore` with the infinitival
+/-- An Italian verb entry extending `Verb` with the infinitival
     complementizer alternation. -/
-structure ItalianVerbEntry extends VerbCore where
+structure ItalianVerbEntry extends Verb where
   /-- Which infinitival complementizers the verb selects -/
   infComplements : List InfComplementizer := []
   deriving Repr, BEq

--- a/Linglib/Fragments/Japanese/Predicates.lean
+++ b/Linglib/Fragments/Japanese/Predicates.lean
@@ -15,8 +15,8 @@ open Semantics.Lexical
 open Semantics.Attitudes.Preferential (AttitudeValence NVPClass)
 open Features (Causative)
 
-/-- Japanese verb entry: extends VerbCore with Japanese inflectional paradigm. -/
-structure JapaneseVerbEntry extends VerbCore where
+/-- Japanese verb entry: extends Verb with Japanese inflectional paradigm. -/
+structure JapaneseVerbEntry extends Verb where
   /-- Nonpast finite form -/
   form3sg : String
   /-- Past form (-ta) -/

--- a/Linglib/Fragments/Korean/Complementizers.lean
+++ b/Linglib/Fragments/Korean/Complementizers.lean
@@ -106,14 +106,14 @@ def kes : { form : String // form = "kes" } :=
 
 /-- *yukamsulewehay-ta* — 'regret'. Preferential negative, stative.
     @cite{bondarenko-2022} §4.3.2. -/
-def yukamsulewehayta : VerbCore where
+def yukamsulewehayta : Verb where
   form := "yukamsulewehay-ta"
   complementType := .finiteClause
   attitude := some (.preferential (.degreeComparison .negative))
   vendlerClass := some .state
 
 /-- *mit-ta* — 'believe'. Doxastic non-veridical, stative. -/
-def mitta : VerbCore where
+def mitta : Verb where
   form := "mit-ta"
   complementType := .finiteClause
   attitude := some (.doxastic .nonVeridical)
@@ -122,7 +122,7 @@ def mitta : VerbCore where
   opaqueContext := true
 
 /-- *sayngkakha-ta* — 'think'. Doxastic non-veridical, activity. -/
-def sayngkakhata : VerbCore where
+def sayngkakhata : Verb where
   form := "sayngkakha-ta"
   complementType := .finiteClause
   attitude := some (.doxastic .nonVeridical)
@@ -130,7 +130,7 @@ def sayngkakhata : VerbCore where
   opaqueContext := true
 
 /-- *haysekha-ta* — 'interpret'. -/
-def haysekhata : VerbCore where
+def haysekhata : Verb where
   form := "haysekha-ta"
   complementType := .finiteClause
   vendlerClass := some .activity
@@ -138,7 +138,7 @@ def haysekhata : VerbCore where
 
 /-- *selmyengha-ta* — 'explain'. Accomplishment; central to
     @cite{bondarenko-2022} §4.4.2 theme-argument analysis. -/
-def selmyenghata : VerbCore where
+def selmyenghata : Verb where
   form := "selmyengha-ta"
   complementType := .finiteClause
   vendlerClass := some .accomplishment

--- a/Linglib/Fragments/Korean/Predicates.lean
+++ b/Linglib/Fragments/Korean/Predicates.lean
@@ -17,8 +17,8 @@ namespace Korean.Predicates
 open Semantics.Lexical
 open Features (Causative)
 
-/-- Korean verb entry: extends VerbCore with Korean inflectional paradigm. -/
-structure KoreanVerbEntry extends VerbCore where
+/-- Korean verb entry: extends Verb with Korean inflectional paradigm. -/
+structure KoreanVerbEntry extends Verb where
   /-- Declarative form (-ta) -/
   formDecl : String
   /-- Past form (-əss-ta) -/

--- a/Linglib/Fragments/Mandarin/Predicates.lean
+++ b/Linglib/Fragments/Mandarin/Predicates.lean
@@ -14,14 +14,14 @@ namespace Mandarin.Predicates
 open Semantics.Lexical
 open Semantics.Attitudes.Preferential (AttitudeValence NVPClass)
 
-/-- Mandarin verb entry: extends VerbCore with no inflectional morphology
+/-- Mandarin verb entry: extends Verb with no inflectional morphology
     (Mandarin is an isolating language). -/
-structure MandarinVerbEntry extends VerbCore where
+structure MandarinVerbEntry extends Verb where
   deriving Repr, BEq
 
 /-- Smart constructor: sets only the citation form (no inflection). -/
-def MandarinVerbEntry.mk' (core : VerbCore) : MandarinVerbEntry :=
-  { toVerbCore := core }
+def MandarinVerbEntry.mk' (core : Verb) : MandarinVerbEntry :=
+  { toVerb := core }
 
 /-- 期待 "qidai" — look forward to (Class 1: positive, non-C-distributive, takes questions). -/
 def qidai : MandarinVerbEntry := .mk' {

--- a/Linglib/Fragments/Portuguese/MoodChoice.lean
+++ b/Linglib/Fragments/Portuguese/MoodChoice.lean
@@ -23,7 +23,7 @@ open Semantics.Lexical
 
 /-- *querer* 'want' — robustly subjunctive-selecting.
     @cite{grano-2024}, (3a): SBJV required. -/
-def querer : VerbCore where
+def querer : Verb where
   form := "querer"
   complementType := .finiteClause
   controlType := .subjectControl
@@ -35,7 +35,7 @@ def querer : VerbCore where
 
 /-- *esperar* 'hope' — cross-linguistically variable (IND/SBJV).
     @cite{grano-2024}, (11): both IND and SBJV accepted. -/
-def esperar : VerbCore where
+def esperar : Verb where
   form := "esperar"
   complementType := .finiteClause
   controlType := .subjectControl
@@ -46,7 +46,7 @@ def esperar : VerbCore where
 
 /-- *pretender* 'intend' — robustly rejects indicative.
     @cite{grano-2024}, (26): SBJV required, IND rejected. -/
-def pretender : VerbCore where
+def pretender : Verb where
   form := "pretender"
   complementType := .infinitival
   controlType := .subjectControl
@@ -57,7 +57,7 @@ def pretender : VerbCore where
 
 /-- *fazer* 'make' — causative, rejects indicative.
     @cite{grano-2024}, (41): SBJV required via *com que*, IND rejected. -/
-def fazer : VerbCore where
+def fazer : Verb where
   form := "fazer"
   complementType := .infinitival
   controlType := .objectControl

--- a/Linglib/Fragments/Romanian/MoodChoice.lean
+++ b/Linglib/Fragments/Romanian/MoodChoice.lean
@@ -27,7 +27,7 @@ open Semantics.Lexical
 
 /-- *a vrea* 'want' — robustly subjunctive-selecting via *să*.
     @cite{grano-2024}, (6): *să* (SBJV) required, *că* (IND) rejected. -/
-def a_vrea : VerbCore where
+def a_vrea : Verb where
   form := "a vrea"
   complementType := .finiteClause
   passivizable := false
@@ -37,7 +37,7 @@ def a_vrea : VerbCore where
 
 /-- *a spera* 'hope' — cross-linguistically variable (IND/SBJV).
     @cite{grano-2024}, (14): both *să* (SBJV) and *că* (IND) accepted. -/
-def a_spera : VerbCore where
+def a_spera : Verb where
   form := "a spera"
   complementType := .finiteClause
   passivizable := false
@@ -46,7 +46,7 @@ def a_spera : VerbCore where
 
 /-- *a intenționa* 'intend' — robustly rejects indicative.
     @cite{grano-2024}, (23): *să* (SBJV) required, *că* (IND) rejected. -/
-def a_intentiona : VerbCore where
+def a_intentiona : Verb where
   form := "a intenționa"
   complementType := .finiteClause
   passivizable := false
@@ -56,7 +56,7 @@ def a_intentiona : VerbCore where
 
 /-- *a face* 'make' — causative, subjunctive-selecting via *să*.
     @cite{grano-2024}, (46): *să* (SBJV) required, *că* (IND) rejected. -/
-def a_face : VerbCore where
+def a_face : Verb where
   form := "a face"
   complementType := .finiteClause
   controlType := .objectControl

--- a/Linglib/Fragments/Spanish/MoodChoice.lean
+++ b/Linglib/Fragments/Spanish/MoodChoice.lean
@@ -23,7 +23,7 @@ open Semantics.Lexical
 
 /-- *querer* 'want' — robustly subjunctive-selecting.
     @cite{grano-2024}, (1a): SBJV required, IND rejected. -/
-def querer : VerbCore where
+def querer : Verb where
   form := "querer"
   complementType := .finiteClause
   controlType := .subjectControl
@@ -35,7 +35,7 @@ def querer : VerbCore where
 
 /-- *esperar* 'hope' — subjunctive in Spanish (unlike Portuguese/French).
     @cite{grano-2024}, (9): SBJV required, IND rejected. -/
-def esperar : VerbCore where
+def esperar : Verb where
   form := "esperar"
   complementType := .finiteClause
   controlType := .subjectControl
@@ -47,7 +47,7 @@ def esperar : VerbCore where
 /-- *tener la intención (de)* 'intend' — robustly rejects indicative.
     @cite{grano-2024}, (25): SBJV required in non-control complements.
     Periphrastic form (nominal predicate). -/
-def tener_la_intencion : VerbCore where
+def tener_la_intencion : Verb where
   form := "tener la intención"
   complementType := .infinitival
   controlType := .subjectControl
@@ -59,7 +59,7 @@ def tener_la_intencion : VerbCore where
 /-- *hacer* 'make' — causative, robustly subjunctive-selecting.
     @cite{grano-2024}, (40): SBJV required, IND rejected.
     Infinitival complements with object control. -/
-def hacer : VerbCore where
+def hacer : Verb where
   form := "hacer"
   complementType := .infinitival
   controlType := .objectControl
@@ -71,7 +71,7 @@ def hacer : VerbCore where
       un aumento al jefe" (SBJV)
     IND complement → belief: "Alice convenció a Emily de que estaba
       diciendo la verdad" (IND) -/
-def convencer : VerbCore where
+def convencer : Verb where
   form := "convencer"
   complementType := .infinitival
   controlType := .objectControl

--- a/Linglib/Fragments/Spanish/Predicates.lean
+++ b/Linglib/Fragments/Spanish/Predicates.lean
@@ -68,9 +68,9 @@ inductive CauserSpec where
 
 /-- A Spanish verb with its causative alternation properties.
 
-    Extends `VerbCore` with Spanish-specific fields for anticausative
+    Extends `Verb` with Spanish-specific fields for anticausative
     marking and event-structural decomposition. -/
-structure SpanishVerbEntry extends VerbCore where
+structure SpanishVerbEntry extends Verb where
   /-- How the anticausative is marked -/
   anticausativeMarking : AnticausativeMarking
   /-- Participates in causative/anticausative alternation -/

--- a/Linglib/Fragments/Turkish/Predicates.lean
+++ b/Linglib/Fragments/Turkish/Predicates.lean
@@ -15,8 +15,8 @@ open Semantics.Lexical
 open Semantics.Attitudes.Preferential (AttitudeValence NVPClass)
 open Features (Causative)
 
-/-- Turkish verb entry: extends VerbCore with Turkish inflectional paradigm. -/
-structure TurkishVerbEntry extends VerbCore where
+/-- Turkish verb entry: extends Verb with Turkish inflectional paradigm. -/
+structure TurkishVerbEntry extends Verb where
   /-- Progressive form (-yor) -/
   formProg : String
   /-- Past form (-dı, -tı) -/

--- a/Linglib/Phenomena/ArgumentStructure/Unaccusativity/IslandSensitivity.lean
+++ b/Linglib/Phenomena/ArgumentStructure/Unaccusativity/IslandSensitivity.lean
@@ -69,7 +69,7 @@ theorem mos_islands_discourse_sourced : mosIslandSources = [.discourse] := rfl
 /-- @cite{storment-2026}'s prediction: every MoS unaccusative licenses
     QI. Quantified version of the per-verb theorems. -/
 theorem mos_unaccusatives_license_qi :
-    ∀ v ∈ mosUnaccusatives, v.toVerbCore.derivedQI = true := by
+    ∀ v ∈ mosUnaccusatives, v.toVerb.derivedQI = true := by
   intro v hv; fin_cases hv <;> rfl
 
 /-! ## §2. Compatibility theorem
@@ -81,7 +81,7 @@ sources, both true. -/
 
 theorem mos_extraction_smuggling_asymmetry :
     mosIslandSources = [.discourse] ∧
-    ∀ v ∈ mosUnaccusatives, v.toVerbCore.derivedQI = true :=
+    ∀ v ∈ mosUnaccusatives, v.toVerb.derivedQI = true :=
   ⟨rfl, mos_unaccusatives_license_qi⟩
 
 /-! ## §3. The diagnostic value

--- a/Linglib/Phenomena/TenseAspect/AspectualConsistency.lean
+++ b/Linglib/Phenomena/TenseAspect/AspectualConsistency.lean
@@ -53,32 +53,32 @@ open Features.DegreeAchievement (DegreeAchievementScale)
 
 /-- "eat": accomplishment + sinc → telic VP with incremental theme. -/
 theorem eat_vendler_inc_consistent :
-    eat.toVerbCore.vendlerClass = some .accomplishment ∧
-    eat.toVerbCore.verbIncClass = some .sinc ∧
+    eat.toVerb.vendlerClass = some .accomplishment ∧
+    eat.toVerb.verbIncClass = some .sinc ∧
     VendlerClass.accomplishment.telicity = .telic := ⟨rfl, rfl, rfl⟩
 
 /-- "build": accomplishment + sinc → telic VP with incremental theme. -/
 theorem build_vendler_inc_consistent :
-    build.toVerbCore.vendlerClass = some .accomplishment ∧
-    build.toVerbCore.verbIncClass = some .sinc ∧
+    build.toVerb.vendlerClass = some .accomplishment ∧
+    build.toVerb.verbIncClass = some .sinc ∧
     VendlerClass.accomplishment.telicity = .telic := ⟨rfl, rfl, rfl⟩
 
 /-- "read": accomplishment + inc → telic VP with incremental (non-strict) theme. -/
 theorem read_vendler_inc_consistent :
-    read.toVerbCore.vendlerClass = some .accomplishment ∧
-    read.toVerbCore.verbIncClass = some .inc ∧
+    read.toVerb.vendlerClass = some .accomplishment ∧
+    read.toVerb.verbIncClass = some .inc ∧
     VendlerClass.accomplishment.telicity = .telic := ⟨rfl, rfl, rfl⟩
 
 /-- "push": activity + cumOnly → atelic VP, no theme-event mapping. -/
 theorem push_vendler_inc_consistent :
-    push.toVerbCore.vendlerClass = some .activity ∧
-    push.toVerbCore.verbIncClass = some .cumOnly ∧
+    push.toVerb.vendlerClass = some .activity ∧
+    push.toVerb.verbIncClass = some .cumOnly ∧
     VendlerClass.activity.telicity = .atelic := ⟨rfl, rfl, rfl⟩
 
 /-- "kick": activity + no verbIncClass → atelic, no incremental theme. -/
 theorem kick_vendler_inc_consistent :
-    kick.toVerbCore.vendlerClass = some .activity ∧
-    kick.toVerbCore.verbIncClass = none ∧
+    kick.toVerb.vendlerClass = some .activity ∧
+    kick.toVerb.verbIncClass = none ∧
     VendlerClass.activity.telicity = .atelic := ⟨rfl, rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════
@@ -92,33 +92,33 @@ theorem kick_vendler_inc_consistent :
 
 /-- "eat": GRAD ✓, SSR ✗ (accomplishment, sinc). -/
 theorem eat_grad_ssr_complementary :
-    predictsGRAD eat.toVerbCore.verbIncClass = true ∧
-    predictsSSR eat.toVerbCore.vendlerClass = false := ⟨rfl, rfl⟩
+    predictsGRAD eat.toVerb.verbIncClass = true ∧
+    predictsSSR eat.toVerb.vendlerClass = false := ⟨rfl, rfl⟩
 
 /-- "build": GRAD ✓, SSR ✗ (accomplishment, sinc). -/
 theorem build_grad_ssr_complementary :
-    predictsGRAD build.toVerbCore.verbIncClass = true ∧
-    predictsSSR build.toVerbCore.vendlerClass = false := ⟨rfl, rfl⟩
+    predictsGRAD build.toVerb.verbIncClass = true ∧
+    predictsSSR build.toVerb.vendlerClass = false := ⟨rfl, rfl⟩
 
 /-- "read": GRAD ✓, SSR ✗ (accomplishment, inc). -/
 theorem read_grad_ssr_complementary :
-    predictsGRAD read.toVerbCore.verbIncClass = true ∧
-    predictsSSR read.toVerbCore.vendlerClass = false := ⟨rfl, rfl⟩
+    predictsGRAD read.toVerb.verbIncClass = true ∧
+    predictsSSR read.toVerb.vendlerClass = false := ⟨rfl, rfl⟩
 
 /-- "push": GRAD ✗, SSR ✓ (activity, cumOnly). -/
 theorem push_grad_ssr_complementary :
-    predictsGRAD push.toVerbCore.verbIncClass = false ∧
-    predictsSSR push.toVerbCore.vendlerClass = true := ⟨rfl, rfl⟩
+    predictsGRAD push.toVerb.verbIncClass = false ∧
+    predictsSSR push.toVerb.vendlerClass = true := ⟨rfl, rfl⟩
 
 /-- "sleep": GRAD ✗, SSR ✓ (state, no incremental theme). -/
 theorem sleep_grad_ssr_complementary :
-    predictsGRAD sleep.toVerbCore.verbIncClass = false ∧
-    predictsSSR sleep.toVerbCore.vendlerClass = true := ⟨rfl, rfl⟩
+    predictsGRAD sleep.toVerb.verbIncClass = false ∧
+    predictsSSR sleep.toVerb.vendlerClass = true := ⟨rfl, rfl⟩
 
 /-- "run": GRAD ✗, SSR ✓ (activity, no incremental theme). -/
 theorem run_grad_ssr_complementary :
-    predictsGRAD run.toVerbCore.verbIncClass = false ∧
-    predictsSSR run.toVerbCore.vendlerClass = true := ⟨rfl, rfl⟩
+    predictsGRAD run.toVerb.verbIncClass = false ∧
+    predictsSSR run.toVerb.vendlerClass = true := ⟨rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 3. Full Licensing Pipeline Convergence Per Verb
@@ -131,7 +131,7 @@ theorem run_grad_ssr_complementary :
 
 /-- "eat": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem eat_full_pipeline :
-    eat.toVerbCore.vendlerClass = some .accomplishment ∧
+    eat.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -140,7 +140,7 @@ theorem eat_full_pipeline :
 
 /-- "arrive": achievement → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem arrive_full_pipeline :
-    arrive.toVerbCore.vendlerClass = some .achievement ∧
+    arrive.toVerb.vendlerClass = some .achievement ∧
     VendlerClass.achievement.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -149,7 +149,7 @@ theorem arrive_full_pipeline :
 
 /-- "sleep": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem sleep_full_pipeline :
-    sleep.toVerbCore.vendlerClass = some .state ∧
+    sleep.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -158,7 +158,7 @@ theorem sleep_full_pipeline :
 
 /-- "run": activity → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem run_full_pipeline :
-    run.toVerbCore.vendlerClass = some .activity ∧
+    run.toVerb.vendlerClass = some .activity ∧
     VendlerClass.activity.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -167,7 +167,7 @@ theorem run_full_pipeline :
 
 /-- "see": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem see_full_pipeline :
-    see.toVerbCore.vendlerClass = some .state ∧
+    see.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -176,7 +176,7 @@ theorem see_full_pipeline :
 
 /-- "leave": achievement → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem leave_full_pipeline :
-    leave.toVerbCore.vendlerClass = some .achievement ∧
+    leave.toVerb.vendlerClass = some .achievement ∧
     VendlerClass.achievement.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -185,7 +185,7 @@ theorem leave_full_pipeline :
 
 /-- "kill": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem kill_full_pipeline :
-    kill.toVerbCore.vendlerClass = some .accomplishment ∧
+    kill.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -196,7 +196,7 @@ theorem kill_full_pipeline :
 
 /-- "give": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem give_full_pipeline :
-    give.toVerbCore.vendlerClass = some .accomplishment ∧
+    give.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -205,7 +205,7 @@ theorem give_full_pipeline :
 
 /-- "cover": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem cover_full_pipeline :
-    cover.toVerbCore.vendlerClass = some .accomplishment ∧
+    cover.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -214,7 +214,7 @@ theorem cover_full_pipeline :
 
 /-- "buy": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem buy_full_pipeline :
-    buy.toVerbCore.vendlerClass = some .accomplishment ∧
+    buy.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -223,7 +223,7 @@ theorem buy_full_pipeline :
 
 /-- "sell": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem sell_full_pipeline :
-    sell.toVerbCore.vendlerClass = some .accomplishment ∧
+    sell.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -232,7 +232,7 @@ theorem sell_full_pipeline :
 
 /-- "break": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem break_full_pipeline :
-    break_.toVerbCore.vendlerClass = some .accomplishment ∧
+    break_.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -241,7 +241,7 @@ theorem break_full_pipeline :
 
 /-- "tear": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem tear_full_pipeline :
-    tear_.toVerbCore.vendlerClass = some .accomplishment ∧
+    tear_.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -250,7 +250,7 @@ theorem tear_full_pipeline :
 
 /-- "burn": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem burn_full_pipeline :
-    burn.toVerbCore.vendlerClass = some .accomplishment ∧
+    burn.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -259,7 +259,7 @@ theorem burn_full_pipeline :
 
 /-- "destroy": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem destroy_full_pipeline :
-    destroy.toVerbCore.vendlerClass = some .accomplishment ∧
+    destroy.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -268,7 +268,7 @@ theorem destroy_full_pipeline :
 
 /-- "melt": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem melt_full_pipeline :
-    melt.toVerbCore.vendlerClass = some .accomplishment ∧
+    melt.toVerb.vendlerClass = some .accomplishment ∧
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -279,7 +279,7 @@ theorem melt_full_pipeline :
 
 /-- "put": achievement → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem put_full_pipeline :
-    put.toVerbCore.vendlerClass = some .achievement ∧
+    put.toVerb.vendlerClass = some .achievement ∧
     VendlerClass.achievement.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -288,7 +288,7 @@ theorem put_full_pipeline :
 
 /-- "meet": achievement → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem meet_full_pipeline :
-    meet.toVerbCore.vendlerClass = some .achievement ∧
+    meet.toVerb.vendlerClass = some .achievement ∧
     VendlerClass.achievement.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
@@ -299,7 +299,7 @@ theorem meet_full_pipeline :
 
 /-- "chase": activity → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem chase_full_pipeline :
-    chase.toVerbCore.vendlerClass = some .activity ∧
+    chase.toVerb.vendlerClass = some .activity ∧
     VendlerClass.activity.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -308,7 +308,7 @@ theorem chase_full_pipeline :
 
 /-- "hit": activity → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem hit_full_pipeline :
-    hit.toVerbCore.vendlerClass = some .activity ∧
+    hit.toVerb.vendlerClass = some .activity ∧
     VendlerClass.activity.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -319,7 +319,7 @@ theorem hit_full_pipeline :
 
 /-- "weigh": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem weigh_full_pipeline :
-    weigh.toVerbCore.vendlerClass = some .state ∧
+    weigh.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -328,7 +328,7 @@ theorem weigh_full_pipeline :
 
 /-- "measure": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem measure_full_pipeline :
-    measure.toVerbCore.vendlerClass = some .state ∧
+    measure.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -337,7 +337,7 @@ theorem measure_full_pipeline :
 
 /-- "enjoy": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem enjoy_full_pipeline :
-    enjoy.toVerbCore.vendlerClass = some .state ∧
+    enjoy.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -346,7 +346,7 @@ theorem enjoy_full_pipeline :
 
 /-- "like": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem like_full_pipeline :
-    like.toVerbCore.vendlerClass = some .state ∧
+    like.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -355,7 +355,7 @@ theorem like_full_pipeline :
 
 /-- "hate": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem hate_full_pipeline :
-    hate.toVerbCore.vendlerClass = some .state ∧
+    hate.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -364,7 +364,7 @@ theorem hate_full_pipeline :
 
 /-- "admire": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem admire_full_pipeline :
-    admire.toVerbCore.vendlerClass = some .state ∧
+    admire.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -373,7 +373,7 @@ theorem admire_full_pipeline :
 
 /-- "envy": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem envy_full_pipeline :
-    envy.toVerbCore.vendlerClass = some .state ∧
+    envy.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -382,7 +382,7 @@ theorem envy_full_pipeline :
 
 /-- "respect": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem respect_full_pipeline :
-    respect.toVerbCore.vendlerClass = some .state ∧
+    respect.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -391,7 +391,7 @@ theorem respect_full_pipeline :
 
 /-- "value": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem value_full_pipeline :
-    value.toVerbCore.vendlerClass = some .state ∧
+    value.toVerb.vendlerClass = some .state ∧
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
@@ -409,20 +409,20 @@ theorem value_full_pipeline :
 
 /-- "arrive": achievement + inherentlyDirectedMotion + bounded path. -/
 theorem arrive_motion_consistent :
-    arrive.toVerbCore.vendlerClass = some .achievement ∧
-    arrive.toVerbCore.levinClass = some .inherentlyDirectedMotion ∧
+    arrive.toVerb.vendlerClass = some .achievement ∧
+    arrive.toVerb.levinClass = some .inherentlyDirectedMotion ∧
     LevinClass.inherentlyDirectedMotion.pathSpec = some .bounded := ⟨rfl, rfl, rfl⟩
 
 /-- "leave": achievement + leave class + source path. -/
 theorem leave_motion_consistent :
-    leave.toVerbCore.vendlerClass = some .achievement ∧
-    leave.toVerbCore.levinClass = some .leave ∧
+    leave.toVerb.vendlerClass = some .achievement ∧
+    leave.toVerb.levinClass = some .leave ∧
     LevinClass.leave.pathSpec = some .source := ⟨rfl, rfl, rfl⟩
 
 /-- "run": activity + mannerOfMotion + no inherent path. -/
 theorem run_motion_consistent :
-    run.toVerbCore.vendlerClass = some .activity ∧
-    run.toVerbCore.levinClass = some .mannerOfMotion ∧
+    run.toVerb.vendlerClass = some .activity ∧
+    run.toVerb.levinClass = some .mannerOfMotion ∧
     LevinClass.mannerOfMotion.pathSpec = none := ⟨rfl, rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════
@@ -438,7 +438,7 @@ theorem run_motion_consistent :
     produce a licensing prediction that agrees with the for/in diagnostic.
     Returns `true` for verbs without vendlerClass (vacuously OK). -/
 def pipelineOK (v : VerbEntry) : Bool :=
-  match v.toVerbCore.vendlerClass with
+  match v.toVerb.vendlerClass with
   | none => true
   | some vc =>
     let tel := vc.telicity
@@ -458,7 +458,7 @@ theorem all_verbs_pipeline_ok :
     accomplishments (telic), cumOnly verbs must be activities (atelic).
     Returns `true` for verbs without verbIncClass (vacuously OK). -/
 def incClassCoherent (v : VerbEntry) : Bool :=
-  match v.toVerbCore.verbIncClass, v.toVerbCore.vendlerClass with
+  match v.toVerb.verbIncClass, v.toVerb.vendlerClass with
   | some .sinc, some vc => vc.telicity == .telic
   | some .inc, some vc => vc.telicity == .telic
   | some .cumOnly, some vc => vc.telicity == .atelic
@@ -472,8 +472,8 @@ theorem all_verbs_inc_coherent :
     change (sinc/inc) and subinterval reference (state/activity).
     Returns `true` if the verb doesn't predict both. -/
 def gradSSRComplementary (v : VerbEntry) : Bool :=
-  !(predictsGRAD v.toVerbCore.verbIncClass &&
-    predictsSSR v.toVerbCore.vendlerClass)
+  !(predictsGRAD v.toVerb.verbIncClass &&
+    predictsSSR v.toVerb.vendlerClass)
 
 /-- No verb in the fragment predicts both GRAD and SSR. -/
 theorem all_verbs_grad_ssr_complementary :
@@ -482,7 +482,7 @@ theorem all_verbs_grad_ssr_complementary :
 /-- Count of verbs with vendlerClass annotations (for coverage tracking).
     Bump this number when adding new vendlerClass annotations. -/
 theorem vendler_coverage_count :
-    (allVerbs.filter (λ v => v.toVerbCore.vendlerClass.isSome)).length = 237 := by
+    (allVerbs.filter (λ v => v.toVerb.vendlerClass.isSome)).length = 237 := by
   native_decide
 
 -- ════════════════════════════════════════════════════
@@ -497,7 +497,7 @@ theorem vendler_coverage_count :
 /-- For a verb with degreeAchievementScale, check that vendlerClass is
     present and matches the derived value from the scale. -/
 def daVendlerConsistent (v : VerbEntry) : Bool :=
-  match v.toVerbCore.degreeAchievementScale, v.toVerbCore.vendlerClass with
+  match v.toVerb.degreeAchievementScale, v.toVerb.vendlerClass with
   | some das, some vc => das.defaultVendlerClass == vc
   | some _, none => false  -- DA scale present but no vendlerClass
   | none, _ => true        -- No DA scale, vacuously OK
@@ -524,20 +524,20 @@ theorem all_verbs_da_vendler_consistent :
     which matches `eat`'s fragment annotation. -/
 theorem k89_eat_refines_k98_matches_fragment :
     Krifka1989.eatAnApple.thematicClass.toVerbIncClass = .sinc ∧
-    eat.toVerbCore.verbIncClass = some .sinc := ⟨rfl, rfl⟩
+    eat.toVerb.verbIncClass = some .sinc := ⟨rfl, rfl⟩
 
 /-- *write a letter* (K89 §4 gradual-effected-patient) refines to K98 sinc,
     which matches `write`'s fragment annotation. -/
 theorem k89_write_refines_k98_matches_fragment :
     Krifka1989.writeALetter.thematicClass.toVerbIncClass = .sinc ∧
-    write.toVerbCore.verbIncClass = some .sinc := ⟨rfl, rfl⟩
+    write.toVerb.verbIncClass = some .sinc := ⟨rfl, rfl⟩
 
 /-- *read a letter* (K89 §4 gradual-patient, lacks UNI-E) refines to
     K98 inc, which matches `read`'s fragment annotation (allows
     re-reading). -/
 theorem k89_read_refines_k98_matches_fragment :
     Krifka1989.readALetter.thematicClass.toVerbIncClass = .inc ∧
-    read.toVerbCore.verbIncClass = some .inc := ⟨rfl, rfl⟩
+    read.toVerb.verbIncClass = some .inc := ⟨rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 8. Propositional Propagation Tests (Typeclass Form)

--- a/Linglib/Semantics/ArgumentStructure/Linking.lean
+++ b/Linglib/Semantics/ArgumentStructure/Linking.lean
@@ -110,7 +110,7 @@ namespace Semantics.ArgumentStructure.EntailmentProfile
     Note: instrument and stimulus have identical canonical profiles
     ({causation, IE}), as do goal and source ({IE}). The function
     defaults to stimulus and goal respectively. Disambiguation requires
-    external context (e.g., `VerbCore.causalSource`). -/
+    external context (e.g., `Verb.causalSource`). -/
 def EntailmentProfile.toRole (p : EntailmentProfile) : Option ThetaRole :=
   if p.volition then some .agent
   else if p.sentience && !p.causation then some .experiencer
@@ -276,7 +276,7 @@ inductive ArgPosition where
     context type.
 
     - `Verb`: what the theory needs to know about the verb. Typically
-      `VerbCore`, but could be `EntailmentProfile` (Dowty) or
+      `Verb`, but could be `EntailmentProfile` (Dowty) or
       `EventTemplate` (Rappaport Hovav & Levin).
     - `Ctx`: what the theory considers relevant about the syntactic
       structure beyond the verb itself:

--- a/Linglib/Semantics/Attitudes/Monotonicity.lean
+++ b/Linglib/Semantics/Attitudes/Monotonicity.lean
@@ -10,7 +10,7 @@ determiners. This makes the parallel between quantifier monotonicity and
 attitude monotonicity explicit: both are instances of the same algebraic
 classification.
 
-Per-verb monotonicity data lives on `VerbCore.complementSig` in the
+Per-verb monotonicity data lives on `Verb.complementSig` in the
 fragment lexicon (`Fragments/English/Predicates/Verbal.lean`), not here.
 This file provides only the derivation logic: given an `EntailmentSig`,
 what follows about conjunction distribution and neg-raising?

--- a/Linglib/Semantics/Composition/LexiconBuilder.lean
+++ b/Linglib/Semantics/Composition/LexiconBuilder.lean
@@ -15,7 +15,7 @@ semantics. Provides:
    list of named entries, replacing the hand-written match-on-strings pattern
    that Studies currently use.
 
-3. **Entry construction** (`mkLexEntry`): given a VerbCore and a
+3. **Entry construction** (`mkLexEntry`): given a Verb and a
    denotation of the appropriate type, produce a `LexEntry F`.
 
 ## Design
@@ -23,7 +23,7 @@ semantics. Provides:
 The dispatch layer does NOT generate denotations from features — that would
 be too theory-laden. It provides the *type* and the *scaffolding*; the Study
 still supplies the denotation. Domain-specific denotation builders
-(`VerbCore.getCoSSemantics`, `VerbCore.veridicality`, etc.) remain in
+(`Verb.getCoSSemantics`, `Verb.veridicality`, etc.) remain in
 `Semantics/Lexical/Verb/VerbEntry.lean`.
 
 ## Usage pattern
@@ -75,7 +75,7 @@ def ComplementType.toTy : ComplementType → Ty
   | .question      => (.e ⇒ .t) ⇒ .e ⇒ .t
 
 /-- The semantic type of a verb, determined by its complement type. -/
-def VerbCore.semanticType (v : VerbCore) : Ty :=
+def Verb.semanticType (v : Verb) : Ty :=
   v.complementType.toTy
 
 namespace Semantics.Composition.LexiconBuilder
@@ -116,7 +116,7 @@ def mergeLexicons {F : Frame} (lex1 lex2 : Lexicon F) : Lexicon F :=
 
     This ensures the entry's type tag matches the verb's argument structure
     by construction. -/
-def mkLexEntry (v : VerbCore) (F : Frame) (denot : F.Denot v.semanticType)
+def mkLexEntry (v : Verb) (F : Frame) (denot : F.Denot v.semanticType)
     : LexEntry F :=
   ⟨v.semanticType, denot⟩
 

--- a/Linglib/Semantics/Lexical/LevinClassProfiles.lean
+++ b/Linglib/Semantics/Lexical/LevinClassProfiles.lean
@@ -25,7 +25,7 @@ that root meaning determines which entailments hold:
 - **Psych-causal verbs** (amuse): stimulus subject
 
 Individual verbs can override class-level profiles via explicit
-`subjectEntailments`/`objectEntailments` on `VerbCore`.
+`subjectEntailments`/`objectEntailments` on `Verb`.
 -/
 
 namespace Features.LevinClassProfiles

--- a/Linglib/Semantics/Lexical/VerbSmuggling.lean
+++ b/Linglib/Semantics/Lexical/VerbSmuggling.lean
@@ -6,72 +6,72 @@ import Linglib.Syntax.Minimalist.Movement.Smuggling
 # Verb ↔ Smuggling Interface
 @cite{collins-2005} @cite{storment-2026} @cite{kratzer-1996}
 
-Promotes the bridge from `VerbCore`'s lexical fields to the smuggling
+Promotes the bridge from `Verb`'s lexical fields to the smuggling
 operators in `Syntax/Minimalism/Movement/Smuggling.lean`. These
-are general operations on `VerbCore` reused across argument-structure
+are general operations on `Verb` reused across argument-structure
 studies (QI, locative inversion, passives), not study-local helpers.
 
 ## Composition
 
 ```
-VerbCore.derivedUnaccusative  →  VerbCore.voiceFor : VoiceHead
-VerbCore.complementType       →  VerbCore.hasComplement : Bool
+Verb.derivedUnaccusative  →  Verb.voiceFor : VoiceHead
+Verb.complementType       →  Verb.hasComplement : Bool
                                        ↓
-                         VerbCore.derivedQI = licensesQI ∘ voiceFor ∘ hasComplement
+                         Verb.derivedQI = licensesQI ∘ voiceFor ∘ hasComplement
 ```
 
-`voiceFor` consults `VerbCore.derivedUnaccusative` (which itself reads
+`voiceFor` consults `Verb.derivedUnaccusative` (which itself reads
 `voiceType.assignsTheta` when present), keeping the chain rooted in the
 deeper Voice-as-not-introducing-external-argument characterization rather
 than the surface `unaccusative : Bool` annotation.
 -/
 
-namespace VerbCore
+namespace Verb
 
 open Minimalist
 
 /-- A verb has a syntactic complement iff its `complementType` is anything
     other than `.none`. Used by smuggling derivations to check that there
     is something to smuggle. -/
-def hasComplement (v : VerbCore) : Bool := v.complementType != .none
+def hasComplement (v : Verb) : Bool := v.complementType != .none
 
 /-- The Voice head determined by a verb's derived unaccusativity:
     non-thematic (anticausative) for unaccusatives, agentive for unergatives.
     Reads `derivedUnaccusative`, which consults `voiceType.assignsTheta`
     when present, so the bridge is grounded in the Voice-as-not-introducing-
     external-argument characterization (@cite{kratzer-1996}). -/
-def voiceFor (v : VerbCore) : VoiceHead :=
+def voiceFor (v : Verb) : VoiceHead :=
   if v.derivedUnaccusative then voiceAnticausative else voiceAgent
 
 /-- Derived prediction: does the verb license quotative inversion?
     Composes `voiceFor` and `hasComplement` through `licensesQI`
     (@cite{storment-2026}, §4: smuggling requires non-phase Voice + a
     complement to smuggle). -/
-def derivedQI (v : VerbCore) : Bool :=
+def derivedQI (v : Verb) : Bool :=
   licensesQI v.voiceFor v.hasComplement
 
 /-- A verb licenses QI iff its derived Voice permits smuggling and it
     has a complement to smuggle. Direct unfolding from `licensesQI`'s
     definition. -/
-theorem derivedQI_iff (v : VerbCore) :
+theorem derivedQI_iff (v : Verb) :
     v.derivedQI = true ↔ v.voiceFor.permitsSmuggling = true ∧ v.hasComplement = true := by
   unfold derivedQI licensesQI
   simp only [Bool.and_eq_true]
 
 /-- Unaccusative verbs project non-thematic (anticausative) Voice. -/
-theorem voiceFor_of_unaccusative (v : VerbCore)
+theorem voiceFor_of_unaccusative (v : Verb)
     (h : v.derivedUnaccusative = true) : v.voiceFor = voiceAnticausative := by
   unfold voiceFor; simp [h]
 
 /-- Unergative verbs project agentive Voice. -/
-theorem voiceFor_of_unergative (v : VerbCore)
+theorem voiceFor_of_unergative (v : Verb)
     (h : v.derivedUnaccusative = false) : v.voiceFor = voiceAgent := by
   unfold voiceFor; simp [h]
 
 /-- An unaccusative verb with a complement licenses QI. The two
     independent properties — non-phase Voice and complement availability —
     suffice. -/
-theorem derivedQI_of_unaccusative_with_complement (v : VerbCore)
+theorem derivedQI_of_unaccusative_with_complement (v : Verb)
     (hu : v.derivedUnaccusative = true) (hc : v.hasComplement = true) :
     v.derivedQI = true := by
   rw [derivedQI_iff, voiceFor_of_unaccusative v hu]
@@ -79,10 +79,10 @@ theorem derivedQI_of_unaccusative_with_complement (v : VerbCore)
 
 /-- An unergative verb cannot license QI (regardless of complement),
     because agentive Voice blocks smuggling. -/
-theorem derivedQI_blocked_when_unergative (v : VerbCore)
+theorem derivedQI_blocked_when_unergative (v : Verb)
     (hu : v.derivedUnaccusative = false) : v.derivedQI = false := by
   unfold derivedQI
   rw [voiceFor_of_unergative v hu]
   exact agentive_blocks_qi _
 
-end VerbCore
+end Verb

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -2,10 +2,10 @@ import Linglib.Semantics.Verb.Defs
 
 /-! # Verb entry — derived API
 
-Classification accessors DERIVED from the primitive `VerbCore` fields:
+Classification accessors DERIVED from the primitive `Verb` fields:
 unaccusativity from voice, veridicality from the attitude builder, presupposition
 status from event structure, theta-role linking, and so on. Verb classification
-is computed here, not stipulated as enum fields on `VerbCore`.
+is computed here, not stipulated as enum fields on `Verb`.
 -/
 
 open Semantics.Presupposition
@@ -23,55 +23,55 @@ open Features.LevinClassProfiles
 /-- Derive unaccusativity from voice type when present, falling back
     to the stored `unaccusative` field. A verb is unaccusative iff its
     Voice does not introduce an external argument (@cite{kratzer-1996}). -/
-def VerbCore.derivedUnaccusative (v : VerbCore) : Bool :=
+def Verb.derivedUnaccusative (v : Verb) : Bool :=
   match v.voiceType with
   | some vt => !vt.assignsTheta
   | none => v.unaccusative
 
 /-- Derive vendlerClass from degreeAchievementScale if present.
     Falls back to the stipulated vendlerClass field. -/
-def VerbCore.derivedVendlerClass (v : VerbCore) : Option VendlerClass :=
+def Verb.derivedVendlerClass (v : Verb) : Option VendlerClass :=
   v.vendlerClass <|> v.degreeAchievementScale.map (·.defaultVendlerClass)
 
 /-- Effective subject entailment profile: verb-level override if present,
     otherwise falls back to the Levin class–level profile
     (@cite{levin-1993}, @cite{dowty-1991}). -/
-def VerbCore.effectiveSubjectEntailments (v : VerbCore) : Option EntailmentProfile :=
+def Verb.effectiveSubjectEntailments (v : Verb) : Option EntailmentProfile :=
   v.subjectEntailments <|> v.levinClass.bind (·.subjectProfile)
 
 /-- Effective object entailment profile: verb-level override if present,
     otherwise falls back to the Levin class–level profile. -/
-def VerbCore.effectiveObjectEntailments (v : VerbCore) : Option EntailmentProfile :=
+def Verb.effectiveObjectEntailments (v : Verb) : Option EntailmentProfile :=
   v.objectEntailments <|> v.levinClass.bind (·.objectProfile)
 
 /-- Veridicality is DERIVED from the attitude builder -/
-def VerbCore.veridicality (v : VerbCore) : Option Veridicality :=
+def Verb.veridicality (v : Verb) : Option Veridicality :=
   v.attitude.map (·.veridicality)
 
 /-- Is this verb a doxastic attitude? -/
-def VerbCore.isDoxastic (v : VerbCore) : Bool :=
+def Verb.isDoxastic (v : Verb) : Bool :=
   v.attitude.map (·.isDoxastic) |>.getD false
 
 /-- Is this verb a preferential attitude? -/
-def VerbCore.isPreferential (v : VerbCore) : Bool :=
+def Verb.isPreferential (v : Verb) : Bool :=
   v.attitude.map (·.isPreferential) |>.getD false
 
 /-- Does this attitude distribute over conjunction?
     DERIVED from complementSig: any signature that refines `.mono`
     (mono, additive, mult, addMult, all) distributes. -/
-def VerbCore.distribOverConj (v : VerbCore) : Bool :=
+def Verb.distribOverConj (v : Verb) : Bool :=
   v.complementSig.map (fun s => decide (s ≤ .mono)) |>.getD false
 
 /-- Is the complement position upward-entailing?
     DERIVED from complementSig. -/
-def VerbCore.isComplementUE (v : VerbCore) : Bool :=
+def Verb.isComplementUE (v : Verb) : Bool :=
   v.complementSig.map (fun s => decide (s ≤ .mono)) |>.getD false
 
 /-- Valence is DERIVED from the attitude builder (for preferential attitudes) -/
-def VerbCore.preferentialValence (v : VerbCore) : Option AttitudeValence :=
+def Verb.preferentialValence (v : Verb) : Option AttitudeValence :=
   v.attitude.bind (·.valence)
 
--- Note: VerbCore.cDistributive, VerbCore.nvpClass, and VerbCore.takesQuestion
+-- Note: Verb.cDistributive, Verb.nvpClass, and Verb.takesQuestion
 -- are derived properties defined in Semantics.Intensional/Attitude/BuilderProperties.lean
 
 /--
@@ -80,23 +80,23 @@ Get the CoS semantics for a verb (if it's a CoS verb).
 Returns `some (cosSemantics t P)` if the verb has a CoS type,
 where `P` is the activity predicate (complement denotation).
 -/
-def VerbCore.getCoSSemantics {W : Type*} (v : VerbCore) (P : W → Prop) :
+def Verb.getCoSSemantics {W : Type*} (v : Verb) (P : W → Prop) :
     Option (PrProp W) :=
   v.cosType.map λ t => cosSemantics t P
 
 /-- Does this verb presuppose its complement via factivity?
     DERIVED from attitude: true iff the verb is doxastic veridical. -/
-def VerbCore.factivePresup (v : VerbCore) : Bool :=
+def Verb.factivePresup (v : Verb) : Bool :=
   match v.attitude with
   | some (.doxastic .veridical) => true
   | _ => false
 
 /-- Does this verb presuppose its complement? -/
-def VerbCore.presupposesComplement (v : VerbCore) : Bool :=
+def Verb.presupposesComplement (v : Verb) : Bool :=
   v.factivePresup || v.cosType.isSome
 
 /-- Is this verb a presupposition trigger? -/
-def VerbCore.isPresupTrigger (v : VerbCore) : Bool :=
+def Verb.isPresupTrigger (v : Verb) : Bool :=
   v.presupType.isSome
 
 /-- Presupposition trigger type DERIVED from event structure rather than
@@ -108,17 +108,17 @@ def VerbCore.isPresupTrigger (v : VerbCore) : Bool :=
     Note: R&S (p. 705) argue that the soft/hard trigger distinction "has
     never been clearly operationalized." We use `.softTrigger` here as a
     placeholder, not as an endorsement of a binary soft/hard taxonomy. -/
-def VerbCore.derivedPresupType (v : VerbCore) : Option PresupTriggerType :=
+def Verb.derivedPresupType (v : Verb) : Option PresupTriggerType :=
   if v.presupposesComplement then some .softTrigger else none
 
 /-- Is this verb a causative? DERIVED from causative field. -/
-def VerbCore.isCausative (v : VerbCore) : Bool :=
+def Verb.isCausative (v : Verb) : Bool :=
   v.causative.isSome
 
 /-- Does this causative verb assert sufficiency (like "make")?
 
     DERIVED: delegates to `Causative.assertsSufficiency`. -/
-def VerbCore.assertsSufficiency (v : VerbCore) : Bool :=
+def Verb.assertsSufficiency (v : Verb) : Bool :=
   v.causative.map (·.assertsSufficiency) |>.getD false
 
 /-- Lexicalist prediction of the external argument's theta role
@@ -137,8 +137,8 @@ def VerbCore.assertsSufficiency (v : VerbCore) : Bool :=
     Contrasts with the Kratzer severing prediction (`VoiceFlavor.thetaRole`),
     which derives the role from Voice flavor rather than verb-internal
     semantics. Studies comparing the two accounts can apply both to the
-    same `VerbCore` and inspect divergence. -/
-def VerbCore.predictedSubjectTheta (v : VerbCore) : Option ThetaRole :=
+    same `Verb` and inspect divergence. -/
+def Verb.predictedSubjectTheta (v : Verb) : Option ThetaRole :=
   if v.controlType == .raising then none
   else if v.levinClass == some .weather then none
   else if v.causalSource.isSome then some .stimulus
@@ -166,7 +166,7 @@ def VerbCore.predictedSubjectTheta (v : VerbCore) : Option ThetaRole :=
     EN-triggering requires matrix negation/questioning (pragmatic,
     via neg-raising), not purely lexical semantics. Temporal, logical,
     and comparative triggers are operators/connectives, not verbs. -/
-def VerbCore.isENTrigger (v : VerbCore) : Bool :=
+def Verb.isENTrigger (v : Verb) : Bool :=
   -- FEAR class: negative-valence preferential attitudes
   (v.preferentialValence == some .negative) ||
   -- FORGET class: negative implicative verbs
@@ -177,7 +177,7 @@ def VerbCore.isENTrigger (v : VerbCore) : Bool :=
 /-- Does this causative verb assert necessity (like "cause")?
 
     DERIVED: delegates to `Causative.assertsNecessity`. -/
-def VerbCore.assertsNecessity (v : VerbCore) : Bool :=
+def Verb.assertsNecessity (v : Verb) : Bool :=
   v.causative.map (·.assertsNecessity) |>.getD false
 
 /-- Does success of this implicative verb entail the complement?
@@ -185,11 +185,11 @@ def VerbCore.assertsNecessity (v : VerbCore) : Bool :=
     DERIVED: delegates to `Implicative.entailsComplement`.
     Returns `some true` for positive implicatives (*manage*, *remember*),
     `some false` for negative (*fail*, *forget*), `none` for non-implicatives. -/
-def VerbCore.entailsComplement (v : VerbCore) : Option Bool :=
+def Verb.entailsComplement (v : Verb) : Option Bool :=
   v.implicative.map (·.entailsComplement)
 
 /-- Is this verb a preferential attitude predicate? -/
-def VerbCore.isPreferentialAttitude (v : VerbCore) : Bool :=
+def Verb.isPreferentialAttitude (v : Verb) : Bool :=
   v.preferentialValence.isSome
 
 /-- Can this verb take a clausal (CP) complement?
@@ -197,18 +197,18 @@ def VerbCore.isPreferentialAttitude (v : VerbCore) : Bool :=
     Checks both primary and alternate complement frames. Used to classify
     verbs as CP-selecting vs non-CP-selecting for coordination studies
     (@cite{schwarzer-2026}). -/
-def VerbCore.canTakeClausalComplement (v : VerbCore) : Bool :=
+def Verb.canTakeClausalComplement (v : Verb) : Bool :=
   v.complementType.isClausal ||
   match v.altComplementType with | some ct => ct.isClausal | none => false
 
 /-- Can this verb take a nominal (DP) complement?
 
     Checks both primary and alternate complement frames. -/
-def VerbCore.canTakeNominalComplement (v : VerbCore) : Bool :=
+def Verb.canTakeNominalComplement (v : Verb) : Bool :=
   v.complementType.isNominal ||
   match v.altComplementType with | some ct => ct.isNominal | none => false
 
 /-- Look up a verb core by citation form and sense tag. -/
-def lookupSense (verbs : List VerbCore) (form : String) (tag : SenseTag := .default) :
-    Option VerbCore :=
+def lookupSense (verbs : List Verb) (form : String) (tag : SenseTag := .default) :
+    Option Verb :=
   verbs.find? (λ v => v.form == form && v.senseTag == tag)

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -17,21 +17,21 @@ import Linglib.Semantics.Lexical.LevinClassProfiles
 /-! # Verb entry — core type
 
 Framework-agnostic types for verb semantics: the selectional/inflectional enums
-(`ComplementType`, `VoiceType`, …) and the `VerbCore` structure that bundles the
+(`ComplementType`, `VoiceType`, …) and the `Verb` structure that bundles the
 semantic fields shared across languages.
 
-`VerbCore` is the **semantic spine** of a verb entry. Its fields are organised
+`Verb` is the **semantic spine** of a verb entry. Its fields are organised
 into facet structures under the `Verb` namespace — `Verb.ArgStructure`,
 `Verb.Aspect`, `Verb.Presupposition`, `Verb.Causation`, `Verb.Attitude`,
-`Verb.Root` — which `VerbCore` composes via `extends`. Flat field access
+`Verb.Root` — which `Verb` composes via `extends`. Flat field access
 (`v.complementType`, `v.attitude`, …) is preserved by `extends`-flattening, and
-language fragments extend `VerbCore` with their own inflectional paradigms.
+language fragments extend `Verb` with their own inflectional paradigms.
 
 Verb classification (factive, causative, attitude, …) is DERIVED from these
 primitive fields in `Semantics/Verb/Basic.lean`, not stipulated as an enum.
 
 ## Main declarations
-* `VerbCore` — the composed verb entry spine
+* `Verb` — the composed verb entry spine
 * `Verb.ArgStructure`, `Verb.Aspect`, `Verb.Presupposition`, `Verb.Causation`,
   `Verb.Attitude`, `Verb.Root` — the field facets
 
@@ -217,7 +217,7 @@ def complementToValence : ComplementType → Valence
 
 /-! ### Field facets
 
-Each facet groups a concern's fields; `VerbCore` composes them via `extends`,
+Each facet groups a concern's fields; `Verb` composes them via `extends`,
 so flat access (`v.complementType`) is preserved. -/
 
 namespace Verb
@@ -343,7 +343,7 @@ causation, attitude, root) plus the citation form, speech-act status, and a
 polysemy disambiguator. Language-specific fragments extend this with
 morphological fields appropriate to their inflectional system.
 -/
-structure VerbCore extends
+structure Verb extends
     Verb.ArgStructure, Verb.Aspect, Verb.Presupposition,
     Verb.Causation, Verb.Attitude, Verb.Root where
   /-- Citation form (cross-linguistic) -/

--- a/Linglib/Studies/AndersonJM2006.lean
+++ b/Linglib/Studies/AndersonJM2006.lean
@@ -315,17 +315,17 @@ theorem experiencer_agent_distinct_same_rank :
   exact ⟨by decide, rfl⟩
 
 -- ============================================================================
--- § 3: VerbCore → Scenario (End-to-End Bridge)
+-- § 3: Verb → Scenario (End-to-End Bridge)
 -- ============================================================================
 
-private def subjectRole (v : VerbCore) : Option ThetaRole :=
+private def subjectRole (v : Verb) : Option ThetaRole :=
   v.effectiveSubjectEntailments.bind (·.toRole)
 
-private def objectRole (v : VerbCore) : Option ThetaRole :=
+private def objectRole (v : Verb) : Option ThetaRole :=
   v.effectiveObjectEntailments.bind (·.toRole)
 
 /-- Derive Anderson's `Scenario` from a Fragment verb entry's derived roles. -/
-def toScenario (v : VerbCore) : Scenario :=
+def toScenario (v : Verb) : Scenario :=
   ⟨(subjectRole v |>.map thetaToCaseRelation).toList ++
    (objectRole v |>.map thetaToCaseRelation).toList⟩
 
@@ -345,7 +345,7 @@ def andersonLinking : LinkingTheory Scenario Unit where
     | _             => none
 
 /-- Anderson's predicted subject theta role for a verb entry. -/
-def andersonPredictedSubjectTheta (v : VerbCore) : Option ThetaRole :=
+def andersonPredictedSubjectTheta (v : Verb) : Option ThetaRole :=
   andersonLinking.predict (toScenario v) () .subject
 
 -- ============================================================================
@@ -378,8 +378,8 @@ theorem experiencer_correctly_predicted :
     verb has a derived subject role. -/
 theorem anderson_linking_accuracy :
     (allVerbs.filter λ v =>
-      (andersonPredictedSubjectTheta v.toVerbCore).isSome ==
-      (subjectRole v.toVerbCore).isSome).length = allVerbs.length := by
+      (andersonPredictedSubjectTheta v.toVerb).isSome ==
+      (subjectRole v.toVerb).isSome).length = allVerbs.length := by
   native_decide
 
 -- ============================================================================
@@ -421,10 +421,10 @@ theorem experiencer_distinguished :
     not collapsed into agent (for verbs with entailment profiles). -/
 theorem experiencer_verbs_correct :
     (allVerbs.filter λ v =>
-      (subjectRole v.toVerbCore) == some .experiencer ∧
-      andersonPredictedSubjectTheta v.toVerbCore == some .experiencer).length =
+      (subjectRole v.toVerb) == some .experiencer ∧
+      andersonPredictedSubjectTheta v.toVerb == some .experiencer).length =
     (allVerbs.filter λ v =>
-      (subjectRole v.toVerbCore) == some .experiencer).length := by
+      (subjectRole v.toVerb) == some .experiencer).length := by
   native_decide
 
 -- ============================================================================

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -460,7 +460,7 @@ theorem angelopoulos_refutes_selection_argument_only
     However, **content/situation selection is not currently a
     Fragment field** — per integration auditor N3, it is paper-
     specific apparatus that lives in this Studies file rather than
-    in `VerbCore`. Without a Fragment field, the orthogonality
+    in `Verb`. Without a Fragment field, the orthogonality
     theorem can only state a *Vendler-stativity* witness, which is
     a proxy for situation-selection (since *pu*-complements
     require stative matrix predicates per Puzzle 3) but not
@@ -471,7 +471,7 @@ theorem angelopoulos_refutes_selection_argument_only
     selection requires a Fragment-level `selectsClauseSort` field,
     queued for a follow-up substrate refactor. -/
 theorem preferential_stative_verb_exists :
-    ∃ (v : VerbCore),
+    ∃ (v : Verb),
       (∃ p, v.attitude = some (.preferential p)) ∧
       v.vendlerClass = some .state :=
   ⟨Greek.StandardModern.Complementizers.metaniono,
@@ -484,7 +484,7 @@ theorem preferential_stative_verb_exists :
     (content), this is the closest we can come to the orthogonality
     claim without a `selectsClauseSort` Fragment field. -/
 theorem doxastic_stative_verb_exists :
-    ∃ (v : VerbCore),
+    ∃ (v : Verb),
       (∃ vd, v.attitude = some (.doxastic vd)) ∧
       v.vendlerClass = some .state :=
   ⟨Greek.StandardModern.Complementizers.pistevo,

--- a/Linglib/Studies/Bhadra2024.lean
+++ b/Linglib/Studies/Bhadra2024.lean
@@ -523,7 +523,7 @@ open English.Predicates.Verbal in
     derives IE classification and correctly predicts both un- and re- blocking.
     kick.levinClass → .hit → .impingementEffecting → unCompatible=false, reCompatible=false -/
 theorem kick_end_to_end :
-    kick.toVerbCore.levinClass = some .hit ∧
+    kick.toVerb.levinClass = some .hit ∧
     (LevinClass.forceTransmissionClass .hit) = .impingementEffecting ∧
     (LevinClass.forceTransmissionClass .hit).unCompatible = false ∧
     LevinClass.reCompatible .hit = false := ⟨rfl, rfl, rfl, rfl⟩
@@ -532,7 +532,7 @@ theorem kick_end_to_end :
     derives PFC classification and correctly predicts both un- and re- compatibility.
     bend.levinClass → .bend → .potentialForChange → unCompatible=true, reCompatible=true -/
 theorem bend_end_to_end :
-    English.Predicates.Verbal.bend.toVerbCore.levinClass = some .bend ∧
+    English.Predicates.Verbal.bend.toVerb.levinClass = some .bend ∧
     (LevinClass.forceTransmissionClass .bend) = .potentialForChange ∧
     (LevinClass.forceTransmissionClass .bend).unCompatible = true ∧
     LevinClass.reCompatible .bend = true := ⟨rfl, rfl, rfl, rfl⟩
@@ -542,7 +542,7 @@ open English.Predicates.Verbal in
     derives COS classification → un- blocked, re- allowed.
     break.levinClass → .break_ → .integralChange → unCompatible=false, reCompatible=true -/
 theorem break_end_to_end :
-    break_.toVerbCore.levinClass = some .break_ ∧
+    break_.toVerb.levinClass = some .break_ ∧
     (LevinClass.forceTransmissionClass .break_) = .integralChange ∧
     (LevinClass.forceTransmissionClass .break_).unCompatible = false ∧
     LevinClass.reCompatible .break_ = true := ⟨rfl, rfl, rfl, rfl⟩

--- a/Linglib/Studies/Bruening2021.lean
+++ b/Linglib/Studies/Bruening2021.lean
@@ -56,7 +56,7 @@ Bruening's positions Lean-checkable against linglib's existing Pylkkänen
 (*melt/build*-class transitives don't license `.np_np` as their alt frame).
 
 **What is deferred**:
-- G4 (frame-conditioned licensing) requires extending `VerbCore` with
+- G4 (frame-conditioned licensing) requires extending `Verb` with
   per-frame implicit fields; schema change is out of scope for this study.
 
 **G1** (sluicing asymmetry) is formalized as a sibling in

--- a/Linglib/Studies/Champollion2017.lean
+++ b/Linglib/Studies/Champollion2017.lean
@@ -286,10 +286,10 @@ theorem meet_matches_postulates :
 
 /-- Fragment verb entries have the right Vendler class for SDR alignment. -/
 theorem verb_vendler_for_sdr :
-    see.toVerbCore.vendlerClass = some .state ∧
-    kill.toVerbCore.vendlerClass = some .accomplishment ∧
-    meet.toVerbCore.vendlerClass = some .achievement ∧
-    eat.toVerbCore.vendlerClass = some .accomplishment :=
+    see.toVerb.vendlerClass = some .state ∧
+    kill.toVerb.vendlerClass = some .accomplishment ∧
+    meet.toVerb.vendlerClass = some .achievement ∧
+    eat.toVerb.vendlerClass = some .accomplishment :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 /-! ### `SSR_univ` ↔ Vendler Bridge -/
@@ -329,18 +329,18 @@ theorem telic_classes_accept_inX :
     inXPrediction .accomplishment = .accept := ⟨rfl, rfl⟩
 
 /-- "sleep" (state) → SSR expected. -/
-theorem sleep_ssr : predictsSSR sleep.toVerbCore.vendlerClass = true := rfl
+theorem sleep_ssr : predictsSSR sleep.toVerb.vendlerClass = true := rfl
 
 /-- "run" (activity) → SSR expected. -/
-theorem run_ssr : predictsSSR run.toVerbCore.vendlerClass = true := rfl
+theorem run_ssr : predictsSSR run.toVerb.vendlerClass = true := rfl
 
 /-- "arrive" (achievement) → no SSR. -/
-theorem arrive_no_ssr : predictsSSR arrive.toVerbCore.vendlerClass = false := rfl
+theorem arrive_no_ssr : predictsSSR arrive.toVerb.vendlerClass = false := rfl
 
 /-- "eat" (accomplishment) → no SSR. -/
-theorem eat_no_ssr : predictsSSR eat.toVerbCore.vendlerClass = false := rfl
+theorem eat_no_ssr : predictsSSR eat.toVerb.vendlerClass = false := rfl
 
 /-- "see" (state) → SSR expected. -/
-theorem see_ssr : predictsSSR see.toVerbCore.vendlerClass = true := rfl
+theorem see_ssr : predictsSSR see.toVerb.vendlerClass = true := rfl
 
 end Champollion2017

--- a/Linglib/Studies/Chierchia1984.lean
+++ b/Linglib/Studies/Chierchia1984.lean
@@ -360,12 +360,12 @@ def ChierchiaControlClass.hasCP : ChierchiaControlClass → Bool
 theorem prominence_no_cp : ChierchiaControlClass.prominence.hasCP = false := rfl
 
 -- ════════════════════════════════════════════════════════════════
--- § 6. Deriving the Classification from VerbCore
+-- § 6. Deriving the Classification from Verb
 -- ════════════════════════════════════════════════════════════════
 
 /-! ## Per-Verb Classification
 
-Derive @cite{chierchia-1984}'s control class from VerbCore fields.
+Derive @cite{chierchia-1984}'s control class from Verb fields.
 
 In Chierchia's taxonomy, ALL control verbs with a fixed, lexically
 determined controller are obligatory — regardless of whether they are
@@ -375,12 +375,12 @@ distinction are orthogonal to the obligatory/semi-obligatory/prominence
 trichotomy.
 
 The semi-obligatory class (decide, signal, recommend) requires a
-VerbCore field for controller optionality, which does not currently
+Verb field for controller optionality, which does not currently
 exist. The prominence class (bother, be dangerous) requires verbs
 not currently in the English Fragment. Therefore, all current Fragment
 control verbs are classified as obligatory. -/
 
-def derivedChierchiaClass (v : VerbCore) : Option ChierchiaControlClass :=
+def derivedChierchiaClass (v : Verb) : Option ChierchiaControlClass :=
   if v.controlType == .none && v.altControlType == .none then none
   else some .obligatory
 
@@ -481,72 +481,72 @@ open English.Predicates.Verbal
     controller and exhibit all six OC properties. -/
 
 theorem try_obligatory :
-    derivedChierchiaClass try_.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass try_.toVerb = some .obligatory := rfl
 theorem manage_obligatory :
-    derivedChierchiaClass manage.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass manage.toVerb = some .obligatory := rfl
 theorem begin_obligatory :
-    derivedChierchiaClass begin_.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass begin_.toVerb = some .obligatory := rfl
 theorem stop_obligatory :
-    derivedChierchiaClass stop.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass stop.toVerb = some .obligatory := rfl
 theorem continue_obligatory :
-    derivedChierchiaClass continue_.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass continue_.toVerb = some .obligatory := rfl
 theorem fail_obligatory :
-    derivedChierchiaClass fail.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass fail.toVerb = some .obligatory := rfl
 
 /-- "persuade" is obligatory control in Chierchia's system — it has
     a fixed controller (the object) and all six OC properties. The
     subject/object distinction does not affect the obligatory class. -/
 theorem persuade_obligatory :
-    derivedChierchiaClass persuade.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass persuade.toVerb = some .obligatory := rfl
 theorem force_obligatory :
-    derivedChierchiaClass force.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass force.toVerb = some .obligatory := rfl
 
 /-- "want" is obligatory control in Chierchia's system — the subject
     is the fixed controller. Despite being an attitude verb, it has
     all six OC properties. (Contrast Landau, who classifies "want"
     as logophoric because of its attitude status.) -/
 theorem want_obligatory :
-    derivedChierchiaClass want.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass want.toVerb = some .obligatory := rfl
 theorem hope_obligatory :
-    derivedChierchiaClass hope.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass hope.toVerb = some .obligatory := rfl
 theorem promise_obligatory :
-    derivedChierchiaClass promise.toVerbCore = some .obligatory := rfl
+    derivedChierchiaClass promise.toVerb = some .obligatory := rfl
 
 -- ── Passivizability: derived agrees with stipulated ──
 
 /-- "try" (subject control): CP blocks passivization, stipulated not passivizable. -/
 theorem try_passivizability_derived :
-    derivedPassivizable try_.toVerbCore.controlType
-    = try_.toVerbCore.passivizable := rfl
+    derivedPassivizable try_.toVerb.controlType
+    = try_.toVerb.passivizable := rfl
 
 /-- "persuade" (object control): CP allows passivization, stipulated passivizable. -/
 theorem persuade_passivizability_derived :
-    derivedPassivizable persuade.toVerbCore.controlType
-    = persuade.toVerbCore.passivizable := rfl
+    derivedPassivizable persuade.toVerb.controlType
+    = persuade.toVerb.passivizable := rfl
 
 /-- "force" (object control): CP allows passivization, stipulated passivizable. -/
 theorem force_passivizability_derived :
-    derivedPassivizable force.toVerbCore.controlType
-    = force.toVerbCore.passivizable := rfl
+    derivedPassivizable force.toVerb.controlType
+    = force.toVerb.passivizable := rfl
 
 -- ── Complement semantic layer: control verbs take property-denoting complements ──
 
 /-- "try" takes an infinitival complement, which denotes a property. -/
 theorem try_property_denoting :
-    complSemLayer try_.toVerbCore.complementType = some .property := rfl
+    complSemLayer try_.toVerb.complementType = some .property := rfl
 
 /-- "want" takes an infinitival complement, which denotes a property. -/
 theorem want_property_denoting :
-    complSemLayer want.toVerbCore.complementType = some .property := rfl
+    complSemLayer want.toVerb.complementType = some .property := rfl
 
 /-- "believe" takes a finite clause, which denotes a proposition. -/
 theorem believe_proposition_denoting :
-    complSemLayer believe.toVerbCore.complementType = some .proposition := rfl
+    complSemLayer believe.toVerb.complementType = some .proposition := rfl
 
 /-- "believe" is not a control verb — consistent with taking a propositional,
     not property-denoting, complement. -/
 theorem believe_not_control :
-    derivedChierchiaClass believe.toVerbCore = none := rfl
+    derivedChierchiaClass believe.toVerb = none := rfl
 
 end VerbVerification
 
@@ -606,16 +606,16 @@ For verbs without an attitude builder (try, manage, begin, stop,
 force, fail), both systems classify them as predicative control. -/
 
 theorem try_agrees :
-    (derivedChierchiaClass try_.toVerbCore).map chierchiaToLandauTier
-    = Landau2015.derivedControlTier try_.toVerbCore := rfl
+    (derivedChierchiaClass try_.toVerb).map chierchiaToLandauTier
+    = Landau2015.derivedControlTier try_.toVerb := rfl
 
 theorem manage_agrees :
-    (derivedChierchiaClass manage.toVerbCore).map chierchiaToLandauTier
-    = Landau2015.derivedControlTier manage.toVerbCore := rfl
+    (derivedChierchiaClass manage.toVerb).map chierchiaToLandauTier
+    = Landau2015.derivedControlTier manage.toVerb := rfl
 
 theorem force_agrees :
-    (derivedChierchiaClass force.toVerbCore).map chierchiaToLandauTier
-    = Landau2015.derivedControlTier force.toVerbCore := rfl
+    (derivedChierchiaClass force.toVerb).map chierchiaToLandauTier
+    = Landau2015.derivedControlTier force.toVerb := rfl
 
 /-! ### Attitude verbs: systematic divergence
 
@@ -629,23 +629,23 @@ Landau groups by attitude status (attitude verbs introduce a
 perspectival coordinate that changes the control mechanism). -/
 
 theorem want_diverges :
-    (derivedChierchiaClass want.toVerbCore).map chierchiaToLandauTier = some .predicative
-    ∧ Landau2015.derivedControlTier want.toVerbCore = some .logophoric :=
+    (derivedChierchiaClass want.toVerb).map chierchiaToLandauTier = some .predicative
+    ∧ Landau2015.derivedControlTier want.toVerb = some .logophoric :=
   ⟨rfl, rfl⟩
 
 theorem hope_diverges :
-    (derivedChierchiaClass hope.toVerbCore).map chierchiaToLandauTier = some .predicative
-    ∧ Landau2015.derivedControlTier hope.toVerbCore = some .logophoric :=
+    (derivedChierchiaClass hope.toVerb).map chierchiaToLandauTier = some .predicative
+    ∧ Landau2015.derivedControlTier hope.toVerb = some .logophoric :=
   ⟨rfl, rfl⟩
 
 theorem promise_diverges :
-    (derivedChierchiaClass promise.toVerbCore).map chierchiaToLandauTier = some .predicative
-    ∧ Landau2015.derivedControlTier promise.toVerbCore = some .logophoric :=
+    (derivedChierchiaClass promise.toVerb).map chierchiaToLandauTier = some .predicative
+    ∧ Landau2015.derivedControlTier promise.toVerb = some .logophoric :=
   ⟨rfl, rfl⟩
 
 theorem persuade_diverges :
-    (derivedChierchiaClass persuade.toVerbCore).map chierchiaToLandauTier = some .predicative
-    ∧ Landau2015.derivedControlTier persuade.toVerbCore = some .logophoric :=
+    (derivedChierchiaClass persuade.toVerb).map chierchiaToLandauTier = some .predicative
+    ∧ Landau2015.derivedControlTier persuade.toVerb = some .logophoric :=
   ⟨rfl, rfl⟩
 
 end CrossSystemVerification

--- a/Linglib/Studies/DegenTonhauser2021.lean
+++ b/Linglib/Studies/DegenTonhauser2021.lean
@@ -271,31 +271,31 @@ def toVerbEntry : Predicate → Option VerbEntry
   | .beAnnoyed => none
   | .beRight => none
 
-/-- Map each D&T predicate to its `VerbCore` — the semantic spine shared by
+/-- Map each D&T predicate to its `Verb` — the semantic spine shared by
     verbal and copular entries. Covers all 20 predicates.
-    Copular entries go through `ClauseEmbeddingAdj.toVerbCore` (English-specific
+    Copular entries go through `ClauseEmbeddingAdj.toVerb` (English-specific
     realization: copula + adjective). -/
-def toPredicateCore : Predicate → VerbCore
-  | .know => know.toVerbCore
-  | .think => think.toVerbCore
-  | .discover => discover.toVerbCore
-  | .see => see.toVerbCore
-  | .say => say.toVerbCore
-  | .hear => hear.toVerbCore
-  | .reveal => reveal.toVerbCore
-  | .acknowledge => acknowledge.toVerbCore
-  | .admit => admit.toVerbCore
-  | .announce => announce.toVerbCore
-  | .confess => confess.toVerbCore
-  | .inform => inform.toVerbCore
-  | .suggest => suggest.toVerbCore
-  | .pretend => pretend.toVerbCore
-  | .confirm => confirm.toVerbCore
-  | .demonstrate => demonstrate.toVerbCore
-  | .establish => establish.toVerbCore
-  | .prove => prove.toVerbCore
-  | .beAnnoyed => beAnnoyed.toVerbCore
-  | .beRight => beRight.toVerbCore
+def toPredicateCore : Predicate → Verb
+  | .know => know.toVerb
+  | .think => think.toVerb
+  | .discover => discover.toVerb
+  | .see => see.toVerb
+  | .say => say.toVerb
+  | .hear => hear.toVerb
+  | .reveal => reveal.toVerb
+  | .acknowledge => acknowledge.toVerb
+  | .admit => admit.toVerb
+  | .announce => announce.toVerb
+  | .confess => confess.toVerb
+  | .inform => inform.toVerb
+  | .suggest => suggest.toVerb
+  | .pretend => pretend.toVerb
+  | .confirm => confirm.toVerb
+  | .demonstrate => demonstrate.toVerb
+  | .establish => establish.toVerb
+  | .prove => prove.toVerb
+  | .beAnnoyed => beAnnoyed.toVerb
+  | .beRight => beRight.toVerb
 
 /-- All 20 D&T predicates (alphabetical). -/
 def allPredicates : List Predicate :=
@@ -320,7 +320,7 @@ theorem all_predicates_take_clause_complement (p : Predicate) :
     (toPredicateCore p).complementType = .finiteClause ∨
     (toPredicateCore p).altComplementType = some .finiteClause := by
   cases p <;>
-    simp [toPredicateCore, Semantics.Gradability.ClauseEmbeddingAdj.toVerbCore,
+    simp [toPredicateCore, Semantics.Gradability.ClauseEmbeddingAdj.toVerb,
           beAnnoyed, beRight] <;>
     first | left; rfl | right; rfl
 

--- a/Linglib/Studies/Dowty1991.lean
+++ b/Linglib/Studies/Dowty1991.lean
@@ -283,7 +283,7 @@ theorem run_both_agree :
     PredictsUnergative runSubjectProfile := ⟨by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
--- § 6. Fragment Bridge: Profiles Match VerbCore Fields
+-- § 6. Fragment Bridge: Profiles Match Verb Fields
 -- ════════════════════════════════════════════════════
 
 /-! These theorems verify that the canonical verb profiles in
@@ -291,37 +291,37 @@ theorem run_both_agree :
     English Fragment verb entries. -/
 
 theorem kick_subject_profile_matches :
-    kick.toVerbCore.subjectEntailments = some kickSubjectProfile := rfl
+    kick.toVerb.subjectEntailments = some kickSubjectProfile := rfl
 
 theorem kick_object_profile_matches :
-    kick.toVerbCore.objectEntailments = some kickObjectProfile := rfl
+    kick.toVerb.objectEntailments = some kickObjectProfile := rfl
 
 theorem eat_subject_profile_matches :
-    eat.toVerbCore.subjectEntailments = some eatSubjectProfile := rfl
+    eat.toVerb.subjectEntailments = some eatSubjectProfile := rfl
 
 theorem eat_object_profile_matches :
-    eat.toVerbCore.objectEntailments = some eatObjectProfile := rfl
+    eat.toVerb.objectEntailments = some eatObjectProfile := rfl
 
 theorem build_subject_profile_matches :
-    build.toVerbCore.subjectEntailments = some buildSubjectProfile := rfl
+    build.toVerb.subjectEntailments = some buildSubjectProfile := rfl
 
 theorem build_object_profile_matches :
-    build.toVerbCore.objectEntailments = some buildObjectProfile := rfl
+    build.toVerb.objectEntailments = some buildObjectProfile := rfl
 
 theorem run_subject_profile_matches :
-    run.toVerbCore.subjectEntailments = some runSubjectProfile := rfl
+    run.toVerb.subjectEntailments = some runSubjectProfile := rfl
 
 theorem arrive_subject_profile_matches :
-    arrive.toVerbCore.subjectEntailments = some arriveSubjectProfile := rfl
+    arrive.toVerb.subjectEntailments = some arriveSubjectProfile := rfl
 
 theorem see_subject_profile_matches :
-    see.toVerbCore.subjectEntailments = some seeSubjectProfile := rfl
+    see.toVerb.subjectEntailments = some seeSubjectProfile := rfl
 
 theorem sweep_subject_profile_matches :
-    sweep.toVerbCore.subjectEntailments = some sweepBasicSubjectProfile := rfl
+    sweep.toVerb.subjectEntailments = some sweepBasicSubjectProfile := rfl
 
 theorem sweep_instr_subject_profile_matches :
-    sweep_instr.toVerbCore.subjectEntailments = some sweepBroomSubjectProfile := rfl
+    sweep_instr.toVerb.subjectEntailments = some sweepBroomSubjectProfile := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 7. Fragment Bridge: Predictions Match Annotations

--- a/Linglib/Studies/Glass2025.lean
+++ b/Linglib/Studies/Glass2025.lean
@@ -213,43 +213,43 @@ veridicality in the Fragment entry. These theorems will BREAK if:
 -- Factive verbs → .factive
 
 theorem know_is_factive :
-    know.toVerbCore.veridicality.map classifyVeridicality = some .factive := by
+    know.toVerb.veridicality.map classifyVeridicality = some .factive := by
   native_decide
 
 theorem realize_is_factive :
-    realize.toVerbCore.veridicality.map classifyVeridicality = some .factive := by
+    realize.toVerb.veridicality.map classifyVeridicality = some .factive := by
   native_decide
 
 theorem discover_is_factive :
-    discover.toVerbCore.veridicality.map classifyVeridicality = some .factive := by
+    discover.toVerb.veridicality.map classifyVeridicality = some .factive := by
   native_decide
 
 theorem notice_is_factive :
-    notice.toVerbCore.veridicality.map classifyVeridicality = some .factive := by
+    notice.toVerb.veridicality.map classifyVeridicality = some .factive := by
   native_decide
 
 -- Non-factive verbs → .nonfactive
 
 theorem believe_is_nonfactive :
-    believe.toVerbCore.veridicality.map classifyVeridicality = some .nonfactive := by
+    believe.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
   native_decide
 
 theorem think_is_nonfactive :
-    think.toVerbCore.veridicality.map classifyVeridicality = some .nonfactive := by
+    think.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
   native_decide
 
 theorem hope_is_nonfactive :
-    hope.toVerbCore.veridicality.map classifyVeridicality = some .nonfactive := by
+    hope.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
   native_decide
 
 theorem fear_is_nonfactive :
-    fear.toVerbCore.veridicality.map classifyVeridicality = some .nonfactive := by
+    fear.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
   native_decide
 
 -- yǐwéi: classified as nonfactive by veridicality alone
 
 theorem yiwei_veridicality_nonfactive :
-    yiwei.toVerbCore.veridicality.map classifyVeridicality = some .nonfactive := by
+    yiwei.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
   native_decide
 
 -- ============================================================================
@@ -281,7 +281,7 @@ def yiweiPostsupType : PostsupType := .weakContrafactive
 
 /-- yǐwéi's veridicality gives nonfactive — no presupposition. -/
 theorem yiwei_derived_nonfactive :
-    yiwei.toVerbCore.veridicality = some .nonVeridical := by native_decide
+    yiwei.toVerb.veridicality = some .nonVeridical := by native_decide
 
 /-- The postsupposition IS necessary: veridicality alone gives .nonfactive
     (no presupposition), but yǐwéi actually has a weak contrafactive
@@ -289,7 +289,7 @@ theorem yiwei_derived_nonfactive :
     Glass's postsupposition classification shows the two diverge — veridicality
     is blind to the postsupposition. -/
 theorem yiwei_postsup_not_from_veridicality :
-    yiwei.toVerbCore.veridicality.map classifyVeridicality = some .nonfactive ∧
+    yiwei.toVerb.veridicality.map classifyVeridicality = some .nonfactive ∧
     yiweiPostsupType = .weakContrafactive :=
   ⟨by native_decide, rfl⟩
 
@@ -320,7 +320,7 @@ theorem contrafactive_gap :
 theorem all_english_attitude_verbs_valid :
     [know, realize, discover, notice, believe, think, want, hope,
      expect, wish, fear, dread, worry].all (fun v =>
-      v.toVerbCore.veridicality.map classifyVeridicality |>.map
+      v.toVerb.veridicality.map classifyVeridicality |>.map
         presupClassIsValid |>.getD true) = true := by
   native_decide
 
@@ -338,12 +338,12 @@ This section exercises the complete pipeline for representative verbs.
 
 /-- End-to-end: "know" is factive, and factive presuppositions are valid. -/
 theorem know_endtoend_valid :
-    (know.toVerbCore.veridicality.map classifyVeridicality).map
+    (know.toVerb.veridicality.map classifyVeridicality).map
       presupClassIsValid = some true := by native_decide
 
 /-- End-to-end: "believe" is nonfactive, and nonfactive is valid. -/
 theorem believe_endtoend_valid :
-    (believe.toVerbCore.veridicality.map classifyVeridicality).map
+    (believe.toVerb.veridicality.map classifyVeridicality).map
       presupClassIsValid = some true := by native_decide
 
 /-- End-to-end: know's presupposition is satisfied in a factive context. -/

--- a/Linglib/Studies/HayKennedyLevin1999.lean
+++ b/Linglib/Studies/HayKennedyLevin1999.lean
@@ -131,36 +131,36 @@ theorem increase_unique_end {α δ Time : Type*} [Add δ]
 /-- HKL eq 26 (closed-range default): "straighten" — closed scale,
     accomplishment (telic). -/
 theorem straighten_closed_accomplishment :
-    straighten.toVerbCore.degreeAchievementScale.map (·.scaleBoundedness) =
+    straighten.toVerb.degreeAchievementScale.map (·.scaleBoundedness) =
       some Boundedness.closed ∧
-    straighten.toVerbCore.vendlerClass = some .accomplishment := ⟨rfl, rfl⟩
+    straighten.toVerb.vendlerClass = some .accomplishment := ⟨rfl, rfl⟩
 
 /-- HKL eq 27 (open-range default): "lengthen" — open scale, activity
     (atelic). -/
 theorem lengthen_open_activity :
-    lengthen.toVerbCore.degreeAchievementScale.map (·.scaleBoundedness) =
+    lengthen.toVerb.degreeAchievementScale.map (·.scaleBoundedness) =
       some Boundedness.open_ ∧
-    lengthen.toVerbCore.vendlerClass = some .activity := ⟨rfl, rfl⟩
+    lengthen.toVerb.vendlerClass = some .activity := ⟨rfl, rfl⟩
 
 /-- HKL §3.1 default: "widen" — open scale, activity (made telic only by
     overt measure phrase, see §3 below). -/
 theorem widen_open_activity :
-    widen.toVerbCore.degreeAchievementScale.map (·.scaleBoundedness) =
+    widen.toVerb.degreeAchievementScale.map (·.scaleBoundedness) =
       some Boundedness.open_ ∧
-    widen.toVerbCore.vendlerClass = some .activity := ⟨rfl, rfl⟩
+    widen.toVerb.vendlerClass = some .activity := ⟨rfl, rfl⟩
 
 /-- HKL §3.1 default: "cool" — open scale, activity (made telic only by
     overt measure phrase or contextual bound). -/
 theorem cool_open_activity :
-    cool.toVerbCore.degreeAchievementScale.map (·.scaleBoundedness) =
+    cool.toVerb.degreeAchievementScale.map (·.scaleBoundedness) =
       some Boundedness.open_ ∧
-    cool.toVerbCore.vendlerClass = some .activity := ⟨rfl, rfl⟩
+    cool.toVerb.vendlerClass = some .activity := ⟨rfl, rfl⟩
 
 /-- HKL §3.1 default: "warm" — open scale, activity. -/
 theorem warm_open_activity :
-    warm.toVerbCore.degreeAchievementScale.map (·.scaleBoundedness) =
+    warm.toVerb.degreeAchievementScale.map (·.scaleBoundedness) =
       some Boundedness.open_ ∧
-    warm.toVerbCore.vendlerClass = some .activity := ⟨rfl, rfl⟩
+    warm.toVerb.vendlerClass = some .activity := ⟨rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 3. Specifying the difference value (HKL §3.1)

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -1265,7 +1265,7 @@ theorem fear_triggers_are_rett_ambidirectional :
 
 /-! ### Connecting English fragment verb entries to EN trigger status
 
-Each of the three branches of `VerbCore.isENTrigger` corresponds to
+Each of the three branches of `Verb.isENTrigger` corresponds to
 one class of JK2021 triggers. The general theorems below show that
 the semantic property (negative valence, negative implicativity,
 causative blocking) is *sufficient* for EN trigger status — the
@@ -1276,26 +1276,26 @@ conclusion follows from the hypothesis, not by enumerating cases.
 /-- Any verb with negative preferential valence is an EN trigger.
     This captures the FEAR class: negative valence activates both p
     (attitude content) and ¬p (desire content). -/
-theorem negative_valence_is_en_trigger (v : VerbCore)
+theorem negative_valence_is_en_trigger (v : Verb)
     (h : v.preferentialValence = some .negative) :
     v.isENTrigger = true := by
-  simp only [VerbCore.isENTrigger, h, show (some AttitudeValence.negative ==
+  simp only [Verb.isENTrigger, h, show (some AttitudeValence.negative ==
     some AttitudeValence.negative) = true from rfl, Bool.true_or]
 
 /-- Any negative implicative verb is an EN trigger.
     This captures the FORGET class: "X forgot to p" entails ¬p in w₀. -/
-theorem negative_implicative_is_en_trigger (v : VerbCore)
+theorem negative_implicative_is_en_trigger (v : Verb)
     (h : v.implicative = some .negative) :
     v.isENTrigger = true := by
-  simp only [VerbCore.isENTrigger, h, show (some Implicative.negative ==
+  simp only [Verb.isENTrigger, h, show (some Implicative.negative ==
     some Implicative.negative) = true from rfl, Bool.true_or, Bool.or_true]
 
 /-- Any causative-prevent verb is an EN trigger.
     This captures the STOP/PREVENT class: blocking entails ¬p in w₀. -/
-theorem prevent_builder_is_en_trigger (v : VerbCore)
+theorem prevent_builder_is_en_trigger (v : Verb)
     (h : v.causative = some .prevent) :
     v.isENTrigger = true := by
-  simp only [VerbCore.isENTrigger, h, show (some Causative.prevent ==
+  simp only [Verb.isENTrigger, h, show (some Causative.prevent ==
     some Causative.prevent) = true from rfl, Bool.or_true]
 
 -- Instantiations for English fragment verbs: the conclusion follows
@@ -1305,27 +1305,27 @@ open English.Predicates.Verbal (fear dread worry forget prevent)
 
 /-- "fear" → negative valence → EN trigger. -/
 theorem english_fear_is_en_trigger :
-    fear.toVerbCore.isENTrigger = true :=
+    fear.toVerb.isENTrigger = true :=
   negative_valence_is_en_trigger _ rfl
 
 /-- "dread" → negative valence → EN trigger. -/
 theorem english_dread_is_en_trigger :
-    dread.toVerbCore.isENTrigger = true :=
+    dread.toVerb.isENTrigger = true :=
   negative_valence_is_en_trigger _ rfl
 
 /-- "worry" → negative valence (uncertainty-based) → EN trigger. -/
 theorem english_worry_is_en_trigger :
-    worry.toVerbCore.isENTrigger = true :=
+    worry.toVerb.isENTrigger = true :=
   negative_valence_is_en_trigger _ rfl
 
 /-- "forget" → negative implicative → EN trigger. -/
 theorem english_forget_is_en_trigger :
-    forget.toVerbCore.isENTrigger = true :=
+    forget.toVerb.isENTrigger = true :=
   negative_implicative_is_en_trigger _ rfl
 
 /-- "prevent" → causative blocking → EN trigger. -/
 theorem english_prevent_is_en_trigger :
-    prevent.toVerbCore.isENTrigger = true :=
+    prevent.toVerb.isENTrigger = true :=
   prevent_builder_is_en_trigger _ rfl
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Karttunen1971.lean
+++ b/Linglib/Studies/Karttunen1971.lean
@@ -213,61 +213,61 @@ theorem cause_karttunen_class :
 -- ── Positive implicatives ──
 
 theorem manage_positive_implicative :
-    manage.toVerbCore.implicative = some .positive := rfl
+    manage.toVerb.implicative = some .positive := rfl
 
 theorem remember_positive_implicative :
-    remember.toVerbCore.implicative = some .positive := rfl
+    remember.toVerb.implicative = some .positive := rfl
 
 theorem dare_positive_implicative :
-    dare.toVerbCore.implicative = some .positive := rfl
+    dare.toVerb.implicative = some .positive := rfl
 
 theorem bother_positive_implicative :
-    bother.toVerbCore.implicative = some .positive := rfl
+    bother.toVerb.implicative = some .positive := rfl
 
 theorem venture_positive_implicative :
-    venture.toVerbCore.implicative = some .positive := rfl
+    venture.toVerb.implicative = some .positive := rfl
 
 theorem condescend_positive_implicative :
-    condescend.toVerbCore.implicative = some .positive := rfl
+    condescend.toVerb.implicative = some .positive := rfl
 
 theorem happen_positive_implicative :
-    happen.toVerbCore.implicative = some .positive := rfl
+    happen.toVerb.implicative = some .positive := rfl
 
 -- ── Negative implicatives (§10, ex. 38) ──
 
 theorem fail_negative_implicative :
-    fail.toVerbCore.implicative = some .negative := rfl
+    fail.toVerb.implicative = some .negative := rfl
 
 theorem forget_negative_implicative :
-    forget.toVerbCore.implicative = some .negative := rfl
+    forget.toVerb.implicative = some .negative := rfl
 
 theorem neglect_negative_implicative :
-    neglect.toVerbCore.implicative = some .negative := rfl
+    neglect.toVerb.implicative = some .negative := rfl
 
 -- ── Non-implicatives ──
 
 theorem hope_not_implicative :
-    hope.toVerbCore.implicative = none := rfl
+    hope.toVerb.implicative = none := rfl
 
 theorem want_not_implicative :
-    want.toVerbCore.implicative = none := rfl
+    want.toVerb.implicative = none := rfl
 
 theorem try_not_implicative :
-    try_.toVerbCore.implicative = none := rfl
+    try_.toVerb.implicative = none := rfl
 
 theorem believe_not_implicative :
-    believe.toVerbCore.implicative = none := rfl
+    believe.toVerb.implicative = none := rfl
 
 -- ── Derived entailment predictions ──
 
 theorem manage_entails :
-    manage.toVerbCore.entailsComplement = some true := by native_decide
+    manage.toVerb.entailsComplement = some true := by native_decide
 
 theorem fail_entails_not :
-    fail.toVerbCore.entailsComplement = some false := by native_decide
+    fail.toVerb.entailsComplement = some false := by native_decide
 
 theorem hope_no_complement_entailment :
-    hope.toVerbCore.entailsComplement = none := rfl
+    hope.toVerb.entailsComplement = none := rfl
 
 -- ── Raising vs control ──
 
@@ -276,18 +276,18 @@ theorem hope_no_complement_entailment :
     Karttunen (§9) describes *happen*'s presupposition as chance-dependence,
     but does not discuss its syntactic control type. -/
 theorem happen_is_raising :
-    happen.toVerbCore.controlType = .raising := rfl
+    happen.toVerb.controlType = .raising := rfl
 
 /-- *dare* and *bother* have both presupposition (occasion verbs) AND
     implicative entailment: "John dared to speak" presupposes risk AND
     entails "John spoke." These are compatible per Karttunen §9. -/
 theorem dare_presup_and_implicative :
-    dare.toVerbCore.presupType = some .prerequisiteSoft ∧
-    dare.toVerbCore.implicative = some .positive := ⟨rfl, rfl⟩
+    dare.toVerb.presupType = some .prerequisiteSoft ∧
+    dare.toVerb.implicative = some .positive := ⟨rfl, rfl⟩
 
 theorem bother_presup_and_implicative :
-    bother.toVerbCore.presupType = some .prerequisiteSoft ∧
-    bother.toVerbCore.implicative = some .positive := ⟨rfl, rfl⟩
+    bother.toVerb.presupType = some .prerequisiteSoft ∧
+    bother.toVerb.implicative = some .positive := ⟨rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 4. Factive vs Implicative (§§0–2)
@@ -300,23 +300,23 @@ theorem bother_presup_and_implicative :
     "John didn't manage to solve it" — entails "he didn't solve it." -/
 
 theorem know_factive_not_implicative :
-    know.toVerbCore.presupType = some .softTrigger ∧
-    know.toVerbCore.implicative = none := ⟨rfl, rfl⟩
+    know.toVerb.presupType = some .softTrigger ∧
+    know.toVerb.implicative = none := ⟨rfl, rfl⟩
 
 theorem manage_implicative_not_factive :
-    manage.toVerbCore.implicative = some .positive ∧
-    manage.toVerbCore.presupType = some .prerequisiteSoft := ⟨rfl, rfl⟩
+    manage.toVerb.implicative = some .positive ∧
+    manage.toVerb.presupType = some .prerequisiteSoft := ⟨rfl, rfl⟩
 
 theorem hope_neither :
-    hope.toVerbCore.presupType = none ∧
-    hope.toVerbCore.implicative = none := ⟨rfl, rfl⟩
+    hope.toVerb.presupType = none ∧
+    hope.toVerb.implicative = none := ⟨rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 5. Sufficient-Only Verbs (§11, ex. 56–59)
 -- ════════════════════════════════════════════════════════════════
 
 theorem force_has_causative :
-    force.toVerbCore.causative = some .force := rfl
+    force.toVerb.causative = some .force := rfl
 
 theorem force_asserts_sufficiency :
     Causative.force.assertsSufficiency = true := rfl

--- a/Linglib/Studies/Karttunen1973.lean
+++ b/Linglib/Studies/Karttunen1973.lean
@@ -49,7 +49,7 @@ open English.Predicates.Verbal
     the complement."
 
     K1973's lists are **lexical, not structural**: there is no clean
-    `inferProjection : VerbCore → ProjectionBehavior`, because the
+    `inferProjection : Verb → ProjectionBehavior`, because the
     Fragment has e.g. `reveal` as `speechActVerb := true` *and* a factive
     soft-trigger (which would be a hole). So the file consolidates K's
     Fragment-attested classifications as list-quantified theorems
@@ -65,11 +65,11 @@ def k1973PlugVerbs : List VerbEntry := [say, tell, promise]
 def k1973HoleVerbs : List VerbEntry := [know, regret, realize, stop, manage, force]
 
 theorem k1973_plug_classification :
-    ∀ v ∈ k1973PlugVerbs, v.toVerbCore.projectionBehavior = some .plug := by
+    ∀ v ∈ k1973PlugVerbs, v.toVerb.projectionBehavior = some .plug := by
   decide
 
 theorem k1973_hole_classification :
-    ∀ v ∈ k1973HoleVerbs, v.toVerbCore.projectionBehavior = some .hole := by
+    ∀ v ∈ k1973HoleVerbs, v.toVerb.projectionBehavior = some .hole := by
   decide
 
 /-- The classes are disjoint. -/
@@ -83,13 +83,13 @@ theorem k1973_plug_hole_disjoint :
     orthogonal to projection-behavior (passes complement presuppositions
     through?). *know* exhibits both. -/
 theorem know_trigger_and_hole :
-    know.toVerbCore.presupType = some .softTrigger ∧
-    know.toVerbCore.projectionBehavior = some .hole := ⟨rfl, rfl⟩
+    know.toVerb.presupType = some .softTrigger ∧
+    know.toVerb.projectionBehavior = some .hole := ⟨rfl, rfl⟩
 
 /-- *say* is a non-trigger AND a plug. -/
 theorem say_nontrigger_and_plug :
-    say.toVerbCore.presupType = none ∧
-    say.toVerbCore.projectionBehavior = some .plug := ⟨rfl, rfl⟩
+    say.toVerb.presupType = none ∧
+    say.toVerb.projectionBehavior = some .plug := ⟨rfl, rfl⟩
 
 /-- K1973 fn 6 (p. 175 paragraph 4): *tell* is a plug for *that*-clauses
     but a hole for indirect questions ("Bill told John that Harry insulted
@@ -99,14 +99,14 @@ theorem say_nontrigger_and_plug :
     the indirect-question case is a separate analysis K credits to
     Permesly 1973 (Ch. 2). -/
 theorem tell_that_clause_is_plug :
-    tell.toVerbCore.projectionBehavior = some .plug := rfl
+    tell.toVerb.projectionBehavior = some .plug := rfl
 
 /-- K1973 §1 (5)/(6) typological contrast: plugs and holes are *distinct*
     profiles. K's own minimal pair uses *order* vs *force*; *order* lacks
     a Fragment annotation, so we use the closest attested pair (*promise*,
     plug; *force*, hole). -/
 theorem promise_force_minimal_pair :
-    promise.toVerbCore.projectionBehavior ≠ force.toVerbCore.projectionBehavior := by
+    promise.toVerb.projectionBehavior ≠ force.toVerb.projectionBehavior := by
   decide
 
 -- ════════════════════════════════════════════════════════════════
@@ -141,11 +141,11 @@ theorem promise_force_minimal_pair :
 
 /-- The Fragment `believe` annotation diverges from K1973 §11. -/
 theorem believe_fragment_is_hole :
-    believe.toVerbCore.projectionBehavior = some .hole := rfl
+    believe.toVerb.projectionBehavior = some .hole := rfl
 
 /-- *believe* has no presupposition trigger (doxastic, not factive). -/
 theorem believe_nontrigger :
-    believe.toVerbCore.presupType = none := rfl
+    believe.toVerb.presupType = none := rfl
 
 /-! ### Contentful disagreement on a concrete scenario
 
@@ -199,7 +199,7 @@ theorem plug_vs_hole_diverge_at_actual :
 theorem karttunen1973_disagrees_with_modern_consensus :
     -- K1973 §11 verdict (plug) ≠ Fragment annotation (hole)
     (some .plug : Option ProjectionBehavior) ≠
-      believe.toVerbCore.projectionBehavior := by decide
+      believe.toVerb.projectionBehavior := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 3. Filter Rules for the Connectives

--- a/Linglib/Studies/KennedyLevin2008.lean
+++ b/Linglib/Studies/KennedyLevin2008.lean
@@ -57,63 +57,63 @@ private def aOpen := English.Predicates.Adjectival.open_
 
 /-- "bend": closed scale → accomplishment (derived = stipulated). -/
 theorem bend_derived_vendler :
-    bend.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    bend.toVerbCore.vendlerClass.get! := rfl
+    bend.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    bend.toVerb.vendlerClass.get! := rfl
 
 /-- "boil": closed scale → accomplishment (derived = stipulated). -/
 theorem boil_derived_vendler :
-    boil.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    boil.toVerbCore.vendlerClass.get! := rfl
+    boil.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    boil.toVerb.vendlerClass.get! := rfl
 
 /-- "rust": open scale → activity (derived = stipulated). -/
 theorem rust_derived_vendler :
-    rust.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    rust.toVerbCore.vendlerClass.get! := rfl
+    rust.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    rust.toVerb.vendlerClass.get! := rfl
 
 /-- "increase": open scale → activity (derived = stipulated). -/
 theorem increase_derived_vendler :
-    increase.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    increase.toVerbCore.vendlerClass.get! := rfl
+    increase.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    increase.toVerb.vendlerClass.get! := rfl
 
 /-- "clean": closed scale → accomplishment (derived = stipulated). -/
 theorem clean_derived_vendler :
-    vClean.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    vClean.toVerbCore.vendlerClass.get! := rfl
+    vClean.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    vClean.toVerb.vendlerClass.get! := rfl
 
 /-- "straighten": closed scale → accomplishment (derived = stipulated). -/
 theorem straighten_derived_vendler :
-    straighten.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    straighten.toVerbCore.vendlerClass.get! := rfl
+    straighten.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    straighten.toVerb.vendlerClass.get! := rfl
 
 /-- "flatten": closed scale → accomplishment (derived = stipulated). -/
 theorem flatten_derived_vendler :
-    flatten.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    flatten.toVerbCore.vendlerClass.get! := rfl
+    flatten.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    flatten.toVerb.vendlerClass.get! := rfl
 
 /-- "open": closed scale → accomplishment (derived = stipulated). -/
 theorem open_derived_vendler :
-    vOpen.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    vOpen.toVerbCore.vendlerClass.get! := rfl
+    vOpen.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    vOpen.toVerb.vendlerClass.get! := rfl
 
 /-- "lengthen": open scale → activity (derived = stipulated). -/
 theorem lengthen_derived_vendler :
-    lengthen.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    lengthen.toVerbCore.vendlerClass.get! := rfl
+    lengthen.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    lengthen.toVerb.vendlerClass.get! := rfl
 
 /-- "widen": open scale → activity (derived = stipulated). -/
 theorem widen_derived_vendler :
-    widen.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    widen.toVerbCore.vendlerClass.get! := rfl
+    widen.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    widen.toVerb.vendlerClass.get! := rfl
 
 /-- "cool": open scale → activity (derived = stipulated). -/
 theorem cool_derived_vendler :
-    vCool.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    vCool.toVerbCore.vendlerClass.get! := rfl
+    vCool.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    vCool.toVerb.vendlerClass.get! := rfl
 
 /-- "warm": open scale → activity (derived = stipulated). -/
 theorem warm_derived_vendler :
-    vWarm.toVerbCore.degreeAchievementScale.get!.defaultVendlerClass =
-    vWarm.toVerbCore.vendlerClass.get! := rfl
+    vWarm.toVerb.degreeAchievementScale.get!.defaultVendlerClass =
+    vWarm.toVerb.vendlerClass.get! := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 2. Adjective-Verb Scale Agreement
@@ -126,42 +126,42 @@ theorem warm_derived_vendler :
 /-- clean (adj, closed) ↔ clean (verb, closed scale). -/
 theorem clean_adj_verb_scale :
     aClean.scaleType =
-    (vClean.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (vClean.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 
 /-- straight (adj, closed) ↔ straighten (verb, closed scale). -/
 theorem straight_straighten_scale :
     English.Predicates.Adjectival.straight.scaleType =
-    (straighten.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (straighten.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 
 /-- flat (adj, closed) ↔ flatten (verb, closed scale). -/
 theorem flat_flatten_scale :
     English.Predicates.Adjectival.flat.scaleType =
-    (flatten.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (flatten.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 
 /-- open (adj, closed) ↔ open (verb, closed scale). -/
 theorem open_adj_verb_scale :
     aOpen.scaleType =
-    (vOpen.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (vOpen.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 
 /-- long (adj, open) ↔ lengthen (verb, open scale). -/
 theorem long_lengthen_scale :
     English.Predicates.Adjectival.long.scaleType =
-    (lengthen.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (lengthen.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 
 /-- wide (adj, open) ↔ widen (verb, open scale). -/
 theorem wide_widen_scale :
     English.Predicates.Adjectival.wide.scaleType =
-    (widen.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (widen.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 
 /-- cool (adj, open) ↔ cool (verb, open scale). -/
 theorem cool_adj_verb_scale :
     aCool.scaleType =
-    (vCool.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (vCool.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 
 /-- warm (adj, open) ↔ warm (verb, open scale). -/
 theorem warm_adj_verb_scale :
     aWarm.scaleType =
-    (vWarm.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (vWarm.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 
 /-- hot (adj, open) ↔ boil (verb, closed scale for boiling point).
     Note: boil reaches a closed endpoint (boiling point) even though the
@@ -169,7 +169,7 @@ theorem warm_adj_verb_scale :
     selects the relevant portion of the scale. -/
 theorem hot_boil_scale_diverges :
     English.Predicates.Adjectival.hot.scaleType = .open_ ∧
-    (boil.toVerbCore.degreeAchievementScale.get!).scaleBoundedness = .closed := ⟨rfl, rfl⟩
+    (boil.toVerb.degreeAchievementScale.get!).scaleBoundedness = .closed := ⟨rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 3. Telicity Diagnostic Predictions
@@ -182,53 +182,53 @@ theorem hot_boil_scale_diverges :
 
 /-- "bent the wire in 5 seconds" — closed-scale DA accepts "in X". -/
 theorem bend_inX :
-    inXPrediction bend.toVerbCore.vendlerClass.get! = .accept := rfl
+    inXPrediction bend.toVerb.vendlerClass.get! = .accept := rfl
 
 /-- "boiled the water in 3 minutes" — closed-scale DA accepts "in X". -/
 theorem boil_inX :
-    inXPrediction boil.toVerbCore.vendlerClass.get! = .accept := rfl
+    inXPrediction boil.toVerb.vendlerClass.get! = .accept := rfl
 
 /-- "cleaned the table in 5 minutes" — closed-scale DA accepts "in X". -/
 theorem clean_inX :
-    inXPrediction vClean.toVerbCore.vendlerClass.get! = .accept := rfl
+    inXPrediction vClean.toVerb.vendlerClass.get! = .accept := rfl
 
 /-- "straightened the wire in 10 seconds" — closed-scale DA accepts "in X". -/
 theorem straighten_inX :
-    inXPrediction straighten.toVerbCore.vendlerClass.get! = .accept := rfl
+    inXPrediction straighten.toVerb.vendlerClass.get! = .accept := rfl
 
 /-- "flattened the dough in 2 minutes" — closed-scale DA accepts "in X". -/
 theorem flatten_inX :
-    inXPrediction flatten.toVerbCore.vendlerClass.get! = .accept := rfl
+    inXPrediction flatten.toVerb.vendlerClass.get! = .accept := rfl
 
 /-- "opened the door in 3 seconds" — closed-scale DA accepts "in X". -/
 theorem open_inX :
-    inXPrediction vOpen.toVerbCore.vendlerClass.get! = .accept := rfl
+    inXPrediction vOpen.toVerb.vendlerClass.get! = .accept := rfl
 
 -- Open-scale: "for X" ✓
 
 /-- "rusted for years" — open-scale DA accepts "for X". -/
 theorem rust_forX :
-    forXPrediction rust.toVerbCore.vendlerClass.get! = .accept := rfl
+    forXPrediction rust.toVerb.vendlerClass.get! = .accept := rfl
 
 /-- "increased for months" — open-scale DA accepts "for X". -/
 theorem increase_forX :
-    forXPrediction increase.toVerbCore.vendlerClass.get! = .accept := rfl
+    forXPrediction increase.toVerb.vendlerClass.get! = .accept := rfl
 
 /-- "lengthened the rope for hours" — open-scale DA accepts "for X". -/
 theorem lengthen_forX :
-    forXPrediction lengthen.toVerbCore.vendlerClass.get! = .accept := rfl
+    forXPrediction lengthen.toVerb.vendlerClass.get! = .accept := rfl
 
 /-- "widened the road for months" — open-scale DA accepts "for X". -/
 theorem widen_forX :
-    forXPrediction widen.toVerbCore.vendlerClass.get! = .accept := rfl
+    forXPrediction widen.toVerb.vendlerClass.get! = .accept := rfl
 
 /-- "cooled for an hour" — open-scale DA accepts "for X". -/
 theorem cool_forX :
-    forXPrediction vCool.toVerbCore.vendlerClass.get! = .accept := rfl
+    forXPrediction vCool.toVerb.vendlerClass.get! = .accept := rfl
 
 /-- "warmed for an hour" — open-scale DA accepts "for X". -/
 theorem warm_forX :
-    forXPrediction vWarm.toVerbCore.vendlerClass.get! = .accept := rfl
+    forXPrediction vWarm.toVerb.vendlerClass.get! = .accept := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 4. Pipeline Convergence
@@ -240,63 +240,63 @@ theorem warm_forX :
 
 /-- "bend": DA pipeline → closed = VendlerClass pipeline → closed. -/
 theorem bend_pipeline_converge :
-    LicensingPipeline.toBoundedness bend.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness bend.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness bend.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness bend.toVerb.vendlerClass.get! := rfl
 
 /-- "boil": DA pipeline → closed = VendlerClass pipeline → closed. -/
 theorem boil_pipeline_converge :
-    LicensingPipeline.toBoundedness boil.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness boil.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness boil.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness boil.toVerb.vendlerClass.get! := rfl
 
 /-- "rust": DA pipeline → open = VendlerClass pipeline → open. -/
 theorem rust_pipeline_converge :
-    LicensingPipeline.toBoundedness rust.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness rust.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness rust.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness rust.toVerb.vendlerClass.get! := rfl
 
 /-- "increase": DA pipeline → open = VendlerClass pipeline → open. -/
 theorem increase_pipeline_converge :
-    LicensingPipeline.toBoundedness increase.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness increase.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness increase.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness increase.toVerb.vendlerClass.get! := rfl
 
 /-- "clean": DA pipeline → closed = VendlerClass pipeline → closed. -/
 theorem clean_pipeline_converge :
-    LicensingPipeline.toBoundedness vClean.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness vClean.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness vClean.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness vClean.toVerb.vendlerClass.get! := rfl
 
 /-- "straighten": DA pipeline → closed = VendlerClass pipeline → closed. -/
 theorem straighten_pipeline_converge :
-    LicensingPipeline.toBoundedness straighten.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness straighten.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness straighten.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness straighten.toVerb.vendlerClass.get! := rfl
 
 /-- "flatten": DA pipeline → closed = VendlerClass pipeline → closed. -/
 theorem flatten_pipeline_converge :
-    LicensingPipeline.toBoundedness flatten.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness flatten.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness flatten.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness flatten.toVerb.vendlerClass.get! := rfl
 
 /-- "open": DA pipeline → closed = VendlerClass pipeline → closed. -/
 theorem open_pipeline_converge :
-    LicensingPipeline.toBoundedness vOpen.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness vOpen.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness vOpen.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness vOpen.toVerb.vendlerClass.get! := rfl
 
 /-- "lengthen": DA pipeline → open = VendlerClass pipeline → open. -/
 theorem lengthen_pipeline_converge :
-    LicensingPipeline.toBoundedness lengthen.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness lengthen.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness lengthen.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness lengthen.toVerb.vendlerClass.get! := rfl
 
 /-- "widen": DA pipeline → open = VendlerClass pipeline → open. -/
 theorem widen_pipeline_converge :
-    LicensingPipeline.toBoundedness widen.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness widen.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness widen.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness widen.toVerb.vendlerClass.get! := rfl
 
 /-- "cool": DA pipeline → open = VendlerClass pipeline → open. -/
 theorem cool_pipeline_converge :
-    LicensingPipeline.toBoundedness vCool.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness vCool.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness vCool.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness vCool.toVerb.vendlerClass.get! := rfl
 
 /-- "warm": DA pipeline → open = VendlerClass pipeline → open. -/
 theorem warm_pipeline_converge :
-    LicensingPipeline.toBoundedness vWarm.toVerbCore.degreeAchievementScale.get! =
-    LicensingPipeline.toBoundedness vWarm.toVerbCore.vendlerClass.get! := rfl
+    LicensingPipeline.toBoundedness vWarm.toVerb.degreeAchievementScale.get! =
+    LicensingPipeline.toBoundedness vWarm.toVerb.vendlerClass.get! := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 5. Substrate-Level Demonstration: K&L → Beavers

--- a/Linglib/Studies/Kratzer1996.lean
+++ b/Linglib/Studies/Kratzer1996.lean
@@ -10,12 +10,12 @@ Two accounts of argument realization make predictions about external
 argument theta roles. The two predicates live next to the types they
 project from: severing in `VoiceFlavor.thetaRole`
 (`Syntax/Minimalist/Voice.lean`) and lexicalist in
-`VerbCore.predictedSubjectTheta`
+`Verb.predictedSubjectTheta`
 (`Semantics/Lexical/VerbEntry.lean`). Both operate over proto-role
 entailment profiles (`subjectEntailments` / `objectEntailments`) rather
 than the legacy `subjectTheta` / `objectTheta` labels (which were
-removed from `VerbCore`). Studies comparing the two accounts apply both
-predicates to the same `VerbCore` and inspect divergence; the
+removed from `Verb`). Studies comparing the two accounts apply both
+predicates to the same `Verb` and inspect divergence; the
 `LinkingTheory` packaging that previously lived in `VoiceTheta.lean`
 was dissolved as having no remaining consumers.
 

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -116,80 +116,80 @@ open Phenomena.TenseAspect.Diagnostics (forXPrediction inXPrediction DiagnosticR
     `example`s, but as `theorem`s they're discoverable via `#check`. -/
 
 /-- "eat" is strictly incremental (consumption: bijective theme-event map). -/
-theorem eat_sinc : eat.toVerbCore.verbIncClass = some .sinc := rfl
+theorem eat_sinc : eat.toVerb.verbIncClass = some .sinc := rfl
 
 /-- "devour" is strictly incremental (consumption variant of eat). -/
-theorem devour_sinc : devour.toVerbCore.verbIncClass = some .sinc := rfl
+theorem devour_sinc : devour.toVerb.verbIncClass = some .sinc := rfl
 
 /-- "build" is strictly incremental (creation: bijective theme-event map). -/
-theorem build_sinc : build.toVerbCore.verbIncClass = some .sinc := rfl
+theorem build_sinc : build.toVerb.verbIncClass = some .sinc := rfl
 
 /-- "write" is strictly incremental (creation verb). -/
-theorem write_sinc : write.toVerbCore.verbIncClass = some .sinc := rfl
+theorem write_sinc : write.toVerb.verbIncClass = some .sinc := rfl
 
 /-- "read" is incremental but not strictly so (allows re-reading per K98 §3.6). -/
-theorem read_inc : read.toVerbCore.verbIncClass = some .inc := rfl
+theorem read_inc : read.toVerb.verbIncClass = some .inc := rfl
 
 /-- "push" is cumulative only (no incremental theme — the formaliser's
     "cumOnly" is shorthand; K98 calls it CUM-without-MSE/MSO). -/
-theorem push_cumOnly : push.toVerbCore.verbIncClass = some .cumOnly := rfl
+theorem push_cumOnly : push.toVerb.verbIncClass = some .cumOnly := rfl
 
 /-- "pull" is cumulative only. -/
-theorem pull_cumOnly : pull.toVerbCore.verbIncClass = some .cumOnly := rfl
+theorem pull_cumOnly : pull.toVerb.verbIncClass = some .cumOnly := rfl
 
 /-- "carry" is cumulative only. -/
-theorem carry_cumOnly : carry.toVerbCore.verbIncClass = some .cumOnly := rfl
+theorem carry_cumOnly : carry.toVerb.verbIncClass = some .cumOnly := rfl
 
 /-- "drag" is cumulative only. -/
-theorem drag_cumOnly : drag.toVerbCore.verbIncClass = some .cumOnly := rfl
+theorem drag_cumOnly : drag.toVerb.verbIncClass = some .cumOnly := rfl
 
 /-- Intransitives have no incremental theme. -/
-theorem sleep_no_inc : sleep.toVerbCore.verbIncClass = none := rfl
-theorem run_no_inc : run.toVerbCore.verbIncClass = none := rfl
+theorem sleep_no_inc : sleep.toVerb.verbIncClass = none := rfl
+theorem run_no_inc : run.toVerb.verbIncClass = none := rfl
 
 /-- Unaccusatives have no incremental theme. -/
-theorem arrive_no_inc : arrive.toVerbCore.verbIncClass = none := rfl
+theorem arrive_no_inc : arrive.toVerb.verbIncClass = none := rfl
 
 /-- Contact verbs have no incremental theme. -/
-theorem kick_no_inc : kick.toVerbCore.verbIncClass = none := rfl
+theorem kick_no_inc : kick.toVerb.verbIncClass = none := rfl
 
 /-! ### Per-Verb Vendler Class Verification -/
 
 /-- "sleep" is a state. -/
-theorem sleep_state : sleep.toVerbCore.vendlerClass = some .state := rfl
+theorem sleep_state : sleep.toVerb.vendlerClass = some .state := rfl
 
 /-- "run" is an activity. -/
-theorem run_activity : run.toVerbCore.vendlerClass = some .activity := rfl
+theorem run_activity : run.toVerb.vendlerClass = some .activity := rfl
 
 /-- "arrive" is an achievement. -/
-theorem arrive_achievement : arrive.toVerbCore.vendlerClass = some .achievement := rfl
+theorem arrive_achievement : arrive.toVerb.vendlerClass = some .achievement := rfl
 
 /-- "eat" is an accomplishment (with quantized object). -/
-theorem eat_accomplishment : eat.toVerbCore.vendlerClass = some .accomplishment := rfl
+theorem eat_accomplishment : eat.toVerb.vendlerClass = some .accomplishment := rfl
 
 /-- "build" is an accomplishment. -/
-theorem build_accomplishment : build.toVerbCore.vendlerClass = some .accomplishment := rfl
+theorem build_accomplishment : build.toVerb.vendlerClass = some .accomplishment := rfl
 
 /-- "read" is an accomplishment. -/
-theorem read_accomplishment : read.toVerbCore.vendlerClass = some .accomplishment := rfl
+theorem read_accomplishment : read.toVerb.vendlerClass = some .accomplishment := rfl
 
 /-- "write" is an accomplishment. -/
-theorem write_accomplishment : write.toVerbCore.vendlerClass = some .accomplishment := rfl
+theorem write_accomplishment : write.toVerb.vendlerClass = some .accomplishment := rfl
 
 /-- "kick" is an activity (semelfactive/contact). -/
-theorem kick_activity : kick.toVerbCore.vendlerClass = some .activity := rfl
+theorem kick_activity : kick.toVerb.vendlerClass = some .activity := rfl
 
 /-- "see" is a state (perception). -/
-theorem see_state : see.toVerbCore.vendlerClass = some .state := rfl
+theorem see_state : see.toVerb.vendlerClass = some .state := rfl
 
 /-- "leave" is an achievement. -/
-theorem leave_achievement : leave.toVerbCore.vendlerClass = some .achievement := rfl
+theorem leave_achievement : leave.toVerb.vendlerClass = some .achievement := rfl
 
 /-- "push" is an activity. -/
-theorem push_activity : push.toVerbCore.vendlerClass = some .activity := rfl
+theorem push_activity : push.toVerb.vendlerClass = some .activity := rfl
 
 /-- "love" is a state. -/
-theorem love_state : love.toVerbCore.vendlerClass = some .state := rfl
+theorem love_state : love.toVerb.vendlerClass = some .state := rfl
 
 /-! ### VendlerClass → MereoTag Bridge -/
 
@@ -240,37 +240,37 @@ theorem state_is_cum :
     K98 §3.3: CumTheta(θ) ∧ CUM(OBJ) → CUM(VP θ OBJ).
     The verb's incrementality class is sinc, and bare plurals are CUM. -/
 theorem eat_apples_atelic :
-    eat.toVerbCore.verbIncClass = some .sinc ∧
+    eat.toVerb.verbIncClass = some .sinc ∧
     VendlerClass.activity.telicity.toMereoTag = .cum := ⟨rfl, rfl⟩
 
 /-- "eat two apples": sinc verb + QUA NP → QUA VP (telic).
     K98 §3.3: SINC(θ) ∧ QUA(OBJ) → QUA(VP θ OBJ).
     The verb's incrementality class is sinc, and "two apples" is QUA. -/
 theorem eat_two_apples_telic :
-    eat.toVerbCore.verbIncClass = some .sinc ∧
+    eat.toVerb.verbIncClass = some .sinc ∧
     VendlerClass.accomplishment.telicity.toMereoTag = .qua := ⟨rfl, rfl⟩
 
 /-- "build a house": sinc verb + QUA NP → QUA VP (telic). -/
 theorem build_a_house_telic :
-    build.toVerbCore.verbIncClass = some .sinc ∧
+    build.toVerb.verbIncClass = some .sinc ∧
     VendlerClass.accomplishment.telicity.toMereoTag = .qua := ⟨rfl, rfl⟩
 
 /-- "read the book": inc verb + QUA NP → VP is telic
     (INC is weaker than SINC, but still transmits QUA from NP to VP
     when the object is quantized, K98 §3.6). -/
 theorem read_the_book_telic :
-    read.toVerbCore.verbIncClass = some .inc ∧
+    read.toVerb.verbIncClass = some .inc ∧
     VendlerClass.accomplishment.telicity.toMereoTag = .qua := ⟨rfl, rfl⟩
 
 /-- "push the cart": cumOnly verb → no telicity transfer from NP.
     Regardless of the NP's reference property, cumOnly verbs yield
     atelic (CUM) VPs. -/
 theorem push_the_cart_atelic :
-    push.toVerbCore.verbIncClass = some .cumOnly := rfl
+    push.toVerb.verbIncClass = some .cumOnly := rfl
 
 /-- "write a letter": sinc verb + QUA NP → QUA VP (telic). -/
 theorem write_a_letter_telic :
-    write.toVerbCore.verbIncClass = some .sinc ∧
+    write.toVerb.verbIncClass = some .sinc ∧
     VendlerClass.accomplishment.telicity.toMereoTag = .qua := ⟨rfl, rfl⟩
 
 /-! ### §4.5 Propositional propagation invocations (typeclass form)
@@ -338,21 +338,21 @@ theorem durative_atelic_licenses_forX (c : VendlerClass)
 
 /-- All sinc-annotated verbs are accomplishments. -/
 theorem sinc_verbs_are_accomplishments :
-    eat.toVerbCore.vendlerClass = some .accomplishment ∧
-    devour.toVerbCore.vendlerClass = some .accomplishment ∧
-    build.toVerbCore.vendlerClass = some .accomplishment ∧
-    write.toVerbCore.vendlerClass = some .accomplishment := ⟨rfl, rfl, rfl, rfl⟩
+    eat.toVerb.vendlerClass = some .accomplishment ∧
+    devour.toVerb.vendlerClass = some .accomplishment ∧
+    build.toVerb.vendlerClass = some .accomplishment ∧
+    write.toVerb.vendlerClass = some .accomplishment := ⟨rfl, rfl, rfl, rfl⟩
 
 /-- The inc-annotated verb "read" is an accomplishment. -/
 theorem inc_verb_is_accomplishment :
-    read.toVerbCore.vendlerClass = some .accomplishment := rfl
+    read.toVerb.vendlerClass = some .accomplishment := rfl
 
 /-- All cumOnly-annotated verbs are activities. -/
 theorem cumOnly_verbs_are_activities :
-    push.toVerbCore.vendlerClass = some .activity ∧
-    pull.toVerbCore.vendlerClass = some .activity ∧
-    carry.toVerbCore.vendlerClass = some .activity ∧
-    drag.toVerbCore.vendlerClass = some .activity := ⟨rfl, rfl, rfl, rfl⟩
+    push.toVerb.vendlerClass = some .activity ∧
+    pull.toVerb.vendlerClass = some .activity ∧
+    carry.toVerb.vendlerClass = some .activity ∧
+    drag.toVerb.vendlerClass = some .activity := ⟨rfl, rfl, rfl, rfl⟩
 
 /-! ## Gradual Change (GRAD) Predictions -/
 
@@ -396,11 +396,11 @@ def GRADVerb.expectedIncClass : GRADVerb → Option VerbIncClass
     `all_grad_data_matches`; this theorem keeps the literal in sync
     with the fragment. -/
 theorem gradVerb_matches_fragment :
-    GRADVerb.eat.expectedIncClass = eat.toVerbCore.verbIncClass ∧
-    GRADVerb.build.expectedIncClass = build.toVerbCore.verbIncClass ∧
-    GRADVerb.read.expectedIncClass = read.toVerbCore.verbIncClass ∧
-    GRADVerb.push.expectedIncClass = push.toVerbCore.verbIncClass ∧
-    GRADVerb.kick.expectedIncClass = kick.toVerbCore.verbIncClass :=
+    GRADVerb.eat.expectedIncClass = eat.toVerb.verbIncClass ∧
+    GRADVerb.build.expectedIncClass = build.toVerb.verbIncClass ∧
+    GRADVerb.read.expectedIncClass = read.toVerb.verbIncClass ∧
+    GRADVerb.push.expectedIncClass = push.toVerb.verbIncClass ∧
+    GRADVerb.kick.expectedIncClass = kick.toVerb.verbIncClass :=
   ⟨rfl, rfl, rfl, rfl, rfl⟩
 
 /-- The dimension along which a verb's GRAD measure operates. -/
@@ -449,15 +449,15 @@ def predictsGRAD : Option VerbIncClass → Bool
 -- Per-verb GRAD verification (fragment-tripwire)
 
 theorem eat_predicts_grad :
-    predictsGRAD eat.toVerbCore.verbIncClass = true := rfl
+    predictsGRAD eat.toVerb.verbIncClass = true := rfl
 theorem build_predicts_grad :
-    predictsGRAD build.toVerbCore.verbIncClass = true := rfl
+    predictsGRAD build.toVerb.verbIncClass = true := rfl
 theorem read_predicts_grad :
-    predictsGRAD read.toVerbCore.verbIncClass = true := rfl
+    predictsGRAD read.toVerb.verbIncClass = true := rfl
 theorem push_no_grad :
-    predictsGRAD push.toVerbCore.verbIncClass = false := rfl
+    predictsGRAD push.toVerb.verbIncClass = false := rfl
 theorem kick_no_grad :
-    predictsGRAD kick.toVerbCore.verbIncClass = false := rfl
+    predictsGRAD kick.toVerb.verbIncClass = false := rfl
 
 /-- All GRAD data matches the K98-expected verb classification. The
     `decide` closure works because `verb.expectedIncClass` is
@@ -549,7 +549,7 @@ theorem k98_eq58_cum_object_accepts_inX :
 theorem eat_refinement_chain :
     Krifka1989.eatAnApple.thematicClass = .gradualConsumedPatient ∧
     Krifka1989.eatAnApple.thematicClass.toVerbIncClass = .sinc ∧
-    eat.toVerbCore.verbIncClass = some .sinc := ⟨rfl, rfl, rfl⟩
+    eat.toVerb.verbIncClass = some .sinc := ⟨rfl, rfl, rfl⟩
 
 /-- K89's *write a letter* (gradual-effected-patient) refines to K98
     sinc, matching *write*'s fragment annotation. K89's distinction
@@ -559,7 +559,7 @@ theorem eat_refinement_chain :
 theorem write_refinement_chain :
     Krifka1989.writeALetter.thematicClass = .gradualEffectedPatient ∧
     Krifka1989.writeALetter.thematicClass.toVerbIncClass = .sinc ∧
-    write.toVerbCore.verbIncClass = some .sinc := ⟨rfl, rfl, rfl⟩
+    write.toVerb.verbIncClass = some .sinc := ⟨rfl, rfl, rfl⟩
 
 /-- K89's *read a letter* (gradual-patient, lacks UNI-E) refines to
     K98 inc — matching *read*'s fragment annotation, which K98 §3.6
@@ -567,7 +567,7 @@ theorem write_refinement_chain :
 theorem read_refinement_chain :
     Krifka1989.readALetter.thematicClass = .gradualPatient ∧
     Krifka1989.readALetter.thematicClass.toVerbIncClass = .inc ∧
-    read.toVerbCore.verbIncClass = some .inc := ⟨rfl, rfl, rfl⟩
+    read.toVerb.verbIncClass = some .inc := ⟨rfl, rfl, rfl⟩
 
 /-! ### Concrete `IsSincVerb` Toy + Applied Propagation -/
 
@@ -722,7 +722,7 @@ end ToyEatInstance
 
 /-- "arrive" is inherently directed motion (K98 §4.7 eq. 78). -/
 theorem arrive_levinClass :
-    arrive.toVerbCore.levinClass = some .inherentlyDirectedMotion := rfl
+    arrive.toVerb.levinClass = some .inherentlyDirectedMotion := rfl
 
 /-- Inherently directed motion → bounded path (K98 §4.5 GOAL specified). -/
 theorem arrive_pathSpec :
@@ -730,7 +730,7 @@ theorem arrive_pathSpec :
 
 /-- "leave" is a leave verb (K98 §4.5 SOURCE-only). -/
 theorem leave_levinClass :
-    leave.toVerbCore.levinClass = some .leave := rfl
+    leave.toVerb.levinClass = some .leave := rfl
 
 /-- Leave verbs → source path. -/
 theorem leave_pathSpec :
@@ -738,7 +738,7 @@ theorem leave_pathSpec :
 
 /-- "run" is manner-of-motion (K98 §4.5 path-neutral; PP supplies path). -/
 theorem run_levinClass :
-    run.toVerbCore.levinClass = some .mannerOfMotion := rfl
+    run.toVerb.levinClass = some .mannerOfMotion := rfl
 
 /-- Manner-of-motion verbs are path-neutral (path comes from PP). -/
 theorem run_pathSpec :
@@ -749,11 +749,11 @@ theorem run_pathSpec :
 
 /-- *arrive* is annotated as an achievement Vendler class. -/
 theorem arrive_vendlerClass_achievement :
-    arrive.toVerbCore.vendlerClass = some .achievement := rfl
+    arrive.toVerb.vendlerClass = some .achievement := rfl
 
 /-- *sleep* is annotated as a state Vendler class. -/
 theorem sleep_vendlerClass_state :
-    sleep.toVerbCore.vendlerClass = some .state := rfl
+    sleep.toVerb.vendlerClass = some .state := rfl
 
 /-! ### PathShape → Telicity → Licensing (K98 §4 MR eq. 71) -/
 
@@ -816,27 +816,27 @@ theorem all_motion_data_correct :
 
 /-- "arrive" (achievement, bounded path) licenses "in X". -/
 theorem arrive_inX :
-    arrive.toVerbCore.vendlerClass = some .achievement ∧
+    arrive.toVerb.vendlerClass = some .achievement ∧
     inXPrediction .achievement = .accept := ⟨rfl, rfl⟩
 
 /-- "leave" (achievement, source path) licenses "in X". -/
 theorem leave_inX :
-    leave.toVerbCore.vendlerClass = some .achievement ∧
+    leave.toVerb.vendlerClass = some .achievement ∧
     inXPrediction .achievement = .accept := ⟨rfl, rfl⟩
 
 /-- "run" (activity, path-neutral) licenses "for X". -/
 theorem run_forX :
-    run.toVerbCore.vendlerClass = some .activity ∧
+    run.toVerb.vendlerClass = some .activity ∧
     forXPrediction .activity = .accept := ⟨rfl, rfl⟩
 
 /-- Motion verb VendlerClass × LevinClass coherence: bounded-path motion
     verbs are achievements, path-neutral ones are activities. -/
 theorem motion_vendler_path_coherence :
-    (arrive.toVerbCore.vendlerClass = some .achievement ∧
+    (arrive.toVerb.vendlerClass = some .achievement ∧
       LevinClass.inherentlyDirectedMotion.pathSpec = some .bounded) ∧
-    (leave.toVerbCore.vendlerClass = some .achievement ∧
+    (leave.toVerb.vendlerClass = some .achievement ∧
       LevinClass.leave.pathSpec = some .source) ∧
-    (run.toVerbCore.vendlerClass = some .activity ∧
+    (run.toVerb.vendlerClass = some .activity ∧
       LevinClass.mannerOfMotion.pathSpec = none) :=
   ⟨⟨rfl, rfl⟩, ⟨rfl, rfl⟩, ⟨rfl, rfl⟩⟩
 

--- a/Linglib/Studies/Landau2015.lean
+++ b/Linglib/Studies/Landau2015.lean
@@ -25,7 +25,7 @@ OC in complement clauses divides into two subtypes:
 - `agrBlocksControl`: The OC-NC generalization — [+Agr] blocks logophoric
   control but not predicative control (70)
 - `TTCContrast`: The six empirical contrasts between the two tiers (table (80))
-- `derivedLandauClass`: Maps VerbCore fields to Landau predicate classes
+- `derivedLandauClass`: Maps Verb fields to Landau predicate classes
 - `DeSeReading`: Object control *de se*/*de te* distinction (table (36))
 
 ## Core Claims
@@ -614,10 +614,10 @@ theorem communicative_deTe :
     objectControlReading .communicative = .deTe := rfl
 
 -- ════════════════════════════════════════════════════════════════
--- § 12: Derived Landau Class from VerbCore
+-- § 12: Derived Landau Class from Verb
 -- ════════════════════════════════════════════════════════════════
 
-/-- Derive @cite{landau-2015}'s predicate class from VerbCore fields.
+/-- Derive @cite{landau-2015}'s predicate class from Verb fields.
 
     This creates a bridge from Fragment verb entries to the TTC by
     deriving the predicate classification from existing semantic fields
@@ -636,7 +636,7 @@ theorem communicative_deTe :
     - `attitude.doxastic` → `.propositional` (believe, think, ...)
     - `attitude.preferential` → `.desiderative` (want, hope, ...)
     - `takesQuestionBase` without attitude → `.interrogative` (wonder, ask) -/
-def derivedLandauClass (v : VerbCore) : Option LandauPredicateClass :=
+def derivedLandauClass (v : Verb) : Option LandauPredicateClass :=
   if v.cosType.isSome then some .aspectual
   else if v.implicative.isSome then some .implicative
   else if v.causative.isSome then some .implicative
@@ -647,7 +647,7 @@ def derivedLandauClass (v : VerbCore) : Option LandauPredicateClass :=
     | some (.preferential _) => some .desiderative
     | none                   => none
 
-/-- Derive control tier from VerbCore fields.
+/-- Derive control tier from Verb fields.
 
     A verb induces logophoric control iff it selects an attitude
     complement — detected by the presence of `attitude`,
@@ -655,7 +655,7 @@ def derivedLandauClass (v : VerbCore) : Option LandauPredicateClass :=
     predicative control.
 
     Returns `none` for verbs that are not control verbs. -/
-def derivedControlTier (v : VerbCore) : Option ControlTier :=
+def derivedControlTier (v : Verb) : Option ControlTier :=
   if v.controlType == ControlType.none && v.altControlType == ControlType.none then Option.none
   else match derivedLandauClass v with
     | some cls => some cls.controlTier
@@ -677,81 +677,81 @@ open English.Predicates.Verbal
 
 /-- "stop" (CoS cessation) → aspectual → predicative -/
 theorem stop_aspectual :
-    derivedLandauClass stop.toVerbCore = some .aspectual := rfl
+    derivedLandauClass stop.toVerb = some .aspectual := rfl
 
 /-- "start" (CoS inception) → aspectual → predicative -/
 theorem start_aspectual :
-    derivedLandauClass start.toVerbCore = some .aspectual := rfl
+    derivedLandauClass start.toVerb = some .aspectual := rfl
 
 /-- "begin" (CoS inception) → aspectual → predicative -/
 theorem begin_aspectual :
-    derivedLandauClass begin_.toVerbCore = some .aspectual := rfl
+    derivedLandauClass begin_.toVerb = some .aspectual := rfl
 
 /-- "continue" (CoS continuation) → aspectual → predicative -/
 theorem continue_aspectual :
-    derivedLandauClass continue_.toVerbCore = some .aspectual := rfl
+    derivedLandauClass continue_.toVerb = some .aspectual := rfl
 
 /-- "manage" (positive implicative) → implicative → predicative -/
 theorem manage_implicative :
-    derivedLandauClass manage.toVerbCore = some .implicative := rfl
+    derivedLandauClass manage.toVerb = some .implicative := rfl
 
 /-- "fail" (negative implicative) → implicative → predicative -/
 theorem fail_implicative :
-    derivedLandauClass fail.toVerbCore = some .implicative := rfl
+    derivedLandauClass fail.toVerb = some .implicative := rfl
 
 /-- "remember" (positive implicative) → implicative → predicative -/
 theorem remember_implicative :
-    derivedLandauClass remember.toVerbCore = some .implicative := rfl
+    derivedLandauClass remember.toVerb = some .implicative := rfl
 
 /-- "forget" (negative implicative) → implicative → predicative -/
 theorem forget_implicative :
-    derivedLandauClass forget.toVerbCore = some .implicative := rfl
+    derivedLandauClass forget.toVerb = some .implicative := rfl
 
 /-- "force" (coercive causative) → implicative → predicative -/
 theorem force_implicative :
-    derivedLandauClass force.toVerbCore = some .implicative := rfl
+    derivedLandauClass force.toVerb = some .implicative := rfl
 
 -- Logophoric (PC) verbs: derived class → logophoric tier
 
 /-- "want" (preferential attitude) → desiderative → logophoric -/
 theorem want_desiderative :
-    derivedLandauClass want.toVerbCore = some .desiderative := rfl
+    derivedLandauClass want.toVerb = some .desiderative := rfl
 
 /-- "hope" (preferential attitude) → desiderative → logophoric -/
 theorem hope_desiderative :
-    derivedLandauClass hope.toVerbCore = some .desiderative := rfl
+    derivedLandauClass hope.toVerb = some .desiderative := rfl
 
 /-- "promise" (preferential attitude) → desiderative → logophoric.
     Previously unclassified; fixed by adding `attitude` to the
     Fragment entry per @cite{landau-2015} (5c). -/
 theorem promise_desiderative :
-    derivedLandauClass promise.toVerbCore = some .desiderative := rfl
+    derivedLandauClass promise.toVerb = some .desiderative := rfl
 
 /-- "persuade" (preferential attitude, object control) → desiderative → logophoric.
     Previously unclassified; fixed by adding `attitude` per
     @cite{landau-2015} table (36). -/
 theorem persuade_desiderative :
-    derivedLandauClass persuade.toVerbCore = some .desiderative := rfl
+    derivedLandauClass persuade.toVerb = some .desiderative := rfl
 
 /-- "regret" (factive) → factive → logophoric -/
 theorem regret_factive :
-    derivedLandauClass regret.toVerbCore = some .factive := rfl
+    derivedLandauClass regret.toVerb = some .factive := rfl
 
 /-- "know" (factive + question) → factive → logophoric -/
 theorem know_factive :
-    derivedLandauClass know.toVerbCore = some .factive := rfl
+    derivedLandauClass know.toVerb = some .factive := rfl
 
 /-- "believe" (doxastic attitude) → propositional → logophoric -/
 theorem believe_propositional :
-    derivedLandauClass believe.toVerbCore = some .propositional := rfl
+    derivedLandauClass believe.toVerb = some .propositional := rfl
 
 /-- "think" (doxastic attitude) → propositional → logophoric -/
 theorem think_propositional :
-    derivedLandauClass think.toVerbCore = some .propositional := rfl
+    derivedLandauClass think.toVerb = some .propositional := rfl
 
 /-- "wonder" (question-embedding, non-attitude) → interrogative → logophoric -/
 theorem wonder_interrogative :
-    derivedLandauClass wonder.toVerbCore = some .interrogative := rfl
+    derivedLandauClass wonder.toVerb = some .interrogative := rfl
 
 -- Negative test: verbs that should NOT be classifiable
 
@@ -760,33 +760,33 @@ theorem wonder_interrogative :
     `derivedLandauClass`. This is correct: "try" is not implicative (trying
     doesn't entail succeeding) and not clearly attitudinal. -/
 theorem try_unclassifiable :
-    derivedLandauClass try_.toVerbCore = none := rfl
+    derivedLandauClass try_.toVerb = none := rfl
 
 -- Control tier verification: derived tier matches expected tier
 
 theorem stop_predicative_tier :
-    (derivedLandauClass stop.toVerbCore).map (·.controlTier) = some .predicative := rfl
+    (derivedLandauClass stop.toVerb).map (·.controlTier) = some .predicative := rfl
 
 theorem manage_predicative_tier :
-    (derivedLandauClass manage.toVerbCore).map (·.controlTier) = some .predicative := rfl
+    (derivedLandauClass manage.toVerb).map (·.controlTier) = some .predicative := rfl
 
 theorem want_logophoric_tier :
-    (derivedLandauClass want.toVerbCore).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass want.toVerb).map (·.controlTier) = some .logophoric := rfl
 
 theorem regret_logophoric_tier :
-    (derivedLandauClass regret.toVerbCore).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass regret.toVerb).map (·.controlTier) = some .logophoric := rfl
 
 theorem believe_logophoric_tier :
-    (derivedLandauClass believe.toVerbCore).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass believe.toVerb).map (·.controlTier) = some .logophoric := rfl
 
 theorem wonder_logophoric_tier :
-    (derivedLandauClass wonder.toVerbCore).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass wonder.toVerb).map (·.controlTier) = some .logophoric := rfl
 
 theorem promise_logophoric_tier :
-    (derivedLandauClass promise.toVerbCore).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass promise.toVerb).map (·.controlTier) = some .logophoric := rfl
 
 theorem persuade_logophoric_tier :
-    (derivedLandauClass persuade.toVerbCore).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass persuade.toVerb).map (·.controlTier) = some .logophoric := rfl
 
 -- Object control de se/de te: per-verb bridge
 

--- a/Linglib/Studies/Ozaki2026.lean
+++ b/Linglib/Studies/Ozaki2026.lean
@@ -395,22 +395,22 @@ theorem source_is_argument_both_frames :
     `derivedUnaccusative` uses the `voiceType` field to compute unaccusativity
     via `VoiceType.assignsTheta`. -/
 theorem hanareru_unaccusative_derived :
-    Japanese.Predicates.hanareru.toVerbCore.derivedUnaccusative = true := rfl
+    Japanese.Predicates.hanareru.toVerb.derivedUnaccusative = true := rfl
 
 /-- Deru's unaccusativity is DERIVED from its voice type. -/
 theorem deru_unaccusative_derived :
-    Japanese.Predicates.deru.toVerbCore.derivedUnaccusative = true := rfl
+    Japanese.Predicates.deru.toVerb.derivedUnaccusative = true := rfl
 
 /-- The stored `unaccusative` flag agrees with the derived value.
     This consistency check ensures that the stipulated field and the
     Voice-based derivation produce the same answer. -/
 theorem hanareru_stored_matches_derived :
     Japanese.Predicates.hanareru.unaccusative =
-    Japanese.Predicates.hanareru.toVerbCore.derivedUnaccusative := rfl
+    Japanese.Predicates.hanareru.toVerb.derivedUnaccusative := rfl
 
 theorem deru_stored_matches_derived :
     Japanese.Predicates.deru.unaccusative =
-    Japanese.Predicates.deru.toVerbCore.derivedUnaccusative := rfl
+    Japanese.Predicates.deru.toVerb.derivedUnaccusative := rfl
 
 /-- Direct passive requires thematic Voice, which departure verbs lack. -/
 theorem direct_passive_requires_voice :

--- a/Linglib/Studies/RobertsSimons2024.lean
+++ b/Linglib/Studies/RobertsSimons2024.lean
@@ -326,7 +326,7 @@ theorem cos_eventphase_agrees_with_prprop (t : CoSType) (P : W → Prop) :
 /-- R&S argue that presupposition status follows from event structure,
     not from a stipulated `presupType`. A verb presupposes its complement
     iff it has factivity or CoS event structure. The `derivedPresupType`
-    accessor on `VerbCore` implements this derivation. -/
+    accessor on `Verb` implements this derivation. -/
 theorem presupposition_derivable_from_event_structure
     (isFactive hasCosType : Bool) :
     (isFactive || hasCosType) = true ↔

--- a/Linglib/Studies/Schwarzer2026.lean
+++ b/Linglib/Studies/Schwarzer2026.lean
@@ -127,37 +127,37 @@ theorem german_vfinal_grounds_preverbal :
 
 /-- *beenden* "end" does not take a *dass*-clause complement. -/
 theorem beenden_nonselecting :
-    beenden.toVerbCore.canTakeClausalComplement = false := rfl
+    beenden.toVerb.canTakeClausalComplement = false := rfl
 
 /-- *streichen* "cancel" does not take a *dass*-clause complement. -/
 theorem streichen_nonselecting :
-    streichen.toVerbCore.canTakeClausalComplement = false := rfl
+    streichen.toVerb.canTakeClausalComplement = false := rfl
 
 /-- *übereilen* "rush" does not take a *dass*-clause complement. -/
 theorem uebereilen_nonselecting :
-    uebereilen.toVerbCore.canTakeClausalComplement = false := rfl
+    uebereilen.toVerb.canTakeClausalComplement = false := rfl
 
 /-- *entwickeln* "develop" does not take a *dass*-clause complement. -/
 theorem entwickeln_nonselecting :
-    entwickeln.toVerbCore.canTakeClausalComplement = false := rfl
+    entwickeln.toVerb.canTakeClausalComplement = false := rfl
 
 -- CP-and-DP-selecting verbs
 
 /-- *veranlassen* "induce" takes both DP and *dass*-clause. -/
 theorem veranlassen_selecting :
-    veranlassen.toVerbCore.canTakeClausalComplement = true := rfl
+    veranlassen.toVerb.canTakeClausalComplement = true := rfl
 
 /-- *vergessen* "forget" takes both DP and *dass*-clause. -/
 theorem vergessen_selecting :
-    vergessen.toVerbCore.canTakeClausalComplement = true := rfl
+    vergessen.toVerb.canTakeClausalComplement = true := rfl
 
 /-- *erwarten* "expect" takes both DP and *dass*-clause. -/
 theorem erwarten_selecting :
-    erwarten.toVerbCore.canTakeClausalComplement = true := rfl
+    erwarten.toVerb.canTakeClausalComplement = true := rfl
 
 /-- *beschließen* "decide" takes both DP and *dass*-clause. -/
 theorem beschliessen_selecting :
-    beschliessen.toVerbCore.canTakeClausalComplement = true := rfl
+    beschliessen.toVerb.canTakeClausalComplement = true := rfl
 
 -- ============================================================================
 -- § 3: Competing Analyses & Structural Predictions
@@ -419,12 +419,12 @@ def selectingVerbs : List GermanVerbEntry :=
 /-- All non-selecting verbs lack clausal complement capability. -/
 theorem nonSelecting_all_false :
     nonSelectingVerbs.all
-      (λ v => !v.toVerbCore.canTakeClausalComplement) = true := by native_decide
+      (λ v => !v.toVerb.canTakeClausalComplement) = true := by native_decide
 
 /-- All selecting verbs have clausal complement capability. -/
 theorem selecting_all_true :
     selectingVerbs.all
-      (λ v => v.toVerbCore.canTakeClausalComplement) = true := by native_decide
+      (λ v => v.toVerb.canTakeClausalComplement) = true := by native_decide
 
 /-- No verb is in both lists. -/
 theorem selecting_nonselecting_disjoint :

--- a/Linglib/Studies/Storment2026.lean
+++ b/Linglib/Studies/Storment2026.lean
@@ -81,13 +81,13 @@ theorem arrive_unaccusative : arrive.unaccusative = true := rfl
 
 /-! ## §3. TransitivityClass derivation
 
-Maps a `VerbCore` to its three-way transitivity classification used by
+Maps a `Verb` to its three-way transitivity classification used by
 the auxiliary-selection system (`Phenomena/AuxiliaryVerbs/Selection.lean`).
 Stays in this study file because `TransitivityClass` lives in `Phenomena/`
 and cannot be imported by substrate (`Semantics/`, `Syntax/`, etc.). -/
 
-/-- Derive `TransitivityClass` from `VerbCore` fields. -/
-def deriveTransitivityClass (v : VerbCore) : TransitivityClass :=
+/-- Derive `TransitivityClass` from `Verb` fields. -/
+def deriveTransitivityClass (v : Verb) : TransitivityClass :=
   if v.unaccusative then .unaccusative
   else match v.complementType with
     | .none => .unergative
@@ -95,19 +95,19 @@ def deriveTransitivityClass (v : VerbCore) : TransitivityClass :=
 
 theorem mos_unaccusatives_transitivity :
     ∀ v ∈ mosUnaccusatives,
-      deriveTransitivityClass v.toVerbCore = .unaccusative := by
+      deriveTransitivityClass v.toVerb = .unaccusative := by
   intro v hv; fin_cases hv <;> rfl
 
 theorem communication_unergatives_transitivity :
     ∀ v ∈ communicationUnergatives,
-      deriveTransitivityClass v.toVerbCore = .unergative := by
+      deriveTransitivityClass v.toVerb = .unergative := by
   intro v hv; fin_cases hv <;> rfl
 
-theorem kick_transitive : deriveTransitivityClass kick.toVerbCore = .transitive := rfl
+theorem kick_transitive : deriveTransitivityClass kick.toVerb = .transitive := rfl
 
 /-! ## §4. Voice bridge
 
-`VerbCore.voiceFor` (defined in `Semantics/Lexical/VerbSmuggling.lean`)
+`Verb.voiceFor` (defined in `Semantics/Lexical/VerbSmuggling.lean`)
 maps unaccusative→non-thematic Voice and
 unergative→agentive Voice. Per @cite{storment-2026}'s §4.3, the Voice
 head is the smuggling projection (not the external-argument introducer
@@ -115,11 +115,11 @@ of @cite{kratzer-1996}); permitting smuggling is equivalent to being
 non-phase, which is equivalent to not introducing an external argument. -/
 
 theorem mos_unaccusatives_nonThematic_voice :
-    ∀ v ∈ mosUnaccusatives, v.toVerbCore.voiceFor = voiceAnticausative := by
+    ∀ v ∈ mosUnaccusatives, v.toVerb.voiceFor = voiceAnticausative := by
   intro v hv; fin_cases hv <;> rfl
 
 theorem communication_unergatives_agentive_voice :
-    ∀ v ∈ communicationUnergatives, v.toVerbCore.voiceFor = voiceAgent := by
+    ∀ v ∈ communicationUnergatives, v.toVerb.voiceFor = voiceAgent := by
   intro v hv; fin_cases hv <;> rfl
 
 /-! ## §5. Auxiliary selection bridge
@@ -129,12 +129,12 @@ select *be* and unergatives select *have*. -/
 
 theorem mos_unaccusatives_select_be :
     ∀ v ∈ mosUnaccusatives,
-      canonicalSelection (deriveTransitivityClass v.toVerbCore) = .be := by
+      canonicalSelection (deriveTransitivityClass v.toVerb) = .be := by
   intro v hv; fin_cases hv <;> rfl
 
 theorem communication_unergatives_select_have :
     ∀ v ∈ communicationUnergatives,
-      canonicalSelection (deriveTransitivityClass v.toVerbCore) = .have := by
+      canonicalSelection (deriveTransitivityClass v.toVerb) = .have := by
   intro v hv; fin_cases hv <;> rfl
 
 /-! ## §6. Levin §37.3 mannerOfSpeaking class membership
@@ -147,7 +147,7 @@ theorem speak_levinClass : speak.levinClass = some .mannerOfSpeaking := rfl
 
 /-! ## §8. Smuggling derivation of QI
 
-`VerbCore.derivedQI` (defined in `Semantics/Lexical/VerbSmuggling.lean`)
+`Verb.derivedQI` (defined in `Semantics/Lexical/VerbSmuggling.lean`)
 derives QI licensing from two independently
 motivated properties: (1) Voice is non-phase (= unaccusative);
 (2) verb has a complement (the quote).
@@ -159,40 +159,40 @@ to block QI; unaccusative `arrive` (no complement) is correctly
 predicted not to license QI (it requires LI, not QI). -/
 
 theorem mos_unaccusatives_derivedQI :
-    ∀ v ∈ mosUnaccusatives, v.toVerbCore.derivedQI = true := by
+    ∀ v ∈ mosUnaccusatives, v.toVerb.derivedQI = true := by
   intro v hv; fin_cases hv <;> rfl
 
 theorem communication_unergatives_derivedQI :
-    ∀ v ∈ communicationUnergatives, v.toVerbCore.derivedQI = false := by
+    ∀ v ∈ communicationUnergatives, v.toVerb.derivedQI = false := by
   intro v hv; fin_cases hv <;> rfl
 
 /-- `arrive` is unaccusative but has no complement: doesn't license QI.
     This is correct — `*"arrived Mary"` requires a fronted locative
     (LI), not a fronted quote (QI). -/
-theorem arrive_no_qi : arrive.toVerbCore.derivedQI = false := rfl
+theorem arrive_no_qi : arrive.toVerb.derivedQI = false := rfl
 
 /-- Consistency: each (verb, QI-datum) pair has its empirical result
     matching `derivedQI`. Pairs the diagnostic data in
     `Unaccusativity/Data.lean` with the smuggling prediction. -/
 theorem qi_data_matches_derivedQI :
-    ∀ p ∈ ([(qi_whisper,    whisper.toVerbCore),
-            (qi_murmur,     murmur.toVerbCore),
-            (qi_shout,      shout.toVerbCore),
-            (qi_cry,        cry.toVerbCore),
-            (qi_scream,     scream.toVerbCore),
-            (qi_mumble,     mumble.toVerbCore),
-            (qi_mutter,     mutter.toVerbCore),
-            (qi_shriek,     shriek.toVerbCore),
-            (qi_yell,       yell.toVerbCore),
-            (qi_groan,      groan.toVerbCore),
-            (qi_grumble,    grumble.toVerbCore),
-            (qi_hiss,       hiss.toVerbCore),
-            (qi_sigh,       sigh.toVerbCore),
-            (qi_whimper,    whimper.toVerbCore),
-            (qi_snap,       snap.toVerbCore),
-            (qi_speak,      speak.toVerbCore),
-            (qi_talk,       talk.toVerbCore)] :
-            List (DiagnosticDatum × VerbCore)),
+    ∀ p ∈ ([(qi_whisper,    whisper.toVerb),
+            (qi_murmur,     murmur.toVerb),
+            (qi_shout,      shout.toVerb),
+            (qi_cry,        cry.toVerb),
+            (qi_scream,     scream.toVerb),
+            (qi_mumble,     mumble.toVerb),
+            (qi_mutter,     mutter.toVerb),
+            (qi_shriek,     shriek.toVerb),
+            (qi_yell,       yell.toVerb),
+            (qi_groan,      groan.toVerb),
+            (qi_grumble,    grumble.toVerb),
+            (qi_hiss,       hiss.toVerb),
+            (qi_sigh,       sigh.toVerb),
+            (qi_whimper,    whimper.toVerb),
+            (qi_snap,       snap.toVerb),
+            (qi_speak,      speak.toVerb),
+            (qi_talk,       talk.toVerb)] :
+            List (DiagnosticDatum × Verb)),
       (p.1.result = .passes) ↔ (p.2.derivedQI = true) := by
   intro p hp; fin_cases hp <;> decide
 
@@ -231,7 +231,7 @@ theorem li_blocks_transitive : li_kick.result = .fails := rfl
     arrive projects non-thematic Voice, permitting VP-smuggling — the
     same mechanism that licenses QI. -/
 theorem li_arrive_smuggling_unified :
-    arrive.toVerbCore.voiceFor = voiceAnticausative ∧
+    arrive.toVerb.voiceFor = voiceAnticausative ∧
     loc_arrive.result = .passes :=
   ⟨rfl, rfl⟩
 

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -463,26 +463,26 @@ theorem dead_also_closed : Adjectival.dead.scaleType = .closed := rfl
 
 /-- Verb fragment entries have closed degreeAchievementScale. -/
 theorem crack_verb_closed_scale :
-    (Verbal.crack.toVerbCore.degreeAchievementScale.get!).scaleBoundedness
+    (Verbal.crack.toVerb.degreeAchievementScale.get!).scaleBoundedness
       = .closed := rfl
 theorem dent_verb_closed_scale :
-    (Verbal.dent.toVerbCore.degreeAchievementScale.get!).scaleBoundedness
+    (Verbal.dent.toVerb.degreeAchievementScale.get!).scaleBoundedness
       = .closed := rfl
 theorem scratch_verb_closed_scale :
-    (Verbal.scratch.toVerbCore.degreeAchievementScale.get!).scaleBoundedness
+    (Verbal.scratch.toVerb.degreeAchievementScale.get!).scaleBoundedness
       = .closed := rfl
 
 /-- Adjective-verb scale agreement: each verb inherits the same
     `Boundedness` as its deverbal adjective. -/
 theorem crack_adj_verb_scale_agree :
     Adjectival.cracked.scaleType =
-    (Verbal.crack.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (Verbal.crack.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 theorem dent_adj_verb_scale_agree :
     Adjectival.dented.scaleType =
-    (Verbal.dent.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (Verbal.dent.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 theorem scratch_adj_verb_scale_agree :
     Adjectival.scratched.scaleType =
-    (Verbal.scratch.toVerbCore.degreeAchievementScale.get!).scaleBoundedness := rfl
+    (Verbal.scratch.toVerb.degreeAchievementScale.get!).scaleBoundedness := rfl
 
 /-- Disturbance adjectives are licensed for degree modification by the
     Kennedy pipeline, just like *full* and *clean*. -/
@@ -527,27 +527,27 @@ theorem cracked_standard_maxEndpoint :
 /-- The pipeline predicts accomplishment for crack (closed → telic →
     durative). -/
 theorem crack_pipeline_predicts_accomplishment :
-    (Verbal.crack.toVerbCore.degreeAchievementScale.get!).defaultVendlerClass
+    (Verbal.crack.toVerb.degreeAchievementScale.get!).defaultVendlerClass
       = .accomplishment := rfl
 
 /-- The Fragment stipulates achievement (punctual telic), capturing the
     *in X* = "after" reading (Tham (9) "The mirror will crack in five
     minutes"). -/
 theorem crack_stipulated_achievement :
-    Verbal.crack.toVerbCore.vendlerClass = some .achievement := rfl
+    Verbal.crack.toVerb.vendlerClass = some .achievement := rfl
 
 /-- Pipeline and Fragment stipulation diverge for *crack*. The
     divergence is internal to linglib (Fragment vs pipeline default),
     not a claim Tham herself makes — see the docstring above. -/
 theorem crack_pipeline_vendler_diverges :
-    (Verbal.crack.toVerbCore.degreeAchievementScale.get!).defaultVendlerClass ≠
-    Verbal.crack.toVerbCore.vendlerClass.get! := by decide
+    (Verbal.crack.toVerb.degreeAchievementScale.get!).defaultVendlerClass ≠
+    Verbal.crack.toVerb.vendlerClass.get! := by decide
 
 /-- *break* (also Levin 45.1) IS an accomplishment — the standard
     pipeline works for it. So the Fragment-level divergence is specific
     to disturbance predicates within the same Levin class. -/
 theorem break_fits_pipeline :
-    Verbal.break_.toVerbCore.vendlerClass = some .accomplishment := rfl
+    Verbal.break_.toVerb.vendlerClass = some .accomplishment := rfl
 
 /-- *crack* and *break* share LevinClass but differ in VendlerClass.
     Both are Levin 45.1 Break verbs, but *crack* is achievement
@@ -556,15 +556,15 @@ theorem break_fits_pipeline :
     Tham's analysis predicts: disturbance predicates have distinctive
     aspectual behavior. -/
 theorem crack_break_same_levin_different_vendler :
-    Verbal.crack.toVerbCore.levinClass = Verbal.break_.toVerbCore.levinClass ∧
-    Verbal.crack.toVerbCore.vendlerClass ≠ Verbal.break_.toVerbCore.vendlerClass :=
+    Verbal.crack.toVerb.levinClass = Verbal.break_.toVerb.levinClass ∧
+    Verbal.crack.toVerb.vendlerClass ≠ Verbal.break_.toVerb.vendlerClass :=
   ⟨rfl, by decide⟩
 
 /-- *shatter* is also achievement — but unlike crack, shatter ONLY has
     the punctual reading. Same Vendler class, different aspectual
     flexibility. VendlerClass is too coarse for disturbance predicates. -/
 theorem shatter_also_achievement :
-    Verbal.shatter.toVerbCore.vendlerClass = some .achievement := rfl
+    Verbal.shatter.toVerb.vendlerClass = some .achievement := rfl
 
 /-- Boundedness convergence: both pipelines agree crack is `.closed`.
     Achievement and accomplishment are both telic → `.closed`, so the
@@ -578,8 +578,8 @@ theorem shatter_also_achievement :
     `Boundedness` ALSO means convergence at `VendlerClass`. For *crack*,
     only `Boundedness` converges. -/
 theorem crack_boundedness_converges_despite_vendler_divergence :
-    LicensingPipeline.toBoundedness (Verbal.crack.toVerbCore.degreeAchievementScale.get!) =
-    LicensingPipeline.toBoundedness (Verbal.crack.toVerbCore.vendlerClass.get!) := rfl
+    LicensingPipeline.toBoundedness (Verbal.crack.toVerb.degreeAchievementScale.get!) =
+    LicensingPipeline.toBoundedness (Verbal.crack.toVerb.vendlerClass.get!) := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 10. Cross-paper engagement: Hay-Kennedy-Levin matrix
@@ -602,7 +602,7 @@ theorem crack_boundedness_converges_despite_vendler_divergence :
 /-- *crack* refutes the strict HKL matrix: closed scale, but BOTH telic
     and atelic readings attested. -/
 theorem crack_refutes_strict_hkl_matrix :
-    (Verbal.crack.toVerbCore.degreeAchievementScale.get!).scaleBoundedness
+    (Verbal.crack.toVerb.degreeAchievementScale.get!).scaleBoundedness
       = Boundedness.closed ∧
     crack.verbInX = true ∧
     crack.verbForX = true := ⟨rfl, rfl, rfl⟩
@@ -901,7 +901,7 @@ theorem largeVase_score_le_one :
     the adjective applies to surfaces that have not undergone the
     CoS event. The substrate-level contrast: B&KG's *crack* root
     asserts `becomesState` (the verbal entry derived from this root
-    inherits it via `Verbal.crack.toVerbCore.degreeAchievementScale`),
+    inherits it via `Verbal.crack.toVerb.degreeAchievementScale`),
     yet the adjectival side `Tham2025.crack.adjEntailsPrecedingChange`
     is false. -/
 


### PR DESCRIPTION
Renames the composed verb-entry type `VerbCore` → `Verb` across the library (51 files), so the type and its facet namespace (`Verb.ArgStructure`, `Verb.Aspect`, …) share one name. The `extends` projection follows: `.toVerbCore` → `.toVerb`.

No `abbrev VerbCore := Verb` shim — a full, decisive rename (per the project's no-backcompat rule). Verified against the full 6011-job library build (0 errors).