### PR TITLE
feat(Studies): Grimm 2018, number and the scale of individuation

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1172,6 +1172,7 @@ import Linglib.Studies.SadakaneKoizumi1995
 import Linglib.Studies.Baker2015
 import Linglib.Studies.Aissen2003
 import Linglib.Studies.Grimm2011
+import Linglib.Studies.Grimm2018
 import Linglib.Studies.DechaineWiltschko2002
 import Linglib.Studies.DeHoopMalchukov2008
 import Linglib.Studies.Haspelmath2021

--- a/Linglib/Core/Mereology.lean
+++ b/Linglib/Core/Mereology.lean
@@ -5,6 +5,8 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Algebra.Order.Ring.Unbundled.Rat
 import Mathlib.Order.Closure
+import Mathlib.Order.Interval.Set.OrdConnected
+import Mathlib.Order.UpperLower.Closure
 import Mathlib.Order.Hom.Lattice
 
 /-!
@@ -652,35 +654,48 @@ def FakeMass {α : Type*} [SemilatticeSup α] (P : α → Prop) : Prop :=
 def convexClosure {α : Type*} [PartialOrder α] (S : Set α) : Set α :=
   { c | ∃ a ∈ S, ∃ b ∈ S, a ≤ c ∧ c ≤ b }
 
+/-- `convexClosure` is mathlib's order-convex hull: the intersection of the
+    upper and lower closures. The construction is consumed, not
+    re-stipulated (same discipline as `Core/Logic/Team/Closure.lean`). -/
+theorem convexClosure_eq_upperClosure_inter_lowerClosure {α : Type*}
+    [PartialOrder α] (S : Set α) :
+    convexClosure S = ↑(upperClosure S) ∩ ↑(lowerClosure S) := by
+  ext c
+  simp only [convexClosure, Set.mem_setOf_eq, Set.mem_inter_iff,
+    SetLike.mem_coe, mem_upperClosure, mem_lowerClosure]
+  tauto
+
 /-- S ⊆ convexClosure S. -/
 theorem subset_convexClosure {α : Type*} [PartialOrder α] (S : Set α) :
     S ⊆ convexClosure S :=
   fun x hx => ⟨x, hx, x, hx, le_refl x, le_refl x⟩
-
-/-- convexClosure is idempotent: Conv(Conv(S)) = Conv(S).
-    If c ∈ Conv(Conv(S)), then a₁ ≤ c ≤ b₂ for some a₁, b₂ ∈ S. -/
-theorem convexClosure_idempotent {α : Type*} [PartialOrder α] (S : Set α) :
-    convexClosure (convexClosure S) = convexClosure S := by
-  ext c; constructor
-  · rintro ⟨a, ⟨a₁, ha₁, a₂, _, ha₁a, _⟩, b, ⟨_, _, b₂, hb₂, _, hbb₂⟩, hac, hcb⟩
-    exact ⟨a₁, ha₁, b₂, hb₂, le_trans ha₁a (le_trans hac (le_refl c)),
-           le_trans (le_refl c) (le_trans hcb hbb₂)⟩
-  · exact fun hc => subset_convexClosure _ hc
 
 /-- Convex closure is monotone: S ⊆ T → Conv(S) ⊆ Conv(T). -/
 theorem convexClosure_mono {α : Type*} [PartialOrder α] {S T : Set α}
     (h : S ⊆ T) : convexClosure S ⊆ convexClosure T :=
   fun _ ⟨a, ha, b, hb, hac, hcb⟩ => ⟨a, h ha, b, h hb, hac, hcb⟩
 
-/-- A set is **convex** under the partial order: every element between
-    two members is itself a member. The fixed-point of `convexClosure`. -/
-def IsConvex {α : Type*} [PartialOrder α] (S : Set α) : Prop :=
-  ∀ ⦃s u : α⦄, s ∈ S → u ∈ S → ∀ ⦃t : α⦄, s ≤ t → t ≤ u → t ∈ S
+/-- The convex closure is order-convex: an intersection of an upper and a
+    lower set (`IsUpperSet.ordConnected`, `IsLowerSet.ordConnected`). -/
+theorem ordConnected_convexClosure {α : Type*} [PartialOrder α] (S : Set α) :
+    (convexClosure S).OrdConnected := by
+  rw [convexClosure_eq_upperClosure_inter_lowerClosure]
+  exact ((upperClosure S).upper.ordConnected).inter
+    ((lowerClosure S).lower.ordConnected)
 
