### PR TITLE
refactor(Core/Order): found PartialRank on partialOrderOfSO; fix cites

### DIFF
--- a/Linglib/Core/Order/PartialRank.lean
+++ b/Linglib/Core/Order/PartialRank.lean
@@ -1,4 +1,4 @@
-import Mathlib.Order.Basic
+import Mathlib.Order.RelClasses
 
 /-!
 # Partial-Rank Orders
@@ -15,17 +15,23 @@ says nothing about ERG or ABS, and the silence is theoretical content.
 No pullback produces this. `Preorder.lift` through `r` (the
 `PullbackPreorder` construction) would make all unranked elements
 mutually equivalent — `r a = r b = none` gives `a ≤ b ≤ a` — losing
-antisymmetry and the isolation. Hence the direct construction: `RankLE`
-is the reflexive closure of the strict comparison `RankLT`, which is
-asymmetric and transitive whenever `<` on `β` is, so the closure is a
-genuine partial order.
+antisymmetry and the isolation.
+
+The order structure itself is mathlib's: `RankLT` is a strict order
+(`IsStrictOrder` instance below), so `partialOrderOfRank` is
+`partialOrderOfSO (RankLT r)` and `RankLE` is its reflexive closure
+(the `Relation.ReflGen` shape). This file's value-add is `RankLT`
+itself, its decidability, and the isolation lemmas. There is no total
+variant: isolation precludes totality whenever any element is unranked.
 
 ## Main declarations
 
 * `Core.Order.RankLT` — strict comparison through a partial rank
 * `Core.Order.RankLE` — its reflexive closure
-* `Core.Order.partialOrderOfRank` — the bundled `PartialOrder`, with
-  `<` definitionally `RankLT`
+* `Core.Order.rankLE_iff_eq_left`/`rankLE_iff_eq_right` — isolation:
+  an unranked element is `≤`-related only to itself
+* `Core.Order.partialOrderOfRank` — `partialOrderOfSO` at `RankLT r`;
+  `<` is definitionally `RankLT` and `≤` is `RankLE`
 -/
 
 namespace Core.Order
@@ -65,10 +71,6 @@ theorem rankLT_iff :
   unfold RankLT
   split <;> simp_all
 
-theorem RankLT.rankLE (h : RankLT r a b) : RankLE r a b := Or.inr h
-
-theorem rankLE_refl (a : α) : RankLE r a a := Or.inl rfl
-
 /-- An unranked element is `≤`-related only to itself (left). -/
 theorem rankLE_iff_eq_left (h : r a = none) : RankLE r a b ↔ a = b := by
   refine ⟨fun hab => hab.resolve_right fun hlt => ?_, Or.inl⟩
@@ -101,39 +103,22 @@ theorem rankLT_irrefl (a : α) : ¬RankLT r a a := fun h => by
   obtain rfl := Option.some.inj (hx.symm.trans hy)
   exact lt_irrefl x hxy
 
-theorem RankLT.asymm (hab : RankLT r a b) : ¬RankLT r b a := fun hba =>
-  rankLT_irrefl a (hab.trans hba)
+/-- `RankLT` is a strict order — the bridge to mathlib's order
+    constructors. -/
+instance (r : α → Option β) [Preorder β] : IsStrictOrder α (RankLT r) where
+  irrefl := rankLT_irrefl
+  trans _ _ _ := RankLT.trans
 
-theorem rankLE_trans (hab : RankLE r a b) (hbc : RankLE r b c) :
-    RankLE r a c := by
-  rcases hab with rfl | hab
-  · exact hbc
-  rcases hbc with rfl | hbc
-  · exact Or.inr hab
-  · exact Or.inr (hab.trans hbc)
+/-- The partial order induced by a partial rank: `partialOrderOfSO` at
+    `RankLT r`, so `<` is definitionally `RankLT r` and `≤` is
+    `RankLE r`. Intended for `scoped instance`s: a theoretical hierarchy
+    is borne by a feature type as an opt-in commitment, never as a
+    global instance.
 
