### PR TITLE
feat(Typology/Color): derive profiles from WALS + IB efficiency study

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1434,6 +1434,7 @@ import Linglib.Phenomena.Iconicity.Basic
 import Linglib.Studies.SchlenkerEtAl2026
 import Linglib.Studies.MajidBosterBowerman2008
 import Linglib.Studies.ZaslavskyEtAl2019
+import Linglib.Studies.ZaslavskyKempRegierTishby2018
 import Linglib.Studies.BeaversKoontzGarboden2020
 import Linglib.Studies.Lucy1994
 import Linglib.Phenomena.Islands.MannerOfSpeaking

--- a/Linglib/Fragments/English/Color.lean
+++ b/Linglib/Fragments/English/Color.lean
@@ -8,14 +8,9 @@ import Linglib.Typology.Color
 namespace English
 
 /-- English: 6 non-derived basic color categories, 11 total basic colors
-    (Berlin-Kay maximum); green vs blue distinct; red vs yellow distinct. -/
+    (Berlin-Kay maximum); green vs blue distinct; red vs yellow distinct.
+    Derived from the WALS Chs 132–135 rows for `eng`. -/
 def colorProfile : Typology.ColorProfile :=
-  { language := "English"
-  , iso := "eng"
-  , family := "Indo-European"
-  , nonDerived := some .six
-  , basic := some .v11
-  , greenBlue := some .distinct
-  , redYellow := some .distinct }
+  Typology.ColorProfile.fromWALS "English" "eng" "Indo-European"
 
 end English

--- a/Linglib/Fragments/French/Color.lean
+++ b/Linglib/Fragments/French/Color.lean
@@ -8,14 +8,9 @@ import Linglib.Typology.Color
 namespace French
 
 /-- French: 6 non-derived basic colors, 11 total basic colors; green (*vert*)
-    vs blue (*bleu*) distinct; red vs yellow distinct. -/
+    vs blue (*bleu*) distinct; red vs yellow distinct.
+    Derived from the WALS Chs 132–135 rows for `fra`. -/
 def colorProfile : Typology.ColorProfile :=
-  { language := "French"
-  , iso := "fra"
-  , family := "Indo-European"
-  , nonDerived := some .six
-  , basic := some .v11
-  , greenBlue := some .distinct
-  , redYellow := some .distinct }
+  Typology.ColorProfile.fromWALS "French" "fra" "Indo-European"
 
 end French

--- a/Linglib/Fragments/German/Color.lean
+++ b/Linglib/Fragments/German/Color.lean
@@ -8,14 +8,9 @@ import Linglib.Typology.Color
 namespace German
 
 /-- German: 6 non-derived basic colors, 11 total basic colors; green (*grün*)
-    vs blue (*blau*) distinct; red vs yellow distinct. -/
+    vs blue (*blau*) distinct; red vs yellow distinct.
+    Derived from the WALS Chs 132–135 rows for `deu`. -/
 def colorProfile : Typology.ColorProfile :=
-  { language := "German"
-  , iso := "deu"
-  , family := "Indo-European"
-  , nonDerived := some .six
-  , basic := some .v11
-  , greenBlue := some .distinct
-  , redYellow := some .distinct }
+  Typology.ColorProfile.fromWALS "German" "deu" "Indo-European"
 
 end German

--- a/Linglib/Fragments/Japanese/Color.lean
+++ b/Linglib/Fragments/Japanese/Color.lean
@@ -11,14 +11,9 @@ namespace Japanese
     (*midori*) vs blue (*ao*) distinct in modern Japanese (though *ao*
     historically covered both — the classic Japanese green-blue case in
     the linguistic-relativity literature); red (*aka*) vs yellow (*kiiro*)
-    distinct. -/
+    distinct.
+    Derived from the WALS Chs 132–135 rows for `jpn`. -/
 def colorProfile : Typology.ColorProfile :=
-  { language := "Japanese"
-  , iso := "jpn"
-  , family := "Japonic"
-  , nonDerived := some .six
-  , basic := some .v11
-  , greenBlue := some .distinct
-  , redYellow := some .distinct }
+  Typology.ColorProfile.fromWALS "Japanese" "jpn" "Japonic"
 
 end Japanese

--- a/Linglib/Fragments/Korean/Color.lean
+++ b/Linglib/Fragments/Korean/Color.lean
@@ -8,14 +8,9 @@ import Linglib.Typology.Color
 namespace Korean
 
 /-- Korean: 6 non-derived basic colors, 11 total basic colors; green vs blue
