### PR TITLE
feat(Features): canonical root Number, HasNumber mixin, unified resolve

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -337,7 +337,10 @@ import Linglib.Core.CylindricAlgebra.DynamicSemantics
 import Linglib.Features.ContainmentPair
 import Linglib.Features.Person
 import Linglib.Features.PhiKernel
-import Linglib.Features.Number
+import Linglib.Features.Number.Basic
+import Linglib.Features.Number.Capabilities
+import Linglib.Features.Number.Decomposition
+import Linglib.Features.Number.Resolve
 import Linglib.Core.CoreConcept
 import Linglib.Morphology.MorphRule
 import Linglib.Morphology.Paradigm

--- a/Linglib/Core/CoreConcept.lean
+++ b/Linglib/Core/CoreConcept.lean
@@ -33,7 +33,7 @@ correspond to conceptual primitives independently motivated in the
 literature, with a denotation defined elsewhere in linglib. -/
 inductive Id where
   /-- Number-feature dual: predicate-modifier "and has exactly 2
-  atomic parts"; denotation in `Features.Number.dualPredOnLattice`. -/
+  atomic parts"; denotation in `Number.dualPredOnLattice`. -/
   | dual
   /-- Number-feature trial. Mentioned in [harbour-2014] as
   morphologically stable but rare. Denotation TBD. -/

--- a/Linglib/Data/UD/Basic.lean
+++ b/Linglib/Data/UD/Basic.lean
@@ -20,7 +20,7 @@ the linglib mirror of its v2 surface, and `Data/UD/` is the standard's area —
 treebank data (CoNLL-U) belongs here beside the vocabulary, paralleling
 `Data/WALS/` (schema + datapoints). Its types are the foundational
 substrate every other layer builds on: `Features/` aliases the feature types
-(`Features.Number := UD.Number`, …) and `Morphology/Word.lean` builds the
+(e.g. `Number.fromUD`/`Number.toUD`, …) and `Morphology/Word.lean` builds the
 ms-word token over the vocabulary.
 The bare `UD` namespace (no `Data.` prefix) is intentional — UD is its own
 external project. Subsumption-order theory over `MorphFeatures` lives in

