### PR TITLE
feat(Syntax/Agreement): canonical-φ agreement paradigm; Mam exemplar

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -288,6 +288,7 @@ import Linglib.Diachronic.CaseGrammaticalization
 import Linglib.Typology.Comparison
 import Linglib.Syntax.Agreement.Controller
 import Linglib.Syntax.Agreement.Basic
+import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Morphology.Containment
 import Linglib.Morphology.DegreeContainment
 import Linglib.Morphology.DM.DomainLocality

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -1,7 +1,7 @@
 import Linglib.Features.Case
-import Linglib.Features.Case
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
+import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Typology.Extraction
 
 /-!
@@ -438,5 +438,45 @@ theorem setB_1sg : setBExponent .p1sg = "chin" := rfl
 
 /-- Set B 3SG marker is the default "tz'=". -/
 theorem setB_3sg : setBExponent .p3sg = defaultSetB := rfl
+
+-- ============================================================================
+-- § Canonical-φ paradigm (descriptive, theory-neutral)
+-- ============================================================================
+
+open Syntax.Agreement
+
+/-! The Set A / Set B tables above are keyed by the Mayan-specific `PersonNumber`
+enum. Re-stated here over the **canonical φ-cell** (`Syntax.Agreement.AgrCell` —
+the same `person × number` a `Pronoun`/`Word` carries, @cite{corbett-1998} §2),
+so a controller's φ (`Word.agrCell`) indexes the agreement paradigm directly:
+pronoun-φ and agreement-φ are one space (@cite{corbett-1998} §1; @cite{scott-2023}
+Ch. 2). Theory-neutral — the table records syncretism (t-, ky-, tz'=, chi) as a
+plain fact; the Distributed-Morphology account of it (impoverishment / Elsewhere;
+@cite{scott-2023} Ch. 4) is theory and lives in the study, not the fragment. -/
+
+/-- A Mayan `PersonNumber` as a canonical φ-cell (person × number). -/
+def pnCell : PersonNumber → AgrCell
+  | .p1sg => .pn .first .Sing  | .p2sg => .pn .second .Sing | .p3sg => .pn .third .Sing
+  | .p1pl => .pn .first .Plur  | .p2pl => .pn .second .Plur | .p3pl => .pn .third .Plur
+
+/-- Set A (ergative) as a descriptive paradigm over canonical φ-cells. -/
+def setAParadigm : Paradigm String :=
+  PersonNumber.all.map fun p => (pnCell p, setAExponent p)
+
+/-- Set B (absolutive) as a descriptive paradigm over canonical φ-cells. -/
+def setBParadigm : Paradigm String :=
+  PersonNumber.all.map fun p => (pnCell p, setBExponent p)
+
+/-- The canonical-φ paradigm agrees with the `PersonNumber`-keyed table. -/
+theorem setAParadigm_consistent (p : PersonNumber) :
+    setAParadigm.realize (pnCell p) = some (setAExponent p) := by
+  cases p <;> rfl
+
+/-- A controller's φ-features index the Set A paradigm directly: a 1sg agent
+    selects its first-person-singular ergative prefix — pronoun-φ driving
+    agreement realization in one shared feature space. -/
+theorem erg_1sg_from_phi :
+    setAParadigm.realizeFor ⟨"", .PRON, { person := some .first, number := some .sg }⟩
+      = some "n-/w-" := by rfl
 
 end Mam

--- a/Linglib/Syntax/Agreement/Paradigm.lean
+++ b/Linglib/Syntax/Agreement/Paradigm.lean
@@ -1,0 +1,90 @@
+import Linglib.Core.Word
+
+/-!
+# Agreement paradigms — the descriptive realization table
+@cite{corbett-1998} @cite{scott-2023}
+
+A **theory-neutral** representation of an agreement paradigm: the descriptive
+table mapping agreement-feature cells to their surface exponents, in the sense
+of @cite{corbett-1998} (*Morphology and Agreement*, Handbook of Morphology) and
+the grammar-sketch chapters of descriptive work like @cite{scott-2023} (Ch. 2:
+Set A / Set B person–number inflection).
+
+## Theory-neutrality
+
+This file records *what forms realize which feature cells* — the paradigm table
+a reference grammar lists. It deliberately commits to **no** generative account
+of *how* the table arises. Syncretism is recorded as a plain fact (two cells, one
+form — a non-injective table), not explained. The competing realizational
+analyses — Distributed Morphology (vocabulary insertion + impoverishment;
+@cite{scott-2023} Ch. 4), Paradigm Function Morphology, HPSG type-hierarchy
+unification — are *theories of* this table and belong in `Studies/`, not here.
+
+## One φ-space with pronouns
+
+Per @cite{corbett-1998} (§1), agreement in the wider sense *includes* pronouns —
+diachronically, agreement morphology grammaticalizes from pronouns. The three
+indisputable agreement features (§2) are exactly **person, number, gender**
+(case is government, not agreement). So an `AgrCell` is the canonical φ-subspace
+a `Pronoun`/`Word` already carries: `Word.agrCell` projects a word's φ-features
+into a paradigm index, so the *same* feature space drives pronoun reference and
+agreement realization — no parallel person/number enum.
+
+## Main declarations
+
+* `AgrCell` — an agreement-feature cell (person × number × gender), in the
+  canonical `UD` feature types.
+* `Paradigm Exp` — a descriptive table: agreement cells to exponents.
+* `Paradigm.realize` — look up the exponent for a cell (exact match).
+* `Word.agrCell` / `Paradigm.realizeFor` — index a paradigm by a word's φ.
+-/
+
+namespace Syntax.Agreement
+
+/-- An agreement-feature cell: the canonical φ-features that may be realized by
+    agreement (@cite{corbett-1998} §2 — person, number, gender; case excluded as
+    government). Uses the same `UD` feature types a `Pronoun`/`Word` carries, so a
+    controller's φ projects directly into the index (`Word.agrCell`). A `none`
+    field is a feature the paradigm does not distinguish. -/
+structure AgrCell where
+  person : Option UD.Person := none
+  number : Option UD.Number := none
+  gender : Option UD.Gender := none
+  deriving DecidableEq, Repr, BEq
+
+/-- Build a person–number cell (the common case: no gender agreement). -/
+def AgrCell.pn (p : UD.Person) (n : UD.Number) : AgrCell :=
+  { person := some p, number := some n }
+
+/-- The φ-cell of a word: its person/number/gender features, as an agreement
+    index. The bridge that lets a pronoun (or any controller) drive an agreement
+    paradigm in the *same* feature space (@cite{corbett-1998} §1). -/
+def _root_.Word.agrCell (w : Word) : AgrCell :=
+  { person := w.features.person, number := w.features.number,
+    gender := w.features.gender }
+
+/-- An agreement paradigm: the descriptive table of (cell, exponent) entries.
+    `Exp` is the exponent type (a surface string, a structured affix, …).
+    A non-injective table records syncretism as a fact; a partial table (a cell
+    with no entry) records defectiveness. -/
+abbrev Paradigm (Exp : Type _) := List (AgrCell × Exp)
+
+namespace Paradigm
+
+variable {Exp : Type _}
+
+/-- The exponent realizing a given cell, by exact match (the first entry whose
+    cell equals `c`). `none` if the paradigm has no entry for the cell. -/
+def realize [DecidableEq Exp] (p : Paradigm Exp) (c : AgrCell) : Option Exp :=
+  (p.find? (·.1 == c)).map (·.2)
+
+/-- Realize the exponent agreeing with a controller word, via its `agrCell`. -/
+def realizeFor [DecidableEq Exp] (p : Paradigm Exp) (controller : Word) : Option Exp :=
+  p.realize controller.agrCell
+
+/-- The cells the paradigm distinguishes (in declaration order). -/
+def cells (p : Paradigm Exp) : List AgrCell := p.map (·.1)
+
+end Paradigm
+
+end Syntax.Agreement

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4590,6 +4590,22 @@
   validated = {true},
   sources   = {Syntax/Agreement/Basic.lean;Studies/Corbett2000.lean}
 }
