### PR TITLE
feat(Semantics/Aspect): dimension-typed scales; derived boundedness

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2423,6 +2423,7 @@ import Linglib.Semantics.Tense.ConditionalShift
 import Linglib.Semantics.Aspect.Basic
 import Linglib.Semantics.Aspect.Composition
 import Linglib.Semantics.Aspect.SubintervalProperty
+import Linglib.Semantics.Aspect.Dimension
 import Linglib.Semantics.Aspect.DegreeAchievement
 import Linglib.Semantics.Aspect.ScalarTelicity
 import Linglib.Semantics.Aspect.ChangeOfState

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -885,7 +885,7 @@ def crack : VerbEntry := .mkRegular {
   unaccusative := true
   vendlerClass := some .achievement
   degreeAchievementScale := some {
-    scaleBoundedness := .closed, dimension := "cracking",
+    dimension := .cracking,
     baseAdjective := some "cracked" }
   causative := some .make
   levinClass := some .break_ }
@@ -899,7 +899,7 @@ def dent : VerbEntry := .mkRegular {
   unaccusative := true
   vendlerClass := some .achievement
   degreeAchievementScale := some {
-    scaleBoundedness := .closed, dimension := "denting",
+    dimension := .denting,
     baseAdjective := some "dented" }
   causative := some .make
   levinClass := some .break_ }
@@ -915,7 +915,7 @@ def scratch : VerbEntry := .mkRegular {
   unaccusative := true
   vendlerClass := some .achievement
   degreeAchievementScale := some {
-    scaleBoundedness := .closed, dimension := "scratching",
+    dimension := .scratching,
     baseAdjective := some "scratched" }
   causative := some .make
   levinClass := some .break_ }
@@ -2219,7 +2219,7 @@ def clean : VerbEntry := .mkRegular {
   complementType := .np
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
-    scaleBoundedness := .closed, dimension := "cleanliness",
+    dimension := .cleanliness,
     baseAdjective := some "clean" }
   verbIncClass := some .sinc
   levinClass := some .clear }
@@ -2686,7 +2686,7 @@ def bend : VerbEntry where
   complementType := .np
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
-    scaleBoundedness := .closed, dimension := "curvature" }
+    dimension := .curvature }
   causative := some .make
   levinClass := some .bend
 
@@ -2697,7 +2697,7 @@ def boil : VerbEntry := .mkRegular {
   complementType := .np
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
-    scaleBoundedness := .closed, dimension := "temperature",
+    dimension := .boiling,
     baseAdjective := some "hot" }
   causative := some .make
   levinClass := some .cooking }
@@ -2711,7 +2711,7 @@ def rust : VerbEntry := .mkRegular {
   unaccusative := true
   vendlerClass := some .activity
   degreeAchievementScale := some {
-    scaleBoundedness := .open_, dimension := "corrosion" }
+    dimension := .corrosion }
   levinClass := some .entitySpecificCoS }
 
 /-- "increase" — Levin 45.6 Calibratable CoS verbs (degree achievements).
@@ -2721,7 +2721,7 @@ def increase : VerbEntry := .mkRegular {
   complementType := .np
   vendlerClass := some .activity
   degreeAchievementScale := some {
-    scaleBoundedness := .open_, dimension := "quantity" }
+    dimension := .quantity }
   levinClass := some .calibratableCoS }
 
 -- ════════════════════════════════════════════════════
@@ -2735,7 +2735,7 @@ def straighten : VerbEntry := .mkRegular {
   complementType := .np
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
-    scaleBoundedness := .closed, dimension := "straightness",
+    dimension := .straightness,
     baseAdjective := some "straight" }
   levinClass := some .otherCoS }
 
@@ -2746,7 +2746,7 @@ def flatten : VerbEntry := .mkRegular {
   complementType := .np
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
-    scaleBoundedness := .closed, dimension := "flatness",
+    dimension := .flatness,
     baseAdjective := some "flat" }
   levinClass := some .otherCoS }
 
@@ -2757,7 +2757,7 @@ def open_ : VerbEntry := .mkRegular {
   complementType := .np
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
-    scaleBoundedness := .closed, dimension := "openness",
+    dimension := .openness,
     baseAdjective := some "open" }
   levinClass := some .otherCoS }
 
@@ -2768,7 +2768,7 @@ def lengthen : VerbEntry := .mkRegular {
   complementType := .np
   vendlerClass := some .activity
   degreeAchievementScale := some {
-    scaleBoundedness := .open_, dimension := "length",
+    dimension := .length,
     baseAdjective := some "long" }
   levinClass := some .calibratableCoS }
 
