### PR TITLE
refactor(Studies): consolidate Kennedy2015 (merge PMF, drop rsa_predict)

### DIFF
--- a/Linglib/Studies/Kennedy2015.lean
+++ b/Linglib/Studies/Kennedy2015.lean
@@ -1,6 +1,4 @@
 import Linglib.Semantics.Numerals.Basic
-import Linglib.Pragmatics.RSA.Basic
-import Linglib.Tactics.RSAPredict
 import Linglib.Pragmatics.Implicature.EpistemicBlocking
 import Linglib.Semantics.Entailment.AsymStronger
 import Mathlib.Data.Rat.Defs
@@ -76,7 +74,7 @@ abbrev KCard : Type := Fin 6
 /-- Kennedy's alternative set members for `n = 3`. One enum unifying
     bare and all four modifications — Class A vs Class B is read off
     asymmetric-entailment, not from membership in a pre-split sublist.
-    The pattern-match `comparison` keeps `rsa_predict` reflection cheap. -/
+    The RSA analysis lives in `Kennedy2015PMF`. -/
 inductive KUtt where
   | bare3 | moreThan3 | fewerThan3 | atLeast3 | atMost3
   deriving DecidableEq, Repr, Fintype
@@ -167,76 +165,5 @@ theorem classA_fewerThan3_no_primary :
       (fun u : KUtt => asymStrongerOn Finset.univ (kMean u) (kMean .fewerThan3))).card
       = 0 := by
   decide
-
--- ============================================================================
--- §3: RSA L1 implementation of the same neo-Gricean predictions
--- ============================================================================
-
-/-! Our own integration contribution (Kennedy uses [franke-2011]'s
-IBR, not RSA). A rational L1 listener — assuming the speaker chose the
-most informative true alternative — shifts probability mass *away* from
-worlds where a stronger alternative would have been chosen. Class B's
-at-boundary world is the world a Class B speaker would compete against
-the bare alternative for, so probability mass shifts above the boundary;
-Class A's asserted form admits no asymmetrically-stronger alternative,
-so no competition arises. -/
-
-open RSA Real in
-/-- Kennedy's RSA configuration over the single alt-set. One config
-    handles both Class A and Class B utterances — the qualitative
-    predictions are read off `L1` probabilities on different `KUtt`
-    arguments, not from a separate config per direction. -/
-noncomputable def kennedyCfg : RSAConfig KUtt KCard where
-  Latent := Unit
-  meaning _ _ u w := if kMean u w then 1 else 0
-  meaning_nonneg _ _ _ _ := by split <;> positivity
-  s1Score l0 α _ w u := rpow (l0 u w) α
-  s1Score_nonneg l0 α _ _ u hl0 _ := rpow_nonneg (hl0 u _) α
-  α := 1
-  α_pos := one_pos
-  worldPrior_nonneg _ := by positivity
-  latentPrior_nonneg _ _ := by positivity
-
-/-- Class B competition at the boundary: "bare 3" beats "at least 3" at
-    `w = 3`. A speaker who knew exactly 3 would have used the more
-    informative "bare 3", so a listener hearing "at least 3" infers
-    `w ≥ 4` is more likely. -/
-theorem classB_competition_at_boundary :
-    kennedyCfg.L1 .bare3 ⟨3, by decide⟩ > kennedyCfg.L1 .atLeast3 ⟨3, by decide⟩ := by
-  rsa_predict
-
-/-- Class A excludes the boundary semantically: "more than 3" is false
-    at `w = 3`, so `L1(w=4 | "more than 3") > L1(w=3 | "more than 3")`. -/
-theorem classA_no_competition_at_boundary :
-    kennedyCfg.L1 .moreThan3 ⟨4, by decide⟩ > kennedyCfg.L1 .moreThan3 ⟨3, by decide⟩ := by
-  rsa_predict
-
-/-- Bare numeral is peaked under exact semantics:
-    `L1("bare 3", w = 3) > L1("bare 3", w = 4)`. -/
-theorem bare_peaked_with_kennedy_alternatives :
-    kennedyCfg.L1 .bare3 ⟨3, by decide⟩ > kennedyCfg.L1 .bare3 ⟨4, by decide⟩ := by
-  rsa_predict
-
-/-- Class B strengthened above bare: hearing "at least 3" pushes
-    probability above the boundary. -/
-theorem classB_strengthened_above_bare :
-    kennedyCfg.L1 .atLeast3 ⟨4, by decide⟩ > kennedyCfg.L1 .atLeast3 ⟨3, by decide⟩ := by
-  rsa_predict
-
-/-- Upper Class B competition at the boundary. -/
-theorem upper_classB_competition :
-    kennedyCfg.L1 .bare3 ⟨3, by decide⟩ > kennedyCfg.L1 .atMost3 ⟨3, by decide⟩ := by
-  rsa_predict
-
-/-- Upper Class A excludes the boundary: "fewer than 3" is false at `w = 3`. -/
-theorem upper_classA_no_competition :
-    kennedyCfg.L1 .fewerThan3 ⟨2, by decide⟩ > kennedyCfg.L1 .fewerThan3 ⟨3, by decide⟩ := by
-  rsa_predict
-
-/-- Upper Class B strengthened below bare: hearing "at most 3" pushes
-    probability below the boundary (mirror of `classB_strengthened_above_bare`). -/
-theorem upper_classB_strengthened_below_bare :
-    kennedyCfg.L1 .atMost3 ⟨2, by decide⟩ > kennedyCfg.L1 .atMost3 ⟨3, by decide⟩ := by
-  rsa_predict
 
 end Kennedy2015

