### PR TITLE
refactor(Syntax/Binding): unify binding on a CommandRelation engine

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -127,6 +127,7 @@ import Linglib.Discourse.Strategy
 import Linglib.Discourse.Scoreboard
 import Linglib.Discourse.AtIssueness
 import Linglib.Features.CoreferenceStatus
+import Linglib.Syntax.Binding.Basic
 import Linglib.Syntax.Binding.Semantics
 import Linglib.Core.CombinationKind
 import Linglib.Semantics.Composition.Combinator

--- a/Linglib/Studies/Chomsky1981.lean
+++ b/Linglib/Studies/Chomsky1981.lean
@@ -2,6 +2,7 @@ import Linglib.Syntax.Minimalist.Coreference
 import Linglib.Phenomena.Anaphora.Coreference
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Pronouns
+import Linglib.Fragments.English.NominalClassification
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Paradigms.AcceptabilityJudgment
 
@@ -34,6 +35,13 @@ namespace Chomsky1981
 open Paradigms.AcceptabilityJudgment
 open Minimalist.Coreference
 open Phenomena.Anaphora.Coreference
+
+/-- English binding under Minimalist (c-command): the framework-neutral engine
+    (`Binding.grammaticalForCoreference`) applied with Minimalism's
+    `CommandRelation` instance (in scope via `open Minimalist.Coreference`) and
+    English's binding-class classifier. -/
+private abbrev grammaticalForCoreference (ws : List Word) : Prop :=
+  Binding.grammaticalForCoreference English.NominalClassification.classifyNominal ws
 
 /-- Coverage of a `PhenomenonData` set under Minimalist binding theory.
 

--- a/Linglib/Studies/Hudson1990.lean
+++ b/Linglib/Studies/Hudson1990.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.DependencyGrammar.Coreference
+import Linglib.Syntax.DependencyGrammar.Nominal
 import Linglib.Phenomena.Anaphora.Coreference
 import Linglib.Paradigms.AcceptabilityJudgment
 
@@ -20,6 +21,13 @@ namespace Hudson1990
 open DepGrammar.Coreference
 open DepGrammar.Nominal
 open Phenomena.Anaphora.Coreference
+
+/-- English binding under dependency grammar (d-command): the framework-neutral
+    engine (`Binding.grammaticalForCoreference`) applied with DG's
+    `CommandRelation` instance (in scope via `open DepGrammar.Coreference`) and
+    English's binding-class classifier. `Bool`-valued for `capturesPhenomenonData`. -/
+private def grammaticalForCoreference (ws : List Word) : Bool :=
+  decide (Binding.grammaticalForCoreference classifyNominal ws)
 
 -- ============================================================================
 -- Capturing the Phenomena Data

--- a/Linglib/Studies/SagWasowBender2003.lean
+++ b/Linglib/Studies/SagWasowBender2003.lean
@@ -2,6 +2,7 @@ import Linglib.Syntax.HPSG.Coreference
 import Linglib.Phenomena.Anaphora.Coreference
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Pronouns
+import Linglib.Fragments.English.NominalClassification
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Paradigms.AcceptabilityJudgment
 
@@ -29,6 +30,13 @@ namespace SagWasowBender2003
 open Paradigms.AcceptabilityJudgment
 open HPSG.Coreference
 open Phenomena.Anaphora.Coreference
+
+/-- English binding under HPSG (ARG-ST outranking): the framework-neutral engine
+    (`Binding.grammaticalForCoreference`) applied with HPSG's `CommandRelation`
+    instance (in scope via `open HPSG.Coreference`) and English's binding-class
+    classifier. `Bool`-valued for `capturesPhenomenonData`. -/
+private def grammaticalForCoreference (ws : List Word) : Bool :=
+  decide (Binding.grammaticalForCoreference English.NominalClassification.classifyNominal ws)
 
 /-- Coverage of a `PhenomenonData` set under HPSG binding. -/
 def capturesCoreferenceData (phenom : PhenomenonData) : Bool :=