-    distinct; red vs yellow distinct. -/
+    distinct; red vs yellow distinct.
+    Derived from the WALS Chs 132–135 rows for `kor`. -/
 def colorProfile : Typology.ColorProfile :=
-  { language := "Korean"
-  , iso := "kor"
-  , family := "Koreanic"
-  , nonDerived := some .six
-  , basic := some .v11
-  , greenBlue := some .distinct
-  , redYellow := some .distinct }
+  Typology.ColorProfile.fromWALS "Korean" "kor" "Koreanic"
 
 end Korean

--- a/Linglib/Fragments/Mandarin/Color.lean
+++ b/Linglib/Fragments/Mandarin/Color.lean
@@ -9,14 +9,9 @@ namespace Mandarin
 
 /-- Mandarin Chinese: 6 non-derived basic colors, 8–8.5 total basic colors;
     green (*lü*) vs blue (*lan*) distinct; red (*hong*) vs yellow (*huang*)
-    distinct. -/
+    distinct.
+    Derived from the WALS Chs 132–135 rows for `cmn`. -/
 def colorProfile : Typology.ColorProfile :=
-  { language := "Mandarin Chinese"
-  , iso := "cmn"
-  , family := "Sino-Tibetan"
-  , nonDerived := some .six
-  , basic := some .v8to8h
-  , greenBlue := some .distinct
-  , redYellow := some .distinct }
+  Typology.ColorProfile.fromWALS "Mandarin Chinese" "cmn" "Sino-Tibetan"
 
 end Mandarin

--- a/Linglib/Fragments/Slavic/Russian/Color.lean
+++ b/Linglib/Fragments/Slavic/Russian/Color.lean
@@ -10,14 +10,9 @@ namespace Russian
 /-- Russian: 6 non-derived basic colors, 11 total basic colors (famously
     distinguishes *sinij* 'dark blue' from *goluboj* 'light blue', but WALS
     counts both within the basic-color count); green (*zelenyj*) vs blue
-    (*sinij*) distinct; red vs yellow distinct. -/
+    (*sinij*) distinct; red vs yellow distinct.
+    Derived from the WALS Chs 132–135 rows for `rus`. -/
 def colorProfile : Typology.ColorProfile :=
-  { language := "Russian"
-  , iso := "rus"
-  , family := "Indo-European"
-  , nonDerived := some .six
-  , basic := some .v11
-  , greenBlue := some .distinct
-  , redYellow := some .distinct }
+  Typology.ColorProfile.fromWALS "Russian" "rus" "Indo-European"
 
 end Russian

--- a/Linglib/Fragments/Spanish/Color.lean
+++ b/Linglib/Fragments/Spanish/Color.lean
@@ -8,14 +8,9 @@ import Linglib.Typology.Color
 namespace Spanish
 
 /-- Spanish: 6 non-derived basic colors, 11 total basic colors; green (*verde*)
-    vs blue (*azul*) distinct; red vs yellow distinct. -/
+    vs blue (*azul*) distinct; red vs yellow distinct.
+    Derived from the WALS Chs 132–135 rows for `spa`. -/
 def colorProfile : Typology.ColorProfile :=
-  { language := "Spanish"
-  , iso := "spa"
-  , family := "Indo-European"
-  , nonDerived := some .six
-  , basic := some .v11
-  , greenBlue := some .distinct
-  , redYellow := some .distinct }
+  Typology.ColorProfile.fromWALS "Spanish" "spa" "Indo-European"
 
 end Spanish