-theorem rankLE_antisymm (hab : RankLE r a b) (hba : RankLE r b a) :
-    a = b := by
-  rcases hab with rfl | hab
-  · rfl
-  rcases hba with rfl | hba
-  · rfl
-  · exact absurd hba hab.asymm
-
-/-- The partial order induced by a partial rank. `≤` is `RankLE r`; `<`
-    is definitionally `RankLT r`. Intended for `scoped instance`s: a
-    theoretical hierarchy is borne by a feature type as an opt-in
-    commitment, never as a global instance. -/
-@[reducible] def partialOrderOfRank (r : α → Option β) [Preorder β] :
-    PartialOrder α where
-  le := RankLE r
-  lt := RankLT r
-  le_refl := rankLE_refl
-  le_trans _ _ _ := rankLE_trans
-  le_antisymm _ _ := rankLE_antisymm
-  lt_iff_le_not_ge a _ :=
-    ⟨fun h => ⟨h.rankLE, fun hba => hba.elim (fun he => rankLT_irrefl a (he ▸ h)) h.asymm⟩,
-     fun ⟨hab, hba⟩ => hab.resolve_left fun he => hba (Or.inl he.symm)⟩
+    See note [reducible non-instances]. -/
+abbrev partialOrderOfRank (r : α → Option β) [Preorder β] :
+    PartialOrder α :=
+  partialOrderOfSO (RankLT r)
 
 end Preorder
 

--- a/Linglib/Features/Case/Basic.lean
+++ b/Linglib/Features/Case/Basic.lean
@@ -19,10 +19,10 @@ theoretical machinery — Blake's hierarchy (here), Caha containment
 corpora annotate — reachable by `toUD`/`fromUD`. The two inventories
 currently coincide cell-for-cell, so both round-trips hold; the
 analytical inventory is where refinements that UD conflates would land
-(e.g. Latin-type general ablative vs. the Uralic proximal-source cell
-both realize as `Abl`), breaking only `fromUD_toUD` — exactly as
-`Person.fromUD_toUD` degrades to `coarsen` under UD's clusivity
-conflation.
+(e.g. the Latin-type syncretic general ablative and the Finnish
+exterior-source ablative both realize as `Abl`), breaking only
+`fromUD_toUD` — exactly as `Person.fromUD_toUD` degrades to `coarsen`
+under UD's clusivity conflation.
 
 This mirrors the `Person`/`Number`/`Gender` API
 (`Features/{Person,Number,Gender}/Basic.lean`): canonical analytical
@@ -190,14 +190,16 @@ The fine-grained spatial cases all sit at the peripheral spatial tier
 (rank 1) since Blake's hierarchy collapses them into a single locative/
 spatial group. -/
 
-/-- Position on Blake's case hierarchy ([blake-1994], §5.8, ex. 68).
+/-- Position on Blake's case hierarchy ([blake-1994]).
 
     Higher rank = more likely to exist in a language's case inventory.
-
-    Ranks: 6 = core (NOM/ACC/ERG/ABS), 5 = GEN, 4 = DAT, 3 = LOC,
-    2 = ABL/INST, 1 = COM/ALL/PERL/BEN + fine-grained spatial cases
-    (ADE/INE/ILL/ELA/SUB/SUP/DEL — Finnish/Hungarian), 0 = peripheral
-    non-spatial (VOC/PART/CAUS/ESS/TRANSL/ABESS/TER/TEM).
+    Blake's hierarchy orders NOM/ACC/ERG/ABS > GEN > DAT > LOC >
+    ABL/INST and lumps everything below into a single undifferentiated
+    "others" tier; the further split of that tier into rank 1
+    (COM/ALL/PERL/BEN + fine-grained spatial cases — Finnish/Hungarian
+    ADE/INE/ILL/ELA/SUB/SUP/DEL) vs rank 0 (peripheral non-spatial:
+    VOC/PART/CAUS/ESS/TRANSL/ABESS/TER/TEM) is this formalization's
+    extrapolation, not Blake's.
 
     Codomain is `Fin 7` — the boundedness is encoded in the type, not as
     a separate `*_bounded` theorem. -/
@@ -214,7 +216,7 @@ def hierarchyRank : Case → Fin 7
 
 /-- An inventory is **contiguous** on Blake's hierarchy: every rank
     between two realized ranks is itself realized. Formalizes Blake's
-    implicational tendency ([blake-1994], §5.8), in a form `decide` can
+    implicational tendency ([blake-1994]), in a form `decide` can
     mechanically check; `isValidInventory_iff_ordConnected` is the
     order-theoretic content. -/
 def IsValidInventory (inv : Finset Case) : Prop :=

--- a/Linglib/Fragments/Finnish/Case.lean
+++ b/Linglib/Fragments/Finnish/Case.lean
@@ -1,5 +1,4 @@
 import Linglib.Features.Case.Basic
-import Linglib.Features.Case.Basic
 import Linglib.Diachronic.CaseGrammaticalization
 import Linglib.Morphology.Case.Allomorphy
 open Morphology.Case.Allomorphy
@@ -140,9 +139,6 @@ def allLocalCases : List LocalCase :=
   , localCaseMatrix .source .external
   , localCaseMatrix .goal   .internal
   , localCaseMatrix .goal   .external ]