--- a/Linglib/Features/Number/Basic.lean
+++ b/Linglib/Features/Number/Basic.lean
@@ -1,0 +1,384 @@
+import Mathlib.Order.Nat
+import Mathlib.Tactic.DeriveFintype
+import Linglib.Data.UD.Basic
+
+/-!
+# Grammatical number — the canonical value space
+[corbett-2000] [harbour-2014] [greenberg-1963] [cysouw-2009]
+
+`Number` is the canonical grammatical-number type: [corbett-2000]'s analytical
+inventory of number values, the vocabulary in which systems, agreement,
+resolution, and semantics are stated. The UD tagset (`UD.Number`) is the
+*realization vocabulary* — the surface morphology a value projects to via
+`Number.toUD` (the analogue of `Pronoun.toWord`) and is ingested from via
+`Number.fromUD` at the corpus boundary. Values UD cannot tag (`general`,
+`minimal`, `augmented`, `unitAugmented`) realize as `none`; conversely
+`UD.Number.Inv`/`.Coll`/`.Count` are morphological form-categories that are
+not values of the count-number system, and have no `Number` preimage.
+The quadral is deliberately excluded: [corbett-2000] reanalyzes apparent
+quadrals (Sursurunga, Tangga) as paucals.
+
+Values are classified along two orthogonal dimensions ([corbett-2000]):
+
+- **System membership**: `general` is *outside* the number system (a form
+  non-committal to cardinality); all others are within it.
+- **Determinacy**: values whose cardinality boundary is fixed (singular=1,
+  dual=2, trial=3) vs those whose boundary varies by context (paucal ≈ 2–6,
+  greater plural ≈ abundance).
+
+## Main declarations
+
+* `Number` — the analytical value inventory ([corbett-2000] Ch 2).
+* `Number.toUD` / `Number.fromUD` — realization to / ingestion from `UD.Number`.
+* `Number.instPartialOrder` — the markedness order: `a ≤ b` iff every system
+  containing `b` also contains `a` (the implicational hierarchy of
+  [greenberg-1963] and [corbett-2000] §2.3, derived as a lower-set theorem
+  from [harbour-2014]'s feature geometry in `Syntax/Minimalist/Phi/Recursion.lean`).
+* `Number.System` — a language's number-value inventory ([corbett-2000] §2.3),
+  with the implicational universals as decidable predicates and their
+  conjunction `System.WellFormed`.
+* `Number.Stage` — [cysouw-2009]'s N1–N4 number-opposition stages, a
+  `LinearOrder`.
+
+## Implementation notes
+
+The [harbour-2014] feature decomposition and its lattice grounding live in
+`Features/Number/Decomposition.lean`; coordinate resolution in
+`Features/Number/Resolve.lean`; the `HasNumber` capability mixin in
+`Features/Number/Capabilities.lean`.
+-/
+
+set_option autoImplicit false
+
+/-- Grammatical number: [corbett-2000]'s analytical inventory of number values.
+    The canonical type — `UD.Number` is its surface realization vocabulary
+    (`Number.toUD`/`Number.fromUD`). -/
+inductive Number where
+  /-- Non-committal to cardinality; *outside* the number system
+      (Bayso *lúban* 'lion(s)', Japanese *inu* 'dog(s)'). -/
+  | general
+  /-- Exactly one (`[+atomic, +minimal]`). -/
+  | singular
+  /-- Exactly two (`[−atomic, +minimal]`). -/
+  | dual
+  /-- Exactly three (recursive `[+minimal]` on the plural region). -/
+  | trial
+  /-- A few — indeterminate boundary (`[−additive]`). -/
+  | paucal
+  /-- More than one — the residual value (`[−atomic]` or `[+additive]`). -/
+  | plural
+  /-- Indeterminate, larger than paucal (recursive `[−additive]`). -/
+  | greaterPaucal
+  /-- Abundance / totality (recursive `[−minimal]` on the plural region). -/
+  | greaterPlural
+  /-- `[+minimal]` without `[±atomic]` — atoms *and* minimal non-atoms;
+      distinct from singular. -/
+  | minimal
+  /-- `[−minimal]` without `[±atomic]` — the complement of minimal. -/
+  | augmented
+  /-- Recursive `[+minimal]` on the augmented region — minimal non-minimal;
+      distinct from dual. -/
+  | unitAugmented
+  /-- Recursive `[+additive]` on a `[+additive]` region (tentative in
+      [harbour-2014]). -/
+  | globalPlural
+  deriving DecidableEq, Repr, Fintype
+
+namespace Number
+
+/-! ### Classification predicates -/
+
+/-- A number value is determinate iff its cardinality boundary is fixed.
+    Minimal and unit augmented are indeterminate: they depend on the
+    composition of the group, not a fixed cardinality. -/
+def isDeterminate : Number → Prop
+  | .singular | .dual | .trial => True
+  | _ => False
+
+instance : DecidablePred isDeterminate := fun n => by
+  cases n <;> unfold isDeterminate <;> infer_instance
+
+/-- A number value participates in the number system (is not general). -/
+def isInSystem : Number → Prop
+  | .general => False
+  | _ => True
+
+instance : DecidablePred isInSystem := fun n => by
+  cases n <;> unfold isInSystem <;> infer_instance
+
+/-- Exact referent-set cardinality for determinate number values.
+
+    Singular denotes exactly 1 individual (atom), dual exactly 2 (pair),
+    trial exactly 3 (triple). All other values have indeterminate or
+    context-dependent cardinality and return `none`.
+
+    Used by `Number.resolve` to derive coordinate resolution from
+    cardinality addition: |A ⊔ B| = |A| + |B| for disjoint sets. -/
+def exactCard : Number → Option Nat
+  | .singular => some 1
+  | .dual     => some 2
+  | .trial    => some 3
+  | _         => none
+
+/-- Whether a value belongs to the `[±minimal]` number system (without
+    `[±atomic]`). In such systems, minimal = atoms ∪ minimal non-atoms,
+    and augmented = everything else. -/
+def isMinAug : Number → Prop
+  | .minimal | .augmented => True
+  | _ => False
+
+instance : DecidablePred isMinAug := fun n => by
+  cases n <;> unfold isMinAug <;> infer_instance
+
+/-- Map a referent-set cardinality back to the finest determinate value.
+    1 → singular, 2 → dual, 3 → trial; sums of 4+ have no determinate value
+    and fall to the residual plural (greater plural is an *abundance* value
+    in [corbett-2000]'s sense, not "four or more"). -/
+def fromCard : Nat → Number
+  | 1 => .singular
+  | 2 => .dual
+  | 3 => .trial
+  | _ => .plural
+
+/-- `fromCard` inverts `exactCard` for determinate values. -/
+theorem fromCard_singular : fromCard 1 = .singular := rfl
+theorem fromCard_dual : fromCard 2 = .dual := rfl
+theorem fromCard_trial : fromCard 3 = .trial := rfl
+
+/-! ### Realization: the UD bridge -/
+
+/-- Realize a number value as a UD morphological tag (general has no UD
+    equivalent; minimal, augmented, and unit augmented cannot be tagged). -/
+def toUD : Number → Option UD.Number
+  | .general        => none
+  | .singular       => some .Sing
+  | .dual           => some .Dual
+  | .trial          => some .Tri
+  | .paucal         => some .Pauc
+  | .plural         => some .Plur
+  | .greaterPaucal  => some .Grpa
+  | .greaterPlural  => some .Grpl
+  | .minimal        => none
+  | .augmented      => none
+  | .unitAugmented  => none
+  | .globalPlural   => none
+
+/-- Ingest a UD morphological tag as a number value (partial).
+
+    Seven core values round-trip cleanly. Three UD tags have no analytical
+    equivalent:
+    - `Inv` (inverse number): marks the *unexpected* number for a given noun —
+      plural for some nouns, singular for others. Not a fixed cardinality.
+    - `Coll` (collective): denotes a group-as-unit (Russian *листва* 'foliage'),
+      distinct from general number, which is non-committal to cardinality.
+    - `Count` (count form): a special form after numerals (Hungarian, Welsh),
+      not equivalent to singular (exactly one). -/
+def fromUD : UD.Number → Option Number
+  | .Sing  => some .singular
+  | .Plur  => some .plural
+  | .Dual  => some .dual
+  | .Tri   => some .trial
+  | .Pauc  => some .paucal
+  | .Grpa  => some .greaterPaucal
+  | .Grpl  => some .greaterPlural
+  | .Inv   => none
+  | .Coll  => none
+  | .Count => none
+
+/-- Round-trip: `fromUD ∘ toUD = id` for all in-system values with a UD tag. -/
+theorem roundtrip_fromUD_toUD :
+    ∀ v ∈ [Number.singular, .dual, .trial, .paucal, .plural,
+           .greaterPaucal, .greaterPlural],
+      v.toUD.bind fromUD = some v := by decide
+
+/-! ### The markedness order
+
+`a ≤ b` means b presupposes a: every number system containing b also
+contains a — the implicational hierarchy of [greenberg-1963] and
+[corbett-2000] §2.3. The order is *derived*, not stipulated: the values
+generated by any well-formed Harbour configuration form a lower set in
+this order (`Minimalist.Phi.Recursion.categories_isLowerSet`, from
+[harbour-2014]'s feature geometry).
+
+Three independent branches:
+```
+[±atomic] branch:        trial   greaterPlural
+                           \        /
+                            dual
+                           /    \
+                     singular    plural
+
+[±minimal] branch:       unitAugmented
+                              |
+                          augmented
+                              |
+                           minimal
+
+Approximative branch:    greaterPaucal    globalPlural
+                              |               |
+                            paucal          plural
+```
+The `[±atomic]` branch and `[±minimal]` branch are independent: singular
+and minimal never cooccur. Plural spans both. `general` is isolated
+(incomparable with all in-system values).
+
+This *typological* order is one of three markedness notions on number and
+must not be conflated with the others: the *specification* order on the
+Harbour decomposition (`Features.ContainmentPair.specLevel`: sg > du > pl,
+linear) and *semantic* markedness ([sauerland-2003], which rides on
+specification). On the sg/pl pair the two orders disagree — here sg and pl
+are incomparable; under specification sg > pl. -/
+
+/-- The markedness ordering on number values. -/
+def markednessLE (a b : Number) : Prop :=
+  a = b ∨ match a, b with
+  -- [±atomic] branch: singular ≤ dual ≤ {trial, greaterPlural};
+  -- plural ≤ dual ≤ {trial, greaterPlural}
+  | .singular, .dual | .singular, .trial | .singular, .greaterPlural => True
+  | .plural, .dual | .plural, .trial | .plural, .greaterPlural => True
+  | .dual, .trial | .dual, .greaterPlural => True
+  -- Approximative branch: plural ≤ paucal ≤ greaterPaucal
+  | .plural, .paucal | .plural, .greaterPaucal => True
+  | .paucal, .greaterPaucal => True
+  -- [±minimal] branch: minimal ≤ augmented ≤ unitAugmented
+  | .minimal, .augmented | .minimal, .unitAugmented => True
+  | .augmented, .unitAugmented => True
+  -- globalPlural: plural ≤ globalPlural
+  | .plural, .globalPlural => True
+  | _, _ => False
+
+instance : ∀ a b : Number, Decidable (markednessLE a b) := fun a b => by
+  unfold markednessLE; cases a <;> cases b <;> exact inferInstance
+
+instance : LE Number := ⟨markednessLE⟩
+
+instance : DecidableRel ((· ≤ ·) : Number → Number → Prop) :=
+  fun a b => inferInstanceAs (Decidable (markednessLE a b))
+
+instance instPartialOrder : PartialOrder Number where
+  le_refl a := by cases a <;> decide
+  le_trans a b c := by cases a <;> cases b <;> cases c <;> decide
+  le_antisymm a b := by cases a <;> cases b <;> decide
+
+/-! ### Number opposition stages ([cysouw-2009], Fig 10.8) -/
+
+/-- Number opposition stages ([cysouw-2009], Fig 10.8): a coarsening of the
+    number values into a four-step hierarchy of typological richness, from no
+    number marking (N1) to full number marking with restricted groups (N3/N4).
+    Linearly ordered by richness. -/
+inductive Stage where
+  /-- Undifferentiated number marking (singular = group unmarked). -/
+  | N1
+  /-- Singular vs group (basic number opposition). -/
+  | N2
+  /-- Restricted group (dual/trial) distinguished from unrestricted. -/
+  | N3
+  /-- Small group (paucal) additionally distinguished. -/
+  | N4
+  deriving DecidableEq, Repr
+
+namespace Stage
+
+/-- Numeric embedding into ℕ preserving the richness order. -/
+def toNat : Stage → Nat
+  | .N1 => 0
+  | .N2 => 1
+  | .N3 => 2
+  | .N4 => 3
+
+instance : LinearOrder Stage :=
+  LinearOrder.lift' toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+
+/-- The order on `Stage` is the `toNat` order. -/
+theorem toNat_le_toNat {a b : Stage} : a ≤ b ↔ a.toNat ≤ b.toNat := Iff.rfl
+
+end Stage
+
+/-! ### Number systems ([corbett-2000] §2.3) -/
+
+/-- A number system: the values available in a language, which are
+    obligatory vs facultative, and whether general number exists
+    ([corbett-2000] §2.3). Per-language instances live with the studies
+    and Fragments that record them. -/
+structure System where
+  name : String
+  /-- Values available within the number system. -/
+  values : List Number
+  /-- Whether the language has general number (a form outside the system). -/
+  hasGeneral : Bool := false
+  /-- Values whose use is optional (facultative). -/
+  facultative : List Number := []
+  deriving DecidableEq
+
+namespace System
+
+/-- Number of values in the system. -/
+def size (ns : System) : Nat := ns.values.length
+
+/-- Whether a value is obligatory (present and not facultative). -/
+def IsObligatory (ns : System) (v : Number) : Prop :=
+  v ∈ ns.values ∧ v ∉ ns.facultative
+
+instance (ns : System) (v : Number) : Decidable (ns.IsObligatory v) := by
+  unfold System.IsObligatory; infer_instance
+
+/-! #### Implicational universals ([greenberg-1963], [corbett-2000] §2.3.1) -/
+
+/-- Trial implies dual: no language has trial without dual. -/
+def TrialImpliesDual (ns : System) : Prop :=
+  .trial ∈ ns.values → .dual ∈ ns.values
+
+/-- Dual implies plural. -/
+def DualImpliesPlural (ns : System) : Prop :=
+  .dual ∈ ns.values → .plural ∈ ns.values
+
+/-- Plural implies singular or minimal ([harbour-2014] Table 1:
+    PL → SG/MIN). Plural requires a "base" value — either singular
+    (from `[±atomic]`) or minimal (from `[±minimal]`). -/
+def PluralImpliesSingularOrMinimal (ns : System) : Prop :=
+  .plural ∈ ns.values → .singular ∈ ns.values ∨ .minimal ∈ ns.values
+
+/-- Augmented implies minimal ([harbour-2014] Table 1: AUG → MIN). -/
+def AugmentedImpliesMinimal (ns : System) : Prop :=
+  .augmented ∈ ns.values → .minimal ∈ ns.values
+
+/-- Unit augmented implies augmented ([harbour-2014] Table 1:
+    U.AUG → AUG). -/
+def UnitAugImpliesAugmented (ns : System) : Prop :=
+  .unitAugmented ∈ ns.values → .augmented ∈ ns.values
+
+instance (ns : System) : Decidable ns.TrialImpliesDual := by
+  unfold TrialImpliesDual; infer_instance
+instance (ns : System) : Decidable ns.DualImpliesPlural := by
+  unfold DualImpliesPlural; infer_instance
+instance (ns : System) : Decidable ns.PluralImpliesSingularOrMinimal := by
+  unfold PluralImpliesSingularOrMinimal; infer_instance
+instance (ns : System) : Decidable ns.AugmentedImpliesMinimal := by
+  unfold AugmentedImpliesMinimal; infer_instance
+instance (ns : System) : Decidable ns.UnitAugImpliesAugmented := by
+  unfold UnitAugImpliesAugmented; infer_instance
+
+/-- A well-formed number system satisfies all implicational universals.
+    Any Fragment-recorded system discharges this by `decide`. -/
+def WellFormed (ns : System) : Prop :=
+  ns.TrialImpliesDual ∧ ns.DualImpliesPlural ∧
+  ns.PluralImpliesSingularOrMinimal ∧ ns.AugmentedImpliesMinimal ∧
+  ns.UnitAugImpliesAugmented
+
+instance (ns : System) : Decidable ns.WellFormed := by
+  unfold WellFormed; infer_instance
+
+/-- The [cysouw-2009] stage a system realizes, by value count:
+    0–1 values → N1 (undifferentiated), 2 → N2 (basic opposition),
+    3 → N3 (restricted group), 4+ → N4 (paucal additionally). -/
+def toStage (ns : System) : Stage :=
+  match ns.size with
+  | 0 | 1 => .N1
+  | 2 => .N2
+  | 3 => .N3
+  | _ => .N4
+
+end System
+
+end Number

--- a/Linglib/Features/Number/Capabilities.lean
+++ b/Linglib/Features/Number/Capabilities.lean
@@ -1,0 +1,100 @@
+import Linglib.Features.Number.Basic
+
+/-!
+# HasNumber — the number-bearing capability
+[corbett-2000]
+
+The typeclass mixin for carriers that bear grammatical number — the number
+axis of the capability tower over lexical carriers (cf. `Proform`/`Bound`/
+`Clusive` in `Syntax/Pronoun/Capabilities.lean`). A consumer (agreement
+checker, resolution, semantics) requires `[HasNumber α]` and works over any
+representation: a UD feature bundle, a `Word`, a `Pronoun`, an agreement
+paradigm cell.
+
+The accessor is `Option`-valued because underspecification is the
+typologically normal case ([corbett-2000]): a carrier with no number marking
+is a wildcard for agreement, not a default singular.
+
+Instances live with their carriers (mathlib-style): `UD.MorphFeatures` here
+(its type is below this file); `Word` in `Morphology/Word.lean`; `Pronoun`/
+`PersonalPronoun` in `Syntax/Pronoun/Capabilities.lean`; paradigm `Cell` in
+`Syntax/Agreement/Paradigm.lean`.
+
+Named `HasNumber`, not `Numbered`: the bare name is taken by the carrier
+type itself, the situation where Lean retains the `Has` prefix
+(`HasEquiv`, `HasSubset`, `HasQuotient`), and the scheme scales across the
+φ-inventory (`HasPerson`, `HasGender`) where adjectival forms do not.
+
+The Minimalist probe/goal inventory (`Minimalist.PhiFeature.number`) is the
+other number-bearing route in the library; it carries `UD.Number` and
+relates to this one by `Number.fromUD`.
+-/
+
+set_option autoImplicit false
+
+/-- A carrier that bears grammatical number. `none` = unmarked or
+    underspecified (a wildcard for agreement, not a default value). -/
+class HasNumber (α : Type*) where
+  /-- The canonical number value the carrier bears. -/
+  numberOf : α → Option Number
+
+/-- A UD morphology bundle bears the number its `number` tag ingests
+    (`Number.fromUD`); tags with no analytical equivalent (`Inv`/`Coll`/
+    `Count`) leave the carrier unvalued. -/
+instance : HasNumber UD.MorphFeatures :=
+  ⟨fun f => f.number.bind Number.fromUD⟩
+
+namespace HasNumber
+
+variable {α : Type*} {β : Type*} [HasNumber α] [HasNumber β]
+
+/-- Number compatibility between two (possibly heterogeneous) carriers:
+    valued numbers must coincide; an unvalued carrier is a wildcard.
+    The number axis of φ-agreement (`UD.MorphFeatures.compatible`). -/
+def Compatible (a : α) (b : β) : Prop :=
+  ∀ na ∈ numberOf a, ∀ nb ∈ numberOf b, na = nb
+
+instance (a : α) (b : β) : Decidable (Compatible a b) := by
+  unfold Compatible; infer_instance
+
+theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
+    Compatible b a :=
+  fun nb hb na ha => (h na ha nb hb).symm
+
+/-- An unvalued carrier is compatible with everything. -/
+theorem compatible_of_none {a : α} (h : numberOf a = none) (b : β) :
+    Compatible a b := by
+  intro na ha
+  rw [h] at ha
+  exact absurd ha (Option.not_mem_none _)
+
+end HasNumber
+
+/-- φ-compatibility entails number compatibility: the `HasNumber` mixin never
+    diverges from the unification-based agreement engine
+    (`UD.MorphFeatures.compatible`). -/
+theorem UD.MorphFeatures.compatible_hasNumber {f1 f2 : UD.MorphFeatures}
+    (h : f1.compatible f2 = true) :
+    HasNumber.Compatible f1 f2 := by
+  intro na ha nb hb
+  have hn : (f1.number.isNone || f2.number.isNone || f1.number == f2.number)
+      = true := by
+    unfold UD.MorphFeatures.compatible at h
+    simp only [Bool.and_eq_true] at h
+    tauto
+  simp only [HasNumber.numberOf, Option.mem_def] at ha hb
+  rcases h1 : f1.number with _ | u1
+  · rw [h1] at ha
+    exact absurd ha (Option.not_mem_none _)
+  · rcases h2 : f2.number with _ | u2
+    · rw [h2] at hb
+      exact absurd hb (Option.not_mem_none _)
+    · rw [h1] at ha
+      rw [h2] at hb
+      rw [h1, h2] at hn
+      simp only [Option.isNone_some, Bool.false_or, beq_iff_eq,
+                 Option.some.injEq] at hn
+      subst hn
+      simp only [Option.bind] at ha hb
+      rw [ha] at hb
+      exact Option.some.inj hb

--- a/Linglib/Features/Number/Decomposition.lean
+++ b/Linglib/Features/Number/Decomposition.lean
@@ -1,21 +1,12 @@
-import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Basic
 import Linglib.Features.ContainmentPair
 
 /-!
-# Number
-[corbett-2000] [harbour-2014]
+# Number — the Harbour feature decomposition and its lattice grounding
+[harbour-2014] [link-1983]
 
-Two components of the number API:
+Binary feature decomposition of the number values ([harbour-2014]):
 
-**§ 1–3: Number Categories** ([corbett-2000]). Eight analytical number
-values organized along two orthogonal dimensions:
-- **System membership**: general number is *outside* the number system (a form
-  non-committal to cardinality); all others are within it.
-- **Determinacy**: values whose cardinality boundary is fixed (singular=1,
-  dual=2, trial=3) vs those whose boundary varies by context (paucal ≈ 2–6,
-  greater plural ≈ abundance).
-
-**§ 4–6: Number Features** ([harbour-2014]). Binary feature decomposition:
 - **[±atomic]**: whether the referent is an atom (singleton) or a non-atom
   (plurality). Singular is [+atomic]; dual and plural are [−atomic].
 - **[±minimal]**: whether the referent is a minimal element of the relevant
@@ -26,10 +17,11 @@ An atom is necessarily a minimal element of any lattice region it belongs to.
 
 This containment parallels person features ([+author] → [+participant]),
 but with an asymmetry worth marking: number's filter is a *theorem* of the
-lattice semantics (§8 — atoms are minimal; [harbour-2016] ch. 9.5 notes the
-odd cooccurrence is contradictory for `±atomic` "by the logic of the
-system"), whereas person's filter is a descriptive convention the same
-chapter rejects. See `Features/ContainmentPair.lean`.
+lattice semantics (the grounding sections below — atoms are minimal;
+[harbour-2016] ch. 9.5 notes the odd cooccurrence is contradictory for
+`±atomic` "by the logic of the system"), whereas person's filter is a
+descriptive convention the same chapter rejects. See
+`Features/ContainmentPair.lean`.
 
 The three well-formed combinations yield the three basic number values:
 - **singular**: [+atomic, +minimal] — atoms (singletons)
@@ -37,167 +29,32 @@ The three well-formed combinations yield the three basic number values:
 - **plural**: [−atomic, −minimal] — non-minimal non-atoms (triads and up)
 
 Trial, unit augmented, and augmented arise from **feature recursion**
-(reapplying [±minimal] to subregions), which is theory-layer material.
-The approximative numbers (paucal, greater paucal, greater plural) require
-the additional feature [±additive], also theory-layer.
+(reapplying [±minimal] to subregions; `Syntax/Minimalist/Phi/Recursion.lean`).
+The approximative numbers require the additional feature [±additive] (§ on
+the additive feature below).
 
-The full typological machinery (number systems, animacy profiles, agreement
-hierarchy, language data) remains in
-`Studies/Corbett2000.lean`.
+## Main declarations
 
+* `Number.Features` — the [±atomic, ±minimal] bundle, with the containment
+  filter `Features.WellFormed` and the `ContainmentPairLike` presentation
+  unifying it with the person skeleton
+  (`featuresEquiv : Features ≃ ContainmentPair`).
+* `Number.latticeToFeatures` — classify a lattice element as
+  singular/dual/plural by its position.
+* `Number.isJoinCompleteIn` / `Number.isRegionJoinComplete` — the
+  [±additive] feature ([harbour-2014]): join-completeness within a region.
+* `Number.dualPredOnLattice` — ⟦DUAL⟧ as a predicate modifier
+  ([jeretic-bassi-gonzalez-yatsushiro-meyer-sauerland-2025]), grounded in
+  the feature decomposition by `dualPredOnLattice_eq_via_features`.
 -/
 
-/-- Grammatical number — UD's descriptive vocabulary (`UD.Number`: `.Sing`, `.Plur`,
-`.Dual`, …) as the canonical type; the analytical apparatus below is its API. -/
-abbrev Features.Number := UD.Number
+set_option autoImplicit false
 
-namespace Features.Number
+namespace Number
 
--- ============================================================================
--- § 1: Number Categories
--- ============================================================================
+open _root_.Features (ContainmentPair ContainmentPairLike)
 
-/-- Number categories in [corbett-2000]'s inventory.
-
-    Two orthogonal classifications:
-    - **System membership**: general is *outside* the number system; all others
-      are within it.
-    - **Determinacy**: values whose cardinality boundary is fixed (singular=1,
-      dual=2, trial=3) vs those whose boundary varies by context (paucal ≈ 2–6,
-      greater plural ≈ all/abundance). -/
-inductive Category where
-  | general        -- non-committal, outside the number system
-  | singular       -- exactly one ([+atomic, +minimal])
-  | dual           -- exactly two ([−atomic, +minimal])
-  | trial          -- exactly three (recursive [+minimal] on plural region)
-  | paucal         -- a few (indeterminate, [−additive])
-  | plural         -- more than one (residual, [−atomic] or [+additive])
-  | greaterPaucal  -- indeterminate, larger than paucal ([−additive]*)
-  | greaterPlural  -- abundance / totality (recursive [−minimal] on plural)
-  | minimal        -- [+minimal] without [±atomic] — includes atoms AND
-                    -- minimal non-atoms; distinct from singular
-  | augmented      -- [−minimal] without [±atomic] — complement of minimal
-  | unitAugmented  -- recursive [+minimal] on augmented region — minimal
-                    -- non-minimal; distinct from dual
-  | globalPlural   -- recursive [+additive] on [+additive] region (tentative)
-  deriving DecidableEq, Repr
-
-namespace Category
-
-/-- A number category is determinate iff its cardinality boundary is fixed.
-    Minimal and unit augmented are indeterminate: they depend on the
-    composition of the group, not a fixed cardinality. -/
-def isDeterminate : Category → Prop
-  | .singular | .dual | .trial => True
-  | _ => False
-
-instance : DecidablePred isDeterminate := fun c => by
-  cases c <;> unfold isDeterminate <;> infer_instance
-
-/-- A number category participates in the number system (is not general). -/
-def isInSystem : Category → Prop
-  | .general => False
-  | _ => True
-
-instance : DecidablePred isInSystem := fun c => by
-  cases c <;> unfold isInSystem <;> infer_instance
-
-/-- Exact referent-set cardinality for determinate number categories.
-
-    Singular denotes exactly 1 individual (atom), dual exactly 2 (pair),
-    trial exactly 3 (triple). All other categories — plural, paucal,
-    greaterPlural, minimal, augmented — have indeterminate or
-    context-dependent cardinality and return `none`.
-
-    Used by `CoordinateResolution.canonicalResolve` to derive resolution
-    from cardinality addition: |A ⊔ B| = |A| + |B| for disjoint sets. -/
-def exactCard : Category → Option Nat
-  | .singular => some 1
-  | .dual     => some 2
-  | .trial    => some 3
-  | _         => none
-
-/-- Whether a category belongs to the [±minimal] number system (without
-    [±atomic]). In such systems, minimal = atoms ∪ minimal non-atoms,
-    and augmented = everything else. Returns `none` for categories
-    outside the MIN/AUG system. -/
-def isMinAug : Category → Prop
-  | .minimal | .augmented => True
-  | _ => False
-
-instance : DecidablePred isMinAug := fun c => by
-  cases c <;> unfold isMinAug <;> infer_instance
-
-/-- Map a referent-set cardinality back to the finest determinate category.
-    1 → singular, 2 → dual, 3 → trial, 4+ → greaterPlural. -/
-def fromCard : Nat → Category
-  | 1 => .singular
-  | 2 => .dual
-  | 3 => .trial
-  | _ => .greaterPlural
-
-/-- `fromCard` inverts `exactCard` for determinate categories. -/
-theorem fromCard_singular : fromCard 1 = .singular := rfl
-theorem fromCard_dual : fromCard 2 = .dual := rfl
-theorem fromCard_trial : fromCard 3 = .trial := rfl
-
-end Category
-
--- ============================================================================
--- § 2: UD Bridges
--- ============================================================================
-
-/-- Map analytical number categories to UD.Number (general has no UD equivalent).
-    Minimal, augmented, unit augmented, and global plural have no UD representation. -/
-def Category.toUD : Category → Option UD.Number
-  | .general        => none
-  | .singular       => some .Sing
-  | .dual           => some .Dual
-  | .trial          => some .Tri
-  | .paucal         => some .Pauc
-  | .plural         => some .Plur
-  | .greaterPaucal  => some .Grpa
-  | .greaterPlural  => some .Grpl
-  | .minimal        => none
-  | .augmented      => none
-  | .unitAugmented  => none
-  | .globalPlural   => none
-
-/-- Map UD.Number to analytical number categories (partial).
-
-    Seven core categories round-trip cleanly. Three UD values have no analytical
-    equivalent:
-    - `Inv` (inverse number): marks the *unexpected* number for a given noun —
-      plural for some nouns, singular for others. Not a fixed cardinality.
-    - `Coll` (collective): denotes a group-as-unit (Russian *листва* 'foliage'),
-      distinct from general number which is non-committal to cardinality.
-    - `Count` (count form): a special form after numerals (Hungarian, Welsh),
-      not equivalent to singular (exactly one). -/
-def Category.fromUD : UD.Number → Option Category
-  | .Sing  => some .singular
-  | .Plur  => some .plural
-  | .Dual  => some .dual
-  | .Tri   => some .trial
-  | .Pauc  => some .paucal
-  | .Grpa  => some .greaterPaucal
-  | .Grpl  => some .greaterPlural
-  | .Inv   => none
-  | .Coll  => none
-  | .Count => none
-
--- ============================================================================
--- § 3: Category Verification
--- ============================================================================
-
-/-- Round-trip: fromUD ∘ toUD = id for all in-system categories. -/
-theorem roundtrip_fromUD_toUD :
-    [Category.singular, .dual, .trial, .paucal, .plural,
-     .greaterPaucal, .greaterPlural].all
-      (λ v => v.toUD.bind Category.fromUD == some v) = true := by decide
-
--- ============================================================================
--- § 4: Number Features
--- ============================================================================
+/-! ### The feature bundle -/
 
 /-- Bivalent number features: [±atomic, ±minimal].
 
@@ -225,37 +82,33 @@ def dualF : Features := ⟨false, true⟩
 /-- Plural features: [−atomic, −minimal]. -/
 def pluralF : Features := ⟨false, false⟩
 
--- ============================================================================
--- § 5: Features ↔ Category Bridge
--- ============================================================================
+/-! ### Features ↔ value bridge -/
 
-/-- Map number features to Corbett's analytical number categories.
+/-- Map a feature bundle to the number value it realizes.
 
-    The three well-formed base feature bundles map to three of
-    [corbett-2000]'s eight categories. The remaining (trial,
+    The three well-formed base bundles map to three of
+    [corbett-2000]'s values. The remaining (trial,
     paucal, etc.) arise from feature recursion and [±additive], which
     require compositional machinery beyond the base feature pair. -/
-def Features.toCategory : Features → Option Category
+def Features.toNumber : Features → Option Number
   | ⟨true, true⟩   => some .singular
   | ⟨false, true⟩  => some .dual
   | ⟨false, false⟩ => some .plural
   | ⟨true, false⟩  => none  -- ill-formed
 
-/-- Map Corbett's number categories to base features (partial).
+/-- Map a number value to its base feature bundle (partial).
 
-    Only the three categories derivable from the base [±atomic, ±minimal]
+    Only the three values derivable from the base [±atomic, ±minimal]
     system have feature equivalents. Trial, paucal, minimal, augmented,
     and the rest require feature recursion, [±additive], or different
     feature activation patterns. -/
-def Features.fromCategory : Category → Option Features
+def Features.ofNumber : Number → Option Features
   | .singular => some singularF
   | .dual     => some dualF
   | .plural   => some pluralF
   | _         => none
 
--- ============================================================================
--- § 6: ContainmentPair Presentation
--- ============================================================================
+/-! ### The `ContainmentPairLike` presentation -/
 
 /-- The `[±atomic, ±minimal]` decomposition is carrier-equivalent to the
 containment pair: `outer` = minimal, `inner` = atomic. The containment
@@ -294,9 +147,7 @@ theorem no_fourth_base_number :
   fun a b c d ha hb hc hd =>
     ContainmentPairLike.no_four_way a b c d ha hb hc hd
 
--- ============================================================================
--- § 7: Features Verification
--- ============================================================================
+/-! ### Verification -/
 
 @[simp] theorem singular_wellFormed : singularF.WellFormed := by decide
 @[simp] theorem dual_wellFormed : dualF.WellFormed := by decide
@@ -312,26 +163,22 @@ theorem illFormed_only : ¬ (⟨true, false⟩ : Features).WellFormed := by deci
 theorem card_wellFormed :
     Fintype.card {nf : Features // nf.WellFormed} = 3 := by decide
 
-/-- Round-trip: fromCategory ∘ toCategory = some for all well-formed features. -/
-theorem roundtrip_fromCategory_toCategory :
+/-- Round-trip: `ofNumber ∘ toNumber = some` for all well-formed features. -/
+theorem roundtrip_ofNumber_toNumber :
     [singularF, dualF, pluralF].all
-      (λ f => f.toCategory.bind Features.fromCategory == some f) = true := by
+      (λ f => f.toNumber.bind Features.ofNumber == some f) = true := by
   decide
 
-/-- toCategory returns none for the filtered bundle. -/
-theorem illFormed_toCategory_none :
-    (⟨true, false⟩ : Features).toCategory = none := rfl
+/-- `toNumber` returns none for the filtered bundle. -/
+theorem illFormed_toNumber_none :
+    (⟨true, false⟩ : Features).toNumber = none := rfl
 
 /-- Containment: [+atomic] → [+minimal] for all well-formed features. -/
 theorem atomic_implies_minimal :
     ∀ f : Features, f.WellFormed → f.isAtomic = true → f.isMinimal = true := by
   decide
 
--- ============================================================================
--- § 8: Lattice-Theoretic Grounding
--- ============================================================================
-
-/-! ### Lattice-Theoretic Grounding
+/-! ### Lattice-theoretic grounding
 
 Number features grounded in a join-semilattice of individuals.
 
@@ -351,8 +198,8 @@ grounding computationally verifiable. They are the `Bool` counterparts
 of `Mereology.Atom` and minimality-in-region. -/
 
 /-- Powerset lattice join (bitwise OR). Atoms are powers of 2;
-    sums are bitwise OR of their atoms. Used across §§8–10 and
-    by `CoordinateResolution` for lattice verification. -/
+    sums are bitwise OR of their atoms. Used across the lattice
+    sections below and by `Number.resolve` for lattice verification. -/
 def bitmaskJoin (a b : Nat) : Nat := Nat.lor a b
 
 /-- Ordering induced by join: a ≤ b iff a ⊔ b = b.
@@ -428,11 +275,7 @@ theorem ps3_pair_is_dual' :
 theorem ps3_triple_is_plural :
     latticeToFeatures bitmaskJoin ps3Domain 7 = pluralF := by decide
 
--- ============================================================================
--- § 9: The Additive Feature
--- ============================================================================
-
-/-! ### The Additive Feature
+/-! ### The additive feature
 [harbour-2014]
 
 [±additive] is the third number feature, characterizing
@@ -467,11 +310,7 @@ def isRegionJoinComplete {D : Type} [DecidableEq D]
     (join : D → D → D) (region : List D) : Bool :=
   region.all fun x => isJoinCompleteIn join region x
 
--- ============================================================================
--- § 10: Additive Feature — Powerset Lattice Examples
--- ============================================================================
-
-/-! ### Powerset Lattice Examples
+/-! ### Additive feature — powerset lattice examples
 
 Paucal vs plural on a powerset lattice (join = bitwise OR). Atoms
 encoded as powers of 2; sums as bitwise OR of their atoms.
@@ -521,10 +360,6 @@ theorem ps5_additive_asymmetry :
     isRegionJoinComplete bitmaskJoin ps5Plural = true ∧
     isRegionJoinComplete bitmaskJoin ps5Paucal = false :=
   ⟨ps5_plural_joinComplete, ps5_paucal_not_joinComplete⟩
-
--- ============================================================================
--- § 11: DUAL Core Concept — Predicate-Modification Denotation
--- ============================================================================
 
 /-! ### DUAL as predicate modifier
 [jeretic-bassi-gonzalez-yatsushiro-meyer-sauerland-2025]
@@ -599,7 +434,7 @@ factors as `P x ∧ latticeToFeatures … x = dualF`.
 
 This grounds the paper's predicate-modifier semantics
 ([jeretic-bassi-gonzalez-yatsushiro-meyer-sauerland-2025] eq 39)
-in the existing Harbour feature decomposition (Number.lean §§4-5):
+in the existing Harbour feature decomposition (the feature bundle above):
 DUAL is *not* a separate primitive but the same conditions used to
 classify a lattice element as `[−atomic, +minimal]`. -/
 theorem dualPredOnLattice_eq_via_features {D : Type} [DecidableEq D]
@@ -621,10 +456,10 @@ theorem dualPredOnLattice_eq_via_features {D : Type} [DecidableEq D]
     unfold latticeToFeatures at hF
     by_cases ha : isAtom join domain x = true
     · simp [ha, singularF, dualF] at hF
-    · simp only [ha, if_false, Bool.not_eq_true] at hF
+    · simp only [ha] at hF
       by_cases hm : isMinimalNonAtom join domain x = true
       · exact hm
-      · simp only [hm, if_false, Bool.not_eq_true] at hF
+      · simp only [hm] at hF
         simp [pluralF, dualF] at hF
 
 /-- On the 3-atom powerset, the dual reading of "is a non-atom"
@@ -640,27 +475,4 @@ theorem ps3_dual_triple_excluded :
     dualPredOnLattice bitmaskJoin ps3Domain (fun _ => true) 7 = false := by
   decide
 
--- ============================================================================
--- § 4: Number Opposition Stages ([cysouw-2009], Fig 10.8)
--- ============================================================================
-
-/-- Number opposition stages ([cysouw-2009], Fig 10.8).
-    A coarsening over the eight [corbett-2000] number values into a
-    four-step hierarchy of typological "richness", from no number marking
-    (N₁) to full number marking with restricted groups (N₃/N₄).
-
-    Used by both [cysouw-2009] (paradigmatic person-marking) and
-    [corbett-2000] (`NumberSystem.toNumberStage` bridge in
-    `Studies/Corbett2000.lean`). -/
-inductive NumberStage where
-  /-- Undifferentiated number marking (singular = group unmarked). -/
-  | N1
-  /-- Singular vs group (basic number opposition). -/
-  | N2
-  /-- Restricted group (dual/trial) distinguished from unrestricted. -/
-  | N3
-  /-- Small group (paucal) additionally distinguished. -/
-  | N4
-  deriving DecidableEq, Repr
-
-end Features.Number
+end Number

--- a/Linglib/Features/Number/Resolve.lean
+++ b/Linglib/Features/Number/Resolve.lean
@@ -1,0 +1,204 @@
+import Linglib.Features.Number.Basic
+import Linglib.Features.Number.Decomposition
+
+/-!
+# Number resolution
+[corbett-2000] [harbour-2014] [link-1983]
+
+The single canonical number-resolution operation: when two number-bearing
+referents combine (conjoined DPs, resolved agreement), the result is
+**derived** from the join-semilattice of individuals ([link-1983]) via
+[harbour-2014]'s feature geometry, then **coarsened** to the values the
+language's number system makes available — the formal content of
+[corbett-2000] §6.3: "the result depends on which number values the
+language has."
+
+- `Number.resolve` computes the finest value for the mereological sum
+  (sg ⊔ sg → du: atom ⊔ atom = pair).
+- `Number.coarsenTo` maps it to an available value
+  (du → pl in a {sg, pl} system like English).
+- `Number.resolveIn` composes the two; `Number.System.resolve` is the
+  system-typed entry point.
+
+Consumers: `Syntax/Minimalist/Agreement/CoordinateResolution.lean` wraps
+`resolveIn` as the number `ResolutionOp` of φ-resolution and proves closure
+over [harbour-2014] Table 3; `Studies/Corbett2000.lean` states the book's
+resolution data over its language systems.
+-/
+
+set_option autoImplicit false
+
+namespace Number
+
+/-! ### Canonical resolution -/
+
+/-- Canonical number resolution: the finest value for the mereological
+    sum of two referents, **derived** from two lattice-theoretic principles.
+    The resolution data are [corbett-2000] §6.3 (resolved dual in
+    Slovene/Sorbian); the value lattice they are derived from is
+    [link-1983]/[harbour-2014]:
+
+    1. **Cardinality addition** (for determinate values):
+       |A ⊔ B| = |A| + |B| for disjoint referent sets A, B.
+       The sum is mapped back to the finest determinate value via
+       `Number.fromCard`.
+
+       - sg(1) + sg(1) = 2 → du
+       - sg(1) + du(2) = 3 → trial
+       - du(2) + du(2) = 4 → plural (no determinate value for sums ≥ 4)
+
+    2. **MIN/AUG lattice join** (for [±minimal] systems without [±atomic]):
+       In a 2-level lattice {minimal, augmented}, the join of any two
+       distinct elements exceeds the minimal. Since coordination requires
+       disjoint referents, the result is always augmented.
+
+    3. **Catch-all**: values without exact cardinality or MIN/AUG
+       membership (plural, paucal, greaterPlural, etc.) resolve to plural
+       — the default non-singular value. -/
+def resolve (a b : Number) : Number :=
+  match a.exactCard, b.exactCard with
+  | some na, some nb => fromCard (na + nb)
+  | _, _ =>
+    if a.isMinAug ∧ b.isMinAug then .augmented
+    else .plural
+
+/-- Canonical resolution is commutative: x ⊔ y = y ⊔ x. -/
+theorem resolve_comm (a b : Number) : resolve a b = resolve b a := by
+  cases a <;> cases b <;> rfl
+
+/-- Canonical resolution is associative: sums of three or more referents
+    resolve the same under any bracketing (cardinalities ≥ 4 all collapse
+    to the residual plural, which absorbs). -/
+theorem resolve_assoc :
+    ∀ a b c : Number, resolve (resolve a b) c = resolve a (resolve b c) := by
+  decide
+
+/-! ### Coarsening to a system -/
+
+/-- Coarsen a value to the nearest available one in a number system.
+
+    Values not present in the system map to their semantic
+    superordinate — the broader value whose referents include
+    the absent value's referents.
+
+    The superordinate map is hand-specified: it is *not* monotone in the
+    markedness order (`Number.instPartialOrder`), whose direction is
+    implicational (b presupposes a), not referent-containment. Its closure
+    over every [harbour-2014] Table 3 system is verified in
+    `Minimalist.Agreement.CoordinateResolution.resolution_closure_table3`. -/
+def coarsenTo (system : List Number) (c : Number) : Number :=
+  if system.contains c then c else
+  match c with
+  | .dual | .trial | .greaterPlural | .globalPlural =>
+    if system.contains .plural then .plural
+    else if system.contains .augmented then .augmented
+    else c
+  | .unitAugmented =>
+    if system.contains .augmented then .augmented else c
+  | .greaterPaucal =>
+    if system.contains .paucal then .paucal
+    else if system.contains .plural then .plural
+    else c
+  | .paucal =>
+    if system.contains .plural then .plural
+    else if system.contains .augmented then .augmented
+    else c
+  | .augmented =>
+    if system.contains .plural then .plural
+    else c
+  | .plural =>
+    if system.contains .augmented then .augmented
+    else if system.contains .greaterPlural then .greaterPlural
+    else c
+  | _ => c
+
+/-- System-parameterized number resolution: canonical lattice join,
+    coarsened to the available values in the target system.
+
+    This derives resolution rules from two independent components:
+    1. Lattice join: sg + sg → du (canonical)
+    2. Coarsening: du → pl in a {sg, pl} system -/
+def resolveIn (system : List Number) (a b : Number) : Number :=
+  coarsenTo system (resolve a b)
+
+/-- System-parameterized resolution is commutative. -/
+theorem resolveIn_comm (system : List Number) (a b : Number) :
+    resolveIn system a b = resolveIn system b a := by
+  simp only [resolveIn, resolve_comm]
+
+/-- Resolution typed by a `Number.System`: resolve in the system's values. -/
+def System.resolve (ns : System) (a b : Number) : Number :=
+  resolveIn ns.values a b
+
+/-! ### Lattice verification
+
+The canonical resolution is verified against a concrete 3-atom
+powerset lattice. Atoms: {a}=1, {b}=2, {c}=4. Pairs: {a,b}=3,
+{a,c}=5, {b,c}=6. Triple: {a,b,c}=7. Join = bitwise OR.
+
+`Number.latticeToFeatures` classifies elements by lattice position:
+atoms → singular, minimal non-atoms → dual, non-minimal non-atoms →
+plural. -/
+
+/-- Atom 1 ⊔ Atom 2 = 3, which is dual (minimal non-atom).
+    Lattice grounding: `resolve sg sg = du`. -/
+theorem lattice_atom_join_dual :
+    latticeToFeatures bitmaskJoin ps3Domain (bitmaskJoin 1 2) = dualF := by
+  decide
+
+/-- Atom 4 ⊔ Pair 3 = 7, which is plural (non-minimal non-atom).
+    Lattice grounding: `resolve sg du = trial` (plural in
+    base system, trial with recursion). -/
+theorem lattice_atom_pair_plural :
+    latticeToFeatures bitmaskJoin ps3Domain (bitmaskJoin 4 3) = pluralF := by
+  decide
+
+/-- The derived `resolve` agrees with the powerset lattice:
+    join in the concrete lattice, then classify via `latticeToFeatures`,
+    matches `resolve` applied to the classified inputs.
+
+    - atom(1) is singular, atom(2) is singular → join=3 is dual
+    - atom(1) is singular, pair(6) is dual → join=7 is plural (= trial with recursion)
+
+    This is the structural proof that `resolve` is the lattice join
+    pushed through `latticeToFeatures`, not a stipulation. -/
+theorem lattice_grounding_agrees :
+    -- sg ⊔ sg → du: atom(1) ⊔ atom(2) = pair(3), classified as dual
+    latticeToFeatures bitmaskJoin ps3Domain (bitmaskJoin 1 2) = dualF ∧
+    -- sg ⊔ du → trial/plural: atom(4) ⊔ pair(3) = triple(7), classified as plural
+    -- (plural in the base 3-atom lattice; trial under Harbour's recursion)
+    latticeToFeatures bitmaskJoin ps3Domain (bitmaskJoin 4 3) = pluralF := by
+  decide
+
+/-! ### System-dependent predictions -/
+
+/-- In a {sg, pl} system (English): sg + sg → pl.
+    Canonical du coarsened to plural. -/
+theorem resolve_sgpl_sg_sg :
+    resolveIn [.singular, .plural] .singular .singular = .plural := rfl
+
+/-- In a {sg, du, pl} system (Slovene): sg + sg → du.
+    Canonical du is available, no coarsening. -/
+theorem resolve_sgdupl_sg_sg :
+    resolveIn [.singular, .dual, .plural] .singular .singular = .dual := rfl
+
+/-- In a {sg, du, pl} system: sg + du → pl (triple = plural without
+    recursion). -/
+theorem resolve_sgdupl_sg_du :
+    resolveIn [.singular, .dual, .plural] .singular .dual = .plural := rfl
+
+/-- In a {sg, du, trial, greaterPl} system (Larike): sg + du → trial. -/
+theorem resolve_larike_sg_du :
+    resolveIn [.singular, .dual, .plural, .trial, .greaterPlural]
+      .singular .dual = .trial := rfl
+
+/-- In a {sg, du, trial, greaterPl} system: sg + sg → du. -/
+theorem resolve_larike_sg_sg :
+    resolveIn [.singular, .dual, .plural, .trial, .greaterPlural]
+      .singular .singular = .dual := rfl
+
+/-- In a {min, aug} system (Winnebago): min + min → aug. -/
+theorem resolve_minAug_min_min :
+    resolveIn [.minimal, .augmented] .minimal .minimal = .augmented := rfl
+
+end Number

--- a/Linglib/Features/PhiKernel.lean
+++ b/Linglib/Features/PhiKernel.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Person
-import Linglib.Features.Number
+import Linglib.Features.Number.Decomposition
 
 /-!
 # The Phi Kernel

--- a/Linglib/Fragments/Dargwa/Agreement.lean
+++ b/Linglib/Fragments/Dargwa/Agreement.lean
@@ -1,7 +1,6 @@
 import Linglib.Features.Prominence
 import Linglib.Data.UD.Basic
 import Linglib.Features.Gender
-import Linglib.Features.Number
 
 /-!
 # Dargwa (Tanti) Agreement [sumbatova-2021]
@@ -36,7 +35,6 @@ The 2SG marker is identical across the clitic set (*=de*) and past
 tense (*=de*), creating a homophony that is typologically unusual.
 -/
 
-open Features (Number)
 
 namespace Dargwa.Agreement
 
@@ -105,7 +103,7 @@ inductive MarkerSet where
     **Clitic set** ("Dargic type"): =da covers 1SG, 1PL, and 2PL
     (ex. 34a: "I, we, you(PL) am, are doing"); =de is 2SG only.
     Table 4.21 confirms: "person clitics: 2SG =de, 1SG/PL, 2PL =da". -/
-def personMarker : MarkerSet → PersonLevel → Number → Option String
+def personMarker : MarkerSet → PersonLevel → UD.Number → Option String
   -- Clitic set: =da for {1SG, 1PL, 2PL}, =de for {2SG}, none for {3}
   | .clitic,   .first,  _   => some "=da"
   | .clitic,   .second, .Sing => some "=de"

--- a/Linglib/Fragments/Dutch/Nouns.lean
+++ b/Linglib/Fragments/Dutch/Nouns.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 import Linglib.Semantics.Kinds.NominalMappingParameter
 
 /-!
@@ -30,6 +31,13 @@ inductive NPNumber where
   | sg | pl | mass
   deriving DecidableEq, Repr
 
+/-- Dutch NP number in the canonical inventory; mass NPs bear no
+    count-number value. -/
+def NPNumber.toNumber : NPNumber → Option Number
+  | .sg => some .singular
+  | .pl => some .plural
+  | .mass => none
+
 /-- Scrambling position in the Dutch middle field. -/
 inductive ScramblingPosition where
   | unscrambled
@@ -44,6 +52,9 @@ structure NP where
   determiner : Option String := none
   position : Option ScramblingPosition := none
   deriving Repr, BEq
+
+/-- A Dutch NP bears its number slot canonically (`HasNumber`). -/
+instance : HasNumber NP := ⟨fun np => np.number.toNumber⟩
 
 def NP.isBarePlural (np : NP) : Bool :=
   np.isBare && np.number == .pl

--- a/Linglib/Fragments/English/Auxiliaries.lean
+++ b/Linglib/Fragments/English/Auxiliaries.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 import Linglib.Features.Person
 import Linglib.Semantics.Modality.ModalTypes
 import Linglib.Features.Register
@@ -98,6 +99,9 @@ structure AuxEntry where
       [u∃-MOD], checked by a single silent [i∃-MOD] operator. -/
   interpretability : Option ModalInterpretability := none
   deriving Repr, BEq
+
+/-- An auxiliary bears its agreement number (`HasNumber`). -/
+instance : HasNumber AuxEntry := ⟨fun a => a.number.bind Number.fromUD⟩
 
 -- Modals (no agreement). Modal meanings follow [kratzer-1981], [palmer-2001].
 -- Each uses cartesianProduct with singleton force (fixed force, variable flavor).

--- a/Linglib/Fragments/English/Auxiliaries.lean
+++ b/Linglib/Fragments/English/Auxiliaries.lean
@@ -1,5 +1,4 @@
 import Linglib.Data.UD.Basic
-import Linglib.Features.Number
 import Linglib.Features.Person
 import Linglib.Semantics.Modality.ModalTypes
 import Linglib.Features.Register
@@ -50,7 +49,7 @@ To find every claim made about a particular entry, grep for
 `Theories/`.
 -/
 
-open Features (Number Person)
+open Features (Person)
 
 namespace English.Auxiliaries
 
@@ -71,7 +70,7 @@ structure AuxEntry where
   auxType : AuxType
   /-- Person/number agreement -/
   person : Option Person := none
-  number : Option Number := none
+  number : Option UD.Number := none
   /-- Morphological tense. `none` for base forms (modals like *can*, *will*).
       Note: "past" modals (*could*, *would*) carry `Past` as a morphological
       feature even when semantically non-past (counterfactual, polite). -/

--- a/Linglib/Fragments/Finnish/Possession.lean
+++ b/Linglib/Fragments/Finnish/Possession.lean
@@ -1,3 +1,4 @@
+import Linglib.Features.Number.Basic
 import Linglib.Typology.Possession
 
 /-!
@@ -81,6 +82,11 @@ inductive FiPossPerson where | first | second | third
 
 inductive FiPossNumber where | sg | pl
   deriving DecidableEq, Repr
+
+/-- The possessive paradigm's number dimension, canonically. -/
+def FiPossNumber.toNumber : FiPossNumber → Number
+  | .sg => .singular
+  | .pl => .plural
 
 def possSuffix : FiPossPerson → FiPossNumber → String
   | .first,  .sg => "-ni"

--- a/Linglib/Fragments/French/Nouns.lean
+++ b/Linglib/Fragments/French/Nouns.lean
@@ -1,5 +1,6 @@
 import Linglib.Features.Gender
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 import Linglib.Semantics.Kinds.NominalMappingParameter
 
 /-! # French Noun Lexicon Fragment
@@ -54,6 +55,9 @@ structure NP where
   /-- The determiner (if not bare) -/
   determiner : Option Determiner := none
   deriving Repr, BEq
+
+/-- An NP bears the number of its `number` slot (`HasNumber`). -/
+instance : HasNumber NP := ⟨fun np => Number.fromUD np.number⟩
 
 
 /--

--- a/Linglib/Fragments/French/Nouns.lean
+++ b/Linglib/Fragments/French/Nouns.lean
@@ -1,14 +1,12 @@
 import Linglib.Features.Gender
 import Linglib.Data.UD.Basic
 import Linglib.Semantics.Kinds.NominalMappingParameter
-import Linglib.Features.Number
 
 /-! # French Noun Lexicon Fragment
 
 French NP structure with gender. Bare arguments restricted ([chierchia-1998] [-arg, +pred]).
 -/
 
-open Features (Number)
 
 namespace French.Nouns
 
@@ -49,8 +47,8 @@ French NPs require determiners in most contexts.
 structure NP where
   /-- The underlying noun -/
   noun : NounEntry
-  /-- Number -/
-  number : Number
+  /-- Grammatical number. -/
+  number : UD.Number
   /-- Is this a bare NP (no determiner)? -/
   isBare : Bool
   /-- The determiner (if not bare) -/
@@ -72,7 +70,7 @@ def frenchMapping : NominalMapping := .predOnly
 
 
 /-- Create a definite NP (le/la/les) -/
-def defNP (n : NounEntry) (num : Number := .Sing) : NP :=
+def defNP (n : NounEntry) (num : UD.Number := .Sing) : NP :=
   let det := match num, n.gender with
     | .Sing, .masculine => Determiner.le
     | .Sing, .feminine => Determiner.la
@@ -98,7 +96,7 @@ def partNP (n : NounEntry) : NP :=
   { noun := n, number := .Sing, isBare := false, determiner := some det }
 
 /-- Create a bare NP (restricted in French) -/
-def bareNP (n : NounEntry) (num : Number := .Sing) : NP :=
+def bareNP (n : NounEntry) (num : UD.Number := .Sing) : NP :=
   { noun := n, number := num, isBare := true }
 
 

--- a/Linglib/Fragments/Ga/Basic.lean
+++ b/Linglib/Fragments/Ga/Basic.lean
@@ -1,3 +1,4 @@
+import Linglib.Features.Number.Basic
 import Linglib.Features.Gender
 import Linglib.Features.Person
 
@@ -50,6 +51,11 @@ inductive Person where | first | second | third
 
 inductive Number where | sg | pl
   deriving DecidableEq, Repr
+
+/-- Ga's two-value system in the canonical inventory. -/
+def Number.toNumber : Number → _root_.Number
+  | .sg => .singular
+  | .pl => .plural
 
 -- ════════════════════════════════════════════════════════════════
 -- § 2: Pronoun Paradigm

--- a/Linglib/Fragments/Ga/Basic.lean
+++ b/Linglib/Fragments/Ga/Basic.lean
@@ -1,6 +1,4 @@
 import Linglib.Features.Gender
-import Linglib.Data.UD.Basic
-import Linglib.Features.Number
 import Linglib.Features.Person
 
 /-!
@@ -39,7 +37,7 @@ diagnostic requires a free Neg head; Gã `-ee` and `-ko` appear
 suffixal) that is orthogonal to the OC story.
 -/
 
-open Features (Number Person)
+open Features (Person)
 
 namespace Ga
 

--- a/Linglib/Fragments/Hungarian/Reciprocals.lean
+++ b/Linglib/Fragments/Hungarian/Reciprocals.lean
@@ -2,6 +2,7 @@ import Linglib.Syntax.Pronoun.Basic
 import Linglib.Semantics.Reference.Reciprocals
 import Linglib.Semantics.Reference.PluralityLicensing
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 
 /-!
 # Hungarian Reciprocal Fragment
@@ -79,6 +80,9 @@ structure AntecedentConfig where
   /-- Verb agreement number -/
   verbAgr : UD.Number
   deriving Repr
+
+/-- An antecedent configuration bears its verb-agreement number (`HasNumber`). -/
+instance : HasNumber AntecedentConfig := ⟨fun c => Number.fromUD c.verbAgr⟩
 
 /-- §3: Quantified NPs. Hungarian quantified NPs are morphologically
     singular (no -ek suffix) and trigger 3SG verb agreement.

--- a/Linglib/Fragments/Hungarian/Reciprocals.lean
+++ b/Linglib/Fragments/Hungarian/Reciprocals.lean
@@ -1,7 +1,7 @@
 import Linglib.Syntax.Pronoun.Basic
 import Linglib.Semantics.Reference.Reciprocals
 import Linglib.Semantics.Reference.PluralityLicensing
-import Linglib.Features.Number
+import Linglib.Data.UD.Basic
 
 /-!
 # Hungarian Reciprocal Fragment
@@ -39,7 +39,6 @@ construction types, while reflexives require morphosyntactic plurality
    (I-)reading. [dalrymple-haug-2024] §2.
 -/
 
-open Features (Number)
 
 namespace Hungarian.Reciprocals
 
@@ -78,7 +77,7 @@ structure AntecedentConfig where
   /-- Semantically plural (denotes multiple individuals) -/
   semanticPl : Bool
   /-- Verb agreement number -/
-  verbAgr : Number
+  verbAgr : UD.Number
   deriving Repr
 
 /-- §3: Quantified NPs. Hungarian quantified NPs are morphologically

--- a/Linglib/Fragments/Italian/Nouns.lean
+++ b/Linglib/Fragments/Italian/Nouns.lean
@@ -1,5 +1,6 @@
 import Linglib.Features.Gender
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 import Linglib.Semantics.Kinds.NominalMappingParameter
 
 /-! # Italian Noun Lexicon Fragment
@@ -94,6 +95,9 @@ structure NP where
   /-- The determiner (if not bare) -/
   determiner : Option Determiner := none
   deriving Repr, BEq
+
+/-- An NP bears the number of its `number` slot (`HasNumber`). -/
+instance : HasNumber NP := ⟨fun np => Number.fromUD np.number⟩
 
 -- ============================================================================
 -- § 6: NP Constructors

--- a/Linglib/Fragments/Italian/Nouns.lean
+++ b/Linglib/Fragments/Italian/Nouns.lean
@@ -1,7 +1,6 @@
 import Linglib.Features.Gender
 import Linglib.Data.UD.Basic
 import Linglib.Semantics.Kinds.NominalMappingParameter
-import Linglib.Features.Number
 
 /-! # Italian Noun Lexicon Fragment
 
@@ -24,7 +23,6 @@ The partitive articles (di + definite article) serve as the obligatory
 indefinite plural — Italian has no bare plural arguments.
 -/
 
-open Features (Number)
 
 namespace Italian.Nouns
 
@@ -89,8 +87,8 @@ inductive Determiner where
 structure NP where
   /-- The underlying noun -/
   noun : NounEntry
-  /-- Number -/
-  number : Number
+  /-- Grammatical number. -/
+  number : UD.Number
   /-- Is this a bare NP (no determiner)? -/
   isBare : Bool
   /-- The determiner (if not bare) -/
@@ -105,7 +103,7 @@ structure NP where
     Uses `il` for masculine singular and `la` for feminine singular
     (the lo/gli allomorphs are phonologically conditioned and not
     modeled here). -/
-def defNP (n : NounEntry) (num : Number := .Sing) : NP :=
+def defNP (n : NounEntry) (num : UD.Number := .Sing) : NP :=
   let det := match num, n.gender with
     | .Sing, .feminine => Determiner.la
     | .Sing, _ => Determiner.il        -- masculine is default
@@ -121,7 +119,7 @@ def indefNP (n : NounEntry) : NP :=
   { noun := n, number := .Sing, isBare := false, determiner := some det }
 
 /-- Create a partitive NP (del/della for mass, dei/delle for plural). -/
-def partNP (n : NounEntry) (num : Number := .Sing) : NP :=
+def partNP (n : NounEntry) (num : UD.Number := .Sing) : NP :=
   let det := match num, n.gender with
     | .Sing, .feminine => Determiner.della
     | .Sing, _ => Determiner.del        -- masculine is default
@@ -130,7 +128,7 @@ def partNP (n : NounEntry) (num : Number := .Sing) : NP :=
   { noun := n, number := num, isBare := false, determiner := some det }
 
 /-- Create a bare NP (restricted in Italian). -/
-def bareNP (n : NounEntry) (num : Number := .Sing) : NP :=
+def bareNP (n : NounEntry) (num : UD.Number := .Sing) : NP :=
   { noun := n, number := num, isBare := true }
 
 -- ============================================================================

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -1,7 +1,6 @@
 import Linglib.Syntax.Pronoun.Basic
 import Linglib.Syntax.Pronoun.Capabilities
 import Linglib.Data.UD.Basic
-import Linglib.Features.Number
 import Linglib.Features.Person
 
 /-! # Italian Pronoun and Clitic Fragment
@@ -30,7 +29,7 @@ and reflexive cases, while 3sg/3pl are not.
 | 3pl    | li/le  | loro   | si   | NOT syncretic
 -/
 
-open Features (Number Person)
+open Features (Person)
 
 namespace Italian.Pronouns
 
@@ -102,7 +101,7 @@ inductive CliticCase where
 structure CliticEntry where
   form : String
   person : Person
-  number : Number
+  number : UD.Number
   case_ : CliticCase
   deriving Repr, BEq
 
@@ -179,18 +178,18 @@ example : Bound.IsAnaphor si_refl := by decide
 example : Bound.IsPronominal lo_cl := by decide
 
 /-- Look up the form for a given person, number, and case in the paradigm. -/
-def lookupForm (p : Person) (n : Number) (c : CliticCase) : Option String :=
+def lookupForm (p : Person) (n : UD.Number) (c : CliticCase) : Option String :=
   (paradigm.find? (fun e => e.person == p && e.number == n && e.case_ == c)).map (·.form)
 
 /-- Are two clitic cases syncretic for a given person/number combination?
     DERIVED from the paradigm data. -/
-def isSyncretic (p : Person) (n : Number) (c1 c2 : CliticCase) : Bool :=
+def isSyncretic (p : Person) (n : UD.Number) (c1 c2 : CliticCase) : Bool :=
   match lookupForm p n c1, lookupForm p n c2 with
   | some f1, some f2 => f1 == f2
   | _, _ => false
 
 /-- DAT/REFL syncretism for a given person/number. -/
-def datReflSyncretic (p : Person) (n : Number) : Bool :=
+def datReflSyncretic (p : Person) (n : UD.Number) : Bool :=
   isSyncretic p n .dative .reflexive
 
 -- ============================================================================

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -1,6 +1,7 @@
 import Linglib.Syntax.Pronoun.Basic
 import Linglib.Syntax.Pronoun.Capabilities
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 import Linglib.Features.Person
 
 /-! # Italian Pronoun and Clitic Fragment
@@ -104,6 +105,9 @@ structure CliticEntry where
   number : UD.Number
   case_ : CliticCase
   deriving Repr, BEq
+
+/-- A clitic bears its φ-slot's number (`HasNumber`). -/
+instance : HasNumber CliticEntry := ⟨fun c => Number.fromUD c.number⟩
 
 /-! ### Clitics as capability carriers (`Proform` / `Bound`)
 

--- a/Linglib/Fragments/Jarawara/PossessedNouns.lean
+++ b/Linglib/Fragments/Jarawara/PossessedNouns.lean
@@ -2,7 +2,6 @@ import Linglib.Morphology.DM.NominalStructure
 import Linglib.Typology.Possession
 import Linglib.Data.UD.Basic
 import Linglib.Features.Gender
-import Linglib.Features.Number
 
 /-!
 # Jarawara Possessed Nouns [adamson-2024] [dixon-2004]
@@ -28,7 +27,6 @@ The iPossessable class maps onto the upper portion of the
 cross-linguistic inalienability hierarchy from `Possession.Typology`.
 -/
 
-open Features (Number)
 
 namespace Jarawara
 
@@ -161,7 +159,7 @@ def PossGender.toSurfaceGender : PossGender → Features.SurfaceGender
     for first person plural. -/
 structure Possessor where
   person : Person
-  number : Number
+  number : UD.Number
   gender : Option PossGender := none  -- only for 3rd person
   deriving DecidableEq, Repr
 

--- a/Linglib/Fragments/Jarawara/PossessedNouns.lean
+++ b/Linglib/Fragments/Jarawara/PossessedNouns.lean
@@ -1,6 +1,7 @@
 import Linglib.Morphology.DM.NominalStructure
 import Linglib.Typology.Possession
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 import Linglib.Features.Gender
 
 /-!
@@ -162,6 +163,9 @@ structure Possessor where
   number : UD.Number
   gender : Option PossGender := none  -- only for 3rd person
   deriving DecidableEq, Repr
+
+/-- A possessor bears its φ-number (`HasNumber`). -/
+instance : HasNumber Possessor := ⟨fun p => Number.fromUD p.number⟩
 
 /-- Possessed noun form: "masculine" (mano) or "feminine" (mani).
     These labels follow [dixon-2004]'s terminology; they reflect

--- a/Linglib/Fragments/Kawapanan/Shawi/Basic.lean
+++ b/Linglib/Fragments/Kawapanan/Shawi/Basic.lean
@@ -1,3 +1,4 @@
+import Linglib.Features.Number.Capabilities
 import Linglib.Features.Case
 import Linglib.Features.Case
 import Linglib.Features.Prominence
@@ -56,6 +57,11 @@ inductive Number where
   | aug   -- augmented (≈ plural)
   deriving DecidableEq, Repr
 
+/-- Shawi's minimal/augmented values in the canonical inventory. -/
+def Number.toNumber : Number → _root_.Number
+  | .min => .minimal
+  | .aug => .augmented
+
 /-- Inclusivity dimension orthogonal to PersonLevel; only relevant for
     1st person (1INCL vs 1EXCL). -/
 inductive Clusivity where
@@ -71,6 +77,9 @@ structure Phi where
   clusivity : Clusivity
   number    : Number
   deriving DecidableEq, Repr
+
+/-- A Shawi φ-bundle bears its min/aug value canonically (`HasNumber`). -/
+instance : HasNumber Phi := ⟨fun φ => some φ.number.toNumber⟩
 
 -- ============================================================================
 -- § 2: Subject agreement (Table 1, indicative)

--- a/Linglib/Fragments/Kawapanan/Shawi/Basic.lean
+++ b/Linglib/Fragments/Kawapanan/Shawi/Basic.lean
@@ -1,7 +1,6 @@
 import Linglib.Features.Case
 import Linglib.Features.Case
 import Linglib.Features.Prominence
-import Linglib.Features.Number
 import Linglib.Features.Person
 
 /-!
@@ -38,7 +37,7 @@ of ergative distribution to a particular Agree configuration — lives in
 `Studies/ClemDeal2024.lean`.
 -/
 
-open Features (Number Person)
+open Features (Person)
 
 namespace Kawapanan.Shawi
 

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -3,7 +3,6 @@ import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 import Linglib.Typology.Extraction
-import Linglib.Features.Number
 
 /-!
 # K'iche' Agreement Fragment [mondloch-2017]
@@ -71,7 +70,6 @@ formal. The formal forms (laal SG, alaq PL) are syntactically
 postverbal and do not participate in the prefix paradigm.
 -/
 
-open Features (Number)
 
 namespace Kiche
 
@@ -91,12 +89,12 @@ inductive Formality where
     Formality is K'iche'-specific. -/
 structure PhiFeatures where
   person : Features.Prominence.PersonLevel
-  number : Number
+  number : UD.Number
   formality : Formality
   deriving DecidableEq, Repr
 
 /-- Shorthand for informal phi features. -/
-abbrev phi (p : Features.Prominence.PersonLevel) (n : Number) : PhiFeatures :=
+abbrev phi (p : Features.Prominence.PersonLevel) (n : UD.Number) : PhiFeatures :=
   ⟨p, n, .informal⟩
 
 -- ============================================================================

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -1,5 +1,6 @@
 import Linglib.Features.Case
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 import Linglib.Typology.Extraction
@@ -92,6 +93,9 @@ structure PhiFeatures where
   number : UD.Number
   formality : Formality
   deriving DecidableEq, Repr
+
+/-- A K'iche' φ-bundle bears its number slot (`HasNumber`). -/
+instance : HasNumber PhiFeatures := ⟨fun φ => Number.fromUD φ.number⟩
 
 /-- Shorthand for informal phi features. -/
 abbrev phi (p : Features.Prominence.PersonLevel) (n : UD.Number) : PhiFeatures :=

--- a/Linglib/Fragments/Mayan/Mam/Pronouns.lean
+++ b/Linglib/Fragments/Mayan/Mam/Pronouns.lean
@@ -106,7 +106,7 @@ def PronCell.person : PronCell → Features.Person
   | .thirdSg | .thirdPl => .third
 
 /-- PronCell number, in the API's vocabulary. -/
-def PronCell.number : PronCell → Features.Number
+def PronCell.number : PronCell → UD.Number
   | .firstSg | .secondSg | .thirdSg => .Sing
   | _ => .Plur
 

--- a/Linglib/Fragments/NezPerce/ClausalEmbedding.lean
+++ b/Linglib/Fragments/NezPerce/ClausalEmbedding.lean
@@ -1,5 +1,6 @@
 import Linglib.Typology.Complementation
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 
 /-!
 # Nez Perce Clausal Embedding Inventory
@@ -293,6 +294,9 @@ structure RelativePronoun where
   number : UD.Number
   forms : List String  -- multiple if idiolectal variation
   deriving Repr
+
+/-- A relative pronoun bears its number slot (`HasNumber`). -/
+instance : HasNumber RelativePronoun := ⟨fun rp => Number.fromUD rp.number⟩
 
 def rp_nom_sg : RelativePronoun := ⟨.Nom, .Sing, ["yox̂"]⟩
 def rp_nom_pl : RelativePronoun := ⟨.Nom, .Plur, ["yox̂me"]⟩

--- a/Linglib/Fragments/Nungon/MedialVerbs.lean
+++ b/Linglib/Fragments/Nungon/MedialVerbs.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 
 /-!
 # Nungon Medial Verb Morphology [sarvasy-2017]
@@ -73,6 +74,9 @@ structure PersonNumber where
   person : UD.Person
   number : UD.Number
   deriving DecidableEq, Repr
+
+/-- A person/number index bears its number slot (`HasNumber`). -/
+instance : HasNumber PersonNumber := ⟨fun pn => Number.fromUD pn.number⟩
 
 /-- A DS suffix entry: form + person/number it indexes. -/
 structure DSSuffix where

--- a/Linglib/Fragments/Spanish/Clitics.lean
+++ b/Linglib/Fragments/Spanish/Clitics.lean
@@ -1,5 +1,4 @@
 import Linglib.Data.UD.Basic
-import Linglib.Features.Number
 import Linglib.Features.Person
 
 /-!
@@ -23,7 +22,7 @@ This syncretism drives the availability of stylistic applicatives.
 
 -/
 
-open Features (Number Person)
+open Features (Person)
 
 namespace Spanish.Clitics
 
@@ -46,7 +45,7 @@ inductive CliticCase where
 structure CliticEntry where
   form : String
   person : Person
-  number : Number
+  number : UD.Number
   case_ : CliticCase
   deriving Repr, BEq
 
@@ -94,20 +93,20 @@ def paradigm : List CliticEntry :=
     los, las, les_dat, se_refl_pl ]
 
 /-- Look up the form for a given person, number, and case in the paradigm. -/
-def lookupForm (p : Person) (n : Number) (c : CliticCase) : Option String :=
+def lookupForm (p : Person) (n : UD.Number) (c : CliticCase) : Option String :=
   (paradigm.find? (fun e => e.person == p && e.number == n && e.case_ == c)).map (·.form)
 
 /-- Are two clitic cases syncretic for a given person/number combination?
     DERIVED from the paradigm data: syncretism holds iff the looked-up
     forms are identical (and both exist). -/
-def isSyncretic (p : Person) (n : Number) (c1 c2 : CliticCase) : Bool :=
+def isSyncretic (p : Person) (n : UD.Number) (c1 c2 : CliticCase) : Bool :=
   match lookupForm p n c1, lookupForm p n c2 with
   | some f1, some f2 => f1 == f2
   | _, _ => false
 
 /-- The set of person/number combinations where DAT and REFL are syncretic.
     This is the key condition for SE-optionality. -/
-def datReflSyncretic (p : Person) (n : Number) : Bool :=
+def datReflSyncretic (p : Person) (n : UD.Number) : Bool :=
   isSyncretic p n .dative .reflexive
 
 -- ============================================================================

--- a/Linglib/Fragments/Spanish/Clitics.lean
+++ b/Linglib/Fragments/Spanish/Clitics.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 import Linglib.Features.Person
 
 /-!
@@ -48,6 +49,9 @@ structure CliticEntry where
   number : UD.Number
   case_ : CliticCase
   deriving Repr, BEq
+
+/-- A clitic bears its φ-slot's number (`HasNumber`). -/
+instance : HasNumber CliticEntry := ⟨fun c => Number.fromUD c.number⟩
 
 -- ============================================================================
 -- § 3: Paradigm Data

--- a/Linglib/Fragments/Swahili/Relativization.lean
+++ b/Linglib/Fragments/Swahili/Relativization.lean
@@ -1,3 +1,4 @@
+import Linglib.Features.Number.Basic
 import Linglib.Typology.RelativeClause.Basic
 import Linglib.Typology.RelativeClause.WALS
 import Linglib.Fragments.Swahili.Basic
@@ -126,6 +127,11 @@ inductive RelPerson where | first | second | third
 /-- Number feature in the Swahili relativization paradigm. -/
 inductive RelGramNum where | sg | pl
   deriving DecidableEq, Repr
+
+/-- The relativization paradigm's number dimension, canonically. -/
+def RelGramNum.toNumber : RelGramNum → Number
+  | .sg => .singular
+  | .pl => .plural
 
 /-- Full pronoun form. -/
 def fullPronoun : RelPerson → RelGramNum → String

--- a/Linglib/Fragments/Turkish/Possession.lean
+++ b/Linglib/Fragments/Turkish/Possession.lean
@@ -1,3 +1,4 @@
+import Linglib.Features.Number.Basic
 import Linglib.Typology.Possession
 
 /-!
@@ -57,6 +58,11 @@ inductive PossPerson where
 inductive PossNumber where
   | sg | pl
   deriving DecidableEq, Repr
+
+/-- The possessive paradigm's number dimension, canonically. -/
+def PossNumber.toNumber : PossNumber → Number
+  | .sg => .singular
+  | .pl => .plural
 
 /-- Possessive suffix forms (after consonant-final stems). -/
 def possSuffix : PossPerson → PossNumber → String

--- a/Linglib/Morphology/Word.lean
+++ b/Linglib/Morphology/Word.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 
 /-!
 # Word — the morphosyntactic word (ms-word) token
@@ -84,6 +85,21 @@ theorem Word.Agree.not_transitive :
        ⟨"he", .PRON, { person := some .third, number := some .Sing, gender := some .Masc }⟩
        (by decide) (by decide))
     (by decide)
+
+/-- A word bears the number its UD morphology ingests (`Number.fromUD`). -/
+instance : HasNumber Word := ⟨fun w => w.features.number.bind Number.fromUD⟩
+
+/-- The φ-projection preserves `numberOf`: a word and its `phi` bundle bear
+    the same number — the defeq `Word.Agree.hasNumber_compatible` relies on. -/
+@[simp] theorem Word.numberOf_phi (w : Word) :
+    HasNumber.numberOf w.phi = HasNumber.numberOf w := rfl
+
+/-- φ-agreement entails number compatibility: the `HasNumber` mixin never
+    diverges from the agreement engine on `Word`. -/
+theorem Word.Agree.hasNumber_compatible {w1 w2 : Word} (h : w1.Agree w2) :
+    HasNumber.Compatible w1 w2 :=
+  fun na ha nb hb =>
+    UD.MorphFeatures.compatible_hasNumber (f1 := w1.phi) (f2 := w2.phi) h na ha nb hb
 
 -- `reflex` is deliberately not an agreement feature: a reflexive-marked token still
 -- agrees with an unmarked one (the φ-projection drops it).

--- a/Linglib/Phenomena/Plurals/VerbalNumber.lean
+++ b/Linglib/Phenomena/Plurals/VerbalNumber.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Number
+import Linglib.Features.Number.Basic
 import Linglib.Data.WALS.Features.F80A
 
 /-!
@@ -26,7 +26,6 @@ languages. 159 have no verbal number; 34 have singular-plural pairs
 
 namespace VerbalNumber
 
-open Features.Number (Category)
 
 -- ============================================================================
 -- § 1: Verbal Number Types
@@ -51,7 +50,7 @@ structure VerbalNumberProfile where
   /-- Whether the language uses suppletion (distinct stems for sg/pl). -/
   hasSuppletion : Bool
   /-- Number values distinguished on the verb. -/
-  verbValues : List Category
+  verbValues : List Number
   deriving BEq
 
 -- ============================================================================

--- a/Linglib/Semantics/Presupposition/PhiFeatures.lean
+++ b/Linglib/Semantics/Presupposition/PhiFeatures.lean
@@ -1,6 +1,6 @@
 import Linglib.Core.Mereology
 import Linglib.Features.ContainmentPair
-import Linglib.Features.Number
+import Linglib.Features.Number.Decomposition
 import Linglib.Features.Person
 import Linglib.Features.Gender
 import Linglib.Semantics.Presupposition.Basic
@@ -146,21 +146,21 @@ def dualSem {E : Type*} (minimalP : E → Prop) : PrProp E where
 @[simp] theorem plSem_eq_phiPresup {E : Type*} (innerP outerP : E → Prop) :
     phiPresup innerP outerP .minimal = plSem E := rfl
 
--- ── Bridge to Features.Number ─────
+-- ── Bridge to Number ─────
 
 /-- Singular features map to the maximal `ContainmentPair` cell (specLevel 2). -/
 @[simp] theorem sg_is_maximal_cell :
-    ContainmentPairLike.toPair Features.Number.singularF = .maximal := rfl
+    ContainmentPairLike.toPair Number.singularF = .maximal := rfl
 
 /-- Plural features map to the minimal cell (specLevel 0). -/
 @[simp] theorem pl_is_minimal_cell :
-    ContainmentPairLike.toPair Features.Number.pluralF = .minimal := rfl
+    ContainmentPairLike.toPair Number.pluralF = .minimal := rfl
 
 /-- The presuppositional asymmetry tracks specification level:
     singular (specLevel 2) has content; plural (specLevel 0) is vacuous. -/
 theorem presup_strength_tracks_specLevel :
-    ContainmentPairLike.specLevel Features.Number.singularF >
-    ContainmentPairLike.specLevel Features.Number.pluralF := by decide
+    ContainmentPairLike.specLevel Number.singularF >
+    ContainmentPairLike.specLevel Number.pluralF := by decide
 
 -- ============================================================================
 -- §3  Person Presuppositions
@@ -233,11 +233,11 @@ theorem person_nesting_from_phi (speaker addressee : E)
     not a per-domain coincidence. -/
 theorem person_number_isomorphism :
     ContainmentPairLike.specLevel Features.Person.firstF =
-      ContainmentPairLike.specLevel Features.Number.singularF ∧
+      ContainmentPairLike.specLevel Number.singularF ∧
     ContainmentPairLike.specLevel Features.Person.secondF =
-      ContainmentPairLike.specLevel Features.Number.dualF ∧
+      ContainmentPairLike.specLevel Number.dualF ∧
     ContainmentPairLike.specLevel Features.Person.thirdF =
-      ContainmentPairLike.specLevel Features.Number.pluralF :=
+      ContainmentPairLike.specLevel Number.pluralF :=
   ⟨rfl, rfl, rfl⟩
 
 end PersonPresuppositions
@@ -340,7 +340,7 @@ theorem gender_person_number_isomorphism :
     ContainmentPairLike.specLevel Features.Gender.neuterF =
       ContainmentPairLike.specLevel Features.Person.firstF ∧
     ContainmentPairLike.specLevel Features.Gender.neuterF =
-      ContainmentPairLike.specLevel Features.Number.singularF ∧
+      ContainmentPairLike.specLevel Number.singularF ∧
     ContainmentPairLike.specLevel Features.Gender.feminineF =
       ContainmentPairLike.specLevel Features.Person.secondF ∧
     ContainmentPairLike.specLevel Features.Gender.masculineF =

--- a/Linglib/Semantics/Quantification/Lexicon.lean
+++ b/Linglib/Semantics/Quantification/Lexicon.lean
@@ -1,5 +1,4 @@
 import Linglib.Data.UD.Basic
-import Linglib.Features.Number
 import Linglib.Morphology.Word
 
 /-!
@@ -25,7 +24,6 @@ in the study files that commit to specific values.
   weak determiners pass `there is/are`)
 -/
 
