### PR TITLE
feat(Features): canonical root Person, clusivity as person values

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -339,6 +339,7 @@ import Linglib.Features.ContainmentPair
 import Linglib.Features.Person.Basic
 import Linglib.Features.Person.Capabilities
 import Linglib.Features.Person.Decomposition
+import Linglib.Features.Person.Interp
 import Linglib.Features.Person.Resolve
 import Linglib.Features.PhiKernel
 import Linglib.Features.Number.Basic

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -336,7 +336,10 @@ import Linglib.Semantics.Composition.Layered
 import Linglib.Core.CylindricAlgebra
 import Linglib.Core.CylindricAlgebra.DynamicSemantics
 import Linglib.Features.ContainmentPair
-import Linglib.Features.Person
+import Linglib.Features.Person.Basic
+import Linglib.Features.Person.Capabilities
+import Linglib.Features.Person.Decomposition
+import Linglib.Features.Person.Resolve
 import Linglib.Features.PhiKernel
 import Linglib.Features.Number.Basic
 import Linglib.Features.Number.Capabilities

--- a/Linglib/Features/Clusivity.lean
+++ b/Linglib/Features/Clusivity.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 
 /-!
 # Clusivity systems — typology of inclusive/exclusive distinctions
@@ -58,7 +58,7 @@ inductive System where
 
 namespace System
 
