### PR TITLE
feat(Semantics/Composition): toy Model, FO compiler, Theory ⊨ bridge

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2327,6 +2327,7 @@ import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Syntax.Minimalist.LongDistanceAgree
 import Linglib.Semantics.Composition.Tree
 import Linglib.Semantics.Composition.Model
+import Linglib.Semantics.Composition.Reduction
 import Linglib.Semantics.Composition.WriterMonad
 
 

--- a/Linglib/Fragments/English/Toy.lean
+++ b/Linglib/Fragments/English/Toy.lean
@@ -5,8 +5,11 @@ import Mathlib.Data.Fintype.Basic
 # Toy English fragment
 
 The pedagogical fragment used by compositional-semantics studies, built the
-model-theoretic way: a first-order signature (`toyLang`), a structure carrying
-the facts (`toyStructure`), the composition model (`toyModel`), and naming maps
+model-theoretic way and in mathlib's concrete-language idiom (after
+`Mathlib/ModelTheory/Algebra/Ring/Basic.lean`): arity-indexed symbol inductives
+(`toyFunc`, `toyRel`), the signature (`toyLang`), per-symbol defeq abbreviations
+(`sleepRel`, …), a structure carrying the facts (`toyStructure`) with one
+`@[simp]` lemma per symbol, the composition model (`toyModel`), and naming maps
 (`toyNaming`) from word forms into the signature. The `ToyLexicon` denotations
 are *read off the model* via `Model.const`/`Model.pred₁ext`/`Model.pred₂ext` —
 the connection is true by construction, with no bridge theorems.
@@ -31,67 +34,155 @@ instance : Fintype ToyEntity where
   elems := {.john, .mary, .pizza, .book}
   complete := fun x => by cases x <;> simp
 
-/-- Unary relation symbols of the toy signature. -/
-inductive ToyRel₁ where
-  | sleep | laugh | student | person | thing | pizza | book
-  deriving Repr, DecidableEq
+/-- Function symbols of the toy signature: constants naming entities. -/
+inductive toyFunc : ℕ → Type
+  | john : toyFunc 0
+  | mary : toyFunc 0
+  deriving DecidableEq
 
-/-- Binary relation symbols of the toy signature. -/
-inductive ToyRel₂ where
-  | see | eat | read
-  deriving Repr, DecidableEq
+/-- Relation symbols of the toy signature: content words at their arities. -/
+inductive toyRel : ℕ → Type
+  | sleep : toyRel 1
+  | laugh : toyRel 1
+  | student : toyRel 1
+  | person : toyRel 1
+  | thing : toyRel 1
+  | pizza : toyRel 1
+  | book : toyRel 1
+  | see : toyRel 2
+  | eat : toyRel 2
+  | read : toyRel 2
+  deriving DecidableEq
 
-/-- The toy lexical signature: every entity is nameable by a constant; content
-words are relation symbols. -/
-def toyLang : Language where
-  Functions := fun n => match n with | 0 => ToyEntity | _ => Empty
-  Relations := fun n => match n with | 1 => ToyRel₁ | 2 => ToyRel₂ | _ => Empty
+/-- The toy lexical signature. -/
+def toyLang : Language :=
+  { Functions := toyFunc
+    Relations := toyRel }
 
-/-- The facts: interpretation of unary symbols. -/
-def interpRel₁ : ToyRel₁ → ToyEntity → Prop := fun r x =>
-  match r, x with
-  | .sleep, .john => True
-  | .sleep, _ => False
-  | .laugh, .john => True
-  | .laugh, .mary => True
-  | .laugh, _ => False
-  | .student, .john => True
-  | .student, .mary => True
-  | .student, _ => False
-  | .person, .john => True
-  | .person, .mary => True
-  | .person, _ => False
-  | .thing, _ => True
-  | .pizza, .pizza => True
-  | .pizza, _ => False
-  | .book, .book => True
-  | .book, _ => False
+/-! Per-symbol abbreviations with the defeq types `toyLang.Constants` /
+`toyLang.Relations n` (mathlib's `addFunc` idiom), so symbols elaborate
+without unfolding `toyLang`. -/
 
-/-- The facts: interpretation of binary symbols (subject-first). -/
-def interpRel₂ : ToyRel₂ → ToyEntity → ToyEntity → Prop := fun r subj obj =>
-  match r, subj, obj with
-  | .see, .john, .mary => True
-  | .see, .mary, .john => True
-  | .see, _, _ => False
-  | .eat, .john, .pizza => True
-  | .eat, .mary, .pizza => True
-  | .eat, _, _ => False
-  | .read, .john, .book => True
-  | .read, .mary, .book => True
-  | .read, _, _ => False
+abbrev johnConst : toyLang.Constants := .john
+abbrev maryConst : toyLang.Constants := .mary
+abbrev sleepRel : toyLang.Relations 1 := .sleep
+abbrev laughRel : toyLang.Relations 1 := .laugh
+abbrev studentRel : toyLang.Relations 1 := .student
+abbrev personRel : toyLang.Relations 1 := .person
+abbrev thingRel : toyLang.Relations 1 := .thing
+abbrev pizzaRel : toyLang.Relations 1 := .pizza
+abbrev bookRel : toyLang.Relations 1 := .book
+abbrev seeRel : toyLang.Relations 2 := .see
+abbrev eatRel : toyLang.Relations 2 := .eat
+abbrev readRel : toyLang.Relations 2 := .read
 
-/-- The toy structure: constants denote themselves; relations carry the facts. -/
+/-! ### The facts -/
+
+namespace ToyFacts
+
+def sleep : ToyEntity → Prop := fun x =>
+  match x with
+  | .john => True
+  | _ => False
+
+def laugh : ToyEntity → Prop := fun x =>
+  match x with
+  | .john => True
+  | .mary => True
+  | _ => False
+
+def student : ToyEntity → Prop := fun x =>
+  match x with
+  | .john => True
+  | .mary => True
+  | _ => False
+
+def person : ToyEntity → Prop := fun x =>
+  match x with
+  | .john => True
+  | .mary => True
+  | _ => False
+
+def thing : ToyEntity → Prop := fun _ => True
+
+def pizza : ToyEntity → Prop := fun x =>
+  match x with
+  | .pizza => True
+  | _ => False
+
+def book : ToyEntity → Prop := fun x =>
+  match x with
+  | .book => True
+  | _ => False
+
+def see : ToyEntity → ToyEntity → Prop := fun subj obj =>
+  match subj, obj with
+  | .john, .mary => True
+  | .mary, .john => True
+  | _, _ => False
+
+def eat : ToyEntity → ToyEntity → Prop := fun subj obj =>
+  match subj, obj with
+  | .john, .pizza => True
+  | .mary, .pizza => True
+  | _, _ => False
+
+def read : ToyEntity → ToyEntity → Prop := fun subj obj =>
+  match subj, obj with
+  | .john, .book => True
+  | .mary, .book => True
+  | _, _ => False
+
+end ToyFacts
+
+/-- The toy structure: constants denote their entities; relations carry the
+facts (binary relations subject-first). -/
 def toyStructure : toyLang.Structure ToyEntity where
   funMap {n} f v :=
-    match n, f, v with
-    | 0, c, _ => c
-    | _ + 1, f, _ => nomatch f
+    match f, v with
+    | .john, _ => ToyEntity.john
+    | .mary, _ => ToyEntity.mary
   RelMap {n} r v :=
-    match n, r, v with
-    | 0, r, _ => nomatch r
-    | 1, r, v => interpRel₁ r (v 0)
-    | 2, r, v => interpRel₂ r (v 0) (v 1)
-    | _ + 3, r, _ => nomatch r
+    match r, v with
+    | .sleep, v => ToyFacts.sleep (v 0)
+    | .laugh, v => ToyFacts.laugh (v 0)
+    | .student, v => ToyFacts.student (v 0)
+    | .person, v => ToyFacts.person (v 0)
+    | .thing, v => ToyFacts.thing (v 0)
+    | .pizza, v => ToyFacts.pizza (v 0)
+    | .book, v => ToyFacts.book (v 0)
+    | .see, v => ToyFacts.see (v 0) (v 1)
+    | .eat, v => ToyFacts.eat (v 0) (v 1)
+    | .read, v => ToyFacts.read (v 0) (v 1)
+
+/-! One `@[simp]` lemma per symbol (mathlib's `funMap_add` discipline), so
+proofs reduce `RelMap`/`funMap` to the named facts without unfolding the
+structure. -/
+
+@[simp] theorem funMap_john (v : Fin 0 → ToyEntity) :
+    toyStructure.funMap johnConst v = ToyEntity.john := rfl
+@[simp] theorem funMap_mary (v : Fin 0 → ToyEntity) :
+    toyStructure.funMap maryConst v = ToyEntity.mary := rfl
+@[simp] theorem relMap_sleep (v : Fin 1 → ToyEntity) :
+    toyStructure.RelMap sleepRel v = ToyFacts.sleep (v 0) := rfl
+@[simp] theorem relMap_laugh (v : Fin 1 → ToyEntity) :
+    toyStructure.RelMap laughRel v = ToyFacts.laugh (v 0) := rfl
+@[simp] theorem relMap_student (v : Fin 1 → ToyEntity) :
+    toyStructure.RelMap studentRel v = ToyFacts.student (v 0) := rfl
+@[simp] theorem relMap_person (v : Fin 1 → ToyEntity) :
+    toyStructure.RelMap personRel v = ToyFacts.person (v 0) := rfl
+@[simp] theorem relMap_thing (v : Fin 1 → ToyEntity) :
+    toyStructure.RelMap thingRel v = ToyFacts.thing (v 0) := rfl
+@[simp] theorem relMap_pizza (v : Fin 1 → ToyEntity) :
+    toyStructure.RelMap pizzaRel v = ToyFacts.pizza (v 0) := rfl
+@[simp] theorem relMap_book (v : Fin 1 → ToyEntity) :
+    toyStructure.RelMap bookRel v = ToyFacts.book (v 0) := rfl
+@[simp] theorem relMap_see (v : Fin 2 → ToyEntity) :
+    toyStructure.RelMap seeRel v = ToyFacts.see (v 0) (v 1) := rfl
+@[simp] theorem relMap_eat (v : Fin 2 → ToyEntity) :
+    toyStructure.RelMap eatRel v = ToyFacts.eat (v 0) (v 1) := rfl
+@[simp] theorem relMap_read (v : Fin 2 → ToyEntity) :
+    toyStructure.RelMap readRel v = ToyFacts.read (v 0) (v 1) := rfl
 
 /-- The toy composition model: extensional (one world). -/
 def toyModel : Model toyLang where
@@ -103,24 +194,24 @@ def toyModel : Model toyLang where
 def toyNaming : LexNaming toyLang where
   names := fun s =>
     match s with
-    | "John" => some ToyEntity.john
-    | "Mary" => some ToyEntity.mary
+    | "John" => some johnConst
+    | "Mary" => some maryConst
     | _ => none
   preds₁ := fun s =>
     match s with
-    | "sleeps" => some ToyRel₁.sleep
-    | "laughs" => some ToyRel₁.laugh
-    | "student" => some ToyRel₁.student
-    | "person" => some ToyRel₁.person
-    | "thing" => some ToyRel₁.thing
-    | "pizza" => some ToyRel₁.pizza
-    | "book" => some ToyRel₁.book
+    | "sleeps" => some sleepRel
+    | "laughs" => some laughRel
+    | "student" => some studentRel
+    | "person" => some personRel
+    | "thing" => some thingRel
+    | "pizza" => some pizzaRel
+    | "book" => some bookRel
     | _ => none
   preds₂ := fun s =>
     match s with
-    | "sees" => some ToyRel₂.see
-    | "eats" => some ToyRel₂.eat
-    | "reads" => some ToyRel₂.read
+    | "sees" => some seeRel
+    | "eats" => some eatRel
+    | "reads" => some readRel
     | _ => none
 
 /-- The toy lexicon, induced by the naming maps over the model. -/
@@ -129,22 +220,22 @@ def toyLexicon : Lexicon ToyEntity Unit := toyModel.lexiconAt toyNaming ()
 namespace ToyLexicon
 
 /-! Denotations read off the model. Each is definitionally the corresponding
-match-function over `ToyEntity`, so `rfl`/`trivial` proofs over them reduce. -/
+fact predicate over `ToyEntity`, so `rfl`/`trivial` proofs over them reduce. -/
 
-def john_sem : Denot ToyEntity Unit .e := toyModel.const ToyEntity.john ()
-def mary_sem : Denot ToyEntity Unit .e := toyModel.const ToyEntity.mary ()
+def john_sem : Denot ToyEntity Unit .e := toyModel.const johnConst ()
+def mary_sem : Denot ToyEntity Unit .e := toyModel.const maryConst ()
 
-def sleeps_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.sleep ()
-def laughs_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.laugh ()
-def student_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.student ()
-def person_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.person ()
-def thing_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.thing ()
-def pizza_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.pizza ()
-def book_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.book ()
+def sleeps_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext sleepRel ()
+def laughs_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext laughRel ()
+def student_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext studentRel ()
+def person_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext personRel ()
+def thing_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext thingRel ()
+def pizza_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext pizzaRel ()
+def book_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext bookRel ()
 
-def sees_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) := toyModel.pred₂ext ToyRel₂.see ()
-def eats_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) := toyModel.pred₂ext ToyRel₂.eat ()
-def reads_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) := toyModel.pred₂ext ToyRel₂.read ()
+def sees_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) := toyModel.pred₂ext seeRel ()
+def eats_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) := toyModel.pred₂ext eatRel ()
+def reads_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) := toyModel.pred₂ext readRel ()
 
 instance : DecidablePred student_sem := fun x =>
   match x with

