### PR TITLE
fix(Semantics/Composition): repair indeterminacy_bind_is_seq elaboration

### DIFF
--- a/Linglib/Semantics/Composition/Effects.lean
+++ b/Linglib/Semantics/Composition/Effects.lean
@@ -1006,10 +1006,10 @@ theorem indeterminacy_pure_is_singleton {A : Type} (x : A) :
     `m : Set A` (= `A → Prop`) and `f : A → Set B`, the result at `b`
     is `∃ a, m a ∧ f a b`. -/
 theorem indeterminacy_bind_is_seq {A B : Type}
-    (m : A → Prop) (f : A → B → Prop) :
-    ((m : Set A) >>= f) = fun b => ∃ a, m a ∧ f a b := by
+    (m : Set A) (f : A → Set B) :
+    m >>= f = {b | ∃ a, m a ∧ f a b} := by
   ext b
-  simp only [Set.bind_def, Set.mem_iUnion, exists_prop]
+  simp only [Set.bind_def, Set.mem_iUnion, Set.mem_setOf_eq, exists_prop]
   rfl
 
 /-- **Indeterminacy obeys ASSOCIATIVITY** — the property [charlow-2020]


### PR DESCRIPTION
Hotfix for #161, which I pushed without a local build (CI toolchain flake masked it; merged before the rerun completed). `indeterminacy_bind_is_seq` doesn't elaborate: with binders typed `A → Prop` / `A → B → Prop`, instance resolution can't see `Set` to find the monad. Binders retyped `Set A` / `A → Set B`, RHS as set-builder. Fix verified compiling locally (identical change in the in-flight Applicative-dissolution branch). 3 lines.