-/-- The 1st-person `Features.Person.Category` distinctions a system
+/-- The 1st-person `Person.Category` distinctions a system
     grammatically encodes. Captures Cysouw 2009's typology operationally:
     `.noClusivity` collapses 1+2 and 1+3 into a single 1pl
     (modeled here by listing only `.augIncl`, since `.augIncl` is the
@@ -66,7 +66,7 @@ namespace System
     distinguishes them; `.minimalAugmented` and `.unitAugmented` further
     split inclusive into minimal (`.minIncl`) vs augmented (`.augIncl`).
     `.numberIndifferent` languages have no plural form, so only `.s1`. -/
-def distinguishedCategories : System → List Features.Person.Category
+def distinguishedCategories : System → List Person.Category
   | .noClusivity        => [.augIncl]                     -- single 1pl form
   | .inclExcl           => [.augIncl, .excl]              -- 1+2(+3) vs 1+3
   | .minimalAugmented   => [.minIncl, .augIncl, .excl]    -- + 1+2 minimal
@@ -101,9 +101,9 @@ inductive Value where
   | exclusive
   deriving DecidableEq, Repr, BEq
 
-open Features.Person (Category)
+open Person (Category)
 
-/-- The [cysouw-2009] `Features.Person.Category` a person + number +
+/-- The [cysouw-2009] `Person.Category` a person + number +
     clusivity triple realizes. Singulars ignore clusivity; clusivity-marked
     first-person non-singulars split inclusive (`.minIncl` dual / `.augIncl`
     plural) from `.excl`. A clusivity-*neutral* first-person plural (English

--- a/Linglib/Features/Person/Basic.lean
+++ b/Linglib/Features/Person/Basic.lean
@@ -1,0 +1,205 @@
+import Linglib.Data.UD.Basic
+import Linglib.Features.Prominence
+
+/-!
+# Person — the canonical inventory
+[cysouw-2009] [harbour-2016] [siewierska-2004]
+
+The root-namespace `Person` type is the canonical, analytical person
+inventory: the values languages' person systems distinguish, with
+clusivity folded in as person values. [harbour-2016]'s quadripartition
+(first exclusive / first inclusive / second / third) and the plain
+tripartition (first / second / third) coexist as inventory values —
+plain `first` is the tripartition cell (English *we*), related to the
+clusivity-marked cells by `coarsen`, exactly as `Number.dual` relates to
+`Number.plural` under coarsening. `zero` is the impersonal person (UD
+`Person=0`; Finnish-type impersonals).
+
+`UD.Person` (`Data/UD/Basic.lean`) is the *realization* vocabulary —
+what corpora annotate — reachable by `toUD`/`fromUD`. UD has no
+clusivity, so `toUD` collapses the quadripartition cells to `.first`
+(`ud_conflates_clusivity`); the analytical values are not recoverable
+from UD alone.
+
+This mirrors the `Number` API (`Features/Number/Basic.lean`): canonical
+analytical inventory at root namespace, UD demoted to realization,
+capability mixin (`Features/Person/Capabilities.lean`), unified
+resolution (`Features/Person/Resolve.lean`), feature decomposition and
+the Cysouw categories (`Features/Person/Decomposition.lean`).
+
+`Features.Prominence.PersonLevel` (the 1/2/3 prominence type used by
+probes and scales) is scheduled to dissolve into projections on this
+type; `toPersonLevel` is the bridge.
+-/
+
+set_option autoImplicit false
+
+/-- Grammatical person — the canonical analytical inventory. Clusivity
+    is a person-value distinction ([cysouw-2009]; [harbour-2016]'s
+    quadripartition), not an orthogonal feature: `firstInclusive` and
+    `firstExclusive` sit alongside the tripartition cell `first`. -/
+inductive Person where
+  /-- First person, clusivity-unmarked: the tripartition cell
+      (English *we*). -/
+  | first
+  /-- First person inclusive: includes the addressee (Indonesian
+      *kita*). -/
+  | firstInclusive
+  /-- First person exclusive: excludes the addressee (Indonesian
+      *kami*). -/
+  | firstExclusive
+  /-- Second person: addressee, not speaker. -/
+  | second
+  /-- Third person: neither speaker nor addressee. -/
+  | third
+  /-- Impersonal/generic person (UD `Person=0`; Finnish-type
+      impersonals). -/
+  | zero
+  deriving DecidableEq, Repr, Fintype
+
+namespace Person
+
+/-! ### Predicates -/
+
+/-- The referent includes the speaker. -/
+def IncludesSpeaker : Person → Prop
+  | .first | .firstInclusive | .firstExclusive => True
+  | _ => False
+
+instance : DecidablePred IncludesSpeaker := fun p => by
+  unfold IncludesSpeaker; cases p <;> infer_instance
+
+/-- The value marks clusivity (a quadripartition cell). -/
+def MarksClusivity : Person → Prop
+  | .firstInclusive | .firstExclusive => True
+  | _ => False
+
+instance : DecidablePred MarksClusivity := fun p => by
+  unfold MarksClusivity; cases p <;> infer_instance
+
+/-- Speech-act participant: speaker or addressee included. `zero` is
+    not a participant value. -/
+def IsSAP : Person → Prop
+  | .third | .zero => False
+  | _ => True
+
+instance : DecidablePred IsSAP := fun p => by
+  unfold IsSAP; cases p <;> infer_instance
+
+/-! ### Coarsening
+
+The quadripartition cells coarsen to the tripartition cell, as
+`Number.dual` coarsens to `Number.plural`: a clusivity-less system
+realizes both inclusive and exclusive referents as plain `first`. -/
+
+/-- Collapse clusivity: the tripartition image of each value. -/
+def coarsen : Person → Person
+  | .firstInclusive | .firstExclusive => .first
+  | p => p
+
+@[simp] theorem coarsen_idempotent (p : Person) :
+    p.coarsen.coarsen = p.coarsen := by cases p <;> rfl
+
+/-- Coarsening erases exactly the clusivity marking. -/
+theorem coarsen_eq_self_iff (p : Person) :
+    p.coarsen = p ↔ ¬MarksClusivity p := by
+  cases p <;> simp [coarsen, MarksClusivity]
+
+/-! ### UD realization vocabulary -/
+
+/-- Realize as UD annotation: clusivity collapses to `Person=1`. -/
+def toUD : Person → UD.Person
+  | .first | .firstInclusive | .firstExclusive => .first
+  | .second => .second
+  | .third => .third
+  | .zero => .zero
+
+/-- Analytical value of a UD annotation. Total: UD's vocabulary is a
+    coarsening of the analytical inventory. -/
+def fromUD : UD.Person → Person
+  | .first => .first
+  | .second => .second
+  | .third => .third
+  | .zero => .zero
+
+/-- UD round-trips on its own image. -/
+@[simp] theorem toUD_fromUD (u : UD.Person) : (fromUD u).toUD = u := by
+  cases u <;> rfl
+
+/-- The analytical inventory does not round-trip through UD: clusivity
+    has no UD image. `fromUD ∘ toUD` is `coarsen`. -/
+theorem fromUD_toUD (p : Person) : fromUD p.toUD = p.coarsen := by
+  cases p <;> rfl
+
+/-- UD conflates the clusivity values under `Person=1`. -/
+theorem ud_conflates_clusivity :
+    Person.firstInclusive.toUD = Person.firstExclusive.toUD := rfl
+
+/-! ### Prominence bridge
+
+`Features.Prominence.PersonLevel` is the legacy 1/2/3 hierarchy type
+(probes, prominence scales); it dissolves into this projection. -/
+
+/-- Project to the three-way prominence level; `zero` is outside the
+    hierarchy. -/
+def toPersonLevel : Person → Option Features.Prominence.PersonLevel
+  | .first | .firstInclusive | .firstExclusive => some .first
+  | .second => some .second
+  | .third => some .third
+  | .zero => none
+
+/-- Embed a prominence level as an analytical value. -/
+def ofPersonLevel : Features.Prominence.PersonLevel → Person
+  | .first => .first
+  | .second => .second
+  | .third => .third
+
+@[simp] theorem toPersonLevel_ofPersonLevel
+    (l : Features.Prominence.PersonLevel) :
+    (ofPersonLevel l).toPersonLevel = some l := by cases l <;> rfl
+
+/-- The person hierarchy 1 < 2 < 3 ([zwicky-1977]; resolution in
+    coordination, [corbett-2006]). Clusivity-marked firsts share rank 0
+    with `first`; `zero` sits outside the hierarchy (sentinel rank 3). -/
+def hierarchyRank : Person → Nat
+  | .first | .firstInclusive | .firstExclusive => 0
+  | .second => 1
+  | .third => 2
+  | .zero => 3
+
+/-! ### Person systems -/
+
+/-- A language's person system: the analytical values its paradigms
+    distinguish. Universals over systems await verification against
+    [cysouw-2009]'s survey — only structural predicates are provided
+    here. -/
+structure System where
+  /-- The person values the system distinguishes. -/
+  values : List Person
+  deriving DecidableEq, Repr
+
+namespace System
+
+/-- The system marks clusivity. -/
+def HasClusivity (ns : System) : Prop :=
+  .firstInclusive ∈ ns.values ∨ .firstExclusive ∈ ns.values
+
+instance : DecidablePred HasClusivity := fun ns => by
+  unfold HasClusivity; infer_instance
+
+/-- The English-type tripartition. -/
+def tripartition : System := ⟨[.first, .second, .third]⟩
+
+/-- The Indonesian/Tagalog-type quadripartition ([harbour-2016]). -/
+def quadripartition : System :=
+  ⟨[.firstInclusive, .firstExclusive, .second, .third]⟩
+
+theorem tripartition_no_clusivity : ¬tripartition.HasClusivity := by
+  decide
+
+theorem quadripartition_clusivity : quadripartition.HasClusivity := by
+  decide
+
+end System
+
+end Person

--- a/Linglib/Features/Person/Capabilities.lean
+++ b/Linglib/Features/Person/Capabilities.lean
@@ -1,0 +1,52 @@
+import Linglib.Features.Person.Basic
+
+/-!
+# Person — carrier capabilities
+[cysouw-2009]
+
+The typeclass mixin for carriers that bear grammatical person — the
+person analogue of `HasNumber` (`Features/Number/Capabilities.lean`).
+`personOf` extracts the carrier's analytical person value; `Compatible`
+is the agreement-checking relation. Carriers that store UD realization
+(`UD.MorphFeatures`) lift through `Person.fromUD`; carriers that store a
+(UD person, clusivity) pair recover the quadripartition cell
+(`Syntax/Pronoun/Capabilities.lean`).
+-/
+
+set_option autoImplicit false
+
+/-- A carrier of grammatical person. `none` = the carrier does not mark
+    person. -/
+class HasPerson (α : Type*) where
+  /-- The analytical person value, if marked. -/
+  personOf : α → Option Person
+
+export HasPerson (personOf)
+
+instance : HasPerson UD.MorphFeatures :=
+  ⟨fun mf => mf.person.map Person.fromUD⟩
+
+instance : HasPerson Person := ⟨some⟩
+
+namespace HasPerson
+
+variable {α β : Type*} [HasPerson α] [HasPerson β]
+
+/-- Two carriers are person-compatible: if both mark person, the values
+    agree. Unmarked carriers are compatible with everything. -/
+def Compatible (a : α) (b : β) : Prop :=
+  ∀ p q, personOf a = some p → personOf b = some q → p = q
+
+instance (a : α) (b : β) : Decidable (Compatible a b) := by
+  unfold Compatible
+  infer_instance
+
+theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
+    Compatible b a := fun p q hp hq => (h q p hq hp).symm
+
+theorem compatible_of_none {a : α} {b : β} (h : personOf a = none) :
+    Compatible a b := fun p _ hp _ => by
+  rw [h] at hp
+  exact absurd hp (by simp)
+
+end HasPerson

--- a/Linglib/Features/Person/Decomposition.lean
+++ b/Linglib/Features/Person/Decomposition.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Features.Person.Basic
 import Linglib.Features.Prominence
 import Linglib.Features.ContainmentPair
 
@@ -38,6 +39,10 @@ The Minimalist-specific extension [±proximate]
 ([pancheva-zubizarreta-2018]) is added in
 `Syntax/Minimalist/Phi/Geometry.lean`.
 
+The canonical analytical inventory (root `Person`) lives in
+`Features/Person/Basic.lean`; this file is its feature decomposition
+and referential-category layer.
+
 **§ 5–9: Person Categories** ([cysouw-2009]). The 8 referential person
 categories from Cysouw's paradigmatic framework. Three singular categories
 (individual speech act roles) and five group categories (attested
@@ -48,11 +53,9 @@ language data) remains in `Phenomena/Agreement/PersonMarkingTypology.lean`.
 
 -/
 
-/-- Grammatical person — UD's descriptive vocabulary (`UD.Person`: `.first`, `.second`,
-`.third`, `.zero`) as the canonical type; the feature theory below is its API. -/
-abbrev Features.Person := UD.Person
+open Features (ContainmentPair ContainmentPairLike)
 
-namespace Features.Person
+namespace Person
 
 -- ============================================================================
 -- § 1: Person Features
@@ -92,15 +95,15 @@ def thirdF : Features := ⟨false, false⟩
 -- § 3: PersonLevel Bridge
 -- ============================================================================
 
-end Features.Person
+end Person
 
 namespace Features.Prominence
 
 /-- Decompose `PersonLevel` into binary person features. -/
-def PersonLevel.toFeatures : PersonLevel → Features.Person.Features
-  | .first  => Features.Person.firstF
-  | .second => Features.Person.secondF
-  | .third  => Features.Person.thirdF
+def PersonLevel.toFeatures : PersonLevel → Person.Features
+  | .first  => Person.firstF
+  | .second => Person.secondF
+  | .third  => Person.thirdF
 
 /-- Convert `UD.Person` to `PersonLevel`. The UD `.zero` (impersonal)
     case has no `PersonLevel` analogue; everything else is direct. -/
@@ -112,7 +115,7 @@ def PersonLevel.ofUDPerson : UD.Person → Option PersonLevel
 
 end Features.Prominence
 
-namespace Features.Person
+namespace Person
 
 open Features.Prominence
 
@@ -286,6 +289,33 @@ theorem ud_conflates_incl_excl :
     Category.toUDPersonNumber .augIncl =
     Category.toUDPersonNumber .excl := rfl
 
+/-- The person coordinate of each referential category — the projection
+    the canonical inventory recovers losslessly where UD cannot:
+    `minIncl`/`augIncl` ↦ `firstInclusive`, `excl` ↦ `firstExclusive`.
+    (The number coordinate is `toUDPersonNumber`'s second component; the
+    full `Category ≃ compatible (Person × Number)` junction is the
+    planned phase-2 theorem.) -/
+def Category.person : Category → Person
+  | .s1        => .first
+  | .s2        => .second
+  | .s3        => .third
+  | .minIncl   => .firstInclusive
+  | .augIncl   => .firstInclusive
+  | .excl      => .firstExclusive
+  | .secondGrp => .second
+  | .thirdGrp  => .third
+
+/-- The person projection tracks speaker inclusion. -/
+theorem person_includesSpeaker_iff (c : Category) :
+    c.person.IncludesSpeaker ↔ c.IncludesSpeaker := by
+  cases c <;> simp [Category.person, Person.IncludesSpeaker,
+    Category.IncludesSpeaker]
+
+/-- Unlike UD realization, the person projection separates inclusive
+    from exclusive. -/
+theorem person_separates_clusivity :
+    Category.augIncl.person ≠ Category.excl.person := by decide
+
 -- ============================================================================
 -- § 8: Category ↔ Features Bridge
 -- ============================================================================
@@ -406,4 +436,4 @@ inductive EpistemicAuthority where
   | disjunct    -- speaker lacks epistemic authority
   deriving DecidableEq, Repr
 
-end Features.Person
+end Person

--- a/Linglib/Features/Person/Interp.lean
+++ b/Linglib/Features/Person/Interp.lean
@@ -1,0 +1,132 @@
+import Linglib.Features.Person.Resolve
+
+/-!
+# Person — referent semantics for the values
+[harbour-2016] [dalrymple-kaplan-2000] [cysouw-2009]
+
+The denotation of a person value as a region of referents: over an
+ontology with speaker `i` and addressee `u`, each value constrains which
+of the two distinguished roles the referent (a `Finset` of individuals)
+includes. `zero` (impersonal) is context-dependent and gets `none` — the
+approximatives precedent of `Number.interp`.
+
+The region semantics grounds the rest of the API:
+
+* `interp_resolve` — coordination unions referents, and the regions are
+  closed under it: a `p`-referent united with a `q`-referent lies in the
+  `resolve p q` region. `Person.resolve_profile`'s profile disjunction is
+  the (i, u)-shadow of this fact (`toProfile_sound`).
+* `IsSAP` is the region property "forces a speech-act participant"
+  (`isSAP_iff_forces`).
+* [harbour-2016]'s partition calculus generates exactly these regions —
+  the certification theorem lives with the calculus in
+  `Studies/Harbour2016.lean` (`quad_cells_are_interp_regions`); the
+  marker-set rendering is [dalrymple-kaplan-2000]'s Fula encoding
+  (`Studies/DalrympleKaplan2000.lean`, `person_resolve_is_union`).
+-/
+
+set_option autoImplicit false
+
+namespace Person
+
+variable {D : Type*} [DecidableEq D]
+
+/-- The region of referents a person value picks out, over an ontology
+    with speaker `i` and addressee `u`: `first` includes the speaker
+    (addressee open — the tripartition cell), the quadripartition cells
+    fix both roles, `zero` is context-dependent (`none`). -/
+def interp (i u : D) : Person → Option (Finset D → Prop)
+  | .first => some fun s => i ∈ s
+  | .firstInclusive => some fun s => i ∈ s ∧ u ∈ s
+  | .firstExclusive => some fun s => i ∈ s ∧ u ∉ s
+  | .second => some fun s => u ∈ s ∧ i ∉ s
+  | .third => some fun s => i ∉ s ∧ u ∉ s
+  | .zero => none
+
+/-- The region, with the empty region for `zero`. -/
+def region (i u : D) (p : Person) : Finset D → Prop :=
+  (interp i u p).getD fun _ => False
+
+instance (i u : D) (p : Person) (s : Finset D) :
+    Decidable (region i u p s) :=
+  match p with
+  | .first => inferInstanceAs (Decidable (i ∈ s))
+  | .firstInclusive => inferInstanceAs (Decidable (i ∈ s ∧ u ∈ s))
+  | .firstExclusive => inferInstanceAs (Decidable (i ∈ s ∧ u ∉ s))
+  | .second => inferInstanceAs (Decidable (u ∈ s ∧ i ∉ s))
+  | .third => inferInstanceAs (Decidable (i ∉ s ∧ u ∉ s))
+  | .zero => isFalse fun h => h
+
+/-- `interp` is defined exactly off the impersonal. -/
+theorem interp_isSome_iff (i u : D) (p : Person) :
+    (interp i u p).isSome ↔ p ≠ .zero := by
+  cases p <;> simp [interp]
+
+/-- **Resolution is referent union**: the regions are closed under
+    coordination — a `p`-referent united with a `q`-referent is a
+    `resolve p q`-referent. The resolution table of
+    `Features/Person/Resolve.lean` is the shadow of this closure. -/
+theorem interp_resolve (i u : D) :
+    ∀ p q : Person, p ≠ .zero → q ≠ .zero →
+    ∀ s t : Finset D,
+      region i u p s → region i u q t →
+      region i u (resolve p q) (s ∪ t) := by
+  intro p q hp hq s t hs ht
+  cases p <;> cases q <;>
+    simp_all [region, interp, resolve, Finset.mem_union] <;> tauto
+
+/-- The profile of `Features/Person/Resolve.lean` is the (i, u)-shadow of
+    the region: `speaker` records whether the region forces `i ∈ s`, and
+    a determinate `addressee` slot records the forced `u`-status. -/
+theorem toProfile_speaker (i u : D) :
+    ∀ (p : Person) (pr : Profile), p.toProfile = some pr →
+    ∀ s : Finset D, region i u p s → (pr.speaker = true ↔ i ∈ s) := by
+  intro p pr hpr s hs
+  cases p <;> simp only [toProfile, Option.some.injEq, reduceCtorEq] at hpr <;>
+    subst hpr <;> simp_all [region, interp]
+
+/-- A determinate addressee slot records the forced `u`-status of the
+    region. -/
+theorem toProfile_addressee (i u : D) :
+    ∀ (p : Person) (pr : Profile) (b : Bool), p.toProfile = some pr →
+    pr.addressee = some b →
+    ∀ s : Finset D, region i u p s → (u ∈ s ↔ b = true) := by
+  intro p pr b hpr hb s hs
+  cases p <;> simp only [toProfile, Option.some.injEq, reduceCtorEq] at hpr <;>
+    subst hpr <;> simp_all [region, interp]
+
+/-- `IsSAP` is the semantic property "the region forces a speech-act
+    participant in the referent": first/second persons do, third does not
+    (the empty referent witnesses). -/
+theorem isSAP_iff_forces (i u : D) :
+    ∀ p : Person, p ≠ .zero →
+      (IsSAP p ↔ ∀ s : Finset D, region i u p s → i ∈ s ∨ u ∈ s) := by
+  intro p hp
+  cases p
+  case zero => exact absurd rfl hp
+  case first =>
+    simp only [IsSAP, region, interp, Option.getD_some, true_iff]
+    exact fun _ h => Or.inl h
+  case firstInclusive =>
+    simp only [IsSAP, region, interp, Option.getD_some, true_iff]
+    exact fun _ h => Or.inl h.1
+  case firstExclusive =>
+    simp only [IsSAP, region, interp, Option.getD_some, true_iff]
+    exact fun _ h => Or.inl h.1
+  case second =>
+    simp only [IsSAP, region, interp, Option.getD_some, true_iff]
+    exact fun _ h => Or.inr h.1
+  case third =>
+    simp only [IsSAP, region, interp, Option.getD_some, false_iff,
+      not_forall]
+    exact ⟨∅, by simp⟩
+
+omit [DecidableEq D] in
+/-- Coarsening widens the region: dropping clusivity loses information,
+    never referents. -/
+theorem region_coarsen (i u : D) (p : Person) (s : Finset D) :
+    region i u p s → region i u p.coarsen s := by
+  cases p <;> simp only [region, interp, coarsen, Option.getD_some] <;>
+    tauto
+
+end Person

--- a/Linglib/Features/Person/Resolve.lean
+++ b/Linglib/Features/Person/Resolve.lean
@@ -1,0 +1,165 @@
+import Linglib.Features.Person.Basic
+
+/-!
+# Person — resolution
+[corbett-2006] [zwicky-1977] [dalrymple-kaplan-2000]
+
+Resolution in coordination: the person of a coordinate structure from
+the persons of its conjuncts (*you and I* → first inclusive). The
+canonical table returns the finest analytical value
+(`first + second = firstInclusive`); systems without the distinction
+coarsen via `resolveIn`, exactly as `Number.resolve`'s canonical dual
+coarsens to plural in {sg, pl} systems.
+
+The table is not stipulated: `resolve_profile` derives it from referent
+union. A person value constrains which discourse roles the referent
+includes (`Profile`: speaker yes/no, addressee yes/no/underdetermined —
+the tripartition `first` leaves the addressee slot open), and
+coordination unions referents — so resolution is pointwise disjunction
+on profiles, [dalrymple-kaplan-2000]'s set-union semantics for person
+resolution. The Zwicky hierarchy (1 < 2 < 3, [zwicky-1977]) falls out:
+in a tripartition system, resolution is minimum of `hierarchyRank`
+(`resolveIn_tripartition_min`).
+
+`zero` (impersonal) does not participate in attested resolution; it is
+treated as an identity by convention (documented, not an empirical
+claim).
+-/
+
+set_option autoImplicit false
+
+namespace Person
+
+/-! ### Canonical resolution -/
+
+/-- Canonical person resolution: the finest analytical value for the
+    coordination of two referents. Speaker inclusion dominates;
+    coordination with the addressee yields the inclusive. `zero` is an
+    identity by convention. -/
+def resolve : Person → Person → Person
+  | .zero, p => p
+  | p, .zero => p
+  | .firstInclusive, _ => .firstInclusive
+  | _, .firstInclusive => .firstInclusive
+  | .first, .second => .firstInclusive
+  | .second, .first => .firstInclusive
+  | .firstExclusive, .second => .firstInclusive
+  | .second, .firstExclusive => .firstInclusive
+  | .first, _ => .first
+  | _, .first => .first
+  | .firstExclusive, _ => .firstExclusive
+  | _, .firstExclusive => .firstExclusive
+  | .second, _ => .second
+  | _, .second => .second
+  | .third, .third => .third
+
+theorem resolve_comm : ∀ a b, resolve a b = resolve b a := by decide
+
+theorem resolve_assoc :
+    ∀ a b c, resolve (resolve a b) c = resolve a (resolve b c) := by
+  decide
+
+@[simp] theorem resolve_zero_left (p : Person) : resolve .zero p = p := by
+  cases p <;> rfl
+
+@[simp] theorem resolve_zero_right (p : Person) : resolve p .zero = p := by
+  cases p <;> rfl
+
+/-! ### The grounding: resolution is referent union
+
+A person value constrains the discourse roles in the referent. The
+profile records speaker inclusion (determinate for every value) and
+addressee inclusion (`none` = underdetermined: the tripartition `first`
+says nothing about the addressee). Coordination unions referents, so
+the resolved profile is the pointwise disjunction — with
+`none ∨ false = none`: if one conjunct's addressee status is open, so
+is the coordination's. -/
+
+/-- Discourse-role inclusion profile of a (non-impersonal) person
+    value. -/
+structure Profile where
+  /-- The referent includes the speaker. -/
+  speaker : Bool
+  /-- The referent includes the addressee; `none` = underdetermined. -/
+  addressee : Option Bool
+  deriving DecidableEq, Repr
+
+/-- The profile of each value; `zero` constrains roles in a
+    context-dependent way and has none. -/
+def toProfile : Person → Option Profile
+  | .first => some ⟨true, none⟩
+  | .firstInclusive => some ⟨true, some true⟩
+  | .firstExclusive => some ⟨true, some false⟩
+  | .second => some ⟨false, some true⟩
+  | .third => some ⟨false, some false⟩
+  | .zero => none
+
+/-- Profiles of unions: pointwise disjunction (three-valued on the
+    addressee slot). -/
+def Profile.or (p q : Profile) : Profile :=
+  ⟨p.speaker || q.speaker,
+    match p.addressee, q.addressee with
+    | some true, _ => some true
+    | _, some true => some true
+    | some false, some false => some false
+    | _, _ => none⟩
+
+/-- **The resolution table is referent union** ([dalrymple-kaplan-2000]):
+    for referential persons, the profile of the resolved value is the
+    disjunction of the conjuncts' profiles. The table is derived, not
+    stipulated. -/
+theorem resolve_profile :
+    ∀ p q : Person, p ≠ .zero → q ≠ .zero →
+      (resolve p q).toProfile =
+        (p.toProfile.bind fun pp => q.toProfile.map pp.or) := by
+  decide
+
+/-- Distinct values have distinct profiles: the referential inventory is
+    exactly the profile space reachable from referents. -/
+theorem toProfile_injOn :
+    ∀ p q : Person, p ≠ .zero → q ≠ .zero →
+      p.toProfile = q.toProfile → p = q := by
+  decide
+
+/-! ### System-relative resolution -/
+
+/-- Coarsen a value into a system: keep it if present, else collapse
+    clusivity. -/
+def coarsenTo (sys : List Person) (p : Person) : Person :=
+  if p ∈ sys then p
+  else if p.coarsen ∈ sys then p.coarsen
+  else p
+
+/-- Resolution within a system: canonical resolution, coarsened. -/
+def resolveIn (sys : List Person) (a b : Person) : Person :=
+  coarsenTo sys (resolve a b)
+
+theorem resolveIn_comm (sys : List Person) (a b : Person) :
+    resolveIn sys a b = resolveIn sys b a := by
+  simp only [resolveIn, resolve_comm]
+
+/-- Resolution typed by a `Person.System`. -/
+def System.resolve (ns : System) (a b : Person) : Person :=
+  resolveIn ns.values a b
+
+/-- In a clusivity system: *you and I* resolves to the inclusive. -/
+theorem resolve_quadripartition_incl :
+    System.quadripartition.resolve .firstExclusive .second =
+      .firstInclusive := by decide
+
+/-- In a tripartition system the canonical inclusive coarsens to plain
+    first: English *you and I* → *we*. -/
+theorem resolve_tripartition_first :
+    System.tripartition.resolve .first .second = .first := by decide
+
+/-- **The Zwicky hierarchy as a corollary** ([zwicky-1977]): in a
+    tripartition system, resolution is minimum of `hierarchyRank` —
+    1 < 2 < 3 is not a primitive but the shadow of referent union. -/
+theorem resolveIn_tripartition_min :
+    ∀ p q : Person, p ∈ System.tripartition.values →
+      q ∈ System.tripartition.values →
+      (System.tripartition.resolve p q).hierarchyRank =
+        min p.hierarchyRank q.hierarchyRank := by
+  decide
+
+end Person

--- a/Linglib/Features/PhiKernel.lean
+++ b/Linglib/Features/PhiKernel.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Features.Number.Decomposition
 
 /-!

--- a/Linglib/Fragments/English/Auxiliaries.lean
+++ b/Linglib/Fragments/English/Auxiliaries.lean
@@ -1,6 +1,7 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities
-import Linglib.Features.Person
+import Linglib.Features.Person.Capabilities
+import Linglib.Features.Person.Decomposition
 import Linglib.Semantics.Modality.ModalTypes
 import Linglib.Features.Register
 import Linglib.Morphology.Word
@@ -50,7 +51,6 @@ To find every claim made about a particular entry, grep for
 `Theories/`.
 -/
 
-open Features (Person)
 
 namespace English.Auxiliaries
 
@@ -70,7 +70,7 @@ structure AuxEntry where
   form : String
   auxType : AuxType
   /-- Person/number agreement -/
-  person : Option Person := none
+  person : Option UD.Person := none
   number : Option UD.Number := none
   /-- Morphological tense. `none` for base forms (modals like *can*, *will*).
       Note: "past" modals (*could*, *would*) carry `Past` as a morphological
@@ -102,6 +102,8 @@ structure AuxEntry where
 
 /-- An auxiliary bears its agreement number (`HasNumber`). -/
 instance : HasNumber AuxEntry := ⟨fun a => a.number.bind Number.fromUD⟩
+
+instance : HasPerson AuxEntry := ⟨fun a => a.person.map Person.fromUD⟩
 
 -- Modals (no agreement). Modal meanings follow [kratzer-1981], [palmer-2001].
 -- Each uses cartesianProduct with singleton force (fixed force, variable flavor).

--- a/Linglib/Fragments/Ga/Basic.lean
+++ b/Linglib/Fragments/Ga/Basic.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Number.Basic
 import Linglib.Features.Gender
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 
 /-!
 # Gã Fragment
@@ -37,8 +37,6 @@ independent morphological argumentation ([pollock-1989]'s
 diagnostic requires a free Neg head; Gã `-ee` and `-ko` appear
 suffixal) that is orthogonal to the OC story.
 -/
-
-open Features (Person)
 
 namespace Ga
 

--- a/Linglib/Fragments/Hausa/TAM.lean
+++ b/Linglib/Fragments/Hausa/TAM.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Features.Gender
 
 /-!
@@ -45,7 +45,7 @@ that pattern).
 
 namespace Hausa.Inflection
 
