### PR TITLE
feat(Core/Order): Branching instances for four rose-tree carriers

### DIFF
--- a/Linglib/Core/Combinatorics/RootedTree/Planar.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Planar.lean
@@ -1,6 +1,7 @@
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Logic.Equiv.Defs
+import Linglib.Core.Order.Branching
 
 set_option autoImplicit false
 
@@ -293,3 +294,27 @@ instance [Inhabited α] : Inhabited (Planar α) :=
 end Planar
 
 end RootedTree
+
+/-! ### Rose-tree interface instances
+
+`Planar` joins the `Core.Order.Branching` tower: Gorn-address
+machinery, the dominance order, and the B&P command bridge come
+generically from the `children` projection. -/
+
+namespace RootedTree.Planar
+
+instance {α : Type*} : Core.Order.Branching (Planar α) := ⟨Planar.children⟩
+
+@[simp] theorem branching_children {α : Type*} (t : Planar α) :
+    Core.Order.Branching.children t = t.children := rfl
+
+instance {α : Type*} : Core.Order.FiniteBranching (Planar α) where
+  sizeOf_children {c t} hc := by
+    cases t with
+    | node a cs =>
+      simp only [branching_children, Planar.children] at hc
+      have := List.sizeOf_lt_of_mem hc
+      simp only [Planar.node.sizeOf_spec]
+      omega
+
+end RootedTree.Planar

--- a/Linglib/Core/Computability/ContextFreeGrammar/Tree.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Tree.lean
@@ -1,5 +1,6 @@
 import Mathlib.Computability.ContextFreeGrammar
 import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
+import Linglib.Core.Order.Branching
 
 /-!
 # Derivation Trees for Context-Free Grammars
@@ -1098,5 +1099,40 @@ theorem validFor_derives {T : Type*} {g : ContextFreeGrammar T}
        ContextFreeRule.Rewrites.input_output⟩).trans
       (derives_yieldList children (fun c hc => validFor_derives c (hchildren c hc)))
 termination_by t
+
+end CFGTree
+
+/-! ### Rose-tree interface instances
+
+`CFGTree.Pos` is the Gorn address — exactly
+`Core.Order.TreePath.toList` — so the generic
+`Core.Order.Branching.subtreeAt` walks the same positions as
+`subtreeAt?`. The structural `size`/`height`/`yield` above remain the
+kernel-computable specializations of the generic API. -/
+
+namespace CFGTree
+
+variable {T N : Type*}
+
+instance : Core.Order.Branching (CFGTree T N) where
+  children
+    | .leaf _ => []
+    | .node _ cs => cs
+
+@[simp] theorem branching_children_leaf (t : T) :
+    Core.Order.Branching.children (CFGTree.leaf (N := N) t) = [] := rfl
+
+@[simp] theorem branching_children_node (nt : N) (cs : List (CFGTree T N)) :
+    Core.Order.Branching.children (CFGTree.node nt cs) = cs := rfl
+
+instance : Core.Order.FiniteBranching (CFGTree T N) where
+  sizeOf_children {c t} hc := by
+    cases t with
+    | leaf _ => simp at hc
+    | node nt cs =>
+      simp only [branching_children_node] at hc
+      have := List.sizeOf_lt_of_mem hc
+      simp only [CFGTree.node.sizeOf_spec]
+      omega
 
 end CFGTree

--- a/Linglib/Core/Order/Branching.lean
+++ b/Linglib/Core/Order/Branching.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Order.TreePath
 import Linglib.Core.Order.Tree
+import Mathlib.Algebra.Free
 
 /-!
 # `Branching`: the rose-tree interface
@@ -134,11 +135,22 @@ def size (t : T) : Nat :=
 termination_by sizeOf t
 decreasing_by exact FiniteBranching.sizeOf_children hc
 
+/-- Attach-free unfolding of `size`, for concrete computation. -/
+theorem size_def (t : T) :
+    size t = 1 + ((children t).map size).sum := by
+  rw [size, List.attach_map_val]
+
 /-- All subtrees including self, pre-order. -/
 def subtrees (t : T) : List T :=
   t :: (children t).attach.flatMap (fun ⟨c, hc⟩ => subtrees c)
 termination_by sizeOf t
 decreasing_by exact FiniteBranching.sizeOf_children hc
