### PR TITLE
refactor(Core/Word): Word.Agree φ-relation; drop form-string gender

### DIFF
--- a/Linglib/Core/UD.lean
+++ b/Linglib/Core/UD.lean
@@ -347,6 +347,12 @@ def MorphFeatures.compatible (f1 f2 : MorphFeatures) : Bool :=
   (f1.person.isNone   || f2.person.isNone   || f1.person == f2.person) &&
   (f1.tense.isNone    || f2.tense.isNone    || f1.tense == f2.tense)
 
+/-- Feature compatibility is reflexive: every bundle is compatible with itself
+    (each feature matches itself). -/
+@[simp] theorem MorphFeatures.compatible_self (f : MorphFeatures) :
+    f.compatible f = true := by
+  simp only [MorphFeatures.compatible, beq_self_eq_true, Bool.or_true, Bool.and_true]
+
 /-- Unify two feature bundles, preferring specified values -/
 def MorphFeatures.unify (f1 f2 : MorphFeatures) : Option MorphFeatures :=
   if f1.compatible f2 then

--- a/Linglib/Core/Word.lean
+++ b/Linglib/Core/Word.lean
@@ -127,6 +127,9 @@ structure Features where
   number : Option Number := none
   person : Option Person := none
   case_ : Option UD.Case := none
+  /-- Grammatical gender (UD.Gender). Carried on the word so φ-agreement is
+      feature-based, not recovered from surface form. -/
+  gender : Option UD.Gender := none
   valence : Option Valence := none
   voice : Option Voice := none
   vform : Option VForm := none
@@ -143,6 +146,26 @@ structure Word where
 
 /-- Convenience constructor for a featureless word (form + category only). -/
 def Word.mk' (form : String) (cat : UD.UPOS) : Word := ⟨form, cat, {}⟩
+
+/-- The φ-feature subset (person, number, gender) of a word, as a
+    `UD.MorphFeatures` bundle. -/
+def Word.phi (w : Word) : UD.MorphFeatures :=
+  { person := w.features.person, number := w.features.number,
+    gender := w.features.gender }
+
+/-- φ-agreement between two words: their person/number/gender features are
+    compatible (an unspecified feature is a wildcard). A reflexive, symmetric
+    *tolerance* relation on `Word` (not transitive), decided by the shared
+    `UD.MorphFeatures.compatible`. This is the feature-based agreement primitive
+    binding and concord consumers share — no surface-form gender lookup. -/
+def Word.Agree (w1 w2 : Word) : Prop := w1.phi.compatible w2.phi
+
+instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
+  unfold Word.Agree; infer_instance
+
+@[refl] theorem Word.Agree.refl (w : Word) : Word.Agree w w :=
+  UD.MorphFeatures.compatible_self w.phi
+
 
 /-- Derive a passive variant: sets voice to passive, valence to intransitive.
     Used to compose with `VerbEntry.toWordPastPart` for passive constructions. -/

--- a/Linglib/Fragments/English/NominalClassification.lean
+++ b/Linglib/Fragments/English/NominalClassification.lean
@@ -6,19 +6,21 @@ import Linglib.Fragments.English.Pronouns
 # English nominal classification for binding
 
 Lexicon-driven classification of English nominals into `Features.BindingClass`,
-plus φ-feature agreement, shared by the coreference/binding analyses in every
-syntactic framework (`Syntax.Minimalist.Coreference`, `Syntax.HPSG.Coreference`,
-`Syntax.DependencyGrammar`). Each previously re-stipulated these with hardcoded
+shared by the coreference/binding analyses in every syntactic framework
+(`Syntax.Minimalist.Coreference`, `Syntax.HPSG.Coreference`,
+`Syntax.DependencyGrammar`). Each previously re-stipulated this with hardcoded
 pronoun-form string lists; routing through `English.Pronouns` makes
 the three frameworks classify against one lexicon.
+
+φ-feature agreement is *not* here: it is `Word.Agree` (`Core.Word`), a
+feature-based relation over `UD.MorphFeatures.compatible` that reads the
+gender carried by `toWord` — no surface-form gender table.
 
 ## Main definitions
 
 * `classifyNominal` — `Word → Option Features.BindingClass`, via the English
   pronoun lexicon lists (`reflexives`/`reciprocals`/personal/`whWords`) with a
   UPOS fallback for R-expressions.