@@ -2779,7 +2779,7 @@ def widen : VerbEntry := .mkRegular {
   complementType := .np
   vendlerClass := some .activity
   degreeAchievementScale := some {
-    scaleBoundedness := .open_, dimension := "width",
+    dimension := .width,
     baseAdjective := some "wide" }
   levinClass := some .calibratableCoS }
 
@@ -2790,7 +2790,7 @@ def cool : VerbEntry := .mkRegular {
   complementType := .np
   vendlerClass := some .activity
   degreeAchievementScale := some {
-    scaleBoundedness := .open_, dimension := "temperature",
+    dimension := .temperature,
     baseAdjective := some "cool" }
   levinClass := some .otherCoS }
 
@@ -2801,7 +2801,7 @@ def warm : VerbEntry := .mkRegular {
   complementType := .np
   vendlerClass := some .activity
   degreeAchievementScale := some {
-    scaleBoundedness := .open_, dimension := "temperature",
+    dimension := .temperature,
     baseAdjective := some "warm" }
   levinClass := some .otherCoS }
 

--- a/Linglib/Semantics/Aspect/DegreeAchievement.lean
+++ b/Linglib/Semantics/Aspect/DegreeAchievement.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Scales.Scale
+import Linglib.Semantics.Aspect.Dimension
 import Linglib.Features.Aktionsart
 
 /-!
@@ -34,16 +35,21 @@ open Features
     Scales with a maximum (closed, upper-bounded) yield telic VPs;
     scales without a maximum (open, lower-bounded) yield atelic VPs. -/
 structure DegreeAchievementScale where
-  /-- The adjectival base's scale boundedness. -/
-  scaleBoundedness : Boundedness
-  /-- The dimension of change (height, temperature, fullness,...). -/
-  dimension : String
+  /-- The scalar dimension the base adjective measures. Its boundedness is the
+      order-mixin profile of the dimension's degree type, recovered by the derived
+      `scaleBoundedness` below — not stored. -/
+  dimension : ScalarTelicity.Dimension
   /-- Citation form of the base adjective (if deadjectival). -/
   baseAdjective : Option String := none
   deriving Repr, BEq
 
+/-- The base scale's boundedness, as a derived view of the dimension (the scale's
+    shape is read off the dimension's order structure, not stored per verb). -/
+def DegreeAchievementScale.scaleBoundedness (s : DegreeAchievementScale) : Boundedness :=
+  s.dimension.boundedness
+
 instance : Inhabited DegreeAchievementScale where
-  default := { scaleBoundedness := .open_, dimension := "" }
+  default := { dimension := .unspecified }
 
 /-- Derive default telicity from scale boundedness — the central claim of
     [kennedy-levin-2008]. Scales with a maximum → telic; scales without → atelic.
@@ -67,31 +73,23 @@ def DegreeAchievementScale.defaultVendlerClass (s : DegreeAchievementScale) : Ve
 -- ════════════════════════════════════════════════════
 
 section
-variable (d : String) (a : Option String)
+variable (a : Option String)
 
-/-- Closed scaleBoundedness → telic. -/
-theorem closed_scale_telic :
-    (DegreeAchievementScale.mk .closed d a).defaultTelicity = .telic := rfl
+/-- A closed dimension (e.g. *straightness*) → telic. -/
+theorem closed_dimension_telic :
+    (DegreeAchievementScale.mk .straightness a).defaultTelicity = .telic := rfl
 
-/-- Open scaleBoundedness → atelic. -/
-theorem open_scale_atelic :
-    (DegreeAchievementScale.mk .open_ d a).defaultTelicity = .atelic := rfl
+/-- An open dimension (e.g. *width*) → atelic. -/
+theorem open_dimension_atelic :
+    (DegreeAchievementScale.mk .width a).defaultTelicity = .atelic := rfl
 
-/-- Upper-bounded → telic (has max → bounded mΔ). -/
-theorem upperBounded_telic :
-    (DegreeAchievementScale.mk .upperBounded d a).defaultTelicity = .telic := rfl
+/-- A closed dimension → accomplishment. -/
+theorem closed_dimension_accomplishment :
+    (DegreeAchievementScale.mk .straightness a).defaultVendlerClass = .accomplishment := rfl
 
