### PR TITLE
feat(Semantics/Composition): interp simp normal form + cleaner tryFA

### DIFF
--- a/Linglib/Semantics/Composition/Tree.lean
+++ b/Linglib/Semantics/Composition/Tree.lean
@@ -303,9 +303,9 @@ omit [Applicative M] [PredAbs M F] in
     interpTerminal F lex w = (lex w).map fun e => ⟨e.ty, e.denot⟩ := rfl
 
 omit [PredAbs M F] in
-/-- Forward FA reduces generally (abstract `σ τ`) — unblocked by the
-`applyForward`/`applyBackward` split. (Backward FA stays type-shape-specific
-because forward fires first when the left daughter is itself a function.) -/
+/-- Forward FA reduces generally (abstract `σ τ`). Backward FA stays
+type-shape-specific, since forward fires first when the left daughter is itself a
+function. -/
 @[simp] theorem applyForward_fn {σ τ : Ty} (f : M (F.Denot (σ ⇒ τ))) (x : M (F.Denot σ)) :
     applyForward (⟨σ ⇒ τ, f⟩ : TypedDenot F M) ⟨σ, x⟩ = some ⟨τ, f <*> x⟩ := by
   simp only [applyForward, ↓reduceDIte]

--- a/Linglib/Semantics/Composition/Tree.lean
+++ b/Linglib/Semantics/Composition/Tree.lean
@@ -275,4 +275,31 @@ theorem interpBinary_eq {F : Frame} [Applicative M] (d1 d2 : TypedDenot F M) :
 
 end Properties
 
+/-! ### Reduction lemmas (the `interp` simp normal form)
+
+Per-constructor `@[simp]` lemmas so a derivation reduces by `simp` toward its
+composed denotation, instead of relying on opaque `rfl` over the whole engine
+call. Mode reduction (`tryFA`/`interpBinary` over concrete types) is the
+complementary layer, and is type-shape-specific because the modes case on `Ty`. -/
+
+section Reduction
+
+variable {C : Type} {F : Frame} {M : Type → Type} [Applicative M] [PredAbs M F]
+
+@[simp] theorem interp_terminal (lex : Lexicon F M) (g : Core.Assignment F.Entity)
+    (c : C) (w : String) :
+    interp F lex g (.terminal c w : Tree C String) = interpTerminal F lex w := rfl
+
+@[simp] theorem interp_node_binary (lex : Lexicon F M) (g : Core.Assignment F.Entity)
+    (c : C) (t₁ t₂ : Tree C String) :
+    interp F lex g (.node c (t₁ :: t₂ :: []))
+      = ((interp F lex g t₁).bind fun d₁ =>
+          (interp F lex g t₂).bind fun d₂ => interpBinary d₁ d₂) := rfl
+
+omit [Applicative M] [PredAbs M F] in
+@[simp] theorem interpTerminal_lookup (lex : Lexicon F M) (w : String) :
+    interpTerminal F lex w = (lex w).map fun e => ⟨e.ty, e.denot⟩ := rfl
+
+end Reduction
+
 end Semantics.Composition.Tree

--- a/Linglib/Semantics/Composition/Tree.lean
+++ b/Linglib/Semantics/Composition/Tree.lean
@@ -86,35 +86,37 @@ def interpFA {F : Frame} {σ τ : Ty}
     (f : F.Denot (σ ⇒ τ)) (x : F.Denot σ) : F.Denot τ :=
   f x
 
