### PR TITLE
refactor(Core/Order): migrate isLicensed/hasMax/hasMin from Bool to Prop

### DIFF
--- a/Linglib/Core/Order/Boundedness.lean
+++ b/Linglib/Core/Order/Boundedness.lean
@@ -1,28 +1,27 @@
 import Mathlib.Order.Basic
 
 /-!
-# Core/Scales/Defs.lean — basic types
+# Scale boundedness and the licensing pipeline
 [kennedy-mcnally-2005] [kennedy-2007] [rotstein-winter-2004] [rouillard-2026]
 
 Foundational scale-classification types used across all gradability/degree
 substrate. No framework-specific operators here (those live in
 `Semantics/Gradability/`).
 
-Contents:
-- `Boundedness` enum + `hasMax`/`hasMin`/`isLicensed`
-- `MereoTag` + `toBoundedness`
-- `LicensingPipeline` typeclass + universal theorem
-- `ScalePolarity` enum
+## Main declarations
 
-This file is part of the Phase A decomposition of the legacy
-`Core/Scales/Scale.lean` dumping ground (master plan v4).
+- `Boundedness`: the four-way endpoint classification, with `HasMax` /
+  `HasMin` / `IsLicensed` predicates.
+- `MereoTag`, `EpistemicTag`: binary classifications mapping into
+  `Boundedness`.
+- `LicensingPipeline`: typeclass for types classifiable into `Boundedness`,
+  with the `universal` agreement theorem.
+- `ScalePolarity`.
 -/
 
 namespace Core.Order
 
--- ════════════════════════════════════════════════════
--- § 1. Scale Boundedness
--- ════════════════════════════════════════════════════
+/-! ### Scale boundedness -/
 
 /-- Classification of scale boundedness.
     [kennedy-mcnally-2005] eq (1) and [kennedy-2007] §4.2 eq (59):
@@ -57,38 +56,50 @@ inductive Boundedness where
   deriving DecidableEq, Repr
 
 /-- Does this scale have an inherent maximum? -/
-def Boundedness.hasMax : Boundedness → Bool
-  | .upperBounded | .closed => true
-  | .open_ | .lowerBounded => false
+def Boundedness.HasMax : Boundedness → Prop
+  | .upperBounded | .closed => True
+  | .open_ | .lowerBounded => False
+
+instance : DecidablePred Boundedness.HasMax
+  | .open_ => isFalse id
+  | .lowerBounded => isFalse id
+  | .upperBounded => isTrue trivial
+  | .closed => isTrue trivial
 
 /-- Does this scale have an inherent minimum? -/
-def Boundedness.hasMin : Boundedness → Bool
-  | .lowerBounded | .closed => true
-  | .open_ | .upperBounded => false
+def Boundedness.HasMin : Boundedness → Prop
+  | .lowerBounded | .closed => True
+  | .open_ | .upperBounded => False
 
-/-- "Any endpoint exists" predicate: returns `true` whenever the scale
-    has at least one bound (max or min). An open scale returns `false`.
+instance : DecidablePred Boundedness.HasMin
+  | .open_ => isFalse id
+  | .lowerBounded => isTrue trivial
+  | .upperBounded => isFalse id
+  | .closed => isTrue trivial
+
+/-- "Any endpoint exists": the scale has at least one bound (max or min);
+    an open scale has none.
 
     **NOT [kennedy-2007]'s full licensing prediction.** Kennedy's actual
     prediction is the 4×2 modifier-class matrix in [kennedy-2007]
     eq (61) (= [kennedy-mcnally-2005] eq (15)): maximizers
     (*completely, perfectly*) require an UPPER endpoint; minimizers
     (*slightly, partially*) require a LOWER endpoint; proportional modifiers