-open Features.Person
+open Person
 open Features (SurfaceGender)
 
 -- ============================================================================
@@ -99,7 +99,7 @@ inductive Mode where
 
 /-- The subject slot of the PAC. Hausa makes a 2sg / 3sg gender
     distinction (M vs F), absent in the plural and 1st person.
-    We use `Features.Person.Category` for the singular/group cut and add
+    We use `Person.Category` for the singular/group cut and add
     a `gender` field that is empty (`none`) outside the 2sg/3sg cells. -/
 structure Subject where
   person : Category

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -2,7 +2,8 @@ import Linglib.Syntax.Pronoun.Basic
 import Linglib.Syntax.Pronoun.Capabilities
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities
-import Linglib.Features.Person
+import Linglib.Features.Person.Capabilities
+import Linglib.Features.Person.Decomposition
 
 /-! # Italian Pronoun and Clitic Fragment
 
@@ -30,7 +31,6 @@ and reflexive cases, while 3sg/3pl are not.
 | 3pl    | li/le  | loro   | si   | NOT syncretic
 -/
 
-open Features (Person)
 
 namespace Italian.Pronouns
 
@@ -101,13 +101,15 @@ inductive CliticCase where
 /-- A single clitic form in the paradigm. -/
 structure CliticEntry where
   form : String
