### PR TITLE
feat(Typology): pronoun API groundwork

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -9,6 +9,7 @@ import Linglib.Features.Dimension
 import Linglib.Features.Gender
 import Linglib.Core.Valence
 import Linglib.Core.Word
+import Linglib.Typology.NegativeConcord
 import Linglib.Typology.PolarityItem
 import Linglib.Typology.Negation
 import Linglib.Features.ClauseForm
@@ -257,6 +258,7 @@ import Linglib.Core.Nominal.Interpret
 import Linglib.Core.Nominal.ArticleInventory
 import Linglib.Syntax.Binding.SpecificityCondition
 import Linglib.Features.Prominence
+import Linglib.Features.OntologicalCategory
 import Linglib.Features.Genericity
 import Linglib.Core.Computability.Subregular.Defs
 import Linglib.Core.Computability.Subregular.StrictlyLocal

--- a/Linglib/Features/OntologicalCategory.lean
+++ b/Linglib/Features/OntologicalCategory.lean
@@ -1,0 +1,60 @@
+import Linglib.Core.UD
+import Linglib.Features.Prominence
+
+/-!
+# Features.OntologicalCategory
+@cite{haspelmath-1997}
+
+The ontological-category axis of pro-forms: the categories @cite{haspelmath-1997}'s
+"correlative pronoun" paradigm (his §3.1.3 Table 3.1) ranges over. The same axis is
+shared by interrogative, demonstrative, relative, and indefinite pronoun types and by
+their pronominal-adverb members (*where* / *when* / *how*), so it lives in `Features/`
+as substrate that both `Typology/` and `Phenomena/` can type their data by.
+
+## Provenance
+
+Promoted from the former `Phenomena.Questions.WhSemanticType` (a Phenomena-layer enum,
+hence unusable as substrate by `Typology/`). The wh-side `entity` case is split into
+`person` / `thing` — the distinction @cite{haspelmath-1997} notes is made "practically
+everywhere" (*who* vs *what*), and the one indefinite and negative pronouns turn on
+(*nobody* vs *nothing*). Renamings: `degree → amount`, `classificatory → property`,
+`locative → place`, `temporal → time`; `reason` (*why*) is retained from the wh side.
+
+## Main declarations
+
+* `OntologicalCategory` — person/thing/property/place/time/manner/amount/reason.
+* `OntologicalCategory.upos` — the part of speech a category realizes as
+  (PRON / ADV / DET): the bridge deciding pronoun vs pronominal-adverb vs determiner.
+* `OntologicalCategory.animacy` — projection to the @cite{aissen-2003} `AnimacyLevel`.
+-/
+
+namespace Features
+
+/-- The ontological category a pro-form ranges over (@cite{haspelmath-1997} Table 3.1),
+    shared by interrogative / demonstrative / relative / indefinite pronoun types. -/
+inductive OntologicalCategory where
+  | person     -- who, somebody, nobody — individuals (animate)
+  | thing      -- what, something, nothing — individuals (inanimate)
+  | property   -- what kind, some kind — sorts/kinds
+  | place      -- where, somewhere, nowhere — locations
+  | time       -- when, sometime, never — times
+  | manner     -- how, somehow — manners
+  | amount     -- how much, how many — degrees/quantities
+  | reason     -- why — reasons/causes
+  deriving DecidableEq, Repr, Inhabited
+
+/-- The part of speech a category realizes as: person/thing → pronoun, place/time/
+    manner/reason → (pronominal) adverb, property/amount → determiner. The bridge that
+    decides whether an indefinite cell is a pronoun (*nobody*) or pro-adverb (*never*). -/
+def OntologicalCategory.upos : OntologicalCategory → UD.UPOS
+  | .person | .thing => .PRON
+  | .place | .time | .manner | .reason => .ADV
+  | .property | .amount => .DET
+
+/-- Animacy of the category on the @cite{aissen-2003} `AnimacyLevel` scale: only
+    `person` is human; the remaining categories are inanimate. -/
+def OntologicalCategory.animacy : OntologicalCategory → Prominence.AnimacyLevel
+  | .person => .human
+  | _       => .inanimate
+
+end Features

--- a/Linglib/Features/Register.lean
+++ b/Linglib/Features/Register.lean
@@ -16,7 +16,7 @@ goals, as in @cite{yoon-etal-2020} for politeness).
 
 ## Connections
 
-* `Pronoun.Entry.register`: pronoun register (T/V/honorific)
+* `PersonalPronoun.register`: pronoun register (T/V/honorific)
 * `Pronoun.AllocutiveEntry.register`: allocutive marker register
 * `English.Auxiliaries.AuxEntry.register`: modal register
 * `Pragmatics.Expressives.OutlookMarker.ModalCompatibility`: outlook marker selectional restrictions

--- a/Linglib/Fragments/Basque/Pronouns.lean
+++ b/Linglib/Fragments/Basque/Pronouns.lean
@@ -20,11 +20,11 @@ open Features.Register (Level)
 -- ============================================================================
 
 /-- *ni* — 1sg. -/
-def ni : Entry :=
+def ni : PersonalPronoun :=
   { form := "ni", person := some .first, number := some .sg }
 
 /-- *gu* — 1pl. -/
-def gu : Entry :=
+def gu : PersonalPronoun :=
   { form := "gu", person := some .first, number := some .pl }
 
 -- ============================================================================
@@ -32,15 +32,15 @@ def gu : Entry :=
 -- ============================================================================
 
 /-- *hi* — 2sg familiar (T form). -/
-def hi : Entry :=
+def hi : PersonalPronoun :=
   { form := "hi", person := some .second, number := some .sg, register := .informal }
 
 /-- *zu* — 2sg formal (V form). -/
-def zu : Entry :=
+def zu : PersonalPronoun :=
   { form := "zu", person := some .second, number := some .sg, register := .formal }
 
 /-- *zuek* — 2pl. -/
-def zuek : Entry :=
+def zuek : PersonalPronoun :=
   { form := "zuek", person := some .second, number := some .pl }
 
 -- ============================================================================
@@ -48,20 +48,20 @@ def zuek : Entry :=
 -- ============================================================================
 
 /-- *hura* — 3sg. -/
-def hura : Entry :=
+def hura : PersonalPronoun :=
   { form := "hura", person := some .third, number := some .sg }
 
 /-- *haiek* — 3pl. -/
-def haiek : Entry :=
+def haiek : PersonalPronoun :=
   { form := "haiek", person := some .third, number := some .pl }
 
 -- ============================================================================
 -- Pronoun Lists
 -- ============================================================================
 
-def secondPersonPronouns : List Entry := [hi, zu]
+def secondPersonPronouns : List PersonalPronoun := [hi, zu]
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [ni, gu] ++ secondPersonPronouns ++ [zuek, hura, haiek]
 
 -- ============================================================================

--- a/Linglib/Fragments/English/Pronouns.lean
+++ b/Linglib/Fragments/English/Pronouns.lean
@@ -70,17 +70,17 @@ inductive PronounType where
 /--
 A lexical entry for a pronoun.
 
-Extends the cross-linguistic `Pronoun.Entry` core (`form`, `person`, `number`,
+Extends the cross-linguistic `PersonalPronoun` core (`form`, `person`, `number`,
 `case_`, `gender`, …): the shared lexical fields are the object's fields *by
 construction*, not via a mapping. The three additional fields below are the
-English-specific extensions the `Pronoun.Entry` docstring anticipates
+English-specific extensions the `PersonalPronoun` docstring anticipates
 (`pronounType`, `wh`) plus the epicene-aware `genderParadigm`, which is finer
-than the inherited `Pronoun.Entry.gender : Option SurfaceGender` (it
+than the inherited `PersonalPronoun.gender : Option SurfaceGender` (it
 distinguishes singular *they* from genuinely genderless forms). The inherited
 `gender` is left at its default in the literals; `PronounEntry.entry` fills it
-from `genderParadigm` so the object's denotation (`Pronoun.Entry.denote`,
-`Pronoun.Entry.phiPresup`) can be taken without storing gender twice. -/
-structure PronounEntry extends Pronoun.Entry where
+from `genderParadigm` so the object's denotation (`PersonalPronoun.denote`,
+`PersonalPronoun.phiPresup`) can be taken without storing gender twice. -/
+structure PronounEntry extends PersonalPronoun where
   /-- Pronoun type -/
   pronounType : PronounType
   /-- Gender paradigm class (3rd-person singular agreement).
@@ -91,12 +91,12 @@ structure PronounEntry extends Pronoun.Entry where
   wh : Bool := false
   deriving Repr, BEq
 
-/-- The canonical `Pronoun.Entry` for this English entry: the inherited core
+/-- The canonical `PersonalPronoun` for this English entry: the inherited core
 with `gender` derived from the epicene-aware `genderParadigm` (epicene and
 unspecified contribute no `SurfaceGender`). Routes English pronouns into
-`Pronoun.Entry.denote`/`phiPresup`. -/
-def PronounEntry.entry (p : PronounEntry) : Pronoun.Entry :=
-  { p.toEntry with gender := p.genderParadigm.bind GenderParadigm.toSurfaceGender }
+`PersonalPronoun.denote`/`phiPresup`. -/
+def PronounEntry.entry (p : PronounEntry) : PersonalPronoun :=
+  { p.toPersonalPronoun with gender := p.genderParadigm.bind GenderParadigm.toSurfaceGender }
 
 -- ============================================================================
 -- Personal Pronouns

--- a/Linglib/Fragments/French/Reciprocals.lean
+++ b/Linglib/Fragments/French/Reciprocals.lean
@@ -22,11 +22,11 @@ namespace French.Reciprocals
 open Pronoun
 
 /-- se — reflexive/reciprocal clitic (monovalent strategy). -/
-def se : Entry :=
+def se : PersonalPronoun :=
   { form := "se", person := some .third }
 
 /-- l'un l'autre — bipartite reciprocal NP (bivalent strategy). -/
-def lunLautre : Entry :=
+def lunLautre : PersonalPronoun :=
   { form := "l'un l'autre", person := some .third, number := some .pl }
 
 /-- The bipartite NP form is distinct from the clitic. -/

--- a/Linglib/Fragments/Galician/Pronouns.lean
+++ b/Linglib/Fragments/Galician/Pronouns.lean
@@ -22,11 +22,11 @@ open Features.Register (Level)
 -- ============================================================================
 
 /-- *eu* — 1sg. -/
-def eu : Entry :=
+def eu : PersonalPronoun :=
   { form := "eu", person := some .first, number := some .sg }
 
 /-- *nós* — 1pl. -/
-def nos : Entry :=
+def nos : PersonalPronoun :=
   { form := "nós", person := some .first, number := some .pl }
 
 -- ============================================================================
@@ -34,19 +34,19 @@ def nos : Entry :=
 -- ============================================================================
 
 /-- *ti* — 2sg familiar (T form). -/
