### PR TITLE
feat(Typology/Indefinite): IndefinitePronoun extends Pronoun + ontology

### DIFF
--- a/Linglib/Fragments/English/Indefinites.lean
+++ b/Linglib/Fragments/English/Indefinites.lean
@@ -24,10 +24,9 @@ open Typology.Indefinite
 /-- English `some-` series (*someone*, *somebody*, *something*, …):
     AAA syncretism, D&A type i unmarked. The form is generic-noun-based
     (the host stems `-one`, `-body`, `-thing` are nouns), per WALS F46A. -/
-def someEntry : IndefiniteEntry where
-  language := "English"
+def someEntry : IndefinitePronoun where
   form := "someone/-body/-thing"
-  gloss := "some(one/body/thing)"
+  ontology := .person
   basis := .genericNoun
   functions := {.specificKnown, .specificUnknown, .irrealis}
 

--- a/Linglib/Fragments/Farsi/Determiners.lean
+++ b/Linglib/Fragments/Farsi/Determiners.lean
@@ -63,7 +63,7 @@ A Farsi indefinite DP entry.
 
 Captures syntactic and semantic properties including EFCI behavior.
 -/
-structure IndefiniteEntry where
+structure IndefiniteDeterminer where
   /-- Surface form (Persian script) -/
   form : String
   /-- Romanization -/
@@ -96,7 +96,7 @@ Key properties:
 - Yields modal variation under epistemic modals
 - Plain existential in DE contexts
 -/
