### PR TITLE
refactor(ArgumentStructure): re-anchor valency alternations

### DIFF
--- a/Linglib/Studies/Bohnemeyer2004.lean
+++ b/Linglib/Studies/Bohnemeyer2004.lean
@@ -1,16 +1,16 @@
 import Linglib.Fragments.Mayan.Yukatek.VerbClasses
 import Linglib.Semantics.Lexical.EventStructure
-import Linglib.Semantics.ArgumentStructure.EntailmentProfile
-import Linglib.Semantics.Causation.Morphological
+import Linglib.Syntax.ArgumentStructure.Alternation
 
 /-!
-# Bohnemeyer 2004: Split Intransitivity in Yukatek Maya
+# Bohnemeyer 2004: Split intransitivity, linking, and lexical representation
 
 @cite{bohnemeyer-2004}
 
 Split intransitivity in Yukatek Maya is governed by **event structure** —
-specifically the distinction between internally- and externally-caused
-events — rather than by lexical aspect alone (contra @cite{kraemer-wunderlich-1999}).
+specifically the distinction between internally- and externally-caused events
+(in the sense of @cite{levin-hovav-1995}) — rather than by lexical aspect
+alone (contra @cite{kraemer-wunderlich-1999}).
 
 ## Core Claims
 
@@ -18,24 +18,28 @@ events — rather than by lexical aspect alone (contra @cite{kraemer-wunderlich-
    structure, and lexical aspect. Event structure partially determines both;
    linking rules operate on event structure directly.
 
-2. **Internal causation determines transitivization type**: internally-caused
-   bases → applicative *-t* (add applied object as U); externally-caused
-   bases → causative *-s* (add instigator as A).
+2. **Internal causation determines the linking pattern under
+   transitivization**: internally-caused bases get *applicative* linking
+   (added applied object → U, original S stays A); externally-caused bases get
+   *causative* linking (added instigator → A, original S → U). The overt
+   transitivizing suffix (*-t* ~ *-s*) usually tracks the linking pattern but
+   can dissociate from it — see below.
 
 3. **Linking-by-viewpoint**: imperfective aspect aligns with the head of the
    causal chain (accusative default); perfective aligns with the tail
    (ergative default).
 
-## Against Aspect-Based Linking
+## Against aspect-based linking
 
 @cite{kraemer-wunderlich-1999} propose lexical aspect as the sole
 linking-relevant property. Two classes of counterevidence:
 
 - **Degree achievements** (grow, darken): aspectually like processes (atelic)
-  but transitivize like state-change verbs (causative pattern).
-- **Non-internally-caused active verbs** (roll, buzz): same stem class and
-  aspect as internally-caused actives (work, play) but show causative
-  linking under transitivization.
+  but transitivize like state-change verbs (causative linking).
+- **Non-internally-caused active verbs** (roll, buzz): take the *applicative*
+  suffix *-t* (like internally-caused actives) yet show *causative* linking,
+  because their bases are externally caused. Suffix and linking dissociate —
+  which a purely aspect-based account cannot predict.
 -/
 
 namespace Bohnemeyer2004
@@ -45,9 +49,7 @@ open Semantics.Aspect (ViewpointAspectB)
 open Mayan (MarkerSet)
 open Yukatek
 
--- ════════════════════════════════════════════════════
--- § 1. Causal Chain and Thematic Hierarchy
--- ════════════════════════════════════════════════════
+/-! ### Causal chain and thematic hierarchy -/
 
 /-- Position in the causal chain of subevents.
     A complex event decomposes into subevents ordered in a causal chain.
@@ -57,48 +59,65 @@ inductive CausalChainPosition where
   | tail  -- caused subevent (last in causal chain)
   deriving DecidableEq, Repr
 
-/-- Thematic hierarchy from causal chain position.
-    rule (31): participant of a causing subevent
-    outranks participant of the caused subevent. -/
-def outranks : CausalChainPosition → CausalChainPosition → Bool
-  | .head, .tail => true
-  | _, _ => false
+/-- Thematic hierarchy from causal-chain position (rule 31): the participant
+    of a causing subevent (`head`) outranks the participant of the caused
+    subevent (`tail`) for linking. -/
+def Outranks : CausalChainPosition → CausalChainPosition → Prop
+  | .head, .tail => True
+  | _, _ => False
 
-theorem head_outranks_tail : outranks .head .tail = true := rfl
-theorem tail_does_not_outrank_head : outranks .tail .head = false := rfl
+/-- The marker set the rule-31 hierarchy projects onto each causal-chain
+    position: the highest-ranked position (`head`, the causer/A role) takes
+    set-A; the outranked position (`tail`, the U role) takes set-B. -/
+def CausalChainPosition.marker : CausalChainPosition → MarkerSet
+  | .head => .setA
+  | .tail => .setB
 
--- ════════════════════════════════════════════════════
--- § 2. Linking-by-Viewpoint
--- ════════════════════════════════════════════════════
+/-- The thematic hierarchy is asymmetric: no position both outranks and is
+    outranked by the same position. -/
+theorem outranks_asymm {a b : CausalChainPosition} (h : Outranks a b) :
+    ¬ Outranks b a := by
+  cases a <;> cases b <;> simp_all [Outranks]
 
-/-- Which end of the causal chain provides the linking default.
-    §7 rule (32):
+/-- The marker assignment respects the hierarchy: an outranking position takes
+    the subject marker (set-A) and the position it outranks takes the object
+    marker (set-B). The split thus *follows from* rule (31) rather than being
+    stipulated. -/
+theorem marker_respects_outranks {a b : CausalChainPosition} (h : Outranks a b) :
+    a.marker = .setA ∧ b.marker = .setB := by
+  cases a <;> cases b <;> simp_all [Outranks, CausalChainPosition.marker]
+
+/-! ### Linking by viewpoint -/
+
+/-- §7 rule (32): viewpoint aspect selects which end of the causal chain
+    provides the linking default.
 
     - Imperfective viewpoints align with the initial (causing) subevent →
-      the highest-ranking role defines the default → accusative pattern.
-    - Perfective viewpoints align with the final (caused) subevent or
-      the chain as a whole → the lowest-ranking role defines the default →
+      the highest-ranking role (`head`) is the default → accusative pattern.
+    - Perfective viewpoints align with the final (caused) subevent or the
+      chain as a whole → the lowest-ranking role (`tail`) is the default →
       ergative pattern. -/
 def linkingDefault : ViewpointAspectB → CausalChainPosition
   | .imperfective => .head
   | .perfective => .tail
 
-/-- Under linking-by-viewpoint, which marker set does the sole argument
-    (S) of an intransitive receive?
+/-- The marker the sole argument (S) of an intransitive receives, derived by
+    composing rule (32) (viewpoint → default position) with rule (31)'s
+    hierarchy projection (position → marker, `CausalChainPosition.marker`).
+    The split *falls out* of the causal chain rather than being stipulated
+    per viewpoint.
 
     - Head default (imperfective): S patterns with A → set-A
     - Tail default (perfective): S patterns with U → set-B -/
-def sMarkerFromViewpoint : ViewpointAspectB → MarkerSet
-  | .imperfective => .setA  -- accusative: S = A
-  | .perfective => .setB    -- ergative: S = U
+def sMarkerFromViewpoint (v : ViewpointAspectB) : MarkerSet :=
+  (linkingDefault v).marker
 
--- ════════════════════════════════════════════════════
--- § 3. Linking-by-Viewpoint Derives the Split
--- ════════════════════════════════════════════════════
+/-! ### Linking by viewpoint derives the split
 
-/-- The linking-by-viewpoint mechanism derives the Yukatek split:
-    perfective status → ergative (set-B), imperfective → accusative (set-A).
-    This matches the observed pattern in the fragment. -/
+The composed mechanism reproduces the Yukatek split recorded in the Fragment's
+`sArgumentMarker`: perfective status → ergative (set-B), imperfective →
+accusative (set-A). -/
+
 theorem linking_derives_completive :
     some (sMarkerFromViewpoint .perfective) = sArgumentMarker .completive := rfl
 
@@ -108,126 +127,183 @@ theorem linking_derives_subjunctive :
 theorem linking_derives_incompletive :
     some (sMarkerFromViewpoint .imperfective) = sArgumentMarker .incompletive := rfl
 
--- ════════════════════════════════════════════════════
--- § 4. Transitivization Type
--- ════════════════════════════════════════════════════
+/-! ### Linking pattern under transitivization -/
 
-/-- Type of transitivization operation, determined by the causation type
-    of the intransitive base (§6, rules 26–27). -/
-inductive TransitivizationType where
-  | applicative  -- internally caused: *-t*, add applied object linked to U
-  | causative    -- externally caused: *-s*, add instigator linked to A
+/-- The argument-realization (linking) pattern produced by transitivization,
+    determined by the causation type of the intransitive base (rules 26–27).
+    This is the *linking* dimension — which participant is added and how the
+    original S is realized — NOT the overt suffix (see `TransitivizerSuffix`).
+
+    - `applicative`: internally caused. The added applied object links to U
+      (set-B); the original S keeps A (set-A).
+    - `causative`: externally caused. The added instigator links to A (set-A);
+      the original S is demoted to U (set-B). -/
+inductive LinkingPattern where
+  | applicative
+  | causative
   deriving DecidableEq, Repr
 
-/-- The causation type of the intransitive base determines which
-    transitivization operation applies.
-
-    rules (26)–(27):
-    - Internally caused base (sing, walk, play): *-t* applicative, adding
-      an applied object. The original S keeps its position.
-    - Externally caused base (die, fall, roll): *-s* causative, adding
-      an instigator as A. The original S is reassigned to U. -/
-def predictTransitivization : InternalExternalCause → TransitivizationType
+/-- The causation type of the intransitive base determines the linking pattern
+    (rules 26–27): internally caused → applicative linking; externally caused
+    → causative linking. -/
+def predictLinking : InternalExternalCause → LinkingPattern
   | .internal => .applicative
   | .external => .causative
 
-/-- Under applicative transitivization, the added participant is linked
-    to U (set-B) and the original S keeps A (set-A). Under causative
-    transitivization, the added instigator takes A (set-A) and the
-    original S moves to U (set-B). -/
-def TransitivizationType.addedArgMarker : TransitivizationType → MarkerSet
-  | .applicative => .setB   -- added applied object → U → set-B
-  | .causative => .setA     -- added instigator → A → set-A
+/-- Predict the linking pattern of a Yukatek verb under transitivization from
+    its causation type. -/
+def verbLinking (v : YukatekVerb) : LinkingPattern :=
+  predictLinking v.causationType
 
-def TransitivizationType.originalArgMarker : TransitivizationType → MarkerSet
-  | .applicative => .setA   -- original S stays as A → set-A
-  | .causative => .setB     -- original S demoted to U → set-B
+/-- Marker assigned to the *added* participant under each linking pattern. -/
+def LinkingPattern.addedArgMarker : LinkingPattern → MarkerSet
+  | .applicative => .setB   -- added applied object → U
+  | .causative => .setA     -- added instigator → A
 
--- ════════════════════════════════════════════════════
--- § 5. Predictions for Individual Verbs
--- ════════════════════════════════════════════════════
+/-- Marker assigned to the *original* S under each linking pattern. -/
+def LinkingPattern.originalArgMarker : LinkingPattern → MarkerSet
+  | .applicative => .setA   -- original S stays A
+  | .causative => .setB     -- original S demoted to U
 
-/-- Predict transitivization for a Yukatek verb from its causation type. -/
-def verbTransitivization (v : YukatekVerb) : TransitivizationType :=
-  predictTransitivization v.causationType
+/-- Applicative and causative linking are mirror images: each assigns to the
+    added argument the marker the other assigns to the original S. The two
+    patterns exhaust how a transitivized clause distributes set-A and set-B. -/
+theorem linking_patterns_swap_markers :
+    LinkingPattern.applicative.addedArgMarker = LinkingPattern.causative.originalArgMarker ∧
+    LinkingPattern.applicative.originalArgMarker = LinkingPattern.causative.addedArgMarker :=
+  ⟨rfl, rfl⟩
 
--- § 5a. Internally caused active verbs → applicative
+/-! ### Transitivizing suffix vs linking
 
-/-- "work" (internally caused active) → applicative transitivization.
+The overt transitivizing suffix is lexically specified and *usually* tracks
+the linking pattern, but the two can dissociate — the paper's central argument
+against aspect-based linking. The suffix is paper-specific lexical data, so it
+lives here rather than in the Fragment. -/
+
+/-- The overt transitivizing suffix (@cite{bohnemeyer-2004}): applicative *-t*
+    or causative *-s*. Distinct from `LinkingPattern`. -/
+inductive TransitivizerSuffix where
+  | applicativeT   -- *-t*
+  | causativeS     -- *-s*
+  deriving DecidableEq, Repr
+
+/-- The suffix each verb the paper documents takes under transitivization.
+    Lexically idiosyncratic — not a function of causation type or stem class
+    (cf. balak' vs péek, both active and externally caused, yet *-t* vs *-s*).
+    Verbs the paper does not document return `none`. -/
+def transitivizerSuffix (v : YukatekVerb) : Option TransitivizerSuffix :=
+  match v.gloss with
+  | "work" | "play" | "eat" | "roll" | "buzz" => some .applicativeT
+  | "die" | "fall" | "move/wiggle" => some .causativeS
+  | _ => none
+
+/-- For an internally-caused base the suffix tracks the linking: applicative
+    *-t* with applicative linking. -/
+theorem meyah_suffix_tracks_linking :
+    transitivizerSuffix meyah = some .applicativeT ∧
+    verbLinking meyah = .applicative := by decide
+
+/-- For an externally-caused inactive base the suffix tracks the linking:
+    causative *-s* with causative linking. -/
+theorem kim_suffix_tracks_linking :
+    transitivizerSuffix kim = some .causativeS ∧
+    verbLinking kim = .causative := by decide
+
+/-- The paper's key argument against aspect-based linking: balak' "roll" and
+    tsiirin "buzz" take the *applicative* suffix *-t* (like the internally-caused
+    actives) yet show *causative* linking, because their bases are externally
+    caused (ex. 10, 11, 22). Suffix and linking dissociate — a contrast a
+    purely aspect-based account cannot predict. -/
+theorem balak_tsiirin_suffix_linking_dissociate :
+    (transitivizerSuffix balak = some .applicativeT ∧ verbLinking balak = .causative) ∧
+    (transitivizerSuffix tsiirin = some .applicativeT ∧ verbLinking tsiirin = .causative) := by
+  decide
+
+/-- péek "move" is active and externally caused like balak', yet takes the
+    *causative* suffix *-s* — the suffix is lexically idiosyncratic,
+    dissociating from causation type and stem class in the opposite direction
+    from balak'. -/
+theorem peek_causative_suffix_active_external :
+    transitivizerSuffix peek = some .causativeS ∧
+    peek.stemClass = .active ∧
+    peek.causationType = .external ∧
+    verbLinking peek = .causative := by decide
+
+/-! ### Predictions for individual verbs -/
+
+-- Internally caused active verbs → applicative
+
+/-- "work" (internally caused active) → applicative linking.
     ex. (4):
     Túun meyah ich u=kòol → 'He's working on his milpa'
     Túun meyah-t-ik u=kòol → 'He's making his milpa' -/
-theorem meyah_applicative : verbTransitivization meyah = .applicative := rfl
+theorem meyah_applicative : verbLinking meyah = .applicative := rfl
 
 /-- "play" (internally caused active) → applicative.
     ex. (5). -/
-theorem baaxal_applicative : verbTransitivization baaxal = .applicative := rfl
+theorem baaxal_applicative : verbLinking baaxal = .applicative := rfl
 
--- § 5b. Externally caused verbs → causative (regardless of stem class)
+-- Externally caused verbs → causative (regardless of stem class)
 
 /-- "die" (inactive, externally caused) → causative.
     ex. (6):
     Túun kim-il Pedro → 'Pedro's dying'
     Juan=e' túun kim-s-ik Pedro → 'Juan is killing Pedro' -/
-theorem kim_causative : verbTransitivization kim = .causative := rfl
+theorem kim_causative : verbLinking kim = .causative := rfl
 
 /-- "fall" (inactive, externally caused) → causative.
     ex. (7). -/
-theorem luub_causative : verbTransitivization luub = .causative := rfl
+theorem luub_causative : verbLinking luub = .causative := rfl
 
--- § 5c. Non-internally-caused ACTIVE verbs → causative (not applicative!)
+-- Non-internally-caused ACTIVE verbs → causative (not applicative linking!)
 -- This is the critical evidence against aspect-based linking.
 
-/-- "roll" (active class but externally caused) → causative transitivization.
+/-- "roll" (active class but externally caused) → causative linking.
     Despite being an active verb (same stem class as "work"), balak' shows
     causative linking because its base is not internally caused.
-    ex. (10), (22): the original S is linked to U,
-    and the added participant is the instigator linked to A. -/
-theorem balak_causative : verbTransitivization balak = .causative := rfl
+    ex. (10), (22): the original S is linked to U, and the added participant
+    is the instigator linked to A. -/
+theorem balak_causative : verbLinking balak = .causative := rfl
 
 /-- "buzz" (active class but externally caused) → causative.
     ex. (11). -/
-theorem tsiirin_causative : verbTransitivization tsiirin = .causative := rfl
+theorem tsiirin_causative : verbLinking tsiirin = .causative := rfl
 
--- § 5d. Positional verbs → causative
+-- Positional verbs → causative
 
 /-- All positional verbs transitivize with causative linking, since they
     denote externally-caused state changes at the event-structure level.
     Control is a participant-structure property, not an event-structure one.
     ex. (25), §6. -/
-theorem kulTal_causative : verbTransitivization kulTal = .causative := rfl
-theorem waalTal_causative : verbTransitivization waalTal = .causative := rfl
+theorem kulTal_causative : verbLinking kulTal = .causative := rfl
+theorem waalTal_causative : verbLinking waalTal = .causative := rfl
 
--- ════════════════════════════════════════════════════
--- § 6. Degree Achievements: Event Type vs Aspect
--- ════════════════════════════════════════════════════
+/-! ### Degree achievements: event type vs aspect -/
 
 /-- Degree achievements are event-structurally state changes, not processes,
     even though they behave atelically.
 
-    §5: ka'n 'get tired' passes state-change
-    diagnostics (resultative *-a'n*, universal quantifier *láah*) despite
-    being atelic in the realization-under-cessation test. -/
+    §5: ka'n 'get tired' passes state-change diagnostics (resultative *-a'n*,
+    universal quantifier *láah*) despite being atelic in the
+    realization-under-cessation test. -/
 theorem kaan_is_state_change :
     kaan.stemClass.eventType = .stateChange := rfl
 
 theorem naak_is_state_change :
     naak.stemClass.eventType = .stateChange := rfl
 
-/-- Degree achievements transitivize like state-change verbs (causative),
-    not like process verbs.
+/-- Degree achievements transitivize like state-change verbs (causative
+    linking), not like process verbs.
 
-    This is the first direct counterevidence against @cite{kraemer-wunderlich-1999}'s
-    aspect-based linking: rule (14) predicts applicative for degree achievements
-    (since they are [-perf] bases), but they exclusively causativize.
-    ex. (21). -/
+    This is the first direct counterevidence against
+    @cite{kraemer-wunderlich-1999}'s aspect-based linking: rule (14) predicts
+    applicative for degree achievements (since they are atelic, hence [-perf]
+    bases), but they exclusively causativize. ex. (21). -/
 theorem degree_achievements_causativize :
-    verbTransitivization kaan = .causative ∧
-    verbTransitivization naak = .causative := ⟨rfl, rfl⟩
+    verbLinking kaan = .causative ∧
+    verbLinking naak = .causative := ⟨rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 7. The Crosscutting: Causation ⊥ Stem Class
--- ════════════════════════════════════════════════════
+/-! ### Causation is orthogonal to stem class -/
 
 /-- Active verbs are processes regardless of causation type. -/
 theorem active_is_process :
@@ -239,124 +315,107 @@ theorem nonactive_are_state_changes :
     VerbStemClass.eventType .inchoative = .stateChange ∧
     VerbStemClass.eventType .positional = .stateChange := ⟨rfl, rfl, rfl⟩
 
-/-- The process/state-change distinction is orthogonal to causation type
-    for active verbs: both internally-caused (meyah) and externally-caused
-    (balak') actives are processes, but they differ in transitivization.
+/-- The process/state-change distinction is orthogonal to causation type for
+    active verbs: both internally-caused (meyah) and externally-caused (balak')
+    actives are processes, but they differ in linking.
 
-    This is the core argument of: linking under
-    transitivization depends on causation type, not event type or aspect. -/
+    This is the core argument: linking under transitivization depends on
+    causation type, not event type or aspect. -/
 theorem causation_orthogonal_to_event_type :
     meyah.stemClass.eventType = balak.stemClass.eventType ∧
-    verbTransitivization meyah ≠ verbTransitivization balak := by
-  exact ⟨rfl, by decide⟩
+    verbLinking meyah ≠ verbLinking balak :=
+  ⟨rfl, by decide⟩
 
-/-- Conversely, verbs with the same causation type but different stem
-    classes get the same transitivization — because it is causation,
-    not class membership, that determines linking.
+/-- Conversely, verbs with the same causation type but different stem classes
+    get the same linking — because it is causation, not class membership, that
+    determines linking.
 
-    kim (inactive) and balak (active) are both externally caused →
-    both causativize. -/
-theorem same_causation_same_transitivization :
-    verbTransitivization kim = verbTransitivization balak := rfl
+    kim (inactive) and balak (active) are both externally caused → both
+    causativize. -/
+theorem same_causation_same_linking :
+    verbLinking kim = verbLinking balak := rfl
 
--- § 7a. hàan "eat" — the key exception proving the rule
+-- hàan "eat" — the key exception proving the rule
 
 /-- hàan "eat" is inactive by stem class but internally caused.
-    ex. (9): hàan takes applicative *-t* (not
-    causative *-s*), exactly as predicted by internal causation.
+    ex. (9): hàan takes applicative *-t* (not causative *-s*), exactly as
+    predicted by internal causation.
 
-    This directly refutes stem-class-based linking: if stem class
-    determined transitivization, hàan (inactive) would causativize
-    like kim "die". Instead, it applicativizes like meyah "work". -/
+    This directly refutes stem-class-based linking: if stem class determined
+    transitivization, hàan (inactive) would causativize like kim "die".
+    Instead, it applicativizes like meyah "work". -/
 theorem haanEat_applicative_despite_inactive :
     haanEat.stemClass = .inactive ∧
-    verbTransitivization haanEat = .applicative := ⟨rfl, rfl⟩
+    verbLinking haanEat = .applicative := ⟨rfl, rfl⟩
 
-/-- hàan patterns with internally-caused active verbs, not with
-    its own (inactive) stem class, for transitivization. -/
+/-- hàan patterns with internally-caused active verbs, not with its own
+    (inactive) stem class, for linking. -/
 theorem haanEat_patterns_with_actives :
-    verbTransitivization haanEat = verbTransitivization meyah := rfl
+    verbLinking haanEat = verbLinking meyah := rfl
 
-/-- hàan and kim are both inactive but get different transitivization
-    because they differ in causation type. -/
+/-- hàan and kim are both inactive but get different linking because they
+    differ in causation type. -/
 theorem inactive_split_by_causation :
     haanEat.stemClass = kim.stemClass ∧
-    verbTransitivization haanEat ≠ verbTransitivization kim := by
-  exact ⟨rfl, by decide⟩
+    verbLinking haanEat ≠ verbLinking kim :=
+  ⟨rfl, by decide⟩
 
--- ════════════════════════════════════════════════════
--- § 8. Bridge to Proto-Role Entailments
--- ════════════════════════════════════════════════════
+/-! ### Bridge to detransitivization
 
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+The three Yukatek detransitivizations are instances of the cross-linguistic
+valency-alternation typology (`Syntax/ArgumentStructure/Alternation.lean`).
+That substrate keeps passive and anticausative distinct by the fate of the
+initial A — passive *denucleativizes* it (retained in participant structure as
+a possible oblique agent), anticausative *suppresses* it (removed entirely). -/
 
-/-- Internal causation corresponds to the Proto-Agent "causation"
-    entailment in @cite{dowty-1991}'s framework: an internally-caused
-    event has a participant who causes (instigates) the event.
+open Syntax.ArgumentStructure.Alternation
+  (ValencyAlternation antipassivization decausativization passivization)
 
-    §2: internal causation is "closely correlated
-    with the properties of control and agentivity." -/
-def InternalExternalCause.impliesCausationEntailment : InternalExternalCause → Bool
-  | .internal => true   -- instigator causes the event
-  | .external => false  -- no instigator
+/-- Detransitivization type in Yukatek, from rules (28)–(30).
 
-/-- Internally caused verbs predict a Proto-Agent subject (has causation
-    entailment); externally caused verbs predict a Proto-Patient subject
-    (lacks causation entailment). This connects Bohnemeyer's event-structure
-    analysis to Dowty's ASP. -/
-theorem internal_implies_agent_causation :
-    InternalExternalCause.impliesCausationEntailment .internal = true := rfl
-
-theorem external_lacks_causation :
-    InternalExternalCause.impliesCausationEntailment .external = false := rfl
-
--- ════════════════════════════════════════════════════
--- § 9. Bridge to Detransitivization
--- ════════════════════════════════════════════════════
-
-open Semantics.Causation.Morphological (IntransitivizationType)
-
-/-- Detransitivization type in Yukatek, from
-    rules (28)–(30).
-
-    - Antipassive (rule 28): removes the caused event, retaining the
-      causing process. Active intransitives inflect like antipassive stems.
-    - Anticausative (rule 29): removes the causing event, retaining the
-      caused state/change. Inactive intransitives inflect like anticausative
-      stems.
-    - Passive (rule 30): like anticausative but adds PROC_C and instigator
-      to the caused event. -/
+    - Antipassive (rule 28): removes the caused event, retaining the causing
+      process. Active intransitives inflect like antipassive stems.
+    - Anticausative (rule 29): removes the causing event, retaining the caused
+      state/change. Inactive intransitives inflect like anticausative stems.
+    - Passive (rule 30): like anticausative but adds PROC_C and instigator to
+      the caused event. -/
 inductive DetransitivizationType where
   | antipassive   -- retain causing process, remove caused event
   | anticausative -- retain caused event, remove causing process
   | passive       -- retain caused event, add instigator
   deriving DecidableEq, Repr
 
-/-- Map Yukatek detransitivization to the general intransitivization
-    typology from `MorphologicalCausation.lean`. Anticausatives remove
-    the external cause (monoeventive); antipassives retain it. -/
-def DetransitivizationType.toGeneral : DetransitivizationType → IntransitivizationType
-  | .anticausative => .anticausative
-  | .antipassive => .unmarked  -- antipassive is not causative-alternation
-  | .passive => .anticausative -- passive also removes the causing participant
+/-- Map each Yukatek detransitivization to its cross-linguistic valency
+    alternation: antipassive → antipassivization (P denucleativized, A → S),
+    anticausative → decausativization (A suppressed, P → S), passive →
+    passivization (A denucleativized but retained, P → S). -/
+def DetransitivizationType.toAlternation : DetransitivizationType → ValencyAlternation
+  | .antipassive => antipassivization
+  | .anticausative => decausativization
+  | .passive => passivization
 
-/-- Active transitive stems detransitivize like antipassive; inactive
-    transitive stems detransitivize like anticausative or passive.
-    ex. (12): p'eh "chip" → antipassive p'èeh,
-    passive p'e'h-el, anticausative p'éeh-el. -/
-theorem antipassive_active_pattern :
-    DetransitivizationType.toGeneral .antipassive = .unmarked := rfl
+/-- All three detransitivizations are valency-decreasing.
+    ex. (12): p'eh "chip" → antipassive p'èeh, passive p'e'h-el,
+    anticausative p'éeh-el. -/
+theorem detransitivizations_decrease_valency :
+    (DetransitivizationType.toAlternation .antipassive).isValencyDecreasing = true ∧
+    (DetransitivizationType.toAlternation .anticausative).isValencyDecreasing = true ∧
+    (DetransitivizationType.toAlternation .passive).isValencyDecreasing = true :=
+  ⟨rfl, rfl, rfl⟩
 
-theorem anticausative_removes_cause :
-    (DetransitivizationType.toGeneral .anticausative).isBieventive = false := rfl
+/-- The fate of the initial A separates passive from anticausative — the
+    distinction the coarser intransitivization typology collapses: passive
+    denucleativizes A (kept in participant structure), anticausative suppresses
+    it (removed). -/
+theorem passive_anticausative_distinct_by_A_fate :
+    (DetransitivizationType.toAlternation .passive).fateOfA = .denucleativized ∧
+    (DetransitivizationType.toAlternation .anticausative).fateOfA = .suppressed :=
+  ⟨rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 10. Template-Level Detransitivization
--- ════════════════════════════════════════════════════
+/-! ### Template-level detransitivization -/
 
-/-- Detransitivization as a template-level operation.
-    rules (28)–(30) decompose detransitivization
-    in terms of which subevent is retained:
+/-- Detransitivization as a template-level operation. rules (28)–(30)
+    decompose detransitivization in terms of which subevent is retained:
 
     - Antipassive: retain the causing process → accomplishment → activity
     - Anticausative: retain the caused change → accomplishment → achievement
@@ -367,8 +426,8 @@ def DetransitivizationType.templateResult : DetransitivizationType → Option Te
   | .anticausative => some .achievement  -- remove PROC+CAUSE, retain CHANGE
   | .passive => some .achievement        -- retain CHANGE, add instigator
 
-/-- Antipassive yields a process (activity); anticausative/passive yield
-    a state change (achievement). This connects to the event type distinction
+/-- Antipassive yields a process (activity); anticausative/passive yield a
+    state change (achievement). This connects to the event type distinction
     that governs verb class membership. -/
 theorem antipassive_yields_process :
     (DetransitivizationType.templateResult .antipassive).map Template.eventType
@@ -378,51 +437,47 @@ theorem anticausative_yields_stateChange :
     (DetransitivizationType.templateResult .anticausative).map Template.eventType
     = some .stateChange := rfl
 
-/-- Anticausative template result matches `Template.intransitiveVariant`
-    from `EventStructure.lean`: both yield achievement from accomplishment. -/
+/-- Anticausative template result matches `Template.intransitiveVariant` from
+    `EventStructure.lean`: both yield achievement from accomplishment. -/
 theorem anticausative_matches_intransitiveVariant :
     DetransitivizationType.templateResult .anticausative
     = Template.intransitiveVariant .accomplishment := rfl
 
--- ════════════════════════════════════════════════════
--- § 11. Additional Verb Predictions
--- ════════════════════════════════════════════════════
+/-! ### Additional verb predictions -/
 
-/-- All externally-caused manner-of-motion verbs causativize,
-    regardless of their active stem class. -/
+/-- All externally-caused manner-of-motion verbs causativize, regardless of
+    their active stem class. -/
 theorem manner_of_motion_all_causative :
-    verbTransitivization chiik = .causative ∧
-    verbTransitivization haarax = .causative ∧
-    verbTransitivization huuy = .causative ∧
-    verbTransitivization mosoon = .causative ∧
-    verbTransitivization pirik = .causative ∧
-    verbTransitivization walak = .causative := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    verbLinking chiik = .causative ∧
+    verbLinking haarax = .causative ∧
+    verbLinking huuy = .causative ∧
+    verbLinking mosoon = .causative ∧
+    verbLinking pirik = .causative ∧
+    verbLinking walak = .causative := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 /-- Additional positional verbs causativize (externally caused). -/
 theorem additional_positionals_causative :
-    verbTransitivization chilTal = .causative ∧
-    verbTransitivization xolTal = .causative := ⟨rfl, rfl⟩
+    verbLinking chilTal = .causative ∧
+    verbLinking xolTal = .causative := ⟨rfl, rfl⟩
 
-/-- Degree achievements in the inactive class causativize despite
-    lacking discrete end states — additional evidence beyond ka'n and na'k. -/
+/-- Degree achievements in the inactive class causativize despite lacking
+    discrete end states — additional evidence beyond ka'n and na'k. -/
 theorem additional_degree_achievements_causative :
-    verbTransitivization lab = .causative ∧
-    verbTransitivization tiil = .causative ∧
-    verbTransitivization tsuuk = .causative := ⟨rfl, rfl, rfl⟩
+    verbLinking lab = .causative ∧
+    verbLinking tiil = .causative ∧
+    verbLinking tsuuk = .causative := ⟨rfl, rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 12. Bridge to SplitErgativity
--- ════════════════════════════════════════════════════
+/-! ### Bridge to split ergativity -/
 
-/-- The linking-by-viewpoint mechanism derives the same alignment
-    as the `SplitErgativity` system parameterized by status category. -/
+/-- The linking-by-viewpoint mechanism derives the same alignment as the
+    `SplitErgativity` system parameterized by status category. -/
 theorem linking_consistent_with_split :
     (yukatekSplit.alignment .completive = .ergative) ∧
     (yukatekSplit.alignment .incompletive = .accusative) := ⟨rfl, rfl⟩
 
-/-- Yukatek's split is aspect-conditioned, like Hindi and Georgian.
-    All three use perfective → ergative, imperfective → accusative
-    (modulo language-specific factor types). -/
+/-- Yukatek's split is aspect-conditioned, like Hindi and Georgian. All three
+    use perfective → ergative, imperfective → accusative (modulo
+    language-specific factor types). -/
 theorem aspect_conditioned_split_family :
     yukatekSplit.alignment .completive =
       Typology.Alignment.hindiSplit.alignment .perfective := rfl

--- a/Linglib/Studies/Creissels2025.lean
+++ b/Linglib/Studies/Creissels2025.lean
@@ -25,10 +25,9 @@ languages. The book proposes a unified framework based on:
 This study file bridges @cite{creissels-2025}'s framework (formalized in
 `Syntax/ArgumentStructure/Alternation.lean`) to existing linglib infrastructure:
 
-- `MorphologicalCausation.lean`: causativization and decausativization
+- `Semantics/Causation/Morphological.lean`: causativization and decausativization
 - `Phenomena/ArgumentStructure/VoiceSystem.lean`: pivot-based voice system typology
-- `Minimalism/Applicative.lean`: Pylkkänen's high/low applicatives
-- `Core/RootDimensions.lean`: Levin's diathesis alternation diagnostics
+- `Syntax/Minimalist/Applicative.lean`: Pylkkänen's high/low applicatives
 -/
 
 namespace Creissels2025
@@ -325,7 +324,7 @@ def mandinka : ObligatoryCodingProfile :=
   , violationsExist := true }
 
 -- ════════════════════════════════════════════════════
--- § 11. Russian -sja polysemy (§8.2, ex. 8)
+-- § 11. Russian -sja polysemy (§1.2, ex. 8)
 -- ════════════════════════════════════════════════════
 
 /-! The Russian verbal suffix *-sja / -s'* is a paradigmatic example of voice
@@ -395,15 +394,17 @@ structure VoiceDistribution where
   alternation : ValencyAlternation
   /-- Fraction of languages with synthetic marking for this alternation. -/
   share : ℚ
-  deriving Repr, BEq
+  deriving Repr
 
-/-- @cite{bahrt-2021} distribution data, cited in §8.3.8. Shares are the
-    fraction of the 222 languages with synthetic marking for each voice
-    alternation type. -/
+/-- @cite{bahrt-2021} distribution data, cited in §8.3.8: the fraction of the
+    222 languages (all genera) with synthetic marking for each voice alternation
+    type. Note (§8.3.8): Bahrt's "applicativization" conflates applicativization
+    with non-causative A/S-nucleativization, so that row is broader than
+    Creissels's `pApplicativization`. -/
 def bahrt2021Distribution : List VoiceDistribution :=
   [ { alternation := causativization,       share := 739/1000 }
   , { alternation := reciprocalization,     share := 604/1000 }
-  , { alternation := pApplicativization,    share := 459/1000 }
+  , { alternation := pApplicativization,    share := 459/1000 }  -- Bahrt's broader "applicativization" (see note)
   , { alternation := reflexivization,       share := 419/1000 }
   , { alternation := decausativization,     share := 360/1000 }
   , { alternation := passivization,         share := 360/1000 }
@@ -461,7 +462,7 @@ structure CodedTerm where
 abbrev CodingFrame := List CodedTerm
 
 def coreCount (f : CodingFrame) : Nat :=
-  (f.filter (fun t => match t.coding with | .core _ => true | _ => false)).length
+  f.countP (fun t => t.coding matches .core _)
 
 /-- Recompute a term's role from transitivity: the sole core term is S; a
     `core S` alongside other cores becomes P (a transitive clause has A and P,
@@ -490,9 +491,11 @@ def removeFirstCore (r : TRRole) : CodingFrame → Option CodingFrame
     if t.coding = .core r then some ts
     else (removeFirstCore r ts).map (t :: ·)
 
-def hasCore (r : TRRole) : CodingFrame → Bool
-  | [] => false
-  | t :: ts => if t.coding = .core r then true else hasCore r ts
+/-- Some core term in the frame bears role `r`. -/
+def HasCore (r : TRRole) (f : CodingFrame) : Prop := ∃ t ∈ f, t.coding = .core r
+
+instance (r : TRRole) (f : CodingFrame) : Decidable (HasCore r f) :=
+  inferInstanceAs (Decidable (∃ t ∈ f, t.coding = .core r))
 
 /-- The atomic voice operations: Creissels's nucleativization /
     denucleativization (§8.1.3) plus cumulation (reflexivization, §8.3.3). -/
@@ -508,7 +511,10 @@ inductive Atom
 abbrev Word := FreeMonoid Atom
 
 /-- Partial transformations of coding frames under Kleisli composition; `f * g`
-    is "apply `f` then `g`" (the `MulOpposite` of `Function.End`-style order). -/
+    is "apply `f` then `g`" (the `MulOpposite` of `Function.End`-style order).
+    Kept a `def` (not `abbrev`) so this `Monoid` is keyed on `FrameMap` and does
+    not leak to bare `_ → Option _`. Not `PFun`: `Part ≠ Option`, and the demos
+    below rely on `Option`'s decidability. -/
 def FrameMap := CodingFrame → Option CodingFrame
 
 instance : Monoid FrameMap where
@@ -529,7 +535,7 @@ def atomDenote : Atom → FrameMap
   | .denucleativize role => fun f => (setFirstCore role .oblique f).map normalizeFrame
   | .suppress role => fun f => (setFirstCore role .suppressed f).map normalizeFrame
   | .cumulate r1 r2 => fun f =>
-      if hasCore r1 f then (removeFirstCore r2 f).map normalizeFrame else none
+      if HasCore r1 f then (removeFirstCore r2 f).map normalizeFrame else none
 
 def atomDelta : Atom → ℤ
   | .nucleativize _ => 1
@@ -599,8 +605,8 @@ theorem netValency_passivization : netValency Word.passivization = -1 := by
   simp only [Word.passivization, netValency, valencyDelta_of, atomDelta]; decide
 
 -- agree with the records' valency direction:
-example : causativization.isValencyIncreasing = true := rfl
-example : passivization.isValencyDecreasing = true := rfl
+theorem causativization_record_increases : causativization.isValencyIncreasing = true := rfl
+theorem passivization_record_decreases : passivization.isValencyDecreasing = true := rfl
 
 /-- Passivization obliquifies the initial A (kept in participant structure);
     P becomes S by normalization. -/
@@ -622,6 +628,20 @@ theorem fate_passivization_agrees :
 theorem fate_decausativization_agrees :
     fateOf (.core .A) .suppressed = decausativization.fateOfA := rfl
 
+/-- Applicativization adds a new core P; on a transitive base this yields a
+    double-P construction (§8.1.8) — no role relabelling required. -/
+theorem denote_applicativization :
+    denote Word.applicativization [⟨0, .core .A⟩, ⟨1, .core .P⟩]
+      = some [⟨0, .core .A⟩, ⟨1, .core .P⟩, ⟨2, .core .P⟩] := by
+  simp only [Word.applicativization, denote_of]; decide
+
+/-- Reflexivization cumulates A and P into a single core term, which normalizes
+    to S (§8.3.3). -/
+theorem denote_reflexivization :
+    denote Word.reflexivization [⟨0, .core .A⟩, ⟨1, .core .P⟩]
+      = some [⟨0, .core .S⟩] := by
+  simp only [Word.reflexivization, denote_of]; decide
+
 /-! ### Real composition for voice stacking (§8.4) -/
 
 /-- Stacking is genuine composition: a word product denotes the Kleisli
@@ -630,6 +650,14 @@ theorem fate_decausativization_agrees :
 theorem denote_stack (x y : Word) (f : CodingFrame) :
     denote (x * y) f = (denote x f).bind (denote y) := by
   rw [map_mul]; rfl
+
+/-- Under stacking, "the A" is frame-relative: after causativization of an
+    intransitive, the participant in role A is the new causer (id 1), not the
+    original (id 0, now P). So a fate must be read off the *current* frame's
+    role-holder, not a frozen "initial A". -/
+theorem caus_A_holder_is_causer :
+    (denote Word.causativization [⟨0, .core .S⟩]).bind (roleHolder .A) = some 1 := by
+  simp only [Word.causativization, denote_of]; decide
 
 /-- §12.3.5: causativization via prior antipassivization is valency-neutral
     (antipassive −1 then causative +1), composed as one transformation. -/

--- a/Linglib/Studies/Creissels2025.lean
+++ b/Linglib/Studies/Creissels2025.lean
@@ -38,9 +38,7 @@ open Semantics.Causation.Morphological
    CausativizabilityData)
 open Interfaces (VoiceSystemProfile VoiceSystemSymmetry VoiceEntry PivotTarget)
 
--- ════════════════════════════════════════════════════
--- § 1. Bridge: Decausativization ↔ IntransitivizationType
--- ════════════════════════════════════════════════════
+/-! ### Bridge: Decausativization ↔ IntransitivizationType -/
 
 /-! §8.3.1.2: "Decausativization suppresses the referent
 of the initial A from participant structure and converts the initial P into
@@ -67,9 +65,7 @@ theorem reflexive_not_decausativization :
     decausativization.involvesCumulation = false :=
   ⟨rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 2. Bridge: Causativization ↔ CausativeConstruction
--- ════════════════════════════════════════════════════
+/-! ### Bridge: Causativization ↔ CausativeConstruction -/
 
 /-! §8.3.1.1 defines causativization as "the
 nucleativization of a participant (the causer) that instigates the event
@@ -108,9 +104,7 @@ theorem complexity_alignment :
     (CausativeComplexity.morphological < CausativeComplexity.periphrastic) :=
   ⟨by decide, by decide⟩
 
--- ════════════════════════════════════════════════════
--- § 3. Bridge: Applicativization ↔ Pylkkänen's ApplType
--- ════════════════════════════════════════════════════
+/-! ### Bridge: Applicativization ↔ Pylkkänen's ApplType -/
 
 /-! §14.1 distinguishes three varieties:
 - P-applicativization (§14.1.1): applied phrase fills P role
@@ -136,9 +130,7 @@ theorem all_applicativizations_nucleativize :
 theorem p_applicativization_valency_increasing :
     pApplicativization.isValencyIncreasing = true := rfl
 
--- ════════════════════════════════════════════════════
--- § 4. Bridge: Symmetrical Voices ↔ VoiceSystemProfile
--- ════════════════════════════════════════════════════
+/-! ### Bridge: Symmetrical Voices ↔ VoiceSystemProfile -/
 
 /-! §8.5: symmetrical voice systems are those in which
 verb morphology marks the selection of a participant as the privileged
@@ -168,9 +160,7 @@ theorem english_is_asymmetrical :
 theorem english_is_active_passive :
     englishVoiceSystem.isActivePassive := by decide
 
--- ════════════════════════════════════════════════════
--- § 5. Passivization vs Decausativization (§8.3.1.2 vs §8.3.2.1)
--- ════════════════════════════════════════════════════
+/-! ### Passivization vs Decausativization (§8.3.1.2 vs §8.3.2.1) -/
 
 /-! §8.3.2.1: "The maintenance of the initial A in
 participant structure is essential to distinguish passivization from
@@ -192,9 +182,7 @@ theorem passive_decausative_distinct :
     passivization.fateOfA ≠ decausativization.fateOfA := by
   simp [passivization, decausativization]
 
--- ════════════════════════════════════════════════════
--- § 6. Bridge: Passivization ↔ Antipassivization structural symmetry
--- ════════════════════════════════════════════════════
+/-! ### Bridge: Passivization ↔ Antipassivization structural symmetry -/
 
 /-! §8.3.2: passivization, antipassivization, and
 S-denucleativization form a natural class — all three denucleativize a core
@@ -222,9 +210,7 @@ theorem denucleativization_paradigm :
     sDenucleativization.fateOfS = .denucleativized :=
   ⟨rfl, rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 7. Bridge: Reflexivization/Reciprocalization ↔ existing data
--- ════════════════════════════════════════════════════
+/-! ### Bridge: Reflexivization/Reciprocalization ↔ existing data -/
 
 /-! §8.3.3: reflexivization and reciprocalization
 cumulate two participant roles (A and P) into a single participant (S).
@@ -246,9 +232,7 @@ theorem refl_recip_same_structure :
     reciprocalization.involvesCumulation = true :=
   ⟨rfl, rfl, rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 8. Voice Marker Stacking (§8.4)
--- ════════════════════════════════════════════════════
+/-! ### Voice Marker Stacking (§8.4) -/
 
 /-! §8.4: voice markers can be stacked compositionally.
 Example from Tswana (§8.4.1, ex. 38):
@@ -270,9 +254,7 @@ def tswana_caus_pass : VoiceStack := [causativization, passivization]
 def tswana_caus_appl_pass : VoiceStack :=
   [causativization, pApplicativization, passivization]
 
--- ════════════════════════════════════════════════════
--- § 9. Portative Derivation (§8.3.7)
--- ════════════════════════════════════════════════════
+/-! ### Portative Derivation (§8.3.7) -/
 
 /-! §8.3.7 identifies portative derivation as a distinct
 voice alternation type that cannot be reduced to either causativization or
@@ -296,9 +278,7 @@ theorem portative_distinct_from_causativization :
     portativeDerivation.newParticipant = some .P :=
   ⟨rfl, rfl, rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 10. Alignment Profiles (§1.3.4)
--- ════════════════════════════════════════════════════
+/-! ### Alignment Profiles (§1.3.4) -/
 
 /-! §1.3.4.2: most languages have a clear preference
 for either A-alignment (S codes like A) or P-alignment (S codes like P).
@@ -323,9 +303,7 @@ def mandinka : ObligatoryCodingProfile :=
   , defaultAlignment := .A_alignment
   , violationsExist := true }
 
--- ════════════════════════════════════════════════════
--- § 11. Russian -sja polysemy (§1.2, ex. 8)
--- ════════════════════════════════════════════════════
+/-! ### Russian -sja polysemy (§1.2, ex. 8) -/
 
 /-! The Russian verbal suffix *-sja / -s'* is a paradigmatic example of voice
 marker polysemy. It marks at least four different voice alternation types:
@@ -345,9 +323,7 @@ def russian_sja : VoiceMarkerProfile :=
 theorem russian_sja_polysemy :
     russian_sja.alternations.length = 4 := rfl
 
--- ════════════════════════════════════════════════════
--- § 12. Tswana -el polysemy (§8.2)
--- ════════════════════════════════════════════════════
+/-! ### Tswana -el polysemy (§8.2) -/
 
 /-! The Tswana voice suffix *-el* (traditionally called "applicative") marks
 both P-nucleativization (applicativization) and A-nucleativization of
@@ -363,9 +339,7 @@ def tswana_el : VoiceMarkerProfile :=
   , marker := "-el"
   , alternations := [pApplicativization, asNucleativizationOfObliques] }
 
--- ════════════════════════════════════════════════════
--- § 13. Causativizability and Voice Alternations
--- ════════════════════════════════════════════════════
+/-! ### Causativizability and Voice Alternations -/
 
 /-! Ch 12 discusses restrictions on causativization.
 @cite{krejci-2012}'s hierarchy (already formalized in
@@ -381,9 +355,7 @@ create an intransitive base first. -/
 def causativization_via_antipassive : VoiceStack :=
   [antipassivization, causativization]
 
--- ════════════════════════════════════════════════════
--- § 14. Cross-linguistic voice distribution (Bahrt 2021)
--- ════════════════════════════════════════════════════
+/-! ### Cross-linguistic voice distribution (Bahrt 2021) -/
 
 /-! §8.3.8 reports @cite{bahrt-2021}'s survey of synthetic voice marking across
 222 languages from all genera. -/
@@ -416,9 +388,7 @@ theorem causativization_most_common :
     (bahrt2021Distribution.head?.map (·.alternation.name)) =
     some "causativization" := rfl
 
--- ════════════════════════════════════════════════════
--- § 15. Compositional denotation of voice stacking (§8.4)
--- ════════════════════════════════════════════════════
+/-! ### Compositional denotation of voice stacking (§8.4) -/
 
 /-! §8.4: voice markers stack, and a combination "operates on its valency
 properties exactly as it could operate on the valency of an underived verb form"

--- a/Linglib/Studies/Creissels2025.lean
+++ b/Linglib/Studies/Creissels2025.lean
@@ -2,6 +2,8 @@ import Linglib.Syntax.ArgumentStructure.Alternation
 import Linglib.Semantics.Causation.Morphological
 import Linglib.Phenomena.ArgumentStructure.VoiceSystem
 import Linglib.Syntax.Minimalist.Applicative
+import Mathlib.Algebra.FreeMonoid.Basic
+import Mathlib.Algebra.Group.TypeTags.Basic
 
 /-!
 # Creissels (2025): Transitivity, Valency, and Voice
@@ -21,7 +23,7 @@ languages. The book proposes a unified framework based on:
   where the same morpheme marks multiple voice alternation types (§8.2)
 
 This study file bridges @cite{creissels-2025}'s framework (formalized in
-`Core/Alternation.lean`) to existing linglib infrastructure:
+`Syntax/ArgumentStructure/Alternation.lean`) to existing linglib infrastructure:
 
 - `MorphologicalCausation.lean`: causativization and decausativization
 - `Phenomena/ArgumentStructure/VoiceSystem.lean`: pivot-based voice system typology