-def ti : Entry :=
+def ti : PersonalPronoun :=
   { form := "ti", person := some .second, number := some .sg, register := .informal }
 
 /-- *vostede* — 2sg formal (V form). -/
-def vostede : Entry :=
+def vostede : PersonalPronoun :=
   { form := "vostede", person := some .second, number := some .sg, register := .formal }
 
 /-- *vós* — 2pl familiar. -/
-def vos_pl : Entry :=
+def vos_pl : PersonalPronoun :=
   { form := "vós", person := some .second, number := some .pl, register := .informal }
 
 /-- *vostedes* — 2pl formal. -/
-def vostedes : Entry :=
+def vostedes : PersonalPronoun :=
   { form := "vostedes", person := some .second, number := some .pl, register := .formal }
 
 -- ============================================================================
@@ -54,28 +54,28 @@ def vostedes : Entry :=
 -- ============================================================================
 
 /-- *el* — 3sg masculine. -/
-def el : Entry :=
+def el : PersonalPronoun :=
   { form := "el", person := some .third, number := some .sg }
 
 /-- *ela* — 3sg feminine. -/
-def ela : Entry :=
+def ela : PersonalPronoun :=
   { form := "ela", person := some .third, number := some .sg }
 
 /-- *eles* — 3pl masculine. -/
-def eles : Entry :=
+def eles : PersonalPronoun :=
   { form := "eles", person := some .third, number := some .pl }
 
 /-- *elas* — 3pl feminine. -/
-def elas : Entry :=
+def elas : PersonalPronoun :=
   { form := "elas", person := some .third, number := some .pl }
 
 -- ============================================================================
 -- Pronoun Lists
 -- ============================================================================
 
-def secondPersonPronouns : List Entry := [ti, vostede]
+def secondPersonPronouns : List PersonalPronoun := [ti, vostede]
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [eu, nos] ++ secondPersonPronouns ++ [vos_pl, vostedes, el, ela, eles, elas]
 
 -- ============================================================================

--- a/Linglib/Fragments/German/Pronouns.lean
+++ b/Linglib/Fragments/German/Pronouns.lean
@@ -37,11 +37,11 @@ open Features.Register (Level)
 -- ============================================================================
 
 /-- *ich* — 1sg. -/
-def ich : Entry :=
+def ich : PersonalPronoun :=
   { form := "ich", person := some .first, number := some .sg }
 
 /-- *du* — 2sg familiar (T form). -/
-def du : Entry :=
+def du : PersonalPronoun :=
   { form := "du", person := some .second, number := some .sg, register := .informal }
 
 /-- *Sie* — polite 2nd person (V form, triggers 3pl agreement).
@@ -49,35 +49,35 @@ def du : Entry :=
     the 3pl series. Agreement person is 3rd (plural), interpretable person
     is 2nd. Can refer to singular or plural addressees.
     @cite{adamson-zompi-2025} -/
-def sie_polite : Entry :=
+def sie_polite : PersonalPronoun :=
   { form := "Sie", person := some .third, number := some .pl, register := .formal,
     referentialPerson := some .second }
 
 /-- *er* — 3sg masculine. -/
-def er : Entry :=
+def er : PersonalPronoun :=
   { form := "er", person := some .third, number := some .sg }
 
 /-- *sie* — 3sg feminine. -/
-def sie_f : Entry :=
+def sie_f : PersonalPronoun :=
   { form := "sie", person := some .third, number := some .sg }
 
 /-- *es* — 3sg neuter. -/
-def es : Entry :=
+def es : PersonalPronoun :=
   { form := "es", person := some .third, number := some .sg }
 
 /-- *wir* — 1pl. -/
-def wir : Entry :=
+def wir : PersonalPronoun :=
   { form := "wir", person := some .first, number := some .pl }
 
 /-- *ihr* — 2pl familiar. -/
-def ihr : Entry :=
+def ihr : PersonalPronoun :=
   { form := "ihr", person := some .second, number := some .pl, register := .informal }
 
 /-- *sie* — 3pl. -/
-def sie_pl : Entry :=
+def sie_pl : PersonalPronoun :=
   { form := "sie", person := some .third, number := some .pl }
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [ich, du, sie_polite, er, sie_f, es, wir, ihr, sie_pl]
 
 -- ============================================================================

--- a/Linglib/Fragments/German/Reciprocals.lean
+++ b/Linglib/Fragments/German/Reciprocals.lean
@@ -23,11 +23,11 @@ namespace German.Reciprocals
 open Pronoun
 
 /-- sich — reflexive/reciprocal pronoun (3rd person). -/
-def sich : Entry :=
+def sich : PersonalPronoun :=
   { form := "sich", person := some .third }
 
 /-- einander — dedicated reciprocal pronoun. -/
-def einander : Entry :=
+def einander : PersonalPronoun :=
   { form := "einander", person := some .third, number := some .pl }
 
 /-- The dedicated reciprocal form is distinct from the reflexive. -/

--- a/Linglib/Fragments/Hindi/Pronouns.lean
+++ b/Linglib/Fragments/Hindi/Pronouns.lean
@@ -20,11 +20,11 @@ open Pronoun
 -- ============================================================================
 
 /-- *maiṃ* — 1sg. -/
-def maiN : Entry :=
+def maiN : PersonalPronoun :=
   { form := "maiṃ", person := some .first, number := some .sg }
 
 /-- *ham* — 1pl. -/
-def ham : Entry :=
+def ham : PersonalPronoun :=
   { form := "ham", person := some .first, number := some .pl }
 
 -- ============================================================================
@@ -32,15 +32,15 @@ def ham : Entry :=
 -- ============================================================================
 
 /-- *tuu* — 2sg non-honorific (intimate/inferior). -/
-def tuu : Entry :=
+def tuu : PersonalPronoun :=
   { form := "tuu", person := some .second, number := some .sg, register := .informal }
 
 /-- *tum* — 2sg honorific (neutral). -/
-def tum : Entry :=
+def tum : PersonalPronoun :=
   { form := "tum", person := some .second, number := some .sg, register := .neutral }
 
 /-- *aap* — 2sg high-honorific (respectful). -/
-def aap : Entry :=
+def aap : PersonalPronoun :=
   { form := "aap", person := some .second, number := some .sg, register := .formal }
 
 -- ============================================================================
@@ -48,20 +48,20 @@ def aap : Entry :=
 -- ============================================================================
 
 /-- *vah* — 3sg (distal demonstrative, standard pronoun). -/
-def vah : Entry :=
+def vah : PersonalPronoun :=
   { form := "vah", person := some .third, number := some .sg }
 
 /-- *ve* — 3pl (distal demonstrative plural). -/
-def ve : Entry :=
+def ve : PersonalPronoun :=
   { form := "ve", person := some .third, number := some .pl }
 
 -- ============================================================================
 -- Pronoun Lists
 -- ============================================================================
 
-def secondPersonPronouns : List Entry := [tuu, tum, aap]
+def secondPersonPronouns : List PersonalPronoun := [tuu, tum, aap]
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [maiN, ham] ++ secondPersonPronouns ++ [vah, ve]
 
 -- ============================================================================

--- a/Linglib/Fragments/Hungarian/Reciprocals.lean
+++ b/Linglib/Fragments/Hungarian/Reciprocals.lean
@@ -47,17 +47,17 @@ open Semantics.Reference.PluralityLicensing
 /-- *egymás* — reciprocal pronoun 'each other'.
     Morphologically invariable: no φ-feature inflection.
     @cite{rakosi-2019} fn. 1. -/
-def egymas : Entry :=
+def egymas : PersonalPronoun :=
   { form := "egymás", person := some .third, number := none }
 
 /-- *maga* — reflexive pronoun (3SG form, for contrast).
     Unlike *egymás*, the reflexive inflects for number:
     *magá-t* (SG.ACC) vs. *maguk-at* (PL.ACC). -/
-def maga : Entry :=
+def maga : PersonalPronoun :=
   { form := "maga", person := some .third, number := some .sg }
 
 /-- *maguk* — reflexive pronoun (3PL form). -/
-def maguk : Entry :=
+def maguk : PersonalPronoun :=
   { form := "maguk", person := some .third, number := some .pl }
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Fragments/Icelandic/Reciprocals.lean
+++ b/Linglib/Fragments/Icelandic/Reciprocals.lean
@@ -22,11 +22,11 @@ open Pronoun
 /-- hvor...annad — bipartite reciprocal NP 'each other'.
 
     Each part inflects independently for case.  -/
-def hvorAnnad : Entry :=
+def hvorAnnad : PersonalPronoun :=
   { form := "hvor...annad", person := some .third, number := some .pl }
 
 /-- sig — reflexive pronoun (for contrast). -/
-def sig : Entry :=
+def sig : PersonalPronoun :=
   { form := "sig", person := some .third }
 
 /-- Icelandic reciprocal is formally distinct from reflexive. -/

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -38,11 +38,11 @@ open Features.Register (Level)
 -- ============================================================================
 
 /-- *io* — 1sg. -/
-def io : Entry :=
+def io : PersonalPronoun :=
   { form := "io", person := some .first, number := some .sg }
 
 /-- *tu* — 2sg familiar (T form). -/
-def tu : Entry :=
+def tu : PersonalPronoun :=
   { form := "tu", person := some .second, number := some .sg, register := .informal }
 
 /-- *Lei* — polite 2sg (V form). Formally 3rd person: triggers 3sg verbal
@@ -50,37 +50,37 @@ def tu : Entry :=
     Interpretably 2nd person: triggers PCC effects, Fancy Constraint effects,
     2PL resolved agreement in coordination.
     @cite{adamson-zompi-2025} -/
-def lei_formal : Entry :=
+def lei_formal : PersonalPronoun :=
   { form := "Lei", person := some .third, number := some .sg, register := .formal,
     referentialPerson := some .second }
 
 /-- *lui* — 3sg masculine. -/
-def lui : Entry :=
+def lui : PersonalPronoun :=
   { form := "lui", person := some .third, number := some .sg }
 
 /-- *lei* — 3sg feminine. -/
-def lei : Entry :=
+def lei : PersonalPronoun :=
   { form := "lei", person := some .third, number := some .sg }
 
 /-- *noi* — 1pl. -/
-def noi : Entry :=
+def noi : PersonalPronoun :=
   { form := "noi", person := some .first, number := some .pl }
 
 /-- *voi* — 2pl (familiar; also used as general 2pl in modern Italian). -/
-def voi : Entry :=
+def voi : PersonalPronoun :=
   { form := "voi", person := some .second, number := some .pl, register := .informal }
 
 /-- *Loro* — 2pl formal (archaic, largely replaced by *voi*). -/
-def loro_formal : Entry :=
+def loro_formal : PersonalPronoun :=
   { form := "Loro", person := some .second, number := some .pl, register := .formal }
 
 /-- *loro* — 3pl. -/
-def loro : Entry :=
+def loro : PersonalPronoun :=
   { form := "loro", person := some .third, number := some .pl }
 
