### PR TITLE
refactor(Core/UD): unify Word features into UD.MorphFeatures

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -8,7 +8,7 @@ and their interfaces. See README.md for documentation links.
 import Linglib.Features.Dimension
 import Linglib.Features.Gender
 import Linglib.Core.Valence
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Typology.NegativeConcord
 import Linglib.Typology.PolarityItem
 import Linglib.Typology.Negation
@@ -38,7 +38,7 @@ import Linglib.Core.Logic.Team.Closure
 import Linglib.Core.Logic.Team.Definability
 import Linglib.Features.Acceptability
 import Linglib.Semantics.Dynamic.ParameterizedUpdate
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Core.Tree
 import Linglib.Features.Coordination
 import Linglib.Core.Logic.Duality

--- a/Linglib/Core/Tree.lean
+++ b/Linglib/Core/Tree.lean
@@ -1,6 +1,6 @@
 import Mathlib.Data.List.Infix
 import Mathlib.Algebra.Free
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Core.Order.Tree
 
 /-!

--- a/Linglib/Core/UD/Basic.lean
+++ b/Linglib/Core/UD/Basic.lean
@@ -326,6 +326,10 @@ structure MorphFeatures where
   definite : Option Definite := none
   degree   : Option Degree   := none
   pronType : Option PronType := none
+  /-- Reflexive (UD `Reflex=Yes`); `false` = feature absent. Distinguishes a reflexive
+      anaphor from a plain personal pronoun; not an agreement feature, so not consulted
+      by `compatible`. -/
+  reflex   : Bool            := false
   person   : Option Person   := none
   verbForm : Option VerbForm := none
   tense    : Option Tense    := none
@@ -337,6 +341,11 @@ structure MorphFeatures where
 
 /-- Empty feature bundle -/
 def MorphFeatures.empty : MorphFeatures := {}
+
+/-- Is this bundle wh-marked — an interrogative or relative pro-form? Derived from
+    `pronType` (UD has no standalone wh feature; wh-ness *is* `PronType ∈ {Int, Rel}`). -/
+def MorphFeatures.isWh (f : MorphFeatures) : Bool :=
+  f.pronType == some .Int || f.pronType == some .Rel
 
 /-- Check if two feature bundles are compatible (unify where both specified) -/
 def MorphFeatures.compatible (f1 f2 : MorphFeatures) : Bool :=
@@ -363,6 +372,7 @@ def MorphFeatures.unify (f1 f2 : MorphFeatures) : Option MorphFeatures :=
       definite := f1.definite <|> f2.definite
       degree   := f1.degree   <|> f2.degree
       pronType := f1.pronType <|> f2.pronType
+      reflex   := f1.reflex   || f2.reflex
       person   := f1.person   <|> f2.person
       verbForm := f1.verbForm <|> f2.verbForm
       tense    := f1.tense    <|> f2.tense

--- a/Linglib/Core/UD/Word.lean
+++ b/Linglib/Core/UD/Word.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Core.Valence
 
 /-!
@@ -6,7 +6,8 @@ import Linglib.Core.Valence
 [biberauer-roberts-2014] [dryer-1992]
 
 The lexical unit and its building blocks: morphological feature types (aliased
-to Universal Dependencies), the `Features` bundle, and the `Word` structure.
+to Universal Dependencies) and the `Word` structure. A word's morphology is one
+`UD.MorphFeatures` bundle — there is no separate word-level feature record.
 
 ## Provenance
 
@@ -117,41 +118,32 @@ inductive HeadDirection where
   deriving Repr, DecidableEq
 
 -- ============================================================================
--- Feature Bundle and Word
+-- Word
 -- ============================================================================
 
-/-- Feature bundle for words. Uses aliased UD types. -/
-structure Features where
-  wh : Bool := false
-  finite : Bool := true
-  number : Option Number := none
-  person : Option Person := none
-  case_ : Option UD.Case := none
-  /-- Grammatical gender (UD.Gender). Carried on the word so φ-agreement is
-      feature-based, not recovered from surface form. -/
-  gender : Option UD.Gender := none
-  valence : Option Valence := none
-  voice : Option Voice := none
-  vform : Option VForm := none
-  tense : Option Tense := none
-  countable : Option MassCount := none  -- for count vs mass nouns
-  /-- Pronoun type (UD `PronType`: personal, reciprocal, interrogative, …). Carried
-      so a pro-form's binding class is read off its own morphology, not its surface form. -/
-  pronType : Option UD.PronType := none
-  /-- Reflexive morphology (UD `Reflex=Yes`). The one binding-relevant feature `PronType`
-      does not encode; distinguishes a reflexive anaphor from a plain personal pronoun. -/
-  reflex : Bool := false
-  deriving Repr, DecidableEq
+/-- A word: the surface-token interface between the lexicon and token-level engines —
+    surface form, UD category, and UD morphology (one `UD.MorphFeatures` bundle; there is no
+    separate word-level feature record), plus lexical valence, the one non-morphological
+    property a Fragment-free engine reads off the token (DG subcategorization).
 
-/-- A word: form + category + features. -/
+    **Admission rule**: a property belongs on `Word` iff a Fragment-free token-level engine
+    reads it; otherwise it lives on the typed lexical carrier (`Pronoun`, `NounEntry`, …) and
+    is consumed via the capability mixins. Identity caveat: `BEq` is form + category, so
+    homographs collapse; a CoNLL-U `lemma` field is the known fix, deferred until a consumer
+    needs it. -/
 structure Word where
   form : String
   cat : UD.UPOS
-  features : Features := {}
+  features : UD.MorphFeatures := {}
+  /-- Lexical valence (subcategorization frame) — lexical, not UD morphology; read by the
+      DG engine off the token. TODO: migrate off `Word` by having the DG engine consume
+      subcategorization from the lexical carrier via a capability mixin (as binding did for
+      `bindingClass`), leaving `Word` the pure CoNLL-U token. -/
+  valence : Option Valence := none
   deriving Repr
 
 /-- Convenience constructor for a featureless word (form + category only). -/
-def Word.mk' (form : String) (cat : UD.UPOS) : Word := ⟨form, cat, {}⟩
+def Word.mk' (form : String) (cat : UD.UPOS) : Word := { form := form, cat := cat }
 
 /-- The φ-feature subset (person, number, gender) of a word, as a
     `UD.MorphFeatures` bundle. -/
@@ -176,8 +168,8 @@ instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
 /-- Derive a passive variant: sets voice to passive, valence to intransitive.
     Used to compose with `VerbEntry.toWordPastPart` for passive constructions. -/
 def Word.asPassive (w : Word) : Word :=
-  { w with features := { w.features with
-      valence := some .intransitive, voice := some Voice.passive } }
+  { w with valence := some .intransitive,
+           features := { w.features with voice := some Voice.passive } }
 
 instance : BEq Word where
   beq w1 w2 := w1.form == w2.form && w1.cat == w2.cat

--- a/Linglib/Discourse/KOS/Grammar.lean
+++ b/Linglib/Discourse/KOS/Grammar.lean
@@ -136,7 +136,7 @@ def jo : DialogueSign String where
 def left : DialogueSign String where
   phon := "left"
   pos := .VERB
-  head := { vform := .finite }
+  head := { verbForm := .finite }
   cont := "leave(x)"
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Discourse/KOS/Grammar.lean
+++ b/Linglib/Discourse/KOS/Grammar.lean
@@ -136,7 +136,7 @@ def jo : DialogueSign String where
 def left : DialogueSign String where
   phon := "left"
   pos := .VERB
-  head := { verbForm := .finite }
+  head := { vform := .finite }
   cont := "leave(x)"
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Features/Case.lean
+++ b/Linglib/Features/Case.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Finset.Card
 import Mathlib.Order.Lattice
 import Mathlib.Tactic.DeriveFintype
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 
 /-!
 # Case — Feature Taxonomy

--- a/Linglib/Features/Gender.lean
+++ b/Linglib/Features/Gender.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Features.PrivativePair
 
 /-!

--- a/Linglib/Features/Number.lean
+++ b/Linglib/Features/Number.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Features.PrivativePair
 
 /-!

--- a/Linglib/Features/OntologicalCategory.lean
+++ b/Linglib/Features/OntologicalCategory.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Features.Prominence
 
 /-!

--- a/Linglib/Features/Person.lean
+++ b/Linglib/Features/Person.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Features.PrivativePair
 

--- a/Linglib/Fragments/Chichewa/Reciprocals.lean
+++ b/Linglib/Fragments/Chichewa/Reciprocals.lean
@@ -23,7 +23,8 @@ def reciprocalAffix : MorphRule Bool :=
   { category := .valence
   , value := "reciprocal"
   , formRule := fun stem => stem ++ "an"
-  , featureRule := fun f => { f with valence := some .intransitive }
+  , featureRule := id
+  , valenceRule := fun _ => some .intransitive
   , semEffect := id
   }
 
@@ -32,7 +33,8 @@ def reflexivePrefix : MorphRule Bool :=
   { category := .valence
   , value := "reflexive"
   , formRule := fun stem => "dzi" ++ stem
-  , featureRule := fun f => { f with valence := some .intransitive }
+  , featureRule := id
+  , valenceRule := fun _ => some .intransitive
   , semEffect := id
   }
 

--- a/Linglib/Fragments/Dargwa/Agreement.lean
+++ b/Linglib/Fragments/Dargwa/Agreement.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Prominence
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.Gender
 
 /-!

--- a/Linglib/Fragments/Dutch/Nouns.lean
+++ b/Linglib/Fragments/Dutch/Nouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Kinds.NominalMappingParameter
 
 /-!