@@ -379,5 +381,265 @@ create an intransitive base first. -/
     compositional voice marker stacking. -/
 def causativization_via_antipassive : VoiceStack :=
   [antipassivization, causativization]
+
+-- ════════════════════════════════════════════════════
+-- § 14. Cross-linguistic voice distribution (Bahrt 2021)
+-- ════════════════════════════════════════════════════
+
+/-! §8.3.8 reports @cite{bahrt-2021}'s survey of synthetic voice marking across
+222 languages from all genera. -/
+
+/-- Cross-linguistic prevalence of a voice alternation type: the share of
+    languages with synthetic marking for it. -/
+structure VoiceDistribution where
+  alternation : ValencyAlternation
+  /-- Fraction of languages with synthetic marking for this alternation. -/
+  share : ℚ
+  deriving Repr, BEq
+
+/-- @cite{bahrt-2021} distribution data, cited in §8.3.8. Shares are the
+    fraction of the 222 languages with synthetic marking for each voice
+    alternation type. -/
+def bahrt2021Distribution : List VoiceDistribution :=
+  [ { alternation := causativization,       share := 739/1000 }
+  , { alternation := reciprocalization,     share := 604/1000 }
+  , { alternation := pApplicativization,    share := 459/1000 }
+  , { alternation := reflexivization,       share := 419/1000 }
+  , { alternation := decausativization,     share := 360/1000 }
+  , { alternation := passivization,         share := 360/1000 }
+  , { alternation := antipassivization,     share := 185/1000 } ]
+
+/-- Causativization is the most common voice alternation type
+    cross-linguistically (@cite{bahrt-2021}). -/
+theorem causativization_most_common :
+    (bahrt2021Distribution.head?.map (·.alternation.name)) =
+    some "causativization" := rfl
+
+-- ════════════════════════════════════════════════════
+-- § 15. Compositional denotation of voice stacking (§8.4)
+-- ════════════════════════════════════════════════════
+
+/-! §8.4: voice markers stack, and a combination "operates on its valency
+properties exactly as it could operate on the valency of an underived verb form"
+— compositional stacking (§8.4.1). We model an alternation as a *word* over
+atomic coding-frame edits (the nucleativization/denucleativization atoms of
+§8.1.3), composition as the free-monoid product, and meaning as a denotation
+into partial transformations of coding frames. Two `MonoidHom`s — `denote` and
+`valencyDelta` — make stacking and the valency grading hold by construction.
+
+End-roles (the S→P of causativization, P→S of passivization) are *derived* by
+`normalizeFrame` from the construction's transitivity, not stipulated — faithful
+to §8.1.3 (whose only atoms are nucleativization/denucleativization; the role
+changes are coding consequences, cf. footnote 5 §8.3.2.1).
+
+This layer currently has a single consumer (this study), so per the project's
+graduation discipline it lives here; the `FrameMap` partial-transformation
+monoid (a Kleisli/`Function.End` analogue) and the `denote`/`valencyDelta`
+apparatus would hoist to `Core/` and `Alternation.lean` once a second study
+consumes them. -/
+
+namespace Stacking
+
+open FreeMonoid (lift of)
+
+/-- A term's coding status in a construction (a *state*; `ParticipantFate` is the
+    *transition*, derived below via `fateOf`). -/
+inductive Coding
+  | core (r : TRRole)
+  | oblique
+  | suppressed
+  deriving DecidableEq
+
+/-- A coding-frame entry: a stable identity (tracked through a derivation) and
+    its current status. -/
+structure CodedTerm where
+  id : Nat
+  coding : Coding
+  deriving DecidableEq
+
+/-- A coding frame (§1.3.3): the participants and their statuses. -/
+abbrev CodingFrame := List CodedTerm
+
+def coreCount (f : CodingFrame) : Nat :=
+  (f.filter (fun t => match t.coding with | .core _ => true | _ => false)).length
+
+/-- Recompute a term's role from transitivity: the sole core term is S; a
+    `core S` alongside other cores becomes P (a transitive clause has A and P,
+    an intransitive clause has S). -/
+def rerole (cc : Nat) : Coding → Coding
+  | .core r => if cc = 1 then .core .S else (match r with | .S => .core .P | _ => .core r)
+  | c => c
+
+/-- Normalize end-roles after an edit — this *derives* the S↔P relabellings a
+    `relabel` atom would otherwise stipulate. -/
+def normalizeFrame (f : CodingFrame) : CodingFrame :=
+  let cc := coreCount f
+  f.map (fun t => ⟨t.id, rerole cc t.coding⟩)
+
+def freshId (f : CodingFrame) : Nat := f.foldl (fun m t => Nat.max m (t.id + 1)) 0
+
+def setFirstCore (r : TRRole) (c : Coding) : CodingFrame → Option CodingFrame
+  | [] => none
+  | t :: ts =>
+    if t.coding = .core r then some (⟨t.id, c⟩ :: ts)
+    else (setFirstCore r c ts).map (t :: ·)
+
+def removeFirstCore (r : TRRole) : CodingFrame → Option CodingFrame
+  | [] => none
+  | t :: ts =>
+    if t.coding = .core r then some ts
+    else (removeFirstCore r ts).map (t :: ·)
+
+def hasCore (r : TRRole) : CodingFrame → Bool
+  | [] => false
+  | t :: ts => if t.coding = .core r then true else hasCore r ts
+
+/-- The atomic voice operations: Creissels's nucleativization /
+    denucleativization (§8.1.3) plus cumulation (reflexivization, §8.3.3). -/
+inductive Atom
+  | nucleativize (target : TRRole)  -- a non-core participant becomes core   (+1)
+  | denucleativize (role : TRRole)  -- core role → oblique (kept)             (−1)
+  | suppress (role : TRRole)        -- core role → suppressed (removed)       (−1)
+  | cumulate (r1 r2 : TRRole)       -- merge two cores into one               (−1)
+  deriving DecidableEq
+
+/-- An alternation as a word over atoms; composition = the free-monoid product
+    (= voice-marker stacking, §8.4). -/
+abbrev Word := FreeMonoid Atom
+
+/-- Partial transformations of coding frames under Kleisli composition; `f * g`
+    is "apply `f` then `g`" (the `MulOpposite` of `Function.End`-style order). -/
+def FrameMap := CodingFrame → Option CodingFrame
+
+instance : Monoid FrameMap where
+  mul f g := fun x => (f x).bind g
+  one := fun x => some x
+  mul_assoc f g h := by
+    funext x
+    show ((f x).bind g).bind h = (f x).bind (fun y => (g y).bind h)
+    cases f x <;> rfl
+  one_mul f := by funext x; rfl
+  mul_one f := by
+    funext x
+    show (f x).bind (fun y => some y) = f x
+    cases f x <;> rfl
+
+def atomDenote : Atom → FrameMap
+  | .nucleativize target => fun f => some (normalizeFrame (f ++ [⟨freshId f, .core target⟩]))
+  | .denucleativize role => fun f => (setFirstCore role .oblique f).map normalizeFrame
+  | .suppress role => fun f => (setFirstCore role .suppressed f).map normalizeFrame
+  | .cumulate r1 r2 => fun f =>
+      if hasCore r1 f then (removeFirstCore r2 f).map normalizeFrame else none
+
+def atomDelta : Atom → ℤ
+  | .nucleativize _ => 1
+  | .denucleativize _ => -1
+  | .suppress _ => -1
+  | .cumulate _ _ => -1
+
+/-- Denotation of a word as a partial coding-frame transformation. A `MonoidHom`,
+    so `map_mul` gives compositional stacking (§8.4.1). -/
+def denote : Word →* FrameMap := lift atomDenote
+
+/-- The valency grading: net change in number of core terms. A `MonoidHom` into
+    `Multiplicative ℤ`, so stacking *adds* deltas. -/
+def valencyDelta : Word →* Multiplicative ℤ :=
+  lift (fun a => Multiplicative.ofAdd (atomDelta a))
+
+def netValency (w : Word) : ℤ := Multiplicative.toAdd (valencyDelta w)
+
+@[simp] theorem denote_of (a : Atom) : denote (of a) = atomDenote a := by
+  simp only [denote, FreeMonoid.lift_eval_of]
+
+@[simp] theorem valencyDelta_of (a : Atom) :
+    valencyDelta (of a) = Multiplicative.ofAdd (atomDelta a) := by
+  simp only [valencyDelta, FreeMonoid.lift_eval_of]
+
+theorem netValency_mul (x y : Word) : netValency (x * y) = netValency x + netValency y := by
+  simp only [netValency, map_mul]; rfl
+
+/-- The substrate `ParticipantFate`, derived from a status transition — reusing
+    the comparative-concept enum rather than forking a new one. -/
+def fateOf : Coding → Coding → ParticipantFate
+  | .core _, .core _ => .maintained
+  | .core _, .oblique => .denucleativized
+  | .core _, .suppressed => .suppressed
+  | _, .core t => .nucleativized t
+  | _, _ => .maintained
+
+/-- Id of the participant currently in core role `r` (frame-relative). -/
+def roleHolder (r : TRRole) : CodingFrame → Option Nat
+  | [] => none
+  | t :: ts => if t.coding = .core r then some t.id else roleHolder r ts
+
+/-! ### Named alternations as words (roles fall out of `normalizeFrame`) -/
+
+namespace Word
+def causativization : Word := of (.nucleativize .A)
+def passivization : Word := of (.denucleativize .A)
+def decausativization : Word := of (.suppress .A)
+def antipassivization : Word := of (.denucleativize .P)
+def applicativization : Word := of (.nucleativize .P)
+def reflexivization : Word := of (.cumulate .A .P)
+/-- §12.3.5: causativizing a transitive verb requires antipassivizing first to
+    create an intransitive base. -/
+def causativizationViaAntipassive : Word := antipassivization * causativization
+end Word
+
+/-! ### Forward bridges: the denotation reproduces the comparative-concept records
+
+These prove the word denotations *agree with* the schema-level
+`ValencyAlternation` records (`Alternation.lean`) where both are defined — the
+legitimate direction, not a redefinition of the schema. -/
+
+theorem netValency_causativization : netValency Word.causativization = 1 := by
+  simp only [Word.causativization, netValency, valencyDelta_of, atomDelta]; decide
+
+theorem netValency_passivization : netValency Word.passivization = -1 := by
+  simp only [Word.passivization, netValency, valencyDelta_of, atomDelta]; decide
+
+-- agree with the records' valency direction:
+example : causativization.isValencyIncreasing = true := rfl
+example : passivization.isValencyDecreasing = true := rfl
+
+/-- Passivization obliquifies the initial A (kept in participant structure);
+    P becomes S by normalization. -/
+theorem denote_passivization :
+    denote Word.passivization [⟨0, .core .A⟩, ⟨1, .core .P⟩]
+      = some [⟨0, .oblique⟩, ⟨1, .core .S⟩] := by
+  simp only [Word.passivization, denote_of]; decide
+
+/-- Decausativization suppresses the initial A (removed). Same net valency as
+    passive, different A-fate — the headline §8.3.1.2 / §8.3.2.1 distinction. -/
+theorem denote_decausativization :
+    denote Word.decausativization [⟨0, .core .A⟩, ⟨1, .core .P⟩]
+      = some [⟨0, .suppressed⟩, ⟨1, .core .S⟩] := by
+  simp only [Word.decausativization, denote_of]; decide
+
+-- the derived fates match the records' `fateOfA`:
+theorem fate_passivization_agrees :
+    fateOf (.core .A) .oblique = passivization.fateOfA := rfl
+theorem fate_decausativization_agrees :
+    fateOf (.core .A) .suppressed = decausativization.fateOfA := rfl
+
+/-! ### Real composition for voice stacking (§8.4) -/
+
+/-- Stacking is genuine composition: a word product denotes the Kleisli
+    composite of its parts (§8.4.1). This gives the denotational counterpart of
+    the record-level, semantics-free `causativization_via_antipassive` (§13). -/
+theorem denote_stack (x y : Word) (f : CodingFrame) :
+    denote (x * y) f = (denote x f).bind (denote y) := by
+  rw [map_mul]; rfl
+
+/-- §12.3.5: causativization via prior antipassivization is valency-neutral
+    (antipassive −1 then causative +1), composed as one transformation. -/
+theorem netValency_causativizationViaAntipassive :
+    netValency Word.causativizationViaAntipassive = 0 := by
+  show netValency (Word.antipassivization * Word.causativization) = 0
+  rw [netValency_mul]
+  simp only [Word.antipassivization, Word.causativization, netValency, valencyDelta_of, atomDelta]
+  decide
+
+end Stacking
 
 end Creissels2025

