### PR TITLE
refactor(Mayan): drop PersonNumber enum, key agreement by Agreement.Cell

### DIFF
--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -89,7 +89,8 @@ the agentive split. Future refinement: split into `intranSAgentive` /
 
 namespace Chol
 
-open Mayan (PersonNumber)
+open Mayan (ExponentTable)
+open Agreement
 
 -- ============================================================================
 -- § 1: Argument Positions (alias to canonical SAP type)
@@ -179,43 +180,31 @@ def absIntranSInNonFinite : Bool := false
     'in my coffee field' p. 76). Plural forms use the inclusive clitic
     `=la` for 1pl (the unmarked plural form per VA §4.2); the exclusive
     paradigm with `=l(oj)oñ` is a per-language refinement not exposed
-    by the pan-Mayan `PersonNumber` substrate. -/
-def setAExponentPreC : PersonNumber → String
-  | .p1sg => "k-"
-  | .p2sg => "a-"
-  | .p3sg => "i-"
-  | .p1pl => "k-…=la"
-  | .p2pl => "a-…=la"
-  | .p3pl => "i-…-ob"
+    by the canonical φ-cell `Agreement.Cell` substrate. -/
+def setAExponentPreC : ExponentTable :=
+  [(.pn .first .Sing, "k-"), (.pn .second .Sing, "a-"), (.pn .third .Sing, "i-"),
+   (.pn .first .Plur, "k-…=la"), (.pn .second .Plur, "a-…=la"), (.pn .third .Plur, "i-…-ob")]
 
 /-- Set A markers: pre-vocalic allomorphs (@cite{vazquez-alvarez-2011}
     Table 10, p. 83). 1sg `k-` is identical pre-C and pre-V; 2sg surfaces
     as `aw-`, 3sg as `(i)y-` (some speakers omit the initial vowel —
     @cite{vazquez-alvarez-2011} examples (12)-(13) p. 76-77). -/
-def setAExponentPreV : PersonNumber → String
-  | .p1sg => "k-"
-  | .p2sg => "aw-"
-  | .p3sg => "(i)y-"
-  | .p1pl => "k-…=la"
-  | .p2pl => "aw-…=la"
-  | .p3pl => "(i)y-…-ob"
+def setAExponentPreV : ExponentTable :=
+  [(.pn .first .Sing, "k-"), (.pn .second .Sing, "aw-"), (.pn .third .Sing, "(i)y-"),
+   (.pn .first .Plur, "k-…=la"), (.pn .second .Plur, "aw-…=la"), (.pn .third .Plur, "(i)y-…-ob")]
 
 /-- Canonical Set A exponent table for cross-Mayan typology. The
     pre-consonantal allomorph is the citation form (matching Q'anjob'al's
     convention); per-context realization uses `setAExponentPreV` before
     vowel-initial roots. -/
-abbrev setAExponent : PersonNumber → String := setAExponentPreC
+abbrev setAExponent : ExponentTable := setAExponentPreC
 
 /-- Set B (absolutive) markers: suffixes (@cite{vazquez-alvarez-2011}
     Table 10, p. 83). 3rd person is null (`-∅`). Plurals use the
     inclusive `=la` clitic for 1pl per the convention above. -/
