### PR TITLE
refactor(Syntax/Case): attach theory API to Case namespace; adopt HasCase

### DIFF
--- a/Linglib/Features/Case/Capabilities.lean
+++ b/Linglib/Features/Case/Capabilities.lean
@@ -27,6 +27,10 @@ instance : HasCase UD.MorphFeatures :=
 
 instance : HasCase Case := ⟨some⟩
 
+/-- `Option Case` is the free case-bearer: `some c` bears `c`, `none` is
+    caseless. -/
+instance : HasCase (Option Case) := ⟨id⟩
+
 namespace HasCase
 
 variable {α β : Type*} [HasCase α] [HasCase β]

--- a/Linglib/Fragments/Finnish/Case.lean
+++ b/Linglib/Fragments/Finnish/Case.lean
@@ -79,7 +79,7 @@ def finnishNomAccSync : Syncretism := nomAccSyncretism
     (-n) are distinct forms. Unlike many IE languages where ABL and INST
     merge, Finnish keeps them separate. -/
 theorem abl_inst_distinct :
-    HierarchyAdjacent .abl .inst := by decide
+    Case.HierarchyAdjacent .abl .inst := by decide
 
 -- ============================================================================
 -- § 3: Local Case Matrix (3 × 2)

--- a/Linglib/Fragments/Latin/Case.lean
+++ b/Linglib/Fragments/Latin/Case.lean
@@ -63,7 +63,7 @@ def neuterSyncretism : Syncretism := nomAccSyncretism
 
 /-- NOM/ACC is same-tier (both rank 6) — trivially adjacent. -/
 theorem neuter_syncretism_adjacent :
-    HierarchyAdjacent .nom .acc := by decide
+    Case.HierarchyAdjacent .nom .acc := by decide
 
 /-- DAT/ABL syncretism in the plural. -/
 def pluralDatAblSyncretism : Syncretism :=
@@ -73,10 +73,10 @@ def pluralDatAblSyncretism : Syncretism :=
     LOC (rank 3) intervenes. But they ARE inventory-adjacent in the
     standard 6-case system that lacks LOC. -/
 theorem dat_abl_not_strictly_adjacent :
-    ¬ HierarchyAdjacent .dat .abl := by decide
+    ¬ Case.HierarchyAdjacent .dat .abl := by decide
 
 theorem dat_abl_inventory_adjacent :
-    InventoryAdjacent coreInventory .dat .abl := by decide
+    Case.InventoryAdjacent coreInventory .dat .abl := by decide
 
 -- ============================================================================
 -- § 3: Case Extension ([heine-2009], Table 29.6)

--- a/Linglib/Fragments/Tamil/Case.lean
+++ b/Linglib/Fragments/Tamil/Case.lean
@@ -32,6 +32,6 @@ def tamilComInstSync : Syncretism := comInstSyncretism
 
 /-- COM/INST are strictly adjacent (ranks 1, 2). -/
 theorem com_inst_adjacent :
-    HierarchyAdjacent .com .inst := by decide
+    Case.HierarchyAdjacent .com .inst := by decide
 
 end Tamil.Case

--- a/Linglib/Fragments/Telugu/Case.lean
+++ b/Linglib/Fragments/Telugu/Case.lean
@@ -44,11 +44,11 @@ example : Case.IsValidInventory caseInventory := by decide
 -- ============================================================================
 
 /-- All nonnominative Telugu cases bear the ACC feature. -/
