### PR TITLE
refactor(Pronoun): add DemonstrativePronoun, rewrite PGG2017 truthfully

### DIFF
--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -4,6 +4,7 @@ import Linglib.Semantics.Presupposition.PhiFeatures
 import Linglib.Core.Logic.Intensional.Variables
 import Linglib.Core.Assignment
 import Linglib.Semantics.Dynamic.Effects.HasFiberedLookup
+import Linglib.Core.Nominal.Interpret
 
 /-!
 # The denotation of a pronoun
@@ -43,7 +44,7 @@ open Semantics.Presupposition.PhiFeatures
 open Semantics.Reference (NominalDenot)
 open Core (Assignment)
 open Core.Logic.Intensional (Frame)
-open Core.Logic.Intensional.Variables (interpPronoun)
+open Core.Logic.Intensional.Variables (interpPronoun DenotGS SitAssignment)
 
 /-- The conjoined φ-feature presupposition of a pronoun entry, over an entity
 domain `E`. The model supplies the entity-level predicates the cells need
@@ -119,3 +120,51 @@ example {F : Frame} [PartialOrder F.Entity] (g : Assignment F.Entity) (i : ℕ)
     ((ellas.denote i speaker addressee isFemale isInanimate).toPrProp scope g).presup ⟨⟩ := by
   refine ⟨⟨trivial, trivial, hFem⟩, ?_⟩
   rfl
+
+/-! ### Pronouns are definite descriptions (@cite{elbourne-2005}, @cite{patel-grosz-grosz-2017})
+
+The thesis that a pronoun *is* a (null-NP) definite description, and a
+demonstrative pronoun is that description plus a D_deix layer, is made concrete
+by routing pronoun denotation through `NominalKind`: a personal pronoun is the
+`.anaphoric` (Schwarz strong-article) definite, a demonstrative pronoun is the
+`.demonstrative` one — which the substrate already proves differ only by the
+deixis presupposition filter (`interpret_demonstrative_eq_anaphoric`). -/
+
+/-- A personal pronoun *is* a definite description: structurally the anaphoric
+(Schwarz strong-article) definite over its restrictor `R` (the φ-feature NP) at
+discourse index `i`. @cite{patel-grosz-grosz-2017}'s "pronoun = null NP + Ddet",
+as a `NominalKind`. -/
+def PersonalPronoun.toNominalKind {F : Frame} (_e : PersonalPronoun)
+    (R : DenotGS F .et) (i : ℕ) : Core.Nominal.NominalKind F :=
+  .anaphoric R i
+
+/-- A demonstrative pronoun is the same definite description plus the D_deix
+layer: `NominalKind.demonstrative` is `.anaphoric` with a deictic feature
+(@cite{patel-grosz-grosz-2017}: DEM = PER + deixis). -/
+def DemonstrativePronoun.toNominalKind {F : Frame} (p : DemonstrativePronoun)
+    (R : DenotGS F .et) (sIdx i : ℕ) : Core.Nominal.NominalKind F :=
+  .demonstrative R p.deictic sIdx i
+
+/-- DEM = PER + deixis at the referential level: erasing the deixis layer
+(`toPersonalPronoun`) leaves the same referent — the deictic feature is a
+presupposition filter, not a selector (@cite{patel-grosz-grosz-2017} §4). -/
+theorem DemonstrativePronoun.referent_eq_personal {F : Frame}
+    (p : DemonstrativePronoun) (R : DenotGS F .et) (sIdx i : ℕ)
+    (g : Assignment F.Entity) (gs : SitAssignment F) :
+    Core.Nominal.interpret (p.toNominalKind R sIdx i) g gs
+      = Core.Nominal.interpret (p.toPersonalPronoun.toNominalKind R i) g gs :=
+  Core.Nominal.interpret_demonstrative_eq_anaphoric R p.deictic sIdx i g gs
+
+/-- "Pronouns are definite descriptions," made precise: the pronoun's referent
+selector (`PersonalPronoun.denote`) coincides with the interpretation of its
+anaphoric-definite structure, whenever the restrictor (φ-features) holds of the
+indexed referent. -/
+theorem PersonalPronoun.denote_selector_eq_toNominalKind {F : Frame} [PartialOrder F.Entity]
+    (e : PersonalPronoun) (i : ℕ) (R : DenotGS F .et)
+    (speaker addressee : F.Entity) (isFemale isInanimate : F.Entity → Prop)
+    (g : Assignment F.Entity) (gs : SitAssignment F) (w : PUnit)
+    (h : R g gs (g i)) :
+    (e.denote i speaker addressee isFemale isInanimate).selector g w
+      = Core.Nominal.interpret (e.toNominalKind R i) g gs := by
+  simp [PersonalPronoun.denote, PersonalPronoun.toNominalKind,
+        Core.Nominal.interpret_anaphoric, interpPronoun, h]

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -1,552 +1,141 @@
-import Linglib.Core.Word
-import Linglib.Features.Definiteness
 import Linglib.Typology.Pronoun.Basic
 import Linglib.Core.Nominal.Determiner
-import Linglib.Phenomena.Anaphora.Coreference
 import Linglib.Fragments.German.Definiteness
-import Linglib.Phenomena.Reference.DirectReference
 
 /-!
 # Patel-Grosz & Grosz (2017): Revisiting Pronominal Typology
