### PR TITLE
feat(Binding): Pronoun.bindingClass + polymorphic BindingSource

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -15,6 +15,7 @@ import Linglib.Typology.Negation
 import Linglib.Features.ClauseForm
 import Linglib.Features.Clusivity
 import Linglib.Syntax.Pronoun.Basic
+import Linglib.Syntax.Pronoun.Mixin
 import Linglib.Typology.Pronoun.WALS
 import Linglib.Typology.Evidentiality
 import Linglib.Core.Logic.FactorsThroughOn

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -130,6 +130,7 @@ import Linglib.Discourse.Scoreboard
 import Linglib.Discourse.AtIssueness
 import Linglib.Features.CoreferenceStatus
 import Linglib.Syntax.Binding.Basic
+import Linglib.Syntax.Binding.Lexical
 import Linglib.Syntax.Binding.Semantics
 import Linglib.Core.CombinationKind
 import Linglib.Semantics.Composition.Combinator

--- a/Linglib/Features/CoreferenceStatus.lean
+++ b/Linglib/Features/CoreferenceStatus.lean
@@ -41,6 +41,6 @@ inductive BindingClass where
   | pronoun
   /-- Referring expression (proper name, full NP). -/
   | rExpression
-  deriving Repr, DecidableEq
+  deriving Repr, BEq, DecidableEq
 
 end Features

--- a/Linglib/Syntax/Binding/Lexical.lean
+++ b/Linglib/Syntax/Binding/Lexical.lean
@@ -103,4 +103,44 @@ example (r : ReflexivePronoun) :
     PronounLike.form r = r.val.form ∧ Lexicon.IsAnaphor r :=
   ⟨rfl, Anaphoric.isAnaphor r⟩
 
+/-! ### A validated consumer: Principle A driven by the declaration
+
+A minimal slice of Principle A (`Binding.reflexiveLicensed`, `Syntax/Binding/Basic.lean`)
+re-expressed over the lexical mixins: it reads the dependent's kind from `[Lexicon α]` and
+the φ-agreement from `[PronounLike α]`, folding the structural command + locality facts into
+`commandsLocally` — *no* `classify : Word → BindingClass` parameter. This validates the mixin
+layer: the engine's Principle-A logic is driven by the lexical *declaration*. -/
+
+/-- Principle A over the mixins: a declared reflexive `dep` is licensed by `ante` iff `ante`
+locally commands it and they φ-agree. A non-reflexive `dep` is vacuously licensed (Principle
+A is silent on it). -/
+def licensesReflexive {α : Type} [Lexicon α] [PronounLike α]
+    (commandsLocally : Prop) (ante dep : α) : Prop :=
+  match Lexicon.bindingClass dep with
+  | some .reflexive => commandsLocally ∧ (PronounLike.phi ante).compatible (PronounLike.phi dep)
+  | _ => True
+
+/-- The reflexive case reduces to *local command ∧ φ-agreement* — exactly the reflexive clause
+of `Binding.reflexiveLicensed`, now driven by `[Lexicon α]` rather than a form-string
+classifier. -/
+theorem licensesReflexive_of_declared {α : Type} [Lexicon α] [PronounLike α]
+    (commandsLocally : Prop) (ante dep : α)
+    (h : Lexicon.bindingClass dep = some .reflexive) :
+    licensesReflexive commandsLocally ante dep
+      = (commandsLocally ∧ (PronounLike.phi ante).compatible (PronounLike.phi dep)) := by
+  simp only [licensesReflexive, h]
+
+private def exHe : Pronoun :=
+  { form := "he", person := some .third, number := some .sg,
+    gender := some .masculine, bindingClass := some .pronoun }
+private def exHimself : Pronoun :=
+  { form := "himself", person := some .third, number := some .sg,
+    gender := some .masculine, bindingClass := some .reflexive }
+
+/-- Validation: `himself` (declaring `.reflexive`), φ-agreeing with and locally commanded by
+`he`, is licensed by Principle A — driven entirely by the declaration, no classifier. -/
+example : licensesReflexive True exHe exHimself := by
+  rw [licensesReflexive_of_declared True exHe exHimself rfl]
+  exact ⟨trivial, by decide⟩
+
 end Binding

--- a/Linglib/Syntax/Binding/Lexical.lean
+++ b/Linglib/Syntax/Binding/Lexical.lean
@@ -64,4 +64,32 @@ instance (a : α) : Decidable (IsRExpression a) := by unfold IsRExpression; infe
 
 end Lexicon
 
