### PR TITLE
refactor(Features): root-Number pronoun field, retype carriers

### DIFF
--- a/Linglib/Features/Person/Capabilities.lean
+++ b/Linglib/Features/Person/Capabilities.lean
@@ -50,3 +50,31 @@ theorem compatible_of_none {a : α} {b : β} (h : personOf a = none) :
   exact absurd hp (by simp)
 
 end HasPerson
+
+/-- φ-compatibility entails person compatibility: the `HasPerson` mixin
+    never diverges from the unification-based agreement engine
+    (`UD.MorphFeatures.compatible`) — the person analogue of
+    `UD.MorphFeatures.compatible_hasNumber`. -/
+theorem UD.MorphFeatures.compatible_hasPerson {f1 f2 : UD.MorphFeatures}
+    (h : f1.compatible f2 = true) :
+    HasPerson.Compatible f1 f2 := by
+  intro pa pb ha hb
+  have hp : (f1.person.isNone || f2.person.isNone || f1.person == f2.person)
+      = true := by
+    unfold UD.MorphFeatures.compatible at h
+    simp only [Bool.and_eq_true] at h
+    tauto
+  simp only [HasPerson.personOf] at ha hb
+  rcases h1 : f1.person with _ | u1
+  · rw [h1] at ha
+    exact absurd ha (by simp)
+  · rcases h2 : f2.person with _ | u2
+    · rw [h2] at hb
+      exact absurd hb (by simp)
+    · rw [h1] at ha
+      rw [h2] at hb
+      rw [h1, h2] at hp
+      simp only [Option.isNone_some, Bool.false_or, beq_iff_eq,
+        Option.some.injEq] at hp
+      simp only [Option.map_some, Option.some.injEq] at ha hb
+      rw [← ha, ← hb, hp]

--- a/Linglib/Features/Person/Decomposition.lean
+++ b/Linglib/Features/Person/Decomposition.lean
@@ -2,6 +2,7 @@ import Linglib.Data.UD.Basic
 import Linglib.Features.Person.Basic
 import Linglib.Features.Prominence
 import Linglib.Features.ContainmentPair
+import Linglib.Features.Number.Basic
 
 /-!
 # Person
@@ -278,21 +279,26 @@ theorem ud_conflates_incl_excl :
     Category.toUDPersonNumber .augIncl =
     Category.toUDPersonNumber .excl := rfl
 
-/-- The [cysouw-2009] category a (canonical person, UD number) pair
-    realizes. Clusivity rides on the person value, so no third argument is
-    needed: singulars ignore clusivity, first-person non-singulars without
-    it (plain `first`) are a syncretism (`none`), and second/third
-    non-singulars map to the group categories. -/
-def Category.ofPersonNumber : Person → UD.Number → Option Category
-  | .first, .Sing | .firstInclusive, .Sing | .firstExclusive, .Sing =>
-      some .s1
-  | .second, .Sing => some .s2
-  | .third, .Sing => some .s3
-  | .firstInclusive, .Dual => some .minIncl
-  | .firstInclusive, .Plur => some .augIncl
-  | .firstExclusive, .Dual | .firstExclusive, .Plur => some .excl
-  | .second, .Dual | .second, .Plur => some .secondGrp
-  | .third, .Dual | .third, .Plur => some .thirdGrp
+/-- The [cysouw-2009] category a (person, number) coordinate pair
+    realizes, over the canonical inventories. Clusivity rides on the
+    person value; the minimal/augmented coordinates give the
+    minimal/augmented inclusives directly (Tagalog *kata* =
+    `(firstInclusive, minimal)` ↦ `minIncl`, the junction coordinates of
+    `Studies/Cysouw2009.lean`); the Maori-type dual alignment maps there
+    too; plain `first` non-singulars are a syncretism (`none`). -/
+def Category.ofPersonNumber : Person → Number → Option Category
+  | .first, .singular | .firstInclusive, .singular
+  | .firstExclusive, .singular => some .s1
+  | .second, .singular => some .s2
+  | .third, .singular => some .s3
+  | .firstInclusive, .minimal | .firstInclusive, .dual => some .minIncl
+  | .firstInclusive, .augmented | .firstInclusive, .plural
+  | .firstInclusive, .general => some .augIncl
+  | .firstExclusive, .dual | .firstExclusive, .plural
+  | .firstExclusive, .general | .firstExclusive, .augmented => some .excl
+  | .second, .dual | .second, .plural | .second, .general =>
+      some .secondGrp
+  | .third, .dual | .third, .plural | .third, .general => some .thirdGrp
   | _, _ => none
 
 /-- The person coordinate of each referential category — the projection
@@ -323,15 +329,18 @@ theorem person_separates_clusivity :
     Category.augIncl.person ≠ Category.excl.person := by decide
 
 /-- `ofPersonNumber` inverts the person projection: every category is
-    recovered from its own coordinates. -/
+    recovered from its coordinates at some number value. -/
 theorem ofPersonNumber_person (c : Category) :
-    ∀ pn, c.toUDPersonNumber = some pn →
-      Category.ofPersonNumber c.person pn.2 = some c := by
-  cases c <;>
-    (intro pn hpn
-     simp only [Category.toUDPersonNumber, Option.some.injEq] at hpn
-     subst hpn
-     rfl)
+    ∃ n, Category.ofPersonNumber c.person n = some c := by
+  cases c
+  · exact ⟨.singular, rfl⟩
+  · exact ⟨.singular, rfl⟩
+  · exact ⟨.singular, rfl⟩
+  · exact ⟨.minimal, rfl⟩
+  · exact ⟨.augmented, rfl⟩
+  · exact ⟨.general, rfl⟩
+  · exact ⟨.general, rfl⟩
+  · exact ⟨.general, rfl⟩
 
 -- ============================================================================
 -- § 8: Category ↔ Features Bridge

--- a/Linglib/Fragments/Basque/Pronouns.lean
+++ b/Linglib/Fragments/Basque/Pronouns.lean
@@ -21,11 +21,11 @@ open Features.Register (Level)
 
 /-- *ni* — 1sg. -/
 def ni : PersonalPronoun :=
-  { form := "ni", person := some .first, number := some .Sing }
+  { form := "ni", person := some .first, number := some .singular }
 
 /-- *gu* — 1pl. -/
 def gu : PersonalPronoun :=
-  { form := "gu", person := some .first, number := some .Plur }
+  { form := "gu", person := some .first, number := some .plural }
 
 -- ============================================================================
 -- Second Person (T/V)
@@ -33,15 +33,15 @@ def gu : PersonalPronoun :=
 
 /-- *hi* — 2sg familiar (T form). -/
 def hi : PersonalPronoun :=
-  { form := "hi", person := some .second, number := some .Sing, register := .informal }
+  { form := "hi", person := some .second, number := some .singular, register := .informal }
 
 /-- *zu* — 2sg formal (V form). -/
 def zu : PersonalPronoun :=
-  { form := "zu", person := some .second, number := some .Sing, register := .formal }
+  { form := "zu", person := some .second, number := some .singular, register := .formal }
 
 /-- *zuek* — 2pl. -/
 def zuek : PersonalPronoun :=
-  { form := "zuek", person := some .second, number := some .Plur }
+  { form := "zuek", person := some .second, number := some .plural }
 
 -- ============================================================================
 -- Third Person
@@ -49,11 +49,11 @@ def zuek : PersonalPronoun :=
 
 /-- *hura* — 3sg. -/
 def hura : PersonalPronoun :=
-  { form := "hura", person := some .third, number := some .Sing }
+  { form := "hura", person := some .third, number := some .singular }
 
 /-- *haiek* — 3pl. -/
 def haiek : PersonalPronoun :=
-  { form := "haiek", person := some .third, number := some .Plur }
+  { form := "haiek", person := some .third, number := some .plural }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -107,8 +107,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .Sing) = true ∧
-    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .singular) = true ∧
+    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/English/Pronouns.lean
+++ b/Linglib/Fragments/English/Pronouns.lean
@@ -39,29 +39,29 @@ open Features (SurfaceGender)
 /-! ### Personal pronouns (`PersonalPronoun`) -/
 
 -- First person (no gender feature). `bindingClass := some .pronoun` is the PersonalPronoun default.
-def i : PersonalPronoun := { form := "I", person := some .first, number := some .Sing, case_ := some .nom }
-def me : PersonalPronoun := { form := "me", person := some .first, number := some .Sing, case_ := some .acc }
-def we : PersonalPronoun := { form := "we", person := some .first, number := some .Plur, case_ := some .nom }
-def us : PersonalPronoun := { form := "us", person := some .first, number := some .Plur, case_ := some .acc }
+def i : PersonalPronoun := { form := "I", person := some .first, number := some .singular, case_ := some .nom }
+def me : PersonalPronoun := { form := "me", person := some .first, number := some .singular, case_ := some .acc }
+def we : PersonalPronoun := { form := "we", person := some .first, number := some .plural, case_ := some .nom }
+def us : PersonalPronoun := { form := "us", person := some .first, number := some .plural, case_ := some .acc }
 
 -- Second person (no gender feature)
-def you : PersonalPronoun := { form := "you", person := some .second, number := some .Sing }
-def you_pl : PersonalPronoun := { form := "you", person := some .second, number := some .Plur }
+def you : PersonalPronoun := { form := "you", person := some .second, number := some .singular }
+def you_pl : PersonalPronoun := { form := "you", person := some .second, number := some .plural }
 
 -- Third person
-def he : PersonalPronoun := { form := "he", person := some .third, number := some .Sing, case_ := some .nom, gender := some .masculine }
-def him : PersonalPronoun := { form := "him", person := some .third, number := some .Sing, case_ := some .acc, gender := some .masculine }
-def she : PersonalPronoun := { form := "she", person := some .third, number := some .Sing, case_ := some .nom, gender := some .feminine }
-def her : PersonalPronoun := { form := "her", person := some .third, number := some .Sing, case_ := some .acc, gender := some .feminine }
-def it : PersonalPronoun := { form := "it", person := some .third, number := some .Sing, gender := some .neuter }
-def they : PersonalPronoun := { form := "they", person := some .third, number := some .Plur, case_ := some .nom }
-def them : PersonalPronoun := { form := "them", person := some .third, number := some .Plur, case_ := some .acc }
+def he : PersonalPronoun := { form := "he", person := some .third, number := some .singular, case_ := some .nom, gender := some .masculine }
+def him : PersonalPronoun := { form := "him", person := some .third, number := some .singular, case_ := some .acc, gender := some .masculine }
+def she : PersonalPronoun := { form := "she", person := some .third, number := some .singular, case_ := some .nom, gender := some .feminine }
+def her : PersonalPronoun := { form := "her", person := some .third, number := some .singular, case_ := some .acc, gender := some .feminine }
+def it : PersonalPronoun := { form := "it", person := some .third, number := some .singular, gender := some .neuter }
+def they : PersonalPronoun := { form := "they", person := some .third, number := some .plural, case_ := some .nom }
+def them : PersonalPronoun := { form := "them", person := some .third, number := some .plural, case_ := some .acc }
 
 -- Third-person singular *they* ([arnold-2026], [balhorn-2004]): same
 -- phonological form and gender-neutral feature as plural *they*, with singular
 -- number. Covers both underspecified and personal singular *they*.
-def they_sg : PersonalPronoun := { form := "they", person := some .third, number := some .Sing, case_ := some .nom }
-def them_sg : PersonalPronoun := { form := "them", person := some .third, number := some .Sing, case_ := some .acc }
+def they_sg : PersonalPronoun := { form := "they", person := some .third, number := some .singular, case_ := some .nom }
+def them_sg : PersonalPronoun := { form := "them", person := some .third, number := some .singular, case_ := some .acc }
 
 /-! ### Reflexive, reciprocal, and wh pronouns (bare `Pronoun`)
 
@@ -69,15 +69,15 @@ These are not referential pronouns; they carry φ-features and a surface form bu
 no denotation of their own. Their binding-theoretic kind is the `bindingClass`
 each declares (tagged per list below). -/
 
-def myself : Pronoun := { form := "myself", person := some .first, number := some .Sing, bindingClass := some .reflexive }
-def yourself : Pronoun := { form := "yourself", person := some .second, number := some .Sing, bindingClass := some .reflexive }
-def himself : Pronoun := { form := "himself", person := some .third, number := some .Sing, gender := some .masculine, bindingClass := some .reflexive }
-def herself : Pronoun := { form := "herself", person := some .third, number := some .Sing, gender := some .feminine, bindingClass := some .reflexive }
-def itself : Pronoun := { form := "itself", person := some .third, number := some .Sing, gender := some .neuter, bindingClass := some .reflexive }
-def ourselves : Pronoun := { form := "ourselves", person := some .first, number := some .Plur, bindingClass := some .reflexive }
-def yourselves : Pronoun := { form := "yourselves", person := some .second, number := some .Plur, bindingClass := some .reflexive }
-def themselves : Pronoun := { form := "themselves", person := some .third, number := some .Plur, bindingClass := some .reflexive }
-def themself : Pronoun := { form := "themself", person := some .third, number := some .Sing, bindingClass := some .reflexive }
+def myself : Pronoun := { form := "myself", person := some .first, number := some .singular, bindingClass := some .reflexive }
+def yourself : Pronoun := { form := "yourself", person := some .second, number := some .singular, bindingClass := some .reflexive }
+def himself : Pronoun := { form := "himself", person := some .third, number := some .singular, gender := some .masculine, bindingClass := some .reflexive }
+def herself : Pronoun := { form := "herself", person := some .third, number := some .singular, gender := some .feminine, bindingClass := some .reflexive }
+def itself : Pronoun := { form := "itself", person := some .third, number := some .singular, gender := some .neuter, bindingClass := some .reflexive }
+def ourselves : Pronoun := { form := "ourselves", person := some .first, number := some .plural, bindingClass := some .reflexive }
+def yourselves : Pronoun := { form := "yourselves", person := some .second, number := some .plural, bindingClass := some .reflexive }
+def themselves : Pronoun := { form := "themselves", person := some .third, number := some .plural, bindingClass := some .reflexive }
+def themself : Pronoun := { form := "themself", person := some .third, number := some .singular, bindingClass := some .reflexive }
 
 def eachOther : Pronoun := { form := "each other", bindingClass := some .reciprocal }
 def oneAnother : Pronoun := { form := "one another", bindingClass := some .reciprocal }
