### PR TITLE
refactor(Features): dissolve PersonLevel into root Person

### DIFF
--- a/Linglib/Features/Person/Basic.lean
+++ b/Linglib/Features/Person/Basic.lean
@@ -1,5 +1,4 @@
 import Linglib.Data.UD.Basic
-import Linglib.Features.Prominence
 
 /-!
 # Person — the canonical inventory
@@ -27,9 +26,8 @@ capability mixin (`Features/Person/Capabilities.lean`), unified
 resolution (`Features/Person/Resolve.lean`), feature decomposition and
 the Cysouw categories (`Features/Person/Decomposition.lean`).
 
-`Features.Prominence.PersonLevel` (the 1/2/3 prominence type used by
-probes and scales) is scheduled to dissolve into projections on this
-type; `toPersonLevel` is the bridge.
+The prominence scale over this inventory (`Person.prominence`, the
+dissolved `Person`'s role) lives in `Features/Prominence.lean`.
 -/
 
 set_option autoImplicit false
@@ -66,16 +64,20 @@ def IncludesSpeaker : Person → Prop
   | .first | .firstInclusive | .firstExclusive => True
   | _ => False
 
-instance : DecidablePred IncludesSpeaker := fun p => by
-  unfold IncludesSpeaker; cases p <;> infer_instance
+instance : DecidablePred IncludesSpeaker := fun p =>
+  match p with
+  | .first | .firstInclusive | .firstExclusive => isTrue trivial
+  | .second | .third | .zero => isFalse fun h => h
 
 /-- The value marks clusivity (a quadripartition cell). -/
 def MarksClusivity : Person → Prop
   | .firstInclusive | .firstExclusive => True
   | _ => False
 
-instance : DecidablePred MarksClusivity := fun p => by
-  unfold MarksClusivity; cases p <;> infer_instance
+instance : DecidablePred MarksClusivity := fun p =>
+  match p with
+  | .firstInclusive | .firstExclusive => isTrue trivial
+  | .first | .second | .third | .zero => isFalse fun h => h
 
 /-- Speech-act participant: speaker or addressee included. `zero` is
     not a participant value. -/
@@ -83,8 +85,10 @@ def IsSAP : Person → Prop
   | .third | .zero => False
   | _ => True
 
-instance : DecidablePred IsSAP := fun p => by
-  unfold IsSAP; cases p <;> infer_instance
+instance : DecidablePred IsSAP := fun p =>
+  match p with
+  | .first | .firstInclusive | .firstExclusive | .second => isTrue trivial
+  | .third | .zero => isFalse fun h => h
 
 /-! ### Coarsening
 
@@ -134,29 +138,6 @@ theorem fromUD_toUD (p : Person) : fromUD p.toUD = p.coarsen := by
 /-- UD conflates the clusivity values under `Person=1`. -/
 theorem ud_conflates_clusivity :
     Person.firstInclusive.toUD = Person.firstExclusive.toUD := rfl
-
-/-! ### Prominence bridge
-
-`Features.Prominence.PersonLevel` is the legacy 1/2/3 hierarchy type
-(probes, prominence scales); it dissolves into this projection. -/
-
-/-- Project to the three-way prominence level; `zero` is outside the
-    hierarchy. -/
-def toPersonLevel : Person → Option Features.Prominence.PersonLevel
-  | .first | .firstInclusive | .firstExclusive => some .first
-  | .second => some .second
-  | .third => some .third
-  | .zero => none
-
-/-- Embed a prominence level as an analytical value. -/
-def ofPersonLevel : Features.Prominence.PersonLevel → Person
-  | .first => .first
-  | .second => .second
-  | .third => .third
-
-@[simp] theorem toPersonLevel_ofPersonLevel
-    (l : Features.Prominence.PersonLevel) :
-    (ofPersonLevel l).toPersonLevel = some l := by cases l <;> rfl
 
 /-- The person hierarchy 1 < 2 < 3 ([zwicky-1977]; resolution in
     coordination, [corbett-2006]). Clusivity-marked firsts share rank 0

--- a/Linglib/Features/Person/Decomposition.lean
+++ b/Linglib/Features/Person/Decomposition.lean
@@ -91,33 +91,15 @@ def secondF : Features := ⟨true, false⟩
 /-- 3rd person features: [−participant, −author]. -/
 def thirdF : Features := ⟨false, false⟩
 
--- ============================================================================
--- § 3: PersonLevel Bridge
--- ============================================================================
-
-end Person
-
-namespace Features.Prominence
-
-/-- Decompose `PersonLevel` into binary person features. -/
-def PersonLevel.toFeatures : PersonLevel → Person.Features
-  | .first  => Person.firstF
-  | .second => Person.secondF
-  | .third  => Person.thirdF
-
-/-- Convert `UD.Person` to `PersonLevel`. The UD `.zero` (impersonal)
-    case has no `PersonLevel` analogue; everything else is direct. -/
-def PersonLevel.ofUDPerson : UD.Person → Option PersonLevel
-  | .first  => some .first
-  | .second => some .second
-  | .third  => some .third
-  | .zero   => none
-
-end Features.Prominence
-
-namespace Person
-
-open Features.Prominence
+/-- Decompose a person value into the binary features. The
+    quadripartition cells share `firstF` (the two-feature system
+    underdetermines clusivity — see `Category.toFeatures`); the
+    impersonal `zero` has no featural decomposition. -/
+def toFeatures : Person → Option Features
+  | .first | .firstInclusive | .firstExclusive => some firstF
+  | .second => some secondF
+  | .third => some thirdF
+  | .zero => none
 
 -- ============================================================================
 -- § 4: ContainmentPair Presentation
@@ -161,13 +143,20 @@ theorem illFormed_only : ¬ (⟨false, true⟩ : Features).WellFormed := by deci
 theorem card_wellFormed :
     Fintype.card {pf : Features // pf.WellFormed} = 3 := by decide
 
-/-- All person levels yield well-formed features. -/
-theorem PersonLevel.toFeatures_wellFormed (p : PersonLevel) :
-    p.toFeatures.WellFormed := by cases p <;> decide
+/-- Every defined decomposition is well-formed. -/
+theorem toFeatures_wellFormed (p : Person) :
+    ∀ f, p.toFeatures = some f → f.WellFormed := by
+  cases p <;> intro f hf <;>
+    simp only [toFeatures, Option.some.injEq, reduceCtorEq] at hf <;>
+    subst hf <;> decide
 
-/-- PersonLevel.isSAP = Features.hasParticipant. -/
-theorem PersonLevel.isSAP_eq_participant (p : PersonLevel) :
-    p.isSAP = p.toFeatures.hasParticipant := by cases p <;> rfl
+/-- `IsSAP` is featural participanthood. -/
+theorem isSAP_iff_participant (p : Person) :
+    ∀ f, p.toFeatures = some f →
+      (p.IsSAP ↔ f.hasParticipant = true) := by
+  cases p <;> intro f hf <;>
+    simp only [toFeatures, Option.some.injEq, reduceCtorEq] at hf <;>
+    subst hf <;> simp [IsSAP, firstF, secondF, thirdF]
 
 /-- No 4-way singular person distinction (inherited from
     `ContainmentPairLike.no_four_way`). -/
@@ -382,36 +371,28 @@ theorem toFeatures_participant_iff_sap (p : Category) :
   cases p <;> simp [Category.toFeatures, Category.IncludesSpeaker, Category.IncludesAddressee]
 
 /-- All 8 categories yield well-formed features. -/
-theorem toFeatures_wellFormed (p : Category) :
+theorem Category.toFeatures_wellFormed (p : Category) :
     p.toFeatures.WellFormed := by cases p <;> decide
 
 -- ============================================================================
--- § 9: Category ↔ PersonLevel Bridge
+-- § 9: Category ↔ Person Bridge
 -- ============================================================================
 
-/-- Map singular Category to PersonLevel (the canonical three-way
-    person distinction used by Phi.Geometry, DifferentialIndexing, etc.).
-    Group categories map to `none` — they encode number distinctions that
-    PersonLevel does not capture. -/
-def Category.toPersonLevel : Category → Option Features.Prominence.PersonLevel
-  | .s1 => some .first
-  | .s2 => some .second
-  | .s3 => some .third
-  | _   => none
+/-- The singular Category of a tripartition person value. -/
+def Category.ofSingularPerson : Person → Option Category
+  | .first  => some .s1
+  | .second => some .s2
+  | .third  => some .s3
+  | _ => none
 
-/-- Map PersonLevel to singular Category. -/
-def Category.fromPersonLevel : Features.Prominence.PersonLevel → Category
-  | .first  => .s1
-  | .second => .s2
-  | .third  => .s3
-
-/-- Round-trip: PersonLevel → Category → PersonLevel is identity. -/
-theorem personLevel_roundtrip (p : Features.Prominence.PersonLevel) :
-    (Category.fromPersonLevel p).toPersonLevel = some p := by
-  cases p <;> rfl
+/-- Round-trip: singular categories are recovered from their person
+    projection. -/
+theorem singular_category_roundtrip (c : Category) (h : c.IsSingular) :
+    Category.ofSingularPerson c.person = some c := by
+  rcases h with rfl | rfl | rfl <;> rfl
 
 /-- includesSpeaker on Category = hasParticipant ∧ hasAuthor on
-    PersonLevel for singular categories: speaker (s1) = [+participant,
+    Person for singular categories: speaker (s1) = [+participant,
     +author], addressee (s2) = [+participant, −author], other (s3) =
     [−participant, −author]. This unifies the Category decomposition
     in `Spanish/PersonFeatures.lean` with `Phi.Geometry.decomposePerson`. -/
@@ -426,7 +407,7 @@ theorem includesAddressee_iff_participant_not_author :
     ¬ Category.s3.IncludesAddressee := by decide
 
 /-- SAP (speech-act participant) = `IncludesSpeaker ∨ IncludesAddressee`
-    for singular categories. This matches `PersonLevel.isSAP`. -/
+    for singular categories. This matches `Person.isSAP`. -/
 theorem singular_sap_match :
     (Category.s1.IncludesSpeaker ∨ Category.s1.IncludesAddressee) ∧
     (Category.s2.IncludesSpeaker ∨ Category.s2.IncludesAddressee) ∧
@@ -436,14 +417,12 @@ theorem singular_sap_match :
 -- § 10: Category Consistency
 -- ============================================================================
 
-/-- Singular categories: Category.toFeatures agrees with
-    PersonLevel.toFeatures via the PersonLevel bridge. -/
-theorem s1_features_match :
-    Category.s1.toFeatures = Features.Prominence.PersonLevel.first.toFeatures := rfl
-theorem s2_features_match :
-    Category.s2.toFeatures = Features.Prominence.PersonLevel.second.toFeatures := rfl
-theorem s3_features_match :
-    Category.s3.toFeatures = Features.Prominence.PersonLevel.third.toFeatures := rfl
+/-- Singular categories: `Category.toFeatures` agrees with the person
+    decomposition through the person projection. -/
+theorem singular_features_match :
+    ∀ c : Category, c.IsSingular →
+      some c.toFeatures = c.person.toFeatures := by
+  rintro c (rfl | rfl | rfl) <;> rfl
 
 -- ============================================================================
 -- § 11: Epistemic Authority ([bickel-nichols-2001])

--- a/Linglib/Features/Prominence.lean
+++ b/Linglib/Features/Prominence.lean
@@ -1,5 +1,6 @@
 import Mathlib.Order.Nat
 import Mathlib.Tactic.DeriveFintype
+import Linglib.Features.Person.Basic
 
 /-!
 # Prominence Scales and Differential Argument Marking [just-2024] [haspelmath-2021]
@@ -215,37 +216,34 @@ theorem definiteness_rank_bounded (d : DefinitenessLevel) : d.rank ≤ 4 := by
 -- § 4: Person Scale ([haspelmath-2021], §6)
 -- ============================================================================
 
-/-- Person prominence scale.
-    1st > 2nd > 3rd. SAP (speech-act participants, 1st/2nd) are more
-    prominent than 3rd person. -/
-inductive PersonLevel where
-  | first
-  | second
-  | third
-  deriving DecidableEq, Repr, Inhabited, Fintype
-
-/-- Numeric rank on the person scale: 1st (2) > 2nd (1) > 3rd (0). -/
-def PersonLevel.rank : PersonLevel → Nat
-  | .first  => 2
+/-- Numeric rank on the person prominence scale: 1st (2) > 2nd (1) >
+    3rd (0) ([haspelmath-2021] §6). Stated over the canonical `Person`
+    inventory (the dissolved `Person`'s role): clusivity-marked
+    firsts rank with `first`; the impersonal `zero` is `[−participant]`
+    and is placed with third person (a linglib convention — the scale's
+    source does not discuss impersonals). -/
+def _root_.Person.prominence : Person → Nat
+  | .first | .firstInclusive | .firstExclusive => 2
   | .second => 1
-  | .third  => 0
+  | .third | .zero => 0
 
-/-- All person levels. -/
-def PersonLevel.all : List PersonLevel := [.first, .second, .third]
+/-- The three-way prominence scale carrier: the tripartition values. -/
+abbrev personScaleLevels : List Person := Person.System.tripartition.values
 
-/-- Whether a person level is a speech-act participant (SAP = local). -/
-def PersonLevel.isSAP : PersonLevel → Bool
-  | .first  => true
-  | .second => true
-  | .third  => false
+/-- Prominence separates the tripartition: on `first`/`second`/`third`
+    the rank function is injective. -/
+theorem person_prominence_injective :
+    ∀ a ∈ personScaleLevels, ∀ b ∈ personScaleLevels,
+      a.prominence = b.prominence → a = b := by decide
 
-/-- Distinct person levels have distinct ranks — the rank function is injective. -/
-theorem person_rank_injective (a b : PersonLevel) (h : a.rank = b.rank) : a = b := by
-  cases a <;> cases b <;> simp_all [PersonLevel.rank]
+/-- Person prominence ranks are bounded: 0 ≤ rank ≤ 2. -/
+theorem person_prominence_bounded (p : Person) : p.prominence ≤ 2 := by
+  cases p <;> simp [Person.prominence]
 
-/-- Person ranks are bounded: 0 ≤ rank ≤ 2. -/
-theorem person_rank_bounded (p : PersonLevel) : p.rank ≤ 2 := by
-  cases p <;> simp [PersonLevel.rank]
+/-- Prominence tracks SAP-hood: rank ≥ 1 iff speech-act participant. -/
+theorem prominence_pos_iff_sap (p : Person) :
+    1 ≤ p.prominence ↔ p.IsSAP := by
+  cases p <;> simp [Person.prominence, Person.IsSAP]
 
 -- ============================================================================
 -- § 5: Argument Role and Marking Channel ([haspelmath-2021], §2–5)
@@ -496,9 +494,9 @@ theorem animacy_mirror_image (cutoff : AnimacyLevel) :
     flagging or indexing. -/
 structure Scenario where
   /-- Person of the A argument -/
-  aPerson : PersonLevel
+  aPerson : Person
   /-- Person of the P argument -/
-  pPerson : PersonLevel
+  pPerson : Person
   deriving DecidableEq, Repr
 
 /-- Whether a scenario is "downstream": A has higher
@@ -506,42 +504,42 @@ structure Scenario where
     association predicts high-rank roles (A) to have high-prominence referents.
     Downstream scenarios tend to get the shortest coding. -/
 def Scenario.isDownstream (s : Scenario) : Bool :=
-  s.aPerson.rank > s.pPerson.rank
+  s.aPerson.prominence > s.pPerson.prominence
 
 /-- Whether a scenario is "upstream": P has higher
     person rank than A. This is the "unusual" direction — against the
     role-reference association. Upstream scenarios tend to get the longest
     coding. -/
 def Scenario.isUpstream (s : Scenario) : Bool :=
-  s.aPerson.rank < s.pPerson.rank
+  s.aPerson.prominence < s.pPerson.prominence
 
 /-- Whether a scenario is "balanced": A and P have the same person rank
     (e.g., 3→3). Intermediate coding predicted. -/
 def Scenario.isBalanced (s : Scenario) : Bool :=
-  s.aPerson.rank == s.pPerson.rank
+  s.aPerson.prominence == s.pPerson.prominence
 
 /-- Whether a scenario is "local": both arguments are SAP (1st or 2nd).
     Local scenarios (1↔2) are frequent and tend to get short coding. -/
 def Scenario.isLocal (s : Scenario) : Bool :=
-  s.aPerson.isSAP && s.pPerson.isSAP
+  decide s.aPerson.IsSAP && decide s.pPerson.IsSAP
 
 /-- Whether a scenario is "direct": SAP acts on 3rd person.
     A subtype of downstream scenarios. -/
 def Scenario.isDirect (s : Scenario) : Bool :=
-  s.aPerson.isSAP && !s.pPerson.isSAP
+  decide s.aPerson.IsSAP && !decide s.pPerson.IsSAP
 
 /-- Whether a scenario is "inverse": 3rd person acts on SAP.
     A subtype of upstream scenarios. -/
 def Scenario.isInverse (s : Scenario) : Bool :=
-  !s.aPerson.isSAP && s.pPerson.isSAP
+  !decide s.aPerson.IsSAP && decide s.pPerson.IsSAP
 
 /-- Whether a scenario is "non-local": 3rd person acts on 3rd person.
     A subtype of balanced scenarios. -/
 def Scenario.isNonlocal (s : Scenario) : Bool :=
-  !s.aPerson.isSAP && !s.pPerson.isSAP
+  !decide s.aPerson.IsSAP && !decide s.pPerson.IsSAP
 
 /-- All 9 person-pair scenarios. Explicit literal so `decide` reduces;
-    the equivalent `(PersonLevel.all.map λ a => PersonLevel.all.map λ p => ⟨a, p⟩).flatten`
+    the equivalent map over `personScaleLevels` pairs
     typechecks but defeats kernel-level `decide` over `Scenario.all.all (...)`. -/
 def Scenario.all : List Scenario :=
   [⟨.first, .first⟩,  ⟨.first, .second⟩,  ⟨.first, .third⟩,
@@ -595,7 +593,7 @@ def Scenario.frequencyClass (s : Scenario) : Nat :=
 /-- Gradient upstream degree: how far P's rank exceeds A's.
     Uses Nat saturating subtraction (negative → 0). -/
 def Scenario.upstreamDegree (s : Scenario) : Nat :=
-  s.pPerson.rank - s.aPerson.rank
+  s.pPerson.prominence - s.aPerson.prominence
 
 theorem downstream_frequency_class :
     (⟨.first, .third⟩ : Scenario).frequencyClass = 2 := rfl

--- a/Linglib/Fragments/Dargwa/Agreement.lean
+++ b/Linglib/Fragments/Dargwa/Agreement.lean
@@ -38,7 +38,6 @@ tense (*=de*), creating a homophony that is typologically unusual.
 
 namespace Dargwa.Agreement
 
-open Features.Prominence (PersonLevel)
 
 -- ============================================================================
 -- § 1: Gender System
@@ -103,20 +102,26 @@ inductive MarkerSet where
     **Clitic set** ("Dargic type"): =da covers 1SG, 1PL, and 2PL
     (ex. 34a: "I, we, you(PL) am, are doing"); =de is 2SG only.
     Table 4.21 confirms: "person clitics: 2SG =de, 1SG/PL, 2PL =da". -/
-def personMarker : MarkerSet → PersonLevel → UD.Number → Option String
+def personMarker : MarkerSet → Person → UD.Number → Option String
   -- Clitic set: =da for {1SG, 1PL, 2PL}, =de for {2SG}, none for {3}
-  | .clitic,   .first,  _   => some "=da"
+  -- (clusivity-marked firsts pattern with first; impersonal unmarked)
+  | _,         .zero,   _   => none
+  | .clitic,   .first,  _ | .clitic, .firstInclusive, _
+  | .clitic,   .firstExclusive, _ => some "=da"
   | .clitic,   .second, .Sing => some "=de"
   | .clitic,   .second, _   => some "=da"    -- 2PL patterns with 1st person
   | .clitic,   .third,  _   => none          -- 3rd unmarked
   -- Irrealis set
-  | .irrealis, .first,  .Sing => some "-d"
-  | .irrealis, .first,  _   => some "-haˁ"   -- (> -he)
+  | .irrealis, .first,  .Sing | .irrealis, .firstInclusive, .Sing
+  | .irrealis, .firstExclusive, .Sing => some "-d"
+  | .irrealis, .first,  _ | .irrealis, .firstInclusive, _
+  | .irrealis, .firstExclusive, _ => some "-haˁ"   -- (> -he)
   | .irrealis, .second, .Sing => some "-t:"    -- (> -t)
   | .irrealis, .second, _   => some "-t:-a"
   | .irrealis, .third,  _   => none
   -- Optative set
-  | .optative, .first,  _   => some "-a"
+  | .optative, .first,  _ | .optative, .firstInclusive, _
+  | .optative, .firstExclusive, _ => some "-a"
   | .optative, .second, .Sing => some "-e"
   | .optative, .second, _   => some "-a"     -- + -ja allocutive
   | .optative, .third,  _   => none
@@ -150,7 +155,7 @@ inductive GenderController where
     If one core argument is a SAP and the other is not, the verb
     agrees with the SAP regardless of case. If both are SAPs,
     agreement is with the absolutive. -/
-def personAgreementController (aPerson pPerson : PersonLevel) : PersonLevel :=
+def personAgreementController (aPerson pPerson : Person) : Person :=
   match aPerson, pPerson with
   | .first,  .third  => .first     -- SAP wins
   | .second, .third  => .second    -- SAP wins
@@ -168,13 +173,13 @@ def personAgreementController (aPerson pPerson : PersonLevel) : PersonLevel :=
     *-i* when A is SAP (1st/2nd) and P is 3rd — the configuration where
     A outranks P in the person hierarchy (1, 2 > 3).
     *-u* otherwise (both SAP, or A is 3rd). -/
-def thematicSuffix (aPerson pPerson : PersonLevel) : String :=
-  if aPerson.isSAP && !pPerson.isSAP then "-i" else "-u"
+def thematicSuffix (aPerson pPerson : Person) : String :=
+  if decide aPerson.IsSAP && !decide pPerson.IsSAP then "-i" else "-u"
 
 /-- Intransitive thematic suffix: *-u* for SAP subjects,
     *-ar* / *-an* for 3rd person subjects. -/
-def intransitiveThematicSuffix (sPerson : PersonLevel) : String :=
-  if sPerson.isSAP then "-u" else "-ar"
+def intransitiveThematicSuffix (sPerson : Person) : String :=
+  if decide sPerson.IsSAP then "-u" else "-ar"
 
 /-- The thematic suffix *-i* marks the same configuration that the
     person agreement hierarchy resolves to the A-argument: SAP acting
@@ -232,11 +237,10 @@ theorem both_sap_absolutive_wins :
 
 /-- The "SAP wins" rule directly reflects the person prominence hierarchy:
     SAP (1st/2nd) > 3rd. This is the same hierarchy formalized in
-    `Features.Prominence.PersonLevel`. -/
+    `Person`. -/
 theorem sap_hierarchy_from_prominence :
-    PersonLevel.first.isSAP = true ∧
-    PersonLevel.second.isSAP = true ∧
-    PersonLevel.third.isSAP = false := ⟨rfl, rfl, rfl⟩
+    Person.first.IsSAP ∧ Person.second.IsSAP ∧ ¬Person.third.IsSAP := by
+  decide
 
 /-- Masculine and feminine prefixes are distinct. -/
 theorem gender_prefixes_distinct :

--- a/Linglib/Fragments/Kawapanan/Shawi/Basic.lean
+++ b/Linglib/Fragments/Kawapanan/Shawi/Basic.lean
@@ -42,7 +42,6 @@ of ergative distribution to a particular Agree configuration — lives in
 
 namespace Kawapanan.Shawi
 
-open Features.Prominence (PersonLevel)
 
 -- ============================================================================
 -- § 1: Number system
@@ -62,7 +61,7 @@ def Number.toNumber : Number → _root_.Number
   | .min => .minimal
   | .aug => .augmented
 
-/-- Inclusivity dimension orthogonal to PersonLevel; only relevant for
+/-- Inclusivity dimension orthogonal to Person; only relevant for
     1st person (1INCL vs 1EXCL). -/
 inductive Clusivity where
   | excl
@@ -73,7 +72,7 @@ inductive Clusivity where
 /-- A φ-feature bundle for a Shawi argument. Field order matches the
     `subjectMarkers` / `objectMarkers` row layout: person, clusivity, number. -/
 structure Phi where
-  person    : PersonLevel
+  person    : Person
   clusivity : Clusivity
   number    : Number
   deriving DecidableEq, Repr
@@ -87,7 +86,7 @@ instance : HasPerson Phi :=
   ⟨fun φ => some (match φ.person, φ.clusivity with
     | .first, .incl => .firstInclusive
     | .first, .excl => .firstExclusive
-    | l, _ => Person.ofPersonLevel l)⟩
+    | l, _ => l)⟩
 
 -- ============================================================================
 -- § 2: Subject agreement (Table 1, indicative)
@@ -96,7 +95,7 @@ instance : HasPerson Phi :=
 /-- Subject agreement suffixes, indicative mood ([clem-deal-2024]
     Table 1, after Hart 1988, Barraza de García 2005, Ulloa to appear).
     Glottal stop is written `'`; optional `(a)` reflects source variation. -/
-def subjectMarkers : List (PersonLevel × Clusivity × Number × Option String) :=
+def subjectMarkers : List (Person × Clusivity × Number × Option String) :=
   [ (.first,  .excl, .min, some "-(a)we")
   , (.first,  .excl, .aug, some "-ai")
   , (.first,  .incl, .min, some "-e'")
@@ -113,7 +112,7 @@ def subjectMarkers : List (PersonLevel × Clusivity × Number × Option String) 
 /-- Object agreement suffixes ([clem-deal-2024] Table 2). 3rd person
     objects show no overt agreement (`∅`); we encode this directly with
     `none` rather than an empty-string sentinel. -/
-def objectMarkers : List (PersonLevel × Clusivity × Number × Option String) :=
+def objectMarkers : List (Person × Clusivity × Number × Option String) :=
   [ (.first,  .excl, .min, some "-ku")
   , (.first,  .excl, .aug, some "-kui")
   , (.first,  .incl, .min, some "-(n)pu'")
@@ -126,7 +125,7 @@ def objectMarkers : List (PersonLevel × Clusivity × Number × Option String) :
 /-- Lookup an agreement suffix; returns `none` if the row is absent or
     the cell itself is null (3rd-person object). -/
 def lookupMarker
-    (paradigm : List (PersonLevel × Clusivity × Number × Option String))
+    (paradigm : List (Person × Clusivity × Number × Option String))
     (φ : Phi) : Option String :=
   (paradigm.find? (λ ⟨p, c, n, _⟩ =>
       p == φ.person && c == φ.clusivity && n == φ.number)).bind (·.2.2.2)
@@ -163,10 +162,10 @@ inductive ObjectPosition where
 
 /-- Local-person (1/2) objects obligatorily move to the high position
     ([clem-deal-2024] §3.2). 3rd-person objects may but need not. -/
-def mustBeHigh : PersonLevel → Bool
-  | .first  => true
+def mustBeHigh : Person → Bool
+  | .first | .firstInclusive | .firstExclusive => true
   | .second => true
-  | .third  => false
+  | .third | .zero => false
 
 -- ============================================================================
 -- § 6: External syntax of the object

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -70,7 +70,7 @@ open Agreement
 
 -- Person-number combinations for Kaqchikel agreement paradigms come from
 -- the canonical φ-cell `Agreement.Cell` (six cells: three persons × two
--- numbers). Projections `.toPersonLevel`, `.isPlural`, and the inventory
+-- numbers). Projections `.toPerson`, `.isPlural`, and the inventory
 -- `Agreement.Cell.pnCells` live in `Syntax/Agreement/Paradigm.lean`.
 
 -- ============================================================================

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -86,10 +86,10 @@ inductive Formality where
   deriving DecidableEq, Repr
 
 /-- A person/number/formality specification. Uses canonical
-    `Features.Prominence.PersonLevel` for cross-language compatibility;
+    `Person` for cross-language compatibility;
     Formality is K'iche'-specific. -/
 structure PhiFeatures where
-  person : Features.Prominence.PersonLevel
+  person : Person
   number : UD.Number
   formality : Formality
   deriving DecidableEq, Repr
@@ -98,7 +98,7 @@ structure PhiFeatures where
 instance : HasNumber PhiFeatures := ⟨fun φ => Number.fromUD φ.number⟩
 
 /-- Shorthand for informal phi features. -/
-abbrev phi (p : Features.Prominence.PersonLevel) (n : UD.Number) : PhiFeatures :=
+abbrev phi (p : Person) (n : UD.Number) : PhiFeatures :=
   ⟨p, n, .informal⟩
 
 -- ============================================================================
@@ -119,7 +119,9 @@ def setBMarker : PhiFeatures → String
   | ⟨.second, .Sing, .formal⟩   => "la"
   | ⟨.second, .Plur, .formal⟩   => "alaq"
   -- Non-binary number falls through to plural; formal non-2nd is Ø
-  | ⟨.first,  _, .informal⟩   => "oj-"
+  | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
+  | ⟨.firstExclusive, _, .informal⟩ => "oj-"
+  | ⟨.zero, _, .informal⟩ => "∅"  -- no zero-person cell in the paradigm
   | ⟨.second, _, .informal⟩   => "ix-"
   | ⟨.third,  _, .informal⟩   => "ee-"
   | ⟨_, _, .formal⟩            => "Ø"
@@ -141,7 +143,9 @@ def setAPreC : PhiFeatures → String
   | ⟨.third,  .Plur, .informal⟩ => "ki-"
   | ⟨.second, .Sing, .formal⟩   => "la"
   | ⟨.second, .Plur, .formal⟩   => "alaq"
-  | ⟨.first,  _, .informal⟩   => "qa-"
+  | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
+  | ⟨.firstExclusive, _, .informal⟩ => "qa-"
+  | ⟨.zero, _, .informal⟩ => "∅"  -- no zero-person cell in the paradigm
   | ⟨.second, _, .informal⟩   => "i-"
   | ⟨.third,  _, .informal⟩   => "ki-"
   | ⟨_, _, .formal⟩            => "Ø"
@@ -157,7 +161,9 @@ def setAPreV : PhiFeatures → String
   | ⟨.third,  .Plur, .informal⟩ => "k-"
   | ⟨.second, .Sing, .formal⟩   => "la"
   | ⟨.second, .Plur, .formal⟩   => "alaq"
-  | ⟨.first,  _, .informal⟩   => "q-"
+  | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
+  | ⟨.firstExclusive, _, .informal⟩ => "q-"
+  | ⟨.zero, _, .informal⟩ => "∅"  -- no zero-person cell in the paradigm
   | ⟨.second, _, .informal⟩   => "iw-"
   | ⟨.third,  _, .informal⟩   => "k-"
   | ⟨_, _, .formal⟩            => "Ø"
@@ -337,7 +343,9 @@ def independentPronoun : PhiFeatures → String
   | ⟨.third,  .Plur, .informal⟩ => "a're'"
   | ⟨.second, .Sing, .formal⟩   => "laal"
   | ⟨.second, .Plur, .formal⟩   => "alaq"
-  | ⟨.first,  _, .informal⟩   => "oj"
+  | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
+  | ⟨.firstExclusive, _, .informal⟩ => "oj"
+  | ⟨.zero, _, .informal⟩ => "∅"  -- no zero-person cell in the paradigm
   | ⟨.second, _, .informal⟩   => "ix"
   | ⟨.third,  _, .informal⟩   => "a're'"
   | ⟨_, _, .formal⟩            => "are'"

--- a/Linglib/Phenomena/Agreement/DifferentialIndexing.lean
+++ b/Linglib/Phenomena/Agreement/DifferentialIndexing.lean
@@ -52,7 +52,7 @@ open Features.Prominence
     participants (SAP: 1st/2nd person) and non-participants (3rd person).
     This mirrors [preminger-2014]'s [±participant] feature decomposition.
 
-    This is coarser than `Features.Prominence.PersonLevel` (1st > 2nd > 3rd),
+    This is coarser than `Person` (1st > 2nd > 3rd),
     which is needed for scenario splits. The binary split suffices for
     indexing because indexing does not distinguish 1st from 2nd. -/
 inductive IndexingPersonLevel where

--- a/Linglib/Studies/AdamsonZompi2025.lean
+++ b/Linglib/Studies/AdamsonZompi2025.lean
@@ -53,7 +53,6 @@ not addressee reference per se.
 
 namespace AdamsonZompi2025
 
-open Features.Prominence (PersonLevel)
 open Minimalist (DecomposedPerson decomposePerson)
 open Minimalist.PConstraint (PCCGrammar IsLicit weakGrammar strongGrammar
   IsInherentlyProximate)
@@ -77,12 +76,12 @@ open Minimalist.PConstraint (PCCGrammar IsLicit weakGrammar strongGrammar
 
     For ordinary (non-polite) pronouns, both layers coincide. -/
 structure DualPersonFeatures where
-  agreementPerson : PersonLevel
-  interpretablePerson : PersonLevel
+  agreementPerson : Person
+  interpretablePerson : Person
   deriving DecidableEq, Repr
 
 /-- Ordinary pronoun: both layers are the same person. -/
-def DualPersonFeatures.ordinary (p : PersonLevel) : DualPersonFeatures :=
+def DualPersonFeatures.ordinary (p : Person) : DualPersonFeatures :=
   ⟨p, p⟩
 
 -- ============================================================================
@@ -134,9 +133,10 @@ def imposter : DualPersonFeatures := .ordinary .third
 
     Note: the person values here are the values the PCC *reads* — the
     central question of the paper is whether these are agreement person
-    or interpretable person. -/
-def weakPCC (ioPerson doPerson : PersonLevel) : Bool :=
-  !(ioPerson == .third && doPerson.isSAP)
+    or interpretable person. "3rd person" is `[−participant]` (non-SAP),
+    which over the full inventory includes the impersonal. -/
+def weakPCC (ioPerson doPerson : Person) : Bool :=
+  !(!decide ioPerson.IsSAP && decide doPerson.IsSAP)
 
 /-- The **Strong PCC**: in a ditransitive clitic cluster, the DO must be
     3rd person. Some Italian speakers have the Strong PCC (§2, p. 5),
@@ -144,11 +144,11 @@ def weakPCC (ioPerson doPerson : PersonLevel) : Bool :=
 
     The Strong PCC entails the Weak PCC: anything banned under the Weak
     PCC is also banned under the Strong PCC. -/
-def strongPCC (_ioPerson doPerson : PersonLevel) : Bool :=
-  doPerson == .third
+def strongPCC (_ioPerson doPerson : Person) : Bool :=
+  !decide doPerson.IsSAP
 
 /-- Strong PCC entails Weak PCC. -/
-theorem strong_entails_weak (io do_ : PersonLevel) :
+theorem strong_entails_weak (io do_ : Person) :
     strongPCC io do_ = true → weakPCC io do_ = true := by
   cases io <;> cases do_ <;> decide
 
@@ -185,8 +185,8 @@ theorem strong_1_2 : strongPCC .first .second = false := rfl
 structure CliticJudgment where
   label : String
   ok : Bool
-  ioPerson : PersonLevel
-  doPerson : PersonLevel
+  ioPerson : Person
+  doPerson : Person
   deriving Repr
 
 -- Standard PCC data (§2, (1)–(3))
@@ -269,7 +269,7 @@ theorem lei_banned_under_both_variants :
     strongPCC .third lei.interpretablePerson = false := ⟨rfl, rfl⟩
 
 /-- For ordinary pronouns (no mismatch), both accounts agree. -/
-theorem ordinary_accounts_agree (p : PersonLevel) :
+theorem ordinary_accounts_agree (p : Person) :
     morphosyntacticPrediction (.ordinary p) =
     syntacticosemanticPrediction (.ordinary p) := rfl
 
@@ -294,7 +294,7 @@ theorem ordinary_accounts_agree (p : PersonLevel) :
 
     We model the Fancy Constraint as reading the same interpretable person
     features as the PCC. -/
-def fancyConstraint (causeePerson : PersonLevel) : Bool :=
+def fancyConstraint (causeePerson : Person) : Bool :=
   -- Causee must be 3rd person (non-participant) when co-occurring
   -- with another argument
   causeePerson == .third
@@ -354,7 +354,7 @@ inductive ResolvedNumber where
   deriving DecidableEq, Repr
 
 def resolvedAgreement (d : DualPersonFeatures) : ResolvedNumber :=
-  if d.interpretablePerson.isSAP then .pl2 else .pl3
+  if decide d.interpretablePerson.IsSAP then .pl2 else .pl3
 
 /-- LEI + 3sg → 2PL resolved agreement ((30)). -/
 theorem lei_resolved_2pl : resolvedAgreement lei = .pl2 := rfl
@@ -394,12 +394,12 @@ theorem lei_agreement_not_participant :
 /-- The Weak PCC reduces to: if IO is [−participant], then DO must be
     [−participant]. Equivalently: ¬(IO lacks [participant] ∧ DO has
     [participant]). -/
-def pccViaParticipant (ioPerson doPerson : PersonLevel) : Bool :=
+def pccViaParticipant (ioPerson doPerson : Person) : Bool :=
   !(!((decomposePerson ioPerson).hasParticipant) &&
      (decomposePerson doPerson).hasParticipant)
 
 /-- `pccViaParticipant` is extensionally equivalent to `weakPCC`. -/
-theorem pcc_participant_equivalence (io do_ : PersonLevel) :
+theorem pcc_participant_equivalence (io do_ : Person) :
     weakPCC io do_ = pccViaParticipant io do_ := by
   cases io <;> cases do_ <;> rfl
 
@@ -413,13 +413,13 @@ theorem pcc_participant_equivalence (io do_ : PersonLevel) :
 
     The Weak PCC (P-Uniqueness inactive) produces the same judgments as
     our `weakPCC` function. -/
-theorem pconstraint_matches_weakPCC (io do_ : PersonLevel) :
+theorem pconstraint_matches_weakPCC (io do_ : Person) :
     IsLicit weakGrammar io do_ ↔ weakPCC io do_ = true := by
   cases io <;> cases do_ <;> decide
 
 /-- The Strong PCC (P-Uniqueness active) produces the same judgments as
     our `strongPCC` function. -/
-theorem pconstraint_matches_strongPCC (io do_ : PersonLevel) :
+theorem pconstraint_matches_strongPCC (io do_ : Person) :
     IsLicit strongGrammar io do_ ↔ strongPCC io do_ = true := by
   cases io <;> cases do_ <;> decide
 
@@ -618,7 +618,7 @@ theorem german_fragment_sie_dual :
     source) are sensitive to interpretable person, so polite pronouns
     trigger them. Assumed-identity effects (exponence-based source) are
     sensitive to formal features, so polite pronouns do NOT trigger them. -/
-def assumedIdentityEffect (formalPerson : PersonLevel) (copulaForm3rd : Bool) : Bool :=
+def assumedIdentityEffect (formalPerson : Person) (copulaForm3rd : Bool) : Bool :=
   -- Exponence-based: reads formal/agreement person.
   -- Effect is ameliorated when copula form is syncretic between
   -- 1st/3rd person (past tense *war*), supporting an exponence account.
@@ -683,7 +683,7 @@ theorem all_fragments_grounded :
 open Person in
 /-- The [±participant] decomposition in `Core/Person/Category.lean`
     (operating on `Category`) is the same decomposition as
-    `Phi.Geometry.decomposePerson` (operating on `PersonLevel`).
+    `Phi.Geometry.decomposePerson` (operating on `Person`).
 
     This theorem bridges the two: for all singular Categories,
     `toFeatures.hasParticipant` equals `decomposePerson.hasParticipant`. -/

--- a/Linglib/Studies/Aissen2003Agreement.lean
+++ b/Linglib/Studies/Aissen2003Agreement.lean
@@ -53,12 +53,12 @@ open Kaqchikel
 /-! Just's binary person split (SAP vs 3rd) is exactly Preminger's
     [±participant] feature decomposition. -/
 
-/-- Map a PersonLevel to Just's IndexingPersonLevel.
+/-- Map a Person to Just's IndexingPersonLevel.
     1st/2nd → SAP, 3rd → third. -/
-def personToLevel : PersonLevel → IndexingPersonLevel
-  | .first  => .sap
+def personToLevel : Person → IndexingPersonLevel
+  | .first | .firstInclusive | .firstExclusive => .sap
   | .second => .sap
-  | .third  => .third
+  | .third | .zero => .third
 
 /-- personToLevel agrees with decomposePerson on the participant split:
     SAP ↔ [+participant], third ↔ [−participant]. -/

--- a/Linglib/Studies/BejarRezac2009.lean
+++ b/Linglib/Studies/BejarRezac2009.lean
@@ -39,17 +39,16 @@ second-cycle information: *m-* appears when valued on cycle I (IA=1P),
 
 namespace BejarRezac2009
 
-open Features.Prominence (PersonLevel)
 open Minimalist.CyclicAgree
 open Agreement
 
 -- ============================================================================
--- § 1: φ-cell → PersonLevel Bridge
+-- § 1: φ-cell → Person Bridge
 -- ============================================================================
 
 /-- Person level of a φ-cell (`Agreement.Cell`). Basque and Georgian share the
     same person→level map. -/
-def toLevel (c : Cell) : PersonLevel :=
+def toLevel (c : Cell) : Person :=
   match c.person with
   | some .first => .first
   | some .second => .second
@@ -59,9 +58,9 @@ def toLevel (c : Cell) : PersonLevel :=
 -- § 2: Basque — pIsIndexed Matches Inverse Context
 -- ============================================================================
 
-/-- Basque `pIsIndexed` agrees with `PersonLevel.isSAP` under the bridge. -/
+/-- Basque `pIsIndexed` agrees with `Person.isSAP` under the bridge. -/
 theorem basque_indexed_eq_sap : ∀ c ∈ Cell.pnCells,
-    Basque.Agreement.pIsIndexed c = (toLevel c).isSAP := by decide
+    Basque.Agreement.pIsIndexed c = decide (toLevel c).IsSAP := by decide
 
 /-- Per-cell verification: each Basque φ-cell's indexing status matches the
     cyclic agree prediction. -/
@@ -94,15 +93,15 @@ theorem basque_p3sg_not_indexed :
     controls → agreement tracks the subject, not the object → not indexed. -/
 theorem basque_indexed_iff_always_inverse : ∀ c ∈ Cell.pnCells,
     (Basque.Agreement.pIsIndexed c = true ↔
-     ∀ ea : PersonLevel, basque.isInverse ea (toLevel c) = true) := by decide
+     ∀ ea : Person, basque.isInverse ea (toLevel c) = true) := by decide
 
 -- ============================================================================
 -- § 3: Georgian — isIndexed Matches Inverse Context
 -- ============================================================================
 
-/-- Georgian `isIndexed` agrees with `PersonLevel.isSAP` under the bridge. -/
+/-- Georgian `isIndexed` agrees with `Person.isSAP` under the bridge. -/
 theorem georgian_indexed_eq_sap : ∀ c ∈ Cell.pnCells,
-    Georgian.Agreement.isIndexed c = (toLevel c).isSAP := by decide
+    Georgian.Agreement.isIndexed c = decide (toLevel c).IsSAP := by decide
 
 /-- Per-cell verification: Georgian 1sg object prefix *m-* exists iff inverse. -/
 theorem georgian_1sg_prefix_and_inverse :
@@ -125,7 +124,7 @@ theorem georgian_3sg_no_prefix_and_direct :
     split in object agreement. -/
 theorem georgian_indexed_iff_always_inverse : ∀ c ∈ Cell.pnCells,
     (Georgian.Agreement.isIndexed c = true ↔
-     ∀ ea : PersonLevel, basque.isInverse ea (toLevel c) = true) := by decide
+     ∀ ea : Person, basque.isInverse ea (toLevel c) = true) := by decide
 
 -- ============================================================================
 -- § 4: Georgian Second-Cycle Morphology
@@ -196,8 +195,8 @@ theorem basque_georgian_same_system :
 /-- The differential P indexing pattern is identical for all six
     person-number φ-cells across both languages. -/
 theorem cross_linguistic_uniformity :
-    (∀ c ∈ Cell.pnCells, Basque.Agreement.pIsIndexed c = (toLevel c).isSAP) ∧
-    (∀ c ∈ Cell.pnCells, Georgian.Agreement.isIndexed c = (toLevel c).isSAP) :=
+    (∀ c ∈ Cell.pnCells, Basque.Agreement.pIsIndexed c = decide (toLevel c).IsSAP) ∧
+    (∀ c ∈ Cell.pnCells, Georgian.Agreement.isIndexed c = decide (toLevel c).IsSAP) :=
   ⟨basque_indexed_eq_sap, georgian_indexed_eq_sap⟩
 
 end BejarRezac2009

--- a/Linglib/Studies/CharnavelMateu2015.lean
+++ b/Linglib/Studies/CharnavelMateu2015.lean
@@ -52,7 +52,6 @@ explicitly.
 
 namespace CharnavelMateu2015
 
-open Features.Prominence (PersonLevel)
 
 -- ============================================================================
 -- § 1: Logophoric Centers (paper §3.5.2, eq. 53)

--- a/Linglib/Studies/ClemDeal2024.lean
+++ b/Linglib/Studies/ClemDeal2024.lean
@@ -45,7 +45,8 @@ machinery as a separate follow-up.
 
 namespace ClemDeal2024
 
-open Features.Prominence (PersonLevel)
+open Minimalist (decomposePerson)
+
 open Deal2024 (DealGrammar isLicit strictlyDescending dpBears
   sd_off_diagonal_iff_outranks)
 open Kawapanan.Shawi (ObjectPosition ObjectSyntax Phi mustBeHigh
@@ -79,7 +80,7 @@ theorem shawi_is_strictly_descending :
     return `true` vacuously — local-person objects never occupy the
     low position (`mustBeHigh` is `true` for them), so this case is
     structurally inaccessible. -/
-def objectVisible : PersonLevel → ObjectPosition → Bool
+def objectVisible : Person → ObjectPosition → Bool
   | .third, .low => false
   | _, _         => true
 
@@ -91,7 +92,7 @@ def objectVisible : PersonLevel → ObjectPosition → Bool
     2. The probe must successfully Agree with the subject as a
        *second* goal — exactly Deal-2024's `isLicit` for the strictly
        descending grammar. -/
-def predictsErgative (subj obj : PersonLevel) (pos : ObjectPosition) : Bool :=
+def predictsErgative (subj obj : Person) (pos : ObjectPosition) : Bool :=
   objectVisible obj pos && isLicit shawiGrammar subj obj
 
 -- ============================================================================
@@ -102,7 +103,7 @@ def predictsErgative (subj obj : PersonLevel) (pos : ObjectPosition) : Bool :=
     reaches the subject — ergative is impossible regardless of the
     subject's features or the object's position. [clem-deal-2024]
     (7a–b), (14a–b), §3 derivation in (15). -/
-theorem erg_with_1p_obj_blocked (subj : PersonLevel) (pos : ObjectPosition) :
+theorem erg_with_1p_obj_blocked (subj : Person) (pos : ObjectPosition) :
     predictsErgative subj .first pos = false := by
   cases subj <;> cases pos <;> rfl
 
@@ -110,21 +111,21 @@ theorem erg_with_1p_obj_blocked (subj : PersonLevel) (pos : ObjectPosition) :
     triggering dynamic narrowing. The subject is then visible as G2
     only if it bears [PART] — i.e., is itself local-person.
     [clem-deal-2024] §3.2, (16). -/
-theorem erg_with_2p_obj_iff_subj_part (subj : PersonLevel) :
+theorem erg_with_2p_obj_iff_subj_part (subj : Person) :
     predictsErgative subj .second .high = dpBears subj .part := by
   cases subj <;> rfl
 
 /-- 3P high object: lacks [SPKR] *and* lacks [PART], so the probe
     neither halts nor narrows. The subject is visible as G2 regardless
     of its features. [clem-deal-2024] (8), (19). -/
-theorem erg_with_3p_obj_high_always (subj : PersonLevel) :
+theorem erg_with_3p_obj_high_always (subj : Person) :
     predictsErgative subj .third .high = true := by
   cases subj <;> rfl
 
 /-- 3P low object: invisible to v. The probe finds only the subject as
     G1; no goal-flag bundle reaches the subject. [clem-deal-2024]
     (24). -/
-theorem erg_with_3p_obj_low_blocked (subj : PersonLevel) :
+theorem erg_with_3p_obj_low_blocked (subj : Person) :
     predictsErgative subj .third .low = false := by
   cases subj <;> rfl
 
@@ -139,8 +140,10 @@ theorem erg_with_3p_obj_low_blocked (subj : PersonLevel) :
     Shawi's hierarchy effect is exactly the one that fell out of
     Deal-2024 on independent grounds. -/
 theorem erg_off_diagonal_iff_subj_outranks_obj
-    (subj obj : PersonLevel) (h_neq : subj ≠ obj) :
-    predictsErgative subj obj .high = true ↔ subj.rank > obj.rank := by
+    (subj obj : Person)
+    (h_neq : decomposePerson subj ≠ decomposePerson obj) :
+    predictsErgative subj obj .high = true ↔
+      subj.prominence > obj.prominence := by
   have h_vis : objectVisible obj .high = true := by cases obj <;> rfl
   unfold predictsErgative
   rw [h_vis, Bool.true_and]
@@ -175,7 +178,7 @@ example : -- row g low (3→3 low): absent
     predictsErgative .third .third .low = false := rfl
 
 /-- Optionality is exactly the `(✓)` cells: 1→3, 2→3, 3→3. -/
-theorem optionality_only_with_3p_object (subj obj : PersonLevel) :
+theorem optionality_only_with_3p_object (subj obj : Person) :
     (predictsErgative subj obj .high ≠ predictsErgative subj obj .low) →
     obj = .third := by
   cases obj <;> cases subj <;> decide
@@ -189,22 +192,16 @@ theorem optionality_only_with_3p_object (subj obj : PersonLevel) :
     Reason: `objectVisible` is `true` for any non-3P object regardless
     of position. -/
 theorem local_object_position_irrelevant
-    (subj obj : PersonLevel) (h : obj ≠ .third) (pos : ObjectPosition) :
+    (subj obj : Person) (h : obj.IsSAP) (pos : ObjectPosition) :
     predictsErgative subj obj pos = isLicit shawiGrammar subj obj := by
-  cases obj
-  · rfl
-  · rfl
-  · exact absurd rfl h
+  cases obj <;> first | rfl | exact h.elim
 
 /-- Bookkeeping: for any local-person object, the Fragment-level
     `mustBeHigh` constraint forces the high position, which is exactly
     what the probe-visibility analysis presupposes. -/
-theorem local_object_must_be_high (p : PersonLevel) (h : p ≠ .third) :
+theorem local_object_must_be_high (p : Person) (h : p.IsSAP) :
     mustBeHigh p = true := by
-  cases p
-  · rfl
-  · rfl
-  · exact absurd rfl h
+  cases p <;> first | rfl | exact h.elim
 
 -- ============================================================================
 -- § 7: Counterexamples to configurational case (paper §4.1)
@@ -216,7 +213,7 @@ theorem local_object_must_be_high (p : PersonLevel) (h : p ≠ .third) :
     value the case feature of NP1 as ergative unless NP2 has already
     been marked for case." Predicts ergative for *every* transitive
     subject. -/
-def configurationalRulePredictsErg (_subj _obj : PersonLevel) : Bool := true
+def configurationalRulePredictsErg (_subj _obj : Person) : Bool := true
 
 /-- The simple rule overgenerates 2→1: it predicts `-ri` on a 2P
     subject with a 1P object, but Shawi disallows it
@@ -238,8 +235,8 @@ theorem configurational_rule_overgenerates_3_to_1 :
     analysis predicts the absence because a low 3P object is invisible
     to the probe, so the subject is G1 rather than G2 — no goal
     flagging, no ergative. -/
-def augmentedConfigRulePredictsErg (subj obj : PersonLevel) : Bool :=
-  decide (subj.rank ≥ obj.rank)
+def augmentedConfigRulePredictsErg (subj obj : Person) : Bool :=
+  decide (subj.prominence ≥ obj.prominence)
 
 theorem augmented_config_rule_overgenerates_3_3_low :
     augmentedConfigRulePredictsErg .third .third = true ∧
@@ -255,7 +252,9 @@ theorem augmented_config_rule_overgenerates_3_3_low :
     ergative — a high-object subject that outranks the object forces
     the object out of postverbal position (to OSV or *pro*-drop). -/
 theorem outranking_subj_blocks_postverbal_obj
-    (subj obj : PersonLevel) (h_neq : subj ≠ obj) (h_rank : subj.rank > obj.rank) :
+    (subj obj : Person)
+    (h_neq : decomposePerson subj ≠ decomposePerson obj)
+    (h_rank : subj.prominence > obj.prominence) :
     objectSyntaxLicit (predictsErgative subj obj .high) .overtPostverbal = false := by
   have h_erg : predictsErgative subj obj .high = true :=
     (erg_off_diagonal_iff_subj_outranks_obj subj obj h_neq).mpr h_rank
@@ -265,7 +264,7 @@ theorem outranking_subj_blocks_postverbal_obj
 /-- The fronted (OSV) and *pro*-drop options remain licit regardless
     of whether the subject bears `-ri`. -/
 theorem fronted_and_prodropped_always_licit
-    (subj obj : PersonLevel) (pos : ObjectPosition) :
+    (subj obj : Person) (pos : ObjectPosition) :
     objectSyntaxLicit (predictsErgative subj obj pos) .overtFronted = true ∧
     objectSyntaxLicit (predictsErgative subj obj pos) .proDropped = true :=
   ⟨rfl, rfl⟩
@@ -286,15 +285,17 @@ theorem fronted_and_prodropped_always_licit
     *without* ergative is not) is structurally true here only by
     construction; deriving it requires the goal-flagging machinery
     flagged in "Follow-ups". -/
-def oagrOnSAvailable : PersonLevel → PersonLevel → ObjectPosition → Bool :=
+def oagrOnSAvailable : Person → Person → ObjectPosition → Bool :=
   predictsErgative
 
 /-- Inheriting the hierarchy bridge: OAgr-on-S is available off the
     diagonal iff the subject outranks the object — same pattern as
     `-ri` itself. -/
 theorem oagrOnS_off_diagonal_iff_subj_outranks_obj
-    (subj obj : PersonLevel) (h_neq : subj ≠ obj) :
-    oagrOnSAvailable subj obj .high = true ↔ subj.rank > obj.rank :=
+    (subj obj : Person)
+    (h_neq : decomposePerson subj ≠ decomposePerson obj) :
+    oagrOnSAvailable subj obj .high = true ↔
+      subj.prominence > obj.prominence :=
   erg_off_diagonal_iff_subj_outranks_obj subj obj h_neq
 
 -- ============================================================================
@@ -313,7 +314,7 @@ theorem shawi_licit_count :
     `isLicit` on the strictly-descending grammar — Shawi inherits the
     Deal-2024 typology wholesale once we condition on "object visible
     to v". -/
-theorem high_object_matches_deal2024 (subj obj : PersonLevel) :
+theorem high_object_matches_deal2024 (subj obj : Person) :
     predictsErgative subj obj .high = isLicit shawiGrammar subj obj := by
   cases obj <;> rfl
 

--- a/Linglib/Studies/Comrie1989.lean
+++ b/Linglib/Studies/Comrie1989.lean
@@ -75,7 +75,7 @@ grounding: the same 3-level hierarchy (human > animate > inanimate)
 governs both phenomena, with no possibility of drift between separate
 definitions.
 
-The same pattern holds for `DefinitenessLevel` and `PersonLevel` — all
+The same pattern holds for `DefinitenessLevel` and `Person` — all
 three prominence scales are defined once in `Features.Prominence` and
 imported by every downstream module. -/
 

--- a/Linglib/Studies/Deal2024.lean
+++ b/Linglib/Studies/Deal2024.lean
@@ -44,7 +44,6 @@ This study file connects [deal-2024]'s framework to both:
 
 namespace Deal2024
 
-open Features.Prominence (PersonLevel)
 open Minimalist (decomposePerson)
 open Minimalist.PConstraint (IsLicit strongGrammar ultraStrongGrammar
   weakGrammar meFirstGrammar)
@@ -69,7 +68,7 @@ inductive PersonFeature where
   deriving DecidableEq, Repr
 
 /-- Does a DP of person level `p` bear feature `f`? -/
-def dpBears (p : PersonLevel) (f : PersonFeature) : Bool :=
+def dpBears (p : Person) (f : PersonFeature) : Bool :=
   match f with
   | .phi  => true
   | .part => (decomposePerson p).hasParticipant
@@ -143,7 +142,7 @@ structure DealGrammar where
     3. If narrowing occurred, IO must bear the narrowed feature to be
        visible to the probe. If IO is invisible → **illicit**.
     4. If no narrowing, IO is always visible → **licit**. -/
-def isLicit (g : DealGrammar) (io do_ : PersonLevel) : Bool :=
+def isLicit (g : DealGrammar) (io do_ : Person) : Bool :=
   let doSatisfies := match g.satisfaction with
     | none => false
     | some f => dpBears do_ f
@@ -253,7 +252,7 @@ theorem sd_3_2 : isLicit strictlyDescending .third .second = false := rfl
 -- § 11: Verification — No PCC
 -- ============================================================================
 
-theorem nopcc_all_licit (io do_ : PersonLevel) :
+theorem nopcc_all_licit (io do_ : Person) :
     isLicit noPCC io do_ = true := by
   cases io <;> cases do_ <;> rfl
 
@@ -263,7 +262,7 @@ theorem nopcc_all_licit (io do_ : PersonLevel) :
 
 /-- Count licit combinations (out of 9 = 3×3). -/
 def licitCount (g : DealGrammar) : Nat :=
-  let ps : List PersonLevel := [.first, .second, .third]
+  let ps : List Person := [.first, .second, .third]
   (ps.flatMap (λ io => ps.filter (λ do_ => isLicit g io do_))).length
 
 theorem strong_licit_count : licitCount strong = 3 := by native_decide
@@ -278,12 +277,12 @@ theorem nopcc_licit_count : licitCount noPCC = 9 := by native_decide
 
 /-- Strong entails Me-first: anything licit under Strong is licit under
     Me-first. (Strong has SAT:[PART] ⊇ SAT:[SPKR].) -/
-theorem strong_entails_mefirst (io do_ : PersonLevel) :
+theorem strong_entails_mefirst (io do_ : Person) :
     isLicit strong io do_ = true → isLicit meFirst io do_ = true := by
   cases io <;> cases do_ <;> decide
 
 /-- Strong entails Weak: anything licit under Strong is licit under Weak. -/
-theorem strong_entails_weak (io do_ : PersonLevel) :
+theorem strong_entails_weak (io do_ : Person) :
     isLicit strong io do_ = true → isLicit weak io do_ = true := by
   cases io <;> cases do_ <;> decide
 
@@ -292,17 +291,17 @@ theorem strong_entails_weak (io do_ : PersonLevel) :
 -- ============================================================================
 
 /-- Deal's Strong PCC matches P&Z's Strong PCC on all 9 cells. -/
-theorem strong_matches_pz (io do_ : PersonLevel) :
+theorem strong_matches_pz (io do_ : Person) :
     isLicit strong io do_ = true ↔ IsLicit strongGrammar io do_ := by
   cases io <;> cases do_ <;> decide
 
 /-- Deal's Weak PCC matches P&Z's Weak PCC on all 9 cells. -/
-theorem weak_matches_pz (io do_ : PersonLevel) :
+theorem weak_matches_pz (io do_ : Person) :
     isLicit weak io do_ = true ↔ IsLicit weakGrammar io do_ := by
   cases io <;> cases do_ <;> decide
 
 /-- Deal's Me-first PCC matches P&Z's Me-first PCC on all 9 cells. -/
-theorem mefirst_matches_pz (io do_ : PersonLevel) :
+theorem mefirst_matches_pz (io do_ : Person) :
     isLicit meFirst io do_ = true ↔ IsLicit meFirstGrammar io do_ := by
   cases io <;> cases do_ <;> decide
 
@@ -346,14 +345,14 @@ theorem sd_ultra_discrepancy_2_2 :
 
     This bridges the two frameworks: "the probe is satisfied" (Deal) ↔
     "no active residue remains" (B&R). -/
-theorem residue_empty_iff_bears_part (p : PersonLevel) :
+theorem residue_empty_iff_bears_part (p : Person) :
     (activeResidue partialProbe (personSpec .standard p)).isEmpty =
     dpBears p .part := by
   cases p <;> native_decide
 
 /-- The converse direction: a DP that does NOT bear [PART] leaves
     non-empty residue — the probe continues to the next cycle. -/
-theorem residue_nonempty_iff_lacks_part (p : PersonLevel) :
+theorem residue_nonempty_iff_lacks_part (p : Person) :
     (!(activeResidue partialProbe (personSpec .standard p)).isEmpty) =
     !dpBears p .part := by
   cases p <;> native_decide
@@ -369,7 +368,7 @@ theorem residue_nonempty_iff_lacks_part (p : PersonLevel) :
     and [ADDR] geometrically entail [PART], any DP that would trigger
     dynamic interaction via [SPKR]↑ or [PART]↑ also satisfies SAT:[PART].
     Therefore, dynamic interaction is irrelevant when SAT = [PART]. -/
-theorem sat_part_absorbs_dynint (dyn : DynInteraction) (io do_ : PersonLevel) :
+theorem sat_part_absorbs_dynint (dyn : DynInteraction) (io do_ : Person) :
     isLicit ⟨some .part, dyn⟩ io do_ = isLicit strong io do_ := by
   cases dyn <;> cases io <;> cases do_ <;> rfl
 
@@ -426,7 +425,7 @@ theorem ad_licit_count : licitCount aDescending = 5 := by native_decide
 
     Attested in Shapsug Adyghe, varieties of Swiss German, Czech,
     and Slovenian. -/
-def reverseLicit (g : DealGrammar) (io do_ : PersonLevel) : Bool :=
+def reverseLicit (g : DealGrammar) (io do_ : Person) : Bool :=
   isLicit g do_ io
 
 /-- Reverse strictly descending PCC (Shapsug Adyghe): DO must outrank IO
@@ -444,33 +443,38 @@ theorem rsd_1_2_bad : reverseLicit reverseSD .first .second = false := rfl
 -- § 19: Characterization Theorems (Table (1), (2a-d))
 -- ============================================================================
 
-/-- Strong PCC (2a): DO must be 3P. Any IO is licit with a 3P DO;
-    any SAP DO is illicit regardless of IO. -/
-theorem strong_iff_3p_do (io do_ : PersonLevel) :
-    isLicit strong io do_ = true ↔ do_ = .third := by
-  cases io <;> cases do_ <;> simp [isLicit, strong, dpBears, decomposePerson]
+/-- Strong PCC (2a): DO must be 3P — i.e. `[−participant]`, which over
+    the full inventory is exactly non-SAP. Any IO is licit with a
+    non-SAP DO; any SAP DO is illicit regardless of IO. -/
+theorem strong_iff_3p_do (io do_ : Person) :
+    isLicit strong io do_ = true ↔ ¬do_.IsSAP := by
+  cases io <;> cases do_ <;> simp [isLicit, strong, dpBears, decomposePerson,
+    Person.IsSAP]
 
-/-- Weak PCC (2b): if IO is 3P, DO must be 3P. Equivalently: the only
-    illicit cells are ⟨3P IO, SAP DO⟩. -/
-theorem weak_illicit_iff (io do_ : PersonLevel) :
-    isLicit weak io do_ = false ↔ io = .third ∧ do_.isSAP = true := by
+/-- Weak PCC (2b): if IO is 3P (`[−participant]`), DO must be 3P.
+    Equivalently: the only illicit cells are ⟨non-SAP IO, SAP DO⟩. -/
+theorem weak_illicit_iff (io do_ : Person) :
+    isLicit weak io do_ = false ↔ ¬io.IsSAP ∧ do_.IsSAP := by
   cases io <;> cases do_ <;> simp [isLicit, weak, dpBears, decomposePerson,
-    PersonLevel.isSAP]
+    Person.IsSAP]
 
 /-- Me-first PCC (2c): if 1P is present, it must be IO. Equivalently:
     DO cannot be 1P. -/
-theorem mefirst_iff_not_1p_do (io do_ : PersonLevel) :
+theorem mefirst_iff_not_1p_do (io do_ : Person) :
     isLicit meFirst io do_ = true ↔ dpBears do_ .spkr = false := by
   cases io <;> cases do_ <;> simp [isLicit, meFirst, dpBears, decomposePerson]
 
-/-- Strictly descending PCC (2d): IO must outrank DO on 1 > 2 > 3.
-    For the 6 non-diagonal cells, this is exactly the pattern.
-    (Diagonal cells: ⟨3,3⟩ and ⟨2,2⟩ are licit; ⟨1,1⟩ is illicit
-    because SAT:[SPKR] fires.) -/
-theorem sd_off_diagonal_iff_outranks (io do_ : PersonLevel) (h : io ≠ do_) :
-    isLicit strictlyDescending io do_ = true ↔ io.rank > do_.rank := by
+/-- Strictly descending PCC (2d): IO must outrank DO on 1 > 2 > 3
+    (prominence). For featurally distinct cells, this is exactly the
+    pattern. (Featurally identical cells — ⟨3,3⟩, ⟨2,2⟩, and the cells
+    the two-feature system conflates — are licit except ⟨1,1⟩, where
+    SAT:[SPKR] fires.) -/
+theorem sd_off_diagonal_iff_outranks (io do_ : Person)
+    (h : decomposePerson io ≠ decomposePerson do_) :
+    isLicit strictlyDescending io do_ = true ↔
+      io.prominence > do_.prominence := by
   cases io <;> cases do_ <;> simp_all [isLicit, strictlyDescending, dpBears,
-    decomposePerson, PersonLevel.rank]
+    decomposePerson, Person.prominence]
 
 -- ============================================================================
 -- § 20: Additional Entailment
@@ -479,7 +483,7 @@ theorem sd_off_diagonal_iff_outranks (io do_ : PersonLevel) (h : io ≠ do_) :
 /-- Strong entails strictly descending: anything licit under Strong
     is licit under SD. (Strong bans all SAP DOs; SD bans only 1P DOs
     and ⟨3P IO, SAP DO⟩.) -/
-theorem strong_entails_sd (io do_ : PersonLevel) :
+theorem strong_entails_sd (io do_ : Person) :
     isLicit strong io do_ = true → isLicit strictlyDescending io do_ = true := by
   cases io <;> cases do_ <;> decide
 
@@ -492,7 +496,7 @@ theorem strong_entails_sd (io do_ : PersonLevel) :
     person features are not independently stipulated but derived from the
     same privative geometry used by [pancheva-zubizarreta-2018]'s
     `satisfiesProminence` and [bejar-rezac-2009]'s `personSpec`. -/
-theorem dpBears_grounded_in_decomposePerson (p : PersonLevel) :
+theorem dpBears_grounded_in_decomposePerson (p : Person) :
     dpBears p .part = (decomposePerson p).hasParticipant ∧
     dpBears p .spkr = (decomposePerson p).hasAuthor := by
   cases p <;> exact ⟨rfl, rfl⟩

--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -604,7 +604,6 @@ needed to formalise Deal's 1st vs 3rd person split. The disjunctive shape
 here is faithful to the framework but currently distinguishes only
 "person-feature-present" vs "no-feature-encountered-T." -/
 
-open Features.Prominence (PersonLevel)
 
 /-- *ke*'s satisfaction condition: matched by any φ-feature (collapsed by
     `sameType` regardless of person value), or by encountering the TP head. -/