-  person : Person
+  person : UD.Person
   number : UD.Number
   case_ : CliticCase
   deriving Repr, BEq
 
 /-- A clitic bears its φ-slot's number (`HasNumber`). -/
 instance : HasNumber CliticEntry := ⟨fun c => Number.fromUD c.number⟩
+
+instance : HasPerson CliticEntry := ⟨fun c => some (Person.fromUD c.person)⟩
 
 /-! ### Clitics as capability carriers (`Proform` / `Bound`)
 
@@ -182,18 +184,18 @@ example : Bound.IsAnaphor si_refl := by decide
 example : Bound.IsPronominal lo_cl := by decide
 
 /-- Look up the form for a given person, number, and case in the paradigm. -/
-def lookupForm (p : Person) (n : UD.Number) (c : CliticCase) : Option String :=
+def lookupForm (p : UD.Person) (n : UD.Number) (c : CliticCase) : Option String :=
   (paradigm.find? (fun e => e.person == p && e.number == n && e.case_ == c)).map (·.form)
 
 /-- Are two clitic cases syncretic for a given person/number combination?
     DERIVED from the paradigm data. -/
-def isSyncretic (p : Person) (n : UD.Number) (c1 c2 : CliticCase) : Bool :=
+def isSyncretic (p : UD.Person) (n : UD.Number) (c1 c2 : CliticCase) : Bool :=
   match lookupForm p n c1, lookupForm p n c2 with
   | some f1, some f2 => f1 == f2
   | _, _ => false
 
 /-- DAT/REFL syncretism for a given person/number. -/
-def datReflSyncretic (p : Person) (n : UD.Number) : Bool :=
+def datReflSyncretic (p : UD.Person) (n : UD.Number) : Bool :=
   isSyncretic p n .dative .reflexive
 
 -- ============================================================================

--- a/Linglib/Fragments/Kawapanan/Shawi/Basic.lean
+++ b/Linglib/Fragments/Kawapanan/Shawi/Basic.lean
@@ -2,7 +2,7 @@ import Linglib.Features.Number.Capabilities
 import Linglib.Features.Case
 import Linglib.Features.Case
 import Linglib.Features.Prominence
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 
 /-!
 # Shawi Agreement Fragment [clem-deal-2024]
@@ -38,7 +38,6 @@ of ergative distribution to a particular Agree configuration — lives in
 `Studies/ClemDeal2024.lean`.
 -/
 
-open Features (Person)
 
 namespace Kawapanan.Shawi
 

--- a/Linglib/Fragments/Mayan/Mam/Pronouns.lean
+++ b/Linglib/Fragments/Mayan/Mam/Pronouns.lean
@@ -30,7 +30,7 @@ her §4.3.3) realizes *disagreeing* values of [±author]/[±participant] —
 Feature values follow her Table 4.4 (p. 183). NB the convention:
 Harbour's [±participant] "functions more like a [+/−hearer] or
 [+/−addressee] feature" (p. 182), so 1EXCL is [−participant] — this
-deliberately diverges from `Features.Person.Features`, whose `wellFormed`
+deliberately diverges from `Person.Features`, whose `wellFormed`
 invariant (author → participant) encodes the speech-act-participant
 convention; hence the fragment-local `ScottFeatures`.
 