-* `phiAgree` — person/number/gender agreement between two nominals, as a `Prop`
-  with a `Decidable` instance.
 -/
 
 namespace English.NominalClassification
@@ -42,32 +44,5 @@ def classifyNominal (w : Word) : Option BindingClass :=
         || English.Pronouns.whWords.any (·.form == w.form) then some .pronoun
   else if isNominalCat w.cat then some .rExpression
   else none
-
-/-- φ-feature agreement (person, number, gender) between two nominals.
-    Person and number compare the morphosyntactic features directly; gender
-    routes through the Fragment's `genderAgrees` (unspecified gender agrees
-    with anything). -/
-def phiAgree (w1 w2 : Word) : Prop :=
-  (match w1.features.person, w2.features.person with
-    | some p1, some p2 => p1 = p2
-    | _, _ => True) ∧
-  (match w1.features.number, w2.features.number with
-    | some n1, some n2 => n1 = n2
-    | _, _ => True) ∧
-  English.Pronouns.genderAgrees w1.form w2.form = true
-
-instance (w1 w2 : Word) : Decidable (phiAgree w1 w2) := by
-  unfold phiAgree
-  have d1 : Decidable
-      (match w1.features.person, w2.features.person with
-       | some p1, some p2 => p1 = p2
-       | _, _ => True) := by
-    split <;> infer_instance
-  have d2 : Decidable
-      (match w1.features.number, w2.features.number with
-       | some n1, some n2 => n1 = n2
-       | _, _ => True) := by
-    split <;> infer_instance
-  exact inferInstance
 
 end English.NominalClassification

--- a/Linglib/Fragments/English/Nouns.lean
+++ b/Linglib/Fragments/English/Nouns.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Word
+import Linglib.Features.Gender
 import Linglib.Morphology.Exponence
 import Linglib.Semantics.Kinds.NominalMappingParameter
 
@@ -35,6 +36,9 @@ structure NounEntry where
   countable : MassCount := .count
   /-- Is this a proper name? -/
   proper : Bool := false
+  /-- Lexical gender, where known (proper names, gendered common nouns) — the
+      single source for a name's gender, read into the `Word` by `toWordSg`. -/
+  gender : Option Features.SurfaceGender := none
   deriving Repr, BEq
 
 /-- Number marking on an English NP -/
@@ -160,11 +164,11 @@ def americano : NounEntry := { formSg := "americano", formPl := "americanos" }
 def latte : NounEntry := { formSg := "latte", formPl := "lattes" }
 def macchiato : NounEntry := { formSg := "macchiato", formPl := "macchiatos" }
 
-def john : NounEntry := { formSg := "John", formPl := none, proper := true }
-def mary : NounEntry := { formSg := "Mary", formPl := none, proper := true }
-def bill : NounEntry := { formSg := "Bill", formPl := none, proper := true }
-def sue : NounEntry := { formSg := "Sue", formPl := none, proper := true }
-def fred : NounEntry := { formSg := "Fred", formPl := none, proper := true }
+def john : NounEntry := { formSg := "John", formPl := none, proper := true, gender := some .masculine }
+def mary : NounEntry := { formSg := "Mary", formPl := none, proper := true, gender := some .feminine }
+def bill : NounEntry := { formSg := "Bill", formPl := none, proper := true, gender := some .masculine }
+def sue : NounEntry := { formSg := "Sue", formPl := none, proper := true, gender := some .feminine }
+def fred : NounEntry := { formSg := "Fred", formPl := none, proper := true, gender := some .masculine }
 
 def bean : NounEntry := { formSg := "bean", formPl := some "beans" }
 
@@ -188,6 +192,7 @@ def NounEntry.toWordSg (n : NounEntry) : Word :=
       number := some .sg
     , countable := if n.proper then none else some n.countable
     , person := if n.proper then some .third else none
+    , gender := n.gender.bind (·.toUDGender)
     }
   }
 

--- a/Linglib/Fragments/English/Pronouns.lean
+++ b/Linglib/Fragments/English/Pronouns.lean
@@ -102,34 +102,6 @@ def reciprocals : List Pronoun := [eachOther, oneAnother]
 /-- Wh-pronouns and wh-adverbs. -/
 def whWords : List Pronoun := [who, whom, what, which, where_, when_, why, how]
 