-theorem acc_nonnom : Syntax.Case.IsNonnominative .acc := by decide
-theorem gen_nonnom : Syntax.Case.IsNonnominative .gen := by decide
-theorem dat_nonnom : Syntax.Case.IsNonnominative .dat := by decide
-theorem loc_nonnom : Syntax.Case.IsNonnominative .loc := by decide
-theorem nom_not_nonnom : ¬ Syntax.Case.IsNonnominative .nom := by decide
+theorem acc_nonnom : Case.IsNonnominative .acc := by decide
+theorem gen_nonnom : Case.IsNonnominative .gen := by decide
+theorem dat_nonnom : Case.IsNonnominative .dat := by decide
+theorem loc_nonnom : Case.IsNonnominative .loc := by decide
+theorem nom_not_nonnom : ¬ Case.IsNonnominative .nom := by decide
 
 /-- Telugu's NOM-vs-oblique split is an ABB pattern — contiguous on the
     containment hierarchy, consistent with case-conditioned VI. -/

--- a/Linglib/Morphology/Case/Allomorphy.lean
+++ b/Linglib/Morphology/Case/Allomorphy.lean
@@ -120,23 +120,23 @@ structure Syncretism where
   deriving Repr
 
 /-- Are two cases adjacent on the hierarchy (same rank or ranks differ by 1)? -/
-def HierarchyAdjacent (c1 c2 : Case) : Prop :=
+def _root_.Case.HierarchyAdjacent (c1 c2 : Case) : Prop :=
   c1.hierarchyRank = c2.hierarchyRank ∨
   c1.hierarchyRank + 1 = c2.hierarchyRank ∨
   c2.hierarchyRank + 1 = c1.hierarchyRank
 
-instance : DecidableRel HierarchyAdjacent := λ _ _ =>
+instance : DecidableRel Case.HierarchyAdjacent := λ _ _ =>
   inferInstanceAs (Decidable (_ ∨ _ ∨ _))
 
 /-- Relaxed adjacency: no case in the inventory falls strictly between
     the two syncretic cases on the hierarchy. -/
-def InventoryAdjacent (inv : Finset Case) (c1 c2 : Case) : Prop :=
+def _root_.Case.InventoryAdjacent (inv : Finset Case) (c1 c2 : Case) : Prop :=
   let lo := min c1.hierarchyRank c2.hierarchyRank
   let hi := max c1.hierarchyRank c2.hierarchyRank
   ∀ c ∈ inv, c = c1 ∨ c = c2 ∨ c.hierarchyRank ≤ lo ∨ c.hierarchyRank ≥ hi
 
-instance (inv : Finset Case) (c1 c2 : Case) : Decidable (InventoryAdjacent inv c1 c2) := by
-  unfold InventoryAdjacent; infer_instance
+instance (inv : Finset Case) (c1 c2 : Case) : Decidable (Case.InventoryAdjacent inv c1 c2) := by
+  unfold Case.InventoryAdjacent; infer_instance
 
 -- ============================================================================
 -- § 5: Well-Known Syncretism Patterns
@@ -159,25 +159,25 @@ def comInstSyncretism : Syncretism :=
     as `theorem` because it is parametric over the hierarchy ranks
     (not a fixed pair). -/
 
-example : HierarchyAdjacent .nom .acc := by decide
-example : HierarchyAdjacent .com .inst := by decide
-example : HierarchyAdjacent .dat .loc := by decide
-example : HierarchyAdjacent .gen .dat := by decide
+example : Case.HierarchyAdjacent .nom .acc := by decide
+example : Case.HierarchyAdjacent .com .inst := by decide
+example : Case.HierarchyAdjacent .dat .loc := by decide
+example : Case.HierarchyAdjacent .gen .dat := by decide
 
 /-- ERG/INST hierarchy non-adjacency (ranks 6, 2): Blake's known
     exception, explained by historical derivation. -/
-example : ¬ HierarchyAdjacent .erg .inst := by decide
+example : ¬ Case.HierarchyAdjacent .erg .inst := by decide
 
 /-- ERG/INST IS inventory-adjacent in a system with only
     {ERG, ABS, INST}. -/
-example : InventoryAdjacent ({.erg, .abs, .inst} : Finset Case) .erg .inst := by
+example : Case.InventoryAdjacent ({.erg, .abs, .inst} : Finset Case) .erg .inst := by
   decide
 
 /-- Same-tier cases are always strictly adjacent. (Parametric over
     the rank — kept as named `theorem` for downstream re-use.) -/