-theorem IsConvex.convexClosure {α : Type*} [PartialOrder α] (S : Set α) :
-    IsConvex (convexClosure S) := by
-  rintro s u ⟨a, ha, _, _, hale, _⟩ ⟨_, _, b, hb, _, hleb⟩ t hst htu
-  exact ⟨a, ha, b, hb, le_trans hale hst, le_trans htu hleb⟩
+/-- A set is order-convex (`Set.OrdConnected`) iff it is a fixed point of
+    `convexClosure` — [kriz-spector-2021] def. 21 and [harbour-2014] (33)
+    are mathlib's `ordConnected_iff_upperClosure_inter_lowerClosure` in
+    closure form. -/
+theorem ordConnected_iff_convexClosure_eq {α : Type*} [PartialOrder α]
+    (S : Set α) : S.OrdConnected ↔ convexClosure S = S := by
+  rw [convexClosure_eq_upperClosure_inter_lowerClosure]
+  exact ordConnected_iff_upperClosure_inter_lowerClosure
+
+/-- convexClosure is idempotent: a corollary of its order-convexity. -/
+theorem convexClosure_idempotent {α : Type*} [PartialOrder α] (S : Set α) :
+    convexClosure (convexClosure S) = convexClosure S :=
+  (ordConnected_iff_convexClosure_eq _).mp (ordConnected_convexClosure S)
 
 /-- `convexClosure` as a mathlib `ClosureOperator (Set α)`.
     Sibling to `algClosureOp`. -/

--- a/Linglib/Features/Number/Basic.lean
+++ b/Linglib/Features/Number/Basic.lean
@@ -55,7 +55,11 @@ set_option autoImplicit false
     (`Number.toUD`/`Number.fromUD`). -/
 inductive Number where
   /-- Non-committal to cardinality; *outside* the number system
-      (Bayso *lúban* 'lion(s)', Japanese *inu* 'dog(s)'). -/
+      (Bayso *lúban* 'lion(s)', Japanese *inu* 'dog(s)'). Not to be
+      conflated with non-countability: a general form is a
+      value-noncommittal form of a noun that *has* number, whereas a
+      non-countable noun lacks the contrast altogether — a countability-class
+      fact, not a number value ([grimm-2018]; `Studies/Grimm2018.lean`). -/
   | general
   /-- Exactly one (`[+atomic, +minimal]`). -/
   | singular

--- a/Linglib/Semantics/Truthmaker/Closure.lean
+++ b/Linglib/Semantics/Truthmaker/Closure.lean
@@ -18,7 +18,7 @@ Closures are not redefined here — they are imported from
 - `Mereology.algClosureOp : ClosureOperator (α → Prop)` bundles it.
 - `Mereology.convexClosure P` is `P^∼` (Jago: convex under parthood).
 - `Mereology.convexClosureOp : ClosureOperator (Set α)` bundles it.
