### PR TITLE
chore: replace native_decide, drop toyModel alias, add bib entries

### DIFF
--- a/Linglib/Semantics/Composition/Effects.lean
+++ b/Linglib/Semantics/Composition/Effects.lean
@@ -629,17 +629,17 @@ theorem gq_cont_roundtrip {F : Frame} (gq : (F.Entity → Prop) → Prop) :
     contAsGQ (gqAsCont gq) = gq := rfl
 
 /-- `every_sem` applied to a restrictor is a `Cont Prop Entity` value. -/
-def every_as_cont (restrictor : toyModel.Entity → Prop) :
-    Cont Prop toyModel.Entity :=
+def every_as_cont (restrictor : toyFrame.Entity → Prop) :
+    Cont Prop toyFrame.Entity :=
   gqAsCont (every_sem restrictor)
 
 /-- `some_sem` applied to a restrictor is a `Cont Prop Entity` value. -/
-def some_as_cont (restrictor : toyModel.Entity → Prop) :
-    Cont Prop toyModel.Entity :=
+def some_as_cont (restrictor : toyFrame.Entity → Prop) :
+    Cont Prop toyFrame.Entity :=
   gqAsCont (some_sem restrictor)
 
 /-- Lowering a scope-taking quantifier = applying it to the scope. -/