-def yeki : IndefiniteEntry :=
+def yeki : IndefiniteDeterminer :=
   { form := "یکی"
   , romanization := "yek-i"
   , gloss := "one-INDF"
@@ -113,7 +113,7 @@ def yeki : IndefiniteEntry :=
 
 Not an EFCI - just a numeral. Contrast with *yek-i*.
 -/
-def yek : IndefiniteEntry :=
+def yek : IndefiniteDeterminer :=
   { form := "یک"
   , romanization := "yek"
   , gloss := "one"
@@ -127,7 +127,7 @@ Indefinite suffix *-i*: Indefiniteness marker.
 
 Attaches to nouns to create indefinites.
 -/
-def indef_i : IndefiniteEntry :=
+def indef_i : IndefiniteDeterminer :=
   { form := "ـی"
   , romanization := "-i"
   , gloss := "-INDF"
@@ -179,7 +179,7 @@ def deContext : EFCIContext :=
 /--
 Get the reading for an EFCI in a given context.
 -/
-def getReading (entry : IndefiniteEntry) (ctx : EFCIContext) : Option EFCIReading :=
+def getReading (entry : IndefiniteDeterminer) (ctx : EFCIContext) : Option EFCIReading :=
   if !entry.isEFCI then
     -- Non-EFCI: just plain existential everywhere
     some .plainExistential
@@ -218,7 +218,7 @@ theorem yeki_de : getReading yeki deContext = some .plainExistential := rfl
 /-- German *irgendein*: EFCI with modal insertion available.
 Cross-linguistic comparison entry; canonical German entry in `German.ModalIndefinites`.
 @cite{kratzer-shimoyama-2002} -/
-def irgendein_de : IndefiniteEntry :=
+def irgendein_de : IndefiniteDeterminer :=
   { form := "irgendein"
   , romanization := "irgendein"
   , gloss := "IRGEND.a"
@@ -231,7 +231,7 @@ def irgendein_de : IndefiniteEntry :=
 
 /-- Romanian *vreun*: EFCI with no rescue mechanism.
 Cross-linguistic comparison entry; see @cite{falaus-2014}. -/
-def vreun_ro : IndefiniteEntry :=
+def vreun_ro : IndefiniteDeterminer :=
   { form := "vreun"
   , romanization := "vreun"
   , gloss := "VREUN"
@@ -258,9 +258,9 @@ theorem vreun_root_ungrammatical : getReading vreun_ro rootContext = none := rfl
 
 open Semantics.Quantification.ChoiceFunction (IndefType SkolemCF)
 
-/-- Farsi plain indefinite entry, extending `IndefiniteEntry` with
+/-- Farsi plain indefinite entry, extending `IndefiniteDeterminer` with
     choice-function properties relevant to @cite{mirrazi-2024}. -/
-structure PlainIndefiniteEntry extends IndefiniteEntry where
+structure PlainIndefiniteEntry extends IndefiniteDeterminer where
   /-- Semantic analysis: choice function or ∃-quantifier. -/
   indefType : IndefType
   /-- Does this determiner carry an independent world/situation variable?
@@ -328,12 +328,12 @@ theorem candTa_has_world_var : candTa.hasWorldVar = true := rfl
 theorem doTa_has_world_var : doTa.hasWorldVar = true := rfl
 
 /-- All Farsi indefinite entries -/
-def allIndefinites : List IndefiniteEntry :=
-  [yeki, yek, indef_i, ye.toIndefiniteEntry, candTa.toIndefiniteEntry,
-   doTa.toIndefiniteEntry]
+def allIndefinites : List IndefiniteDeterminer :=
+  [yeki, yek, indef_i, ye.toIndefiniteDeterminer, candTa.toIndefiniteDeterminer,
+   doTa.toIndefiniteDeterminer]
 
 /-- Lookup by romanization -/
-def lookup (romanization : String) : Option IndefiniteEntry :=
+def lookup (romanization : String) : Option IndefiniteDeterminer :=
   allIndefinites.find? λ e => e.romanization == romanization
 
 

--- a/Linglib/Fragments/German/Indefinites.lean
+++ b/Linglib/Fragments/German/Indefinites.lean
@@ -30,19 +30,17 @@ open Typology.Indefinite
 /-- German *irgend-*: dedicated indefinite prefix (special basis),
     epistemic indefinite (D&A type iv).
     @cite{aloni-port-2015}; @cite{bubnov-2026} §6, Table 3. -/
-def irgendEntry : IndefiniteEntry where
-  language := "German"
+def irgendEntry : IndefinitePronoun where
   form := "irgend-"
-  gloss := "some (epistemic)"
+  ontology := .person
   basis := .special
   functions := {.specificUnknown, .irrealis}
 
 /-- German *jemand* 'someone' / *etwas* 'something': generic-noun-derived
     (etymologically *je-man[d]* 'ever-person'); used for SK + SU. -/
-def jemandEntry : IndefiniteEntry where
-  language := "German"
+def jemandEntry : IndefinitePronoun where
   form := "jemand/etwas"
-  gloss := "someone/something"
+  ontology := .person
   basis := .genericNoun
   functions := {.specificKnown, .specificUnknown}
 

--- a/Linglib/Fragments/Kannada/Indefinites.lean
+++ b/Linglib/Fragments/Kannada/Indefinites.lean
@@ -25,19 +25,17 @@ open Typology.Indefinite
 /-- Kannada *-oo*: specific-unknown indefinite suffix on interrogative
     bases (e.g., *yāru-oo* 'someone'). D&A type vii: `dep(v,x) ∧ var(∅,x)`.
     @cite{haspelmath-1997}, @cite{degano-aloni-2025}. -/
-def ooEntry : IndefiniteEntry where
-  language := "Kannada"
+def ooEntry : IndefinitePronoun where
   form := "yāru-oo"
-  gloss := "someone (specific unknown)"
+  ontology := .person
   basis := .interrogative
   functions := {.specificUnknown}
 
 /-- Kannada *-aadaruu*: non-specific indefinite suffix on interrogative
     bases (e.g., *yāru-aadaruu* 'anyone'). D&A type iii: `var(v,x)`. -/
-def aadaruuEntry : IndefiniteEntry where
-  language := "Kannada"
+def aadaruuEntry : IndefinitePronoun where
   form := "yāru-aadaruu"
-  gloss := "anyone (non-specific)"
+  ontology := .person
   basis := .interrogative
   functions := {.irrealis}
 

--- a/Linglib/Fragments/Latin/Indefinites.lean
+++ b/Linglib/Fragments/Latin/Indefinites.lean
@@ -25,20 +25,18 @@ open Typology.Indefinite
     Interrogative-based: `ali-` + interrogative `quis`. D&A type iv
     epistemic (`var(∅,x)`); distribution matches profile.
     @cite{haspelmath-1997}, @cite{bubnov-2026} Table 1. -/
-def aliEntry : IndefiniteEntry where
-  language := "Latin"
+def aliEntry : IndefinitePronoun where
   form := "aliquis"
-  gloss := "someone (non-specific/unknown)"
+  ontology := .person
   basis := .interrogative
   functions := {.specificUnknown, .irrealis}
 
 /-- Latin *quidam*: specific-known indefinite (interrogative `qui` + `-dam`).
     D&A type v `dep(∅,x)`.
     @cite{haspelmath-1997}, @cite{bubnov-2026} Table 1. -/
-def damEntry : IndefiniteEntry where
-  language := "Latin"
+def damEntry : IndefinitePronoun where
   form := "quidam"
-  gloss := "a certain (one)"
+  ontology := .person
   basis := .interrogative
   functions := {.specificKnown}
 

--- a/Linglib/Fragments/Slavic/Russian/Indefinites.lean
+++ b/Linglib/Fragments/Slavic/Russian/Indefinites.lean
@@ -22,7 +22,7 @@ semantics `var(∅,x)` — D&A type iv epistemic. Its restriction to the
 specific-unknown function (not also non-specific) is due to paradigmatic
 competition with *-nibud'*. The D&A theoretical profile of type iv
 permits both SU and NS, but *-to*'s actual distribution is SU only —
-captured by `IndefiniteEntry.consistentWith` in
+captured by `IndefinitePronoun.consistentWith` in
 `Semantics/Quantification/DeganoAloni2025.lean`.
 -/
 
@@ -35,10 +35,9 @@ open Typology.Indefinite
 /-- *кто-нибудь* (*kto-nibud'*): non-specific indefinite, interrogative
     `kto` 'who' + suffix `-nibud'`. Imperatives, questions, irrealis.
     "Купи что-нибудь" 'Buy something [I don't care what]'. D&A type iii. -/
-def nibudEntry : IndefiniteEntry where
-  language := "Russian"
+def nibudEntry : IndefinitePronoun where
   form := "kto-nibud'"
-  gloss := "some...or other (non-specific)"
+  ontology := .person
   basis := .interrogative
   functions := {.irrealis}
 
@@ -51,20 +50,18 @@ def nibudEntry : IndefiniteEntry where
     both SU and NS, but *-to*'s actual distribution is SU only because
     *-nibud'* (type iii) blocks it for NS. The narrower-than-profile claim
     is `consistentWith` (subset, not equality). -/
-def toEntry : IndefiniteEntry where
-  language := "Russian"
+def toEntry : IndefinitePronoun where
   form := "kto-to"
-  gloss := "some (particular, unknown)"
+  ontology := .person
   basis := .interrogative
   functions := {.specificUnknown}
 
 /-- *кое-кто* (*koe-kto*): specific-known indefinite, prefix `koe-` +
     interrogative `kto`. Speaker knows the referent's identity.
     "Кое-кто пришёл" 'Someone [I know who] came'. D&A type v `dep(∅,x)`. -/
-def koeEntry : IndefiniteEntry where
-  language := "Russian"
+def koeEntry : IndefinitePronoun where
   form := "koe-kto"
-  gloss := "some (I know which)"
+  ontology := .person
   basis := .interrogative
   functions := {.specificKnown}
 

--- a/Linglib/Fragments/Yakut/Indefinites.lean
+++ b/Linglib/Fragments/Yakut/Indefinites.lean
@@ -40,10 +40,9 @@ open Typology.Indefinite
     both specific-known and specific-unknown functions (ABB syncretism).
     @cite{stachowski-menz-1998} p. 423; @cite{bubnov-2026} Table 1
     (D&A type ii). -/
-def ereEntry : IndefiniteEntry where
-  language := "Yakut"
+def ereEntry : IndefinitePronoun where
   form := "kim ere"
-  gloss := "somebody (specific)"
+  ontology := .person
   basis := .interrogative
   functions := {.specificKnown, .specificUnknown}
 
@@ -51,10 +50,9 @@ def ereEntry : IndefiniteEntry where
     indefinites; `kim eme` 'somebody, anybody'.
     @cite{stachowski-menz-1998} p. 423; @cite{bubnov-2026} Table 1
     (D&A type iii). -/
-def emeEntry : IndefiniteEntry where
-  language := "Yakut"
+def emeEntry : IndefinitePronoun where
   form := "kim eme"
-  gloss := "somebody, anybody (non-specific)"
+  ontology := .person
   basis := .interrogative
   functions := {.irrealis}
 
@@ -62,10 +60,9 @@ def emeEntry : IndefiniteEntry where
     `kim bayarar` 'whoever (s)he may be, every'. Outside D&A's SK/SU/NS
     subdivision — its surface D&A classification is `none`.
     @cite{stachowski-menz-1998} p. 423. -/
-def bayararEntry : IndefiniteEntry where
-  language := "Yakut"
+def bayararEntry : IndefinitePronoun where
   form := "kim bayarar"
-  gloss := "whoever, every (free choice)"
+  ontology := .person
   basis := .interrogative
   functions := {.freeChoice, .conditional}
 
@@ -74,10 +71,9 @@ def bayararEntry : IndefiniteEntry where
     (@cite{stachowski-menz-1998} p. 423: 'anybody'). Covers questions,
     conditionals, comparatives, and both negation regions. Outside D&A's
     SK/SU/NS subdivision. -/
-def daEntry : IndefiniteEntry where
-  language := "Yakut"
+def daEntry : IndefinitePronoun where
   form := "kim da"
-  gloss := "anybody (polarity-sensitive)"
+  ontology := .person
   basis := .interrogative
   functions := {.question, .conditional, .comparative,
                 .indirectNeg, .directNeg}

--- a/Linglib/Studies/Bubnov2026.lean
+++ b/Linglib/Studies/Bubnov2026.lean
@@ -45,7 +45,7 @@ test case. Key claims:
   `var(y,x)` and `dep(y,x)`. `type_vi_contradictory` derives the gap.
 - `Nanosyntax.Core`: `spellout` and `abaViolation` demonstrate the negative
   result — nanosyntax predicts containment that indefinites lack.
-- `Typology.Indefinite`: `IndefiniteEntry` (consensus function-coverage
+- `Typology.Indefinite`: `IndefinitePronoun` (consensus function-coverage
   + morphological-basis data) and `classifyTriple` for syncretism patterns.
 - `DeganoAloni2025`: `DAType` and
   `surfaceDAType` / `consistentWith` projections from entries to D&A types.

--- a/Linglib/Studies/DeganoAloni2025.lean
+++ b/Linglib/Studies/DeganoAloni2025.lean
@@ -5,7 +5,7 @@ import Linglib.Typology.Indefinite
 @cite{degano-aloni-2025} @cite{hodges-1997} @cite{vaananen-2007}
 
 Degano & Aloni 2025's 7-type classification of indefinite pronouns,
-projected from the consensus `Typology.Indefinite.IndefiniteEntry`
+projected from the consensus `Typology.Indefinite.IndefinitePronoun`
 substrate (Haspelmath 1997 function-coverage data).
 
 The team-semantic logic primitives D&A use (Hodges 1997 / Väänänen 2007:
@@ -41,11 +41,11 @@ type table is for reference.
   parameter choices.
 - `DAType.profile`: each type's theoretical coverage on the
   Haspelmath SK/SU/irrealis triangle.
-- `IndefiniteEntry.surfaceDAType`: classify an entry by exact match
+- `IndefinitePronoun.surfaceDAType`: classify an entry by exact match
   of its actual function-coverage to a D&A type's profile. Returns
   `none` when the entry covers a region D&A doesn't subdivide (e.g.,
   free choice, polarity-sensitive forms) or when actual ⊊ profile.
-- `IndefiniteEntry.consistentWith`: weaker relation — actual coverage
+- `IndefinitePronoun.consistentWith`: weaker relation — actual coverage
   is a subset of the theoretical profile. Used for entries where
   paradigmatic competition narrows the actual distribution
   (e.g., Russian *kto-to* ⊊ type-iv epistemic profile).
@@ -223,12 +223,12 @@ theorem DAType.profile_subset_specificityRegion (t : DAType) :
 end DeganoAloni2025
 
 -- ============================================================================
--- §2. IndefiniteEntry projections
+-- §2. IndefinitePronoun projections
 -- ============================================================================
 
-/- Methods on `IndefiniteEntry` live in its own namespace so that
+/- Methods on `IndefinitePronoun` live in its own namespace so that
    dot notation (`entry.surfaceDAType`) resolves them. -/
-namespace Typology.Indefinite.IndefiniteEntry
+namespace Typology.Indefinite.IndefinitePronoun
 
 open DeganoAloni2025
 
@@ -239,7 +239,7 @@ open DeganoAloni2025
     (free choice, polarity-sensitive uses, or any function outside
     SK/SU/NS) or when actual coverage is a proper subset of any type's
     profile (a paradigmatic-competition case — see `consistentWith`). -/
-def surfaceDAType (e : IndefiniteEntry) : Option DAType :=
+def surfaceDAType (e : IndefinitePronoun) : Option DAType :=
   if e.functions = DAType.unmarked.profile then some .unmarked
   else if e.functions = DAType.specific.profile then some .specific
   else if e.functions = DAType.nonSpecific.profile then some .nonSpecific
@@ -254,7 +254,7 @@ def surfaceDAType (e : IndefiniteEntry) : Option DAType :=
     paradigmatic-competition cases such as Russian *kto-to* (type-iv
     epistemic profile permits SU + NS, but *-to* covers only SU because
     *-nibud'* blocks it from NS — see @cite{bubnov-2026} §7). -/
-def consistentWith (e : IndefiniteEntry) (t : DAType) : Bool :=
+def consistentWith (e : IndefinitePronoun) (t : DAType) : Bool :=
   decide (e.functions ⊆ t.profile)
 
-end Typology.Indefinite.IndefiniteEntry
+end Typology.Indefinite.IndefinitePronoun

--- a/Linglib/Studies/Haspelmath1997.lean
+++ b/Linglib/Studies/Haspelmath1997.lean
@@ -23,7 +23,7 @@ bridge theorems verifying that each Fragment's encoded morphological-basis
 distribution matches the @cite{wals-2013} F46A classification of the same
 language by ISO 639-3 join.
 
-The substrate (`HaspelmathFunction` enum + `IndefiniteEntry`/`IndefiniteParadigm`
+The substrate (`HaspelmathFunction` enum + `IndefinitePronoun`/`IndefiniteParadigm`
 structs + `MorphologicalBasis` + WALS converters) lives in
 `Typology/Indefinite.lean`.
 

--- a/Linglib/Studies/Haspelmath1997Polarity.lean
+++ b/Linglib/Studies/Haspelmath1997Polarity.lean
@@ -43,7 +43,7 @@ classification), this file owns the polarity-side claims:
   entries (verifies that NPI items the polarity Fragments declare are
   licensed in the contexts the Haspelmath polarity-sensitive forms cover)
 
-The substrate (`HaspelmathFunction`, `IndefiniteEntry`, `IndefiniteParadigm`,
+The substrate (`HaspelmathFunction`, `IndefinitePronoun`, `IndefiniteParadigm`,
 `MorphologicalBasis`, contiguity / coverage / disjointness predicates,
 `wals46A` and converters) lives in `Typology/Indefinite.lean`.
 
@@ -63,7 +63,7 @@ The substrate (`HaspelmathFunction`, `IndefiniteEntry`, `IndefiniteParadigm`,
 
 The 17 paradigms are hand-stipulated here rather than derived from
 `Fragments/{Lang}/Indefinites.lean` because the per-form
-`IndefiniteEntry.functions` field commits to a particular analysis of how
+`IndefinitePronoun.functions` field commits to a particular analysis of how
 forms partition the 9-function map, and the polarity-side analysis
 (Haspelmath 1997's contiguity-driven encoding) genuinely differs from the
 existing Fragment-side analysis (Degano-Aloni 2025 / Bubnov 2026's
@@ -148,8 +148,8 @@ def ch46Counts : List WALSCount :=
       (ch46.filter (·.value == .existentialConstruction)).length⟩ ]
 
 /-! Helpers (`wals46A`, `formCount`, `allFunctions`, `AllContiguous`,
-    `CoversAllFunctions`, `FormsDisjoint`, `IndefiniteEntry.coverage`)
-    are defined on `IndefiniteParadigm` / `IndefiniteEntry` in
+    `CoversAllFunctions`, `FormsDisjoint`, `IndefinitePronoun.coverage`)
+    are defined on `IndefiniteParadigm` / `IndefinitePronoun` in
     `Typology/Indefinite.lean`. The `Prop`-valued predicates have
     `Decidable` instances; theorems use them directly without `= true`
     tails (mathlib idiom). -/
@@ -165,20 +165,20 @@ def english : IndefiniteParadigm :=
   { language := "English"
   , isoCode := "eng"
   , forms :=
-    [ { language := "English", form := "some-",
-        gloss := "somebody, something, somewhere",
+    [ { form := "some-",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.specificKnown, .specificUnknown} }
-    , { language := "English", form := "any- (NPI)",
-        gloss := "anybody, anything in DE/nonveridical",
+    , { form := "any- (NPI)",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.irrealis, .question, .conditional, .indirectNeg} }
-    , { language := "English", form := "no-",
-        gloss := "nobody, nothing, nowhere",
+    , { form := "no-",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.directNeg} }
-    , { language := "English", form := "any- (FC)",
-        gloss := "anybody can do that; taller than anybody",
+    , { form := "any- (FC)",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -209,28 +209,28 @@ def russian : IndefiniteParadigm :=
   { language := "Russian"
   , isoCode := "rus"
   , forms :=
-    [ { language := "Russian", form := "кое-кто (koe-kto)",
-        gloss := "specific known: speaker knows the referent's identity",
+    [ { form := "кое-кто (koe-kto)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.specificKnown} }
-    , { language := "Russian", form := "кто-то (kto-to)",
-        gloss := "epistemic (D&A 2025 type iv): SU + NS",
+    , { form := "кто-то (kto-to)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.specificUnknown, .irrealis} }
-    , { language := "Russian", form := "кто-нибудь (kto-nibud')",
-        gloss := "non-specific / irrealis: 'anyone, no matter who'",
+    , { form := "кто-нибудь (kto-nibud')",
+        ontology := .person,
         basis := .interrogative,
         functions := {.irrealis} }
-    , { language := "Russian", form := "кто-либо (kto-libo)",
-        gloss := "polarity-sensitive: questions, conditionals, indirect neg",
+    , { form := "кто-либо (kto-libo)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.question, .conditional, .indirectNeg} }
-    , { language := "Russian", form := "никто (nikto)",
-        gloss := "nikto ne prisel 'nobody NEG came' (negative concord)",
+    , { form := "никто (nikto)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.directNeg} }
-    , { language := "Russian", form := "кто угодно (kto ugodno)",
-        gloss := "universal/free choice: anyone at all",
+    , { form := "кто угодно (kto ugodno)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -240,24 +240,24 @@ def german : IndefiniteParadigm :=
   { language := "German"
   , isoCode := "deu"
   , forms :=
-    [ { language := "German", form := "jemand",
-        gloss := "somebody (specific reference)",
+    [ { form := "jemand",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.specificKnown, .specificUnknown} }
-    , { language := "German", form := "irgendwer",
-        gloss := "irgend- prefix marks non-specificity / ignorance",
+    , { form := "irgendwer",
+        ontology := .person,
         basis := .special,
         functions := {.irrealis, .question} }
-    , { language := "German", form := "wer (conditional)",
-        gloss := "bare wh-word in conditional / indirect neg",
+    , { form := "wer (conditional)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.conditional, .indirectNeg} }
-    , { language := "German", form := "niemand",
-        gloss := "negative indefinite",
+    , { form := "niemand",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.directNeg} }
-    , { language := "German", form := "jeder",
-        gloss := "universal/free choice: anyone/everyone",
+    , { form := "jeder",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -266,17 +266,17 @@ def japanese : IndefiniteParadigm :=
   { language := "Japanese"
   , isoCode := "jpn"
   , forms :=
-    [ { language := "Japanese", form := "dare-ka",
-        gloss := "wh + ka: existential/non-specific",
+    [ { form := "dare-ka",
+        ontology := .person,
         basis := .interrogative,
         functions := {.specificKnown, .specificUnknown, .irrealis,
                       .question, .conditional} }
-    , { language := "Japanese", form := "dare-mo (neg)",
-        gloss := "wh + mo under negation: nobody",
+    , { form := "dare-mo (neg)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.indirectNeg, .directNeg} }
-    , { language := "Japanese", form := "dare-demo",
-        gloss := "wh + demo: free choice / concessive",
+    , { form := "dare-demo",
+        ontology := .person,
         basis := .interrogative,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -286,12 +286,12 @@ def mandarin : IndefiniteParadigm :=
   { language := "Mandarin Chinese"
   , isoCode := "cmn"
   , forms :=
-    [ { language := "Mandarin", form := "yǒu rén (有人)",
-        gloss := "existential: 'there is someone'",
+    [ { form := "yǒu rén (有人)",
+        ontology := .person,
         basis := .existentialConstruction,
         functions := {.specificKnown, .specificUnknown} }
-    , { language := "Mandarin", form := "shéi (谁, non-interrog.)",
-        gloss := "wh-word in non-interrogative uses; 7 functions",
+    , { form := "shéi (谁, non-interrog.)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.irrealis, .question, .conditional, .indirectNeg,
                       .directNeg, .comparative, .freeChoice} } ] }
@@ -301,24 +301,24 @@ def turkish : IndefiniteParadigm :=
   { language := "Turkish"
   , isoCode := "tur"
   , forms :=
-    [ { language := "Turkish", form := "birisi",
-        gloss := "specific indefinite: 'a certain person'",
+    [ { form := "birisi",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.specificKnown, .specificUnknown} }
-    , { language := "Turkish", form := "biri",
-        gloss := "non-specific in irrealis",
+    , { form := "biri",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.irrealis} }
-    , { language := "Turkish", form := "kimse",
-        gloss := "polarity-sensitive: questions, conditionals",
+    , { form := "kimse",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.question, .conditional, .indirectNeg} }
-    , { language := "Turkish", form := "hiç kimse",
-        gloss := "negative indefinite with hiç intensifier",
+    , { form := "hiç kimse",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.directNeg} }
-    , { language := "Turkish", form := "herhangi biri",
-        gloss := "free choice: any person at all",
+    , { form := "herhangi biri",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -327,17 +327,17 @@ def hindi : IndefiniteParadigm :=
   { language := "Hindi-Urdu"
   , isoCode := "hin"
   , forms :=
-    [ { language := "Hindi-Urdu", form := "koii",
-        gloss := "general indefinite: someone/anyone",
+    [ { form := "koii",
+        ontology := .person,
         basis := .special,
         functions := {.specificKnown, .specificUnknown, .irrealis,
                       .question, .conditional} }
-    , { language := "Hindi-Urdu", form := "koii nahiiN",
-        gloss := "koii + negation: nobody",
+    , { form := "koii nahiiN",
+        ontology := .person,
         basis := .special,
         functions := {.indirectNeg, .directNeg} }
-    , { language := "Hindi-Urdu", form := "koii bhii",
-        gloss := "koii + bhii (even/also): anyone at all (FC)",
+    , { form := "koii bhii",
+        ontology := .person,
         basis := .special,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -346,16 +346,16 @@ def italian : IndefiniteParadigm :=
   { language := "Italian"
   , isoCode := "ita"
   , forms :=
-    [ { language := "Italian", form := "qualcuno",
-        gloss := "specific/irrealis indefinite",
+    [ { form := "qualcuno",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.specificKnown, .specificUnknown, .irrealis} }
-    , { language := "Italian", form := "nessuno",
-        gloss := "N-word: polarity-sensitive + direct negation",
+    , { form := "nessuno",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.question, .conditional, .indirectNeg, .directNeg} }
-    , { language := "Italian", form := "qualunque/qualsiasi",
-        gloss := "free choice universal",
+    , { form := "qualunque/qualsiasi",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -364,20 +364,20 @@ def finnish : IndefiniteParadigm :=
   { language := "Finnish"
   , isoCode := "fin"
   , forms :=
-    [ { language := "Finnish", form := "joku",
-        gloss := "specific indefinite",
+    [ { form := "joku",
+        ontology := .person,
         basis := .special,
         functions := {.specificKnown, .specificUnknown} }
-    , { language := "Finnish", form := "joku (irrealis)",
-        gloss := "joku in irrealis / non-specific",
+    , { form := "joku (irrealis)",
+        ontology := .person,
         basis := .special,
         functions := {.irrealis} }
-    , { language := "Finnish", form := "kukaan",
-        gloss := "polarity-sensitive indefinite (direct-negation function realized as ei + connegative-V + kukaan)",
+    , { form := "kukaan",
+        ontology := .person,
         basis := .special,
         functions := {.question, .conditional, .indirectNeg, .directNeg} }
-    , { language := "Finnish", form := "kuka tahansa",
-        gloss := "free choice: whoever / anyone at all",
+    , { form := "kuka tahansa",
+        ontology := .person,
         basis := .special,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -386,20 +386,20 @@ def korean : IndefiniteParadigm :=
   { language := "Korean"
   , isoCode := "kor"
   , forms :=
-    [ { language := "Korean", form := "nwukwu-nka (누군가)",
-        gloss := "wh + nka: specific indefinite",
+    [ { form := "nwukwu-nka (누군가)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.specificKnown, .specificUnknown} }
-    , { language := "Korean", form := "nwukwu (누구)",
-        gloss := "bare wh-word: non-specific indefinite",
+    , { form := "nwukwu (누구)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.irrealis, .question, .conditional} }
-    , { language := "Korean", form := "nwukwu-to (누구도, neg)",
-        gloss := "wh + to under negation: nobody",
+    , { form := "nwukwu-to (누구도, neg)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.indirectNeg, .directNeg} }
-    , { language := "Korean", form := "nwukwu-na (누구나)",
-        gloss := "wh + na: free choice / universal",
+    , { form := "nwukwu-na (누구나)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -408,20 +408,20 @@ def hungarian : IndefiniteParadigm :=
   { language := "Hungarian"
   , isoCode := "hun"
   , forms :=
-    [ { language := "Hungarian", form := "valaki",
-        gloss := "specific indefinite",
+    [ { form := "valaki",
+        ontology := .person,
         basis := .interrogative,
         functions := {.specificKnown, .specificUnknown} }
-    , { language := "Hungarian", form := "valaki (irrealis)",
-        gloss := "valaki in irrealis and question contexts",
+    , { form := "valaki (irrealis)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.irrealis, .question} }
-    , { language := "Hungarian", form := "senki",
-        gloss := "negative indefinite (with sem in direct neg)",
+    , { form := "senki",
+        ontology := .person,
         basis := .interrogative,
         functions := {.conditional, .indirectNeg, .directNeg} }
-    , { language := "Hungarian", form := "akárki / bárki",
-        gloss := "free choice: anyone at all",
+    , { form := "akárki / bárki",
+        ontology := .person,
         basis := .interrogative,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -430,20 +430,20 @@ def georgian : IndefiniteParadigm :=
   { language := "Georgian"
   , isoCode := "kat"
   , forms :=
-    [ { language := "Georgian", form := "vinme (ვინმე)",
-        gloss := "general indefinite: someone",
+    [ { form := "vinme (ვინმე)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.specificKnown, .specificUnknown, .irrealis} }
-    , { language := "Georgian", form := "vinme (question context)",
-        gloss := "vinme in question/conditional contexts",
+    , { form := "vinme (question context)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.question, .conditional} }
-    , { language := "Georgian", form := "aravin (არავინ)",
-        gloss := "negative indefinite: nobody",
+    , { form := "aravin (არავინ)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.indirectNeg, .directNeg} }
-    , { language := "Georgian", form := "nebismieri (ნებისმიერი)",
-        gloss := "free choice: any/every",
+    , { form := "nebismieri (ნებისმიერი)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -452,20 +452,20 @@ def quechua : IndefiniteParadigm :=
   { language := "Quechua (Imbabura)"
   , isoCode := "qvi"
   , forms :=
-    [ { language := "Quechua", form := "pi-taj",
-        gloss := "wh-based indefinite: someone",
+    [ { form := "pi-taj",
+        ontology := .person,
         basis := .interrogative,
         functions := {.specificKnown, .specificUnknown, .irrealis, .question} }
-    , { language := "Quechua", form := "pi-pash",
-        gloss := "wh + pash: in conditional/neg scope",
+    , { form := "pi-pash",
+        ontology := .person,
         basis := .interrogative,
         functions := {.conditional, .indirectNeg} }
-    , { language := "Quechua", form := "mana pi-pash",
-        gloss := "negation + wh + pash: nobody",
+    , { form := "mana pi-pash",
+        ontology := .person,
         basis := .interrogative,
         functions := {.directNeg} }
-    , { language := "Quechua", form := "maijan-pash",
-        gloss := "free choice: anyone",
+    , { form := "maijan-pash",
+        ontology := .person,
         basis := .interrogative,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -474,13 +474,13 @@ def yoruba : IndefiniteParadigm :=
   { language := "Yoruba"
   , isoCode := "yor"
   , forms :=
-    [ { language := "Yoruba", form := "ẹnìkan",
-        gloss := "general indefinite: somebody",
+    [ { form := "ẹnìkan",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.specificKnown, .specificUnknown, .irrealis,
                       .question, .conditional} }
-    , { language := "Yoruba", form := "ẹ̀nìkẹ́ni",
-        gloss := "polarity-sensitive + free choice",
+    , { form := "ẹ̀nìkẹ́ni",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.indirectNeg, .directNeg, .comparative, .freeChoice} } ] }
 
@@ -489,17 +489,17 @@ def thai : IndefiniteParadigm :=
   { language := "Thai"
   , isoCode := "tha"
   , forms :=
-    [ { language := "Thai", form := "khraj (ใคร)",
-        gloss := "wh-word as general indefinite",
+    [ { form := "khraj (ใคร)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.specificKnown, .specificUnknown, .irrealis,
                       .question, .conditional} }
-    , { language := "Thai", form := "mâj mii khraj (ไม่มีใคร)",
-        gloss := "NEG + exist + wh: nobody",
+    , { form := "mâj mii khraj (ไม่มีใคร)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.indirectNeg, .directNeg} }
-    , { language := "Thai", form := "khraj kɔ̂ (ใครก็)",
-        gloss := "wh + kɔ̂ particle: free choice",
+    , { form := "khraj kɔ̂ (ใครก็)",
+        ontology := .person,
         basis := .interrogative,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -508,20 +508,20 @@ def tagalog : IndefiniteParadigm :=
   { language := "Tagalog"
   , isoCode := "tgl"
   , forms :=
-    [ { language := "Tagalog", form := "may isa",
-        gloss := "existential + 'one': someone",
+    [ { form := "may isa",
+        ontology := .person,
         basis := .existentialConstruction,
         functions := {.specificKnown, .specificUnknown, .irrealis} }
-    , { language := "Tagalog", form := "sinuman",
-        gloss := "wh-based polarity-sensitive indefinite",
+    , { form := "sinuman",
+        ontology := .person,
         basis := .existentialConstruction,
         functions := {.question, .conditional, .indirectNeg} }
-    , { language := "Tagalog", form := "walang (tao)",
-        gloss := "negative existential: nobody",
+    , { form := "walang (tao)",
+        ontology := .person,
         basis := .existentialConstruction,
         functions := {.directNeg} }
-    , { language := "Tagalog", form := "kahit sino",
-        gloss := "concessive + wh: anyone at all (FC)",
+    , { form := "kahit sino",
+        ontology := .person,
         basis := .existentialConstruction,
         functions := {.comparative, .freeChoice} } ] }
 
@@ -530,17 +530,17 @@ def swahili : IndefiniteParadigm :=
   { language := "Swahili"
   , isoCode := "swh"
   , forms :=
-    [ { language := "Swahili", form := "mtu (fulani)",
-        gloss := "person (+ certain): someone",
+    [ { form := "mtu (fulani)",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.specificKnown, .specificUnknown, .irrealis,
                       .question, .conditional} }
-    , { language := "Swahili", form := "hakuna mtu / mtu … -si-",
-        gloss := "negative existential or negative verb concord",
+    , { form := "hakuna mtu / mtu … -si-",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.indirectNeg, .directNeg} }
-    , { language := "Swahili", form := "mtu ye yote",
-        gloss := "person any whatsoever: free choice",
+    , { form := "mtu ye yote",
+        ontology := .person,
         basis := .genericNoun,
         functions := {.comparative, .freeChoice} } ] }
 

--- a/Linglib/Typology/Indefinite.lean
+++ b/Linglib/Typology/Indefinite.lean
@@ -1,6 +1,7 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
 import Linglib.Data.WALS.Features.F46A
+import Linglib.Typology.Pronoun.Basic
 
 /-!
 # Indefinite-pronoun typology — consensus substrate
@@ -8,9 +9,10 @@ import Linglib.Data.WALS.Features.F46A
 
 Theory-neutral types for cross-linguistic indefinite-pronoun data, following
 the same `Typology/{Domain}.lean` pattern as `WordOrder.lean`,
-`Adposition.lean`, `MorphProfile.lean`. Plugged into per-language
-`LanguageProfile.indefinites` via `withIndefinites` (see
-`Typology/LanguageProfile.lean`).
+`Adposition.lean`, `MorphProfile.lean`. The lexical object `IndefinitePronoun`
+`extends` the general `Pronoun` (`Typology/Pronoun/Basic.lean`), so an
+indefinite pronoun is a single object that flows through the Pronoun API and
+carries its own implicational-map distribution.
 
 Theory-specific apparatus (Degano & Aloni's 7-type team-semantic typology,
 choice-function denotations, Hamblin alternatives, …) lives as projections
@@ -22,8 +24,9 @@ grammar would record.
 ## Schema
 
 - `HaspelmathFunction`: 9 functions on @cite{haspelmath-1997}'s implicational map
+- `OntologicalCategory`: 7 core categories (+ determiner, reason) of §3.1.3
 - `MorphologicalBasis`: 4 morphological strategies (= 4 of WALS F46A's 5 cells)
-- `IndefiniteEntry`: a form's gloss + basis + function-coverage
+- `IndefinitePronoun`: `extends Pronoun` with ontology + basis + function-coverage
 - `IndefiniteParadigm`: a language's full paradigm + ISO 639-3 code
 
 ## WALS bridge
@@ -31,8 +34,8 @@ grammar would record.
 `MorphologicalBasis.toWALS46A` maps each basis to its WALS F46A cell;
 `IndefiniteParadigm.toWALS46A` derives the paradigm-level F46A classification
 (including the `.mixed` cell when forms use multiple bases) from the per-form
-basis distribution. Cross-linguistic bridge theorems live in
-`Phenomena/Indefinites/Typology.lean`.
+basis distribution. Cross-linguistic bridge theorems anchored on a paper live
+in that paper's `Studies/AuthorYear.lean`.
 -/
 
 set_option autoImplicit false
@@ -135,6 +138,50 @@ def HaspelmathFunction.isContiguous (funcs : List HaspelmathFunction) : Bool :=
   | f :: _ => funcs.all (HaspelmathFunction.bfsReachable funcs f 15).contains
 
 -- ============================================================================
+-- §1b. Ontological categories (@cite{haspelmath-1997} §3.1.3)
+-- ============================================================================
+
+/-- The ontological categories of indefinite pronouns
+    (@cite{haspelmath-1997} §3.1.3, Table 3.1). The seven core categories —
+    person, thing, property, place, time, manner, amount — are the categories
+    "most often expressed by simple means in the languages of the world"; the
+    human/non-human cut (person vs thing, *somebody* vs *something*) is made
+    practically everywhere. `determiner` ('which', distinct from substantival
+    'who'/'what') and `reason` ('why') are common but non-universal (English
+    and German have no indefinite *somewhy*). -/
+inductive OntologicalCategory where
+  /-- Person: *somebody/someone* (interrogative *who?*). -/
+  | person
+  /-- Thing: *something* (interrogative *what?*). -/
+  | thing
+  /-- Property / kind: *some kind of* (interrogative *what kind?*). -/
+  | property
+  /-- Place: *somewhere* (interrogative *where?*). -/
+  | place
+  /-- Time: *sometime* (interrogative *when?*). -/
+  | time
+  /-- Manner: *somehow* (interrogative *how?*). -/
+  | manner
+  /-- Amount: *some amount* (interrogative *how much?*). -/
+  | amount
+  /-- Determiner: *some N* / 'which' — non-universal, distinct from the
+      substantival 'who'/'what'. -/
+  | determiner
+  /-- Reason / cause: 'for some reason' (interrogative *why?*) — non-universal. -/
+  | reason
+  deriving DecidableEq, Repr, BEq
+
+/-- The seven core ontological categories realized "practically everywhere"
+    (@cite{haspelmath-1997} §3.1.3); excludes the non-universal `determiner`
+    and `reason`. -/
+def OntologicalCategory.core : List OntologicalCategory :=
+  [.person, .thing, .property, .place, .time, .manner, .amount]
+
+/-- All nine ontological categories (the seven core plus `determiner`, `reason`). -/
+def OntologicalCategory.all : List OntologicalCategory :=
+  OntologicalCategory.core ++ [.determiner, .reason]
+
+-- ============================================================================
 -- §2. Morphological basis (= WALS F46A categories)
 -- ============================================================================
 
@@ -165,31 +212,36 @@ def MorphologicalBasis.toWALS46A : MorphologicalBasis → F46A.IndefinitePronoun
 -- §3. Entry + paradigm
 -- ============================================================================
 
-/-- A single indefinite-pronoun form: surface form, gloss, morphological
-    basis, and the @cite{haspelmath-1997} functions it covers.
+/-- A single indefinite pronoun — the canonical lexical object, `extends`ing the
+    general `Pronoun` (surface `form` + φ-features) with the indefinite-specific
+    structure: its `ontology`-cal category (@cite{haspelmath-1997} §3.1.3), its
+    morphological `basis`, and the `functions` it covers on the implicational map.
 
-    `functions` is the realized cross-linguistic distribution
-    (textbook-consensus data). Theory-specific predictions about which
-    functions a form *should* cover (Degano & Aloni 7-type team-semantics,
-    choice-function denotation, Hamblin alternatives) are projections of
-    this entry into theory-side types, not fields of the entry. -/
-structure IndefiniteEntry where
-  language : String
-  /-- Surface form including any required host (e.g., "kim ere", "irgend-"). -/
-  form : String
-  gloss : String
+    This is the single source of truth for an indefinite pronoun: it *is* a
+    `Pronoun`, so it flows through the Pronoun API, and it carries its own
+    distribution. `functions` is the realized cross-linguistic distribution
+    (textbook-consensus data); theory-specific predictions about which functions
+    a form *should* cover (Degano & Aloni 7-type team-semantics, choice-function
+    denotation, Hamblin alternatives) are projections into theory-side types,
+    not fields here. -/
+structure IndefinitePronoun extends Pronoun where
+  /-- The @cite{haspelmath-1997} §3.1.3 ontological category (person, thing, …). -/
+  ontology : OntologicalCategory
+  /-- The morphological derivation strategy (interrogative-based, etc.). -/
   basis : MorphologicalBasis
+  /-- The functions on @cite{haspelmath-1997}'s implicational map this form
+      covers (a contiguous region; see `IndefiniteParadigm.AllContiguous`). -/
   functions : Finset HaspelmathFunction
   deriving DecidableEq
 
-/-- Manual `Repr` showing just `language.form` to avoid the `unsafe`
+/-- Manual `Repr` showing just the surface `form` to avoid the `unsafe`
     `Repr (Finset α)` instance from `Mathlib.Data.Finset.Sort`, which
-    would propagate unsafety into every consumer of `IndefiniteEntry`. -/
-instance : Repr IndefiniteEntry where
-  reprPrec e _ := s!"{e.language}.{e.form}"
+    would propagate unsafety into every consumer of `IndefinitePronoun`. -/
+instance : Repr IndefinitePronoun where
+  reprPrec e _ := s!"{e.form}"
 
 /-- Does this entry cover function `f`? -/
-def IndefiniteEntry.covers (e : IndefiniteEntry) (f : HaspelmathFunction) : Bool :=
+def IndefinitePronoun.covers (e : IndefinitePronoun) (f : HaspelmathFunction) : Bool :=
   decide (f ∈ e.functions)
 
 /-- A language's full indefinite-pronoun paradigm. `isoCode` is ISO 639-3,
@@ -197,15 +249,15 @@ def IndefiniteEntry.covers (e : IndefiniteEntry) (f : HaspelmathFunction) : Bool
 structure IndefiniteParadigm where
   language : String
   isoCode : String
-  forms : List IndefiniteEntry
-  deriving DecidableEq, Repr -- inherits manual Repr IndefiniteEntry
+  forms : List IndefinitePronoun
+  deriving DecidableEq, Repr -- inherits manual Repr IndefinitePronoun
 
 namespace IndefiniteParadigm
 
 variable (p : IndefiniteParadigm)
 
 /-- Forms in `p` whose distribution covers function `f`. -/
-def formsFor (f : HaspelmathFunction) : List IndefiniteEntry :=
+def formsFor (f : HaspelmathFunction) : List IndefinitePronoun :=
   p.forms.filter (·.covers f)
 
 /-- The first form (in declaration order) covering `f`, if any. Used to
@@ -268,11 +320,11 @@ end IndefiniteParadigm
 
 /-- For each form, the list of functions it covers, in `HaspelmathFunction.all`
     order. -/
-def IndefiniteEntry.functionList (e : IndefiniteEntry) : List HaspelmathFunction :=
+def IndefinitePronoun.functionList (e : IndefinitePronoun) : List HaspelmathFunction :=
   HaspelmathFunction.all.filter (e.covers ·)
 
 /-- Coverage of a single form: number of functions it spans. -/
-def IndefiniteEntry.coverage (e : IndefiniteEntry) : Nat :=
+def IndefinitePronoun.coverage (e : IndefinitePronoun) : Nat :=
   e.functionList.length
 
 -- ============================================================================


### PR DESCRIPTION
Unify indefinite pronouns onto one canonical object in the Pronoun API.

- `Typology.Indefinite.IndefiniteEntry` → `IndefinitePronoun extends Pronoun` (single source of truth; reuses the existing Haspelmath map theory). Dropped the redundant per-entry `language`/`gloss`.
- New `OntologicalCategory` (Haspelmath §3.1.3: 7 core + determiner/reason) as first-class data.
- Farsi's unrelated local determiner type disambiguated to `IndefiniteDeterminer`.