### PR TITLE
feat(Syntax/Case): unify case containment as an object; Pantcheva directional dimension + denotation

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1191,6 +1191,7 @@ import Linglib.Studies.Haspelmath2021
 import Linglib.Studies.Karlsson2017
 import Linglib.Studies.Woolford1997
 import Linglib.Studies.Marantz1991
+import Linglib.Studies.Pantcheva2011
 import Linglib.Studies.Pesetsky2013
 import Linglib.Studies.BakerVinokurova2010
 import Linglib.Studies.Comrie1989

--- a/Linglib/Fragments/Finnish/Case.lean
+++ b/Linglib/Fragments/Finnish/Case.lean
@@ -1,6 +1,7 @@
 import Linglib.Features.Case.Basic
 import Linglib.Diachronic.CaseGrammaticalization
 import Linglib.Morphology.Case.Allomorphy
+import Linglib.Syntax.Case.Order
 open Morphology.Case.Allomorphy
 
 /-!
@@ -45,15 +46,19 @@ namespace Finnish.Case
     abessive added to Case; internal/external local pairs collapsed):
     - NOM →.nom, ACC →.acc (pronoun/total-object accusative)
     - GEN →.gen, PART →.part
-    - INE/ADE →.loc, ELA/ABL →.abl, ILL/ALL →.all
+    - the 6 local cases as *distinct* cells: INE/ELA/ILL (interior),
+      ADE/ABL/ALL (exterior) — via the shared `Region × PathDir`
+      decomposition (`Syntax/Case/Order.lean`)
     - ESS →.ess, TRANSL →.transl, ABESS →.abess
     - INSTR →.inst, COM →.com -/
 def caseInventory : Finset Case :=
-  {.nom, .acc, .gen, .part, .loc, .abl, .all, .ess, .transl, .abess, .inst, .com}
+  {.nom, .acc, .gen, .part, .ine, .ade, .ela, .abl, .ill, .all,
+   .ess, .transl, .abess, .inst, .com}
 
-/-- Finnish's mapped inventory **fails** strict contiguity: GEN (rank 5)
-    and LOC (rank 3) have no DAT (rank 4) between them. Finnish uses
-    allative for recipient function instead of a dedicated dative.
+/-- Finnish's inventory **fails** strict contiguity: the spatial tier
+    (rank ≤ 2) and GEN/core (rank ≥ 5) have no LOC (rank 3) or DAT
+    (rank 4) between them. Finnish uses allative for recipient function
+    instead of a dedicated dative.
 
     This illustrates Blake's hedge: the hierarchy holds "usually" but
     languages like Finnish fill the dative slot with a local case
@@ -113,22 +118,34 @@ structure LocalCase where
   coreCase : Case
   deriving DecidableEq, Repr, Inhabited
 
-/-- The 3×2 local case matrix.
+/-- The Finnish directional dimension as the shared `Case.PathDir`
+    (static = the locative Place base). -/
+def Direction.toPathDir : Direction → Case.PathDir
+  | .static => .place
+  | .source => .source
+  | .goal => .goal
 
-    |           | Internal     | External     |
-    |-----------|-------------|-------------|
+/-- The Finnish location type as the shared `Case.Region`. -/
+def LocationType.toRegion : LocationType → Case.Region
+  | .internal => .interior
+  | .external => .exterior
+
+/-- The 3×2 local case matrix, mapping each cell to its *distinct* `Case`
+    via the shared `Region × PathDir` decomposition
+    (`Syntax/Case/Order.lean`) — no longer collapsing internal/external
+    (cf. the deleted `static_collapses_to_loc`).
+
+    |           | Internal      | External      |
+    |-----------|---------------|---------------|
     | Static    | inessive -ssA | adessive -llA |
     | Source    | elative -stA  | ablative -ltA |
-    | Goal      | illative -Vn  | allative -lle |
-
-    Case collapses each row into a single value (static →.loc,
-    source →.abl, goal →.all). The matrix reveals the full structure. -/
+    | Goal      | illative -Vn  | allative -lle | -/
 def localCaseMatrix : Direction → LocationType → LocalCase
