### PR TITLE
feat(Pronoun): clusivity φ-feature; disambiguate nominal classifiers

### DIFF
--- a/Linglib/Core/Nominal/Description.lean
+++ b/Linglib/Core/Nominal/Description.lean
@@ -8,7 +8,7 @@ import Linglib.Features.Definiteness
 @cite{moroney-2021} @cite{schwarz-2009} @cite{schwarz-2013}
 @cite{sharvy-1980} @cite{kriz-2015}
 
-A single sum type `NominalKind F` covering the principal flavors of nominal
+A single sum type `Description F` covering the principal flavors of nominal
 description that the syntax–semantics interface needs to distinguish:
 
 - bare noun (number-neutral; covert type-shifts decide the reading)
@@ -50,7 +50,7 @@ unified `F.Denot` machinery rather than ad-hoc `E → Bool` predicates.
 - **`possessive` carries possessor + relation expressions** rather than
   conflating them with the restrictor. The relation has type `e ⇒ e ⇒ t`,
   and the possessor is an `e`-type expression that may itself be derived
-  from a `NominalKind` higher in the structure.
+  from a `Description` higher in the structure.
 
 - **Reuses `Features.Deixis.Feature`** for the deictic content, so
   Shan/English/Latin/German fragments share the same enum.
@@ -69,10 +69,12 @@ open Core.Logic.Intensional.Variables
 -- § The Sum Type
 -- ════════════════════════════════════════════════════════════════
 
-/-- Principal flavors of nominal description. The frame parameter `F` supplies
-    the entity domain and index set so all subexpressions live in the same
-    `F.Denot` universe. -/
-inductive NominalKind (F : Frame) where
+/-- Principal flavors of nominal description — the *definiteness/reference*
+    axis (bare/indefinite vs the definite subtypes), orthogonal to
+    `Features.BindingClass` (binding distribution) and to a pronoun's lexical
+    kind. The frame parameter `F` supplies the entity domain and index set so
+    all subexpressions live in the same `F.Denot` universe. -/
+inductive Description (F : Frame) where
   /-- Bare noun (no overt determiner). The actual reading — kind, indefinite,
       unique, or anaphoric — is selected by the language's covert type-shift
       hierarchy (@cite{chierchia-1998}, @cite{dayal-2004}). -/
@@ -108,13 +110,13 @@ inductive NominalKind (F : Frame) where
 -- § Classification Predicates (derivable, no semantics yet)
 -- ════════════════════════════════════════════════════════════════
 
-namespace NominalKind
+namespace Description
 
 variable {F : Frame}
 
 /-- Is this a definite description (in the broad sense — uniqueness,
     familiarity, demonstrative, or possessive)? -/
-def isDefinite : NominalKind F → Prop
+def isDefinite : Description F → Prop
   | .bare _              => False
   | .indefinite _        => False
   | .unique _ _          => True
@@ -127,7 +129,7 @@ instance : DecidablePred (@isDefinite F) := fun n => by
 
 /-- Does this description require a discourse antecedent? Anaphoric and
     demonstrative do; unique/possessive/bare/indefinite do not. -/
-def isAnaphoric : NominalKind F → Prop
+def isAnaphoric : Description F → Prop
   | .anaphoric _ _       => True
   | .demonstrative ..    => True
   | _                    => False
@@ -138,16 +140,16 @@ instance : DecidablePred (@isAnaphoric F) := fun n => by
 /-- Does this description bind a structural situation pronoun? Coppock–Beaver
     uniqueness and demonstratives do (resource situation for maximality and
     deictic check); the other constructors do not. -/
-def usesSituationPronoun : NominalKind F → Bool
+def usesSituationPronoun : Description F → Bool
   | .unique _ _          => true
   | .demonstrative ..    => true
   | _                    => false
 
-/-- Map each `NominalKind` flavor to the @cite{schwarz-2009}–@cite{schwarz-2013}
+/-- Map each `Description` flavor to the @cite{schwarz-2009}–@cite{schwarz-2013}
     presupposition type it expresses, where applicable. Bare and indefinite
     return `none` because they are not (in themselves) definites. -/
 def expectedPresupType :
-    NominalKind F → Option Features.Definiteness.DefPresupType
+    Description F → Option Features.Definiteness.DefPresupType
   | .bare _              => none
   | .indefinite _        => none
   | .unique _ _          => some .uniqueness
@@ -157,12 +159,12 @@ def expectedPresupType :
 
 /-- Definites are exactly those flavors with a non-`none` expected
     presupposition type. By construction. -/
-theorem isDefinite_iff_expectedPresup_some (n : NominalKind F) :
+theorem isDefinite_iff_expectedPresup_some (n : Description F) :
     n.isDefinite ↔ n.expectedPresupType.isSome = true := by
   cases n <;> simp [isDefinite, expectedPresupType]
 
 /-- Anaphoric flavors all carry the familiarity presupposition type. -/
-theorem isAnaphoric_implies_familiarity (n : NominalKind F)
+theorem isAnaphoric_implies_familiarity (n : Description F)
     (h : n.isAnaphoric) :
     n.expectedPresupType = some .familiarity := by
   cases n <;> simp [isAnaphoric] at h
@@ -179,7 +181,7 @@ theorem isAnaphoric_implies_familiarity (n : NominalKind F)
     it fills the situation-pronoun slot, which `interpret` discards
     (`interpret_unique_index_irrelevant`). -/
 def ofPresupType (p : Features.Definiteness.DefPresupType)
-    (restrictor : DenotGS F .et) (idx : Nat) : NominalKind F :=
+    (restrictor : DenotGS F .et) (idx : Nat) : Description F :=
   match p with
   | .uniqueness  => .unique restrictor idx
   | .familiarity => .anaphoric restrictor idx
@@ -190,6 +192,6 @@ theorem expectedPresupType_ofPresupType
     (ofPresupType p R idx).expectedPresupType = some p := by
   cases p <;> rfl
 
-end NominalKind
+end Description
 
 end Core.Nominal

--- a/Linglib/Core/Nominal/Determiner.lean
+++ b/Linglib/Core/Nominal/Determiner.lean
@@ -34,9 +34,9 @@ localized to a single declaration.
 ## Implementation notes
 
 An `Article`'s admissible @cite{schwarz-2009} strengths are `Article.presupTypes`
-(Frame-free, read off `uses`); its denotation is `Article.toNominalKinds`
-(`Core/Nominal/DeterminerLicensing.lean`, Frame-aware) — the set of `NominalKind`s
-those strengths admit via `NominalKind.ofPresupType`, so a syncretic article like
+(Frame-free, read off `uses`); its denotation is `Article.toDescriptions`
+(`Core/Nominal/DeterminerLicensing.lean`, Frame-aware) — the set of `Description`s
+those strengths admit via `Description.ofPresupType`, so a syncretic article like
 English *the* denotes *both* the weak and the strong description.
 `Demonstrative.denote` (deictic), the `Quantifier` generalized quantifier
 (`Core/Logic/Quantification`), and the `Possessive` possession relation remain
@@ -247,8 +247,8 @@ end Determiner
 The @cite{schwarz-2009} presupposition types an article *can* express — its
 admissible readings, read off `uses`. A syncretic article (English *the*) admits
 both; a weak- or strong-only article admits one. The image of these under