+/-! ### Single-kind marker mixins
+
+A carrier all of whose pro-forms declare one binding kind — the `[Anaphoric α]`-style
+markers. Prop-mixins over `[Lexicon α]`, instantiable on a *single-kind* carrier (a subtype
+of a lexicon narrowed to one class) but NOT on the multi-kind `Pronoun` record (whose
+`bindingClass` varies per entry; use the per-element `Lexicon.Is*` predicates there).
+Stacking these is how a pronoun *kind* is composed and *derived*, never stipulated. -/
+
+/-- All pro-forms of `α` are Principle-A anaphors. -/
+class Anaphoric (α : Type) [Lexicon α] : Prop where
+  isAnaphor : ∀ a : α, Lexicon.IsAnaphor a
+
+/-- All pro-forms of `α` are Principle-B pronominals. -/
+class Pronominal (α : Type) [Lexicon α] : Prop where
+  isPronominal : ∀ a : α, Lexicon.IsPronominal a
+
+/-- All pro-forms of `α` are Principle-C R-expressions. -/
+class RExpression (α : Type) [Lexicon α] : Prop where
+  isRExpression : ∀ a : α, Lexicon.IsRExpression a
+
+/-- A **reflexive pronoun**, derived not stipulated: the sub-carrier of `Pronoun` whose
+declaration is `.reflexive`. The dissolution of "should `ReflexivePronoun` be a `structure`?"
+— it is the narrowed carrier, and it is `Anaphoric` by construction. -/
+abbrev ReflexivePronoun := {p : Pronoun // p.bindingClass = some .reflexive}
+
+instance : Lexicon ReflexivePronoun := ⟨fun r => r.val.bindingClass⟩
+instance : Anaphoric ReflexivePronoun := ⟨fun r => Or.inl r.property⟩
+
 end Binding

--- a/Linglib/Syntax/Binding/Lexical.lean
+++ b/Linglib/Syntax/Binding/Lexical.lean
@@ -1,0 +1,67 @@
+import Linglib.Syntax.Pronoun.Basic
+import Linglib.Features.CoreferenceStatus
+
+/-!
+# The lexical interface to binding
+[chomsky-1981]
+
+The lexical half of binding theory, as a mixin. A carrier `α` is a `Binding.Lexicon`
+when each of its pro-forms *declares* a `Features.BindingClass` — which binding
+principle governs it. The framework-neutral binding engine
+(`Syntax/Binding/Basic.lean`) reads a pro-form's declared class rather than recovering
+it from surface form strings or lexicon-list membership: the lexical entry is the
+source of truth for its own binding role.
+
+The universal `Pronoun` record is the canonical instance (via its `bindingClass`
+field). A syntactic theory's representation (`Word`, an HPSG synsem, …) can instance
+it too — which is what lets the binding principles abstract over `[Binding.Lexicon α]`
+instead of taking an explicit `classify : Word → Option BindingClass` parameter.
+
+## Main declarations
+
+* `Binding.Lexicon` — a carrier whose pro-forms declare a `BindingClass`.
+* `Binding.Lexicon.{IsAnaphor, IsPronominal, IsRExpression}` — the Principle A / B / C
+  partitions, read off the declaration.
+
+## Implementation notes
+
+The *per-kind* marker mixins (`Reflexive α`, `Personal α`, …) of the long-horizon design
+attach to dedicated single-kind carriers, not to the universal `Pronoun` record (whose
+`bindingClass` varies per entry, so no type-level "all of `α` is reflexive" holds). They
+are deferred to the theory layer; the per-element `IsAnaphor`/… predicates here serve the
+multi-kind record.
+-/
+
+namespace Binding
+
+open Features (BindingClass)
+
+/-- A carrier whose pro-forms declare a `Features.BindingClass` — the lexical interface
+the binding engine reads. `none` is a bare φ-shell that declares no class. -/
+class Lexicon (α : Type) where
+  /-- The binding class `a` declares, if any. -/
+  bindingClass : α → Option BindingClass
+
+instance : Lexicon Pronoun := ⟨Pronoun.bindingClass⟩
+
+namespace Lexicon
+
+variable {α : Type} [Lexicon α]
+
+/-- `a` declares a Principle-A anaphor (reflexive or reciprocal). -/
+def IsAnaphor (a : α) : Prop :=
+  bindingClass a = some .reflexive ∨ bindingClass a = some .reciprocal
+
+/-- `a` declares a Principle-B pronominal. -/
+def IsPronominal (a : α) : Prop := bindingClass a = some .pronoun
+
+/-- `a` declares a Principle-C R-expression. -/
+def IsRExpression (a : α) : Prop := bindingClass a = some .rExpression
+
+instance (a : α) : Decidable (IsAnaphor a) := by unfold IsAnaphor; infer_instance
+instance (a : α) : Decidable (IsPronominal a) := by unfold IsPronominal; infer_instance
+instance (a : α) : Decidable (IsRExpression a) := by unfold IsRExpression; infer_instance
+
+end Lexicon
+
+end Binding

--- a/Linglib/Syntax/Binding/Lexical.lean
+++ b/Linglib/Syntax/Binding/Lexical.lean
@@ -6,129 +6,45 @@ import Linglib.Features.CoreferenceStatus
 # The lexical interface to binding
 [chomsky-1981]
 
-The lexical half of binding theory, as a mixin. A carrier `α` is a `Binding.Lexicon`
-when each of its pro-forms *declares* a `Features.BindingClass` — which binding
-principle governs it. The framework-neutral binding engine
-(`Syntax/Binding/Basic.lean`) reads a pro-form's declared class rather than recovering
-it from surface form strings or lexicon-list membership: the lexical entry is the
-source of truth for its own binding role.
+A pro-form's binding role is its `Features.BindingClass` (which binding principle — A / B / C —
+governs it), declared on the entry as `Pronoun.bindingClass`. A binding theory reads this
+declaration rather than recovering the class from surface form strings: the lexical entry is
+the source of truth for its own binding role.
 
