### PR TITLE
refactor(Studies): reformalize Dong et al. 2026 as value of information

### DIFF
--- a/Linglib/Studies/DongEtAl2026PMF.lean
+++ b/Linglib/Studies/DongEtAl2026PMF.lean
@@ -1,150 +1,322 @@
-import Linglib.Pragmatics.RSA.Operators
-import Mathlib.Probability.Distributions.Uniform
+import Linglib.Core.Probability.Posterior
 
 /-!
-# @cite{dong-etal-2026} on mathlib `PMF` (binary identification)
-@cite{dong-etal-2026}
+# @cite{dong-etal-2026}: the Value-of-Information clarify-or-commit model
 
-PMF-shaped formalisation of the paper's 4 findings on binary
-identification. The task is intentionally degenerate: at any target,
-exactly one utterance applies (matching pair).
+A PMF-level formalisation of the decision-theoretic Value of Information
+(VoI) framework for adaptive human–agent communication. An agent holds a
+belief `b : PMF Θ` over latent user intents and may either **commit** to an
+action now or **clarify** by asking a question before committing. The paper
+operationalises the choice through the classical Value of Information: ask a
+question only when its expected improvement in the downstream decision
+outweighs the communication cost.
 
-All 4 findings are vacuous-zero: the wrong guess has L0 = 0, so its S1/L1
-mass is 0, hence "correct > wrong".
+A question is modelled as an answer kernel `κ : Θ → PMF Y` — the paper's
+`p(y ∣ q, θ)`, the distribution of answer `y` were `θ` the true intent. Its
+answer marginal `p(y ∣ q, b)` and the updated belief `b_y` are the project's
+`PMF.marginal κ b` and `PMF.posterior κ b y`; `weightedPosteriorValue_eq`
+identifies the (total) per-answer term used here with `p(y) · V(b_y)`.
 
-Stakes parameter `k` (animal: 1, medical: 10) is irrelevant to the
-qualitative predictions because the L0 gate zeros incorrect responses.
+## Main definitions
 
-For the simplest PMF formulation, we set α = 1 and use a unit cost factor
-(no stakes-dependence). Both bundled-API configs (`animalCfg`, `medicalCfg`)
-in the paper collapse to the same PMF model after qualitative-only migration.
+* `EU U b a` — expected utility of committing to action `a` under belief `b`.
+* `V U b` — value of acting now, `⨆ a, EU U b a`.
+* `Vpost U b κ` — expected value after asking `κ`, `∑' y, p(y) · V(b_y)`.
+* `VoI U b κ` — value of information, `Vpost U b κ - V U b`.
+* `NetVoI c U b κ` — `VoI` net of the per-question cost `c`.
+* `worthAsking c U b κ` — the clarify-or-commit decision, `c < VoI U b κ`.
+
+## Main statements
+
+* `V_le_Vpost` — information never has negative value: `V U b ≤ Vpost U b κ`.
+* `V_add_VoI` — `VoI` is the honest increment: `V U b + VoI U b κ = Vpost U b κ`.
+* `VoI_smul` — `VoI` is positive-homogeneous in the utility (stakes scale).
+* `worthAsking_mono_stakes` — holding belief, question, and cost fixed,
+  raising the stakes (scaling the utility) keeps a question worth asking, so
+  the commit-without-asking region shrinks as stakes rise. This is the
+  *ceteris-paribus mechanism* behind the paper's Mixed-Stakes prediction:
+  scaling utility scales `VoI`, so a question clearing a fixed cost at low
+  stakes (`U = 1`, guessing an animal) clears it at high stakes (`U = 10`,
+  diagnosing a disease). `medical_worth_asking_of_animal` is the named
+  instance. The model isolates the utility-scaling mechanism; it does not
+  encode the experiments' differing candidate-set sizes or answer models.
+
+## Implementation notes
+
+Utilities are `ℝ≥0∞`-valued so the model lives natively on `PMF`. `VoI` uses
+truncated subtraction, but `V_le_Vpost` makes the gap genuine rather than
+clipped to `0`. Homogeneity needs only `s ≠ ∞` (via `ENNReal.mul_sub`); no
+finiteness of `V`/`Vpost` is assumed, so the core results hold for arbitrary
+intent, action, and answer types.
+
+The worth-asking region is the strict `c < VoI U b κ` (equivalently
+`0 < NetVoI`), matching the paper's "commit when `max_q NetVoI ≤ 0`" rule.
+The cross-question `argmax` selection of the policy is out of scope: the
+results here concern the per-question clarify-or-commit decision.
+
+This PMF/`ℝ≥0∞` formulation parallels the `ℝ`-valued expected-information-gain
+substrate `Core.Agent.ExperimentDesign.eig` (with value function `V U`):
+`V_le_Vpost` is the PMF analogue of `ExperimentDesign.eig_nonneg_of_convex`
+and of `Phenomena.Clarification.evpi_nonneg`. The theory-neutral
+clarify-or-commit data lives in `Phenomena/Clarification/Basic.lean`.
+
+## Todo
+
+* Discharge the `Phenomena/Clarification/Basic.lean` docstring claim that EVPI
+  is the upper bound on VoI for any question into a theorem
+  `worthAsking c U b κ → c < EVPI`.
+* Relate `VoI` / `V_le_Vpost` to `Core.Agent.ExperimentDesign.eig` /
+  `eig_nonneg_of_convex` (bridging the `ℝ≥0∞`-on-`PMF` and `ℝ`-on-`Fintype`
+  carriers) so the two statements of "information has nonnegative value" become
+  one fact.
+* Lift a shared "clarify when value exceeds cost" `Predict` predicate into the
+  `Phenomena/Clarification` hub that this account and a rival soft-gate
+  (logistic) account both instantiate, exposing sharp-threshold vs. soft-gate
+  as a formal decision-rule choice.
 -/
 
 set_option autoImplicit false
 