--- a/Linglib/Syntax/ArgumentStructure/Alternation.lean
+++ b/Linglib/Syntax/ArgumentStructure/Alternation.lean
@@ -3,13 +3,24 @@ import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
 
 /-!
 # Valency Alternation Typology
-@cite{creissels-2025}
 
-A unified framework for describing valency alternations cross-linguistically,
-following @cite{creissels-2025}'s framework for transitivity, valency, and
-voice. This file provides the core vocabulary that subsumes both
-@cite{levin-1993}'s English-specific diathesis alternations and
-@cite{creissels-2025}'s cross-linguistic voice alternation typology.
+@cite{comrie-1989} @cite{dixon-1994} @cite{dixon-aikhenvald-2000} @cite{song-1996}
+@cite{creissels-2025} @cite{levin-1993}
+
+A framework-neutral vocabulary for describing valency alternations
+cross-linguistically. The underlying typology of valency-changing operations —
+causative, anticausative/decausative, passive, antipassive, applicative,
+reflexive/reciprocal, and the increase or decrease of core arguments — is the
+cross-framework consensus of @cite{comrie-1989}, @cite{dixon-1994} on
+ergativity and A/S/P, @cite{dixon-aikhenvald-2000}'s *Changing Valency*, and
+@cite{song-1996} on causatives. @cite{creissels-2025} provides the modern
+synthesis and the nucleativization/denucleativization terminology used here;
+@cite{levin-1993} supplies the English diathesis-alternation inventory bridged
+in the final section.
+
+This file is substrate: it defines the alternation *types*. Per-paper data and
+cross-linguistic distributions live in the consuming study files (e.g.
+`Studies/Creissels2025.lean`).
 
 ## TR-roles
 