--- a/Linglib/Studies/HalpertHammerly2026.lean
+++ b/Linglib/Studies/HalpertHammerly2026.lean
@@ -73,7 +73,6 @@ namespace HalpertHammerly2026
 
 open Bantu
 open Person (Features)
-open Features.Prominence (PersonLevel)
 
 -- ============================================================================
 -- § 1: Person–Animacy Containment Bridge

--- a/Linglib/Studies/Harbour2016.lean
+++ b/Linglib/Studies/Harbour2016.lean
@@ -272,16 +272,18 @@ theorem number_hierarchy_is_spec_ordering :
 /-! ### Bridge to Cyclic Agree ([bejar-rezac-2009]) -/
 
 open Minimalist.CyclicAgree (personSpec)
-open Features.Prominence (PersonLevel)
 
 /-- The person hierarchy from `ContainmentPair.specLevel` agrees with the segment-count
 hierarchy of [bejar-rezac-2009]'s Cyclic Agree: in the standard geometry, `specLevel + 1
 = segment count` (1st: 2/[π, participant, speaker]; 2nd: 1/[π, participant]; 3rd: 0/[π]).
 The person hierarchy is *one* hierarchy in two formalizations — featural (spec level) and
 configurational (probe depth). -/
-theorem specLevel_agrees_with_segments (p : PersonLevel) :
-    ContainmentPairLike.specLevel p.toFeatures + 1 = (personSpec .standard p).length := by
-  cases p <;> rfl
+theorem specLevel_agrees_with_segments (p : Person) :
+    ∀ f, p.toFeatures = some f →
+      ContainmentPairLike.specLevel f + 1 = (personSpec .standard p).length := by
+  cases p <;> intro f hf <;>
+    simp only [Person.toFeatures, Option.some.injEq, reduceCtorEq] at hf <;>
+    subst hf <;> rfl
 
 /-! ### Bridge to Corbett (2000): attested number systems are generable ([harbour-2014])
 

--- a/Linglib/Studies/PanchevaZubizarreta2018.lean
+++ b/Linglib/Studies/PanchevaZubizarreta2018.lean
@@ -46,7 +46,6 @@ that PCC effects diagnose *interpretable* (not agreement) person.
 
 namespace PanchevaZubizarreta2018
 
-open Features.Prominence (PersonLevel)
 open Features.Logophoricity (LogophoricRole pointOfViewPrinciple)
 open Minimalist (DecomposedPerson decomposePerson)
 open Minimalist.PConstraint
@@ -84,13 +83,13 @@ theorem positiveFeatureCount_values :
 
 /-- **The Person Hierarchy is derived, not stipulated** (paper §2.1, p. 1296:
     "We seek to derive it from more fundamental principles"). The order
-    induced by `PersonLevel.rank` (1P > 2P > 3P) coincides with the order
+    induced by `Person.prominence` (1P > 2P > 3P) coincides with the order
     induced by the count of positive features in the decomposition.
 
     Note: The two functions are not pointwise equal (3 vs 2, 2 vs 1, 0 vs 0)
     because `rank` collapses the SAP/non-SAP gap, but the orders match. -/
-theorem personHierarchy_from_features (p q : PersonLevel) :
-    p.rank ≤ q.rank ↔
+theorem personHierarchy_from_features (p q : Person) :
+    p.prominence ≤ q.prominence ↔
     positiveFeatureCount (decomposePerson p) ≤
     positiveFeatureCount (decomposePerson q) := by
   cases p <;> cases q <;> decide
@@ -237,7 +236,7 @@ theorem family_logophoric_assignments :
     yields an Appl domain that semantically satisfies the P-Constraint.
     The four parametric clauses in (12) are not free-standing stipulations:
     they are precisely the conditions on IO-as-POV consistency. -/
-theorem isLicit_imp_io_pov (g : PCCGrammar) (io do_ : PersonLevel) :
+theorem isLicit_imp_io_pov (g : PCCGrammar) (io do_ : Person) :
     IsLicit g io do_ → PConstraintSatisfied g ⟨io, do_, io⟩ := by
   rintro (h | ⟨hprom, hrest⟩)
   · exact Or.inl h
@@ -246,7 +245,7 @@ theorem isLicit_imp_io_pov (g : PCCGrammar) (io do_ : PersonLevel) :
 /-- Conversely, if any Appl domain over ⟨io, do_⟩ with IO as POV center
     satisfies the P-Constraint, the combination is licit. Together with
     `isLicit_imp_io_pov`, this characterizes `IsLicit` semantically. -/
-theorem io_pov_imp_isLicit (g : PCCGrammar) (io do_ : PersonLevel) :
+theorem io_pov_imp_isLicit (g : PCCGrammar) (io do_ : Person) :
     PConstraintSatisfied g ⟨io, do_, io⟩ → IsLicit g io do_ := by
   rintro (h | ⟨_, hprom, hrest⟩)
   · exact Or.inl h
@@ -264,20 +263,20 @@ theorem pov_principle_at_io_attitude_grammar :
 --
 -- Where Fragment clitic data exists (Italian, Spanish), the PCC
 -- predictions are derived from the actual fragment forms via
--- `PersonLevel.ofUDPerson`. For French, Catalan, Kambera, Bulgarian no
+-- `Person.ofUDPerson`. For French, Catalan, Kambera, Bulgarian no
 -- ditransitive-clitic fragment is yet defined in linglib, so the
 -- predictions cite paper examples but read directly off the parameter
 -- settings. Adding `Fragments/{French,Catalan,Bulgarian}/Pronouns.lean`
 -- would let those theorems be similarly grounded.
 -- ============================================================================
 
-open Features.Prominence (PersonLevel)
 
-/-- Helper: extract a `PersonLevel` from a clitic entry whose `person`
+/-- Helper: extract a `Person` from a clitic entry whose `person`
     field is a `UD.Person`. Returns `none` only on `.zero` (impersonal),
     which object clitics never bear. -/
-private def cliticLevel? (p : UD.Person) : Option PersonLevel :=
-  PersonLevel.ofUDPerson p
+private def cliticLevel? : UD.Person → Option Person
+  | .zero => none
+  | p => some (Person.fromUD p)
 
 -- ── Italian (Romance, weak ∼ strong PCC variation per [adamson-zompi-2025]) ──
 

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -118,22 +118,22 @@ open Agreement
 /-- Bears [+participant]? Derived from [harley-ritter-2002]'s
     feature geometry via `decomposePerson` (Phi/Geometry.lean). -/
 def IsParticipant (c : Agreement.Cell) : Prop :=
-  (decomposePerson c.toPersonLevel).hasParticipant = true
+  (decomposePerson c.toPerson).hasParticipant = true
 
 instance : DecidablePred IsParticipant := fun c =>
-  inferInstanceAs (Decidable ((decomposePerson c.toPersonLevel).hasParticipant = true))
+  inferInstanceAs (Decidable ((decomposePerson c.toPerson).hasParticipant = true))
 
 /-- Bears [+author]? -/
 def IsAuthor (c : Agreement.Cell) : Prop :=
-  (decomposePerson c.toPersonLevel).hasAuthor = true
+  (decomposePerson c.toPerson).hasAuthor = true
 
 instance : DecidablePred IsAuthor := fun c =>
-  inferInstanceAs (Decidable ((decomposePerson c.toPersonLevel).hasAuthor = true))
+  inferInstanceAs (Decidable ((decomposePerson c.toPerson).hasAuthor = true))
 
 /-- Convert a person-number cell to a PhiFeature list for the Agree
     infrastructure. -/
 def toPhiFeatures (c : Agreement.Cell) : List PhiFeature :=
-  [.person c.toPersonLevel, .number (if c.isPlural then .Plur else .Sing)]
+  [.person c.toPerson, .number (if c.isPlural then .Plur else .Sing)]
 
 -- ============================================================================
 -- § 2: DM Vocabulary Insertion ([halle-marantz-1993])
@@ -159,7 +159,7 @@ def setBVocab : Vocabulary :=
     on the cell's person + number features. NOT a salience scale —
     see module docstring. -/
 def afRank (c : Agreement.Cell) : Nat :=
-  probeResolutionRank c.toPersonLevel c.isPlural
+  probeResolutionRank c.toPerson c.isPlural
 
 /-- Person restriction ([preminger-2014] (25)): at most one core
     argument can bear [+participant]. Derives from the Person

--- a/Linglib/Studies/Scott2021.lean
+++ b/Linglib/Studies/Scott2021.lean
@@ -58,7 +58,6 @@ namespace Scott2021
 
 open Core Swahili
 open Minimalist (FeatureBundle FeatureVal PhiFeature)
-open Features.Prominence (PersonLevel)
 
 -- ============================================================================
 -- § 1: DP-Internal Categories
@@ -228,7 +227,7 @@ def hasPerson (fb : FeatureBundle) : Bool :=
     | _ => false
 
 /-- Helper: extract the person level if present. -/
-def getPerson (fb : FeatureBundle) : Option PersonLevel :=
+def getPerson (fb : FeatureBundle) : Option Person :=
   fb.findSome? fun f => match f with
     | .valued (.phi (.person p)) => some p
     | _ => none

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -178,7 +178,7 @@ open Agreement
 
 /-- PhiFeature list per Mam person-number cell. -/
 def mamToPhiFeatures (c : Agreement.Cell) : List PhiFeature :=
-  [.person c.toPersonLevel, .number (if c.isPlural then .Plur else .Sing)]
+  [.person c.toPerson, .number (if c.isPlural then .Plur else .Sing)]
 
 /-- Set A (ERG) vocabulary entries: φ-features on Voice (.v)
     yield the morphological exponent ([scott-2023] Table 2.8).

--- a/Linglib/Studies/Toosarvandani2023.lean
+++ b/Linglib/Studies/Toosarvandani2023.lean
@@ -639,7 +639,7 @@ theorem wrong_order_produces_plural :
 
 /-- Map PronType to the coarser 3-way person distinction in
     `Features.Prominence`. All third-person animacy subtypes collapse. -/
-def PronType.toPersonLevel : PronType → Person
+def PronType.toPerson : PronType → Person
   | .first  => .first
   | .second => .second
   | _       => .third
@@ -647,7 +647,7 @@ def PronType.toPersonLevel : PronType → Person
 /-- PCC respects person prominence: when subject is strictly more prominent
     in person (not just animacy), PCC is licit. -/
 theorem pcc_person_refinement : ∀ p1 p2 : PronType,
-    p1.toPersonLevel.prominence > p2.toPersonLevel.prominence → pccLicit p1 p2 = true := by
+    p1.toPerson.prominence > p2.toPerson.prominence → pccLicit p1 p2 = true := by
   decide
 
 /-- Map PronType to binary person features (±participant, ±author). -/
@@ -659,7 +659,7 @@ def PronType.toPersonFeatures : PronType → Person.Features
 /-- The two independent decompositions of person agree:
     PronType → PersonFeatures and PronType → Person → Features. -/
 theorem person_features_consistent : ∀ p : PronType,
-    p.toPersonFeatures = p.toPersonLevel.toFeatures := by decide
+    p.toPersonFeatures = p.toPerson.toFeatures := by decide
 
 /-- Map third-person pronoun types to AnimacyLevel. Elder and human both
     map to `.human` — elder is a human subtype. SAPs return `none`. -/

--- a/Linglib/Studies/Toosarvandani2023.lean
+++ b/Linglib/Studies/Toosarvandani2023.lean
@@ -639,7 +639,7 @@ theorem wrong_order_produces_plural :
 
 /-- Map PronType to the coarser 3-way person distinction in
     `Features.Prominence`. All third-person animacy subtypes collapse. -/
-def PronType.toPersonLevel : PronType → Features.Prominence.PersonLevel
+def PronType.toPersonLevel : PronType → Person
   | .first  => .first
   | .second => .second
   | _       => .third
@@ -647,7 +647,7 @@ def PronType.toPersonLevel : PronType → Features.Prominence.PersonLevel
 /-- PCC respects person prominence: when subject is strictly more prominent
     in person (not just animacy), PCC is licit. -/
 theorem pcc_person_refinement : ∀ p1 p2 : PronType,
-    p1.toPersonLevel.rank > p2.toPersonLevel.rank → pccLicit p1 p2 = true := by
+    p1.toPersonLevel.prominence > p2.toPersonLevel.prominence → pccLicit p1 p2 = true := by
   decide
 
 /-- Map PronType to binary person features (±participant, ±author). -/
@@ -657,7 +657,7 @@ def PronType.toPersonFeatures : PronType → Person.Features
   | _       => ⟨false, false⟩
 
 /-- The two independent decompositions of person agree:
-    PronType → PersonFeatures and PronType → PersonLevel → Features. -/
+    PronType → PersonFeatures and PronType → Person → Features. -/
 theorem person_features_consistent : ∀ p : PronType,
     p.toPersonFeatures = p.toPersonLevel.toFeatures := by decide
 

--- a/Linglib/Syntax/Agreement/Paradigm.lean
+++ b/Linglib/Syntax/Agreement/Paradigm.lean
@@ -65,10 +65,10 @@ def Cell.pn (p : UD.Person) (n : UD.Number) : Cell :=
 def Cell.isSAP (c : Cell) : Bool :=
   c.person == some .first || c.person == some .second
 
-/-- The person level of a cell, on the `Features.Prominence.PersonLevel` scale
+/-- The person level of a cell, on the `Person` scale
     (an unspecified or 0-person cell maps to `.third`). Adapts a φ-cell to
     consumers that reason on person prominence (decomposition, indexing). -/
-def Cell.toPersonLevel (c : Cell) : Features.Prominence.PersonLevel :=
+def Cell.toPersonLevel (c : Cell) : Person :=
   match c.person with
   | some .first => .first
   | some .second => .second

--- a/Linglib/Syntax/Agreement/Paradigm.lean
+++ b/Linglib/Syntax/Agreement/Paradigm.lean
@@ -68,7 +68,7 @@ def Cell.isSAP (c : Cell) : Bool :=
 /-- The person level of a cell, on the `Person` scale
     (an unspecified or 0-person cell maps to `.third`). Adapts a φ-cell to
     consumers that reason on person prominence (decomposition, indexing). -/
-def Cell.toPersonLevel (c : Cell) : Person :=
+def Cell.toPerson (c : Cell) : Person :=
   match c.person with
   | some .first => .first
   | some .second => .second

--- a/Linglib/Syntax/Minimalist/Agree.lean
+++ b/Linglib/Syntax/Minimalist/Agree.lean
@@ -256,7 +256,7 @@ def applyAgree (probeFeats goalFeats : FeatureBundle) (ftype : FeatureVal) :
 
     T has [uφ], subject DP has [φ] → T gets valued φ.
     The `.third` value on person probes is a conventional placeholder —
-    `sameType` ignores the specific `PersonLevel` value, matching any
+    `sameType` ignores the specific `Person` value, matching any
     `.person _` against any `.person _`. -/
 structure TAgree where
   tHead : SyntacticObject

--- a/Linglib/Syntax/Minimalist/Agreement/CoordinateResolution.lean
+++ b/Linglib/Syntax/Minimalist/Agreement/CoordinateResolution.lean
@@ -2,6 +2,7 @@ import Linglib.Features.Number.Resolve
 import Linglib.Features.Prominence
 import Linglib.Syntax.Minimalist.Agreement.GenderResolution
 import Linglib.Syntax.Minimalist.Phi.Recursion
+import Linglib.Features.Person.Resolve
 
 /-!
 # Coordinate Agreement Resolution
@@ -60,7 +61,6 @@ open Minimalist.Agreement.GenderResolution (AnnotatedFeature)
 
 namespace Minimalist.Agreement.CoordinateResolution
 
-open Features.Prominence (PersonLevel)
 
 -- ============================================================================
 -- § 1: Resolution Operations
@@ -131,19 +131,18 @@ theorem resolution_closure_table3 :
 
 /-- Person resolution: most marked wins ([noyer-1997]).
 
-    1st > 2nd > 3rd. The person with the higher prominence rank
-    determines the resolved person on &P. This follows from person
-    features being privative: [+participant] subsumes [−participant],
-    and [+author] subsumes [−author]. Resolution always succeeds. -/
-def personResolve : PersonLevel → PersonLevel → Option PersonLevel
-  | .first,  _       => some .first
-  | _,       .first  => some .first
-  | .second, _       => some .second
-  | _,       .second => some .second
-  | .third,  .third  => some .third
+    1st > 2nd > 3rd. **Derived, not stipulated**: Noyer's privative
+    resolution is the canonical referent-union resolution
+    (`Person.resolve`, `Features/Person/Resolve.lean`) coarsened to the
+    tripartition — the `[±author, ±participant]` system cannot represent
+    the clusivity the canonical inclusive output carries
+    (`Person.resolveIn_tripartition_min` is the hierarchy fact).
+    Resolution always succeeds. -/
+def personResolve (p q : Person) : Option Person :=
+  some (Person.resolve p q).coarsen
 
 /-- Person resolution operation. -/
-def personOp : ResolutionOp PersonLevel := ⟨personResolve⟩
+def personOp : ResolutionOp Person := ⟨personResolve⟩
 
 -- ============================================================================
 -- § 4: Percolation and Annotated Resolution
@@ -175,7 +174,7 @@ theorem number_total (system : List Number) (a b : Number) :
     ((numberOp system).resolve a b).isSome = true := rfl
 
 /-- Person resolution always succeeds. -/
-theorem person_total (p₁ p₂ : PersonLevel) :
+theorem person_total (p₁ p₂ : Person) :
     (personResolve p₁ p₂).isSome = true := by
   cases p₁ <;> cases p₂ <;> rfl
 
@@ -208,7 +207,7 @@ theorem number_comm (system : List Number) (a b : Number) :
   simp only [numberOp, Number.resolveIn_comm]
 
 /-- Person resolution is commutative (both directions yield max). -/
-theorem person_comm (p₁ p₂ : PersonLevel) :
+theorem person_comm (p₁ p₂ : Person) :
     personResolve p₁ p₂ = personResolve p₂ p₁ := by
   cases p₁ <;> cases p₂ <;> rfl
 
@@ -221,7 +220,7 @@ theorem person_comm (p₁ p₂ : PersonLevel) :
     agreement is a gender phenomenon, not a number or person one. -/
 theorem gender_only_fallible :
     (∀ system a b, ((numberOp system).resolve a b).isSome = true) ∧
-    (∀ p₁ p₂ : PersonLevel, (personResolve p₁ p₂).isSome = true) ∧
+    (∀ p₁ p₂ : Person, (personResolve p₁ p₂).isSome = true) ∧
     (∃ g₁ g₂ : GenderResolution.FeatureBundle Bool,
       (GenderResolution.resolve g₁ g₂).isSome = false) :=
   ⟨number_total, person_total, ⟨[⟨true, .interpretable⟩], [⟨false, .interpretable⟩], rfl⟩⟩
@@ -232,13 +231,13 @@ theorem gender_only_fallible :
 
 /-- A phi-feature bundle for a single conjunct DP. -/
 structure PhiBundle (G : Type) where
-  person : AnnotatedFeature PersonLevel
+  person : AnnotatedFeature Person
   number : AnnotatedFeature Number
   gender : GenderResolution.FeatureBundle G
 
 /-- Resolved phi-features for a conjoined DP (&P). -/
 structure PhiResolved (G : Type) where
-  person : Option PersonLevel
+  person : Option Person
   number : Option Number
   gender : Option (List G)
 

--- a/Linglib/Syntax/Minimalist/CyclicAgree.lean
+++ b/Linglib/Syntax/Minimalist/CyclicAgree.lean
@@ -80,7 +80,6 @@ not the others.
 
 namespace Minimalist.CyclicAgree
 
-open Features.Prominence (PersonLevel)
 open Minimalist (DecomposedPerson decomposePerson)
 
 -- ============================================================================
@@ -116,9 +115,9 @@ inductive Geometry where
 /-- The person specification for a given person value under a geometry.
 
     Returns the list of segments a DP of this person bears. -/
-def personSpec (geom : Geometry) : PersonLevel → List Segment
-  | .third  => [.pi]
-  | .first  => match geom with
+def personSpec (geom : Geometry) : Person → List Segment
+  | .third | .zero => [.pi]
+  | .first | .firstInclusive | .firstExclusive => match geom with
     | .standard  => [.pi, .participant, .speaker]
     | .addressee => [.pi, .participant]
   | .second => match geom with
@@ -126,7 +125,7 @@ def personSpec (geom : Geometry) : PersonLevel → List Segment
     | .addressee => [.pi, .participant, .addressee]
 
 /-- The most specified person under a given geometry. -/
-def mostSpecified : Geometry → PersonLevel
+def mostSpecified : Geometry → Person
   | .standard  => .first
   | .addressee => .second
 
@@ -211,7 +210,7 @@ inductive Controller where
     Returns `true` iff the EA matches at least one segment that the
     IA left unmatched. -/
 def eaAgrees (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : PersonLevel) : Bool :=
+    (ea ia : Person) : Bool :=
   let residue := activeResidue probe (personSpec geom ia)
   let residueAfterEA := activeResidue residue (personSpec geom ea)
   residueAfterEA.length < residue.length
@@ -223,24 +222,24 @@ def eaAgrees (geom : Geometry) (probe : ProbeArticulation)
     segment; otherwise IA controls (either it fully checked the
     probe, or it left residue the EA couldn't match). -/
 def agreementController (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : PersonLevel) : Controller :=
+    (ea ia : Person) : Controller :=
   if eaAgrees geom probe ea ia then .ea else .ia
 
 /-- The person value that the core agreement slot realizes. -/
 def agreementValue (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : PersonLevel) : PersonLevel :=
+    (ea ia : Person) : Person :=
   match agreementController geom probe ea ia with
   | .ea => ea
   | .ia => ia
 
 /-- Convenience: controller using an `AgreementSystem`. -/
 def AgreementSystem.controller (sys : AgreementSystem)
-    (ea ia : PersonLevel) : Controller :=
+    (ea ia : Person) : Controller :=
   agreementController sys.geometry sys.probe ea ia
 
 /-- Convenience: agreement value using an `AgreementSystem`. -/
 def AgreementSystem.value (sys : AgreementSystem)
-    (ea ia : PersonLevel) : PersonLevel :=
+    (ea ia : Person) : Person :=
   agreementValue sys.geometry sys.probe ea ia
 
 -- ============================================================================
@@ -257,7 +256,7 @@ def AgreementSystem.value (sys : AgreementSystem)
 
     Returns `(cycleI, cycleII)` — the segments deactivated on each cycle. -/
 def cycleSegments (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : PersonLevel) : ProbeArticulation × ProbeArticulation :=
+    (ea ia : Person) : ProbeArticulation × ProbeArticulation :=
   let iaSpec := personSpec geom ia
   let cycleI := probe.filter (fun s => iaSpec.contains s)
   let residue := activeResidue probe iaSpec
@@ -271,7 +270,7 @@ def cycleSegments (geom : Geometry) (probe : ProbeArticulation)
     one segment. This is the configuration that creates second-cycle
     morphological effects in languages like Georgian and Nishnaabemwin. -/
 def hasSecondCycleEffect (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : PersonLevel) : Bool :=
+    (ea ia : Person) : Bool :=
   let (c1, c2) := cycleSegments geom probe ea ia
   !c1.isEmpty && !c2.isEmpty
 
@@ -286,17 +285,17 @@ def hasSecondCycleEffect (geom : Geometry) (probe : ProbeArticulation)
     Inverse contexts trigger PLC violations on the EA's π-features,
     requiring repair strategies (added probe or R-Case). -/
 def isInverseContext (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : PersonLevel) : Bool :=
+    (ea ia : Person) : Bool :=
   !eaAgrees geom probe ea ia
 
 /-- Direct context: the EA Agrees with at least one residue segment. -/
 def isDirectContext (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : PersonLevel) : Bool :=
+    (ea ia : Person) : Bool :=
   eaAgrees geom probe ea ia
 
 /-- Convenience: inverse using an `AgreementSystem`. -/
 def AgreementSystem.isInverse (sys : AgreementSystem)
-    (ea ia : PersonLevel) : Bool :=
+    (ea ia : Person) : Bool :=
   isInverseContext sys.geometry sys.probe ea ia
 
 -- ============================================================================
@@ -316,14 +315,14 @@ def AgreementSystem.isInverse (sys : AgreementSystem)
     Returns `true` if the EA is person-licensed (its π-features were
     checked by the core probe on cycle II). -/
 def eaIsLicensed (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : PersonLevel) : Bool :=
+    (ea ia : Person) : Bool :=
   eaAgrees geom probe ea ia
 
 /-- PLC violation: EA is NOT person-licensed. Exactly characterizes
     inverse contexts — this is the paper's key insight connecting
     syntactic derivation to morphological repair. -/
 theorem plc_violation_iff_inverse (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : PersonLevel) :
+    (ea ia : Person) :
     eaIsLicensed geom probe ea ia = false ↔
     isInverseContext geom probe ea ia = true := by
   simp [eaIsLicensed, isInverseContext]
@@ -347,7 +346,7 @@ inductive RepairStrategy where
 /-- Does a given EA→IA combination require repair under this system?
 
     Repair is needed iff the context is inverse. -/
-def needsRepair (sys : AgreementSystem) (ea ia : PersonLevel) : Bool :=
+def needsRepair (sys : AgreementSystem) (ea ia : Person) : Bool :=
   sys.isInverse ea ia
 
 -- ============================================================================
@@ -356,7 +355,7 @@ def needsRepair (sys : AgreementSystem) (ea ia : PersonLevel) : Bool :=
 
 /-- In the standard geometry, a person value has [participant] as a segment
     iff `DecomposedPerson.hasParticipant` is true. -/
-theorem std_participant_matches_decomposed (p : PersonLevel) :
+theorem std_participant_matches_decomposed (p : Person) :
     (personSpec .standard p).contains .participant =
     (decomposePerson p).hasParticipant := by
   cases p <;> decide
@@ -388,17 +387,17 @@ theorem std_second_entails_third :
 -- ============================================================================
 
 /-- Flat probe: IA always fully checks the probe, regardless of person. -/
-theorem flat_no_residue (geom : Geometry) (ia : PersonLevel) :
+theorem flat_no_residue (geom : Geometry) (ia : Person) :
     activeResidue flatProbe (personSpec geom ia) = [] := by
   cases ia <;> cases geom <;> decide
 
 /-- Flat probe: IA always controls — no PH effects. -/
-theorem flat_ia_controls (geom : Geometry) (ea ia : PersonLevel) :
+theorem flat_ia_controls (geom : Geometry) (ea ia : Person) :
     agreementController geom flatProbe ea ia = .ia := by
   cases ea <;> cases ia <;> cases geom <;> decide
 
 /-- Flat probe: all contexts are inverse (no EA agreement). -/
-theorem flat_all_inverse (geom : Geometry) (ea ia : PersonLevel) :
+theorem flat_all_inverse (geom : Geometry) (ea ia : Person) :
     isInverseContext geom flatProbe ea ia = true := by
   cases ea <;> cases ia <;> cases geom <;> decide
 
@@ -410,7 +409,7 @@ section PartialProbe
 
 /-- Partial probe: same behavior in both geometries, since [participant]
     is geometry-independent. -/
-theorem partial_geometry_invariant (ea ia : PersonLevel) :
+theorem partial_geometry_invariant (ea ia : Person) :
     agreementValue .standard partialProbe ea ia =
     agreementValue .addressee partialProbe ea ia := by
   cases ea <;> cases ia <;> decide
@@ -432,15 +431,15 @@ theorem basque_2_3 : basque.value .second .third = .second := by decide
 theorem basque_3_3 : basque.value .third .third = .third := by decide
 
 /-- Basque: SAP IA → inverse context (agreement displacement to IA). -/
-theorem basque_sap_ia_inverse (ea : PersonLevel) :
+theorem basque_sap_ia_inverse (ea : Person) :
     basque.isInverse ea .first = true ∧
     basque.isInverse ea .second = true := by
   constructor <;> cases ea <;> decide
 
 /-- Basque: 3P IA + SAP EA → direct context (EA controls). -/
-theorem basque_3p_ia_direct (ea : PersonLevel) (h : ea ≠ .third) :
+theorem basque_3p_ia_direct (ea : Person) (h : ea.IsSAP) :
     isDirectContext .standard partialProbe ea .third = true := by
-  cases ea <;> simp_all <;> decide
+  cases ea <;> simp_all [Person.IsSAP] <;> decide
 
 /-- Basque: 3P IA + 3P EA → inverse (neither fully checks). -/
 theorem basque_3_3_inverse : basque.isInverse .third .third = true := by
@@ -471,7 +470,7 @@ theorem nish_2_3 : nishnaabemwin.value .second .third = .second := by decide
 theorem nish_3_3 : nishnaabemwin.value .third .third = .third := by decide
 
 /-- Nishnaabemwin: 2P IA → always inverse (2nd is most specified). -/
-theorem nish_2p_ia_inverse (ea : PersonLevel) :
+theorem nish_2p_ia_inverse (ea : Person) :
     nishnaabemwin.isInverse ea .second = true := by
   cases ea <;> decide
 
@@ -503,7 +502,7 @@ theorem georgian_1_3_second_cycle :
   decide
 
 /-- Georgian: when IA is SAP, no second cycle (IA fully checks). -/
-theorem georgian_no_second_cycle_sap_ia (ea : PersonLevel) :
+theorem georgian_no_second_cycle_sap_ia (ea : Person) :
     hasSecondCycleEffect .standard partialProbe ea .first = false ∧
     hasSecondCycleEffect .standard partialProbe ea .second = false := by
   constructor <;> cases ea <;> decide
@@ -532,7 +531,7 @@ theorem nish_2_1_cycle_segments :
     against personSpec(p), applying the same filter again removes nothing,
     so `eaAgrees` returns false. -/
 theorem same_person_ia_controls (geom : Geometry) (probe : ProbeArticulation)
-    (p : PersonLevel) :
+    (p : Person) :
     agreementController geom probe p p = .ia := by
   simp only [agreementController]
   -- eaAgrees returns Bool; show it's false so `if` takes else branch
@@ -570,7 +569,7 @@ theorem most_specified_controls_vs_third_addr :
 /-- The direct/inverse split exhaustively partitions the paradigm:
     every EA→IA combination is either direct or inverse, never both. -/
 theorem direct_inverse_exhaustive (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : PersonLevel) :
+    (ea ia : Person) :
     (isDirectContext geom probe ea ia = true) ≠
     (isInverseContext geom probe ea ia = true) := by
   simp only [isDirectContext, isInverseContext]
@@ -597,7 +596,7 @@ theorem direct_inverse_exhaustive (geom : Geometry) (probe : ProbeArticulation)
 
     So `pIsIndexed` ↔ the IA controls (the agreement slot shows the
     object's features) ↔ inverse context. -/
-theorem partial_probe_sap_ia_is_inverse (ea : PersonLevel) :
+theorem partial_probe_sap_ia_is_inverse (ea : Person) :
     isInverseContext .standard partialProbe ea .first = true ∧
     isInverseContext .standard partialProbe ea .second = true := by
   constructor <;> cases ea <;> decide
@@ -619,10 +618,10 @@ theorem partial_probe_3p_ia_sap_ea_is_direct :
     produce direct contexts (when EA is SAP).
 
     This theorem proves the key direction: SAP IA → inverse (indexed). -/
-theorem sap_ia_indexed_via_inverse (p : PersonLevel) (h : p ≠ .third) :
-    ∀ ea : PersonLevel,
+theorem sap_ia_indexed_via_inverse (p : Person) (h : p.IsSAP) :
+    ∀ ea : Person,
       isInverseContext .standard partialProbe ea p = true := by
-  intro ea; cases p <;> cases ea <;> simp_all <;> decide
+  intro ea; cases p <;> cases ea <;> simp_all [Person.IsSAP] <;> decide
 
 -- ============================================================================
 -- § 18: Inverse Context Counts
@@ -630,7 +629,7 @@ theorem sap_ia_indexed_via_inverse (p : PersonLevel) (h : p ≠ .third) :
 
 /-- Count inverse contexts in a 3×3 paradigm. -/
 def inverseCount (sys : AgreementSystem) : Nat :=
-  let ps : List PersonLevel := [.first, .second, .third]
+  let ps : List Person := [.first, .second, .third]
   (ps.flatMap (λ ea => ps.filter (λ ia => sys.isInverse ea ia))).length
 
 /-- Swahili (flat): all 9 cells are inverse (no PH sensitivity). -/

--- a/Linglib/Syntax/Minimalist/Features.lean
+++ b/Linglib/Syntax/Minimalist/Features.lean
@@ -25,18 +25,18 @@ Interpretability is determined by the combination of feature type and
 host category: person on N is +Interpretable, person on T is
 –Interpretable. `isInterpretableOn` encodes this mapping.
 
-## Design Decision: `PersonLevel` replaces `Nat`
+## Design Decision: `Person` replaces `Nat`
 
-`PhiFeature.person` uses `Features.Prominence.PersonLevel` (`.first |.second
+`PhiFeature.person` uses `Person` (`.first |.second
 |.third`) rather than a raw `Nat`. This eliminates the possibility of
 meaningless person values (e.g., `person 47`) and grounds the feature
 inventory in the same canonical type used across the library:
 
