### PR TITLE
refactor(Semantics/Definiteness): dissolve Core/Nominal, add determiner API

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -275,11 +275,11 @@ import Linglib.Semantics.Focus.Comparability
 import Linglib.Features.Prosody
 import Linglib.Features.Definiteness
 import Linglib.Features.Deixis
-import Linglib.Core.Nominal.Description
-import Linglib.Core.Nominal.Maximality
-import Linglib.Core.Nominal.Interpret
-import Linglib.Core.Nominal.Determiner
-import Linglib.Core.Nominal.DeterminerLicensing
+import Linglib.Semantics.Definiteness.Description
+import Linglib.Semantics.Definiteness.Maximality
+import Linglib.Semantics.Definiteness.Interpret
+import Linglib.Features.Determiner
+import Linglib.Semantics.Definiteness.DeterminerLicensing
 import Linglib.Syntax.Binding.SpecificityCondition
 import Linglib.Features.Prominence
 import Linglib.Features.OntologicalCategory

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -278,8 +278,9 @@ import Linglib.Features.Deixis
 import Linglib.Semantics.Definiteness.Description
 import Linglib.Semantics.Definiteness.Maximality
 import Linglib.Semantics.Definiteness.Interpret
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Semantics.Definiteness.DeterminerLicensing
+import Linglib.Semantics.Definiteness.DeterminerDenotation
 import Linglib.Syntax.Binding.SpecificityCondition
 import Linglib.Features.Prominence
 import Linglib.Features.OntologicalCategory

--- a/Linglib/Features/CoreferenceStatus.lean
+++ b/Linglib/Features/CoreferenceStatus.lean
@@ -29,7 +29,7 @@ inductive CoreferenceStatus where
 
     The *binding-distribution* axis (anaphor/pronominal/r-expression, with the
     anaphor class split into reflexive/reciprocal) — orthogonal to a nominal's
-    `Core.Nominal.Description` (definiteness/reference flavor) and to a
+    `Semantics.Definiteness.Description` (definiteness/reference flavor) and to a
     pronoun's lexical kind. -/
 inductive BindingClass where
   /-- Reflexive anaphor (*himself*, *herself*, *themselves*). -/

