### PR TITLE
style(Semantics/Composition): drop redundant ASCII section banners

### DIFF
--- a/Linglib/Semantics/Composition/Applicative.lean
+++ b/Linglib/Semantics/Composition/Applicative.lean
@@ -34,9 +34,6 @@ set_option autoImplicit false
 
 namespace Semantics.Composition.Applicative
 
--- ════════════════════════════════════════════════════════════════
--- §1 Reader Applicative
--- ════════════════════════════════════════════════════════════════
 
 /-! ### Reader applicative
 
@@ -75,9 +72,6 @@ theorem reader_composition (u : E → B → C) (v : E → A → B) (w : E → A)
 
 end ReaderApplicative
 
--- ════════════════════════════════════════════════════════════════
--- §2 Composed Applicatives
--- ════════════════════════════════════════════════════════════════
 
 /-! ### Composed applicative functors
 
@@ -125,9 +119,6 @@ theorem composed_composition (u : E₁ → E₂ → B → C)
 
 end ComposedApplicatives
 
--- ════════════════════════════════════════════════════════════════
--- §3 Variable-Free Semantics
--- ════════════════════════════════════════════════════════════════
 
 /-! ### Variable-free semantics as Reader Entity
 
@@ -170,9 +161,6 @@ theorem vf_she_saw_her_composed (saw : E → E → Bool) :
 
 end VariableFree
 
--- ════════════════════════════════════════════════════════════════
--- §4 Set Applicative
--- ════════════════════════════════════════════════════════════════
 
 /-! ### Set applicative
 
@@ -237,9 +225,6 @@ theorem set_composition (u : Set (B → C)) (v : Set (A → B))
 
 end SetApplicative
 
--- ════════════════════════════════════════════════════════════════
--- §5 Continuation Applicative
--- ════════════════════════════════════════════════════════════════
 
 /-! ### Continuation applicative
 
@@ -265,9 +250,6 @@ theorem cont_ap_eq (m : Cont R (A → B)) (n : Cont R A) :
 
 end ContinuationApplicative
 
--- ════════════════════════════════════════════════════════════════
--- §6 Typed Assignment Family
--- ════════════════════════════════════════════════════════════════
 
 /-! ### Typed assignment family Gᵣ
 

--- a/Linglib/Semantics/Composition/Continuation.lean
+++ b/Linglib/Semantics/Composition/Continuation.lean
@@ -56,9 +56,6 @@ def Cont.lower (m : Cont A A) : A := m id
     ``` -/
 abbrev Tower (C : Type u) (B : Type v) (A : Type w) := (A → B) → C
 
--- ════════════════════════════════════════════════════
--- § Monad instance
--- ════════════════════════════════════════════════════
 
 /-! The continuation monad's laws (left/right identity, associativity, and the
 functor laws) are exactly those of `LawfulMonad`, so we register `Cont R` as a

--- a/Linglib/Semantics/Composition/MaybeMonad.lean
+++ b/Linglib/Semantics/Composition/MaybeMonad.lean
@@ -57,9 +57,6 @@ namespace Semantics.Composition.MaybeMonad
 open Core.Duality (Truth3 Prop3)
 open Semantics.Presupposition (PrProp)
 
--- ════════════════════════════════════════════════════════════════
--- §1 Connectives on Option Bool
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §1 Connectives on `Option Bool`
 
@@ -133,9 +130,6 @@ private theorem foldl_meetWK_none {α : Type} (ys : List α) (φ : α → Option
 
 end Connectives
 
--- ════════════════════════════════════════════════════════════════
--- §2 The Intensional-Presuppositional Monad Iₚ
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §2 The monad `Iₚ`
 
@@ -162,9 +156,6 @@ abbrev Iₚ (I : Type) := ReaderT I Option
 
 end IMonad
 
--- ════════════════════════════════════════════════════════════════
--- §3 Monad Laws for Iₚ
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §3 Monad laws
 
@@ -176,9 +167,6 @@ no scope; Grove fn. 13), and Associativity makes cyclic scope-taking
 (roll-up pied-piping) sound (the presuppositional analog of
 [charlow-2020]'s ASSOCIATIVITY theorem for the set monad). -/
 
--- ════════════════════════════════════════════════════════════════
--- §4 Semantic Operations
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §4 Evaluation and presuppositional universal
 
@@ -247,9 +235,6 @@ theorem forallP_undef {α : Type} (xs : List α) (φ : α → Option Bool)
 
 end Operations
 
--- ════════════════════════════════════════════════════════════════
--- §5 Attitude Verb Semantics
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §5 `believe` via doxastic accessibility
 
@@ -274,9 +259,6 @@ def believe (dox : E → W → W → Bool) (worlds : List W)
 
 end AttitudeVerbs
 
--- ════════════════════════════════════════════════════════════════
--- §6 Bridges
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §6 Bridges to existing linglib types
 

--- a/Linglib/Semantics/Composition/SetMonad.lean
+++ b/Linglib/Semantics/Composition/SetMonad.lean
@@ -36,9 +36,6 @@ namespace Semantics.Composition.SetMonad
 
 open Semantics.Composition.Applicative (setPure setAp)
 
--- ════════════════════════════════════════════════════════════════
--- §1 Set Monad Operations
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §1 Set monad operations
 
@@ -87,9 +84,6 @@ def setMap (f : A → B) (m : Set A) : Set B := f <$> m
 
 end Operations
 
--- ════════════════════════════════════════════════════════════════
--- §2 Monad Laws
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §2 Monad laws
 
@@ -128,9 +122,6 @@ theorem set_associativity (m : Set A) (f : A → Set B) (g : B → Set C) :
 
 end MonadLaws
 
--- ════════════════════════════════════════════════════════════════
--- §3 Closure Operators
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §3 Closure operators
 
@@ -156,9 +147,6 @@ def existsClosure (m : Prop → Prop) : Prop := ∃ p, m p ∧ p
 
 end Closure
 
--- ════════════════════════════════════════════════════════════════
--- §4 Bridge to Applicative.lean
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §4 Bridge to Applicative.lean
 
@@ -194,9 +182,6 @@ theorem setAp_from_setBind (m : Set (A → B)) (n : Set A) :
 
 end ApplicativeBridge
 
--- ════════════════════════════════════════════════════════════════
--- §5 LIFT Decomposition
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §5 LIFT decomposition
 
@@ -239,9 +224,6 @@ theorem lift_eq_A_eta (domain : List F.Entity) (j : F.Entity)
 
 end LiftDecomposition
 
--- ════════════════════════════════════════════════════════════════
--- §6 Higher-Order Alternative Sets
--- ════════════════════════════════════════════════════════════════
 
 /-! ### §6 Higher-order alternative sets
 


### PR DESCRIPTION
Strip `-- ════` divider lines and `-- §N Name` orphan section comments from Applicative, Continuation, MaybeMonad, SetMonad. Each banner had a `/-! ### -/` markdown header below it (invisible to doc-gen4 without the conversion); the banners were pure redundant noise.