### PR TITLE
refactor(Core/UD): drop value aliases, add carrier pronType

### DIFF
--- a/Linglib/Core/UD/Word.lean
+++ b/Linglib/Core/UD/Word.lean
@@ -35,61 +35,23 @@ Types without UD equivalents remain defined here:
 -- Aliased Types (backed by UD)
 -- ============================================================================
 
-/-- Grammatical number. Aliased to UD.Number for cross-linguistic compatibility. -/
+/-- Grammatical number. Aliased to UD.Number; constructors are UD's own
+(`.Sing`, `.Plur`, `.Dual`, …) — there are no lowercase value aliases. -/
 abbrev Number := UD.Number
 
-namespace Number
-/-- Singular (compatibility alias for UD.Number.Sing) -/
-@[match_pattern] abbrev sg : Number := .Sing
-/-- Plural (compatibility alias for UD.Number.Plur) -/
-@[match_pattern] abbrev pl : Number := .Plur
-/-- Dual (compatibility alias for UD.Number.Dual). Used for lexical
-items that morphologically restrict to two-atom domains
-(e.g. English `both`/`neither`, Slovenian dual, Icelandic `hvor`). -/
-@[match_pattern] abbrev du : Number := .Dual
-end Number
-
-/-- Grammatical person. Aliased to UD.Person for cross-linguistic compatibility.
-
-    Constructors are: `.first`, `.second`, `.third`, `.zero`
-    (no compatibility aliases needed - names match) -/
+/-- Grammatical person. Aliased to UD.Person; constructors are UD's own
+(`.first`, `.second`, `.third`, `.zero`). -/
 abbrev Person := UD.Person
 
-/-- Voice: active vs passive. Aliased to UD.Voice. -/
+/-- Voice. Aliased to UD.Voice; constructors are UD's own (`.Act`, `.Pass`, …). -/
 abbrev Voice := UD.Voice
 
-namespace Voice
-/-- Active voice (compatibility alias) -/
-abbrev active : Voice := .Act
-/-- Passive voice (compatibility alias) -/
-abbrev passive : Voice := .Pass
-end Voice
-
-/-- Verb form. Aliased to UD.VerbForm. -/
+/-- Verb form. Aliased to UD.VerbForm; constructors are UD's own
+(`.Fin`, `.Inf`, `.Part`, …). -/
 abbrev VForm := UD.VerbForm
 
-namespace VForm
-/-- Finite (compatibility alias) -/
-abbrev finite : VForm := .Fin
-/-- Infinitive (compatibility alias) -/
-abbrev infinitive : VForm := .Inf
-/-- Past participle (compatibility alias - maps to Part) -/
-abbrev pastParticiple : VForm := .Part
-/-- Present participle (compatibility alias - maps to Part) -/
-abbrev presParticiple : VForm := .Part
-end VForm
-
-/-- Tense. Aliased to UD.Tense. -/
+/-- Tense. Aliased to UD.Tense; constructors are UD's own (`.Past`, `.Pres`, `.Fut`, …). -/
 abbrev Tense := UD.Tense
-
-namespace Tense
-/-- Past tense (compatibility alias) -/
-abbrev past : Tense := .Past
-/-- Present tense (compatibility alias) -/
-abbrev present : Tense := .Pres
-/-- Future tense (compatibility alias) -/
-abbrev future : Tense := .Fut
-end Tense
 
 -- ============================================================================
 -- Types Without UD Equivalents
@@ -161,7 +123,7 @@ instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
     (detransitivization) is a frame-level fact carried by the passive analysis on
     `DepTree.frames`, not token data. Composes with `VerbEntry.toWordPastPart`. -/
 def Word.asPassive (w : Word) : Word :=
-  { w with features := { w.features with voice := some Voice.passive } }
+  { w with features := { w.features with voice := some .Pass } }
 
 instance : BEq Word where
   beq w1 w2 := w1.form == w2.form && w1.cat == w2.cat

--- a/Linglib/Fragments/Basque/Pronouns.lean
+++ b/Linglib/Fragments/Basque/Pronouns.lean
@@ -21,11 +21,11 @@ open Features.Register (Level)
 
 /-- *ni* — 1sg. -/
 def ni : PersonalPronoun :=
-  { form := "ni", person := some .first, number := some .sg }
+  { form := "ni", person := some .first, number := some .Sing }
 
 /-- *gu* — 1pl. -/
 def gu : PersonalPronoun :=
-  { form := "gu", person := some .first, number := some .pl }
+  { form := "gu", person := some .first, number := some .Plur }
 
 -- ============================================================================
 -- Second Person (T/V)
@@ -33,15 +33,15 @@ def gu : PersonalPronoun :=
 
 /-- *hi* — 2sg familiar (T form). -/
 def hi : PersonalPronoun :=
-  { form := "hi", person := some .second, number := some .sg, register := .informal }
+  { form := "hi", person := some .second, number := some .Sing, register := .informal }
 
 /-- *zu* — 2sg formal (V form). -/
 def zu : PersonalPronoun :=
-  { form := "zu", person := some .second, number := some .sg, register := .formal }
+  { form := "zu", person := some .second, number := some .Sing, register := .formal }
 
 /-- *zuek* — 2pl. -/
 def zuek : PersonalPronoun :=
-  { form := "zuek", person := some .second, number := some .pl }
+  { form := "zuek", person := some .second, number := some .Plur }
 
 -- ============================================================================
 -- Third Person
@@ -49,11 +49,11 @@ def zuek : PersonalPronoun :=
 
 /-- *hura* — 3sg. -/
 def hura : PersonalPronoun :=
-  { form := "hura", person := some .third, number := some .sg }
+  { form := "hura", person := some .third, number := some .Sing }
 
 /-- *haiek* — 3pl. -/
 def haiek : PersonalPronoun :=
-  { form := "haiek", person := some .third, number := some .pl }
+  { form := "haiek", person := some .third, number := some .Plur }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -107,8 +107,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .sg) = true ∧
-    allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .Sing) = true ∧
+    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/English/Auxiliaries.lean
+++ b/Linglib/Fragments/English/Auxiliaries.lean
@@ -177,10 +177,10 @@ def ought : AuxEntry where
 
 -- Do-support
 def do_ : AuxEntry where
-  form := "do"; auxType := .doSupport; number := some .pl
+  form := "do"; auxType := .doSupport; number := some .Plur
   negForm := some "don't"; negIrregular := true    -- [dont] not *[dunt]
 def does : AuxEntry where
-  form := "does"; auxType := .doSupport; person := some .third; number := some .sg
+  form := "does"; auxType := .doSupport; person := some .third; number := some .Sing
   negForm := some "doesn't"
 def did : AuxEntry where
   form := "did"; auxType := .doSupport; tense := some .Past
@@ -188,27 +188,27 @@ def did : AuxEntry where
 
 -- Be
 def am : AuxEntry where
-  form := "am"; auxType := .be; person := some .first; number := some .sg
+  form := "am"; auxType := .be; person := some .first; number := some .Sing
   negForm := none                                  -- *amn't: paradigm gap
 def is_ : AuxEntry where
-  form := "is"; auxType := .be; person := some .third; number := some .sg
+  form := "is"; auxType := .be; person := some .third; number := some .Sing
   negForm := some "isn't"
 def are : AuxEntry where
-  form := "are"; auxType := .be; number := some .pl
+  form := "are"; auxType := .be; number := some .Plur
   negForm := some "aren't"
 def was : AuxEntry where
-  form := "was"; auxType := .be; number := some .sg; tense := some .Past
+  form := "was"; auxType := .be; number := some .Sing; tense := some .Past
   negForm := some "wasn't"
 def were : AuxEntry where
-  form := "were"; auxType := .be; number := some .pl; tense := some .Past
+  form := "were"; auxType := .be; number := some .Plur; tense := some .Past
   negForm := some "weren't"
 
 -- Have
 def have_ : AuxEntry where
-  form := "have"; auxType := .have; number := some .pl
+  form := "have"; auxType := .have; number := some .Plur
   negForm := some "haven't"
 def has : AuxEntry where
-  form := "has"; auxType := .have; person := some .third; number := some .sg
+  form := "has"; auxType := .have; person := some .third; number := some .Sing
   negForm := some "hasn't"
 def had : AuxEntry where
   form := "had"; auxType := .have; tense := some .Past

--- a/Linglib/Fragments/English/Determiners.lean
+++ b/Linglib/Fragments/English/Determiners.lean
@@ -39,7 +39,7 @@ def none_ : QuantifierEntry :=
   { form := "none", qforce := .negative, allowsMass := true, monotonicity := .decreasing }
 
 def few : QuantifierEntry :=