-/-- Lower-bounded → atelic (no max → unbounded mΔ). -/
-theorem lowerBounded_atelic :
-    (DegreeAchievementScale.mk .lowerBounded d a).defaultTelicity = .atelic := rfl
-
-/-- Closed scaleBoundedness → accomplishment. -/
-theorem closed_scale_accomplishment :
-    (DegreeAchievementScale.mk .closed d a).defaultVendlerClass = .accomplishment := rfl
-
-/-- Open scaleBoundedness → activity. -/
-theorem open_scale_activity :
-    (DegreeAchievementScale.mk .open_ d a).defaultVendlerClass = .activity := rfl
+/-- An open dimension → activity. -/
+theorem open_dimension_activity :
+    (DegreeAchievementScale.mk .width a).defaultVendlerClass = .activity := rfl
 
 end
 

--- a/Linglib/Semantics/Aspect/Dimension.lean
+++ b/Linglib/Semantics/Aspect/Dimension.lean
@@ -1,0 +1,42 @@
+import Linglib.Core.Scales.Defs
+
+/-!
+# Scalar dimensions
+
+A *dimension* is what a scalar (degree-achievement) verb's base adjective
+measures — straightness, width, temperature, … . It is the categorical primitive
+a fragment entry stores; the scale's **boundedness is not stored** but recovered
+from the dimension as a derived view (`Dimension.boundedness`), grounded to the
+order structure of the dimension's degree type in `Semantics/Aspect/ScalarTelicity.lean`.
+
+This replaces storing `Boundedness` as a flag on each verb: distinct dimensions
+that share a boundedness shape (e.g. `width` and `length`) stay distinct, and a
+single physical quantity used on different scales is distinguished — *boil*
+targets a bounded `boiling` scale, *cool*/*warm* an open `temperature` one.
+-/
+
+namespace ScalarTelicity
+
+open Core.Scale (Boundedness)
+
+/-- The scalar dimension a degree-achievement verb's base adjective measures. -/
+inductive Dimension
+  /-- Closed scales (a maximal degree exists → telic). -/
+  | straightness | flatness | openness | cleanliness | curvature
+  | cracking | denting | scratching | boiling
+  /-- Open / unbounded-above scales (no maximal degree → atelic). -/
+  | length | width | temperature | corrosion | quantity
+  /-- No committed dimension (default). -/
+  | unspecified
+  deriving DecidableEq, Repr, BEq
+
+/-- The boundedness shape of a dimension — a derived categorical view of whether
+    its degree type has a greatest element. Grounded to the order mixin by
+    `ScalarTelicity.hasGreatest_degree_iff_closed`. -/
+def Dimension.boundedness : Dimension → Boundedness
+  | .straightness | .flatness | .openness | .cleanliness | .curvature
+  | .cracking | .denting | .scratching | .boiling => .closed
+  | .length | .width | .temperature | .corrosion | .quantity
+  | .unspecified => .open_
+
+end ScalarTelicity

--- a/Linglib/Semantics/Aspect/ScalarTelicity.lean
+++ b/Linglib/Semantics/Aspect/ScalarTelicity.lean
@@ -1,5 +1,7 @@
+import Linglib.Semantics.Aspect.Dimension
 import Linglib.Semantics.Degree.MeasureFunction
 import Linglib.Semantics.ArgumentStructure.Affectedness.Hierarchy
+import Linglib.Core.Scales.Bounds
 import Mathlib.Order.BoundedOrder.Basic
 import Mathlib.Order.Max
 import Mathlib.Order.WithBot
@@ -110,24 +112,40 @@ end
 
 /-! ### Dimensions: boundedness as the order structure of the degree type
 
-A *dimension* (what the adjective measures) is the categorical primitive; its
-boundedness is the order-mixin profile of its degree type, read off structurally
-rather than stored. -/
+`Dimension` (in `Semantics/Aspect/Dimension.lean`) is the categorical primitive a
+fragment stores. Its boundedness is *not* stored: each dimension has a degree type
+(`Dimension.degree`) whose order-mixin profile determines it, and
+`hasGreatest_degree_iff_closed` grounds the derived `Dimension.boundedness` view to
+that order structure. -/
 
-/-- Scalar dimensions a degree-achievement verb's base adjective can measure. -/
-inductive Dimension
-  | straightness | fullness | cleanliness
-  | width | length | height
-  | temperature
-  deriving DecidableEq, Repr
+open Core.Scale (Boundedness HasGreatest hasGreatest_of_orderTop not_hasGreatest_of_noMaxOrder)
 
 /-- The degree type for each dimension. Boundedness is structural: closed
     dimensions carry `OrderTop` (`WithTop ℕ`), unbounded-above ones `NoMaxOrder`
     (`ℕ`). The carrier is a computable order-shape, not a real magnitude — only the
     mixin matters. -/
 abbrev Dimension.degree : Dimension → Type
-  | .straightness | .fullness | .cleanliness => WithTop ℕ
-  | .width | .length | .height | .temperature => ℕ
+  | .straightness | .flatness | .openness | .cleanliness | .curvature
+  | .cracking | .denting | .scratching | .boiling => WithTop ℕ
+  | .length | .width | .temperature | .corrosion | .quantity
+  | .unspecified => ℕ
+
+instance (d : Dimension) : LinearOrder d.degree := by cases d <;> exact inferInstance
+
+/-- **Grounding.** The derived `Dimension.boundedness` view agrees with the order
+    structure: a dimension is closed exactly when its degree type has a greatest
+    element. So `boundedness` is not a free-standing table — it tracks `OrderTop` /
+    `NoMaxOrder` on `Dimension.degree`. -/
+theorem hasGreatest_degree_iff_closed (d : Dimension) :
+    HasGreatest d.degree ↔ d.boundedness = .closed := by
+  cases d
+  case straightness | flatness | openness | cleanliness | curvature
+    | cracking | denting | scratching | boiling =>
+      show HasGreatest (WithTop ℕ) ↔ _
+      exact iff_of_true hasGreatest_of_orderTop rfl
+  case length | width | temperature | corrosion | quantity | unspecified =>
+      show HasGreatest ℕ ↔ _
+      exact iff_of_false not_hasGreatest_of_noMaxOrder (by decide)
 
 /-- A closed dimension yields a telic reading (a Quantized witness at `⊤`). -/
 theorem straightness_telic :

--- a/Linglib/Studies/KennedyLevin2008.lean
+++ b/Linglib/Studies/KennedyLevin2008.lean
@@ -30,8 +30,8 @@ telic (accomplishment) verb, an open-scale base an atelic (activity) verb.
   `OrderTop` / `NoMaxOrder` mixins (witness `g_φ = ⊤`), feeding [beavers-2011]'s
   affectedness hierarchy. Here it is instantiated at the dimensions the verbs
   measure — `straighten_telic` (straightness, closed), `widen_atelic` (width,
-  open) — matched to the fragment tags by `straighten_scale_hasMax` /
-  `widen_scale_no_max`. The variable-telicity contrast of [kennedy-levin-2008] §3.3.
+  open) — grounded to the verbs' stored dimensions by `straighten_dimension` /
+  `widen_dimension`. The variable-telicity contrast of [kennedy-levin-2008] §3.3.
 
 ## Implementation notes
 
@@ -343,16 +343,14 @@ theorem widen_atelic :
       Quantized (reachesSome (δ := Dimension.width.degree)) g :=
   width_atelic
 
-/-- The dimension assignments match the fragment's current scale tags:
-    *straighten* closed (`hasMax`), *widen* open (no max). (Phase 3 of the
-    boundedness→mixin migration replaces the tag with the dimension itself.) -/
-theorem straighten_scale_hasMax :
-    straighten.toVerb.degreeAchievementScale.get!.scaleBoundedness.hasMax = true := by
-  decide
+/-- The fragment stores each verb's *dimension* directly (boundedness is derived):
+    *straighten* measures straightness, *widen* width — so `straighten_telic` /
+    `widen_atelic` above apply to the actual lexical entries. -/
+theorem straighten_dimension :
+    straighten.toVerb.degreeAchievementScale.get!.dimension = .straightness := rfl
 
-theorem widen_scale_no_max :
-    widen.toVerb.degreeAchievementScale.get!.scaleBoundedness.hasMax = false := by
-  decide
+theorem widen_dimension :
+    widen.toVerb.degreeAchievementScale.get!.dimension = .width := rfl
 
 /-! #### Telicity at the `AffectednessDegree` level -/
 


### PR DESCRIPTION
Phase 3 of the boundedness→mixin cut (builds on #111). `DegreeAchievementScale` now stores `dimension : Dimension` (what the adjective measures); `scaleBoundedness` becomes a derived view, so the scale's boundedness is read off the dimension's order structure rather than stored as a flag.

- New `Semantics/Aspect/Dimension.lean` + `Dimension.degree`/`hasGreatest_degree_iff_closed` in `ScalarTelicity.lean` ground the derived `boundedness` to `OrderTop`/`NoMaxOrder`.
- All 15 English DA fragment entries migrated; *boil*'s bounded `boiling` scale split from open `temperature` (*cool*/*warm*).