--- a/Linglib/Syntax/Binding/Basic.lean
+++ b/Linglib/Syntax/Binding/Basic.lean
@@ -1,0 +1,277 @@
+import Linglib.Core.Word
+import Linglib.Features.CoreferenceStatus
+
+/-!
+# Binding principles over a command relation
+@cite{barker-pullum-1990} @cite{chomsky-1981} @cite{pollard-sag-1994}
+
+A framework-neutral binding engine. The binding principles (A/B/C) and the
+coreference-status computation are stated **once**, parameterized by a
+`CommandRelation` — the structural-prominence order they range over. The three
+syntactic frameworks formalized in linglib supply that relation and inherit the
+principles unchanged:
+
+* Minimalism — c-command (tree geometry)
+* HPSG — ARG-ST outranking (obliqueness)
+* Dependency grammar — d-command (dependency subgraph)
+
+@cite{barker-pullum-1990} give the general notion of which c-command,
+m-command, and the rest are instances; the linglib frameworks' command notions
+are further instances. Stating the principles over the abstract relation makes
+the cross-framework convergence a theorem rather than a coincidence: any two
+`CommandRelation`s that agree on a clause predict the same binding facts.
+
+## Main declarations
+
+* `Pos` — a binding position in a simple clause (subject / object).
+* `SimpleClause` / `parseSimpleClause` — the clause representation the
+  principles range over, and a surface-list parser.
+* `CommandRelation` — the abstract command relation + locality (the only piece
+  a framework supplies).
+* `reflexiveLicensed` / `reciprocalLicensed` / `pronounLocallyFree` /
+  `rExpressionFree` — Principles A / B / C, derived over `[CommandRelation]`,
+  `Word.Agree`, and a binding-class classifier.
+* `grammaticalForCoreference`, `computeCoreferenceStatus` — top-level
+  predictions, derived once.
+
+## Implementation notes
+
+The binding-class classifier (`Word → Option BindingClass`) is a *language*
+parameter, orthogonal to the *framework* parameter `CommandRelation`; it is
+passed explicitly rather than baked in, so the engine imports no Fragment.
+A language (English, …) supplies the classifier; a framework supplies the
+command relation; a study combines them.
+-/
+
+namespace Binding
+
+open Features (BindingClass CoreferenceStatus)
+
+/-- A binding position in a simple clause. The verb is not a binding position. -/
+inductive Pos where
+  | subject
+  | object
+  deriving DecidableEq, Repr
+
+/-- A simple (mono-clausal, transitive-or-intransitive) clause: the
+    representation binding principles range over. `semanticPl` records whether
+    the subject *denotes* a plurality, which can diverge from morphosyntactic
+    number (@cite{rakosi-2019}); it defaults to the syntactic number. -/
+structure SimpleClause where
+  subject : Word
+  verb : Word
+  object : Option Word
+  semanticPl : Bool := subject.features.number == some .pl
+  deriving Repr
+
+/-- The `Word` at a position, if present. -/
+def SimpleClause.at? (c : SimpleClause) : Pos → Option Word
+  | .subject => some c.subject
+  | .object => c.object
+
+/-- Is this a nominal part-of-speech (proper noun, common noun, or pronoun)? A
+    theory-neutral UPOS check the clause parser uses to recognize arguments. -/
+def isNominalCat (cat : UD.UPOS) : Bool :=
+  cat == .PROPN || cat == .NOUN || cat == .PRON
+
+/-- Parse a surface word list into a simple clause: `[subj, verb, obj]` or
+    `[subj, verb]`, requiring nominal subject/object and a verb. -/
+def parseSimpleClause (ws : List Word) : Option SimpleClause :=
+  match ws with
+  | [subj, v, obj] =>
+    if isNominalCat subj.cat && v.cat == .VERB && isNominalCat obj.cat then
+      some { subject := subj, verb := v, object := some obj }
+    else none
+  | [subj, v] =>
+    if isNominalCat subj.cat && v.cat == .VERB then
+      some { subject := subj, verb := v, object := none }
+    else none
+  | _ => none
+
+/-- A **command relation** (@cite{barker-pullum-1990}): the structural-prominence
+    order binding principles are defined over, together with the locality
+    (same-binding-domain) restriction. The frameworks' c-command, ARG-ST
+    outranking, and d-command are instances. This is the *only* component a
+    syntactic framework must supply to obtain the binding principles. -/
+class CommandRelation where
+  /-- Does the element at position `i` structurally command the element at `j`? -/
+  commands : SimpleClause → Pos → Pos → Prop
+  /-- Are positions `i` and `j` within the same binding (locality) domain? -/
+  sameDomain : SimpleClause → Pos → Pos → Prop
+  /-- `commands` is decidable — frameworks compute it from concrete structure. -/
+  commandsDec : (c : SimpleClause) → (i j : Pos) → Decidable (commands c i j)
+  /-- `sameDomain` is decidable. -/
+  sameDomainDec : (c : SimpleClause) → (i j : Pos) → Decidable (sameDomain c i j)
+
+instance [CommandRelation] (c : SimpleClause) (i j : Pos) :
+    Decidable (CommandRelation.commands c i j) := CommandRelation.commandsDec c i j
+
+instance [CommandRelation] (c : SimpleClause) (i j : Pos) :
+    Decidable (CommandRelation.sameDomain c i j) := CommandRelation.sameDomainDec c i j
+
+variable [CommandRelation]
+
+-- The classifier mapping a word to its binding class is a language parameter
+-- (English supplies one); the engine stays Fragment-free.
+variable (classify : Word → Option BindingClass)
+
+/-! ### Principle A (anaphors) -/
+
+/-- **Principle A.** A reflexive object is licensed iff it is commanded by the
+    subject within the local domain *and* agrees with it in φ-features
+    (`Word.Agree`). Vacuously true when the object is not a reflexive. -/
+def reflexiveLicensed (c : SimpleClause) : Prop :=
+  match c.object with
+  | none => False
+  | some obj =>
+    match classify obj with
+    | some .reflexive =>
+      CommandRelation.commands c .subject .object ∧
+      CommandRelation.sameDomain c .subject .object ∧
+      Word.Agree c.subject obj
+    | _ => True
+
+instance (c : SimpleClause) : Decidable (reflexiveLicensed classify c) := by
+  unfold reflexiveLicensed; split
+  · infer_instance
+  · split <;> infer_instance
+
+/-- **Principle A** for reciprocals: licensed iff commanded by the subject in
+    the local domain and the subject denotes a *plurality* (an LF condition —
+    semantic, not morphosyntactic, plurality; @cite{rakosi-2019}). -/
+def reciprocalLicensed (c : SimpleClause) : Prop :=
+  match c.object with
+  | none => False
+  | some obj =>
+    match classify obj with
+    | some .reciprocal =>
+      CommandRelation.commands c .subject .object ∧
+      CommandRelation.sameDomain c .subject .object ∧
+      c.semanticPl = true
+    | _ => True
+
+instance (c : SimpleClause) : Decidable (reciprocalLicensed classify c) := by
+  unfold reciprocalLicensed; split
+  · infer_instance
+  · split <;> infer_instance
+
+/-! ### Principle B (pronouns) -/
+
+/-- **Principle B.** A pronoun object must be free in its local domain: it must
+    *not* be both commanded by the subject and in the same domain. -/
+def pronounLocallyFree (c : SimpleClause) : Prop :=
+  match c.object with
+  | none => True
+  | some obj =>
+    match classify obj with
+    | some .pronoun =>
+      ¬ (CommandRelation.commands c .subject .object ∧
+         CommandRelation.sameDomain c .subject .object)
+    | _ => True
+
+instance (c : SimpleClause) : Decidable (pronounLocallyFree classify c) := by
+  unfold pronounLocallyFree; split
+  · infer_instance
+  · split <;> infer_instance
+
+/-! ### Principle C (R-expressions) -/
+
+/-- **Principle C.** An R-expression object coindexed with a pronominal subject
+    is blocked when the subject commands it. -/
+def rExpressionFree (c : SimpleClause) : Prop :=
+  match classify c.subject with
+  | some .pronoun =>
+    match c.object with
+    | some obj =>
+      match classify obj with
+      | some .rExpression => ¬ CommandRelation.commands c .subject .object
+      | _ => True
+    | none => True
+  | _ => True
+
+instance (c : SimpleClause) : Decidable (rExpressionFree classify c) := by
+  unfold rExpressionFree
+  split
+  · split
+    · split <;> infer_instance
+    · infer_instance
+  · infer_instance
+
+/-! ### Top-level acceptability -/
+
+/-- Is a surface word list grammatical for coreference? Anaphors cannot be
+    subjects (no commander); a pronoun object locally commanded by the subject
+    violates Principle B; reflexive/reciprocal objects must be licensed. -/
+def grammaticalForCoreference (ws : List Word) : Prop :=
+  match parseSimpleClause ws with
+  | none => False
+  | some c =>
+    match classify c.subject with
+    | some .reflexive => False
+    | some .reciprocal => False
+    | _ =>
+      match c.object with
+      | none => True
+      | some obj =>
+        match classify obj with
+        | some .reflexive => reflexiveLicensed classify c
+        | some .reciprocal => reciprocalLicensed classify c
+        | some .pronoun => False
+        | _ => True
+
+instance (ws : List Word) : Decidable (grammaticalForCoreference classify ws) := by
+  unfold grammaticalForCoreference; split
+  · infer_instance
+  · split
+    · infer_instance
+    · infer_instance
+    · split
+      · infer_instance
+      · split <;> infer_instance
+
+/-- Coreference status of positions `i`, `j` under the command relation:
+    Principle A makes a commanded anaphor obligatorily coreferent; Principle B/C
+    block a commanded pronoun/R-expression; otherwise coreference is possible. -/
+def computeCoreferenceStatus (c : SimpleClause) (i j : Pos) : CoreferenceStatus :=
+  match c.at? j with
+  | none => .unspecified
+  | some tgt =>
+    if CommandRelation.commands c i j ∧ CommandRelation.sameDomain c i j then
+      match classify tgt with
+      | some .reflexive => .obligatory
+      | some .reciprocal => .obligatory
+      | some .pronoun => .blocked
+      | some .rExpression => .blocked
+      | none => .unspecified
+    else
+      match classify tgt with
+      | some .reflexive => .blocked
+      | some .reciprocal => .blocked
+      | some .pronoun => .possible
+      | some .rExpression => .possible
+      | none => .unspecified
+
+/-! ### Cross-framework convergence
+
+Stated over the abstract relation, the principles depend on the framework only
+through `CommandRelation`. Two frameworks that agree on a clause's command and
+locality facts therefore make identical binding predictions — by construction,
+not coincidence. -/
+
+omit [CommandRelation] in
+/-- If two command relations agree on the relevant command and locality facts
+    of a clause, they license a reflexive identically. The cross-framework
+    convergence the prose comparisons assert, made a theorem. -/
+theorem reflexiveLicensed_congr
+    (R₁ R₂ : CommandRelation) (classify : Word → Option BindingClass)
+    (c : SimpleClause)
+    (hc : R₁.commands c .subject .object ↔ R₂.commands c .subject .object)
+    (hd : R₁.sameDomain c .subject .object ↔ R₂.sameDomain c .subject .object) :
+    @reflexiveLicensed R₁ classify c ↔ @reflexiveLicensed R₂ classify c := by
+  rcases hobj : c.object with _ | obj
+  · simp only [reflexiveLicensed, hobj]
+  · rcases hbc : classify obj with _ | bc
+    · simp only [reflexiveLicensed, hobj, hbc]
+    · cases bc <;> simp only [reflexiveLicensed, hobj, hbc, hc, hd]
+
+end Binding

--- a/Linglib/Syntax/DependencyGrammar/Coreference.lean
+++ b/Linglib/Syntax/DependencyGrammar/Coreference.lean
@@ -1,68 +1,37 @@
 import Linglib.Syntax.DependencyGrammar.Basic
-import Linglib.Syntax.DependencyGrammar.Nominal
-import Linglib.Features.CoreferenceStatus
+import Linglib.Syntax.Binding.Basic
 
 /-!
 # Dependency-grammar coreference (binding)
 
