### PR TITLE
feat(Studies): Sutton & Filip 2021, count/mass for granular nouns

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -17,6 +17,7 @@ import Linglib.Typology.Negation
 import Linglib.Features.ClauseForm
 import Linglib.Features.Clusivity
 import Linglib.Features.Indefinite
+import Linglib.Features.Individuation
 import Linglib.Syntax.Pronoun.Basic
 import Linglib.Syntax.Pronoun.Capabilities
 import Linglib.Syntax.Pronoun.Demonstrative
@@ -2635,6 +2636,7 @@ import Linglib.Studies.BarLev2021
 import Linglib.Studies.Enguehard2024
 import Linglib.Studies.Magri2014
 import Linglib.Studies.Sauerland2003
+import Linglib.Studies.SuttonFilip2021
 import Linglib.Phenomena.Plurals.VerbalNumber
 import Linglib.Studies.Gajewski2002
 import Linglib.Studies.Gajewski2011

--- a/Linglib/Features/Individuation.lean
+++ b/Linglib/Features/Individuation.lean
@@ -1,0 +1,51 @@
+import Mathlib.Order.Nat
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# The scale of individuation
+[grimm-2018] [sutton-filip-2021]
+
+Individuation types: equivalence classes of nominal descriptions by
+individuation properties, linearly ordered from entities with no
+perceptible minimal units to fully independent individuals
+([grimm-2018] (17)/(19)). Graduated from `Studies/Grimm2018.lean` on
+gaining its second consumer: [grimm-2018] partitions the scale into
+grammatical countability classes by order-preserving maps;
+[sutton-filip-2021] organizes count/mass *lexicalization options* by the
+same notional classes (granulars are the pivotal type: count as English
+*lentil*, mass as English *rice* or Czech *čočka*). The mereotopological
+content of the middle types (units clumped together vs. connected but
+separable) is the `SelfConnected` apparatus of `Core/Mereotopology.lean`.
+-/
+
+set_option autoImplicit false
+
+/-- Individuation types ([grimm-2018] (17)/(19)): the scale
+    substance < granular aggregate < collective aggregate < individual. -/
+inductive IndividuationType where
+  /-- No perceptible minimal units (liquids, substances: *water*, *mud*). -/
+  | substance
+  /-- Perceptible units, typically not separated from one another
+      (*rice*, *sand*, *lentils*). -/
+  | granularAggregate
+  /-- Perceptible units, separated but spatially or functionally connected
+      (*ants*, *cherries*; functional aggregates: *furniture*). -/
+  | collectiveAggregate
+  /-- Independent, free-standing units (*dog*, *chair*). -/
+  | individualEntity
+  deriving DecidableEq, Repr, Fintype
+
+namespace IndividuationType
+
+/-- Numeric embedding preserving the individuation order. -/
+def toNat : IndividuationType → Nat
+  | .substance => 0
+  | .granularAggregate => 1
+  | .collectiveAggregate => 2
+  | .individualEntity => 3
+
+instance : LinearOrder IndividuationType :=
+  LinearOrder.lift' toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+
+end IndividuationType

--- a/Linglib/Studies/Grimm2018.lean
+++ b/Linglib/Studies/Grimm2018.lean
@@ -1,4 +1,5 @@
 import Mathlib.Order.Interval.Set.OrdConnected
+import Linglib.Features.Individuation
 import Linglib.Features.MassCount
 import Linglib.Features.Number.Basic
 import Linglib.Features.Prominence
@@ -67,41 +68,12 @@ set_option autoImplicit false
 namespace Grimm2018
 
 
-/-! ### The scale of individuation -/
+/-! ### The scale of individuation
 
