### PR TITLE
feat(Subregular): tier-rule prediction is right-myopic (over-commitment)

### DIFF
--- a/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
@@ -119,4 +119,13 @@ theorem IsUnboundedCircumambient.not_myopic {f : List α → List β}
 @[simp] theorem not_isMyopicTowards_iff {f : List α → List β} {s : Direction} :
     ¬ IsMyopicTowards f s ↔ UnboundedDependence f s := not_not
 
+/-- **Prefix-determined ⟹ right-myopic.** A map each of whose output coordinates is
+fixed by the input's *strict prefix* (`{k | k < i}`) has no rightward look-ahead, so
+it is myopic towards the right. (The canonical left-to-right scan has this shape.) -/
+theorem IsMyopicTowards.right_of_prefixDetermined {f : List α → List β}
+    (h : ∀ i, OutputDependsOn f i {k | k < i}) : IsMyopicTowards f .right := by
+  intro hunb
+  obtain ⟨u, v, i, hlen, _, hag, hne⟩ := hunb 0
+  exact hne (h i u v hlen fun k hk => hag k (by simp only [Set.mem_setOf_eq] at hk; omega))
+
 end Core.Computability.Subregular.Function

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -2,6 +2,7 @@ import Mathlib.Data.Fintype.Option
 import Linglib.Core.Computability.StringHom
 import Linglib.Core.Computability.Subregular.Function.Direction
 import Linglib.Core.Computability.Subregular.Function.Subsequential
+import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 
 /-!
 # Tier-based rules (`TierRule`)
@@ -316,5 +317,47 @@ theorem applyToString_isLeftSubsequential_of_id_tier [Fintype α]
     -- `none = lastContextOf []` definitionally
     exact r.toIdTierSFST_runFrom_eq_applyToStringAux h_id h_side [] input
   exact h_run ▸ r.toIdTierSFST.isLeftSubsequential
+
+/-! ### Myopia: the tier-rule prediction has no look-ahead -/
+
+/-- `applyToString`'s coordinate `i` is the rule's prediction over the strict input
+prefix: `applyAt r (input.take i)` (in range; `none` otherwise). -/
+theorem applyToStringAux_getElem? (r : TierRule α) :
+    ∀ (input past : List α) (i : ℕ),
+      (applyToString.applyToStringAux r input past)[i]?
+        = if i < input.length then some (r.applyAt (past ++ input.take i)) else none
+  | [], _, i => by simp [applyToString.applyToStringAux]
+  | _ :: _, _, 0 => by simp [applyToString.applyToStringAux]
+  | x :: xs, past, i + 1 => by
+      simp only [applyToString.applyToStringAux, List.getElem?_cons_succ,
+        List.length_cons, List.take_succ_cons, Nat.add_lt_add_iff_right]
+      rw [applyToStringAux_getElem? r xs (past ++ [x]) i, List.append_assoc,
+        List.singleton_append]
+
+theorem applyToString_getElem? (r : TierRule α) (u : List α) (i : ℕ) :
+    (r.applyToString u)[i]?
+      = if i < u.length then some (r.applyAt (u.take i)) else none := by
+  rw [applyToString, applyToStringAux_getElem?]; simp
+
+/-- `applyToString` is **prefix-determined**: its `i`-th output is fixed by the input's
+strict prefix `{k | k < i}`. -/
+theorem applyToString_prefixDetermined (r : TierRule α) (i : ℕ) :
+    OutputDependsOn r.applyToString i {k | k < i} := by
+  intro u v hlen hag
+  rw [applyToString_getElem?, applyToString_getElem?, hlen]
+  have htake : u.take i = v.take i := by
+    apply List.ext_getElem?
+    intro k
+    rcases lt_or_ge k i with hk | hk
+    · simpa only [List.getElem?_take_of_lt hk] using hag k hk
+    · simp [List.getElem?_take_eq_none hk]
+  rw [htake]
+
+/-- **The tier-rule prediction mechanism is right-myopic** — it has no look-ahead.
+Consequently no tier-rule-based prediction (the formal core of a `HarmonySystem`) can
+compute a *non-myopic* harmony, such as an unbounded-circumambient pattern. -/
+theorem applyToString_isRightMyopic (r : TierRule α) :
+    IsMyopicTowards r.applyToString .right :=
+  IsMyopicTowards.right_of_prefixDetermined (applyToString_prefixDetermined r)
 
 end Phonology.Subregular.TierRule


### PR DESCRIPTION
The formal core of the harmony-as-tier-rule over-commitment — the premise behind the `Process/` dissolve.

- `SideDeterminacy.lean`: `IsMyopicTowards.right_of_prefixDetermined` — a map whose every output coordinate is fixed by the input's strict prefix has no rightward look-ahead.
- `TierRule.lean`: `applyToString` is prefix-determined (output `i` = `applyAt r (input.take i)`), hence `applyToString_isRightMyopic` — the tier-rule prediction mechanism (the formal core of any `HarmonySystem`) is right-myopic.

Paired with #223's `tutrugbu_nonmyopic`: the tier-rule framing is myopic-bounded, but attested harmony (circumambient Tutrugbu ATR) is not — so the tier-rule account provably cannot reach it. `TierRule` is now a second consumer of `SideDeterminacy`, earning its Core placement. (The fully-typed "no `HarmonySystem` map = `tutrugbuATR`" needs a `HarmonySystem → (List → List)` map + a `Segment`/`Seg` bridge — deferred.)