-Reflexives require short dependency paths; locality is defined as the
-subgraph rooted at the verb of the matrix clause. The c-command analogue
-in dependency grammar is *d-command*: a node `x` d-commands `y` iff `y` is
-in the subtree rooted at `x`'s mother. @cite{hudson-1990},
-@cite{gibson-2025}.
+Binding via **d-command** and locality (@cite{hudson-1990}, @cite{gibson-2025}).
+The c-command analogue in dependency grammar is *d-command*: `x` d-commands `y`
+iff both are dependents of the same head and `x` bears the subject relation.
+Locality is the dependency subgraph rooted at the matrix verb.
 
-## Main declarations
+As with the other frameworks, the binding principles are *not* restated here:
+this file supplies dependency grammar's command relation as a
+`Binding.CommandRelation` instance, and the framework-neutral engine
+(`Syntax/Binding/Basic.lean`) derives Principles A/B/C over it. The file is
+language-neutral — it imports no Fragment.
 
-* `SimpleClause` — clause-rooted subgraph for binding-domain bookkeeping.
-* `dCommands`, `sameLocalDomain` — the d-command relation and its locality
-  restriction.
-* `reflexiveLicensed`, `reciprocalLicensed`, `pronounLocallyFree` — the
-  binding-theory licensing predicates over a simple clause.
-* `grammaticalForCoreference` — top-level acceptability check consumed by
-  `Studies/Hudson1990.lean`.
+## Main definitions
 
-## Implementation notes
-
-* Predicate-shape definitions are `Bool`-valued, inheriting the
-  substrate-wide convention from `Basic.lean`. A migration to
-  `Prop` + `[DecidablePred]` is a project-wide refactor target.
+- `toDepTree`, `dCommands`, `subjectDCommandsObject`, `sameLocalDomain` — the
+  d-command relation and its locality restriction, over a `Binding.SimpleClause`.
+- `instance : CommandRelation` — the dependency-grammar instance of the abstract
+  command relation (d-command); the engine supplies Principles A/B/C over it.
 -/
 
 namespace DepGrammar.Coreference
 
-open DepGrammar Nominal
+open Binding (SimpleClause Pos CommandRelation)
 
-/-! ### Clauses and locality -/
+/-! ### D-command from the dependency tree -/
 
-/-- Simple clause structure: a subgraph rooted at the main verb. -/
-structure SimpleClause where
-  subject : Word
-  verb : Word
-  object : Option Word
-  /-- Whether the subject denotes a plurality. Defaults to matching
-      syntactic number. Override for languages where syntactic and
-      semantic number diverge (@cite{rakosi-2019}). -/
-  semanticPl : Bool := subject.features.number == some .pl
-  deriving Repr
-
-/-- Parse a simple transitive sentence into a clause. -/
-def parseSimpleClause (ws : List Word) : Option SimpleClause :=
-  match ws with
-  | [subj, v, obj] =>
-    if isNominalCat subj.cat && v.cat == .VERB && isNominalCat obj.cat then
-      some { subject := subj, verb := v, object := some obj }
-    else none
-  | [subj, v] =>
-    if isNominalCat subj.cat && v.cat == .VERB then
-      some { subject := subj, verb := v, object := none }
-    else none
-  | _ => none
-
-/-- Build a dependency tree from a simple clause.
-
-    Indices: 0 = subject, 1 = verb (root), 2 = object (if present).
-    Dependencies: subject ←nsubj— verb, object ←obj— verb. -/
-def SimpleClause.toDepTree (clause : SimpleClause) : DepTree :=
+/-- Build a dependency tree from a clause. Indices: 0 = subject, 1 = verb
+    (root), 2 = object (if present); subject ←nsubj— verb, object ←obj— verb. -/
+def toDepTree (clause : SimpleClause) : DepTree :=
   let words := match clause.object with
     | none => [clause.subject, clause.verb]
     | some obj => [clause.subject, clause.verb, obj]
@@ -72,91 +41,52 @@ def SimpleClause.toDepTree (clause : SimpleClause) : DepTree :=
     | some _ => [⟨1, 2, .obj⟩]
   { words := words, deps := deps, rootIdx := 1 }
 
-/-- Same local domain: both subject and object are dependents of the
-    same head (the verb), hence in the same dependency subgraph. -/
+/-- D-command: the word at `i` d-commands the word at `j` if both are dependents
+    of the same head and `i` bears the subject relation (nsubj). -/
+def dCommands (tree : DepTree) (i j : Nat) : Bool :=
+  tree.deps.any fun di =>
+    di.depIdx == i && di.depType == .nsubj &&
+    tree.deps.any fun dj => dj.depIdx == j && di.headIdx == dj.headIdx
+
+/-- Subject d-commands object: both dependents of the verb, subject bears nsubj. -/
+def subjectDCommandsObject (clause : SimpleClause) : Bool :=
+  match clause.object with
+  | none => false
+  | some _ => dCommands (toDepTree clause) 0 2
+
+/-- Both positions are dependents of the same head (the verb) — one domain. -/
 def sameLocalDomain (clause : SimpleClause) : Bool :=
   match clause.object with
   | none => true
   | some _ =>
-    let tree := clause.toDepTree
-    (tree.deps.any λ d => d.depIdx == 0 && d.headIdx == tree.rootIdx) &&
-    (tree.deps.any λ d => d.depIdx == 2 && d.headIdx == tree.rootIdx)
+    let tree := toDepTree clause
+    (tree.deps.any fun d => d.depIdx == 0 && d.headIdx == tree.rootIdx) &&
+    (tree.deps.any fun d => d.depIdx == 2 && d.headIdx == tree.rootIdx)
 
-/-! ### D-command -/
+/-! ### Dependency grammar as a command relation -/
 
-/-- D-command: word at index `i` d-commands word at index `j` in a
-    dependency tree if both are dependents of the same head and `i`
-    bears the subject relation (nsubj). -/
-def dCommands (tree : DepTree) (i j : Nat) : Bool :=
-  tree.deps.any λ di =>
-    di.depIdx == i && di.depType == .nsubj &&
-    tree.deps.any λ dj =>
-      dj.depIdx == j && di.headIdx == dj.headIdx
+/-- The dependency-grammar command relation: d-command. Object→subject never
+    holds (only the subject bears nsubj). -/
+def commands (c : SimpleClause) : Pos → Pos → Prop
+  | .subject, .object => subjectDCommandsObject c = true
+  | _, _ => False
 
-/-- Subject d-commands object: derived from the dependency tree.
-    Both are dependents of the verb, and the subject bears nsubj. -/
-def subjectDCommandsObject (clause : SimpleClause) : Bool :=
-  match clause.object with
-  | none => false
-  | some _ => dCommands clause.toDepTree 0 2
+instance (c : SimpleClause) (i j : Pos) : Decidable (commands c i j) := by
+  unfold commands; split <;> infer_instance
 
-/-! ### Binding-theory licensing -/
+/-- Locality: in a simple clause all positions share the one binding domain. -/
+def sameDomain (c : SimpleClause) (_ _ : Pos) : Prop := sameLocalDomain c = true
 
-/-- Reflexive is licensed if d-commanded by an agreeing antecedent in the
-    local domain. -/
-def reflexiveLicensed (clause : SimpleClause) : Bool :=
-  match clause.object with
-  | none => false
-  | some obj =>
-    match classifyNominal obj with
-    | some .reflexive =>
-      subjectDCommandsObject clause &&
-      sameLocalDomain clause &&
-      decide (Word.Agree clause.subject obj)
-    | _ => true
+instance (c : SimpleClause) (i j : Pos) : Decidable (sameDomain c i j) :=
+  inferInstanceAs (Decidable (sameLocalDomain c = true))
 
