### PR TITLE
refactor(Negation): align fragments + substrate with mathlib conventions

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -597,6 +597,7 @@ import Linglib.Paradigms.WugTest
 import Linglib.Paradigms.AcceptabilityJudgment
 import Linglib.Paradigms.SelfPacedReading
 -- Fragments
+import Linglib.Fragments.Arabic.ModernStandard.Negation
 import Linglib.Fragments.Arabic.ModernStandard.Relativization
 import Linglib.Fragments.Arabic.Egyptian.Morph
 import Linglib.Fragments.Arabic.ModernStandard.Plurals

--- a/Linglib/Fragments/Arabic/ModernStandard/Negation.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Negation.lean
@@ -1,101 +1,39 @@
 import Linglib.Typology.Negation
 
 /-!
-# Modern Standard Arabic Negation
-@cite{ryding-2005} @cite{benmamoun-2000}
+# Modern Standard Arabic negation
 
-The MSA standard-negation system per @cite{ryding-2005} ch 37
-(pp. 641–656) and @cite{benmamoun-2000} ch 6 (pp. 94–109).
+The MSA standard-negation inventory — four preverbal particles (*laa*, *lam*,
+*lan*, *maa*) plus the inflecting copular verb *lays-a* 'to not be' — typed
+against `Typology.Negation` and bundled into a `NegationSystem` and a
+`NegationProfile`.
 
-## The five-marker inventory
+## Main definitions
 
-- *laa* لا — co-occurs with imperfective verbs (default present-tense
-  reading; Ryding §37.2.1.2). Also: stand-alone "no" (§37.2.1.1);
-  negative imperative with jussive (§37.2.1.5); reduplicated for
-  "neither…nor"; constituent negation as in *laa rajul-a fii d-daar-i*
-  'no man in the house' (Benmamoun §6.1.1, ex. 6, citing Moutaouakil
-  1993). The constituent-negation use is unavailable to *lam* and
-  *lan* — see Benmamoun §6.1.1 ex. 6b–c.
-- *lam* لمْ — co-occurs with past-tense reference; the verb appears
-  in the jussive (Ryding §37.2.2; pattern documented at §35.1).
-- *lan* لنْ — co-occurs with future-tense reference; the verb
-  appears in the subjunctive (Ryding §37.2.3 / §35.2).
-- *maa* ما — focal / literary past negation (Ryding §37.2.4;
-  Benmamoun §6.4).
-- *lays-a* ليس — inflecting verb 'not be'; sister of *kaan-a*; takes
-  its complement in the accusative (Ryding §37.1, p. 641). Carries
-  full person / number / gender agreement (paradigm at Benmamoun
-  §6.3, ex. 25, p. 102): *las-tu* 1SG, *las-ta* 2SG.M, *las-ti* 2SG.F,
-  *lays-a* 3SG.M, *lays-at* 3SG.F, *las-tumaa* 2DU, *lays-aa* 3DU.M,
-  *lays-ataa* 3DU.F, *las-naa* 1PL, *las-tum* 2PL.M, *las-tunna* 2PL.F,
-  *lays-uu* 3PL.M, *las-na* 3PL.F. Restricted to present-tense
-  interpretation; cannot co-occur with future or past-inflected verbs
-  (Benmamoun §6.3.3, p. 105, citing Fassi Fehri 1993:208 n25).
+* `negMarkers` — the five sentential negators.
+* `negationSystem` — markers plus WALS Ch 112A/143A/144A datapoints (`ofISO "arb"`).
+* `negationProfile` — the WALS Ch 112–115 typology coding.
 
-## Empirical distributional patterns
+## Implementation notes
 
-These are descriptive patterns documented in @cite{benmamoun-2000}
-ch 6 (the analytic apparatus — NegP, head movement, feature checking
-— is not adopted by this Fragment file):
+*lam* / *lan* condition a mood shift (jussive / subjunctive) on an otherwise
+finite verb, and *lays-a* supplies a finite copula where the affirmative is
+verbless — read here as Miestamo's A/Fin, extending it from a verb *losing*
+finiteness to a clause *gaining* it. So MSA negation is WALS Ch 113 `.both`
+(symmetric *laa* / *maa* plus asymmetric *lam* / *lan* / *lays-a*) with the
+Ch 114 `.finAndCat` subtype.
 
-- **Complementary distribution of tense exponence**: when the negative
-  inflects for tense (*lam*, *lan*), the verb cannot also inflect for
-  tense (Benmamoun §6.1.2, ex. 7–8): \**ṭ-ṭullaab-u lam ðahab-uu*
-  (both tense-marked) is ill-formed.
-- **Negative–verb adjacency**: no subject or adverb may intervene
-  between *lam* / *lan* and the verb they negate (Benmamoun §6.1.3,
-  ex. 12, citing Hassan 1973, Fassi Fehri 1993:164, Moutaouakil
-  1993:83, Shlonsky 1997:103).
-- **Verbless-sentence restriction**: *laa* / *lam* / *lan* cannot
-  occur in verbless (equational) sentences. Negating a past or future
-  copular sentence requires inserting *kaan-a* (Benmamoun §6.1.3
-  ex. 13–14, citing Fassi Fehri 1993:164 and Moutaouakil 1993:82–88).
-- **lays-a's distinctive properties**: unlike the other particles,
-  *lays-a* (a) is mobile (can be separated from the predicate by the
-  subject), (b) carries agreement, (c) appears in verbless sentences
-  with present-tense interpretation (Benmamoun §6.3, p. 102–104).
+MSA (`arb`) is absent from @cite{miestamo-2005} and from WALS Ch 113A/114A
+(which carry only Egyptian `arz`), so `symmetry` and `asymmetrySubtype` are a
+project-internal extrapolation, not Miestamo's own coding; the position fields
+(Ch 143A/144A) are WALS-pulled by `NegationSystem.ofISO`.
 
-## Asymmetry
+## References
 