-- `Mereology.IsConvex` is the convex predicate.
+- `Set.OrdConnected` is the convex predicate (via `Mereology.convexClosure`).
 - The regular closure `P^*` is `convexClosure (AlgClosure P)`.
 
 This file provides the **truthmaker-flavored vocabulary** (`IsClosed`,
@@ -64,17 +64,18 @@ section Convex
 variable {S : Type*} [PartialOrder S]
 
 /-- A proposition is **convex** iff it lies between any two of its
-    members in the partial order. Re-export of `Mereology.IsConvex`. -/
-abbrev IsConvex (p : TMProp S) : Prop := Mereology.IsConvex p
+    members in the partial order — mathlib's `Set.OrdConnected`, in
+    Jago's vocabulary. -/
+abbrev IsConvex (p : TMProp S) : Prop := Set.OrdConnected p
 
 /-- Convex closure of a `TMProp`. Re-export of `Mereology.convexClosure`
     (recall `Set α = α → Prop = TMProp α` definitionally). -/
 abbrev convexClose (p : TMProp S) : TMProp S := convexClosure p
 
 /-- The convex closure of `p` is convex. Re-export of
-    `Mereology.IsConvex.convexClosure`. -/
+    `Mereology.ordConnected_convexClosure`. -/
 theorem isConvex_convexClose (p : TMProp S) : IsConvex (convexClose p) :=
-  Mereology.IsConvex.convexClosure p
+  Mereology.ordConnected_convexClosure p
 
 end Convex
 

--- a/Linglib/Studies/Grimm2018.lean
+++ b/Linglib/Studies/Grimm2018.lean
@@ -1,0 +1,494 @@
+import Mathlib.Order.Interval.Set.OrdConnected
+import Linglib.Features.MassCount
+import Linglib.Features.Number.Basic
+import Linglib.Features.Prominence
+
+/-!
+# Grimm (2018) — Grammatical Number and the Scale of Individuation
+[grimm-2018]
+
+Formalizes the core framework of:
+
+  Grimm, S. (2018). Grammatical number and the scale of individuation.
+  *Language* 94(3). 527–574.
+
+## Core contributions
+
+1. **The scale of individuation** (his (17)/(19)): individuation types —
+   equivalence classes of nominal descriptions by individuation
+   properties — are linearly ordered:
+   substance < granular aggregate < collective aggregate < individual.
+
+2. **The order-preservation thesis** (his §3.4): a language's grammatical
+   countability classes also partition nominal descriptions, and the
+   classification map from individuation types to countability classes is
+   **order-preserving**. Consequently every countability class is a
+   *contiguous segment* of the scale — formally, the fibers of a monotone
+   classification are `Set.OrdConnected` (the same mathlib predicate that
+   states [harbour-2014]'s convexity condition in
+   `Syntax/Minimalist/Phi/Recursion.lean`). His hypothetical
+   discontinuous system (Table 21) is refuted by `decide`.
+
+3. **Countability beyond the binary** (his §2): Welsh, Turkana, Maltese
+   (tripartite: non-countable, collective/singulative, singular/plural) and
+   Dagaare (four classes, including an inverse-marked one) against
+   English's binary cut and Yudja's near-absent cut.
+
+4. **The markedness/coding prediction** (his §4.4, after Jakobson and
+   Greenberg): which value of a class's contrast is zero-coded tracks the
+   class's position on the scale — single-reference default for highly
+   individuated classes, multiple-reference default for aggregate classes
+   (the singulative), no contrast at the bottom. Dagaare's inverse number
+   marking is this prediction at work, *not* a `Number` value — confirming
+   the canonical inventory's exclusion of `UD.Number.Inv`.
+
+5. **Animacy refinement** (his §4.2): collective/singulative classes
+   *ascend* the animacy hierarchy (inverse of Smith-Stark plural marking);
+   the per-language collective regions nest (Maltese ⊆ Welsh ⊆ Turkana).
+
+## Connections
+
+* Countability classes are not `Number` values: Welsh collectives take
+  plural agreement while Maltese collectives take singular ([grimm-2018]
+  §2.1, §2.3), so the unit/aggregate contrast cross-cuts the agreement
+  values — vindicating the value space of `Features/Number/Basic.lean`.
+* Each class carries a `Number.System` (`WelshClass.system` etc.), so
+  Grimm's classes plug into the implicational universals; this generalizes
+  the two-class `CountMassNumberInteraction` of `Studies/Corbett2000.lean`.
+* English's binary partition is `Features.MassCount`
+  (`english_matches_massCount`) — the binary feature becomes the 2-cell
+  instance of the scale, not a primitive.
+* `countable : Bool` as a lexical field is refuted twice over: structurally
+  by [borer-2005] (see `Studies/Borer2005.lean`) and scalarly here.
+-/
+
+set_option autoImplicit false
+
+namespace Grimm2018
+
+
+/-! ### The scale of individuation -/
+
+/-- Individuation types ([grimm-2018] (17)/(19)): equivalence classes of
+    nominal descriptions by individuation properties, from entities with no
+    perceptible minimal units to fully independent individuals. The
+    mereotopological content of the middle types (units clumped together
+    vs. connected but separable) is the `SelfConnected` apparatus of
+    `Core/Mereotopology.lean`. -/
+inductive IndividuationType where
+  /-- No perceptible minimal units (liquids, substances: *water*). -/
+  | substance
+  /-- Perceptible units, typically not separated from one another
+      (*rice*, *sand*). -/
+  | granularAggregate
+  /-- Perceptible units, separated but spatially or functionally connected
+      (*ants*, *cherries*). -/
+  | collectiveAggregate
+  /-- Independent, free-standing units (*dog*, *chair*). -/
+  | individualEntity
+  deriving DecidableEq, Repr, Fintype
+
+namespace IndividuationType
+
+/-- Numeric embedding preserving the individuation order. -/
+def toNat : IndividuationType → Nat
+  | .substance => 0
+  | .granularAggregate => 1
+  | .collectiveAggregate => 2
+  | .individualEntity => 3
+
+instance : LinearOrder IndividuationType :=
+  LinearOrder.lift' toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+
+end IndividuationType
+
+/-! ### The order-preservation thesis
+
+[grimm-2018] §3.4: nominal descriptions are partitioned both into
+individuation types (Π_I, ordered by the scale) and into a language's
+grammatical countability classes (Π_G, ordered); the thesis is that the
+classification map is order-preserving (`Monotone`). The structural
+consequence — each grammatical class is a contiguous segment of the scale,
+"no category spans two disconnected segments" — is the `Set.OrdConnected`-ness
+of the classification's fibers. -/
+
+/-- A monotone classification has order-convex fibers: each countability
+    class picks out a contiguous segment of the scale. One composition of
+    mathlib primitives (`Set.ordConnected_singleton.preimage_mono`); the
+    predicate is the same `Set.OrdConnected` that states [harbour-2014]'s
+    convexity condition (`Mereology.ordConnected_iff_convexClosure_eq`). -/
+theorem ordConnected_fiber_of_monotone {α C : Type*} [Preorder α]
+    [PartialOrder C] {f : α → C} (hf : Monotone f) (c : C) :
+    (f ⁻¹' {c}).OrdConnected :=
+  Set.ordConnected_singleton.preimage_mono hf
+
+/-! ### Per-language countability systems ([grimm-2018] §2, Tables 19–20)
+
+Each language's classes are ordered by their scale position; the
+classification maps are the language rows of Table 20 (Dagaare, Welsh,
+English) and the §2 descriptions (Turkana §2.2, Maltese §2.3, Yudja §4.1).
+Monotonicity is checked by `decide`; convexity of every class follows from
+`ordConnected_fiber_of_monotone`. -/
+
+/-- Welsh ([grimm-2018] §2.1, Table 2): tripartite — non-countable
+    (*llefrith* 'milk'), collective/unit (*adar*/*ader-yn* 'birds/bird'),
+    singular/plural (*cadair*/*cadair-iau* 'chair/chairs'). -/
+inductive WelshClass where
+  | nonCountable | collectiveUnit | singularPlural
+  deriving DecidableEq, Repr, Fintype
+
+namespace WelshClass
+
+def toNat : WelshClass → Nat
+  | .nonCountable => 0
+  | .collectiveUnit => 1
+  | .singularPlural => 2
+
+instance : LinearOrder WelshClass :=
+  LinearOrder.lift' toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+
+end WelshClass
+
+/-- Welsh's classification of the scale ([grimm-2018] Table 20 and fn. 20):
+    substances are non-countable, granular and collective aggregates fall in
+    the collective/unit class, individuals in singular/plural. -/
+def welshClassify : IndividuationType → WelshClass
+  | .substance => .nonCountable
+  | .granularAggregate => .collectiveUnit
+  | .collectiveAggregate => .collectiveUnit
+  | .individualEntity => .singularPlural
+
+/-- Welsh respects the scale ([grimm-2018] fn. 20 works this case). -/
+theorem welsh_monotone : Monotone welshClassify := by decide
+
+/-- Turkana ([grimm-2018] §2.2, Tables 5–7) patterns with Welsh: same
+    tripartite shape, with the collective/singulative class reaching types
+    of people (the animacy difference is §4.2 material, not a different
+    class structure on the four-type scale). -/
+abbrev turkanaClassify : IndividuationType → WelshClass := welshClassify
+
+/-- Maltese ([grimm-2018] §2.3, Tables 8–11): same tripartite shape;
+    differs in agreement (collective is formally singular) and in admitting
+    foodstuffs/materials with conventional-portion singulatives. -/
+abbrev malteseClassify : IndividuationType → WelshClass := welshClassify
+
+/-- Dagaare ([grimm-2018] §2.4, Table 20): four classes — non-countable,
+    optional-singulative non-countable (*-ruu*, granular aggregates),
+    plural-default countable (*-ri* codes the singular: inverse marking),
+    and singular-default countable (*-ri* codes the plural). -/
+inductive DagaareClass where
+  | nonCountable | singulativeNonCount | pluralDefault | singularDefault
+  deriving DecidableEq, Repr, Fintype
+
+namespace DagaareClass
+
+def toNat : DagaareClass → Nat
+  | .nonCountable => 0
+  | .singulativeNonCount => 1
+  | .pluralDefault => 2
+  | .singularDefault => 3
+
+instance : LinearOrder DagaareClass :=
+  LinearOrder.lift' toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+
+end DagaareClass
+
+/-- Dagaare's classification ([grimm-2018] Table 20): each individuation
+    type gets its own grammatical class — the partition is exactly as
+    fine-grained as the scale. -/
+def dagaareClassify : IndividuationType → DagaareClass
+  | .substance => .nonCountable
+  | .granularAggregate => .singulativeNonCount
+  | .collectiveAggregate => .pluralDefault
+  | .individualEntity => .singularDefault
+
+theorem dagaare_monotone : Monotone dagaareClassify := by decide
+
+/-- English ([grimm-2018] Table 20): binary — non-countable covers
+    substances *and* aggregates (*foliage*, *rice*), singular/plural covers
+    individuals. -/
+inductive EnglishClass where
+  | nonCountable | singularPlural
+  deriving DecidableEq, Repr, Fintype
+
+namespace EnglishClass
+
+def toNat : EnglishClass → Nat
+  | .nonCountable => 0
+  | .singularPlural => 1
+
+instance : LinearOrder EnglishClass :=
+  LinearOrder.lift' toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+
+end EnglishClass
+
+def englishClassify : IndividuationType → EnglishClass
+  | .individualEntity => .singularPlural
+  | _ => .nonCountable
+
+theorem english_monotone : Monotone englishClassify := by decide
+
+/-- Yudja ([grimm-2018] §4.1, Table 24): the limiting case — only the most
+    highly individuated nouns (humans) manifest grammatical number (optional
+    *-i*); everything else is unspecified. Formally the same binary shape as
+    English with the cut moved to the top of the scale; we record it through
+    `EnglishClass` with its own classification. -/
+def yudjaClassify : IndividuationType → EnglishClass
+  | _ => .nonCountable
+
+theorem yudja_monotone : Monotone yudjaClassify := by decide
+
+/-! ### The impossible system ([grimm-2018] Table 21)
+
+A hypothetical language whose singular/plural class covers granular
+aggregates and individuals while a distinct collective/singulative class
+intervenes. The singular/plural fiber is discontinuous on the scale, so no
+order on the classes makes the classification monotone. -/
+
+/-- Table 21's "Bad System": granular aggregates and individuals share a
+    class that excludes the intervening collective aggregates. -/
+def badClassify : IndividuationType → WelshClass
+  | .substance => .nonCountable
+  | .granularAggregate => .singularPlural
+  | .collectiveAggregate => .collectiveUnit
+  | .individualEntity => .singularPlural
+
+/-- The Bad System's singular/plural class is *not* a contiguous segment of
+    the scale. -/
+theorem bad_fiber_not_ordConnected :
+    ¬ (badClassify ⁻¹' {WelshClass.singularPlural}).OrdConnected := by
+  intro h
+  have : badClassify .collectiveAggregate = .singularPlural :=
+    h.out (x := .granularAggregate) rfl (y := .individualEntity) rfl
+      ⟨by decide, by decide⟩
+  exact absurd this (by decide)
+
+/-- Hence no partial order on the classes makes the Bad System
+    order-preserving ([grimm-2018] fn. 21): with the given class order it is
+    not monotone, and `ordConnected_fiber_of_monotone` rules out every
+    other order as well. -/
+theorem bad_not_monotone (po : PartialOrder WelshClass) :
+    letI := po
+    ¬ Monotone badClassify := by
+  letI := po
+  exact fun hf =>
+    bad_fiber_not_ordConnected (ordConnected_fiber_of_monotone hf _)
+
+/-! ### Coding and markedness ([grimm-2018] §3.4 Table 20, §4.4)
+
+Each class codes one value of its contrast overtly and leaves the other
+zero. The prediction (after Jakobson, Greenberg via [grimm-2018] §4.4): the
+default (zero-coded) designation tracks individuation — multiple-reference
+default for aggregate classes, single-reference default for individual
+classes. Dagaare's *inverse number marking* is the visible signature: the
+same morpheme *-ri* codes plural on singular-default nouns and singular on
+plural-default nouns. The inverse is a *coding* fact, not a number value —
+`UD.Number.Inv` has no `Number` preimage by design
+(`Features/Number/Basic.lean`). -/
+
+/-- The coding pattern of a countability class ([grimm-2018] Table 20):
+    which value, if any, is overtly coded against a zero-coded default. -/
+inductive ClassCoding where
+  /-- No number contrast (Welsh *llefrith* 'milk'). -/
+  | noContrast
+  /-- Zero-coded aggregate, coded unit — the singulative
+      (Welsh *-yn*, Turkana, Maltese *-a*, Dagaare *-ruu*). -/
+  | codedUnit
+  /-- Zero-coded plural, coded singular (Dagaare *-ri* on plural-default
+      nouns: inverse marking). -/
+  | codedSingular
+  /-- Zero-coded singular, coded plural (English *-s*, Welsh *-au*,
+      Dagaare *-ri* on singular-default nouns). -/
+  | codedPlural
+  deriving DecidableEq, Repr, Fintype
+
+/-- The default (zero-coded) designation of a class: nothing, multiple
+    referents, or a single referent. -/
+inductive DefaultReference where
+  | none | multiple | single
+  deriving DecidableEq, Repr, Fintype
+
+namespace DefaultReference
+
+def toNat : DefaultReference → Nat
+  | .none => 0
+  | .multiple => 1
+  | .single => 2
+
+instance : LinearOrder DefaultReference :=
+  LinearOrder.lift' toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+
+end DefaultReference
+
+/-- What a coding pattern leaves as the zero-coded default. -/
+def ClassCoding.default : ClassCoding → DefaultReference
+  | .noContrast => .none
+  | .codedUnit => .multiple
+  | .codedSingular => .multiple
+  | .codedPlural => .single
+
+/-- Welsh coding by class (Table 20): 0 / 0+singulative *-yn* /
+    0+plural *-au*. -/
+def welshCoding : WelshClass → ClassCoding
+  | .nonCountable => .noContrast
+  | .collectiveUnit => .codedUnit
+  | .singularPlural => .codedPlural
+
+/-- Dagaare coding by class (Table 20): 0 / optional singulative *-ruu* /
+    inverse singular *-ri* / plural *-ri*. -/
+def dagaareCoding : DagaareClass → ClassCoding
+  | .nonCountable => .noContrast
+  | .singulativeNonCount => .codedUnit
+  | .pluralDefault => .codedSingular
+  | .singularDefault => .codedPlural
+
+/-- English coding by class: 0 / plural *-s*. -/
+def englishCoding : EnglishClass → ClassCoding
+  | .nonCountable => .noContrast
+  | .singularPlural => .codedPlural
+
+/-! **The markedness prediction** ([grimm-2018] §4.4): along the scale, the
+zero-coded default ascends none → multiple → single — the more individuated
+the class, the more likely single reference is the default. Verified per
+language. -/
+
+theorem welsh_default_monotone :
+    Monotone (fun i => (welshCoding (welshClassify i)).default) := by decide
+
+theorem dagaare_default_monotone :
+    Monotone (fun i => (dagaareCoding (dagaareClassify i)).default) := by
+  decide
+
+theorem english_default_monotone :
+    Monotone (fun i => (englishCoding (englishClassify i)).default) := by
+  decide
+
+/-- Dagaare's two *-ri* classes differ only in coding direction — the
+    formal content of "inverse number marking" ([grimm-2018] §2.4,
+    Tables 15–17). -/
+theorem dagaare_inverse_marking :
+    (dagaareCoding .pluralDefault).default = .multiple ∧
+    (dagaareCoding .singularDefault).default = .single ∧
+    dagaareCoding .pluralDefault ≠ dagaareCoding .singularDefault := by
+  decide
+
+/-! ### Classes carry number systems
+
+A countability class determines which `Number` values its nouns contrast —
+the per-class generalization of `Corbett2000.CountMassNumberInteraction`
+(count system vs. mass system). All class systems satisfy the implicational
+universals. -/
+
+/-- The `Number.System` a Welsh countability class makes available. The
+    collective/unit class contrasts an aggregate with a unit; its
+    *agreement* values are singular and plural ([grimm-2018] (5)–(6):
+    collective *adar* takes plural agreement, singulative *ader-yn*
+    singular), so its system coincides with singular/plural — the class
+    difference lives in coding (`welshCoding`), not in the value
+    inventory. -/
+def WelshClass.system : WelshClass → Number.System
+  | .nonCountable => { name := "Welsh non-countable", values := [] }
+  | .collectiveUnit =>
+      { name := "Welsh collective/unit", values := [.singular, .plural] }
+  | .singularPlural =>
+      { name := "Welsh singular/plural", values := [.singular, .plural] }
+
+/-- Every Welsh class system satisfies the implicational universals. -/
+theorem welsh_systems_wellFormed : ∀ c : WelshClass, c.system.WellFormed := by
+  decide
+
+/-! ### English's binary cut is `MassCount`
+
+[grimm-2018]'s Table 20 row for English *is* the mass/count distinction:
+the binary feature of `Features/MassCount.lean` is the 2-cell instance of a
+scale partition, not an independent primitive. (Lexical `countable : Bool`
+is refuted structurally by [borer-2005] and scalarly here — the field's
+honest replacement is an individuation type.) -/
+
+/-- English's countability classes through `MassCount`. -/
+def englishMassCount : IndividuationType → MassCount
+  | .individualEntity => .count
+  | _ => .mass
+
+/-- The English classification and the mass/count feature are the same
+    partition. -/
+theorem english_matches_massCount :
+    ∀ i, englishClassify i = .singularPlural ↔ englishMassCount i = .count := by
+  decide
+
+/-! ### Animacy refinement ([grimm-2018] §4.2)
+
+Collective/singulative classes interact with animacy *inversely* to
+Smith-Stark plural marking: plural marking descends the animacy hierarchy
+from the top, while collective classes ascend it from below — Welsh's
+collective class stops at inanimates and small/mid animals, Turkana's
+reaches types of people, Maltese's is essentially limited to insects.
+Membership regions nest along animacy. We record the animacy reach of the
+collective class on the simplified hierarchy [grimm-2018] adopts
+(human > higher animate > lower animate > inanimate, after Haspelmath's
+higher/lower animate split) and verify the nesting; the full
+animacy-individuation product lattice (his Fig. 3) and the connectedness
+conjecture over it are left as the documented next step. -/
+
+/-- Simplified animacy tiers for the collective class ([grimm-2018] §4.2). -/
+inductive AnimacyTier where
+  | inanimate | lowerAnimate | higherAnimate | human
+  deriving DecidableEq, Repr, Fintype
+
+namespace AnimacyTier
+
+def toNat : AnimacyTier → Nat
+  | .inanimate => 0
+  | .lowerAnimate => 1
+  | .higherAnimate => 2
+  | .human => 3
+
+instance : LinearOrder AnimacyTier :=
+  LinearOrder.lift' toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+
+end AnimacyTier
+
+/-- Grimm's simplified tiers refine into the library's animacy substrate
+    (`Features.Prominence.AnimacyRank`, the scale `Studies/Corbett2000.lean`
+    states the Animacy Hierarchy constraints over). -/
+def AnimacyTier.toRank : AnimacyTier → Features.Prominence.AnimacyRank
+  | .inanimate => .discreteInanimate
+  | .lowerAnimate => .lowerAnimal
+  | .higherAnimate => .higherAnimal
+  | .human => .human
+
+/-- The refinement preserves the animacy order (stated through
+    `AnimacyRank.toNat`, the substrate's ranking). -/
+theorem AnimacyTier.toRank_monotone :
+    Monotone (fun t : AnimacyTier => (t.toRank).toNat) := by decide
+
+/-- The three languages with tripartite systems, as anchors for the §4.2
+    animacy data. -/
+inductive CollectiveLang where
+  | maltese | welsh | turkana
+  deriving DecidableEq, Repr, Fintype
+
+/-- The animacy ceiling of each language's collective/singulative class
+    ([grimm-2018] §4.2, Fig. 4): Maltese ≈ insects (lower animates), Welsh
+    ≈ small and mid-sized animals (higher animates), Turkana ≈ types of
+    people (humans). The region is upward-bounded: everything from
+    inanimate aggregates up to the ceiling. -/
+def collectiveCeiling : CollectiveLang → AnimacyTier
+  | .maltese => .lowerAnimate
+  | .welsh => .higherAnimate
+  | .turkana => .human
+
+/-- The collective regions nest along animacy: Maltese ⊆ Welsh ⊆ Turkana
+    ([grimm-2018] Fig. 4). Since each region is the down-set of its
+    ceiling, nesting is ceiling order. -/
+theorem collective_regions_nest :
+    collectiveCeiling .maltese ≤ collectiveCeiling .welsh ∧
+    collectiveCeiling .welsh ≤ collectiveCeiling .turkana := by decide
+
+end Grimm2018

--- a/Linglib/Syntax/Minimalist/Phi/Recursion.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Recursion.lean
@@ -565,33 +565,12 @@ first-person plural, there must lie a [−additive] first-person paucal.
 This nonconvex cut violates the general requirement that basic meanings
 be convex ([gaerdenfors-2004]).
 
-The formalization connects to `Mereology.convexClosure` (Core/Mereology.lean §13):
-a nonconvex region under `convexClosure` strictly expands, witnessing
-elements that "should" be in the region but aren't. -/
-
-section Convexity
-
-variable {D : Type*} [PartialOrder D]
-
-/-- A region is convex in a lattice: between any two members, all
-    intermediaries are also members. [harbour-2014] (33). -/
-def isConvex (L : Set D) : Prop :=
-  ∀ a b c : D, a ∈ L → b ∈ L → a ≤ c → c ≤ b → c ∈ L
-
-/-- Convex regions are fixed points of convex closure: Conv(L) = L. -/
-theorem convex_iff_closure_eq (L : Set D) :
-    isConvex L ↔ Mereology.convexClosure L = L := by
-  constructor
-  · intro hconv
-    ext c; constructor
-    · rintro ⟨a, ha, b, hb, hac, hcb⟩
-      exact hconv a b c ha hb hac hcb
-    · exact fun hc => Mereology.subset_convexClosure L hc
-  · intro heq a b c ha hb hac hcb
-    have : c ∈ Mereology.convexClosure L := ⟨a, ha, b, hb, hac, hcb⟩
-    rwa [heq] at this
-
-end Convexity
+Convexity here is mathlib's `Set.OrdConnected`: a region is convex iff it
+is a fixed point of `Mereology.convexClosure`
+(`Mereology.ordConnected_iff_convexClosure_eq`) — the same predicate that
+states [grimm-2018]'s no-discontinuous-category condition on countability
+classes (`Studies/Grimm2018.lean`), so Harbour's and Grimm's convexity
+requirements are the same predicate. -/
 
 -- ============================================================================
 -- § 14: Axiom of Extension

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23429,6 +23429,21 @@
   validated = {true},
   sources   = {Dialogue/DisjunctiveUpdate.lean}
 }
+@article{grimm-2018,
+  author    = {Grimm, Scott},
+  year      = {2018},
+  title     = {Grammatical Number and the Scale of Individuation},
+  journal   = {Language},
+  volume    = {94},
+  number    = {3},
+  pages     = {527--574},
+  doi       = {10.1353/lan.2018.0035},
+  subfield  = {semantics/countability},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Studies/Grimm2018.lean}
+}
+
 @phdthesis{grimm-2012,
   author    = {Grimm, Scott},
   year      = {2012},


### PR DESCRIPTION
Capstone consumer of the Number API (#135): `Studies/Grimm2018.lean` formalizes Grimm (2018, *Language* 94(3)) — the individuation scale as a `LinearOrder`, per-language countability systems (Welsh/Turkana/Maltese/Dagaare/English/Yudja) with order-preserving classification maps, the Table-21 discontinuous system refuted for every possible class order, the §4.4 markedness prediction as per-language monotonicity (Dagaare inverse marking = coding fact, confirming the `UD.Number.Inv` exclusion), per-class `Number.System`s discharging the implicational universals, `MassCount` as the 2-cell instance, and animacy-ceiling nesting wired to `Features.Prominence.AnimacyRank`.

- First commit grounds convexity in mathlib: `Mereology.IsConvex` and Phi/Recursion's duplicate collapse onto `Set.OrdConnected`, with `convexClosure` derived as `upperClosure ∩ lowerClosure` — Kríž–Spector, Harbour, Grimm, and Jago convexity become one mathlib notion.