### PR TITLE
fix(Typology/Gender): count controller genders, not noun classes

### DIFF
--- a/Linglib/Fragments/Archi/Gender.lean
+++ b/Linglib/Fragments/Archi/Gender.lean
@@ -31,7 +31,11 @@ def genderTypology : GenderProfile :=
     (agreementTargets := [.predicate, .verb])
     (semanticBases := [.rationality, .sex, .animacy])
 
-example : genderTypology.iso639 = "aqc" ∧ genderTypology.name = "Archi" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "aqc" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Archi" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 end Archi.Gender

--- a/Linglib/Fragments/Dyirbal/Gender.lean
+++ b/Linglib/Fragments/Dyirbal/Gender.lean
@@ -29,7 +29,11 @@ def genderTypology : GenderProfile :=
     (agreementTargets := [.attributive])
     (semanticBases := [.sex, .animacy, .shape])
 
-example : genderTypology.iso639 = "dbl" ∧ genderTypology.name = "Dyirbal" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "dbl" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Dyirbal" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 end Dyirbal.Gender

--- a/Linglib/Fragments/English/Gender.lean
+++ b/Linglib/Fragments/English/Gender.lean
@@ -28,7 +28,11 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine, .neuter])
 
-example : genderTypology.iso639 = "eng" ∧ genderTypology.name = "English" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "eng" := rfl
+
+theorem genderTypology_name : genderTypology.name = "English" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 end English.Gender

--- a/Linglib/Fragments/Finnish/Gender.lean
+++ b/Linglib/Fragments/Finnish/Gender.lean
@@ -16,7 +16,11 @@ def genderTypology : GenderProfile :=
   .fromWALS "Finnish" "fin"
     (rawGenderCount := 0)
 
-example : genderTypology.iso639 = "fin" ∧ genderTypology.name = "Finnish" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "fin" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Finnish" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 end Finnish.Gender

--- a/Linglib/Fragments/French/Gender.lean
+++ b/Linglib/Fragments/French/Gender.lean
@@ -23,11 +23,16 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])
 
-example : genderTypology.iso639 = "fra" ∧ genderTypology.name = "French" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "fra" := rfl
+
+theorem genderTypology_name : genderTypology.name = "French" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- French is in [corbett-1991]'s "canonical" cell:
     sex-based, 2-or-3 gender, semantic + formal. -/
-example : genderTypology.IsCanonicalGender := by decide
+theorem isCanonicalGender_genderTypology :
+    genderTypology.IsCanonicalGender := by decide
 
 end French.Gender

--- a/Linglib/Fragments/Fula/Gender.lean
+++ b/Linglib/Fragments/Fula/Gender.lean
@@ -4,15 +4,16 @@ import Linglib.Typology.Gender
 # Fula Gender
 [corbett-1991] [corbett-2013]
 
-~20+ noun classes (Atlantic, Niger-Congo). One of the richest class systems
-in Africa. Sample maximum in Corbett's 22-language exemplar.
+"About twenty genders, depending on the dialect" ([corbett-1991] §7.1.1)
+— one of the richest gender systems in Africa (Atlantic, Niger-Congo).
+Sample maximum in Corbett's 22-language exemplar.
 -/
 
 namespace Fula.Gender
 
 open Typology.Gender
 
-/-- Fula gender typology: 20-class Atlantic, semantic + formal. -/
+/-- Fula gender typology: ~20 genders (Atlantic), semantic + formal. -/
 def genderTypology : GenderProfile :=
   .fromWALS "Fula" "ful"
     (rawGenderCount := 20)
@@ -22,10 +23,15 @@ def genderTypology : GenderProfile :=
     (agreementTargets := [.attributive, .predicate, .personalPronoun, .verb])
     (semanticBases := [.humanness, .animacy, .shape])
 
-example : genderTypology.iso639 = "ful" ∧ genderTypology.name = "Fula" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "ful" := rfl
 
-/-- Fula is a noun-class system (20+ classes per [corbett-1991]). -/
-example : genderTypology.IsNounClassSystem := by decide
+theorem genderTypology_name : genderTypology.name = "Fula" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
+
+/-- Fula is a noun-class system (~20 genders per [corbett-1991]). -/
+theorem isNounClassSystem_genderTypology :
+    genderTypology.IsNounClassSystem := by decide
 
 end Fula.Gender

