### PR TITLE
refactor(Typology/Gender): drop dead WALS fallbacks; mathlib headers

### DIFF
--- a/Linglib/Fragments/Archi/Gender.lean
+++ b/Linglib/Fragments/Archi/Gender.lean
@@ -25,9 +25,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "Archi" "aqc"
     (rawGenderCount := 4)
-    (genderCountFb := .four)
-    (basisFb := .sexBased)
-    (assignmentFb := .semanticOnly)
     (agreementTargets := [.predicate, .verb])
     (semanticBases := [.rationality, .sex, .animacy])
 

--- a/Linglib/Fragments/Dyirbal/Gender.lean
+++ b/Linglib/Fragments/Dyirbal/Gender.lean
@@ -23,9 +23,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "Dyirbal" "dbl"
     (rawGenderCount := 4)
-    (genderCountFb := .four)
-    (basisFb := .sexBased)
-    (assignmentFb := .semanticOnly)
     (agreementTargets := [.attributive])
     (semanticBases := [.sex, .animacy, .shape])
 

--- a/Linglib/Fragments/English/Gender.lean
+++ b/Linglib/Fragments/English/Gender.lean
@@ -21,9 +21,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "English" "eng"
     (rawGenderCount := 3)
-    (genderCountFb := .three)
-    (basisFb := .sexBased)
-    (assignmentFb := .semanticOnly)
     (agreementTargets := [.personalPronoun])
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine, .neuter])

--- a/Linglib/Fragments/French/Gender.lean
+++ b/Linglib/Fragments/French/Gender.lean
@@ -16,9 +16,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "French" "fra"
     (rawGenderCount := 2)
-    (genderCountFb := .two)
-    (basisFb := .sexBased)
-    (assignmentFb := .semanticAndFormal)
     (agreementTargets := [.attributive, .predicate, .personalPronoun])
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])

--- a/Linglib/Fragments/German/Gender.lean
+++ b/Linglib/Fragments/German/Gender.lean
@@ -133,9 +133,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "German" "deu"
     (rawGenderCount := 3)
-    (genderCountFb := .three)
-    (basisFb := .sexBased)
-    (assignmentFb := .semanticAndFormal)
     (agreementTargets := [.attributive, .predicate, .relativePronoun, .personalPronoun])
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine, .neuter])

--- a/Linglib/Fragments/Hausa/Gender.lean
+++ b/Linglib/Fragments/Hausa/Gender.lean
@@ -162,9 +162,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "Hausa" "hau"
     (rawGenderCount := 2)
-    (genderCountFb := .two)
-    (basisFb := .sexBased)
-    (assignmentFb := .semanticAndFormal)
     (agreementTargets := [.attributive, .personalPronoun, .verb])
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])

--- a/Linglib/Fragments/Hebrew/Gender.lean
+++ b/Linglib/Fragments/Hebrew/Gender.lean
@@ -16,9 +16,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "Hebrew" "heb"
     (rawGenderCount := 2)
-    (genderCountFb := .two)
-    (basisFb := .sexBased)
-    (assignmentFb := .semanticAndFormal)
     (agreementTargets := [.attributive, .predicate, .verb])
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])

--- a/Linglib/Fragments/Hindi/Gender.lean
+++ b/Linglib/Fragments/Hindi/Gender.lean
@@ -16,9 +16,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "Hindi-Urdu" "hin"
     (rawGenderCount := 2)
-    (genderCountFb := .two)
-    (basisFb := .sexBased)
-    (assignmentFb := .semanticAndFormal)
     (agreementTargets := [.attributive, .predicate, .verb])
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])

--- a/Linglib/Fragments/Shona/Gender.lean
+++ b/Linglib/Fragments/Shona/Gender.lean
@@ -16,9 +16,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "Shona" "sna"
     (rawGenderCount := 8)
-    (genderCountFb := .fivePlus)
-    (basisFb := .nonSexBased)
-    (assignmentFb := .semanticAndFormal)
     (agreementTargets := [.attributive, .predicate, .relativePronoun,
                           .personalPronoun, .verb])
     (semanticBases := [.humanness])

--- a/Linglib/Fragments/Slavic/Russian/Gender.lean
+++ b/Linglib/Fragments/Slavic/Russian/Gender.lean
@@ -196,9 +196,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "Russian" "rus"
     (rawGenderCount := 3)
-    (genderCountFb := .three)
-    (basisFb := .sexBased)
-    (assignmentFb := .semanticAndFormal)
     (agreementTargets := [.attributive, .predicate, .relativePronoun,
                           .personalPronoun, .verb])
     (semanticBases := [.sex])

--- a/Linglib/Fragments/Spanish/Gender.lean
+++ b/Linglib/Fragments/Spanish/Gender.lean
@@ -169,9 +169,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "Spanish" "spa"
     (rawGenderCount := 2)
-    (genderCountFb := .two)
-    (basisFb := .sexBased)
-    (assignmentFb := .semanticAndFormal)
     (agreementTargets := [.attributive, .predicate, .personalPronoun])
     (semanticBases := [.sex])
     (attestedSurfaceGenders := [.masculine, .feminine])

