### PR TITLE
feat(Core/Logic/Entailment): Entails/Valid schema + mathlib FO bridge

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -32,6 +32,8 @@ import Linglib.Typology.Evidentiality
 import Linglib.Core.Logic.FactorsThroughOn
 import Linglib.Core.Logic.Truth3
 import Linglib.Core.Logic.Consequence
+import Linglib.Core.Logic.Entailment.Basic
+import Linglib.Core.Logic.Entailment.FirstOrder
 import Linglib.Core.Logic.ThreeValuedLogic
 import Linglib.Core.Logic.Bilateral.Defs
 import Linglib.Core.Logic.Bilateral.Classical

--- a/Linglib/Core/Logic/Entailment/Basic.lean
+++ b/Linglib/Core/Logic/Entailment/Basic.lean
@@ -1,0 +1,76 @@
+import Mathlib.Data.List.Basic
+
+/-!
+# Shared entailment schema
+
+`Entails`/`Valid` over an abstract satisfaction relation `sat : Pt → Prp → Prop`, where the
+*evaluation point* `Pt` is either a **world** (intra-model entailment, the dominant linglib
+idiom `∀ w, p w → q w`) or a **model/structure** (logical consequence — see
+`Core.Logic.Entailment.FirstOrder` for the mathlib first-order instance, where this schema
+reduces to mathlib's `T ⊨ᵇ φ`).
+
+This is the unmixed, single-mode core of `Core.Logic.Consequence.MixedConsequence`
+([cobreros-etal-2012]); the mixed (different premise/conclusion mode) version lives there and
+is what genuinely two-standard relations (Strawson entailment, tolerant/strict) instantiate.
+
+## Main definitions
+
+* `Entails` / `Valid` — the abstract schema and its premise-free specialization
+* `propEntails` — the intra-model instance over propositions as world-sets (`W → Prop`),
+  replacing the per-file `entails := (· ⊆ ·)` / `∀ w, p w → q w` definitions
+-/
+
+namespace Core.Logic.Entailment
+
+variable {Pt Prp : Type*}
+
+/-- `Entails sat Γ φ`: every evaluation point satisfying all premises also satisfies `φ`. -/
+def Entails (sat : Pt → Prp → Prop) (Γ : List Prp) (φ : Prp) : Prop :=
+  ∀ x : Pt, (∀ γ ∈ Γ, sat x γ) → sat x φ
+
+/-- `Valid sat φ`: `φ` holds at every evaluation point (premise-free `Entails`). -/
+def Valid (sat : Pt → Prp → Prop) (φ : Prp) : Prop :=
+  ∀ x : Pt, sat x φ
+
+theorem valid_iff_entails_nil (sat : Pt → Prp → Prop) (φ : Prp) :
+    Valid sat φ ↔ Entails sat [] φ := by
+  simp [Valid, Entails]
+
+/-- Reflexivity: a premise entails itself. -/
+theorem entails_self (sat : Pt → Prp → Prop) (φ : Prp) : Entails sat [φ] φ :=
+  fun _ h => h φ (by simp)
+
+/-- Premise monotonicity: a superset of premises entails at least as much. -/
+theorem entails_mono_premises {sat : Pt → Prp → Prop} {Γ Δ : List Prp} {φ : Prp}
+    (hsub : ∀ γ ∈ Γ, γ ∈ Δ) (h : Entails sat Γ φ) : Entails sat Δ φ :=
+  fun x hΔ => h x (fun γ hγ => hΔ γ (hsub γ hγ))
+
+/-- Cut: if every member of `Δ` follows from `Γ` and `φ` follows from `Δ`, then `φ`
+    follows from `Γ`. -/
+theorem entails_cut {sat : Pt → Prp → Prop} {Γ Δ : List Prp} {φ : Prp}
+    (hΔ : ∀ δ ∈ Δ, Entails sat Γ δ) (h : Entails sat Δ φ) : Entails sat Γ φ :=
+  fun x hΓ => h x (fun δ hδ => hΔ δ hδ x hΓ)
+
+/-! ### Intra-model propositional entailment
+
+The dominant linglib instance: `Pt := W` (worlds/indices), propositions are world-sets
+`W → Prop`, and `sat w p := p w`. -/
+
+/-- `p ⊨ q` over propositions-as-world-sets: `∀ w, p w → q w`. The canonical instance of
+`Entails` with `Pt := W`, `sat w r := r w`. -/
+def propEntails {W : Type*} (p q : W → Prop) : Prop :=
+  Entails (Pt := W) (fun w r => r w) [p] q
+
+theorem propEntails_iff {W : Type*} (p q : W → Prop) :
+    propEntails p q ↔ ∀ w, p w → q w := by
+  simp [propEntails, Entails]
+
+@[refl] theorem propEntails_refl {W : Type*} (p : W → Prop) : propEntails p p :=
+  (propEntails_iff p p).mpr fun _ h => h
+
+theorem propEntails_trans {W : Type*} {p q r : W → Prop}
+    (h₁ : propEntails p q) (h₂ : propEntails q r) : propEntails p r :=
+  (propEntails_iff _ _).mpr fun w hp =>
+    (propEntails_iff _ _).mp h₂ w ((propEntails_iff _ _).mp h₁ w hp)
+
+end Core.Logic.Entailment

--- a/Linglib/Core/Logic/Entailment/FirstOrder.lean
+++ b/Linglib/Core/Logic/Entailment/FirstOrder.lean
@@ -1,0 +1,42 @@
+import Mathlib.ModelTheory.Satisfiability
+import Linglib.Core.Logic.Entailment.Basic
+
+/-!
+# First-order logical consequence as an `Entails` instance
+
+mathlib's first-order semantic consequence `T ⊨ᵇ φ`
+(`FirstOrder.Language.Theory.ModelsBoundedFormula`) is the instance of
+`Core.Logic.Entailment.Valid` whose evaluation points are the *models of `T`* and whose
+satisfaction relation is `sat M φ := M ⊨ φ` (`Sentence.Realize`). First-order premises are
+folded into the theory `T`, so the premise-free `Valid` already captures FO consequence.
+
+This is the **base case** of the shared entailment schema: any linglib fragment whose truth
+conditions are genuinely first-order — e.g. DRT static truth, which already interprets DRSs
+into `FirstOrder.Language.Structure`s via `DRS.Realize` — can route its entailment through
+this bridge and inherit mathlib's first-order metatheory (compactness, completeness, Łoś,
+elementary maps) rather than re-deriving it.
+
+## Main results
+
+* `valid_iff_models` — linglib `Valid` over `T`'s models, with `sat = Realize`, *is*
+  mathlib's `T ⊨ᵇ φ`.
+-/
+
+open FirstOrder Language Core.Logic.Entailment
+
+namespace Core.Logic.Entailment.FirstOrder
+
+universe u v
+
+variable {L : Language.{u, v}}
+
+/-- **The base case**: `Core.Logic.Entailment.Valid` over the models of a first-order theory
+`T`, with satisfaction `M ⊨ ψ` (`Sentence.Realize`), is exactly mathlib's first-order
+semantic consequence `T ⊨ᵇ φ`. The two are definitionally the same `∀ M ⊨ T, M ⊨ φ`; the
+bridge is `models_sentence_iff`. -/
+theorem valid_iff_models (T : L.Theory) (φ : L.Sentence) :
+    Valid (Pt := FirstOrder.Language.Theory.ModelType.{u, v, max u v} T)
+      (fun M ψ => Sentence.Realize M ψ) φ ↔ T ⊨ᵇ φ :=
+  FirstOrder.Language.Theory.models_sentence_iff.symm
+
+end Core.Logic.Entailment.FirstOrder


### PR DESCRIPTION
A shared entailment vocabulary over an abstract satisfaction relation, with mathlib's first-order consequence as the base case — the substrate for unifying the ~35 reinvented `entails`/`valid` definitions.

- `Entails`/`Valid` over `sat : Pt → Prp → Prop`, where the evaluation point `Pt` is a world (intra-model) or a model/structure (logical consequence); + `propEntails` for the dominant `∀ w, p w → q w` idiom, with refl/trans/cut/monotonicity.
- `valid_iff_models` : mathlib's `T ⊨ᵇ φ` *is* `Valid` over `T`'s models with `sat = Sentence.Realize` (proved by `models_sentence_iff`). FO-expressible fragments can route entailment through this and inherit mathlib's FO metatheory.
- Additive: two new `Core/Logic/Entailment/` files; consumer migration onto `propEntails` is a follow-up.