@@ -160,6 +171,13 @@ structure ValencyAlternation where
   initialTransitive : Option Bool
   /-- Is the derived construction transitive? -/
   derivedTransitive : Option Bool
+  /-- Morphological coding of the alternation (voice vs. flexivalency).
+      Defaults to `.uncoded`, the morphologically unmarked baseline. Coding is
+      a *per-language* property: the same structural alternation may be coded
+      (voice) in one language and uncoded (flexivalency) in another — e.g.
+      Tswana decausative (synthetic) vs. English *break/break* (uncoded). Set
+      `marking` when instantiating an alternation for a specific language. -/
+  marking : AlternationMarking := .uncoded
   deriving Repr, BEq
 
 -- ════════════════════════════════════════════════════
@@ -410,38 +428,6 @@ structure VoiceMarkerProfile where
   /-- Which alternation types this marker can encode -/
   alternations : List ValencyAlternation
   deriving Repr, BEq
-
--- ════════════════════════════════════════════════════
--- § 8. Voice Alternation Distribution (§8.3.8)
--- ════════════════════════════════════════════════════
-
-/-- Cross-linguistic prevalence of voice alternation types.
-
-    §8.3.8, citing @cite{bahrt-2021}: distribution of
-    synthetic voice marking across 222 languages from all genera. -/
-structure VoiceDistribution where
-  alternation : ValencyAlternation
-  /-- Percentage of languages with synthetic marking for this alternation -/
-  percentage : Float
-  deriving Repr, BEq
-
-/-- @cite{bahrt-2021} distribution data, cited in
-    §8.3.8. Percentages represent languages (out of 222) with synthetic
-    marking for each voice alternation type. -/
-def bahrt2021Distribution : List VoiceDistribution :=
-  [ { alternation := causativization,       percentage := 73.9 }
-  , { alternation := reciprocalization,     percentage := 60.4 }
-  , { alternation := pApplicativization,    percentage := 45.9 }
-  , { alternation := reflexivization,       percentage := 41.9 }
-  , { alternation := decausativization,     percentage := 36.0 }
-  , { alternation := passivization,         percentage := 36.0 }
-  , { alternation := antipassivization,     percentage := 18.5 } ]
-
-/-- Causativization is the most common voice alternation type
-    cross-linguistically (@cite{bahrt-2021}). -/
-theorem causativization_most_common :
-    (bahrt2021Distribution.head?.map (·.alternation.name)) =
-    some "causativization" := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 9. Properties

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4201,6 +4201,27 @@
   validated = {true},
   sources   = {Fragments/Jarawara/PossessedNouns.lean}
 }