-def secondPersonPronouns : List Entry := [tu, lei_formal]
+def secondPersonPronouns : List PersonalPronoun := [tu, lei_formal]
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [io] ++ secondPersonPronouns ++ [lui, lei, noi, voi, loro_formal, loro]
 
 -- ============================================================================

--- a/Linglib/Fragments/Japanese/Pronouns.lean
+++ b/Linglib/Fragments/Japanese/Pronouns.lean
@@ -23,21 +23,21 @@ open Features.Register (Level)
 -- ============================================================================
 
 /-- 私 *watashi* — 1sg neutral/polite. -/
-def watashi : Entry :=
+def watashi : PersonalPronoun :=
   { form := "watashi", script := some "私", person := some .first, number := some .sg, register := .formal }
 
 /-- 僕 *boku* — 1sg informal, masculine-associated via register
     (no inherent gender feature; cf. @cite{ochs-1992}). -/
-def boku : Entry :=
+def boku : PersonalPronoun :=
   { form := "boku", script := some "僕", person := some .first, number := some .sg, register := .informal }
 
 /-- 俺 *ore* — 1sg male very informal. Strongly indexes masculine identity
     through assertive/coarse interactional stance (@cite{ochs-1992}). -/
-def ore : Entry :=
+def ore : PersonalPronoun :=
   { form := "ore", script := some "俺", person := some .first, number := some .sg, register := .informal }
 
 /-- 私たち *watashitachi* — 1pl. -/
-def watashitachi : Entry :=
+def watashitachi : PersonalPronoun :=
   { form := "watashitachi", script := some "私たち", person := some .first, number := some .pl }
 
 -- ============================================================================
@@ -45,11 +45,11 @@ def watashitachi : Entry :=
 -- ============================================================================
 
 /-- 君 *kimi* — 2sg plain. -/
-def kimi : Entry :=
+def kimi : PersonalPronoun :=
   { form := "kimi", script := some "君", person := some .second, number := some .sg, register := .informal }
 
 /-- あなた *anata* — 2sg polite. -/
-def anata : Entry :=
+def anata : PersonalPronoun :=
   { form := "anata", script := some "あなた", person := some .second, number := some .sg, register := .formal }
 
 -- ============================================================================
@@ -57,15 +57,15 @@ def anata : Entry :=
 -- ============================================================================
 
 /-- 彼 *kare* — 3sg masculine. -/
-def kare : Entry :=
+def kare : PersonalPronoun :=
   { form := "kare", script := some "彼", person := some .third, number := some .sg }
 
 /-- 彼女 *kanojo* — 3sg feminine. -/
-def kanojo : Entry :=
+def kanojo : PersonalPronoun :=
   { form := "kanojo", script := some "彼女", person := some .third, number := some .sg }
 
 /-- 彼ら *karera* — 3pl. -/
-def karera : Entry :=
+def karera : PersonalPronoun :=
   { form := "karera", script := some "彼ら", person := some .third, number := some .pl }
 
 -- ============================================================================
@@ -76,16 +76,16 @@ def karera : Entry :=
     Formally distinct from the reflexive *jibun* (自分). This is an
     NP/argument reciprocal strategy (reciprocal pronoun), unlike
     languages that mark reciprocity on the verb. -/
-def otagai : Entry :=
+def otagai : PersonalPronoun :=
   { form := "otagai", script := some "互い", person := some .third, number := some .pl }
 
 -- ============================================================================
 -- Pronoun Lists
 -- ============================================================================
 
-def secondPersonPronouns : List Entry := [kimi, anata]
+def secondPersonPronouns : List PersonalPronoun := [kimi, anata]
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [watashi, boku, ore, watashitachi] ++ secondPersonPronouns ++ [kare, kanojo, karera, otagai]
 
 -- ============================================================================

--- a/Linglib/Fragments/Korean/Pronouns.lean
+++ b/Linglib/Fragments/Korean/Pronouns.lean
@@ -52,15 +52,15 @@ open Features.Register (Level)
 -- ============================================================================
 
 /-- 나 *na* — 1sg plain. -/
-def na : Entry :=
+def na : PersonalPronoun :=
   { form := "na", script := some "나", person := some .first, number := some .sg, register := .informal }
 
 /-- 저 *jeo* — 1sg humble. -/
-def jeo : Entry :=
+def jeo : PersonalPronoun :=
   { form := "jeo", script := some "저", person := some .first, number := some .sg, register := .formal }
 
 /-- 우리 *uri* — 1pl. -/
-def uri : Entry :=
+def uri : PersonalPronoun :=
   { form := "uri", script := some "우리", person := some .first, number := some .pl }
 
 -- ============================================================================
@@ -68,11 +68,11 @@ def uri : Entry :=
 -- ============================================================================
 
 /-- 너 *neo* — 2sg plain. -/
-def neo : Entry :=
+def neo : PersonalPronoun :=
   { form := "neo", script := some "너", person := some .second, number := some .sg, register := .informal }
 
 /-- 당신 *dangsin* — 2sg polite. -/
-def dangsin : Entry :=
+def dangsin : PersonalPronoun :=
   { form := "dangsin", script := some "당신", person := some .second, number := some .sg, register := .formal }
 
 -- ============================================================================
@@ -81,14 +81,14 @@ def dangsin : Entry :=
 
 /-- 그 *geu* (Yale: *ku*) — 3sg masculine, **literary** register.
     76,235 written vs 145 oral tokens (@cite{kwon-lee-2026} fn. 2). -/
-def geu : Entry :=
+def geu : PersonalPronoun :=
   { form := "geu", script := some "그", person := some .third, number := some .sg
   , gender := some .masculine, register := .formal }
 
 /-- 그녀 *geunyeo* (Yale: *kunye*) — 3sg feminine, **literary** register.
     Compound of *ku* ('that') + *nye* ('female'). 25,085 written vs
     9 oral tokens (@cite{kwon-lee-2026} fn. 2). -/
-def geunyeo : Entry :=
+def geunyeo : PersonalPronoun :=
   { form := "geunyeo", script := some "그녀", person := some .third, number := some .sg
   , gender := some .feminine, register := .formal }
 
@@ -98,13 +98,13 @@ def geunyeo : Entry :=
     *geu*/*geunyeo*. Implies familiarity between speaker and referent
     (@cite{kwon-lee-2026} §5). The overt-pronoun referential form
     tested in @cite{kwon-lee-2026}'s experiments. -/
-def gyae : Entry :=
+def gyae : PersonalPronoun :=
   { form := "gyae", script := some "걔", person := some .third, number := some .sg
   , register := .informal }
 
 /-- 그들 *geudeul* — 3pl. Plural of *geu*; literary in register
     (the colloquial plural is the proximal demonstrative + *ai-tul*). -/
-def geudeul : Entry :=
+def geudeul : PersonalPronoun :=
   { form := "geudeul", script := some "그들", person := some .third, number := some .pl
   , register := .formal }
 
@@ -112,14 +112,14 @@ def geudeul : Entry :=
 -- Pronoun Lists
 -- ============================================================================
 
-def secondPersonPronouns : List Entry := [neo, dangsin]
+def secondPersonPronouns : List PersonalPronoun := [neo, dangsin]
 
 /-- 3rd-person pronouns: literary *geu*/*geunyeo*/*geudeul* and
     colloquial *gyae*. Yale-romanization variants (*ku*/*kunye*/*kutul*/
     *kyay*) refer to the same lexical items. -/
-def thirdPersonPronouns : List Entry := [geu, geunyeo, geudeul, gyae]
+def thirdPersonPronouns : List PersonalPronoun := [geu, geunyeo, geudeul, gyae]
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [na, jeo, uri] ++ secondPersonPronouns ++ thirdPersonPronouns
 
 -- ============================================================================

--- a/Linglib/Fragments/Magahi/Pronouns.lean
+++ b/Linglib/Fragments/Magahi/Pronouns.lean
@@ -19,11 +19,11 @@ open Pronoun
 -- ============================================================================
 
 /-- *hum* — 1sg. -/
-def hum : Entry :=
+def hum : PersonalPronoun :=
   { form := "hum", person := some .first, number := some .sg }
 
 /-- *hum sab* — 1pl. -/
-def humSab : Entry :=
+def humSab : PersonalPronoun :=
   { form := "hum sab", person := some .first, number := some .pl }
 
 -- ============================================================================
@@ -31,15 +31,15 @@ def humSab : Entry :=
 -- ============================================================================
 
 /-- *tõ* — 2sg non-honorific. -/
-def toN : Entry :=
+def toN : PersonalPronoun :=
   { form := "tõ", person := some .second, number := some .sg, register := .informal }
 
 /-- *tũ* — 2sg honorific. -/
-def tuN : Entry :=
+def tuN : PersonalPronoun :=
   { form := "tũ", person := some .second, number := some .sg, register := .neutral }
 
 /-- *apne* — 2sg high-honorific. -/
-def apne : Entry :=
+def apne : PersonalPronoun :=
   { form := "apne", person := some .second, number := some .sg, register := .formal }
 
 -- ============================================================================
@@ -47,24 +47,24 @@ def apne : Entry :=
 -- ============================================================================
 
 /-- *i* — 3sg proximal. -/
-def i_prox : Entry :=
+def i_prox : PersonalPronoun :=
   { form := "i", person := some .third, number := some .sg }
 
 /-- *ũ* — 3sg distal. -/
-def uN : Entry :=
+def uN : PersonalPronoun :=
   { form := "ũ", person := some .third, number := some .sg }
 
 /-- *ũ sab* — 3pl distal. -/
-def uNSab : Entry :=
+def uNSab : PersonalPronoun :=
   { form := "ũ sab", person := some .third, number := some .pl }
 
 -- ============================================================================
 -- Pronoun Lists
 -- ============================================================================
 
-def secondPersonPronouns : List Entry := [toN, tuN, apne]
+def secondPersonPronouns : List PersonalPronoun := [toN, tuN, apne]
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [hum, humSab] ++ secondPersonPronouns ++ [i_prox, uN, uNSab]
 
 -- ============================================================================

--- a/Linglib/Fragments/Maithili/Pronouns.lean
+++ b/Linglib/Fragments/Maithili/Pronouns.lean
@@ -20,11 +20,11 @@ open Pronoun
 -- ============================================================================
 
 /-- *hum* — 1sg. -/
-def hum : Entry :=
+def hum : PersonalPronoun :=
   { form := "hum", person := some .first, number := some .sg }
 
 /-- *hum sab* — 1pl. -/
-def humSab : Entry :=
+def humSab : PersonalPronoun :=
   { form := "hum sab", person := some .first, number := some .pl }
 
 -- ============================================================================
@@ -32,15 +32,15 @@ def humSab : Entry :=
 -- ============================================================================
 
 /-- *tõ* — 2sg non-honorific. -/
-def toN : Entry :=
+def toN : PersonalPronoun :=
   { form := "tõ", person := some .second, number := some .sg, register := .informal }
 
 /-- *ahã* — 2sg honorific. -/