--- a/Linglib/Studies/ZaslavskyKempRegierTishby2018.lean
+++ b/Linglib/Studies/ZaslavskyKempRegierTishby2018.lean
@@ -1,0 +1,146 @@
+import Linglib.Pragmatics.Efficiency
+import Linglib.Fragments.English.Color
+import Linglib.Fragments.French.Color
+import Linglib.Fragments.German.Color
+import Linglib.Fragments.Japanese.Color
+import Linglib.Fragments.Korean.Color
+import Linglib.Fragments.Mandarin.Color
+import Linglib.Fragments.Spanish.Color
+import Linglib.Fragments.Slavic.Russian.Color
+
+/-!
+# Zaslavsky, Kemp, Regier & Tishby (2018): efficient compression in color naming
+@cite{zaslavsky-kemp-regier-tishby-2018} @cite{berlin-kay-1969} @cite{wals-2013}
+
+@cite{zaslavsky-kemp-regier-tishby-2018} argue that color-naming systems
+efficiently compress meanings into words by optimizing the Information
+Bottleneck (IB) trade-off between lexicon **complexity** (the information rate
+`I(M;W)`) and **accuracy** (`I(W;U)`). Cross-language variation is captured by a
+single trade-off parameter β, and the Berlin & Kay evolutionary sequence
+(@cite{berlin-kay-1969}: dark/light, then red, then green/yellow, then blue, …)
+falls out as motion *up the complexity axis* — successive systems carve color
+space more finely, paying complexity for accuracy.
+
+This file is the consumer that makes the per-language WALS color profiles
+(`Fragments/{Lang}/Color.lean`, typed by `Typology.ColorProfile`) observable
+through the efficient-communication framework in `Pragmatics.Efficiency`
+(`CostPair`, `weightedCost = cost₂ + β·cost₁`, `efficiencyLossAt`).
+
+## What is derived vs. cited
+
+* **Derived** (from the WALS-sourced Fragment profiles): the Berlin-Kay
+  *complexity coordinate* of each sampled language — the number of basic color
+  categories (WALS Ch 133). The IB complexity `I(M;W)` of a deterministic
+  K-word system is bounded by `log K`, so the category count is a monotone
+  *handle* on the complexity axis (not `I(M;W)` itself).
+* **Bridge** (via `Pragmatics.Efficiency`): the β-scalarized IB objective
+  `weightedCost` is monotone in this complexity coordinate, so the Berlin-Kay
+  category ordering is exactly an ordering on the IB complexity axis.
+* **Cited stimulus** (from the paper, not formalized): real languages are
+  *near*-optimal — they lie close to the IB curve with small efficiency loss
+  `ε_l`, at a fitted `β_l ≳ 1` (e.g. English `β_l ≈ 1.085`, Fig. 4). The
+  formal anchor here is only the idealized optimum (zero loss at coincidence);
+  the empirical near-optimality is the paper's measured result.
+
+## Main results
+
+* `bk_complexity_strictMono`: the category-count handle is strictly monotone in
+  the WALS Ch 133 ordering (the Berlin-Kay sequence).
+* `weightedCost_mono_in_complexity`: more categories ⇒ higher β-scalarized IB
+  complexity cost, for every β ≥ 0 — the structural bridge.
+* `sample_all_warm_and_cool_split`: every sampled language distinguishes both
+  red/yellow and green/blue (all are high-complexity, late-sequence systems).
+-/
+
+namespace ZaslavskyKempRegierTishby2018
+
+open Typology Pragmatics.Efficiency
+
+/-! ### The Berlin-Kay complexity coordinate -/
+
+/-- A representative basic-category count for each WALS Ch 133 bucket (its lower
+    bound). Only the *ordering* matters: this is a monotone handle on the IB
+    complexity axis `I(M;W) ≤ log K`, where `K` is the number of color words. -/
+def basicCount : BasicColorCount → ℕ
+  | .v3to4  => 3
+  | .v4to5  => 4
+  | .v6to6h => 6
+  | .v7to7h => 7
+  | .v8to8h => 8
+  | .v9to10 => 9
+  | .v11    => 11
+
+/-- IB complexity handle for a color profile: its basic-category count
+    (`0` when WALS records no Ch 133 datum). -/
+def ibComplexity (p : ColorProfile) : ℕ := (p.basic.map basicCount).getD 0
+
+/-- The category-count handle is strictly monotone along the WALS Ch 133
+    ordering — i.e. along the Berlin & Kay evolutionary sequence
+    (@cite{berlin-kay-1969}). -/
+theorem bk_complexity_strictMono :
+    basicCount .v3to4 < basicCount .v4to5 ∧
+    basicCount .v4to5 < basicCount .v6to6h ∧
+    basicCount .v6to6h < basicCount .v7to7h ∧
+    basicCount .v7to7h < basicCount .v8to8h ∧
+    basicCount .v8to8h < basicCount .v9to10 ∧
+    basicCount .v9to10 < basicCount .v11 := by decide
+
+/-! ### Bridge to the Information-Bottleneck objective -/
+
+/-- A color system as a `Pragmatics.Efficiency.CostPair`: `cost₁` is the IB
+    complexity handle (category count), `cost₂` is the system's accuracy/
+    distortion component, left abstract (WALS does not record it per language). -/
+def ibCost (p : ColorProfile) (acc : ℝ) : CostPair :=
+  { cost₁ := (ibComplexity p : ℝ), cost₂ := acc }
+
+/-- **Structural bridge.** Under the β-scalarized IB objective `weightedCost`,
+    a system with more basic categories has at least as high a complexity cost,
+    for every β ≥ 0 and any fixed accuracy. The Berlin-Kay category ordering is
+    therefore an ordering on the IB complexity axis the paper plots. -/
+theorem weightedCost_mono_in_complexity
+    {p q : ColorProfile} (acc β : ℝ) (hβ : 0 ≤ β)
+    (h : ibComplexity p ≤ ibComplexity q) :
+    weightedCost (ibCost p acc) β ≤ weightedCost (ibCost q acc) β := by
+  have hc : (ibComplexity p : ℝ) ≤ (ibComplexity q : ℝ) := by exact_mod_cast h
+  have := mul_le_mul_of_nonneg_left hc hβ
+  simp only [weightedCost, ibCost]
+  linarith
+
+/-- The idealized anchor of the paper's near-optimality finding: a color system
+    that coincides with the IB-optimal system at its fitted β has zero
+    efficiency loss. Real languages are *near*-optimal (small nonzero `ε_l`),
+    which is the paper's measured result rather than a theorem here. -/
+theorem optimal_system_zero_loss (c : CostPair) (β : ℝ) :
+    efficiencyLossAt c c β = 0 := efficiencyLossAt_self c β
+
+/-! ### The Fragment sample -/
+
+/-- The eight WALS-sourced color profiles formalized as Fragments. All are
+    industrialized-language systems near the top of the Berlin & Kay sequence. -/
+def sample : List ColorProfile :=
+  [English.colorProfile, French.colorProfile, German.colorProfile,
+   Japanese.colorProfile, Korean.colorProfile, Mandarin.colorProfile,
+   Spanish.colorProfile, Russian.colorProfile]
+
+/-- Every sampled language draws both the warm (red/yellow) and cool
+    (green/blue) boundaries — all are high-complexity, late-sequence systems,
+    consistent with their high category counts and fitted `β_l > 1`. -/
+theorem sample_all_warm_and_cool_split :
+    ∀ p ∈ sample, p.redYellow = some .distinct ∧ p.greenBlue = some .distinct := by
+  decide
+
+/-- Concrete complexity contrast: English (11 basic terms) sits higher on the IB
+    complexity axis than Mandarin (8–8.5), as the Berlin-Kay sequence predicts. -/
+theorem english_more_complex_than_mandarin :
+    ibComplexity Mandarin.colorProfile < ibComplexity English.colorProfile := by
+  decide
+
+/-- The contrast lifts to the IB objective: for every β ≥ 0 (and any fixed
+    accuracy), English's β-scalarized complexity cost is at least Mandarin's. -/
+theorem english_weightedCost_ge_mandarin (acc β : ℝ) (hβ : 0 ≤ β) :
+    weightedCost (ibCost Mandarin.colorProfile acc) β ≤
+    weightedCost (ibCost English.colorProfile acc) β :=
+  weightedCost_mono_in_complexity acc β hβ
+    (le_of_lt english_more_complex_than_mandarin)
+
+end ZaslavskyKempRegierTishby2018