-    (*half*) require BOTH. A single Bool can't encode this — to be faithful,
-    split into `licensesMaximizer`/`licensesMinimizer`/`licensesProportional`.
+    (*half*) require BOTH — for modifier-specific licensing, consult
+    `HasMax`/`HasMin` directly. This predicate suffices for callers that
+    only distinguish "open" from "any-endpoint-exists" (Interpretive
+    Economy, [kennedy-2007] §4.3; Rouillard's MIP, [rouillard-2026]). -/
+def Boundedness.IsLicensed : Boundedness → Prop
+  | .closed | .lowerBounded | .upperBounded => True
+  | .open_ => False
 
-    The current Bool is sufficient for callers that only need to distinguish
-    "open" from "any-endpoint-exists" (e.g. Interpretive Economy gating a
-    relative vs. absolute interpretation, [kennedy-2007] §4.3, or
-    Rouillard's MIP, [rouillard-2026]). For modifier-specific
-    licensing, consumers must consult `hasMax`/`hasMin` directly. -/
-def Boundedness.isLicensed : Boundedness → Bool
-  | .closed | .lowerBounded | .upperBounded => true
-  | .open_ => false
+instance : DecidablePred Boundedness.IsLicensed
+  | .open_ => isFalse id
+  | .lowerBounded => isTrue trivial
+  | .upperBounded => isTrue trivial
+  | .closed => isTrue trivial
 
--- ════════════════════════════════════════════════════
--- § 1b. MereoTag + LicensingPipeline
--- ════════════════════════════════════════════════════
+/-! ### MereoTag and the licensing pipeline -/
 
 /-- Binary mereological classification: the shared abstraction underlying
     all four licensing frameworks (Kennedy, Rouillard, Krifka, Zwarts). -/
@@ -115,8 +126,12 @@ namespace LicensingPipeline
 
 variable {α : Type*} [LicensingPipeline α]
 
-def isLicensed (a : α) : Bool :=
-  (toBoundedness a).isLicensed
+/-- A pipeline input is licensed iff its boundedness classification is. -/
+def IsLicensed (a : α) : Prop :=
+  (toBoundedness a).IsLicensed
+
+instance : DecidablePred (IsLicensed (α := α)) := fun a =>
+  inferInstanceAs (Decidable (toBoundedness a).IsLicensed)
 
 instance : LicensingPipeline Boundedness where
   toBoundedness := id
@@ -129,8 +144,9 @@ instance : LicensingPipeline MereoTag where
     of which framework they come. -/
 theorem universal {α β : Type*} [LicensingPipeline α] [LicensingPipeline β]
     (a : α) (b : β) (h : toBoundedness a = toBoundedness b) :
-    isLicensed a = isLicensed b := by
-  simp only [isLicensed, h]
+    IsLicensed a ↔ IsLicensed b := by
+  unfold IsLicensed
+  rw [h]
 
 end LicensingPipeline
 
@@ -147,28 +163,26 @@ instance : LicensingPipeline EpistemicTag where
     | .qualitative => .open_
 
 theorem epistemicFA_licensed :
-    LicensingPipeline.isLicensed EpistemicTag.finitelyAdditive = true := rfl
+    LicensingPipeline.IsLicensed EpistemicTag.finitelyAdditive := trivial
 
 theorem epistemicQualitative_blocked :
-    LicensingPipeline.isLicensed EpistemicTag.qualitative = false := rfl
+    ¬ LicensingPipeline.IsLicensed EpistemicTag.qualitative := id
 
 theorem five_frameworks_agree
     (m : MereoTag) (e : EpistemicTag)
     (h : LicensingPipeline.toBoundedness m = LicensingPipeline.toBoundedness e) :
-    LicensingPipeline.isLicensed m = LicensingPipeline.isLicensed e :=
+    LicensingPipeline.IsLicensed m ↔ LicensingPipeline.IsLicensed e :=
   LicensingPipeline.universal m e h
 
-theorem epistemicFA_eq_qua :
-    LicensingPipeline.isLicensed EpistemicTag.finitelyAdditive =
-    LicensingPipeline.isLicensed MereoTag.qua := rfl
+theorem epistemicFA_iff_qua :
+    LicensingPipeline.IsLicensed EpistemicTag.finitelyAdditive ↔
+    LicensingPipeline.IsLicensed MereoTag.qua := Iff.rfl
 
-theorem epistemicQualitative_eq_cum :
-    LicensingPipeline.isLicensed EpistemicTag.qualitative =
-    LicensingPipeline.isLicensed MereoTag.cum := rfl
+theorem epistemicQualitative_iff_cum :
+    LicensingPipeline.IsLicensed EpistemicTag.qualitative ↔
+    LicensingPipeline.IsLicensed MereoTag.cum := Iff.rfl
 
--- ════════════════════════════════════════════════════
--- § 1d. Scale Polarity
--- ════════════════════════════════════════════════════
+/-! ### Scale polarity -/
 
 /-- Intrinsic polarity of a scale dimension.
     `positive`: the unmarked direction (tall, hot, confident).

--- a/Linglib/Core/Order/ComparativeScale.lean
+++ b/Linglib/Core/Order/ComparativeScale.lean
@@ -59,8 +59,12 @@ structure AdditiveScale (α : Type*) [SemilatticeSup α] extends ComparativeScal
 namespace ComparativeScale
 
 /-- Licensing prediction from the underlying boundedness. -/
-def isLicensed {α : Type*} [Preorder α] (S : ComparativeScale α) : Bool :=
-  S.boundedness.isLicensed
+def IsLicensed {α : Type*} [Preorder α] (S : ComparativeScale α) : Prop :=
+  S.boundedness.IsLicensed
+
+instance {α : Type*} [Preorder α] (S : ComparativeScale α) :
+    Decidable S.IsLicensed :=
+  inferInstanceAs (Decidable S.boundedness.IsLicensed)
 
 end ComparativeScale
 

--- a/Linglib/Phenomena/TenseAspect/AspectualConsistency.lean
+++ b/Linglib/Phenomena/TenseAspect/AspectualConsistency.lean
@@ -135,8 +135,8 @@ theorem eat_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "arrive": achievement → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem arrive_full_pipeline :
@@ -144,8 +144,8 @@ theorem arrive_full_pipeline :
     VendlerClass.achievement.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .achievement = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .achievement = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "sleep": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem sleep_full_pipeline :
@@ -153,8 +153,8 @@ theorem sleep_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "run": activity → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem run_full_pipeline :
@@ -162,8 +162,8 @@ theorem run_full_pipeline :
     VendlerClass.activity.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .activity = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .activity = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "see": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem see_full_pipeline :
@@ -171,8 +171,8 @@ theorem see_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "leave": achievement → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem leave_full_pipeline :
@@ -180,8 +180,8 @@ theorem leave_full_pipeline :
     VendlerClass.achievement.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .achievement = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .achievement = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "kill": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem kill_full_pipeline :
@@ -189,8 +189,8 @@ theorem kill_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 -- Accomplishment verbs (telic, "in X")
 
@@ -200,8 +200,8 @@ theorem give_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "cover": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem cover_full_pipeline :
@@ -209,8 +209,8 @@ theorem cover_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "buy": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem buy_full_pipeline :
@@ -218,8 +218,8 @@ theorem buy_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "sell": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem sell_full_pipeline :
@@ -227,8 +227,8 @@ theorem sell_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "break": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem break_full_pipeline :
@@ -236,8 +236,8 @@ theorem break_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "tear": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem tear_full_pipeline :
@@ -245,8 +245,8 @@ theorem tear_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "burn": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem burn_full_pipeline :
@@ -254,8 +254,8 @@ theorem burn_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "destroy": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem destroy_full_pipeline :
@@ -263,8 +263,8 @@ theorem destroy_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "melt": accomplishment → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem melt_full_pipeline :
@@ -272,8 +272,8 @@ theorem melt_full_pipeline :
     VendlerClass.accomplishment.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .accomplishment = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 -- Achievement verbs (telic, "in X")
 
@@ -283,8 +283,8 @@ theorem put_full_pipeline :
     VendlerClass.achievement.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .achievement = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .achievement = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "meet": achievement → telic → QUA → closed → licensed → "in X" ✓. -/
 theorem meet_full_pipeline :
@@ -292,8 +292,8 @@ theorem meet_full_pipeline :
     VendlerClass.achievement.telicity = .telic ∧
     Telicity.telic.toMereoTag = .qua ∧
     MereoTag.qua.toBoundedness = .closed ∧
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    inXPrediction .achievement = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    inXPrediction .achievement = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 -- Activity verbs (atelic, "for X")
 
@@ -303,8 +303,8 @@ theorem chase_full_pipeline :
     VendlerClass.activity.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .activity = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .activity = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "hit": activity → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem hit_full_pipeline :
@@ -312,8 +312,8 @@ theorem hit_full_pipeline :
     VendlerClass.activity.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .activity = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .activity = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 -- State verbs (atelic, "for X")
 
@@ -323,8 +323,8 @@ theorem weigh_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "measure": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem measure_full_pipeline :
@@ -332,8 +332,8 @@ theorem measure_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "enjoy": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem enjoy_full_pipeline :
@@ -341,8 +341,8 @@ theorem enjoy_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "like": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem like_full_pipeline :
@@ -350,8 +350,8 @@ theorem like_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "hate": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem hate_full_pipeline :
@@ -359,8 +359,8 @@ theorem hate_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "admire": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem admire_full_pipeline :
@@ -368,8 +368,8 @@ theorem admire_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "envy": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem envy_full_pipeline :
@@ -377,8 +377,8 @@ theorem envy_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "respect": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem respect_full_pipeline :
@@ -386,8 +386,8 @@ theorem respect_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 /-- "value": state → atelic → CUM → open → blocked → "for X" ✓. -/
 theorem value_full_pipeline :
@@ -395,8 +395,8 @@ theorem value_full_pipeline :
     VendlerClass.state.telicity = .atelic ∧
     Telicity.atelic.toMereoTag = .cum ∧
     MereoTag.cum.toBoundedness = .open_ ∧
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    forXPrediction .state = .accept := ⟨rfl, rfl, rfl, rfl, by decide, rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 4. Motion Verb Cross-Classification
@@ -431,28 +431,31 @@ theorem run_motion_consistent :
 
 /-! These tests loop over `allVerbs` so adding a new verb to the fragment
     automatically includes it in the test suite — no per-verb theorem needed.
-    If a new verb has an inconsistent annotation, `native_decide` fails. -/
+    If a new verb has an inconsistent annotation, the decision-procedure
+    checks fail. -/
 
 /-- Pipeline consistency: for any verb with a vendlerClass annotation,
     the VendlerClass → Telicity → MereoTag → Boundedness chain must
     produce a licensing prediction that agrees with the for/in diagnostic.
-    Returns `true` for verbs without vendlerClass (vacuously OK). -/
-def pipelineOK (v : VerbEntry) : Bool :=
+    Vacuously OK for verbs without vendlerClass. Licensed (telic) verbs
+    accept "in X"; blocked (atelic) verbs accept or are coerced with
+    "for X" (semelfactives are coerced). -/
+def PipelineOK (v : VerbEntry) : Prop :=
   match v.toVerb.vendlerClass with
-  | none => true
+  | none => True
   | some vc =>
-    let tel := vc.telicity
-    let mt := tel.toMereoTag
-    let bnd := mt.toBoundedness
-    let licensed := LicensingPipeline.isLicensed bnd
-    -- Licensed (telic) verbs accept "in X"; blocked (atelic) verbs
-    -- accept or are coerced with "for X" (semelfactives are coerced).
-    if licensed then inXPrediction vc == .accept
-    else forXPrediction vc == .accept || forXPrediction vc == .coerced
+    (LicensingPipeline.IsLicensed vc.telicity.toMereoTag.toBoundedness ∧
+      inXPrediction vc = .accept) ∨
+    (¬ LicensingPipeline.IsLicensed vc.telicity.toMereoTag.toBoundedness ∧
+      (forXPrediction vc = .accept ∨ forXPrediction vc = .coerced))
 
+instance (v : VerbEntry) : Decidable (PipelineOK v) := by
+  unfold PipelineOK
+  split <;> infer_instance
+
+set_option maxRecDepth 2048 in
 /-- Every verb in the fragment passes pipeline consistency. -/
-theorem all_verbs_pipeline_ok :
-    allVerbs.all pipelineOK = true := by native_decide
+theorem all_verbs_pipeline_ok : ∀ v ∈ allVerbs, PipelineOK v := by decide
 
 /-- VendlerClass × VerbIncClass coherence: sinc/inc verbs must be
     accomplishments (telic), cumOnly verbs must be activities (atelic).

--- a/Linglib/Semantics/Aspect/Boundedness.lean
+++ b/Linglib/Semantics/Aspect/Boundedness.lean
@@ -43,9 +43,9 @@ instance : Core.Order.LicensingPipeline SituationBoundedness where
   toBoundedness s := s.toMereoTag.toBoundedness
 
 theorem bounded_licensed :
-    Core.Order.LicensingPipeline.isLicensed SituationBoundedness.bounded = true := rfl
+    Core.Order.LicensingPipeline.IsLicensed SituationBoundedness.bounded := trivial
 
 theorem unbounded_blocked :
-    Core.Order.LicensingPipeline.isLicensed SituationBoundedness.unbounded = false := rfl
+    ¬ Core.Order.LicensingPipeline.IsLicensed SituationBoundedness.unbounded := id
 
 end Semantics.Aspect

--- a/Linglib/Semantics/Attitudes/EpistemicThreshold.lean
+++ b/Linglib/Semantics/Attitudes/EpistemicThreshold.lean
@@ -645,7 +645,7 @@ theorem meetsThreshold_eq_positiveSem (cr : AgentCredence E W) (θ : ℚ)
     full"); cross-source agreement is `LicensingPipeline.universal`
     (`Core/Order/Boundedness.lean`). -/
 theorem epistemicScale_licensed :
-    epistemicBoundedness.isLicensed = true := rfl
+    epistemicBoundedness.IsLicensed := trivial
 
 -- ============================================================================
 -- §9. Connection to Holliday–Icard Epistemic Likelihood

--- a/Linglib/Semantics/Degree/DirectedMeasure.lean
+++ b/Linglib/Semantics/Degree/DirectedMeasure.lean
@@ -14,7 +14,7 @@ semantics.
 ## Main declarations
 
 - `DirectedMeasure`: the bundled measure structure.
-- `DirectedMeasure.licensed`: endpoint-based licensing via `Boundedness.isLicensed`.
+- `DirectedMeasure.IsLicensed`: endpoint-based licensing via `Boundedness.IsLicensed`.
 - `DirectedMeasure.numeral`, `DirectedMeasure.adjective`: Kennedy-style
   numeral and gradable-adjective domains.
 
@@ -67,7 +67,10 @@ variable {D : Type*} [LinearOrder D] {E : Type*}
     See `Boundedness.isLicensed` for the caveat — this checks
     "any endpoint exists", not [kennedy-2007]'s full
     modifier-class licensing matrix. -/
-def licensed (dm : DirectedMeasure D E) : Bool := dm.boundedness.isLicensed
+def IsLicensed (dm : DirectedMeasure D E) : Prop := dm.boundedness.IsLicensed
+
+instance (dm : DirectedMeasure D E) : Decidable dm.IsLicensed :=
+  inferInstanceAs (Decidable dm.boundedness.IsLicensed)
 
 end DirectedMeasure
 
@@ -100,15 +103,15 @@ def adjective (μ : W → α) (b : Boundedness) : DirectedMeasure α W :=
 
 /-- Numeral domains are always licensed (closed scale). -/
 theorem numeral_licensed (μ : W → α) :
-    (numeral μ).licensed = true := rfl
+    (numeral μ).IsLicensed := trivial
 
 /-- Class B adjectives (closed scale) are licensed. -/
 theorem classB_licensed (μ : W → α) :
-    (adjective μ .closed).licensed = true := rfl
+    (adjective μ .closed).IsLicensed := trivial
 
 /-- Class A adjectives (open scale) are blocked. -/
 theorem classA_blocked (μ : W → α) :
-    (adjective μ .open_).licensed = false := rfl
+    ¬ (adjective μ .open_).IsLicensed := id
 
 end DirectedMeasure
 

--- a/Linglib/Semantics/Degree/Predicate.lean
+++ b/Linglib/Semantics/Degree/Predicate.lean
@@ -107,11 +107,11 @@ theorem bimonotone_no_optimum {W : Type*} (P : α → W → Prop)
 
 /-- Closed scales predict licensing (Kennedy: "completely full" ✓;
     Rouillard: telic VP E-TIA ✓). -/
-theorem closed_isLicensed : Boundedness.closed.isLicensed = true := rfl
+theorem closed_isLicensed : Boundedness.closed.IsLicensed := trivial
 
 /-- Open scales predict blocking (Kennedy: "??completely tall";
     Rouillard: atelic VP E-TIA ✗). -/
-theorem open_notLicensed : Boundedness.open_.isLicensed = false := rfl
+theorem open_notLicensed : ¬ Boundedness.open_.IsLicensed := id
 
 -- ════════════════════════════════════════════════════
 -- § 6. Degree Properties ([fox-2007] §2)

--- a/Linglib/Semantics/Gradability/Basic.lean
+++ b/Linglib/Semantics/Gradability/Basic.lean
@@ -284,15 +284,15 @@ def adjMeasure {max : Nat} {W : Type*} (μ : W → Degree max)
 
 theorem closedAdj_licensed {max : Nat} {W : Type*} (μ : W → Degree max)
     (entry : GradableAdjEntry) (h : entry.scaleType = .closed) :
-    (adjMeasure μ entry).licensed = true := by
+    (adjMeasure μ entry).IsLicensed := by
   simp [adjMeasure, DirectedMeasure.adjective,
-        DirectedMeasure.licensed, Boundedness.isLicensed, h]
+        DirectedMeasure.IsLicensed, Boundedness.IsLicensed, h]
 
 theorem openAdj_blocked {max : Nat} {W : Type*} (μ : W → Degree max)
     (entry : GradableAdjEntry) (h : entry.scaleType = .open_) :
-    (adjMeasure μ entry).licensed = false := by
+    ¬ (adjMeasure μ entry).IsLicensed := by
   simp [adjMeasure, DirectedMeasure.adjective,
-        DirectedMeasure.licensed, Boundedness.isLicensed, h]
+        DirectedMeasure.IsLicensed, Boundedness.IsLicensed, h]
 
 theorem degree_nontrivial {max : Nat} (h : 1 ≤ max) :
     ∃ x : Degree max, x ≠ ⊤ := by