--- a/Linglib/Fragments/Georgian/Gender.lean
+++ b/Linglib/Fragments/Georgian/Gender.lean
@@ -22,7 +22,11 @@ def genderTypology : GenderProfile :=
   .fromWALS "Georgian" "kat"
     (rawGenderCount := 0)
 
-example : genderTypology.iso639 = "kat" ∧ genderTypology.name = "Georgian" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "kat" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Georgian" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 end Georgian.Gender

--- a/Linglib/Fragments/German/Gender.lean
+++ b/Linglib/Fragments/German/Gender.lean
@@ -140,10 +140,15 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine, .neuter])
 
-example : genderTypology.iso639 = "deu" ∧ genderTypology.name = "German" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "deu" := rfl
+
+theorem genderTypology_name : genderTypology.name = "German" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- German is in [corbett-1991]'s "canonical" cell. -/
-example : genderTypology.IsCanonicalGender := by decide
+theorem isCanonicalGender_genderTypology :
+    genderTypology.IsCanonicalGender := by decide
 
 end German.Gender

--- a/Linglib/Fragments/Hausa/Gender.lean
+++ b/Linglib/Fragments/Hausa/Gender.lean
@@ -169,11 +169,16 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])
 
-example : genderTypology.iso639 = "hau" ∧ genderTypology.name = "Hausa" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "hau" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Hausa" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- Hausa is in [corbett-1991]'s "canonical" cell (2-gender,
     sex-based, semantic + formal). -/
-example : genderTypology.IsCanonicalGender := by decide
+theorem isCanonicalGender_genderTypology :
+    genderTypology.IsCanonicalGender := by decide
 
 end Hausa.Gender

--- a/Linglib/Fragments/Hebrew/Gender.lean
+++ b/Linglib/Fragments/Hebrew/Gender.lean
@@ -23,10 +23,15 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])
 
-example : genderTypology.iso639 = "heb" ∧ genderTypology.name = "Hebrew" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "heb" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Hebrew" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- Hebrew is in [corbett-1991]'s "canonical" cell. -/
-example : genderTypology.IsCanonicalGender := by decide
+theorem isCanonicalGender_genderTypology :
+    genderTypology.IsCanonicalGender := by decide
 
 end Hebrew.Gender

--- a/Linglib/Fragments/Hindi/Gender.lean
+++ b/Linglib/Fragments/Hindi/Gender.lean
@@ -23,10 +23,15 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])
 
-example : genderTypology.iso639 = "hin" ∧ genderTypology.name = "Hindi-Urdu" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "hin" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Hindi-Urdu" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- Hindi-Urdu is in [corbett-1991]'s "canonical" cell. -/
-example : genderTypology.IsCanonicalGender := by decide
+theorem isCanonicalGender_genderTypology :
+    genderTypology.IsCanonicalGender := by decide
 
 end Hindi.Gender

--- a/Linglib/Fragments/Irish/Gender.lean
+++ b/Linglib/Fragments/Irish/Gender.lean
@@ -24,10 +24,15 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])
 
-example : genderTypology.iso639 = "gle" ∧ genderTypology.name = "Irish" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "gle" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Irish" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- Irish is in [corbett-1991]'s "canonical" cell. -/
-example : genderTypology.IsCanonicalGender := by decide
+theorem isCanonicalGender_genderTypology :
+    genderTypology.IsCanonicalGender := by decide
 
 end Irish.Gender

--- a/Linglib/Fragments/Japanese/Gender.lean
+++ b/Linglib/Fragments/Japanese/Gender.lean
@@ -16,7 +16,11 @@ def genderTypology : GenderProfile :=
   .fromWALS "Japanese" "jpn"
     (rawGenderCount := 0)
 
-example : genderTypology.iso639 = "jpn" ∧ genderTypology.name = "Japanese" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "jpn" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Japanese" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 end Japanese.Gender

--- a/Linglib/Fragments/Korean/Gender.lean
+++ b/Linglib/Fragments/Korean/Gender.lean
@@ -16,7 +16,11 @@ def genderTypology : GenderProfile :=
   .fromWALS "Korean" "kor"
     (rawGenderCount := 0)
 
-example : genderTypology.iso639 = "kor" ∧ genderTypology.name = "Korean" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "kor" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Korean" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 end Korean.Gender

