### PR TITLE
feat(Syntax/Adposition): theory-neutral Adposition API + spatial AxPart refinement

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -307,6 +307,8 @@ import Linglib.Core.Computability.StringHom
 import Linglib.Features.VerbCluster
 import Linglib.Features.Case.Basic
 import Linglib.Features.Case.Capabilities
+import Linglib.Syntax.Adposition.Basic
+import Linglib.Syntax.Adposition.Spatial
 import Linglib.Syntax.Case.Order
 import Linglib.Typology.Alignment
 import Linglib.Diachronic.CaseGrammaticalization

--- a/Linglib/Syntax/Adposition/Basic.lean
+++ b/Linglib/Syntax/Adposition/Basic.lean
@@ -1,0 +1,160 @@
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# Adposition: the function-marking relator
+[hagege-2010] [dryer-2013] [svenonius-2010]
+
+The P-head word class — a **function-marking relator** — as a theory-neutral
+object, sibling to `Syntax/Pronoun` in the closed-class function-word family.
+The base encodes only the cross-framework criteria that *define* the category;
+every framework (Minimalist cartography, HPSG, CCG, Dependency Grammar,
+cognitive grammar) and every semantic theory (Pantcheva direction, Zwarts path
+algebra, the Svenonius `AxPart` decomposition in `Adposition/Spatial.lean`)
+*plugs into* this base rather than defining it — exactly as Caha's containment
+refines `Case` without being `Case`.
+
+## Defining criteria (typological tradition: [hagege-2010], [dryer-2013])
+
+1. **governs a complement** (the Ground/régime) — a relator; `[]` is the
+   intransitive/particle limit;
+2. **marks the function** of that complement — a `RelationType`;
+3. **closed-class grammatical** element (a category fact; may inflect/agree —
+   Celtic, Uralic, Hebrew);
+4. **fixed linearization** relative to the complement (a *set*: a lexeme may be
+   both pre- and post-positional, e.g. Dutch *op*);
+5. **exponence** on the grammaticalization cline (the case-affix boundary).
+
+## Main declarations
+
+* `Adposition` — the category object (the five criteria as fields)
+* `Adposition.RelationType` / `Linearization` / `Complement` / `Exponence` /
+  `Form` — the criterion vocabularies
+* `Adposition.isIntransitive` / `isComplex` / `isAmbipositional`
+-/
+
+namespace Adposition
+
+/-- The relation an adposition marks (criterion 2) — coarse only. A spatial
+    relation's internal structure (`AxPart × Region × PathDir × Bound`) is a
+    *theory* (`Adposition/Spatial.lean`), never part of the category. -/
+inductive RelationType where
+  /-- Spatial: in/on/under/to/from. Refined by the cartographic decomposition. -/
+  | spatial
+  /-- Temporal: before/after/during/until. -/
+  | temporal
+  /-- Grammatical/relational: of/by/with — function-marking (agent, instrument,
+      comitative). The marked role is a Study-level refinement, not a base field. -/
+  | grammatical
+  /-- Logical/abstract: because-of/despite/concerning. -/
+  | logical
+  deriving DecidableEq, Repr, Fintype, Inhabited
+
+/-- A linearization of an adposition with respect to its complement
+    (criterion 4). The per-lexeme companion to the language-level
+    `Typology.Adposition.AdpositionOrder`. -/
+inductive Linearization where
+  /-- Preposition: P precedes the complement. -/
+  | pre
+  /-- Postposition: P follows the complement. -/
+  | post
+  /-- Circumposition: P brackets the complement (two exponents). -/
+  | circum
+  /-- Inposition: P appears inside/second-position in the complement. -/
+  | inposition
+  deriving DecidableEq, Repr, Fintype
+
+/-- What an adposition governs (criterion 1) — P-specific complement types
+    (NOT the verb-argument `Features.Complementation.ComplementType`, which
+    carries ditransitive frames an adposition never selects). -/
+inductive Complement where
+  | np
+  | pp
+  | clause
+  /-- Adjectival complement (Dutch *tot voor kort* 'until recently'). -/
+  | ap
+  deriving DecidableEq, Repr, Fintype
+
+/-- Exponence on the grammaticalization cline (criterion 5). `affix` is the
+    boundary at which the adposition becomes a `Case` exponent — the point where
+    this object and `Case` meet on the cline (`Diachronic.CaseGrammaticalization`). -/
+inductive Exponence where
+  | free
+  | clitic
+  | affix
+  deriving DecidableEq, Repr, Fintype, Inhabited
+
+/-- The form of an adposition: a single word, or a complex/multi-word adposition
+    (*in front of*, *on top of*). -/
+inductive Form where
+  | simple (s : String)
+  | complex (parts : List String)
+  deriving DecidableEq, Repr
+
+/-- The surface string of a form (complex forms joined by spaces). -/
+def Form.text : Form → String
+  | .simple s => s
+  | .complex parts => " ".intercalate parts
+
+end Adposition
+
+/-- An adposition: the five defining criteria as fields. Theory-neutral —
+    spatial/grammatical refinements and framework analyses consume it. -/
+structure Adposition where
+  form : Adposition.Form
+  /-- Criterion 2: the relation marked. -/
+  relation : Adposition.RelationType
+  /-- Criterion 1: complement types selected. `[]` = intransitive (particle). -/
+  complement : List Adposition.Complement
+  /-- Criterion 4: allowed linearizations (set semantics; may be several). -/
+  linearization : List Adposition.Linearization
+  /-- Criterion 5: exponence on the cline. -/
+  exponence : Adposition.Exponence := .free
+  /-- Criterion 3 refinement: inflects/agrees with the complement's φ-features
+      (Celtic *agam*, Hungarian, Hebrew). -/
+  agreesWithComplement : Bool := false
+  deriving Repr, DecidableEq
+
+namespace Adposition
+
+/-- Intransitive (the particle limit): governs no complement. -/
+def isIntransitive (a : Adposition) : Bool := a.complement.isEmpty
+
+/-- Complex/multi-word adposition (*in front of*). -/
+def isComplex (a : Adposition) : Bool :=
+  match a.form with
+  | .complex _ => true
+  | .simple _ => false
+
+/-- Ambipositional: allows both pre- and post-positional order (Dutch *op*). -/
+def isAmbipositional (a : Adposition) : Bool :=
+  a.linearization.contains .pre && a.linearization.contains .post
+
+/-! ### Smoke tests — the mature fields exercised (stress-test seeds) -/
+
+/-- English *in*: simple spatial preposition over an NP. -/
+def english_in : Adposition :=
+  { form := .simple "in", relation := .spatial, complement := [.np],
+    linearization := [.pre] }
+
+/-- English *in front of*: a complex/multi-word spatial preposition. -/
+def english_inFrontOf : Adposition :=
+  { form := .complex ["in", "front", "of"], relation := .spatial,
+    complement := [.np], linearization := [.pre] }
+
+/-- Dutch *op*: ambipositional (both pre- and post-positional). -/
+def dutch_op : Adposition :=
+  { form := .simple "op", relation := .spatial, complement := [.np],
+    linearization := [.pre, .post] }
+
+/-- Irish *ag* 'at': a grammatical preposition that **inflects** for its
+    complement (*agam* 'at-me', *agat* 'at-you'). -/
+def irish_ag : Adposition :=
+  { form := .simple "ag", relation := .grammatical, complement := [.np],
+    linearization := [.pre], agreesWithComplement := true }
+
+example : english_inFrontOf.isComplex = true := by decide
+example : dutch_op.isAmbipositional = true := by decide
+example : irish_ag.agreesWithComplement = true := by decide
+example : english_in.isIntransitive = false := by decide
+
+end Adposition

