### PR TITLE
feat(Syntax/Pronoun): order Strength, add Pronoun.strength field

### DIFF
--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -111,7 +111,7 @@ structure CliticEntry where
 The clitic is its own bespoke struct — capabilities abstract over it without merging it into
 `Pronoun` (the `FunLike`-over-many-hom-types pattern). Deficiency is deliberately *not* a capability
 here: it is per-series (the whole clitic paradigm is `.clitic`), modelled by `cliticStrength` below
-and `Strength.rank`, not by a per-element accessor. -/
+and the `Strength` order, not by a per-element accessor. -/
 
 /-- A clitic's surface form + φ-features (person/number). -/
 instance : Proform CliticEntry :=
@@ -159,7 +159,10 @@ def si_refl_pl : CliticEntry := { form := "si", person := .third, number := .Plu
 -- § 3: Paradigm and Syncretism
 -- ============================================================================
 
-/-- The full clitic paradigm as a flat list. -/
+/-- The traditional atonic (object) paradigm as a flat list. NB: the series is
+    not strength-homogeneous — [cardinaletti-starke-1999] classify dative
+    *loro* as *weak*, not clitic (not verb-adjacent, never clusters); see
+    `loroDatStrength` below. The rest are clitics proper. -/
 def paradigm : List CliticEntry :=
   [ mi_acc, mi_dat, mi_refl,
     ti_acc, ti_dat, ti_refl,
@@ -251,18 +254,31 @@ theorem has_both_numbers :
 -- § 5: Cardinaletti–Starke deficiency classes
 -- ============================================================================
 
-/-- Italian's two pronoun series instantiate two Cardinaletti–Starke deficiency
-    classes ([cardinaletti-starke-1999]): the strong forms (`allPronouns`)
-    are `.strong`; the object clitics (`paradigm`) are `.clitic`. -/
+/-- Italian's tonic series (`allPronouns`) instantiates the Cardinaletti–Starke
+    `.strong` class ([cardinaletti-starke-1999]). -/
 def strongStrength : Strength := .strong
 
-/-- The object-clitic series is the maximally deficient `.clitic` class. -/
+/-- The object clitics (`paradigm` minus dative *loro*) are the maximally
+    deficient `.clitic` class: verb-adjacent heads that cluster
+    ([cardinaletti-starke-1999]). -/
 def cliticStrength : Strength := .clitic
 
-/-- The clitic series is structurally more deficient than the strong series
-    (lower `Strength.rank`): the deficiency ordering behind their complementary
-    distribution (clitics host-adjacent and unfocusable, strong forms free). -/
-theorem clitics_more_deficient :
-    Strength.rank cliticStrength < Strength.rank strongStrength := by decide
+/-- Dative *loro* is [cardinaletti-starke-1999]'s parade case for separating
+    weak from clitic: deficient (reduced vs *a loro*, no coordination) but a
+    maximal projection — not verb-adjacent, never clustering, bears word
+    stress. -/
+def loroDatStrength : Strength := .weak
+
+/-- The clitic series is structurally more deficient than the strong series:
+    the deficiency ordering behind their complementary distribution (clitics
+    host-adjacent and unfocusable, strong forms free). -/
+theorem clitics_more_deficient : cliticStrength < strongStrength := by decide
+
+/-- The traditional atonic paradigm is not strength-homogeneous: dative *loro*
+    (weak) sits strictly between the clitics and the strong series
+    ([cardinaletti-starke-1999]). -/
+theorem atonic_series_not_homogeneous :
+    cliticStrength < loroDatStrength ∧ loroDatStrength < strongStrength :=
+  ⟨by decide, by decide⟩
 
 end Italian.Pronouns

--- a/Linglib/Fragments/Mixtec/SMPM/Basic.lean
+++ b/Linglib/Fragments/Mixtec/SMPM/Basic.lean
@@ -125,11 +125,10 @@ def controlledSubjectStrength : Pronoun.Strength := PronounForm.cliticStrength
 
 /-- SMPM's ban on nonclitic controlled subjects (67) realizes the
     Cardinaletti–Starke prediction: the required form is strictly more
-    deficient (lower `Strength.rank`) than the nonclitic strong alternative.
-    Derived from the shared deficiency ranking, not stipulated. -/
+    deficient than the nonclitic strong alternative. Derived from the shared
+    deficiency order, not stipulated. -/
 theorem controlledSubject_is_most_deficient :
-    Pronoun.Strength.rank controlledSubjectStrength
-      < Pronoun.Strength.rank PronounForm.noncliticStrength := by decide
+    controlledSubjectStrength < PronounForm.noncliticStrength := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 4: Embedded Clause Typology (table 26)

--- a/Linglib/Studies/Ariel2001.lean
+++ b/Linglib/Studies/Ariel2001.lean
@@ -217,14 +217,13 @@ def strengthToAccessibility : Strength → AccessibilityLevel
   | .clitic => .cliticizedPron
 
 /-- `strengthToAccessibility` is antitone in structural strength: a more
-    deficient pronoun (lower `rank`) marks higher accessibility, so the
-    clitic > weak > strong accessibility ordering follows from the intrinsic
-    deficiency order rather than being restated. -/
+    deficient pronoun (lower in the deficiency order) marks higher
+    accessibility, so the clitic > weak > strong accessibility ordering
+    follows from the intrinsic deficiency order rather than being restated. -/
 theorem strengthToAccessibility_antitone {a b : Strength}
-    (h : a.rank < b.rank) :
+    (h : a < b) :
     (strengthToAccessibility b).rank < (strengthToAccessibility a).rank := by
-  cases a <;> cases b <;>
-    simp_all [Strength.rank, strengthToAccessibility, AccessibilityLevel.rank]
+  cases a <;> cases b <;> revert h <;> decide
 
 /-- All three pronoun strengths coarsen to the same definiteness level. -/
 theorem strength_coarsening_agrees :

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -367,12 +367,11 @@ theorem smpm_copy_cannot_bear_focus :
     (copyControlProfile smpmCopyControlType).copyCanBearFocus = false := rfl
 
 /-- The clitic requirement, derived from the fragment and routed through the
-    Cardinaletti–Starke deficiency ranking: the required controlled-subject form
-    is strictly more deficient (lower `Strength.rank`) than the nonclitic strong
-    alternative. -/
+    Cardinaletti–Starke deficiency order: the required controlled-subject form
+    is strictly more deficient than the nonclitic strong alternative. -/
 theorem smpm_controlled_must_be_clitic :
-    Pronoun.Strength.rank Mixtec.SMPM.controlledSubjectStrength
-      < Pronoun.Strength.rank Mixtec.SMPM.PronounForm.noncliticStrength :=
+    Mixtec.SMPM.controlledSubjectStrength
+      < Mixtec.SMPM.PronounForm.noncliticStrength :=
   Mixtec.SMPM.controlledSubject_is_most_deficient
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Syntax/Pronoun/Basic.lean
+++ b/Linglib/Syntax/Pronoun/Basic.lean
@@ -1,3 +1,4 @@
+import Mathlib.Order.Nat
 import Linglib.Data.UD.Basic
 import Linglib.Features.Case
 import Linglib.Features.Register
@@ -30,7 +31,8 @@ in as fields of the general `Pronoun`.
 * `PersonalPronoun` — personal/referential pronoun: `extends Pronoun` with the
   register and referential-person features specific to deictic pronouns.
 * `Pronoun.Strength` — [cardinaletti-starke-1999] strong/weak/clitic
-  deficiency order (via `Strength.rank`). Orthogonal to
+  deficiency scale, a `LinearOrder` (`clitic < weak < strong`), carried
+  per-series by `Pronoun.strength`. Orthogonal to
   [dechaine-wiltschko-2002]'s categorial pro-DP/φP/NP axis; a framework's
   structural account of the order stays in its study file.
 * `Pronoun.AllocutiveEntry` — speaker–addressee (allocutive) markers.
@@ -39,6 +41,63 @@ in as fields of the general `Pronoun`.
 open Features (Number Person)
 
 set_option autoImplicit false
+
+/-! ### Structural deficiency ([cardinaletti-starke-1999]) -/
+
+/-- [cardinaletti-starke-1999]'s three pronoun classes, linearly ordered by
+    structural deficiency: `clitic < weak < strong` (more structure = greater;
+    C&S's morphological asymmetry is exactly this chain). The classes are
+    structural/distributional — clitic = deficient head, weak = deficient
+    phrase, strong = non-deficient phrase; (un)stressedness is explicitly
+    *not* the defining property (C&S document stressed deficients and
+    unstressed strongs). Framework-neutral: only the scale lives here; a
+    framework's structural account of it stays in its study file (e.g.
+    [patel-grosz-grosz-2017]), and it is orthogonal to
+    [dechaine-wiltschko-2002]'s pro-DP/pro-φP/pro-NP categorial axis.
+    [cetnarowska-2004] and [jung-migdalski-2022] refine the scale four ways
+    (splitting `strong` into stressed/unstressed); that refinement and its
+    monotone collapse onto this scale live with those studies. -/
+inductive Pronoun.Strength where
+  /-- Deficient and a *head* (X°) at surface structure: verb-adjacent,
+      clustering, prosodically dependent (Italian *lo*, French *le*, Slovak
+      *mu*). Bottom of the scale. -/
+  | clitic
+  /-- Deficient but a *maximal projection*: confined to derived XP positions,
+      non-coordinable, yet a prosodic word of its own (German *es*, Slovak
+      *ono*, Italian dative *loro*). -/
+  | weak
+  /-- Non-deficient maximal projection: full structure — coordinable,
+      c-modifiable, possible in θ- and peripheral positions, bears its own
+      range restriction (Italian/French *lui*, Slovak *jemu*). Top of the
+      scale. -/
+  | strong
+  deriving DecidableEq, Repr
+
+namespace Pronoun.Strength
+
+/-- Numeric embedding into ℕ preserving the deficiency order. -/
+def toNat : Strength → Nat
+  | .clitic => 0
+  | .weak   => 1
+  | .strong => 2
+
+instance : LinearOrder Strength :=
+  LinearOrder.lift' toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+
+/-- A clitic is more deficient than a weak pronoun. -/
+theorem clitic_lt_weak : (.clitic : Strength) < .weak := by decide
+
+/-- A weak pronoun is more deficient than a strong one. -/
+theorem weak_lt_strong : (.weak : Strength) < .strong := by decide
+
+/-- `clitic` is the most deficient class. -/
+theorem clitic_le (s : Strength) : .clitic ≤ s := by cases s <;> decide
+
+/-- `strong` is the least deficient class. -/
+theorem le_strong (s : Strength) : s ≤ .strong := by cases s <;> decide
+
+end Pronoun.Strength
 
 /-- The general pronoun object: the morphosyntactic core shared by every pronoun
     type (personal, indefinite, demonstrative, interrogative, …). Carries what is true
@@ -85,6 +144,13 @@ structure Pronoun where
       a theory may instead source the class structurally or from context. `none` for a bare
       φ-shell. -/
   bindingClass : Option Features.BindingClass := none
+  /-- [cardinaletti-starke-1999] deficiency class of the form-*series* this entry
+      represents, when the series is homogeneous (an Italian object clitic
+      `some .clitic`, French *lui* `some .strong`). `none` = unrecorded, or no
+      stable class ([jung-migdalski-2022]'s double-duty forms). Consumers
+      condition on `some`; there is no default class — C&S's deficient-as-default
+      ("Minimize Structure") is a refutable theory claim, not API. -/
+  strength : Option Pronoun.Strength := none
   deriving Repr, BEq, DecidableEq
 
 /-- Cross-linguistic *personal/referential* pronoun: the general `Pronoun` object
@@ -156,30 +222,6 @@ def WellFormed (p : Pronoun) : Prop :=
 
 instance (p : Pronoun) : Decidable p.WellFormed := by
   unfold WellFormed; infer_instance
-
-/-! ### Structural deficiency ([cardinaletti-starke-1999]) -/
-
-/-- [cardinaletti-starke-1999]'s three pronoun classes, ordered by
-    structural deficiency (strong > weak > clitic). Framework-neutral: only the
-    ranking lives here, and it is orthogonal to [dechaine-wiltschko-2002]'s
-    pro-DP/pro-φP/pro-NP categorial axis. A framework's structural account of
-    the ranking stays in its study file (e.g. [patel-grosz-grosz-2017]). -/
-inductive Strength where
-  /-- Full, stressed forms (e.g., English *me*, French *moi*). -/
-  | strong
-  /-- Reduced, unstressed but phonologically independent (e.g., German *es*). -/
-  | weak
-  /-- Phonologically deficient, attached to a host (e.g., French *me*, *te*, *le*). -/
-  | clitic
-  deriving DecidableEq, Repr
-
-/-- Structural-richness rank: 2 (strong, least deficient) to 0 (clitic, most
-    deficient). The [cardinaletti-starke-1999] deficiency hierarchy is the
-    reverse order. -/
-def Strength.rank : Strength → Nat
-  | .strong => 2
-  | .weak   => 1
-  | .clitic => 0
 
 /-! ### Lexical entry schemas ([alok-bhalla-2026]) -/
 

--- a/Linglib/Syntax/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Pronoun/Capabilities.lean
@@ -40,8 +40,9 @@ lives in `Features/CoreferenceStatus.lean` — neither is pronoun-specific. Two 
 ([cardinaletti-starke-1999] `Pronoun.Strength`) is *per-series*, not per-element: every carrier's
 strength is carrier-uniform (Italian clitics are all `.clitic`; the Mixtec clitic/nonclitic *fields*
 have fixed strengths), so an `α → Strength` accessor would be constant on every carrier — a
-per-*type* fact, not a per-element capability, and it is already served by per-series `def`s +
-`Strength.rank`. The finer *lexical-kind* axis (personal vs relative vs interrogative vs
+per-*type* fact, not a per-element capability. It is served by the `Pronoun.strength` field
+(series-level, `none` when not homogeneous) and the `Strength` linear order, not by a class.
+The finer *lexical-kind* axis (personal vs relative vs interrogative vs
 demonstrative) is `Pronoun.pronType` — real UD morphology on the carrier (no invented enum),
 threaded onto the projected word by `toWord`.
 -/

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -32160,3 +32160,27 @@
   subfield  = {semantics/reference},
   role      = {foundational}
 }
+
+@article{cetnarowska-2004,
+  author    = {Cetnarowska, Bo{\.z}ena},
+  year      = {2004},
+  title     = {The scale of pronominal strength in {Polish}: An {OT} analysis of unstressed and weak pronouns},
+  journal   = {Pozna{\'n} Studies in Contemporary Linguistics},
+  volume    = {39},
+  pages     = {39--57},
+  subfield  = {syntax/clitics},
+  role      = {cited}
+}
+
+@article{jung-migdalski-2022,
+  author    = {Jung, Hakyung and Migdalski, Krzysztof},
+  year      = {2022},
+  title     = {Toward a four-way pronoun hierarchy: A view from {Slavic}},
+  journal   = {Journal of Slavic Linguistics},
+  volume    = {30},
+  number    = {FASL 29 extra issue},
+  pages     = {1--11},
+  doi       = {10.1353/jsl.2022.a923070},
+  subfield  = {syntax/clitics},
+  role      = {cited}
+}


### PR DESCRIPTION
Replaces `Strength.rank : Nat` with a `LinearOrder` on `Pronoun.Strength` (clitic < weak < strong, C&S's morphological asymmetry) and adds the per-series `Pronoun.strength : Option Strength` field; consumer theorems (Italian, Mixtec, Ostrove2026) restated as order facts.

- constructor glosses rewritten structurally (deficiency × X-bar status) per C&S's own anti-stress annexe, verified against the primary source
- Italian dative *loro* reclassified weak per C&S; new `atonic_series_not_homogeneous`
- verified bib entries cetnarowska-2004, jung-migdalski-2022 (four-way refinement rivals, cited in the docstring)