### PR TITLE
refactor(Semantics/Kinds): Prop existential closure, derive dkpIsLocal

### DIFF
--- a/Linglib/Semantics/Kinds/NominalMappingParameter.lean
+++ b/Linglib/Semantics/Kinds/NominalMappingParameter.lean
@@ -465,15 +465,11 @@ theorem bare_plural_ok_bare_singular_not (bp : BlockingPrinciple)
 
 -- Scopelessness (Theoretical Basis)
 
-/--
-Bare plurals are scopeless because DKP introduces a LOCAL existential.
-
-The existential reading from DKP cannot scope out because the coercion
-applies inside the predicate abstract.
-
-See `Phenomena/Generics/KindReference.lean` for empirical scope data.
--/
-def dkpIsLocal : Bool := true
+/-! Bare plurals are scopeless because DKP introduces a *local* existential: the
+existential closure sits inside negation and cannot scope out. This locality is the
+theorem `chierchia_position_invariant` below — Chierchia's derivation is the same
+whether or not the bare plural has scrambled. See `Phenomena/Generics/KindReference.lean`
+for empirical scope data. -/
 
 /--
 When ∩ is undefined (NP doesn't denote a kind), we fall back to ∃.
@@ -486,91 +482,47 @@ For non-kind-denoting NPs like "parts of that machine":
 def fallbackToExists (isKindDenoting : Bool) (bp : BlockingPrinciple) : Bool :=
   !isKindDenoting ∧ !bp.existsBlocked
 
--- DKP Derivation Machinery (for Scrambling Comparison)
-
-/-!
-## Computational DKP
+/-! ### DKP scope derivation (Chierchia side of the scrambling comparison)
 [krifka-2004] [chierchia-1998]
 
-Simplified, decidable formalization of Chierchia's DKP for concrete
-scrambling comparisons with [krifka-2004]. Uses `List Entity` and `Bool`
-(rather than `Set Atom` and `Prop`) so that examples reduce by `rfl`.
+Chierchia's Derived Kind Predication introduces the existential *locally* — where the
+kind meets the predicate — so negation always scopes outside it. Modelled with plain
+`Prop` existential closure (`existsClose`) over the kind's instances. Krifka's
+position-sensitive ∃-shift in `Krifka2004.lean` reuses the same `existsClose`, so the two
+accounts share one closure and differ only in where negation sits; they are compared on
+the Dutch scrambling data in `Studies/LeBruynDeSwart2022.lean`.
 
-The parallel Krifka machinery is in `Krifka2004.lean`; both are
-instantiated side-by-side in `Studies/LeBruynDeSwart2022.lean`, where the
-scrambling data adjudicate the two accounts.
--/
+`existsClose` is Partee's `A` (existential closure) in plain extensional form. The same
+operator dressed in the DWP/Gallin deep embedding is
+`Semantics.Composition.TypeShifting.A`, needed there for type-shift metatheory but not
+for this scope contrast. -/
 
 section DKPDerivation
 
-variable {Entity World : Type}
+variable {Entity : Type*}
 
-/-- A kind's extension at each world (the instances) -/
-abbrev KindExtension (Entity World : Type) := World → List Entity
+/-- Existential closure of a property `P` against a predicate `Q` over a finite domain:
+`∃ x ∈ dom, P x ∧ Q x`. Partee's `A` type shift in plain extensional form; `reducible`
+so concrete instances are `Decidable`. -/
+@[reducible] def existsClose (dom : List Entity) (P Q : Entity → Prop) : Prop :=
+  ∃ x ∈ dom, P x ∧ Q x
 
-/-- A VP meaning (intensional) -/
-abbrev ChierchiaVP (Entity World : Type) := Entity → World → Bool
+/-- Chierchia's DKP, unscrambled `[niet [BP V]]`: `¬ ∃ x ∈ kind, P x ∧ Q x`. The
+existential is introduced locally, so negation scopes outside it (narrow scope). -/
+def chierchiaDerivUnscrambled (kind : List Entity) (P Q : Entity → Prop) : Prop :=
+  ¬ existsClose kind P Q
 
-/-- A sentence meaning (proposition) -/
-abbrev ChierchiaSent (World : Type) := World → Bool
+/-- Chierchia's DKP, scrambled `[BP [niet V]]`: identical to the unscrambled derivation.
+DKP locality means surface position cannot move the existential. -/
+def chierchiaDerivScrambled (kind : List Entity) (P Q : Entity → Prop) : Prop :=
+  ¬ existsClose kind P Q
 
-/--
-DKP (Derived Kind Predication): Coerce a kind to work with object-level predicates.
-
-Given a kind (represented by its extension at each world) and an object-level VP,
-DKP introduces existential quantification:
-
-  DKP(VP)(k) = λw. ∃x ∈ k(w). VP(x)(w)
-
-Property: The ∃ is introduced HERE, at the point of composition,
-not at a syntactic position. This makes DKP position-invariant.
--/
-def dkpApply
-    (kind : KindExtension Entity World)
-    (vp : ChierchiaVP Entity World)
-    : ChierchiaSent World :=
-  λ w => (kind w).any (λ x => vp x w)
-
-/--
-Chierchia's derivation for "[niet [BP V]]" (unscrambled).
-
-1. BP = kind k
-2. VP = λx.V(x)
-3. DKP: ∃x[k(x) ∧ V(x)]
-4. Negation: ¬∃x[k(x) ∧ V(x)]
--/
-def chierchiaDerivUnscrambled
-    (kind : KindExtension Entity World)
-    (vp : ChierchiaVP Entity World)
-    : ChierchiaSent World :=
-  λ w => !(dkpApply kind vp w)
-
-/--
-Chierchia's derivation for "[BP [niet V]]" (scrambled).
-
-In Chierchia's system, scrambling doesn't change the derivation.
-DKP still applies when the kind meets the predicate, and the ∃
-is introduced at that point (the trace position in LF).
-
-Result: Same as unscrambled — ¬∃x[k(x) ∧ V(x)]
--/
-def chierchiaDerivScrambled
-    (kind : KindExtension Entity World)
-    (vp : ChierchiaVP Entity World)
-    : ChierchiaSent World :=
-  -- Scrambling is invisible to DKP — same derivation
-  λ w => !(dkpApply kind vp w)
-
-/--
-Chierchia's DKP is position-invariant.
-
-Scrambled and unscrambled derivations yield the same meaning.
-This is the source of Chierchia's incorrect prediction for Dutch scrambling.
--/
-theorem chierchia_position_invariant
-    (kind : KindExtension Entity World)
-    (vp : ChierchiaVP Entity World)
-    : chierchiaDerivScrambled kind vp = chierchiaDerivUnscrambled kind vp := rfl
+/-- **DKP is local**: the scrambled and unscrambled derivations coincide, so Chierchia
+predicts obligatory narrow scope regardless of surface position. This is the content the
+former `dkpIsLocal : Bool := true` stipulated — now a theorem about the derivations. -/
+theorem chierchia_position_invariant (kind : List Entity) (P Q : Entity → Prop) :
+    chierchiaDerivScrambled kind P Q = chierchiaDerivUnscrambled kind P Q :=
+  rfl
 
 end DKPDerivation
 

--- a/Linglib/Studies/Krifka2004.lean
+++ b/Linglib/Studies/Krifka2004.lean
@@ -28,14 +28,14 @@ bare plurals and their wide scope under scrambling.
 * `IsExtensiveMeasure` — the count noun's uniqueness + additivity laws
 * `singularize`, `pluralize` — number morphology (fill `1` / bind `∃ n`)
 * `availableInterpretations`, `kind_requires_topic` — topic-gating of kind reference
-* `existsShiftApply`, `krifkaDerivScrambled`, `krifkaDerivUnscrambled` — the decidable
-  surface-position ∃-shift used for the Dutch/German scrambling contrast
+* `krifkaDerivScrambled`, `krifkaDerivUnscrambled` — the surface-position ∃-shift (built
+  on the shared closure `NMP.existsClose`) used for the Dutch/German scrambling contrast
 * `scope_follows_position` — scrambled and unscrambled derivations diverge
 -/
 
 namespace Krifka2004
 
-open Semantics.Kinds.NMP (Individual)
+open Semantics.Kinds.NMP (Individual existsClose)
 
 /-! ### Count and mass denotations
 
@@ -125,61 +125,41 @@ theorem kind_requires_topic {p : InfoStructure}
 
 /-! ### Surface-position ∃-shift (scrambling)
 
-A decidable mirror of the property denotation above, parallel to the Chierchia DKP
-machinery in `Semantics.Kinds.NMP` (`dkpApply`, `chierchiaDerivScrambled` /
-`chierchiaDerivUnscrambled`): `Bool`- and `List`-valued so the scrambling contrast in
-`Studies.LeBruynDeSwart2022` reduces by `decide` / `rfl`. Krifka's type shift applies
-"as late, or as locally, as possible" (§4.2), so the ∃-shift sits at the bare NP's
-surface position: a bare plural under negation scopes narrow, while one raised above
-negation scopes wide. -/
+Krifka's existential type shift is a *local type repair* applied "as late, or as locally,
+as possible" (§4.2) at the bare NP's surface position, so scope follows position: a bare
+plural under negation scopes narrow, one raised above negation scopes wide. Built on the
+shared closure `NMP.existsClose`, so Krifka's narrow reading is *definitionally*
+Chierchia's DKP derivation (`NMP.chierchiaDerivUnscrambled`); the accounts diverge only
+on the scrambled reading (compared in `Studies/LeBruynDeSwart2022.lean`). -/
 
 section Scrambling
 
-variable {Entity World : Type}
+variable {Entity : Type*}
 
-/-- A bare-NP property (decidable layer). -/
-abbrev KrifkaProp (Entity World : Type) := World → Entity → Bool
+/-- Unscrambled `[niet [BP V]]`: ∃-shift below negation — `¬ ∃ x ∈ dom, P x ∧ Q x`
+(narrow scope). Definitionally `NMP.chierchiaDerivUnscrambled`. -/
+def krifkaDerivUnscrambled (dom : List Entity) (P Q : Entity → Prop) : Prop :=
+  ¬ existsClose dom P Q
 
-/-- A VP meaning (decidable layer). -/
-abbrev KrifkaVP (Entity World : Type) := Entity → World → Bool
+/-- Scrambled `[BP [niet V]]`: ∃-shift above negation — `∃ x ∈ dom, P x ∧ ¬ Q x`
+(wide scope over negation). -/
+def krifkaDerivScrambled (dom : List Entity) (P Q : Entity → Prop) : Prop :=
+  existsClose dom P (fun x => ¬ Q x)
 
-/-- A sentence meaning (decidable layer). -/
-abbrev KrifkaSent (World : Type) := World → Bool
-
-/-- VP negation. -/
-def KrifkaVP.neg (vp : KrifkaVP Entity World) : KrifkaVP Entity World :=
-  fun x w => !vp x w
-
-/-- `∃`-shift applied at the surface position: `∃ x ∈ domain. P(w)(x) ∧ VP(x)(w)`. -/
-def existsShiftApply (domain : List Entity) (prop : KrifkaProp Entity World)
-    (vp : KrifkaVP Entity World) : KrifkaSent World :=
-  fun w => domain.any (fun x => prop w x && vp x w)
-
-/-- Unscrambled `[niet [BP V]]`: `¬∃x[P(x) ∧ V(x)]` (narrow scope). -/
-def krifkaDerivUnscrambled (domain : List Entity) (prop : KrifkaProp Entity World)
-    (vp : KrifkaVP Entity World) : KrifkaSent World :=
-  fun w => !(existsShiftApply domain prop vp w)
-
-/-- Scrambled `[BP [niet V]]`: `∃x[P(x) ∧ ¬V(x)]` (wide scope over negation). -/
-def krifkaDerivScrambled (domain : List Entity) (prop : KrifkaProp Entity World)
-    (vp : KrifkaVP Entity World) : KrifkaSent World :=
-  existsShiftApply domain prop (KrifkaVP.neg vp)
-
-/-- Scope follows surface position: the scrambled (wide-scope) and unscrambled
-(narrow-scope) derivations genuinely diverge. Witnessed by a two-element domain in
-which one element satisfies the VP and the other does not. -/
+/-- **Scope follows position**: the scrambled (wide) and unscrambled (narrow) derivations
+diverge on some model — witnessed by a two-element domain where one element satisfies the
+predicate and the other does not. -/
 theorem scope_follows_position :
-    ∃ (Entity World : Type) (w : World) (domain : List Entity)
-      (prop : KrifkaProp Entity World) (vp : KrifkaVP Entity World),
-      krifkaDerivScrambled domain prop vp w ≠ krifkaDerivUnscrambled domain prop vp w :=
-  ⟨Bool, Unit, (), [true, false], fun _ _ => true, fun b _ => b, by decide⟩
-
-/-- Position-sensitivity, *derived* from the derivations rather than stipulated: on
-the `scope_follows_position` witness, the scrambled and unscrambled derivations
-disagree. Contrast `Semantics.Kinds.NMP.dkpIsLocal`, which is position-invariant. -/
-def existentialShiftPositionSensitive : Bool :=
-  krifkaDerivScrambled [true, false] (fun _ _ => true) (fun b _ => b) () !=
-    krifkaDerivUnscrambled [true, false] (fun _ _ => true) (fun b _ => b) ()
+    ∃ (Entity : Type) (dom : List Entity) (P Q : Entity → Prop),
+      krifkaDerivScrambled dom P Q ≠ krifkaDerivUnscrambled dom P Q := by
+  refine ⟨Bool, [true, false], fun _ => True, fun b => b = true, ?_⟩
+  intro h
+  have hs : krifkaDerivScrambled [true, false] (fun _ => True) (fun b => b = true) := by
+    unfold krifkaDerivScrambled; decide
+  rw [h] at hs
+  have hu : ¬ krifkaDerivUnscrambled [true, false] (fun _ => True) (fun b => b = true) := by
+    unfold krifkaDerivUnscrambled; decide
+  exact hu hs
 
 end Scrambling
 

--- a/Linglib/Studies/LeBruynDeSwart2022.lean
+++ b/Linglib/Studies/LeBruynDeSwart2022.lean
@@ -12,63 +12,56 @@ arguments for the kinds approach. But **scrambled** bare plurals in Dutch/German
 unambiguously take *wide* scope over negation and quantifiers, *while keeping kind
 reference*. This adjudicates two accounts:
 
-* [chierchia-1998] (with [dayal-2004]): bare plurals denote kinds; the existential
-  comes from Derived Kind Predication, which is *local*, so scope is position-invariant
-  and cannot be wide (`NMP.chierchia_position_invariant`).
-* [krifka-2004]: bare plurals are properties; the existential type shift is a *local
-  type repair* at the surface position, so a scrambled (raised) bare plural scopes wide
+* [chierchia-1998] (with [dayal-2004]): bare plurals denote kinds; the existential comes
+  from Derived Kind Predication, which is *local*, so scope is position-invariant and
+  cannot be wide (`NMP.chierchia_position_invariant`).
+* [krifka-2004]: bare plurals are properties; the existential type shift is a *local type
+  repair* at the surface position, so a scrambled (raised) bare plural scopes wide
   (`Krifka2004.scope_follows_position`).
 
-The scrambling data falsify the kinds approach's locality and confirm Krifka's
-position-sensitive shift. Wide scope and kind reference turn out to be dissociable: a
-scrambled bare plural with a kind-level predicate (*haten* 'hate') keeps its kind
-reading.
+Both accounts share one existential closure (`NMP.existsClose`) and differ only in where
+negation sits: Chierchia always keeps it outside (`¬ ∃`), Krifka lets it move inside under
+scrambling (`∃ ¬`). The scrambling data falsify the kinds approach's locality and confirm
+Krifka's position-sensitive shift. Wide scope and kind reference are dissociable.
 
 ## Main declarations
 * `chierchia_invariant_krifka_sensitive` — the theoretical crux: Chierchia's DKP is
   position-invariant for *every* model, while Krifka's ∃-shift diverges on *some* model
-* `theories_diverge_on_scrambling` — on a concrete two-book model the accounts agree on
-  the unscrambled reading and disagree on the scrambled one
-* `krifka_matches_scrambling_data` — Krifka's wide-scope prediction matches the Dutch
-  datum `dutchScrambledBoeken`
+* `theories_agree_unscrambled` / `theories_diverge_on_scrambling` — on a concrete two-book
+  model the accounts agree on the unscrambled reading and disagree on the scrambled one
+* `krifka_matches_scrambling_data` — Krifka's wide-scope reading matches `dutchScrambledBoeken`
 * `scrambled_keeps_kind_reference` — scrambling affects scope, not kindhood
 -/
 
 namespace LeBruynDeSwart2022
 
 open Semantics.Kinds.NMP
-  (KindExtension ChierchiaVP chierchiaDerivScrambled chierchiaDerivUnscrambled
-   chierchia_position_invariant)
-open Krifka2004
-  (KrifkaProp KrifkaVP existsShiftApply krifkaDerivScrambled krifkaDerivUnscrambled
-   scope_follows_position)
+  (chierchiaDerivScrambled chierchiaDerivUnscrambled chierchia_position_invariant)
+open Krifka2004 (krifkaDerivScrambled krifkaDerivUnscrambled scope_follows_position)
 open Phenomena.Generics.KindReference (dutchScrambledBoeken dutchScrambledKindBoeken)
 
 /-! ### The theoretical crux
 
-Chierchia's Derived Kind Predication is *local*: the existential is introduced where
-the kind meets the predicate, regardless of surface position, so scrambled and
-unscrambled derivations coincide. Krifka's existential type shift instead sits at the
-bare NP's surface position, so the two can diverge. -/
+Chierchia's Derived Kind Predication introduces the existential *locally*, so negation
+always scopes outside it and scrambled = unscrambled. Krifka's existential type shift sits
+at the bare NP's surface position, so the two can diverge. -/
 
-/-- The accounts make categorically different scope predictions: Chierchia's derivation
-is position-invariant for *every* kind and VP, whereas Krifka's diverges scrambled vs.
-unscrambled on *some* model. -/
+/-- The accounts make categorically different scope predictions: Chierchia's derivation is
+position-invariant for *every* domain, property, and predicate, whereas Krifka's diverges
+scrambled vs. unscrambled on *some* model. -/
 theorem chierchia_invariant_krifka_sensitive :
-    (∀ {Entity World : Type} (kind : KindExtension Entity World)
-       (vp : ChierchiaVP Entity World),
-       chierchiaDerivScrambled kind vp = chierchiaDerivUnscrambled kind vp) ∧
-    (∃ (Entity World : Type) (w : World) (domain : List Entity)
-       (prop : KrifkaProp Entity World) (vp : KrifkaVP Entity World),
-       krifkaDerivScrambled domain prop vp w ≠ krifkaDerivUnscrambled domain prop vp w) :=
-  ⟨fun kind vp => chierchia_position_invariant kind vp, scope_follows_position⟩
+    (∀ (Entity : Type) (kind : List Entity) (P Q : Entity → Prop),
+       chierchiaDerivScrambled kind P Q = chierchiaDerivUnscrambled kind P Q) ∧
+    (∃ (Entity : Type) (dom : List Entity) (P Q : Entity → Prop),
+       krifkaDerivScrambled dom P Q ≠ krifkaDerivUnscrambled dom P Q) :=
+  ⟨fun _ kind P Q => chierchia_position_invariant kind P Q, scope_follows_position⟩
 
 /-! ### A concrete model: two books, one finished
 
-Le Bruyn & de Swart's *Het klopt dat ik boeken niet heb uitgelezen* ("it's true that
-there are books I didn't finish"): with two books, one finished and one not, the
-scrambled bare plural is true (there is an unfinished book) but the unscrambled reading
-is false (it would mean "I finished no books"). -/
+Le Bruyn & de Swart's *Het klopt dat ik boeken niet heb uitgelezen* ("it's true that there
+are books I didn't finish"): with two books, one finished and one not, the scrambled bare
+plural is true (there is an unfinished book) but the unscrambled reading is false (it would
+mean "I finished no books"). -/
 
 inductive Book where
   | b1
@@ -77,46 +70,48 @@ inductive Book where
 
 def bookDomain : List Book := [.b1, .b2]
 
-/-- "books" as a property (true of every book). -/
-def isBook : KrifkaProp Book Unit := fun _ _ => true
+/-- "books" — true of every book. -/
+def isBook : Book → Prop := fun _ => True
 
-/-- "finished": b1 finished, b2 not. -/
-def finishedVP : KrifkaVP Book Unit := fun b _ =>
-  match b with
-  | .b1 => true
-  | .b2 => false
+/-- "finished" — true of `b1`, false of `b2`. -/
+def finished : Book → Prop := fun b => b = .b1
 
-/-- The same world as a kind extension (Chierchia's input). -/
-def bookKind : KindExtension Book Unit := fun _ => bookDomain
-
-/-- The VP as Chierchia's object-level predicate (same data as Krifka's). -/
-def finishedChierchia : ChierchiaVP Book Unit := finishedVP
-
--- Krifka distinguishes the two positions: narrow (false) vs wide (true).
-example : krifkaDerivUnscrambled bookDomain isBook finishedVP () = false := rfl
-example : krifkaDerivScrambled bookDomain isBook finishedVP () = true := rfl
+-- Krifka distinguishes the positions: unscrambled narrow (false), scrambled wide (true).
+example : ¬ krifkaDerivUnscrambled bookDomain isBook finished := by
+  unfold krifkaDerivUnscrambled isBook finished bookDomain; decide
+example : krifkaDerivScrambled bookDomain isBook finished := by
+  unfold krifkaDerivScrambled isBook finished bookDomain; decide
 
 -- Chierchia collapses them: both narrow (false), by DKP locality.
-example : chierchiaDerivUnscrambled bookKind finishedChierchia () = false := rfl
-example : chierchiaDerivScrambled bookKind finishedChierchia () = false := rfl
+example : ¬ chierchiaDerivScrambled bookDomain isBook finished := by
+  unfold chierchiaDerivScrambled isBook finished bookDomain; decide
 
 /-! ### The decisive divergence -/
 
-/-- The accounts agree on the unscrambled reading but diverge on the scrambled one:
-Chierchia keeps narrow scope (`false`) where Krifka derives wide scope (`true`). -/
-theorem theories_diverge_on_scrambling :
-    chierchiaDerivUnscrambled bookKind finishedChierchia () =
-        krifkaDerivUnscrambled bookDomain isBook finishedVP () ∧
-    chierchiaDerivScrambled bookKind finishedChierchia () ≠
-        krifkaDerivScrambled bookDomain isBook finishedVP () := by
-  refine ⟨rfl, ?_⟩
-  decide
-
-/-- Krifka's wide-scope prediction for the scrambled bare plural matches the Dutch
-datum (`dutchScrambledBoeken.wideOK`): there are books I didn't finish. -/
-theorem krifka_matches_scrambling_data :
-    krifkaDerivScrambled bookDomain isBook finishedVP () = dutchScrambledBoeken.wideOK :=
+/-- The accounts agree on the unscrambled reading: both are `¬ ∃ x ∈ dom, P x ∧ Q x`. -/
+theorem theories_agree_unscrambled :
+    chierchiaDerivUnscrambled bookDomain isBook finished =
+      krifkaDerivUnscrambled bookDomain isBook finished :=
   rfl
+
+/-- …but diverge on the scrambled reading: Chierchia keeps narrow scope (`false`) where
+Krifka derives wide scope (`true`). -/
+theorem theories_diverge_on_scrambling :
+    chierchiaDerivScrambled bookDomain isBook finished ≠
+      krifkaDerivScrambled bookDomain isBook finished := by
+  intro h
+  have hk : krifkaDerivScrambled bookDomain isBook finished := by
+    unfold krifkaDerivScrambled isBook finished bookDomain; decide
+  rw [← h] at hk
+  have hc : ¬ chierchiaDerivScrambled bookDomain isBook finished := by
+    unfold chierchiaDerivScrambled isBook finished bookDomain; decide
+  exact hc hk
+
+/-- Krifka's scrambled reading is wide, matching the Dutch datum
+(`dutchScrambledBoeken.wideOK`): there are books I didn't finish. -/
+theorem krifka_matches_scrambling_data :
+    krifkaDerivScrambled bookDomain isBook finished ∧ dutchScrambledBoeken.wideOK = true :=
+  ⟨by unfold krifkaDerivScrambled isBook finished bookDomain; decide, rfl⟩
 
 /-! ### Wide scope and kind reference are dissociable -/
 


### PR DESCRIPTION
Substrate follow-up to #235: unify the kind-reference scope-derivation layer onto one plain-`Prop` existential closure and derive DKP locality instead of stipulating it.

- De-stipulate `dkpIsLocal : Bool := true` → the theorem `chierchia_position_invariant` (DKP gives the same narrow scope scrambled or not).
- Collapse the two duplicate `Bool`/`List.any` closures (`dkpApply`, `existsShiftApply`) into one `Prop` `existsClose`; both accounts share it and differ only in where `¬` sits. The scope contrast is now `¬∃` (Chierchia/narrow) vs `∃¬` (Krifka/wide).
- Plain Lean `Prop` + `Decidable`, not `Frame`/`TypeShifting.A`: the DWP deep embedding is for type-shift metatheory, not a bare ∃-vs-¬ contrast.

Depends on #235.