### PR TITLE
refactor(Core/Order): move Mereology into Core/Order

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -326,7 +326,7 @@ import Linglib.Core.Scales.EpistemicScale.Cancellation
 import Linglib.Core.Scales.EpistemicScale.CancellationFin4
 import Linglib.Core.Scales.EpistemicScale.Completeness
 import Linglib.Core.Scales.EpistemicScale.Representability
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Core.Mereotopology
 import Linglib.Core.Scales.MereoDim
 import Linglib.Semantics.Attitudes.ContentIndividual

--- a/Linglib/Core/Mereotopology.lean
+++ b/Linglib/Core/Mereotopology.lean
@@ -1,13 +1,13 @@
 import Mathlib.Topology.Connected.Basic
 import Mathlib.Topology.Order.Lattice
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 
 /-!
 # Mereotopology
 [casati-varzi-1999] [grimm-2012] [krifka-2021]
 
 Mereotopological infrastructure grounded in Mathlib's `TopologicalSpace`,
-`IsConnected`, and `closure`. Extends `Core/Mereology.lean` (algebraic
+`IsConnected`, and `closure`. Extends `Core/Order/Mereology.lean` (algebraic
 parthood, overlap, CUM/DIV/QUA) with topological structure (connection,
 self-connection, touch).
 

--- a/Linglib/Core/Order/Mereology.lean
+++ b/Linglib/Core/Order/Mereology.lean
@@ -301,17 +301,10 @@ class ExtMeasure (α : Type*) [SemilatticeSup α]
       We axiomatize it directly since `SemilatticeSup` lacks complementation. -/
   strict_mono : ∀ (x y : α), y < x → μ y < μ x
 
-/-- Measure phrases create QUA predicates: {x : μ(x) = n} is QUA
-    whenever μ is an extensive measure.
-    [krifka-1998] §2.2: "two kilograms of flour" is QUA because
-    no proper part of a 2kg entity also weighs 2kg. -/
-theorem extMeasure_qua {α : Type*} [SemilatticeSup α]
-    {μ : α → ℚ} [hμ : ExtMeasure α μ] (n : ℚ) (_hn : 0 < n) :
-    QUA (fun x => μ x = n) := by
-  intro x y hx hlt hy
-  have hsm := hμ.strict_mono x y hlt
-  rw [hy, hx] at hsm
-  exact absurd hsm (lt_irrefl _)
+/-! Measure phrases create QUA predicates: `{x : μ(x) = n}` is QUA whenever
+μ is an extensive measure ([krifka-1998] §2.2: "two kilograms of flour" is
+QUA because no proper part of a 2kg entity also weighs 2kg). The theorem
+`extMeasure_qua` is stated in §9 below, derived via `qua_pullback`. -/
 
 -- ════════════════════════════════════════════════════
 -- § 6. QMOD: Quantizing Modification ([krifka-1989])
@@ -485,19 +478,15 @@ theorem singleton_qua {α : Type*} [PartialOrder α]
   subst hx; subst hy
   exact absurd hlt (lt_irrefl _)
 
-/-- `extMeasure_qua` derived from `qua_pullback` + `singleton_qua`.
-    This shows that `extMeasure_qua` is a special case of QUA pullback:
+/-- Measure phrases create QUA predicates: `{x : μ(x) = n}` is QUA
+    whenever μ is an extensive measure ([krifka-1998] §2.2).
+    A special case of QUA pullback:
 
       {x | μ(x) = n} = (· = n) ∘ μ
 
-    and QUA pulls back along the StrictMono map μ.
-
-    Note: unlike the original `extMeasure_qua`, this derivation does not
-    require `0 < n`. The positivity hypothesis was an artifact of the
-    direct proof; the pullback route is strictly more general.
-
-    The original `extMeasure_qua` is preserved for backward compatibility. -/
-theorem extMeasure_qua' {α : Type*} [SemilatticeSup α]
+    and QUA pulls back along the StrictMono map μ. No positivity
+    hypothesis on `n` is needed — the pullback route is fully general. -/
+theorem extMeasure_qua {α : Type*} [SemilatticeSup α]
     {μ : α → ℚ} [hμ : ExtMeasure α μ] (n : ℚ) :
     QUA (fun x => μ x = n) :=
   qua_pullback (extMeasure_strictMono hμ) (singleton_qua n)
@@ -865,50 +854,5 @@ theorem subserves {α : Type*} [Preorder α] {q p : α → Prop}
     (h : IsContentPart q p) : Subserves q p := h.2
 
 end IsContentPart
-
--- ════════════════════════════════════════════════════
--- § 16. Strict-Part Reflection and Preservation
---      (paper [bondarenko-elliott-2026] eqs. 53/54)
--- ════════════════════════════════════════════════════
-
-/-- **Strict-part reflection** for a partial function.
-    A partial map `f : α → Option β` *reflects* proper parthood when
-    every proper sub-image `q' < f(x)` is the image of some proper
-    sub-input `x' < x`. Generic reusable formulation; specialized in
-    `Studies/BondarenkoElliott2026.lean` to MSI
-    (Mapping to Sub-parts of the Input). -/
-def StrictPartReflecting {α β : Type*} [Preorder α] [Preorder β]
-    (f : α → Option β) : Prop :=
-  ∀ ⦃x q q'⦄, f x = some q → q' < q → ∃ x', x' < x ∧ f x' = some q'
-
-/-- **Strict-part preservation** for a partial function.
-    A partial map `f : α → Option β` *preserves* proper parthood when
-    every proper sub-input `x' < x` (with `f x` defined) yields a proper
-    sub-image of `f(x)`. Generic reusable formulation; specialized in
-    `Studies/BondarenkoElliott2026.lean` to MSO
-    (Mapping to Sub-parts of the Output). -/
-def StrictPartPreserving {α β : Type*} [Preorder α] [Preorder β]
-    (f : α → Option β) : Prop :=
-  ∀ ⦃x x' qx⦄, x' < x → f x = some qx → ∃ qx', qx' < qx ∧ f x' = some qx'
-
--- ════════════════════════════════════════════════════
--- § 17. IsContentPart counterexample helper
--- ════════════════════════════════════════════════════
-
-/-- A singleton `{q}` is **not** a conjunctive part of `p` whenever some
-    `q' ∈ p` lacks `q` as a sub-element (i.e., `¬ q ≤ q'`). The Down
-    clause of `IsContentPart` requires every `p`-element to have a
-    `{q}`-element below it; with only `q` available, `q ≤ q'` must hold
-    for every `q' ∈ p`.
-
-    Used for paper [bondarenko-elliott-2026] eq. 95 to discriminate
-    classical entailment from conjunctive parthood. -/
-theorem not_isContentPart_of_singleton_not_le {α : Type*} [Preorder α]
-    {q : α} {p : α → Prop} {q' : α} (hq' : p q') (h : ¬ q ≤ q') :
-    ¬ IsContentPart (· = q) p := by
-  intro ⟨hd, _⟩
-  obtain ⟨t, ht, hle⟩ := hd q' hq'
-  -- ht : t = q (from singleton membership), so q ≤ q' would follow
-  exact h (ht ▸ hle)
 
 end Mereology

--- a/Linglib/Core/Scales/MereoDim.lean
+++ b/Linglib/Core/Scales/MereoDim.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Core.Scales.Scale
 import Mathlib.Algebra.Order.Archimedean.Basic
 import Mathlib.Algebra.Order.Field.Rat
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Order.Field.Rat
 # Mereology ↔ Scale Bridge
 [champollion-2017] [kennedy-2007] [krifka-1989] [krifka-1998] [rouillard-2026]
 
-Cross-pillar connection between `Core/Mereology.lean` (CUM/QUA/ExtMeasure)
+Cross-pillar connection between `Core/Order/Mereology.lean` (CUM/QUA/ExtMeasure)
 and `Core/Scale.lean` (ComparativeScale/Boundedness/MIP/degree properties).
 
 The two pillars are independently motivated:
@@ -141,7 +141,7 @@ theorem singleton_qua_closed (n : ℚ) :
   ⟨singleton_qua n, rfl⟩
 
 /-- ExtMeasure singletons `{x | μ(x) = n}` are QUA and correspond to
-    closed scales. Combines `extMeasure_qua'` (mereological) with the
+    closed scales. Combines `extMeasure_qua` (mereological) with the
     boundedness annotation (scale-theoretic).
 
     This is the measure-theoretic version of `singleton_qua_closed`:
@@ -150,7 +150,7 @@ theorem singleton_qua_closed (n : ℚ) :
 theorem extMeasure_singleton_closed {α : Type*} [SemilatticeSup α]
     {μ : α → ℚ} [hμ : ExtMeasure α μ] (n : ℚ) :
     QUA (fun x => μ x = n) ∧ quaBoundedness = Core.Scale.Boundedness.closed :=
-  ⟨extMeasure_qua' n, rfl⟩
+  ⟨extMeasure_qua n, rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 4. CUM Sum Extensibility

--- a/Linglib/Features/Number/Interp.lean
+++ b/Linglib/Features/Number/Interp.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Number.Basic
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 
 /-!
 # Number — lattice semantics for the values

--- a/Linglib/Fragments/ASL/Height.lean
+++ b/Linglib/Fragments/ASL/Height.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Quantification.DomainRestriction
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Semantics.Presupposition.Basic
 
 /-!
@@ -126,7 +126,7 @@ def heightToDDRP {E : Type*} (zone : E → VerticalHeight) : HeightDDRP E where
 
     ⟦arc⟧ = λx: ¬Atom(x). x
 
-    This uses `Mereology.Atom` from `Core/Mereology.lean`. The at-issue
+    This uses `Mereology.Atom` from `Core/Order/Mereology.lean`. The at-issue
     content is the identity — arc contributes only a presupposition, not
     assertoric content. -/
 def arcPresup (E : Type*) [PartialOrder E] : PrProp E where

--- a/Linglib/Morphology/Exponence.lean
+++ b/Linglib/Morphology/Exponence.lean
@@ -161,7 +161,7 @@ def singularNounRule {α : Type} (atomPred : α → Bool) :
 /-- Plural rule for nouns (regular: append -s).
 
     Semantics: `pred ↦ closurePred pred ∧ ¬Atom`
-    where `closurePred` is Link's algebraic closure (from `Core/Mereology.lean`).
+    where `closurePred` is Link's algebraic closure (from `Core/Order/Mereology.lean`).
 
     This makes "dogs" true of plural individuals (sums of dogs). -/
 def pluralNounRule {α : Type}

--- a/Linglib/Semantics/Aspect/Cumulativity.lean
+++ b/Linglib/Semantics/Aspect/Cumulativity.lean
@@ -85,7 +85,7 @@ private theorem cum_propagation_of_cumTheta {θ : α → β → Prop} {OBJ : α 
 
     **Functional case**: When θ is a function (not a relation) with
     `IsSumHom` + `Function.Injective`, this reduces to
-    `qua_of_injective_sumHom` in `Core/Mereology.lean` via
+    `qua_of_injective_sumHom` in `Core/Order/Mereology.lean` via
     `qua_pullback`. The relational UP + MSO conditions collapse to
     functional injectivity + monotonicity.
 

--- a/Linglib/Semantics/Classifier/Basic.lean
+++ b/Linglib/Semantics/Classifier/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Typology.ClassifierSystem
 import Linglib.Semantics.Plurality.Algebra
 
@@ -8,7 +8,7 @@ import Linglib.Semantics.Plurality.Algebra
 
 Unified compositional semantics for classifier constructions, connecting
 the typological vocabulary in `Typology` to the mereological
-infrastructure in `Core.Mereology` and the materialization homomorphism
+infrastructure in `Mereology` and the materialization homomorphism
 in `Semantics.Plurality.Algebra`.
 
 ## Two Semantic Strategies

--- a/Linglib/Semantics/Events/CEM.lean
+++ b/Linglib/Semantics/Events/CEM.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Core.Scales.MereoDim
 import Linglib.Semantics.Events.Basic
 import Linglib.Features.Aktionsart
@@ -8,12 +8,12 @@ import Linglib.Features.Aktionsart
 [bach-1986] [champollion-2017]
 
 Event-specific mereological infrastructure built on top of the generic
-`Core.Mereology` definitions. Specializes `CUM`, `QUA`, `IsSumHom`, etc.
+`Mereology` definitions. Specializes `CUM`, `QUA`, `IsSumHom`, etc.
 to event structures with `EventCEM`, thematic role homomorphisms, and
 Vendler class bridges.
 
 Generic mereological definitions (`CUM`, `DIV`, `QUA`, `Atom`, `AlgClosure`,
-`IsSumHom`, `Overlap`, `ExtMeasure`, `QMOD`) live in `Core.Mereology`.
+`IsSumHom`, `Overlap`, `ExtMeasure`, `QMOD`) live in `Mereology`.
 -/
 
 namespace Semantics.Events.CEM
@@ -23,7 +23,7 @@ open Features
 open _root_.Mereology
 
 -- Generic mereological vocabulary (CUM/QUA/AlgClosure/QMOD/ExtMeasure
--- /MereoDim/LaxMeasureSquare/...) lives in `Core.Mereology` and
+-- /MereoDim/LaxMeasureSquare/...) lives in `Mereology` and
 -- `Core.Scales.MereoDim`. Consumers do `open Mereology` to bring it
 -- into scope rather than relying on re-exports here.
 

