### PR TITLE
chore(Case): clear API debt — stale paths, ReflGen claim, native_decide, IsLowerSet bridge

### DIFF
--- a/Linglib/Core/Order/PartialRank.lean
+++ b/Linglib/Core/Order/PartialRank.lean
@@ -19,10 +19,11 @@ antisymmetry and the isolation.
 
 The order structure itself is mathlib's: `RankLT` is a strict order
 (`IsStrictOrder` instance below), so `partialOrderOfRank` is
-`partialOrderOfSO (RankLT r)` and `RankLE` is its reflexive closure
-(the `Relation.ReflGen` shape). This file's value-add is `RankLT`
-itself, its decidability, and the isolation lemmas. There is no total
-variant: isolation precludes totality whenever any element is unranked.
+`partialOrderOfSO (RankLT r)` and `RankLE` (`a = b ∨ RankLT r a b`) is
+exactly the reflexive-closure shape `partialOrderOfSO` uses for `≤`.
+This file's value-add is `RankLT` itself, its decidability, and the
+isolation lemmas. There is no total variant: isolation precludes
+totality whenever any element is unranked.
 
 ## Main declarations
 

--- a/Linglib/Morphology/Containment.lean
+++ b/Linglib/Morphology/Containment.lean
@@ -17,7 +17,7 @@ predicate over `List Nat` (a list of form-class indices), with both a
 computable `Bool` decision procedure and a `Prop` wrapper carrying a
 `Decidable` instance. Domain-specific instantiations live elsewhere:
 
-- Case allomorphy (`Core/Case/Allomorphy.lean`)
+- Case allomorphy (`Morphology/Case/Allomorphy.lean`)
 - Degree morphology (`Morphology/DegreeContainment.lean`)
 
 What *explains* the gap is theory-laden and contested. The DM

--- a/Linglib/Studies/AndersonJM2006.lean
+++ b/Linglib/Studies/AndersonJM2006.lean
@@ -71,7 +71,7 @@ open English.Predicates.Verbal
 that arise as their feature bundles, the subject-selection hierarchy over
 those bundles, predicate scenarios (argument-structure tuples of relations),
 and the morphological-case → relation map. Originally landed as standalone
-substrate in `Core/Case/FeatureBundle.lean`; inlined here because only this
+substrate in `Features/Case/Basic.lean`; inlined here because only this
 study consumes it. -/
 
 /-- Anderson's three first-order case features (Ch. 6). -/

--- a/Linglib/Studies/Caha2009.lean
+++ b/Linglib/Studies/Caha2009.lean
@@ -1,3 +1,4 @@
+import Mathlib.Order.UpperLower.Basic
 import Linglib.Features.Case.Basic
 import Linglib.Syntax.Case.Order
 import Linglib.Fragments.Dargwa.Case
@@ -45,7 +46,7 @@ inserts a "prepositional" between GEN and DAT ([caha-2009] (16),
 p. 12). Vocatives are explicitly excluded from Caha's scope
 ([caha-2009] §1.1 fn. 4, p. 9). For the substrate's encoding of
 this hierarchy and how it relates to Caha's actual sequence, see
-`Core/Case/Order.lean`.
+`Syntax/Case/Order.lean`.
 
 Of 22 Fragment case inventories, 19 conform; the three principled
 exceptions are: Dargwa (ergative — Caha is keyed to accusative
@@ -62,7 +63,7 @@ open scoped Case.Caha
 
 Does an inventory respect Caha's containment hierarchy? True iff `inv`
 is downward-closed under the scoped Caha order (`Case.Caha`;
-containment) defined in `Core/Case/Order.lean`: whenever `c ∈ inv` and
+containment) defined in `Syntax/Case/Order.lean`: whenever `c ∈ inv` and
 `d ≤ c`, then `d ∈ inv`. Off-hierarchy cases (ERG, ABS, INST, COM, …)
 impose no constraint — in the Caha order they only have `c ≤ c`, so
 the downward-closure condition is vacuous. On-hierarchy `c` of rank
@@ -78,6 +79,16 @@ def RespectsCahaContainment (inv : Finset Case) : Prop :=
 
 instance (inv : Finset Case) : Decidable (RespectsCahaContainment inv) := by
   unfold RespectsCahaContainment; infer_instance
