### PR TITLE
feat(Features/Case): HasCase mixin; dedup Romance clitic schema

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -305,6 +305,7 @@ import Linglib.Core.Computability.Subregular.Function.WeaklyDeterministic
 import Linglib.Core.Computability.StringHom
 import Linglib.Features.VerbCluster
 import Linglib.Features.Case.Basic
+import Linglib.Features.Case.Capabilities
 import Linglib.Syntax.Case.Order
 import Linglib.Typology.Alignment
 import Linglib.Diachronic.CaseGrammaticalization
@@ -680,6 +681,7 @@ import Linglib.Fragments.English.Indefinites
 import Linglib.Fragments.English.PolarityMarking
 import Linglib.Fragments.Slavic.Belarusian.Case
 import Linglib.Fragments.Slavic.Bulgarian.Evidentials
+import Linglib.Fragments.Romance.Clitics
 import Linglib.Fragments.Slavic.Case
 import Linglib.Fragments.Slavic.Cassubian.Case
 import Linglib.Fragments.Slavic.Params

--- a/Linglib/Features/Case/Capabilities.lean
+++ b/Linglib/Features/Case/Capabilities.lean
@@ -1,0 +1,86 @@
+import Linglib.Core.Order.Flat
+import Linglib.Features.Case.Basic
+
+/-!
+# Case — carrier capabilities
+[blake-1994] [corbett-2006]
+
+The typeclass mixin for carriers that bear grammatical case — the case
+analogue of `HasPerson` (`Features/Person/Capabilities.lean`). `caseOf`
+extracts the carrier's analytical case value; `Compatible` is the
+concord-checking relation. Carriers that store UD realization
+(`UD.MorphFeatures`) lift through `Case.fromUD`.
+-/
+
+set_option autoImplicit false
+
+/-- A carrier of grammatical case. `none` = the carrier does not mark
+    case. -/
+class HasCase (α : Type*) where
+  /-- The analytical case value, if marked. -/
+  caseOf : α → Option Case
+
+export HasCase (caseOf)
+
+instance : HasCase UD.MorphFeatures :=
+  ⟨fun mf => mf.case_.map Case.fromUD⟩
+
+instance : HasCase Case := ⟨some⟩
+
+namespace HasCase
+
+variable {α β : Type*} [HasCase α] [HasCase β]
+
+/-- Two carriers are case-compatible: the slot values are compatible in
+    the flat information order (`Compat`) — if both mark case, the values
+    agree; unmarked carriers are wildcards. The concord-checking
+    relation. -/
+def Compatible (a : α) (b : β) : Prop :=
+  Compat (α := Flat Case) (caseOf a) (caseOf b)
+
+instance (a : α) (b : β) : Decidable (Compatible a b) := by
+  unfold Compatible
+  infer_instance
+
+theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
+    Compatible b a :=
+  h.symm
+
+theorem compatible_of_none {a : α} (h : caseOf a = none) (b : β) :
+    Compatible a b := by
+  unfold Compatible
+  rw [h]
+  exact bot_compat _
+
+end HasCase
+
+/-- φ-compatibility entails case compatibility: the `HasCase` mixin
+    never diverges from the unification-based agreement engine
+    (`UD.MorphFeatures.compatible`) — the case analogue of
+    `UD.MorphFeatures.compatible_hasPerson`. -/
+theorem UD.MorphFeatures.compatible_hasCase {f1 f2 : UD.MorphFeatures}
+    (h : f1.compatible f2 = true) :
+    HasCase.Compatible f1 f2 := by
+  unfold HasCase.Compatible
+  rw [Flat.compat_iff]
+  intro ca ha cb hb
+  have hc : (f1.case_.isNone || f2.case_.isNone || f1.case_ == f2.case_)
+      = true := by
+    unfold UD.MorphFeatures.compatible at h
+    simp only [Bool.and_eq_true] at h
+    tauto
+  simp only [HasCase.caseOf] at ha hb
+  rcases h1 : f1.case_ with _ | u1
+  · rw [h1] at ha
+    exact absurd ha (by simp)
+  · rcases h2 : f2.case_ with _ | u2
+    · rw [h2] at hb
+      exact absurd hb (by simp)
+    · rw [h1] at ha
+      rw [h2] at hb
+      rw [h1, h2] at hc
+      simp only [Option.isNone_some, Bool.false_or, beq_iff_eq,
+        Option.some.injEq] at hc
+      simp only [Option.map_some] at ha hb
+      subst hc
+      exact (Option.some.inj ha).symm.trans (Option.some.inj hb)

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -1,9 +1,7 @@
 import Linglib.Syntax.Pronoun.Basic
 import Linglib.Syntax.Pronoun.Capabilities