-- `Features.Prominence.PersonLevel` — framework-agnostic person hierarchy
+- `Person` — framework-agnostic person hierarchy
 - `Phi.Geometry.DecomposedPerson` — [preminger-2014]'s [±participant,
-  ±author] decomposition, now mapping from `PersonLevel`
+  ±author] decomposition, now mapping from `Person`
 - `DifferentialIndexing.IndexingPersonLevel` — [just-2024]'s SAP/3rd
-  binary split, bridged to `PersonLevel`
+  binary split, bridged to `Person`
 
 For unvalued (probe) features, the value is irrelevant —
 `FeatureVal.sameType` matches any `.person _` against any `.person _`
@@ -57,7 +57,7 @@ open Features.Prominence
 
 /-- Phi-features (agreement features). -/
 inductive PhiFeature where
-  | person : PersonLevel → PhiFeature
+  | person : Person → PhiFeature
   | number : UD.Number → PhiFeature      -- grammatical number (UD.Number)
   | gender : Nat → PhiFeature        -- language-specific encoding
   deriving Repr, DecidableEq

--- a/Linglib/Syntax/Minimalist/PConstraint.lean
+++ b/Linglib/Syntax/Minimalist/PConstraint.lean
@@ -46,7 +46,6 @@ its `Decidable` instance directly; for proofs about specific cells, prefer
 
 namespace Minimalist.PConstraint
 