-/-- Try FA in both orders, sequencing effects in linear order (the left
-daughter's effects fire first regardless of which daughter is the
-function). -/
+/-- Forward FA: the function is the left daughter `df`, the argument `da`. -/
+def applyForward {F : Frame} {M : Type → Type} [Applicative M]
+    (df da : TypedDenot F M) : Option (TypedDenot F M) :=
+  match hf : df.ty with
+  | .fn σ τ =>
+    if ha : σ = da.ty then
+      let f : M (F.Denot (σ ⇒ τ)) := hf ▸ df.val
+      let a : M (F.Denot σ) := ha ▸ da.val
+      some ⟨τ, f <*> a⟩
+    else none
+  | _ => none
+
+/-- Backward FA: the function is the right daughter `df`, the argument `da`. The
+left daughter `da` sequences first, hence the `(λ x g => g x)` combinator. -/
+def applyBackward {F : Frame} {M : Type → Type} [Applicative M]
+    (da df : TypedDenot F M) : Option (TypedDenot F M) :=
+  match hf : df.ty with
+  | .fn σ τ =>
+    if ha : σ = da.ty then
+      let f : M (F.Denot (σ ⇒ τ)) := hf ▸ df.val
+      let a : M (F.Denot σ) := ha ▸ da.val
+      some ⟨τ, (λ x g => g x) <$> a <*> f⟩
+    else none
+  | _ => none
+
+/-- Try FA in both orders, sequencing effects in linear order (the left daughter's
+effects fire first regardless of which daughter is the function): function on the
+left (`applyForward`), else on the right (`applyBackward`). -/
 def tryFA {F : Frame} {M : Type → Type} [Applicative M]
     (d1 d2 : TypedDenot F M) : Option (TypedDenot F M) :=