--- a/Linglib/Fragments/Latin/Gender.lean
+++ b/Linglib/Fragments/Latin/Gender.lean
@@ -23,9 +23,15 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine, .neuter])
 
-example : genderTypology.iso639 = "lat" ∧ genderTypology.name = "Latin" := ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "lat" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Latin" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- Latin is in [corbett-1991]'s "canonical" cell. -/
-example : genderTypology.IsCanonicalGender := by decide
+theorem isCanonicalGender_genderTypology :
+    genderTypology.IsCanonicalGender := by decide
 
 end Latin.Gender

--- a/Linglib/Fragments/Mandarin/Gender.lean
+++ b/Linglib/Fragments/Mandarin/Gender.lean
@@ -16,7 +16,11 @@ def genderTypology : GenderProfile :=
   .fromWALS "Mandarin Chinese" "cmn"
     (rawGenderCount := 0)
 
-example : genderTypology.iso639 = "cmn" ∧ genderTypology.name = "Mandarin Chinese" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "cmn" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Mandarin Chinese" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 end Mandarin.Gender

--- a/Linglib/Fragments/Quechua/Gender.lean
+++ b/Linglib/Fragments/Quechua/Gender.lean
@@ -18,7 +18,11 @@ def genderTypology : GenderProfile :=
   .fromWALS "Quechua (Cusco)" "quz"
     (rawGenderCount := 0)
 
-example : genderTypology.iso639 = "quz" ∧ genderTypology.name = "Quechua (Cusco)" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "quz" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Quechua (Cusco)" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 end Quechua.Gender

--- a/Linglib/Fragments/Romanian/Gender.lean
+++ b/Linglib/Fragments/Romanian/Gender.lean
@@ -23,10 +23,15 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine, .neuter])
 
-example : genderTypology.iso639 = "ron" ∧ genderTypology.name = "Romanian" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "ron" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Romanian" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- Romanian is in [corbett-1991]'s "canonical" cell. -/
-example : genderTypology.IsCanonicalGender := by decide
+theorem isCanonicalGender_genderTypology :
+    genderTypology.IsCanonicalGender := by decide
 
 end Romanian.Gender

--- a/Linglib/Fragments/Shona/Gender.lean
+++ b/Linglib/Fragments/Shona/Gender.lean
@@ -4,7 +4,8 @@ import Linglib.Typology.Gender
 # Shona Gender
 [corbett-1991] [corbett-2013]
 
-Bantu noun-class system. Carstens 2026 cites 8 active gender classes.
+Bantu noun-class system. [carstens-2026] cites 8 active genders
+(controller genders); only 1/2 and 7/8 are interpretable.
 -/
 
 namespace Shona.Gender
@@ -22,10 +23,15 @@ def genderTypology : GenderProfile :=
                           .personalPronoun, .verb])
     (semanticBases := [.humanness])
 
-example : genderTypology.iso639 = "sna" ∧ genderTypology.name = "Shona" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "sna" := rfl
 
-/-- Shona is a noun-class system (Bantu, 8 classes per [carstens-2026]). -/
-example : genderTypology.IsNounClassSystem := by decide
+theorem genderTypology_name : genderTypology.name = "Shona" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
+
+/-- Shona is a noun-class system (Bantu, 8 genders per [carstens-2026]). -/
+theorem isNounClassSystem_genderTypology :
+    genderTypology.IsNounClassSystem := by decide
 
 end Shona.Gender

--- a/Linglib/Fragments/Slavic/Russian/Gender.lean
+++ b/Linglib/Fragments/Slavic/Russian/Gender.lean
@@ -204,10 +204,15 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine, .neuter])
 
-example : genderTypology.iso639 = "rus" ∧ genderTypology.name = "Russian" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "rus" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Russian" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- Russian is in [corbett-1991]'s "canonical" cell. -/
-example : genderTypology.IsCanonicalGender := by decide
+theorem isCanonicalGender_genderTypology :
+    genderTypology.IsCanonicalGender := by decide
 
 end Russian.Gender

--- a/Linglib/Fragments/Spanish/Gender.lean
+++ b/Linglib/Fragments/Spanish/Gender.lean
@@ -176,10 +176,15 @@ def genderTypology : GenderProfile :=
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])
 