-open Features (Number)
 
 set_option autoImplicit false
 
@@ -57,7 +55,7 @@ inductive Strength where
 structure QuantifierEntry where
   form : String
   qforce : QForce
-  numberRestriction : Option Number := none
+  numberRestriction : Option UD.Number := none
   allowsMass : Bool := false
   monotonicity : Monotonicity := .increasing
   strength : Strength := .weak

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -33,7 +33,7 @@ and deictic uses (his §2.1.1); binding is the external β-operator
 
 Number values beyond singular/plural (dual, trial, …) and the non-sex-based
 surface genders contribute the vacuous cell here; the principled route is the
-`Features.Number.Category.fromUD`/`Features.Gender.Features.fromSurfaceGender`
+`Number.fromUD`/`Features.Gender.Features.fromSurfaceGender`
 bridges plus `ContainmentPairLike.toPair`, deferred until a study needs them.
 -/
 

--- a/Linglib/Studies/AlonsoOvalleMoghiseh2025b.lean
+++ b/Linglib/Studies/AlonsoOvalleMoghiseh2025b.lean
@@ -72,7 +72,7 @@ def allEntities : List Entity := [.t1, .t2, .t12]
 def allWorlds : List World := [.w1, .w2, .w12]
 
 /-- Mereological atom predicate. Corresponds to `[+atomic]` in