@@ -97,10 +97,10 @@ Genuine deictic demonstratives — a two-way proximal/distal distance system ([m
 Unlike German *der* (a strong-article personal pronoun, see [patel-grosz-grosz-2017]), these encode
 a real spatial contrast, so they are `Demonstrative` carriers. -/
 
-def this_ : DemonstrativePronoun := { form := "this", person := some .third, number := some .Sing, deixis := .proximal }
-def that_ : DemonstrativePronoun := { form := "that", person := some .third, number := some .Sing, deixis := .distal }
-def these : DemonstrativePronoun := { form := "these", person := some .third, number := some .Plur, deixis := .proximal }
-def those : DemonstrativePronoun := { form := "those", person := some .third, number := some .Plur, deixis := .distal }
+def this_ : DemonstrativePronoun := { form := "this", person := some .third, number := some .singular, deixis := .proximal }
+def that_ : DemonstrativePronoun := { form := "that", person := some .third, number := some .singular, deixis := .distal }
+def these : DemonstrativePronoun := { form := "these", person := some .third, number := some .plural, deixis := .proximal }
+def those : DemonstrativePronoun := { form := "those", person := some .third, number := some .plural, deixis := .distal }
 
 /-- The four English demonstrative pronouns. -/
 def demonstratives : List DemonstrativePronoun := [this_, that_, these, those]

--- a/Linglib/Fragments/French/Reciprocals.lean
+++ b/Linglib/Fragments/French/Reciprocals.lean
@@ -27,7 +27,7 @@ def se : PersonalPronoun :=
 
 /-- l'un l'autre — bipartite reciprocal NP (bivalent strategy). -/
 def lunLautre : PersonalPronoun :=
-  { form := "l'un l'autre", person := some .third, number := some .Plur }
+  { form := "l'un l'autre", person := some .third, number := some .plural }
 
 /-- The bipartite NP form is distinct from the clitic. -/
 theorem bipartite_distinct_from_clitic :

--- a/Linglib/Fragments/Galician/Pronouns.lean
+++ b/Linglib/Fragments/Galician/Pronouns.lean
@@ -23,11 +23,11 @@ open Features.Register (Level)
 
 /-- *eu* — 1sg. -/
 def eu : PersonalPronoun :=
-  { form := "eu", person := some .first, number := some .Sing }
+  { form := "eu", person := some .first, number := some .singular }
 
 /-- *nós* — 1pl. -/
 def nos : PersonalPronoun :=
-  { form := "nós", person := some .first, number := some .Plur }
+  { form := "nós", person := some .first, number := some .plural }
 
 -- ============================================================================
 -- Second Person (T/V, sg and pl)
@@ -35,19 +35,19 @@ def nos : PersonalPronoun :=
 
 /-- *ti* — 2sg familiar (T form). -/
 def ti : PersonalPronoun :=
-  { form := "ti", person := some .second, number := some .Sing, register := .informal }
+  { form := "ti", person := some .second, number := some .singular, register := .informal }
 
 /-- *vostede* — 2sg formal (V form). -/
 def vostede : PersonalPronoun :=
-  { form := "vostede", person := some .second, number := some .Sing, register := .formal }
+  { form := "vostede", person := some .second, number := some .singular, register := .formal }
 
 /-- *vós* — 2pl familiar. -/
 def vos_pl : PersonalPronoun :=
-  { form := "vós", person := some .second, number := some .Plur, register := .informal }
+  { form := "vós", person := some .second, number := some .plural, register := .informal }
 
 /-- *vostedes* — 2pl formal. -/
 def vostedes : PersonalPronoun :=
-  { form := "vostedes", person := some .second, number := some .Plur, register := .formal }
+  { form := "vostedes", person := some .second, number := some .plural, register := .formal }
 
 -- ============================================================================
 -- Third Person
@@ -55,19 +55,19 @@ def vostedes : PersonalPronoun :=
 
 /-- *el* — 3sg masculine. -/
 def el : PersonalPronoun :=
-  { form := "el", person := some .third, number := some .Sing }
+  { form := "el", person := some .third, number := some .singular }
 
 /-- *ela* — 3sg feminine. -/
 def ela : PersonalPronoun :=
-  { form := "ela", person := some .third, number := some .Sing }
+  { form := "ela", person := some .third, number := some .singular }
 
 /-- *eles* — 3pl masculine. -/
 def eles : PersonalPronoun :=
-  { form := "eles", person := some .third, number := some .Plur }
+  { form := "eles", person := some .third, number := some .plural }
 
 /-- *elas* — 3pl feminine. -/
 def elas : PersonalPronoun :=
-  { form := "elas", person := some .third, number := some .Plur }
+  { form := "elas", person := some .third, number := some .plural }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -114,8 +114,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .Sing) = true ∧
-    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .singular) = true ∧
+    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/German/AdjAgreement.lean
+++ b/Linglib/Fragments/German/AdjAgreement.lean
@@ -24,7 +24,7 @@ def predFeatures : List MAGFeatureType := []
 
 /-- German attributive adjectives carry φ + κ (strong endings). -/
 def attrFeatures : List MAGFeatureType :=
-  [ .phi (.number .Plur), .phi (.number .Sing)
+  [ .phi (.number .plural), .phi (.number .singular)
   , .phi (.gender 0), .phi (.gender 1), .phi (.gender 2)
   , .kappa .nom, .kappa .acc, .kappa .dat, .kappa .gen ]
 

--- a/Linglib/Fragments/German/Pronouns.lean
+++ b/Linglib/Fragments/German/Pronouns.lean
@@ -37,11 +37,11 @@ open Features.Register (Level)
 
 /-- *ich* — 1sg. -/
 def ich : PersonalPronoun :=
-  { form := "ich", person := some .first, number := some .Sing }
+  { form := "ich", person := some .first, number := some .singular }
 
 /-- *du* — 2sg familiar (T form). -/
 def du : PersonalPronoun :=
-  { form := "du", person := some .second, number := some .Sing, register := .informal }
+  { form := "du", person := some .second, number := some .singular, register := .informal }
 
 /-- *Sie* — polite 2nd person (V form, triggers 3pl agreement).
     Unlike Italian LEI (3sg.f) and Spanish USTED (3sg), German SIE uses
@@ -49,32 +49,32 @@ def du : PersonalPronoun :=
     is 2nd. Can refer to singular or plural addressees.
     [adamson-zompi-2025] -/
 def sie_polite : PersonalPronoun :=
-  { form := "Sie", person := some .third, number := some .Plur, register := .formal,
+  { form := "Sie", person := some .third, number := some .plural, register := .formal,
     referentialPerson := some .second }
 
 /-- *er* — 3sg masculine. -/
 def er : PersonalPronoun :=
-  { form := "er", person := some .third, number := some .Sing }
+  { form := "er", person := some .third, number := some .singular }
 
 /-- *sie* — 3sg feminine. -/
 def sie_f : PersonalPronoun :=
-  { form := "sie", person := some .third, number := some .Sing }
+  { form := "sie", person := some .third, number := some .singular }
 
 /-- *es* — 3sg neuter. -/
 def es : PersonalPronoun :=
-  { form := "es", person := some .third, number := some .Sing }
+  { form := "es", person := some .third, number := some .singular }
 
 /-- *wir* — 1pl. -/
 def wir : PersonalPronoun :=
-  { form := "wir", person := some .first, number := some .Plur }
+  { form := "wir", person := some .first, number := some .plural }
 
 /-- *ihr* — 2pl familiar. -/
 def ihr : PersonalPronoun :=
-  { form := "ihr", person := some .second, number := some .Plur, register := .informal }
+  { form := "ihr", person := some .second, number := some .plural, register := .informal }
 
 /-- *sie* — 3pl. -/
 def sie_pl : PersonalPronoun :=
-  { form := "sie", person := some .third, number := some .Plur }
+  { form := "sie", person := some .third, number := some .plural }
 
 def allPronouns : List PersonalPronoun :=
   [ich, du, sie_polite, er, sie_f, es, wir, ihr, sie_pl]
@@ -94,7 +94,7 @@ theorem sie_polite_dual_person :
     sie_polite.referentialPerson = some .second := ⟨rfl, rfl⟩
 
 /-- SIE uses 3pl, unlike Italian LEI (3sg) and Spanish USTED (3sg). -/
-theorem sie_is_plural : sie_polite.number = some .Plur := rfl
+theorem sie_is_plural : sie_polite.number = some .plural := rfl
 
 /-- All three persons are attested. -/
 theorem has_all_persons :

--- a/Linglib/Fragments/German/Reciprocals.lean
+++ b/Linglib/Fragments/German/Reciprocals.lean
@@ -28,7 +28,7 @@ def sich : PersonalPronoun :=
 
 /-- einander — dedicated reciprocal pronoun. -/
 def einander : PersonalPronoun :=
-  { form := "einander", person := some .third, number := some .Plur }
+  { form := "einander", person := some .third, number := some .plural }
 
 /-- The dedicated reciprocal form is distinct from the reflexive. -/
 theorem einander_distinct_from_sich :

--- a/Linglib/Fragments/Greek/StandardModern/AdjAgreement.lean
+++ b/Linglib/Fragments/Greek/StandardModern/AdjAgreement.lean
@@ -21,7 +21,7 @@ open Minimalist.Modification
 
 /-- φ-features realized on Greek adjectives: number and gender. -/
 private def phiFeatures : List MAGFeatureType :=
-  [ .phi (.number .Plur), .phi (.number .Sing)
+  [ .phi (.number .plural), .phi (.number .singular)
   , .phi (.gender 0), .phi (.gender 1), .phi (.gender 2) ]
 
 /-- κ-features realized on Greek adjectives: full 3-case system

--- a/Linglib/Fragments/Hindi/Pronouns.lean
+++ b/Linglib/Fragments/Hindi/Pronouns.lean
@@ -21,11 +21,11 @@ open Pronoun
 
 /-- *maiṃ* — 1sg. -/
 def maiN : PersonalPronoun :=
-  { form := "maiṃ", person := some .first, number := some .Sing }
+  { form := "maiṃ", person := some .first, number := some .singular }
 
 /-- *ham* — 1pl. -/
 def ham : PersonalPronoun :=
-  { form := "ham", person := some .first, number := some .Plur }
+  { form := "ham", person := some .first, number := some .plural }
 
 -- ============================================================================
 -- Second Person (three-level honorific)
@@ -33,15 +33,15 @@ def ham : PersonalPronoun :=
 
 /-- *tuu* — 2sg non-honorific (intimate/inferior). -/
 def tuu : PersonalPronoun :=
-  { form := "tuu", person := some .second, number := some .Sing, register := .informal }
+  { form := "tuu", person := some .second, number := some .singular, register := .informal }
 
 /-- *tum* — 2sg honorific (neutral). -/
 def tum : PersonalPronoun :=
-  { form := "tum", person := some .second, number := some .Sing, register := .neutral }
+  { form := "tum", person := some .second, number := some .singular, register := .neutral }
 
 /-- *aap* — 2sg high-honorific (respectful). -/
 def aap : PersonalPronoun :=
-  { form := "aap", person := some .second, number := some .Sing, register := .formal }
+  { form := "aap", person := some .second, number := some .singular, register := .formal }
 
 -- ============================================================================
 -- Third Person (demonstrative-based)
@@ -49,11 +49,11 @@ def aap : PersonalPronoun :=
 
 /-- *vah* — 3sg (distal demonstrative, standard pronoun). -/
 def vah : PersonalPronoun :=
-  { form := "vah", person := some .third, number := some .Sing }
+  { form := "vah", person := some .third, number := some .singular }
 
 /-- *ve* — 3pl (distal demonstrative plural). -/
 def ve : PersonalPronoun :=
-  { form := "ve", person := some .third, number := some .Plur }
+  { form := "ve", person := some .third, number := some .plural }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -94,8 +94,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .Sing) = true ∧
-    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .singular) = true ∧
+    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/Hungarian/Reciprocals.lean
+++ b/Linglib/Fragments/Hungarian/Reciprocals.lean
@@ -57,11 +57,11 @@ def egymas : PersonalPronoun :=
     Unlike *egymás*, the reflexive inflects for number:
     *magá-t* (SG.ACC) vs. *maguk-at* (PL.ACC). -/
 def maga : PersonalPronoun :=
-  { form := "maga", person := some .third, number := some .Sing }
+  { form := "maga", person := some .third, number := some .singular }
 
 /-- *maguk* — reflexive pronoun (3PL form). -/
 def maguk : PersonalPronoun :=
-  { form := "maguk", person := some .third, number := some .Plur }
+  { form := "maguk", person := some .third, number := some .plural }
 
 -- ════════════════════════════════════════════════════════════════
 -- Antecedent Constructions ([rakosi-2019] §§3-6)
@@ -181,7 +181,7 @@ theorem egymas_invariable : egymas.number = none := rfl
 
 /-- The reflexive DOES inflect for number. -/
 theorem reflexive_inflects :
-    maga.number = some .Sing ∧ maguk.number = some .Plur := ⟨rfl, rfl⟩
+    maga.number = some .singular ∧ maguk.number = some .plural := ⟨rfl, rfl⟩
 
 /-- When the local antecedent is a singular bound pronoun, only the
     wide-scope (I-)reading is available.

--- a/Linglib/Fragments/Icelandic/Reciprocals.lean
+++ b/Linglib/Fragments/Icelandic/Reciprocals.lean
@@ -23,7 +23,7 @@ open Pronoun
 
     Each part inflects independently for case.  -/
 def hvorAnnad : PersonalPronoun :=
-  { form := "hvor...annad", person := some .third, number := some .Plur }
+  { form := "hvor...annad", person := some .third, number := some .plural }
 
 /-- sig — reflexive pronoun (for contrast). -/
 def sig : PersonalPronoun :=

--- a/Linglib/Fragments/Italian/AdjAgreement.lean
+++ b/Linglib/Fragments/Italian/AdjAgreement.lean
@@ -21,7 +21,7 @@ open Minimalist.Modification
 
 /-- Italian adjective φ-features: number and gender only. -/
 def phiFeatures : List MAGFeatureType :=
-  [ .phi (.number .Plur), .phi (.number .Sing)
+  [ .phi (.number .plural), .phi (.number .singular)
   , .phi (.gender 0), .phi (.gender 1) ]
 
 /-- Italian DP features include κ (case is always a DP feature per fn 17,

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -43,11 +43,11 @@ open Features.Register (Level)
 
 /-- *io* — 1sg. -/
 def io : PersonalPronoun :=
-  { form := "io", person := some .first, number := some .Sing }
+  { form := "io", person := some .first, number := some .singular }
 
 /-- *tu* — 2sg familiar (T form). -/
 def tu : PersonalPronoun :=
-  { form := "tu", person := some .second, number := some .Sing, register := .informal }
+  { form := "tu", person := some .second, number := some .singular, register := .informal }
 
 /-- *Lei* — polite 2sg (V form). Formally 3rd person: triggers 3sg verbal
     agreement, patterns with 3sg.f clitics, binds 3rd person reflexive *si*.
@@ -55,32 +55,32 @@ def tu : PersonalPronoun :=
     2PL resolved agreement in coordination.
     [adamson-zompi-2025] -/
 def lei_formal : PersonalPronoun :=
-  { form := "Lei", person := some .third, number := some .Sing, register := .formal,
+  { form := "Lei", person := some .third, number := some .singular, register := .formal,
     referentialPerson := some .second }
 
 /-- *lui* — 3sg masculine. -/
 def lui : PersonalPronoun :=
-  { form := "lui", person := some .third, number := some .Sing }
+  { form := "lui", person := some .third, number := some .singular }
 
 /-- *lei* — 3sg feminine. -/
 def lei : PersonalPronoun :=
-  { form := "lei", person := some .third, number := some .Sing }
+  { form := "lei", person := some .third, number := some .singular }
 
 /-- *noi* — 1pl. -/
 def noi : PersonalPronoun :=
-  { form := "noi", person := some .first, number := some .Plur }
+  { form := "noi", person := some .first, number := some .plural }
 
 /-- *voi* — 2pl (familiar; also used as general 2pl in modern Italian). -/
 def voi : PersonalPronoun :=
-  { form := "voi", person := some .second, number := some .Plur, register := .informal }
+  { form := "voi", person := some .second, number := some .plural, register := .informal }
 
 /-- *Loro* — 2pl formal (archaic, largely replaced by *voi*). -/
 def loro_formal : PersonalPronoun :=
-  { form := "Loro", person := some .second, number := some .Plur, register := .formal }
+  { form := "Loro", person := some .second, number := some .plural, register := .formal }
 
 /-- *loro* — 3pl. -/
 def loro : PersonalPronoun :=
-  { form := "loro", person := some .third, number := some .Plur }
+  { form := "loro", person := some .third, number := some .plural }
 
 def secondPersonPronouns : List PersonalPronoun := [tu, lei_formal]
 
@@ -252,8 +252,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .Sing) = true ∧
-    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .singular) = true ∧
+    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
 
 -- ============================================================================
 -- § 5: Cardinaletti–Starke deficiency classes

--- a/Linglib/Fragments/Japanese/Pronouns.lean
+++ b/Linglib/Fragments/Japanese/Pronouns.lean
@@ -23,21 +23,21 @@ open Features.Register (Level)
 
 /-- 私 *watashi* — 1sg neutral/polite. -/
 def watashi : PersonalPronoun :=
-  { form := "watashi", script := some "私", person := some .first, number := some .Sing, register := .formal }
+  { form := "watashi", script := some "私", person := some .first, number := some .singular, register := .formal }
 
 /-- 僕 *boku* — 1sg informal, masculine-associated via register
     (no inherent gender feature; cf. [ochs-1992]). -/
 def boku : PersonalPronoun :=
-  { form := "boku", script := some "僕", person := some .first, number := some .Sing, register := .informal }
+  { form := "boku", script := some "僕", person := some .first, number := some .singular, register := .informal }
 
 /-- 俺 *ore* — 1sg male very informal. Strongly indexes masculine identity
     through assertive/coarse interactional stance ([ochs-1992]). -/
 def ore : PersonalPronoun :=
-  { form := "ore", script := some "俺", person := some .first, number := some .Sing, register := .informal }
+  { form := "ore", script := some "俺", person := some .first, number := some .singular, register := .informal }
 
 /-- 私たち *watashitachi* — 1pl. -/
 def watashitachi : PersonalPronoun :=
-  { form := "watashitachi", script := some "私たち", person := some .first, number := some .Plur }
+  { form := "watashitachi", script := some "私たち", person := some .first, number := some .plural }
 
 -- ============================================================================
 -- Second Person (T/V)
@@ -45,11 +45,11 @@ def watashitachi : PersonalPronoun :=
 
 /-- 君 *kimi* — 2sg plain. -/
 def kimi : PersonalPronoun :=
-  { form := "kimi", script := some "君", person := some .second, number := some .Sing, register := .informal }
+  { form := "kimi", script := some "君", person := some .second, number := some .singular, register := .informal }
 
 /-- あなた *anata* — 2sg polite. -/
 def anata : PersonalPronoun :=
-  { form := "anata", script := some "あなた", person := some .second, number := some .Sing, register := .formal }
+  { form := "anata", script := some "あなた", person := some .second, number := some .singular, register := .formal }
 
 -- ============================================================================
 -- Third Person
@@ -57,15 +57,15 @@ def anata : PersonalPronoun :=
 
 /-- 彼 *kare* — 3sg masculine. -/
 def kare : PersonalPronoun :=
-  { form := "kare", script := some "彼", person := some .third, number := some .Sing }
+  { form := "kare", script := some "彼", person := some .third, number := some .singular }
 
 /-- 彼女 *kanojo* — 3sg feminine. -/
 def kanojo : PersonalPronoun :=
-  { form := "kanojo", script := some "彼女", person := some .third, number := some .Sing }
+  { form := "kanojo", script := some "彼女", person := some .third, number := some .singular }
 
 /-- 彼ら *karera* — 3pl. -/
 def karera : PersonalPronoun :=
-  { form := "karera", script := some "彼ら", person := some .third, number := some .Plur }
+  { form := "karera", script := some "彼ら", person := some .third, number := some .plural }
 
 -- ============================================================================
 -- Reciprocal Pronoun
@@ -76,7 +76,7 @@ def karera : PersonalPronoun :=
     NP/argument reciprocal strategy (reciprocal pronoun), unlike
     languages that mark reciprocity on the verb. -/
 def otagai : PersonalPronoun :=
-  { form := "otagai", script := some "互い", person := some .third, number := some .Plur }
+  { form := "otagai", script := some "互い", person := some .third, number := some .plural }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -126,8 +126,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .Sing) = true ∧
-    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .singular) = true ∧
+    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
 
 /-- 1st person has register-based distinction. -/
 theorem first_person_register :