--- a/Linglib/Typology/Color.lean
+++ b/Linglib/Typology/Color.lean
@@ -22,16 +22,13 @@ the Berlin & Kay tradition.
 - `RedYellowRelation` (Ch 135): red/yellow boundary
 - `ColorProfile`: per-language bundle (all four chapters)
 
-Per-language data lives in `Fragments/{Lang}/Color.lean`.
+Per-language data lives in `Fragments/{Lang}/Color.lean`, derived from the
+WALS rows via `ColorProfile.fromWALS` rather than hand-transcribed.
 -/
-
-set_option autoImplicit false
 
 namespace Typology
 
--- ============================================================================
--- WALS Ch 132: Number of non-derived basic color categories
--- ============================================================================
+/-! ### WALS Ch 132: Number of non-derived basic color categories -/
 
 /-- Number of non-derived basic color categories (WALS Ch 132,
     @cite{kay-maffi-2013}). Ranges from 3 to 6 along the Berlin & Kay
@@ -47,13 +44,12 @@ inductive NonDerivedColorCount where
   | six
   deriving DecidableEq, Repr
 
--- ============================================================================
--- WALS Ch 133: Total number of basic color categories
--- ============================================================================
+/-! ### WALS Ch 133: Total number of basic color categories -/
 
 /-- Total number of basic color categories including derived ones