+
+/-- Containment-respect is `IsLowerSet` under the scoped Caha order — the
+    Caha analogue of `Case.isValidInventory_iff_ordConnected` (Blake).
+    The two contiguity predicates on `Finset Case` are thus both
+    order-theoretic closure properties, on the partial Caha order and the
+    total Blake rank respectively. -/
+theorem respectsCahaContainment_iff_isLowerSet (inv : Finset Case) :
+    RespectsCahaContainment inv ↔ IsLowerSet (inv : Set Case) := by
+  simp only [RespectsCahaContainment, IsLowerSet, Finset.mem_coe]
+  exact ⟨fun h _ _ hba ha => h _ ha _ hba, fun h _ hc _ hdc => h hdc hc⟩
 
 /-! ## Slavic substrate: containment lemmas
 

--- a/Linglib/Studies/KeenanComrie1977.lean
+++ b/Linglib/Studies/KeenanComrie1977.lean
@@ -355,7 +355,7 @@ theorem kc_at_least_as_detailed_as_wals :
 /-! HC₂ ("any RC-forming strategy must apply to a continuous segment of the
 AH") is a paper-anchored claim. The contiguity machinery (`contiguousOnAH`,
 `AHPosition.rank`) lives in `Typology/RelativeClause/Basic.lean` because it
-mirrors `Core/Case/Hierarchy.lean::validInventory` and is genuinely
+mirrors `Features/Case/Basic.lean`'s `IsValidInventory` and is genuinely
 framework-agnostic. The specific contiguous-segment witnesses below
 exemplify HC₂ on the AH and are part of [keenan-comrie-1977]'s core
 argumentation. -/

--- a/Linglib/Studies/Pesetsky2013.lean
+++ b/Linglib/Studies/Pesetsky2013.lean
@@ -565,7 +565,7 @@ theorem russian_obliques_in_pesetsky_core :
     (NOM⊂ACC⊂GEN⊂DAT⊂LOC⊂...), coincides with the standard
     five-case core. Pesetsky additionally puts INST in `pesetskyCore`
     (via `.P`) — this is the case Caha's hierarchy doesn't rank
