### PR TITLE
feat(Core/Order): polymorphic markedness cutoff; derive prominence monotonicity from it

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -92,6 +92,7 @@ import Linglib.Core.Order.Normality
 import Linglib.Core.Order.SimilarityOrdering
 import Linglib.Core.Order.Plausibility
 import Linglib.Core.Order.Satisfaction
+import Linglib.Core.Order.Markedness
 import Linglib.Core.Order.PartialRank
 import Linglib.Core.Order.PartialUnify
 import Linglib.Core.Order.Flat

--- a/Linglib/Core/Order/Markedness.lean
+++ b/Linglib/Core/Order/Markedness.lean
@@ -1,0 +1,43 @@
+import Mathlib.Order.UpperLower.Basic
+import Mathlib.Order.Interval.Set.Basic
+
+/-!
+# Markedness cutoffs on a scale
+
+The order-theoretic core of differential-marking cutoffs, generic over any
+scale (any `[Preorder S]`). A cutoff marks one end of the scale; the marked
+region is an `Set.Ici`/`Set.Iic`, hence an upper/lower set — the "staircase"
+monotonicity ([aissen-2003]) that every prominence scale (animacy,
+definiteness, person, …) shares. Stated once here over the order **mixin**,
+so each scale instantiates it rather than re-proving by `decide`.
+
+## Main declarations
+
+* `Core.Order.atOrAbove` / `atOrBelow` — the cutoff predicates (`c ≤ ·` / `· ≤ c`)
+* `Core.Order.atOrAbove_isUpperSet` / `atOrBelow_isLowerSet` — monotonicity,
+  for any scale
+-/
+
+namespace Core.Order
+
+variable {S : Type*}
+
+/-- The "marked above a cutoff" predicate on a scale: at or above `c`. The
+    prominent-end cutoff shared by every differential-marking scale. -/
+def atOrAbove [Preorder S] (c s : S) : Prop := c ≤ s
+
+/-- The "marked below a cutoff" predicate: at or below `c` (the anti-monotone
+    cutoff, for high-default roles). -/
+def atOrBelow [Preorder S] (c s : S) : Prop := s ≤ c
+
+/-- **Marking the prominent end is monotone**: the marked region of an
+    `atOrAbove` cutoff is an upper set, for ANY scale. Replaces per-scale
+    `decide` proofs of the staircase property. -/
+theorem atOrAbove_isUpperSet [Preorder S] (c : S) :
+    IsUpperSet {s | atOrAbove c s} := fun _ _ hab h => le_trans h hab
+
+/-- Marking the non-prominent end is anti-monotone: a lower set, any scale. -/
+theorem atOrBelow_isLowerSet [Preorder S] (c : S) :
+    IsLowerSet {s | atOrBelow c s} := fun _ _ hab h => le_trans hab h
+
+end Core.Order

--- a/Linglib/Features/Prominence.lean
+++ b/Linglib/Features/Prominence.lean
@@ -395,6 +395,46 @@ def DifferentialMarkingProfile.isMonotoneA (p : DifferentialMarkingProfile) : Bo
             else true
       else true
 
