### PR TITLE
feat(Studies): Landman 2020, Iceberg semantics for mass and count

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1236,6 +1236,7 @@ import Linglib.Phenomena.ArgumentStructure.Unaccusativity.Data
 import Linglib.Studies.Storment2026
 import Linglib.Phenomena.ArgumentStructure.DiathesisAlternations.Data
 import Linglib.Studies.Adger2003
+import Linglib.Studies.Landman2020
 import Linglib.Studies.Levin1993
 import Linglib.Studies.Osborne2019
 import Linglib.Phenomena.ArgumentStructure.TheoryComparison

--- a/Linglib/Core/Mereology.lean
+++ b/Linglib/Core/Mereology.lean
@@ -709,7 +709,96 @@ def convexClosureOp {α : Type*} [PartialOrder α] :
   idempotent' := convexClosure_idempotent
 
 -- ════════════════════════════════════════════════════
--- § 15. Conjunctive Parthood (Jago Def 5; [jago-2026])
+-- § 15. Predicate Disjointness and Individuation Perspectives
+-- ════════════════════════════════════════════════════
+
+/-! ### Predicate disjointness and individuation perspectives
+
+A predicate is *overlapping* if two distinct members share a part, and
+*disjoint* otherwise; a maximally disjoint subset is an individuation
+perspective ([landman-2011]'s variants; [landman-2020]'s disjointness
+thesis: counting requires a disjoint base). The null schema unions all
+perspectives ([sutton-filip-2021]). Parameterized over an arbitrary
+overlap relation `ov` (mereologically, `x ⊓ y ≠ ⊥`); graduated from
+`Studies/SuttonFilip2021.lean` on gaining its second consumer
+(`Studies/Landman2020.lean`). -/
+
+section Individuation
+
+variable {α : Type*} (ov : α → α → Prop)
+
+/-- Two distinct members of `P` share a part. -/
+def OverlapPred (P : Set α) : Prop :=
+  ∃ x ∈ P, ∃ y ∈ P, x ≠ y ∧ ov x y
+
+/-- No two distinct members of `P` share a part. -/
+def DisjointPred (P : Set α) : Prop := ¬ OverlapPred ov P
+
+/-- `OverlapPred` is monotone under inclusion. -/
+theorem overlapPred_mono {P Q : Set α} (h : P ⊆ Q)
+    (hP : OverlapPred ov P) : OverlapPred ov Q :=
+  let ⟨x, hx, y, hy, hne, hov⟩ := hP
+  ⟨x, h hx, y, h hy, hne, hov⟩
+
+/-- A subset of a disjoint predicate is disjoint. -/
+theorem DisjointPred.anti {P Q : Set α} (h : P ⊆ Q)
+    (hQ : DisjointPred ov Q) : DisjointPred ov P :=
+  fun hP => hQ (overlapPred_mono ov h hP)
+
+/-- A maximally disjoint subset of `P`: disjoint, and unextendable within
+    `P` — an individuation perspective. -/
+def IsMaxDisjointIn (D P : Set α) : Prop :=
+  D ⊆ P ∧ DisjointPred ov D ∧ ∀ x ∈ P, x ∉ D → OverlapPred ov (insert x D)
+
+/-- The null individuation schema: the union of *all* maximally disjoint
+    subsets — what counts as 'one' under any perspective
+    ([sutton-filip-2021] (32), after [landman-2011]). -/
+def nullSchema (P : Set α) : Set α :=
+  {x | ∃ D, IsMaxDisjointIn ov D P ∧ x ∈ D}
+
+/-- The union of two distinct maximal disjoint subsets overlaps: if `x`
+    distinguishes `D₂` from `D₁`, then `D₁`'s maximality makes
+    `insert x D₁` overlap, and the offending pair lies in `D₁ ∪ D₂`. -/
+theorem overlapPred_union_of_maxDisjoint_ne {D₁ D₂ P : Set α}
+    (h₁ : IsMaxDisjointIn ov D₁ P) (h₂ : IsMaxDisjointIn ov D₂ P)
+    (hne : D₁ ≠ D₂) : OverlapPred ov (D₁ ∪ D₂) := by
+  obtain ⟨x, hx₂, hx₁⟩ | ⟨x, hx₁, hx₂⟩ :
+      (∃ x, x ∈ D₂ ∧ x ∉ D₁) ∨ (∃ x, x ∈ D₁ ∧ x ∉ D₂) := by
+    by_contra hcon
+    push_neg at hcon
+    exact hne (Set.Subset.antisymm hcon.2 hcon.1)
+  · exact overlapPred_mono ov
+      (Set.insert_subset_iff.mpr ⟨Or.inr hx₂, fun a ha => Or.inl ha⟩)
+      (h₁.2.2 x (h₂.1 hx₂) hx₁)
+  · exact overlapPred_mono ov
+      (Set.insert_subset_iff.mpr ⟨Or.inl hx₁, fun a ha => Or.inr ha⟩)
+      (h₂.2.2 x (h₁.1 hx₁) hx₂)
+
+/-- If two distinct maximal disjoint subsets exist, the null schema is
+    overlapping: null-schema counting bases are mass exactly when
+    individuation is perspectival. -/
+theorem overlapPred_nullSchema {D₁ D₂ P : Set α}
+    (h₁ : IsMaxDisjointIn ov D₁ P) (h₂ : IsMaxDisjointIn ov D₂ P)
+    (hne : D₁ ≠ D₂) : OverlapPred ov (nullSchema ov P) :=
+  overlapPred_mono ov
+    (Set.union_subset (fun a ha => ⟨D₁, h₁, ha⟩) (fun a ha => ⟨D₂, h₂, ha⟩))
+    (overlapPred_union_of_maxDisjoint_ne ov h₁ h₂ hne)
+
+/-- A disjoint predicate is its own unique perspective: the null schema
+    returns it unchanged. -/
+theorem nullSchema_eq_of_disjoint {P : Set α} (h : DisjointPred ov P) :
+    nullSchema ov P = P := by
+  ext x
+  constructor
+  · rintro ⟨D, hD, hx⟩
+    exact hD.1 hx
+  · intro hx
+    exact ⟨P, ⟨Set.Subset.rfl, h, fun y hy hny => absurd hy hny⟩, hx⟩
+
+end Individuation
+
+-- ════════════════════════════════════════════════════
+-- § 16. Conjunctive Parthood (Jago Def 5; [jago-2026])
 -- ════════════════════════════════════════════════════
 
 /-- **Down clause** of conjunctive parthood: every element of `p` has a