--- a/Linglib/Fragments/English/Auxiliaries.lean
+++ b/Linglib/Fragments/English/Auxiliaries.lean
@@ -226,7 +226,7 @@ def AuxEntry.toWord (a : AuxEntry) : Word :=
   { form := a.form
   , cat := .AUX
   , features := {
-      verbForm := some .finite
+      verbForm := some .Fin
       , person := a.person
       , number := a.number
     }

--- a/Linglib/Fragments/English/Auxiliaries.lean
+++ b/Linglib/Fragments/English/Auxiliaries.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Modality.ModalTypes
 import Linglib.Features.Register
 
@@ -226,7 +226,7 @@ def AuxEntry.toWord (a : AuxEntry) : Word :=
   { form := a.form
   , cat := .AUX
   , features := {
-      finite := true
+      verbForm := some .finite
       , person := a.person
       , number := a.number
     }

--- a/Linglib/Fragments/English/Complementizers.lean
+++ b/Linglib/Fragments/English/Complementizers.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # English Complementizers Lexicon Fragment

--- a/Linglib/Fragments/English/Determiners.lean
+++ b/Linglib/Fragments/English/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Quantification.Lexicon
 
 /-!

--- a/Linglib/Fragments/English/FunctionWords.lean
+++ b/Linglib/Fragments/English/FunctionWords.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # English Miscellaneous Function Words Fragment

--- a/Linglib/Fragments/English/Modifiers/Adjectives.lean
+++ b/Linglib/Fragments/English/Modifiers/Adjectives.lean
@@ -18,7 +18,7 @@ Both share scale type and antonym information, but serve different grammatical f
 
 -/
 
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.PropertyDomain
 import Linglib.Morphology.Exponence
 import Linglib.Morphology.DegreeContainment

--- a/Linglib/Fragments/English/Nouns.lean
+++ b/Linglib/Fragments/English/Nouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.Gender
 import Linglib.Morphology.Exponence
 import Linglib.Semantics.Kinds.NominalMappingParameter
@@ -190,7 +190,6 @@ def NounEntry.toWordSg (n : NounEntry) : Word :=
   , cat := if n.proper then .PROPN else .NOUN
   , features := {
       number := some .sg
-    , countable := if n.proper then none else some n.countable
     , person := if n.proper then some .third else none
     , gender := n.gender.bind (·.toUDGender)
     }
@@ -203,7 +202,6 @@ def NounEntry.toWordPl (n : NounEntry) : Word :=
   , cat := .NOUN
   , features := {
       number := some .pl
-    , countable := some n.countable
     }
   }
 
@@ -216,7 +214,6 @@ def NounEntry.toStem {α : Type} (n : NounEntry) : Morphology.Stem (α → Bool)
   { lemma_ := n.formSg
   , cat := if n.proper then .PROPN else .NOUN
   , baseFeatures := { number := some .Sing
-                    , countable := if n.proper then none else some n.countable
                     , person := if n.proper then some .third else none }
   , paradigm :=
       if n.countable == .count && !n.proper then

--- a/Linglib/Fragments/English/Nouns.lean
+++ b/Linglib/Fragments/English/Nouns.lean
@@ -189,7 +189,7 @@ def NounEntry.toWordSg (n : NounEntry) : Word :=
   { form := n.formSg
   , cat := if n.proper then .PROPN else .NOUN
   , features := {
-      number := some .sg
+      number := some .Sing
     , person := if n.proper then some .third else none
     , gender := n.gender.bind (·.toUDGender)
     }
@@ -201,7 +201,7 @@ def NounEntry.toWordPl (n : NounEntry) : Word :=
   { form := (n.formPl.getD (n.formSg ++ "s"))
   , cat := .NOUN
   , features := {
-      number := some .pl
+      number := some .Plur
     }
   }
 

--- a/Linglib/Fragments/English/NumeralModifiers.lean
+++ b/Linglib/Fragments/English/NumeralModifiers.lean
@@ -18,7 +18,7 @@ from "up to" (positive), predicting divergent framing effects.
 
 -/
 
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.PropertyDomain
 import Linglib.Features.Valence
 import Linglib.Semantics.Numerals.Basic

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -3325,12 +3325,12 @@ def lookup (form : String) : Option VerbEntry :=
 def VerbEntry.toWord3sg (v : VerbEntry) : Word :=
   { form := v.form3sg
   , cat := .VERB
+  , valence := some (complementToValence v.complementType)
   , features := {
-      valence := some (complementToValence v.complementType)
-      , number := some .sg
+      number := some .sg
       , person := some .third
       , voice := some .active
-      , vform := some .finite
+      , verbForm := some .finite
       , tense := some .present
     }
   }
@@ -3339,9 +3339,9 @@ def VerbEntry.toWord3sg (v : VerbEntry) : Word :=
 def VerbEntry.toWordPl (v : VerbEntry) : Word :=
   { form := v.form
   , cat := .VERB
+  , valence := some (complementToValence v.complementType)
   , features := {
-      valence := some (complementToValence v.complementType)
-      , number := some .pl
+      number := some .pl
       , tense := some .present
     }
   }
@@ -3350,9 +3350,9 @@ def VerbEntry.toWordPl (v : VerbEntry) : Word :=
 def VerbEntry.toWordBase (v : VerbEntry) : Word :=
   { form := v.form
   , cat := .VERB
+  , valence := some (complementToValence v.complementType)
   , features := {
-      valence := some (complementToValence v.complementType)
-      , vform := some .infinitive
+      verbForm := some .infinitive
     }
   }
 
@@ -3360,9 +3360,9 @@ def VerbEntry.toWordBase (v : VerbEntry) : Word :=
 def VerbEntry.toWordPast (v : VerbEntry) : Word :=
   { form := v.formPast
   , cat := .VERB
+  , valence := some (complementToValence v.complementType)
   , features := {
-      valence := some (complementToValence v.complementType)
-      , vform := some .finite
+      verbForm := some .finite
       , voice := some .active
       , tense := some .past
     }
@@ -3375,9 +3375,9 @@ def VerbEntry.toWordPast (v : VerbEntry) : Word :=
 def VerbEntry.toWordPastPart (v : VerbEntry) : Word :=
   { form := v.formPastPart
   , cat := .VERB
+  , valence := some (complementToValence v.complementType)
   , features := {
-      valence := some (complementToValence v.complementType)
-      , vform := some .pastParticiple
+      verbForm := some .pastParticiple
     }
   }
 
@@ -3385,9 +3385,9 @@ def VerbEntry.toWordPastPart (v : VerbEntry) : Word :=
 def VerbEntry.toWordPresPart (v : VerbEntry) : Word :=
   { form := v.formPresPart
   , cat := .VERB
+  , valence := some (complementToValence v.complementType)
   , features := {
-      valence := some (complementToValence v.complementType)
-      , vform := some .presParticiple
+      verbForm := some .presParticiple
     }
   }
 
@@ -3512,26 +3512,26 @@ theorem forget_entails_not_complement_derived :
 def VerbEntry.toStem {σ : Type} (v : VerbEntry) : Morphology.Stem σ :=
   { lemma_ := v.form
   , cat := .VERB
-  , baseFeatures := { valence := some (complementToValence v.complementType)
-                    , vform := some .infinitive }
+  , baseFeatures := { verbForm := some .infinitive }
+  , baseValence := some (complementToValence v.complementType)
   , paradigm :=
     [ { category := .agreement .subj, value := "3sg"
       , formRule := λ _ => v.form3sg
       , featureRule := λ f => { f with number := some .Sing
                                      , person := some .third
-                                     , vform := some .finite }
+                                     , verbForm := some .finite }
       , semEffect := id, delegatedSemantics := true }
     , { category := .tense, value := "past"
       , formRule := λ _ => v.formPast
-      , featureRule := λ f => { f with vform := some .finite }
+      , featureRule := λ f => { f with verbForm := some .finite }
       , semEffect := id, delegatedSemantics := true }
     , { category := .tense, value := "pastpart"
       , formRule := λ _ => v.formPastPart
-      , featureRule := λ f => { f with vform := some .pastParticiple }
+      , featureRule := λ f => { f with verbForm := some .pastParticiple }
       , semEffect := id, delegatedSemantics := true }
     , { category := .aspect, value := "prespart"
       , formRule := λ _ => v.formPresPart
-      , featureRule := λ f => { f with vform := some .presParticiple }
+      , featureRule := λ f => { f with verbForm := some .presParticiple }
       , semEffect := id, delegatedSemantics := true }
     ] }
 

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -3327,11 +3327,11 @@ def VerbEntry.toWord3sg (v : VerbEntry) : Word :=
   , cat := .VERB
   , valence := some (complementToValence v.complementType)
   , features := {
-      number := some .sg
+      number := some .Sing
       , person := some .third
-      , voice := some .active
-      , verbForm := some .finite
-      , tense := some .present
+      , voice := some .Act
+      , verbForm := some .Fin
+      , tense := some .Pres
     }
   }
 
@@ -3341,8 +3341,8 @@ def VerbEntry.toWordPl (v : VerbEntry) : Word :=
   , cat := .VERB
   , valence := some (complementToValence v.complementType)
   , features := {
-      number := some .pl
-      , tense := some .present
+      number := some .Plur
+      , tense := some .Pres
     }
   }
 
@@ -3352,7 +3352,7 @@ def VerbEntry.toWordBase (v : VerbEntry) : Word :=
   , cat := .VERB
   , valence := some (complementToValence v.complementType)
   , features := {
-      verbForm := some .infinitive
+      verbForm := some .Inf
     }
   }
 
@@ -3362,9 +3362,9 @@ def VerbEntry.toWordPast (v : VerbEntry) : Word :=
   , cat := .VERB
   , valence := some (complementToValence v.complementType)
   , features := {
-      verbForm := some .finite
-      , voice := some .active
-      , tense := some .past
+      verbForm := some .Fin
+      , voice := some .Act
+      , tense := some .Past
     }
   }
 
@@ -3377,7 +3377,7 @@ def VerbEntry.toWordPastPart (v : VerbEntry) : Word :=
   , cat := .VERB
   , valence := some (complementToValence v.complementType)
   , features := {
-      verbForm := some .pastParticiple
+      verbForm := some .Part
     }
   }
 
@@ -3387,7 +3387,7 @@ def VerbEntry.toWordPresPart (v : VerbEntry) : Word :=
   , cat := .VERB
   , valence := some (complementToValence v.complementType)
   , features := {
-      verbForm := some .presParticiple
+      verbForm := some .Part
     }
   }
 
@@ -3512,26 +3512,26 @@ theorem forget_entails_not_complement_derived :
 def VerbEntry.toStem {σ : Type} (v : VerbEntry) : Morphology.Stem σ :=
   { lemma_ := v.form
   , cat := .VERB
-  , baseFeatures := { verbForm := some .infinitive }
+  , baseFeatures := { verbForm := some .Inf }
   , baseValence := some (complementToValence v.complementType)
   , paradigm :=
     [ { category := .agreement .subj, value := "3sg"
       , formRule := λ _ => v.form3sg
       , featureRule := λ f => { f with number := some .Sing
                                      , person := some .third
-                                     , verbForm := some .finite }
+                                     , verbForm := some .Fin }
       , semEffect := id, delegatedSemantics := true }
     , { category := .tense, value := "past"
       , formRule := λ _ => v.formPast
-      , featureRule := λ f => { f with verbForm := some .finite }
+      , featureRule := λ f => { f with verbForm := some .Fin }
       , semEffect := id, delegatedSemantics := true }
     , { category := .tense, value := "pastpart"
       , formRule := λ _ => v.formPastPart
-      , featureRule := λ f => { f with verbForm := some .pastParticiple }
+      , featureRule := λ f => { f with verbForm := some .Part }
       , semEffect := id, delegatedSemantics := true }
     , { category := .aspect, value := "prespart"
       , formRule := λ _ => v.formPresPart
-      , featureRule := λ f => { f with verbForm := some .presParticiple }
+      , featureRule := λ f => { f with verbForm := some .Part }
       , semEffect := id, delegatedSemantics := true }
     ] }
 

--- a/Linglib/Fragments/English/Pronouns.lean
+++ b/Linglib/Fragments/English/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.Case
 import Linglib.Features.Gender
 import Linglib.Syntax.Pronoun.Basic

--- a/Linglib/Fragments/Farsi/Determiners.lean
+++ b/Linglib/Fragments/Farsi/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Quantification.ChoiceFunction
 import Linglib.Semantics.Modality.ModalTypes
 import Mathlib.Data.Rat.Defs

--- a/Linglib/Fragments/French/Determiners.lean
+++ b/Linglib/Fragments/French/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Quantification.Lexicon
 
 /-!

--- a/Linglib/Fragments/French/Nouns.lean
+++ b/Linglib/Fragments/French/Nouns.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Gender
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Kinds.NominalMappingParameter
 
 /-! # French Noun Lexicon Fragment

--- a/Linglib/Fragments/Ga/Basic.lean
+++ b/Linglib/Fragments/Ga/Basic.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Gender
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Gã Fragment

--- a/Linglib/Fragments/Greek/StandardModern/Reciprocals.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Reciprocals.lean
@@ -28,7 +28,8 @@ def nonactiveVoiceSuffix : MorphRule Bool :=
   { category := .voice
   , value := "nonactive"
   , formRule := fun stem => stem ++ "ome"
-  , featureRule := fun f => { f with valence := some .intransitive }
+  , featureRule := id
+  , valenceRule := fun _ => some .intransitive
   , semEffect := id
   }
 

--- a/Linglib/Fragments/Italian/Nouns.lean
+++ b/Linglib/Fragments/Italian/Nouns.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Gender
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Kinds.NominalMappingParameter
 
 /-! # Italian Noun Lexicon Fragment

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -1,6 +1,6 @@
 import Linglib.Syntax.Pronoun.Basic
 import Linglib.Syntax.Pronoun.Capabilities
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-! # Italian Pronoun and Clitic Fragment
 

--- a/Linglib/Fragments/Japanese/Determiners.lean
+++ b/Linglib/Fragments/Japanese/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Fragments.English.Determiners
 
 /-! # Japanese Quantifier Fragment

--- a/Linglib/Fragments/Japanese/Nouns.lean
+++ b/Linglib/Fragments/Japanese/Nouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Typology.ClassifierSystem
 import Linglib.Fragments.Japanese.Classifier
 import Linglib.Semantics.Kinds.NominalMappingParameter

