### PR TITLE
refactor(Core): dissolve UD into Data/UD, Word into Morphology

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -8,8 +8,8 @@ and their interfaces. See README.md for documentation links.
 import Linglib.Features.Dimension
 import Linglib.Features.Gender
 import Linglib.Core.Valence
-import Linglib.Core.UniversalDependencies
-import Linglib.Core.Subsumption
+import Linglib.Data.UD.Basic
+import Linglib.Morphology.Unification
 import Linglib.Typology.NegativeConcord
 import Linglib.Typology.PolarityItem
 import Linglib.Typology.Negation
@@ -2455,6 +2455,7 @@ import Linglib.Semantics.Lexical.Roots.Closure
 import Linglib.Semantics.Lexical.Roots.SalienceClass
 import Linglib.Morphology.RootTypology
 import Linglib.Morphology.TheorySpace
+import Linglib.Morphology.Word
 import Linglib.Semantics.Spatial.Trace
 import Linglib.Semantics.Events.Adjacency
 import Linglib.Semantics.Events.InitialFinalParts

--- a/Linglib/Core/Tree.lean
+++ b/Linglib/Core/Tree.lean
@@ -1,7 +1,8 @@
 import Mathlib.Data.List.Infix
 import Mathlib.Algebra.Free
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Core.Order.Tree
+import Linglib.Morphology.Word
 
 /-!
 # Trees

--- a/Linglib/Data/UD/Basic.lean
+++ b/Linglib/Data/UD/Basic.lean
@@ -11,15 +11,20 @@ These provide theory-neutral lexical categories, morphological annotations,
 and grammatical relations that can be used in Phenomena/ and mapped to/from
 theory-specific categories (CCG.Cat, Minimalism features, DG trees, etc.).
 
+Official site: <https://universaldependencies.org/>
+
 ## Provenance
 
-Lifted from `Core/Lexical/UD.lean` in the cleanup that dissolved
-`Core/Lexical/`. UD is an external typological standard
-([de-marneffe-zeman-2021]); its types are the foundational
-substrate every other layer aliases against (see `Core/Word.lean`).
-The bare `UD` namespace (no `Core.` prefix) is intentional — UD is its
-own external project, and this file is the linglib mirror of its
-v2 surface.
+UD is an external annotation standard ([de-marneffe-zeman-2021]); this file is
+the linglib mirror of its v2 surface, and `Data/UD/` is the standard's area —
+treebank data (CoNLL-U) belongs here beside the vocabulary, paralleling
+`Data/WALS/` (schema + datapoints). Its types are the foundational
+substrate every other layer builds on: `Features/` aliases the feature types
+(`Features.Number := UD.Number`, …) and `Morphology/Word.lean` builds the
+ms-word token over the vocabulary.
+The bare `UD` namespace (no `Data.` prefix) is intentional — UD is its own
+external project. Subsumption-order theory over `MorphFeatures` lives in
+`Morphology/Unification.lean` (mathlib-importing); this file stays mathlib-light.
 -/
 
 namespace UD
@@ -351,7 +356,7 @@ def MorphFeatures.isWh (f : MorphFeatures) : Bool :=
     ([shieber-1986] §3.2.3)? Total over *all* option-valued fields: a conflict in any
     committed feature makes unification fail. (`reflex` needs no clause — a `Bool` slot
     with `false` = absent is always joinable by `||`.) The order-theoretic
-    characterization is proved in `Core/Subsumption.lean`. -/
+    characterization is proved in `Morphology/Unification.lean`. -/
 def MorphFeatures.compatible (f1 f2 : MorphFeatures) : Bool :=
   (f1.number.isNone   || f2.number.isNone   || f1.number == f2.number) &&
   (f1.gender.isNone   || f2.gender.isNone   || f1.gender == f2.gender) &&
@@ -410,7 +415,7 @@ def MorphFeatures.merge (f1 f2 : MorphFeatures) : MorphFeatures where
   polarity := f1.polarity <|> f2.polarity
 
 /-- Unify two feature bundles ([shieber-1986] §3.2.3): the least upper bound in the
