### PR TITLE
fix(Studies): re-source Corbett gender/number studies on the monographs

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2828,6 +2828,7 @@ import Linglib.Fragments.Hebrew.Gender
 import Linglib.Fragments.Latin.Gender
 import Linglib.Fragments.Romanian.Gender
 import Linglib.Fragments.Dyirbal.Gender
+import Linglib.Fragments.Archi.Gender
 import Linglib.Fragments.Georgian.Gender
 import Linglib.Fragments.Swahili.Gender
 import Linglib.Fragments.Zulu.Gender

--- a/Linglib/Fragments/Archi/Gender.lean
+++ b/Linglib/Fragments/Archi/Gender.lean
@@ -1,0 +1,37 @@
+import Linglib.Typology.Gender
+
+/-!
+# Archi Gender
+@cite{corbett-2013} @cite{corbett-1991}
+
+WALS @cite{corbett-2013} (Chs 30/31/32) classifies Archi (Nakh-Daghestanian,
+ISO `aqc`) as a 4-gender, sex-based, semantic-assignment system. Its four
+genders are I (male rationals), II (female rationals), III (most animals and
+some inanimates), and IV (the residue); gender shows in pervasive agreement
+on verbs and predicates.
+
+@cite{corbett-1991} documents phonological and morphological correlates for
+the III/IV split, so the monograph treats assignment as semantic *and formal*
+rather than semantic-only — a per-Study override at `Studies/Corbett1991.lean`.
+-/
+
+namespace Archi.Gender
+
+open Typology.Gender
+
+/-- Archi gender typology per WALS @cite{corbett-2013}: 4-gender, sex-based,
+    semantic assignment (Nakh-Daghestanian). Agreement targets per
+    @cite{corbett-1991} (pervasive predicate and verbal agreement). -/
+def genderTypology : GenderProfile :=
+  .fromWALS "Archi" "aqc"
+    (rawGenderCount := 4)
+    (genderCountFb := .four)
+    (basisFb := .sexBased)
+    (assignmentFb := .semanticOnly)
+    (agreementTargets := [.predicate, .verb])
+    (semanticBases := [.rationality, .sex, .animacy])
+
+example : genderTypology.iso639 = "aqc" ∧ genderTypology.name = "Archi" :=
+  ⟨rfl, rfl⟩
+
+end Archi.Gender

--- a/Linglib/Fragments/English/Gender.lean
+++ b/Linglib/Fragments/English/Gender.lean
@@ -6,10 +6,10 @@ import Linglib.Typology.Gender
 
 WALS @cite{corbett-2013} classifies English as 3-gender, sex-based,
 semantic-only on the strength of the *he/she/it* pronoun distinction.
-This is the more recent of Corbett's two classifications; his 1991
-monograph applies a stricter controller-marking criterion that excludes
-English from the gender typology. The Corbett 1991 view is a per-Study
-override at `Studies/Corbett1991.lean`.
+This agrees with @cite{corbett-1991}, which treats English as a
+*pronominal gender system*: it has the category of gender (3 genders,
+*he/she/it*), assigned on purely semantic grounds, but gender surfaces
+only in personal, possessive, and reflexive pronouns.
 -/
 
 namespace English.Gender

--- a/Linglib/Studies/Corbett1991.lean
+++ b/Linglib/Studies/Corbett1991.lean
@@ -18,7 +18,7 @@ import Linglib.Fragments.Slavic.Russian.Gender
 import Linglib.Fragments.Latin.Gender
 import Linglib.Fragments.Romanian.Gender
 import Linglib.Fragments.Dyirbal.Gender
-import Linglib.Fragments.Georgian.Gender
+import Linglib.Fragments.Archi.Gender
 import Linglib.Fragments.Swahili.Gender
 import Linglib.Fragments.Zulu.Gender
 import Linglib.Fragments.Fula.Gender
@@ -41,27 +41,29 @@ semanticBases, attestedSurfaceGenders) are local per-language commitments.
 ## Sample composition
 
 22 languages chosen to span all five `GenderCount` values:
-- **No gender** (English, Mandarin, Japanese, Turkish, Finnish, Korean,
-  Quechua — 7 languages).
+- **No gender** (Mandarin, Japanese, Turkish, Finnish, Korean, Quechua —
+  6 languages).
 - **2 genders** (French, Spanish, Hindi-Urdu, Irish, Hebrew, Hausa —
   6 languages).