@@ -100,7 +100,7 @@ inductive PronCell where
   deriving DecidableEq, Repr
 
 /-- PronCell person, in the API's vocabulary. -/
-def PronCell.person : PronCell → Features.Person
+def PronCell.person : PronCell → UD.Person
   | .firstSg | .firstPlExcl | .firstPlIncl => .first
   | .secondSg | .secondPl => .second
   | .thirdSg | .thirdPl => .third
@@ -119,7 +119,7 @@ def PronCell.clusivity : PronCell → Option Features.Clusivity.Value
 /-- [scott-2023]'s bivalent φ-features (Table 4.4, after [harbour-2016]):
     [±author], [±participant], [±singular]. Fragment-local because the
     participant convention (≈ [±hearer]: 1EXCL is [−participant]) is
-    incompatible with `Features.Person.Features`' author → participant
+    incompatible with `Person.Features`' author → participant
     invariant. -/
 structure ScottFeatures where
   author : Bool

--- a/Linglib/Fragments/Nungon/MedialVerbs.lean
+++ b/Linglib/Fragments/Nungon/MedialVerbs.lean
@@ -1,5 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities
+import Linglib.Features.Person.Capabilities
 
 /-!
 # Nungon Medial Verb Morphology [sarvasy-2017]
@@ -77,6 +78,8 @@ structure PersonNumber where
 
 /-- A person/number index bears its number slot (`HasNumber`). -/
 instance : HasNumber PersonNumber := ⟨fun pn => Number.fromUD pn.number⟩
+
+instance : HasPerson PersonNumber := ⟨fun pn => some (Person.fromUD pn.person)⟩
 
 /-- A DS suffix entry: form + person/number it indexes. -/
 structure DSSuffix where

--- a/Linglib/Fragments/Spanish/Clitics.lean
+++ b/Linglib/Fragments/Spanish/Clitics.lean
@@ -1,6 +1,7 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities
-import Linglib.Features.Person
+import Linglib.Features.Person.Capabilities
+import Linglib.Features.Person.Decomposition
 
 /-!
 # Spanish Clitic Paradigm
@@ -23,7 +24,6 @@ This syncretism drives the availability of stylistic applicatives.
 
 -/
 
-open Features (Person)
 
 namespace Spanish.Clitics
 
@@ -45,13 +45,15 @@ inductive CliticCase where
 /-- A single clitic form in the paradigm. -/
 structure CliticEntry where
   form : String
-  person : Person
+  person : UD.Person
   number : UD.Number
   case_ : CliticCase
   deriving Repr, BEq
 
 /-- A clitic bears its φ-slot's number (`HasNumber`). -/
 instance : HasNumber CliticEntry := ⟨fun c => Number.fromUD c.number⟩
+
+instance : HasPerson CliticEntry := ⟨fun c => some (Person.fromUD c.person)⟩
 
 -- ============================================================================
 -- § 3: Paradigm Data
@@ -97,20 +99,20 @@ def paradigm : List CliticEntry :=
     los, las, les_dat, se_refl_pl ]
 
 /-- Look up the form for a given person, number, and case in the paradigm. -/
-def lookupForm (p : Person) (n : UD.Number) (c : CliticCase) : Option String :=
+def lookupForm (p : UD.Person) (n : UD.Number) (c : CliticCase) : Option String :=
   (paradigm.find? (fun e => e.person == p && e.number == n && e.case_ == c)).map (·.form)
 
 /-- Are two clitic cases syncretic for a given person/number combination?
     DERIVED from the paradigm data: syncretism holds iff the looked-up
     forms are identical (and both exist). -/
-def isSyncretic (p : Person) (n : UD.Number) (c1 c2 : CliticCase) : Bool :=
+def isSyncretic (p : UD.Person) (n : UD.Number) (c1 c2 : CliticCase) : Bool :=
   match lookupForm p n c1, lookupForm p n c2 with
   | some f1, some f2 => f1 == f2
   | _, _ => false
 
 /-- The set of person/number combinations where DAT and REFL are syncretic.
     This is the key condition for SE-optionality. -/
-def datReflSyncretic (p : Person) (n : UD.Number) : Bool :=
+def datReflSyncretic (p : UD.Person) (n : UD.Number) : Bool :=
   isSyncretic p n .dative .reflexive
 
 -- ============================================================================

--- a/Linglib/Fragments/Spanish/PersonFeatures.lean
+++ b/Linglib/Fragments/Spanish/PersonFeatures.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 
 /-!
 # Person Feature Decomposition for Spanish Clitics
@@ -19,7 +19,7 @@ the Fission-specific combination with [±singular].
 
 namespace Spanish.PersonFeatures
 
-open Features.Person
+open Person
 
 -- ============================================================================
 -- § 1: Fission Applicability

--- a/Linglib/Fragments/Tagalog/Pronouns.lean
+++ b/Linglib/Fragments/Tagalog/Pronouns.lean
@@ -1,7 +1,7 @@
 import Linglib.Syntax.Pronoun.Basic
 import Linglib.Typology.Pronoun.WALS
 import Linglib.Features.Clusivity
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 
 /-!
 # Tagalog pronoun profile (WALS Chs 39, 40, 44–48)
@@ -80,7 +80,7 @@ def clusivitySystem : Features.Clusivity.System := .minimalAugmented
     Table 12.2 lists alongside *katá* is a separate 1sg.GEN+2sg.NOM portmanteau
     ([schachter-otanes-1972] p. 89), not a 1du.in pronoun. -/
 
-open Features.Person (Category)
+open Person (Category)
 
 -- 1st singular
 def ako    : PersonalPronoun := { form := "ako",    person := some .first,  number := some .Sing, case_ := some .Nom }

--- a/Linglib/Morphology/Word.lean
+++ b/Linglib/Morphology/Word.lean
@@ -1,5 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities
+import Linglib.Features.Person.Capabilities
 
 /-!
 # Word — the morphosyntactic word (ms-word) token
@@ -88,6 +89,8 @@ theorem Word.Agree.not_transitive :
 
 /-- A word bears the number its UD morphology ingests (`Number.fromUD`). -/
 instance : HasNumber Word := ⟨fun w => w.features.number.bind Number.fromUD⟩
+
+instance : HasPerson Word := ⟨fun w => w.features.person.map Person.fromUD⟩
 
 /-- The φ-projection preserves `numberOf`: a word and its `phi` bundle bear
     the same number — the defeq `Word.Agree.hasNumber_compatible` relies on. -/

--- a/Linglib/Semantics/Presupposition/PhiFeatures.lean
+++ b/Linglib/Semantics/Presupposition/PhiFeatures.lean
@@ -1,7 +1,7 @@
 import Linglib.Core.Mereology
 import Linglib.Features.ContainmentPair
 import Linglib.Features.Number.Decomposition
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Features.Gender
 import Linglib.Semantics.Presupposition.Basic
 
@@ -232,11 +232,11 @@ theorem person_nesting_from_phi (speaker addressee : E)
     so `phiPresup_nesting` applies to both: the nesting is structural,
     not a per-domain coincidence. -/
 theorem person_number_isomorphism :
-    ContainmentPairLike.specLevel Features.Person.firstF =
+    ContainmentPairLike.specLevel Person.firstF =
       ContainmentPairLike.specLevel Number.singularF ∧
-    ContainmentPairLike.specLevel Features.Person.secondF =
+    ContainmentPairLike.specLevel Person.secondF =
       ContainmentPairLike.specLevel Number.dualF ∧
-    ContainmentPairLike.specLevel Features.Person.thirdF =
+    ContainmentPairLike.specLevel Person.thirdF =
       ContainmentPairLike.specLevel Number.pluralF :=
   ⟨rfl, rfl, rfl⟩
 
@@ -338,13 +338,13 @@ theorem gender_nesting_from_phi (isInanimate isFemale : E → Prop)
     all three domains share the phi kernel structure. -/
 theorem gender_person_number_isomorphism :
     ContainmentPairLike.specLevel Features.Gender.neuterF =
-      ContainmentPairLike.specLevel Features.Person.firstF ∧
+      ContainmentPairLike.specLevel Person.firstF ∧
     ContainmentPairLike.specLevel Features.Gender.neuterF =
       ContainmentPairLike.specLevel Number.singularF ∧
     ContainmentPairLike.specLevel Features.Gender.feminineF =
-      ContainmentPairLike.specLevel Features.Person.secondF ∧
+      ContainmentPairLike.specLevel Person.secondF ∧
     ContainmentPairLike.specLevel Features.Gender.masculineF =
-      ContainmentPairLike.specLevel Features.Person.thirdF :=
+      ContainmentPairLike.specLevel Person.thirdF :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 end GenderPresuppositions

--- a/Linglib/Studies/AckemaNeeleman2018.lean
+++ b/Linglib/Studies/AckemaNeeleman2018.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 
 /-!
 # Ackema & Neeleman (2018): Features of Person
@@ -17,7 +17,7 @@ the pronoun object or its consumers are committed to. A&N's PROX/DIST geometry
 is one of several competing decompositions (cf. [harbour-2016]'s
 `Studies/Harbour2016.lean`); the widely-adopted, framework-neutral
 representation is person + number + clusivity, encapsulated typologically by
-[cysouw-2009]'s `Features.Person.Category`. The deliverable here is
+[cysouw-2009]'s `Person.Category`. The deliverable here is
 therefore `specToCategory`: a *converter* from an A&N feature structure to that
 neutral inventory. A consumer that wants the feature geometry imports it;
 everyone else uses the neutral category.