-import Linglib.Data.UD.Basic
-import Linglib.Features.Number.Capabilities
-import Linglib.Features.Person.Capabilities
 import Linglib.Features.Person.Decomposition
+import Linglib.Fragments.Romance.Clitics
 
 /-! # Italian Pronoun and Clitic Fragment
 
@@ -91,41 +89,11 @@ def allPronouns : List PersonalPronoun :=
 -- § 2: Clitic Paradigm
 -- ============================================================================
 
-/-- The three-way case distinction for Italian clitics. -/
-inductive CliticCase where
-  | accusative
-  | dative
-  | reflexive
-  deriving DecidableEq, Repr
+open Romance.Clitics (CliticEntry CliticCase)
 
-/-- A single clitic form in the paradigm. -/
-structure CliticEntry where
-  form : String
-  person : UD.Person
-  number : UD.Number
-  case_ : CliticCase
-  deriving Repr, BEq
-
-/-- A clitic bears its φ-slot's number (`HasNumber`). -/
-instance : HasNumber CliticEntry := ⟨fun c => Number.fromUD c.number⟩
-
-instance : HasPerson CliticEntry := ⟨fun c => some (Person.fromUD c.person)⟩
-
-/-! ### Clitics as capability carriers (`Proform` / `Bound`)
-
-The clitic is its own bespoke struct — capabilities abstract over it without merging it into
-`Pronoun` (the `FunLike`-over-many-hom-types pattern). Deficiency is deliberately *not* a capability
-here: it is per-series (the whole clitic paradigm is `.clitic`), modelled by `cliticStrength` below
-and the `Strength` order, not by a per-element accessor. -/
-
-/-- A clitic's surface form + φ-features (person/number). -/
-instance : Proform CliticEntry :=
-  ⟨CliticEntry.form, fun c => { person := some c.person, number := some c.number }⟩
-
-/-- Binding class from the clitic's case: a reflexive clitic (*si*, *mi* …) is a Principle-A
-    anaphor; an accusative/dative object clitic is a Principle-B pronominal. -/
-instance : Bound CliticEntry :=
-  ⟨fun c => match c.case_ with | .reflexive => .reflexive | _ => .pronoun⟩
+/-! Schema and capability instances (`Proform`/`Bound`/`HasPerson`/
+`HasNumber`/`HasCase`) are the shared Romance clitic schema
+(`Fragments/Romance/Clitics.lean`). -/
 
 -- 1sg clitics
 def mi_acc : CliticEntry := { form := "mi", person := .first, number := .Sing, case_ := .accusative }
@@ -184,19 +152,17 @@ example : Bound.IsAnaphor si_refl := by decide
 example : Bound.IsPronominal lo_cl := by decide
 
 /-- Look up the form for a given person, number, and case in the paradigm. -/
-def lookupForm (p : UD.Person) (n : UD.Number) (c : CliticCase) : Option String :=
-  (paradigm.find? (fun e => e.person == p && e.number == n && e.case_ == c)).map (·.form)
+def lookupForm : UD.Person → UD.Number → CliticCase → Option String :=
+  Romance.Clitics.lookupForm paradigm
 
 /-- Are two clitic cases syncretic for a given person/number combination?
-    DERIVED from the paradigm data. -/
-def isSyncretic (p : UD.Person) (n : UD.Number) (c1 c2 : CliticCase) : Bool :=
-  match lookupForm p n c1, lookupForm p n c2 with
-  | some f1, some f2 => f1 == f2
-  | _, _ => false
+    Derived from the paradigm data. -/
+def isSyncretic : UD.Person → UD.Number → CliticCase → CliticCase → Bool :=
+  Romance.Clitics.isSyncretic paradigm
 
 /-- DAT/REFL syncretism for a given person/number. -/
-def datReflSyncretic (p : UD.Person) (n : UD.Number) : Bool :=
-  isSyncretic p n .dative .reflexive
+def datReflSyncretic : UD.Person → UD.Number → Bool :=
+  Romance.Clitics.datReflSyncretic paradigm
 
 -- ============================================================================
 -- § 4: Verification Theorems