-    [harbour-2014] (`Features.Number`) and `Mereology.Atom`. -/
+    [harbour-2014] (`Number.Features`) and `Mereology.Atom`. -/
 def isAtom : Entity → Prop
   | .t1 | .t2 => True
   | .t12 => False
@@ -501,7 +501,7 @@ theorem full_paradigm :
 -- ============================================================================
 
 /-- CI domain = atom filter of all entities. Connects SING (eq. 42) to
-    `Features.Number.Category.singular` ([+atomic]). -/
+    `Number.singular` ([+atomic]). -/
 theorem ciDomain_is_atoms : ciDomain = allEntities.filter (fun e => decide (isAtom e)) := rfl
 
 /-- The Farsi/English SCI divergence in one theorem.

--- a/Linglib/Studies/Corbett2000.lean
+++ b/Linglib/Studies/Corbett2000.lean
@@ -1,7 +1,7 @@
 import Linglib.Fragments.English.Plurals
 import Linglib.Fragments.Japanese.Plurals
 import Linglib.Syntax.Minimalist.Agreement.CoordinateResolution
-import Linglib.Features.Number
+import Linglib.Features.Number.Resolve
 import Linglib.Syntax.Agreement.Basic
 import Linglib.Semantics.Kinds.NominalMappingParameter
 