@@ -49,12 +49,12 @@ on a layer they are undefined, which is what bounds the inventory.
   incoherent and the output space is finite, so no nonattested person is
   generated.
 * `specToCategory` + `inventory_distinct` — the converter to the neutral
-  `Features.Person.Category`, faithful on the seven attested persons.
+  `Person.Category`, faithful on the seven attested persons.
 -/
 
 namespace AckemaNeeleman2018
 
-open Features.Person (Category)
+open Person (Category)
 
 /-! ### The person space and the two features -/
 

--- a/Linglib/Studies/AdamsonZompi2025.lean
+++ b/Linglib/Studies/AdamsonZompi2025.lean
@@ -5,7 +5,7 @@ import Linglib.Fragments.Italian.Pronouns
 import Linglib.Fragments.Spanish.Pronouns
 import Linglib.Fragments.Spanish.PersonFeatures
 import Linglib.Fragments.German.Pronouns
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Studies.Deal2024
 
 /-!
@@ -680,7 +680,7 @@ theorem all_fragments_grounded :
 -- § 16: Person Category Bridge — Unifying Person Decompositions
 -- ============================================================================
 
-open Features.Person in
+open Person in
 /-- The [±participant] decomposition in `Core/Person/Category.lean`
     (operating on `Category`) is the same decomposition as
     `Phi.Geometry.decomposePerson` (operating on `PersonLevel`).

--- a/Linglib/Studies/CharnavelMateu2015.lean
+++ b/Linglib/Studies/CharnavelMateu2015.lean
@@ -3,7 +3,7 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.Tactic.DeriveFintype
 import Linglib.Features.Logophoricity
 import Linglib.Features.Empathy
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Fragments.Spanish.Clitics
 
 /-!

--- a/Linglib/Studies/Cysouw2009.lean
+++ b/Linglib/Studies/Cysouw2009.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Features.Number.Basic
 import Linglib.Fragments.Finnish.Negation
 
@@ -39,7 +39,7 @@ sharing a class are homophonous (marked by the same form).
 
 namespace Cysouw2009
 
-open Features.Person
+open Person
 
 -- ============================================================================
 -- §2: Paradigmatic Structure

--- a/Linglib/Studies/DalrympleKaplan2000.lean
+++ b/Linglib/Studies/DalrympleKaplan2000.lean
@@ -1,5 +1,5 @@
 import Linglib.Morphology.Unification
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Fintype.Powerset
@@ -310,13 +310,13 @@ either marker is participanthood. The map collapses exactly the inclusive/exclus
 distinction — Fula's `{S}` and `{S, H}` land on the same binary value — which is the
 formal content of §6.2's "fewer pronominal distinctions". -/
 
-open Features.Person in
+open Person in
 /-- Project a marker set onto the binary decomposition. -/
-def toBinary (p : PersonSet) : Features.Person.Features :=
+def toBinary (p : PersonSet) : Person.Features :=
   { hasParticipant := Marker.S ∈ p ∨ Marker.H ∈ p
     hasAuthor := Marker.S ∈ p }
 
-open Features.Person in
+open Person in
 theorem toBinary_values :
     toBinary fula1exc = firstF ∧ toBinary fula1inc = firstF ∧
     toBinary fula2 = secondF ∧ toBinary fula3 = thirdF := by

--- a/Linglib/Studies/DalrympleKaplan2000.lean
+++ b/Linglib/Studies/DalrympleKaplan2000.lean
@@ -1,5 +1,6 @@
 import Linglib.Morphology.Unification
 import Linglib.Features.Person.Decomposition
+import Linglib.Features.Person.Resolve
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Fintype.Powerset
@@ -233,6 +234,29 @@ theorem english_table :
 theorem jose_y_tu :
     resolve eng3 eng2 = eng2 ∧ resolve eng3 eng2 ≠ eng1 := by
   constructor <;> decide
+
+/-! ### The substrate bridge: `Person.resolve` is marker-set union -/
+
+/-- The marker sets of the canonical quadripartition values — the Fula
+    encoding (87). Plain `first` underdetermines clusivity (their §6.2
+    English collapse picks `{S, H}` by stipulation), and `zero` is
+    outside the system, so both map to `none`. -/
+def markerSetOf : Person → Option PersonSet
+  | .firstExclusive => some fula1exc
+  | .firstInclusive => some fula1inc
+  | .second => some fula2
+  | .third => some fula3
+  | _ => none
+
+/-- The substrate's canonical resolution is the paper's union (77)/(93):
+    on the quadripartition, `Person.resolve` commutes with the marker
+    encoding — the same grounding `Person.resolve_profile` states
+    intrinsically, here in the paper's own vocabulary. -/
+theorem person_resolve_is_union :
+    ∀ p q : Person, ∀ sp sq : PersonSet,
+      markerSetOf p = some sp → markerSetOf q = some sq →
+      markerSetOf (Person.resolve p q) = some (resolve sp sq) := by
+  decide
 
 /-- Two markers bound the system (§6.3): at most four person values are expressible,
     matching the maximally differentiated (Fula-type) inventory. -/

--- a/Linglib/Studies/DechaineWiltschko2002.lean
+++ b/Linglib/Studies/DechaineWiltschko2002.lean
@@ -34,8 +34,8 @@ view that `Pronoun.Strength`'s docstring flags as orthogonal.
 ## Implementation notes
 
 The φP layer is the locus of the person/number/gender φ-features modelled in
-`Features.Person` etc.; `hasPhiLayer` marks which categories project it. A full
-federation of the φ-internal geometry to `Features.Person` is left to follow-up.
+`UD.Person` etc.; `hasPhiLayer` marks which categories project it. A full
+federation of the φ-internal geometry to `UD.Person` is left to follow-up.
 -/
 
 namespace DechaineWiltschko2002
@@ -58,7 +58,7 @@ def Category.hasDLayer : Category → Bool
   | .proNP => false
 
 /-- Whether the category projects a φP layer — the locus of the person/number/
-    gender φ-features (cf. `Features.Person`). A bare `proNP` has none. -/
+    gender φ-features (cf. `UD.Person`). A bare `proNP` has none. -/
 def Category.hasPhiLayer : Category → Bool
   | .proDP => true
   | .prophiP => true

--- a/Linglib/Studies/HalpertHammerly2026.lean
+++ b/Linglib/Studies/HalpertHammerly2026.lean
@@ -1,7 +1,7 @@
 import Linglib.Fragments.Bantu.Params
 import Linglib.Fragments.Xhosa.Basic
 import Linglib.Fragments.Swahili.Basic
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Morphology.DM.Categorizer
 
 /-!
@@ -72,7 +72,7 @@ is derived from it via `AnimacyFeatures.toCoreClass`.
 namespace HalpertHammerly2026
 
 open Bantu
-open Features.Person (Features)
+open Person (Features)
 open Features.Prominence (PersonLevel)
 
 -- ============================================================================
@@ -101,7 +101,7 @@ def ProminenceFeatures.wellFormed (pf : ProminenceFeatures) : Bool :=
 
 /-- Extract the person projection. -/
 def ProminenceFeatures.personFeatures (pf : ProminenceFeatures) :
-    Features.Person.Features :=
+    Person.Features :=
   ⟨pf.hasParticipant, pf.hasAuthor⟩
 
 /-- Extract the animacy projection. -/
@@ -148,14 +148,14 @@ theorem firstF_person_is_human_animate :
   | false => simp [ProminenceFeatures.wellFormed] at hw
 
 /-- Person and animacy features share the `ContainmentPair` structure.
-    Both `Features.Person.Features` and `AnimacyFeatures` are `ContainmentPairLike`
+    Both `Person.Features` and `AnimacyFeatures` are `ContainmentPairLike`
     instances — the same three-cell, no-four-way-distinction architecture.
     This is not a coincidence: they are fragments of the same containment
     hierarchy ([hammerly-2023]). -/
 theorem person_animacy_same_structure :
-    (Features.ContainmentPairLike.toPair Features.Person.firstF).WellFormed ∧
+    (Features.ContainmentPairLike.toPair Person.firstF).WellFormed ∧
     (Features.ContainmentPairLike.toPair AnimacyFeatures.human).WellFormed ∧
-    (Features.ContainmentPairLike.toPair Features.Person.thirdF).WellFormed ∧
+    (Features.ContainmentPairLike.toPair Person.thirdF).WellFormed ∧
     (Features.ContainmentPairLike.toPair AnimacyFeatures.inanimate).WellFormed :=
   ⟨by decide, by decide, by decide, by decide⟩
 

--- a/Linglib/Studies/Harbour2016.lean
+++ b/Linglib/Studies/Harbour2016.lean
@@ -2,7 +2,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Finset.NAry
 import Mathlib.Data.Finset.Lattice.Fold
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Features.Number.Decomposition
 import Linglib.Syntax.Minimalist.CyclicAgree
 import Linglib.Syntax.Minimalist.Phi.Recursion
@@ -48,7 +48,7 @@ being stipulated:
 * `Examples` — the concrete three-element ontology `{i, u, o} = Fin 3`, where the
   partition cells live and the derived theorems are `decide`-checked.
 * `signOf` — Harbour's `±author`/`±participant` *signs* for a Cysouw `Category`