-The universal `Pronoun` record is the canonical instance (via its `bindingClass`
-field). A syntactic theory's representation (`Word`, an HPSG synsem, …) can instance
-it too — which is what lets the binding principles abstract over `[Binding.Lexicon α]`
-instead of taking an explicit `classify : Word → Option BindingClass` parameter.
+The connection is kept deliberately concrete — predicates on the `Pronoun` record. A
+`Lexicon`/`HasBindingClass` *typeclass* over the class accessor is intentionally **not**
+introduced: a `Word`'s class is language-dependent (so `Lexicon Word` would be non-canonical),
+and a `Pronoun` instance would only project the field — so that abstraction waits for a second
+intrinsic-declaration carrier, or a carrier-based engine, to justify it.
 
 ## Main declarations
 
-* `Binding.Lexicon` — a carrier whose pro-forms declare a `BindingClass`.
-* `Binding.Lexicon.{IsAnaphor, IsPronominal, IsRExpression}` — the Principle A / B / C
-  partitions, read off the declaration.
-
-## Implementation notes
-
-The *per-kind* marker mixins (`Reflexive α`, `Personal α`, …) of the long-horizon design
-attach to dedicated single-kind carriers, not to the universal `Pronoun` record (whose
-`bindingClass` varies per entry, so no type-level "all of `α` is reflexive" holds). They
-are deferred to the theory layer; the per-element `IsAnaphor`/… predicates here serve the
-multi-kind record.
+* `Pronoun.{IsAnaphor, IsPronominal, IsRExpression}` — the Principle A / B / C partitions, read
+  off `Pronoun.bindingClass`.
 -/
 
-namespace Binding
+namespace Pronoun
 
-open Features (BindingClass)
+/-- `p` declares a Principle-A anaphor (reflexive or reciprocal). -/
+def IsAnaphor (p : Pronoun) : Prop :=
+  p.bindingClass = some .reflexive ∨ p.bindingClass = some .reciprocal
 
-/-- A carrier whose pro-forms declare a `Features.BindingClass` — the lexical interface
-the binding engine reads. `none` is a bare φ-shell that declares no class. -/
-class Lexicon (α : Type) where
-  /-- The binding class `a` declares, if any. -/
-  bindingClass : α → Option BindingClass
+/-- `p` declares a Principle-B pronominal. -/
+def IsPronominal (p : Pronoun) : Prop := p.bindingClass = some .pronoun
 
-instance : Lexicon Pronoun := ⟨Pronoun.bindingClass⟩
+/-- `p` declares a Principle-C R-expression. -/
+def IsRExpression (p : Pronoun) : Prop := p.bindingClass = some .rExpression
 