-  { form := "few", qforce := .proportional, numberRestriction := some .pl
+  { form := "few", qforce := .proportional, numberRestriction := some .Plur
   , monotonicity := .decreasing }
 
 def some_ : QuantifierEntry :=
@@ -52,7 +52,7 @@ def half : QuantifierEntry :=
 def most : QuantifierEntry :=
   { form := "most"
   , qforce := .proportional
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , allowsMass := true
   , monotonicity := .increasing
   , strength := .strong  -- B&C Table II: *"There are most cats"
@@ -62,7 +62,7 @@ def most : QuantifierEntry :=
 def all : QuantifierEntry :=
   { form := "all"
   , qforce := .universal
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , allowsMass := true
   , monotonicity := .increasing
   , strength := .strong  -- B&C Table II: *"There is all cats"
@@ -72,7 +72,7 @@ def all : QuantifierEntry :=
 def every : QuantifierEntry :=
   { form := "every"
   , qforce := .universal
-  , numberRestriction := some .sg
+  , numberRestriction := some .Sing
   , monotonicity := .increasing
   , strength := .strong  -- B&C Table II: *"There is every cat"
   }
@@ -81,7 +81,7 @@ def every : QuantifierEntry :=
 def each : QuantifierEntry :=
   { form := "each"
   , qforce := .universal
-  , numberRestriction := some .sg
+  , numberRestriction := some .Sing
   , monotonicity := .increasing
   , strength := .strong  -- B&C Table II: *"There is each cat"
   }
@@ -90,7 +90,7 @@ def each : QuantifierEntry :=
 def many : QuantifierEntry :=
   { form := "many"
   , qforce := .proportional
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , monotonicity := .increasing
   }
 
@@ -142,29 +142,29 @@ def the : QuantifierEntry :=
   { form := "the", qforce := .definite, allowsMass := true, strength := .strong }
 
 def this : QuantifierEntry :=
-  { form := "this", qforce := .definite, numberRestriction := some .sg, strength := .strong }
+  { form := "this", qforce := .definite, numberRestriction := some .Sing, strength := .strong }
 
 def that : QuantifierEntry :=
-  { form := "that", qforce := .definite, numberRestriction := some .sg, strength := .strong }
+  { form := "that", qforce := .definite, numberRestriction := some .Sing, strength := .strong }
 
 def these : QuantifierEntry :=
-  { form := "these", qforce := .definite, numberRestriction := some .pl, strength := .strong }
+  { form := "these", qforce := .definite, numberRestriction := some .Plur, strength := .strong }
 
 def those : QuantifierEntry :=
-  { form := "those", qforce := .definite, numberRestriction := some .pl, strength := .strong }
+  { form := "those", qforce := .definite, numberRestriction := some .Plur, strength := .strong }
 
 def a : QuantifierEntry :=
-  { form := "a", qforce := .existential, numberRestriction := some .sg }
+  { form := "a", qforce := .existential, numberRestriction := some .Sing }
 
 def an : QuantifierEntry :=
-  { form := "an", qforce := .existential, numberRestriction := some .sg }
+  { form := "an", qforce := .existential, numberRestriction := some .Sing }
 
 /-- "both" - universal dual, presupposes exactly 2.
     K&S (83a): [_Det each of the two] ⇒ both.
     Compositional denotation `both_sem` lives in
     `Semantics.Quantification.Quantifier`.
 
-    `numberRestriction := some .du` carries the dual core concept
+    `numberRestriction := some .Dual` carries the dual core concept
     ([harbour-2014] `[−atomic, +minimal]`); the cardinality clause
     `|R| ≥ 2` on the denotation side reflects the Harbour
     `dualPredOnLattice` reading
@@ -172,7 +172,7 @@ def an : QuantifierEntry :=
 def both : QuantifierEntry :=
   { form := "both"
   , qforce := .universal
-  , numberRestriction := some .du
+  , numberRestriction := some .Dual
   , monotonicity := .increasing
   , strength := .strong  -- K&S §3.2: definite dets are strong
   }
@@ -184,7 +184,7 @@ def both : QuantifierEntry :=
 def neither : QuantifierEntry :=
   { form := "neither"
   , qforce := .negative
-  , numberRestriction := some .du
+  , numberRestriction := some .Dual
   , monotonicity := .decreasing
   , strength := .strong  -- K&S §3.3: negative strong
   }

--- a/Linglib/Fragments/English/Pronouns.lean
+++ b/Linglib/Fragments/English/Pronouns.lean
@@ -39,29 +39,29 @@ open Features (SurfaceGender)
 /-! ### Personal pronouns (`PersonalPronoun`) -/
 
 -- First person (no gender feature). `bindingClass := some .pronoun` is the PersonalPronoun default.
-def i : PersonalPronoun := { form := "I", person := some .first, number := some .sg, case_ := some .nom }
-def me : PersonalPronoun := { form := "me", person := some .first, number := some .sg, case_ := some .acc }
-def we : PersonalPronoun := { form := "we", person := some .first, number := some .pl, case_ := some .nom }
-def us : PersonalPronoun := { form := "us", person := some .first, number := some .pl, case_ := some .acc }
+def i : PersonalPronoun := { form := "I", person := some .first, number := some .Sing, case_ := some .nom }
+def me : PersonalPronoun := { form := "me", person := some .first, number := some .Sing, case_ := some .acc }
+def we : PersonalPronoun := { form := "we", person := some .first, number := some .Plur, case_ := some .nom }
+def us : PersonalPronoun := { form := "us", person := some .first, number := some .Plur, case_ := some .acc }
 
 -- Second person (no gender feature)
-def you : PersonalPronoun := { form := "you", person := some .second, number := some .sg }
-def you_pl : PersonalPronoun := { form := "you", person := some .second, number := some .pl }
+def you : PersonalPronoun := { form := "you", person := some .second, number := some .Sing }
+def you_pl : PersonalPronoun := { form := "you", person := some .second, number := some .Plur }
 
 -- Third person
-def he : PersonalPronoun := { form := "he", person := some .third, number := some .sg, case_ := some .nom, gender := some .masculine }
-def him : PersonalPronoun := { form := "him", person := some .third, number := some .sg, case_ := some .acc, gender := some .masculine }
-def she : PersonalPronoun := { form := "she", person := some .third, number := some .sg, case_ := some .nom, gender := some .feminine }
-def her : PersonalPronoun := { form := "her", person := some .third, number := some .sg, case_ := some .acc, gender := some .feminine }
-def it : PersonalPronoun := { form := "it", person := some .third, number := some .sg, gender := some .neuter }
-def they : PersonalPronoun := { form := "they", person := some .third, number := some .pl, case_ := some .nom }
-def them : PersonalPronoun := { form := "them", person := some .third, number := some .pl, case_ := some .acc }
+def he : PersonalPronoun := { form := "he", person := some .third, number := some .Sing, case_ := some .nom, gender := some .masculine }
+def him : PersonalPronoun := { form := "him", person := some .third, number := some .Sing, case_ := some .acc, gender := some .masculine }
+def she : PersonalPronoun := { form := "she", person := some .third, number := some .Sing, case_ := some .nom, gender := some .feminine }
+def her : PersonalPronoun := { form := "her", person := some .third, number := some .Sing, case_ := some .acc, gender := some .feminine }
+def it : PersonalPronoun := { form := "it", person := some .third, number := some .Sing, gender := some .neuter }
+def they : PersonalPronoun := { form := "they", person := some .third, number := some .Plur, case_ := some .nom }
+def them : PersonalPronoun := { form := "them", person := some .third, number := some .Plur, case_ := some .acc }
 
 -- Third-person singular *they* ([arnold-2026], [balhorn-2004]): same
 -- phonological form and gender-neutral feature as plural *they*, with singular
 -- number. Covers both underspecified and personal singular *they*.
-def they_sg : PersonalPronoun := { form := "they", person := some .third, number := some .sg, case_ := some .nom }
-def them_sg : PersonalPronoun := { form := "them", person := some .third, number := some .sg, case_ := some .acc }
+def they_sg : PersonalPronoun := { form := "they", person := some .third, number := some .Sing, case_ := some .nom }
+def them_sg : PersonalPronoun := { form := "them", person := some .third, number := some .Sing, case_ := some .acc }
 
 /-! ### Reflexive, reciprocal, and wh pronouns (bare `Pronoun`)
 
@@ -69,27 +69,27 @@ These are not referential pronouns; they carry φ-features and a surface form bu
 no denotation of their own. Their binding-theoretic kind is the `bindingClass`
 each declares (tagged per list below). -/
 
-def myself : Pronoun := { form := "myself", person := some .first, number := some .sg, bindingClass := some .reflexive }
-def yourself : Pronoun := { form := "yourself", person := some .second, number := some .sg, bindingClass := some .reflexive }
-def himself : Pronoun := { form := "himself", person := some .third, number := some .sg, gender := some .masculine, bindingClass := some .reflexive }
-def herself : Pronoun := { form := "herself", person := some .third, number := some .sg, gender := some .feminine, bindingClass := some .reflexive }
-def itself : Pronoun := { form := "itself", person := some .third, number := some .sg, gender := some .neuter, bindingClass := some .reflexive }
-def ourselves : Pronoun := { form := "ourselves", person := some .first, number := some .pl, bindingClass := some .reflexive }
-def yourselves : Pronoun := { form := "yourselves", person := some .second, number := some .pl, bindingClass := some .reflexive }
-def themselves : Pronoun := { form := "themselves", person := some .third, number := some .pl, bindingClass := some .reflexive }
-def themself : Pronoun := { form := "themself", person := some .third, number := some .sg, bindingClass := some .reflexive }
+def myself : Pronoun := { form := "myself", person := some .first, number := some .Sing, bindingClass := some .reflexive }
+def yourself : Pronoun := { form := "yourself", person := some .second, number := some .Sing, bindingClass := some .reflexive }
+def himself : Pronoun := { form := "himself", person := some .third, number := some .Sing, gender := some .masculine, bindingClass := some .reflexive }
+def herself : Pronoun := { form := "herself", person := some .third, number := some .Sing, gender := some .feminine, bindingClass := some .reflexive }
+def itself : Pronoun := { form := "itself", person := some .third, number := some .Sing, gender := some .neuter, bindingClass := some .reflexive }
+def ourselves : Pronoun := { form := "ourselves", person := some .first, number := some .Plur, bindingClass := some .reflexive }
+def yourselves : Pronoun := { form := "yourselves", person := some .second, number := some .Plur, bindingClass := some .reflexive }
+def themselves : Pronoun := { form := "themselves", person := some .third, number := some .Plur, bindingClass := some .reflexive }
+def themself : Pronoun := { form := "themself", person := some .third, number := some .Sing, bindingClass := some .reflexive }
 
 def eachOther : Pronoun := { form := "each other", bindingClass := some .reciprocal }
 def oneAnother : Pronoun := { form := "one another", bindingClass := some .reciprocal }
 
-def who : Pronoun := { form := "who", bindingClass := some .pronoun }
-def whom : Pronoun := { form := "whom", case_ := some .acc, bindingClass := some .pronoun }
-def what : Pronoun := { form := "what", bindingClass := some .pronoun }
-def which : Pronoun := { form := "which", bindingClass := some .pronoun }
-def where_ : Pronoun := { form := "where", bindingClass := some .pronoun }
-def when_ : Pronoun := { form := "when", bindingClass := some .pronoun }
-def why : Pronoun := { form := "why", bindingClass := some .pronoun }
-def how : Pronoun := { form := "how", bindingClass := some .pronoun }
+def who : Pronoun := { form := "who", pronType := some .Int, bindingClass := some .pronoun }
+def whom : Pronoun := { form := "whom", case_ := some .acc, pronType := some .Int, bindingClass := some .pronoun }
+def what : Pronoun := { form := "what", pronType := some .Int, bindingClass := some .pronoun }
+def which : Pronoun := { form := "which", pronType := some .Int, bindingClass := some .pronoun }
+def where_ : Pronoun := { form := "where", pronType := some .Int, bindingClass := some .pronoun }
+def when_ : Pronoun := { form := "when", pronType := some .Int, bindingClass := some .pronoun }
+def why : Pronoun := { form := "why", pronType := some .Int, bindingClass := some .pronoun }
+def how : Pronoun := { form := "how", pronType := some .Int, bindingClass := some .pronoun }
 
 /-! ### Demonstrative pronouns (`DemonstrativePronoun`)
 
@@ -97,10 +97,10 @@ Genuine deictic demonstratives — a two-way proximal/distal distance system ([m
 Unlike German *der* (a strong-article personal pronoun, see [patel-grosz-grosz-2017]), these encode
 a real spatial contrast, so they are `Demonstrative` carriers. -/
 
-def this_ : DemonstrativePronoun := { form := "this", person := some .third, number := some .sg, deixis := .proximal }
-def that_ : DemonstrativePronoun := { form := "that", person := some .third, number := some .sg, deixis := .distal }
-def these : DemonstrativePronoun := { form := "these", person := some .third, number := some .pl, deixis := .proximal }
-def those : DemonstrativePronoun := { form := "those", person := some .third, number := some .pl, deixis := .distal }
+def this_ : DemonstrativePronoun := { form := "this", person := some .third, number := some .Sing, deixis := .proximal }
+def that_ : DemonstrativePronoun := { form := "that", person := some .third, number := some .Sing, deixis := .distal }
+def these : DemonstrativePronoun := { form := "these", person := some .third, number := some .Plur, deixis := .proximal }
+def those : DemonstrativePronoun := { form := "those", person := some .third, number := some .Plur, deixis := .distal }
 
 /-- The four English demonstrative pronouns. -/
 def demonstratives : List DemonstrativePronoun := [this_, that_, these, those]
@@ -124,6 +124,10 @@ def whWords : List Pronoun := [who, whom, what, which, where_, when_, why, how]
 
 /-- Every reflexive entry is a Principle-A anaphor by its declaration. -/
 theorem reflexives_are_anaphors : ∀ p ∈ reflexives, Bound.IsAnaphor p := by decide
+
+/-- Every wh-word projects as wh-marked: the entry's `PronType=Int` reaches the surface
+word's morphology (`UD.MorphFeatures.isWh`) through `Pronoun.toWord`. -/
+theorem whWords_project_isWh : ∀ p ∈ whWords, p.toWord.features.isWh := by decide
 
 end English.Pronouns
 

--- a/Linglib/Fragments/French/Determiners.lean
+++ b/Linglib/Fragments/French/Determiners.lean
@@ -32,7 +32,7 @@ alternative *les deux* (`les_deux`). -/
 def tous : QuantifierEntry :=
   { form := "tous"
   , qforce := .universal
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , allowsMass := true
   , monotonicity := .increasing
   , strength := .strong
@@ -42,7 +42,7 @@ def tous : QuantifierEntry :=
 def chaque : QuantifierEntry :=
   { form := "chaque"
   , qforce := .universal
-  , numberRestriction := some .sg
+  , numberRestriction := some .Sing
   , monotonicity := .increasing
   , strength := .strong
   }
@@ -54,7 +54,7 @@ See JereticEtAl2025 §5.2. -/
 def aucun : QuantifierEntry :=
   { form := "aucun"
   , qforce := .negative
-  , numberRestriction := some .sg
+  , numberRestriction := some .Sing
   , monotonicity := .decreasing
   , strength := .strong
   }
@@ -65,7 +65,7 @@ expression that serves as an indirect alternative for the unpronounceable
 def les_deux : QuantifierEntry :=
   { form := "les deux"
   , qforce := .definite
-  , numberRestriction := some .du
+  , numberRestriction := some .Dual
   , monotonicity := .nonMonotone
   , strength := .strong
   }
@@ -74,7 +74,7 @@ def les_deux : QuantifierEntry :=
 def quelques : QuantifierEntry :=
   { form := "quelques"
   , qforce := .existential
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , monotonicity := .increasing
   }
 
@@ -82,14 +82,14 @@ def quelques : QuantifierEntry :=
 def un : QuantifierEntry :=
   { form := "un"
   , qforce := .existential
-  , numberRestriction := some .sg
+  , numberRestriction := some .Sing
   }
 
 /-- *les* — definite plural article. -/
 def les : QuantifierEntry :=
   { form := "les"
   , qforce := .definite
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , allowsMass := true
   , strength := .strong
   }
@@ -103,7 +103,7 @@ times') is more complex than *toujours*. -/
 def toujours : QuantifierEntry :=
   { form := "toujours"
   , qforce := .universal
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , monotonicity := .increasing
   , strength := .strong
   }

--- a/Linglib/Fragments/French/Reciprocals.lean
+++ b/Linglib/Fragments/French/Reciprocals.lean
@@ -27,7 +27,7 @@ def se : PersonalPronoun :=
 
 /-- l'un l'autre — bipartite reciprocal NP (bivalent strategy). -/
 def lunLautre : PersonalPronoun :=
-  { form := "l'un l'autre", person := some .third, number := some .pl }
+  { form := "l'un l'autre", person := some .third, number := some .Plur }
 
 /-- The bipartite NP form is distinct from the clitic. -/
 theorem bipartite_distinct_from_clitic :

--- a/Linglib/Fragments/Galician/Pronouns.lean
+++ b/Linglib/Fragments/Galician/Pronouns.lean
@@ -23,11 +23,11 @@ open Features.Register (Level)
 
 /-- *eu* — 1sg. -/
 def eu : PersonalPronoun :=
-  { form := "eu", person := some .first, number := some .sg }
+  { form := "eu", person := some .first, number := some .Sing }
 
 /-- *nós* — 1pl. -/
 def nos : PersonalPronoun :=
-  { form := "nós", person := some .first, number := some .pl }
+  { form := "nós", person := some .first, number := some .Plur }
 
 -- ============================================================================
 -- Second Person (T/V, sg and pl)
@@ -35,19 +35,19 @@ def nos : PersonalPronoun :=
 
 /-- *ti* — 2sg familiar (T form). -/
 def ti : PersonalPronoun :=
-  { form := "ti", person := some .second, number := some .sg, register := .informal }
+  { form := "ti", person := some .second, number := some .Sing, register := .informal }
 
 /-- *vostede* — 2sg formal (V form). -/
 def vostede : PersonalPronoun :=
-  { form := "vostede", person := some .second, number := some .sg, register := .formal }
+  { form := "vostede", person := some .second, number := some .Sing, register := .formal }
 
 /-- *vós* — 2pl familiar. -/
 def vos_pl : PersonalPronoun :=
-  { form := "vós", person := some .second, number := some .pl, register := .informal }
+  { form := "vós", person := some .second, number := some .Plur, register := .informal }
 
 /-- *vostedes* — 2pl formal. -/
 def vostedes : PersonalPronoun :=
-  { form := "vostedes", person := some .second, number := some .pl, register := .formal }
+  { form := "vostedes", person := some .second, number := some .Plur, register := .formal }
 
 -- ============================================================================
 -- Third Person
@@ -55,19 +55,19 @@ def vostedes : PersonalPronoun :=
 
 /-- *el* — 3sg masculine. -/
 def el : PersonalPronoun :=
-  { form := "el", person := some .third, number := some .sg }
+  { form := "el", person := some .third, number := some .Sing }
 
 /-- *ela* — 3sg feminine. -/
 def ela : PersonalPronoun :=
-  { form := "ela", person := some .third, number := some .sg }
+  { form := "ela", person := some .third, number := some .Sing }
 
 /-- *eles* — 3pl masculine. -/
 def eles : PersonalPronoun :=
-  { form := "eles", person := some .third, number := some .pl }
+  { form := "eles", person := some .third, number := some .Plur }
 
 /-- *elas* — 3pl feminine. -/
 def elas : PersonalPronoun :=
-  { form := "elas", person := some .third, number := some .pl }
+  { form := "elas", person := some .third, number := some .Plur }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -114,8 +114,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .sg) = true ∧
-    allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .Sing) = true ∧
+    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/German/Pronouns.lean
+++ b/Linglib/Fragments/German/Pronouns.lean
@@ -37,11 +37,11 @@ open Features.Register (Level)
 
 /-- *ich* — 1sg. -/
 def ich : PersonalPronoun :=
-  { form := "ich", person := some .first, number := some .sg }
+  { form := "ich", person := some .first, number := some .Sing }
 
 /-- *du* — 2sg familiar (T form). -/
 def du : PersonalPronoun :=
-  { form := "du", person := some .second, number := some .sg, register := .informal }
+  { form := "du", person := some .second, number := some .Sing, register := .informal }
 
 /-- *Sie* — polite 2nd person (V form, triggers 3pl agreement).
     Unlike Italian LEI (3sg.f) and Spanish USTED (3sg), German SIE uses
@@ -49,32 +49,32 @@ def du : PersonalPronoun :=
     is 2nd. Can refer to singular or plural addressees.
     [adamson-zompi-2025] -/
 def sie_polite : PersonalPronoun :=
-  { form := "Sie", person := some .third, number := some .pl, register := .formal,
+  { form := "Sie", person := some .third, number := some .Plur, register := .formal,
     referentialPerson := some .second }
 
 /-- *er* — 3sg masculine. -/
 def er : PersonalPronoun :=
-  { form := "er", person := some .third, number := some .sg }
+  { form := "er", person := some .third, number := some .Sing }
 
 /-- *sie* — 3sg feminine. -/
 def sie_f : PersonalPronoun :=
-  { form := "sie", person := some .third, number := some .sg }
+  { form := "sie", person := some .third, number := some .Sing }
 
 /-- *es* — 3sg neuter. -/
 def es : PersonalPronoun :=
-  { form := "es", person := some .third, number := some .sg }
+  { form := "es", person := some .third, number := some .Sing }
 
 /-- *wir* — 1pl. -/
 def wir : PersonalPronoun :=
-  { form := "wir", person := some .first, number := some .pl }
+  { form := "wir", person := some .first, number := some .Plur }
 
 /-- *ihr* — 2pl familiar. -/
 def ihr : PersonalPronoun :=
-  { form := "ihr", person := some .second, number := some .pl, register := .informal }
+  { form := "ihr", person := some .second, number := some .Plur, register := .informal }
 
 /-- *sie* — 3pl. -/
 def sie_pl : PersonalPronoun :=
-  { form := "sie", person := some .third, number := some .pl }
+  { form := "sie", person := some .third, number := some .Plur }
 
 def allPronouns : List PersonalPronoun :=
   [ich, du, sie_polite, er, sie_f, es, wir, ihr, sie_pl]
@@ -94,7 +94,7 @@ theorem sie_polite_dual_person :
     sie_polite.referentialPerson = some .second := ⟨rfl, rfl⟩
 
 /-- SIE uses 3pl, unlike Italian LEI (3sg) and Spanish USTED (3sg). -/
-theorem sie_is_plural : sie_polite.number = some .pl := rfl
+theorem sie_is_plural : sie_polite.number = some .Plur := rfl
 
 /-- All three persons are attested. -/
 theorem has_all_persons :

--- a/Linglib/Fragments/German/Reciprocals.lean
+++ b/Linglib/Fragments/German/Reciprocals.lean
@@ -28,7 +28,7 @@ def sich : PersonalPronoun :=
 
 /-- einander — dedicated reciprocal pronoun. -/
 def einander : PersonalPronoun :=
-  { form := "einander", person := some .third, number := some .pl }
+  { form := "einander", person := some .third, number := some .Plur }
 
 /-- The dedicated reciprocal form is distinct from the reflexive. -/
 theorem einander_distinct_from_sich :

--- a/Linglib/Fragments/Hindi/Pronouns.lean
+++ b/Linglib/Fragments/Hindi/Pronouns.lean
@@ -21,11 +21,11 @@ open Pronoun
 
 /-- *maiṃ* — 1sg. -/
 def maiN : PersonalPronoun :=
-  { form := "maiṃ", person := some .first, number := some .sg }
+  { form := "maiṃ", person := some .first, number := some .Sing }
 
 /-- *ham* — 1pl. -/
 def ham : PersonalPronoun :=
-  { form := "ham", person := some .first, number := some .pl }
+  { form := "ham", person := some .first, number := some .Plur }
 
 -- ============================================================================
 -- Second Person (three-level honorific)
@@ -33,15 +33,15 @@ def ham : PersonalPronoun :=
 
 /-- *tuu* — 2sg non-honorific (intimate/inferior). -/
 def tuu : PersonalPronoun :=
-  { form := "tuu", person := some .second, number := some .sg, register := .informal }
+  { form := "tuu", person := some .second, number := some .Sing, register := .informal }
 
 /-- *tum* — 2sg honorific (neutral). -/
 def tum : PersonalPronoun :=
-  { form := "tum", person := some .second, number := some .sg, register := .neutral }
+  { form := "tum", person := some .second, number := some .Sing, register := .neutral }
 
 /-- *aap* — 2sg high-honorific (respectful). -/
 def aap : PersonalPronoun :=
-  { form := "aap", person := some .second, number := some .sg, register := .formal }
+  { form := "aap", person := some .second, number := some .Sing, register := .formal }
 
 -- ============================================================================
 -- Third Person (demonstrative-based)
@@ -49,11 +49,11 @@ def aap : PersonalPronoun :=
 
 /-- *vah* — 3sg (distal demonstrative, standard pronoun). -/
 def vah : PersonalPronoun :=
-  { form := "vah", person := some .third, number := some .sg }
+  { form := "vah", person := some .third, number := some .Sing }
 
 /-- *ve* — 3pl (distal demonstrative plural). -/
 def ve : PersonalPronoun :=
-  { form := "ve", person := some .third, number := some .pl }
+  { form := "ve", person := some .third, number := some .Plur }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -94,8 +94,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .sg) = true ∧
-    allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .Sing) = true ∧
+    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/Hungarian/Reciprocals.lean
+++ b/Linglib/Fragments/Hungarian/Reciprocals.lean
@@ -54,11 +54,11 @@ def egymas : PersonalPronoun :=
     Unlike *egymás*, the reflexive inflects for number:
     *magá-t* (SG.ACC) vs. *maguk-at* (PL.ACC). -/
 def maga : PersonalPronoun :=
-  { form := "maga", person := some .third, number := some .sg }
+  { form := "maga", person := some .third, number := some .Sing }
 
 /-- *maguk* — reflexive pronoun (3PL form). -/
 def maguk : PersonalPronoun :=
-  { form := "maguk", person := some .third, number := some .pl }
+  { form := "maguk", person := some .third, number := some .Plur }
 
 -- ════════════════════════════════════════════════════════════════
 -- Antecedent Constructions ([rakosi-2019] §§3-6)
@@ -87,7 +87,7 @@ def quantifiedNP : AntecedentConfig :=
   { name := "Quantified NP (két/három/néhány + SG noun)"
     syntacticPl := false
     semanticPl := true
-    verbAgr := .sg }
+    verbAgr := .Sing }
 
 /-- §4: Singular coordinate DPs. Two conjoined singular NPs can
     trigger either SG or PL agreement from the left periphery.
@@ -98,7 +98,7 @@ def singularCoordinate : AntecedentConfig :=
   { name := "Singular coordinate DP (X és Y + 3SG verb)"
     syntacticPl := false
     semanticPl := true
-    verbAgr := .sg }
+    verbAgr := .Sing }
 
 /-- §5: Collective nouns. Hungarian collective nouns never trigger
     plural agreement (\*voltak for *személyzet*).
@@ -108,7 +108,7 @@ def collectiveNoun : AntecedentConfig :=
   { name := "Collective noun (személyzet, család, pár)"
     syntacticPl := false
     semanticPl := true
-    verbAgr := .sg }
+    verbAgr := .Sing }
 
 /-- §6: Bound variable antecedent. Embedded pro-dropped SG subject
     bound by matrix coordination. Forces wide-scope (I-)reading.