-open Features.Prominence (PersonLevel)
 open Minimalist (DecomposedPerson decomposePerson)
 
 -- ============================================================================
@@ -138,31 +137,31 @@ def pg3Grammar : PCCGrammar := { prominence := .author }
 
 /-- A DP is *inherently* [+PROXIMATE] iff it is a SAP ([pancheva-zubizarreta-2018]
     (11)). Third person can only be [+PROXIMATE] contextually. -/
-def IsInherentlyProximate (p : PersonLevel) : Prop :=
+def IsInherentlyProximate (p : Person) : Prop :=
   (decomposePerson p).hasProximate = true
 
-instance (p : PersonLevel) : Decidable (IsInherentlyProximate p) :=
+instance (p : Person) : Decidable (IsInherentlyProximate p) :=
   inferInstanceAs (Decidable (_ = true))
 
 /-- A DP inherently satisfies a P-Prominence setting. -/
-def SatisfiesProminence (s : PProminence) (p : PersonLevel) : Prop :=
+def SatisfiesProminence (s : PProminence) (p : Person) : Prop :=
   match s with
   | .proximate   => (decomposePerson p).hasProximate = true
   | .participant => (decomposePerson p).hasParticipant = true
   | .author      => (decomposePerson p).hasAuthor = true
 
-instance (s : PProminence) (p : PersonLevel) :
+instance (s : PProminence) (p : Person) :
     Decidable (SatisfiesProminence s p) := by
   cases s <;> exact inferInstanceAs (Decidable (_ = true))
 
 /-- **Clause (12a) — Domain.** When the domain is restricted and no [+author]
     DP is present, the P-Constraint does not apply. -/