--- a/Linglib/Studies/Landman2020.lean
+++ b/Linglib/Studies/Landman2020.lean
@@ -1,0 +1,452 @@
+import Mathlib.Order.CompleteBooleanAlgebra
+import Mathlib.Data.Set.Card
+import Linglib.Core.Mereology
+
+/-!
+# Landman (2020) — Iceberg Semantics for Mass Nouns and Count Nouns
+[landman-2020]
+
+Formalizes the formal core of:
+
+  Landman, F. (2020). *Iceberg Semantics for Mass Nouns and Count Nouns:
+  A New Framework for Boolean Semantics*. Studies in Linguistics and
+  Philosophy 105. Springer.
+
+## The framework
+
+Mountain semantics (Link-style Boolean semantics, [link-1983]) grounds
+counting in *atomicity*: singular count nouns denote sets of Boolean
+atoms. Iceberg semantics replaces this vertical picture with a horizontal
+one: every interpretation is an **i-set** ⟨body, base⟩ where the base
+*generates* the body under sum, and the mass/count distinction lives in
+the base — **count iff the base is disjoint** (§6.1.2); mass and count
+are perspectives on the same stuff, and Boolean atoms play no role.
+
+## Main results (all generic over a complete Boolean algebra)
+
+* `ISet`, the two null i-sets, and `ISet.body_eq_of_base_empty` (the
+  nulls are exactly the empty-based i-sets — his §6.1.2 Lemma).
+* **Counting is correct given disjointness, not atomicity** (the
+  mathematical heart of ch. 5): for a disjoint, ⊥-free `Z`, membership in
+  a sum of `Z`-elements is membership in the summands
+  (`mem_iff_le_sSup_of_disjoint`, by frame distributivity), so every
+  element of `*Z` is recovered from its distribution set
+  (`sSup_partsIn`), the distribution map is injective (`partsIn_injOn`),
+  and `card` counts correctly.
+* `atomsIn_eq_of_disjoint` (a ⊥-free disjoint set is all-minimal) and the
+  §6.1.2 Lemma `ISet.IsCount.isNeat`: **count i-sets are neat** — with
+  the book's *atomisticity* definition of neat, which §6.1.2 explicitly
+  substitutes for the base-atomicity of [landman-2011]/[landman-2016].
+* **The Head Principle** (§5.3): `base(α) = (body α] ∩ base(H)`, and its
+  Lemma — disjointness inherits from head to complex
+  (`ISet.headBase_disjoint`) — making mass/count *compositional*.
+* `ISet.plur` leaves the base fixed (`ISet.plur_base_eq_headBase`), so
+  pluralization preserves countness (`ISet.plur_isCount`) — the generic
+  content of the §5.4 *white cats* computation, where
+  `(*body(P)] ∩ base(P) = base(P)`.
+* The noun classes: number-neutral neat mass nouns (*poultry*,
+  `⟨*X₀, *X₀⟩`, §7.1) are neat (`numberNeutral_isNeat`) but their base
+  overlaps (`star_overlapPred`, hence mass); atomless bases are mess
+  (*water*, §8.1.5: `not_neat_of_atomless`).
+
+## Connections
+
+* The disjointness machinery is `Core/Mereology`'s
+  `OverlapPred`/`DisjointPred`/`nullSchema` (shared with
+  [sutton-filip-2021], whose counting bases are this book's bases and
+  whose individuation schemas select among its perspectives —
+  `Mereology.IsMaxDisjointIn`).
+* Mountain semantics' pluralization `*` is the Link closure of
+  `Semantics/Plurality/Algebra.lean`; Iceberg's `star` is its
+  complete-join generalization (sums of arbitrary subsets, so
+  `*∅ = {⊥}`).
+* The base-perspective on mass/count is the semantic ground for keeping
+  countability out of the `Number` value space
+  (`Features/Number/Basic.lean`): count/mass classifies *bases*; number
+  values classify referents.
+-/
+
+set_option autoImplicit false
+
+namespace Landman2020
+
+open Mereology (OverlapPred DisjointPred)
+
+variable {B : Type*} [CompleteBooleanAlgebra B]
+
+/-! ### Boolean background (his ch. 2)
+
+`star X` is closure under arbitrary sums — `*X = {b : ∃ Y ⊆ X, b = ⊔Y}`,
+so `*∅ = {⊥}`. Mereological overlap is non-null meet. `plus Z` is `Z⁺`
+(`Z` minus the null element); `atomsIn Z` is the set of minimal elements
+of `Z⁺` — *Z-atoms*, relativized to `Z`, not Boolean atoms. -/
+
+/-- Closure of `X` under arbitrary sums. -/
+def star (X : Set B) : Set B := {b | ∃ Y ⊆ X, b = sSup Y}
+
+theorem subset_star {X : Set B} : X ⊆ star X :=
+  fun x hx => ⟨{x}, Set.singleton_subset_iff.mpr hx, sSup_singleton.symm⟩
+
+theorem sSup_mem_star {X Y : Set B} (h : Y ⊆ X) : sSup Y ∈ star X :=
+  ⟨Y, h, rfl⟩
+
+theorem star_mono {X Y : Set B} (h : X ⊆ Y) : star X ⊆ star Y :=
+  fun _ ⟨Z, hZ, hb⟩ => ⟨Z, hZ.trans h, hb⟩
+
+theorem sSup_star_eq {X : Set B} : sSup (star X) = sSup X :=
+  le_antisymm
+    (sSup_le fun _ ⟨Y, hY, hb⟩ => hb ▸ sSup_le_sSup hY)
+    (sSup_le_sSup subset_star)
+
+theorem star_empty : star (∅ : Set B) = {⊥} := by
+  ext b
+  constructor
+  · rintro ⟨Y, hY, rfl⟩
+    rw [Set.subset_empty_iff.mp hY, sSup_empty]
+    rfl
+  · rintro rfl
+    exact ⟨∅, Set.Subset.rfl, sSup_empty.symm⟩
+
+/-- `star` is idempotent: a sum of sums of `X`-elements is a sum of
+    `X`-elements. -/
+theorem star_star {X : Set B} : star (star X) = star X := by
+  refine Set.Subset.antisymm ?_ subset_star
+  rintro b ⟨Y, hY, rfl⟩
+  classical
+  choose Z hZsub hZsup using fun y (hy : y ∈ Y) => hY hy
+  refine ⟨⋃ (y : B) (hy : y ∈ Y), Z y hy, ?_, le_antisymm ?_ ?_⟩
+  · simp only [Set.iUnion_subset_iff]
+    exact hZsub
+  · refine sSup_le fun y hy => ?_
+    rw [hZsup y hy]
+    refine sSup_le_sSup fun w hw => ?_
+    exact Set.mem_iUnion.mpr ⟨y, Set.mem_iUnion.mpr ⟨hy, hw⟩⟩
+  · refine sSup_le fun w hw => ?_
+    obtain ⟨y, hy⟩ := Set.mem_iUnion.mp hw
+    obtain ⟨hyY, hwZ⟩ := Set.mem_iUnion.mp hy
+    calc w ≤ sSup (Z y hyY) := le_sSup hwZ
+      _ = y := (hZsup y hyY).symm
+      _ ≤ sSup Y := le_sSup hyY
+
+/-- Mereological overlap: a non-null common part. -/
+def mOverlap (x y : B) : Prop := x ⊓ y ≠ ⊥
+
+/-- `Z⁺`: `Z` minus the null element. -/
+def plus (Z : Set B) : Set B := Z \ {⊥}
+
+/-- The `Z`-atoms: minimal elements of `Z⁺` (his ch. 2; relativized to
+    `Z`, not Boolean atoms). -/
+def atomsIn (Z : Set B) : Set B :=
+  {z ∈ plus Z | ∀ y ∈ plus Z, y ≤ z → y = z}
+
+/-- `Z` is atomistic: every element of `Z⁺` is the sum of the `Z`-atoms
+    below it (his `ATOM_{Z,b} = (b] ∩ ATOM_Z` and `b = ⊔ATOM_{Z,b}`). -/
+def Atomistic (Z : Set B) : Prop :=
+  ∀ b ∈ plus Z, b = sSup (Set.Iic b ∩ atomsIn Z)
+
+/-- In a ⊥-free disjoint set everything is minimal: `ATOM_Z = Z`
+    (his §6.1.2 Lemma, step 2: a disjoint base is its own set of
+    base-atoms). -/
+theorem atomsIn_eq_of_disjoint {Z : Set B} (hZ : DisjointPred mOverlap Z)
+    (hbot : ⊥ ∉ Z) : atomsIn Z = Z := by
+  ext z
+  constructor
+  · rintro ⟨⟨hz, _⟩, _⟩
+    exact hz
+  · intro hz
+    have hzbot : z ∉ ({⊥} : Set B) :=
+      fun h => hbot (Set.mem_singleton_iff.mp h ▸ hz)
+    refine ⟨⟨hz, hzbot⟩, ?_⟩
+    rintro y ⟨hy, hybot⟩ hle
+    by_contra hne
+    refine hZ ⟨y, hy, z, hz, hne, ?_⟩
+    show y ⊓ z ≠ ⊥
+    rw [inf_eq_left.mpr hle]
+    exact fun h => hybot (Set.mem_singleton_iff.mpr h)
+
+/-! ### Counting from disjointness (his ch. 5)
+
+Mountain semantics counts in terms of Boolean atoms; Iceberg semantics
+observes that **disjointness** of the base is what makes counting
+correct. The distribution set `D_Z(x) = (x] ∩ Z` recovers `x` exactly
+when `Z` is disjoint — by frame distributivity, an element of a disjoint
+`Z` is below a sum of `Z`-elements only by being one of them. -/
+
+/-- The distribution set `D_Z(x) = (x] ∩ Z` (his §5.2). -/
+def partsIn (Z : Set B) (x : B) : Set B := {z ∈ Z | z ≤ x}
+
+/-- **Membership in a sum is membership in the summands** (for disjoint,
+    ⊥-free `Z`): `z ≤ ⊔Y ↔ z ∈ Y`. The frame law
+    `z ⊓ ⊔Y = ⨆ y ∈ Y, z ⊓ y` reduces a stray `z` to a sum of nulls. -/
+theorem mem_iff_le_sSup_of_disjoint {Z Y : Set B}
+    (hZ : DisjointPred mOverlap Z) (hbot : ⊥ ∉ Z) (hY : Y ⊆ Z)
+    {z : B} (hz : z ∈ Z) : z ≤ sSup Y ↔ z ∈ Y := by
+  refine ⟨fun hle => ?_, fun h => le_sSup h⟩
+  by_contra hzY
+  have hzbot : z ≠ ⊥ := fun h => hbot (h ▸ hz)
+  apply hzbot
+  have h1 : z = z ⊓ sSup Y := (inf_eq_left.mpr hle).symm
+  rw [inf_sSup_eq] at h1
+  rw [h1]
+  refine le_antisymm (iSup_le fun y => iSup_le fun hy => le_of_eq ?_) bot_le
+  by_contra hne
+  exact hZ ⟨z, hz, y, hY hy, fun he => hzY (he ▸ hy), hne⟩
+
+/-- The distribution set of a sum of `Z`-elements is exactly the set
+    summed: counting reads the parts off correctly. -/
+theorem partsIn_sSup {Z Y : Set B} (hZ : DisjointPred mOverlap Z)
+    (hbot : ⊥ ∉ Z) (hY : Y ⊆ Z) : partsIn Z (sSup Y) = Y := by
+  ext z
+  simp only [partsIn, Set.mem_sep_iff]
+  constructor
+  · rintro ⟨hz, hle⟩
+    exact (mem_iff_le_sSup_of_disjoint hZ hbot hY hz).mp hle
+  · intro hz
+    exact ⟨hY hz, le_sSup hz⟩
+
+/-- Every element of `*Z` is the sum of its distribution set. -/
+theorem sSup_partsIn {Z : Set B} (hZ : DisjointPred mOverlap Z)
+    (hbot : ⊥ ∉ Z) {x : B} (hx : x ∈ star Z) :
+    sSup (partsIn Z x) = x := by
+  obtain ⟨Y, hY, rfl⟩ := hx
+  rw [partsIn_sSup hZ hbot hY]
+
+/-- Distribution is injective on `*Z`: a plurality is determined by what
+    it distributes to. **Disjointness, not atomicity, is what counting
+    needs** — the central claim of Iceberg semantics, as a theorem. -/
+theorem partsIn_injOn {Z : Set B} (hZ : DisjointPred mOverlap Z)
+    (hbot : ⊥ ∉ Z) : Set.InjOn (partsIn Z) (star Z) :=
+  fun x hx x' hx' h => by
+    rw [← sSup_partsIn hZ hbot hx, ← sSup_partsIn hZ hbot hx', h]
+
+/-- `card_Z(x) = |D_Z(x)|` (his §5.2; presupposes `Z` disjoint, which is
+    what `partsIn_injOn` certifies as sufficient). -/
+noncomputable def card (Z : Set B) (x : B) : ℕ := (partsIn Z x).ncard
+
+/-! ### I-sets and count – mass – neat – mess (his §6.1) -/
+
+/-- An i-set: a body and a base that generates it under sum
+    (his §5.1/§6.1.2: `body(X) ⊆ *base(X)` and `⊔body(X) = ⊔base(X)`). -/
+structure ISet (B : Type*) [CompleteBooleanAlgebra B] where
+  /-- The standard denotation. -/
+  body : Set B
+  /-- The generating set: the things that count as one. -/
+  base : Set B
+  body_subset_star : body ⊆ star base
+  sSup_body_eq : sSup body = sSup base
+
+namespace ISet
+
+/-- The singular null i-set ⟨∅, ∅⟩ (his §6.1.2 Lemma). -/
+def nullEmpty : ISet B :=
+  ⟨∅, ∅, Set.empty_subset _, rfl⟩
+
+/-- The plural null i-set ⟨{⊥}, ∅⟩ (his §6.1.2 Lemma; `*∅ = {⊥}`). -/
+def nullBot : ISet B :=
+  ⟨{⊥}, ∅, by simp [star_empty], by rw [sSup_singleton, sSup_empty]⟩
+
+/-- An i-set is null iff its base is empty. -/
+def IsNull (X : ISet B) : Prop := X.base = ∅
+
+/-- Count: the base is disjoint (his §6.1.2). -/
+def IsCount (X : ISet B) : Prop := DisjointPred mOverlap X.base
+
+/-- Mass: if non-null then not count (his §6.1.2; the null i-sets are
+    both count and mass). -/
+def IsMass (X : ISet B) : Prop := ¬X.IsNull → ¬X.IsCount
+
+/-- Neat: the base is atomistic with disjoint base-atoms — the book's
+    §6.1.2 definition, which explicitly replaces the base-atomicity of
+    [landman-2011]/[landman-2016] by base-atomisticity. -/
+def IsNeat (X : ISet B) : Prop :=
+  Atomistic X.base ∧ DisjointPred mOverlap (atomsIn X.base)
+
+/-- Mess: if non-null then not neat. -/
+def IsMess (X : ISet B) : Prop := ¬X.IsNull → ¬X.IsNeat
+
+/-- An empty-based i-set has body `∅` or `{⊥}`: the two null i-sets are
+    the only ones (his §6.1.2 Lemma). -/
+theorem body_eq_of_base_empty (X : ISet B) (h : X.base = ∅) :
+    X.body = ∅ ∨ X.body = {⊥} := by
+  have hsub : X.body ⊆ {⊥} := by
+    rw [← star_empty, ← h]
+    exact X.body_subset_star
+  exact Set.subset_singleton_iff_eq.mp hsub
+
+/-- **Count i-sets are neat** (his §6.1.2 Lemma, claim 2): a ⊥-free
+    disjoint base is its own set of base-atoms, and trivially
+    atomistic. -/
+theorem IsCount.isNeat {X : ISet B} (hX : X.IsCount)
+    (hbot : ⊥ ∉ X.base) : X.IsNeat := by
+  have hatoms : atomsIn X.base = X.base := atomsIn_eq_of_disjoint hX hbot
+  constructor
+  · intro b hb
+    rw [hatoms]
+    exact le_antisymm (le_sSup ⟨le_refl b, hb.1⟩) (sSup_le fun y hy => hy.1)
+  · rw [hatoms]
+    exact hX
+
+/-! ### The Head Principle (his §5.3)
+
+`base(α) = (body(α)] ∩ base(H)`: the base of a complex NP is the base of
+its *head*, restricted to the parts of the complex's body. The
+accompanying Lemma is one line — `base(α) ⊆ base(H)` — and gives the
+compositionality of mass/count: a complex NP with a count head is
+count. -/
+
+/-- The head-principle base: the head's base elements that are parts of
+    the complex's body. -/
+def headBase (bodyC : Set B) (H : ISet B) : Set B :=
+  {b ∈ H.base | b ≤ sSup bodyC}
+
+/-- His §5.3 Lemma, verbatim: "If `base(H)` is disjoint then `base(α)` is
+    disjoint. Proof: `base(α) ⊆ base(H)`. ∎" -/
+theorem headBase_disjoint {bodyC : Set B} {H : ISet B}
+    (hH : DisjointPred mOverlap H.base) :
+    DisjointPred mOverlap (headBase bodyC H) :=
+  Mereology.DisjointPred.anti mOverlap (Set.sep_subset _ _) hH
+
+/-! ### Pluralization (his §5.4)
+
+`plur(P) = ⟨*body(P), (*body(P)] ∩ base(P)⟩`. Since
+`⊔*body(P) = ⊔body(P) = ⊔base(P)`, the head-principle restriction is
+vacuous: pluralization leaves the base fixed — in the worked *white cats*
+example, `base(WHITE CATS) = base(WHITE CAT) = CAT ∩ WHITE`. -/
+
+/-- Pluralization: close the body under sum; the base stays. -/
+def plur (P : ISet B) : ISet B where
+  body := star P.body
+  base := P.base
+  body_subset_star := fun b hb => by
+    rw [← star_star (X := P.base)]
+    exact star_mono P.body_subset_star hb
+  sSup_body_eq := by rw [sSup_star_eq, P.sSup_body_eq]
+
+/-- The book's `(*body(P)] ∩ base(P)` is just `base(P)`: every base
+    element is a part of the total body, so the head-principle
+    restriction is vacuous under pluralization. -/
+theorem plur_base_eq_headBase (P : ISet B) :
+    (P.plur).base = headBase (P.plur).body P := by
+  unfold plur headBase
+  ext b
+  simp only [Set.mem_sep_iff, iff_self_and]
+  intro hb
+  rw [sSup_star_eq, P.sSup_body_eq]
+  exact le_sSup hb
+
+/-- Pluralization preserves countness: the mass/count nature of a noun is
+    unaffected by number morphology — it lives in the base. -/
+theorem plur_isCount {P : ISet B} (hP : P.IsCount) : (P.plur).IsCount :=
+  hP
+
+end ISet
+
+/-! ### The noun classes (his ch. 7–8)
+
+Number-neutral neat mass nouns (*poultry*, *livestock*, §7.1): the
+singular/plural distinction is not articulated — `⟨*X₀, *X₀⟩` for a
+disjoint `X₀` (his `DOM-BIRD`). The base overlaps (so: mass), but its
+atoms are exactly `X₀` (so: neat). Mess mass nouns (*water*, §8.1.5): the
+base has no minimal elements at all, so atomisticity fails outright. -/
+
+/-- A sum-closure properly overlaps once there are two distinct ⊥-free
+    generators: `x₀` and `x₀ ⊔ x₁` are distinct members of `*X₀` sharing
+    the part `x₀`. Hence number-neutral nouns are **mass**. -/
+theorem star_overlapPred {X₀ : Set B} (hbot : ⊥ ∉ X₀)
+    (hdisj : DisjointPred mOverlap X₀) {x₀ x₁ : B}
+    (h₀ : x₀ ∈ X₀) (h₁ : x₁ ∈ X₀) (hne : x₀ ≠ x₁) :
+    OverlapPred mOverlap (star X₀) := by
+  have hsup : x₀ ⊔ x₁ ∈ star X₀ := by
+    refine ⟨{x₀, x₁}, ?_, sSup_pair.symm⟩
+    rintro y (rfl | rfl) <;> assumption
+  refine ⟨x₀, subset_star h₀, x₀ ⊔ x₁, hsup, ?_, ?_⟩
+  · intro he
+    have hle : x₁ ≤ x₀ := he ▸ le_sup_right
+    refine hdisj ⟨x₁, h₁, x₀, h₀, fun h => hne h.symm, ?_⟩
+    show x₁ ⊓ x₀ ≠ ⊥
+    rw [inf_eq_left.mpr hle]
+    exact fun h => hbot (h ▸ h₁)
+  · show x₀ ⊓ (x₀ ⊔ x₁) ≠ ⊥
+    rw [inf_sup_self]
+    exact fun h => hbot (h ▸ h₀)
+
+/-- The number-neutral neat mass i-set `⟨*X₀, *X₀⟩` (his §7.1: *poultry*
+    with `X₀ = DOM-BIRD`). -/
+def numberNeutral (X₀ : Set B) : ISet B where
+  body := star X₀
+  base := star X₀
+  body_subset_star := subset_star
+  sSup_body_eq := rfl
+
+/-- The atoms of a sum-closure are the generators: for ⊥-free disjoint
+    `X₀`, `ATOM_{*X₀} = X₀`. -/
+theorem atomsIn_star_of_disjoint {X₀ : Set B}
+    (hdisj : DisjointPred mOverlap X₀) (hbot : ⊥ ∉ X₀) :
+    atomsIn (star X₀) = X₀ := by
+  ext z
+  constructor
+  · rintro ⟨⟨hzstar, hzbot⟩, hmin⟩
+    obtain ⟨Y, hY, rfl⟩ := hzstar
+    obtain ⟨y, hyY, hybot⟩ : ∃ y ∈ Y, y ≠ ⊥ := by
+      by_contra hcon
+      push_neg at hcon
+      exact hzbot (Set.mem_singleton_iff.mpr (sSup_eq_bot.mpr hcon))
+    have heq : y = sSup Y :=
+      hmin y ⟨subset_star (hY hyY),
+        fun h => hybot (Set.mem_singleton_iff.mp h)⟩ (le_sSup hyY)
+    exact heq ▸ hY hyY
+  · intro hz
+    have hzbot : z ∉ ({⊥} : Set B) :=
+      fun h => hbot (Set.mem_singleton_iff.mp h ▸ hz)
+    refine ⟨⟨subset_star hz, hzbot⟩, ?_⟩
+    rintro y ⟨hystar, hybot⟩ hle
+    obtain ⟨Y, hY, rfl⟩ := hystar
+    obtain ⟨x', hx'Y, hx'bot⟩ : ∃ x' ∈ Y, x' ≠ ⊥ := by
+      by_contra hcon
+      push_neg at hcon
+      exact hybot (Set.mem_singleton_iff.mpr (sSup_eq_bot.mpr hcon))
+    have hx'le : x' ≤ z := le_trans (le_sSup hx'Y) hle
+    have hx'z : x' = z := by
+      by_contra hne
+      refine hdisj ⟨x', hY hx'Y, z, hz, hne, ?_⟩
+      show x' ⊓ z ≠ ⊥
+      rw [inf_eq_left.mpr hx'le]
+      exact hx'bot
+    exact le_antisymm hle (hx'z ▸ le_sSup hx'Y)
+
+/-- Number-neutral nouns are **neat**: the base `*X₀` overlaps, but it is
+    atomistic over the disjoint generator set `X₀` (his §7.1: *poultry*
+    is a neat mass i-set). -/
+theorem numberNeutral_isNeat {X₀ : Set B}
+    (hdisj : DisjointPred mOverlap X₀) (hbot : ⊥ ∉ X₀) :
+    (numberNeutral X₀).IsNeat := by
+  have hatoms : atomsIn (star X₀) = X₀ :=
+    atomsIn_star_of_disjoint hdisj hbot
+  refine ⟨?_, ?_⟩
+  · rintro b ⟨hbstar, hbbot⟩
+    obtain ⟨Y, hY, rfl⟩ := hbstar
+    show sSup Y = sSup (Set.Iic (sSup Y) ∩ atomsIn (star X₀))
+    rw [hatoms]
+    refine le_antisymm (sSup_le fun y hy => ?_) (sSup_le ?_)
+    · rcases eq_or_ne y ⊥ with rfl | hyne
+      · exact bot_le
+      · exact le_sSup ⟨le_sSup hy, hY hy⟩
+    · rintro y ⟨hyle, _⟩
+      exact hyle
+  · show DisjointPred mOverlap (atomsIn (star X₀))
+    rw [hatoms]
+    exact hdisj
+
+/-- A non-trivial atomless base is **mess** (his §8.1.5: *water*'s base
+    has no minimal elements — space can always be shaved off a region
+    containing a molecule — so atomisticity fails). -/
+theorem not_neat_of_atomless {X : ISet B} (h : atomsIn X.base = ∅)
+    {b : B} (hb : b ∈ X.base) (hbne : b ≠ ⊥) : ¬X.IsNeat := by
+  rintro ⟨hatomistic, -⟩
+  have hbplus : b ∈ plus X.base :=
+    ⟨hb, fun h' => hbne (Set.mem_singleton_iff.mp h')⟩
+  have := hatomistic b hbplus
+  rw [h, Set.inter_empty, sSup_empty] at this
+  exact hbne this
+
+end Landman2020

--- a/Linglib/Studies/SuttonFilip2021.lean
+++ b/Linglib/Studies/SuttonFilip2021.lean
@@ -41,7 +41,11 @@ lacks one, counts everything — cf. `Grimm2018.yudjaClassify`).
 ## Main declarations
 
 * `OverlapPred`/`IsMaxDisjointIn`/`nullSchema` — the schema machinery over
-  an arbitrary overlap relation.
+  an arbitrary overlap relation. The disjoint-counting-base thesis and the
+  multiple-perspectives ("variants") idea this packages originate with
+  [landman-2011] and [landman-2016]; the chapter's own contribution is the
+  null schema `𝒮₀` and the unified `𝒪`/`𝒮ᵢ` mechanism. The machinery is a
+  graduation candidate when a Landman-anchored study lands.
 * `overlapPred_union_of_maxDisjoint_ne` — the load-bearing generic fact:
   the union of two *distinct* maximal disjoint subsets overlaps. Hence
   `nullSchema`-saturated entries are mass whenever individuation is
@@ -51,8 +55,10 @@ lacks one, counts everything — cf. `Grimm2018.yudjaClassify`).
   graduated individuation scale (`Features/Individuation.lean`), with the
   junction theorems: the count option *ascends* the scale
   (`count_option_monotone`) and the mass option *descends* it