--- a/Linglib/Fragments/English/Toy.lean
+++ b/Linglib/Fragments/English/Toy.lean
@@ -1,24 +1,28 @@
-import Linglib.Core.Logic.Intensional.Defs
+import Linglib.Semantics.Composition.Model
 import Mathlib.Data.Fintype.Basic
 
 /-!
 # Toy English fragment
 
-Minimal pedagogical fragment for compositional-semantics studies:
-- `ToyEntity` — four entities (john, mary, pizza, book)
-- index type is `Unit` (extensional toy model)
-- `ToyLexicon` — basic lexical entries (sleeps, sees, eats, reads, etc.)
+The pedagogical fragment used by compositional-semantics studies, built the
+model-theoretic way: a first-order signature (`toyLang`), a structure carrying
+the facts (`toyStructure`), the composition model (`toyModel`), and naming maps
+(`toyNaming`) from word forms into the signature. The `ToyLexicon` denotations
+are *read off the model* via `Model.const`/`Model.pred₁ext`/`Model.pred₂ext` —
+the connection is true by construction, with no bridge theorems.
 
 Lives in `Fragments/` so substrate files cannot import it — worked examples
 over this fragment belong in `Studies/`. The namespace remains
-`Semantics.Montague` pending the planned rebuild of this fixture as a
-`Semantics.Composition.Model` instance.
+`Semantics.Montague` for continuity with the engine's `Lexicon`.
 -/
 
 namespace Semantics.Montague
 
 open Core.Logic.Intensional
+open FirstOrder
+open Semantics.Composition
 
+/-- The four entities. -/
 inductive ToyEntity where
   | john | mary | pizza | book
   deriving Repr, DecidableEq
@@ -27,79 +31,140 @@ instance : Fintype ToyEntity where
   elems := {.john, .mary, .pizza, .book}
   complete := fun x => by cases x <;> simp
 
+/-- Unary relation symbols of the toy signature. -/
+inductive ToyRel₁ where
+  | sleep | laugh | student | person | thing | pizza | book
+  deriving Repr, DecidableEq
+
+/-- Binary relation symbols of the toy signature. -/
+inductive ToyRel₂ where
+  | see | eat | read
+  deriving Repr, DecidableEq
+
+/-- The toy lexical signature: every entity is nameable by a constant; content
+words are relation symbols. -/
+def toyLang : Language where
+  Functions := fun n => match n with | 0 => ToyEntity | _ => Empty
+  Relations := fun n => match n with | 1 => ToyRel₁ | 2 => ToyRel₂ | _ => Empty
+
+/-- The facts: interpretation of unary symbols. -/
+def interpRel₁ : ToyRel₁ → ToyEntity → Prop := fun r x =>
+  match r, x with
+  | .sleep, .john => True
+  | .sleep, _ => False
+  | .laugh, .john => True
+  | .laugh, .mary => True
+  | .laugh, _ => False
+  | .student, .john => True
+  | .student, .mary => True
+  | .student, _ => False
+  | .person, .john => True
+  | .person, .mary => True
+  | .person, _ => False
+  | .thing, _ => True
+  | .pizza, .pizza => True
+  | .pizza, _ => False
+  | .book, .book => True
+  | .book, _ => False
+
+/-- The facts: interpretation of binary symbols (subject-first). -/
+def interpRel₂ : ToyRel₂ → ToyEntity → ToyEntity → Prop := fun r subj obj =>
+  match r, subj, obj with
+  | .see, .john, .mary => True
+  | .see, .mary, .john => True
+  | .see, _, _ => False
+  | .eat, .john, .pizza => True
+  | .eat, .mary, .pizza => True
+  | .eat, _, _ => False
+  | .read, .john, .book => True
+  | .read, .mary, .book => True
+  | .read, _, _ => False
+
+/-- The toy structure: constants denote themselves; relations carry the facts. -/
+def toyStructure : toyLang.Structure ToyEntity where
+  funMap {n} f v :=
+    match n, f, v with
+    | 0, c, _ => c
+    | _ + 1, f, _ => nomatch f
+  RelMap {n} r v :=
+    match n, r, v with
+    | 0, r, _ => nomatch r
+    | 1, r, v => interpRel₁ r (v 0)
+    | 2, r, v => interpRel₂ r (v 0) (v 1)
+    | _ + 3, r, _ => nomatch r
+
+/-- The toy composition model: extensional (one world). -/
+def toyModel : Model toyLang where
+  E := ToyEntity
+  W := Unit
+  interp _ := toyStructure
+
+/-- The naming maps: word forms into the toy signature. -/
+def toyNaming : LexNaming toyLang where
+  names := fun s =>
+    match s with
+    | "John" => some ToyEntity.john
+    | "Mary" => some ToyEntity.mary
+    | _ => none
+  preds₁ := fun s =>
+    match s with
+    | "sleeps" => some ToyRel₁.sleep
+    | "laughs" => some ToyRel₁.laugh
+    | "student" => some ToyRel₁.student
+    | "person" => some ToyRel₁.person
+    | "thing" => some ToyRel₁.thing
+    | "pizza" => some ToyRel₁.pizza
+    | "book" => some ToyRel₁.book
+    | _ => none
+  preds₂ := fun s =>
+    match s with
+    | "sees" => some ToyRel₂.see
+    | "eats" => some ToyRel₂.eat
+    | "reads" => some ToyRel₂.read
+    | _ => none
+
+/-- The toy lexicon, induced by the naming maps over the model. -/
+def toyLexicon : Lexicon ToyEntity Unit := toyModel.lexiconAt toyNaming ()
+
 namespace ToyLexicon
 
-open ToyEntity
+/-! Denotations read off the model. Each is definitionally the corresponding
+match-function over `ToyEntity`, so `rfl`/`trivial` proofs over them reduce. -/
 
-def john_sem : Denot ToyEntity Unit .e := ToyEntity.john
-def mary_sem : Denot ToyEntity Unit .e := ToyEntity.mary
+def john_sem : Denot ToyEntity Unit .e := toyModel.const ToyEntity.john ()
+def mary_sem : Denot ToyEntity Unit .e := toyModel.const ToyEntity.mary ()
 
-def sleeps_sem : Denot ToyEntity Unit (.e ⇒ .t) :=
-  λ x => match x with
-    | .john => True
-    | _ => False
+def sleeps_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.sleep ()
+def laughs_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.laugh ()
+def student_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.student ()
+def person_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.person ()
+def thing_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.thing ()
+def pizza_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.pizza ()
+def book_sem : Denot ToyEntity Unit (.e ⇒ .t) := toyModel.pred₁ext ToyRel₁.book ()
 
-def laughs_sem : Denot ToyEntity Unit (.e ⇒ .t) :=
-  λ x => match x with
-    | .john => True
-    | .mary => True
-    | _ => False
+def sees_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) := toyModel.pred₂ext ToyRel₂.see ()
+def eats_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) := toyModel.pred₂ext ToyRel₂.eat ()
+def reads_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) := toyModel.pred₂ext ToyRel₂.read ()
 
-def sees_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) :=
-  λ obj => λ subj => match subj, obj with
-    | .john, .mary => True
-    | .mary, .john => True
-    | _, _ => False
+instance : DecidablePred student_sem := fun x =>
+  match x with
+  | .john | .mary => .isTrue trivial
+  | .pizza | .book => .isFalse id
 