--- a/Linglib/Features/Deixis.lean
+++ b/Linglib/Features/Deixis.lean
@@ -33,7 +33,7 @@ when a fragment actually needs it, not in anticipation. Specifically:
   invisible` constructors when a fragment needs them.
 - **Elevation contrasts** (Dyirbal, Nepali): add when needed.
 
-This is the centralized type referenced by `Core.Nominal.Description.deictic`
+This is the centralized type referenced by `Semantics.Definiteness.Description.deictic`
 (forthcoming) and by demonstrative entries in `Fragments/`.
 -/
 

--- a/Linglib/Features/Determiner.lean
+++ b/Linglib/Features/Determiner.lean
@@ -35,7 +35,7 @@ localized to a single declaration.
 
 An `Article`'s admissible [schwarz-2009] strengths are `Article.presupTypes`
 (Frame-free, read off `uses`); its denotation is `Article.toDescriptions`
-(`Core/Nominal/DeterminerLicensing.lean`, Frame-aware) — the set of `Description`s
+(`Semantics/Definiteness/DeterminerLicensing.lean`, Frame-aware) — the set of `Description`s
 those strengths admit via `Description.ofPresupType`, so a syncretic article like
 English *the* denotes *both* the weak and the strong description.
 `DemonstrativeDeterminer.denote` (deictic), the `Quantifier` generalized quantifier

--- a/Linglib/Features/Indefinite.lean
+++ b/Linglib/Features/Indefinite.lean
@@ -15,7 +15,7 @@ This file is therefore word-class-**neutral**: the [haspelmath-1997] feature dim
 coverage, ontology, morphological basis) and the `Indefinite` *capability* (`[Indefinite α]`) that
 exposes them over any carrier. The capability is the indefinite analogue of mathlib's
 `MonoidHomClass`-over-`MonoidHom`: a carrier-class-specific indefinite object (`IndefinitePronoun`
-in `Syntax/Pronoun/Indefinite.lean`; a future `IndefiniteDeterminer` over `Core.Nominal`'s
+in `Syntax/Pronoun/Indefinite.lean`; a future `IndefiniteDeterminer` over `Semantics.Definiteness`'s
 `Determiner`) supplies one `instance : Indefinite That`, and generic code reads the series data via
 `[Indefinite α]`.
 
@@ -195,7 +195,7 @@ end Indefinite
 
     Word-class-neutral by design (`Indefinite` ≠ pronoun): the sole current carrier is
     `Indefinite.IndefinitePronoun` (`Syntax/Pronoun/Indefinite.lean`), but an indefinite determiner
-    (over `Core.Nominal`'s `Determiner`) or pro-adverb supplies its own `instance : Indefinite That`
+    (over `Semantics.Definiteness`'s `Determiner`) or pro-adverb supplies its own `instance : Indefinite That`
     and is then read by the same generic `[Indefinite α]` code. This is the indefinite analogue of
     mathlib's `MonoidHomClass`-over-`MonoidHom`/`RingHom`. -/
 class Indefinite (α : Type*) where

--- a/Linglib/Fragments/Akan/Definiteness.lean
+++ b/Linglib/Fragments/Akan/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # Akan Definiteness Fragment

--- a/Linglib/Fragments/Akan/Definiteness.lean
+++ b/Linglib/Fragments/Akan/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # Akan Definiteness Fragment

--- a/Linglib/Fragments/Cantonese/Definiteness.lean
+++ b/Linglib/Fragments/Cantonese/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # Cantonese Definiteness Fragment

--- a/Linglib/Fragments/Cantonese/Definiteness.lean
+++ b/Linglib/Fragments/Cantonese/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # Cantonese Definiteness Fragment

--- a/Linglib/Fragments/English/Definiteness.lean
+++ b/Linglib/Fragments/English/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # English Definiteness Fragment

--- a/Linglib/Fragments/English/Definiteness.lean
+++ b/Linglib/Fragments/English/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # English Definiteness Fragment

--- a/Linglib/Fragments/Fering/Definiteness.lean
+++ b/Linglib/Fragments/Fering/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # Fering Definiteness Fragment

--- a/Linglib/Fragments/Fering/Definiteness.lean
+++ b/Linglib/Fragments/Fering/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # Fering Definiteness Fragment

--- a/Linglib/Fragments/German/Definiteness.lean
+++ b/Linglib/Fragments/German/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # German Definiteness Fragment

--- a/Linglib/Fragments/German/Definiteness.lean
+++ b/Linglib/Fragments/German/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # German Definiteness Fragment

--- a/Linglib/Fragments/HaitianCreole/Definiteness.lean
+++ b/Linglib/Fragments/HaitianCreole/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # Haitian Creole Definiteness Fragment

--- a/Linglib/Fragments/HaitianCreole/Definiteness.lean
+++ b/Linglib/Fragments/HaitianCreole/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # Haitian Creole Definiteness Fragment

--- a/Linglib/Fragments/Hausa/Definiteness.lean
+++ b/Linglib/Fragments/Hausa/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # Hausa Definiteness Fragment

--- a/Linglib/Fragments/Hausa/Definiteness.lean
+++ b/Linglib/Fragments/Hausa/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # Hausa Definiteness Fragment

--- a/Linglib/Fragments/Lakhota/Definiteness.lean
+++ b/Linglib/Fragments/Lakhota/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # Lakhota Definiteness Fragment

--- a/Linglib/Fragments/Lakhota/Definiteness.lean
+++ b/Linglib/Fragments/Lakhota/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # Lakhota Definiteness Fragment

--- a/Linglib/Fragments/Mandarin/Definiteness.lean
+++ b/Linglib/Fragments/Mandarin/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # Mandarin Definiteness Fragment

--- a/Linglib/Fragments/Mandarin/Definiteness.lean
+++ b/Linglib/Fragments/Mandarin/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # Mandarin Definiteness Fragment

--- a/Linglib/Fragments/MauritianCreole/Definiteness.lean
+++ b/Linglib/Fragments/MauritianCreole/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # Mauritian Creole Definiteness Fragment

--- a/Linglib/Fragments/MauritianCreole/Definiteness.lean
+++ b/Linglib/Fragments/MauritianCreole/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # Mauritian Creole Definiteness Fragment

--- a/Linglib/Fragments/Shan/Definiteness.lean
+++ b/Linglib/Fragments/Shan/Definiteness.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Definiteness
 import Linglib.Features.Deixis
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Semantics.Definiteness.Maximality
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Semantics.Kinds.NominalMappingParameter

--- a/Linglib/Fragments/Shan/Definiteness.lean
+++ b/Linglib/Fragments/Shan/Definiteness.lean
@@ -1,7 +1,7 @@
 import Linglib.Features.Definiteness
 import Linglib.Features.Deixis
-import Linglib.Core.Nominal.Determiner
-import Linglib.Core.Nominal.Maximality
+import Linglib.Features.Determiner
+import Linglib.Semantics.Definiteness.Maximality
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Semantics.Kinds.NominalMappingParameter
 import Linglib.Semantics.Kinds.MeaningPreservation
@@ -146,12 +146,12 @@ theorem shan_demonstratives_encode_distance :
 
     The demonstrative combines the restrictor P with a spatial filter
     encoding proximity to the speaker. The cardinality presupposition
-    (|P_s| = 1) is handled by `Core.Nominal.russellIotaList` returning
+    (|P_s| = 1) is handled by `Semantics.Definiteness.russellIotaList` returning
     `none` when no unique satisfier exists. -/
 def demDenotation {E : Type} (domain : List E) (dem : ShanDemonstrative)
     (restrictor : E → Bool) (spatialPred : Features.Deixis.Feature → E → Bool) :
     Option E :=
-  Core.Nominal.russellIotaList domain
+  Semantics.Definiteness.russellIotaList domain
     (fun e => restrictor e && spatialPred dem.spatial e)
 
 /-- A bare definite description (no demonstrative) uses no filter:
@@ -159,7 +159,7 @@ def demDenotation {E : Type} (domain : List E) (dem : ShanDemonstrative)
     spatial location. This is the uniqueness-based (weak) reading. -/
 def bareDefinite {E : Type} (domain : List E) (restrictor : E → Bool) :
     Option E :=
-  Core.Nominal.russellIotaList domain restrictor
+  Semantics.Definiteness.russellIotaList domain restrictor
 
 /-- The demonstrative refines the bare definite: when the bare description
     selects a referent that also satisfies the spatial predicate, both
@@ -172,8 +172,8 @@ theorem dem_refines_bare {E : Type} (domain : List E)
     (hBare : bareDefinite domain restrictor = some e)
     (hSpatial : spatialPred dem.spatial e = true) :
     demDenotation domain dem restrictor spatialPred = some e := by
-  rw [bareDefinite, Core.Nominal.russellIotaList_eq_some_iff] at hBare
-  rw [demDenotation, Core.Nominal.russellIotaList_eq_some_iff]
+  rw [bareDefinite, Semantics.Definiteness.russellIotaList_eq_some_iff] at hBare
+  rw [demDenotation, Semantics.Definiteness.russellIotaList_eq_some_iff]
   have : domain.filter (fun e' => restrictor e' && spatialPred dem.spatial e') =
          (domain.filter restrictor).filter (fun e' => spatialPred dem.spatial e') := by
     rw [List.filter_filter]

--- a/Linglib/Fragments/Thai/Definiteness.lean
+++ b/Linglib/Fragments/Thai/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 
 /-!
 # Thai Definiteness Fragment

--- a/Linglib/Fragments/Thai/Definiteness.lean
+++ b/Linglib/Fragments/Thai/Definiteness.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # Thai Definiteness Fragment

--- a/Linglib/Phenomena/Anaphora/DonkeyAnaphora.lean
+++ b/Linglib/Phenomena/Anaphora/DonkeyAnaphora.lean
@@ -1,6 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.Definiteness
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 import Linglib.Fragments.German.Definiteness
 import Linglib.Fragments.Thai.Definiteness
 import Linglib.Fragments.Mandarin.Definiteness

--- a/Linglib/Phenomena/Anaphora/DonkeyAnaphora.lean
+++ b/Linglib/Phenomena/Anaphora/DonkeyAnaphora.lean
@@ -1,6 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.Definiteness
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Fragments.German.Definiteness
 import Linglib.Fragments.Thai.Definiteness
 import Linglib.Fragments.Mandarin.Definiteness

--- a/Linglib/Semantics/Definiteness/Basic.lean
+++ b/Linglib/Semantics/Definiteness/Basic.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Composition.TypeShifting
 import Linglib.Semantics.Reference.Donnellan
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Features.Definiteness
-import Linglib.Core.Nominal.Maximality
+import Linglib.Semantics.Definiteness.Maximality
 import Linglib.Fragments.English.Determiners
 
 /-!
@@ -13,7 +13,7 @@ import Linglib.Fragments.English.Determiners
 Connective tissue between definite-description denotations and the rest of
 the library. The denotational layer itself lives in two canonical pieces:
 
-- `Core.Nominal.russellIotaList` (the per-context referent selector,
+- `Semantics.Definiteness.russellIotaList` (the per-context referent selector,
   Russellian iota over a `List E` filtered by a `Bool` predicate), and
 - `Semantics.Presupposition.PrProp.presupOfReferent` (the combinator lifting a
   referent selector and a scope predicate into a `PrProp W`).
@@ -58,7 +58,7 @@ open Features.Definiteness (DefPresupType Definiteness)
 been introduced into the discourse and are available for anaphoric reference.
 Familiarity-based definites (Schwarz's strong article) are evaluated by
 running the canonical Russellian-iota selector
-(`Core.Nominal.russellIotaList`) over `dc.salient` rather than the full
+(`Semantics.Definiteness.russellIotaList`) over `dc.salient` rather than the full
 domain. -/
 structure DiscourseContext (E : Type) where
   /-- Entities currently salient/familiar in discourse -/

--- a/Linglib/Semantics/Definiteness/Description.lean
+++ b/Linglib/Semantics/Definiteness/Description.lean
@@ -57,10 +57,10 @@ unified `F.Denot` machinery rather than ad-hoc `E → Bool` predicates.
 
 - **No semantic interpretation here.** This file only declares the type and
   a handful of classification predicates. The interpretation function lives
-  in `Core/Nominal/Interpret.lean`.
+  in `Semantics/Definiteness/Interpret.lean`.
 -/
 
-namespace Core.Nominal
+namespace Semantics.Definiteness
 
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
@@ -194,4 +194,4 @@ theorem expectedPresupType_ofPresupType
 
 end Description
 
-end Core.Nominal
+end Semantics.Definiteness

--- a/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
@@ -1,0 +1,150 @@
+import Linglib.Semantics.Definiteness.Interpret
+import Linglib.Semantics.Definiteness.DeterminerLicensing
+import Linglib.Semantics.Reference.Nominal
+
+/-!
+# The denotation of a determiner
+
+[schwarz-2009] [patel-grosz-grosz-2017] [coppock-beaver-2015] [moroney-2021]
+
+Gives the determiner lexical records (`Syntax/Determiner/Basic.lean`) meanings,
+as `NominalDenot`s — the determiner half of the API whose pronoun half is
+`Semantics/Reference/PronounDenotation.lean`. The wiring is parallel:
+
+| | pronoun | determiner |
+|---|---|---|
+| lexical record | `PersonalPronoun` | `Article`, `DemonstrativeDeterminer` |
+| selector | `interpPronoun` (`g ↦ g i`) | `Semantics.Definiteness.interpret` |
+| intrinsic presupposition | φ-features (`phiPresup`) | deixis (`deixisPresup`) |
+
+The selector is the canonical `Description` interpretation — determiner-as-object
+and the interpreted description pick the same individual *by construction*, not
+via a bridge theorem. The intrinsic presupposition is where a demonstrative's
+deictic feature projects: deixis filters the referent but never selects it
+(`denote_selector_eq_anaphoric`, the API-level form of
+`interpret_demonstrative_eq_anaphoric`).
+
+## Main declarations
+
+* `Description.denote` — a description's `NominalDenot` (vacuous intrinsic
+  presupposition; a definite's only presupposition is definedness).
+* `DemonstrativeDeterminer.deixisPresup` — the deictic presupposition over an
+  entity domain, with model-supplied proximity predicates (parallel to
+  `PersonalPronoun.phiPresup`'s `speaker`/`addressee`).
+* `DemonstrativeDeterminer.denote` — the demonstrative's `NominalDenot`
+  (previously deferred in the lexical file's implementation notes).
+* `Article.denotations` — an article's possible `NominalDenot`s, the image of
+  `Article.toDescriptions` under `Description.denote`; a syncretic article
+  (English *the*) denotes both the weak and the strong description.
+
+## Implementation notes
+
+Context is the bi-assignment `Assignment F.Entity × SitAssignment F` and the
+world coordinate is trivial (`PUnit`), matching the static case of
+`PersonalPronoun.denote`. `Quantifier` (a generalized quantifier, not an
+individual denotation — it has no `NominalDenot`) and `Possessive` remain
+deferred.
+-/
+
+namespace Semantics.Definiteness
+
+open Semantics.Reference (NominalDenot)
+open Core.Logic.Intensional (Frame)
+open Core.Logic.Intensional.Variables
+open Core (Assignment)
+open Features.Definiteness (DefPresupType)
+
+variable {F : Frame}
+
+/-! ### Descriptions as nominal denotations -/
+
+/-- A description's denotation as a `NominalDenot`: the selector is the
+canonical interpretation function `interpret`, and the intrinsic
+presupposition is vacuous — a definite's only presupposition is that the
+selector is defined. The static case; world is trivial. -/
+noncomputable def Description.denote (k : Description F) :
+    NominalDenot (Assignment F.Entity × SitAssignment F) PUnit F.Entity where
+  presup := fun _ _ => True
+  selector := fun gp _ => interpret k gp.1 gp.2
+
+/-- The by-construction identity: a description's selector *is* `interpret`. -/
+@[simp]
+theorem Description.denote_selector (k : Description F)
+    (g : Assignment F.Entity) (gs : SitAssignment F) (w : PUnit) :
+    k.denote.selector (g, gs) w = interpret k g gs := rfl
+
+/-! ### The demonstrative determiner's denotation -/
+
+/-- The deictic presupposition of a demonstrative determiner, over an entity
+domain. The model supplies the proximity predicates the deixis cells need
+(parallel to the `speaker`/`addressee`/`isFemale` parameters of
+`PersonalPronoun.phiPresup`); an `unspecified` feature contributes the
+trivial presupposition. -/
+def _root_.DemonstrativeDeterminer.deixisPresup (dem : DemonstrativeDeterminer)
+    (proximal medial distal : F.Entity → Prop) : F.Entity → Prop :=
+  match dem.deictic with
+  | .proximal    => proximal
+  | .medial      => medial
+  | .distal      => distal
+  | .unspecified => fun _ => True
+
+/-- A demonstrative determiner's denotation as a `NominalDenot` (the
+`DemonstrativeDeterminer.denote` deferred by the lexical file): the selector
+is the canonical interpretation of the demonstrative description at discourse
+index `d`, and the intrinsic presupposition is the deictic presupposition
+imposed on the indexed referent `g d` — parallel to `PersonalPronoun.denote`,
+with deixis in place of φ-features. -/
+noncomputable def _root_.DemonstrativeDeterminer.denote (dem : DemonstrativeDeterminer)
+    (R : DenotGS F .et) (sIdx d : Nat)
+    (proximal medial distal : F.Entity → Prop) :
+    NominalDenot (Assignment F.Entity × SitAssignment F) PUnit F.Entity where
+  presup := fun gp _ => dem.deixisPresup proximal medial distal (gp.1 d)
+  selector := fun gp _ =>
+    interpret (.demonstrative R dem.deictic sIdx d) gp.1 gp.2
+
+/-- Deixis filters, it does not select: a demonstrative determiner's selector
+is exactly the bare anaphoric description's selector. The API-level form of
+`interpret_demonstrative_eq_anaphoric` — the deictic content lives entirely
+in the `presup` component. -/
+theorem DemonstrativeDeterminer.denote_selector_eq_anaphoric
+    (dem : DemonstrativeDeterminer) (R : DenotGS F .et) (sIdx d : Nat)
+    (proximal medial distal : F.Entity → Prop) :
+    (dem.denote R sIdx d proximal medial distal).selector
+      = (Description.anaphoric R d).denote.selector := by
+  funext gp w
+  exact interpret_demonstrative_eq_anaphoric R dem.deictic sIdx d gp.1 gp.2
+
+/-- Two demonstrative determiners differing only in deictic feature share a
+selector — *this* and *that* pick the same referent and differ only in what
+they presuppose about it. -/
+theorem DemonstrativeDeterminer.denote_selector_congr
+    (dem₁ dem₂ : DemonstrativeDeterminer) (R : DenotGS F .et) (sIdx d : Nat)
+    (proximal medial distal : F.Entity → Prop) :
+    (dem₁.denote R sIdx d proximal medial distal).selector
+      = (dem₂.denote R sIdx d proximal medial distal).selector := by
+  rw [DemonstrativeDeterminer.denote_selector_eq_anaphoric,
+      DemonstrativeDeterminer.denote_selector_eq_anaphoric]
+
+/-! ### The article's denotations -/
+
+/-- An article's possible denotations: the `NominalDenot`s of its admissible
+descriptions (`Article.toDescriptions`). A syncretic article (English *the*)
+denotes both the weak and the strong description; a German weak or strong
+article denotes exactly one. -/
+noncomputable def _root_.Article.denotations (a : Article)
+    (R : DenotGS F .et) (idx : Nat) :
+    List (NominalDenot (Assignment F.Entity × SitAssignment F) PUnit F.Entity) :=
+  (a.toDescriptions R idx).map Description.denote
+
+/-- Every denotation of an article arises from a description the article
+licenses — the denotational pipeline and the licensing pipeline agree. -/
+theorem Article.denotations_licensed (a : Article)
+    (R : DenotGS F .et) (idx : Nat)
+    (nd : NominalDenot (Assignment F.Entity × SitAssignment F) PUnit F.Entity)
+    (h : nd ∈ a.denotations R idx) :
+    ∃ k : Description F,
+      Determiner.licenses [.article a] k ∧ nd = k.denote := by
+  obtain ⟨k, hk, rfl⟩ := List.mem_map.mp h
+  exact ⟨k, Determiner.licenses_mem_toDescriptions a R idx k hk, rfl⟩
+
+end Semantics.Definiteness

--- a/Linglib/Semantics/Definiteness/DeterminerLicensing.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerLicensing.lean
@@ -1,5 +1,5 @@
-import Linglib.Core.Nominal.Determiner
-import Linglib.Core.Nominal.Description
+import Linglib.Features.Determiner
+import Linglib.Semantics.Definiteness.Description
 
 /-!
 # Determiner licensing
@@ -12,7 +12,7 @@ Frame-parameterized `Description` substrate.
 
 open Core.Logic.Intensional (Frame)
 open Core.Logic.Intensional.Variables (DenotGS)
-open Core.Nominal (Description)
+open Semantics.Definiteness (Description)
 open Features.Definiteness (DefPresupType)
 
 namespace Determiner

--- a/Linglib/Semantics/Definiteness/DeterminerLicensing.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerLicensing.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Semantics.Definiteness.Description
 
 /-!

--- a/Linglib/Semantics/Definiteness/Interpret.lean
+++ b/Linglib/Semantics/Definiteness/Interpret.lean
@@ -34,6 +34,7 @@ namespace Semantics.Definiteness
 
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
+open Core (Assignment)
 
 variable {F : Frame}
 

--- a/Linglib/Semantics/Definiteness/Interpret.lean
+++ b/Linglib/Semantics/Definiteness/Interpret.lean
@@ -1,5 +1,5 @@
-import Linglib.Core.Nominal.Description
-import Linglib.Core.Nominal.Maximality
+import Linglib.Semantics.Definiteness.Description
+import Linglib.Semantics.Definiteness.Maximality
 
 /-!
 # Interpretation of Nominal Descriptions
@@ -12,7 +12,7 @@ failure (no unique satisfier; no satisfying antecedent at the discourse
 index) or inapplicability (indefinites do not denote a single entity at
 this layer — they need separate existential-closure machinery).
 
-The interpretation composes the operators in `Core/Nominal/Maximality.lean`:
+The interpretation composes the operators in `Semantics/Definiteness/Maximality.lean`:
 
 - `bare` and `unique` ↦ `russellIota` (order-free uniqueness; languages with
   mereological structure can opt into `sharvyMax` instead by providing a
@@ -30,7 +30,7 @@ and discourse index (the deictic feature is for presupposition checking,
 not referent selection).
 -/
 
-namespace Core.Nominal
+namespace Semantics.Definiteness
 
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
@@ -217,4 +217,4 @@ theorem interpret_anaphoric_eq_unique_of_existsUnique
   rw [interpret_unique_eq_some_of_existsUnique R sIdx g gs (g i) hSat hUniq,
       interpret_anaphoric, if_pos hSat]
 
-end Core.Nominal
+end Semantics.Definiteness

--- a/Linglib/Semantics/Definiteness/Maximality.lean
+++ b/Linglib/Semantics/Definiteness/Maximality.lean
@@ -5,7 +5,7 @@ import Linglib.Core.Logic.Intensional.Variables
 [sharvy-1980] [kriz-2015] [coppock-beaver-2015] [russell-1905]
 
 Predicate operators consumed by the `Description` interpretation function in
-`Core/Nominal/Interpret.lean`. All operators live over
+`Semantics/Definiteness/Interpret.lean`. All operators live over
 `Core.Logic.Intensional.Frame.Denot` so they slot directly into the IL stack.
 
 ## What this module provides
@@ -31,7 +31,7 @@ Predicate operators consumed by the `Description` interpretation function in
 ## Design notes
 
 - **No semantic interpretation here.** This file provides only the operators.
-  `Core/Nominal/Interpret.lean` wires `Description` constructors to them.
+  `Semantics/Definiteness/Interpret.lean` wires `Description` constructors to them.
 
 - **Ord-free vs. order-relative.** `russellIota` uses only `Eq`; `sharvyMax`
   requires `PartialOrder F.Entity`. This is the [sharvy-1980] /
@@ -42,11 +42,11 @@ Predicate operators consumed by the `Description` interpretation function in
 - **`Option` is the right return type.** A definite description with an
   unsatisfied uniqueness presupposition has no referent; rather than throw
   an exception or produce an arbitrary witness, we return `none`. The
-  interpretation function in `Core/Nominal/Interpret.lean` lifts this to
+  interpretation function in `Semantics/Definiteness/Interpret.lean` lifts this to
   presupposition failure at the propositional level.
 -/
 
-namespace Core.Nominal
+namespace Semantics.Definiteness
 
 open Core.Logic.Intensional
 
@@ -245,4 +245,4 @@ theorem uniqueness_implies_homogeneous_classical
       rw [hxe] at hSx; exact hS hSx
   · left; intro x hx; exact (h ⟨x, hx⟩).elim
 
-end Core.Nominal
+end Semantics.Definiteness

--- a/Linglib/Semantics/Evidential/Basic.lean
+++ b/Linglib/Semantics/Evidential/Basic.lean
@@ -7,7 +7,7 @@ import Linglib.Semantics.Evidential.Defs
 Derived predicates and the Aikhenvald-cell mapping that lets typological
 classifications be DERIVED from declared inventories rather than hardcoded
 per-language. Mirrors the `Determiner.markingStrategy` pattern at
-`Core/Nominal/Determiner.lean`: typological classifications are theorems
+`Semantics/Definiteness/Determiner.lean`: typological classifications are theorems
 about the declared inventory, not stipulations.
 
 ## Main declarations

--- a/Linglib/Semantics/Evidential/Defs.lean
+++ b/Linglib/Semantics/Evidential/Defs.lean
@@ -5,7 +5,7 @@ import Linglib.Features.Evidentiality
 [aikhenvald-2004] [de-haan-2013] [murray-2017]
 
 The evidential as a lexical object, following the Determiner-API pattern
-(`Core/Nominal/Determiner.lean`). The base `Evidential` carries only what is
+(`Semantics/Definiteness/Determiner.lean`). The base `Evidential` carries only what is
 universal to all evidential markers — a surface `form`; each specialization
 (`DirectEvidential`, `ReportativeEvidential`, `InferentialEvidential`) adds
 its own structure: an `Exponent` (realization strategy) plus a fine-grained
@@ -32,7 +32,7 @@ a language's WALS cell is a theorem about its declared evidentials.
   temporal anchoring) is deferred to `Studies/{Author}{Year}.lean` files
   which provide opt-in typeclass instances on `Entry`. This file is the
   framework-agnostic lexical and typological-derivation substrate only.
-* Mirrors the `Core/Nominal/Determiner.lean` pattern: structure +
+* Mirrors the `Semantics/Definiteness/Determiner.lean` pattern: structure +
   `Exponent` realization enum + `Entry` heterogeneous sum + typological
   derivations as theorems about the declared inventory.
 -/

--- a/Linglib/Semantics/Kinds/MeaningPreservation.lean
+++ b/Linglib/Semantics/Kinds/MeaningPreservation.lean
@@ -342,7 +342,7 @@ type-shift converts this intensional property into a different semantic type:
 - ∃ (`.exists`): `⟨s,⟨e,t⟩⟩ × s → Prop` — existential closure at a world
 
 These connect the abstract shift-selection machinery to Chierchia's `down`
-operator and the `Core.Nominal.russellIotaList` /
+operator and the `Semantics.Definiteness.russellIotaList` /
 `Semantics.Presupposition.PrProp.presupOfReferent` canonical pieces consumed by
 `Semantics/Definiteness/Basic.lean`.
 -/

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -40,7 +40,7 @@ content (singularProp = false), but is used referentially.
 import Linglib.Semantics.Reference.Basic
 import Linglib.Semantics.Reference.Nominal
 import Linglib.Semantics.Presupposition.Basic
-import Linglib.Core.Nominal.Maximality
+import Linglib.Semantics.Definiteness.Maximality
 
 namespace Semantics.Reference.Donnellan
 
@@ -49,7 +49,7 @@ open Core.Intension (rigid IsRigid rigid_isRigid)
 open Semantics.Presupposition (PrProp)
 open Semantics.Presupposition.PrProp (presupOfReferent)
 open Semantics.Reference.Basic
-open Core.Nominal (russellIotaList)
+open Semantics.Definiteness (russellIotaList)
 
 /-! ## Use Modes -/
 

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -4,7 +4,7 @@ import Linglib.Semantics.Presupposition.PhiFeatures
 import Linglib.Core.Logic.Intensional.Variables
 import Linglib.Core.Logic.Assignment
 import Linglib.Semantics.Dynamic.Effects.HasFiberedLookup
-import Linglib.Core.Nominal.Interpret
+import Linglib.Semantics.Definiteness.Interpret
 
 /-!
 # The denotation of a pronoun
@@ -129,7 +129,7 @@ personal/demonstrative split is the [schwarz-2009] weak/strong-article split:
 PER (*er*) the **weak** article (`Description.ofPresupType .uniqueness` = `.unique`),
 "DEM" (*der*) the **strong** article (`…ofPresupType .familiarity` = `.anaphoric`,
 the weak description plus an anaphoric index). PG&G's "DEM = PER + index" is the
-weak/strong refinement `Core.Nominal.interpret_anaphoric_eq_unique_of_existsUnique`;
+weak/strong refinement `Semantics.Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`;
 the strength round-trips through `expectedPresupType`. The extra layer is that index,
 **not** spatial deixis (footnote 1) — *der* is a strong *personal* pronoun, not a
 separate type; genuine deictic demonstratives are `Description.demonstrative`.
@@ -145,13 +145,13 @@ exactly when `g i` is the unique satisfier. -/
 description whenever the restrictor holds of the indexed referent: the
 **strong-article** (`Description.ofPresupType .familiarity`) reading, since the
 anaphoric index *is* the indexed entity. The **weak** reading coincides too when
-that entity is the unique satisfier (`Core.Nominal.interpret_anaphoric_eq_unique_of_existsUnique`). -/
+that entity is the unique satisfier (`Semantics.Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`). -/
 theorem PersonalPronoun.denote_selector_eq_ofPresupType {F : Frame} [PartialOrder F.Entity]
     (e : PersonalPronoun) (i : ℕ) (R : DenotGS F .et)
     (speaker addressee : F.Entity) (isFemale isInanimate : F.Entity → Prop)
     (g : Assignment F.Entity) (gs : SitAssignment F) (w : PUnit)
     (h : R g gs (g i)) :
     (e.denote i speaker addressee isFemale isInanimate).selector g w
-      = Core.Nominal.interpret (Core.Nominal.Description.ofPresupType .familiarity R i) g gs := by
-  show some (g i) = Core.Nominal.interpret (.anaphoric R i) g gs
-  rw [Core.Nominal.interpret_anaphoric, if_pos h]
+      = Semantics.Definiteness.interpret (Semantics.Definiteness.Description.ofPresupType .familiarity R i) g gs := by
+  show some (g i) = Semantics.Definiteness.interpret (.anaphoric R i) g gs
+  rw [Semantics.Definiteness.interpret_anaphoric, if_pos h]

--- a/Linglib/Studies/Beck2001.lean
+++ b/Linglib/Studies/Beck2001.lean
@@ -116,7 +116,7 @@ for the right-hand-spine entailments. -/
     (the simplest case, paper p. 92), this is `A \ {x}`.
 
     *Layered-grounding gap*: the full eq 76 invokes Sharvy max
-    (`Core/Nominal/Maximality.lean` provides the substrate) and Link `*`
+    (`Semantics/Definiteness/Maximality.lean` provides the substrate) and Link `*`
     (`Plurality/Algebra.lean`); current `A.erase x` is the simplest
     case. Promoting `otherOnesAmongThem` to consume `Nominal/Maximality`
     is queued (Tier-4 of the cross-framework auditor's recommendation

--- a/Linglib/Studies/CoppockBeaver2015.lean
+++ b/Linglib/Studies/CoppockBeaver2015.lean
@@ -1,6 +1,6 @@
-import Linglib.Core.Nominal.Description
-import Linglib.Core.Nominal.Interpret
-import Linglib.Core.Nominal.Maximality
+import Linglib.Semantics.Definiteness.Description
+import Linglib.Semantics.Definiteness.Interpret
+import Linglib.Semantics.Definiteness.Maximality
 
 /-!
 # Coppock & Beaver (2015): Definiteness and Determinacy
@@ -21,7 +21,7 @@ loses this distinction.
 
 ## What this file tests
 
-The factorization is operationalized in `Core.Nominal.Maximality` as
+The factorization is operationalized in `Semantics.Definiteness.Maximality` as
 `Existence`, `Uniqueness`, and `existsUnique` over `F.Denot .et`. This
 study file builds three concrete restrictors over a tiny frame (sun /
 moon / mars; one index) and verifies:
@@ -31,7 +31,7 @@ moon / mars; one index) and verifies:
    Uniqueness (the multi-witness `planet` extension).
 2. **Russellian collapse** — `existsUnique` is true exactly for
    restrictors with a singleton extension (`theSun`).
-3. **Interpretation alignment** — `Core.Nominal.interpret` on a
+3. **Interpretation alignment** — `Semantics.Definiteness.interpret` on a
    `.unique` description returns `none` precisely in the Russellian
    failure cases (no extension, or non-unique extension).
 4. **Negation-projection contrast** — the Uniqueness component projects
@@ -43,7 +43,7 @@ namespace CoppockBeaver2015
 
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
-open Core.Nominal
+open Semantics.Definiteness
 
 -- ════════════════════════════════════════════════════════════════
 -- §1: A tiny frame for the projection diagnostics
@@ -133,7 +133,7 @@ theorem planet_not_existsUnique :
   exact planet_existence_without_uniqueness.2 hUniq
 
 -- ════════════════════════════════════════════════════════════════
--- §4: Alignment with `Core.Nominal.interpret`
+-- §4: Alignment with `Semantics.Definiteness.interpret`
 -- ════════════════════════════════════════════════════════════════
 
 /-- A trivial bi-assignment: every entity slot is `sun`, every situation

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Features.Definiteness
-import Linglib.Core.Nominal.Maximality
+import Linglib.Semantics.Definiteness.Maximality
 import Linglib.Core.Logic.Intensional.Rigidity
 import Linglib.Semantics.Questions.Partition.QUD
 import Linglib.Semantics.Questions.PrecisionProjection
@@ -67,7 +67,7 @@ open Core (WorldTimeIndex)
 open Semantics.Presupposition (PrProp)
 open Semantics.Presupposition.PrProp (presupOfReferent presupOfReferent_presup
   presupOfReferent_assertion_some presupOfReferent_assertion_none)
-open Core.Nominal (russellIotaList)
+open Semantics.Definiteness (russellIotaList)
 open Features.Definiteness (DefPresupType)
 open Core.SitVarStatus (SitVarStatus)
 open Semantics.Definiteness (qforceToPresupType)
@@ -467,7 +467,7 @@ section RefAttr
 -- TODO: Bool→Prop migration of isMurderer/isInsane/isTable/isCoveredWithBooks/
 -- isDonkey/isBeaten/isPresident/isSpy/isGhost/isQuiet cascades to
 -- Linglib/Semantics/Presupposition/Basic.lean (presupOfReferent : (W → Option E) → ...)
--- and Linglib/Core/Nominal/Maximality.lean (russellIotaList : List E → (E → Bool) → Option E).
+-- and Linglib/Semantics/Definiteness/Maximality.lean (russellIotaList : List E → (E → Bool) → Option E).
 -- These predicates feed into the_sit'/the_sit/definiteNominal which require E → W → Bool.
 -- Migration deferred until those external Core APIs migrate to Prop with [DecidablePred].
 

--- a/Linglib/Studies/Hanink2021.lean
+++ b/Linglib/Studies/Hanink2021.lean
@@ -1,6 +1,6 @@
-import Linglib.Core.Nominal.Description
-import Linglib.Core.Nominal.Interpret
-import Linglib.Core.Nominal.Maximality
+import Linglib.Semantics.Definiteness.Description
+import Linglib.Semantics.Definiteness.Interpret
+import Linglib.Semantics.Definiteness.Maximality
 import Linglib.Syntax.Pronoun.Demonstrative
 
 /-!
@@ -22,7 +22,7 @@ The IL substrate operationalizes this in two parallel pieces:
 - **`SitAssignment F := Nat → F.Index`** in `Core.Logic.Intensional.Variables`
   is the situation-pronoun assignment, parallel to the entity
   assignment.
-- **`Description.unique R sIdx`** in `Core.Nominal.Description`
+- **`Description.unique R sIdx`** in `Semantics.Definiteness.Description`
   carries a `situationIdx : Nat` recording *which* situation pronoun
   the description is bound to.
 
@@ -51,7 +51,7 @@ namespace Hanink2021
 
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
-open Core.Nominal
+open Semantics.Definiteness
 
 -- ════════════════════════════════════════════════════════════════
 -- §1: A two-room frame for the resource-situation diagnostic
@@ -160,7 +160,7 @@ theorem same_description_different_referents :
 /-- The index argument to `.unique` does not select among situations at
     the interpretation layer — the restrictor `R` already takes the full
     situation assignment, and the index records *which* pronoun is
-    bound. (`Core.Nominal.interpret_unique_index_irrelevant` makes this
+    bound. (`Semantics.Definiteness.interpret_unique_index_irrelevant` makes this
     explicit.) The Hanink claim is recovered via the restrictor calling
     `interpSitPronoun sIdx`, not via the interpreter inspecting `sIdx`. -/
 theorem unique_index_does_not_alter_referent_directly :

--- a/Linglib/Studies/Jenks2018.lean
+++ b/Linglib/Studies/Jenks2018.lean
@@ -1,12 +1,12 @@
 import Linglib.Features.Definiteness
-import Linglib.Core.Nominal.Description
-import Linglib.Core.Nominal.Interpret
+import Linglib.Semantics.Definiteness.Description
+import Linglib.Semantics.Definiteness.Interpret
 import Linglib.Semantics.Presupposition.MaximizePresupposition
 import Linglib.Semantics.Kinds.MeaningPreservation
 import Linglib.Semantics.Classifier.Basic
 import Linglib.Studies.Schwarz2009
-import Linglib.Core.Nominal.Determiner
-import Linglib.Core.Nominal.DeterminerLicensing
+import Linglib.Features.Determiner
+import Linglib.Semantics.Definiteness.DeterminerLicensing
 import Linglib.Fragments.Mandarin.Definiteness
 import Linglib.Fragments.Cantonese.Definiteness
 
@@ -24,8 +24,8 @@ Maximize Presupposition + [schlenker-2012] Gricean reduction)
 selects between them.
 
 The substrate already operationalizes the inventory layer:
-`Core.Nominal.Description.{unique,anaphoric}` are ι and ι^x;
-`Core.Nominal.Determiner.markingStrategy` derives the four-cell
+`Semantics.Definiteness.Description.{unique,anaphoric}` are ι and ι^x;
+`Semantics.Definiteness.Determiner.markingStrategy` derives the four-cell
 typology directly named after Jenks 2018 in `Features.Definiteness`.
 The Mandarin Fragment commits `marking := .markedAnaphoric`.
 This file focuses on what is distinctly Jenks: the typological
@@ -40,7 +40,7 @@ namespace Jenks2018
 open Features.Definiteness
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
-open Core.Nominal
+open Semantics.Definiteness
 
 abbrev mandarinDets := Mandarin.Definiteness.determiners
 abbrev cantoneseDets := Cantonese.Definiteness.determiners
@@ -273,7 +273,7 @@ Dem-Clf-N`).
 
 Faithfully formalizing §4.4 requires a property-typed-index variant
 on `Description.anaphoric`. This is recorded as a TODO at the substrate