-  (`mass_option_antitone`) — [grimm-2018]'s Table 20 in `[±O, ±S]`
-  clothing.
+  (`mass_option_antitone`). Ordering Table 9.1 by [grimm-2018]'s scale is
+  this study's bridge, not the chapter's (it cites [grimm-2012] and Grimm &
+  Levin 2017, not [grimm-2018]); the theorems show the two frameworks'
+  landscapes coincide.
 * A concrete furniture/rice model on nonempty `Finset`s: *furniture*'s
   identified units overlap (table vs. vanity), *rice*'s grains are disjoint
   in `baspred` yet its counting base overlaps — the accessibility puzzle's
@@ -67,7 +73,7 @@ lacks one, counts everything — cf. `Grimm2018.yudjaClassify`).
 * The cluster/MSSC content of granular `baspred` frames is [grimm-2012]'s
   mereotopology — `Core/Mereotopology.lean`.
 * Their counting condition (cardinality only over disjoint bases, their
-  (A1) and Landman's overlap thesis) is the semantic ground for why
+  (A1), after [landman-2011]'s overlap thesis) is the semantic ground for why
   countability classes, not `Number` values, carry the count/mass
   distinction (`Features/Number/Basic.lean`).
 -/
@@ -85,7 +91,9 @@ models below use nonempty `Finset` intersection). A predicate is
 
 variable {α : Type*} (ov : α → α → Prop)
 