@@ -53,79 +53,56 @@ Formalizes the core typological framework from:
 
 namespace Corbett2000
 
--- Number categories, predicates, and UD bridges are in `Features/Number.lean`.
--- We alias `NumberValue` here for backward compatibility within this file.
-open Features.Number
-
-abbrev NumberValue := Category
+-- The number value space, `Number.System`, `Number.Stage`, and the
+-- implicational universals live in `Features/Number/Basic.lean`;
+-- resolution in `Features/Number/Resolve.lean`. This file records the
+-- book's language data and predictions over that substrate.
 
 /-! ### Number Systems (Ch 2, §2.3) -/
-
-/-- A number system specifies the values available in a language,
-    which are obligatory vs facultative, and whether general number exists. -/
-structure NumberSystem where
-  name : String
-  /-- Values available within the number system -/
-  values : List NumberValue
-  /-- Whether the language has general number (a form outside the system) -/
-  hasGeneral : Bool := false
-  /-- Values whose use is optional (facultative) -/
-  facultative : List NumberValue := []
-  deriving DecidableEq
-
-/-- Number of values in the system. -/
-def NumberSystem.size (ns : NumberSystem) : Nat := ns.values.length
-
-/-- Whether a value is obligatory (present and not facultative). -/
-def NumberSystem.IsObligatory (ns : NumberSystem) (v : NumberValue) : Prop :=
-  v ∈ ns.values ∧ v ∉ ns.facultative
-
-instance (ns : NumberSystem) (v : NumberValue) : Decidable (ns.IsObligatory v) := by
-  unfold NumberSystem.IsObligatory; infer_instance
 
 -- Language number systems
 
 /-- English: obligatory sg–pl, no general number. -/
-def englishNS : NumberSystem :=
+def englishNS : Number.System :=
   { name := "English", values := [.singular, .plural] }
 
 /-- Russian: obligatory sg–pl, no general number. -/
-def russianNS : NumberSystem :=
+def russianNS : Number.System :=
   { name := "Russian", values := [.singular, .plural] }
 
 /-- Upper Sorbian: sg–dual–pl, all obligatory. -/
-def upperSorbianNS : NumberSystem :=
+def upperSorbianNS : Number.System :=
   { name := "Upper Sorbian", values := [.singular, .dual, .plural] }
 
 /-- Bayso (Cushitic): sg–paucal–pl within the system; general form *lúban*
     'lion(s)' exists outside it. Four controller values total. -/
-def baysoNS : NumberSystem :=
+def baysoNS : Number.System :=
   { name := "Bayso"
     values := [.singular, .paucal, .plural]
     hasGeneral := true }
 
 /-- Slovene: sg–dual–pl, but the dual is facultative (plural substitutes). -/
-def sloveneNS : NumberSystem :=
+def sloveneNS : Number.System :=
   { name := "Slovene"
     values := [.singular, .dual, .plural]
     facultative := [.dual] }
 
 /-- Larike (Central Moluccan): sg–dual–trial–pl, dual and trial both
     facultative (plural can substitute for either). -/
-def larikeNS : NumberSystem :=
+def larikeNS : Number.System :=
   { name := "Larike"
     values := [.singular, .dual, .trial, .plural]
     facultative := [.dual, .trial] }
 
 /-- Lihir (Oceanic): sg–dual–trial–paucal–pl, five values — the richest
     well-documented system. -/
-def lihirNS : NumberSystem :=
+def lihirNS : Number.System :=
   { name := "Lihir"
     values := [.singular, .dual, .trial, .paucal, .plural] }
 
 /-- Japanese: sg–pl within the system, but general number exists
     (bare *inu* 'dog(s)' is non-committal). -/