-    (WALS Ch 133, @cite{kay-maffi-2013}). Ranges from 3–4 (minimal systems)
-    to 11 (maximal, e.g., English, Russian). -/
+    (WALS Ch 133, @cite{kay-maffi-2013a}). Ranges from 3–4 (minimal systems)
+    to the top bucket, WALS's "more than 10" — canonically 11 basic terms,
+    the Berlin & Kay Stage-VII maximum (e.g., English, Russian). -/
 inductive BasicColorCount where
   | v3to4
   | v4to5
@@ -64,12 +60,10 @@ inductive BasicColorCount where
   | v11
   deriving DecidableEq, Repr
 
--- ============================================================================
--- WALS Ch 134: Green and blue
--- ============================================================================
+/-! ### WALS Ch 134: Green and blue -/
 
 /-- How a language treats the green-blue region of color space
-    (WALS Ch 134, @cite{kay-maffi-2013}). The classic *grue* / green-blue
+    (WALS Ch 134, @cite{kay-maffi-2013b}). The classic *grue* / green-blue
     composite distinction, with several other composite patterns
     (with black, with yellow). -/
 inductive GreenBlueRelation where
@@ -89,12 +83,10 @@ inductive GreenBlueRelation where
   | noTerm
   deriving DecidableEq, Repr
 
--- ============================================================================
--- WALS Ch 135: Red and yellow
--- ============================================================================
+/-! ### WALS Ch 135: Red and yellow -/
 
 /-- How a language treats the red-yellow region of color space
-    (WALS Ch 135, @cite{kay-maffi-2013}). -/
+    (WALS Ch 135, @cite{kay-maffi-2013c}). -/
 inductive RedYellowRelation where
   /-- Separate terms for red and yellow. -/
   | distinct
@@ -108,9 +100,7 @@ inductive RedYellowRelation where
   | noTerm
   deriving DecidableEq, Repr
 
--- ============================================================================
--- Per-language profile
--- ============================================================================
+/-! ### Per-language profile -/
 
 /-- A language's color-naming profile across @cite{wals-2013} Chs 132–135.
     Coverage is sparse (~120 languages); fields are optional. -/
@@ -128,9 +118,7 @@ structure ColorProfile where
   redYellow : Option RedYellowRelation := none
   deriving Repr
 
--- ============================================================================
--- WALS converters
--- ============================================================================
+/-! ### WALS converters -/
 
 /-- Convert WALS 132A non-derived-color-count values into the substrate enum. -/
 def fromWALS132A : Data.WALS.F132A.NumberOfNonDerivedBasicColourCategories → NonDerivedColorCount
@@ -170,12 +158,24 @@ def fromWALS135A : Data.WALS.F135A.RedAndYellow → RedYellowRelation
   | .yellowGreenVsRed     => .yellowGreenVsRed
   | .none                 => .noTerm
 
--- ============================================================================
--- WALS distribution data
--- ============================================================================
+/-- Build a `ColorProfile` from the WALS Chs 132–135 rows for an ISO 639-3
+    code, mapping each chapter's datapoint through its converter; a field for
+    which WALS has no row is `none`. Makes the per-language Fragment profiles
+    true-by-construction from the auto-generated WALS tables rather than
+    hand-transcribed literals. -/
+def ColorProfile.fromWALS (language iso family : String) : ColorProfile :=
+  { language := language
+  , iso := iso
+  , family := family
+  , nonDerived := (Data.WALS.F132A.lookupISO iso).map (λ d => fromWALS132A d.value)
+  , basic := (Data.WALS.F133A.lookupISO iso).map (λ d => fromWALS133A d.value)
+  , greenBlue := (Data.WALS.F134A.lookupISO iso).map (λ d => fromWALS134A d.value)
+  , redYellow := (Data.WALS.F135A.lookupISO iso).map (λ d => fromWALS135A d.value) }
+
+/-! ### WALS distribution data -/
 
 /-- WALS Ch 134 distribution: green-blue boundary patterns
-    (@cite{kay-maffi-2013}, n = 120). -/
+    (@cite{kay-maffi-2013b}, n = 120). -/
 structure GreenBlueCounts where
   distinct : Nat
   merged : Nat
