### PR TITLE
feat(Features): Number.interp, lattice semantics for the values

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -341,6 +341,7 @@ import Linglib.Features.PhiKernel
 import Linglib.Features.Number.Basic
 import Linglib.Features.Number.Capabilities
 import Linglib.Features.Number.Decomposition
+import Linglib.Features.Number.Interp
 import Linglib.Features.Number.Resolve
 import Linglib.Core.CoreConcept
 import Linglib.Morphology.MorphRule

--- a/Linglib/Features/Number/Decomposition.lean
+++ b/Linglib/Features/Number/Decomposition.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Number.Basic
+import Linglib.Features.Number.Interp
 import Linglib.Features.ContainmentPair
 
 /-!
@@ -197,6 +198,16 @@ by a join operation and a finite domain, making the lattice-theoretic
 grounding computationally verifiable. They are the `Bool` counterparts
 of `Mereology.Atom` and minimality-in-region. -/
 
+/-! The decidable layer below mirrors the general lattice semantics of
+`Features/Number/Interp.lean` on finite, list-enumerated domains: the
+`Bool`-valued `isAtom` is domain-relative minimality (`Number.minimalIn
+(· ∈ domain)` — `isAtom_iff_minimalIn`), `isMinimalNonAtom` mirrors
+minimality over the non-atoms (`isMinimalNonAtom_iff_minimalIn`), and
+`isJoinCompleteIn` mirrors `Number.additiveIn`
+(`isJoinCompleteIn_iff_additiveIn`). `Interp`'s `Mereology.Atom` is
+global minimality; the two agree when the domain enumerates a
+downward-closed region of `D⁺`. -/
+
 /-- Powerset lattice join (bitwise OR). Atoms are powers of 2;
     sums are bitwise OR of their atoms. Used across the lattice
     sections below and by `Number.resolve` for lattice verification. -/
@@ -226,6 +237,53 @@ def isMinimalNonAtom {D : Type} [DecidableEq D]
   let nonAtoms := domain.filter (! isAtom join domain ·)
   nonAtoms.contains x &&
   nonAtoms.all fun y => y == x || !(joinLE join y x)
