### PR TITLE
feat(Core/Order): add IsIntervalContent substrate

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -330,6 +330,7 @@ import Linglib.Core.Order.ComparativeProbability.CancellationFin4
 import Linglib.Core.Order.ComparativeProbability.Completeness
 import Linglib.Core.Order.ComparativeProbability.Representability
 import Linglib.Core.Order.Mereology
+import Linglib.Core.Order.IntervalContent
 import Linglib.Semantics.Attitudes.ContentIndividual
 import Linglib.Core.Agent.BToM
 import Linglib.Core.Agent.Emotion

--- a/Linglib/Core/Order/IntervalContent.lean
+++ b/Linglib/Core/Order/IntervalContent.lean
@@ -1,0 +1,132 @@
+import Mathlib.Order.Interval.Basic
+import Mathlib.Order.Bounds.Basic
+import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
+import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Ring.Rat
+import Mathlib.Tactic.Abel
+
+/-!
+# Interval contents on ordered types
+[krifka-1989] [krifka-1998] [rouillard-2026]
+
+A finitely additive, strictly positive content on the nonempty closed
+intervals of a preorder, valued in an ordered additive monoid. The
+order-theoretic sibling of `ExtMeasure` (`Core/Order/Mereology.lean`,
+[krifka-1998]'s extensive measure functions over a `SemilatticeSup`):
+disjoint intervals have no interval join, so the two substrates coexist
+rather than one subsuming the other.
+
+## Main declarations
+
+- `IsIntervalContent`: additivity over interval concatenation plus strict
+  positivity on nondegenerate intervals.
+- `IsIntervalContent.ofStrictMono`: Stieltjes-style constructor — a
+  strictly monotone potential `F` into an ordered group induces the
+  content `fun i => F i.snd - F i.fst`.
+- `IsIntervalContent.measure_lt_of_left_lt`: moving the left endpoint
+  strictly right strictly decreases measure.
+- `IsIntervalContent.not_isLeast_rightAnchored`: over a dense order, the
+  measures of right-anchored covers `[l, s]` with `l` strictly below a
+  point have no least element — the domain-general form of
+  [rouillard-2026]'s G-TIA information collapse.
+-/
+
+namespace Core.Order
+
+variable {α M : Type*}
+
+/-- A finitely additive, strictly positive content on the nonempty closed
+    intervals of a preorder: the order-interval counterpart of
+    [krifka-1998]'s extensive measure functions (`ExtMeasure`). -/
+class IsIntervalContent [Preorder α] [AddCommMonoid M] [PartialOrder M]
+    (μ : NonemptyInterval α → M) : Prop where
+  /-- Additivity over interval concatenation. -/
+  additive : ∀ (a b c : α) (hab : a ≤ b) (hbc : b ≤ c),
+    μ ⟨⟨a, c⟩, hab.trans hbc⟩ = μ ⟨⟨a, b⟩, hab⟩ + μ ⟨⟨b, c⟩, hbc⟩
+  /-- Strict positivity on nondegenerate intervals. -/
+  positive : ∀ (a b : α) (h : a < b), 0 < μ ⟨⟨a, b⟩, h.le⟩
+
+/-- A strictly antitone image of a set with no greatest element has no
+    least element. -/
+theorem _root_.StrictAntiOn.not_isLeast_image {β γ : Type*} [Preorder β]
+    [Preorder γ] {f : β → γ} {t : Set β} (hf : StrictAntiOn f t)
+    (ht : ∀ x ∈ t, ∃ y ∈ t, x < y) (x : γ) :
+    ¬ IsLeast (f '' t) x := by
+  rintro ⟨⟨l, hl, rfl⟩, hLB⟩
+  obtain ⟨l', hl', hll'⟩ := ht l hl
+  exact (lt_iff_le_not_ge.mp (hf hl hl' hll')).2 (hLB ⟨l', hl', rfl⟩)
+
+namespace IsIntervalContent
+
+section Preorder
+
+variable [Preorder α] [AddCommMonoid M] [PartialOrder M]
+  (μ : NonemptyInterval α → M) [IsIntervalContent μ]
+
+/-- Degenerate intervals have measure zero, given cancellation. -/
+theorem degenerate_eq_zero [IsCancelAdd M] (a : α) :
+    μ ⟨⟨a, a⟩, le_refl a⟩ = 0 := by
+  have h := additive (μ := μ) a a a (le_refl a) (le_refl a)
+  exact add_left_cancel (a := μ ⟨⟨a, a⟩, le_refl a⟩) (by rw [add_zero, ← h])
+
+/-- Moving the left endpoint strictly right strictly decreases measure. -/
+theorem measure_lt_of_left_lt [AddRightStrictMono M]
+    {a b s : α} (hab : a < b) (hbs : b ≤ s) :
+    μ ⟨⟨b, s⟩, hbs⟩ < μ ⟨⟨a, s⟩, hab.le.trans hbs⟩ := by
+  rw [additive (μ := μ) a b s hab.le hbs]
+  exact lt_add_of_pos_left _ (positive (μ := μ) a b hab)
+
+/-- Moving the right endpoint strictly right strictly increases measure. -/
+theorem measure_lt_of_lt_right [AddLeftStrictMono M]
+    {a b s : α} (hab : a ≤ b) (hbs : b < s) :
+    μ ⟨⟨a, b⟩, hab⟩ < μ ⟨⟨a, s⟩, hab.trans hbs.le⟩ := by
+  rw [additive (μ := μ) a b s hab hbs.le]
+  exact lt_add_of_pos_right _ (positive (μ := μ) b s hbs)
+
+end Preorder
+
+section Dense
+
+variable [LinearOrder α] [DenselyOrdered α] [AddCommMonoid M]
+  [PartialOrder M] [AddRightStrictMono M]
+  (μ : NonemptyInterval α → M) [IsIntervalContent μ]
+
+/-- **No minimal right-anchored cover**: over a dense order, the measures
+    of intervals `[l, s]` with left endpoint strictly below `a` have no
+    least element — the domain-general form of [rouillard-2026]'s G-TIA
+    information collapse ("there cannot be a smallest open interval to
+    include a closed time"). -/
+theorem not_isLeast_rightAnchored {a s : α} (has : a ≤ s) (x : M) :
+    ¬ IsLeast (Set.range fun l : Set.Iio a =>
+      μ ⟨⟨l.1, s⟩, (l.2.trans_le has).le⟩) x := by
+  rw [← Set.image_univ]
+  refine StrictAntiOn.not_isLeast_image ?_ (fun p _ => ?_) x
+  · intro p _ q _ hpq
+    exact measure_lt_of_left_lt μ hpq (q.2.trans_le has).le
+  · obtain ⟨m, hm₁, hm₂⟩ := exists_between p.2
+    exact ⟨⟨m, hm₂⟩, Set.mem_univ _, hm₁⟩
+
+end Dense
+
+section OfStrictMono
+
+variable [Preorder α] {G : Type*} [AddCommGroup G] [PartialOrder G]
+  [IsOrderedAddMonoid G]
+
+/-- Stieltjes-style constructor: a strictly monotone potential into an
+    ordered group induces an interval content. Additivity is telescoping;
+    positivity is the strict monotonicity. -/
+theorem ofStrictMono (F : α → G) (hF : StrictMono F) :
+    IsIntervalContent (fun i : NonemptyInterval α => F i.snd - F i.fst) where
+  additive a b c _ _ := by dsimp only; abel
+  positive a b h := sub_pos.mpr (hF h)
+
+/-- Interval length on `ℚ` is a content (non-vacuity witness). -/
+example : IsIntervalContent (fun i : NonemptyInterval ℚ => i.snd - i.fst) :=
+  ofStrictMono _ strictMono_id
+
+end OfStrictMono
+
+end IsIntervalContent
+
+end Core.Order

--- a/Linglib/Core/Order/IntervalContent.lean
+++ b/Linglib/Core/Order/IntervalContent.lean
@@ -1,7 +1,8 @@
 import Mathlib.Order.Interval.Basic
-import Mathlib.Order.Bounds.Basic
+import Mathlib.Order.Bounds.Image
 import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Interval.Basic
 import Mathlib.Algebra.Order.Ring.Rat
 import Mathlib.Tactic.Abel
 
@@ -15,6 +16,11 @@ order-theoretic sibling of `ExtMeasure` (`Core/Order/Mereology.lean`,
 [krifka-1998]'s extensive measure functions over a `SemilatticeSup`):
 disjoint intervals have no interval join, so the two substrates coexist
 rather than one subsuming the other.
+
+Mathlib's `NonemptyInterval.length` is the canonical group-valued example
+(`ofStrictMono` at `F = id`); its `length_add` is additivity over
+*Minkowski* interval addition, orthogonal to the *concatenation*
+additivity axiomatized here, which mathlib does not state.
 
 ## Main declarations
 
@@ -45,16 +51,6 @@ class IsIntervalContent [Preorder α] [AddCommMonoid M] [PartialOrder M]
     μ ⟨⟨a, c⟩, hab.trans hbc⟩ = μ ⟨⟨a, b⟩, hab⟩ + μ ⟨⟨b, c⟩, hbc⟩
   /-- Strict positivity on nondegenerate intervals. -/
   positive : ∀ (a b : α) (h : a < b), 0 < μ ⟨⟨a, b⟩, h.le⟩
-
-/-- A strictly antitone image of a set with no greatest element has no
-    least element. -/
-theorem _root_.StrictAntiOn.not_isLeast_image {β γ : Type*} [Preorder β]
-    [Preorder γ] {f : β → γ} {t : Set β} (hf : StrictAntiOn f t)
-    (ht : ∀ x ∈ t, ∃ y ∈ t, x < y) (x : γ) :
-    ¬ IsLeast (f '' t) x := by
-  rintro ⟨⟨l, hl, rfl⟩, hLB⟩
-  obtain ⟨l', hl', hll'⟩ := ht l hl
-  exact (lt_iff_le_not_ge.mp (hf hl hl' hll')).2 (hLB ⟨l', hl', rfl⟩)
 
 namespace IsIntervalContent
 
@@ -95,16 +91,21 @@ variable [LinearOrder α] [DenselyOrdered α] [AddCommMonoid M]
     of intervals `[l, s]` with left endpoint strictly below `a` have no
     least element — the domain-general form of [rouillard-2026]'s G-TIA
     information collapse ("there cannot be a smallest open interval to
-    include a closed time"). -/
+    include a closed time"). Decomposes through `StrictAnti.map_isLeast`:
+    a least measure would be a greatest left endpoint, which density
+    forbids. -/
 theorem not_isLeast_rightAnchored {a s : α} (has : a ≤ s) (x : M) :
     ¬ IsLeast (Set.range fun l : Set.Iio a =>
       μ ⟨⟨l.1, s⟩, (l.2.trans_le has).le⟩) x := by
-  rw [← Set.image_univ]
-  refine StrictAntiOn.not_isLeast_image ?_ (fun p _ => ?_) x
-  · intro p _ q _ hpq
-    exact measure_lt_of_left_lt μ hpq (q.2.trans_le has).le
-  · obtain ⟨m, hm₁, hm₂⟩ := exists_between p.2
-    exact ⟨⟨m, hm₂⟩, Set.mem_univ _, hm₁⟩
+  intro h
+  obtain ⟨l, rfl⟩ := h.1
+  have hanti : StrictAnti fun l : Set.Iio a =>
+      μ ⟨⟨l.1, s⟩, (l.2.trans_le has).le⟩ :=
+    fun p q hpq => measure_lt_of_left_lt μ hpq (q.2.trans_le has).le
+  rw [← Set.image_univ] at h
+  have hg : IsGreatest Set.univ l := hanti.map_isLeast.mp h
+  obtain ⟨m, hm₁, hm₂⟩ := exists_between l.2
+  exact absurd (hg.2 (Set.mem_univ (⟨m, hm₂⟩ : Set.Iio a))) (not_le.mpr hm₁)
 
 end Dense
 
@@ -115,14 +116,15 @@ variable [Preorder α] {G : Type*} [AddCommGroup G] [PartialOrder G]
 
 /-- Stieltjes-style constructor: a strictly monotone potential into an
     ordered group induces an interval content. Additivity is telescoping;
-    positivity is the strict monotonicity. -/
+    positivity is the strict monotonicity. At `F = id` this recovers
+    `NonemptyInterval.length`. -/
 theorem ofStrictMono (F : α → G) (hF : StrictMono F) :
     IsIntervalContent (fun i : NonemptyInterval α => F i.snd - F i.fst) where
   additive a b c _ _ := by dsimp only; abel
   positive a b h := sub_pos.mpr (hF h)
 
-/-- Interval length on `ℚ` is a content (non-vacuity witness). -/
-example : IsIntervalContent (fun i : NonemptyInterval ℚ => i.snd - i.fst) :=
+/-- `NonemptyInterval.length` on `ℚ` is a content (non-vacuity witness). -/
+example : IsIntervalContent (NonemptyInterval.length (α := ℚ)) :=
   ofStrictMono _ strictMono_id
 
 end OfStrictMono

--- a/Linglib/Core/Order/Mereology.lean
+++ b/Linglib/Core/Order/Mereology.lean
@@ -290,7 +290,9 @@ theorem Overlap.symm {γ : Type*} [PartialOrder γ] {x y : γ}
 
 /-- Extensive measure function: additive over non-overlapping entities.
     [krifka-1998] §2.2, eq. (7): μ(x ⊕ y) = μ(x) + μ(y) when ¬O(x,y).
-    Examples: weight, volume, number (cardinality). -/
+    Examples: weight, volume, number (cardinality). Order-interval sibling:
+    `IsIntervalContent` (`Core/Order/IntervalContent.lean`) — disjoint
+    intervals have no interval join, so the two substrates coexist. -/
 class ExtMeasure (α : Type*) [SemilatticeSup α]
     (μ : α → ℚ) : Prop where
   /-- Additivity: μ is additive over non-overlapping entities. -/

--- a/Linglib/Studies/Rouillard2026.lean
+++ b/Linglib/Studies/Rouillard2026.lean
@@ -3,6 +3,7 @@ import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Ring
 import Linglib.Core.Order.Boundedness
+import Linglib.Core.Order.IntervalContent
 import Linglib.Semantics.Degree.Predicate
 import Linglib.Core.Order.Interval
 import Linglib.Semantics.Entailment.Extremum
@@ -93,18 +94,15 @@ variable {α : Type*} [AddCommMonoid α] [LinearOrder α]
 
 /-! ### Time measure -/
 
-/-- A temporal measure: assigns durations in an ordered additive monoid `α`
-    to intervals. [rouillard-2026] §2.2.2: temporal measure units (days,
-    hours) are additive (eq. 6) and positive (eq. 7); richness of `Time`
-    additionally lets any interval be padded or trimmed to any target
-    measure within a one-sided bound, with left-padding available at a
-    fixed right endpoint (PTSs are right-anchored at speech time).
-    Instantiate `α := ℕ` for the discrete integer-numeral reading or
-    `α := ℚ≥0` over dense time for the reading that drives the G-TIA
-    collapse (`ratLength` below). -/
+/-- A temporal measure: an `IsIntervalContent` (additivity, [rouillard-2026]
+    eq. 6; positivity, eq. 7) together with two saturation axioms — richness
+    of `Time` lets any interval be trimmed or right-anchored-extended to any
+    target measure (PTSs are anchored at speech time). Instantiate `α := ℕ`
+    for the discrete integer-numeral reading or `α := ℚ≥0` over dense time
+    for the reading that drives the G-TIA collapse (`ratLength` below). -/
 class TimeMeasure (Time : Type*) [LinearOrder Time] {α : Type*}
     [AddCommMonoid α] [LinearOrder α]
-    (μ : NonemptyInterval Time → α) : Prop where
+    (μ : NonemptyInterval Time → α) : Prop extends IsIntervalContent μ where
   /-- Any interval can be subdivided to a subinterval with a given smaller
       measure. -/
   subdivisible : ∀ (i : NonemptyInterval Time) (m : α), m ≤ μ i →
@@ -113,11 +111,6 @@ class TimeMeasure (Time : Type*) [LinearOrder Time] {α : Type*}
       given larger measure keeping its right endpoint fixed. -/
   extensibleLeft : ∀ (i : NonemptyInterval Time) (m : α), μ i ≤ m →
     ∃ j : NonemptyInterval Time, i ≤ j ∧ j.snd = i.snd ∧ μ j = m
-  /-- Additivity over interval concatenation ([rouillard-2026] eq. 6). -/
-  additive : ∀ (a b c : Time) (hab : a ≤ b) (hbc : b ≤ c),
-    μ ⟨⟨a, c⟩, hab.trans hbc⟩ = μ ⟨⟨a, b⟩, hab⟩ + μ ⟨⟨b, c⟩, hbc⟩
-  /-- Positivity on nondegenerate intervals ([rouillard-2026] eq. 7). -/
-  positive : ∀ (a b : Time) (h : a < b), 0 < μ ⟨⟨a, b⟩, h.le⟩
 
 namespace TimeMeasure
 
@@ -128,15 +121,6 @@ theorem extensible {μ : NonemptyInterval Time → α} [TimeMeasure Time μ]
     ∃ j : NonemptyInterval Time, i ≤ j ∧ μ j = m :=
   let ⟨j, hij, _, hjμ⟩ := TimeMeasure.extensibleLeft i m h
   ⟨j, hij, hjμ⟩
-
-/-- Moving the left endpoint strictly right strictly decreases measure:
-    additivity plus positivity. The engine of the G-TIA shrink argument. -/
-theorem measure_lt_of_left_lt [AddRightStrictMono α]
-    (μ : NonemptyInterval Time → α) [TimeMeasure Time μ]
-    {a b s : Time} (hab : a < b) (hbs : b ≤ s) :
-    μ ⟨⟨b, s⟩, hbs⟩ < μ ⟨⟨a, s⟩, hab.le.trans hbs⟩ := by
-  rw [TimeMeasure.additive (μ := μ) a b s hab.le hbs]
-  exact lt_add_of_pos_left _ (TimeMeasure.positive (μ := μ) a b hab)
 
 end TimeMeasure
 
@@ -478,7 +462,7 @@ theorem gTIAOpen_no_isLeast [DenselyOrdered Time] [AddRightStrictMono α]
     NonemptyInterval.ext (Prod.ext rfl hRight')
   have hlt : μ ptsGI'.toInterval < x := by
     rw [← hμ, he]
-    exact TimeMeasure.measure_lt_of_left_lt μ hLeft' (hRight' ▸ ptsGI'.valid)
+    exact IsIntervalContent.measure_lt_of_left_lt μ hLeft' (hRight' ▸ ptsGI'.valid)
   exact absurd (hLB hmem) (not_le.mpr hlt)
 
 /-- **Positive G-TIAs are not MIP-licensed** over dense time: the
@@ -501,6 +485,16 @@ jointly satisfiable at a concrete dense model. -/
 def ratLength (i : NonemptyInterval ℚ) : ℚ≥0 :=
   ⟨i.snd - i.fst, sub_nonneg.mpr i.fst_le_snd⟩
 
+instance : IsIntervalContent ratLength where
+  additive a b c hab hbc := by
+    apply NNRat.ext
+    show c - a = (b - a) + (c - b)
+    ring
+  positive a b h := by
+    rw [← NNRat.coe_pos]
+    show (0 : ℚ) < b - a
+    linarith
+
 instance : TimeMeasure ℚ ratLength where
   subdivisible i m h := by
     have hm : (m : ℚ) ≤ i.snd - i.fst := NNRat.coe_le_coe.mpr h
@@ -520,14 +514,6 @@ instance : TimeMeasure ℚ ratLength where
     · apply NNRat.ext
       show i.snd - (i.snd - (m : ℚ)) = (m : ℚ)
       ring
-  additive a b c hab hbc := by
-    apply NNRat.ext
-    show c - a = (b - a) + (c - b)
-    ring
-  positive a b h := by
-    rw [← NNRat.coe_pos]
-    show (0 : ℚ) < b - a
-    linarith
 
 /-- The blocking theorem's hypotheses discharge at the rational length
     model: positive G-TIAs over `ℚ`-time are not MIP-licensed. -/


### PR DESCRIPTION
Extracts the pure-math half of `TimeMeasure` into `Core/Order/IntervalContent.lean`: a finitely additive, strictly positive content on `NonemptyInterval` — the order-interval sibling of `Mereology.ExtMeasure` ([krifka-1998] extensive measures; disjoint intervals have no join, so the substrates coexist, cross-referenced both ways).

- `IsIntervalContent` {additive, positive} over any preorder/ordered-monoid pair, plus the Stieltjes-style `ofStrictMono` constructor (a strictly monotone potential induces the content; `id` gives interval length on ℚ).
- `measure_lt_of_left_lt` / `measure_lt_of_lt_right`, `degenerate_eq_zero`, and the domain-general `not_isLeast_rightAnchored` (no minimal right-anchored cover over a dense order), decomposed through a general `StrictAntiOn.not_isLeast_image` transfer lemma.
- `Studies/Rouillard2026.lean`: `TimeMeasure` now `extends IsIntervalContent`, keeping only the paper's two saturation axioms; `ratLength` splits into a content instance plus the saturation instance.