-theorem same_tier_adjacent (c1 c2 : Case)
+theorem _root_.Case.same_tier_adjacent (c1 c2 : Case)
     (h : c1.hierarchyRank = c2.hierarchyRank) :
-    HierarchyAdjacent c1 c2 := Or.inl h
+    Case.HierarchyAdjacent c1 c2 := Or.inl h
 
 -- ============================================================================
 -- § 7: *ABA and Syncretism Examples

--- a/Linglib/Morphology/Nanosyntax/Basic.lean
+++ b/Linglib/Morphology/Nanosyntax/Basic.lean
@@ -78,7 +78,7 @@ open Morphology.Case.Allomorphy
     (not necessarily contiguous on the fseq). -/
 structure LexEntry where
   /-- The rank (depth) of the stored tree on the fseq.
-      Corresponds to `Syntax.Case.Order.containmentRank`. -/
+      Corresponds to `Case.containmentRank`. -/
   rank : Nat
   /-- The phonological exponent. -/
   exponent : String
@@ -282,7 +282,7 @@ end CaseExamples
     containment hierarchy. Returns `none` for cases not on the
     standard fseq (e.g., ERG/ABS). -/
 def caseToRank (c : Case) : Option Nat :=
-  Syntax.Case.containmentRank c
+  Case.containmentRank c
 
 /-- Spellout a case directly: look up the case's rank, then
     apply phrasal spellout. -/

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -79,7 +79,7 @@ def TeluguCase.toCore : TeluguCase → Case
   | .loc => .loc
 
 /-- Is this Telugu case nonnominative? Derived from
-    `Syntax.Case.IsNonnominative`, which is `(.acc : Case) ≤ c` under the
+    `Case.IsNonnominative`, which is `(.acc : Case) ≤ c` under the
     [caha-2009]/[mcfadden-2018] containment ordering. The full
     containment hierarchy lives at `Syntax.Case.Order` (`containmentRank`,
     `cahaLE`); Aitha's *n*-head VI rules condition on this binary
@@ -87,10 +87,10 @@ def TeluguCase.toCore : TeluguCase → Case
     the *n* head — the layered hierarchy is the substrate, the binary
     split is the Telugu-*n*-specific reduction. -/
 def TeluguCase.IsNonnom (c : TeluguCase) : Prop :=
-  Syntax.Case.IsNonnominative c.toCore
+  Case.IsNonnominative c.toCore
 
 instance (c : TeluguCase) : Decidable (TeluguCase.IsNonnom c) :=
-  inferInstanceAs (Decidable (Syntax.Case.IsNonnominative c.toCore))
+  inferInstanceAs (Decidable (Case.IsNonnominative c.toCore))
 
 -- ────────────────────────────────────────────────────────────────────
 -- Strong noun paradigm: *illu* 'house'

--- a/Linglib/Studies/Bubnov2026.lean
+++ b/Linglib/Studies/Bubnov2026.lean
@@ -60,7 +60,7 @@ set_option autoImplicit false
 namespace Bubnov2026
 
 open DeganoAloni2025
-open scoped Syntax.Case.Caha
+open scoped Case.Caha
 open DeganoAloni2025.DependenceLogic
 open Morphology.Nanosyntax
 open Dekier2021