-- **3 genders** (German, Russian, Latin, Romanian — 4 languages).
-- **4 genders** (Dyirbal, Georgian — 2 languages).
+- **3 genders** (German, Russian, Latin, Romanian, and — as a *pronominal*
+  gender system — English — 5 languages).
+- **4 genders** (Dyirbal, Archi — 2 languages).
 - **5+ noun classes** (Swahili, Zulu, Fula — 3 languages).
 
 The sample includes Bantu noun-class systems (Swahili, Zulu) and Fula
-(20+ classes), the Australian 4-class system Dyirbal, and the Caucasian
-rationality-based Georgian system, alongside the canonical European
-sex-based 2/3 systems.
+(20+ classes), the Australian 4-class system Dyirbal, and the
+Nakh-Daghestanian 4-gender system Archi (sex-based at the rational tier,
+non-rational genders by animacy), alongside the canonical European
+sex-based 2/3 systems and English's pronominal gender.
 
 ## What this file deliberately omits
 
 Aggregate-count theorems (`sample_X_count = N`, `gender_scale_range`,
 `sample_diversity`) — these go stale every time a Fragment is added to
 the sample and were the "aggregate-count theorems" anti-pattern. The
-substantive Corbett 1991 generalisations (Agreement Hierarchy properties,
-no-purely-formal claim, basis × count interactions) are kept; ISO sanity
-remains as a drift sentry.
+substantive Corbett 1991 generalisations (the no-purely-formal-assignment
+finding, Agreement Hierarchy properties, the canonical-gender notion) are
+kept; ISO sanity remains as a drift sentry.
 -/
 
 set_option autoImplicit false
@@ -71,18 +73,17 @@ namespace Corbett1991
 open Typology.Gender
 open Syntax.Agreement (AgreementTarget)
 
--- ============================================================================
--- §1. The 22-language exemplar sample
--- ============================================================================
+/-! ### The 22-language exemplar sample -/
 
 /-! Per-language profiles drawn from `Fragments/{Lang}/Gender.lean` via
     `GenderProfile.fromWALS`. Aliases here for concise reference below.
 
-    Three languages are record-updated to match Corbett's 1991 monograph
-    where it diverges from his later WALS chapters @cite{corbett-2013}.
-    The divergences are first-class theorems in §9 below — exposing them
-    rather than hiding them inside the Fragment. -/
+    Two languages (Dyirbal, Archi) are record-updated to match Corbett's
+    1991 monograph where it diverges from his later WALS chapters
+    @cite{corbett-2013}. The divergences are first-class theorems below —
+    exposing them rather than hiding them inside the Fragment. -/
 
+private abbrev english   := English.Gender.genderTypology
 private abbrev mandarin  := Mandarin.Gender.genderTypology
 private abbrev japanese  := Japanese.Gender.genderTypology
 private abbrev turkish   := Turkish.Gender.genderTypology
@@ -103,18 +104,8 @@ private abbrev swahili   := Swahili.Gender.genderTypology
 private abbrev zulu      := Zulu.Gender.genderTypology
 private abbrev fula      := Fula.Gender.genderTypology
 
-/-! Corbett-1991 record-overrides for the 3 languages where Corbett's 1991
+/-! Corbett-1991 record-overrides for the 2 languages where Corbett's 1991
     book disagrees with his 2013 WALS chapters. -/
-
-/-- Corbett 1991: English has no grammatical gender (the *he/she/it*
-    pronoun distinction is natural gender, not a controller-marked system).
-    WALS @cite{corbett-2013} F30A says 3-gender. Override here. -/
-private def english : GenderProfile :=
-  { English.Gender.genderTypology with
-    genderCount := .none, rawGenderCount := 0
-    basis := .noGender, assignment := .noGender
-    agreementTargets := [], semanticBases := []
-    attestedSurfaceGenders := [] }
 
 /-- Corbett 1991: Dyirbal is 4-class non-sex-based (the system's organising
     criteria cut across biological sex). WALS @cite{corbett-2013} F31A says
@@ -123,30 +114,26 @@ private def dyirbal : GenderProfile :=
   { Dyirbal.Gender.genderTypology with
     basis := .nonSexBased }
 
-/-- Corbett 1991: Georgian is a 4-class non-sex-based gender system on the
-    rationality/animacy split (agreement on pronouns + verbs). WALS
-    @cite{corbett-2013} F30A/31A/32A says no gender on the noun-side-marking
-    criterion. Override. -/
-private def georgian : GenderProfile :=
-  { Georgian.Gender.genderTypology with
-    genderCount := .four, rawGenderCount := 4
-    basis := .nonSexBased, assignment := .semanticOnly
-    agreementTargets := [.personalPronoun, .verb]
-    semanticBases := [.rationality, .animacy] }
+/-- Corbett 1991: Archi assignment is semantic *and formal* — the monograph
+    documents phonological/morphological correlates for the gender III/IV
+    split. WALS @cite{corbett-2013} F32A codes Archi as semantic-only.
+    Override the assignment; count/basis/targets agree with WALS. -/
+private def archi : GenderProfile :=
+  { Archi.Gender.genderTypology with
+    assignment := .semanticAndFormal }
 