--- a/Linglib/Semantics/Spatial/Path.lean
+++ b/Linglib/Semantics/Spatial/Path.lean
@@ -80,17 +80,17 @@ def PathShape.toBoundedness : PathShape → Core.Order.Boundedness
     [zwarts-2005]: "to the store" creates a telic VP because the path
     set is bounded, corresponding to a closed scale. -/
 theorem bounded_path_licensed :
-    PathShape.bounded.toBoundedness.isLicensed = true := rfl
+    PathShape.bounded.toBoundedness.IsLicensed := trivial
 
 /-- Source paths are licensed (closed scale at the origin end). -/
 theorem source_path_licensed :
-    PathShape.source.toBoundedness.isLicensed = true := rfl
+    PathShape.source.toBoundedness.IsLicensed := trivial
 
 /-- Unbounded paths are blocked (open scale → no inherent endpoint).
     [zwarts-2005]: "towards the store" creates an atelic VP because
     the path set is unbounded, corresponding to an open scale. -/
 theorem unbounded_path_blocked :
-    PathShape.unbounded.toBoundedness.isLicensed = false := rfl
+    ¬ PathShape.unbounded.toBoundedness.IsLicensed := id
 
 -- ════════════════════════════════════════════════════
 -- § 4. Path Adjacency

--- a/Linglib/Semantics/Spatial/Trace.lean
+++ b/Linglib/Semantics/Spatial/Trace.lean
@@ -143,9 +143,9 @@ theorem unbounded_atelic : pathShapeToTelicity .unbounded = .atelic := rfl
     telic ↔ licensed (closed scale), atelic ↔ blocked (open scale).
     This connects the spatial classification to the scale-theoretic one. -/
 theorem telicity_boundedness_agree (s : PathShape) :