--- a/Linglib/Semantics/Kinds/NominalMappingParameter.lean
+++ b/Linglib/Semantics/Kinds/NominalMappingParameter.lean
@@ -37,7 +37,7 @@ import Mathlib.Data.Set.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.UpperLower.Basic
 import Linglib.Data.UD.Basic
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Core.Logic.Intensional.Rigidity
 import Linglib.Morphology.Word
 
@@ -127,7 +127,7 @@ mass extensions are closed under union and subset.
 def IsMass (P : Property World Atom) : Prop :=
   ∀ w (x : Individual Atom), x ∈ P w ↔ ∀ a ∈ x, Individual.atom a ∈ P w
 
--- Bridge Theorems to Core/Mereology
+-- Bridge Theorems to Core/Order/Mereology
 
 section MereologyBridge
 
@@ -148,7 +148,7 @@ theorem isMass_cum (P : Property World Atom) (hMass : IsMass World Atom P) (w : 
 
 end MereologyBridge
 
--- Plural Closure (Link's *P via Core/Mereology.AlgClosure)
+-- Plural Closure (Link's *P via Core/Order/Mereology.AlgClosure)
 
 /--
 Plural closure of a property: close extensions under join (⊔) at each world.

--- a/Linglib/Semantics/Measurement.lean
+++ b/Linglib/Semantics/Measurement.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Core.Scales.MereoDim
 import Linglib.Features.Aktionsart
 import Linglib.Semantics.Gradability.StatesBased

--- a/Linglib/Semantics/Measurement/Basic.lean
+++ b/Linglib/Semantics/Measurement/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Core.Scales.Scale
 import Linglib.Semantics.Entailment.Extremum
 import Linglib.Features.Dimension
@@ -375,11 +375,11 @@ theorem extensive_measureFn_qmod_qua
     {E : Type*} [inst : SemilatticeSup E]
     {μ : MeasureFn E}
     (hExt : MeasureFn.IsExtensive μ)
-    {R : E → Prop} {n : ℚ} (hn : 0 < n) :
+    {R : E → Prop} {n : ℚ} (_hn : 0 < n) :
     Mereology.QUA (Mereology.QMOD R μ.apply n) := by
   intro x y ⟨_, hx_eq⟩ hlt ⟨_, hy_eq⟩
   have hExt' : @Mereology.ExtMeasure E inst μ.apply := hExt
-  have hμ_qua := @Mereology.extMeasure_qua E inst μ.apply hExt' n hn
+  have hμ_qua := @Mereology.extMeasure_qua E inst μ.apply hExt' n
   exact hμ_qua x y hx_eq hlt hy_eq
 
 /-- **Bridge to QMOD.** Scontras's `applyNumeral` and Krifka's `QMOD` check the

--- a/Linglib/Semantics/Plurality/Algebra.lean
+++ b/Linglib/Semantics/Plurality/Algebra.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 
 /-!
 # Link 1983: The Logical Analysis of Plurals and Mass Terms
@@ -29,7 +29,7 @@ later simplification, not Link 1983's actual ontology; see
 Link's `*` IS `Mereology.AlgClosure`; Link's cumulative reference IS
 `Mereology.CUM`; Link's atom IS `Mereology.Atom`. The notation in this
 file (`star`, `IsDistr`, etc.) is preserved for paper-faithful
-legibility but is definitionally identical to the `Core/Mereology.lean`
+legibility but is definitionally identical to the `Core/Order/Mereology.lean`
 substrate. Materialization homomorphism `Materialization` corresponds to
 mathlib's `SupHom` and could be folded into it (Todo).
 

--- a/Linglib/Semantics/Plurality/Cover.lean
+++ b/Linglib/Semantics/Plurality/Cover.lean
@@ -1,7 +1,7 @@
 import Mathlib.Order.Bounds.Basic
 import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Data.Finset.Lattice.Fold
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 
 /-!
 # Schwarzschild Covers and Partitions

--- a/Linglib/Semantics/Plurality/Implicature.lean
+++ b/Linglib/Semantics/Plurality/Implicature.lean
@@ -31,7 +31,7 @@ disjunction ([fox-2007]).
 
 The plural individual `x` is modelled as `Finset Atom` with `a ∈ x`
 for "a is an atomic part of x". The paper uses mereological `≤_AT`
-(atomic part-of) over `Core/Mereology.lean`'s lattice-based `Atom`
+(atomic part-of) over `Core/Order/Mereology.lean`'s lattice-based `Atom`
 predicate. The `Finset` representation is simpler and adequate for the
 exhaustification proofs; a mereological formulation can be added as a
 bridge if needed.
@@ -43,7 +43,7 @@ bridge if needed.
 * Bridge to `Plurality.Distributivity.pluralTruthValue` (K&S
   divergence): `¬ (∀ P x w, existPL x P x w ↔ pluralTruthValue P x w
   = .true)` — counterexample at any mixed-truth `(P, x)`.
-* Mereological reformulation against `Core.Mereology.Atom` /
+* Mereological reformulation against `Mereology.Atom` /
   `Mereology.AlgClosure` for unification with Link's `*P` family.
 -/
 

--- a/Linglib/Semantics/Plurality/Reference.lean
+++ b/Linglib/Semantics/Plurality/Reference.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 
 /-!
 # Nominal Reference Predicates (Mass / Count / Bare Plural)
@@ -19,7 +19,7 @@ the Krifka–Link–Champollion algebraic semantics tradition.
 
 ## Implementation notes
 
-Thin re-exports of `Core/Mereology.lean` primitives under nominal-
+Thin re-exports of `Core/Order/Mereology.lean` primitives under nominal-
 reference names. The `CUM`/`QUA` definitional criteria are classical
 ([krifka-1989] §1) and widely known to be inadequate for the
 modern mass/count picture — [chierchia-1998] argues mass nouns
@@ -55,7 +55,7 @@ abbrev CountNoun {α : Type*} [PartialOrder α] (P : α → Prop) : Prop := QUA 
 abbrev BarePlural {α : Type*} [SemilatticeSup α] (P : α → Prop) : α → Prop :=
   AlgClosure P
 
-/-- Bare plurals are cumulative (reuses `algClosure_cum` from `Core/Mereology.lean`). -/
+/-- Bare plurals are cumulative (reuses `algClosure_cum` from `Core/Order/Mereology.lean`). -/
 theorem barePlural_cum {α : Type*} [SemilatticeSup α] {P : α → Prop} :
     CUM (BarePlural P) :=
   algClosure_cum

--- a/Linglib/Semantics/Plurality/Trivalent.lean
+++ b/Linglib/Semantics/Plurality/Trivalent.lean
@@ -15,7 +15,7 @@ as a subset-universal proposition `λ w => ∀ a ∈ z, P a w` for some
 sub-plurality `z ⊆ x`. This captures K&S's predictions in monotonic
 contexts but is **not** their actual `Cand_x`: K&S build candidates from
 convex closures of sub-plurality bundles (substrate at
-`Core.Mereology.convexClosure`), yielding generalised-quantifier candidates
+`Mereology.convexClosure`), yielding generalised-quantifier candidates
 that pattern with [schwarzschild-1996]-style covers and
 [brisson-1998]'s ill-fitting covers but diverge in non-monotonic
 contexts. For the cases formalised here the two predictions coincide; the
@@ -53,7 +53,7 @@ The bivalent bridge to [kriz-2016]'s `addressesIssue` is proved in
 
 * Replace `candidateProp` with K&S's faithful `Cand_x` (def. 21 in
   [kriz-spector-2021] — UNVERIFIED definition number) via
-  `Core.Mereology.convexClosure`. Current simplification matches K&S
+  `Mereology.convexClosure`. Current simplification matches K&S
   predictions only in monotonic contexts; non-monotonic cases (e.g. the
   "exactly one student read the books" example, see
   `Studies/KrizSpector2021.lean`) require the enriched generalised

--- a/Linglib/Semantics/Presupposition/PhiFeatures.lean
+++ b/Linglib/Semantics/Presupposition/PhiFeatures.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Features.ContainmentPair
 import Linglib.Features.Number.Decomposition
 import Linglib.Features.Person.Decomposition

--- a/Linglib/Semantics/Quantification/UnifiedUniversal.lean
+++ b/Linglib/Semantics/Quantification/UnifiedUniversal.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 
 /-!
 # Unified Semantics for Universal Quantification

--- a/Linglib/Semantics/Spatial/Path.lean
+++ b/Linglib/Semantics/Spatial/Path.lean
@@ -13,7 +13,7 @@ The key linguistic insight: the boundedness of a directional
 PP determines whether the VP it creates is telic or atelic. Bounded PPs
 ("to the store") yield telic VPs; unbounded PPs ("towards the store")
 yield atelic VPs. This parallels the QUA/CUM mereological classification
-from `Core/Mereology.lean`.
+from `Core/Order/Mereology.lean`.
 
 ## Sections
 

--- a/Linglib/Semantics/Truthmaker/Basic.lean
+++ b/Linglib/Semantics/Truthmaker/Basic.lean
@@ -1,11 +1,11 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Core.Logic.Bilateral.Defs
 import Mathlib.Order.UpperLower.Basic
 import Mathlib.Order.UpperLower.CompleteLattice
 
 /-! # Truthmaker Semantics [fine-2017] [bondarenko-elliott-2026] [jago-2026]
 
-State-based propositions grounded in `Core/Mereology.lean`. Propositions are
+State-based propositions grounded in `Core/Order/Mereology.lean`. Propositions are
 sets of *verifying states*, where states form a join-semilattice (the same
 `SemilatticeSup` infrastructure used for events and plural individuals).
 

--- a/Linglib/Semantics/Truthmaker/Closure.lean
+++ b/Linglib/Semantics/Truthmaker/Closure.lean
@@ -12,7 +12,7 @@ satisfy three closure conditions:
 - **Regular (`P^*`)**: both closed and convex.
 
 Closures are not redefined here — they are imported from
-`Core/Mereology.lean`:
+`Core/Order/Mereology.lean`:
 
 - `Mereology.AlgClosure P` is `P^⊔` (Jago: closed under fusion).
 - `Mereology.algClosureOp : ClosureOperator (α → Prop)` bundles it.
@@ -93,7 +93,7 @@ def IsRegular (p : TMProp S) : Prop := IsClosed p ∧ IsConvex p
 
 /-- Regular closure: convexify the algebraic closure.
     `regularClose p = (p^⊔)^∼` — composition of the two closure
-    operators of `Core/Mereology.lean`. -/
+    operators of `Core/Order/Mereology.lean`. -/
 def regularClose (p : TMProp S) : TMProp S :=
   convexClose (AlgClosure p)
 

--- a/Linglib/Studies/BondarenkoElliott2026.lean
+++ b/Linglib/Studies/BondarenkoElliott2026.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Semantics.Truthmaker.Inexact
 import Linglib.Semantics.Truthmaker.Entailment
 import Linglib.Studies.Pasternak2019
@@ -70,9 +70,9 @@ The contrast in (2) follows.
   paper** — captures Sharvit's empirical contrast in (2).
 - `believes_closure_under_conjunction` (§6.1, eq. 79) — summation
   closure on believings + content-of-sum-is-meet ⇒ closure under ∧.
-- `Mereology.not_isContentPart_of_singleton_not_le` (§6.3, eq. 95) —
-  generic Mereology lemma; the paper's discriminating witness for
-  conjunctive parthood (Jago Def 5) is a one-line application.
+- `not_isContentPart_of_singleton_not_le` (§6.3, eq. 95) — the paper's
+  discriminating witness for conjunctive parthood (Jago Def 5) is a
+  one-line application.
 - `believes_does_not_always_close_under_intersection` — cross-framework:
   B&E's mereological `Believes` does NOT close under conjunction the way
   Hintikka's `boxAt` does, witnessed by a non-believings-closed model.
@@ -125,30 +125,20 @@ section Constraints
 variable {V E W : Type*} [Preorder V] [Preorder E]
 
 /-- **MSI** — *Mapping to Sub-parts of the Input* (paper eq. 44).
-    A content function preserves proper informational parthood:
-    every proper part `p' <_BE CONT(x)` is the content of some proper sub-`x`.
-
-    See `MSI_iff_strictPartReflecting` for the identification with the
-    generic `Mereology.StrictPartReflecting` (instantiated at the
-    `OrderDual` of `Set W`'s subset order, since paper eq. 43 uses the
-    flipped convention `p' <_BE p` iff `p ⊊ p'`). -/
+    A content function *reflects* proper informational parthood:
+    every proper part `p' <_BE CONT(x)` is the content of some proper
+    sub-`x`. (Paper eq. 43 uses the flipped convention `p' <_BE p` iff
+    `p ⊊ p'`, hence `propLT`.) -/
 def MSI (CONT : V → Option (Set W)) : Prop :=
   ∀ ⦃x p p'⦄, CONT x = some p → propLT p' p →
     ∃ x', x' < x ∧ CONT x' = some p'
 
 /-- **MSO** — *Mapping to Sub-parts of the Output* (paper eq. 48).
-    A theme function preserves proper sub-eventualities:
-    every proper sub-`e` has a corresponding proper sub-`THEME(e)`.
-
-    Equivalent to `Mereology.StrictPartPreserving` (the relationship is
-    `Iff.rfl` since both use the standard `<` on `E`). -/
+    A theme function *preserves* proper sub-eventualities:
+    every proper sub-`e` has a corresponding proper sub-`THEME(e)`. -/
 def MSO (THEME : V → Option E) : Prop :=
   ∀ ⦃e e' te⦄, e' < e → THEME e = some te →
     ∃ x', x' < te ∧ THEME e' = some x'
-
-/-- MSO is exactly `Mereology.StrictPartPreserving`. -/
-theorem MSO_iff_strictPartPreserving (THEME : V → Option E) :
-    MSO THEME ↔ Mereology.StrictPartPreserving THEME := Iff.rfl
 
 /-- **TECM** — *Theme-Event Content Matching* (paper eqs. 59, 65).
     For `believe`-class predicates `P`, the content of an event equals
@@ -647,6 +637,19 @@ being a philosopher").
 section ConjunctiveParthoodDemo
 variable {W : Type*}
 
+/-- A singleton `{q}` is **not** a conjunctive part of `p` whenever some
+    `q' ∈ p` lacks `q` as a sub-element (i.e., `¬ q ≤ q'`). The Down
+    clause of `Mereology.IsContentPart` requires every `p`-element to
+    have a `{q}`-element below it; with only `q` available, `q ≤ q'`
+    must hold for every `q' ∈ p`. -/
+theorem not_isContentPart_of_singleton_not_le {α : Type*} [Preorder α]
+    {q : α} {p : α → Prop} {q' : α} (hq' : p q') (h : ¬ q ≤ q') :
+    ¬ Mereology.IsContentPart (· = q) p := by
+  intro ⟨hd, _⟩
+  obtain ⟨t, ht, hle⟩ := hd q' hq'
+  -- ht : t = q (from singleton membership), so q ≤ q' would follow
+  exact h (ht ▸ hle)
+
 /-- **§6.3 discriminating witness** (paper eq. 95). Given three
     propositions `p₁` (linguist), `p₂` (philosopher), `p₃` (American
     linguist) with the natural entailment relations, the alternative
@@ -656,14 +659,14 @@ variable {W : Type*}
     What fails: the **second conjunct of paper eq. 94** ("every `p' ∈ Q'`
     has some `p ∈ Q` with `p ⊆ p'`"). Take `p₂ ∈ Q' = {p₁, p₂}`; the
     only candidate `p ∈ Q = {p₃}` is `p₃` itself, but `p₃ ⊆ p₂` is
-    false. The proof is a one-line application of the generic
-    `Mereology.not_isContentPart_of_singleton_not_le`. -/
+    false. The proof is a one-line application of
+    `not_isContentPart_of_singleton_not_le`. -/
 theorem conjunctive_parthood_blocks_disj_intro
     (p₁ p₂ p₃ : Set W)
     (_h_p3_p1 : p₃ ⊆ p₁)        -- "American linguist" ⊆ "linguist"
     (h_not_p3_p2 : ¬ p₃ ⊆ p₂) :  -- "American linguist" ⊄ "philosopher"
     ¬ Mereology.IsContentPart (· = p₃) ({p₁, p₂} : Set (Set W)) :=
-  Mereology.not_isContentPart_of_singleton_not_le
+  not_isContentPart_of_singleton_not_le
     (q := p₃) (p := ({p₁, p₂} : Set (Set W)))
     (Set.mem_insert_iff.mpr (Or.inr rfl)) h_not_p3_p2
 

--- a/Linglib/Studies/Borer2005.lean
+++ b/Linglib/Studies/Borer2005.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Typology.ClassifierSystem
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Features.MassCount
@@ -10,7 +10,7 @@ import Linglib.Features.MassCount
 Compositional interpretation of the nominal extended projection
 via mereological predicates. Bridges the syntactic spine
 N(F0) → n(F1) → Q(F2) → Num(F3) → D(F4) from `ExtendedProjection`
-to the CUM/QUA distinction from `Core/Mereology`.
+to the CUM/QUA distinction from `Core/Order/Mereology`.
 
 ## Core Thesis
 
@@ -504,7 +504,7 @@ A full formal comparison belongs in `Theories/Comparisons/`.
 /-! ### Bridge to [krifka-1998] / Mereology
 
 Borer's individuation connects directly to Krifka's event mereology
-already formalized in `Core/Mereology`:
+already formalized in `Core/Order/Mereology`:
 
 - `Div` on the nominal domain produces QUA predicates
 - QUA nominal arguments create telic (QUA) VPs via `qua_pullback`
@@ -513,7 +513,7 @@ already formalized in `Core/Mereology`:
   is QUA, and QUA pulls back through the eat-theme homomorphism
 
 The composition `qua_pullback (θ : Event → Entity) (div_qua P)` is
-already supported by `Core/Mereology` §8.
+already supported by `Core/Order/Mereology` §8.
 -/
 
 end Borer2005

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Dynamic.Core.DynamicTy2
 import Linglib.Semantics.Dynamic.Connectives.CCP
 import Linglib.Semantics.Composition.Continuation
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Mathlib.Control.Monad.Writer
 import Mathlib.Data.List.Sublists
 

--- a/Linglib/Studies/FaginHalpern1994.lean
+++ b/Linglib/Studies/FaginHalpern1994.lean
@@ -178,7 +178,7 @@ def Nonnegative {W E : Type*} (kp : KripkeKP W E) : Prop :=
 
     - `IsUpwardEntailing = Monotone` (`Entailment/Polarity.lean`)
     - `ScopeUpwardMono ↔ ∀ R, Monotone (q R)` (`Core/Quantification.lean`)
-    - `IsSumHom.monotone : Monotone f` (`Core/Mereology.lean`)
+    - `IsSumHom.monotone : Monotone f` (`Core/Order/Mereology.lean`)
     - `MeasureMonotone ↔ ∀ i w, Monotone (wcr i w)` (this definition)
 
     The world-independent special case `isProbabilistic` from

--- a/Linglib/Studies/GrimmDocekal2021.lean
+++ b/Linglib/Studies/GrimmDocekal2021.lean
@@ -1,6 +1,6 @@
 import Mathlib.Logic.Relation
 import Mathlib.Data.Finset.Lattice.Fold
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Features.Individuation
 
 /-!
@@ -58,7 +58,7 @@ Their §3.5 extends [krifka-1995b]'s kind-based semantics with
 * **`maxClusters_disjointPred`** — distinct maximal clusters never
   overlap: the *-oje* counting base is disjoint, so aggregate counting
   is certified by exactly the disjointness that [landman-2020]'s
-  counting theorems require (`Core/Mereology.DisjointPred`; cf.
+  counting theorems require (`Mereology.DisjointPred`; cf.
   `Studies/Landman2020.lean`).
 * **`ojeSem_determinate`** — the (64) semantics fixes the cardinality of
   maximal clusters uniquely: the formal content of *\*tři dvoje klíče*

--- a/Linglib/Studies/Krifka1989.lean
+++ b/Linglib/Studies/Krifka1989.lean
@@ -89,10 +89,10 @@ open Phenomena.TenseAspect.Diagnostics
     weight). -/
 theorem qmod_qua {α : Type*} [SemilatticeSup α]
     {R : α → Prop} {μ : α → ℚ} [hμ : ExtMeasure α μ]
-    {n : ℚ} (hn : 0 < n) :
+    {n : ℚ} (_hn : 0 < n) :
     QUA (QMOD R μ n) := by
   intro x y ⟨_, hx_eq⟩ hlt ⟨_, hy_eq⟩
-  have hμ_qua := extMeasure_qua (μ := μ) n hn
+  have hμ_qua := extMeasure_qua (μ := μ) n
   exact hμ_qua x y hx_eq hlt hy_eq
 
 /-- A CUM mass noun combined with QMOD (via an extensive measure)

--- a/Linglib/Studies/Landman2020.lean
+++ b/Linglib/Studies/Landman2020.lean
@@ -1,6 +1,6 @@
 import Mathlib.Order.CompleteBooleanAlgebra
 import Mathlib.Data.Set.Card
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 
 /-!
 # Landman (2020) — Iceberg Semantics for Mass Nouns and Count Nouns
@@ -51,7 +51,7 @@ are perspectives on the same stuff, and Boolean atoms play no role.
 
 ## Connections
 
-* The disjointness machinery is `Core/Mereology`'s
+* The disjointness machinery is `Core/Order/Mereology`'s
   `OverlapPred`/`DisjointPred`/`nullSchema` (shared with
   [sutton-filip-2021], whose counting bases are this book's bases and
   whose individuation schemas select among its perspectives —

--- a/Linglib/Studies/LittleMoroneyRoyer2022.lean
+++ b/Linglib/Studies/LittleMoroneyRoyer2022.lean
@@ -1,5 +1,5 @@
 import Linglib.Typology.ClassifierSystem
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Syntax.Tree.Cat
 import Linglib.Core.Logic.Assignment
 import Linglib.Core.Logic.Intensional.Frame

--- a/Linglib/Studies/Moon2026.lean
+++ b/Linglib/Studies/Moon2026.lean
@@ -1,5 +1,5 @@
 import Linglib.Core.Mereotopology
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Studies.Borer2005
 import Linglib.Semantics.Aspect.Incremental
 import Linglib.Studies.Filip2012
@@ -106,7 +106,7 @@ structure Recipe (α : Type*) (n : ℕ) where
     is 5:2:1.5 whether made with 50ml, 20ml, 15ml or with 100ml,
     40ml, 30ml of the respective ingredients.
 
-    Uses `ExtMeasure.μ` from `Core/Mereology.lean`. -/
+    Uses `ExtMeasure.μ` from `Core/Order/Mereology.lean`. -/
 def RatioHolds {n : ℕ} (μ : α → ℚ) (recipe : Recipe α n)
     (parts : Fin n → α) : Prop :=
   ∀ i j, μ (parts i) * recipe.ratios j = μ (parts j) * recipe.ratios i

--- a/Linglib/Studies/Moroney2021.lean
+++ b/Linglib/Studies/Moroney2021.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Definiteness
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Core.Nominal.Determiner
 import Linglib.Core.Nominal.DeterminerLicensing
 import Linglib.Core.Nominal.Description

--- a/Linglib/Studies/Pasternak2019.lean
+++ b/Linglib/Studies/Pasternak2019.lean
@@ -2,7 +2,7 @@ import Linglib.Semantics.Gradability.StatesBased
 import Linglib.Semantics.Attitudes.Confidence
 import Linglib.Semantics.ArgumentStructure.Defs
 import Linglib.Studies.Wellwood2015
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Fragments.English.Predicates.Verbal
 
 /-!
@@ -343,7 +343,7 @@ When `Event = Event Time` and the preorder comes from
 becomes: vP-predicates respect the event-mereology part-of. We expose
 two substrate consequences below: a downward-closure inheritance lemma
 for sort-determined predicates (using `Event.Mereology.sort_preserved`),
-and a g-homogeneity bridge to `Core/Mereology.lean::gHomogeneous`
+and a g-homogeneity bridge to `Core/Order/Mereology.lean::gHomogeneous`
 (triggered when the carrier is a `PartialOrder`).
 
 CSW [cariani-santorio-wellwood-2024] share Pasternak's monotonicity

--- a/Linglib/Studies/Rouillard2026.lean
+++ b/Linglib/Studies/Rouillard2026.lean
@@ -110,7 +110,7 @@ variable {W Time : Type*} [LinearOrder Time]
     are additive, hence any interval can be padded or trimmed to any
     target measure within a one-sided bound.
 
-    Mathlib correspondence: `Core.Mereology.ExtMeasure` is ℚ-valued and
+    Mathlib correspondence: `Mereology.ExtMeasure` is ℚ-valued and
     requires `[SemilatticeSup α]` on the carrier. Intervals are not
     join-semilattices (disjoint intervals cannot be joined into an
     interval), so `ExtMeasure` does not apply directly. `TimeMeasure`
@@ -293,7 +293,7 @@ theorem upwardMonotone_hasIsLeast_of_witness {W : Type*}
     level (matching Rouillard's Table 1) without claiming a structural
     derivation through the MIP at this level of substrate generality. A
     follow-up rebuild on ℚ-valued time-measure substrate (paralleling
-    `Core.Mereology.ExtMeasure`) would let the collapse argument
+    `Mereology.ExtMeasure`) would let the collapse argument
     discharge end-to-end. -/
 theorem no_smallest_open_PTS_geometric [DenselyOrdered Time]
     (rt : Interval Time) (ptsGI : GInterval Time)

--- a/Linglib/Studies/Sauerland2003.lean
+++ b/Linglib/Studies/Sauerland2003.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Linglib.Semantics.Plurality.Algebra
 import Linglib.Semantics.Plurality.Cover
 import Linglib.Features.ContainmentPair

--- a/Linglib/Studies/SuttonFilip2021.lean
+++ b/Linglib/Studies/SuttonFilip2021.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Fintype.Powerset
 import Linglib.Features.Individuation
 import Linglib.Features.MassCount
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 
 /-!
 # Sutton & Filip (2021) — The Count/Mass Distinction for Granular Nouns
@@ -87,7 +87,7 @@ namespace SuttonFilip2021
 
 Their (16)–(18): the schema machinery (`Mereology.OverlapPred`,
 `Mereology.IsMaxDisjointIn`, `Mereology.nullSchema` for `𝒮₀`, their (32))
-lives in `Core/Mereology.lean`, shared with [landman-2020]
+lives in `Core/Order/Mereology.lean`, shared with [landman-2020]
 (`Studies/Landman2020.lean`), whose disjointness thesis it packages.
 A predicate is *overlapping* if two distinct members overlap (their (17)
 omits the distinctness, under which any inhabited predicate self-overlaps

--- a/Linglib/Syntax/MereologicalSyntax/Interpretation.lean
+++ b/Linglib/Syntax/MereologicalSyntax/Interpretation.lean
@@ -12,7 +12,7 @@ mereological syntax to the semantic individuation operator (`Div`) from
 [borer-2005]'s nominal theory, closing the gap between two
 independent uses of mereology in the library:
 
-1. **Semantic mereology** (`Core/Mereology.lean`): part-whole over entities.
+1. **Semantic mereology** (`Core/Order/Mereology.lean`): part-whole over entities.
    CUM (cumulative), QUA (quantized), Div (individuation to atoms).
 2. **Syntactic mereology** (`MereologicalSyntax/`): part-of over syntactic
    objects. SynObj, subjoin, Dimensionality.

--- a/Linglib/Syntax/Minimalist/Phi/Recursion.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Recursion.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Number.Decomposition
 import Linglib.Features.Number.Interp
-import Linglib.Core.Mereology
+import Linglib.Core.Order.Mereology
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.UpperLower.Basic
 


### PR DESCRIPTION
Moves `Core/Mereology.lean` → `Core/Order/Mereology.lean` (pure order/lattice mathematics belongs under `Core/Order/`; first step of the Core dissolution — Mereotopology and Scales to follow).

- §16–§17 (`StrictPartReflecting`/`StrictPartPreserving`, singleton-IsContentPart helper) dissolve into `Studies/BondarenkoElliott2026.lean`, their only consumer; the `MSO ↔ StrictPartPreserving` Iff.rfl bridge and a dangling `MSI_iff_strictPartReflecting` docstring promise are deleted
- backcompat `extMeasure_qua` collapsed into the more general pullback-derived version (positivity hypothesis dropped)

May need a trivial rebase against #168 (adjacent import lines in `Fragments/ASL/Height.lean`).