### PR TITLE
refactor(Features): root-Person pronoun field, Cysouw-verified typology

### DIFF
--- a/Linglib/Features/Clusivity.lean
+++ b/Linglib/Features/Clusivity.lean
@@ -87,38 +87,13 @@ def hasMinimalAugmented (s : System) : Bool :=
 
 end System
 
-/-! ### Per-referent clusivity value -/
-
-/-- The clusivity value of a *referent*: whether a non-singular first-person
-    form includes the addressee. This is the framework-neutral per-pronoun
-    feature (the `Pronoun` object carries `Option Value`); it is `none` where
-    clusivity is unmarked (English *we*) or inapplicable (non-first-person).
-    Contrast `System`, which classifies a *language*. -/
-inductive Value where
-  /-- Inclusive: includes the addressee (1+2, optionally +others). -/
-  | inclusive
-  /-- Exclusive: excludes the addressee (1+others). -/
-  | exclusive
-  deriving DecidableEq, Repr, BEq
-
-open Person (Category)
-
-/-- The [cysouw-2009] `Person.Category` a person + number +
-    clusivity triple realizes. Singulars ignore clusivity; clusivity-marked
-    first-person non-singulars split inclusive (`.minIncl` dual / `.augIncl`
-    plural) from `.excl`. A clusivity-*neutral* first-person plural (English
-    *we*) is a syncretism over those cells, so it has no single category
-    (`none`). This is the bridge from the neutral φ-features to the typological
-    inventory. -/
-def categoryOf : UD.Person → UD.Number → Option Value → Option Category
-  | .first,  .Sing, _               => some .s1
-  | .second, .Sing, _               => some .s2
-  | .third,  .Sing, _               => some .s3
-  | .first,  .Dual, some .inclusive => some .minIncl
-  | .first,  .Plur, some .inclusive => some .augIncl
-  | .first,  _,     some .exclusive => some .excl
-  | .second, .Plur, _               => some .secondGrp
-  | .third,  .Plur, _               => some .thirdGrp
-  | _,       _,     _               => none
+/-! The per-referent clusivity `Value` (inclusive/exclusive) and the
+`categoryOf` bridge were dissolved into the canonical person inventory:
+clusivity is a person-value distinction (`Person.firstInclusive` /
+`Person.firstExclusive`, `Features/Person/Basic.lean`), and the category
+bridge is `Person.Category.ofPersonNumber`
+(`Features/Person/Decomposition.lean`). This file keeps the
+paradigm-level `System` typology, which classifies how a language's
+pronoun paradigm carves the person–number space. -/
 
 end Features.Clusivity

--- a/Linglib/Features/Clusivity.lean
+++ b/Linglib/Features/Clusivity.lean
@@ -30,60 +30,109 @@ set_option autoImplicit false
 
 namespace Features.Clusivity
 
-/-- Cysouw 2009 typology of pronominal clusivity systems.
-
-The cuts: (a) is incl/excl distinguished at all? (b) is the inclusive
-itself further split into minimal vs augmented? -/
+/-- The five common marking types of the first person complex
+    ([cysouw-2009] Table 3.2; the attested-and-common five of the
+    fifteen possible patterns, his Fig 3.1–3.2). Classified by which of
+    the categories 1+2, 1+2+3, 1+3 receive specialized morphemes. The
+    five rare attested patterns ((Pf)–(Pj), his §3.6.6) are not
+    represented. -/
 inductive System where
-  /-- No clusivity distinction; 1pl is one category (English *we*,
-      German *wir*, Standard Mandarin *wǒmen*). -/
-  | noClusivity
-  /-- Plain incl/excl: separate 1pl forms for 1+2(+3) vs 1+3
-      (Indonesian *kita*/*kami*, Tok Pisin *yumi*/*mipela*,
-      Mandarin colloquial *zánmen*/*wǒmen*). -/
-  | inclExcl
-  /-- Minimal-augmented: inclusive further splits into minimal (1+2 only,
-      surfaces as a 1-dual-inclusive form) vs augmented (1+2+others); the
-      exclusive remains a single category. Tagalog *kata*/*tayo*/*kami*
-      (per [schachter-otanes-1972] Chart 7), many Australian
-      languages. -/
+  /-- (Pb) No-we: none of 1+2, 1+2+3, 1+3 marked by a specialized
+      morpheme (English verbal inflection; Pirahã, which lacks group
+      marking altogether). -/
+  | noWe
+  /-- (Pa) Unified-we: all three categories marked by the same
+      specialized morpheme (English *we*, German *wir*). -/
+  | unifiedWe
+  /-- (Pc) Only-inclusive: 1+2 and 1+2+3 share a specialized inclusive
+      morpheme; 1+3 is marked by the first-person singular morpheme,
+      not a specialized one (Maká). -/
+  | onlyInclusive
+  /-- (Pd) Inclusive/exclusive: inclusive (1+2, 1+2+3) and exclusive
+      (1+3) each get a specialized morpheme (Apalai; Indonesian
+      *kita*/*kami*). -/
+  | inclusiveExclusive
+  /-- (Pe) Minimal/augmented: all three categories get separate
+      specialized morphemes (Tagalog *kata*/*tayo*/*kami* per
+      [schachter-otanes-1972] Chart 7; Ilocano *ta*/*tayo*/*mi*, his
+      Fig 3.5–3.6). -/
   | minimalAugmented