-    subsumption order when the bundles are compatible (`Core/Subsumption.lean` proves
+    subsumption order when the bundles are compatible (`Morphology/Unification.lean` proves
     the lub laws), failure (`none`) on conflicting information. -/
 def MorphFeatures.unify (f1 f2 : MorphFeatures) : Option MorphFeatures :=
   if f1.compatible f2 then some (f1.merge f2) else none
@@ -578,59 +583,3 @@ structure DepArc where
   deriving DecidableEq, Repr
 
 end UD
-
--- ============================================================================
--- Word: the CoNLL-U surface token
--- ============================================================================
-
-structure Word where
-  form : String
-  cat : UD.UPOS
-  features : UD.MorphFeatures := {}
-  deriving Repr
-
-/-- Convenience constructor for a featureless word (form + category only). -/
-def Word.mk' (form : String) (cat : UD.UPOS) : Word := { form := form, cat := cat }
-
-/-- The φ-feature subset (person, number, gender) of a word, as a
-    `UD.MorphFeatures` bundle. -/
-def Word.phi (w : Word) : UD.MorphFeatures :=
-  { person := w.features.person, number := w.features.number,
-    gender := w.features.gender }
-
-/-- φ-agreement between two words: their person/number/gender features are
-    compatible (an unspecified feature is a wildcard). A reflexive, symmetric
-    *tolerance* relation on `Word` (not transitive), decided by the shared
-    `UD.MorphFeatures.compatible`. This is the feature-based agreement primitive
-    binding and concord consumers share — no surface-form gender lookup. -/
-def Word.Agree (w1 w2 : Word) : Prop := w1.phi.compatible w2.phi
-
-instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
-  unfold Word.Agree; infer_instance
-
-@[refl] theorem Word.Agree.refl (w : Word) : Word.Agree w w :=
-  UD.MorphFeatures.compatible_self w.phi
-
-/-- φ-agreement is symmetric — the docstring's "symmetric tolerance relation", as a
-    theorem. (It is *not* transitive: an unspecified feature is a wildcard, so
-    `she ~ they ~ he` while `she ≁ he`.) -/
-@[symm] theorem Word.Agree.symm {w1 w2 : Word} (h : Word.Agree w1 w2) : Word.Agree w2 w1 := by
-  unfold Word.Agree at h ⊢
-  rwa [UD.MorphFeatures.compatible_comm]
-
-
-/-- Derive a passive variant: sets voice to passive. The valence change
-    (detransitivization) is a frame-level fact carried by the passive analysis on
-    `DepTree.frames`, not token data. Composes with `VerbEntry.toWordPastPart`. -/
-def Word.asPassive (w : Word) : Word :=
-  { w with features := { w.features with voice := some .Pass } }
-
-instance : BEq Word where
-  beq w1 w2 := w1.form == w2.form && w1.cat == w2.cat
-
-instance : ToString Word where
-  toString w := w.form
-
-/-- Convert a word list to a readable string. -/
-def wordsToString (ws : List Word) : String :=
-  " ".intercalate (ws.map (·.form))

--- a/Linglib/Features/Case.lean
+++ b/Linglib/Features/Case.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Finset.Card
 import Mathlib.Order.Lattice
 import Mathlib.Tactic.DeriveFintype
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Case — Feature Taxonomy

--- a/Linglib/Features/Gender.lean
+++ b/Linglib/Features/Gender.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.PrivativePair
 
 /-!

--- a/Linglib/Features/Number.lean
+++ b/Linglib/Features/Number.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.PrivativePair
 
 /-!

--- a/Linglib/Features/OntologicalCategory.lean
+++ b/Linglib/Features/OntologicalCategory.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 
 /-!

--- a/Linglib/Features/Person.lean
+++ b/Linglib/Features/Person.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Features.PrivativePair
 

--- a/Linglib/Fragments/Dargwa/Agreement.lean
+++ b/Linglib/Fragments/Dargwa/Agreement.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Prominence
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Gender
 import Linglib.Features.Number
 

--- a/Linglib/Fragments/Dutch/Nouns.lean
+++ b/Linglib/Fragments/Dutch/Nouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Kinds.NominalMappingParameter
 
 /-!

--- a/Linglib/Fragments/English/Auxiliaries.lean
+++ b/Linglib/Fragments/English/Auxiliaries.lean
@@ -1,8 +1,9 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Number
 import Linglib.Features.Person
 import Linglib.Semantics.Modality.ModalTypes
 import Linglib.Features.Register
+import Linglib.Morphology.Word
 
 /-!
 # English Auxiliaries Lexicon Fragment

--- a/Linglib/Fragments/English/Complementizers.lean
+++ b/Linglib/Fragments/English/Complementizers.lean
@@ -1,4 +1,5 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
+import Linglib.Morphology.Word
 
 /-!
 # English Complementizers Lexicon Fragment

--- a/Linglib/Fragments/English/Determiners.lean
+++ b/Linglib/Fragments/English/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Quantification.Lexicon
 
 /-!

--- a/Linglib/Fragments/English/FunctionWords.lean
+++ b/Linglib/Fragments/English/FunctionWords.lean
@@ -1,4 +1,5 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
+import Linglib.Morphology.Word
 
 /-!
 # English Miscellaneous Function Words Fragment

--- a/Linglib/Fragments/English/Modifiers/Adjectives.lean
+++ b/Linglib/Fragments/English/Modifiers/Adjectives.lean
@@ -18,11 +18,12 @@ Both share scale type and antonym information, but serve different grammatical f
 
 -/
 
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.PropertyDomain
 import Linglib.Morphology.Exponence
 import Linglib.Morphology.DegreeContainment
 import Linglib.Semantics.Gradability.Basic
+import Linglib.Morphology.Word
 
 namespace English.Modifiers.Adjectives
 

--- a/Linglib/Fragments/English/Nouns.lean
+++ b/Linglib/Fragments/English/Nouns.lean
@@ -1,8 +1,9 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Gender
 import Linglib.Morphology.Exponence
 import Linglib.Semantics.Kinds.NominalMappingParameter
 import Linglib.Features.MassCount
+import Linglib.Morphology.Word
 
 /-! # English Noun Lexicon Fragment
 

--- a/Linglib/Fragments/English/NumeralModifiers.lean
+++ b/Linglib/Fragments/English/NumeralModifiers.lean
@@ -18,7 +18,7 @@ from "up to" (positive), predicting divergent framing effects.
 
 -/
 
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.PropertyDomain
 import Linglib.Features.Valence
 import Linglib.Semantics.Numerals.Basic

--- a/Linglib/Fragments/English/Pronouns.lean
+++ b/Linglib/Fragments/English/Pronouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Case
 import Linglib.Features.Gender
 import Linglib.Syntax.Pronoun.Basic

--- a/Linglib/Fragments/Farsi/Determiners.lean
+++ b/Linglib/Fragments/Farsi/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Quantification.ChoiceFunction
 import Linglib.Semantics.Modality.ModalTypes
 import Mathlib.Data.Rat.Defs

--- a/Linglib/Fragments/French/Determiners.lean
+++ b/Linglib/Fragments/French/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Quantification.Lexicon
 
 /-!

--- a/Linglib/Fragments/French/Nouns.lean
+++ b/Linglib/Fragments/French/Nouns.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Gender
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Kinds.NominalMappingParameter
 import Linglib.Features.Number
 

--- a/Linglib/Fragments/Ga/Basic.lean
+++ b/Linglib/Fragments/Ga/Basic.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Gender
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Number
 import Linglib.Features.Person
 

--- a/Linglib/Fragments/Italian/Nouns.lean
+++ b/Linglib/Fragments/Italian/Nouns.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Gender
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Kinds.NominalMappingParameter
 import Linglib.Features.Number
 

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -1,6 +1,6 @@
 import Linglib.Syntax.Pronoun.Basic
 import Linglib.Syntax.Pronoun.Capabilities
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Number
 import Linglib.Features.Person
 

--- a/Linglib/Fragments/Japanese/Determiners.lean
+++ b/Linglib/Fragments/Japanese/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Fragments.English.Determiners
 
 /-! # Japanese Quantifier Fragment

--- a/Linglib/Fragments/Japanese/Nouns.lean
+++ b/Linglib/Fragments/Japanese/Nouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Typology.ClassifierSystem
 import Linglib.Fragments.Japanese.Classifier
 import Linglib.Semantics.Kinds.NominalMappingParameter

--- a/Linglib/Fragments/Jarawara/PossessedNouns.lean
+++ b/Linglib/Fragments/Jarawara/PossessedNouns.lean
@@ -1,6 +1,6 @@
 import Linglib.Morphology.DM.NominalStructure
 import Linglib.Typology.Possession
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Gender
 import Linglib.Features.Number
 

--- a/Linglib/Fragments/Mandarin/Determiners.lean
+++ b/Linglib/Fragments/Mandarin/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Typology.ClassifierSystem
 import Linglib.Fragments.English.Determiners
 import Linglib.Fragments.Mandarin.Classifiers

--- a/Linglib/Fragments/Mandarin/Nouns.lean
+++ b/Linglib/Fragments/Mandarin/Nouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Typology.ClassifierSystem
 import Linglib.Fragments.Mandarin.Classifiers
 import Linglib.Semantics.Kinds.NominalMappingParameter

--- a/Linglib/Fragments/Mandarin/Reciprocals.lean
+++ b/Linglib/Fragments/Mandarin/Reciprocals.lean
@@ -1,4 +1,5 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
+import Linglib.Morphology.Word
 
 /-!
 # Mandarin Reciprocal Fragment

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Case
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 import Linglib.Typology.Extraction

--- a/Linglib/Fragments/Mayan/Mam/ExtractionMorphology.lean
+++ b/Linglib/Fragments/Mayan/Mam/ExtractionMorphology.lean
@@ -1,5 +1,5 @@
 import Linglib.Typology.Extraction
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Mam Extraction Morphology Fragment [elkins-torrence-brown-2026]

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -1,8 +1,9 @@
 import Linglib.Features.Case
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Syntax.Case.Alignment
 import Linglib.Syntax.Agreement.Paradigm
+import Linglib.Morphology.Word
 
 /-!
 # Shared Mayan Fragment Infrastructure

--- a/Linglib/Fragments/Mixtec/SMPM/Basic.lean
+++ b/Linglib/Fragments/Mixtec/SMPM/Basic.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Gender
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Syntax.Pronoun.Basic
 
 /-!

--- a/Linglib/Fragments/NezPerce/ClausalEmbedding.lean
+++ b/Linglib/Fragments/NezPerce/ClausalEmbedding.lean
@@ -1,5 +1,5 @@
 import Linglib.Typology.Complementation
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Nez Perce Clausal Embedding Inventory

--- a/Linglib/Fragments/Nungon/MedialVerbs.lean
+++ b/Linglib/Fragments/Nungon/MedialVerbs.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Nungon Medial Verb Morphology [sarvasy-2017]

--- a/Linglib/Fragments/Slavic/Czech/Determiners.lean
+++ b/Linglib/Fragments/Slavic/Czech/Determiners.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Negation.CzechNegation
 
 /-!

--- a/Linglib/Fragments/Spanish/Clitics.lean
+++ b/Linglib/Fragments/Spanish/Clitics.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Number
 import Linglib.Features.Person
 

--- a/Linglib/Fragments/Wambaya/Reciprocals.lean
+++ b/Linglib/Fragments/Wambaya/Reciprocals.lean
@@ -1,4 +1,5 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
+import Linglib.Morphology.Word
 
 /-!
 # Wambaya Reciprocal Fragment

--- a/Linglib/Fragments/Yoruba/FocusParticles.lean
+++ b/Linglib/Fragments/Yoruba/FocusParticles.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Typology.WordOrder
 
 /-!

--- a/Linglib/Morphology/MorphRule.lean
+++ b/Linglib/Morphology/MorphRule.lean
@@ -1,6 +1,7 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Core.Valence
 import Linglib.Syntax.Agreement.Controller
+import Linglib.Morphology.Word
 
 /-!
 # Morphological Infrastructure

--- a/Linglib/Morphology/Unification.lean
+++ b/Linglib/Morphology/Unification.lean
@@ -1,9 +1,9 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Mathlib.Order.Bounds.Basic
 import Mathlib.Order.BoundedOrder.Basic
 
 /-!
-# Subsumption and unification for feature bundles
+# Unification: subsumption and joins for feature bundles
 [shieber-1986]
 
 The information ordering of unification-based grammar ([shieber-1986] §3.2), on
@@ -34,8 +34,14 @@ Unification (§3.2.3) is "the most general feature structure `D` such that `D′
 
 ## Implementation notes
 
-Lives apart from `Core/UniversalDependencies.lean` so that the (heavily imported) UD
-vocabulary stays mathlib-free; this file is the one that pays for `Mathlib.Order`.
+Morphology owns the bundle algebra: `MorphFeatures` is the token's morphology (UD's
+Feats column), unification at the ms-word level is the morphology/syntax interface
+operation, and the order's natural in-house consumers are DM's Subset Principle
+(insert an exponent iff `exponent.features ≤ morpheme.features`) and Nanosyntax
+spellout — its dual. Lives apart from `Data/UD/Basic.lean` so the (heavily imported)
+standard mirror stays mathlib-free — this file is the one that pays for
+`Mathlib.Order` — and it is the canonical home for order instances on
+`UD.MorphFeatures`.
 -/
 
 set_option autoImplicit false