-def ahaN : Entry :=
+def ahaN : PersonalPronoun :=
   { form := "ahã", person := some .second, number := some .sg, register := .neutral }
 
 /-- *apne* — 2sg high-honorific. -/
-def apne : Entry :=
+def apne : PersonalPronoun :=
   { form := "apne", person := some .second, number := some .sg, register := .formal }
 
 -- ============================================================================
@@ -48,24 +48,24 @@ def apne : Entry :=
 -- ============================================================================
 
 /-- *ũ* — 3sg non-honorific (distal). -/
-def uN : Entry :=
+def uN : PersonalPronoun :=
   { form := "ũ", person := some .third, number := some .sg, register := .informal }
 
 /-- *o* — 3sg honorific. -/
-def o : Entry :=
+def o : PersonalPronoun :=
   { form := "o", person := some .third, number := some .sg, register := .neutral }
 
 /-- *ũ sab* — 3pl. -/
-def uNSab : Entry :=
+def uNSab : PersonalPronoun :=
   { form := "ũ sab", person := some .third, number := some .pl }
 
 -- ============================================================================
 -- Pronoun Lists
 -- ============================================================================
 
-def secondPersonPronouns : List Entry := [toN, ahaN, apne]
+def secondPersonPronouns : List PersonalPronoun := [toN, ahaN, apne]
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [hum, humSab] ++ secondPersonPronouns ++ [uN, o, uNSab]
 
 -- ============================================================================

--- a/Linglib/Fragments/Punjabi/Pronouns.lean
+++ b/Linglib/Fragments/Punjabi/Pronouns.lean
@@ -19,11 +19,11 @@ open Pronoun
 -- ============================================================================
 
 /-- *maiṃ* — 1sg. -/
-def maiN : Entry :=
+def maiN : PersonalPronoun :=
   { form := "maiṃ", person := some .first, number := some .sg }
 
 /-- *asiiṃ* — 1pl. -/
-def asiiN : Entry :=
+def asiiN : PersonalPronoun :=
   { form := "asiiṃ", person := some .first, number := some .pl }
 
 -- ============================================================================
@@ -31,11 +31,11 @@ def asiiN : Entry :=
 -- ============================================================================
 
 /-- *tũ* — 2sg non-honorific. -/
-def tuN : Entry :=
+def tuN : PersonalPronoun :=
   { form := "tũ", person := some .second, number := some .sg, register := .informal }
 
 /-- *tusii* — 2sg honorific (also 2pl). -/
-def tusii : Entry :=
+def tusii : PersonalPronoun :=
   { form := "tusii", person := some .second, number := some .sg, register := .formal }
 
 -- ============================================================================
@@ -43,20 +43,20 @@ def tusii : Entry :=
 -- ============================================================================
 
 /-- *uh* — 3sg (distal demonstrative). -/
-def uh_sg : Entry :=
+def uh_sg : PersonalPronoun :=
   { form := "uh", person := some .third, number := some .sg }
 
 /-- *uh* — 3pl (same form as 3sg in standard Punjabi). -/
-def uh_pl : Entry :=
+def uh_pl : PersonalPronoun :=
   { form := "uh", person := some .third, number := some .pl }
 
 -- ============================================================================
 -- Pronoun Lists
 -- ============================================================================
 
-def secondPersonPronouns : List Entry := [tuN, tusii]
+def secondPersonPronouns : List PersonalPronoun := [tuN, tusii]
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [maiN, asiiN] ++ secondPersonPronouns ++ [uh_sg, uh_pl]
 
 -- ============================================================================

--- a/Linglib/Fragments/Slavic/Czech/PolarityItems.lean
+++ b/Linglib/Fragments/Slavic/Czech/PolarityItems.lean
@@ -34,6 +34,7 @@ def nikdo : PolarityItemEntry :=
   , licensingContexts := [.negation, .nobody, .withoutClause]
   , scalarDirection := .strengthening
   , morphology := .indefPlusNeg
+  , nWordStatus := some .nWord
   , notes := "Strict-NC n-word; *Nikdo nepřišel* / *Neviděl nikoho*" }
 
 /-- *nic* — N-word for non-human ('nothing'). -/
@@ -44,6 +45,7 @@ def nic : PolarityItemEntry :=
   , licensingContexts := [.negation, .nobody, .withoutClause]
   , scalarDirection := .strengthening
   , morphology := .indefPlusNeg
+  , nWordStatus := some .nWord
   , notes := "Non-human n-word; *Nic neviděl*" }
 
 /-- *nikdy* — Temporal n-word ('never'). -/
@@ -54,6 +56,7 @@ def nikdy : PolarityItemEntry :=
   , licensingContexts := [.negation, .nobody, .withoutClause]
   , scalarDirection := .strengthening
   , morphology := .indefPlusNeg
+  , nWordStatus := some .nWord
   , notes := "Temporal n-word; *Nikdy nepřišel*" }
 
 /-- *nikam* — Locative n-word ('nowhere'). -/
@@ -64,6 +67,7 @@ def nikam : PolarityItemEntry :=
   , licensingContexts := [.negation, .nobody, .withoutClause]
   , scalarDirection := .strengthening
   , morphology := .indefPlusNeg
+  , nWordStatus := some .nWord
   , notes := "Locative directional n-word; *Nikam nejde* 'goes nowhere'" }
 
 /-- *žádný* — Determiner n-word ('no/none'). -/
@@ -73,6 +77,7 @@ def zadny : PolarityItemEntry :=
   , baseForce := .existential
   , licensingContexts := [.negation, .nobody, .withoutClause]
   , scalarDirection := .strengthening
+  , nWordStatus := some .nWord
   , notes :=
       "Determiner/pronoun n-word ('no/none'); morphologically distinct " ++
       "from the *ni-* series but functionally parallel" }

--- a/Linglib/Fragments/Slavic/Czech/Reciprocals.lean
+++ b/Linglib/Fragments/Slavic/Czech/Reciprocals.lean
@@ -19,7 +19,7 @@ namespace Czech.Reciprocals
 open Pronoun
 
 /-- se — reflexive/reciprocal clitic. -/
-def se : Entry :=
+def se : PersonalPronoun :=
   { form := "se", person := some .third }
 
 /-- The same form serves both reciprocal and reflexive functions. -/

--- a/Linglib/Fragments/Slavic/Russian/PolarityItems.lean
+++ b/Linglib/Fragments/Slavic/Russian/PolarityItems.lean
@@ -2,70 +2,88 @@ import Linglib.Typology.PolarityItem
 
 /-!
 # Russian Polarity-Sensitive Items
-@cite{haspelmath-1997}
+@cite{haspelmath-1997} @cite{zeijlstra-2004} @cite{giannakidou-1998}
 
-Russian indefinite pronoun polarity items, typed by the categories from
-`Typology.PolarityItem`.
+Russian indefinite-pronoun polarity items, typed by the theory-neutral
+categories from `Typology.PolarityItem`. The classification follows
+@cite{haspelmath-1997}'s implicational map for the Russian series: the
+*-либо* series spans the weak-NPI functions (irrealis non-specific,
+question, conditional, comparative, indirect negation), while the *ни-*
+series occupies the *direct negation* function as strict negative-concord
+items, obligatorily co-occurring with clausemate verbal negation *не*.
 
-- **кто-либо** (kto-libo): Weak NPI (questions, conditionals, indirect negation)
-- **никто** (nikto): N-word, negative concord
-- **кто угодно** (kto ugodno): Free choice item
+- **кто-либо** (kto-libo): weak NPI — questions, conditionals,
+  comparatives, indirect negation.
+- **никто / ничего / никогда** (nikto / nichego / nikogda): strict-NC
+  *ни-* words, obligatory clausemate *не* (@cite{zeijlstra-2004},
+  @cite{giannakidou-1998}).
+- **кто угодно** (kto ugodno): free-choice item.
+
+The substrate has no dedicated n-word/negative-concord `PolarityType` case
+(negative concord is a planned extension), so the strict-NC *ни-* series is
+approximated as `.npiStrong` (anti-additive licensing) — the same choice the
+Czech sibling fragment makes for its cognate *ni-* series.
 -/
 
 namespace Russian.PolarityItems
 
 open Typology.PolarityItem
 
--- ============================================================================
--- NPIs
--- ============================================================================
+/-! ### Weak NPI (the *-либо* series) -/
 
-/-- *кто-либо* (kto-libo) — Weak NPI.
-    Polarity-sensitive indefinite licensed in questions, conditionals,
-    and indirect negation scope. -/
+/-- *кто-либо* (kto-libo) — weak NPI. The *-либо* series is licensed across
+    the DE functions of @cite{haspelmath-1997}'s map: questions, conditionals,
+    comparatives, and indirect (non-clausemate) negation — distinct from the
+    direct-negation *ни-* series below. -/
 def ktoLibo : PolarityItemEntry :=
   { form := "кто-либо (kto-libo)"
   , polarityType := .npiWeak
   , baseForce := .existential
-  , licensingContexts := [.question, .conditionalAntecedent, .negation]
+  , licensingContexts := [.question, .conditionalAntecedent, .negation, .comparativeS]
   , scalarDirection := .strengthening
-  , notes := "Polarity-sensitive indefinite" }
+  , notes := "Polarity-sensitive indefinite; spans the weak-NPI functions" }
 
-/-- *никто* (nikto) — N-word, negative concord.
-    Requires clause-level negation: 'nikto ne prišël' (nobody NEG came). -/
+/-! ### Strict-NC *ни-* words (the direct-negation series) -/
+
+/-- *никто* (nikto) — strict-NC n-word ('nobody'). Direct-negation series;
+    requires clausemate negation: 'nikto ne prišël' (nobody NEG came). -/
 def nikto : PolarityItemEntry :=
   { form := "никто (nikto)"
-  , polarityType := .npiWeak
+  , polarityType := .npiStrong
   , baseForce := .existential
   , licensingContexts := [.negation, .nobody, .withoutClause]
   , scalarDirection := .strengthening
-  , notes := "N-word; negative concord: 'nikto ne prišël'" }
+  , morphology := .indefPlusNeg
+  , nWordStatus := some .nWord
+  , notes := "Strict-NC n-word; negative concord: 'nikto ne prišël'" }
 
-/-- *ничего* (nichego) — Non-human N-word; obligatory negative concord.
-    'Ničego ne videl' (NEG saw nothing) = "(I) saw nothing". -/
+/-- *ничего* (nichego) — non-human strict-NC n-word ('nothing').
+    'Ničego ne videl' = '(I) saw nothing'. -/
 def nichego : PolarityItemEntry :=
   { form := "ничего (nichego)"
-  , polarityType := .npiWeak
+  , polarityType := .npiStrong
   , baseForce := .existential
   , licensingContexts := [.negation, .nobody, .withoutClause]
   , scalarDirection := .strengthening
-  , notes := "Non-human N-word; genitive form ничего; co-occurs with не" }
+  , morphology := .indefPlusNeg
+  , nWordStatus := some .nWord
+  , notes := "Non-human n-word; genitive form ничего; co-occurs with не" }
 