+@incollection{corbett-1998,
+  author    = {Corbett, Greville G.},
+  year      = {1998},
+  title     = {Morphology and Agreement},
+  booktitle = {The Handbook of Morphology},
+  editor    = {Spencer, Andrew and Zwicky, Arnold M.},
+  pages     = {191--205},
+  publisher = {Blackwell},
+  address   = {Oxford},
+  isbn      = {9780631226949},
+  subfield  = {typology/agreement},
+  role      = {cited},
+  validated = {true},
+  sources   = {Syntax/Agreement/Paradigm.lean}
+}
+
 @book{corbett-2006,
   author    = {Corbett, Greville G.},
   year      = {2006},


### PR DESCRIPTION
Agreement morphology and pronouns are one φ-system (@cite{corbett-1998}: agreement in the wide sense includes pronouns; the agreement features are person/number/gender, case excluded as government). So agreement paradigms should be keyed by the *same* canonical φ a pronoun carries — not a parallel per-language person/number enum.

- `Syntax/Agreement/Paradigm.lean`: theory-neutral `AgrCell` (canonical `UD` person/number/gender) + `Paradigm`/`realize` table + `Word.agrCell` projection, so a controller's φ indexes a paradigm directly. Syncretism recorded as a fact; the realizational account (DM impoverishment, etc.) is theory and stays in Studies.
- `Mayan/Params.lean`: `PersonNumber.toAgrCell` (the bridge connecting the pan-Mayan cell inventory to canonical φ) + generic `PersonNumber.paradigm`/`paradigm_realize` — so **every** Mayan language's `setAExponent`/`setBExponent` is canonical-φ-indexable, proven faithful once. No per-language code.
- `Mam`: `erg_1sg_from_phi` — a 1sg controller's φ selecting its ergative marker. Scott 2023's DM analysis stays in `Studies/Scott2023`.