### PR TITLE
refactor(Syntax): move Y-model Tree out of Core into Syntax/Tree

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -45,7 +45,8 @@ import Linglib.Core.Logic.Team.Closure
 import Linglib.Core.Logic.Team.Definability
 import Linglib.Features.Acceptability
 import Linglib.Semantics.Dynamic.ParameterizedUpdate
-import Linglib.Core.Tree
+import Linglib.Syntax.Tree.Basic
+import Linglib.Syntax.Tree.Cat
 import Linglib.Features.Coordination
 import Linglib.Core.Logic.Duality
 import Linglib.Core.Logic.Quantification

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -36,7 +36,7 @@ namespace Morphology.Nanosyntax
 -- §1: NanoTree
 -- ============================================================================
 
-/-- A nanosyntactic feature tree. Simpler than `Core.Tree` — no
+/-- A nanosyntactic feature tree. Simpler than `Syntax` — no
     traces, no binding, no category/word split. Just labeled nodes
     with an ordered list of daughters.
 

--- a/Linglib/Semantics/Alternatives/Structural.lean
+++ b/Linglib/Semantics/Alternatives/Structural.lean
@@ -1,6 +1,6 @@
 import Mathlib.Logic.Relation
 import Mathlib.Data.Set.Basic
-import Linglib.Core.Tree
+import Linglib.Syntax.Tree.Cat
 import Linglib.Semantics.Alternatives.Source
 
 /-!
@@ -42,7 +42,7 @@ structural operations. For φ = "John ate some of the cake":
 
 ## Tree Type
 
-Uses the unified `Tree C W` from `Core.Tree`. All definitions are
+Uses the unified `Tree C W` from `Syntax`. All definitions are
 parameterized over the category type `C`, so they work with UD-grounded
 `Cat`, framework-specific categories, or any `C` with `BEq`/`DecidableEq`.
 
@@ -58,7 +58,7 @@ parameterized over the category type `C`, so they work with UD-grounded
 
 namespace Alternatives.Structural
 
-open Core.Tree
+open Syntax
 open Tree
 
 -- ═══════════════════════════════════════════════════════════════════════

--- a/Linglib/Semantics/Composition/Tree.lean
+++ b/Linglib/Semantics/Composition/Tree.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Tree
+import Linglib.Syntax.Tree.Basic
 import Linglib.Core.Logic.Intensional.Frame
 import Linglib.Core.Logic.Intensional.Variables
 import Linglib.Semantics.Composition.LexEntry
@@ -168,7 +168,7 @@ def interpBinary {F : Frame} {M : Type → Type} [Applicative M]
 
 /-! ### Tree interpretation -/
 
-open Core.Tree
+open Syntax
 
 section TreeInterp
 

--- a/Linglib/Studies/Asudeh2022.lean
+++ b/Linglib/Studies/Asudeh2022.lean
@@ -433,7 +433,7 @@ theorem glue_inverse_false : ¬glue_inverse_meaning := by
     engine. -/
 
 open Semantics.Scope
-open Core.Tree
+open Syntax
 open Semantics.Composition.Tree
 open Core.Logic.Intensional.Variables
 

--- a/Linglib/Studies/BaleKhanjian2014.lean
+++ b/Linglib/Studies/BaleKhanjian2014.lean
@@ -1,5 +1,5 @@
 import Mathlib.Data.Fintype.Powerset
-import Linglib.Core.Tree
+import Linglib.Syntax.Tree.Cat
 import Linglib.Semantics.Alternatives.Structural
 import Linglib.Fragments.Armenian.ClassifierSystem
 
@@ -77,7 +77,7 @@ with classifiers).
 - A toy 3-boy domain with both general-number and strict-plural denotations
   (per eq. 9).
 - The four syntactic structures (eqs. 21, 20, 32a, 32b) as `Tree Cat String`,