-/-- Reciprocals must be d-commanded by a semantically plural antecedent.
-    The plurality requirement is semantic, not morphosyntactic
-    (@cite{rakosi-2019}). -/
-def reciprocalLicensed (clause : SimpleClause) : Bool :=
-  match clause.object with
-  | none => false
-  | some obj =>
-    match classifyNominal obj with
-    | some .reciprocal =>
-      subjectDCommandsObject clause &&
-      sameLocalDomain clause &&
-      clause.semanticPl
-    | _ => true
-
-/-- A pronoun must not be d-commanded by a coreferent antecedent locally. -/
-def pronounLocallyFree (clause : SimpleClause) : Bool :=
-  match clause.object with
-  | none => true
-  | some obj =>
-    match classifyNominal obj with
-    | some .pronoun =>
-      !(subjectDCommandsObject clause && sameLocalDomain clause)
-    | _ => true
-
-/-! ### Top-level acceptability -/
-
-/-- Is a sentence grammatical for coreference under dependency binding? -/
-def grammaticalForCoreference (ws : List Word) : Bool :=
-  match parseSimpleClause ws with
-  | none => false
-  | some clause =>
-    match classifyNominal clause.subject with
-    | some .reflexive => false
-    | some .reciprocal => false
-    | _ =>
-      match clause.object with
-      | none => true
-      | some obj =>
-        match classifyNominal obj with
-        | some .reflexive => reflexiveLicensed clause
-        | some .reciprocal => reciprocalLicensed clause
-        | some .pronoun => false
-        | _ => true
+/-- The dependency-grammar instance of the abstract command relation
+    (@cite{barker-pullum-1990}): d-command. The engine supplies Principles
+    A/B/C; a study applies them with this instance and a language classifier. -/
+instance : CommandRelation where
+  commands := commands
+  sameDomain := sameDomain
+  commandsDec := fun c i j => inferInstance
+  sameDomainDec := fun c i j => inferInstance
 
 end DepGrammar.Coreference

--- a/Linglib/Syntax/HPSG/Coreference.lean
+++ b/Linglib/Syntax/HPSG/Coreference.lean
@@ -1,426 +1,83 @@
-/-
-HPSG Coreference (Binding).
-
-Binding theory using MODE and ARG-ST outranking,
-per @cite{sag-wasow-bender-2003} and @cite{pollard-sag-1994} (binding theory).
-
-SWB2003 has two binding principles (not three):
-- **Principle A**: [MODE ana] must be outranked by a coindexed element
-- **Principle B**: [MODE ref] must NOT be outranked by a coindexed element
-
-Both pronouns and R-expressions are [MODE ref], so Principle B subsumes
-the Chomskyan Principle C. No separate "Principle C" is needed.
--/
-
 import Linglib.Syntax.HPSG.Basic
-import Linglib.Fragments.English.Nouns
-import Linglib.Fragments.English.Pronouns
-import Linglib.Fragments.English.NominalClassification
-import Linglib.Fragments.English.Predicates.Verbal
-import Linglib.Features.CoreferenceStatus
-import Linglib.Paradigms.AcceptabilityJudgment
+import Linglib.Syntax.Binding.Basic
 
-open Paradigms.AcceptabilityJudgment
+/-!
+# HPSG Coreference (Binding)
 
-private abbrev john := English.Nouns.john.toWordSg
-private abbrev mary := English.Nouns.mary.toWordSg
-private abbrev they := English.Pronouns.they.toWord
-private abbrev sees := English.Predicates.Verbal.see.toWord3sg
-private abbrev see := English.Predicates.Verbal.see.toWordPl
-private abbrev himself := English.Pronouns.himself.toWord
-private abbrev herself := English.Pronouns.herself.toWord
-private abbrev themselves := English.Pronouns.themselves.toWord
-private abbrev him := English.Pronouns.him.toWord
-private abbrev her := English.Pronouns.her.toWord
-private abbrev them := English.Pronouns.them.toWord
-private abbrev eachOther := English.Pronouns.eachOther.toWord
+Binding via **ARG-ST outranking** (obliqueness order), following
+@cite{sag-wasow-bender-2003} Ch. 7 and @cite{pollard-sag-1994}. The c-command
+analogue in HPSG is *outranking* on the ARG-ST list: a less-oblique argument
+(the subject, at position 0) outranks a more-oblique one (the object, at
+position 1).
+
+As with the other frameworks, the binding principles are *not* restated here:
+this file supplies HPSG's command relation as a `Binding.CommandRelation`
+instance, and the framework-neutral engine (`Syntax/Binding/Basic.lean`) derives
+Principles A/B over it. (SWB2003's two-principle MODE system — Principle B
+subsuming Principle C — is the model-theoretic RSRL formalization in
+`Syntax/HPSG/Binding.lean`; this file is the ARG-ST command relation the shared
+engine consumes.) The file is language-neutral — it imports no Fragment.
+
+## Main definitions
+
+- `toArgSt`, `subjectOutranksObject`, `sameArgSt` — the ARG-ST outranking
+  relation and its locality restriction, over a `Binding.SimpleClause`.
+- `instance : CommandRelation` — the HPSG instance of the abstract command
+  relation (ARG-ST outranking); the engine supplies the binding principles.
+-/
 
 namespace HPSG.Coreference
 
-open Features (BindingClass)
-open English.NominalClassification (isNominalCat classifyNominal)
+open Binding (SimpleClause Pos CommandRelation)
 
--- ============================================================================
--- MODE Classification
--- ============================================================================
-
-section ModeClassification
-
-/-- Derive MODE feature from a word, via the shared `classifyNominal`.
-
-    Per @cite{sag-wasow-bender-2003}:
-    - Reflexives and reciprocals → [MODE ana]
-    - Personal pronouns and R-expressions → [MODE ref] -/
-def classifyMode (w : Word) : Option HPSG.Mode :=
-  match classifyNominal w with
-  | some .reflexive   => some .ana
-  | some .reciprocal  => some .ana
-  | some .pronoun     => some .ref
-  | some .rExpression => some .ref
-  | none              => none
-
-/-- Is this word an anaphor ([MODE ana])? -/
-def isAnaphor (w : Word) : Bool :=
-  classifyMode w == some .ana
-
-/-- Is this word a reflexive specifically? -/
-def isReflexive (w : Word) : Bool :=
-  match classifyNominal w with
-  | some .reflexive => true
-  | _               => false
-
-/-- Is this word a reciprocal? -/
-def isReciprocal (w : Word) : Bool :=
-  match classifyNominal w with
-  | some .reciprocal => true
-  | _                => false
-
-end ModeClassification
-
--- ============================================================================
--- ARG-ST and Outranking
--- ============================================================================
-
-section ArgStOutranking
-
-/-- Simple clause structure with ARG-ST for binding.
-
-    ARG-ST is implicitly [subject, object] — subject at position 0
-    outranks object at position 1. -/
-structure SimpleClause where
-  subject : Word
-  verb : Word
-  object : Option Word
-  /-- Whether the subject denotes a plurality. Defaults to matching
-      syntactic number. Override for languages where syntactic and
-      semantic number diverge (@cite{rakosi-2019}). -/
-  semanticPl : Bool := subject.features.number == some .pl
-  deriving Repr
-
-/-- Parse a simple transitive sentence into a clause. -/
-def parseSimpleClause (ws : List Word) : Option SimpleClause :=
-  match ws with
-  | [subj, v, obj] =>
-    if isNominalCat subj.cat && v.cat == .VERB && isNominalCat obj.cat then
-      some { subject := subj, verb := v, object := some obj }
-    else none
-  | [subj, v] =>
-    if isNominalCat subj.cat && v.cat == .VERB then
-      some { subject := subj, verb := v, object := none }
-    else none
-  | _ => none
+/-! ### ARG-ST outranking -/
 
 /-- Convert a word to a minimal HPSG Synsem for ARG-ST construction. -/
-private def wordToSynsem (w : Word) : HPSG.Synsem :=
-  { cat := w.cat }
+private def wordToSynsem (w : Word) : HPSG.Synsem := { cat := w.cat }
 
-/-- Build the ARG-ST for a simple clause from its arguments.
-
-    ARG-ST = [subject, object] — the verb's argument structure list,
+/-- Build the ARG-ST for a clause from its arguments: `[subject, object]`,
     ordered by obliqueness (@cite{sag-wasow-bender-2003}). -/