--- a/Linglib/Morphology/Unification.lean
+++ b/Linglib/Morphology/Unification.lean
@@ -35,13 +35,16 @@ Unification (§3.2.3) is "the most general feature structure `D` such that `D′
 ## Implementation notes
 
 Morphology owns the bundle algebra: `MorphFeatures` is the token's morphology (UD's
-Feats column), unification at the ms-word level is the morphology/syntax interface
-operation, and the order's natural in-house consumers are DM's Subset Principle
-(insert an exponent iff `exponent.features ≤ morpheme.features`) and Nanosyntax
-spellout — its dual. Lives apart from `Data/UD/Basic.lean` so the (heavily imported)
-standard mirror stays mathlib-free — this file is the one that pays for
-`Mathlib.Order` — and it is the canonical home for order instances on
-`UD.MorphFeatures`.
+Feats column), and unification at the ms-word level is the morphology/syntax interface
+operation. A natural in-house consumer is the *matching clause* of DM's Subset
+Principle (an exponent is insertable iff `exponent.features ≤ morpheme.features`);
+the competition clause — most-specified-wins — is separate `argmax` machinery, already
+implemented in `Morphology/DM/VocabularyInsertion.lean`. (Nanosyntax's Superset
+Principle is *not* a consumer: it matches by containment of syntactic trees, see
+`Nanosyntax/TreeSpellout.lean`'s `NanoTree.contains`, not by an order on flat
+bundles.) Lives apart from `Data/UD/Basic.lean` so the (heavily imported) standard
+mirror stays mathlib-free — this file is the one that pays for `Mathlib.Order` — and
+it is the canonical home for order instances on `UD.MorphFeatures`.
 -/
 
 set_option autoImplicit false