-    (pathShapeToTelicity s = .telic) ↔ (s.toBoundedness.isLicensed = true) := by
+    (pathShapeToTelicity s = .telic) ↔ s.toBoundedness.IsLicensed := by
   cases s <;> simp [pathShapeToTelicity, PathShape.toBoundedness,
-    Core.Order.Boundedness.isLicensed]
+    Core.Order.Boundedness.IsLicensed]
 
 /-- LicensingPipeline instance for PathShape via the `pathShapeToTelicity`
     bridge. Co-located with the bridge per the convention noted in

--- a/Linglib/Studies/Beltrama2025.lean
+++ b/Linglib/Studies/Beltrama2025.lean
@@ -377,15 +377,15 @@ open Core.Order (LicensingPipeline)
     while their resistance to *very*/*extremely* is pragmatic (§6.2),
     not structural. -/
 theorem mpa_licensed_by_pipeline :
-    LicensingPipeline.isLicensed decent.scaleType = true ∧
-    LicensingPipeline.isLicensed acceptable.scaleType = true ∧
-    LicensingPipeline.isLicensed adequate.scaleType = true := ⟨rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed decent.scaleType ∧
+    LicensingPipeline.IsLicensed acceptable.scaleType ∧
+    LicensingPipeline.IsLicensed adequate.scaleType := ⟨trivial, trivial, trivial⟩
 
 /-- *good* is also licensed (same scale structure). The difference
     between MPAs and *good* is in standard type, not in structural
     licensing. -/
 theorem good_also_licensed :
-    LicensingPipeline.isLicensed good.scaleType = true := rfl
+    LicensingPipeline.IsLicensed good.scaleType := trivial
 
 -- ============================================================================
 -- § 11. Integration: Evaluative Valence

--- a/Linglib/Studies/FoxHackl2006Numerals.lean
+++ b/Linglib/Studies/FoxHackl2006Numerals.lean
@@ -108,6 +108,6 @@ theorem foxHackl_atLeast_verified :
 
 /-- Kennedy numeral domains are always licensed (closed scale). -/
 theorem kennedy_numeral_licensed {W : Type*} (μ : W → ℕ) :
-    (DirectedMeasure.numeral μ).licensed = true := rfl
+    (DirectedMeasure.numeral μ).IsLicensed := trivial
 
 end FoxHackl2006Numerals

--- a/Linglib/Studies/Kennedy2007Licensing.lean
+++ b/Linglib/Studies/Kennedy2007Licensing.lean
@@ -18,7 +18,7 @@ and Phenomena data (`closurePuzzle`, `completelyModifier`).
 ## Bridge Structure
 
 1. **Fragment → DirectedMeasure**: each Fragment entry's `scaleType`
-   determines a `DirectedMeasure`, whose `.licensed` field yields the
+   determines a `DirectedMeasure`, whose `IsLicensed` predicate yields the
    licensing prediction.
 
 2. **DirectedMeasure → Data**: the licensing prediction matches the
@@ -387,9 +387,9 @@ and the `Boundedness` scale-structure substrate.
 
 Per the matrix:
 - **Maximizers / proportional** (*completely, perfectly, absolutely, half*)
-  require an UPPER endpoint → license iff `Boundedness.hasMax = true`.
+  require an UPPER endpoint → license iff `Boundedness.HasMax`.
 - **Minimizers / diminishers** (*slightly, partially, somewhat*) require
-  a LOWER endpoint → license iff `Boundedness.hasMin = true`.
+  a LOWER endpoint → license iff `Boundedness.HasMin`.
 - **Intensifiers** (*very, extremely*) work on all scales (modulo
   pragmatic considerations).
 - **Measure phrases** (*6 feet tall*) work on all dimensional scales
@@ -398,11 +398,18 @@ Per the matrix:
 This is the genuine Tier C #3 bridge from the §1 Boundedness audit
 (0.230.420) — supersedes the decorative `closedScale_satEntity_*`
 theorems landed and unanimously audit-flagged in 0.230.436. -/
-def licenses : DegreeModifierType → Core.Order.Boundedness → Bool
-  | .proportional, b => b.hasMax
-  | .diminisher, b => b.hasMin
-  | .intensifier, _ => true
-  | .measurePhrase, _ => true
+def Licenses : DegreeModifierType → Core.Order.Boundedness → Prop
+  | .proportional, b => b.HasMax
+  | .diminisher, b => b.HasMin
+  | .intensifier, _ => True
+  | .measurePhrase, _ => True
+
+instance : ∀ (m : DegreeModifierType) (b : Core.Order.Boundedness),
+    Decidable (Licenses m b)
+  | .proportional, b => inferInstanceAs (Decidable b.HasMax)
+  | .diminisher, b => inferInstanceAs (Decidable b.HasMin)
+  | .intensifier, _ => isTrue trivial
+  | .measurePhrase, _ => isTrue trivial
 
 end Kennedy2007Licensing
 
@@ -424,25 +431,25 @@ open Kennedy2007Licensing
 
 /-- "tall" (open scale) → DirectedMeasure blocks degree modification. -/
 theorem tall_blocks_completely {max : Nat} {W : Type*} (μ : W → Degree max) :
-    (adjMeasure μ tall).licensed = false :=
+    ¬ (adjMeasure μ tall).IsLicensed :=
   openAdj_blocked μ tall rfl
 
 /-- "full" (closed scale) → DirectedMeasure licenses degree modification. -/
 theorem full_licenses_completely {max : Nat} {W : Type*} (μ : W → Degree max) :
-    (adjMeasure μ full).licensed = true :=
+    (adjMeasure μ full).IsLicensed :=
   closedAdj_licensed μ full rfl
 
 /-- "wet" (lower-bounded) → DirectedMeasure licenses. -/
 theorem wet_licensed {max : Nat} {W : Type*} (μ : W → Degree max) :
-    (adjMeasure μ wet).licensed = true := by
+    (adjMeasure μ wet).IsLicensed := by
   simp only [adjMeasure, DirectedMeasure.adjective,
-        DirectedMeasure.licensed, wet, Boundedness.isLicensed]
+        DirectedMeasure.IsLicensed, wet, Boundedness.IsLicensed]
 
 /-- "dry" (upper-bounded) → DirectedMeasure licenses. -/
 theorem dry_licensed {max : Nat} {W : Type*} (μ : W → Degree max) :
-    (adjMeasure μ dry).licensed = true := by
+    (adjMeasure μ dry).IsLicensed := by
   simp only [adjMeasure, DirectedMeasure.adjective,
-        DirectedMeasure.licensed, dry, Boundedness.isLicensed]
+        DirectedMeasure.IsLicensed, dry, Boundedness.IsLicensed]
 
 -- ════════════════════════════════════════════════════
 -- § 2. DirectedMeasure → Data Bridges
@@ -452,16 +459,18 @@ theorem dry_licensed {max : Nat} {W : Type*} (μ : W → Degree max) :
     closed-scale adjectives license "completely", open-scale ones don't.
     Matches `closurePuzzle.worksWithClosed` / `.worksWithOpen`. -/
 theorem closurePuzzle_predicted {max : Nat} {W : Type*} (μ : W → Degree max) :
-    (adjMeasure μ full).licensed = closurePuzzle.worksWithClosed ∧
-    (adjMeasure μ tall).licensed = closurePuzzle.worksWithOpen := by
-  exact ⟨closedAdj_licensed μ full rfl, openAdj_blocked μ tall rfl⟩
+    ((adjMeasure μ full).IsLicensed ↔ closurePuzzle.worksWithClosed = true) ∧
+    ((adjMeasure μ tall).IsLicensed ↔ closurePuzzle.worksWithOpen = true) :=
+  ⟨iff_of_true (closedAdj_licensed μ full rfl) rfl,
+   iff_of_false (openAdj_blocked μ tall rfl) (by decide)⟩
 
 /-- "completely" works with AGA-max (closed) but not RGA (open).
     `adjMeasure` licensing matches `completelyModifier` fields. -/
 theorem completely_distribution {max : Nat} {W : Type*} (μ : W → Degree max) :
-    (adjMeasure μ full).licensed = completelyModifier.worksWithAGAMax ∧
-    (adjMeasure μ tall).licensed = completelyModifier.worksWithRGA := by
-  exact ⟨closedAdj_licensed μ full rfl, openAdj_blocked μ tall rfl⟩
+    ((adjMeasure μ full).IsLicensed ↔ completelyModifier.worksWithAGAMax = true) ∧
+    ((adjMeasure μ tall).IsLicensed ↔ completelyModifier.worksWithRGA = true) :=
+  ⟨iff_of_true (closedAdj_licensed μ full rfl) rfl,
+   iff_of_false (openAdj_blocked μ tall rfl) (by decide)⟩
 
 -- ════════════════════════════════════════════════════
 -- § 3. LicensingPipeline Bridges
@@ -469,30 +478,27 @@ theorem completely_distribution {max : Nat} {W : Type*} (μ : W → Degree max) 
 
 /-- "tall" through the universal pipeline: open_ → blocked. -/
 theorem adj_pipeline_tall :
-    LicensingPipeline.isLicensed tall.scaleType = false := rfl
+    ¬ LicensingPipeline.IsLicensed tall.scaleType := id
 
 /-- "full" through the universal pipeline: closed → licensed. -/
 theorem adj_pipeline_full :
-    LicensingPipeline.isLicensed full.scaleType = true := rfl
+    LicensingPipeline.IsLicensed full.scaleType := trivial
 
 /-- "wet" through the universal pipeline: lowerBounded → licensed. -/
 theorem adj_pipeline_wet :
-    LicensingPipeline.isLicensed wet.scaleType = true := rfl
+    LicensingPipeline.IsLicensed wet.scaleType := trivial
 
 /-- "dry" through the universal pipeline: upperBounded → licensed. -/
 theorem adj_pipeline_dry :
-    LicensingPipeline.isLicensed dry.scaleType = true := rfl
+    LicensingPipeline.IsLicensed dry.scaleType := trivial
 
 /-- Pipeline agrees with DirectedMeasure for all four test adjectives. -/
 theorem pipeline_agrees_with_measure {max : Nat} {W : Type*} (μ : W → Degree max) :
-    LicensingPipeline.isLicensed tall.scaleType = (adjMeasure μ tall).licensed ∧
-    LicensingPipeline.isLicensed full.scaleType = (adjMeasure μ full).licensed ∧
-    LicensingPipeline.isLicensed wet.scaleType = (adjMeasure μ wet).licensed ∧
-    LicensingPipeline.isLicensed dry.scaleType = (adjMeasure μ dry).licensed := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;>
-    simp [LicensingPipeline.isLicensed, LicensingPipeline.toBoundedness,
-          adjMeasure, DirectedMeasure.adjective, DirectedMeasure.licensed,
-          tall, full, wet, dry, Boundedness.isLicensed]
+    (LicensingPipeline.IsLicensed tall.scaleType ↔ (adjMeasure μ tall).IsLicensed) ∧
+    (LicensingPipeline.IsLicensed full.scaleType ↔ (adjMeasure μ full).IsLicensed) ∧
+    (LicensingPipeline.IsLicensed wet.scaleType ↔ (adjMeasure μ wet).IsLicensed) ∧
+    (LicensingPipeline.IsLicensed dry.scaleType ↔ (adjMeasure μ dry).IsLicensed) :=
+  ⟨Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 4. Scale Structure → Comparison Class Sensitivity
@@ -559,16 +565,16 @@ theorem dry_no_cc_convergence :
     *wet*. Their resistance to *very*/*extremely* is pragmatic (conflicts
     with middling inference), not structural. -/
 theorem mpa_licensed :