--- a/Linglib/Studies/Caha2009.lean
+++ b/Linglib/Studies/Caha2009.lean
@@ -56,12 +56,12 @@ Ch. 6), and Hungarian (GEN-less, dative-as-possessor syncretism per
 
 namespace Caha2009
 
-open scoped Syntax.Case.Caha
+open scoped Case.Caha
 
 /-! ## Caha containment-respect predicate
 
 Does an inventory respect Caha's containment hierarchy? True iff `inv`
-is downward-closed under the scoped Caha order (`Syntax.Case.Caha`;
+is downward-closed under the scoped Caha order (`Case.Caha`;
 containment) defined in `Core/Case/Order.lean`: whenever `c ∈ inv` and
 `d ≤ c`, then `d ∈ inv`. Off-hierarchy cases (ERG, ABS, INST, COM, …)
 impose no constraint — in the Caha order they only have `c ≤ c`, so
@@ -88,7 +88,7 @@ predicate (which lives here in this study file, not in `Core/`). -/
 theorem slavicCore_respectsCaha :
     RespectsCahaContainment Slavic.Case.coreInventory := by decide
 
-/-- Vacuous: `Syntax.Case.Order.containmentRank .voc = none` faithfully
+/-- Vacuous: `Case.containmentRank .voc = none` faithfully
     encodes Caha's own scope choice ([caha-2009] §1.1 fn. 4,
     p. 9: "Vocatives ... are ignored throughout this dissertation"). -/
 theorem slavicSeven_respectsCaha :
@@ -237,11 +237,11 @@ namespace Slavic
 /-- Caha's Slavic-specific Case sequence ([caha-2009] (16), p. 12
     for Russian; (7) p. 238 confirms the same for Serbian): NOM – ACC –
     GEN – PREP/LOC – DAT – INS. Re-export from
-    `Syntax.Case.Order.cahaSlavicRank` (the substrate definition). For
+    `Case.cahaSlavicRank` (the substrate definition). For
     the relationship to `containmentRank` (LOC at top, INST
-    off-hierarchy), see `Syntax.Case.Order.cahaSlavicRank_vs_containmentRank`. -/
+    off-hierarchy), see `Case.cahaSlavicRank_vs_containmentRank`. -/
 abbrev slavicRank : Case → Option (Fin 6) :=
-  Syntax.Case.cahaSlavicRank
+  Case.cahaSlavicRank
 
 /-- A morphological paradigm encoded as a form-class index per cell.
     Indices correspond to the Slavic case sequence: 0=NOM, 1=ACC,

--- a/Linglib/Studies/Pesetsky2013.lean
+++ b/Linglib/Studies/Pesetsky2013.lean
@@ -572,7 +572,7 @@ theorem russian_obliques_in_pesetsky_core :
     identify the same five-case core, with Pesetsky adding INST
     outside the Caha hierarchy. -/
 theorem pesetsky_caha_compatible_prefix :
-    pesetskyCore.filter (fun c => (Syntax.Case.containmentRank c).isSome) =
+    pesetskyCore.filter (fun c => (Case.containmentRank c).isSome) =
       ({.nom, .acc, .gen, .dat, .loc} : Finset Case) := by
   decide
 

--- a/Linglib/Studies/SmithMoskalEtAl2019.lean
+++ b/Linglib/Studies/SmithMoskalEtAl2019.lean
@@ -307,14 +307,14 @@ def caseAtPos : Nat → Option Case
   | 2 => some .dat
   | _ => none
 
-/-- Case partition: derived from `Syntax.Case.IsOblique` via `caseAtPos`.
+/-- Case partition: derived from `Case.IsOblique` via `caseAtPos`.
     ABS and ERG are off-hierarchy in `containmentRank` (`IsOblique` is
     `False` for them); DAT contains GEN's representation in the Caha
     order so `IsOblique .dat` is `True`. The boundary thus corresponds
     to [caha-2009]'s Unmarked-Dependent vs Oblique split — *as a
     consequence* of the order substrate, not as a stipulated threshold. -/
 def caseDomainPartition : DomainPartition Bool := λ i =>
-  (caseAtPos i).elim false (λ c => decide (Syntax.Case.IsOblique c))
+  (caseAtPos i).elim false (λ c => decide (Case.IsOblique c))
 
 /-- Number partition: SG (position 0) + PL (position 1) in domain
     `false` (non-dual); DL (position 2) in domain `true` (dual).