@@ -118,7 +118,7 @@ def boundVariable : AntecedentConfig :=
   { name := "Bound singular pro-drop (coordination in matrix)"
     syntacticPl := false
     semanticPl := true
-    verbAgr := .sg }
+    verbAgr := .Sing }
 
 /-- Standard plural antecedent (baseline).
     Ex: "A gyerek-ek látták egymás-t a tükörben." -/
@@ -126,7 +126,7 @@ def pluralAntecedent : AntecedentConfig :=
   { name := "Plural NP (standard)"
     syntacticPl := true
     semanticPl := true
-    verbAgr := .pl }
+    verbAgr := .Plur }
 
 /-- All four singular-antecedent constructions from [rakosi-2019]. -/
 def singularConstructions : List AntecedentConfig :=
@@ -175,7 +175,7 @@ theorem egymas_invariable : egymas.number = none := rfl
 
 /-- The reflexive DOES inflect for number. -/
 theorem reflexive_inflects :
-    maga.number = some .sg ∧ maguk.number = some .pl := ⟨rfl, rfl⟩
+    maga.number = some .Sing ∧ maguk.number = some .Plur := ⟨rfl, rfl⟩
 
 /-- When the local antecedent is a singular bound pronoun, only the
     wide-scope (I-)reading is available.