+/-- **Wiring to the scale order**: pointwise monotonicity (marking closed under
+    moving *up* both scales) yields the `isMonotoneP` staircase. A
+    one-dimensional cutoff discharges the hypothesis with `le_trans` on the
+    scale's `LinearOrder` (`Core.Order.atOrAbove_isUpperSet`), so cutoff
+    profiles inherit monotonicity from the order rather than `decide`. -/
+theorem DifferentialMarkingProfile.isMonotoneP_of (p : DifferentialMarkingProfile)
+    (h : ∀ {a a' : AnimacyLevel} {d d' : DefinitenessLevel},
+      a ≤ a' → d ≤ d' → p.marks a d = true → p.marks a' d' = true) :
+    p.isMonotoneP = true := by
+  simp only [isMonotoneP, List.all_eq_true]
+  intro a _ d _
+  split
+  · next hm =>
+    simp only [List.all_eq_true]
+    intro a' _ d' _
+    split
+    · next hcond =>
+      simp only [Bool.and_eq_true, decide_eq_true_eq, ge_iff_le] at hcond
+      exact h hcond.1 hcond.2 hm
+    · rfl
+  · rfl
+
+/-- Anti-monotone (lower-set) counterpart of `isMonotoneP_of`, for A/R roles. -/
+theorem DifferentialMarkingProfile.isMonotoneA_of (p : DifferentialMarkingProfile)
+    (h : ∀ {a a' : AnimacyLevel} {d d' : DefinitenessLevel},
+      a' ≤ a → d' ≤ d → p.marks a d = true → p.marks a' d' = true) :
+    p.isMonotoneA = true := by
+  simp only [isMonotoneA, List.all_eq_true]
+  intro a _ d _
+  split
+  · next hm =>
+    simp only [List.all_eq_true]
+    intro a' _ d' _
+    split
+    · next hcond =>
+      simp only [Bool.and_eq_true, decide_eq_true_eq] at hcond
+      exact h hcond.1 hcond.2 hm
+    · rfl
+  · rfl
+
 /-- Role-appropriate monotonicity: low-default roles (P, T) must be monotone
     (upper set), high-default roles (A, R) must be anti-monotone (lower set).
     S profiles are vacuously monotone. -/
@@ -456,25 +496,40 @@ def DifferentialMarkingProfile.definitenessCutoffA
 -- § 9: One-Dimensional Monotonicity Theorems
 -- ============================================================================
 
-/-- Animacy-cutoff P profiles are always monotone. -/
+/-- Animacy-cutoff P profiles are always monotone — the marked region is the
+    upper set `Core.Order.atOrAbove cutoff` on the animacy axis, lifted through
+    `isMonotoneP_of` by `le_trans`. -/
 theorem animacyCutoffP_monotone (ch : MarkingChannel) (cutoff : AnimacyLevel) :
     (DifferentialMarkingProfile.animacyCutoffP "" ch cutoff).isMonotone = true := by
-  cases ch <;> cases cutoff <;> decide
+  apply DifferentialMarkingProfile.isMonotoneP_of
+  intro a a' _ _ haa' _ hm
+  simp only [DifferentialMarkingProfile.animacyCutoffP, decide_eq_true_eq] at hm ⊢
+  exact Core.Order.atOrAbove_isUpperSet cutoff haa' hm
 
-/-- Definiteness-cutoff P profiles are always monotone. -/
+/-- Definiteness-cutoff P profiles are always monotone — same `isMonotoneP_of`
+    + `le_trans`, now on the definiteness axis. -/
 theorem definitenessCutoffP_monotone (ch : MarkingChannel) (cutoff : DefinitenessLevel) :
     (DifferentialMarkingProfile.definitenessCutoffP "" ch cutoff).isMonotone = true := by
-  cases ch <;> cases cutoff <;> decide
+  apply DifferentialMarkingProfile.isMonotoneP_of
+  intro _ _ d d' _ hdd' hm
+  simp only [DifferentialMarkingProfile.definitenessCutoffP, decide_eq_true_eq] at hm ⊢
+  exact Core.Order.atOrAbove_isUpperSet cutoff hdd' hm
 
-/-- Animacy-cutoff A profiles are always monotone (anti-monotone). -/
+/-- Animacy-cutoff A profiles are always anti-monotone (lower set). -/
 theorem animacyCutoffA_monotone (ch : MarkingChannel) (cutoff : AnimacyLevel) :
     (DifferentialMarkingProfile.animacyCutoffA "" ch cutoff).isMonotone = true := by
-  cases ch <;> cases cutoff <;> decide
+  apply DifferentialMarkingProfile.isMonotoneA_of
+  intro a a' _ _ ha'a _ hm
+  simp only [DifferentialMarkingProfile.animacyCutoffA, decide_eq_true_eq] at hm ⊢
+  exact Core.Order.atOrBelow_isLowerSet cutoff ha'a hm
 