--- a/Linglib/Studies/Wood2015.lean
+++ b/Linglib/Studies/Wood2015.lean
@@ -401,8 +401,8 @@ theorem middle_predicts_none :
     SpecApplP because Appl assigns dative case and *-st* lacks case
     features. -/
 theorem st_blocked_from_specApplP :
-    applLowRecipient.specCanBearCase false = false ∧
-    applLowRecipient.specCanBearCase true = true := ⟨rfl, rfl⟩
+    applLowRecipient.specCanBearCase (none : Option Case) = false ∧
+    applLowRecipient.specCanBearCase (some Case.dat) = true := ⟨rfl, rfl⟩
 
 /-- In ditransitive *-st* alternations, Appl datives are retained
     because Appl assigns case independently of Voice

--- a/Linglib/Syntax/Case/CaseFilter.lean
+++ b/Linglib/Syntax/Case/CaseFilter.lean
@@ -1,3 +1,4 @@
+import Linglib.Features.Case.Capabilities
 import Linglib.Syntax.Minimalist.Features
 
 /-!
@@ -64,9 +65,18 @@ def DPFeatures.withUnvaluedCase (phi : List PhiFeature) : DPFeatures :=
 def DPFeatures.withCase (phi : List PhiFeature) (c : Case) : DPFeatures :=
   ⟨phi, .valued (.case c)⟩
 
-/-- Does a DP satisfy the Case Filter? (has valued Case) -/
+/-- A DP bears the case its valued Case feature carries; an unvalued
+    Case feature (or a degenerate non-Case feature in the slot) is
+    caseless. -/
+instance : HasCase DPFeatures :=
+  ⟨fun dp => match dp.caseFeature with
+    | .valued (.case c) => some c
+    | _ => none⟩
+
+/-- Does a DP satisfy the Case Filter? — it bears a case
+    (`HasCase.caseOf` is `some`). -/
 def satisfiesCaseFilter (dp : DPFeatures) : Bool :=
-  dp.caseFeature.isValued
+  (HasCase.caseOf dp).isSome
 
 /-- Convert DPFeatures to a FeatureBundle. -/
 def DPFeatures.toBundle (dp : DPFeatures) : FeatureBundle :=

--- a/Linglib/Syntax/Case/Dependent.lean
+++ b/Linglib/Syntax/Case/Dependent.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Case.Basic
+import Linglib.Features.Case.Capabilities
 /-!
 # Dependent Case Theory
 [marantz-1991] [baker-2015]
@@ -128,9 +129,12 @@ structure CasedNP where
   source : CaseSource
   deriving DecidableEq, Repr
 
+/-- A cased NP bears its assigned case. -/
+instance : HasCase CasedNP := ⟨fun np => some np.case⟩
+
 /-- Look up the assigned case for an NP by label. -/
 def getCaseOf (label : String) (results : List CasedNP) : Option Case :=
-  (results.find? (·.label == label)).map (·.case)
+  (results.find? (·.label == label)).bind HasCase.caseOf
 
 /-- Look up the case source for an NP by label. -/
 def getSourceOf (label : String) (results : List CasedNP) : Option CaseSource :=

--- a/Linglib/Syntax/Case/Order.lean
+++ b/Linglib/Syntax/Case/Order.lean
@@ -6,8 +6,8 @@ import Linglib.Features.Case.Basic
 [caha-2009] [mcfadden-2018]
 
 Caha's containment order on `Case`, as a **scoped** instance
-(`open scoped Syntax.Case.Caha` to use `≤`): theoretical orders are
-borne by features as opt-in commitments, not as global instances — the
+(`open scoped Case.Caha` to use `≤`): theoretical orders are borne by
+features as opt-in commitments, not as global instances — the
 inventory's default is order-free. Each case on the hierarchy literally
 *contains* the representations of all cases below it:
 
@@ -26,13 +26,14 @@ case is a downward-closed stack of case shells — and
 `cahaLT_iff_kshells_ssubset` certifies that the rank order is its
 shadow: the order is derived from the decomposition, not stipulated.
 