-  | .static, .internal => ⟨"inessive",  "-ssA", .static, .internal, .loc⟩
-  | .static, .external => ⟨"adessive",  "-llA", .static, .external, .loc⟩
-  | .source, .internal => ⟨"elative",   "-stA", .source, .internal, .abl⟩
+  | .static, .internal => ⟨"inessive",  "-ssA", .static, .internal, .ine⟩
+  | .static, .external => ⟨"adessive",  "-llA", .static, .external, .ade⟩
+  | .source, .internal => ⟨"elative",   "-stA", .source, .internal, .ela⟩
   | .source, .external => ⟨"ablative",  "-ltA", .source, .external, .abl⟩
-  | .goal,   .internal => ⟨"illative",  "-Vn",  .goal,   .internal, .all⟩
+  | .goal,   .internal => ⟨"illative",  "-Vn",  .goal,   .internal, .ill⟩
   | .goal,   .external => ⟨"allative",  "-lle", .goal,   .external, .all⟩
 
 /-- All 6 local cases as a flat list. -/
@@ -140,21 +157,19 @@ def allLocalCases : List LocalCase :=
   , localCaseMatrix .goal   .internal
   , localCaseMatrix .goal   .external ]
 
-/-- Case collapses each direction row: both internal and external
-    static cases map to.loc. -/
-theorem static_collapses_to_loc :
-    (localCaseMatrix .static .internal).coreCase =
-    (localCaseMatrix .static .external).coreCase := rfl
+/-- Each cell's `Case` is exactly what the shared `Case.toCase`
+    decomposition builds from its `Region × PathDir` coordinates — the
+    matrix is the shared spatial decomposition, not a private table. -/
+theorem coreCase_eq_toCase (d : Direction) (l : LocationType) :
+    some (localCaseMatrix d l).coreCase =
+      Case.toCase l.toRegion d.toPathDir := by
+  cases d <;> cases l <;> rfl
 
-/-- Both source cases map to.abl. -/
-theorem source_collapses_to_abl :
-    (localCaseMatrix .source .internal).coreCase =
-    (localCaseMatrix .source .external).coreCase := rfl
-
-/-- Both goal cases map to.all. -/
-theorem goal_collapses_to_all :
-    (localCaseMatrix .goal .internal).coreCase =
-    (localCaseMatrix .goal .external).coreCase := rfl
+/-- The 6 local cases are 6 *distinct* `Case` cells — the faithful
+    decomposition keeps internal and external apart (the lossy collapse
+    of the old `*_collapses_to_*` theorems is gone). -/
+theorem localCases_distinct :
+    (allLocalCases.map LocalCase.coreCase).Nodup := by decide
 
 /-- All 6 local cases appear in the full Finnish inventory. -/
 theorem localCases_subset_inventory :

--- a/Linglib/Fragments/Hungarian/Case.lean
+++ b/Linglib/Fragments/Hungarian/Case.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Case.Basic
-import Linglib.Features.Case.Basic
+import Linglib.Syntax.Case.Order
 /-!
 # Hungarian Case Inventory [kenesei-vago-fenyvesi-1998] [rounds-2001] [caha-2008]
 
@@ -40,21 +40,19 @@ This Fragment exposes a 9-element `Finset Case` capturing the
 broad case-functions that participate in Blake's hierarchy:
 
 - **Grammatical**: NOM (∅), ACC (-t), DAT (-nak / -nek)