-  match hf : d1.ty with
-  | .fn σ τ =>
-    if ha : σ = d2.ty then
-      let f : M (F.Denot (σ ⇒ τ)) := hf ▸ d1.val
-      let a : M (F.Denot σ) := ha ▸ d2.val
-      some ⟨τ, f <*> a⟩
-    else
-      match hf' : d2.ty with
-      | .fn σ' τ' =>
-        if ha' : σ' = d1.ty then
-          let f : M (F.Denot (σ' ⇒ τ')) := hf' ▸ d2.val
-          let a : M (F.Denot σ') := ha' ▸ d1.val
-          some ⟨τ', (λ x g => g x) <$> a <*> f⟩
-        else none
-      | _ => none
-  | _ =>
-    match hf : d2.ty with
-    | .fn σ τ =>
-      if ha : σ = d1.ty then
-        let f : M (F.Denot (σ ⇒ τ)) := hf ▸ d2.val
-        let a : M (F.Denot σ) := ha ▸ d1.val
-        some ⟨τ, (λ x g => g x) <$> a <*> f⟩
-      else none
-    | _ => none
+  applyForward d1 d2 <|> applyBackward d1 d2
 
 /-- IFA: Intensional Functional Application ([von-fintel-heim-2011] Step 10).
 
@@ -299,6 +301,19 @@ variable {C : Type} {F : Frame} {M : Type → Type} [Applicative M] [PredAbs M F
 omit [Applicative M] [PredAbs M F] in
 @[simp] theorem interpTerminal_lookup (lex : Lexicon F M) (w : String) :
     interpTerminal F lex w = (lex w).map fun e => ⟨e.ty, e.denot⟩ := rfl
+
+omit [PredAbs M F] in
+/-- Forward FA reduces generally (abstract `σ τ`) — unblocked by the
+`applyForward`/`applyBackward` split. (Backward FA stays type-shape-specific
+because forward fires first when the left daughter is itself a function.) -/
+@[simp] theorem applyForward_fn {σ τ : Ty} (f : M (F.Denot (σ ⇒ τ))) (x : M (F.Denot σ)) :
+    applyForward (⟨σ ⇒ τ, f⟩ : TypedDenot F M) ⟨σ, x⟩ = some ⟨τ, f <*> x⟩ := by
+  simp only [applyForward, ↓reduceDIte]
+
+omit [PredAbs M F] in
+@[simp] theorem tryFA_forward {σ τ : Ty} (f : M (F.Denot (σ ⇒ τ))) (x : M (F.Denot σ)) :
+    tryFA (⟨σ ⇒ τ, f⟩ : TypedDenot F M) ⟨σ, x⟩ = some ⟨τ, f <*> x⟩ := by
+  simp only [tryFA, applyForward_fn]; rfl
 
 end Reduction
 

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -741,15 +741,11 @@ framework-level identity, no toy lexicon required. Worked tree-level
 derivations at `M = Cont` (scope) and `M = Writer` (CI) live in
 `Studies/BumfordCharlow2024.lean` alongside the toy-model demonstrations. -/
 
-/-- The engine's FA mode applies the function daughter to the argument
-through `Applicative`'s `<*>`. With `aApp_eq_structuredApp_fa`, this
-composes into "FA = meta-combinator **A** at forward application": the
-H&K engine and the effect calculus share one application operation. -/
-theorem tryFA_function_left {F : Frame} {M : Type → Type} [Applicative M]
-    {σ τ : Ty} (f : M (F.Denot (σ ⇒ τ))) (a : M (F.Denot σ)) :
-    Tree.tryFA ⟨σ ⇒ τ, f⟩ (⟨σ, a⟩ : Tree.TypedDenot F M) =
-      some ⟨τ, f <*> a⟩ := by
-  simp [Tree.tryFA]
+/-! The engine's FA mode applies the function daughter to the argument through
+`Applicative`'s `<*>` — the substrate lemma `Tree.tryFA_forward`. With
+`aApp_eq_structuredApp_fa`, this composes into "FA = meta-combinator **A** at
+forward application": the H&K engine and the effect calculus share one application
+operation. -/
 
 end TreeEngine
 

--- a/Linglib/Studies/HeimKratzer1998.lean
+++ b/Linglib/Studies/HeimKratzer1998.lean
@@ -166,6 +166,30 @@ theorem scope_readings_differ : surfaceScopeProp ≠ inverseScopeProp := by
   intro h
   exact inverse_scope_false (h ▸ surface_scope_true)
 
+/-! ### The engine computes the readings
+
+The QR trees and the hand-written `surfaceScopeProp`/`inverseScopeProp` are linked
+by `interp`: running the engine on a tree yields exactly the corresponding reading.
+So the scope-ambiguity result is a fact about the *engine's* output, not a parallel
+re-implementation alongside it. -/
+
+/-- Surface scope: the engine computes the hand-written reading. -/
+theorem interp_computes_surface :
+    interp toyFrame quantLex g₀ tree_surface = some ⟨Ty.t, surfaceScopeProp⟩ := rfl
+
+/-- Inverse scope: likewise. -/
+theorem interp_computes_inverse :
+    interp toyFrame quantLex g₀ tree_inverse = some ⟨Ty.t, inverseScopeProp⟩ := rfl
+
+/-- Scope ambiguity, stated about the engine: the two QR derivations interpret to
+genuinely different meanings. -/
+theorem scope_ambiguity_computed :
+    interp toyFrame quantLex g₀ tree_surface ≠ interp toyFrame quantLex g₀ tree_inverse := by
+  rw [interp_computes_surface, interp_computes_inverse]
+  intro h
+  have : surfaceScopeProp = inverseScopeProp := by injection h with h'; injection h'
+  exact scope_readings_differ this
+
 /-! ### Unified tree: the same sentence with UD categories
 
 The QR tree as `Tree Cat String` — carrying real UD-grounded categories


### PR DESCRIPTION
Make `interp` reduce by `simp` toward its denotation instead of opaque whole-engine `rfl`, and clean up the FA mode.

- **Reduction lemmas**: `interp_terminal`, `interp_node_binary`, `interpTerminal_lookup` (structural), `applyForward_fn`/`tryFA_forward` (forward FA reduces *generally*, abstract types). The simp set is confluent/loop-free; it pays off at `M ≠ Id` (where `<*>` doesn't `rfl`-reduce).
- **`tryFA` factored** into `applyForward`/`applyBackward` + `tryFA := applyForward d1 d2 <|> applyBackward d1 d2` (was a 26-line nested match). Behavior-preserving (proven `tryFA' = tryFA` over Ty²; full build + every importer's `rfl`/`decide` survive). The split is what unblocks the general forward-FA reduction lemma.
- **`HeimKratzer1998` engine-driven**: `interp_computes_surface`/`interp_computes_inverse` prove `interp` of each QR tree equals the hand-written scope reading, and `scope_ambiguity_computed` restates the ambiguity about `interp`'s output.
- Drops the now-redundant `BumfordCharlow2024.tryFA_function_left` (= `Tree.tryFA_forward`).

Follow-ups (not blocking): route the FA helpers through `canApply` to collapse the dependent casts to one site; apply the same factoring to `tryIFA`.