--- a/Linglib/Fragments/Icelandic/Reciprocals.lean
+++ b/Linglib/Fragments/Icelandic/Reciprocals.lean
@@ -23,7 +23,7 @@ open Pronoun
 
     Each part inflects independently for case.  -/
 def hvorAnnad : PersonalPronoun :=
-  { form := "hvor...annad", person := some .third, number := some .pl }
+  { form := "hvor...annad", person := some .third, number := some .Plur }
 
 /-- sig — reflexive pronoun (for contrast). -/
 def sig : PersonalPronoun :=

--- a/Linglib/Fragments/Italian/Determiners.lean
+++ b/Linglib/Fragments/Italian/Determiners.lean
@@ -36,21 +36,21 @@ def ogni : ItalianQuantifierEntry :=
   , qforce := .universal
   , monotonicity := .increasing
   , strength := .strong
-  , numberRestriction := some .sg }
+  , numberRestriction := some .Sing }
 
 /-- *qualche* — some (invariant, singular, existential). -/
 def qualche : ItalianQuantifierEntry :=
   { form := "qualche"
   , qforce := .existential
   , monotonicity := .increasing
-  , numberRestriction := some .sg }
+  , numberRestriction := some .Sing }
 
 /-- *nessuno* — no one (masculine, singular, negative concord). -/
 def nessuno : ItalianQuantifierEntry :=
   { form := "nessuno"
   , qforce := .negative
   , monotonicity := .decreasing
-  , numberRestriction := some .sg
+  , numberRestriction := some .Sing
   , gender := some .masculine }
 
 /-- *nessuna* — no one (feminine, singular, negative concord). -/
@@ -58,7 +58,7 @@ def nessuna : ItalianQuantifierEntry :=
   { form := "nessuna"
   , qforce := .negative
   , monotonicity := .decreasing
-  , numberRestriction := some .sg
+  , numberRestriction := some .Sing
   , gender := some .feminine }
 
 /-- *tutti* — all (masculine, plural, universal). -/
@@ -67,7 +67,7 @@ def tutti : ItalianQuantifierEntry :=
   , qforce := .universal
   , monotonicity := .increasing
   , strength := .strong
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , gender := some .masculine }
 
 /-- *tutte* — all (feminine, plural, universal). -/
@@ -76,7 +76,7 @@ def tutte : ItalianQuantifierEntry :=
   , qforce := .universal
   , monotonicity := .increasing
   , strength := .strong
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , gender := some .feminine }
 
 /-- *alcuni* — some (masculine, plural, existential). -/
@@ -84,7 +84,7 @@ def alcuni : ItalianQuantifierEntry :=
   { form := "alcuni"
   , qforce := .existential
   , monotonicity := .increasing
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , gender := some .masculine }
 
 /-- *alcune* — some (feminine, plural, existential). -/
@@ -92,7 +92,7 @@ def alcune : ItalianQuantifierEntry :=
   { form := "alcune"
   , qforce := .existential
   , monotonicity := .increasing
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , gender := some .feminine }
 
 /-- *molti* — many (masculine, plural, proportional). -/
@@ -100,7 +100,7 @@ def molti : ItalianQuantifierEntry :=
   { form := "molti"
   , qforce := .proportional
   , monotonicity := .increasing
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , gender := some .masculine }
 
 /-- *molte* — many (feminine, plural, proportional). -/
@@ -108,7 +108,7 @@ def molte : ItalianQuantifierEntry :=
   { form := "molte"
   , qforce := .proportional
   , monotonicity := .increasing
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , gender := some .feminine }
 
 /-- *pochi* — few (masculine, plural, proportional, decreasing). -/
@@ -116,7 +116,7 @@ def pochi : ItalianQuantifierEntry :=
   { form := "pochi"
   , qforce := .proportional
   , monotonicity := .decreasing
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , gender := some .masculine }
 
 /-- *poche* — few (feminine, plural, proportional, decreasing). -/
@@ -124,7 +124,7 @@ def poche : ItalianQuantifierEntry :=
   { form := "poche"
   , qforce := .proportional
   , monotonicity := .decreasing
-  , numberRestriction := some .pl
+  , numberRestriction := some .Plur
   , gender := some .feminine }
 
 /-- All Italian quantifier entries. -/

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -39,11 +39,11 @@ open Features.Register (Level)
 
 /-- *io* — 1sg. -/
 def io : PersonalPronoun :=
-  { form := "io", person := some .first, number := some .sg }
+  { form := "io", person := some .first, number := some .Sing }
 
 /-- *tu* — 2sg familiar (T form). -/
 def tu : PersonalPronoun :=
-  { form := "tu", person := some .second, number := some .sg, register := .informal }
+  { form := "tu", person := some .second, number := some .Sing, register := .informal }
 
 /-- *Lei* — polite 2sg (V form). Formally 3rd person: triggers 3sg verbal
     agreement, patterns with 3sg.f clitics, binds 3rd person reflexive *si*.
@@ -51,32 +51,32 @@ def tu : PersonalPronoun :=
     2PL resolved agreement in coordination.
     [adamson-zompi-2025] -/
 def lei_formal : PersonalPronoun :=
-  { form := "Lei", person := some .third, number := some .sg, register := .formal,
+  { form := "Lei", person := some .third, number := some .Sing, register := .formal,
     referentialPerson := some .second }
 
 /-- *lui* — 3sg masculine. -/
 def lui : PersonalPronoun :=
-  { form := "lui", person := some .third, number := some .sg }
+  { form := "lui", person := some .third, number := some .Sing }
 
 /-- *lei* — 3sg feminine. -/
 def lei : PersonalPronoun :=
-  { form := "lei", person := some .third, number := some .sg }
+  { form := "lei", person := some .third, number := some .Sing }
 
 /-- *noi* — 1pl. -/
 def noi : PersonalPronoun :=
-  { form := "noi", person := some .first, number := some .pl }
+  { form := "noi", person := some .first, number := some .Plur }
 
 /-- *voi* — 2pl (familiar; also used as general 2pl in modern Italian). -/
 def voi : PersonalPronoun :=
-  { form := "voi", person := some .second, number := some .pl, register := .informal }
+  { form := "voi", person := some .second, number := some .Plur, register := .informal }
 
 /-- *Loro* — 2pl formal (archaic, largely replaced by *voi*). -/
 def loro_formal : PersonalPronoun :=
-  { form := "Loro", person := some .second, number := some .pl, register := .formal }
+  { form := "Loro", person := some .second, number := some .Plur, register := .formal }
 
 /-- *loro* — 3pl. -/
 def loro : PersonalPronoun :=
-  { form := "loro", person := some .third, number := some .pl }
+  { form := "loro", person := some .third, number := some .Plur }
 
 def secondPersonPronouns : List PersonalPronoun := [tu, lei_formal]
 
@@ -240,8 +240,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .sg) = true ∧
-    allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .Sing) = true ∧
+    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
 -- ============================================================================
 -- § 5: Cardinaletti–Starke deficiency classes

--- a/Linglib/Fragments/Japanese/Pronouns.lean
+++ b/Linglib/Fragments/Japanese/Pronouns.lean
@@ -23,21 +23,21 @@ open Features.Register (Level)
 
 /-- 私 *watashi* — 1sg neutral/polite. -/
 def watashi : PersonalPronoun :=
-  { form := "watashi", script := some "私", person := some .first, number := some .sg, register := .formal }
+  { form := "watashi", script := some "私", person := some .first, number := some .Sing, register := .formal }
 
 /-- 僕 *boku* — 1sg informal, masculine-associated via register
     (no inherent gender feature; cf. [ochs-1992]). -/
 def boku : PersonalPronoun :=
-  { form := "boku", script := some "僕", person := some .first, number := some .sg, register := .informal }
+  { form := "boku", script := some "僕", person := some .first, number := some .Sing, register := .informal }
 
 /-- 俺 *ore* — 1sg male very informal. Strongly indexes masculine identity
     through assertive/coarse interactional stance ([ochs-1992]). -/
 def ore : PersonalPronoun :=
-  { form := "ore", script := some "俺", person := some .first, number := some .sg, register := .informal }
+  { form := "ore", script := some "俺", person := some .first, number := some .Sing, register := .informal }
 
 /-- 私たち *watashitachi* — 1pl. -/
 def watashitachi : PersonalPronoun :=
-  { form := "watashitachi", script := some "私たち", person := some .first, number := some .pl }
+  { form := "watashitachi", script := some "私たち", person := some .first, number := some .Plur }
 
 -- ============================================================================
 -- Second Person (T/V)
@@ -45,11 +45,11 @@ def watashitachi : PersonalPronoun :=
 
 /-- 君 *kimi* — 2sg plain. -/
 def kimi : PersonalPronoun :=
-  { form := "kimi", script := some "君", person := some .second, number := some .sg, register := .informal }
+  { form := "kimi", script := some "君", person := some .second, number := some .Sing, register := .informal }
 
 /-- あなた *anata* — 2sg polite. -/
 def anata : PersonalPronoun :=