-/-! ### Gender lookup (@cite{konnelly-cowper-2020}) -/
-
-/-- Surface gender of a pronoun form: *he*/*she*/*it* are
-    `.masculine`/`.feminine`/`.neuter`; *they* (and any form with no gender
-    feature) is `none` — the @cite{konnelly-cowper-2020} Elsewhere case. -/
-def genderOf (form : String) : Option SurfaceGender :=
-  if form ∈ ["he", "him", "himself"] then some .masculine
-  else if form ∈ ["she", "her", "herself"] then some .feminine
-  else if form ∈ ["it", "itself"] then some .neuter
-  else none
-
-/-- Surface gender of a proper name, if known; `none` otherwise. -/
-def nameGender (form : String) : Option SurfaceGender :=
-  if form ∈ ["John", "Bill", "Fred"] then some .masculine
-  else if form ∈ ["Mary", "Sue"] then some .feminine
-  else none
-
-/-- Do two forms agree in gender? A form with no gender feature (`none` —
-    1st/2nd person, singular *they*) agrees with anything, matching the
-    @cite{konnelly-cowper-2020}/Bjorkman subset condition (∅ ⊆ S). -/
-def genderAgrees (form1 form2 : String) : Bool :=
-  let g1 := (nameGender form1).orElse (fun _ => genderOf form1)
-  let g2 := (nameGender form2).orElse (fun _ => genderOf form2)
-  match g1, g2 with
-  | none, _ => true
-  | _, none => true
-  | some a, some b => a == b
-
 end English.Pronouns
 
 namespace English
@@ -142,11 +114,7 @@ def pronouns : List PersonalPronoun :=
    Pronouns.he, Pronouns.him, Pronouns.she, Pronouns.her, Pronouns.it,
    Pronouns.they, Pronouns.them, Pronouns.they_sg, Pronouns.them_sg]
 
-/-! ### Consistency: structural gender field agrees with the `genderOf` function -/
-
-theorem he_gender_consistent : Pronouns.he.gender = Pronouns.genderOf "he" := rfl
-theorem she_gender_consistent : Pronouns.she.gender = Pronouns.genderOf "she" := rfl
-theorem it_gender_consistent : Pronouns.it.gender = Pronouns.genderOf "it" := rfl
+/-! ### Gender feature facts (@cite{konnelly-cowper-2020}, @cite{arnold-2026}) -/
 
 /-- Singular *they* bears no gender feature — the @cite{konnelly-cowper-2020}
     Elsewhere case. -/

--- a/Linglib/Phenomena/Anaphora/Coreference.lean
+++ b/Linglib/Phenomena/Anaphora/Coreference.lean
@@ -19,17 +19,17 @@ open Paradigms.AcceptabilityJudgment
 
 namespace Phenomena.Anaphora.Coreference
 
-private def john : Word := ⟨"John", .PROPN, { number := some .sg, person := some .third }⟩
+private def john : Word := ⟨"John", .PROPN, { number := some .sg, person := some .third, gender := some .Masc }⟩
 private def sees : Word := ⟨"sees", .VERB, { valence := some .transitive, number := some .sg, person := some .third }⟩
-private def himself : Word := ⟨"himself", .PRON, { person := some .third, number := some .sg }⟩
-private def mary : Word := ⟨"Mary", .PROPN, { number := some .sg, person := some .third }⟩
-private def herself : Word := ⟨"herself", .PRON, { person := some .third, number := some .sg }⟩
+private def himself : Word := ⟨"himself", .PRON, { person := some .third, number := some .sg, gender := some .Masc }⟩
+private def mary : Word := ⟨"Mary", .PROPN, { number := some .sg, person := some .third, gender := some .Fem }⟩
+private def herself : Word := ⟨"herself", .PRON, { person := some .third, number := some .sg, gender := some .Fem }⟩
 private def they : Word := ⟨"they", .PRON, { person := some .third, number := some .pl, case_ := some .nom }⟩
 private def see : Word := ⟨"see", .VERB, { valence := some .transitive, number := some .pl }⟩
 private def themselves : Word := ⟨"themselves", .PRON, { person := some .third, number := some .pl }⟩