-  reusing `Core.Tree`.
+  reusing `Syntax`.
 - Two structural-complexity theorems via `Tree.size`: indefinite plural
   is *strictly larger* than indefinite singular (no Katzir competition);
   definite plural is *equal in size* to definite singular (Katzir
@@ -113,7 +113,7 @@ set_option autoImplicit false
 
 namespace BaleKhanjian2014
 
-open Core.Tree
+open Syntax
 
 -- ============================================================================
 -- §1: Toy domain (eq. 9)

--- a/Linglib/Studies/BarkerPullum1990.lean
+++ b/Linglib/Studies/BarkerPullum1990.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Tree
+import Linglib.Syntax.Tree.Cat
 import Linglib.Core.Order.Tree
 import Linglib.Core.Order.Command
 import Mathlib.Data.Set.Basic
@@ -54,8 +54,8 @@ inductive Dir where | L | R
 /-- Address = path from root -/
 abbrev Address := List Dir
 
-open Core.Tree (Tree)
-open Core.Tree.Tree (leaf bin)
+open Syntax (Tree)
+open Syntax.Tree (leaf bin)
 
 /-- Get subtree at address (binary branching only) -/
 def atAddr {W : Type} : Tree Unit W → Address → Option (Tree Unit W)

--- a/Linglib/Studies/Bruening2025.lean
+++ b/Linglib/Studies/Bruening2025.lean
@@ -39,8 +39,8 @@ proving c-selection is not reducible to s-selection.
 namespace Bruening2025
 
 open BrueningAlKhalaf2020
-open Core.Tree (Cat)
-open Core.Tree.Cat (NP AdvP AdjP)
+open Syntax (Cat)
+open Syntax.Cat (NP AdvP AdjP)
 
 -- ============================================================================
 -- § 1: Experiment Data Structure

--- a/Linglib/Studies/BrueningAlKhalaf2020.lean
+++ b/Linglib/Studies/BrueningAlKhalaf2020.lean
@@ -1,6 +1,6 @@
 import Linglib.Typology.WordOrder
 import Linglib.Features.Coordination
-import Linglib.Core.Tree
+import Linglib.Syntax.Tree.Cat
 import Linglib.Syntax.Minimalist.Basic
 import Linglib.Fragments.English.WordOrder
 import Mathlib.Data.Finset.Basic
@@ -47,8 +47,8 @@ DP-first (~77%), supporting bottom-up accounts instead.
 namespace BrueningAlKhalaf2020
 
 open Features.Coordination
-open Core.Tree (Cat)
-open Core.Tree.Cat (NP VP AdjP AdvP PP)
+open Syntax (Cat)
+open Syntax.Cat (NP VP AdjP AdvP PP)
 open Typology.WordOrder
 
 -- ============================================================================
@@ -288,7 +288,7 @@ inductive Supercategory where
   deriving DecidableEq, Repr
 
 /-- Categories belonging to each supercategory, grounded in the `Cat`
-    category system from `Core.Tree`. The inclusion order on `Finset Cat`
+    category system from `Syntax`. The inclusion order on `Finset Cat`
     gives the lattice structure: `Supercategory.cats .pred` and
     `Supercategory.cats .mod` are elements ordered by ⊆. -/
 def Supercategory.cats : Supercategory → Finset Cat

--- a/Linglib/Studies/FoxKatzir2011.lean
+++ b/Linglib/Studies/FoxKatzir2011.lean
@@ -203,10 +203,10 @@ subset of our `formalAlternatives`.
     with contextually salient material, enabling examples like
     Matsumoto's "warm"/"a little bit more than warm" (ex. 36). -/
 def substitutionSourceFC {C W : Type}
-    (lexicon : List (Core.Tree.Tree C W))
-    (φ : Core.Tree.Tree C W)
-    (salient : List (Core.Tree.Tree C W)) :
-    List (Core.Tree.Tree C W) :=
+    (lexicon : List (Syntax.Tree C W))
+    (φ : Syntax.Tree C W)
+    (salient : List (Syntax.Tree C W)) :
+    List (Syntax.Tree C W) :=
   lexicon ++ φ.subtrees ++ salient
 
 /-- Structural alternatives with contextual extension (definition 37).
@@ -216,10 +216,10 @@ def substitutionSourceFC {C W : Type}
     When `salient = []`, this reduces to [katzir-2007]'s original
     `structuralAlternatives` (modulo the focus restriction; see above). -/
 def formalAlternatives {C W : Type}
-    (lex : List (Core.Tree.Tree C W))
-    (φ : Core.Tree.Tree C W)
-    (salient : List (Core.Tree.Tree C W)) :
-    Set (Core.Tree.Tree C W) :=
+    (lex : List (Syntax.Tree C W))
+    (φ : Syntax.Tree C W)
+    (salient : List (Syntax.Tree C W)) :
+    Set (Syntax.Tree C W) :=
   {ψ | Alternatives.Structural.atMostAsComplex
     (substitutionSourceFC lex φ salient) ψ φ}
 

--- a/Linglib/Studies/Guerrini2026.lean
+++ b/Linglib/Studies/Guerrini2026.lean
@@ -1846,7 +1846,7 @@ open Core.Logic.Intensional (Frame)
 open Semantics.Montague (Lexicon)
 open Semantics.Composition.Tree
 open Semantics.Quantification.CovertQuantifier (genThreshold dist dpp)
-open Core.Tree
+open Syntax
 
 /-- Demo entity domain: three individual lions plus the lion-kind
     (the maximal sum ∩lions_{s₀}, treated as a fourth entity). -/

--- a/Linglib/Studies/HeimKratzer1998.lean
+++ b/Linglib/Studies/HeimKratzer1998.lean
@@ -1,3 +1,4 @@
+import Linglib.Syntax.Tree.Cat
 import Linglib.Semantics.Composition.Tree
 import Linglib.Core.Logic.Intensional.Variables
 import Linglib.Semantics.Composition.ToyDomain
@@ -53,7 +54,7 @@ namespace HeimKratzer1998
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
 open Semantics.Montague
-open Core.Tree
+open Syntax
 open Semantics.Composition.Tree
 open Semantics.Quantification.Quantifier
 

--- a/Linglib/Studies/JereticEtAl2025.lean
+++ b/Linglib/Studies/JereticEtAl2025.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Number.Decomposition
-import Linglib.Core.Tree
+import Linglib.Syntax.Tree.Cat
 import Linglib.Semantics.Quantification.Lexicon
 import Linglib.Semantics.Alternatives.Source
 import Linglib.Semantics.Alternatives.Indirect
@@ -513,7 +513,7 @@ with the silent witness *tous_DUAL V*.
 
 section WorkedExample
 
-open Core.Tree
+open Syntax
 open Alternatives Alternatives.Structural
 
 /-- Two domains: a 2-cup world (`w2`) and a 3-cup world (`w3`).

--- a/Linglib/Studies/Katzir2007.lean
+++ b/Linglib/Studies/Katzir2007.lean
@@ -1,3 +1,4 @@
+import Linglib.Syntax.Tree.Cat
 import Linglib.Semantics.Composition.Tree
 import Linglib.Semantics.Composition.ToyDomain
 import Linglib.Semantics.Quantification.Quantifier
@@ -34,7 +35,7 @@ from being generated, licensing the scalar implicature.
 
 namespace Katzir2007
 
-open Core.Tree
+open Syntax
 open Semantics.Composition.Tree
 open Semantics.Montague (toyModel ToyEntity)
 open Semantics.Montague.ToyLexicon (sleeps_sem)

--- a/Linglib/Studies/LittleMoroneyRoyer2022.lean
+++ b/Linglib/Studies/LittleMoroneyRoyer2022.lean
@@ -1,6 +1,6 @@
 import Linglib.Typology.ClassifierSystem
 import Linglib.Core.Mereology
-import Linglib.Core.Tree
+import Linglib.Syntax.Tree.Cat
 import Linglib.Core.Logic.Assignment
 import Linglib.Core.Logic.Intensional.Frame
 import Linglib.Semantics.Composition.Tree
@@ -51,7 +51,7 @@ open Typology
 open Core.Logic.Intensional (Frame Ty)
 open Semantics.Montague (LexEntry Lexicon)
 open Semantics.Composition.Tree (interp)
-open Core.Tree (Tree)
+open Syntax (Tree)
 
 abbrev chol := Chol.classifierSystem
 abbrev shan := Shan.classifierSystem

--- a/Linglib/Studies/LoGuercio2025.lean
+++ b/Linglib/Studies/LoGuercio2025.lean
@@ -121,7 +121,7 @@ namespace LoGuercio2025
 
 open Pragmatics.Expressives
 open Alternatives.Structural
-open Core.Tree
+open Syntax
 open Data.Examples (LinguisticExample)
 
 -- BEGIN GENERATED EXAMPLES

--- a/Linglib/Studies/Rooth1992.lean
+++ b/Linglib/Studies/Rooth1992.lean
@@ -407,7 +407,7 @@ theorem bridge_qa_incongruent :
 open Core.Logic.Intensional
 -- (open removed: Assignment alias eliminated upstream)
 open Semantics.Montague (Lexicon)
-open Core.Tree
+open Syntax
 open Semantics.Composition.Tree
 
 /-- Entity domain for the focus model. -/

--- a/Linglib/Studies/Scott2021.lean
+++ b/Linglib/Studies/Scott2021.lean
@@ -1,5 +1,5 @@
 import Linglib.Typology.RelativeClause.Basic
-import Linglib.Core.Tree
+import Linglib.Syntax.Tree.Cat
 import Linglib.Fragments.Swahili.Relativization
 import Linglib.Morphology.DM.VocabularyInsertion
 import Linglib.Syntax.Minimalist.Features
@@ -42,7 +42,7 @@ Following [landau-2006] and [van-urk-2018]:
 Pronouns: [DP D [NumP Num [nP n_anim [PersP Pers:x]]]]
 Lexical DPs: [DP D [NumP Num [nP n/n_anim [√P √]]]]
 
-Modeled using `Core.Tree DPCat String` with Minimalism-grounded
+Modeled using `Syntax DPCat String` with Minimalism-grounded
 categories (D, Num, n, Pers).
 
 ## Vocabulary Insertion (FeatureBundle-Based)
@@ -79,7 +79,7 @@ instance : Inhabited DPCat := ⟨.D⟩
 -- § 2: Tree-Based DP Structure
 -- ============================================================================
 
-open Core.Tree (Tree)
+open Syntax (Tree)
 
 /-- 1SG pronoun *mi*: [DP D [NumP Num:sg [nP n_anim [PersP 1]]]]
     [scott-2021]. -/

--- a/Linglib/Studies/TrinhHaida2015.lean
+++ b/Linglib/Studies/TrinhHaida2015.lean
@@ -54,8 +54,8 @@ licenses.
 
 namespace TrinhHaida2015
 
-open Core.Tree (Tree Cat)
-open Core.Tree.Cat
+open Syntax (Tree Cat)
+open Syntax.Cat
 open Alternatives.Symmetric (isSymmetric)
 open Exhaustification (innocent predToFinset altsFromPreds)
 

--- a/Linglib/Syntax/Minimalist/SpellOut.lean
+++ b/Linglib/Syntax/Minimalist/SpellOut.lean
@@ -40,11 +40,11 @@ for the full admissibility conditions.
 
 import Linglib.Syntax.Minimalist.Basic
 import Linglib.Syntax.Minimalist.HeadFunction
-import Linglib.Core.Tree
+import Linglib.Syntax.Tree.Cat
 
 namespace Minimalist
 
-open Core.Tree
+open Syntax
 
 /-! ## LF branch of Spell-Out -/
 

--- a/Linglib/Syntax/SynGraph.lean
+++ b/Linglib/Syntax/SynGraph.lean
@@ -44,7 +44,7 @@ impossibility of sideward/downward movement.
   embedding `SyntacticObject → SynGraph` is not built — it would have to
   pick `Quot.out` or a stipulated planar representative, neither of which
   is consumer-callable cleanly.
-- `Core.Tree C W`: n-ary tree for compositional interpretation, not a
+- `Syntax C W`: n-ary tree for compositional interpretation, not a
   syntactic structure type.
 -/
 

--- a/Linglib/Syntax/Tree/Basic.lean
+++ b/Linglib/Syntax/Tree/Basic.lean
@@ -1,124 +1,80 @@
 import Mathlib.Data.List.Infix
 import Mathlib.Algebra.Free
-import Linglib.Data.UD.Basic
 import Linglib.Core.Order.Tree
-import Linglib.Morphology.Word
 
 /-!
-# Trees
+# Constituency Trees
 
-Unified tree type parameterized by node labels (`C`) and terminal content (`W`).
+The **constituency tree and LF interface format** of the Syntax layer:
+one tree type, parameterized by node labels (`C`) and terminal content
+(`W`), shared by the frameworks whose structures *are* constituency
+trees — not by all of syntax. The library has two structural hubs:
 
-## `Tree C W` — The Y-Model Tree
+1. **`Syntax.Tree` (this file)** — for constituency: H&K composition
+   reads it (LF), Katzir structural operations transform it (PF),
+   Minimalist derivations project *down* to it at Spell-Out.
+2. **`Core.Order.TreeOrder` + the B&P command library** — the genuinely
+   framework-agnostic layer, where non-constituency frameworks connect
+   via their own node types (HPSG signs, DG word-indices, Minimalist
+   syntactic objects), each with its own dominance order.
 
-N-ary branching with categories on every node. Supports both:
+Frameworks whose structures are **not** trees do not and cannot
+instantiate this type: CCG derivations are proof trees (nodes are rule
+applications); HPSG signs are reentrant feature structures (structure
+sharing has no tree representation); dependency structures are
+head-indexed graphs; multidominance objects are nonplanar (which is why
+`Syntax/Minimalist/` keeps its own `SyntacticObject` and only projects
+to `Tree` at the interface).
+
+## `Syntax.Tree C W`
+
+N-ary branching with categories on every node. Read by both interfaces:
 - **Compositional interpretation** (LF): `interp`/`evalTree`
-  in `Composition/Tree.lean` — type-driven, ignores categories
+  in `Semantics/Composition/Tree.lean` — type-driven, ignores categories
 - **Structural operations** (PF): [katzir-2007] `StructOp` (substitution,
-  deletion, contraction) in `Alternatives/Structural.lean` — category-aware
+  deletion, contraction) in `Semantics/Alternatives/Structural.lean` —
+  category-aware
 