-/-- *никогда* (nikogda) — Temporal N-word; obligatory negative concord.
-    'Nikogda ne prixodil' (never NEG came) = "(He) never came". -/
+/-- *никогда* (nikogda) — temporal strict-NC n-word ('never').
+    'Nikogda ne prixodil' = '(He) never came'. -/
 def nikogda : PolarityItemEntry :=
   { form := "никогда (nikogda)"
-  , polarityType := .npiWeak
+  , polarityType := .npiStrong
   , baseForce := .temporal
   , licensingContexts := [.negation, .nobody, .withoutClause]
   , scalarDirection := .strengthening
-  , notes := "Temporal N-word; co-occurs with не" }
+  , morphology := .indefPlusNeg
+  , nWordStatus := some .nWord
+  , notes := "Temporal n-word; co-occurs with не" }
 
--- ============================================================================
--- FCI
--- ============================================================================
+/-! ### Free choice item -/
 
-/-- *кто угодно* (kto ugodno) — Free choice item.
+/-- *кто угодно* (kto ugodno) — free choice item.
     Universal-like: 'anyone at all'. -/
 def ktoUgodno : PolarityItemEntry :=
   { form := "кто угодно (kto ugodno)"
@@ -74,24 +92,32 @@ def ktoUgodno : PolarityItemEntry :=
   , licensingContexts := [.modalPossibility, .modalNecessity, .imperative, .generic]
   , notes := "Free choice: 'kto ugodno možet èto sdelat'' (anyone can do that)" }
 
--- ============================================================================
--- Joint
--- ============================================================================
+/-! ### Inventory -/
 
 /-- The Russian polarity-item inventory: the Fragment-side joint listing
     every polarity item this fragment defines. -/
 def items : List PolarityItemEntry :=
   [ktoLibo, nikto, nichego, nikogda, ktoUgodno]
 
--- ============================================================================
--- Verification
--- ============================================================================
+/-! ### Verification -/
 
+/-- The strict-NC *ни-* word `nikto` and the free-choice `kto ugodno` have
+    distinct polarity types. -/
 theorem nikto_ktoUgodno_distinct :
     nikto.polarityType ≠ ktoUgodno.polarityType := by decide
 
-theorem russian_npis_strengthening :
-    [ktoLibo, nikto, nichego, nikogda].all
-      (λ e => e.scalarDirection == .strengthening) = true := by native_decide
+/-- Every NPI in the inventory is scalar-strengthening. The free-choice
+    `kto ugodno` is correctly excluded by the substrate `isNPI` guard rather
+    than dropped from a hand-listed sublist. -/
+theorem npis_strengthening :
+    ∀ e ∈ items, e.isNPI → e.scalarDirection = .strengthening := by
+  decide
+
+/-- The strict-NC *ни-* series is classified as n-words via `nWordStatus`, no longer
+    leaning on the strong-NPI `polarityType` slot: every `.npiStrong` entry in the
+    inventory carries `some .nWord`. -/
+theorem niSeries_are_nwords :
+    ∀ e ∈ items, e.polarityType = .npiStrong → e.nWordStatus = some .nWord := by
+  decide
 
 end Russian.PolarityItems

--- a/Linglib/Fragments/Slavic/Russian/Reciprocals.lean
+++ b/Linglib/Fragments/Slavic/Russian/Reciprocals.lean
@@ -18,12 +18,12 @@ namespace Russian.Reciprocals
 open Pronoun
 
 /-- друг друга *drug druga* — reciprocal pronoun 'each other'. -/
-def drugDruga : Entry :=
+def drugDruga : PersonalPronoun :=
   { form := "drug druga", script := some "друг друга"
   , person := some .third, number := some .pl }
 
 /-- себя *sebja* — reflexive pronoun (for contrast). -/
-def sebja : Entry :=
+def sebja : PersonalPronoun :=
   { form := "sebja", script := some "себя"
   , person := some .third }
 

--- a/Linglib/Fragments/Spanish/Pronouns.lean
+++ b/Linglib/Fragments/Spanish/Pronouns.lean
@@ -37,11 +37,11 @@ open Features.Register (Level)
 -- ============================================================================
 
 /-- *yo* — 1sg. -/
-def yo : Entry :=
+def yo : PersonalPronoun :=
   { form := "yo", person := some .first, number := some .sg }
 
 /-- *tú* — 2sg familiar (T form). -/
-def tu : Entry :=
+def tu : PersonalPronoun :=
   { form := "tú", person := some .second, number := some .sg, register := .informal }
 
 /-- *usted* — polite 2sg (V form, triggers 3sg agreement).
@@ -49,36 +49,36 @@ def tu : Entry :=
     effects: *la* as USTED.ACC is banned in 3>USTED configurations
     (@cite{rezac-2011}, @cite{adamson-zompi-2025} §6.1).
     @cite{adamson-zompi-2025} -/
-def usted : Entry :=
+def usted : PersonalPronoun :=
   { form := "usted", person := some .third, number := some .sg, register := .formal,
     referentialPerson := some .second }
 
 /-- *él* — 3sg masculine. -/
-def el : Entry :=
+def el : PersonalPronoun :=
   { form := "él", person := some .third, number := some .sg }
 
 /-- *ella* — 3sg feminine. -/
-def ella : Entry :=
+def ella : PersonalPronoun :=
   { form := "ella", person := some .third, number := some .sg }
 
 /-- *nosotros* — 1pl. -/
-def nosotros : Entry :=
+def nosotros : PersonalPronoun :=
   { form := "nosotros", person := some .first, number := some .pl }
 
 /-- *vosotros* — 2pl familiar (Peninsular). -/
-def vosotros : Entry :=
+def vosotros : PersonalPronoun :=
   { form := "vosotros", person := some .second, number := some .pl, register := .informal }
 
 /-- *ustedes* — 2pl formal / general (triggers 3pl agreement). -/
-def ustedes : Entry :=
+def ustedes : PersonalPronoun :=
   { form := "ustedes", person := some .third, number := some .pl, register := .formal,
     referentialPerson := some .second }
 
 /-- *ellos* — 3pl masculine. -/
-def ellos : Entry :=
+def ellos : PersonalPronoun :=
   { form := "ellos", person := some .third, number := some .pl }
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [yo, tu, usted, el, ella, nosotros, vosotros, ustedes, ellos]
 
 -- ============================================================================

--- a/Linglib/Fragments/Tamil/Pronouns.lean
+++ b/Linglib/Fragments/Tamil/Pronouns.lean
@@ -22,15 +22,15 @@ open Pronoun
 -- ============================================================================
 
 /-- *naan* — 1sg. -/
-def naan : Entry :=
+def naan : PersonalPronoun :=
   { form := "naan", person := some .first, number := some .sg }
 
 /-- *naam* — 1pl inclusive (speaker + addressee). -/
-def naam : Entry :=
+def naam : PersonalPronoun :=
   { form := "naam", person := some .first, number := some .pl }
 
 /-- *naangaL* — 1pl exclusive (speaker + others, not addressee). -/
-def naangaL : Entry :=
+def naangaL : PersonalPronoun :=
   { form := "naangaL", person := some .first, number := some .pl }
 
 -- ============================================================================
@@ -38,11 +38,11 @@ def naangaL : Entry :=
 -- ============================================================================
 
 /-- *nii* — 2sg non-honorific. -/
-def nii : Entry :=
+def nii : PersonalPronoun :=
   { form := "nii", person := some .second, number := some .sg, register := .informal }
 
 /-- *niingaL* — 2sg honorific (also 2pl). -/
-def niingaL : Entry :=
+def niingaL : PersonalPronoun :=
   { form := "niingaL", person := some .second, number := some .sg, register := .formal }
 
 -- ============================================================================
@@ -50,28 +50,28 @@ def niingaL : Entry :=
 -- ============================================================================
 
 /-- *avan* — 3sg masculine. -/
-def avan : Entry :=
+def avan : PersonalPronoun :=
   { form := "avan", person := some .third, number := some .sg }
 
 /-- *avaL* — 3sg feminine. -/
-def avaL : Entry :=
+def avaL : PersonalPronoun :=
   { form := "avaL", person := some .third, number := some .sg }
 
 /-- *avar* — 3sg honorific. -/
-def avar : Entry :=
+def avar : PersonalPronoun :=
   { form := "avar", person := some .third, number := some .sg, register := .formal }
 
 /-- *avarkaL* — 3pl (human). -/
-def avarkaL : Entry :=
+def avarkaL : PersonalPronoun :=
   { form := "avarkaL", person := some .third, number := some .pl }
 
 -- ============================================================================
 -- Pronoun Lists
 -- ============================================================================
 
-def secondPersonPronouns : List Entry := [nii, niingaL]
+def secondPersonPronouns : List PersonalPronoun := [nii, niingaL]
 
-def allPronouns : List Entry :=
+def allPronouns : List PersonalPronoun :=
   [naan, naam, naangaL] ++ secondPersonPronouns ++ [avan, avaL, avar, avarkaL]
 
 -- ============================================================================

--- a/Linglib/Fragments/Wan/Reciprocals.lean
+++ b/Linglib/Fragments/Wan/Reciprocals.lean
@@ -50,17 +50,17 @@ open Features.Logophoricity
     Note: *ē* in the same example is the reflexive marker (REFL), not the
     logophoric pronoun. The reciprocal reading arises from the combination
     of REFL *ē* + RECIP *ɔ̄ŋ*. -/
-def logPl : Entry :=
+def logPl : PersonalPronoun :=
   { form := "mɔ̄", person := some .third, number := some .pl }
 
 /-- Wan reflexive marker *ē* (REFL). Combines with reciprocal marker
     *ɔ̄ŋ* to form the reciprocal construction. -/
-def refl : Entry :=
+def refl : PersonalPronoun :=
   { form := "ē", person := some .third }
 
 /-- Wan reciprocal marker *ɔ̄ŋ* (RECIP). Appears after reflexive *ē*
     to yield the reciprocal reading. -/
-def recip : Entry :=
+def recip : PersonalPronoun :=
   { form := "ɔ̄ŋ", person := some .third, number := some .pl }
 
 /-- Wan 3pl ordinary (non-logophoric) pronoun *à* (low tone).
@@ -72,7 +72,7 @@ def recip : Entry :=
     Note: *tú* in the same example is an adverb 'completely', not a
     pronoun. The 3PL pronoun is *à* (grave accent), tonally distinct
     from copula *á* (acute accent) in (28). -/
-def ordinaryPl : Entry :=
+def ordinaryPl : PersonalPronoun :=
   { form := "à", person := some .third, number := some .pl }
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Phenomena/Questions/Basic.lean
+++ b/Linglib/Phenomena/Questions/Basic.lean
@@ -1,35 +1,27 @@
 import Linglib.Core.Word
