### PR TITLE
refactor(Core/Scales): audit and compress EpistemicScale

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1557,6 +1557,7 @@ import Linglib.Studies.TrinhHaida2015
 import Linglib.Studies.Yalcin2007
 import Linglib.Studies.Mandelkern2019
 import Linglib.Studies.KlinedinstRothschild2012
+import Linglib.Studies.HollidayIcard2013
 import Linglib.Studies.HollidayMandelkern2024
 import Linglib.Studies.Haspelmath1997
 import Linglib.Studies.AlonsoOvalleMenendezBenito2010

--- a/Linglib/Core/Logic/BeliefRevision.lean
+++ b/Linglib/Core/Logic/BeliefRevision.lean
@@ -189,8 +189,8 @@ private theorem mu_eq_zero_of_singletons {W : Type*} [Fintype W] [DecidableEq W]
   | cons a t ha ih =>
     intro hall
     rw [Finset.coe_cons, Set.insert_eq a ↑t]
-    have hdisj : ∀ x, x ∈ ({a} : Set W) → x ∉ (↑t : Set W) :=
-      fun x hx hxt => ha (Set.mem_singleton_iff.mp hx ▸ Finset.mem_coe.mp hxt)
+    have hdisj : Disjoint ({a} : Set W) ↑t :=
+      Set.disjoint_singleton_left.mpr fun hxt => ha (Finset.mem_coe.mp hxt)
     rw [m.additive {a} ↑t hdisj,
         hall a (Finset.mem_cons_self a t),
         ih (fun w hw => hall w (Finset.mem_cons.mpr (Or.inr hw))),
@@ -215,7 +215,7 @@ open Core.Scale in
 private theorem condMu_compl {W : Type*}
     (m : CondMeasure W) (ψ φ : Set W) :
     m.condMu ψ φ + m.condMu ψᶜ φ = m.condMu Set.univ φ := by
-  have := m.cond_additive ψ ψᶜ φ (fun x hx hxc => hxc hx)
+  have := m.cond_additive ψ ψᶜ φ disjoint_compl_right
   rw [Set.union_compl_self] at this
   exact this.symm
 

--- a/Linglib/Core/Logic/RankingFunction.lean
+++ b/Linglib/Core/Logic/RankingFunction.lean
@@ -58,8 +58,6 @@ probabilities):
 | P(A∩B) = P(A)·P(B|A)         | κ(A∩B) = κ(A) + κ(B|A)          |
 | P(A∩B) = P(A)·P(B) (indep.)  | κ(A∩B) = κ(A) + κ(B) (indep.)   |
 
-See `ConditioningMode.ranking` in `Core/Scales/EpistemicScale/Conditional.lean`
-for the conditioning-mode classification.
 -/
 
 namespace Core.Logic.Ranking

--- a/Linglib/Core/Scales/EpistemicScale/Cancellation.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Cancellation.lean
@@ -1117,4 +1117,23 @@ theorem representable_iff_cancellation {n : ℕ} (sys : EpistemicSystemFA (Fin n
   ⟨fun ⟨m, hm⟩ => representable_implies_cancellation m hm,
    cancellation_implies_representable sys⟩
 
+/-- A null atom plus a representability oracle one cardinality down yields
+    cancellation: swap the null atom to position 0 and apply `null_elem_reduce`. -/
+theorem cancellation_of_null_atom {n : ℕ} (sys : EpistemicSystemFA (Fin (n + 2)))
+    {j : Fin (n + 2)} (hj : sys.ge ∅ {j})
+    (sub : ∀ sys' : EpistemicSystemFA (Fin (n + 1)), Representable sys') :
+    Cancellation (n + 2) sys.ge := by
+  set σ := Equiv.swap (0 : Fin (n + 2)) j with hσ
+  have h0 : (transportFA σ sys).ge ∅ {0} := by
+    rw [perm_null_iff]
+    have : σ.symm 0 = j := by simp [hσ]
+    rwa [this]
+  have hnn : ∃ i : Fin (n + 1), ¬(transportFA σ sys).ge ∅ {Fin.succ i} := by
+    obtain ⟨k, hk⟩ := not_all_null (transportFA σ sys)
+    obtain ⟨i, rfl⟩ : ∃ i, Fin.succ i = k :=
+      Fin.exists_succ_eq.mpr fun h => hk (h ▸ h0)
+    exact ⟨i, hk⟩
+  obtain ⟨m, hm⟩ := perm_repr σ sys (null_elem_reduce _ h0 hnn sub)
+  exact representable_implies_cancellation m hm
+
 end Core.Scale

--- a/Linglib/Core/Scales/EpistemicScale/Cancellation.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Cancellation.lean
@@ -99,7 +99,7 @@ private lemma mu_finset_sum {n : ℕ} (m : FinAddMeasure (Fin n))
     have hdisj : Disjoint ({a} : Set (Fin n)) ↑S :=
       Set.disjoint_singleton_left.mpr (fun h => ha (Finset.mem_coe.mp h))
     have hins : (↑(insert a S) : Set (Fin n)) = ({a} : Set (Fin n)) ∪ ↑S := by
-      rw [Finset.coe_insert]; exact Set.insert_eq a ↑S
+      rw [Finset.coe_insert, Set.insert_eq]
     rw [hins, m.additive _ _ hdisj, ih, Finset.sum_insert ha]
 
 private lemma list_sum_pos {l : List ℚ}
@@ -114,7 +114,7 @@ private lemma list_sum_pos {l : List ℚ}
       fun y hy => hnn y (List.mem_cons.mpr (Or.inr hy))
     rcases List.mem_cons.mp hx with rfl | hxtl
     · linarith [List.sum_nonneg htl_nn]
-    · linarith [hnn hd (List.mem_cons.mpr (Or.inl rfl)), ih htl_nn hxtl]
+    · linarith [hnn hd (.head _), ih htl_nn hxtl]
 
 /-- The portfolio value (weighted sum of measure differences) equals the
     dot product of singleton measures with the weighted comparison sums.
@@ -131,7 +131,7 @@ private lemma single_comp_sum {n : ℕ} (m : FinAddMeasure (Fin n))
       m.mu {i} * ((comparisonVec n L R i : ℤ) : ℚ)) := by
   rw [mu_finset_sum m L, mu_finset_sum m R, finset_sum_as_univ L, finset_sum_as_univ R,
       ← Finset.sum_sub_distrib]
-  apply Finset.sum_congr rfl; intro i _
+  refine Finset.sum_congr rfl fun i _ => ?_
   simp only [comparisonVec]
   by_cases hL : i ∈ L <;> by_cases hR : i ∈ R <;> simp_all [Finset.disjoint_left.mp hd]
 
@@ -142,9 +142,7 @@ private lemma portfolio_interchange {n : ℕ} (m : FinAddMeasure (Fin n))
   induction P with
   | nil =>
     simp only [List.map_nil, List.sum_nil]
-    symm; apply Finset.sum_eq_zero; intro i _
-    show m.mu {i} * (List.map _ []).sum = 0
-    simp
+    exact (Finset.sum_eq_zero fun i _ => by simp [Portfolio.weightedSum]).symm
   | cons wc tl ih =>
     simp only [List.map_cons, List.sum_cons]; rw [ih]
     -- Unfold weightedSum for cons
@@ -156,7 +154,7 @@ private lemma portfolio_interchange {n : ℕ} (m : FinAddMeasure (Fin n))
     -- Suffices: w*(mu L - mu R) = Σ mu{i}*(w*compVec i)
     congr 1
     rw [single_comp_sum m wc.left wc.right wc.disjoint, Finset.mul_sum]
-    apply Finset.sum_congr rfl; intro i _; exact mul_left_comm _ _ _
+    exact Finset.sum_congr rfl fun i _ => mul_left_comm _ _ _
 
 /-- **Easy direction**: If μ represents the ordering, no neutral portfolio has a
     strict member. Each comparison contributes wⱼ·(μ(Aⱼ)−μ(Bⱼ)) ≥ 0 to the
@@ -175,7 +173,7 @@ theorem representable_implies_cancellation {n : ℕ}
   have hnn : ∀ x ∈ P.map f, (0 : ℚ) ≤ x := by
     intro x hx
     obtain ⟨wc', hwc'_mem, rfl⟩ := List.mem_map.mp hx
-    exact mul_nonneg (le_of_lt wc'.weight_pos)
+    exact mul_nonneg wc'.weight_pos.le
       (sub_nonneg.mpr ((hm _ _).mp (hValid wc' hwc'_mem)))
   -- The strict term is strictly positive
   have hlt : m.mu ↑wc.left > m.mu ↑wc.right := by
@@ -230,23 +228,16 @@ private theorem feasible_to_measure {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     Representable sys := by
   obtain ⟨hnn, hsum, hcompat⟩ := hp
   -- Nonneg: each summand is nonneg
-  have h_nonneg : ∀ A, 0 ≤ atomMu p A := by
-    intro A; simp only [atomMu]
-    induction (Finset.univ : Finset (Fin n)) using Finset.induction_on with
-    | empty => simp
-    | @insert a s has ih =>
-      rw [Finset.sum_insert has]
-      exact add_nonneg (by split <;> [exact hnn a; exact le_refl 0]) ih
+  have h_nonneg : ∀ A, 0 ≤ atomMu p A := fun A =>
+    Finset.sum_nonneg fun i _ => by split <;> [exact hnn i; rfl]
   -- Finite additivity via pointwise case split on membership
   have h_additive : ∀ A B : Set (Fin n), Disjoint A B →
       atomMu p (A ∪ B) = atomMu p A + atomMu p B := by
     intro A B hAB
-    have hdisj : ∀ x ∈ A, x ∉ B := fun x hx => Set.disjoint_left.mp hAB hx
     simp only [atomMu, ← Finset.sum_add_distrib]
-    apply Finset.sum_congr rfl
-    intro i _
+    refine Finset.sum_congr rfl fun i _ => ?_
     by_cases hA : i ∈ A <;> by_cases hB : i ∈ B <;>
-      simp_all [Set.mem_union]
+      simp_all [Set.mem_union, Set.disjoint_left.mp hAB]
   -- Normalization: all atoms in univ
   have h_total : atomMu p Set.univ = 1 := by
     simp only [atomMu, Set.mem_univ, ite_true, hsum]
@@ -272,8 +263,7 @@ private theorem feasible_to_measure {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     exact atomMu_eq_finset_sum p _
   -- Unfold inducedGe (a def, not auto-reduced) and rewrite atomMu to finset sums
   change sys.ge C D ↔ atomMu p C ≥ atomMu p D
-  rw [hmuC, hmuD]
-  exact key
+  rw [hmuC, hmuD]; exact key
 
 -- ── Step 4a. Not all singletons null ─────────────
 
@@ -291,7 +281,7 @@ private lemma ge_empty_of_all_null {n : ℕ} (sys : EpistemicSystemFA (Fin n))
       ext x; simp only [Set.mem_diff, Set.mem_union, Set.mem_singleton_iff, Finset.mem_coe]
       constructor
       · rintro ⟨hx | hx, hnx⟩ <;> [exact hx; exact absurd hx hnx]
-      · intro hx; subst hx; exact ⟨Or.inl rfl, fun h => haS' (Finset.mem_coe.mp h)⟩
+      · rintro rfl; exact ⟨Or.inl rfl, fun h => haS' (Finset.mem_coe.mp h)⟩
     rw [Finset.coe_insert, Set.insert_eq]
     exact sys.trans ∅ ↑S' ({a} ∪ ↑S') ih
       (by rw [sys.additive ↑S' ({a} ∪ ↑S'), h1, h2]; exact hall a)
@@ -313,63 +303,15 @@ private lemma finRange_map_sum {α : Type*} [AddCommMonoid α] {k : ℕ} (f : Fi
     rw [List.finRange_succ, List.map_cons, List.sum_cons, List.map_map]
     rw [ih (f ∘ Fin.succ), Fin.sum_univ_succ]; simp [Function.comp]
 
-/-- Split a sum over `Fin ((n + 2) + k)` into nonneg + normUp + normLo + ordering. -/
-private lemma sum_split_n2k {n k : ℕ} (f : Fin ((n + 2) + k) → ℚ) :
-    ∑ i : Fin ((n + 2) + k), f i =
-    (∑ i : Fin n, f ⟨i.val, by omega⟩) +
-    f ⟨n, by omega⟩ + f ⟨n + 1, by omega⟩ +
-    (∑ m : Fin k, f ⟨n + 2 + m.val, by omega⟩) := by
-  simp only [Fin.sum_univ_add, Fin.sum_univ_two, Fin.natAdd, Fin.castAdd, Fin.castLE,
-    Fin.val_zero, Fin.val_one, Nat.add_zero, add_assoc]
-
 /-- The comparison-vector dot product equals the finset-sum difference. -/
 private lemma compVec_as_sum_diff {n : ℕ} (A B : Finset (Fin n)) (x : Fin n → ℚ)
     (hdisj : Disjoint A B) :
     ∑ j : Fin n, ((comparisonVec n A B j : ℤ) : ℚ) * x j = A.sum x - B.sum x := by
   rw [finset_sum_as_univ A x, finset_sum_as_univ B x, ← Finset.sum_sub_distrib]
-  apply Finset.sum_congr rfl; intro j _
+  refine Finset.sum_congr rfl fun j _ => ?_
   simp only [comparisonVec]
-  by_cases hA : j ∈ A <;> by_cases hB : j ∈ B
-  · exact absurd hB (Finset.disjoint_left.mp hdisj hA)
-  · simp [hA, hB]
-  · simp [hA, hB]
-  · simp [hA, hB]
-
-/-- Construct a portfolio from Fin-indexed data: pairs with positive weights. -/
-private noncomputable def portfolioOfWeights {n : ℕ}
-    (pairs : List (Finset (Fin n) × Finset (Fin n)))
-    (ws : Fin pairs.length → ℚ)
-    (h_disj : ∀ m : Fin pairs.length, Disjoint (pairs.get m).1 (pairs.get m).2)
-    (h_pos : ∀ m : Fin pairs.length, 0 < ws m) :
-    Portfolio n :=
-  (List.finRange pairs.length).map fun m =>
-    ⟨(pairs.get m).1, (pairs.get m).2, ws m, h_disj m, h_pos m⟩
-
-/-- The weighted sum of `portfolioOfWeights` equals the Fin-indexed sum. -/
-private theorem weightedSum_portfolioOfWeights {n : ℕ}
-    (pairs : List (Finset (Fin n) × Finset (Fin n)))
-    (ws : Fin pairs.length → ℚ)
-    (h_disj : ∀ m, Disjoint (pairs.get m).1 (pairs.get m).2)
-    (h_pos : ∀ m, 0 < ws m) (j : Fin n) :
-    Portfolio.weightedSum (portfolioOfWeights pairs ws h_disj h_pos) j =
-    ∑ m : Fin pairs.length,
-      ws m * ((comparisonVec n (pairs.get m).1 (pairs.get m).2 j : ℤ) : ℚ) := by
-  simp only [portfolioOfWeights, Portfolio.weightedSum, List.map_map]
-  exact finRange_map_sum _
-
-/-- Validity of `portfolioOfWeights`: each entry's pair has `ge`. -/
-private theorem isValid_portfolioOfWeights {n : ℕ}
-    (pairs : List (Finset (Fin n) × Finset (Fin n)))
-    (ws : Fin pairs.length → ℚ)
-    (h_disj : ∀ m, Disjoint (pairs.get m).1 (pairs.get m).2)
-    (h_pos : ∀ m, 0 < ws m)
-    (ge : Set (Fin n) → Set (Fin n) → Prop)
-    (h_ge : ∀ m : Fin pairs.length, ge ↑(pairs.get m).1 ↑(pairs.get m).2) :
-    (portfolioOfWeights pairs ws h_disj h_pos).isValid ge := by
-  intro wc hwc
-  simp only [portfolioOfWeights] at hwc
-  obtain ⟨m, _, rfl⟩ := List.mem_map.mp hwc
-  exact h_ge m
+  by_cases hA : j ∈ A <;> by_cases hB : j ∈ B <;>
+    simp_all [Finset.disjoint_left.mp hdisj]
 
 /-- All disjoint `ge`-pairs: disjoint (A, B) where `sys.ge ↑A ↑B`. -/
 private noncomputable def gePairsOf {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
@@ -381,266 +323,21 @@ private theorem gePairs_mem {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     (A B : Finset (Fin n)) (hd : Disjoint A B) (hge : sys.ge ↑A ↑B) :
     (A, B) ∈ gePairsOf sys := by
   simp only [gePairsOf, Finset.mem_toList, Finset.mem_filter, Finset.mem_product,
-    Finset.mem_univ, true_and]
-  exact ⟨hd, hge⟩
+    Finset.mem_univ, true_and]; exact ⟨hd, hge⟩
 
 private theorem gePairs_disj {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     (m : Fin (gePairsOf sys).length) :
     Disjoint ((gePairsOf sys).get m).1 ((gePairsOf sys).get m).2 := by
   have := List.get_mem (gePairsOf sys) m
-  simp only [gePairsOf, Finset.mem_toList, Finset.mem_filter] at this
-  exact this.2.1
+  simp only [gePairsOf, Finset.mem_toList, Finset.mem_filter] at this; exact this.2.1
 
 private theorem gePairs_ge {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     (m : Fin (gePairsOf sys).length) :
     sys.ge ↑((gePairsOf sys).get m).1 ↑((gePairsOf sys).get m).2 := by
   have := List.get_mem (gePairsOf sys) m
-  simp only [gePairsOf, Finset.mem_toList, Finset.mem_filter] at this
-  exact this.2.2
+  simp only [gePairsOf, Finset.mem_toList, Finset.mem_filter] at this; exact this.2.2
 
-/-- **Farkas alternative for the ordering LP**: either a one-directional
-    probability representation exists, or there is a valid portfolio
-    whose weighted comparison sums are strictly negative at every atom.
-
-    Applies `Polyhedral.farkas` to the system encoding the ordering LP
-    {p ≥ 0, 1ᵀp = 1, compVec(A,B)·p ≥ 0 for each ge-pair}, then maps
-    both Farkas alternatives back to the goal.
-
-    Note: this gives the **one-directional** (→) condition only.
-    Strengthening to ↔ requires `cancel_strengthens_to_bidir`. -/
-private theorem farkas_ordering_lp {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
-    (∃ p : Fin n → ℚ, (∀ i, 0 ≤ p i) ∧ Finset.univ.sum p = 1 ∧
-      ∀ (A B : Finset (Fin n)), Disjoint A B →
-        sys.ge ↑A ↑B → A.sum p ≥ B.sum p) ∨
-    (∃ P : Portfolio n, P.isValid sys.ge ∧
-      ∀ i : Fin n, P.weightedSum i < 0) := by
-  -- Enumerate all disjoint ge-pairs
-  let gePairs : List (Finset (Fin n) × Finset (Fin n)) := gePairsOf sys
-  let k := gePairs.length
-  -- Constraint function: n nonnegativity + 1 normUp + 1 normLo + k ordering
-  let ineqFn : Fin ((n + 2) + k) → Polyhedral.Ineq n := fun i =>
-    if h : i.val < n then
-      ⟨fun j => if j = ⟨i.val, h⟩ then -1 else 0, 0⟩
-    else if _ : i.val = n then
-      ⟨fun _ => 1, 1⟩
-    else if _ : i.val = n + 1 then
-      ⟨fun _ => -1, -1⟩
-    else
-      have hm : i.val - (n + 2) < k := by omega
-      let pair := gePairs.get ⟨i.val - (n + 2), hm⟩
-      ⟨fun j => -(((comparisonVec n pair.1 pair.2 j : ℤ) : ℚ)), 0⟩
-  let S : Polyhedral.System n := List.ofFn ineqFn
-  have hget : ∀ i : Fin ((n + 2) + k), ineqFn i ∈ S :=
-    fun i => List.mem_ofFn.mpr ⟨i, rfl⟩
-  have hgePairsMem : ∀ (A B : Finset (Fin n)), Disjoint A B → sys.ge ↑A ↑B →
-      (A, B) ∈ gePairs := gePairs_mem sys
-  have hgePairsDisj : ∀ m : Fin k, Disjoint (gePairs.get m).1 (gePairs.get m).2 :=
-    gePairs_disj sys
-  have hgePairsGe : ∀ m : Fin k, sys.ge ↑(gePairs.get m).1 ↑(gePairs.get m).2 :=
-    gePairs_ge sys
-  -- Apply Farkas
-  rcases Polyhedral.farkas S with ⟨x, hx⟩ | hcert
-  · -- ═══ Feasible case: extract probability vector ═══
-    left
-    have hsat : ∀ i : Fin ((n + 2) + k), (ineqFn i).sat x := fun i => hx _ (hget i)
-    refine ⟨x, ?_, ?_, ?_⟩
-    · -- Nonnegativity: from constraint -xᵢ ≤ 0
-      intro i
-      have h := hsat ⟨i.val, by omega⟩
-      simp only [ineqFn, dif_pos i.isLt, Polyhedral.Ineq.sat, Polyhedral.dot] at h
-      simp only [ite_mul, neg_one_mul, zero_mul, Finset.sum_ite_eq', Finset.mem_univ,
-        ite_true] at h
-      linarith
-    · -- Normalization: from 1ᵀx ≤ 1 and -1ᵀx ≤ -1
-      have h_up := hsat ⟨n, by omega⟩
-      have h_lo := hsat ⟨n + 1, by omega⟩
-      have hup_eq : ineqFn ⟨n, by omega⟩ = ⟨fun (_ : Fin n) => (1 : ℚ), 1⟩ := by
-        simp [ineqFn]
-      have hlo_eq : ineqFn ⟨n + 1, by omega⟩ = ⟨fun (_ : Fin n) => (-1 : ℚ), -1⟩ := by
-        simp [ineqFn]
-      rw [Polyhedral.Ineq.sat, Polyhedral.dot, hup_eq] at h_up
-      rw [Polyhedral.Ineq.sat, Polyhedral.dot, hlo_eq] at h_lo
-      simp only [one_mul] at h_up
-      simp only [neg_one_mul, Finset.sum_neg_distrib] at h_lo
-      linarith
-    · -- Ordering: from -(compVec · x) ≤ 0
-      intro A B hdisj hge
-      obtain ⟨⟨m, hm⟩, hget_m⟩ := List.mem_iff_get.mp (hgePairsMem A B hdisj hge)
-      have h := hsat ⟨n + 2 + m, by omega⟩
-      have hord_eq : ineqFn ⟨n + 2 + m, by omega⟩ =
-          ⟨fun j => -(((comparisonVec n (gePairs.get ⟨m, hm⟩).1
-            (gePairs.get ⟨m, hm⟩).2 j : ℤ) : ℚ)), 0⟩ := by
-        simp [ineqFn, show ¬(n + 2 + m < n) from by omega,
-          show ¬(n + 2 + m = n) from by omega,
-          show ¬(n + 2 + m = n + 1) from by omega]
-      rw [Polyhedral.Ineq.sat, Polyhedral.dot, hord_eq] at h
-      simp only [hget_m, neg_mul, Finset.sum_neg_distrib] at h
-      linarith [compVec_as_sum_diff A B x hdisj]
-  · -- ═══ Certificate case: build portfolio with negative weighted sums ═══
-    right
-    obtain ⟨cert⟩ := hcert
-    have hlen : S.length = (n + 2) + k := List.length_ofFn
-    have hS_get : ∀ i : Fin S.length,
-        S.get i = ineqFn (i.cast hlen) := fun i => List.get_ofFn ineqFn i
-    -- Cast cert weights to natural indices
-    let ws : Fin ((n + 2) + k) → ℚ := fun i => cert.ws (i.cast hlen.symm)
-    have ws_nn : ∀ i, 0 ≤ ws i := fun i => cert.nonneg _
-    -- Transport: reindex sums from Fin S.length to Fin ((n+2)+k)
-    have hreindex : ∀ f : Fin S.length → ℚ,
-        ∑ i : Fin S.length, f i =
-        ∑ i : Fin ((n + 2) + k), f (i.cast hlen.symm) :=
-      fun f => Fintype.sum_equiv (finCongr hlen) _ _ (fun i => by simp [finCongr])
-    have hcoeffsZero : ∀ j : Fin n,
-        ∑ i : Fin ((n + 2) + k), ws i * (ineqFn i).lhs j = 0 := by
-      intro j
-      have h := cert.coeffsZero j
-      rw [hreindex] at h; simp_rw [hS_get] at h; exact h
-    have hboundNeg :
-        ∑ i : Fin ((n + 2) + k), ws i * (ineqFn i).rhs < 0 := by
-      have h := cert.boundNeg
-      rw [hreindex] at h; simp_rw [hS_get] at h; exact h
-    -- Decompose boundNeg: ws(n) - ws(n+1) < 0
-    have hbound_decomp : ws ⟨n, by omega⟩ - ws ⟨n + 1, by omega⟩ < 0 := by
-      have h := hboundNeg
-      rw [sum_split_n2k] at h
-      have h_nn_zero : ∑ i : Fin n, ws ⟨i.val, by omega⟩ * (ineqFn ⟨i.val, by omega⟩).rhs = 0 :=
-        Finset.sum_eq_zero fun i _ => by simp [ineqFn, dif_pos i.isLt]
-      have h_ord_zero : ∑ m : Fin k, ws ⟨n + 2 + m.val, by omega⟩ *
-          (ineqFn ⟨n + 2 + m.val, by omega⟩).rhs = 0 :=
-        Finset.sum_eq_zero fun m _ => by
-          have : ineqFn ⟨n + 2 + m.val, by omega⟩ =
-              ⟨fun j => -(((comparisonVec n (gePairs.get ⟨m.val, m.isLt⟩).1
-                (gePairs.get ⟨m.val, m.isLt⟩).2 j : ℤ) : ℚ)), 0⟩ := by
-            simp [ineqFn, show ¬(n + 2 + m.val < n) from by omega,
-              show ¬(n + 2 + m.val = n) from by omega,
-              show ¬(n + 2 + m.val = n + 1) from by omega]
-          rw [this]; exact mul_zero _
-      have h_up : (ineqFn ⟨n, by omega⟩).rhs = 1 := by simp [ineqFn]
-      have h_lo : (ineqFn ⟨n + 1, by omega⟩).rhs = -1 := by
-        simp [ineqFn, show ¬(n + 1 < n) from by omega]
-      simp only [h_nn_zero, h_ord_zero, h_up, h_lo, zero_add, add_zero] at h; linarith
-    -- Helper: evaluate ineqFn at nonneg/norm/ordering indices
-    have hineq_nn : ∀ (i : Fin n) (j : Fin n),
-        (ineqFn ⟨i.val, by omega⟩).lhs j = if j = i then -1 else 0 := by
-      intro i _; simp only [ineqFn, dif_pos i.isLt]
-    have hineq_up : ∀ j : Fin n, (ineqFn ⟨n, by omega⟩).lhs j = 1 := by
-      intro _; simp [ineqFn]
-    have hineq_lo : ∀ j : Fin n, (ineqFn ⟨n + 1, by omega⟩).lhs j = -1 := by
-      intro _; simp [ineqFn, show ¬(n + 1 < n) from by omega]
-    have hineq_ord : ∀ (m : Fin k) (j : Fin n),
-        (ineqFn ⟨n + 2 + m.val, by omega⟩).lhs j =
-        -(((comparisonVec n (gePairs.get ⟨m.val, m.isLt⟩).1
-            (gePairs.get ⟨m.val, m.isLt⟩).2 j : ℤ) : ℚ)) := by
-      intro m _
-      simp [ineqFn, show ¬(n + 2 + m.val < n) from by omega,
-        show ¬(n + 2 + m.val = n) from by omega,
-        show ¬(n + 2 + m.val = n + 1) from by omega]
-    -- Decompose coeffsZero: ordering sums = -ws_nn(j) + (ws_up - ws_lo)
-    have hord_sum : ∀ j : Fin n,
-        ∑ m : Fin k, ws ⟨n + 2 + m.val, by omega⟩ *
-          (-(((comparisonVec n (gePairs.get ⟨m.val, m.isLt⟩).1
-               (gePairs.get ⟨m.val, m.isLt⟩).2 j : ℤ) : ℚ))) =
-        ws ⟨j.val, by omega⟩ - (ws ⟨n, by omega⟩ - ws ⟨n + 1, by omega⟩) := by
-      intro j; have h := hcoeffsZero j
-      rw [sum_split_n2k] at h
-      have h_nn : ∑ i : Fin n, ws ⟨i.val, by omega⟩ * (ineqFn ⟨i.val, by omega⟩).lhs j =
-          -ws ⟨j.val, by omega⟩ := by
-        rw [Finset.sum_eq_single j]
-        · rw [hineq_nn j j]; simp
-        · intro i _ hij; rw [hineq_nn i j, if_neg (Ne.symm hij)]; ring
-        · intro h; exact absurd (Finset.mem_univ j) h
-      rw [h_nn, hineq_up, hineq_lo] at h
-      simp_rw [hineq_ord] at h
-      linarith
-    -- Ordering weighted sums are < 0
-    have hord_neg : ∀ j : Fin n,
-        ∑ m : Fin k, ws ⟨n + 2 + m.val, by omega⟩ *
-          ((comparisonVec n (gePairs.get ⟨m.val, m.isLt⟩).1
-            (gePairs.get ⟨m.val, m.isLt⟩).2 j : ℤ) : ℚ) < 0 := by
-      intro j
-      have h := hord_sum j
-      have : ∑ m : Fin k, ws ⟨n + 2 + m.val, by omega⟩ *
-          ((comparisonVec n (gePairs.get ⟨m.val, m.isLt⟩).1
-            (gePairs.get ⟨m.val, m.isLt⟩).2 j : ℤ) : ℚ) =
-        -(∑ m : Fin k, ws ⟨n + 2 + m.val, by omega⟩ *
-          (-(((comparisonVec n (gePairs.get ⟨m.val, m.isLt⟩).1
-            (gePairs.get ⟨m.val, m.isLt⟩).2 j : ℤ) : ℚ)))) := by
-        simp only [mul_neg, Finset.sum_neg_distrib, neg_neg]
-      rw [this, h]
-      linarith [ws_nn ⟨j.val, by omega⟩, hbound_decomp]
-    -- Build portfolio with perturbed weights (ws_ord + ε) to ensure all > 0
-    let ws_ord : Fin k → ℚ := fun m => ws ⟨n + 2 + m.val, by omega⟩
-    by_cases hn : n = 0
-    · subst hn
-      refine ⟨[], ?_, fun j => Fin.elim0 j⟩
-      intro wc h; cases h
-    · -- n ≥ 1: use perturbed weights
-      have hn' : 0 < n := Nat.pos_of_ne_zero hn
-      let neg_sums : Fin n → ℚ := fun j =>
-        ∑ m : Fin k, ws_ord m *
-          ((comparisonVec n (gePairs.get ⟨m.val, m.isLt⟩).1
-            (gePairs.get ⟨m.val, m.isLt⟩).2 j : ℤ) : ℚ)
-      have hns_neg : ∀ j, neg_sums j < 0 := hord_neg
-      let cv_bound : ℚ := ↑k + 1
-      have hcv_pos : 0 < cv_bound := by positivity
-      let min_gap : ℚ := if _ : 0 < k then
-        Finset.univ.inf' ⟨⟨0, hn'⟩, Finset.mem_univ _⟩ (fun j => -neg_sums j)
-      else 1
-      have hmin_pos : 0 < min_gap := by
-        simp only [min_gap]; split
-        · rw [Finset.lt_inf'_iff]; exact fun j _ => neg_pos.mpr (hns_neg j)
-        · exact one_pos
-      let ε : ℚ := min_gap / (2 * cv_bound)
-      have hε_pos : 0 < ε := div_pos hmin_pos (by positivity)
-      let ws_pert : Fin k → ℚ := fun m => ws_ord m + ε
-      have h_pert_pos : ∀ m, 0 < ws_pert m :=
-        fun m => add_pos_of_nonneg_of_pos (ws_nn ⟨n + 2 + m.val, by omega⟩) hε_pos
-      let P := portfolioOfWeights gePairs ws_pert hgePairsDisj h_pert_pos
-      refine ⟨P, isValid_portfolioOfWeights _ _ _ _ _ hgePairsGe, fun j => ?_⟩
-      rw [weightedSum_portfolioOfWeights]
-      -- Perturbed sum = original sum + ε * Σ cv
-      have h_split :
-          ∑ m : Fin k, ws_pert m * ((comparisonVec n (gePairs.get m).1
-            (gePairs.get m).2 j : ℤ) : ℚ) =
-          neg_sums j + ε * ∑ m : Fin k,
-            ((comparisonVec n (gePairs.get m).1
-              (gePairs.get m).2 j : ℤ) : ℚ) := by
-        simp only [ws_pert, add_mul, Finset.sum_add_distrib, Finset.mul_sum]; ring
-      rw [h_split]
-      -- Bound each compVec entry by 1
-      have hcv_le1 : ∀ m : Fin k, ((comparisonVec n (gePairs.get m).1
-          (gePairs.get m).2 j : ℤ) : ℚ) ≤ 1 := by
-        intro m
-        suffices h : (comparisonVec n (gePairs.get m).1 (gePairs.get m).2 j : ℤ) ≤ 1 by
-          exact_mod_cast h
-        simp only [comparisonVec]
-        by_cases hA : j ∈ (gePairs.get m).1 <;> by_cases hB : j ∈ (gePairs.get m).2
-        · exact absurd hB (Finset.disjoint_left.mp (hgePairsDisj m) hA)
-        all_goals simp_all
-      -- Sum of compVec entries ≤ k
-      have hcvs_le : (∑ m : Fin k, ((comparisonVec n (gePairs.get m).1
-          (gePairs.get m).2 j : ℤ) : ℚ)) ≤ ↑k :=
-        le_trans (Finset.sum_le_sum fun m _ => hcv_le1 m)
-          (by simp [Finset.sum_const, Finset.card_univ, Fintype.card_fin])
-      -- ε * cv_bound = min_gap / 2
-      have hε_eq : ε * cv_bound = min_gap / 2 := by
-        simp only [ε]
-        rw [div_mul_eq_mul_div, mul_div_mul_right _ _ (ne_of_gt hcv_pos)]
-      -- min_gap ≤ -neg_sums j
-      have hmin_le : min_gap ≤ -neg_sums j := by
-        simp only [min_gap]; split
-        · exact Finset.inf'_le _ (Finset.mem_univ j)
-        · exfalso
-          have hk0 : k = 0 := by omega
-          have : neg_sums j = 0 := by
-            show ∑ m : Fin k, _ = 0
-            have : (Finset.univ : Finset (Fin k)) = ∅ := by
-              ext ⟨m, hm⟩; simp; omega
-            simp [this]
-          linarith [hns_neg j]
-      nlinarith [mul_le_mul_of_nonneg_left hcvs_le (le_of_lt hε_pos)]
-
--- ── Step 4b'. Cancellation strengthens → to ↔ ───
+-- ── Step 4b. The ordering LP: one Farkas application ─────
 
 /-- Split a sum over `Fin ((n + k) + K)` into nonneg + ordering + strict parts. -/
 private lemma sum_three_parts {n k K : ℕ} (f : Fin ((n + k) + K) → ℚ) :
@@ -698,38 +395,41 @@ private theorem strictPairs_mem {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     (A B : Finset (Fin n)) (hd : Disjoint A B) (hge : sys.ge ↑A ↑B) (hng : ¬sys.ge ↑B ↑A) :
     (A, B) ∈ strictPairsOf sys := by
   simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter, Finset.mem_product,
-    Finset.mem_univ, true_and]
-  exact ⟨hd, hge, hng⟩
+    Finset.mem_univ, true_and]; exact ⟨hd, hge, hng⟩
 
 private theorem strictPairs_disj {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     (m : Fin (strictPairsOf sys).length) :
     Disjoint ((strictPairsOf sys).get m).1 ((strictPairsOf sys).get m).2 := by
   have := List.get_mem (strictPairsOf sys) m
-  simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter] at this
-  exact this.2.1
+  simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter] at this; exact this.2.1
 
 private theorem strictPairs_ge {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     (m : Fin (strictPairsOf sys).length) :
     sys.ge ↑((strictPairsOf sys).get m).1 ↑((strictPairsOf sys).get m).2 := by
   have := List.get_mem (strictPairsOf sys) m
-  simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter] at this
-  exact this.2.2.1
+  simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter] at this; exact this.2.2.1
 
 private theorem strictPairs_strict {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     (m : Fin (strictPairsOf sys).length) :
     ¬sys.ge ↑((strictPairsOf sys).get m).2 ↑((strictPairsOf sys).get m).1 := by
   have := List.get_mem (strictPairsOf sys) m
-  simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter] at this
-  exact this.2.2.2
+  simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter] at this; exact this.2.2.2
 
-private theorem cancel_strengthens_to_bidir {n : ℕ} (sys : EpistemicSystemFA (Fin n))
-    (hcancel : Cancellation n sys.ge)
-    (hexists : ∃ p : Fin n → ℚ, (∀ i, 0 ≤ p i) ∧ Finset.univ.sum p = 1 ∧
-      ∀ (A B : Finset (Fin n)), Disjoint A B →
-        sys.ge ↑A ↑B → A.sum p ≥ B.sum p) :
+/-- `(univ, ∅)` is always a strict pair, so the strict list is nonempty. -/
+private theorem strictPairs_length_pos {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
+    0 < (strictPairsOf sys).length :=
+  List.length_pos_of_mem (strictPairs_mem sys Finset.univ ∅ (Finset.disjoint_empty_right _)
+    (by rw [Finset.coe_univ, Finset.coe_empty]; exact sys.mono _ _ (Set.empty_subset _))
+    (by rw [Finset.coe_univ, Finset.coe_empty]; exact sys.nonTrivial))
+
+/-- The core LP step: cancellation implies the feasibility polytope is nonempty.
+    One Farkas application to the LP {p ≥ 0; compVec·p ≥ 0 per ge-pair;
+    compVec·p ≥ 1 per strict pair}: a feasible point normalizes to a member of
+    `feasibleWeights`; an infeasibility certificate assembles a valid neutral
+    portfolio with a strict member, contradicting cancellation. -/
+private theorem cancellation_nonempty {n : ℕ} (sys : EpistemicSystemFA (Fin n))
+    (hcancel : Cancellation n sys.ge) :
     ∃ p, p ∈ feasibleWeights n sys := by
-  obtain ⟨p₀, hnn₀, hsum₀, hge₀⟩ := hexists
-  -- Enumerate all ge pairs
   let gePairs : List (Finset (Fin n) × Finset (Fin n)) := gePairsOf sys
   let k := gePairs.length
   let sp := strictPairsOf sys
@@ -740,361 +440,263 @@ private theorem cancel_strengthens_to_bidir {n : ℕ} (sys : EpistemicSystemFA (
     gePairs_disj sys
   have hgePairsGe : ∀ m : Fin k, sys.ge ↑(gePairs.get m).1 ↑(gePairs.get m).2 :=
     gePairs_ge sys
-  -- Case split: are there strict pairs?
-  by_cases hK : K = 0
-  · -- No strict pairs: p₀ is already ↔ feasible
-    refine ⟨p₀, hnn₀, hsum₀, fun A B hdisj => ⟨hge₀ A B hdisj, fun hge => ?_⟩⟩
-    -- Need: sys.ge ↑A ↑B. Suppose not → strict pair exists, contradicting K = 0
-    by_contra hng
-    have hBA : sys.ge ↑B ↑A := (sys.total ↑A ↑B).resolve_left hng
-    have hmem := strictPairs_mem sys B A hdisj.symm hBA hng
-    have hempty : (strictPairsOf sys).length = 0 := hK
-    have : (strictPairsOf sys) = [] := by
-      rcases strictPairsOf sys with _ | ⟨_, _⟩ <;> simp_all
-    simp [this] at hmem
-  · -- Strict pairs exist: build augmented LP and apply Farkas
-    have hK_pos : 0 < K := Nat.pos_of_ne_zero hK
-    -- Build constraint function: n nonneg + k ordering + K strict
-    let ineqFn : Fin ((n + k) + K) → Polyhedral.Ineq n := fun i =>
-      if h : i.val < n then
-        ⟨fun j => if j = ⟨i.val, h⟩ then -1 else 0, 0⟩
-      else if _ : i.val < n + k then
-        ⟨fun j => -(((comparisonVec n (gePairs.get ⟨i.val - n, by omega⟩).1
-            (gePairs.get ⟨i.val - n, by omega⟩).2 j : ℤ) : ℚ)), 0⟩
-      else
-        ⟨fun j => -(((comparisonVec n (sp.get ⟨i.val - (n + k), by omega⟩).1
-            (sp.get ⟨i.val - (n + k), by omega⟩).2 j : ℤ) : ℚ)), -1⟩
-    let S : Polyhedral.System n := List.ofFn ineqFn
-    have hget : ∀ i : Fin ((n + k) + K), ineqFn i ∈ S :=
-      fun i => List.mem_ofFn.mpr ⟨i, rfl⟩
-    -- Apply Farkas
-    rcases Polyhedral.farkas S with ⟨x, hx⟩ | hcert
-    · -- ═══ Feasible case: extract and normalize ═══
-      have hsat : ∀ i : Fin ((n + k) + K), (ineqFn i).sat x := fun i => hx _ (hget i)
-      -- Extract nonnegativity
-      have hx_nn : ∀ i : Fin n, 0 ≤ x i := by
-        intro i
-        have h := hsat ⟨i.val, by omega⟩
-        simp only [ineqFn, dif_pos i.isLt, Polyhedral.Ineq.sat, Polyhedral.dot] at h
-        simp only [ite_mul, neg_one_mul, zero_mul, Finset.sum_ite_eq', Finset.mem_univ,
-          ite_true] at h
-        linarith
-      -- Extract ordering constraints
-      have hx_ord : ∀ (A B : Finset (Fin n)), Disjoint A B →
-          sys.ge ↑A ↑B → A.sum x ≥ B.sum x := by
-        intro A B hdisj hge
-        obtain ⟨⟨m, hm⟩, hget_m⟩ := List.mem_iff_get.mp (hgePairsMem A B hdisj hge)
-        have h := hsat ⟨n + m, by omega⟩
-        simp only [ineqFn, show ¬(n + m < n) from by omega, dite_false,
-          show (n + m < n + k) from by omega, dite_true,
-          Polyhedral.Ineq.sat, Polyhedral.dot] at h
-        simp only [show n + m - n = m from by omega] at h
-        simp only [neg_mul, Finset.sum_neg_distrib] at h
-        have hcv := compVec_as_sum_diff A B x hdisj
-        rw [hget_m] at h; linarith
-      -- Extract strict constraints
-      have hx_strict : ∀ s : Fin K, (sp.get s).1.sum x ≥ (sp.get s).2.sum x + 1 := by
-        intro ⟨s, hs⟩
-        have h := hsat ⟨n + k + s, by omega⟩
-        simp only [ineqFn, show ¬(n + k + s < n) from by omega, dite_false,
-          show ¬(n + k + s < n + k) from by omega,
-          Polyhedral.Ineq.sat, Polyhedral.dot] at h
-        simp only [show n + k + s - (n + k) = s from by omega] at h
-        simp only [neg_mul, Finset.sum_neg_distrib] at h
-        linarith [compVec_as_sum_diff (sp.get ⟨s, hs⟩).1 (sp.get ⟨s, hs⟩).2 x
-          (strictPairs_disj sys ⟨s, hs⟩)]
-      -- Normalize: Σx > 0 (from strict constraint on pair 0)
-      have hsum_pos : 0 < Finset.univ.sum x := by
-        have hpair : 0 < (sp.get ⟨0, hK_pos⟩).1.sum x := by
-          linarith [hx_strict ⟨0, hK_pos⟩,
-            Finset.sum_nonneg (fun i (_ : i ∈ (sp.get ⟨0, hK_pos⟩).2) => hx_nn i)]
-        linarith [Finset.sum_le_univ_sum_of_nonneg hx_nn (s := (sp.get ⟨0, hK_pos⟩).1)]
-      -- Define normalized vector
-      let σ := Finset.univ.sum x
-      have hσ_pos : 0 < σ := hsum_pos
-      have hσ_ne : σ ≠ 0 := ne_of_gt hσ_pos
-      refine ⟨fun i => x i / σ, fun i => div_nonneg (hx_nn i) (le_of_lt hσ_pos), ?_, ?_⟩
-      · -- Σ(x/σ) = 1
-        show Finset.univ.sum (fun i => x i / σ) = 1
-        rw [← Finset.sum_div]; exact div_self hσ_ne
-      · -- ↔ for disjoint pairs
-        intro A B hdisj
-        constructor
-        · -- → direction
-          intro hge
-          show A.sum (fun i => x i / σ) ≥ B.sum (fun i => x i / σ)
+  have hK_pos : 0 < K := strictPairs_length_pos sys
+  -- constraint function: n nonneg + k ordering + K strict
+  let ineqFn : Fin ((n + k) + K) → Polyhedral.Ineq n := fun i =>
+    if h : i.val < n then
+      ⟨fun j => if j = ⟨i.val, h⟩ then -1 else 0, 0⟩
+    else if _ : i.val < n + k then
+      ⟨fun j => -(((comparisonVec n (gePairs.get ⟨i.val - n, by omega⟩).1
+          (gePairs.get ⟨i.val - n, by omega⟩).2 j : ℤ) : ℚ)), 0⟩
+    else
+      ⟨fun j => -(((comparisonVec n (sp.get ⟨i.val - (n + k), by omega⟩).1
+          (sp.get ⟨i.val - (n + k), by omega⟩).2 j : ℤ) : ℚ)), -1⟩
+  let S : Polyhedral.System n := List.ofFn ineqFn
+  have hget : ∀ i : Fin ((n + k) + K), ineqFn i ∈ S :=
+    fun i => List.mem_ofFn.mpr ⟨i, rfl⟩
+  -- Apply Farkas
+  rcases Polyhedral.farkas S with ⟨x, hx⟩ | hcert
+  · -- ═══ Feasible case: extract and normalize ═══
+    have hsat : ∀ i : Fin ((n + k) + K), (ineqFn i).sat x := fun i => hx _ (hget i)
+    -- Extract nonnegativity
+    have hx_nn : ∀ i : Fin n, 0 ≤ x i := by
+      intro i
+      have h := hsat ⟨i.val, by omega⟩
+      simp only [ineqFn, dif_pos i.isLt, Polyhedral.Ineq.sat, Polyhedral.dot, ite_mul,
+        neg_one_mul, zero_mul, Finset.sum_ite_eq', Finset.mem_univ, ite_true] at h
+      linarith
+    -- Extract ordering constraints
+    have hx_ord : ∀ (A B : Finset (Fin n)), Disjoint A B →
+        sys.ge ↑A ↑B → A.sum x ≥ B.sum x := by
+      intro A B hdisj hge
+      obtain ⟨⟨m, hm⟩, hget_m⟩ := List.mem_iff_get.mp (hgePairsMem A B hdisj hge)
+      have h := hsat ⟨n + m, by omega⟩
+      simp only [ineqFn, show ¬(n + m < n) from by omega, dite_false,
+        show (n + m < n + k) from by omega, dite_true,
+        Polyhedral.Ineq.sat, Polyhedral.dot] at h
+      simp only [show n + m - n = m from by omega] at h
+      simp only [neg_mul, Finset.sum_neg_distrib] at h
+      have hcv := compVec_as_sum_diff A B x hdisj
+      rw [hget_m] at h; linarith
+    -- Extract strict constraints
+    have hx_strict : ∀ s : Fin K, (sp.get s).1.sum x ≥ (sp.get s).2.sum x + 1 := by
+      intro ⟨s, hs⟩
+      have h := hsat ⟨n + k + s, by omega⟩
+      simp only [ineqFn, show ¬(n + k + s < n) from by omega, dite_false,
+        show ¬(n + k + s < n + k) from by omega,
+        Polyhedral.Ineq.sat, Polyhedral.dot] at h
+      simp only [show n + k + s - (n + k) = s from by omega] at h
+      simp only [neg_mul, Finset.sum_neg_distrib] at h
+      linarith [compVec_as_sum_diff (sp.get ⟨s, hs⟩).1 (sp.get ⟨s, hs⟩).2 x
+        (strictPairs_disj sys ⟨s, hs⟩)]
+    -- Normalize: Σx > 0 (from strict constraint on pair 0)
+    have hsum_pos : 0 < Finset.univ.sum x := by
+      have hpair : 0 < (sp.get ⟨0, hK_pos⟩).1.sum x := by
+        linarith [hx_strict ⟨0, hK_pos⟩,
+          Finset.sum_nonneg (fun i (_ : i ∈ (sp.get ⟨0, hK_pos⟩).2) => hx_nn i)]
+      linarith [Finset.sum_le_univ_sum_of_nonneg hx_nn (s := (sp.get ⟨0, hK_pos⟩).1)]
+    -- Define normalized vector
+    let σ := Finset.univ.sum x
+    have hσ_pos : 0 < σ := hsum_pos
+    have hσ_ne : σ ≠ 0 := ne_of_gt hσ_pos
+    refine ⟨fun i => x i / σ, fun i => div_nonneg (hx_nn i) (le_of_lt hσ_pos), ?_, ?_⟩
+    · -- Σ(x/σ) = 1
+      show Finset.univ.sum (fun i => x i / σ) = 1
+      rw [← Finset.sum_div]; exact div_self hσ_ne
+    · -- ↔ for disjoint pairs
+      intro A B hdisj
+      refine ⟨fun hge => ?_, fun hge => ?_⟩
+      · -- → direction
+        show A.sum (fun i => x i / σ) ≥ B.sum (fun i => x i / σ)
+        rw [← Finset.sum_div, ← Finset.sum_div]
+        exact div_le_div_of_nonneg_right (hx_ord A B hdisj hge) (le_of_lt hσ_pos)
+      · -- ← direction (contrapositive)
+        by_contra hng
+        have hBA : sys.ge ↑B ↑A := (sys.total ↑A ↑B).resolve_left hng
+        have hmem := strictPairs_mem sys B A hdisj.symm hBA hng
+        obtain ⟨⟨s, hs⟩, hgets⟩ := List.mem_iff_get.mp hmem
+        have hgap := hx_strict ⟨s, hs⟩
+        rw [hgets] at hgap
+        -- B.sum x > A.sum x, so A.sum (x/σ) < B.sum (x/σ)
+        have hlt : A.sum (fun i => x i / σ) < B.sum (fun i => x i / σ) := by
           rw [← Finset.sum_div, ← Finset.sum_div]
-          exact div_le_div_of_nonneg_right (hx_ord A B hdisj hge) (le_of_lt hσ_pos)
-        · -- ← direction (contrapositive)
-          intro hge
-          by_contra hng
-          have hBA : sys.ge ↑B ↑A := (sys.total ↑A ↑B).resolve_left hng
-          have hmem := strictPairs_mem sys B A hdisj.symm hBA hng
-          obtain ⟨⟨s, hs⟩, hgets⟩ := List.mem_iff_get.mp hmem
-          have hgap := hx_strict ⟨s, hs⟩
-          rw [hgets] at hgap
-          -- B.sum x > A.sum x, so A.sum (x/σ) < B.sum (x/σ)
-          have hlt : A.sum (fun i => x i / σ) < B.sum (fun i => x i / σ) := by
-            rw [← Finset.sum_div, ← Finset.sum_div]
-            exact div_lt_div_of_pos_right (by linarith) hσ_pos
-          linarith
-    · -- ═══ Infeasible case: certificate → cancellation violation ═══
-      exfalso
-      obtain ⟨cert⟩ := hcert
-      have hlen : S.length = (n + k) + K := List.length_ofFn
-      -- Cast cert weights to natural indices
-      let ws : Fin ((n + k) + K) → ℚ := fun i => cert.ws (i.cast hlen.symm)
-      have ws_nn : ∀ i, 0 ≤ ws i := fun i => cert.nonneg _
-      -- Transport: reindex sums
-      have hreindex : ∀ f : Fin S.length → ℚ,
-          ∑ i : Fin S.length, f i =
-          ∑ i : Fin ((n + k) + K), f (i.cast hlen.symm) :=
-        fun f => Fintype.sum_equiv (finCongr hlen) _ _ (fun i => by simp [finCongr])
-      have hS_get : ∀ i : Fin S.length,
-          S.get i = ineqFn (i.cast hlen) := fun i => List.get_ofFn ineqFn i
-      -- Coefficients zero
-      have hcoeffsZero : ∀ j : Fin n,
-          ∑ i : Fin ((n + k) + K), ws i * (ineqFn i).lhs j = 0 := by
-        intro j
-        have h := cert.coeffsZero j
-        rw [hreindex] at h; simp_rw [hS_get] at h; exact h
-      -- Bound negative
-      have hboundNeg :
-          ∑ i : Fin ((n + k) + K), ws i * (ineqFn i).rhs < 0 := by
-        have h := cert.boundNeg
-        rw [hreindex] at h; simp_rw [hS_get] at h; exact h
-      -- ── Decompose boundNeg: strict weights sum > 0 ──
-      have hstrictWtSum : 0 < ∑ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩ := by
-        rw [sum_three_parts] at hboundNeg
-        have h1 : ∑ i : Fin n, ws ⟨i.val, by omega⟩ * (ineqFn ⟨i.val, by omega⟩).rhs = 0 :=
-          Finset.sum_eq_zero fun i _ => by
-            have : (ineqFn ⟨i.val, by omega⟩).rhs = 0 := by
-              simp only [ineqFn, dif_pos i.isLt]
-            simp [this]
-        have h2 : ∑ m : Fin k, ws ⟨n + m.val, by omega⟩ *
-            (ineqFn ⟨n + m.val, by omega⟩).rhs = 0 :=
-          Finset.sum_eq_zero fun m _ => by
-            have : (ineqFn ⟨n + m.val, by omega⟩).rhs = 0 := by
-              simp only [ineqFn, show ¬(n + m.val < n) from by omega,
-                show n + m.val < n + k from by omega, dite_false, dite_true]
-            simp [this]
-        have h3 : ∑ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩ *
-            (ineqFn ⟨(n + k) + s.val, by omega⟩).rhs =
-            -(∑ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩) := by
-          have hrhs : ∀ s : Fin K, (ineqFn ⟨(n + k) + s.val, by omega⟩).rhs = (-1 : ℚ) := by
-            intro s; simp only [ineqFn, show ¬((n + k) + s.val < n) from by omega,
-              show ¬((n + k) + s.val < n + k) from by omega, dite_false]
-          simp_rw [hrhs, mul_neg_one, Finset.sum_neg_distrib]
+          exact div_lt_div_of_pos_right (by linarith) hσ_pos
         linarith
-      -- ── Find s₀ with positive strict weight ──
-      obtain ⟨s₀, _, hs₀⟩ : ∃ s ∈ (Finset.univ : Finset (Fin K)),
-          0 < ws ⟨(n + k) + s.val, by omega⟩ := by
-        by_contra hall; push_neg at hall
-        have : ∑ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩ = 0 :=
-          Finset.sum_eq_zero fun s hs => le_antisymm (hall s hs)
-            (ws_nn ⟨(n + k) + s.val, by omega⟩)
-        linarith
-      -- ── Coefficient decomposition via sum_three_parts ──
-      have hDecomp : ∀ j : Fin n,
-          ws ⟨j.val, by omega⟩ +
-          (∑ m : Fin k, ws ⟨n + m.val, by omega⟩ *
-            ((comparisonVec n (gePairs.get m).1 (gePairs.get m).2 j : ℤ) : ℚ)) +
-          (∑ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩ *
-            ((comparisonVec n (sp.get s).1 (sp.get s).2 j : ℤ) : ℚ)) = 0 := by
-        intro j; have h := hcoeffsZero j
-        rw [sum_three_parts] at h
-        -- Nonneg: only the j-th row contributes -ws(j)
-        have h_nn : ∑ i : Fin n, ws ⟨i.val, by omega⟩ * (ineqFn ⟨i.val, by omega⟩).lhs j =
-            -ws ⟨j.val, by omega⟩ := by
-          rw [Finset.sum_eq_single j]
-          · simp only [ineqFn, dif_pos j.isLt]; simp
-          · intro i _ hij
+  · -- ═══ Infeasible case: certificate → cancellation violation ═══
+    exfalso
+    obtain ⟨cert⟩ := hcert
+    have hlen : S.length = (n + k) + K := List.length_ofFn
+    -- Cast cert weights to natural indices
+    let ws : Fin ((n + k) + K) → ℚ := fun i => cert.ws (i.cast hlen.symm)
+    have ws_nn : ∀ i, 0 ≤ ws i := fun i => cert.nonneg _
+    -- Transport: reindex sums
+    have hreindex : ∀ f : Fin S.length → ℚ,
+        ∑ i : Fin S.length, f i =
+        ∑ i : Fin ((n + k) + K), f (i.cast hlen.symm) :=
+      fun f => Fintype.sum_equiv (finCongr hlen) _ _ (fun i => by simp [finCongr])
+    have hS_get : ∀ i : Fin S.length,
+        S.get i = ineqFn (i.cast hlen) := fun i => List.get_ofFn ineqFn i
+    -- Coefficients zero
+    have hcoeffsZero : ∀ j : Fin n,
+        ∑ i : Fin ((n + k) + K), ws i * (ineqFn i).lhs j = 0 := by
+      intro j
+      have h := cert.coeffsZero j
+      rw [hreindex] at h; simp_rw [hS_get] at h; exact h
+    -- Bound negative
+    have hboundNeg :
+        ∑ i : Fin ((n + k) + K), ws i * (ineqFn i).rhs < 0 := by
+      have h := cert.boundNeg
+      rw [hreindex] at h; simp_rw [hS_get] at h; exact h
+    -- ── Decompose boundNeg: strict weights sum > 0 ──
+    have hstrictWtSum : 0 < ∑ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩ := by
+      rw [sum_three_parts] at hboundNeg
+      have h1 : ∑ i : Fin n, ws ⟨i.val, by omega⟩ * (ineqFn ⟨i.val, by omega⟩).rhs = 0 :=
+        Finset.sum_eq_zero fun i _ => by
+          have : (ineqFn ⟨i.val, by omega⟩).rhs = 0 := by
             simp only [ineqFn, dif_pos i.isLt]
-            simp [show j ≠ i from Ne.symm hij]
-          · intro h; exact absurd (Finset.mem_univ j) h
-        -- Ordering: simplify lhs
-        have h_ord : ∀ m : Fin k, ws ⟨n + m.val, by omega⟩ *
-            (ineqFn ⟨n + m.val, by omega⟩).lhs j =
-            -(ws ⟨n + m.val, by omega⟩ *
-              ((comparisonVec n (gePairs.get m).1 (gePairs.get m).2 j : ℤ) : ℚ)) := by
-          intro m
-          have : (ineqFn ⟨n + m.val, by omega⟩).lhs j =
-              -(((comparisonVec n (gePairs.get ⟨m.val, m.isLt⟩).1
-                (gePairs.get ⟨m.val, m.isLt⟩).2 j : ℤ) : ℚ)) := by
+          simp [this]
+      have h2 : ∑ m : Fin k, ws ⟨n + m.val, by omega⟩ *
+          (ineqFn ⟨n + m.val, by omega⟩).rhs = 0 :=
+        Finset.sum_eq_zero fun m _ => by
+          have : (ineqFn ⟨n + m.val, by omega⟩).rhs = 0 := by
             simp only [ineqFn, show ¬(n + m.val < n) from by omega,
               show n + m.val < n + k from by omega, dite_false, dite_true]
-            have : (⟨n + m.val - n, by omega⟩ : Fin k) = m := by
-              ext; show n + m.val - n = m.val; omega
-            rw [this]
-          rw [this]; ring
-        -- Strict: simplify lhs
-        have h_str : ∀ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩ *
-            (ineqFn ⟨(n + k) + s.val, by omega⟩).lhs j =
-            -(ws ⟨(n + k) + s.val, by omega⟩ *
-              ((comparisonVec n (sp.get s).1 (sp.get s).2 j : ℤ) : ℚ)) := by
-          intro s
-          have : (ineqFn ⟨(n + k) + s.val, by omega⟩).lhs j =
-              -(((comparisonVec n (sp.get ⟨s.val, s.isLt⟩).1
-                (sp.get ⟨s.val, s.isLt⟩).2 j : ℤ) : ℚ)) := by
-            simp only [ineqFn, show ¬((n + k) + s.val < n) from by omega,
-              show ¬((n + k) + s.val < n + k) from by omega, dite_false]
-            have : (⟨(n + k) + s.val - (n + k), by omega⟩ : Fin K) = s := by
-              ext; show (n + k) + s.val - (n + k) = s.val; omega
-            rw [this]
-          rw [this]; ring
-        simp_rw [h_nn, h_ord, Finset.sum_neg_distrib, h_str, Finset.sum_neg_distrib] at h
-        linarith
-      -- ── Build portfolio violating cancellation ──
-      let Q_ord : List (WComparison n) :=
-        (List.finRange k).filterMap fun m =>
-          if h : 0 < ws ⟨n + m.val, by omega⟩ then
-            some ⟨(gePairs.get m).1, (gePairs.get m).2,
-              ws ⟨n + m.val, by omega⟩, hgePairsDisj m, h⟩
-          else none
-      let Q_strict : List (WComparison n) :=
-        (List.finRange K).filterMap fun s =>
-          if h : 0 < ws ⟨(n + k) + s.val, by omega⟩ then
-            some ⟨(sp.get s).1, (sp.get s).2,
-              ws ⟨(n + k) + s.val, by omega⟩, strictPairs_disj sys s, h⟩
-          else none
-      let Q_sing : List (WComparison n) :=
-        (List.finRange n).filterMap fun j =>
-          if h : 0 < ws ⟨j.val, by omega⟩ then
-            some ⟨{j}, ∅, ws ⟨j.val, by omega⟩, Finset.disjoint_empty_right _, h⟩
-          else none
-      let Q : Portfolio n := Q_ord ++ Q_strict ++ Q_sing
-      have hQ_strict : Q.hasStrict sys.ge :=
-        ⟨⟨(sp.get s₀).1, (sp.get s₀).2, ws ⟨(n + k) + s₀.val, by omega⟩,
-          strictPairs_disj sys s₀, hs₀⟩,
-          List.mem_append_left _ (List.mem_append_right _
-            (List.mem_filterMap.mpr ⟨s₀, List.mem_finRange s₀, dif_pos hs₀⟩)),
-          strictPairs_strict sys s₀⟩
-      have hQ_valid : Q.isValid sys.ge := by
-        intro wc hwc
-        rcases List.mem_append.mp hwc with h | h
-        · rcases List.mem_append.mp h with h | h
-          · obtain ⟨m, _, hm⟩ := List.mem_filterMap.mp h
-            split_ifs at hm with hpos
-            cases hm; exact hgePairsGe m
-          · obtain ⟨s, _, hs⟩ := List.mem_filterMap.mp h
-            split_ifs at hs with hpos
-            cases hs; exact strictPairs_ge sys s
-        · obtain ⟨j, _, hj⟩ := List.mem_filterMap.mp h
-          split_ifs at hj with hpos
-          cases hj
-          simp only [Finset.coe_singleton, Finset.coe_empty]
-          exact sys.mono ∅ {j} (Set.empty_subset _)
-      have hQ_neutral : Q.isNeutral := by
-        intro j
-        show Portfolio.weightedSum (Q_ord ++ Q_strict ++ Q_sing) j = 0
-        simp only [Portfolio.weightedSum, List.map_append, List.sum_append]
-        rw [show (Q_ord.map _).sum = _ from filterMap_weightedSum
-              (fun m => ((gePairs.get m).1, (gePairs.get m).2))
-              (fun m => ws ⟨n + m.val, by omega⟩)
-              (fun m => ws_nn ⟨n + m.val, by omega⟩) hgePairsDisj j,
-            show (Q_strict.map _).sum = _ from filterMap_weightedSum
-              (fun s => ((sp.get s).1, (sp.get s).2))
-              (fun s => ws ⟨(n + k) + s.val, by omega⟩)
-              (fun s => ws_nn ⟨(n + k) + s.val, by omega⟩)
-              (strictPairs_disj sys) j,
-            show (Q_sing.map _).sum = _ from filterMap_weightedSum
-              (fun i => ({i}, (∅ : Finset (Fin n))))
-              (fun i => ws ⟨i.val, by omega⟩)
-              (fun i => ws_nn ⟨i.val, by omega⟩)
-              (fun _ => Finset.disjoint_empty_right _) j]
-        have hsing : ∑ i : Fin n, ws ⟨i.val, by omega⟩ *
-            ((comparisonVec n {i} ∅ j : ℤ) : ℚ) = ws ⟨j.val, by omega⟩ := by
-          rw [Finset.sum_eq_single j]
-          · simp [comparisonVec, Finset.mem_singleton]
-          · intro i _ hij
-            simp [comparisonVec, Finset.mem_singleton, Ne.symm hij]
-          · intro h; exact absurd (Finset.mem_univ j) h
-        rw [hsing]; linarith [hDecomp j]
-      exact absurd hQ_strict (hcancel Q hQ_valid hQ_neutral)
-
--- ── Step 4c. Certificate → cancellation violation ───
-
-private lemma toList_map_sum {α : Type*} [AddCommMonoid α] {ι : Type*}
-    (s : Finset ι) (f : ι → α) :
-    (s.val.toList.map f).sum = s.sum f := by
-  rw [← Multiset.sum_coe, ← Multiset.map_coe, Multiset.coe_toList]; rfl
-
-private lemma compVec_single_empty {n : ℕ} (a j : Fin n) :
-    comparisonVec n {a} ∅ j = if j = a then 1 else 0 := by
-  unfold comparisonVec; simp only [Finset.mem_singleton]; split <;> simp
-
-private lemma weightedSum_append {n : ℕ} (P Q : List (WComparison n)) (i : Fin n) :
-    Portfolio.weightedSum (List.append P Q) i =
-    Portfolio.weightedSum P i + Portfolio.weightedSum Q i := by
-  unfold Portfolio.weightedSum
-  show (List.map _ (P ++ Q)).sum = (List.map _ P).sum + (List.map _ Q).sum
-  rw [List.map_append, List.sum_append]
-
-/-- Singleton portfolio: one ({i}, ∅, dᵢ) entry per atom. -/
-private noncomputable def singletonPortfolio {n : ℕ} (d : Fin n → ℚ) (hd : ∀ i, 0 < d i) :
-    List (WComparison n) :=
-  (Finset.univ : Finset (Fin n)).val.toList.map fun i =>
-    (⟨{i}, ∅, d i, Finset.disjoint_empty_right _, hd i⟩ : WComparison n)
-
-private theorem weightedSum_singletonPortfolio {n : ℕ} (d : Fin n → ℚ) (hd : ∀ i, 0 < d i)
-    (j : Fin n) :
-    Portfolio.weightedSum (singletonPortfolio d hd) j = d j := by
-  unfold singletonPortfolio Portfolio.weightedSum
-  rw [List.map_map]
-  conv => lhs; arg 1; arg 1; ext i; simp only [Function.comp]; rw [compVec_single_empty]
-  simp only [Int.cast_ite, Int.cast_one, Int.cast_zero, mul_ite, mul_one, mul_zero]
-  rw [toList_map_sum, Finset.sum_ite_eq, if_pos (Finset.mem_univ j)]
-
-/-- An infeasibility certificate (valid portfolio with strictly negative
-    weighted sums at every atom) yields a neutral portfolio with a strict
-    member, violating cancellation.
-
-    Construction: append ({i}, ∅, dᵢ) for each atom i with dᵢ = −wsum(i) > 0.
-    Neutrality: wsum(j) + dⱼ = 0 by construction.
-    Strictness: ∃ i₀ with ¬sys.ge ∅ {i₀} (from `not_all_null`). -/
-private theorem certificate_to_violation {n : ℕ} (sys : EpistemicSystemFA (Fin n))
-    (P : Portfolio n) (hV : P.isValid sys.ge)
-    (hNeg : ∀ i : Fin n, P.weightedSum i < 0) :
-    ∃ Q : Portfolio n, Q.isValid sys.ge ∧ Q.isNeutral ∧ Q.hasStrict sys.ge := by
-  let d : Fin n → ℚ := fun i => -P.weightedSum i
-  have hd : ∀ i, 0 < d i := fun i => by simp only [d]; linarith [hNeg i]
-  let singles := singletonPortfolio d hd
-  refine ⟨List.append P singles, ?valid, ?neutral, ?strict⟩
-  case valid =>
-    intro wc hwc
-    rcases List.mem_append.mp hwc with h | h
-    · exact hV wc h
-    · obtain ⟨i, _, rfl⟩ := List.mem_map.mp h
-      simp only [Finset.coe_singleton, Finset.coe_empty]
-      exact sys.mono ∅ {i} (Set.empty_subset _)
-  case neutral =>
-    intro j
-    rw [weightedSum_append P singles j, weightedSum_singletonPortfolio d hd j]
-    simp only [d]; linarith
-  case strict =>
-    obtain ⟨i₀, hi₀⟩ := not_all_null sys
-    refine ⟨⟨{i₀}, ∅, d i₀, Finset.disjoint_empty_right _, hd i₀⟩, ?mem, ?str⟩
-    case mem =>
-      exact List.mem_append.mpr (Or.inr
-        (List.mem_map.mpr ⟨i₀, Multiset.mem_toList.mpr (Finset.mem_univ i₀), rfl⟩))
-    case str =>
-      simp only [Finset.coe_empty, Finset.coe_singleton]; exact hi₀
+          simp [this]
+      have h3 : ∑ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩ *
+          (ineqFn ⟨(n + k) + s.val, by omega⟩).rhs =
+          -(∑ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩) := by
+        have hrhs : ∀ s : Fin K, (ineqFn ⟨(n + k) + s.val, by omega⟩).rhs = (-1 : ℚ) := by
+          intro s; simp only [ineqFn, show ¬((n + k) + s.val < n) from by omega,
+            show ¬((n + k) + s.val < n + k) from by omega, dite_false]
+        simp_rw [hrhs, mul_neg_one, Finset.sum_neg_distrib]
+      linarith
+    -- ── Find s₀ with positive strict weight ──
+    obtain ⟨s₀, _, hs₀⟩ : ∃ s ∈ (Finset.univ : Finset (Fin K)),
+        0 < ws ⟨(n + k) + s.val, by omega⟩ := by
+      by_contra hall; push_neg at hall
+      have : ∑ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩ = 0 :=
+        Finset.sum_eq_zero fun s hs => le_antisymm (hall s hs)
+          (ws_nn ⟨(n + k) + s.val, by omega⟩)
+      linarith
+    -- ── Coefficient decomposition via sum_three_parts ──
+    have hDecomp : ∀ j : Fin n,
+        ws ⟨j.val, by omega⟩ +
+        (∑ m : Fin k, ws ⟨n + m.val, by omega⟩ *
+          ((comparisonVec n (gePairs.get m).1 (gePairs.get m).2 j : ℤ) : ℚ)) +
+        (∑ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩ *
+          ((comparisonVec n (sp.get s).1 (sp.get s).2 j : ℤ) : ℚ)) = 0 := by
+      intro j; have h := hcoeffsZero j
+      rw [sum_three_parts] at h
+      -- Nonneg: only the j-th row contributes -ws(j)
+      have h_nn : ∑ i : Fin n, ws ⟨i.val, by omega⟩ * (ineqFn ⟨i.val, by omega⟩).lhs j =
+          -ws ⟨j.val, by omega⟩ := by
+        rw [Finset.sum_eq_single j]
+        · simp only [ineqFn, dif_pos j.isLt]; simp
+        · intro i _ hij
+          simp only [ineqFn, dif_pos i.isLt]
+          simp [show j ≠ i from Ne.symm hij]
+        · intro h; exact absurd (Finset.mem_univ j) h
+      -- Ordering: simplify lhs
+      have h_ord : ∀ m : Fin k, ws ⟨n + m.val, by omega⟩ *
+          (ineqFn ⟨n + m.val, by omega⟩).lhs j =
+          -(ws ⟨n + m.val, by omega⟩ *
+            ((comparisonVec n (gePairs.get m).1 (gePairs.get m).2 j : ℤ) : ℚ)) := by
+        intro m
+        have : (ineqFn ⟨n + m.val, by omega⟩).lhs j =
+            -(((comparisonVec n (gePairs.get ⟨m.val, m.isLt⟩).1
+              (gePairs.get ⟨m.val, m.isLt⟩).2 j : ℤ) : ℚ)) := by
+          simp only [ineqFn, show ¬(n + m.val < n) from by omega,
+            show n + m.val < n + k from by omega, dite_false, dite_true]
+          have : (⟨n + m.val - n, by omega⟩ : Fin k) = m := by
+            ext; show n + m.val - n = m.val; omega
+          rw [this]
+        rw [this]; ring
+      -- Strict: simplify lhs
+      have h_str : ∀ s : Fin K, ws ⟨(n + k) + s.val, by omega⟩ *
+          (ineqFn ⟨(n + k) + s.val, by omega⟩).lhs j =
+          -(ws ⟨(n + k) + s.val, by omega⟩ *
+            ((comparisonVec n (sp.get s).1 (sp.get s).2 j : ℤ) : ℚ)) := by
+        intro s
+        have : (ineqFn ⟨(n + k) + s.val, by omega⟩).lhs j =
+            -(((comparisonVec n (sp.get ⟨s.val, s.isLt⟩).1
+              (sp.get ⟨s.val, s.isLt⟩).2 j : ℤ) : ℚ)) := by
+          simp only [ineqFn, show ¬((n + k) + s.val < n) from by omega,
+            show ¬((n + k) + s.val < n + k) from by omega, dite_false]
+          have : (⟨(n + k) + s.val - (n + k), by omega⟩ : Fin K) = s := by
+            ext; show (n + k) + s.val - (n + k) = s.val; omega
+          rw [this]
+        rw [this]; ring
+      simp_rw [h_nn, h_ord, Finset.sum_neg_distrib, h_str, Finset.sum_neg_distrib] at h
+      linarith
+    -- ── Build portfolio violating cancellation ──
+    let Q_ord : List (WComparison n) :=
+      (List.finRange k).filterMap fun m =>
+        if h : 0 < ws ⟨n + m.val, by omega⟩ then
+          some ⟨(gePairs.get m).1, (gePairs.get m).2,
+            ws ⟨n + m.val, by omega⟩, hgePairsDisj m, h⟩
+        else none
+    let Q_strict : List (WComparison n) :=
+      (List.finRange K).filterMap fun s =>
+        if h : 0 < ws ⟨(n + k) + s.val, by omega⟩ then
+          some ⟨(sp.get s).1, (sp.get s).2,
+            ws ⟨(n + k) + s.val, by omega⟩, strictPairs_disj sys s, h⟩
+        else none
+    let Q_sing : List (WComparison n) :=
+      (List.finRange n).filterMap fun j =>
+        if h : 0 < ws ⟨j.val, by omega⟩ then
+          some ⟨{j}, ∅, ws ⟨j.val, by omega⟩, Finset.disjoint_empty_right _, h⟩
+        else none
+    let Q : Portfolio n := Q_ord ++ Q_strict ++ Q_sing
+    have hQ_strict : Q.hasStrict sys.ge :=
+      ⟨⟨(sp.get s₀).1, (sp.get s₀).2, ws ⟨(n + k) + s₀.val, by omega⟩,
+        strictPairs_disj sys s₀, hs₀⟩,
+        List.mem_append_left _ (List.mem_append_right _
+          (List.mem_filterMap.mpr ⟨s₀, List.mem_finRange s₀, dif_pos hs₀⟩)),
+        strictPairs_strict sys s₀⟩
+    have hQ_valid : Q.isValid sys.ge := by
+      intro wc hwc
+      rcases List.mem_append.mp hwc with h | h
+      · rcases List.mem_append.mp h with h | h
+        · obtain ⟨m, _, hm⟩ := List.mem_filterMap.mp h
+          split_ifs at hm with hpos
+          cases hm; exact hgePairsGe m
+        · obtain ⟨s, _, hs⟩ := List.mem_filterMap.mp h
+          split_ifs at hs with hpos
+          cases hs; exact strictPairs_ge sys s
+      · obtain ⟨j, _, hj⟩ := List.mem_filterMap.mp h
+        split_ifs at hj with hpos
+        cases hj
+        simp only [Finset.coe_singleton, Finset.coe_empty]
+        exact sys.mono ∅ {j} (Set.empty_subset _)
+    have hQ_neutral : Q.isNeutral := by
+      intro j
+      show Portfolio.weightedSum (Q_ord ++ Q_strict ++ Q_sing) j = 0
+      simp only [Portfolio.weightedSum, List.map_append, List.sum_append]
+      rw [show (Q_ord.map _).sum = _ from filterMap_weightedSum
+            (fun m => ((gePairs.get m).1, (gePairs.get m).2))
+            (fun m => ws ⟨n + m.val, by omega⟩)
+            (fun m => ws_nn ⟨n + m.val, by omega⟩) hgePairsDisj j,
+          show (Q_strict.map _).sum = _ from filterMap_weightedSum
+            (fun s => ((sp.get s).1, (sp.get s).2))
+            (fun s => ws ⟨(n + k) + s.val, by omega⟩)
+            (fun s => ws_nn ⟨(n + k) + s.val, by omega⟩)
+            (strictPairs_disj sys) j,
+          show (Q_sing.map _).sum = _ from filterMap_weightedSum
+            (fun i => ({i}, (∅ : Finset (Fin n))))
+            (fun i => ws ⟨i.val, by omega⟩)
+            (fun i => ws_nn ⟨i.val, by omega⟩)
+            (fun _ => Finset.disjoint_empty_right _) j]
+      have hsing : ∑ i : Fin n, ws ⟨i.val, by omega⟩ *
+          ((comparisonVec n {i} ∅ j : ℤ) : ℚ) = ws ⟨j.val, by omega⟩ := by
+        rw [Finset.sum_eq_single j]
+        · simp [comparisonVec, Finset.mem_singleton]
+        · intro i _ hij
+          simp [comparisonVec, Finset.mem_singleton, Ne.symm hij]
+        · intro h; exact absurd (Finset.mem_univ j) h
+      rw [hsing]; linarith [hDecomp j]
+    exact absurd hQ_strict (hcancel Q hQ_valid hQ_neutral)
 
 -- ── Step 4d. Compose: cancellation → feasible weights ──
-
-/-- The core LP step: cancellation implies the feasibility polytope is nonempty.
-    Three-step proof:
-    1. `farkas_ordering_lp` — either a → solution exists, or a certificate does
-    2. Certificate case: `certificate_to_violation` converts it to a neutral
-       portfolio with strict member, contradicting cancellation
-    3. → solution case: `cancel_strengthens_to_bidir` upgrades → to ↔ -/
-private theorem cancellation_nonempty {n : ℕ} (sys : EpistemicSystemFA (Fin n))
-    (hcancel : Cancellation n sys.ge) :
-    ∃ p, p ∈ feasibleWeights n sys := by
-  rcases farkas_ordering_lp sys with h | ⟨P, hV, hNeg⟩
-  · exact cancel_strengthens_to_bidir sys hcancel h
-  · obtain ⟨Q, hQV, hQN, hQS⟩ := certificate_to_violation sys P hV hNeg
-    exact absurd hQS (hcancel Q hQV hQN)
 
 /-- **Scott's theorem** (hard direction): if no valid neutral portfolio has a
     strict member, then a finitely additive measure exists representing the
@@ -1125,9 +727,7 @@ theorem cancellation_of_null_atom {n : ℕ} (sys : EpistemicSystemFA (Fin (n + 2
     Cancellation (n + 2) sys.ge := by
   set σ := Equiv.swap (0 : Fin (n + 2)) j with hσ
   have h0 : (transportFA σ sys).ge ∅ {0} := by
-    rw [perm_null_iff]
-    have : σ.symm 0 = j := by simp [hσ]
-    rwa [this]
+    rw [perm_null_iff, show σ.symm 0 = j by simp [hσ]]; exact hj
   have hnn : ∃ i : Fin (n + 1), ¬(transportFA σ sys).ge ∅ {Fin.succ i} := by
     obtain ⟨k, hk⟩ := not_all_null (transportFA σ sys)
     obtain ⟨i, rfl⟩ : ∃ i, Fin.succ i = k :=

--- a/Linglib/Core/Scales/EpistemicScale/Cancellation.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Cancellation.lean
@@ -91,19 +91,13 @@ def Cancellation (n : ℕ) (ge : Set (Fin n) → Set (Fin n) → Prop) : Prop :=
 -- § 3. Easy Direction: representable → cancellation
 -- ═══════════════════════════════════════════════════════════════
 
-private lemma mu_zero {W : Type*} (m : FinAddMeasure W) : m.mu ∅ = 0 := by
-  have h := m.additive ∅ ∅ (fun x hx => hx.elim)
-  rw [Set.empty_union] at h; linarith
-
 private lemma mu_finset_sum {n : ℕ} (m : FinAddMeasure (Fin n))
     (S : Finset (Fin n)) : m.mu ↑S = S.sum (fun i => m.mu {i}) := by
   induction S using Finset.induction_on with
-  | empty => simp [Finset.coe_empty, mu_zero m]
+  | empty => simp [Finset.coe_empty, m.mu_empty]
   | @insert a S ha ih =>
-    have hdisj : ∀ x, x ∈ ({a} : Set (Fin n)) → x ∉ (↑S : Set (Fin n)) := by
-      intro x hx hxS
-      rw [Set.mem_singleton_iff] at hx; subst hx
-      exact ha (Finset.mem_coe.mp hxS)
+    have hdisj : Disjoint ({a} : Set (Fin n)) ↑S :=
+      Set.disjoint_singleton_left.mpr (fun h => ha (Finset.mem_coe.mp h))
     have hins : (↑(insert a S) : Set (Fin n)) = ({a} : Set (Fin n)) ∪ ↑S := by
       rw [Finset.coe_insert]; exact Set.insert_eq a ↑S
     rw [hins, m.additive _ _ hdisj, ih, Finset.sum_insert ha]
@@ -170,10 +164,10 @@ private lemma portfolio_interchange {n : ℕ} (m : FinAddMeasure (Fin n))
     interchange lemma, the value also equals Σᵢ μ({i})·weightedSum(i) = 0
     by neutrality. -/
 theorem representable_implies_cancellation {n : ℕ}
-    (sys : EpistemicSystemFA (Fin n))
+    {ge : Set (Fin n) → Set (Fin n) → Prop}
     (m : FinAddMeasure (Fin n))
-    (hm : ∀ A B, sys.ge A B ↔ m.inducedGe A B) :
-    Cancellation n sys.ge := by
+    (hm : ∀ A B, ge A B ↔ m.inducedGe A B) :
+    Cancellation n ge := by
   intro P hValid hNeutral ⟨wc, hwc_mem, hwc_strict⟩
   -- Define the portfolio valuation function
   let f : WComparison n → ℚ := fun wc => wc.weight * (m.mu ↑wc.left - m.mu ↑wc.right)
@@ -233,7 +227,7 @@ private theorem atomMu_eq_finset_sum {n : ℕ} (p : Fin n → ℚ) (S : Finset (
     then applies the ↔ condition from `feasibleWeights`. -/
 private theorem feasible_to_measure {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     {p : Fin n → ℚ} (hp : p ∈ feasibleWeights n sys) :
-    ∃ m : FinAddMeasure (Fin n), ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
+    Representable sys := by
   obtain ⟨hnn, hsum, hcompat⟩ := hp
   -- Nonneg: each summand is nonneg
   have h_nonneg : ∀ A, 0 ≤ atomMu p A := by
@@ -244,9 +238,10 @@ private theorem feasible_to_measure {n : ℕ} (sys : EpistemicSystemFA (Fin n))
       rw [Finset.sum_insert has]
       exact add_nonneg (by split <;> [exact hnn a; exact le_refl 0]) ih
   -- Finite additivity via pointwise case split on membership
-  have h_additive : ∀ A B : Set (Fin n), (∀ x, x ∈ A → x ∉ B) →
+  have h_additive : ∀ A B : Set (Fin n), Disjoint A B →
       atomMu p (A ∪ B) = atomMu p A + atomMu p B := by
-    intro A B hdisj
+    intro A B hAB
+    have hdisj : ∀ x ∈ A, x ∉ B := fun x hx => Set.disjoint_left.mp hAB hx
     simp only [atomMu, ← Finset.sum_add_distrib]
     apply Finset.sum_congr rfl
     intro i _
@@ -264,7 +259,7 @@ private theorem feasible_to_measure {n : ℕ} (sys : EpistemicSystemFA (Fin n))
   have hfinDisj : Disjoint (Finset.univ.filter (· ∈ C)) (Finset.univ.filter (· ∈ D)) := by
     rw [Finset.disjoint_left]; intro x hx1 hx2
     simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx1 hx2
-    exact hdisj x hx1 hx2
+    exact Set.disjoint_left.mp hdisj hx1 hx2
   -- hcompat on filter-finsets, transported to Sets via coercion identity
   have key := hcompat _ _ hfinDisj
   rw [hCeq, hDeq] at key
@@ -303,7 +298,7 @@ private lemma ge_empty_of_all_null {n : ℕ} (sys : EpistemicSystemFA (Fin n))
 
 /-- Not all singletons can be null: ∃ i, ¬sys.ge ∅ {i}. If all were null,
     FA induction gives sys.ge ∅ Set.univ, contradicting nonTrivial. -/
-private theorem not_all_null {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
+theorem not_all_null {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
     ∃ i : Fin n, ¬sys.ge ∅ {i} := by
   by_contra hall; push_neg at hall
   exact sys.nonTrivial (by rw [← Finset.coe_univ]; exact ge_empty_of_all_null sys hall _)
@@ -1111,34 +1106,15 @@ private theorem cancellation_nonempty {n : ℕ} (sys : EpistemicSystemFA (Fin n)
 theorem cancellation_implies_representable {n : ℕ}
     (sys : EpistemicSystemFA (Fin n))
     (hcancel : Cancellation n sys.ge) :
-    ∃ m : FinAddMeasure (Fin n), ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
+    Representable sys := by
   obtain ⟨p, hp⟩ := cancellation_nonempty sys hcancel
   exact feasible_to_measure sys hp
 
--- ═══════════════════════════════════════════════════════════════
--- § 5. FA → Cancellation for small n
--- ═══════════════════════════════════════════════════════════════
-
-/-- Extend `∅ ≿ S` to `∅ ≿ T` by absorbing one null atom `a`, where
-    `{a} \ T = ∅` and `T \ {a} = S`. -/
-private lemma ge_empty_extend {n : ℕ} (sys : EpistemicSystemFA (Fin n))
-    {a : Fin n} {S T : Set (Fin n)} (hNull : sys.ge ∅ {a}) (hRest : sys.ge ∅ S)
-    (h1 : ({a} : Set (Fin n)) \ T = ∅) (h2 : T \ ({a} : Set (Fin n)) = S) :
-    sys.ge ∅ T :=
-  sys.trans ∅ {a} T hNull ((sys.additive {a} T).mpr (h1 ▸ h2 ▸ hRest))
-
-/-- Not all 4 singletons can be null (non-triviality). -/
-theorem not_all_null_fin4 (sys : EpistemicSystemFA (Fin 4))
-    (h0 : sys.ge ∅ {(0 : Fin 4)}) (h1 : sys.ge ∅ {(1 : Fin 4)})
-    (h2 : sys.ge ∅ {(2 : Fin 4)}) (h3 : sys.ge ∅ {(3 : Fin 4)}) : False := by
-  have h01 : sys.ge ∅ ({0, 1} : Set (Fin 4)) :=
-    ge_empty_extend sys h1 h0
-      (by ext x; fin_cases x <;> simp_all) (by ext x; fin_cases x <;> simp_all)
-  have h012 : sys.ge ∅ ({0, 1, 2} : Set (Fin 4)) :=
-    ge_empty_extend sys h2 h01
-      (by ext x; fin_cases x <;> simp_all) (by ext x; fin_cases x <;> simp_all)
-  exact sys.nonTrivial (ge_empty_extend sys h3 h012
-    (by ext x; simp) (by ext x; fin_cases x <;> simp_all))
-
+/-- **Scott's theorem**: an FA system is representable by a finitely additive
+    measure iff it satisfies the cancellation property. -/
+theorem representable_iff_cancellation {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
+    Representable sys ↔ Cancellation n sys.ge :=
+  ⟨fun ⟨m, hm⟩ => representable_implies_cancellation m hm,
+   cancellation_implies_representable sys⟩
 
 end Core.Scale

--- a/Linglib/Core/Scales/EpistemicScale/Cancellation.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Cancellation.lean
@@ -92,8 +92,8 @@ def Cancellation (n : ℕ) (ge : Set (Fin n) → Set (Fin n) → Prop) : Prop :=
 -- ═══════════════════════════════════════════════════════════════
 
 private lemma mu_zero {W : Type*} (m : FinAddMeasure W) : m.mu ∅ = 0 := by
-  have := m.additive ∅ ∅ (fun x hx => hx.elim)
-  simp only [Set.empty_union] at this; linarith
+  have h := m.additive ∅ ∅ (fun x hx => hx.elim)
+  rw [Set.empty_union] at h; linarith
 
 private lemma mu_finset_sum {n : ℕ} (m : FinAddMeasure (Fin n))
     (S : Finset (Fin n)) : m.mu ↑S = S.sum (fun i => m.mu {i}) := by
@@ -108,15 +108,6 @@ private lemma mu_finset_sum {n : ℕ} (m : FinAddMeasure (Fin n))
       rw [Finset.coe_insert]; exact Set.insert_eq a ↑S
     rw [hins, m.additive _ _ hdisj, ih, Finset.sum_insert ha]
 
-private lemma list_sum_nonneg {l : List ℚ} (h : ∀ x ∈ l, (0 : ℚ) ≤ x) :
-    0 ≤ l.sum := by
-  induction l with
-  | nil => simp
-  | cons hd tl ih =>
-    simp only [List.sum_cons]
-    exact add_nonneg (h hd (List.mem_cons.mpr (Or.inl rfl)))
-      (ih (fun x hx => h x (List.mem_cons.mpr (Or.inr hx))))
-
 private lemma list_sum_pos {l : List ℚ}
     (hnn : ∀ x ∈ l, (0 : ℚ) ≤ x) (hp : ∃ x ∈ l, (0 : ℚ) < x) :
     (0 : ℚ) < l.sum := by
@@ -128,7 +119,7 @@ private lemma list_sum_pos {l : List ℚ}
     have htl_nn : ∀ y ∈ tl, (0 : ℚ) ≤ y :=
       fun y hy => hnn y (List.mem_cons.mpr (Or.inr hy))
     rcases List.mem_cons.mp hx with rfl | hxtl
-    · linarith [list_sum_nonneg htl_nn]
+    · linarith [List.sum_nonneg htl_nn]
     · linarith [hnn hd (List.mem_cons.mpr (Or.inl rfl)), ih htl_nn hxtl]
 
 /-- The portfolio value (weighted sum of measure differences) equals the
@@ -150,12 +141,6 @@ private lemma single_comp_sum {n : ℕ} (m : FinAddMeasure (Fin n))
   simp only [comparisonVec]
   by_cases hL : i ∈ L <;> by_cases hR : i ∈ R <;> simp_all [Finset.disjoint_left.mp hd]
 
-private lemma finset_mul_sum {n : ℕ} (s : Finset (Fin n)) (f : Fin n → ℚ) (c : ℚ) :
-    c * s.sum f = s.sum (fun i => c * f i) := by
-  induction s using Finset.induction_on with
-  | empty => simp
-  | @insert a s ha ih => simp only [Finset.sum_insert ha, mul_add]; rw [ih]
-
 private lemma portfolio_interchange {n : ℕ} (m : FinAddMeasure (Fin n))
     (P : Portfolio n) :
     (P.map (fun wc => wc.weight * (m.mu ↑wc.left - m.mu ↑wc.right))).sum =
@@ -176,7 +161,7 @@ private lemma portfolio_interchange {n : ℕ} (m : FinAddMeasure (Fin n))
     simp_rw [hwsum, mul_add, Finset.sum_add_distrib]
     -- Suffices: w*(mu L - mu R) = Σ mu{i}*(w*compVec i)
     congr 1
-    rw [single_comp_sum m wc.left wc.right wc.disjoint, finset_mul_sum]
+    rw [single_comp_sum m wc.left wc.right wc.disjoint, Finset.mul_sum]
     apply Finset.sum_congr rfl; intro i _; exact mul_left_comm _ _ _
 
 /-- **Easy direction**: If μ represents the ordering, no neutral portfolio has a
@@ -265,11 +250,8 @@ private theorem feasible_to_measure {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     simp only [atomMu, ← Finset.sum_add_distrib]
     apply Finset.sum_congr rfl
     intro i _
-    by_cases hA : i ∈ A <;> by_cases hB : i ∈ B
-    · exact absurd hB (hdisj i hA)
-    · simp [Set.mem_union, hA, hB]
-    · simp [Set.mem_union, hA, hB]
-    · simp [Set.mem_union, hA, hB]
+    by_cases hA : i ∈ A <;> by_cases hB : i ∈ B <;>
+      simp_all [Set.mem_union]
   -- Normalization: all atoms in univ
   have h_total : atomMu p Set.univ = 1 := by
     simp only [atomMu, Set.mem_univ, ite_true, hsum]
@@ -377,7 +359,7 @@ private theorem weightedSum_portfolioOfWeights {n : ℕ}
     Portfolio.weightedSum (portfolioOfWeights pairs ws h_disj h_pos) j =
     ∑ m : Fin pairs.length,
       ws m * ((comparisonVec n (pairs.get m).1 (pairs.get m).2 j : ℤ) : ℚ) := by
-  simp only [portfolioOfWeights, Portfolio.weightedSum, List.map_map, Function.comp]
+  simp only [portfolioOfWeights, Portfolio.weightedSum, List.map_map]
   exact finRange_map_sum _
 
 /-- Validity of `portfolioOfWeights`: each entry's pair has `ge`. -/
@@ -393,6 +375,33 @@ private theorem isValid_portfolioOfWeights {n : ℕ}
   simp only [portfolioOfWeights] at hwc
   obtain ⟨m, _, rfl⟩ := List.mem_map.mp hwc
   exact h_ge m
+
+/-- All disjoint `ge`-pairs: disjoint (A, B) where `sys.ge ↑A ↑B`. -/
+private noncomputable def gePairsOf {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
+    List (Finset (Fin n) × Finset (Fin n)) :=
+  ((Finset.univ ×ˢ Finset.univ : Finset _).filter
+    (fun ab => Disjoint ab.1 ab.2 ∧ sys.ge ↑ab.1 ↑ab.2)).toList
+
+private theorem gePairs_mem {n : ℕ} (sys : EpistemicSystemFA (Fin n))
+    (A B : Finset (Fin n)) (hd : Disjoint A B) (hge : sys.ge ↑A ↑B) :
+    (A, B) ∈ gePairsOf sys := by
+  simp only [gePairsOf, Finset.mem_toList, Finset.mem_filter, Finset.mem_product,
+    Finset.mem_univ, true_and]
+  exact ⟨hd, hge⟩
+
+private theorem gePairs_disj {n : ℕ} (sys : EpistemicSystemFA (Fin n))
+    (m : Fin (gePairsOf sys).length) :
+    Disjoint ((gePairsOf sys).get m).1 ((gePairsOf sys).get m).2 := by
+  have := List.get_mem (gePairsOf sys) m
+  simp only [gePairsOf, Finset.mem_toList, Finset.mem_filter] at this
+  exact this.2.1
+
+private theorem gePairs_ge {n : ℕ} (sys : EpistemicSystemFA (Fin n))
+    (m : Fin (gePairsOf sys).length) :
+    sys.ge ↑((gePairsOf sys).get m).1 ↑((gePairsOf sys).get m).2 := by
+  have := List.get_mem (gePairsOf sys) m
+  simp only [gePairsOf, Finset.mem_toList, Finset.mem_filter] at this
+  exact this.2.2
 
 /-- **Farkas alternative for the ordering LP**: either a one-directional
     probability representation exists, or there is a valid portfolio
@@ -411,9 +420,7 @@ private theorem farkas_ordering_lp {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
     (∃ P : Portfolio n, P.isValid sys.ge ∧
       ∀ i : Fin n, P.weightedSum i < 0) := by
   -- Enumerate all disjoint ge-pairs
-  let gePairs : List (Finset (Fin n) × Finset (Fin n)) :=
-    ((Finset.univ ×ˢ Finset.univ : Finset _).filter
-      (fun ab => Disjoint ab.1 ab.2 ∧ sys.ge ↑ab.1 ↑ab.2)).toList
+  let gePairs : List (Finset (Fin n) × Finset (Fin n)) := gePairsOf sys
   let k := gePairs.length
   -- Constraint function: n nonnegativity + 1 normUp + 1 normLo + k ordering
   let ineqFn : Fin ((n + 2) + k) → Polyhedral.Ineq n := fun i =>
@@ -431,21 +438,11 @@ private theorem farkas_ordering_lp {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
   have hget : ∀ i : Fin ((n + 2) + k), ineqFn i ∈ S :=
     fun i => List.mem_ofFn.mpr ⟨i, rfl⟩
   have hgePairsMem : ∀ (A B : Finset (Fin n)), Disjoint A B → sys.ge ↑A ↑B →
-      (A, B) ∈ gePairs := by
-    intro A B hd hge
-    simp only [gePairs, Finset.mem_toList, Finset.mem_filter, Finset.mem_product,
-      Finset.mem_univ, true_and]
-    exact ⟨hd, hge⟩
-  have hgePairsDisj : ∀ m : Fin k, Disjoint (gePairs.get m).1 (gePairs.get m).2 := by
-    intro ⟨m, hm⟩
-    have := List.get_mem gePairs ⟨m, hm⟩
-    simp only [gePairs, Finset.mem_toList, Finset.mem_filter] at this
-    exact this.2.1
-  have hgePairsGe : ∀ m : Fin k, sys.ge ↑(gePairs.get m).1 ↑(gePairs.get m).2 := by
-    intro ⟨m, hm⟩
-    have := List.get_mem gePairs ⟨m, hm⟩
-    simp only [gePairs, Finset.mem_toList, Finset.mem_filter] at this
-    exact this.2.2
+      (A, B) ∈ gePairs := gePairs_mem sys
+  have hgePairsDisj : ∀ m : Fin k, Disjoint (gePairs.get m).1 (gePairs.get m).2 :=
+    gePairs_disj sys
+  have hgePairsGe : ∀ m : Fin k, sys.ge ↑(gePairs.get m).1 ↑(gePairs.get m).2 :=
+    gePairs_ge sys
   -- Apply Farkas
   rcases Polyhedral.farkas S with ⟨x, hx⟩ | hcert
   · -- ═══ Feasible case: extract probability vector ═══
@@ -629,7 +626,7 @@ private theorem farkas_ordering_lp {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
       have hcvs_le : (∑ m : Fin k, ((comparisonVec n (gePairs.get m).1
           (gePairs.get m).2 j : ℤ) : ℚ)) ≤ ↑k :=
         le_trans (Finset.sum_le_sum fun m _ => hcv_le1 m)
-          (by simp [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul])
+          (by simp [Finset.sum_const, Finset.card_univ, Fintype.card_fin])
       -- ε * cv_bound = min_gap / 2
       have hε_eq : ε * cv_bound = min_gap / 2 := by
         simp only [ε]
@@ -730,7 +727,6 @@ private theorem strictPairs_strict {n : ℕ} (sys : EpistemicSystemFA (Fin n))
   simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter] at this
   exact this.2.2.2
 
-set_option maxHeartbeats 1600000 in
 private theorem cancel_strengthens_to_bidir {n : ℕ} (sys : EpistemicSystemFA (Fin n))
     (hcancel : Cancellation n sys.ge)
     (hexists : ∃ p : Fin n → ℚ, (∀ i, 0 ≤ p i) ∧ Finset.univ.sum p = 1 ∧
@@ -739,28 +735,16 @@ private theorem cancel_strengthens_to_bidir {n : ℕ} (sys : EpistemicSystemFA (
     ∃ p, p ∈ feasibleWeights n sys := by
   obtain ⟨p₀, hnn₀, hsum₀, hge₀⟩ := hexists
   -- Enumerate all ge pairs
-  let gePairs : List (Finset (Fin n) × Finset (Fin n)) :=
-    ((Finset.univ ×ˢ Finset.univ : Finset _).filter
-      (fun ab => Disjoint ab.1 ab.2 ∧ sys.ge ↑ab.1 ↑ab.2)).toList
+  let gePairs : List (Finset (Fin n) × Finset (Fin n)) := gePairsOf sys
   let k := gePairs.length
   let sp := strictPairsOf sys
   let K := sp.length
   have hgePairsMem : ∀ (A B : Finset (Fin n)), Disjoint A B → sys.ge ↑A ↑B →
-      (A, B) ∈ gePairs := by
-    intro A B hd hge
-    simp only [gePairs, Finset.mem_toList, Finset.mem_filter, Finset.mem_product,
-      Finset.mem_univ, true_and]
-    exact ⟨hd, hge⟩
-  have hgePairsDisj : ∀ m : Fin k, Disjoint (gePairs.get m).1 (gePairs.get m).2 := by
-    intro ⟨m, hm⟩
-    have := List.get_mem gePairs ⟨m, hm⟩
-    simp only [gePairs, Finset.mem_toList, Finset.mem_filter] at this
-    exact this.2.1
-  have hgePairsGe : ∀ m : Fin k, sys.ge ↑(gePairs.get m).1 ↑(gePairs.get m).2 := by
-    intro ⟨m, hm⟩
-    have := List.get_mem gePairs ⟨m, hm⟩
-    simp only [gePairs, Finset.mem_toList, Finset.mem_filter] at this
-    exact this.2.2
+      (A, B) ∈ gePairs := gePairs_mem sys
+  have hgePairsDisj : ∀ m : Fin k, Disjoint (gePairs.get m).1 (gePairs.get m).2 :=
+    gePairs_disj sys
+  have hgePairsGe : ∀ m : Fin k, sys.ge ↑(gePairs.get m).1 ↑(gePairs.get m).2 :=
+    gePairs_ge sys
   -- Case split: are there strict pairs?
   by_cases hK : K = 0
   · -- No strict pairs: p₀ is already ↔ feasible
@@ -826,14 +810,10 @@ private theorem cancel_strengthens_to_bidir {n : ℕ} (sys : EpistemicSystemFA (
           (strictPairs_disj sys ⟨s, hs⟩)]
       -- Normalize: Σx > 0 (from strict constraint on pair 0)
       have hsum_pos : 0 < Finset.univ.sum x := by
-        have hs0 := hx_strict ⟨0, hK_pos⟩
-        have hA := Finset.sum_nonneg (fun i (_ : i ∈ (sp.get ⟨0, hK_pos⟩).1) => hx_nn i)
-        have hB := Finset.sum_nonneg (fun i (_ : i ∈ (sp.get ⟨0, hK_pos⟩).2) => hx_nn i)
-        calc Finset.univ.sum x
-            ≥ (sp.get ⟨0, hK_pos⟩).1.sum x := Finset.sum_le_univ_sum_of_nonneg hx_nn
-          _ ≥ (sp.get ⟨0, hK_pos⟩).2.sum x + 1 := hs0
-          _ ≥ 0 + 1 := by linarith
-          _ > 0 := by linarith
+        have hpair : 0 < (sp.get ⟨0, hK_pos⟩).1.sum x := by
+          linarith [hx_strict ⟨0, hK_pos⟩,
+            Finset.sum_nonneg (fun i (_ : i ∈ (sp.get ⟨0, hK_pos⟩).2) => hx_nn i)]
+        linarith [Finset.sum_le_univ_sum_of_nonneg hx_nn (s := (sp.get ⟨0, hK_pos⟩).1)]
       -- Define normalized vector
       let σ := Finset.univ.sum x
       have hσ_pos : 0 < σ := hsum_pos
@@ -848,10 +828,8 @@ private theorem cancel_strengthens_to_bidir {n : ℕ} (sys : EpistemicSystemFA (
         · -- → direction
           intro hge
           show A.sum (fun i => x i / σ) ≥ B.sum (fun i => x i / σ)
-          have h := hx_ord A B hdisj hge
-          rw [show A.sum (fun i => x i / σ) = A.sum x / σ from by rw [Finset.sum_div],
-              show B.sum (fun i => x i / σ) = B.sum x / σ from by rw [Finset.sum_div]]
-          exact div_le_div_of_nonneg_right h (le_of_lt hσ_pos)
+          rw [← Finset.sum_div, ← Finset.sum_div]
+          exact div_le_div_of_nonneg_right (hx_ord A B hdisj hge) (le_of_lt hσ_pos)
         · -- ← direction (contrapositive)
           intro hge
           by_contra hng
@@ -862,8 +840,7 @@ private theorem cancel_strengthens_to_bidir {n : ℕ} (sys : EpistemicSystemFA (
           rw [hgets] at hgap
           -- B.sum x > A.sum x, so A.sum (x/σ) < B.sum (x/σ)
           have hlt : A.sum (fun i => x i / σ) < B.sum (fun i => x i / σ) := by
-            rw [show A.sum (fun i => x i / σ) = A.sum x / σ from by rw [Finset.sum_div],
-                show B.sum (fun i => x i / σ) = B.sum x / σ from by rw [Finset.sum_div]]
+            rw [← Finset.sum_div, ← Finset.sum_div]
             exact div_lt_div_of_pos_right (by linarith) hσ_pos
           linarith
     · -- ═══ Infeasible case: certificate → cancellation violation ═══
@@ -1142,29 +1119,26 @@ theorem cancellation_implies_representable {n : ℕ}
 -- § 5. FA → Cancellation for small n
 -- ═══════════════════════════════════════════════════════════════
 
+/-- Extend `∅ ≿ S` to `∅ ≿ T` by absorbing one null atom `a`, where
+    `{a} \ T = ∅` and `T \ {a} = S`. -/
+private lemma ge_empty_extend {n : ℕ} (sys : EpistemicSystemFA (Fin n))
+    {a : Fin n} {S T : Set (Fin n)} (hNull : sys.ge ∅ {a}) (hRest : sys.ge ∅ S)
+    (h1 : ({a} : Set (Fin n)) \ T = ∅) (h2 : T \ ({a} : Set (Fin n)) = S) :
+    sys.ge ∅ T :=
+  sys.trans ∅ {a} T hNull ((sys.additive {a} T).mpr (h1 ▸ h2 ▸ hRest))
+
 /-- Not all 4 singletons can be null (non-triviality). -/
 theorem not_all_null_fin4 (sys : EpistemicSystemFA (Fin 4))
     (h0 : sys.ge ∅ {(0 : Fin 4)}) (h1 : sys.ge ∅ {(1 : Fin 4)})
     (h2 : sys.ge ∅ {(2 : Fin 4)}) (h3 : sys.ge ∅ {(3 : Fin 4)}) : False := by
-  have h01 : sys.ge ∅ ({0, 1} : Set (Fin 4)) := by
-    have : sys.ge {1} ({0, 1} : Set (Fin 4)) := by
-      rw [sys.additive {1} {0, 1}]
-      rw [show ({1} : Set (Fin 4)) \ {0, 1} = ∅ from by ext x; fin_cases x <;> simp_all]
-      rw [show ({0, 1} : Set (Fin 4)) \ {1} = {0} from by ext x; fin_cases x <;> simp_all]
-      exact h0
-    exact sys.trans _ _ _ h1 this
-  have h012 : sys.ge ∅ ({0, 1, 2} : Set (Fin 4)) := by
-    have : sys.ge {2} ({0, 1, 2} : Set (Fin 4)) := by
-      rw [sys.additive {2} {0, 1, 2}]
-      rw [show ({2} : Set (Fin 4)) \ {0, 1, 2} = ∅ from by ext x; fin_cases x <;> simp_all]
-      rw [show ({0, 1, 2} : Set (Fin 4)) \ {2} = {0, 1} from by ext x; fin_cases x <;> simp_all]
-      exact h01
-    exact sys.trans _ _ _ h2 this
-  exact sys.nonTrivial (sys.trans _ _ _ h3
-    ((sys.additive {3} Set.univ).mpr
-      (by rw [show ({3} : Set (Fin 4)) \ Set.univ = ∅ from by ext x; simp,
-              show (Set.univ : Set (Fin 4)) \ {3} = {0, 1, 2} from by ext x; fin_cases x <;> simp_all]
-          exact h012)))
+  have h01 : sys.ge ∅ ({0, 1} : Set (Fin 4)) :=
+    ge_empty_extend sys h1 h0
+      (by ext x; fin_cases x <;> simp_all) (by ext x; fin_cases x <;> simp_all)
+  have h012 : sys.ge ∅ ({0, 1, 2} : Set (Fin 4)) :=
+    ge_empty_extend sys h2 h01
+      (by ext x; fin_cases x <;> simp_all) (by ext x; fin_cases x <;> simp_all)
+  exact sys.nonTrivial (ge_empty_extend sys h3 h012
+    (by ext x; simp) (by ext x; fin_cases x <;> simp_all))
 
 
 end Core.Scale

--- a/Linglib/Core/Scales/EpistemicScale/CancellationFin4.lean
+++ b/Linglib/Core/Scales/EpistemicScale/CancellationFin4.lean
@@ -14,7 +14,7 @@ Scott cancellation, hence is representable by a finitely additive measure
 ## Main declarations
 
 * `Core.Scale.fa_cancellation_fin4` — FA axioms imply cancellation on `Fin 4`.
-* `Core.Scale.theorem8a_fin4` — every FA system on `Fin 4` is representable.
+* `Core.Scale.representable_fin4` — every FA system on `Fin 4` is representable.
 * `Core.Scale.no_null_cancellation` — cancellation for systems with no null atoms.
 * `Core.Scale.ge_union_context`, `ge_generalized_merge`, `ge_mono_dominated`,
   `ge_empty_target` — reusable consequences of the FA axioms (any arity).
@@ -759,7 +759,7 @@ A `Fin 3` system with no null atoms extends to a `Fin 4` system by adding a
 new world, then by the restriction to the original three.  The extension
 preserves the FA axioms and the absence of null atoms, and reflects
 cancellation, so `no_null_cancellation` discharges the no-null case of
-`fa_cancellation_fin3`; null atoms reduce to `theorem8a_fin2`.  Theorem 8a
+`fa_cancellation_fin3`; null atoms reduce to `representable_fin2`.  Theorem 8a
 for `Fin 3` then *follows from* cancellation — replacing the former
 measure-by-measure case analysis. -/
 
@@ -944,23 +944,6 @@ private theorem cancellation_extendFA (sys : EpistemicSystemFA (Fin 3))
       exact absurd (Finset.mem_coe.mp h3) (last_notMem_map _)
     · rwa [hL, hR, restrict3_coe_map, restrict3_coe_map] at hge
 
-/-- Not every atom of a `Fin 3` FA system can be null. -/
-private theorem not_all_null_fin3 (sys : EpistemicSystemFA (Fin 3))
-    (h0 : sys.ge ∅ {(0 : Fin 3)}) (h1 : sys.ge ∅ {(1 : Fin 3)})
-    (h2 : sys.ge ∅ {(2 : Fin 3)}) : False := by
-  have h01 : sys.ge ∅ ({0, 1} : Set (Fin 3)) := by
-    have : sys.ge {1} ({0, 1} : Set (Fin 3)) := by
-      rw [sys.additive {1} {0, 1}]
-      rw [show ({1} : Set (Fin 3)) \ {0, 1} = ∅ from by ext x; fin_cases x <;> simp_all]
-      rw [show ({0, 1} : Set (Fin 3)) \ {1} = {0} from by ext x; fin_cases x <;> simp_all]
-      exact h0
-    exact sys.trans _ _ _ h1 this
-  exact sys.nonTrivial (sys.trans _ _ _ h2
-    ((sys.additive {2} Set.univ).mpr
-      (by rw [show ({2} : Set (Fin 3)) \ Set.univ = ∅ from by ext x; simp,
-              show (Set.univ : Set (Fin 3)) \ {2} = {0, 1} from by ext x; fin_cases x <;> simp_all]
-          exact h01)))
-
 /-- **Cancellation for Fin 3**, structurally: null atoms reduce to `Fin 2`
     representability; the no-null case extends lexicographically into `Fin 4`
     and pulls back through `no_null_cancellation`. -/
@@ -970,23 +953,27 @@ theorem fa_cancellation_fin3 (sys : EpistemicSystemFA (Fin 3)) :
   · have hnn : ∃ i : Fin 2, ¬sys.ge ∅ {Fin.succ i} := by
       by_contra hall
       push_neg at hall
-      exact not_all_null_fin3 sys h0 (hall 0) (hall 1)
-    obtain ⟨m, hm⟩ := null_elem_reduce sys h0 hnn (fun sys' => theorem8a_fin2 sys')
-    exact representable_implies_cancellation sys m hm
+      obtain ⟨i, hi⟩ := not_all_null sys
+      fin_cases i
+      · exact hi h0
+      · exact hi (by simpa using hall 0)
+      · exact hi (by simpa using hall 1)
+    obtain ⟨m, hm⟩ := null_elem_reduce sys h0 hnn (fun sys' => representable_fin2 sys')
+    exact representable_implies_cancellation m hm
   · by_cases h1 : sys.ge ∅ {(1 : Fin 3)}
     · obtain ⟨m, hm⟩ := perm_repr (Equiv.swap 0 1) sys
         (null_elem_reduce (transportFA (Equiv.swap 0 1) sys)
           ((perm_null_convert _ _ 0 1 (by decide)).mpr h1)
           ⟨0, fun h => h0 ((perm_null_convert _ _ 1 0 (by decide)).mp h)⟩
-          (fun sys' => theorem8a_fin2 sys'))
-      exact representable_implies_cancellation sys m hm
+          (fun sys' => representable_fin2 sys'))
+      exact representable_implies_cancellation m hm
     · by_cases h2 : sys.ge ∅ {(2 : Fin 3)}
       · obtain ⟨m, hm⟩ := perm_repr (Equiv.swap 0 2) sys
           (null_elem_reduce (transportFA (Equiv.swap 0 2) sys)
             ((perm_null_convert _ _ 0 2 (by decide)).mpr h2)
             ⟨0, fun h => h1 ((perm_null_convert _ _ 1 1 (by decide)).mp h)⟩
-            (fun sys' => theorem8a_fin2 sys'))
-        exact representable_implies_cancellation sys m hm
+            (fun sys' => representable_fin2 sys'))
+        exact representable_implies_cancellation m hm
       · have hnull : ∀ i : Fin 3, ¬sys.ge ∅ {i} := fun i => by fin_cases i <;> assumption
         exact cancellation_extendFA sys
           (no_null_cancellation (extendFA sys) (extendFA_no_null sys hnull))
@@ -994,8 +981,7 @@ theorem fa_cancellation_fin3 (sys : EpistemicSystemFA (Fin 3)) :
 /-- **Theorem 8a for Fin 3**: every FA system on three elements is representable —
     now *derived from* Scott cancellation, replacing the former measure-by-measure
     case analysis. -/
-theorem theorem8a_fin3 (sys : EpistemicSystemFA (Fin 3)) :
-    ∃ m : FinAddMeasure (Fin 3), ∀ A B, sys.ge A B ↔ m.inducedGe A B :=
+theorem representable_fin3 (sys : EpistemicSystemFA (Fin 3)) : Representable sys :=
   cancellation_implies_representable sys (fa_cancellation_fin3 sys)
 
 /-- Null element `0` on `Fin 4`: cancellation via null reduction to `Fin 3`. -/
@@ -1003,8 +989,8 @@ private theorem fa_cancellation_fin4_null0' (sys : EpistemicSystemFA (Fin 4))
     (h0 : sys.ge ∅ {(0 : Fin 4)})
     (hnn : ∃ i : Fin 3, ¬sys.ge ∅ {Fin.succ i}) :
     Cancellation 4 sys.ge := by
-  obtain ⟨m, hm⟩ := null_elem_reduce sys h0 hnn (fun sys' => theorem8a_fin3 sys')
-  exact representable_implies_cancellation sys m hm
+  obtain ⟨m, hm⟩ := null_elem_reduce sys h0 hnn (fun sys' => representable_fin3 sys')
+  exact representable_implies_cancellation m hm
 
 /-- **Theorem 8a (Fin 4), structural**: every FA system on `Fin 4` satisfies
     cancellation. Null cases reduce to `Fin 3` (existing `null_elem_reduce` machinery);
@@ -1015,34 +1001,38 @@ theorem fa_cancellation_fin4 (sys : EpistemicSystemFA (Fin 4)) :
   by_cases h0 : sys.ge ∅ {(0 : Fin 4)}
   · exact fa_cancellation_fin4_null0' sys h0 (by
       by_contra hall; push_neg at hall
-      exact not_all_null_fin4 sys h0 (hall 0) (hall 1) (hall 2))
+      obtain ⟨i, hi⟩ := not_all_null sys
+      fin_cases i
+      · exact hi h0
+      · exact hi (by simpa using hall 0)
+      · exact hi (by simpa using hall 1)
+      · exact hi (by simpa using hall 2))
   · by_cases h1 : sys.ge ∅ {(1 : Fin 4)}
     · obtain ⟨m, hm⟩ := perm_repr (Equiv.swap 0 1) sys
         (null_elem_reduce (transportFA (Equiv.swap 0 1) sys)
           ((perm_null_convert _ _ 0 1 (by decide)).mpr h1)
           ⟨0, fun h => h0 ((perm_null_convert _ _ 1 0 (by decide)).mp h)⟩
-          (fun sys' => theorem8a_fin3 sys'))
-      exact representable_implies_cancellation sys m hm
+          (fun sys' => representable_fin3 sys'))
+      exact representable_implies_cancellation m hm
     · by_cases h2 : sys.ge ∅ {(2 : Fin 4)}
       · obtain ⟨m, hm⟩ := perm_repr (Equiv.swap 0 2) sys
           (null_elem_reduce (transportFA (Equiv.swap 0 2) sys)
             ((perm_null_convert _ _ 0 2 (by decide)).mpr h2)
             ⟨0, fun h => h1 ((perm_null_convert _ _ 1 1 (by decide)).mp h)⟩
-            (fun sys' => theorem8a_fin3 sys'))
-        exact representable_implies_cancellation sys m hm
+            (fun sys' => representable_fin3 sys'))
+        exact representable_implies_cancellation m hm
       · by_cases h3 : sys.ge ∅ {(3 : Fin 4)}
         · obtain ⟨m, hm⟩ := perm_repr (Equiv.swap 0 3) sys
             (null_elem_reduce (transportFA (Equiv.swap 0 3) sys)
               ((perm_null_convert _ _ 0 3 (by decide)).mpr h3)
               ⟨0, fun h => h1 ((perm_null_convert _ _ 1 1 (by decide)).mp h)⟩
-              (fun sys' => theorem8a_fin3 sys'))
-          exact representable_implies_cancellation sys m hm
+              (fun sys' => representable_fin3 sys'))
+          exact representable_implies_cancellation m hm
         · exact no_null_cancellation sys (fun i => by fin_cases i <;> assumption)
 
 /-- **Theorem 8a for Fin 4**: every FA system on 4 elements is representable.
     Via Scott cancellation — see `Cancellation.lean` for the framework. -/
-theorem theorem8a_fin4 (sys : EpistemicSystemFA (Fin 4)) :
-    ∃ (m : FinAddMeasure (Fin 4)), ∀ A B, sys.ge A B ↔ m.inducedGe A B :=
+theorem representable_fin4 (sys : EpistemicSystemFA (Fin 4)) : Representable sys :=
   cancellation_implies_representable sys (fa_cancellation_fin4 sys)
 
 end Core.Scale

--- a/Linglib/Core/Scales/EpistemicScale/CancellationFin4.lean
+++ b/Linglib/Core/Scales/EpistemicScale/CancellationFin4.lean
@@ -16,8 +16,6 @@ Scott cancellation, hence is representable by a finitely additive measure
 * `Core.Scale.fa_cancellation_fin4` — FA axioms imply cancellation on `Fin 4`.
 * `Core.Scale.representable_fin4` — every FA system on `Fin 4` is representable.
 * `Core.Scale.no_null_cancellation` — cancellation for systems with no null atoms.
-* `Core.Scale.ge_union_context`, `ge_generalized_merge`, `ge_mono_dominated`,
-  `ge_empty_target` — reusable consequences of the FA axioms (any arity).
 
 ## Implementation notes
 
@@ -32,85 +30,6 @@ itself are private plumbing; only the theorems above are exported.
 -/
 
 namespace Core.Scale
-
-/-- **Add common context** (from Axiom A + the diff-cancellation): for `C` disjoint
-    from both `X` and `Y`, `X ≿ Y ↔ (X ∪ C) ≿ (Y ∪ C)`. -/
-lemma ge_union_context {n : ℕ} (sys : EpistemicSystemFA (Fin n)) (X Y C : Set (Fin n))
-    (hCX : Disjoint C X) (hCY : Disjoint C Y) :
-    sys.ge X Y ↔ sys.ge (X ∪ C) (Y ∪ C) := by
-  rw [sys.additive X Y, sys.additive (X ∪ C) (Y ∪ C)]
-  have hCXl : ∀ x, x ∈ C → x ∉ X := fun x hx => Set.disjoint_left.mp hCX hx
-  have hCYl : ∀ x, x ∈ C → x ∉ Y := fun x hx => Set.disjoint_left.mp hCY hx
-  have e1 : (X ∪ C) \ (Y ∪ C) = X \ Y := by
-    ext x
-    have := hCXl x
-    simp only [Set.mem_diff, Set.mem_union]
-    tauto
-  have e2 : (Y ∪ C) \ (X ∪ C) = Y \ X := by
-    ext x
-    have := hCYl x
-    simp only [Set.mem_diff, Set.mem_union]
-    tauto
-  rw [e1, e2]
-
-/-- **Generalized merge**: two valid comparisons whose left parts are disjoint and
-    whose right parts are disjoint merge into their union — even with pivot overlaps
-    (X₁∩Y₂, X₂∩Y₁ ≠ ∅). The width-2 additivity in full generality.
-    Derivation: add context `X₂\Y₁` to the first and `Y₁\X₂` to the second, transit
-    through `X₂∪Y₁`, then restore the pivot `P = X₂∩Y₁` via Axiom A. -/
-lemma ge_generalized_merge {n : ℕ} (sys : EpistemicSystemFA (Fin n))
-    {X₁ Y₁ X₂ Y₂ : Set (Fin n)}
-    (h1 : sys.ge X₁ Y₁) (h2 : sys.ge X₂ Y₂)
-    (hX : Disjoint X₁ X₂) (hY : Disjoint Y₁ Y₂) :
-    sys.ge (X₁ ∪ X₂) (Y₁ ∪ Y₂) := by
-  have hXl : ∀ x, x ∈ X₁ → x ∉ X₂ := fun x hx => Set.disjoint_left.mp hX hx
-  have hYl : ∀ x, x ∈ Y₂ → x ∉ Y₁ := fun x hy2 hy1 => Set.disjoint_left.mp hY hy1 hy2
-  -- context C₁ = X₂ \ Y₁ added to (X₁ ≿ Y₁)
-  have step1 : sys.ge (X₁ ∪ (X₂ \ Y₁)) (Y₁ ∪ (X₂ \ Y₁)) :=
-    (ge_union_context sys X₁ Y₁ (X₂ \ Y₁)
-      (Set.disjoint_left.mpr fun x hx hx1 => hXl x hx1 hx.1)
-      (Set.disjoint_left.mpr fun x hx hxY1 => hx.2 hxY1)).mp h1
-  -- context C₂ = Y₁ \ X₂ added to (X₂ ≿ Y₂)
-  have step2 : sys.ge (X₂ ∪ (Y₁ \ X₂)) (Y₂ ∪ (Y₁ \ X₂)) :=
-    (ge_union_context sys X₂ Y₂ (Y₁ \ X₂)
-      (Set.disjoint_left.mpr fun x hx hx2 => hx.2 hx2)
-      (Set.disjoint_left.mpr fun x hx hxY2 => hYl x hxY2 hx.1)).mp h2
-  have hmid : Y₁ ∪ (X₂ \ Y₁) = X₂ ∪ (Y₁ \ X₂) := by
-    ext x; simp only [Set.mem_union, Set.mem_diff]; tauto
-  rw [hmid] at step1
-  have htrans : sys.ge (X₁ ∪ (X₂ \ Y₁)) (Y₂ ∪ (Y₁ \ X₂)) := sys.trans _ _ _ step1 step2
-  set P : Set (Fin n) := X₂ ∩ Y₁ with hP
-  have hLHS : X₁ ∪ (X₂ \ Y₁) = (X₁ ∪ X₂) \ P := by
-    ext x
-    have := hXl x
-    simp only [Set.mem_union, Set.mem_diff, hP, Set.mem_inter_iff, not_and]
-    tauto
-  have hRHS : Y₂ ∪ (Y₁ \ X₂) = (Y₁ ∪ Y₂) \ P := by
-    ext x
-    have := hYl x
-    simp only [Set.mem_union, Set.mem_diff, hP, Set.mem_inter_iff, not_and]
-    tauto
-  rw [hLHS, hRHS] at htrans
-  have hPsubX : P ⊆ X₁ ∪ X₂ := Set.inter_subset_left.trans Set.subset_union_right
-  have hPsubY : P ⊆ Y₁ ∪ Y₂ := Set.inter_subset_right.trans Set.subset_union_left
-  have key := (ge_union_context sys ((X₁ ∪ X₂) \ P) ((Y₁ ∪ Y₂) \ P) P
-    (Set.disjoint_left.mpr fun x hxP hxd => hxd.2 hxP)
-    (Set.disjoint_left.mpr fun x hxP hxd => hxd.2 hxP)).mp htrans
-  rwa [Set.diff_union_of_subset hPsubX, Set.diff_union_of_subset hPsubY] at key
-
-/-- **Mono-domination discharge**: a single valid comparison `X ≿ Y` with `X ⊆ P`
-    and `Q ⊆ Y` proves `P ≿ Q` (monotonicity twice + transitivity). Used to discharge
-    the merge-to-single target when one family member already dominates it. -/
-lemma ge_mono_dominated {n : ℕ} (sys : EpistemicSystemFA (Fin n))
-    {X Y P Q : Set (Fin n)} (h : sys.ge X Y) (hXP : X ⊆ P) (hQY : Q ⊆ Y) :
-    sys.ge P Q :=
-  sys.trans _ _ _ (sys.mono X P hXP) (sys.trans _ _ _ h (sys.mono Q Y hQY))
-
-/-- **Trivial-target discharge**: `P ≿ ∅` always (monotonicity, `∅ ⊆ P`). The
-    merge-to-single base case when the target's negative part is empty. -/
-lemma ge_empty_target {n : ℕ} (sys : EpistemicSystemFA (Fin n)) (P : Set (Fin n)) :
-    sys.ge P ∅ :=
-  sys.mono ∅ P (Set.empty_subset P)
 
 /-! ### Merge-to-single infrastructure
 
@@ -944,39 +863,17 @@ private theorem cancellation_extendFA (sys : EpistemicSystemFA (Fin 3))
       exact absurd (Finset.mem_coe.mp h3) (last_notMem_map _)
     · rwa [hL, hR, restrict3_coe_map, restrict3_coe_map] at hge
 
-/-- **Cancellation for Fin 3**, structurally: null atoms reduce to `Fin 2`
+/-- **Cancellation for Fin 3**, structurally: a null atom reduces to `Fin 2`
     representability; the no-null case extends lexicographically into `Fin 4`
     and pulls back through `no_null_cancellation`. -/
 theorem fa_cancellation_fin3 (sys : EpistemicSystemFA (Fin 3)) :
     Cancellation 3 sys.ge := by
-  by_cases h0 : sys.ge ∅ {(0 : Fin 3)}
-  · have hnn : ∃ i : Fin 2, ¬sys.ge ∅ {Fin.succ i} := by
-      by_contra hall
-      push_neg at hall
-      obtain ⟨i, hi⟩ := not_all_null sys
-      fin_cases i
-      · exact hi h0
-      · exact hi (by simpa using hall 0)
-      · exact hi (by simpa using hall 1)
-    obtain ⟨m, hm⟩ := null_elem_reduce sys h0 hnn (fun sys' => representable_fin2 sys')
-    exact representable_implies_cancellation m hm
-  · by_cases h1 : sys.ge ∅ {(1 : Fin 3)}
-    · obtain ⟨m, hm⟩ := perm_repr (Equiv.swap 0 1) sys
-        (null_elem_reduce (transportFA (Equiv.swap 0 1) sys)
-          ((perm_null_convert _ _ 0 1 (by decide)).mpr h1)
-          ⟨0, fun h => h0 ((perm_null_convert _ _ 1 0 (by decide)).mp h)⟩
-          (fun sys' => representable_fin2 sys'))
-      exact representable_implies_cancellation m hm
-    · by_cases h2 : sys.ge ∅ {(2 : Fin 3)}
-      · obtain ⟨m, hm⟩ := perm_repr (Equiv.swap 0 2) sys
-          (null_elem_reduce (transportFA (Equiv.swap 0 2) sys)
-            ((perm_null_convert _ _ 0 2 (by decide)).mpr h2)
-            ⟨0, fun h => h1 ((perm_null_convert _ _ 1 1 (by decide)).mp h)⟩
-            (fun sys' => representable_fin2 sys'))
-        exact representable_implies_cancellation m hm
-      · have hnull : ∀ i : Fin 3, ¬sys.ge ∅ {i} := fun i => by fin_cases i <;> assumption
-        exact cancellation_extendFA sys
-          (no_null_cancellation (extendFA sys) (extendFA_no_null sys hnull))
+  by_cases h : ∃ j, sys.ge ∅ {j}
+  · obtain ⟨j, hj⟩ := h
+    exact cancellation_of_null_atom sys hj representable_fin2
+  · push_neg at h
+    exact cancellation_extendFA sys
+      (no_null_cancellation (extendFA sys) (extendFA_no_null sys h))
 
 /-- **Theorem 8a for Fin 3**: every FA system on three elements is representable —
     now *derived from* Scott cancellation, replacing the former measure-by-measure
@@ -984,51 +881,16 @@ theorem fa_cancellation_fin3 (sys : EpistemicSystemFA (Fin 3)) :
 theorem representable_fin3 (sys : EpistemicSystemFA (Fin 3)) : Representable sys :=
   cancellation_implies_representable sys (fa_cancellation_fin3 sys)
 
-/-- Null element `0` on `Fin 4`: cancellation via null reduction to `Fin 3`. -/
-private theorem fa_cancellation_fin4_null0' (sys : EpistemicSystemFA (Fin 4))
-    (h0 : sys.ge ∅ {(0 : Fin 4)})
-    (hnn : ∃ i : Fin 3, ¬sys.ge ∅ {Fin.succ i}) :
-    Cancellation 4 sys.ge := by
-  obtain ⟨m, hm⟩ := null_elem_reduce sys h0 hnn (fun sys' => representable_fin3 sys')
-  exact representable_implies_cancellation m hm
-
 /-- **Theorem 8a (Fin 4), structural**: every FA system on `Fin 4` satisfies
-    cancellation. Null cases reduce to `Fin 3` (existing `null_elem_reduce` machinery);
-    the no-null case is the merge reduction `no_null_cancellation`. Replaces the
-    88-chamber `fa_cancellation_fin4`. -/
+    cancellation. A null atom reduces to `Fin 3`; the no-null case is the merge
+    reduction `no_null_cancellation`. -/
 theorem fa_cancellation_fin4 (sys : EpistemicSystemFA (Fin 4)) :
     Cancellation 4 sys.ge := by
-  by_cases h0 : sys.ge ∅ {(0 : Fin 4)}
-  · exact fa_cancellation_fin4_null0' sys h0 (by
-      by_contra hall; push_neg at hall
-      obtain ⟨i, hi⟩ := not_all_null sys
-      fin_cases i
-      · exact hi h0
-      · exact hi (by simpa using hall 0)
-      · exact hi (by simpa using hall 1)
-      · exact hi (by simpa using hall 2))
-  · by_cases h1 : sys.ge ∅ {(1 : Fin 4)}
-    · obtain ⟨m, hm⟩ := perm_repr (Equiv.swap 0 1) sys
-        (null_elem_reduce (transportFA (Equiv.swap 0 1) sys)
-          ((perm_null_convert _ _ 0 1 (by decide)).mpr h1)
-          ⟨0, fun h => h0 ((perm_null_convert _ _ 1 0 (by decide)).mp h)⟩
-          (fun sys' => representable_fin3 sys'))
-      exact representable_implies_cancellation m hm
-    · by_cases h2 : sys.ge ∅ {(2 : Fin 4)}
-      · obtain ⟨m, hm⟩ := perm_repr (Equiv.swap 0 2) sys
-          (null_elem_reduce (transportFA (Equiv.swap 0 2) sys)
-            ((perm_null_convert _ _ 0 2 (by decide)).mpr h2)
-            ⟨0, fun h => h1 ((perm_null_convert _ _ 1 1 (by decide)).mp h)⟩
-            (fun sys' => representable_fin3 sys'))
-        exact representable_implies_cancellation m hm
-      · by_cases h3 : sys.ge ∅ {(3 : Fin 4)}
-        · obtain ⟨m, hm⟩ := perm_repr (Equiv.swap 0 3) sys
-            (null_elem_reduce (transportFA (Equiv.swap 0 3) sys)
-              ((perm_null_convert _ _ 0 3 (by decide)).mpr h3)
-              ⟨0, fun h => h1 ((perm_null_convert _ _ 1 1 (by decide)).mp h)⟩
-              (fun sys' => representable_fin3 sys'))
-          exact representable_implies_cancellation m hm
-        · exact no_null_cancellation sys (fun i => by fin_cases i <;> assumption)
+  by_cases h : ∃ j, sys.ge ∅ {j}
+  · obtain ⟨j, hj⟩ := h
+    exact cancellation_of_null_atom sys hj representable_fin3
+  · push_neg at h
+    exact no_null_cancellation sys h
 
 /-- **Theorem 8a for Fin 4**: every FA system on 4 elements is representable.
     Via Scott cancellation — see `Cancellation.lean` for the framework. -/

--- a/Linglib/Core/Scales/EpistemicScale/CancellationFin4.lean
+++ b/Linglib/Core/Scales/EpistemicScale/CancellationFin4.lean
@@ -53,8 +53,7 @@ private lemma cmpVec_mergeCmp {n : ℕ} (c d : Finset (Fin n) × Finset (Fin n))
     cmpVec (mergeCmp c d) i = cmpVec c i + cmpVec d i := by
   have h1 : i ∈ c.1 → i ∉ d.1 := fun h => Finset.disjoint_left.mp hpos h
   have h2 : i ∈ c.2 → i ∉ d.2 := fun h => Finset.disjoint_left.mp hneg h
-  simp only [cmpVec, mergeCmp, Finset.mem_sdiff, Finset.mem_union]
-  split_ifs <;> simp_all
+  simp only [cmpVec, mergeCmp, Finset.mem_sdiff, Finset.mem_union]; split_ifs <;> simp_all
 
 /-- `mergeCmp` of two valid comparisons is valid, given the disjointness conditions.
     Uses `ge_generalized_merge` then Axiom A to reach disjoint normal form. -/
@@ -101,15 +100,13 @@ private lemma null_from_pair (sys : EpistemicSystemFA (Fin 4))
     ∃ i, sys.ge (∅ : Set (Fin 4)) {i} := by
   -- A ⊆ D and C ⊆ B (membership facts from disjointness)
   have hAD : A ⊆ D := by
-    intro a ha
-    by_contra haD
+    intro a ha; by_contra haD
     have := hle a
     simp only [cmpVec, if_pos ha, if_neg (Finset.disjoint_left.mp hABd ha), if_neg haD,
       sub_zero] at this
     split_ifs at this <;> omega
   have hCB : C ⊆ B := by
-    intro c hc
-    by_contra hcB
+    intro c hc; by_contra hcB
     have := hle c
     simp only [cmpVec, if_pos hc, if_neg (Finset.disjoint_left.mp hCDd hc), if_neg hcB,
       sub_zero] at this
@@ -124,15 +121,13 @@ private lemma null_from_pair (sys : EpistemicSystemFA (Fin 4))
       Finset.sdiff_eq_empty_iff_subset.mpr hCB, Finset.coe_empty] at hax
   -- symmetric: ge A D, ge A C, ge A D? -> ge ∅ (D \ A)
   have hAC : sys.ge ↑A ↑C := sys.trans _ _ _ hAB (sys.mono ↑C ↑B (Finset.coe_subset.mpr hCB))
-  have hAD_ge : sys.ge ↑A ↑D := sys.trans _ _ _ hAC hCD
   have hDA : sys.ge (∅ : Set (Fin 4)) ↑(D \ A) := by
-    have hax := (sys.additive ↑A ↑D).mp hAD_ge
+    have hax := (sys.additive ↑A ↑D).mp (sys.trans _ _ _ hAC hCD)
     rwa [← Finset.coe_sdiff, ← Finset.coe_sdiff,
       Finset.sdiff_eq_empty_iff_subset.mpr hAD, Finset.coe_empty] at hax
   -- strict coordinate i₀ ∈ (B \ C) ∪ (D \ A)
   have hmem : i₀ ∈ B \ C ∨ i₀ ∈ D \ A := by
-    simp only [cmpVec, Finset.mem_sdiff] at hlt ⊢
-    split_ifs at hlt <;> simp_all
+    simp only [cmpVec, Finset.mem_sdiff] at hlt ⊢; split_ifs at hlt <;> simp_all
   rcases hmem with hm | hm
   · exact ⟨i₀, sys.trans _ _ _ hBC (sys.mono {i₀} ↑(B \ C)
       (by rw [Set.singleton_subset_iff]; exact Finset.mem_coe.mpr hm))⟩
@@ -147,31 +142,25 @@ private def toQVec (c : Finset (Fin 4) × Finset (Fin 4)) : Fin 4 → ℚ :=
 
 private lemma toQVec_apply (c : Finset (Fin 4) × Finset (Fin 4)) (k : Fin 4) :
     toQVec c k = (if k ∈ c.1 then (1 : ℚ) else 0) - (if k ∈ c.2 then 1 else 0) := by
-  simp only [toQVec, cmpVec]
-  split_ifs <;> norm_num
+  simp only [toQVec, cmpVec]; split_ifs <;> norm_num
 
 private lemma posSupport_toQVec {c : Finset (Fin 4) × Finset (Fin 4)} (hc : Disjoint c.1 c.2) :
     SignVec.posSupport (toQVec c) = c.1 := by
   ext k
   rw [SignVec.mem_posSupport, toQVec_apply]
   by_cases h1 : k ∈ c.1 <;> by_cases h2 : k ∈ c.2 <;>
-    first
-      | exact absurd h2 (Finset.disjoint_left.mp hc h1)
-      | norm_num [h1, h2]
+    first | exact absurd h2 (Finset.disjoint_left.mp hc h1) | norm_num [h1, h2]
 
 private lemma negSupport_toQVec {c : Finset (Fin 4) × Finset (Fin 4)} (hc : Disjoint c.1 c.2) :
     SignVec.negSupport (toQVec c) = c.2 := by
   ext k
   rw [SignVec.mem_negSupport, toQVec_apply]
   by_cases h1 : k ∈ c.1 <;> by_cases h2 : k ∈ c.2 <;>
-    first
-      | exact absurd h2 (Finset.disjoint_left.mp hc h1)
-      | norm_num [h1, h2]
+    first | exact absurd h2 (Finset.disjoint_left.mp hc h1) | norm_num [h1, h2]
 
 private lemma cmpVec_swap (A B : Finset (Fin 4)) (i : Fin 4) :
     cmpVec (B, A) i = -cmpVec (A, B) i := by
-  simp only [cmpVec]
-  ring
+  simp only [cmpVec]; ring
 
 /-- Comparisons with both parts empty contribute nothing to the vector sum. -/
 private lemma cvSumList_filter_ne_empty (L : List (Finset (Fin 4) × Finset (Fin 4)))
@@ -219,25 +208,20 @@ private lemma v1_tailored
   by_cases hemp : ∃ c ∈ L, c.1 = ∅ ∧ c.2.Nonempty
   · obtain ⟨c, hcL, hc1, k, hk⟩ := hemp
     refine Or.inl ⟨c, hcL, c, hcL, fun i => ?_, k, ?_⟩
-    · simp only [cmpVec, hc1, if_neg (Finset.notMem_empty i)]
-      split_ifs <;> omega
-    · simp only [cmpVec, hc1, if_neg (Finset.notMem_empty k), if_pos hk]
-      omega
+    · simp only [cmpVec, hc1, if_neg (Finset.notMem_empty i)]; split_ifs <;> omega
+    · simp only [cmpVec, hc1, if_neg (Finset.notMem_empty k), if_pos hk]; omega
   -- Step B: the right disjunct as an escape hatch
   by_cases hrd : ∃ c ∈ L, Disjoint vneg c.1 ∧ Disjoint vpos c.2
   · exact Or.inr hrd
   have h0 : ∀ c ∈ L, c.1 = ∅ → c.2 = ∅ := by
-    intro c hc h1
-    by_contra h2
+    intro c hc h1; by_contra h2
     exact hemp ⟨c, hc, h1, Finset.nonempty_iff_ne_empty.mpr h2⟩
   -- Step C: the balanced ℚ sign-vector family on `L′ ∪ {reversed target}`
   set L' := L.filter (fun c => c.1 ≠ ∅) with hL'
   set l : List (Fin 4 → ℚ) := ((vneg, vpos) :: L').map toQVec with hl
   set S : Finset (Fin 4 → ℚ) := l.toFinset with hS
   have hfil : ∀ i, cvSumList L' i = cvSumList L i := by
-    intro i
-    rw [hL']
-    exact cvSumList_filter_ne_empty L h0 i
+    intro i; rw [hL']; exact cvSumList_filter_ne_empty L h0 i
   have hmem_shape : ∀ v ∈ S, ∃ c, (c = (vneg, vpos) ∨ c ∈ L') ∧ toQVec c = v := by
     intro v hv
     rw [hS, List.mem_toFinset, hl, List.mem_map] at hv
@@ -250,30 +234,25 @@ private lemma v1_tailored
   have hsign : ∀ v ∈ S, ∀ i, v i = -1 ∨ v i = 0 ∨ v i = 1 := by
     intro v hv i
     obtain ⟨c, _, rfl⟩ := hmem_shape v hv
-    rw [toQVec_apply]
-    split_ifs <;> norm_num
+    rw [toQVec_apply]; split_ifs <;> norm_num
   have hposne : ∀ v ∈ S, ∃ i, v i = 1 := by
     intro v hv
     obtain ⟨c, hc, rfl⟩ := hmem_shape v hv
     rcases hc with rfl | hc
     · obtain ⟨k, hk⟩ := hne
       refine ⟨k, ?_⟩
-      rw [toQVec_apply, if_pos hk, if_neg (Finset.disjoint_right.mp hvpvn hk)]
-      norm_num
+      rw [toQVec_apply, if_pos hk, if_neg (Finset.disjoint_right.mp hvpvn hk)]; norm_num
     · have hcL : c ∈ L := List.mem_of_mem_filter hc
       have hc1 : c.1 ≠ ∅ := by simpa using List.of_mem_filter hc
       obtain ⟨k, hk⟩ := Finset.nonempty_iff_ne_empty.mpr hc1
       refine ⟨k, ?_⟩
-      rw [toQVec_apply, if_pos hk, if_neg (Finset.disjoint_left.mp (hdisj c hcL) hk)]
-      norm_num
+      rw [toQVec_apply, if_pos hk, if_neg (Finset.disjoint_left.mp (hdisj c hcL) hk)]; norm_num
   have hSne : S.Nonempty := by
     refine ⟨toQVec (vneg, vpos), ?_⟩
     rw [hS, List.mem_toFinset, hl]
     exact List.mem_map.mpr ⟨(vneg, vpos), List.mem_cons.mpr (Or.inl rfl), rfl⟩
   have hdQ : ∀ v ∈ S, 0 < ((l.count v : ℕ) : ℚ) := by
-    intro v hv
-    rw [hS, List.mem_toFinset] at hv
-    exact_mod_cast List.count_pos_iff.mpr hv
+    intro v hv; rw [hS, List.mem_toFinset] at hv; exact_mod_cast List.count_pos_iff.mpr hv
   have hbal : ∑ v ∈ S, ((l.count v : ℕ) : ℚ) • v = 0 := by
     funext i
     rw [Finset.sum_apply]
@@ -283,14 +262,10 @@ private lemma v1_tailored
       List.map_map]
     simp only [Function.comp_def, List.map_cons, List.sum_cons]
     have hLs : (L'.map (fun c => toQVec c i)).sum = ((cvSumList L' i : ℤ) : ℚ) := by
-      simp only [toQVec, cvSumList]
-      rw [Int.cast_list_sum, List.map_map]
-      rfl
+      simp only [toQVec, cvSumList]; rw [Int.cast_list_sum, List.map_map]; rfl
     rw [hLs, hfil i, hsum i]
     simp only [toQVec]
-    rw [cmpVec_swap]
-    push_cast
-    ring
+    rw [cmpVec_swap]; push_cast; ring
   -- no-g-merge transfers to the vector family
   have hSnogm : ∀ v ∈ S, ∀ w ∈ S, v ≠ w →
       ¬(Disjoint (SignVec.posSupport v) (SignVec.posSupport w) ∧ Disjoint (SignVec.negSupport v) (SignVec.negSupport w)) := by
@@ -305,12 +280,11 @@ private lemma v1_tailored
     · exact hrd ⟨c, List.mem_of_mem_filter hc, hg1.symm, hg2.symm⟩
     · have hcc' : c ≠ c' := fun he => hvw (by rw [he])
       have hcL : c ∈ L := List.mem_of_mem_filter hc
-      have hc'L : c' ∈ L := List.mem_of_mem_filter hc'
       have hp1 := List.perm_cons_erase hcL
-      have hc'e : c' ∈ L.erase c := (List.mem_erase_of_ne (Ne.symm hcc')).mpr hc'L
+      have hc'e : c' ∈ L.erase c :=
+        (List.mem_erase_of_ne (Ne.symm hcc')).mpr (List.mem_of_mem_filter hc')
       have hp2 := List.perm_cons_erase hc'e
-      exact hnogm ⟨c, c', (L.erase c).erase c',
-        hp1.trans (List.Perm.cons c hp2), hg1, hg2⟩
+      exact hnogm ⟨c, c', (L.erase c).erase c', hp1.trans (List.Perm.cons c hp2), hg1, hg2⟩
   -- Carathéodory pivot, then the finite core
   obtain ⟨S', hS'S, hS'ne, hS'card, d', hd', hsum'⟩ :=
     Caratheodory.exists_posdep_card_le_five S (fun v => ((l.count v : ℕ) : ℚ)) hdQ hSne hbal
@@ -330,26 +304,19 @@ private lemma v1_tailored
     rcases eq_or_ne (w i) 1 with h2 | h2
     · rw [h2, hps' i h2]; norm_num
     rcases hsign v hvS i with h | h | h <;> rcases hsign w hwS i with h' | h' | h' <;>
-      first
-        | exact absurd h h1
-        | exact absurd h' h2
-        | (rw [h, h']; norm_num)
+      first | exact absurd h h1 | exact absurd h' h2 | (rw [h, h']; norm_num)
   have hvstrict : ∃ i, v i + w i < 0 := by
     by_contra hall
     push_neg at hall
     have heq : ∀ i, w i = -v i := fun i =>
       le_antisymm (by have := hvle i; linarith) (by have := hall i; linarith)
     refine hSnogm v hvS w hwS hvw ⟨?_, ?_⟩
-    · rw [Finset.disjoint_left]
-      intro k hk hk'
+    · rw [Finset.disjoint_left]; intro k hk hk'
       rw [SignVec.mem_posSupport] at hk hk'
-      rw [heq k, hk] at hk'
-      norm_num at hk'
-    · rw [Finset.disjoint_left]
-      intro k hk hk'
+      rw [heq k, hk] at hk'; norm_num at hk'
+    · rw [Finset.disjoint_left]; intro k hk hk'
       rw [SignVec.mem_negSupport] at hk hk'
-      rw [heq k, hk] at hk'
-      norm_num at hk'
+      rw [heq k, hk] at hk'; norm_num at hk'
   -- map the pair back to comparisons
   obtain ⟨c, hc, rfl⟩ := hmem_shape v hvS
   obtain ⟨c', hc', rfl⟩ := hmem_shape w hwS
@@ -371,13 +338,9 @@ private lemma v1_tailored
   · -- both from `L`: the null pair
     refine Or.inl ⟨c, List.mem_of_mem_filter hc, c', List.mem_of_mem_filter hc',
       fun i => ?_, ?_⟩
-    · have h := hvle i
-      simp only [toQVec] at h
-      exact_mod_cast h
+    · have h := hvle i; simp only [toQVec] at h; exact_mod_cast h
     · obtain ⟨i, hi⟩ := hvstrict
-      refine ⟨i, ?_⟩
-      simp only [toQVec] at hi
-      exact_mod_cast hi
+      refine ⟨i, ?_⟩; simp only [toQVec] at hi; exact_mod_cast hi
 
 /-- **Recombine** (case 4 of the merge recursion): if a member `c` is valid, the
     reversed target `r = (vneg, vpos)` generalized-merges `c` (`Disjoint vneg c.1`,
@@ -406,15 +369,13 @@ private lemma recombine (sys : EpistemicSystemFA (Fin 4))
     exact ⟨Finset.sdiff_disjoint, Disjoint.mono_left Finset.sdiff_subset hcd⟩
   have hmerge := mergeCmp_valid sys (c := (p, q)) (d := c) hX hc hdp hdq
   have e1 : (mergeCmp (p, q) c).1 = vpos := by
-    apply Finset.ext; intro x
+    refine Finset.ext fun x => ?_
     have h1 := dvv x; have h2 := dvc1 x; have h3 := dvc2 x; have h4 := dc x
-    simp only [mergeCmp, hp, hq, Finset.mem_sdiff, Finset.mem_union]
-    tauto
+    simp only [mergeCmp, hp, hq, Finset.mem_sdiff, Finset.mem_union]; tauto
   have e2 : (mergeCmp (p, q) c).2 = vneg := by
-    apply Finset.ext; intro x
+    refine Finset.ext fun x => ?_
     have h1 := dvv x; have h2 := dvc1 x; have h3 := dvc2 x; have h4 := dc x
-    simp only [mergeCmp, hp, hq, Finset.mem_sdiff, Finset.mem_union]
-    tauto
+    simp only [mergeCmp, hp, hq, Finset.mem_sdiff, Finset.mem_union]; tauto
   rwa [e1, e2] at hmerge
 
 /-- **Merge-to-single**: on a no-null Fin 4 system, any valid family of disjoint
@@ -465,14 +426,12 @@ private theorem merge_to_single (sys : EpistemicSystemFA (Fin 4))
             have a4 : i ∈ c.1 → i ∉ c.2 := fun h => Finset.disjoint_left.mp (hdisj c hcL) h
             simp only [cmpVec, Finset.mem_union, Finset.mem_sdiff]
             by_cases h1v : i ∈ vpos <;> by_cases h2v : i ∈ vneg <;>
-              by_cases h3v : i ∈ c.1 <;> by_cases h4v : i ∈ c.2 <;>
-              simp_all
+              by_cases h3v : i ∈ c.1 <;> by_cases h4v : i ∈ c.2 <;> simp_all
           have hpq : Disjoint ((vpos \ c.1) ∪ (c.2 \ vneg)) ((vneg \ c.2) ∪ (c.1 \ vpos)) := by
             rw [Finset.disjoint_left]; intro x hxp hxq
             have a1 : x ∈ vpos → x ∉ vneg := fun h => Finset.disjoint_left.mp hvpvn h
             have a4 : x ∈ c.1 → x ∉ c.2 := fun h => Finset.disjoint_left.mp (hdisj c hcL) h
-            simp only [Finset.mem_union, Finset.mem_sdiff] at hxp hxq
-            tauto
+            simp only [Finset.mem_union, Finset.mem_sdiff] at hxp hxq; tauto
           have hdisj' : ∀ x ∈ L.erase c, Disjoint x.1 x.2 :=
             fun x hx => hdisj x (List.mem_of_mem_erase hx)
           have hvalid' : ∀ x ∈ L.erase c, sys.ge ↑x.1 ↑x.2 :=
@@ -497,10 +456,8 @@ private theorem merge_to_single (sys : EpistemicSystemFA (Fin 4))
         · exact hvalid x (hrestsub x hx)
       have hsum' : ∀ i, cvSumList (mergeCmp c d :: rest) i = cmpVec (vpos, vneg) i := by
         intro i
-        rw [cvSumList_cons, cmpVec_mergeCmp c d hpd hnd i, ← hsum i,
-            cvSumList_perm hperm i]
-        simp only [cvSumList_cons]
-        omega
+        rw [cvSumList_cons, cmpVec_mergeCmp c d hpd hnd i, ← hsum i, cvSumList_perm hperm i]
+        simp only [cvSumList_cons]; omega
       exact merge_to_single sys hnull (mergeCmp c d :: rest) hdisj' hvalid' vpos vneg hvpvn hsum'
   · -- trivial-target discharge: vneg = ∅
     rw [Finset.not_nonempty_iff_eq_empty] at hne
@@ -539,16 +496,13 @@ private lemma cvSumList_replicate {n : ℕ} (m : ℕ) (c : Finset (Fin n) × Fin
 private lemma weight_mul_den (q : ℚ) : q * (q.den : ℚ) = (q.num : ℚ) := by
   have h := Rat.num_div_den q
   have hd : (q.den : ℚ) ≠ 0 := by exact_mod_cast q.den_ne_zero
-  rw [div_eq_iff hd] at h
-  exact h.symm
+  rw [div_eq_iff hd] at h; exact h.symm
 
 private lemma den_prod_pos (P : List (WComparison 4)) :
     0 < (P.map (fun wc => wc.weight.den)).prod := by
   induction P with
   | nil => simp
-  | cons a P ih =>
-    simp only [List.map_cons, List.prod_cons]
-    exact Nat.mul_pos a.weight.den_pos ih
+  | cons a P ih => simp only [List.map_cons, List.prod_cons]; exact Nat.mul_pos a.weight.den_pos ih
 
 /-- Casting the integer multiplicities back to `ℚ` recovers `D · weightedSum`. -/
 private lemma cleared_sum_eq (P : Portfolio 4) (i : Fin 4) (D : ℕ)
@@ -582,8 +536,7 @@ private theorem exists_balanced_list (sys : EpistemicSystemFA (Fin 4))
   have hDpos : 0 < D := hD ▸ den_prod_pos P
   have hdvd : ∀ wc, List.Mem wc P → wc.weight.den ∣ D := by
     intro wc hwc
-    rw [hD]
-    exact List.dvd_prod (by simp only [List.mem_map]; exact ⟨wc, hwc, rfl⟩)
+    rw [hD]; exact List.dvd_prod (by simp only [List.mem_map]; exact ⟨wc, hwc, rfl⟩)
   set mult : WComparison 4 → ℕ :=
     fun wc => (wc.weight.num * (D / wc.weight.den : ℕ)).toNat with hmult
   have hcast : ∀ wc, List.Mem wc P → ((mult wc : ℤ) : ℚ) = wc.weight * (D : ℚ) := by
@@ -593,14 +546,10 @@ private theorem exists_balanced_list (sys : EpistemicSystemFA (Fin 4))
       rw [hk]; exact Nat.mul_div_cancel_left k wc.weight.den_pos
     have hnumpos : 0 < wc.weight.num := Rat.num_pos.mpr wc.weight_pos
     have hkpos : 0 < k := Nat.pos_of_ne_zero (by rintro rfl; rw [Nat.mul_zero] at hk; omega)
-    have hmz : 0 ≤ wc.weight.num * (D / wc.weight.den : ℕ) := by
-      rw [hdk]; positivity
-    rw [hmult]
-    simp only
-    rw [Int.toNat_of_nonneg hmz, hdk]
-    push_cast
-    rw [hk]
-    push_cast
+    have hmz : 0 ≤ wc.weight.num * (D / wc.weight.den : ℕ) := by rw [hdk]; positivity
+    rw [hmult]; simp only
+    rw [Int.toNat_of_nonneg hmz, hdk]; push_cast
+    rw [hk]; push_cast
     rw [← mul_assoc, weight_mul_den]
   have hmultpos : ∀ wc, List.Mem wc P → 1 ≤ mult wc := by
     intro wc hwc
@@ -609,9 +558,7 @@ private theorem exists_balanced_list (sys : EpistemicSystemFA (Fin 4))
       rw [hk]; exact Nat.mul_div_cancel_left k wc.weight.den_pos
     have hnumpos : 0 < wc.weight.num := Rat.num_pos.mpr wc.weight_pos
     have hkpos : 0 < k := Nat.pos_of_ne_zero (by rintro rfl; rw [Nat.mul_zero] at hk; omega)
-    rw [hmult]
-    simp only
-    rw [hdk]
+    rw [hmult]; simp only; rw [hdk]
     have hp : 0 < wc.weight.num * (k : ℤ) := by positivity
     omega
   set Lfull : List (Finset (Fin 4) × Finset (Fin 4)) :=
@@ -622,43 +569,30 @@ private theorem exists_balanced_list (sys : EpistemicSystemFA (Fin 4))
     obtain ⟨wc, hwc, hc⟩ := hc
     exact ⟨wc, hwc, List.eq_of_mem_replicate hc⟩
   have hLdisj : ∀ c ∈ Lfull, Disjoint c.1 c.2 := by
-    intro c hc
-    obtain ⟨wc, _, rfl⟩ := hmemLfull c hc
-    exact wc.disjoint
+    intro c hc; obtain ⟨wc, _, rfl⟩ := hmemLfull c hc; exact wc.disjoint
   have hLvalid : ∀ c ∈ Lfull, sys.ge ↑c.1 ↑c.2 := by
-    intro c hc
-    obtain ⟨wc, hwc, rfl⟩ := hmemLfull c hc
-    exact hvalid wc hwc
+    intro c hc; obtain ⟨wc, hwc, rfl⟩ := hmemLfull c hc; exact hvalid wc hwc
   have hLsum : ∀ i, cvSumList Lfull i = 0 := by
     intro i
     have hstep : cvSumList Lfull i =
         (P.map (fun wc => (mult wc : ℤ) * cmpVec (wc.left, wc.right) i)).sum := by
       rw [hLfull, cvSumList_flatMap]
-      congr 1
-      apply List.map_congr_left
-      intro wc _
-      rw [cvSumList_replicate]
+      exact congrArg _ (List.map_congr_left fun wc _ => cvSumList_replicate _ _ _)
     have hzero : ((cvSumList Lfull i : ℤ) : ℚ) = 0 := by
       rw [hstep, cleared_sum_eq P i D mult hcast, hneutral i, mul_zero]
     exact_mod_cast hzero
   have hsLfull : (s.left, s.right) ∈ Lfull := by
     rw [hLfull, List.mem_flatMap]
     exact ⟨s, hsmem, List.mem_replicate.mpr ⟨by have := hmultpos s hsmem; omega, rfl⟩⟩
-  refine ⟨Lfull.erase (s.left, s.right), ?_, ?_, ?_⟩
-  · intro c hc
-    exact hLdisj c (List.mem_of_mem_erase hc)
-  · intro c hc
-    exact hLvalid c (List.mem_of_mem_erase hc)
-  · intro i
-    have hperm := List.perm_cons_erase hsLfull
-    have h1 : cvSumList Lfull i
-        = cmpVec (s.left, s.right) i + cvSumList (Lfull.erase (s.left, s.right)) i := by
-      rw [cvSumList_perm hperm i, cvSumList_cons]
-    have h2 : cvSumList (Lfull.erase (s.left, s.right)) i = - cmpVec (s.left, s.right) i := by
-      have := hLsum i; omega
-    rw [h2]
-    simp only [cmpVec]
-    split_ifs <;> omega
+  refine ⟨Lfull.erase (s.left, s.right), fun c hc => hLdisj c (List.mem_of_mem_erase hc),
+    fun c hc => hLvalid c (List.mem_of_mem_erase hc), fun i => ?_⟩
+  have hperm := List.perm_cons_erase hsLfull
+  have h1 : cvSumList Lfull i
+      = cmpVec (s.left, s.right) i + cvSumList (Lfull.erase (s.left, s.right)) i := by
+    rw [cvSumList_perm hperm i, cvSumList_cons]
+  have h2 : cvSumList (Lfull.erase (s.left, s.right)) i = - cmpVec (s.left, s.right) i := by
+    have := hLsum i; omega
+  rw [h2]; simp only [cmpVec]; split_ifs <;> omega
 
 /-- **No-null case** of Theorem 8a (Fin 4): when no atom is null, every valid neutral
     portfolio is non-strict, via the merge reduction `merge_to_single`. -/
@@ -696,8 +630,7 @@ def extendFA (sys : EpistemicSystemFA (Fin 3)) : EpistemicSystemFA (Fin 4) where
     · by_cases ha : Fin.last 3 ∈ A
       · exact Or.inr ⟨iff_of_true hb ha, sys.mono _ _ fun i hi => hAB hi⟩
       · exact Or.inl ⟨hb, ha⟩
-    · exact Or.inr ⟨iff_of_false hb (fun h => hb (hAB h)),
-        sys.mono _ _ fun i hi => hAB hi⟩
+    · exact Or.inr ⟨iff_of_false hb fun h => hb (hAB h), sys.mono _ _ fun i hi => hAB hi⟩
   bottom := Or.inl ⟨trivial, fun h => h⟩
   nonTrivial := by
     rintro (⟨h3, -⟩ | ⟨hiff, -⟩)
@@ -765,16 +698,13 @@ private lemma extendFA_no_null (sys : EpistemicSystemFA (Fin 3))
     · exact h3
     · refine hnull i ?_
       have he : restrict3 {Fin.castSucc i} = {i} := by
-        ext k
-        simp [restrict3, Fin.castSucc_inj, eq_comm]
+        ext k; simp [restrict3, Fin.castSucc_inj, eq_comm]
       rwa [show restrict3 ∅ = ∅ from rfl, he] at hge
 
 /-- The new world never lies in an embedded finset. -/
 private lemma last_notMem_map (s : Finset (Fin 3)) :
     Fin.last 3 ∉ s.map Fin.castSuccEmb := by
-  rw [Finset.mem_map]
-  rintro ⟨i, -, hi⟩
-  exact absurd hi (Fin.castSucc_lt_last i).ne
+  rw [Finset.mem_map]; rintro ⟨i, -, hi⟩; exact absurd hi (Fin.castSucc_lt_last i).ne
 
 /-- Embedded finsets restrict back to themselves. -/
 private lemma restrict3_coe_map (s : Finset (Fin 3)) :
@@ -788,9 +718,7 @@ private def embedComparison (wc : WComparison 3) : WComparison 4 where
   left := wc.left.map Fin.castSuccEmb
   right := wc.right.map Fin.castSuccEmb
   weight := wc.weight
-  disjoint := by
-    rw [Finset.disjoint_map]
-    exact wc.disjoint
+  disjoint := by rw [Finset.disjoint_map]; exact wc.disjoint
   weight_pos := wc.weight_pos
 
 private lemma comparisonVec_map_last (A B : Finset (Fin 3)) :
@@ -804,8 +732,7 @@ private lemma comparisonVec_map_castSucc (A B : Finset (Fin 3)) (i : Fin 3) :
   show ((if Fin.castSuccEmb i ∈ A.map Fin.castSuccEmb then 1 else 0) -
       (if Fin.castSuccEmb i ∈ B.map Fin.castSuccEmb then 1 else 0) : ℤ) =
     comparisonVec 3 A B i
-  simp only [Finset.mem_map']
-  rfl
+  simp only [Finset.mem_map']; rfl
 
 /-- Cancellation transfers back along the lexicographic extension. -/
 private theorem cancellation_extendFA (sys : EpistemicSystemFA (Fin 3))
@@ -818,12 +745,9 @@ private theorem cancellation_extendFA (sys : EpistemicSystemFA (Fin 3))
     have hL : (embedComparison wc).left = wc.left.map Fin.castSuccEmb := rfl
     have hR : (embedComparison wc).right = wc.right.map Fin.castSuccEmb := rfl
     refine Or.inr ⟨iff_of_false ?_ ?_, ?_⟩
-    · rw [hL]
-      exact fun h3 => last_notMem_map _ (Finset.mem_coe.mp h3)
-    · rw [hR]
-      exact fun h3 => last_notMem_map _ (Finset.mem_coe.mp h3)
-    · rw [hL, hR, restrict3_coe_map, restrict3_coe_map]
-      exact hvalid wc hwcP
+    · rw [hL]; exact fun h3 => last_notMem_map _ (Finset.mem_coe.mp h3)
+    · rw [hR]; exact fun h3 => last_notMem_map _ (Finset.mem_coe.mp h3)
+    · rw [hL, hR, restrict3_coe_map, restrict3_coe_map]; exact hvalid wc hwcP
   · -- neutrality: the new coordinate vanishes; the old ones are unchanged
     refine Fin.lastCases ?_ ?_
     · simp only [Portfolio.weightedSum, List.map_map]
@@ -841,8 +765,7 @@ private theorem cancellation_extendFA (sys : EpistemicSystemFA (Fin 3))
       have he : Portfolio.weightedSum (P.map embedComparison) i.castSucc =
           P.weightedSum i := by
         simp only [Portfolio.weightedSum, List.map_map]
-        congr 1
-        refine List.map_congr_left fun wc _ => ?_
+        refine congrArg _ (List.map_congr_left fun wc _ => ?_)
         show (embedComparison wc).weight *
             ((comparisonVec 4 (embedComparison wc).left (embedComparison wc).right
               i.castSucc : ℤ) : ℚ) =
@@ -851,16 +774,14 @@ private theorem cancellation_extendFA (sys : EpistemicSystemFA (Fin 3))
           show (embedComparison wc).right = wc.right.map Fin.castSuccEmb from rfl,
           comparisonVec_map_castSucc,
           show (embedComparison wc).weight = wc.weight from rfl]
-      rw [he]
-      exact hneutral i
+      rw [he]; exact hneutral i
   · -- strictness transfers
     obtain ⟨wc, hwcP, hstr⟩ := hstrict
     refine ⟨embedComparison wc, List.mem_map.mpr ⟨wc, hwcP, rfl⟩, fun hge => hstr ?_⟩
     have hL : (embedComparison wc).left = wc.left.map Fin.castSuccEmb := rfl
     have hR : (embedComparison wc).right = wc.right.map Fin.castSuccEmb := rfl
     rcases hge with ⟨h3, -⟩ | ⟨-, hge⟩
-    · rw [hR] at h3
-      exact absurd (Finset.mem_coe.mp h3) (last_notMem_map _)
+    · rw [hR] at h3; exact absurd (Finset.mem_coe.mp h3) (last_notMem_map _)
     · rwa [hL, hR, restrict3_coe_map, restrict3_coe_map] at hge
 
 /-- **Cancellation for Fin 3**, structurally: a null atom reduces to `Fin 2`

--- a/Linglib/Core/Scales/EpistemicScale/CancellationFin4.lean
+++ b/Linglib/Core/Scales/EpistemicScale/CancellationFin4.lean
@@ -134,14 +134,8 @@ private lemma cmpVec_mergeCmp {n : ℕ} (c d : Finset (Fin n) × Finset (Fin n))
     cmpVec (mergeCmp c d) i = cmpVec c i + cmpVec d i := by
   have h1 : i ∈ c.1 → i ∉ d.1 := fun h => Finset.disjoint_left.mp hpos h
   have h2 : i ∈ c.2 → i ∉ d.2 := fun h => Finset.disjoint_left.mp hneg h
-  by_cases hc1 : i ∈ c.1 <;> by_cases hc2 : i ∈ c.2 <;>
-    by_cases hd1 : i ∈ d.1 <;> by_cases hd2 : i ∈ d.2 <;>
-    first
-      | exact absurd hd1 (h1 hc1)
-      | exact absurd hd2 (h2 hc2)
-      | (simp only [cmpVec, mergeCmp, Finset.mem_sdiff, Finset.mem_union, hc1, hc2, hd1, hd2,
-          or_true, or_false, and_true, and_false, not_true, not_false_iff, if_true,
-          if_false] <;> omega)
+  simp only [cmpVec, mergeCmp, Finset.mem_sdiff, Finset.mem_union]
+  split_ifs <;> simp_all
 
 /-- `mergeCmp` of two valid comparisons is valid, given the disjointness conditions.
     Uses `ge_generalized_merge` then Axiom A to reach disjoint normal form. -/
@@ -219,8 +213,7 @@ private lemma null_from_pair (sys : EpistemicSystemFA (Fin 4))
   -- strict coordinate i₀ ∈ (B \ C) ∪ (D \ A)
   have hmem : i₀ ∈ B \ C ∨ i₀ ∈ D \ A := by
     simp only [cmpVec, Finset.mem_sdiff] at hlt ⊢
-    by_cases hiA : i₀ ∈ A <;> by_cases hiB : i₀ ∈ B <;>
-      by_cases hiC : i₀ ∈ C <;> by_cases hiD : i₀ ∈ D <;> simp_all
+    split_ifs at hlt <;> simp_all
   rcases hmem with hm | hm
   · exact ⟨i₀, sys.trans _ _ _ hBC (sys.mono {i₀} ↑(B \ C)
       (by rw [Set.singleton_subset_iff]; exact Finset.mem_coe.mpr hm))⟩
@@ -288,10 +281,9 @@ private lemma cvSumList_filter_ne_empty (L : List (Finset (Fin 4) × Finset (Fin
     pair with the reversed target is mono-domination (excluded), a g-merge pair inside
     `L` is excluded by `hnogm`, leaving a g-merge with the reversed target.
     Verified true for all families (expert proof + exhaustive ≤5-circuit check). -/
-private lemma v1_tailored (sys : EpistemicSystemFA (Fin 4))
+private lemma v1_tailored
     (L : List (Finset (Fin 4) × Finset (Fin 4)))
     (hdisj : ∀ c ∈ L, Disjoint c.1 c.2)
-    (hvalid : ∀ c ∈ L, sys.ge ↑c.1 ↑c.2)
     {vpos vneg : Finset (Fin 4)}
     (hvpvn : Disjoint vpos vneg)
     (hsum : ∀ i, cvSumList L i = cmpVec (vpos, vneg) i)
@@ -447,16 +439,16 @@ private lemma v1_tailored (sys : EpistemicSystemFA (Fin 4))
   · -- the reversed target anti-dominated by `c'` is mono-domination, excluded
     exfalso
     refine hnotdom c' (List.mem_of_mem_filter hc') ?_ ?_
-    · rw [posSupport_toQVec (hdisj' c' (Or.inr hc')),
-        negSupport_toQVec (hdisj' _ (Or.inl rfl))] at had2; exact had2
-    · rw [posSupport_toQVec (hdisj' _ (Or.inl rfl)),
-        negSupport_toQVec (hdisj' c' (Or.inr hc'))] at had1; exact had1
+    · rwa [posSupport_toQVec (hdisj' c' (Or.inr hc')),
+        negSupport_toQVec (hdisj' _ (Or.inl rfl))] at had2
+    · rwa [posSupport_toQVec (hdisj' _ (Or.inl rfl)),
+        negSupport_toQVec (hdisj' c' (Or.inr hc'))] at had1
   · exfalso
     refine hnotdom c (List.mem_of_mem_filter hc) ?_ ?_
-    · rw [posSupport_toQVec (hdisj' c (Or.inr hc)),
-        negSupport_toQVec (hdisj' _ (Or.inl rfl))] at had1; exact had1
-    · rw [posSupport_toQVec (hdisj' _ (Or.inl rfl)),
-        negSupport_toQVec (hdisj' c (Or.inr hc))] at had2; exact had2
+    · rwa [posSupport_toQVec (hdisj' c (Or.inr hc)),
+        negSupport_toQVec (hdisj' _ (Or.inl rfl))] at had1
+    · rwa [posSupport_toQVec (hdisj' _ (Or.inl rfl)),
+        negSupport_toQVec (hdisj' c (Or.inr hc))] at had2
   · -- both from `L`: the null pair
     refine Or.inl ⟨c, List.mem_of_mem_filter hc, c', List.mem_of_mem_filter hc',
       fun i => ?_, ?_⟩
@@ -488,17 +480,11 @@ private lemma recombine (sys : EpistemicSystemFA (Fin 4))
   have dvc2 : ∀ x, x ∈ vpos → x ∉ c.2 := fun x h => Finset.disjoint_left.mp hrc2 h
   have dc : ∀ x, x ∈ c.1 → x ∉ c.2 := fun x h => Finset.disjoint_left.mp hcd h
   have hdp : Disjoint p c.1 := by
-    rw [Finset.disjoint_left]; intro x hxp hxc1
-    rw [hp, Finset.mem_union, Finset.mem_sdiff, Finset.mem_sdiff] at hxp
-    rcases hxp with ⟨_, hn⟩ | ⟨hxc2, _⟩
-    · exact hn hxc1
-    · exact dc x hxc1 hxc2
+    rw [hp, Finset.disjoint_union_left]
+    exact ⟨Finset.sdiff_disjoint, Disjoint.mono_left Finset.sdiff_subset hcd.symm⟩
   have hdq : Disjoint q c.2 := by
-    rw [Finset.disjoint_left]; intro x hxq hxc2
-    rw [hq, Finset.mem_union, Finset.mem_sdiff, Finset.mem_sdiff] at hxq
-    rcases hxq with ⟨_, hn⟩ | ⟨hxc1, _⟩
-    · exact hn hxc2
-    · exact dc x hxc1 hxc2
+    rw [hq, Finset.disjoint_union_left]
+    exact ⟨Finset.sdiff_disjoint, Disjoint.mono_left Finset.sdiff_subset hcd⟩
   have hmerge := mergeCmp_valid sys (c := (p, q)) (d := c) hX hc hdp hdq
   have e1 : (mergeCmp (p, q) c).1 = vpos := by
     apply Finset.ext; intro x
@@ -510,8 +496,7 @@ private lemma recombine (sys : EpistemicSystemFA (Fin 4))
     have h1 := dvv x; have h2 := dvc1 x; have h3 := dvc2 x; have h4 := dc x
     simp only [mergeCmp, hp, hq, Finset.mem_sdiff, Finset.mem_union]
     tauto
-  rw [e1, e2] at hmerge
-  exact hmerge
+  rwa [e1, e2] at hmerge
 
 /-- **Merge-to-single**: on a no-null Fin 4 system, any valid family of disjoint
     comparisons whose vector-sum equals a single comparison vector `(vpos, vneg)`
@@ -539,7 +524,7 @@ private theorem merge_to_single (sys : EpistemicSystemFA (Fin 4))
       push_neg at hdom
       by_cases hgm : ∃ c d rest, L.Perm (c :: d :: rest) ∧ Disjoint c.1 d.1 ∧ Disjoint c.2 d.2
       case neg =>
-        rcases v1_tailored sys L hdisj hvalid hvpvn hsum hne hdom hgm with
+        rcases v1_tailored L hdisj hvpvn hsum hne hdom hgm with
           ⟨c, hcL, d, hdL, hle, i0, hlt⟩ | ⟨c, hcL, hrc1, hrc2⟩
         · -- null pair → null atom → contradicts hnull
           obtain ⟨i, hi⟩ := null_from_pair sys (hvalid c hcL) (hvalid d hdL)
@@ -562,7 +547,7 @@ private theorem merge_to_single (sys : EpistemicSystemFA (Fin 4))
             simp only [cmpVec, Finset.mem_union, Finset.mem_sdiff]
             by_cases h1v : i ∈ vpos <;> by_cases h2v : i ∈ vneg <;>
               by_cases h3v : i ∈ c.1 <;> by_cases h4v : i ∈ c.2 <;>
-              simp_all <;> omega
+              simp_all
           have hpq : Disjoint ((vpos \ c.1) ∪ (c.2 \ vneg)) ((vneg \ c.2) ∪ (c.1 \ vpos)) := by
             rw [Finset.disjoint_left]; intro x hxp hxq
             have a1 : x ∈ vpos → x ∉ vneg := fun h => Finset.disjoint_left.mp hvpvn h
@@ -688,10 +673,7 @@ private theorem exists_balanced_list (sys : EpistemicSystemFA (Fin 4))
     have hdk : D / wc.weight.den = k := by
       rw [hk]; exact Nat.mul_div_cancel_left k wc.weight.den_pos
     have hnumpos : 0 < wc.weight.num := Rat.num_pos.mpr wc.weight_pos
-    have hkpos : 0 < k := by
-      rcases Nat.eq_zero_or_pos k with h0 | h
-      · rw [h0, Nat.mul_zero] at hk; omega
-      · exact h
+    have hkpos : 0 < k := Nat.pos_of_ne_zero (by rintro rfl; rw [Nat.mul_zero] at hk; omega)
     have hmz : 0 ≤ wc.weight.num * (D / wc.weight.den : ℕ) := by
       rw [hdk]; positivity
     rw [hmult]
@@ -707,10 +689,7 @@ private theorem exists_balanced_list (sys : EpistemicSystemFA (Fin 4))
     have hdk : D / wc.weight.den = k := by
       rw [hk]; exact Nat.mul_div_cancel_left k wc.weight.den_pos
     have hnumpos : 0 < wc.weight.num := Rat.num_pos.mpr wc.weight_pos
-    have hkpos : 0 < k := by
-      rcases Nat.eq_zero_or_pos k with h0 | h
-      · rw [h0, Nat.mul_zero] at hk; omega
-      · exact h
+    have hkpos : 0 < k := Nat.pos_of_ne_zero (by rintro rfl; rw [Nat.mul_zero] at hk; omega)
     rw [hmult]
     simp only
     rw [hdk]
@@ -836,14 +815,13 @@ def extendFA (sys : EpistemicSystemFA (Fin 3)) : EpistemicSystemFA (Fin 4) where
     · -- the new world sits in `A \ B`: both sides true by dominance
       exact iff_of_true (Or.inl ⟨ha, hb⟩) (Or.inl ⟨⟨ha, hb⟩, fun h => hb h.1⟩)
     · -- the new world sits in `B \ A`: both sides false
-      have hab : Fin.last 3 ∉ A \ B := fun h => ha h.1
-      constructor
+      refine iff_of_false ?_ ?_
       · rintro (⟨h3, -⟩ | ⟨hiff, -⟩)
-        · exact absurd h3 ha
-        · exact absurd (hiff.mpr hb) ha
+        · exact ha h3
+        · exact ha (hiff.mpr hb)
       · rintro (⟨h3, -⟩ | ⟨hiff, -⟩)
-        · exact absurd h3 hab
-        · exact absurd (hiff.mpr ⟨hb, ha⟩) hab
+        · exact ha h3.1
+        · exact ha (hiff.mpr ⟨hb, ha⟩).1
     · -- the new world is absent everywhere; restriction additivity again
       have hab : Fin.last 3 ∉ A \ B := fun h => ha h.1
       have hba : Fin.last 3 ∉ B \ A := fun h => hb h.1

--- a/Linglib/Core/Scales/EpistemicScale/Completeness.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Completeness.lean
@@ -63,45 +63,33 @@ private theorem belowCount_univ {W : Type*} [Fintype W]
     (sys : EpistemicSystemFA W) :
     belowCount sys Set.univ = Fintype.card (Finset W) := by
   unfold belowCount
-  rw [Finset.filter_true_of_mem]
-  · exact Finset.card_univ
-  · intro S _; exact sys.mono _ _ (Set.subset_univ _)
+  rw [Finset.filter_true_of_mem fun S _ => sys.mono _ _ (Set.subset_univ _)]
+  exact Finset.card_univ
 
 private theorem belowCount_mono {W : Type*} [Fintype W]
     (sys : EpistemicSystemFA W) (A B : Set W)
     (h : sys.ge A B) : belowCount sys A ≥ belowCount sys B := by
-  unfold belowCount
-  apply Finset.card_le_card
-  intro S hS
+  refine Finset.card_le_card fun S hS => ?_
   rw [Finset.mem_filter] at hS ⊢
   exact ⟨hS.1, sys.trans _ _ _ h hS.2⟩
 
 private theorem belowCount_strict {W : Type*} [Fintype W]
     (sys : EpistemicSystemFA W) (A B : Set W)
     (h : ¬sys.ge A B) : belowCount sys A < belowCount sys B := by
-  unfold belowCount
-  apply Finset.card_lt_card
-  refine ⟨?_, ?_⟩
-  · intro S hS
-    rw [Finset.mem_filter] at hS ⊢
-    have hBA := (sys.total A B).resolve_left h
-    exact ⟨hS.1, sys.trans _ _ _ hBA hS.2⟩
-  · intro hsub
-    have : B.toFinset ∈ Finset.univ.filter (fun S : Finset W => sys.ge A ↑S) :=
+  refine Finset.card_lt_card ⟨fun S hS => ?_, fun hsub => ?_⟩
+  · rw [Finset.mem_filter] at hS ⊢
+    exact ⟨hS.1, sys.trans _ _ _ ((sys.total A B).resolve_left h) hS.2⟩
+  · have : B.toFinset ∈ Finset.univ.filter (fun S : Finset W => sys.ge A ↑S) :=
       hsub (Finset.mem_filter.mpr ⟨Finset.mem_univ _, by rw [Set.coe_toFinset]; exact sys.refl B⟩)
-    rw [Finset.mem_filter] at this
-    rw [Set.coe_toFinset] at this
+    rw [Finset.mem_filter, Set.coe_toFinset] at this
     exact h this.2
 
 private theorem belowCount_iff {W : Type*} [Fintype W]
     (sys : EpistemicSystemFA W) (A B : Set W) :
     belowCount sys A ≥ belowCount sys B ↔ sys.ge A B := by
-  constructor
-  · intro hcount
-    by_contra hng
-    have := belowCount_strict sys A B hng
-    omega
-  · exact belowCount_mono sys A B
+  refine ⟨fun hcount => by_contra fun hng => ?_, belowCount_mono sys A B⟩
+  have := belowCount_strict sys A B hng
+  omega
 
 private theorem ge_div_iff {a b d : ℚ} (hd : 0 < d) :
     a / d ≥ b / d ↔ a ≥ b := by
@@ -119,29 +107,22 @@ theorem exists_qualAddMeasure_repr {W : Type*} [Fintype W]
   have hd : (0 : ℚ) < N - E := by
     have := belowCount_strict sys ∅ Set.univ sys.nonTrivial
     rw [belowCount_univ] at this
-    rw [hN, hE]
-    exact sub_pos.mpr (by exact_mod_cast this)
+    exact sub_pos.mpr (by rw [hN, hE]; exact_mod_cast this)
   -- the affine map t ↦ (t − E)/(N − E) is an order isomorphism
   have key : ∀ A B : Set W,
       ((belowCount sys A : ℚ) - E) / (N - E) ≥ ((belowCount sys B : ℚ) - E) / (N - E) ↔
-      sys.ge A B := by
-    intro A B
-    rw [ge_div_iff hd, ge_iff_le, sub_le_sub_iff_right, Nat.cast_le]
-    exact belowCount_iff sys A B
+      sys.ge A B := fun A B => by
+    rw [ge_div_iff hd, ge_iff_le, sub_le_sub_iff_right, Nat.cast_le]; exact belowCount_iff sys A B
   have hAle : ∀ A : Set W, E ≤ (belowCount sys A : ℚ) := fun A => by
-    rw [hE, Nat.cast_le]
-    exact belowCount_mono sys A ∅ (sys.mono ∅ A (Set.empty_subset A))
+    rw [hE, Nat.cast_le]; exact belowCount_mono sys A ∅ (sys.mono ∅ A (Set.empty_subset A))
   refine ⟨⟨fun A => ((belowCount sys A : ℚ) - E) / (N - E),
     fun A => div_nonneg (sub_nonneg.mpr (hAle A)) hd.le,
-    by simp only [← hE, sub_self, zero_div],
-    ?_, ?_⟩, fun A B => (key A B).symm⟩
+    by simp only [← hE, sub_self, zero_div], ?_, ?_⟩, fun A B => (key A B).symm⟩
   · show ((belowCount sys Set.univ : ℚ) - E) / (N - E) = 1
-    rw [belowCount_univ, ← hN]
-    exact div_self hd.ne'
+    rw [belowCount_univ, ← hN]; exact div_self hd.ne'
   · intro A B
     show _ ≥ _ ↔ _ ≥ _
-    rw [key A B, key (A \ B) (B \ A)]
-    exact sys.additive A B
+    rw [key A B, key (A \ B) (B \ A)]; exact sys.additive A B
 
 /-- Helper: if ge A {b} for every b ∈ B, then ge A B, given monotonicity (T)
     and right-union (J). Proved by Finset induction on B.toFinset. -/
@@ -212,12 +193,9 @@ theorem exists_dominationLift_repr {W : Type*} [Fintype W]
 private theorem union_diff_union_disjoint {W : Type*} (A B C : Set W)
     (hAC : ∀ x, x ∈ A → x ∉ C) : (A ∪ C) \ (B ∪ C) = A \ B := by
   ext x; simp only [Set.mem_diff, Set.mem_union]
-  constructor
-  · rintro ⟨hx | hx, hnx⟩
-    · exact ⟨hx, fun hb => hnx (Or.inl hb)⟩
-    · exact absurd (Or.inr hx) hnx
-  · rintro ⟨hxA, hxnB⟩
-    exact ⟨Or.inl hxA, fun h => h.elim hxnB (hAC x hxA)⟩
+  refine ⟨fun h => h.1.elim (fun hx => ⟨hx, fun hb => h.2 (Or.inl hb)⟩)
+    (fun hx => absurd (Or.inr hx) h.2), fun ⟨hxA, hxnB⟩ =>
+    ⟨Or.inl hxA, fun h => h.elim hxnB (hAC x hxA)⟩⟩
 
 /-- **Algebraic bridge**: Axiom A and the finite additivity property
     of `AdditiveScale` are equivalent for any comparison on sets. -/
@@ -227,20 +205,13 @@ theorem axiomA_iff_fa {W : Type*} (ge : Set W → Set W → Prop) :
       (ge A B ↔ ge (A ∪ C) (B ∪ C))) := by
   constructor
   · intro hA A B C hAC hBC
-    have h1 := hA A B
     have h2 := hA (A ∪ C) (B ∪ C)
     rw [union_diff_union_disjoint A B C hAC, union_diff_union_disjoint B A C hBC] at h2
-    exact h1.trans h2.symm
+    exact (hA A B).trans h2.symm
   · intro hFA A B
-    have hdA : ∀ x, x ∈ A \ B → x ∉ A ∩ B :=
-      fun x ⟨_, hxnB⟩ ⟨_, hxB⟩ => hxnB hxB
-    have hdB : ∀ x, x ∈ B \ A → x ∉ A ∩ B :=
-      fun x ⟨_, hxnA⟩ ⟨hxA, _⟩ => hxnA hxA
-    have hA_eq : (A \ B) ∪ (A ∩ B) = A := Set.diff_union_inter A B
-    have hB_eq : (B \ A) ∪ (A ∩ B) = B := by
-      rw [Set.inter_comm]; exact Set.diff_union_inter B A
-    have h := hFA (A \ B) (B \ A) (A ∩ B) hdA hdB
-    rw [hA_eq, hB_eq] at h
+    have h := hFA (A \ B) (B \ A) (A ∩ B)
+      (fun x ⟨_, hxnB⟩ ⟨_, hxB⟩ => hxnB hxB) (fun x ⟨_, hxnA⟩ ⟨hxA, _⟩ => hxnA hxA)
+    rw [Set.diff_union_inter A B, Set.inter_comm A B, Set.diff_union_inter B A] at h
     exact h.symm
 
 end Core.Scale

--- a/Linglib/Core/Scales/EpistemicScale/Completeness.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Completeness.lean
@@ -6,12 +6,14 @@ import Mathlib.Tactic.IntervalCases
 
 The top-level results of [holliday-icard-2013] / [kraft-pratt-seidenberg-1959]:
 
-* `Core.Scale.theorem8a` — for `|W| < 5`, every FA model is representable by a
-  finitely additive probability measure (FA = FP∞ below five worlds).
-* `Core.Scale.theorem8b` — at `|W| = 5`, FA is strictly weaker than FP∞
-  (the KPS counterexample).
-* `Core.Scale.theorem6_completeness`, `theorem2_completeness` — qualitative
-  completeness results ([van-der-hoek-1996]; [halpern-2003] Thm. 7.5.1a).
+* `Core.Scale.representable_of_card_lt_five` — for `|W| < 5`, every FA model is
+  representable by a finitely additive probability measure (FA = FP∞ below
+  five worlds).
+* `Core.Scale.exists_nonrepresentable_of_five_le_card` — for `|W| ≥ 5`, FA is
+  strictly weaker than FP∞ (the KPS counterexample, padded with null atoms).
+* `Core.Scale.exists_qualAddMeasure_repr`, `exists_dominationLift_repr` —
+  qualitative completeness results ([van-der-hoek-1996]; [halpern-2003]
+  Thm. 7.5.1a).
 * `Core.Scale.axiomA_iff_fa` — Axiom A is equivalent to disjoint-union
   invariance (finite additivity).
 -/
@@ -21,44 +23,32 @@ namespace Core.Scale
 
 -- ── Theorem 8 (Kraft, [kraft-pratt-seidenberg-1959]) ───
 
-set_option maxHeartbeats 1600000 in
-/-- **Theorem 8a**: for |W| < 5,
-    every FA model is representable by a finitely additive probability
-    measure. Below 5 worlds, the logics FA and FP∞ coincide.
-
-    The proof transfers an arbitrary `Fintype W` to `Fin n` via
-    `Fintype.equivFin`, applies the per-cardinality proof for n ∈ {0,1,2,3,4},
-    and transports the resulting measure back. -/
-theorem theorem8a {W : Type*} [Fintype W]
+/-- **Theorem 8a** ([kraft-pratt-seidenberg-1959]; [holliday-icard-2013]
+    Theorem 8): below five worlds every FA system is representable —
+    FA and FP∞ coincide. -/
+theorem representable_of_card_lt_five {W : Type*} [Fintype W]
     (sys : EpistemicSystemFA W) (hcard : Fintype.card W < 5) :
-    ∃ (m : FinAddMeasure W), ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
+    Representable sys := by
   haveI : DecidableEq W := Classical.typeDecidableEq W
   let e := Fintype.equivFin W
-  -- Each `n ∈ {1,2,3,4}` case transports the per-cardinality measure back via `e`.
-  have transfer : ∀ {n} (e : W ≃ Fin n),
-      (∃ m' : FinAddMeasure (Fin n), ∀ A B, (transportFA e sys).ge A B ↔ m'.inducedGe A B) →
-      ∃ m : FinAddMeasure W, ∀ A B, sys.ge A B ↔ m.inducedGe A B :=
-    fun e ⟨m', hm'⟩ => ⟨transportMeasure e m', transfer_repr e sys m' hm'⟩
   set n := Fintype.card W with hn_def
   interval_cases n
-  · -- n = 0: impossible
-    exfalso
-    have : (∅ : Set (Fin 0)) = Set.univ := by ext x; exact Fin.elim0 x
-    exact (transportFA e sys).nonTrivial (this ▸ (transportFA e sys).refl ∅)
-  · exact transfer e (theorem8a_fin1 (transportFA e sys))
-  · exact transfer e (theorem8a_fin2 (transportFA e sys))
-  · exact transfer e (theorem8a_fin3 (transportFA e sys))
-  · exact transfer e (theorem8a_fin4 (transportFA e sys))
+  · exact (no_fa_empty (transportFA e sys)).elim
+  · exact perm_repr e sys (representable_fin1 (transportFA e sys))
+  · exact perm_repr e sys (representable_fin2 (transportFA e sys))
+  · exact perm_repr e sys (representable_fin3 (transportFA e sys))
+  · exact perm_repr e sys (representable_fin4 (transportFA e sys))
 
-/-- **Theorem 8b**: for |W| ≥ 5,
-    FA is strictly weaker than FP∞ — there exists a 5-element type
-    with an FA ordering admitting no finitely additive measure
-    representation. -/
-theorem theorem8b :
-    ∃ (W : Type) (_ : Fintype W) (sys : EpistemicSystemFA W),
-      Fintype.card W = 5 ∧
-      ¬∃ (m : FinAddMeasure W), ∀ A B, sys.ge A B ↔ m.inducedGe A B :=
-  ⟨Fin 5, inferInstance, kpsSystemFA, Fintype.card_fin 5, kps_not_representable⟩
+/-- **Theorem 8b** ([kraft-pratt-seidenberg-1959] Theorem 8): at every
+    cardinality ≥ 5 some FA system is non-representable, so FA is strictly
+    weaker than FP∞. -/
+theorem exists_nonrepresentable_of_five_le_card {W : Type*} [Fintype W]
+    (hcard : 5 ≤ Fintype.card W) :
+    ∃ sys : EpistemicSystemFA W, ¬Representable sys := by
+  haveI : DecidableEq W := Classical.typeDecidableEq W
+  obtain ⟨sysF, hsysF⟩ := exists_nonrepresentable_fin hcard
+  exact ⟨transportFA (Fintype.equivFin W).symm sysF,
+    fun h => hsysF (perm_repr (Fintype.equivFin W).symm sysF h)⟩
 
 -- ── Completeness (Theorems 2 and 6) ─────────────
 
@@ -118,42 +108,40 @@ private theorem ge_div_iff {a b d : ℚ} (hd : 0 < d) :
   rw [ge_iff_le, ge_iff_le, div_le_div_iff_of_pos_right hd]
 
 /-- **Theorem 6 completeness** ([holliday-icard-2013], Theorem 6; [van-der-hoek-1996]):
-    every EpistemicSystemFA is representable by a **qualitatively additive** measure.
-
-    Construction: define μ(A) = |{S : Finset W | ge A S}| / 2^|W|.
-    Totality + transitivity of ge ensure μ A ≥ μ B ↔ ge A B;
-    qualitative additivity then follows from Axiom A. -/
-theorem theorem6_completeness {W : Type*} [Fintype W]
+    every FA system is representable by a qualitatively additive measure —
+    the dominated-set count, affinely renormalised so μ(∅) = 0 and μ(Ω) = 1. -/
+theorem exists_qualAddMeasure_repr {W : Type*} [Fintype W]
     (sys : EpistemicSystemFA W) :
     ∃ (m : QualAddMeasure W), ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
   classical
-  let N : ℚ := Fintype.card (Finset W)
-  have hN_pos : (0 : ℚ) < N := Nat.cast_pos.mpr Fintype.card_pos
-  let mu : Set W → ℚ := fun A => (belowCount sys A : ℚ) / N
-  refine ⟨⟨mu, ?nonneg, ?total, ?qualAdd⟩, ?repr⟩
-  case nonneg =>
-    intro A; exact div_nonneg (Nat.cast_nonneg _) (le_of_lt hN_pos)
-  case total =>
-    show (belowCount sys Set.univ : ℚ) / N = 1
-    rw [belowCount_univ]; exact div_self (ne_of_gt hN_pos)
-  case qualAdd =>
+  set E : ℚ := (belowCount sys ∅ : ℚ) with hE
+  set N : ℚ := (Fintype.card (Finset W) : ℚ) with hN
+  have hd : (0 : ℚ) < N - E := by
+    have := belowCount_strict sys ∅ Set.univ sys.nonTrivial
+    rw [belowCount_univ] at this
+    rw [hN, hE]
+    exact sub_pos.mpr (by exact_mod_cast this)
+  -- the affine map t ↦ (t − E)/(N − E) is an order isomorphism
+  have key : ∀ A B : Set W,
+      ((belowCount sys A : ℚ) - E) / (N - E) ≥ ((belowCount sys B : ℚ) - E) / (N - E) ↔
+      sys.ge A B := by
     intro A B
-    show (belowCount sys A : ℚ) / N ≥ (belowCount sys B : ℚ) / N ↔
-         (belowCount sys (A \ B) : ℚ) / N ≥ (belowCount sys (B \ A) : ℚ) / N
-    rw [ge_div_iff hN_pos, ge_div_iff hN_pos]
-    constructor
-    · intro h
-      have hge := (belowCount_iff sys A B).mp (by exact_mod_cast h)
-      exact_mod_cast (belowCount_iff sys (A \ B) (B \ A)).mpr (sys.additive A B |>.mp hge)
-    · intro h
-      have hge := (belowCount_iff sys (A \ B) (B \ A)).mp (by exact_mod_cast h)
-      exact_mod_cast (belowCount_iff sys A B).mpr (sys.additive A B |>.mpr hge)
-  case repr =>
-    intro A B
-    show sys.ge A B ↔ (belowCount sys A : ℚ) / N ≥ (belowCount sys B : ℚ) / N
-    rw [ge_div_iff hN_pos]
-    exact ⟨fun h => by exact_mod_cast (belowCount_iff sys A B).mpr h,
-           fun h => (belowCount_iff sys A B).mp (by exact_mod_cast h)⟩
+    rw [ge_div_iff hd, ge_iff_le, sub_le_sub_iff_right, Nat.cast_le]
+    exact belowCount_iff sys A B
+  have hAle : ∀ A : Set W, E ≤ (belowCount sys A : ℚ) := fun A => by
+    rw [hE, Nat.cast_le]
+    exact belowCount_mono sys A ∅ (sys.mono ∅ A (Set.empty_subset A))
+  refine ⟨⟨fun A => ((belowCount sys A : ℚ) - E) / (N - E),
+    fun A => div_nonneg (sub_nonneg.mpr (hAle A)) hd.le,
+    by simp only [← hE, sub_self, zero_div],
+    ?_, ?_⟩, fun A B => (key A B).symm⟩
+  · show ((belowCount sys Set.univ : ℚ) - E) / (N - E) = 1
+    rw [belowCount_univ, ← hN]
+    exact div_self hd.ne'
+  · intro A B
+    show _ ≥ _ ↔ _ ≥ _
+    rw [key A B, key (A \ B) (B \ A)]
+    exact sys.additive A B
 
 /-- Helper: if ge A {b} for every b ∈ B, then ge A B, given monotonicity (T)
     and right-union (J). Proved by Finset induction on B.toFinset. -/
@@ -190,7 +178,7 @@ private lemma ge_of_forall_singleton {W : Type*} [Fintype W]
     on a single model, without formalizing the syntax or proof system.
 
     Construction: `ge_w u v := sys.ge {u} {v}`. -/
-theorem theorem2_completeness {W : Type*} [Fintype W]
+theorem exists_dominationLift_repr {W : Type*} [Fintype W]
     (sys : EpistemicSystemW W)
     (hTran : ∀ A B C : Set W, sys.ge A B → sys.ge B C → sys.ge A C)
     (hJ : EpistemicAxiom.J sys.ge)

--- a/Linglib/Core/Scales/EpistemicScale/Completeness.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Completeness.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Scales.EpistemicScale.Representability
 import Linglib.Core.Scales.EpistemicScale.CancellationFin4
+import Mathlib.Tactic.IntervalCases
 
 /-! # KPS representation and completeness theorems
 
@@ -33,24 +34,21 @@ theorem theorem8a {W : Type*} [Fintype W]
     ∃ (m : FinAddMeasure W), ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
   haveI : DecidableEq W := Classical.typeDecidableEq W
   let e := Fintype.equivFin W
+  -- Each `n ∈ {1,2,3,4}` case transports the per-cardinality measure back via `e`.
+  have transfer : ∀ {n} (e : W ≃ Fin n),
+      (∃ m' : FinAddMeasure (Fin n), ∀ A B, (transportFA e sys).ge A B ↔ m'.inducedGe A B) →
+      ∃ m : FinAddMeasure W, ∀ A B, sys.ge A B ↔ m.inducedGe A B :=
+    fun e ⟨m', hm'⟩ => ⟨transportMeasure e m', transfer_repr e sys m' hm'⟩
   set n := Fintype.card W with hn_def
   interval_cases n
   · -- n = 0: impossible
     exfalso
     have : (∅ : Set (Fin 0)) = Set.univ := by ext x; exact Fin.elim0 x
     exact (transportFA e sys).nonTrivial (this ▸ (transportFA e sys).refl ∅)
-  · -- n = 1
-    obtain ⟨m', hm'⟩ := theorem8a_fin1 (transportFA e sys)
-    exact ⟨transportMeasure e m', transfer_repr e sys m' hm'⟩
-  · -- n = 2
-    obtain ⟨m', hm'⟩ := theorem8a_fin2 (transportFA e sys)
-    exact ⟨transportMeasure e m', transfer_repr e sys m' hm'⟩
-  · -- n = 3
-    obtain ⟨m', hm'⟩ := theorem8a_fin3 (transportFA e sys)
-    exact ⟨transportMeasure e m', transfer_repr e sys m' hm'⟩
-  · -- n = 4
-    obtain ⟨m', hm'⟩ := theorem8a_fin4 (transportFA e sys)
-    exact ⟨transportMeasure e m', transfer_repr e sys m' hm'⟩
+  · exact transfer e (theorem8a_fin1 (transportFA e sys))
+  · exact transfer e (theorem8a_fin2 (transportFA e sys))
+  · exact transfer e (theorem8a_fin3 (transportFA e sys))
+  · exact transfer e (theorem8a_fin4 (transportFA e sys))
 
 /-- **Theorem 8b**: for |W| ≥ 5,
     FA is strictly weaker than FP∞ — there exists a 5-element type
@@ -221,6 +219,18 @@ theorem theorem2_completeness {W : Type*} [Fintype W]
 
 -- ── Bridge: Axiom A ↔ FA ────────────────────────
 
+/-- Adding a set `C` disjoint from `A` to both sides of a difference leaves
+    `A \ B` unchanged: `(A ∪ C) \ (B ∪ C) = A \ B`. -/
+private theorem union_diff_union_disjoint {W : Type*} (A B C : Set W)
+    (hAC : ∀ x, x ∈ A → x ∉ C) : (A ∪ C) \ (B ∪ C) = A \ B := by
+  ext x; simp only [Set.mem_diff, Set.mem_union]
+  constructor
+  · rintro ⟨hx | hx, hnx⟩
+    · exact ⟨hx, fun hb => hnx (Or.inl hb)⟩
+    · exact absurd (Or.inr hx) hnx
+  · rintro ⟨hxA, hxnB⟩
+    exact ⟨Or.inl hxA, fun h => h.elim hxnB (hAC x hxA)⟩
+
 /-- **Algebraic bridge**: Axiom A and the finite additivity property
     of `AdditiveScale` are equivalent for any comparison on sets. -/
 theorem axiomA_iff_fa {W : Type*} (ge : Set W → Set W → Prop) :
@@ -231,23 +241,7 @@ theorem axiomA_iff_fa {W : Type*} (ge : Set W → Set W → Prop) :
   · intro hA A B C hAC hBC
     have h1 := hA A B
     have h2 := hA (A ∪ C) (B ∪ C)
-    have hd1 : (A ∪ C) \ (B ∪ C) = A \ B := by
-      ext x; simp only [Set.mem_diff, Set.mem_union]
-      constructor
-      · rintro ⟨hx | hx, hnx⟩
-        · exact ⟨hx, fun hb => hnx (Or.inl hb)⟩
-        · exact absurd (Or.inr hx) hnx
-      · rintro ⟨hxA, hxnB⟩
-        exact ⟨Or.inl hxA, fun h => h.elim hxnB (hAC x hxA)⟩
-    have hd2 : (B ∪ C) \ (A ∪ C) = B \ A := by
-      ext x; simp only [Set.mem_diff, Set.mem_union]
-      constructor
-      · rintro ⟨hx | hx, hnx⟩
-        · exact ⟨hx, fun ha => hnx (Or.inl ha)⟩
-        · exact absurd (Or.inr hx) hnx
-      · rintro ⟨hxB, hxnA⟩
-        exact ⟨Or.inl hxB, fun h => h.elim hxnA (hBC x hxB)⟩
-    rw [hd1, hd2] at h2
+    rw [union_diff_union_disjoint A B C hAC, union_diff_union_disjoint B A C hBC] at h2
     exact h1.trans h2.symm
   · intro hFA A B
     have hdA : ∀ x, x ∈ A \ B → x ∉ A ∩ B :=

--- a/Linglib/Core/Scales/EpistemicScale/Conditional.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Conditional.lean
@@ -114,32 +114,16 @@ noncomputable def FinAddMeasure.toCondMeasure {W : Type*}
   cond_nonneg := fun A B => div_nonneg (m.nonneg _) (m.nonneg _)
   cond_norm := fun B hne => by
     simp only [Set.inter_self] at hne ⊢
-    have hB : m.mu B ≠ 0 := by
-      intro h; apply hne; rw [h, div_zero]
-    exact div_self hB
+    exact div_self fun h => hne (by rw [h, div_zero])
   cond_additive := fun A₁ A₂ B hdisj => by
-    have hd : ∀ x, x ∈ A₁ ∩ B → x ∉ A₂ ∩ B :=
-      fun x ⟨h1, _⟩ ⟨h2, _⟩ => hdisj x h1 h2
-    rw [Set.union_inter_distrib_right, m.additive _ _ hd, add_div]
+    rw [Set.union_inter_distrib_right,
+      m.additive (A₁ ∩ B) (A₂ ∩ B) (fun x h1 h2 => hdisj x h1.1 h2.1), add_div]
   cond_chain := fun A B C => by
-    -- P(A ∩ B | C) = μ(A ∩ B ∩ C) / μ(C)
-    -- P(A | B ∩ C) · P(B | C) = [μ(A ∩ (B ∩ C)) / μ(B ∩ C)] · [μ(B ∩ C) / μ(C)]
-    -- Since A ∩ (B ∩ C) = A ∩ B ∩ C, this is μ(A∩B∩C)/μ(B∩C) · μ(B∩C)/μ(C)
-    -- = μ(A∩B∩C)/μ(C) when μ(B∩C) ≠ 0, and 0 = 0 otherwise.
-    -- μ(A∩B∩C)/μ(C) = [μ(A∩B∩C)/μ(B∩C)] · [μ(B∩C)/μ(C)]
-    -- Standard ratio algebra: a/c = (a/b)·(b/c), case-splitting on b = 0.
-    -- When b = 0: a ≤ b = 0 (subset monotonicity) so a = 0, both sides = 0.
-    -- When b ≠ 0: cancel b in numerator/denominator.
+    -- Ratio algebra a/c = (a/b)·(b/c): when μ(B∩C)=0 both sides vanish, else cancel.
     rw [Set.inter_assoc]
     by_cases hBC : m.mu (B ∩ C) = 0
-    · have hABC : m.mu (A ∩ (B ∩ C)) = 0 := by
-        have : m.mu (B ∩ C) ≥ m.mu (A ∩ (B ∩ C)) := by
-          have hd : ∀ x, x ∈ A ∩ (B ∩ C) → x ∉ (B ∩ C) \ (A ∩ (B ∩ C)) :=
-            fun x hx ⟨_, hna⟩ => hna hx
-          have := m.additive (A ∩ (B ∩ C)) ((B ∩ C) \ (A ∩ (B ∩ C))) hd
-          rw [Set.union_diff_cancel Set.inter_subset_right] at this
-          linarith [m.nonneg ((B ∩ C) \ (A ∩ (B ∩ C)))]
-        linarith [m.nonneg (A ∩ (B ∩ C))]
+    · have hABC : m.mu (A ∩ (B ∩ C)) = 0 :=
+        le_antisymm (hBC ▸ m.mu_mono Set.inter_subset_right) (m.nonneg _)
       simp [hABC, hBC]
     · rw [div_mul_div_comm, mul_comm (m.mu (A ∩ (B ∩ C))), mul_div_mul_left _ _ hBC]
   cond_univ := fun A => by simp [Set.inter_univ, m.total, div_one]

--- a/Linglib/Core/Scales/EpistemicScale/Conditional.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Conditional.lean
@@ -1,4 +1,6 @@
 import Linglib.Core.Scales.EpistemicScale.Defs
+import Mathlib.Algebra.Order.BigOperators.Group.List
+import Mathlib.Tactic.Ring
 
 /-!
 # Conditional Plausibility and Probabilistic Update
@@ -10,44 +12,21 @@ and imaging under a single algebraic framework (Cond1–Cond4).
 This file formalizes:
 1. **Conditional probability measures** (Popper space axioms P1–P4)
 2. **The ratio construction** (Halpern Thm 3.3.1): FinAddMeasure → CondMeasure
-3. **Jeffrey's rule**: update under uncertain evidence
-4. **Conditioning modes**: classifying the update operations across linglib
+3. **Jeffrey's rule**: update under uncertain evidence, packaged as a
+   finitely additive measure (`jeffreyMeasure`)
 
-## Conditioning Unification
+## Conditioning across linglib
 
-Four conditioning operations in linglib are instances of conditional
-plausibility:
-
-| Module | Operation | Mode |
-|--------|-----------|------|
-| `EpistemicScale/Conditional` | `condMu A B` | Bayesian (ratio) |
-| `BayesianSemantics` | `PMF.condProbSet` | Bayesian (marginalization) |
-| `Dynamic/Core/Update` | `InfoState.update s φ` | Eliminative |
-| `SDS/MeasureTheory` | (placeholder) | Continuous Bayesian |
-
-The eliminative mode is the special case where P(A|B) ∈ {0, 1}:
-each world either survives or is eliminated.
-
+Several conditioning operations elsewhere in linglib are instances of
+conditional plausibility: `PMF.condProbSet` (`BayesianSemantics`) is the same
+ratio construction as `toCondMeasure`; `InfoState.update` (`Dynamic/Core/Update`)
+is the eliminative special case where P(A|B) ∈ {0, 1}; Spohn ranking
+conditionalization ([spohn-1988], `Core/Logic/RankingFunction`) is its
+order-of-magnitude analogue. Bayesian conditioning is the point-partition
+special case of Jeffrey's rule (`bayesian_is_jeffrey`).
 -/
 
 namespace Core.Scale
-
-/-! ### Conditioning modes -/
-
-/-- Classification of conditioning modes used across linglib.
-
-    - **eliminative**: keep only worlds satisfying evidence. The
-      resulting measure is 0/1-valued. (`Dynamic/Core/Update.lean`)
-    - **bayesian**: P(A|B) = P(A ∩ B)/P(B). Standard ratio conditioning.
-      (`BayesianSemantics.lean`, this file)
-    - **jeffrey**: update with uncertain evidence over a partition.
-      Generalizes Bayesian: P'(A) = Σᵢ P(A|Eᵢ) · q(Eᵢ). -/
-inductive ConditioningMode where
-  | eliminative
-  | bayesian
-  | jeffrey
-  | ranking   -- [spohn-1988]: κ_φ(w) = κ(w) - κ(φ) for φ-worlds
-  deriving DecidableEq, Repr
 
 /-! ### Conditional probability measure (Popper space) -/
 
@@ -65,10 +44,12 @@ structure CondMeasure (W : Type*) extends FinAddMeasure W where
   /-- P2: normalization — P(B|B) = 1 for normal B -/
   cond_norm : ∀ B, condMu B B ≠ 0 → condMu B B = 1
   /-- P3: conditional additivity -/
-  cond_additive : ∀ A₁ A₂ B, (∀ x, x ∈ A₁ → x ∉ A₂) →
+  cond_additive : ∀ A₁ A₂ B, Disjoint A₁ A₂ →
     condMu (A₁ ∪ A₂) B = condMu A₁ B + condMu A₂ B
   /-- P4: chain rule — P(A ∩ B | C) = P(A | B ∩ C) · P(B | C) -/
   cond_chain : ∀ A B C, condMu (A ∩ B) C = condMu A (B ∩ C) * condMu B C
+  /-- Conditioning sees only the part inside the evidence: P(A|B) = P(A ∩ B|B) -/
+  cond_inter : ∀ A B, condMu A B = condMu (A ∩ B) B
   /-- Unconditional connection: P(A | Ω) = μ(A) -/
   cond_univ : ∀ A, condMu A Set.univ = mu A
 
@@ -95,6 +76,12 @@ theorem bayes (m : CondMeasure W) (A B : Set W) :
   simp only [Set.inter_univ] at h1 h2
   rw [← h1, ← h2, Set.inter_comm]
 
+/-- For normal `B`, `P(Ω|B) = 1`. -/
+theorem condMu_univ_of_normal (m : CondMeasure W) {B : Set W}
+    (hB : m.condMu B B ≠ 0) : m.condMu Set.univ B = 1 := by
+  rw [m.cond_inter Set.univ B, Set.univ_inter]
+  exact m.cond_norm B hB
+
 end CondMeasure
 
 /-! ### Ratio construction (Halpern Theorem 3.3.1) -/
@@ -117,7 +104,8 @@ noncomputable def FinAddMeasure.toCondMeasure {W : Type*}
     exact div_self fun h => hne (by rw [h, div_zero])
   cond_additive := fun A₁ A₂ B hdisj => by
     rw [Set.union_inter_distrib_right,
-      m.additive (A₁ ∩ B) (A₂ ∩ B) (fun x h1 h2 => hdisj x h1.1 h2.1), add_div]
+      m.additive (A₁ ∩ B) (A₂ ∩ B)
+        (hdisj.mono Set.inter_subset_left Set.inter_subset_left), add_div]
   cond_chain := fun A B C => by
     -- Ratio algebra a/c = (a/b)·(b/c): when μ(B∩C)=0 both sides vanish, else cancel.
     rw [Set.inter_assoc]
@@ -126,12 +114,13 @@ noncomputable def FinAddMeasure.toCondMeasure {W : Type*}
         le_antisymm (hBC ▸ m.mu_mono Set.inter_subset_right) (m.nonneg _)
       simp [hABC, hBC]
     · rw [div_mul_div_comm, mul_comm (m.mu (A ∩ (B ∩ C))), mul_div_mul_left _ _ hBC]
+  cond_inter := fun A B => by rw [Set.inter_assoc, Set.inter_self]
   cond_univ := fun A => by simp [Set.inter_univ, m.total, div_one]
 
 /-! ### Jeffrey's rule -/
 
-/-- An evidence partition: a finite collection of mutually exclusive,
-    exhaustive propositions with new probability assignments. -/
+/-- An evidence partition: pairwise-disjoint cells covering the space, with new
+    probability assignments summing to 1. -/
 structure EvidencePartition (W : Type*) where
   /-- The partition cells -/
   cells : List (Set W)
@@ -139,57 +128,73 @@ structure EvidencePartition (W : Type*) where
   weights : List ℚ
   /-- Cells and weights are aligned -/
   aligned : cells.length = weights.length
+  /-- Cells are pairwise disjoint -/
+  disjointCells : cells.Pairwise Disjoint
+  /-- Cells cover the space -/
+  exhaustive : cells.foldr (· ∪ ·) ∅ = Set.univ
   /-- Weights are non-negative -/
   weights_nonneg : ∀ q ∈ weights, 0 ≤ q
   /-- Weights sum to 1 -/
   weights_sum : weights.sum = 1
 
-/-- Jeffrey's rule: update a conditional measure with uncertain evidence.
-
-    Given a partition {E₁,..., Eₙ} with new probabilities q₁,..., qₙ:
-    P'(A) = Σᵢ P(A | Eᵢ) · qᵢ
-
-    This generalizes Bayesian conditioning: standard conditioning on E
-    is the special case where qₑ = 1 and all other qᵢ = 0.
-
-    [jeffrey-1965], The Logic of Decision; [halpern-2003] §3.4. -/
+/-- Jeffrey's rule ([jeffrey-1965]; [halpern-2003] §3.4): update with uncertain
+    evidence, P'(A) = Σᵢ P(A | Eᵢ) · qᵢ. -/
 def jeffreyUpdate {W : Type*} (m : CondMeasure W)
     (ev : EvidencePartition W) : Set W → ℚ :=
-  fun A =>
-    let pairs := ev.cells.zip ev.weights
-    pairs.foldl (fun acc ⟨E, q⟩ => acc + m.condMu A E * q) 0
-
-/-- Jeffrey's rule preserves non-negativity. -/
-private lemma foldl_condMu_nonneg {W : Type*} (m : CondMeasure W) (A : Set W)
-    (pairs : List (Set W × ℚ)) (acc : ℚ) (hacc : 0 ≤ acc)
-    (hpairs : ∀ p ∈ pairs, 0 ≤ p.2) :
-    0 ≤ pairs.foldl (fun acc ⟨E, q⟩ => acc + m.condMu A E * q) acc := by
-  induction pairs generalizing acc with
-  | nil => simpa using hacc
-  | cons hd t ih =>
-    simp only [List.foldl]
-    apply ih
-    · exact add_nonneg hacc (mul_nonneg (m.cond_nonneg A hd.1)
-        (hpairs hd List.mem_cons_self))
-    · intro p hp; exact hpairs p (List.mem_cons_of_mem _ hp)
+  fun A => ((ev.cells.zip ev.weights).map (fun p => m.condMu A p.1 * p.2)).sum
 
 theorem jeffreyUpdate_nonneg {W : Type*} (m : CondMeasure W)
     (ev : EvidencePartition W) (A : Set W) :
-    0 ≤ jeffreyUpdate m ev A := by
-  unfold jeffreyUpdate
-  apply foldl_condMu_nonneg m A _ 0 (le_refl 0)
-  intro ⟨E, q⟩ hEq
-  exact ev.weights_nonneg q (List.of_mem_zip hEq).2
+    0 ≤ jeffreyUpdate m ev A :=
+  List.sum_nonneg fun x hx => by
+    obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hx
+    exact mul_nonneg (m.cond_nonneg A p.1) (ev.weights_nonneg p.2 (List.of_mem_zip hp).2)
 
-/-- Bayesian conditioning is Jeffrey conditioning with a point partition. -/
-theorem bayesian_is_jeffrey {W : Type*} (m : CondMeasure W) (B : Set W)
-    (_hB : m.condMu B B ≠ 0) (A : Set W) :
+theorem jeffreyUpdate_additive {W : Type*} (m : CondMeasure W)
+    (ev : EvidencePartition W) (A B : Set W) (hAB : Disjoint A B) :
+    jeffreyUpdate m ev (A ∪ B) = jeffreyUpdate m ev A + jeffreyUpdate m ev B := by
+  simp only [jeffreyUpdate]
+  induction ev.cells.zip ev.weights with
+  | nil => simp
+  | cons p l ih =>
+    simp only [List.map_cons, List.sum_cons, ih, m.cond_additive A B p.1 hAB]
+    ring
+
+/-- Jeffrey update is normalized when every cell is normal. -/
+theorem jeffreyUpdate_total {W : Type*} (m : CondMeasure W)
+    (ev : EvidencePartition W) (hnorm : ∀ E ∈ ev.cells, m.condMu E E ≠ 0) :
+    jeffreyUpdate m ev Set.univ = 1 := by
+  simp only [jeffreyUpdate]
+  have hcell : ∀ p ∈ ev.cells.zip ev.weights,
+      m.condMu Set.univ p.1 * p.2 = Prod.snd p := by
+    intro p hp
+    rw [m.condMu_univ_of_normal (hnorm p.1 (List.of_mem_zip hp).1), one_mul]
+  rw [List.map_congr_left hcell, List.map_snd_zip (le_of_eq ev.aligned.symm),
+    ev.weights_sum]
+
+/-- **Jeffrey's rule yields a measure**: for a partition of normal cells, the
+    Jeffrey update is a finitely additive probability measure. -/
+def jeffreyMeasure {W : Type*} (m : CondMeasure W) (ev : EvidencePartition W)
+    (hnorm : ∀ E ∈ ev.cells, m.condMu E E ≠ 0) : FinAddMeasure W where
+  mu := jeffreyUpdate m ev
+  nonneg := jeffreyUpdate_nonneg m ev
+  additive := jeffreyUpdate_additive m ev
+  total := jeffreyUpdate_total m ev hnorm
+
+/-- Bayesian conditioning is Jeffrey conditioning with the partition `{B, Bᶜ}`
+    and weights `1, 0`. -/
+theorem bayesian_is_jeffrey {W : Type*} (m : CondMeasure W) (B A : Set W) :
     m.condMu A B = jeffreyUpdate m
-      { cells := [B], weights := [1],
+      { cells := [B, Bᶜ], weights := [1, 0],
         aligned := rfl,
-        weights_nonneg := fun q hq => by simp [List.mem_singleton.mp hq],
-        weights_sum := by simp } A := by
-  simp [jeffreyUpdate, List.zip, List.foldl, mul_one]
+        disjointCells := List.pairwise_pair.mpr disjoint_compl_right,
+        exhaustive := by
+          rw [List.foldr_cons, List.foldr_cons, List.foldr_nil,
+            Set.union_empty, Set.union_compl_self],
+        weights_nonneg := fun q hq => by
+          rcases List.mem_pair.mp hq with rfl | rfl <;> norm_num,
+        weights_sum := by norm_num } A := by
+  simp [jeffreyUpdate]
 
 /-! ### Conditional plausibility and epistemic comparison -/
 
@@ -200,22 +205,5 @@ theorem condMeasure_reflexive_per_evidence {W : Type*}
     (m : CondMeasure W) (B : Set W) :
     EpistemicAxiom.R (fun A C => m.condGe A C B) :=
   fun _ => le_refl _
-
-/-! ### Conditioning mode relationships -/
-
--- **PMF** (BayesianSemantics.lean + `Linglib.Core.Probability.Finite`):
--- `pmf.probOfSet event` computes P(event) = Σ_θ mass(θ) · 1[event(θ)].
--- Conditioning a `PMF` on evidence B is `pmf.condProbSet B A`, the
--- ratio construction P(A|B) = P(A ∩ B)/P(B); this is the same construction
--- as `(toCondMeasure m).condMu A B`.
---
--- **InfoState.update** (Dynamic/Core/Update.lean): eliminative
--- conditioning — each possibility either survives (P = 1) or is
--- removed (P = 0). Under a uniform distribution, this equals Bayesian
--- conditioning: P(A|φ) = |A ∩ {w | φ w}| / |{w | φ w}|.
---
--- **Jeffrey conditioning**: generalizes Bayesian conditioning.
--- Bayesian conditioning on B is Jeffrey conditioning with the point
--- partition {B} and weight 1 (see `bayesian_is_jeffrey` above).
 
 end Core.Scale

--- a/Linglib/Core/Scales/EpistemicScale/Conditional.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Conditional.lean
@@ -103,9 +103,8 @@ noncomputable def FinAddMeasure.toCondMeasure {W : Type*}
     simp only [Set.inter_self] at hne ⊢
     exact div_self fun h => hne (by rw [h, div_zero])
   cond_additive := fun A₁ A₂ B hdisj => by
-    rw [Set.union_inter_distrib_right,
-      m.additive (A₁ ∩ B) (A₂ ∩ B)
-        (hdisj.mono Set.inter_subset_left Set.inter_subset_left), add_div]
+    rw [Set.union_inter_distrib_right, m.additive (A₁ ∩ B) (A₂ ∩ B)
+      (hdisj.mono Set.inter_subset_left Set.inter_subset_left), add_div]
   cond_chain := fun A B C => by
     -- Ratio algebra a/c = (a/b)·(b/c): when μ(B∩C)=0 both sides vanish, else cancel.
     rw [Set.inter_assoc]
@@ -156,21 +155,16 @@ theorem jeffreyUpdate_additive {W : Type*} (m : CondMeasure W)
   simp only [jeffreyUpdate]
   induction ev.cells.zip ev.weights with
   | nil => simp
-  | cons p l ih =>
-    simp only [List.map_cons, List.sum_cons, ih, m.cond_additive A B p.1 hAB]
-    ring
+  | cons p l ih => simp only [List.map_cons, List.sum_cons, ih, m.cond_additive A B p.1 hAB]; ring
 
 /-- Jeffrey update is normalized when every cell is normal. -/
 theorem jeffreyUpdate_total {W : Type*} (m : CondMeasure W)
     (ev : EvidencePartition W) (hnorm : ∀ E ∈ ev.cells, m.condMu E E ≠ 0) :
     jeffreyUpdate m ev Set.univ = 1 := by
   simp only [jeffreyUpdate]
-  have hcell : ∀ p ∈ ev.cells.zip ev.weights,
-      m.condMu Set.univ p.1 * p.2 = Prod.snd p := by
-    intro p hp
-    rw [m.condMu_univ_of_normal (hnorm p.1 (List.of_mem_zip hp).1), one_mul]
-  rw [List.map_congr_left hcell, List.map_snd_zip (le_of_eq ev.aligned.symm),
-    ev.weights_sum]
+  rw [List.map_congr_left fun p hp => by
+      rw [m.condMu_univ_of_normal (hnorm p.1 (List.of_mem_zip hp).1), one_mul],
+    List.map_snd_zip (le_of_eq ev.aligned.symm), ev.weights_sum]
 
 /-- **Jeffrey's rule yields a measure**: for a partition of normal cells, the
     Jeffrey update is a finitely additive probability measure. -/

--- a/Linglib/Core/Scales/EpistemicScale/Defs.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Defs.lean
@@ -7,12 +7,12 @@ import Mathlib.Tactic.Linarith
 
 [holliday-icard-2013] [halpern-2003] [van-der-hoek-1996]
 
-Epistemic likelihood scales: the `EpistemicScale` arm of the categorical
-diagram in `Core/Scales/Scale.lean`.
+Epistemic likelihood scales: comparative-likelihood orders on propositions
+(`Set W`), their axiom hierarchy, and their measure semantics.
 
 [holliday-icard-2013] study the logic of "at least as likely as" (≿) on
 propositions, defining a hierarchy of axiom systems (W ⊂ F ⊂ FA) whose
-qualitative additivity axiom is the epistemic counterpart of `AdditiveScale.fa`.
+qualitative additivity axiom is the epistemic counterpart of finite additivity.
 
 **Axiom hierarchy** ([holliday-icard-2013], Figure 3; axioms in Figures 4–6):
 
@@ -23,9 +23,10 @@ qualitative additivity axiom is the epistemic counterpart of `AdditiveScale.fa`.
 | FA     | F + Tot, Tran, A       | Qualitatively additive measures    |
 | FP∞    | FA + Scott cancellation | Finitely additive measures         |
 
-**Bridge**: Axiom A (epistemic qualitative additivity) and `AdditiveScale.fa`
-(mereological finite additivity) are algebraically equivalent — both express
-that a comparison factors through disjoint parts.
+**Bridge**: Axiom A (epistemic qualitative additivity) is equivalent to
+disjoint-augmentation invariance — the same law-shape that `AdditiveScale.fa`
+(`Core/Scales/Comparative.lean`) imposes on degree carriers. The equivalence
+is `axiomA_iff_fa` in `Completeness.lean`.
 
 References:
 - Holliday, W. & Icard, T. (2013). Measure Semantics and Qualitative
@@ -185,8 +186,8 @@ structure FinAddMeasure (W : Type*) where
   mu : Set W → ℚ
   /-- Non-negativity -/
   nonneg : ∀ A, 0 ≤ mu A
-  /-- Finite additivity: μ(A ∪ B) = μ(A) + μ(B) when A ∩ B = ∅ -/
-  additive : ∀ A B, (∀ x, x ∈ A → x ∉ B) → mu (A ∪ B) = mu A + mu B
+  /-- Finite additivity: μ(A ∪ B) = μ(A) + μ(B) for disjoint A, B -/
+  additive : ∀ A B, Disjoint A B → mu (A ∪ B) = mu A + mu B
   /-- Normalization -/
   total : mu Set.univ = 1
 
@@ -209,27 +210,27 @@ theorem inducedGe_axiomT (m : FinAddMeasure W) :
     EpistemicAxiom.T m.inducedGe := by
   intro A B hAB
   show m.mu B ≥ m.mu A
-  rw [(Set.union_diff_cancel hAB).symm, m.additive A (B \ A) (fun _ hx ⟨_, hna⟩ => hna hx)]
+  rw [(Set.union_diff_cancel hAB).symm, m.additive A (B \ A) disjoint_sdiff_self_right]
   exact le_add_of_nonneg_right (m.nonneg (B \ A))
 
 /-- μ(∅) = 0 for any finitely additive measure.
     Follows from additivity: μ(∅ ∪ ∅) = μ(∅) + μ(∅), but ∅ ∪ ∅ = ∅. -/
 theorem mu_empty (m : FinAddMeasure W) : m.mu ∅ = 0 := by
-  have hempty := m.additive ∅ ∅ (fun _ hx => hx.elim)
+  have hempty := m.additive ∅ ∅ disjoint_bot_left
   rw [Set.empty_union] at hempty
   linarith
 
 /-- Subset monotonicity: `A ⊆ B → μ(A) ≤ μ(B)`. -/
 theorem mu_mono (m : FinAddMeasure W) {A B : Set W} (h : A ⊆ B) :
     m.mu A ≤ m.mu B := by
-  have hunion := m.additive A (B \ A) (fun _ hx ⟨_, hna⟩ => hna hx)
+  have hunion := m.additive A (B \ A) disjoint_sdiff_self_right
   rw [Set.union_diff_cancel h] at hunion
   linarith [m.nonneg (B \ A)]
 
 /-- Complement measure: `μ(A) + μ(Aᶜ) = 1`. -/
 theorem mu_compl (m : FinAddMeasure W) (A : Set W) :
     m.mu A + m.mu Aᶜ = 1 := by
-  have hunion := m.additive A Aᶜ (fun _ hx hxc => hxc hx)
+  have hunion := m.additive A Aᶜ disjoint_compl_right
   rw [Set.union_compl_self] at hunion
   linarith [m.total]
 
@@ -239,11 +240,11 @@ theorem mu_qadd (m : FinAddMeasure W) (A B : Set W) :
     m.mu A ≥ m.mu B ↔ m.mu (A \ B) ≥ m.mu (B \ A) := by
   have hmuA : m.mu A = m.mu (A \ B) + m.mu (A ∩ B) := by
     conv_lhs => rw [(Set.diff_union_inter A B).symm]
-    exact m.additive _ _ (fun _ ⟨_, hxnb⟩ ⟨_, hxb⟩ => hxnb hxb)
+    exact m.additive _ _ (Set.disjoint_left.mpr fun _ hx hy => hx.2 hy.2)
   have hmuB : m.mu B = m.mu (B \ A) + m.mu (A ∩ B) := by
     conv_lhs => rw [show B = (B \ A) ∪ (A ∩ B) from by
       rw [Set.inter_comm]; exact (Set.diff_union_inter B A).symm]
-    exact m.additive _ _ (fun _ ⟨_, hxna⟩ ⟨hxa, _⟩ => hxna hxa)
+    exact m.additive _ _ (Set.disjoint_left.mpr fun _ hx hy => hx.2 hy.1)
   rw [hmuA, hmuB]
   exact add_le_add_iff_right (m.mu (A ∩ B))
 
@@ -264,21 +265,6 @@ def toSystemFA (m : FinAddMeasure W) : EpistemicSystemFA W where
   trans := fun _ _ _ hab hbc => le_trans hbc hab
   additive := m.mu_qadd
 
-/-- Extract a world prior from a finitely additive measure by
-    evaluating μ on singletons: prior(w) = μ({w}).
-
-    This bridges the epistemic likelihood representation theorem
-    to RSA's `worldPrior` field. The resulting function maps each
-    world to a non-negative rational, suitable for use as an
-    unnormalized prior. -/
-noncomputable def toWorldPrior (m : FinAddMeasure W) : W → ℚ :=
-  fun w => m.mu {w}
-
-/-- Singleton measures are non-negative. -/
-theorem toWorldPrior_nonneg (m : FinAddMeasure W) (w : W) :
-    0 ≤ m.toWorldPrior w :=
-  m.nonneg {w}
-
 end FinAddMeasure
 
 -- ── Qualitatively Additive Measures ──────────────
@@ -289,17 +275,16 @@ end FinAddMeasure
     condition: μ(A) ≥ μ(B) ↔ μ(A \ B) ≥ μ(B \ A).
 
     [holliday-icard-2013] Theorem 6: System FA is sound and complete
-    with respect to qualitatively additive measure models.
-
-    Note: the paper's definition of qualitatively additive measures includes μ(∅) = 0, but we omit it here
-    because the completeness proof (Theorem 6) constructs a measure with
-    μ(∅) > 0 (belowCount counts ∅ itself via reflexivity). The soundness
-    direction (`toSystemFA`) takes `mu_empty` as an explicit hypothesis. -/
+    with respect to qualitatively additive measure models. The completeness
+    construction (`exists_qualAddMeasure_repr`) realises μ(∅) = 0 by an
+    affine renormalisation of the dominated-set count. -/
 structure QualAddMeasure (W : Type*) where
   /-- The measure function -/
   mu : Set W → ℚ
   /-- Non-negativity -/
   nonneg : ∀ A, 0 ≤ mu A
+  /-- The impossible proposition has measure zero -/
+  mu_empty : mu ∅ = 0
   /-- Normalization -/
   total : mu Set.univ = 1
   /-- Qualitative additivity: μ(A) ≥ μ(B) ↔ μ(A \ B) ≥ μ(B \ A) -/
@@ -313,34 +298,28 @@ variable {W : Type*}
 def inducedGe (m : QualAddMeasure W) (A B : Set W) : Prop :=
   m.mu A ≥ m.mu B
 
-/-- Monotonicity for qualitatively additive measures with μ(∅) = 0:
+/-- Monotonicity for qualitatively additive measures:
     A ⊆ B → μ(B) ≥ μ(A). Follows from qualAdd + μ(∅) = 0 + nonneg. -/
-theorem inducedGe_axiomT (m : QualAddMeasure W) (h_empty : m.mu ∅ = 0) :
+theorem inducedGe_axiomT (m : QualAddMeasure W) :
     EpistemicAxiom.T m.inducedGe := by
   intro A B hAB
   show m.mu B ≥ m.mu A
-  rw [m.qualAdd B A, Set.diff_eq_empty.mpr hAB, h_empty]
+  rw [m.qualAdd B A, Set.diff_eq_empty.mpr hAB, m.mu_empty]
   exact m.nonneg (B \ A)
 
-/-- A qualitatively additive measure with μ(∅) = 0 induces System FA.
+/-- A qualitatively additive measure induces System FA.
     Soundness direction of [holliday-icard-2013] Theorem 6:
-    every qualitatively additive measure model (with μ(∅) = 0) satisfies
-    the FA axioms.
-
-    The `h_empty` hypothesis is needed for monotonicity and non-triviality;
-    it is NOT a field on `QualAddMeasure` because the completeness proof
-    constructs a measure where μ(∅) > 0. -/
-def toSystemFA (m : QualAddMeasure W) (h_empty : m.mu ∅ = 0) :
-    EpistemicSystemFA W where
+    every qualitatively additive measure model satisfies the FA axioms. -/
+def toSystemFA (m : QualAddMeasure W) : EpistemicSystemFA W where
   ge := m.inducedGe
   refl := fun _ => le_refl _
-  mono := m.inducedGe_axiomT h_empty
+  mono := m.inducedGe_axiomT
   bottom := by
     show m.mu Set.univ ≥ m.mu ∅
-    rw [h_empty]; exact m.nonneg Set.univ
+    rw [m.mu_empty]; exact m.nonneg Set.univ
   nonTrivial := by
     show ¬(m.mu ∅ ≥ m.mu Set.univ)
-    rw [h_empty, m.total]; exact not_le.mpr one_pos
+    rw [m.mu_empty, m.total]; exact not_le.mpr one_pos
   total := fun A B => le_total (m.mu B) (m.mu A)
   trans := fun _ _ _ hab hbc => le_trans hbc hab
   additive := m.qualAdd
@@ -350,9 +329,10 @@ end QualAddMeasure
 /-- Every finitely additive measure is qualitatively additive.
     Proof: μ(A) = μ(A \ B) + μ(A ∩ B) and μ(B) = μ(B \ A) + μ(A ∩ B),
     so μ(A) ≥ μ(B) ↔ μ(A \ B) ≥ μ(B \ A). -/
-noncomputable def FinAddMeasure.toQualAdd {W : Type*} (m : FinAddMeasure W) : QualAddMeasure W where
+def FinAddMeasure.toQualAdd {W : Type*} (m : FinAddMeasure W) : QualAddMeasure W where
   mu := m.mu
   nonneg := m.nonneg
+  mu_empty := m.mu_empty
   total := m.total
   qualAdd := m.mu_qadd
 

--- a/Linglib/Core/Scales/EpistemicScale/Defs.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Defs.lean
@@ -1,10 +1,6 @@
 import Linglib.Core.Scales.Scale
 import Linglib.Core.Order.ComparativeProbability.Defs
-import Mathlib.Data.Fintype.Powerset
-import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Tactic.Linarith
-import Mathlib.Tactic.FinCases
-import Mathlib.Tactic.IntervalCases
 
 /-!
 # Epistemic Comparative Likelihood
@@ -134,17 +130,13 @@ namespace EpistemicSystemFA
 
 variable {W : Type*} (sys : EpistemicSystemFA W)
 
-instance : ComparativeProbability.IsLikelihoodMono sys.ge where
-  mono A B h := sys.mono A B h
+instance : ComparativeProbability.IsLikelihoodMono sys.ge := ⟨sys.mono⟩
 
-instance : IsTrans (Set W) sys.ge where
-  trans A B C := sys.trans A B C
+instance : IsTrans (Set W) sys.ge := ⟨sys.trans⟩
 
-instance : ComparativeProbability.IsQualitativeAdditive sys.ge where
-  qadd A B := sys.additive A B
+instance : ComparativeProbability.IsQualitativeAdditive sys.ge := ⟨sys.additive⟩
 
-instance : ComparativeProbability.IsNontrivial sys.ge where
-  bot_not_ge_top := sys.nonTrivial
+instance : ComparativeProbability.IsNontrivial sys.ge := ⟨sys.nonTrivial⟩
 
 end EpistemicSystemFA
 
@@ -183,7 +175,7 @@ def EpistemicSystemFA.toGFCPreorder {W : Type*} (sys : EpistemicSystemFA W) :
   refl := sys.refl
   trans := sys.trans
   mono := sys.mono
-  complRev := fun A B hAB => ComparativeProbability.complRev A B hAB
+  complRev := ComparativeProbability.complRev
 
 -- ── Measure Semantics ───────────────────────────
 
@@ -217,35 +209,43 @@ theorem inducedGe_axiomT (m : FinAddMeasure W) :
     EpistemicAxiom.T m.inducedGe := by
   intro A B hAB
   show m.mu B ≥ m.mu A
-  have hdecomp : B = A ∪ (B \ A) := (Set.union_diff_cancel hAB).symm
-  have hdisj : ∀ x, x ∈ A → x ∉ B \ A := fun x hx ⟨_, hna⟩ => hna hx
-  rw [hdecomp, m.additive A (B \ A) hdisj]
+  rw [(Set.union_diff_cancel hAB).symm, m.additive A (B \ A) (fun _ hx ⟨_, hna⟩ => hna hx)]
   exact le_add_of_nonneg_right (m.nonneg (B \ A))
 
 /-- μ(∅) = 0 for any finitely additive measure.
     Follows from additivity: μ(∅ ∪ ∅) = μ(∅) + μ(∅), but ∅ ∪ ∅ = ∅. -/
 theorem mu_empty (m : FinAddMeasure W) : m.mu ∅ = 0 := by
-  have hempty : m.mu (∅ ∪ ∅) = m.mu ∅ + m.mu ∅ :=
-    m.additive ∅ ∅ (fun x hx => hx.elim)
-  simp only [Set.empty_union] at hempty
-  have h : m.mu ∅ + m.mu ∅ = m.mu ∅ + 0 := by rw [add_zero]; exact hempty.symm
-  exact add_left_cancel h
+  have hempty := m.additive ∅ ∅ (fun _ hx => hx.elim)
+  rw [Set.empty_union] at hempty
+  linarith
 
 /-- Subset monotonicity: `A ⊆ B → μ(A) ≤ μ(B)`. -/
 theorem mu_mono (m : FinAddMeasure W) {A B : Set W} (h : A ⊆ B) :
     m.mu A ≤ m.mu B := by
-  have hdisj : ∀ x, x ∈ A → x ∉ B \ A := fun x hx ⟨_, hna⟩ => hna hx
-  have hunion := m.additive A (B \ A) hdisj
+  have hunion := m.additive A (B \ A) (fun _ hx ⟨_, hna⟩ => hna hx)
   rw [Set.union_diff_cancel h] at hunion
   linarith [m.nonneg (B \ A)]
 
 /-- Complement measure: `μ(A) + μ(Aᶜ) = 1`. -/
 theorem mu_compl (m : FinAddMeasure W) (A : Set W) :
     m.mu A + m.mu Aᶜ = 1 := by
-  have hdisj : ∀ x, x ∈ A → x ∉ Aᶜ := fun x hx hxc => hxc hx
-  have hunion := m.additive A Aᶜ hdisj
+  have hunion := m.additive A Aᶜ (fun _ hx hxc => hxc hx)
   rw [Set.union_compl_self] at hunion
   linarith [m.total]
+
+/-- Qualitative additivity for a finitely additive measure: splitting `A` and `B`
+    into the shared part `A ∩ B` and the private parts cancels the shared part. -/
+theorem mu_qadd (m : FinAddMeasure W) (A B : Set W) :
+    m.mu A ≥ m.mu B ↔ m.mu (A \ B) ≥ m.mu (B \ A) := by
+  have hmuA : m.mu A = m.mu (A \ B) + m.mu (A ∩ B) := by
+    conv_lhs => rw [(Set.diff_union_inter A B).symm]
+    exact m.additive _ _ (fun _ ⟨_, hxnb⟩ ⟨_, hxb⟩ => hxnb hxb)
+  have hmuB : m.mu B = m.mu (B \ A) + m.mu (A ∩ B) := by
+    conv_lhs => rw [show B = (B \ A) ∪ (A ∩ B) from by
+      rw [Set.inter_comm]; exact (Set.diff_union_inter B A).symm]
+    exact m.additive _ _ (fun _ ⟨_, hxna⟩ ⟨hxa, _⟩ => hxna hxa)
+  rw [hmuA, hmuB]
+  exact add_le_add_iff_right (m.mu (A ∩ B))
 
 /-- Every finitely additive measure satisfies the FA axioms.
     A fortiori from [holliday-icard-2013] Theorem 6 soundness,
@@ -262,20 +262,7 @@ def toSystemFA (m : FinAddMeasure W) : EpistemicSystemFA W where
     rw [m.mu_empty, m.total]; exact not_le.mpr one_pos
   total := fun A B => le_total (m.mu B) (m.mu A)
   trans := fun _ _ _ hab hbc => le_trans hbc hab
-  additive := by
-    intro A B
-    show m.mu A ≥ m.mu B ↔ m.mu (A \ B) ≥ m.mu (B \ A)
-    have hdA : ∀ x, x ∈ A \ B → x ∉ A ∩ B := fun x ⟨_, hxnb⟩ ⟨_, hxb⟩ => hxnb hxb
-    have hdB : ∀ x, x ∈ B \ A → x ∉ A ∩ B := fun x ⟨_, hxna⟩ ⟨hxa, _⟩ => hxna hxa
-    have hmuA : m.mu A = m.mu (A \ B) + m.mu (A ∩ B) := by
-      conv_lhs => rw [(Set.diff_union_inter A B).symm]
-      exact m.additive _ _ hdA
-    have hmuB : m.mu B = m.mu (B \ A) + m.mu (A ∩ B) := by
-      conv_lhs => rw [show B = (B \ A) ∪ (A ∩ B) from by
-        rw [Set.inter_comm]; exact (Set.diff_union_inter B A).symm]
-      exact m.additive _ _ hdB
-    rw [hmuA, hmuB]
-    exact add_le_add_iff_right (m.mu (A ∩ B))
+  additive := m.mu_qadd
 
 /-- Extract a world prior from a finitely additive measure by
     evaluating μ on singletons: prior(w) = μ({w}).
@@ -332,9 +319,7 @@ theorem inducedGe_axiomT (m : QualAddMeasure W) (h_empty : m.mu ∅ = 0) :
     EpistemicAxiom.T m.inducedGe := by
   intro A B hAB
   show m.mu B ≥ m.mu A
-  have hAB_diff : A \ B = ∅ := Set.diff_eq_empty.mpr hAB
-  rw [m.qualAdd B A]
-  rw [hAB_diff, h_empty]
+  rw [m.qualAdd B A, Set.diff_eq_empty.mpr hAB, h_empty]
   exact m.nonneg (B \ A)
 
 /-- A qualitatively additive measure with μ(∅) = 0 induces System FA.
@@ -358,9 +343,7 @@ def toSystemFA (m : QualAddMeasure W) (h_empty : m.mu ∅ = 0) :
     rw [h_empty, m.total]; exact not_le.mpr one_pos
   total := fun A B => le_total (m.mu B) (m.mu A)
   trans := fun _ _ _ hab hbc => le_trans hbc hab
-  additive := by
-    intro A B; show m.mu A ≥ m.mu B ↔ m.mu (A \ B) ≥ m.mu (B \ A)
-    exact m.qualAdd A B
+  additive := m.qualAdd
 
 end QualAddMeasure
 
@@ -371,20 +354,7 @@ noncomputable def FinAddMeasure.toQualAdd {W : Type*} (m : FinAddMeasure W) : Qu
   mu := m.mu
   nonneg := m.nonneg
   total := m.total
-  qualAdd := fun A B => by
-    have hdA : ∀ x, x ∈ A \ B → x ∉ A ∩ B :=
-      fun x ⟨_, hxnB⟩ ⟨_, hxB⟩ => hxnB hxB
-    have hdB : ∀ x, x ∈ B \ A → x ∉ A ∩ B :=
-      fun x ⟨_, hxnA⟩ ⟨hxA, _⟩ => hxnA hxA
-    have hmuA : m.mu A = m.mu (A \ B) + m.mu (A ∩ B) := by
-      conv_lhs => rw [show A = (A \ B) ∪ (A ∩ B) from (Set.diff_union_inter A B).symm]
-      exact m.additive _ _ hdA
-    have hmuB : m.mu B = m.mu (B \ A) + m.mu (A ∩ B) := by
-      conv_lhs => rw [show B = (B \ A) ∪ (A ∩ B) from by
-        rw [Set.inter_comm]; exact (Set.diff_union_inter B A).symm]
-      exact m.additive _ _ hdB
-    rw [hmuA, hmuB]
-    exact add_le_add_iff_right (m.mu (A ∩ B))
+  qualAdd := m.mu_qadd
 
 -- ── World-Ordering Semantics ────────────────────
 
@@ -481,17 +451,13 @@ namespace FinAddMeasure
 
 variable {W : Type*} (m : FinAddMeasure W)
 
-instance : ComparativeProbability.IsLikelihoodMono m.inducedGe where
-  mono a b h := m.inducedGe_axiomT a b h
+instance : ComparativeProbability.IsLikelihoodMono m.inducedGe := ⟨m.inducedGe_axiomT⟩
 
-instance : IsTrans (Set W) m.inducedGe where
-  trans _ _ _ hab hbc := le_trans hbc hab
+instance : IsTrans (Set W) m.inducedGe := ⟨fun _ _ _ hab hbc => le_trans hbc hab⟩
 
-instance : ComparativeProbability.IsQualitativeAdditive m.inducedGe where
-  qadd a b := m.toSystemFA.additive a b
+instance : ComparativeProbability.IsQualitativeAdditive m.inducedGe := ⟨m.toSystemFA.additive⟩
 
-instance : ComparativeProbability.IsNontrivial m.inducedGe where
-  bot_not_ge_top := m.toSystemFA.nonTrivial
+instance : ComparativeProbability.IsNontrivial m.inducedGe := ⟨m.toSystemFA.nonTrivial⟩
 
 end FinAddMeasure
 

--- a/Linglib/Core/Scales/EpistemicScale/Defs.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Defs.lean
@@ -1,6 +1,7 @@
 import Linglib.Core.Scales.Scale
 import Linglib.Core.Order.ComparativeProbability.Defs
 import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Tauto
 
 /-!
 # Epistemic Comparative Likelihood
@@ -140,6 +141,84 @@ instance : ComparativeProbability.IsQualitativeAdditive sys.ge := ⟨sys.additiv
 instance : ComparativeProbability.IsNontrivial sys.ge := ⟨sys.nonTrivial⟩
 
 end EpistemicSystemFA
+
+/-! ### Consequences of the FA axioms -/
+
+/-- **Add common context**: for `C` disjoint from both `X` and `Y`,
+    `X ≿ Y ↔ (X ∪ C) ≿ (Y ∪ C)`. -/
+lemma ge_union_context {W : Type*} (sys : EpistemicSystemFA W) (X Y C : Set W)
+    (hCX : Disjoint C X) (hCY : Disjoint C Y) :
+    sys.ge X Y ↔ sys.ge (X ∪ C) (Y ∪ C) := by
+  rw [sys.additive X Y, sys.additive (X ∪ C) (Y ∪ C)]
+  have hCXl : ∀ x, x ∈ C → x ∉ X := fun x hx => Set.disjoint_left.mp hCX hx
+  have hCYl : ∀ x, x ∈ C → x ∉ Y := fun x hx => Set.disjoint_left.mp hCY hx
+  have e1 : (X ∪ C) \ (Y ∪ C) = X \ Y := by
+    ext x
+    have := hCXl x
+    simp only [Set.mem_diff, Set.mem_union]
+    tauto
+  have e2 : (Y ∪ C) \ (X ∪ C) = Y \ X := by
+    ext x
+    have := hCYl x
+    simp only [Set.mem_diff, Set.mem_union]
+    tauto
+  rw [e1, e2]
+
+/-- **Generalized merge**: two valid comparisons with disjoint left parts and
+    disjoint right parts merge into their union, even with pivot overlaps.
+    Derivation: add context to each side, transit through `X₂ ∪ Y₁`, then
+    restore the pivot `X₂ ∩ Y₁` via Axiom A. -/
+lemma ge_generalized_merge {W : Type*} (sys : EpistemicSystemFA W)
+    {X₁ Y₁ X₂ Y₂ : Set W}
+    (h1 : sys.ge X₁ Y₁) (h2 : sys.ge X₂ Y₂)
+    (hX : Disjoint X₁ X₂) (hY : Disjoint Y₁ Y₂) :
+    sys.ge (X₁ ∪ X₂) (Y₁ ∪ Y₂) := by
+  have hXl : ∀ x, x ∈ X₁ → x ∉ X₂ := fun x hx => Set.disjoint_left.mp hX hx
+  have hYl : ∀ x, x ∈ Y₂ → x ∉ Y₁ := fun x hy2 hy1 => Set.disjoint_left.mp hY hy1 hy2
+  -- context C₁ = X₂ \ Y₁ added to (X₁ ≿ Y₁)
+  have step1 : sys.ge (X₁ ∪ (X₂ \ Y₁)) (Y₁ ∪ (X₂ \ Y₁)) :=
+    (ge_union_context sys X₁ Y₁ (X₂ \ Y₁)
+      (Set.disjoint_left.mpr fun x hx hx1 => hXl x hx1 hx.1)
+      (Set.disjoint_left.mpr fun x hx hxY1 => hx.2 hxY1)).mp h1
+  -- context C₂ = Y₁ \ X₂ added to (X₂ ≿ Y₂)
+  have step2 : sys.ge (X₂ ∪ (Y₁ \ X₂)) (Y₂ ∪ (Y₁ \ X₂)) :=
+    (ge_union_context sys X₂ Y₂ (Y₁ \ X₂)
+      (Set.disjoint_left.mpr fun x hx hx2 => hx.2 hx2)
+      (Set.disjoint_left.mpr fun x hx hxY2 => hYl x hxY2 hx.1)).mp h2
+  have hmid : Y₁ ∪ (X₂ \ Y₁) = X₂ ∪ (Y₁ \ X₂) := by
+    ext x; simp only [Set.mem_union, Set.mem_diff]; tauto
+  rw [hmid] at step1
+  have htrans : sys.ge (X₁ ∪ (X₂ \ Y₁)) (Y₂ ∪ (Y₁ \ X₂)) := sys.trans _ _ _ step1 step2
+  set P : Set W := X₂ ∩ Y₁ with hP
+  have hLHS : X₁ ∪ (X₂ \ Y₁) = (X₁ ∪ X₂) \ P := by
+    ext x
+    have := hXl x
+    simp only [Set.mem_union, Set.mem_diff, hP, Set.mem_inter_iff, not_and]
+    tauto
+  have hRHS : Y₂ ∪ (Y₁ \ X₂) = (Y₁ ∪ Y₂) \ P := by
+    ext x
+    have := hYl x
+    simp only [Set.mem_union, Set.mem_diff, hP, Set.mem_inter_iff, not_and]
+    tauto
+  rw [hLHS, hRHS] at htrans
+  have hPsubX : P ⊆ X₁ ∪ X₂ := Set.inter_subset_left.trans Set.subset_union_right
+  have hPsubY : P ⊆ Y₁ ∪ Y₂ := Set.inter_subset_right.trans Set.subset_union_left
+  have key := (ge_union_context sys ((X₁ ∪ X₂) \ P) ((Y₁ ∪ Y₂) \ P) P
+    (Set.disjoint_left.mpr fun x hxP hxd => hxd.2 hxP)
+    (Set.disjoint_left.mpr fun x hxP hxd => hxd.2 hxP)).mp htrans
+  rwa [Set.diff_union_of_subset hPsubX, Set.diff_union_of_subset hPsubY] at key
+
+/-- **Mono-domination**: a valid comparison `X ≿ Y` with `X ⊆ P` and `Q ⊆ Y`
+    proves `P ≿ Q`. -/
+lemma ge_mono_dominated {W : Type*} (sys : EpistemicSystemFA W)
+    {X Y P Q : Set W} (h : sys.ge X Y) (hXP : X ⊆ P) (hQY : Q ⊆ Y) :
+    sys.ge P Q :=
+  sys.trans _ _ _ (sys.mono X P hXP) (sys.trans _ _ _ h (sys.mono Q Y hQY))
+
+/-- `P ≿ ∅` always (monotonicity). -/
+lemma ge_empty_target {W : Type*} (sys : EpistemicSystemFA W) (P : Set W) :
+    sys.ge P ∅ :=
+  sys.mono ∅ P (Set.empty_subset P)
 
 -- ── GFC Order ([harrison-trainor-holliday-icard-2018] Definition 2.7) ──
 

--- a/Linglib/Core/Scales/EpistemicScale/Defs.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Defs.lean
@@ -150,18 +150,12 @@ lemma ge_union_context {W : Type*} (sys : EpistemicSystemFA W) (X Y C : Set W)
     (hCX : Disjoint C X) (hCY : Disjoint C Y) :
     sys.ge X Y ↔ sys.ge (X ∪ C) (Y ∪ C) := by
   rw [sys.additive X Y, sys.additive (X ∪ C) (Y ∪ C)]
-  have hCXl : ∀ x, x ∈ C → x ∉ X := fun x hx => Set.disjoint_left.mp hCX hx
-  have hCYl : ∀ x, x ∈ C → x ∉ Y := fun x hx => Set.disjoint_left.mp hCY hx
+  have hCXl := Set.disjoint_left.mp hCX
+  have hCYl := Set.disjoint_left.mp hCY
   have e1 : (X ∪ C) \ (Y ∪ C) = X \ Y := by
-    ext x
-    have := hCXl x
-    simp only [Set.mem_diff, Set.mem_union]
-    tauto
+    ext x; simp only [Set.mem_diff, Set.mem_union]; have := @hCXl x; tauto
   have e2 : (Y ∪ C) \ (X ∪ C) = Y \ X := by
-    ext x
-    have := hCYl x
-    simp only [Set.mem_diff, Set.mem_union]
-    tauto
+    ext x; simp only [Set.mem_diff, Set.mem_union]; have := @hCYl x; tauto
   rw [e1, e2]
 
 /-- **Generalized merge**: two valid comparisons with disjoint left parts and
@@ -175,38 +169,27 @@ lemma ge_generalized_merge {W : Type*} (sys : EpistemicSystemFA W)
     sys.ge (X₁ ∪ X₂) (Y₁ ∪ Y₂) := by
   have hXl : ∀ x, x ∈ X₁ → x ∉ X₂ := fun x hx => Set.disjoint_left.mp hX hx
   have hYl : ∀ x, x ∈ Y₂ → x ∉ Y₁ := fun x hy2 hy1 => Set.disjoint_left.mp hY hy1 hy2
-  -- context C₁ = X₂ \ Y₁ added to (X₁ ≿ Y₁)
+  -- context C₁ = X₂ \ Y₁ added to (X₁ ≿ Y₁); C₂ = Y₁ \ X₂ added to (X₂ ≿ Y₂)
   have step1 : sys.ge (X₁ ∪ (X₂ \ Y₁)) (Y₁ ∪ (X₂ \ Y₁)) :=
-    (ge_union_context sys X₁ Y₁ (X₂ \ Y₁)
-      (Set.disjoint_left.mpr fun x hx hx1 => hXl x hx1 hx.1)
+    (ge_union_context sys X₁ Y₁ (X₂ \ Y₁) (Set.disjoint_left.mpr fun x hx hx1 => hXl x hx1 hx.1)
       (Set.disjoint_left.mpr fun x hx hxY1 => hx.2 hxY1)).mp h1
-  -- context C₂ = Y₁ \ X₂ added to (X₂ ≿ Y₂)
   have step2 : sys.ge (X₂ ∪ (Y₁ \ X₂)) (Y₂ ∪ (Y₁ \ X₂)) :=
-    (ge_union_context sys X₂ Y₂ (Y₁ \ X₂)
-      (Set.disjoint_left.mpr fun x hx hx2 => hx.2 hx2)
+    (ge_union_context sys X₂ Y₂ (Y₁ \ X₂) (Set.disjoint_left.mpr fun x hx hx2 => hx.2 hx2)
       (Set.disjoint_left.mpr fun x hx hxY2 => hYl x hxY2 hx.1)).mp h2
-  have hmid : Y₁ ∪ (X₂ \ Y₁) = X₂ ∪ (Y₁ \ X₂) := by
-    ext x; simp only [Set.mem_union, Set.mem_diff]; tauto
-  rw [hmid] at step1
+  rw [show Y₁ ∪ (X₂ \ Y₁) = X₂ ∪ (Y₁ \ X₂) by ext x; simp only [Set.mem_union, Set.mem_diff]; tauto]
+    at step1
   have htrans : sys.ge (X₁ ∪ (X₂ \ Y₁)) (Y₂ ∪ (Y₁ \ X₂)) := sys.trans _ _ _ step1 step2
   set P : Set W := X₂ ∩ Y₁ with hP
   have hLHS : X₁ ∪ (X₂ \ Y₁) = (X₁ ∪ X₂) \ P := by
-    ext x
-    have := hXl x
-    simp only [Set.mem_union, Set.mem_diff, hP, Set.mem_inter_iff, not_and]
-    tauto
+    ext x; have := hXl x; simp only [Set.mem_union, Set.mem_diff, hP, Set.mem_inter_iff, not_and]; tauto
   have hRHS : Y₂ ∪ (Y₁ \ X₂) = (Y₁ ∪ Y₂) \ P := by
-    ext x
-    have := hYl x
-    simp only [Set.mem_union, Set.mem_diff, hP, Set.mem_inter_iff, not_and]
-    tauto
+    ext x; have := hYl x; simp only [Set.mem_union, Set.mem_diff, hP, Set.mem_inter_iff, not_and]; tauto
   rw [hLHS, hRHS] at htrans
-  have hPsubX : P ⊆ X₁ ∪ X₂ := Set.inter_subset_left.trans Set.subset_union_right
-  have hPsubY : P ⊆ Y₁ ∪ Y₂ := Set.inter_subset_right.trans Set.subset_union_left
   have key := (ge_union_context sys ((X₁ ∪ X₂) \ P) ((Y₁ ∪ Y₂) \ P) P
     (Set.disjoint_left.mpr fun x hxP hxd => hxd.2 hxP)
     (Set.disjoint_left.mpr fun x hxP hxd => hxd.2 hxP)).mp htrans
-  rwa [Set.diff_union_of_subset hPsubX, Set.diff_union_of_subset hPsubY] at key
+  rwa [Set.diff_union_of_subset (Set.inter_subset_left.trans Set.subset_union_right),
+    Set.diff_union_of_subset (Set.inter_subset_right.trans Set.subset_union_left)] at key
 
 /-- **Mono-domination**: a valid comparison `X ≿ Y` with `X ⊆ P` and `Q ⊆ Y`
     proves `P ≿ Q`. -/
@@ -296,22 +279,19 @@ theorem inducedGe_axiomT (m : FinAddMeasure W) :
     Follows from additivity: μ(∅ ∪ ∅) = μ(∅) + μ(∅), but ∅ ∪ ∅ = ∅. -/
 theorem mu_empty (m : FinAddMeasure W) : m.mu ∅ = 0 := by
   have hempty := m.additive ∅ ∅ disjoint_bot_left
-  rw [Set.empty_union] at hempty
-  linarith
+  rw [Set.empty_union] at hempty; linarith
 
 /-- Subset monotonicity: `A ⊆ B → μ(A) ≤ μ(B)`. -/
 theorem mu_mono (m : FinAddMeasure W) {A B : Set W} (h : A ⊆ B) :
     m.mu A ≤ m.mu B := by
   have hunion := m.additive A (B \ A) disjoint_sdiff_self_right
-  rw [Set.union_diff_cancel h] at hunion
-  linarith [m.nonneg (B \ A)]
+  rw [Set.union_diff_cancel h] at hunion; linarith [m.nonneg (B \ A)]
 
 /-- Complement measure: `μ(A) + μ(Aᶜ) = 1`. -/
 theorem mu_compl (m : FinAddMeasure W) (A : Set W) :
     m.mu A + m.mu Aᶜ = 1 := by
   have hunion := m.additive A Aᶜ disjoint_compl_right
-  rw [Set.union_compl_self] at hunion
-  linarith [m.total]
+  rw [Set.union_compl_self] at hunion; linarith [m.total]
 
 /-- Qualitative additivity for a finitely additive measure: splitting `A` and `B`
     into the shared part `A ∩ B` and the private parts cancels the shared part. -/
@@ -321,11 +301,9 @@ theorem mu_qadd (m : FinAddMeasure W) (A B : Set W) :
     conv_lhs => rw [(Set.diff_union_inter A B).symm]
     exact m.additive _ _ (Set.disjoint_left.mpr fun _ hx hy => hx.2 hy.2)
   have hmuB : m.mu B = m.mu (B \ A) + m.mu (A ∩ B) := by
-    conv_lhs => rw [show B = (B \ A) ∪ (A ∩ B) from by
-      rw [Set.inter_comm]; exact (Set.diff_union_inter B A).symm]
+    conv_lhs => rw [show B = (B \ A) ∪ (A ∩ B) by rw [Set.inter_comm]; exact (Set.diff_union_inter B A).symm]
     exact m.additive _ _ (Set.disjoint_left.mpr fun _ hx hy => hx.2 hy.1)
-  rw [hmuA, hmuB]
-  exact add_le_add_iff_right (m.mu (A ∩ B))
+  rw [hmuA, hmuB]; exact add_le_add_iff_right (m.mu (A ∩ B))
 
 /-- Every finitely additive measure satisfies the FA axioms.
     A fortiori from [holliday-icard-2013] Theorem 6 soundness,
@@ -334,12 +312,8 @@ def toSystemFA (m : FinAddMeasure W) : EpistemicSystemFA W where
   ge := m.inducedGe
   refl := m.inducedGe_axiomR
   mono := m.inducedGe_axiomT
-  bottom := by
-    show m.mu Set.univ ≥ m.mu ∅
-    rw [m.mu_empty]; exact m.nonneg Set.univ
-  nonTrivial := by
-    show ¬(m.mu ∅ ≥ m.mu Set.univ)
-    rw [m.mu_empty, m.total]; exact not_le.mpr one_pos
+  bottom := by show m.mu Set.univ ≥ m.mu ∅; rw [m.mu_empty]; exact m.nonneg Set.univ
+  nonTrivial := by show ¬(m.mu ∅ ≥ m.mu Set.univ); rw [m.mu_empty, m.total]; exact not_le.mpr one_pos
   total := fun A B => le_total (m.mu B) (m.mu A)
   trans := fun _ _ _ hab hbc => le_trans hbc hab
   additive := m.mu_qadd
@@ -383,8 +357,7 @@ theorem inducedGe_axiomT (m : QualAddMeasure W) :
     EpistemicAxiom.T m.inducedGe := by
   intro A B hAB
   show m.mu B ≥ m.mu A
-  rw [m.qualAdd B A, Set.diff_eq_empty.mpr hAB, m.mu_empty]
-  exact m.nonneg (B \ A)
+  rw [m.qualAdd B A, Set.diff_eq_empty.mpr hAB, m.mu_empty]; exact m.nonneg (B \ A)
 
 /-- A qualitatively additive measure induces System FA.
     Soundness direction of [holliday-icard-2013] Theorem 6:
@@ -393,12 +366,8 @@ def toSystemFA (m : QualAddMeasure W) : EpistemicSystemFA W where
   ge := m.inducedGe
   refl := fun _ => le_refl _
   mono := m.inducedGe_axiomT
-  bottom := by
-    show m.mu Set.univ ≥ m.mu ∅
-    rw [m.mu_empty]; exact m.nonneg Set.univ
-  nonTrivial := by
-    show ¬(m.mu ∅ ≥ m.mu Set.univ)
-    rw [m.mu_empty, m.total]; exact not_le.mpr one_pos
+  bottom := by show m.mu Set.univ ≥ m.mu ∅; rw [m.mu_empty]; exact m.nonneg Set.univ
+  nonTrivial := by show ¬(m.mu ∅ ≥ m.mu Set.univ); rw [m.mu_empty, m.total]; exact not_le.mpr one_pos
   total := fun A B => le_total (m.mu B) (m.mu A)
   trans := fun _ _ _ hab hbc => le_trans hbc hab
   additive := m.qualAdd

--- a/Linglib/Core/Scales/EpistemicScale/Entailments.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Entailments.lean
@@ -59,12 +59,11 @@ private noncomputable def uf3 : FinAddMeasure (Fin 3) where
   nonneg := λ A => add_nonneg (add_nonneg
     (by split <;> norm_num) (by split <;> norm_num)) (by split <;> norm_num)
   additive := λ A B hAB => by
-    have hdisj : ∀ x ∈ A, x ∉ B := λ x hx => Set.disjoint_left.mp hAB hx
     simp only [Set.mem_union]
     by_cases h0A : (0 : Fin 3) ∈ A <;> by_cases h0B : (0 : Fin 3) ∈ B <;>
     by_cases h1A : (1 : Fin 3) ∈ A <;> by_cases h1B : (1 : Fin 3) ∈ B <;>
     by_cases h2A : (2 : Fin 3) ∈ A <;> by_cases h2B : (2 : Fin 3) ∈ B <;>
-    simp_all <;> linarith
+    simp_all [Set.disjoint_left] <;> linarith
   total := by simp only [Set.mem_univ, ite_true]; norm_num
 
 private theorem uf3_mu_eq (A : Set (Fin 3)) :
@@ -83,16 +82,13 @@ private theorem uf3_mu_2 : uf3.mu {(2 : Fin 3)} = 1/3 := by
   simp only [uf3_mu_eq, Set.mem_singleton_iff, Fin.reduceEq, reduceIte]; norm_num
 
 private theorem uf3_mu_union_12 : uf3.mu ({(1 : Fin 3)} ∪ {2}) = 2/3 := by
-  rw [uf3.additive _ _ (Set.disjoint_singleton.mpr (by omega))]
-  rw [uf3_mu_1, uf3_mu_2]; norm_num
+  rw [uf3.additive _ _ (Set.disjoint_singleton.mpr (by omega)), uf3_mu_1, uf3_mu_2]; norm_num
 
 private theorem uf3_mu_pair_01 : uf3.mu ({0, 1} : Set (Fin 3)) = 2/3 := by
-  rw [show ({0, 1} : Set (Fin 3)) = {0} ∪ {1} from Set.insert_eq 0 {1}]
-  rw [uf3.additive _ _ (Set.disjoint_singleton.mpr (by omega))]
-  rw [uf3_mu_0, uf3_mu_1]; norm_num
+  rw [show ({0, 1} : Set (Fin 3)) = {0} ∪ {1} from Set.insert_eq 0 {1},
+    uf3.additive _ _ (Set.disjoint_singleton.mpr (by omega)), uf3_mu_0, uf3_mu_1]; norm_num
 
-private theorem uf3_mu_compl' (A : Set (Fin 3)) :
-    uf3.mu Aᶜ = 1 - uf3.mu A := by
+private theorem uf3_mu_compl' (A : Set (Fin 3)) : uf3.mu Aᶜ = 1 - uf3.mu A := by
   have := uf3.mu_compl A; linarith
 
 /-- I1 is invalid for measure semantics: with uniform measure on Fin 3,
@@ -105,9 +101,8 @@ theorem measure_not_I1 :
   have h02 : uf3.inducedGe {(0 : Fin 3)} {2} := by
     unfold FinAddMeasure.inducedGe; rw [uf3_mu_0, uf3_mu_2]
   have hconc := hI1 {(0 : Fin 3)} {1} {2} h01 h02
-  unfold FinAddMeasure.inducedGe at hconc
-  simp only [Set.sup_eq_union] at hconc
-  rw [uf3_mu_0, uf3_mu_union_12] at hconc; linarith
+  simp only [FinAddMeasure.inducedGe, Set.sup_eq_union, uf3_mu_0, uf3_mu_union_12] at hconc
+  linarith
 
 /-- I2 is invalid for measure semantics: with uniform measure on Fin 3,
     {0,1} ≿ {0,1}ᶜ but ¬({0,1} ≿ univ). -/
@@ -115,11 +110,9 @@ theorem measure_not_I2 :
     ∃ m : FinAddMeasure (Fin 3), ¬patternI2 m.inducedGe := by
   refine ⟨uf3, λ hI2 => ?_⟩
   have hge : uf3.inducedGe ({0, 1} : Set (Fin 3)) ({0, 1} : Set (Fin 3))ᶜ := by
-    unfold FinAddMeasure.inducedGe
-    rw [uf3_mu_pair_01, uf3_mu_compl', uf3_mu_pair_01]; linarith
+    simp only [FinAddMeasure.inducedGe, uf3_mu_pair_01, uf3_mu_compl']; linarith
   have hconc := hI2 ({0, 1} : Set (Fin 3)) Set.univ hge
-  unfold FinAddMeasure.inducedGe at hconc
-  rw [uf3_mu_pair_01, uf3.total] at hconc; linarith
+  simp only [FinAddMeasure.inducedGe, uf3_mu_pair_01, uf3.total] at hconc; linarith
 
 /-- I3 is invalid for measure semantics: with uniform measure on Fin 3,
     Probably({0,1}) but ¬({0,1} ≿ univ). -/
@@ -127,14 +120,11 @@ theorem measure_not_I3 :
     ∃ m : FinAddMeasure (Fin 3), ¬patternI3 m.inducedGe := by
   refine ⟨uf3, λ hI3 => ?_⟩
   have hprob : Probably uf3.inducedGe ({0, 1} : Set (Fin 3)) := by
-    constructor
-    · unfold FinAddMeasure.inducedGe
-      rw [uf3_mu_pair_01, uf3_mu_compl', uf3_mu_pair_01]; linarith
-    · intro h; unfold FinAddMeasure.inducedGe at h
-      rw [uf3_mu_pair_01, uf3_mu_compl', uf3_mu_pair_01] at h; linarith
+    refine ⟨by simp only [FinAddMeasure.inducedGe, uf3_mu_pair_01, uf3_mu_compl']; linarith,
+      fun h => ?_⟩
+    simp only [FinAddMeasure.inducedGe, uf3_mu_pair_01, uf3_mu_compl'] at h; linarith
   have hconc := hI3 ({0, 1} : Set (Fin 3)) Set.univ hprob
-  unfold FinAddMeasure.inducedGe at hconc
-  rw [uf3_mu_pair_01, uf3.total] at hconc; linarith
+  simp only [FinAddMeasure.inducedGe, uf3_mu_pair_01, uf3.total] at hconc; linarith
 
 end MeasureSemantics
 
@@ -185,38 +175,30 @@ theorem dominationLift_V1 {W : Type*} (ge_w : W → W → Prop) :
 theorem dominationLift_V2 {W : Type*} (ge_w : W → W → Prop) :
     patternV2 (dominationLift ge_w) := by
   intro A B ⟨hAB, hABnot⟩
-  constructor
-  · constructor
-    · -- ge A Aᶜ: ∀ b ∈ Aᶜ, ∃ a ∈ A, ge_w a b.
-      -- b ∈ Aᶜ → b ∉ A → b ∉ A ∩ B. Since Aᶜ ⊆ (A ∩ B)ᶜ, use hAB.
-      intro b hb
-      have hb' : b ∈ (A ∩ B)ᶜ := fun ⟨ha, _⟩ => hb ha
-      obtain ⟨a, ⟨ha, _⟩, hge⟩ := hAB b hb'
-      exact ⟨a, ha, hge⟩
-    · -- ¬ge Aᶜ A: if so, every b ∈ A has dominator in Aᶜ ⊆ (A ∩ B)ᶜ.
-      -- Then every b ∈ A ∩ B (⊆ A) has dominator in (A ∩ B)ᶜ, so ge (A∩B)ᶜ (A∩B).
-      intro hc; apply hABnot; intro b ⟨hbA, _⟩
-      obtain ⟨a, ha, hge⟩ := hc b hbA
-      exact ⟨a, fun ⟨haA, _⟩ => ha haA, hge⟩
-  · constructor
-    · intro b hb
-      have hb' : b ∈ (A ∩ B)ᶜ := fun ⟨_, hbB⟩ => hb hbB
-      obtain ⟨a, ⟨_, ha⟩, hge⟩ := hAB b hb'
-      exact ⟨a, ha, hge⟩
-    · intro hc; apply hABnot; intro b ⟨_, hbB⟩
-      obtain ⟨a, ha, hge⟩ := hc b hbB
-      exact ⟨a, fun ⟨_, haB⟩ => ha haB, hge⟩
+  refine ⟨⟨?_, ?_⟩, ?_, ?_⟩
+  · -- ge A Aᶜ: Aᶜ ⊆ (A ∩ B)ᶜ, use hAB.
+    intro b hb
+    obtain ⟨a, ⟨ha, _⟩, hge⟩ := hAB b (fun ⟨ha, _⟩ => hb ha)
+    exact ⟨a, ha, hge⟩
+  · -- ¬ge Aᶜ A: restricts to ge (A∩B)ᶜ (A∩B).
+    intro hc; apply hABnot; intro b ⟨hbA, _⟩
+    obtain ⟨a, ha, hge⟩ := hc b hbA
+    exact ⟨a, fun ⟨haA, _⟩ => ha haA, hge⟩
+  · intro b hb
+    obtain ⟨a, ⟨_, ha⟩, hge⟩ := hAB b (fun ⟨_, hbB⟩ => hb hbB)
+    exact ⟨a, ha, hge⟩
+  · intro hc; apply hABnot; intro b ⟨_, hbB⟩
+    obtain ⟨a, ha, hge⟩ := hc b hbB
+    exact ⟨a, fun ⟨_, haB⟩ => ha haB, hge⟩
 
 theorem dominationLift_V3 {W : Type*} (ge_w : W → W → Prop) :
     patternV3 (dominationLift ge_w) := by
   intro A B ⟨hA, hAnot⟩
   constructor
-  · -- ge (A ∪ B) (A ∪ B)ᶜ: b ∈ (A ∪ B)ᶜ = Aᶜ ∩ Bᶜ → b ∈ Aᶜ → use hA.
-    rw [compl_sup]; intro b ⟨hbAc, _⟩
+  · rw [compl_sup]; intro b ⟨hbAc, _⟩
     obtain ⟨a, ha, hge⟩ := hA b hbAc
     exact ⟨a, Set.mem_union_left B ha, hge⟩
-  · -- ¬ge (A ∪ B)ᶜ (A ∪ B): if so, restricting to A ⊆ A ∪ B gives ge Aᶜ A.
-    rw [compl_sup]; intro hc; apply hAnot; intro b hbA
+  · rw [compl_sup]; intro hc; apply hAnot; intro b hbA
     obtain ⟨a, ⟨haAc, _⟩, hge⟩ := hc b (Set.mem_union_left B hbA)
     exact ⟨a, haAc, hge⟩
 
@@ -231,7 +213,6 @@ theorem dominationLift_V5 {W : Type*} (ge_w : W → W → Prop) (hRefl : ∀ w, 
 theorem dominationLift_V6 {W : Type*} [Nonempty W] (ge_w : W → W → Prop) :
     patternV6 (dominationLift ge_w) := by
   intro A hAc
-  -- dominationLift ge_w ∅ Aᶜ forces Aᶜ = ∅ (no function from Aᶜ to ∅)
   have hAuniv : A = Set.univ := by
     ext x; simp only [Set.mem_univ, iff_true]
     by_contra hx; obtain ⟨a, ha, _⟩ := hAc x hx; exact ha.elim
@@ -245,8 +226,7 @@ theorem dominationLift_V7 {W : Type*} (ge_w : W → W → Prop) :
     patternV7 (dominationLift ge_w) := by
   intro A ⟨_, hAnot⟩ hempty
   by_cases hne : (A : Set W).Nonempty
-  · obtain ⟨x, hx⟩ := hne
-    obtain ⟨a, ha, _⟩ := hempty x hx; exact ha.elim
+  · obtain ⟨x, hx⟩ := hne; exact (hempty x hx).choose_spec.1.elim
   · rw [Set.not_nonempty_iff_eq_empty] at hne
     rw [hne, Set.compl_empty] at hAnot
     exact hAnot (fun b hb => hb.elim)
@@ -258,21 +238,13 @@ theorem dominationLift_V7 {W : Type*} (ge_w : W → W → Prop) :
 theorem dominationLift_not_V11 :
     ∃ (W : Type) (ge_w : W → W → Prop),
       (∀ w, ge_w w w) ∧ ¬patternV11 (dominationLift ge_w) := by
-  refine ⟨Fin 2, fun _ _ => True, fun _ => trivial, ?_⟩
-  intro h
-  -- B = {0}, A = Set.univ
+  refine ⟨Fin 2, fun _ _ => True, fun _ => trivial, fun h => ?_⟩
   have hBA : dominationLift (fun (_ _ : Fin 2) => True) {(0 : Fin 2)} Set.univ :=
     fun _ _ => ⟨0, rfl, trivial⟩
-  have hprobA : Probably (dominationLift (fun (_ _ : Fin 2) => True)) Set.univ := by
-    refine ⟨fun b hb => absurd (Set.mem_univ b) hb, ?_⟩
-    intro hge
-    obtain ⟨a, ha, _⟩ := hge (0 : Fin 2) (Set.mem_univ _)
-    exact absurd (Set.mem_univ a) ha
-  have hresult := h Set.univ {(0 : Fin 2)} hBA hprobA
-  -- hresult : Probably {0}, i.e., {0} ≿ {1} and ¬({1} ≿ {0})
-  -- But {1} ≿ {0} since ge_w is total: 1 ≥ 0.
-  apply hresult.2
-  intro b _
+  have hprobA : Probably (dominationLift (fun (_ _ : Fin 2) => True)) Set.univ :=
+    ⟨fun b hb => absurd (Set.mem_univ b) hb, fun hge =>
+      absurd (Set.mem_univ _) (hge (0 : Fin 2) (Set.mem_univ _)).choose_spec.1⟩
+  refine (h Set.univ {(0 : Fin 2)} hBA hprobA).2 (fun b _ => ?_)
   exact ⟨1, fun h1 => absurd (Set.mem_singleton_iff.mp h1) (by omega), trivial⟩
 
 /-- V12 is valid for world-ordering semantics with a preorder (Fact 1 in
@@ -283,12 +255,8 @@ theorem dominationLift_V12 {W : Type*} (ge_w : W → W → Prop)
     patternV12 (dominationLift ge_w) := by
   intro A B hBA hA y hyBc
   by_cases hyA : y ∈ A
-  · -- y ∈ A: from ge B A, get b ∈ B with b ≥ y.
-    exact hBA y hyA
-  · -- y ∈ Aᶜ: from ge A Aᶜ, get a ∈ A with a ≥ y.
-    --          from ge B A, get b ∈ B with b ≥ a.
-    --          transitivity: b ≥ a ≥ y → b ≥ y.
-    obtain ⟨a, haA, hge_ay⟩ := hA y hyA
+  · exact hBA y hyA
+  · obtain ⟨a, haA, hge_ay⟩ := hA y hyA
     obtain ⟨b, hbB, hge_ba⟩ := hBA a haA
     exact ⟨b, hbB, hTrans b a y hge_ba hge_ay⟩
 
@@ -298,18 +266,16 @@ theorem dominationLift_V12 {W : Type*} (ge_w : W → W → Prop)
 theorem dominationLift_not_V13 :
     ∃ (W : Type) (ge_w : W → W → Prop),
       (∀ w, ge_w w w) ∧ ¬patternV13 (dominationLift ge_w) := by
-  refine ⟨Fin 2, fun _ _ => True, fun _ => trivial, ?_⟩
-  intro h
+  refine ⟨Fin 2, fun _ _ => True, fun _ => trivial, fun h => ?_⟩
   have hA : ({0} : Set (Fin 2)) \ {1} = {0} := by
     ext x; simp only [Set.mem_diff, Set.mem_singleton_iff]; omega
   have hstrict : Strict (dominationLift (fun (_ _ : Fin 2) => True)) ({0} \ {1}) ∅ :=
     ⟨fun b hb => hb.elim, fun hge => by
       obtain ⟨a, ha, _⟩ := hge (0 : Fin 2) (by rw [hA]; rfl); exact ha.elim⟩
-  have hresult := h {0} {1} hstrict
   have huniv : ({0} : Set (Fin 2)) ∪ {1} = Set.univ := by
     ext x; simp only [Set.mem_union, Set.mem_singleton_iff, Set.mem_univ, iff_true]; omega
-  simp only [Set.sup_eq_union] at hresult
-  rw [huniv] at hresult
+  have hresult := h {0} {1} hstrict
+  simp only [Set.sup_eq_union, huniv] at hresult
   exact hresult.2 (fun b _ => ⟨1, rfl, trivial⟩)
 
 /-- I1 is valid for world-ordering semantics: the "disjunction problem". -/
@@ -366,22 +332,14 @@ theorem matchingLift_V2 {W : Type*} (ge_w : W → W → Prop) :
     patternV2 (matchingLift ge_w) := by
   intro A B ⟨⟨f, hf, hinj⟩, hABnot⟩
   refine ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩
-  · -- matchingLift ge_w A Aᶜ: restrict f from (A∩B)ᶜ to Aᶜ
-    exact ⟨f,
-      fun b hb => ⟨(hf b (fun h => hb h.1)).1.1, (hf b (fun h => hb h.1)).2⟩,
+  · exact ⟨f, fun b hb => ⟨(hf b (fun h => hb h.1)).1.1, (hf b (fun h => hb h.1)).2⟩,
       fun b₁ b₂ h1 h2 => hinj b₁ b₂ (fun h => h1 h.1) (fun h => h2 h.1)⟩
-  · -- ¬matchingLift ge_w Aᶜ A: any g : A → Aᶜ restricts to A∩B → (A∩B)ᶜ
-    intro ⟨g, hg, ginj⟩
-    exact hABnot ⟨g,
+  · exact fun ⟨g, hg, ginj⟩ => hABnot ⟨g,
       fun b hb => ⟨fun h => (hg b hb.1).1 h.1, (hg b hb.1).2⟩,
       fun b₁ b₂ h1 h2 => ginj b₁ b₂ h1.1 h2.1⟩
-  · -- matchingLift ge_w B Bᶜ: restrict f from (A∩B)ᶜ to Bᶜ
-    exact ⟨f,
-      fun b hb => ⟨(hf b (fun h => hb h.2)).1.2, (hf b (fun h => hb h.2)).2⟩,
+  · exact ⟨f, fun b hb => ⟨(hf b (fun h => hb h.2)).1.2, (hf b (fun h => hb h.2)).2⟩,
       fun b₁ b₂ h1 h2 => hinj b₁ b₂ (fun h => h1 h.2) (fun h => h2 h.2)⟩
-  · -- ¬matchingLift ge_w Bᶜ B: any g : B → Bᶜ restricts to A∩B → (A∩B)ᶜ
-    intro ⟨g, hg, ginj⟩
-    exact hABnot ⟨g,
+  · exact fun ⟨g, hg, ginj⟩ => hABnot ⟨g,
       fun b hb => ⟨fun h => (hg b hb.2).1 h.2, (hg b hb.2).2⟩,
       fun b₁ b₂ h1 h2 => ginj b₁ b₂ h1.2 h2.2⟩
 
@@ -390,24 +348,13 @@ theorem matchingLift_V3 {W : Type*} (ge_w : W → W → Prop) :
   intro A B ⟨hA, hAnot⟩
   obtain ⟨f, hf, hinj⟩ := hA
   constructor
-  · -- ge (A ∪ B) (A ∪ B)ᶜ: f maps Aᶜ ↪ A, and (A ∪ B)ᶜ ⊆ Aᶜ,
-    -- so restriction to (A ∪ B)ᶜ still injective, images land in A ⊆ A ∪ B.
-    rw [compl_sup]
-    exact ⟨f,
-      fun b ⟨hbAc, _⟩ =>
-        let ⟨ha, hge⟩ := hf b hbAc
-        ⟨Set.mem_union_left B ha, hge⟩,
+  · rw [compl_sup]
+    exact ⟨f, fun b ⟨hbAc, _⟩ => let ⟨ha, hge⟩ := hf b hbAc; ⟨Set.mem_union_left B ha, hge⟩,
       fun b₁ b₂ ⟨h1, _⟩ ⟨h2, _⟩ => hinj b₁ b₂ h1 h2⟩
-  · -- ¬ge (A ∪ B)ᶜ (A ∪ B): if so, restricting g to A ⊆ A ∪ B
-    -- gives an injection A → Aᶜ (since (A ∪ B)ᶜ ⊆ Aᶜ), contradicting hAnot.
-    intro ⟨g, hg, ginj⟩
-    apply hAnot
-    exact ⟨g,
-      fun b hbA => by
-        obtain ⟨hgc, hge⟩ := hg b (Set.mem_union_left B hbA)
-        exact ⟨fun hga => hgc (Set.mem_union_left B hga), hge⟩,
-      fun b₁ b₂ h1 h2 =>
-        ginj b₁ b₂ (Set.mem_union_left B h1) (Set.mem_union_left B h2)⟩
+  · refine fun ⟨g, hg, ginj⟩ => hAnot ⟨g, fun b hbA => ?_,
+      fun b₁ b₂ h1 h2 => ginj b₁ b₂ (Set.mem_union_left B h1) (Set.mem_union_left B h2)⟩
+    obtain ⟨hgc, hge⟩ := hg b (Set.mem_union_left B hbA)
+    exact ⟨fun hga => hgc (Set.mem_union_left B hga), hge⟩
 
 theorem matchingLift_V4 {W : Type*} (ge_w : W → W → Prop) :
     patternV4 (matchingLift ge_w) := by
@@ -420,7 +367,6 @@ theorem matchingLift_V5 {W : Type*} (ge_w : W → W → Prop) (hRefl : ∀ w, ge
 theorem matchingLift_V6 {W : Type*} [Nonempty W] (ge_w : W → W → Prop) :
     patternV6 (matchingLift ge_w) := by
   intro A hAc
-  -- matchingLift ge_w ∅ Aᶜ forces Aᶜ = ∅ (no injection from Aᶜ to ∅)
   have hAuniv : A = Set.univ := by
     ext x; simp only [Set.mem_univ, iff_true]
     by_contra hx; obtain ⟨f, hf, _⟩ := hAc; obtain ⟨ha, _⟩ := hf x hx; exact ha.elim
@@ -428,19 +374,14 @@ theorem matchingLift_V6 {W : Type*} [Nonempty W] (ge_w : W → W → Prop) :
   show matchingLift ge_w Set.univ Set.univᶜ ∧ ¬matchingLift ge_w Set.univᶜ Set.univ
   rw [Set.compl_univ]
   exact ⟨⟨id, fun b hb => hb.elim, fun _ _ h1 => h1.elim⟩,
-    fun ⟨f, hf, _⟩ => by
-      obtain ⟨w⟩ := ‹Nonempty W›
-      obtain ⟨ha, _⟩ := hf w (Set.mem_univ w)
-      exact ha.elim⟩
+    fun ⟨f, hf, _⟩ => by obtain ⟨w⟩ := ‹Nonempty W›; exact (hf w (Set.mem_univ w)).1.elim⟩
 
 theorem matchingLift_V7 {W : Type*} (ge_w : W → W → Prop) :
     patternV7 (matchingLift ge_w) := by
   intro A ⟨_, hAnot⟩ hempty
-  -- hempty : matchingLift ge_w ∅ A, i.e. ∃ f, ∀ b ∈ A, f b ∈ ∅ — impossible if A nonempty
   obtain ⟨f, hf, _⟩ := hempty
   by_cases hne : (A : Set W).Nonempty
-  · obtain ⟨x, hx⟩ := hne
-    obtain ⟨ha, _⟩ := hf x hx; exact ha.elim
+  · obtain ⟨x, hx⟩ := hne; exact (hf x hx).1.elim
   · rw [Set.not_nonempty_iff_eq_empty] at hne
     rw [hne, Set.compl_empty] at hAnot
     exact hAnot ⟨id, fun b hb => hb.elim, fun _ _ h1 => h1.elim⟩
@@ -488,9 +429,8 @@ private theorem matchingLift_iter_ne_of_lt {W : Type*} {A B : Set W} {f : W → 
   induction i with
   | zero =>
     intro j hj heq
-    have : f^[j] p ∈ B := matchingLift_iter_in_B hfmem j (by omega) (fun m _ => hall m)
     simp only [Function.iterate_zero, id_eq] at heq
-    exact hpB (heq ▸ this)
+    exact hpB (heq ▸ matchingLift_iter_in_B hfmem j (by omega) (fun m _ => hall m))
   | succ i' ih =>
     intro j hj heq
     obtain ⟨j', rfl⟩ : ∃ j', j = j' + 1 := ⟨j - 1, by omega⟩
@@ -588,10 +528,8 @@ private theorem matchingLift_complement_reversal {W : Type*} [Finite W]
     fun w hwA hwB => Nat.find_spec (hExits w hwA hwB)
   have ei_min : ∀ w hwA hwB m, m < ei w hwA hwB → f^[m] w ∈ A :=
     fun w hwA hwB m hm => by_contra fun h => Nat.find_min (hExits w hwA hwB) hm h
-  -- The witness: f^[k] for A ∩ Bᶜ (chain exit), identity for Aᶜ ∩ Bᶜ
   let g : W → W := fun w =>
     if hwA : w ∈ A then if hwB : w ∈ B then w else f^[ei w hwA hwB] w else w
-  -- Express g(b') as f^[k] b' uniformly for all b' ∈ Bᶜ
   have g_iter : ∀ b' (_ : b' ∉ B), ∃ k,
       g b' = f^[k] b' ∧ f^[k] b' ∉ A ∧ ∀ m, m < k → f^[m] b' ∈ A := by
     intro b' hb'
@@ -600,11 +538,9 @@ private theorem matchingLift_complement_reversal {W : Type*} [Finite W]
         ei_spec b' hbA hb', ei_min b' hbA hb'⟩
     · exact ⟨0, by simp [g, dif_neg hbA], hbA, fun _ hm => absurd hm (by omega)⟩
   refine ⟨g, fun b' hb' => ?_, fun b₁ b₂ hb1 hb2 heq => ?_⟩
-  · -- Membership in Aᶜ and dominance
-    obtain ⟨k, hgk, hnotA, hkA⟩ := g_iter b' hb'
+  · obtain ⟨k, hgk, hnotA, hkA⟩ := g_iter b' hb'
     exact ⟨hgk ▸ hnotA, hgk ▸ matchingLift_chain_dominance hRefl hfge hTrans k hkA⟩
-  · -- Injectivity: all four cases via chain_origin_eq
-    obtain ⟨k₁, hgk1, -, hk1A⟩ := g_iter b₁ hb1
+  · obtain ⟨k₁, hgk1, -, hk1A⟩ := g_iter b₁ hb1
     obtain ⟨k₂, hgk2, -, hk2A⟩ := g_iter b₂ hb2
     rw [hgk1, hgk2] at heq
     exact matchingLift_chain_origin_eq hfmem hinj_f hb1 hb2 hk1A hk2A heq
@@ -676,18 +612,15 @@ theorem matchingLift_V13 {W : Type*} [Finite W] (ge_w : W → W → Prop)
     rw [Set.not_nonempty_iff_eq_empty] at h
     apply hNotEmpty; rw [h]
     exact ⟨id, fun b hb => hb.elim, fun _ _ _ _ h => h⟩
-  constructor
-  · exact ⟨id, fun b hb => ⟨Set.mem_union_right A hb, hRefl b⟩,
-           fun _ _ _ _ h => h⟩
-  · intro ⟨f, hf, hinj⟩
-    have hle : (A ∪ B).ncard ≤ B.ncard :=
-      Set.ncard_le_ncard_of_injOn f (fun b hb => (hf b hb).1)
-        (fun b₁ hb₁ b₂ hb₂ heq => hinj b₁ b₂ hb₁ hb₂ heq) (Set.toFinite _)
-    have hsub : B ⊂ A ∪ B :=
-      ⟨Set.subset_union_right, fun h => hABne.elim fun x hx =>
-        hx.2 (h (Set.mem_union_left B hx.1))⟩
-    have hlt := Set.ncard_lt_ncard hsub (Set.toFinite _)
-    omega
+  refine ⟨⟨id, fun b hb => ⟨Set.mem_union_right A hb, hRefl b⟩, fun _ _ _ _ h => h⟩,
+    fun ⟨f, hf, hinj⟩ => ?_⟩
+  have hle : (A ∪ B).ncard ≤ B.ncard :=
+    Set.ncard_le_ncard_of_injOn f (fun b hb => (hf b hb).1)
+      (fun b₁ hb₁ b₂ hb₂ heq => hinj b₁ b₂ hb₁ hb₂ heq) (Set.toFinite _)
+  have hsub : B ⊂ A ∪ B := ⟨Set.subset_union_right, fun h =>
+    hABne.elim fun x hx => hx.2 (h (Set.mem_union_left B hx.1))⟩
+  have hlt := Set.ncard_lt_ncard hsub (Set.toFinite _)
+  omega
 
 /-- I1 is **invalid** for the m-lifting (Fact 5 in [holliday-icard-2013]).
     Counterexample: W = Fin 2, ge_w total. A = {0}, B = {0}, C = {1}.
@@ -696,24 +629,17 @@ theorem matchingLift_V13 {W : Type*} [Finite W] (ge_w : W → W → Prop)
 theorem matchingLift_not_I1 :
     ∃ (W : Type) (ge_w : W → W → Prop),
       (∀ w, ge_w w w) ∧ ¬patternI1 (matchingLift ge_w) := by
-  refine ⟨Fin 2, fun _ _ => True, fun _ => trivial, ?_⟩
-  intro h
-  -- I1 says: A ≿ B → A ≿ C → A ≿ (B ∪ C)
-  -- Take A = {0}, B = {0}, C = {1}
+  refine ⟨Fin 2, fun _ _ => True, fun _ => trivial, fun h => ?_⟩
   have hAB : matchingLift (fun (_ _ : Fin 2) => True) {(0 : Fin 2)} {0} :=
     ⟨id, fun b hb => ⟨hb, trivial⟩, fun _ _ _ _ h => h⟩
   have hAC : matchingLift (fun (_ _ : Fin 2) => True) {(0 : Fin 2)} {1} :=
     ⟨fun _ => 0, fun _ hb => ⟨rfl, trivial⟩,
-     fun b₁ b₂ h1 h2 _ => by
-       rw [Set.mem_singleton_iff] at h1 h2; rw [h1, h2]⟩
-  have hresult := h {(0 : Fin 2)} {0} {1} hAB hAC
-  -- hresult : matchingLift {0} ({0} ∪ {1}) = matchingLift {0} univ
+     fun b₁ b₂ h1 h2 _ => by rw [Set.mem_singleton_iff] at h1 h2; rw [h1, h2]⟩
   have huniv : ({0} : Set (Fin 2)) ∪ {1} = Set.univ := by
     ext x; simp only [Set.mem_union, Set.mem_singleton_iff, Set.mem_univ, iff_true]; omega
-  simp only [Set.sup_eq_union] at hresult
-  rw [huniv] at hresult
+  have hresult := h {(0 : Fin 2)} {0} {1} hAB hAC
+  simp only [Set.sup_eq_union, huniv] at hresult
   obtain ⟨f, hf, hinj⟩ := hresult
-  -- f(b) ∈ {0} for all b, so f 0 = 0 = f 1, but injectivity forces 0 = 1
   have hf0 := Set.mem_singleton_iff.mp (hf 0 (Set.mem_univ _)).1
   have hf1 := Set.mem_singleton_iff.mp (hf 1 (Set.mem_univ _)).1
   exact absurd (hinj 0 1 (Set.mem_univ _) (Set.mem_univ _) (hf0.trans hf1.symm)) (by omega)
@@ -759,13 +685,11 @@ theorem matchingLift_not_I3 :
       (∀ w, ge_w w w) ∧ ¬patternI3 (matchingLift ge_w) := by
   refine ⟨Fin 3, fun _ _ => True, fun _ => trivial, fun h => ?_⟩
   refine matchingLift_pair01_not_univ (h _ Set.univ ⟨matchingLift_pair01_AAc, ?_⟩)
-  -- ¬matchingLift Aᶜ A: Aᶜ = {2}, need injection {0,1} → {2}, impossible
   intro ⟨f, hf, hinj⟩
   have h0 := (hf 0 (Set.mem_insert 0 {1})).1
   have h1 := (hf 1 (Or.inr rfl : (1 : Fin 3) ∈ ({0, 1} : Set (Fin 3)))).1
   simp only [Set.mem_compl_iff, Set.mem_insert_iff, Set.mem_singleton_iff, not_or] at h0 h1
-  have := hinj 0 1 (Set.mem_insert 0 {1}) (Or.inr rfl) (by omega)
-  omega
+  have := hinj 0 1 (Set.mem_insert 0 {1}) (Or.inr rfl) (by omega); omega
 
 /-! #### GFC preorder -/
 

--- a/Linglib/Core/Scales/EpistemicScale/Entailments.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Entailments.lean
@@ -58,7 +58,8 @@ private noncomputable def uf3 : FinAddMeasure (Fin 3) where
     (if (2 : Fin 3) ∈ A then (1:ℚ)/3 else 0)
   nonneg := λ A => add_nonneg (add_nonneg
     (by split <;> norm_num) (by split <;> norm_num)) (by split <;> norm_num)
-  additive := λ A B hdisj => by
+  additive := λ A B hAB => by
+    have hdisj : ∀ x ∈ A, x ∉ B := λ x hx => Set.disjoint_left.mp hAB hx
     simp only [Set.mem_union]
     by_cases h0A : (0 : Fin 3) ∈ A <;> by_cases h0B : (0 : Fin 3) ∈ B <;>
     by_cases h1A : (1 : Fin 3) ∈ A <;> by_cases h1B : (1 : Fin 3) ∈ B <;>
@@ -82,14 +83,12 @@ private theorem uf3_mu_2 : uf3.mu {(2 : Fin 3)} = 1/3 := by
   simp only [uf3_mu_eq, Set.mem_singleton_iff, Fin.reduceEq, reduceIte]; norm_num
 
 private theorem uf3_mu_union_12 : uf3.mu ({(1 : Fin 3)} ∪ {2}) = 2/3 := by
-  rw [uf3.additive _ _ (λ x hx hx2 => by
-    rw [Set.mem_singleton_iff] at hx hx2; omega)]
+  rw [uf3.additive _ _ (Set.disjoint_singleton.mpr (by omega))]
   rw [uf3_mu_1, uf3_mu_2]; norm_num
 
 private theorem uf3_mu_pair_01 : uf3.mu ({0, 1} : Set (Fin 3)) = 2/3 := by
   rw [show ({0, 1} : Set (Fin 3)) = {0} ∪ {1} from Set.insert_eq 0 {1}]
-  rw [uf3.additive _ _ (λ x hx hx1 => by
-    rw [Set.mem_singleton_iff] at hx hx1; omega)]
+  rw [uf3.additive _ _ (Set.disjoint_singleton.mpr (by omega))]
   rw [uf3_mu_0, uf3_mu_1]; norm_num
 
 private theorem uf3_mu_compl' (A : Set (Fin 3)) :
@@ -99,14 +98,13 @@ private theorem uf3_mu_compl' (A : Set (Fin 3)) :
 /-- I1 is invalid for measure semantics: with uniform measure on Fin 3,
     {0} ≿ {1} and {0} ≿ {2} but ¬({0} ≿ {1,2}). -/
 theorem measure_not_I1 :
-    ¬∀ (m : FinAddMeasure (Fin 3)), patternI1 m.inducedGe := by
-  intro hall
-  have hI1 := hall uf3 {(0 : Fin 3)} {1} {2}
+    ∃ m : FinAddMeasure (Fin 3), ¬patternI1 m.inducedGe := by
+  refine ⟨uf3, λ hI1 => ?_⟩
   have h01 : uf3.inducedGe {(0 : Fin 3)} {1} := by
     unfold FinAddMeasure.inducedGe; rw [uf3_mu_0, uf3_mu_1]
   have h02 : uf3.inducedGe {(0 : Fin 3)} {2} := by
     unfold FinAddMeasure.inducedGe; rw [uf3_mu_0, uf3_mu_2]
-  have hconc := hI1 h01 h02
+  have hconc := hI1 {(0 : Fin 3)} {1} {2} h01 h02
   unfold FinAddMeasure.inducedGe at hconc
   simp only [Set.sup_eq_union] at hconc
   rw [uf3_mu_0, uf3_mu_union_12] at hconc; linarith
@@ -114,29 +112,27 @@ theorem measure_not_I1 :
 /-- I2 is invalid for measure semantics: with uniform measure on Fin 3,
     {0,1} ≿ {0,1}ᶜ but ¬({0,1} ≿ univ). -/
 theorem measure_not_I2 :
-    ¬∀ (m : FinAddMeasure (Fin 3)), patternI2 m.inducedGe := by
-  intro hall
-  have hI2 := hall uf3 ({0, 1} : Set (Fin 3)) Set.univ
+    ∃ m : FinAddMeasure (Fin 3), ¬patternI2 m.inducedGe := by
+  refine ⟨uf3, λ hI2 => ?_⟩
   have hge : uf3.inducedGe ({0, 1} : Set (Fin 3)) ({0, 1} : Set (Fin 3))ᶜ := by
     unfold FinAddMeasure.inducedGe
     rw [uf3_mu_pair_01, uf3_mu_compl', uf3_mu_pair_01]; linarith
-  have hconc := hI2 hge
+  have hconc := hI2 ({0, 1} : Set (Fin 3)) Set.univ hge
   unfold FinAddMeasure.inducedGe at hconc
   rw [uf3_mu_pair_01, uf3.total] at hconc; linarith
 
 /-- I3 is invalid for measure semantics: with uniform measure on Fin 3,
     Probably({0,1}) but ¬({0,1} ≿ univ). -/
 theorem measure_not_I3 :
-    ¬∀ (m : FinAddMeasure (Fin 3)), patternI3 m.inducedGe := by
-  intro hall
-  have hI3 := hall uf3 ({0, 1} : Set (Fin 3)) Set.univ
+    ∃ m : FinAddMeasure (Fin 3), ¬patternI3 m.inducedGe := by
+  refine ⟨uf3, λ hI3 => ?_⟩
   have hprob : Probably uf3.inducedGe ({0, 1} : Set (Fin 3)) := by
     constructor
     · unfold FinAddMeasure.inducedGe
       rw [uf3_mu_pair_01, uf3_mu_compl', uf3_mu_pair_01]; linarith
     · intro h; unfold FinAddMeasure.inducedGe at h
       rw [uf3_mu_pair_01, uf3_mu_compl', uf3_mu_pair_01] at h; linarith
-  have hconc := hI3 hprob
+  have hconc := hI3 ({0, 1} : Set (Fin 3)) Set.univ hprob
   unfold FinAddMeasure.inducedGe at hconc
   rw [uf3_mu_pair_01, uf3.total] at hconc; linarith
 
@@ -146,22 +142,21 @@ end MeasureSemantics
 
 section QualitativeAdditivity
 
-/-- I1 is invalid for FA: the measure-induced FA system on Fin 3 is a
-    counterexample (every finitely additive measure induces an FA system
-    via `toSystemFA`). -/
-theorem fa_not_I1 : ¬∀ (W : Type) (sys : EpistemicSystemFA W),
-    patternI1 sys.ge :=
-  λ hall => measure_not_I1 λ m => hall (Fin 3) m.toSystemFA
+/-- I1 is invalid for FA: every finitely additive measure induces an FA system
+    via `toSystemFA`, so the measure counterexample transfers. -/
+theorem fa_not_I1 : ∃ (W : Type) (sys : EpistemicSystemFA W), ¬patternI1 sys.ge :=
+  let ⟨m, hm⟩ := measure_not_I1
+  ⟨Fin 3, m.toSystemFA, hm⟩
 
 /-- I2 is invalid for FA. -/
-theorem fa_not_I2 : ¬∀ (W : Type) (sys : EpistemicSystemFA W),
-    patternI2 sys.ge :=
-  λ hall => measure_not_I2 λ m => hall (Fin 3) m.toSystemFA
+theorem fa_not_I2 : ∃ (W : Type) (sys : EpistemicSystemFA W), ¬patternI2 sys.ge :=
+  let ⟨m, hm⟩ := measure_not_I2
+  ⟨Fin 3, m.toSystemFA, hm⟩
 
 /-- I3 is invalid for FA. -/
-theorem fa_not_I3 : ¬∀ (W : Type) (sys : EpistemicSystemFA W),
-    patternI3 sys.ge :=
-  λ hall => measure_not_I3 λ m => hall (Fin 3) m.toSystemFA
+theorem fa_not_I3 : ∃ (W : Type) (sys : EpistemicSystemFA W), ¬patternI3 sys.ge :=
+  let ⟨m, hm⟩ := measure_not_I3
+  ⟨Fin 3, m.toSystemFA, hm⟩
 
 end QualitativeAdditivity
 

--- a/Linglib/Core/Scales/EpistemicScale/Entailments.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Entailments.lean
@@ -73,31 +73,13 @@ private theorem uf3_mu_eq (A : Set (Fin 3)) :
     (if (2 : Fin 3) ∈ A then (1:ℚ)/3 else 0) := rfl
 
 private theorem uf3_mu_0 : uf3.mu {(0 : Fin 3)} = 1/3 := by
-  rw [uf3_mu_eq]
-  have h0 : (0 : Fin 3) ∈ ({(0 : Fin 3)} : Set _) := rfl
-  have h1 : (1 : Fin 3) ∉ ({(0 : Fin 3)} : Set _) :=
-    fun h => absurd (Set.mem_singleton_iff.mp h) (by omega)
-  have h2 : (2 : Fin 3) ∉ ({(0 : Fin 3)} : Set _) :=
-    fun h => absurd (Set.mem_singleton_iff.mp h) (by omega)
-  rw [if_pos h0, if_neg h1, if_neg h2]; norm_num
+  simp only [uf3_mu_eq, Set.mem_singleton_iff, Fin.reduceEq, reduceIte]; norm_num
 
 private theorem uf3_mu_1 : uf3.mu {(1 : Fin 3)} = 1/3 := by
-  rw [uf3_mu_eq]
-  have h0 : (0 : Fin 3) ∉ ({(1 : Fin 3)} : Set _) :=
-    fun h => absurd (Set.mem_singleton_iff.mp h) (by omega)
-  have h1 : (1 : Fin 3) ∈ ({(1 : Fin 3)} : Set _) := rfl
-  have h2 : (2 : Fin 3) ∉ ({(1 : Fin 3)} : Set _) :=
-    fun h => absurd (Set.mem_singleton_iff.mp h) (by omega)
-  rw [if_neg h0, if_pos h1, if_neg h2]; norm_num
+  simp only [uf3_mu_eq, Set.mem_singleton_iff, Fin.reduceEq, reduceIte]; norm_num
 
 private theorem uf3_mu_2 : uf3.mu {(2 : Fin 3)} = 1/3 := by
-  rw [uf3_mu_eq]
-  have h0 : (0 : Fin 3) ∉ ({(2 : Fin 3)} : Set _) :=
-    fun h => absurd (Set.mem_singleton_iff.mp h) (by omega)
-  have h1 : (1 : Fin 3) ∉ ({(2 : Fin 3)} : Set _) :=
-    fun h => absurd (Set.mem_singleton_iff.mp h) (by omega)
-  have h2 : (2 : Fin 3) ∈ ({(2 : Fin 3)} : Set _) := rfl
-  rw [if_neg h0, if_neg h1, if_pos h2]; norm_num
+  simp only [uf3_mu_eq, Set.mem_singleton_iff, Fin.reduceEq, reduceIte]; norm_num
 
 private theorem uf3_mu_union_12 : uf3.mu ({(1 : Fin 3)} ∪ {2}) = 2/3 := by
   rw [uf3.additive _ _ (λ x hx hx2 => by
@@ -168,27 +150,18 @@ section QualitativeAdditivity
     counterexample (every finitely additive measure induces an FA system
     via `toSystemFA`). -/
 theorem fa_not_I1 : ¬∀ (W : Type) (sys : EpistemicSystemFA W),
-    patternI1 sys.ge := by
-  intro hall
-  apply measure_not_I1
-  intro m
-  exact hall (Fin 3) m.toSystemFA
+    patternI1 sys.ge :=
+  λ hall => measure_not_I1 λ m => hall (Fin 3) m.toSystemFA
 
 /-- I2 is invalid for FA. -/
 theorem fa_not_I2 : ¬∀ (W : Type) (sys : EpistemicSystemFA W),
-    patternI2 sys.ge := by
-  intro hall
-  apply measure_not_I2
-  intro m
-  exact hall (Fin 3) m.toSystemFA
+    patternI2 sys.ge :=
+  λ hall => measure_not_I2 λ m => hall (Fin 3) m.toSystemFA
 
 /-- I3 is invalid for FA. -/
 theorem fa_not_I3 : ¬∀ (W : Type) (sys : EpistemicSystemFA W),
-    patternI3 sys.ge := by
-  intro hall
-  apply measure_not_I3
-  intro m
-  exact hall (Fin 3) m.toSystemFA
+    patternI3 sys.ge :=
+  λ hall => measure_not_I3 λ m => hall (Fin 3) m.toSystemFA
 
 end QualitativeAdditivity
 
@@ -383,9 +356,7 @@ section MLift
 theorem matchingLift_implies_dominationLift {W : Type*} {ge_w : W → W → Prop}
     {A B : Set W} (h : matchingLift ge_w A B) : dominationLift ge_w A B := by
   obtain ⟨f, hf, _⟩ := h
-  intro b hbB
-  obtain ⟨ha, hge⟩ := hf b hbB
-  exact ⟨f b, ha, hge⟩
+  exact fun b hbB => ⟨f b, (hf b hbB).1, (hf b hbB).2⟩
 
 theorem matchingLift_V1 {W : Type*} (ge_w : W → W → Prop) :
     patternV1 (matchingLift ge_w) := patternV1_holds
@@ -717,13 +688,10 @@ theorem matchingLift_V13 {W : Type*} [Finite W] (ge_w : W → W → Prop)
     have hle : (A ∪ B).ncard ≤ B.ncard :=
       Set.ncard_le_ncard_of_injOn f (fun b hb => (hf b hb).1)
         (fun b₁ hb₁ b₂ hb₂ heq => hinj b₁ b₂ hb₁ hb₂ heq) (Set.toFinite _)
-    have hsub : B ⊂ A ∪ B := by
-      constructor
-      · exact Set.subset_union_right
-      · intro h; obtain ⟨x, hx⟩ := hABne
-        exact hx.2 (h (Set.mem_union_left B hx.1))
-    have hlt : B.ncard < (A ∪ B).ncard :=
-      Set.ncard_lt_ncard hsub (Set.toFinite _)
+    have hsub : B ⊂ A ∪ B :=
+      ⟨Set.subset_union_right, fun h => hABne.elim fun x hx =>
+        hx.2 (h (Set.mem_union_left B hx.1))⟩
+    have hlt := Set.ncard_lt_ncard hsub (Set.toFinite _)
     omega
 
 /-- I1 is **invalid** for the m-lifting (Fact 5 in [holliday-icard-2013]).
@@ -750,13 +718,32 @@ theorem matchingLift_not_I1 :
   simp only [Set.sup_eq_union] at hresult
   rw [huniv] at hresult
   obtain ⟨f, hf, hinj⟩ := hresult
-  -- f : Fin 2 → Fin 2 with f(b) ∈ {0} for all b, i.e. f = const 0
-  have hf0 : f 0 ∈ ({0} : Set (Fin 2)) := (hf 0 (Set.mem_univ _)).1
-  have hf1 : f 1 ∈ ({0} : Set (Fin 2)) := (hf 1 (Set.mem_univ _)).1
-  rw [Set.mem_singleton_iff] at hf0 hf1
-  -- f 0 = 0 and f 1 = 0, but f is injective on univ → 0 = 1, contradiction
-  have := hinj 0 1 (Set.mem_univ _) (Set.mem_univ _) (by rw [hf0, hf1])
-  exact absurd this (by omega)
+  -- f(b) ∈ {0} for all b, so f 0 = 0 = f 1, but injectivity forces 0 = 1
+  have hf0 := Set.mem_singleton_iff.mp (hf 0 (Set.mem_univ _)).1
+  have hf1 := Set.mem_singleton_iff.mp (hf 1 (Set.mem_univ _)).1
+  exact absurd (hinj 0 1 (Set.mem_univ _) (Set.mem_univ _) (hf0.trans hf1.symm)) (by omega)
+
+/-- Shared counterexample core for I2/I3: with the total relation on `Fin 3`,
+    `{0,1}` m-lifts its complement `{2}` (injection `_ ↦ 0`) but not all of
+    `univ` (no injection `Fin 3 ↪ {0,1}`, by pigeonhole). -/
+private theorem matchingLift_pair01_AAc :
+    matchingLift (fun (_ _ : Fin 3) => True) ({0, 1} : Set (Fin 3)) ({0, 1} : Set (Fin 3))ᶜ :=
+  ⟨fun _ => 0, fun _ _ => ⟨Set.mem_insert 0 {1}, trivial⟩, fun b₁ b₂ hb1 hb2 _ => by
+    simp only [Set.mem_compl_iff, Set.mem_insert_iff, Set.mem_singleton_iff, not_or] at hb1 hb2
+    omega⟩
+
+private theorem matchingLift_pair01_not_univ :
+    ¬matchingLift (fun (_ _ : Fin 3) => True) ({0, 1} : Set (Fin 3)) Set.univ := by
+  intro ⟨f, hf, hinj⟩
+  have h0 := (hf 0 (Set.mem_univ _)).1
+  have h1 := (hf 1 (Set.mem_univ _)).1
+  have h2 := (hf 2 (Set.mem_univ _)).1
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at h0 h1 h2
+  rcases h0 with h0 | h0 <;> rcases h1 with h1 | h1 <;> rcases h2 with h2 | h2 <;>
+    first
+    | (have := hinj 0 1 (Set.mem_univ _) (Set.mem_univ _) (by omega); omega)
+    | (have := hinj 0 2 (Set.mem_univ _) (Set.mem_univ _) (by omega); omega)
+    | (have := hinj 1 2 (Set.mem_univ _) (Set.mem_univ _) (by omega); omega)
 
 /-- I2 is **invalid** for the m-lifting (Fact 5 in [holliday-icard-2013]).
     Counterexample: W = Fin 3, ge_w total. A = {0,1}, B = univ.
@@ -764,34 +751,9 @@ theorem matchingLift_not_I1 :
     since |A| = 2 < 3 = |univ|. -/
 theorem matchingLift_not_I2 :
     ∃ (W : Type) (ge_w : W → W → Prop),
-      (∀ w, ge_w w w) ∧ ¬patternI2 (matchingLift ge_w) := by
-  refine ⟨Fin 3, fun _ _ => True, fun _ => trivial, ?_⟩
-  intro h
-  -- A = {0,1}, B = univ
-  -- A ≿ Aᶜ: Aᶜ = {2}, need injection {2} → {0,1}, e.g. f(2) = 0
-  have hAAc : matchingLift (fun (_ _ : Fin 3) => True) ({0, 1} : Set (Fin 3)) ({0, 1} : Set (Fin 3))ᶜ := by
-    refine ⟨fun _ => 0, fun b hb => ⟨Set.mem_insert 0 {1}, trivial⟩, ?_⟩
-    intro b₁ b₂ hb1 hb2 _
-    -- b₁, b₂ ∈ {0,1}ᶜ = {2}
-    have : b₁ ∈ ({0, 1} : Set (Fin 3))ᶜ := hb1
-    have : b₂ ∈ ({0, 1} : Set (Fin 3))ᶜ := hb2
-    simp only [Set.mem_compl_iff, Set.mem_insert_iff, Set.mem_singleton_iff, not_or] at *
-    omega
-  -- I2 gives: matchingLift A univ
-  have hresult := h ({0, 1} : Set (Fin 3)) Set.univ hAAc
-  obtain ⟨f, hf, hinj⟩ := hresult
-  -- f : Fin 3 → Fin 3 with f(b) ∈ {0,1} for all b ∈ univ
-  -- So f maps {0,1,2} → {0,1}: pigeonhole, not injective
-  have h0 := (hf 0 (Set.mem_univ _)).1
-  have h1 := (hf 1 (Set.mem_univ _)).1
-  have h2 := (hf 2 (Set.mem_univ _)).1
-  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at h0 h1 h2
-  -- f maps 3 elements to {0,1} — pigeonhole
-  rcases h0 with h0 | h0 <;> rcases h1 with h1 | h1 <;> rcases h2 with h2 | h2 <;>
-    first
-    | (have := hinj 0 1 (Set.mem_univ _) (Set.mem_univ _) (by omega); omega)
-    | (have := hinj 0 2 (Set.mem_univ _) (Set.mem_univ _) (by omega); omega)
-    | (have := hinj 1 2 (Set.mem_univ _) (Set.mem_univ _) (by omega); omega)
+      (∀ w, ge_w w w) ∧ ¬patternI2 (matchingLift ge_w) :=
+  ⟨Fin 3, fun _ _ => True, fun _ => trivial, fun h =>
+    matchingLift_pair01_not_univ (h _ Set.univ matchingLift_pair01_AAc)⟩
 
 /-- I3 is **invalid** for the m-lifting (Fact 5 in [holliday-icard-2013]).
     Same counterexample as I2: W = Fin 3, ge_w total, A = {0,1}, B = univ.
@@ -800,34 +762,15 @@ theorem matchingLift_not_I2 :
 theorem matchingLift_not_I3 :
     ∃ (W : Type) (ge_w : W → W → Prop),
       (∀ w, ge_w w w) ∧ ¬patternI3 (matchingLift ge_w) := by
-  refine ⟨Fin 3, fun _ _ => True, fun _ => trivial, ?_⟩
-  intro h
-  -- A = {0,1}, B = univ. Probably A holds, but ¬matchingLift A univ.
-  have hprob : Probably (matchingLift (fun (_ _ : Fin 3) => True)) ({0, 1} : Set (Fin 3)) := by
-    constructor
-    · -- matchingLift A Aᶜ: Aᶜ = {2}, inject f(2) = 0
-      refine ⟨fun _ => 0, fun b hb => ⟨Set.mem_insert 0 {1}, trivial⟩, ?_⟩
-      intro b₁ b₂ hb1 hb2 _
-      simp only [Set.mem_compl_iff, Set.mem_insert_iff, Set.mem_singleton_iff, not_or] at hb1 hb2
-      omega
-    · -- ¬matchingLift Aᶜ A: Aᶜ = {2}, need injection {0,1} → {2}, impossible
-      intro ⟨f, hf, hinj⟩
-      have h0 := (hf 0 (Set.mem_insert 0 {1})).1
-      have h1 := (hf 1 (Or.inr rfl : (1 : Fin 3) ∈ ({0, 1} : Set (Fin 3)))).1
-      simp only [Set.mem_compl_iff, Set.mem_insert_iff, Set.mem_singleton_iff, not_or] at h0 h1
-      have := hinj 0 1 (Set.mem_insert 0 {1}) (Or.inr rfl) (by omega)
-      omega
-  have hresult := h ({0, 1} : Set (Fin 3)) Set.univ hprob
-  obtain ⟨f, hf, hinj⟩ := hresult
-  have h0 := (hf 0 (Set.mem_univ _)).1
-  have h1 := (hf 1 (Set.mem_univ _)).1
-  have h2 := (hf 2 (Set.mem_univ _)).1
-  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at h0 h1 h2
-  rcases h0 with h0 | h0 <;> rcases h1 with h1 | h1 <;> rcases h2 with h2 | h2 <;>
-    first
-    | (have := hinj 0 1 (Set.mem_univ _) (Set.mem_univ _) (by omega); omega)
-    | (have := hinj 0 2 (Set.mem_univ _) (Set.mem_univ _) (by omega); omega)
-    | (have := hinj 1 2 (Set.mem_univ _) (Set.mem_univ _) (by omega); omega)
+  refine ⟨Fin 3, fun _ _ => True, fun _ => trivial, fun h => ?_⟩
+  refine matchingLift_pair01_not_univ (h _ Set.univ ⟨matchingLift_pair01_AAc, ?_⟩)
+  -- ¬matchingLift Aᶜ A: Aᶜ = {2}, need injection {0,1} → {2}, impossible
+  intro ⟨f, hf, hinj⟩
+  have h0 := (hf 0 (Set.mem_insert 0 {1})).1
+  have h1 := (hf 1 (Or.inr rfl : (1 : Fin 3) ∈ ({0, 1} : Set (Fin 3)))).1
+  simp only [Set.mem_compl_iff, Set.mem_insert_iff, Set.mem_singleton_iff, not_or] at h0 h1
+  have := hinj 0 1 (Set.mem_insert 0 {1}) (Or.inr rfl) (by omega)
+  omega
 
 /-! #### GFC preorder -/
 
@@ -847,9 +790,7 @@ theorem matchingLift_not_total :
     have h2 := hf 2 (by simp [Set.mem_insert_iff, Set.mem_singleton_iff])
     have h1 := hf 1 (by simp [Set.mem_insert_iff, Set.mem_singleton_iff])
     simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at h2 h1
-    have hf2 : f 2 = 3 := by omega
-    have hf1 : f 1 = 3 := by omega
-    exact absurd (hinj 2 1 (by simp) (by simp) (by rw [hf2, hf1])) (by omega)
+    exact absurd (hinj 2 1 (by simp) (by simp) (by omega)) (by omega)
   · intro ⟨f, hf, _⟩
     have h3 := hf 3 (by simp [Set.mem_insert_iff, Set.mem_singleton_iff])
     simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at h3

--- a/Linglib/Core/Scales/EpistemicScale/Representability.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Representability.lean
@@ -96,10 +96,9 @@ private theorem toFS_diff (A B : Set (Fin 5)) :
   ext x; simp only [toFS_mem, Set.mem_diff, Finset.mem_sdiff]
 
 private theorem toFS_subset (A B : Set (Fin 5)) :
-    A ⊆ B ↔ toFS A ⊆ toFS B := by
-  constructor
-  · intro h x hx; rw [toFS_mem] at hx ⊢; exact h hx
-  · intro h x hx; exact (toFS_mem B x).mp (h ((toFS_mem A x).mpr hx))
+    A ⊆ B ↔ toFS A ⊆ toFS B :=
+  ⟨fun h x hx => by rw [toFS_mem] at hx ⊢; exact h hx,
+   fun h x hx => (toFS_mem B x).mp (h ((toFS_mem A x).mpr hx))⟩
 
 private noncomputable def kpsRankSet (A : Set (Fin 5)) : ℕ := kpsRank (toFS A)
 private noncomputable def kpsGe (A B : Set (Fin 5)) : Prop := kpsRankSet A ≥ kpsRankSet B
@@ -109,19 +108,15 @@ noncomputable def kpsSystemFA : EpistemicSystemFA (Fin 5) where
   refl := λ A => le_refl (kpsRankSet A)
   mono := λ {A B} hAB => kps_mono_finset _ _ ((toFS_subset A B).mp hAB)
   bottom := by
-    simp only [EpistemicAxiom.F, kpsGe, kpsRankSet, toFS_univ, toFS_empty]
-    exact kps_bottom_finset
+    simp only [EpistemicAxiom.F, kpsGe, kpsRankSet, toFS_univ, toFS_empty]; exact kps_bottom_finset
   nonTrivial := by
-    simp only [EpistemicAxiom.BT, kpsGe, kpsRankSet, toFS_univ, toFS_empty]
-    decide
+    simp only [EpistemicAxiom.BT, kpsGe, kpsRankSet, toFS_univ, toFS_empty]; decide
   total := λ A B => le_total (kpsRankSet B) (kpsRankSet A)
   trans := λ {_ _ _} hab hbc => le_trans hbc hab
-  additive := by
-    intro A B
+  additive A B := by
     show kpsRank (toFS A) ≥ kpsRank (toFS B) ↔
          kpsRank (toFS (A \ B)) ≥ kpsRank (toFS (B \ A))
-    rw [toFS_diff, toFS_diff]
-    exact kps_additive_finset (toFS A) (toFS B)
+    rw [toFS_diff, toFS_diff]; exact kps_additive_finset (toFS A) (toFS B)
 
 private theorem mu_pair (m : FinAddMeasure (Fin 5)) (a b : Fin 5) (hab : a ≠ b) :
     m.mu ({a, b} : Set (Fin 5)) = m.mu {a} + m.mu {b} := by
@@ -135,9 +130,8 @@ private theorem mu_triple (m : FinAddMeasure (Fin 5)) (a b c : Fin 5)
       rw [Set.mem_singleton_iff] at hx
       simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hxbc
       subst hx; rcases hxbc with rfl | rfl
-      · exact absurd rfl hab
-      · exact absurd rfl hac)]
-  rw [mu_pair m b c hbc, add_assoc]
+      exacts [absurd rfl hab, absurd rfl hac]),
+    mu_pair m b c hbc, add_assoc]
 
 theorem kps_not_representable : ¬Representable kpsSystemFA := by
   intro ⟨m, hm⟩
@@ -150,23 +144,19 @@ theorem kps_not_representable : ¬Representable kpsSystemFA := by
   have hord1 : ¬ kpsGe ({1, 3} : Set (Fin 5)) {0} := by
     unfold kpsGe kpsRankSet
     rw [show toFS ({1, 3} : Set (Fin 5)) = {1, 3} by ext x; simp [toFS_mem],
-        show toFS ({(0 : Fin 5)} : Set (Fin 5)) = {0} by ext x; simp [toFS_mem]]
-    decide
+        show toFS ({(0 : Fin 5)} : Set (Fin 5)) = {0} by ext x; simp [toFS_mem]]; decide
   have hord2 : ¬ kpsGe ({0, 1} : Set (Fin 5)) {2, 3} := by
     unfold kpsGe kpsRankSet
     rw [show toFS ({0, 1} : Set (Fin 5)) = {0, 1} by ext x; simp [toFS_mem],
-        show toFS ({2, 3} : Set (Fin 5)) = {2, 3} by ext x; simp [toFS_mem]]
-    decide
+        show toFS ({2, 3} : Set (Fin 5)) = {2, 3} by ext x; simp [toFS_mem]]; decide
   have hord3 : ¬ kpsGe ({0, 3} : Set (Fin 5)) {1, 4} := by
     unfold kpsGe kpsRankSet
     rw [show toFS ({0, 3} : Set (Fin 5)) = {0, 3} by ext x; simp [toFS_mem],
-        show toFS ({1, 4} : Set (Fin 5)) = {1, 4} by ext x; simp [toFS_mem]]
-    decide
+        show toFS ({1, 4} : Set (Fin 5)) = {1, 4} by ext x; simp [toFS_mem]]; decide
   have hord4 : kpsGe ({0, 1, 3} : Set (Fin 5)) {2, 4} := by
     unfold kpsGe kpsRankSet
     rw [show toFS ({0, 1, 3} : Set (Fin 5)) = {0, 1, 3} by ext x; simp [toFS_mem],
-        show toFS ({2, 4} : Set (Fin 5)) = {2, 4} by ext x; simp [toFS_mem]]
-    decide
+        show toFS ({2, 4} : Set (Fin 5)) = {2, 4} by ext x; simp [toFS_mem]]; decide
   -- Convert to measure inequalities via the representation isomorphism
   have hmeas1 : m.mu ({1, 3} : Set _) < m.mu ({(0 : Fin 5)} : Set _) :=
     not_le.mp (λ h => hord1 ((hm _ _).mpr h))
@@ -220,16 +210,14 @@ theorem null_removal_disjoint {W : Type*} (sys : EpistemicSystemFA W)
   have null_sub : ∀ S : Set W, sys.ge (S \ {j}) S := by
     intro S
     by_cases hj_in : j ∈ S
-    · rw [sys.additive (S \ {j}) S]
-      have h1 : (S \ {j}) \ S = ∅ := by
-        ext x; simp only [Set.mem_diff, Set.mem_empty_iff_false, iff_false]
-        tauto
-      have h2 : S \ (S \ {j}) = {j} := by
-        ext x; simp only [Set.mem_diff, Set.mem_singleton_iff]
-        constructor
-        · rintro ⟨hx, hn⟩; by_contra hne; exact hn ⟨hx, hne⟩
-        · rintro rfl; exact ⟨hj_in, fun ⟨_, h⟩ => h rfl⟩
-      rw [h1, h2]; exact hj
+    · rw [sys.additive (S \ {j}) S,
+        show (S \ {j}) \ S = ∅ by
+          ext x; simp only [Set.mem_diff, Set.mem_empty_iff_false, iff_false]; tauto,
+        show S \ (S \ {j}) = {j} by
+          ext x; simp only [Set.mem_diff, Set.mem_singleton_iff]
+          exact ⟨fun ⟨hx, hn⟩ => by by_contra hne; exact hn ⟨hx, hne⟩,
+            by rintro rfl; exact ⟨hj_in, fun ⟨_, h⟩ => h rfl⟩⟩]
+      exact hj
     · rw [Set.diff_singleton_eq_self hj_in]; exact sys.refl S
   by_cases hjC : j ∈ C
   · have hjnD : j ∉ D := Set.disjoint_left.mp hdisj hjC
@@ -259,8 +247,7 @@ def comapFA {α W : Type*} (f : α → W) (hf : Function.Injective f)
   mono _ _ hAB := sys.mono _ _ (Set.image_mono hAB)
   bottom := by
     show sys.ge (f '' Set.univ) (f '' ∅)
-    rw [Set.image_empty]
-    exact sys.mono _ _ (Set.empty_subset _)
+    rw [Set.image_empty]; exact sys.mono _ _ (Set.empty_subset _)
   nonTrivial := by
     show ¬sys.ge (f '' ∅) (f '' Set.univ)
     rwa [Set.image_empty, Set.image_univ]
@@ -268,8 +255,7 @@ def comapFA {α W : Type*} (f : α → W) (hf : Function.Injective f)
   trans _ _ _ h1 h2 := sys.trans _ _ _ h1 h2
   additive A B := by
     show sys.ge (f '' A) (f '' B) ↔ sys.ge (f '' (A \ B)) (f '' (B \ A))
-    rw [Set.image_diff hf, Set.image_diff hf]
-    exact sys.additive _ _
+    rw [Set.image_diff hf, Set.image_diff hf]; exact sys.additive _ _
 
 /-- Null element reduction: if atom 0 is null in an FA system on `Fin (n+2)` and
     some atom is not, representability reduces along `Fin.succ` to `Fin (n+1)`. -/
@@ -288,11 +274,8 @@ theorem null_elem_reduce {n : ℕ} (sys : EpistemicSystemFA (Fin (n + 2)))
     mu := fun A => m_r.mu (Fin.succ ⁻¹' A)
     nonneg := fun A => m_r.nonneg _
     additive := fun A B hdisj => by
-      rw [Set.preimage_union]
-      exact m_r.additive _ _ (hdisj.preimage _)
-    total := by
-      show m_r.mu (Fin.succ ⁻¹' Set.univ) = 1
-      rw [Set.preimage_univ]; exact m_r.total
+      rw [Set.preimage_union]; exact m_r.additive _ _ (hdisj.preimage _)
+    total := by rw [Set.preimage_univ]; exact m_r.total
   }, reduce_to_disjoint sys _ (fun C D hdisj => ?_)⟩
   rw [null_removal_disjoint sys 0 hn0 C D hdisj,
       ← succ_image_preimage C, ← succ_image_preimage D]
@@ -309,9 +292,7 @@ theorem no_fa_empty (sys : EpistemicSystemFA (Fin 0)) : False := by
 private theorem set_fin1_eq (A : Set (Fin 1)) : A = ∅ ∨ A = Set.univ := by
   by_cases h : (0 : Fin 1) ∈ A
   · right; ext x; simp [Fin.eq_zero x, h]
-  · left; ext x; constructor
-    · intro hx; rw [Fin.eq_zero x] at hx; exact absurd hx h
-    · intro hx; exact hx.elim
+  · left; ext x; exact ⟨fun hx => absurd (Fin.eq_zero x ▸ hx) h, fun hx => hx.elim⟩
 
 private noncomputable def measure_fin1 : FinAddMeasure (Fin 1) where
   mu := fun A => if (0 : Fin 1) ∈ A then 1 else 0
@@ -321,8 +302,7 @@ private noncomputable def measure_fin1 : FinAddMeasure (Fin 1) where
     · exact absurd h0B (Set.disjoint_left.mp hdisj h0A)
     · simp [Set.mem_union, h0A, h0B]
     · simp [Set.mem_union, h0A, h0B]
-    · have : (0 : Fin 1) ∉ A ∪ B := fun h => h.elim h0A h0B
-      simp [h0A, h0B, this]
+    · simp [h0A, h0B, show (0 : Fin 1) ∉ A ∪ B from fun h => h.elim h0A h0B]
   total := by simp [Set.mem_univ]
 
 theorem representable_fin1 (sys : EpistemicSystemFA (Fin 1)) : Representable sys := by
@@ -361,19 +341,17 @@ private theorem mf2_empty (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1) :
 
 private theorem mf2_zero (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1) :
     (measure_fin2 a ha ha1).mu {(0 : Fin 2)} = a := by
-  rw [measure_fin2_mu]
-  have h0 : (0 : Fin 2) ∈ ({(0 : Fin 2)} : Set _) := rfl
-  have h1 : (1 : Fin 2) ∉ ({(0 : Fin 2)} : Set _) := by
-    simp only [Set.mem_singleton_iff]; exact fun h => absurd (Fin.ext_iff.mp h) (by omega)
-  rw [if_pos h0, if_neg h1]; linarith
+  rw [measure_fin2_mu, if_pos (show (0 : Fin 2) ∈ ({(0 : Fin 2)} : Set _) from rfl),
+    if_neg (show (1 : Fin 2) ∉ ({(0 : Fin 2)} : Set _) by
+      simp only [Set.mem_singleton_iff]; exact fun h => absurd (Fin.ext_iff.mp h) (by omega))]
+  linarith
 
 private theorem mf2_one (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1) :
     (measure_fin2 a ha ha1).mu {(1 : Fin 2)} = 1 - a := by
-  rw [measure_fin2_mu]
-  have h0 : (0 : Fin 2) ∉ ({(1 : Fin 2)} : Set _) := by
-    simp only [Set.mem_singleton_iff]; exact fun h => absurd (Fin.ext_iff.mp h) (by omega)
-  have h1 : (1 : Fin 2) ∈ ({(1 : Fin 2)} : Set _) := rfl
-  rw [if_neg h0, if_pos h1]; linarith
+  rw [measure_fin2_mu, if_neg (show (0 : Fin 2) ∉ ({(1 : Fin 2)} : Set _) by
+      simp only [Set.mem_singleton_iff]; exact fun h => absurd (Fin.ext_iff.mp h) (by omega)),
+    if_pos (show (1 : Fin 2) ∈ ({(1 : Fin 2)} : Set _) from rfl)]
+  linarith
 
 private theorem mf2_univ (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1) :
     (measure_fin2 a ha ha1).mu (Set.univ : Set (Fin 2)) = 1 := by
@@ -531,11 +509,8 @@ def transportMeasure {W α : Type*}
   mu := fun A => m.mu (e '' A)
   nonneg := fun A => m.nonneg _
   additive := fun A B hdisj => by
-    rw [Set.image_union]
-    exact m.additive _ _ ((Set.disjoint_image_iff e.injective).mpr hdisj)
-  total := by
-    rw [Set.image_univ_of_surjective e.surjective]
-    exact m.total
+    rw [Set.image_union]; exact m.additive _ _ ((Set.disjoint_image_iff e.injective).mpr hdisj)
+  total := by rw [Set.image_univ_of_surjective e.surjective]; exact m.total
 
 theorem transfer_repr {W α : Type*}
     (e : W ≃ α) (sys : EpistemicSystemFA W) (m : FinAddMeasure α)
@@ -543,8 +518,7 @@ theorem transfer_repr {W α : Type*}
     ∀ A B : Set W, sys.ge A B ↔ (transportMeasure e m).inducedGe A B := by
   intro A B
   have h := hm (e '' A) (e '' B)
-  simp only [transportFA, comapFA, Equiv.symm_image_image] at h
-  exact h
+  simpa only [transportFA, comapFA, Equiv.symm_image_image] using h
 
 /-- Null pattern transport: j is null in `transportFA σ sys` iff `σ.symm j` is null in `sys`. -/
 theorem perm_null_iff {n : ℕ} (σ : Fin n ≃ Fin n)
@@ -569,26 +543,22 @@ def padFA {n : ℕ} (sys : EpistemicSystemFA (Fin n)) : EpistemicSystemFA (Fin (
   mono _ _ hAB := sys.mono _ _ (Set.preimage_mono hAB)
   bottom := by
     show sys.ge (Fin.castSucc ⁻¹' Set.univ) (Fin.castSucc ⁻¹' ∅)
-    rw [Set.preimage_univ, Set.preimage_empty]
-    exact sys.bottom
+    rw [Set.preimage_univ, Set.preimage_empty]; exact sys.bottom
   nonTrivial := by
     show ¬sys.ge (Fin.castSucc ⁻¹' ∅) (Fin.castSucc ⁻¹' Set.univ)
-    rw [Set.preimage_univ, Set.preimage_empty]
-    exact sys.nonTrivial
+    rw [Set.preimage_univ, Set.preimage_empty]; exact sys.nonTrivial
   total _ _ := sys.total _ _
   trans _ _ _ h1 h2 := sys.trans _ _ _ h1 h2
   additive A B := by
     show sys.ge _ _ ↔ sys.ge _ _
-    rw [Set.preimage_diff, Set.preimage_diff]
-    exact sys.additive _ _
+    rw [Set.preimage_diff, Set.preimage_diff]; exact sys.additive _ _
 
 /-- The padded atom is null. -/
 theorem padFA_last_null {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
     (padFA sys).ge ∅ {Fin.last n} := by
   show sys.ge (Fin.castSucc ⁻¹' ∅) (Fin.castSucc ⁻¹' {Fin.last n})
   rw [Set.preimage_empty, show Fin.castSucc ⁻¹' {Fin.last n} = (∅ : Set (Fin n)) from
-    Set.eq_empty_of_forall_notMem fun i hi => (Fin.castSucc_lt_last i).ne hi]
-  exact sys.refl ∅
+    Set.eq_empty_of_forall_notMem fun i hi => (Fin.castSucc_lt_last i).ne hi]; exact sys.refl ∅
 
 /-- Padding reflects representability: a measure for `padFA sys` assigns the
     padded atom measure zero, so its `Fin.castSucc`-image restriction represents
@@ -599,10 +569,7 @@ theorem representable_of_padFA {n : ℕ} {sys : EpistemicSystemFA (Fin n)}
   have hinj := Fin.castSucc_injective n
   have hlast : m.mu {Fin.last n} = 0 := by
     have h0 : m.mu ∅ ≥ m.mu {Fin.last n} := (hm _ _).mp (padFA_last_null sys)
-    rw [m.mu_empty] at h0
-    linarith [m.nonneg {Fin.last n}]
-  have hdisj : Disjoint (Fin.castSucc '' (Set.univ : Set (Fin n))) {Fin.last n} :=
-    Set.disjoint_singleton_right.mpr fun ⟨i, _, hi⟩ => (Fin.castSucc_lt_last i).ne hi
+    rw [m.mu_empty] at h0; linarith [m.nonneg {Fin.last n}]
   have hcover : Fin.castSucc '' (Set.univ : Set (Fin n)) ∪ {Fin.last n} = Set.univ := by
     rw [Set.image_univ]
     ext i
@@ -610,16 +577,16 @@ theorem representable_of_padFA {n : ℕ} {sys : EpistemicSystemFA (Fin n)}
     rcases Fin.eq_castSucc_or_eq_last i with ⟨j, rfl⟩ | rfl
     · exact Or.inl ⟨j, rfl⟩
     · exact Or.inr rfl
+  have hdisj : Disjoint (Fin.castSucc '' (Set.univ : Set (Fin n))) {Fin.last n} :=
+    Set.disjoint_singleton_right.mpr fun ⟨i, _, hi⟩ => (Fin.castSucc_lt_last i).ne hi
   have htotal : m.mu (Fin.castSucc '' (Set.univ : Set (Fin n))) = 1 := by
     have := m.additive _ _ hdisj
-    rw [hcover, m.total, hlast, add_zero] at this
-    linarith
+    rw [hcover, m.total, hlast, add_zero] at this; linarith
   refine ⟨{
     mu := fun A => m.mu (Fin.castSucc '' A)
     nonneg := fun A => m.nonneg _
     additive := fun A B hd => by
-      rw [Set.image_union]
-      exact m.additive _ _ ((Set.disjoint_image_iff hinj).mpr hd)
+      rw [Set.image_union]; exact m.additive _ _ ((Set.disjoint_image_iff hinj).mpr hd)
     total := htotal
   }, fun A B => ?_⟩
   have key := hm (Fin.castSucc '' A) (Fin.castSucc '' B)

--- a/Linglib/Core/Scales/EpistemicScale/Representability.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Representability.lean
@@ -553,14 +553,6 @@ theorem perm_null_iff {n : ℕ} (σ : Fin n ≃ Fin n)
   show sys.ge (σ.symm '' ∅) (σ.symm '' {j}) ↔ sys.ge ∅ {σ.symm j}
   simp only [Set.image_empty, Set.image_singleton]
 
-/-- Concrete null pattern conversion: if `σ.symm j = k` then null-at-j in transported
-    system iff null-at-k in original. -/
-theorem perm_null_convert {n : ℕ} (σ : Fin n ≃ Fin n)
-    (sys : EpistemicSystemFA (Fin n)) (j k : Fin n)
-    (hk : σ.symm j = k) :
-    (transportFA σ sys).ge ∅ {j} ↔ sys.ge ∅ {k} := by
-  rw [perm_null_iff, hk]
-
 /-- Representability transports backward along any equivalence. -/
 theorem perm_repr {W α : Type*} (σ : W ≃ α) (sys : EpistemicSystemFA W)
     (h : Representable (transportFA σ sys)) : Representable sys := by

--- a/Linglib/Core/Scales/EpistemicScale/Representability.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Representability.lean
@@ -1,4 +1,7 @@
 import Linglib.Core.Scales.EpistemicScale.Defs
+import Mathlib.Data.Fintype.Powerset
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Tactic.FinCases
 
 /-!
 # Representability of Epistemic Systems
@@ -113,16 +116,13 @@ noncomputable def kpsSystemFA : EpistemicSystemFA (Fin 5) where
 
 private theorem mu_pair (m : FinAddMeasure (Fin 5)) (a b : Fin 5) (hab : a ≠ b) :
     m.mu ({a, b} : Set (Fin 5)) = m.mu {a} + m.mu {b} := by
-  have hunion : ({a, b} : Set (Fin 5)) = {a} ∪ {b} := Set.insert_eq a {b}
-  rw [hunion, m.additive {a} {b} (λ x hx hxb => by
+  rw [Set.insert_eq a {b}, m.additive {a} {b} (λ x hx hxb => by
     rw [Set.mem_singleton_iff] at hx hxb; exact hab (hx ▸ hxb))]
 
 private theorem mu_triple (m : FinAddMeasure (Fin 5)) (a b c : Fin 5)
     (hab : a ≠ b) (hac : a ≠ c) (hbc : b ≠ c) :
     m.mu ({a, b, c} : Set (Fin 5)) = m.mu {a} + m.mu {b} + m.mu {c} := by
-  have hunion : ({a, b, c} : Set (Fin 5)) = {a} ∪ ({b, c} : Set (Fin 5)) := by
-    ext x; simp only [Set.mem_insert_iff, Set.mem_singleton_iff, Set.mem_union]
-  rw [hunion, m.additive {a} {b, c} (λ x hx hxbc => by
+  rw [Set.insert_eq a ({b, c} : Set (Fin 5)), m.additive {a} {b, c} (λ x hx hxbc => by
     rw [Set.mem_singleton_iff] at hx
     simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hxbc
     subst hx; rcases hxbc with rfl | rfl
@@ -141,24 +141,24 @@ theorem kps_not_representable :
   -- Ordering facts: three strict (rank <), one weak (rank ≥)
   have hord1 : ¬ kpsGe ({1, 3} : Set (Fin 5)) {0} := by
     unfold kpsGe kpsRankSet
-    have h1 : toFS ({1, 3} : Set (Fin 5)) = {1, 3} := by ext x; simp [toFS_mem]
-    have h2 : toFS ({(0 : Fin 5)} : Set (Fin 5)) = {0} := by ext x; simp [toFS_mem]
-    rw [h1, h2]; decide
+    rw [show toFS ({1, 3} : Set (Fin 5)) = {1, 3} by ext x; simp [toFS_mem],
+        show toFS ({(0 : Fin 5)} : Set (Fin 5)) = {0} by ext x; simp [toFS_mem]]
+    decide
   have hord2 : ¬ kpsGe ({0, 1} : Set (Fin 5)) {2, 3} := by
     unfold kpsGe kpsRankSet
-    have h1 : toFS ({0, 1} : Set (Fin 5)) = {0, 1} := by ext x; simp [toFS_mem]
-    have h2 : toFS ({2, 3} : Set (Fin 5)) = {2, 3} := by ext x; simp [toFS_mem]
-    rw [h1, h2]; decide
+    rw [show toFS ({0, 1} : Set (Fin 5)) = {0, 1} by ext x; simp [toFS_mem],
+        show toFS ({2, 3} : Set (Fin 5)) = {2, 3} by ext x; simp [toFS_mem]]
+    decide
   have hord3 : ¬ kpsGe ({0, 3} : Set (Fin 5)) {1, 4} := by
     unfold kpsGe kpsRankSet
-    have h1 : toFS ({0, 3} : Set (Fin 5)) = {0, 3} := by ext x; simp [toFS_mem]
-    have h2 : toFS ({1, 4} : Set (Fin 5)) = {1, 4} := by ext x; simp [toFS_mem]
-    rw [h1, h2]; decide
+    rw [show toFS ({0, 3} : Set (Fin 5)) = {0, 3} by ext x; simp [toFS_mem],
+        show toFS ({1, 4} : Set (Fin 5)) = {1, 4} by ext x; simp [toFS_mem]]
+    decide
   have hord4 : kpsGe ({0, 1, 3} : Set (Fin 5)) {2, 4} := by
     unfold kpsGe kpsRankSet
-    have h1 : toFS ({0, 1, 3} : Set (Fin 5)) = {0, 1, 3} := by ext x; simp [toFS_mem]
-    have h2 : toFS ({2, 4} : Set (Fin 5)) = {2, 4} := by ext x; simp [toFS_mem]
-    rw [h1, h2]; decide
+    rw [show toFS ({0, 1, 3} : Set (Fin 5)) = {0, 1, 3} by ext x; simp [toFS_mem],
+        show toFS ({2, 4} : Set (Fin 5)) = {2, 4} by ext x; simp [toFS_mem]]
+    decide
   -- Convert to measure inequalities via the representation isomorphism
   have hmeas1 : m.mu ({1, 3} : Set _) < m.mu ({(0 : Fin 5)} : Set _) :=
     not_le.mp (λ h => hord1 ((hm _ _).mpr h))
@@ -228,14 +228,13 @@ theorem null_removal_disjoint {W : Type*} (sys : EpistemicSystemFA W)
     by_cases hj_in : j ∈ S
     · rw [sys.additive (S \ {j}) S]
       have h1 : (S \ {j}) \ S = ∅ := by
-        ext x; constructor
-        · intro ⟨⟨_, _⟩, hns⟩; exact absurd (by assumption) hns
-        · intro h; exact h.elim
+        ext x; simp only [Set.mem_diff, Set.mem_empty_iff_false, iff_false]
+        tauto
       have h2 : S \ (S \ {j}) = {j} := by
         ext x; simp only [Set.mem_diff, Set.mem_singleton_iff]
         constructor
-        · intro ⟨hx, hn⟩; by_contra hne; exact hn ⟨hx, hne⟩
-        · intro hx; subst hx; exact ⟨hj_in, fun ⟨_, h⟩ => h rfl⟩
+        · rintro ⟨hx, hn⟩; by_contra hne; exact hn ⟨hx, hne⟩
+        · rintro rfl; exact ⟨hj_in, fun ⟨_, h⟩ => h rfl⟩
       rw [h1, h2]; exact hj
     · rw [Set.diff_singleton_eq_self hj_in]; exact sys.refl S
   by_cases hjC : j ∈ C
@@ -359,7 +358,7 @@ private noncomputable def measure_fin2 (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1) 
     simp only [Set.mem_union]
     by_cases h0A : (0 : Fin 2) ∈ A <;> by_cases h0B : (0 : Fin 2) ∈ B <;>
     by_cases h1A : (1 : Fin 2) ∈ A <;> by_cases h1B : (1 : Fin 2) ∈ B <;>
-    simp_all <;> linarith
+    simp_all
   total := by simp only [Set.mem_univ, ite_true]; linarith
 
 private theorem measure_fin2_mu (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1) (A : Set (Fin 2)) :
@@ -434,7 +433,7 @@ private theorem fin2_dispatch (sys : EpistemicSystemFA (Fin 2))
   -- ∅ vs ∅
   · exact ⟨fun _ => le_refl _, fun _ => sys.refl _⟩
   -- ∅ vs {0}
-  · show sys.ge ∅ {0} ↔ _ ≥ _; rw [hme, hm0]; exact ⟨fun h => he0.mp h, fun h => he0.mpr h⟩
+  · show sys.ge ∅ {0} ↔ _ ≥ _; rw [hme, hm0]; exact he0
   -- ∅ vs {1}
   · show sys.ge ∅ {1} ↔ _ ≥ _; rw [hme, hm1]
     exact ⟨fun h => by linarith [he1.mp h], fun h => he1.mpr (by linarith)⟩
@@ -445,31 +444,29 @@ private theorem fin2_dispatch (sys : EpistemicSystemFA (Fin 2))
   · show sys.ge {0} ∅ ↔ _ ≥ _; rw [hm0, hme]
     exact ⟨fun _ => ha, fun _ => sys.mono _ _ (Set.empty_subset _)⟩
   -- {0} vs {0}: not disjoint
-  · exfalso; exact hdisj 0 rfl rfl
+  · exact (hdisj 0 rfl rfl).elim
   -- {0} vs {1}
-  · show sys.ge {0} {1} ↔ _ ≥ _; rw [hm0, hm1]
-    exact ⟨fun h => h01.mp h, fun h => h01.mpr h⟩
+  · show sys.ge {0} {1} ↔ _ ≥ _; rw [hm0, hm1]; exact h01
   -- {0} vs univ: not disjoint
-  · exfalso; exact hdisj 0 rfl (Set.mem_univ _)
+  · exact (hdisj 0 rfl (Set.mem_univ _)).elim
   -- {1} vs ∅
   · show sys.ge {1} ∅ ↔ _ ≥ _; rw [hm1, hme]
     exact ⟨fun _ => by linarith, fun _ => sys.mono _ _ (Set.empty_subset _)⟩
   -- {1} vs {0}
-  · show sys.ge {1} {0} ↔ _ ≥ _; rw [hm1, hm0]
-    exact ⟨fun h => h10.mp h, fun h => h10.mpr h⟩
+  · show sys.ge {1} {0} ↔ _ ≥ _; rw [hm1, hm0]; exact h10
   -- {1} vs {1}: not disjoint
-  · exfalso; exact hdisj 1 rfl rfl
+  · exact (hdisj 1 rfl rfl).elim
   -- {1} vs univ: not disjoint
-  · exfalso; exact hdisj 1 rfl (Set.mem_univ _)
+  · exact (hdisj 1 rfl (Set.mem_univ _)).elim
   -- univ vs ∅
   · show sys.ge Set.univ ∅ ↔ _ ≥ _; rw [hmu, hme]
     exact ⟨fun _ => by linarith, fun _ => sys.mono _ _ (Set.empty_subset _)⟩
   -- univ vs {0}: not disjoint
-  · exfalso; exact hdisj 0 (Set.mem_univ _) rfl
+  · exact (hdisj 0 (Set.mem_univ _) rfl).elim
   -- univ vs {1}: not disjoint
-  · exfalso; exact hdisj 1 (Set.mem_univ _) rfl
+  · exact (hdisj 1 (Set.mem_univ _) rfl).elim
   -- univ vs univ: not disjoint
-  · exfalso; exact hdisj 0 (Set.mem_univ _) (Set.mem_univ _)
+  · exact (hdisj 0 (Set.mem_univ _) (Set.mem_univ _)).elim
 
 -- ── Card 2: Main theorem ───────────────────────────
 

--- a/Linglib/Core/Scales/EpistemicScale/Representability.lean
+++ b/Linglib/Core/Scales/EpistemicScale/Representability.lean
@@ -10,21 +10,30 @@ import Mathlib.Tactic.FinCases
 
 FA systems on small domains (|W| ≤ 4) are representable by finitely additive
 probability measures (**Theorem 8a**, [kraft-pratt-seidenberg-1959]).
-For |W| ≥ 5, this fails: the KPS counterexample provides an FA system with
-no representing measure (**Theorem 8b**).
+For every |W| ≥ 5 this fails: padding the KPS counterexample with null atoms
+gives a non-representable FA system at each cardinality (**Theorem 8b**).
 
 ## Contents
 
-1. **KPS counterexample** (Fin 5): non-representable FA system (`kpsSystemFA`,
-   `kps_not_representable`)
-2. **Shared infrastructure**: null element reduction (`null_elem_reduce`),
-   transport/permutation (`transportFA`, `perm_repr`)
-3. **Small-cardinality proofs**: Fin 0 (`no_fa_empty`), Fin 1 (`theorem8a_fin1`),
-   Fin 2 (`theorem8a_fin2`).  Fin 3 and Fin 4 are derived from Scott cancellation
-   in `CancellationFin4.lean` (`theorem8a_fin3`, `theorem8a_fin4`).
+1. **`Representable`**: the representability predicate.
+2. **KPS counterexample** (Fin 5): non-representable FA system (`kpsSystemFA`,
+   `kps_not_representable`); null-atom padding (`padFA`,
+   `exists_nonrepresentable_fin`) extends it to every `Fin n` with `n ≥ 5`.
+3. **Shared infrastructure**: injection pullback (`comapFA`), null element
+   reduction (`null_elem_reduce`), transport/permutation (`transportFA`,
+   `perm_repr`)
+4. **Small-cardinality proofs**: Fin 0 (`no_fa_empty`), Fin 1
+   (`representable_fin1`), Fin 2 (`representable_fin2`).  Fin 3 and Fin 4 are
+   derived from Scott cancellation in `CancellationFin4.lean`
+   (`representable_fin3`, `representable_fin4`).
 -/
 
 namespace Core.Scale
+
+/-- An FA system is **representable** when some finitely additive probability
+    measure induces exactly its comparison relation. -/
+def Representable {W : Type*} (sys : EpistemicSystemFA W) : Prop :=
+  ∃ m : FinAddMeasure W, ∀ A B, sys.ge A B ↔ m.inducedGe A B
 
 -- ── KPS Counterexample Infrastructure ──────────────
 
@@ -116,22 +125,21 @@ noncomputable def kpsSystemFA : EpistemicSystemFA (Fin 5) where
 
 private theorem mu_pair (m : FinAddMeasure (Fin 5)) (a b : Fin 5) (hab : a ≠ b) :
     m.mu ({a, b} : Set (Fin 5)) = m.mu {a} + m.mu {b} := by
-  rw [Set.insert_eq a {b}, m.additive {a} {b} (λ x hx hxb => by
-    rw [Set.mem_singleton_iff] at hx hxb; exact hab (hx ▸ hxb))]
+  rw [Set.insert_eq a {b}, m.additive {a} {b} (Set.disjoint_singleton.mpr hab)]
 
 private theorem mu_triple (m : FinAddMeasure (Fin 5)) (a b c : Fin 5)
     (hab : a ≠ b) (hac : a ≠ c) (hbc : b ≠ c) :
     m.mu ({a, b, c} : Set (Fin 5)) = m.mu {a} + m.mu {b} + m.mu {c} := by
-  rw [Set.insert_eq a ({b, c} : Set (Fin 5)), m.additive {a} {b, c} (λ x hx hxbc => by
-    rw [Set.mem_singleton_iff] at hx
-    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hxbc
-    subst hx; rcases hxbc with rfl | rfl
-    · exact absurd rfl hab
-    · exact absurd rfl hac)]
+  rw [Set.insert_eq a ({b, c} : Set (Fin 5)), m.additive {a} {b, c}
+    (Set.disjoint_left.mpr fun x hx hxbc => by
+      rw [Set.mem_singleton_iff] at hx
+      simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hxbc
+      subst hx; rcases hxbc with rfl | rfl
+      · exact absurd rfl hab
+      · exact absurd rfl hac)]
   rw [mu_pair m b c hbc, add_assoc]
 
-theorem kps_not_representable :
-    ¬∃ (m : FinAddMeasure (Fin 5)), ∀ A B, kpsSystemFA.ge A B ↔ m.inducedGe A B := by
+theorem kps_not_representable : ¬Representable kpsSystemFA := by
   intro ⟨m, hm⟩
   set P := m.mu ({(0 : Fin 5)} : Set (Fin 5))
   set Q := m.mu ({(1 : Fin 5)} : Set (Fin 5))
@@ -191,37 +199,23 @@ attribute [local instance] Classical.propDecidable
 
 -- ── Reduction Lemma ────────────────────────────────
 
-theorem measure_axiomA {W : Type*} (m : FinAddMeasure W) (A B : Set W) :
-    m.inducedGe A B ↔ m.inducedGe (A \ B) (B \ A) := by
-  show m.mu A ≥ m.mu B ↔ m.mu (A \ B) ≥ m.mu (B \ A)
-  have hdA : ∀ x, x ∈ A \ B → x ∉ A ∩ B := fun x ⟨_, hxnb⟩ ⟨_, hxb⟩ => hxnb hxb
-  have hdB : ∀ x, x ∈ B \ A → x ∉ A ∩ B := fun x ⟨_, hxna⟩ ⟨hxa, _⟩ => hxna hxa
-  have hmuA : m.mu A = m.mu (A \ B) + m.mu (A ∩ B) := by
-    conv_lhs => rw [(Set.diff_union_inter A B).symm]
-    exact m.additive _ _ hdA
-  have hmuB : m.mu B = m.mu (B \ A) + m.mu (A ∩ B) := by
-    conv_lhs => rw [show B = (B \ A) ∪ (A ∩ B) from by
-      rw [Set.inter_comm]; exact (Set.diff_union_inter B A).symm]
-    exact m.additive _ _ hdB
-  rw [hmuA, hmuB]
-  exact add_le_add_iff_right (m.mu (A ∩ B))
-
+/-- Agreement on disjoint pairs suffices for full representability (Axiom A
+    reduces every comparison to a disjoint one). -/
 theorem reduce_to_disjoint {W : Type*} (sys : EpistemicSystemFA W)
     (m : FinAddMeasure W)
-    (h : ∀ C D : Set W, (∀ x, x ∈ C → x ∉ D) →
-      (sys.ge C D ↔ m.inducedGe C D)) :
+    (h : ∀ C D : Set W, Disjoint C D → (sys.ge C D ↔ m.inducedGe C D)) :
     ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
   intro A B
-  rw [sys.additive A B, measure_axiomA m A B]
-  exact h _ _ (fun x ⟨_, hxnB⟩ ⟨_, hxnA⟩ => hxnA (by assumption))
+  rw [sys.additive A B]
+  exact (h _ _ disjoint_sdiff_sdiff).trans (m.mu_qadd A B).symm
 
 -- ── Null element reduction ────────────────────────────
 
-/-- Removing a null element from both sides of a disjoint comparison preserves `ge`.
-    When `sys.ge ∅ {j}` (j is null) and C, D are disjoint, `sys.ge C D ↔ sys.ge (C\{j}) (D\{j})`. -/
+/-- Removing a null element (`sys.ge ∅ {j}`) from both sides of a disjoint
+    comparison preserves `ge`. -/
 theorem null_removal_disjoint {W : Type*} (sys : EpistemicSystemFA W)
     (j : W) (hj : sys.ge ∅ {j})
-    (C D : Set W) (hdisj : ∀ x, x ∈ C → x ∉ D) :
+    (C D : Set W) (hdisj : Disjoint C D) :
     sys.ge C D ↔ sys.ge (C \ {j}) (D \ {j}) := by
   have null_sub : ∀ S : Set W, sys.ge (S \ {j}) S := by
     intro S
@@ -238,7 +232,7 @@ theorem null_removal_disjoint {W : Type*} (sys : EpistemicSystemFA W)
       rw [h1, h2]; exact hj
     · rw [Set.diff_singleton_eq_self hj_in]; exact sys.refl S
   by_cases hjC : j ∈ C
-  · have hjnD : j ∉ D := fun h => hdisj j hjC h
+  · have hjnD : j ∉ D := Set.disjoint_left.mp hdisj hjC
     rw [Set.diff_singleton_eq_self hjnD]
     exact ⟨fun h => sys.trans _ _ _ (null_sub C) h,
            fun h => sys.trans _ _ _ (sys.mono _ _ Set.diff_subset) h⟩
@@ -248,64 +242,60 @@ theorem null_removal_disjoint {W : Type*} (sys : EpistemicSystemFA W)
              fun h => sys.trans _ _ _ h (null_sub D)⟩
     · rw [Set.diff_singleton_eq_self hjD]
 
-/-- `Fin.succ '' (Fin.succ ⁻¹' S) = S \ {0}` for `S : Set (Fin (n+1))`.
-    The image of `Fin.succ` covers exactly the non-zero elements. -/
+/-- `Fin.succ '' (Fin.succ ⁻¹' S) = S \ {0}` for `S : Set (Fin (n+1))`. -/
 private theorem succ_image_preimage {n : ℕ} (S : Set (Fin (n + 1))) :
     Fin.succ '' (Fin.succ ⁻¹' S) = S \ {(0 : Fin (n + 1))} := by
   rw [Set.image_preimage_eq_range_inter, Fin.range_succ]
   ext x; simp only [Set.mem_inter_iff, Set.mem_compl_iff, Set.mem_singleton_iff,
     Set.mem_diff]; exact And.comm
 
-set_option maxHeartbeats 3200000 in
-/-- Null element reduction: if element 0 is null in an FA system on Fin (n+2), reduce
-    to Fin (n+1) via Fin.succ and delegate to a sub-theorem. -/
+/-- Pull back an FA system along an injection: `α`-propositions compare via their
+    images. Non-triviality requires a witness and must be supplied. -/
+def comapFA {α W : Type*} (f : α → W) (hf : Function.Injective f)
+    (sys : EpistemicSystemFA W) (hnt : ¬sys.ge ∅ (Set.range f)) :
+    EpistemicSystemFA α where
+  ge A B := sys.ge (f '' A) (f '' B)
+  refl _ := sys.refl _
+  mono _ _ hAB := sys.mono _ _ (Set.image_mono hAB)
+  bottom := by
+    show sys.ge (f '' Set.univ) (f '' ∅)
+    rw [Set.image_empty]
+    exact sys.mono _ _ (Set.empty_subset _)
+  nonTrivial := by
+    show ¬sys.ge (f '' ∅) (f '' Set.univ)
+    rwa [Set.image_empty, Set.image_univ]
+  total _ _ := sys.total _ _
+  trans _ _ _ h1 h2 := sys.trans _ _ _ h1 h2
+  additive A B := by
+    show sys.ge (f '' A) (f '' B) ↔ sys.ge (f '' (A \ B)) (f '' (B \ A))
+    rw [Set.image_diff hf, Set.image_diff hf]
+    exact sys.additive _ _
+
+/-- Null element reduction: if atom 0 is null in an FA system on `Fin (n+2)` and
+    some atom is not, representability reduces along `Fin.succ` to `Fin (n+1)`. -/
 theorem null_elem_reduce {n : ℕ} (sys : EpistemicSystemFA (Fin (n + 2)))
     (hn0 : sys.ge ∅ {(0 : Fin (n + 2))})
     (hnn : ∃ i : Fin (n + 1), ¬sys.ge ∅ {Fin.succ i})
-    (sub_repr : ∀ sys' : EpistemicSystemFA (Fin (n + 1)),
-      ∃ m : FinAddMeasure (Fin (n + 1)), ∀ A B, sys'.ge A B ↔ m.inducedGe A B) :
-    ∃ m : FinAddMeasure (Fin (n + 2)), ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
-  -- Step 1: Build restricted system on Fin (n+1)
-  let sys_r : EpistemicSystemFA (Fin (n + 1)) := {
-    ge := fun A B => sys.ge (Fin.succ '' A) (Fin.succ '' B)
-    refl := fun A => sys.refl _
-    mono := fun A B hAB => sys.mono _ _ (Set.image_mono hAB)
-    bottom := by
-      show sys.ge (Fin.succ '' Set.univ) (Fin.succ '' ∅)
-      simp only [Set.image_empty]
-      exact sys.mono _ _ (Set.empty_subset _)
-    nonTrivial := by
-      show ¬sys.ge (Fin.succ '' ∅) (Fin.succ '' Set.univ)
-      simp only [Set.image_empty]
-      obtain ⟨i, hi⟩ := hnn
-      intro h
-      exact hi (sys.trans _ _ _ h (sys.mono _ _
-        (Set.singleton_subset_iff.mpr ⟨i, Set.mem_univ _, rfl⟩)))
-    total := fun A B => sys.total _ _
-    trans := fun A B C h1 h2 => sys.trans _ _ _ h1 h2
-    additive := fun A B => by
-      show sys.ge (Fin.succ '' A) (Fin.succ '' B) ↔
-           sys.ge (Fin.succ '' (A \ B)) (Fin.succ '' (B \ A))
-      rw [Set.image_diff (Fin.succ_injective (n + 1)),
-          Set.image_diff (Fin.succ_injective (n + 1))]
-      exact sys.additive _ _
-  }
-  -- Step 2: Get sub-measure
-  obtain ⟨m_r, hm_r⟩ := sub_repr sys_r
-  -- Step 3: Lift measure (null element gets weight 0)
+    (sub_repr : ∀ sys' : EpistemicSystemFA (Fin (n + 1)), Representable sys') :
+    Representable sys := by
+  have hnt : ¬sys.ge ∅ (Set.range (Fin.succ : Fin (n + 1) → Fin (n + 2))) := by
+    obtain ⟨i, hi⟩ := hnn
+    exact fun h => hi (sys.trans _ _ _ h
+      (sys.mono _ _ (Set.singleton_subset_iff.mpr ⟨i, rfl⟩)))
+  obtain ⟨m_r, hm_r⟩ := sub_repr (comapFA Fin.succ (Fin.succ_injective _) sys hnt)
+  -- lift the sub-measure (the null element gets weight 0)
   refine ⟨{
     mu := fun A => m_r.mu (Fin.succ ⁻¹' A)
     nonneg := fun A => m_r.nonneg _
     additive := fun A B hdisj => by
       rw [Set.preimage_union]
-      exact m_r.additive _ _ (fun x hxA hxB => hdisj (Fin.succ x) hxA hxB)
+      exact m_r.additive _ _ (hdisj.preimage _)
     total := by
       show m_r.mu (Fin.succ ⁻¹' Set.univ) = 1
       rw [Set.preimage_univ]; exact m_r.total
   }, reduce_to_disjoint sys _ (fun C D hdisj => ?_)⟩
-  -- Step 4: Prove representation for disjoint C, D
-  rw [null_removal_disjoint sys 0 hn0 C D hdisj]
-  rw [← succ_image_preimage C, ← succ_image_preimage D]
+  rw [null_removal_disjoint sys 0 hn0 C D hdisj,
+      ← succ_image_preimage C, ← succ_image_preimage D]
   exact hm_r (Fin.succ ⁻¹' C) (Fin.succ ⁻¹' D)
 
 -- ── Card 0: impossible ─────────────────────────────
@@ -328,15 +318,14 @@ private noncomputable def measure_fin1 : FinAddMeasure (Fin 1) where
   nonneg := fun A => by split <;> norm_num
   additive := fun A B hdisj => by
     by_cases h0A : (0 : Fin 1) ∈ A <;> by_cases h0B : (0 : Fin 1) ∈ B
-    · exact absurd h0B (hdisj 0 h0A)
+    · exact absurd h0B (Set.disjoint_left.mp hdisj h0A)
     · simp [Set.mem_union, h0A, h0B]
     · simp [Set.mem_union, h0A, h0B]
     · have : (0 : Fin 1) ∉ A ∪ B := fun h => h.elim h0A h0B
       simp [h0A, h0B, this]
   total := by simp [Set.mem_univ]
 
-theorem theorem8a_fin1 (sys : EpistemicSystemFA (Fin 1)) :
-    ∃ (m : FinAddMeasure (Fin 1)), ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
+theorem representable_fin1 (sys : EpistemicSystemFA (Fin 1)) : Representable sys := by
   refine ⟨measure_fin1, fun A B => ?_⟩
   rcases set_fin1_eq A with rfl | rfl <;> rcases set_fin1_eq B with rfl | rfl
   · exact ⟨fun _ => le_refl _, fun _ => sys.refl _⟩
@@ -355,6 +344,7 @@ private noncomputable def measure_fin2 (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1) 
   nonneg := fun A => add_nonneg (by split <;> [exact ha; exact le_refl _])
     (by split <;> [linarith; exact le_refl _])
   additive := fun A B hdisj => by
+    have hd : ∀ x ∈ A, x ∉ B := fun x hx => Set.disjoint_left.mp hdisj hx
     simp only [Set.mem_union]
     by_cases h0A : (0 : Fin 2) ∈ A <;> by_cases h0B : (0 : Fin 2) ∈ B <;>
     by_cases h1A : (1 : Fin 2) ∈ A <;> by_cases h1B : (1 : Fin 2) ∈ B <;>
@@ -425,9 +415,10 @@ private theorem fin2_dispatch (sys : EpistemicSystemFA (Fin 2))
     (h01 : sys.ge {(0 : Fin 2)} {1} ↔ a ≥ 1 - a)
     (h10 : sys.ge {(1 : Fin 2)} {0} ↔ 1 - a ≥ a)
     :
-    ∀ C D : Set (Fin 2), (∀ x, x ∈ C → x ∉ D) →
+    ∀ C D : Set (Fin 2), Disjoint C D →
       (sys.ge C D ↔ (measure_fin2 a ha ha1).inducedGe C D) := by
-  intro C D hdisj
+  intro C D hCD
+  have hdisj : ∀ x ∈ C, x ∉ D := fun x hx => Set.disjoint_left.mp hCD hx
   rcases set_fin2_eq C with rfl | rfl | rfl | rfl <;>
   rcases set_fin2_eq D with rfl | rfl | rfl | rfl
   -- ∅ vs ∅
@@ -470,8 +461,7 @@ private theorem fin2_dispatch (sys : EpistemicSystemFA (Fin 2))
 
 -- ── Card 2: Main theorem ───────────────────────────
 
-theorem theorem8a_fin2 (sys : EpistemicSystemFA (Fin 2)) :
-    ∃ (m : FinAddMeasure (Fin 2)), ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
+theorem representable_fin2 (sys : EpistemicSystemFA (Fin 2)) : Representable sys := by
   by_cases h_null0 : sys.ge ∅ {(0 : Fin 2)}
   · -- Case 1: ge ∅ {0} → a = 0
     have h_nnull1 : ¬sys.ge ∅ {(1 : Fin 2)} := fun h => not_both_null_fin2 sys ⟨h_null0, h⟩
@@ -531,35 +521,18 @@ theorem theorem8a_fin2 (sys : EpistemicSystemFA (Fin 2)) :
 
 -- ── Transport + Permutation infrastructure ────────────
 
-noncomputable def transportFA {W α : Type*} (e : W ≃ α)
-    (sys : EpistemicSystemFA W) : EpistemicSystemFA α where
-  ge := fun A B => sys.ge (e.symm '' A) (e.symm '' B)
-  refl := fun A => sys.refl _
-  mono := fun A B hAB => sys.mono _ _ (Set.image_mono hAB)
-  bottom := by
-    show sys.ge (e.symm '' Set.univ) (e.symm '' ∅)
-    rw [Set.image_univ_of_surjective e.symm.surjective, Set.image_empty]
-    exact sys.bottom
-  nonTrivial := by
-    show ¬sys.ge (e.symm '' ∅) (e.symm '' Set.univ)
-    rw [Set.image_empty, Set.image_univ_of_surjective e.symm.surjective]
-    exact sys.nonTrivial
-  total := fun A B => sys.total _ _
-  trans := fun A B C h1 h2 => sys.trans _ _ _ h1 h2
-  additive := fun A B => by
-    show sys.ge (e.symm '' A) (e.symm '' B) ↔
-         sys.ge (e.symm '' (A \ B)) (e.symm '' (B \ A))
-    rw [Set.image_diff e.symm.injective, Set.image_diff e.symm.injective]
-    exact sys.additive _ _
+def transportFA {W α : Type*} (e : W ≃ α)
+    (sys : EpistemicSystemFA W) : EpistemicSystemFA α :=
+  comapFA e.symm e.symm.injective sys
+    (by rw [Equiv.range_eq_univ]; exact sys.nonTrivial)
 
-noncomputable def transportMeasure {W α : Type*}
+def transportMeasure {W α : Type*}
     (e : W ≃ α) (m : FinAddMeasure α) : FinAddMeasure W where
   mu := fun A => m.mu (e '' A)
   nonneg := fun A => m.nonneg _
   additive := fun A B hdisj => by
     rw [Set.image_union]
-    exact m.additive _ _ (fun x ⟨a, ha, hea⟩ ⟨b, hb, heb⟩ =>
-      hdisj a ha (e.injective (hea ▸ heb) ▸ hb))
+    exact m.additive _ _ ((Set.disjoint_image_iff e.injective).mpr hdisj)
   total := by
     rw [Set.image_univ_of_surjective e.surjective]
     exact m.total
@@ -570,7 +543,7 @@ theorem transfer_repr {W α : Type*}
     ∀ A B : Set W, sys.ge A B ↔ (transportMeasure e m).inducedGe A B := by
   intro A B
   have h := hm (e '' A) (e '' B)
-  simp only [transportFA, Equiv.symm_image_image] at h
+  simp only [transportFA, comapFA, Equiv.symm_image_image] at h
   exact h
 
 /-- Null pattern transport: j is null in `transportFA σ sys` iff `σ.symm j` is null in `sys`. -/
@@ -588,16 +561,88 @@ theorem perm_null_convert {n : ℕ} (σ : Fin n ≃ Fin n)
     (transportFA σ sys).ge ∅ {j} ↔ sys.ge ∅ {k} := by
   rw [perm_null_iff, hk]
 
-/-- Permutation transport for representability: if `transportFA σ sys` is representable,
-    then so is `sys`. -/
-theorem perm_repr {n : ℕ} (σ : Fin n ≃ Fin n) (sys : EpistemicSystemFA (Fin n))
-    (h : ∃ m : FinAddMeasure (Fin n),
-         ∀ A B, (transportFA σ sys).ge A B ↔ m.inducedGe A B) :
-    ∃ m : FinAddMeasure (Fin n), ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
+/-- Representability transports backward along any equivalence. -/
+theorem perm_repr {W α : Type*} (σ : W ≃ α) (sys : EpistemicSystemFA W)
+    (h : Representable (transportFA σ sys)) : Representable sys := by
   obtain ⟨m, hm⟩ := h
   exact ⟨transportMeasure σ m, transfer_repr σ sys m hm⟩
 
+-- ── Null-atom padding: Theorem 8b at every cardinality ≥ 5 ──
 
+/-- Pad an FA system with one null atom: comparisons on `Fin (n + 1)` are decided
+    by the preimage restriction to the first `n` atoms. -/
+def padFA {n : ℕ} (sys : EpistemicSystemFA (Fin n)) : EpistemicSystemFA (Fin (n + 1)) where
+  ge A B := sys.ge (Fin.castSucc ⁻¹' A) (Fin.castSucc ⁻¹' B)
+  refl _ := sys.refl _
+  mono _ _ hAB := sys.mono _ _ (Set.preimage_mono hAB)
+  bottom := by
+    show sys.ge (Fin.castSucc ⁻¹' Set.univ) (Fin.castSucc ⁻¹' ∅)
+    rw [Set.preimage_univ, Set.preimage_empty]
+    exact sys.bottom
+  nonTrivial := by
+    show ¬sys.ge (Fin.castSucc ⁻¹' ∅) (Fin.castSucc ⁻¹' Set.univ)
+    rw [Set.preimage_univ, Set.preimage_empty]
+    exact sys.nonTrivial
+  total _ _ := sys.total _ _
+  trans _ _ _ h1 h2 := sys.trans _ _ _ h1 h2
+  additive A B := by
+    show sys.ge _ _ ↔ sys.ge _ _
+    rw [Set.preimage_diff, Set.preimage_diff]
+    exact sys.additive _ _
 
+/-- The padded atom is null. -/
+theorem padFA_last_null {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :
+    (padFA sys).ge ∅ {Fin.last n} := by
+  show sys.ge (Fin.castSucc ⁻¹' ∅) (Fin.castSucc ⁻¹' {Fin.last n})
+  rw [Set.preimage_empty, show Fin.castSucc ⁻¹' {Fin.last n} = (∅ : Set (Fin n)) from
+    Set.eq_empty_of_forall_notMem fun i hi => (Fin.castSucc_lt_last i).ne hi]
+  exact sys.refl ∅
+
+/-- Padding reflects representability: a measure for `padFA sys` assigns the
+    padded atom measure zero, so its `Fin.castSucc`-image restriction represents
+    `sys`. -/
+theorem representable_of_padFA {n : ℕ} {sys : EpistemicSystemFA (Fin n)}
+    (h : Representable (padFA sys)) : Representable sys := by
+  obtain ⟨m, hm⟩ := h
+  have hinj := Fin.castSucc_injective n
+  have hlast : m.mu {Fin.last n} = 0 := by
+    have h0 : m.mu ∅ ≥ m.mu {Fin.last n} := (hm _ _).mp (padFA_last_null sys)
+    rw [m.mu_empty] at h0
+    linarith [m.nonneg {Fin.last n}]
+  have hdisj : Disjoint (Fin.castSucc '' (Set.univ : Set (Fin n))) {Fin.last n} :=
+    Set.disjoint_singleton_right.mpr fun ⟨i, _, hi⟩ => (Fin.castSucc_lt_last i).ne hi
+  have hcover : Fin.castSucc '' (Set.univ : Set (Fin n)) ∪ {Fin.last n} = Set.univ := by
+    rw [Set.image_univ]
+    ext i
+    simp only [Set.mem_union, Set.mem_range, Set.mem_singleton_iff, Set.mem_univ, iff_true]
+    rcases Fin.eq_castSucc_or_eq_last i with ⟨j, rfl⟩ | rfl
+    · exact Or.inl ⟨j, rfl⟩
+    · exact Or.inr rfl
+  have htotal : m.mu (Fin.castSucc '' (Set.univ : Set (Fin n))) = 1 := by
+    have := m.additive _ _ hdisj
+    rw [hcover, m.total, hlast, add_zero] at this
+    linarith
+  refine ⟨{
+    mu := fun A => m.mu (Fin.castSucc '' A)
+    nonneg := fun A => m.nonneg _
+    additive := fun A B hd => by
+      rw [Set.image_union]
+      exact m.additive _ _ ((Set.disjoint_image_iff hinj).mpr hd)
+    total := htotal
+  }, fun A B => ?_⟩
+  have key := hm (Fin.castSucc '' A) (Fin.castSucc '' B)
+  rwa [show (padFA sys).ge (Fin.castSucc '' A) (Fin.castSucc '' B) ↔ sys.ge A B from by
+    show sys.ge (Fin.castSucc ⁻¹' (Fin.castSucc '' A)) _ ↔ _
+    rw [Set.preimage_image_eq A hinj, Set.preimage_image_eq B hinj]] at key
+
+/-- **Theorem 8b at every cardinality**: for `n ≥ 5` there is a non-representable
+    FA system on `Fin n` — the KPS counterexample, padded with null atoms. -/
+theorem exists_nonrepresentable_fin {n : ℕ} (h : 5 ≤ n) :
+    ∃ sys : EpistemicSystemFA (Fin n), ¬Representable sys := by
+  induction n, h using Nat.le_induction with
+  | base => exact ⟨kpsSystemFA, kps_not_representable⟩
+  | succ n _ ih =>
+    obtain ⟨sys, hsys⟩ := ih
+    exact ⟨padFA sys, fun h => hsys (representable_of_padFA h)⟩
 
 end Core.Scale

--- a/Linglib/Studies/HollidayIcard2013.lean
+++ b/Linglib/Studies/HollidayIcard2013.lean
@@ -100,13 +100,9 @@ theorem fa_qualAdd_complete {W : Type*} [Fintype W] (sys : EpistemicSystemFA W) 
 /-- **Theorem 8** ([kraft-pratt-seidenberg-1959]): every FA system on `Fin n`
     is representable by a finitely additive measure iff `n < 5`. -/
 theorem fa_representable_iff_card_lt_five (n : ℕ) :
-    (∀ sys : EpistemicSystemFA (Fin n), Representable sys) ↔ n < 5 := by
-  constructor
-  · intro h
-    by_contra hge
-    obtain ⟨sys, hsys⟩ := exists_nonrepresentable_fin (n := n) (by omega)
-    exact hsys (h sys)
-  · intro h sys
-    exact representable_of_card_lt_five sys (by simpa using h)
+    (∀ sys : EpistemicSystemFA (Fin n), Representable sys) ↔ n < 5 :=
+  ⟨fun h => by_contra fun hge =>
+      let ⟨sys, hsys⟩ := exists_nonrepresentable_fin (n := n) (by omega); hsys (h sys),
+    fun h sys => representable_of_card_lt_five sys (by simpa using h)⟩
 
 end HollidayIcard2013

--- a/Linglib/Studies/HollidayIcard2013.lean
+++ b/Linglib/Studies/HollidayIcard2013.lean
@@ -1,0 +1,112 @@
+import Linglib.Core.Scales.EpistemicScale.Entailments
+import Linglib.Core.Scales.EpistemicScale.Completeness
+
+/-!
+# Holliday & Icard (2013): Measure semantics for epistemic comparatives
+
+[holliday-icard-2013] ask which semantics for the epistemic comparative
+*at least as likely as* matches speakers' inference judgments. The benchmark
+is measure semantics: *φ is at least as likely as ψ* is true iff μ(φ) ≥ μ(ψ)
+for a probability measure μ over the worlds compatible with the relevant
+evidence.
+
+The paper's argument, formalized on the `Core/Scales/EpistemicScale` substrate:
+
+1. **The disjunction problem** (Fact 1). Kratzer-style world-ordering
+   semantics — the *l*-lifting of a world order to propositions, due to
+   [lewis-1973] — validates the patterns I1–I3 that measure semantics
+   refutes. I1 is the signature case: from *φ ≿ ψ* and *φ ≿ χ* it licenses
+   *φ ≿ ψ ∨ χ*, predicting that a fair die's showing one is at least as
+   likely as its showing an even number. (`disjunction_problem`,
+   `measures_refute_I_patterns`)
+2. **The m-lifting repair** (Fact 5). Requiring *distinct* dominating
+   witnesses — an injection rather than a choice function — yields a lifting
+   that agrees with measure semantics on every pattern in the paper's
+   Figure 1. (`mLift_validates_V11_V12_V13`, `mLift_refutes_I_patterns`)
+3. **Completeness for qualitative additivity** (Theorem 6; [van-der-hoek-1996]).
+   The logic FA is sound and complete for qualitatively additive measures.
+   (`fa_qualAdd_complete`)
+4. **FA vs. finite additivity** (Theorem 8; [kraft-pratt-seidenberg-1959]).
+   FA and the finitely-additive logic FP∞ coincide exactly below five worlds:
+   the KPS ordering separates them at every |W| ≥ 5.
+   (`fa_representable_iff_card_lt_five`)
+
+See also [yalcin-2010] for the inference-pattern inventory V1–V13/I1–I3 and
+[halpern-2003] for the l-lifting's completeness.
+-/
+
+namespace HollidayIcard2013
+
+open Core.Scale ComparativeProbability
+
+/-! ### Fact 1: the disjunction problem -/
+
+/-- **Fact 1** (the disjunction problem): the l-lifting of any reflexive world
+    order validates all three measure-invalid patterns I1–I3. -/
+theorem disjunction_problem {W : Type*} (ge_w : W → W → Prop)
+    (hRefl : ∀ w, ge_w w w) :
+    patternI1 (dominationLift ge_w) ∧ patternI2 (dominationLift ge_w) ∧
+    patternI3 (dominationLift ge_w) :=
+  ⟨dominationLift_I1 ge_w, dominationLift_I2 ge_w hRefl, dominationLift_I3 ge_w hRefl⟩
+
+/-- Measure semantics refutes each of I1–I3 (uniform measure on three worlds). -/
+theorem measures_refute_I_patterns :
+    (∃ m : FinAddMeasure (Fin 3), ¬patternI1 m.inducedGe) ∧
+    (∃ m : FinAddMeasure (Fin 3), ¬patternI2 m.inducedGe) ∧
+    (∃ m : FinAddMeasure (Fin 3), ¬patternI3 m.inducedGe) :=
+  ⟨measure_not_I1, measure_not_I2, measure_not_I3⟩
+
+/-- The l-lifting also misses two valid patterns: V11 and V13 fail. -/
+theorem lLift_refutes_V11_V13 :
+    (∃ (W : Type) (ge_w : W → W → Prop),
+      (∀ w, ge_w w w) ∧ ¬patternV11 (dominationLift ge_w)) ∧
+    (∃ (W : Type) (ge_w : W → W → Prop),
+      (∀ w, ge_w w w) ∧ ¬patternV13 (dominationLift ge_w)) :=
+  ⟨dominationLift_not_V11, dominationLift_not_V13⟩
+
+/-! ### Fact 5: the m-lifting matches measure semantics -/
+
+/-- **Fact 5**, validity half: on a finite preorder the m-lifting validates the
+    distinctive patterns V11–V13 (V1–V7 hold for any world relation). -/
+theorem mLift_validates_V11_V12_V13 {W : Type*} [Finite W] (ge_w : W → W → Prop)
+    (hRefl : ∀ w, ge_w w w)
+    (hTrans : ∀ u v w, ge_w u v → ge_w v w → ge_w u w) :
+    patternV11 (matchingLift ge_w) ∧ patternV12 (matchingLift ge_w) ∧
+    patternV13 (matchingLift ge_w) :=
+  ⟨matchingLift_V11 ge_w hRefl hTrans, matchingLift_V12 ge_w hRefl hTrans,
+   matchingLift_V13 ge_w hRefl⟩
+
+/-- **Fact 5**, invalidity half: the m-lifting refutes I1–I3, dissolving the
+    disjunction problem. -/
+theorem mLift_refutes_I_patterns :
+    (∃ (W : Type) (ge_w : W → W → Prop),
+      (∀ w, ge_w w w) ∧ ¬patternI1 (matchingLift ge_w)) ∧
+    (∃ (W : Type) (ge_w : W → W → Prop),
+      (∀ w, ge_w w w) ∧ ¬patternI2 (matchingLift ge_w)) ∧
+    (∃ (W : Type) (ge_w : W → W → Prop),
+      (∀ w, ge_w w w) ∧ ¬patternI3 (matchingLift ge_w)) :=
+  ⟨matchingLift_not_I1, matchingLift_not_I2, matchingLift_not_I3⟩
+
+/-! ### Theorem 6: completeness for qualitatively additive measures -/
+
+/-- **Theorem 6** ([van-der-hoek-1996]): every FA system is represented by a
+    qualitatively additive measure. -/
+theorem fa_qualAdd_complete {W : Type*} [Fintype W] (sys : EpistemicSystemFA W) :
+    ∃ m : QualAddMeasure W, ∀ A B, sys.ge A B ↔ m.inducedGe A B :=
+  exists_qualAddMeasure_repr sys
+
+/-! ### Theorem 8: FA = FP∞ exactly below five worlds -/
+
+/-- **Theorem 8** ([kraft-pratt-seidenberg-1959]): every FA system on `Fin n`
+    is representable by a finitely additive measure iff `n < 5`. -/
+theorem fa_representable_iff_card_lt_five (n : ℕ) :
+    (∀ sys : EpistemicSystemFA (Fin n), Representable sys) ↔ n < 5 := by
+  constructor
+  · intro h
+    by_contra hge
+    obtain ⟨sys, hsys⟩ := exists_nonrepresentable_fin (n := n) (by omega)
+    exact hsys (h sys)
+  · intro h sys
+    exact representable_of_card_lt_five sys (by simpa using h)
+
+end HollidayIcard2013


### PR DESCRIPTION
Mathematical audit of the EpistemicScale stack, −900 LOC net while adding content.

- paper-faithful `QualAddMeasure` (μ(∅) = 0 via affine renormalisation of the Theorem 6 construction); Scott's theorem as an iff with a single Farkas pass; `padFA` null-atom padding giving Theorem 8b at every |W| ≥ 5; `comapFA`/`Representable`; Jeffrey's rule packaged as a `FinAddMeasure`; all `maxHeartbeats` dropped
- adds `Studies/HollidayIcard2013.lean` consuming the substrate (disjunction problem, m-lift matrix, FA = FP∞ dichotomy)