-namespace Lexicon
+instance (p : Pronoun) : Decidable p.IsAnaphor := by unfold IsAnaphor; infer_instance
+instance (p : Pronoun) : Decidable p.IsPronominal := by unfold IsPronominal; infer_instance
+instance (p : Pronoun) : Decidable p.IsRExpression := by unfold IsRExpression; infer_instance
 
-variable {α : Type} [Lexicon α]
+/-! ### Validation: Principle A is driven by the declaration
 
-/-- `a` declares a Principle-A anaphor (reflexive or reciprocal). -/
-def IsAnaphor (a : α) : Prop :=
-  bindingClass a = some .reflexive ∨ bindingClass a = some .reciprocal
-
-/-- `a` declares a Principle-B pronominal. -/
-def IsPronominal (a : α) : Prop := bindingClass a = some .pronoun
-
-/-- `a` declares a Principle-C R-expression. -/
-def IsRExpression (a : α) : Prop := bindingClass a = some .rExpression
-
-instance (a : α) : Decidable (IsAnaphor a) := by unfold IsAnaphor; infer_instance
-instance (a : α) : Decidable (IsPronominal a) := by unfold IsPronominal; infer_instance
-instance (a : α) : Decidable (IsRExpression a) := by unfold IsRExpression; infer_instance
-
-end Lexicon
-
-/-! ### Single-kind marker mixins
-
-A carrier all of whose pro-forms declare one binding kind — the `[Anaphoric α]`-style
-markers. Prop-mixins over `[Lexicon α]`, instantiable on a *single-kind* carrier (a subtype
-of a lexicon narrowed to one class) but NOT on the multi-kind `Pronoun` record (whose
-`bindingClass` varies per entry; use the per-element `Lexicon.Is*` predicates there).
-Stacking these is how a pronoun *kind* is composed and *derived*, never stipulated. -/
-
-/-- All pro-forms of `α` are Principle-A anaphors. -/
-class Anaphoric (α : Type) [Lexicon α] : Prop where
-  isAnaphor : ∀ a : α, Lexicon.IsAnaphor a
-
-/-- All pro-forms of `α` are Principle-B pronominals. -/
-class Pronominal (α : Type) [Lexicon α] : Prop where
-  isPronominal : ∀ a : α, Lexicon.IsPronominal a
-
-/-- All pro-forms of `α` are Principle-C R-expressions. -/
-class RExpression (α : Type) [Lexicon α] : Prop where
-  isRExpression : ∀ a : α, Lexicon.IsRExpression a
-
-/-- A **reflexive pronoun**, derived not stipulated: the sub-carrier of `Pronoun` whose
-declaration is `.reflexive`. The dissolution of "should `ReflexivePronoun` be a `structure`?"
-— it is the narrowed carrier, and it is `Anaphoric` by construction. -/
-abbrev ReflexivePronoun := {p : Pronoun // p.bindingClass = some .reflexive}
-
-instance : Lexicon ReflexivePronoun := ⟨fun r => r.val.bindingClass⟩
-instance : Anaphoric ReflexivePronoun := ⟨fun r => Or.inl r.property⟩
-instance : PronounLike ReflexivePronoun where
-  form := fun r => r.val.form
-  phi := fun r => r.val.toWord.phi
-
-/-- `ReflexivePronoun` carries the full lexical stack — `PronounLike` (word-class: form + φ)
-*and* the `Anaphoric` marker (Principle A) — composed with no diamond, since the word-class
-and binding axes are orthogonal. -/
-example (r : ReflexivePronoun) :
-    PronounLike.form r = r.val.form ∧ Lexicon.IsAnaphor r :=
-  ⟨rfl, Anaphoric.isAnaphor r⟩
-
-/-! ### A validated consumer: Principle A driven by the declaration
-
-A minimal slice of Principle A (`Binding.reflexiveLicensed`, `Syntax/Binding/Basic.lean`)
-re-expressed over the lexical mixins: it reads the dependent's kind from `[Lexicon α]` and
-the φ-agreement from `[PronounLike α]`, folding the structural command + locality facts into
-`commandsLocally` — *no* `classify : Word → BindingClass` parameter. This validates the mixin
-layer: the engine's Principle-A logic is driven by the lexical *declaration*. -/
-
-/-- Principle A over the mixins: a declared reflexive `dep` is licensed by `ante` iff `ante`
-locally commands it and they φ-agree. A non-reflexive `dep` is vacuously licensed (Principle
-A is silent on it). -/
-def licensesReflexive {α : Type} [Lexicon α] [PronounLike α]
-    (commandsLocally : Prop) (ante dep : α) : Prop :=
-  match Lexicon.bindingClass dep with
-  | some .reflexive => commandsLocally ∧ (PronounLike.phi ante).compatible (PronounLike.phi dep)
-  | _ => True
-
-/-- The reflexive case reduces to *local command ∧ φ-agreement* — exactly the reflexive clause
-of `Binding.reflexiveLicensed`, now driven by `[Lexicon α]` rather than a form-string
-classifier. -/
-theorem licensesReflexive_of_declared {α : Type} [Lexicon α] [PronounLike α]
-    (commandsLocally : Prop) (ante dep : α)
-    (h : Lexicon.bindingClass dep = some .reflexive) :
-    licensesReflexive commandsLocally ante dep
-      = (commandsLocally ∧ (PronounLike.phi ante).compatible (PronounLike.phi dep)) := by
-  simp only [licensesReflexive, h]
+Inlining the reflexive clause of `Binding.reflexiveLicensed` (`Syntax/Binding/Basic.lean`) —
+*local command ∧ φ-agreement* for a dependent that declares `.reflexive` — shows the engine's
+Principle-A logic reads the lexical declaration (`bindingClass`) and the `[PronounLike]`
+φ-features, with no `classify : Word → BindingClass` form-string recovery. -/
 
 private def exHe : Pronoun :=
   { form := "he", person := some .third, number := some .sg,
@@ -137,10 +53,12 @@ private def exHimself : Pronoun :=
   { form := "himself", person := some .third, number := some .sg,
     gender := some .masculine, bindingClass := some .reflexive }
 
-/-- Validation: `himself` (declaring `.reflexive`), φ-agreeing with and locally commanded by
-`he`, is licensed by Principle A — driven entirely by the declaration, no classifier. -/
-example : licensesReflexive True exHe exHimself := by
-  rw [licensesReflexive_of_declared True exHe exHimself rfl]
-  exact ⟨trivial, by decide⟩
+/-- `himself` declares `.reflexive`, and — φ-agreeing with and locally commanded by `he` —
+satisfies Principle A (`command ∧ φ-agreement`), read entirely off the declaration. -/
+example :
+    (match exHimself.bindingClass with
+     | some .reflexive => True ∧ (PronounLike.phi exHe).compatible (PronounLike.phi exHimself)
+     | _ => True) :=
+  ⟨trivial, by decide⟩
 
-end Binding
+end Pronoun

--- a/Linglib/Syntax/Binding/Lexical.lean
+++ b/Linglib/Syntax/Binding/Lexical.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Pronoun.Basic
+import Linglib.Syntax.Pronoun.Mixin
 import Linglib.Features.CoreferenceStatus
 
 /-!
@@ -91,5 +92,15 @@ abbrev ReflexivePronoun := {p : Pronoun // p.bindingClass = some .reflexive}
 
 instance : Lexicon ReflexivePronoun := ⟨fun r => r.val.bindingClass⟩
 instance : Anaphoric ReflexivePronoun := ⟨fun r => Or.inl r.property⟩
+instance : PronounLike ReflexivePronoun where
+  form := fun r => r.val.form
+  phi := fun r => r.val.toWord.phi
+
+/-- `ReflexivePronoun` carries the full lexical stack — `PronounLike` (word-class: form + φ)
+*and* the `Anaphoric` marker (Principle A) — composed with no diamond, since the word-class
+and binding axes are orthogonal. -/
+example (r : ReflexivePronoun) :
+    PronounLike.form r = r.val.form ∧ Lexicon.IsAnaphor r :=
+  ⟨rfl, Anaphoric.isAnaphor r⟩
 
 end Binding

--- a/Linglib/Syntax/Pronoun/Basic.lean
+++ b/Linglib/Syntax/Pronoun/Basic.lean
@@ -4,6 +4,7 @@ import Linglib.Features.Register
 import Linglib.Features.Prominence
 import Linglib.Features.Gender
 import Linglib.Features.Clusivity
+import Linglib.Features.CoreferenceStatus
 
 /-!
 # Pronoun
@@ -63,6 +64,13 @@ structure Pronoun where
   gender : Option Features.SurfaceGender := none
   /-- Native script form (hangul, kanji, Devanagari, …). -/
   script : Option String := none
+  /-- The binding class this pro-form declares — which binding principle governs it
+      (Principle A anaphor: `.reflexive`/`.reciprocal`; Principle B pronominal:
+      `.pronoun`; Principle C R-expression). The pro-form is the source of truth for
+      its own binding role; the binding engine reads this declaration rather than
+      recovering the class from surface strings. `none` for a bare φ-shell that
+      declares no class. -/
+  bindingClass : Option Features.BindingClass := none
   deriving Repr, BEq, DecidableEq
 
 /-- Cross-linguistic *personal/referential* pronoun: the general `Pronoun` object

--- a/Linglib/Syntax/Pronoun/Mixin.lean
+++ b/Linglib/Syntax/Pronoun/Mixin.lean
@@ -1,0 +1,36 @@
+import Linglib.Syntax.Pronoun.Basic
+import Linglib.Core.Word
+
+/-!
+# The pronoun word-class as a mixin
+
+`PronounLike α` is the lexical word-class interface — a surface form and agreement
+φ-features (`UD.MorphFeatures`) — abstracted over carriers, so that the `Pronoun` record,
+a `Core.Word`, or a syntactic theory's representation are all treated uniformly. It is the
+`[Pronoun α]`-style half of the lexical mixin pair (the binding half is `Binding.Lexicon`):
+binding and agreement range over `[PronounLike α]` rather than a concrete pronoun type.
+
+## Main declarations
+
+* `PronounLike` — a carrier with a surface form and φ-features; instances for the `Pronoun`
+  record and `Core.Word`.
+-/
+
+set_option autoImplicit false
+
+/-- A carrier whose inhabitants are pronoun-like: a surface `form` and agreement φ-features
+(`phi : α → UD.MorphFeatures`). The lexical word-class interface, abstracted over carriers
+so binding/agreement can range over `[PronounLike α]`. -/
+class PronounLike (α : Type) where
+  /-- Surface form. -/
+  form : α → String
+  /-- Agreement φ-features. -/
+  phi : α → UD.MorphFeatures
+
+instance : PronounLike Pronoun where
+  form := Pronoun.form
+  phi := fun p => p.toWord.phi
+
+instance : PronounLike Word where
+  form := Word.form
+  phi := Word.phi

--- a/Linglib/Syntax/Pronoun/Mixin.lean
+++ b/Linglib/Syntax/Pronoun/Mixin.lean
@@ -6,9 +6,9 @@ import Linglib.Core.Word
 
 `PronounLike α` is the lexical word-class interface — a surface form and agreement
 φ-features (`UD.MorphFeatures`) — abstracted over carriers, so that the `Pronoun` record,
-a `Core.Word`, or a syntactic theory's representation are all treated uniformly. It is the
-`[Pronoun α]`-style half of the lexical mixin pair (the binding half is `Binding.Lexicon`):
-binding and agreement range over `[PronounLike α]` rather than a concrete pronoun type.
+a `Core.Word`, or a syntactic theory's representation are all treated uniformly, so binding
+and agreement range over `[PronounLike α]` rather than a concrete pronoun type. A pro-form's
+binding role is carried separately, by the `Pronoun.bindingClass` declaration.
 
 ## Main declarations
 


### PR DESCRIPTION
Make a pro-form declare its `BindingClass` on the entry, and make *where the binding class comes from* polymorphic — `Features.BindingSource α := α → Option BindingClass`.

- Each English pronoun entry def declares its `Pronoun.bindingClass`; `classifyNominal : BindingSource Word` **reads that declaration** (lexicon lookup), so the three binding studies (Chomsky1981/SagWasowBender2003/Hudson1990) are now declaration-driven — one source of truth, no list-membership classifier.
- `Pronoun.{IsAnaphor,IsPronominal,IsRExpression}` predicates; `reflexives_are_anaphors` checks the tagging.
- `BindingSource` names the source abstraction: the lexical declaration ([chomsky-1981]'s GB classes) is one; structural (HPSG) and contextual (minimal-pronoun) are future instances.
- Dropped the unconsumed `PronounLike` and the redundant second classifier per a multi-agent audit.