### PR TITLE
feat(Core/Order): FiniteBranching mixin, yield, and linear precedence

### DIFF
--- a/Linglib/Core/Order/Branching.lean
+++ b/Linglib/Core/Order/Branching.lean
@@ -20,12 +20,13 @@ precedence and planarity are real structure that mathlib's
 `Quiver`/`Digraph`/`SimpleGraph` forget, so those are forgetful shadows
 of this class, not its basis.
 
-**No well-foundedness is required here.** The path machinery recurses
-on the *path* (structurally decreasing `List Nat`), not on `T`, so
-this class is law-free on the carrier and still theorem-rich; carriers
-with infinite depth are admissible. Recursion *on the carrier* (size,
-subtree enumeration, yield) needs the `FiniteBranching` mixin (future
-work, phase 2).
+**No well-foundedness is required for the base class.** The path
+machinery recurses on the *path* (structurally decreasing `List Nat`),
+not on `T`, so `Branching` is law-free on the carrier and still
+theorem-rich; carriers with infinite depth are admissible. Recursion
+*on the carrier* (`size`, `subtrees`, `yield`, `inductionOn`) needs
+the `FiniteBranching` mixin below, whose one law — children strictly
+decrease `sizeOf` — concrete inductives discharge by `cases` + `omega`.
 
 Known instance candidates across the library (2026-06-06 audit):
 `Syntax.Tree` (constituency), `NanoTree` (Nanosyntax features),
@@ -105,6 +106,78 @@ def toTreeOrder (t : T) : TreeOrder TreePath where
   root_in_nodes := bot_mem_validPaths t
   root_le_all := fun _ _ => List.nil_prefix
   ancestor_connected := fun _ _ _ h₁ h₂ => TreePath.prefix_or_prefix h₁ h₂
+
+end Branching
+
+/-! ### `FiniteBranching`: the recursion mixin
+
+Recursion *on the carrier* (size, subtree enumeration, yield,
+induction) is not definable from `Branching` alone: Lean cannot see
+structural decrease through a class field. The mixin supplies the
+missing law — children strictly decrease `sizeOf` — which concrete
+inductive carriers discharge by `cases` + `omega` over their
+auto-derived `SizeOf`. -/
+
+/-- A `Branching` carrier whose children strictly decrease `sizeOf`.
+Unlocks carrier recursion: `size`, `subtrees`, `yield`, `inductionOn`. -/
+class FiniteBranching (T : Type*) [SizeOf T] extends Branching T where
+  /-- Children are `sizeOf`-smaller than their parent. -/
+  sizeOf_children : ∀ {c t : T}, c ∈ Branching.children t → sizeOf c < sizeOf t
+
+namespace Branching
+
+variable {T : Type*} [SizeOf T] [FiniteBranching T]
+
+/-- Number of nodes. -/
+def size (t : T) : Nat :=
+  1 + ((children t).attach.map (fun ⟨c, hc⟩ => size c)).sum
+termination_by sizeOf t
+decreasing_by exact FiniteBranching.sizeOf_children hc
+
+/-- All subtrees including self, pre-order. -/
+def subtrees (t : T) : List T :=
+  t :: (children t).attach.flatMap (fun ⟨c, hc⟩ => subtrees c)
+termination_by sizeOf t
+decreasing_by exact FiniteBranching.sizeOf_children hc
+
+theorem self_mem_subtrees (t : T) : t ∈ subtrees t := by
+  rw [subtrees]; exact List.mem_cons_self ..
+
+/-- Strong induction over a `FiniteBranching` carrier: prove `motive t`
+from `motive` on all children. -/
+theorem inductionOn {motive : T → Prop} (t : T)
+    (ih : ∀ t, (∀ c ∈ children t, motive c) → motive t) : motive t := by
+  induction ht : sizeOf t using Nat.strong_induction_on generalizing t with
+  | _ n ihn =>
+    subst ht
+    exact ih t fun c hc =>
+      ihn (sizeOf c) (FiniteBranching.sizeOf_children hc) c rfl
+
+end Branching
+
+/-! ### `HasContent` and yield
+
+Separate class because not every rose-tree carrier has terminal
+content (Nanosyntax trees carry features on every node; CFG derivation
+trees distinguish terminal from nonterminal types). -/
+
+/-- Carriers whose nodes may carry pronounceable terminal content. -/
+class HasContent (T : Type*) (W : outParam Type*) where
+  /-- Terminal content, if any. -/
+  content? : T → Option W
+
+export HasContent (content?)
+
+namespace Branching
+
+variable {T W : Type*} [SizeOf T] [FiniteBranching T] [HasContent T W]
+
+/-- Terminal yield, left to right: the frontier string. The most basic
+tree-to-string map — linear precedence lives over it. -/
+def yield (t : T) : List W :=
+  (content? t).toList ++ (children t).attach.flatMap (fun ⟨c, hc⟩ => yield c)
+termination_by sizeOf t
+decreasing_by exact FiniteBranching.sizeOf_children hc
 
 end Branching
 