-level (`Core/Nominal/Description.lean`) rather than encoded as a
+level (`Semantics/Definiteness/Description.lean`) rather than encoded as a
 placeholder theorem. -/
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Jenks2018.lean
+++ b/Linglib/Studies/Jenks2018.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Presupposition.MaximizePresupposition
 import Linglib.Semantics.Kinds.MeaningPreservation
 import Linglib.Semantics.Classifier.Basic
 import Linglib.Studies.Schwarz2009
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Semantics.Definiteness.DeterminerLicensing
 import Linglib.Fragments.Mandarin.Definiteness
 import Linglib.Fragments.Cantonese.Definiteness

--- a/Linglib/Studies/Moroney2021.lean
+++ b/Linglib/Studies/Moroney2021.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Definiteness
 import Linglib.Core.Order.Mereology
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Semantics.Definiteness.DeterminerLicensing
 import Linglib.Semantics.Definiteness.Description
 import Linglib.Semantics.Definiteness.Interpret

--- a/Linglib/Studies/Moroney2021.lean
+++ b/Linglib/Studies/Moroney2021.lean
@@ -1,9 +1,9 @@
 import Linglib.Features.Definiteness
 import Linglib.Core.Order.Mereology
-import Linglib.Core.Nominal.Determiner
-import Linglib.Core.Nominal.DeterminerLicensing
-import Linglib.Core.Nominal.Description
-import Linglib.Core.Nominal.Interpret
+import Linglib.Features.Determiner
+import Linglib.Semantics.Definiteness.DeterminerLicensing
+import Linglib.Semantics.Definiteness.Description
+import Linglib.Semantics.Definiteness.Interpret
 import Linglib.Semantics.Kinds.MeaningPreservation
 import Linglib.Semantics.Kinds.NominalMappingParameter
 import Linglib.Semantics.Definiteness.Basic