-  /-- Unit-augmented: minimal-augmented plus a separate 1+2+1 form
-      ("we two and one other"); rare (e.g. Rembarrnga). -/
-  | unitAugmented
-  /-- No grammatical number distinction in pronouns at all (Pirahã *ti*
-      'I/we'); the clusivity question is moot. -/
-  | numberIndifferent
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Fintype
 
 namespace System
 
-/-- The 1st-person `Person.Category` distinctions a system
-    grammatically encodes. Captures Cysouw 2009's typology operationally:
-    `.noClusivity` collapses 1+2 and 1+3 into a single 1pl
-    (modeled here by listing only `.augIncl`, since `.augIncl` is the
-    closest catch-all for collapsed first-person plural); `.inclExcl`
-    distinguishes them; `.minimalAugmented` and `.unitAugmented` further
-    split inclusive into minimal (`.minIncl`) vs augmented (`.augIncl`).
-    `.numberIndifferent` languages have no plural form, so only `.s1`. -/
-def distinguishedCategories : System → List Person.Category
-  | .noClusivity        => [.augIncl]                     -- single 1pl form
-  | .inclExcl           => [.augIncl, .excl]              -- 1+2(+3) vs 1+3
-  | .minimalAugmented   => [.minIncl, .augIncl, .excl]    -- + 1+2 minimal
-  | .unitAugmented      => [.minIncl, .augIncl, .excl]    -- + 1+2+1 not in Category
-  | .numberIndifferent  => []                             -- no 1pl distinction
+/-! Fig 3.10's nested questions: each type answers one more question
+positively than its predecessor, which is exactly why the types form
+the First Person Hierarchy (3.26). -/
 
-/-- A system grammatically distinguishes inclusive from exclusive iff
-    its first-person inventory contains an exclusive category. Derived
-    from `distinguishedCategories` (was a stipulated pattern-match before
-    the 0.230.544 audit). -/
-def hasInclExcl (s : System) : Bool :=
-  s.distinguishedCategories.contains .excl
+/-- Some specialized 'we' morpheme exists. -/
+def specializedWe : System → Bool
+  | .noWe => false
+  | _ => true
 
-/-- A system distinguishes minimal-inclusive from augmented-inclusive iff
-    its first-person inventory contains the minimal-inclusive category. -/
-def hasMinimalAugmented (s : System) : Bool :=
-  s.distinguishedCategories.contains .minIncl
+/-- The inclusive (1+2, 1+2+3) has marking distinct from the
+    exclusive. -/
+def specializedInclusive : System → Bool
+  | .noWe | .unifiedWe => false
+  | _ => true
+
+/-- The exclusive (1+3) has its own specialized morpheme. -/
+def specializedExclusive : System → Bool
+  | .inclusiveExclusive | .minimalAugmented => true
+  | _ => false
+
+/-- The inclusive is split: separate morphemes for 1+2 and 1+2+3. -/
+def splitInclusive : System → Bool
+  | .minimalAugmented => true
+  | _ => false
+
+/-- A system grammatically distinguishes inclusive from exclusive. -/
+abbrev hasInclExcl (s : System) : Bool := s.specializedExclusive
+
+/-- A system distinguishes minimal from augmented inclusive. -/
+abbrev hasMinimalAugmented (s : System) : Bool := s.splitInclusive
+
+/-- **Addressee inclusion implication I** ([cysouw-2009] (3.23),
+    Fig 3.8): a specialized exclusive requires a specialized inclusive.
+    The converse fails — only-inclusive systems are the witness. (Over
+    the common types; the rare Binandere pattern, his (3.22)/(Pj), is
+    the noted incidental exception.) -/
+theorem exclusive_implies_inclusive :
+    ∀ s : System, s.specializedExclusive → s.specializedInclusive := by
+  decide
+
+theorem not_inclusive_implies_exclusive :
+    ¬ ∀ s : System, s.specializedInclusive → s.specializedExclusive := by
+  decide
+
+/-- **Addressee inclusion implication II** ([cysouw-2009] (3.24),
+    Fig 3.9): a split inclusive requires a specialized exclusive
+    (disregarding the rare (Pf)/(Pg) patterns, his §3.6.6). -/
+theorem splitInclusive_implies_exclusive :
+    ∀ s : System, s.splitInclusive → s.specializedExclusive := by
+  decide
+
+/-- Position in the **First Person Hierarchy** ([cysouw-2009] (3.26)):
+    no-we > unified-we > only-inclusive > inclusive/exclusive >
+    minimal/augmented (rank counts the Fig 3.10 questions answered
+    positively). -/
+def hierarchyRank : System → Nat
+  | .noWe => 0
+  | .unifiedWe => 1
+  | .onlyInclusive => 2
+  | .inclusiveExclusive => 3
+  | .minimalAugmented => 4
+
+/-- The hierarchy is exactly the nesting of Fig 3.10's questions: each
+    of the four predicates is monotone in hierarchy rank, so each type's
+    profile extends its predecessor's by one positive answer. -/
+theorem hierarchy_is_question_nesting :
+    ∀ s t : System, s.hierarchyRank ≤ t.hierarchyRank →
+      (s.specializedWe → t.specializedWe = true) ∧
+      (s.specializedInclusive → t.specializedInclusive = true) ∧
+      (s.specializedExclusive → t.specializedExclusive = true) ∧
+      (s.splitInclusive → t.splitInclusive = true) := by
+  decide
 
 end System
 

