### PR TITLE
refactor(Features): factor the HasX.Compatible faithfulness layer through Flat

### DIFF
--- a/Linglib/Core/Order/Flat.lean
+++ b/Linglib/Core/Order/Flat.lean
@@ -186,6 +186,51 @@ theorem compat_iff [DecidableEq α] {a b : Flat α} :
     · rw [if_neg hxy]
       exact iff_of_false (by simp) (λ h => hxy (h x rfl y rfl))
 
+/-- Compatibility lifts through an `Option`-projection. If two raw values
+    `a b : Option U` are equal-or-absent — the shape of one clause of a
+    feature-bundle compatibility check, `(a.isNone || b.isNone || a == b)`
+    — then their images under any ingest `ι : U → Option F` are `Compat`
+    in `Flat F`. The order-theoretic core shared by the per-feature
+    agreement-faithfulness theorems (`HasX.compatible_hasX`); the
+    feature-specific part is only selecting `a`/`b`'s clause out of the
+    full bundle check. -/
+theorem compat_of_clause {U F : Type*} [DecidableEq U] [DecidableEq F]
+    (ι : U → Option F) {a b : Option U}
+    (h : (a.isNone || b.isNone || a == b) = true) :
+    Compat (α := Flat F) (a.bind ι) (b.bind ι) := by
+  rw [compat_iff]
+  intro x hx y hy
+  cases a with
+  | none => exact absurd hx.symm (Option.some_ne_none x)
+  | some u =>
+    cases b with
+    | none => exact absurd hy.symm (Option.some_ne_none y)
+    | some v =>
+      simp only [Option.isNone_some, Bool.false_or, beq_iff_eq,
+        Option.some.injEq] at h
+      subst h
+      exact Option.some.inj (hx.symm.trans hy)
+
+/-- `compat_of_clause` for a total ingest `g : U → F` (lifted via
+    `Option.map`). The `Compat` conclusion is stated in `.map` form so it
+    unifies with `.map`-shaped carrier projections. -/
+theorem compat_of_clause_map {U F : Type*} [DecidableEq U] [DecidableEq F]
+    (g : U → F) {a b : Option U}
+    (h : (a.isNone || b.isNone || a == b) = true) :
+    Compat (α := Flat F) (a.map g) (b.map g) := by
+  rw [compat_iff]
+  intro x hx y hy
+  cases a with
+  | none => exact absurd hx.symm (Option.some_ne_none x)
+  | some u =>
+    cases b with
+    | none => exact absurd hy.symm (Option.some_ne_none y)
+    | some v =>
+      simp only [Option.isNone_some, Bool.false_or, beq_iff_eq,
+        Option.some.injEq] at h
+      subst h
+      exact Option.some.inj (hx.symm.trans hy)
+
 /-! ### The flat lattice is non-distributive
 
 A flat slot with three distinct atoms, lifted with a top, is the

--- a/Linglib/Features/Case/Capabilities.lean
+++ b/Linglib/Features/Case/Capabilities.lean
@@ -39,12 +39,8 @@ variable {α β : Type*} [HasCase α] [HasCase β]
     the flat information order (`Compat`) — if both mark case, the values
     agree; unmarked carriers are wildcards. The concord-checking
     relation. -/
-def Compatible (a : α) (b : β) : Prop :=
+abbrev Compatible (a : α) (b : β) : Prop :=
   Compat (α := Flat Case) (caseOf a) (caseOf b)
-
-instance (a : α) (b : β) : Decidable (Compatible a b) := by
-  unfold Compatible
-  infer_instance
 
 theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
     Compatible b a :=
@@ -52,9 +48,8 @@ theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
 
 theorem compatible_of_none {a : α} (h : caseOf a = none) (b : β) :
     Compatible a b := by
-  unfold Compatible
-  rw [h]
-  exact bot_compat _
+  show Compat (α := Flat Case) (caseOf a) (caseOf b)
+  rw [h]; exact bot_compat _
 
 end HasCase
 