--- a/Linglib/Morphology/Word.lean
+++ b/Linglib/Morphology/Word.lean
@@ -1,0 +1,91 @@
+import Linglib.Data.UD.Basic
+
+/-!
+# Word — the morphosyntactic word (ms-word) token
+[kalin-bjorkman-etal-2026]
+
+The surface token: the unit that (morpho)syntax treats as a word. Wordhood minimally
+splits into the **ms-word** (this type) and the **p-word** (the prosodic word,
+`Phonology/Prosodic/Word.lean`) — the "one area of robust consensus" on the wordhood
+problem ([kalin-bjorkman-etal-2026] §3.2); we follow the Element in calling ms-words
+simply *words*. The split is descriptive, not a Lexicalist commitment: ms-words are
+"crucial for lexicalist theories" but used descriptively by non-lexicalist ones too
+(§3.2.1, §3.3), and this token carries no theory of how words are formed.
+
+`Word` completes Morphology's word inventory: `MorphWord` is word-*internal* structure,
+`MorphRule`/`Stem` are word-forming *processes*, `Word` is the resulting *token* —
+form + UD category + one `UD.MorphFeatures` bundle, i.e. a CoNLL-U row. The
+ms- vs p-boundness typology relating the two word notions ([kalin-bjorkman-etal-2026]
+Table 3) is formalized in `Studies/KalinBjorkmanEtAl2026.lean`.
+
+## Main declarations
+
+* `Word` — the token, with its **admission rule** (see the declaration docstring).
+* `Word.phi` — the φ-feature projection (person/number/gender).
+* `Word.Agree` — φ-agreement: a reflexive, symmetric, non-transitive tolerance relation.
+* `Word.asPassive` — passive variant (voice morphology only; valence effects are
+  `DepTree.frames`-level facts).
+-/
+
+set_option autoImplicit false
+
+/-- A word: the pure CoNLL-U surface token — surface form, UD category, and UD
+    morphology (one `UD.MorphFeatures` bundle; there is no separate word-level feature
+    record).
+
+    **Admission rule**: a property belongs on `Word` iff a Fragment-free token-level
+    engine reads it off the token's *own* data; otherwise it lives on the typed lexical
+    carrier (`Pronoun`, `NounEntry`, `Verb`, …) or on the consuming framework's own
+    structures (e.g. DG subcategorization premises live on `DepTree.frames`, not here).
+    Identity caveat: `BEq` is form + category, so homographs collapse; a CoNLL-U
+    `lemma` field is the known fix, deferred until a consumer needs it. -/
+structure Word where
+  form : String
+  cat : UD.UPOS
+  features : UD.MorphFeatures := {}
+  deriving Repr
+
+/-- Convenience constructor for a featureless word (form + category only). -/
+def Word.mk' (form : String) (cat : UD.UPOS) : Word := { form := form, cat := cat }
+
+/-- The φ-feature subset (person, number, gender) of a word, as a
+    `UD.MorphFeatures` bundle. -/
+def Word.phi (w : Word) : UD.MorphFeatures :=
+  { person := w.features.person, number := w.features.number,
+    gender := w.features.gender }
+
+/-- φ-agreement between two words: their person/number/gender features are
+    compatible (an unspecified feature is a wildcard). A reflexive, symmetric
+    *tolerance* relation on `Word` (not transitive), decided by the shared
+    `UD.MorphFeatures.compatible`. This is the feature-based agreement primitive
+    binding and concord consumers share — no surface-form gender lookup. -/
+def Word.Agree (w1 w2 : Word) : Prop := w1.phi.compatible w2.phi
+
+instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
+  unfold Word.Agree; infer_instance
+
+@[refl] theorem Word.Agree.refl (w : Word) : Word.Agree w w :=
+  UD.MorphFeatures.compatible_self w.phi
+
+/-- φ-agreement is symmetric — the docstring's "symmetric tolerance relation", as a
+    theorem. (It is *not* transitive: an unspecified feature is a wildcard, so
+    `she ~ they ~ he` while `she ≁ he`.) -/
+@[symm] theorem Word.Agree.symm {w1 w2 : Word} (h : Word.Agree w1 w2) : Word.Agree w2 w1 := by
+  unfold Word.Agree at h ⊢
+  rwa [UD.MorphFeatures.compatible_comm]
+
+/-- Derive a passive variant: sets voice to passive. The valence change
+    (detransitivization) is a frame-level fact carried by the passive analysis on
+    `DepTree.frames`, not token data. Composes with `VerbEntry.toWordPastPart`. -/
+def Word.asPassive (w : Word) : Word :=
+  { w with features := { w.features with voice := some UD.Voice.Pass } }
+
+instance : BEq Word where
+  beq w1 w2 := w1.form == w2.form && w1.cat == w2.cat
+
+instance : ToString Word where
+  toString w := w.form
+
+/-- Convert a word list to a readable string. -/
+def wordsToString (ws : List Word) : String :=
+  " ".intercalate (ws.map (·.form))

