### PR TITLE
feat(Studies): Harbour 2014, paucity, abundance, theory of number

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1926,6 +1926,7 @@ import Linglib.Studies.HalpertHammerly2026
 import Linglib.Studies.AdamsonAnagnostopoulou2025
 import Linglib.Studies.Amato2025Agreement
 import Linglib.Studies.Toosarvandani2023
+import Linglib.Studies.Harbour2014
 import Linglib.Studies.Harbour2016
 import Linglib.Studies.Keine2019
 import Linglib.Studies.Keine2020

--- a/Linglib/Features/Number/Basic.lean
+++ b/Linglib/Features/Number/Basic.lean
@@ -206,11 +206,13 @@ this order (`Minimalist.Phi.Recursion.categories_isLowerSet`, from
 
 Three independent branches:
 ```
-[±atomic] branch:        trial   greaterPlural
-                           \        /
-                            dual
-                           /    \
-                     singular    plural
+[±atomic] branch:    trial    greaterPlural
+                       |        /
+                      dual     /
+                       |      /
+                   singular  /
+                       |    /
+                    plural
 
 [±minimal] branch:       unitAugmented
                               |
@@ -236,11 +238,13 @@ are incomparable; under specification sg > pl. -/
 /-- The markedness ordering on number values. -/
 def markednessLE (a b : Number) : Prop :=
   a = b ∨ match a, b with
-  -- [±atomic] branch: singular ≤ dual ≤ {trial, greaterPlural};
-  -- plural ≤ dual ≤ {trial, greaterPlural}
-  | .singular, .dual | .singular, .trial | .singular, .greaterPlural => True
-  | .plural, .dual | .plural, .trial | .plural, .greaterPlural => True
-  | .dual, .trial | .dual, .greaterPlural => True
+  -- [±atomic] branch ([harbour-2014] Table 1: TR → DU, DU → SG, SG → PL):
+  -- plural ≤ singular ≤ dual ≤ trial; greaterPlural requires singular and
+  -- plural but NOT dual (Table 1: GR.PL → PL/AUG; Fula is sg/pl/grpl)
+  | .singular, .dual | .singular, .trial => True
+  | .plural, .singular | .plural, .dual | .plural, .trial => True
+  | .plural, .greaterPlural => True
+  | .dual, .trial => True
   -- Approximative branch: plural ≤ paucal ≤ greaterPaucal
   | .plural, .paucal | .plural, .greaterPaucal => True
   | .paucal, .greaterPaucal => True
@@ -329,13 +333,41 @@ instance (ns : System) (v : Number) : Decidable (ns.IsObligatory v) := by
 
 /-! #### Implicational universals ([greenberg-1963], [corbett-2000] §2.3.1) -/
 
-/-- Trial implies dual: no language has trial without dual. -/
+/-- Trial implies dual ([harbour-2014] Table 1: TR → DU). -/
 def TrialImpliesDual (ns : System) : Prop :=
   .trial ∈ ns.values → .dual ∈ ns.values
 
-/-- Dual implies plural. -/
+/-- Dual implies singular ([harbour-2014] Table 1: DU → SG). -/
+def DualImpliesSingular (ns : System) : Prop :=
+  .dual ∈ ns.values → .singular ∈ ns.values
+
+/-- Singular implies plural ([harbour-2014] Table 1: SG → PL). -/
+def SingularImpliesPlural (ns : System) : Prop :=
+  .singular ∈ ns.values → .plural ∈ ns.values
+
+/-- Dual implies plural ([greenberg-1966], [corbett-2000] §2.3.1; the
+    composition of DU → SG and SG → PL). -/
 def DualImpliesPlural (ns : System) : Prop :=
   .dual ∈ ns.values → .plural ∈ ns.values
+
+/-- Minimal implies augmented or plural ([harbour-2014] Table 1:
+    MIN → AUG/PL). -/
+def MinimalImpliesAugmentedOrPlural (ns : System) : Prop :=
+  .minimal ∈ ns.values → .augmented ∈ ns.values ∨ .plural ∈ ns.values
+
+/-- Paucal implies plural ([harbour-2014] Table 1: PC → PL). -/
+def PaucalImpliesPlural (ns : System) : Prop :=
+  .paucal ∈ ns.values → .plural ∈ ns.values
+
+/-- Greater paucal implies paucal ([harbour-2014] Table 1: GR.PC → PC). -/
+def GreaterPaucalImpliesPaucal (ns : System) : Prop :=
+  .greaterPaucal ∈ ns.values → .paucal ∈ ns.values
+
+/-- Greater plural implies plural or augmented ([harbour-2014] Table 1:
+    GR.PL → PL/AUG) — disjunctive, so it is a `System` predicate, not a
+    markedness-order edge. -/
+def GreaterPluralImpliesPluralOrAugmented (ns : System) : Prop :=
+  .greaterPlural ∈ ns.values → .plural ∈ ns.values ∨ .augmented ∈ ns.values
 
 /-- Plural implies singular or minimal ([harbour-2014] Table 1:
     PL → SG/MIN). Plural requires a "base" value — either singular
@@ -354,8 +386,20 @@ def UnitAugImpliesAugmented (ns : System) : Prop :=
 
 instance (ns : System) : Decidable ns.TrialImpliesDual := by
   unfold TrialImpliesDual; infer_instance
+instance (ns : System) : Decidable ns.DualImpliesSingular := by
+  unfold DualImpliesSingular; infer_instance
+instance (ns : System) : Decidable ns.SingularImpliesPlural := by
+  unfold SingularImpliesPlural; infer_instance
 instance (ns : System) : Decidable ns.DualImpliesPlural := by
   unfold DualImpliesPlural; infer_instance
+instance (ns : System) : Decidable ns.MinimalImpliesAugmentedOrPlural := by
+  unfold MinimalImpliesAugmentedOrPlural; infer_instance
+instance (ns : System) : Decidable ns.PaucalImpliesPlural := by
+  unfold PaucalImpliesPlural; infer_instance
+instance (ns : System) : Decidable ns.GreaterPaucalImpliesPaucal := by
+  unfold GreaterPaucalImpliesPaucal; infer_instance
+instance (ns : System) : Decidable ns.GreaterPluralImpliesPluralOrAugmented := by
+  unfold GreaterPluralImpliesPluralOrAugmented; infer_instance
 instance (ns : System) : Decidable ns.PluralImpliesSingularOrMinimal := by
   unfold PluralImpliesSingularOrMinimal; infer_instance
 instance (ns : System) : Decidable ns.AugmentedImpliesMinimal := by
@@ -363,12 +407,15 @@ instance (ns : System) : Decidable ns.AugmentedImpliesMinimal := by
 instance (ns : System) : Decidable ns.UnitAugImpliesAugmented := by
   unfold UnitAugImpliesAugmented; infer_instance
 
-/-- A well-formed number system satisfies all implicational universals.
-    Any Fragment-recorded system discharges this by `decide`. -/
+/-- A well-formed number system satisfies all implicational universals
+    ([harbour-2014] Table 1). Any Fragment-recorded system discharges this
+    by `decide`. -/
 def WellFormed (ns : System) : Prop :=
-  ns.TrialImpliesDual ∧ ns.DualImpliesPlural ∧
-  ns.PluralImpliesSingularOrMinimal ∧ ns.AugmentedImpliesMinimal ∧
-  ns.UnitAugImpliesAugmented
+  ns.TrialImpliesDual ∧ ns.DualImpliesSingular ∧ ns.SingularImpliesPlural ∧
+  ns.DualImpliesPlural ∧ ns.PluralImpliesSingularOrMinimal ∧
+  ns.MinimalImpliesAugmentedOrPlural ∧ ns.AugmentedImpliesMinimal ∧
+  ns.UnitAugImpliesAugmented ∧ ns.PaucalImpliesPlural ∧
+  ns.GreaterPaucalImpliesPaucal ∧ ns.GreaterPluralImpliesPluralOrAugmented
 
 instance (ns : System) : Decidable ns.WellFormed := by
   unfold WellFormed; infer_instance

--- a/Linglib/Studies/Harbour2014.lean
+++ b/Linglib/Studies/Harbour2014.lean
@@ -1,0 +1,247 @@
+import Mathlib.Order.Interval.Set.OrdConnected
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Powerset
+import Linglib.Features.Number.Decomposition
+import Linglib.Syntax.Minimalist.Phi.Recursion
+
+/-!
+# Harbour (2014) — Paucity, Abundance, and the Theory of Number
+[harbour-2014]
+
+Formalizes the central results of:
+
+  Harbour, D. (2014). Paucity, abundance, and the theory of number.
+  *Language* 90(1). 185–229.
+
+The paper's substrate is already the library's: the [±atomic, ±minimal]
+decomposition and the [±additive] join-completeness feature live in
+`Features/Number/Decomposition.lean` (his (10), (20), (21), conditions (11)
+complement completeness and (12) fungibility), and the parameter space —
+activation (22) and feature recursion (23) — with the lower-set derivation
+of the implicational universals lives in `Syntax/Minimalist/Phi/Recursion.lean`.
+This file consumes that substrate and states the paper's own claims.
+
+## Main results
+
+1. **The convexity disparity** (§4.5): `{±atomic}` and `{±minimal}` can be a
+   language's sole number feature; `{±additive}` cannot. His (33) defines
+   lattice convexity — *verbatim* mathlib's `Set.OrdConnected`, the same
+   predicate as [grimm-2018]'s scale-segment condition and the fixed points
+   of `Mereology.convexClosure` — and the first-person lattice makes the
+   [+additive] value region nonconvex: between the speaker atom and any
+   [+additive] plurality lies a [−additive] paucity (`firstPerson_additive_
+   not_ordConnected`, the previously prose-only claim). By the convexity
+   condition (32), `{±additive}` alone is illicit.
+
+2. **The axiom of extension** (§4.2, (27)): feature bundles are sets, so
+   `[+F −F]` is the maximal specification of a single feature — there is no
+   dyad augmented (25) or quadral (26), and trial/unit augmented are the
+   highest exact numbers.
+
+3. **Greenberg-style implications as corollaries** (§5.1, (34) and Table 1):
+   every *attested* Table 3 system satisfies all Table 1 universals
+   (`table3_systems_wellFormed`), via `HarbourConfig.toSystem` — the typed
+   bridge from the generative inventory to `Number.System`. The named
+   implications TR → DU, DU → SG, SG → PL, PC → PL, GR.PC → PC hold across
+   the whole well-formed parameter space (`tr_du` etc.).
+
+4. **Universals are about attested systems**: the unattested setting
+   `{±additive, ±minimal*}` would generate minimal–unit-augmented–paucal–
+   plural (Table 3's lacuna row), which *violates* U.AUG → AUG
+   (`lacuna_violates_uaug`) — Table 1 is contingent on the typology's gaps,
+   which Harbour argues are themselves contingent (pp. 214–215).
+
+5. **Composed number** (§5.2, Table 4): Mele-Fila's article and pronoun
+   syncretisms track the two values of [±additive] — plural belongs to both
+   natural classes because the feature classifies it both ways relative to
+   the two cuts.
+
+## Connections
+
+* The §6 critique of privative feature geometries (Harley & Ritter 2002) —
+  bivalence affords `[+F −F]` and the three-way `[+F]`/`[−F]`/absent
+  contrast that privativity cannot — is the same argument that re-grounded
+  the φ-skeleton as `Features/ContainmentPair.lean` (containment filters are
+  the geometric tradition; Harbour rejects them).
+* Verified against the publication: Table 1 (p. 186), Table 3 (p. 214; the
+  `{±minimal, ±atomic}` exemplar is Kiowa), Table 4 (p. 216), (27), (32),
+  (33), Figure 8 and the §4.5 argument (pp. 210–212).
+-/
+
+set_option autoImplicit false
+
+namespace Harbour2014
+
+open Minimalist.Phi.Recursion (HarbourConfig harbour2014Table3)
+
+/-! ### Convexity (§4.5): (33) is `Set.OrdConnected` -/
+
+/-- [harbour-2014] (33): "a lattice region L is convex if and only if
+    `c ∈ L` whenever `a, b ∈ L` and `a ⊑ c ⊑ b`" — definitionally
+    mathlib's `Set.OrdConnected`, hence the same predicate as
+    [grimm-2018]'s no-discontinuous-class condition and the fixed points of
+    `Mereology.convexClosure`. -/
+theorem ordConnected_iff_convexity_def {α : Type*} [Preorder α] (L : Set α) :
+    L.OrdConnected ↔ ∀ a ∈ L, ∀ b ∈ L, ∀ c, a ≤ c → c ≤ b → c ∈ L := by
+  constructor
+  · intro h a ha b hb c hac hcb
+    exact h.out ha hb ⟨hac, hcb⟩
+  · intro h
+    exact ⟨fun a ha b hb c hc => h a ha b hb c hc.1 hc.2⟩
+
+/-- The first-person(-exclusive) lattice over the ontology
+    {i, o, o′, o″} (`0` = the speaker atom i): every element contains i
+    ([harbour-2014] Figure 8, modeled on a four-element carrier). -/
+def firstPerson : Set (Finset (Fin 4)) := {s | 0 ∈ s}
+
+/-- The [+additive] value region of `{±additive}` on the first-person
+    lattice, with the conventional cut at triads: the join-complete upper
+    region *and* the speaker atom {i}, which — being the unique member of
+    its equivalence class — is its own join-complete region defined by a
+    single horizontal cut ([harbour-2014] p. 211, Figure 8). -/
+def firstPersonAdditive : Set (Finset (Fin 4)) :=
+  {s | 0 ∈ s ∧ (s.card = 1 ∨ 3 ≤ s.card)}
+
+instance : DecidablePred (· ∈ firstPersonAdditive) := fun s =>
+  decidable_of_iff (0 ∈ s ∧ (s.card = 1 ∨ 3 ≤ s.card)) Iff.rfl
+
+/-- Both parts of the [+additive] region are genuinely join-complete
+    ((7): the sum of any two elements stays within): the upper region is
+    closed under union, and the atom trivially so. -/
+theorem firstPersonAdditive_parts_joinComplete :
+    (∀ s t : Finset (Fin 4), 0 ∈ s ∧ 3 ≤ s.card → 0 ∈ t ∧ 3 ≤ t.card →
+      0 ∈ s ∪ t ∧ 3 ≤ (s ∪ t).card) ∧
+    ({0} : Finset (Fin 4)) ∪ {0} = {0} := by
+  constructor
+  · decide
+  · decide
+
+/-- **The §4.5 disparity, as a theorem** (previously prose): the
+    [+additive] value region of the first-person lattice is *nonconvex* —
+    "between the [+additive] first-person atom and any [+additive]
+    first-person plural, there must lie a [−additive] first-person paucal"
+    (p. 212). Witness: i ⊑ io ⊑ ioo′, with the dyad io in the paucal gap.
+    By the convexity condition (32) — basic meanings must be convex
+    ([gaerdenfors-2004]) — `{±additive}` cannot be a language's sole
+    number feature, while `{±atomic}` and `{±minimal}` (whose cuts are
+    single horizontal lines) can. -/
+theorem firstPerson_additive_not_ordConnected :
+    ¬ firstPersonAdditive.OrdConnected := by
+  intro h
+  have h01 : ({0, 1} : Finset (Fin 4)) ∈ firstPersonAdditive :=
+    h.out (x := {0}) (by decide) (y := {0, 1, 2}) (by decide)
+      ⟨by decide, by decide⟩
+  exact absurd h01 (by decide)
+
+/-! ### The axiom of extension (§4.2)
+
+Feature bundles are sets, so (27) {a, a} = {a}: `[+F −F]` is the maximal
+specification a single feature admits. This rules out the dyad augmented
+(25) `*[+minimal −minimal −minimal]` and the quadral (26)
+`*[+minimal −minimal −minimal −atomic]` — they are not richer bundles at
+all — and caps exact numbers at trial and unit augmented. -/
+
+/-- (27) in bundle form: a third occurrence of a feature value adds
+    nothing — the putative quadral bundle *is* the trial bundle. -/
+theorem axiom_of_extension :
+    ({true, false, false} : Finset Bool) = {true, false} := by decide
+
+/-- A single bivalent feature's value set has at most two elements —
+    `[+F −F]` is maximal complexity. -/
+theorem feature_set_card_le_two : ∀ s : Finset Bool, s.card ≤ 2 := by decide
+
+/-! ### Typology (§5.1): Table 1 universals as corollaries
+
+(34) Typological implication schema: if category A must cooccur with
+category B, then the parameter setting for A generates B. The named
+Table 1 implications hold across the entire well-formed parameter space,
+and every attested Table 3 system satisfies the full universal set through
+`HarbourConfig.toSystem`. -/
+
+open Minimalist.Phi.Recursion in
+/-- TR → DU, DU → SG, SG → PL, PC → PL, and GR.PC → PC ([harbour-2014]
+    Table 1) hold for every well-formed parameter setting — Greenberg-style
+    universals as corollaries of the feature geometry, not stipulations. -/
+theorem table1_implications_generated :
+    ∀ c : HarbourConfig, c.wellFormed →
+      (.trial ∈ c.surfaceCategories → .dual ∈ c.surfaceCategories) ∧
+      (.dual ∈ c.surfaceCategories → .singular ∈ c.surfaceCategories) ∧
+      (.singular ∈ c.surfaceCategories → .plural ∈ c.surfaceCategories) ∧
+      (.paucal ∈ c.surfaceCategories → .plural ∈ c.surfaceCategories) ∧
+      (.greaterPaucal ∈ c.surfaceCategories →
+        .paucal ∈ c.surfaceCategories) := by
+  decide
+
+/-- Every attested Table 3 system, read as a `Number.System` through the
+    `HarbourConfig.toSystem` bridge, satisfies all Table 1 universals
+    (`Number.System.WellFormed`). The generative inventory and the
+    descriptive inventory agree. -/
+theorem table3_systems_wellFormed :
+    harbour2014Table3.all
+      (fun e => decide (e.config.toSystem).WellFormed) = true := by decide
+
+/-! ### The lacunae (§5.1, pp. 214–215)
+
+Four parameter settings are well-formed but unattested:
+`{±additive, ±minimal*}`, `{±additive*, ±minimal}`,
+`{±additive*, ±minimal*}`, and `{±additive*, ±minimal*, ±atomic}`.
+Harbour argues the gaps are contingent (unit augmentation and multiple
+approximative numbers are independently rare). The first lacuna shows the
+universals are claims about *attested* systems: its generated system
+violates U.AUG → AUG. -/
+
+/-- The unattested setting `{±additive, ±minimal*}` (Table 3's first
+    lacuna row): minimal, unit augmented, paucal, plural. -/
+def uaugLacuna : HarbourConfig :=
+  ⟨false, true, true, true, false⟩
+
+/-- The lacuna's system has unit augmented without augmented — Table 1's
+    U.AUG → AUG would fail were it attested. The universal is protected by
+    the (contingent) typological gap, exactly as the paper's discussion of
+    the lacunae implies. -/
+theorem lacuna_violates_uaug :
+    uaugLacuna.wellFormed = true ∧
+    ¬ (uaugLacuna.toSystem).WellFormed := by
+  constructor
+  · decide
+  · decide
+
+/-! ### Composed number (§5.2): Mele-Fila, Table 4
+
+Mele-Fila (singular–dual–paucal–plural–greater plural) crosscuts two
+syncretism patterns: the definite article *a* covers plural and greater
+plural — exactly the values carrying (+additive) — while the pronoun
+*raateu* covers paucal and plural — exactly the values carrying
+(−additive). Plural belongs to both natural classes because, with two
+conventionalized cuts, it is [−additive] relative to the high cut and
+[+additive] relative to the low one. -/
+
+/-- Mele-Fila's five values ([harbour-2014] Table 4). -/
+def meleFilaValues : List Number :=
+  [.singular, .dual, .paucal, .plural, .greaterPlural]
+
+/-- The [±additive] signs a Mele-Fila value carries (Table 4, bottom row):
+    plural carries both. -/
+def additiveSigns : Number → List Bool
+  | .singular => [false]
+  | .dual => [false]
+  | .paucal => [false]
+  | .plural => [false, true]
+  | .greaterPlural => [true]
+  | _ => []
+
+/-- The article *a* realizes exactly the (+additive) values, the pronoun
+    *raateu* exactly the (−additive) ones; plural is in both classes —
+    the featural content of Table 4's syncretisms. -/
+theorem meleFila_syncretism_classes :
+    (meleFilaValues.filter (fun v => (additiveSigns v).contains true)
+      = [.plural, .greaterPlural]) ∧
+    (meleFilaValues.filter (fun v => (additiveSigns v).contains false)
+      = [.singular, .dual, .paucal, .plural]) := by decide
+
+/-- Mele-Fila's inventory satisfies the Table 1 universals. -/
+theorem meleFila_wellFormed :
+    Number.System.WellFormed
+      { name := "Mele-Fila", values := meleFilaValues } := by decide
+
+end Harbour2014

--- a/Linglib/Syntax/Minimalist/Phi/Recursion.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Recursion.lean
@@ -221,7 +221,7 @@ structure HarbourConfig where
   /-- Whether [±additive] recurses (splitting paucal into paucal +
       greater paucal). Marked `*` on [±additive] in Table 3. -/
   recurseOnAdditive : Bool
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Fintype
 
 /-- Well-formedness: feature activation prerequisites.
 
@@ -245,16 +245,19 @@ def HarbourConfig.wellFormed (c : HarbourConfig) : Bool :=
     - [±atomic] alone: singular vs non-singular (= plural)
     - [±minimal] alone: minimal vs non-minimal (= augmented)
     - [±atomic] + [±minimal]: singular, dual, plural (the base partition)
-    - + [±minimal] recursion (with [±atomic]): trial, greater plural
+    - + [±minimal] recursion (with [±atomic]): trial (the residue remains
+      plural)
     - + [±minimal] recursion (without [±atomic]): unit augmented
     - + [±additive]: paucal (+ plural when base is MIN/AUG, since
       [±additive] splits augmented into paucal and plural)
     - + [±additive] recursion: greater paucal
 
-    The list includes superordinate categories (e.g., `.plural` remains
-    alongside `.trial` and `.greaterPlural` when recursion is active,
-    and `.augmented` remains alongside `.paucal` and `.plural`).
-    This is required for the lower-set property. -/
+    Recursion on the plural region (with [±atomic]) adds `.trial`; the
+    residue keeps the label `.plural` — [harbour-2014] Table 3 lists
+    Larike as singular, dual, trial, *plural* (greater plural is reserved
+    for [±additive]-derived values). `.augmented` remains alongside
+    `.paucal` and `.plural` when [±additive] splits it; superordinates are
+    required for the lower-set property. -/
 def HarbourConfig.categories (c : HarbourConfig) : List Number :=
   let base :=
     if c.hasAtomic && c.hasMinimal then [.singular, .dual, .plural]
@@ -263,7 +266,7 @@ def HarbourConfig.categories (c : HarbourConfig) : List Number :=
     else []
   let recursive :=
     if c.recurseOnPlural then
-      if c.hasAtomic then [.trial, .greaterPlural]
+      if c.hasAtomic then [.trial]
       else [.unitAugmented]  -- recursion on augmented without [±atomic]
     else []
   let additive :=
@@ -453,25 +456,28 @@ Key predictions:
 /-- Surface categories: the morphologically distinct number values.
 
     Unlike `categories` (which includes superordinates for the lower-set
-    property), this removes categories that have been split into
-    subcategories by recursion or [±additive]:
+    property), this removes a category that has been split into
+    subcategories by [±additive]:
 
-    - **Plural** is removed when [±minimal] recursion (with [±atomic])
-      splits it into trial + greater plural. The surface "plural" IS
-      greater plural (groups of 4+).
     - **Augmented** is removed when [±additive] (without [±atomic]) splits
-      it into paucal + plural. The surface system is minimal/paucal/plural.
+      it into paucal + plural. The surface system is minimal/paucal/plural
+      (Mebengokre, [harbour-2014] Table 3).
 
-    The resulting counts match [harbour-2014] Table 3 exactly. -/
+    The resulting label sets and counts match [harbour-2014] Table 3. -/
 def HarbourConfig.surfaceCategories (c : HarbourConfig) : List Number :=
   let cats := c.categories
-  -- Plural is split by [±minimal] recursion when [±atomic] is active
-  let removePlural := c.recurseOnPlural && c.hasAtomic
   -- Augmented is split by [±additive] when base is MIN/AUG (no [±atomic])
   let removeAugmented := c.hasAdditive && !c.hasAtomic && c.hasMinimal
-  cats.filter fun cat =>
-    !(removePlural && cat == .plural) &&
-    !(removeAugmented && cat == .augmented)
+  cats.filter fun cat => !(removeAugmented && cat == .augmented)
+
+/-- The `Number.System` a configuration generates: surface values as the
+    inventory. The empty configuration leaves Number⁰ featureless — general
+    number ([harbour-2014] (24); Pirahã, Classical Chinese). -/
+def HarbourConfig.toSystem (c : HarbourConfig) (name : String := "") :
+    Number.System :=
+  { name := name
+    values := c.surfaceCategories
+    hasGeneral := c.surfaceCategories.isEmpty }
 
 /-- [harbour-2014] Table 3 entry: a `HarbourConfig` connected to
     the predicted system size and an example language. -/
@@ -498,7 +504,7 @@ def harbour2014Table3 : List Harbour2014Entry := [
   -- {±minimal*}: minimal, unit augmented, augmented
   ⟨⟨false, true, false, true, false⟩, 3, "Rembarrnga"⟩,
   -- {±minimal, ±atomic}: singular, dual, plural
-  ⟨⟨true, true, false, false, false⟩, 3, "Larike"⟩,
+  ⟨⟨true, true, false, false, false⟩, 3, "Kiowa"⟩,
   -- {±additive, ±atomic}₁: singular, paucal, plural
   ⟨⟨true, false, true, false, false⟩, 3, "Bayso"⟩,
   -- {±additive, ±atomic}₂

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23429,6 +23429,18 @@
   validated = {true},
   sources   = {Dialogue/DisjunctiveUpdate.lean}
 }
+@book{greenberg-1966,
+  author    = {Greenberg, Joseph H.},
+  year      = {1966},
+  title     = {Language Universals, with Special Reference to Feature Hierarchies},
+  publisher = {Mouton},
+  address   = {The Hague},
+  subfield  = {typology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Features/Number/Basic.lean;Studies/Harbour2014.lean}
+}
+
 @article{grimm-2018,
   author    = {Grimm, Scott},
   year      = {2018},


### PR DESCRIPTION
`Studies/Harbour2014.lean` — the originating paper of the Number feature substrate, verified against the publication (*Language* 90(1), 185–229): the §4.5 convexity disparity as a theorem (`firstPerson_additive_not_ordConnected` — the [+additive] region of the first-person lattice is non-`OrdConnected`, so `{±additive}` alone is illicit; previously prose), axiom-of-extension (27) facts, Table 1 universals as corollaries of the parameter space (`table1_implications_generated`), `table3_systems_wellFormed` via the new `HarbourConfig.toSystem` bridge, the U.AUG→AUG lacuna theorem, and Mele-Fila Table 4 syncretism classes.

- Verification corrections to substrate (first commit): Table 3's `{±minimal, ±atomic}` exemplar is Kiowa, not Larike; recursion residue keeps the label plural (greater plural is [±additive]-derived, per Table 3); markedness order matched to Table 1 (`plural ≤ singular` added; `dual/singular ≤ greaterPlural` dropped — GR.PL → PL/AUG is disjunctive); `Number.System` universals completed to the full Table 1 set; greenberg-1966 bib entry.