-def DomainExempt (g : PCCGrammar) (io do_ : PersonLevel) : Prop :=
+def DomainExempt (g : PCCGrammar) (io do_ : Person) : Prop :=
   g.restrictedDomain = true ∧
     (decomposePerson io).hasAuthor = false ∧
     (decomposePerson do_).hasAuthor = false
 
-instance (g : PCCGrammar) (io do_ : PersonLevel) :
+instance (g : PCCGrammar) (io do_ : Person) :
     Decidable (DomainExempt g io do_) :=
   inferInstanceAs (Decidable (_ ∧ _ ∧ _))
 
@@ -170,32 +169,32 @@ instance (g : PCCGrammar) (io do_ : PersonLevel) :
     requirement, either inherently or — for `.proximate` only — by
     contextual marking when paired with another non-proximate 3P
     ([pancheva-zubizarreta-2018] §4.1.4). -/
-def IOSatisfiesProminence (g : PCCGrammar) (io do_ : PersonLevel) : Prop :=
+def IOSatisfiesProminence (g : PCCGrammar) (io do_ : Person) : Prop :=
   SatisfiesProminence g.prominence io ∨
     (g.prominence = .proximate ∧
      ¬ SatisfiesProminence g.prominence io ∧
      ¬ SatisfiesProminence g.prominence do_)
 