-    LicensingPipeline.isLicensed decent.scaleType = true ∧
-    LicensingPipeline.isLicensed acceptable.scaleType = true ∧
-    LicensingPipeline.isLicensed adequate.scaleType = true := ⟨rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed decent.scaleType ∧
+    LicensingPipeline.IsLicensed acceptable.scaleType ∧
+    LicensingPipeline.IsLicensed adequate.scaleType := ⟨trivial, trivial, trivial⟩
 
 /-- MPAs and *good* have the same scale-structure licensing status
     (both lower-bounded → licensed). Their difference is in standard
     type (functional vs contextual), not in structural licensing. -/
 theorem mpa_good_same_licensing :
-    LicensingPipeline.isLicensed decent.scaleType =
-    LicensingPipeline.isLicensed good.scaleType := rfl
+    LicensingPipeline.IsLicensed decent.scaleType ↔
+    LicensingPipeline.IsLicensed good.scaleType := Iff.rfl
 
 /-- IE path diverges for MPAs: lower-bounded → minEndpoint, but MPAs
     actually receive a functional standard. This is a genuine exception
@@ -591,9 +597,9 @@ theorem mpa_ie_exception :
     `licenses .diminisher` and `naturalWithCompletely` from
     `licenses .proportional`. Provable by `decide` over the 5×2 grid. -/
 theorem k2007_matrix_agrees_with_typology :