@@ -445,7 +445,7 @@ theorem derive_consistent_with_stipulated :
 -- §8: Bridge to the canonical referent selector
 -- ============================================================================
 
-open Core.Nominal (russellIotaList)
+open Semantics.Definiteness (russellIotaList)
 
 /-- The type-shift system and the canonical referent selector agree:
 
@@ -623,14 +623,14 @@ theorem demonstrative_adds_spatial_info {E : Type}
     (spatialPred : Feature → E → Bool) :
     Shan.Definiteness.demDenotation domain
       Shan.Definiteness.naj restrictor spatialPred =
-      Core.Nominal.russellIotaList domain
+      Semantics.Definiteness.russellIotaList domain
         (fun e => restrictor e && spatialPred .proximal e) ∧
     Shan.Definiteness.demDenotation domain
       Shan.Definiteness.nan restrictor spatialPred =
-      Core.Nominal.russellIotaList domain
+      Semantics.Definiteness.russellIotaList domain
         (fun e => restrictor e && spatialPred .distal e) ∧
     Shan.Definiteness.bareDefinite domain restrictor =
-      Core.Nominal.russellIotaList domain restrictor :=
+      Semantics.Definiteness.russellIotaList domain restrictor :=
   ⟨rfl, rfl, rfl⟩
 
 -- ============================================================================