+import Linglib.Features.OntologicalCategory
 
 /-!
 # Questions: Basic Types and Shared Infrastructure
 @cite{dayal-2016} @cite{groenendijk-stokhof-1984} @cite{anand-hardt-mccloskey-2021}
 
-Theory-neutral types for question-answer phenomena.
+Theory-neutral types for question-answer phenomena. The semantic type of a wh-phrase
+(*who*/*what*/*where*/…) is the shared `Features.OntologicalCategory` axis — its
+wh-side distribution is empirically motivated by the Santa Cruz Sluicing Corpus
+(@cite{anand-hardt-mccloskey-2021}), where these categories show radically different
+frequencies.
 
 -/
 
 namespace Phenomena.Questions
-
-/-- Semantic type of a wh-phrase, classifying what domain the wh-word
-    ranges over. The taxonomy is empirically motivated by distributional
-    patterns in the Santa Cruz Sluicing Corpus, where these types show radically different frequencies. -/
-inductive WhSemanticType where
-  | entity          -- who, what, which N — ranges over individuals
-  | degree          -- how much, how many, how ADJ — ranges over degrees
-  | reason          -- why — ranges over reasons/causes
-  | manner          -- how — ranges over manners
-  | temporal        -- when — ranges over times
-  | locative        -- where — ranges over locations
-  | classificatory  -- what kind of, what sort of — ranges over kinds
-  deriving DecidableEq, Repr, Inhabited
 
 -- Question Types
 
 /-- Classification of question types by answer form.
 
     Note: this classifies the *form* of the question and expected answer,
-    not the semantic type of the wh-phrase. For semantic type (entity,
-    degree, reason, etc.), see `WhSemanticType`. -/
+    not the semantic type of the wh-phrase. For semantic type (person/thing/
+    amount/reason/…), see `Features.OntologicalCategory`. -/
 inductive QuestionType where
   | polar           -- Yes/no questions: "Did John leave?"
   | whSingular      -- Singular wh: "Who left?"
@@ -39,17 +31,17 @@ inductive QuestionType where
   | whManner        -- Manner: "How did John leave?"
   deriving DecidableEq, Repr
 