-private def him : Word := ⟨"him", .PRON, { person := some .third, number := some .sg, case_ := some .acc }⟩
-private def her : Word := ⟨"her", .PRON, { person := some .third, number := some .sg, case_ := some .acc }⟩
-private def he : Word := ⟨"he", .PRON, { person := some .third, number := some .sg, case_ := some .nom }⟩
+private def him : Word := ⟨"him", .PRON, { person := some .third, number := some .sg, case_ := some .acc, gender := some .Masc }⟩
+private def her : Word := ⟨"her", .PRON, { person := some .third, number := some .sg, case_ := some .acc, gender := some .Fem }⟩
+private def he : Word := ⟨"he", .PRON, { person := some .third, number := some .sg, case_ := some .nom, gender := some .Masc }⟩
 private def them : Word := ⟨"them", .PRON, { person := some .third, number := some .pl, case_ := some .acc }⟩
 
 /-- Reflexives require local c-commanding antecedent. -/

--- a/Linglib/Studies/Arnold2026.lean
+++ b/Linglib/Studies/Arnold2026.lean
@@ -200,12 +200,12 @@ theorem table1_all_license_underspecified (a : AntecedentType) :
 
 /-- Singular *they* bears no gender feature — the @cite{konnelly-cowper-2020}
     Elsewhere case: *they* spells out a φ-bundle with none of
-    `[MASC]`/`[FEM]`/`[INANIM]`, so `genderOf` is `none`, not a positive epicene
+    `[MASC]`/`[FEM]`/`[INANIM]`, so its `gender` field is `none`, not a positive epicene
     value. -/
 theorem singThey_genderless :
-    English.Pronouns.genderOf "they" = none ∧
-    English.Pronouns.genderOf "them" = none ∧
-    English.Pronouns.genderOf "themself" = none := by
+    English.Pronouns.they.gender = none ∧
+    English.Pronouns.them.gender = none ∧
+    English.Pronouns.themself.gender = none := by
   exact ⟨rfl, rfl, rfl⟩
 
 /-- Singular *they*'s lexical entry carries no surface gender

--- a/Linglib/Studies/KonnellyCowper2020.lean
+++ b/Linglib/Studies/KonnellyCowper2020.lean
@@ -558,13 +558,13 @@ theorem stage3_they_from_structure (ctx : ReferentContext) :
     a gender feature. This makes explicit the connection K&C's analysis reveals:
     epicene is not a positive gender class but the **absence** of a contrastive
     gender feature — the elsewhere case in VI competition. The Fragment encodes
-    that absence directly as `genderOf "they" = none`. -/
+    that absence directly as `they.gender = none`. -/
 theorem elsewhere_is_genderless :
     subsetPrinciple pronounVIs ungenderedBundle = some "they" ∧
-    English.Pronouns.genderOf "they" = none :=
+    English.Pronouns.they.gender = none :=
   ⟨by decide, rfl⟩
 
-/-- The VI competition and the Fragment's `genderOf` are consistent across all
+/-- The VI competition and the lexicon `gender` fields are consistent across all
     four pronoun forms: each VI exponent maps to its expected surface gender, and
     *they* — the elsewhere exponent — to the absence of one (`none`).
 
@@ -572,10 +572,10 @@ theorem elsewhere_is_genderless :
     Fragment's gender field: VI *derives* which form is used, and the Fragment
     *records* the gender (or its absence). -/
 theorem vi_fragment_consistency :
-    English.Pronouns.genderOf "she" = some .feminine ∧
-    English.Pronouns.genderOf "he" = some .masculine ∧
-    English.Pronouns.genderOf "it" = some .neuter ∧
-    English.Pronouns.genderOf "they" = none :=
+    English.Pronouns.she.gender = some .feminine ∧
+    English.Pronouns.he.gender = some .masculine ∧
+    English.Pronouns.it.gender = some .neuter ∧
+    English.Pronouns.they.gender = none :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 -- ============================================================================

--- a/Linglib/Syntax/DependencyGrammar/Coreference.lean
+++ b/Linglib/Syntax/DependencyGrammar/Coreference.lean
@@ -112,7 +112,7 @@ def reflexiveLicensed (clause : SimpleClause) : Bool :=
     | some .reflexive =>
       subjectDCommandsObject clause &&
       sameLocalDomain clause &&
-      decide (phiAgree clause.subject obj)
+      decide (Word.Agree clause.subject obj)
     | _ => true
 
 /-- Reciprocals must be d-commanded by a semantically plural antecedent.

--- a/Linglib/Syntax/DependencyGrammar/Nominal.lean
+++ b/Linglib/Syntax/DependencyGrammar/Nominal.lean
@@ -22,7 +22,8 @@ Fragments providing instances; the test-word lexemes should move to
 
 ## Main declarations
 