--- a/Linglib/Fragments/Romance/Clitics.lean
+++ b/Linglib/Fragments/Romance/Clitics.lean
@@ -1,0 +1,96 @@
+import Linglib.Data.UD.Basic
+import Linglib.Features.Case.Capabilities
+import Linglib.Features.Number.Capabilities
+import Linglib.Features.Person.Capabilities
+import Linglib.Syntax.Pronoun.Capabilities
+
+/-!
+# Romance Clitic Paradigm Schema
+[munoz-perez-2026]
+
+The shared schema for Romance object-clitic paradigms: the three-way
+ACC/DAT/REFL paradigm contrast, the clitic entry record with its
+capability instances, and the paradigm-derived syncretism predicates.
+Italian (`Fragments/Italian/Pronouns.lean`) and Spanish
+(`Fragments/Spanish/Clitics.lean`) instantiate it with their paradigm
+data; the syncretism predicates drive [munoz-perez-2026]'s stylistic
+applicatives.
+
+REFL is a paradigm cell, not a case value: Romance reflexive clitics
+neutralize the accusative/dative contrast, so `CliticCase.toCase` sends
+it to `none` while ACC/DAT project to the analytical inventory.
+
+The clitic is its own bespoke struct — capabilities (`Proform`, `Bound`,
+`HasPerson`, `HasNumber`, `HasCase`) abstract over it without merging it
+into `Pronoun` (the `FunLike`-over-many-hom-types pattern). Deficiency is
+deliberately *not* a capability: it is per-series (a whole clitic paradigm
+is `.clitic`), modelled by the per-language `cliticStrength` and the
+`Strength` order, not by a per-element accessor.
+-/
+
+namespace Romance.Clitics
+
+/-- The three-way paradigm contrast for Romance object clitics. -/
+inductive CliticCase where
+  | accusative
+  | dative
+  | reflexive
+  deriving DecidableEq, Repr
+
+/-- Project a paradigm cell to the analytical case inventory. REFL
+    neutralizes the accusative/dative contrast, so it projects to
+    `none`. -/
+def CliticCase.toCase : CliticCase → Option Case
+  | .accusative => some .acc
+  | .dative => some .dat
+  | .reflexive => none
+
+/-- A single clitic form in a paradigm. -/
+structure CliticEntry where
+  form : String
+  person : UD.Person
+  number : UD.Number
+  case_ : CliticCase
+  deriving Repr, BEq
+
+/-- A clitic bears its φ-slot's number (`HasNumber`). -/
+instance : HasNumber CliticEntry := ⟨fun c => Number.fromUD c.number⟩
+
+instance : HasPerson CliticEntry := ⟨fun c => some (Person.fromUD c.person)⟩
+
+/-- A clitic bears the analytical case its paradigm cell projects to;
+    reflexives, neutralizing the contrast, bear `none`. -/
+instance : HasCase CliticEntry := ⟨fun c => c.case_.toCase⟩
+
+/-- A clitic's surface form + φ-features (person/number). -/
+instance : Proform CliticEntry :=
+  ⟨CliticEntry.form, fun c => { person := some c.person, number := some c.number }⟩
+
+/-- Binding class from the clitic's paradigm cell: a reflexive clitic is a
+    Principle-A anaphor; an accusative/dative object clitic is a
+    Principle-B pronominal. -/
+instance : Bound CliticEntry :=
+  ⟨fun c => match c.case_ with | .reflexive => .reflexive | _ => .pronoun⟩
+
+/-- Look up the form for a given person, number, and paradigm cell. -/
+def lookupForm (paradigm : List CliticEntry) (p : UD.Person) (n : UD.Number)
+    (c : CliticCase) : Option String :=
+  (paradigm.find? (fun e => e.person == p && e.number == n && e.case_ == c)).map
+    (·.form)
+
+/-- Are two paradigm cells syncretic for a given person/number
+    combination? Derived from the paradigm data: syncretism holds iff the
+    looked-up forms are identical (and both exist). -/
+def isSyncretic (paradigm : List CliticEntry) (p : UD.Person) (n : UD.Number)
+    (c1 c2 : CliticCase) : Bool :=
+  match lookupForm paradigm p n c1, lookupForm paradigm p n c2 with
+  | some f1, some f2 => f1 == f2
+  | _, _ => false
+
+/-- DAT/REFL syncretism for a given person/number — the key condition for
+    SE-optionality ([munoz-perez-2026]). -/
+def datReflSyncretic (paradigm : List CliticEntry) (p : UD.Person)
+    (n : UD.Number) : Bool :=
+  isSyncretic paradigm p n .dative .reflexive
+
+end Romance.Clitics

--- a/Linglib/Fragments/Romance/Clitics.lean
+++ b/Linglib/Fragments/Romance/Clitics.lean
@@ -16,9 +16,15 @@ Italian (`Fragments/Italian/Pronouns.lean`) and Spanish
 data; the syncretism predicates drive [munoz-perez-2026]'s stylistic
 applicatives.
 
