### PR TITLE
refactor(Phonology/OptimalityTheory): Fin-typed Corr edge, drop wf

### DIFF
--- a/Linglib/Phonology/Autosegmental/BasemapCorrespondence.lean
+++ b/Linglib/Phonology/Autosegmental/BasemapCorrespondence.lean
@@ -153,16 +153,13 @@ theorem basemapViolations_eq_zero_imp
   rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff] at hZero
   apply List.ext_getElem hLen
   intro n hn₁ hn₂
-  have hmem : (n, n) ∈ (Corr.parallel t₁ t₂).edge .lhs .rhs := by
-    rw [Corr.parallel_edge_lhs_rhs, Finset.mem_image]
-    refine ⟨n, ?_, rfl⟩
-    rw [Finset.mem_range, Nat.lt_min]
-    exact ⟨hn₁, hn₂⟩
-  have := hZero hmem
-  simp only [Corr.parallel_form_lhs, Corr.parallel_form_rhs,
-             not_not] at this
-  rw [List.getElem?_eq_getElem hn₁, List.getElem?_eq_getElem hn₂] at this
-  exact Option.some_inj.mp this
+  have hmem : ((⟨n, hn₁⟩ : Fin t₁.length), (⟨n, hn₂⟩ : Fin t₂.length)) ∈
+      (Corr.parallel t₁ t₂).edge .lhs .rhs := by
+    rw [Corr.parallel_edge_lhs_rhs]
+    exact (Corr.mem_diagDiag _ _).mpr rfl
+  have hne := hZero hmem
+  simp only [Corr.parallel_form_lhs, Corr.parallel_form_rhs, not_not] at hne
+  simpa using hne
 
 /-! ### NamedConstraint bridge -/
 

--- a/Linglib/Phonology/OptimalityTheory/Correspondence.lean
+++ b/Linglib/Phonology/OptimalityTheory/Correspondence.lean
@@ -40,9 +40,13 @@ model-theoretic treatment of @cite{payne-vu-heinz-2017} and
 
 ## Main results
 
-* `Corr.exists_orderIso_of_faithful` — a correspondence with no MAX, DEP,
-  INTEGRITY, UNIFORMITY, or LINEARITY violation is the graph of an order
-  isomorphism (the converse of the `identity_*_zero` lemmas).
+* `Corr.IsFaithful` — the conjunction of the five order-relevant zeros
+  (MAX, DEP, INTEGRITY, UNIFORMITY, LINEARITY).
+* `Corr.isFaithful_iff_exists_orderIso` — a correspondence is faithful iff
+  its edge is the graph of an order isomorphism between the two position
+  orders.
+* `Corr.exists_orderIso_of_faithful` — the forward direction (the converse
+  of the `identity_*_zero` lemmas).
 -/
 
 namespace Phonology.Correspondence
@@ -70,12 +74,11 @@ inductive RedupRole where
 
 /-- A correspondence diagram: role-indexed `form`s and a directed
     correspondence relation `edge` between positions (@cite{mccarthy-prince-1995}
-    Def. 10). `edge_lt_length` bounds each pair to in-range positions. -/
+    Def. 10). The in-range bound is carried by the `Fin`-indexed type of
+    `edge` rather than a separate well-formedness field. -/
 structure Corr (Role : Type*) (α : Type*) where
   form : Role → List α
-  edge : Role → Role → Finset (ℕ × ℕ)
-  edge_lt_length : ∀ r₁ r₂, ∀ p ∈ edge r₁ r₂,
-    p.1 < (form r₁).length ∧ p.2 < (form r₂).length
+  edge : (r₁ r₂ : Role) → Finset (Fin (form r₁).length × Fin (form r₂).length)
 
 namespace Corr
 