+
+/-- The `Bool` atom test is domain-relative minimality: the decidable
+    mirror of `Number.minimalIn (· ∈ domain)` for the lattice join. -/
+theorem isAtom_iff_minimalIn {D : Type} [SemilatticeSup D] [DecidableEq D]
+    (domain : List D) (x : D) :
+    isAtom (· ⊔ ·) domain x = true ↔ minimalIn (· ∈ domain) x := by
+  simp only [isAtom, joinLE, minimalIn, Bool.and_eq_true, List.contains_iff,
+    List.all_eq_true, Bool.or_eq_true, beq_iff_eq, Bool.not_eq_true',
+    beq_eq_false_iff_ne, ne_eq]
+  refine and_congr_right fun _ => ?_
+  constructor
+  · intro h y hy hyx
+    rcases h y hy with rfl | hn
+    · rfl
+    · exact absurd (sup_eq_right.mpr hyx) hn
+  · intro h y hy
+    by_cases hyx : y ≤ x
+    · exact Or.inl (h y hy hyx)
+    · exact Or.inr fun he => hyx (sup_eq_right.mp he)
+
+/-- The `Bool` minimal-non-atom test mirrors `Number.minimalIn` over the
+    domain's non-atoms — the region `interp` assigns to the dual. -/
+theorem isMinimalNonAtom_iff_minimalIn {D : Type} [SemilatticeSup D]
+    [DecidableEq D] (domain : List D) (x : D) :
+    isMinimalNonAtom (· ⊔ ·) domain x = true ↔
+      minimalIn (fun y => y ∈ domain ∧ ¬minimalIn (· ∈ domain) y) x := by
+  have hmem : ∀ y : D,
+      (y ∈ domain.filter (! isAtom (· ⊔ ·) domain ·)) ↔
+        (y ∈ domain ∧ ¬minimalIn (· ∈ domain) y) := by
+    intro y
+    rw [List.mem_filter, Bool.not_eq_true', ← isAtom_iff_minimalIn,
+      Bool.not_eq_true]
+  simp only [isMinimalNonAtom, joinLE, minimalIn, Bool.and_eq_true,
+    List.contains_iff, List.all_eq_true, Bool.or_eq_true, beq_iff_eq,
+    Bool.not_eq_true', beq_eq_false_iff_ne, ne_eq]
+  rw [and_congr_left fun _ => hmem x]
+  refine and_congr_right fun _ => ?_
+  constructor
+  · intro h y hy hyx
+    rcases h y ((hmem y).mpr hy) with rfl | hn
+    · rfl
+    · exact absurd (sup_eq_right.mpr hyx) hn
+  · intro h y hy
+    by_cases hyx : y ≤ x
+    · exact Or.inl (h y ((hmem y).mp hy) hyx)
+    · exact Or.inr fun he => hyx (sup_eq_right.mp he)
+
 
 /-- Convert lattice membership to number features using join structure.
     Atoms → singular, minimal non-atoms → dual, others → plural. -/
@@ -309,6 +367,16 @@ def isJoinCompleteIn {D : Type} [DecidableEq D]
 def isRegionJoinComplete {D : Type} [DecidableEq D]
     (join : D → D → D) (region : List D) : Bool :=
   region.all fun x => isJoinCompleteIn join region x
+
+/-- The `Bool` join-completeness test mirrors `Number.additiveIn` on the
+    enumerated region. -/
+theorem isJoinCompleteIn_iff_additiveIn {D : Type} [SemilatticeSup D]
+    [DecidableEq D] (region : List D) (x : D) :
+    isJoinCompleteIn (· ⊔ ·) region x = true ↔
+      additiveIn (· ∈ region) x := by
+  simp only [isJoinCompleteIn, additiveIn, Bool.and_eq_true,
+    List.contains_iff, List.all_eq_true]
+
 
 /-! ### Additive feature — powerset lattice examples
 

--- a/Linglib/Features/Number/Interp.lean
+++ b/Linglib/Features/Number/Interp.lean
@@ -1,0 +1,159 @@
+import Linglib.Features.Number.Basic
+import Linglib.Core.Mereology
+
+/-!
+# Number — lattice semantics for the values
+[harbour-2014] [link-1983]
+
+The denotation of a number value as a predicate restrictor over a
+join-semilattice of individuals ([link-1983]): `Number.interp P n` is the
+region of `P`'s lattice the value `n` picks out, composed from the
+feature semantics of [harbour-2014] —
+
+- **(20)** `[±atomic]` = λx. (¬)atom(x) — `Mereology.Atom`;
+- **(21)** `[±minimal]` = minimality in a region — `Number.minimalIn`;
+- **(10)** `[±additive]` = join-completeness in a region —
+  `Number.additiveIn`.
+
+The exact values (singular … unit augmented) are compositions of (20)
+and (21) over `P` alone; the approximative values (paucal, greater
+paucal, greater plural, global plural) additionally require a
+conventionalized cut — a contextually supplied subregion ([harbour-2014]
+(14), the sociosemantic convention) — so `interp` returns `none` for
+them: their semantics is `additiveIn` relative to a cut the lexicon does
+not fix.
+
+This is the *featural* characterization of the values (the regions
+`latticeToFeatures` classifies, `Features/Number/Decomposition.lean`,
+which hosts the decidable mirrors and the equivalence lemmas). The
+inclusive/exclusive interpretation of the plural in assertion is a
+separate, pragmatic layer ([corbett-2000] Ch 7; Sauerland-style
+competition) and is deliberately not encoded here.
+
+Because the domain is any `SemilatticeSup`, the same operator interprets
+*verbal* number: pluractionality is `interp` at the event lattice
+(`Phenomena/Plurals/VerbalNumber.lean`), and `[+additive]`'s identity
+with cumulativity (`additive_subregion_is_cum`, `Mereology.CUM`) is the
+number–aspect–telicity nexus of [harbour-2014] §4.4.
+
+The `[±minimal]`/`[±additive]` predicates were first stated in
+`Syntax/Minimalist/Phi/Recursion.lean` and graduate here as the general
+substrate; Recursion consumes them for the feature-recursion theory.
+-/
+
+set_option autoImplicit false
+
+namespace Number
+
+variable {D : Type*} [SemilatticeSup D]
+
+/-! ### The feature semantics ([harbour-2014] (20), (21), (10)) -/
+
+/-- `[+minimal]` in region `P`: `x` is a minimal element of `P` under `≤`
+    ([harbour-2014] (21): `x` has no proper `P`-part below it). -/
+def minimalIn (P : D → Prop) (x : D) : Prop :=
+  P x ∧ ∀ y, P y → y ≤ x → y = x
+
+/-- `[+additive]` in region `Q`: `x` is join-complete in `Q`
+    ([harbour-2014] (10): ∀ y ∈ Q, x ⊔ y ∈ Q). -/
+def additiveIn (Q : D → Prop) (x : D) : Prop :=
+  Q x ∧ ∀ y, Q y → Q (x ⊔ y)
+
+/-- The `[+additive]` region is closed under join: joining two
+    `[+additive]` elements gives another. -/
+theorem additiveIn_sup {Q : D → Prop}
+    {x y : D} (hx : additiveIn Q x) (hy : additiveIn Q y) :
+    additiveIn Q (x ⊔ y) := by
+  refine ⟨hx.2 y hy.1, fun z hz => ?_⟩
+  rw [sup_assoc]
+  exact hx.2 (y ⊔ z) (hy.2 z hz)
+
+/-- Atoms are minimal in any region containing them: the lattice-theoretic
+    grounding of the containment `[+atomic] → [+minimal]`, and the reason
+    `[±atomic]` cannot undergo feature recursion ([harbour-2014] §4.2):
+    `[±minimal]` over an all-atom region selects all of it or nothing. -/
+theorem minimalIn_of_atom {P : D → Prop}
+    (hAllAtoms : ∀ x, P x → Mereology.Atom x)
+    {x : D} (hPx : P x) : minimalIn P x :=
+  ⟨hPx, fun y _ hle => hAllAtoms x hPx y hle⟩
+
+/-- The `[−minimal]` complement of an all-atom region is empty
+    ([harbour-2014] §4.2). -/
+theorem not_nonminimal_of_atoms {P : D → Prop}
+    (hAllAtoms : ∀ x, P x → Mereology.Atom x) (x : D) :
+    ¬(P x ∧ ¬minimalIn P x) :=
+  fun ⟨hPx, hNonMin⟩ => hNonMin (minimalIn_of_atom hAllAtoms hPx)
+
+/-- The `[+additive]` subregion is cumulative (`Mereology.CUM`): the
+    number–aspect–telicity nexus of [harbour-2014] §4.4 — mass nouns are
+    `[+additive]` (cumulative), telic predicates `[−additive]`
+    (quantized), with one feature governing both. -/
+theorem additive_subregion_is_cum (Q : D → Prop) :
+    Mereology.CUM (fun x => additiveIn Q x) :=
+  fun x y hx hy => additiveIn_sup hx hy
+
+/-! ### The value denotations -/
+
+/-- The non-atoms of `P`: `[−atomic]` restricted to `P`. -/
+def nonAtomsOf (P : D → Prop) : D → Prop :=
+  fun x => P x ∧ ¬Mereology.Atom x
+
+/-- The denotation of a number value over the region `P`, composed from
+    (20)/(21):
+
+    * `general` — non-committal: `P` itself;
+    * `singular` — the atoms of `P`;
+    * `dual` — the minimal non-atoms (`[−atomic +minimal]`);
+    * `plural` — the non-minimal non-atoms (`[−atomic −minimal]`, the
+      featural exclusive plural);
+    * `trial` — `[±minimal]` recursion: the minimal elements of the
+      plural region;
+    * `minimal` / `augmented` / `unitAugmented` — the `[±minimal]`-only
+      system and its recursion;
+    * approximative values — `none`: they are `additiveIn` relative to a
+      conventionalized cut the lexicon does not supply. -/
+def interp (P : D → Prop) : Number → Option (D → Prop)
+  | .general => some P
+  | .singular => some fun x => P x ∧ Mereology.Atom x
+  | .dual => some (minimalIn (nonAtomsOf P))
+  | .trial => some (minimalIn fun x => nonAtomsOf P x ∧ ¬minimalIn (nonAtomsOf P) x)
+  | .plural => some fun x => nonAtomsOf P x ∧ ¬minimalIn (nonAtomsOf P) x
+  | .minimal => some (minimalIn P)
+  | .augmented => some fun x => P x ∧ ¬minimalIn P x
+  | .unitAugmented => some (minimalIn fun x => P x ∧ ¬minimalIn P x)
+  | _ => none
+
+/-- The values `interp` defines are exactly the non-approximative,
+    in-system values together with `general`: the approximatives are the
+    cut-dependent ones. -/
+theorem interp_isSome_iff (P : D → Prop) (n : Number) :
+    (interp P n).isSome ↔
+      n ∉ ([.paucal, .greaterPaucal, .greaterPlural, .globalPlural] :
+        List Number) := by
+  cases n <;> simp [interp]
+
+/-- Singular entails minimal over any region: the value-level containment
+    `[+atomic] → [+minimal]`, derived from `minimalIn_of_atom` rather than
+    stipulated — the semantic ground of `Number.Features.WellFormed`
+    (`Features/Number/Decomposition.lean`). -/
+theorem singular_subset_minimal (P : D → Prop) {x : D}
+    (h : P x ∧ Mereology.Atom x) : minimalIn P x :=
+  ⟨h.1, fun y _ hle => h.2 y hle⟩
+
+/-- Dual and plural partition the non-atoms: every non-atom of `P` is
+    dual or plural, never both — the `[±minimal]` split of the
+    `[−atomic]` region. -/
+theorem dual_plural_partition (P : D → Prop) (x : D)
+    (hx : nonAtomsOf P x) :
+    (minimalIn (nonAtomsOf P) x ∨
+      (nonAtomsOf P x ∧ ¬minimalIn (nonAtomsOf P) x)) ∧
+    ¬(minimalIn (nonAtomsOf P) x ∧
+      (nonAtomsOf P x ∧ ¬minimalIn (nonAtomsOf P) x)) := by
+  constructor
+  · by_cases h : minimalIn (nonAtomsOf P) x
+    · exact Or.inl h
+    · exact Or.inr ⟨hx, h⟩
+  · rintro ⟨hmin, -, hnmin⟩
+    exact hnmin hmin
+
+end Number

--- a/Linglib/Phenomena/Plurals/VerbalNumber.lean
+++ b/Linglib/Phenomena/Plurals/VerbalNumber.lean
@@ -22,6 +22,11 @@ Key distinctions:
 WALS Feature 80A records verbal number and suppletion across 193
 languages. 159 have no verbal number; 34 have singular-plural pairs
 (with or without suppletion); 7 have sg-du-pl triples.
+
+Semantically, verbal number is the nominal operator at the event lattice:
+`Number.interp` (`Features/Number/Interp.lean`) is domain-polymorphic over
+any join-semilattice, so event-plurality readings are `interp` applied to
+event predicates rather than individual predicates.
 -/
 
 namespace VerbalNumber

--- a/Linglib/Studies/Corbett2000.lean
+++ b/Linglib/Studies/Corbett2000.lean
@@ -186,6 +186,12 @@ theorem all_augmented_implies_minimal :
 theorem all_unitAug_implies_augmented :
     ∀ ns ∈ allNumberSystems, ns.UnitAugImpliesAugmented := by decide
 
+/-- Every system the book records satisfies the *full* Table-1 universal
+    set ([harbour-2014]) — all eleven implications, not only the five
+    originally checked above. -/
+theorem allNumberSystems_wellFormed :
+    ∀ ns ∈ allNumberSystems, ns.WellFormed := by decide
+
 /-! ### Animacy Hierarchy and Number Marking (Ch 3) -/
 
 open Features.Prominence (AnimacyRank)

--- a/Linglib/Studies/Landman2020.lean
+++ b/Linglib/Studies/Landman2020.lean
@@ -223,6 +223,41 @@ theorem partsIn_injOn {Z : Set B} (hZ : DisjointPred mOverlap Z)
     what `partsIn_injOn` certifies as sufficient). -/
 noncomputable def card (Z : Set B) (x : B) : ℕ := (partsIn Z x).ncard
 