-REFL is a paradigm cell, not a case value: Romance reflexive clitics
-neutralize the accusative/dative contrast, so `CliticCase.toCase` sends
-it to `none` while ACC/DAT project to the analytical inventory.
+REFL is a paradigm cell, not a case value. In the languages instantiated
+here (Italian, Spanish) the third-person reflexive (*si*/*se*) is a
+single form that does not determine the accusative/dative contrast — at
+first/second person the contrast is syncretic throughout — so
+`CliticCase.toCase` sends REFL to `none` while ACC/DAT project to the
+analytical inventory. This is a commitment scoped to those languages:
+Romanian contrasts reflexive accusative *se* with reflexive dative *își*,
+so a Romanian instantiation must split the REFL cell (or make the
+projection person-sensitive) rather than reuse this `toCase`.
 
 The clitic is its own bespoke struct — capabilities (`Proform`, `Bound`,
 `HasPerson`, `HasNumber`, `HasCase`) abstract over it without merging it
@@ -38,8 +44,9 @@ inductive CliticCase where
   deriving DecidableEq, Repr
 
 /-- Project a paradigm cell to the analytical case inventory. REFL
-    neutralizes the accusative/dative contrast, so it projects to
-    `none`. -/
+    projects to `none`: in Italian/Spanish the reflexive does not
+    determine the accusative/dative contrast. (Romanian, contrasting
+    reflexive *se*/*își*, needs a split REFL cell instead.) -/
 def CliticCase.toCase : CliticCase → Option Case
   | .accusative => some .acc
   | .dative => some .dat

--- a/Linglib/Fragments/Spanish/Clitics.lean
+++ b/Linglib/Fragments/Spanish/Clitics.lean
@@ -1,7 +1,5 @@
-import Linglib.Data.UD.Basic
-import Linglib.Features.Number.Capabilities
-import Linglib.Features.Person.Capabilities
 import Linglib.Features.Person.Decomposition
+import Linglib.Fragments.Romance.Clitics
 
 /-!
 # Spanish Clitic Paradigm
@@ -27,37 +25,12 @@ This syncretism drives the availability of stylistic applicatives.
 
 namespace Spanish.Clitics
 
--- ============================================================================
--- § 1: Clitic Cases
--- ============================================================================
+open Romance.Clitics (CliticEntry CliticCase)
 
-/-- The three-way case distinction for Spanish clitics. -/
-inductive CliticCase where
-  | accusative
-  | dative
-  | reflexive
-  deriving DecidableEq, Repr
+/-! ### Paradigm data
 
--- ============================================================================
--- § 2: Clitic Entries
--- ============================================================================
-
-/-- A single clitic form in the paradigm. -/
-structure CliticEntry where
-  form : String
-  person : UD.Person
-  number : UD.Number
-  case_ : CliticCase
-  deriving Repr, BEq
-
-/-- A clitic bears its φ-slot's number (`HasNumber`). -/
-instance : HasNumber CliticEntry := ⟨fun c => Number.fromUD c.number⟩
-
-instance : HasPerson CliticEntry := ⟨fun c => some (Person.fromUD c.person)⟩
-
--- ============================================================================
--- § 3: Paradigm Data
--- ============================================================================
+Schema and capability instances are the shared Romance clitic schema
+(`Fragments/Romance/Clitics.lean`). -/
 
 -- 1SG clitics
 def me_acc : CliticEntry := { form := "me", person := .first, number := .Sing, case_ := .accusative }
@@ -86,9 +59,7 @@ def las : CliticEntry := { form := "las", person := .third, number := .Plur, cas
 def les_dat : CliticEntry := { form := "les", person := .third, number := .Plur, case_ := .dative }
 def se_refl_pl : CliticEntry := { form := "se", person := .third, number := .Plur, case_ := .reflexive }
 
--- ============================================================================
--- § 4: Paradigm and Syncretism
--- ============================================================================
+/-! ### Paradigm and syncretism -/
 
 /-- The full clitic paradigm as a flat list. -/
 def paradigm : List CliticEntry :=
@@ -99,25 +70,20 @@ def paradigm : List CliticEntry :=
     los, las, les_dat, se_refl_pl ]
 
 /-- Look up the form for a given person, number, and case in the paradigm. -/
