### PR TITLE
feat(Syntax/Agreement): hierarchy constraint over split features

### DIFF
--- a/Linglib/Core/Order/Flat.lean
+++ b/Linglib/Core/Order/Flat.lean
@@ -165,6 +165,27 @@ instance [DecidableEq α] : PartialUnify (Flat α) where
           if x = y then some (some x) else none from rfl, if_pos hxy]
       rfl
 
+/-- Slot compatibility, characterized: committed values must coincide;
+    an uncommitted slot is a wildcard. -/
+theorem compat_iff [DecidableEq α] {a b : Flat α} :
+    Compat a b ↔ ∀ x : α, a = some x → ∀ y : α, b = some y → x = y := by
+  rw [compat_iff_isSome_unify]
+  show (Flat.unify a b).isSome = true ↔ _
+  match a, b with
+  | none, b =>
+    exact iff_of_true rfl (λ x hx => nomatch hx)
+  | some x, none =>
+    exact iff_of_true rfl (λ x' _ y hy => nomatch hy)
+  | some x, some y =>
+    show (if x = y then some (some x : Flat α) else none).isSome = true ↔ _
+    by_cases hxy : x = y
+    · subst hxy
+      exact iff_of_true (by rw [if_pos rfl]; rfl)
+        (λ x' hx' y' hy' =>
+          (Option.some.inj hx').symm.trans (Option.some.inj hy'))
+    · rw [if_neg hxy]
+      exact iff_of_false (by simp) (λ h => hxy (h x rfl y rfl))
+
 /-! ### The flat lattice is non-distributive
 
 A flat slot with three distinct atoms, lifted with a top, is the

--- a/Linglib/Core/Order/PartialUnify.lean
+++ b/Linglib/Core/Order/PartialUnify.lean
@@ -205,3 +205,56 @@ instance : PartialUnify ((t : F) → S t) where
 end Pi
 
 end PartialUnify
+
+/-! ### Compatibility
+
+The consistency relation of unification: two elements are compatible when
+they have a common upper bound — equivalently (`compat_iff_isSome_unify`),
+when they unify. On feature carriers this is the agreement relation
+([carpenter-1992]; [shieber-1986]'s "compatible"). -/
+
+section Compat
+
+variable {α β : Type*}
+
+/-- Two elements are compatible: bounded above — the consistency relation
+    of unification. An `abbrev` so the `BddAbove` API applies directly. -/
+abbrev Compat [Preorder α] (a b : α) : Prop :=
+  BddAbove ({a, b} : Set α)
+
+/-- A common upper bound witnesses compatibility. -/
+theorem Compat.of_le [Preorder α] {a b u : α} (ha : a ≤ u) (hb : b ≤ u) :
+    Compat a b :=
+  ⟨u, PartialUnify.mem_upperBounds_pair.mpr ⟨ha, hb⟩⟩
+
+theorem Compat.symm [Preorder α] {a b : α} (h : Compat a b) : Compat b a := by
+  obtain ⟨u, hu⟩ := h
+  obtain ⟨ha, hb⟩ := PartialUnify.mem_upperBounds_pair.mp hu
+  exact Compat.of_le hb ha
+
+theorem compat_self [Preorder α] (a : α) : Compat a a :=
+  Compat.of_le le_rfl le_rfl
+
+/-- `⊥` is a wildcard: compatible with everything. -/
+theorem bot_compat [Preorder α] [OrderBot α] (a : α) : Compat (⊥ : α) a :=
+  Compat.of_le bot_le le_rfl
+
+theorem compat_bot [Preorder α] [OrderBot α] (a : α) : Compat a (⊥ : α) :=
+  Compat.of_le le_rfl bot_le
+
+/-- Monotone maps preserve compatibility. -/
+theorem Monotone.compat [Preorder α] [Preorder β] {f : α → β}
+    (hf : Monotone f) {a b : α} (h : Compat a b) : Compat (f a) (f b) := by
+  obtain ⟨u, hu⟩ := h
+  obtain ⟨ha, hb⟩ := PartialUnify.mem_upperBounds_pair.mp hu
+  exact Compat.of_le (hf ha) (hf hb)
+
+/-- Compatibility is decided by unification. -/
+theorem compat_iff_isSome_unify [PartialOrder α] [PartialUnify α] {a b : α} :
+    Compat a b ↔ (PartialUnify.unify a b).isSome :=
+  PartialUnify.isSome_unify_iff_bddAbove.symm
+
+instance [PartialOrder α] [PartialUnify α] (a b : α) : Decidable (Compat a b) :=
+  decidable_of_iff _ PartialUnify.isSome_unify_iff_bddAbove
+
+end Compat

--- a/Linglib/Features/Gender/Capabilities.lean
+++ b/Linglib/Features/Gender/Capabilities.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.Order.Flat
 import Linglib.Features.Gender.Basic
 
 /-!
@@ -42,24 +43,25 @@ namespace HasGender
 variable {α : Type*} {β : Type*} [HasGender α] [HasGender β]
 
 /-- Gender compatibility between two (possibly heterogeneous) carriers:
-    valued genders must coincide; an unvalued carrier is a wildcard.
+    the slot values are compatible in the flat information order (`Compat`)
+    — valued genders must coincide; an unvalued carrier is a wildcard.
     The gender axis of φ-agreement (`UD.MorphFeatures.compatible`). -/
 def Compatible (a : α) (b : β) : Prop :=
-  ∀ ga ∈ genderOf a, ∀ gb ∈ genderOf b, ga = gb
+  Compat (α := Flat Gender) (genderOf a) (genderOf b)
 
 instance (a : α) (b : β) : Decidable (Compatible a b) := by
   unfold Compatible; infer_instance
 
 theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
     Compatible b a :=
-  fun gb hb ga ha => (h ga ha gb hb).symm
+  h.symm
 
 /-- An unvalued carrier is compatible with everything. -/
 theorem compatible_of_none {a : α} (h : genderOf a = none) (b : β) :
     Compatible a b := by
-  intro ga ha
-  rw [h] at ha
-  exact absurd ha (Option.not_mem_none _)
+  unfold Compatible
+  rw [h]
+  exact bot_compat _
 
 end HasGender
 
@@ -69,13 +71,15 @@ end HasGender
 theorem UD.MorphFeatures.compatible_hasGender {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasGender.Compatible f1 f2 := by
+  unfold HasGender.Compatible
+  rw [Flat.compat_iff]
   intro ga ha gb hb
   have hg : (f1.gender.isNone || f2.gender.isNone || f1.gender == f2.gender)
       = true := by
     unfold UD.MorphFeatures.compatible at h
     simp only [Bool.and_eq_true] at h
     tauto
-  simp only [HasGender.genderOf, Option.mem_def] at ha hb
+  simp only [HasGender.genderOf] at ha hb
   rcases h1 : f1.gender with _ | u1
   · rw [h1] at ha
     exact absurd ha (Option.not_mem_none _)

--- a/Linglib/Features/Number/Capabilities.lean
+++ b/Linglib/Features/Number/Capabilities.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.Order.Flat
 import Linglib.Features.Number.Basic
 
 /-!
@@ -49,24 +50,25 @@ namespace HasNumber
 variable {α : Type*} {β : Type*} [HasNumber α] [HasNumber β]
 
 /-- Number compatibility between two (possibly heterogeneous) carriers:
-    valued numbers must coincide; an unvalued carrier is a wildcard.
+    the slot values are compatible in the flat information order (`Compat`)
+    — valued numbers must coincide; an unvalued carrier is a wildcard.
     The number axis of φ-agreement (`UD.MorphFeatures.compatible`). -/
 def Compatible (a : α) (b : β) : Prop :=
-  ∀ na ∈ numberOf a, ∀ nb ∈ numberOf b, na = nb
+  Compat (α := Flat Number) (numberOf a) (numberOf b)
 
 instance (a : α) (b : β) : Decidable (Compatible a b) := by
   unfold Compatible; infer_instance
 
 theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
     Compatible b a :=
-  fun nb hb na ha => (h na ha nb hb).symm
+  h.symm
 
 /-- An unvalued carrier is compatible with everything. -/
 theorem compatible_of_none {a : α} (h : numberOf a = none) (b : β) :
     Compatible a b := by
-  intro na ha
-  rw [h] at ha
-  exact absurd ha (Option.not_mem_none _)
+  unfold Compatible
+  rw [h]
+  exact bot_compat _
 
 end HasNumber
 
@@ -76,13 +78,15 @@ end HasNumber
 theorem UD.MorphFeatures.compatible_hasNumber {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasNumber.Compatible f1 f2 := by
+  unfold HasNumber.Compatible
+  rw [Flat.compat_iff]
   intro na ha nb hb
   have hn : (f1.number.isNone || f2.number.isNone || f1.number == f2.number)
       = true := by
     unfold UD.MorphFeatures.compatible at h
     simp only [Bool.and_eq_true] at h
     tauto
-  simp only [HasNumber.numberOf, Option.mem_def] at ha hb
+  simp only [HasNumber.numberOf] at ha hb
   rcases h1 : f1.number with _ | u1
   · rw [h1] at ha
     exact absurd ha (Option.not_mem_none _)

--- a/Linglib/Features/Person/Capabilities.lean
+++ b/Linglib/Features/Person/Capabilities.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.Order.Flat
 import Linglib.Features.Person.Basic
 
 /-!
@@ -32,22 +33,25 @@ namespace HasPerson
 
 variable {α β : Type*} [HasPerson α] [HasPerson β]
 
-/-- Two carriers are person-compatible: if both mark person, the values
-    agree. Unmarked carriers are compatible with everything. -/
+/-- Two carriers are person-compatible: the slot values are compatible in
+    the flat information order (`Compat`) — if both mark person, the values
+    agree; unmarked carriers are wildcards. -/
 def Compatible (a : α) (b : β) : Prop :=
-  ∀ p q, personOf a = some p → personOf b = some q → p = q
+  Compat (α := Flat Person) (personOf a) (personOf b)
 
 instance (a : α) (b : β) : Decidable (Compatible a b) := by
   unfold Compatible
   infer_instance
 
 theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
-    Compatible b a := fun p q hp hq => (h q p hq hp).symm
+    Compatible b a :=
+  h.symm
 
-theorem compatible_of_none {a : α} {b : β} (h : personOf a = none) :
-    Compatible a b := fun p _ hp _ => by
-  rw [h] at hp
-  exact absurd hp (by simp)
+theorem compatible_of_none {a : α} (h : personOf a = none) (b : β) :
+    Compatible a b := by
+  unfold Compatible
+  rw [h]
+  exact bot_compat _
 
 end HasPerson
 
@@ -58,7 +62,9 @@ end HasPerson
 theorem UD.MorphFeatures.compatible_hasPerson {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasPerson.Compatible f1 f2 := by
-  intro pa pb ha hb
+  unfold HasPerson.Compatible
+  rw [Flat.compat_iff]
+  intro pa ha pb hb
   have hp : (f1.person.isNone || f2.person.isNone || f1.person == f2.person)
       = true := by
     unfold UD.MorphFeatures.compatible at h
@@ -76,5 +82,6 @@ theorem UD.MorphFeatures.compatible_hasPerson {f1 f2 : UD.MorphFeatures}
       rw [h1, h2] at hp
       simp only [Option.isNone_some, Bool.false_or, beq_iff_eq,
         Option.some.injEq] at hp
-      simp only [Option.map_some, Option.some.injEq] at ha hb
-      rw [← ha, ← hb, hp]
+      simp only [Option.map_some] at ha hb
+      subst hp
+      exact (Option.some.inj ha).symm.trans (Option.some.inj hb)

--- a/Linglib/Morphology/Word.lean
+++ b/Linglib/Morphology/Word.lean
@@ -101,8 +101,7 @@ instance : HasPerson Word := ⟨fun w => w.features.person.map Person.fromUD⟩
     diverges from the agreement engine on `Word`. -/
 theorem Word.Agree.hasNumber_compatible {w1 w2 : Word} (h : w1.Agree w2) :
     HasNumber.Compatible w1 w2 :=
-  fun na ha nb hb =>
-    UD.MorphFeatures.compatible_hasNumber (f1 := w1.phi) (f2 := w2.phi) h na ha nb hb
+  UD.MorphFeatures.compatible_hasNumber (f1 := w1.phi) (f2 := w2.phi) h
 
 -- `reflex` is deliberately not an agreement feature: a reflexive-marked token still
 -- agrees with an unmarked one (the φ-projection drops it).


### PR DESCRIPTION
The agreement keystone, phase 1 — Syntax/Agreement finally speaks Features through one order-theoretic relation.

- `Compat a b := BddAbove {a, b}` named once in Core/Order (Carpenter/Shieber consistency), with `Monotone.compat`, wildcard/symmetry lemmas, and decidability via `PartialUnify`; the three φ-mixin `Compatible`s derive it on the `Flat` slot order (triplicated defs and proofs deleted).
- `SplitFeature` hoists to `Features/SplitFeature.lean` at its second consumer, gaining `Half` (uF/iF — concord vs index) and `proj`.
- New `Syntax/Agreement/Hierarchy.lean`: Corbett's monotonicity claim formalized as `HierarchyCompliant := IsLowerSet {t | pattern t = .iF}`, with `card_compliant = 6` (cuts of the 5-chain), Smith 2021's 3/4-pattern theorem, `Realizes` (target valuations check against split-feature controllers via `Compat`), and the *committee has…they / have…it* contrast end-to-end by `decide`. The `verb`-rank anomaly is documented, not silently re-ranked.