-- **Local — 3 × 3 matrix collapsed to direction only**:
-    - static (→ `.loc`): inessive (-ban / -ben), adessive (-nál / -nél),
-      superessive (-n / -on / -en / -ön)
-    - source (→ `.abl`): elative (-ból / -ből), ablative (-tól / -től),
-      delative (-ról / -ről)
-    - goal   (→ `.all`): illative (-ba / -be), allative
-      (-hoz / -hez / -höz), sublative (-ra / -re)
+- **Local — the full 3 × 3 matrix**, as distinct cells via the shared
+  `Region × PathDir` decomposition (`Syntax/Case/Order.lean`):
+    - interior: inessive (-ban / -ben → `.ine`), elative
+      (-ból / -ből → `.ela`), illative (-ba / -be → `.ill`)
+    - exterior: adessive (-nál / -nél → `.ade`), ablative
+      (-tól / -től → `.abl`), allative (-hoz → `.all`)
+    - surface: superessive (-n / -on → `.sup`), delative
+      (-ról / -ről → `.del`), sublative (-ra / -re → `.sub`)
 - **Other**: INST (-val / -vel), COM (= INS-form per [kenesei-vago-fenyvesi-1998];
   separate Finset element here), CAUS (-ért, "causal-final")
 
-**What `Case` can express but this inventory omits**:
+**What `Case` still omits**:
 
-- `.sup`, `.sub`, `.del` (the surface-series spatial cells) would
-  preserve Hungarian's surface-row local cases distinctly rather than
-  collapsing to the direction-only triple.
 - `.ess` (essive-modal -ul / -ül), `.transl` (translative -vá / -vé),
   `.ter` (terminative -ig), `.tem` (temporal -kor) — all attested in
   both grammars, omitted here.
@@ -68,12 +66,27 @@ broad case-functions that participate in Blake's hierarchy:
 
 namespace Hungarian.Case
 
-/-- Hungarian case inventory: 9-element sample of `Case`. The
-    omission of `.gen` reflects the descriptive-grammar consensus
-    ([kenesei-vago-fenyvesi-1998], [rounds-2001]) and
+/-- Hungarian case inventory. The 9 local cases are now distinct cells
+    (the full 3 × 3 surface/interior/exterior × static/source/goal
+    matrix). The omission of `.gen` reflects the descriptive-grammar
+    consensus ([kenesei-vago-fenyvesi-1998], [rounds-2001]) and
     [caha-2008] §5 — Hungarian has no morphological genitive. -/
 def caseInventory : Finset Case :=
-  {.nom, .acc, .dat, .loc, .abl, .all, .inst, .com, .caus}
+  {.nom, .acc, .dat, .ine, .ade, .sup, .ela, .abl, .del, .ill, .all, .sub,
+   .inst, .com, .caus}
+
+/-- Hungarian's 9 local cases as `Region × PathDir` coordinates — the
+    full 3 × 3 matrix the shared decomposition makes expressible. -/
+def localCases : List (Case.Region × Case.PathDir) :=
+  [ (.interior, .place), (.exterior, .place), (.surface, .place),
+    (.interior, .source), (.exterior, .source), (.surface, .source),
+    (.interior, .goal), (.exterior, .goal), (.surface, .goal) ]
+
+/-- All 9 local cases project to *distinct* `Case` cells — the surface
+    series (`.sup`/`.del`/`.sub`) is preserved, not collapsed to the
+    direction-only triple. -/
+theorem localCases_distinct :
+    (localCases.filterMap (fun rd => Case.toCase rd.1 rd.2)).Nodup := by decide
 
 /-- Hungarian fails Blake's strict contiguity at rank 5 (GEN), since
     the inventory has DAT (rank 4) without GEN. Parallels Finnish's

--- a/Linglib/Studies/Caha2009.lean
+++ b/Linglib/Studies/Caha2009.lean
@@ -204,12 +204,17 @@ theorem ukrainian_respectsCaha :
 theorem dargwa_not_respectsCaha :
     ¬ RespectsCahaContainment Dargwa.Case.caseInventory := by decide
 