--- a/Linglib/Features/Person/Basic.lean
+++ b/Linglib/Features/Person/Basic.lean
@@ -170,9 +170,8 @@ def hierarchyRank : Person → Nat
 /-! ### Person systems -/
 
 /-- A language's person system: the analytical values its paradigms
-    distinguish. Universals over systems await verification against
-    [cysouw-2009]'s survey — only structural predicates are provided
-    here. -/
+    distinguish ([cysouw-2009]; the paradigm-level marking typology is
+    `Features.Clusivity.System`, his Table 3.2). -/
 structure System where
   /-- The person values the system distinguishes. -/
   values : List Person
@@ -199,6 +198,25 @@ theorem tripartition_no_clusivity : ¬tripartition.HasClusivity := by
 
 theorem quadripartition_clusivity : quadripartition.HasClusivity := by
   decide
+
+/-- **Addressee inclusion implication I** at the value level
+    ([cysouw-2009] (3.23), Fig 3.8): a distinguished exclusive requires a
+    distinguished inclusive. The converse fails — only-inclusive systems
+    (his (Pc), Maká) have an inclusive value whose exclusive is covered
+    by the singular morpheme. (Over the common paradigm types; the rare
+    Binandere pattern, his (3.22)/(Pj), is the noted incidental
+    exception.) -/
+def ExclusiveImpliesInclusive (ns : System) : Prop :=
+  .firstExclusive ∈ ns.values → .firstInclusive ∈ ns.values
+
+instance : DecidablePred ExclusiveImpliesInclusive := fun ns => by
+  unfold ExclusiveImpliesInclusive; infer_instance
+
+theorem tripartition_exclImpliesIncl :
+    tripartition.ExclusiveImpliesInclusive := by decide
+
+theorem quadripartition_exclImpliesIncl :
+    quadripartition.ExclusiveImpliesInclusive := by decide
 
 end System
 

--- a/Linglib/Features/Person/Decomposition.lean
+++ b/Linglib/Features/Person/Decomposition.lean
@@ -182,10 +182,10 @@ theorem no_fourth_person :
 -- § 6: Person Categories (Cysouw)
 -- ============================================================================
 
-/-- The 8 referential person categories ([cysouw-2009], Fig 10.1).
-
-Three singular categories (individual speech act roles) and five group
-categories (attested combinations of participants). -/
+/-- The 8 referential person categories ([cysouw-2009] ch. 3: the three
+singular participants plus the five attested of the seven logical groups
+of Table 3.1 — 1+1 (mass speaking) and 2+2 (present-audience-only) are
+dismissed as not grammaticalized, his §3.4). -/
 inductive Category where
   | s1        -- speaker (1st person singular)
   | s2        -- addressee (2nd person singular)

--- a/Linglib/Features/Person/Decomposition.lean
+++ b/Linglib/Features/Person/Decomposition.lean
@@ -289,6 +289,23 @@ theorem ud_conflates_incl_excl :
     Category.toUDPersonNumber .augIncl =
     Category.toUDPersonNumber .excl := rfl
 
+/-- The [cysouw-2009] category a (canonical person, UD number) pair
+    realizes. Clusivity rides on the person value, so no third argument is
+    needed: singulars ignore clusivity, first-person non-singulars without
+    it (plain `first`) are a syncretism (`none`), and second/third
+    non-singulars map to the group categories. -/
+def Category.ofPersonNumber : Person → UD.Number → Option Category
+  | .first, .Sing | .firstInclusive, .Sing | .firstExclusive, .Sing =>
+      some .s1
+  | .second, .Sing => some .s2
+  | .third, .Sing => some .s3
+  | .firstInclusive, .Dual => some .minIncl
+  | .firstInclusive, .Plur => some .augIncl
+  | .firstExclusive, .Dual | .firstExclusive, .Plur => some .excl
+  | .second, .Dual | .second, .Plur => some .secondGrp
+  | .third, .Dual | .third, .Plur => some .thirdGrp
+  | _, _ => none
+
 /-- The person coordinate of each referential category — the projection
     the canonical inventory recovers losslessly where UD cannot:
     `minIncl`/`augIncl` ↦ `firstInclusive`, `excl` ↦ `firstExclusive`.
@@ -315,6 +332,17 @@ theorem person_includesSpeaker_iff (c : Category) :
     from exclusive. -/
 theorem person_separates_clusivity :
     Category.augIncl.person ≠ Category.excl.person := by decide