-Parameterized by category type `C` (UD tags, CCG categories, feature
-bundles, `Unit` for unlabeled, ...) and terminal type `W`.
+The generic core is `terminal`/`node` with the pluggable category
+parameter `C` (UD tags, feature bundles, `Unit` for unlabeled, ...).
+The `trace` and `bind` constructors encode the **trace-theoretic / QR**
+analysis of movement specifically ([heim-kratzer-1998] Ch. 5): indexed
+traces plus λ-binders. Rival representations of movement are *not*
+expressible on this type — copy theory needs a side-car chain relation
+over `TreePath`s, and multidominance needs the nonplanar
+`SyntacticObject` (`Syntax/Minimalist/Multidominance.lean`). Frameworks
+without movement simply never construct these cases. Binder–trace
+well-formedness (each `bind n` binding a matching `trace n`) is a
+predicate to be imposed, not a type guarantee; `bind`'s category label
+is recorded for uniformity but is not consulted by `interp` or
+`StructOp`.
 
 ### Instantiations
 
 - `Tree Unit String` — category-free, for H&K composition. Use convenience
   constructors `.leaf`, `.bin`, `.un`, `.tr`, `.binder`.
-- `Tree Cat String` — UD-grounded categories, for Katzir structural alternatives.
-- `Tree Unit LIToken` — bare phrase structure, for Minimalist syntax
-  (categories inside `LIToken`, not on nodes).
-
-## `Cat` — Default Category System
-
-Grounded in Universal Dependencies UPOS. Word-level categories via
-`head : UPOS → Cat`, phrasal via `proj : UPOS → Cat`, plus `S` and `CP`.
+- `Tree Cat String` — UD-grounded categories (`Syntax/Tree/Cat.lean`),
+  for Katzir structural alternatives.
+- `Tree Unit LIToken` — bare phrase structure projected from Minimalist
+  syntax at Spell-Out via `FreeMagma.toTree` (categories inside the
+  token, not on nodes).
 
 ## `TreePath` and `Tree.toTreeOrder`
 
 A `TreePath` is a list of child indices identifying a subtree position.
 The forgetful map `Tree.toTreeOrder` extracts the dominance partial order
 from any `Tree C W` as a `Core.Order.TreeOrder TreePath`, making the
