### PR TITLE
feat(Features): generalize BundleLike to per-slot order types

### DIFF
--- a/Linglib/Features/Basic.lean
+++ b/Linglib/Features/Basic.lean
@@ -14,7 +14,7 @@ assignment over a feature space, an attribute-value structure, a
 hierarchical tree whose root label is the flat bundle. They agree about
 what a bundle *says*: which features it specifies, with which values.
 `BundleLike` captures that shared observation language — a single
-valuation `val : B → (t : F) → Option (V t)` — so that specification,
+valuation `val : B → (t : F) → S t` — so that specification,
 subsumption, and the information order are stated once and inherited by
 every representation.
 
@@ -25,13 +25,18 @@ itself carry theoretical content. Representations whose valuation is
 injective opt into `LawfulBundleLike` and get extensionality and the
 subsumption partial order.
 
-Both parameters are fully general. The feature space `F` is data, not a
-built-in inventory, so per-language and per-theory feature sets are
-choices of `F`. The value family `V` covers the standard ontologies:
-`V t := Unit` is privative, `V t := Bool` is bivalent `[±F]`, any enum
-gives multivalent features, a mode-tagged product recovers
-valued/unvalued distinctions, and `V t := ℚ` recovers gradient feature
-theories.
+All three parameters are fully general. The feature space `F` is data,
+not a built-in inventory, so per-language and per-theory feature sets
+are choices of `F`. The slot family `S : F → Type*` is the per-feature
+information space — it carries its own order, so each slot may be (a)
+`Flat (V t)` for a single atom from an enum `V t` (the determinate
+case: privative if `V t := Unit`, bivalent if `V t := Bool`,
+multivalent for an enum, mode-tagged products for valued/unvalued
+distinctions, `ℚ` for gradient theories); or (b) `(Finset α)ᵒᵈ` for
+indeterminate values in the sense of [dalrymple-kaplan-2000]; or (c)
+some richer order for layered or hierarchical features. The lattice
+theory is proved once at the Pi level and inherited by every choice of
+`S`.
 
 ## Main declarations
 
@@ -83,80 +88,78 @@ instantiates `BundleLike` in its own file.
 
 universe u v
 
-/-- `BundleLike B F V`: `B` presents feature bundles over the feature
-space `F`, with values of feature `t` drawn from `V t`. The single
-primitive is the valuation: which value, if any, a bundle assigns to
-each feature. -/
-class BundleLike (B : Type*) (F : outParam Type*) (V : outParam (F → Type*)) where
-  /-- The value, if any, that the bundle assigns to feature `t`. -/
-  val : B → (t : F) → Option (V t)
+/-- `BundleLike B F S`: `B` presents feature bundles over the feature
+space `F`, with slot `t` taking values in the order space `S t`. The
+single primitive is the valuation: a function reading off the slot
+value at each feature.
+
+The slot type `S t` carries its own order. The canonical flat-atomic
+slot is `Flat (V t)` for an atom enum `V t`; richer slot orders
+(`Finset α` for indeterminacy in the sense of [dalrymple-kaplan-2000],
+nested attribute spaces for UD layered features) are obtained by
+choosing different `S`. -/
+class BundleLike (B : Type*) (F : outParam Type*) (S : outParam (F → Type*)) where
+  /-- The value the bundle assigns to feature `t`. -/
+  val : B → (t : F) → S t
 
 /-- An extensional bundle representation: bundles with the same valuation
 are equal. Structured representations whose internal organization
 outruns their valuation are deliberately not lawful. -/
-class LawfulBundleLike (B : Type*) {F : Type*} {V : F → Type*}
-    [BundleLike B F V] : Prop where
-  val_injective : Function.Injective (BundleLike.val (B := B) (F := F) (V := V))
+class LawfulBundleLike (B : Type*) {F : Type*} {S : F → Type*}
+    [BundleLike B F S] : Prop where
+  val_injective : Function.Injective (BundleLike.val (B := B) (F := F) (S := S))
 
 namespace BundleLike
 
-variable {B F : Type*} {V : F → Type*} [BundleLike B F V]
+variable {B F : Type*} {S : F → Type*} [BundleLike B F S]
 
 /-- Extensionality for lawful representations. -/
 @[ext]
 theorem ext [LawfulBundleLike B] {b₁ b₂ : B}