--- a/Linglib/Fragments/Swahili/Gender.lean
+++ b/Linglib/Fragments/Swahili/Gender.lean
@@ -23,9 +23,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "Swahili" "swh"
     (rawGenderCount := 7)
-    (genderCountFb := .fivePlus)
-    (basisFb := .nonSexBased)
-    (assignmentFb := .semanticAndFormal)
     (agreementTargets := [.attributive, .predicate, .relativePronoun,
                           .personalPronoun, .verb])
     (semanticBases := [.humanness, .animacy, .shape])

--- a/Linglib/Fragments/Zulu/Gender.lean
+++ b/Linglib/Fragments/Zulu/Gender.lean
@@ -23,9 +23,6 @@ open Typology.Gender
 def genderTypology : GenderProfile :=
   .fromWALS "Zulu" "zul"
     (rawGenderCount := 8)
-    (genderCountFb := .fivePlus)
-    (basisFb := .nonSexBased)
-    (assignmentFb := .semanticAndFormal)
     (agreementTargets := [.attributive, .predicate, .relativePronoun,
                           .personalPronoun, .verb])
     (semanticBases := [.humanness, .animacy, .shape])

--- a/Linglib/Typology/Gender.lean
+++ b/Linglib/Typology/Gender.lean
@@ -59,9 +59,7 @@ private abbrev ch30 := Data.WALS.F30A.allData
 private abbrev ch31 := Data.WALS.F31A.allData
 private abbrev ch32 := Data.WALS.F32A.allData
 
--- ============================================================================
--- §1. Substrate enums
--- ============================================================================
+/-! ### Substrate enums -/
 
 /-- Number of gender / noun class distinctions in a language (WALS Ch 30). -/
 inductive GenderCount where
@@ -121,9 +119,7 @@ inductive SemanticBasis where
   | rationality
   deriving DecidableEq, BEq, Repr
 
--- ============================================================================
--- §2. GenderProfile (Fragment-side joint)
--- ============================================================================
+/-! ### GenderProfile (Fragment-side joint) -/
 
 /-- A language's gender profile combining WALS Chs 30/31/32 + extra fields
     (raw count, agreement targets per [corbett-1991]'s Agreement
@@ -161,9 +157,7 @@ structure GenderProfile where
   attestedSurfaceGenders : List Features.SurfaceGender := []
   deriving Repr, DecidableEq
 
--- ============================================================================
--- §3. Helper predicates
--- ============================================================================
+/-! ### Helper predicates -/
 
 namespace GenderProfile
 
@@ -244,9 +238,7 @@ def lowestAgreementTarget (p : GenderProfile) : Option AgreementTarget :=
 
 end GenderProfile
 
--- ============================================================================
--- §4. WALS converters
--- ============================================================================
+/-! ### WALS converters -/
 
 /-- WALS Ch 30A → `GenderCount`. -/
 def fromWALS30A : Data.WALS.F30A.GenderCount → GenderCount
@@ -269,9 +261,7 @@ def fromWALS32A :
   | .semantic          => .semanticOnly
   | .semanticAndFormal => .semanticAndFormal
 
--- ============================================================================
--- §5. WALS Lookup Helpers + Smart Constructor
--- ============================================================================
+/-! ### WALS Lookup Helpers + Smart Constructor -/
 
 def walsGenderCount (iso : String) : Option GenderCount :=
   (Data.WALS.F30A.lookupISO iso).map (fromWALS30A ·.value)
@@ -284,7 +274,8 @@ def walsAssignment (iso : String) : Option AssignmentSystem :=
 
 /-- Build a `GenderProfile` from an ISO 639-3 code via WALS lookups for
     Chs 30/31/32. The three required-field fallbacks (`genderCountFb`,
-    `basisFb`, `assignmentFb`) fire only when WALS is silent for that ISO.
+    `basisFb`, `assignmentFb`) fire only when WALS is silent for that ISO;
+    omit them for WALS-covered languages (dead arguments otherwise).
     The `rawGenderCount`, `agreementTargets`, `semanticBases`, and
     `attestedSurfaceGenders` fields are paper-stipulated per [corbett-1991]
     — they are not derivable from any WALS chapter and must be passed
@@ -307,9 +298,7 @@ def GenderProfile.fromWALS
   , semanticBases
   , attestedSurfaceGenders }
 
--- ============================================================================
--- §6. WALS distribution facts
--- ============================================================================
+/-! ### WALS distribution facts -/
 
 /-! Earlier revisions of this file carried five aggregate-count theorems on
     the full WALS Ch 30/31/32 corpora (`ch30_no_gender_modal`,


### PR DESCRIPTION
The `*Fb` fallback args never fire for the 13 WALS-covered Gender fragments — WALS chs 30A/31A/32A answer for those ISOs, so the values were dead arguments restating WALS data (completes the iso-keyed derivation pattern of #75/#69; the `isRawCountConsistent` sentries from #143 guard against future WALS-data drift). The 5 WALS-silent fragments (Fula, Irish, Latin, Romanian, Xhosa) keep theirs, which are load-bearing. Also converts `-- ===` section banners to `/-! ### -/` headers in `Typology/Gender.lean`.