-B&P command-relation library (`Linglib.Core.Order.Command`) applicable
-to concrete trees regardless of category type.
+B&P command-relation library (`Linglib.Core.Order.Command`,
+[barker-pullum-1990]) applicable to concrete trees regardless of
+category type.
 -/
 
-namespace Core.Tree
+namespace Syntax
 
--- ════════════════════════════════════════════════════════════════════
--- §1  Default Category System (UD-grounded)
--- ════════════════════════════════════════════════════════════════════
+/-! ### The tree type -/
 
-open UD
-
-/-- Default syntactic category system grounded in Universal Dependencies
-UPOS ([de-marneffe-zeman-2021]).
-
-- `head pos` — word-level (terminal): wraps a UPOS tag directly
-- `proj pos` — maximal X-bar projection of a UPOS head
-- `S` — sentence/clause (not a projection of a single lexical head)
-- `CP` — complementizer phrase
-
-Phrasal categories are derived systematically: NP = `proj .NOUN`,
-VP = `proj .VERB`, DP = `proj .DET`, ConjP = `proj .CCONJ`, etc.
-
-This is one possible instantiation of `Tree`'s `C` parameter.
-Framework-specific category systems (CCG functors, Minimalist
-feature bundles, etc.) can be used instead. -/
-inductive Cat where
-  | head : UPOS → Cat
-  | proj : UPOS → Cat
-  | S
-  | CP
-  deriving DecidableEq, Repr
-
-instance : Inhabited Cat := ⟨.S⟩
-
-instance : BEq Cat := ⟨λ a b => decide (a = b)⟩
-
-instance : LawfulBEq Cat where
-  eq_of_beq h := of_decide_eq_true h
-  rfl := decide_eq_true rfl
-
--- ── Abbreviations ──────────────────────────────────────────────────
--- Short names matching traditional notation. Each abbreviation is
--- marked @[match_pattern] so it can be used in pattern position.
-
-namespace Cat
-
--- Word-level (heads / terminals)
-@[match_pattern] abbrev N     : Cat := .head .NOUN
-@[match_pattern] abbrev V     : Cat := .head .VERB
-@[match_pattern] abbrev Det   : Cat := .head .DET
-@[match_pattern] abbrev Adj   : Cat := .head .ADJ
-@[match_pattern] abbrev Adv   : Cat := .head .ADV
-@[match_pattern] abbrev P     : Cat := .head .ADP
-@[match_pattern] abbrev Conj  : Cat := .head .CCONJ
-@[match_pattern] abbrev Neg   : Cat := .head .PART
-@[match_pattern] abbrev C     : Cat := .head .SCONJ
-@[match_pattern] abbrev Num   : Cat := .head .NUM
-@[match_pattern] abbrev Pron  : Cat := .head .PRON
-@[match_pattern] abbrev Aux   : Cat := .head .AUX
-
--- Phrasal (maximal projections)
-@[match_pattern] abbrev NP    : Cat := .proj .NOUN
-@[match_pattern] abbrev VP    : Cat := .proj .VERB
-@[match_pattern] abbrev DP    : Cat := .proj .DET
-@[match_pattern] abbrev PP    : Cat := .proj .ADP
-@[match_pattern] abbrev AdjP  : Cat := .proj .ADJ
-@[match_pattern] abbrev AdvP  : Cat := .proj .ADV
-@[match_pattern] abbrev ConjP : Cat := .proj .CCONJ
-@[match_pattern] abbrev NegP  : Cat := .proj .PART
-@[match_pattern] abbrev NumP  : Cat := .proj .NUM
-
-end Cat
-
-
--- ════════════════════════════════════════════════════════════════════
--- §2  Unified Tree Type
--- ════════════════════════════════════════════════════════════════════
-
-/-- Framework-neutral tree, parameterized by node label type `C`
-and terminal word type `W`.
+/-- Constituency tree, parameterized by node label type `C` and terminal
+word type `W`.
 
 - `terminal c w` — leaf carrying category `c` and word `w`
 - `node c cs` — internal node with category `c` and children `cs`