-def japaneseNS : NumberSystem :=
+def japaneseNS : Number.System :=
   { name := "Japanese"
     values := [.singular, .plural]
     hasGeneral := true }
@@ -139,34 +116,34 @@ def japaneseNS : NumberSystem :=
     with the same-complexity plural alternative — see
     `Studies/BaleKhanjian2014.lean`. Korean (Kim 2005)
     and Turkish (Bliss 2004) pattern alike per BK 2014 §2.3 and fn 14. -/
-def westernArmenianNS : NumberSystem :=
+def westernArmenianNS : Number.System :=
   { name := "Western Armenian"
     values := [.singular, .plural]
     hasGeneral := true }
 
 /-- Pirahã (Mura): no number category at all. -/
-def pirahaNS : NumberSystem :=
+def pirahaNS : Number.System :=
   { name := "Pirahã", values := [] }
 
 /-- Winnebago (Siouan): minimal–augmented, two values. {±minimal} only
     ([harbour-2014] Table 3). -/
-def winnebagoNS : NumberSystem :=
+def winnebagoNS : Number.System :=
   { name := "Winnebago", values := [.minimal, .augmented] }
 
 /-- Rembarrnga (Australian): minimal–unit augmented–augmented, three values.
     {±minimal*} — feature recursion on [±minimal] without [±atomic]
     ([harbour-2014] Table 3). -/
-def rembarrnganS : NumberSystem :=
+def rembarrnganS : Number.System :=
   { name := "Rembarrnga"
     values := [.minimal, .unitAugmented, .augmented] }
 
 /-- Mebengokre (Jê): minimal–paucal–plural, three values.
     {±additive, ±minimal} ([harbour-2014] Table 3). -/
-def mebengokreNS : NumberSystem :=
+def mebengokreNS : Number.System :=
   { name := "Mebengokre"
     values := [.minimal, .paucal, .plural] }
 
-def allNumberSystems : List NumberSystem :=
+def allNumberSystems : List Number.System :=
   [englishNS, russianNS, upperSorbianNS, baysoNS, sloveneNS,
    larikeNS, lihirNS, japaneseNS, westernArmenianNS, pirahaNS,
    winnebagoNS, rembarrnganS, mebengokreNS]
@@ -191,42 +168,8 @@ theorem slovene_dual_facultative :
 theorem larike_both_facultative :
     .dual ∈ larikeNS.facultative ∧ .trial ∈ larikeNS.facultative := by decide
 
--- Implicational universals ([greenberg-1963], Corbett §2.3.1)
-
-/-- Trial implies dual: no language has trial without dual. -/
-def NumberSystem.TrialImpliesDual (ns : NumberSystem) : Prop :=
-  .trial ∈ ns.values → .dual ∈ ns.values
-
-/-- Dual implies plural. -/
-def NumberSystem.DualImpliesPlural (ns : NumberSystem) : Prop :=
-  .dual ∈ ns.values → .plural ∈ ns.values
-
-/-- Plural implies singular or minimal ([harbour-2014] Table 1:
-    PL → SG/MIN). Plural requires a "base" category — either singular
-    (from [±atomic]) or minimal (from [±minimal]). -/
-def NumberSystem.PluralImpliesSingularOrMinimal (ns : NumberSystem) : Prop :=
-  .plural ∈ ns.values →
-    .singular ∈ ns.values ∨ .minimal ∈ ns.values ∨ ns.values = []
-
-/-- Augmented implies minimal ([harbour-2014] Table 1: AUG → MIN). -/
-def NumberSystem.AugmentedImpliesMinimal (ns : NumberSystem) : Prop :=
-  .augmented ∈ ns.values → .minimal ∈ ns.values
-
-/-- Unit augmented implies augmented ([harbour-2014] Table 1:
-    U.AUG → AUG). -/
-def NumberSystem.UnitAugImpliesAugmented (ns : NumberSystem) : Prop :=
-  .unitAugmented ∈ ns.values → .augmented ∈ ns.values
-
-instance (ns : NumberSystem) : Decidable ns.TrialImpliesDual := by
-  unfold NumberSystem.TrialImpliesDual; infer_instance
-instance (ns : NumberSystem) : Decidable ns.DualImpliesPlural := by
-  unfold NumberSystem.DualImpliesPlural; infer_instance
-instance (ns : NumberSystem) : Decidable ns.PluralImpliesSingularOrMinimal := by
-  unfold NumberSystem.PluralImpliesSingularOrMinimal; infer_instance
-instance (ns : NumberSystem) : Decidable ns.AugmentedImpliesMinimal := by
-  unfold NumberSystem.AugmentedImpliesMinimal; infer_instance
-instance (ns : NumberSystem) : Decidable ns.UnitAugImpliesAugmented := by
-  unfold NumberSystem.UnitAugImpliesAugmented; infer_instance
+-- Implicational universals ([greenberg-1963], Corbett §2.3.1) — the
+-- predicates live on `Number.System`; here they are checked on the data.
 
 theorem all_trial_implies_dual :
     ∀ ns ∈ allNumberSystems, ns.TrialImpliesDual := by decide
@@ -410,11 +353,11 @@ theorem no_attributive_only_semantic :
     The target system is typically a subset of the controller system. -/
 structure ControllerTargetSystem where
   name : String
-  controllerValues : List NumberValue
-  targetValues : List NumberValue
+  controllerValues : List Number
+  targetValues : List Number
   /-- Number appearing when controller lacks specification (§6.1.2).
       Most languages default to singular; Tsez defaults to plural. -/
-  defaultNumber : NumberValue := .singular
+  defaultNumber : Number := .singular
   deriving DecidableEq
 
 /-- Whether controller and target systems differ in size. -/
@@ -457,11 +400,11 @@ theorem english_no_mismatch : ¬ englishCT.HasMismatch := by decide
 structure IndividuationProfile where
   name : String
   /-- Number values available at each hierarchy position -/
-  valuesAt : AnimacyRank → List NumberValue
+  valuesAt : AnimacyRank → List Number
   /-- Minor number values: restricted to a closed class of nouns (e.g.,
       Hebrew dual for body-part nouns, Maltese dual). Constraints IV–VII
       govern the distribution of minor numbers. -/
-  minorValues : List NumberValue := []
+  minorValues : List Number := []
 
 /-- **Constraint II** (Corbett Ch 4): if trial exists at position X, then dual
     exists at X and at all positions higher on the animacy hierarchy. -/
@@ -535,41 +478,24 @@ inductive ResolutionStrategy where
   | closestConjunct
   deriving DecidableEq, Repr
 
-/-- The result of resolving two number values under semantic resolution.
-
-    Note: this function produces `.trial` for `sg + du` unconditionally.
-    In languages without trial, the result is meaningless — use
-    `semanticResolveIn` for language-sensitive resolution. -/
-def NumberValue.semanticResolve (a b : NumberValue) : NumberValue :=
-  match a, b with
-  | .singular, .singular => .plural  -- 1 + 1 > 1
-  | .singular, .dual     => .trial   -- 1 + 2 = 3 (in languages with trial)
-  | .dual, .singular     => .trial
-  | _, _ => .plural                   -- default: conjunction yields plural
-
-/-- Language-sensitive semantic resolution: if the raw result is not in
-    the language's number system, fall back to plural. -/
-def NumberValue.semanticResolveIn (ns : NumberSystem) (a b : NumberValue) : NumberValue :=
-  let raw := NumberValue.semanticResolve a b
-  if ns.values.contains raw then raw else .plural
-
-/-- Semantic resolution: sg + sg → pl. -/
+/-- Semantic resolution in English ({sg, pl}): sg + sg → pl — the
+    lattice-canonical dual coarsens to plural (`Number.System.resolve`,
+    `Features/Number/Resolve.lean`). -/
 theorem sg_sg_resolves_pl :
-    NumberValue.semanticResolve .singular .singular = .plural := rfl
+    englishNS.resolve .singular .singular = .plural := by decide
 
-/-- Semantic resolution: sg + du → tri (in languages with trial). -/
-theorem sg_du_resolves_tri :
-    NumberValue.semanticResolve .singular .dual = .trial := rfl
+/-- In Upper Sorbian (which has dual), sg + sg resolves to dual: the
+    lattice-canonical result survives uncoarsened ([corbett-2000] §6.3). -/
+theorem sg_sg_resolves_du_with_dual :
+    upperSorbianNS.resolve .singular .singular = .dual := by decide
 
 /-- In languages without trial, sg + du resolves to pl. -/
 theorem sg_du_resolves_pl_without_trial :
-    NumberValue.semanticResolveIn englishNS .singular .dual = .plural := by
-  decide
+    englishNS.resolve .singular .dual = .plural := by decide
 
 /-- In Larike (which has trial), sg + du keeps trial. -/
 theorem sg_du_resolves_tri_with_trial :
-    NumberValue.semanticResolveIn larikeNS .singular .dual = .trial := by
-  decide
+    larikeNS.resolve .singular .dual = .trial := by decide
 
 /-! ### Bridges to AnimacyRank, Fragment plurality profiles -/
 
@@ -582,7 +508,7 @@ theorem animacy_rank_ordering_consistent :
     AnimacyRank.higherAnimal.toNat > AnimacyRank.discreteInanimate.toNat := by
   decide
 
-/-- Bridge: English `NumberSystem` matches the English plurality profile in
+/-- Bridge: English `Number.System` matches the English plurality profile in
     `English.Plurals` — both record a 2-value obligatory system. -/
 theorem english_matches_plurals_typology :
     englishNS.size = 2 ∧
@@ -608,38 +534,23 @@ theorem bayso_general_with_system :
     baysoNS.size = 3 := by
   decide
 
-/-! ### Bridge to Cysouw NumberStage (Features.Number) -/
+/-! ### Bridge to Cysouw `Number.Stage` -/
 
-open Features.Number (NumberStage)
-
-/-- Map a Corbett NumberSystem to Cysouw's NumberStage hierarchy by
-    counting the number of non-general values in the system.
-    - 0–1 values → N1 (undifferentiated)
-    - 2 values → N2 (basic sg/pl opposition)
-    - 3 values (has dual or paucal) → N3
-    - 4+ values → N4 -/
-def NumberSystem.toNumberStage (ns : NumberSystem) : NumberStage :=
-  match ns.size with
-  | 0 | 1 => .N1
-  | 2 => .N2
-  | 3 => .N3
-  | _ => .N4
-
-theorem piraha_N1 : pirahaNS.toNumberStage = .N1 := by decide
-theorem english_N2 : englishNS.toNumberStage = .N2 := by decide
-theorem russian_N2 : russianNS.toNumberStage = .N2 := by decide
-theorem japanese_N2 : japaneseNS.toNumberStage = .N2 := by decide
-theorem upperSorbian_N3 : upperSorbianNS.toNumberStage = .N3 := by decide
-theorem larike_N4 : larikeNS.toNumberStage = .N4 := by decide
+theorem piraha_N1 : pirahaNS.toStage = .N1 := by decide
+theorem english_N2 : englishNS.toStage = .N2 := by decide
+theorem russian_N2 : russianNS.toStage = .N2 := by decide
+theorem japanese_N2 : japaneseNS.toStage = .N2 := by decide
+theorem upperSorbian_N3 : upperSorbianNS.toStage = .N3 := by decide
+theorem larike_N4 : larikeNS.toStage = .N4 := by decide
 
 /-- Corbett's implicational hierarchy (trial → dual → plural → singular) is
     consistent with Cysouw's N-stages: a system at stage Nₖ has exactly k
     number oppositions, matching `size` = k for k ≤ 4. -/
 theorem numberStage_consistent_with_size :
-    pirahaNS.size = 0 ∧ pirahaNS.toNumberStage = .N1 ∧
-    englishNS.size = 2 ∧ englishNS.toNumberStage = .N2 ∧
-    upperSorbianNS.size = 3 ∧ upperSorbianNS.toNumberStage = .N3 ∧
-    larikeNS.size = 4 ∧ larikeNS.toNumberStage = .N4 := by
+    pirahaNS.size = 0 ∧ pirahaNS.toStage = .N1 ∧
+    englishNS.size = 2 ∧ englishNS.toStage = .N2 ∧
+    upperSorbianNS.size = 3 ∧ upperSorbianNS.toStage = .N3 ∧
+    larikeNS.size = 4 ∧ larikeNS.toStage = .N4 := by
   decide
 
 /-! ### Bridge to Chierchia (1998) Nominal Mapping Parameter -/
@@ -692,23 +603,6 @@ instance : DecidablePred PluralInterpretation.IncludesSingleton :=
 /-- The compositional (pre-pragmatic) interpretation is always inclusive. -/
 theorem compositional_plural_is_inclusive :
     PluralInterpretation.inclusive.IncludesSingleton := trivial
-
-/-! ### Bridge to Unified Coordinate Resolution -/
-
-open Minimalist.Agreement.CoordinateResolution
-
-/-- Corbett's `semanticResolveIn` agrees with the lattice-grounded
-    `numberResolveIn` for any system containing `.plural`.
-
-    `numberResolveIn` computes the canonical lattice join (sg+sg→du)
-    then coarsens to the target system. `semanticResolveIn` computes
-    semantic summation (sg+sg→pl) then coarsens. For {sg,pl} systems,
-    these agree because the coarsening step absorbs the difference
-    (du→pl = pl→pl). -/
-theorem numberResolveIn_eq_semanticResolveIn (a b : NumberValue) :
-    numberResolveIn englishNS.values a b
-    = some (NumberValue.semanticResolveIn englishNS a b) := by
-  cases a <;> cases b <;> decide
 
 /-! ### Minor Number Constraints IV–VII (Ch 4) -/
 
@@ -834,7 +728,7 @@ theorem associative_requires_human :
       p.minAnimacy.toNat ≥ AnimacyRank.human.toNat := by decide
 
 /-- Bridge: Japanese has both associative plural (here) and general number
-    (from the NumberSystem), reflecting the interaction between the two. -/
+    (from the Number.System), reflecting the interaction between the two. -/
 theorem japanese_associative_with_general :
     japaneseNS.hasGeneral = true ∧
     japaneseAssoc.sameAsAdditive = false := by
@@ -855,9 +749,9 @@ structure CountMassNumberInteraction where
   /-- Does the language allow mass nouns to inflect for number? -/
   massNounsInflect : Bool
   /-- Number system for count nouns -/
-  countSystem : NumberSystem
+  countSystem : Number.System
   /-- Number system for mass nouns (often smaller or empty) -/
-  massSystem : NumberSystem
+  massSystem : Number.System
   deriving DecidableEq
 
 /-- English: count nouns inflect obligatorily, mass nouns do not

--- a/Linglib/Studies/Cysouw2009.lean
+++ b/Linglib/Studies/Cysouw2009.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Person
-import Linglib.Features.Number
+import Linglib.Features.Number.Basic
 import Linglib.Fragments.Finnish.Negation
 
 /-!
@@ -627,14 +627,13 @@ theorem independent_more_explicit :
 -- §16: Number Opposition Hierarchy (Fig 10.8)
 -- ============================================================================
 
-/-! `NumberStage` (Cysouw Fig 10.8) lives in `Features/Number.lean` —
+/-! `Number.Stage` (Cysouw Fig 10.8) lives in `Features/Number/Basic.lean` —
     promoted to substrate because both [cysouw-2009] and
     [corbett-2000] consume it. -/
 
-open Features.Number (NumberStage)
 
 /-- Classify a paradigm's number stage by checking singular/group opposition. -/
-def ParadigmaticStructure.numberStage (s : ParadigmaticStructure) : NumberStage :=
+def ParadigmaticStructure.numberStage (s : ParadigmaticStructure) : Number.Stage :=
   -- Check if there's any singular ≠ group distinction at all
   let hasSgGrpOpposition := Category.all.filter (decide ·.IsSingular) |>.any λ sg =>
     Category.all.filter (decide ·.IsGroup) |>.any λ grp =>
@@ -678,7 +677,7 @@ theorem piraha_P1 : piraha.personStage = .P1 := by decide
 /-- Position in Cysouw's cognitive map (Fig 10.6), combining
     the number-of-forms-for-'we' with the paradigm type. -/
 structure CognitiveMapPosition where
-  numberStage : NumberStage
+  numberStage : Number.Stage
   personStage : PersonStage
   singularType : SingularType
   firstPersonComplexType : FirstPersonComplexType

--- a/Linglib/Studies/Harbour2016.lean
+++ b/Linglib/Studies/Harbour2016.lean
@@ -3,7 +3,7 @@ import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Finset.NAry
 import Mathlib.Data.Finset.Lattice.Fold
 import Linglib.Features.Person
-import Linglib.Features.Number
+import Linglib.Features.Number.Decomposition
 import Linglib.Syntax.Minimalist.CyclicAgree
 import Linglib.Syntax.Minimalist.Phi.Recursion
 import Linglib.Syntax.Minimalist.Phi.Lattice
@@ -233,7 +233,7 @@ hierarchy `sg > du > pl` are both the specification ordering `maximal > intermed
 minimal`. -/
 
 open Features (ContainmentPairLike)
-open Features.Number (singularF dualF pluralF)
+open Number (singularF dualF pluralF)
 
 /-- The person hierarchy `1 > 2 > 3` is the specification ordering of `ContainmentPair`
 (maximal > intermediate > minimal), connecting [harbour-2016]'s lattice approach to the
@@ -252,8 +252,8 @@ structural reflection of the phi kernel, not an identification of the categories
 theorem number_hierarchy_is_spec_ordering :
     ContainmentPairLike.specLevel singularF > ContainmentPairLike.specLevel dualF ∧
     ContainmentPairLike.specLevel dualF > ContainmentPairLike.specLevel pluralF :=
-  ContainmentPairLike.specLevel_strict_order Features.Number.singular_is_maximal
-    Features.Number.dual_is_intermediate Features.Number.plural_is_minimal
+  ContainmentPairLike.specLevel_strict_order Number.singular_is_maximal
+    Number.dual_is_intermediate Number.plural_is_minimal
 
 /-! ### Bridge to Cyclic Agree ([bejar-rezac-2009]) -/
 

--- a/Linglib/Studies/JereticEtAl2025.lean
+++ b/Linglib/Studies/JereticEtAl2025.lean
@@ -1,5 +1,5 @@
 import Linglib.Core.CoreConcept
-import Linglib.Features.Number
+import Linglib.Features.Number.Decomposition
 import Linglib.Core.Tree
 import Linglib.Semantics.Quantification.Lexicon
 import Linglib.Semantics.Alternatives.Source