-instance (g : PCCGrammar) (io do_ : PersonLevel) :
+instance (g : PCCGrammar) (io do_ : Person) :
     Decidable (IOSatisfiesProminence g io do_) :=
   inferInstanceAs (Decidable (_ ∨ _))
 
 /-- **Clause (12c) — P-Uniqueness.** The DO does not also inherently satisfy
     the prominence requirement. (Contextual proximate-marking on the IO
     does not propagate to the DO.) -/
-def UniquenessSatisfied (g : PCCGrammar) (do_ : PersonLevel) : Prop :=
+def UniquenessSatisfied (g : PCCGrammar) (do_ : Person) : Prop :=
   ¬ SatisfiesProminence g.prominence do_
 
-instance (g : PCCGrammar) (do_ : PersonLevel) :
+instance (g : PCCGrammar) (do_ : Person) :
     Decidable (UniquenessSatisfied g do_) :=
   inferInstanceAs (Decidable (¬ _))
 
 /-- **Clause (12d) — P-Primacy.** When P-Uniqueness would block, a [+author]
     IO rescues. -/
-def PrimacyRescues (g : PCCGrammar) (io : PersonLevel) : Prop :=
+def PrimacyRescues (g : PCCGrammar) (io : Person) : Prop :=
   g.primacy = true ∧ (decomposePerson io).hasAuthor = true
 
