### PR TITLE
refactor(Mayan): generic PersonNumber→canonical-φ paradigm lift

### DIFF
--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -439,44 +439,16 @@ theorem setB_1sg : setBExponent .p1sg = "chin" := rfl
 /-- Set B 3SG marker is the default "tz'=". -/
 theorem setB_3sg : setBExponent .p3sg = defaultSetB := rfl
 
--- ============================================================================
--- § Canonical-φ paradigm (descriptive, theory-neutral)
--- ============================================================================
-
-open Syntax.Agreement
-
-/-! The Set A / Set B tables above are keyed by the Mayan-specific `PersonNumber`
-enum. Re-stated here over the **canonical φ-cell** (`Syntax.Agreement.AgrCell` —
-the same `person × number` a `Pronoun`/`Word` carries, @cite{corbett-1998} §2),
-so a controller's φ (`Word.agrCell`) indexes the agreement paradigm directly:
-pronoun-φ and agreement-φ are one space (@cite{corbett-1998} §1; @cite{scott-2023}
-Ch. 2). Theory-neutral — the table records syncretism (t-, ky-, tz'=, chi) as a
-plain fact; the Distributed-Morphology account of it (impoverishment / Elsewhere;
-@cite{scott-2023} Ch. 4) is theory and lives in the study, not the fragment. -/
-
-/-- A Mayan `PersonNumber` as a canonical φ-cell (person × number). -/
-def pnCell : PersonNumber → AgrCell
-  | .p1sg => .pn .first .Sing  | .p2sg => .pn .second .Sing | .p3sg => .pn .third .Sing
-  | .p1pl => .pn .first .Plur  | .p2pl => .pn .second .Plur | .p3pl => .pn .third .Plur
-
-/-- Set A (ergative) as a descriptive paradigm over canonical φ-cells. -/
-def setAParadigm : Paradigm String :=
-  PersonNumber.all.map fun p => (pnCell p, setAExponent p)
-
-/-- Set B (absolutive) as a descriptive paradigm over canonical φ-cells. -/
-def setBParadigm : Paradigm String :=
-  PersonNumber.all.map fun p => (pnCell p, setBExponent p)
-
-/-- The canonical-φ paradigm agrees with the `PersonNumber`-keyed table. -/
-theorem setAParadigm_consistent (p : PersonNumber) :
-    setAParadigm.realize (pnCell p) = some (setAExponent p) := by
-  cases p <;> rfl
-
-/-- A controller's φ-features index the Set A paradigm directly: a 1sg agent
-    selects its first-person-singular ergative prefix — pronoun-φ driving
-    agreement realization in one shared feature space. -/
+/-- A controller's φ-features index the agreement paradigm directly: a 1sg agent
+    selects its first-person-singular ergative prefix. The Set A table
+    (`setAExponent`) lifts to canonical φ-cells via `PersonNumber.paradigm`, so a
+    pronoun's `Word.agrCell` drives agreement realization in one shared feature
+    space (@cite{corbett-1998}; @cite{scott-2023} Ch. 2). The realizational
+    account (impoverishment / Elsewhere; @cite{scott-2023} Ch. 4) is theory and
+    stays in the study. -/
 theorem erg_1sg_from_phi :
-    setAParadigm.realizeFor ⟨"", .PRON, { person := some .first, number := some .sg }⟩
-      = some "n-/w-" := by rfl
+    (PersonNumber.paradigm setAExponent).realizeFor
+      ⟨"", .PRON, { person := some .first, number := some .sg }⟩ = some "n-/w-" := by
+  rfl
 
 end Mam

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -2,6 +2,7 @@ import Linglib.Features.Case
 import Linglib.Core.UD
 import Linglib.Features.Prominence
 import Linglib.Syntax.Case.Alignment
+import Linglib.Syntax.Agreement.Paradigm
 
 /-!
 # Shared Mayan Fragment Infrastructure
@@ -360,6 +361,29 @@ def isPlural : PersonNumber → Bool
 /-- All six values, useful for `decide`-checked drift sentries. -/
 def all : List PersonNumber :=
   [.p1sg, .p2sg, .p3sg, .p1pl, .p2pl, .p3pl]
+
+/-- A Mayan `PersonNumber` as a canonical φ-cell (`Syntax.Agreement.AgrCell` —
+    person × number, the same φ a `Pronoun`/`Word` carries). The bridge that lets
+    the per-language Set A / Set B paradigms be keyed by canonical φ, so a
+    controller's φ (`Word.agrCell`) indexes them directly (@cite{corbett-1998}). -/
+def toAgrCell : PersonNumber → Syntax.Agreement.AgrCell
+  | .p1sg => .pn .first .Sing  | .p2sg => .pn .second .Sing | .p3sg => .pn .third .Sing
+  | .p1pl => .pn .first .Plur  | .p2pl => .pn .second .Plur | .p3pl => .pn .third .Plur
+
+/-- Lift a per-cell exponent function (a language's Set A / Set B table) to a
+    descriptive agreement paradigm keyed by canonical φ-cells. The one place the
+    `PersonNumber`-table-to-canonical-φ conversion lives; each language's
+    `setAParadigm`/`setBParadigm` is just `PersonNumber.paradigm setAExponent`. -/
+def paradigm (exp : PersonNumber → String) : Syntax.Agreement.Paradigm String :=
+  PersonNumber.all.map fun p => (p.toAgrCell, exp p)
+
+/-- Realizing a lifted paradigm at a cell recovers the exponent — for *any*
+    exponent function. Since the cell is canonical φ, a controller's
+    `Word.agrCell` indexes the paradigm directly (this is the unification, proven
+    once rather than per language). -/
+theorem paradigm_realize (exp : PersonNumber → String) (p : PersonNumber) :
+    (paradigm exp).realize p.toAgrCell = some (exp p) := by
+  cases p <;> rfl
 
 end PersonNumber
 


### PR DESCRIPTION
Follow-up to #84 (the per-language paradigm blocks were boilerplate). Factor the `PersonNumber`→canonical-φ conversion into one place: `PersonNumber.toAgrCell` (the bridge) + generic `PersonNumber.paradigm`/`paradigm_realize` in `Mayan/Params.lean`, proven faithful once for all Mayan languages. Mam trims to a single `erg_1sg_from_phi` demo; the other Mayan files need no per-language code.