-Other orders (Blake's typological frequency in
-`Features/Case/Basic.lean`, per-language syncretism graphs) likewise
-live as named `def`s or scoped instances rather than competing global
-instances on `Case`.
+All declarations live in the root `Case` namespace (the namespace
+follows the subject, not the file location — this file stays in
+`Syntax/Case/` as nanosyntactic theory substrate). Other orders
+(Blake's typological frequency in `Features/Case/Basic.lean`,
+per-language syncretism graphs) likewise live as named `def`s or scoped
+instances rather than competing global instances on `Case`.
 -/
 
-namespace Syntax
 namespace Case
 
 open Core.Order (RankLT RankLE)
@@ -44,7 +45,8 @@ open Core.Order (RankLT RankLE)
 
     Returns `none` for cases not on the containment hierarchy
     (e.g., ERG/ABS in ergative systems, or minor cases whose containment
-    structure is less well established).
+    structure is less well established). Codomain `Option (Fin 5)` — the
+    boundedness is encoded in the type, matching `Case.hierarchyRank`.
 
     **Encoding caveat.** [caha-2009]'s Universal Case sequence is
     NOM-ACC-GEN-DAT-INST-COM (no LOC); his Russian-specific sequence
@@ -56,7 +58,7 @@ open Core.Order (RankLT RankLE)
     verdict-equivalent; inventories with INST or COM *without* LOC may
     diverge. For paradigm-shape work that needs Caha's actual Slavic
     ordering, see `cahaSlavicRank` below. -/
-def containmentRank : _root_.Case → Option Nat
+def containmentRank : Case → Option (Fin 5)
   | .nom => some 0
   | .acc => some 1
   | .gen => some 2
@@ -76,7 +78,7 @@ def containmentRank : _root_.Case → Option Nat
     are all on-hierarchy in Caha's Slavic encoding (hence `Fin 6`); the
     remaining `Case` cells, which are not part of that system, map to
     `none`. -/
-def cahaSlavicRank : _root_.Case → Option (Fin 6)
+def cahaSlavicRank : Case → Option (Fin 6)
   | .nom  => some 0
   | .acc  => some 1
   | .gen  => some 2
@@ -103,12 +105,12 @@ theorem cahaSlavicRank_vs_containmentRank :
 /-- Strict containment on Caha-rank Cases: both must have a rank, and the
     first's must be strictly smaller. False whenever either side is
     off-hierarchy. -/
-abbrev cahaLT : _root_.Case → _root_.Case → Prop := RankLT containmentRank
+abbrev cahaLT : Case → Case → Prop := RankLT containmentRank
 
 /-- The Caha containment order. `c₁ ≤ c₂` iff either they are equal, or
     `cahaLT c₁ c₂`. Off-hierarchy cases are reflexively `≤` themselves and
     incomparable with everything else. -/
-abbrev cahaLE : _root_.Case → _root_.Case → Prop := RankLE containmentRank
+abbrev cahaLE : Case → Case → Prop := RankLE containmentRank
 
 /-! ### The decomposition behind the order
 
@@ -121,7 +123,7 @@ rank encoding above is the shadow of that decomposition. -/
     functional sequence, with shells indexed abstractly). Stipulated
     independently of `containmentRank`; `cahaLT_iff_kshells_ssubset`
     certifies the two agree. -/
-def kshells : _root_.Case → Option (Finset (Fin 5))
+def kshells : Case → Option (Finset (Fin 5))
   | .nom => some {0}
   | .acc => some {0, 1}
   | .gen => some {0, 1, 2}
@@ -134,26 +136,26 @@ def kshells : _root_.Case → Option (Finset (Fin 5))
     through the shell stacks (`<` on `Finset` is strict inclusion `⊂`).
     The rank encoding is certified against the structural containment
     claim, not stipulated alongside it. -/