-def setBExponent : PersonNumber → String
-  | .p1sg => "-oñ"
-  | .p2sg => "-ety"
-  | .p3sg => "-∅"
-  | .p1pl => "-oñ=la"
-  | .p2pl => "-ety=la"
-  | .p3pl => "-∅-ob"
+def setBExponent : ExponentTable :=
+  [(.pn .first .Sing, "-oñ"), (.pn .second .Sing, "-ety"), (.pn .third .Sing, "-∅"),
+   (.pn .first .Plur, "-oñ=la"), (.pn .second .Plur, "-ety=la"), (.pn .third .Plur, "-∅-ob")]
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches (Cholan, Q'anjob'alan, Tseltalan, K'ichean) per
@@ -223,7 +212,7 @@ def setBExponent : PersonNumber → String
     pan-Mayan: Mam's default Set B `tz'=` surfaces in the 3sg slot
     (@cite{scott-2023}), and `MayanLang.isStandard` excludes Mam from
     the relevant cross-Mayan theorem (`mayan_p3sg_abs_null`). -/
-theorem p3sg_abs_null : setBExponent .p3sg = "-∅" := rfl
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 
 /-- 3rd person Set A allomorphy: pre-consonantal `i-` vs pre-vocalic
     `(i)y-`. Distinct from Q'anjob'al's `s-` vs `y-` (the proto-Mayan
@@ -231,7 +220,8 @@ theorem p3sg_abs_null : setBExponent .p3sg = "-∅" := rfl
     and Chol inherited the leveled form per @cite{kaufman-norman-1984}
     p. 91). -/
 theorem p3sg_erg_allomorphy :
-    setAExponentPreC .p3sg = "i-" ∧ setAExponentPreV .p3sg = "(i)y-" :=
+    setAExponentPreC.realize (.pn .third .Sing) = some "i-" ∧
+    setAExponentPreV.realize (.pn .third .Sing) = some "(i)y-" :=
   ⟨rfl, rfl⟩
 
 end Chol

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -61,16 +61,17 @@ deliberately avoids picking sides on that question.
 
 namespace Kaqchikel
 
-open Mayan (PersonNumber)
+open Mayan (ExponentTable)
+open Agreement
 
 -- ============================================================================
 -- § 1: Person-Number Inventory
 -- ============================================================================
 
 -- Person-number combinations for Kaqchikel agreement paradigms come from
--- the pan-Mayan `Mayan.PersonNumber` enum (six cells: three
--- persons × two numbers). Projections `.person`, `.isPlural`, and the
--- full inventory `PersonNumber.all` live in `Mayan/Params.lean`.
+-- the canonical φ-cell `Agreement.Cell` (six cells: three persons × two
+-- numbers). Projections `.toPersonLevel`, `.isPlural`, and the inventory
+-- `Agreement.Cell.pnCells` live in `Syntax/Agreement/Paradigm.lean`.
 
 -- ============================================================================
 -- § 1b: ABS Position (LOW-ABS / HIGH-ABS)
@@ -89,13 +90,9 @@ def absPosition : Mayan.ABSPosition := .high
     transitive agent (@cite{preminger-2014} Ch. 3, table (29)).
     Parenthesized segments are dropped in certain phonological
     contexts; the grapheme *j* represents a voiceless velar fricative. -/
-def setAExponent : PersonNumber → String
-  | .p1sg => "n/w-"
-  | .p2sg => "a(w)-"
-  | .p3sg => "r(u)/u-"
-  | .p1pl => "q(a)-"
-  | .p2pl => "i(w)-"
-  | .p3pl => "k(i)-"
+def setAExponent : ExponentTable :=
+  [(.pn .first .Sing, "n/w-"), (.pn .second .Sing, "a(w)-"), (.pn .third .Sing, "r(u)/u-"),
+   (.pn .first .Plur, "q(a)-"), (.pn .second .Plur, "i(w)-"), (.pn .third .Plur, "k(i)-")]
 
 -- ============================================================================
 -- § 3: Set B (ABS) Vocabulary
@@ -105,13 +102,9 @@ def setAExponent : PersonNumber → String
     the absolutive argument. The 3SG form (∅) is
     also the Elsewhere entry — the default when no more specific entry
     matches, as in the failure case of obligatory agreement (Ch. 5). -/
-def setBExponent : PersonNumber → String
-  | .p1sg => "in-"
-  | .p2sg => "at-"
-  | .p3sg => "∅"
-  | .p1pl => "oj-"
-  | .p2pl => "ix-"
-  | .p3pl => "e-"
+def setBExponent : ExponentTable :=
+  [(.pn .first .Sing, "in-"), (.pn .second .Sing, "at-"), (.pn .third .Sing, "∅"),
+   (.pn .first .Plur, "oj-"), (.pn .second .Plur, "ix-"), (.pn .third .Plur, "e-")]
 
 -- ============================================================================
 -- § 4: Argument Positions (alias to canonical SAP type)
@@ -169,8 +162,8 @@ def kaqArgPositions : List ArgPosition := [.A, .P, .S]
     single agreement marker (or `none` for person-restriction
     violations). -/
 structure AFAgreementDatum where
-  subject : PersonNumber
-  object : PersonNumber
+  subject : Cell
+  object : Cell
   marker : Option String
   deriving Repr
 
@@ -184,27 +177,27 @@ structure AFAgreementDatum where
     test person restriction violations ((25)). -/
 def afParadigm : List AFAgreementDatum :=
   [ -- Table (22), rows 1–3: both 3rd person, number determines marker
-    ⟨.p3sg, .p3sg, some "∅"⟩         -- default: 3SG×3SG → ∅
-  , ⟨.p3pl, .p3sg, some "e-"⟩        -- [+plural] outranks default
-  , ⟨.p3pl, .p3pl, some "e-"⟩        -- [+plural] both → 3PL
+    ⟨.pn .third .Sing, .pn .third .Sing, some "∅"⟩         -- default: 3SG×3SG → ∅
+  , ⟨.pn .third .Plur, .pn .third .Sing, some "e-"⟩        -- [+plural] outranks default
+  , ⟨.pn .third .Plur, .pn .third .Plur, some "e-"⟩        -- [+plural] both → 3PL
     -- Table (22), rows 4–7: one [+participant] argument with 3SG
-  , ⟨.p1sg, .p3sg, some "in-"⟩       -- 1SG [+participant]
-  , ⟨.p2sg, .p3sg, some "at-"⟩       -- 2SG [+participant]
-  , ⟨.p1pl, .p3sg, some "oj-"⟩       -- 1PL [+participant]
-  , ⟨.p2pl, .p3sg, some "ix-"⟩       -- 2PL [+participant]
+  , ⟨.pn .first .Sing, .pn .third .Sing, some "in-"⟩       -- 1SG [+participant]
+  , ⟨.pn .second .Sing, .pn .third .Sing, some "at-"⟩      -- 2SG [+participant]
+  , ⟨.pn .first .Plur, .pn .third .Sing, some "oj-"⟩       -- 1PL [+participant]
+  , ⟨.pn .second .Plur, .pn .third .Sing, some "ix-"⟩      -- 2PL [+participant]
     -- Table (22), rows 8–11: [+participant] outranks [+plural]
-  , ⟨.p1sg, .p3pl, some "in-"⟩       -- 1SG participant > 3PL plural
-  , ⟨.p2sg, .p3pl, some "at-"⟩       -- 2SG participant > 3PL plural
-  , ⟨.p1pl, .p3pl, some "oj-"⟩       -- 1PL participant > 3PL plural
-  , ⟨.p2pl, .p3pl, some "ix-"⟩       -- 2PL participant > 3PL plural
+  , ⟨.pn .first .Sing, .pn .third .Plur, some "in-"⟩       -- 1SG participant > 3PL plural
+  , ⟨.pn .second .Sing, .pn .third .Plur, some "at-"⟩      -- 2SG participant > 3PL plural
+  , ⟨.pn .first .Plur, .pn .third .Plur, some "oj-"⟩       -- 1PL participant > 3PL plural
+  , ⟨.pn .second .Plur, .pn .third .Plur, some "ix-"⟩      -- 2PL participant > 3PL plural
     -- Commutativity (§3.2, fn. a): swapping subj/obj → same marker
-  , ⟨.p3sg, .p3pl, some "e-"⟩        -- = {3PL, 3SG} swapped
-  , ⟨.p3sg, .p1sg, some "in-"⟩       -- = {1SG, 3SG} swapped
-  , ⟨.p3sg, .p2sg, some "at-"⟩       -- = {2SG, 3SG} swapped
-  , ⟨.p3pl, .p2sg, some "at-"⟩       -- = {2SG, 3PL} swapped
+  , ⟨.pn .third .Sing, .pn .third .Plur, some "e-"⟩        -- = {3PL, 3SG} swapped
+  , ⟨.pn .third .Sing, .pn .first .Sing, some "in-"⟩       -- = {1SG, 3SG} swapped
+  , ⟨.pn .third .Sing, .pn .second .Sing, some "at-"⟩      -- = {2SG, 3SG} swapped
+  , ⟨.pn .third .Plur, .pn .second .Sing, some "at-"⟩      -- = {2SG, 3PL} swapped
     -- Person restriction violations (25)
-  , ⟨.p1sg, .p2sg, none⟩             -- *two [+participant] args
-  , ⟨.p2sg, .p1sg, none⟩             -- *two [+participant] args
+  , ⟨.pn .first .Sing, .pn .second .Sing, none⟩            -- *two [+participant] args
+  , ⟨.pn .second .Sing, .pn .first .Sing, none⟩            -- *two [+participant] args
   ]
 
 -- ============================================================================

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -352,7 +352,8 @@ theorem pronoun_setB_correspondence :
 -- § 12: Cross-Mayan Canonical Wrappers
 -- ============================================================================
 
-open Mayan (PersonNumber MarkerLinearity)
+open Mayan (MarkerLinearity ExponentTable)
+open Agreement
 
 /-- K'iche' is HIGH-ABS: Set B markers appear pre-stem on Infl. -/
 def absPosition : Mayan.ABSPosition := .high
@@ -364,28 +365,29 @@ def setALinearity : MarkerLinearity := .prefixal
 def setBLinearity : MarkerLinearity := .prefixal
 
 /-- Canonical Set A exponent table (pre-consonantal allomorph; informal),
-    keyed on `Mayan.PersonNumber` for cross-Mayan consumption. -/
-def setAExponent : PersonNumber → String
-  | .p1sg => setAPreC (phi .first  .Sing)
-  | .p2sg => setAPreC (phi .second .Sing)
-  | .p3sg => setAPreC (phi .third  .Sing)
-  | .p1pl => setAPreC (phi .first  .Plur)
-  | .p2pl => setAPreC (phi .second .Plur)
-  | .p3pl => setAPreC (phi .third  .Plur)
+    keyed on the canonical φ-cell `Agreement.Cell` for cross-Mayan consumption. -/
+def setAExponent : ExponentTable :=
+  [(.pn .first .Sing, setAPreC (phi .first  .Sing)),
+   (.pn .second .Sing, setAPreC (phi .second .Sing)),
+   (.pn .third .Sing, setAPreC (phi .third  .Sing)),
+   (.pn .first .Plur, setAPreC (phi .first  .Plur)),
+   (.pn .second .Plur, setAPreC (phi .second .Plur)),
+   (.pn .third .Plur, setAPreC (phi .third  .Plur))]
 
-/-- Canonical Set B exponent table (informal) keyed on `Mayan.PersonNumber`. -/
-def setBExponent : PersonNumber → String
-  | .p1sg => setBMarker (phi .first  .Sing)
-  | .p2sg => setBMarker (phi .second .Sing)
-  | .p3sg => setBMarker (phi .third  .Sing)
-  | .p1pl => setBMarker (phi .first  .Plur)
-  | .p2pl => setBMarker (phi .second .Plur)
-  | .p3pl => setBMarker (phi .third  .Plur)
+/-- Canonical Set B exponent table (informal) keyed on the canonical φ-cell
+    `Agreement.Cell`. -/
+def setBExponent : ExponentTable :=
+  [(.pn .first .Sing, setBMarker (phi .first  .Sing)),
+   (.pn .second .Sing, setBMarker (phi .second .Sing)),
+   (.pn .third .Sing, setBMarker (phi .third  .Sing)),
+   (.pn .first .Plur, setBMarker (phi .first  .Plur)),
+   (.pn .second .Plur, setBMarker (phi .second .Plur)),
+   (.pn .third .Plur, setBMarker (phi .third  .Plur))]
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per @cite{kaufman-norman-1984} Table 8. **Not**
     pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
-theorem p3sg_abs_null : setBExponent .p3sg = "∅" := rfl
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "∅" := rfl
 
 /-- K'iche''s extraction profile: Agent-Focus Antipassive is productive
     (@cite{mondloch-2017} Lesson 22, with parallel coverage at Lessons

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -75,16 +75,17 @@ with neutral patterns in dependent clauses (England 1983b;
 
 namespace Mam
 
-open Mayan (PersonNumber MarkerLinearity)
+open Mayan (MarkerLinearity ExponentTable)
+open Agreement
 
 -- ============================================================================
 -- § 1: Person-Number Inventory
 -- ============================================================================
 
--- Person-number values come from the pan-Mayan `Mayan.PersonNumber`
--- enum (six cells: three persons × two numbers). Projections `.person`,
--- `.isPlural`, and the full inventory `PersonNumber.all` live in
--- `Mayan/Params.lean`.
+-- Person-number values are the canonical φ-cells `Agreement.Cell`
+-- (six relevant cells: three persons × two numbers). Build them with
+-- `Agreement.Cell.pn` (e.g. `.pn .first .Sing`); the six-cell inventory
+-- is `Agreement.Cell.pnCells`.
 
 -- ============================================================================
 -- § 2: Agreement Marker Paradigms (theory-neutral)
@@ -94,13 +95,9 @@ open Mayan (PersonNumber MarkerLinearity)
     cross-reference the transitive agent (@cite{scott-2023}, Table 2.8).
     All six cells have distinct exponents (with t- syncretism for 2sg/3sg
     and ky- syncretism for 2pl/3pl). -/
-def setAExponent : PersonNumber → String
-  | .p1sg => "n-/w-"
-  | .p2sg => "t-"
-  | .p3sg => "t-"
-  | .p1pl => "q-"
-  | .p2pl => "ky-"
-  | .p3pl => "ky-"
+def setAExponent : ExponentTable :=
+  [(.pn .first .Sing, "n-/w-"), (.pn .second .Sing, "t-"), (.pn .third .Sing, "t-"),
+   (.pn .first .Plur, "q-"), (.pn .second .Plur, "ky-"), (.pn .third .Plur, "ky-")]
 
 /-- Set B (ABS) markers per cell (@cite{scott-2023}, Table 3.5).
     The 2/3SG form tz'= is the **default** — it appears both for real
@@ -113,19 +110,15 @@ def setAExponent : PersonNumber → String
     should treat them as derived from the Elsewhere entry. See
     `setBSpecificCells` for the cells that have actual specific
     Vocabulary Items in the DM analysis. -/
-def setBExponent : PersonNumber → String
-  | .p1sg => "chin"
-  | .p2sg => "tz'="
-  | .p3sg => "tz'="
-  | .p1pl => "qo"
-  | .p2pl => "chi"
-  | .p3pl => "chi"
+def setBExponent : ExponentTable :=
+  [(.pn .first .Sing, "chin"), (.pn .second .Sing, "tz'="), (.pn .third .Sing, "tz'="),
+   (.pn .first .Plur, "qo"), (.pn .second .Plur, "chi"), (.pn .third .Plur, "chi")]
 
 /-- The four Set B cells that have specific Vocabulary Items (per
     Scott's DM analysis). 2sg and 3sg are NOT included — they fall
     through to the Elsewhere entry. -/
-def setBSpecificCells : List PersonNumber :=
-  [.p1sg, .p1pl, .p2pl, .p3pl]
+def setBSpecificCells : List Cell :=
+  [.pn .first .Sing, .pn .first .Plur, .pn .second .Plur, .pn .third .Plur]
 
 /-- The default (Elsewhere) Set B marker. Surfaces in transitives when
     Infl's probe is blocked, and also for 2/3SG intransitive S. -/
@@ -428,26 +421,25 @@ def extractionProfile : Typology.ExtractionProfile :=
 -- ============================================================================
 
 /-- Set A 1SG marker. -/
-theorem setA_1sg : setAExponent .p1sg = "n-/w-" := rfl
+theorem setA_1sg : setAExponent.realize (.pn .first .Sing) = some "n-/w-" := rfl
 
 /-- Set A 3SG marker is "t-" (the default singular Set A — syncretic with 2SG). -/
-theorem setA_3sg : setAExponent .p3sg = "t-" := rfl
+theorem setA_3sg : setAExponent.realize (.pn .third .Sing) = some "t-" := rfl
 
 /-- Set B 1SG marker is "chin". -/
-theorem setB_1sg : setBExponent .p1sg = "chin" := rfl
+theorem setB_1sg : setBExponent.realize (.pn .first .Sing) = some "chin" := rfl
 
 /-- Set B 3SG marker is the default "tz'=". -/
-theorem setB_3sg : setBExponent .p3sg = defaultSetB := rfl
+theorem setB_3sg : setBExponent.realize (.pn .third .Sing) = some defaultSetB := rfl
 
 /-- A controller's φ-features index the agreement paradigm directly: a 1sg agent
     selects its first-person-singular ergative prefix. The Set A table
-    (`setAExponent`) lifts to canonical φ-cells via `PersonNumber.paradigm`, so a
-    pronoun's `Word.agrCell` drives agreement realization in one shared feature
-    space (@cite{corbett-1998}; @cite{scott-2023} Ch. 2). The realizational
-    account (impoverishment / Elsewhere; @cite{scott-2023} Ch. 4) is theory and
-    stays in the study. -/
+    (`setAExponent`) is keyed by canonical φ-cells, so a pronoun's `Word.agrCell`
+    drives agreement realization in one shared feature space (@cite{corbett-1998};
+    @cite{scott-2023} Ch. 2). The realizational account (impoverishment /
+    Elsewhere; @cite{scott-2023} Ch. 4) is theory and stays in the study. -/
 theorem erg_1sg_from_phi :
-    (PersonNumber.paradigm setAExponent).realizeFor
+    setAExponent.realizeFor
       ⟨"", .PRON, { person := some .first, number := some .sg }⟩ = some "n-/w-" := by
   rfl
 

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -41,6 +41,8 @@ to intransitive subjects (via Infl⁰).
 
 namespace Mayan
 
+open Agreement
+
 -- ============================================================================
 -- § 1: Mayan Absolutive Parameter (observable)
 -- ============================================================================
@@ -331,61 +333,15 @@ abbrev ergCaseTseltalan : Features.Prominence.ArgumentRole → Features.Case :=
 -- § 5: Person-Number Paradigm
 -- ============================================================================
 
-/-- The pan-Mayan person/number agreement paradigm.
-
-    Six values cover the consensus across Cholan, K'ichean,
-    Q'anjob'alan, and Tseltalan agreement morphology
-    (@cite{kaufman-norman-1984} Tables 7-8 reconstruct this paradigm
-    to proto-Cholan with `-∅` 3sg invariant). Languages with an
-    inclusive/exclusive distinction in 1pl (Chol's `-on lojon` 1plExcl
-    per @cite{kaufman-norman-1984} p. 91) accommodate the refinement
-    at the per-language level. -/
-inductive PersonNumber where
-  | p1sg | p2sg | p3sg
-  | p1pl | p2pl | p3pl
-  deriving DecidableEq, Repr
-
-namespace PersonNumber
-
-/-- Project the person component (independent of number). -/
-def person : PersonNumber → Features.Prominence.PersonLevel
-  | .p1sg | .p1pl => .first
-  | .p2sg | .p2pl => .second
-  | .p3sg | .p3pl => .third
-
-/-- Is this a plural form? -/
-def isPlural : PersonNumber → Bool
-  | .p1sg | .p2sg | .p3sg => false
-  | .p1pl | .p2pl | .p3pl => true
-
-/-- All six values, useful for `decide`-checked drift sentries. -/
-def all : List PersonNumber :=
-  [.p1sg, .p2sg, .p3sg, .p1pl, .p2pl, .p3pl]
-
-/-- A Mayan `PersonNumber` as a canonical φ-cell (`Agreement.Cell` —
-    person × number, the same φ a `Pronoun`/`Word` carries). The bridge that lets
-    the per-language Set A / Set B paradigms be keyed by canonical φ, so a
-    controller's φ (`Word.agrCell`) indexes them directly (@cite{corbett-1998}). -/
-def toAgrCell : PersonNumber → Agreement.Cell
-  | .p1sg => .pn .first .Sing  | .p2sg => .pn .second .Sing | .p3sg => .pn .third .Sing
-  | .p1pl => .pn .first .Plur  | .p2pl => .pn .second .Plur | .p3pl => .pn .third .Plur
-
-/-- Lift a per-cell exponent function (a language's Set A / Set B table) to a
-    descriptive agreement paradigm keyed by canonical φ-cells. The one place the
-    `PersonNumber`-table-to-canonical-φ conversion lives; each language's
-    `setAParadigm`/`setBParadigm` is just `PersonNumber.paradigm setAExponent`. -/
-def paradigm (exp : PersonNumber → String) : Agreement.Paradigm String :=
-  PersonNumber.all.map fun p => (p.toAgrCell, exp p)
-
-/-- Realizing a lifted paradigm at a cell recovers the exponent — for *any*
-    exponent function. Since the cell is canonical φ, a controller's
-    `Word.agrCell` indexes the paradigm directly (this is the unification, proven
-    once rather than per language). -/
-theorem paradigm_realize (exp : PersonNumber → String) (p : PersonNumber) :
-    (paradigm exp).realize p.toAgrCell = some (exp p) := by
-  cases p <;> rfl
-
-end PersonNumber
+/-! The pan-Mayan person/number agreement paradigm is keyed by the canonical
+    φ-cell `Agreement.Cell` (the same φ a `Pronoun`/`Word` carries): the six
+    cells covering the cross-Mayan consensus (Cholan, K'ichean, Q'anjob'alan,
+    Tseltalan; @cite{kaufman-norman-1984} Tables 7-8) are exactly
+    `Agreement.Cell.pnCells`. Per-language Set A / Set B tables are
+    `Agreement.Paradigm String` values constructed over those cells, so a
+    controller's `Word.agrCell` indexes them directly (@cite{corbett-1998}).
+    Languages with a 1pl inclusive/exclusive split (Chol's `-on lojon` 1plExcl,
+    @cite{kaufman-norman-1984} p. 91) refine at the per-language level. -/
 
 -- ============================================================================
 -- § 6: Verb Form (transitive vs Agent Focus)
@@ -411,10 +367,11 @@ def VerbForm.hasSetA : VerbForm → Bool
 -- § 7: Exponent Tables
 -- ============================================================================
 
-/-- An exponent table mapping each person/number value to its surface
-    string realization. Per-language `setAExponent` and `setBExponent`
-    populate this; cross-Mayan typology theorems quantify over it. -/
-abbrev ExponentTable := PersonNumber → String
+/-- An exponent table: a descriptive agreement paradigm over canonical φ-cells
+    (`Agreement.Cell`), mapping each person/number cell to its surface string.
+    Per-language `setAExponent`/`setBExponent` populate this; cross-Mayan
+    typology theorems quantify over it. -/
+abbrev ExponentTable := Agreement.Paradigm String
 
 /-- Decidable predicate: the third-person singular slot is morphologically
     null. An invariant of the **standard** Mayan branches per
@@ -431,7 +388,9 @@ abbrev ExponentTable := PersonNumber → String
     disjunction form is kernel-decidable (unlike a `String.replace`
     normalization, which is opaque to `decide`). -/
 def ExponentTable.IsThirdSgZero (e : ExponentTable) : Prop :=
-  e .p3sg = "-∅" ∨ e .p3sg = "∅" ∨ e .p3sg = "∅-"
+  e.realize (.pn .third .Sing) = some "-∅" ∨
+  e.realize (.pn .third .Sing) = some "∅" ∨
+  e.realize (.pn .third .Sing) = some "∅-"
 
 instance (e : ExponentTable) : Decidable e.IsThirdSgZero := by
   unfold ExponentTable.IsThirdSgZero; exact inferInstance

--- a/Linglib/Fragments/Mayan/Qanjobal/AgentFocus.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/AgentFocus.lean
@@ -56,10 +56,10 @@ namespace Qanjobal
 
 open Minimalist
 
--- Person-number paradigm and Set A / Set B exponent tables
--- (`PersonNumber`, `setAExponent`, `setAExponentPreC`, `setAExponentPreV`,
--- `setBExponent`) live in Qanjobal/Agreement.lean — agreement morphology
--- is general, not AF-specific.
+-- Person-number paradigm (keyed by the canonical φ-cell `Agreement.Cell`)
+-- and Set A / Set B exponent tables (`setAExponent`, `setAExponentPreC`,
+-- `setAExponentPreV`, `setBExponent`) live in Qanjobal/Agreement.lean —
+-- agreement morphology is general, not AF-specific.
 
 -- ============================================================================
 -- § 1: Status Suffixes

--- a/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
@@ -70,7 +70,8 @@ language family.
 
 namespace Qanjobal
 
-open Mayan (PersonNumber)
+open Mayan (ExponentTable)
+open Agreement
 
 -- ============================================================================
 -- § 1: Argument Positions (alias to canonical SAP type)
@@ -107,44 +108,33 @@ def absPosition : Mayan.ABSPosition := .high
 
 /-- Set A (ergative/possessive) markers: pre-consonantal allomorphs
     (@cite{coon-mateo-pedro-preminger-2014} table (13)). -/
-def setAExponentPreC : PersonNumber → String
-  | .p1sg => "hin-"
-  | .p2sg => "ha-"
-  | .p3sg => "s-"
-  | .p1pl => "ko-"
-  | .p2pl => "he-"
-  | .p3pl => "s-…heb'"
+def setAExponentPreC : ExponentTable :=
+  [(.pn .first .Sing, "hin-"), (.pn .second .Sing, "ha-"), (.pn .third .Sing, "s-"),
+   (.pn .first .Plur, "ko-"), (.pn .second .Plur, "he-"), (.pn .third .Plur, "s-…heb'")]
 
 /-- Set A (ergative/possessive) markers: pre-vocalic allomorphs
     (@cite{coon-mateo-pedro-preminger-2014} table (13)). -/
-def setAExponentPreV : PersonNumber → String
-  | .p1sg => "w-"
-  | .p2sg => "h-"
-  | .p3sg => "y-"
-  | .p1pl => "j-"
-  | .p2pl => "hey-"
-  | .p3pl => "y-…heb'"
+def setAExponentPreV : ExponentTable :=
+  [(.pn .first .Sing, "w-"), (.pn .second .Sing, "h-"), (.pn .third .Sing, "y-"),
+   (.pn .first .Plur, "j-"), (.pn .second .Plur, "hey-"), (.pn .third .Plur, "y-…heb'")]
 
 /-- Canonical Set A exponent table for cross-Mayan typology. The
     pre-consonantal allomorph is the citation form; per-context
     realization uses `setAExponentPreV` before vowels. -/
-abbrev setAExponent : PersonNumber → String := setAExponentPreC
+abbrev setAExponent : ExponentTable := setAExponentPreC
 
 /-- Set B (absolutive) markers: suffixes
     (@cite{coon-mateo-pedro-preminger-2014} table (13)). -/
-def setBExponent : PersonNumber → String
-  | .p1sg => "-in"
-  | .p2sg => "-ach"
-  | .p3sg => "-∅"
-  | .p1pl => "-on"
-  | .p2pl => "-ex"
-  | .p3pl => "heb'"
+def setBExponent : ExponentTable :=
+  [(.pn .first .Sing, "-in"), (.pn .second .Sing, "-ach"), (.pn .third .Sing, "-∅"),
+   (.pn .first .Plur, "-on"), (.pn .second .Plur, "-ex"), (.pn .third .Plur, "heb'")]
 
 /-- 3rd person absolutive is null (∅). -/
-theorem p3sg_abs_null : setBExponent .p3sg = "-∅" := rfl
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 
 /-- 3rd person ergative (pre-vocalic) is *y-*, pre-consonantal is *s-*. -/
 theorem p3sg_erg_allomorphy :
-    setAExponentPreC .p3sg = "s-" ∧ setAExponentPreV .p3sg = "y-" := ⟨rfl, rfl⟩
+    setAExponentPreC.realize (.pn .third .Sing) = some "s-" ∧
+    setAExponentPreV.realize (.pn .third .Sing) = some "y-" := ⟨rfl, rfl⟩
 
 end Qanjobal

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -35,7 +35,8 @@ Set A indicates A; Set B indicates S and P alike.
 
 namespace Tseltal
 
-open Mayan (MarkerSet PersonNumber MarkerLinearity)
+open Mayan (MarkerSet MarkerLinearity ExponentTable)
+open Agreement
 
 -- Re-export shared Tseltalan types
 export Mayan.Tseltalan (GramFunction)
@@ -91,28 +92,20 @@ def setBLinearity : MarkerLinearity := .suffixal
 /-- Set A (ERG/GEN) exponents for Oxchuc Tseltal (@cite{polian-2013}).
     Prefixes on the verb or possessed noun. Forms shown as
     `pre-C/pre-V` allomorph pairs. -/
-def setAExponent : PersonNumber → String
-  | .p1sg => "k-/j-"
-  | .p2sg => "a-/aw-"
-  | .p3sg => "s-/y-"
-  | .p1pl => "k-/j-"
-  | .p2pl => "a-/aw-"
-  | .p3pl => "s-/y-"
+def setAExponent : ExponentTable :=
+  [(.pn .first .Sing, "k-/j-"), (.pn .second .Sing, "a-/aw-"), (.pn .third .Sing, "s-/y-"),
+   (.pn .first .Plur, "k-/j-"), (.pn .second .Plur, "a-/aw-"), (.pn .third .Plur, "s-/y-")]
 
 /-- Set B (ABS) exponents for Oxchuc Tseltal (@cite{polian-2013}).
     Suffixes on the verb stem. 3rd person singular is null (`-∅`). -/
-def setBExponent : PersonNumber → String
-  | .p1sg => "-on"
-  | .p2sg => "-at"
-  | .p3sg => "-∅"
-  | .p1pl => "-otik"
-  | .p2pl => "-ex"
-  | .p3pl => "-ik"
+def setBExponent : ExponentTable :=
+  [(.pn .first .Sing, "-on"), (.pn .second .Sing, "-at"), (.pn .third .Sing, "-∅"),
+   (.pn .first .Plur, "-otik"), (.pn .second .Plur, "-ex"), (.pn .third .Plur, "-ik")]
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per @cite{kaufman-norman-1984} Table 8. **Not**
     pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
-theorem p3sg_abs_null : setBExponent .p3sg = "-∅" := rfl
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 
 /-- Tseltal Set B differs from Tsotsil in linearity (suffixal vs
     prefixal-or-suffixal); the marker set assignment is identical. -/

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -34,7 +34,8 @@ aspect-conditioned split (in contrast with Cholan; per @cite{polian-2013}).
 
 namespace Tsotsil
 
-open Mayan (MarkerSet PersonNumber MarkerLinearity)
+open Mayan (MarkerSet MarkerLinearity ExponentTable)
+open Agreement
 
 -- Re-export shared Tseltalan types
 export Mayan.Tseltalan (GramFunction)
@@ -94,29 +95,21 @@ def setBLinearity : MarkerLinearity := .either
     (@cite{polian-2013}). Prefixes on the verb (for ERG) or the possessed
     noun (for GEN). Forms vary by following segment; shown as
     `pre-C/pre-V` allomorph pairs. -/
-def setAExponent : PersonNumber → String
-  | .p1sg => "k-/j-"
-  | .p2sg => "a-/av-"
-  | .p3sg => "s-/y-"
-  | .p1pl => "k-/j-"
-  | .p2pl => "a-/av-"
-  | .p3pl => "s-/y-"
+def setAExponent : ExponentTable :=
+  [(.pn .first .Sing, "k-/j-"), (.pn .second .Sing, "a-/av-"), (.pn .third .Sing, "s-/y-"),
+   (.pn .first .Plur, "k-/j-"), (.pn .second .Plur, "a-/av-"), (.pn .third .Plur, "s-/y-")]
 
 /-- Set B (ABS) exponents for Zinacantec Tsotsil (@cite{polian-2013}).
     3rd person singular has no overt exponent (`-∅`). Some forms show
     allomorphic alternation depending on suffix harmony. -/
-def setBExponent : PersonNumber → String
-  | .p1sg => "-on/-un"
-  | .p2sg => "-ot/-at"
-  | .p3sg => "-∅"
-  | .p1pl => "-otik/-utik"
-  | .p2pl => "-oxuk"
-  | .p3pl => "-ik"
+def setBExponent : ExponentTable :=
+  [(.pn .first .Sing, "-on/-un"), (.pn .second .Sing, "-ot/-at"), (.pn .third .Sing, "-∅"),
+   (.pn .first .Plur, "-otik/-utik"), (.pn .second .Plur, "-oxuk"), (.pn .third .Plur, "-ik")]
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per @cite{kaufman-norman-1984} Table 8. **Not**
     pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
-theorem p3sg_abs_null : setBExponent .p3sg = "-∅" := rfl
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 
 -- ============================================================================
 -- § 5: Extraction Profile

--- a/Linglib/Phenomena/Ergativity/MayanAlignment.lean
+++ b/Linglib/Phenomena/Ergativity/MayanAlignment.lean
@@ -44,7 +44,7 @@ empirical literature, not an editorial synthesis.
 
 namespace Phenomena.Ergativity.MayanAlignment
 
-open Mayan (MayanLang PersonNumber MarkerLinearity ABSPosition)
+open Mayan (MayanLang MarkerLinearity ABSPosition)
 
 -- ============================================================================
 -- § 1: Per-Language Dispatchers

--- a/Linglib/Studies/Aissen2003Agreement.lean
+++ b/Linglib/Studies/Aissen2003Agreement.lean
@@ -103,8 +103,9 @@ theorem kaqchikel_A_and_P_indexed :
     distinct: every person-number combination gets a unique marker in
     each set (except 3SG which is ∅ in Set B). -/
 theorem kaqchikel_dual_paradigms :
-    setAExponent .p1sg ≠ setBExponent .p1sg ∧
-    setAExponent .p2sg ≠ setBExponent .p2sg := by decide
+    setAExponent.realize (.pn .first .Sing) ≠ setBExponent.realize (.pn .first .Sing) ∧
+    setAExponent.realize (.pn .second .Sing) ≠ setBExponent.realize (.pn .second .Sing) := by
+  decide
 
 -- ============================================================================
 -- § 4: Kaqchikel Argument Roles ↔ Just's ArgumentRole

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -107,9 +107,9 @@ transitives + K'ichee' fragment + Zulu fragment) to formalize.
 
 namespace Preminger2014
 
-open Mayan (PersonNumber)
 open Kaqchikel
 open Minimalist
+open Agreement
 
 -- ============================================================================
 -- § 1: Feature Decomposition (grounded in PersonGeometry.lean)
@@ -117,28 +117,23 @@ open Minimalist
 
 /-- Bears [+participant]? Derived from @cite{harley-ritter-2002}'s
     feature geometry via `decomposePerson` (PersonGeometry.lean). -/
-def IsParticipant (pn : PersonNumber) : Prop :=
-  (decomposePerson pn.person).hasParticipant = true
+def IsParticipant (c : Agreement.Cell) : Prop :=
+  (decomposePerson c.toPersonLevel).hasParticipant = true
 
-instance : DecidablePred IsParticipant := fun pn =>
-  inferInstanceAs (Decidable ((decomposePerson pn.person).hasParticipant = true))
+instance : DecidablePred IsParticipant := fun c =>
+  inferInstanceAs (Decidable ((decomposePerson c.toPersonLevel).hasParticipant = true))
 
 /-- Bears [+author]? -/
-def IsAuthor (pn : PersonNumber) : Prop :=
-  (decomposePerson pn.person).hasAuthor = true
+def IsAuthor (c : Agreement.Cell) : Prop :=
+  (decomposePerson c.toPersonLevel).hasAuthor = true
 
-instance : DecidablePred IsAuthor := fun pn =>
-  inferInstanceAs (Decidable ((decomposePerson pn.person).hasAuthor = true))
+instance : DecidablePred IsAuthor := fun c =>
+  inferInstanceAs (Decidable ((decomposePerson c.toPersonLevel).hasAuthor = true))
 
 /-- Convert a person-number cell to a PhiFeature list for the Agree
     infrastructure. -/
-def toPhiFeatures : PersonNumber → List PhiFeature
-  | .p1sg => [.person .first, .number .sg]
-  | .p2sg => [.person .second, .number .sg]
-  | .p3sg => [.person .third, .number .sg]
-  | .p1pl => [.person .first, .number .pl]
-  | .p2pl => [.person .second, .number .pl]
-  | .p3pl => [.person .third, .number .pl]
+def toPhiFeatures (c : Agreement.Cell) : List PhiFeature :=
+  [.person c.toPersonLevel, .number (if c.isPlural then .pl else .sg)]
 
 -- ============================================================================
 -- § 2: DM Vocabulary Insertion (@cite{halle-marantz-1993})
@@ -147,11 +142,13 @@ def toPhiFeatures : PersonNumber → List PhiFeature
 /-- Set A as DM Vocabulary entries, contextualized to Voice/v.
     Built via the shared `makePersonVocab` helper. -/
 def setAVocab : Vocabulary :=
-  makePersonVocab PersonNumber.all toPhiFeatures setAExponent (some .v)
+  makePersonVocab Agreement.Cell.pnCells toPhiFeatures
+    (fun c => (setAExponent.realize c).getD "") (some .v)
 
 /-- Set B as DM Vocabulary entries, contextualized to Infl/T. -/
 def setBVocab : Vocabulary :=
-  makePersonVocab PersonNumber.all toPhiFeatures setBExponent (some .T)
+  makePersonVocab Agreement.Cell.pnCells toPhiFeatures
+    (fun c => (setBExponent.realize c).getD "") (some .T)
 
 -- ============================================================================
 -- § 3: Two-Probe Relativized Probing (@cite{bejar-rezac-2003}, applied per §4.4)
@@ -161,8 +158,8 @@ def setBVocab : Vocabulary :=
     two-probe (π⁰ ≫ #⁰) system. Computed via `probeResolutionRank`
     on the cell's person + number features. NOT a salience scale —
     see module docstring. -/
-def afRank (pn : PersonNumber) : Nat :=
-  probeResolutionRank pn.person pn.isPlural
+def afRank (c : Agreement.Cell) : Nat :=
+  probeResolutionRank c.toPersonLevel c.isPlural
 
 /-- Person restriction (@cite{preminger-2014} (25)): at most one core
     argument can bear [+participant]. Derives from the Person
@@ -173,17 +170,17 @@ def afRank (pn : PersonNumber) : Nat :=
     only one can be licensed; the derivation crashes if both occur.
     This is the syntactic licensing story, not the morphological
     clitic-slot competition. -/
-def PersonRestrictionOk (subj obj : PersonNumber) : Prop :=
+def PersonRestrictionOk (subj obj : Agreement.Cell) : Prop :=
   ¬(IsParticipant subj ∧ IsParticipant obj)
 
-instance (subj obj : PersonNumber) : Decidable (PersonRestrictionOk subj obj) :=
+instance (subj obj : Agreement.Cell) : Decidable (PersonRestrictionOk subj obj) :=
   inferInstanceAs (Decidable (¬(IsParticipant subj ∧ IsParticipant obj)))
 
 /-- Compute the AF agreement target: the higher-ranked argument under
     the two-probe system. When both have equal rank, the subject is
     chosen (yielding the same marker either way). Returns `none` if
     the person restriction is violated. -/
-def afAgreementTarget (subj obj : PersonNumber) : Option PersonNumber :=
+def afAgreementTarget (subj obj : Agreement.Cell) : Option Agreement.Cell :=
   if PersonRestrictionOk subj obj then
     if afRank subj ≥ afRank obj then some subj else some obj
   else none
@@ -191,8 +188,8 @@ def afAgreementTarget (subj obj : PersonNumber) : Option PersonNumber :=
 /-- The AF agreement marker for a given subject-object combination:
     Set B exponent of the resolved target, or `none` for restriction
     violations. -/
-def afMarker (subj obj : PersonNumber) : Option String :=
-  (afAgreementTarget subj obj).map setBExponent
+def afMarker (subj obj : Agreement.Cell) : Option String :=
+  (afAgreementTarget subj obj).bind setBExponent.realize
 
 -- ============================================================================
 -- § 4: Verification — Grounding in PersonGeometry
@@ -204,15 +201,15 @@ def afMarker (subj obj : PersonNumber) : Option String :=
     theorems (per-cell-rfl-inflation anti-pattern). -/
 theorem feature_decomposition_correct :
     -- IsParticipant matches H&R 2002 + B&R 2003 expectations
-    IsParticipant .p1sg ∧
-    IsParticipant .p2sg ∧
-    ¬IsParticipant .p3sg ∧
-    ¬IsParticipant .p3pl ∧
+    IsParticipant (.pn .first .Sing) ∧
+    IsParticipant (.pn .second .Sing) ∧
+    ¬IsParticipant (.pn .third .Sing) ∧
+    ¬IsParticipant (.pn .third .Plur) ∧
     -- author entails participant (H&R 2002 containment)
-    (∀ pn ∈ PersonNumber.all, IsAuthor pn → IsParticipant pn) ∧
+    (∀ c ∈ Agreement.Cell.pnCells, IsAuthor c → IsParticipant c) ∧
     -- two-probe ranks: [+participant] → 2, [+plural,−participant] → 1, 3SG → 0
-    afRank .p1sg = 2 ∧ afRank .p2sg = 2 ∧
-    afRank .p3pl = 1 ∧ afRank .p3sg = 0 := by
+    afRank (.pn .first .Sing) = 2 ∧ afRank (.pn .second .Sing) = 2 ∧
+    afRank (.pn .third .Plur) = 1 ∧ afRank (.pn .third .Sing) = 0 := by
   refine ⟨?_, ?_, ?_, ?_, ?_, rfl, rfl, rfl, rfl⟩
   all_goals decide
 
@@ -232,7 +229,7 @@ theorem af_paradigm_correct :
     relativized probing — the probes see both arguments
     symmetrically. -/
 theorem af_commutative :
-    PersonNumber.all.all (λ s => PersonNumber.all.all (λ o =>
+    Agreement.Cell.pnCells.all (λ s => Agreement.Cell.pnCells.all (λ o =>
       afMarker s o == afMarker o s)) = true := by
   decide
 
@@ -240,8 +237,8 @@ theorem af_commutative :
     argument is 1st/2nd and the other is 3PL, the marker reflects
     the participant (clitic-doubling output of π⁰), not the plural. -/
 theorem participant_over_plural :
-    afMarker .p1sg .p3pl = some "in-" ∧
-    afMarker .p3pl .p2sg = some "at-" :=
+    afMarker (.pn .first .Sing) (.pn .third .Plur) = some "in-" ∧
+    afMarker (.pn .third .Plur) (.pn .second .Sing) = some "at-" :=
   ⟨rfl, rfl⟩
 
 /-- PLC violation: two [+participant] arguments are blocked. Default
@@ -250,13 +247,13 @@ theorem participant_over_plural :
     signature of obligatory-but-failure-tolerant Agree
     (@cite{preminger-2014} Ch. 5). -/
 theorem restriction_and_default :
-    afMarker .p1sg .p2sg = none ∧
-    afMarker .p2sg .p1sg = none ∧
-    afMarker .p3sg .p3sg = some "∅" :=
+    afMarker (.pn .first .Sing) (.pn .second .Sing) = none ∧
+    afMarker (.pn .second .Sing) (.pn .first .Sing) = none ∧
+    afMarker (.pn .third .Sing) (.pn .third .Sing) = some "∅" :=
   ⟨rfl, rfl, rfl⟩
 
 /-- Person restriction is symmetric on the cells. -/
-theorem person_restriction_symmetric (s o : PersonNumber) :
+theorem person_restriction_symmetric (s o : Agreement.Cell) :
     PersonRestrictionOk s o ↔ PersonRestrictionOk o s := by
   unfold PersonRestrictionOk
   exact ⟨fun h ⟨h₁, h₂⟩ => h ⟨h₂, h₁⟩, fun h ⟨h₁, h₂⟩ => h ⟨h₂, h₁⟩⟩
@@ -276,9 +273,9 @@ theorem person_restriction_symmetric (s o : PersonNumber) :
     competition for 3pl+3pl). -/
 theorem ch7_arg3_participant_vs_plural_asymmetry :
     -- 1+2 is blocked (PLC violation)
-    afMarker .p1sg .p2sg = none ∧
+    afMarker (.pn .first .Sing) (.pn .second .Sing) = none ∧
     -- but 3pl+3pl is fine (no parallel licensing condition for #⁰)
-    afMarker .p3pl .p3pl = some "e-" :=
+    afMarker (.pn .third .Plur) (.pn .third .Plur) = some "e-" :=
   ⟨rfl, rfl⟩
 
 /-- @cite{preminger-2014} Ch 7 arg 4 smoke-check (p. 125–126,
@@ -296,15 +293,15 @@ theorem ch7_arg3_participant_vs_plural_asymmetry :
     awaits extending the fragment with strong pronouns and a
     suffix-stripping bridge function. -/
 theorem ch7_arg4_form_distinctness_smoke_check :
-    setBExponent .p1sg = "in-" ∧
-    setBExponent .p2sg = "at-" ∧
-    setBExponent .p1pl = "oj-" ∧
-    setBExponent .p2pl = "ix-" ∧
-    setBExponent .p3pl = "e-" ∧
-    setBExponent .p1sg ≠ setBExponent .p3pl ∧
-    setBExponent .p2sg ≠ setBExponent .p3pl ∧
-    setBExponent .p1pl ≠ setBExponent .p3pl ∧
-    setBExponent .p2pl ≠ setBExponent .p3pl :=
+    setBExponent.realize (.pn .first .Sing) = some "in-" ∧
+    setBExponent.realize (.pn .second .Sing) = some "at-" ∧
+    setBExponent.realize (.pn .first .Plur) = some "oj-" ∧
+    setBExponent.realize (.pn .second .Plur) = some "ix-" ∧
+    setBExponent.realize (.pn .third .Plur) = some "e-" ∧
+    setBExponent.realize (.pn .first .Sing) ≠ setBExponent.realize (.pn .third .Plur) ∧
+    setBExponent.realize (.pn .second .Sing) ≠ setBExponent.realize (.pn .third .Plur) ∧
+    setBExponent.realize (.pn .first .Plur) ≠ setBExponent.realize (.pn .third .Plur) ∧
+    setBExponent.realize (.pn .second .Plur) ≠ setBExponent.realize (.pn .third .Plur) :=
   ⟨rfl, rfl, rfl, rfl, rfl, by decide, by decide, by decide, by decide⟩
 
 end Preminger2014

--- a/Linglib/Studies/Scott2023Agreement.lean
+++ b/Linglib/Studies/Scott2023Agreement.lean
@@ -56,8 +56,8 @@ both paths.
 
 namespace Scott2023
 
-open Mayan (PersonNumber)
 open Minimalist Mam
+open Agreement
 
 -- ============================================================================
 -- § 0: Minimalism-Specific Vocabulary (Set A / Set B as VI entries)
@@ -70,19 +70,15 @@ open Minimalist Mam
     `FeatureBundle` and `Cat` for use with `spellout`. -/
 
 /-- PhiFeature list per Mam person-number cell. -/
-def mamToPhiFeatures : PersonNumber → List PhiFeature
-  | .p1sg => [.person .first, .number .sg]
-  | .p2sg => [.person .second, .number .sg]
-  | .p3sg => [.person .third, .number .sg]
-  | .p1pl => [.person .first, .number .pl]
-  | .p2pl => [.person .second, .number .pl]
-  | .p3pl => [.person .third, .number .pl]
+def mamToPhiFeatures (c : Agreement.Cell) : List PhiFeature :=
+  [.person c.toPersonLevel, .number (if c.isPlural then .pl else .sg)]
 
 /-- Set A (ERG) vocabulary entries: φ-features on Voice (.v)
     yield the morphological exponent (@cite{scott-2023} Table 2.8).
     All six cells have specific entries. -/
 def setAVocab : Vocabulary :=
-  makePersonVocab PersonNumber.all mamToPhiFeatures setAExponent (some .v)
+  makePersonVocab Agreement.Cell.pnCells mamToPhiFeatures
+    (fun c => (setAExponent.realize c).getD "") (some .v)
 
 /-- Set B (ABS) vocabulary entries: φ-features on Infl (.T)
     yield the morphological exponent (@cite{scott-2023} Table 3.5).
@@ -91,7 +87,8 @@ def setAVocab : Vocabulary :=
     (no features, tz'=) which surfaces when no specific entry
     matches — also catching the blocked-Infl-probe case in transitives. -/
 def setBVocab : Vocabulary :=
-  makePersonVocab setBSpecificCells mamToPhiFeatures setBExponent (some .T) ++
+  makePersonVocab setBSpecificCells mamToPhiFeatures
+    (fun c => (setBExponent.realize c).getD "") (some .T) ++
     [{ features := [], exponent := defaultSetB, context := some .T }]
 
 /-- Which Minimalist head φ-Agrees with each argument position.

--- a/Linglib/Syntax/Agreement/Paradigm.lean
+++ b/Linglib/Syntax/Agreement/Paradigm.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Word
+import Linglib.Features.Prominence
 
 /-!
 # Agreement paradigms — the descriptive realization table
@@ -60,6 +61,18 @@ def Cell.pn (p : UD.Person) (n : UD.Number) : Cell :=
     person-conditioned phenomena like differential indexing (@cite{corbett-1998}). -/
 def Cell.isSAP (c : Cell) : Bool :=
   c.person == some .first || c.person == some .second
+
+/-- The person level of a cell, on the `Features.Prominence.PersonLevel` scale
+    (an unspecified or 0-person cell maps to `.third`). Adapts a φ-cell to
+    consumers that reason on person prominence (decomposition, indexing). -/
+def Cell.toPersonLevel (c : Cell) : Features.Prominence.PersonLevel :=
+  match c.person with
+  | some .first => .first
+  | some .second => .second
+  | _ => .third
+
+/-- Is this a plural cell? -/
+def Cell.isPlural (c : Cell) : Bool := c.number == some .Plur
 
 /-- The basic 3-person × {singular, plural} inventory of φ-cells — the cells a
     person/number agreement paradigm ranges over. -/


### PR DESCRIPTION
Eliminates the pan-Mayan `PersonNumber` enum (and its parallel `person`/`isPlural`/`all`/`toAgrCell`/`paradigm` API); Mayan Set A/B paradigms and cross-Mayan typology now key directly off the canonical φ-cell `Agreement.Cell` (`ExponentTable := Agreement.Paradigm String`). Adds `Cell.toPersonLevel`/`Cell.isPlural` to the agreement substrate for the DM consumers (Preminger 2014, Scott 2023).