-instance (g : PCCGrammar) (io : PersonLevel) : Decidable (PrimacyRescues g io) :=
+instance (g : PCCGrammar) (io : Person) : Decidable (PrimacyRescues g io) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 -- ============================================================================
@@ -208,14 +207,14 @@ instance (g : PCCGrammar) (io : PersonLevel) : Decidable (PrimacyRescues g io) :
     - Domain-exempt configurations are vacuously licit.
     - Otherwise, the IO must satisfy P-Prominence; and either
       P-Uniqueness is inactive, or it is satisfied, or P-Primacy rescues. -/
-def IsLicit (g : PCCGrammar) (io do_ : PersonLevel) : Prop :=
+def IsLicit (g : PCCGrammar) (io do_ : Person) : Prop :=
   DomainExempt g io do_ ∨
     (IOSatisfiesProminence g io do_ ∧
       (g.uniqueness = false ∨
        UniquenessSatisfied g do_ ∨
        PrimacyRescues g io))
 
-instance (g : PCCGrammar) (io do_ : PersonLevel) :
+instance (g : PCCGrammar) (io do_ : Person) :
     Decidable (IsLicit g io do_) :=
   inferInstanceAs (Decidable (_ ∨ _))
 
@@ -223,16 +222,23 @@ instance (g : PCCGrammar) (io do_ : PersonLevel) :
 -- § 6: Enumeration via `Finset`
 -- ============================================================================
 