--- a/Linglib/Fragments/Korean/Pronouns.lean
+++ b/Linglib/Fragments/Korean/Pronouns.lean
@@ -52,15 +52,15 @@ open Features.Register (Level)
 
 /-- 나 *na* — 1sg plain. -/
 def na : PersonalPronoun :=
-  { form := "na", script := some "나", person := some .first, number := some .Sing, register := .informal }
+  { form := "na", script := some "나", person := some .first, number := some .singular, register := .informal }
 
 /-- 저 *jeo* — 1sg humble. -/
 def jeo : PersonalPronoun :=
-  { form := "jeo", script := some "저", person := some .first, number := some .Sing, register := .formal }
+  { form := "jeo", script := some "저", person := some .first, number := some .singular, register := .formal }
 
 /-- 우리 *uri* — 1pl. -/
 def uri : PersonalPronoun :=
-  { form := "uri", script := some "우리", person := some .first, number := some .Plur }
+  { form := "uri", script := some "우리", person := some .first, number := some .plural }
 
 -- ============================================================================
 -- Second Person (T/V)
@@ -68,11 +68,11 @@ def uri : PersonalPronoun :=
 
 /-- 너 *neo* — 2sg plain. -/
 def neo : PersonalPronoun :=
-  { form := "neo", script := some "너", person := some .second, number := some .Sing, register := .informal }
+  { form := "neo", script := some "너", person := some .second, number := some .singular, register := .informal }
 
 /-- 당신 *dangsin* — 2sg polite. -/
 def dangsin : PersonalPronoun :=
-  { form := "dangsin", script := some "당신", person := some .second, number := some .Sing, register := .formal }
+  { form := "dangsin", script := some "당신", person := some .second, number := some .singular, register := .formal }
 
 -- ============================================================================
 -- Third Person
@@ -81,14 +81,14 @@ def dangsin : PersonalPronoun :=
 /-- 그 *geu* (Yale: *ku*) — 3sg masculine, **literary** register.
     76,235 written vs 145 oral tokens ([kwon-lee-2026] fn. 2). -/
 def geu : PersonalPronoun :=
-  { form := "geu", script := some "그", person := some .third, number := some .Sing
+  { form := "geu", script := some "그", person := some .third, number := some .singular
   , gender := some .masculine, register := .formal }
 
 /-- 그녀 *geunyeo* (Yale: *kunye*) — 3sg feminine, **literary** register.
     Compound of *ku* ('that') + *nye* ('female'). 25,085 written vs
     9 oral tokens ([kwon-lee-2026] fn. 2). -/
 def geunyeo : PersonalPronoun :=
-  { form := "geunyeo", script := some "그녀", person := some .third, number := some .Sing
+  { form := "geunyeo", script := some "그녀", person := some .third, number := some .singular
   , gender := some .feminine, register := .formal }
 
 /-- 걔 *gyae* (Yale: *kyay*) — 3sg gender-neutral, **colloquial** pronoun.
@@ -98,13 +98,13 @@ def geunyeo : PersonalPronoun :=
     ([kwon-lee-2026] §5). The overt-pronoun referential form
     tested in [kwon-lee-2026]'s experiments. -/
 def gyae : PersonalPronoun :=
-  { form := "gyae", script := some "걔", person := some .third, number := some .Sing
+  { form := "gyae", script := some "걔", person := some .third, number := some .singular
   , register := .informal }
 
 /-- 그들 *geudeul* — 3pl. Plural of *geu*; literary in register
     (the colloquial plural is the proximal demonstrative + *ai-tul*). -/
 def geudeul : PersonalPronoun :=
-  { form := "geudeul", script := some "그들", person := some .third, number := some .Plur
+  { form := "geudeul", script := some "그들", person := some .third, number := some .plural
   , register := .formal }
 
 -- ============================================================================
@@ -167,8 +167,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .Sing) = true ∧
-    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .singular) = true ∧
+    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
 
 /-- 1st person has plain/humble register distinction. -/
 theorem first_person_humble :

--- a/Linglib/Fragments/Magahi/Pronouns.lean
+++ b/Linglib/Fragments/Magahi/Pronouns.lean
@@ -20,11 +20,11 @@ open Pronoun
 
 /-- *hum* — 1sg. -/
 def hum : PersonalPronoun :=
-  { form := "hum", person := some .first, number := some .Sing }
+  { form := "hum", person := some .first, number := some .singular }
 
 /-- *hum sab* — 1pl. -/
 def humSab : PersonalPronoun :=
-  { form := "hum sab", person := some .first, number := some .Plur }
+  { form := "hum sab", person := some .first, number := some .plural }
 
 -- ============================================================================
 -- Second Person (three-level honorific)
@@ -32,15 +32,15 @@ def humSab : PersonalPronoun :=
 
 /-- *tõ* — 2sg non-honorific. -/
 def toN : PersonalPronoun :=
-  { form := "tõ", person := some .second, number := some .Sing, register := .informal }
+  { form := "tõ", person := some .second, number := some .singular, register := .informal }
 
 /-- *tũ* — 2sg honorific. -/
 def tuN : PersonalPronoun :=
-  { form := "tũ", person := some .second, number := some .Sing, register := .neutral }
+  { form := "tũ", person := some .second, number := some .singular, register := .neutral }
 
 /-- *apne* — 2sg high-honorific. -/
 def apne : PersonalPronoun :=
-  { form := "apne", person := some .second, number := some .Sing, register := .formal }
+  { form := "apne", person := some .second, number := some .singular, register := .formal }
 
 -- ============================================================================
 -- Third Person (demonstrative-based)
@@ -48,15 +48,15 @@ def apne : PersonalPronoun :=
 
 /-- *i* — 3sg proximal. -/
 def i_prox : PersonalPronoun :=
-  { form := "i", person := some .third, number := some .Sing }
+  { form := "i", person := some .third, number := some .singular }
 
 /-- *ũ* — 3sg distal. -/
 def uN : PersonalPronoun :=
-  { form := "ũ", person := some .third, number := some .Sing }
+  { form := "ũ", person := some .third, number := some .singular }
 
 /-- *ũ sab* — 3pl distal. -/
 def uNSab : PersonalPronoun :=
-  { form := "ũ sab", person := some .third, number := some .Plur }
+  { form := "ũ sab", person := some .third, number := some .plural }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -97,8 +97,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .Sing) = true ∧
-    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .singular) = true ∧
+    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/Maithili/Pronouns.lean
+++ b/Linglib/Fragments/Maithili/Pronouns.lean
@@ -21,11 +21,11 @@ open Pronoun
 
 /-- *hum* — 1sg. -/
 def hum : PersonalPronoun :=
-  { form := "hum", person := some .first, number := some .Sing }
+  { form := "hum", person := some .first, number := some .singular }
 
 /-- *hum sab* — 1pl. -/
 def humSab : PersonalPronoun :=
-  { form := "hum sab", person := some .first, number := some .Plur }
+  { form := "hum sab", person := some .first, number := some .plural }
 
 -- ============================================================================
 -- Second Person (three-level honorific)
@@ -33,15 +33,15 @@ def humSab : PersonalPronoun :=
 
 /-- *tõ* — 2sg non-honorific. -/
 def toN : PersonalPronoun :=
-  { form := "tõ", person := some .second, number := some .Sing, register := .informal }
+  { form := "tõ", person := some .second, number := some .singular, register := .informal }
 
 /-- *ahã* — 2sg honorific. -/
 def ahaN : PersonalPronoun :=