@@ -155,9 +111,7 @@ variable {C W : Type}
 @[match_pattern] abbrev tr (n : Nat) : Tree Unit W := .trace n ()
 @[match_pattern] abbrev binder (n : Nat) (body : Tree Unit W) : Tree Unit W := .bind n () body
 
--- ════════════════════════════════════════════════════════════════════
--- §3  Basic Accessors
--- ════════════════════════════════════════════════════════════════════
+/-! ### Basic accessors -/
 
 /-- Category label of the root node. Total: every constructor carries
 a category (including `bind`, where it labels the result of PA). -/
@@ -167,9 +121,7 @@ def cat : Tree C W → C
   | .trace _ c => c
   | .bind _ c _ => c
 
--- ════════════════════════════════════════════════════════════════════
--- §4  Structural Equality
--- ════════════════════════════════════════════════════════════════════
+/-! ### Structural equality -/
 
 /-- Structural equality for trees (mutual recursion through List). -/
 def beq [BEq C] [BEq W] : Tree C W → Tree C W → Bool
@@ -246,9 +198,7 @@ end
 
 instance [DecidableEq C] [DecidableEq W] : DecidableEq (Tree C W) := decEq
 
--- ════════════════════════════════════════════════════════════════════
--- §5  Size
--- ════════════════════════════════════════════════════════════════════
+/-! ### Size -/
 
 /-- Number of nodes in the tree. -/
 def size : Tree C W → Nat