-theorem cahaLT_iff_kshells_ssubset (c₁ c₂ : _root_.Case) :
+theorem cahaLT_iff_kshells_ssubset (c₁ c₂ : Case) :
     cahaLT c₁ c₂ ↔ RankLT kshells c₁ c₂ := by
   revert c₁ c₂; decide
 
 /-! ### The Caha order as scoped instances
 
 A feature bears its theoretical order as an opt-in commitment
-(`open scoped Syntax.Case.Caha`), never as a global instance on the
+(`open scoped Case.Caha`), never as a global instance on the
 inventory. The instance is `Core.Order.partialOrderOfRank`, so `≤` is
 definitionally `cahaLE` and `<` is `cahaLT`. -/
 
 namespace Caha
 
-scoped instance instPartialOrderCaha : PartialOrder _root_.Case :=
+scoped instance instPartialOrderCaha : PartialOrder Case :=
   Core.Order.partialOrderOfRank containmentRank
 
-scoped instance (c₁ c₂ : _root_.Case) : Decidable (c₁ ≤ c₂) :=
+scoped instance (c₁ c₂ : Case) : Decidable (c₁ ≤ c₂) :=
   inferInstanceAs (Decidable (cahaLE c₁ c₂))
 
-scoped instance (c₁ c₂ : _root_.Case) : Decidable (c₁ < c₂) :=
+scoped instance (c₁ c₂ : Case) : Decidable (c₁ < c₂) :=
   inferInstanceAs (Decidable (cahaLT c₁ c₂))
 
 end Caha
@@ -165,10 +167,10 @@ open scoped Caha
     natural class underlies NOM-vs-oblique stem allomorphy: a VI rule
     conditioned on `[ACC]` captures the split found cross-linguistically
     (one of his arguments that the nominative is featurally empty). -/
-def IsNonnominative (c : _root_.Case) : Prop := (.acc : _root_.Case) ≤ c
+def IsNonnominative (c : Case) : Prop := (.acc : Case) ≤ c
 
-instance (c : _root_.Case) : Decidable (IsNonnominative c) :=
-  inferInstanceAs (Decidable ((.acc : _root_.Case) ≤ c))
+instance (c : Case) : Decidable (IsNonnominative c) :=
+  inferInstanceAs (Decidable ((.acc : Case) ≤ c))
 
 /-- A case is **oblique** iff its representation contains GEN's, i.e.
     `(.gen : Case) ≤ c` in the Caha order — the traditional
@@ -177,10 +179,10 @@ instance (c : _root_.Case) : Decidable (IsNonnominative c) :=
     not the terminology). Ergative-aligned ABS/ERG are off-hierarchy in
     `containmentRank` and so satisfy `¬ IsOblique` (consistent with
     their parallel-to-NOM/ACC structural status). -/
-def IsOblique (c : _root_.Case) : Prop := (.gen : _root_.Case) ≤ c
+def IsOblique (c : Case) : Prop := (.gen : Case) ≤ c
 
-instance (c : _root_.Case) : Decidable (IsOblique c) :=
-  inferInstanceAs (Decidable ((.gen : _root_.Case) ≤ c))
+instance (c : Case) : Decidable (IsOblique c) :=
+  inferInstanceAs (Decidable ((.gen : Case) ≤ c))
 
 /-- The four core McFadden-hierarchy cases stratify cleanly between
     non-oblique (NOM, ACC) and oblique (GEN, DAT). -/
@@ -199,14 +201,13 @@ theorem isOblique_erg_abs_false :
 
 /-! ### Sanity chain: NOM < ACC < GEN < DAT < LOC -/
 