-`NominalKind.ofPresupType` is the article's set of possible denotations
-(`Article.toNominalKinds`, in `DeterminerLicensing.lean`). -/
+`Description.ofPresupType` is the article's set of possible denotations
+(`Article.toDescriptions`, in `DeterminerLicensing.lean`). -/
 
 /-- The @cite{schwarz-2009} strengths an article admits, read off its `uses` (as a
 list — `DefPresupType` is binary, so its content is the membership-closure). -/

--- a/Linglib/Core/Nominal/DeterminerLicensing.lean
+++ b/Linglib/Core/Nominal/DeterminerLicensing.lean
@@ -5,24 +5,24 @@ import Linglib.Core.Nominal.Description
 # Determiner licensing
 
 `Determiner.licenses`: does a declared `List Determiner.Entry` have the surface
-form needed to realize a given `NominalKind` constructor? Kept separate from
+form needed to realize a given `Description` constructor? Kept separate from
 `Determiner.lean` so that marking-only Fragments do not transitively import the
-Frame-parameterized `NominalKind` substrate.
+Frame-parameterized `Description` substrate.
 -/
 
 open Core.Logic.Intensional (Frame)
 open Core.Logic.Intensional.Variables (DenotGS)
-open Core.Nominal (NominalKind)
+open Core.Nominal (Description)
 open Features.Definiteness (DefPresupType)
 
 namespace Determiner
 
 /-- Does the declared determiner set have the surface form needed to realize the
-given `NominalKind` constructor? Bare nominals are always licensed; unique and
+given `Description` constructor? Bare nominals are always licensed; unique and
 anaphoric definites need a determiner exponing the corresponding presupposition
 type (`MarksPresup`); indefinite/demonstrative/possessive need a determiner of
 that kind. -/
-def licenses {F : Frame} (ds : List Entry) : NominalKind F → Prop
+def licenses {F : Frame} (ds : List Entry) : Description F → Prop
   | .bare _           => True
   | .indefinite _     => ∃ e ∈ ds, e.IsIndefiniteArticle
   | .unique _ _       => MarksPresup ds .uniqueness
@@ -30,21 +30,21 @@ def licenses {F : Frame} (ds : List Entry) : NominalKind F → Prop
   | .demonstrative .. => ∃ e ∈ ds, e.IsDemonstrative
   | .possessive ..    => ∃ e ∈ ds, e.IsPossessive
 
-instance {F : Frame} (ds : List Entry) (k : NominalKind F) : Decidable (licenses ds k) := by
+instance {F : Frame} (ds : List Entry) (k : Description F) : Decidable (licenses ds k) := by
   cases k <;> unfold licenses <;> infer_instance
 
 /-! ### An article's possible denotations
 
-The deferred `Article.denote`: an article denotes the **set** of `NominalKind`s its
-admissible strengths (`Article.presupTypes`) realize through `NominalKind.ofPresupType`
+The deferred `Article.denote`: an article denotes the **set** of `Description`s its
+admissible strengths (`Article.presupTypes`) realize through `Description.ofPresupType`
 — a syncretic article (English *the*) denotes both the weak and the strong
 description, not a single one. -/
 
 /-- An article's possible (definite-description) denotations: the image of its
-admissible @cite{schwarz-2009} strengths under `NominalKind.ofPresupType`. -/
-def _root_.Article.toNominalKinds {F : Frame} (a : Article)
-    (R : DenotGS F .et) (idx : Nat) : List (NominalKind F) :=
-  a.presupTypes.map (NominalKind.ofPresupType · R idx)
+admissible @cite{schwarz-2009} strengths under `Description.ofPresupType`. -/
+def _root_.Article.toDescriptions {F : Frame} (a : Article)
+    (R : DenotGS F .et) (idx : Nat) : List (Description F) :=
+  a.presupTypes.map (Description.ofPresupType · R idx)
 
 /-- Licensing through `ofPresupType` is exactly `MarksPresup`: a determiner set
 licenses the weak/strong denotation of strength `p` iff some determiner expones a