-def lookupForm (p : UD.Person) (n : UD.Number) (c : CliticCase) : Option String :=
-  (paradigm.find? (fun e => e.person == p && e.number == n && e.case_ == c)).map (·.form)
+def lookupForm : UD.Person → UD.Number → CliticCase → Option String :=
+  Romance.Clitics.lookupForm paradigm
 
 /-- Are two clitic cases syncretic for a given person/number combination?
-    DERIVED from the paradigm data: syncretism holds iff the looked-up
-    forms are identical (and both exist). -/
-def isSyncretic (p : UD.Person) (n : UD.Number) (c1 c2 : CliticCase) : Bool :=
-  match lookupForm p n c1, lookupForm p n c2 with
-  | some f1, some f2 => f1 == f2
-  | _, _ => false
+    Derived from the paradigm data. -/
+def isSyncretic : UD.Person → UD.Number → CliticCase → CliticCase → Bool :=
+  Romance.Clitics.isSyncretic paradigm
 
 /-- The set of person/number combinations where DAT and REFL are syncretic.
     This is the key condition for SE-optionality. -/
-def datReflSyncretic (p : UD.Person) (n : UD.Number) : Bool :=
-  isSyncretic p n .dative .reflexive
+def datReflSyncretic : UD.Person → UD.Number → Bool :=
+  Romance.Clitics.datReflSyncretic paradigm
 
--- ============================================================================
--- § 5: Verification Theorems
--- ============================================================================
+/-! ### Verification theorems -/
 
 /-- 1SG: dative and reflexive are syncretic (both "me"). -/
 theorem syncretic_1sg : datReflSyncretic .first .Sing = true := rfl

--- a/Linglib/Morphology/Word.lean
+++ b/Linglib/Morphology/Word.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Features.Case.Capabilities
 import Linglib.Features.Number.Capabilities
 import Linglib.Features.Person.Capabilities
 
@@ -91,6 +92,8 @@ theorem Word.Agree.not_transitive :
 instance : HasNumber Word := ⟨fun w => w.features.number.bind Number.fromUD⟩
 
 instance : HasPerson Word := ⟨fun w => w.features.person.map Person.fromUD⟩
+
+instance : HasCase Word := ⟨fun w => w.features.case_.map Case.fromUD⟩
 
 /-- The φ-projection preserves `numberOf`: a word and its `phi` bundle bear
     the same number — the defeq `Word.Agree.hasNumber_compatible` relies on. -/

--- a/Linglib/Syntax/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Pronoun/Capabilities.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Features.Case.Capabilities
 import Linglib.Features.Number.Capabilities
 import Linglib.Features.Person.Capabilities
 import Linglib.Features.CoreferenceStatus
@@ -147,6 +148,26 @@ theorem personOf_toWord (p : Pronoun) :
   cases p.person with
   | none => rfl
   | some per => exact congrArg some (Person.fromUD_toUD per)
+
+/-! ### The case axis: `HasCase` instances and faithfulness -/
+
+/-- A pronoun bears its analytical case directly — the carrier field is
+root-`Case`-typed. -/
+instance : HasCase Pronoun := ⟨fun p => p.case_⟩
+
+instance : HasCase PersonalPronoun := ⟨fun p => HasCase.caseOf p.toPronoun⟩
+
+/-- Projecting a pronoun to a `Word` realizes its case through UD
+losslessly: `Case.toUD` is currently a bijection, so — unlike person
+(clusivity lost) and number (minimal/augmented lost) — the round-trip is
+the identity. This is the theorem that degrades when an analytical
+refinement splits a UD cell (`Case.fromUD_toUD`). -/
+theorem caseOf_toWord (p : Pronoun) :
+    HasCase.caseOf p.toWord = HasCase.caseOf p := by
+  show (p.case_.map Case.toUD).map Case.fromUD = p.case_
+  cases p.case_ with
+  | none => rfl
+  | some c => exact congrArg some (Case.fromUD_toUD c)
 
 /-! ### Orthogonal data-mixin: `Deictic` -/
 


### PR DESCRIPTION
Completes the Case carrier API on the Person/Number pattern and kills the Italian/Spanish CliticCase duplication.

- `Features/Case/Capabilities.lean`: `HasCase` mixin with `Compat (Flat Case)` concord-checking; `Word`/`Pronoun` instances; `compatible_hasCase` (mixin never diverges from the unification engine) and `caseOf_toWord` faithfulness
- `Fragments/Romance/Clitics.lean`: shared clitic schema (ACC/DAT/REFL paradigm cells; `CliticCase.toCase` projects REFL to `none` since reflexives neutralize the case contrast); Italian/Spanish keep paradigm data only