@@ -92,27 +95,28 @@ def IsSymmetric (c : Corr Role α) : Prop :=
 /-- MAX (@cite{mccarthy-prince-1995} A.1): the count of `form r₁` positions with
     no correspondent in `form r₂`. MAX-OO is basemap faithfulness (@cite{benua-1997}). -/
 def maxViol (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
-  ((Finset.range (c.form r₁).length) \ (c.edge r₁ r₂).image Prod.fst).card
+  (Finset.univ \ (c.edge r₁ r₂).image Prod.fst).card
 
 /-- DEP (@cite{mccarthy-prince-1995} A.2): the count of `form r₂` positions with
     no correspondent in `form r₁`. DEP-IO prohibits epenthesis. -/
 def depViol (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
-  ((Finset.range (c.form r₂).length) \ (c.edge r₁ r₂).image Prod.snd).card
+  (Finset.univ \ (c.edge r₁ r₂).image Prod.snd).card
 
 /-- IDENT (@cite{mccarthy-prince-1995} A.3): corresponding pairs whose segments
     differ. IDENT-OO is OO-faithfulness (@cite{benua-1997}, @cite{mccarthy-2005},
-    @cite{rolle-2018}). See `identViolFeature` for the feature-by-feature
-    variant. -/
+    @cite{rolle-2018}). Each coordinate of a correspondence pair is a `Fin`
+    in range, so `(form r₁)[p.1]` is the total indexed lookup (no `Option`).
+    See `identViolFeature` for the feature-by-feature variant. -/
 def identViol [DecidableEq α] (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
   ((c.edge r₁ r₂).filter fun p =>
-    (c.form r₁)[p.1]? ≠ (c.form r₂)[p.2]?).card
+    (c.form r₁)[p.1] ≠ (c.form r₂)[p.2]).card
 
 /-- Featural IDENT (@cite{mccarthy-prince-1995} A.3): corresponding pairs
     differing under `proj` (@cite{benua-1997}, @cite{rose-walker-2011}). -/
 def identViolFeature {F : Type*} [DecidableEq F] (proj : α → F)
     (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
   ((c.edge r₁ r₂).filter fun p =>
-    (c.form r₁)[p.1]?.map proj ≠ (c.form r₂)[p.2]?.map proj).card
+    proj (c.form r₁)[p.1] ≠ proj (c.form r₂)[p.2]).card
 
 /-! ### Contiguity -/
 
@@ -123,47 +127,59 @@ instance : (l : List ℕ) → Decidable (IsContiguous l) :=
   inferInstanceAs ((l : List ℕ) → Decidable (List.IsChain _ l))
 
 /-- I-CONTIGUITY "No Skipping" (@cite{mccarthy-prince-1995} A.4a): the domain
-    of correspondence is contiguous in `form r₁`. -/
+    of correspondence is contiguous in `form r₁`. The `Fin`-valued domain is
+    projected to its `ℕ` values and sorted before the chain check. -/
 def contigIViol (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
-  let dom := ((c.edge r₁ r₂).image Prod.fst).sort (· ≤ ·)
+  let dom := (((c.edge r₁ r₂).image Prod.fst).image Fin.val).sort (· ≤ ·)
   if IsContiguous dom then 0 else 1
 
 /-- O-CONTIGUITY "No Intrusion" (@cite{mccarthy-prince-1995} A.4b): the range
     of correspondence is contiguous in `form r₂`. -/
 def contigOViol (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
-  let rng := ((c.edge r₁ r₂).image Prod.snd).sort (· ≤ ·)
+  let rng := (((c.edge r₁ r₂).image Prod.snd).image Fin.val).sort (· ≤ ·)
   if IsContiguous rng then 0 else 1
 
 /-! ### Anchors -/
 
-/-- L-ANCHOR (@cite{mccarthy-prince-1995} A.5): leftmost positions correspond. -/
+/-- L-ANCHOR (@cite{mccarthy-prince-1995} A.5): leftmost positions correspond.
+    When either form is empty there is no leftmost position, so the constraint
+    is vacuously satisfied; otherwise the `Fin` endpoints are the two `0`s. -/
 def anchorLViol (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
-  if (c.form r₁).length = 0 ∨ (c.form r₂).length = 0 then 0
-  else if (0, 0) ∈ c.edge r₁ r₂ then 0 else 1
+  if h : (c.form r₁).length = 0 ∨ (c.form r₂).length = 0 then 0
+  else
+    have h₁ : 0 < (c.form r₁).length := Nat.pos_of_ne_zero (fun e => h (Or.inl e))
+    have h₂ : 0 < (c.form r₂).length := Nat.pos_of_ne_zero (fun e => h (Or.inr e))
+    if (⟨0, h₁⟩, ⟨0, h₂⟩) ∈ c.edge r₁ r₂ then 0 else 1
 
-/-- R-ANCHOR (@cite{mccarthy-prince-1995} A.5): rightmost positions correspond. -/
+/-- R-ANCHOR (@cite{mccarthy-prince-1995} A.5): rightmost positions correspond.
+    The `Fin` endpoints are the two `Fin.last`s when both forms are nonempty. -/
 def anchorRViol (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
-  if (c.form r₁).length = 0 ∨ (c.form r₂).length = 0 then 0
-  else if ((c.form r₁).length - 1, (c.form r₂).length - 1) ∈ c.edge r₁ r₂
+  if h : (c.form r₁).length = 0 ∨ (c.form r₂).length = 0 then 0
+  else
+    have h₁ : 0 < (c.form r₁).length := Nat.pos_of_ne_zero (fun e => h (Or.inl e))
+    have h₂ : 0 < (c.form r₂).length := Nat.pos_of_ne_zero (fun e => h (Or.inr e))
+    if (⟨(c.form r₁).length - 1, Nat.pred_lt_self h₁⟩,
+        ⟨(c.form r₂).length - 1, Nat.pred_lt_self h₂⟩) ∈ c.edge r₁ r₂
        then 0 else 1
 
 /-! ### Linearity, uniformity, integrity -/
 
 /-- LINEARITY "No Metathesis" (@cite{mccarthy-prince-1995} A.6): the count of
-    inversion pairs `(i₁,j₁), (i₂,j₂) ∈ edge` with `i₁ < i₂` but `j₂ < j₁`. -/
+    inversion pairs `(i₁,j₁), (i₂,j₂) ∈ edge` with `i₁ < i₂` but `j₂ < j₁`
+    (coordinates compared via `Fin.lt`). -/
 def linearityViol (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
   ((c.edge r₁ r₂ ×ˢ c.edge r₁ r₂).filter fun pq => pq.1.1 < pq.2.1 ∧ pq.2.2 < pq.1.2).card
 
 /-- UNIFORMITY "No Coalescence" (@cite{mccarthy-prince-1995} A.7): the count of
     `form r₂` positions with more than one correspondent in `form r₁`. -/
 def uniformityViol (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
-  ((Finset.range (c.form r₂).length).filter fun j =>
+  ((Finset.univ : Finset (Fin (c.form r₂).length)).filter fun j =>
     ((c.edge r₁ r₂).filter fun p => p.2 = j).card > 1).card
 
 /-- INTEGRITY "No Breaking" (@cite{mccarthy-prince-1995} A.8): the count of
     `form r₁` positions with more than one correspondent in `form r₂`. -/
 def integrityViol (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
-  ((Finset.range (c.form r₁).length).filter fun i =>
+  ((Finset.univ : Finset (Fin (c.form r₁).length)).filter fun i =>
     ((c.edge r₁ r₂).filter fun p => p.1 = i).card > 1).card
 
 /-! ### Faithfulness predicate bridges
@@ -174,29 +190,29 @@ named characterizations the order-isomorphism theorem is assembled from. -/
 
 theorem maxViol_eq_zero_iff (c : Corr Role α) (r₁ r₂ : Role) :
     c.maxViol r₁ r₂ = 0 ↔
-      Finset.range (c.form r₁).length ⊆ (c.edge r₁ r₂).image Prod.fst := by
+      (Finset.univ : Finset (Fin (c.form r₁).length)) ⊆ (c.edge r₁ r₂).image Prod.fst := by
   simp only [maxViol, Finset.card_eq_zero, Finset.sdiff_eq_empty_iff_subset]
 
 theorem depViol_eq_zero_iff (c : Corr Role α) (r₁ r₂ : Role) :
     c.depViol r₁ r₂ = 0 ↔
-      Finset.range (c.form r₂).length ⊆ (c.edge r₁ r₂).image Prod.snd := by
+      (Finset.univ : Finset (Fin (c.form r₂).length)) ⊆ (c.edge r₁ r₂).image Prod.snd := by
   simp only [depViol, Finset.card_eq_zero, Finset.sdiff_eq_empty_iff_subset]
 
 theorem integrityViol_eq_zero_iff (c : Corr Role α) (r₁ r₂ : Role) :
     c.integrityViol r₁ r₂ = 0 ↔
-      ∀ i, i < (c.form r₁).length → ((c.edge r₁ r₂).filter fun p => p.1 = i).card ≤ 1 := by
+      ∀ i, ((c.edge r₁ r₂).filter fun p => p.1 = i).card ≤ 1 := by
   rw [integrityViol, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
   constructor
-  · intro h i hi; have := h (Finset.mem_range.mpr hi); omega
-  · intro h i hi; have := h i (Finset.mem_range.mp hi); omega
+  · intro h i; have := h (Finset.mem_univ i); omega
+  · intro h i _; have := h i; omega
 
 theorem uniformityViol_eq_zero_iff (c : Corr Role α) (r₁ r₂ : Role) :
     c.uniformityViol r₁ r₂ = 0 ↔
-      ∀ j, j < (c.form r₂).length → ((c.edge r₁ r₂).filter fun p => p.2 = j).card ≤ 1 := by
+      ∀ j, ((c.edge r₁ r₂).filter fun p => p.2 = j).card ≤ 1 := by
   rw [uniformityViol, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
   constructor
-  · intro h j hj; have := h (Finset.mem_range.mpr hj); omega
-  · intro h j hj; have := h j (Finset.mem_range.mp hj); omega
+  · intro h j; have := h (Finset.mem_univ j); omega
+  · intro h j _; have := h j; omega
 
 theorem linearityViol_eq_zero_iff (c : Corr Role α) (r₁ r₂ : Role) :
     c.linearityViol r₁ r₂ = 0 ↔
@@ -212,18 +228,59 @@ theorem linearityViol_eq_zero_iff (c : Corr Role α) (r₁ r₂ : Role) :
 
 /-! ### Universal constructors -/
 
-private theorem range_image_wf (n m₁ m₂ : ℕ) (h₁ : n ≤ m₁) (h₂ : n ≤ m₂) :
-    ∀ p ∈ (Finset.range n).image (fun i => (i, i)),
-      p.1 < m₁ ∧ p.2 < m₂ := by
-  intro p hmem
-  simp only [Finset.mem_image, Finset.mem_range] at hmem
-  obtain ⟨i, hi, rfl⟩ := hmem
-  exact ⟨lt_of_lt_of_le hi h₁, lt_of_lt_of_le hi h₂⟩
+/-- The parallel-pair diagonal in `Fin`-coordinates: `(0,0), (1,1), …` up to
+    `min m n`, each index cast up into the two position types via `Fin.castLE`. -/
+def diagDiag (m n : ℕ) : Finset (Fin m × Fin n) :=
+  (Finset.univ : Finset (Fin (min m n))).image
+    (fun i => (i.castLE (min_le_left _ _), i.castLE (min_le_right _ _)))
 
-private theorem image_swap_diag (n : ℕ) :
-    ((Finset.range n).image (fun i => (i, i))).image Prod.swap =
-      (Finset.range n).image (fun i => (i, i)) := by
-  rw [Finset.image_image]; rfl
+/-- Membership in the diagonal: `(a, b) ∈ diagDiag m n` iff the two indices
+    have equal underlying values. -/
+theorem mem_diagDiag {m n : ℕ} (a : Fin m) (b : Fin n) :
+    (a, b) ∈ diagDiag m n ↔ (a : ℕ) = (b : ℕ) := by
+  simp only [diagDiag, Finset.mem_image, Finset.mem_univ, true_and]
+  constructor
+  · rintro ⟨i, hi⟩
+    rw [Prod.mk.injEq] at hi
+    have h1 : (a : ℕ) = (i : ℕ) := congrArg Fin.val hi.1.symm
+    have h2 : (b : ℕ) = (i : ℕ) := congrArg Fin.val hi.2.symm
+    rw [h1, h2]
+  · intro hab
+    refine ⟨⟨a.1, by have := a.2; have := b.2; omega⟩, ?_⟩
+    rw [Prod.mk.injEq]
+    exact ⟨Fin.ext rfl, Fin.ext hab⟩
+
+theorem diagDiag_image_fst {m : ℕ} :
+    (diagDiag m m).image Prod.fst = (Finset.univ : Finset (Fin m)) := by
+  ext a
+  simp only [Finset.mem_image, Finset.mem_univ, iff_true, Prod.exists]
+  exact ⟨a, a, (mem_diagDiag a a).mpr rfl, rfl⟩
+
+theorem diagDiag_image_snd {m : ℕ} :
+    (diagDiag m m).image Prod.snd = (Finset.univ : Finset (Fin m)) := by
+  ext b
+  simp only [Finset.mem_image, Finset.mem_univ, iff_true, Prod.exists]
+  exact ⟨b, b, (mem_diagDiag b b).mpr rfl, rfl⟩
+
+/-- The diagonal has `min m n` pairs — one per index of the shorter form. -/
+theorem diagDiag_card (m n : ℕ) : (diagDiag m n).card = min m n := by
+  have hinj : Function.Injective
+      (fun i : Fin (min m n) => (i.castLE (min_le_left m n), i.castLE (min_le_right m n))) :=
+    fun _ _ hab => Fin.ext (congrArg (Fin.val ∘ Prod.fst) hab)
+  rw [diagDiag, Finset.card_image_of_injective _ hinj, Finset.card_univ, Fintype.card_fin]
+
+private theorem image_swap_diagDiag (m n : ℕ) :
+    (diagDiag m n).image Prod.swap = diagDiag n m := by
+  ext p
+  rw [Finset.mem_image]
+  constructor
+  · rintro ⟨q, hq, rfl⟩
+    rw [mem_diagDiag]
+    exact ((mem_diagDiag q.1 q.2).mp hq).symm
+  · intro hp
+    refine ⟨p.swap, ?_, p.swap_swap⟩
+    rw [mem_diagDiag]
+    exact ((mem_diagDiag p.1 p.2).mp hp).symm
 
 /-- Universal constructor: where `hasEdge` holds, the parallel-pair
     correspondence `(0,0), (1,1), …` truncated to `min` of the two lengths;
@@ -232,16 +289,7 @@ private theorem image_swap_diag (n : ℕ) :
 def diagram (form : Role → List α) (hasEdge : Role → Role → Prop)
     [DecidableRel hasEdge] : Corr Role α where
   form := form
-  edge r₁ r₂ := if hasEdge r₁ r₂ then
-    (Finset.range (min (form r₁).length (form r₂).length)).image fun i => (i, i)
-  else ∅
-  edge_lt_length := by
-    intro r₁ r₂ p hmem
-    by_cases h : hasEdge r₁ r₂
-    · rw [if_pos h] at hmem
-      exact range_image_wf _ _ _ (min_le_left _ _) (min_le_right _ _) p hmem
-    · rw [if_neg h] at hmem
-      simp at hmem
+  edge r₁ r₂ := if hasEdge r₁ r₂ then diagDiag (form r₁).length (form r₂).length else ∅
 
 @[simp] theorem diagram_form (form : Role → List α) (hasEdge : Role → Role → Prop)
     [DecidableRel hasEdge] (r : Role) :
@@ -250,20 +298,18 @@ def diagram (form : Role → List α) (hasEdge : Role → Role → Prop)
 theorem diagram_edge (form : Role → List α) (hasEdge : Role → Role → Prop)
     [DecidableRel hasEdge] (r₁ r₂ : Role) :
     (diagram form hasEdge).edge r₁ r₂ =
-      if hasEdge r₁ r₂ then
-        (Finset.range (min (form r₁).length (form r₂).length)).image (fun i => (i, i))
-      else ∅ := rfl
+      if hasEdge r₁ r₂ then diagDiag (form r₁).length (form r₂).length else ∅ := rfl
 
 theorem diagram_edge_pos (form : Role → List α) (hasEdge : Role → Role → Prop)
     [DecidableRel hasEdge] {r₁ r₂ : Role} (h : hasEdge r₁ r₂) :
-    (diagram form hasEdge).edge r₁ r₂ =
-      (Finset.range (min (form r₁).length (form r₂).length)).image (fun i => (i, i)) := by
+    (diagram form hasEdge).edge r₁ r₂ = diagDiag (form r₁).length (form r₂).length := by
   rw [diagram_edge, if_pos h]
 
 theorem diagram_edge_neg (form : Role → List α) (hasEdge : Role → Role → Prop)
     [DecidableRel hasEdge] {r₁ r₂ : Role} (h : ¬ hasEdge r₁ r₂) :
     (diagram form hasEdge).edge r₁ r₂ = ∅ := by
   rw [diagram_edge, if_neg h]
+  rfl
 
 /-- A `diagram` over a symmetric predicate is a symmetric correspondence —
     symmetry *derived*, not stipulated. -/
@@ -272,8 +318,8 @@ theorem diagram_isSymmetric (form : Role → List α) (hasEdge : Role → Role �
     IsSymmetric (diagram form hasEdge) := by
   intro r₁ r₂
   by_cases h : hasEdge r₁ r₂
-  · rw [diagram_edge_pos _ _ (hsymm h), diagram_edge_pos _ _ h, image_swap_diag,
-      Nat.min_comm (form r₂).length (form r₁).length]
+  · rw [diagram_edge_pos _ _ (hsymm h), diagram_edge_pos _ _ h]
+    exact (image_swap_diagDiag _ _).symm
   · rw [diagram_edge_neg _ _ (fun h' => h (hsymm h')), diagram_edge_neg _ _ h,
       Finset.image_empty]
 
@@ -322,26 +368,29 @@ theorem reduplication_isSymmetric (input base reduplicant : List α) :
   simp only [parallel]; exact diagram_edge_neg _ _ (by cases r <;> decide)
 
 @[simp] theorem parallel_edge_lhs_rhs (s₁ s₂ : List α) :
-    (parallel s₁ s₂).edge .lhs .rhs =
-      (Finset.range (min s₁.length s₂.length)).image (fun i => (i, i)) := by
+    (parallel s₁ s₂).edge .lhs .rhs = diagDiag s₁.length s₂.length := by
   simp only [parallel]; exact diagram_edge_pos _ _ (by decide)
 
 @[simp] theorem parallel_edge_rhs_lhs (s₁ s₂ : List α) :
-    (parallel s₁ s₂).edge .rhs .lhs =
-      (Finset.range (min s₁.length s₂.length)).image (fun i => (i, i)) := by
-  rw [parallel_isSymmetric s₁ s₂ .lhs .rhs, parallel_edge_lhs_rhs, image_swap_diag]
+    (parallel s₁ s₂).edge .rhs .lhs = diagDiag s₂.length s₁.length := by
+  rw [parallel_isSymmetric s₁ s₂ .lhs .rhs, parallel_edge_lhs_rhs]
+  exact image_swap_diagDiag _ _
 
 theorem identity_max_zero (s : List α) :
     (identity s).maxViol .lhs .rhs = 0 := by
-  simp only [identity, maxViol, parallel_form_lhs, parallel_edge_lhs_rhs,
-             Finset.image_image, Function.comp_def, Finset.image_id']
-  simp
+  rw [maxViol_eq_zero_iff]
+  intro i _
+  rw [show (identity s).edge .lhs .rhs = diagDiag s.length s.length from parallel_edge_lhs_rhs s s,
+      Finset.mem_image]
+  exact ⟨(i, i), (mem_diagDiag i i).mpr rfl, rfl⟩
 
 theorem identity_dep_zero (s : List α) :
     (identity s).depViol .lhs .rhs = 0 := by
-  simp only [identity, depViol, parallel_form_rhs, parallel_edge_lhs_rhs,
-             Finset.image_image, Function.comp_def, Finset.image_id']
-  simp
+  rw [depViol_eq_zero_iff]
+  intro j _
+  rw [show (identity s).edge .lhs .rhs = diagDiag s.length s.length from parallel_edge_lhs_rhs s s,
+      Finset.mem_image]
+  exact ⟨(j, j), (mem_diagDiag j j).mpr rfl, rfl⟩
 
 theorem identity_ident_zero [DecidableEq α] (s : List α) :
     (identity s).identViol .lhs .rhs = 0 := by
@@ -349,9 +398,9 @@ theorem identity_ident_zero [DecidableEq α] (s : List α) :
              parallel_edge_lhs_rhs]
   rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
   intro p hp
-  rw [Finset.mem_image] at hp
-  obtain ⟨i, _, rfl⟩ := hp
-  simp
+  have hpq : (p.1 : ℕ) = (p.2 : ℕ) := (mem_diagDiag p.1 p.2).mp (by simpa using hp)
+  simp only [not_not]
+  exact congrArg (s[·]) (Fin.ext hpq)
 
 theorem identity_identFeature_zero {F : Type*} [DecidableEq F] (proj : α → F)
     (s : List α) :
@@ -360,89 +409,149 @@ theorem identity_identFeature_zero {F : Type*} [DecidableEq F] (proj : α → F)
              parallel_edge_lhs_rhs]
   rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
   intro p hp
-  rw [Finset.mem_image] at hp
-  obtain ⟨i, _, rfl⟩ := hp
-  simp
+  have hpq : (p.1 : ℕ) = (p.2 : ℕ) := (mem_diagDiag p.1 p.2).mp (by simpa using hp)
+  simp only [not_not]
+  exact congrArg (fun i => proj s[i]) (Fin.ext hpq)
 
 /-! ### Faithfulness as order-isomorphism -/
 
-/-- **Faithful ⟹ order-isomorphism.** A correspondence with no MAX, DEP,
-    INTEGRITY, UNIFORMITY, or LINEARITY violation is the graph of an order
-    isomorphism between the two position orders — the converse of the
-    `identity_*_zero` lemmas, and the formal content of M&P's fully-faithful
-    candidate being the identity (the simultaneous zero of
-    @cite{mccarthy-prince-1995} (A.1), (A.2), (A.6), (A.7), (A.8)). -/
+/-- The five order-relevant zeros bundled: a correspondence is **faithful**
+    (on the `(r₁, r₂)` edge) when it has no MAX, DEP, INTEGRITY, UNIFORMITY,
+    or LINEARITY violation (@cite{mccarthy-prince-1995} (A.1), (A.2), (A.6),
+    (A.7), (A.8)). This is exactly the hypothesis set under which the edge is
+    the graph of an order isomorphism. -/
+structure IsFaithful (c : Corr Role α) (r₁ r₂ : Role) : Prop where
+  max : c.maxViol r₁ r₂ = 0
+  dep : c.depViol r₁ r₂ = 0
+  integrity : c.integrityViol r₁ r₂ = 0
+  uniformity : c.uniformityViol r₁ r₂ = 0
+  linearity : c.linearityViol r₁ r₂ = 0
+
+/-- MAX + INTEGRITY: the edge is the graph of a function `Fin n → Fin m`. The
+    `Fin`-typed storage means `p ∈ edge` already gives `p : Fin n × Fin m`, so
+    no in-range packaging is needed. -/
+private theorem exists_corrFun (c : Corr Role α) (r₁ r₂ : Role)
+    (hmax : c.maxViol r₁ r₂ = 0) (hint : c.integrityViol r₁ r₂ = 0) :
+    ∃ f : Fin (c.form r₁).length → Fin (c.form r₂).length,
+      ∀ i j, (i, j) ∈ c.edge r₁ r₂ ↔ f i = j := by
+  set E := c.edge r₁ r₂ with hE
+  have hsubL : Finset.univ ⊆ E.image Prod.fst := (maxViol_eq_zero_iff c r₁ r₂).mp hmax
+  have hfunL : ∀ i, (E.filter (fun p => p.1 = i)).card ≤ 1 :=
+    (integrityViol_eq_zero_iff c r₁ r₂).mp hint
+  have hexU : ∀ i, ∃! j, (i, j) ∈ E := by
+    intro i
+    have hmem : i ∈ E.image Prod.fst := hsubL (Finset.mem_univ i)
+    rw [Finset.mem_image] at hmem
+    obtain ⟨p, hp, hp1⟩ := hmem
+    have hpE : (i, p.2) ∈ E := by simpa [← hp1] using hp
+    refine ⟨p.2, hpE, fun j hj => ?_⟩
+    have hcard := hfunL i
+    rw [Finset.card_le_one] at hcard
+    have h1 : (i, p.2) ∈ E.filter (fun q => q.1 = i) := Finset.mem_filter.mpr ⟨hpE, rfl⟩
+    have h2 : (i, j) ∈ E.filter (fun q => q.1 = i) := Finset.mem_filter.mpr ⟨hj, rfl⟩
+    simpa using hcard _ h2 _ h1
+  choose f hf _ using fun i => hexU i
+  refine ⟨f, fun i j => ⟨fun hmem => ?_, ?_⟩⟩
+  · obtain ⟨_, _, huniq⟩ := hexU i
+    exact (huniq (f i) (hf i)).trans (huniq j hmem).symm
+  · rintro rfl; exact hf i
+
+/-- **Faithful ⟺ order-isomorphism.** A correspondence is faithful (no MAX,
+    DEP, INTEGRITY, UNIFORMITY, or LINEARITY violation) iff its edge is the
+    graph of an order isomorphism between the two position orders. The forward
+    direction is the converse of the `identity_*_zero` lemmas, and the formal
+    content of M&P's fully-faithful candidate being the identity. -/
+theorem isFaithful_iff_exists_orderIso (c : Corr Role α) (r₁ r₂ : Role) :
+    c.IsFaithful r₁ r₂ ↔
+      ∃ e : Fin (c.form r₁).length ≃o Fin (c.form r₂).length,
+        ∀ i j, (i, j) ∈ c.edge r₁ r₂ ↔ e i = j := by
+  set n := (c.form r₁).length with hn
+  set m := (c.form r₂).length with hm
+  set E := c.edge r₁ r₂ with hE
+  constructor
+  · rintro ⟨hmax, hdep, hint, huni, hlin⟩
+    obtain ⟨f, mem_iff⟩ := exists_corrFun c r₁ r₂ hmax hint
+    have hfunR : ∀ j, (E.filter (fun p => p.2 = j)).card ≤ 1 :=
+      (uniformityViol_eq_zero_iff c r₁ r₂).mp huni
+    have hnoinv : ∀ p ∈ E, ∀ q ∈ E, p.1 < q.1 → ¬ q.2 < p.2 :=
+      (linearityViol_eq_zero_iff c r₁ r₂).mp hlin
+    -- UNIFORMITY: `f` is injective.
+    have hinj : Function.Injective f := by
+      intro a b hab
+      have ha : (a, f a) ∈ E := (mem_iff a (f a)).mpr rfl
+      have hb : (b, f b) ∈ E := (mem_iff b (f b)).mpr rfl
+      rw [hab] at ha
+      have hcard := hfunR (f b)
+      rw [Finset.card_le_one] at hcard
+      have h1 : (a, f b) ∈ E.filter (fun p => p.2 = f b) := Finset.mem_filter.mpr ⟨ha, rfl⟩
+      have h2 : (b, f b) ∈ E.filter (fun p => p.2 = f b) := Finset.mem_filter.mpr ⟨hb, rfl⟩
+      exact (Prod.ext_iff.mp (hcard _ h1 _ h2)).1
+    -- DEP: `f` is surjective.
+    have hsubR : Finset.univ ⊆ E.image Prod.snd := (depViol_eq_zero_iff c r₁ r₂).mp hdep
+    have hsurj : Function.Surjective f := by
+      intro j
+      have hmem : j ∈ E.image Prod.snd := hsubR (Finset.mem_univ j)
+      rw [Finset.mem_image] at hmem
+      obtain ⟨p, hp, hp2⟩ := hmem
+      exact ⟨p.1, (mem_iff p.1 j).mp (by simpa [← hp2] using hp)⟩
+    -- LINEARITY = 0: `f` is strictly monotone.
+    have hmono : StrictMono f := by
+      intro a b hab
+      have ha : (a, f a) ∈ E := (mem_iff a (f a)).mpr rfl
+      have hb : (b, f b) ∈ E := (mem_iff b (f b)).mpr rfl
+      rcases lt_or_gt_of_ne (fun h => (ne_of_lt hab) (hinj h)) with h | h
+      · exact h
+      · exact absurd h (hnoinv _ ha _ hb hab)
+    refine ⟨StrictMono.orderIsoOfSurjective f hmono hsurj, fun i j => ?_⟩
+    rw [mem_iff, StrictMono.coe_orderIsoOfSurjective]
+  · rintro ⟨e, he⟩
+    -- The edge is `{(i, e i)}`; each zero follows from `e` being a bijection.
+    have hmem : ∀ i j, (i, j) ∈ E ↔ e i = j := he
+    refine ⟨?_, ?_, ?_, ?_, ?_⟩
+    · rw [maxViol_eq_zero_iff]
+      intro i _
+      rw [Finset.mem_image]
+      exact ⟨(i, e i), (hmem i (e i)).mpr rfl, rfl⟩
+    · rw [depViol_eq_zero_iff]
+      intro j _
+      rw [Finset.mem_image]
+      exact ⟨(e.symm j, j), (hmem (e.symm j) j).mpr (e.apply_symm_apply j), rfl⟩
+    · rw [integrityViol_eq_zero_iff]
+      intro i
+      rw [Finset.card_le_one]
+      intro p hp q hq
+      rw [Finset.mem_filter] at hp hq
+      have hp' := (hmem p.1 p.2).mp hp.1
+      have hq' := (hmem q.1 q.2).mp hq.1
+      apply Prod.ext (hp.2.trans hq.2.symm)
+      rw [← hp', ← hq', hp.2, hq.2]
+    · rw [uniformityViol_eq_zero_iff]
+      intro j
+      rw [Finset.card_le_one]
+      intro p hp q hq
+      rw [Finset.mem_filter] at hp hq
+      have hp' := (hmem p.1 p.2).mp hp.1
+      have hq' := (hmem q.1 q.2).mp hq.1
+      have hpj : e p.1 = j := hp'.trans hp.2
+      have hqj : e q.1 = j := hq'.trans hq.2
+      have : p.1 = q.1 := e.injective (hpj.trans hqj.symm)
+      exact Prod.ext this (hp.2.trans hq.2.symm)
+    · rw [linearityViol_eq_zero_iff]
+      intro p hp q hq hpq
+      have hp' := (hmem p.1 p.2).mp hp
+      have hq' := (hmem q.1 q.2).mp hq
+      rw [← hp', ← hq']
+      exact not_lt.mpr (le_of_lt (e.lt_iff_lt.mpr hpq))
+
+/-- **Faithful ⟹ order-isomorphism** (the forward direction of
+    `isFaithful_iff_exists_orderIso`). -/
 theorem exists_orderIso_of_faithful (c : Corr Role α) (r₁ r₂ : Role)
     (hmax : c.maxViol r₁ r₂ = 0) (hdep : c.depViol r₁ r₂ = 0)
     (hint : c.integrityViol r₁ r₂ = 0) (huni : c.uniformityViol r₁ r₂ = 0)
     (hlin : c.linearityViol r₁ r₂ = 0) :
     ∃ e : Fin (c.form r₁).length ≃o Fin (c.form r₂).length,
-      ∀ (i : Fin (c.form r₁).length) (j : Fin (c.form r₂).length),
-        ((i : ℕ), (j : ℕ)) ∈ c.edge r₁ r₂ ↔ e i = j := by
-  set n := (c.form r₁).length with hn
-  set m := (c.form r₂).length with hm
-  set E := c.edge r₁ r₂ with hE
-  have hwf : ∀ p ∈ E, p.1 < n ∧ p.2 < m := c.edge_lt_length r₁ r₂
-  have hsubL : Finset.range n ⊆ E.image Prod.fst := (maxViol_eq_zero_iff c r₁ r₂).mp hmax
-  have hsubR : Finset.range m ⊆ E.image Prod.snd := (depViol_eq_zero_iff c r₁ r₂).mp hdep
-  have hfunL : ∀ i, i < n → (E.filter (fun p => p.1 = i)).card ≤ 1 :=
-    (integrityViol_eq_zero_iff c r₁ r₂).mp hint
-  have hfunR : ∀ j, j < m → (E.filter (fun p => p.2 = j)).card ≤ 1 :=
-    (uniformityViol_eq_zero_iff c r₁ r₂).mp huni
-  have hnoinv : ∀ p ∈ E, ∀ q ∈ E, p.1 < q.1 → ¬ q.2 < p.2 :=
-    (linearityViol_eq_zero_iff c r₁ r₂).mp hlin
-  -- MAX + INTEGRITY: every left position has a *unique* correspondent.
-  have hexU : ∀ i, i < n → ∃! j, ((i, j) ∈ E) := by
-    intro i hi
-    have hmem : i ∈ E.image Prod.fst := hsubL (Finset.mem_range.mpr hi)
-    rw [Finset.mem_image] at hmem
-    obtain ⟨p, hp, hp1⟩ := hmem
-    have hpE : (i, p.2) ∈ E := by simpa [← hp1] using hp
-    refine ⟨p.2, hpE, fun j hj => ?_⟩
-    have hcard := hfunL i hi
-    rw [Finset.card_le_one] at hcard
-    have h1 : (i, p.2) ∈ E.filter (fun q => q.1 = i) := Finset.mem_filter.mpr ⟨hpE, rfl⟩
-    have h2 : (i, j) ∈ E.filter (fun q => q.1 = i) := Finset.mem_filter.mpr ⟨hj, rfl⟩
-    simpa using hcard _ h2 _ h1
-  -- Extract `f : Fin n → Fin m` choosing the unique correspondent, with `mem_iff`.
-  have hpick : ∀ i : Fin n, ∃ j : Fin m, ((i : ℕ), (j : ℕ)) ∈ E := fun i =>
-    let ⟨j, hj, _⟩ := hexU i i.2; ⟨⟨j, (hwf _ hj).2⟩, hj⟩
-  choose f hf using hpick
-  have mem_iff : ∀ (i : Fin n) (j : Fin m), ((i : ℕ), (j : ℕ)) ∈ E ↔ f i = j := by
-    refine fun i j => ⟨fun hmem => ?_, ?_⟩
-    · obtain ⟨j', _, huniq⟩ := hexU i i.2
-      exact Fin.ext ((huniq _ (hf i)).trans (huniq _ hmem).symm)
-    · rintro rfl; exact hf i
-  -- UNIFORMITY: `f` is injective (a single right position has one source).
-  have hinj : Function.Injective f := by
-    intro a b hab
-    have ha : ((a : ℕ), (f a : ℕ)) ∈ E := (mem_iff a (f a)).mpr rfl
-    have hb : ((b : ℕ), (f b : ℕ)) ∈ E := (mem_iff b (f b)).mpr rfl
-    rw [hab] at ha
-    have hcard := hfunR (f b) (f b).2
-    rw [Finset.card_le_one] at hcard
-    have h1 : ((a : ℕ), (f b : ℕ)) ∈ E.filter (fun p => p.2 = (f b : ℕ)) :=
-      Finset.mem_filter.mpr ⟨ha, rfl⟩
-    have h2 : ((b : ℕ), (f b : ℕ)) ∈ E.filter (fun p => p.2 = (f b : ℕ)) :=
-      Finset.mem_filter.mpr ⟨hb, rfl⟩
-    exact Fin.ext (by simpa using congrArg Prod.fst (hcard _ h1 _ h2))
-  -- DEP: `f` is surjective (every right position is hit).
-  have hsurj : Function.Surjective f := by
-    intro j
-    have hmem : (j : ℕ) ∈ E.image Prod.snd := hsubR (Finset.mem_range.mpr j.2)
-    rw [Finset.mem_image] at hmem
-    obtain ⟨p, hp, hp2⟩ := hmem
-    exact ⟨⟨p.1, (hwf _ hp).1⟩, (mem_iff ⟨p.1, (hwf _ hp).1⟩ j).mp (by simpa [← hp2] using hp)⟩
-  -- LINEARITY = 0: no inversions, so `f` is strictly monotone.
-  have hmono : StrictMono f := by
-    intro a b hab
-    have ha : ((a : ℕ), (f a : ℕ)) ∈ E := (mem_iff a (f a)).mpr rfl
-    have hb : ((b : ℕ), (f b : ℕ)) ∈ E := (mem_iff b (f b)).mpr rfl
-    rcases lt_or_gt_of_ne (fun h => (ne_of_lt hab) (hinj h)) with h | h
-    · exact h
-    · exact absurd h (hnoinv _ ha _ hb hab)
-  refine ⟨StrictMono.orderIsoOfSurjective f hmono hsurj, fun i j => ?_⟩
-  rw [mem_iff, StrictMono.coe_orderIsoOfSurjective]
+      ∀ i j, (i, j) ∈ c.edge r₁ r₂ ↔ e i = j :=
+  (isFaithful_iff_exists_orderIso c r₁ r₂).mp ⟨hmax, hdep, hint, huni, hlin⟩
 
 /-- A faithful correspondence forces equal lengths (no deletion, no
     epenthesis). -/
@@ -520,7 +629,7 @@ namespace Corr
 def RoleQuiv {Role α : Type*} (_ : Corr Role α) : Type _ := Role
 
 instance {Role α : Type*} (c : Corr Role α) : Quiver (RoleQuiv c) where
-  Hom r₁ r₂ := { p : ℕ × ℕ // p ∈ c.edge r₁ r₂ }
+  Hom r₁ r₂ := { p : Fin (c.form r₁).length × Fin (c.form r₂).length // p ∈ c.edge r₁ r₂ }
 
 end Corr
 

--- a/Linglib/Phonology/OptimalityTheory/StratalCorr.lean
+++ b/Linglib/Phonology/OptimalityTheory/StratalCorr.lean
@@ -98,17 +98,11 @@ def StratalRole.label : StratalRole → String
 /-- Build the parallel-pair edge between two equal-or-shorter forms:
     `(0, 0), (1, 1), …` up to the shorter length. The substrate edge
     type for both within-stratum (IO-correspondence) and cross-stratum
-    (feeding) relations. -/
-def parallelEdge {α : Type*} (s₁ s₂ : List α) : Finset (ℕ × ℕ) :=
-  (Finset.range (min s₁.length s₂.length)).image fun i => (i, i)
-
-theorem parallelEdge_wf {α : Type*} (s₁ s₂ : List α) :
-    ∀ p ∈ parallelEdge s₁ s₂, p.1 < s₁.length ∧ p.2 < s₂.length := by
-  intro p hmem
-  simp only [parallelEdge, Finset.mem_image, Finset.mem_range] at hmem
-  obtain ⟨i, hi, rfl⟩ := hmem
-  exact ⟨lt_of_lt_of_le hi (min_le_left _ _),
-         lt_of_lt_of_le hi (min_le_right _ _)⟩
+    (feeding) relations. The in-range bound is carried by the `Fin`-indexed
+    type (`Corr.diagDiag`), so no separate well-formedness lemma is needed. -/
+def parallelEdge {α : Type*} (s₁ s₂ : List α) :
+    Finset (Fin s₁.length × Fin s₂.length) :=
+  Corr.diagDiag s₁.length s₂.length
 
 -- ============================================================================
 -- § 3: StratalDerivation → Corr StratalRole α
@@ -174,7 +168,7 @@ end Phonology.Stratal
 namespace Phonology.StratalToTCT
 
 open Phonology.Correspondence (Corr)
-open Phonology.Stratal (StratalRole stratalDerivToCorr parallelEdge parallelEdge_wf)
+open Phonology.Stratal (StratalRole stratalDerivToCorr parallelEdge)
 open Phonology.TCT (Role)
 
 /-- The canonical projection from stratal roles to TCT roles, encoding

--- a/Linglib/Phonology/ParadigmUniformity/Antifaithfulness.lean
+++ b/Linglib/Phonology/ParadigmUniformity/Antifaithfulness.lean
@@ -61,7 +61,7 @@ variable {Role : Type*} {α : Type*}
     paradigmatically related forms are pushed apart rather than together. -/
 def antifaithViol [DecidableEq α] (c : Corr Role α) (r₁ r₂ : Role) : ℕ :=
   ((c.edge r₁ r₂).filter fun p =>
-    (c.form r₁)[p.1]? = (c.form r₂)[p.2]?).card
+    (c.form r₁)[p.1] = (c.form r₂)[p.2]).card
 
 -- ============================================================================
 -- § 2: Polarity duality with IDENT
@@ -79,7 +79,7 @@ theorem antifaith_plus_ident_eq_edge_card [DecidableEq α]
     antifaithViol c r₁ r₂ + Corr.identViol c r₁ r₂ = (c.edge r₁ r₂).card :=
   Finset.card_filter_add_card_filter_not
     (s := c.edge r₁ r₂)
-    (fun p => (c.form r₁)[p.1]? = (c.form r₂)[p.2]?)
+    (fun p => (c.form r₁)[p.1] = (c.form r₂)[p.2])
 
 -- ============================================================================
 -- § 3: Identity correspondence is maximally antifaith-violating
@@ -94,14 +94,10 @@ theorem identity_antifaith_max [DecidableEq α] (s : List α) :
   have hAdd := antifaith_plus_ident_eq_edge_card (Corr.identity s)
                   Phonology.Correspondence.Side.lhs
                   Phonology.Correspondence.Side.rhs
-  rw [Corr.identity_ident_zero] at hAdd
-  rw [Nat.add_zero] at hAdd
+  rw [Corr.identity_ident_zero, Nat.add_zero] at hAdd
   rw [hAdd]
-  show ((Corr.identity s).edge .lhs .rhs).card = s.length
-  show ((Corr.parallel s s).edge .lhs .rhs).card = s.length
-  rw [Corr.parallel_edge_lhs_rhs]
-  rw [Finset.card_image_of_injective _ (fun _ _ h => (Prod.mk.injEq _ _ _ _).mp h |>.1)]
-  simp
+  simp only [Corr.identity, Corr.parallel_edge_lhs_rhs]
+  exact (Corr.diagDiag_card s.length s.length).trans (min_self s.length)
 
 -- ============================================================================
 -- § 4: NamedConstraint bridge

--- a/Linglib/Phonology/ParadigmUniformity/Transderivational.lean
+++ b/Linglib/Phonology/ParadigmUniformity/Transderivational.lean
@@ -64,32 +64,12 @@ def diagramWithEdge {α : Type}
   form := Role.formOf input base derivative
   edge r₁ r₂ :=
     match r₁, r₂ with
-    | .base, .derivative => ooEdge
-    | .input, .base       =>
-        (Finset.range (min input.length base.length)).image fun i => (i, i)
-    | .input, .derivative =>
-        (Finset.range (min input.length derivative.length)).image fun i => (i, i)
+    | .base, .derivative =>
+        -- Lift the ℕ-indexed `ooEdge` into the `Fin`-indexed storage using `hOO`.
+        ooEdge.attach.image fun p => (⟨p.1.1, (hOO p.1 p.2).1⟩, ⟨p.1.2, (hOO p.1 p.2).2⟩)
+    | .input, .base       => Corr.diagDiag input.length base.length
+    | .input, .derivative => Corr.diagDiag input.length derivative.length
     | _, _ => ∅
-  edge_lt_length := by
-    intro r₁ r₂ p hmem
-    match r₁, r₂, hmem with
-    | .base, .derivative, h => exact hOO p h
-    | .input, .base, h =>
-        simp only [Finset.mem_image, Finset.mem_range] at h
-        obtain ⟨i, hi, rfl⟩ := h
-        exact ⟨lt_of_lt_of_le hi (min_le_left _ _),
-               lt_of_lt_of_le hi (min_le_right _ _)⟩
-    | .input, .derivative, h =>
-        simp only [Finset.mem_image, Finset.mem_range] at h
-        obtain ⟨i, hi, rfl⟩ := h
-        exact ⟨lt_of_lt_of_le hi (min_le_left _ _),
-               lt_of_lt_of_le hi (min_le_right _ _)⟩
-    | .input, .input, h => exact absurd h (Finset.notMem_empty _)
-    | .base, .base, h => exact absurd h (Finset.notMem_empty _)
-    | .base, .input, h => exact absurd h (Finset.notMem_empty _)
-    | .derivative, .base, h => exact absurd h (Finset.notMem_empty _)
-    | .derivative, .input, h => exact absurd h (Finset.notMem_empty _)
-    | .derivative, .derivative, h => exact absurd h (Finset.notMem_empty _)
 
 /-- The parallel-pair specialization: the OO edge is the parallel `(i, i)`
     correspondence up to `min base.length derivative.length`. For
@@ -150,14 +130,14 @@ theorem identOO_when_equal {α : Type} [DecidableEq α]
     (input shared : List α) :
     identOOViol (diagram input shared shared) = 0 := by
   have hedge : (diagram input shared shared).edge Role.base Role.derivative =
-      (Finset.range (min shared.length shared.length)).image (fun i => (i, i)) := by
+      Corr.diagDiag shared.length shared.length := by
     simp only [diagram]
     exact Corr.diagram_edge_pos _ _ (by decide)
   unfold identOOViol Corr.identViol
   rw [hedge, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
   intro p hp
-  rw [Finset.mem_image] at hp
-  obtain ⟨i, _, rfl⟩ := hp
-  exact fun h => h rfl
+  have hpq : (p.1 : ℕ) = (p.2 : ℕ) := (Corr.mem_diagDiag p.1 p.2).mp hp
+  simp only [not_not]
+  exact congrArg (fun i : Fin shared.length => shared[i]) (Fin.ext hpq)
 
 end Phonology.ParadigmUniformity.Transderivational


### PR DESCRIPTION
Store `Corr.edge` as `Finset (Fin (form r₁).length × Fin (form r₂).length)` rather than `Finset (ℕ × ℕ)` plus a `wf` range invariant. Constraint defs and proofs become coercion-free, and the faithful⟺order-isomorphism characterization (`IsFaithful` iff, a leaf result) lands in `Fin` form. Kernel `decide` is unaffected — McCarthyPrince1995 ≈12s.