-/-- All 22 language profiles in the Corbett 1991 sample. English, Dyirbal,
-    and Georgian are the record-overridden versions; the WALS originals
-    are at `Fragments.{English,Dyirbal,Georgian}.Gender.genderTypology`. -/
+/-- All 22 language profiles in the Corbett 1991 sample. Dyirbal and Archi
+    are the record-overridden versions (the WALS originals are at
+    `Fragments.{Dyirbal,Archi}.Gender.genderTypology`); every other language,
+    including English, uses its WALS-derived Fragment value directly. -/
 def allProfiles : List GenderProfile :=
   [ english, mandarin, japanese, turkish, finnish, korean, quechua
   , french, spanish, hindiUrdu, irish, hebrew, hausa
   , german, russian, latin, romanian
-  , dyirbal, georgian
+  , dyirbal, archi
   , swahili, zulu, fula ]
 
--- ============================================================================
--- §2. Sample-level structural sanity
--- ============================================================================
+/-! ### Sample-level structural sanity -/
 
 /-- All raw gender counts are consistent with their WALS bins. -/
 theorem all_raw_consistent :
@@ -176,9 +163,7 @@ theorem all_assignments_attested :
     (∃ p ∈ allProfiles, p.assignment = .semanticOnly) ∧
     (∃ p ∈ allProfiles, p.assignment = .semanticAndFormal) := by decide
 
--- ============================================================================
--- §3. Cross-linguistic generalisations (Corbett 1991)
--- ============================================================================
+/-! ### Cross-linguistic generalisations -/
 
 /-- All 2- and 3-gender systems in the sample are sex-based. Reflects the
     cross-linguistic pattern that small gender systems organise around sex. -/
@@ -196,14 +181,6 @@ theorem no_purely_formal_in_sample :
         p.assignment = .semanticOnly ∨ p.assignment = .semanticAndFormal := by
   decide
 
-/-- All 3-gender systems in the sample use semantic + formal assignment.
-    Sex-based 3-gender systems require formal correlates because the
-    masculine/feminine/neuter distinction can't be determined by semantics
-    alone. -/
-theorem three_gender_always_formal :
-    ∀ p ∈ allProfiles,
-      p.genderCount = .three → p.assignment = .semanticAndFormal := by decide
-
 /-- A gender system without any agreement is not a gender system — genders
     are precisely the categories that trigger agreement. -/
 theorem gender_implies_agreement :
@@ -211,12 +188,12 @@ theorem gender_implies_agreement :
       (p.genderCount ≠ .none → p.HasAgreement) ∧
       (p.genderCount = .none → ¬ p.HasAgreement) := by decide
 
--- ============================================================================
--- §4. Corbett's Agreement Hierarchy
--- ============================================================================
+/-! ### Corbett's Agreement Hierarchy -/
 
-/-! @cite{corbett-1991}'s Agreement Hierarchy:
-    attributive > predicate > relative pronoun > personal pronoun > verb. -/
+/-! @cite{corbett-1991}'s Agreement Hierarchy has four positions:
+    attributive > predicate > relative pronoun > personal pronoun.
+    Verbal agreement (the substrate's `.verb` `AgreementTarget`, tested
+    below) is subsumed under the predicate position in Corbett's scheme. -/
 
 /-- Verb agreement implies higher-target agreement in the sample (none of
     the languages agree only on verbs). -/
@@ -231,15 +208,13 @@ theorem agreement_hierarchy_verb_implies_higher :
 theorem no_verb_only_agreement :
     ∀ p ∈ allProfiles, p.agreementTargets ≠ [.verb] := by decide
 
-/-- No gendered language in the sample has agreement only on personal
-    pronouns: pronoun agreement always co-occurs with at least one other
-    target. -/
-theorem no_pronoun_only_agreement :
-    ∀ p ∈ allProfiles,
-      (p.genderCount ≠ .none ∧ .personalPronoun ∈ p.agreementTargets) →
-        .attributive ∈ p.agreementTargets ∨
-        .predicate ∈ p.agreementTargets ∨
-        .verb ∈ p.agreementTargets := by decide
+/-- English is the sample's pronominal gender system: it has gender
+    (3 genders, *he/she/it*) but gender surfaces only on personal pronouns —
+    the canonical case of a system whose agreement sits at the low end of
+    @cite{corbett-1991}'s hierarchy. -/
+theorem english_pronominal_gender :
+    english.genderCount ≠ .none ∧
+    english.agreementTargets = [.personalPronoun] := by decide
 
 /-- Noun-class systems (5+) show agreement on more targets than smaller
     systems. In the sample, all noun-class systems agree on ≥4 of the 5