-/-- Individuation types ([grimm-2018] (17)/(19)): equivalence classes of
-    nominal descriptions by individuation properties, from entities with no
-    perceptible minimal units to fully independent individuals. The
-    mereotopological content of the middle types (units clumped together
-    vs. connected but separable) is the `SelfConnected` apparatus of
-    `Core/Mereotopology.lean`. -/
-inductive IndividuationType where
-  /-- No perceptible minimal units (liquids, substances: *water*). -/
-  | substance
-  /-- Perceptible units, typically not separated from one another
-      (*rice*, *sand*). -/
-  | granularAggregate
-  /-- Perceptible units, separated but spatially or functionally connected
-      (*ants*, *cherries*). -/
-  | collectiveAggregate
-  /-- Independent, free-standing units (*dog*, *chair*). -/
-  | individualEntity
-  deriving DecidableEq, Repr, Fintype
-
-namespace IndividuationType
-
-/-- Numeric embedding preserving the individuation order. -/
-def toNat : IndividuationType → Nat
-  | .substance => 0
-  | .granularAggregate => 1
-  | .collectiveAggregate => 2
-  | .individualEntity => 3
-
-instance : LinearOrder IndividuationType :=
-  LinearOrder.lift' toNat
-    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
-
-end IndividuationType
+`IndividuationType` — the scale substance < granular aggregate <
+collective aggregate < individual ([grimm-2018] (17)/(19)) — lives in
+`Features/Individuation.lean`, shared with [sutton-filip-2021]'s
+count/mass lexicalization options (`Studies/SuttonFilip2021.lean`). -/
 
 /-! ### The order-preservation thesis
 