@@ -652,7 +652,7 @@ theorem shan_clf_is_atomization {α : Type*} [PartialOrder α]
     = Semantics.Classifier.clfForNoun P := rfl
 
 -- ============================================================================
--- §14: Integration with the Core.Nominal API
+-- §14: Integration with the Semantics.Definiteness API
 -- ============================================================================
 
 /-! The §1–§7 derivation works at the level of `DefMarkingParams` (three
@@ -667,7 +667,7 @@ finding: Shan licenses anaphoric definiteness without any anaphoric article. -/
 
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
-open Core.Nominal (Description)
+open Semantics.Definiteness (Description)
 
 /-- Shorthand handles for the four Table 4.4 determiner sets, each defined in
     its language fragment (`Fragments.{Lang}.Definiteness.determiners`).
@@ -758,7 +758,7 @@ theorem english_mandarin_articleType_collapse :
 theorem english_mandarin_inventory_distinct :
     englishDets ≠ mandarinDets := by decide
 
-/-- Shan-specific consequence of `Core.Nominal.interpret_bare_eq_unique`:
+/-- Shan-specific consequence of `Semantics.Definiteness.interpret_bare_eq_unique`:
     a bare definite description and a uniqueness definite over the same
     restrictor select the same referent. This is the Core-API analogue of
     Moroney's claim that bare nouns in Shan express weak/uniqueness
@@ -767,10 +767,10 @@ theorem shan_bare_unique_agreement {F : Frame}
     (R : DenotGS F .et) (sIdx : Nat)
     (g : Core.Assignment F.Entity)
     (gs : SitAssignment F) :
-    Core.Nominal.interpret (.bare R) g gs =
-      Core.Nominal.interpret (.unique R sIdx) g gs := rfl
+    Semantics.Definiteness.interpret (.bare R) g gs =
+      Semantics.Definiteness.interpret (.unique R sIdx) g gs := rfl
 
-/-- Shan-specific consequence of `Core.Nominal.interpret_demonstrative_eq_anaphoric`:
+/-- Shan-specific consequence of `Semantics.Definiteness.interpret_demonstrative_eq_anaphoric`:
     the demonstrative's deictic feature is a presupposition filter, not a
     referent selector. Demonstrative- and anaphoric-marked descriptions
     over the same restrictor and discourse index pick the same entity.
@@ -780,8 +780,8 @@ theorem shan_demonstrative_anaphoric_agreement {F : Frame}
     (R : DenotGS F .et) (deictic : Features.Deixis.Feature) (sIdx d : Nat)
     (g : Core.Assignment F.Entity)
     (gs : SitAssignment F) :
-    Core.Nominal.interpret (.demonstrative R deictic sIdx d) g gs =
-      Core.Nominal.interpret (.anaphoric R d) g gs := rfl
+    Semantics.Definiteness.interpret (.demonstrative R deictic sIdx d) g gs =
+      Semantics.Definiteness.interpret (.anaphoric R d) g gs := rfl
 
 -- ============================================================================
 -- §15: Refutation of [jenks-2018]'s Typological Prediction

--- a/Linglib/Studies/PaapeVasishth2026.lean
+++ b/Linglib/Studies/PaapeVasishth2026.lean
@@ -1,6 +1,6 @@
 import Linglib.Phenomena.SyntacticAmbiguity.Basic
 import Linglib.Semantics.Definiteness.Basic
-import Linglib.Core.Nominal.Maximality
+import Linglib.Semantics.Definiteness.Maximality
 import Linglib.Semantics.Presupposition.Basic
 
 /-!
@@ -516,7 +516,7 @@ open Semantics.Definiteness (modifierNecessary)
 open Semantics.Presupposition (PrProp)
 open Semantics.Presupposition.PrProp (presupOfReferent presupOfReferent_presup
   presupOfReferent_assertion_some presupOfReferent_assertion_none)
-open Core.Nominal (russellIotaList)
+open Semantics.Definiteness (russellIotaList)
 
 /-- Toy discourse entity for the uniqueness worked example. -/
 inductive DiscEntity where

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Pronoun.Basic
-import Linglib.Core.Nominal.Determiner
+import Linglib.Features.Determiner
 import Linglib.Fragments.German.Definiteness
 import Linglib.Studies.Schwarz2009
 import Linglib.Semantics.Presupposition.PhiFeatures
@@ -29,7 +29,7 @@ by an added pragmatic effect (emotivity §5.1, disambiguation §5.2, register §
 The contributions are made *true by construction* on shared substrate:
 
 * **DEM = PER + anaphoric index** is the [schwarz-2009] weak/strong refinement
-  `Core.Nominal.interpret_anaphoric_eq_unique_of_existsUnique`: the strong description
+  `Semantics.Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`: the strong description
   (DEM, `.anaphoric`) and the weak description (PER, `.unique`) over one restrictor
   pick the same referent exactly when the indexed entity is the unique satisfier —
   off that, DEM is anaphoric in a way PER is not. Both denote via
@@ -148,14 +148,14 @@ theorem schwarz_pgg_german_consistent :
     *different* referents. Reusing [schwarz-2009] §8's two-satisfier scenario:
     the weak PER fails uniqueness (two satisfiers → `none`) while the strong DEM
     reads off the discourse index. This is the divergence direction the convergence
-    theorem (`Core.Nominal.interpret_anaphoric_eq_unique_of_existsUnique`) rules out
+    theorem (`Semantics.Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`) rules out
     only under uniqueness. -/
 theorem der_er_can_diverge :
-    Core.Nominal.interpret
-        (Core.Nominal.Description.ofPresupType .uniqueness Schwarz2009.studentRestr 0)
+    Semantics.Definiteness.interpret
+        (Semantics.Definiteness.Description.ofPresupType .uniqueness Schwarz2009.studentRestr 0)
         Schwarz2009.gAlice Schwarz2009.gs0
-      ≠ Core.Nominal.interpret
-        (Core.Nominal.Description.ofPresupType .familiarity Schwarz2009.studentRestr 0)
+      ≠ Semantics.Definiteness.interpret
+        (Semantics.Definiteness.Description.ofPresupType .familiarity Schwarz2009.studentRestr 0)
         Schwarz2009.gAlice Schwarz2009.gs0 :=
   Schwarz2009.two_articles_can_disagree
 
@@ -177,19 +177,19 @@ open Semantics.Presupposition.PhiFeatures (femSem)
     feature *drives* the definite description's restrictor rather than re-stipulating it. -/
 theorem feminine_per_restrictor_is_femSem {F : Core.Logic.Intensional.Frame}
     (isFemale : F.Entity → Prop) (sIdx : Nat) :
-    Core.Nominal.Description.ofPresupType .uniqueness
+    Semantics.Definiteness.Description.ofPresupType .uniqueness
         (fun _ _ x => (femSem isFemale).presup x) sIdx
-      = Core.Nominal.Description.unique (fun _ _ x => isFemale x) sIdx := rfl
+      = Semantics.Definiteness.Description.unique (fun _ _ x => isFemale x) sIdx := rfl
 
 /-- Consequently a feminine PER picks the *unique female* — the gender presupposition is the
     restrictor of the weak-article definite (`ιx[isFemale x]`). -/
 theorem feminine_per_picks_unique_female {F : Core.Logic.Intensional.Frame}
     (isFemale : F.Entity → Prop) (sIdx : Nat)
     (g : Core.Assignment F.Entity) (gs : Core.Logic.Intensional.Variables.SitAssignment F) :
-    Core.Nominal.interpret
-        (Core.Nominal.Description.ofPresupType .uniqueness
+    Semantics.Definiteness.interpret
+        (Semantics.Definiteness.Description.ofPresupType .uniqueness
           (fun _ _ x => (femSem isFemale).presup x) sIdx) g gs
-      = Core.Nominal.russellIota (fun x => isFemale x) :=
-  Core.Nominal.interpret_unique (fun _ _ x => isFemale x) sIdx g gs
+      = Semantics.Definiteness.russellIota (fun x => isFemale x) :=
+  Semantics.Definiteness.interpret_unique (fun _ _ x => isFemale x) sIdx g gs
 
 end PatelGroszGrosz2017

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Pronoun.Basic
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Fragments.German.Definiteness
 import Linglib.Studies.Schwarz2009
 import Linglib.Semantics.Presupposition.PhiFeatures

--- a/Linglib/Studies/Schwarz2009.lean
+++ b/Linglib/Studies/Schwarz2009.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Definiteness
-import Linglib.Features.Determiner
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Semantics.Definiteness.Description
 import Linglib.Semantics.Definiteness.Interpret
 import Linglib.Fragments.German.Definiteness

--- a/Linglib/Studies/Schwarz2009.lean
+++ b/Linglib/Studies/Schwarz2009.lean
@@ -1,7 +1,7 @@
 import Linglib.Features.Definiteness
-import Linglib.Core.Nominal.Determiner
-import Linglib.Core.Nominal.Description
-import Linglib.Core.Nominal.Interpret
+import Linglib.Features.Determiner
+import Linglib.Semantics.Definiteness.Description
+import Linglib.Semantics.Definiteness.Interpret
 import Linglib.Fragments.German.Definiteness
 import Linglib.Fragments.English.Definiteness
 
@@ -30,13 +30,13 @@ the distinction at the surface.
 
 The split is operationalized in the Core layer by:
 
-- **`Core.Nominal.Description`** — distinct `.unique` (weak) and
+- **`Semantics.Definiteness.Description`** — distinct `.unique` (weak) and
   `.anaphoric` (strong) constructors, with different argument shapes
   (`.unique` carries a *situation* index for resource-situation binding;
   `.anaphoric` carries a *discourse* index for antecedent lookup).
-- **`Core.Nominal.Description.expectedPresupType`** — projects each kind
+- **`Semantics.Definiteness.Description.expectedPresupType`** — projects each kind
   to the [schwarz-2009] presupposition type it expresses.
-- **`Core.Nominal.Determiner`** — the declared determiner set records the
+- **`Semantics.Definiteness.Determiner`** — the declared determiner set records the
   morphological inventory; `Determiner.IsSyncretic` is the predicate that
   distinguishes English-style syncretism from German-style bipartition.
 
@@ -66,7 +66,7 @@ namespace Schwarz2009
 open Features.Definiteness
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
-open Core.Nominal
+open Semantics.Definiteness
 
 -- ════════════════════════════════════════════════════════════════
 -- §1: The two presupposition types are genuinely distinct

--- a/Linglib/Syntax/Determiner/Basic.lean
+++ b/Linglib/Syntax/Determiner/Basic.lean
@@ -38,7 +38,6 @@ An `Article`'s admissible [schwarz-2009] strengths are `Article.presupTypes`
 (`Semantics/Definiteness/DeterminerLicensing.lean`, Frame-aware) — the set of `Description`s
 those strengths admit via `Description.ofPresupType`, so a syncretic article like
 English *the* denotes *both* the weak and the strong description.
-`DemonstrativeDeterminer.denote` (deictic), the `Quantifier` generalized quantifier
 (`Core/Logic/Quantification`), and the `Possessive` possession relation remain
 deferred; `Quantifier`/`Possessive` are declared but not fleshed out beyond `form`.
 This file stays the Frame-free lexical/typological layer.

--- a/Linglib/Syntax/Pronoun/Demonstrative.lean
+++ b/Linglib/Syntax/Pronoun/Demonstrative.lean
@@ -32,7 +32,7 @@ set_option autoImplicit false
 /-- A deictic demonstrative pronoun: the general `Pronoun` (form + φ) plus the
     `Features.Deixis.Feature` it encodes — its proximal/medial/distal contrast (or `unspecified`
     for a distance-neutral demonstrative like German *dieser*). Carries no separate denotation here;
-    its meaning is the deictic `Core.Nominal.Description.demonstrative` over its restrictor. -/
+    its meaning is the deictic `Semantics.Definiteness.Description.demonstrative` over its restrictor. -/
 structure DemonstrativePronoun extends Pronoun where
   /-- Demonstratives are UD `PronType=Dem`; the *type* fixes the morphology. -/
   pronType := some UD.PronType.Dem


### PR DESCRIPTION
Continues the Core dissolution: `Core/Nominal/` dissolves and gains the determiner half of the pronoun/determiner denotation API.

- `Description`/`Maximality`/`Interpret`/`DeterminerLicensing` → `Semantics/Definiteness/` (namespace `Semantics.Definiteness`; `Definiteness/Basic.lean` already self-described as connective tissue over exactly this layer)
- `Determiner` lexical core → `Syntax/Determiner/Basic.lean`, the exact parallel of `Syntax/Pronoun/Basic.lean`
- New `Semantics/Definiteness/DeterminerDenotation.lean` mirroring `PronounDenotation.lean`: `Description.denote : NominalDenot` (selector = canonical `interpret` by construction), `DemonstrativeDeterminer.denote` (deixis presupposition via model-supplied proximity predicates, parallel to `phiPresup`; previously deferred), `Article.denotations` (syncretic *the* denotes weak + strong), with `denote_selector_eq_anaphoric` (deixis filters, never selects) and `denotations_licensed` (denotation and licensing pipelines agree)
- `Quantifier` GQ and `Possessive` remain deferred, documented