-    adjectiveTypologyExamples.all (fun d =>
-      licenses .diminisher d.scaleType == d.naturalWithSlightly &&
-      licenses .proportional d.scaleType == d.naturalWithCompletely) = true := by
+    ∀ d ∈ adjectiveTypologyExamples,
+      (Licenses .diminisher d.scaleType ↔ d.naturalWithSlightly = true) ∧
+      (Licenses .proportional d.scaleType ↔ d.naturalWithCompletely = true) := by
   decide
 
 /-- Per-modifier consistency: each `DegreeModifierDatum`'s
@@ -605,10 +611,10 @@ theorem k2007_matrix_agrees_with_typology :
     — only `.closed` and `.lowerBounded` satisfy that, of which `.closed`
     is the natural reading for the *full*-class data. -/
 theorem k2007_modifier_data_agrees :
-    degreeModifierExamples.all (fun d =>
-      licenses d.modifierType .closed == d.worksWithAGAMax &&
-      licenses d.modifierType .lowerBounded == d.worksWithAGAMin &&
-      licenses d.modifierType .open_ == d.worksWithRGA) = true := by
+    ∀ d ∈ degreeModifierExamples,
+      (Licenses d.modifierType .closed ↔ d.worksWithAGAMax = true) ∧
+      (Licenses d.modifierType .lowerBounded ↔ d.worksWithAGAMin = true) ∧
+      (Licenses d.modifierType .open_ ↔ d.worksWithRGA = true) := by
   decide
 
 /-- The audit's `closurePuzzle` (full vs tall, completely modifier) is a
@@ -616,8 +622,8 @@ theorem k2007_modifier_data_agrees :
     matches `worksWithClosed`, and `licenses .proportional .open_ = false`
     matches `worksWithOpen`. -/
 theorem closurePuzzle_via_matrix :
-    licenses .proportional .closed = closurePuzzle.worksWithClosed ∧
-    licenses .proportional .open_ = closurePuzzle.worksWithOpen :=
-  ⟨rfl, rfl⟩
+    (Licenses .proportional .closed ↔ closurePuzzle.worksWithClosed = true) ∧
+    (Licenses .proportional .open_ ↔ closurePuzzle.worksWithOpen = true) := by
+  decide
 
 end Kennedy2007Licensing.Bridge

--- a/Linglib/Studies/Kennedy2007Typology.lean
+++ b/Linglib/Studies/Kennedy2007Typology.lean
@@ -78,23 +78,23 @@ theorem bent_scaleType_consistency :
 
 /-- "tall" (open scale): pipeline blocked = "completely" doesn't work with RGA. -/
 theorem tall_completely_agrees :
-    LicensingPipeline.isLicensed tall.scaleType =
-    completelyModifier.worksWithRGA := rfl
+    LicensingPipeline.IsLicensed tall.scaleType ↔
+    completelyModifier.worksWithRGA = true := by decide
 
 /-- "full" (closed scale): pipeline licensed = "completely" works with AGA-max. -/
 theorem full_completely_agrees :
-    LicensingPipeline.isLicensed full.scaleType =
-    completelyModifier.worksWithAGAMax := rfl
+    LicensingPipeline.IsLicensed full.scaleType ↔
+    completelyModifier.worksWithAGAMax = true := by decide
 
 /-- "tall": typology's naturalWithCompletely matches pipeline prediction. -/
 theorem tall_completely_from_pipeline :
-    tallTypology.naturalWithCompletely =
-    LicensingPipeline.isLicensed tall.scaleType := rfl
+    tallTypology.naturalWithCompletely = true ↔
+    LicensingPipeline.IsLicensed tall.scaleType := by decide
 
 /-- "full": typology's naturalWithCompletely matches pipeline prediction. -/
 theorem full_completely_from_pipeline :
-    fullTypology.naturalWithCompletely =
-    LicensingPipeline.isLicensed full.scaleType := rfl
+    fullTypology.naturalWithCompletely = true ↔
+    LicensingPipeline.IsLicensed full.scaleType := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 4. Threshold Shift ↔ Open Scale

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -760,17 +760,17 @@ theorem sleep_vendlerClass_state :
 /-- Bounded path → telic → licensed. K98 §4 eq. 74 *walked from X to Y*. -/
 theorem bounded_pipeline :
     pathShapeToTelicity .bounded = .telic ∧
-    LicensingPipeline.isLicensed PathShape.bounded = true := ⟨rfl, rfl⟩
+    LicensingPipeline.IsLicensed PathShape.bounded := ⟨rfl, trivial⟩
 
 /-- Source path → telic → licensed. K98 §4 eq. 73 *Mary left the house*. -/
 theorem source_pipeline :
     pathShapeToTelicity .source = .telic ∧
-    LicensingPipeline.isLicensed PathShape.source = true := ⟨rfl, rfl⟩
+    LicensingPipeline.IsLicensed PathShape.source := ⟨rfl, trivial⟩
 
 /-- Unbounded path → atelic → blocked. K98 §4 eq. 75 *walked towards X*. -/
 theorem unbounded_pipeline :
     pathShapeToTelicity .unbounded = .atelic ∧
-    LicensingPipeline.isLicensed PathShape.unbounded = false := ⟨rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed PathShape.unbounded := ⟨rfl, id⟩
 
 /-! ### Motion VP data (K98 §4.5 eq. 74-75) -/
 

--- a/Linglib/Studies/Rett2026.lean
+++ b/Linglib/Studies/Rett2026.lean
@@ -449,41 +449,41 @@ adjective fragment. -/
     minimum-standard absolutes (wet, dirty) and maximum-standard absolutes
     (dry, clean), which still license EN because only one endpoint is
     available for MAX to target. -/
-def licensesComparativeEN (b : Boundedness) : Bool :=
-  !(b.hasMax && b.hasMin)
+def LicensesComparativeEN (b : Boundedness) : Prop :=
+  ¬ (b.HasMax ∧ b.HasMin)
+
+instance (b : Boundedness) : Decidable (LicensesComparativeEN b) :=
+  inferInstanceAs (Decidable ¬ (b.HasMax ∧ b.HasMin))
 
 /-- "tall" (open scale) licenses EN in comparatives. -/
 theorem tall_licenses_EN :