-example : genderTypology.iso639 = "spa" ∧ genderTypology.name = "Spanish" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "spa" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Spanish" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- Spanish is in [corbett-1991]'s "canonical" cell. -/
-example : genderTypology.IsCanonicalGender := by decide
+theorem isCanonicalGender_genderTypology :
+    genderTypology.IsCanonicalGender := by decide
 
 end Spanish.Gender

--- a/Linglib/Fragments/Swahili/Gender.lean
+++ b/Linglib/Fragments/Swahili/Gender.lean
@@ -4,23 +4,25 @@ import Linglib.Typology.Gender
 # Swahili Gender
 [corbett-1991] [corbett-2013]
 
-~15 noun classes (singular/plural pairings + locatives). Bantu noun-class
-system: semantic + formal assignment via prefixes. Full agreement across
-determiners, adjectives, verbs, pronouns, numerals, possessives.
-
-`attestedSurfaceGenders := []` because the 15-class system doesn't fit
-the Indo-European `SurfaceGender` enum; per-Fragment lexical files would
-expose a fine-grained `Class` type for noun-class agreement morphology.
+7 controller genders — the singular/plural pairings 1/2, 3/4, 5/6, 7/8,
+9/10, 11/10, 15 of [corbett-1991]'s Table 3.4 — over ~15 traditional
+noun classes; the locative classes 16/17/18 are minor target genders,
+not controller genders ([corbett-1991] §6.3.3). Semantic + formal
+assignment via prefixes, with concord on all five `AgreementTarget`
+positions (Swahili concord also reaches numerals, possessives, and
+demonstratives, which the enum does not model). `attestedSurfaceGenders`
+stays `[]`: noun-class agreement doesn't map onto the Indo-European
+`SurfaceGender` scheme.
 -/
 
 namespace Swahili.Gender
 
 open Typology.Gender
 
-/-- Swahili gender typology: 15-class Bantu, semantic + formal. -/
+/-- Swahili gender typology: 7 controller genders (Bantu), semantic + formal. -/
 def genderTypology : GenderProfile :=
   .fromWALS "Swahili" "swh"
-    (rawGenderCount := 15)
+    (rawGenderCount := 7)
     (genderCountFb := .fivePlus)
     (basisFb := .nonSexBased)
     (assignmentFb := .semanticAndFormal)
@@ -28,10 +30,15 @@ def genderTypology : GenderProfile :=
                           .personalPronoun, .verb])
     (semanticBases := [.humanness, .animacy, .shape])
 
-example : genderTypology.iso639 = "swh" ∧ genderTypology.name = "Swahili" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "swh" := rfl
 
-/-- Swahili is a noun-class system (5+ classes per [corbett-1991]). -/
-example : genderTypology.IsNounClassSystem := by decide
+theorem genderTypology_name : genderTypology.name = "Swahili" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
+
+/-- Swahili is a noun-class system (5+ genders per [corbett-1991]). -/
+theorem isNounClassSystem_genderTypology :
+    genderTypology.IsNounClassSystem := by decide
 
 end Swahili.Gender

--- a/Linglib/Fragments/Turkish/Gender.lean
+++ b/Linglib/Fragments/Turkish/Gender.lean
@@ -16,7 +16,11 @@ def genderTypology : GenderProfile :=
   .fromWALS "Turkish" "tur"
     (rawGenderCount := 0)
 
-example : genderTypology.iso639 = "tur" ∧ genderTypology.name = "Turkish" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "tur" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Turkish" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 end Turkish.Gender

--- a/Linglib/Fragments/Xhosa/Gender.lean
+++ b/Linglib/Fragments/Xhosa/Gender.lean
@@ -4,8 +4,9 @@ import Linglib.Typology.Gender
 # Xhosa Gender
 [corbett-1991] [corbett-2013]
 
-Bantu noun-class system. Carstens 2026 cites 5 active gender classes for
-the agreement-side analysis; the morphological inventory is larger.
+Bantu noun-class system. [carstens-2026] cites 5 active genders —
+controller genders 1/2, 3/4, 5/6, 7/8, 9/10 (labels A–E) — for the
+agreement-side analysis; the morphological class inventory is larger.
 -/
 
 namespace Xhosa.Gender