-def SimpleClause.toArgSt (clause : SimpleClause) : HPSG.ArgSt :=
+def toArgSt (clause : SimpleClause) : HPSG.ArgSt :=
   match clause.object with
   | none => { args := [wordToSynsem clause.subject] }
   | some obj => { args := [wordToSynsem clause.subject, wordToSynsem obj] }
 
-/-- Does the subject outrank the object on ARG-ST?
-
-    Derived from `ArgSt.outranks`: subject at position 0 outranks
-    object at position 1 iff `0 < 1 ∧ 1 < args.length`. -/
+/-- Subject outranks object on ARG-ST: subject at 0 outranks object at 1. -/
 def subjectOutranksObject (clause : SimpleClause) : Bool :=
-  clause.toArgSt.outranks 0 1
+  (toArgSt clause).outranks 0 1
 
-/-- Subject and object are on the same ARG-ST list: both are valid
-    indices in the ARG-ST built from the verb's argument structure. -/
+/-- Both positions are on the same ARG-ST list (the local binding domain). -/
 def sameArgSt (clause : SimpleClause) : Bool :=
   match clause.object with
   | none => true
-  | some _ => 1 < clause.toArgSt.args.length
+  | some _ => 1 < (toArgSt clause).args.length
 
-end ArgStOutranking
+/-! ### HPSG as a command relation -/
 
--- ============================================================================
--- φ-agreement requirement on anaphors
--- ============================================================================
+/-- The HPSG command relation: ARG-ST outranking. The subject (0) outranks the
+    object (1); the object does not outrank the subject. -/
+def commands (c : SimpleClause) : Pos → Pos → Prop
+  | .subject, .object => subjectOutranksObject c = true
+  | .object, .subject => (toArgSt c).outranks 1 0 = true
+  | _, _ => False
 
--- ============================================================================
--- Binding Principles
--- ============================================================================
+instance (c : SimpleClause) (i j : Pos) : Decidable (commands c i j) := by
+  unfold commands; split <;> infer_instance
 
-section BindingConstraints
+/-- Locality: the arguments share one ARG-ST list. -/
+def sameDomain (c : SimpleClause) (_ _ : Pos) : Prop := sameArgSt c = true
 
-/-- Principle A (SWB2003): An anaphor ([MODE ana]) must be outranked by a
-    coindexed element on the same ARG-ST list.
+instance (c : SimpleClause) (i j : Pos) : Decidable (sameDomain c i j) :=
+  inferInstanceAs (Decidable (sameArgSt c = true))
 