--- a/Linglib/Fragments/Jarawara/PossessedNouns.lean
+++ b/Linglib/Fragments/Jarawara/PossessedNouns.lean
@@ -1,6 +1,6 @@
 import Linglib.Morphology.DM.NominalStructure
 import Linglib.Typology.Possession
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.Gender
 
 /-!

--- a/Linglib/Fragments/Mandarin/Determiners.lean
+++ b/Linglib/Fragments/Mandarin/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Typology.ClassifierSystem
 import Linglib.Fragments.English.Determiners
 import Linglib.Fragments.Mandarin.Classifiers

--- a/Linglib/Fragments/Mandarin/Nouns.lean
+++ b/Linglib/Fragments/Mandarin/Nouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Typology.ClassifierSystem
 import Linglib.Fragments.Mandarin.Classifiers
 import Linglib.Semantics.Kinds.NominalMappingParameter

--- a/Linglib/Fragments/Mandarin/Reciprocals.lean
+++ b/Linglib/Fragments/Mandarin/Reciprocals.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Mandarin Reciprocal Fragment
@@ -34,11 +34,11 @@ def daLaiDaQu : CompoundRecip :=
 
 /-- 互相 hùxiāng — adverb 'mutually'. -/
 def huxiang : Word :=
-  ⟨"hùxiāng", .ADV, {}⟩
+  { form :="hùxiāng", cat := .ADV, features := {}}
 
 /-- 自己 zìjǐ — reflexive pronoun (for contrast). -/
 def ziji : Word :=
-  ⟨"zìjǐ", .PRON, { person := some .third }⟩
+  { form :="zìjǐ", cat := .PRON, features := { person := some .third }}
 
 /-- Compound reciprocal form is distinct from reflexive. -/
 theorem recip_distinct_from_reflexive :

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Case
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 import Linglib.Typology.Extraction

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -440,7 +440,7 @@ theorem setB_3sg : setBExponent.realize (.pn .third .Sing) = some defaultSetB :=
     Elsewhere; [scott-2023] Ch. 4) is theory and stays in the study. -/
 theorem erg_1sg_from_phi :
     setAExponent.realizeFor
-      ⟨"", .PRON, { person := some .first, number := some .sg }⟩ = some "n-/w-" := by
+      { form :="", cat := .PRON, features := { person := some .first, number := some .sg }} = some "n-/w-" := by
   rfl
 
 end Mam

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -440,7 +440,7 @@ theorem setB_3sg : setBExponent.realize (.pn .third .Sing) = some defaultSetB :=
     Elsewhere; [scott-2023] Ch. 4) is theory and stays in the study. -/
 theorem erg_1sg_from_phi :
     setAExponent.realizeFor
-      { form :="", cat := .PRON, features := { person := some .first, number := some .sg }} = some "n-/w-" := by
+      { form :="", cat := .PRON, features := { person := some .first, number := some .Sing }} = some "n-/w-" := by
   rfl
 
 end Mam

--- a/Linglib/Fragments/Mayan/Mam/ExtractionMorphology.lean
+++ b/Linglib/Fragments/Mayan/Mam/ExtractionMorphology.lean
@@ -1,5 +1,5 @@
 import Linglib.Typology.Extraction
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Mam Extraction Morphology Fragment [elkins-torrence-brown-2026]

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Case
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Syntax.Case.Alignment
 import Linglib.Syntax.Agreement.Paradigm

--- a/Linglib/Fragments/Mixtec/SMPM/Basic.lean
+++ b/Linglib/Fragments/Mixtec/SMPM/Basic.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Gender
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Syntax.Pronoun.Basic
 
 /-!

--- a/Linglib/Fragments/NezPerce/ClausalEmbedding.lean
+++ b/Linglib/Fragments/NezPerce/ClausalEmbedding.lean
@@ -1,5 +1,5 @@
 import Linglib.Typology.Complementation
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 
 /-!
 # Nez Perce Clausal Embedding Inventory

--- a/Linglib/Fragments/Nungon/MedialVerbs.lean
+++ b/Linglib/Fragments/Nungon/MedialVerbs.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 
 /-!
 # Nungon Medial Verb Morphology [sarvasy-2017]

--- a/Linglib/Fragments/Slavic/Czech/Determiners.lean
+++ b/Linglib/Fragments/Slavic/Czech/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Negation.CzechNegation
 
 /-!

--- a/Linglib/Fragments/Spanish/Clitics.lean
+++ b/Linglib/Fragments/Spanish/Clitics.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Spanish Clitic Paradigm

--- a/Linglib/Fragments/Swahili/Reciprocals.lean
+++ b/Linglib/Fragments/Swahili/Reciprocals.lean
@@ -24,7 +24,8 @@ def reciprocalAffix : MorphRule Bool :=
   { category := .valence
   , value := "reciprocal"
   , formRule := fun stem => stem ++ "an"
-  , featureRule := fun f => { f with valence := some .intransitive }
+  , featureRule := id
+  , valenceRule := fun _ => some .intransitive
   , semEffect := id
   }
 
@@ -33,7 +34,8 @@ def reflexivePrefix : MorphRule Bool :=
   { category := .valence
   , value := "reflexive"
   , formRule := fun stem => "ji" ++ stem
-  , featureRule := fun f => { f with valence := some .intransitive }
+  , featureRule := id
+  , valenceRule := fun _ => some .intransitive
   , semEffect := id
   }
 

--- a/Linglib/Fragments/Wambaya/Reciprocals.lean
+++ b/Linglib/Fragments/Wambaya/Reciprocals.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Wambaya Reciprocal Fragment
@@ -24,7 +24,7 @@ namespace Wambaya.Reciprocals
     The gloss value represents the morpheme; surface allomorphs vary
     by auxiliary paradigm. -/
 def rrMorpheme : Word :=
-  ⟨"-ngg-", .PART, {}⟩
+  { form :="-ngg-", cat := .PART, features := {}}
 
 /-- The same morpheme serves both reciprocal and reflexive functions. -/
 def isIdenticalToReflexive : Bool := true

--- a/Linglib/Fragments/Yoruba/FocusParticles.lean
+++ b/Linglib/Fragments/Yoruba/FocusParticles.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Yorùbá Focus Particles [aremu-2026]

--- a/Linglib/Morphology/MorphRule.lean
+++ b/Linglib/Morphology/MorphRule.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Syntax.Agreement.Controller
 
 /-!
@@ -306,7 +306,12 @@ structure MorphRule (σ : Type) where
   /-- How the surface form changes -/
   formRule : String → String
   /-- How morphosyntactic features change -/
-  featureRule : Features → Features
+  featureRule : UD.MorphFeatures → UD.MorphFeatures
+  /-- How lexical valence changes — `id` except for valence-changing morphology
+      (reciprocal, passive, causative affixes), where subcategorization change is the
+      rule's whole point. Valence is lexical, not UD morphology, so it is its own
+      effect channel rather than a `featureRule` component. -/
+  valenceRule : Option Valence → Option Valence := fun v => v
   /-- Semantic effect (`id` when meaning is delegated to a higher layer) -/
   semEffect : σ → σ
   /-- Is the word-level semantic contribution delegated to a higher
@@ -323,22 +328,26 @@ structure Stem (σ : Type) where
   /-- Syntactic category -/
   cat : UD.UPOS
   /-- Base morphosyntactic features -/
-  baseFeatures : Features := {}
+  baseFeatures : UD.MorphFeatures := {}
+  /-- Base lexical valence (subcategorization) — lexical, beside the morphology. -/
+  baseValence : Option Valence := none
   /-- Available inflectional rules -/
   paradigm : List (MorphRule σ)
 
 variable {σ : Type}
 
-/-- Apply a morphological rule to generate an inflected form + meaning. -/
+/-- Apply a morphological rule to generate an inflected form + meaning. Threads
+    morphology only; a rule's `valenceRule` acts on `Stem.baseValence` at the consumer
+    that builds `Word`s. -/
 def Stem.inflect (s : Stem σ) (rule : MorphRule σ) (baseMeaning : σ) :
-    String × Features × σ :=
+    String × UD.MorphFeatures × σ :=
   ( rule.formRule s.lemma_
   , rule.featureRule s.baseFeatures
   , rule.semEffect baseMeaning )
 
 /-- Generate all forms in the paradigm (base + inflected). -/
 def Stem.allForms (s : Stem σ) (baseMeaning : σ) :
-    List (String × Features × σ) :=
+    List (String × UD.MorphFeatures × σ) :=
   (s.lemma_, s.baseFeatures, baseMeaning) ::
     s.paradigm.map (s.inflect · baseMeaning)
 