-    licensesComparativeEN English.Modifiers.Adjectives.tall.scaleType = true := rfl
+    LicensesComparativeEN English.Modifiers.Adjectives.tall.scaleType := by decide
 
 /-- "full" (closed scale) does NOT license EN in comparatives. -/
 theorem full_blocks_EN :
-    licensesComparativeEN English.Modifiers.Adjectives.full.scaleType = false := rfl
+    ¬ LicensesComparativeEN English.Modifiers.Adjectives.full.scaleType := by decide
 
 /-- "expensive" (open scale) licenses EN in comparatives. -/
 theorem expensive_licenses_EN :
-    licensesComparativeEN English.Modifiers.Adjectives.expensive.scaleType = true := rfl
+    LicensesComparativeEN English.Modifiers.Adjectives.expensive.scaleType := by decide
 
 /-- "dead" (closed scale) does NOT license EN in comparatives. -/
 theorem dead_blocks_EN :
-    licensesComparativeEN English.Modifiers.Adjectives.dead.scaleType = false := rfl
+    ¬ LicensesComparativeEN English.Modifiers.Adjectives.dead.scaleType := by decide
 
-/-- `licensesComparativeEN` is the De Morgan dual of "both endpoints
-    exist" — EN is licensed iff some endpoint is open. This is now
-    `rfl` because the def itself is the structural form; the theorem
-    is retained as a named statement of the prediction's content. -/
+/-- `LicensesComparativeEN` is the De Morgan dual of "both endpoints
+    exist" — EN is licensed iff some endpoint is open. -/
 theorem licensesComparativeEN_iff_some_endpoint_open (b : Boundedness) :
-    licensesComparativeEN b = !b.hasMax || !b.hasMin := by
-  cases b <;> rfl
+    LicensesComparativeEN b ↔ (¬ b.HasMax ∨ ¬ b.HasMin) :=
+  not_and_or
 
 /-- The closed-scale exclusion: a fully closed scale never licenses
     comparative EN. Dual of `licensesComparativeEN_iff_some_endpoint_open`,
     stated in the form [kennedy-mcnally-2005] would recognize
     (absolute adjectives = closed scales = no EN). -/
 theorem closed_blocks_comparativeEN (b : Boundedness)
-    (h : (b.hasMax && b.hasMin) = true) : licensesComparativeEN b = false := by
-  unfold licensesComparativeEN
-  rw [h]; rfl
+    (h : b.HasMax ∧ b.HasMin) : ¬ LicensesComparativeEN b :=
+  not_not_intro h
 
 -- ════════════════════════════════════════════════════
 -- § 5. Manner Implicature Data

--- a/Linglib/Studies/Rouillard2026.lean
+++ b/Linglib/Studies/Rouillard2026.lean
@@ -60,10 +60,10 @@ def BoundaryType.toBoundedness : BoundaryType → Core.Order.Boundedness
   | .open_ => .open_
 
 theorem closedBoundary_licensed :
-    (BoundaryType.toBoundedness .closed).isLicensed = true := rfl
+    (BoundaryType.toBoundedness .closed).IsLicensed := trivial
 
 theorem openBoundary_blocked :
-    (BoundaryType.toBoundedness .open_).isLicensed = false := rfl
+    ¬ (BoundaryType.toBoundedness .open_).IsLicensed := id
 
 instance : Core.Order.LicensingPipeline BoundaryType where
   toBoundedness := BoundaryType.toBoundedness
@@ -440,16 +440,16 @@ consumed by the empirical predictions below. Codebase plumbing
 /-- Telic VPs route through `LicensingPipeline` to the licensed (closed)
     boundedness tag. -/
 theorem telic_predicts_licensing (c : VendlerClass) (h : c.telicity = .telic) :
-    (LicensingPipeline.toBoundedness c).isLicensed = true := by
-  show (c.telicity.toMereoTag.toBoundedness).isLicensed = true
-  rw [h]; rfl
+    (LicensingPipeline.toBoundedness c).IsLicensed := by
+  show (c.telicity.toMereoTag.toBoundedness).IsLicensed
+  rw [h]; trivial
 
 /-- Atelic VPs route through `LicensingPipeline` to the unlicensed (open)
     boundedness tag. -/
 theorem atelic_predicts_blocking (c : VendlerClass) (h : c.telicity = .atelic) :
-    (LicensingPipeline.toBoundedness c).isLicensed = false := by
-  show (c.telicity.toMereoTag.toBoundedness).isLicensed = false
-  rw [h]; rfl
+    ¬ (LicensingPipeline.toBoundedness c).IsLicensed := by
+  show ¬ (c.telicity.toMereoTag.toBoundedness).IsLicensed
+  rw [h]; exact id
 
 /-! ### Cross-source licensing sentry
 
@@ -463,26 +463,26 @@ caught here; pairwise agreement between any two sources is
 /-- Every registered `LicensingPipeline` source maps its "closed" variant to
     licensed. -/
 theorem sources_agree_closed :
-    LicensingPipeline.isLicensed Boundedness.closed = true ∧
-    LicensingPipeline.isLicensed MereoTag.qua = true ∧
-    LicensingPipeline.isLicensed Telicity.telic = true ∧
-    LicensingPipeline.isLicensed VendlerClass.accomplishment = true ∧
-    LicensingPipeline.isLicensed NonemptyInterval.BoundaryType.closed = true ∧
-    LicensingPipeline.isLicensed SituationBoundedness.bounded = true ∧
-    LicensingPipeline.isLicensed EpistemicTag.finitelyAdditive = true :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Boundedness.closed ∧
+    LicensingPipeline.IsLicensed MereoTag.qua ∧
+    LicensingPipeline.IsLicensed Telicity.telic ∧
+    LicensingPipeline.IsLicensed VendlerClass.accomplishment ∧
+    LicensingPipeline.IsLicensed NonemptyInterval.BoundaryType.closed ∧
+    LicensingPipeline.IsLicensed SituationBoundedness.bounded ∧
+    LicensingPipeline.IsLicensed EpistemicTag.finitelyAdditive :=
+  ⟨trivial, trivial, trivial, trivial, trivial, trivial, trivial⟩
 
 /-- Every registered `LicensingPipeline` source maps its "open" variant to
     blocked. -/
 theorem sources_agree_open :
-    LicensingPipeline.isLicensed Boundedness.open_ = false ∧
-    LicensingPipeline.isLicensed MereoTag.cum = false ∧
-    LicensingPipeline.isLicensed Telicity.atelic = false ∧
-    LicensingPipeline.isLicensed VendlerClass.state = false ∧
-    LicensingPipeline.isLicensed NonemptyInterval.BoundaryType.open_ = false ∧
-    LicensingPipeline.isLicensed SituationBoundedness.unbounded = false ∧
-    LicensingPipeline.isLicensed EpistemicTag.qualitative = false :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+    ¬ LicensingPipeline.IsLicensed Boundedness.open_ ∧
+    ¬ LicensingPipeline.IsLicensed MereoTag.cum ∧
+    ¬ LicensingPipeline.IsLicensed Telicity.atelic ∧
+    ¬ LicensingPipeline.IsLicensed VendlerClass.state ∧
+    ¬ LicensingPipeline.IsLicensed NonemptyInterval.BoundaryType.open_ ∧
+    ¬ LicensingPipeline.IsLicensed SituationBoundedness.unbounded ∧
+    ¬ LicensingPipeline.IsLicensed EpistemicTag.qualitative :=
+  ⟨id, id, id, id, id, id, id⟩
 
 /-! ### Rouillard's analytical apparatus -/
 