-def eats_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) :=
-  λ obj => λ subj => match subj, obj with
-    | .john, .pizza => True
-    | .mary, .pizza => True
-    | _, _ => False
-
-def reads_sem : Denot ToyEntity Unit (.e ⇒ .e ⇒ .t) :=
-  λ obj => λ subj => match subj, obj with
-    | .john, .book => True
-    | .mary, .book => True
-    | _, _ => False
-
-def student_sem : Denot ToyEntity Unit (.e ⇒ .t) :=
-  λ x => match x with
-    | .john => True
-    | .mary => True
-    | _ => False
-
-def person_sem : Denot ToyEntity Unit (.e ⇒ .t) :=
-  λ x => match x with
-    | .john => True
-    | .mary => True
-    | _ => False
-
-def thing_sem : Denot ToyEntity Unit (.e ⇒ .t) :=
-  λ _ => True
-
-instance : DecidablePred student_sem :=
-  fun x => match x with
-    | .john | .mary => .isTrue (by simp [student_sem])
-    | .pizza | .book => .isFalse (by simp [student_sem])
-
-instance : DecidablePred person_sem :=
-  fun x => match x with
-    | .john | .mary => .isTrue (by simp [person_sem])
-    | .pizza | .book => .isFalse (by simp [person_sem])
+instance : DecidablePred person_sem := fun x =>
+  match x with
+  | .john | .mary => .isTrue trivial
+  | .pizza | .book => .isFalse id
 
 instance : DecidablePred thing_sem := fun _ => .isTrue trivial
 
-def pizza_sem : Denot ToyEntity Unit (.e ⇒ .t) :=
-  λ x => match x with
-    | .pizza => True
-    | _ => False
-
-def book_sem : Denot ToyEntity Unit (.e ⇒ .t) :=
-  λ x => match x with
-    | .book => True
-    | _ => False
-
 end ToyLexicon
+
+/-- Engine smoke test: "John sleeps" composes (via the real `Tree.interp`, over the
+naming-map-induced lexicon) to the model's fact. -/
+example :
+    Tree.interp ToyEntity Unit toyLexicon (fun _ => ToyEntity.john)
+      (.node () [.terminal () "John", .terminal () "sleeps"] : Syntax.Tree Unit String)
+      = some ⟨.t, ToyLexicon.sleeps_sem ToyLexicon.john_sem⟩ := rfl
 
 end Semantics.Montague

--- a/Linglib/Fragments/English/Toy.lean
+++ b/Linglib/Fragments/English/Toy.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Composition.Model
+import Linglib.Semantics.Composition.Reduction
 import Mathlib.Data.Fintype.Basic
 
 /-!
@@ -216,6 +217,18 @@ def toyNaming : LexNaming toyLang where
 
 /-- The toy lexicon, induced by the naming maps over the model. -/
 def toyLexicon : Lexicon ToyEntity Unit := toyModel.lexiconAt toyNaming ()
+
+/-- The toy naming maps classify each word once. -/
+theorem toyNaming_disjoint : toyNaming.Disjoint := by
+  refine ⟨?_, ?_, ?_⟩ <;>
+    · intro s R h
+      simp only [toyNaming] at h ⊢
+      split at h <;> simp_all
+
+/-- The default logical vocabulary is fresh for the toy naming maps. -/
+theorem toyNaming_freshFor : FOWords.FreshFor {} toyNaming := by
+  intro s hs
+  fin_cases hs <;> exact ⟨rfl, rfl, rfl⟩
 
 namespace ToyLexicon
 

--- a/Linglib/Semantics/Composition/Model.lean
+++ b/Linglib/Semantics/Composition/Model.lean
@@ -27,6 +27,17 @@ terms. Nothing model-theoretic lives on the objects or in the lexicon data.
 * `barbara` — cross-model logical consequence (truth in all models), the payoff over a fixed
   entity/world frame
 * `interp_pronoun_trace`, `genderRestriction` — the projection discipline for API objects
+
+## Implementation notes
+
+`interp : W → L.Structure E` carries structures as **terms**, not instances — a world-indexed
+*family* of structures on one carrier cannot be instance-based (same rationale as
+equational_theories' term-level `Magma.FOStructure`). The cost is explicit instance threading
+(`letI := m.interp w`) when interfacing with instance-based mathlib API such as
+`Formula.Realize`. Concrete fragments should follow mathlib's concrete-language idiom
+(`Mathlib/ModelTheory/Algebra/Ring/Basic.lean`): arity-indexed symbol inductives, per-symbol
+defeq `abbrev`s, and one `@[simp]` `funMap`/`RelMap` lemma per symbol — see
+`Fragments/English/Toy.lean`.
 -/
 
 set_option autoImplicit false

--- a/Linglib/Semantics/Composition/Model.lean
+++ b/Linglib/Semantics/Composition/Model.lean
@@ -76,9 +76,10 @@ def Model.pred₂ (m : Model L) (R : L.Relations 2) :
     Denot m.E m.W (.e ⇒ .e ⇒ .intens .t) :=
   fun y x w => (m.interp w).RelMap R (fun i => if i = 0 then x else y)
 
-/-- A constant's (proper name's) interpretation at world `w`. -/
+/-- A constant's (proper name's) interpretation at world `w` (the world-indexed
+`Structure.constantMap`). -/
 def Model.const (m : Model L) (c : L.Constants) (w : m.W) : Denot m.E m.W .e :=
-  (m.interp w).funMap c (fun i => i.elim0)
+  (m.interp w).funMap c default
 
 /-- A unary predicate's extensional denotation at world `w` (`e ⇒ t`): the extension
 of `Model.pred₁`. -/

--- a/Linglib/Semantics/Composition/Model.lean
+++ b/Linglib/Semantics/Composition/Model.lean
@@ -19,9 +19,11 @@ terms. Nothing model-theoretic lives on the objects or in the lexicon data.
 ## Main declarations
 
 * `Model` — entity domain `E`, worlds `W`, and a world-indexed family `interp : W → L.Structure E`
-* `Model.pred₁` / `Model.pred₂` — model-sourced predicate denotations
-* `interp_model_sourced` — the real `Tree.interp` composes a model-sourced lexicon to a
-  world-threading proposition, truth bottoming out in `RelMap`
+* `Model.pred₁` / `Model.pred₂` — model-sourced intensional predicate denotations;
+  `Model.const`, `Model.pred₁ext` / `Model.pred₂ext` — their extensions at a world
+* `LexNaming`, `Model.lexiconAt` — build a `Lexicon` from naming maps into the signature
+* `interp_model_sourced`, `interp_lexiconAt_predication` — the real `Tree.interp` composes a
+  model-sourced lexicon, truth bottoming out in `RelMap`
 * `barbara` — cross-model logical consequence (truth in all models), the payoff over a fixed
   entity/world frame
 * `interp_pronoun_trace`, `genderRestriction` — the projection discipline for API objects
@@ -58,10 +60,56 @@ def Model.pred₁ (m : Model L) (R : L.Relations 1) : Denot m.E m.W (.e ⇒ .int
   fun x w => (m.interp w).RelMap R (fun _ => x)
 
 /-- A binary content predicate's denotation, sourced from the model (`e ⇒ e ⇒ ⟨s,t⟩`,
-object-first then subject, matching `Frame`'s `eet` convention). -/
+object-first then subject, matching the `eet` convention). -/
 def Model.pred₂ (m : Model L) (R : L.Relations 2) :
     Denot m.E m.W (.e ⇒ .e ⇒ .intens .t) :=
   fun y x w => (m.interp w).RelMap R (fun i => if i = 0 then x else y)
+
+/-- A constant's (proper name's) interpretation at world `w`. -/
+def Model.const (m : Model L) (c : L.Constants) (w : m.W) : Denot m.E m.W .e :=
+  (m.interp w).funMap c (fun i => i.elim0)
+
+/-- A unary predicate's extensional denotation at world `w` (`e ⇒ t`): the extension
+of `Model.pred₁`. -/
+def Model.pred₁ext (m : Model L) (R : L.Relations 1) (w : m.W) :
+    Denot m.E m.W (.e ⇒ .t) :=
+  fun x => (m.interp w).RelMap R (fun _ => x)
+
+/-- A binary predicate's extensional denotation at world `w` (`e ⇒ e ⇒ t`, object-first):
+the extension of `Model.pred₂`. -/
+def Model.pred₂ext (m : Model L) (R : L.Relations 2) (w : m.W) :
+    Denot m.E m.W (.e ⇒ .e ⇒ .t) :=
+  fun y x => (m.interp w).RelMap R (fun i => if i = 0 then x else y)
+
+@[simp] theorem Model.pred₁_apply (m : Model L) (R : L.Relations 1) (x : m.E) (w : m.W) :
+    m.pred₁ R x w = m.pred₁ext R w x := rfl
+
+@[simp] theorem Model.pred₂_apply (m : Model L) (R : L.Relations 2) (y x : m.E) (w : m.W) :
+    m.pred₂ R y x w = m.pred₂ext R w y x := rfl
+
+/-! ### Lexicon from signature
+
+A fragment supplies *naming maps* from word forms into the signature; the model induces the
+lexicon. Denotations never live in the fragment data — they are read off `funMap`/`RelMap`. -/
+
+/-- Naming maps from word forms into a signature: proper names to constants, content words
+to relation symbols. -/
+structure LexNaming (L : Language.{u, v}) where
+  /-- Proper names denote constants. -/
+  names : String → Option L.Constants := fun _ => none
+  /-- Common nouns / intransitive verbs denote unary relation symbols. -/
+  preds₁ : String → Option (L.Relations 1) := fun _ => none
+  /-- Transitive verbs denote binary relation symbols. -/
+  preds₂ : String → Option (L.Relations 2) := fun _ => none
+
+/-- The extensional lexicon a naming map induces at world `w`: names denote constants'
+interpretations (`e`), unary symbols extensional predicates (`e ⇒ t`), binary symbols
+object-first relations (`e ⇒ e ⇒ t`) — all sourced from the model. -/
+def Model.lexiconAt (m : Model L) (nm : LexNaming L) (w : m.W) : Lexicon m.E m.W :=
+  fun s =>
+    (nm.names s).map (fun c => ⟨.e, m.const c w⟩) <|>
+    (nm.preds₁ s).map (fun R => ⟨.e ⇒ .t, m.pred₁ext R w⟩) <|>
+    (nm.preds₂ s).map (fun R => ⟨.e ⇒ .e ⇒ .t, m.pred₂ext R w⟩)
 
 /-! ### Engine integration: the real `Tree.interp` composes a model-sourced lexicon -/
 
@@ -84,6 +132,19 @@ theorem interp_model_sourced (m : Model L) (subj : m.E) (R : L.Relations 1)
     (g : Core.Assignment m.E) :
     interp m.E m.W (lexFromModel m subj R) g predicationTree
       = some ⟨.intens .t, fun w => (m.interp w).RelMap R (fun _ => subj)⟩ :=