--- a/Linglib/Core/Order/TreePath.lean
+++ b/Linglib/Core/Order/TreePath.lean
@@ -207,6 +207,50 @@ def IsSister (p q : TreePath) : Prop := p ≠ q ∧ p.parent = q.parent
 theorem isSister_symm {p q : TreePath} (h : IsSister p q) : IsSister q p :=
   ⟨h.1.symm, h.2.symm⟩
 
+/-! ### Linear precedence
+
+The PF-side order that dominance forgets: `p` precedes `q` iff their
+paths diverge at some common prefix with `p` taking an earlier branch.
+Defined only between dominance-incomparable positions
+(`Precedes.not_le`, `Precedes.not_ge`) — a node neither precedes nor
+follows its ancestors, the ID/LP division of labor. -/
+
+/-- `p` linearly precedes `q`: at some shared position `r`, `p`
+continues into an earlier child than `q`. -/
+def Precedes (p q : TreePath) : Prop :=
+  ∃ (r : List Nat) (i j : Nat), i < j ∧
+    (r ++ [i]) <+: p.toList ∧ (r ++ [j]) <+: q.toList
+
+namespace Precedes
+
+/-- Two extensions of the same position by single indices that are both
+prefixes of one path carry the same index. -/
+private theorem branch_unique {r : List Nat} {i j : Nat} {l : List Nat}
+    (hi : (r ++ [i]) <+: l) (hj : (r ++ [j]) <+: l) : i = j := by
+  have hcomp := List.prefix_or_prefix_of_prefix hi hj
+  have hlen : (r ++ [i]).length = (r ++ [j]).length := by simp
+  rcases hcomp with h | h
+  · simpa using List.append_inj_right (h.eq_of_length hlen) rfl
+  · simpa using (List.append_inj_right (h.eq_of_length hlen.symm) rfl).symm
+
+theorem irrefl (p : TreePath) : ¬ Precedes p p := by
+  rintro ⟨r, i, j, hij, hi, hj⟩
+  exact absurd (branch_unique hi hj) (Nat.ne_of_lt hij)
+
+/-- Precedence excludes dominance. -/
+theorem not_le {p q : TreePath} (h : Precedes p q) : ¬ p ≤ q := by
+  rintro hle
+  obtain ⟨r, i, j, hij, hi, hj⟩ := h
+  exact absurd (branch_unique (hi.trans hle) hj) (Nat.ne_of_lt hij)
+
+/-- Precedence excludes being dominated. -/
+theorem not_ge {p q : TreePath} (h : Precedes p q) : ¬ q ≤ p := by
+  rintro hle
+  obtain ⟨r, i, j, hij, hi, hj⟩ := h
+  exact absurd (branch_unique hi (hj.trans hle)) (Nat.ne_of_lt hij)
+
+end Precedes
+
 end TreePath
 
 end Core.Order

--- a/Linglib/Syntax/Tree/Basic.lean
+++ b/Linglib/Syntax/Tree/Basic.lean
@@ -321,6 +321,32 @@ instance {C W : Type} : Core.Order.Branching (Tree C W) where
     | .trace _ _ => []
     | .bind _ _ body => [body]
 
+/-- Children strictly decrease `sizeOf`, unlocking the generic
+recursion API (`Branching.size`, `subtrees`, `yield`, `inductionOn`). -/
+instance {C W : Type} : Core.Order.FiniteBranching (Tree C W) where
+  sizeOf_children {c t} hc := by
+    cases t with
+    | terminal _ _ => simp [Core.Order.Branching.children] at hc
+    | node _ cs =>
+      simp only [Core.Order.Branching.children] at hc
+      have := List.sizeOf_lt_of_mem hc
+      simp only [Tree.node.sizeOf_spec]
+      omega
+    | trace _ _ => simp [Core.Order.Branching.children] at hc
+    | bind _ _ body =>
+      simp only [Core.Order.Branching.children, List.mem_singleton] at hc
+      subst hc
+      simp only [Tree.bind.sizeOf_spec]
+      omega
+
+/-- Terminal content: the word at a `terminal`; traces, binders, and
+internal nodes are contentless, so `Branching.yield` computes the
+frontier string. -/
+instance {C W : Type} : Core.Order.HasContent (Tree C W) W where
+  content?
+    | .terminal _ w => some w
+    | _ => none
+
 end Syntax
 
 /-! ### FreeMagma → Tree forgetful map -/


### PR DESCRIPTION
Phase 2 of the tree abstraction tower.

- `FiniteBranching`: recursion mixin (one law: children strictly decrease `sizeOf`) deriving `size`, `subtrees`, and `inductionOn` for every instance
- `HasContent` + `Branching.yield`: the frontier string (terminal yield), previously missing from the tree API
- `TreePath.Precedes`: linear precedence as branch divergence, with `irrefl`/`not_le`/`not_ge` — the ID/LP division of labor as theorems
- `Syntax.Tree` gains `FiniteBranching` and `HasContent` instances