-    (h : ∀ t, val (V := V) b₁ t = val b₂ t) : b₁ = b₂ :=
+    (h : ∀ t, val (S := S) b₁ t = val b₂ t) : b₁ = b₂ :=
   LawfulBundleLike.val_injective (funext h)
 
-/-- `b` specifies feature `t` (assigns it some value). -/
-def Specifies (b : B) (t : F) : Prop :=
-  ∃ v, val b t = some v
+/-- `b` specifies feature `t` (assigns it more than the slot's bottom
+information). For flat slots this coincides with "the slot is `some`";
+for richer slots (set-valued indeterminacy) it means "the slot has not
+been left at `Finset.univ`" (in the order dual where superset = less
+determinate). Only `Bot` is required; the order is not. -/
+def Specifies [∀ t, Bot (S t)] (b : B) (t : F) : Prop :=
+  val (S := S) b t ≠ ⊥
 
-instance (b : B) (t : F) : Decidable (Specifies b t) :=
-  decidable_of_iff _ Option.isSome_iff_exists
+instance [∀ t, Bot (S t)] [∀ t, DecidableEq (S t)]
+    (b : B) (t : F) : Decidable (Specifies (S := S) b t) :=
+  inferInstanceAs (Decidable (val (S := S) b t ≠ ⊥))
 
-/-- Subsumption: `b₁` subsumes into `b₂` when every feature `b₁`
-specifies is specified by `b₂` with the same value. The information
-order of the feature-structure literature ([shieber-1986]): `b₂` is at
-least as specified as `b₁`. -/
+section Order
+
+variable [∀ t, PartialOrder (S t)]
+
+/-- Subsumption: pointwise ≤ on slots — `b₂` is at least as specified as
+`b₁` ([shieber-1986] §3.2.2; [carpenter-1992] Definition 2.1). For flat
+slots this is `Option.FlatLE`; for set-valued slots it is the
+indeterminacy order ([dalrymple-kaplan-2000]: superset = less
+determinate). -/
 def Subsumes (b₁ b₂ : B) : Prop :=
-  ∀ t (v : V t), val b₁ t = some v → val b₂ t = some v
+  ∀ t, val (S := S) b₁ t ≤ val b₂ t
 
-theorem subsumes_refl (b : B) : Subsumes b b :=
-  λ _ _ h => h
+theorem subsumes_refl (b : B) : Subsumes (S := S) b b :=
+  λ _ => le_rfl
 
-theorem subsumes_trans {b₁ b₂ b₃ : B} (h₁₂ : Subsumes b₁ b₂)
-    (h₂₃ : Subsumes b₂ b₃) : Subsumes b₁ b₃ :=
-  λ t v hv => h₂₃ t v (h₁₂ t v hv)
+theorem subsumes_trans {b₁ b₂ b₃ : B}
+    (h₁₂ : Subsumes (S := S) b₁ b₂) (h₂₃ : Subsumes b₂ b₃) :
+    Subsumes (S := S) b₁ b₃ :=
+  λ t => le_trans (h₁₂ t) (h₂₃ t)
 
-/-- On a lawful representation, subsumption is antisymmetric. -/
+/-- On a lawful representation with partial slot orders, subsumption is
+antisymmetric. -/
 theorem subsumes_antisymm [LawfulBundleLike B] {b₁ b₂ : B}
-    (h₁ : Subsumes b₁ b₂) (h₂ : Subsumes b₂ b₁) : b₁ = b₂ :=
-  ext λ t => by
-    cases hv : val (V := V) b₁ t with
-    | some v => exact (h₁ t v hv).symm
-    | none =>
-      cases hw : val (V := V) b₂ t with
-      | some w => exact hv ▸ h₂ t w hw
-      | none => rfl
+    (h₁ : Subsumes (S := S) b₁ b₂) (h₂ : Subsumes b₂ b₁) : b₁ = b₂ :=
+  ext λ t => le_antisymm (h₁ t) (h₂ t)
 