-theorem scope_lower_eq_gq_id (restrictor scope' : toyModel.Entity → Prop) :
+theorem scope_lower_eq_gq_id (restrictor scope' : toyFrame.Entity → Prop) :
     handleScope (gqAsCont (every_sem restrictor) |>.bind
       (λ x => Cont.pure (scope' x))) =
     every_sem restrictor scope' := rfl
@@ -789,7 +789,7 @@ theorem john_sees_himself_via_C :
 
     This connects adjunction mechanism
     to [heim-kratzer-1998]'s predicate abstraction. -/
-theorem binding_C_agrees_with_hk (g : Core.Assignment toyModel.Entity) :
+theorem binding_C_agrees_with_hk (g : Core.Assignment toyFrame.Entity) :
     counitApp ba' (store ToyEntity.john)
       (λ i => ToyLexicon.sees_sem i) =
     ToyLexicon.sees_sem (g[1 ↦ ToyEntity.john] 1)
@@ -800,7 +800,7 @@ theorem binding_C_agrees_with_hk (g : Core.Assignment toyModel.Entity) :
   simp only [Function.update_self]
 
 /-- C and H&K agree for Mary as well: `C(<) ▷(m) (λi. sees i) = sees m m`. -/
-theorem binding_C_agrees_with_hk_mary (g : Core.Assignment toyModel.Entity) :
+theorem binding_C_agrees_with_hk_mary (g : Core.Assignment toyFrame.Entity) :
     counitApp ba' (store ToyEntity.mary)
       (λ i => ToyLexicon.sees_sem i) =
     ToyLexicon.sees_sem (g[2 ↦ ToyEntity.mary] 2)

--- a/Linglib/Semantics/Composition/ToyDomain.lean
+++ b/Linglib/Semantics/Composition/ToyDomain.lean
@@ -19,9 +19,6 @@ inductive ToyEntity where
 
 def toyFrame : Frame := { Entity := ToyEntity, Index := Unit }
 
-/-- Backward-compatible alias. -/
-abbrev toyModel := toyFrame
-
 namespace ToyLexicon
 
 open ToyEntity

--- a/Linglib/Semantics/Composition/TypeShifting.lean
+++ b/Linglib/Semantics/Composition/TypeShifting.lean
@@ -31,7 +31,7 @@ namespace Semantics.Composition.TypeShifting
 
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Conjunction (typeRaise)
-open Semantics.Montague (toyModel ToyEntity)
+open Semantics.Montague (toyFrame ToyEntity)
 
 variable {F : Frame}
 
@@ -387,7 +387,7 @@ theorem BE_A_id (domain : List F.Entity) (P : F.Denot Ty.et)
     `A(BE(⟦every⟧(P)))(Q) = ∃x[P(x) ∧ Q(x)]` — existential, not universal.
     Verified on the toy model. -/
 private def toyDomain₁ : List ToyEntity := [.john, .mary, .pizza]
-private def toyEvery : toyModel.Denot Ty.ett := fun P => ∀ x ∈ toyDomain₁, P x
+private def toyEvery : toyFrame.Denot Ty.ett := fun P => ∀ x ∈ toyDomain₁, P x
 
 /-- For non-principal GQs, the round-trip changes truth conditions.
     `every(⊤) = True` but `A(BE(every))(⊤) = False` — the round-trip
@@ -410,9 +410,9 @@ open Semantics.Montague.ToyLexicon (john_sem)
 
 private def toyDomain₂ : List ToyEntity := [.john, .mary, .pizza, .book]
 
-example : lift (F := toyModel) john_sem Semantics.Montague.ToyLexicon.sleeps_sem :=
+example : lift (F := toyFrame) john_sem Semantics.Montague.ToyLexicon.sleeps_sem :=
   show Semantics.Montague.ToyLexicon.sleeps_sem john_sem from trivial
-example : BE (F := toyModel) (lift john_sem) = ident john_sem :=
+example : BE (F := toyFrame) (lift john_sem) = ident john_sem :=
   BE_lift_eq_ident john_sem
 
 end ToyExamples

--- a/Linglib/Semantics/ContentLayer.lean
+++ b/Linglib/Semantics/ContentLayer.lean
@@ -217,7 +217,7 @@ private def kfWorlds : List KFWorld := [.kingBald, .kingHairy, .noKing1, .noKing
     Corresponds to the standard propositional-denial reading of (30). -/
 theorem kf_propositional_denial :
     offensiveLayers kfProp (λ w => w == .kingHairy) kfWorlds = [.atIssue] := by
-  native_decide
+  decide
 
 /-- Presuppositional denial: correction "no king exists" conflicts with
     both `pr` and `fr`.
@@ -231,7 +231,7 @@ theorem kf_propositional_denial :
 theorem kf_presuppositional_denial :
     offensiveLayers kfProp (λ w => w == .noKing1 || w == .noKing2) kfWorlds
     = [.presupposition, .atIssue] := by
-  native_decide
+  decide
 
 /-! ### Example 2: Possibility → Necessity (29)
 
@@ -268,7 +268,7 @@ private def modalWorlds : List ModalW := [.possNotNec, .nec]
 theorem modal_implicature_denial :
     offensiveLayers modalProp (λ w => w == .nec) modalWorlds
     = [.implicature] := by
-  native_decide
+  decide
 
 /-! ### `BiLayered`: 2-layer ⟨A, N⟩ Prop-valued sibling
 

--- a/Linglib/Semantics/Definiteness/Basic.lean
+++ b/Linglib/Semantics/Definiteness/Basic.lean
@@ -42,7 +42,7 @@ This module retains:
 namespace Semantics.Definiteness
 
 open Core.Logic.Intensional (Frame Ty)
-open Semantics.Montague (toyModel ToyEntity)
+open Semantics.Montague (toyFrame ToyEntity)
 open Semantics.Quantification.Quantifier (every_sem some_sem Ty.det)
 open Semantics.Composition.TypeShifting (iota lift)
 open Semantics.Presupposition (PrProp)

--- a/Linglib/Semantics/Quantification/Quantifier.lean
+++ b/Linglib/Semantics/Quantification/Quantifier.lean
@@ -27,7 +27,7 @@ witness type.
 namespace Semantics.Quantification.Quantifier
 
 open Core.Logic.Intensional
-open Semantics.Montague (toyModel ToyEntity)
+open Semantics.Montague (toyFrame ToyEntity)
 open Core.Quantification
 
 export Core.Quantification
@@ -100,28 +100,28 @@ instance : Fintype ToyEntity where
   elems := {.john, .mary, .pizza, .book}
   complete := fun x => by cases x <;> simp
 
-/-- Bridge: `toyModel.Entity = ToyEntity` is definitional but opaque to
+/-- Bridge: `toyFrame.Entity = ToyEntity` is definitional but opaque to
     instance search. -/
-instance : Fintype toyModel.Entity :=
+instance : Fintype toyFrame.Entity :=
   show Fintype ToyEntity by infer_instance
 
 /-! ### Toy lexicon -/
 
 section ToyLexicon
 
-def student_sem : toyModel.Denot (.e ⇒ .t) :=
+def student_sem : toyFrame.Denot (.e ⇒ .t) :=
   λ x => match x with
     | .john => True
     | .mary => True
     | _ => False
 
-def person_sem : toyModel.Denot (.e ⇒ .t) :=
+def person_sem : toyFrame.Denot (.e ⇒ .t) :=
   λ x => match x with
     | .john => True
     | .mary => True
     | _ => False
 
-def thing_sem : toyModel.Denot (.e ⇒ .t) :=
+def thing_sem : toyFrame.Denot (.e ⇒ .t) :=
   λ _ => True
 
 instance : DecidablePred student_sem :=

--- a/Linglib/Studies/Asudeh2022.lean
+++ b/Linglib/Studies/Asudeh2022.lean
@@ -366,7 +366,7 @@ end EveryLovesSome
 /-! The Glue logic tells us *how* to compose meanings but not *what*
     the meanings are. The meaning terms are ordinary Montague-style
     denotations. We connect Glue proofs to truth conditions by
-    evaluating them over the same `toyModel` used by
+    evaluating them over the same `toyFrame` used by
     `QuantifierComposition.lean`.
 
     The toy model has no `love` predicate, so we use `sees_sem` as
@@ -438,15 +438,15 @@ open Semantics.Composition.Tree
 open Core.Logic.Intensional.Variables
 
 /-- Lexicon for the QR bridge (matching QuantifierComposition). -/
-private def bridgeLex : Lexicon toyModel := λ word =>
+private def bridgeLex : Lexicon toyFrame := λ word =>
   match word with
-  | "every" => some ⟨Ty.det, (every_sem : toyModel.Denot Ty.det)⟩
-  | "some" => some ⟨Ty.det, (some_sem : toyModel.Denot Ty.det)⟩
+  | "every" => some ⟨Ty.det, (every_sem : toyFrame.Denot Ty.det)⟩
+  | "some" => some ⟨Ty.det, (some_sem : toyFrame.Denot Ty.det)⟩
   | "person" => some ⟨.e ⇒ .t, person_sem⟩
   | "sees" => some ⟨.e ⇒ .e ⇒ .t, ToyLexicon.sees_sem⟩
   | _ => none
 
-private def g₀ : Core.Assignment toyModel.Entity := λ _ => .john
+private def g₀ : Core.Assignment toyFrame.Entity := λ _ => .john
 
 /-- Surface scope QR tree (∀>∃):
     `[S [DP every person] [1 [S [DP some person] [2 [S t₁ [VP sees t₂]]]]]]` -/

--- a/Linglib/Studies/Belnap1970.lean
+++ b/Linglib/Studies/Belnap1970.lean
@@ -75,7 +75,7 @@ open Core.Duality (Truth3)
 open Aristotelian (Square SquareRelations)
 open Semantics.Quantification.Quantifier
 open Core.Logic.Intensional (Frame)
-open Semantics.Montague (toyModel ToyEntity)
+open Semantics.Montague (toyFrame ToyEntity)
 
 -- ════════════════════════════════════════════════════════════════
 -- §2–3. Conditional Assertion as PrProp
@@ -365,7 +365,7 @@ theorem i_conversion_equitrue {m : Frame} [Fintype m.Entity]
 theorem i_conversion_not_equiassertive :
     ∃ (m : Frame) (_ : Fintype m.Entity) (C B : m.Entity → Bool),
     ((restrictedExists C B).presup () ∧ ¬(restrictedExists B C).presup ()) := by
-  refine ⟨toyModel, inferInstance,
+  refine ⟨toyFrame, inferInstance,
     (λ x => match x with | .john => true | _ => false),
     (λ _ => false), ?_⟩
   simp only [restrictedExists]

--- a/Linglib/Studies/HeimKratzer1998.lean
+++ b/Linglib/Studies/HeimKratzer1998.lean
@@ -60,10 +60,10 @@ open Semantics.Quantification.Quantifier
 
 /-! ### Model and lexicon -/
 
-def quantLex : Lexicon toyModel := λ word =>
+def quantLex : Lexicon toyFrame := λ word =>
   match word with
-  | "every" => some ⟨Ty.det, (every_sem : toyModel.Denot Ty.det)⟩
-  | "some" => some ⟨Ty.det, (some_sem : toyModel.Denot Ty.det)⟩
+  | "every" => some ⟨Ty.det, (every_sem : toyFrame.Denot Ty.det)⟩
+  | "some" => some ⟨Ty.det, (some_sem : toyFrame.Denot Ty.det)⟩
   | "student" => some ⟨.e ⇒ .t, student_sem⟩
   | "person" => some ⟨.e ⇒ .t, person_sem⟩
   | "sleeps" => some ⟨.e ⇒ .t, ToyLexicon.sleeps_sem⟩
@@ -71,7 +71,7 @@ def quantLex : Lexicon toyModel := λ word =>
   | "sees" => some ⟨.e ⇒ .e ⇒ .t, ToyLexicon.sees_sem⟩
   | _ => none
 
-def g₀ : Core.Assignment toyModel.Entity := λ _ => .john
+def g₀ : Core.Assignment toyFrame.Entity := λ _ => .john
 
 /-! ### "Every student sleeps" -/
 

--- a/Linglib/Studies/Katzir2007.lean
+++ b/Linglib/Studies/Katzir2007.lean
@@ -37,7 +37,7 @@ namespace Katzir2007
 
 open Syntax
 open Semantics.Composition.Tree
-open Semantics.Montague (toyModel ToyEntity)
+open Semantics.Montague (toyFrame ToyEntity)
 open Semantics.Montague.ToyLexicon (sleeps_sem)
 open Semantics.Quantification.Quantifier (some_sem every_sem student_sem)
 
@@ -106,14 +106,14 @@ cannot be generated from L(φ) = lexicon ∪ subtrees(φ) because
 the source tree φ contains neither category. -/
 
 /-- φ contains no ConjP anywhere in its structure. -/
-theorem no_conjp : φ.containsCat Cat.ConjP = false := by native_decide
+theorem no_conjp : φ.containsCat Cat.ConjP = false := by decide
 
 /-- φ contains no NegP anywhere in its structure. -/
-theorem no_negp : φ.containsCat Cat.NegP = false := by native_decide
+theorem no_negp : φ.containsCat Cat.NegP = false := by decide
 
 /-- None of φ's subtrees contain ConjP either. -/
 theorem subtrees_lack_conjp :
-    φ.subtrees.all (λ t => !t.containsCat Cat.ConjP) = true := by native_decide
+    φ.subtrees.all (λ t => !t.containsCat Cat.ConjP) = true := by decide
 
 -- Therefore: "some but not all students sleep" requires introducing
 -- ConjP and NegP structure not available in L(φ), so it is not a

--- a/Linglib/Studies/Ladusaw1979.lean
+++ b/Linglib/Studies/Ladusaw1979.lean
@@ -33,7 +33,7 @@ namespace Ladusaw1979
 open Core.Quantification
 open Typology.PolarityItem (LicensingContext)
 open Core.Logic.Intensional
-open Semantics.Montague (toyModel ToyEntity)
+open Semantics.Montague (toyFrame ToyEntity)
 open Semantics.Quantification.Quantifier
 
 -- ============================================================================

--- a/Linglib/Studies/ScontrasPearl2021.lean
+++ b/Linglib/Studies/ScontrasPearl2021.lean
@@ -61,7 +61,7 @@ def ccg_john_eats_pizza : DerivStep :=
 -- Extended Semantic Lexicon (matching the toy model)
 
 /-- Extended lexicon with all entities and predicates -/
-def extendedLexicon : SemLexicon toyModel := λ word cat =>
+def extendedLexicon : SemLexicon toyFrame := λ word cat =>
   match word, cat with
   -- Proper names
   | "John", .atom .NP => some ⟨NP, ToyEntity.john⟩

--- a/Linglib/Syntax/CCG/Interface.lean
+++ b/Linglib/Syntax/CCG/Interface.lean
@@ -45,7 +45,7 @@ structure SemLexEntry (F : Frame) where
   sem : F.Denot (catToTy cat)
 
 /-- Semantic lexicon for the toy model -/
-def semLexicon : List (SemLexEntry toyModel) := [
+def semLexicon : List (SemLexEntry toyFrame) := [
   -- Proper names: NP (type e)
   ⟨"John", NP, ToyEntity.john⟩,
   ⟨"Mary", NP, ToyEntity.mary⟩,
@@ -74,11 +74,11 @@ def semLexicon : List (SemLexEntry toyModel) := [
 -- Syntactically: John:NP  sleeps:S\NP  ⇒  S
 -- Semantically: sleeps_sem(john_sem) : t
 
-def john_sem' : toyModel.Denot (catToTy NP) := ToyEntity.john
-def sleeps_sem' : toyModel.Denot (catToTy IV) := ToyLexicon.sleeps_sem
+def john_sem' : toyFrame.Denot (catToTy NP) := ToyEntity.john
+def sleeps_sem' : toyFrame.Denot (catToTy IV) := ToyLexicon.sleeps_sem
 
 -- The semantic derivation mirrors the syntactic one
-def john_sleeps_sem : toyModel.Denot (catToTy S) :=
+def john_sleeps_sem : toyFrame.Denot (catToTy S) :=
   sleeps_sem' john_sem'
 
 -- Example: "John sees Mary"
@@ -93,34 +93,34 @@ def john_sleeps_sem : toyModel.Denot (catToTy S) :=
 --   sees_sem(mary) : e → t
 --   (sees_sem(mary))(john) : t
 
-def sees_sem' : toyModel.Denot (catToTy TV) := ToyLexicon.sees_sem
-def mary_sem' : toyModel.Denot (catToTy NP) := ToyEntity.mary
+def sees_sem' : toyFrame.Denot (catToTy TV) := ToyLexicon.sees_sem
+def mary_sem' : toyFrame.Denot (catToTy NP) := ToyEntity.mary
 
 -- Step 1: sees Mary
-def sees_mary_sem : toyModel.Denot (catToTy IV) :=
+def sees_mary_sem : toyFrame.Denot (catToTy IV) :=
   sees_sem' mary_sem'  -- function application
 
 -- Step 2: John (sees Mary)
-def john_sees_mary_sem : toyModel.Denot (catToTy S) :=
+def john_sees_mary_sem : toyFrame.Denot (catToTy S) :=
   sees_mary_sem john_sem'  -- function application
 
 -- Example: "Mary sees John"
 
-def mary_sees_john_sem : toyModel.Denot (catToTy S) :=
+def mary_sees_john_sem : toyFrame.Denot (catToTy S) :=
   (sees_sem' john_sem') mary_sem'
 
 -- Example: "John eats pizza"
 
-def eats_sem' : toyModel.Denot (catToTy TV) := ToyLexicon.eats_sem
-def pizza_sem' : toyModel.Denot (catToTy NP) := ToyEntity.pizza
+def eats_sem' : toyFrame.Denot (catToTy TV) := ToyLexicon.eats_sem
+def pizza_sem' : toyFrame.Denot (catToTy NP) := ToyEntity.pizza
 
-def john_eats_pizza_sem : toyModel.Denot (catToTy S) :=
+def john_eats_pizza_sem : toyFrame.Denot (catToTy S) :=
   (eats_sem' pizza_sem') john_sem'
 
 -- Truth Conditions from CCG Derivations
 
 /-- A sentence is true if its meaning holds. -/
-def sentenceTrue (meaning : toyModel.Denot .t) : Prop :=
+def sentenceTrue (meaning : toyFrame.Denot .t) : Prop :=
   meaning
 
 -- Derivation-Driven Semantic Composition
@@ -197,8 +197,8 @@ theorem composition_is_application {F : Frame} {σ τ : Ty}
 /--
 For a lexical entry, we can always extract its meaning.
 -/
-theorem lexical_has_meaning (entry : SemLexEntry toyModel) :
-    ∃ (meaning : toyModel.Denot (catToTy entry.cat)), meaning = entry.sem :=
+theorem lexical_has_meaning (entry : SemLexEntry toyFrame) :
+    ∃ (meaning : toyFrame.Denot (catToTy entry.cat)), meaning = entry.sem :=
   ⟨entry.sem, rfl⟩
 
 /--
@@ -216,23 +216,23 @@ theorem combination_has_meaning {F : Frame} {x y : Cat}
 /-- The complete derivation of "John sees Mary" preserving types -/
 theorem john_sees_mary_typed_derivation :
     -- 1. sees : (S\NP)/NP has type e → e → t
-    let sees_ty : toyModel.Denot (catToTy TV) := ToyLexicon.sees_sem
+    let sees_ty : toyFrame.Denot (catToTy TV) := ToyLexicon.sees_sem
     -- 2. Mary : NP has type e
-    let mary_ty : toyModel.Denot (catToTy NP) := ToyEntity.mary
+    let mary_ty : toyFrame.Denot (catToTy NP) := ToyEntity.mary
     -- 3. sees Mary : S\NP has type e → t
-    let sees_mary_ty : toyModel.Denot (catToTy IV) := sees_ty mary_ty
+    let sees_mary_ty : toyFrame.Denot (catToTy IV) := sees_ty mary_ty
     -- 4. John : NP has type e
-    let john_ty : toyModel.Denot (catToTy NP) := ToyEntity.john
+    let john_ty : toyFrame.Denot (catToTy NP) := ToyEntity.john
     -- 5. John sees Mary : S has type t
-    let result : toyModel.Denot (catToTy S) := sees_mary_ty john_ty
+    let result : toyFrame.Denot (catToTy S) := sees_mary_ty john_ty
     -- The result is the expected truth value
     result := trivial
 
 /-- The derivation of "Mary sleeps" preserving types -/
 theorem mary_sleeps_typed_derivation :
-    let sleeps_ty : toyModel.Denot (catToTy IV) := ToyLexicon.sleeps_sem
-    let mary_ty : toyModel.Denot (catToTy NP) := ToyEntity.mary
-    let result : toyModel.Denot (catToTy S) := sleeps_ty mary_ty
+    let sleeps_ty : toyFrame.Denot (catToTy IV) := ToyLexicon.sleeps_sem
+    let mary_ty : toyFrame.Denot (catToTy NP) := ToyEntity.mary
+    let result : toyFrame.Denot (catToTy S) := sleeps_ty mary_ty
     ¬result := id
 
 -- THE HOMOMORPHISM PRINCIPLE
@@ -285,7 +285,7 @@ structure Interp (F : Frame) where
 def SemLexicon (F : Frame) := String → Cat → Option (Interp F)
 
 /-- The toy semantic lexicon -/
-def toySemLexicon : SemLexicon toyModel := λ word cat =>
+def toySemLexicon : SemLexicon toyFrame := λ word cat =>
   match word, cat with
   -- Proper names
   | "John", .atom .NP => some ⟨NP, ToyEntity.john⟩
@@ -311,8 +311,8 @@ Interpret a CCG derivation, computing its meaning from the lexicon.
 
 Returns `none` if the derivation is ill-formed or uses unknown words.
 -/
-def DerivStep.interp (d : DerivStep) (lex : SemLexicon toyModel)
-    : Option (Interp toyModel) :=
+def DerivStep.interp (d : DerivStep) (lex : SemLexicon toyFrame)
+    : Option (Interp toyFrame) :=
   match d with
   | .lex entry => lex entry.form entry.cat
 
@@ -325,7 +325,7 @@ def DerivStep.interp (d : DerivStep) (lex : SemLexicon toyModel)
           if h : c2 = y then
             -- m1 : catToTy y ⇒ catToTy x
             -- m2 : catToTy c2 = catToTy y
-            let m2' : toyModel.Denot (catToTy y) := h ▸ m2
+            let m2' : toyFrame.Denot (catToTy y) := h ▸ m2
             some ⟨x, m1 m2'⟩
           else none
       | _ => none
@@ -339,7 +339,7 @@ def DerivStep.interp (d : DerivStep) (lex : SemLexicon toyModel)
           if h : c1 = y then
             -- m2 : catToTy y ⇒ catToTy x
             -- m1 : catToTy c1 = catToTy y
-            let m1' : toyModel.Denot (catToTy y) := h ▸ m1
+            let m1' : toyFrame.Denot (catToTy y) := h ▸ m1
             some ⟨x, m2 m1'⟩
           else none
       | _ => none
@@ -355,7 +355,7 @@ def DerivStep.interp (d : DerivStep) (lex : SemLexicon toyModel)
             -- m1 : catToTy y1 → catToTy x
             -- m2 : catToTy z → catToTy y2
             -- B m1 m2 : catToTy z → catToTy x
-            let m2' : toyModel.Denot (catToTy z ⇒ catToTy y1) :=
+            let m2' : toyFrame.Denot (catToTy z ⇒ catToTy y1) :=
               h ▸ m2
             some ⟨x / z, B m1 m2'⟩
           else none
@@ -372,7 +372,7 @@ def DerivStep.interp (d : DerivStep) (lex : SemLexicon toyModel)
             -- m1 : catToTy z → catToTy y1
             -- m2 : catToTy y2 → catToTy x
             -- B m2 m1 : catToTy z → catToTy x
-            let m1' : toyModel.Denot (catToTy z ⇒ catToTy y2) :=
+            let m1' : toyFrame.Denot (catToTy z ⇒ catToTy y2) :=
               h ▸ m1
             some ⟨x \ z, B m2 m1'⟩
           else none
@@ -406,15 +406,15 @@ def DerivStep.interp (d : DerivStep) (lex : SemLexicon toyModel)
         let ty := catToTy c1
         -- Only conjoinable types can be coordinated
         if ty.isConjoinable then
-          let m2' : toyModel.Denot (catToTy c1) := h ▸ m2
-          some ⟨c1, genConj ty toyModel m1 m2'⟩
+          let m2' : toyFrame.Denot (catToTy c1) := h ▸ m2
+          some ⟨c1, genConj ty toyFrame m1 m2'⟩
         else none
       else none
 
 -- INTERPRETATION EXAMPLES
 
 /-- Helper to extract meaning from interpretation result -/
-def getMeaning (result : Option (Interp toyModel)) : Option Prop :=
+def getMeaning (result : Option (Interp toyFrame)) : Option Prop :=
   match result with
   | some ⟨.atom .S, m⟩ => some m
   | _ => none
@@ -524,7 +524,7 @@ Extract the meaning of a coordination derivation as a function.
 For an S/NP derivation (like "John likes and Mary hates"),
 the meaning is a predicate on entities.
 -/
-def getPredicateMeaning (result : Option (Interp toyModel))
+def getPredicateMeaning (result : Option (Interp toyFrame))
     : Option (ToyEntity → Prop) :=
   match result with
   | some ⟨.rslash (.atom .S) (.atom .NP), m⟩ => some m

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -32501,3 +32501,36 @@
   subfield  = {syntax/clitics},
   role      = {cited}
 }
+
+% REF: Keenan, E. L. & Faltz, L. M. (1985). Boolean Semantics for Natural Language. Reidel.
+@book{keenan-faltz-1985,
+  author    = {Keenan, Edward L. and Faltz, Leonard M.},
+  year      = {1985},
+  title     = {Boolean Semantics for Natural Language},
+  series    = {Synthese Language Library},
+  volume    = {23},
+  publisher = {D. Reidel},
+  address   = {Dordrecht},
+  doi       = {10.1007/978-94-009-6404-4},
+  subfield  = {semantics/compositional},
+  role      = {cited},
+  validated = {true},
+  sources   = {Semantics/Composition/TypeShifting.lean}
+}
+
+% REF: Wilder, C. (2008). Shared constituents and linearization. In K. Johnson (ed.), Topics in Ellipsis. CUP.
+@incollection{wilder-2008,
+  author    = {Wilder, Chris},
+  year      = {2008},
+  title     = {Shared Constituents and Linearization},
+  booktitle = {Topics in Ellipsis},
+  editor    = {Johnson, Kyle},
+  pages     = {229--258},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  url       = {https://www.cambridge.org/core/books/abs/topics-in-ellipsis/shared-constituents-and-linearization/EB5C6F507C43676742AEC7B8EFE32F7C},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Syntax/Minimalist/Multidominance.lean}
+}


### PR DESCRIPTION
Hygiene bundle from the Composition and Tree audits.

- 6× `native_decide` → `decide` (ContentLayer layered-denial theorems, Katzir2007 `containsCat` checks — small closed-term computations)
- `toyModel` alias dropped; 12 callers renamed to `toyFrame`
- verified bib entries for `keenan-faltz-1985` and `wilder-2008` (fixes the dangling key in Multidominance.lean); bibliography regenerated in CI