--- a/Linglib/Paradigms/AcceptabilityJudgment.lean
+++ b/Linglib/Paradigms/AcceptabilityJudgment.lean
@@ -1,8 +1,9 @@
 import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Tactic.NormNum
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.ClauseForm
+import Linglib.Morphology.Word
 
 /-!
 # Acceptability Judgment Paradigm

--- a/Linglib/Phenomena/Anaphora/DonkeyAnaphora.lean
+++ b/Linglib/Phenomena/Anaphora/DonkeyAnaphora.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Definiteness
 import Linglib.Core.Nominal.Determiner
 import Linglib.Fragments.German.Definiteness

--- a/Linglib/Phenomena/Attitudes/ConjunctionDistribution.lean
+++ b/Linglib/Phenomena/Attitudes/ConjunctionDistribution.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-! # Conjunction Distribution: Empirical Data
 

--- a/Linglib/Phenomena/Attitudes/IntentionalIdentity.lean
+++ b/Linglib/Phenomena/Attitudes/IntentionalIdentity.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Intentional Identity Data [chatzikyriakidis-etal-2025]

--- a/Linglib/Phenomena/AuxiliaryVerbs/Selection.lean
+++ b/Linglib/Phenomena/AuxiliaryVerbs/Selection.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Be/Have Auxiliary Selection in European Perfects