-  (theory-laden; cf. the neutral `Features.Person.Category.toFeatures`).
+  (theory-laden; cf. the neutral `Person.Category.toFeatures`).
 
 ## Main results (all *derived*, none stipulated)
 
@@ -240,12 +240,12 @@ open Number (singularF dualF pluralF)
 hierarchy in [bejar-rezac-2009]'s Cyclic Agree and [preminger-2014]'s relativized
 probing. -/
 theorem person_hierarchy_is_spec_ordering :
-    ContainmentPairLike.specLevel Features.Person.firstF >
-      ContainmentPairLike.specLevel Features.Person.secondF ∧
-    ContainmentPairLike.specLevel Features.Person.secondF >
-      ContainmentPairLike.specLevel Features.Person.thirdF :=
-  ContainmentPairLike.specLevel_strict_order Features.Person.firstF_is_maximal
-    Features.Person.secondF_is_intermediate Features.Person.thirdF_is_minimal
+    ContainmentPairLike.specLevel Person.firstF >
+      ContainmentPairLike.specLevel Person.secondF ∧
+    ContainmentPairLike.specLevel Person.secondF >
+      ContainmentPairLike.specLevel Person.thirdF :=
+  ContainmentPairLike.specLevel_strict_order Person.firstF_is_maximal
+    Person.secondF_is_intermediate Person.thirdF_is_minimal
 
 /-- The number hierarchy `sg > du > pl` is the *same* specification ordering — the
 structural reflection of the phi kernel, not an identification of the categories. -/
@@ -330,18 +330,18 @@ theorem bridge_configs_wellFormed :
 
 /-! ### Harbour's sign decomposition of the Cysouw categories ([harbour-2016] Table 4.3)
 
-The neutral `Features.Person.Category.toFeatures` underdetermines the group categories
+The neutral `Person.Category.toFeatures` underdetermines the group categories
 (`excl`/`minIncl`/`augIncl` all `⟨true,true⟩`). Harbour's **operational signs** distinguish
 them; that distinction is *this theory's* commitment, derived from the partition above. A
-dedicated `Sign` carrier is used rather than `Features.Person.Features`, because the
+dedicated `Sign` carrier is used rather than `Person.Features`, because the
 exclusive's `+author −participant` is exactly the combination the neutral type's `wellFormed`
 invariant (SAP containment: author ⟹ participant) rejects — for operations, not SAP-membership
 predicates, that invariant does not apply ([harbour-2016] Ch. 9). -/
 
-open Features.Person (Category)
+open Person (Category)
 
 /-- A Harbour `±author`/`±participant` sign — bivalent feature *values* ([harbour-2016]
-Ch. 9), distinct from the SAP-membership `Features.Person.Features`. -/
+Ch. 9), distinct from the SAP-membership `Person.Features`. -/
 structure Sign where
   author : Bool
   participant : Bool

--- a/Linglib/Studies/Harbour2016.lean
+++ b/Linglib/Studies/Harbour2016.lean
@@ -3,6 +3,7 @@ import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Finset.NAry
 import Mathlib.Data.Finset.Lattice.Fold
 import Linglib.Features.Person.Decomposition
+import Linglib.Features.Person.Interp
 import Linglib.Features.Number.Decomposition
 import Linglib.Syntax.Minimalist.CyclicAgree
 import Linglib.Syntax.Minimalist.Phi.Recursion
@@ -164,6 +165,19 @@ theorem quad_disjoint :
 
 /-- The quadripartition has four cells. -/
 theorem quad_card : (cellsOf quadRaws).card = 4 := by decide
+
+/-- **The calculus certifies the canonical inventory**: over the
+    referent lattice, the four quadripartition cells are exactly the
+    regions `Person.interp` assigns to the four quadripartition values
+    (speaker `0`, addressee `1`). The generative system and the
+    analytical inventory (`Features/Person/Basic.lean`) agree cell by
+    cell. -/
+theorem quad_cells_are_interp_regions :
+    ∀ s ∈ ℒπ,
+      (s ∈ inclusive ↔ Person.region (0 : Ω) 1 .firstInclusive s) ∧
+      (s ∈ exclusive ↔ Person.region (0 : Ω) 1 .firstExclusive s) ∧
+      (s ∈ secondP ↔ Person.region (0 : Ω) 1 .second s) ∧
+      (s ∈ thirdP ↔ Person.region (0 : Ω) 1 .third s) := by decide
 
 /-! #### Standard tripartition — participant composes outermost ([harbour-2016] §4.3.4) -/
 

--- a/Linglib/Studies/HartmannZimmermann2007.lean
+++ b/Linglib/Studies/HartmannZimmermann2007.lean
@@ -184,7 +184,7 @@ def exSitu_selective : FocusUtterance :=
 /-- Ex-situ + contrastive focus (paper eq. 27):
     *cî kawài akèe ta yî* 'it is only EATING that is going on.'
     Approximated with 3sg.M relative completive — paper uses the 4sg
-    impersonal *akèe* which `Features.Person.Category` does not yet expose. -/
+    impersonal *akèe* which `Person.Category` does not yet expose. -/
 def exSitu_contrastive : FocusUtterance :=
   mkExSituUtt cmp_3sm_R .masculine true (fun _ => rfl) .contrastive
 

--- a/Linglib/Studies/MunozPerez2026.lean
+++ b/Linglib/Studies/MunozPerez2026.lean
@@ -248,7 +248,7 @@ open Morphology.DM
 open Spanish.PersonFeatures
 open Spanish.Predicates
 open Spanish.Clitics
-open Features.Person
+open Person
 
 /-- The Spanish-specific realization output of Fission: two clitic
     positions. Cl₁ surfaces person features (`me`/`te`), Cl₂ is

--- a/Linglib/Studies/PanchevaZubizarreta2018.lean
+++ b/Linglib/Studies/PanchevaZubizarreta2018.lean
@@ -1,6 +1,6 @@
 import Linglib.Syntax.Minimalist.PConstraint
 import Linglib.Features.Logophoricity
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Fragments.Italian.Pronouns
 import Linglib.Fragments.Spanish.Clitics
 import Linglib.Studies.CharnavelMateu2015

--- a/Linglib/Studies/Sauerland2003.lean
+++ b/Linglib/Studies/Sauerland2003.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Plurality.Algebra
 import Linglib.Semantics.Plurality.Cover
 import Linglib.Features.ContainmentPair
 import Linglib.Features.Number.Decomposition
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Features.Gender
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Phenomena.Plurals.Multiplicity
@@ -694,7 +694,7 @@ theorem politeness_uses_unmarked :
     -- Plural (number)
     isSemanticUnmarked (ContainmentPairLike.toPair Number.pluralF) = true ∧
     -- 3rd person
-    isSemanticUnmarked (ContainmentPairLike.toPair Features.Person.thirdF) = true ∧
+    isSemanticUnmarked (ContainmentPairLike.toPair Person.thirdF) = true ∧
     -- Masculine (gender)
     isSemanticUnmarked (ContainmentPairLike.toPair Features.Gender.masculineF) = true :=
   ⟨rfl, rfl, rfl⟩
@@ -704,7 +704,7 @@ theorem politeness_uses_unmarked :
     restrictions on the addressee. -/
 theorem marked_not_polite :
     isSemanticMarked (ContainmentPairLike.toPair Number.singularF) = true ∧
-    isSemanticMarked (ContainmentPairLike.toPair Features.Person.firstF) = true ∧
+    isSemanticMarked (ContainmentPairLike.toPair Person.firstF) = true ∧
     isSemanticMarked (ContainmentPairLike.toPair Features.Gender.neuterF) = true :=
   ⟨rfl, rfl, rfl⟩
 

--- a/Linglib/Studies/Toosarvandani2023.lean
+++ b/Linglib/Studies/Toosarvandani2023.lean
@@ -5,7 +5,7 @@ import Mathlib.Data.Finset.NAry
 import Mathlib.Data.Finset.Prod
 import Mathlib.Data.Finset.Erase
 import Mathlib.Data.Fintype.Basic
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Syntax.Minimalist.Phi.Lattice
 
 /-!
@@ -49,7 +49,7 @@ with first- and second-person plural pronouns.
 - §6 Structural properties of the PCC condition
 - §7 Denotation ↔ PCC correspondence
 - §8 Heterogeneity and SINGULAR/PLURAL composition order
-- §9 Bridges to `Features.Person` and `Features.Prominence`
+- §9 Bridges to `UD.Person` and `Features.Prominence`
 
 ## Note on absolute vs relative PCC
 
@@ -634,7 +634,7 @@ theorem wrong_order_produces_plural :
       oplus (speakerDen zd) (singularFilter (participantDen zd)) := by decide
 
 -- ============================================================================
--- § 9: Bridges to Features.Person / Features.Prominence
+-- § 9: Bridges to UD.Person / Features.Prominence
 -- ============================================================================
 
 /-- Map PronType to the coarser 3-way person distinction in
@@ -651,7 +651,7 @@ theorem pcc_person_refinement : ∀ p1 p2 : PronType,
   decide
 
 /-- Map PronType to binary person features (±participant, ±author). -/
-def PronType.toPersonFeatures : PronType → Features.Person.Features
+def PronType.toPersonFeatures : PronType → Person.Features
   | .first  => ⟨true, true⟩
   | .second => ⟨true, false⟩
   | _       => ⟨false, false⟩

--- a/Linglib/Studies/Wang2023.lean
+++ b/Linglib/Studies/Wang2023.lean
@@ -437,7 +437,7 @@ theorem plural_strategy_is_plSem :
 /-- The 3rd-person strategy targets the minimal PERSON cell,
     which is `thirdSem` — the PrProp with vacuous presupposition. -/
 theorem thirdPerson_strategy_is_third :