-/-- Definiteness-cutoff A profiles are always monotone (anti-monotone). -/
+/-- Definiteness-cutoff A profiles are always anti-monotone (lower set). -/
 theorem definitenessCutoffA_monotone (ch : MarkingChannel) (cutoff : DefinitenessLevel) :
     (DifferentialMarkingProfile.definitenessCutoffA "" ch cutoff).isMonotone = true := by
-  cases ch <;> cases cutoff <;> decide
+  apply DifferentialMarkingProfile.isMonotoneA_of
+  intro _ _ d d' _ hd'd hm
+  simp only [DifferentialMarkingProfile.definitenessCutoffA, decide_eq_true_eq] at hm ⊢
+  exact Core.Order.atOrBelow_isLowerSet cutoff hd'd hm
 
 -- ============================================================================
 -- § 10: Mirror Image Theorem ([just-2024], §3)

--- a/Linglib/Features/Prominence.lean
+++ b/Linglib/Features/Prominence.lean
@@ -1,5 +1,6 @@
 import Mathlib.Order.Nat
 import Mathlib.Tactic.DeriveFintype
+import Linglib.Core.Order.Markedness
 import Linglib.Features.Person.Basic
 
 /-!
@@ -80,7 +81,7 @@ instance : LinearOrder AnimacyLevel :=
 /-- All animacy levels (exhaustive enumeration for finite verification). -/
 def AnimacyLevel.all : List AnimacyLevel := [.human, .animate, .inanimate]
 
-theorem AnimacyLevel.all_length : AnimacyLevel.all.length = 3 := by native_decide
+theorem AnimacyLevel.all_length : AnimacyLevel.all.length = 3 := by decide
 
 -- ============================================================================
 -- § 1b: Fine-Grained Animacy Hierarchy ([corbett-2000], [smith-stark-1974])
@@ -147,7 +148,7 @@ theorem AnimacyRank.hierarchy_ordering :
     AnimacyRank.higherAnimal.toNat > AnimacyRank.lowerAnimal.toNat ∧
     AnimacyRank.lowerAnimal.toNat > AnimacyRank.discreteInanimate.toNat ∧
     AnimacyRank.discreteInanimate.toNat > AnimacyRank.nondiscreteInanimate.toNat := by
-  native_decide
+  decide
 
 /-- The hierarchy predicts: if a language marks plural at rank r, it marks
     plural at all ranks above r. -/
@@ -185,12 +186,18 @@ def DefinitenessLevel.rank : DefinitenessLevel → Nat
   | .indefiniteSpecific => 1
   | .nonSpecific        => 0
 
+/-- NonSpecific < IndefiniteSpecific < Definite < ProperName < PersonalPronoun
+    (ordered by prominence rank). -/
+instance : LinearOrder DefinitenessLevel :=
+  LinearOrder.lift' DefinitenessLevel.rank
+    (fun a b h => by cases a <;> cases b <;> simp_all [DefinitenessLevel.rank])
+
 /-- All definiteness levels (exhaustive enumeration). -/
 def DefinitenessLevel.all : List DefinitenessLevel :=
   [.personalPronoun, .properName, .definite, .indefiniteSpecific, .nonSpecific]
 
 theorem DefinitenessLevel.all_length : DefinitenessLevel.all.length = 5 := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 3: Scale Ordering Verification