-* `BindingClass`, `isNominalCat`, `classifyNominal`, `phiAgree` — re-exported.
+* `BindingClass`, `isNominalCat`, `classifyNominal` — re-exported. φ-agreement
+  is `Word.Agree` (Core), not re-exported here.
 * `john`, `mary`, `they`, `sees`, `see`, `himself`, `herself`,
   `themselves`, `him`, `her`, `them`, `eachOther` — English test words.
 -/
@@ -30,7 +31,7 @@ Fragments providing instances; the test-word lexemes should move to
 namespace DepGrammar.Nominal
 
 export Features (BindingClass)
-export English.NominalClassification (isNominalCat classifyNominal phiAgree)
+export English.NominalClassification (isNominalCat classifyNominal)
 
 /-! ### Shared English test words
 

--- a/Linglib/Syntax/HPSG/Coreference.lean
+++ b/Linglib/Syntax/HPSG/Coreference.lean
@@ -2,7 +2,7 @@
 HPSG Coreference (Binding).
 
 Binding theory using MODE and ARG-ST outranking,
-per @cite{sag-wasow-bender-2003} Ch. 7 and @cite{pollard-sag-1994} (binding theory).
+per @cite{sag-wasow-bender-2003} and @cite{pollard-sag-1994} (binding theory).
 
 SWB2003 has two binding principles (not three):
 - **Principle A**: [MODE ana] must be outranked by a coindexed element
@@ -38,7 +38,7 @@ private abbrev eachOther := English.Pronouns.eachOther.toWord
 namespace HPSG.Coreference
 
 open Features (BindingClass)
-open English.NominalClassification (isNominalCat classifyNominal phiAgree)
+open English.NominalClassification (isNominalCat classifyNominal)
 
 -- ============================================================================
 -- MODE Classification
@@ -48,7 +48,7 @@ section ModeClassification
 
 /-- Derive MODE feature from a word, via the shared `classifyNominal`.
 
-    Per @cite{sag-wasow-bender-2003} Ch. 7:
+    Per @cite{sag-wasow-bender-2003}:
     - Reflexives and reciprocals → [MODE ana]
     - Personal pronouns and R-expressions → [MODE ref] -/
 def classifyMode (w : Word) : Option HPSG.Mode :=
@@ -117,7 +117,7 @@ private def wordToSynsem (w : Word) : HPSG.Synsem :=
 /-- Build the ARG-ST for a simple clause from its arguments.
 
     ARG-ST = [subject, object] — the verb's argument structure list,
-    ordered by obliqueness (@cite{sag-wasow-bender-2003} Ch. 7). -/
+    ordered by obliqueness (@cite{sag-wasow-bender-2003}). -/
 def SimpleClause.toArgSt (clause : SimpleClause) : HPSG.ArgSt :=
   match clause.object with
   | none => { args := [wordToSynsem clause.subject] }
@@ -140,7 +140,7 @@ def sameArgSt (clause : SimpleClause) : Bool :=
 end ArgStOutranking
 
 -- ============================================================================
--- Anaphoric Agreement Principle
+-- φ-agreement requirement on anaphors
 -- ============================================================================
 
 -- ============================================================================
@@ -152,7 +152,7 @@ section BindingConstraints
 /-- Principle A (SWB2003): An anaphor ([MODE ana]) must be outranked by a
     coindexed element on the same ARG-ST list.
 
-    For reflexives, the coindexed antecedent must also satisfy the AAP. -/
+    For reflexives, the coindexed antecedent must also φ-agree with it. -/
 def reflexiveLicensed (clause : SimpleClause) : Bool :=
   match clause.object with
   | none => false
@@ -161,7 +161,7 @@ def reflexiveLicensed (clause : SimpleClause) : Bool :=
     | some .reflexive =>
       subjectOutranksObject clause &&
       sameArgSt clause &&
-      decide (phiAgree clause.subject obj)
+      decide (Word.Agree clause.subject obj)
     | _ => true
 
 /-- Principle A for reciprocals: a reciprocal ([MODE ana]) must be outranked
@@ -260,7 +260,7 @@ def localCoreferenceBlocked (ws : List Word) : Bool :=
 #guard reflexiveLicensedInSentence [they, see, themselves]   -- ✓
 #guard !grammaticalForCoreference [themselves, see, them]    -- ✗
 