-Standard MSA negation has **both symmetric and asymmetric**
-constructions (the WALS Ch 113 `.both` value). Symmetric branch:
-*laa* + present-tense indicative; *maa* + past-tense indicative.
-Asymmetric branch:
-
-- *lam* → jussive, *lan* → subjunctive (Ryding §35.1, §35.2): the
-  choice of negative marker conditions a paradigm-internal mood shift
-  on an otherwise finite verb (Miestamo's A/Cat — TAM-marking change).
-- *lays-a* introduces a finite copular verb where the affirmative
-  would be verbless (Ryding §37.1.2 p. 642): the negation introduces
-  finiteness where the affirmative has none (Miestamo's A/Fin —
-  finiteness change), parallel to Mandarin *méi(yǒu)* in
-  @cite{miestamo-2005} pp. 90–91.
-
-Combined, this places MSA in the WALS Ch 113 `.both` cell with the
-WALS Ch 114 `.finAndCat` subtype.
-
-**Note on source basis.** MSA (`arb`) is **not in** @cite{miestamo-2005}'s
-297-language sample (verified against the index of languages, pp. 470–476)
-and **not in** the WALS Ch 113A/114A datasets (which only carry the `aeg`
-row for `arz` Egyptian Arabic — classified there as `.symmetric` /
-`.nonAssignable`, since Egyptian *ma-…-š* doesn't trigger the mood shifts
-MSA's *lam*/*lan* do). The values populated below are therefore a
-project-internal extrapolation applying Miestamo's framework to the MSA
-data Ryding §37 + Benmamoun ch 6 describe; they should not be cited as
-Miestamo's own classification of MSA.
-
-## Out of scope
-
-- N-word / NPI behaviour of *ʾaḥad-un* 'anyone' under negation —
-  belongs in `Fragments/Arabic/ModernStandard/PolarityItems.lean` if
-  added later.
-- Exceptive *ʾillaa*, focal negation, constituent negation beyond the
-  *laa rajul-a* pattern noted above — Ryding §37.3 covers these but
-  they are not part of WALS Ch 112's "standard sentential negation"
-  target.
-- The dialectal *ma…š* bipartite negation of Egyptian / Moroccan
-  Arabic (Benmamoun ch 5) — belongs in
-  `Fragments/Arabic/Egyptian/Negation.lean` if added later.
+* @cite{ryding-2005} ch. 37: §37.1 *lays-a* (paradigm chart §37.1.1),
+  §37.2 the particles (*laa* §37.2.1, *lam* §37.2.2.1, *maa* §37.2.2.2,
+  *lan* §37.2.3); jussive §35.1, subjunctive §34.2.
+* @cite{benmamoun-2000} ch. 6.
 -/
 
 namespace Arabic.ModernStandard.Negation
@@ -103,9 +41,9 @@ namespace Arabic.ModernStandard.Negation
 open Typology.Negation
 
 /-- The five-marker inventory: *laa* (general / present), *lam* (past),
-    *lan* (future), *maa* (focal/literary past), *lays-a* (copular).
-    All four particles precede the verb; *lays-a* is itself a verb
-    inflecting for person/number/gender. Per Ryding ch 37. -/
+    *lan* (future), *maa* (past, colloquial-leaning), *lays-a* (copular). The
+    four particles precede the verb; *lays-a* is itself a verb inflecting for
+    person / number / gender. -/
 def negMarkers : List NegMarkerEntry :=
   [ { form := "laa"
     , gloss := "NEG.IPFV"
@@ -129,18 +67,13 @@ def negMarkers : List NegMarkerEntry :=
     , position := .preverbal }
   ]
 
-/-- Bundled `NegationSystem` (markers + WALS Ch 112A/143A/144A
-    datapoints pulled from `Data.WALS` by ISO code `arb`). -/
+/-- Bundled `NegationSystem` (markers + WALS Ch 112A/143A/144A datapoints
+    pulled from `Data.WALS` by ISO code `arb`). -/
 def negationSystem : NegationSystem :=
   NegationSystem.ofISO "arb" negMarkers
 
-/-- WALS-typology bundle. The marker classification at `morphemeType`
-    privileges the *laa* / *lam* / *lan* / *maa* particles (the
-    productive sentential negators on finite verbs) over the verbal
-    *lays-a*; the asymmetry comes from the tense/mood-conditioned
-    alternation. Per Ryding §37 + Benmamoun ch 6 + the Miestamo
-    construction-typology framing in
-    `Studies/Miestamo2005.lean`. -/
+/-- Modern Standard Arabic negation profile (WALS Ch 112-115 + Greco/JinKoenig
+    fields); see the module docstring for the `.both` / `.finAndCat` rationale. -/
 def negationProfile : NegationProfile :=
   { language := "Arabic (Modern Standard)"
   , iso := "arb"
@@ -148,7 +81,7 @@ def negationProfile : NegationProfile :=
   , symmetry := .both
   , asymmetrySubtype := .finAndCat
   , negIndefinite := none
-  , negMarkers := ["laa", "lam", "lan", "maa", "lays-a"]
+  , negMarkers := negMarkers.map (·.form)
   , negIsHead := none
   , enAttested := none }
 

--- a/Linglib/Fragments/Burmese/Negation.lean
+++ b/Linglib/Fragments/Burmese/Negation.lean
@@ -89,13 +89,13 @@ def burmeseTAM : TAMAvailability :=
 
 /-! ## Verification -/
 
-theorem sa_paradigm_size : saParadigm.length = 3 := by native_decide
+theorem sa_paradigm_size : saParadigm.length = 3 := by decide
 
 /-- All negative forms are identical: TAM is neutralized. -/
 theorem tam_neutralized :
     let negForms := saParadigm.map (·.negative)
     negForms.all (· == "ma-sa-bu") = true := by
-  native_decide
+  decide
 
 /-- The affirmative has 3 distinct TAM forms; the negative has 1. -/
 theorem paradigmatic_asymmetry :
@@ -107,22 +107,7 @@ theorem paradigmatic_asymmetry :
 theorem affirmative_forms_distinct :
     let affForms := saParadigm.map (·.affirmative)
     affForms.length = 3 ∧ affForms.eraseDups.length = 3 := by
-  exact ⟨rfl, by native_decide⟩
-
-private def hasSubstr (s sub : String) : Bool := (s.splitOn sub).length > 1
-
-/-- All negative forms contain the circumfix *ma-...-bu*. -/
-theorem all_neg_circumfix :
-    saParadigm.all (fun e =>
-      hasSubstr e.negative "ma-" && hasSubstr e.negative "-bu") = true := by
-  native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+  exact ⟨rfl, by decide⟩
 
 /-- Burmese negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/English/Negation.lean
+++ b/Linglib/Fragments/English/Negation.lean
@@ -94,30 +94,23 @@ def allExamples : List NegExample :=
 
 /-! ## Verification -/
 
-theorem all_examples_count : allExamples.length = 5 := by native_decide
+theorem all_examples_count : allExamples.length = 5 := by decide
 
 /-- 3 symmetric + 2 asymmetric = SymAsy. -/
 theorem symasy_distribution :
     (allExamples.filter (·.symmetric)).length = 3 ∧
     (allExamples.filter (fun e => !e.symmetric)).length = 2 := by
-  exact ⟨by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide⟩
 
 /-- Asymmetric constructions all involve do-support. -/
 theorem asymmetric_iff_dosupport :
     allExamples.all (fun e => e.symmetric == !e.doSupport) = true := by
-  native_decide
+  decide
 
 /-- Symmetric constructions do not involve do-support. -/
 theorem symmetric_no_dosupport :
     (allExamples.filter (·.symmetric)).all (fun e => !e.doSupport) = true := by
-  native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+  decide
 
 /-- English negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/Finnish/Negation.lean
+++ b/Linglib/Fragments/Finnish/Negation.lean
@@ -35,9 +35,7 @@ namespace Finnish.Negation
 open Morphology (MorphCategory MorphRule InflDistribution)
 open Typology.Negation
 
--- ============================================================================
--- § 0: Marker + System (Fragment-side joint)
--- ============================================================================
+/-! ### Marker and system -/
 
 /-- *ei* — Finnish's negative auxiliary verb, cited in 3sg form.
     Genuine auxiliary: inflects for person and number (`negParadigm` below
@@ -59,9 +57,7 @@ def ei : NegMarkerEntry :=
 def negationSystem : NegationSystem :=
   NegationSystem.ofISO "fin" [ei]
 
--- ============================================================================
--- § 1: Negative Auxiliary Paradigm
--- ============================================================================
+/-! ### Negative auxiliary paradigm -/
 
 /-- Person–number features for the Finnish negative auxiliary. -/
 structure NegForm where
@@ -79,9 +75,7 @@ def negParadigm : List NegForm :=
   , ⟨2, "pl", "ette"⟩
   , ⟨3, "pl", "eivät"⟩ ]
 
--- ============================================================================
--- § 2: Connegative Formation
--- ============================================================================
+/-! ### Connegative formation -/
 
 /-- The connegative `MorphRule`: strips tense marking from the main verb,
     leaving only the bare stem. The negative auxiliary carries tense instead.
@@ -112,9 +106,7 @@ def negAgreementRule (person : Nat) (number : String) : MorphRule Bool :=
   , semEffect := id
   , delegatedSemantics := true }
 
--- ============================================================================
--- § 3: Inflection Distribution
--- ============================================================================
+/-! ### Inflection distribution -/
 
 /-- Finnish negative construction inflection distribution.
 
@@ -126,22 +118,10 @@ def finnishNegDistribution : InflDistribution :=
   { onAux := [.negation, .tense, .agreement .subj]
   , onLex := [.stem, .aspect] }
 
--- ============================================================================
--- § 4: Verification Theorems
--- ============================================================================
+/-! ### Verification -/
 
 /-- The paradigm has exactly 6 forms (3 persons × 2 numbers). -/
-theorem paradigm_size : negParadigm.length = 6 := by native_decide
-
-/-- All singular forms are monosyllabic (≤ 2 characters). -/
-theorem singular_short :
-    (negParadigm.filter (·.number == "sg")).all
-      (fun f => f.form.length ≤ 2) = true := by native_decide
-
-/-- All forms share the stem *e-* (first character is 'e'). -/
-theorem shared_stem :
-    negParadigm.all (fun f => f.form.get ⟨0⟩ == 'e') = true := by
-  native_decide
+theorem paradigm_size : negParadigm.length = 6 := by decide
 
 /-- The connegative rule's semantic effect is Boolean negation. -/
 theorem connegative_negates : connegativeRule.semEffect true = false := rfl
@@ -151,13 +131,6 @@ theorem connegative_negates : connegativeRule.semEffect true = false := rfl
 theorem neg_aux_respects_bybee :
     MorphCategory.peripherality .negation <
     MorphCategory.peripherality (.agreement .subj) := by decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
 
 /-- Finnish negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/French/Negation.lean
+++ b/Linglib/Fragments/French/Negation.lean
@@ -119,29 +119,7 @@ def allExamples : List NegExample :=
 /-! ## Verification -/
 
 /-- All tenses are available under negation (no paradigmatic gaps). -/
-theorem all_tenses_available : allExamples.length = 5 := by native_decide
-
-private def hasSubstr (s sub : String) : Bool := (s.splitOn sub).length > 1
-
-/-- All formal negatives contain *pas*. -/
-theorem formal_contains_pas :
-    allExamples.all (fun e => hasSubstr e.negativeFormal "pas") = true := by
-  native_decide
-
-/-- All formal negatives contain the *n* component (*ne* or *n'*). -/
-theorem formal_contains_n :
-    allExamples.all (fun e =>
-      hasSubstr e.negativeFormal "ne " || hasSubstr e.negativeFormal "n'") = true := by
-  native_decide
-
-/-- All colloquial negatives contain *pas*. -/
-theorem colloquial_contains_pas :
-    allExamples.all (fun e => hasSubstr e.negativeColloquial "pas") = true := by
-  native_decide
-
--- ════════════════════════════════════════════════════
--- Expletive Negation Markers
--- ════════════════════════════════════════════════════
+theorem all_tenses_available : allExamples.length = 5 := by decide
 
 /-! ## Expletive Negation
 @cite{jin-koenig-2021}
@@ -205,18 +183,11 @@ def enTriggerNegators : List ENTriggerNegator :=
     low-entrenchment EN uses *ne...pas* (the standard negator). -/
 theorem high_entrenchment_uses_ne_alone :
     (enTriggerNegators.filter (·.highEntrenchment)).all
-      (·.enNegatorForm == "ne") = true := by native_decide
+      (·.enNegatorForm == "ne") = true := by decide
 
 /-- French EN marker = preverbal *ne* = same clitic as in standard
     *ne...pas*, but without the reinforcer. -/
 theorem en_marker_is_ne_clitic : enMarker = neClitic := rfl
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
 
 /-- French negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/German/Negation.lean
+++ b/Linglib/Fragments/German/Negation.lean
@@ -99,24 +99,8 @@ def allExamples : List NegExample :=
 
 /-! ## Verification -/
 
-private def hasSubstr (s sub : String) : Bool := (s.splitOn sub).length > 1
-
-/-- German negation is symmetric: the negative form is always the
-    affirmative + *nicht*, with no structural change. We verify this
-    by checking that each negative example contains *nicht*. -/
-theorem all_negative_contain_nicht :
-    allExamples.all (fun e => hasSubstr e.negative "nicht") = true := by
-  native_decide
-
 /-- All five tenses are available under negation (no paradigmatic gaps). -/
-theorem all_tenses_available : allExamples.length = 5 := by native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+theorem all_tenses_available : allExamples.length = 5 := by decide
 
 /-- German negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/Greek/StandardModern/Negation.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Negation.lean
@@ -30,9 +30,7 @@ open Semantics.Modality.Kratzer (ModalBase OrderingSource necessity)
 
 abbrev World := Fin 4
 
--- ============================================================================
--- § 1: Negation Marker Entries (Tsiakmakis 2025 paper apparatus)
--- ============================================================================
+/-! ### Negation marker entries -/
 
 /-- A Greek sentential negation marker, augmented with the mood/NCI
     properties from @cite{tsiakmakis-2025}'s NEG₁/NEG₂ analysis.
@@ -76,9 +74,7 @@ def min : MoodMarkerEntry :=
   , isStandardNegation := false
   , licensesNCIs := false }
 
--- ============================================================================
--- § 1b: Cross-linguistic substrate (Typology.Negation)
--- ============================================================================
+/-! ### Cross-linguistic substrate -/
 
 /-- *dhen* in Core substrate form. Cross-linguistic typology face of the
     indicative negator; the paper-specific mood/NCI apparatus lives on
@@ -101,9 +97,7 @@ def minMarker : Typology.Negation.NegMarkerEntry :=
 def negationSystem : Typology.Negation.NegationSystem :=
   Typology.Negation.NegationSystem.ofISO "ell" [dhenMarker, minMarker]
 
--- ============================================================================
--- § 2: Semantics
--- ============================================================================
+/-! ### Semantics -/
 
 /-- Semantics of *dhen*: standard truth-functional negation.
     ⟦dhen⟧ = λp.¬p -/
@@ -126,10 +120,6 @@ def minNegSem (f : ModalBase World) (g : OrderingSource World) (p : World → Pr
 def minExplSem (f : ModalBase World) (g : OrderingSource World) (p : World → Prop)
     (w : World) : Prop :=
   necessity f g p w
-
--- ============================================================================
--- § 3: Structural Properties
--- ============================================================================
 
 /-- Greek has exactly two sentential negation markers. -/
 def allMarkers : List MoodMarkerEntry := [dhen, min]

--- a/Linglib/Fragments/Hixkaryana/Negation.lean
+++ b/Linglib/Fragments/Hixkaryana/Negation.lean
@@ -62,31 +62,17 @@ def allExamples : List NegExample := [immPast]
 
 /-! ## Verification -/
 
-theorem all_examples_count : allExamples.length = 1 := by native_decide
+theorem all_examples_count : allExamples.length = 1 := by decide
 
 /-- All constructions are asymmetric. -/
 theorem all_asymmetric :
     allExamples.all (fun e => !e.symmetric) = true := by
-  native_decide
+  decide
 
 /-- Negation introduces a copula as the finite element. -/
 theorem copula_as_finite :
     allExamples.all (·.copulaFinite) = true := by
-  native_decide
-
-private def hasSubstr (s sub : String) : Bool := (s.splitOn sub).length > 1
-
-/-- All negative examples contain the suffix *-hira*. -/
-theorem all_negative_contain_hira :
-    allExamples.all (fun e => hasSubstr e.negative "-hira") = true := by
-  native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+  decide
 
 /-- Hixkaryana negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/Italian/Negation.lean
+++ b/Linglib/Fragments/Italian/Negation.lean
@@ -52,13 +52,6 @@ def non : NegMarkerEntry :=
 def negationSystem : NegationSystem :=
   NegationSystem.ofISO "ita" [non]
 
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
-
 /-- Italian negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=
   { language := "Italian"

--- a/Linglib/Fragments/Januubi/Negation.lean
+++ b/Linglib/Fragments/Januubi/Negation.lean
@@ -45,9 +45,7 @@ namespace Januubi.Negation
 
 open Typology.Negation
 
--- ════════════════════════════════════════════════════
--- § 1. Standard Negation
--- ════════════════════════════════════════════════════
+/-! ### Standard negation -/
 
 /-- *maa* — Januubi Arabic's standard sentential negation particle.
     Same form used as the EN marker across all attested EN-trigger
@@ -68,9 +66,7 @@ def standardNeg : String := maa.form
 def negationSystem : NegationSystem :=
   NegationSystem.ofISO "" [maa]
 
--- ════════════════════════════════════════════════════
--- § 2. Expletive Negation Markers
--- ════════════════════════════════════════════════════
+/-! ### Expletive negation markers -/
 
 /-- An expletive negation marker used in a specific trigger context. -/
 structure ENNegator where
@@ -92,9 +88,7 @@ def enNegator : ENNegator where
     standard and expletive negation. -/
 theorem en_negator_is_standard : enNegator.isStandardNeg = true := rfl
 
--- ════════════════════════════════════════════════════
--- § 3. Trigger-Specific Examples
--- ════════════════════════════════════════════════════
+/-! ### Trigger-specific examples -/
 
 /-- A glossed EN example from Januubi. -/
 structure ENExample where
@@ -131,9 +125,7 @@ def barelyExample : ENExample where
 def allExamples : List ENExample :=
   [beforeExample, barelyExample]
 
--- ════════════════════════════════════════════════════
--- § 4. Structural Constraints on EN
--- ════════════════════════════════════════════════════
+/-! ### Structural Constraints on EN -/
 
 open Phenomena.Negation.ExpletiveNegation (ENBlockingReason)
 

--- a/Linglib/Fragments/Japanese/Negation.lean
+++ b/Linglib/Fragments/Japanese/Negation.lean
@@ -114,38 +114,21 @@ def japaneseNegDistribution : NegInflDistribution :=
 
 /-! ## Verification -/
 
-theorem taberu_paradigm_size : taberuParadigm.length = 5 := by native_decide
-theorem yomu_paradigm_size : yomuParadigm.length = 2 := by native_decide
+theorem taberu_paradigm_size : taberuParadigm.length = 5 := by decide
+theorem yomu_paradigm_size : yomuParadigm.length = 2 := by decide
 
-private def hasSubstr (s sub : String) : Bool := (s.splitOn sub).length > 1
-
-/-- The verb stem in negative forms differs from affirmative — asymmetry
-    is visible: negative past *tabenakatta* does not contain the affirmative
-    past suffix *-ta* directly on the stem. -/
-theorem neg_past_differs_from_aff_past :
-    let affPast := (taberuParadigm.filter (·.formLabel == "past")).head!
-    let negPast := affPast.negative
-    negPast = "tabenakatta" ∧ hasSubstr negPast "nakatta" = true := by
-  exact ⟨by native_decide, by native_decide⟩
-
-/-- All negative forms contain the negative morpheme *na*. -/
-theorem all_neg_contain_na :
-    taberuParadigm.all (fun e => hasSubstr e.negative "na") = true := by
-  native_decide
+/-- The negative past form is *tabenakatta* — built on the negative stem,
+    not the affirmative past *tabeta*. -/
+theorem neg_past_form :
+    (taberuParadigm.filter (·.formLabel == "past")).head!.negative
+      = "tabenakatta" := by decide
 
 /-- The distribution shows that tense moves from stem to suffix under negation. -/
 theorem tense_moves_to_suffix :
     japaneseNegDistribution.affirmativeOnStem.contains .tense = true ∧
     japaneseNegDistribution.negativeOnStem.contains .tense = false ∧
     japaneseNegDistribution.negativeOnSuffix.contains .tense = true := by
-  native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+  decide
 
 /-- Japanese negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/Mandarin/Negation.lean
+++ b/Linglib/Fragments/Mandarin/Negation.lean
@@ -124,20 +124,20 @@ def negatorContexts : List NegatorDistribution :=
 
 /-! ## Verification -/
 
-theorem all_examples_count : allExamples.length = 5 := by native_decide
+theorem all_examples_count : allExamples.length = 5 := by decide
 
 /-- The *bù* constructions are symmetric; the *méi* constructions are not. -/
 theorem bu_symmetric_mei_asymmetric :
     (allExamples.filter (·.negator == "bù")).all (·.symmetric) = true ∧
     (allExamples.filter (fun e => e.negator == "méi" || e.negator == "méi-yǒu")).all
       (fun e => !e.symmetric) = true := by
-  exact ⟨by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide⟩
 
 /-- 3 symmetric + 2 asymmetric constructions = SymAsy. -/
 theorem symasy_distribution :
     (allExamples.filter (·.symmetric)).length = 3 ∧
     (allExamples.filter (fun e => !e.symmetric)).length = 2 := by
-  exact ⟨by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide⟩
 
 /-! ## Bridge to AspectComparison
 
@@ -148,10 +148,6 @@ theorem meiyou_matches_aspect_comparison :
     Mandarin.AspectComparison.meiyou.hanzi = "没有" ∧
     Mandarin.AspectComparison.meiyou.pinyin = "méi-yǒu" :=
   ⟨rfl, rfl⟩
-
--- ════════════════════════════════════════════════════
--- Expletive Negation Markers
--- ════════════════════════════════════════════════════
 
 /-! ## Expletive Negation
 @cite{jin-koenig-2021}
@@ -224,7 +220,7 @@ def enTriggerNegators : List ENTriggerNegator :=
     prohibition (@cite{jin-koenig-2021}, §6.1.1, ex. 14). -/
 theorem fear_uses_imperative_neg :
     (enTriggerNegators.filter (·.triggerClass == "FEAR")).all
-      (·.enNegatorForm == "bié") = true := by native_decide
+      (·.enNegatorForm == "bié") = true := by decide
 
 /-- REGRET/COMPLAIN triggers use the deontic negator *bùgāi* 'shouldn't'.
     This connects to the behavioral-standards semantics: ¬p is consistent
@@ -233,14 +229,7 @@ theorem fear_uses_imperative_neg :
 theorem regret_uses_deontic_neg :
     (enTriggerNegators.filter (fun e =>
       e.triggerClass == "REGRET" || e.triggerClass == "COMPLAIN")).all
-      (·.enNegatorForm == "bùgāi") = true := by native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+      (·.enNegatorForm == "bùgāi") = true := by decide
 
 /-- Mandarin Chinese negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/Maori/Negation.lean
+++ b/Linglib/Fragments/Maori/Negation.lean
@@ -79,26 +79,12 @@ def allExamples : List NegExample := [progressive, past]
 
 /-! ## Verification -/
 
-theorem all_examples_count : allExamples.length = 2 := by native_decide
+theorem all_examples_count : allExamples.length = 2 := by decide
 
 /-- All constructions are asymmetric (A/Fin). -/
 theorem all_asymmetric :
     allExamples.all (fun e => !e.symmetric) = true := by
-  native_decide
-
-private def hasSubstr (s sub : String) : Bool := (s.splitOn sub).length > 1
-
-/-- All negative examples contain the negator *Kāhore*. -/
-theorem all_negative_contain_kahore :
-    allExamples.all (fun e => hasSubstr e.negative "Kāhore") = true := by
-  native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+  decide
 
 /-- Maori negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/Quechua/Negation.lean
+++ b/Linglib/Fragments/Quechua/Negation.lean
@@ -87,25 +87,18 @@ def allExamples : List NegExample :=
 
 /-! ## Verification -/
 
-theorem example_count : allExamples.length = 3 := by native_decide
+theorem example_count : allExamples.length = 3 := by decide
 
 /-- Mixed: some symmetric, some asymmetric = SymAsy. -/
 theorem symasy_distribution :
     (allExamples.filter (·.symmetric)).length = 1 ∧
     (allExamples.filter (fun e => !e.symmetric)).length = 2 := by
-  exact ⟨by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide⟩
 
 /-- Asymmetric constructions are exactly those requiring -chu. -/
 theorem asymmetric_iff_chu :
     allExamples.all (fun e => e.symmetric == !e.requiresChu) = true := by
-  native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+  decide
 
 /-- Quechua (Imbabura) negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/Slavic/Czech/Negation.lean
+++ b/Linglib/Fragments/Slavic/Czech/Negation.lean
@@ -121,30 +121,7 @@ def allConcordExamples : List NegConcordExample := [nikdo, nic, nikdy]
 
 /-! ## Verification -/
 
-theorem all_examples_count : allExamples.length = 4 := by native_decide
-
-/-- All negative forms begin with *Ne* (prefix attached). -/
-theorem all_negative_start_ne :
-    allExamples.all (fun e => e.negative.startsWith "Ne") = true := by
-  native_decide
-
-/-- All negative concord sentences contain a verb with *ne-* prefix. -/
-theorem all_concord_contain_ne :
-    allConcordExamples.all (fun e =>
-      (e.sentence.splitOn "ne").length > 1) = true := by
-  native_decide
-
-/-- All n-words begin with *ni-*. -/
-theorem all_nwords_ni_prefix :
-    allConcordExamples.all (fun e => e.nword.startsWith "ni") = true := by
-  native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+theorem all_examples_count : allExamples.length = 4 := by decide
 
 /-- Czech negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/Slavic/Russian/Negation.lean
+++ b/Linglib/Fragments/Slavic/Russian/Negation.lean
@@ -115,34 +115,9 @@ def allConcordExamples : List NegConcordExample := [nikto, nichego, nikogda]
 
 /-! ## Verification -/
 
-private def hasSubstr (s sub : String) : Bool := (s.splitOn sub).length > 1
-
 theorem ne_form : ne.form = "не" := rfl
 
-theorem all_examples_count : allExamples.length = 4 := by native_decide
-
-/-- All negative examples contain *не* (or sentence-initial *Не*). -/
-theorem all_negative_contain_ne :
-    allExamples.all (fun e =>
-      hasSubstr e.negative "не" || hasSubstr e.negative "Не") = true := by
-  native_decide
-
-/-- All negative concord examples contain *не* alongside the n-word. -/
-theorem all_concord_contain_ne :
-    allConcordExamples.all (fun e => hasSubstr e.sentence "не") = true := by
-  native_decide
-
-/-- All n-words begin with *ни-*. -/
-theorem all_nwords_ni_prefix :
-    allConcordExamples.all (fun e => e.nword.startsWith "ни") = true := by
-  native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+theorem all_examples_count : allExamples.length = 4 := by decide
 
 /-- Russian negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/Spanish/Negation.lean
+++ b/Linglib/Fragments/Spanish/Negation.lean
@@ -117,21 +117,7 @@ def postverbalNada : NegConcordExample :=
 /-! ## Verification -/
 
 /-- All five tenses are available under negation (no paradigmatic gaps). -/
-theorem all_tenses_available : allExamples.length = 5 := by native_decide
-
-private def hasSubstr (s sub : String) : Bool := (s.splitOn sub).length > 1
-
-/-- All negative examples contain *no*. -/
-theorem all_negative_contain_no :
-    allExamples.all (fun e => hasSubstr e.negative " no ") = true := by
-  native_decide
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+theorem all_tenses_available : allExamples.length = 5 := by decide
 
 /-- Spanish negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/Turkish/Negation.lean
+++ b/Linglib/Fragments/Turkish/Negation.lean
@@ -83,34 +83,17 @@ def gelParadigm : List NegParadigmEntry :=
 
 /-! ## Verification -/
 
-theorem gel_paradigm_size : gelParadigm.length = 5 := by native_decide
+theorem gel_paradigm_size : gelParadigm.length = 5 := by decide
 
 /-- Most constructions are symmetric. -/
 theorem mostly_symmetric :
-    (gelParadigm.filter (·.symmetric)).length = 4 := by native_decide
+    (gelParadigm.filter (·.symmetric)).length = 4 := by decide
 
 /-- The aorist is the only asymmetric construction. -/
 theorem aorist_asymmetric :
     (gelParadigm.filter (fun e => !e.symmetric)).length = 1 ∧
     (gelParadigm.filter (fun e => !e.symmetric)).head!.formLabel = "aorist" := by
-  exact ⟨by native_decide, rfl⟩
-
-private def hasSubstr (s sub : String) : Bool := (s.splitOn sub).length > 1
-
-/-- The aorist negative marker *-z* differs from the affirmative *-r*:
-    this is paradigmatic asymmetry (A/Cat). -/
-theorem aorist_different_markers :
-    let aor := (gelParadigm.filter (·.formLabel == "aorist")).head!
-    hasSubstr aor.affirmative "ir" = true ∧
-    hasSubstr aor.negative "ez" = true := by
-  exact ⟨by native_decide, by native_decide⟩
-
-
--- ============================================================================
--- NegationProfile bundle (consumed by Studies/Dryer2013.lean and
--- Studies/Miestamo2005.lean per the project's "per-language data flows
--- through Fragments" rule)
--- ============================================================================
+  exact ⟨by decide, rfl⟩
 
 /-- Turkish negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Typology.Negation.NegationProfile :=

--- a/Linglib/Fragments/ZarmaSonrai/Negation.lean
+++ b/Linglib/Fragments/ZarmaSonrai/Negation.lean
@@ -42,9 +42,7 @@ namespace ZarmaSonrai.Negation
 
 open Typology.Negation
 
--- ════════════════════════════════════════════════════
--- § 1. Standard Negation
--- ════════════════════════════════════════════════════
+/-! ### Standard negation -/
 
 /-- *si* — imperfective negation marker. Aspect-conditioned alternation
     with perfective *mana*/*batu*. Parallel to Mandarin's bù/méi split. -/
@@ -78,15 +76,13 @@ def ipfvNeg : String := si.form
 def pfvNeg : String := mana.form
 def pfvNeg2 : String := batu.form
 
--- ════════════════════════════════════════════════════
--- § 2. Expletive Negation Markers
--- ════════════════════════════════════════════════════
-
 /-- Aspect governs expletive negation marker choice. -/
 inductive ENAspect where
   | ipfv   -- imperfective complement → si
   | pfv    -- perfective complement → mana/batu
   deriving DecidableEq, Repr
+
+/-! ### Expletive negation markers -/
 
 /-- An expletive negation marker used in a specific trigger context. -/
 structure ENNegator where
@@ -115,9 +111,7 @@ def enPfv : ENNegator where
 theorem en_negators_are_standard :
     enIpfv.isStandardNeg = true ∧ enPfv.isStandardNeg = true := ⟨rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 3. Trigger-Specific Examples
--- ════════════════════════════════════════════════════
+/-! ### Trigger-specific examples -/
 
 /-- A glossed EN example from Zarma-Sonrai. -/
 structure ENExample where
@@ -174,9 +168,7 @@ def hideExample : ENExample where
 def allExamples : List ENExample :=
   [delayExample, cannotWaitExample, hideExample]
 
--- ════════════════════════════════════════════════════
--- § 4. Aspect-Based Negator Selection
--- ════════════════════════════════════════════════════
+/-! ### Aspect-based negator selection -/
 
 /-- The EN negator is determined by the aspectual properties of the
     complement clause, not by the trigger class. This is a general

--- a/Linglib/Typology/Negation.lean
+++ b/Linglib/Typology/Negation.lean
@@ -5,7 +5,6 @@ import Linglib.Data.WALS.Features.F114A
 import Linglib.Data.WALS.Features.F115A
 import Linglib.Data.WALS.Features.F143A
 import Linglib.Data.WALS.Features.F144A
-import Linglib.Data.WALS.Features.F144B
 import Linglib.Typology.NegativeConcord
 
 /-!
@@ -20,7 +19,7 @@ Mirrors the `Linglib/Typology/Possession.lean` (Possession), `Question.lean`
 (Question), and `Case.lean` (Case) substrate-extension pattern: the
 substrate carries (a) per-paradigm-entry schema (`NegMarkerEntry`,
 `NegationSystem`), (b) the WALS-bundled per-language `NegationProfile`,
-(c) WALS converters and aggregate-distribution helpers / theorems.
+(c) WALS converters and sample-counting helpers.
 
 ## What lives here
 
@@ -45,8 +44,10 @@ substrate carries (a) per-paradigm-entry schema (`NegMarkerEntry`,
   `def negationProfile : NegationProfile` alongside `def negationSystem`.
   Sibling pattern (mirrors `Typology/Possession.lean::PossessionProfile`):
   the marker-side joint is independent from the typology-feature joint.
-- `fromWALS112A`/`113A`/`114A`/`115A`/`143A` converters.
-- WALS aggregate distribution theorems for Ch 112-115/143A/144A core.
+- `ofWALS112A`/`fromWALS113A`/`114A`/`115A`/`143A` converters.
+- `countByMorphemeType`/`countBySymmetry` sample-counting helpers (consumed by
+  `Studies/Dryer2013Negation.lean`) and the `NegIndefiniteStrategy.admits`
+  negative-concord bridge.
 
 ## Theory-laden caveats
 
@@ -70,17 +71,7 @@ set_option autoImplicit false
 
 namespace Typology.Negation
 
-private abbrev ch112  := Data.WALS.F112A.allData
-private abbrev ch113  := Data.WALS.F113A.allData
-private abbrev ch114  := Data.WALS.F114A.allData
-private abbrev ch115  := Data.WALS.F115A.allData
-private abbrev ch143A := Data.WALS.F143A.allData
-private abbrev ch144A := Data.WALS.F144A.allData
-private abbrev ch144B := Data.WALS.F144B.allData
-
--- ============================================================================
--- §1. Substrate enums
--- ============================================================================
+/-! ### Substrate enums -/
 
 /-- Type of the standard negation morpheme @cite{dryer-2013-wals}.
 
@@ -198,9 +189,7 @@ inductive NegMorphemePosition where
   | none
   deriving DecidableEq, BEq, Repr
 
--- ============================================================================
--- §2. NegMarkerEntry / NegationSystem (Fragment marker-side joint)
--- ============================================================================
+/-! ### NegMarkerEntry / NegationSystem (Fragment marker-side joint) -/
 
 /-- One language's standard sentential negation marker. -/
 structure NegMarkerEntry where
@@ -245,9 +234,7 @@ structure NegationSystem where
     := none
   deriving Repr
 
--- ============================================================================
--- §3. NegationProfile (Fragment typology-feature joint)
--- ============================================================================
+/-! ### NegationProfile (Fragment typology-feature joint) -/
 
 /-- A language's negation profile across WALS Chapters 112-115, plus
     fields from @cite{greco-2020} (`negIsHead`) and @cite{jin-koenig-2021}
@@ -284,9 +271,7 @@ structure NegationProfile where
   enAttested : Option Bool := none
   deriving Repr
 
--- ============================================================================
--- §4. WALS converters
--- ============================================================================
+/-! ### WALS converters -/
 
 /-- WALS Ch 112A → `NegMorphemeType`. -/
 def ofWALS112A : Data.WALS.F112A.NegativeMorphemeType → NegMorphemeType
@@ -352,9 +337,7 @@ def NegationSystem.ofISO (iso : String) (markers : List NegMarkerEntry) :
   , wals144A := (Data.WALS.F144A.lookupISO iso).map (·.value)
   }
 
--- ============================================================================
--- §5. NegationProfile helpers (Fragment-consumed)
--- ============================================================================
+/-! ### NegationProfile helpers (Fragment-consumed) -/
 
 /-- Does a language use a given morpheme type? -/
 def NegationProfile.hasMorphemeType (p : NegationProfile)
@@ -382,10 +365,7 @@ def countByMorphemeType (langs : List NegationProfile)
 def countBySymmetry (langs : List NegationProfile) (s : NegSymmetry) : Nat :=
   (langs.filter (·.symmetry == s)).length
 
--- ============================================================================
--- §6. Negative concord: bridge WALS 115A strategy ↔ item-level n-word status
---     (@cite{giannakidou-2000}, @cite{van-der-auwera-van-alsenoy-2016})
--- ============================================================================
+/-! ### Negative concord: WALS 115A strategy ↔ item-level n-word status -/
 
 open Typology.NegativeConcord (NWordStatus)
 
@@ -412,68 +392,5 @@ theorem nWord_vs_negQuantifier :
     (NegIndefiniteStrategy.cooccur).admits .nWord = true ∧
     (NegIndefiniteStrategy.preclude).admits .nWord = false ∧
     (NegIndefiniteStrategy.preclude).admits .negQuantifier = true := by decide
-
--- ============================================================================
--- §7. Theory-neutral WALS distribution facts (corpus-only generalisations)
--- ============================================================================
-
-/-- Ch 112: negative particles outnumber negative affixes. -/
-theorem particles_most_common :
-    (ch112.filter (·.value == .negativeParticle)).length >
-    (ch112.filter (·.value == .negativeAffix)).length := by native_decide
-
-/-- Ch 112: negative auxiliary verbs are rare (< 5% of sample). -/
-theorem aux_verbs_rare :
-    (ch112.filter (·.value == .negativeAuxiliaryVerb)).length * 20 <
-    ch112.length := by native_decide
-
-/-- Ch 113: SymAsy (both) is the most common type, followed by Sym, then Asy. -/
-theorem symasy_most_common :
-    let sym := (ch113.filter (·.value == .symmetric)).length
-    let asy := (ch113.filter (·.value == .asymmetric)).length
-    let both := (ch113.filter (·.value == .both)).length
-    both > sym ∧ sym > asy := by
-  exact ⟨by native_decide, by native_decide⟩
-
-/-- Ch 114: A/Cat is the most common single asymmetry subtype, then A/Fin,
-    then A/NonReal. -/
-theorem acat_most_common_subtype :
-    let aCat := (ch114.filter (·.value == .aCat)).length
-    let aFin := (ch114.filter (·.value == .aFin)).length
-    let aNon := (ch114.filter (·.value == .aNonreal)).length
-    aCat > aFin ∧ aFin > aNon := by
-  exact ⟨by native_decide, by native_decide⟩
-
-/-- Ch 115: negative concord (co-occurrence) outnumbers preclusion by 15×. -/
-theorem neg_concord_dominant :
-    let cooccur :=
-      (ch115.filter (·.value == .predicateNegationAlsoPresent)).length
-    let preclude := (ch115.filter (·.value == .noPredicateNegation)).length
-    cooccur > preclude * 15 := by native_decide
-
-/-- Ch 115: preclusion of predicate negation is the rarest strategy. -/
-theorem preclusion_rarest :
-    let preclude := (ch115.filter (·.value == .noPredicateNegation)).length
-    let mixed    := (ch115.filter (·.value == .mixedBehaviour)).length
-    let negEx    :=
-      (ch115.filter (·.value == .negativeExistentialConstruction)).length
-    preclude ≤ mixed ∧ preclude ≤ negEx := by
-  exact ⟨by native_decide, by native_decide⟩
-
-/-- Ch 143A: preverbal negation (particle or affix) dominates postverbal. -/
-theorem ch143A_preverbal_dominates :
-    let preParticle := (ch143A.filter (·.value == .negv)).length
-    let preAffix    := (ch143A.filter (·.value == .negV)).length
-    let postParticle := (ch143A.filter (·.value == .vneg)).length
-    let postAffix    := (ch143A.filter (·.value == .vNeg)).length
-    preParticle + preAffix > postParticle + postAffix := by native_decide
-
-/-- Ch 144B: immediately preverbal is the most common position for
-    negative words. -/
-theorem ch144B_immed_preverbal_dominant :
-    (ch144B.filter (·.value == .immedPreverbal)).length >
-    (ch144B.filter (·.value == .immedPostverbal)).length +
-    (ch144B.filter (·.value == .endNotImmedPostverbal)).length := by
-  native_decide
 
 end Typology.Negation


### PR DESCRIPTION
Mathlib-conventions cleanup of the negation fragment files and substrate.

- `Fragments/Arabic` MSA negation rewritten (terse docstring, verified Ryding citations, derive-not-duplicate) and wired into `Linglib.lean` (was an orphan import).
- `Typology/Negation`: dropped the WALS-corpus distribution theorems (`native_decide` over 1000+ rows, infeasible under kernel `decide`).
- 18 fragment files: `native_decide`→`decide`, cut low-value String surface-form shape-checks, `-- ===` banners → `/-! ### ` markdown headers.