@@ -273,9 +223,7 @@ where
   | [] => 0
   | t :: ts => leafCount t + leafCountList ts
 
--- ════════════════════════════════════════════════════════════════════
--- §5b  Binary-Tree Recursor (for `Tree Unit W`)
--- ════════════════════════════════════════════════════════════════════
+/-! ### Binary-tree recursor (for `Tree Unit W`) -/
 
 /-- Custom recursor for binary trees over `Tree Unit W`. The default
 `induction` tactic refuses nested inductives like `Tree`; this recursor
@@ -306,9 +254,7 @@ def binRec {W : Type} {motive : Tree Unit W → Sort*}
 termination_by t => t.size
 decreasing_by all_goals (simp only [Tree.size, Tree.size.sizeList]; omega)
 
--- ════════════════════════════════════════════════════════════════════
--- §6  Subtrees
--- ════════════════════════════════════════════════════════════════════
+/-! ### Subtrees -/
 
 /-- All subtrees including self (pre-order traversal). -/
 def subtrees : Tree C W → List (Tree C W)
@@ -321,9 +267,7 @@ where
   | [] => []
   | t :: ts => subtrees t ++ subtreesList ts
 
--- ════════════════════════════════════════════════════════════════════
--- §7  Category Queries
--- ════════════════════════════════════════════════════════════════════
+/-! ### Category queries -/
 
 /-- Whether a category appears anywhere in the tree. -/
 def containsCat [BEq C] (target : C) : Tree C W → Bool