@@ -248,29 +223,14 @@ theorem noun_class_rich_agreement :
     ∀ p ∈ allProfiles,
       p.IsNounClassSystem → p.agreementTargets.length ≥ 4 := by decide
 
--- ============================================================================
--- §5. Basis × count interactions
--- ============================================================================
+/-! ### Basis × count interactions -/
 
 /-- Non-sex-based systems in the sample have ≥4 genders. When gender is not
     organised around sex, the system tends to proliferate. -/
 theorem non_sex_based_more_genders :
     ∀ p ∈ allProfiles, p.basis = .nonSexBased → p.rawGenderCount ≥ 4 := by decide
 
-/-- Semantic-only assignment in the sample is restricted to non-sex-based
-    systems. Sex-based systems typically have formal correlates. -/
-theorem semantic_only_is_non_sex_based :
-    ∀ p ∈ allProfiles,
-      p.assignment = .semanticOnly → p.basis = .nonSexBased := by decide
-
-/-- All sex-based systems in the sample use semantic + formal assignment. -/
-theorem sex_based_always_formal :
-    ∀ p ∈ allProfiles,
-      p.basis = .sexBased → p.assignment = .semanticAndFormal := by decide
-
--- ============================================================================
--- §6. Canonical-gender notion
--- ============================================================================
+/-! ### Canonical-gender notion -/
 
 /-- European languages in the sample (and Hindi-Urdu) all have canonical
     gender systems (sex-based, 2 or 3 genders, semantic + formal). -/
@@ -280,9 +240,7 @@ theorem canonical_gender_attested :
     latin.IsCanonicalGender ∧ romanian.IsCanonicalGender ∧
     hindiUrdu.IsCanonicalGender := by decide
 
--- ============================================================================
--- §7. SurfaceGender bridge (post Bool→Prop migration)
--- ============================================================================
+/-! ### SurfaceGender bridge -/
 
 /-- Every 2- or 3-gender sex-based language in the sample exposes the
     appropriate `Features.SurfaceGender` values via the
@@ -295,31 +253,20 @@ theorem surface_gender_bridge_populated :
       (p.genderCount = .three ∧ p.basis = .sexBased →
         p.attestedSurfaceGenders.length = 3) := by decide
 
--- ============================================================================
--- §8. ISO code sanity (drift sentry)
--- ============================================================================
+/-! ### ISO code sanity (drift sentry) -/
 
 theorem iso_codes_unique :
     (allProfiles.map (·.iso639)).eraseDups.length = allProfiles.length := by
   decide
 
--- ============================================================================
--- §9. Within-Corbett (1991 vs 2013) divergence theorems
--- ============================================================================
+/-! ### Within-Corbett (1991 vs 2013) divergence theorems -/
 
-/-! Three first-class disagreements between Corbett's 1991 monograph and
-    his 2013 WALS chapters. The 1991 values are this Studies file's
-    `english/dyirbal/georgian` overrides; the 2013 values are the
-    Fragment-side `Fragments.{Lang}.Gender.genderTypology` (which goes
-    through `GenderProfile.fromWALS`). Linglib's interconnection-density
-    thesis: incompatibilities visible. -/
-
-/-- Corbett 1991 vs 2013: English. The 1991 monograph applies a strict
-    controller-marking criterion (English has none); the 2013 WALS chapter
-    treats the *he/she/it* pronoun distinction as a 3-gender system. -/
-theorem english_corbett1991_vs_corbett2013 :
-    english.genderCount = .none ∧
-    English.Gender.genderTypology.genderCount = .three := by decide
+/-! Two first-class disagreements between Corbett's 1991 monograph and his
+    2013 WALS chapters. The 1991 values are this Studies file's `dyirbal`
+    and `archi` overrides; the 2013 values are the Fragment-side
+    `Fragments.{Lang}.Gender.genderTypology` (which goes through
+    `GenderProfile.fromWALS`). Linglib's interconnection-density thesis:
+    incompatibilities visible. -/
 
 /-- Corbett 1991 vs 2013: Dyirbal. The 1991 monograph treats Dyirbal as
     non-sex-based (organising principles cut across sex); the 2013 WALS
