### PR TITLE
feat(Semantics/Aspect): ground telicity in order mixin, drop hasMax

### DIFF
--- a/Linglib/Semantics/Aspect/DegreeAchievement.lean
+++ b/Linglib/Semantics/Aspect/DegreeAchievement.lean
@@ -54,19 +54,15 @@ instance : Inhabited DegreeAchievementScale where
 /-- Derive default telicity from scale boundedness — the central claim of
     [kennedy-levin-2008]. Scales with a maximum → telic; scales without → atelic.
 
-    The mapping follows `Boundedness.hasMax`:
-    - `.closed` (has max) → `.telic`
-    - `.upperBounded` (has max) → `.telic`
-    - `.open_` (no max) → `.atelic`
-    - `.lowerBounded` (no max) → `.atelic` -/
+    Delegates to `Dimension.defaultTelicity` — a scale with a maximal degree gives
+    a telic verb — grounded to the order mixin in `ScalarTelicity`. -/
 def DegreeAchievementScale.defaultTelicity (s : DegreeAchievementScale) : Telicity :=
-  if s.scaleBoundedness.hasMax then .telic else .atelic
+  s.dimension.defaultTelicity
 
-/-- Derive default VendlerClass from scale boundedness.
-    All degree achievements are dynamic and durative, so:
-    telic → accomplishment, atelic → activity. -/
+/-- Default Vendler class, delegating to `Dimension.defaultVendlerClass`:
+    closed scale → accomplishment, open → activity. -/
 def DegreeAchievementScale.defaultVendlerClass (s : DegreeAchievementScale) : VendlerClass :=
-  if s.scaleBoundedness.hasMax then .accomplishment else .activity
+  s.dimension.defaultVendlerClass
 
 -- ════════════════════════════════════════════════════
 -- § Theorems
@@ -97,22 +93,24 @@ end
     degree achievements are always dynamic and durative. -/
 theorem default_vendler_is_dynamic (s : DegreeAchievementScale) :
     s.defaultVendlerClass = .accomplishment ∨ s.defaultVendlerClass = .activity := by
-  simp only [DegreeAchievementScale.defaultVendlerClass]
-  cases h : s.scaleBoundedness.hasMax <;> simp
+  simp only [DegreeAchievementScale.defaultVendlerClass,
+    ScalarTelicity.Dimension.defaultVendlerClass]
+  cases s.dimension.boundedness <;> simp
 
 /-- defaultTelicity agrees with the telicity of defaultVendlerClass. -/
 theorem telicity_vendler_agree (s : DegreeAchievementScale) :
     s.defaultVendlerClass.telicity = s.defaultTelicity := by
-  simp only [DegreeAchievementScale.defaultVendlerClass, DegreeAchievementScale.defaultTelicity]
-  cases h : s.scaleBoundedness.hasMax <;> simp [VendlerClass.telicity]
+  simp only [DegreeAchievementScale.defaultVendlerClass, DegreeAchievementScale.defaultTelicity,
+    ScalarTelicity.Dimension.defaultVendlerClass, ScalarTelicity.Dimension.defaultTelicity]
+  cases s.dimension.boundedness <;> simp [VendlerClass.telicity]
 
 -- ════════════════════════════════════════════════════
 -- § LicensingPipeline instance
 -- ════════════════════════════════════════════════════
 
-/-- LicensingPipeline instance for DegreeAchievementScale:
-    maps through scaleBoundedness directly. hasMax → closed, else open. -/
+/-- LicensingPipeline instance: a degree-achievement scale's boundedness is its
+    dimension's (a derived view, no stored flag). -/
 instance : LicensingPipeline DegreeAchievementScale where
-  toBoundedness s := if s.scaleBoundedness.hasMax then .closed else .open_
+  toBoundedness s := s.scaleBoundedness
 
 end Features.DegreeAchievement

--- a/Linglib/Semantics/Aspect/Dimension.lean
+++ b/Linglib/Semantics/Aspect/Dimension.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Scales.Defs
+import Linglib.Features.Aktionsart
 
 /-!
 # Scalar dimensions
@@ -18,6 +19,7 @@ targets a bounded `boiling` scale, *cool*/*warm* an open `temperature` one.
 namespace ScalarTelicity
 
 open Core.Scale (Boundedness)
+open Features (Telicity VendlerClass)
 
 /-- The scalar dimension a degree-achievement verb's base adjective measures. -/
 inductive Dimension
@@ -38,5 +40,20 @@ def Dimension.boundedness : Dimension → Boundedness
   | .cracking | .denting | .scratching | .boiling => .closed
   | .length | .width | .temperature | .corrosion | .quantity
   | .unspecified => .open_
+
+/-- Default telicity, derived from the dimension's boundedness (a scale with a
+    maximal degree gives a telic degree achievement). Grounded to the order mixin
+    by `ScalarTelicity.defaultTelicity_telic_iff_hasGreatest`. -/
+def Dimension.defaultTelicity (d : Dimension) : Telicity :=
+  match d.boundedness with
+  | .closed | .upperBounded => .telic
+  | .open_ | .lowerBounded => .atelic
+
+/-- Default Vendler class: degree achievements are dynamic and durative, so a
+    closed scale gives an accomplishment, an open one an activity. -/
+def Dimension.defaultVendlerClass (d : Dimension) : VendlerClass :=
+  match d.boundedness with
+  | .closed | .upperBounded => .accomplishment
+  | .open_ | .lowerBounded => .activity
 
 end ScalarTelicity

--- a/Linglib/Semantics/Aspect/ScalarTelicity.lean
+++ b/Linglib/Semantics/Aspect/ScalarTelicity.lean
@@ -147,6 +147,16 @@ theorem hasGreatest_degree_iff_closed (d : Dimension) :
       show HasGreatest ℕ ↔ _
       exact iff_of_false not_hasGreatest_of_noMaxOrder (by decide)
 
+/-- **The Kennedy–Levin thesis, as a theorem.** The computable
+    `Dimension.defaultTelicity` table is exactly the order-theoretic fact: a
+    dimension is telic iff its degree type has a greatest element (`OrderTop`). So
+    the telicity a fragment consumes is grounded in the scale's order structure,
+    not stipulated. -/
+theorem defaultTelicity_telic_iff_hasGreatest (d : Dimension) :
+    d.defaultTelicity = .telic ↔ HasGreatest d.degree := by
+  rw [hasGreatest_degree_iff_closed]
+  cases d <;> simp [Dimension.defaultTelicity, Dimension.boundedness]
+
 /-- A closed dimension yields a telic reading (a Quantized witness at `⊤`). -/
 theorem straightness_telic :
     ∃ g : Dimension.straightness.degree,


### PR DESCRIPTION
Phase 4 (final) of the boundedness→mixin cut. Degree-achievement telicity no longer routes through `Boundedness.hasMax`: `defaultTelicity`/`defaultVendlerClass` delegate to `Dimension.defaultTelicity`/`defaultVendlerClass`, and `LicensingPipeline` reads the derived `scaleBoundedness` directly.

- New capstone `defaultTelicity_telic_iff_hasGreatest`: the computable telicity table *is* the order-theoretic fact — a dimension is telic iff its degree type has a greatest element (`OrderTop`). The Kennedy–Levin thesis as a theorem.
- `Boundedness`/`hasMax` survive only as the derived classification view (used by other, non-DA consumers).