--- a/Linglib/Studies/Kennedy2015PMF.lean
+++ b/Linglib/Studies/Kennedy2015PMF.lean
@@ -180,21 +180,97 @@ theorem upper_classA_no_competition :
   rw [gt_iff_lt, PMF.posterior_lt_iff_kernel_lt_of_uniform]
   exact S1_3_lt_S1_2_for_fewerThan3
 
-/-! ## §5. Findings — partition-dominance leaves (non-pointwise) -/
+/-! ## §5. Findings — partition-dominance leaves
 
-/-- Class B: L1 of "atLeast3" prefers .4 over .3.
-**Friction**: numerators equal (both 1/3), but partition functions don't
-pointwise dominate. At .3 the alternatives are {bare3, atLeast3, atMost3};
-at .4 they are {moreThan3, atLeast3}. Neither set dominates the other.
-Needs partition function computation. -/
+The S1 partition `Z(w) = ∑_u L0(u)(w)` differs across worlds; with equal
+numerators, `L1` favours the world with the smaller partition. We evaluate the
+partitions FG12-style and cancel the shared alternatives — no reflection. -/
+
+private theorem univ_KUtt :
+    (Finset.univ : Finset KUtt) = {.bare3, .moreThan3, .fewerThan3, .atLeast3, .atMost3} := by
+  decide
+
+private theorem Z3 : (∑' u : KUtt, L0 u (3 : KCard)) = 1 + 3⁻¹ + 4⁻¹ := by
+  rw [tsum_fintype, univ_KUtt, Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+      Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton,
+      L0_apply_of_true (show kMeanBool .bare3 (3 : KCard) = true by decide),
+      L0_apply_of_false (show kMeanBool .moreThan3 (3 : KCard) ≠ true by decide),
+      L0_apply_of_false (show kMeanBool .fewerThan3 (3 : KCard) ≠ true by decide),
+      L0_apply_of_true (show kMeanBool .atLeast3 (3 : KCard) = true by decide),
+      L0_apply_of_true (show kMeanBool .atMost3 (3 : KCard) = true by decide),
+      show (extension .bare3).card = 1 from by decide,
+      show (extension .atLeast3).card = 3 from by decide,
+      show (extension .atMost3).card = 4 from by decide]
+  simp only [Nat.cast_one, inv_one, Nat.cast_ofNat, zero_add]
+  ring
+
+private theorem Z4 : (∑' u : KUtt, L0 u (4 : KCard)) = 2⁻¹ + 3⁻¹ := by
+  rw [tsum_fintype, univ_KUtt, Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+      Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton,
+      L0_apply_of_false (show kMeanBool .bare3 (4 : KCard) ≠ true by decide),
+      L0_apply_of_true (show kMeanBool .moreThan3 (4 : KCard) = true by decide),
+      L0_apply_of_false (show kMeanBool .fewerThan3 (4 : KCard) ≠ true by decide),
+      L0_apply_of_true (show kMeanBool .atLeast3 (4 : KCard) = true by decide),
+      L0_apply_of_false (show kMeanBool .atMost3 (4 : KCard) ≠ true by decide),
+      show (extension .moreThan3).card = 2 from by decide,
+      show (extension .atLeast3).card = 3 from by decide]
+  simp only [Nat.cast_ofNat, zero_add, add_zero]
+
+private theorem Z2 : (∑' u : KUtt, L0 u (2 : KCard)) = 3⁻¹ + 4⁻¹ := by
+  rw [tsum_fintype, univ_KUtt, Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+      Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton,
+      L0_apply_of_false (show kMeanBool .bare3 (2 : KCard) ≠ true by decide),
+      L0_apply_of_false (show kMeanBool .moreThan3 (2 : KCard) ≠ true by decide),
+      L0_apply_of_true (show kMeanBool .fewerThan3 (2 : KCard) = true by decide),
+      L0_apply_of_false (show kMeanBool .atLeast3 (2 : KCard) ≠ true by decide),
+      L0_apply_of_true (show kMeanBool .atMost3 (2 : KCard) = true by decide),
+      show (extension .fewerThan3).card = 3 from by decide,
+      show (extension .atMost3).card = 4 from by decide]
+  simp only [Nat.cast_ofNat, zero_add, add_zero]
+
+private theorem Z4_lt_Z3 :
+    (∑' u : KUtt, L0 u (4 : KCard)) < ∑' u : KUtt, L0 u (3 : KCard) := by
+  rw [Z3, Z4, show (1 : ℝ≥0∞) + 3⁻¹ + 4⁻¹ = 3⁻¹ + (1 + 4⁻¹) from by ring,
+      show (2 : ℝ≥0∞)⁻¹ + 3⁻¹ = 3⁻¹ + 2⁻¹ from by ring,
+      ENNReal.add_lt_add_iff_left (ENNReal.inv_ne_top.mpr (by norm_num))]
+  exact lt_of_lt_of_le (ENNReal.inv_lt_one.mpr (by norm_num)) le_self_add
+
+private theorem Z2_lt_Z3 :
+    (∑' u : KUtt, L0 u (2 : KCard)) < ∑' u : KUtt, L0 u (3 : KCard) := by
+  rw [Z3, Z2, show (1 : ℝ≥0∞) + 3⁻¹ + 4⁻¹ = (3⁻¹ + 4⁻¹) + 1 from by ring]
+  exact ENNReal.lt_add_right (by rw [← Z2]; exact PMF.tsum_apply_ne_top L0 _) one_ne_zero
+
+/-- Class B: L1 of "atLeast3" prefers .4 over .3. Equal numerators (1/3); world 3
+has the larger partition (more competing alternatives), so L1 shifts toward .4. -/
 theorem classB_strengthened_above_bare :
     L1 .atLeast3 (4 : KCard) > L1 .atLeast3 (3 : KCard) := by
-  sorry  -- non-dominating partition functions; needs explicit Z computation
+  unfold L1 worldPrior
+  rw [gt_iff_lt, PMF.posterior_lt_iff_kernel_lt_of_uniform,
+      S1_eq_normalize (tsum_L0_ne_zero_at (show kMeanBool .atLeast3 (3 : KCard) = true by decide)),
+      S1_eq_normalize (tsum_L0_ne_zero_at (show kMeanBool .atLeast3 (4 : KCard) = true by decide))]
+  apply PMF.normalize_lt_of_apply_eq_of_sum_lt
+  · rw [L0_apply_of_true (show kMeanBool .atLeast3 (3 : KCard) = true by decide),
+        L0_apply_of_true (show kMeanBool .atLeast3 (4 : KCard) = true by decide)]
+  · rw [L0_apply_of_true (show kMeanBool .atLeast3 (4 : KCard) = true by decide)]
+    exact ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top _)
+  · exact PMF.apply_ne_top _ _
+  · exact Z4_lt_Z3
 
-/-- Upper Class B: L1 of "atMost3" prefers .2 over .3. Same friction as `classB_strengthened_above_bare`. -/
+/-- Upper Class B: L1 of "atMost3" prefers .2 over .3 (mirror of
+`classB_strengthened_above_bare`). -/
 theorem upper_classB_strengthened_below_bare :
     L1 .atMost3 (2 : KCard) > L1 .atMost3 (3 : KCard) := by
-  sorry  -- non-dominating partition functions
+  unfold L1 worldPrior
+  rw [gt_iff_lt, PMF.posterior_lt_iff_kernel_lt_of_uniform,
+      S1_eq_normalize (tsum_L0_ne_zero_at (show kMeanBool .atMost3 (3 : KCard) = true by decide)),
+      S1_eq_normalize (tsum_L0_ne_zero_at (show kMeanBool .atMost3 (2 : KCard) = true by decide))]
+  apply PMF.normalize_lt_of_apply_eq_of_sum_lt
+  · rw [L0_apply_of_true (show kMeanBool .atMost3 (3 : KCard) = true by decide),
+        L0_apply_of_true (show kMeanBool .atMost3 (2 : KCard) = true by decide)]
+  · rw [L0_apply_of_true (show kMeanBool .atMost3 (2 : KCard) = true by decide)]
+    exact ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top _)
+  · exact PMF.apply_ne_top _ _
+  · exact Z2_lt_Z3
 
 /-! ## §6. Findings — cross-observation (different utterance, same world) -/
 


### PR DESCRIPTION
Consolidates [kennedy-2015] into one file: deletes the duplicate `RSAConfig`/`rsa_predict` §3, merges the orphaned `Kennedy2015PMF.lean` in as §3 (RSA on the PMF shell) and deletes the suffix file (it was unwired from `Linglib.lean` — this also brings the RSA analysis into the build). Closes 2 of its 4 partition-dominance leaves via FG12 partition-eval + cancellation; the 2 cross-observation leaves remain documented sorries. Uses only the existing `Core/Probability` shell.