@@ -329,12 +276,12 @@ theorem dyirbal_corbett1991_vs_corbett2013 :
     dyirbal.basis = .nonSexBased ∧
     Dyirbal.Gender.genderTypology.basis = .sexBased := by decide
 
-/-- Corbett 1991 vs 2013: Georgian. The 1991 monograph treats Georgian's
-    rationality/animacy split as a 4-class gender system (agreement on
-    pronouns + verbs); the 2013 WALS chapter codes it as no-gender on the
-    noun-side-marking criterion. -/
-theorem georgian_corbett1991_vs_corbett2013 :
-    georgian.genderCount = .four ∧
-    Georgian.Gender.genderTypology.genderCount = .none := by decide
+/-- Corbett 1991 vs 2013: Archi. The 1991 monograph documents phonological
+    and morphological correlates for the gender III/IV split, so it treats
+    assignment as semantic *and formal*; the 2013 WALS chapter (F32A) codes
+    Archi as semantic assignment only. -/
+theorem archi_corbett1991_vs_corbett2013 :
+    archi.assignment = .semanticAndFormal ∧
+    Archi.Gender.genderTypology.assignment = .semanticOnly := by decide
 
 end Corbett1991

--- a/Linglib/Studies/Corbett2000.lean
+++ b/Linglib/Studies/Corbett2000.lean
@@ -933,9 +933,9 @@ structure PredicateHierarchyProfile where
 private def predicatePositions : List PredicateTarget :=
   [.verb, .participle, .adjective, .noun]
 
-/-- The Predicate Hierarchy monotonicity constraint: once semantic agreement
-    becomes possible at a sub-position, it remains possible at all higher
-    positions. -/
+/-- The Predicate Hierarchy (@cite{comrie-1975}) monotonicity constraint:
+    once semantic agreement becomes possible at a sub-position, it remains
+    possible at all higher positions. -/
 def PredicateHierarchyProfile.RespectsHierarchy (p : PredicateHierarchyProfile) : Prop :=
   ∀ t1 ∈ predicatePositions, ∀ t2 ∈ predicatePositions,
     t1.rank ≥ t2.rank ∨ t1 ∉ p.semanticTargets ∨ t2 ∈ p.semanticTargets

--- a/Linglib/Studies/Corbett2000.lean
+++ b/Linglib/Studies/Corbett2000.lean
@@ -921,9 +921,9 @@ theorem japanese_count_mass_uniform :
 
 open Syntax.Agreement (PredicateTarget)
 
-/-- Russian: predicate adjectives agree in gender/number, but past-tense
-    verbs also do — illustrating the Predicate Hierarchy within the
-    agreement target position. -/
+/-- A predicate-hierarchy profile records the sub-positions (verb, participle,
+    adjective, noun) where semantic agreement is possible for a controller —
+    e.g. Russian honorific *vy*. -/
 structure PredicateHierarchyProfile where
   name : String
   /-- Predicate sub-positions where semantic agreement is possible. -/
@@ -943,15 +943,19 @@ def PredicateHierarchyProfile.RespectsHierarchy (p : PredicateHierarchyProfile) 
 instance (p : PredicateHierarchyProfile) : Decidable p.RespectsHierarchy := by
   unfold PredicateHierarchyProfile.RespectsHierarchy; infer_instance
 
-/-- Russian *deca* ('children'): semantic agreement on predicate adjective
-    and noun, but not on finite verb. Participial agreement follows
-    adjective. -/
-def russianDecaPredHier : PredicateHierarchyProfile :=
-  { name := "Russian deca (Predicate Hierarchy)"
-    semanticTargets := [.participle, .adjective, .noun] }
+/-- Russian honorific *vy* 'you' (polite singular): grammatically plural but
+    referring to one person, so semantic agreement = singular. Per
+    @cite{corbett-2000}'s Predicate Hierarchy data, the finite verb and
+    participle keep syntactic (plural) agreement, while the long-form
+    predicate adjective and the predicate noun take singular (semantic)
+    agreement. -/
+def russianHonorificVy : PredicateHierarchyProfile :=
+  { name := "Russian honorific vy (Predicate Hierarchy)"
+    semanticTargets := [.adjective, .noun] }
 
-/-- The Russian Predicate Hierarchy profile respects monotonicity. -/
+/-- The Russian honorific-*vy* profile respects Predicate Hierarchy
+    monotonicity. -/
 theorem russian_predicate_hierarchy_holds :
-    russianDecaPredHier.RespectsHierarchy := by decide
+    russianHonorificVy.RespectsHierarchy := by decide
 
 end Corbett2000