@@ -192,7 +192,7 @@ def walsGreenBlue : GreenBlueCounts :=
   , other := 22 }
 
 /-- WALS Ch 135 distribution: red-yellow boundary patterns
-    (@cite{kay-maffi-2013}, n = 120). -/
+    (@cite{kay-maffi-2013c}, n = 120). -/
 structure RedYellowCounts where
   distinct : Nat
   merged : Nat
@@ -208,9 +208,7 @@ def walsRedYellow : RedYellowCounts :=
   , merged := 15
   , other := 7 }
 
--- ============================================================================
--- Cross-linguistic generalizations
--- ============================================================================
+/-! ### Cross-linguistic generalizations -/
 
 /-- The *grue* pattern (merged green/blue) is the majority for the green-blue
     dimension (68 of 120 = 57%), more than double the distinct-terms pattern

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -5132,6 +5132,66 @@
   role      = {cited},
   sources   = {Phenomena/Morphology/Typology.lean}
 }% REF: Baerman, M. et al. (2005). *The Syntax-Morphology Interface*. CUP.
+@book{berlin-kay-1969,
+  author    = {Berlin, Brent and Kay, Paul},
+  year      = {1969},
+  title     = {Basic Color Terms: Their Universality and Evolution},
+  publisher = {University of California Press},
+  address   = {Berkeley},
+  isbn      = {9780520014428},
+  subfield  = {semantics/lexical},
+  validated = {true},
+  role      = {cited},
+  sources   = {Typology/Color.lean}
+}
+@incollection{kay-maffi-2013,
+  author    = {Kay, Paul and Maffi, Luisa},
+  year      = {2013},
+  title     = {Number of Non-Derived Basic Colour Categories},
+  booktitle = {The World Atlas of Language Structures Online},
+  editor    = {Dryer, Matthew S. and Haspelmath, Martin},
+  publisher = {Max Planck Institute for Evolutionary Anthropology},
+  url       = {https://wals.info/chapter/132},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  sources   = {Typology/Color.lean}
+}
+@incollection{kay-maffi-2013a,
+  author    = {Kay, Paul and Maffi, Luisa},
+  year      = {2013},
+  title     = {Number of Basic Colour Categories},
+  booktitle = {The World Atlas of Language Structures Online},
+  editor    = {Dryer, Matthew S. and Haspelmath, Martin},
+  publisher = {Max Planck Institute for Evolutionary Anthropology},
+  url       = {https://wals.info/chapter/133},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  sources   = {Typology/Color.lean}
+}
+@incollection{kay-maffi-2013b,
+  author    = {Kay, Paul and Maffi, Luisa},
+  year      = {2013},
+  title     = {Green and Blue},
+  booktitle = {The World Atlas of Language Structures Online},
+  editor    = {Dryer, Matthew S. and Haspelmath, Martin},
+  publisher = {Max Planck Institute for Evolutionary Anthropology},
+  url       = {https://wals.info/chapter/134},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  sources   = {Typology/Color.lean}
+}
+@incollection{kay-maffi-2013c,
+  author    = {Kay, Paul and Maffi, Luisa},
+  year      = {2013},
+  title     = {Red and Yellow},
+  booktitle = {The World Atlas of Language Structures Online},
+  editor    = {Dryer, Matthew S. and Haspelmath, Martin},
+  publisher = {Max Planck Institute for Evolutionary Anthropology},
+  url       = {https://wals.info/chapter/135},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  sources   = {Typology/Color.lean}
+}
 @article{grimm-2011,
   author    = {Grimm, Scott},
   year      = {2011},


### PR DESCRIPTION
Random-file audit of `Fragments/English/Color.lean` — the file was already clean; the findings were on its substrate and the orphaned 8-language profile cluster.

- Derive the 8 per-language `ColorProfile`s from the WALS Ch 132–135 tables via a new `ColorProfile.fromWALS` (first caller of the previously-unused `fromWALS132A–135A` converters); substrate `/-! ### -/` header + chapter-specific `kay-maffi-2013` cite cleanup; adds `berlin-kay-1969` + `kay-maffi-2013{,a,b,c}` bib entries.
- Add `Studies/ZaslavskyKempRegierTishby2018.lean`: gives the profiles a consumer, bridging the Berlin-Kay category counts to the Information-Bottleneck complexity axis via `Pragmatics.Efficiency`.