-  { form := "anata", script := some "あなた", person := some .second, number := some .sg, register := .formal }
+  { form := "anata", script := some "あなた", person := some .second, number := some .Sing, register := .formal }
 
 -- ============================================================================
 -- Third Person
@@ -57,15 +57,15 @@ def anata : PersonalPronoun :=
 
 /-- 彼 *kare* — 3sg masculine. -/
 def kare : PersonalPronoun :=
-  { form := "kare", script := some "彼", person := some .third, number := some .sg }
+  { form := "kare", script := some "彼", person := some .third, number := some .Sing }
 
 /-- 彼女 *kanojo* — 3sg feminine. -/
 def kanojo : PersonalPronoun :=
-  { form := "kanojo", script := some "彼女", person := some .third, number := some .sg }
+  { form := "kanojo", script := some "彼女", person := some .third, number := some .Sing }
 
 /-- 彼ら *karera* — 3pl. -/
 def karera : PersonalPronoun :=
-  { form := "karera", script := some "彼ら", person := some .third, number := some .pl }
+  { form := "karera", script := some "彼ら", person := some .third, number := some .Plur }
 
 -- ============================================================================
 -- Reciprocal Pronoun
@@ -76,7 +76,7 @@ def karera : PersonalPronoun :=
     NP/argument reciprocal strategy (reciprocal pronoun), unlike
     languages that mark reciprocity on the verb. -/
 def otagai : PersonalPronoun :=
-  { form := "otagai", script := some "互い", person := some .third, number := some .pl }
+  { form := "otagai", script := some "互い", person := some .third, number := some .Plur }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -126,8 +126,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .sg) = true ∧
-    allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .Sing) = true ∧
+    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
 /-- 1st person has register-based distinction. -/
 theorem first_person_register :

--- a/Linglib/Fragments/Korean/Pronouns.lean
+++ b/Linglib/Fragments/Korean/Pronouns.lean
@@ -52,15 +52,15 @@ open Features.Register (Level)
 
 /-- 나 *na* — 1sg plain. -/
 def na : PersonalPronoun :=
-  { form := "na", script := some "나", person := some .first, number := some .sg, register := .informal }
+  { form := "na", script := some "나", person := some .first, number := some .Sing, register := .informal }
 
 /-- 저 *jeo* — 1sg humble. -/
 def jeo : PersonalPronoun :=
-  { form := "jeo", script := some "저", person := some .first, number := some .sg, register := .formal }
+  { form := "jeo", script := some "저", person := some .first, number := some .Sing, register := .formal }
 
 /-- 우리 *uri* — 1pl. -/
 def uri : PersonalPronoun :=
-  { form := "uri", script := some "우리", person := some .first, number := some .pl }
+  { form := "uri", script := some "우리", person := some .first, number := some .Plur }
 
 -- ============================================================================
 -- Second Person (T/V)
@@ -68,11 +68,11 @@ def uri : PersonalPronoun :=
 
 /-- 너 *neo* — 2sg plain. -/
 def neo : PersonalPronoun :=
-  { form := "neo", script := some "너", person := some .second, number := some .sg, register := .informal }
+  { form := "neo", script := some "너", person := some .second, number := some .Sing, register := .informal }
 
 /-- 당신 *dangsin* — 2sg polite. -/
 def dangsin : PersonalPronoun :=
-  { form := "dangsin", script := some "당신", person := some .second, number := some .sg, register := .formal }
+  { form := "dangsin", script := some "당신", person := some .second, number := some .Sing, register := .formal }
 
 -- ============================================================================
 -- Third Person
@@ -81,14 +81,14 @@ def dangsin : PersonalPronoun :=
 /-- 그 *geu* (Yale: *ku*) — 3sg masculine, **literary** register.
     76,235 written vs 145 oral tokens ([kwon-lee-2026] fn. 2). -/
 def geu : PersonalPronoun :=
-  { form := "geu", script := some "그", person := some .third, number := some .sg
+  { form := "geu", script := some "그", person := some .third, number := some .Sing
   , gender := some .masculine, register := .formal }
 
 /-- 그녀 *geunyeo* (Yale: *kunye*) — 3sg feminine, **literary** register.
     Compound of *ku* ('that') + *nye* ('female'). 25,085 written vs
     9 oral tokens ([kwon-lee-2026] fn. 2). -/
 def geunyeo : PersonalPronoun :=
-  { form := "geunyeo", script := some "그녀", person := some .third, number := some .sg
+  { form := "geunyeo", script := some "그녀", person := some .third, number := some .Sing
   , gender := some .feminine, register := .formal }
 
 /-- 걔 *gyae* (Yale: *kyay*) — 3sg gender-neutral, **colloquial** pronoun.
@@ -98,13 +98,13 @@ def geunyeo : PersonalPronoun :=
     ([kwon-lee-2026] §5). The overt-pronoun referential form
     tested in [kwon-lee-2026]'s experiments. -/
 def gyae : PersonalPronoun :=
-  { form := "gyae", script := some "걔", person := some .third, number := some .sg
+  { form := "gyae", script := some "걔", person := some .third, number := some .Sing
   , register := .informal }
 
 /-- 그들 *geudeul* — 3pl. Plural of *geu*; literary in register
     (the colloquial plural is the proximal demonstrative + *ai-tul*). -/
 def geudeul : PersonalPronoun :=
-  { form := "geudeul", script := some "그들", person := some .third, number := some .pl
+  { form := "geudeul", script := some "그들", person := some .third, number := some .Plur
   , register := .formal }
 
 -- ============================================================================
@@ -167,8 +167,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .sg) = true ∧
-    allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .Sing) = true ∧
+    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
 /-- 1st person has plain/humble register distinction. -/
 theorem first_person_humble :

--- a/Linglib/Fragments/Magahi/Pronouns.lean
+++ b/Linglib/Fragments/Magahi/Pronouns.lean
@@ -20,11 +20,11 @@ open Pronoun
 
 /-- *hum* — 1sg. -/
 def hum : PersonalPronoun :=
-  { form := "hum", person := some .first, number := some .sg }
+  { form := "hum", person := some .first, number := some .Sing }
 
 /-- *hum sab* — 1pl. -/
 def humSab : PersonalPronoun :=
-  { form := "hum sab", person := some .first, number := some .pl }
+  { form := "hum sab", person := some .first, number := some .Plur }
 
 -- ============================================================================
 -- Second Person (three-level honorific)
@@ -32,15 +32,15 @@ def humSab : PersonalPronoun :=
 
 /-- *tõ* — 2sg non-honorific. -/
 def toN : PersonalPronoun :=
-  { form := "tõ", person := some .second, number := some .sg, register := .informal }
+  { form := "tõ", person := some .second, number := some .Sing, register := .informal }
 
 /-- *tũ* — 2sg honorific. -/
 def tuN : PersonalPronoun :=
-  { form := "tũ", person := some .second, number := some .sg, register := .neutral }
+  { form := "tũ", person := some .second, number := some .Sing, register := .neutral }
 
 /-- *apne* — 2sg high-honorific. -/
 def apne : PersonalPronoun :=
-  { form := "apne", person := some .second, number := some .sg, register := .formal }
+  { form := "apne", person := some .second, number := some .Sing, register := .formal }
 
 -- ============================================================================
 -- Third Person (demonstrative-based)
@@ -48,15 +48,15 @@ def apne : PersonalPronoun :=
 
 /-- *i* — 3sg proximal. -/
 def i_prox : PersonalPronoun :=
-  { form := "i", person := some .third, number := some .sg }
+  { form := "i", person := some .third, number := some .Sing }
 
 /-- *ũ* — 3sg distal. -/
 def uN : PersonalPronoun :=
-  { form := "ũ", person := some .third, number := some .sg }
+  { form := "ũ", person := some .third, number := some .Sing }
 
 /-- *ũ sab* — 3pl distal. -/
 def uNSab : PersonalPronoun :=
-  { form := "ũ sab", person := some .third, number := some .pl }
+  { form := "ũ sab", person := some .third, number := some .Plur }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -97,8 +97,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .sg) = true ∧
-    allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .Sing) = true ∧
+    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/Maithili/Pronouns.lean
+++ b/Linglib/Fragments/Maithili/Pronouns.lean
@@ -21,11 +21,11 @@ open Pronoun
 
 /-- *hum* — 1sg. -/
 def hum : PersonalPronoun :=
-  { form := "hum", person := some .first, number := some .sg }
+  { form := "hum", person := some .first, number := some .Sing }
 
 /-- *hum sab* — 1pl. -/
 def humSab : PersonalPronoun :=
-  { form := "hum sab", person := some .first, number := some .pl }
+  { form := "hum sab", person := some .first, number := some .Plur }
 
 -- ============================================================================
 -- Second Person (three-level honorific)
@@ -33,15 +33,15 @@ def humSab : PersonalPronoun :=
 
 /-- *tõ* — 2sg non-honorific. -/
 def toN : PersonalPronoun :=
-  { form := "tõ", person := some .second, number := some .sg, register := .informal }
+  { form := "tõ", person := some .second, number := some .Sing, register := .informal }
 
 /-- *ahã* — 2sg honorific. -/
 def ahaN : PersonalPronoun :=
-  { form := "ahã", person := some .second, number := some .sg, register := .neutral }
+  { form := "ahã", person := some .second, number := some .Sing, register := .neutral }
 
 /-- *apne* — 2sg high-honorific. -/
 def apne : PersonalPronoun :=
-  { form := "apne", person := some .second, number := some .sg, register := .formal }
+  { form := "apne", person := some .second, number := some .Sing, register := .formal }
 
 -- ============================================================================
 -- Third Person (honorific-sensitive)
@@ -49,15 +49,15 @@ def apne : PersonalPronoun :=
 
 /-- *ũ* — 3sg non-honorific (distal). -/
 def uN : PersonalPronoun :=
-  { form := "ũ", person := some .third, number := some .sg, register := .informal }
+  { form := "ũ", person := some .third, number := some .Sing, register := .informal }
 
 /-- *o* — 3sg honorific. -/
 def o : PersonalPronoun :=
-  { form := "o", person := some .third, number := some .sg, register := .neutral }
+  { form := "o", person := some .third, number := some .Sing, register := .neutral }
 
 /-- *ũ sab* — 3pl. -/
 def uNSab : PersonalPronoun :=
-  { form := "ũ sab", person := some .third, number := some .pl }
+  { form := "ũ sab", person := some .third, number := some .Plur }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -98,8 +98,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .sg) = true ∧
-    allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .Sing) = true ∧
+    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/Punjabi/Pronouns.lean
+++ b/Linglib/Fragments/Punjabi/Pronouns.lean
@@ -20,11 +20,11 @@ open Pronoun
 
 /-- *maiṃ* — 1sg. -/
 def maiN : PersonalPronoun :=
-  { form := "maiṃ", person := some .first, number := some .sg }
+  { form := "maiṃ", person := some .first, number := some .Sing }
 
 /-- *asiiṃ* — 1pl. -/
 def asiiN : PersonalPronoun :=
-  { form := "asiiṃ", person := some .first, number := some .pl }
+  { form := "asiiṃ", person := some .first, number := some .Plur }
 
 -- ============================================================================
 -- Second Person (two-level honorific)
@@ -32,11 +32,11 @@ def asiiN : PersonalPronoun :=
 
 /-- *tũ* — 2sg non-honorific. -/
 def tuN : PersonalPronoun :=
-  { form := "tũ", person := some .second, number := some .sg, register := .informal }
+  { form := "tũ", person := some .second, number := some .Sing, register := .informal }
 
 /-- *tusii* — 2sg honorific (also 2pl). -/
 def tusii : PersonalPronoun :=