-@cite{patel-grosz-grosz-2017} @cite{cardinaletti-starke-1999} @cite{elbourne-2005}
-@cite{postal-1966} @cite{schwarz-2009} @cite{schwarz-2013} @cite{levshina-stoynova-2023}
+@cite{patel-grosz-grosz-2017} @cite{schwarz-2009} @cite{schwarz-2013}
+@cite{elbourne-2005} @cite{cardinaletti-starke-1999}
 
-@cite{patel-grosz-grosz-2017} (LI 48(2)) argue that 3rd-person pronouns split
-into two structural types:
+@cite{patel-grosz-grosz-2017} (LI 48(2)) argue, for German, that personal
+pronouns (PER: *er/sie/es*) and demonstrative pronouns (DEM: *der/die/das*) have
+the **same core makeup** — both a null NP plus a definite-determiner head (Ddet),
+i.e. both are definite descriptions — and that DEM merely **adds a D_deix
+layer**. The PER/DEM distribution then follows from **structural economy**
+(*Minimize DP!*): PER, being less structured, is the default; DEM is licensed
+only by an added pragmatic effect (emotivity §5.1, disambiguation §5.2,
+register §5.3).
 
-- **PER** (personal): D_det + NP (weak article only)
-- **DEM** (demonstrative): D_deix + D_det + NP (strong article)
+The paper's three contributions are made *true by construction* on substrate
+they motivated, rather than stipulated here:
 