+
+/-- `ofPersonNumber` inverts the person projection: every category is
+    recovered from its own coordinates. -/
+theorem ofPersonNumber_person (c : Category) :
+    ∀ pn, c.toUDPersonNumber = some pn →
+      Category.ofPersonNumber c.person pn.2 = some c := by
+  cases c <;>
+    (intro pn hpn
+     simp only [Category.toUDPersonNumber, Option.some.injEq] at hpn
+     subst hpn
+     rfl)
 
 -- ============================================================================
 -- § 8: Category ↔ Features Bridge

--- a/Linglib/Fragments/Ga/Basic.lean
+++ b/Linglib/Fragments/Ga/Basic.lean
@@ -47,6 +47,12 @@ namespace Ga
 inductive Person where | first | second | third
   deriving DecidableEq, Repr
 
+/-- Ga's three-way person in the canonical inventory. -/
+def Person.toPerson : Person → _root_.Person
+  | .first => .first
+  | .second => .second
+  | .third => .third
+
 inductive Number where | sg | pl
   deriving DecidableEq, Repr
 

--- a/Linglib/Fragments/Jarawara/PossessedNouns.lean
+++ b/Linglib/Fragments/Jarawara/PossessedNouns.lean
@@ -2,6 +2,7 @@ import Linglib.Morphology.DM.NominalStructure
 import Linglib.Typology.Possession
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities
+import Linglib.Features.Person.Capabilities
 import Linglib.Features.Gender
 
 /-!
@@ -166,6 +167,15 @@ structure Possessor where
 
 /-- A possessor bears its φ-number (`HasNumber`). -/
 instance : HasNumber Possessor := ⟨fun p => Number.fromUD p.number⟩
+
+/-- Jarawara's local person in the canonical inventory. -/
+def Person.toPerson : Person → _root_.Person
+  | .first => .first
+  | .second => .second
+  | .third => .third
+
+/-- A possessor bears its φ-person (`HasPerson`). -/
+instance : HasPerson Possessor := ⟨fun p => some p.person.toPerson⟩
 
 /-- Possessed noun form: "masculine" (mano) or "feminine" (mani).
     These labels follow [dixon-2004]'s terminology; they reflect

--- a/Linglib/Fragments/Kawapanan/Shawi/Basic.lean
+++ b/Linglib/Fragments/Kawapanan/Shawi/Basic.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Number.Capabilities
+import Linglib.Features.Person.Capabilities
 import Linglib.Features.Case
 import Linglib.Features.Case
 import Linglib.Features.Prominence
@@ -79,6 +80,14 @@ structure Phi where
 
 /-- A Shawi φ-bundle bears its min/aug value canonically (`HasNumber`). -/
 instance : HasNumber Phi := ⟨fun φ => some φ.number.toNumber⟩
+
+/-- A Shawi φ-bundle bears its analytical person: the local
+    (level, clusivity) pair recovers the quadripartition cell. -/
+instance : HasPerson Phi :=
+  ⟨fun φ => some (match φ.person, φ.clusivity with
+    | .first, .incl => .firstInclusive
+    | .first, .excl => .firstExclusive
+    | l, _ => Person.ofPersonLevel l)⟩
 
 -- ============================================================================
 -- § 2: Subject agreement (Table 1, indicative)

--- a/Linglib/Fragments/Mayan/Mam/Pronouns.lean
+++ b/Linglib/Fragments/Mayan/Mam/Pronouns.lean
@@ -63,14 +63,12 @@ def qini : PersonalPronoun :=
     (base *qo* [+author,−sg] + enclitic; glottalization from the enclitic,
     her fn. 7). -/
 def qoy : PersonalPronoun :=
-  { form := "qoy", person := some .first, number := some .Plur,
-    clusivity := some .exclusive }
+  { form := "qoy", person := some .firstExclusive, number := some .Plur, }
 
 /-- *qo* — 1PL inclusive independent pronoun; monomorphemic (1INCL's
     [+author,+participant] values *agree*, so no enclitic). -/
 def qo : PersonalPronoun :=
-  { form := "qo", person := some .first, number := some .Plur,
-    clusivity := some .inclusive }
+  { form := "qo", person := some .firstInclusive, number := some .Plur, }
 
 /-- *qi* — 2PL pronoun, both series; bimorphemic *q+=i* (§4.3.3.2).
     Word-vs-enclitic status left open by Scott (p. 163). -/
@@ -110,11 +108,14 @@ def PronCell.number : PronCell → UD.Number
   | .firstSg | .secondSg | .thirdSg => .Sing
   | _ => .Plur
 
-/-- PronCell clusivity (1PL cells only), in the API's vocabulary. -/
-def PronCell.clusivity : PronCell → Option Features.Clusivity.Value
-  | .firstPlExcl => some .exclusive
-  | .firstPlIncl => some .inclusive
-  | _ => none
+/-- PronCell person in the canonical inventory: clusivity rides on the
+    person value. -/
+def PronCell.toPerson : PronCell → Person
+  | .firstSg => .first
+  | .firstPlExcl => .firstExclusive
+  | .firstPlIncl => .firstInclusive
+  | .secondSg | .secondPl => .second
+  | .thirdSg | .thirdPl => .third
 
 /-- [scott-2023]'s bivalent φ-features (Table 4.4, after [harbour-2016]):
     [±author], [±participant], [±singular]. Fragment-local because the