@@ -418,30 +425,32 @@ def DifferentialMarkingProfile.isDefinitenessOnly (p : DifferentialMarkingProfil
 -- ============================================================================
 
 /-- Construct a one-dimensional animacy-based P-marking profile: P arguments
-    at or above the cutoff are marked. (For A marking, use `animacyCutoffA`.) -/
+    at or above the cutoff are marked. (For A marking, use `animacyCutoffA`.)
+    The cutoff is the scale's `LinearOrder` (`Core.Order.atOrAbove`), not a
+    raw rank comparison. -/
 def DifferentialMarkingProfile.animacyCutoffP
     (name : String) (channel : MarkingChannel) (cutoff : AnimacyLevel)
     : DifferentialMarkingProfile :=
-  { name, role := .P, channel, marks := λ a _ => a.rank ≥ cutoff.rank }
+  { name, role := .P, channel, marks := λ a _ => decide (cutoff ≤ a) }
 
 /-- Construct a one-dimensional definiteness-based P-marking profile. -/
 def DifferentialMarkingProfile.definitenessCutoffP
     (name : String) (channel : MarkingChannel) (cutoff : DefinitenessLevel)
     : DifferentialMarkingProfile :=
-  { name, role := .P, channel, marks := λ _ d => d.rank ≥ cutoff.rank }
+  { name, role := .P, channel, marks := λ _ d => decide (cutoff ≤ d) }
 
 /-- Construct a one-dimensional animacy-based A-marking profile: A arguments
     at or below the cutoff are marked (anti-monotone / lower set). -/
 def DifferentialMarkingProfile.animacyCutoffA
     (name : String) (channel : MarkingChannel) (cutoff : AnimacyLevel)
     : DifferentialMarkingProfile :=
-  { name, role := .A, channel, marks := λ a _ => a.rank ≤ cutoff.rank }
+  { name, role := .A, channel, marks := λ a _ => decide (a ≤ cutoff) }
 
 /-- Construct a one-dimensional definiteness-based A-marking profile. -/
 def DifferentialMarkingProfile.definitenessCutoffA
     (name : String) (channel : MarkingChannel) (cutoff : DefinitenessLevel)
     : DifferentialMarkingProfile :=
-  { name, role := .A, channel, marks := λ _ d => d.rank ≤ cutoff.rank }
+  { name, role := .A, channel, marks := λ _ d => decide (d ≤ cutoff) }
 
 -- ============================================================================
 -- § 9: One-Dimensional Monotonicity Theorems
@@ -450,22 +459,22 @@ def DifferentialMarkingProfile.definitenessCutoffA
 /-- Animacy-cutoff P profiles are always monotone. -/
 theorem animacyCutoffP_monotone (ch : MarkingChannel) (cutoff : AnimacyLevel) :
     (DifferentialMarkingProfile.animacyCutoffP "" ch cutoff).isMonotone = true := by
-  cases ch <;> cases cutoff <;> native_decide
+  cases ch <;> cases cutoff <;> decide
 
 /-- Definiteness-cutoff P profiles are always monotone. -/
 theorem definitenessCutoffP_monotone (ch : MarkingChannel) (cutoff : DefinitenessLevel) :
     (DifferentialMarkingProfile.definitenessCutoffP "" ch cutoff).isMonotone = true := by
-  cases ch <;> cases cutoff <;> native_decide
+  cases ch <;> cases cutoff <;> decide
 
 /-- Animacy-cutoff A profiles are always monotone (anti-monotone). -/
 theorem animacyCutoffA_monotone (ch : MarkingChannel) (cutoff : AnimacyLevel) :
     (DifferentialMarkingProfile.animacyCutoffA "" ch cutoff).isMonotone = true := by
-  cases ch <;> cases cutoff <;> native_decide
+  cases ch <;> cases cutoff <;> decide
 
 /-- Definiteness-cutoff A profiles are always monotone (anti-monotone). -/
 theorem definitenessCutoffA_monotone (ch : MarkingChannel) (cutoff : DefinitenessLevel) :
     (DifferentialMarkingProfile.definitenessCutoffA "" ch cutoff).isMonotone = true := by
-  cases ch <;> cases cutoff <;> native_decide
+  cases ch <;> cases cutoff <;> decide
 
 -- ============================================================================
 -- § 10: Mirror Image Theorem ([just-2024], §3)
@@ -480,7 +489,7 @@ theorem animacy_mirror_image (cutoff : AnimacyLevel) :
       DefinitenessLevel.all.all (λ d =>
         (DifferentialMarkingProfile.animacyCutoffP "" .indexing cutoff).marks a d ||
         (DifferentialMarkingProfile.animacyCutoffA "" .indexing cutoff).marks a d)) = true := by