-Minimize DP! makes PER the default; DEM requires pragmatic licensing
-(emotivity, disambiguation, register). The structural account builds directly
-on @cite{schwarz-2009}/@cite{schwarz-2013}'s weak/strong article typology
-(German's inventory is `Fragments/German/Definiteness.lean`); §F-§G below
-give the bridge.
+* **DEM = PER + deixis** is the type `DemonstrativePronoun extends
+  PersonalPronoun` (`Typology/Pronoun/Basic.lean`) — a demonstrative pronoun
+  structurally *contains* a personal pronoun, mirroring `Determiner.Demonstrative
+  extends Determiner`. So "DEM contains PER" is the `extends`, not a typological
+  universal asserted over invented data.
+* **Pronouns are definite descriptions** is
+  `PersonalPronoun.denote_selector_eq_toNominalKind`
+  (`Semantics/Reference/PronounDenotation.lean`): a pronoun's referent is the
+  `NominalKind.anaphoric` strong-article definite over its φ-feature restrictor.
+* The **two-article ↔ two-D-layer** correlation (§4) is read off the determiner
+  inventory (`Determiner.articleType`), not stipulated.
 
-## Key Claims
+## Implementation notes
 
-1. If a language has DEM pronouns, it also has PER pronouns (DEM ⊂ PER)
-2. DEM use requires pragmatic licensing (Minimize DP!)
-3. Article system predicts D-layer structure
-
-## Substrate consumed
-
-- `Pronoun.Strength` (Cardinaletti-Starke 1999) — three-way strength
-  enum (strong/weak/clitic), shared with `Studies/Ariel2001.lean`.
-
-## Gradient Component
-
-Following @cite{levshina-stoynova-2023} / `WordOrder/Gradience.lean`, we encode
-continuous measures of pronoun system complexity: inventory sizes, licensing
-context counts, and strength-level counts.
-
+The paper is German-focused (with Bavarian in §5.3 and passing mention of
+Portuguese/French/Hebrew). The earlier ~11-language `dLayers`/licensing table, a
+five-context licensing inventory, and a Finnish "counterexample" had no basis in
+the text and have been removed. *Minimize DP!* as a genuine node-count order
+(over `Pareto.lean`/`FeaturePreorder`) is left as a `Todo`; here the economy is
+recorded structurally (DEM carries the extra D_deix layer) and in prose.
 -/
 
 namespace PatelGroszGrosz2017
 
-open Phenomena.Anaphora.Coreference
+open Features.Definiteness (ArticleType)
 
-open Pronoun (Strength)
-open Features.Definiteness (ArticleType DefiniteUseType BridgingSubtype WeakArticleStrategy
-  useTypeToPresupType bridgingPresupType DefPresupType)
-
--- ============================================================================
--- §A: Inductive Types
--- ============================================================================
-
-/-- @cite{patel-grosz-grosz-2017}: structural classification of 3rd-person pronouns.
-
-PER pronouns project only D_det (weak article layer).
-DEM pronouns project D_deix + D_det (strong article layer). -/
-inductive PronounClass where
-  | per   -- Personal: D_det + NP (weak article only)
-  | dem   -- Demonstrative: D_deix + D_det + NP (strong article)
-  deriving DecidableEq, Repr
-
-/-- Pragmatic contexts that license DEM pronoun use (@cite{patel-grosz-grosz-2017} §3).
-
-Minimize DP! requires DEM to be pragmatically licensed. These are the
-five licensing contexts identified by PG&G. -/
+/-- The **three** pragmatic contexts that license a demonstrative pronoun in
+    German (@cite{patel-grosz-grosz-2017} §5): a positive pragmatic effect must
+    override the *Minimize DP!* preference for the less-structured PER. -/
 inductive DEMLicensingContext where
-  | emotivity       -- Emotional engagement with referent
-  | disambiguation  -- Multiple potential antecedents
-  | register        -- Colloquial/informal register
-  | deixis          -- Spatial/temporal pointing
-  | contrast        -- Contrastive topic/focus
+  /-- §5.1 Emotivity — the speaker expresses emotional engagement with the referent. -/
+  | emotivity
+  /-- §5.2 Disambiguation — DEM avoids the most prominent antecedent (anti-topicality). -/
+  | disambiguation
+  /-- §5.3 Register — colloquial/informal register. -/
+  | register
   deriving DecidableEq, Repr
 
--- ============================================================================
--- §B: Per-Language Datum Structure
--- ============================================================================
+/-! ### German pronoun inventory -/
 
-/-- A 3rd-person pronoun form in a language's inventory. -/
-structure PronounForm where
-  form : String
-  pronClass : PronounClass
-  gender : Option String := none  -- "m"/"f"/"n" or none
-  number : Option Number := none
-  strengths : List Strength := [.strong]
-  deriving Repr, BEq
+-- Personal pronouns (PER): the Ddet + null-NP core, no deixis layer.
+def er  : PersonalPronoun := { form := "er",  person := some .third, number := some .Sing, gender := some .masculine }
+def sie : PersonalPronoun := { form := "sie", person := some .third, number := some .Sing, gender := some .feminine }
+def es  : PersonalPronoun := { form := "es",  person := some .third, number := some .Sing, gender := some .neuter }
 
-/-- Per-language pronoun system datum (@cite{patel-grosz-grosz-2017} + @cite{cardinaletti-starke-1999}).
+-- Demonstrative pronouns (DEM): the PER core plus a D_deix layer.
+def der : DemonstrativePronoun := { form := "der", person := some .third, number := some .Sing, gender := some .masculine, deictic := .distal }
+def die : DemonstrativePronoun := { form := "die", person := some .third, number := some .Sing, gender := some .feminine,  deictic := .distal }
+def das : DemonstrativePronoun := { form := "das", person := some .third, number := some .Sing, gender := some .neuter,    deictic := .distal }
 
-Each datum records the full 3rd-person pronoun inventory, declared determiner
-set, D-layer count, DEM licensing contexts, and DEM productivity. The article
-system type (`articleType`) is *derived* from `determiners` rather than
-stipulated — the declared `Determiner.Entry` list is the single source of
-truth for definiteness data. -/
-structure PronounSystemDatum where
+/-- A language's 3rd-person pronoun system: its PER and DEM inventories, its
+    article inventory (the single source of truth for `articleType`), and the
+    pragmatic contexts licensing DEM. -/
+structure PronounSystem where
   language : String
-  isoCode : String
-  /-- Available 3rd-person pronoun forms -/
-  forms : List PronounForm
-  /-- Declared determiner set (single source of truth from which
-      `articleType` is derived). -/
+  personal : List PersonalPronoun
+  demonstrative : List DemonstrativePronoun
   determiners : List Determiner.Entry
-  /-- Number of D-layers: 1 = D_det only (PER), 2 = D_deix + D_det (PER+DEM) -/
-  dLayers : Nat
-  /-- Pragmatic contexts licensing DEM use (empty for PER-only languages) -/
-  demLicensing : List DEMLicensingContext
-  /-- Whether DEM pronouns are productive (freely usable) as 3rd-person reference -/
-  demProductive : Bool
+  licensing : List DEMLicensingContext
 
-/-- Schwarz/Patel-Grosz–Grosz `ArticleType` classification, derived from the
-    declared determiner set. Not stipulated — this is the projection through
-    `Determiner.articleType`. -/
-def PronounSystemDatum.articleType (d : PronounSystemDatum) : ArticleType :=
-  Determiner.articleType d.determiners
+namespace PronounSystem
 
--- ============================================================================
--- §C: Language Data (~11 languages from @cite{patel-grosz-grosz-2017})
--- ============================================================================
+/-- Number of D-layers, **derived**: a language with demonstrative pronouns
+    projects the D_deix layer (2); a PER-only language has one (Ddet only). -/
+def dLayers (s : PronounSystem) : Nat := if s.demonstrative.isEmpty then 1 else 2
 
-/-- Determiner-set shorthand: bipartite (German/Bavarian/Portuguese — distinct
-    weak vs strong articles, no syncretism). Derives `.weakAndStrong`. -/
-private def bipartiteDets : List Determiner.Entry :=
-  [ .article { form := "weak", definiteness := .definite, exponent := .dedicatedMorpheme,
-               uses := [.immediateSituation, .largerSituation] },
-    .article { form := "strong", definiteness := .definite, exponent := .dedicatedMorpheme,
-               uses := [.anaphoric, .donkey] },
-    .article { form := "indef", definiteness := .indefinite, exponent := .dedicatedMorpheme },
-    .demonstrative { form := "dem", deictic := .unspecified },
-    .possessive { form := "poss" } ]
+/-- The Schwarz `ArticleType`, **derived** from the determiner inventory. -/
+def articleType (s : PronounSystem) : ArticleType := Determiner.articleType s.determiners
 
-/-- Determiner-set shorthand: syncretic single article (English/Romance — *the*,
-    *le/la*, *il*, *el*, *o/a*, *ell*). Derives `.weakOnly` via
-    `.generallyMarked`. -/
-private def syncreticDets : List Determiner.Entry :=
-  [ .article { form := "the", definiteness := .definite, exponent := .dedicatedMorpheme,
-               uses := [.immediateSituation, .largerSituation, .anaphoric, .donkey] },
-    .article { form := "indef", definiteness := .indefinite, exponent := .dedicatedMorpheme },
-    .demonstrative { form := "dem", deictic := .unspecified },
-    .possessive { form := "poss" } ]
+end PronounSystem
 
-/-- Determiner-set shorthand: no overt articles (Hebrew/Czech/Finnish — no
-    article paradigm; the demonstrative is optional). Derives `.none_` via
-    `.unmarked`. -/
-private def noArticleDets : List Determiner.Entry :=
-  [ .demonstrative { form := "dem", deictic := .unspecified },
-    .possessive { form := "poss" } ]
+/-- German: PER *er/sie/es*, DEM *der/die/das*, weak/strong articles, all three
+    DEM-licensing contexts attested (@cite{patel-grosz-grosz-2017} §5). -/
+def german : PronounSystem :=
+  { language := "German"
+    personal := [er, sie, es]
+    demonstrative := [der, die, das]
+    determiners := German.Definiteness.determiners
+    licensing := [.emotivity, .disambiguation, .register] }
 
-/-- Determiner-set shorthand: weak only (Kutchi Gujarati — single postnominal
-    definite marker exponing only uniqueness, no separate anaphoric form).
-    Derives `.weakOnly` via `.generallyMarked`. -/
-private def weakOnlyDets : List Determiner.Entry :=
-  [ .article { form := "def", definiteness := .definite, exponent := .dedicatedMorpheme,
-               uses := [.immediateSituation, .largerSituation] },
-    .demonstrative { form := "dem", deictic := .unspecified },
-    .possessive { form := "poss" } ]
+/-! ### The three contributions, derived -/
 
-def germanData : PronounSystemDatum :=
-  { language := "German", isoCode := "de"
-    forms := [ ⟨"er",  .per, some "m", some .sg, [.strong, .weak]⟩
-             , ⟨"sie", .per, some "f", some .sg, [.strong, .weak]⟩
-             , ⟨"es",  .per, some "n", some .sg, [.strong, .weak]⟩
-             , ⟨"der", .dem, some "m", some .sg, [.strong]⟩
-             , ⟨"die", .dem, some "f", some .sg, [.strong]⟩
-             , ⟨"das", .dem, some "n", some .sg, [.strong]⟩ ]
-    determiners := bipartiteDets
-    dLayers := 2
-    demLicensing := [.emotivity, .disambiguation, .register, .deixis, .contrast]
-    demProductive := true }
+/-- **DEM = PER + deixis** (the core-makeup claim): every demonstrative pronoun
+    structurally contains a personal pronoun — true by the `extends`, not a
+    stipulated universal over a language sample. The φ-features (person/number/
+    gender) live on the shared PER core; the deixis is the only addition. -/
+theorem dem_contains_per (d : DemonstrativePronoun) :
+    d.toPersonalPronoun.person = d.person ∧ d.toPersonalPronoun.number = d.number :=
+  ⟨rfl, rfl⟩
 
-def bavarianData : PronounSystemDatum :=
-  { language := "Bavarian", isoCode := "bar"
-    forms := [ ⟨"er",  .per, some "m", some .sg, [.strong, .weak]⟩
-             , ⟨"sie", .per, some "f", some .sg, [.strong, .weak]⟩
-             , ⟨"es",  .per, some "n", some .sg, [.strong, .weak]⟩
-             , ⟨"der", .dem, some "m", some .sg, [.strong]⟩
-             , ⟨"die", .dem, some "f", some .sg, [.strong]⟩
-             , ⟨"des", .dem, some "n", some .sg, [.strong]⟩ ]
-    determiners := bipartiteDets
-    dLayers := 2
-    demLicensing := [.emotivity, .disambiguation, .register, .deixis, .contrast]
-    demProductive := true }
+/-- **Gender concord is uniform across PER and DEM** because gender is a feature
+    of the shared PER core, not of the deixis layer. This is the structural basis
+    for @cite{patel-grosz-grosz-2017} §3's corpus finding that gender mismatches
+    (a grammatically neuter noun like *Ehepaar* 'married couple' referred to by a
+    non-neuter pronoun) are *equally* available for PER and DEM — falsifying the
+    claim that demonstratives must match grammatical gender. -/
+theorem dem_gender_is_per_gender (d : DemonstrativePronoun) :
+    d.gender = d.toPersonalPronoun.gender := rfl
 
-def portugueseData : PronounSystemDatum :=
-  { language := "Portuguese", isoCode := "pt"
-    forms := [ ⟨"ele",    .per, some "m", some .sg, [.strong]⟩
-             , ⟨"ela",    .per, some "f", some .sg, [.strong]⟩
-             , ⟨"esse",   .dem, some "m", some .sg, [.strong]⟩
-             , ⟨"aquele", .dem, some "m", some .sg, [.strong]⟩ ]
-    determiners := bipartiteDets
-    dLayers := 2
-    demLicensing := [.deixis, .contrast]
-    demProductive := false }
+/-- German projects two D-layers — **derived** from the presence of DEM forms,
+    not stipulated as a `Nat`. -/
+theorem german_two_layers : german.dLayers = 2 := by decide
 
-def hebrewData : PronounSystemDatum :=
-  { language := "Hebrew", isoCode := "he"
-    forms := [ ⟨"hu", .per, some "m", some .sg, [.strong]⟩
-             , ⟨"hi", .per, some "f", some .sg, [.strong]⟩
-             , ⟨"ze", .dem, some "m", some .sg, [.strong]⟩
-             , ⟨"zo", .dem, some "f", some .sg, [.strong]⟩ ]
-    determiners := noArticleDets
-    dLayers := 2
-    demLicensing := [.deixis, .disambiguation]
-    demProductive := false }
+/-- German's article system is `.weakAndStrong` (two distinct article forms) —
+    derived from the determiner inventory, matching its two D-layers
+    (@cite{patel-grosz-grosz-2017} §4). -/
+theorem german_weakAndStrong : german.articleType = .weakAndStrong := by decide
 
-def czechData : PronounSystemDatum :=
-  { language := "Czech", isoCode := "cs"
-    forms := [ ⟨"on",  .per, some "m", some .sg, [.strong, .weak, .clitic]⟩
-             , ⟨"ona", .per, some "f", some .sg, [.strong, .weak, .clitic]⟩
-             , ⟨"ono", .per, some "n", some .sg, [.strong, .weak, .clitic]⟩
-             , ⟨"ten", .dem, some "m", some .sg, [.strong]⟩
-             , ⟨"ta",  .dem, some "f", some .sg, [.strong]⟩
-             , ⟨"to",  .dem, some "n", some .sg, [.strong]⟩ ]
-    determiners := noArticleDets
-    dLayers := 2
-    demLicensing := [.emotivity, .disambiguation, .contrast]
-    demProductive := false }
-
-def frenchData : PronounSystemDatum :=
-  { language := "French", isoCode := "fr"
-    forms := [ ⟨"il",   .per, some "m", some .sg, [.strong, .weak, .clitic]⟩
-             , ⟨"elle", .per, some "f", some .sg, [.strong, .weak, .clitic]⟩ ]
-    determiners := syncreticDets
-    dLayers := 1
-    demLicensing := []
-    demProductive := false }
-
-def italianData : PronounSystemDatum :=
-  { language := "Italian", isoCode := "it"
-    forms := [ ⟨"lui", .per, some "m", some .sg, [.strong, .weak, .clitic]⟩
-             , ⟨"lei", .per, some "f", some .sg, [.strong, .weak, .clitic]⟩ ]
-    determiners := syncreticDets
-    dLayers := 1
-    demLicensing := []
-    demProductive := false }
-
-def spanishData : PronounSystemDatum :=
-  { language := "Spanish", isoCode := "es"
-    forms := [ ⟨"él",   .per, some "m", some .sg, [.strong, .weak, .clitic]⟩
-             , ⟨"ella", .per, some "f", some .sg, [.strong, .weak, .clitic]⟩ ]
-    determiners := syncreticDets
-    dLayers := 1
-    demLicensing := []
-    demProductive := false }
-
-def catalanData : PronounSystemDatum :=
-  { language := "Catalan", isoCode := "ca"
-    forms := [ ⟨"ell",  .per, some "m", some .sg, [.strong, .weak, .clitic]⟩
-             , ⟨"ella", .per, some "f", some .sg, [.strong, .weak, .clitic]⟩ ]
-    determiners := syncreticDets
-    dLayers := 1
-    demLicensing := []
-    demProductive := false }
-
-def kutchiGujaratiData : PronounSystemDatum :=
-  { language := "Kutchi Gujarati", isoCode := "gju"
-    forms := [ ⟨"a",  .per, none, some .sg, [.strong]⟩
-             , ⟨"ā",  .per, none, some .pl, [.strong]⟩ ]
-    determiners := weakOnlyDets
-    dLayers := 1
-    demLicensing := []
-    demProductive := false }
-
-def englishData : PronounSystemDatum :=
-  { language := "English", isoCode := "en"
-    forms := [ ⟨"he",  .per, some "m", some .sg, [.strong]⟩
-             , ⟨"she", .per, some "f", some .sg, [.strong]⟩
-             , ⟨"it",  .per, some "n", some .sg, [.strong]⟩ ]
-    determiners := syncreticDets
-    dLayers := 1
-    demLicensing := []
-    demProductive := false }
-
-/-- All 11 languages from @cite{patel-grosz-grosz-2017} survey. -/
-def allData : List PronounSystemDatum :=
-  [ germanData, bavarianData, portugueseData, hebrewData, czechData
-  , frenchData, italianData, spanishData, catalanData, kutchiGujaratiData
-  , englishData ]
-
-theorem allData_count : allData.length = 11 := by decide
-
-/-- Finnish: "hän" (3sg human, PER, no gender), "he" (3pl human, PER),
-    "se" (3sg non-human / DEM), "tämä" (proximal DEM), "tuo" (distal DEM).
-    No articles. "se" is productively used as 3rd-person reference in
-    colloquial Finnish.
-    Not part of @cite{patel-grosz-grosz-2017} sample — a counterexample to the article-DEM
-    productivity correlation (2 D-layers, productive DEM, but no articles). -/
-def finnishData : PronounSystemDatum :=
-  { language := "Finnish", isoCode := "fi"
-    forms := [ ⟨"hän",  .per, none, some .sg, [.strong]⟩
-             , ⟨"he",   .per, none, some .pl, [.strong]⟩
-             , ⟨"se",   .dem, none, some .sg, [.strong]⟩
-             , ⟨"tämä", .dem, none, some .sg, [.strong]⟩
-             , ⟨"tuo",  .dem, none, some .sg, [.strong]⟩ ]
-    determiners := noArticleDets
-    dLayers := 2
-    demLicensing := [.deixis, .contrast]
-    demProductive := true }
-
--- ============================================================================
--- §D: Gradient Measures (following WordOrder/Gradience.lean pattern)
--- ============================================================================
-
-/-- Gradient pronoun system profile, analogous to `GradientWOProfile`.
-
-Captures continuous variation in pronoun system complexity across languages. -/
-structure PronounComplexityProfile where
-  name : String
-  isoCode : String
-  /-- Number of distinct PER pronoun forms -/
-  perInventory : Nat
-  /-- Number of distinct DEM pronoun forms usable as pronouns -/
-  demInventory : Nat
-  /-- Number of pragmatic contexts licensing DEM use (0–5 scale) -/
-  demLicensingCount : Nat
-  /-- Pronoun strength levels available: 1=strong only, 2=strong+weak, 3=strong+weak+clitic -/
-  strengthLevels : Nat
-  deriving Repr, DecidableEq
-
-/-- Compute gradient profile from a `PronounSystemDatum`. -/
-def PronounSystemDatum.toProfile (d : PronounSystemDatum) : PronounComplexityProfile :=
-  let perForms := d.forms.filter (·.pronClass == .per)
-  let demForms := d.forms.filter (·.pronClass == .dem)
-  let allStrengths : List Strength := d.forms.flatMap (·.strengths)
-  let hasClitic : Bool := allStrengths.any (· == .clitic)
-  let hasWeak : Bool := allStrengths.any (· == .weak)
-  let levels := 1 + (if hasWeak then 1 else 0) + (if hasClitic then 1 else 0)
-  { name := d.language
-    isoCode := d.isoCode
-    perInventory := perForms.length
-    demInventory := demForms.length
-    demLicensingCount := d.demLicensing.length
-    strengthLevels := levels }
-
-def germanProfile : PronounComplexityProfile := germanData.toProfile
-def bavarianProfile : PronounComplexityProfile := bavarianData.toProfile
-def portugueseProfile : PronounComplexityProfile := portugueseData.toProfile
-def hebrewProfile : PronounComplexityProfile := hebrewData.toProfile
-def czechProfile : PronounComplexityProfile := czechData.toProfile
-def frenchProfile : PronounComplexityProfile := frenchData.toProfile
-def italianProfile : PronounComplexityProfile := italianData.toProfile
-def spanishProfile : PronounComplexityProfile := spanishData.toProfile
-def catalanProfile : PronounComplexityProfile := catalanData.toProfile
-def kutchiGujaratiProfile : PronounComplexityProfile := kutchiGujaratiData.toProfile
-def englishProfile : PronounComplexityProfile := englishData.toProfile
-
-/-- All 11 gradient pronoun system profiles. -/
-def allProfiles : List PronounComplexityProfile :=
-  [ germanProfile, bavarianProfile, portugueseProfile, hebrewProfile, czechProfile
-  , frenchProfile, italianProfile, spanishProfile, catalanProfile
-  , kutchiGujaratiProfile, englishProfile ]
-
-theorem allProfiles_count : allProfiles.length = 11 := by decide
-
-def finnishProfile : PronounComplexityProfile := finnishData.toProfile
-
-/-- Finnish has productive DEM with no articles — a counterexample to the
-    PG&G sample's dem_productivity_from_article_system generalization. -/
-theorem finnish_counterexample_to_article_dem :
-    finnishData.dLayers == 2 ∧ finnishData.demProductive ∧
-    finnishData.articleType == .none_ := by decide
-
--- ============================================================================
--- §E: Verified Generalizations
--- ============================================================================
-
-/-! ### PG&G Core Claims -/
-
-/-- **Minimize DP!** (@cite{patel-grosz-grosz-2017} §3): Languages where DEM is productive
-all require pragmatic licensing (demLicensing is non-empty).
-
-DEM is the marked choice; PER is the default. -/
-theorem minimize_dp :
-    (allData.filter (·.demProductive)).all
-      (·.demLicensing.length > 0) = true := by decide
-
-/-- **Implicational universal**: If DEM exists in a language's inventory,
-PER also exists. No language has DEM without PER.
-
-This follows from PG&G's structural claim: DEM = D_deix + D_det + NP,
-where D_det is the PER layer. DEM presupposes PER structurally. -/
-theorem dem_implies_per :
-    allData.all (λ d =>
-      if d.forms.any (·.pronClass == .dem)
-      then d.forms.any (·.pronClass == .per)
-      else true) = true := by decide
-
-/-- **Article-D-layer correlation** (@cite{schwarz-2009} → PG&G):
-Languages with both weak and strong articles have 2 D-layers. -/
-theorem strong_article_two_layers :
-    (allData.filter (·.articleType == .weakAndStrong)).all
-      (·.dLayers == 2) = true := by decide
-
-/-- PER-only languages (1 D-layer) have only weak or no articles.
-The converse of `strong_article_two_layers`. -/
-theorem one_layer_no_strong_articles :
-    (allData.filter (·.dLayers == 1)).all
-      (·.articleType != .weakAndStrong) = true := by decide
-
-/-! ### Gradient Claims -/
-
-/-- **PER inventory is continuous**: ranges from 2 (Kutchi Gujarati)
-to 3 (most languages with m/f/n), not a binary split. -/
-theorem per_inventory_range :
-    kutchiGujaratiProfile.perInventory = 2 ∧
-    germanProfile.perInventory = 3 ∧
-    allProfiles.all (·.perInventory ≥ 2) = true := by decide
-
-/-- **DEM inventory correlates with article system**: languages with
-weakAndStrong articles have non-zero DEM inventory. -/
-theorem strong_articles_have_dem_forms :
-    (allData.filter (·.articleType == .weakAndStrong)).all
-      (λ d => (d.forms.filter (·.pronClass == .dem)).length > 0) = true := by decide
-
-/-- **Strength levels vary**: Romance languages (French, Italian, Spanish, Catalan)
-have 3 strength levels (strong+weak+clitic), while Germanic typically has 2. -/
-theorem romance_three_strength_levels :
-    let romance := [frenchProfile, italianProfile, spanishProfile, catalanProfile]
-    romance.all (·.strengthLevels == 3) = true := by decide
-
-/-- Germanic languages with DEM (German, Bavarian) have 2 strength levels. -/
-theorem germanic_two_strength_levels :
-    let germanic := [germanProfile, bavarianProfile]
-    germanic.all (·.strengthLevels == 2) = true := by decide
-
-/-- DEM licensing count ranges from 0 to 5, forming a continuum
-rather than a binary productive/non-productive distinction. -/
-theorem dem_licensing_is_gradient :
-    englishProfile.demLicensingCount = 0 ∧
-    germanProfile.demLicensingCount = 5 ∧
-    allProfiles.any (·.demLicensingCount == 2) = true ∧
-    allProfiles.any (·.demLicensingCount == 3) = true := by decide
-
-/-! ### Open Problem -/
-
-/-- **DEM productivity tracks overt strong articles** (pattern in PG&G data):
-
-Among 2-layer languages, only those with overt weak+strong article
-morphology (German, Bavarian) have productive DEM. Languages with
-2 D-layers but no overt articles (Hebrew, Czech) or limited article
-systems restrict DEM.
-
-@cite{schwarz-2013} §5.5 provides the theoretical link: the strong article
-conventionalizes the D_deix layer, making DEM pronouns (which also
-project D_deix) more accessible. Without overt strong articles, D_deix
-is available syntactically but not conventionalized for reference tracking.
-
-Open question: *why* does article-system conventionalization affect pronoun
-productivity? PG&G suggest familiarity/frequency; @cite{schwarz-2013} suggests
-the strong article's anaphoric function naturally extends to pronominal use. -/
-theorem dem_productivity_from_article_system :
-    (allData.filter (λ d => d.dLayers == 2 ∧ d.demProductive)).all
-      (·.articleType == .weakAndStrong) = true := by decide
-
--- ============================================================================
--- §F: Bridge to @cite{schwarz-2013} (chronologically-prior article typology)
--- ============================================================================
-
-/-! ### Schwarz article types ↔ PG&G pronoun D-layers
-
-@cite{schwarz-2013} §5.5 explicitly connects the article contrast to
-pronouns: "pronouns are definite articles without overt NP". German
-d-pronouns (*der*/*die*/*das*) are identical to strong articles. The
-pronominal domain shows parallel contrasts.
-
-Structural mapping:
-- Schwarz weak article = PG&G D_det layer = PER pronoun
-- Schwarz strong article = PG&G D_deix + D_det = DEM pronoun
-
-Each weak/strong article inventory lives in its language's
-`Fragments/{Lang}/Definiteness.lean` (German, Fering, Akan, Lakhota, Hausa,
-Mauritian/Haitian Creole). -/
-
-/-- Languages with two overt article forms in @cite{schwarz-2013} correspond
-    to 2-D-layer languages in @cite{patel-grosz-grosz-2017}. Verified for
-    German, which appears in both datasets: German's inventory derives the
-    `.bipartite` cell (two distinct articles, *vom* weak / *dem* strong); PG&G
-    code German as 2-D-layer with the `weakAndStrong` article type. -/
+/-- The @cite{schwarz-2009}/@cite{schwarz-2013} weak/strong article typology meets
+    @cite{patel-grosz-grosz-2017}'s D-layer count: German's two distinct article
+    forms (which derive `.bipartite`) correspond to its two D-layers and the
+    `.weakAndStrong` article type. All three facts are derived from the German
+    determiner inventory + the DEM forms, not stipulated. -/
 theorem schwarz_pgg_german_consistent :
     Determiner.markingStrategy German.Definiteness.determiners = .bipartite ∧
-    germanData.dLayers == 2 ∧
-    germanData.articleType == .weakAndStrong :=
+    german.dLayers = 2 ∧
+    german.articleType = .weakAndStrong :=
   ⟨German.Definiteness.marking, by decide⟩
-
--- ============================================================================
--- §G: Bridges
--- ============================================================================
-
-/-! ### Bridge 1: PronounClass ↔ AnaphorType (Coreference.lean) -/
-
-/-- PER pronouns correspond to `AnaphorType.pronoun` in Coreference.lean.
-DEM pronouns have no direct AnaphorType counterpart — they are structurally
-richer than simple pronouns but not descriptions either. -/
-def pronClassToAnaphorType : PronounClass → AnaphorType
-  | .per => .pronoun
-  | .dem => .pronoun  -- DEM is a subtype of pronoun in binding theory
-
-/-- All PER forms map to the pronoun binding pattern (Principle B domain). -/
-theorem per_is_pronoun_binding :
-    pronClassToAnaphorType .per = .pronoun := rfl
-
-/-! ### Bridge 2: DEM pronouns ↔ Kaplan-style true demonstratives
-
-DEM pronouns require D_deix — the same structural layer that hosts
-Kaplan's demonstration. True demonstratives in `Demonstratives.lean`
-have a `Demonstration` component; DEM pronouns require D_deix licensing.
-
-The connection: D_deix is the syntactic home of the demonstration.
-PER pronouns lack D_deix, so they cannot be true demonstratives. -/
-
-/-- DEM pronouns require D_deix (dLayers = 2), which is the structural
-position for Kaplan's demonstration. PER-only languages (dLayers = 1)
-cannot have true demonstrative pronouns. -/
-theorem dem_requires_deixis_layer :
-    allData.all (λ d =>
-      if d.forms.any (·.pronClass == .dem)
-      then d.dLayers == 2
-      else true) = true := by decide
-
-/-! ### Bridge 3: PER pronouns ↔ Direct Reference
-
-PER pronouns are directly referential in Kaplan's sense: they
-contribute their referent to the proposition, with no descriptive
-content (no D_deix, no demonstration, no descriptive component).
-
-This connects to `DirectReference.lean`'s modal argument: PER
-pronouns, like names, are rigid designators. DEM pronouns may
-involve a descriptive/deictic component (D_deix), making them
-potentially non-rigid under some analyses. -/
-
-/-- PER-only languages have no descriptive D-layer: all forms are
-directly referential (rigid designators). -/
-theorem per_only_directly_referential :
-    (allData.filter (·.dLayers == 1)).all
-      (λ d => d.forms.all (·.pronClass == .per)) = true := by decide
-
-/-! ### Bridge 4: Article system ↔ D-layer count
-
-@cite{schwarz-2009} establishes that the weak/strong article distinction
-is structurally real (D_det vs D_deix + D_det). PG&G build on this:
-languages with both article types have the structural space for DEM. -/
-
-/-- No-article languages with DEM (Hebrew, Czech) show that D-layers
-can exist without overt article morphology. The D_deix layer is
-present in the syntax even without morphological exponence. -/
-theorem covert_deixis_layer :
-    (allData.filter (λ d => d.articleType == .none_ ∧ d.dLayers == 2)).length > 0 := by
-  decide
 
 end PatelGroszGrosz2017

--- a/Linglib/Typology/Pronoun/Basic.lean
+++ b/Linglib/Typology/Pronoun/Basic.lean
@@ -3,6 +3,7 @@ import Linglib.Features.Case
 import Linglib.Features.Register
 import Linglib.Features.Prominence
 import Linglib.Features.Gender
+import Linglib.Features.Deixis
 
 /-!
 # Pronoun
@@ -78,6 +79,19 @@ structure PersonalPronoun extends Pronoun where
       referential person coincides with formal person.
       @cite{adamson-zompi-2025} -/
   referentialPerson : Option Features.Prominence.PersonLevel := none
+  deriving Repr, BEq
+
+/-- A *demonstrative* pronoun (German *der/die/das*, Bavarian *de/dia*): a
+personal pronoun plus a D_deix layer. @cite{patel-grosz-grosz-2017}'s central
+thesis — DEM = PER + deixis — is *literally* this one `extends` and one field,
+the same move as `Determiner.Demonstrative extends Determiner` and sharing the
+same `Features.Deixis.Feature`. Because the PER core is recovered by
+`.toPersonalPronoun`, "a demonstrative pronoun structurally contains a personal
+pronoun" is true by construction, not a stipulated typological universal. -/
+structure DemonstrativePronoun extends PersonalPronoun where
+  /-- The D_deix feature (proximal/medial/distal/unspecified), shared with
+      `Determiner.Demonstrative` and `NominalKind.demonstrative`. -/
+  deictic : Features.Deixis.Feature := .unspecified
   deriving Repr, BEq
 
 namespace Pronoun


### PR DESCRIPTION
Adds `DemonstrativePronoun extends PersonalPronoun` (DEM = PER + deixis, mirroring `Determiner.Demonstrative`) and routes pronoun denotation through `NominalKind` — making @cite{patel-grosz-grosz-2017}'s theses (DEM contains PER; pronouns ARE definite descriptions) true by construction. Rewrites `Studies/PatelGroszGrosz2017.lean` truthfully: the paper is a German case study, so the prior ~11-language survey, 5-context licensing, and Finnish "counterexample" (all fabricated) are removed; the three real contributions (DEM=PER+deixis, pronoun-as-definite-description, two-article↔two-D-layer) now derive (552 → ~135 lines).