-    honStrategyCell .thirdPerson = ContainmentPairLike.toPair Features.Person.thirdF :=
+    honStrategyCell .thirdPerson = ContainmentPairLike.toPair Person.thirdF :=
   rfl
 
 /-- Both strategies target cells whose presuppositional denotations

--- a/Linglib/Syntax/Agreement/Paradigm.lean
+++ b/Linglib/Syntax/Agreement/Paradigm.lean
@@ -2,6 +2,7 @@ import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Morphology.Word
 import Linglib.Features.Number.Capabilities
+import Linglib.Features.Person.Capabilities
 
 /-!
 # Agreement paradigms — the descriptive realization table
@@ -79,6 +80,8 @@ def Cell.isPlural (c : Cell) : Bool := c.number == some .Plur
 /-- A cell bears the number its UD slot ingests (`Number.fromUD`); an
     undistinguished slot leaves the cell unvalued (wildcard). -/
 instance : HasNumber Cell := ⟨fun c => c.number.bind Number.fromUD⟩
+
+instance : HasPerson Cell := ⟨fun c => c.person.map Person.fromUD⟩
 
 /-- The basic 3-person × {singular, plural} inventory of φ-cells — the cells a
     person/number agreement paradigm ranges over. -/

--- a/Linglib/Syntax/Minimalist/Phi/Geometry.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Geometry.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 
 /-!
 # Person Feature Geometry [harley-ritter-2002] [bejar-rezac-2003]
@@ -48,7 +48,7 @@ alignment systems ([pancheva-zubizarreta-2018] §2.1 (11)).
 
 ## Relationship to Core PersonFeatures
 
-`DecomposedPerson` extends `Features.Person.Features`
+`DecomposedPerson` extends `Person.Features`
 (the framework-neutral [±participant, ±author] decomposition) with
 the Minimalism-specific [±proximate] feature. The two-feature core
 is shared across all theoretical frameworks; `[±proximate]` is
@@ -88,7 +88,7 @@ open Features.Prominence
     geometry, extended with `[±proximate]` from
     [pancheva-zubizarreta-2018].
 
-    Extends `Features.Person.Features` (the framework-neutral
+    Extends `Person.Features` (the framework-neutral
     [±participant, ±author] core) with the Minimalism-specific
     [±proximate] feature:
 
@@ -105,7 +105,7 @@ open Features.Prominence
     [−participant]. We encode this as `Bool` for computational
     convenience; the well-formedness constraint `wellFormed`
     ensures the privative entailments are maintained. -/
-structure DecomposedPerson extends Features.Person.Features where
+structure DecomposedPerson extends Person.Features where
   /-- Bears [proximate]? SAPs inherently; 3P contextually. -/
   hasProximate : Bool
   deriving DecidableEq, Repr

--- a/Linglib/Syntax/Minimalist/SpeechActs.lean
+++ b/Linglib/Syntax/Minimalist/SpeechActs.lean
@@ -8,7 +8,7 @@ import Linglib.Discourse.Intentionality
 import Linglib.Discourse.Commitment.Basic
 import Linglib.Features.Evidentiality
 import Linglib.Fragments.English.Pronouns
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 
 /-!
 # Configurational Point-of-View Roles
@@ -36,7 +36,6 @@ c-commands content.
 
 -/
 
-open Features (Person)
 
 namespace Minimalist.SpeechActs
 
@@ -262,7 +261,7 @@ theorem seat_of_knowledge_interrogative {W E P T : Type*} (ctx : KContext W E P 
     1st person → SPEAKER (Spec-SAP)
     2nd person → HEARER (complement of SA)
     3rd person / zero → neither (referential, not a discourse role) -/
-def personToRole : Person → Option PRole
+def personToRole : UD.Person → Option PRole
   | .first  => some .speaker
   | .second => some .hearer
   | .third  => none
@@ -293,7 +292,7 @@ theorem third_person_no_role :
 
 /-- Discourse role is determined entirely by person feature. -/
 theorem discourse_role_from_person (p : PersonalPronoun)
-    (per : Person) (hp : p.person = some per) :
+    (per : UD.Person) (hp : p.person = some per) :
     pronounDiscourseRole p = personToRole per := by
   simp [pronounDiscourseRole, hp]
 

--- a/Linglib/Syntax/Pronoun/Basic.lean
+++ b/Linglib/Syntax/Pronoun/Basic.lean
@@ -6,7 +6,7 @@ import Linglib.Features.Prominence
 import Linglib.Features.Gender
 import Linglib.Features.Clusivity
 import Linglib.Features.CoreferenceStatus
-import Linglib.Features.Person
+import Linglib.Features.Person.Decomposition
 import Linglib.Morphology.Word
 
 /-!
@@ -37,7 +37,6 @@ in as fields of the general `Pronoun`.
 * `Pronoun.AllocutiveEntry` — speaker–addressee (allocutive) markers.
 -/
 
-open Features (Person)
 
 set_option autoImplicit false
 
@@ -112,7 +111,7 @@ structure Pronoun where
   /-- Surface form (romanization or orthographic). -/
   form : String
   /-- Grammatical person (UD.Person via Core.Word abbrev). -/
-  person : Option Person := none
+  person : Option UD.Person := none
   /-- Grammatical number. -/
   number : Option UD.Number := none
   /-- Clusivity (inclusive/exclusive) of a first-person non-singular form — the
@@ -205,7 +204,7 @@ def toWord (p : Pronoun) : Word :=
     person-reference, *derived* (not stored). `none` when person/number is
     underspecified, or for a clusivity-unmarked first-person plural (a syncretism
     over `.minIncl`/`.augIncl`/`.excl`, e.g. English *we*). -/
-def category (p : Pronoun) : Option Features.Person.Category :=
+def category (p : Pronoun) : Option Person.Category :=
   match p.person, p.number with
   | some per, some num => Features.Clusivity.categoryOf per num p.clusivity
   | _, _ => none

--- a/Linglib/Syntax/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Pronoun/Capabilities.lean
@@ -1,5 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities
+import Linglib.Features.Person.Capabilities
 import Linglib.Features.CoreferenceStatus
 import Linglib.Features.Register
 import Linglib.Features.Prominence
@@ -119,6 +120,37 @@ the same value off the carrier and off the projected token (`Pronoun.toWord`
 threads `number` faithfully). -/
 theorem numberOf_toWord (p : Pronoun) :
     HasNumber.numberOf p.toWord = HasNumber.numberOf p := rfl
+
+/-! ### The person axis: `HasPerson` instances and faithfulness -/
+
+/-- A pronoun's analytical person: the (UD person, clusivity) field pair
+recovers the quadripartition cell — Tagalog *kami* = `firstExclusive` —
+so consumers unify on root `Person` before any carrier retype. -/
+instance : HasPerson Pronoun :=
+  ⟨fun p => p.person.map fun ud =>
+    match ud, p.clusivity with
+    | .first, some .inclusive => .firstInclusive
+    | .first, some .exclusive => .firstExclusive
+    | ud, _ => Person.fromUD ud⟩
+
+instance : HasPerson PersonalPronoun :=
+  ⟨fun p => HasPerson.personOf p.toPronoun⟩
+
+/-- Projecting a pronoun to a `Word` coarsens its person: `Word` carries
+UD realization, which has no clusivity — the mixin makes the loss
+explicit rather than silent. -/
+theorem personOf_toWord (p : Pronoun) :
+    HasPerson.personOf p.toWord =
+      (HasPerson.personOf p).map Person.coarsen := by
+  show p.person.map Person.fromUD =
+    (p.person.map _).map Person.coarsen
+  cases p.person with
+  | none => rfl
+  | some ud =>
+    cases ud <;> cases hc : p.clusivity <;>
+      first
+        | rfl
+        | (rename_i v; cases v <;> rfl)
 
 /-! ### Orthogonal data-mixins: `Deictic`, `Clusive` -/
 


### PR DESCRIPTION
The Person API — phases 1+2 (the Number #135–#140 arc in one PR): root-namespace `Person` — first / firstInclusive / firstExclusive / second / third / zero — with clusivity folded in as person values; the `Features.Person := UD.Person` abbrev is deleted and UD demoted to realization (`toUD` collapses the quadripartition cells; `fromUD ∘ toUD = coarsen`). `HasPerson` wired into nine carriers (the Pronoun instance derives the quadripartition cell from the (person, clusivity) field pair), with `personOf_toWord` making realization loss explicit (`map coarsen`, not `rfl`).

The semantics is derived end to end: `Person.interp` assigns each value a referent region (speaker/addressee inclusion); `interp_resolve` proves the coordination table is referent union, with the Zwicky 1 < 2 < 3 hierarchy as `resolveIn_tripartition_min` and the `Profile` disjunction as its (i,u)-shadow. Two primary-source certifications: `Harbour2016.quad_cells_are_interp_regions` (the partition calculus generates exactly the inventory's regions, cell by cell) and `DalrympleKaplan2000.person_resolve_is_union` (the resolution commutes with their Fula marker encoding).

- Old `Features/Person.lean` restructured as `Features/Person/Decomposition.lean` (namespace `Person.*`); `Category.person` projection added toward the `Category ≃ Person × Number` junction (deferred pending Cysouw verification).
- `Person.System` ships structural predicates only; typological universals await verification against Cysouw 2009.