--- a/Linglib/Fragments/Mixtec/SMPM/Basic.lean
+++ b/Linglib/Fragments/Mixtec/SMPM/Basic.lean
@@ -86,12 +86,12 @@ def cl1sg : PersonalPronoun :=
     strength := some .clitic }
 
 def cl1plIncl : PersonalPronoun :=
-  { form := "=(y)é", person := some .first, number := some .Plur,
-    clusivity := some .inclusive, strength := some .clitic }
+  { form := "=(y)é", person := some .firstInclusive, number := some .Plur,
+     strength := some .clitic }
 
 def cl1plExcl : PersonalPronoun :=
-  { form := "=ndú", person := some .first, number := some .Plur,
-    clusivity := some .exclusive, strength := some .clitic }
+  { form := "=ndú", person := some .firstExclusive, number := some .Plur,
+     strength := some .clitic }
 
 def cl2sg : PersonalPronoun :=
   { form := "=ú", person := some .second, number := some .Sing,
@@ -143,8 +143,8 @@ def str1sg : PersonalPronoun :=
     strength := some .strong }
 
 def str1plExcl : PersonalPronoun :=
-  { form := "ndú'ú", person := some .first, number := some .Plur,
-    clusivity := some .exclusive, strength := some .strong }
+  { form := "ndú'ú", person := some .firstExclusive, number := some .Plur,
+     strength := some .strong }
 
 def str2sg : PersonalPronoun :=
   { form := "yô'o", person := some .second, number := some .Sing,
@@ -182,8 +182,7 @@ theorem series_homogeneous :
 /-- Paired variants share their φ-features — the two series differ in
     deficiency class, not in person/number/clusivity content. -/
 theorem pairs_share_phi : ∀ pr ∈ localPairs, ∀ s ∈ pr.2,
-    pr.1.person = s.person ∧ pr.1.number = s.number ∧
-    pr.1.clusivity = s.clusivity := by decide
+    pr.1.person = s.person ∧ pr.1.number = s.number := by decide
 
 /-- Within each pair, the clitic is strictly more deficient — derived from
     the shared deficiency order, not stipulated. -/

--- a/Linglib/Fragments/Tagalog/Pronouns.lean
+++ b/Linglib/Fragments/Tagalog/Pronouns.lean
@@ -95,17 +95,17 @@ def siya   : PersonalPronoun := { form := "siya",   person := some .third,  numb
 def niya   : PersonalPronoun := { form := "niya",   person := some .third,  number := some .Sing, case_ := some .Gen }
 def kaniya : PersonalPronoun := { form := "kaniya", person := some .third,  number := some .Sing, case_ := some .Dat }
 -- 1st dual inclusive (minimal inclusive): *kata*
-def kata   : PersonalPronoun := { form := "kata",   person := some .first,  number := some .Dual, clusivity := some .inclusive, case_ := some .Nom }
-def nita   : PersonalPronoun := { form := "nita",   person := some .first,  number := some .Dual, clusivity := some .inclusive, case_ := some .Gen }
-def kanita : PersonalPronoun := { form := "kanita", person := some .first,  number := some .Dual, clusivity := some .inclusive, case_ := some .Dat }
+def kata   : PersonalPronoun := { form := "kata",   person := some .firstInclusive,  number := some .Dual, case_ := some .Nom }
+def nita   : PersonalPronoun := { form := "nita",   person := some .firstInclusive,  number := some .Dual, case_ := some .Gen }
+def kanita : PersonalPronoun := { form := "kanita", person := some .firstInclusive,  number := some .Dual, case_ := some .Dat }
 -- 1st plural inclusive (augmented inclusive): *tayo*
-def tayo   : PersonalPronoun := { form := "tayo",   person := some .first,  number := some .Plur, clusivity := some .inclusive, case_ := some .Nom }
-def natin  : PersonalPronoun := { form := "natin",  person := some .first,  number := some .Plur, clusivity := some .inclusive, case_ := some .Gen }
-def atin   : PersonalPronoun := { form := "atin",   person := some .first,  number := some .Plur, clusivity := some .inclusive, case_ := some .Dat }
+def tayo   : PersonalPronoun := { form := "tayo",   person := some .firstInclusive,  number := some .Plur, case_ := some .Nom }
+def natin  : PersonalPronoun := { form := "natin",  person := some .firstInclusive,  number := some .Plur, case_ := some .Gen }
+def atin   : PersonalPronoun := { form := "atin",   person := some .firstInclusive,  number := some .Plur, case_ := some .Dat }
 -- 1st plural exclusive: *kami*
-def kami   : PersonalPronoun := { form := "kami",   person := some .first,  number := some .Plur, clusivity := some .exclusive, case_ := some .Nom }
-def namin  : PersonalPronoun := { form := "namin",  person := some .first,  number := some .Plur, clusivity := some .exclusive, case_ := some .Gen }
-def amin   : PersonalPronoun := { form := "amin",   person := some .first,  number := some .Plur, clusivity := some .exclusive, case_ := some .Dat }
+def kami   : PersonalPronoun := { form := "kami",   person := some .firstExclusive,  number := some .Plur, case_ := some .Nom }
+def namin  : PersonalPronoun := { form := "namin",  person := some .firstExclusive,  number := some .Plur, case_ := some .Gen }
+def amin   : PersonalPronoun := { form := "amin",   person := some .firstExclusive,  number := some .Plur, case_ := some .Dat }
 -- 2nd plural
 def kayo   : PersonalPronoun := { form := "kayo",   person := some .second, number := some .Plur, case_ := some .Nom }
 def ninyo  : PersonalPronoun := { form := "ninyo",  person := some .second, number := some .Plur, case_ := some .Gen }
@@ -134,14 +134,14 @@ theorem angSeries_categories_match :
 /-- Tagalog marks inclusive/exclusive in the first-person plural: *tayo* is
     inclusive, *kami* exclusive — read off the object's `clusivity` field. -/
 theorem incl_excl_distinct :
-    tayo.clusivity = some .inclusive ∧ kami.clusivity = some .exclusive := ⟨rfl, rfl⟩
+    tayo.person = some .firstInclusive ∧ kami.person = some .firstExclusive := ⟨rfl, rfl⟩
 
 /-- The minimal-augmented property: a dual inclusive *kata* (1+2) alongside the
     plural inclusive *tayo* — what makes Tagalog minimal-augmented rather than
     plain inclusive/exclusive ([cysouw-2009]). -/
 theorem minimal_augmented :
-    kata.number = some .Dual ∧ kata.clusivity = some .inclusive ∧
-    tayo.number = some .Plur ∧ tayo.clusivity = some .inclusive := ⟨rfl, rfl, rfl, rfl⟩
+    kata.number = some .Dual ∧ kata.person = some .firstInclusive ∧
+    tayo.number = some .Plur ∧ tayo.person = some .firstInclusive := ⟨rfl, rfl, rfl, rfl⟩
 
 /-- Cross-substrate consistency: the inventory contains a minimal-inclusive
     (dual inclusive) form iff the language commits to the minimal-augmented

--- a/Linglib/Fragments/Tamil/Pronouns.lean
+++ b/Linglib/Fragments/Tamil/Pronouns.lean
@@ -26,11 +26,11 @@ def naan : PersonalPronoun :=
 
 /-- *naam* — 1pl inclusive (speaker + addressee). -/
 def naam : PersonalPronoun :=
-  { form := "naam", person := some .first, number := some .Plur, clusivity := some .inclusive }
+  { form := "naam", person := some .firstInclusive, number := some .Plur }
 
 /-- *naangaL* — 1pl exclusive (speaker + others, not addressee). -/
 def naangaL : PersonalPronoun :=
-  { form := "naangaL", person := some .first, number := some .Plur, clusivity := some .exclusive }
+  { form := "naangaL", person := some .firstExclusive, number := some .Plur }
 
 -- ============================================================================
 -- Second Person (two-level honorific)
@@ -102,9 +102,11 @@ theorem has_both_numbers :
     allPronouns.any (·.number == some .Sing) = true ∧
     allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
 
-/-- Tamil has inclusive/exclusive distinction in 1pl. -/
+/-- Tamil has the inclusive/exclusive distinction in 1pl — carried on the
+    person values themselves. -/
 theorem has_incl_excl :
-    (allPronouns.filter (fun p => p.person == some .first && p.number == some .Plur)).length = 2 := rfl
+    allPronouns.any (·.person == some .firstInclusive) = true ∧
+    allPronouns.any (·.person == some .firstExclusive) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Syntax/Minimalist/SpeechActs.lean
+++ b/Linglib/Syntax/Minimalist/SpeechActs.lean
@@ -261,8 +261,8 @@ theorem seat_of_knowledge_interrogative {W E P T : Type*} (ctx : KContext W E P 
     1st person → SPEAKER (Spec-SAP)
     2nd person → HEARER (complement of SA)
     3rd person / zero → neither (referential, not a discourse role) -/
-def personToRole : UD.Person → Option PRole
-  | .first  => some .speaker
+def personToRole : Person → Option PRole
+  | .first | .firstInclusive | .firstExclusive => some .speaker
   | .second => some .hearer
   | .third  => none
   | .zero   => none
@@ -292,7 +292,7 @@ theorem third_person_no_role :
 
 /-- Discourse role is determined entirely by person feature. -/
 theorem discourse_role_from_person (p : PersonalPronoun)
-    (per : UD.Person) (hp : p.person = some per) :
+    (per : Person) (hp : p.person = some per) :
     pronounDiscourseRole p = personToRole per := by
   simp [pronounDiscourseRole, hp]
 

--- a/Linglib/Syntax/Pronoun/Basic.lean
+++ b/Linglib/Syntax/Pronoun/Basic.lean
@@ -110,17 +110,13 @@ end Pronoun.Strength
 structure Pronoun where
   /-- Surface form (romanization or orthographic). -/
   form : String
-  /-- Grammatical person (UD.Person via Core.Word abbrev). -/
-  person : Option UD.Person := none
+  /-- Grammatical person — the canonical analytical inventory (root
+      `Person`). Clusivity is carried as a person value: Tagalog *tayo* =
+      `firstInclusive`, *kami* = `firstExclusive`; English *we* = plain
+      `first` ([cysouw-2009]). -/
+  person : Option Person := none
   /-- Grammatical number. -/
   number : Option UD.Number := none
-  /-- Clusivity (inclusive/exclusive) of a first-person non-singular form — the
-      inclusive/exclusive split of the 1st-person plural/dual. A φ-feature borne
-      by any such pro-form (personal, possessive, reflexive), like `gender`;
-      `none` where unmarked (English *we*) or inapplicable. Distinguishes
-      Tagalog *tayo* (incl) / *kami* (excl) and *natin* (our.incl) / *namin*
-      (our.excl). [cysouw-2009] -/
-  clusivity : Option Features.Clusivity.Value := none
   /-- Grammatical case. -/
   case_ : Option Features.Case := none
   /-- Grammatical gender. For 3rd-person pronouns in gendered languages
@@ -189,7 +185,8 @@ open Features (SurfaceGender)
     surface as adverbs) stay in the relevant fragment. -/
 def toWord (p : Pronoun) : Word :=
   { form := p.form, cat := .PRON,
-    features := { person := p.person, number := p.number, case_ := p.case_,
+    features := { person := p.person.map Person.toUD, number := p.number,
+                  case_ := p.case_,
                   gender := p.gender.bind (·.toUDGender),
                   -- carry the binding-relevant morphology so a projected pro-form's class is
                   -- read off its own features, not recovered by surface-form lookup
@@ -199,14 +196,15 @@ def toWord (p : Pronoun) : Word :=
 
 /-! ### Derived person category and well-formedness ([cysouw-2009]) -/
 
-/-- The [cysouw-2009] `Category` this pronoun's person + number + clusivity
-    realizes, when fully specified — the neutral typological view of its
+/-- The [cysouw-2009] `Category` this pronoun's person + number realizes,
+    when fully specified — the neutral typological view of its
     person-reference, *derived* (not stored). `none` when person/number is
-    underspecified, or for a clusivity-unmarked first-person plural (a syncretism
-    over `.minIncl`/`.augIncl`/`.excl`, e.g. English *we*). -/
+    underspecified, or for a clusivity-unmarked first-person plural (plain
+    `first`, a syncretism over `.minIncl`/`.augIncl`/`.excl`, e.g. English
+    *we*). -/
 def category (p : Pronoun) : Option Person.Category :=
   match p.person, p.number with
-  | some per, some num => Features.Clusivity.categoryOf per num p.clusivity
+  | some per, some num => Person.Category.ofPersonNumber per num
   | _, _ => none
 
 /-- Well-formedness of a pronoun's φ-features: clusivity is borne only by a
@@ -215,8 +213,8 @@ def category (p : Pronoun) : Option Person.Category :=
     person-value type tower would have enforced, carried as a *predicate* (the
     mathlib way) so illegal states are catchable without fragmenting the type. -/
 def WellFormed (p : Pronoun) : Prop :=
-  p.clusivity ≠ none →
-    p.person = some .first ∧ (p.number = some .Dual ∨ p.number = some .Plur)
+  ∀ per, p.person = some per → per.MarksClusivity →
+    p.number = some .Dual ∨ p.number = some .Plur
 
 instance (p : Pronoun) : Decidable p.WellFormed := by
   unfold WellFormed; infer_instance

--- a/Linglib/Syntax/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Pronoun/Capabilities.lean
@@ -31,7 +31,7 @@ object (`Word`), or a future theory representation; each supplies its own instan
 * `bindingClassOf_toWord` — the faithfulness certificate: the binding engine's canonical
   morphology source (`Binding.bindingClassOf`) agrees with the `Bound` mixin on every
   projected pro-form, so the surface engine and the carrier capability never diverge.
-* `Deictic`, `Clusive` — orthogonal data-mixins (register / referential person; clusivity).
+* `Deictic` — orthogonal data-mixin (register / referential person).
 
 ## Implementation notes
 
@@ -123,15 +123,10 @@ theorem numberOf_toWord (p : Pronoun) :
 
 /-! ### The person axis: `HasPerson` instances and faithfulness -/
 
-/-- A pronoun's analytical person: the (UD person, clusivity) field pair
-recovers the quadripartition cell — Tagalog *kami* = `firstExclusive` —
-so consumers unify on root `Person` before any carrier retype. -/
-instance : HasPerson Pronoun :=
-  ⟨fun p => p.person.map fun ud =>
-    match ud, p.clusivity with
-    | .first, some .inclusive => .firstInclusive
-    | .first, some .exclusive => .firstExclusive
-    | ud, _ => Person.fromUD ud⟩
+/-- A pronoun bears its analytical person directly — the carrier field is
+root-`Person`-typed, clusivity included (Tagalog *kami* =
+`firstExclusive`). -/
+instance : HasPerson Pronoun := ⟨fun p => p.person⟩
 
 instance : HasPerson PersonalPronoun :=
   ⟨fun p => HasPerson.personOf p.toPronoun⟩
@@ -142,17 +137,13 @@ explicit rather than silent. -/
 theorem personOf_toWord (p : Pronoun) :
     HasPerson.personOf p.toWord =
       (HasPerson.personOf p).map Person.coarsen := by
-  show p.person.map Person.fromUD =
-    (p.person.map _).map Person.coarsen
+  show (p.person.map Person.toUD).map Person.fromUD =
+    p.person.map Person.coarsen
   cases p.person with
   | none => rfl
-  | some ud =>
-    cases ud <;> cases hc : p.clusivity <;>
-      first
-        | rfl
-        | (rename_i v; cases v <;> rfl)
+  | some per => exact congrArg some (Person.fromUD_toUD per)
 
-/-! ### Orthogonal data-mixins: `Deictic`, `Clusive` -/
+/-! ### Orthogonal data-mixin: `Deictic` -/
 
 /-- A deictic carrier exposes register and — when it diverges from agreement person — referential
 person, the features specific to personal/referential pronouns ([adamson-zompi-2025]). -/
@@ -164,11 +155,3 @@ class Deictic (α : Type*) [Proform α] where
 
 instance : Deictic PersonalPronoun :=
   ⟨PersonalPronoun.register, PersonalPronoun.referentialPerson⟩
-
-/-- A carrier that may mark clusivity (inclusive/exclusive on a 1st-person non-singular form;
-[cysouw-2009]). -/
-class Clusive (α : Type*) [Proform α] where
-  /-- Clusivity value, `none` where unmarked or inapplicable. -/
-  clusivity : α → Option Features.Clusivity.Value
-
-instance : Clusive Pronoun := ⟨Pronoun.clusivity⟩

--- a/Linglib/Typology/Pronoun/WALS.lean
+++ b/Linglib/Typology/Pronoun/WALS.lean
@@ -383,17 +383,16 @@ end Pronoun
 
 namespace Pronoun
 
-/-- WALS Ch 39 image of a Cysouw clusivity system (`Features.Clusivity.System`):
-    WALS Ch 39 collapses Cysouw's `.inclExcl`, `.minimalAugmented`, and
-    `.unitAugmented` into the single value `.inclusiveExclusive`. The
-    function is therefore many-to-one: given a WALS Ch 39 value, the
-    Cysouw value is underdetermined. -/
+/-- WALS Ch 39 image of a Cysouw first-person-complex type
+    (`Features.Clusivity.System`): WALS Ch 39 (Cysouw's own chapter)
+    collapses the minimal/augmented split, so the map is many-to-one —
+    given a WALS value, the paradigm type is underdetermined. -/
 def InclusiveExclusive.fromClusivity : Features.Clusivity.System → InclusiveExclusive
-  | .noClusivity        => .noDistinction
-  | .inclExcl           => .inclusiveExclusive
-  | .minimalAugmented   => .inclusiveExclusive
-  | .unitAugmented      => .inclusiveExclusive
-  | .numberIndifferent  => .weEqualsI
+  | .noWe                => .noWe
+  | .unifiedWe           => .noDistinction
+  | .onlyInclusive       => .onlyInclusive
+  | .inclusiveExclusive  => .inclusiveExclusive
+  | .minimalAugmented    => .inclusiveExclusive
 
 end Pronoun
 


### PR DESCRIPTION
Phase 3a of the Person API plus the Cysouw verification the spec gated on.

**The retype**: `Pronoun.person` is now root-`Person`-typed and the `clusivity` side field is deleted — Tagalog *tayo* is `person := some .firstInclusive`, one field, no triple-encoding. `Features.Clusivity.Value` and `categoryOf` dissolve (`Person.Category.ofPersonNumber` replaces the bridge); the `Clusive` mixin dies; `toWord` realizes via `Person.toUD`; the `WellFormed` clusivity-needs-nonsingular invariant restates over `MarksClusivity`. Fragment sweeps: Tagalog, Tamil, Mam, Mixtec, Shawi (+`HasPerson` from its local min/aug pair), Ga/Jarawara rogue locals get projections.

**The verification** (against the supplied Cysouw PDF, ch. 3): `Features.Clusivity.System` realigned to the five common first-person-complex types of Table 3.2 — the old enum lacked **only-inclusive** (Pc) and carried two cases that aren't we-types. Now with Fig 3.10's four nested predicates and the verified theorems: **(3.23)** exclusive → inclusive (converse refuted by only-inclusive), **(3.24)** split-inclusive → exclusive, and the **(3.26) First Person Hierarchy** as a question-nesting monotonicity theorem. `Person.System` gains the value-level (3.23) universal; the Category docstring's "Fig 10.1" citation was a hallucination — the real source is Table 3.1 + §3.4–3.5, now cited.

- `PersonLevel` dissolution is phase 3b (32-file Minimalist Agree surface, own PR); the `Category ≃ Person × Number` junction stays deferred pending ch. 6–7 (the number side of the composite).