-example : (.nom : _root_.Case) ≤ .acc := by decide
-example : (.acc : _root_.Case) ≤ .gen := by decide
-example : (.gen : _root_.Case) ≤ .dat := by decide
-example : (.dat : _root_.Case) ≤ .loc := by decide
+example : (.nom : Case) ≤ .acc := by decide
+example : (.acc : Case) ≤ .gen := by decide
+example : (.gen : Case) ≤ .dat := by decide
+example : (.dat : Case) ≤ .loc := by decide
 
 /-- Off-hierarchy cases (ERG) are incomparable with on-hierarchy cases. -/
-example : ¬ ((.erg : _root_.Case) ≤ .nom) := by decide
-example : ¬ ((.nom : _root_.Case) ≤ .erg) := by decide
+example : ¬ ((.erg : Case) ≤ .nom) := by decide
+example : ¬ ((.nom : Case) ≤ .erg) := by decide
 
 end Case
-end Syntax

--- a/Linglib/Syntax/Minimalist/Applicative.lean
+++ b/Linglib/Syntax/Minimalist/Applicative.lean
@@ -1,3 +1,4 @@
+import Linglib.Features.Case.Capabilities
 import Linglib.Syntax.Minimalist.VerbalDecomposition
 import Linglib.Syntax.Minimalist.Voice
 
@@ -201,20 +202,23 @@ theorem ethical_possessive_middle_asymmetry :
 /-- Can a given element merge in SpecApplP?
 
     [wood-2015] Ch. 5 (§5.3.2): Appl assigns **dative case** to its
-    specifier. Therefore only elements that can bear case can merge
-    in SpecApplP. The Icelandic clitic -st lacks case features and
-    is thus blocked from SpecApplP, even though it can merge in
-    SpecVoiceP and SpecpP (where no case is assigned to the specifier). -/
-def ApplHead.specCanBearCase (appl : ApplHead) (bearerHasCase : Bool) : Bool :=
-  if appl.assignsDative then bearerHasCase
+    specifier. Therefore only case-bearing elements (`HasCase` carriers
+    with `caseOf ≠ none`) can merge in SpecApplP. The Icelandic clitic
+    -st lacks case features and is thus blocked from SpecApplP, even
+    though it can merge in SpecVoiceP and SpecpP (where no case is
+    assigned to the specifier). -/
+def ApplHead.specCanBearCase {α : Type*} [HasCase α] (appl : ApplHead)
+    (x : α) : Bool :=
+  if appl.assignsDative then (HasCase.caseOf x).isSome
   else true
 
-/-- -st (caseless) cannot merge in SpecApplP ([wood-2015] §5.3.2). -/
+/-- -st (caseless: `caseOf = none`) cannot merge in SpecApplP
+    ([wood-2015] §5.3.2). -/
 theorem caseless_blocked_in_specAppl :
-    applLowRecipient.specCanBearCase false = false := rfl
+    applLowRecipient.specCanBearCase (none : Option Case) = false := rfl
 
 /-- A case-bearing DP CAN merge in SpecApplP. -/
 theorem caseful_ok_in_specAppl :
-    applLowRecipient.specCanBearCase true = true := rfl
+    applLowRecipient.specCanBearCase (some Case.dat) = true := rfl
 
 end Minimalist


### PR DESCRIPTION
Consolidation around the root Case API (mathlib namespace-follows-subject rule; files stay put).

- `Syntax.Case.{containmentRank,cahaSlavicRank,cahaLT,cahaLE,kshells,IsNonnominative,IsOblique}` → `Case.*`; scoped order is now `open scoped Case.Caha`; `containmentRank` codomain `Option Nat` → `Option (Fin 5)` matching `hierarchyRank`'s boundedness discipline; `Morphology.Case.Allomorphy.{HierarchyAdjacent,InventoryAdjacent}` → `Case.*`
- `HasCase` adoption at the last field-peeking case-bearers: `DPFeatures` (Case Filter restated as `(caseOf dp).isSome`), `CasedNP` (`getCaseOf` routes through `caseOf`), `ApplHead.specCanBearCase` (raw `Bool` → `[HasCase α]` carrier; Icelandic *-st* caselessness now derives from `caseOf = none`)