@@ -54,10 +54,10 @@ The prediction is computed via:
 
 ## Connection to linglib infrastructure
 
-- `Features.Number.dualPredOnLattice` is the predicate-modification
+- `Number.dualPredOnLattice` is the predicate-modification
   denotation of DUAL (paper eq 39 / §8 eq 98b), grounded in the
   existing Harbour `dualF = ⟨−atomic, +minimal⟩` and bridged via
-  `Features.Number.dualPredOnLattice_eq_via_features`.
+  `Number.dualPredOnLattice_eq_via_features`.
 - `Alternatives.Indirect.indirectFrom` lifts an indirect alternative
   into an `AlternativeSource`, plugging into the
   `Alternatives.Structural.violatesMP` competition operator.

--- a/Linglib/Studies/Sauerland2003.lean
+++ b/Linglib/Studies/Sauerland2003.lean
@@ -2,7 +2,7 @@ import Linglib.Core.Mereology
 import Linglib.Semantics.Plurality.Algebra
 import Linglib.Semantics.Plurality.Cover
 import Linglib.Features.ContainmentPair
-import Linglib.Features.Number
+import Linglib.Features.Number.Decomposition
 import Linglib.Features.Person
 import Linglib.Features.Gender
 import Linglib.Semantics.Presupposition.Basic
@@ -692,7 +692,7 @@ which proves that all three cross-linguistic honorific strategies
     three cross-linguistic politeness strategies. -/
 theorem politeness_uses_unmarked :
     -- Plural (number)
-    isSemanticUnmarked (ContainmentPairLike.toPair Features.Number.pluralF) = true ∧
+    isSemanticUnmarked (ContainmentPairLike.toPair Number.pluralF) = true ∧
     -- 3rd person
     isSemanticUnmarked (ContainmentPairLike.toPair Features.Person.thirdF) = true ∧
     -- Masculine (gender)
@@ -703,7 +703,7 @@ theorem politeness_uses_unmarked :
     politeness — their presuppositions would impose unwanted
     restrictions on the addressee. -/
 theorem marked_not_polite :
-    isSemanticMarked (ContainmentPairLike.toPair Features.Number.singularF) = true ∧
+    isSemanticMarked (ContainmentPairLike.toPair Number.singularF) = true ∧
     isSemanticMarked (ContainmentPairLike.toPair Features.Person.firstF) = true ∧
     isSemanticMarked (ContainmentPairLike.toPair Features.Gender.neuterF) = true :=
   ⟨rfl, rfl, rfl⟩

--- a/Linglib/Studies/Wang2023.lean
+++ b/Linglib/Studies/Wang2023.lean
@@ -431,7 +431,7 @@ section DomainBridges
     which is `plSem` — the PrProp with vacuous presupposition.
     `pl_is_minimal_cell` (PhiFeatures) proves `pluralF` maps to `.minimal`. -/
 theorem plural_strategy_is_plSem :
-    honStrategyCell .plural = ContainmentPairLike.toPair Features.Number.pluralF :=
+    honStrategyCell .plural = ContainmentPairLike.toPair Number.pluralF :=
   rfl
 
 /-- The 3rd-person strategy targets the minimal PERSON cell,

--- a/Linglib/Syntax/Agreement/Paradigm.lean
+++ b/Linglib/Syntax/Agreement/Paradigm.lean
@@ -1,6 +1,7 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Morphology.Word
+import Linglib.Features.Number.Capabilities
 
 /-!
 # Agreement paradigms — the descriptive realization table
@@ -74,6 +75,10 @@ def Cell.toPersonLevel (c : Cell) : Features.Prominence.PersonLevel :=
 
 /-- Is this a plural cell? -/
 def Cell.isPlural (c : Cell) : Bool := c.number == some .Plur
+
+/-- A cell bears the number its UD slot ingests (`Number.fromUD`); an
+    undistinguished slot leaves the cell unvalued (wildcard). -/
+instance : HasNumber Cell := ⟨fun c => c.number.bind Number.fromUD⟩
 
 /-- The basic 3-person × {singular, plural} inventory of φ-cells — the cells a
     person/number agreement paradigm ranges over. -/

--- a/Linglib/Syntax/Minimalist/Agreement/CoordinateResolution.lean
+++ b/Linglib/Syntax/Minimalist/Agreement/CoordinateResolution.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Number
+import Linglib.Features.Number.Resolve
 import Linglib.Features.Prominence
 import Linglib.Syntax.Minimalist.Agreement.GenderResolution
 import Linglib.Syntax.Minimalist.Phi.Recursion
@@ -32,21 +32,22 @@ resolution can fail (empty intersection → language-specific default).
 
 ## Number resolution — lattice grounding
 
-Number resolution is derived from the join-semilattice of individuals
-([link-1983]) via [harbour-2014]'s feature geometry:
-
-1. `canonicalResolve` computes the finest category from the lattice join
-2. `coarsenTo` maps it to the available categories in a number system
-3. `numberResolveIn` composes the two
+Number resolution is `Number.resolve`/`Number.resolveIn`
+(`Features/Number/Resolve.lean`): the finest value from the lattice join
+([link-1983], [harbour-2014]), coarsened to the available values in the
+target number system. This file wraps it as the number `ResolutionOp` of
+φ-resolution and proves it closed over [harbour-2014] Table 3.
 
 ## Relation to existing modules
 
+- `Features/Number/Resolve.lean`: the canonical resolution operation
+  (`Number.resolve`, `Number.coarsenTo`, `Number.resolveIn`).
 - `Phi/Recursion.lean`: `HarbourConfig.surfaceCategories` provides the
-  set of available number categories. `numberResolveConfig` composes
+  set of available number values. `numberResolveConfig` composes
   canonical resolution with coarsening to a Harbour configuration.
 - `GenderResolution.lean`: compositional endpoint for gender resolution.
-- `Corbett2000.lean`: defines `semanticResolve` (= `canonicalResolve`
-  without the MIN/AUG branch, coarsened inline).
+- `Corbett2000.lean`: states the book's resolution data over its
+  language systems via `Number.System.resolve`.
 - `Carstens2026.lean`: instantiates the Bantu gender system and connects
   all three resolution levels.
 -/
@@ -59,7 +60,6 @@ open Minimalist.Agreement.GenderResolution (AnnotatedFeature)
 
 namespace Minimalist.Agreement.CoordinateResolution
 
-open Features.Number (Category)
 open Features.Prominence (PersonLevel)
 
 -- ============================================================================
@@ -81,194 +81,24 @@ structure ResolutionOp (F : Type) where
 -- § 2: Lattice-Grounded Number Resolution
 -- ============================================================================
 
-/-! ### Lattice-Grounded Number Resolution
+/-! ### Number resolution — wrapping `Number.resolveIn`
 [harbour-2014] [corbett-2000] [link-1983]
 
-Number resolution for conjoined DPs is grounded in the join-semilattice
-of individuals ([link-1983]). The referent of "X and Y" is the
-mereological sum x ⊔ y, and the sum's number category is determined by
-its lattice position ([harbour-2014] §4):
+The referent of "X and Y" is the mereological sum x ⊔ y; its number value
+is `Number.resolve` of the conjuncts' values, coarsened to the language's
+system (`Number.resolveIn`) — see `Features/Number/Resolve.lean` for the
+derivation and the system-dependent predictions (English sg + sg → pl,
+Slovene sg + sg → du, Larike sg + du → trial, Winnebago min + min → aug). -/
 
-- atom ⊔ atom (disjoint) = pair → **dual** ([−atomic, +minimal])
-- atom ⊔ pair (disjoint) = triple → **trial** (minimal in plural region)
-- pair ⊔ pair (disjoint) = 4+ → **greater plural** (non-minimal in plural)
-- anything ⊔ non-minimal non-atom = non-minimal → **plural**
+/-- Number resolution operation for a given number system: `Number.resolveIn`
+    as the (total) number dimension of φ-resolution. -/
+def numberOp (system : List Number) : ResolutionOp Number :=
+  ⟨fun a b => some (Number.resolveIn system a b)⟩
 
-This CANONICAL resolution gives the finest possible category. Languages
-then **coarsen** the result to their available categories:
-
-- In a {sg, pl} system (English): du coarsens to pl → sg + sg → **pl**
-- In a {sg, du, pl} system (Slovene): du is available → sg + sg → **du**
-- In a {sg, du, trial, greaterPl} system: sg + du → **trial**
-
-The coarsening is the formal content of [corbett-2000] §6.3:
-"the result depends on which number values the language has." -/
-
-/-- Canonical number resolution: the finest category for the mereological
-    sum of two referents, **derived** from two lattice-theoretic principles
-    ([harbour-2014]):
-
-    1. **Cardinality addition** (for determinate categories):
-       |A ⊔ B| = |A| + |B| for disjoint referent sets A, B.
-       The sum is mapped back to the finest determinate category via
-       `Category.fromCard`.
-
-       - sg(1) + sg(1) = 2 → du
-       - sg(1) + du(2) = 3 → trial
-       - du(2) + du(2) = 4 → greaterPlural
-
-    2. **MIN/AUG lattice join** (for [±minimal] systems without [±atomic]):
-       In a 2-level lattice {minimal, augmented}, the join of any two
-       distinct elements exceeds the minimal. Since coordination requires
-       disjoint referents, the result is always augmented.
-
-    3. **Catch-all**: Categories without exact cardinality or MIN/AUG
-       membership (plural, paucal, greaterPlural, etc.) resolve to plural
-       — the default non-singular category. -/
-def canonicalResolve (a b : Category) : Category :=
-  match a.exactCard, b.exactCard with
-  | some na, some nb => Category.fromCard (na + nb)
-  | _, _ =>
-    if a.isMinAug ∧ b.isMinAug then .augmented
-    else .plural
-
-/-- Canonical resolution is commutative: x ⊔ y = y ⊔ x. -/
-theorem canonical_comm (a b : Category) :
-    canonicalResolve a b = canonicalResolve b a := by
-  cases a <;> cases b <;> rfl
-
-/-- Coarsen a category to the nearest available one in a number system.
-
-    Categories not present in the system map to their semantic
-    superordinate — the broader category whose referents include
-    the absent category's referents. -/
-def coarsenTo (system : List Category) (c : Category) : Category :=
-  if system.contains c then c else
-  match c with
-  | .dual | .trial | .greaterPlural | .globalPlural =>
-    if system.contains .plural then .plural
-    else if system.contains .augmented then .augmented
-    else c
-  | .unitAugmented =>
-    if system.contains .augmented then .augmented else c
-  | .greaterPaucal =>
-    if system.contains .paucal then .paucal
-    else if system.contains .plural then .plural
-    else c
-  | .paucal =>
-    if system.contains .plural then .plural
-    else if system.contains .augmented then .augmented
-    else c
-  | .augmented =>
-    if system.contains .plural then .plural
-    else c
-  | .plural =>
-    if system.contains .augmented then .augmented
-    else if system.contains .greaterPlural then .greaterPlural
-    else c
-  | _ => c
-
-/-- System-parameterized number resolution: canonical lattice join,
-    coarsened to the available categories in the target system.
-
-    This derives resolution rules from two independent components:
-    1. Lattice join: sg + sg → du (canonical)
-    2. Coarsening: du → pl in a {sg, pl} system -/
-def numberResolveIn (system : List Category)
-    (a b : Category) : Option Category :=
-  some (coarsenTo system (canonicalResolve a b))
-
-/-- Number resolution operation for a given number system. -/
-def numberOp (system : List Category) : ResolutionOp Category :=
-  ⟨numberResolveIn system⟩
-
-/-- `numberResolveIn` with the system from a `HarbourConfig`. -/
+/-- `Number.resolveIn` with the system from a `HarbourConfig`. -/
 def numberResolveConfig (c : Phi.Recursion.HarbourConfig)