--- a/Linglib/Phenomena/Ellipsis/FragmentAnswers.lean
+++ b/Linglib/Phenomena/Ellipsis/FragmentAnswers.lean
@@ -27,7 +27,7 @@ Fragment answers differ from sluicing:
 
 -/
 
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 ## Connection to RSA Theory

--- a/Linglib/Phenomena/Ellipsis/NPEllipsis.lean
+++ b/Linglib/Phenomena/Ellipsis/NPEllipsis.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Quantification.BinominalDefs
 
 /-!

--- a/Linglib/Phenomena/Ellipsis/Sluicing.lean
+++ b/Linglib/Phenomena/Ellipsis/Sluicing.lean
@@ -47,7 +47,7 @@ Case matching follows from the continuation analysis:
 
 -/
 
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 namespace Phenomena.Ellipsis.Sluicing
 

--- a/Linglib/Phenomena/Ellipsis/VPEllipsis.lean
+++ b/Linglib/Phenomena/Ellipsis/VPEllipsis.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # VP Ellipsis: Empirical Data

--- a/Linglib/Phenomena/Focus/Basic.lean
+++ b/Linglib/Phenomena/Focus/Basic.lean
@@ -12,7 +12,7 @@ Empirical data on focus interpretation effects (association with focus, contrast
 
 -/
 
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.InformationStructure
 
 open Features.InformationStructure (FIPApplication)

--- a/Linglib/Phenomena/Focus/ProsodicExhaustivity.lean
+++ b/Linglib/Phenomena/Focus/ProsodicExhaustivity.lean
@@ -32,7 +32,7 @@ This phenomenon relates to mention-all vs mention-some:
 
 -/
 
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 ## Connection to RSA Theory

--- a/Linglib/Phenomena/NullSubject/Defs.lean
+++ b/Linglib/Phenomena/NullSubject/Defs.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Subject-Context Vocabulary

--- a/Linglib/Phenomena/Politeness/Honorifics.lean
+++ b/Linglib/Phenomena/Politeness/Honorifics.lean
@@ -13,7 +13,7 @@ encode addressee features — and the morphosyntactic expression of honorifics.
 
 -/
 
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 namespace Phenomena.Politeness.Honorifics
 

--- a/Linglib/Phenomena/Questions/Basic.lean
+++ b/Linglib/Phenomena/Questions/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.OntologicalCategory
 
 /-!

--- a/Linglib/Pragmatics/Implicature/Basic.lean
+++ b/Linglib/Pragmatics/Implicature/Basic.lean
@@ -1,5 +1,6 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Entailment.Polarity
+import Linglib.Morphology.Word
 
 /-!
 # Neo-Gricean Pragmatics: Basic Definitions

--- a/Linglib/Semantics/ArgumentStructure/Defs.lean
+++ b/Linglib/Semantics/ArgumentStructure/Defs.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Events.Basic
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.ArgumentStructure.Linking
 
 /-!

--- a/Linglib/Semantics/Aspect/Composition.lean
+++ b/Linglib/Semantics/Aspect/Composition.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Aktionsart
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.MassCount
 
 /-!

--- a/Linglib/Semantics/Dynamic/DiscourseRef.lean
+++ b/Linglib/Semantics/Dynamic/DiscourseRef.lean
@@ -47,10 +47,11 @@ This separation enables anaphora to indefinites under negation:
 
 -/
 
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Dynamic.Connectives.CCP
 import Linglib.Features.MassCount
 import Mathlib.Data.Fintype.Basic
+import Linglib.Morphology.Word
 
 
 

--- a/Linglib/Semantics/Kinds/NominalMappingParameter.lean
+++ b/Linglib/Semantics/Kinds/NominalMappingParameter.lean
@@ -36,9 +36,10 @@ import Linglib.Features.MassCount
 import Mathlib.Data.Set.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.UpperLower.Basic
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Core.Mereology
 import Linglib.Core.Logic.Intensional.Rigidity
+import Linglib.Morphology.Word
 
 
 

--- a/Linglib/Semantics/Mood/ClauseType.lean
+++ b/Linglib/Semantics/Mood/ClauseType.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Mood.Basic
 import Linglib.Semantics.Mood.IllocutionaryMood
 import Linglib.Discourse.Roles
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Clause Type: Force × Mood

--- a/Linglib/Semantics/Quantification/Lexicon.lean
+++ b/Linglib/Semantics/Quantification/Lexicon.lean
@@ -1,5 +1,6 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Number
+import Linglib.Morphology.Word
 
 /-!
 # Quantifier lexicon — shared structure

--- a/Linglib/Semantics/TypeTheoretic/Basic.lean
+++ b/Linglib/Semantics/TypeTheoretic/Basic.lean
@@ -2,7 +2,7 @@ import Mathlib.Data.Set.Basic
 import Linglib.Core.Logic.Intensional.Rigidity
 import Linglib.Discourse.CommonGround
 import Linglib.Semantics.Presupposition.Basic
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Type Theory with Records — Core Foundations

--- a/Linglib/Studies/AlexeyenkoZeijlstra2025.lean
+++ b/Linglib/Studies/AlexeyenkoZeijlstra2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Data.WALS.Features.F87A
 import Linglib.Syntax.Minimalist.Modification
 import Linglib.Fragments.Greek.StandardModern.AdjAgreement

--- a/Linglib/Studies/AnandHardtMcCloskey2021.lean
+++ b/Linglib/Studies/AnandHardtMcCloskey2021.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Phenomena.Ellipsis.Sluicing
 import Linglib.Syntax.Minimalist.Ellipsis.FormalMatching
 import Linglib.Syntax.Minimalist.Ellipsis.DeletionDomain

--- a/Linglib/Studies/Cacchioli2025.lean
+++ b/Linglib/Studies/Cacchioli2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Syntax.Minimalist.Agree
 import Linglib.Typology.Complementation
 import Linglib.Fragments.Tigrinya.ClausePrefixes

--- a/Linglib/Studies/FillmoreKayOConnor1988.lean
+++ b/Linglib/Studies/FillmoreKayOConnor1988.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Acceptability
 import Linglib.Syntax.ConstructionGrammar.Studies.FillmoreKayOConnor1988
 import Linglib.Typology.PolarityItem

--- a/Linglib/Studies/Gibson2025.lean
+++ b/Linglib/Studies/Gibson2025.lean
@@ -1,7 +1,8 @@
 import Linglib.Syntax.DependencyGrammar.Formal.HarmonicOrder
 import Linglib.Data.WALS.Features.F95A
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Typology.WordOrder
+import Linglib.Morphology.Word
 
 /-!
 # Gibson 2025: DLM and the Head-Direction Generalization

--- a/Linglib/Studies/Gotham2017.lean
+++ b/Linglib/Studies/Gotham2017.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Copredication: [gotham-2017]'s account + bridge data

--- a/Linglib/Studies/Haspelmath1997Polarity.lean
+++ b/Linglib/Studies/Haspelmath1997Polarity.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Data.WALS.Aggregation
 import Linglib.Data.WALS.Features.F46A
 import Linglib.Typology.PolarityItem

--- a/Linglib/Studies/KehlerRohde2013.lean
+++ b/Linglib/Studies/KehlerRohde2013.lean
@@ -1,5 +1,5 @@
 import Linglib.Discourse.Coherence
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Discourse.Centering.Rule1
 import Linglib.Discourse.Centering.Instances.GrammaticalRole
 

--- a/Linglib/Studies/OsborneLi2023.lean
+++ b/Linglib/Studies/OsborneLi2023.lean
@@ -1,7 +1,8 @@
 import Linglib.Syntax.DependencyGrammar.Basic
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Data.Examples.Schema
 import Linglib.Syntax.DependencyGrammar.Coordination
+import Linglib.Morphology.Word
 
 /-!
 # CRDC: Conjunct Referential Dependency Constraint

--- a/Linglib/Studies/RomeroHan2004.lean
+++ b/Linglib/Studies/RomeroHan2004.lean
@@ -1,5 +1,5 @@
 import Linglib.Discourse.CommonGround
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Romero & Han (2004): Negative Yes/No Questions and Epistemic Bias

--- a/Linglib/Studies/TurkHirsch2026.lean
+++ b/Linglib/Studies/TurkHirsch2026.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.InformationStructure
 import Linglib.Core.Logic.Intensional.Premise
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Semantics.Alternatives.AltMeaning
 import Linglib.Semantics.Polarity.Operator
 import Linglib.Semantics.Focus.Interpretation

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Fragments.Mandarin.QuestionParticles
 import Linglib.Semantics.Modality.Kernel
 import Linglib.Features.QParticleLayer

--- a/Linglib/Syntax/Agreement/Paradigm.lean
+++ b/Linglib/Syntax/Agreement/Paradigm.lean
@@ -1,5 +1,6 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
+import Linglib.Morphology.Word
 
 /-!
 # Agreement paradigms — the descriptive realization table

--- a/Linglib/Syntax/Binding/Basic.lean
+++ b/Linglib/Syntax/Binding/Basic.lean
@@ -1,5 +1,6 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.CoreferenceStatus
+import Linglib.Morphology.Word
 
 /-!
 # Binding principles over a command relation

--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -3,7 +3,7 @@ import Linglib.Syntax.ConstructionGrammar.Studies.GoldbergShirtz2025
 import Linglib.Syntax.ConstructionGrammar.Studies.FillmoreKayOConnor1988
 import Linglib.Core.CombinationKind
 import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 
 /-!
 # Argument Structure Constructions

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -1,6 +1,7 @@
 import Mathlib.Data.List.Basic
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Core.Valence
+import Linglib.Morphology.Word
 
 /-!
 # Dependency grammar substrate

--- a/Linglib/Syntax/DependencyGrammar/Nominal.lean
+++ b/Linglib/Syntax/DependencyGrammar/Nominal.lean
@@ -1,8 +1,9 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.CoreferenceStatus
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Pronouns
 import Linglib.Fragments.English.Predicates.Verbal
+import Linglib.Morphology.Word
 
 /-!
 # Shared English test words for DG coreference theories

--- a/Linglib/Syntax/HPSG/Basic.lean
+++ b/Linglib/Syntax/HPSG/Basic.lean
@@ -3,7 +3,8 @@ HPSG formalization: typed feature structures, signs, and phrase structure schema
 [pollard-sag-1994], [sag-wasow-bender-2003], [ginzburg-sag-2000].
 -/
 
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
+import Linglib.Morphology.Word
 
 namespace HPSG
 

--- a/Linglib/Syntax/Minimalist/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Basic.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Set.Basic
 import Mathlib.Data.Multiset.Basic
 import Mathlib.Algebra.Free
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Core.Combinatorics.RootedTree.Decorated
 
 /-!

--- a/Linglib/Syntax/Minimalist/Features.lean
+++ b/Linglib/Syntax/Minimalist/Features.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Case
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Features.Number
 

--- a/Linglib/Syntax/Pronoun/Basic.lean
+++ b/Linglib/Syntax/Pronoun/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.Case
 import Linglib.Features.Register
 import Linglib.Features.Prominence
@@ -7,6 +7,7 @@ import Linglib.Features.Clusivity
 import Linglib.Features.CoreferenceStatus
 import Linglib.Features.Number
 import Linglib.Features.Person
+import Linglib.Morphology.Word
 
 /-!
 # Pronoun

--- a/Linglib/Syntax/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Pronoun/Capabilities.lean
@@ -1,10 +1,11 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Features.CoreferenceStatus
 import Linglib.Features.Register
 import Linglib.Features.Prominence
 import Linglib.Features.Clusivity
 import Linglib.Syntax.Binding.Basic
 import Linglib.Syntax.Pronoun.Basic
+import Linglib.Morphology.Word
 
 /-!
 # Pronoun capabilities — a mixin tower over pronoun carriers

--- a/Linglib/Typology/Adposition.lean
+++ b/Linglib/Typology/Adposition.lean
@@ -1,5 +1,5 @@
 import Linglib.Data.WALS.Features.F85A
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Typology.WordOrder
 
 /-!

--- a/Linglib/Typology/AuxiliaryVerbs.lean
+++ b/Linglib/Typology/AuxiliaryVerbs.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Morphology.MorphRule
 
 /-!

--- a/Linglib/Typology/ClauseChaining.lean
+++ b/Linglib/Typology/ClauseChaining.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.UniversalDependencies
+import Linglib.Data.UD.Basic
 import Linglib.Typology.WordOrder
 
 /-! # Clause Chaining Typology [sarvasy-aikhenvald-2025] [foley-r-d-van-valin-1984] [longacre-2007]


### PR DESCRIPTION
First Core-dissolution PR; establishes the pattern *standard mirrors to `Data/`, constructed objects to their subfield, theory beside its consumers*.

- `Core/UniversalDependencies.lean` → `Data/UD/Basic.lean` — the pure UD v2 mirror (<https://universaldependencies.org/>), treebank data (CoNLL-U) to live beside it, paralleling `Data/WALS/`; 89-importer sweep, namespace unchanged.
- `Word` + `phi`/`Agree`/`asPassive` → `Morphology/Word.lean` — the **ms-word** token per [kalin-bjorkman-etal-2026] §3.2's consensus ms-/p-word split (p-word: `Phonology/Prosodic/Word.lean`); restores the admission-rule docstring that the #121 splice silently dropped.
- `Core/Subsumption.lean` → `Morphology/Unification.lean` — the bundle algebra beside the token; DM Subset Principle / Nanosyntax spellout are its natural in-house consumers.