-
-/-- The matrix has exactly 6 cells. -/
-theorem localCases_count : allLocalCases.length = 6 := by native_decide
 
 /-- Case collapses each direction row: both internal and external
     static cases map to.loc. -/

--- a/Linglib/Syntax/Case/Dependent.lean
+++ b/Linglib/Syntax/Case/Dependent.lean
@@ -43,7 +43,7 @@ cross-linguistic validation, and competing analyses live in
   the source of dyadic unaccusatives, with lexical ABL from *kara*
   bleeding dependent case
 - `Studies/Caha2009.lean` — typological prediction at the inventory level,
-  using the `PartialOrder Case` instance from `Core/Case/Order.lean`
+  using the scoped Caha `PartialOrder` from `Syntax/Case/Order.lean`
   and the `RespectsCahaContainment` predicate now defined in `Caha2009.lean`
   itself. The dependent case algorithm produces values in `Case`;
   their relative ranking is the canonical containment order, which
@@ -60,9 +60,9 @@ cross-linguistic validation, and competing analyses live in
   framework: one obligatory primary licenser per clause + secondary
   licensers as a last-resort response to convergence failure, deriving
   DOM patterns as the surface signature of secondary-licenser activation
-- `Core/Case/Order.lean` — the containment hierarchy (`PartialOrder
-  Case`); `Core/Case/Allomorphy.lean` — the framework-neutral
-  `AllomorphyPattern` and *ABA substrate; `Studies/
+- `Syntax/Case/Order.lean` — the containment hierarchy (a *scoped*
+  `PartialOrder` on `Case`); `Morphology/Case/Allomorphy.lean` — the
+  framework-neutral `AllomorphyPattern` and *ABA substrate; `Studies/
   Caha2009.lean` — the Caha-specific `RespectsCahaContainment`
   predicate that consumes `Case` values
 

--- a/Linglib/Syntax/Case/Order.lean
+++ b/Linglib/Syntax/Case/Order.lean
@@ -46,16 +46,16 @@ open Core.Order (RankLT RankLE)
     (e.g., ERG/ABS in ergative systems, or minor cases whose containment
     structure is less well established).
 
-    **Encoding caveat.** [caha-2009] (10b), p. 10 gives the Universal
-    Case sequence NOM-ACC-GEN-DAT-INST-COM (no LOC); the Russian-specific
-    sequence (16) p. 12 inserts PREP between GEN and DAT. The encoding
+    **Encoding caveat.** [caha-2009]'s Universal Case sequence is
+    NOM-ACC-GEN-DAT-INST-COM (no LOC); his Russian-specific sequence
+    inserts the prepositional/locative between GEN and DAT. The encoding
     below — NOM=0, ACC=1, GEN=2, DAT=3, LOC=4, INST=none — matches
     neither verbatim; it is closer to Blake's typological hierarchy
-    ([blake-1994] §5.8, which Caha himself argues on p. 31 should
-    coincide with his sequence). For Slavic 6-case inventories the
-    encoding choice is verdict-equivalent; inventories with INST or COM
-    *without* LOC may diverge. For paradigm-shape work that needs Caha's
-    actual Slavic ordering, see `cahaSlavicRank` below. -/
+    ([blake-1994], which Caha argues should coincide with his sequence).
+    For Slavic 6-case inventories the encoding choice is
+    verdict-equivalent; inventories with INST or COM *without* LOC may
+    diverge. For paradigm-shape work that needs Caha's actual Slavic
+    ordering, see `cahaSlavicRank` below. -/
 def containmentRank : _root_.Case → Option Nat
   | .nom => some 0
   | .acc => some 1
@@ -64,19 +64,18 @@ def containmentRank : _root_.Case → Option Nat
   | .loc => some 4
   | _ => none
 
-/-- Caha's Slavic-specific Case sequence ([caha-2009] (16) p. 12 for
-    Russian; (7) p. 238 confirms the same for Serbian): NOM – ACC – GEN –
-    PREP/LOC – DAT – INS. Differs from `containmentRank` in placing LOC
-    between GEN and DAT (not at top) and INST at the top (not
-    off-hierarchy). Use this rank for paradigm-shape contiguity claims
-    referencing Caha's Slavic data; use `containmentRank` for inventory
-    downward-closure verdicts (where the choice is Slavic-equivalent).
+/-- Caha's Slavic-specific Case sequence ([caha-2009]; stated for
+    Russian and confirmed for Serbian): NOM – ACC – GEN – PREP/LOC –
+    DAT – INS. Differs from `containmentRank` in placing LOC between GEN
+    and DAT (not at top) and INST at the top (not off-hierarchy). Use
+    this rank for paradigm-shape contiguity claims referencing Caha's
+    Slavic data; use `containmentRank` for inventory downward-closure
+    verdicts (where the choice is Slavic-equivalent).
 
-    Returns `Fin 6` rather than `Option Nat`: all six cases are
-    on-hierarchy in Caha's Slavic encoding; there are no off-hierarchy
-    cases for the Slavic noun system. The `Option` is preserved for
-    consistency with `containmentRank`'s API and to flag non-Slavic
-    cases as not-in-the-Slavic-sequence. -/
+    Codomain `Option (Fin 6)`: the six cases of the Slavic noun system
+    are all on-hierarchy in Caha's Slavic encoding (hence `Fin 6`); the
+    remaining `Case` cells, which are not part of that system, map to
+    `none`. -/
 def cahaSlavicRank : _root_.Case → Option (Fin 6)
   | .nom  => some 0
   | .acc  => some 1
@@ -162,20 +161,22 @@ end Caha
 open scoped Caha
 
 /-- A case is **nonnominative** iff its representation contains ACC's, i.e.
-    `(.acc : Case) ≤ c` in the Caha order. [mcfadden-2018] argues this is
-    the key natural class for stem allomorphy: a VI rule conditioned on
-    `[ACC]` captures the NOM-vs-oblique split found cross-linguistically. -/
+    `(.acc : Case) ≤ c` in the Caha order. [mcfadden-2018] argues this
+    natural class underlies NOM-vs-oblique stem allomorphy: a VI rule
+    conditioned on `[ACC]` captures the split found cross-linguistically
+    (one of his arguments that the nominative is featurally empty). -/
 def IsNonnominative (c : _root_.Case) : Prop := (.acc : _root_.Case) ≤ c
 
 instance (c : _root_.Case) : Decidable (IsNonnominative c) :=
   inferInstanceAs (Decidable ((.acc : _root_.Case) ≤ c))
 
 /-- A case is **oblique** iff its representation contains GEN's, i.e.
-    `(.gen : Case) ≤ c` in the Caha order. Per [caha-2009]'s
-    Unmarked-Dependent vs Oblique split, NOM/ACC are unmarked-dependent
-    and GEN/DAT/LOC/INS/COM/etc. are oblique. Ergative-aligned ABS/ERG
-    are off-hierarchy in `containmentRank` and so satisfy `¬ IsOblique`
-    (consistent with their parallel-to-NOM/ACC structural status). -/
+    `(.gen : Case) ≤ c` in the Caha order — the traditional
+    structural-vs-oblique split (NOM/ACC vs GEN and above), stated
+    through the containment encoding ([caha-2009] supplies the encoding,
+    not the terminology). Ergative-aligned ABS/ERG are off-hierarchy in
+    `containmentRank` and so satisfy `¬ IsOblique` (consistent with
+    their parallel-to-NOM/ACC structural status). -/
 def IsOblique (c : _root_.Case) : Prop := (.gen : _root_.Case) ≤ c
 
 instance (c : _root_.Case) : Decidable (IsOblique c) :=
@@ -189,7 +190,9 @@ theorem isOblique_split_core :
 
 /-- Ergative-aligned ABS/ERG are not oblique under the Caha hierarchy
     (off-hierarchy → incomparable with GEN). This makes the predicate
-    usable for SMSE 2019-style ergative paradigms (Wardaman, Khinalugh). -/
+    usable for the ergative pronominal paradigms of
+    [smith-moskal-xu-kang-bobaljik-2019] (Wardaman, Khinalugh —
+    `Studies/SmithMoskalEtAl2019.lean`). -/
 theorem isOblique_erg_abs_false :
     ¬ IsOblique .erg ∧ ¬ IsOblique .abs := by
   refine ⟨?_, ?_⟩ <;> decide


### PR DESCRIPTION
Audit follow-up to #203: mathlib conformance + citation hygiene.

- `PartialRank`: one `IsStrictOrder (RankLT r)` instance + `abbrev partialOrderOfRank := partialOrderOfSO (RankLT r)` replaces the hand-proved order block; isolation lemmas and decidability remain the file's value-add
- de-number unverified Blake/Caha section-page cites; own the sub-ABL/INST tier split (it is our extrapolation, not Blake's); fix the UD `Abl`-conflation characterization and the oblique-split attribution; `SMSE 2019` → `[smith-moskal-xu-kang-bobaljik-2019]`
- hygiene: Finnish duplicate import + `native_decide` aggregate-count theorem dropped; stale `Core/Case/` paths in `Dependent.lean`