-/-- (17): two distinct members of `P` share a part. -/
+/-- (17): two distinct members of `P` share a part. (Their formula omits
+    distinctness, under which any inhabited predicate self-overlaps via
+    `x ∘ x`; we state the intended reading.) -/
 def OverlapPred (P : Set α) : Prop :=
   ∃ x ∈ P, ∃ y ∈ P, x ≠ y ∧ ov x y
 
@@ -99,8 +107,8 @@ theorem overlapPred_mono {P Q : Set α} (h : P ⊆ Q)
   ⟨x, h hx, y, h hy, hne, hov⟩
 
 /-- A maximally disjoint subset of `P`: disjoint, and unextendable within
-    `P` (Landman's individuation perspectives; the range of the schemas
-    `𝒮ᵢ`). -/
+    `P` ([landman-2011]'s variants — individuation perspectives; the range
+    of the schemas `𝒮ᵢ`). -/
 def IsMaxDisjointIn (D P : Set α) : Prop :=
   D ⊆ P ∧ DisjointPred ov D ∧ ∀ x ∈ P, x ∉ D → OverlapPred ov (insert x D)
 

--- a/Linglib/Studies/SuttonFilip2021.lean
+++ b/Linglib/Studies/SuttonFilip2021.lean
@@ -1,6 +1,7 @@
 import Mathlib.Data.Fintype.Powerset
 import Linglib.Features.Individuation
 import Linglib.Features.MassCount