@@ -556,7 +556,7 @@ def eTIAData : List ETIADatum :=
     the datum is acceptable. The pipeline routes through the
     Telicity → MereoTag → Boundedness chain (§ 11). -/
 def eTIA_predicted (d : ETIADatum) : Prop :=
-  (LicensingPipeline.toBoundedness d.vendlerClass).isLicensed = true ↔ d.acceptable
+  (LicensingPipeline.toBoundedness d.vendlerClass).IsLicensed ↔ d.acceptable
 
 instance (d : ETIADatum) : Decidable (eTIA_predicted d) := by
   unfold eTIA_predicted; infer_instance

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -450,7 +450,7 @@ theorem all_disturbance_compatible_with_much :
 /-! Verify that the Fragment adjective entries classify disturbance
     adjectives with the correct `Boundedness` value. These are
     consumption sites for the substrate, not bridges — `closedAdj_licensed`
-    and `LicensingPipeline.isLicensed` are foundational and are called
+    and `LicensingPipeline.IsLicensed` are foundational and are called
     inline. -/
 
 theorem cracked_is_closed : Adjectival.cracked.scaleType = .closed := rfl
@@ -488,10 +488,10 @@ theorem scratch_adj_verb_scale_agree :
 /-- Disturbance adjectives are licensed for degree modification by the
     Kennedy pipeline, just like *full* and *clean*. -/
 theorem cracked_licensed {max : Nat} {W : Type*} (μ : W → Semantics.Degree.Degree max) :
-    (adjMeasure μ Adjectival.cracked).licensed = true :=
+    (adjMeasure μ Adjectival.cracked).IsLicensed :=
   closedAdj_licensed μ Adjectival.cracked rfl
 theorem cracked_pipeline_licensed :
-    LicensingPipeline.isLicensed Adjectival.cracked.scaleType = true := rfl
+    LicensingPipeline.IsLicensed Adjectival.cracked.scaleType := trivial
 
 /-! Interpretive Economy predicts a max-endpoint standard for
     disturbance adjectives (closed → maxEndpoint). This interacts
@@ -625,18 +625,18 @@ theorem crack_refutes_strict_hkl_matrix :
     modification. -/
 theorem cracked_licensing_converges_with_kennedy2007
     {max : Nat} {W : Type*} (μ : W → Semantics.Degree.Degree max) :
-    (adjMeasure μ Adjectival.cracked).licensed =
-    (adjMeasure μ Adjectival.full).licensed := by
-  rw [closedAdj_licensed μ Adjectival.cracked rfl,
-      closedAdj_licensed μ Adjectival.full rfl]
+    (adjMeasure μ Adjectival.cracked).IsLicensed ↔
+    (adjMeasure μ Adjectival.full).IsLicensed :=
+  iff_of_true (closedAdj_licensed μ Adjectival.cracked rfl)
+    (closedAdj_licensed μ Adjectival.full rfl)
 
 /-- All three disturbance adjectives converge with Kennedy 2007 at
     `Boundedness`. -/
 theorem all_disturbance_pipeline_licensed :
-    LicensingPipeline.isLicensed Adjectival.cracked.scaleType = true ∧
-    LicensingPipeline.isLicensed Adjectival.dented.scaleType = true ∧
-    LicensingPipeline.isLicensed Adjectival.scratched.scaleType = true :=
-  ⟨rfl, rfl, rfl⟩
+    LicensingPipeline.IsLicensed Adjectival.cracked.scaleType ∧
+    LicensingPipeline.IsLicensed Adjectival.dented.scaleType ∧
+    LicensingPipeline.IsLicensed Adjectival.scratched.scaleType :=
+  ⟨trivial, trivial, trivial⟩
 
 -- ════════════════════════════════════════════════════
 -- § 12. Cross-paper engagement: Sassoon 2013 binding insufficiency

--- a/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
@@ -418,7 +418,7 @@ The aspectual chain: `hasMax → bounded RP → telic resultative`. -/
 RP boundedness. Scales with a maximum endpoint yield bounded RPs (the RP denotes
 a delimited endstate). Scales without a maximum yield unbounded RPs. -/
 def adjScaleToRPBoundedness (b : Core.Order.Boundedness) : Boundedness :=
-  if b.hasMax then .bounded else .unbounded
+  if b.HasMax then .bounded else .unbounded
 
 /-- Closed scales yield bounded RPs. -/
 theorem closed_scale_bounded :
@@ -438,10 +438,10 @@ theorem lower_bounded_scale_unbounded :
 
 /-- The full aspectual chain: a closed-scale adjective as RP yields a telic
     resultative. `hasMax → bounded → telic → accomplishment`. -/
-theorem closed_scale_telic_resultative (b : Core.Order.Boundedness) (hMax : b.hasMax = true) :
+theorem closed_scale_telic_resultative (b : Core.Order.Boundedness) (hMax : b.HasMax) :
     resultativeVendlerClass (adjScaleToRPBoundedness b) = .accomplishment := by
-  cases b <;> simp [Core.Order.Boundedness.hasMax] at hMax <;>
-    simp [adjScaleToRPBoundedness, Core.Order.Boundedness.hasMax,
+  cases b <;> simp [Core.Order.Boundedness.HasMax] at hMax <;>
+    simp [adjScaleToRPBoundedness, Core.Order.Boundedness.HasMax,
       resultativeVendlerClass, resultativeAspect, AspectualProfile.toVendlerClass]
 
 /-- The dry/wet contrast: dry is productive (bounded → telic),
@@ -750,7 +750,7 @@ subconstruction satisfying the hypotheses, not just the attested entries. -/
 
 /-- **Aspect chain**: any adjective with a scale maximum, used as an RP
     in a resultative, produces a telic accomplishment. -/
-theorem aspect_chain (b : Core.Order.Boundedness) (hMax : b.hasMax = true) :
+theorem aspect_chain (b : Core.Order.Boundedness) (hMax : b.HasMax) :
     let rpB := adjScaleToRPBoundedness b
     rpB = .bounded ∧
     resultativeVendlerClass rpB = .accomplishment ∧


### PR DESCRIPTION
Bool→Prop for the Boundedness licensing family: `Boundedness.IsLicensed`/`HasMax`/`HasMin`, `LicensingPipeline.IsLicensed`, `DirectedMeasure.IsLicensed`, all with `DecidablePred`/`Decidable` instances; the Bool versions are deleted, no shims.

- `= true`/`= false` equation theorems become bare/negated Props; agreement equations become Iffs (`LicensingPipeline.universal` is now an Iff); Bool algebra becomes ∧/∨/¬ (Rett2026 De Morgan family now proved by `not_and_or`/`not_not_intro`).
- `AspectualConsistency.pipelineOK` → `PipelineOK : Prop`; its fragment-wide check drops `native_decide` for kernel `decide`.
- Same-named symbols in other domains (case, ellipsis, extraction, NPI licensing) are distinct defs and untouched.