--- a/Linglib/Morphology/Paradigm.lean
+++ b/Linglib/Morphology/Paradigm.lean
@@ -135,7 +135,7 @@ def ParadigmSystem.isTransparent {n : Nat} {Form : Type} [BEq Form] [DecidableEq
     `String`-typed surface forms. -/
 def ParadigmSystem.fromStems {σ : Type} (stems : List (Morphology.Stem σ))
     (baseMeaning : σ) (numCells : Nat)
-    (cellExtractor : List (String × Features × σ) → Fin numCells → String) :
+    (cellExtractor : List (String × UD.MorphFeatures × σ) → Fin numCells → String) :
     ParadigmSystem numCells String :=
   let allParadigms := stems.map λ s =>
     let forms := s.allForms baseMeaning

--- a/Linglib/Paradigms/AcceptabilityJudgment.lean
+++ b/Linglib/Paradigms/AcceptabilityJudgment.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Tactic.NormNum
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.ClauseForm
 
 /-!

--- a/Linglib/Phenomena/Anaphora/Coreference.lean
+++ b/Linglib/Phenomena/Anaphora/Coreference.lean
@@ -19,18 +19,18 @@ open Paradigms.AcceptabilityJudgment
 
 namespace Phenomena.Anaphora.Coreference
 
-private def john : Word := { form :="John", cat := .PROPN, features := { number := some .sg, person := some .third, gender := some .Masc }}
-private def sees : Word := { form :="sees", cat := .VERB, valence := some .transitive, features := { number := some .sg, person := some .third }}
-private def himself : Word := { form :="himself", cat := .PRON, features := { person := some .third, number := some .sg, gender := some .Masc, reflex := true }}
-private def mary : Word := { form :="Mary", cat := .PROPN, features := { number := some .sg, person := some .third, gender := some .Fem }}
-private def herself : Word := { form :="herself", cat := .PRON, features := { person := some .third, number := some .sg, gender := some .Fem, reflex := true }}
-private def they : Word := { form :="they", cat := .PRON, features := { person := some .third, number := some .pl, case_ := some .nom }}
-private def see : Word := { form :="see", cat := .VERB, valence := some .transitive, features := { number := some .pl }}
-private def themselves : Word := { form :="themselves", cat := .PRON, features := { person := some .third, number := some .pl, reflex := true }}
-private def him : Word := { form :="him", cat := .PRON, features := { person := some .third, number := some .sg, case_ := some .acc, gender := some .Masc }}
-private def her : Word := { form :="her", cat := .PRON, features := { person := some .third, number := some .sg, case_ := some .acc, gender := some .Fem }}
-private def he : Word := { form :="he", cat := .PRON, features := { person := some .third, number := some .sg, case_ := some .nom, gender := some .Masc }}
-private def them : Word := { form :="them", cat := .PRON, features := { person := some .third, number := some .pl, case_ := some .acc }}
+private def john : Word := { form :="John", cat := .PROPN, features := { number := some .Sing, person := some .third, gender := some .Masc }}
+private def sees : Word := { form :="sees", cat := .VERB, valence := some .transitive, features := { number := some .Sing, person := some .third }}
+private def himself : Word := { form :="himself", cat := .PRON, features := { person := some .third, number := some .Sing, gender := some .Masc, reflex := true }}
+private def mary : Word := { form :="Mary", cat := .PROPN, features := { number := some .Sing, person := some .third, gender := some .Fem }}
+private def herself : Word := { form :="herself", cat := .PRON, features := { person := some .third, number := some .Sing, gender := some .Fem, reflex := true }}
+private def they : Word := { form :="they", cat := .PRON, features := { person := some .third, number := some .Plur, case_ := some .nom }}
+private def see : Word := { form :="see", cat := .VERB, valence := some .transitive, features := { number := some .Plur }}
+private def themselves : Word := { form :="themselves", cat := .PRON, features := { person := some .third, number := some .Plur, reflex := true }}
+private def him : Word := { form :="him", cat := .PRON, features := { person := some .third, number := some .Sing, case_ := some .acc, gender := some .Masc }}
+private def her : Word := { form :="her", cat := .PRON, features := { person := some .third, number := some .Sing, case_ := some .acc, gender := some .Fem }}
+private def he : Word := { form :="he", cat := .PRON, features := { person := some .third, number := some .Sing, case_ := some .nom, gender := some .Masc }}
+private def them : Word := { form :="them", cat := .PRON, features := { person := some .third, number := some .Plur, case_ := some .acc }}
 
 /-- Reflexives require local c-commanding antecedent. -/
 def reflexiveCoreferenceData : PhenomenonData := {
@@ -121,11 +121,11 @@ def complementaryDistributionData : PhenomenonData := {
 -- Reciprocal Coreference Data
 -- ============================================================================
 
-private def sam : Word := { form :="Sam", cat := .PROPN, features := { number := some .sg, person := some .third }}
-private def pat : Word := { form :="Pat", cat := .PROPN, features := { number := some .sg, person := some .third }}
+private def sam : Word := { form :="Sam", cat := .PROPN, features := { number := some .Sing, person := some .third }}
+private def pat : Word := { form :="Pat", cat := .PROPN, features := { number := some .Sing, person := some .third }}
 private def and_ : Word := { form :="and", cat := .CCONJ, features := {}}
 private def saw : Word := { form :="saw", cat := .VERB, valence := some .transitive}
-private def eachOther : Word := { form :="each other", cat := .PRON, features := { person := some .third, number := some .pl }}
+private def eachOther : Word := { form :="each other", cat := .PRON, features := { person := some .third, number := some .Plur }}
 
 /-- Reciprocals require a plural/coordinated antecedent and local binding. -/
 def reciprocalCoreferenceData : PhenomenonData := {

--- a/Linglib/Phenomena/Anaphora/Coreference.lean
+++ b/Linglib/Phenomena/Anaphora/Coreference.lean
@@ -19,18 +19,18 @@ open Paradigms.AcceptabilityJudgment
 
 namespace Phenomena.Anaphora.Coreference
 
-private def john : Word := ⟨"John", .PROPN, { number := some .sg, person := some .third, gender := some .Masc }⟩
-private def sees : Word := ⟨"sees", .VERB, { valence := some .transitive, number := some .sg, person := some .third }⟩
-private def himself : Word := ⟨"himself", .PRON, { person := some .third, number := some .sg, gender := some .Masc, reflex := true }⟩
-private def mary : Word := ⟨"Mary", .PROPN, { number := some .sg, person := some .third, gender := some .Fem }⟩
-private def herself : Word := ⟨"herself", .PRON, { person := some .third, number := some .sg, gender := some .Fem, reflex := true }⟩
-private def they : Word := ⟨"they", .PRON, { person := some .third, number := some .pl, case_ := some .nom }⟩
-private def see : Word := ⟨"see", .VERB, { valence := some .transitive, number := some .pl }⟩
-private def themselves : Word := ⟨"themselves", .PRON, { person := some .third, number := some .pl, reflex := true }⟩
-private def him : Word := ⟨"him", .PRON, { person := some .third, number := some .sg, case_ := some .acc, gender := some .Masc }⟩
-private def her : Word := ⟨"her", .PRON, { person := some .third, number := some .sg, case_ := some .acc, gender := some .Fem }⟩
-private def he : Word := ⟨"he", .PRON, { person := some .third, number := some .sg, case_ := some .nom, gender := some .Masc }⟩
-private def them : Word := ⟨"them", .PRON, { person := some .third, number := some .pl, case_ := some .acc }⟩
+private def john : Word := { form :="John", cat := .PROPN, features := { number := some .sg, person := some .third, gender := some .Masc }}
+private def sees : Word := { form :="sees", cat := .VERB, valence := some .transitive, features := { number := some .sg, person := some .third }}
+private def himself : Word := { form :="himself", cat := .PRON, features := { person := some .third, number := some .sg, gender := some .Masc, reflex := true }}
+private def mary : Word := { form :="Mary", cat := .PROPN, features := { number := some .sg, person := some .third, gender := some .Fem }}
+private def herself : Word := { form :="herself", cat := .PRON, features := { person := some .third, number := some .sg, gender := some .Fem, reflex := true }}
+private def they : Word := { form :="they", cat := .PRON, features := { person := some .third, number := some .pl, case_ := some .nom }}
+private def see : Word := { form :="see", cat := .VERB, valence := some .transitive, features := { number := some .pl }}
+private def themselves : Word := { form :="themselves", cat := .PRON, features := { person := some .third, number := some .pl, reflex := true }}
+private def him : Word := { form :="him", cat := .PRON, features := { person := some .third, number := some .sg, case_ := some .acc, gender := some .Masc }}
+private def her : Word := { form :="her", cat := .PRON, features := { person := some .third, number := some .sg, case_ := some .acc, gender := some .Fem }}
+private def he : Word := { form :="he", cat := .PRON, features := { person := some .third, number := some .sg, case_ := some .nom, gender := some .Masc }}
+private def them : Word := { form :="them", cat := .PRON, features := { person := some .third, number := some .pl, case_ := some .acc }}
 
 /-- Reflexives require local c-commanding antecedent. -/
 def reflexiveCoreferenceData : PhenomenonData := {
@@ -121,11 +121,11 @@ def complementaryDistributionData : PhenomenonData := {
 -- Reciprocal Coreference Data
 -- ============================================================================
 
-private def sam : Word := ⟨"Sam", .PROPN, { number := some .sg, person := some .third }⟩
-private def pat : Word := ⟨"Pat", .PROPN, { number := some .sg, person := some .third }⟩
-private def and_ : Word := ⟨"and", .CCONJ, {}⟩
-private def saw : Word := ⟨"saw", .VERB, { valence := some .transitive }⟩
-private def eachOther : Word := ⟨"each other", .PRON, { person := some .third, number := some .pl }⟩
+private def sam : Word := { form :="Sam", cat := .PROPN, features := { number := some .sg, person := some .third }}
+private def pat : Word := { form :="Pat", cat := .PROPN, features := { number := some .sg, person := some .third }}
+private def and_ : Word := { form :="and", cat := .CCONJ, features := {}}
+private def saw : Word := { form :="saw", cat := .VERB, valence := some .transitive}
+private def eachOther : Word := { form :="each other", cat := .PRON, features := { person := some .third, number := some .pl }}
 
 /-- Reciprocals require a plural/coordinated antecedent and local binding. -/
 def reciprocalCoreferenceData : PhenomenonData := {

--- a/Linglib/Phenomena/Anaphora/DonkeyAnaphora.lean
+++ b/Linglib/Phenomena/Anaphora/DonkeyAnaphora.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.Definiteness
 import Linglib.Core.Nominal.Determiner
 import Linglib.Fragments.German.Definiteness

--- a/Linglib/Phenomena/Attitudes/ConjunctionDistribution.lean
+++ b/Linglib/Phenomena/Attitudes/ConjunctionDistribution.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-! # Conjunction Distribution: Empirical Data
 

--- a/Linglib/Phenomena/Attitudes/IntentionalIdentity.lean
+++ b/Linglib/Phenomena/Attitudes/IntentionalIdentity.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Intentional Identity Data [chatzikyriakidis-etal-2025]

--- a/Linglib/Phenomena/AuxiliaryVerbs/Selection.lean
+++ b/Linglib/Phenomena/AuxiliaryVerbs/Selection.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Be/Have Auxiliary Selection in European Perfects

--- a/Linglib/Phenomena/Ellipsis/FragmentAnswers.lean
+++ b/Linglib/Phenomena/Ellipsis/FragmentAnswers.lean
@@ -27,7 +27,7 @@ Fragment answers differ from sluicing:
 
 -/
 
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 ## Connection to RSA Theory

--- a/Linglib/Phenomena/Ellipsis/NPEllipsis.lean
+++ b/Linglib/Phenomena/Ellipsis/NPEllipsis.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Quantification.BinominalDefs
 
 /-!

--- a/Linglib/Phenomena/Ellipsis/Sluicing.lean
+++ b/Linglib/Phenomena/Ellipsis/Sluicing.lean
@@ -47,7 +47,7 @@ Case matching follows from the continuation analysis:
 
 -/
 
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 namespace Phenomena.Ellipsis.Sluicing
 

--- a/Linglib/Phenomena/Ellipsis/VPEllipsis.lean
+++ b/Linglib/Phenomena/Ellipsis/VPEllipsis.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # VP Ellipsis: Empirical Data

--- a/Linglib/Phenomena/Focus/Basic.lean
+++ b/Linglib/Phenomena/Focus/Basic.lean
@@ -12,7 +12,7 @@ Empirical data on focus interpretation effects (association with focus, contrast
 
 -/
 
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.InformationStructure
 
 open Features.InformationStructure (FIPApplication)

--- a/Linglib/Phenomena/Focus/ProsodicExhaustivity.lean
+++ b/Linglib/Phenomena/Focus/ProsodicExhaustivity.lean
@@ -32,7 +32,7 @@ This phenomenon relates to mention-all vs mention-some:
 
 -/
 
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 ## Connection to RSA Theory

--- a/Linglib/Phenomena/NullSubject/Defs.lean
+++ b/Linglib/Phenomena/NullSubject/Defs.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 
 /-!
 # Subject-Context Vocabulary

--- a/Linglib/Phenomena/Politeness/Honorifics.lean
+++ b/Linglib/Phenomena/Politeness/Honorifics.lean
@@ -13,7 +13,7 @@ encode addressee features — and the morphosyntactic expression of honorifics.
 
 -/
 
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 namespace Phenomena.Politeness.Honorifics
 

--- a/Linglib/Phenomena/Questions/Basic.lean
+++ b/Linglib/Phenomena/Questions/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.OntologicalCategory
 
 /-!

--- a/Linglib/Pragmatics/Implicature/Basic.lean
+++ b/Linglib/Pragmatics/Implicature/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Entailment.Polarity
 
 /-!

--- a/Linglib/Semantics/ArgumentStructure/Defs.lean
+++ b/Linglib/Semantics/ArgumentStructure/Defs.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Events.Basic
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.ArgumentStructure.Linking
 
 /-!

--- a/Linglib/Semantics/Aspect/Composition.lean
+++ b/Linglib/Semantics/Aspect/Composition.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Aktionsart
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # VP-Level Situation Type Composition

--- a/Linglib/Semantics/Dynamic/DiscourseRef.lean
+++ b/Linglib/Semantics/Dynamic/DiscourseRef.lean
@@ -47,7 +47,7 @@ This separation enables anaphora to indefinites under negation:
 
 -/
 
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Semantics.Dynamic.Connectives.CCP
 import Mathlib.Data.Fintype.Basic
 

--- a/Linglib/Semantics/Kinds/NominalMappingParameter.lean
+++ b/Linglib/Semantics/Kinds/NominalMappingParameter.lean
@@ -35,7 +35,7 @@ come from Mathlib for free, giving us Link's semilattice directly.
 import Mathlib.Data.Set.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.UpperLower.Basic
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Core.Mereology
 import Linglib.Core.Logic.Intensional.Rigidity
 

--- a/Linglib/Semantics/Mood/ClauseType.lean
+++ b/Linglib/Semantics/Mood/ClauseType.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Mood.Basic
 import Linglib.Semantics.Mood.IllocutionaryMood
 import Linglib.Discourse.Roles
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 
 /-!
 # Clause Type: Force × Mood

--- a/Linglib/Semantics/Quantification/Lexicon.lean
+++ b/Linglib/Semantics/Quantification/Lexicon.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Quantifier lexicon — shared structure

--- a/Linglib/Semantics/TypeTheoretic/Basic.lean
+++ b/Linglib/Semantics/TypeTheoretic/Basic.lean
@@ -2,7 +2,7 @@ import Mathlib.Data.Set.Basic
 import Linglib.Core.Logic.Intensional.Rigidity
 import Linglib.Discourse.CommonGround
 import Linglib.Semantics.Presupposition.Basic
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 
 /-!
 # Type Theory with Records — Core Foundations

--- a/Linglib/Studies/AlexeyenkoZeijlstra2025.lean
+++ b/Linglib/Studies/AlexeyenkoZeijlstra2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Data.WALS.Features.F87A
 import Linglib.Syntax.Minimalist.Modification
 import Linglib.Fragments.Greek.StandardModern.AdjAgreement

--- a/Linglib/Studies/AnandHardtMcCloskey2021.lean
+++ b/Linglib/Studies/AnandHardtMcCloskey2021.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Phenomena.Ellipsis.Sluicing
 import Linglib.Syntax.Minimalist.Ellipsis.FormalMatching
 import Linglib.Syntax.Minimalist.Ellipsis.DeletionDomain

--- a/Linglib/Studies/Cacchioli2025.lean
+++ b/Linglib/Studies/Cacchioli2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Syntax.Minimalist.Agree
 import Linglib.Typology.Complementation
 import Linglib.Fragments.Tigrinya.ClausePrefixes

--- a/Linglib/Studies/DeMarneffeNivre2019.lean
+++ b/Linglib/Studies/DeMarneffeNivre2019.lean
@@ -53,21 +53,21 @@ open DepGrammar DepGrammar.LongDistance DepGrammar.Coordination
 Words: what(0) did(1) John(2) see(3). The wh-word attaches as `obj` of
 the main verb. -/
 def exWhatDidJohnSee : DepTree :=
-  { words := [⟨"what", .PRON, { wh := true }⟩, Word.mk' "did" .AUX,
+  { words := [{ form :="what", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "did" .AUX,
               Word.mk' "John" .PROPN, Word.mk' "see" .VERB]
     deps  := [⟨1, 2, .nsubj⟩, ⟨1, 3, .aux⟩, ⟨1, 0, .obj⟩]
     rootIdx := 1 }
 
 /-- "Who saw Mary?" — subject wh-question (no gap needed). -/
 def exWhoSawMary : DepTree :=
-  { words := [⟨"who", .PRON, { wh := true }⟩, Word.mk' "saw" .VERB,
+  { words := [{ form :="who", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "saw" .VERB,
               Word.mk' "Mary" .PROPN]
     deps  := [⟨1, 0, .nsubj⟩, ⟨1, 2, .obj⟩]
     rootIdx := 1 }
 
 /-- "Who did John see?" — object wh-question with `who`. -/
 def exWhoDidJohnSee : DepTree :=
-  { words := [⟨"who", .PRON, { wh := true }⟩, Word.mk' "did" .AUX,
+  { words := [{ form :="who", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "did" .AUX,
               Word.mk' "John" .PROPN, Word.mk' "see" .VERB]
     deps  := [⟨1, 2, .nsubj⟩, ⟨1, 3, .aux⟩, ⟨1, 0, .obj⟩]
     rootIdx := 1 }
@@ -118,7 +118,7 @@ def exJohnWondersIfMarySleeps : DepTree :=
 Words: John(0) wonders(1) what(2) Mary(3) saw(4). -/
 def exJohnWondersWhatMarySaw : DepTree :=
   { words := [Word.mk' "John" .PROPN, Word.mk' "wonders" .VERB,
-              ⟨"what", .PRON, { wh := true }⟩,
+              { form :="what", cat := .PRON, features := { pronType := some .Int }},
               Word.mk' "Mary" .PROPN, Word.mk' "saw" .VERB]
     deps  := [⟨1, 0, .nsubj⟩, ⟨1, 4, .ccomp⟩, ⟨4, 3, .nsubj⟩, ⟨4, 2, .obj⟩]
     rootIdx := 1 }
@@ -187,7 +187,7 @@ def exRNR_enhanced : DepGraph := enhanceSharedDeps exRNR
 
 /-- Object wh-questions have a `[wh]` filler at index 0. -/
 theorem whatDidJohnSee_has_wh :
-    exWhatDidJohnSee.words[0]?.map (·.features.wh) = some true := rfl
+    exWhatDidJohnSee.words[0]?.map (·.features.isWh) = some true := rfl
 
 /-- Subject wh-questions don't need gaps (empty gap list). -/
 theorem whoSawMary_no_gap :

--- a/Linglib/Studies/FillmoreKayOConnor1988.lean
+++ b/Linglib/Studies/FillmoreKayOConnor1988.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.Acceptability
 import Linglib.Syntax.ConstructionGrammar.Studies.FillmoreKayOConnor1988
 import Linglib.Typology.PolarityItem

--- a/Linglib/Studies/Gibson2025.lean
+++ b/Linglib/Studies/Gibson2025.lean
@@ -1,6 +1,6 @@
 import Linglib.Syntax.DependencyGrammar.Formal.HarmonicOrder
 import Linglib.Data.WALS.Features.F95A
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Gibson 2025: DLM and the Head-Direction Generalization

--- a/Linglib/Studies/Gotham2017.lean
+++ b/Linglib/Studies/Gotham2017.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Copredication: [gotham-2017]'s account + bridge data

--- a/Linglib/Studies/Haspelmath1997Polarity.lean
+++ b/Linglib/Studies/Haspelmath1997Polarity.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Data.WALS.Aggregation
 import Linglib.Data.WALS.Features.F46A
 import Linglib.Typology.PolarityItem

--- a/Linglib/Studies/KehlerRohde2013.lean
+++ b/Linglib/Studies/KehlerRohde2013.lean
@@ -1,5 +1,5 @@
 import Linglib.Discourse.Coherence
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Discourse.Centering.Rule1
 import Linglib.Discourse.Centering.Instances.GrammaticalRole
 

--- a/Linglib/Studies/Osborne2019.lean
+++ b/Linglib/Studies/Osborne2019.lean
@@ -33,7 +33,7 @@ the corresponding valency frames.
 ```
 Fragment VerbEntry.complementType ← lexical data (sleep=.none, kick=.np, give=.np_np)
     ↓ complementToValence
-VerbEntry.toWord3sg.features.valence ← intransitive / transitive / ditransitive
+VerbEntry.toWord3sg.valence ← intransitive / transitive / ditransitive
     ↓
 DepTree instances ← concrete parse trees
     ↓
@@ -97,25 +97,25 @@ private def lex_kicked : LexEntry :=
 
 /-- sleep.complementType =.none → intransitive. -/
 theorem sleep_valence_from_fragment :
-    sleeps.features.valence = some .intransitive := rfl
+    sleeps.valence = some .intransitive := rfl
 
 /-- devour.complementType =.np → transitive. -/
 theorem devour_valence_from_fragment :
-    devours.features.valence = some .transitive := rfl
+    devours.valence = some .transitive := rfl
 
 /-- give.complementType =.np_np → ditransitive. -/
 theorem give_valence_from_fragment :
-    gives.features.valence = some .ditransitive := rfl
+    gives.valence = some .ditransitive := rfl
 
 /-- kick.complementType =.np → transitive (active). -/
 theorem kick_valence_from_fragment :
-    kicked.features.valence = some .transitive := rfl
+    kicked.valence = some .transitive := rfl
 
 /-- The passive valence (intransitive) is consistent with the passive rule:
     the rule removes the obj slot from the transitive frame. -/
 theorem passive_valence_consistent :
-    kicked_pass.features.valence = some .intransitive ∧
-    kicked.features.valence = some .transitive ∧
+    kicked_pass.valence = some .intransitive ∧
+    kicked.valence = some .transitive ∧
     passiveRule.applies lex_kicked = true ∧
     (passiveRule.transform lex_kicked).argStr.slots.any (·.depType == .obj) = false :=
   ⟨rfl, rfl, rfl, rfl⟩
@@ -305,7 +305,7 @@ theorem ditrans_verb_obj_catena_not_constituent :
     7. Passive + spurious obj correctly rejected ✗ -/
 theorem valency_derivation_chain :
     -- Fragment grounding
-    kicked.features.valence = some .transitive ∧
+    kicked.valence = some .transitive ∧
     -- Active: frame ✓, subcat ✓
     satisfiesArgStr activeTree 1 argStr_VN = true ∧
     checkVerbSubcat activeTree = true ∧

--- a/Linglib/Studies/OsborneLi2023.lean
+++ b/Linglib/Studies/OsborneLi2023.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.DependencyGrammar.Basic
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Data.Examples.Schema
 import Linglib.Syntax.DependencyGrammar.Coordination
 
@@ -422,9 +422,9 @@ CRDC's contribution from other determinants of acceptability. -/
 /-- Tree for "Max and Lucie talked about him."
     `Max(0) and(1) Lucie(2) talked(3) about(4) him(5)`. -/
 def ex2a_tree : DepTree :=
-  { words := [ ⟨"Max", .PROPN, {}⟩, ⟨"and", .CCONJ, {}⟩
-             , ⟨"Lucie", .PROPN, {}⟩, ⟨"talked", .VERB, {}⟩
-             , ⟨"about", .ADP, {}⟩, ⟨"him", .PRON, {}⟩ ]
+  { words := [ { form :="Max", cat := .PROPN, features := {}}, { form :="and", cat := .CCONJ, features := {}}
+             , { form :="Lucie", cat := .PROPN, features := {}}, { form :="talked", cat := .VERB, features := {}}
+             , { form :="about", cat := .ADP, features := {}}, { form :="him", cat := .PRON, features := {}} ]
     deps  := [ ⟨3, 0, .nsubj⟩, ⟨0, 1, .cc⟩, ⟨0, 2, .conj⟩
              , ⟨3, 5, .obl⟩, ⟨5, 4, .case_⟩ ]
     rootIdx := 3 }
@@ -434,8 +434,8 @@ theorem ex2a_predicts_questionable :
 
 /-- Tree for "Max talked about himself." — non-coordinate baseline. -/
 def ex9a_tree : DepTree :=
-  { words := [ ⟨"Max", .PROPN, {}⟩, ⟨"talked", .VERB, {}⟩
-             , ⟨"about", .ADP, {}⟩, ⟨"himself", .PRON, {}⟩ ]
+  { words := [ { form :="Max", cat := .PROPN, features := {}}, { form :="talked", cat := .VERB, features := {}}
+             , { form :="about", cat := .ADP, features := {}}, { form :="himself", cat := .PRON, features := {}} ]
     deps  := [ ⟨1, 0, .nsubj⟩, ⟨1, 3, .obl⟩, ⟨3, 2, .case_⟩ ]
     rootIdx := 1 }
 
@@ -447,8 +447,8 @@ theorem ex9a_predicts_acceptable :
     Condition B, not the CRDC; here we record only that the CRDC is
     silent. -/
 def ex9b_tree : DepTree :=
-  { words := [ ⟨"Max", .PROPN, {}⟩, ⟨"talked", .VERB, {}⟩
-             , ⟨"about", .ADP, {}⟩, ⟨"him", .PRON, {}⟩ ]
+  { words := [ { form :="Max", cat := .PROPN, features := {}}, { form :="talked", cat := .VERB, features := {}}
+             , { form :="about", cat := .ADP, features := {}}, { form :="him", cat := .PRON, features := {}} ]
     deps  := [ ⟨1, 0, .nsubj⟩, ⟨1, 3, .obl⟩, ⟨3, 2, .case_⟩ ]
     rootIdx := 1 }
 
@@ -460,10 +460,10 @@ theorem ex9b_crdc_silent :
     `John` is a full valent. CRDC's permitted direction (conjunct
     anaphor of full antecedent). -/
 def ex24a_tree : DepTree :=
-  { words := [ ⟨"John", .PROPN, {}⟩, ⟨"talked", .VERB, {}⟩
-             , ⟨"about", .ADP, {}⟩, ⟨"himself", .PRON, {}⟩
-             , ⟨"and", .CCONJ, {}⟩, ⟨"his", .PRON, {}⟩
-             , ⟨"mother", .NOUN, {}⟩ ]
+  { words := [ { form :="John", cat := .PROPN, features := {}}, { form :="talked", cat := .VERB, features := {}}
+             , { form :="about", cat := .ADP, features := {}}, { form :="himself", cat := .PRON, features := {}}
+             , { form :="and", cat := .CCONJ, features := {}}, { form :="his", cat := .PRON, features := {}}
+             , { form :="mother", cat := .NOUN, features := {}} ]
     deps  := [ ⟨1, 0, .nsubj⟩, ⟨1, 3, .obl⟩, ⟨3, 2, .case_⟩
              , ⟨3, 4, .cc⟩, ⟨3, 6, .conj⟩, ⟨6, 5, .nmod⟩ ]
     rootIdx := 1 }
@@ -477,9 +477,9 @@ theorem ex24a_predicts_acceptable :
     `both...and` strengthening; the CRDC alone predicts
     `.questionable`. -/
 def ex5a_tree : DepTree :=
-  { words := [ ⟨"Both", .CCONJ, {}⟩, ⟨"John", .PROPN, {}⟩
-             , ⟨"and", .CCONJ, {}⟩, ⟨"Mary", .PROPN, {}⟩
-             , ⟨"love", .VERB, {}⟩, ⟨"him", .PRON, {}⟩ ]
+  { words := [ { form :="Both", cat := .CCONJ, features := {}}, { form :="John", cat := .PROPN, features := {}}
+             , { form :="and", cat := .CCONJ, features := {}}, { form :="Mary", cat := .PROPN, features := {}}
+             , { form :="love", cat := .VERB, features := {}}, { form :="him", cat := .PRON, features := {}} ]
     deps  := [ ⟨4, 1, .nsubj⟩, ⟨1, 0, .cc⟩, ⟨1, 2, .cc⟩
              , ⟨1, 3, .conj⟩, ⟨4, 5, .obj⟩ ]
     rootIdx := 4 }
@@ -493,10 +493,10 @@ theorem ex5a_predicts_questionable :
     coord. Permitted direction; the CRDC is silent on `him↔John`
     co-valuation because `him` is a conjunct valent (not a full valent). -/
 def ex28d_tree : DepTree :=
-  { words := [ ⟨"John", .PROPN, {}⟩, ⟨"expected", .VERB, {}⟩
-             , ⟨"Mary", .PROPN, {}⟩, ⟨"and", .CCONJ, {}⟩
-             , ⟨"him", .PRON, {}⟩, ⟨"to", .PART, {}⟩
-             , ⟨"leave", .VERB, {}⟩, ⟨"soon", .ADV, {}⟩ ]
+  { words := [ { form :="John", cat := .PROPN, features := {}}, { form :="expected", cat := .VERB, features := {}}
+             , { form :="Mary", cat := .PROPN, features := {}}, { form :="and", cat := .CCONJ, features := {}}
+             , { form :="him", cat := .PRON, features := {}}, { form :="to", cat := .PART, features := {}}
+             , { form :="leave", cat := .VERB, features := {}}, { form :="soon", cat := .ADV, features := {}} ]
     deps  := [ ⟨1, 0, .nsubj⟩, ⟨1, 2, .obj⟩, ⟨2, 3, .cc⟩
              , ⟨2, 4, .conj⟩, ⟨1, 6, .xcomp⟩, ⟨6, 5, .mark⟩
              , ⟨6, 7, .advmod⟩ ]

--- a/Linglib/Studies/RomeroHan2004.lean
+++ b/Linglib/Studies/RomeroHan2004.lean
@@ -1,5 +1,5 @@
 import Linglib.Discourse.CommonGround
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Romero & Han (2004): Negative Yes/No Questions and Epistemic Bias

--- a/Linglib/Studies/Ross1967.lean
+++ b/Linglib/Studies/Ross1967.lean
@@ -33,29 +33,29 @@ namespace Ross1967
 -- §1. Lexical entries for example sentences
 -- ============================================================================
 
-private def what : Word := ⟨"what", .PRON, { wh := true }⟩
-private def did : Word := ⟨"did", .AUX, {}⟩
-private def john : Word := ⟨"John", .DET, { number := some .sg, person := some .third }⟩
-private def buy : Word := ⟨"buy", .VERB, { valence := some .transitive, number := some .pl }⟩
-private def you : Word := ⟨"you", .DET, { person := some .second, case_ := some .nom }⟩
-private def wonder : Word := ⟨"wonder", .VERB, { valence := some .transitive, number := some .pl }⟩
-private def who : Word := ⟨"who", .PRON, { wh := true }⟩
-private def bought : Word := ⟨"bought", .VERB, { valence := some .transitive, vform := some .finite }⟩
-private def see : Word := ⟨"see", .VERB, { valence := some .transitive, number := some .pl }⟩
-private def met : Word := ⟨"met", .VERB, { valence := some .transitive, vform := some .finite }⟩
-private def man : Word := ⟨"man", .NOUN, { number := some .sg, countable := some .count }⟩
-private def that : Word := ⟨"that", .DET, { number := some .sg }⟩
-private def saw : Word := ⟨"saw", .VERB, { valence := some .transitive, vform := some .finite }⟩
-private def leave : Word := ⟨"leave", .VERB, { valence := some .intransitive, number := some .pl }⟩
-private def before : Word := ⟨"before", .ADP, {}⟩
-private def because : Word := ⟨"because", .SCONJ, {}⟩
-private def books : Word := ⟨"books", .NOUN, { number := some .pl, countable := some .count }⟩
-private def and_ : Word := ⟨"and", .CCONJ, {}⟩
-private def sell : Word := ⟨"sell", .VERB, { valence := some .transitive, number := some .pl }⟩
-private def do_ : Word := ⟨"do", .AUX, { number := some .pl }⟩
-private def the : Word := ⟨"the", .DET, {}⟩
-private def sees : Word := ⟨"sees", .VERB, { valence := some .transitive, number := some .sg, person := some .third }⟩
-private def mary : Word := ⟨"Mary", .DET, { number := some .sg, person := some .third }⟩
+private def what : Word := { form :="what", cat := .PRON, features := { pronType := some .Int }}
+private def did : Word := { form :="did", cat := .AUX, features := {}}
+private def john : Word := { form :="John", cat := .DET, features := { number := some .sg, person := some .third }}
+private def buy : Word := { form :="buy", cat := .VERB, valence := some .transitive, features := { number := some .pl }}
+private def you : Word := { form :="you", cat := .DET, features := { person := some .second, case_ := some .nom }}
+private def wonder : Word := { form :="wonder", cat := .VERB, valence := some .transitive, features := { number := some .pl }}
+private def who : Word := { form :="who", cat := .PRON, features := { pronType := some .Int }}
+private def bought : Word := { form :="bought", cat := .VERB, valence := some .transitive, features := { verbForm := some .finite }}
+private def see : Word := { form :="see", cat := .VERB, valence := some .transitive, features := { number := some .pl }}
+private def met : Word := { form :="met", cat := .VERB, valence := some .transitive, features := { verbForm := some .finite }}
+private def man : Word := { form :="man", cat := .NOUN, features := { number := some .sg }}
+private def that : Word := { form :="that", cat := .DET, features := { number := some .sg }}
+private def saw : Word := { form :="saw", cat := .VERB, valence := some .transitive, features := { verbForm := some .finite }}
+private def leave : Word := { form :="leave", cat := .VERB, valence := some .intransitive, features := { number := some .pl }}
+private def before : Word := { form :="before", cat := .ADP, features := {}}
+private def because : Word := { form :="because", cat := .SCONJ, features := {}}
+private def books : Word := { form :="books", cat := .NOUN, features := { number := some .pl }}
+private def and_ : Word := { form :="and", cat := .CCONJ, features := {}}
+private def sell : Word := { form :="sell", cat := .VERB, valence := some .transitive, features := { number := some .pl }}
+private def do_ : Word := { form :="do", cat := .AUX, features := { number := some .pl }}
+private def the : Word := { form :="the", cat := .DET, features := {}}
+private def sees : Word := { form :="sees", cat := .VERB, valence := some .transitive, features := { number := some .sg, person := some .third }}
+private def mary : Word := { form :="Mary", cat := .DET, features := { number := some .sg, person := some .third }}
 
 -- ============================================================================
 -- §2. Island constraint examples

--- a/Linglib/Studies/Ross1967.lean
+++ b/Linglib/Studies/Ross1967.lean
@@ -35,27 +35,27 @@ namespace Ross1967
 
 private def what : Word := { form :="what", cat := .PRON, features := { pronType := some .Int }}
 private def did : Word := { form :="did", cat := .AUX, features := {}}
-private def john : Word := { form :="John", cat := .DET, features := { number := some .sg, person := some .third }}
-private def buy : Word := { form :="buy", cat := .VERB, valence := some .transitive, features := { number := some .pl }}
+private def john : Word := { form :="John", cat := .DET, features := { number := some .Sing, person := some .third }}
+private def buy : Word := { form :="buy", cat := .VERB, valence := some .transitive, features := { number := some .Plur }}
 private def you : Word := { form :="you", cat := .DET, features := { person := some .second, case_ := some .nom }}
-private def wonder : Word := { form :="wonder", cat := .VERB, valence := some .transitive, features := { number := some .pl }}
+private def wonder : Word := { form :="wonder", cat := .VERB, valence := some .transitive, features := { number := some .Plur }}
 private def who : Word := { form :="who", cat := .PRON, features := { pronType := some .Int }}
-private def bought : Word := { form :="bought", cat := .VERB, valence := some .transitive, features := { verbForm := some .finite }}
-private def see : Word := { form :="see", cat := .VERB, valence := some .transitive, features := { number := some .pl }}
-private def met : Word := { form :="met", cat := .VERB, valence := some .transitive, features := { verbForm := some .finite }}
-private def man : Word := { form :="man", cat := .NOUN, features := { number := some .sg }}
-private def that : Word := { form :="that", cat := .DET, features := { number := some .sg }}
-private def saw : Word := { form :="saw", cat := .VERB, valence := some .transitive, features := { verbForm := some .finite }}
-private def leave : Word := { form :="leave", cat := .VERB, valence := some .intransitive, features := { number := some .pl }}
+private def bought : Word := { form :="bought", cat := .VERB, valence := some .transitive, features := { verbForm := some .Fin }}
+private def see : Word := { form :="see", cat := .VERB, valence := some .transitive, features := { number := some .Plur }}
+private def met : Word := { form :="met", cat := .VERB, valence := some .transitive, features := { verbForm := some .Fin }}
+private def man : Word := { form :="man", cat := .NOUN, features := { number := some .Sing }}
+private def that : Word := { form :="that", cat := .DET, features := { number := some .Sing }}
+private def saw : Word := { form :="saw", cat := .VERB, valence := some .transitive, features := { verbForm := some .Fin }}
+private def leave : Word := { form :="leave", cat := .VERB, valence := some .intransitive, features := { number := some .Plur }}
 private def before : Word := { form :="before", cat := .ADP, features := {}}
 private def because : Word := { form :="because", cat := .SCONJ, features := {}}
-private def books : Word := { form :="books", cat := .NOUN, features := { number := some .pl }}
+private def books : Word := { form :="books", cat := .NOUN, features := { number := some .Plur }}
 private def and_ : Word := { form :="and", cat := .CCONJ, features := {}}
-private def sell : Word := { form :="sell", cat := .VERB, valence := some .transitive, features := { number := some .pl }}
-private def do_ : Word := { form :="do", cat := .AUX, features := { number := some .pl }}
+private def sell : Word := { form :="sell", cat := .VERB, valence := some .transitive, features := { number := some .Plur }}
+private def do_ : Word := { form :="do", cat := .AUX, features := { number := some .Plur }}
 private def the : Word := { form :="the", cat := .DET, features := {}}
-private def sees : Word := { form :="sees", cat := .VERB, valence := some .transitive, features := { number := some .sg, person := some .third }}
-private def mary : Word := { form :="Mary", cat := .DET, features := { number := some .sg, person := some .third }}
+private def sees : Word := { form :="sees", cat := .VERB, valence := some .transitive, features := { number := some .Sing, person := some .third }}
+private def mary : Word := { form :="Mary", cat := .DET, features := { number := some .Sing, person := some .third }}
 
 -- ============================================================================
 -- §2. Island constraint examples

--- a/Linglib/Studies/SagWasowBender2003Extraction.lean
+++ b/Linglib/Studies/SagWasowBender2003Extraction.lean
@@ -133,7 +133,7 @@ theorem absolute_islands_block :
 /-- The gap introduction mechanism correctly removes complements. -/
 theorem gap_removes_complement :
     let see_ss : Synsem := { cat := .VERB, val := { subj := [.NOUN], comps := [.NOUN] } }
-    let see_w : Word := ⟨"see", .VERB, {}⟩
+    let see_w : Word := { form :="see", cat := .VERB, features := {}}
     (gapComplement see_w see_ss 0).map
       (fun p => p.1.synsem.val.comps.isEmpty && p.2.gaps == [.NOUN]) = some true := by
   decide

--- a/Linglib/Studies/TurkHirsch2026.lean
+++ b/Linglib/Studies/TurkHirsch2026.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.InformationStructure
 import Linglib.Core.Logic.Intensional.Premise
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Semantics.Alternatives.AltMeaning
 import Linglib.Semantics.Polarity.Operator
 import Linglib.Semantics.Focus.Interpretation

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Fragments.Mandarin.QuestionParticles
 import Linglib.Semantics.Modality.Kernel
 import Linglib.Features.QParticleLayer

--- a/Linglib/Syntax/Agreement/Paradigm.lean
+++ b/Linglib/Syntax/Agreement/Paradigm.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.Prominence
 
 /-!

--- a/Linglib/Syntax/Binding/Basic.lean
+++ b/Linglib/Syntax/Binding/Basic.lean
@@ -61,7 +61,7 @@ structure SimpleClause where
   subject : Word
   verb : Word
   object : Option Word
-  semanticPl : Bool := subject.features.number == some .pl
+  semanticPl : Bool := subject.features.number == some .Plur
   deriving Repr
 
 /-- The `Word` at a position, if present. -/

--- a/Linglib/Syntax/Binding/Basic.lean
+++ b/Linglib/Syntax/Binding/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.CoreferenceStatus
 
 /-!

--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -3,7 +3,7 @@ import Linglib.Syntax.ConstructionGrammar.Studies.GoldbergShirtz2025
 import Linglib.Syntax.ConstructionGrammar.Studies.FillmoreKayOConnor1988
 import Linglib.Core.CombinationKind
 import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 
 /-!
 # Argument Structure Constructions

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -1,5 +1,5 @@
 import Mathlib.Data.List.Basic
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Dependency grammar substrate
@@ -197,7 +197,7 @@ def checkVerbSubcat (t : DepTree) : Bool :=
         let subjCount := countDepsOfType t i .nsubj
         let objCount := countDepsOfType t i .obj
         let iobjCount := countDepsOfType t i .iobj
-        match w.features.valence with
+        match w.valence with
         | some .intransitive => subjCount >= 1 && objCount == 0
         | some .transitive => subjCount >= 1 && objCount == 1
         | some .ditransitive => subjCount >= 1 && objCount == 1 && iobjCount == 1

--- a/Linglib/Syntax/DependencyGrammar/Coordination.lean
+++ b/Linglib/Syntax/DependencyGrammar/Coordination.lean
@@ -88,7 +88,7 @@ def checkArgStrMatch (t : DepTree) : Bool :=
       match t.words[d.headIdx]?, t.words[d.depIdx]? with
       | some hw, some dw =>
         if hw.cat == UD.UPOS.VERB then
-          hw.features.valence == dw.features.valence
+          hw.valence == dw.valence
         else true
       | _, _ => false
     else true

--- a/Linglib/Syntax/DependencyGrammar/Formal/CoordinationParallelism.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/CoordinationParallelism.lean
@@ -114,7 +114,7 @@ def gappingPreEllipsis : DepTree :=
 /-- ATB extraction: "What did John buy and Mary sell?", symmetric
     extraction of `what` from both conjuncts. -/
 def atbExtraction : DepTree :=
-  { words := [ ⟨"what", .PRON, { wh := true }⟩, Word.mk' "did" .AUX
+  { words := [ { form :="what", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "did" .AUX
              , Word.mk' "John" .PROPN, Word.mk' "buy" .VERB
              , Word.mk' "and" .CCONJ, Word.mk' "Mary" .PROPN
              , Word.mk' "sell" .VERB ]

--- a/Linglib/Syntax/DependencyGrammar/Formal/Discontinuity.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/Discontinuity.lean
@@ -94,7 +94,7 @@ def classifyDisplacement (d : Dependency) : DisplacementDir :=
 /-- **Wh-fronting**: "What did you eat?". The catena `{what(0), eat(3)}` is
     risen — connected via `obj` but `did(1), you(2)` intervene. -/
 def whFrontingTree : DepTree :=
-  { words := [ ⟨"what", .PRON, { wh := true }⟩, Word.mk' "did" .AUX
+  { words := [ { form :="what", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "did" .AUX
              , Word.mk' "you" .PRON, Word.mk' "eat" .VERB ]
     deps := [⟨3, 2, .nsubj⟩, ⟨3, 0, .obj⟩, ⟨3, 1, .aux⟩]
     rootIdx := 3 }

--- a/Linglib/Syntax/DependencyGrammar/Formal/Government.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/Government.lean
@@ -109,13 +109,15 @@ def matchGovFeature (w : Word) (feat : GovernedFeature) (reqVal : GovernedValue)
     | some .Gen => reqVal = .gen
     | _ => true
   | .VForm =>
-    match w.features.vform with
+    match w.features.verbForm with
     | some .Inf => reqVal = .infinitive
     | some .Part => reqVal = .gerund || reqVal = .participle
     | some .Fin => reqVal = .finite || reqVal = .base
     | _ => true
   | .Finiteness =>
-    if w.features.finite then reqVal = .finite else reqVal = .nonfinite
+    -- finiteness is read off verbForm (no stored finiteness flag); only an explicit
+    -- infinitive counts as nonfinite, matching the old default-finite behavior
+    if w.features.verbForm != some .Inf then reqVal = .finite else reqVal = .nonfinite
   | .Mood => true
 
 /-- A dependency tree satisfies its government requirements when every
@@ -137,33 +139,33 @@ def checkGovernment (t : DepTree) (govReqs : List GovRequirement) : Bool :=
 /-- "She wants to go": `wants(1)` heads `she(0)` (nsubj) and `go(3)`
     (xcomp); `go(3)` heads `to(2)` (mark). -/
 def exSheWantsToGo : DepTree :=
-  { words := [ ⟨"she", .PRON, { case_ := some .Nom }⟩
-             , ⟨"wants", .VERB, { valence := some .transitive }⟩
-             , ⟨"to", .PART, {}⟩
-             , ⟨"go", .VERB, { vform := some .Inf }⟩ ]
+  { words := [ { form :="she", cat := .PRON, features := { case_ := some .Nom }}
+             , { form :="wants", cat := .VERB, valence := some .transitive}
+             , { form :="to", cat := .PART, features := {}}
+             , { form :="go", cat := .VERB, features := { verbForm := some .Inf }} ]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 3, .xcomp⟩, ⟨3, 2, .mark⟩]
     rootIdx := 1 }
 
 /-- "She enjoys swimming": `enjoys(1)` heads `she(0)` (nsubj) and
     `swimming(2)` (xcomp). -/
 def exSheEnjoysSwimming : DepTree :=
-  { words := [ ⟨"she", .PRON, { case_ := some .Nom }⟩
-             , ⟨"enjoys", .VERB, { valence := some .transitive }⟩
-             , ⟨"swimming", .VERB, { vform := some .Part }⟩ ]
+  { words := [ { form :="she", cat := .PRON, features := { case_ := some .Nom }}
+             , { form :="enjoys", cat := .VERB, valence := some .transitive}
+             , { form :="swimming", cat := .VERB, features := { verbForm := some .Part }} ]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .xcomp⟩]
     rootIdx := 1 }
 
 /-- "with him": preposition governs accusative — well-formed. -/
 def exWithHim : DepTree :=
-  { words := [ ⟨"with", .ADP, {}⟩
-             , ⟨"him", .PRON, { case_ := some .Acc }⟩ ]
+  { words := [ { form :="with", cat := .ADP, features := {}}
+             , { form :="him", cat := .PRON, features := { case_ := some .Acc }} ]
     deps := [⟨0, 1, .obj⟩]
     rootIdx := 0 }
 
 /-- "with he": preposition government violation (nominative for accusative). -/
 def exWithHe : DepTree :=
-  { words := [ ⟨"with", .ADP, {}⟩
-             , ⟨"he", .PRON, { case_ := some .Nom }⟩ ]
+  { words := [ { form :="with", cat := .ADP, features := {}}
+             , { form :="he", cat := .PRON, features := { case_ := some .Nom }} ]
     deps := [⟨0, 1, .obj⟩]
     rootIdx := 0 }
 

--- a/Linglib/Syntax/DependencyGrammar/Formal/Islands.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/Islands.lean
@@ -68,7 +68,7 @@ catena whose rising catena violates the corresponding island constraint. -/
 
 /-- DG tree for the left-branch island *"Whose do you like house?". -/
 def islandLeftBranch : DepTree :=
-  { words := [ ⟨"whose", .DET, { wh := true }⟩, Word.mk' "do" .AUX
+  { words := [ { form :="whose", cat := .DET, features := { pronType := some .Int }}, Word.mk' "do" .AUX
              , Word.mk' "you" .PRON, Word.mk' "like" .VERB
              , Word.mk' "house" .NOUN ]
     deps := [ ⟨1, 3, .ccomp⟩, ⟨1, 2, .nsubj⟩
@@ -78,7 +78,7 @@ def islandLeftBranch : DepTree :=
 /-- DG tree for the subject island *"Which car did the driver of ignore the light?"
 ([osborne-2019], §9.7, ex. 48). -/
 def islandSubject : DepTree :=
-  { words := [ ⟨"which", .DET, { wh := true }⟩, Word.mk' "car" .NOUN
+  { words := [ { form :="which", cat := .DET, features := { pronType := some .Int }}, Word.mk' "car" .NOUN
              , Word.mk' "did" .AUX, Word.mk' "the" .DET
              , Word.mk' "driver" .NOUN, Word.mk' "of" .ADP
              , Word.mk' "ignore" .VERB, Word.mk' "the" .DET
@@ -92,7 +92,7 @@ def islandSubject : DepTree :=
 /-- DG tree for the adjunct island *"What do they argue before cleaning?"
 ([osborne-2019], §9.8, ex. 50b/59, simplified). -/
 def islandAdjunct : DepTree :=
-  { words := [ ⟨"what", .PRON, { wh := true }⟩, Word.mk' "do" .AUX
+  { words := [ { form :="what", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "do" .AUX
              , Word.mk' "they" .PRON, Word.mk' "argue" .VERB
              , Word.mk' "before" .SCONJ, Word.mk' "cleaning" .VERB ]
     deps := [ ⟨1, 3, .ccomp⟩, ⟨1, 2, .nsubj⟩
@@ -102,7 +102,7 @@ def islandAdjunct : DepTree :=
 /-- DG tree for the wh-island *"Which judge might they inquire surprised?"
 ([osborne-2019], §9.9, ex. 61b', simplified). -/
 def islandWhIsland : DepTree :=
-  { words := [ ⟨"which", .DET, { wh := true }⟩, Word.mk' "judge" .NOUN
+  { words := [ { form :="which", cat := .DET, features := { pronType := some .Int }}, Word.mk' "judge" .NOUN
              , Word.mk' "might" .AUX, Word.mk' "they" .PRON
              , Word.mk' "inquire" .VERB, Word.mk' "surprised" .VERB ]
     deps := [ ⟨2, 4, .ccomp⟩, ⟨2, 3, .nsubj⟩
@@ -113,7 +113,7 @@ def islandWhIsland : DepTree :=
 /-- DG tree for the specified-NP island ??"Who did you find those pictures of?"
 ([osborne-2019], §9.6, ex. 36b). -/
 def islandSpecifiedNP : DepTree :=
-  { words := [ ⟨"who", .PRON, { wh := true }⟩, Word.mk' "did" .AUX
+  { words := [ { form :="who", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "did" .AUX
              , Word.mk' "you" .PRON, Word.mk' "find" .VERB
              , Word.mk' "those" .DET, Word.mk' "pictures" .NOUN
              , Word.mk' "of" .ADP ]

--- a/Linglib/Syntax/DependencyGrammar/Formal/NonProjective.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/NonProjective.lean
@@ -124,7 +124,7 @@ gap degree 1) covers attested data. -/
 
 /-- Minimal crossing tree: arcs `0 → 2` and `1 → 3` cross. -/
 def nonProjectiveTree : DepTree :=
-  { words := [ ⟨"A", .NOUN, {}⟩, ⟨"B", .VERB, {}⟩, ⟨"C", .NOUN, {}⟩, ⟨"D", .VERB, {}⟩ ]
+  { words := [ { form :="A", cat := .NOUN, features := {}}, { form :="B", cat := .VERB, features := {}}, { form :="C", cat := .NOUN, features := {}}, { form :="D", cat := .VERB, features := {}} ]
     deps := [ ⟨0, 2, .obj⟩, ⟨1, 3, .obj⟩ ]
     rootIdx := 0 }
 

--- a/Linglib/Syntax/DependencyGrammar/LongDistance.lean
+++ b/Linglib/Syntax/DependencyGrammar/LongDistance.lean
@@ -122,7 +122,7 @@ def isLDWellFormed (t : DepTree) (gaps : List (Nat × Nat × GapType)) : Bool :=
   gaps.all λ (fillerIdx, _, _) =>
     match t.words[fillerIdx]? with
     | some w =>
-      w.features.wh || fillerIdx < t.rootIdx ||
+      w.features.isWh || fillerIdx < t.rootIdx ||
         t.deps.any λ d => d.headIdx == fillerIdx && d.depType == .acl
     | none => false
 

--- a/Linglib/Syntax/DependencyGrammar/Nominal.lean
+++ b/Linglib/Syntax/DependencyGrammar/Nominal.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.CoreferenceStatus
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Pronouns

--- a/Linglib/Syntax/HPSG/Basic.lean
+++ b/Linglib/Syntax/HPSG/Basic.lean
@@ -3,7 +3,7 @@ HPSG formalization: typed feature structures, signs, and phrase structure schema
 [pollard-sag-1994], [sag-wasow-bender-2003], [ginzburg-sag-2000].
 -/
 
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 namespace HPSG
 

--- a/Linglib/Syntax/HPSG/HeadFiller.lean
+++ b/Linglib/Syntax/HPSG/HeadFiller.lean
@@ -306,7 +306,7 @@ private def see_word : Word := { form :="see", cat := .VERB, valence := some .tr
 private def see_synsem : Synsem :=
   { cat := .VERB, val := { subj := [.NOUN], comps := [.NOUN] } }
 
-private def john_word : Word := { form :="John", cat := .PROPN, features := { number := some .sg }}
+private def john_word : Word := { form :="John", cat := .PROPN, features := { number := some .Sing }}
 private def what_word : Word := { form :="what", cat := .PRON, features := { pronType := some .Int }}
 
 -- Step 1: Gap the complement of "see"

--- a/Linglib/Syntax/HPSG/HeadFiller.lean
+++ b/Linglib/Syntax/HPSG/HeadFiller.lean
@@ -302,12 +302,12 @@ Derivation sketch:
 section DerivationExamples
 
 -- Lexical entries for the derivation
-private def see_word : Word := ⟨"see", .VERB, { valence := some .transitive }⟩
+private def see_word : Word := { form :="see", cat := .VERB, valence := some .transitive}
 private def see_synsem : Synsem :=
   { cat := .VERB, val := { subj := [.NOUN], comps := [.NOUN] } }
 
-private def john_word : Word := ⟨"John", .PROPN, { number := some .sg }⟩
-private def what_word : Word := ⟨"what", .PRON, { wh := true }⟩
+private def john_word : Word := { form :="John", cat := .PROPN, features := { number := some .sg }}
+private def what_word : Word := { form :="what", cat := .PRON, features := { pronType := some .Int }}
 
 -- Step 1: Gap the complement of "see"
 -- gapComplement returns (gapped_sign, slash_value)

--- a/Linglib/Syntax/HPSG/RelativeClauses.lean
+++ b/Linglib/Syntax/HPSG/RelativeClauses.lean
@@ -64,10 +64,10 @@ structure Relativizer where
   modifiesCat : UD.UPOS := .NOUN
 
 /-- Standard English relativizers. -/
-def relThat : Relativizer := { word := ⟨"that", .SCONJ, {}⟩ }
-def relWho : Relativizer := { word := ⟨"who", .PRON, { wh := true }⟩ }
-def relWhich : Relativizer := { word := ⟨"which", .PRON, { wh := true }⟩ }
-def relWhom : Relativizer := { word := ⟨"whom", .PRON, { wh := true }⟩ }
+def relThat : Relativizer := { word := { form :="that", cat := .SCONJ, features := {}} }
+def relWho : Relativizer := { word := { form :="who", cat := .PRON, features := { pronType := some .Rel }} }
+def relWhich : Relativizer := { word := { form :="which", cat := .PRON, features := { pronType := some .Rel }} }
+def relWhom : Relativizer := { word := { form :="whom", cat := .PRON, features := { pronType := some .Rel }} }
 
 /-- The `RelativeClause.NPRelType` this relativizer realizes: a `wh`-pronoun
     (who/which/whom) is a relative pronoun; the complementizer "that"/∅ leaves
@@ -151,7 +151,7 @@ section DerivationExample
 
 Object relative clause: the gap is in object position of "read". -/
 
-private def read_word : Word := ⟨"read", .VERB, { valence := some .transitive }⟩
+private def read_word : Word := { form :="read", cat := .VERB, valence := some .transitive}
 private def read_synsem : Synsem :=
   { cat := .VERB, val := { subj := [.NOUN], comps := [.NOUN] } }
 
@@ -176,7 +176,7 @@ private def read_slash : SlashValue :=
 #guard read_sign.synsem.val.comps == []
 
 -- Step 2: Head-Subject with "John"
-private def john_word : Word := ⟨"John", .PROPN, {}⟩
+private def john_word : Word := { form :="John", cat := .PROPN, features := {}}
 private def john_sign : Sign := .word john_word { cat := .PROPN }
 
 private def clause_tracked : TrackedSign :=
@@ -206,7 +206,7 @@ example : relClause.realization = { position := .directObject, npRel := .gap } :
 -- We clear the slash in the relative clause result.
 
 -- Step 4: Head-Modifier with "book"
-private def book_word : Word := ⟨"book", .NOUN, {}⟩
+private def book_word : Word := { form :="book", cat := .NOUN, features := {}}
 private def book_sign : Sign := .word book_word { cat := .NOUN }
 
 -- The relative clause can modify a noun
@@ -230,7 +230,7 @@ section SubjectRelative
 
 Subject relative clause: the gap is in subject position. -/
 
-private def saw_word : Word := ⟨"saw", .VERB, { valence := some .transitive }⟩
+private def saw_word : Word := { form :="saw", cat := .VERB, valence := some .transitive}
 private def saw_synsem : Synsem :=
   { cat := .VERB, val := { subj := [.NOUN], comps := [.NOUN] } }
 
@@ -251,7 +251,7 @@ private def who_relClause : RelClauseDerivation :=
 #guard who_relClause.isMod
 #guard who_relClause.result.sign.synsem.mod == some .NOUN
 
-private def boy_word : Word := ⟨"boy", .NOUN, {}⟩
+private def boy_word : Word := { form :="boy", cat := .NOUN, features := {}}
 private def boy_sign : Sign := .word boy_word { cat := .NOUN }
 
 private def modified_boy : Option Sign :=

--- a/Linglib/Syntax/Minimalist/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Basic.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Set.Basic
 import Mathlib.Data.Multiset.Basic
 import Mathlib.Algebra.Free
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Core.Combinatorics.RootedTree.Decorated
 
 /-!

--- a/Linglib/Syntax/Minimalist/Features.lean
+++ b/Linglib/Syntax/Minimalist/Features.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Case
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.Prominence
 
 /-!

--- a/Linglib/Syntax/Pronoun/Basic.lean
+++ b/Linglib/Syntax/Pronoun/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.Case
 import Linglib.Features.Register
 import Linglib.Features.Prominence

--- a/Linglib/Syntax/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Pronoun/Capabilities.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 import Linglib.Features.CoreferenceStatus
 import Linglib.Features.Register
 import Linglib.Features.Prominence

--- a/Linglib/Syntax/WordGrammar/LexicalRules.lean
+++ b/Linglib/Syntax/WordGrammar/LexicalRules.lean
@@ -31,7 +31,7 @@ open DepGrammar (ArgStr ArgSlot Dir)
 structure LexEntry where
   form : String
   cat : UD.UPOS
-  features : Features
+  features : UD.MorphFeatures
   argStr : ArgStr
   inv : Bool := false
   deriving Repr

--- a/Linglib/Typology/Adposition.lean
+++ b/Linglib/Typology/Adposition.lean
@@ -1,5 +1,5 @@
 import Linglib.Data.WALS.Features.F85A
-import Linglib.Core.Word
+import Linglib.Core.UD.Word
 
 /-!
 # Adposition typology: shared substrate type

--- a/Linglib/Typology/AuxiliaryVerbs.lean
+++ b/Linglib/Typology/AuxiliaryVerbs.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UD
+import Linglib.Core.UD.Basic
 import Linglib.Morphology.MorphRule
 
 /-!

--- a/Linglib/Typology/ClauseChaining.lean
+++ b/Linglib/Typology/ClauseChaining.lean
@@ -1,5 +1,5 @@
-import Linglib.Core.UD
-import Linglib.Core.Word
+import Linglib.Core.UD.Basic
+import Linglib.Core.UD.Word
 
 /-! # Clause Chaining Typology [sarvasy-aikhenvald-2025] [foley-r-d-van-valin-1984] [longacre-2007]
 


### PR DESCRIPTION
Dissolves the parallel feature bundles: `Core.Word.Features` is deleted and `Word.features` is one `UD.MorphFeatures` bundle (which gains the missing UD `Reflex`); `Word` moves to `Core/UD/Word.lean` beside `Core/UD/Basic.lean` and carries an explicit admission rule (a property lives on `Word` iff a Fragment-free token-level engine reads it).

- `wh`/`finite` become derived (`pronType ∈ {Int, Rel}`, `verbForm`); `vform` → UD's `verbForm`; `countable` evicted (no token-level readers); `valence` stays as a `Word` field for the DG engine, with a TODO to migrate it to a carrier capability.
- `MorphRule` gains a dedicated `valenceRule` channel (reciprocal/passive affixes); `Stem` gains `baseValence`.
- Local builds skipped per CI-as-gate; expect CI to be authoritative.