--- a/Linglib/Syntax/Adposition/Spatial.lean
+++ b/Linglib/Syntax/Adposition/Spatial.lean
@@ -1,0 +1,92 @@
+import Linglib.Syntax.Adposition.Basic
+import Linglib.Syntax.Case.Order
+
+/-!
+# Spatial adpositions: the cartographic refinement
+[svenonius-2010] [svenonius-2006] [pantcheva-2011] [zwarts-2005]
+
+The refinement a *theory* supplies for `Adposition` with `relation = .spatial`:
+the Cinque-Rizzi/Svenonius decomposition of the spatial relation into
+**axial part × region × direction × boundedness**. This is the spatial slice
+of the universal functional sequence ([svenonius-2010]); a temporal or
+grammatical adposition has none of it, which is why it refines a relation
+rather than defining the category.
+
+The decomposition **reuses the Case spatial substrate**: direction is
+`Case.PathDir` (Pantcheva's Place ⊂ Goal ⊂ Source ⊂ Route) and region is
+`Case.Region` — an adposition and a spatial case spell out the *same* content
+([cinque, this volume]: spatial P, adverb, particle, and case all spell out
+portions of one configuration). The genuinely new piece is `AxPart`, the
+object-geometry axial parts ([svenonius-2006]) that case morphology lacks — and
+unlike `PathDir`/`Region`, the axial parts are a **flat paradigm**, not a ranked
+containment, so `AxPart` does not instantiate the `partialOrderOfRank` gadget.
+
+## Main declarations
+
+* `Adposition.AxPart` — Svenonius axial parts (front/back/top/…), the differentia
+* `Adposition.SpatialReading` — the cartographic decomposition (the plug-in type)
+* `Adposition.SpatialReading.toCase` is left to per-language Studies
+-/
+
+namespace Adposition
+
+/-- Axial parts ([svenonius-2006]): the object-geometry regions a spatial
+    adposition projects onto the Ground's axes. *behind* = `back`, *under* =
+    `bottom`, *on top of* = `top`, *in front of* = `front`, *beside* = `side`,
+    *inside* = `interior`, *outside* = `exterior`. A flat paradigm (the axes are
+    not nested), distinct from the ranked `Case.PathDir`/`Case.Region`. -/
+inductive AxPart where
+  | front
+  | back
+  | top
+  | bottom
+  | side
+  | interior
+  | exterior
+  deriving DecidableEq, Repr, Fintype
+
+/-- The cartographic decomposition of a spatial adposition's `relation`
+    ([svenonius-2010]): an axial part (Svenonius), a stative region (reused
+    `Case.Region`), a direction (reused `Case.PathDir`, Pantcheva), and a
+    boundedness ([zwarts-2005], the *separate* algebraic axis — `to` vs
+    `towards`). Theories own the slices; this is the shared vocabulary that a
+    `relation = .spatial` adposition is refined into. -/
+structure SpatialReading where
+  /-- The axial part, if the P is axial/complex (*behind*); `none` for the simple
+      directional/locative Ps (*in*/*to*/*from*). -/
+  axPart : Option AxPart := none
+  /-- The stative region (interior/surface/exterior), reused from `Case`. -/
+  region : Option Case.Region := none
+  /-- The direction (Place/Goal/Source/Route), reused from `Case` (Pantcheva). -/
+  direction : Case.PathDir
+  /-- Boundedness ([zwarts-2005]): bounded (telic *to*) vs unbounded (atelic
+      *towards*) — orthogonal to direction. -/
+  bounded : Bool := false
+  deriving Repr, DecidableEq
+
+/-- The directional denotation of a spatial reading is the reused
+    `Case.PathDir.denote` — a spatial adposition and a spatial case with the
+    same direction share one meaning, two exponences. -/
+def SpatialReading.denote (r : SpatialReading) : Case.PathProfile :=
+  r.direction.denote
+
+/-! ### Smoke tests — the differentia and the reuse -/
+
+/-- *behind*: an axial preposition (back), stative, no direction change. -/
+def behind : SpatialReading :=
+  { axPart := some .back, direction := .place }
+
+/-- *under*: axial (bottom), stative. -/
+def under : SpatialReading :=
+  { axPart := some .bottom, direction := .place }
+
+/-- *into*: interior goal, bounded — no axial part (a simple directional P). -/
+def into : SpatialReading :=
+  { region := some .interior, direction := .goal, bounded := true }
+
+/-- The axial parts case morphology lacks are genuinely present here. -/
+example : behind.axPart = some .back := by decide
+/-- A simple directional reading reuses `PathDir.denote` (the Case substrate). -/
+example : into.denote = Case.PathDir.goal.denote := by rfl
+
+end Adposition


### PR DESCRIPTION
The mature, framework-neutral Adposition object (the P-head word class, sibling to `Pronoun`) — the API any theory plugs into, to be stress-tested by Studies (Broekhuis-Corver, Svenonius, a Celtic inflected-P fragment) afterward.

- `Adposition/Basic.lean` — the category as the five typological criteria (Hagège/Dryer): `relation`, `complement` (P-specific), set-valued `linearization` (Dutch *op* is both pre- and post-positional), `exponence` (the case-affix cline), `agreesWithComplement` (Celtic *agam*), and complex/multi-word `Form` (*in front of*). Theory-neutral: no cartography baked in.
- `Adposition/Spatial.lean` — the `relation = spatial` refinement: `AxPart` (Svenonius axial parts — the differentia case lacks, a flat paradigm) + `SpatialReading` reusing `Case.Region`/`Case.PathDir`; `SpatialReading.denote` reuses `PathDir.denote` so a spatial P and a spatial case with the same direction share one meaning by `rfl`.

Bib follow-up: add verified `hagege-2010`, `svenonius-2006` entries before the docstring `[key]`s render.