@@ -336,9 +280,7 @@ where
   | [] => false
   | t :: ts => containsCat target t || containsCatList target ts
 
--- ════════════════════════════════════════════════════════════════════
--- §8  Leaf Substitution
--- ════════════════════════════════════════════════════════════════════
+/-! ### Leaf substitution -/
 
 /-- Substitute all terminals of category `c` carrying word `target`
 with `replacement`. This is the most common structural operation:
@@ -360,9 +302,7 @@ where
 
 end Tree
 
--- ════════════════════════════════════════════════════════════════════
--- §9  TreePath and Forgetful Map to TreeOrder
--- ════════════════════════════════════════════════════════════════════
+/-! ### TreePath and the forgetful map to TreeOrder -/
 
 /-- A path from the root of a tree, encoded as a list of child indices.
 
@@ -435,28 +375,26 @@ def toTreeOrder (t : Tree C W) : Core.Order.TreeOrder TreePath where
 
 end Tree
 
-end Core.Tree
+end Syntax
 
--- ════════════════════════════════════════════════════════════════════
--- §10  FreeMagma → Tree forgetful map
--- ════════════════════════════════════════════════════════════════════
+/-! ### FreeMagma → Tree forgetful map -/
 
 namespace FreeMagma
 
-/-- Forgetful map from a free magma to a binary `Core.Tree.Tree Unit α`.
+/-- Forgetful map from a free magma to a binary `Syntax.Tree Unit α`.
 
 The image lives in a strict subset of `Tree Unit α`: only `.terminal ()`
 (from `.of`) and the binary `.node () [_, _]` (from `.mul`) are produced;
 the n-ary `.node`, `.trace`, and `.bind` constructors are never used.
 
-By composition with `Core.Tree.Tree.toTreeOrder`, every `FreeMagma α`
-inherits a `Core.Order.TreeOrder Core.Tree.TreePath`, making B&P's
+By composition with `Syntax.Tree.toTreeOrder`, every `FreeMagma α`
+inherits a `Core.Order.TreeOrder Syntax.TreePath`, making B&P's
 framework-agnostic command-relation library
 (`Linglib.Core.Order.Command`) directly applicable.
 
-Universe note: capped at `α : Type` because `Core.Tree.Tree` is monomorphic
+Universe note: capped at `α : Type` because `Syntax.Tree` is monomorphic
 in `Type 0`; sufficient for `LIToken`-indexed `SyntacticObject`. -/
-def toTree {α : Type} : FreeMagma α → Core.Tree.Tree Unit α
+def toTree {α : Type} : FreeMagma α → Syntax.Tree Unit α
   | .of a => .terminal () a
   | .mul l r => .node () [l.toTree, r.toTree]
 