-/-- The set of person combinations the grammar predicts to be licit. -/
-def licitFinset (g : PCCGrammar) : Finset (PersonLevel × PersonLevel) :=
-  Finset.univ.filter fun p => IsLicit g p.1 p.2
+/-- The prediction domain: PCC varieties are stated over 1/2/3 clitic
+    combinations (the tripartition; clusivity-marked and impersonal
+    clitics are outside the paper's typology). -/
+def cliticPairs : Finset (Person × Person) :=
+  ({.first, .second, .third} ×ˢ {.first, .second, .third})
+
+/-- The set of person combinations the grammar predicts to be licit
+    (within the paper's domain). -/
+def licitFinset (g : PCCGrammar) : Finset (Person × Person) :=
+  cliticPairs.filter fun p => IsLicit g p.1 p.2
 
 /-- Cardinality of the licit set (out of 9 total combinations). -/
 def licitCount (g : PCCGrammar) : ℕ := (licitFinset g).card
 
 @[simp]
-theorem mem_licitFinset (g : PCCGrammar) (p : PersonLevel × PersonLevel) :
-    p ∈ licitFinset g ↔ IsLicit g p.1 p.2 := by
+theorem mem_licitFinset (g : PCCGrammar) (p : Person × Person) :
+    p ∈ licitFinset g ↔ p ∈ cliticPairs ∧ IsLicit g p.1 p.2 := by
   simp [licitFinset]
 
 -- ============================================================================
@@ -264,16 +270,17 @@ instance (g₁ g₂ : PCCGrammar) : Decidable (g₁ ≤ g₂) :=
 
 /-- Entailment in unfolded form: every licit cell of `g₁` is licit in `g₂`. -/
 theorem le_iff_isLicit_imp (g₁ g₂ : PCCGrammar) :
-    g₁ ≤ g₂ ↔ ∀ io do_ : PersonLevel, IsLicit g₁ io do_ → IsLicit g₂ io do_ := by
+    g₁ ≤ g₂ ↔ ∀ io do_ : Person, (io, do_) ∈ cliticPairs →
+      IsLicit g₁ io do_ → IsLicit g₂ io do_ := by
   constructor
-  · intro h io do_ hlic
-    have : (io, do_) ∈ licitFinset g₁ := by simp [hlic]
-    have := h this
-    simpa using this
+  · intro h io do_ hmem hlic
+    have h1 : (io, do_) ∈ licitFinset g₁ :=
+      (mem_licitFinset _ _).mpr ⟨hmem, hlic⟩
+    exact ((mem_licitFinset _ _).mp (h h1)).2
   · intro h p hp
     rcases p with ⟨io, do_⟩
-    simp at hp ⊢
-    exact h io do_ hp
+    rw [mem_licitFinset] at hp ⊢
+    exact ⟨hp.1, h io do_ hp.1 hp.2⟩
 
 -- ============================================================================
 -- § 9: Semantic Grounding — the P-Constraint over Appl Domains
@@ -285,11 +292,11 @@ theorem le_iff_isLicit_imp (g₁ g₂ : PCCGrammar) :
     center; in the unmarked case this is the IO at the phase edge. -/
 structure ApplDomain where
   /-- The indirect-object argument introduced by Appl. -/
-  io : PersonLevel
+  io : Person
   /-- The direct-object argument inside VP. -/
-  do_ : PersonLevel
+  do_ : Person
   /-- The DP selected as point-of-view center within the phase. -/
-  povCenter : PersonLevel
+  povCenter : Person
   deriving DecidableEq, Repr
 
 /-- The IO is the canonical POV-center candidate ([pancheva-zubizarreta-2018]
@@ -322,7 +329,7 @@ instance (g : PCCGrammar) (a : ApplDomain) :
     which IO-as-POV-center is consistent with the interpretable person
     feature on Appl. -/
 theorem isLicit_iff_exists_appl_satisfying
-    (g : PCCGrammar) (io do_ : PersonLevel) :
+    (g : PCCGrammar) (io do_ : Person) :
     IsLicit g io do_ ↔
       ∃ a : ApplDomain, a.io = io ∧ a.do_ = do_ ∧ PConstraintSatisfied g a := by
   constructor

--- a/Linglib/Syntax/Minimalist/Phi/Geometry.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Geometry.lean
@@ -56,7 +56,7 @@ specific to [pancheva-zubizarreta-2018]'s P-Constraint.
 
 ## Person Type
 
-`decomposePerson` takes `Features.Prominence.PersonLevel` (`.first |
+`decomposePerson` takes `Person` (`.first |
 .second |.third`) — the canonical person type shared across the
 library — rather than a raw `Nat`. This eliminates meaningless
 person values and grounds the decomposition in the same type used
@@ -128,10 +128,12 @@ def DecomposedPerson.wellFormed (dp : DecomposedPerson) : Bool :=
 
     3rd person is [-proximate] by default; contextual [+proximate]
     marking is handled by the P-Constraint evaluation. -/
-def decomposePerson : PersonLevel → DecomposedPerson
-  | .first  => { hasParticipant := true,  hasAuthor := true,  hasProximate := true }
+def decomposePerson : Person → DecomposedPerson
+  | .first | .firstInclusive | .firstExclusive =>
+      { hasParticipant := true,  hasAuthor := true,  hasProximate := true }
   | .second => { hasParticipant := true,  hasAuthor := false, hasProximate := true }
-  | .third  => { hasParticipant := false, hasAuthor := false, hasProximate := false }
+  | .third | .zero =>
+      { hasParticipant := false, hasAuthor := false, hasProximate := false }
 
 -- ============================================================================
 -- § 3: Probe Targets
@@ -156,7 +158,7 @@ inductive ProbeTarget where
 
     A DP with person value `person` and number `isPlural` is visible
     to the probe iff it bears the probe's target feature. -/
-def probeVisible (target : ProbeTarget) (person : PersonLevel) (isPlural : Bool) : Bool :=
+def probeVisible (target : ProbeTarget) (person : Person) (isPlural : Bool) : Bool :=
   match target with
   | .participant => (decomposePerson person).hasParticipant
   | .plural => isPlural
@@ -181,7 +183,7 @@ def probeVisible (target : ProbeTarget) (person : PersonLevel) (isPlural : Bool)
     See module docstring for why this is a convenience encoding,
     not an endorsement of the salience-scale analyses
     [preminger-2014] Ch. 7 argues against. -/
-def probeResolutionRank (person : PersonLevel) (isPlural : Bool) : Nat :=
+def probeResolutionRank (person : Person) (isPlural : Bool) : Nat :=
   if (decomposePerson person).hasParticipant then 2
   else if isPlural then 1
   else 0
@@ -191,16 +193,18 @@ def probeResolutionRank (person : PersonLevel) (isPlural : Bool) : Nat :=
 -- ============================================================================
 
 /-- All person values yield well-formed decompositions. -/
-theorem all_decompositions_wellFormed (p : PersonLevel) :
+theorem all_decompositions_wellFormed (p : Person) :
     (decomposePerson p).wellFormed = true := by
   cases p <;> rfl
 
 /-- `decomposePerson` is consistent with the framework-neutral
-    `PersonLevel.toFeatures`: the [±participant, ±author] core of
+    `Person.toFeatures`: the [±participant, ±author] core of
     the Minimalist decomposition agrees with Core Person.Features. -/
-theorem decomposePerson_toFeatures_eq (p : PersonLevel) :
-    (decomposePerson p).toFeatures = p.toFeatures := by
-  cases p <;> rfl
+theorem decomposePerson_toFeatures_eq (p : Person) :
+    ∀ f, p.toFeatures = some f → (decomposePerson p).toFeatures = f := by
+  cases p <;> intro f hf <;>
+    simp only [Person.toFeatures, Option.some.injEq, reduceCtorEq] at hf <;>
+    subst hf <;> rfl
 
 /-- Rank is monotone in the probe hierarchy: any DP visible to π⁰
     (rank 2) outranks any DP visible only to #⁰ (rank 1), which

--- a/Linglib/Syntax/Pronoun/Basic.lean
+++ b/Linglib/Syntax/Pronoun/Basic.lean
@@ -169,7 +169,7 @@ structure PersonalPronoun extends Pronoun where
       resolved agreement). For ordinary pronouns, leave as `none` —
       referential person coincides with formal person.
       [adamson-zompi-2025] -/
-  referentialPerson : Option Features.Prominence.PersonLevel := none
+  referentialPerson : Option Person := none
   deriving Repr, BEq, DecidableEq
 
 namespace Pronoun

--- a/Linglib/Syntax/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Pronoun/Capabilities.lean
@@ -151,7 +151,7 @@ class Deictic (α : Type*) [Proform α] where
   /-- Register level (T/V, honorific tiers). -/
   register : α → Features.Register.Level
   /-- Referential person when it diverges from formal/agreement person; `none` otherwise. -/
-  referentialPerson : α → Option Features.Prominence.PersonLevel
+  referentialPerson : α → Option Person
 
 instance : Deictic PersonalPronoun :=
   ⟨PersonalPronoun.register, PersonalPronoun.referentialPerson⟩


### PR DESCRIPTION
Phase 3b of the Person API: `Features.Prominence.PersonLevel` is deleted — its role is `Person.prominence` (rank 2/1/0 over the canonical inventory; clusivity-marked firsts rank with first, the impersonal with third, documented as a linglib convention) plus the existing `Person.IsSAP`, with `prominence_pos_iff_sap` tying them together. The `Person/Basic ← Prominence` import flips; the bridge projections die.

Swept 32 files. The substantive per-site decisions, each documented at the site:
- `personSpec`/`decomposePerson`/paradigm matches extend over the full inventory (clusivity cells pattern with first; `zero` as `[−participant]`).
- **Noyer resolution derived, not stipulated**: `CoordinateResolution.personResolve` is now `Person.resolve` coarsened to the tripartition — the privative feature system cannot represent the clusivity the canonical inclusive output carries.
- PCC characterizations restated featurally: "3rd person" = `[−participant]` = non-SAP, so Deal 2024's and Adamson–Zompì's grammars stay true over the extended inventory (the syntactic `= .third` encodings were artifacts that went false at `zero`); P&Z's `licitFinset` enumerates the paper's tripartition clitic domain explicitly.
- SAP-intent hypotheses (`≠ .third`) restated as `IsSAP`; off-diagonal PCC hypotheses as featural distinctness.
- `IsSAP`/`MarksClusivity`/`IncludesSpeaker` decidability instances rebuilt match-based so `rfl`/`decide` reduce definitionally.

`IndexingPersonLevel` (the binary [±participant] indexing scale) is a distinct documented type and stays.