--- AAP violations (agreement mismatches)
+-- φ-agreement violations (mismatches)
 #guard !reflexiveLicensedInSentence [john, sees, herself]    -- ✗ gender mismatch
 #guard !reflexiveLicensedInSentence [they, see, himself]     -- ✗ number mismatch
 
@@ -309,7 +309,7 @@ theorem reflexive_pairs_captured :
     -- Pair 7: reciprocal requires plural antecedent
     (grammaticalForCoreference [they, see, eachOther] = true ∧
      grammaticalForCoreference [john, sees, eachOther] = false) := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- CoreferenceTheory Interface Implementation
@@ -331,7 +331,7 @@ def computeCoreferenceStatus (clause : SimpleClause) (i j : Nat) : Features.Core
       match classifyMode obj with
       | some .ana =>
         -- Principle A: anaphor must be outranked — check agreement
-        if subjectOutranksObject clause && sameArgSt clause && decide (phiAgree clause.subject obj)
+        if subjectOutranksObject clause && sameArgSt clause && decide (Word.Agree clause.subject obj)
         then .obligatory
         else .blocked
       | some .ref =>
@@ -413,7 +413,7 @@ tree geometry:
 Both theories make the same predictions for simple cases:
 1. Subject outranks object ↔ Subject c-commands object
 2. Same ARG-ST list ↔ Same binding domain (local clause)
-3. AAP (agreement) ↔ Feature checking
+3. φ-agreement ↔ Feature checking
 
 The difference is in mechanism:
 - Minimalism: structural (tree geometry, c-command via `cCommandsIn`)

--- a/Linglib/Syntax/Minimalist/Coreference.lean
+++ b/Linglib/Syntax/Minimalist/Coreference.lean
@@ -19,7 +19,7 @@ Coreference constraints via c-command and locality following @cite{chomsky-1981}
 namespace Minimalist.Coreference
 
 open Features (BindingClass)
-open English.NominalClassification (isNominalCat classifyNominal phiAgree)
+open English.NominalClassification (isNominalCat classifyNominal)
 
 /-- Simple clause structure for coreference checking.
     `semanticPl` tracks whether the subject denotes a plurality,
@@ -134,7 +134,7 @@ def reflexiveLicensed (clause : SimpleClause) : Prop :=
     | some .reflexive =>
       subjectCCommandsObject clause ∧
       sameLocalDomain clause ∧
-      phiAgree clause.subject obj
+      Word.Agree clause.subject obj
     | _ => True
 
 instance (clause : SimpleClause) : Decidable (reflexiveLicensed clause) := by
@@ -266,7 +266,7 @@ def computeCoreferenceStatus (clause : SimpleClause) (i j : Nat) : Features.Core
     | some obj =>
       match classifyNominal obj with
       | some .reflexive =>
-        if subjectCCommandsObject clause ∧ sameLocalDomain clause ∧ phiAgree clause.subject obj
+        if subjectCCommandsObject clause ∧ sameLocalDomain clause ∧ Word.Agree clause.subject obj
         then .obligatory
         else .blocked
       | some .reciprocal =>

--- a/Linglib/Typology/Pronoun/Basic.lean
+++ b/Linglib/Typology/Pronoun/Basic.lean
@@ -100,7 +100,8 @@ open Features (SurfaceGender)
     surface as adverbs) stay in the relevant fragment. -/
 def toWord (p : Pronoun) : Word :=
   { form := p.form, cat := .PRON,
-    features := { person := p.person, number := p.number, case_ := p.case_ } }
+    features := { person := p.person, number := p.number, case_ := p.case_,
+                  gender := p.gender.bind (·.toUDGender) } }
 
 /-! ### Derived person category and well-formedness (@cite{cysouw-2009}) -/
 


### PR DESCRIPTION
Make φ-agreement a feature-based relation on `Word`, dissolving the English form-string gender hack.

- `Word.Agree : Word → Word → Prop` (Core), via the existing `UD.MorphFeatures.compatible`; `gender` added to `Word.Features` (as `UD.Gender`, within-Core) so `toWord`/`toWordSg` are lossless.
- The three binding frameworks rewired off the fragment-local `phiAgree`; `genderOf`/`genderAgrees`/`nameGender` + drift-sentries dissolved (gender now sourced from the lexicon objects' field; names gained a `gender`); Konnelly-Cowper/Arnold restated against `.gender`.
- `native_decide` → `decide` (HPSG); reworded the "AAP" coinage (collides with the Anaphor Agreement Effect); softened an unverified chapter cite.