+/-! ### Exact numbers: the junction with [harbour-2014]
+
+[harbour-2014] (30) characterizes the exact number values over a
+generating set of atoms as cardinality classes — singular `|x| = 1`,
+dual `|x| = 2`, trial `|x| = 3` — with (31) the successor-like function
+that extends them. This book's `card` certifies precisely that counting:
+over a disjoint base, the cardinality of a sum is the number of
+generators summed. Two frameworks formalized from their own primary
+sources, agreeing on one counting operation by theorem. -/
+
+/-- Over a disjoint base, the Landman cardinality of a sum is the number
+    of generators summed — [harbour-2014]'s (30) cardinality classes are
+    `card`-classes. -/
+theorem card_sSup {Z Y : Set B} (hZ : DisjointPred mOverlap Z)
+    (hbot : ⊥ ∉ Z) (hY : Y ⊆ Z) : card Z (sSup Y) = Y.ncard := by
+  rw [card, partsIn_sSup hZ hbot hY]
+
+/-- A generator counts as one (Harbour's singular: `|x| = 1`). -/
+theorem card_self {Z : Set B} (hZ : DisjointPred mOverlap Z)
+    (hbot : ⊥ ∉ Z) {z : B} (hz : z ∈ Z) : card Z z = 1 := by
+  have h := card_sSup hZ hbot (Set.singleton_subset_iff.mpr hz)
+  rw [sSup_singleton] at h
+  rw [h, Set.ncard_singleton]
+
+/-- A sum of two distinct generators counts as two (Harbour's dual:
+    `|x| = 2` — the value `Number.interp` assigns the minimal
+    non-atoms). -/
+theorem card_pair {Z : Set B} (hZ : DisjointPred mOverlap Z)
+    (hbot : ⊥ ∉ Z) {z₁ z₂ : B} (h₁ : z₁ ∈ Z) (h₂ : z₂ ∈ Z)
+    (hne : z₁ ≠ z₂) : card Z (z₁ ⊔ z₂) = 2 := by
+  have h := card_sSup hZ hbot (Y := {z₁, z₂}) (by
+    rintro y (rfl | rfl) <;> assumption)
+  rw [sSup_pair] at h
+  rw [h, Set.ncard_pair hne]
+
 /-! ### I-sets and count – mass – neat – mess (his §6.1) -/
 
 /-- An i-set: a body and a base that generates it under sum

--- a/Linglib/Syntax/Minimalist/Phi/Recursion.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Recursion.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Number.Decomposition
+import Linglib.Features.Number.Interp
 import Linglib.Core.Mereology
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.UpperLower.Basic
@@ -340,87 +341,11 @@ theorem sixteen_wellformed_configs :
               HarbourConfig.mk a m d r ra
     (allConfigs.filter HarbourConfig.wellFormed).length = 16 := by decide
 
--- ============================================================================
--- § 11: Lattice-Grounded Feature Predicates
--- ============================================================================
-
-/-! ### Lattice-Grounded Feature Predicates
-[harbour-2014]
-
-The three number features are predicates on a join-semilattice of
-individuals:
-- **(20)** [±atomic] = λx. (¬)atom(x) — IS `Mereology.Atom`
-- **(21)** [±minimal] = λP λx. (¬)∃y(P(y) ∧ y ⊏ x), presupposing P(x)
-- **(10)** [±additive] = λP λx. (¬)∀y(Q(y) → Q(x ⊔ y)), presupposing Q(x)
-
-[+additive] IS cumulativity restricted to a subregion: the set of
-[+additive] elements is CUM. This connects number to aspect/telicity
-([harbour-2014] §4.4): mass nouns satisfy [+additive], telic
-predicates satisfy [−additive]. -/
-
-section LatticeFeatures
-
-variable {D : Type*} [SemilatticeSup D]
-
-/-- [+minimal] in region P: x is a minimal element of P under ≤.
-    [harbour-2014] (21): x has no proper P-part below it. -/
-def minimalInPred (P : D → Prop) (x : D) : Prop :=
-  P x ∧ ∀ y, P y → y ≤ x → y = x
-
-/-- [+additive] in region Q: x is join-complete in Q.
-    [harbour-2014] (10): ∀y ∈ Q, x ⊔ y ∈ Q. -/
-def additiveInPred (Q : D → Prop) (x : D) : Prop :=
-  Q x ∧ ∀ y, Q y → Q (x ⊔ y)
-
-/-- The [+additive] region is CUM: joining two [+additive] elements
-    gives another [+additive] element.
-
-    This is the formal link between number and aspect/telicity
-    ([harbour-2014] §4.4): mass nouns are [+additive] (cumulative),
-    telic predicates are [−additive] (quantized), and the features
-    governing both are the same. -/
-theorem additive_region_cum (Q : D → Prop)
-    (x y : D) (hx : additiveInPred Q x) (hy : additiveInPred Q y) :
-    additiveInPred Q (x ⊔ y) := by
-  refine ⟨hx.2 y hy.1, fun z hz => ?_⟩
-  rw [sup_assoc]
-  exact hx.2 (y ⊔ z) (hy.2 z hz)
-
-/-- Atoms are trivially minimal in any region containing them.
-    Grounding of [+atomic] → [+minimal] in lattice theory: atoms
-    have no proper parts, so they are minimal everywhere.
-
-    **Consequence for recursion** ([harbour-2014] §4.2):
-    [±minimal] applied to a region of atoms selects ALL of them
-    ([+minimal]) or NONE ([−minimal] = ∅). Feature recursion on
-    an all-atom region adds no information, which is why [±atomic]
-    cannot undergo meaningful feature recursion. -/
-theorem atoms_all_minimal (P : D → Prop)
-    (hAllAtoms : ∀ x, P x → Mereology.Atom x)
-    (x : D) (hPx : P x) :
-    minimalInPred P x :=
-  ⟨hPx, fun y _ hle => hAllAtoms x hPx y hle⟩
-
-/-- The [−minimal] complement of an all-atom region is empty:
-    no atom fails to be minimal. This is the formal reason
-    [±atomic] cannot recurse ([harbour-2014] §4.2). -/
-theorem atoms_no_nonminimal (P : D → Prop)
-    (hAllAtoms : ∀ x, P x → Mereology.Atom x)
-    (x : D) :
-    ¬(P x ∧ ¬minimalInPred P x) :=
-  fun ⟨hPx, hNonMin⟩ => hNonMin (atoms_all_minimal P hAllAtoms x hPx)
-
-/-- The [+additive] subregion is cumulative (`Mereology.CUM`).
-    This is the formal content of [harbour-2014] §4.4:
-    [+additive] IS cumulativity restricted to a subregion.
-    The number-aspect connection runs through exactly this identity:
-    mass nouns are [+additive] (CUM), telic predicates are [−additive]
-    (not CUM). -/
-theorem additive_subregion_is_cum (Q : D → Prop) :
-    Mereology.CUM (fun x => additiveInPred Q x) :=
-  fun x y hx hy => additive_region_cum Q x y hx hy
-
-end LatticeFeatures
+/-! The lattice-grounded feature predicates — [harbour-2014]'s (20)
+`[±atomic]`, (21) `[±minimal]`, (10) `[±additive]` as predicates over a
+join-semilattice, with the CUM identity for the number–aspect nexus —
+graduated to `Features/Number/Interp.lean` (`Number.minimalIn`,
+`Number.additiveIn`, `Number.additive_subregion_is_cum`). -/
 
 -- ============================================================================
 -- § 12: Surface Categories and Typological Predictions


### PR DESCRIPTION
Completes the Number API's semantic layer: `Features/Number/Interp.lean` defines `Number.interp` — the denotation of each value over any join-semilattice, composed from Harbour's verified feature semantics ((20)/(21); approximatives return `none` as cut-dependent per (14)) — with the `[±minimal]`/`[±additive]` predicates graduated from Phi/Recursion §11 and the containment `[+atomic] → [+minimal]` derived, not stipulated. Domain-polymorphism makes verbal number the same operator at the event lattice.

- Decomposition's Bool lattice tests are now certified mirrors: `isAtom_iff_minimalIn`, `isMinimalNonAtom_iff_minimalIn`, `isJoinCompleteIn_iff_additiveIn` (the twice-flagged duplication, resolved by equivalence lemmas per the general/specialized file discipline).
- Second commit adds the **Harbour–Landman counting junction** in `Studies/Landman2020.lean` (`card_sSup`: Landman's card of a sum = number of generators = Harbour's (30) cardinality classes) and `Corbett2000.allNumberSystems_wellFormed`: all 13 recorded systems pass the full eleven-universal Table-1 set by `decide`.