--- a/Linglib/Studies/Corbett2000.lean
+++ b/Linglib/Studies/Corbett2000.lean
@@ -329,23 +329,28 @@ inductive AgreementControl where
   | semantic   -- meaning-driven: *committee* denotes a group of individuals
   deriving DecidableEq, Repr
 
-/-- An agreement profile for a controller type records whether semantic
-    agreement is available at each target position. -/
+/-- An agreement profile for a controller type records the targets where
+    semantic (meaning-driven) agreement is available. -/
 structure AgreementProfile where
   /-- Controller description -/
   controller : String
-  /-- Whether semantic (meaning-driven) agreement is possible at each target -/
-  semanticPossible : AgreementTarget → Bool
+  /-- Targets where semantic (meaning-driven) agreement is possible. -/
+  semanticTargets : List AgreementTarget
+
+/-- The four positions of @cite{corbett-1991}'s Agreement Hierarchy (`verb`
+    is not one of them — see `Syntax.Agreement.AgreementTarget`). -/
+private def hierarchyPositions : List AgreementTarget :=
+  [.attributive, .predicate, .relativePronoun, .personalPronoun]
 
 /-- The Agreement Hierarchy monotonicity constraint: once semantic agreement
     becomes possible at a target, it remains possible at all targets further
     right (= lower `Syntax.Agreement.AgreementTarget.rank`) on the hierarchy. -/
-def AgreementProfile.respectsHierarchy (p : AgreementProfile) : Bool :=
-  let targets := [AgreementTarget.attributive, .predicate,
-                   .relativePronoun, .personalPronoun]
-  targets.all λ t1 =>
-    targets.all λ t2 =>
-      t1.rank <= t2.rank || !p.semanticPossible t1 || p.semanticPossible t2
+def AgreementProfile.RespectsHierarchy (p : AgreementProfile) : Prop :=
+  ∀ t1 ∈ hierarchyPositions, ∀ t2 ∈ hierarchyPositions,
+    t1.rank ≤ t2.rank ∨ t1 ∉ p.semanticTargets ∨ t2 ∈ p.semanticTargets
+
+instance (p : AgreementProfile) : Decidable p.RespectsHierarchy := by
+  unfold AgreementProfile.RespectsHierarchy; infer_instance
 
 -- Language data
 
@@ -353,51 +358,42 @@ def AgreementProfile.respectsHierarchy (p : AgreementProfile) : Bool :=
     semantic agreement possible in predicate, relative pronoun, and
     personal pronoun. -/
 def britishCommittee : AgreementProfile :=
+  -- *these committee (no); the committee have decided / who have... / they (yes)
   { controller := "committee (British English)"
-    semanticPossible := λ
-      | .attributive     => false  -- *these committee
-      | .predicate       => true   -- the committee have decided
-      | .relativePronoun => true   -- the committee, who have...
-      | .personalPronoun => true   -- the committee... they
-      | .verb      => true }
+    semanticTargets := [.predicate, .relativePronoun, .personalPronoun, .verb] }
 
 /-- American English *committee*: semantic agreement rare in predicate,
     but available in relative and personal pronoun. -/
 def americanCommittee : AgreementProfile :=
+  -- ?the committee have decided (rare in AmE): no predicate/verb; pronouns yes
   { controller := "committee (American English)"
-    semanticPossible := λ
-      | .attributive     => false
-      | .predicate       => false  -- ?the committee have decided (rare in AmE)
-      | .relativePronoun => true
-      | .personalPronoun => true
-      | .verb      => false }
+    semanticTargets := [.relativePronoun, .personalPronoun] }
 
 /-- Serbo-Croatian *deca* 'children': morphologically feminine singular,
     semantically plural. Semantic agreement available everywhere. -/
 def serboCroatDeca : AgreementProfile :=
   { controller := "deca 'children' (Serbo-Croatian)"
-    semanticPossible := λ _ => true }
+    semanticTargets := [.attributive, .predicate, .relativePronoun, .personalPronoun, .verb] }
 
 def allAgreementProfiles : List AgreementProfile :=
   [britishCommittee, americanCommittee, serboCroatDeca]
 
 /-- The Agreement Hierarchy is respected by all profiled controllers. -/
 theorem agreement_hierarchy_holds :
-    allAgreementProfiles.all (·.respectsHierarchy) = true := by native_decide
+    ∀ p ∈ allAgreementProfiles, p.RespectsHierarchy := by decide
 
 /-- Once semantic agreement reaches the personal pronoun (rightmost),
     it is necessarily available there for all our controllers. -/
 theorem semantic_at_pronoun :