-  { form := "tusii", person := some .second, number := some .sg, register := .formal }
+  { form := "tusii", person := some .second, number := some .Sing, register := .formal }
 
 -- ============================================================================
 -- Third Person (demonstrative-based)
@@ -44,11 +44,11 @@ def tusii : PersonalPronoun :=
 
 /-- *uh* — 3sg (distal demonstrative). -/
 def uh_sg : PersonalPronoun :=
-  { form := "uh", person := some .third, number := some .sg }
+  { form := "uh", person := some .third, number := some .Sing }
 
 /-- *uh* — 3pl (same form as 3sg in standard Punjabi). -/
 def uh_pl : PersonalPronoun :=
-  { form := "uh", person := some .third, number := some .pl }
+  { form := "uh", person := some .third, number := some .Plur }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -85,8 +85,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .sg) = true ∧
-    allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .Sing) = true ∧
+    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/Slavic/Russian/Reciprocals.lean
+++ b/Linglib/Fragments/Slavic/Russian/Reciprocals.lean
@@ -20,7 +20,7 @@ open Pronoun
 /-- друг друга *drug druga* — reciprocal pronoun 'each other'. -/
 def drugDruga : PersonalPronoun :=
   { form := "drug druga", script := some "друг друга"
-  , person := some .third, number := some .pl }
+  , person := some .third, number := some .Plur }
 
 /-- себя *sebja* — reflexive pronoun (for contrast). -/
 def sebja : PersonalPronoun :=

--- a/Linglib/Fragments/Spanish/Pronouns.lean
+++ b/Linglib/Fragments/Spanish/Pronouns.lean
@@ -37,11 +37,11 @@ open Features.Register (Level)
 
 /-- *yo* — 1sg. -/
 def yo : PersonalPronoun :=
-  { form := "yo", person := some .first, number := some .sg }
+  { form := "yo", person := some .first, number := some .Sing }
 
 /-- *tú* — 2sg familiar (T form). -/
 def tu : PersonalPronoun :=
-  { form := "tú", person := some .second, number := some .sg, register := .informal }
+  { form := "tú", person := some .second, number := some .Sing, register := .informal }
 
 /-- *usted* — polite 2sg (V form, triggers 3sg agreement).
     Agreement person is 3rd, interpretable person is 2nd. Triggers PCC
@@ -49,33 +49,33 @@ def tu : PersonalPronoun :=
     ([rezac-2011], [adamson-zompi-2025] §6.1).
     [adamson-zompi-2025] -/
 def usted : PersonalPronoun :=
-  { form := "usted", person := some .third, number := some .sg, register := .formal,
+  { form := "usted", person := some .third, number := some .Sing, register := .formal,
     referentialPerson := some .second }
 
 /-- *él* — 3sg masculine. -/
 def el : PersonalPronoun :=
-  { form := "él", person := some .third, number := some .sg }
+  { form := "él", person := some .third, number := some .Sing }
 
 /-- *ella* — 3sg feminine. -/
 def ella : PersonalPronoun :=
-  { form := "ella", person := some .third, number := some .sg }
+  { form := "ella", person := some .third, number := some .Sing }
 
 /-- *nosotros* — 1pl. -/
 def nosotros : PersonalPronoun :=
-  { form := "nosotros", person := some .first, number := some .pl }
+  { form := "nosotros", person := some .first, number := some .Plur }
 
 /-- *vosotros* — 2pl familiar (Peninsular). -/
 def vosotros : PersonalPronoun :=
-  { form := "vosotros", person := some .second, number := some .pl, register := .informal }
+  { form := "vosotros", person := some .second, number := some .Plur, register := .informal }
 
 /-- *ustedes* — 2pl formal / general (triggers 3pl agreement). -/
 def ustedes : PersonalPronoun :=
-  { form := "ustedes", person := some .third, number := some .pl, register := .formal,
+  { form := "ustedes", person := some .third, number := some .Plur, register := .formal,
     referentialPerson := some .second }
 
 /-- *ellos* — 3pl masculine. -/
 def ellos : PersonalPronoun :=
-  { form := "ellos", person := some .third, number := some .pl }
+  { form := "ellos", person := some .third, number := some .Plur }
 
 def allPronouns : List PersonalPronoun :=
   [yo, tu, usted, el, ella, nosotros, vosotros, ustedes, ellos]

--- a/Linglib/Fragments/Tagalog/Pronouns.lean
+++ b/Linglib/Fragments/Tagalog/Pronouns.lean
@@ -83,37 +83,37 @@ def clusivitySystem : Features.Clusivity.System := .minimalAugmented
 open Features.Person (Category)
 
 -- 1st singular
-def ako    : PersonalPronoun := { form := "ako",    person := some .first,  number := some .sg, case_ := some .Nom }
-def ko     : PersonalPronoun := { form := "ko",     person := some .first,  number := some .sg, case_ := some .Gen }
-def akin   : PersonalPronoun := { form := "akin",   person := some .first,  number := some .sg, case_ := some .Dat }
+def ako    : PersonalPronoun := { form := "ako",    person := some .first,  number := some .Sing, case_ := some .Nom }
+def ko     : PersonalPronoun := { form := "ko",     person := some .first,  number := some .Sing, case_ := some .Gen }
+def akin   : PersonalPronoun := { form := "akin",   person := some .first,  number := some .Sing, case_ := some .Dat }
 -- 2nd singular
-def ikaw   : PersonalPronoun := { form := "ikaw",   person := some .second, number := some .sg, case_ := some .Nom }
-def mo     : PersonalPronoun := { form := "mo",     person := some .second, number := some .sg, case_ := some .Gen }
-def iyo    : PersonalPronoun := { form := "iyo",    person := some .second, number := some .sg, case_ := some .Dat }
+def ikaw   : PersonalPronoun := { form := "ikaw",   person := some .second, number := some .Sing, case_ := some .Nom }
+def mo     : PersonalPronoun := { form := "mo",     person := some .second, number := some .Sing, case_ := some .Gen }
+def iyo    : PersonalPronoun := { form := "iyo",    person := some .second, number := some .Sing, case_ := some .Dat }
 -- 3rd singular
-def siya   : PersonalPronoun := { form := "siya",   person := some .third,  number := some .sg, case_ := some .Nom }
-def niya   : PersonalPronoun := { form := "niya",   person := some .third,  number := some .sg, case_ := some .Gen }
-def kaniya : PersonalPronoun := { form := "kaniya", person := some .third,  number := some .sg, case_ := some .Dat }
+def siya   : PersonalPronoun := { form := "siya",   person := some .third,  number := some .Sing, case_ := some .Nom }
+def niya   : PersonalPronoun := { form := "niya",   person := some .third,  number := some .Sing, case_ := some .Gen }
+def kaniya : PersonalPronoun := { form := "kaniya", person := some .third,  number := some .Sing, case_ := some .Dat }
 -- 1st dual inclusive (minimal inclusive): *kata*
-def kata   : PersonalPronoun := { form := "kata",   person := some .first,  number := some .du, clusivity := some .inclusive, case_ := some .Nom }
-def nita   : PersonalPronoun := { form := "nita",   person := some .first,  number := some .du, clusivity := some .inclusive, case_ := some .Gen }
-def kanita : PersonalPronoun := { form := "kanita", person := some .first,  number := some .du, clusivity := some .inclusive, case_ := some .Dat }
+def kata   : PersonalPronoun := { form := "kata",   person := some .first,  number := some .Dual, clusivity := some .inclusive, case_ := some .Nom }
+def nita   : PersonalPronoun := { form := "nita",   person := some .first,  number := some .Dual, clusivity := some .inclusive, case_ := some .Gen }
+def kanita : PersonalPronoun := { form := "kanita", person := some .first,  number := some .Dual, clusivity := some .inclusive, case_ := some .Dat }
 -- 1st plural inclusive (augmented inclusive): *tayo*
-def tayo   : PersonalPronoun := { form := "tayo",   person := some .first,  number := some .pl, clusivity := some .inclusive, case_ := some .Nom }
-def natin  : PersonalPronoun := { form := "natin",  person := some .first,  number := some .pl, clusivity := some .inclusive, case_ := some .Gen }
-def atin   : PersonalPronoun := { form := "atin",   person := some .first,  number := some .pl, clusivity := some .inclusive, case_ := some .Dat }
+def tayo   : PersonalPronoun := { form := "tayo",   person := some .first,  number := some .Plur, clusivity := some .inclusive, case_ := some .Nom }
+def natin  : PersonalPronoun := { form := "natin",  person := some .first,  number := some .Plur, clusivity := some .inclusive, case_ := some .Gen }
+def atin   : PersonalPronoun := { form := "atin",   person := some .first,  number := some .Plur, clusivity := some .inclusive, case_ := some .Dat }
 -- 1st plural exclusive: *kami*
-def kami   : PersonalPronoun := { form := "kami",   person := some .first,  number := some .pl, clusivity := some .exclusive, case_ := some .Nom }
-def namin  : PersonalPronoun := { form := "namin",  person := some .first,  number := some .pl, clusivity := some .exclusive, case_ := some .Gen }
-def amin   : PersonalPronoun := { form := "amin",   person := some .first,  number := some .pl, clusivity := some .exclusive, case_ := some .Dat }
+def kami   : PersonalPronoun := { form := "kami",   person := some .first,  number := some .Plur, clusivity := some .exclusive, case_ := some .Nom }
+def namin  : PersonalPronoun := { form := "namin",  person := some .first,  number := some .Plur, clusivity := some .exclusive, case_ := some .Gen }
+def amin   : PersonalPronoun := { form := "amin",   person := some .first,  number := some .Plur, clusivity := some .exclusive, case_ := some .Dat }
 -- 2nd plural
-def kayo   : PersonalPronoun := { form := "kayo",   person := some .second, number := some .pl, case_ := some .Nom }
-def ninyo  : PersonalPronoun := { form := "ninyo",  person := some .second, number := some .pl, case_ := some .Gen }
-def inyo   : PersonalPronoun := { form := "inyo",   person := some .second, number := some .pl, case_ := some .Dat }
+def kayo   : PersonalPronoun := { form := "kayo",   person := some .second, number := some .Plur, case_ := some .Nom }
+def ninyo  : PersonalPronoun := { form := "ninyo",  person := some .second, number := some .Plur, case_ := some .Gen }
+def inyo   : PersonalPronoun := { form := "inyo",   person := some .second, number := some .Plur, case_ := some .Dat }
 -- 3rd plural
-def sila   : PersonalPronoun := { form := "sila",   person := some .third,  number := some .pl, case_ := some .Nom }
-def nila   : PersonalPronoun := { form := "nila",   person := some .third,  number := some .pl, case_ := some .Gen }
-def kanila : PersonalPronoun := { form := "kanila", person := some .third,  number := some .pl, case_ := some .Dat }
+def sila   : PersonalPronoun := { form := "sila",   person := some .third,  number := some .Plur, case_ := some .Nom }
+def nila   : PersonalPronoun := { form := "nila",   person := some .third,  number := some .Plur, case_ := some .Gen }
+def kanila : PersonalPronoun := { form := "kanila", person := some .third,  number := some .Plur, case_ := some .Dat }
 
 /-- The Tagalog independent-pronoun inventory (all three case series). -/
 def pronouns : List PersonalPronoun :=
@@ -140,8 +140,8 @@ theorem incl_excl_distinct :
     plural inclusive *tayo* — what makes Tagalog minimal-augmented rather than
     plain inclusive/exclusive ([cysouw-2009]). -/
 theorem minimal_augmented :
-    kata.number = some .du ∧ kata.clusivity = some .inclusive ∧
-    tayo.number = some .pl ∧ tayo.clusivity = some .inclusive := ⟨rfl, rfl, rfl, rfl⟩
+    kata.number = some .Dual ∧ kata.clusivity = some .inclusive ∧
+    tayo.number = some .Plur ∧ tayo.clusivity = some .inclusive := ⟨rfl, rfl, rfl, rfl⟩
 
 /-- Cross-substrate consistency: the inventory contains a minimal-inclusive
     (dual inclusive) form iff the language commits to the minimal-augmented

--- a/Linglib/Fragments/Tamil/Pronouns.lean
+++ b/Linglib/Fragments/Tamil/Pronouns.lean
@@ -22,15 +22,15 @@ open Pronoun
 
 /-- *naan* — 1sg. -/
 def naan : PersonalPronoun :=
-  { form := "naan", person := some .first, number := some .sg }
+  { form := "naan", person := some .first, number := some .Sing }
 
 /-- *naam* — 1pl inclusive (speaker + addressee). -/
 def naam : PersonalPronoun :=
-  { form := "naam", person := some .first, number := some .pl, clusivity := some .inclusive }
+  { form := "naam", person := some .first, number := some .Plur, clusivity := some .inclusive }
 
 /-- *naangaL* — 1pl exclusive (speaker + others, not addressee). -/
 def naangaL : PersonalPronoun :=
-  { form := "naangaL", person := some .first, number := some .pl, clusivity := some .exclusive }
+  { form := "naangaL", person := some .first, number := some .Plur, clusivity := some .exclusive }
 
 -- ============================================================================
 -- Second Person (two-level honorific)
@@ -38,11 +38,11 @@ def naangaL : PersonalPronoun :=
 
 /-- *nii* — 2sg non-honorific. -/
 def nii : PersonalPronoun :=
-  { form := "nii", person := some .second, number := some .sg, register := .informal }
+  { form := "nii", person := some .second, number := some .Sing, register := .informal }
 
 /-- *niingaL* — 2sg honorific (also 2pl). -/
 def niingaL : PersonalPronoun :=
-  { form := "niingaL", person := some .second, number := some .sg, register := .formal }
+  { form := "niingaL", person := some .second, number := some .Sing, register := .formal }
 
 -- ============================================================================
 -- Third Person
@@ -50,19 +50,19 @@ def niingaL : PersonalPronoun :=
 
 /-- *avan* — 3sg masculine. -/
 def avan : PersonalPronoun :=
-  { form := "avan", person := some .third, number := some .sg }
+  { form := "avan", person := some .third, number := some .Sing }
 
 /-- *avaL* — 3sg feminine. -/
 def avaL : PersonalPronoun :=
-  { form := "avaL", person := some .third, number := some .sg }
+  { form := "avaL", person := some .third, number := some .Sing }
 
 /-- *avar* — 3sg honorific. -/
 def avar : PersonalPronoun :=
-  { form := "avar", person := some .third, number := some .sg, register := .formal }
+  { form := "avar", person := some .third, number := some .Sing, register := .formal }
 
 /-- *avarkaL* — 3pl (human). -/
 def avarkaL : PersonalPronoun :=
-  { form := "avarkaL", person := some .third, number := some .pl }
+  { form := "avarkaL", person := some .third, number := some .Plur }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -99,12 +99,12 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .sg) = true ∧
-    allPronouns.any (·.number == some .pl) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .Sing) = true ∧
+    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
 /-- Tamil has inclusive/exclusive distinction in 1pl. -/
 theorem has_incl_excl :