+import Linglib.Core.Mereology
 
 /-!
 # Sutton & Filip (2021) — The Count/Mass Distinction for Granular Nouns
@@ -84,81 +85,16 @@ namespace SuttonFilip2021
 
 /-! ### Overlap, disjointness, and individuation schemas
 
-Their (16)–(18), stated over an arbitrary overlap relation `ov` (the
-mereological instantiation is `∃ z ≠ ⊥, z ⊑ x ∧ z ⊑ y`; the concrete
-models below use nonempty `Finset` intersection). A predicate is
-*overlapping* if two distinct members overlap; *disjoint* otherwise. -/
+Their (16)–(18): the schema machinery (`Mereology.OverlapPred`,
+`Mereology.IsMaxDisjointIn`, `Mereology.nullSchema` for `𝒮₀`, their (32))
+lives in `Core/Mereology.lean`, shared with [landman-2020]
+(`Studies/Landman2020.lean`), whose disjointness thesis it packages.
+A predicate is *overlapping* if two distinct members overlap (their (17)
+omits the distinctness, under which any inhabited predicate self-overlaps
+via `x ∘ x`; the substrate states the intended reading). -/
 
-variable {α : Type*} (ov : α → α → Prop)
-
-/-- (17): two distinct members of `P` share a part. (Their formula omits
-    distinctness, under which any inhabited predicate self-overlaps via
-    `x ∘ x`; we state the intended reading.) -/
-def OverlapPred (P : Set α) : Prop :=
-  ∃ x ∈ P, ∃ y ∈ P, x ≠ y ∧ ov x y
-
-/-- (18): `DISJOINT(P) ↔ ¬OVERLAP(P)`. -/
-def DisjointPred (P : Set α) : Prop := ¬ OverlapPred ov P
-
-/-- `OverlapPred` is monotone under inclusion. -/
-theorem overlapPred_mono {P Q : Set α} (h : P ⊆ Q)
-    (hP : OverlapPred ov P) : OverlapPred ov Q :=
-  let ⟨x, hx, y, hy, hne, hov⟩ := hP
-  ⟨x, h hx, y, h hy, hne, hov⟩
-
-/-- A maximally disjoint subset of `P`: disjoint, and unextendable within
-    `P` ([landman-2011]'s variants — individuation perspectives; the range
-    of the schemas `𝒮ᵢ`). -/
-def IsMaxDisjointIn (D P : Set α) : Prop :=
-  D ⊆ P ∧ DisjointPred ov D ∧ ∀ x ∈ P, x ∉ D → OverlapPred ov (insert x D)
-
-/-- The null individuation schema `𝒮₀` ((32)): the union of *all*
-    maximally disjoint subsets — what counts as 'one' under any
-    perspective. -/
-def nullSchema (P : Set α) : Set α :=
-  {x | ∃ D, IsMaxDisjointIn ov D P ∧ x ∈ D}
-
-/-- **The union of two distinct maximal disjoint subsets overlaps.** The
-    generic fact behind mass-hood by perspectival individuation: if `x`
-    distinguishes `D₂` from `D₁`, then `D₁`'s maximality makes
-    `insert x D₁` overlap, and the offending pair lies in `D₁ ∪ D₂`. -/
-theorem overlapPred_union_of_maxDisjoint_ne {D₁ D₂ P : Set α}
-    (h₁ : IsMaxDisjointIn ov D₁ P) (h₂ : IsMaxDisjointIn ov D₂ P)
-    (hne : D₁ ≠ D₂) : OverlapPred ov (D₁ ∪ D₂) := by
-  obtain ⟨x, hx₂, hx₁⟩ | ⟨x, hx₁, hx₂⟩ :
-      (∃ x, x ∈ D₂ ∧ x ∉ D₁) ∨ (∃ x, x ∈ D₁ ∧ x ∉ D₂) := by
-    by_contra hcon
-    push_neg at hcon
-    exact hne (Set.Subset.antisymm hcon.2 hcon.1)
-  · exact overlapPred_mono ov
-      (Set.insert_subset_iff.mpr ⟨Or.inr hx₂, fun a ha => Or.inl ha⟩)
-      (h₁.2.2 x (h₂.1 hx₂) hx₁)
-  · exact overlapPred_mono ov
-      (Set.insert_subset_iff.mpr ⟨Or.inl hx₁, fun a ha => Or.inr ha⟩)
-      (h₂.2.2 x (h₁.1 hx₁) hx₂)
-
-/-- If individuation is perspectival — two distinct maximal disjoint
-    subsets exist — the null schema yields an overlapping counting base:
-    `𝒮₀`-saturated entries are mass ((32) and their §9.4.3). -/
-theorem overlapPred_nullSchema {D₁ D₂ P : Set α}
-    (h₁ : IsMaxDisjointIn ov D₁ P) (h₂ : IsMaxDisjointIn ov D₂ P)
-    (hne : D₁ ≠ D₂) : OverlapPred ov (nullSchema ov P) :=
-  overlapPred_mono ov
-    (Set.union_subset (fun a ha => ⟨D₁, h₁, ha⟩) (fun a ha => ⟨D₂, h₂, ha⟩))
-    (overlapPred_union_of_maxDisjoint_ne ov h₁ h₂ hne)
-
-/-- For an already-disjoint predicate there is exactly one perspective:
-    the null schema returns the predicate itself. Prototypical objects
-    (*cat*) are therefore stably count — `(𝒮ᵢ(𝒪(cat)))` does not vary
-    with `i` (their §9.4.3). -/
-theorem nullSchema_eq_of_disjoint {P : Set α} (h : DisjointPred ov P) :
-    nullSchema ov P = P := by
-  ext x
-  constructor
-  · rintro ⟨D, hD, hx⟩
-    exact hD.1 hx
-  · intro hx
-    refine ⟨P, ⟨Set.Subset.rfl, h, fun y hy hny => absurd hy hny⟩, hx⟩
+open Mereology (OverlapPred DisjointPred IsMaxDisjointIn nullSchema
+  overlapPred_nullSchema)
 
 /-! ### The `[±O, ±S]` categorization and Table 9.1
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23441,6 +23441,32 @@
   sources   = {Features/Number/Basic.lean;Studies/Harbour2014.lean}
 }
 