-    allAgreementProfiles.all (·.semanticPossible .personalPronoun) = true := by
-  native_decide
+    ∀ p ∈ allAgreementProfiles, .personalPronoun ∈ p.semanticTargets := by decide
 
 /-- No controller has semantic agreement only at the attributive position
     (the leftmost) without also having it further right — this would violate
     the monotonicity constraint. -/
 theorem no_attributive_only_semantic :
-    allAgreementProfiles.all (λ p =>
-      !p.semanticPossible .attributive ||
-       p.semanticPossible .personalPronoun) = true := by native_decide
+    ∀ p ∈ allAgreementProfiles,
+      .attributive ∈ p.semanticTargets → .personalPronoun ∈ p.semanticTargets := by
+  decide
 
 -- ============================================================================
 -- §5: Controller–Target Mismatch (Ch 6, §6.1)
@@ -930,31 +926,32 @@ open Syntax.Agreement (PredicateTarget)
     agreement target position. -/
 structure PredicateHierarchyProfile where
   name : String
-  /-- Whether semantic agreement is available at each predicate sub-position -/
-  semanticPossible : PredicateTarget → Bool
+  /-- Predicate sub-positions where semantic agreement is possible. -/
+  semanticTargets : List PredicateTarget
+
+/-- The four sub-positions of the Predicate Hierarchy. -/
+private def predicatePositions : List PredicateTarget :=
+  [.verb, .participle, .adjective, .noun]
 
 /-- The Predicate Hierarchy monotonicity constraint: once semantic agreement
     becomes possible at a sub-position, it remains possible at all higher
     positions. -/
-def PredicateHierarchyProfile.respectsHierarchy (p : PredicateHierarchyProfile) : Bool :=
-  let targets := [PredicateTarget.verb, .participle, .adjective, .noun]
-  targets.all λ t1 =>
-    targets.all λ t2 =>
-      t1.rank >= t2.rank || !p.semanticPossible t1 || p.semanticPossible t2
+def PredicateHierarchyProfile.RespectsHierarchy (p : PredicateHierarchyProfile) : Prop :=
+  ∀ t1 ∈ predicatePositions, ∀ t2 ∈ predicatePositions,
+    t1.rank ≥ t2.rank ∨ t1 ∉ p.semanticTargets ∨ t2 ∈ p.semanticTargets
+
+instance (p : PredicateHierarchyProfile) : Decidable p.RespectsHierarchy := by
+  unfold PredicateHierarchyProfile.RespectsHierarchy; infer_instance
 
 /-- Russian *deca* ('children'): semantic agreement on predicate adjective
     and noun, but not on finite verb. Participial agreement follows
     adjective. -/
 def russianDecaPredHier : PredicateHierarchyProfile :=
   { name := "Russian deca (Predicate Hierarchy)"
-    semanticPossible := λ
-      | .verb       => false
-      | .participle => true
-      | .adjective  => true
-      | .noun       => true }
+    semanticTargets := [.participle, .adjective, .noun] }
 
 /-- The Russian Predicate Hierarchy profile respects monotonicity. -/
 theorem russian_predicate_hierarchy_holds :
-    russianDecaPredHier.respectsHierarchy = true := by native_decide
+    russianDecaPredHier.RespectsHierarchy := by decide
 
 end Corbett2000

--- a/Linglib/Syntax/Agreement/Basic.lean
+++ b/Linglib/Syntax/Agreement/Basic.lean
@@ -56,11 +56,12 @@ theorem AgreementTarget.rank_injective :
   fun a b h => by cases a <;> cases b <;> simp_all [AgreementTarget.rank]
 
 -- ============================================================================
--- § 2: Predicate Hierarchy (@cite{corbett-2000} Ch 6)
+-- § 2: Predicate Hierarchy (@cite{comrie-1975}; @cite{corbett-2000} Ch 6)
 -- ============================================================================
 
-/-- The Predicate Hierarchy (@cite{corbett-2000}) decomposes the predicate
-    position on the Agreement Hierarchy into a sub-hierarchy:
+/-- The Predicate Hierarchy (@cite{comrie-1975}, systematised by
+    @cite{corbett-2000}) decomposes the predicate position on the Agreement
+    Hierarchy into a sub-hierarchy:
     verb < participle < adjective < noun.
 
     Semantic agreement increases monotonically along this sub-hierarchy:

--- a/Linglib/Syntax/Agreement/Basic.lean
+++ b/Linglib/Syntax/Agreement/Basic.lean
@@ -3,10 +3,15 @@ import Mathlib.Order.Nat
 /-!
 # Agreement Target Hierarchy @cite{corbett-1991}
 