@@ -64,27 +59,8 @@ end HasCase
     `UD.MorphFeatures.compatible_hasPerson`. -/
 theorem UD.MorphFeatures.compatible_hasCase {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
-    HasCase.Compatible f1 f2 := by
-  unfold HasCase.Compatible
-  rw [Flat.compat_iff]
-  intro ca ha cb hb
-  have hc : (f1.case_.isNone || f2.case_.isNone || f1.case_ == f2.case_)
-      = true := by
+    HasCase.Compatible f1 f2 :=
+  Flat.compat_of_clause_map Case.fromUD <| by
     unfold UD.MorphFeatures.compatible at h
     simp only [Bool.and_eq_true] at h
     tauto
-  simp only [HasCase.caseOf] at ha hb
-  rcases h1 : f1.case_ with _ | u1
-  · rw [h1] at ha
-    exact absurd ha (by simp)
-  · rcases h2 : f2.case_ with _ | u2
-    · rw [h2] at hb
-      exact absurd hb (by simp)
-    · rw [h1] at ha
-      rw [h2] at hb
-      rw [h1, h2] at hc
-      simp only [Option.isNone_some, Bool.false_or, beq_iff_eq,
-        Option.some.injEq] at hc
-      simp only [Option.map_some] at ha hb
-      subst hc
-      exact (Option.some.inj ha).symm.trans (Option.some.inj hb)

--- a/Linglib/Features/Gender/Capabilities.lean
+++ b/Linglib/Features/Gender/Capabilities.lean
@@ -46,11 +46,8 @@ variable {α : Type*} {β : Type*} [HasGender α] [HasGender β]
     the slot values are compatible in the flat information order (`Compat`)
     — valued genders must coincide; an unvalued carrier is a wildcard.
     The gender axis of φ-agreement (`UD.MorphFeatures.compatible`). -/
-def Compatible (a : α) (b : β) : Prop :=
+abbrev Compatible (a : α) (b : β) : Prop :=
   Compat (α := Flat Gender) (genderOf a) (genderOf b)
-
-instance (a : α) (b : β) : Decidable (Compatible a b) := by
-  unfold Compatible; infer_instance
 
 theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
     Compatible b a :=
@@ -59,9 +56,8 @@ theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
 /-- An unvalued carrier is compatible with everything. -/
 theorem compatible_of_none {a : α} (h : genderOf a = none) (b : β) :
     Compatible a b := by
-  unfold Compatible
-  rw [h]
-  exact bot_compat _
+  show Compat (α := Flat Gender) (genderOf a) (genderOf b)
+  rw [h]; exact bot_compat _
 
 end HasGender
 
@@ -70,28 +66,8 @@ end HasGender
     (`UD.MorphFeatures.compatible`). -/
 theorem UD.MorphFeatures.compatible_hasGender {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
-    HasGender.Compatible f1 f2 := by
-  unfold HasGender.Compatible
-  rw [Flat.compat_iff]
-  intro ga ha gb hb
-  have hg : (f1.gender.isNone || f2.gender.isNone || f1.gender == f2.gender)
-      = true := by
+    HasGender.Compatible f1 f2 :=
+  Flat.compat_of_clause_map Gender.fromUD <| by
     unfold UD.MorphFeatures.compatible at h
     simp only [Bool.and_eq_true] at h
     tauto
-  simp only [HasGender.genderOf] at ha hb
-  rcases h1 : f1.gender with _ | u1
-  · rw [h1] at ha
-    exact absurd ha (Option.not_mem_none _)
-  · rcases h2 : f2.gender with _ | u2
-    · rw [h2] at hb
-      exact absurd hb (Option.not_mem_none _)
-    · rw [h1] at ha
-      rw [h2] at hb
-      rw [h1, h2] at hg
-      simp only [Option.isNone_some, Bool.false_or, beq_iff_eq,
-                 Option.some.injEq] at hg
-      subst hg
-      have ha' : Gender.fromUD u1 = ga := Option.some.inj ha
-      have hb' : Gender.fromUD u1 = gb := Option.some.inj hb
-      rw [← ha', ← hb']

--- a/Linglib/Features/Number/Capabilities.lean
+++ b/Linglib/Features/Number/Capabilities.lean
@@ -53,11 +53,8 @@ variable {α : Type*} {β : Type*} [HasNumber α] [HasNumber β]
     the slot values are compatible in the flat information order (`Compat`)
     — valued numbers must coincide; an unvalued carrier is a wildcard.
     The number axis of φ-agreement (`UD.MorphFeatures.compatible`). -/
-def Compatible (a : α) (b : β) : Prop :=
+abbrev Compatible (a : α) (b : β) : Prop :=
   Compat (α := Flat Number) (numberOf a) (numberOf b)
-
-instance (a : α) (b : β) : Decidable (Compatible a b) := by
-  unfold Compatible; infer_instance
 
 theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
     Compatible b a :=
@@ -66,9 +63,8 @@ theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
 /-- An unvalued carrier is compatible with everything. -/
 theorem compatible_of_none {a : α} (h : numberOf a = none) (b : β) :
     Compatible a b := by
-  unfold Compatible
-  rw [h]
-  exact bot_compat _
+  show Compat (α := Flat Number) (numberOf a) (numberOf b)
+  rw [h]; exact bot_compat _
 
 end HasNumber
 
@@ -77,28 +73,8 @@ end HasNumber
     (`UD.MorphFeatures.compatible`). -/
 theorem UD.MorphFeatures.compatible_hasNumber {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
-    HasNumber.Compatible f1 f2 := by
-  unfold HasNumber.Compatible
-  rw [Flat.compat_iff]
-  intro na ha nb hb
-  have hn : (f1.number.isNone || f2.number.isNone || f1.number == f2.number)
-      = true := by
+    HasNumber.Compatible f1 f2 :=
+  Flat.compat_of_clause Number.fromUD <| by
     unfold UD.MorphFeatures.compatible at h
     simp only [Bool.and_eq_true] at h
     tauto
-  simp only [HasNumber.numberOf] at ha hb
-  rcases h1 : f1.number with _ | u1
-  · rw [h1] at ha
-    exact absurd ha (Option.not_mem_none _)
-  · rcases h2 : f2.number with _ | u2
-    · rw [h2] at hb
-      exact absurd hb (Option.not_mem_none _)
-    · rw [h1] at ha
-      rw [h2] at hb
-      rw [h1, h2] at hn
-      simp only [Option.isNone_some, Bool.false_or, beq_iff_eq,
-                 Option.some.injEq] at hn
-      subst hn
-      simp only [Option.bind] at ha hb
-      rw [ha] at hb
-      exact Option.some.inj hb

--- a/Linglib/Features/Person/Capabilities.lean
+++ b/Linglib/Features/Person/Capabilities.lean
@@ -36,12 +36,8 @@ variable {α β : Type*} [HasPerson α] [HasPerson β]
 /-- Two carriers are person-compatible: the slot values are compatible in
     the flat information order (`Compat`) — if both mark person, the values
     agree; unmarked carriers are wildcards. -/
-def Compatible (a : α) (b : β) : Prop :=
+abbrev Compatible (a : α) (b : β) : Prop :=
   Compat (α := Flat Person) (personOf a) (personOf b)
-
-instance (a : α) (b : β) : Decidable (Compatible a b) := by
-  unfold Compatible
-  infer_instance
 
 theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
     Compatible b a :=
@@ -49,9 +45,8 @@ theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
 
 theorem compatible_of_none {a : α} (h : personOf a = none) (b : β) :
     Compatible a b := by
-  unfold Compatible
-  rw [h]
-  exact bot_compat _
+  show Compat (α := Flat Person) (personOf a) (personOf b)
+  rw [h]; exact bot_compat _
 
 end HasPerson
 
@@ -61,27 +56,8 @@ end HasPerson
     `UD.MorphFeatures.compatible_hasNumber`. -/
 theorem UD.MorphFeatures.compatible_hasPerson {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
-    HasPerson.Compatible f1 f2 := by
-  unfold HasPerson.Compatible
-  rw [Flat.compat_iff]
-  intro pa ha pb hb
-  have hp : (f1.person.isNone || f2.person.isNone || f1.person == f2.person)
-      = true := by
+    HasPerson.Compatible f1 f2 :=
+  Flat.compat_of_clause_map Person.fromUD <| by
     unfold UD.MorphFeatures.compatible at h
     simp only [Bool.and_eq_true] at h
     tauto
-  simp only [HasPerson.personOf] at ha hb
-  rcases h1 : f1.person with _ | u1
-  · rw [h1] at ha
-    exact absurd ha (by simp)
-  · rcases h2 : f2.person with _ | u2
-    · rw [h2] at hb
-      exact absurd hb (by simp)
-    · rw [h1] at ha
-      rw [h2] at hb
-      rw [h1, h2] at hp
-      simp only [Option.isNone_some, Bool.false_or, beq_iff_eq,
-        Option.some.injEq] at hp
-      simp only [Option.map_some] at ha hb
-      subst hp
-      exact (Option.some.inj ha).symm.trans (Option.some.inj hb)


### PR DESCRIPTION
Dedup the four near-identical `HasX.Compatible` mixins now that WechslerZlatic2000 consumes the surface non-vacuously.

- `Flat.compat_of_clause`/`compat_of_clause_map`: the order-theoretic core of the agreement-faithfulness proofs (lift a bundle-compatibility clause through an `Option`-projection), stated once in `Core/Order/Flat.lean` — no `MorphFeatures` dependency, so the data layer stays uncoupled
- `Features/{Person,Number,Gender,Case}/Capabilities.lean`: `Compatible` is now an `abbrev` (so `Decidable`/`comm`/`of_none` reuse the existing `Compat` API — the per-class `Decidable` instances are deleted), and each 27-line `compatible_hasX` proof collapses to a 5-line application of the shared core

Net −51 lines; API byte-for-byte preserved (WZ2000 concord `decide`, `Word.Agree`, CaseFilter all unchanged).