-    For reflexives, the coindexed antecedent must also φ-agree with it. -/
-def reflexiveLicensed (clause : SimpleClause) : Bool :=
-  match clause.object with
-  | none => false
-  | some obj =>
-    match classifyNominal obj with
-    | some .reflexive =>
-      subjectOutranksObject clause &&
-      sameArgSt clause &&
-      decide (Word.Agree clause.subject obj)
-    | _ => true
-
-/-- Principle A for reciprocals: a reciprocal ([MODE ana]) must be outranked
-    by a semantically plural coindexed element. The plurality requirement
-    is semantic (LF), not morphosyntactic — reciprocals are licensed by
-    quantified NPs, singular coordinate DPs, and collective nouns that
-    are syntactically singular (@cite{rakosi-2019}). -/
-def reciprocalLicensed (clause : SimpleClause) : Bool :=
-  match clause.object with
-  | none => false
-  | some obj =>
-    match classifyNominal obj with
-    | some .reciprocal =>
-      subjectOutranksObject clause &&
-      sameArgSt clause &&
-      clause.semanticPl
-    | _ => true
-
-/-- Principle B (SWB2003): A [MODE ref] element must NOT be outranked
-    by a coindexed element on the same ARG-ST list.
-
-    This applies to both pronouns and R-expressions (both are [MODE ref]).
-    In a simple clause, the subject outranks the object, so any [MODE ref]
-    object that is coindexed with the subject violates Principle B.
-
-    Note: `grammaticalForCoreference` only tests this for pronouns, since
-    R-expression objects are typically not coindexed with the subject.
-    `computeCoreferenceStatus` applies Principle B to all [MODE ref] elements
-    for explicit coindexation queries. -/
-def refLocallyFree (clause : SimpleClause) : Bool :=
-  match clause.object with
-  | none => true
-  | some obj =>
-    match classifyMode obj with
-    | some .ref =>
-      !(subjectOutranksObject clause && sameArgSt clause)
-    | _ => true
-
-end BindingConstraints
-
--- ============================================================================
--- Combined Check
--- ============================================================================
-
-section CombinedCheck
-
-/-- Is a sentence free of binding violations under HPSG binding theory?
-
-    Checks Principle A (anaphors must be outranked) and
-    Principle B (pronouns must not be locally bound).
-
-    For R-expression objects, no binding violation arises because
-    coindexation with the subject is not assumed. Use
-    `computeCoreferenceStatus` for explicit coindexation queries. -/
-def grammaticalForCoreference (ws : List Word) : Bool :=
-  match parseSimpleClause ws with
-  | none => false
-  | some clause =>
-    -- Anaphors cannot be subjects (no outranker available)
-    match classifyNominal clause.subject with
-    | some .reflexive => false
-    | some .reciprocal => false
-    | _ =>
-      match clause.object with
-      | none => true
-      | some obj =>
-        match classifyNominal obj with
-        | some .reflexive => reflexiveLicensed clause
-        | some .reciprocal => reciprocalLicensed clause
-        | some .pronoun => false  -- Principle B: [MODE ref] locally bound → blocked
-        | _ => true  -- R-expressions: no coindexation assumed, no violation
-
-/-- Check if reflexive is licensed in a sentence -/
-def reflexiveLicensedInSentence (ws : List Word) : Bool :=
-  match parseSimpleClause ws with
-  | none => false
-  | some clause => reflexiveLicensed clause
-
-/-- Check if local coreference is blocked by Principle B ([MODE ref]).
-
-    Applies to both pronouns and R-expressions. -/
-def localCoreferenceBlocked (ws : List Word) : Bool :=
-  match parseSimpleClause ws with
-  | none => false
-  | some clause => !refLocallyFree clause
-
--- ============================================================================
--- Tests
--- ============================================================================
-
--- Principle A: reflexives licensed when outranked with agreement
-#guard reflexiveLicensedInSentence [john, sees, himself]     -- ✓
-#guard !grammaticalForCoreference [himself, sees, john]      -- ✗ anaphor in subject
-#guard reflexiveLicensedInSentence [mary, sees, herself]     -- ✓
-#guard !grammaticalForCoreference [herself, sees, mary]      -- ✗
-#guard reflexiveLicensedInSentence [they, see, themselves]   -- ✓
-#guard !grammaticalForCoreference [themselves, see, them]    -- ✗
-
--- φ-agreement violations (mismatches)
-#guard !reflexiveLicensedInSentence [john, sees, herself]    -- ✗ gender mismatch
-#guard !reflexiveLicensedInSentence [they, see, himself]     -- ✗ number mismatch
-
--- Principle A: reciprocals require plural antecedent
-#guard grammaticalForCoreference [they, see, eachOther]      -- ✓ plural antecedent
-#guard !grammaticalForCoreference [eachOther, see, them]     -- ✗ anaphor in subject
-#guard !grammaticalForCoreference [john, sees, eachOther]    -- ✗ singular antecedent
-
--- Principle B: [MODE ref] must be locally free
-#guard localCoreferenceBlocked [john, sees, him]             -- ✓ pronoun
-#guard localCoreferenceBlocked [mary, sees, her]             -- ✓ pronoun
-#guard localCoreferenceBlocked [john, sees, mary]            -- ✓ R-expression
-
--- ============================================================================
--- Capturing Phenomena Data
--- ============================================================================
-
-/-- Check all pairs in a `PhenomenonData` under HPSG's coreference predicate. -/
-def capturesCoreferenceData (phenom : PhenomenonData) : Bool :=
-  capturesPhenomenonData grammaticalForCoreference phenom
-
--- ============================================================================
--- Per-Pair Verification
--- ============================================================================
-
-/-- Check each pair individually for reflexive coreference -/
-theorem reflexive_pairs_captured :
-    -- Pair 1: john sees himself vs himself sees john
-    (grammaticalForCoreference [john, sees, himself] = true ∧
-     grammaticalForCoreference [himself, sees, john] = false) ∧
-    -- Pair 2: mary sees herself vs herself sees mary
-    (grammaticalForCoreference [mary, sees, herself] = true ∧
-     grammaticalForCoreference [herself, sees, mary] = false) ∧
-    -- Pair 3: they see themselves vs themselves see them
-    (grammaticalForCoreference [they, see, themselves] = true ∧
-     grammaticalForCoreference [themselves, see, them] = false) ∧
-    -- Pair 4: agreement - john sees himself vs john sees herself
-    (grammaticalForCoreference [john, sees, himself] = true ∧
-     grammaticalForCoreference [john, sees, herself] = false) ∧
-    -- Pair 5: agreement - they see themselves vs they see himself
-    (grammaticalForCoreference [they, see, themselves] = true ∧
-     grammaticalForCoreference [they, see, himself] = false) ∧
-    -- Pair 6: reciprocal - they see each other vs each other see them
-    (grammaticalForCoreference [they, see, eachOther] = true ∧
-     grammaticalForCoreference [eachOther, see, them] = false) ∧
-    -- Pair 7: reciprocal requires plural antecedent
-    (grammaticalForCoreference [they, see, eachOther] = true ∧
-     grammaticalForCoreference [john, sees, eachOther] = false) := by
-  decide
-
--- ============================================================================
--- CoreferenceTheory Interface Implementation
--- ============================================================================
-
-/-- Compute coreference status for positions i and j using ARG-ST outranking.
-
-    Position 0 = subject, position 2 = object.
-
-    Applies both binding principles uniformly:
-    - Principle A: [MODE ana] at j outranked by coindexed i → obligatory
-    - Principle B: [MODE ref] at j outranked by coindexed i → blocked -/
-def computeCoreferenceStatus (clause : SimpleClause) (i j : Nat) : Features.CoreferenceStatus :=
-  if i == 0 && j == 2 then
-    -- Subject outranks object on ARG-ST
-    match clause.object with
-    | none => .unspecified
-    | some obj =>
-      match classifyMode obj with
-      | some .ana =>
-        -- Principle A: anaphor must be outranked — check agreement
-        if subjectOutranksObject clause && sameArgSt clause && decide (Word.Agree clause.subject obj)
-        then .obligatory
-        else .blocked
-      | some .ref =>
-        -- Principle B: [MODE ref] must NOT be outranked by coindexed element
-        -- Applies to both pronouns and R-expressions
-        if subjectOutranksObject clause && sameArgSt clause
-        then .blocked
-        else .possible
-      | _ => .unspecified
-  else if i == 2 && j == 0 then
-    -- Does the object outrank the subject on ARG-ST?
-    -- Derived: outranks requires i < j, but object (1) > subject (0)
-    let objectOutranks := clause.toArgSt.outranks 1 0
-    match classifyMode clause.subject with
-    | some .ana =>
-      if objectOutranks && sameArgSt clause
-      then .obligatory
-      else .blocked
-    | some .ref =>
-      if objectOutranks && sameArgSt clause
-      then .blocked
-      else .possible
-    | _ => .unspecified
-  else
-    .unspecified
-
--- Principle B applies uniformly to [MODE ref] — both pronouns and R-expressions
-private def johnSeesHim : SimpleClause := { subject := john, verb := sees, object := some him }
-private def johnSeesMary : SimpleClause := { subject := john, verb := sees, object := some mary }
-private def johnSeesHimself : SimpleClause := { subject := john, verb := sees, object := some himself }
-
--- Principle A: anaphor must be outranked → obligatory coreference
-#guard computeCoreferenceStatus johnSeesHimself 0 2 == .obligatory
--- Principle B: pronoun outranked → blocked
-#guard computeCoreferenceStatus johnSeesHim 0 2 == .blocked
--- Principle B: R-expression outranked → also blocked (subsumes Principle C)
-#guard computeCoreferenceStatus johnSeesMary 0 2 == .blocked
-
-end CombinedCheck
-
--- ============================================================================
--- Theoretical Notes
--- ============================================================================
-
-/-
-## SWB2003 Binding Theory
-
-### MODE (not PPRO)
-
-SWB2003 replaces the Chomskyan three-way classification
-(anaphor / pronoun / R-expression → Principles A/B/C) with a
-single-feature system based on MODE:
-
-- [MODE ana]: anaphors (reflexives, reciprocals)
-- [MODE ref]: both personal pronouns AND R-expressions
-
-This yields exactly two binding principles:
-- **Principle A**: [MODE ana] must be outranked by a coindexed element
-- **Principle B**: [MODE ref] must NOT be outranked by a coindexed element
-
-There is no "Principle C" — Principle B subsumes it, since both pronouns
-and R-expressions are [MODE ref]. Both are blocked from being locally
-bound by a coindexed element.
-
-Note: Some secondary sources incorrectly attribute a PPRO feature to
-SWB2003. The textbook's binding theory uses only MODE and ARG-ST.
-
-### ARG-ST and Outranking
-
-Binding is defined over the ARG-ST (argument structure) list, not over
-tree geometry:
-
-    ARG-ST = SPR ⊕ COMPS
-
-"X outranks Y" iff X precedes Y on some ARG-ST list.
-
-### Comparison with Minimalism
-
-Both theories make the same predictions for simple cases:
-1. Subject outranks object ↔ Subject c-commands object
-2. Same ARG-ST list ↔ Same binding domain (local clause)
-3. φ-agreement ↔ Feature checking
-
-The difference is in mechanism:
-- Minimalism: structural (tree geometry, c-command via `cCommandsIn`)
-- HPSG: feature-based (ARG-ST ordering via `ArgSt.outranks`, constraint satisfaction)
-
-In this implementation, HPSG outranking is derived from the actual ARG-ST
-list built from the clause's arguments, not hardcoded.
--/
+/-- The HPSG instance of the abstract command relation
+    (@cite{barker-pullum-1990}): ARG-ST outranking. The engine supplies the
+    binding principles; a study applies them with this instance and a language
+    classifier. -/
+instance : CommandRelation where
+  commands := commands
+  sameDomain := sameDomain
+  commandsDec := fun c i j => inferInstance
+  sameDomainDec := fun c i j => inferInstance
 
 end HPSG.Coreference

--- a/Linglib/Syntax/Minimalist/Coreference.lean
+++ b/Linglib/Syntax/Minimalist/Coreference.lean
@@ -1,307 +1,108 @@
-import Linglib.Fragments.English.Nouns
-import Linglib.Fragments.English.Pronouns
-import Linglib.Fragments.English.NominalClassification
 import Linglib.Syntax.Minimalist.Basic
-import Linglib.Features.CoreferenceStatus
+import Linglib.Syntax.Binding.Basic
 
 /-!
 # Minimalist Coreference (Binding)
 
-Coreference constraints via c-command and locality following @cite{chomsky-1981}.
+Binding via **c-command** and locality (@cite{chomsky-1981}). The binding
+principles themselves are *not* restated here: this file supplies Minimalism's
+command relation (c-command, read off the phrase-structure tree) as a
+`Syntax.Binding.CommandRelation` instance, and the framework-neutral engine
+(`Syntax/Binding/Basic.lean`) derives Principles A/B/C and the coreference
+predictions from it. The file is language-neutral — it imports no Fragment; a
+study combines this instance with a language's binding-class classifier.
 
 ## Main definitions
 
-- `BindingClass`, `SimpleClause`
-- `reflexiveLicensed`, `pronounLocallyFree`, `grammaticalForCoreference`
-
+- `subjectCCommandsObject` / `objectCCommandsSubject` — c-command from tree
+  geometry.
+- `instance : CommandRelation` — the Minimalist instance of the abstract
+  command relation (c-command); the engine supplies Principles A/B/C over it.
 -/
 
 namespace Minimalist.Coreference
 