-The Agreement Hierarchy (@cite{corbett-1991}) ranks morphosyntactic targets
-by likelihood of showing agreement: attributive adjectives are most likely,
-verbs least likely. If a language shows gender/number agreement on a lower
-target, it shows agreement on all higher targets.
+@cite{corbett-1991}'s Agreement Hierarchy has four positions —
+attributive > predicate > relative pronoun > personal pronoun — along which
+the likelihood of *semantic* (rather than syntactic) agreement increases
+monotonically from left to right.
+
+The `AgreementTarget` enum below additionally carries a `verb` target, ranked
+below personal pronoun, for languages with verbal gender/number agreement.
+Corbett subsumes verbal agreement under the predicate position, so `verb` is
+a linglib refinement, not a fifth position of Corbett's hierarchy.
 
 This type is shared by gender typology (`Linglib/Typology/Gender.lean` and
 `Studies/Corbett1991.lean`) and number agreement
@@ -15,11 +20,12 @@ This type is shared by gender typology (`Linglib/Typology/Gender.lean` and
 
 namespace Syntax.Agreement
 
-/-- Morphosyntactic targets where agreement can surface, ordered by the
-    Agreement Hierarchy (@cite{corbett-1991}).
+/-- Morphosyntactic targets where agreement can surface, ranked by
+    @cite{corbett-1991}'s Agreement Hierarchy (with `verb` as a linglib
+    refinement below personal pronoun — see the module docstring).
 
-    Higher rank = more likely to show agreement (closer to controller).
-    Lower rank = less likely (further from controller, more semantic). -/
+    Higher rank = closer to the controller, agreement more syntactic.
+    Lower rank = further from the controller, agreement more semantic. -/
 inductive AgreementTarget where
   | attributive       -- attributive adjective (e.g. French *un bon livre*)
   | predicate         -- predicate adjective/verb (e.g. Russian *kniga interesnaja*)

--- a/Linglib/Typology/Gender.lean
+++ b/Linglib/Typology/Gender.lean
@@ -140,8 +140,10 @@ structure GenderProfile where
   basis : GenderBasis
   /-- Ch 32: assignment system. -/
   assignment : AssignmentSystem
-  /-- Where gender agreement surfaces (@cite{corbett-1991} Agreement
-      Hierarchy: attributive > predicate > relative > pronoun > verb). -/
+  /-- Where gender agreement surfaces. @cite{corbett-1991}'s Agreement
+      Hierarchy has four positions (attributive > predicate > relative
+      pronoun > personal pronoun); `verb` is a linglib refinement for
+      verbal agreement (see `Syntax.Agreement.AgreementTarget`). -/
   agreementTargets : List AgreementTarget
   /-- Semantic dimensions organising the system. -/
   semanticBases : List SemanticBasis

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4576,6 +4576,20 @@
   validated = {true},
   sources   = {Phenomena/Plurals/Typology.lean;Phenomena/Agreement/Studies/Corbett2000.lean}
 }% REF: Corbett, G. G. (2006). Agreement. Cambridge: Cambridge University Press.
+@article{comrie-1975,
+  author    = {Comrie, Bernard},
+  year      = {1975},
+  title     = {Polite plurals and predicate agreement},
+  journal   = {Language},
+  volume    = {51},
+  number    = {2},
+  pages     = {406--418},
+  doi       = {10.2307/412863},
+  subfield  = {typology/agreement},
+  role      = {cited},
+  validated = {true},
+  sources   = {Syntax/Agreement/Basic.lean;Studies/Corbett2000.lean}
+}
 @book{corbett-2006,
   author    = {Corbett, Greville G.},
   year      = {2006},


### PR DESCRIPTION
Audit the Corbett gender (1991) and number (2000) studies against the source monographs; clean up the shared Agreement Hierarchy substrate.

- Corbett1991: drop the fabricated Georgian profile (Corbett never discusses Georgian; it is genderless), re-source the 4-gender slot on Archi, recode English as Corbett's pronominal gender, correct the Agreement Hierarchy to four positions, drop sample generalizations that correctly-coded English falsifies.
- Corbett2000: Bool→Prop hierarchy predicates proved by decide (not native_decide); re-source the §17 predicate-hierarchy example to honorific vy, replacing a profile mis-attributed to Corbett 2000.
- Substrate: correct the Agreement Hierarchy attribution in Syntax/Agreement/Basic and Typology/Gender (four positions; verb is a linglib refinement, not a Corbett position).