+@book{dixon-aikhenvald-2000,
+  editor    = {Dixon, R. M. W. and Aikhenvald, Alexandra Y.},
+  year      = {2000},
+  title     = {Changing Valency: Case Studies in Transitivity},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  subfield  = {typology},
+  role      = {cited},
+  sources   = {Syntax/ArgumentStructure/Alternation.lean}
+}
+@book{bahrt-2021,
+  author    = {Bahrt, Nicklas Norby},
+  year      = {2021},
+  title     = {Voice Syncretism},
+  series    = {Studies in Diversity Linguistics},
+  publisher = {Language Science Press},
+  address   = {Berlin},
+  subfield  = {typology},
+  role      = {cited},
+  sources   = {Studies/Creissels2025.lean}
+}
 @article{bochvar-1937,
   author    = {Bochvar, D. A.},
   year      = {1937},


### PR DESCRIPTION
Rework the valency-alternation formalization across substrate and studies.

- Re-anchor `Alternation.lean` off Creissels 2025 onto Comrie 1989 / Dixon & Aikhenvald 2000 (fixes an existing chronology violation — Chierchia1984 / KoontzGarboden2009 already imported a 2025-anchored file); add a per-language `marking` field; move Bahrt 2021 data to the Creissels study.
- Rewrite `Bohnemeyer2004` to mathlib idiom (markdown headers, `Prop` predicates, split linking vs morpheme); route detransitivization through `ValencyAlternation`.
- Add a compositional denotation layer for voice-marker stacking (§8.4) to `Studies/Creissels2025`.