-open Features (BindingClass)
-open English.NominalClassification (isNominalCat classifyNominal)
+open Binding (SimpleClause Pos CommandRelation)
 
-/-- Simple clause structure for coreference checking.
-    `semanticPl` tracks whether the subject denotes a plurality,
-    independently of syntactic number. In English, these coincide.
-    In Hungarian, quantified NPs, singular coordinate DPs, and
-    collective nouns are syntactically singular but semantically
-    plural (@cite{rakosi-2019}). Defaults to matching syntactic number. -/
-structure SimpleClause where
-  subject : Word
-  verb : Word
-  object : Option Word
-  /-- Whether the subject denotes a plurality (multiple individuals).
-      Defaults to matching the syntactic number feature. Override for
-      languages where syntactic and semantic number diverge. -/
-  semanticPl : Bool := subject.features.number == some .pl
-  deriving Repr
+/-! ### C-command from tree geometry -/
 
-def parseSimpleClause (ws : List Word) : Option SimpleClause :=
-  match ws with
-  | [subj, v, obj] =>
-    if isNominalCat subj.cat && v.cat == .VERB && isNominalCat obj.cat then
-      some { subject := subj, verb := v, object := some obj }
-    else none
-  | [subj, v] =>
-    if isNominalCat subj.cat && v.cat == .VERB then
-      some { subject := subj, verb := v, object := none }
-    else none
-  | _ => none
-
-/-- Convert a word to a Minimalist syntactic object (leaf with UPOS mapped
-    to Cat and phonological form attached). -/
+/-- Convert a word to a Minimalist syntactic object (leaf with UPOS mapped to
+    Cat and phonological form attached). -/
 private def wordToSO (w : Word) (id : Nat) : SyntacticObject :=
   mkLeafPhon (uposToCat w.cat) [] w.form id
 