-    (compare `Core/Case/Order.lean`'s docstring listing
+    (compare `Syntax/Case/Order.lean`'s docstring listing
     "ERG, ABS, INST, COM" as off-hierarchy).
 
     A non-trivial *agreement* — not refutation. The two frameworks

--- a/Linglib/Studies/Woolford1997.lean
+++ b/Linglib/Studies/Woolford1997.lean
@@ -265,19 +265,19 @@ def predictDitransitive (p : DitransPattern) : Bool :=
 
 /-- All allowed transitive patterns are predicted as allowed. -/
 theorem trans_allowed_predicted :
-    npTransAllowed.all predictTransitive = true := by native_decide
+    npTransAllowed.all predictTransitive = true := by decide
 
 /-- All prohibited transitive patterns are predicted as prohibited. -/
 theorem trans_prohibited_predicted :
-    npTransProhibited.all (λ p => !predictTransitive p) = true := by native_decide
+    npTransProhibited.all (λ p => !predictTransitive p) = true := by decide
 
 /-- The allowed/prohibited lists are disjoint. -/
 theorem trans_disjoint :
-    npTransAllowed.all (λ p => npTransProhibited.all (· != p)) = true := by native_decide
+    npTransAllowed.all (λ p => npTransProhibited.all (· != p)) = true := by decide
 
 /-- The allowed/prohibited lists cover all NOM/ERG × ACC/OBJ combinations. -/
 theorem trans_complete :
-    npTransAllowed.length + npTransProhibited.length = 4 := by native_decide
+    npTransAllowed.length + npTransProhibited.length = 4 := by decide
 
 /-- maxAcc for transitives: NOM subject → 1 ACC slot. -/
 theorem trans_nom_maxAcc : maxAcc 2 0 = 1 := rfl
@@ -291,21 +291,21 @@ theorem trans_erg_maxAcc : maxAcc 2 1 = 0 := rfl
 
 /-- All allowed ditransitive patterns are predicted. -/
 theorem ditrans_allowed_predicted :
-    npDitransAllowed.all predictDitransitive = true := by native_decide
+    npDitransAllowed.all predictDitransitive = true := by decide
 
 /-- All prohibited ditransitive patterns are rejected. -/
 theorem ditrans_prohibited_predicted :
-    npDitransProhibited.all (λ p => !predictDitransitive p) = true := by native_decide
+    npDitransProhibited.all (λ p => !predictDitransitive p) = true := by decide
 
 /-- The allowed/prohibited lists are disjoint. -/
 theorem ditrans_disjoint :
     npDitransAllowed.all (λ p => npDitransProhibited.all (· != p)) = true := by
-  native_decide
+  decide
 
 /-- The allowed/prohibited lists cover all 12 NOM/ERG × {ACC,OBJ,DAT}² patterns
     (excluding DAT-DAT which never arises). -/
 theorem ditrans_complete :
-    npDitransAllowed.length + npDitransProhibited.length = 12 := by native_decide
+    npDitransAllowed.length + npDitransProhibited.length = 12 := by decide
 
 /-- maxAcc for ditransitives: ERG subject, no DAT → 1 ACC slot. -/
 theorem ditrans_erg_maxAcc : maxAcc 3 1 = 1 := rfl
@@ -460,12 +460,12 @@ theorem kalkatungu_ditrans :
     passes the prediction function. -/
 theorem all_predicted_trans_valid :
     [nezPerce, thangu, kalkatungu].all (λ params =>
-      (availableTransPatterns params).all predictTransitive) = true := by native_decide
+      (availableTransPatterns params).all predictTransitive) = true := by decide
 
 /-- All predicted ditransitive patterns pass the prediction function. -/
 theorem all_predicted_ditrans_valid :
     [nezPerce, thangu, kalkatungu].all (λ params =>
-      (availableDitransPatterns params).all predictDitransitive) = true := by native_decide
+      (availableDitransPatterns params).all predictDitransitive) = true := by decide
 
 -- ============================================================================
 -- § 13: Mapping to Case
@@ -523,7 +523,7 @@ theorem agree_on_nom_acc_transitive :
     getCaseOf "obj" depResult = some .acc ∧
     (TransPattern.mk .nom .acc).object.toCoreCase = .acc := by
   constructor
-  · native_decide
+  · decide
   · rfl
 
 /-- Where they diverge: Woolford distinguishes OBJ from ACC.

--- a/Linglib/Syntax/Agreement/Controller.lean
+++ b/Linglib/Syntax/Agreement/Controller.lean
@@ -56,7 +56,7 @@ With the parametric form, the projection round-trips:
 - **Case** — case-marking (nom/erg/abs/dat/...) is orthogonal to
   grammatical role. Quirky-case subjects in Icelandic, ergative-case
   agents in Tsakhur, etc. are case phenomena, not controller-role
-  phenomena. Case lives in `Core/Case/`.
+  phenomena. Case lives in `Features/Case/` and `Syntax/Case/`.
 - **φ-features** (person, number, gender) — these are properties of
   the CONTROLLER NP that determine agreement values. Not encoded in
   the controller-role enum itself.


### PR DESCRIPTION
Audit debt pass before the spatial-decomposition extension.

- 6 stale `Core/Case/` docstring paths → live targets (`Features/Case/Basic`, `Syntax/Case/Order`, `Morphology/Case/Allomorphy`); they rendered as broken doc-gen4 cross-refs
- `PartialRank.lean`: drop the false `Relation.ReflGen` claim (`RankLE` is `a = b ∨ RankLT`, the `partialOrderOfSO` reflexive-closure shape)
- `Woolford1997.lean`: 11 `native_decide` → `decide` (project rule; builds fast)
- `Caha2009.lean`: `respectsCahaContainment_iff_isLowerSet` — the Caha analogue of Blake's `isValidInventory_iff_ordConnected`, making both contiguity predicates order-theoretic closure properties

Note: the audit's proposed rank-reindex abstraction was *not* built — `partialOrderOfRank` already abstracts (the future spatial orientation rank is just another instance), and the only reindex consumer would vacate `cahaLT_iff_kshells_ssubset`'s certification by defining `kshells` from the rank.