@@ -23,10 +24,15 @@ def genderTypology : GenderProfile :=
                           .personalPronoun, .verb])
     (semanticBases := [.humanness, .animacy])
 
-example : genderTypology.iso639 = "xho" ∧ genderTypology.name = "Xhosa" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "xho" := rfl
+
+theorem genderTypology_name : genderTypology.name = "Xhosa" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
 
 /-- Xhosa is a noun-class system (Bantu, 5+ classes). -/
-example : genderTypology.IsNounClassSystem := by decide
+theorem isNounClassSystem_genderTypology :
+    genderTypology.IsNounClassSystem := by decide
 
 end Xhosa.Gender

--- a/Linglib/Fragments/Zulu/Gender.lean
+++ b/Linglib/Fragments/Zulu/Gender.lean
@@ -4,17 +4,24 @@ import Linglib.Typology.Gender
 # Zulu Gender
 [corbett-1991] [corbett-2013]
 
-~15 noun classes. Bantu noun-class system parallel to Swahili.
+Bantu noun-class system parallel to Swahili: 8 controller genders
+(singular/plural pairings 1/2, 3/4, 5/6, 7/8, 9/10, 11/10, 14, 15;
+class 1a/2a nouns take 1/2 concords) over ~15 traditional noun classes.
+The count applies [corbett-1991]'s pairing convention (§6.3, as in his
+Table 3.4 for Swahili) to the standard Nguni inventory; Corbett 1991
+mentions Zulu only in passing.
+-- UNVERIFIED: the figure 8 is not yet checked against a dedicated Zulu
+grammar.
 -/
 
 namespace Zulu.Gender
 
 open Typology.Gender
 
-/-- Zulu gender typology: 15-class Bantu, semantic + formal. -/
+/-- Zulu gender typology: 8 controller genders (Bantu), semantic + formal. -/
 def genderTypology : GenderProfile :=
   .fromWALS "Zulu" "zul"
-    (rawGenderCount := 15)
+    (rawGenderCount := 8)
     (genderCountFb := .fivePlus)
     (basisFb := .nonSexBased)
     (assignmentFb := .semanticAndFormal)
@@ -22,10 +29,15 @@ def genderTypology : GenderProfile :=
                           .personalPronoun, .verb])
     (semanticBases := [.humanness, .animacy, .shape])
 
-example : genderTypology.iso639 = "zul" ∧ genderTypology.name = "Zulu" :=
-  ⟨rfl, rfl⟩
+theorem genderTypology_iso639 : genderTypology.iso639 = "zul" := rfl
 
-/-- Zulu is a noun-class system (5+ classes per [corbett-1991]). -/
-example : genderTypology.IsNounClassSystem := by decide
+theorem genderTypology_name : genderTypology.name = "Zulu" := rfl
+
+theorem isRawCountConsistent_genderTypology :
+    genderTypology.IsRawCountConsistent := by decide
+
+/-- Zulu is a noun-class system (5+ genders per [corbett-1991]). -/
+theorem isNounClassSystem_genderTypology :
+    genderTypology.IsNounClassSystem := by decide
 
 end Zulu.Gender

--- a/Linglib/Fragments/Zulu/Gender.lean
+++ b/Linglib/Fragments/Zulu/Gender.lean
@@ -2,16 +2,17 @@ import Linglib.Typology.Gender
 
 /-!
 # Zulu Gender
-[corbett-1991] [corbett-2013]
+[corbett-1991] [corbett-2013] [poulos-msimang-1998]
 
-Bantu noun-class system parallel to Swahili: 8 controller genders
-(singular/plural pairings 1/2, 3/4, 5/6, 7/8, 9/10, 11/10, 14, 15;
-class 1a/2a nouns take 1/2 concords) over ~15 traditional noun classes.
-The count applies [corbett-1991]'s pairing convention (§6.3, as in his
-Table 3.4 for Swahili) to the standard Nguni inventory; Corbett 1991
-mentions Zulu only in passing.
--- UNVERIFIED: the figure 8 is not yet checked against a dedicated Zulu
-grammar.
+Bantu noun-class system parallel to Swahili: 8 controller genders — the
+singular/plural pairings 1/2, 3/4, 5/6, 7/8, 9/10, 11/10, 14, 15 — over
+the 15-class Nguni inventory of [poulos-msimang-1998] §1.2 (classes 1,
+2, 1a, 2b, 3–11, 14, 15; 12 and 13 absent). Classes 1a/2b "use the same
+concords as classes 1 and 2"; class 11 plurals fall in class 10; class
+15 infinitives show no singular/plural distinction; locative classes
+16/17/18 are number-neutral. The count applies [corbett-1991]'s pairing
+convention (§6.3, as in his Table 3.4 for Swahili) to those concord
+facts.
 -/
 
 namespace Zulu.Gender

