### PR TITLE
feat(Subregular/Function): strictness witnesses for subseq ⊊ WD ⊊ regular

### DIFF
--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -22,17 +22,19 @@ trivial, so its cell output is a *one-sided* rule — non-interacting.
 
 * `IsBimachineWeaklyDeterministic.of_letterLeftSubsequential` — subsequential ⊆ WD.
 * `IsBimachineComputable.of_weaklyDeterministic` — WD ⊆ regular.
+* `weaklyDeterministic_strict_subset_regular` — the second inclusion is *proper*.
 
 ## Strictness
 
-The inclusions are *proper*, witnessed by attested harmony patterns formalized in
-`Studies/` (not imported here — Core stays study-agnostic):
+Both inclusions are proper:
 
-* **WD ⊊ regular**: Tutrugbu ATR (`McCollumEtAl2020.tutrugbu_not_weaklyDeterministic`)
-  `RequiresBothSides`, so no non-interacting bimachine computes it.
-* **subsequential ⊊ WD**: Maasai ATR (`MeinhardtEtAl2024.maasai_weaklyDeterministic`) is a
-  genuinely two-sided union — `IsUnboundedCircumambient`, hence not right-myopic, hence
-  not left-subsequential (`IsLetterLeftSubsequential.isRightMyopic`) — yet WD.
+* **WD ⊊ regular** — `weaklyDeterministic_strict_subset_regular`: the conjunctive spread
+  `conjBM` (a target raised iff a trigger occurs on *both* sides) is bimachine-computable
+  but `RequiresBothSides`. Tutrugbu ATR is the attested instance
+  (`McCollumEtAl2020.tutrugbu_not_weaklyDeterministic`).
+* **subsequential ⊊ WD** — Maasai ATR (`MeinhardtEtAl2024.maasai_not_letterLeftSubsequential`)
+  is a genuinely two-sided union, `IsUnboundedCircumambient` hence not right-myopic hence
+  not left-subsequential, yet WD.
 -/
 
 namespace Core.Computability.Subregular.Function
@@ -75,5 +77,114 @@ theorem IsBimachineComputable.of_weaklyDeterministic {f : List α → List α}
     (h : IsBimachineWeaklyDeterministic f) : IsBimachineComputable f := by
   obtain ⟨L, R, _, _, B, hrun, _⟩ := h
   exact ⟨L, R, inferInstance, inferInstance, B, hrun⟩