-/-- Build a phrase structure tree from a simple clause.
-
-    Transitive: `{subj, {verb, obj}}` — subject is specifier,
-    verb–object is a head-complement pair.
-    Intransitive: `{subj, verb}` — subject and verb are co-daughters.
-
-    C-command follows from the tree geometry:
-    - Subject c-commands object (subject's sister contains object)
-    - Object does NOT c-command subject (object's sister is verb leaf) -/
-def SimpleClause.toSyntacticObject (clause : SimpleClause) : SyntacticObject :=
+/-- Build a phrase-structure tree from a clause: transitive `{subj, {verb, obj}}`
+    (subject specifier, verb–object a head-complement pair), intransitive
+    `{subj, verb}`. C-command follows from the geometry. -/
+def toSyntacticObject (clause : SimpleClause) : SyntacticObject :=
   let subjSO := wordToSO clause.subject 0
   let verbSO := wordToSO clause.verb 1
   match clause.object with
   | none => merge subjSO verbSO
-  | some obj =>
-    let objSO := wordToSO obj 2
-    merge subjSO (merge verbSO objSO)
+  | some obj => merge subjSO (merge verbSO (wordToSO obj 2))
 
-/-- The subject as a syntactic object for tree-relative c-command checks. -/
-private def SimpleClause.subjectSO (clause : SimpleClause) : SyntacticObject :=
+private def subjectSO (clause : SimpleClause) : SyntacticObject :=
   wordToSO clause.subject 0
 
-/-- The object as a syntactic object, if present. -/
-private def SimpleClause.objectSO? (clause : SimpleClause) : Option SyntacticObject :=
+private def objectSO? (clause : SimpleClause) : Option SyntacticObject :=
   clause.object.map fun obj => wordToSO obj 2
 
-/-- Subject c-commands object: derived from the phrase structure tree.
-    In `{subj, {verb, obj}}`, the subject's sister is `{verb, obj}`,
-    which contains the object. -/
+/-- Subject c-commands object: in `{subj, {verb, obj}}`, the subject's sister
+    `{verb, obj}` contains the object. -/
 def subjectCCommandsObject (clause : SimpleClause) : Prop :=
-  match clause.objectSO? with
+  match objectSO? clause with
   | none => False
-  | some objSO => cCommandsIn clause.toSyntacticObject clause.subjectSO objSO
+  | some objSO => cCommandsIn (toSyntacticObject clause) (subjectSO clause) objSO
 
 instance (clause : SimpleClause) : Decidable (subjectCCommandsObject clause) := by
-  unfold subjectCCommandsObject
-  cases clause.objectSO? <;> infer_instance
+  unfold subjectCCommandsObject; cases objectSO? clause <;> infer_instance
 
-/-- Object does not c-command subject: derived from the tree.
-    In `{subj, {verb, obj}}`, the object's sister is `verb`,
-    which does not contain the subject. -/
+/-- Object does not c-command subject: in `{subj, {verb, obj}}`, the object's
+    sister `verb` does not contain the subject. -/
 def objectCCommandsSubject (clause : SimpleClause) : Prop :=
-  match clause.objectSO? with
+  match objectSO? clause with
   | none => False
-  | some objSO => cCommandsIn clause.toSyntacticObject objSO clause.subjectSO
+  | some objSO => cCommandsIn (toSyntacticObject clause) objSO (subjectSO clause)
 
 instance (clause : SimpleClause) : Decidable (objectCCommandsSubject clause) := by
-  unfold objectCCommandsSubject
-  cases clause.objectSO? <;> infer_instance
+  unfold objectCCommandsSubject; cases objectSO? clause <;> infer_instance
 
-/-- Same local domain: both subject and object are subterms of the same
-    clause tree (the minimal domain containing a SUBJECT). -/
+/-- Both positions are in the local clause tree (the minimal domain). -/
 def sameLocalDomain (clause : SimpleClause) : Prop :=
-  let tree := clause.toSyntacticObject
-  match clause.objectSO? with
+  match objectSO? clause with
   | none => True
   | some objSO =>
-    contains tree clause.subjectSO ∧ contains tree objSO
+    contains (toSyntacticObject clause) (subjectSO clause) ∧
+    contains (toSyntacticObject clause) objSO
 
 instance (clause : SimpleClause) : Decidable (sameLocalDomain clause) := by
-  unfold sameLocalDomain
-  cases clause.objectSO? <;> infer_instance
+  unfold sameLocalDomain; cases objectSO? clause <;> infer_instance
 
-/-- Binding domain check: in a simple clause, all positions share a domain. -/
-def inSameBindingDomain (_clause : SimpleClause) (_pos1 _pos2 : String) : Prop :=
-  True
+/-! ### Minimalism as a command relation -/
 
-instance (clause : SimpleClause) (pos1 pos2 : String) :
-    Decidable (inSameBindingDomain clause pos1 pos2) := by
-  unfold inSameBindingDomain; infer_instance
+/-- The Minimalist command relation: c-command read off the tree. -/
+def commands (c : SimpleClause) : Pos → Pos → Prop
+  | .subject, .object => subjectCCommandsObject c
+  | .object, .subject => objectCCommandsSubject c
+  | _, _ => False
 
-/-- Principle A: Reflexives must be bound locally -/
-def reflexiveLicensed (clause : SimpleClause) : Prop :=
-  match clause.object with
-  | none => False
-  | some obj =>
-    match classifyNominal obj with
-    | some .reflexive =>
-      subjectCCommandsObject clause ∧
-      sameLocalDomain clause ∧
-      Word.Agree clause.subject obj
-    | _ => True
+instance (c : SimpleClause) (i j : Pos) : Decidable (commands c i j) := by
+  unfold commands; split <;> infer_instance
 
-instance (clause : SimpleClause) : Decidable (reflexiveLicensed clause) := by
-  unfold reflexiveLicensed
-  split <;> first | infer_instance | (split <;> infer_instance)
+/-- Locality: in a simple clause all positions share the one binding domain. -/
+def sameDomain (c : SimpleClause) (_ _ : Pos) : Prop := sameLocalDomain c
 
-/-- Reciprocals must be locally c-commanded by a semantically plural
-    antecedent. Unlike reflexive licensing (which uses narrow-syntactic
-    φ-agreement, hence requires morphosyntactic plurality), reciprocal
-    licensing is an LF interpretive condition under the Y-model:
-    the antecedent must *denote* a plurality, but need not bear plural
-    morphology or trigger plural verb agreement.
-    @cite{rakosi-2019}: Hungarian *egymás* is licensed by quantified NPs,
-    singular coordinate DPs, and collective nouns — all syntactically
-    singular but semantically plural. -/
-def reciprocalLicensed (clause : SimpleClause) : Prop :=
-  match clause.object with
-  | none => False
-  | some obj =>
-    match classifyNominal obj with
-    | some .reciprocal =>
-      subjectCCommandsObject clause ∧
-      sameLocalDomain clause ∧
-      clause.semanticPl = true  -- LF condition: semantic plurality suffices
-    | _ => True
+instance (c : SimpleClause) (i j : Pos) : Decidable (sameDomain c i j) :=
+  inferInstanceAs (Decidable (sameLocalDomain c))
 
-instance (clause : SimpleClause) : Decidable (reciprocalLicensed clause) := by
-  unfold reciprocalLicensed
-  split <;> first | infer_instance | (split <;> infer_instance)
+/-- Minimalism is an instance of the abstract command relation
+    (@cite{barker-pullum-1990}). The binding principles
+    (`Syntax.Binding.grammaticalForCoreference` etc.) come from the engine;
+    a study applies them with this instance in scope and a language classifier. -/
+instance : CommandRelation where
+  commands := commands
+  sameDomain := sameDomain
+  commandsDec := fun c i j => inferInstance
+  sameDomainDec := fun c i j => inferInstance
 
-/-- Principle B: Pronouns must be free locally -/
-def pronounLocallyFree (clause : SimpleClause) : Prop :=
-  match clause.object with
-  | none => True
-  | some obj =>
-    match classifyNominal obj with
-    | some .pronoun =>
-      ¬ (subjectCCommandsObject clause ∧ sameLocalDomain clause)
-    | _ => True
-
-instance (clause : SimpleClause) : Decidable (pronounLocallyFree clause) := by
-  unfold pronounLocallyFree
-  split <;> first | infer_instance | (split <;> infer_instance)
-
-/-- Principle C: R-expressions must be free everywhere.
-
-    An R-expression is free iff no coreferential pronoun c-commands it.
-    In a simple clause `{subj, {verb, obj}}`, a pronominal subject
-    c-commands the object (via tree-relative `cCommandsIn`), so
-    subject–object coreference with an R-expression object is blocked.
-
-    Note: WLM (@cite{takahashi-hulsey-2009}, @cite{gong-2022}) can
-    bleed Condition C by merging the NP restrictor at a chain position
-    above the binder. This function checks the *surface* tree; the
-    WLM escape is modeled via `wlmAvoidsCondC` in `LateMerger.lean`. -/
-def rExpressionFree (clause : SimpleClause) : Prop :=
-  match classifyNominal clause.subject with
-  | some .pronoun =>
-    match clause.object with
-    | some obj =>
-      match classifyNominal obj with
-      | some .rExpression =>
-        -- Condition C: R-expression object must NOT be c-commanded
-        -- by the coreferential pronominal subject
-        ¬ subjectCCommandsObject clause
-      | _ => True
-    | none => True
-  | _ => True
-
-instance (clause : SimpleClause) : Decidable (rExpressionFree clause) := by
-  unfold rExpressionFree
-  split <;> first
-    | infer_instance
-    | (split <;> first | infer_instance | (split <;> infer_instance))
-
-/-- Grammatical for coreference under Minimalist binding -/
-def grammaticalForCoreference (ws : List Word) : Prop :=
-  match parseSimpleClause ws with
-  | none => False
-  | some clause =>
-    match classifyNominal clause.subject with
-    | some .reflexive => False
-    | some .reciprocal => False
-    | _ =>
-      match clause.object with
-      | none => True
-      | some obj =>
-        match classifyNominal obj with
-        | some .reflexive => reflexiveLicensed clause
-        | some .reciprocal => reciprocalLicensed clause
-        | some .pronoun => False
-        | _ => True
-
-instance (ws : List Word) : Decidable (grammaticalForCoreference ws) := by
-  unfold grammaticalForCoreference
-  split <;> first
-    | infer_instance
-    | (split <;> first
-        | infer_instance
-        | (split <;> first | infer_instance | (split <;> infer_instance)))
-
-def reflexiveLicensedInSentence (ws : List Word) : Prop :=
-  match parseSimpleClause ws with
-  | none => False
-  | some clause => reflexiveLicensed clause
-
-instance (ws : List Word) : Decidable (reflexiveLicensedInSentence ws) := by
-  unfold reflexiveLicensedInSentence
-  cases parseSimpleClause ws <;> infer_instance
-
-def pronounCoreferenceBlocked (ws : List Word) : Prop :=
-  match parseSimpleClause ws with
-  | none => False
-  | some clause => ¬ pronounLocallyFree clause
-
-instance (ws : List Word) : Decidable (pronounCoreferenceBlocked ws) := by
-  unfold pronounCoreferenceBlocked
-  cases parseSimpleClause ws <;> infer_instance
-
-structure MinimalistCoreferenceGrammar where
-  strictLocality : Bool := true
-
-def defaultGrammar : MinimalistCoreferenceGrammar := {}
-
-def computeCoreferenceStatus (clause : SimpleClause) (i j : Nat) : Features.CoreferenceStatus :=
-  if i = 0 ∧ j = 2 then
-    match clause.object with
-    | none => .unspecified
-    | some obj =>
-      match classifyNominal obj with
-      | some .reflexive =>
-        if subjectCCommandsObject clause ∧ sameLocalDomain clause ∧ Word.Agree clause.subject obj
-        then .obligatory
-        else .blocked
-      | some .reciprocal =>
-        if subjectCCommandsObject clause ∧ sameLocalDomain clause ∧
-           clause.semanticPl = true  -- LF: semantic plurality
-        then .obligatory
-        else .blocked
-      | some .pronoun =>
-        if subjectCCommandsObject clause ∧ sameLocalDomain clause
-        then .blocked
-        else .possible
-      | some .rExpression =>
-        -- Condition C: pronoun subject c-commanding R-expression object
-        -- blocks coreference (the R-expression is not free)
-        if subjectCCommandsObject clause
-        then .blocked
-        else .possible
-      | none => .unspecified
-  else if i = 2 ∧ j = 0 then
-    -- Object→subject: does the object c-command the subject?
-    -- Derived from tree: in {subj, {verb, obj}}, object does NOT c-command subject
-    match classifyNominal clause.subject with
-    | some .reflexive =>
-      if objectCCommandsSubject clause ∧ sameLocalDomain clause
-      then .obligatory
-      else .blocked
-    | some .reciprocal =>
-      if objectCCommandsSubject clause ∧ sameLocalDomain clause
-      then .obligatory
-      else .blocked
-    | some .pronoun =>
-      if objectCCommandsSubject clause ∧ sameLocalDomain clause
-      then .blocked
-      else .possible
-    | _ => .possible
-  else
-    .unspecified
 end Minimalist.Coreference


### PR DESCRIPTION
The three binding frameworks (HPSG, Minimalist, DG) were ~80% duplicate, differing only in their command relation. Factor the shared engine out.

- `Syntax/Binding/Basic.lean`: a `CommandRelation` class (@cite{barker-pullum-1990}) + the binding principles (A/B/C), `grammaticalForCoreference`, and `computeCoreferenceStatus` stated **once** over it, parameterized by a language's binding-class classifier (engine imports no Fragment).
- HPSG / Minimalist / DG `Coreference.lean` become English-free `CommandRelation` instances (ARG-ST outranking / c-command / d-command); the study files assemble engine × instance × English classifier.
- `reflexiveLicensed_congr`: cross-framework convergence as a theorem, not a prose comment.

Net −310 lines despite adding the engine.