+
+/-- Attach-free unfolding of `subtrees`, for concrete computation. -/
+theorem subtrees_def (t : T) :
+    subtrees t = t :: (children t).flatMap subtrees := by
+  rw [subtrees]
+  simp [List.flatMap_def]
 
 theorem self_mem_subtrees (t : T) : t ∈ subtrees t := by
   rw [subtrees]; exact List.mem_cons_self ..
@@ -179,6 +191,34 @@ def yield (t : T) : List W :=
 termination_by sizeOf t
 decreasing_by exact FiniteBranching.sizeOf_children hc
 
+/-- Attach-free unfolding of `yield`, for concrete computation. -/
+theorem yield_def (t : T) :
+    yield t = (content? t).toList ++ (children t).flatMap yield := by
+  rw [yield]
+  simp [List.flatMap_def]
+
 end Branching
+
+/-! ### Instance: `FreeMagma`
+
+Mathlib's free magma is the binary rose tree (bare phrase structure in
+the Minimalist reading); the instance lives here because mathlib types
+take their instances in the class's home file. The bespoke
+`FreeMagma.toTree` bridge in `Syntax/Tree/Basic.lean` becomes one of
+two routes to the position machinery — this instance is the direct one. -/
+
+instance {α : Type*} : Branching (FreeMagma α) where
+  children
+    | .of _ => []
+    | .mul l r => [l, r]
+
+instance {α : Type*} : FiniteBranching (FreeMagma α) where
+  sizeOf_children {c t} hc := by
+    cases t with
+    | of _ => simp [Branching.children] at hc
+    | mul l r =>
+      simp only [Branching.children, List.mem_cons, List.not_mem_nil, or_false] at hc
+      have hmul : sizeOf (FreeMagma.mul l r) = 1 + sizeOf l + sizeOf r := rfl
+      rcases hc with rfl | rfl <;> omega
 
 end Core.Order

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -1,4 +1,5 @@
 import Linglib.Morphology.Nanosyntax.Basic
+import Linglib.Core.Order.Branching
 
 /-!
 # Nanosyntax: Tree-Based Spellout
@@ -294,3 +295,36 @@ theorem chain_contains_iff_ge {F : Type} [DecidableEq F] (feat : Nat → F)
     exact decide_or_iff (by omega)
 
 end Morphology.Nanosyntax
+
+/-! ### Rose-tree interface instances
+
+`NanoTree` joins the `Core.Order.Branching` tower. The structural
+`size`/`beq`/`contains` above remain the kernel-computable
+specializations ([file-level generality discipline]: WF-derived
+generics do not kernel-reduce, so `rfl`-style spell-out evaluations
+need the structural forms). -/
+
+namespace Morphology.Nanosyntax.NanoTree
+
+instance {F : Type} : Core.Order.Branching (NanoTree F) where
+  children
+    | .leaf _ => []
+    | .node _ cs => cs
+
+@[simp] theorem branching_children_leaf {F : Type} (f : F) :
+    Core.Order.Branching.children (NanoTree.leaf f) = [] := rfl
+
+@[simp] theorem branching_children_node {F : Type} (f : F) (cs : List (NanoTree F)) :
+    Core.Order.Branching.children (NanoTree.node f cs) = cs := rfl
+
+instance {F : Type} : Core.Order.FiniteBranching (NanoTree F) where
+  sizeOf_children {c t} hc := by
+    cases t with
+    | leaf _ => simp at hc
+    | node f cs =>
+      simp only [branching_children_node] at hc
+      have := List.sizeOf_lt_of_mem hc
+      simp only [NanoTree.node.sizeOf_spec]
+      omega
+
+end Morphology.Nanosyntax.NanoTree


### PR DESCRIPTION
Phase 3 of the tree abstraction tower: `FreeMagma`, `Planar`, `CFGTree`, and `NanoTree` join `Syntax.Tree` as `Branching`/`FiniteBranching` instances — each now inherits Gorn addresses, the dominance order with mathlib's rooted-tree stack, and the B&P command bridge from its `children` projection.

- attach-free `size_def`/`subtrees_def`/`yield_def` unfold lemmas for concrete computation
- per-instance `children` simp lemmas
- structural per-carrier `size`/`yield` are kept as kernel-computable specializations: WF-derived generics do not kernel-reduce, so `rfl`-style evaluations (Nanosyntax spell-out demos, CFG soundness proofs) need them — the file-level generality discipline's general + specialization pattern