--- a/Linglib/Studies/Corbett1991.lean
+++ b/Linglib/Studies/Corbett1991.lean
@@ -51,7 +51,7 @@ semanticBases, attestedSurfaceGenders) are local per-language commitments.
 - **5+ noun classes** (Swahili, Zulu, Fula — 3 languages).
 
 The sample includes Bantu noun-class systems (Swahili, Zulu) and Fula
-(20+ classes), the Australian 4-class system Dyirbal, and the
+(~20 genders), the Australian 4-class system Dyirbal, and the
 Nakh-Daghestanian 4-gender system Archi (sex-based at the rational tier,
 non-rational genders by animacy), alongside the canonical European
 sex-based 2/3 systems and English's pronominal gender.

--- a/Linglib/Typology/Gender.lean
+++ b/Linglib/Typology/Gender.lean
@@ -32,10 +32,11 @@ substrate-extension pattern. Fragment-importable.
 
 ## Theory-laden caveats
 
-- **`GenderCount.fivePlus` is a single bin** for systems with 5+ noun
-  classes. The boundary between "gender" (2-3) and "noun class" (4+) is
-  conventional, not categorical ([corbett-1991]). Bantu languages
-  with ~15 classes and Fula with ~20 are both `.fivePlus`.
+- **`GenderCount.fivePlus` is a single bin** for systems with 5+ genders.
+  The boundary between "gender" (2-3) and "noun class" (4+) is
+  conventional, not categorical ([corbett-1991]). Raw counts are
+  controller genders, not morphological classes: Swahili has 7 genders
+  over ~15 traditional noun classes; Fula has ~20 genders.
 - **`SemanticBasis` lists 5 dimensions** (sex, animacy, humanness, shape,
   rationality); other classifications (e.g. Aikhenvald 2003 noun-classifier
   semantics) cut differently.
@@ -134,7 +135,10 @@ structure GenderProfile where
   iso639 : String
   /-- Ch 30: number of genders (WALS bin). -/
   genderCount : GenderCount
-  /-- Actual number of gender / noun class categories. -/
+  /-- Number of controller genders: sets of nouns taking the same
+      agreements, typically singular/plural pairings ([corbett-1991] §6.3).
+      For Bantu this counts genders like 1/2 — *not* the larger
+      traditional noun-class inventory (Swahili: 7 genders, ~15 classes). -/
   rawGenderCount : Nat
   /-- Ch 31: sex-based or non-sex-based. -/
   basis : GenderBasis

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -3947,6 +3947,18 @@
   validated = {true},
   sources   = {Phenomena/Gender/Typology.lean}
 }% REF: Dowty, D. (1991). Thematic proto-roles and argument selection. *Language* 67(3), 547–619. — Proto-Agent P1 (volitional i
+@book{poulos-msimang-1998,
+  author    = {Poulos, George and Msimang, Christian T.},
+  year      = {1998},
+  title     = {A Linguistic Analysis of Zulu},
+  publisher = {Via Afrika},
+  address   = {Cape Town},
+  isbn      = {9780799415261},
+  subfield  = {comparative},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Zulu/Gender.lean}
+}
 @book{diesing-1992,
   author    = {Diesing, Molly},
   year      = {1992},


### PR DESCRIPTION
rawGenderCount was split between two conventions: Swahili/Zulu counted morphological noun classes (15) while Xhosa/Shona counted controller genders (5/8). Adopts the WALS/Corbett convention substrate-wide, verified against primary sources: Swahili = 7 (Corbett 1991, Table 3.4), Fula = ~20 genders (Corbett 1991 §7.1.1), Zulu = 8 (pairings and concord facts from Poulos & Msimang 1998 §1.2; adds the bib entry).

- All 25 `Fragments/*/Gender.lean` convert anonymous `example`s to named theorems and gain an `isRawCountConsistent_genderTypology` sentry.