### PR TITLE
feat(Core/Intensional): operator extensionality, CF construal collapse

### DIFF
--- a/Linglib/Core/Logic/Intensional/Rigidity.lean
+++ b/Linglib/Core/Logic/Intensional/Rigidity.lean
@@ -30,6 +30,8 @@ versions; `Frame.lean` provides the IL-typed versions.
 - `StableCharacter` — Kaplan's stable character predicate
 - `ReferentialMode` — Partee 1973's three-way classification
 - `SitVarStatus` — Elbourne 2013's two-way classification
+- `IsExtensionalAt` — operator extensionality (local truth-functionality);
+  the operator-side dual of `IsRigid`
 -/
 
 namespace Core
@@ -344,3 +346,92 @@ theorem sitVarStatus_roundtrip (s : SitVarStatus) :
     rcases hm with rfl | rfl <;> rfl
 
 end Core.SitVarStatus
+
+namespace Core
+
+/-! ### Operator extensionality
+
+The operator-side dual of `IsRigid`: an operator on intensions is
+*extensional at* `w` when its value at `w` depends on its argument only
+through the argument's extension at `w` (local truth-functionality at
+`β = Prop`). Negation and the other pointwise connectives are extensional
+everywhere; quantifiers over indices (`Core.Logic.Modal.box`) are not.
+`Semantics.Gradability.Classification.isExtensional` (Kamp 1975's
+extensional adjective operators) is the entity-indexed `∀ w`-closure of
+this notion. -/
+
+/-- `O` is extensional at `w`: its value at `w` depends on the argument
+intension only through the argument's extension at `w`. Equivalently,
+`O · w` factors through evaluation at `w` (`isExtensionalAt_iff_factorsThrough`). -/
+def IsExtensionalAt {W α β : Type*} (O : (W → α) → W → β) (w : W) : Prop :=
+  ∀ p q : W → α, p w = q w → O p w = O q w
+
+/-- `O` is extensional: extensional at every index. -/
+def IsExtensional {W α β : Type*} (O : (W → α) → W → β) : Prop :=
+  ∀ w, IsExtensionalAt O w
+
+/-- Extensionality at `w` is `O · w` factoring through evaluation at `w`. -/
+theorem isExtensionalAt_iff_factorsThrough {W α β : Type*}
+    (O : (W → α) → W → β) (w : W) :
+    IsExtensionalAt O w ↔ Function.FactorsThrough (O · w) (· w) :=
+  ⟨fun h _ _ hpq => h _ _ hpq, fun h _ _ hpq => h hpq⟩
+
+/-- The iff form at `β = Prop`, the shape semantic theorems consume. -/
+theorem isExtensionalAt_iff {W α : Type*} (O : (W → α) → W → Prop) (w : W) :
+    IsExtensionalAt O w ↔
+      ∀ p q : W → α, p w = q w → (O p w ↔ O q w) :=
+  ⟨fun h p q hpq => iff_of_eq (h p q hpq), fun h p q hpq => propext (h p q hpq)⟩
+
+/-- Refutation by witness: a pair agreeing at `w` on which `O` differs. -/
+theorem not_isExtensionalAt_iff_exists_witness {W α β : Type*}
+    {O : (W → α) → W → β} {w : W} :
+    ¬ IsExtensionalAt O w ↔ ∃ p q, p w = q w ∧ O p w ≠ O q w := by
+  simp only [IsExtensionalAt, not_forall, exists_prop]
+
+namespace IsExtensionalAt
+
+variable {W : Type*} {w : W}
+
+/-- Evaluation itself is extensional. -/
+theorem eval {α : Type*} : IsExtensionalAt (fun (p : W → α) w' => p w') w :=
+  fun _ _ hpq => hpq
+
+/-- Constant operators are extensional. -/
+theorem const {α : Type*} (P : W → Prop) :
+    IsExtensionalAt (fun (_ : W → α) w' => P w') w :=
+  fun _ _ _ => rfl
+
+/-- Pointwise negation is extensional — "negation is not an intensional
+operator". -/
+theorem neg : IsExtensionalAt (fun p (w' : W) => ¬ p w') w :=
+  fun _ _ hpq => congrArg Not hpq
+
+/-- Extensional operators are closed under pointwise conjunction. -/
+theorem and {α : Type*} {O₁ O₂ : (W → α) → W → Prop}
+    (h₁ : IsExtensionalAt O₁ w) (h₂ : IsExtensionalAt O₂ w) :
+    IsExtensionalAt (fun p w' => O₁ p w' ∧ O₂ p w') w :=
+  fun p q hpq => congrArg₂ And (h₁ p q hpq) (h₂ p q hpq)
+
+/-- Extensional operators are closed under pointwise disjunction. -/
+theorem or {α : Type*} {O₁ O₂ : (W → α) → W → Prop}
+    (h₁ : IsExtensionalAt O₁ w) (h₂ : IsExtensionalAt O₂ w) :
+    IsExtensionalAt (fun p w' => O₁ p w' ∨ O₂ p w') w :=
+  fun p q hpq => congrArg₂ Or (h₁ p q hpq) (h₂ p q hpq)
+
+/-- Extensional operators are closed under pointwise negation. -/
+theorem not {α : Type*} {O : (W → α) → W → Prop}
+    (h : IsExtensionalAt O w) :
+    IsExtensionalAt (fun p w' => ¬ O p w') w :=
+  fun p q hpq => congrArg Not (h p q hpq)
+
+/-- Towers of extensional operators are extensional: if `O₁`, `O₂` are
+extensional at `w`, so is `O₂` applied over `O₁`'s output intension.
+Scope-inertness lifts through whole stacks of extensional operators. -/
+theorem comp {α β : Type*} {O₁ : (W → α) → W → β} {O₂ : (W → β) → W → Prop}
+    (h₂ : IsExtensionalAt O₂ w) (h₁ : IsExtensionalAt O₁ w) :
+    IsExtensionalAt (fun p w' => O₂ (fun s => O₁ p s) w') w :=
+  fun p q hpq => h₂ _ _ (h₁ p q hpq)
+
+end IsExtensionalAt
+
+end Core

--- a/Linglib/Semantics/Quantification/ChoiceFunction.lean
+++ b/Linglib/Semantics/Quantification/ChoiceFunction.lean
@@ -1,5 +1,6 @@
 import Mathlib.Init
 import Linglib.Core.Logic.Intensional.Rigidity
+import Linglib.Core.Logic.Modal.Defs
 import Linglib.Core.Logic.Quantification.Basic
 
 /-!
@@ -190,6 +191,101 @@ theorem SkolemCF.cross_world_variation {S E : Type*}
     f.evalAt .bound w₁ w₂ P ≠ f.evalAt .bound w₂ w₁ P := by
   simp [SkolemCF.evalAt]
   exact Ne.symm hVary
+
+/-! ### Intensional restrictors and construal collapse
+
+[owusu-2022]'s entry (67) — ⟦bí⟧ = λs.λP : CH(f_s). f_s(P(s)) — feeds one
+situation `s` to both the CF's skolem index and the restrictor. Here the
+restrictor is a genuine intension `Core.Intension S (E → Prop)`. Curry
+note: Owusu types P as ⟨e,st⟩ (entity-first) and writes P(s) informally
+for the s-extension {x | P(x)(s)}; `applyIntension` takes the
+situation-first transpose so that `P s` is that extension literally.
+
+The collapse/divergence pair formalizes [zimmermann-2026]'s gloss of the
+account — "as negation is not an intensional operator, the situational
+skolem argument of the choice function cannot be shifted away from the
+actual resource situation … resulting in wide scope only": operators
+extensional at the matrix situation (`Core.IsExtensionalAt`) neutralize
+the free/bound distinction for the situation pronoun
+(`bound_free_collapse`), while situation quantifiers (`box`:
+conditionals, attitudes) separate the construals
+(`bound_free_diverge_box`). The content-side dual — rigid restrictors
+collapse the readings under any operator — is [mirrazi-2024]'s fixed-set
+observation (`Studies/Mirrazi2024`'s `deRe_eq_pseudoDeDicto_when_rigid`).
+
+Scope notes: the dichotomy classifies *situation-index* construals under
+a single operator. Mixed towers (negation over a modal) correctly do not
+collapse — narrow readings under the modal remain available — and the
+individual skolem index carrying [owusu-2022]'s functional readings is
+beyond this fragment. -/
+
+open Core.Logic.Modal
+
+/-- Apply a skolemized CF at `s` to an intensional restrictor, evaluating
+both at the same index — [owusu-2022]'s f_s(P(s)) (entry (67), modulo
+currying; see the section docstring). -/
+def SkolemCF.applyIntension {S E : Type*} (f : SkolemCF S E) (s : S)
+    (P : Core.Intension S (E → Prop)) : E :=
+  f s (P s)
+
+/-- On rigid restrictors, `applyIntension` is the extensional `apply`. -/
+theorem SkolemCF.applyIntension_rigid {S E : Type*} (f : SkolemCF S E)
+    (s : S) (N : E → Prop) :
+    f.applyIntension s (Core.Intension.rigid N) = f.apply s N := rfl
+
+/-- `SitVarStatus`-dispatched intensional application: the `free`
+construal anchors the CF and restrictor to the context situation `s₀`;
+the `bound` construal rides the local index `sOp` supplied by a
+scope-taking operator. The intensional generalization of `evalAt`. -/
+def SkolemCF.applyIntensionAt {S E : Type*} (f : SkolemCF S E)
+    (status : SitVarStatus) (sOp s₀ : S)
+    (P : Core.Intension S (E → Prop)) : E :=
+  match status with
+  | .free  => f.applyIntension s₀ P
+  | .bound => f.applyIntension sOp P
+
+/-- `evalAt` is `applyIntensionAt` on a rigid restrictor. -/
+theorem SkolemCF.evalAt_eq_applyIntensionAt {S E : Type*}
+    (f : SkolemCF S E) (status : SitVarStatus) (w₀ wBound : S)
+    (N : E → Prop) :
+    f.evalAt status w₀ wBound N =
+      f.applyIntensionAt status wBound w₀ (Core.Intension.rigid N) := by
+  cases status <;> rfl
+
+/-- **Construal collapse**: under any operator extensional at the matrix
+situation `s₀`, the bound and free construals of the situation pronoun
+are truth-conditionally indistinguishable — for any CF and any
+intensional restrictor. Instantiated at pointwise negation
+(`Core.IsExtensionalAt.neg`) this derives wide-scope-only under
+negation; see `Studies/Zimmermann2026`. -/
+theorem bound_free_collapse {S E : Type*} {O : (S → Prop) → S → Prop}
+    {s₀ : S} (hO : Core.IsExtensionalAt O s₀) (f : SkolemCF S E)
+    (P : Core.Intension S (E → Prop)) (VP : E → S → Prop) :
+    (O (fun s => VP (f.applyIntensionAt .bound s s₀ P) s) s₀ ↔
+     O (fun s => VP (f.applyIntensionAt .free s s₀ P) s) s₀) :=
+  iff_of_eq (hO _ _ rfl)
+
+/-- **Construal divergence**: a situation quantifier (`box`) separates
+the bound and free construals — two situations, a restrictor whose
+extension varies, a CF tracking its index. -/
+theorem bound_free_diverge_box :
+    ∃ (S E : Type) (R : AccessRel S) (f : SkolemCF S E)
+      (P : Core.Intension S (E → Prop)) (VP : E → S → Prop) (s₀ : S),
+      box R (fun s => VP (f.applyIntensionAt .bound s s₀ P) s) s₀ ∧
+      ¬ box R (fun s => VP (f.applyIntensionAt .free s s₀ P) s) s₀ := by
+  refine ⟨Bool, Bool, universalR, fun s _ => s, fun s x => x = s,
+    fun x s => x = s, false, fun v _ => rfl, fun h => ?_⟩
+  exact Bool.noConfusion (h true trivial)
+
+/-- `box` is not extensional: the operator side of the dichotomy is
+genuine. -/
+theorem box_not_extensionalAt :
+    ∃ (S : Type) (R : AccessRel S) (s₀ : S),
+      ¬ Core.IsExtensionalAt (box R) s₀ := by
+  refine ⟨Bool, universalR, false,
+    Core.not_isExtensionalAt_iff_exists_witness.mpr ?_⟩
+  refine ⟨fun s => s = s, fun s => false = s, rfl, fun h => ?_⟩
+  exact Bool.noConfusion ((iff_of_eq h).mp (fun v _ => rfl) true trivial)
 
 /-! ### Bridge to B&C existential semantics
 

--- a/Linglib/Studies/Mirrazi2024.lean
+++ b/Linglib/Studies/Mirrazi2024.lean
@@ -159,7 +159,7 @@ def widePseudoDeDictoTC
     (vp : E → W → Prop)
     (w₀ : W) : Prop :=
   ∀ w' ∈ worlds, R agent w₀ w' →
-    ¬vp (f w' (nounProp w')) w'
+    ¬vp (f.applyIntensionAt .bound w' w₀ nounProp) w'
 
 /-- The truth conditions for the genuine wide scope de re reading.
 
@@ -175,7 +175,7 @@ def wideDeReTC
     (vp : E → W → Prop)
     (w₀ : W) : Prop :=
   ∀ w' ∈ worlds, R agent w₀ w' →
-    ¬vp (f w₀ (nounProp w₀)) w'
+    ¬vp (f.applyIntensionAt .free w' w₀ nounProp) w'
 
 /-- The key structural fact: de re and pseudo-de dicto differ exactly in
     whether the CF's world argument is bound (varies with w') or free
@@ -194,7 +194,8 @@ theorem deRe_eq_pseudoDeDicto_when_rigid
     (hRigidCF : ∀ w, f w = f w₀) :
     widePseudoDeDictoTC W E f R agent worlds nounProp vp w₀ ↔
     wideDeReTC W E f R agent worlds nounProp vp w₀ := by
-  unfold widePseudoDeDictoTC wideDeReTC
+  unfold widePseudoDeDictoTC wideDeReTC SkolemCF.applyIntensionAt
+    SkolemCF.applyIntension
   constructor <;> intro h w' hw' hR
   · rw [← hRigidNP w', ← hRigidCF w']; exact h w' hw' hR
   · rw [hRigidNP w', hRigidCF w']; exact h w' hw' hR

--- a/Linglib/Studies/Owusu2022.lean
+++ b/Linglib/Studies/Owusu2022.lean
@@ -21,6 +21,8 @@ the rival analyses in [bombi-2018], [schwarz-2013],
 * `Owusu2022.bi_wide_scope_specific` — the ∃ > ¬ reading of the `.bi`
   denotation is specific (its witness is the CF's choice), derived from
   the substrate's `cf_wide_scope_specific`.
+* `Owusu2022.tying_contentful` — entry (67)'s same-index tying of CF
+  and restrictor is contentful in both coordinates.
 * `Owusu2022.Onipa`, `Owusu2022.preferAma` — a two-person model of
   §3.2.5 ex. (21) *Onipa bí a-n-to dwom* 'a certain person didn't sing'.
 * `Owusu2022.bi_wide_scope_witnessed`, `Owusu2022.someone_sang` — on
@@ -35,11 +37,18 @@ binds no situation variable, so the CF's referent is fixed before
 negation applies and ¬ > ∃ is underivable. The general lemma states what
 the ∃ > ¬ reading entails; the two-person model witnesses it on a model
 falsifying ¬ > ∃ — the case where the readings come apart. The
-narrow-scope readings in conditional antecedents (situation pronoun
-bound locally) and the opaque readings under intensional verbs (a skolem
-*world* index, §3.3.3, following Mirrazi's world-skolemized CFs — a 2019
-ms., published as [mirrazi-2024]) need binding machinery beyond the
-fixed-situation fragment formalized here.
+operator-side derivation — extensional operators provably neutralize the
+situation pronoun's free/bound distinction, situation quantifiers
+provably separate it — lives in the substrate
+(`Semantics/Quantification/ChoiceFunction`: `bound_free_collapse`,
+`bound_free_diverge_box`). The narrow-scope readings in conditional
+antecedents (situation pronoun bound locally) and the opaque readings
+under intensional verbs (a skolem *world* index, §3.3.3, following
+Mirrazi's world-skolemized CFs — a 2019 ms., published as
+[mirrazi-2024]) need binding machinery beyond the fixed-situation
+fragment formalized here, as do the functional readings bound by
+individual quantifiers (the *biara* subject/object asymmetry via weak
+crossover on the individual skolem index).
 
 ## Todo
 
@@ -51,6 +60,11 @@ fixed-situation fragment formalized here.
 * Narrow-scope *bí* in conditional antecedents (situation pronoun bound
   locally) and opaque *bí* under intensional verbs (skolem world index,
   §3.3.3).
+* The individual skolem index: functional readings under *biara*
+  'every' and the subject/object asymmetry via weak crossover (§3.3).
+* The over-generation argument against free ∃-closure: the unavailable
+  ∃-below-negation reading (the analysis' (50)) and the
+  downward-entailing weak-truth-conditions scenario.
 * The *bí nó* (anaphoric definite) vs *nó bí* (partitive) order
   contrast (§3.4).
 -/
@@ -62,32 +76,52 @@ namespace Owusu2022
 open Akan.Determiners
 
 /-- [owusu-2022]'s denotation table for the Akan indefinite contrast:
-*bí* applies a skolemized choice function at the situation of its
-argument (entry (67)). The `.bare` cell is `none` — *not CF-analyzed
-here*, not undefined: bare NPs receive kind/indefinite readings
-(App. A) outside the CF analysis. -/
+*bí* applies a skolemized choice function to an intensional restrictor
+at the situation of its argument (entry (67); the same index feeds the
+CF and the restrictor — `SkolemCF.applyIntension`). The `.bare` cell is
+`none` — *not CF-analyzed here*, not undefined: bare NPs receive
+kind/indefinite readings (App. A) outside the CF analysis. -/
 def skolemDenot {S E : Type*} (f : SkolemCF S E) (s₀ : S) :
-    Indefinite → Option ((E → Prop) → E)
-  | .bi => some (f.apply s₀)
+    Indefinite → Option (Core.Intension S (E → Prop) → E)
+  | .bi => some (f.applyIntension s₀)
   | .bare => none
 
 @[simp] theorem skolemDenot_bi {S E : Type*} (f : SkolemCF S E) (s₀ : S) :
-    skolemDenot f s₀ .bi = some (f.apply s₀) := rfl
+    skolemDenot f s₀ .bi = some (f.applyIntension s₀) := rfl
 
 @[simp] theorem skolemDenot_bare {S E : Type*} (f : SkolemCF S E) (s₀ : S) :
     skolemDenot f s₀ .bare = none := rfl
 
 /-- [owusu-2022]'s wide-scope-under-negation prediction (§3.2.5, §3.3)
 for the `.bi` denotation: the ∃ > ¬ reading is *specific* — if the
-CF-selected member of the non-empty restrictor fails `VP`, some
-restrictor member fails `VP`, witnessed by the CF's choice. It does not
-entail the narrow-scope ¬ > ∃ (see the model below). -/
+CF-selected member of the (at `s₀`) non-empty restrictor fails `VP`,
+some restrictor member fails `VP`, witnessed by the CF's choice. It does
+not entail the narrow-scope ¬ > ∃ (see the model below). -/
 theorem bi_wide_scope_specific {S E : Type*}
     {f : SkolemCF S E} {s₀ : S} (hf : (f s₀).isCorrect)
-    {N VP : E → Prop} (hN : ∃ x, N x) :
-    ∀ d ∈ skolemDenot f s₀ .bi, ¬ VP (d N) → ∃ x, N x ∧ ¬ VP x := by
+    {P : Core.Intension S (E → Prop)} {VP : E → Prop} (hN : ∃ x, P s₀ x) :
+    ∀ d ∈ skolemDenot f s₀ .bi, ¬ VP (d P) → ∃ x, P s₀ x ∧ ¬ VP x := by
   simp only [skolemDenot_bi, Option.mem_some_iff, forall_eq']
   exact cf_wide_scope_specific (f s₀) hf hN
+
+/-- Entry (67)'s same-index tying is contentful in both coordinates:
+a single CF/restrictor pair where the tied denotation `f_s(P(s))`
+differs from the restrictor-shifted variant `f_s(P(s'))` and from the
+CF-index-shifted variant `f_s'(P(s))`. -/
+theorem tying_contentful :
+    ∃ (S E : Type) (f : SkolemCF S E) (P : Core.Intension S (E → Prop))
+      (s s' : S), f.applyIntension s P ≠ f s (P s') ∧
+        f.applyIntension s P ≠ f s' (P s) := by
+  classical
+  refine ⟨Bool, Bool × Bool,
+    fun s N => (s, if N (s, true) then true else false),
+    fun s x => x.2 = s, true, false, ?_, ?_⟩
+  · simp only [SkolemCF.applyIntension]
+    rw [if_pos trivial, if_neg (fun h => Bool.noConfusion h)]
+    decide
+  · simp only [SkolemCF.applyIntension]
+    rw [if_pos trivial]
+    decide
 
 /-! ### A two-person model of ex. (21)
 
@@ -121,11 +155,14 @@ theorem preferAma_correct : preferAma.isCorrect := by
     · exact absurd hPx h
 
 /-- The wide-scope (∃ > ¬) reading of ex. (21) is witnessed: the `.bi`
-denotation picks *Ama* from the *onipa* domain, and she did not sing. -/
+denotation picks *Ama* from the (rigid, on this one-situation model)
+*onipa* domain, and she did not sing. -/
 theorem bi_wide_scope_witnessed :
-    ∀ d ∈ skolemDenot preferAma () .bi, ¬ ToDwom (d (fun _ => True)) := by
+    ∀ d ∈ skolemDenot preferAma () .bi,
+      ¬ ToDwom (d (Core.Intension.rigid (fun _ => True))) := by
   simp only [skolemDenot_bi, Option.mem_some_iff, forall_eq']
-  simp only [SkolemCF.apply, preferAma, if_true]
+  simp only [SkolemCF.applyIntension, Core.Intension.rigid, preferAma,
+    if_true]
   exact id
 
 /-- The narrow-scope (¬ > ∃) reading of ex. (21) — 'no person sang' —

--- a/Linglib/Studies/Zimmermann2026.lean
+++ b/Linglib/Studies/Zimmermann2026.lean
@@ -28,6 +28,9 @@ and that the two-way African comparison discriminates between CF- and
   passenger model.
 * `Zimmermann2026.bi_reading_not_narrow` — (15): the CF reading is not
   the ¬ > ∃ reading on [owusu-2022]'s two-person model.
+* `Zimmermann2026.bi_negation_construals_collapse` — the review's
+  "negation is not an intensional operator" gloss: extensionality of
+  negation collapses the situation pronoun's bound/free construals.
 
 ## Implementation notes
 
@@ -80,6 +83,7 @@ end Hausa.Determiners.Indefinite
 namespace Zimmermann2026
 
 open Core.Quantification
+open Semantics.Quantification.ChoiceFunction
 
 /-- (13): under the ∃-analysis (16b), the two scopings of *wani* under
 negation are truth-conditionally distinct — on [zimmermann-2008]'s
@@ -98,8 +102,28 @@ is true while ¬ > ∃ is false. The interpretive gap that selects (16a)
 over (16b) for *bí*. -/
 theorem bi_reading_not_narrow :
     ∀ d ∈ Owusu2022.skolemDenot Owusu2022.preferAma () .bi,
-      ¬ ((¬ ∃ x, Owusu2022.ToDwom x) ↔ ¬ Owusu2022.ToDwom (d (fun _ => True))) :=
+      ¬ ((¬ ∃ x, Owusu2022.ToDwom x) ↔
+        ¬ Owusu2022.ToDwom (d (Core.Intension.rigid (fun _ => True)))) :=
   fun d hd h =>
     h.mpr (Owusu2022.bi_wide_scope_witnessed d hd) Owusu2022.someone_sang
+
+/-- The review's negation gloss, formalized: "as negation is not an
+intensional operator, the situational skolem argument of the choice
+function cannot be shifted away from the actual resource situation …
+resulting in wide scope only". Pointwise negation is extensional
+(`Core.IsExtensionalAt.neg`), so by the substrate's
+`bound_free_collapse` the bound and free construals of *bí*'s situation
+pronoun coincide under negation — for any CF and restrictor; the wide
+(free) construal is the only reading. Situation quantifiers separate
+the construals (`bound_free_diverge_box`), so the collapse is negation's
+extensionality at work, not a triviality. -/
+theorem bi_negation_construals_collapse {S E : Type*}
+    (f : SkolemCF S E) (s₀ : S) (P : Core.Intension S (E → Prop))
+    (VP : E → S → Prop) :
+    ((fun p s => ¬ p s)
+        (fun s => VP (f.applyIntensionAt .bound s s₀ P) s) s₀ ↔
+     (fun p s => ¬ p s)
+        (fun s => VP (f.applyIntensionAt .free s s₀ P) s) s₀) :=
+  bound_free_collapse Core.IsExtensionalAt.neg f P VP
 
 end Zimmermann2026


### PR DESCRIPTION
Deepens the Owusu 2022 / Zimmermann 2026 indefinite-scope formalization with the scope-neutralization dichotomy, after a four-lens design audit of the substrate shape.

- `Core.IsExtensionalAt` (Rigidity.lean): operator extensionality — the operator-side dual of `IsRigid`, with `FactorsThrough` bridge, closure lemmas (neg/and/or/not/comp), refutation-by-witness
- `SkolemCF.applyIntension` + `applyIntensionAt` (ChoiceFunction.lean): Owusu's entry (67) intensional restrictor; `evalAt` and `apply` recovered as rigid specializations; `bound_free_collapse` / `bound_free_diverge_box` derive wide-scope-only-under-negation
- Mirrazi2024 `widePseudoDeDictoTC`/`wideDeReTC` refactored to call `applyIntensionAt` (derive-don't-duplicate)
- Owusu2022 `skolemDenot` cells now intensional (faithful to (67)); `tying_contentful` certifies both index coordinates; Zimmermann2026 gains the negation-collapse corollary

Audit-driven: general eq-form over (W→α)→W→β not iff-only; primitive in Rigidity.lean not a new file; collapse family in substrate (2 paper consumers); intensional type fixes the audit's faithfulness flag on entry (67).