-    (a b : Category) : Option Category :=
-  numberResolveIn c.surfaceCategories a b
-
--- § 2b: Powerset Lattice Verification
-
-/-! The canonical resolution is verified against a concrete 3-atom
-    powerset lattice. Atoms: {a}=1, {b}=2, {c}=4. Pairs: {a,b}=3,
-    {a,c}=5, {b,c}=6. Triple: {a,b,c}=7. Join = bitwise OR.
-
-    `Features.Number.latticeToFeatures` classifies elements by lattice
-    position: atoms → singular, minimal non-atoms → dual, non-minimal
-    non-atoms → plural. -/
-
-open Features.Number (bitmaskJoin ps3Domain) in
-
-/-- Atom 1 ⊔ Atom 2 = 3, which is dual (minimal non-atom).
-    Lattice grounding: `canonicalResolve sg sg = du`. -/
-theorem lattice_atom_join_dual :
-    Features.Number.latticeToFeatures bitmaskJoin ps3Domain (bitmaskJoin 1 2) =
-      Features.Number.dualF := by decide
-
-open Features.Number (bitmaskJoin ps3Domain) in
-
-/-- Atom 4 ⊔ Pair 3 = 7, which is plural (non-minimal non-atom).
-    Lattice grounding: `canonicalResolve sg du = trial` (plural in
-    base system, trial with recursion). -/
-theorem lattice_atom_pair_plural :
-    Features.Number.latticeToFeatures bitmaskJoin ps3Domain (bitmaskJoin 4 3) =
-      Features.Number.pluralF := by decide
-
-open Features.Number (bitmaskJoin ps3Domain) in
-
-/-- The derived `canonicalResolve` agrees with the powerset lattice:
-    join in the concrete lattice, then classify via `latticeToFeatures`,
-    matches `canonicalResolve` applied to the classified inputs.
-
-    - atom(1) is singular, atom(2) is singular → join=3 is dual
-    - atom(1) is singular, pair(6) is dual → join=7 is plural (= trial with recursion)
-
-    This is the structural proof that `canonicalResolve` is the lattice join
-    pushed through `latticeToFeatures`, not a stipulation. -/
-theorem lattice_grounding_agrees :
-    -- sg ⊔ sg → du: atom(1) ⊔ atom(2) = pair(3), classified as dual
-    Features.Number.latticeToFeatures bitmaskJoin ps3Domain (bitmaskJoin 1 2)
-      = Features.Number.dualF ∧
-    -- sg ⊔ du → trial/plural: atom(4) ⊔ pair(3) = triple(7), classified as plural
-    -- (plural in the base 3-atom lattice; trial under Harbour's recursion)
-    Features.Number.latticeToFeatures bitmaskJoin ps3Domain (bitmaskJoin 4 3)
-      = Features.Number.pluralF := by
-  decide
-
--- § 2c: System-Dependent Predictions
-
-/-- In a {sg, pl} system (English): sg + sg → pl.
-    Canonical du coarsened to plural. -/
-theorem resolve_sgpl_sg_sg :
-    numberResolveIn [.singular, .plural] .singular .singular =
-      some .plural := rfl
-
-/-- In a {sg, du, pl} system (Slovene): sg + sg → du.
-    Canonical du is available, no coarsening. -/
-theorem resolve_sgdupl_sg_sg :
-    numberResolveIn [.singular, .dual, .plural] .singular .singular =
-      some .dual := rfl
-
-/-- In a {sg, du, pl} system: sg + du → pl (triple = plural without
-    recursion). -/
-theorem resolve_sgdupl_sg_du :
-    numberResolveIn [.singular, .dual, .plural] .singular .dual =
-      some .plural := rfl
-
-/-- In a {sg, du, trial, greaterPl} system (Larike): sg + du → trial. -/
-theorem resolve_larike_sg_du :
-    numberResolveIn [.singular, .dual, .plural, .trial, .greaterPlural]
-      .singular .dual = some .trial := rfl
-
-/-- In a {sg, du, trial, greaterPl} system: sg + sg → du. -/
-theorem resolve_larike_sg_sg :
-    numberResolveIn [.singular, .dual, .plural, .trial, .greaterPlural]
-      .singular .singular = some .dual := rfl
-
-/-- In a {min, aug} system (Winnebago): min + min → aug. -/
-theorem resolve_minAug_min_min :
-    numberResolveIn [.minimal, .augmented] .minimal .minimal =
-      some .augmented := rfl
+    (a b : Number) : Option Number :=
+  some (Number.resolveIn c.surfaceCategories a b)
 
 -- § 2d: Resolution Closure
 
@@ -276,23 +106,23 @@ theorem resolve_minAug_min_min :
 
 Number resolution is **closed** under every well-formed number system
 generated by [harbour-2014]'s feature recursion: for any two
-categories `a, b` in a system `S`, the resolved category
-`coarsenTo S (canonicalResolve a b)` is also in `S`.
+values `a, b` in a system `S`, the resolved value
+`Number.resolveIn S a b` is also in `S`.
 
-This is a non-trivial structural property — `canonicalResolve` can
-produce categories not in the target system (e.g., `du` from `sg + sg`
-in a {sg, pl} system), but `coarsenTo` always maps the result back to
-an available category. The theorem verifies this for all 15 Table 3
-entries (12 distinct configs, covering 2–5 value systems). -/
+This is a non-trivial structural property — `Number.resolve` can
+produce values not in the target system (e.g., `du` from `sg + sg`
+in a {sg, pl} system), but `Number.coarsenTo` always maps the result
+back to an available value. The theorem verifies this for all 15
+Table 3 entries (12 distinct configs, covering 2–5 value systems). -/
 
 /-- Resolution closure: for every Harbour 2014 Table 3 system, resolving
-    any two categories from the system produces a category in the system. -/
+    any two values from the system produces a value in the system. -/
 theorem resolution_closure_table3 :
     Phi.Recursion.harbour2014Table3.all (fun entry =>
       let sys := entry.config.surfaceCategories
       sys.all (fun a =>
         sys.all (fun b =>
-          sys.contains (coarsenTo sys (canonicalResolve a b))
+          sys.contains (Number.resolveIn sys a b)
         ))) = true := by decide
 
 -- ============================================================================
@@ -341,8 +171,8 @@ def resolveAnnotated {F : Type} (op : ResolutionOp F)
 -- ============================================================================
 
 /-- Number resolution always succeeds for any system. -/
-theorem number_total (system : List Category) (a b : Category) :
-    (numberResolveIn system a b).isSome = true := rfl
+theorem number_total (system : List Number) (a b : Number) :
+    ((numberOp system).resolve a b).isSome = true := rfl
 
 /-- Person resolution always succeeds. -/
 theorem person_total (p₁ p₂ : PersonLevel) :
@@ -373,9 +203,9 @@ theorem gender_singleton_iff_match {G : Type} [BEq G] [LawfulBEq G] (g₁ g₂ :
 -- ============================================================================
 
 /-- Number resolution is commutative for any system. -/
-theorem number_comm (system : List Category) (a b : Category) :
-    numberResolveIn system a b = numberResolveIn system b a := by
-  simp only [numberResolveIn, canonical_comm]
+theorem number_comm (system : List Number) (a b : Number) :
+    (numberOp system).resolve a b = (numberOp system).resolve b a := by
+  simp only [numberOp, Number.resolveIn_comm]
 
 /-- Person resolution is commutative (both directions yield max). -/
 theorem person_comm (p₁ p₂ : PersonLevel) :
@@ -390,7 +220,7 @@ theorem person_comm (p₁ p₂ : PersonLevel) :
     successfully, but gender can fail. This explains why default
     agreement is a gender phenomenon, not a number or person one. -/
 theorem gender_only_fallible :
-    (∀ system a b, (numberResolveIn system a b).isSome = true) ∧
+    (∀ system a b, ((numberOp system).resolve a b).isSome = true) ∧
     (∀ p₁ p₂ : PersonLevel, (personResolve p₁ p₂).isSome = true) ∧
     (∃ g₁ g₂ : GenderResolution.FeatureBundle Bool,
       (GenderResolution.resolve g₁ g₂).isSome = false) :=
@@ -403,13 +233,13 @@ theorem gender_only_fallible :
 /-- A phi-feature bundle for a single conjunct DP. -/
 structure PhiBundle (G : Type) where
   person : AnnotatedFeature PersonLevel
-  number : AnnotatedFeature Category
+  number : AnnotatedFeature Number
   gender : GenderResolution.FeatureBundle G
 
 /-- Resolved phi-features for a conjoined DP (&P). -/
 structure PhiResolved (G : Type) where
   person : Option PersonLevel
-  number : Option Category
+  number : Option Number
   gender : Option (List G)
 
 /-- Resolve all phi-features for two conjoined DPs.
@@ -419,7 +249,7 @@ structure PhiResolved (G : Type) where
     - Person: hierarchy (`personOp`)
     - Gender: `GenderResolution.resolve` (percolation + intersection) -/
 def resolveCoordinate {G : Type} [BEq G]
-    (system : List Category) (dp1 dp2 : PhiBundle G) : PhiResolved G :=
+    (system : List Number) (dp1 dp2 : PhiBundle G) : PhiResolved G :=
   { person := resolveAnnotated personOp dp1.person dp2.person
     number := resolveAnnotated (numberOp system) dp1.number dp2.number
     gender := GenderResolution.resolve dp1.gender dp2.gender }

--- a/Linglib/Syntax/Minimalist/Features.lean
+++ b/Linglib/Syntax/Minimalist/Features.lean
@@ -1,7 +1,6 @@
 import Linglib.Features.Case
 import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
-import Linglib.Features.Number
 
 /-!
 # Feature Infrastructure for Minimalist Agree
@@ -47,7 +46,6 @@ for probes.
 
 -/
 
-open Features (Number)
 
 namespace Minimalist
 
@@ -60,7 +58,7 @@ open Features.Prominence
 /-- Phi-features (agreement features). -/
 inductive PhiFeature where
   | person : PersonLevel → PhiFeature
-  | number : Number → PhiFeature      -- grammatical number (UD.Number)
+  | number : UD.Number → PhiFeature      -- grammatical number (UD.Number)
   | gender : Nat → PhiFeature        -- language-specific encoding
   deriving Repr, DecidableEq
 

--- a/Linglib/Syntax/Minimalist/Phi/Recursion.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Recursion.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Number
+import Linglib.Features.Number.Decomposition
 import Linglib.Core.Mereology
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.UpperLower.Basic
@@ -40,11 +40,11 @@ Recursion on **non-singular** (the [−atomic] region, before the base
 
 The implicational universals (trial → dual → plural → singular, etc.) are
 not stipulated — they are a theorem of the feature geometry. The generated
-categories form a **lower set** in the markedness partial order on
-`Category`: if a marked category is generated, all less-marked categories
-it presupposes are also generated (§ 8).
+values form a **lower set** in the markedness partial order on `Number`
+(`Number.instPartialOrder`, `Features/Number/Basic.lean`): if a marked value
+is generated, all less-marked values it presupposes are also generated (§ 8).
 
-This is a lattice-theoretic property: the partial order on categories is
+This is a lattice-theoretic property: the partial order on values is
 the presupposition ordering, and the `IsLowerSet` formulation (Mathlib)
 captures all implicational universals in a single statement.
 
@@ -52,7 +52,7 @@ captures all implicational universals in a single statement.
 
 namespace Minimalist.Phi.Recursion
 
-open Features.Number
+open Number (Features singularF dualF pluralF)
 
 -- ============================================================================
 -- § 1: Recursion Regions
@@ -113,7 +113,7 @@ def unitAugmented : RecursiveNumber := ⟨dualRegion, true⟩
 def augmented : RecursiveNumber := ⟨dualRegion, false⟩
 
 -- ============================================================================
--- § 3: Mapping to Corbett Categories
+-- § 3: Mapping to Corbett Values
 -- ============================================================================
 
 /-- Map recursive features to [corbett-2000]'s number categories.
@@ -121,7 +121,7 @@ def augmented : RecursiveNumber := ⟨dualRegion, false⟩
     Recursion target determines the category:
     - On the plural region ([−atomic, −minimal]): trial / greater plural
     - On the non-singular region ([−atomic, +minimal]): unit augmented / augmented -/
-def RecursiveNumber.toCategory (r : RecursiveNumber) : Category :=
+def RecursiveNumber.toNumber (r : RecursiveNumber) : Number :=
   if r.region.base.isMinimal then
     -- Recursion on the non-singular ([−atomic, +minimal]) region
     if r.isMinimalInRegion then .unitAugmented else .augmented
@@ -129,10 +129,10 @@ def RecursiveNumber.toCategory (r : RecursiveNumber) : Category :=
     -- Recursion on the plural ([−atomic, −minimal]) region
     if r.isMinimalInRegion then .trial else .greaterPlural
 
-theorem trial_toCategory : trial.toCategory = .trial := rfl
-theorem greaterPlural_toCategory : greaterPlural.toCategory = .greaterPlural := rfl
-theorem unitAugmented_toCategory : unitAugmented.toCategory = .unitAugmented := rfl
-theorem augmented_toCategory : augmented.toCategory = .augmented := rfl
+theorem trial_toNumber : trial.toNumber = .trial := rfl
+theorem greaterPlural_toNumber : greaterPlural.toNumber = .greaterPlural := rfl
+theorem unitAugmented_toNumber : unitAugmented.toNumber = .unitAugmented := rfl
+theorem augmented_toNumber : augmented.toNumber = .augmented := rfl
 
 -- ============================================================================
 -- § 4: Impossibility of Singular Recursion
@@ -157,9 +157,9 @@ theorem no_singular_recursion : ¬∃ (r : Region), r.base = singularF := by
 /-- Each recursion yields exactly 2 new categories: the [+minimal] and
     [−minimal] subregions are always distinct. -/
 theorem recursion_yields_two (reg : Region) :
-    (⟨reg, true⟩ : RecursiveNumber).toCategory ≠
-    (⟨reg, false⟩ : RecursiveNumber).toCategory := by
-  simp only [RecursiveNumber.toCategory]
+    (⟨reg, true⟩ : RecursiveNumber).toNumber ≠
+    (⟨reg, false⟩ : RecursiveNumber).toNumber := by
+  simp only [RecursiveNumber.toNumber]
   have := reg.base_nonatomic
   cases ha : reg.base.isAtomic <;> cases hm : reg.base.isMinimal <;> simp_all
 
@@ -177,10 +177,10 @@ theorem unitAug_presupposes_dual : unitAugmented.region.base = dualF := rfl
 theorem recursion_presupposes_base (r : RecursiveNumber) :
     r.region.base.WellFormed := r.region.base_wf
 
-/-- Base categories of recursive numbers map to Corbett categories. -/
+/-- Base regions of recursive numbers map to Corbett values. -/
 theorem recursion_base_categories :
-    trial.region.base.toCategory = some .plural ∧
-    unitAugmented.region.base.toCategory = some .dual := ⟨rfl, rfl⟩
+    trial.region.base.toNumber = some .plural ∧
+    unitAugmented.region.base.toNumber = some .dual := ⟨rfl, rfl⟩
 
 -- ============================================================================
 -- § 6: Only Two Recursion Regions
@@ -198,76 +198,6 @@ theorem only_two_regions (r : Region) : r.base = dualF ∨ r.base = pluralF := b
   · exact Or.inl rfl  -- false, true → dualF
   · simp at hna  -- true, false → contradiction
   · simp at hna  -- true, true → contradiction
-
--- ============================================================================
--- § 7: Markedness Partial Order on Categories
--- ============================================================================
-
-/-! The markedness ordering on number categories, derived from
-    [harbour-2014]'s feature geometry and [corbett-2000]'s
-    implicational hierarchy. `a ≤ b` means b presupposes a: every
-    number system containing b also contains a.
-
-    Three independent branches:
-    ```
-    [±atomic] branch:        trial   greaterPlural
-                               \        /
-                                dual
-                               /    \
-                         singular    plural
-
-    [±minimal] branch:       unitAugmented
-                                  |
-                              augmented
-                                  |
-                               minimal
-
-    Approximative branch:    greaterPaucal    globalPlural
-                                  |               |
-                                paucal          plural
-    ```
-    The [±atomic] branch (singular, dual, trial, greaterPlural) and
-    [±minimal] branch (minimal, augmented, unitAugmented) are INDEPENDENT:
-    singular and minimal never cooccur; they arise from different feature
-    activations. Plural spans both branches: it appears in [±atomic]
-    systems as [−atomic] and in [±additive, ±minimal] systems as [+additive].
-
-    `general` is isolated (incomparable with all in-system categories). -/
-
-/-- The markedness ordering on number categories as a decidable relation. -/
-def markednessLE (a b : Category) : Bool :=
-  a == b || match a, b with
-  -- [±atomic] branch: singular ≤ dual ≤ {trial, greaterPlural}
-  -- plural ≤ dual ≤ {trial, greaterPlural}
-  | .singular, .dual | .singular, .trial | .singular, .greaterPlural => true
-  | .plural, .dual | .plural, .trial | .plural, .greaterPlural => true
-  | .dual, .trial | .dual, .greaterPlural => true
-  -- Approximative branch: plural ≤ paucal ≤ greaterPaucal
-  | .plural, .paucal | .plural, .greaterPaucal => true
-  | .paucal, .greaterPaucal => true
-  -- [±minimal] branch: minimal ≤ augmented ≤ unitAugmented
-  | .minimal, .augmented | .minimal, .unitAugmented => true
-  | .augmented, .unitAugmented => true
-  -- globalPlural: plural ≤ globalPlural
-  | .plural, .globalPlural => true
-  | _, _ => false
-
-instance : LE Category where
-  le a b := markednessLE a b = true
-
-instance : DecidableRel (fun (a b : Category) => a ≤ b) :=
-  fun a b => show Decidable (markednessLE a b = true) from inferInstance
-
-instance : Fintype Category where
-  elems := {.general, .singular, .dual, .trial, .paucal,
-            .plural, .greaterPaucal, .greaterPlural,
-            .minimal, .augmented, .unitAugmented, .globalPlural}
-  complete x := by cases x <;> simp [Finset.mem_insert, Finset.mem_singleton]
-
-instance : PartialOrder Category where
-  le_refl a := by cases a <;> decide
-  le_trans a b c := by cases a <;> cases b <;> cases c <;> decide
-  le_antisymm a b := by cases a <;> cases b <;> decide
 
 -- ============================================================================
 -- § 8: Harbour Configuration Space
@@ -325,7 +255,7 @@ def HarbourConfig.wellFormed (c : HarbourConfig) : Bool :=
     alongside `.trial` and `.greaterPlural` when recursion is active,
     and `.augmented` remains alongside `.paucal` and `.plural`).
     This is required for the lower-set property. -/
-def HarbourConfig.categories (c : HarbourConfig) : List Category :=
+def HarbourConfig.categories (c : HarbourConfig) : List Number :=
   let base :=
     if c.hasAtomic && c.hasMinimal then [.singular, .dual, .plural]
     else if c.hasAtomic then [.singular, .plural]
@@ -371,7 +301,7 @@ def HarbourConfig.categories (c : HarbourConfig) : List Category :=
     a lower set in the markedness partial order: if `b` is generated and
     `a ≤ b`, then `a` is also generated. -/
 theorem categories_lowerSet (c : HarbourConfig) (hw : c.wellFormed = true)
-    (a b : Category) (hab : a ≤ b) (hb : c.categories.contains b = true) :
+    (a b : Number) (hab : a ≤ b) (hb : c.categories.contains b = true) :
     c.categories.contains a = true := by
   obtain ⟨ca, cm, cd, cr, cra⟩ := c
   revert hw hab hb
@@ -380,7 +310,7 @@ theorem categories_lowerSet (c : HarbourConfig) (hw : c.wellFormed = true)
 
 /-- The lower set property stated via Mathlib's `IsLowerSet`. -/
 theorem categories_isLowerSet (c : HarbourConfig) (hw : c.wellFormed = true) :
-    IsLowerSet {cat : Category | c.categories.contains cat = true} :=
+    IsLowerSet {cat : Number | c.categories.contains cat = true} :=
   fun a b hab ha => categories_lowerSet c hw b a hab ha
 
 -- ============================================================================
@@ -533,7 +463,7 @@ Key predictions:
       it into paucal + plural. The surface system is minimal/paucal/plural.
 
     The resulting counts match [harbour-2014] Table 3 exactly. -/
-def HarbourConfig.surfaceCategories (c : HarbourConfig) : List Category :=
+def HarbourConfig.surfaceCategories (c : HarbourConfig) : List Number :=
   let cats := c.categories
   -- Plural is split by [±minimal] recursion when [±atomic] is active
   let removePlural := c.recurseOnPlural && c.hasAtomic

--- a/Linglib/Syntax/Minimalist/SpeechActs.lean
+++ b/Linglib/Syntax/Minimalist/SpeechActs.lean
@@ -8,7 +8,6 @@ import Linglib.Discourse.Intentionality
 import Linglib.Discourse.Commitment.Basic
 import Linglib.Features.Evidentiality
 import Linglib.Fragments.English.Pronouns
-import Linglib.Features.Number
 import Linglib.Features.Person
 
 /-!
@@ -37,7 +36,7 @@ c-commands content.
 
 -/
 
-open Features (Number Person)
+open Features (Person)
 
 namespace Minimalist.SpeechActs
 

--- a/Linglib/Syntax/Pronoun/Basic.lean
+++ b/Linglib/Syntax/Pronoun/Basic.lean
@@ -6,7 +6,6 @@ import Linglib.Features.Prominence
 import Linglib.Features.Gender
 import Linglib.Features.Clusivity
 import Linglib.Features.CoreferenceStatus
-import Linglib.Features.Number
 import Linglib.Features.Person
 import Linglib.Morphology.Word
 
@@ -19,7 +18,7 @@ structure (the morphosyntactic core every pronoun type shares), the
 allocutive markers, and [cardinaletti-starke-1999]'s `Strength` deficiency
 classification.
 
-Cross-categorial features a pronoun carries — `Person`, `Number`, `Gender`,
+Cross-categorial features a pronoun carries — person, number, gender,
 `Case` — are not redefined here; they live under `Features/` and are composed
 in as fields of the general `Pronoun`.
 
@@ -38,7 +37,7 @@ in as fields of the general `Pronoun`.
 * `Pronoun.AllocutiveEntry` — speaker–addressee (allocutive) markers.
 -/
 
-open Features (Number Person)
+open Features (Person)
 
 set_option autoImplicit false
 
@@ -115,7 +114,7 @@ structure Pronoun where
   /-- Grammatical person (UD.Person via Core.Word abbrev). -/
   person : Option Person := none
   /-- Grammatical number. -/
-  number : Option Number := none
+  number : Option UD.Number := none
   /-- Clusivity (inclusive/exclusive) of a first-person non-singular form — the
       inclusive/exclusive split of the 1st-person plural/dual. A φ-feature borne
       by any such pro-form (personal, possessive, reflexive), like `gender`;

--- a/Linglib/Syntax/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Pronoun/Capabilities.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Features.Number.Capabilities
 import Linglib.Features.CoreferenceStatus
 import Linglib.Features.Register
 import Linglib.Features.Prominence
@@ -106,6 +107,18 @@ theorem bindingClassOf_toWord (p : Pronoun) (h : p.bindingClass ≠ some .rExpre
         case Rcp => exact absurd ((hr hp).symm.trans hb) (by simp)
         all_goals (simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide)
     | rExpression => exact absurd hb h
+
+/-! ### The number axis: `HasNumber` instances and faithfulness -/
+
+/-- A pronoun bears the number its φ-slot ingests (`Number.fromUD`). -/
+instance : HasNumber Pronoun := ⟨fun p => p.number.bind Number.fromUD⟩
+instance : HasNumber PersonalPronoun := ⟨fun p => HasNumber.numberOf p.toPronoun⟩
+
+/-- Projecting a pronoun to a `Word` preserves its number: the mixin reads
+the same value off the carrier and off the projected token (`Pronoun.toWord`
+threads `number` faithfully). -/
+theorem numberOf_toWord (p : Pronoun) :
+    HasNumber.numberOf p.toWord = HasNumber.numberOf p := rfl
 
 /-! ### Orthogonal data-mixins: `Deictic`, `Clusive` -/
 


### PR DESCRIPTION
Unified Number API (Pronoun-spike treatment): root-namespace `Number` (ex-`Features.Number.Category`) is canonical, `UD.Number` demoted to realization vocabulary (`toUD`/`fromUD`); `Features/Number/` splits into Basic/Decomposition/Capabilities/Resolve with the `HasNumber` mixin, `Number.System` graduated from Corbett2000, and one resolution op replacing `semanticResolve`/`canonicalResolve` and their bridge theorem. Rebased onto #134 (ContainmentPairLike presentation).

- Deliberate behavioral correction: sg + sg now resolves to **dual** in dual-having systems (Corbett §6.3, Slovene/Upper Sorbian); the old `semanticResolve` gave plural unconditionally. Also `fromCard` sends sums ≥ 4 to plural (greater plural is an abundance value), which makes `resolve` associative (`resolve_assoc`).
- Second commit wires every remaining number-bearing carrier through `HasNumber` (17 instances) and projects the local sg/pl and min/aug Fragment enums into the canonical inventory.
- Carriers still store `UD.Number`; retyping them is staged follow-up.