--- a/Linglib/Syntax/Tree/Cat.lean
+++ b/Linglib/Syntax/Tree/Cat.lean
@@ -1,0 +1,81 @@
+import Linglib.Data.UD.Basic
+import Linglib.Syntax.Tree.Basic
+
+/-!
+# Default Category System (UD-grounded)
+
+`Syntax.Cat` — the default instantiation of `Syntax.Tree`'s category
+parameter `C`, grounded in Universal Dependencies UPOS
+([de-marneffe-zeman-2021]). Word-level categories via `head : UPOS → Cat`,
+phrasal via `proj : UPOS → Cat`, plus `S` and `CP`.
+
+Split from `Syntax/Tree/Basic.lean` so that category-generic consumers
+(e.g. the type-driven composition engine, which ignores categories) do
+not carry the UD dataset in their transitive imports.
+-/
+
+namespace Syntax
+
+/-- Default syntactic category system grounded in Universal Dependencies
+UPOS ([de-marneffe-zeman-2021]).
+
+- `head pos` — word-level (terminal): wraps a UPOS tag directly
+- `proj pos` — maximal X-bar projection of a UPOS head
+- `S` — sentence/clause (not a projection of a single lexical head)
+- `CP` — complementizer phrase
+
+Phrasal categories are derived systematically: NP = `proj .NOUN`,
+VP = `proj .VERB`, DP = `proj .DET`, ConjP = `proj .CCONJ`, etc.
+
+This is one possible instantiation of `Tree`'s `C` parameter.
+Framework-specific category systems (CCG functors, Minimalist
+feature bundles, etc.) can be used instead. -/
+inductive Cat where
+  | head : UD.UPOS → Cat
+  | proj : UD.UPOS → Cat
+  | S
+  | CP
+  deriving DecidableEq, Repr
+
+instance : Inhabited Cat := ⟨.S⟩
+
+instance : BEq Cat := ⟨λ a b => decide (a = b)⟩
+
+instance : LawfulBEq Cat where
+  eq_of_beq h := of_decide_eq_true h
+  rfl := decide_eq_true rfl
+
+-- ── Abbreviations ──────────────────────────────────────────────────
+-- Short names matching traditional notation. Each abbreviation is
+-- marked @[match_pattern] so it can be used in pattern position.
+
+namespace Cat
+
+-- Word-level (heads / terminals)
+@[match_pattern] abbrev N     : Cat := .head .NOUN
+@[match_pattern] abbrev V     : Cat := .head .VERB
+@[match_pattern] abbrev Det   : Cat := .head .DET
+@[match_pattern] abbrev Adj   : Cat := .head .ADJ
+@[match_pattern] abbrev Adv   : Cat := .head .ADV
+@[match_pattern] abbrev P     : Cat := .head .ADP
+@[match_pattern] abbrev Conj  : Cat := .head .CCONJ
+@[match_pattern] abbrev Neg   : Cat := .head .PART
+@[match_pattern] abbrev C     : Cat := .head .SCONJ
+@[match_pattern] abbrev Num   : Cat := .head .NUM
+@[match_pattern] abbrev Pron  : Cat := .head .PRON
+@[match_pattern] abbrev Aux   : Cat := .head .AUX
+
+-- Phrasal (maximal projections)
+@[match_pattern] abbrev NP    : Cat := .proj .NOUN
+@[match_pattern] abbrev VP    : Cat := .proj .VERB
+@[match_pattern] abbrev DP    : Cat := .proj .DET
+@[match_pattern] abbrev PP    : Cat := .proj .ADP
+@[match_pattern] abbrev AdjP  : Cat := .proj .ADJ
+@[match_pattern] abbrev AdvP  : Cat := .proj .ADV
+@[match_pattern] abbrev ConjP : Cat := .proj .CCONJ
+@[match_pattern] abbrev NegP  : Cat := .proj .PART
+@[match_pattern] abbrev NumP  : Cat := .proj .NUM
+
+end Cat
+
+end Syntax


### PR DESCRIPTION
Part of the Core junk-drawer dissolution. `Core/Tree.lean` was framework-committed syntax misfiled as neutral infrastructure: the `trace`/`bind` constructors carry QR-tradition movement theory, and the file imported upward (`Data.UD`, plus a dead `Morphology.Word` import, now dropped).

- `Core/Tree.lean` → `Syntax/Tree/Basic.lean` (tree type, paths, dominance/`toTreeOrder`, FreeMagma bridge) + `Syntax/Tree/Cat.lean` (UD-grounded default categories)
- Namespace `Core.Tree` → `Syntax`: the type is now `Syntax.Tree` (kills the doubled `Core.Tree.Tree`), `Syntax.Cat`, `Syntax.TreePath`
- The composition engine imports `Basic` only — the category-generic engine no longer carries the UD dataset in its transitive closure; `Cat` consumers import `Cat` explicitly
- 21 consumer files swept

Full local build green (6015 jobs).