+
+/-! ### Strictness: WD ⊊ regular
+
+A *conjunctive* spread — a target raised iff a trigger occurs on **both** sides — is
+bimachine-computable but `RequiresBothSides`, so no non-interacting bimachine computes
+it. (Tutrugbu ATR is the attested instance; `McCollumEtAl2020.tutrugbu_not_weaklyDeterministic`.) -/
+
+/-- Toy alphabet for the conjunctive-spread witness: a trigger, a recessive target, and
+its raised form. -/
+inductive ConjSym | trig | tgt | raised
+  deriving DecidableEq, Repr
+
+instance : Fintype ConjSym := ⟨{.trig, .tgt, .raised}, fun x => by cases x <;> simp⟩
+
+/-- A target raises iff a trigger occurs on **both** sides — left/right states track a
+trigger seen on each side, and the cell genuinely needs both (`l && r`). -/
+def conjBM : Bimachine Bool Bool ConjSym ConjSym where
+  lInit := false
+  lStep l s := l || (s == .trig)
+  rInit := false
+  rStep r s := r || (s == .trig)
+  out l s r := if (l && r) && s == .tgt then .raised else s
+
+private theorem conjBM_lState (xs : List ConjSym) :
+    conjBM.lState xs = xs.any (· == .trig) := by
+  show xs.foldl (fun l s => l || (s == .trig)) false = _
+  have key : ∀ (acc : Bool) (ys : List ConjSym),
+      ys.foldl (fun l s => l || (s == .trig)) acc = (acc || ys.any (· == .trig)) := by
+    intro acc ys; induction ys generalizing acc with
+    | nil => simp
+    | cons y ys ih => simp [ih, Bool.or_assoc]
+  simpa using key false xs
+
+private theorem conjBM_rState (xs : List ConjSym) :
+    conjBM.rState xs = xs.any (· == .trig) := by
+  show xs.foldr (fun s r => r || (s == .trig)) false = _
+  induction xs with
+  | nil => rfl
+  | cons y ys ih => simp [ih, Bool.or_comm]
+
+/-- Witness word at distance `d`: a medial `tgt` flanked by `d` neutral fillers and a
+`trig` on each end. -/
+def conjBase (d : ℕ) : List ConjSym :=
+  .trig :: List.replicate d .raised ++ .tgt :: List.replicate d .raised ++ [.trig]
+
+private theorem conjBase_getElem_tgt (d : ℕ) : (conjBase d)[d + 1]? = some .tgt := by
+  simp [conjBase]
+
+private theorem conjBase_take (d : ℕ) :
+    (conjBase d).take (d + 1) = .trig :: List.replicate d .raised := by
+  simp [conjBase]
+
+private theorem conjBase_drop (d : ℕ) :
+    (conjBase d).drop (d + 2) = List.replicate d .raised ++ [.trig] := by
+  simp only [conjBase, List.drop_append, List.length_cons, List.length_replicate]
+  simp only [show d + 2 - (d + 1) = 1 from by omega]
+  simp
+
+/-- The conjunctive spread requires both sides: the base raises a medial target (trigger
+on each side), but removing either far trigger reverts it. -/
+theorem conjBM_requiresBothSides : RequiresBothSides conjBM.run := by
+  intro d
+  refine ⟨conjBase d, d + 1, by simp [conjBase], ?_,
+    ⟨(conjBase d).set 0 .raised, by simp [conjBase], ?_, ?_, ?_⟩,
+    ⟨(conjBase d).set (2 * d + 2) .raised, by simp [conjBase], ?_, ?_, ?_⟩⟩
+  -- Goal 1: base changes at d+1 (both sides have a trigger → tgt raises to .raised ≠ .tgt)
+  · rw [conjBM.run_getElem?, conjBM_lState, conjBM_rState,
+        conjBase_getElem_tgt, conjBase_take d, conjBase_drop d]
+    simp [List.any_cons, List.any_replicate, List.any_append, conjBM]
+  -- Goal 2: uL AgreeFrom — set at 0 differs only at 0, so agree from (d+1)-d = 1 ≤ k
+  · intro k hk
+    exact (List.getElem?_set_ne (by omega)).symm
+  -- Goal 3: uL[d+1]? = base[d+1]? since d+1 ≠ 0
+  · rw [List.getElem?_set_ne (by omega)]
+  -- Goal 4: uL revert — lState = false (no trigger in take) → cell outputs .tgt
+  · have htake_uL : ((conjBase d).set 0 .raised).take (d + 1) = List.replicate (d + 1) .raised := by
+      rw [List.take_set, conjBase_take]
+      simp [List.set_cons_zero, List.replicate_succ]
+    have hdrop_uL : ((conjBase d).set 0 .raised).drop (d + 2) =
+        List.replicate d .raised ++ [.trig] := by
+      rw [List.drop_set_of_lt (by omega), conjBase_drop]
+    rw [conjBM.run_getElem?, conjBM_lState, conjBM_rState,
+        List.getElem?_set_ne (by omega : (0 : ℕ) ≠ d + 1), conjBase_getElem_tgt,
+        htake_uL, hdrop_uL]
+    simp [List.any_replicate, List.any_append, List.any_cons, conjBM]
+  -- Goal 5: uR AgreeUpto — set at 2*d+2 differs only there, so agree upto (d+1)+d = 2*d+1 < 2*d+2
+  · intro k hk
+    exact (List.getElem?_set_ne (by omega)).symm
+  -- Goal 6: uR[d+1]? = base[d+1]? since d+1 ≠ 2*d+2
+  · rw [List.getElem?_set_ne (by omega)]
+  -- Goal 7: uR revert — rState = false (no trigger in drop) → cell outputs .tgt
+  · have htake_uR : ((conjBase d).set (2 * d + 2) .raised).take (d + 1) =
+        .trig :: List.replicate d .raised := by
+      rw [List.take_set_of_le (by omega), conjBase_take]
+    have hdrop_uR : ((conjBase d).set (2 * d + 2) .raised).drop (d + 2) =
+        List.replicate (d + 1) .raised := by
+      rw [show (2 * d + 2 : ℕ) = d + 2 + d from by omega, ← List.set_drop, conjBase_drop]
+      rw [List.set_append_right d ConjSym.raised (by simp)]
+      simp [List.replicate_succ']
+    rw [conjBM.run_getElem?, conjBM_lState, conjBM_rState,
+        List.getElem?_set_ne (by omega : 2 * d + 2 ≠ d + 1), conjBase_getElem_tgt,
+        htake_uR, hdrop_uR]
+    simp [List.any_replicate, List.any_cons, conjBM]
+
+theorem weaklyDeterministic_strict_subset_regular :
+    ∃ f : List ConjSym → List ConjSym,
+      IsBimachineComputable f ∧ ¬ IsBimachineWeaklyDeterministic f :=
+  ⟨conjBM.run, ⟨Bool, Bool, inferInstance, inferInstance, conjBM, rfl⟩,
+   not_isBimachineWeaklyDeterministic_of_requiresBothSides conjBM_requiresBothSides⟩
 
 end Core.Computability.Subregular.Function

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -6,6 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Core.Computability.Subregular.Function.ISL
 import Linglib.Core.Computability.Subregular.Function.OSL
 import Linglib.Core.Computability.Subregular.Function.Subsequential
+import Linglib.Core.Computability.Subregular.Function.LetterSubsequential
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 import Linglib.Core.Computability.Subregular.Function.Bimachine
 
@@ -399,5 +400,12 @@ theorem maasai_isUnboundedCircumambient : IsUnboundedCircumambient maasai := by
 Covariation (both languages) and interaction (Tutrugbu only) come apart. -/
 theorem maasai_not_requiresBothSides : ¬ RequiresBothSides maasai := fun h =>
   not_isBimachineWeaklyDeterministic_of_requiresBothSides h maasai_weaklyDeterministic
+
+/-- **Strictness witness `subsequential ⊊ WD`**: Maasai is weakly deterministic yet *not*
+left-subsequential. A synchronous left-subsequential map is right-myopic
+(`IsLetterLeftSubsequential.isRightMyopic`), but Maasai's bidirectional spread is not
+(`maasai_isUnboundedCircumambient`). -/
+theorem maasai_not_letterLeftSubsequential : ¬ IsLetterLeftSubsequential maasai := fun h =>
+  maasai_isUnboundedCircumambient.not_myopic .right h.isRightMyopic
 
 end MeinhardtEtAl2024


### PR DESCRIPTION
Makes #230's lattice inclusions *proper*.

- **subsequential ⊊ WD** — `MeinhardtEtAl2024.maasai_not_letterLeftSubsequential`: Maasai is WD (#229) but not left-subsequential (a synchronous left-subsequential map is right-myopic, Maasai isn't). One line from `maasai_isUnboundedCircumambient.not_myopic` + `isRightMyopic`.
- **WD ⊊ regular** — `weaklyDeterministic_strict_subset_regular` (Hierarchy): an abstract conjunctive spread `conjBM` (raise iff a trigger on *both* sides) is bimachine-computable yet `RequiresBothSides`, so not WD. Tutrugbu is the attested instance.

Full build green.