-/-- Finnish has no dedicated dative — the allative (-lle) covers
-    recipient function ([blake-1994] Ch. 6, ALL → DAT extension;
-    [karlsson-2017] confirms). The inventory has rank 4 (LOC)
-    without rank 3 (DAT). -/
-theorem finnish_not_respectsCaha :
-    ¬ RespectsCahaContainment Finnish.Case.caseInventory := by decide
+/-- Finnish *respects* nominal Caha containment — vacuously. Under the
+    faithful spatial decomposition (`Syntax/Case/Order.lean`), Finnish's
+    locatives are the off-chain spatial cells (INE/ELA/ILL, ADE/ABL/ALL,
+    on the orthogonal *directional* containment, not the nominal one), so
+    its only on-nominal-chain cases are NOM/ACC/GEN — downward-closed.
+    The richness Finnish shows is on the directional dimension
+    ([pantcheva-2011]); on the nominal chain it has no LOC-without-DAT
+    gap. (Its allative-for-dative recipient function lives in
+    `Finnish.Case.allative_extends_to_dative`.) -/
+theorem finnish_respectsCaha :
+    RespectsCahaContainment Finnish.Case.caseInventory := by decide
 
 /-- Hungarian has no morphological genitive — both standard reference
     grammars ([kenesei-vago-fenyvesi-1998] §1.10, [rounds-2001]

--- a/Linglib/Studies/Pantcheva2011.lean
+++ b/Linglib/Studies/Pantcheva2011.lean
@@ -1,0 +1,117 @@
+import Linglib.Morphology.Containment
+import Linglib.Syntax.Case.Order
+
+/-!
+# Pantcheva 2011: syncretism in directional expressions
+[pantcheva-2011] [bobaljik-2012] [caha-2009]
+
+The directional containment object Place ⊂ Goal ⊂ Source ⊂ Route lives in
+`Syntax/Case/Order.lean` (`Case.PathDir`); this study tests its
+**syncretism prediction**. Of the logically possible syncretism patterns
+over the four path roles, only a few are attested, under two constraints
+([pantcheva-2011] §9.2):
+
+* **\*ABA** (contiguity): a syncretism targets only *adjacent* heads on
+  the containment chain — the framework-neutral
+  `Morphology.Containment` object, *the same* used for nominal case
+  allomorphy ([caha-2009], [bobaljik-2012]).
+* **\*A&¬A**: Goal and Source never share a marker. Source is the
+  semantic *reversal* of Goal ([pantcheva-2011] §9.2.2), so a
+  Goal=Source marker would be contradictory — a *pragmatic* constraint,
+  not a structural one.
+
+Together they cut the 15 set-partitions of {Place, Goal, Source, Route}
+to **four** possible patterns (`possible_syncretisms`), Pantcheva's
+Types 1–4. (Her Tables 9.2/9.3 enumerate 14, omitting one *ABA-excluded
+pattern — Goal=Route skipping Source; the enumeration here is over all
+15.) Attested instantiations (her Table 9.4): English *at*/*to*/*from*
+(all distinct, Type 1); Estonian `-l`/`-l-le`/`-l-t` and Imbabura
+Quechua `-pi`/`-man`/`-man-da`, where the Source marker morphologically
+contains the Goal marker — the shell containment made visible; Georgian
+Location=Goal (Type 3, her Table 9.1).
+
+## Main declarations
+
+* `Pantcheva2011.possible` — the two-constraint filter (*ABA via
+  `Containment`, *A&¬A via `goalSourceMerged`)
+* `Pantcheva2011.possible_syncretisms` — exactly the four attested
+  patterns; `four_possible`, `aba_excluded`, `ana_excluded`
+* `Pantcheva2011.source_contains_goal` — the morphological-containment
+  fact, read off the shared `PathDir` shell decomposition
+-/
+
+namespace Pantcheva2011
+
+open Morphology.Containment (isContiguous)
+
+/-- A syncretism pattern over the four path roles, in containment order
+    [Place, Goal, Source, Route], as form-class indices. -/
+abbrev Pattern := List Nat
+
+/-- The 15 canonical syncretism patterns — restricted-growth strings over
+    four positions, i.e. the set-partitions of {Place, Goal, Source,
+    Route} up to relabeling. -/
+def allPatterns : List Pattern :=
+  [[0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 0, 1, 1], [0, 0, 1, 2],
+   [0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 0, 2], [0, 1, 1, 0], [0, 1, 1, 1],
+   [0, 1, 1, 2], [0, 1, 2, 0], [0, 1, 2, 1], [0, 1, 2, 2], [0, 1, 2, 3]]
+
+/-- **\*A&¬A**: Goal (position 1) and Source (position 2) share a form
+    class. Forbidden — Source is the reversal of Goal, so a Goal=Source
+    marker is contradictory ([pantcheva-2011] §9.2.2). -/
+def goalSourceMerged : Pattern → Bool
+  | _ :: g :: s :: _ => g == s
+  | _ => false
+
+/-- A syncretism pattern is **possible** iff it is contiguous (\*ABA, via
+    the shared `Morphology.Containment` object) and keeps Goal distinct
+    from Source (\*A&¬A). -/
+def possible (p : Pattern) : Bool :=
+  isContiguous p && !goalSourceMerged p
+
+/-- **The syncretism typology** ([pantcheva-2011] Tables 9.2/9.3): of the
+    15 logically possible patterns, exactly four are attested — the
+    contiguous ones keeping Goal and Source distinct. These are her
+    Types 1–4: all-distinct (Type 1, English), Place=Goal (Type 3,
+    Georgian), Source=Route (Type 2), and Place=Goal with Source=Route
+    (Type 4). -/
+theorem possible_syncretisms :
+    allPatterns.filter possible =
+      [[0, 0, 1, 1], [0, 0, 1, 2], [0, 1, 2, 2], [0, 1, 2, 3]] := by decide
+
+/-- Exactly four syncretism patterns are possible. -/
+theorem four_possible : (allPatterns.filter possible).length = 4 := by decide
+
+/-- Seven of the eleven excluded patterns violate \*ABA (non-contiguous —
+    a syncretism spanning non-adjacent path roles). -/
+theorem aba_excluded :
+    (allPatterns.filter (fun p => !isContiguous p)).length = 7 := by decide
+
+/-- The remaining four excluded patterns are contiguous but merge Goal
+    with Source — the \*A&¬A constraint, unique to the directional domain
+    (the nominal Caha containment has no analogue). -/
+theorem ana_excluded :
+    (allPatterns.filter
+      (fun p => isContiguous p && goalSourceMerged p)).length = 4 := by
+  decide
+
+/-! ### Morphological containment (Table 4.2)
+
+The Source structure contains the Goal structure, visible where the
+Source marker contains the Goal marker (Quechua `-man` ⊂ `-man-da`).
+This is the shell containment of the shared `PathDir` object — not a
+fact re-stipulated here, but read off `Case.PathDir.shells`. -/
+
+/-- Source contains Goal contains Place, as shell-stack inclusion — the
+    morphological-containment fact, from the substrate decomposition. -/
+theorem source_contains_goal :
+    Case.PathDir.place.shells ⊂ Case.PathDir.goal.shells ∧
+    Case.PathDir.goal.shells ⊂ Case.PathDir.source.shells ∧
+    Case.PathDir.source.shells ⊂ Case.PathDir.route.shells := by
+  refine ⟨?_, ?_, ?_⟩ <;> decide
+
+/-- Georgian's Location=Goal syncretism ([pantcheva-2011] Table 9.1) is
+    one of the four possible patterns (Type 3). -/
+theorem georgian_loc_goal_possible : possible [0, 0, 1, 2] = true := by decide
+
+end Pantcheva2011

--- a/Linglib/Syntax/Case/Order.lean
+++ b/Linglib/Syntax/Case/Order.lean
@@ -2,36 +2,39 @@ import Mathlib.Data.Finset.Basic
 import Linglib.Core.Order.PartialRank
 import Linglib.Features.Case.Basic
 /-!
-# Caha Containment Order on Case
-[caha-2009] [mcfadden-2018]
+# Containment orders on Case
+[caha-2009] [pantcheva-2011] [mcfadden-2018]
 
-Caha's containment order on `Case`, as a **scoped** instance
-(`open scoped Case.Caha` to use `≤`): theoretical orders are borne by
-features as opt-in commitments, not as global instances — the
-inventory's default is order-free. Each case on the hierarchy literally
-*contains* the representations of all cases below it:
+The **object**: a case feature carries a containment structure — its
+value is a downward-closed stack of nested feature shells, and one value
+*contains* another iff its shell stack does. The order is then the
+partial-rank order `Core.Order.partialOrderOfRank` over a shell-rank
+(unranked elements isolated), and the empirical *ABA syncretism law over
+it is the framework-neutral `Morphology.Containment.ViolatesABA`
+(syncretism targets only adjacent cells). Both the order gadget and the
+*ABA predicate name no paper.
 
-    [[[[[ NOM ] ACC ] GEN ] DAT ] LOC ]
+This file holds the two case-feature **instances** of that object,
+organized by the object, not by author:
 
-Cases without a `containmentRank` (ERG, ABS, INST, COM, …) are silent —
-incomparable with on-hierarchy cases under `≤`, except for reflexivity.
-That silence is the theoretical content: Caha's hierarchy is silent on
-those cases. The order itself is `Core.Order.partialOrderOfRank` —
-the partial-rank gadget whose unranked elements are isolated — so
-reflexivity/transitivity/antisymmetry come from the substrate, not from
-per-hierarchy hand proofs.
+* **Nominal containment** ([caha-2009]): NOM ⊂ ACC ⊂ GEN ⊂ DAT ⊂ LOC,
+  via `containmentRank`/`kshells`. ERG/ABS/INST/… are off-hierarchy
+  (silent — `containmentRank → none`), and that silence is the
+  theoretical content.
+* **Directional containment** ([pantcheva-2011]): Place ⊂ Goal ⊂ Source
+  ⊂ Route on the orthogonal *path* dimension, via `PathDir`/`dirRank`.
+  The spatial case cells (`ine`/`ela`/`ill`, `ade`/`abl`/`all`,
+  `sup`/`del`/`sub`) decompose as `Region × PathDir` (`spatialDecomp`),
+  so cells inert under the nominal hierarchy gain structure.
 
-`kshells` states the containment claim structurally — each on-hierarchy
-case is a downward-closed stack of case shells — and
-`cahaLT_iff_kshells_ssubset` certifies that the rank order is its
-shadow: the order is derived from the decomposition, not stipulated.
+Both reuse the *same* `partialOrderOfRank` gadget and certify the order
+as the shadow of the shell decomposition (`*_iff_kshells_ssubset` /
+`*_iff_shells_ssubset`) — derived, not stipulated.
 
-All declarations live in the root `Case` namespace (the namespace
-follows the subject, not the file location — this file stays in
-`Syntax/Case/` as nanosyntactic theory substrate). Other orders
-(Blake's typological frequency in `Features/Case/Basic.lean`,
-per-language syncretism graphs) likewise live as named `def`s or scoped
-instances rather than competing global instances on `Case`.
+Orders are **scoped** instances (`open scoped Case.Caha`): theoretical
+orders are opt-in commitments, never global instances on the inventory.
+Declarations live in the root `Case` namespace (the namespace follows the
+subject; the file stays in `Syntax/Case/` as nanosyntactic substrate).
 -/
 
 namespace Case
@@ -209,5 +212,125 @@ example : (.dat : Case) ≤ .loc := by decide
 /-- Off-hierarchy cases (ERG) are incomparable with on-hierarchy cases. -/
 example : ¬ ((.erg : Case) ≤ .nom) := by decide
 example : ¬ ((.nom : Case) ≤ .erg) := by decide
+
+/-! ### Directional containment ([pantcheva-2011])
+
+The second instance of the containment object, on the orthogonal *path*
+dimension: Place ⊂ Goal ⊂ Source ⊂ Route ([pantcheva-2011]'s functional
+sequence, ex. 2). A Source path structurally contains a Goal path —
+reflected morphologically where the Source marker contains the Goal
+marker (Imbabura Quechua Goal `-man` ⊂ Source `-man-da`; Estonian
+`-l` ⊂ `-l-le` ⊂ `-l-t`). Unlike the nominal containment, every path
+head is on the chain, so the order is total. -/
+
+/-- The path-direction heads, in containment order
+    Place ⊂ Goal ⊂ Source ⊂ Route ([pantcheva-2011] ex. 2). -/
+inductive PathDir where
+  /-- Place: static location (the locative base; no motion). -/
+  | place
+  /-- Goal: motion *to* (built on Place). -/
+  | goal
+  /-- Source: motion *from* (built on Goal — the reversal). -/
+  | source
+  /-- Route: motion *via/through* (built on Source). -/
+  | route
+  deriving DecidableEq, Repr, Fintype
+
+/-- Containment rank: how many path heads the direction nests.
+    Place=0 ⊂ Goal=1 ⊂ Source=2 ⊂ Route=3. -/
+def PathDir.rank : PathDir → Fin 4
+  | .place => 0
+  | .goal => 1
+  | .source => 2
+  | .route => 3
+
+/-- The shell stack of a path direction: the downward-closed set of path
+    heads its structure contains ([pantcheva-2011]'s nested
+    [Route [Source [Goal [Place]]]]). Stipulated independently of `rank`;
+    `lt_iff_shells_ssubset` certifies they agree. -/
+def PathDir.shells : PathDir → Finset (Fin 4)
+  | .place => {0}
+  | .goal => {0, 1}
+  | .source => {0, 1, 2}
+  | .route => {0, 1, 2, 3}
+
+/-- **The order is the shadow of the decomposition**: directional
+    containment (strict rank) coincides with strict inclusion of shell
+    stacks — the directional analogue of `cahaLT_iff_kshells_ssubset`. -/
+theorem PathDir.lt_iff_shells_ssubset (d₁ d₂ : PathDir) :
+    d₁.rank < d₂.rank ↔ d₁.shells ⊂ d₂.shells := by
+  revert d₁ d₂; decide
+
+/-- The path direction a spatial case expresses, if any. Robust across
+    the inventory — direction is determinable even on the cells where
+    region is conflated (`regionOf` is the partial companion). The
+    spatial case cells decompose as `Region × PathDir`. -/
+def dirOf : Case → Option PathDir
+  | .loc | .ine | .ade | .sup => some .place
+  | .ill | .all | .sub => some .goal
+  | .ela | .abl | .del => some .source
+  | .perl => some .route
+  | _ => none
+
+/-! ### The orthogonal Region axis
+
+The `Place`-internal localization Pantcheva does *not* decompose
+(interior/surface/exterior), orthogonal to `PathDir`. Spatial case
+systems (Finnish, Hungarian, Daghestanian) cross it with direction. -/
+
+/-- The spatial region a case localizes in. Orthogonal to `PathDir`. -/
+inductive Region where
+  /-- Interior: in/into/out-of (Finnish inessive/illative/elative). -/
+  | interior
+  /-- Surface: on/onto/off-of (Hungarian superessive/sublative/delative). -/
+  | surface
+  /-- Exterior: at/to/from (Finnish adessive/allative/ablative). -/
+  | exterior
+  deriving DecidableEq, Repr, Fintype
+
+/-- Build a spatial case from its `Region × PathDir` decomposition — the
+    constructor direction spatial-case fragments consume. The 3 × 3
+    region-specific cells; `route` is region-neutral in these
+    inventories (`none`). -/
+def toCase : Region → PathDir → Option Case
+  | .interior, .place => some .ine
+  | .interior, .goal => some .ill
+  | .interior, .source => some .ela
+  | .surface, .place => some .sup
+  | .surface, .goal => some .sub
+  | .surface, .source => some .del
+  | .exterior, .place => some .ade
+  | .exterior, .goal => some .all
+  | .exterior, .source => some .abl
+  | _, .route => none
+
+/-- The region a case localizes in, under the spatial reading. The
+    exterior series is `ade`/`all`/`abl` (Finnish's external local
+    cases). **Conflation caveat**: `all`/`abl` double as the *general*
+    allative/ablative (Latin-type, region-neutral); the spatial
+    decomposition reads them as exterior-goal/source, the use the
+    analytical split `Features/Case/Basic.lean` anticipates separating.
+    `loc` is the genuinely region-neutral general locative (`none`). -/
+def regionOf : Case → Option Region
+  | .ine | .ela | .ill => some .interior
+  | .sup | .del | .sub => some .surface
+  | .ade | .all | .abl => some .exterior
+  | _ => none
+
+/-- Analyze a spatial case into `Region × PathDir`, where both are
+    determinable (lossy on region-conflated cells; the faithful inverse
+    of `toCase` on the 3 × 3 region-specific cells). -/
+def spatialDecomp (c : Case) : Option (Region × PathDir) :=
+  match regionOf c, dirOf c with
+  | some r, some d => some (r, d)
+  | _, _ => none
+
+/-- `toCase` and `spatialDecomp` are inverse on the region-specific
+    cells — the decomposition round-trips where region is not conflated.
+    (`route` is region-neutral, hence `none` on both sides.) -/
+theorem spatialDecomp_toCase (r : Region) (d : PathDir) :
+    (toCase r d).bind spatialDecomp =
+      (toCase r d).map (fun _ => (r, d)) := by
+  cases r <;> cases d <;> decide
 
 end Case

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -140,6 +140,18 @@
   role      = {formalized},
   sources   = {Phenomena/Reference/Studies/SikosEtAl2021.lean;Phenomena/Reference/Studies/SikosEtAl2021Bridge.lean}
 }% REF: George, B. R. (2011). Question Embedding and the Semantics of Answers. UCLA PhD dissertation.