-/-- The semantic type of the wh-phrase, when the question is a wh-question.
-    Returns `none` for polar and alternative questions. For `whSingular`
-    and `whPlural`, the semantic type depends on the specific wh-word used,
-    so we default to `entity` — the caller should refine if needed. -/
-def QuestionType.whSemanticType : QuestionType → Option WhSemanticType
-  | .polar      => none
+/-- The ontological category of the wh-phrase, when the question is a wh-question.
+    Returns `none` for polar and alternative questions. For `whSingular`/`whPlural`
+    the person/thing split depends on the specific wh-word (*who* vs *what*/*which*),
+    so we default to `person` — the caller should refine per wh-word. -/
+def QuestionType.whSemanticType : QuestionType → Option Features.OntologicalCategory
+  | .polar       => none
   | .alternative => none
-  | .whSingular => some .entity   -- default; could be temporal, locative, etc.
-  | .whPlural   => some .entity
-  | .whReason   => some .reason
-  | .whManner   => some .manner
+  | .whSingular  => some .person   -- default; *who* vs *what* refined per wh-word
+  | .whPlural    => some .person
+  | .whReason    => some .reason
+  | .whManner    => some .manner
 
 /-- Answer completeness -/
 inductive AnswerCompleteness where

--- a/Linglib/Semantics/Numerals/Basic.lean
+++ b/Linglib/Semantics/Numerals/Basic.lean
@@ -163,7 +163,7 @@ instance : ToString BareNumeral where
     of, under a choice of bare-numeral semantics (`bareMeaning` exact vs.
     `atLeastMeaning` lower-bound — only the bare `.eq` form consults `bare`; the
     four modified forms are theory-independent `relationalGQ` denotations). A
-    method on the numeral object, mirroring `Pronoun.Entry.denote`. -/
+    method on the numeral object, mirroring `PersonalPronoun.denote`. -/
 def _root_.Numeral.Entry.denoteUnder (e : Numeral.Entry) (bare : Nat → Nat → Prop) :
     Nat → Prop :=
   match e.comparison with
@@ -364,7 +364,7 @@ end GQTBridge
 The lexical numeral object (`Core.Scale.Comparison`, `Numeral.Entry`) is owned by
 `Typology/Numeral/Basic.lean`; this section is the *semantics* side — it imports
 that object and provides its `relationalGQ` denotation, mirroring how
-`Semantics/Reference/PronounDenotation.lean` denotes the `Pronoun.Entry` object.
+`Semantics/Reference/PronounDenotation.lean` denotes the `PersonalPronoun` object.
 The denotation is **by construction** a `Core.Scale.relationalGQ`, so every lemma
 about `relationalGQ` transfers to every numeral entry. `Comparison.rel` lives in
 `Core.Scale`; `Entry.denoteUnder` (the cardinal, theory-parameterized reading) is

--- a/Linglib/Semantics/Reference/Binding.lean
+++ b/Linglib/Semantics/Reference/Binding.lean
@@ -9,7 +9,7 @@ Per @cite{buring-2012} §3, a bound pronoun has the *same* denotation as a free
 one — the variable `g(i)` — with binding supplied externally by the β-operator.
 That assignment-based binding is the project-canonical `interpPronoun` /
 `lambdaAbsG` (`Core.Logic.Intensional.Variables`), also the selector of the
-unified pronoun denotation `Pronoun.Entry.denote`; this file develops the
+unified pronoun denotation `PersonalPronoun.denote`; this file develops the
 continuation rendering (`W`, `hkBinding`/`bsBinding`) and the cylindric-algebra
 view of the assignment update.
 

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -99,7 +99,7 @@ beyond definedness of that selector.
 This is the single source of truth for definite descriptions in the library;
 familiarity-based, anaphoric, and discourse-restricted variants are
 `NominalDenot`s with different selectors, and pronouns add a φ-feature presup
-(see `Pronoun.Entry.denote`). -/
+(see `PersonalPronoun.denote`). -/
 def definiteNominal {W E : Type*} (domain : List E) (restrictor : E → W → Bool) :
     NominalDenot Unit W E :=
   NominalDenot.ofReferent (attributiveContent domain restrictor)

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -8,7 +8,7 @@ import Linglib.Semantics.Dynamic.Effects.HasFiberedLookup
 /-!
 # The denotation of a pronoun
 
-Gives the `Pronoun.Entry` lexical record a meaning, as a `NominalDenot`: the
+Gives the `PersonalPronoun` lexical record a meaning, as a `NominalDenot`: the
 selector is the project-canonical variable denotation `interpPronoun`
 (`g ↦ g i`), so the pronoun-as-object and the bare assignment-indexed
 variable are the same individual *by construction* — not via a bridge
@@ -24,9 +24,9 @@ and deictic uses (his §2.1.1); binding is the external β-operator
 
 ## Main definitions
 
-* `Pronoun.Entry.phiPresup` — the conjoined φ-feature presupposition of an
+* `PersonalPronoun.phiPresup` — the conjoined φ-feature presupposition of an
   entry (absent or featurally-uncovered values contribute `PrProp.top`).
-* `Pronoun.Entry.denote` — the pronoun's `NominalDenot` (static case).
+* `PersonalPronoun.denote` — the pronoun's `NominalDenot` (static case).
 
 ## Implementation notes
 
@@ -37,8 +37,6 @@ bridges plus `PhiFeatures.toPair`, deferred until a study needs them.
 -/
 
 set_option autoImplicit false
-
-namespace Pronoun
 
 open Semantics.Presupposition (PrProp)
 open Semantics.Presupposition.PhiFeatures
@@ -52,7 +50,7 @@ domain `E`. The model supplies the entity-level predicates the cells need
 (`speaker`/`addressee` for person, `isFemale`/`isInanimate` for gender;
 number atomicity comes from the `PartialOrder`). A feature that is absent —
 or present but outside the cells' coverage — contributes `PrProp.top`. -/
-def Entry.phiPresup {E : Type*} [PartialOrder E] (e : Entry)
+def PersonalPronoun.phiPresup {E : Type*} [PartialOrder E] (e : PersonalPronoun)
     (speaker addressee : E) (isFemale isInanimate : E → Prop) : PrProp E :=
   PrProp.and
     (match e.person with
@@ -75,7 +73,7 @@ def Entry.phiPresup {E : Type*} [PartialOrder E] (e : Entry)
 variable denotation `interpPronoun i` (always defined under a total
 assignment), and the intrinsic presupposition is the φ-feature presupposition
 imposed on the resolved referent `g i`. The static case; world is trivial. -/
-def Entry.denote {F : Frame} [PartialOrder F.Entity] (e : Entry) (i : ℕ)
+def PersonalPronoun.denote {F : Frame} [PartialOrder F.Entity] (e : PersonalPronoun) (i : ℕ)
     (speaker addressee : F.Entity) (isFemale isInanimate : F.Entity → Prop) :
     NominalDenot (Assignment F.Entity) PUnit F.Entity where
   presup := fun g _ => (e.phiPresup speaker addressee isFemale isInanimate).presup (g i)
@@ -102,7 +100,7 @@ theorem interpPronoun_eq_iLookup {F : Frame} (i : ℕ) (g : Assignment F.Entity)
 
 /-- A 3rd-person plural feminine entry (Spanish *ellas*), used to exercise
 the φ-feature presupposition. -/
-private def ellas : Entry :=
+private def ellas : PersonalPronoun :=
   { form := "ellas", person := some .third, number := some .Plur,
     gender := some .feminine }
 
@@ -121,5 +119,3 @@ example {F : Frame} [PartialOrder F.Entity] (g : Assignment F.Entity) (i : ℕ)
     ((ellas.denote i speaker addressee isFemale isInanimate).toPrProp scope g).presup ⟨⟩ := by
   refine ⟨⟨trivial, trivial, hFem⟩, ?_⟩
   rfl
-
-end Pronoun

--- a/Linglib/Studies/Buring2012.lean
+++ b/Linglib/Studies/Buring2012.lean
@@ -7,7 +7,7 @@ import Linglib.Semantics.Reference.PronounDenotation
 
 @cite{buring-2012}'s handbook survey of pronoun semantics makes several claims
 this file states as theorems about the *unified* pronoun denotation
-(`Pronoun.Entry.denote` / `Pronoun.Entry.phiPresup`) applied to the English
+(`PersonalPronoun.denote` / `PersonalPronoun.phiPresup`) applied to the English
 Fragment's lexical entries (`English.Pronouns`) — not about a local
 re-implementation. This is the "theory-hub denotation as study-file constraint":
 the object the rest of the codebase attributes to pronouns is the object these
@@ -70,7 +70,7 @@ lexeme; the lexical entry is identical, binding lives in the assignment. -/
 theorem she_bound_reading (b : F.Entity) :
     (she.entry.denote i spk adr isFemale isInanimate).selector (g.update i b) ⟨⟩
       = some b := by
-  simp only [Pronoun.Entry.denote, interpPronoun, Assignment.update_at]
+  simp only [PersonalPronoun.denote, interpPronoun, Assignment.update_at]
 
 /-- Epicene *they* (@cite{arnold-2026}) carries no gender presupposition: its
 denotation is defined of a referent regardless of gender — the structural

--- a/Linglib/Typology/Negation.lean
+++ b/Linglib/Typology/Negation.lean
@@ -6,6 +6,7 @@ import Linglib.Data.WALS.Features.F115A
 import Linglib.Data.WALS.Features.F143A
 import Linglib.Data.WALS.Features.F144A
 import Linglib.Data.WALS.Features.F144B
+import Linglib.Typology.NegativeConcord
 
 /-!
 # Typology.Negation
@@ -380,6 +381,37 @@ def countByMorphemeType (langs : List NegationProfile)
 /-- Count of languages in a sample with a given symmetry type. -/
 def countBySymmetry (langs : List NegationProfile) (s : NegSymmetry) : Nat :=
   (langs.filter (·.symmetry == s)).length
+
+-- ============================================================================
+-- §6. Negative concord: bridge WALS 115A strategy ↔ item-level n-word status
+--     (@cite{giannakidou-2000}, @cite{van-der-auwera-van-alsenoy-2016})
+-- ============================================================================
+
+open Typology.NegativeConcord (NWordStatus)
+
+/-- Whether the negative-indefinite system shows negative concord
+    (@cite{van-der-auwera-van-alsenoy-2016}): WALS 115A `cooccur` (concord) and `mixed`
+    (position-dependent) do; `preclude` (double negation) and `negExistential` do not.
+    Broader than `NegationProfile.hasNegConcord`, which tests `cooccur` only. -/
+def NegIndefiniteStrategy.hasNegativeConcord : NegIndefiniteStrategy → Bool
+  | .cooccur | .mixed => true
+  | .preclude | .negExistential => false
+
+/-- Whether an item-level n-word status is consistent with a language's WALS 115A
+    negative-indefinite strategy: an n-word needs a concord system, an inherently
+    negative quantifier a non-concord (double-negation / neg-existential) one, an NPI
+    any (@cite{van-der-auwera-van-alsenoy-2016}). -/
+def NegIndefiniteStrategy.admits : NegIndefiniteStrategy → NWordStatus → Bool
+  | strat, .nWord => strat.hasNegativeConcord
+  | strat, .negQuantifier => !strat.hasNegativeConcord
+  | _, .npi => true
+
+/-- N-words live in negative-concord systems, inherently negative quantifiers in
+    double-negation ones (@cite{van-der-auwera-van-alsenoy-2016}). -/
+theorem nWord_vs_negQuantifier :
+    (NegIndefiniteStrategy.cooccur).admits .nWord = true ∧
+    (NegIndefiniteStrategy.preclude).admits .nWord = false ∧
+    (NegIndefiniteStrategy.preclude).admits .negQuantifier = true := by decide
 
 -- ============================================================================
 -- §7. Theory-neutral WALS distribution facts (corpus-only generalisations)

--- a/Linglib/Typology/NegativeConcord.lean
+++ b/Linglib/Typology/NegativeConcord.lean
@@ -1,0 +1,86 @@
+/-!
+# Typology.NegativeConcord
+@cite{giannakidou-2000} @cite{van-der-auwera-van-alsenoy-2016}
+
+Lightweight, Fragment-importable types for negative concord: the item-level n-word
+status, the NC subtype, and the clausal-position parameter the strict/non-strict
+contrast turns on.
+
+Kept separate from `Typology/Negation.lean` (the WALS-based negation survey) so that
+`Typology/PolarityItem.lean` and Fragment lexicons can import the n-word classification
+without pulling in the WALS datapoint files. `Negation.lean` imports *this* file to
+bridge the item-level status to its language-level WALS 115A `NegIndefiniteStrategy`
+(`NegIndefiniteStrategy.hasNegativeConcord` / `.admits`).
+
+## Main declarations
+
+* `NWordStatus` — n-word / negative-quantifier / NPI (item-level).
+* `NegConcordSubtype` — strict / non-strict / negative-spread.
+* `NWordPosition` + `NegConcordSubtype.nmRequired` — the strict/non-strict contrast,
+  derived from the type.
+-/
+
+namespace Typology.NegativeConcord
+
+/-- Item-level status of a negation-sensitive indefinite: the n-word vs
+    negative-quantifier vs NPI trichotomy. @cite{giannakidou-2000} gives the minimal,
+    deliberately theory-neutral definition — n-words "occur in NC structures and can be
+    associated with negative meaning" — and stresses their heterogeneity. The *internal*
+    semantics is contested (negative existential vs polarity-sensitive universal vs an
+    NPI licensed by a null negation); this enum records only the distributional class,
+    which @cite{van-der-auwera-van-alsenoy-2016} take as the basis of the NC typology.
+    Lets a strict-NC n-word (Russian никто, Italian *nessuno*) be classified honestly
+    rather than borrowing a strong-NPI slot in `Typology.PolarityItem`. -/
+inductive NWordStatus where
+  /-- N-word: occurs in negative-concord structures (Romance *nessuno*, Slavic никто,
+      Greek *típota*, Hungarian *semmi*); licenses a negative fragment answer ("Nothing.")
+      yet typically co-occurs with a clausal negation marker. -/
+  | nWord
+  /-- Inherently negative quantifier: negates on its own with no concord; two stack to
+      double negation. English *nobody*, German *niemand*. -/
+  | negQuantifier
+  /-- Negative-polarity item: non-negative, licensed by (not contributing) negation,
+      occurs across a wider range of contexts (questions, conditionals, comparatives).
+      English *anybody*. -/
+  | npi
+  deriving DecidableEq, BEq, Repr
+
+/-- Subtype of negative concord (@cite{van-der-auwera-van-alsenoy-2016};
+    @cite{giannakidou-2000}). `strict` keeps the clausal negation marker regardless of
+    n-word position (Greek, Hungarian, Slavic); `nonStrict` drops it when the n-word is
+    preverbal but requires it postverbally (Italian, Spanish, Portuguese);
+    `negativeSpread` has several n-words share one negation with no clausal marker at all
+    (French *personne n'a rien dit*). @cite{van-der-auwera-van-alsenoy-2016} find
+    `strict` far more frequent than `nonStrict`, and `nonStrict` itself heterogeneous —
+    not cleanly a single category. -/
+inductive NegConcordSubtype where
+  | strict
+  | nonStrict
+  | negativeSpread
+  deriving DecidableEq, BEq, Repr
+
+/-- Position of an n-word relative to the finite verb — the parameter the strict vs
+    non-strict contrast turns on. -/
+inductive NWordPosition where
+  | preverbal
+  | postverbal
+  deriving DecidableEq, BEq, Repr
+
+/-- Whether a clausal negation marker is required, given the NC subtype and the n-word's
+    position (@cite{giannakidou-2000}: strict NC keeps the marker regardless of position;
+    non-strict drops it for a preverbal n-word but requires it postverbally; negative
+    spread has no clausal marker). The strict/non-strict contrast falls out of the type. -/
+def NegConcordSubtype.nmRequired : NegConcordSubtype → NWordPosition → Bool
+  | .strict, _ => true
+  | .nonStrict, .preverbal => false
+  | .nonStrict, .postverbal => true
+  | .negativeSpread, _ => false
+
+/-- The strict vs non-strict contrast: both require the marker postverbally, but only
+    strict requires it preverbally (@cite{giannakidou-2000}). -/
+theorem strict_nonstrict_contrast :
+    NegConcordSubtype.strict.nmRequired .preverbal = true ∧
+    NegConcordSubtype.nonStrict.nmRequired .preverbal = false ∧
+    NegConcordSubtype.nonStrict.nmRequired .postverbal = true := by decide
+
+end Typology.NegativeConcord

--- a/Linglib/Typology/PolarityItem.lean
+++ b/Linglib/Typology/PolarityItem.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.LicensingContext
+import Linglib.Typology.NegativeConcord
 
 /-!
 # Typology.PolarityItem
@@ -278,6 +279,11 @@ structure PolarityItemEntry where
   morphology : NPIMorphology := .plain
   /-- Type of alternatives introduced -/
   alternativeType : AlternativeType := .unspecified
+  /-- Negative-concord / n-word status (@cite{giannakidou-2000},
+      @cite{van-der-auwera-van-alsenoy-2016}). `none` for items outside the
+      negative-concord system; strict-NC n-words set `some .nWord` here rather than
+      leaning on a strong-NPI `polarityType`. -/
+  nWordStatus : Option NegativeConcord.NWordStatus := none
   /-- Notes -/
   notes : String := ""
   deriving Repr

--- a/Linglib/Typology/Pronoun/Basic.lean
+++ b/Linglib/Typology/Pronoun/Basic.lean
@@ -8,10 +8,10 @@ import Linglib.Features.Gender
 # Pronoun
 
 Lexical core for the pronoun as a grammatical object: the general `Pronoun`
-structure (the morphosyntactic core every pronoun type shares), the `Entry`
-schema for personal/referential pronouns (which `extends Pronoun`), allocutive
-markers, the `Spec` referent-preference type, and @cite{cardinaletti-starke-1999}'s
-`Strength` deficiency classification.
+structure (the morphosyntactic core every pronoun type shares), the
+`PersonalPronoun` schema for personal/referential pronouns (which `extends Pronoun`),
+allocutive markers, the `Spec` referent-preference type, and
+@cite{cardinaletti-starke-1999}'s `Strength` deficiency classification.
 
 Cross-categorial features a pronoun carries — `Person`, `Number`, `Gender`,
 `Case` — are not redefined here; they live under `Features/` and are composed
@@ -22,7 +22,7 @@ in as fields of the general `Pronoun`.
 * `Pronoun` — the general pronoun object: surface form + agreement φ-features,
   everything true of *all* pronouns. Specializations `extends` it (mathlib-style:
   the general concept gets the plain name).
-* `Pronoun.Entry` — personal/referential pronoun entry: `extends Pronoun` with the
+* `PersonalPronoun` — personal/referential pronoun: `extends Pronoun` with the
   register and referential-person features specific to deictic pronouns.
 * `Pronoun.Strength` — @cite{cardinaletti-starke-1999} strong/weak/clitic
   deficiency order (via `Strength.rank`). Orthogonal to
@@ -38,7 +38,7 @@ set_option autoImplicit false
 /-- The general pronoun object: the morphosyntactic core shared by every pronoun
     type (personal, indefinite, demonstrative, interrogative, …). Carries only what
     is true of *all* pronouns — surface form and agreement φ-features — and has no
-    denotation of its own; each specialization (`Pronoun.Entry` for personal/
+    denotation of its own; each specialization (`PersonalPronoun` for personal/
     referential pronouns, and future `IndefinitePronoun` etc.) `extends` this and
     supplies its own meaning. Coexists with `namespace Pronoun` (a type and a
     namespace may share a name, cf. `List`). -/
@@ -57,6 +57,27 @@ structure Pronoun where
   gender : Option Features.SurfaceGender := none
   /-- Native script form (hangul, kanji, Devanagari, …). -/
   script : Option String := none
+  deriving Repr, BEq
+
+/-- Cross-linguistic *personal/referential* pronoun: the general `Pronoun` object
+(form + φ-features) plus the register and referential-person features specific to
+deictic pronouns. Covers personal pronouns across all Fragment languages;
+language-specific extensions (e.g., English PronounType/wh) remain in their
+respective Fragment files. -/
+structure PersonalPronoun extends Pronoun where
+  /-- Register level (formality/honorifics). Binary T/V systems use
+      `.informal`/`.formal`; ternary honorific systems (Hindi, Magahi,
+      Maithili, Korean) use all three levels. -/
+  register : Features.Register.Level := .informal
+  /-- Referential person — who the pronoun refers to in terms of discourse
+      role — when it diverges from formal/agreement person. For polite
+      pronouns (Italian LEI, Spanish USTED, German SIE), the formal `person`
+      field is 3rd (governing agreement, clitic allomorphy, reflexive binding),
+      while `referentialPerson` is 2nd (governing the PCC, Fancy Constraint,
+      resolved agreement). For ordinary pronouns, leave as `none` —
+      referential person coincides with formal person.
+      @cite{adamson-zompi-2025} -/
+  referentialPerson : Option Features.Prominence.PersonLevel := none
   deriving Repr, BEq
 
 namespace Pronoun
@@ -104,27 +125,6 @@ inductive Spec where
   | theyThem   -- they/them/theirs
   deriving DecidableEq, Repr, BEq
 
-/-- Cross-linguistic *personal/referential* pronoun entry: the general `Pronoun`
-object (form + φ-features) plus the register and referential-person features
-specific to deictic pronouns. Covers personal pronouns across all Fragment
-languages; language-specific extensions (e.g., English PronounType/wh) remain in
-their respective Fragment files. -/
-structure Entry extends _root_.Pronoun where
-  /-- Register level (formality/honorifics). Binary T/V systems use
-      `.informal`/`.formal`; ternary honorific systems (Hindi, Magahi,
-      Maithili, Korean) use all three levels. -/
-  register : Level := .informal
-  /-- Referential person — who the pronoun refers to in terms of discourse
-      role — when it diverges from formal/agreement person. For polite
-      pronouns (Italian LEI, Spanish USTED, German SIE), the formal `person`
-      field is 3rd (governing agreement, clitic allomorphy, reflexive binding),
-      while `referentialPerson` is 2nd (governing the PCC, Fancy Constraint,
-      resolved agreement). For ordinary pronouns, leave as `none` —
-      referential person coincides with formal person.
-      @cite{adamson-zompi-2025} -/
-  referentialPerson : Option Features.Prominence.PersonLevel := none
-  deriving Repr, BEq
-
 /-- Cross-linguistic allocutive marker entry.
 
 Covers verbal suffixes, particles, and clitics that realize allocutive
@@ -132,7 +132,7 @@ agreement across all Fragment languages. -/
 structure AllocutiveEntry where
   /-- Surface form of the marker -/
   form : String
-  /-- Register level (matching Entry.register scale) -/
+  /-- Register level (matching PersonalPronoun.register scale) -/
   register : Level
   /-- Gloss string (e.g., "IMP.NH", "POL", "2sg.DAT.fam") -/
   gloss : String

--- a/Linglib/Typology/Pronoun/Basic.lean
+++ b/Linglib/Typology/Pronoun/Basic.lean
@@ -7,17 +7,23 @@ import Linglib.Features.Gender
 /-!
 # Pronoun
 
-Lexical core for the pronoun as a grammatical object: the `Entry` schema
-fragments instantiate, allocutive markers, the `Spec` referent-preference type,
-and @cite{cardinaletti-starke-1999}'s `Strength` deficiency classification.
+Lexical core for the pronoun as a grammatical object: the general `Pronoun`
+structure (the morphosyntactic core every pronoun type shares), the `Entry`
+schema for personal/referential pronouns (which `extends Pronoun`), allocutive
+markers, the `Spec` referent-preference type, and @cite{cardinaletti-starke-1999}'s
+`Strength` deficiency classification.
 
 Cross-categorial features a pronoun carries — `Person`, `Number`, `Gender`,
 `Case` — are not redefined here; they live under `Features/` and are composed
-in as `Entry` fields.
+in as fields of the general `Pronoun`.
 
 ## Main declarations
 
-* `Pronoun.Entry` — cross-linguistic lexical pronoun entry (form + features).
+* `Pronoun` — the general pronoun object: surface form + agreement φ-features,
+  everything true of *all* pronouns. Specializations `extends` it (mathlib-style:
+  the general concept gets the plain name).
+* `Pronoun.Entry` — personal/referential pronoun entry: `extends Pronoun` with the
+  register and referential-person features specific to deictic pronouns.
 * `Pronoun.Strength` — @cite{cardinaletti-starke-1999} strong/weak/clitic
   deficiency order (via `Strength.rank`). Orthogonal to
   @cite{dechaine-wiltschko-2002}'s categorial pro-DP/φP/NP axis; a framework's
@@ -28,6 +34,30 @@ in as `Entry` fields.
 -/
 
 set_option autoImplicit false
+
+/-- The general pronoun object: the morphosyntactic core shared by every pronoun
+    type (personal, indefinite, demonstrative, interrogative, …). Carries only what
+    is true of *all* pronouns — surface form and agreement φ-features — and has no
+    denotation of its own; each specialization (`Pronoun.Entry` for personal/
+    referential pronouns, and future `IndefinitePronoun` etc.) `extends` this and
+    supplies its own meaning. Coexists with `namespace Pronoun` (a type and a
+    namespace may share a name, cf. `List`). -/
+structure Pronoun where
+  /-- Surface form (romanization or orthographic). -/
+  form : String
+  /-- Grammatical person (UD.Person via Core.Word abbrev). -/
+  person : Option Person := none
+  /-- Grammatical number. -/
+  number : Option Number := none
+  /-- Grammatical case. -/
+  case_ : Option Features.Case := none
+  /-- Grammatical gender. For 3rd-person pronouns in gendered languages
+      (French il/elle, German er/sie/es, …). 1st/2nd-person pronouns and
+      languages without pronominal gender leave this `none`. -/
+  gender : Option Features.SurfaceGender := none
+  /-- Native script form (hangul, kanji, Devanagari, …). -/
+  script : Option String := none
+  deriving Repr, BEq
 
 namespace Pronoun
 
@@ -74,24 +104,12 @@ inductive Spec where
   | theyThem   -- they/them/theirs
   deriving DecidableEq, Repr, BEq
 
-/-- Cross-linguistic pronoun entry.
-
-Covers personal pronouns across all Fragment languages. Language-specific
-extensions (e.g., English PronounType/wh) remain in their respective
-Fragment files. -/
-structure Entry where
-  /-- Surface form (romanization or orthographic) -/
-  form : String
-  /-- Grammatical person (UD.Person via Core.Word abbrev) -/
-  person : Option Person := none
-  /-- Grammatical number -/
-  number : Option Number := none
-  /-- Grammatical case -/
-  case_ : Option Features.Case := none
-  /-- Grammatical gender. For 3rd-person pronouns in gendered languages
-      (French il/elle, German er/sie/es, etc.). 1st/2nd-person pronouns
-      and languages without pronominal gender leave this as `none`. -/
-  gender : Option SurfaceGender := none
+/-- Cross-linguistic *personal/referential* pronoun entry: the general `Pronoun`
+object (form + φ-features) plus the register and referential-person features
+specific to deictic pronouns. Covers personal pronouns across all Fragment
+languages; language-specific extensions (e.g., English PronounType/wh) remain in
+their respective Fragment files. -/
+structure Entry extends _root_.Pronoun where
   /-- Register level (formality/honorifics). Binary T/V systems use
       `.informal`/`.formal`; ternary honorific systems (Hindi, Magahi,
       Maithili, Korean) use all three levels. -/
@@ -105,8 +123,6 @@ structure Entry where
       referential person coincides with formal person.
       @cite{adamson-zompi-2025} -/
   referentialPerson : Option Features.Prominence.PersonLevel := none
-  /-- Native script form (hangul, kanji, Devanagari, etc.) -/
-  script : Option String := none
   deriving Repr, BEq
 
 /-- Cross-linguistic allocutive marker entry.

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -5770,6 +5770,20 @@
   role      = {cited},
   sources   = {Phenomena/Imperatives/Typology.lean}
 }% REF: Barker, C. & Shan, C. (2014). Continuations and Natural Language. Ch. 16.
+
+@article{van-der-auwera-van-alsenoy-2016,
+  author    = {van der Auwera, Johan and Van Alsenoy, Lauren},
+  year      = {2016},
+  title     = {On the typology of negative concord},
+  journal   = {Studies in Language},
+  volume    = {40},
+  number    = {3},
+  pages     = {473--512},
+  doi       = {10.1075/sl.40.3.01van},
+  subfield  = {comparative},
+  role      = {formalized},
+  sources   = {Typology/NegativeConcord.lean;Typology/Negation.lean}
+}
 @book{barker-shan-2014,
   author    = {Barker, Chris and Shan, Chung-chieh},
   year      = {2014},
@@ -10179,6 +10193,19 @@
   validated = {true},
   role      = {foundational},
   sources   = {Phenomena/Polarity/NPIs.lean;Phenomena/Polarity/Typology.lean}
+}
+@article{giannakidou-2000,
+  author    = {Giannakidou, Anastasia},
+  year      = {2000},
+  title     = {Negative ... Concord?},
+  journal   = {Natural Language and Linguistic Theory},
+  volume    = {18},
+  number    = {3},
+  pages     = {457--523},
+  doi       = {10.1023/A:1006477315705},
+  subfield  = {semantics/lexical},
+  role      = {formalized},
+  sources   = {Typology/NegativeConcord.lean;Typology/Negation.lean}
 }
 @incollection{heim-2001,
   author    = {Heim, Irene},


### PR DESCRIPTION
Substrate + hierarchy for the pronoun API. Full `lake build Linglib` green.

- `Features.OntologicalCategory`: promote `WhSemanticType` from Phenomena to substrate, split `entity` into person/thing; Questions reuses it.
- `Typology.NegativeConcord`: item-level n-word status (Giannakidou 2000; Van der Auwera & Van Alsenoy 2016); Russian/Czech n-words typed via `NWordStatus`.
- `Pronoun`/`PersonalPronoun`: extract the general `Pronoun` object (form + φ-features + ontological category); `Entry` → `PersonalPronoun extends Pronoun`.
- `IndefinitePronoun extends Pronoun`: composes `BaseForce` + the `PolarityItemEntry`/`NWordStatus` overlay; quantificational denotation (fills `NominalKind.indefinite`), not the referential `PersonalPronoun.denote`.