-    (allPronouns.filter (fun p => p.person == some .first && p.number == some .pl)).length = 2 := rfl
+    (allPronouns.filter (fun p => p.person == some .first && p.number == some .Plur)).length = 2 := rfl
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/Wan/Reciprocals.lean
+++ b/Linglib/Fragments/Wan/Reciprocals.lean
@@ -51,7 +51,7 @@ open Features.Logophoricity
     logophoric pronoun. The reciprocal reading arises from the combination
     of REFL *ē* + RECIP *ɔ̄ŋ*. -/
 def logPl : PersonalPronoun :=
-  { form := "mɔ̄", person := some .third, number := some .pl }
+  { form := "mɔ̄", person := some .third, number := some .Plur }
 
 /-- Wan reflexive marker *ē* (REFL). Combines with reciprocal marker
     *ɔ̄ŋ* to form the reciprocal construction. -/
@@ -61,7 +61,7 @@ def refl : PersonalPronoun :=
 /-- Wan reciprocal marker *ɔ̄ŋ* (RECIP). Appears after reflexive *ē*
     to yield the reciprocal reading. -/
 def recip : PersonalPronoun :=
-  { form := "ɔ̄ŋ", person := some .third, number := some .pl }
+  { form := "ɔ̄ŋ", person := some .third, number := some .Plur }
 
 /-- Wan 3pl ordinary (non-logophoric) pronoun *à* (low tone).
     In (32): "wì mù tēŋ tú gé **à** ɔ̄ŋ lɔ̄ lé"
@@ -73,7 +73,7 @@ def recip : PersonalPronoun :=
     pronoun. The 3PL pronoun is *à* (grave accent), tonally distinct
     from copula *á* (acute accent) in (28). -/
 def ordinaryPl : PersonalPronoun :=
-  { form := "à", person := some .third, number := some .pl }
+  { form := "à", person := some .third, number := some .Plur }
 
 -- ════════════════════════════════════════════════════════════════
 -- § 2: Logophoric Properties

--- a/Linglib/Semantics/Quantification/Lexicon.lean
+++ b/Linglib/Semantics/Quantification/Lexicon.lean
@@ -13,7 +13,7 @@ in the study files that commit to specific values.
 
 - `form` — surface form
 - `qforce` — quantificational force (universal, existential, …)
-- `numberRestriction` — `none` (number-neutral), or `some .sg`/`.pl`/`.du`
+- `numberRestriction` — `none` (number-neutral), or `some .Sing`/`.pl`/`.du`
   (a single grammatical number; `.du` covers items like English *both*
   and French *les deux* whose meaning composition uses the dual core
   concept [jeretic-bassi-gonzalez-yatsushiro-meyer-sauerland-2025])

--- a/Linglib/Studies/AdamsonZompi2025.lean
+++ b/Linglib/Studies/AdamsonZompi2025.lean
@@ -709,11 +709,11 @@ theorem person_geometry_matches_core_features :
     and why it can address multiple addressees, unlike LEI/USTED. -/
 theorem cross_linguistic_number :
     -- LEI is formally singular (§3, (8): "3sg verbal agreement")
-    Italian.Pronouns.lei_formal.number = some .sg ∧
+    Italian.Pronouns.lei_formal.number = some .Sing ∧
     -- USTED is formally singular
-    Spanish.Pronouns.usted.number = some .sg ∧
+    Spanish.Pronouns.usted.number = some .Sing ∧
     -- SIE is formally PLURAL — the typological outlier (§6.2, (45))
-    German.Pronouns.sie_polite.number = some .pl := ⟨rfl, rfl, rfl⟩
+    German.Pronouns.sie_polite.number = some .Plur := ⟨rfl, rfl, rfl⟩
 
 /-- Despite different agreement numbers, all three polite pronouns trigger
     PCC effects identically — confirming that the PCC reads *person*

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -414,18 +414,18 @@ theorem english_demonstratives_are_definite :
 -- φ-feature content is stated.
 theorem it_entry_classification :
     English.Pronouns.it.person = some .third ∧
-    English.Pronouns.it.number = some .sg :=
+    English.Pronouns.it.number = some .Sing :=
   ⟨rfl, rfl⟩
 
 theorem he_entry_classification :
     English.Pronouns.he.person = some .third ∧
-    English.Pronouns.he.number = some .sg ∧
+    English.Pronouns.he.number = some .Sing ∧
     English.Pronouns.he.case_ = some .nom :=
   ⟨rfl, rfl, rfl⟩
 
 theorem she_entry_classification :
     English.Pronouns.she.person = some .third ∧
-    English.Pronouns.she.number = some .sg ∧
+    English.Pronouns.she.number = some .Sing ∧
     English.Pronouns.she.case_ = some .nom :=
   ⟨rfl, rfl, rfl⟩
 

--- a/Linglib/Studies/JereticEtAl2025.lean
+++ b/Linglib/Studies/JereticEtAl2025.lean
@@ -224,13 +224,13 @@ encoding here is consistent with it.
 
 Justification per cell:
 - English *all* → `.lexicalDual` because `English.Determiners.both`
-  has `numberRestriction := some .du` (see `both_neither_dual_marked`).
+  has `numberRestriction := some .Dual` (see `both_neither_dual_marked`).
 - English *no* → `.lexicalDual` via *neither*.
 - French *tous* → `.unpronounceableWithIndirectAlt` because
   `French.Determiners.les_deux` has `numberRestriction :=
-  some .du` and is no more complex than *tous les NP*.
+  some .Dual` and is no more complex than *tous les NP*.
 - French *aucun* → `.noCompetitor` because no Fragment entry has both
-  `qforce = .negative` and `numberRestriction = some .du` and no
+  `qforce = .negative` and `numberRestriction = some .Dual` and no
   surrogate at sufficient simplicity exists (paper §5.2).
 - German *alle* → `.lexicalDual` via *beide* (Fragment not yet built).
 - German *keine* → `.noCompetitor` per paper §5.2 (no German *neither*).
@@ -295,10 +295,10 @@ but checks: if `English.Determiners.both` were not
 would be exposed as out of sync with the lexicon. -/
 
 /-- English realizes the dual core concept iff some entry in the
-lexicon carries `numberRestriction = some .du`. For English this is
+lexicon carries `numberRestriction = some .Dual`. For English this is
 witnessed by `both` and `neither`. -/
 def englishRealizesDual : Prop :=
-  ∃ q ∈ English.Determiners.allQuantifiers, q.numberRestriction = some .du
+  ∃ q ∈ English.Determiners.allQuantifiers, q.numberRestriction = some .Dual
 
 theorem english_realizes_dual : englishRealizesDual :=
   ⟨English.Determiners.both, by
@@ -310,14 +310,14 @@ French *both*); it does have `les_deux` realizing the dual core
 concept on the definite slot. This is the paper's central observation:
 French has the dual concept but lacks its universal lexicalization. -/
 def frenchHasDualOnDefinite : Prop :=
-  French.Determiners.les_deux.numberRestriction = some .du
+  French.Determiners.les_deux.numberRestriction = some .Dual
 
 theorem french_dual_on_definite : frenchHasDualOnDefinite := rfl
 
 /-- French *tous* is plural-restricted, NOT dual — the gap the paper
 explains via Indirect Alternatives. -/
 theorem french_tous_not_lexical_dual :
-    French.Determiners.tous.numberRestriction ≠ some .du := by
+    French.Determiners.tous.numberRestriction ≠ some .Dual := by
   decide
 
 /-- The grounding bridge: `lexiconCompetitor .english .universal =
@@ -326,7 +326,7 @@ quantifier with `qforce = .universal` (which is *both*). -/
 theorem english_universal_competitor_grounded :
     lexiconCompetitor .english .universal = .lexicalDual ∧
     ∃ q ∈ English.Determiners.allQuantifiers,
-      q.qforce = .universal ∧ q.numberRestriction = some .du :=
+      q.qforce = .universal ∧ q.numberRestriction = some .Dual :=
   ⟨rfl, English.Determiners.both, by
     simp only [English.Determiners.allQuantifiers, List.mem_cons]
     tauto, rfl, rfl⟩
@@ -338,8 +338,8 @@ realizing dual on the definite slot (the indirect alternative). -/
 theorem french_universal_competitor_grounded :
     lexiconCompetitor .french .universal = .unpronounceableWithIndirectAlt ∧
     French.Determiners.tous.qforce = .universal ∧