-  cases cutoff <;> native_decide
+  cases cutoff <;> decide
 
 -- ============================================================================
 -- § 11: Scenarios ([haspelmath-2021], §6)

--- a/Linglib/Studies/Aissen2003.lean
+++ b/Linglib/Studies/Aissen2003.lean
@@ -129,26 +129,35 @@ def allDOMProfiles : List DOMProfile :=
   [spanishDOM, russianDOM, turkishDOM, hebrewDOM, persianDOM,
    catalanDOM, hindiDOM, noDOMProfile]
 
-theorem allDOMProfiles_count : allDOMProfiles.length = 8 := by native_decide
+theorem allDOMProfiles_count : allDOMProfiles.length = 8 := by decide
 
 -- §0.1 Per-language monotonicity (Aissen's central prediction: every DOM
--- pattern forms an upper set in the bidimensional animacy × definiteness grid)
+-- pattern forms an upper set in the bidimensional animacy × definiteness
+-- grid). The one-dimensional cutoff languages inherit it directly from the
+-- generic `animacyCutoffP_monotone`/`definitenessCutoffP_monotone` (proved
+-- once over the scale's `LinearOrder`), rather than re-deciding per language.
 
-theorem spanish_monotone : spanishDOM.isMonotone = true := by native_decide
-theorem russian_monotone : russianDOM.isMonotone = true := by native_decide
-theorem turkish_monotone : turkishDOM.isMonotone = true := by native_decide
-theorem hebrew_monotone : hebrewDOM.isMonotone = true := by native_decide
-theorem persian_monotone : persianDOM.isMonotone = true := by native_decide
-theorem catalan_monotone : catalanDOM.isMonotone = true := by native_decide
-theorem hindi_monotone : hindiDOM.isMonotone = true := by native_decide
-theorem no_dom_monotone : noDOMProfile.isMonotone = true := by native_decide
+theorem spanish_monotone : spanishDOM.isMonotone = true :=
+  animacyCutoffP_monotone .flagging .human
+theorem russian_monotone : russianDOM.isMonotone = true :=
+  animacyCutoffP_monotone .flagging .animate
+theorem turkish_monotone : turkishDOM.isMonotone = true :=
+  definitenessCutoffP_monotone .flagging .definite
+theorem hebrew_monotone : hebrewDOM.isMonotone = true :=
+  definitenessCutoffP_monotone .flagging .definite
+theorem persian_monotone : persianDOM.isMonotone = true :=
+  definitenessCutoffP_monotone .flagging .definite
+theorem catalan_monotone : catalanDOM.isMonotone = true :=
+  definitenessCutoffP_monotone .flagging .personalPronoun
+theorem hindi_monotone : hindiDOM.isMonotone = true := by decide
+theorem no_dom_monotone : noDOMProfile.isMonotone = true := by decide
 
 /-- **Aissen's DOM monotonicity universal**: all attested DOM patterns in
     the sample form upper sets in the bidimensional animacy × definiteness
     grid. No language marks a less-prominent object while leaving a
     more-prominent one unmarked. -/
 theorem dom_monotonicity_universal :
-    allDOMProfiles.all (·.isMonotone) = true := by native_decide
+    allDOMProfiles.all (·.isMonotone) = true := by decide
 
 -- §0.2 One-dimensional classification
 

--- a/Linglib/Studies/KeenanComrie1977.lean
+++ b/Linglib/Studies/KeenanComrie1977.lean
@@ -175,6 +175,20 @@ theorem prc_verified :
 theorem every_language_has_primary :
     ∀ markers ∈ allSamples, ∃ m ∈ markers, m.IsPrimary := by decide
 
+/-- **The PRC is order upward-closure**: in any PRC-satisfying language, a
+    primary marker's coverage is an `IsUpperSet` on the `AHPosition` scale
+    order. Keenan & Comrie's Primary Relativization Constraint *is* the
+    order-theoretic "upper set" property — the same `IsUpperSet` that
+    `Core.Order.Markedness` uses for differential-marking cutoffs — rather
+    than a bespoke rank predicate. -/
+theorem isUpperSet_of_satisfiesPRC {markers : List Marker} (h : SatisfiesPRC markers)
+    {m : Marker} (hm : m ∈ markers) (hp : m.IsPrimary) :
+    IsUpperSet {p : AHPosition | m.Covers p} := by
+  intro a b hab ha
+  rcases eq_or_lt_of_le hab with rfl | hlt
+  · exact ha
+  · exact h m hm hp a (by cases a <;> decide) ha b (by cases b <;> decide) hlt
+
 -- ============================================================================
 -- § 4: Cross-Linguistic Patterns
 -- ============================================================================

--- a/Linglib/Typology/RelativeClause/Basic.lean
+++ b/Linglib/Typology/RelativeClause/Basic.lean
@@ -1,3 +1,6 @@
+import Mathlib.Tactic.DeriveFintype
+import Mathlib.Order.UpperLower.Basic
+import Mathlib.Order.Interval.Set.OrdConnected
 import Linglib.Features.Definiteness
 import Linglib.Typology.Extraction
 
@@ -69,7 +72,7 @@ inductive AHPosition where
   /-- Object of comparison: the least accessible position
       ("the person [that I am taller than _]"). -/
   | objComparison
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Fintype
 
 /-- Numeric rank of a position on the Accessibility Hierarchy.
     Higher rank = more accessible = more languages can relativize it. -/
@@ -80,6 +83,14 @@ def AHPosition.rank : AHPosition → Nat
   | .oblique        => 3
   | .genitive       => 2
   | .objComparison  => 1
+
+/-- The accessibility order on `AHPosition` (the scale mixin): `p₁ ≤ p₂` iff
+    `p₁` is no more accessible than `p₂`. Lets HC₂ continuity and the PRC be
+    stated through mathlib's `Set.OrdConnected` / `IsUpperSet` rather than
+    bespoke rank arithmetic. -/
+instance : LinearOrder AHPosition :=
+  LinearOrder.lift' AHPosition.rank
+    (fun a b h => by cases a <;> cases b <;> simp_all [AHPosition.rank])
 
 /-- Position p1 is at least as accessible as p2 on the hierarchy. -/
 def AHPosition.atLeastAsAccessible (p1 p2 : AHPosition) : Prop :=


### PR DESCRIPTION
Vertical slice validating the 'no tower, just mixins' Scale design on one consumer (Aissen 2003 DOM).

- `Core/Order/Markedness.lean`: generic `atOrAbove`/`atOrBelow` cutoff predicates + `isUpperSet`/`isLowerSet` monotonicity over any `[Preorder S]` — the staircase property proved once, for every scale
- prominence cutoffs (`animacyCutoffP`/`definitenessCutoffP`/…) now use the scale's `LinearOrder` (`cutoff ≤ a`), not raw `.rank` Nat
- adds the missing `LinearOrder DefinitenessLevel` instance (animacy had one; definiteness didn't — a latent gap the lift surfaced)
- `Aissen2003`: the 6 one-dimensional DOM languages inherit monotonicity from the generic `animacyCutoffP_monotone`/`definitenessCutoffP_monotone` instead of re-deciding per language
- removes 11 `native_decide` (8 Prominence + 3 Aissen) in favour of kernel `decide` / the generic lemmas

No `Scale` class tower (the audited-and-rejected design): scales are mathlib order mixins + a generic operation. The remaining prominence scales (person, givenness, accessibility) and DOM consumers follow the same pattern in the sweep.