-  { form := "ahã", person := some .second, number := some .Sing, register := .neutral }
+  { form := "ahã", person := some .second, number := some .singular, register := .neutral }
 
 /-- *apne* — 2sg high-honorific. -/
 def apne : PersonalPronoun :=
-  { form := "apne", person := some .second, number := some .Sing, register := .formal }
+  { form := "apne", person := some .second, number := some .singular, register := .formal }
 
 -- ============================================================================
 -- Third Person (honorific-sensitive)
@@ -49,15 +49,15 @@ def apne : PersonalPronoun :=
 
 /-- *ũ* — 3sg non-honorific (distal). -/
 def uN : PersonalPronoun :=
-  { form := "ũ", person := some .third, number := some .Sing, register := .informal }
+  { form := "ũ", person := some .third, number := some .singular, register := .informal }
 
 /-- *o* — 3sg honorific. -/
 def o : PersonalPronoun :=
-  { form := "o", person := some .third, number := some .Sing, register := .neutral }
+  { form := "o", person := some .third, number := some .singular, register := .neutral }
 
 /-- *ũ sab* — 3pl. -/
 def uNSab : PersonalPronoun :=
-  { form := "ũ sab", person := some .third, number := some .Plur }
+  { form := "ũ sab", person := some .third, number := some .plural }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -98,8 +98,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .Sing) = true ∧
-    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .singular) = true ∧
+    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -90,15 +90,17 @@ inductive Formality where
     Formality is K'iche'-specific. -/
 structure PhiFeatures where
   person : Person
-  number : UD.Number
+  number : Number
   formality : Formality
   deriving DecidableEq, Repr
 
 /-- A K'iche' φ-bundle bears its number slot (`HasNumber`). -/
-instance : HasNumber PhiFeatures := ⟨fun φ => Number.fromUD φ.number⟩
+instance : HasNumber PhiFeatures := ⟨fun φ => some φ.number⟩
+
+instance : HasPerson PhiFeatures := ⟨fun φ => some φ.person⟩
 
 /-- Shorthand for informal phi features. -/
-abbrev phi (p : Person) (n : UD.Number) : PhiFeatures :=
+abbrev phi (p : Person) (n : Number) : PhiFeatures :=
   ⟨p, n, .informal⟩
 
 -- ============================================================================
@@ -110,14 +112,14 @@ abbrev phi (p : Person) (n : UD.Number) : PhiFeatures :=
     that cross-reference S (intransitive subject) and P (transitive
     object). [mondloch-2017] Lessons 9, 15. -/
 def setBMarker : PhiFeatures → String
-  | ⟨.first,  .Sing, .informal⟩ => "in-"
-  | ⟨.second, .Sing, .informal⟩ => "at-"
-  | ⟨.third,  .Sing, .informal⟩ => "∅"
-  | ⟨.first,  .Plur, .informal⟩ => "oj-"
-  | ⟨.second, .Plur, .informal⟩ => "ix-"
-  | ⟨.third,  .Plur, .informal⟩ => "ee-"
-  | ⟨.second, .Sing, .formal⟩   => "la"
-  | ⟨.second, .Plur, .formal⟩   => "alaq"
+  | ⟨.first,  .singular, .informal⟩ => "in-"
+  | ⟨.second, .singular, .informal⟩ => "at-"
+  | ⟨.third,  .singular, .informal⟩ => "∅"
+  | ⟨.first,  .plural, .informal⟩ => "oj-"
+  | ⟨.second, .plural, .informal⟩ => "ix-"
+  | ⟨.third,  .plural, .informal⟩ => "ee-"
+  | ⟨.second, .singular, .formal⟩   => "la"
+  | ⟨.second, .plural, .formal⟩   => "alaq"
   -- Non-binary number falls through to plural; formal non-2nd is Ø
   | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
   | ⟨.firstExclusive, _, .informal⟩ => "oj-"
@@ -135,14 +137,14 @@ def setBMarker : PhiFeatures → String
     possessive pronouns before consonant-initial nouns.
     [mondloch-2017] Lessons 7, 15. -/
 def setAPreC : PhiFeatures → String
-  | ⟨.first,  .Sing, .informal⟩ => "nu-/in-"
-  | ⟨.second, .Sing, .informal⟩ => "a-"
-  | ⟨.third,  .Sing, .informal⟩ => "u-"
-  | ⟨.first,  .Plur, .informal⟩ => "qa-"
-  | ⟨.second, .Plur, .informal⟩ => "i-"
-  | ⟨.third,  .Plur, .informal⟩ => "ki-"
-  | ⟨.second, .Sing, .formal⟩   => "la"
-  | ⟨.second, .Plur, .formal⟩   => "alaq"
+  | ⟨.first,  .singular, .informal⟩ => "nu-/in-"
+  | ⟨.second, .singular, .informal⟩ => "a-"
+  | ⟨.third,  .singular, .informal⟩ => "u-"
+  | ⟨.first,  .plural, .informal⟩ => "qa-"
+  | ⟨.second, .plural, .informal⟩ => "i-"
+  | ⟨.third,  .plural, .informal⟩ => "ki-"
+  | ⟨.second, .singular, .formal⟩   => "la"
+  | ⟨.second, .plural, .formal⟩   => "alaq"
   | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
   | ⟨.firstExclusive, _, .informal⟩ => "qa-"
   | ⟨.zero, _, .informal⟩ => "∅"  -- no zero-person cell in the paradigm
@@ -153,14 +155,14 @@ def setAPreC : PhiFeatures → String
 /-- Set A (ergative) markers before vowel-initial roots.
     [mondloch-2017] Lesson 8. -/
 def setAPreV : PhiFeatures → String
-  | ⟨.first,  .Sing, .informal⟩ => "w-"
-  | ⟨.second, .Sing, .informal⟩ => "aw-"
-  | ⟨.third,  .Sing, .informal⟩ => "r-"
-  | ⟨.first,  .Plur, .informal⟩ => "q-"
-  | ⟨.second, .Plur, .informal⟩ => "iw-"
-  | ⟨.third,  .Plur, .informal⟩ => "k-"
-  | ⟨.second, .Sing, .formal⟩   => "la"
-  | ⟨.second, .Plur, .formal⟩   => "alaq"
+  | ⟨.first,  .singular, .informal⟩ => "w-"
+  | ⟨.second, .singular, .informal⟩ => "aw-"
+  | ⟨.third,  .singular, .informal⟩ => "r-"
+  | ⟨.first,  .plural, .informal⟩ => "q-"
+  | ⟨.second, .plural, .informal⟩ => "iw-"
+  | ⟨.third,  .plural, .informal⟩ => "k-"
+  | ⟨.second, .singular, .formal⟩   => "la"
+  | ⟨.second, .plural, .formal⟩   => "alaq"
   | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
   | ⟨.firstExclusive, _, .informal⟩ => "q-"
   | ⟨.zero, _, .informal⟩ => "∅"  -- no zero-person cell in the paradigm
@@ -250,45 +252,45 @@ theorem kiche_not_tripartite :
 -- ============================================================================
 
 /-- 1SG absolutive: in- -/
-theorem setB_1sg : setBMarker (phi .first .Sing) = "in-" := rfl
+theorem setB_1sg : setBMarker (phi .first .singular) = "in-" := rfl
 /-- 2SG absolutive: at- -/
-theorem setB_2sg : setBMarker (phi .second .Sing) = "at-" := rfl
+theorem setB_2sg : setBMarker (phi .second .singular) = "at-" := rfl
 /-- 3SG absolutive: ∅ (null morpheme) -/
-theorem setB_3sg : setBMarker (phi .third .Sing) = "∅" := rfl
+theorem setB_3sg : setBMarker (phi .third .singular) = "∅" := rfl
 /-- 1PL absolutive: oj- -/
-theorem setB_1pl : setBMarker (phi .first .Plur) = "oj-" := rfl
+theorem setB_1pl : setBMarker (phi .first .plural) = "oj-" := rfl
 /-- 2PL absolutive: ix- -/
-theorem setB_2pl : setBMarker (phi .second .Plur) = "ix-" := rfl
+theorem setB_2pl : setBMarker (phi .second .plural) = "ix-" := rfl
 /-- 3PL absolutive: ee- -/
-theorem setB_3pl : setBMarker (phi .third .Plur) = "ee-" := rfl
+theorem setB_3pl : setBMarker (phi .third .plural) = "ee-" := rfl
 /-- 2SG.FORM: la (postverbal) -/
-theorem setB_2sg_form : setBMarker ⟨.second, .Sing, .formal⟩ = "la" := rfl
+theorem setB_2sg_form : setBMarker ⟨.second, .singular, .formal⟩ = "la" := rfl
 /-- 2PL.FORM: alaq (postverbal) -/
-theorem setB_2pl_form : setBMarker ⟨.second, .Plur, .formal⟩ = "alaq" := rfl
+theorem setB_2pl_form : setBMarker ⟨.second, .plural, .formal⟩ = "alaq" := rfl
 
 -- ============================================================================
 -- § 8: Set A Per-Cell Verification
 -- ============================================================================
 
 /-- 1SG ergative (preC): nu‑ or in‑ -/
-theorem setA_1sg : setAPreC (phi .first .Sing) = "nu-/in-" := rfl
+theorem setA_1sg : setAPreC (phi .first .singular) = "nu-/in-" := rfl
 /-- 2SG ergative (preC): a- -/
-theorem setA_2sg : setAPreC (phi .second .Sing) = "a-" := rfl
+theorem setA_2sg : setAPreC (phi .second .singular) = "a-" := rfl
 /-- 3SG ergative (preC): u- -/
-theorem setA_3sg : setAPreC (phi .third .Sing) = "u-" := rfl
+theorem setA_3sg : setAPreC (phi .third .singular) = "u-" := rfl
 /-- 1PL ergative (preC): qa- -/
-theorem setA_1pl : setAPreC (phi .first .Plur) = "qa-" := rfl
+theorem setA_1pl : setAPreC (phi .first .plural) = "qa-" := rfl
 /-- 2PL ergative (preC): i- -/
-theorem setA_2pl : setAPreC (phi .second .Plur) = "i-" := rfl
+theorem setA_2pl : setAPreC (phi .second .plural) = "i-" := rfl
 /-- 3PL ergative (preC): ki- -/
-theorem setA_3pl : setAPreC (phi .third .Plur) = "ki-" := rfl
+theorem setA_3pl : setAPreC (phi .third .plural) = "ki-" := rfl
 
 /-- 1SG ergative (preV): w- -/
-theorem setA_preV_1sg : setAPreV (phi .first .Sing) = "w-" := rfl
+theorem setA_preV_1sg : setAPreV (phi .first .singular) = "w-" := rfl
 /-- 2SG ergative (preV): aw- -/
-theorem setA_preV_2sg : setAPreV (phi .second .Sing) = "aw-" := rfl
+theorem setA_preV_2sg : setAPreV (phi .second .singular) = "aw-" := rfl
 /-- 3SG ergative (preV): r- -/
-theorem setA_preV_3sg : setAPreV (phi .third .Sing) = "r-" := rfl
+theorem setA_preV_3sg : setAPreV (phi .third .singular) = "r-" := rfl
 
 -- ============================================================================
 -- § 9: Set A / Set B Identity (Possessives = Set A)
@@ -301,10 +303,10 @@ theorem setA_preV_3sg : setAPreV (phi .third .Sing) = "r-" := rfl
     morphological paradigm. [mondloch-2017] Lesson 15 explicitly
     notes this identity. -/
 theorem possessives_equal_setA :
-    setAPreC (phi .first .Plur) = "qa-" ∧
-    setAPreC (phi .second .Sing) = "a-" ∧
-    setAPreC (phi .third .Sing) = "u-" ∧
-    setAPreC (phi .third .Plur) = "ki-" :=
+    setAPreC (phi .first .plural) = "qa-" ∧
+    setAPreC (phi .second .singular) = "a-" ∧
+    setAPreC (phi .third .singular) = "u-" ∧
+    setAPreC (phi .third .plural) = "ki-" :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 -- ============================================================================
@@ -313,18 +315,18 @@ theorem possessives_equal_setA :
 
 /-- All informal Set B markers are prefixes. -/
 theorem setB_informal_prefix :