-/-- Disjunctive characterization of subsumption; the decidable form. -/
-theorem subsumes_iff_forall_eq {b₁ b₂ : B} :
-    Subsumes b₁ b₂ ↔
-      ∀ t, val (V := V) b₁ t = none ∨ val b₁ t = val b₂ t := by
-  constructor
-  · intro h t
-    cases hv : val (V := V) b₁ t with
-    | none => exact .inl rfl
-    | some v => exact .inr (h t v hv).symm
-  · intro h t v hv
-    rcases h t with h' | h'
-    · rw [hv] at h'; exact absurd h' (Option.some_ne_none v)
-    · rw [← h', hv]
-
-instance [Fintype F] [∀ t, DecidableEq (V t)] (b₁ b₂ : B) :
-    Decidable (Subsumes b₁ b₂) :=
-  decidable_of_iff _ subsumes_iff_forall_eq.symm
+instance [Fintype F] [∀ t, DecidableLE (S t)] (b₁ b₂ : B) :
+    Decidable (Subsumes (S := S) b₁ b₂) :=
+  inferInstanceAs (Decidable (∀ t, val b₁ t ≤ val b₂ t))
 
 /-- The subsumption partial order on a lawful representation. Not an
 instance: a representation may carry its own canonical order. -/
@@ -166,6 +169,8 @@ def partialOrder [LawfulBundleLike B] : PartialOrder B where
   le_refl := subsumes_refl
   le_trans _ _ _ := subsumes_trans
   le_antisymm _ _ := subsumes_antisymm
+
+end Order
 
 end BundleLike
 
@@ -185,7 +190,7 @@ namespace Bundle
 
 variable {F : Type u} {V : F → Type v}
 
-instance : BundleLike (Bundle F V) F V :=
+instance : BundleLike (Bundle F V) F (λ t => Flat (V t)) :=
   ⟨λ b => b⟩
 
 instance : LawfulBundleLike (Bundle F V) :=
@@ -195,14 +200,15 @@ instance : LawfulBundleLike (Bundle F V) :=
 `BundleLike.Subsumes`. -/
 theorem le_iff_subsumes {b₁ b₂ : Bundle F V} :
     b₁ ≤ b₂ ↔ BundleLike.Subsumes b₁ b₂ :=
-  ⟨λ h t v => h t v, λ h t v => h t v⟩
+  Iff.rfl
 
 instance [Fintype F] [∀ t, DecidableEq (V t)] (b₁ b₂ : Bundle F V) :
     Decidable (b₁ ≤ b₂) :=
   inferInstanceAs (Decidable (∀ t, b₁ t ≤ b₂ t))
 
 @[simp]
-theorem val_bot (t : F) : BundleLike.val (⊥ : Bundle F V) t = none :=
+theorem val_bot (t : F) :
+    BundleLike.val (⊥ : Bundle F V) t = (none : Flat (V t)) :=
   rfl
 
 /-- The bundle specifying exactly one feature. -/
@@ -211,29 +217,29 @@ def single [DecidableEq F] (t : F) (v : V t) : Bundle F V :=
 
 @[simp]
 theorem val_single_self [DecidableEq F] (t : F) (v : V t) :
-    BundleLike.val (single t v) t = some v := by
+    BundleLike.val (single t v) t = (some v : Flat (V t)) := by
   simp [single, BundleLike.val]
 
 @[simp]
 theorem val_single_of_ne [DecidableEq F] {s t : F} (h : s ≠ t) (v : V t) :
-    BundleLike.val (single t v) s = none := by
+    BundleLike.val (single t v) s = (none : Flat (V s)) := by
   simp only [single, BundleLike.val, Function.update_of_ne h]
   rfl
 
 @[simp]
 theorem not_specifies_bot (t : F) : ¬ BundleLike.Specifies (⊥ : Bundle F V) t :=
-  λ ⟨_, hv⟩ => by simp at hv
+  λ hv => hv rfl
 
 @[simp]
 theorem specifies_single [DecidableEq F] {s t : F} (v : V t) :
     BundleLike.Specifies (single t v) s ↔ s = t := by
   constructor
-  · intro ⟨w, hw⟩
-    by_contra h
-    rw [val_single_of_ne h] at hw
-    exact Option.some_ne_none w hw.symm
+  · intro h
+    by_contra hne
+    exact h (val_single_of_ne hne v)
   · rintro rfl
-    exact ⟨v, val_single_self s v⟩
+    intro h
+    exact Option.some_ne_none v (val_single_self s v ▸ h)
 
 end Bundle
 
@@ -241,16 +247,18 @@ end Features
 
 namespace BundleLike
 
-variable {B F : Type*} {V : F → Type*} [BundleLike B F V]
+variable {B F : Type*} {S : F → Type*} [BundleLike B F S]
 
-/-- Any bundle representation carries the subsumption order pulled back
-along its valuation, packaged as a `Core.Order.PullbackPreorder` into the
-canonical carrier. Coarsenings between representations (e.g. assembly
-trees to flat bundles) then factor through
+/-- Any bundle representation with a finite signature carries the
+subsumption order pulled back along its valuation into the Pi
+`(t : F) → S t`, packaged as a `Core.Order.PullbackPreorder`.
+Coarsenings between representations factor through
 `Core.Order.PullbackPreorder.coarsen_via_monotone`. A `def`, not an
 instance, matching `PullbackPreorder`'s own convention. -/
-def subsumptionPreorder [Fintype F] [∀ t, DecidableEq (V t)] :
-    Core.Order.PullbackPreorder B (Features.Bundle F V) :=
-  .ofProj (λ b => (val b : Features.Bundle F V)) (λ _ _ => inferInstance)
+def subsumptionPreorder [Fintype F] [∀ t, PartialOrder (S t)]
+    [∀ t, DecidableLE (S t)] :
+    Core.Order.PullbackPreorder B ((t : F) → S t) :=
+  .ofProj (λ b => (val (S := S) b : (t : F) → S t)) fun a a' =>
+    inferInstanceAs (Decidable (∀ t, val a t ≤ val a' t))
 
 end BundleLike

--- a/Linglib/Morphology/Unification.lean
+++ b/Linglib/Morphology/Unification.lean
@@ -518,9 +518,10 @@ end MorphFeatureType
 
 namespace MorphFeatures
 
-/-- The valuation: project each slot, normalizing `reflex : Bool` to
-`Option Unit`. -/
-def val (f : MorphFeatures) : (t : MorphFeatureType) → Option (MorphFeatureType.Val t)
+/-- The valuation: project each slot as a `Flat` value, normalizing
+`reflex : Bool` to a privative `Flat Unit`. -/
+def val (f : MorphFeatures) :
+    (t : MorphFeatureType) → Flat (MorphFeatureType.Val t)
   | .number   => f.number
   | .gender   => f.gender
   | .case_    => f.case_
@@ -536,7 +537,8 @@ def val (f : MorphFeatures) : (t : MorphFeatureType) → Option (MorphFeatureTyp
   | .voice    => f.voice
   | .polarity => f.polarity
 
-instance : BundleLike MorphFeatures MorphFeatureType MorphFeatureType.Val where
+instance : BundleLike MorphFeatures MorphFeatureType
+    (fun t => Flat (MorphFeatureType.Val t)) where
   val := MorphFeatures.val
 
 private theorem reflex_eq_of_val_reflex_eq {b1 b2 : Bool}

--- a/Linglib/Morphology/Unification.lean
+++ b/Linglib/Morphology/Unification.lean
@@ -1,5 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.Basic
+import Linglib.Core.Order.PartialUnify
 import Mathlib.Order.Bounds.Basic
 import Mathlib.Order.BoundedOrder.Basic
 
@@ -290,61 +291,6 @@ theorem unify_isLUB {f g u : MorphFeatures} (h : f.unify g = some u) :
       exact merge_le (hv (Set.mem_insert _ _)) (hv (Set.mem_insert_of_mem _ rfl))
   · simp [hc] at h
 
-private theorem orElse_comm_of_clause {α : Type _} [BEq α] [LawfulBEq α]
-    {a b : Option α} (hcl : (a.isNone || b.isNone || a == b) = true) :
-    (a <|> b) = (b <|> a) := by
-  cases a with
-  | none => cases b <;> rfl
-  | some x =>
-    cases b with
-    | none => rfl
-    | some y => simp [clause_of_some_some hcl]
-
-/-- Unification is commutative — a consequence of *total* compatibility: doubly
-committed slots agree, so the per-field left bias washes out. -/
-theorem unify_comm (f g : MorphFeatures) : f.unify g = g.unify f := by
-  unfold unify
-  by_cases hc : f.compatible g = true
-  · have hc2 : g.compatible f = true := compatible_comm f g ▸ hc
-    simp only [hc, hc2, if_true, Option.some.injEq]
-    simp only [compatible, Bool.and_eq_true] at hc
-    obtain ⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨h1, h2⟩, h3⟩, h4⟩, h5⟩, h6⟩, h7⟩, h8⟩, h9⟩, h10⟩, h11⟩, h12⟩, h13⟩ := hc
-    unfold merge
-    simp only [mk.injEq]
-    exact ⟨orElse_comm_of_clause h1, orElse_comm_of_clause h2, orElse_comm_of_clause h3,
-           orElse_comm_of_clause h4, orElse_comm_of_clause h5, orElse_comm_of_clause h6,
-           Bool.or_comm _ _, orElse_comm_of_clause h7, orElse_comm_of_clause h8,
-           orElse_comm_of_clause h9, orElse_comm_of_clause h10, orElse_comm_of_clause h11,
-           orElse_comm_of_clause h12, orElse_comm_of_clause h13⟩
-  · have hc' : ¬ g.compatible f = true := by rwa [compatible_comm g f]
-    simp [hc, hc']
-
-private theorem orElse_self {α : Type _} (a : Option α) : (a <|> a) = a := by
-  cases a <;> rfl
-
-/-- Unification is idempotent (§3.2.3's example law). -/
-@[simp] theorem unify_self (f : MorphFeatures) : f.unify f = some f := by
-  unfold unify
-  simp only [compatible_self, if_true, Option.some.injEq]
-  unfold merge
-  cases f
-  simp only [mk.injEq]
-  exact ⟨orElse_self _, orElse_self _, orElse_self _, orElse_self _, orElse_self _,
-         orElse_self _, Bool.or_self _, orElse_self _, orElse_self _, orElse_self _,
-         orElse_self _, orElse_self _, orElse_self _, orElse_self _⟩
-
-/-- Variables are unification identity elements (§3.2.3's example law): unifying with
-the empty bundle returns the other input. -/
-@[simp] theorem bot_unify (f : MorphFeatures) : (⊥ : MorphFeatures).unify f = some f := by
-  have hb : (⊥ : MorphFeatures).compatible f = true :=
-    compatible_of_le (u := f) bot_le le_rfl
-  unfold unify
-  simp only [hb, if_true, Option.some.injEq]
-  show merge ⊥ f = f
-  unfold merge
-  cases f
-  rfl
-
 /-! ### Generalization: the meet
 
 Shieber's *generalization* (anti-unification): the most specific bundle subsumed by
@@ -431,112 +377,72 @@ instance : SemilatticeInf MorphFeatures :=
 
 /-! ### Unification computes least upper bounds — further laws -/
 
+/-- `MorphFeatures` carries the pairwise-LUB structure of [carpenter-1992]'s
+bounded complete partial order: `unify` is the partial join, with
+`unify_isLUB` and `compatible_iff_bddAbove` supplying the two class
+axioms. The unification laws — commutativity, associativity (with
+failure propagating), `⊥`-identity, idempotence, monotonicity — are
+inherited as one-line corollaries of the generic theorems in
+`Core/Order/PartialUnify.lean`. -/
+instance : PartialUnify MorphFeatures where
+  unify := MorphFeatures.unify
+  isLUB_of_unify_eq_some := unify_isLUB
+  isSome_unify_of_bddAbove {a b} h :=
+    (unify_eq_some_iff a b).mpr h
+
+/-- The instance-projected `unify` is the same function as
+`MorphFeatures.unify`. -/
+@[simp] theorem unify_eq_partialUnify (f g : MorphFeatures) :
+    PartialUnify.unify f g = f.unify g := rfl
+
 /-- Unification succeeds with value `u` exactly when `u` is the least upper bound. -/
 theorem unify_eq_some_iff_isLUB {f g u : MorphFeatures} :
     f.unify g = some u ↔ IsLUB {f, g} u := by
-  refine ⟨unify_isLUB, fun hu => ?_⟩
-  have hc : f.compatible g = true :=
-    compatible_of_le (hu.1 (Set.mem_insert _ _)) (hu.1 (Set.mem_insert_of_mem _ rfl))
-  have hm : f.unify g = some (f.merge g) := by simp [unify, hc]
-  rw [hm, Option.some_inj]
-  exact (unify_isLUB hm).unique hu
+  rw [← unify_eq_partialUnify]
+  exact PartialUnify.unify_eq_some_iff_isLUB
 
-private theorem isLUB_pair_step {f g h v u : MorphFeatures} (hv : IsLUB {f, g} v) :
-    IsLUB {v, h} u ↔ IsLUB ({f, g, h} : Set MorphFeatures) u := by
-  have hub : upperBounds ({v, h} : Set MorphFeatures) = upperBounds {f, g, h} := by
-    ext w
-    constructor
-    · intro hw x hx
-      rcases hx with rfl | rfl | rfl
-      · exact (hv.1 (Set.mem_insert _ _)).trans (hw (Set.mem_insert _ _))
-      · exact (hv.1 (Set.mem_insert_of_mem _ rfl)).trans (hw (Set.mem_insert _ _))
-      · exact hw (Set.mem_insert_of_mem _ rfl)
-    · intro hw x hx
-      rcases hx with rfl | rfl
-      · exact hv.2 fun y hy => by
-          rcases hy with rfl | rfl
-          · exact hw (Set.mem_insert _ _)
-          · exact hw (Set.mem_insert_of_mem _ (Set.mem_insert _ _))
-      · exact hw (Set.mem_insert_of_mem _ (Set.mem_insert_of_mem _ rfl))
-  unfold IsLUB
-  rw [hub]
+/-- Unification is commutative — a consequence of *total* compatibility: doubly
+committed slots agree, so the per-field left bias washes out. -/
+theorem unify_comm (f g : MorphFeatures) : f.unify g = g.unify f := by
+  rw [← unify_eq_partialUnify, ← unify_eq_partialUnify]
+  exact PartialUnify.unify_comm f g
+
+/-- Unification is idempotent (§3.2.3's example law). -/
+@[simp] theorem unify_self (f : MorphFeatures) : f.unify f = some f := by
+  rw [← unify_eq_partialUnify]; exact PartialUnify.unify_self f
+
+/-- Variables are unification identity elements (§3.2.3's example law):
+unifying with the empty bundle returns the other input. -/
+@[simp] theorem bot_unify (f : MorphFeatures) :
+    (⊥ : MorphFeatures).unify f = some f := by
+  rw [← unify_eq_partialUnify]; exact PartialUnify.bot_unify f
 
 /-- Unification is associative, with failure propagating ([shieber-1986] §3.2.3's
 order-independence): both associations compute the lub of all three bundles. -/
 theorem unify_assoc (f g h : MorphFeatures) :
     (f.unify g).bind (·.unify h) = (g.unify h).bind (f.unify ·) := by
-  apply Option.ext
-  intro u
-  simp only [Option.bind_eq_some_iff]
-  constructor
-  · rintro ⟨v, hv, hu⟩
-    have h3 : IsLUB ({f, g, h} : Set MorphFeatures) u :=
-      (isLUB_pair_step (unify_isLUB hv)).mp (unify_isLUB hu)
-    have hgh : g.compatible h = true := by
-      refine compatible_of_le (u := u) ?_ ?_
-      · exact h3.1 (Set.mem_insert_of_mem _ (Set.mem_insert _ _))
-      · exact h3.1 (Set.mem_insert_of_mem _ (Set.mem_insert_of_mem _ rfl))
-    refine ⟨g.merge h, by simp [unify, hgh], ?_⟩
-    have hw : IsLUB ({g, h} : Set MorphFeatures) (g.merge h) :=
-      unify_isLUB (by simp [unify, hgh])
-    rw [unify_eq_some_iff_isLUB]
-    have : IsLUB ({g, h, f} : Set MorphFeatures) u := by
-      have : ({g, h, f} : Set MorphFeatures) = {f, g, h} := by
-        ext x; simp [Set.mem_insert_iff]; tauto
-      rw [this]; exact h3
-    have step := (isLUB_pair_step hw).mpr this
-    have : ({g.merge h, f} : Set MorphFeatures) = {f, g.merge h} := Set.pair_comm _ _
-    rwa [← this]
-  · rintro ⟨w, hw, hu⟩
-    have hu' : IsLUB ({g.merge h, f} : Set MorphFeatures) u := by
-      rw [Set.pair_comm]
-      rw [unify_eq_some_iff_isLUB] at hu
-      have hwm : g.merge h = w := by
-        have : g.unify h = some w := hw
-        have hgh : g.compatible h = true :=
-          compatible_of_le ((unify_isLUB hw).1 (Set.mem_insert _ _))
-            ((unify_isLUB hw).1 (Set.mem_insert_of_mem _ rfl))
-        simpa [unify, hgh] using this
-      rwa [← hwm] at hu
-    have h3 : IsLUB ({g, h, f} : Set MorphFeatures) u := by
-      have hgh : g.compatible h = true :=
-        compatible_of_le ((unify_isLUB hw).1 (Set.mem_insert _ _))
-          ((unify_isLUB hw).1 (Set.mem_insert_of_mem _ rfl))
-      exact (isLUB_pair_step (unify_isLUB (by simp [unify, hgh] :
-        g.unify h = some (g.merge h)))).mp hu'
-    have h3' : IsLUB ({f, g, h} : Set MorphFeatures) u := by
-      have : ({g, h, f} : Set MorphFeatures) = {f, g, h} := by
-        ext x; simp [Set.mem_insert_iff]; tauto
-      rwa [this] at h3
-    have hfg : f.compatible g = true := by
-      refine compatible_of_le (u := u) ?_ ?_
-      · exact h3'.1 (Set.mem_insert _ _)
-      · exact h3'.1 (Set.mem_insert_of_mem _ (Set.mem_insert _ _))
-    refine ⟨f.merge g, by simp [unify, hfg], ?_⟩
-    rw [unify_eq_some_iff_isLUB]
-    exact (isLUB_pair_step (unify_isLUB (by simp [unify, hfg] :
-      f.unify g = some (f.merge g)))).mpr h3'
+  have := PartialUnify.unify_assoc f g h
+  simp only [unify_eq_partialUnify] at this
+  exact this
 
 /-- The empty bundle is a right identity for unification. -/
-@[simp] theorem unify_bot (f : MorphFeatures) : f.unify (⊥ : MorphFeatures) = some f := by
-  rw [unify_comm]; exact bot_unify f
+@[simp] theorem unify_bot (f : MorphFeatures) :
+    f.unify (⊥ : MorphFeatures) = some f := by
+  rw [← unify_eq_partialUnify]; exact PartialUnify.unify_bot f
 
 /-- Unification fails exactly on incompatible inputs. -/
 theorem unify_eq_none_iff (f g : MorphFeatures) :
     f.unify g = none ↔ ¬ Compatible f g := by
-  rw [← compatible_iff_bddAbove]
-  unfold unify
-  by_cases hc : f.compatible g = true <;> simp [hc]
+  rw [← unify_eq_partialUnify]
+  exact PartialUnify.unify_eq_none_iff (a := f) (b := g)
 
 /-- Unification is monotone where defined: shrinking both inputs preserves success and
 shrinks the output. (Unguarded `merge`-monotonicity is false — the guard is needed.) -/
 theorem unify_mono {f₁ f₂ g₁ g₂ u₂ : MorphFeatures} (hf : f₁ ≤ f₂) (hg : g₁ ≤ g₂)
     (h2 : f₂.unify g₂ = some u₂) : ∃ u₁, f₁.unify g₁ = some u₁ ∧ u₁ ≤ u₂ := by
-  have hlub := unify_isLUB h2
-  have hf1 : f₁ ≤ u₂ := hf.trans (hlub.1 (Set.mem_insert _ _))
-  have hg1 : g₁ ≤ u₂ := hg.trans (hlub.1 (Set.mem_insert_of_mem _ rfl))
-  have hc : f₁.compatible g₁ = true := compatible_of_le hf1 hg1
-  exact ⟨f₁.merge g₁, by simp [unify, hc], merge_le hf1 hg1⟩
+  rw [← unify_eq_partialUnify] at h2
+  obtain ⟨u₁, hu₁, hle⟩ := PartialUnify.unify_mono hf hg h2
+  exact ⟨u₁, unify_eq_partialUnify _ _ ▸ hu₁, hle⟩
 
 end UD.MorphFeatures
 

--- a/Linglib/Studies/DalrympleKaplan2000.lean
+++ b/Linglib/Studies/DalrympleKaplan2000.lean
@@ -331,4 +331,54 @@ theorem binary_collapses_clusivity :
   · simp [toBinary, fula1exc, fula1inc]
   · decide
 
+/-! ### BundleLike with `Finset` slots: the generic substrate accommodates indeterminacy
+
+A multi-feature indeterminacy bundle is just a Pi type with `Finset` slots,
+ordered superset-first (more determinate = smaller set). `BundleLike`'s
+slot type family `S : F → Type*` (parameter `S` carrying its own
+order) covers this case without any new generic machinery: `S t :=
+(Finset (V t))ᵒᵈ`. The `BundleLike.Subsumes` order then reads, per slot,
+`b₁ t ≤ b₂ t` in the order dual — i.e. `(b₂ t).1 ⊆ (b₁ t).1` — which is
+exactly the §4 (eq. 25) information-as-set-of-possibilities convention.
+
+This is the structural payoff: a feature-space tweak (Finset slots
+instead of Flat slots), not a re-development of the lattice theory. -/
+
+/-- An indeterminacy bundle: each slot holds a `Finset` of possible
+atomic values, ordered superset-first via `Finset`'s order dual. -/
+abbrev IndetBundle (F : Type*) (V : F → Type*) : Type _ :=
+  (t : F) → (Finset (V t))ᵒᵈ
+
+namespace IndetBundle
+
+variable {F : Type*} {V : F → Type*}
+
+instance : BundleLike (IndetBundle F V) F
+    (fun t => (Finset (V t))ᵒᵈ) :=
+  ⟨fun b => b⟩
+
+instance : LawfulBundleLike (IndetBundle F V) :=
+  ⟨fun _ _ h => h⟩
+
+end IndetBundle
+
+/-! Concrete witness: a 1-feature Case-indeterminacy bundle. We
+exhibit two bundles — *was* {NOM, ACC} and *wer* {NOM} — and confirm
+that `wer` subsumes (is more determinate than) `was`, via the
+generic `BundleLike.Subsumes`. -/
+
+/-- A single-feature Case bundle. -/
+abbrev CaseBundle := IndetBundle Unit (fun _ => Case)
+
+def wasBundle : CaseBundle := fun _ => OrderDual.toDual was
+def werBundle : CaseBundle := fun _ => OrderDual.toDual wer
+
+/-- *wer* {NOM} is more determinate than *was* {NOM, ACC}: their
+subsumption in the generic `BundleLike` order matches set-superset on
+the slot. -/
+theorem wer_subsumes_was : BundleLike.Subsumes wasBundle werBundle := by
+  intro _
+  show wer ⊆ was
+  decide
+
 end DalrympleKaplan2000


### PR DESCRIPTION
Depends on #130 (BCPO substrate), #131 (Unification PartialUnify migration).

Generalizes `BundleLike B F V` (val with `Option (V t)` codomain) to `BundleLike B F S` (val with `S t` codomain), so each slot may carry its own order. The flat-atomic case (`S t := Flat (V t)`) is one instance; set-valued indeterminacy ([dalrymple-kaplan-2000]: `S t := (Finset (V t))ᵒᵈ`, where superset = less determinate) is another; layered features can choose `F := Attribute × Layer`. The lattice theory is stated once and inherited via mathlib's Pi instances.

- `BundleLike` signature change: `S : F → Type*` per-slot order space
- `Specifies` needs `[∀ t, Bot]` only; `Subsumes` needs `[∀ t, PartialOrder]` (which factors into refl/trans + lawful antisymm)
- `subsumptionPreorder` pulls back into the bare Pi `(t : F) → S t`
- `Features.Bundle F V` unchanged at the use site (kept as `(t : F) → Flat (V t)`); its instance now sets `S := Flat ∘ V`
- `UD.MorphFeatures` instance updated similarly
- New witness in `Studies/DalrympleKaplan2000.lean`: `IndetBundle F V := (t : F) → (Finset (V t))ᵒᵈ` carries `BundleLike` + `LawfulBundleLike`, and `wer_subsumes_was` confirms the generic `BundleLike.Subsumes` matches set-superset on Case slots — same theorems, different slot order, no re-proof