+  rfl
+
+/-- **Engine integration for `lexiconAt`**: a name–verb predication composes (via real backward
+FA) to a truth value read off `RelMap` at the lexicon's world. The fragment supplies only the
+naming maps. -/
+theorem interp_lexiconAt_predication (m : Model L) (nm : LexNaming L) (w : m.W)
+    (g : Core.Assignment m.E) {s v : String} {c : L.Constants} {R : L.Relations 1}
+    (hs : nm.names s = some c) (hv : nm.names v = none) (hv₁ : nm.preds₁ v = some R) :
+    interp m.E m.W (m.lexiconAt nm w) g
+      (.node () [.terminal () s, .terminal () v] : Tree Unit String)
+      = some ⟨.t, (m.interp w).RelMap R (fun _ => m.const c w)⟩ := by
+  simp only [interp_node_binary, interp_terminal, interpTerminal_lookup, Model.lexiconAt,
+    hs, hv, hv₁]
   rfl
 
 /-! ### Cross-model logical consequence -/

--- a/Linglib/Semantics/Composition/Reduction.lean
+++ b/Linglib/Semantics/Composition/Reduction.lean
@@ -1,0 +1,689 @@
+import Linglib.Semantics.Composition.Model
+import Linglib.Core.Logic.Quantification.Basic
+import Mathlib.ModelTheory.Semantics
+import Mathlib.Tactic.FinCases
+
+/-!
+# Reduction: the FO fragment of type-driven composition
+
+Compiles the first-order fragment of [heim-kratzer-1998] trees into mathlib
+`FirstOrder.Language.Formula`s and proves agreement with the engine: whenever
+`compileFO` succeeds, the denotation `Tree.interp` composes is equivalent to
+mathlib `Realize` of the compiled formula over the model — the same triangle
+`Semantics/Dynamic/DRS/Reduction.lean` proves for DRT.
+
+Trace indices are the formulas' free-variable type (`ℕ`), so the Heim-Kratzer
+bind index *is* the variable name, and assignment update `g[n ↦ x]` on the
+engine side is literally `Function.update` on the realize side. Quantifiers
+bind exactly one trace, so closure is by the *computable* singleton binders
+`Formula.all₁` / `Formula.ex₁` (mathlib's `iAlls`/`iExs` are noncomputable).
+
+## Main declarations
+
+* `Formula.all₁` / `Formula.ex₁` — computable singleton closures, with
+  `realize_all₁` / `realize_ex₁` phrased via `Function.update`
+* `FOWords`, `Model.lexiconFO` — the logical vocabulary over a naming-map
+  lexicon; `FOWords.FreshFor`, `LexNaming.Disjoint` — well-formedness
+* `compileFO` — the partial compiler over QR'd Heim-Kratzer tree shapes
+* `interp_compileFO`, `holdsAt_iff_realize` — the agreement theorem
+* `holdsAt_of_models` — consequence transfer (cross-model entailment from
+  first-order consequence)
+
+*Most* (and the other proportional determiners) is deliberately outside the
+compiled fragment: its first-order undefinability is the planned
+Barwise-Cooper payoff theorem, and the principled reason `compileFO` is
+partial.
+-/
+
+set_option autoImplicit false
+
+universe u v
+
+/-! ### Computable singleton binders
+
+In mathlib's `FirstOrder.Language.Formula` namespace: generic FO utilities
+(upstream candidates), not composition-specific. -/
+
+namespace FirstOrder.Language.Formula
+
+open FirstOrder Language
+
+variable {L : Language.{u, v}}
+
+/-- The relabeling sending the named free variable `n` to the bound side. -/
+private def toBound (n : ℕ) : ℕ → ℕ ⊕ Fin 1 := fun k =>
+  if k = n then Sum.inr 0 else Sum.inl k
+
+/-- Universally close the named free variable `n`. Computable, unlike
+mathlib's `Formula.iAlls`. -/
+def all₁ (n : ℕ) (φ : L.Formula ℕ) : L.Formula ℕ :=
+  (BoundedFormula.relabel (toBound n) φ).all
+
+/-- Existentially close the named free variable `n`. Computable, unlike
+mathlib's `Formula.iExs`. -/
+def ex₁ (n : ℕ) (φ : L.Formula ℕ) : L.Formula ℕ :=
+  (BoundedFormula.relabel (toBound n) φ).ex
+
+variable {M : Type*} [L.Structure M]
+
+private theorem realize_relabel_update (n : ℕ) (φ : L.Formula ℕ) (v : ℕ → M) (x : M) :
+    (BoundedFormula.relabel (toBound n) φ).Realize v
+      (Fin.snoc (default : Fin 0 → M) x) ↔
+      φ.Realize (Function.update v n x) := by
+  rw [BoundedFormula.realize_relabel]
+  refine iff_of_eq (congrArg₂ (BoundedFormula.Realize φ) ?_ ?_)
+  · funext k
+    by_cases hk : k = n <;> simp [hk, toBound, Function.update_apply, Fin.snoc]
+  · funext i
+    exact i.elim0
+
+theorem realize_all₁ {n : ℕ} {φ : L.Formula ℕ} {v : ℕ → M} :
+    (all₁ n φ).Realize v ↔ ∀ x : M, φ.Realize (Function.update v n x) := by
+  have h : (all₁ n φ).Realize v
+      = BoundedFormula.Realize (BoundedFormula.relabel (toBound n) φ).all v default := rfl
+  rw [h, BoundedFormula.realize_all]
+  exact forall_congr' fun x => realize_relabel_update n φ v x
+
+theorem realize_ex₁ {n : ℕ} {φ : L.Formula ℕ} {v : ℕ → M} :
+    (ex₁ n φ).Realize v ↔ ∃ x : M, φ.Realize (Function.update v n x) := by
+  have h : (ex₁ n φ).Realize v
+      = BoundedFormula.Realize (BoundedFormula.relabel (toBound n) φ).ex v default := rfl
+  rw [h, BoundedFormula.realize_ex]
+  exact exists_congr fun x => realize_relabel_update n φ v x
+
+end FirstOrder.Language.Formula
+
+namespace Semantics.Composition
+
+open FirstOrder Language
+open FirstOrder.Language.Formula (all₁ ex₁)
+open Core.Logic.Intensional
+open Core.Quantification (every_sem some_sem no_sem)
+open Semantics.Montague (Lexicon)
+open Semantics.Composition.Tree
+open Syntax (Tree)
+
+variable {L : Language.{u, v}}
+
+/-! ### The logical vocabulary -/
+
+/-- Word forms for the compiled logical vocabulary, parameterizable per
+fragment/language. -/
+structure FOWords where
+  every : String := "every"
+  some_ : String := "some"
+  no : String := "no"
+  not_ : String := "not"
+  and_ : String := "and"
+  or_ : String := "or"
+
+/-- The logical vocabulary's lexicon entries: GQ denotations from
+`Core.Quantification`, truth-functional connectives from
+`Core.Logic.Intensional`. The connectives flip arguments so that
+`[t₁ [and t₂]]` composes to `⟦t₁⟧ ∧ ⟦t₂⟧`. -/
+def FOWords.lexicon (fw : FOWords) (E W : Type) : Lexicon E W := fun s =>
+  if s = fw.every then some ⟨(.e ⇒ .t) ⇒ (.e ⇒ .t) ⇒ .t, every_sem⟩
+  else if s = fw.some_ then some ⟨(.e ⇒ .t) ⇒ (.e ⇒ .t) ⇒ .t, some_sem⟩
+  else if s = fw.no then some ⟨(.e ⇒ .t) ⇒ (.e ⇒ .t) ⇒ .t, no_sem⟩
+  else if s = fw.not_ then some ⟨.t ⇒ .t, neg⟩
+  else if s = fw.and_ then some ⟨.t ⇒ .t ⇒ .t, fun q p => conj p q⟩
+  else if s = fw.or_ then some ⟨.t ⇒ .t ⇒ .t, fun q p => disj p q⟩
+  else none
+
+/-- A naming-map lexicon extended with the logical vocabulary. Content words
+take priority; `FOWords.FreshFor` rules out collisions. -/
+def Model.lexiconFO (m : Model L) (fw : FOWords) (nm : LexNaming L) (w : m.W) :
+    Lexicon m.E m.W := fun s =>
+  m.lexiconAt nm w s <|> fw.lexicon m.E m.W s
+
+/-- The logical word forms are fresh for the naming maps. -/
+def FOWords.FreshFor (fw : FOWords) (nm : LexNaming L) : Prop :=
+  ∀ s ∈ [fw.every, fw.some_, fw.no, fw.not_, fw.and_, fw.or_],
+    nm.names s = none ∧ nm.preds₁ s = none ∧ nm.preds₂ s = none
+
+/-- Each word form names at most one kind of symbol, so the compiler's
+classification of a word agrees with the lexicon's lookup order. -/
+structure LexNaming.Disjoint (nm : LexNaming L) : Prop where
+  names_of_preds₁ : ∀ s R, nm.preds₁ s = some R → nm.names s = none
+  names_of_preds₂ : ∀ s R, nm.preds₂ s = some R → nm.names s = none
+  preds₁_of_preds₂ : ∀ s R, nm.preds₂ s = some R → nm.preds₁ s = none
+
+/-! ### The compiler
+
+Recognized (QR'd Heim-Kratzer) shapes: name/trace–verb predication with
+optional object, sentence negation `[not t]`, sentence coordination
+`[t₁ [and t₂]]`, and quantified clauses `[[Q N] [bind k body]]`. Everything
+else — in particular *most* — is outside the fragment and compiles to
+`none`. -/
+
+/-- Compile an entity subtree: a proper name or a trace. -/
+def compileTerm (nm : LexNaming L) : Tree Unit String → Option (L.Term ℕ)
+  | .terminal _ s => (nm.names s).map Constants.term
+  | .trace k _ => some (Term.var k)
+  | _ => none
+
+/-- Compile a predicate subtree applied to a subject term: an intransitive
+verb, or a transitive verb with a name/trace object. -/
+def compilePred (nm : LexNaming L) (τ : L.Term ℕ) :
+    Tree Unit String → Option (L.Formula ℕ)
+  | .terminal _ v => (nm.preds₁ v).map fun R => R.formula₁ τ
+  | .node _ [.terminal _ v, obj] =>
+      (nm.preds₂ v).bind fun R =>
+        (compileTerm nm obj).map fun τₒ => R.formula₂ τ τₒ
+  | _ => none
+
+/-- Compile the FO fragment of a tree to a first-order formula with trace
+indices as free variables. Partial: `none` outside the fragment. -/
+def compileFO (fw : FOWords) (nm : LexNaming L) :
+    Tree Unit String → Option (L.Formula ℕ)
+  | .node _ [.terminal _ s, r] =>
+      if s = fw.not_ then (compileFO fw nm r).map BoundedFormula.not
+      else (nm.names s).bind fun c => compilePred nm (Constants.term c) r
+  | .node _ [.trace k _, r] => compilePred nm (Term.var k) r
+  | .node _ [.node _ [.terminal _ q, .terminal _ nw], .bind k _ body] =>
+      (nm.preds₁ nw).bind fun R =>
+        (compileFO fw nm body).bind fun ψ =>
+          if q = fw.every then some (all₁ k ((R.formula₁ (Term.var k)).imp ψ))
+          else if q = fw.some_ then some (ex₁ k (R.formula₁ (Term.var k) ⊓ ψ))
+          else if q = fw.no then
+            some (all₁ k ((R.formula₁ (Term.var k)).imp ψ.not))
+          else none
+  | .node _ [l, .node _ [.terminal _ s, t₂] ] =>
+      if s = fw.and_ then
+        (compileFO fw nm l).bind fun φ₁ =>
+          (compileFO fw nm t₂).map fun φ₂ => φ₁ ⊓ φ₂
+      else if s = fw.or_ then
+        (compileFO fw nm l).bind fun φ₁ =>
+          (compileFO fw nm t₂).map fun φ₂ => φ₁ ⊔ φ₂
+      else none
+  | _ => none
+
+/-! ### Lookup lemmas -/
+
+/-- The six logical word forms are pairwise distinct. -/
+def FOWords.Nodup (fw : FOWords) : Prop :=
+  ([fw.every, fw.some_, fw.no, fw.not_, fw.and_, fw.or_] : List String).Nodup
+
+section Lookups
+
+variable (m : Model L) (fw : FOWords) (nm : LexNaming L) (w : m.W)
+
+theorem Model.lexiconFO_names {s : String} {c : L.Constants}
+    (h : nm.names s = some c) :
+    m.lexiconFO fw nm w s = some ⟨.e, m.const c w⟩ := by
+  simp [Model.lexiconFO, Model.lexiconAt, h]
+
+theorem Model.lexiconFO_preds₁ {s : String} {R : L.Relations 1}
+    (h : nm.preds₁ s = some R) (h₀ : nm.names s = none) :
+    m.lexiconFO fw nm w s = some ⟨.e ⇒ .t, m.pred₁ext R w⟩ := by
+  simp [Model.lexiconFO, Model.lexiconAt, h, h₀]
+
+theorem Model.lexiconFO_preds₂ {s : String} {R : L.Relations 2}
+    (h : nm.preds₂ s = some R) (h₀ : nm.names s = none)
+    (h₁ : nm.preds₁ s = none) :
+    m.lexiconFO fw nm w s = some ⟨.e ⇒ .e ⇒ .t, m.pred₂ext R w⟩ := by
+  simp [Model.lexiconFO, Model.lexiconAt, h, h₀, h₁]
+
+/-- At a word fresh for the naming maps, lookup falls through to the logical
+vocabulary. -/
+theorem Model.lexiconFO_fresh {s : String}
+    (h₀ : nm.names s = none) (h₁ : nm.preds₁ s = none)
+    (h₂ : nm.preds₂ s = none) :
+    m.lexiconFO fw nm w s = fw.lexicon m.E m.W s := by
+  simp [Model.lexiconFO, Model.lexiconAt, h₀, h₁, h₂]
+
+end Lookups
+
+namespace FOWords
+
+variable {fw : FOWords}
+
+private theorem nodup_ne (hnd : fw.Nodup) :
+    (fw.some_ ≠ fw.every) ∧
+    (fw.no ≠ fw.every ∧ fw.no ≠ fw.some_) ∧
+    (fw.not_ ≠ fw.every ∧ fw.not_ ≠ fw.some_ ∧ fw.not_ ≠ fw.no) ∧
+    (fw.and_ ≠ fw.every ∧ fw.and_ ≠ fw.some_ ∧ fw.and_ ≠ fw.no ∧
+      fw.and_ ≠ fw.not_) ∧
+    (fw.or_ ≠ fw.every ∧ fw.or_ ≠ fw.some_ ∧ fw.or_ ≠ fw.no ∧
+      fw.or_ ≠ fw.not_ ∧ fw.or_ ≠ fw.and_) := by
+  simp only [FOWords.Nodup, List.nodup_cons, List.mem_cons,
+    List.not_mem_nil, or_false, not_or, List.nodup_nil, and_true] at hnd
+  obtain ⟨⟨h1, h2, h3, h4, h5⟩, ⟨h6, h7, h8, h9⟩, ⟨h10, h11, h12⟩, ⟨h13, h14⟩, h15, -⟩ := hnd
+  exact ⟨Ne.symm h1, ⟨Ne.symm h2, Ne.symm h6⟩, ⟨Ne.symm h3, Ne.symm h7, Ne.symm h10⟩,
+    ⟨Ne.symm h4, Ne.symm h8, Ne.symm h11, Ne.symm h13⟩,
+    ⟨Ne.symm h5, Ne.symm h9, Ne.symm h12, Ne.symm h14, Ne.symm h15⟩⟩
+
+variable (E W : Type)
+
+theorem lexicon_every :
+    fw.lexicon E W fw.every
+      = some ⟨(.e ⇒ .t) ⇒ (.e ⇒ .t) ⇒ .t, every_sem⟩ := by
+  simp [FOWords.lexicon]
+
+theorem lexicon_some (hnd : fw.Nodup) :
+    fw.lexicon E W fw.some_
+      = some ⟨(.e ⇒ .t) ⇒ (.e ⇒ .t) ⇒ .t, some_sem⟩ := by
+  obtain ⟨h1, _, _, _, _⟩ := nodup_ne hnd
+  simp [FOWords.lexicon, h1]
+
+theorem lexicon_no (hnd : fw.Nodup) :
+    fw.lexicon E W fw.no
+      = some ⟨(.e ⇒ .t) ⇒ (.e ⇒ .t) ⇒ .t, no_sem⟩ := by
+  obtain ⟨_, ⟨h1, h2⟩, _, _, _⟩ := nodup_ne hnd
+  simp [FOWords.lexicon, h1, h2]
+
+theorem lexicon_not (hnd : fw.Nodup) :
+    fw.lexicon E W fw.not_ = some ⟨.t ⇒ .t, neg⟩ := by
+  obtain ⟨_, _, ⟨h1, h2, h3⟩, _, _⟩ := nodup_ne hnd
+  simp [FOWords.lexicon, h1, h2, h3]
+
+theorem lexicon_and (hnd : fw.Nodup) :
+    fw.lexicon E W fw.and_
+      = some ⟨.t ⇒ .t ⇒ .t, fun q p => conj p q⟩ := by
+  obtain ⟨_, _, _, ⟨h1, h2, h3, h4⟩, _⟩ := nodup_ne hnd
+  simp [FOWords.lexicon, h1, h2, h3, h4]
+
+theorem lexicon_or (hnd : fw.Nodup) :
+    fw.lexicon E W fw.or_
+      = some ⟨.t ⇒ .t ⇒ .t, fun q p => disj p q⟩ := by
+  obtain ⟨_, _, _, _, ⟨h1, h2, h3, h4, h5⟩⟩ := nodup_ne hnd
+  simp [FOWords.lexicon, h1, h2, h3, h4, h5]
+
+/-- Extract the naming-map-freshness triple for a logical word. -/
+theorem FreshFor.at {nm : LexNaming L} (h : fw.FreshFor nm) {s : String}
+    (hs : s ∈ [fw.every, fw.some_, fw.no, fw.not_, fw.and_, fw.or_]) :
+    nm.names s = none ∧ nm.preds₁ s = none ∧ nm.preds₂ s = none :=
+  h s hs
+
+end FOWords
+
+/-! ### Realization at a model's world
+
+`Model` carries structures as terms, so `Realize` needs the instance fixed
+per world; `realizeAt`/`termAt` package that. -/
+
+/-- Realize a formula over the model's structure at world `w`. -/
+def Model.realizeAt (m : Model L) (w : m.W) (φ : L.Formula ℕ)
+    (g : Core.Assignment m.E) : Prop :=
+  letI := m.interp w
+  φ.Realize g
+
+/-- Realize a term over the model's structure at world `w`. -/
+def Model.termAt (m : Model L) (w : m.W) (τ : L.Term ℕ)
+    (g : Core.Assignment m.E) : m.E :=
+  letI := m.interp w
+  τ.realize g
+
+section RealizeAt
+
+variable (m : Model L) (w : m.W) (g : Core.Assignment m.E)
+
+theorem Model.termAt_var (k : ℕ) : m.termAt w (Term.var k) g = g k := rfl
+
+theorem Model.termAt_const (c : L.Constants) :
+    m.termAt w (Constants.term c) g = m.const c w := by
+  letI := m.interp w
+  exact Term.realize_constants
+
+theorem Model.realizeAt_not (φ : L.Formula ℕ) :
+    m.realizeAt w φ.not g ↔ ¬ m.realizeAt w φ g := by
+  letI := m.interp w
+  exact Formula.realize_not
+
+theorem Model.realizeAt_inf (φ ψ : L.Formula ℕ) :
+    m.realizeAt w (φ ⊓ ψ) g ↔ m.realizeAt w φ g ∧ m.realizeAt w ψ g := by
+  letI := m.interp w
+  exact Formula.realize_inf
+
+theorem Model.realizeAt_sup (φ ψ : L.Formula ℕ) :
+    m.realizeAt w (φ ⊔ ψ) g ↔ m.realizeAt w φ g ∨ m.realizeAt w ψ g := by
+  letI := m.interp w
+  exact Formula.realize_sup
+
+theorem Model.realizeAt_imp (φ ψ : L.Formula ℕ) :
+    m.realizeAt w (φ.imp ψ) g ↔ (m.realizeAt w φ g → m.realizeAt w ψ g) := by
+  letI := m.interp w
+  exact Formula.realize_imp
+
+theorem Model.realizeAt_all₁ (k : ℕ) (φ : L.Formula ℕ) :
+    m.realizeAt w (all₁ k φ) g ↔
+      ∀ x : m.E, m.realizeAt w φ (Function.update g k x) := by
+  letI := m.interp w
+  exact FirstOrder.Language.Formula.realize_all₁
+
+theorem Model.realizeAt_ex₁ (k : ℕ) (φ : L.Formula ℕ) :
+    m.realizeAt w (ex₁ k φ) g ↔
+      ∃ x : m.E, m.realizeAt w φ (Function.update g k x) := by
+  letI := m.interp w
+  exact FirstOrder.Language.Formula.realize_ex₁
+
+/-- Atomic agreement, unary: realization of `R(τ)` is the model-sourced
+extensional predicate at the term's value. -/
+theorem Model.realizeAt_formula₁ (R : L.Relations 1) (τ : L.Term ℕ) :
+    m.realizeAt w (R.formula₁ τ) g ↔ m.pred₁ext R w (m.termAt w τ g) := by
+  letI := m.interp w
+  rw [Model.realizeAt, Formula.realize_rel₁]
+  exact iff_of_eq (congrArg _ (funext fun i => by fin_cases i; rfl))
+
+/-- Atomic agreement, binary: realization of `R(τ₁, τ₂)` is the model-sourced
+object-first relation at the terms' values (subject first in the vector). -/
+theorem Model.realizeAt_formula₂ (R : L.Relations 2) (τ₁ τ₂ : L.Term ℕ) :
+    m.realizeAt w (R.formula₂ τ₁ τ₂) g ↔
+      m.pred₂ext R w (m.termAt w τ₂ g) (m.termAt w τ₁ g) := by
+  letI := m.interp w
+  rw [Model.realizeAt, Formula.realize_rel₂]
+  exact iff_of_eq (congrArg _ (funext fun i => by fin_cases i <;> rfl))
+
+end RealizeAt
+
+/-! ### Engine reduction helpers (at `M = Id`) -/
+
+section EngineHelpers
+
+variable {E W : Type}
+
+/-- Forward FA at `Id`, with the applicative collapsed. -/
+private theorem interpBinary_fa {σ τ : Ty} (f : Denot E W (σ ⇒ τ)) (x : Denot E W σ) :
+    interpBinary (M := Id) ⟨σ ⇒ τ, f⟩ ⟨σ, x⟩ = some ⟨τ, f x⟩ := by
+  rw [interpBinary_eq, tryFA_forward]
+  rfl
+
+/-- Backward FA at `Id`: entity subject, unary predicate. -/
+private theorem interpBinary_e_et (x : Denot E W .e) (P : Denot E W (.e ⇒ .t)) :
+    interpBinary (M := Id) ⟨.e, x⟩ ⟨.e ⇒ .t, P⟩ = some ⟨.t, P x⟩ := rfl
+
+/-- Backward FA at `Id`: sentence subject, sentential operator. -/
+private theorem interpBinary_t_tt (p : Denot E W .t) (F : Denot E W (.t ⇒ .t)) :
+    interpBinary (M := Id) ⟨.t, p⟩ ⟨.t ⇒ .t, F⟩ = some ⟨.t, F p⟩ := rfl
+
+private theorem predAbs_id_dist :
+    PredAbs.dist? (M := Id) (E := E) (W := W) = some (fun _ f => f) := rfl
+
+/-- The `.bind` node at `Id`, given the body's interpretation at the outer
+assignment: it denotes an entity predicate agreeing pointwise with the body
+at updated assignments. -/
+private theorem interp_bind_exists (lex : Lexicon E W) (g : Core.Assignment E)
+    (k : ℕ) (c : Unit) (body : Tree Unit String) {p : Denot E W .t}
+    (hbody : Tree.interp E W lex g body = some ⟨.t, p⟩) :
+    ∃ F : Denot E W (.e ⇒ .t),
+      Tree.interp E W lex g (.bind k c body) = some ⟨.fn .e .t, F⟩ ∧
+      ∀ (x : E) (px : Denot E W .t),
+        Tree.interp E W lex (Function.update g k x) body = some ⟨.t, px⟩ →
+        F x = px := by
+  refine ⟨?_, ?_, ?_⟩
+  rotate_left
+  · conv_lhs => rw [Tree.interp]
+    rw [predAbs_id_dist, hbody]
+    rfl
+  · intro x px hx
+    simp only [hx]
+    rfl
+
+end EngineHelpers
+
+/-! ### Agreement -/
+
+section Agreement
+
+variable (m : Model L) (fw : FOWords) (nm : LexNaming L) (w : m.W)
+
+/-- Entity-subtree agreement: a compiled term's engine value is its
+realization over the model. -/
+theorem interp_compileTerm (g : Core.Assignment m.E) :
+    ∀ {t : Tree Unit String} {τ : L.Term ℕ}, compileTerm nm t = some τ →
+      Tree.interp m.E m.W (m.lexiconFO fw nm w) g t
+        = some ⟨.e, m.termAt w τ g⟩
+  | .terminal _ s, τ, h => by
+      simp only [compileTerm, Option.map_eq_some_iff] at h
+      obtain ⟨c, hc, rfl⟩ := h
+      rw [interp_terminal, interpTerminal_lookup, m.lexiconFO_names fw nm w hc,
+        Option.map_some, m.termAt_const]
+  | .trace k _, τ, h => by
+      simp only [compileTerm, Option.some.injEq] at h
+      subst h
+      rfl
+
+/-- Predication agreement: subject term + predicate subtree compose to the
+compiled atom's realization. -/
+theorem interp_compilePred (hdj : nm.Disjoint) (g : Core.Assignment m.E)
+    {subj : Tree Unit String} {τ : L.Term ℕ}
+    (hsubj : compileTerm nm subj = some τ) :
+    ∀ {r : Tree Unit String} {φ : L.Formula ℕ}, compilePred nm τ r = some φ →
+      ∀ c : Unit,
+        Tree.interp m.E m.W (m.lexiconFO fw nm w) g (.node c [subj, r])
+          = some ⟨.t, m.realizeAt w φ g⟩
+  | .terminal _ v, φ, h, c => by
+      simp only [compilePred, Option.map_eq_some_iff] at h
+      obtain ⟨R, hR, rfl⟩ := h
+      rw [interp_node_binary, interp_compileTerm m fw nm w g hsubj, Option.bind_some,
+        interp_terminal, interpTerminal_lookup,
+        m.lexiconFO_preds₁ fw nm w hR (hdj.names_of_preds₁ v R hR),
+        Option.map_some, Option.bind_some, interpBinary_e_et]
+      congr 1
+      exact congrArg _ (propext (m.realizeAt_formula₁ w g R τ)).symm
+  | .node _ [.terminal _ v, obj], φ, h, c => by
+      simp only [compilePred, Option.bind_eq_some_iff, Option.map_eq_some_iff] at h
+      obtain ⟨R, hR, τₒ, hobj, rfl⟩ := h
+      rw [interp_node_binary, interp_compileTerm m fw nm w g hsubj, Option.bind_some,
+        interp_node_binary, interp_terminal, interpTerminal_lookup,
+        m.lexiconFO_preds₂ fw nm w hR (hdj.names_of_preds₂ v R hR)
+          (hdj.preds₁_of_preds₂ v R hR),
+        Option.map_some, Option.bind_some,
+        interp_compileTerm m fw nm w g hobj, Option.bind_some,
+        interpBinary_fa, Option.bind_some, interpBinary_e_et]
+      congr 1
+      exact congrArg _ (propext (m.realizeAt_formula₂ w g R τ τₒ)).symm
+
+/-- **The agreement theorem**: whenever the compiler succeeds, the engine's
+composed denotation *is* the realization of the compiled formula over the
+model at `w` — the DRT triangle for type-driven composition. -/
+theorem interp_compileFO (hnd : fw.Nodup) (hfr : fw.FreshFor nm)
+    (hdj : nm.Disjoint) (t : Tree Unit String) :
+    ∀ {φ : L.Formula ℕ} (g : Core.Assignment m.E), compileFO fw nm t = some φ →
+      Tree.interp m.E m.W (m.lexiconFO fw nm w) g t
+        = some ⟨.t, m.realizeAt w φ g⟩ := by
+  induction t using compileFO.induct fw with
+  | case1 a a₁ r ih =>
+    -- negation [not r]
+    intro φ g h
+    simp only [compileFO, ↓reduceIte, Option.map_eq_some_iff] at h
+    obtain ⟨ψ, hψ, rfl⟩ := h
+    have hfr₁ := hfr.at (s := fw.not_) (by simp)
+    rw [interp_node_binary, interp_terminal, interpTerminal_lookup,
+      m.lexiconFO_fresh fw nm w hfr₁.1 hfr₁.2.1 hfr₁.2.2,
+      FOWords.lexicon_not m.E m.W hnd, Option.map_some, Option.bind_some,
+      ih g hψ, Option.bind_some, interpBinary_fa]
+    congr 1
+  | case2 a a₁ s r hs =>
+    -- name-subject predication
+    intro φ g h
+    simp only [compileFO, if_neg hs, Option.bind_eq_some_iff] at h
+    obtain ⟨c, hc, hpred⟩ := h
+    exact interp_compilePred m fw nm w hdj g
+      (by simp [compileTerm, hc]) hpred a
+  | case3 a k a₁ r =>
+    -- trace-subject predication
+    intro φ g h
+    simp only [compileFO] at h
+    exact interp_compilePred m fw nm w hdj g (by simp [compileTerm]) h a
+  | case4 a a₁ a₂ q a₃ nw k a₄ body ih =>
+    -- quantified clause [[Q N] [bind k body]]
+    intro φ g h
+    simp only [compileFO, Option.bind_eq_some_iff] at h
+    obtain ⟨R, hR, ψ, hψ, hq⟩ := h
+    obtain ⟨F, hbind, hF⟩ :=
+      interp_bind_exists (m.lexiconFO fw nm w) g k a₄ body (ih g hψ)
+    have hquant : ∀ x : m.E,
+        F x = m.realizeAt w ψ (Function.update g k x) := fun x =>
+      hF x _ (ih (Function.update g k x) hψ)
+    have hrestr : ∀ x : m.E,
+        m.realizeAt w (Relations.formula₁ R (Term.var k)) (Function.update g k x)
+          ↔ m.pred₁ext R w x := by
+      intro x
+      rw [m.realizeAt_formula₁, m.termAt_var, Function.update_self]
+    have hN := m.lexiconFO_preds₁ fw nm w hR (hdj.names_of_preds₁ _ _ hR)
+    by_cases hq1 : q = fw.every
+    · rw [if_pos hq1] at hq
+      cases hq
+      subst hq1
+      have hfr₁ := hfr.at (s := fw.every) (by simp)
+      rw [interp_node_binary, interp_node_binary, interp_terminal,
+        interpTerminal_lookup,
+        m.lexiconFO_fresh fw nm w hfr₁.1 hfr₁.2.1 hfr₁.2.2,
+        FOWords.lexicon_every m.E m.W, Option.map_some, Option.bind_some,
+        interp_terminal, interpTerminal_lookup, hN, Option.map_some,
+        Option.bind_some, interpBinary_fa, Option.bind_some, hbind,
+        Option.bind_some, interpBinary_fa]
+      congr 1
+      refine congrArg _ (propext ?_)
+      rw [m.realizeAt_all₁ w g]
+      simp only [Core.Quantification.every_sem, m.realizeAt_imp]
+      exact forall_congr' fun x =>
+        imp_congr (hrestr x).symm (by rw [hquant x])
+    · rw [if_neg hq1] at hq
+      by_cases hq2 : q = fw.some_
+      · rw [if_pos hq2] at hq
+        cases hq
+        subst hq2
+        have hfr₁ := hfr.at (s := fw.some_) (by simp)
+        rw [interp_node_binary, interp_node_binary, interp_terminal,
+          interpTerminal_lookup,
+          m.lexiconFO_fresh fw nm w hfr₁.1 hfr₁.2.1 hfr₁.2.2,
+          FOWords.lexicon_some m.E m.W hnd, Option.map_some, Option.bind_some,
+          interp_terminal, interpTerminal_lookup, hN, Option.map_some,
+          Option.bind_some, interpBinary_fa, Option.bind_some, hbind,
+          Option.bind_some, interpBinary_fa]
+        congr 1
+        refine congrArg _ (propext ?_)
+        rw [m.realizeAt_ex₁ w g]
+        simp only [Core.Quantification.some_sem, m.realizeAt_inf]
+        exact exists_congr fun x =>
+          and_congr (hrestr x).symm (by rw [hquant x])
+      · rw [if_neg hq2] at hq
+        by_cases hq3 : q = fw.no
+        · rw [if_pos hq3] at hq
+          cases hq
+          subst hq3
+          have hfr₁ := hfr.at (s := fw.no) (by simp)
+          rw [interp_node_binary, interp_node_binary, interp_terminal,
+            interpTerminal_lookup,
+            m.lexiconFO_fresh fw nm w hfr₁.1 hfr₁.2.1 hfr₁.2.2,
+            FOWords.lexicon_no m.E m.W hnd, Option.map_some, Option.bind_some,
+            interp_terminal, interpTerminal_lookup, hN, Option.map_some,
+            Option.bind_some, interpBinary_fa, Option.bind_some, hbind,
+            Option.bind_some, interpBinary_fa]
+          congr 1
+          refine congrArg _ (propext ?_)
+          rw [m.realizeAt_all₁ w g]
+          simp only [Core.Quantification.no_sem, m.realizeAt_imp,
+            m.realizeAt_not]
+          exact forall_congr' fun x =>
+            imp_congr (hrestr x).symm (by rw [hquant x])
+        · rw [if_neg hq3] at hq
+          simp at hq
+  | case5 a l a₁ a₂ t₂ hl₁ hl₂ ihl iht =>
+    -- coordination [l [and t₂]]
+    intro φ g h
+    simp only [compileFO, ↓reduceIte, Option.bind_eq_some_iff,
+      Option.map_eq_some_iff] at h
+    obtain ⟨φ₁, h₁, φ₂, h₂, rfl⟩ := h
+    have hfr₁ := hfr.at (s := fw.and_) (by simp)
+    rw [interp_node_binary, ihl g h₁, Option.bind_some, interp_node_binary,
+      interp_terminal, interpTerminal_lookup,
+      m.lexiconFO_fresh fw nm w hfr₁.1 hfr₁.2.1 hfr₁.2.2,
+      FOWords.lexicon_and m.E m.W hnd, Option.map_some, Option.bind_some,
+      iht g h₂, Option.bind_some, interpBinary_fa, Option.bind_some,
+      interpBinary_t_tt]
+    congr 1
+    refine congrArg _ (propext ?_)
+    rw [m.realizeAt_inf w g]
+    exact Iff.rfl
+  | case6 a l a₁ a₂ t₂ hl₁ hl₂ hne ihl iht =>
+    -- coordination [l [or t₂]]
+    intro φ g h
+    simp only [compileFO, if_neg hne, ↓reduceIte, Option.bind_eq_some_iff,
+      Option.map_eq_some_iff] at h
+    obtain ⟨φ₁, h₁, φ₂, h₂, rfl⟩ := h
+    have hfr₁ := hfr.at (s := fw.or_) (by simp)
+    rw [interp_node_binary, ihl g h₁, Option.bind_some, interp_node_binary,
+      interp_terminal, interpTerminal_lookup,
+      m.lexiconFO_fresh fw nm w hfr₁.1 hfr₁.2.1 hfr₁.2.2,
+      FOWords.lexicon_or m.E m.W hnd, Option.map_some, Option.bind_some,
+      iht g h₂, Option.bind_some, interpBinary_fa, Option.bind_some,
+      interpBinary_t_tt]
+    congr 1
+    refine congrArg _ (propext ?_)
+    rw [m.realizeAt_sup w g]
+    exact Iff.rfl
+  | case7 a l a₁ a₂ s t₂ hl₁ hl₂ hs₁ hs₂ =>
+    intro φ g h
+    simp only [compileFO, if_neg hs₁, if_neg hs₂] at h
+    simp at h
+  | case8 t hex₁ hex₂ hex₃ hex₄ =>
+    intro φ g h
+    rw [compileFO.eq_def] at h
+    split at h
+    all_goals
+      first
+        | simp at h
+        | exact (hex₁ _ _ _ _ rfl).elim
+        | exact (hex₂ _ _ _ _ rfl).elim
+        | exact (hex₃ _ _ _ _ _ _ _ _ _ rfl).elim
+        | exact (hex₄ _ _ _ _ _ _ rfl).elim
+
+
+end Agreement
+
+/-! ### Truth and consequence transfer -/
+
+section Consequence
+
+variable (m : Model L) (fw : FOWords) (nm : LexNaming L) (w : m.W)
+
+/-- Truth of a tree at a model's world under an assignment: it composes to a
+true truth value. -/
+def HoldsAt (lex : Lexicon m.E m.W) (g : Core.Assignment m.E)
+    (t : Tree Unit String) : Prop :=
+  ∃ p, Tree.interp m.E m.W lex g t = some ⟨.t, p⟩ ∧ p
+
+theorem holdsAt_iff_realize (hnd : fw.Nodup) (hfr : fw.FreshFor nm)
+    (hdj : nm.Disjoint) {t : Tree Unit String} {φ : L.Formula ℕ}
+    (h : compileFO fw nm t = some φ) (g : Core.Assignment m.E) :
+    HoldsAt m (m.lexiconFO fw nm w) g t ↔ m.realizeAt w φ g := by
+  constructor
+  · rintro ⟨p, hp, htrue⟩
+    have := (interp_compileFO m fw nm w hnd hfr hdj t g h).symm.trans hp
+    simp only [Option.some.injEq, TypedDenot.mk.injEq, heq_eq_eq,
+      true_and] at this
+    rw [this]
+    exact htrue
+  · intro hr
+    exact ⟨_, interp_compileFO m fw nm w hnd hfr hdj t g h, hr⟩
+
+/-- **Consequence transfer**: first-order consequence between compiled
+formulas yields cross-model entailment between the trees — for every
+composition model, world, and assignment. -/
+theorem holdsAt_of_models (hnd : fw.Nodup) (hfr : fw.FreshFor nm)
+    (hdj : nm.Disjoint) {t₁ t₂ : Tree Unit String} {φ₁ φ₂ : L.Formula ℕ}
+    (h₁ : compileFO fw nm t₁ = some φ₁) (h₂ : compileFO fw nm t₂ = some φ₂)
+    (hmod : ∀ (M : Type) (S : L.Structure M) (v : ℕ → M),
+      @Formula.Realize L M S ℕ φ₁ v → @Formula.Realize L M S ℕ φ₂ v)
+    (g : Core.Assignment m.E) :
+    HoldsAt m (m.lexiconFO fw nm w) g t₁ →
+      HoldsAt m (m.lexiconFO fw nm w) g t₂ := by
+  rw [holdsAt_iff_realize m fw nm w hnd hfr hdj h₁ g,
+    holdsAt_iff_realize m fw nm w hnd hfr hdj h₂ g]
+  exact hmod m.E (m.interp w) g
+
+end Consequence
+
+end Semantics.Composition
+
+namespace Semantics.Composition
+
+/-- The default logical vocabulary is pairwise distinct. -/
+theorem FOWords.nodup_default : ({} : FOWords).Nodup := by
+  unfold FOWords.Nodup
+  decide
+
+end Semantics.Composition

--- a/Linglib/Semantics/Composition/Reduction.lean
+++ b/Linglib/Semantics/Composition/Reduction.lean
@@ -1,6 +1,7 @@
 import Linglib.Semantics.Composition.Model
 import Linglib.Core.Logic.Quantification.Basic
 import Mathlib.ModelTheory.Semantics
+import Mathlib.ModelTheory.Satisfiability
 import Mathlib.Tactic.FinCases
 
 /-!
@@ -685,5 +686,125 @@ namespace Semantics.Composition
 theorem FOWords.nodup_default : ({} : FOWords).Nodup := by
   unfold FOWords.Nodup
   decide
+
+end Semantics.Composition
+
+/-! ### Bridge to mathlib `Theory` consequence
+
+For universe-0 languages, composition models and mathlib's bundled models
+coincide: tree entailment over nonempty-domain composition models *is*
+first-order consequence over the empty theory, and compactness transfers
+to families of trees. (`ModelType` requires nonempty carriers, hence the
+nonempty-domain restriction — standard in the GQ literature.) -/
+
+namespace Semantics.Composition
+
+open FirstOrder Language
+open Semantics.Montague (Lexicon)
+open Syntax (Tree)
+
+section TheoryBridge
+
+variable {L₀ : Language.{0, 0}} (fw : FOWords) (nm : LexNaming L₀)
+
+/-- A first-order structure as a one-world composition model. -/
+def Model.ofStructure (M : Type) (S : L₀.Structure M) : Model L₀ :=
+  ⟨M, Unit, fun _ => S⟩
+
+private theorem modelEmpty (M : Type) [L₀.Structure M] : M ⊨ (∅ : L₀.Theory) :=
+  ⟨fun _φ hφ => absurd hφ (by simp)⟩
+
+/-- **Tree entailment is first-order consequence**: mathlib's `⊨ᵇ` over the
+empty theory coincides with cross-model entailment between compiled trees,
+over nonempty-domain composition models. -/
+theorem models_imp_iff_entails (hnd : fw.Nodup) (hfr : fw.FreshFor nm)
+    (hdj : nm.Disjoint) {t₁ t₂ : Tree Unit String} {φ₁ φ₂ : L₀.Formula ℕ}
+    (h₁ : compileFO fw nm t₁ = some φ₁) (h₂ : compileFO fw nm t₂ = some φ₂) :
+    (∅ : L₀.Theory) ⊨ᵇ φ₁.imp φ₂ ↔
+      ∀ (m : Model L₀), Nonempty m.E → ∀ (w : m.W) (g : Core.Assignment m.E),
+        HoldsAt m (m.lexiconFO fw nm w) g t₁ →
+          HoldsAt m (m.lexiconFO fw nm w) g t₂ := by
+  constructor
+  · intro hmod m hne w g
+    rw [holdsAt_iff_realize m fw nm w hnd hfr hdj h₁ g,
+      holdsAt_iff_realize m fw nm w hnd hfr hdj h₂ g]
+    letI := m.interp w
+    haveI : m.E ⊨ (∅ : L₀.Theory) := modelEmpty m.E
+    haveI : Nonempty m.E := hne
+    have h := hmod ⟨m.E⟩ g default
+    exact BoundedFormula.realize_imp.mp h
+  · intro hent M v xs
+    have hxs : xs = default := funext fun i => i.elim0
+    subst hxs
+    rw [BoundedFormula.realize_imp]
+    have := hent (Model.ofStructure M M.struc) M.nonempty' () v
+    rw [holdsAt_iff_realize (Model.ofStructure M M.struc) fw nm ()
+        hnd hfr hdj h₁ v,
+      holdsAt_iff_realize (Model.ofStructure M M.struc) fw nm ()
+        hnd hfr hdj h₂ v] at this
+    exact this
+
+/-! ### Closed trees as sentences, and compactness -/
+
+/-- A compiled formula with no occurring free variables, as a sentence. -/
+def _root_.FirstOrder.Language.Formula.toSentence (φ : L₀.Formula ℕ)
+    (h : φ.freeVarFinset = ∅) : L₀.Sentence :=
+  φ.restrictFreeVar fun x => absurd x.2 (by simp [h])
+
+theorem realize_toSentence {M : Type} [L₀.Structure M] (φ : L₀.Formula ℕ)
+    (h : φ.freeVarFinset = ∅) (v : ℕ → M) :
+    (M ⊨ φ.toSentence h) ↔ φ.Realize v :=
+  BoundedFormula.realize_restrictFreeVar v
+    (fun a => absurd a.2 (by simp [h]))
+
+/-- **Compactness at the tree level**: a family of closed fragment trees is
+jointly satisfiable in a nonempty-domain composition model iff every finite
+subfamily is. The nontrivial direction is mathlib's compactness theorem
+(`Theory.isSatisfiable_iff_isFinitelySatisfiable`, via ultraproducts). -/
+theorem holdsAt_compactness (hnd : fw.Nodup) (hfr : fw.FreshFor nm)
+    (hdj : nm.Disjoint) {ι : Type} (trees : ι → Tree Unit String)
+    (φs : ι → L₀.Formula ℕ)
+    (hc : ∀ i, compileFO fw nm (trees i) = some (φs i))
+    (hcl : ∀ i, (φs i).freeVarFinset = ∅) :
+    (∃ (m : Model L₀) (_ : Nonempty m.E) (w : m.W) (g : Core.Assignment m.E),
+        ∀ i, HoldsAt m (m.lexiconFO fw nm w) g (trees i)) ↔
+      ∀ s : Finset ι,
+        ∃ (m : Model L₀) (_ : Nonempty m.E) (w : m.W) (g : Core.Assignment m.E),
+          ∀ i ∈ s, HoldsAt m (m.lexiconFO fw nm w) g (trees i) := by
+  constructor
+  · rintro ⟨m, hne, w, g, hall⟩ s
+    exact ⟨m, hne, w, g, fun i _ => hall i⟩
+  · intro hfin
+    have hsat : Theory.IsSatisfiable
+        (L := L₀) (Set.range fun i => (φs i).toSentence (hcl i)) := by
+      rw [Theory.isSatisfiable_iff_isFinitelySatisfiable]
+      intro T₀ hT₀
+      classical
+      choose f hf using fun (x : T₀) => hT₀ x.2
+      obtain ⟨m, hne, w, g, hs⟩ := hfin (Finset.univ.image f)
+      letI := m.interp w
+      haveI : Nonempty m.E := hne
+      haveI : m.E ⊨ (T₀ : L₀.Theory) := by
+        refine ⟨fun ψ hψ => ?_⟩
+        obtain ⟨x, rfl⟩ : ∃ x : T₀, (φs (f x)).toSentence (hcl (f x)) = ψ :=
+          ⟨⟨ψ, hψ⟩, hf ⟨ψ, hψ⟩⟩
+        rw [realize_toSentence (v := g)]
+        have hold := hs (f x) (Finset.mem_image_of_mem f (Finset.mem_univ x))
+        rw [holdsAt_iff_realize m fw nm w hnd hfr hdj (hc (f x)) g] at hold
+        exact hold
+      exact Theory.Model.isSatisfiable m.E
+    obtain ⟨N⟩ := hsat
+    letI := N.struc
+    haveI := N.nonempty'
+    refine ⟨Model.ofStructure N N.struc, N.nonempty', (),
+      fun _ => Classical.arbitrary N, fun i => ?_⟩
+    rw [holdsAt_iff_realize (Model.ofStructure N N.struc) fw nm ()
+      hnd hfr hdj (hc i) _]
+    have : (N : Type) ⊨ (φs i).toSentence (hcl i) :=
+      N.is_model.realize_of_mem _ (Set.mem_range_self i)
+    exact (realize_toSentence (M := (N : Type)) (φs i) (hcl i)
+      (fun _ => Classical.arbitrary N)).mp this
+
+end TheoryBridge
 
 end Semantics.Composition

--- a/Linglib/Studies/BarwiseCooper1981.lean
+++ b/Linglib/Studies/BarwiseCooper1981.lean
@@ -245,13 +245,13 @@ open Semantics.Montague.ToyLexicon (student_sem thing_sem)
 theorem every_not_symmetric : ¬ QSymmetric (every_sem (α := ToyEntity)) := by
   intro h
   have := (h student_sem thing_sem).mp (fun x _ => trivial)
-  exact absurd (this ToyEntity.pizza trivial) (by simp [student_sem])
+  exact absurd (this ToyEntity.pizza trivial) id
 
 /-- `⟦no⟧` is NOT positive strong: no(A,A) = false when A is non-empty. -/
 theorem no_not_positive_strong : ¬ PositiveStrong (no_sem (α := ToyEntity)) := by
   intro h
   have := h student_sem
-  exact this ToyEntity.john (by simp [student_sem]) (by simp [student_sem])
+  exact this ToyEntity.john trivial trivial
 
 end ToyWitnesses
 

--- a/Linglib/Studies/HeimKratzer1998.lean
+++ b/Linglib/Studies/HeimKratzer1998.lean
@@ -205,4 +205,54 @@ def synTree_everyStudentSleeps : Tree Cat String :=
      .bind 1 .S
        (.node .S (.trace 1 .NP :: .node .VP (.terminal .V "sleeps" :: []) :: [])) :: [])
 
+/-! ### First-order reduction
+
+The textbook trees are in the compiled FO fragment
+(`Composition/Reduction.lean`): they compile to mathlib
+`FirstOrder.Language.Formula`s, and by the agreement theorem the engine's
+truth conditions *are* model-theoretic realization over `toyModel`. -/
+
+section Reduction
+
+open Semantics.Composition
+
+/-- The textbook trees compile. -/
+example : (compileFO {} toyNaming tree_everyStudentSleeps).isSome = true := rfl
+example : (compileFO {} toyNaming tree_someStudentSleeps).isSome = true := rfl
+
+/-- The agreement theorem instantiated at the toy model: for any tree in the
+fragment, engine truth conditions are `Realize` of the compiled formula. -/
+theorem interp_eq_realize {t : Tree Unit String} {φ : toyLang.Formula ℕ}
+    (h : compileFO {} toyNaming t = some φ) (g : Core.Assignment ToyEntity) :
+    Tree.interp ToyEntity Unit (toyModel.lexiconFO {} toyNaming ()) g t
+      = some ⟨.t, toyModel.realizeAt () φ g⟩ :=
+  interp_compileFO toyModel {} toyNaming () FOWords.nodup_default
+    toyNaming_freshFor toyNaming_disjoint t g h
+
+/-- "Some student sleeps" holds in the toy model, via the engine. -/
+theorem someStudentSleeps_holds (g : Core.Assignment ToyEntity) :
+    HoldsAt toyModel (toyModel.lexiconFO {} toyNaming ()) g
+      tree_someStudentSleeps :=
+  ⟨_, rfl, ⟨ToyEntity.john, trivial, trivial⟩⟩
+
+/-- "John sleeps and Mary laughs". -/
+def tree_conj : Tree Unit String :=
+  .bin (.bin (.leaf "John") (.leaf "sleeps"))
+       (.bin (.leaf "and") (.bin (.leaf "Mary") (.leaf "laughs")))
+
+/-- **Consequence transfer**: conjunction elimination is a first-order
+consequence, so the entailment holds in the toy model — and by the same
+theorem in *every* composition model interpreting the signature. -/
+theorem conj_entails_first (g : Core.Assignment ToyEntity) :
+    HoldsAt toyModel (toyModel.lexiconFO {} toyNaming ()) g tree_conj →
+      HoldsAt toyModel (toyModel.lexiconFO {} toyNaming ()) g
+        (.bin (.leaf "John") (.leaf "sleeps")) :=
+  holdsAt_of_models toyModel {} toyNaming () FOWords.nodup_default
+    toyNaming_freshFor toyNaming_disjoint rfl rfl
+    (fun _ S v h => by
+      letI := S
+      exact (FirstOrder.Language.Formula.realize_inf.mp h).1) g
+
+end Reduction
+
 end HeimKratzer1998

--- a/Linglib/Studies/KeenanStavi1986.lean
+++ b/Linglib/Studies/KeenanStavi1986.lean
@@ -34,7 +34,7 @@ theorem every_not_existential : ¬ Existential (every_sem (α := ToyEntity)) := 
   have hFwd := (h thing_sem student_sem).mpr
   have : every_sem (fun x => thing_sem x ∧ student_sem x) (fun _ => True) := by
     intro x _; trivial
-  exact absurd (hFwd this ToyEntity.pizza trivial) (by simp [student_sem])
+  exact absurd (hFwd this ToyEntity.pizza trivial) id
 
 /-- `⟦most⟧` is NOT existential (K&S §3.3). -/
 theorem most_not_existential : ¬ Existential (most_sem (α := ToyEntity)) := by


### PR DESCRIPTION
Grounds the composition engine in mathlib ModelTheory: naming-map lexicon constructor and toy fragment rebuilt as a `Model` instance (mathlib concrete-language idiom), partial FO compiler over QR'd H&K trees with the `interp`/`Realize` agreement theorem, and tree entailment as `Theory` consequence with compactness.