--- a/Linglib/Studies/SuttonFilip2021.lean
+++ b/Linglib/Studies/SuttonFilip2021.lean
@@ -1,0 +1,353 @@
+import Mathlib.Data.Fintype.Powerset
+import Linglib.Features.Individuation
+import Linglib.Features.MassCount
+
+/-!
+# Sutton & Filip (2021) — The Count/Mass Distinction for Granular Nouns
+[sutton-filip-2021]
+
+Formalizes the core of:
+
+  Sutton, P. R. & Filip, H. (2021). The count/mass distinction for granular
+  nouns. In H. Filip (ed.), *Countability in Natural Language*, 252–291.
+  Cambridge University Press.
+
+## The account
+
+Lexical entries are tripartite (their (33)): a basic predicate (`baspred`,
+number-neutral conceptual content), a counting base (`cbase`), and an
+extension. Two mechanisms mediate between them: the **object identifying
+function** 𝒪 (their (30)), which selects the perceptually/functionally
+salient units if the concept specifies any, and **individuation schemas**
+𝒮ᵢ, which select a maximally disjoint subset of those units; the **null
+schema** 𝒮₀ (their (32)) instead unions *all* maximally disjoint subsets.
+Grammatical counting requires a disjoint counting base, so:
+
+* count = `[+O, +S]` (a specific schema over identified objects — *cat*,
+  *lentil*, Finnish *huonekalut* 'items of furniture');
+* mass = `[−S]` (null schema): either `[+O, −S]` (*furniture* — objects
+  identified but overlapping, so cardinality comparison is available) or
+  `[−O, −S]` (*rice*, Czech *čočka* 'lentil', *mud* — no object function
+  in the counting base at all).
+
+The **accessibility puzzle**: *rice* denotes stuff made of perceptually
+salient, *disjoint* grains, yet `#three rices` cannot mean 'three grains of
+rice' (only container/subkind readings). On this account the grains live in
+`baspred` but are not passed to `cbase` — and an *implicit* unit-extracting
+shift would be a generalized `[−O,−S] → [+O,+S]` operation, incompatible
+with a lexicalized mass/count distinction (their §9.5.4; Yudja, which
+lacks one, counts everything — cf. `Grimm2018.yudjaClassify`).
+
+## Main declarations
+
+* `OverlapPred`/`IsMaxDisjointIn`/`nullSchema` — the schema machinery over
+  an arbitrary overlap relation.
+* `overlapPred_union_of_maxDisjoint_ne` — the load-bearing generic fact:
+  the union of two *distinct* maximal disjoint subsets overlaps. Hence
+  `nullSchema`-saturated entries are mass whenever individuation is
+  perspectival (`overlapPred_nullSchema`), and stable for prototypical
+  objects (`nullSchema_eq_of_disjoint`).
+* `Categorization` (`[±O, ±S]`) and Table 9.1 (`table91`) over the
+  graduated individuation scale (`Features/Individuation.lean`), with the
+  junction theorems: the count option *ascends* the scale
+  (`count_option_monotone`) and the mass option *descends* it
+  (`mass_option_antitone`) — [grimm-2018]'s Table 20 in `[±O, ±S]`
+  clothing.
+* A concrete furniture/rice model on nonempty `Finset`s: *furniture*'s
+  identified units overlap (table vs. vanity), *rice*'s grains are disjoint
+  in `baspred` yet its counting base overlaps — the accessibility puzzle's
+  two halves (`furniture_units_overlap`, `rice_accessibility`).
+
+## Connections
+
+* Second consumer of the individuation scale — the graduation that moved
+  `IndividuationType` to `Features/Individuation.lean` (with [grimm-2018]).
+* `MassCount` records the *outcome* of categorization
+  (`Categorization.massCount`); the `[±O, ±S]` features are its analysis.
+* The cluster/MSSC content of granular `baspred` frames is [grimm-2012]'s
+  mereotopology — `Core/Mereotopology.lean`.
+* Their counting condition (cardinality only over disjoint bases, their
+  (A1) and Landman's overlap thesis) is the semantic ground for why
+  countability classes, not `Number` values, carry the count/mass
+  distinction (`Features/Number/Basic.lean`).
+-/
+
+set_option autoImplicit false
+
+namespace SuttonFilip2021
+
+/-! ### Overlap, disjointness, and individuation schemas
+
+Their (16)–(18), stated over an arbitrary overlap relation `ov` (the
+mereological instantiation is `∃ z ≠ ⊥, z ⊑ x ∧ z ⊑ y`; the concrete
+models below use nonempty `Finset` intersection). A predicate is
+*overlapping* if two distinct members overlap; *disjoint* otherwise. -/
+
+variable {α : Type*} (ov : α → α → Prop)
+
+/-- (17): two distinct members of `P` share a part. -/
+def OverlapPred (P : Set α) : Prop :=
+  ∃ x ∈ P, ∃ y ∈ P, x ≠ y ∧ ov x y
+
+/-- (18): `DISJOINT(P) ↔ ¬OVERLAP(P)`. -/
+def DisjointPred (P : Set α) : Prop := ¬ OverlapPred ov P
+
+/-- `OverlapPred` is monotone under inclusion. -/
+theorem overlapPred_mono {P Q : Set α} (h : P ⊆ Q)
+    (hP : OverlapPred ov P) : OverlapPred ov Q :=
+  let ⟨x, hx, y, hy, hne, hov⟩ := hP
+  ⟨x, h hx, y, h hy, hne, hov⟩
+
+/-- A maximally disjoint subset of `P`: disjoint, and unextendable within
+    `P` (Landman's individuation perspectives; the range of the schemas
+    `𝒮ᵢ`). -/
+def IsMaxDisjointIn (D P : Set α) : Prop :=
+  D ⊆ P ∧ DisjointPred ov D ∧ ∀ x ∈ P, x ∉ D → OverlapPred ov (insert x D)
+
+/-- The null individuation schema `𝒮₀` ((32)): the union of *all*
+    maximally disjoint subsets — what counts as 'one' under any
+    perspective. -/
+def nullSchema (P : Set α) : Set α :=
+  {x | ∃ D, IsMaxDisjointIn ov D P ∧ x ∈ D}
+
+/-- **The union of two distinct maximal disjoint subsets overlaps.** The
+    generic fact behind mass-hood by perspectival individuation: if `x`
+    distinguishes `D₂` from `D₁`, then `D₁`'s maximality makes
+    `insert x D₁` overlap, and the offending pair lies in `D₁ ∪ D₂`. -/
+theorem overlapPred_union_of_maxDisjoint_ne {D₁ D₂ P : Set α}
+    (h₁ : IsMaxDisjointIn ov D₁ P) (h₂ : IsMaxDisjointIn ov D₂ P)
+    (hne : D₁ ≠ D₂) : OverlapPred ov (D₁ ∪ D₂) := by
+  obtain ⟨x, hx₂, hx₁⟩ | ⟨x, hx₁, hx₂⟩ :
+      (∃ x, x ∈ D₂ ∧ x ∉ D₁) ∨ (∃ x, x ∈ D₁ ∧ x ∉ D₂) := by
+    by_contra hcon
+    push_neg at hcon
+    exact hne (Set.Subset.antisymm hcon.2 hcon.1)
+  · exact overlapPred_mono ov
+      (Set.insert_subset_iff.mpr ⟨Or.inr hx₂, fun a ha => Or.inl ha⟩)
+      (h₁.2.2 x (h₂.1 hx₂) hx₁)
+  · exact overlapPred_mono ov
+      (Set.insert_subset_iff.mpr ⟨Or.inl hx₁, fun a ha => Or.inr ha⟩)
+      (h₂.2.2 x (h₁.1 hx₁) hx₂)
+
+/-- If individuation is perspectival — two distinct maximal disjoint
+    subsets exist — the null schema yields an overlapping counting base:
+    `𝒮₀`-saturated entries are mass ((32) and their §9.4.3). -/
+theorem overlapPred_nullSchema {D₁ D₂ P : Set α}
+    (h₁ : IsMaxDisjointIn ov D₁ P) (h₂ : IsMaxDisjointIn ov D₂ P)
+    (hne : D₁ ≠ D₂) : OverlapPred ov (nullSchema ov P) :=
+  overlapPred_mono ov
+    (Set.union_subset (fun a ha => ⟨D₁, h₁, ha⟩) (fun a ha => ⟨D₂, h₂, ha⟩))
+    (overlapPred_union_of_maxDisjoint_ne ov h₁ h₂ hne)
+
+/-- For an already-disjoint predicate there is exactly one perspective:
+    the null schema returns the predicate itself. Prototypical objects
+    (*cat*) are therefore stably count — `(𝒮ᵢ(𝒪(cat)))` does not vary
+    with `i` (their §9.4.3). -/
+theorem nullSchema_eq_of_disjoint {P : Set α} (h : DisjointPred ov P) :
+    nullSchema ov P = P := by
+  ext x
+  constructor
+  · rintro ⟨D, hD, hx⟩
+    exact hD.1 hx
+  · intro hx
+    refine ⟨P, ⟨Set.Subset.rfl, h, fun y hy hny => absurd hy hny⟩, hx⟩
+
+/-! ### The `[±O, ±S]` categorization and Table 9.1
+
+`[+O]`: the counting base contains the object identifying function 𝒪;
+`[+S]`: it is interpreted under a specific schema `𝒮ᵢ` rather than `𝒮₀`.
+Count nouns are `[+O, +S]`; mass nouns are `[−S]`. -/
+
+/-- The two binary features classifying counting bases (their §9.4.4). -/
+structure Categorization where
+  /-- The counting base contains the object identifying function 𝒪. -/
+  hasObjectFn : Bool
+  /-- The counting base is interpreted under a specific schema `𝒮ᵢ`
+      (rather than the null schema `𝒮₀`). -/
+  hasSpecificSchema : Bool
+  deriving DecidableEq, Repr
+
+/-- Count iff `[+O, +S]`; everything `[−S]` is mass (Table 9.1's
+    generalizations). -/
+def Categorization.massCount : Categorization → MassCount
+  | ⟨true, true⟩ => .count
+  | _ => .mass
+
+/-- Table 9.1: the categorization options available to each notional
+    class, stated over the graduated individuation scale. Substances are
+    `[−O, −S]` only (*mud*); granulars lexicalize either way (*lentil* vs
+    *rice*/*čočka*); collective artifacts are `[+O, ±S]` (*huonekalut* vs
+    *furniture*); prototypical objects are `[+O, +S]` (*cat*). -/
+def table91 : IndividuationType → List Categorization
+  | .substance => [⟨false, false⟩]
+  | .granularAggregate => [⟨true, true⟩, ⟨false, false⟩]
+  | .collectiveAggregate => [⟨true, true⟩, ⟨true, false⟩]
+  | .individualEntity => [⟨true, true⟩]
+
+/-- A count lexicalization is available from granular aggregates upward —
+    availability of `[+O, +S]` is monotone on the individuation scale. -/
+theorem count_option_monotone :
+    Monotone (fun i =>
+      (table91 i).any (fun c => c.hasObjectFn && c.hasSpecificSchema)) := by
+  decide
+
+/-- A mass lexicalization is available from collective aggregates
+    downward — availability of `[−S]` is antitone on the scale. Together
+    with `count_option_monotone`, this is [grimm-2018]'s Table 20
+    landscape derived from the `[±O, ±S]` analysis: the count/mass
+    boundary can only fall *across* the scale, never gerrymander it. -/
+theorem mass_option_antitone :
+    Antitone (fun i => (table91 i).any (fun c => !c.hasSpecificSchema)) := by
+  decide
+
+/-- Every notional class has at least one lexicalization, and the
+    cross-linguistically variable classes (granular, collective artifact)
+    are exactly those with two ([sutton-filip-2021] §9.3.1: *lentil* vs
+    *čočka*, *furniture* vs *huonekalut*). -/
+theorem variable_classes :
+    (∀ i, (table91 i) ≠ []) ∧
+    (∀ i, (table91 i).length = 2 ↔
+      (i = .granularAggregate ∨ i = .collectiveAggregate)) := by
+  constructor
+  · decide
+  · decide
+
+/-! ### A concrete model: furniture and rice
+
+Carrier: nonempty subsets of a small atom domain, overlap = nonempty
+intersection. *Furniture* (their §9.4.2–9.4.3): a table `t`, a mirror `m`,
+and the vanity `t ⊔ m` are all functional units, so `𝒪(furniture)`
+overlaps — two individuation perspectives exist (count the vanity as one,
+or the table and mirror as two). *Rice*: the basic predicate knows the
+grains (disjoint!) and their aggregates, but the `[−O, −S]` counting base
+is the null schema over the whole predicate — overlapping. The grains are
+real and inaccessible: the accessibility puzzle. -/
+
+/-- Mereological overlap on `Finset` parts: nonempty intersection. -/
+def fovl (s t : Finset (Fin 3)) : Prop := (s ∩ t).Nonempty
+
+instance : ∀ s t, Decidable (fovl s t) := fun s t =>
+  inferInstanceAs (Decidable (s ∩ t).Nonempty)
+
+instance {a : Finset (Fin 3)} {P : Set (Finset (Fin 3))}
+    [DecidablePred (· ∈ P)] : DecidablePred (· ∈ insert a P) := fun x =>
+  decidable_of_iff (x = a ∨ x ∈ P) (by simp [Set.mem_insert_iff])
+
+instance {P : Set (Finset (Fin 3))} [DecidablePred (· ∈ P)] :
+    Decidable (OverlapPred fovl P) := by
+  unfold OverlapPred; infer_instance
+
+instance {P : Set (Finset (Fin 3))} [DecidablePred (· ∈ P)] :
+    Decidable (DisjointPred fovl P) :=
+  decidable_of_iff (¬ OverlapPred fovl P) Iff.rfl
+
+instance {P Q : Set (Finset (Fin 3))} [DecidablePred (· ∈ P)]
+    [DecidablePred (· ∈ Q)] : Decidable (P ⊆ Q) :=
+  decidable_of_iff (∀ x, x ∈ P → x ∈ Q) Iff.rfl
+
+instance {D P : Set (Finset (Fin 3))} [DecidablePred (· ∈ D)]
+    [DecidablePred (· ∈ P)] : Decidable (IsMaxDisjointIn fovl D P) :=
+  decidable_of_iff
+    ((∀ x, x ∈ D → x ∈ P) ∧ DisjointPred fovl D ∧
+      ∀ x, x ∈ P → x ∉ D → OverlapPred fovl (insert x D)) Iff.rfl
+
+/-- The identified units of *furniture* on a two-atom domain: table `{0}`,
+    mirror `{1}`, and the vanity `{0, 1}` they jointly compose. -/
+def furnitureUnits : Set (Finset (Fin 3)) :=
+  {s | s = {0} ∨ s = {1} ∨ s = {0, 1}}
+
+instance : DecidablePred (· ∈ furnitureUnits) := fun s =>
+  decidable_of_iff (s = {0} ∨ s = {1} ∨ s = {0, 1}) Iff.rfl
+
+/-- The piece perspective: count the table and the mirror. -/
+def piecePerspective : Set (Finset (Fin 3)) := {s | s = {0} ∨ s = {1}}
+
+instance : DecidablePred (· ∈ piecePerspective) := fun s =>
+  decidable_of_iff (s = {0} ∨ s = {1}) Iff.rfl
+
+/-- The vanity perspective: count the composed unit. -/
+def vanityPerspective : Set (Finset (Fin 3)) := {s | s = {0, 1}}
+
+instance : DecidablePred (· ∈ vanityPerspective) := fun s =>
+  decidable_of_iff (s = {0, 1}) Iff.rfl
+
+/-- `𝒪(furniture)` is overlapping: the vanity shares parts with the table.
+    Hence *furniture* is `[+O, −S]`: object units exist (cardinality
+    comparisons are licensed) but the null schema's base overlaps — mass. -/
+theorem furniture_units_overlap : OverlapPred fovl furnitureUnits := by
+  decide
+
+/-- The two individuation perspectives on the furniture units — count the
+    pieces, or count the vanity — are both maximally disjoint, and differ;
+    by `overlapPred_nullSchema` the null-schema counting base is
+    overlapping, which is *why* `#three furnitures` fails. -/
+theorem furniture_two_perspectives :
+    IsMaxDisjointIn fovl piecePerspective furnitureUnits ∧
+    IsMaxDisjointIn fovl vanityPerspective furnitureUnits ∧
+    OverlapPred fovl (nullSchema fovl furnitureUnits) := by
+  refine ⟨by decide, by decide,
+    overlapPred_nullSchema fovl (D₁ := piecePerspective)
+      (D₂ := vanityPerspective) (by decide) (by decide) ?_⟩
+  intro h
+  have h0 : ({0} : Finset (Fin 3)) ∈ vanityPerspective := by
+    rw [← h]; exact Or.inl rfl
+  exact absurd h0 (by decide)
+
+/-- *Rice* on a three-grain domain: the basic predicate contains the
+    grains and their aggregates (its `extension = unit ∨ collection`,
+    their (29)). -/
+def riceBaspred : Set (Finset (Fin 3)) := {s | s.Nonempty}
+
+instance : DecidablePred (· ∈ riceBaspred) := fun s =>
+  inferInstanceAs (Decidable s.Nonempty)
+
+/-- The grains of rice: the atoms. -/
+def riceGrains : Set (Finset (Fin 3)) :=
+  {s | s = {0} ∨ s = {1} ∨ s = {2}}
+
+instance : DecidablePred (· ∈ riceGrains) := fun s =>
+  decidable_of_iff (s = {0} ∨ s = {1} ∨ s = {2}) Iff.rfl
+
+/-- The heap perspective on rice: one three-grain aggregate. -/
+def heapPerspective : Set (Finset (Fin 3)) := {s | s = {0, 1, 2}}
+
+instance : DecidablePred (· ∈ heapPerspective) := fun s =>
+  decidable_of_iff (s = {0, 1, 2}) Iff.rfl
+
+/-- **The accessibility puzzle, both halves** ((Q2), §9.5.3): the grains
+    are part of *rice*'s basic predicate and are perfectly disjoint — they
+    intuitively count as one — yet the `[−O, −S]` counting base (the null
+    schema over the whole basic predicate) is overlapping, because grain
+    and heap perspectives are both maximal. Grammatical counting is
+    blocked: salience without accessibility. -/
+theorem rice_accessibility :
+    riceGrains ⊆ riceBaspred ∧
+    DisjointPred fovl riceGrains ∧
+    OverlapPred fovl (nullSchema fovl riceBaspred) := by
+  refine ⟨by decide, by decide,
+    overlapPred_nullSchema fovl
+      (D₁ := riceGrains) (D₂ := heapPerspective)
+      (by decide) (by decide) ?_⟩
+  intro h
+  have h0 : ({0} : Finset (Fin 3)) ∈ heapPerspective := by
+    rw [← h]; exact Or.inl rfl
+  exact absurd h0 (by decide)
+
+/-! ### Cross-linguistic variation as a schema substitution
+
+Finnish *huonekalut* 'items of furniture' is the count counterpart of
+*furniture*: identical basic predicate, with the null schema replaced by a
+contextually specified one — `⟦huonekalut⟧^𝒮ᵢ = ⟦furniture⟧^{𝒮₀ ↦ 𝒮ᵢ}`
+(their p. 278). On the model: each *specific* perspective on the furniture
+units is disjoint, hence countable. The same substitution relates Czech
+*čočka* to English *lentil(s)* among granulars. -/
+
+/-- Each specific individuation perspective on the furniture units is a
+    disjoint counting base — `[+O, +S]` is count (*huonekalut*), even
+    though the `[+O, −S]` null-schema base overlaps (*furniture*). -/
+theorem huonekalut_count :
+    DisjointPred fovl piecePerspective ∧
+    DisjointPred fovl vanityPerspective := by
+  exact ⟨by decide, by decide⟩
+
+end SuttonFilip2021

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23441,6 +23441,22 @@
   sources   = {Features/Number/Basic.lean;Studies/Harbour2014.lean}
 }
 
+@incollection{sutton-filip-2021,
+  author    = {Sutton, Peter R. and Filip, Hana},
+  year      = {2021},
+  title     = {The Count/Mass Distinction for Granular Nouns},
+  booktitle = {Countability in Natural Language},
+  editor    = {Filip, Hana},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  pages     = {252--291},
+  doi       = {10.1017/9781316823774.011},
+  subfield  = {semantics/countability},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Studies/SuttonFilip2021.lean;Features/Individuation.lean}
+}
+
 @article{grimm-2018,
   author    = {Grimm, Scott},
   year      = {2018},


### PR DESCRIPTION
`Studies/SuttonFilip2021.lean` — ch. 9 of Filip (ed.), *Countability in Natural Language* (CUP 2021, 252–291): the [±O, ±S] analysis of count/mass. Generic schema machinery (`OverlapPred`/`IsMaxDisjointIn`/`nullSchema`) with the load-bearing theorem that two distinct maximal disjoint subsets union to an overlapping set — so null-schema counting bases are mass exactly when individuation is perspectival; Table 9.1 over the individuation scale with junction theorems (`count_option_monotone`/`mass_option_antitone` — Grimm's Table 20 landscape derived from [±O, ±S]); concrete furniture/rice models proving the accessibility puzzle's two halves (`rice_accessibility`: grains disjoint in the basic predicate, counting base overlapping) and the Finnish `𝒮₀ ↦ 𝒮ᵢ` substitution (`huonekalut_count`).

- First commit graduates `IndividuationType` from `Studies/Grimm2018.lean` to `Features/Individuation.lean` — second consumer reached, per the ≥2-studies rule.