+@article{landman-2011,
+  author    = {Landman, Fred},
+  year      = {2011},
+  title     = {Count Nouns -- Mass Nouns -- Neat Nouns -- Mess Nouns},
+  journal   = {The Baltic International Yearbook of Cognition, Logic and Communication},
+  volume    = {6},
+  pages     = {1--67},
+  subfield  = {semantics/countability},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/SuttonFilip2021.lean}
+}
+
+@article{landman-2016,
+  author    = {Landman, Fred},
+  year      = {2016},
+  title     = {Iceberg Semantics for Count Nouns and Mass Nouns: The Evidence from Portions},
+  journal   = {The Baltic International Yearbook of Cognition, Logic and Communication},
+  volume    = {11},
+  pages     = {1--48},
+  subfield  = {semantics/countability},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/SuttonFilip2021.lean}
+}
+
 @incollection{sutton-filip-2021,
   author    = {Sutton, Peter R. and Filip, Hana},
   year      = {2021},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23441,6 +23441,21 @@
   sources   = {Features/Number/Basic.lean;Studies/Harbour2014.lean}
 }
 
+@book{landman-2020,
+  author    = {Landman, Fred},
+  year      = {2020},
+  title     = {Iceberg Semantics for Mass Nouns and Count Nouns: A New Framework for Boolean Semantics},
+  series    = {Studies in Linguistics and Philosophy},
+  volume    = {105},
+  publisher = {Springer},
+  address   = {Cham},
+  doi       = {10.1007/978-3-030-42711-5},
+  subfield  = {semantics/countability},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Studies/Landman2020.lean}
+}
+
 @article{landman-2011,
   author    = {Landman, Fred},
   year      = {2011},


### PR DESCRIPTION
`Studies/Landman2020.lean` — the Iceberg monograph (Springer SLP 105), fully generic over a complete Boolean algebra: i-sets ⟨body, base⟩, the null i-sets and their characterization, **counting-from-disjointness as theorems** (`mem_iff_le_sSup_of_disjoint` via the frame law; `sSup_partsIn`/`partsIn_injOn` — disjointness, not atomicity, is what counting needs), the §6.1.2 Lemma count → neat (under the book's base-atomisticity, which deliberately replaces Landman 2011/2016's base-atomicity), the §5.3 Head Principle with its one-line compositionality lemma, `plur` fixing the base, and the noun classes (number-neutral neat mass *poultry*; atomless mess *water*).

- First commit recovers the Landman-provenance docs commit that the #138 squash missed.
- Second commit graduates the individuation-schema machinery (`OverlapPred`/`DisjointPred`/`IsMaxDisjointIn`/`nullSchema`) from `Studies/SuttonFilip2021.lean` to `Core/Mereology` — second consumer reached.