-namespace DongEtAl2026.PMF
+namespace DongEtAl2026
 
 open scoped ENNReal
 
-/-- Binary identification task (simplified from the paper's Mixed-Stakes
-    20 Questions, which uses 100 animals / 15 diseases). -/
-inductive Target where | t₁ | t₂
-  deriving DecidableEq, Repr, Fintype
+variable {Θ A Y : Type*}
 
-instance : Nonempty Target := ⟨.t₁⟩
+/-! ### Expected utility and the value of acting now -/
 
-/-- Boolean match: does guess match target? -/
-def targetMatches : Target → Target → Bool
-  | .t₁, .t₁ => true
-  | .t₂, .t₂ => true
-  | _, _ => false
+/-- Expected utility of committing to action `a` under belief `b`. -/
+noncomputable def EU (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (a : A) : ℝ≥0∞ :=
+  ∑' θ, b θ * U θ a
 
-/-! ## §1. L0 — uniform on extension via `RSA.L0OfBoolMeaning` -/
+/-- Value of acting now: the best expected utility achievable under `b`. -/
+noncomputable def V (U : Θ → A → ℝ≥0∞) (b : PMF Θ) : ℝ≥0∞ :=
+  ⨆ a, EU U b a
 
-abbrev extension (u : Target) : Finset Target :=
-  RSA.extensionOf targetMatches u
+/-! ### The value of a question -/
 
-theorem extension_nonempty (u : Target) : (extension u).Nonempty := by
-  cases u
-  · exact ⟨.t₁, RSA.mem_extensionOf.mpr (by decide)⟩
-  · exact ⟨.t₂, RSA.mem_extensionOf.mpr (by decide)⟩
+/-- Per-answer contribution to the post-question value, written through the
+joint `b θ · κ θ y` so it is total — answers with zero marginal contribute
+`0` without needing a posterior. Equals `p(y) · V(b_y)` whenever the answer
+marginal is non-zero; see `weightedPosteriorValue_eq`. -/
+noncomputable def weightedPosteriorValue (U : Θ → A → ℝ≥0∞) (b : PMF Θ)
+    (κ : Θ → PMF Y) (y : Y) : ℝ≥0∞ :=
+  ⨆ a, ∑' θ, b θ * κ θ y * U θ a
 
-noncomputable def L0 (u : Target) : PMF Target :=
-  RSA.L0OfBoolMeaning targetMatches u (extension_nonempty u)
+/-- Expected value after asking question `κ` (the per-intent answer model
+`p(y ∣ q, θ)`): the answer-marginal expectation of the value of acting on
+the resulting posterior belief. -/
+noncomputable def Vpost (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (κ : Θ → PMF Y) : ℝ≥0∞ :=
+  ∑' y, weightedPosteriorValue U b κ y
 
-@[simp] theorem mem_support_L0_iff (u : Target) (w : Target) :
-    w ∈ (L0 u).support ↔ targetMatches u w = true :=
-  RSA.mem_support_L0OfBoolMeaning_iff _ _
+/-- Value of information of question `κ`: how much the best achievable
+expected utility improves, in expectation, by asking before committing. -/
+noncomputable def VoI (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (κ : Θ → PMF Y) : ℝ≥0∞ :=
+  Vpost U b κ - V U b
 
-theorem L0_apply_of_true {u : Target} {w : Target} (h : targetMatches u w = true) :
-    L0 u w = ((extension u).card : ℝ≥0∞)⁻¹ :=
-  RSA.L0OfBoolMeaning_apply_of_mem _ h
+/-- Net value of information: `VoI` minus the per-question communication
+cost `c`. -/
+noncomputable def NetVoI (c : ℝ≥0∞) (U : Θ → A → ℝ≥0∞) (b : PMF Θ)
+    (κ : Θ → PMF Y) : ℝ≥0∞ :=
+  VoI U b κ - c
 
-theorem L0_apply_of_false {u : Target} {w : Target} (h : targetMatches u w ≠ true) :
-    L0 u w = 0 :=
-  RSA.L0OfBoolMeaning_apply_of_not_mem _ h
+/-- The clarify-or-commit decision: asking `κ` is worth its cost exactly
+when its value of information exceeds the communication cost (equivalently
+`0 < NetVoI`; see `netVoI_pos_iff_worthAsking`). -/
+def worthAsking (c : ℝ≥0∞) (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (κ : Θ → PMF Y) : Prop :=
+  c < VoI U b κ
 
-private theorem L0_apply_ne_zero {u : Target} {w : Target} (h : targetMatches u w = true) :
-    L0 u w ≠ 0 := by
-  rw [← PMF.mem_support_iff, mem_support_L0_iff]; exact h
+/-- The per-answer term equals the answer probability times the value of
+acting on the posterior — the bridge to the project's `PMF.posterior`
+substrate (`b_y`) and `PMF.marginal` (`p(y)`). -/
+theorem weightedPosteriorValue_eq (U : Θ → A → ℝ≥0∞) (b : PMF Θ)
+    (κ : Θ → PMF Y) (y : Y) (h : PMF.marginal κ b y ≠ 0) :
+    weightedPosteriorValue U b κ y = PMF.marginal κ b y * V U (PMF.posterior κ b y h) := by
+  unfold weightedPosteriorValue V
+  rw [ENNReal.mul_iSup]
+  refine iSup_congr fun a => ?_
+  unfold EU
+  rw [← ENNReal.tsum_mul_left]
+  refine tsum_congr fun θ => ?_
+  rw [← mul_assoc, PMF.marginal_mul_posterior_apply]
 
-/-! ## §2. S1 — speaker as `PMF.normalize` of L0 -/
+/-! ### Information never has negative value -/
 
-theorem L0_tsum_utterance_ne_top (w : Target) : ∑' u, (L0 u w : ℝ≥0∞) ≠ ∞ :=
-  PMF.tsum_apply_ne_top (fun u => L0 u) w
+/-- **Value of information is nonnegative**: in expectation, the option to
+update the belief before acting can only help. The decision-theoretic core
+of the framework. -/
+theorem V_le_Vpost (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (κ : Θ → PMF Y) :
+    V U b ≤ Vpost U b κ := by
+  unfold V
+  refine iSup_le fun a => ?_
+  have key : ∀ θ, b θ * U θ a = ∑' y, b θ * κ θ y * U θ a := fun θ => by
+    rw [ENNReal.tsum_mul_right, ENNReal.tsum_mul_left, PMF.tsum_coe, mul_one]
+  calc EU U b a = ∑' θ, b θ * U θ a := rfl
+    _ = ∑' θ, ∑' y, b θ * κ θ y * U θ a := tsum_congr key
+    _ = ∑' y, ∑' θ, b θ * κ θ y * U θ a := ENNReal.tsum_comm
+    _ ≤ ∑' y, ⨆ a', ∑' θ, b θ * κ θ y * U θ a' :=
+        ENNReal.tsum_le_tsum fun y => le_iSup (fun a' => ∑' θ, b θ * κ θ y * U θ a') a
+    _ = Vpost U b κ := rfl
 
-private theorem tsum_L0_ne_zero_at {u : Target} {w : Target} (h : targetMatches u w = true) :
-    (∑' u', (L0 u' w : ℝ≥0∞)) ≠ 0 :=
-  PMF.tsum_apply_ne_zero L0 (a := u) (L0_apply_ne_zero h)
+/-- `VoI` is the honest gap between acting-now and acting-after-asking, not a
+value clipped to `0` by truncated subtraction. -/
+theorem V_add_VoI (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (κ : Θ → PMF Y) :
+    V U b + VoI U b κ = Vpost U b κ := by
+  rw [VoI, add_tsub_cancel_of_le (V_le_Vpost U b κ)]
 
-/-- Pragmatic speaker: each world has at least one matching utterance,
-so no fallback is needed (every world is non-degenerate in the binary task). -/
-noncomputable def S1 (w : Target) : PMF Target :=
-  PMF.normalize (fun u => L0 u w)
-    (tsum_L0_ne_zero_at (u := w) (by cases w <;> decide))
-    (L0_tsum_utterance_ne_top w)
+/-! ### Stakes: positive-homogeneity of the value of information -/
 
-theorem S1_apply (w : Target) (u : Target) :
-    S1 w u = L0 u w * (∑' u', L0 u' w)⁻¹ :=
-  PMF.normalize_apply _ _ _
+/-- Expected utility is homogeneous of degree one in the utility. -/
+@[simp] theorem EU_smul (s : ℝ≥0∞) (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (a : A) :
+    EU (s • U) b a = s * EU U b a := by
+  unfold EU
+  rw [← ENNReal.tsum_mul_left]
+  refine tsum_congr fun θ => ?_
+  simp only [Pi.smul_apply, smul_eq_mul]
+  ring
 
-/-! ## §3. L1 — Bayesian inversion against the uniform world prior -/
+/-- The value of acting now is homogeneous of degree one in the utility. -/
+@[simp] theorem V_smul (s : ℝ≥0∞) (U : Θ → A → ℝ≥0∞) (b : PMF Θ) :
+    V (s • U) b = s * V U b := by
+  unfold V
+  rw [ENNReal.mul_iSup]
+  exact iSup_congr fun a => EU_smul s U b a
 
-noncomputable def worldPrior : PMF Target := PMF.uniformOfFintype Target
+/-- Each per-answer post-question term is homogeneous of degree one in the
+utility. -/
+@[simp] theorem weightedPosteriorValue_smul (s : ℝ≥0∞) (U : Θ → A → ℝ≥0∞) (b : PMF Θ)
+    (κ : Θ → PMF Y) (y : Y) :
+    weightedPosteriorValue (s • U) b κ y = s * weightedPosteriorValue U b κ y := by
+  unfold weightedPosteriorValue
+  rw [ENNReal.mul_iSup]
+  refine iSup_congr fun a => ?_
+  rw [← ENNReal.tsum_mul_left]
+  refine tsum_congr fun θ => ?_
+  simp only [Pi.smul_apply, smul_eq_mul]
+  ring
 
-theorem worldPrior_ne_zero (w : Target) : worldPrior w ≠ 0 :=
-  (worldPrior.mem_support_iff w).mp (PMF.mem_support_uniformOfFintype w)
+/-- The post-question value is homogeneous of degree one in the utility. -/
+@[simp] theorem Vpost_smul (s : ℝ≥0∞) (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (κ : Θ → PMF Y) :
+    Vpost (s • U) b κ = s * Vpost U b κ := by
+  unfold Vpost
+  rw [← ENNReal.tsum_mul_left]
+  exact tsum_congr fun y => weightedPosteriorValue_smul s U b κ y
 
-private theorem S1_ne_zero_at {u : Target} {w : Target} (h : targetMatches u w = true) :
-    S1 w u ≠ 0 := by
-  rw [S1, ← PMF.mem_support_iff, PMF.mem_support_normalize_iff]
-  exact L0_apply_ne_zero h
+/-- Scaling every utility by a finite stakes factor `s` scales the value of
+information by `s`: `VoI` is positive-homogeneous of degree one. -/
+theorem VoI_smul {s : ℝ≥0∞} (hs : s ≠ ∞) (U : Θ → A → ℝ≥0∞) (b : PMF Θ)
+    (κ : Θ → PMF Y) :
+    VoI (s • U) b κ = s * VoI U b κ := by
+  unfold VoI
+  rw [Vpost_smul, V_smul, ENNReal.mul_sub fun _ _ => hs]
 
-theorem L1_marginal_ne_zero (u : Target) :
-    PMF.marginal S1 worldPrior u ≠ 0 := by
-  cases u
-  · exact PMF.marginal_ne_zero _ _ _ (worldPrior_ne_zero .t₁) (S1_ne_zero_at (by decide))
-  · exact PMF.marginal_ne_zero _ _ _ (worldPrior_ne_zero .t₂) (S1_ne_zero_at (by decide))
+/-- The agent's policy is `worthAsking` exactly when net value of information
+is positive — the strict side of the paper's `NetVoI ≤ 0` commit rule. -/
+theorem netVoI_pos_iff_worthAsking (c : ℝ≥0∞) (U : Θ → A → ℝ≥0∞) (b : PMF Θ)
+    (κ : Θ → PMF Y) :
+    0 < NetVoI c U b κ ↔ worthAsking c U b κ := by
+  rw [NetVoI, worthAsking, tsub_pos_iff_lt]
 
-noncomputable def L1 (u : Target) : PMF Target :=
-  PMF.posterior S1 worldPrior u (L1_marginal_ne_zero u)
+/-- **Stakes monotonicity**: if a question is worth asking at stakes `s`, it
+remains worth asking at any higher (finite) stakes `s'`. Raising the stakes
+shrinks the region in which the agent commits without clarifying. -/
+theorem worthAsking_mono_stakes {s s' : ℝ≥0∞} (hs : s ≠ ∞) (hs' : s' ≠ ∞)
+    (hss' : s ≤ s') (c : ℝ≥0∞) (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (κ : Θ → PMF Y)
+    (h : worthAsking c (s • U) b κ) : worthAsking c (s' • U) b κ := by
+  rw [worthAsking, VoI_smul hs] at h
+  rw [worthAsking, VoI_smul hs']
+  exact lt_of_lt_of_le h (by gcongr)
 
-/-! ## §4. Findings — all vacuous-zero -/
+/-- The Mixed-Stakes mechanism, holding belief, question, and cost fixed: a
+question worth its cost at low (animal, `U = 1`) stakes is worth its cost at
+high (medical, `U = 10`) stakes, because scaling utility scales `VoI`. -/
+theorem medical_worth_asking_of_animal (c : ℝ≥0∞) (U : Θ → A → ℝ≥0∞)
+    (b : PMF Θ) (κ : Θ → PMF Y) (h : worthAsking c U b κ) :
+    worthAsking c ((10 : ℝ≥0∞) • U) b κ := by
+  have h1 : worthAsking c ((1 : ℝ≥0∞) • U) b κ := by rwa [one_smul]
+  exact worthAsking_mono_stakes ENNReal.one_ne_top ENNReal.ofNat_ne_top (by norm_num)
+    c U b κ h1
 
-/-- S1 prefers correct guess: at world .t₁, utterance .t₂ has L0 = 0
-(targetMatches .t₂ .t₁ = false), so S1 .t₁ .t₂ = 0.
+/-! ### Uninformative questions carry no value -/
 
-Same-base comparison (same world .t₁), different utterances → use
-`normalize_lt_iff_lt` to reduce to L0 score comparison. -/
-theorem S1_prefers_correct : S1 .t₁ .t₂ < S1 .t₁ .t₁ := by
-  rw [S1, PMF.normalize_lt_iff_lt]
-  rw [L0_apply_of_false (by decide : targetMatches .t₂ .t₁ ≠ true)]
-  exact pos_iff_ne_zero.mpr (L0_apply_ne_zero (by decide))
+/-- A constant answer kernel `fun _ => q` (the answer distribution does not
+depend on the true intent `θ`) leaves the post-question value equal to the
+value of acting now: the posterior never moves off the prior. The structural
+converse of `V_le_Vpost`. -/
+theorem Vpost_const_eq_V (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (q : PMF Y) :
+    Vpost U b (fun _ => q) = V U b := by
+  unfold Vpost weightedPosteriorValue V EU
+  have hw : ∀ y, (⨆ a, ∑' θ, b θ * q y * U θ a) = q y * ⨆ a, ∑' θ, b θ * U θ a := by
+    intro y
+    rw [ENNReal.mul_iSup]
+    refine iSup_congr fun a => ?_
+    rw [← ENNReal.tsum_mul_left]
+    exact tsum_congr fun θ => by ring
+  simp_rw [hw]
+  rw [ENNReal.tsum_mul_right, PMF.tsum_coe, one_mul]
 
-/-- S1 facing target .t₁ prefers utterance .t₁ over .t₂. -/
-theorem S1_animal_prefers_correct : S1 .t₁ .t₁ > S1 .t₁ .t₂ :=
-  S1_prefers_correct
+/-- An uninformative question has zero value of information. -/
+theorem VoI_const_eq_zero (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (q : PMF Y) :
+    VoI U b (fun _ => q) = 0 := by
+  rw [VoI, Vpost_const_eq_V, tsub_self]
 
-/-- Same prediction at "medical" stakes (the binary task is degenerate;
-qualitative prediction unchanged by the stakes parameter). -/
-theorem S1_medical_prefers_correct : S1 .t₁ .t₁ > S1 .t₁ .t₂ :=
-  S1_prefers_correct
+/-- **Negative test**: an uninformative question is never worth asking, for
+any cost `c` (including `c = 0`). Truncated subtraction does not manufacture
+spurious value when the answer is independent of the intent. -/
+theorem not_worthAsking_const (c : ℝ≥0∞) (U : Θ → A → ℝ≥0∞) (b : PMF Θ) (q : PMF Y) :
+    ¬ worthAsking c U b (fun _ => q) := by
+  rw [worthAsking, VoI_const_eq_zero, not_lt]
+  exact zero_le'
 
-/-- Per-world S1 leaf for L1: at world .t₂, utterance .t₁ doesn't apply,
-so S1 .t₂ .t₁ = 0. At world .t₁, S1 .t₁ .t₁ > 0. -/
-theorem S1_t2_lt_S1_t1_for_t1 : S1 .t₂ .t₁ < S1 .t₁ .t₁ := by
-  exact PMF.normalize_lt_of_apply_zero_pos _ _ _ _ _ _ _
-    (L0_apply_of_false (by decide : targetMatches .t₁ .t₂ ≠ true))
-    (L0_apply_ne_zero (by decide : targetMatches .t₁ .t₁ = true))
+/-! ### A worked Mixed-Stakes 20 Questions instance
 
-/-- L1 correctly identifies target from utterance. -/
-theorem L1_animal_identifies : L1 .t₁ .t₁ > L1 .t₁ .t₂ := by
-  unfold L1 worldPrior
-  rw [gt_iff_lt, PMF.posterior_lt_iff_kernel_lt_of_uniform]
-  exact S1_t2_lt_S1_t1_for_t1
+The binary core of the 20-Questions task: two candidate targets, a guess for
+each, and a perfectly-informative yes/no question. This is a positive
+witness — `worthAsking` is genuinely satisfiable, not vacuous — and shows the
+animal → medical transfer concretely. -/
 
-/-- Same prediction at "medical" stakes. -/
-theorem L1_medical_identifies : L1 .t₁ .t₁ > L1 .t₁ .t₂ :=
-  L1_animal_identifies
+/-- Correct-guess utility: `1` if the guessed action matches the target,
+else `0`. -/
+def correctnessUtility : Bool → Bool → ℝ≥0∞ := fun θ a => if a = θ then 1 else 0
 
-end DongEtAl2026.PMF
+/-- Uniform prior belief over the two targets. -/
+noncomputable def uniformBelief : PMF Bool := PMF.uniformOfFintype Bool
+
+/-- A perfectly-informative question: the answer reveals the target. -/
+noncomputable def revealingQuestion : Bool → PMF Bool := fun θ => PMF.pure θ
+
+theorem V_uniform : V correctnessUtility uniformBelief = 2⁻¹ := by
+  have hEU : ∀ a : Bool, EU correctnessUtility uniformBelief a = 2⁻¹ := by
+    intro a
+    unfold EU correctnessUtility uniformBelief
+    rw [tsum_fintype, Fintype.sum_bool]
+    simp only [PMF.uniformOfFintype_apply, Fintype.card_bool, Nat.cast_ofNat]
+    cases a <;> simp
+  unfold V
+  simp only [hEU, iSup_const]
+
+theorem Vpost_revealing :
+    Vpost correctnessUtility uniformBelief revealingQuestion = 1 := by
+  have hwpv : ∀ y : Bool,
+      weightedPosteriorValue correctnessUtility uniformBelief revealingQuestion y = 2⁻¹ := by
+    intro y
+    unfold weightedPosteriorValue correctnessUtility uniformBelief revealingQuestion
+    simp only [PMF.pure_apply, PMF.uniformOfFintype_apply, Fintype.card_bool, Nat.cast_ofNat,
+      tsum_fintype, Fintype.sum_bool, iSup_bool_eq]
+    cases y <;> simp
+  unfold Vpost
+  rw [tsum_fintype, Fintype.sum_bool, hwpv, hwpv, ENNReal.inv_two_add_inv_two]
+
+/-- A revealing question is worth asking at zero cost: its value of
+information is strictly positive (`Vpost = 1 > 2⁻¹ = V`). -/
+theorem revealing_worth_asking :
+    worthAsking 0 correctnessUtility uniformBelief revealingQuestion := by
+  rw [worthAsking, VoI, V_uniform, Vpost_revealing, tsub_pos_iff_lt]
+  exact ENNReal.inv_lt_one.mpr (by norm_num)
+
+/-- …and therefore worth asking at the high (medical) stakes too. -/
+theorem revealing_worth_asking_medical :
+    worthAsking 0 ((10 : ℝ≥0∞) • correctnessUtility) uniformBelief revealingQuestion :=
+  medical_worth_asking_of_animal 0 _ _ _ revealing_worth_asking
+
+end DongEtAl2026


### PR DESCRIPTION
The committed file formalized an RSA L0/S1/L1 chain, but @cite{dong-etal-2026} is a Value-of-Information clarify-or-commit decision model (no RSA chain, no α; stakes are central). Rewrite faithfully on the `PMF.posterior` substrate: VoI ≥ 0, stakes homogeneity, a worked 20-Questions witness, and an uninformative-question negative test.