-    French.Determiners.tous.numberRestriction ≠ some .du ∧
-    French.Determiners.les_deux.numberRestriction = some .du := by
+    French.Determiners.tous.numberRestriction ≠ some .Dual ∧
+    French.Determiners.les_deux.numberRestriction = some .Dual := by
   refine ⟨rfl, rfl, ?_, rfl⟩
   decide
 

--- a/Linglib/Studies/Rakosi2019.lean
+++ b/Linglib/Studies/Rakosi2019.lean
@@ -129,7 +129,7 @@ theorem inclusive_not_anaphor :
 theorem quantified_np_asymmetry :
     reciprocalLicensed quantifiedNP = true ∧
     pluralReflexiveLicensed quantifiedNP = false ∧
-    quantifiedNP.verbAgr = .sg := ⟨rfl, rfl, rfl⟩
+    quantifiedNP.verbAgr = .Sing := ⟨rfl, rfl, rfl⟩
 
 /-- §4: Singular coordinate DPs.
 
@@ -141,7 +141,7 @@ theorem quantified_np_asymmetry :
 theorem coordinate_dp_asymmetry :
     reciprocalLicensed singularCoordinate = true ∧
     pluralReflexiveLicensed singularCoordinate = false ∧
-    singularCoordinate.verbAgr = .sg := ⟨rfl, rfl, rfl⟩
+    singularCoordinate.verbAgr = .Sing := ⟨rfl, rfl, rfl⟩
 
 /-- §5: Collective noun antecedents.
 
@@ -156,7 +156,7 @@ theorem coordinate_dp_asymmetry :
 theorem collective_noun_asymmetry :
     reciprocalLicensed collectiveNoun = true ∧
     pluralReflexiveLicensed collectiveNoun = false ∧
-    collectiveNoun.verbAgr = .sg := ⟨rfl, rfl, rfl⟩
+    collectiveNoun.verbAgr = .Sing := ⟨rfl, rfl, rfl⟩
 
 /-- §6: Bound variable antecedent.
 
@@ -170,7 +170,7 @@ theorem collective_noun_asymmetry :
 theorem bound_variable_asymmetry :
     reciprocalLicensed boundVariable = true ∧
     pluralReflexiveLicensed boundVariable = false ∧
-    boundVariable.verbAgr = .sg := ⟨rfl, rfl, rfl⟩
+    boundVariable.verbAgr = .Sing := ⟨rfl, rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 4: Connection to Formal Semantics
@@ -237,7 +237,7 @@ theorem egymas_no_number_feature :
     *maguk* (PL). The anaphor's number must match the verb's agreement,
     confirming that reflexive licensing is morphosyntactic. -/
 theorem reflexive_number_paradigm :
-    maga.number = some .sg ∧ maguk.number = some .pl := ⟨rfl, rfl⟩
+    maga.number = some .Sing ∧ maguk.number = some .Plur := ⟨rfl, rfl⟩
 
 /-- The morphological invariance of *egymás* predicts it should be
     insensitive to verb agreement number — and it is: reciprocals are

--- a/Linglib/Syntax/Pronoun/Basic.lean
+++ b/Linglib/Syntax/Pronoun/Basic.lean
@@ -67,6 +67,12 @@ structure Pronoun where
   gender : Option Features.SurfaceGender := none
   /-- Native script form (hangul, kanji, Devanagari, …). -/
   script : Option String := none
+  /-- Pronoun type (UD `PronType`): the pro-form's lexical kind — personal (`Prs`),
+      interrogative (`Int`), relative (`Rel`), demonstrative (`Dem`), … Real UD morphology,
+      threaded onto the projected word by `toWord`; doubles as the lexical-kind axis the
+      capability tower deferred. Reciprocal (`Rcp`) is *not* stored: `toWord` derives it
+      from `bindingClass = .reciprocal`. `none` where unspecified. -/
+  pronType : Option UD.PronType := none
   /-- The binding class this pro-form declares — its `Features.BindingSource Pronoun` value:
       Principle A anaphor (`.reflexive`/`.reciprocal`), B pronominal (`.pronoun`), or C
       R-expression. *One* source of an expression's binding class — the lexical declaration
@@ -84,6 +90,8 @@ structure PersonalPronoun extends Pronoun where
   /-- Personal pronouns are Principle-B pronominals: the *type* fixes the binding class
       ([chomsky-1981]), overriding `Pronoun`'s `none` default so entries needn't restate it. -/
   bindingClass := some .pronoun
+  /-- Personal pronouns are UD `PronType=Prs`; the *type* fixes the morphology. -/
+  pronType := some UD.PronType.Prs
   /-- Register level (formality/honorifics). Binary T/V systems use
       `.informal`/`.formal`; ternary honorific systems (Hindi, Magahi,
       Maithili, Korean) use all three levels. -/
@@ -117,7 +125,8 @@ def toWord (p : Pronoun) : Word :=
                   -- carry the binding-relevant morphology so a projected pro-form's class is
                   -- read off its own features, not recovered by surface-form lookup
                   reflex := p.bindingClass == some .reflexive,
-                  pronType := if p.bindingClass == some .reciprocal then some .Rcp else none } }
+                  pronType := if p.bindingClass == some .reciprocal then some .Rcp
+                              else p.pronType } }
 
 /-! ### Derived person category and well-formedness ([cysouw-2009]) -/
 
@@ -138,7 +147,7 @@ def category (p : Pronoun) : Option Features.Person.Category :=
     mathlib way) so illegal states are catchable without fragmenting the type. -/
 def WellFormed (p : Pronoun) : Prop :=
   p.clusivity ≠ none →
-    p.person = some .first ∧ (p.number = some .du ∨ p.number = some .pl)
+    p.person = some .first ∧ (p.number = some .Dual ∨ p.number = some .Plur)
 
 instance (p : Pronoun) : Decidable p.WellFormed := by
   unfold WellFormed; infer_instance

--- a/Linglib/Syntax/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Pronoun/Capabilities.lean
@@ -40,8 +40,9 @@ lives in `Features/CoreferenceStatus.lean` — neither is pronoun-specific. Two 
 strength is carrier-uniform (Italian clitics are all `.clitic`; the Mixtec clitic/nonclitic *fields*
 have fixed strengths), so an `α → Strength` accessor would be constant on every carrier — a
 per-*type* fact, not a per-element capability, and it is already served by per-series `def`s +
-`Strength.rank`. A finer *lexical-kind* axis (personal vs relative vs interrogative) is not reducible
-to the A/B/C role and needs a kind enum not worth inventing ahead of a consumer.
+`Strength.rank`. The finer *lexical-kind* axis (personal vs relative vs interrogative vs
+demonstrative) is `Pronoun.pronType` — real UD morphology on the carrier (no invented enum),
+threaded onto the projected word by `toWord`.
 -/
 
 set_option autoImplicit false
@@ -72,23 +73,36 @@ instance : Bound PersonalPronoun := ⟨fun p => p.toPronoun.bindingClass.getD .p
 /-- The canonical morphology source agrees with the mixin: a pro-form's projected word
 classifies (`Binding.bindingClassOf`, reading `Reflex`/`PronType`/category) exactly as the
 carrier's `Bound` class — `Pronoun.toWord` threads the binding morphology faithfully, so the
-surface engine and the capability never diverge. (Excludes a pronoun lexically declared an
-R-expression — a configuration no entry uses — whose surface category `.PRON` would win.) -/
-theorem bindingClassOf_toWord (p : Pronoun) (h : p.bindingClass ≠ some .rExpression) :
+surface engine and the capability never diverge. Two coherence premises, both vacuous for
+every actual entry: the pronoun is not lexically declared an R-expression (its surface
+category `.PRON` would win), and it does not *store* `PronType=Rcp` (reciprocal is derived
+by `toWord` from `bindingClass = .reciprocal`, never stored). -/
+theorem bindingClassOf_toWord (p : Pronoun) (h : p.bindingClass ≠ some .rExpression)
+    (hr : p.pronType = some .Rcp → p.bindingClass = some .reciprocal) :
     Binding.bindingClassOf p.toWord = Bound.source p := by
   show Binding.bindingClassOf p.toWord = some (p.bindingClass.getD .pronoun)
   rcases hb : p.bindingClass with _ | c
-  · simp [Binding.bindingClassOf, Pronoun.toWord, hb]
+  · rcases hp : p.pronType with _ | pt
+    · simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]
+    · cases pt
+      case Rcp => exact absurd ((hr hp).symm.trans hb) (by simp)
+      all_goals (simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide)
   · cases c with
     | reflexive =>
-      simp [Binding.bindingClassOf, Pronoun.toWord, hb]
-      decide
+      rcases hp : p.pronType with _ | pt
+      · simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide
+      · cases pt <;> (simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide)
     | reciprocal =>
-      simp [Binding.bindingClassOf, Pronoun.toWord, hb]
-      decide
+      rcases hp : p.pronType with _ | pt
+      · simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide
+      · cases pt <;> (simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide)
     | pronoun =>
-      simp [Binding.bindingClassOf, Pronoun.toWord, hb]
-      decide
+      rcases hp : p.pronType with _ | pt
+      · simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]
+        try decide
+      · cases pt
+        case Rcp => exact absurd ((hr hp).symm.trans hb) (by simp)
+        all_goals (simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide)
     | rExpression => exact absurd hb h
 
 /-! ### Orthogonal data-mixins: `Deictic`, `Clusive` -/

--- a/Linglib/Syntax/Pronoun/Demonstrative.lean
+++ b/Linglib/Syntax/Pronoun/Demonstrative.lean
@@ -34,6 +34,8 @@ set_option autoImplicit false
     for a distance-neutral demonstrative like German *dieser*). Carries no separate denotation here;
     its meaning is the deictic `Core.Nominal.Description.demonstrative` over its restrictor. -/
 structure DemonstrativePronoun extends Pronoun where
+  /-- Demonstratives are UD `PronType=Dem`; the *type* fixes the morphology. -/
+  pronType := some UD.PronType.Dem
   /-- The deictic feature (proximal/medial/distal, or `unspecified`). -/
   deixis : Features.Deixis.Feature
   deriving Repr, DecidableEq

--- a/Linglib/Syntax/WordGrammar/LexicalRules.lean
+++ b/Linglib/Syntax/WordGrammar/LexicalRules.lean
@@ -84,13 +84,13 @@ def auxInversionRule : LexRule :=
 def passiveRule : LexRule :=
   { name := "Passive"
     applies := λ e =>
-      e.cat == .VERB && e.features.voice != some Voice.passive &&
+      e.cat == .VERB && e.features.voice != some .Pass &&
       e.argStr.slots.any (·.depType == .obj)
     transform := λ e =>
       let newSlots := e.argStr.slots.filter (·.depType != .obj)
       let withByPhrase := newSlots ++ [⟨.obl, .right, false, some .ADP⟩]
       { e with
-        features := { e.features with voice := some Voice.passive }
+        features := { e.features with voice := some .Pass }
         argStr := { slots := withByPhrase } } }
 
 -- ============================================================================


### PR DESCRIPTION
Tier-2 of the Word/Pronoun cleanup. Deletes Word.lean's 12 lowercase value-abbrevs (`Number.sg`, `VForm.finite`, `Tense.past`, …) — the deferred UD-alias sweep — migrating alias-typed sites to UD's own constructors (type-directed: HPSG's own `VForm`, NPNumber, world-state `.du` etc. left untouched). Adds carrier-side `Pronoun.pronType` (UD `PronType`; `Prs`/`Dem` type-defaults, `Int` on English wh-entries), threaded by `toWord` — delivering the deferred lexical-kind axis as real UD morphology and making projected wh-words `isWh` (`whWords_project_isWh`); the faithfulness certificate gains the matching `Rcp`-coherence premise.