### PR TITLE
feat(Core/Nominal): ofPresupType denotation; PER/DEM as weak/strong

### DIFF
--- a/Linglib/Core/Nominal/Description.lean
+++ b/Linglib/Core/Nominal/Description.lean
@@ -5,7 +5,7 @@ import Linglib.Features.Definiteness
 /-!
 # Nominal Descriptions: Unified Sum Type
 @cite{coppock-beaver-2015} @cite{patel-grosz-grosz-2017} @cite{hanink-2021}
-@cite{bondarenko-2023} @cite{moroney-2021} @cite{schwarz-2009} @cite{schwarz-2013}
+@cite{moroney-2021} @cite{schwarz-2009} @cite{schwarz-2013}
 @cite{sharvy-1980} @cite{kriz-2015}
 
 A single sum type `NominalKind F` covering the principal flavors of nominal
@@ -14,8 +14,8 @@ description that the syntax–semantics interface needs to distinguish:
 - bare noun (number-neutral; covert type-shifts decide the reading)
 - indefinite (∃; introduces a new discourse referent)
 - unique (Coppock–Beaver weak/uniqueness; Sharvy/Križ maximal)
-- anaphoric (Schwarz strong-article familiarity; Hanink-indexed)
-- demonstrative (Patel-Grosz–Grosz/Davis: a separate object, not "strong the")
+- anaphoric (Schwarz strong-article familiarity; Hanink-indexed; PG&G's German *der*)
+- demonstrative (genuinely deictic this/that: a deictic feature, distinct from the strong article)
 - possessive (definite via a possession relation)
 
 The whole type is parameterized by a `Core.Logic.Intensional.Frame`, so all
@@ -25,9 +25,9 @@ unified `F.Denot` machinery rather than ad-hoc `E → Bool` predicates.
 ## Design notes
 
 - **Restrictors are `DenotGS F .et`.** Both entity assignments and situation
-  assignments are first-class. This is the @cite{hanink-2021} /
-  @cite{bondarenko-2023} position: a noun's resource situation is a *bound
-  variable* in the structure, not a free contextual parameter.
+  assignments are first-class. This is the @cite{hanink-2021} position: a noun's
+  resource situation is a *bound variable* in the structure, not a free
+  contextual parameter.
 
 - **`unique` carries a situation-pronoun index.** Weak-article
   (@cite{coppock-beaver-2015} uniqueness) definites are evaluated at a
@@ -39,12 +39,13 @@ unified `F.Denot` machinery rather than ad-hoc `E → Bool` predicates.
   discourse referent, the `discourseIdx`-th entity slot. This is the entity
   assignment's role.
 
-- **`demonstrative` is a separate constructor.** @cite{patel-grosz-grosz-2017}
-  and the Patel-Grosz–Grosz–Davis tradition reject the pure "demonstrative =
-  strong article" identification. A demonstrative carries **both** a discourse
-  index *and* a deictic feature (`Features.Deixis.Feature`). Its restrictor is
-  also evaluated at a situation pronoun (the situation in which the deictic
-  predicate is checked).
+- **`demonstrative` is a separate constructor** for *genuinely deictic*
+  demonstratives (this/that; @cite{moroney-2021} Shan *nâj*/*nân*): it carries
+  **both** a discourse/pointing index *and* a deictic feature
+  (`Features.Deixis.Feature`), checked at a situation pronoun. This is **distinct**
+  from the @cite{schwarz-2009} strong article (`anaphoric`): @cite{patel-grosz-grosz-2017}
+  analyze German *der* as the strong article (`anaphoric`), not as a deictic
+  demonstrative — their footnote 1 doubts *der* is truly demonstrative at all.
 
 - **`possessive` carries possessor + relation expressions** rather than
   conflating them with the restrictor. The relation has type `e ⇒ e ⇒ t`,
@@ -86,10 +87,10 @@ inductive NominalKind (F : Frame) where
   /-- Schwarz strong-article / Hanink-indexed anaphoric definite. The
       `discourseIdx`-th entity-assignment slot is the antecedent. -/
   | anaphoric (restrictor : DenotGS F .et) (discourseIdx : Nat)
-  /-- Demonstrative (this/that). Carries a deictic feature
-      (@cite{patel-grosz-grosz-2017} D-deix layer; @cite{moroney-2021} §2.1.3
-      Shan *nâj*/*nân*) and a discourse/pointing index. The restrictor is
-      checked at the resource situation pointed to by `situationIdx`. -/
+  /-- Demonstrative (genuinely deictic this/that). Carries a deictic feature
+      (@cite{moroney-2021} Shan *nâj*/*nân*) and a discourse/pointing index; the
+      restrictor is checked at the resource situation `situationIdx`. Distinct from
+      the @cite{schwarz-2009} strong article `anaphoric` (PG&G's German *der*). -/
   | demonstrative
       (restrictor : DenotGS F .et)
       (deictic : Features.Deixis.Feature)
@@ -166,6 +167,28 @@ theorem isAnaphoric_implies_familiarity (n : NominalKind F)
     n.expectedPresupType = some .familiarity := by
   cases n <;> simp [isAnaphoric] at h
   all_goals rfl
+
+/-- The definite description for a @cite{schwarz-2009} presupposition type: the
+    **weak** article (uniqueness) is `unique`, the **strong** article (familiarity)
+    is `anaphoric`. A section of `expectedPresupType` over the two article
+    strengths, so any item carrying a `DefPresupType` — a determiner, a definite,
+    or (per @cite{patel-grosz-grosz-2017}) a personal/demonstrative pronoun —
+    denotes by `ofPresupType` and recovers its strength via `expectedPresupType`.
+
+    `idx` is the strong article's anaphoric/discourse index; for the weak article
+    it fills the situation-pronoun slot, which `interpret` discards
+    (`interpret_unique_index_irrelevant`). -/
+def ofPresupType (p : Features.Definiteness.DefPresupType)
+    (restrictor : DenotGS F .et) (idx : Nat) : NominalKind F :=
+  match p with
+  | .uniqueness  => .unique restrictor idx
+  | .familiarity => .anaphoric restrictor idx
+
+/-- `ofPresupType` is a section of `expectedPresupType`: the strength round-trips. -/
+theorem expectedPresupType_ofPresupType
+    (p : Features.Definiteness.DefPresupType) (R : DenotGS F .et) (idx : Nat) :
+    (ofPresupType p R idx).expectedPresupType = some p := by
+  cases p <;> rfl
 
 end NominalKind
 

--- a/Linglib/Core/Nominal/Determiner.lean
+++ b/Linglib/Core/Nominal/Determiner.lean
@@ -33,12 +33,15 @@ localized to a single declaration.
 
 ## Implementation notes
 
-The semantic side — `Article.denote`, `Demonstrative.denote`, the `Quantifier`
-denotation as a generalized quantifier (`Core/Logic/Quantification`), the
-`Possessive` possession relation — is deferred to the migration of the
-nominal-description substrate; this file is the Frame-free lexical and
-typological layer only. `Quantifier` and `Possessive` are therefore declared but
-not yet fleshed out beyond the shared `form`.
+An `Article`'s admissible @cite{schwarz-2009} strengths are `Article.presupTypes`
+(Frame-free, read off `uses`); its denotation is `Article.toNominalKinds`
+(`Core/Nominal/DeterminerLicensing.lean`, Frame-aware) — the set of `NominalKind`s
+those strengths admit via `NominalKind.ofPresupType`, so a syncretic article like
+English *the* denotes *both* the weak and the strong description.
+`Demonstrative.denote` (deictic), the `Quantifier` generalized quantifier
+(`Core/Logic/Quantification`), and the `Possessive` possession relation remain
+deferred; `Quantifier`/`Possessive` are declared but not fleshed out beyond `form`.
+This file stays the Frame-free lexical/typological layer.
 -/
 
 open Features.Definiteness
@@ -238,3 +241,30 @@ example : markingStrategy
     = .unmarked := by decide
 
 end Determiner
+
+/-! ### Admissible article strengths
+
+The @cite{schwarz-2009} presupposition types an article *can* express — its
+admissible readings, read off `uses`. A syncretic article (English *the*) admits
+both; a weak- or strong-only article admits one. The image of these under
+`NominalKind.ofPresupType` is the article's set of possible denotations
+(`Article.toNominalKinds`, in `DeterminerLicensing.lean`). -/
+
+/-- The @cite{schwarz-2009} strengths an article admits, read off its `uses` (as a
+list — `DefPresupType` is binary, so its content is the membership-closure). -/
+def Article.presupTypes (a : Article) : List DefPresupType :=
+  a.uses.map useTypeToPresupType
+
+/-- An article admits strength `p` iff a one-article inventory containing it marks
+`p` — the single-article case of `Determiner.MarksPresup`. -/
+theorem Article.mem_presupTypes_iff_marksPresup (a : Article) (p : DefPresupType) :
+    p ∈ a.presupTypes ↔ Determiner.MarksPresup [.article a] p := by
+  unfold Article.presupTypes Determiner.MarksPresup
+  rw [List.mem_map]
+  constructor
+  · rintro ⟨u, hu, rfl⟩
+    exact ⟨.article a, List.mem_singleton_self _, u, hu, rfl⟩
+  · rintro ⟨e, he, u, hu, rfl⟩
+    rw [List.mem_singleton] at he
+    subst he
+    exact ⟨u, hu, rfl⟩

--- a/Linglib/Core/Nominal/DeterminerLicensing.lean
+++ b/Linglib/Core/Nominal/DeterminerLicensing.lean
@@ -11,7 +11,9 @@ Frame-parameterized `NominalKind` substrate.
 -/
 
 open Core.Logic.Intensional (Frame)
+open Core.Logic.Intensional.Variables (DenotGS)
 open Core.Nominal (NominalKind)
+open Features.Definiteness (DefPresupType)
 
 namespace Determiner
 
@@ -30,5 +32,36 @@ def licenses {F : Frame} (ds : List Entry) : NominalKind F → Prop
 
 instance {F : Frame} (ds : List Entry) (k : NominalKind F) : Decidable (licenses ds k) := by
   cases k <;> unfold licenses <;> infer_instance
+
+/-! ### An article's possible denotations
+
+The deferred `Article.denote`: an article denotes the **set** of `NominalKind`s its
+admissible strengths (`Article.presupTypes`) realize through `NominalKind.ofPresupType`
+— a syncretic article (English *the*) denotes both the weak and the strong
+description, not a single one. -/
+
+/-- An article's possible (definite-description) denotations: the image of its
+admissible @cite{schwarz-2009} strengths under `NominalKind.ofPresupType`. -/
+def _root_.Article.toNominalKinds {F : Frame} (a : Article)
+    (R : DenotGS F .et) (idx : Nat) : List (NominalKind F) :=
+  a.presupTypes.map (NominalKind.ofPresupType · R idx)
+
+/-- Licensing through `ofPresupType` is exactly `MarksPresup`: a determiner set
+licenses the weak/strong denotation of strength `p` iff some determiner expones a
+definite use of presupposition type `p`. The denotation pipeline (`ofPresupType`)
+and the inventory pipeline (`MarksPresup`) coincide by construction. -/
+theorem licenses_ofPresupType {F : Frame} (ds : List Entry)
+    (p : DefPresupType) (R : DenotGS F .et) (idx : Nat) :
+    licenses ds (NominalKind.ofPresupType p R idx) ↔ MarksPresup ds p := by
+  cases p <;> exact Iff.rfl
+
+/-- An article licenses each of its own possible denotations. -/
+theorem licenses_mem_toNominalKinds {F : Frame} (a : Article)
+    (R : DenotGS F .et) (idx : Nat) (k : NominalKind F)
+    (hk : k ∈ a.toNominalKinds R idx) :
+    licenses [.article a] k := by
+  obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hk
+  exact (licenses_ofPresupType [.article a] p R idx).mpr
+    ((Article.mem_presupTypes_iff_marksPresup a p).mp hp)
 
 end Determiner

--- a/Linglib/Core/Nominal/Interpret.lean
+++ b/Linglib/Core/Nominal/Interpret.lean
@@ -202,4 +202,19 @@ theorem interpret_anaphoric_isSome_iff
   · simp [h]
   · simp [h]
 
+/-- @cite{patel-grosz-grosz-2017}'s "DEM = PER + index": the **strong** article
+    (`anaphoric` at index `i`) and the **weak** article (`unique`) over a shared
+    restrictor pick the same referent exactly when the indexed entity `g i` is the
+    unique satisfier of `R`. The hypotheses are load-bearing — off this condition
+    the strong (the indexed entity) and weak (the unique satisfier) articles
+    diverge, PG&G's point that the strong article is anaphoric in a way the weak
+    one is not. -/
+theorem interpret_anaphoric_eq_unique_of_existsUnique
+    (R : DenotGS F .et) (sIdx i : Nat)
+    (g : Assignment F.Entity) (gs : SitAssignment F)
+    (hSat : R g gs (g i)) (hUniq : ∀ y, R g gs y → y = g i) :
+    interpret (.anaphoric R i) g gs = interpret (.unique R sIdx) g gs := by
+  rw [interpret_unique_eq_some_of_existsUnique R sIdx g gs (g i) hSat hUniq,
+      interpret_anaphoric, if_pos hSat]
+
 end Core.Nominal

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -123,48 +123,35 @@ example {F : Frame} [PartialOrder F.Entity] (g : Assignment F.Entity) (i : ℕ)
 
 /-! ### Pronouns are definite descriptions (@cite{elbourne-2005}, @cite{patel-grosz-grosz-2017})
 
-The thesis that a pronoun *is* a (null-NP) definite description, and a
-demonstrative pronoun is that description plus a D_deix layer, is made concrete
-by routing pronoun denotation through `NominalKind`: a personal pronoun is the
-`.anaphoric` (Schwarz strong-article) definite, a demonstrative pronoun is the
-`.demonstrative` one — which the substrate already proves differ only by the
-deixis presupposition filter (`interpret_demonstrative_eq_anaphoric`). -/
+A referential pronoun *is* a (null-NP) definite description over its φ-feature
+restrictor — a `NominalKind`. @cite{patel-grosz-grosz-2017}'s proposal is that the
+personal/demonstrative split is the @cite{schwarz-2009} weak/strong-article split:
+PER (*er*) the **weak** article (`NominalKind.ofPresupType .uniqueness` = `.unique`),
+"DEM" (*der*) the **strong** article (`…ofPresupType .familiarity` = `.anaphoric`,
+the weak description plus an anaphoric index). PG&G's "DEM = PER + index" is the
+weak/strong refinement `Core.Nominal.interpret_anaphoric_eq_unique_of_existsUnique`;
+the strength round-trips through `expectedPresupType`. The extra layer is that index,
+**not** spatial deixis (footnote 1) — *der* is a strong *personal* pronoun, not a
+separate type; genuine deictic demonstratives are `NominalKind.demonstrative`.
 
-/-- A personal pronoun *is* a definite description: structurally the anaphoric
-(Schwarz strong-article) definite over its restrictor `R` (the φ-feature NP) at
-discourse index `i`. @cite{patel-grosz-grosz-2017}'s "pronoun = null NP + Ddet",
-as a `NominalKind`. -/
-def PersonalPronoun.toNominalKind {F : Frame} (_e : PersonalPronoun)
-    (R : DenotGS F .et) (i : ℕ) : Core.Nominal.NominalKind F :=
-  .anaphoric R i
+Caveat on `denote` below: the project's canonical `PersonalPronoun.denote` realizes
+the @cite{buring-2012} assignment lookup `g i` — the *indexed/anaphoric* referent,
+i.e. the **strong** arm — so the bridge proves `denote` = `ofPresupType .familiarity`.
+PG&G's *weak* PER (`ofPresupType .uniqueness`, the uniqueness iota over the
+φ-restrictor) is a distinct denotation `denote` does not compute; the two arms agree
+exactly when `g i` is the unique satisfier. -/
 
-/-- A demonstrative pronoun is the same definite description plus the D_deix
-layer: `NominalKind.demonstrative` is `.anaphoric` with a deictic feature
-(@cite{patel-grosz-grosz-2017}: DEM = PER + deixis). -/
-def DemonstrativePronoun.toNominalKind {F : Frame} (p : DemonstrativePronoun)
-    (R : DenotGS F .et) (sIdx i : ℕ) : Core.Nominal.NominalKind F :=
-  .demonstrative R p.deictic sIdx i
-
-/-- DEM = PER + deixis at the referential level: erasing the deixis layer
-(`toPersonalPronoun`) leaves the same referent — the deictic feature is a
-presupposition filter, not a selector (@cite{patel-grosz-grosz-2017} §4). -/
-theorem DemonstrativePronoun.referent_eq_personal {F : Frame}
-    (p : DemonstrativePronoun) (R : DenotGS F .et) (sIdx i : ℕ)
-    (g : Assignment F.Entity) (gs : SitAssignment F) :
-    Core.Nominal.interpret (p.toNominalKind R sIdx i) g gs
-      = Core.Nominal.interpret (p.toPersonalPronoun.toNominalKind R i) g gs :=
-  Core.Nominal.interpret_demonstrative_eq_anaphoric R p.deictic sIdx i g gs
-
-/-- "Pronouns are definite descriptions," made precise: the pronoun's referent
-selector (`PersonalPronoun.denote`) coincides with the interpretation of its
-anaphoric-definite structure, whenever the restrictor (φ-features) holds of the
-indexed referent. -/
-theorem PersonalPronoun.denote_selector_eq_toNominalKind {F : Frame} [PartialOrder F.Entity]
+/-- A pronoun's @cite{buring-2012} variable-lookup referent equals its definite
+description whenever the restrictor holds of the indexed referent: the
+**strong-article** (`NominalKind.ofPresupType .familiarity`) reading, since the
+anaphoric index *is* the indexed entity. The **weak** reading coincides too when
+that entity is the unique satisfier (`Core.Nominal.interpret_anaphoric_eq_unique_of_existsUnique`). -/
+theorem PersonalPronoun.denote_selector_eq_ofPresupType {F : Frame} [PartialOrder F.Entity]
     (e : PersonalPronoun) (i : ℕ) (R : DenotGS F .et)
     (speaker addressee : F.Entity) (isFemale isInanimate : F.Entity → Prop)
     (g : Assignment F.Entity) (gs : SitAssignment F) (w : PUnit)
     (h : R g gs (g i)) :
     (e.denote i speaker addressee isFemale isInanimate).selector g w
-      = Core.Nominal.interpret (e.toNominalKind R i) g gs := by
-  simp [PersonalPronoun.denote, PersonalPronoun.toNominalKind,
-        Core.Nominal.interpret_anaphoric, interpPronoun, h]
+      = Core.Nominal.interpret (Core.Nominal.NominalKind.ofPresupType .familiarity R i) g gs := by
+  show some (g i) = Core.Nominal.interpret (.anaphoric R i) g gs
+  rw [Core.Nominal.interpret_anaphoric, if_pos h]

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -1,141 +1,157 @@
 import Linglib.Typology.Pronoun.Basic
 import Linglib.Core.Nominal.Determiner
 import Linglib.Fragments.German.Definiteness
+import Linglib.Studies.Schwarz2009
 
 /-!
 # Patel-Grosz & Grosz (2017): Revisiting Pronominal Typology
 @cite{patel-grosz-grosz-2017} @cite{schwarz-2009} @cite{schwarz-2013}
 @cite{elbourne-2005} @cite{cardinaletti-starke-1999}
 
-@cite{patel-grosz-grosz-2017} (LI 48(2)) argue, for German, that personal
-pronouns (PER: *er/sie/es*) and demonstrative pronouns (DEM: *der/die/das*) have
-the **same core makeup** — both a null NP plus a definite-determiner head (Ddet),
-i.e. both are definite descriptions — and that DEM merely **adds a D_deix
-layer**. The PER/DEM distribution then follows from **structural economy**
-(*Minimize DP!*): PER, being less structured, is the default; DEM is licensed
-only by an added pragmatic effect (emotivity §5.1, disambiguation §5.2,
-register §5.3).
+@cite{patel-grosz-grosz-2017} (LI 48(2)) argue, for German, that personal pronouns
+(PER: *er/sie/es*) and demonstrative pronouns (DEM: *der/die/das*) have the **same
+core makeup** — both a null NP plus a definite determiner — and differ only in that
+DEM adds an **anaphoric index**: DEM is the @cite{schwarz-2009} *strong* article,
+PER the *weak* article ("the latter are anaphoric in a way that the former are
+not"). The extra layer is that index, **not** spatial deixis — their footnote 1
+stresses "it is far from clear that there is anything truly 'demonstrative' about"
+German DEMs. So here *der/die/das* are **strong-article `PersonalPronoun`s**, not a
+separate demonstrative type; the genuinely deictic `NominalKind.demonstrative` is a
+different object. The PER/DEM distribution then follows from **structural economy**
+(*Minimize DP!*): PER, being less structured, is the default; DEM is licensed only
+by an added pragmatic effect (emotivity §5.1, disambiguation §5.2, register §5.3).
 
-The paper's three contributions are made *true by construction* on substrate
-they motivated, rather than stipulated here:
+The contributions are made *true by construction* on shared substrate:
 
-* **DEM = PER + deixis** is the type `DemonstrativePronoun extends
-  PersonalPronoun` (`Typology/Pronoun/Basic.lean`) — a demonstrative pronoun
-  structurally *contains* a personal pronoun, mirroring `Determiner.Demonstrative
-  extends Determiner`. So "DEM contains PER" is the `extends`, not a typological
-  universal asserted over invented data.
-* **Pronouns are definite descriptions** is
-  `PersonalPronoun.denote_selector_eq_toNominalKind`
-  (`Semantics/Reference/PronounDenotation.lean`): a pronoun's referent is the
-  `NominalKind.anaphoric` strong-article definite over its φ-feature restrictor.
-* The **two-article ↔ two-D-layer** correlation (§4) is read off the determiner
-  inventory (`Determiner.articleType`), not stipulated.
+* **DEM = PER + anaphoric index** is the @cite{schwarz-2009} weak/strong refinement
+  `Core.Nominal.interpret_anaphoric_eq_unique_of_existsUnique`: the strong description
+  (DEM, `.anaphoric`) and the weak description (PER, `.unique`) over one restrictor
+  pick the same referent exactly when the indexed entity is the unique satisfier —
+  off that, DEM is anaphoric in a way PER is not. Both denote via
+  `NominalKind.ofPresupType`, with the strength round-tripping through
+  `expectedPresupType` (`NominalKind.expectedPresupType_ofPresupType`); the
+  off-uniqueness **divergence** — DEM and PER picking *different* referents — is
+  `der_er_can_diverge`, reusing @cite{schwarz-2009} §8's two-satisfier scenario.
+* The **two-series ↔ two-article** correlation (§4) is read off the determiner
+  inventory (`Determiner.articleType`) and the lexicalized strong series, not
+  stipulated.
 
 ## Implementation notes
 
-The paper is German-focused (with Bavarian in §5.3 and passing mention of
-Portuguese/French/Hebrew). The earlier ~11-language `dLayers`/licensing table, a
-five-context licensing inventory, and a Finnish "counterexample" had no basis in
-the text and have been removed. *Minimize DP!* as a genuine node-count order
-(over `Pareto.lean`/`FeaturePreorder`) is left as a `Todo`; here the economy is
-recorded structurally (DEM carries the extra D_deix layer) and in prose.
+The paper is German-focused (Bavarian in §5.3, passing Portuguese/French/Hebrew).
+The earlier ~11-language table, a five-context licensing inventory, and a Finnish
+"counterexample" had no basis in the text and were removed. *Minimize DP!* as a
+genuine node-count order (over `Pareto.lean`/`FeaturePreorder`) is left as a `Todo`.
+The §3 corpus finding — that gender mismatches (e.g. neuter *Mädchen*/*Ehepaar* with
+a non-neuter pronoun) are *equally* available for PER and DEM, PG&G's argument
+against a [±NP] split — is recorded in prose, as formalizing it needs antecedent
+modeling absent here.
 -/
 
 namespace PatelGroszGrosz2017
 
 open Features.Definiteness (ArticleType)
 
-/-- The **three** pragmatic contexts that license a demonstrative pronoun in
-    German (@cite{patel-grosz-grosz-2017} §5): a positive pragmatic effect must
+/-- The **three** pragmatic contexts that license the strong-article ("DEM") series
+    in German (@cite{patel-grosz-grosz-2017} §5): a positive pragmatic effect must
     override the *Minimize DP!* preference for the less-structured PER. -/
 inductive DEMLicensingContext where
   /-- §5.1 Emotivity — the speaker expresses emotional engagement with the referent. -/
   | emotivity
   /-- §5.2 Disambiguation — DEM avoids the most prominent antecedent (anti-topicality). -/
   | disambiguation
-  /-- §5.3 Register — colloquial/informal register. -/
+  /-- §5.3 Register — colloquial/dialectal register. -/
   | register
   deriving DecidableEq, Repr
 
-/-! ### German pronoun inventory -/
+/-! ### German 3rd-person pronoun inventory
 
--- Personal pronouns (PER): the Ddet + null-NP core, no deixis layer.
+@cite{patel-grosz-grosz-2017} footnote 1: German *der/die/das* are not truly
+demonstrative — they are the **strong-article** counterpart of the personal-pronoun
+series. So both series are `PersonalPronoun`, differing only in @cite{schwarz-2009}
+article strength; which series a form belongs to is recorded here (the `weak`/`strong`
+split of `PronounSystem`), not in the theory-neutral `PersonalPronoun` schema. -/
+
+-- Weak series (PER): the uniqueness/weak article.
 def er  : PersonalPronoun := { form := "er",  person := some .third, number := some .Sing, gender := some .masculine }
 def sie : PersonalPronoun := { form := "sie", person := some .third, number := some .Sing, gender := some .feminine }
 def es  : PersonalPronoun := { form := "es",  person := some .third, number := some .Sing, gender := some .neuter }
 
--- Demonstrative pronouns (DEM): the PER core plus a D_deix layer.
-def der : DemonstrativePronoun := { form := "der", person := some .third, number := some .Sing, gender := some .masculine, deictic := .distal }
-def die : DemonstrativePronoun := { form := "die", person := some .third, number := some .Sing, gender := some .feminine,  deictic := .distal }
-def das : DemonstrativePronoun := { form := "das", person := some .third, number := some .Sing, gender := some .neuter,    deictic := .distal }
+-- Strong series ("DEM"): the same core plus the strong-article anaphoric index.
+def der : PersonalPronoun := { form := "der", person := some .third, number := some .Sing, gender := some .masculine }
+def die : PersonalPronoun := { form := "die", person := some .third, number := some .Sing, gender := some .feminine }
+def das : PersonalPronoun := { form := "das", person := some .third, number := some .Sing, gender := some .neuter }
 
-/-- A language's 3rd-person pronoun system: its PER and DEM inventories, its
-    article inventory (the single source of truth for `articleType`), and the
-    pragmatic contexts licensing DEM. -/
+/-- A language's 3rd-person pronoun system as PG&G analyze it: the weak (PER) and
+    strong ("DEM") article series, the article inventory (source of `articleType`),
+    and the pragmatic contexts licensing the strong series. -/
 structure PronounSystem where
   language : String
-  personal : List PersonalPronoun
-  demonstrative : List DemonstrativePronoun
+  weak : List PersonalPronoun
+  strong : List PersonalPronoun
   determiners : List Determiner.Entry
   licensing : List DEMLicensingContext
 
 namespace PronounSystem
 
-/-- Number of D-layers, **derived**: a language with demonstrative pronouns
-    projects the D_deix layer (2); a PER-only language has one (Ddet only). -/
-def dLayers (s : PronounSystem) : Nat := if s.demonstrative.isEmpty then 1 else 2
+/-- The language lexicalizes a distinct strong-article series (PG&G's added D-layer):
+    at least one strong form is present. Derived, not stipulated. -/
+def LexicalizesStrong (s : PronounSystem) : Prop := 0 < s.strong.length
 
-/-- The Schwarz `ArticleType`, **derived** from the determiner inventory. -/
-def articleType (s : PronounSystem) : ArticleType := Determiner.articleType s.determiners
+instance : DecidablePred LexicalizesStrong :=
+  fun s => inferInstanceAs (Decidable (0 < s.strong.length))
 
 end PronounSystem
 
-/-- German: PER *er/sie/es*, DEM *der/die/das*, weak/strong articles, all three
-    DEM-licensing contexts attested (@cite{patel-grosz-grosz-2017} §5). -/
+/-- German: weak PER *er/sie/es*, strong "DEM" *der/die/das*, weak/strong articles,
+    all three licensing contexts attested (@cite{patel-grosz-grosz-2017} §5). -/
 def german : PronounSystem :=
   { language := "German"
-    personal := [er, sie, es]
-    demonstrative := [der, die, das]
+    weak := [er, sie, es]
+    strong := [der, die, das]
     determiners := German.Definiteness.determiners
     licensing := [.emotivity, .disambiguation, .register] }
 
-/-! ### The three contributions, derived -/
+/-! ### The contributions, derived -/
 
-/-- **DEM = PER + deixis** (the core-makeup claim): every demonstrative pronoun
-    structurally contains a personal pronoun — true by the `extends`, not a
-    stipulated universal over a language sample. The φ-features (person/number/
-    gender) live on the shared PER core; the deixis is the only addition. -/
-theorem dem_contains_per (d : DemonstrativePronoun) :
-    d.toPersonalPronoun.person = d.person ∧ d.toPersonalPronoun.number = d.number :=
-  ⟨rfl, rfl⟩
-
-/-- **Gender concord is uniform across PER and DEM** because gender is a feature
-    of the shared PER core, not of the deixis layer. This is the structural basis
-    for @cite{patel-grosz-grosz-2017} §3's corpus finding that gender mismatches
-    (a grammatically neuter noun like *Ehepaar* 'married couple' referred to by a
-    non-neuter pronoun) are *equally* available for PER and DEM — falsifying the
-    claim that demonstratives must match grammatical gender. -/
-theorem dem_gender_is_per_gender (d : DemonstrativePronoun) :
-    d.gender = d.toPersonalPronoun.gender := rfl
-
-/-- German projects two D-layers — **derived** from the presence of DEM forms,
-    not stipulated as a `Nat`. -/
-theorem german_two_layers : german.dLayers = 2 := by decide
+/-- German lexicalizes a distinct strong-article pronoun series — **derived** from
+    the presence of *der/die/das*, not stipulated. -/
+theorem german_lexicalizes_strong : german.LexicalizesStrong := by decide
 
 /-- German's article system is `.weakAndStrong` (two distinct article forms) —
-    derived from the determiner inventory, matching its two D-layers
+    derived from the determiner inventory, matching its weak/strong pronoun series
     (@cite{patel-grosz-grosz-2017} §4). -/
-theorem german_weakAndStrong : german.articleType = .weakAndStrong := by decide
+theorem german_weakAndStrong :
+    Determiner.articleType german.determiners = .weakAndStrong := by decide
 
-/-- The @cite{schwarz-2009}/@cite{schwarz-2013} weak/strong article typology meets
-    @cite{patel-grosz-grosz-2017}'s D-layer count: German's two distinct article
-    forms (which derive `.bipartite`) correspond to its two D-layers and the
-    `.weakAndStrong` article type. All three facts are derived from the German
-    determiner inventory + the DEM forms, not stipulated. -/
+/-- The @cite{schwarz-2009}/@cite{schwarz-2013} weak/strong typology meets PG&G's
+    two-series claim: German's two distinct article forms (deriving `.bipartite`)
+    correspond to its lexicalized strong series and the `.weakAndStrong` article
+    type — all derived from the determiner inventory + the strong forms. -/
 theorem schwarz_pgg_german_consistent :
     Determiner.markingStrategy German.Definiteness.determiners = .bipartite ∧
-    german.dLayers = 2 ∧
-    german.articleType = .weakAndStrong :=
-  ⟨German.Definiteness.marking, by decide⟩
+    german.LexicalizesStrong ∧
+    Determiner.articleType german.determiners = .weakAndStrong :=
+  ⟨German.Definiteness.marking, german_lexicalizes_strong, german_weakAndStrong⟩
+
+/-! ### The empirical payoff: the two series can diverge -/
+
+/-- @cite{patel-grosz-grosz-2017}'s actual claim — DEM "is anaphoric in a way" PER
+    "is not" — made concrete: the strong-article "DEM" reading (*der*,
+    `ofPresupType .familiarity`) and the weak-article PER reading (*er*,
+    `ofPresupType .uniqueness`), over **one** restrictor and bi-assignment, pick
+    *different* referents. Reusing @cite{schwarz-2009} §8's two-satisfier scenario:
+    the weak PER fails uniqueness (two satisfiers → `none`) while the strong DEM
+    reads off the discourse index. This is the divergence direction the convergence
+    theorem (`Core.Nominal.interpret_anaphoric_eq_unique_of_existsUnique`) rules out
+    only under uniqueness. -/
+theorem der_er_can_diverge :
+    Core.Nominal.interpret
+        (Core.Nominal.NominalKind.ofPresupType .uniqueness Schwarz2009.studentRestr 0)
+        Schwarz2009.gAlice Schwarz2009.gs0
+      ≠ Core.Nominal.interpret
+        (Core.Nominal.NominalKind.ofPresupType .familiarity Schwarz2009.studentRestr 0)
+        Schwarz2009.gAlice Schwarz2009.gs0 :=
+  Schwarz2009.two_articles_can_disagree
 
 end PatelGroszGrosz2017

--- a/Linglib/Typology/Pronoun/Basic.lean
+++ b/Linglib/Typology/Pronoun/Basic.lean
@@ -3,7 +3,6 @@ import Linglib.Features.Case
 import Linglib.Features.Register
 import Linglib.Features.Prominence
 import Linglib.Features.Gender
-import Linglib.Features.Deixis
 
 /-!
 # Pronoun
@@ -79,19 +78,6 @@ structure PersonalPronoun extends Pronoun where
       referential person coincides with formal person.
       @cite{adamson-zompi-2025} -/
   referentialPerson : Option Features.Prominence.PersonLevel := none
-  deriving Repr, BEq
-
-/-- A *demonstrative* pronoun (German *der/die/das*, Bavarian *de/dia*): a
-personal pronoun plus a D_deix layer. @cite{patel-grosz-grosz-2017}'s central
-thesis — DEM = PER + deixis — is *literally* this one `extends` and one field,
-the same move as `Determiner.Demonstrative extends Determiner` and sharing the
-same `Features.Deixis.Feature`. Because the PER core is recovered by
-`.toPersonalPronoun`, "a demonstrative pronoun structurally contains a personal
-pronoun" is true by construction, not a stipulated typological universal. -/
-structure DemonstrativePronoun extends PersonalPronoun where
-  /-- The D_deix feature (proximal/medial/distal/unspecified), shared with
-      `Determiner.Demonstrative` and `NominalKind.demonstrative`. -/
-  deictic : Features.Deixis.Feature := .unspecified
   deriving Repr, BEq
 
 namespace Pronoun


### PR DESCRIPTION
Routes the personal/demonstrative split through the Schwarz weak/strong-article distinction (`DefPresupType ↔ NominalKind`) rather than a separate `DemonstrativePronoun` type, correcting #68's PG&G (2017) modeling — their footnote 1: *der* is a strong personal pronoun, not a deictic demonstrative.

- `NominalKind.ofPresupType` (a section of `expectedPresupType`) + the `Article.presupTypes`/`toNominalKinds` denotation bridge (discharges the deferred `Article.denote`; `licenses ↔ MarksPresup`).
- `der_er_can_diverge`: the weak/strong empirical payoff, reusing Schwarz2009 §8.