@@ -52,13 +52,13 @@ definite use of presupposition type `p`. The denotation pipeline (`ofPresupType`
 and the inventory pipeline (`MarksPresup`) coincide by construction. -/
 theorem licenses_ofPresupType {F : Frame} (ds : List Entry)
     (p : DefPresupType) (R : DenotGS F .et) (idx : Nat) :
-    licenses ds (NominalKind.ofPresupType p R idx) ↔ MarksPresup ds p := by
+    licenses ds (Description.ofPresupType p R idx) ↔ MarksPresup ds p := by
   cases p <;> exact Iff.rfl
 
 /-- An article licenses each of its own possible denotations. -/
-theorem licenses_mem_toNominalKinds {F : Frame} (a : Article)
-    (R : DenotGS F .et) (idx : Nat) (k : NominalKind F)
-    (hk : k ∈ a.toNominalKinds R idx) :
+theorem licenses_mem_toDescriptions {F : Frame} (a : Article)
+    (R : DenotGS F .et) (idx : Nat) (k : Description F)
+    (hk : k ∈ a.toDescriptions R idx) :
     licenses [.article a] k := by
   obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hk
   exact (licenses_ofPresupType [.article a] p R idx).mpr

--- a/Linglib/Core/Nominal/Interpret.lean
+++ b/Linglib/Core/Nominal/Interpret.lean
@@ -6,7 +6,7 @@ import Linglib.Core.Nominal.Maximality
 @cite{coppock-beaver-2015} @cite{hanink-2021} @cite{schwarz-2009}
 @cite{patel-grosz-grosz-2017} @cite{sharvy-1980}
 
-Maps `NominalKind F` to a referent in `Option F.Entity`, relative to a
+Maps `Description F` to a referent in `Option F.Entity`, relative to a
 (entity, situation) bi-assignment. `none` represents either presupposition
 failure (no unique satisfier; no satisfying antecedent at the discourse
 index) or inapplicability (indefinites do not denote a single entity at
@@ -41,9 +41,9 @@ variable {F : Frame}
 -- § The Interpretation Function
 -- ════════════════════════════════════════════════════════════════
 
-/-- Denotation of a `NominalKind` at a bi-assignment, as `Option F.Entity`.
+/-- Denotation of a `Description` at a bi-assignment, as `Option F.Entity`.
     `none` is presupposition failure or inapplicability. -/
-noncomputable def interpret (k : NominalKind F)
+noncomputable def interpret (k : Description F)
     (g : Assignment F.Entity) (gs : SitAssignment F) : Option F.Entity :=
   match k with
   | .bare R                     => russellIota (fun x => R g gs x)

--- a/Linglib/Core/Nominal/Maximality.lean
+++ b/Linglib/Core/Nominal/Maximality.lean
@@ -4,7 +4,7 @@ import Linglib.Core.Logic.Intensional.Variables
 # Maximality and Coppock–Beaver Factorization
 @cite{sharvy-1980} @cite{kriz-2015} @cite{coppock-beaver-2015} @cite{russell-1905}
 
-Predicate operators consumed by the `NominalKind` interpretation function in
+Predicate operators consumed by the `Description` interpretation function in
 `Core/Nominal/Interpret.lean`. All operators live over
 `Core.Logic.Intensional.Frame.Denot` so they slot directly into the IL stack.
 
@@ -31,7 +31,7 @@ Predicate operators consumed by the `NominalKind` interpretation function in
 ## Design notes
 
 - **No semantic interpretation here.** This file provides only the operators.
-  `Core/Nominal/Interpret.lean` wires `NominalKind` constructors to them.
+  `Core/Nominal/Interpret.lean` wires `Description` constructors to them.
 
 - **Ord-free vs. order-relative.** `russellIota` uses only `Eq`; `sharvyMax`
   requires `PartialOrder F.Entity`. This is the @cite{sharvy-1980} /

--- a/Linglib/Features/Clusivity.lean
+++ b/Linglib/Features/Clusivity.lean
@@ -87,4 +87,38 @@ def hasMinimalAugmented (s : System) : Bool :=
 
 end System
 
+/-! ### Per-referent clusivity value -/
+
+/-- The clusivity value of a *referent*: whether a non-singular first-person
+    form includes the addressee. This is the framework-neutral per-pronoun
+    feature (the `Pronoun` object carries `Option Value`); it is `none` where
+    clusivity is unmarked (English *we*) or inapplicable (non-first-person).
+    Contrast `System`, which classifies a *language*. -/
+inductive Value where
+  /-- Inclusive: includes the addressee (1+2, optionally +others). -/
+  | inclusive
+  /-- Exclusive: excludes the addressee (1+others). -/
+  | exclusive
+  deriving DecidableEq, Repr, BEq
+
+open Features.Person (Category)
+
+/-- The @cite{cysouw-2009} `Features.Person.Category` a person + number +
+    clusivity triple realizes. Singulars ignore clusivity; clusivity-marked
+    first-person non-singulars split inclusive (`.minIncl` dual / `.augIncl`
+    plural) from `.excl`. A clusivity-*neutral* first-person plural (English
+    *we*) is a syncretism over those cells, so it has no single category
+    (`none`). This is the bridge from the neutral φ-features to the typological
+    inventory. -/
+def categoryOf : UD.Person → UD.Number → Option Value → Option Category
+  | .first,  .Sing, _               => some .s1
+  | .second, .Sing, _               => some .s2
+  | .third,  .Sing, _               => some .s3
+  | .first,  .Dual, some .inclusive => some .minIncl
+  | .first,  .Plur, some .inclusive => some .augIncl
+  | .first,  _,     some .exclusive => some .excl
+  | .second, .Plur, _               => some .secondGrp
+  | .third,  .Plur, _               => some .thirdGrp
+  | _,       _,     _               => none
+
 end Features.Clusivity

--- a/Linglib/Features/CoreferenceStatus.lean
+++ b/Linglib/Features/CoreferenceStatus.lean
@@ -26,8 +26,13 @@ inductive CoreferenceStatus where
     syntactic frameworks (HPSG, Dependency Grammar, Minimalism) so their
     `classifyNominal` functions return the same type. The per-language
     realization (which forms are which) lives in a Fragment helper (e.g.
-    `English.NominalClassification`). -/
-inductive NominalType where
+    `English.NominalClassification`).
+
+    The *binding-distribution* axis (anaphor/pronominal/r-expression, with the
+    anaphor class split into reflexive/reciprocal) — orthogonal to a nominal's
+    `Core.Nominal.Description` (definiteness/reference flavor) and to a
+    pronoun's lexical kind. -/
+inductive BindingClass where
   /-- Reflexive anaphor (*himself*, *herself*, *themselves*). -/
   | reflexive
   /-- Reciprocal anaphor (*each other*, *one another*). -/

--- a/Linglib/Features/Deixis.lean
+++ b/Linglib/Features/Deixis.lean
@@ -33,7 +33,7 @@ when a fragment actually needs it, not in anticipation. Specifically:
   invisible` constructors when a fragment needs them.
 - **Elevation contrasts** (Dyirbal, Nepali): add when needed.
 
-This is the centralized type referenced by `Core.Nominal.NominalKind.deictic`
+This is the centralized type referenced by `Core.Nominal.Description.deictic`
 (forthcoming) and by demonstrative entries in `Fragments/`.
 -/
 

--- a/Linglib/Fragments/English/NominalClassification.lean
+++ b/Linglib/Fragments/English/NominalClassification.lean
@@ -5,7 +5,7 @@ import Linglib.Fragments.English.Pronouns
 /-!
 # English nominal classification for binding
 
-Lexicon-driven classification of English nominals into `Features.NominalType`,
+Lexicon-driven classification of English nominals into `Features.BindingClass`,
 plus φ-feature agreement, shared by the coreference/binding analyses in every
 syntactic framework (`Syntax.Minimalist.Coreference`, `Syntax.HPSG.Coreference`,
 `Syntax.DependencyGrammar`). Each previously re-stipulated these with hardcoded
@@ -14,7 +14,7 @@ the three frameworks classify against one lexicon.
 
 ## Main definitions
 
-* `classifyNominal` — `Word → Option Features.NominalType`, via the English
+* `classifyNominal` — `Word → Option Features.BindingClass`, via the English
   pronoun lexicon lists (`reflexives`/`reciprocals`/personal/`whWords`) with a
   UPOS fallback for R-expressions.
 * `phiAgree` — person/number/gender agreement between two nominals, as a `Prop`
@@ -23,7 +23,7 @@ the three frameworks classify against one lexicon.
 
 namespace English.NominalClassification
 
-open Features (NominalType)
+open Features (BindingClass)
 
 /-- Is this a nominal category (proper noun, common noun, or pronoun)? -/
 def isNominalCat (c : UD.UPOS) : Bool :=
@@ -35,7 +35,7 @@ def isNominalCat (c : UD.UPOS) : Bool :=
     than a per-entry tag: a form in `reflexives` or `reciprocals` is an anaphor,
     a form in the personal or wh lists is a pronoun, and any other nominal
     category is an R-expression. -/
-def classifyNominal (w : Word) : Option NominalType :=
+def classifyNominal (w : Word) : Option BindingClass :=
   if English.Pronouns.reflexives.any (·.form == w.form) then some .reflexive
   else if English.Pronouns.reciprocals.any (·.form == w.form) then some .reciprocal
   else if English.pronouns.any (·.form == w.form)

--- a/Linglib/Fragments/English/Pronouns.lean
+++ b/Linglib/Fragments/English/Pronouns.lean
@@ -15,7 +15,7 @@ denotation of their own).
 The pronoun *kind* is encoded by **which lexicon list** a form sits in
 (`English.pronouns`, `reflexives`, `reciprocals`, `whWords`) — there is no
 per-entry kind tag. Binding theories read
-`English.NominalClassification.classifyNominal` (→ `Features.NominalType`),
+`English.NominalClassification.classifyNominal` (→ `Features.BindingClass`),
 dispatching on those lists, rather than any English-local type.
 
 ## Gender (@cite{konnelly-cowper-2020})

--- a/Linglib/Fragments/Tagalog/Pronouns.lean
+++ b/Linglib/Fragments/Tagalog/Pronouns.lean
@@ -1,3 +1,4 @@
+import Linglib.Typology.Pronoun.Basic
 import Linglib.Typology.Pronoun.WALS
 import Linglib.Features.Clusivity
 import Linglib.Features.Person
@@ -66,53 +67,92 @@ namespace Tagalog
 def clusivitySystem : Features.Clusivity.System := .minimalAugmented
 
 -- ============================================================================
--- Pronoun paradigm (structured)
+-- Pronoun paradigm (person + number + clusivity, three case series)
 -- ============================================================================
 
-/-- A row of the Tagalog pronoun paradigm: a Cysouw 2009 person/number
-    category and its three case forms. -/
-structure PronounRow where
-  category : Features.Person.Category
-  /-- *ang*-form (SPEC / NOM). -/
-  angForm : String
-  /-- *ng*-form (POSS / GEN). -/
-  ngForm : String
-  /-- *sa*-form (LOC / DAT). -/
-  saForm : String
-  deriving Repr
+/-! The independent-pronoun paradigm per @cite{schachter-otanes-1972} Chart 7
+    (p. 88): each cell is a `PersonalPronoun` carrying person, number, and
+    clusivity, in three case series — *ang* (NOM), *ng* (GEN), *sa* (DAT). The
+    @cite{cysouw-2009} `category` is *derived* from those features
+    (`Pronoun.category`), not stored. The minimal-augmented split is the dual
+    inclusive *kata* (1+2) vs the plural inclusive *tayo* (1+2+others), with the
+    exclusive *kami* (1+others). The *kitá* form @cite{himmelmann-2005-tagalog}
+    Table 12.2 lists alongside *katá* is a separate 1sg.GEN+2sg.NOM portmanteau
+    (@cite{schachter-otanes-1972} p. 89), not a 1du.in pronoun. -/
 
-/-- The Tagalog independent-pronoun paradigm per @cite{schachter-otanes-1972}
-    Chart 7 (p. 88), mapped onto Cysouw 2009 categories.
+open Features.Person (Category)
 
-    The 1.DU.IN.NOM cell is *kata* per S&O Chart 7; the *kitá* form
-    @cite{himmelmann-2005-tagalog} Table 12.2 lists alongside *katá* is
-    in S&O p. 89 a separate portmanteau combining 1sg.GEN with 2sg.NOM
-    (in 'I [verb] you' clauses), not a 1du.in pronoun. -/
-def pronounParadigm : List PronounRow :=
-  [ { category := .s1,        angForm := "ako",   ngForm := "ko",     saForm := "akin"   }
-  , { category := .s2,        angForm := "ikaw",  ngForm := "mo",     saForm := "iyo"    }
-  , { category := .s3,        angForm := "siya",  ngForm := "niya",   saForm := "kaniya" }
-  , { category := .minIncl,   angForm := "kata",  ngForm := "nita",   saForm := "kanita" }
-  , { category := .augIncl,   angForm := "tayo",  ngForm := "natin",  saForm := "atin"   }
-  , { category := .excl,      angForm := "kami",  ngForm := "namin",  saForm := "amin"   }
-  , { category := .secondGrp, angForm := "kayo",  ngForm := "ninyo",  saForm := "inyo"   }
-  , { category := .thirdGrp,  angForm := "sila",  ngForm := "nila",   saForm := "kanila" }
-  ]
+-- 1st singular
+def ako    : PersonalPronoun := { form := "ako",    person := some .first,  number := some .sg, case_ := some .Nom }
+def ko     : PersonalPronoun := { form := "ko",     person := some .first,  number := some .sg, case_ := some .Gen }
+def akin   : PersonalPronoun := { form := "akin",   person := some .first,  number := some .sg, case_ := some .Dat }
+-- 2nd singular
+def ikaw   : PersonalPronoun := { form := "ikaw",   person := some .second, number := some .sg, case_ := some .Nom }
+def mo     : PersonalPronoun := { form := "mo",     person := some .second, number := some .sg, case_ := some .Gen }
+def iyo    : PersonalPronoun := { form := "iyo",    person := some .second, number := some .sg, case_ := some .Dat }
+-- 3rd singular
+def siya   : PersonalPronoun := { form := "siya",   person := some .third,  number := some .sg, case_ := some .Nom }
+def niya   : PersonalPronoun := { form := "niya",   person := some .third,  number := some .sg, case_ := some .Gen }
+def kaniya : PersonalPronoun := { form := "kaniya", person := some .third,  number := some .sg, case_ := some .Dat }
+-- 1st dual inclusive (minimal inclusive): *kata*
+def kata   : PersonalPronoun := { form := "kata",   person := some .first,  number := some .du, clusivity := some .inclusive, case_ := some .Nom }
+def nita   : PersonalPronoun := { form := "nita",   person := some .first,  number := some .du, clusivity := some .inclusive, case_ := some .Gen }
+def kanita : PersonalPronoun := { form := "kanita", person := some .first,  number := some .du, clusivity := some .inclusive, case_ := some .Dat }
+-- 1st plural inclusive (augmented inclusive): *tayo*
+def tayo   : PersonalPronoun := { form := "tayo",   person := some .first,  number := some .pl, clusivity := some .inclusive, case_ := some .Nom }
+def natin  : PersonalPronoun := { form := "natin",  person := some .first,  number := some .pl, clusivity := some .inclusive, case_ := some .Gen }
+def atin   : PersonalPronoun := { form := "atin",   person := some .first,  number := some .pl, clusivity := some .inclusive, case_ := some .Dat }
+-- 1st plural exclusive: *kami*
+def kami   : PersonalPronoun := { form := "kami",   person := some .first,  number := some .pl, clusivity := some .exclusive, case_ := some .Nom }
+def namin  : PersonalPronoun := { form := "namin",  person := some .first,  number := some .pl, clusivity := some .exclusive, case_ := some .Gen }
+def amin   : PersonalPronoun := { form := "amin",   person := some .first,  number := some .pl, clusivity := some .exclusive, case_ := some .Dat }
+-- 2nd plural
+def kayo   : PersonalPronoun := { form := "kayo",   person := some .second, number := some .pl, case_ := some .Nom }
+def ninyo  : PersonalPronoun := { form := "ninyo",  person := some .second, number := some .pl, case_ := some .Gen }
+def inyo   : PersonalPronoun := { form := "inyo",   person := some .second, number := some .pl, case_ := some .Dat }
+-- 3rd plural
+def sila   : PersonalPronoun := { form := "sila",   person := some .third,  number := some .pl, case_ := some .Nom }
+def nila   : PersonalPronoun := { form := "nila",   person := some .third,  number := some .pl, case_ := some .Gen }
+def kanila : PersonalPronoun := { form := "kanila", person := some .third,  number := some .pl, case_ := some .Dat }
 
-/-- The categories enumerated by the paradigm are exactly Cysouw's
-    canonical ordering (singulars first, then groups). Subsumes a
-    `length = Category.all.length` claim. -/
-theorem pronounParadigm_categories_match :
-    pronounParadigm.map (·.category) = Features.Person.Category.all := rfl
+/-- The Tagalog independent-pronoun inventory (all three case series). -/
+def pronouns : List PersonalPronoun :=
+  [ako, ko, akin, ikaw, mo, iyo, siya, niya, kaniya,
+   kata, nita, kanita, tayo, natin, atin, kami, namin, amin,
+   kayo, ninyo, inyo, sila, nila, kanila]
 
-/-- Cross-substrate consistency: the paradigm includes a minimal-inclusive
-    row iff the language commits to the minimal-augmented clusivity
-    system. The forward direction encodes the minimal-augmented type's
-    definition (a separate "we two" form for speaker + addressee only);
-    the converse here holds because Tagalog has both. -/
-theorem clusivity_system_consistent_with_paradigm :
-    (pronounParadigm.map (·.category)).contains .minIncl =
+/-- The *ang* (nominative) series, one form per @cite{cysouw-2009} category in
+    canonical order. -/
+def angSeries : List PersonalPronoun := [ako, ikaw, siya, kata, tayo, kami, kayo, sila]
+
+/-- The *ang* series realizes exactly @cite{cysouw-2009}'s eight person
+    categories — *derived* from each form's person + number + clusivity, not
+    stored as a tag. -/
+theorem angSeries_categories_match :
+    angSeries.map (·.category) = Category.all.map some := by decide
+
+/-- Tagalog marks inclusive/exclusive in the first-person plural: *tayo* is
+    inclusive, *kami* exclusive — read off the object's `clusivity` field. -/
+theorem incl_excl_distinct :
+    tayo.clusivity = some .inclusive ∧ kami.clusivity = some .exclusive := ⟨rfl, rfl⟩
+
+/-- The minimal-augmented property: a dual inclusive *kata* (1+2) alongside the
+    plural inclusive *tayo* — what makes Tagalog minimal-augmented rather than
+    plain inclusive/exclusive (@cite{cysouw-2009}). -/
+theorem minimal_augmented :
+    kata.number = some .du ∧ kata.clusivity = some .inclusive ∧
+    tayo.number = some .pl ∧ tayo.clusivity = some .inclusive := ⟨rfl, rfl, rfl, rfl⟩
+
+/-- Cross-substrate consistency: the inventory contains a minimal-inclusive
+    (dual inclusive) form iff the language commits to the minimal-augmented
+    clusivity system. -/
+theorem clusivity_system_consistent :
+    pronouns.any (fun p => decide (p.category = some .minIncl)) =
       clusivitySystem.hasMinimalAugmented := by decide
+
+/-- Every Tagalog pronoun is well-formed: clusivity is borne only by the
+    first-person dual/plural forms (`Pronoun.WellFormed`). -/
+theorem all_wellFormed : pronouns.all (fun p => decide p.WellFormed) = true := by decide
 
 /-- WALS Ch 39's coding of Tagalog agrees with the image of its Cysouw
     clusivity system under `fromClusivity`. The WALS value is derived from the

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -124,15 +124,15 @@ example {F : Frame} [PartialOrder F.Entity] (g : Assignment F.Entity) (i : ℕ)
 /-! ### Pronouns are definite descriptions (@cite{elbourne-2005}, @cite{patel-grosz-grosz-2017})
 
 A referential pronoun *is* a (null-NP) definite description over its φ-feature
-restrictor — a `NominalKind`. @cite{patel-grosz-grosz-2017}'s proposal is that the
+restrictor — a `Description`. @cite{patel-grosz-grosz-2017}'s proposal is that the
 personal/demonstrative split is the @cite{schwarz-2009} weak/strong-article split:
-PER (*er*) the **weak** article (`NominalKind.ofPresupType .uniqueness` = `.unique`),
+PER (*er*) the **weak** article (`Description.ofPresupType .uniqueness` = `.unique`),
 "DEM" (*der*) the **strong** article (`…ofPresupType .familiarity` = `.anaphoric`,
 the weak description plus an anaphoric index). PG&G's "DEM = PER + index" is the
 weak/strong refinement `Core.Nominal.interpret_anaphoric_eq_unique_of_existsUnique`;
 the strength round-trips through `expectedPresupType`. The extra layer is that index,
 **not** spatial deixis (footnote 1) — *der* is a strong *personal* pronoun, not a
-separate type; genuine deictic demonstratives are `NominalKind.demonstrative`.
+separate type; genuine deictic demonstratives are `Description.demonstrative`.
 
 Caveat on `denote` below: the project's canonical `PersonalPronoun.denote` realizes
 the @cite{buring-2012} assignment lookup `g i` — the *indexed/anaphoric* referent,
@@ -143,7 +143,7 @@ exactly when `g i` is the unique satisfier. -/
 
 /-- A pronoun's @cite{buring-2012} variable-lookup referent equals its definite
 description whenever the restrictor holds of the indexed referent: the
-**strong-article** (`NominalKind.ofPresupType .familiarity`) reading, since the
+**strong-article** (`Description.ofPresupType .familiarity`) reading, since the
 anaphoric index *is* the indexed entity. The **weak** reading coincides too when
 that entity is the unique satisfier (`Core.Nominal.interpret_anaphoric_eq_unique_of_existsUnique`). -/
 theorem PersonalPronoun.denote_selector_eq_ofPresupType {F : Frame} [PartialOrder F.Entity]
@@ -152,6 +152,6 @@ theorem PersonalPronoun.denote_selector_eq_ofPresupType {F : Frame} [PartialOrde
     (g : Assignment F.Entity) (gs : SitAssignment F) (w : PUnit)
     (h : R g gs (g i)) :
     (e.denote i speaker addressee isFemale isInanimate).selector g w
-      = Core.Nominal.interpret (Core.Nominal.NominalKind.ofPresupType .familiarity R i) g gs := by
+      = Core.Nominal.interpret (Core.Nominal.Description.ofPresupType .familiarity R i) g gs := by
   show some (g i) = Core.Nominal.interpret (.anaphoric R i) g gs
   rw [Core.Nominal.interpret_anaphoric, if_pos h]

--- a/Linglib/Studies/Hanink2021.lean
+++ b/Linglib/Studies/Hanink2021.lean
@@ -21,7 +21,7 @@ The IL substrate operationalizes this in two parallel pieces:
 - **`SitAssignment F := Nat → F.Index`** in `Core.Logic.Intensional.Variables`
   is the situation-pronoun assignment, parallel to the entity
   assignment.
-- **`NominalKind.unique R sIdx`** in `Core.Nominal.Description`
+- **`Description.unique R sIdx`** in `Core.Nominal.Description`
   carries a `situationIdx : Nat` recording *which* situation pronoun
   the description is bound to.
 
@@ -167,17 +167,17 @@ theorem unique_index_does_not_alter_referent_directly :
       = interpret (F := F) (.unique tableAtSit0 7) g₀ gsKitchen :=
   interpret_unique_index_irrelevant _ _ _ _ _
 
-/-- Among `NominalKind` constructors, exactly `unique` and
+/-- Among `Description` constructors, exactly `unique` and
     `demonstrative` are flagged as binding a structural situation
     pronoun. Anaphoric definites do not — they consult the entity
     assignment for an antecedent, not the situation assignment. -/
 theorem situation_binders_classified
     (R : DenotGS F .et) (deictic : Features.Deixis.Feature) (sIdx d : Nat) :
-    (NominalKind.unique R sIdx).usesSituationPronoun = true ∧
-    (NominalKind.demonstrative R deictic sIdx d).usesSituationPronoun = true ∧
-    (NominalKind.anaphoric R d).usesSituationPronoun = false ∧
-    (NominalKind.bare R).usesSituationPronoun = false ∧
-    (NominalKind.indefinite R).usesSituationPronoun = false := by
+    (Description.unique R sIdx).usesSituationPronoun = true ∧
+    (Description.demonstrative R deictic sIdx d).usesSituationPronoun = true ∧
+    (Description.anaphoric R d).usesSituationPronoun = false ∧
+    (Description.bare R).usesSituationPronoun = false ∧
+    (Description.indefinite R).usesSituationPronoun = false := by
   refine ⟨rfl, rfl, rfl, rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Jenks2018.lean
+++ b/Linglib/Studies/Jenks2018.lean
@@ -24,7 +24,7 @@ Maximize Presupposition + @cite{schlenker-2012} Gricean reduction)
 selects between them.
 
 The substrate already operationalizes the inventory layer:
-`Core.Nominal.NominalKind.{unique,anaphoric}` are ι and ι^x;
+`Core.Nominal.Description.{unique,anaphoric}` are ι and ι^x;
 `Core.Nominal.Determiner.markingStrategy` derives the four-cell
 typology directly named after Jenks 2018 in `Features.Definiteness`.
 The Mandarin Fragment commits `marking := .markedAnaphoric`.
@@ -137,7 +137,7 @@ theorem demonstrative_licensed
 /-- A Mandarin bare definite and its `.unique` counterpart over the
     same restrictor pick the same referent — the bare-N route to
     unique definiteness (paper §4.1: ι via Chierchia type-shift) is
-    extensionally the `NominalKind.unique` denotation at the API
+    extensionally the `Description.unique` denotation at the API
     layer. Parallels `Moroney2021.shan_bare_unique_agreement`. -/
 theorem bare_unique_agreement
     (R : DenotGS F .et) (sIdx : Nat)
@@ -262,7 +262,7 @@ theorem clf_is_atomization {α : Type*} [PartialOrder α]
 /-! Jenks (2018, p. 513) is explicit that his anaphoric article ι^x
 takes an index argument of type ⟨e,t⟩ (a property), departing from
 @cite{schwarz-2009}/@cite{schwarz-2013}'s type ⟨e⟩ (an individual).
-The substrate's `NominalKind.anaphoric R d` carries `d : Nat` — a
+The substrate's `Description.anaphoric R d` carries `d : Nat` — a
 discourse-index slot resolved through the entity assignment, which
 matches Schwarz's individual-typed index, not Jenks's property-typed
 one. For Schwarz-style and ordinary demonstrative cases this divergence
@@ -272,7 +272,7 @@ proper names + demonstratives composing as `Pred(Zhangsan) +
 Dem-Clf-N`).
 
 Faithfully formalizing §4.4 requires a property-typed-index variant
-on `NominalKind.anaphoric`. This is recorded as a TODO at the substrate
+on `Description.anaphoric`. This is recorded as a TODO at the substrate
 level (`Core/Nominal/Description.lean`) rather than encoded as a
 placeholder theorem. -/
 
@@ -290,7 +290,7 @@ the natural slot for any MP-instance.
 The `IndexCandidate` carrier below is a minimal 2-bit witness type
 sufficient to demonstrate the principle's qualitative behavior
 (prefer indexed when index is available; neutral otherwise). A
-fuller instantiation would parameterize over `NominalKind F` and the
+fuller instantiation would parameterize over `Description F` and the
 discourse-context predicate licensing the index — that refactor
 belongs in a substrate file (`Semantics/Presupposition/Index.lean`)
 when a second consumer needs it. -/
@@ -356,7 +356,7 @@ Two empirical points the paper makes (p. 524-526):
 The substrate has `Roberts2012` QUD machinery in
 `Phenomena/Discourse/Strategy/QUDStack.lean` (per memory:
 `project_qud_dissolution.md`). A faithful formalization of paper §5.3
-would need a topic predicate over `NominalKind` configurations
+would need a topic predicate over `Description` configurations
 co-occurring with QUD-stack state — substrate the linglib has but
 that this study file does not yet plug into.
 
@@ -444,7 +444,7 @@ properly). -/
     This is one half of paper §4.3's covariation contrast (the
     *strict* half). The other half — bare N covarying via situation
     binding — requires the property-typed index variant on
-    `NominalKind.anaphoric` flagged in §5 to express cleanly, and is
+    `Description.anaphoric` flagged in §5 to express cleanly, and is
     deferred. -/
 theorem demonstrative_strict_under_situation_variation
     (R : DenotGS F .et) (deictic : Features.Deixis.Feature)

--- a/Linglib/Studies/Moroney2021.lean
+++ b/Linglib/Studies/Moroney2021.lean
@@ -667,7 +667,7 @@ finding: Shan licenses anaphoric definiteness without any anaphoric article. -/
 
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
-open Core.Nominal (NominalKind)
+open Core.Nominal (Description)
 
 /-- Shorthand handles for the four Table 4.4 determiner sets, each defined in
     its language fragment (`Fragments.{Lang}.Definiteness.determiners`).
@@ -699,7 +699,7 @@ theorem mandarin_in_markedAnaphoric :
   Mandarin.Definiteness.marking
 
 /-- Moroney's central observation, stated against the determiner set:
-    Shan has *no* determiner that licenses an `.anaphoric` `NominalKind`,
+    Shan has *no* determiner that licenses an `.anaphoric` `Description`,
     yet expresses anaphoric definiteness through bare nouns and optional
     demonstratives. The licensing predicate makes this morphologically
     visible — `.anaphoric` is not licensed (no determiner expones a

--- a/Linglib/Studies/Newman2024.lean
+++ b/Linglib/Studies/Newman2024.lean
@@ -314,7 +314,7 @@ def tuckIn (_existingSpecs : Nat) : SpecPosition := .innermost
     - KPs (inherent case → non-DP) cannot A-move (no [·D·] checking)
     - wh-DPs check more features than plain DPs (DOMA)
     - DPs can satisfy both [·D·] and [·X·] probes -/
-inductive NominalType where
+inductive DPType where
   | whDP   -- wh-phrase (who, what)
   | dp     -- full DP (the cat, John)
   | nonDP  -- KP or non-DP phrase (PP, CP, AP)
@@ -325,7 +325,7 @@ inductive NominalType where
     - DP: checks [·D·] and [·X·]
     - non-DP: checks [·X·] only
     No nominal checks [·V·] (only VP can). -/
-def NominalType.checksMerge : NominalType → MergeFeature → Bool
+def DPType.checksMerge : DPType → MergeFeature → Bool
   | .whDP, .D | .whDP, .X => true
   | .dp, .D | .dp, .X => true
   | .nonDP, .X => true
@@ -335,14 +335,14 @@ def NominalType.checksMerge : NominalType → MergeFeature → Bool
     This is NOT a Merge feature on V/v but appears on functional
     heads (C). It is what makes wh-DPs strictly more powerful
     than plain DPs in the feature-checking hierarchy. -/
-def NominalType.checksWh : NominalType → Bool
+def DPType.checksWh : DPType → Bool
   | .whDP => true
   | _ => false
 
 /-- Feature-checking capacity for A-movement (to Spec,TP via [·D·])
     plus Ā-features ([·wh·]). This count drives Weak Economy
     comparisons in DOMA configurations. -/
-def NominalType.aMovementFeatures : NominalType → Nat
+def DPType.aMovementFeatures : DPType → Nat
   | .whDP => 2  -- [·D·] on T + [·wh·] on C
   | .dp => 1    -- [·D·] on T only
   | .nonDP => 0 -- cannot A-move (lacks [·D·])
@@ -350,7 +350,7 @@ def NominalType.aMovementFeatures : NominalType → Nat
 /-- The entailment hierarchy: wh-DP ⊇ DP ⊇ non-DP.
     Each type can check a superset of the features checkable by
     the types below it. -/
-def NominalType.subsumes : NominalType → NominalType → Bool
+def DPType.subsumes : DPType → DPType → Bool
   | .whDP, _ => true
   | .dp, .dp | .dp, .nonDP => true
   | .nonDP, .nonDP => true
@@ -358,7 +358,7 @@ def NominalType.subsumes : NominalType → NominalType → Bool
 
 /-- Can this nominal type undergo A-movement?
     Requires checking [·D·] on T. -/
-def NominalType.canAMove (n : NominalType) : Bool := n.checksMerge .D
+def DPType.canAMove (n : DPType) : Bool := n.checksMerge .D
 
 /-- Test whether a single FreeMagma branch is a K-headed leaf. -/
 private def isKLeaf : FreeMagma (LIToken ⊕ Nat) → Bool
@@ -507,28 +507,28 @@ theorem transitive_forms_complex :
 -- IO passives.
 
 /-- non-DPs (KPs) cannot check [·D·]. -/
-theorem nonDP_cannot_check_D : NominalType.checksMerge .nonDP .D = false := rfl
-theorem nonDP_can_check_X : NominalType.checksMerge .nonDP .X = true := rfl
+theorem nonDP_cannot_check_D : DPType.checksMerge .nonDP .D = false := rfl
+theorem nonDP_can_check_X : DPType.checksMerge .nonDP .X = true := rfl
 
 /-- DPs can check both [·D·] and [·X·]. -/
-theorem dp_checks_D : NominalType.checksMerge .dp .D = true := rfl
-theorem dp_checks_X : NominalType.checksMerge .dp .X = true := rfl
+theorem dp_checks_D : DPType.checksMerge .dp .D = true := rfl
+theorem dp_checks_X : DPType.checksMerge .dp .X = true := rfl
 
 /-- wh-DPs additionally check [·wh·] on C. -/
-theorem whDP_checks_wh : NominalType.checksWh .whDP = true := rfl
-theorem dp_no_wh : NominalType.checksWh .dp = false := rfl
+theorem whDP_checks_wh : DPType.checksWh .whDP = true := rfl
+theorem dp_no_wh : DPType.checksWh .dp = false := rfl
 
 /-- The entailment hierarchy is a total preorder. -/
-theorem whDP_subsumes_dp : NominalType.subsumes .whDP .dp = true := rfl
-theorem dp_subsumes_nonDP : NominalType.subsumes .dp .nonDP = true := rfl
-theorem nonDP_not_subsumes_dp : NominalType.subsumes .nonDP .dp = false := rfl
+theorem whDP_subsumes_dp : DPType.subsumes .whDP .dp = true := rfl
+theorem dp_subsumes_nonDP : DPType.subsumes .dp .nonDP = true := rfl
+theorem nonDP_not_subsumes_dp : DPType.subsumes .nonDP .dp = false := rfl
 
 /-- A-movement accessibility: DPs and wh-DPs can A-move; non-DPs cannot.
     This is the core of the no-IO-passive explanation for languages
     with inherent case on indirect objects. -/
-theorem nonDP_cannot_amove : NominalType.canAMove .nonDP = false := rfl
-theorem dp_can_amove : NominalType.canAMove .dp = true := rfl
-theorem whDP_can_amove : NominalType.canAMove .whDP = true := rfl
+theorem nonDP_cannot_amove : DPType.canAMove .nonDP = false := rfl
+theorem dp_can_amove : DPType.canAMove .dp = true := rfl
+theorem whDP_can_amove : DPType.canAMove .whDP = true := rfl
 
 -- ============================================================================
 -- § 4: Symmetric Passives
@@ -556,20 +556,20 @@ theorem high_io_has_vp_spec :
 -- subject (not DO). Weak Economy explains this: IO-to-subject checks
 -- more features because the IO is a wh-DP (checking [·D·] + [·wh·])
 -- while DO is a plain DP (checking [·D·] only).
--- Feature counts are derived from the NominalType hierarchy.
+-- Feature counts are derived from the DPType hierarchy.
 
 /-- IO-to-subject in wh-passive: IO is a wh-DP.
-    Feature count derived from `NominalType.aMovementFeatures .whDP`.
+    Feature count derived from `DPType.aMovementFeatures .whDP`.
     Unlike Greek CD (§7), DOMA operations are pure alternatives at the
     same derivational step — not in a bleeding relation. -/
 def ioToSubjectWh : PendingOp where
-  featuresChecked := NominalType.aMovementFeatures .whDP
+  featuresChecked := DPType.aMovementFeatures .whDP
   bleeds := []
 
 /-- DO-to-subject in wh-passive: DO is a plain DP.
-    Feature count derived from `NominalType.aMovementFeatures .dp`. -/
+    Feature count derived from `DPType.aMovementFeatures .dp`. -/
 def doToSubjectWh : PendingOp where
-  featuresChecked := NominalType.aMovementFeatures .dp
+  featuresChecked := DPType.aMovementFeatures .dp
   bleeds := []
 
 /-- Weak Economy prefers IO-to-subject (checks more features). -/

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -16,7 +16,7 @@ PER the *weak* article ("the latter are anaphoric in a way that the former are
 not"). The extra layer is that index, **not** spatial deixis — their footnote 1
 stresses "it is far from clear that there is anything truly 'demonstrative' about"
 German DEMs. So here *der/die/das* are **strong-article `PersonalPronoun`s**, not a
-separate demonstrative type; the genuinely deictic `NominalKind.demonstrative` is a
+separate demonstrative type; the genuinely deictic `Description.demonstrative` is a
 different object. The PER/DEM distribution then follows from **structural economy**
 (*Minimize DP!*): PER, being less structured, is the default; DEM is licensed only
 by an added pragmatic effect (emotivity §5.1, disambiguation §5.2, register §5.3).
@@ -28,8 +28,8 @@ The contributions are made *true by construction* on shared substrate:
   (DEM, `.anaphoric`) and the weak description (PER, `.unique`) over one restrictor
   pick the same referent exactly when the indexed entity is the unique satisfier —
   off that, DEM is anaphoric in a way PER is not. Both denote via
-  `NominalKind.ofPresupType`, with the strength round-tripping through
-  `expectedPresupType` (`NominalKind.expectedPresupType_ofPresupType`); the
+  `Description.ofPresupType`, with the strength round-tripping through
+  `expectedPresupType` (`Description.expectedPresupType_ofPresupType`); the
   off-uniqueness **divergence** — DEM and PER picking *different* referents — is
   `der_er_can_diverge`, reusing @cite{schwarz-2009} §8's two-satisfier scenario.
 * The **two-series ↔ two-article** correlation (§4) is read off the determiner
@@ -147,10 +147,10 @@ theorem schwarz_pgg_german_consistent :
     only under uniqueness. -/
 theorem der_er_can_diverge :
     Core.Nominal.interpret
-        (Core.Nominal.NominalKind.ofPresupType .uniqueness Schwarz2009.studentRestr 0)
+        (Core.Nominal.Description.ofPresupType .uniqueness Schwarz2009.studentRestr 0)
         Schwarz2009.gAlice Schwarz2009.gs0
       ≠ Core.Nominal.interpret
-        (Core.Nominal.NominalKind.ofPresupType .familiarity Schwarz2009.studentRestr 0)
+        (Core.Nominal.Description.ofPresupType .familiarity Schwarz2009.studentRestr 0)
         Schwarz2009.gAlice Schwarz2009.gs0 :=
   Schwarz2009.two_articles_can_disagree
 

--- a/Linglib/Studies/Schwarz2009.lean
+++ b/Linglib/Studies/Schwarz2009.lean
@@ -30,11 +30,11 @@ the distinction at the surface.
 
 The split is operationalized in the Core layer by:
 
-- **`Core.Nominal.NominalKind`** — distinct `.unique` (weak) and
+- **`Core.Nominal.Description`** — distinct `.unique` (weak) and
   `.anaphoric` (strong) constructors, with different argument shapes
   (`.unique` carries a *situation* index for resource-situation binding;
   `.anaphoric` carries a *discourse* index for antecedent lookup).
-- **`Core.Nominal.NominalKind.expectedPresupType`** — projects each kind
+- **`Core.Nominal.Description.expectedPresupType`** — projects each kind
   to the @cite{schwarz-2009} presupposition type it expresses.
 - **`Core.Nominal.Determiner`** — the declared determiner set records the
   morphological inventory; `Determiner.IsSyncretic` is the predicate that
@@ -96,19 +96,19 @@ variable {F : Frame}
 /-- The weak article (`.unique` in the Core sum type) projects to the
     uniqueness presupposition. -/
 theorem unique_is_uniqueness (R : DenotGS F .et) (sIdx : Nat) :
-    (NominalKind.unique R sIdx).expectedPresupType = some .uniqueness := rfl
+    (Description.unique R sIdx).expectedPresupType = some .uniqueness := rfl
 
 /-- The strong article (`.anaphoric` in the Core sum type) projects to the
     familiarity presupposition. -/
 theorem anaphoric_is_familiarity (R : DenotGS F .et) (d : Nat) :
-    (NominalKind.anaphoric R d).expectedPresupType = some .familiarity := rfl
+    (Description.anaphoric R d).expectedPresupType = some .familiarity := rfl
 
 /-- The two articles project to distinct presupposition types — the
     central @cite{schwarz-2009} contrast at the type level. -/
 theorem unique_anaphoric_presup_distinct
     (R : DenotGS F .et) (sIdx d : Nat) :
-    (NominalKind.unique R sIdx).expectedPresupType ≠
-      (NominalKind.anaphoric R d).expectedPresupType := by
+    (Description.unique R sIdx).expectedPresupType ≠
+      (Description.anaphoric R d).expectedPresupType := by
   rw [unique_is_uniqueness, anaphoric_is_familiarity]
   intro h
   exact two_presup_types_distinct (Option.some_inj.mp h)
@@ -151,8 +151,8 @@ theorem strong_article_consults_entity_assignment
     claim that uniqueness is *situational* and familiarity is *anaphoric*. -/
 theorem situation_binding_classifies_articles
     (R : DenotGS F .et) (sIdx d : Nat) :
-    (NominalKind.unique R sIdx).usesSituationPronoun = true ∧
-    (NominalKind.anaphoric R d).usesSituationPronoun = false := ⟨rfl, rfl⟩
+    (Description.unique R sIdx).usesSituationPronoun = true ∧
+    (Description.anaphoric R d).usesSituationPronoun = false := ⟨rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- §4: Morphological correlate — German bipartite vs English syncretic

--- a/Linglib/Syntax/DependencyGrammar/Nominal.lean
+++ b/Linglib/Syntax/DependencyGrammar/Nominal.lean
@@ -22,14 +22,14 @@ Fragments providing instances; the test-word lexemes should move to
 
 ## Main declarations
 
-* `NominalType`, `isNominalCat`, `classifyNominal`, `phiAgree` — re-exported.
+* `BindingClass`, `isNominalCat`, `classifyNominal`, `phiAgree` — re-exported.
 * `john`, `mary`, `they`, `sees`, `see`, `himself`, `herself`,
   `themselves`, `him`, `her`, `them`, `eachOther` — English test words.
 -/
 
 namespace DepGrammar.Nominal
 
-export Features (NominalType)
+export Features (BindingClass)
 export English.NominalClassification (isNominalCat classifyNominal phiAgree)
 
 /-! ### Shared English test words

--- a/Linglib/Syntax/HPSG/Coreference.lean
+++ b/Linglib/Syntax/HPSG/Coreference.lean
@@ -37,7 +37,7 @@ private abbrev eachOther := English.Pronouns.eachOther.toWord
 
 namespace HPSG.Coreference
 
-open Features (NominalType)
+open Features (BindingClass)
 open English.NominalClassification (isNominalCat classifyNominal phiAgree)
 
 -- ============================================================================

--- a/Linglib/Syntax/Minimalist/Coreference.lean
+++ b/Linglib/Syntax/Minimalist/Coreference.lean
@@ -11,14 +11,14 @@ Coreference constraints via c-command and locality following @cite{chomsky-1981}
 
 ## Main definitions
 
-- `NominalType`, `SimpleClause`
+- `BindingClass`, `SimpleClause`
 - `reflexiveLicensed`, `pronounLocallyFree`, `grammaticalForCoreference`
 
 -/
 
 namespace Minimalist.Coreference
 
-open Features (NominalType)
+open Features (BindingClass)
 open English.NominalClassification (isNominalCat classifyNominal phiAgree)
 
 /-- Simple clause structure for coreference checking.

--- a/Linglib/Typology/Pronoun/Basic.lean
+++ b/Linglib/Typology/Pronoun/Basic.lean
@@ -3,6 +3,7 @@ import Linglib.Features.Case
 import Linglib.Features.Register
 import Linglib.Features.Prominence
 import Linglib.Features.Gender
+import Linglib.Features.Clusivity
 
 /-!
 # Pronoun
@@ -49,6 +50,13 @@ structure Pronoun where
   person : Option Person := none
   /-- Grammatical number. -/
   number : Option Number := none
+  /-- Clusivity (inclusive/exclusive) of a first-person non-singular form — the
+      inclusive/exclusive split of the 1st-person plural/dual. A φ-feature borne
+      by any such pro-form (personal, possessive, reflexive), like `gender`;
+      `none` where unmarked (English *we*) or inapplicable. Distinguishes
+      Tagalog *tayo* (incl) / *kami* (excl) and *natin* (our.incl) / *namin*
+      (our.excl). @cite{cysouw-2009} -/
+  clusivity : Option Features.Clusivity.Value := none
   /-- Grammatical case. -/
   case_ : Option Features.Case := none
   /-- Grammatical gender. For 3rd-person pronouns in gendered languages
@@ -93,6 +101,30 @@ open Features (SurfaceGender)
 def toWord (p : Pronoun) : Word :=
   { form := p.form, cat := .PRON,
     features := { person := p.person, number := p.number, case_ := p.case_ } }
+
+/-! ### Derived person category and well-formedness (@cite{cysouw-2009}) -/
+
+/-- The @cite{cysouw-2009} `Category` this pronoun's person + number + clusivity
+    realizes, when fully specified — the neutral typological view of its
+    person-reference, *derived* (not stored). `none` when person/number is
+    underspecified, or for a clusivity-unmarked first-person plural (a syncretism
+    over `.minIncl`/`.augIncl`/`.excl`, e.g. English *we*). -/
+def category (p : Pronoun) : Option Features.Person.Category :=
+  match p.person, p.number with
+  | some per, some num => Features.Clusivity.categoryOf per num p.clusivity
+  | _, _ => none
+
+/-- Well-formedness of a pronoun's φ-features: clusivity is borne only by a
+    first-person non-singular (dual/plural) form — the inclusive/exclusive split
+    of the 1st-person plural/dual (@cite{cysouw-2009}). This is the invariant a
+    person-value type tower would have enforced, carried as a *predicate* (the
+    mathlib way) so illegal states are catchable without fragmenting the type. -/
+def WellFormed (p : Pronoun) : Prop :=
+  p.clusivity ≠ none →
+    p.person = some .first ∧ (p.number = some .du ∨ p.number = some .pl)
+
+instance (p : Pronoun) : Decidable p.WellFormed := by
+  unfold WellFormed; infer_instance
 
 /-! ### Structural deficiency (@cite{cardinaletti-starke-1999}) -/
 


### PR DESCRIPTION
Two pieces of Pronoun-API groundwork:

- **Clusivity φ-feature** on the base `Pronoun` (Cysouw incl/excl), with a `WellFormed` invariant and a derived `category`; Tagalog migrated onto person + number + clusivity.
- **Disambiguate the nominal classification axes** (rename): `Features.NominalType` → `BindingClass` (binding distribution), `Core.Nominal.NominalKind` → `Description` (definiteness/reference flavor), `Newman2024.NominalType` → `DPType` (Merge-feature checking).