+% REF: Pantcheva, M. B. (2011). Decomposing Path: The Nanosyntax of Directional Expressions.
+@phdthesis{pantcheva-2011,
+  author    = {Pantcheva, Marina Blagoeva},
+  year      = {2011},
+  title     = {Decomposing {P}ath: The Nanosyntax of Directional Expressions},
+  school    = {University of Troms{\o}},
+  type      = {Ph.D. Dissertation},
+  subfield  = {morphosyntax/case},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Syntax/Case/Order.lean}
+}
 @phdthesis{george-2011,
   author    = {George, Benjamin Ross},
   year      = {2011},


### PR DESCRIPTION
Centers the case-containment substrate on the **object**, not the paper: a graded shell chain (`Core.Order.partialOrderOfRank`) with the *ABA syncretism law (`Morphology.Containment.ViolatesABA`) — both framework-agnostic. The nominal (Caha) and directional (Pantcheva) containments are two **instances**, papers as citations.

- `Syntax/Case/Order.lean` reframed 'Caha file' → 'Containment orders on Case'; adds the directional object `PathDir` (Place⊂Goal⊂Source⊂Route) with `shells` + `lt_iff_shells_ssubset` (the directional twin of `cahaLT_iff_kshells_ssubset`), plus `Region`/`toCase`/`spatialDecomp` connecting the previously-inert spatial cells
- `Studies/Pantcheva2011.lean`: of the 15 syncretism partitions over {Place,Goal,Source,Route}, exactly 4 possible — *ABA (shared `Containment` object) + *A&¬A (Goal=Source forbidden, flagged semantic); `source_contains_goal` read off the substrate shells
- **Finnish/Hungarian retargeted** onto the shared decomposition: the lossy 6→3 / 3×3→direction collapses are gone (faithful distinct cells; the `*_collapses_to_*` anti-theorems deleted). Finnish now *respects* nominal Caha containment — correct: its locatives are off the nominal chain
- read from the Pantcheva (2011) thesis; `pantcheva-2011` bib added (verified fields, handle omitted)

Deferred: Dargwa's 8-localization island retarget; the person/number/gender ContainmentPair grand-bridge (verification found no *ABA consumer there — not built, to avoid forced abstraction over 10 merged files).