-    SetBIsPrefix (phi .first .Sing) ∧
-    SetBIsPrefix (phi .second .Sing) ∧
-    SetBIsPrefix (phi .third .Sing) ∧
-    SetBIsPrefix (phi .first .Plur) ∧
-    SetBIsPrefix (phi .second .Plur) ∧
-    SetBIsPrefix (phi .third .Plur) :=
+    SetBIsPrefix (phi .first .singular) ∧
+    SetBIsPrefix (phi .second .singular) ∧
+    SetBIsPrefix (phi .third .singular) ∧
+    SetBIsPrefix (phi .first .plural) ∧
+    SetBIsPrefix (phi .second .plural) ∧
+    SetBIsPrefix (phi .third .plural) :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 /-- Formal Set B markers are NOT prefixes (they're postverbal). -/
 theorem setB_formal_postverbal :
-    ¬ SetBIsPrefix ⟨.second, .Sing, .formal⟩ ∧
-    ¬ SetBIsPrefix ⟨.second, .Plur, .formal⟩ :=
+    ¬ SetBIsPrefix ⟨.second, .singular, .formal⟩ ∧
+    ¬ SetBIsPrefix ⟨.second, .plural, .formal⟩ :=
   ⟨by decide, by decide⟩
 
 -- ============================================================================
@@ -335,14 +337,14 @@ theorem setB_formal_postverbal :
     sentences and as emphatic/contrastive pronouns in verbal sentences.
     [mondloch-2017] Lesson 4. -/
 def independentPronoun : PhiFeatures → String
-  | ⟨.first,  .Sing, .informal⟩ => "in"
-  | ⟨.second, .Sing, .informal⟩ => "at"
-  | ⟨.third,  .Sing, .informal⟩ => "are'"
-  | ⟨.first,  .Plur, .informal⟩ => "oj"
-  | ⟨.second, .Plur, .informal⟩ => "ix"
-  | ⟨.third,  .Plur, .informal⟩ => "a're'"
-  | ⟨.second, .Sing, .formal⟩   => "laal"
-  | ⟨.second, .Plur, .formal⟩   => "alaq"
+  | ⟨.first,  .singular, .informal⟩ => "in"
+  | ⟨.second, .singular, .informal⟩ => "at"
+  | ⟨.third,  .singular, .informal⟩ => "are'"
+  | ⟨.first,  .plural, .informal⟩ => "oj"
+  | ⟨.second, .plural, .informal⟩ => "ix"
+  | ⟨.third,  .plural, .informal⟩ => "a're'"
+  | ⟨.second, .singular, .formal⟩   => "laal"
+  | ⟨.second, .plural, .formal⟩   => "alaq"
   | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
   | ⟨.firstExclusive, _, .informal⟩ => "oj"
   | ⟨.zero, _, .informal⟩ => "∅"  -- no zero-person cell in the paradigm
@@ -355,10 +357,10 @@ def independentPronoun : PhiFeatures → String
     This is expected for an ergative language where the independent
     pronouns pattern with absolutive agreement. -/
 theorem pronoun_setB_correspondence :
-    independentPronoun (phi .first .Sing)  = "in"  ∧
-    independentPronoun (phi .second .Sing) = "at"  ∧
-    independentPronoun (phi .first .Plur)  = "oj"  ∧
-    independentPronoun (phi .second .Plur) = "ix"  :=
+    independentPronoun (phi .first .singular)  = "in"  ∧
+    independentPronoun (phi .second .singular) = "at"  ∧
+    independentPronoun (phi .first .plural)  = "oj"  ∧
+    independentPronoun (phi .second .plural) = "ix"  :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 -- ============================================================================
@@ -380,22 +382,22 @@ def setBLinearity : MarkerLinearity := .prefixal
 /-- Canonical Set A exponent table (pre-consonantal allomorph; informal),
     keyed on the canonical φ-cell `Agreement.Cell` for cross-Mayan consumption. -/
 def setAExponent : ExponentTable :=
-  [(.pn .first .Sing, setAPreC (phi .first  .Sing)),
-   (.pn .second .Sing, setAPreC (phi .second .Sing)),
-   (.pn .third .Sing, setAPreC (phi .third  .Sing)),
-   (.pn .first .Plur, setAPreC (phi .first  .Plur)),
-   (.pn .second .Plur, setAPreC (phi .second .Plur)),
-   (.pn .third .Plur, setAPreC (phi .third  .Plur))]
+  [(.pn .first .Sing, setAPreC (phi .first  .singular)),
+   (.pn .second .Sing, setAPreC (phi .second .singular)),
+   (.pn .third .Sing, setAPreC (phi .third  .singular)),
+   (.pn .first .Plur, setAPreC (phi .first  .plural)),
+   (.pn .second .Plur, setAPreC (phi .second .plural)),
+   (.pn .third .Plur, setAPreC (phi .third  .plural))]
 
 /-- Canonical Set B exponent table (informal) keyed on the canonical φ-cell
     `Agreement.Cell`. -/
 def setBExponent : ExponentTable :=
-  [(.pn .first .Sing, setBMarker (phi .first  .Sing)),
-   (.pn .second .Sing, setBMarker (phi .second .Sing)),
-   (.pn .third .Sing, setBMarker (phi .third  .Sing)),
-   (.pn .first .Plur, setBMarker (phi .first  .Plur)),
-   (.pn .second .Plur, setBMarker (phi .second .Plur)),
-   (.pn .third .Plur, setBMarker (phi .third  .Plur))]
+  [(.pn .first .Sing, setBMarker (phi .first  .singular)),
+   (.pn .second .Sing, setBMarker (phi .second .singular)),
+   (.pn .third .Sing, setBMarker (phi .third  .singular)),
+   (.pn .first .Plur, setBMarker (phi .first  .plural)),
+   (.pn .second .Plur, setBMarker (phi .second .plural)),
+   (.pn .third .Plur, setBMarker (phi .third  .plural))]
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per [kaufman-norman-1984] Table 8. **Not**

--- a/Linglib/Fragments/Mayan/Mam/Pronouns.lean
+++ b/Linglib/Fragments/Mayan/Mam/Pronouns.lean
@@ -57,28 +57,28 @@ def iDisagr : PersonalPronoun :=
 /-- *qini* — 1SG independent pronoun; bimorphemic *qin+=i* (base *qin*
     [+author,+sg] + disagreement enclitic, Table 4.9). -/
 def qini : PersonalPronoun :=
-  { form := "qini", person := some .first, number := some .Sing }
+  { form := "qini", person := some .first, number := some .singular }
 
 /-- *qoy* — 1PL exclusive independent pronoun; bimorphemic *qo'+=y*
     (base *qo* [+author,−sg] + enclitic; glottalization from the enclitic,
     her fn. 7). -/
 def qoy : PersonalPronoun :=
-  { form := "qoy", person := some .firstExclusive, number := some .Plur, }
+  { form := "qoy", person := some .firstExclusive, number := some .plural, }
 
 /-- *qo* — 1PL inclusive independent pronoun; monomorphemic (1INCL's
     [+author,+participant] values *agree*, so no enclitic). -/
 def qo : PersonalPronoun :=
-  { form := "qo", person := some .firstInclusive, number := some .Plur, }
+  { form := "qo", person := some .firstInclusive, number := some .plural, }
 
 /-- *qi* — 2PL pronoun, both series; bimorphemic *q+=i* (§4.3.3.2).
     Word-vs-enclitic status left open by Scott (p. 163). -/
 def qi : PersonalPronoun :=
-  { form := "qi", person := some .second, number := some .Plur }
+  { form := "qi", person := some .second, number := some .plural }
 
 /-- *qa* — 3PL pronoun, both series; also the generic plural marker of the
     language (her (42)–(44)). Word-vs-enclitic status left open. -/
 def qa : PersonalPronoun :=
-  { form := "qa", person := some .third, number := some .Plur }
+  { form := "qa", person := some .third, number := some .plural }
 
 /-- The clusivity-marked entries satisfy the API's well-formedness invariant
     (clusivity only on 1st-person non-singular). -/

--- a/Linglib/Fragments/Mixtec/SMPM/Basic.lean
+++ b/Linglib/Fragments/Mixtec/SMPM/Basic.lean
@@ -82,23 +82,23 @@ focus ((65), with *íntàà* 'only'; speaker comment at (66)). Each entry
 declares the C&S class on the shared `Pronoun.strength` field. -/
 
 def cl1sg : PersonalPronoun :=
-  { form := "=ì", person := some .first, number := some .Sing,
+  { form := "=ì", person := some .first, number := some .singular,
     strength := some .clitic }
 
 def cl1plIncl : PersonalPronoun :=
-  { form := "=(y)é", person := some .firstInclusive, number := some .Plur,
+  { form := "=(y)é", person := some .firstInclusive, number := some .plural,
      strength := some .clitic }
 
 def cl1plExcl : PersonalPronoun :=
-  { form := "=ndú", person := some .firstExclusive, number := some .Plur,
+  { form := "=ndú", person := some .firstExclusive, number := some .plural,
      strength := some .clitic }
 
 def cl2sg : PersonalPronoun :=
-  { form := "=ú", person := some .second, number := some .Sing,
+  { form := "=ú", person := some .second, number := some .singular,
     strength := some .clitic }
 
 def cl2pl : PersonalPronoun :=
-  { form := "=ndó", person := some .second, number := some .Plur,
+  { form := "=ndó", person := some .second, number := some .plural,
     strength := some .clitic }
 
 /-- Surface form of the nonlocal (3rd person) clitic for each gender ((5);
@@ -120,12 +120,12 @@ def cl3 (g : Gender) : PersonalPronoun :=
 
 /-- *=nà* — nonlocal plural, neutral ((5)). -/
 def cl3plNeutral : PersonalPronoun :=
-  { form := "=nà", person := some .third, number := some .Plur,
+  { form := "=nà", person := some .third, number := some .plural,
     gender := some .common, strength := some .clitic }
 
 /-- *=ná* — nonlocal plural, feminine ((5)). -/
 def cl3plFem : PersonalPronoun :=
-  { form := "=ná", person := some .third, number := some .Plur,
+  { form := "=ná", person := some .third, number := some .plural,
     gender := some .feminine, strength := some .clitic }
 
 /-! ### Non-clitic series ((4), (62))
@@ -139,19 +139,19 @@ McCloskey & Hale 1984 on Irish). Being phrasal, they are not lexical
 entries here. -/
 
 def str1sg : PersonalPronoun :=
-  { form := "yù'u", person := some .first, number := some .Sing,
+  { form := "yù'u", person := some .first, number := some .singular,
     strength := some .strong }
 
 def str1plExcl : PersonalPronoun :=
-  { form := "ndú'ú", person := some .firstExclusive, number := some .Plur,
+  { form := "ndú'ú", person := some .firstExclusive, number := some .plural,
      strength := some .strong }
 
 def str2sg : PersonalPronoun :=
-  { form := "yô'o", person := some .second, number := some .Sing,
+  { form := "yô'o", person := some .second, number := some .singular,
     strength := some .strong }
 
 def str2pl : PersonalPronoun :=
-  { form := "ndó'ó", person := some .second, number := some .Plur,
+  { form := "ndó'ó", person := some .second, number := some .plural,
     strength := some .strong }
 
 /-! ### Series structure -/

--- a/Linglib/Fragments/Punjabi/Pronouns.lean
+++ b/Linglib/Fragments/Punjabi/Pronouns.lean
@@ -20,11 +20,11 @@ open Pronoun
 
 /-- *maiṃ* — 1sg. -/
 def maiN : PersonalPronoun :=
-  { form := "maiṃ", person := some .first, number := some .Sing }
+  { form := "maiṃ", person := some .first, number := some .singular }
 
 /-- *asiiṃ* — 1pl. -/
 def asiiN : PersonalPronoun :=
-  { form := "asiiṃ", person := some .first, number := some .Plur }
+  { form := "asiiṃ", person := some .first, number := some .plural }
 
 -- ============================================================================
 -- Second Person (two-level honorific)
@@ -32,11 +32,11 @@ def asiiN : PersonalPronoun :=
 
 /-- *tũ* — 2sg non-honorific. -/
 def tuN : PersonalPronoun :=
-  { form := "tũ", person := some .second, number := some .Sing, register := .informal }
+  { form := "tũ", person := some .second, number := some .singular, register := .informal }
 
 /-- *tusii* — 2sg honorific (also 2pl). -/
 def tusii : PersonalPronoun :=
-  { form := "tusii", person := some .second, number := some .Sing, register := .formal }
+  { form := "tusii", person := some .second, number := some .singular, register := .formal }
 
 -- ============================================================================
 -- Third Person (demonstrative-based)
@@ -44,11 +44,11 @@ def tusii : PersonalPronoun :=
 
 /-- *uh* — 3sg (distal demonstrative). -/
 def uh_sg : PersonalPronoun :=
-  { form := "uh", person := some .third, number := some .Sing }
+  { form := "uh", person := some .third, number := some .singular }
 
 /-- *uh* — 3pl (same form as 3sg in standard Punjabi). -/
 def uh_pl : PersonalPronoun :=
-  { form := "uh", person := some .third, number := some .Plur }
+  { form := "uh", person := some .third, number := some .plural }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -85,8 +85,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .Sing) = true ∧
-    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .singular) = true ∧
+    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
 
 /-- 2nd person pronouns are all second person. -/
 theorem second_person_all_2p :

--- a/Linglib/Fragments/Slavic/Russian/AdjAgreement.lean
+++ b/Linglib/Fragments/Slavic/Russian/AdjAgreement.lean
@@ -21,7 +21,7 @@ open Minimalist.Modification
 
 /-- Russian long-form features: φ (number, gender) + κ (6-case). -/
 def longFormFeatures : List MAGFeatureType :=
-  [ .phi (.number .Plur), .phi (.number .Sing)
+  [ .phi (.number .plural), .phi (.number .singular)
   , .phi (.gender 0), .phi (.gender 1), .phi (.gender 2)
   , .kappa .nom, .kappa .acc, .kappa .dat
   , .kappa .gen, .kappa .abl ]

--- a/Linglib/Fragments/Slavic/Russian/Reciprocals.lean
+++ b/Linglib/Fragments/Slavic/Russian/Reciprocals.lean
@@ -20,7 +20,7 @@ open Pronoun
 /-- друг друга *drug druga* — reciprocal pronoun 'each other'. -/
 def drugDruga : PersonalPronoun :=
   { form := "drug druga", script := some "друг друга"
-  , person := some .third, number := some .Plur }
+  , person := some .third, number := some .plural }
 
 /-- себя *sebja* — reflexive pronoun (for contrast). -/
 def sebja : PersonalPronoun :=

--- a/Linglib/Fragments/Spanish/Pronouns.lean
+++ b/Linglib/Fragments/Spanish/Pronouns.lean
@@ -37,11 +37,11 @@ open Features.Register (Level)
 
 /-- *yo* — 1sg. -/
 def yo : PersonalPronoun :=
-  { form := "yo", person := some .first, number := some .Sing }
+  { form := "yo", person := some .first, number := some .singular }
 
 /-- *tú* — 2sg familiar (T form). -/
 def tu : PersonalPronoun :=
-  { form := "tú", person := some .second, number := some .Sing, register := .informal }
+  { form := "tú", person := some .second, number := some .singular, register := .informal }
 
 /-- *usted* — polite 2sg (V form, triggers 3sg agreement).
     Agreement person is 3rd, interpretable person is 2nd. Triggers PCC
@@ -49,33 +49,33 @@ def tu : PersonalPronoun :=
     ([rezac-2011], [adamson-zompi-2025] §6.1).
     [adamson-zompi-2025] -/
 def usted : PersonalPronoun :=
-  { form := "usted", person := some .third, number := some .Sing, register := .formal,
+  { form := "usted", person := some .third, number := some .singular, register := .formal,
     referentialPerson := some .second }
 
 /-- *él* — 3sg masculine. -/
 def el : PersonalPronoun :=
-  { form := "él", person := some .third, number := some .Sing }
+  { form := "él", person := some .third, number := some .singular }
 
 /-- *ella* — 3sg feminine. -/
 def ella : PersonalPronoun :=
-  { form := "ella", person := some .third, number := some .Sing }
+  { form := "ella", person := some .third, number := some .singular }
 
 /-- *nosotros* — 1pl. -/
 def nosotros : PersonalPronoun :=
-  { form := "nosotros", person := some .first, number := some .Plur }
+  { form := "nosotros", person := some .first, number := some .plural }
 
 /-- *vosotros* — 2pl familiar (Peninsular). -/
 def vosotros : PersonalPronoun :=
-  { form := "vosotros", person := some .second, number := some .Plur, register := .informal }
+  { form := "vosotros", person := some .second, number := some .plural, register := .informal }
 
 /-- *ustedes* — 2pl formal / general (triggers 3pl agreement). -/
 def ustedes : PersonalPronoun :=
-  { form := "ustedes", person := some .third, number := some .Plur, register := .formal,
+  { form := "ustedes", person := some .third, number := some .plural, register := .formal,
     referentialPerson := some .second }
 
 /-- *ellos* — 3pl masculine. -/
 def ellos : PersonalPronoun :=
-  { form := "ellos", person := some .third, number := some .Plur }
+  { form := "ellos", person := some .third, number := some .plural }
 
 def allPronouns : List PersonalPronoun :=
   [yo, tu, usted, el, ella, nosotros, vosotros, ustedes, ellos]

--- a/Linglib/Fragments/Tagalog/Pronouns.lean
+++ b/Linglib/Fragments/Tagalog/Pronouns.lean
@@ -83,37 +83,37 @@ def clusivitySystem : Features.Clusivity.System := .minimalAugmented
 open Person (Category)
 
 -- 1st singular
-def ako    : PersonalPronoun := { form := "ako",    person := some .first,  number := some .Sing, case_ := some .Nom }
-def ko     : PersonalPronoun := { form := "ko",     person := some .first,  number := some .Sing, case_ := some .Gen }
-def akin   : PersonalPronoun := { form := "akin",   person := some .first,  number := some .Sing, case_ := some .Dat }
+def ako    : PersonalPronoun := { form := "ako",    person := some .first,  number := some .singular, case_ := some .Nom }
+def ko     : PersonalPronoun := { form := "ko",     person := some .first,  number := some .singular, case_ := some .Gen }
+def akin   : PersonalPronoun := { form := "akin",   person := some .first,  number := some .singular, case_ := some .Dat }
 -- 2nd singular
-def ikaw   : PersonalPronoun := { form := "ikaw",   person := some .second, number := some .Sing, case_ := some .Nom }
-def mo     : PersonalPronoun := { form := "mo",     person := some .second, number := some .Sing, case_ := some .Gen }
-def iyo    : PersonalPronoun := { form := "iyo",    person := some .second, number := some .Sing, case_ := some .Dat }
+def ikaw   : PersonalPronoun := { form := "ikaw",   person := some .second, number := some .singular, case_ := some .Nom }
+def mo     : PersonalPronoun := { form := "mo",     person := some .second, number := some .singular, case_ := some .Gen }
+def iyo    : PersonalPronoun := { form := "iyo",    person := some .second, number := some .singular, case_ := some .Dat }
 -- 3rd singular
-def siya   : PersonalPronoun := { form := "siya",   person := some .third,  number := some .Sing, case_ := some .Nom }
-def niya   : PersonalPronoun := { form := "niya",   person := some .third,  number := some .Sing, case_ := some .Gen }
-def kaniya : PersonalPronoun := { form := "kaniya", person := some .third,  number := some .Sing, case_ := some .Dat }
+def siya   : PersonalPronoun := { form := "siya",   person := some .third,  number := some .singular, case_ := some .Nom }
+def niya   : PersonalPronoun := { form := "niya",   person := some .third,  number := some .singular, case_ := some .Gen }
+def kaniya : PersonalPronoun := { form := "kaniya", person := some .third,  number := some .singular, case_ := some .Dat }
 -- 1st dual inclusive (minimal inclusive): *kata*
-def kata   : PersonalPronoun := { form := "kata",   person := some .firstInclusive,  number := some .Dual, case_ := some .Nom }
-def nita   : PersonalPronoun := { form := "nita",   person := some .firstInclusive,  number := some .Dual, case_ := some .Gen }
-def kanita : PersonalPronoun := { form := "kanita", person := some .firstInclusive,  number := some .Dual, case_ := some .Dat }
+def kata   : PersonalPronoun := { form := "kata",   person := some .firstInclusive,  number := some .dual, case_ := some .Nom }
+def nita   : PersonalPronoun := { form := "nita",   person := some .firstInclusive,  number := some .dual, case_ := some .Gen }
+def kanita : PersonalPronoun := { form := "kanita", person := some .firstInclusive,  number := some .dual, case_ := some .Dat }
 -- 1st plural inclusive (augmented inclusive): *tayo*
-def tayo   : PersonalPronoun := { form := "tayo",   person := some .firstInclusive,  number := some .Plur, case_ := some .Nom }
-def natin  : PersonalPronoun := { form := "natin",  person := some .firstInclusive,  number := some .Plur, case_ := some .Gen }
-def atin   : PersonalPronoun := { form := "atin",   person := some .firstInclusive,  number := some .Plur, case_ := some .Dat }
+def tayo   : PersonalPronoun := { form := "tayo",   person := some .firstInclusive,  number := some .plural, case_ := some .Nom }
+def natin  : PersonalPronoun := { form := "natin",  person := some .firstInclusive,  number := some .plural, case_ := some .Gen }
+def atin   : PersonalPronoun := { form := "atin",   person := some .firstInclusive,  number := some .plural, case_ := some .Dat }
 -- 1st plural exclusive: *kami*
-def kami   : PersonalPronoun := { form := "kami",   person := some .firstExclusive,  number := some .Plur, case_ := some .Nom }
-def namin  : PersonalPronoun := { form := "namin",  person := some .firstExclusive,  number := some .Plur, case_ := some .Gen }
-def amin   : PersonalPronoun := { form := "amin",   person := some .firstExclusive,  number := some .Plur, case_ := some .Dat }
+def kami   : PersonalPronoun := { form := "kami",   person := some .firstExclusive,  number := some .plural, case_ := some .Nom }
+def namin  : PersonalPronoun := { form := "namin",  person := some .firstExclusive,  number := some .plural, case_ := some .Gen }
+def amin   : PersonalPronoun := { form := "amin",   person := some .firstExclusive,  number := some .plural, case_ := some .Dat }
 -- 2nd plural
-def kayo   : PersonalPronoun := { form := "kayo",   person := some .second, number := some .Plur, case_ := some .Nom }
-def ninyo  : PersonalPronoun := { form := "ninyo",  person := some .second, number := some .Plur, case_ := some .Gen }
-def inyo   : PersonalPronoun := { form := "inyo",   person := some .second, number := some .Plur, case_ := some .Dat }
+def kayo   : PersonalPronoun := { form := "kayo",   person := some .second, number := some .plural, case_ := some .Nom }
+def ninyo  : PersonalPronoun := { form := "ninyo",  person := some .second, number := some .plural, case_ := some .Gen }
+def inyo   : PersonalPronoun := { form := "inyo",   person := some .second, number := some .plural, case_ := some .Dat }
 -- 3rd plural
-def sila   : PersonalPronoun := { form := "sila",   person := some .third,  number := some .Plur, case_ := some .Nom }
-def nila   : PersonalPronoun := { form := "nila",   person := some .third,  number := some .Plur, case_ := some .Gen }
-def kanila : PersonalPronoun := { form := "kanila", person := some .third,  number := some .Plur, case_ := some .Dat }
+def sila   : PersonalPronoun := { form := "sila",   person := some .third,  number := some .plural, case_ := some .Nom }
+def nila   : PersonalPronoun := { form := "nila",   person := some .third,  number := some .plural, case_ := some .Gen }
+def kanila : PersonalPronoun := { form := "kanila", person := some .third,  number := some .plural, case_ := some .Dat }
 
 /-- The Tagalog independent-pronoun inventory (all three case series). -/
 def pronouns : List PersonalPronoun :=
@@ -140,8 +140,8 @@ theorem incl_excl_distinct :
     plural inclusive *tayo* — what makes Tagalog minimal-augmented rather than
     plain inclusive/exclusive ([cysouw-2009]). -/
 theorem minimal_augmented :
-    kata.number = some .Dual ∧ kata.person = some .firstInclusive ∧
-    tayo.number = some .Plur ∧ tayo.person = some .firstInclusive := ⟨rfl, rfl, rfl, rfl⟩
+    kata.number = some .dual ∧ kata.person = some .firstInclusive ∧
+    tayo.number = some .plural ∧ tayo.person = some .firstInclusive := ⟨rfl, rfl, rfl, rfl⟩
 
 /-- Cross-substrate consistency: the inventory contains a minimal-inclusive
     (dual inclusive) form iff the language commits to the minimal-augmented

--- a/Linglib/Fragments/Tamil/Pronouns.lean
+++ b/Linglib/Fragments/Tamil/Pronouns.lean
@@ -22,15 +22,15 @@ open Pronoun
 
 /-- *naan* — 1sg. -/
 def naan : PersonalPronoun :=
-  { form := "naan", person := some .first, number := some .Sing }
+  { form := "naan", person := some .first, number := some .singular }
 
 /-- *naam* — 1pl inclusive (speaker + addressee). -/
 def naam : PersonalPronoun :=
-  { form := "naam", person := some .firstInclusive, number := some .Plur }
+  { form := "naam", person := some .firstInclusive, number := some .plural }
 
 /-- *naangaL* — 1pl exclusive (speaker + others, not addressee). -/
 def naangaL : PersonalPronoun :=
-  { form := "naangaL", person := some .firstExclusive, number := some .Plur }
+  { form := "naangaL", person := some .firstExclusive, number := some .plural }
 
 -- ============================================================================
 -- Second Person (two-level honorific)
@@ -38,11 +38,11 @@ def naangaL : PersonalPronoun :=
 
 /-- *nii* — 2sg non-honorific. -/
 def nii : PersonalPronoun :=
-  { form := "nii", person := some .second, number := some .Sing, register := .informal }
+  { form := "nii", person := some .second, number := some .singular, register := .informal }
 
 /-- *niingaL* — 2sg honorific (also 2pl). -/
 def niingaL : PersonalPronoun :=
-  { form := "niingaL", person := some .second, number := some .Sing, register := .formal }
+  { form := "niingaL", person := some .second, number := some .singular, register := .formal }
 
 -- ============================================================================
 -- Third Person
@@ -50,19 +50,19 @@ def niingaL : PersonalPronoun :=
 
 /-- *avan* — 3sg masculine. -/
 def avan : PersonalPronoun :=
-  { form := "avan", person := some .third, number := some .Sing }
+  { form := "avan", person := some .third, number := some .singular }
 
 /-- *avaL* — 3sg feminine. -/
 def avaL : PersonalPronoun :=
-  { form := "avaL", person := some .third, number := some .Sing }
+  { form := "avaL", person := some .third, number := some .singular }
 
 /-- *avar* — 3sg honorific. -/
 def avar : PersonalPronoun :=
-  { form := "avar", person := some .third, number := some .Sing, register := .formal }
+  { form := "avar", person := some .third, number := some .singular, register := .formal }
 
 /-- *avarkaL* — 3pl (human). -/
 def avarkaL : PersonalPronoun :=
-  { form := "avarkaL", person := some .third, number := some .Plur }
+  { form := "avarkaL", person := some .third, number := some .plural }
 
 -- ============================================================================
 -- Pronoun Lists
@@ -99,8 +99,8 @@ theorem has_all_persons :
 
 /-- Both singular and plural are attested. -/
 theorem has_both_numbers :
-    allPronouns.any (·.number == some .Sing) = true ∧
-    allPronouns.any (·.number == some .Plur) = true := ⟨rfl, rfl⟩
+    allPronouns.any (·.number == some .singular) = true ∧
+    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
 
 /-- Tamil has the inclusive/exclusive distinction in 1pl — carried on the
     person values themselves. -/

--- a/Linglib/Fragments/Wan/Reciprocals.lean
+++ b/Linglib/Fragments/Wan/Reciprocals.lean
@@ -51,7 +51,7 @@ open Features.Logophoricity
     logophoric pronoun. The reciprocal reading arises from the combination
     of REFL *ē* + RECIP *ɔ̄ŋ*. -/
 def logPl : PersonalPronoun :=
-  { form := "mɔ̄", person := some .third, number := some .Plur }
+  { form := "mɔ̄", person := some .third, number := some .plural }
 
 /-- Wan reflexive marker *ē* (REFL). Combines with reciprocal marker
     *ɔ̄ŋ* to form the reciprocal construction. -/
@@ -61,7 +61,7 @@ def refl : PersonalPronoun :=
 /-- Wan reciprocal marker *ɔ̄ŋ* (RECIP). Appears after reflexive *ē*
     to yield the reciprocal reading. -/
 def recip : PersonalPronoun :=
-  { form := "ɔ̄ŋ", person := some .third, number := some .Plur }
+  { form := "ɔ̄ŋ", person := some .third, number := some .plural }
 
 /-- Wan 3pl ordinary (non-logophoric) pronoun *à* (low tone).
     In (32): "wì mù tēŋ tú gé **à** ɔ̄ŋ lɔ̄ lé"
@@ -73,7 +73,7 @@ def recip : PersonalPronoun :=
     pronoun. The 3PL pronoun is *à* (grave accent), tonally distinct
     from copula *á* (acute accent) in (28). -/
 def ordinaryPl : PersonalPronoun :=
-  { form := "à", person := some .third, number := some .Plur }
+  { form := "à", person := some .third, number := some .plural }
 
 -- ════════════════════════════════════════════════════════════════
 -- § 2: Logophoric Properties

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -61,8 +61,8 @@ def PersonalPronoun.phiPresup {E : Type*} [PartialOrder E] (e : PersonalPronoun)
       | _            => PrProp.top)
     (PrProp.and
       (match e.number with
-        | some .Sing => sgSem E
-        | some .Plur => plSem E
+        | some .singular => sgSem E
+        | some .plural => plSem E
         | _          => PrProp.top)
       (match e.gender with
         | some .feminine  => femSem isFemale
@@ -102,7 +102,7 @@ theorem interpPronoun_eq_iLookup {F : Frame} (i : ℕ) (g : Assignment F.Entity)
 /-- A 3rd-person plural feminine entry (Spanish *ellas*), used to exercise
 the φ-feature presupposition. -/
 private def ellas : PersonalPronoun :=
-  { form := "ellas", person := some .third, number := some .Plur,
+  { form := "ellas", person := some .third, number := some .plural,
     gender := some .feminine }
 
 /-- Negative: a feminine pronoun is undefined of a non-feminine referent. -/

--- a/Linglib/Studies/AdamsonZompi2025.lean
+++ b/Linglib/Studies/AdamsonZompi2025.lean
@@ -709,11 +709,11 @@ theorem person_geometry_matches_core_features :
     and why it can address multiple addressees, unlike LEI/USTED. -/
 theorem cross_linguistic_number :
     -- LEI is formally singular (§3, (8): "3sg verbal agreement")
-    Italian.Pronouns.lei_formal.number = some .Sing ∧
+    Italian.Pronouns.lei_formal.number = some .singular ∧
     -- USTED is formally singular
-    Spanish.Pronouns.usted.number = some .Sing ∧
+    Spanish.Pronouns.usted.number = some .singular ∧
     -- SIE is formally PLURAL — the typological outlier (§6.2, (45))
-    German.Pronouns.sie_polite.number = some .Plur := ⟨rfl, rfl, rfl⟩
+    German.Pronouns.sie_polite.number = some .plural := ⟨rfl, rfl, rfl⟩
 
 /-- Despite different agreement numbers, all three polite pronouns trigger
     PCC effects identically — confirming that the PCC reads *person*

--- a/Linglib/Studies/Cysouw2009.lean
+++ b/Linglib/Studies/Cysouw2009.lean
@@ -656,19 +656,33 @@ inductive PersonStage where
   | P4  -- minimal inclusive vs augmented inclusive distinguished
   deriving DecidableEq, Repr
 
-/-- Classify a paradigm's person differentiation stage. -/
+/-- Classify a paradigm's person differentiation stage, per the Fig 10.9
+    tree as instantiated by Fig 10.7's columns: the only-inclusive and
+    inclusive/exclusive types both sit at P3 (an inclusive–exclusive
+    opposition is present either way); paradigms with an undifferentiated
+    first person complex (no-we, unified-we) are P2 when the non-first
+    non-singulars are differentiated and P1 under vertical homophony
+    (P0 when the singulars are undifferentiated too). (Corrected against
+    the source: a previous revision placed unified-we at P1 and
+    only-inclusive at P2, one stage below Fig 10.7's columns.) -/
 def ParadigmaticStructure.personStage (s : ParadigmaticStructure) : PersonStage :=
   match s.firstPersonComplexType with
-  | .Pb => if s.singularType == .Se then .P0 else .P1
-  | .Pa => .P1  -- all non-singular first person unified
-  | .Pc => .P2  -- inclusive specialized but not exclusive
+  | .Pa | .Pb =>
+    if s.homophonous .secondGrp .thirdGrp then
+      if s.singularType == .Se then .P0 else .P1
+    else .P2
+  | .Pc => .P3  -- inclusive specialized: incl/excl opposition present
   | .Pd => .P3  -- inclusive vs exclusive
   | .Pe => .P4  -- min.incl vs aug.incl vs excl
 
 theorem ilocano_P4 : ilocano.personStage = .P4 := by decide
 theorem mandara_P3 : mandara.personStage = .P3 := by decide
-theorem english_pron_P1 : englishPronouns.personStage = .P1 := by decide
-theorem piraha_P1 : piraha.personStage = .P1 := by decide
+/-- English pronouns are unified-we with differentiated *you*/*they*:
+    column P2 of Fig 10.7. -/
+theorem english_pron_P2 : englishPronouns.personStage = .P2 := by decide
+/-- Pirahã is no-we with non-singular reference via the (distinct)
+    singular forms: P2, with Fig 10.7's no-we column. -/
+theorem piraha_P2 : piraha.personStage = .P2 := by decide
 
 -- ============================================================================
 -- §18: Cognitive Map Summary

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -414,18 +414,18 @@ theorem english_demonstratives_are_definite :
 -- φ-feature content is stated.
 theorem it_entry_classification :
     English.Pronouns.it.person = some .third ∧
-    English.Pronouns.it.number = some .Sing :=
+    English.Pronouns.it.number = some .singular :=
   ⟨rfl, rfl⟩
 
 theorem he_entry_classification :
     English.Pronouns.he.person = some .third ∧
-    English.Pronouns.he.number = some .Sing ∧
+    English.Pronouns.he.number = some .singular ∧
     English.Pronouns.he.case_ = some .nom :=
   ⟨rfl, rfl, rfl⟩
 
 theorem she_entry_classification :
     English.Pronouns.she.person = some .third ∧
-    English.Pronouns.she.number = some .Sing ∧
+    English.Pronouns.she.number = some .singular ∧
     English.Pronouns.she.case_ = some .nom :=
   ⟨rfl, rfl, rfl⟩
 

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -521,7 +521,7 @@ theorem both_probes_unvalued :
 theorem phi_and_oblique_agree_parallel :
     -- φ-Agree pipeline: value person, then number, then spellout
     (applyAgree voiceProbe dp3sg (.phi (.person .third))).bind
-      (λ fb => applyAgree fb dp3sg (.phi (.number .Sing))) = some voiceFullyAgreed ∧
+      (λ fb => applyAgree fb dp3sg (.phi (.number .singular))) = some voiceFullyAgreed ∧
     spellout setAVocab voiceFullyAgreed (some .v) = some "t-" ∧
     -- Oblique-Agree pipeline: value oblique, then spellout
     applyAgree voiceOblProbe [.valued (.oblique true)] (.oblique false) =

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -78,14 +78,14 @@ article strength; which series a form belongs to is recorded here (the `weak`/`s
 split of `PronounSystem`), not in the theory-neutral `PersonalPronoun` schema. -/
 
 -- Weak series (PER): the uniqueness/weak article.
-def er  : PersonalPronoun := { form := "er",  person := some .third, number := some .Sing, gender := some .masculine }
-def sie : PersonalPronoun := { form := "sie", person := some .third, number := some .Sing, gender := some .feminine }
-def es  : PersonalPronoun := { form := "es",  person := some .third, number := some .Sing, gender := some .neuter }
+def er  : PersonalPronoun := { form := "er",  person := some .third, number := some .singular, gender := some .masculine }
+def sie : PersonalPronoun := { form := "sie", person := some .third, number := some .singular, gender := some .feminine }
+def es  : PersonalPronoun := { form := "es",  person := some .third, number := some .singular, gender := some .neuter }
 
 -- Strong series ("DEM"): the same core plus the strong-article anaphoric index.
-def der : PersonalPronoun := { form := "der", person := some .third, number := some .Sing, gender := some .masculine }
-def die : PersonalPronoun := { form := "die", person := some .third, number := some .Sing, gender := some .feminine }
-def das : PersonalPronoun := { form := "das", person := some .third, number := some .Sing, gender := some .neuter }
+def der : PersonalPronoun := { form := "der", person := some .third, number := some .singular, gender := some .masculine }
+def die : PersonalPronoun := { form := "die", person := some .third, number := some .singular, gender := some .feminine }
+def das : PersonalPronoun := { form := "das", person := some .third, number := some .singular, gender := some .neuter }
 
 /-- A language's 3rd-person pronoun system as PG&G analyze it: the weak (PER) and
     strong ("DEM") article series, the article inventory (source of `articleType`),

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -133,7 +133,7 @@ instance : DecidablePred IsAuthor := fun c =>
 /-- Convert a person-number cell to a PhiFeature list for the Agree
     infrastructure. -/
 def toPhiFeatures (c : Agreement.Cell) : List PhiFeature :=
-  [.person c.toPerson, .number (if c.isPlural then .Plur else .Sing)]
+  [.person c.toPerson, .number (if c.isPlural then .plural else .singular)]
 
 -- ============================================================================
 -- § 2: DM Vocabulary Insertion ([halle-marantz-1993])

--- a/Linglib/Studies/Rakosi2019.lean
+++ b/Linglib/Studies/Rakosi2019.lean
@@ -237,7 +237,7 @@ theorem egymas_no_number_feature :
     *maguk* (PL). The anaphor's number must match the verb's agreement,
     confirming that reflexive licensing is morphosyntactic. -/
 theorem reflexive_number_paradigm :
-    maga.number = some .Sing ∧ maguk.number = some .Plur := ⟨rfl, rfl⟩
+    maga.number = some .singular ∧ maguk.number = some .plural := ⟨rfl, rfl⟩
 
 /-- The morphological invariance of *egymás* predicts it should be
     insensitive to verb agreement number — and it is: reciprocals are

--- a/Linglib/Studies/Scott2021.lean
+++ b/Linglib/Studies/Scott2021.lean
@@ -181,8 +181,8 @@ theorem delete_persP_idempotent : deletePersP pronTreeCl1 = pronTreeCl1 := rfl
 def terminalToFeature : DPCat → String → Option FeatureVal
   | .Pers, "1" => some (.phi (.person .first))
   | .Pers, "2" => some (.phi (.person .second))
-  | .Num, "sg" => some (.phi (.number .Sing))
-  | .Num, "pl" => some (.phi (.number .Plur))
+  | .Num, "sg" => some (.phi (.number .singular))
+  | .Num, "pl" => some (.phi (.number .plural))
   | .n, "anim" => some (.phi (.gender 1))
   | _, _ => none
 
@@ -206,14 +206,14 @@ end
     (Order follows depth-first tree traversal.) -/
 theorem features_1sg :
     extractFeatures pronTree1sg =
-    [.valued (.phi (.number .Sing)),
+    [.valued (.phi (.number .singular)),
      .valued (.phi (.gender 1)),
      .valued (.phi (.person .first))] := by decide
 
 /-- After PersP deletion, features are: [number:sg, gender:anim] — no person. -/
 theorem features_after_deletion :
     extractFeatures (deletePersP pronTree1sg) =
-    [.valued (.phi (.number .Sing)),
+    [.valued (.phi (.number .singular)),
      .valued (.phi (.gender 1))] := by decide
 
 -- ============================================================================
@@ -235,7 +235,7 @@ def getPerson (fb : FeatureBundle) : Option Person :=
 /-- Helper: is the number singular? -/
 def isSg (fb : FeatureBundle) : Bool :=
   fb.any fun f => match f with
-    | .valued (.phi (.number .Sing)) => true
+    | .valued (.phi (.number .singular)) => true
     | _ => false
 
 /-- Helper: does the bundle contain animacy? -/

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -178,7 +178,7 @@ open Agreement
 
 /-- PhiFeature list per Mam person-number cell. -/
 def mamToPhiFeatures (c : Agreement.Cell) : List PhiFeature :=
-  [.person c.toPerson, .number (if c.isPlural then .Plur else .Sing)]
+  [.person c.toPerson, .number (if c.isPlural then .plural else .singular)]
 
 /-- Set A (ERG) vocabulary entries: φ-features on Voice (.v)
     yield the morphological exponent ([scott-2023] Table 2.8).
@@ -214,13 +214,13 @@ def agreeProbe : ArgPosition → Option Cat
     Placeholder values (.third, .Sing) are irrelevant — `sameType` matching
     ensures any Person/Number goal is found regardless. -/
 def voiceProbe : FeatureBundle :=
-  [.unvalued (.phi (.person .third)), .unvalued (.phi (.number .Sing))]
+  [.unvalued (.phi (.person .third)), .unvalued (.phi (.number .singular))]
 
 /-- Infl's probe features: [uPerson, uNumber].
     In intransitives, these are valued by S. In transitives, the probe
     is blocked by Voice_TR before reaching any DP. -/
 def inflProbe : FeatureBundle :=
-  [.unvalued (.phi (.person .third)), .unvalued (.phi (.number .Sing))]
+  [.unvalued (.phi (.person .third)), .unvalued (.phi (.number .singular))]
 
 -- ============================================================================
 -- § 2: Goal Feature Bundles (3SG test case)
@@ -228,7 +228,7 @@ def inflProbe : FeatureBundle :=
 
 /-- A 3SG DP's features: [Person:3, Number:sg]. -/
 def dp3sg : FeatureBundle :=
-  [.valued (.phi (.person .third)), .valued (.phi (.number .Sing))]
+  [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
 
 -- ============================================================================
 -- § 3: Agree Valuation — Voice agrees with agent
@@ -237,25 +237,25 @@ def dp3sg : FeatureBundle :=
 /-- Voice's [uPerson] is valued as [Person:3] from a 3SG agent. -/
 theorem voice_agrees_person :
     applyAgree voiceProbe dp3sg (.phi (.person .third)) =
-    some [.valued (.phi (.person .third)), .unvalued (.phi (.number .Sing))] := by
+    some [.valued (.phi (.person .third)), .unvalued (.phi (.number .singular))] := by
   native_decide
 
 /-- After person agreement, Voice's [uNumber] is valued as [Number:sg].
     This is the second step of φ-Agree: person first, then number. -/
 theorem voice_agrees_number :
-    let afterPerson := [.valued (.phi (.person .third)), .unvalued (.phi (.number .Sing))]
-    applyAgree afterPerson dp3sg (.phi (.number .Sing)) =
-    some [.valued (.phi (.person .third)), .valued (.phi (.number .Sing))] := by
+    let afterPerson := [.valued (.phi (.person .third)), .unvalued (.phi (.number .singular))]
+    applyAgree afterPerson dp3sg (.phi (.number .singular)) =
+    some [.valued (.phi (.person .third)), .valued (.phi (.number .singular))] := by
   native_decide
 
 /-- Full φ-valuation of Voice by a 3SG agent: both person and number valued. -/
 def voiceFullyAgreed : FeatureBundle :=
-  [.valued (.phi (.person .third)), .valued (.phi (.number .Sing))]
+  [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
 
 /-- The two-step Agree pipeline produces a fully valued bundle. -/
 theorem voice_agree_pipeline :
     (applyAgree voiceProbe dp3sg (.phi (.person .third))).bind
-      (λ fb => applyAgree fb dp3sg (.phi (.number .Sing))) =
+      (λ fb => applyAgree fb dp3sg (.phi (.number .singular))) =
     some voiceFullyAgreed := by
   native_decide
 
@@ -271,7 +271,7 @@ theorem setA_spellout_3sg :
 /-- Set A spellout for 1SG: Voice with [Person:1, Number:sg] yields A1SG marker. -/
 theorem setA_spellout_1sg :
     let v1sg : FeatureBundle :=
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     spellout setAVocab v1sg (some .v) = some "n-/w-" := by
   native_decide
 
@@ -285,7 +285,7 @@ theorem setA_spellout_1sg :
     entry is selected: "tz'=". -/
 theorem setB_intransitive_3sg :
     let inflAgreed : FeatureBundle :=
-      [.valued (.phi (.person .third)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
     spellout setBVocab inflAgreed (some .T) = some "tz'=" := by
   native_decide
 
@@ -306,7 +306,7 @@ theorem setB_transitive_default :
     vs. probe failure). -/
 theorem setB_same_surface :
     let inflAgreed3sg : FeatureBundle :=
-      [.valued (.phi (.person .third)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
     let inflBlocked : FeatureBundle := []
     spellout setBVocab inflAgreed3sg (some .T) =
     spellout setBVocab inflBlocked (some .T) := by
@@ -317,7 +317,7 @@ theorem setB_same_surface :
     agreement, producing a distinct exponent. -/
 theorem setB_intransitive_1sg :
     let t1sg : FeatureBundle :=
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     spellout setBVocab t1sg (some .T) = some "chin" := by
   native_decide
 
@@ -330,7 +330,7 @@ theorem setB_transitive_ignores_object :
     spellout setBVocab inflBlocked (some .T) = some "tz'=" ∧
     -- Compare: a 1SG intransitive S would trigger "chin"
     let inflAgreed1sg : FeatureBundle :=
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     spellout setBVocab inflAgreed1sg (some .T) = some "chin" := by
   exact ⟨by native_decide, by native_decide⟩
 
@@ -355,7 +355,7 @@ theorem probe_restriction_yields_default :
     spellout setBVocab ([] : FeatureBundle) (some .T) = some "tz'=" ∧
     -- Intransitive 1SG: probe succeeds → "chin" (not default)
     spellout setBVocab
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
       (some .T) = some "chin" := by
   exact ⟨by native_decide, by native_decide⟩
 
@@ -369,15 +369,15 @@ theorem probe_restriction_yields_default :
 theorem intransitive_pipeline_1sg :
     -- Infl Agrees with 1SG S
     (applyAgree inflProbe
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
       (.phi (.person .third))).bind
       (λ fb => applyAgree fb
-        [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
-        (.phi (.number .Sing))) =
-    some [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))] ∧
+        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
+        (.phi (.number .singular))) =
+    some [.valued (.phi (.person .first)), .valued (.phi (.number .singular))] ∧
     -- Spells out as "chin" (not default "tz'=")
     spellout setBVocab
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
       (some .T) = some "chin" := by
   exact ⟨by native_decide, by native_decide⟩
 
@@ -395,7 +395,7 @@ theorem intransitive_pipeline_1sg :
 theorem full_pipeline_3sg_transitive :
     -- Step 1-2: Voice Agrees and spells out as Set A
     (applyAgree voiceProbe dp3sg (.phi (.person .third))).bind
-      (λ fb => applyAgree fb dp3sg (.phi (.number .Sing))) = some voiceFullyAgreed ∧
+      (λ fb => applyAgree fb dp3sg (.phi (.number .singular))) = some voiceFullyAgreed ∧
     spellout setAVocab voiceFullyAgreed (some .v) = some "t-" ∧
     -- Step 3-4: Infl probe blocked → default Set B
     spellout setBVocab ([] : FeatureBundle) (some .T) = some "tz'=" ∧
@@ -485,7 +485,7 @@ theorem transitive_is_probe_failure :
     its φ-features. `attemptAgree` maps the `some _` result to `.valued`. -/
 theorem intransitive_is_real_agreement :
     attemptAgree inflProbe
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
       (.phi (.person .third)) = .valued := by
   native_decide
 
@@ -523,7 +523,7 @@ theorem satisfaction_derives_patient_no_agree :
 /-- In an intransitive clause, `mamInflSatisfaction` is satisfied by
     φ-features and DOES copy them — matching `IsPhiAgreed .S`. -/
 theorem satisfaction_derives_intranS_agree :
-    let dp1sg := [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+    let dp1sg := [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     mamInflSatisfaction.isSatisfied dp1sg none = true ∧
     mamInflSatisfaction.copiedFeatures dp1sg none = true ∧
     ArgPosition.IsPhiAgreed .S :=
@@ -537,7 +537,7 @@ theorem satisfaction_matches_fragment :
     (mamInflSatisfaction.copiedFeatures [] (some .v) = true ↔
       ArgPosition.IsPhiAgreed .P) ∧
     (mamInflSatisfaction.copiedFeatures
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
       none = true ↔
       ArgPosition.IsPhiAgreed .S) := by
   refine ⟨?_, ?_⟩
@@ -583,7 +583,7 @@ def mamImpoverishmentRule : Morphology.DM.Impoverishment.ImpoverishmentRule :=
     (λ fb => fb.any (λ f => match f with
       | .valued (.phi (.person .first)) => true
       | _ => false))
-    (.phi (.number .Sing))
+    (.phi (.number .singular))
 
 /-- Mam's rule is paradigmatic — discharged by the smart constructor. -/
 theorem mamImpoverishment_paradigmatic :
@@ -594,29 +594,29 @@ theorem mamImpoverishment_paradigmatic :
 theorem impoverishment_fires_1sg :
     mamImpoverishmentRule.condition
       (Morphology.DM.Impoverishment.Neighborhood.ofBundle
-        [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]) := by
+        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]) := by
   decide
 
 /-- The impoverishment rule does NOT fire for 3rd person bundles. -/
 theorem impoverishment_blocked_3sg :
     ¬ mamImpoverishmentRule.condition
         (Morphology.DM.Impoverishment.Neighborhood.ofBundle
-          [.valued (.phi (.person .third)), .valued (.phi (.number .Sing))]) := by
+          [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]) := by
   decide
 
 /-- After impoverishment, the number feature is deleted from 1st
     person bundles, bleeding insertion of the base morpheme *qin*. -/
 theorem impoverishment_deletes_number :
     mamImpoverishmentRule.applyToBundle
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))] =
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))] =
     [.valued (.phi (.person .first))] := by
   decide
 
 /-- Without impoverishment (3rd person), the number feature survives. -/
 theorem no_impoverishment_preserves :
     mamImpoverishmentRule.applyToBundle
-      [.valued (.phi (.person .third)), .valued (.phi (.number .Sing))] =
-    [.valued (.phi (.person .third)), .valued (.phi (.number .Sing))] := by
+      [.valued (.phi (.person .third)), .valued (.phi (.number .singular))] =
+    [.valued (.phi (.person .third)), .valued (.phi (.number .singular))] := by
   decide
 
 end AgreeSpellout

--- a/Linglib/Syntax/Minimalist/Agree.lean
+++ b/Linglib/Syntax/Minimalist/Agree.lean
@@ -265,10 +265,10 @@ structure TAgree where
   subjFeatures : FeatureBundle
   -- T has unvalued phi
   t_has_uphi : hasUnvaluedFeature tFeatures (.phi (.person .third)) = true ∨
-               hasUnvaluedFeature tFeatures (.phi (.number .Sing)) = true
+               hasUnvaluedFeature tFeatures (.phi (.number .singular)) = true
   -- Subject has valued phi
   subj_has_phi : hasValuedFeature subjFeatures (.phi (.person .third)) = true ∨
-                 hasValuedFeature subjFeatures (.phi (.number .Sing)) = true
+                 hasValuedFeature subjFeatures (.phi (.number .singular)) = true
 
 /-- C-Agree: C probes for [Q] feature
 
@@ -606,7 +606,7 @@ def mamInflSatisfaction : SatisfactionCond :=
     (no Voice_TR in the way). Feature match is satisfied → real agreement. -/
 theorem mam_intransitive_satisfied :
     mamInflSatisfaction.isSatisfied
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
       none = true := by rfl
 
 /-- Transitive environment: the probe encounters Voice_TR (category.v).
@@ -621,7 +621,7 @@ theorem mam_transitive_no_copy :
 /-- In the intransitive case, features ARE copied — yielding real agreement. -/
 theorem mam_intransitive_copies :
     mamInflSatisfaction.copiedFeatures
-      [.valued (.phi (.person .first)), .valued (.phi (.number .Sing))]
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
       none = true := by rfl
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Features.lean
+++ b/Linglib/Syntax/Minimalist/Features.lean
@@ -1,6 +1,7 @@
 import Linglib.Features.Case
 import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
+import Linglib.Features.Number.Basic
 
 /-!
 # Feature Infrastructure for Minimalist Agree
@@ -58,7 +59,7 @@ open Features.Prominence
 /-- Phi-features (agreement features). -/
 inductive PhiFeature where
   | person : Person → PhiFeature
-  | number : UD.Number → PhiFeature      -- grammatical number (UD.Number)
+  | number : Number → PhiFeature         -- grammatical number (canonical inventory)
   | gender : Nat → PhiFeature        -- language-specific encoding
   deriving Repr, DecidableEq
 

--- a/Linglib/Syntax/Pronoun/Basic.lean
+++ b/Linglib/Syntax/Pronoun/Basic.lean
@@ -115,8 +115,10 @@ structure Pronoun where
       `firstInclusive`, *kami* = `firstExclusive`; English *we* = plain
       `first` ([cysouw-2009]). -/
   person : Option Person := none
-  /-- Grammatical number. -/
-  number : Option UD.Number := none
+  /-- Grammatical number — the canonical analytical inventory (root
+      `Number`); UD realization via `Number.toUD` (partial: the
+      minimal/augmented values have no UD tag). -/
+  number : Option Number := none
   /-- Grammatical case. -/
   case_ : Option Features.Case := none
   /-- Grammatical gender. For 3rd-person pronouns in gendered languages
@@ -185,7 +187,8 @@ open Features (SurfaceGender)
     surface as adverbs) stay in the relevant fragment. -/
 def toWord (p : Pronoun) : Word :=
   { form := p.form, cat := .PRON,
-    features := { person := p.person.map Person.toUD, number := p.number,
+    features := { person := p.person.map Person.toUD,
+                  number := p.number.bind Number.toUD,
                   case_ := p.case_,
                   gender := p.gender.bind (·.toUDGender),
                   -- carry the binding-relevant morphology so a projected pro-form's class is
@@ -214,7 +217,8 @@ def category (p : Pronoun) : Option Person.Category :=
     mathlib way) so illegal states are catchable without fragmenting the type. -/
 def WellFormed (p : Pronoun) : Prop :=
   ∀ per, p.person = some per → per.MarksClusivity →
-    p.number = some .Dual ∨ p.number = some .Plur
+    p.number = some .dual ∨ p.number = some .plural ∨
+    p.number = some .minimal ∨ p.number = some .augmented
 
 instance (p : Pronoun) : Decidable p.WellFormed := by
   unfold WellFormed; infer_instance

--- a/Linglib/Syntax/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Pronoun/Capabilities.lean
@@ -111,15 +111,20 @@ theorem bindingClassOf_toWord (p : Pronoun) (h : p.bindingClass ≠ some .rExpre
 
 /-! ### The number axis: `HasNumber` instances and faithfulness -/
 
-/-- A pronoun bears the number its φ-slot ingests (`Number.fromUD`). -/
-instance : HasNumber Pronoun := ⟨fun p => p.number.bind Number.fromUD⟩
+/-- A pronoun bears its analytical number directly — the carrier field is
+root-`Number`-typed. -/
+instance : HasNumber Pronoun := ⟨fun p => p.number⟩
 instance : HasNumber PersonalPronoun := ⟨fun p => HasNumber.numberOf p.toPronoun⟩
 
-/-- Projecting a pronoun to a `Word` preserves its number: the mixin reads
-the same value off the carrier and off the projected token (`Pronoun.toWord`
-threads `number` faithfully). -/
+/-- Projecting a pronoun to a `Word` realizes its number through UD: the
+round-trip is identity exactly on UD-expressible values — the
+minimal/augmented values are lost to realization (`Number.toUD` is
+partial), the number analogue of `personOf_toWord`'s coarsening. -/
 theorem numberOf_toWord (p : Pronoun) :
-    HasNumber.numberOf p.toWord = HasNumber.numberOf p := rfl
+    HasNumber.numberOf p.toWord =
+      p.number.bind fun n => n.toUD.bind Number.fromUD := by
+  show (p.number.bind Number.toUD).bind Number.fromUD = _
+  cases p.number <;> rfl
 
 /-! ### The person axis: `HasPerson` instances and faithfulness -/
 


### PR DESCRIPTION
Number's phase 3, closing the asymmetry the Person arc exposed: `Pronoun.number` is now root-`Number`-typed (matching its person sibling), as are Kiche's `PhiFeatures.number` and the Minimalist `PhiFeature.number` constructor; ~90 literal sites swept error-driven across 14 files (`.Sing → .singular` etc.). `numberOf_toWord` makes realization loss explicit — `Number.toUD` is partial (minimal/augmented have no UD tag), the number analogue of `personOf_toWord`'s coarsening. `Category.ofPersonNumber` upgrades to root `Number`, which makes Tagalog *kata*'s category derivable at last (`(firstInclusive, minimal) ↦ minIncl`, the #147 junction coordinates).

Second commit, from verifying against the Cysouw PDF while sweeping:
- **Fig 10.8 verified** (the `Number.Stage` N1–N4 citation was the last flagged-unverified item — it matches the source's hierarchical tree of number oppositions exactly).
- **`PersonStage` corrected**: Fig 10.7's columns put unified-we and no-we at P2 and only-inclusive at P3; the previous classification ran one stage low (English pronouns and Pirahã are now correctly P2, with the correction documented in the docstring).
- `UD.MorphFeatures.compatible_hasPerson` — the missing person analogue of the number faithfulness theorem; plus `HasPerson` for Kiche.