### PR TITLE
feat(Studies): B&C C12, more-than-half is not FO-definable

### DIFF
--- a/Linglib/Studies/BarwiseCooper1981.lean
+++ b/Linglib/Studies/BarwiseCooper1981.lean
@@ -1,4 +1,7 @@
 import Linglib.Features.Acceptability
+import Mathlib.Data.Finset.Fin
+import Mathlib.Data.Set.Card
+import Mathlib.Order.Interval.Finset.Nat
 import Linglib.Fragments.English.Determiners
 import Linglib.Fragments.English.Toy
 import Linglib.Phenomena.Quantification.Inventory
@@ -409,3 +412,347 @@ theorem domain_restriction_preserves_conservativity :
   exact conservative_domain_restricted (conservativity_universal q)
 
 end Phenomena.Quantification.Bridge
+
+/-! ### Appendix C: *more than half* is not first-order definable
+
+[barwise-cooper-1981] Appendix C (C12, p. 213): over a first-order language
+with equality and two unary predicate symbols `U`, `V`, **no sentence** is
+true in exactly the finite models where more than half the V's are U's
+(`2·|U∩V| > |V|`). B&C treat *most* via *more than half* "to avoid problems
+of vagueness"; the theorem is the formal core of their claim that *most*
+must be a determiner, not a quantifier (their C13, deferred).
+
+The proof is the paper's own (pp. 213–214), a hand-rolled Fraïssé argument:
+for each `m`, two structures on `Fin (3m+1)` — `V = [0,2m)`, `U₁ = [0,m)`,
+`U₂ = [0,m+1)` — disagree on *more than half* but agree on every formula
+with fewer than `m` quantifiers-plus-free-variables (their condition (6)),
+because a region-respecting correspondence can always be extended:
+"there is always enough room". -/
+
+namespace BarwiseCooper1981
+
+open FirstOrder Language
+
+/-- Relation symbols: two unary predicates. -/
+inductive uvRel : ℕ → Type
+  | U : uvRel 1
+  | V : uvRel 1
+  deriving DecidableEq
+
+/-- The monadic language of C12 (equality is built into the formula type). -/
+def L_UV : Language :=
+  { Functions := fun _ => Empty
+    Relations := uvRel }
+
+abbrev uRel : L_UV.Relations 1 := .U
+abbrev vRel : L_UV.Relations 1 := .V
+
+/-- Quantifier count of a formula (`c(φ)` minus the free-variable count in
+B&C's notation). -/
+def numQuant : ∀ {α : Type} {n : ℕ}, L_UV.BoundedFormula α n → ℕ
+  | _, _, .falsum => 0
+  | _, _, .equal _ _ => 0
+  | _, _, .rel _ _ => 0
+  | _, _, .imp f₁ f₂ => numQuant f₁ + numQuant f₂
+  | _, _, .all f => numQuant f + 1
+
+/-- `M₁`: `U` is `[0, m)`, `V` is `[0, 2m)` — exactly half the V's are U's. -/
+@[reducible] def struc₁ (m : ℕ) : L_UV.Structure (Fin (3 * m + 1)) where
+  funMap := fun f _ => f.elim
+  RelMap {n} r v :=
+    match r, v with
+    | .U, v => (v 0).val < m
+    | .V, v => (v 0).val < 2 * m
+
+/-- `M₂`: `U` is `[0, m+1)`, `V` is `[0, 2m)` — more than half the V's are
+U's. -/
+@[reducible] def struc₂ (m : ℕ) : L_UV.Structure (Fin (3 * m + 1)) where
+  funMap := fun f _ => f.elim
+  RelMap {n} r v :=
+    match r, v with
+    | .U, v => (v 0).val < m + 1
+    | .V, v => (v 0).val < 2 * m
+
+/-- Realization in `M₁` (structures are term-level, so instances are pinned
+explicitly). -/
+def Realize₁ (m : ℕ) {ℓ : ℕ} (φ : L_UV.BoundedFormula Empty ℓ)
+    (xs : Fin ℓ → Fin (3 * m + 1)) : Prop :=
+  @BoundedFormula.Realize L_UV _ (struc₁ m) Empty ℓ φ default xs
+
+/-- Realization in `M₂`. -/
+def Realize₂ (m : ℕ) {ℓ : ℕ} (φ : L_UV.BoundedFormula Empty ℓ)
+    (xs : Fin ℓ → Fin (3 * m + 1)) : Prop :=
+  @BoundedFormula.Realize L_UV _ (struc₂ m) Empty ℓ φ default xs
+
+/-- B&C's one-one correspondence (proof of C12, condition on `aᵢ ↔ bᵢ`):
+pairing-injective, and respecting the `U`-regions (`U₁` against `U₂`) and
+the shared `V`-region. -/
+structure RegionMatch (m : ℕ) {ℓ : ℕ} (a b : Fin ℓ → Fin (3 * m + 1)) : Prop where
+  inj : ∀ i j, a i = a j ↔ b i = b j
+  inU : ∀ i, (a i).val < m ↔ (b i).val < m + 1
+  inV : ∀ i, (a i).val < 2 * m ↔ (b i).val < 2 * m
+
+/-- Every `L_UV`-term is a variable (the language has no function symbols). -/
+private theorem term_eq_var {γ : Type} (t : L_UV.Term γ) : ∃ i, t = Term.var i := by
+  cases t with
+  | var i => exact ⟨i, rfl⟩
+  | func f _ => exact f.elim
+
+/-- Fresh element in a value-interval of `Fin (3m+1)`: if fewer elements are
+used than the interval holds, something in it is unused. -/
+private theorem exists_fresh (m lo hi : ℕ) (hhi : hi ≤ 3 * m + 1)
+    (used : Finset (Fin (3 * m + 1))) (hcard : used.card < hi - lo) :
+    ∃ y : Fin (3 * m + 1), lo ≤ y.val ∧ y.val < hi ∧ y ∉ used := by
+  by_contra h
+  push_neg at h
+  have hsub : (Finset.Ico lo hi).attachFin
+      (fun x hx => lt_of_lt_of_le (Finset.mem_Ico.mp hx).2 hhi) ⊆ used := by
+    intro y hy
+    have := (Finset.mem_attachFin _).mp hy
+    exact h y (Finset.mem_Ico.mp this).1 (Finset.mem_Ico.mp this).2
+  have := Finset.card_le_card hsub
+  rw [Finset.card_attachFin, Nat.card_Ico] at this
+  omega
+
+/-- Extending a correspondence with an already-matched pair. -/
+private theorem regionMatch_snoc_matched (m : ℕ) {ℓ : ℕ}
+    {a b : Fin ℓ → Fin (3 * m + 1)} (h : RegionMatch m a b) (i : Fin ℓ) :
+    RegionMatch m (Fin.snoc a (a i)) (Fin.snoc b (b i)) := by
+  refine ⟨?_, ?_, ?_⟩
+  · intro p q
+    induction p using Fin.lastCases with
+    | last =>
+      induction q using Fin.lastCases with
+      | last => simp
+      | cast q => simpa only [Fin.snoc_last, Fin.snoc_castSucc] using h.inj i q
+    | cast p =>
+      induction q using Fin.lastCases with
+      | last => simpa only [Fin.snoc_last, Fin.snoc_castSucc] using h.inj p i
+      | cast q => simpa only [Fin.snoc_castSucc] using h.inj p q
+  · intro p
+    induction p using Fin.lastCases with
+    | last => simpa only [Fin.snoc_last] using h.inU i
+    | cast p => simpa only [Fin.snoc_castSucc] using h.inU p
+  · intro p
+    induction p using Fin.lastCases with
+    | last => simpa only [Fin.snoc_last] using h.inV i
+    | cast p => simpa only [Fin.snoc_castSucc] using h.inV p
+
+/-- Extending a correspondence with a fresh, region-matched pair. -/
+private theorem regionMatch_snoc_fresh (m : ℕ) {ℓ : ℕ}
+    {a b : Fin ℓ → Fin (3 * m + 1)} (h : RegionMatch m a b)
+    {x y : Fin (3 * m + 1)} (hxa : ∀ i, a i ≠ x) (hyb : ∀ i, b i ≠ y)
+    (hU : x.val < m ↔ y.val < m + 1) (hV : x.val < 2 * m ↔ y.val < 2 * m) :
+    RegionMatch m (Fin.snoc a x) (Fin.snoc b y) := by
+  refine ⟨?_, ?_, ?_⟩
+  · intro p q
+    induction p using Fin.lastCases with
+    | last =>
+      induction q using Fin.lastCases with
+      | last => simp
+      | cast q =>
+        simp only [Fin.snoc_last, Fin.snoc_castSucc]
+        exact iff_of_false (fun e => hxa q e.symm) (fun e => hyb q e.symm)
+    | cast p =>
+      induction q using Fin.lastCases with
+      | last =>
+        simp only [Fin.snoc_last, Fin.snoc_castSucc]
+        exact iff_of_false (hxa p) (hyb p)
+      | cast q => simpa only [Fin.snoc_castSucc] using h.inj p q
+  · intro p
+    induction p using Fin.lastCases with
+    | last => simpa only [Fin.snoc_last] using hU
+    | cast p => simpa only [Fin.snoc_castSucc] using h.inU p
+  · intro p
+    induction p using Fin.lastCases with
+    | last => simpa only [Fin.snoc_last] using hV
+    | cast p => simpa only [Fin.snoc_castSucc] using h.inV p
+
+/-- Extend a correspondence by an `M₁`-side element ("there is always enough
+room", B&C p. 214). -/
+private theorem extend₁₂ (m : ℕ) {ℓ : ℕ} (hℓ : ℓ + 1 < m)
+    {a b : Fin ℓ → Fin (3 * m + 1)} (h : RegionMatch m a b)
+    (x : Fin (3 * m + 1)) :
+    ∃ y, RegionMatch m (Fin.snoc a x) (Fin.snoc b y) := by
+  by_cases hx : ∃ i, a i = x
+  · obtain ⟨i, rfl⟩ := hx
+    exact ⟨b i, regionMatch_snoc_matched m h i⟩
+  · push_neg at hx
+    have hused : (Finset.image b Finset.univ).card ≤ ℓ :=
+      le_trans Finset.card_image_le (by simp)
+    have hbne : ∀ {y : Fin (3 * m + 1)}, y ∉ Finset.image b Finset.univ →
+        ∀ i, b i ≠ y := fun hy i hbi =>
+      hy (hbi ▸ Finset.mem_image_of_mem b (Finset.mem_univ i))
+    by_cases h1 : x.val < m
+    · obtain ⟨y, hy1, hy2, hy3⟩ := exists_fresh m 0 (m + 1) (by omega)
+        (Finset.image b Finset.univ) (by omega)
+      exact ⟨y, regionMatch_snoc_fresh m h hx (hbne hy3)
+        (by omega) (by omega)⟩
+    · by_cases h2 : x.val < 2 * m
+      · obtain ⟨y, hy1, hy2, hy3⟩ := exists_fresh m (m + 1) (2 * m) (by omega)
+          (Finset.image b Finset.univ) (by omega)
+        exact ⟨y, regionMatch_snoc_fresh m h hx (hbne hy3)
+          (by omega) (by omega)⟩
+      · obtain ⟨y, hy1, hy2, hy3⟩ := exists_fresh m (2 * m) (3 * m + 1) (by omega)
+          (Finset.image b Finset.univ) (by omega)
+        exact ⟨y, regionMatch_snoc_fresh m h hx (hbne hy3)
+          (by omega) (by omega)⟩
+
+/-- Extend a correspondence by an `M₂`-side element. -/
+private theorem extend₂₁ (m : ℕ) {ℓ : ℕ} (hℓ : ℓ + 1 < m)
+    {a b : Fin ℓ → Fin (3 * m + 1)} (h : RegionMatch m a b)
+    (y : Fin (3 * m + 1)) :
+    ∃ x, RegionMatch m (Fin.snoc a x) (Fin.snoc b y) := by
+  by_cases hy : ∃ i, b i = y
+  · obtain ⟨i, rfl⟩ := hy
+    exact ⟨a i, regionMatch_snoc_matched m h i⟩
+  · push_neg at hy
+    have hused : (Finset.image a Finset.univ).card ≤ ℓ :=
+      le_trans Finset.card_image_le (by simp)
+    have hane : ∀ {x : Fin (3 * m + 1)}, x ∉ Finset.image a Finset.univ →
+        ∀ i, a i ≠ x := fun hx i hai =>
+      hx (hai ▸ Finset.mem_image_of_mem a (Finset.mem_univ i))
+    by_cases h1 : y.val < m + 1
+    · obtain ⟨x, hx1, hx2, hx3⟩ := exists_fresh m 0 m (by omega)
+        (Finset.image a Finset.univ) (by omega)
+      exact ⟨x, regionMatch_snoc_fresh m h (hane hx3) hy
+        (by omega) (by omega)⟩
+    · by_cases h2 : y.val < 2 * m
+      · obtain ⟨x, hx1, hx2, hx3⟩ := exists_fresh m m (2 * m) (by omega)
+          (Finset.image a Finset.univ) (by omega)
+        exact ⟨x, regionMatch_snoc_fresh m h (hane hx3) hy
+          (by omega) (by omega)⟩
+      · obtain ⟨x, hx1, hx2, hx3⟩ := exists_fresh m (2 * m) (3 * m + 1) (by omega)
+          (Finset.image a Finset.univ) (by omega)
+        exact ⟨x, regionMatch_snoc_fresh m h (hane hx3) hy
+          (by omega) (by omega)⟩
+
+/-- B&C's condition (6) (p. 214): a formula whose quantifier count plus
+free-variable count is below `m` cannot distinguish region-matched tuples
+across `M₁`/`M₂`. Structural induction; at each quantifier "there is always
+enough room to extend the one-one correspondence one more step". -/
+theorem realize_iff_of_regionMatch (m : ℕ) :
+    ∀ {ℓ : ℕ} (φ : L_UV.BoundedFormula Empty ℓ), numQuant φ + ℓ < m →
+      ∀ {a b : Fin ℓ → Fin (3 * m + 1)}, RegionMatch m a b →
+        (Realize₁ m φ a ↔ Realize₂ m φ b) := by
+  intro ℓ φ
+  induction φ with
+  | falsum =>
+    intro _ a b _
+    exact Iff.rfl
+  | equal t₁ t₂ =>
+    intro _ a b h
+    obtain ⟨i, rfl⟩ := term_eq_var t₁
+    obtain ⟨j, rfl⟩ := term_eq_var t₂
+    rcases i with e | i
+    · exact e.elim
+    rcases j with e | j
+    · exact e.elim
+    simpa [Realize₁, Realize₂, Term.realize] using h.inj i j
+  | rel R ts =>
+    intro _ a b h
+    cases R with
+    | U =>
+      obtain ⟨i, hi⟩ := term_eq_var (ts 0)
+      rcases i with e | i
+      · exact e.elim
+      show ((fun k => @Term.realize L_UV _ (struc₁ m) _ (Sum.elim default a) (ts k)) 0).val < m ↔
+        ((fun k => @Term.realize L_UV _ (struc₂ m) _ (Sum.elim default b) (ts k)) 0).val < m + 1
+      simp only [hi, Term.realize_var, Sum.elim_inr]
+      exact h.inU i
+    | V =>
+      obtain ⟨i, hi⟩ := term_eq_var (ts 0)
+      rcases i with e | i
+      · exact e.elim
+      show ((fun k => @Term.realize L_UV _ (struc₁ m) _ (Sum.elim default a) (ts k)) 0).val < 2 * m ↔
+        ((fun k => @Term.realize L_UV _ (struc₂ m) _ (Sum.elim default b) (ts k)) 0).val < 2 * m
+      simp only [hi, Term.realize_var, Sum.elim_inr]
+      exact h.inV i
+  | imp f₁ f₂ ih₁ ih₂ =>
+    intro hc a b h
+    simp only [numQuant] at hc
+    simp only [Realize₁, Realize₂, BoundedFormula.realize_imp] at *
+    exact imp_congr (ih₁ (by omega) h) (ih₂ (by omega) h)
+  | @all k f ih =>
+    intro hc a b h
+    simp only [numQuant] at hc
+    have hc' : numQuant f + (k + 1) < m := by omega
+    have hℓ : k + 1 < m := by omega
+    simp only [Realize₁, Realize₂, BoundedFormula.realize_all] at *
+    constructor
+    · intro hall y
+      obtain ⟨x, hx⟩ := extend₂₁ m hℓ h y
+      exact (ih hc' hx).mp (hall x)
+    · intro hall x
+      obtain ⟨y, hy⟩ := extend₁₂ m hℓ h x
+      exact (ih hc' hy).mpr (hall y)
+
+/-! ### The theorem -/
+
+/-- The *more than half* truth condition over a structure: more than half
+the V's are U's (`Card(U ∩ V) > ½ Card(V)`, B&C p. 213). -/
+def MoreThanHalf (M : Type) (S : L_UV.Structure M) : Prop :=
+  2 * Set.ncard {x : M | S.RelMap uRel ![x] ∧ S.RelMap vRel ![x]} >
+    Set.ncard {x : M | S.RelMap vRel ![x]}
+
+private theorem ncard_val_lt (n c : ℕ) (hc : c ≤ n) :
+    Set.ncard {x : Fin n | x.val < c} = c := by
+  have hset : {x : Fin n | x.val < c} = ↑((Finset.Ico 0 c).attachFin
+      (fun x hx => lt_of_lt_of_le (Finset.mem_Ico.mp hx).2 hc)) := by
+    ext x
+    simp [Finset.mem_attachFin, Finset.mem_Ico]
+  rw [hset, Set.ncard_coe_finset, Finset.card_attachFin, Nat.card_Ico]
+  omega
+
+/-- **C12** ([barwise-cooper-1981], Appendix C p. 213): no first-order
+sentence over two unary predicates is true in exactly the finite models
+where more than half the V's are U's. The formal core of B&C's claim that
+*most* is a determiner, not a quantifier. -/
+theorem more_than_half_not_definable :
+    ¬ ∃ φ : L_UV.Sentence, ∀ (M : Type) [Fintype M] (S : L_UV.Structure M),
+      (@Sentence.Realize L_UV M S φ ↔ MoreThanHalf M S) := by
+  rintro ⟨φ, hφ⟩
+  set m := numQuant φ + 1 with hm
+  have hm1 : 1 ≤ m := by omega
+  -- M₁ does not satisfy more-than-half: |U₁ ∩ V| = m, |V| = 2m
+  have hmth₁ : ¬ MoreThanHalf (Fin (3 * m + 1)) (struc₁ m) := by
+    have hUV : {x : Fin (3 * m + 1) |
+        (struc₁ m).RelMap uRel ![x] ∧ (struc₁ m).RelMap vRel ![x]}
+        = {x : Fin (3 * m + 1) | x.val < m} := by
+      ext x
+      show (x.val < m ∧ x.val < 2 * m) ↔ x.val < m
+      omega
+    have hV : {x : Fin (3 * m + 1) | (struc₁ m).RelMap vRel ![x]}
+        = {x : Fin (3 * m + 1) | x.val < 2 * m} := rfl
+    unfold MoreThanHalf
+    rw [hUV, hV, ncard_val_lt _ _ (by omega), ncard_val_lt _ _ (by omega)]
+    omega
+  -- M₂ satisfies more-than-half: |U₂ ∩ V| = m + 1, |V| = 2m
+  have hmth₂ : MoreThanHalf (Fin (3 * m + 1)) (struc₂ m) := by
+    have hUV : {x : Fin (3 * m + 1) |
+        (struc₂ m).RelMap uRel ![x] ∧ (struc₂ m).RelMap vRel ![x]}
+        = {x : Fin (3 * m + 1) | x.val < m + 1} := by
+      ext x
+      show (x.val < m + 1 ∧ x.val < 2 * m) ↔ x.val < m + 1
+      omega
+    have hV : {x : Fin (3 * m + 1) | (struc₂ m).RelMap vRel ![x]}
+        = {x : Fin (3 * m + 1) | x.val < 2 * m} := rfl
+    unfold MoreThanHalf
+    rw [hUV, hV, ncard_val_lt _ _ (by omega), ncard_val_lt _ _ (by omega)]
+    omega
+  -- but they agree on φ, by condition (6) at the empty correspondence
+  have hagree : Realize₁ m φ default ↔ Realize₂ m φ default :=
+    realize_iff_of_regionMatch m φ (by omega)
+      ⟨fun i => i.elim0, fun i => i.elim0, fun i => i.elim0⟩
+  have hsent₁ : @Sentence.Realize L_UV _ (struc₁ m) φ ↔ Realize₁ m φ default := by
+    unfold Realize₁
+    exact iff_of_eq (congrArg₂ (@BoundedFormula.Realize L_UV _ (struc₁ m) Empty 0 φ)
+      (funext fun e => e.elim) (funext fun i => i.elim0))
+  have hsent₂ : @Sentence.Realize L_UV _ (struc₂ m) φ ↔ Realize₂ m φ default := by
+    unfold Realize₂
+    exact iff_of_eq (congrArg₂ (@BoundedFormula.Realize L_UV _ (struc₂ m) Empty 0 φ)
+      (funext fun e => e.elim) (funext fun i => i.elim0))
+  exact hmth₁ ((hφ _ (struc₁ m)).mp
+    (hsent₁.mpr (hagree.mpr (hsent₂.mp ((hφ _ (struc₂ m)).mpr hmth₂)))))
+
+end BarwiseCooper1981

--- a/Linglib/Studies/BarwiseCooper1981.lean
+++ b/Linglib/Studies/BarwiseCooper1981.lean
@@ -457,7 +457,7 @@ def numQuant : ∀ {α : Type} {n : ℕ}, L_UV.BoundedFormula α n → ℕ
   | _, _, .all f => numQuant f + 1
 
 /-- `M₁`: `U` is `[0, m)`, `V` is `[0, 2m)` — exactly half the V's are U's. -/
-@[reducible] def struc₁ (m : ℕ) : L_UV.Structure (Fin (3 * m + 1)) where
+@[reducible] def struc₁ (m k : ℕ) : L_UV.Structure (Fin k) where
   funMap := fun f _ => f.elim
   RelMap {n} r v :=
     match r, v with
@@ -466,7 +466,7 @@ def numQuant : ∀ {α : Type} {n : ℕ}, L_UV.BoundedFormula α n → ℕ
 
 /-- `M₂`: `U` is `[0, m+1)`, `V` is `[0, 2m)` — more than half the V's are
 U's. -/
-@[reducible] def struc₂ (m : ℕ) : L_UV.Structure (Fin (3 * m + 1)) where
+@[reducible] def struc₂ (m k : ℕ) : L_UV.Structure (Fin k) where
   funMap := fun f _ => f.elim
   RelMap {n} r v :=
     match r, v with
@@ -475,19 +475,19 @@ U's. -/
 
 /-- Realization in `M₁` (structures are term-level, so instances are pinned
 explicitly). -/
-def Realize₁ (m : ℕ) {ℓ : ℕ} (φ : L_UV.BoundedFormula Empty ℓ)
-    (xs : Fin ℓ → Fin (3 * m + 1)) : Prop :=
-  @BoundedFormula.Realize L_UV _ (struc₁ m) Empty ℓ φ default xs
+def Realize₁ (m k : ℕ) {ℓ : ℕ} (φ : L_UV.BoundedFormula Empty ℓ)
+    (xs : Fin ℓ → Fin k) : Prop :=
+  @BoundedFormula.Realize L_UV _ (struc₁ m k) Empty ℓ φ default xs
 
 /-- Realization in `M₂`. -/
-def Realize₂ (m : ℕ) {ℓ : ℕ} (φ : L_UV.BoundedFormula Empty ℓ)
-    (xs : Fin ℓ → Fin (3 * m + 1)) : Prop :=
-  @BoundedFormula.Realize L_UV _ (struc₂ m) Empty ℓ φ default xs
+def Realize₂ (m k : ℕ) {ℓ : ℕ} (φ : L_UV.BoundedFormula Empty ℓ)
+    (xs : Fin ℓ → Fin k) : Prop :=
+  @BoundedFormula.Realize L_UV _ (struc₂ m k) Empty ℓ φ default xs
 
 /-- B&C's one-one correspondence (proof of C12, condition on `aᵢ ↔ bᵢ`):
 pairing-injective, and respecting the `U`-regions (`U₁` against `U₂`) and
 the shared `V`-region. -/
-structure RegionMatch (m : ℕ) {ℓ : ℕ} (a b : Fin ℓ → Fin (3 * m + 1)) : Prop where
+structure RegionMatch (m k : ℕ) {ℓ : ℕ} (a b : Fin ℓ → Fin k) : Prop where
   inj : ∀ i j, a i = a j ↔ b i = b j
   inU : ∀ i, (a i).val < m ↔ (b i).val < m + 1
   inV : ∀ i, (a i).val < 2 * m ↔ (b i).val < 2 * m
@@ -500,9 +500,9 @@ private theorem term_eq_var {γ : Type} (t : L_UV.Term γ) : ∃ i, t = Term.var
 
 /-- Fresh element in a value-interval of `Fin (3m+1)`: if fewer elements are
 used than the interval holds, something in it is unused. -/
-private theorem exists_fresh (m lo hi : ℕ) (hhi : hi ≤ 3 * m + 1)
-    (used : Finset (Fin (3 * m + 1))) (hcard : used.card < hi - lo) :
-    ∃ y : Fin (3 * m + 1), lo ≤ y.val ∧ y.val < hi ∧ y ∉ used := by
+private theorem exists_fresh (k lo hi : ℕ) (hhi : hi ≤ k)
+    (used : Finset (Fin k)) (hcard : used.card < hi - lo) :
+    ∃ y : Fin k, lo ≤ y.val ∧ y.val < hi ∧ y ∉ used := by
   by_contra h
   push_neg at h
   have hsub : (Finset.Ico lo hi).attachFin
@@ -515,9 +515,9 @@ private theorem exists_fresh (m lo hi : ℕ) (hhi : hi ≤ 3 * m + 1)
   omega
 
 /-- Extending a correspondence with an already-matched pair. -/
-private theorem regionMatch_snoc_matched (m : ℕ) {ℓ : ℕ}
-    {a b : Fin ℓ → Fin (3 * m + 1)} (h : RegionMatch m a b) (i : Fin ℓ) :
-    RegionMatch m (Fin.snoc a (a i)) (Fin.snoc b (b i)) := by
+private theorem regionMatch_snoc_matched (m k : ℕ) {ℓ : ℕ}
+    {a b : Fin ℓ → Fin k} (h : RegionMatch m k a b) (i : Fin ℓ) :
+    RegionMatch m k (Fin.snoc a (a i)) (Fin.snoc b (b i)) := by
   refine ⟨?_, ?_, ?_⟩
   · intro p q
     induction p using Fin.lastCases with
@@ -539,11 +539,11 @@ private theorem regionMatch_snoc_matched (m : ℕ) {ℓ : ℕ}
     | cast p => simpa only [Fin.snoc_castSucc] using h.inV p
 
 /-- Extending a correspondence with a fresh, region-matched pair. -/
-private theorem regionMatch_snoc_fresh (m : ℕ) {ℓ : ℕ}
-    {a b : Fin ℓ → Fin (3 * m + 1)} (h : RegionMatch m a b)
-    {x y : Fin (3 * m + 1)} (hxa : ∀ i, a i ≠ x) (hyb : ∀ i, b i ≠ y)
+private theorem regionMatch_snoc_fresh (m k : ℕ) {ℓ : ℕ}
+    {a b : Fin ℓ → Fin k} (h : RegionMatch m k a b)
+    {x y : Fin k} (hxa : ∀ i, a i ≠ x) (hyb : ∀ i, b i ≠ y)
     (hU : x.val < m ↔ y.val < m + 1) (hV : x.val < 2 * m ↔ y.val < 2 * m) :
-    RegionMatch m (Fin.snoc a x) (Fin.snoc b y) := by
+    RegionMatch m k (Fin.snoc a x) (Fin.snoc b y) := by
   refine ⟨?_, ?_, ?_⟩
   · intro p q
     induction p using Fin.lastCases with
@@ -570,71 +570,71 @@ private theorem regionMatch_snoc_fresh (m : ℕ) {ℓ : ℕ}
 
 /-- Extend a correspondence by an `M₁`-side element ("there is always enough
 room", B&C p. 214). -/
-private theorem extend₁₂ (m : ℕ) {ℓ : ℕ} (hℓ : ℓ + 1 < m)
-    {a b : Fin ℓ → Fin (3 * m + 1)} (h : RegionMatch m a b)
-    (x : Fin (3 * m + 1)) :
-    ∃ y, RegionMatch m (Fin.snoc a x) (Fin.snoc b y) := by
+private theorem extend₁₂ (m k : ℕ) (hk : 3 * m ≤ k) {ℓ : ℕ} (hℓ : ℓ + 1 < m)
+    {a b : Fin ℓ → Fin k} (h : RegionMatch m k a b)
+    (x : Fin k) :
+    ∃ y, RegionMatch m k (Fin.snoc a x) (Fin.snoc b y) := by
   by_cases hx : ∃ i, a i = x
   · obtain ⟨i, rfl⟩ := hx
-    exact ⟨b i, regionMatch_snoc_matched m h i⟩
+    exact ⟨b i, regionMatch_snoc_matched m k h i⟩
   · push_neg at hx
     have hused : (Finset.image b Finset.univ).card ≤ ℓ :=
       le_trans Finset.card_image_le (by simp)
-    have hbne : ∀ {y : Fin (3 * m + 1)}, y ∉ Finset.image b Finset.univ →
+    have hbne : ∀ {y : Fin k}, y ∉ Finset.image b Finset.univ →
         ∀ i, b i ≠ y := fun hy i hbi =>
       hy (hbi ▸ Finset.mem_image_of_mem b (Finset.mem_univ i))
     by_cases h1 : x.val < m
-    · obtain ⟨y, hy1, hy2, hy3⟩ := exists_fresh m 0 (m + 1) (by omega)
+    · obtain ⟨y, hy1, hy2, hy3⟩ := exists_fresh k 0 (m + 1) (by omega)
         (Finset.image b Finset.univ) (by omega)
-      exact ⟨y, regionMatch_snoc_fresh m h hx (hbne hy3)
+      exact ⟨y, regionMatch_snoc_fresh m k h hx (hbne hy3)
         (by omega) (by omega)⟩
     · by_cases h2 : x.val < 2 * m
-      · obtain ⟨y, hy1, hy2, hy3⟩ := exists_fresh m (m + 1) (2 * m) (by omega)
+      · obtain ⟨y, hy1, hy2, hy3⟩ := exists_fresh k (m + 1) (2 * m) (by omega)
           (Finset.image b Finset.univ) (by omega)
-        exact ⟨y, regionMatch_snoc_fresh m h hx (hbne hy3)
+        exact ⟨y, regionMatch_snoc_fresh m k h hx (hbne hy3)
           (by omega) (by omega)⟩
-      · obtain ⟨y, hy1, hy2, hy3⟩ := exists_fresh m (2 * m) (3 * m + 1) (by omega)
+      · obtain ⟨y, hy1, hy2, hy3⟩ := exists_fresh k (2 * m) k (by omega)
           (Finset.image b Finset.univ) (by omega)
-        exact ⟨y, regionMatch_snoc_fresh m h hx (hbne hy3)
+        exact ⟨y, regionMatch_snoc_fresh m k h hx (hbne hy3)
           (by omega) (by omega)⟩
 
 /-- Extend a correspondence by an `M₂`-side element. -/
-private theorem extend₂₁ (m : ℕ) {ℓ : ℕ} (hℓ : ℓ + 1 < m)
-    {a b : Fin ℓ → Fin (3 * m + 1)} (h : RegionMatch m a b)
-    (y : Fin (3 * m + 1)) :
-    ∃ x, RegionMatch m (Fin.snoc a x) (Fin.snoc b y) := by
+private theorem extend₂₁ (m k : ℕ) (hk : 3 * m ≤ k) {ℓ : ℕ} (hℓ : ℓ + 1 < m)
+    {a b : Fin ℓ → Fin k} (h : RegionMatch m k a b)
+    (y : Fin k) :
+    ∃ x, RegionMatch m k (Fin.snoc a x) (Fin.snoc b y) := by
   by_cases hy : ∃ i, b i = y
   · obtain ⟨i, rfl⟩ := hy
-    exact ⟨a i, regionMatch_snoc_matched m h i⟩
+    exact ⟨a i, regionMatch_snoc_matched m k h i⟩
   · push_neg at hy
     have hused : (Finset.image a Finset.univ).card ≤ ℓ :=
       le_trans Finset.card_image_le (by simp)
-    have hane : ∀ {x : Fin (3 * m + 1)}, x ∉ Finset.image a Finset.univ →
+    have hane : ∀ {x : Fin k}, x ∉ Finset.image a Finset.univ →
         ∀ i, a i ≠ x := fun hx i hai =>
       hx (hai ▸ Finset.mem_image_of_mem a (Finset.mem_univ i))
     by_cases h1 : y.val < m + 1
-    · obtain ⟨x, hx1, hx2, hx3⟩ := exists_fresh m 0 m (by omega)
+    · obtain ⟨x, hx1, hx2, hx3⟩ := exists_fresh k 0 m (by omega)
         (Finset.image a Finset.univ) (by omega)
-      exact ⟨x, regionMatch_snoc_fresh m h (hane hx3) hy
+      exact ⟨x, regionMatch_snoc_fresh m k h (hane hx3) hy
         (by omega) (by omega)⟩
     · by_cases h2 : y.val < 2 * m
-      · obtain ⟨x, hx1, hx2, hx3⟩ := exists_fresh m m (2 * m) (by omega)
+      · obtain ⟨x, hx1, hx2, hx3⟩ := exists_fresh k m (2 * m) (by omega)
           (Finset.image a Finset.univ) (by omega)
-        exact ⟨x, regionMatch_snoc_fresh m h (hane hx3) hy
+        exact ⟨x, regionMatch_snoc_fresh m k h (hane hx3) hy
           (by omega) (by omega)⟩
-      · obtain ⟨x, hx1, hx2, hx3⟩ := exists_fresh m (2 * m) (3 * m + 1) (by omega)
+      · obtain ⟨x, hx1, hx2, hx3⟩ := exists_fresh k (2 * m) k (by omega)
           (Finset.image a Finset.univ) (by omega)
-        exact ⟨x, regionMatch_snoc_fresh m h (hane hx3) hy
+        exact ⟨x, regionMatch_snoc_fresh m k h (hane hx3) hy
           (by omega) (by omega)⟩
 
 /-- B&C's condition (6) (p. 214): a formula whose quantifier count plus
 free-variable count is below `m` cannot distinguish region-matched tuples
 across `M₁`/`M₂`. Structural induction; at each quantifier "there is always
 enough room to extend the one-one correspondence one more step". -/
-theorem realize_iff_of_regionMatch (m : ℕ) :
+theorem realize_iff_of_regionMatch (m k : ℕ) (hk : 3 * m ≤ k) :
     ∀ {ℓ : ℕ} (φ : L_UV.BoundedFormula Empty ℓ), numQuant φ + ℓ < m →
-      ∀ {a b : Fin ℓ → Fin (3 * m + 1)}, RegionMatch m a b →
-        (Realize₁ m φ a ↔ Realize₂ m φ b) := by
+      ∀ {a b : Fin ℓ → Fin k}, RegionMatch m k a b →
+        (Realize₁ m k φ a ↔ Realize₂ m k φ b) := by
   intro ℓ φ
   induction φ with
   | falsum =>
@@ -656,16 +656,16 @@ theorem realize_iff_of_regionMatch (m : ℕ) :
       obtain ⟨i, hi⟩ := term_eq_var (ts 0)
       rcases i with e | i
       · exact e.elim
-      show ((fun k => @Term.realize L_UV _ (struc₁ m) _ (Sum.elim default a) (ts k)) 0).val < m ↔
-        ((fun k => @Term.realize L_UV _ (struc₂ m) _ (Sum.elim default b) (ts k)) 0).val < m + 1
+      show ((fun p => @Term.realize L_UV _ (struc₁ m k) _ (Sum.elim default a) (ts p)) 0).val < m ↔
+        ((fun p => @Term.realize L_UV _ (struc₂ m k) _ (Sum.elim default b) (ts p)) 0).val < m + 1
       simp only [hi, Term.realize_var, Sum.elim_inr]
       exact h.inU i
     | V =>
       obtain ⟨i, hi⟩ := term_eq_var (ts 0)
       rcases i with e | i
       · exact e.elim
-      show ((fun k => @Term.realize L_UV _ (struc₁ m) _ (Sum.elim default a) (ts k)) 0).val < 2 * m ↔
-        ((fun k => @Term.realize L_UV _ (struc₂ m) _ (Sum.elim default b) (ts k)) 0).val < 2 * m
+      show ((fun p => @Term.realize L_UV _ (struc₁ m k) _ (Sum.elim default a) (ts p)) 0).val < 2 * m ↔
+        ((fun p => @Term.realize L_UV _ (struc₂ m k) _ (Sum.elim default b) (ts p)) 0).val < 2 * m
       simp only [hi, Term.realize_var, Sum.elim_inr]
       exact h.inV i
   | imp f₁ f₂ ih₁ ih₂ =>
@@ -673,18 +673,18 @@ theorem realize_iff_of_regionMatch (m : ℕ) :
     simp only [numQuant] at hc
     simp only [Realize₁, Realize₂, BoundedFormula.realize_imp] at *
     exact imp_congr (ih₁ (by omega) h) (ih₂ (by omega) h)
-  | @all k f ih =>
+  | @all j f ih =>
     intro hc a b h
     simp only [numQuant] at hc
-    have hc' : numQuant f + (k + 1) < m := by omega
-    have hℓ : k + 1 < m := by omega
+    have hc' : numQuant f + (j + 1) < m := by omega
+    have hℓ : j + 1 < m := by omega
     simp only [Realize₁, Realize₂, BoundedFormula.realize_all] at *
     constructor
     · intro hall y
-      obtain ⟨x, hx⟩ := extend₂₁ m hℓ h y
+      obtain ⟨x, hx⟩ := extend₂₁ m k hk hℓ h y
       exact (ih hc' hx).mp (hall x)
     · intro hall x
-      obtain ⟨y, hy⟩ := extend₁₂ m hℓ h x
+      obtain ⟨y, hy⟩ := extend₁₂ m k hk hℓ h x
       exact (ih hc' hy).mpr (hall y)
 
 /-! ### The theorem -/
@@ -715,44 +715,490 @@ theorem more_than_half_not_definable :
   set m := numQuant φ + 1 with hm
   have hm1 : 1 ≤ m := by omega
   -- M₁ does not satisfy more-than-half: |U₁ ∩ V| = m, |V| = 2m
-  have hmth₁ : ¬ MoreThanHalf (Fin (3 * m + 1)) (struc₁ m) := by
+  have hmth₁ : ¬ MoreThanHalf (Fin (3 * m + 1)) (struc₁ m (3 * m + 1)) := by
     have hUV : {x : Fin (3 * m + 1) |
-        (struc₁ m).RelMap uRel ![x] ∧ (struc₁ m).RelMap vRel ![x]}
+        (struc₁ m (3 * m + 1)).RelMap uRel ![x] ∧ (struc₁ m (3 * m + 1)).RelMap vRel ![x]}
         = {x : Fin (3 * m + 1) | x.val < m} := by
       ext x
       show (x.val < m ∧ x.val < 2 * m) ↔ x.val < m
       omega
-    have hV : {x : Fin (3 * m + 1) | (struc₁ m).RelMap vRel ![x]}
+    have hV : {x : Fin (3 * m + 1) | (struc₁ m (3 * m + 1)).RelMap vRel ![x]}
         = {x : Fin (3 * m + 1) | x.val < 2 * m} := rfl
     unfold MoreThanHalf
     rw [hUV, hV, ncard_val_lt _ _ (by omega), ncard_val_lt _ _ (by omega)]
     omega
   -- M₂ satisfies more-than-half: |U₂ ∩ V| = m + 1, |V| = 2m
-  have hmth₂ : MoreThanHalf (Fin (3 * m + 1)) (struc₂ m) := by
+  have hmth₂ : MoreThanHalf (Fin (3 * m + 1)) (struc₂ m (3 * m + 1)) := by
     have hUV : {x : Fin (3 * m + 1) |
-        (struc₂ m).RelMap uRel ![x] ∧ (struc₂ m).RelMap vRel ![x]}
+        (struc₂ m (3 * m + 1)).RelMap uRel ![x] ∧ (struc₂ m (3 * m + 1)).RelMap vRel ![x]}
         = {x : Fin (3 * m + 1) | x.val < m + 1} := by
       ext x
       show (x.val < m + 1 ∧ x.val < 2 * m) ↔ x.val < m + 1
       omega
-    have hV : {x : Fin (3 * m + 1) | (struc₂ m).RelMap vRel ![x]}
+    have hV : {x : Fin (3 * m + 1) | (struc₂ m (3 * m + 1)).RelMap vRel ![x]}
         = {x : Fin (3 * m + 1) | x.val < 2 * m} := rfl
     unfold MoreThanHalf
     rw [hUV, hV, ncard_val_lt _ _ (by omega), ncard_val_lt _ _ (by omega)]
     omega
   -- but they agree on φ, by condition (6) at the empty correspondence
-  have hagree : Realize₁ m φ default ↔ Realize₂ m φ default :=
-    realize_iff_of_regionMatch m φ (by omega)
+  have hagree : Realize₁ m (3 * m + 1) φ default ↔ Realize₂ m (3 * m + 1) φ default :=
+    realize_iff_of_regionMatch m (3 * m + 1) (by omega) φ (by omega)
       ⟨fun i => i.elim0, fun i => i.elim0, fun i => i.elim0⟩
-  have hsent₁ : @Sentence.Realize L_UV _ (struc₁ m) φ ↔ Realize₁ m φ default := by
+  have hsent₁ : @Sentence.Realize L_UV _ (struc₁ m (3 * m + 1)) φ ↔ Realize₁ m (3 * m + 1) φ default := by
     unfold Realize₁
-    exact iff_of_eq (congrArg₂ (@BoundedFormula.Realize L_UV _ (struc₁ m) Empty 0 φ)
+    exact iff_of_eq (congrArg₂ (@BoundedFormula.Realize L_UV _ (struc₁ m (3 * m + 1)) Empty 0 φ)
       (funext fun e => e.elim) (funext fun i => i.elim0))
-  have hsent₂ : @Sentence.Realize L_UV _ (struc₂ m) φ ↔ Realize₂ m φ default := by
+  have hsent₂ : @Sentence.Realize L_UV _ (struc₂ m (3 * m + 1)) φ ↔ Realize₂ m (3 * m + 1) φ default := by
     unfold Realize₂
-    exact iff_of_eq (congrArg₂ (@BoundedFormula.Realize L_UV _ (struc₂ m) Empty 0 φ)
+    exact iff_of_eq (congrArg₂ (@BoundedFormula.Realize L_UV _ (struc₂ m (3 * m + 1)) Empty 0 φ)
       (funext fun e => e.elim) (funext fun i => i.elim0))
-  exact hmth₁ ((hφ _ (struc₁ m)).mp
-    (hsent₁.mpr (hagree.mpr (hsent₂.mp ((hφ _ (struc₂ m)).mpr hmth₂)))))
+  exact hmth₁ ((hφ _ (struc₁ m (3 * m + 1))).mp
+    (hsent₁.mpr (hagree.mpr (hsent₂.mp ((hφ _ (struc₂ m (3 * m + 1))).mpr hmth₂)))))
+
+end BarwiseCooper1981
+
+/-! ### Appendix C: C13 — *most* is a determiner, not a quantifier
+
+[barwise-cooper-1981] C13 (pp. 214–215): extend the monadic language with a
+quantifier symbol `Q`, where `Qx[φ(x)]` means "more than half of all things
+satisfy φ". Even in this language, no sentence is true in exactly the finite
+models where more than half the V's are U's: the *relativized* quantifier is
+not definable from the *unrelativized* one. So *most* cannot be a unary
+sentence operator over the domain — it must be a determiner (a footnote
+credits a related unpublished 1965 theorem to David Kaplan).
+
+The proof is B&C's: a translation `star` eliminating `Q` (`Qx θ` becomes
+"every `x` outside `V` and the free variables satisfies `θ*`"), correct on
+models where the domain swamps `V` (property (P), via "a trivial
+automorphism argument"), reducing to C12's models. -/
+
+namespace BarwiseCooper1981
+
+/-- Formulas of B&C's `L(Q)`: the monadic language of C12 (atoms `U`, `V`,
+equality) plus the unrelativized majority quantifier `Qx[·]`. De Bruijn
+indices; atoms apply directly to variables (the language has no function
+symbols). -/
+inductive QFormula : ℕ → Type where
+  | falsum {n : ℕ} : QFormula n
+  | equal {n : ℕ} (i j : Fin n) : QFormula n
+  | isU {n : ℕ} (i : Fin n) : QFormula n
+  | isV {n : ℕ} (i : Fin n) : QFormula n
+  | imp {n : ℕ} (f₁ f₂ : QFormula n) : QFormula n
+  | all {n : ℕ} (f : QFormula (n + 1)) : QFormula n
+  | qx {n : ℕ} (f : QFormula (n + 1)) : QFormula n
+
+namespace QFormula
+
+/-- Realization over a finite monadic model `⟨E, U, V⟩`. The `Q` clause is
+B&C's: more than half of all things satisfy the body. -/
+def Realize {E : Type} [Fintype E] (U V : E → Prop) :
+    ∀ {n : ℕ}, QFormula n → (Fin n → E) → Prop
+  | _, .falsum, _ => False
+  | _, .equal i j, xs => xs i = xs j
+  | _, .isU i, xs => U (xs i)
+  | _, .isV i, xs => V (xs i)
+  | _, .imp f₁ f₂, xs => f₁.Realize U V xs → f₂.Realize U V xs
+  | _, .all f, xs => ∀ x, f.Realize U V (Fin.snoc xs x)
+  | _, .qx f, xs =>
+      2 * Set.ncard {a | f.Realize U V (Fin.snoc xs a)} > Fintype.card E
+
+/-- Quantifier count (`all` and `qx` both count). -/
+def numQ : ∀ {n : ℕ}, QFormula n → ℕ
+  | _, .falsum => 0
+  | _, .equal _ _ => 0
+  | _, .isU _ => 0
+  | _, .isV _ => 0
+  | _, .imp f₁ f₂ => numQ f₁ + numQ f₂
+  | _, .all f => numQ f + 1
+  | _, .qx f => numQ f + 1
+
+/-- `Q`-freeness: the first-order fragment of `L(Q)`. -/
+def QFree : ∀ {n : ℕ}, QFormula n → Prop
+  | _, .falsum => True
+  | _, .equal _ _ => True
+  | _, .isU _ => True
+  | _, .isV _ => True
+  | _, .imp f₁ f₂ => QFree f₁ ∧ QFree f₂
+  | _, .all f => QFree f
+  | _, .qx _ => False
+
+/-- Negation. -/
+def not {n : ℕ} (f : QFormula n) : QFormula n := f.imp .falsum
+
+/-- Disjunction (classical). -/
+def or {n : ℕ} (f g : QFormula n) : QFormula n := f.not.imp g
+
+theorem realize_or {E : Type} [Fintype E] {U V : E → Prop} {n : ℕ}
+    {f g : QFormula n} {xs : Fin n → E} :
+    (f.or g).Realize U V xs ↔ f.Realize U V xs ∨ g.Realize U V xs := by
+  show ((f.Realize U V xs → False) → g.Realize U V xs) ↔ _
+  by_cases hf : f.Realize U V xs
+  · simp [hf]
+  · simp [hf]
+
+/-- Finite disjunction. -/
+def orList {n : ℕ} : List (QFormula n) → QFormula n
+  | [] => .falsum
+  | f :: l => f.or (orList l)
+
+theorem realize_orList {E : Type} [Fintype E] {U V : E → Prop} {n : ℕ}
+    {xs : Fin n → E} : ∀ {l : List (QFormula n)},
+    (orList l).Realize U V xs ↔ ∃ f ∈ l, f.Realize U V xs
+  | [] => by simp [orList, Realize]
+  | f :: l => by
+      simp only [orList, realize_or, realize_orList, List.mem_cons]
+      constructor
+      · rintro (h | ⟨g, hg, hr⟩)
+        · exact ⟨f, Or.inl rfl, h⟩
+        · exact ⟨g, Or.inr hg, hr⟩
+      · rintro ⟨g, (rfl | hg), hr⟩
+        · exact Or.inl hr
+        · exact Or.inr ⟨g, hg, hr⟩
+
+/-- "The last variable equals one of the first `n`." -/
+def eqAny (n : ℕ) : QFormula (n + 1) :=
+  orList ((List.finRange n).map fun i => .equal (Fin.last n) i.castSucc)
+
+theorem realize_eqAny {E : Type} [Fintype E] {U V : E → Prop} {n : ℕ}
+    {ys : Fin (n + 1) → E} :
+    (eqAny n).Realize U V ys ↔ ∃ i : Fin n, ys (Fin.last n) = ys i.castSucc := by
+  simp only [eqAny, realize_orList, List.mem_map, List.mem_finRange]
+  constructor
+  · rintro ⟨f, ⟨i, -, rfl⟩, hr⟩
+    exact ⟨i, hr⟩
+  · rintro ⟨i, hi⟩
+    exact ⟨_, ⟨i, trivial, rfl⟩, hi⟩
+
+/-- B&C's `Q`-elimination (`ψ*`, p. 215): `Qx θ` becomes "every `x` that is
+outside `V` and distinct from the free variables satisfies `θ*`". -/
+def star : ∀ {n : ℕ}, QFormula n → QFormula n
+  | _, .falsum => .falsum
+  | _, .equal i j => .equal i j
+  | _, .isU i => .isU i
+  | _, .isV i => .isV i
+  | _, .imp f₁ f₂ => .imp (star f₁) (star f₂)
+  | _, .all f => .all (star f)
+  | n, .qx f => .all ((QFormula.isV (Fin.last n)).or ((eqAny n).or (star f)))
+
+theorem qFree_orList : ∀ {n : ℕ} {l : List (QFormula n)},
+    (∀ f ∈ l, QFree f) → QFree (orList l)
+  | _, [], _ => trivial
+  | _, f :: l, h =>
+      ⟨⟨h f (.head _), trivial⟩, qFree_orList fun g hg => h g (.tail _ hg)⟩
+
+theorem qFree_eqAny (n : ℕ) : QFree (eqAny n) :=
+  qFree_orList fun f hf => by
+    obtain ⟨i, -, rfl⟩ := List.mem_map.mp hf
+    trivial
+
+theorem qFree_star : ∀ {n : ℕ} (f : QFormula n), QFree (star f)
+  | _, .falsum => trivial
+  | _, .equal _ _ => trivial
+  | _, .isU _ => trivial
+  | _, .isV _ => trivial
+  | _, .imp f₁ f₂ => ⟨qFree_star f₁, qFree_star f₂⟩
+  | _, .all f => qFree_star f
+  | n, .qx f =>
+      ⟨⟨trivial, trivial⟩, ⟨⟨qFree_eqAny n, trivial⟩, qFree_star f⟩⟩
+
+theorem numQ_orList : ∀ {n : ℕ} {l : List (QFormula n)},
+    (∀ f ∈ l, numQ f = 0) → numQ (orList l) = 0
+  | _, [], _ => rfl
+  | _, f :: l, h => by
+      show numQ f + 0 + numQ (orList l) = 0
+      rw [h f (.head _), numQ_orList fun g hg => h g (.tail _ hg)]
+
+theorem numQ_eqAny (n : ℕ) : numQ (eqAny n) = 0 :=
+  numQ_orList fun f hf => by
+    obtain ⟨i, -, rfl⟩ := List.mem_map.mp hf
+    rfl
+
+theorem numQ_star : ∀ {n : ℕ} (f : QFormula n), numQ (star f) = numQ f
+  | _, .falsum => rfl
+  | _, .equal _ _ => rfl
+  | _, .isU _ => rfl
+  | _, .isV _ => rfl
+  | _, .imp f₁ f₂ => by
+      show numQ (star f₁) + numQ (star f₂) = _
+      rw [numQ_star f₁, numQ_star f₂]; rfl
+  | _, .all f => by
+      show numQ (star f) + 1 = _
+      rw [numQ_star f]; rfl
+  | n, .qx f => by
+      show 0 + 0 + (numQ (eqAny n) + 0 + numQ (star f)) + 1 = numQ f + 1
+      rw [numQ_eqAny, numQ_star f]
+      omega
+
+/-- `L(Q)`-realization is invariant under automorphisms of the monadic model
+(B&C's "trivial automorphism argument", p. 215). -/
+theorem realize_equivMap {E : Type} [Fintype E] {U V : E → Prop} (σ : E ≃ E)
+    (hU : ∀ x, U (σ x) ↔ U x) (hV : ∀ x, V (σ x) ↔ V x) :
+    ∀ {n : ℕ} (f : QFormula n) (xs : Fin n → E),
+      f.Realize U V (σ ∘ xs) ↔ f.Realize U V xs
+  | _, .falsum, _ => Iff.rfl
+  | _, .equal i j, xs => σ.apply_eq_iff_eq
+  | _, .isU i, xs => hU _
+  | _, .isV i, xs => hV _
+  | _, .imp f₁ f₂, xs =>
+      imp_congr (realize_equivMap σ hU hV f₁ xs) (realize_equivMap σ hU hV f₂ xs)
+  | _, .all f, xs => by
+      have key : ∀ x, Fin.snoc (σ ∘ xs) (σ x) = σ ∘ Fin.snoc xs x := fun x =>
+        funext fun p => by
+          induction p using Fin.lastCases <;>
+            simp [Fin.snoc_last, Fin.snoc_castSucc]
+      constructor
+      · intro h x
+        have := h (σ x)
+        rw [key x] at this
+        exact (realize_equivMap σ hU hV f _).mp this
+      · intro h x
+        have hx : Fin.snoc (σ ∘ xs) x = σ ∘ Fin.snoc xs (σ.symm x) := by
+          have := key (σ.symm x)
+          simpa using this
+        rw [show (x : E) = σ (σ.symm x) by simp] at *
+        rw [key (σ.symm x)]
+        exact (realize_equivMap σ hU hV f _).mpr (h _)
+  | _, .qx f, xs => by
+      show 2 * Set.ncard {a | f.Realize U V (Fin.snoc (σ ∘ xs) a)} > _ ↔
+        2 * Set.ncard {a | f.Realize U V (Fin.snoc xs a)} > _
+      have key : ∀ x, Fin.snoc (σ ∘ xs) (σ x) = σ ∘ Fin.snoc xs x := fun x =>
+        funext fun p => by
+          induction p using Fin.lastCases <;>
+            simp [Fin.snoc_last, Fin.snoc_castSucc]
+      have hset : {a | f.Realize U V (Fin.snoc (σ ∘ xs) a)}
+          = σ '' {a | f.Realize U V (Fin.snoc xs a)} := by
+        ext a
+        simp only [Set.mem_setOf_eq, Set.mem_image]
+        constructor
+        · intro h
+          refine ⟨σ.symm a, ?_, by simp⟩
+          rw [show (a : E) = σ (σ.symm a) by simp, key (σ.symm a)] at h
+          exact (realize_equivMap σ hU hV f _).mp h
+        · rintro ⟨a', ha', rfl⟩
+          rw [key a']
+          exact (realize_equivMap σ hU hV f _).mpr ha'
+      rw [hset, Set.ncard_image_of_injective _ σ.injective]
+
+/-- The `Q`-free condition (6): the C12 argument for the `L(Q)` fragment
+over the C12 model pair. -/
+theorem qfree_realize_iff (m k : ℕ) (hk : 3 * m ≤ k) :
+    ∀ {ℓ : ℕ} (ψ : QFormula ℓ), QFree ψ → numQ ψ + ℓ < m →
+      ∀ {a b : Fin ℓ → Fin k}, RegionMatch m k a b →
+        (ψ.Realize (fun x => x.val < m) (fun x => x.val < 2 * m) a ↔
+          ψ.Realize (fun x => x.val < m + 1) (fun x => x.val < 2 * m) b) := by
+  intro ℓ ψ
+  induction ψ with
+  | falsum =>
+    intro _ _ a b _
+    exact Iff.rfl
+  | equal i j =>
+    intro _ _ a b h
+    show a i = a j ↔ b i = b j
+    exact h.inj i j
+  | isU i =>
+    intro _ _ a b h
+    exact h.inU i
+  | isV i =>
+    intro _ _ a b h
+    exact h.inV i
+  | imp f₁ f₂ ih₁ ih₂ =>
+    intro hq hc a b h
+    show (_ → _) ↔ (_ → _)
+    have hcc : numQ (f₁.imp f₂) = numQ f₁ + numQ f₂ := rfl
+    exact imp_congr (ih₁ hq.1 (by omega) h) (ih₂ hq.2 (by omega) h)
+  | @all j f ih =>
+    intro hq hc a b h
+    have hcc : numQ f.all = numQ f + 1 := rfl
+    have hc' : numQ f + (j + 1) < m := by omega
+    have hℓ : j + 1 < m := by omega
+    show (∀ x, _) ↔ (∀ y, _)
+    constructor
+    · intro hall y
+      obtain ⟨x, hx⟩ := extend₂₁ m k hk hℓ h y
+      exact (ih hq hc' hx).mp (hall x)
+    · intro hall x
+      obtain ⟨y, hy⟩ := extend₁₂ m k hk hℓ h x
+      exact (ih hq hc' hy).mpr (hall y)
+  | qx f ih =>
+    intro hq
+    exact hq.elim
+
+/-- B&C's property (P) (p. 215): on models with `U ⊆ V` whose domain is at
+least twice `|V|` plus the complexity of `ψ`, the `Q`-elimination `star` is
+correct — the domain "swamps out" `U` and `V`. -/
+theorem realize_star_iff {E : Type} [Fintype E] {U V : E → Prop}
+    (hUV : ∀ x, U x → V x) :
+    ∀ {n : ℕ} (ψ : QFormula n),
+      2 * (Set.ncard {x | V x} + (numQ ψ + n)) ≤ Fintype.card E →
+      ∀ xs : Fin n → E, ((star ψ).Realize U V xs ↔ ψ.Realize U V xs)
+  | _, .falsum, _, _ => Iff.rfl
+  | _, .equal _ _, _, _ => Iff.rfl
+  | _, .isU _, _, _ => Iff.rfl
+  | _, .isV _, _, _ => Iff.rfl
+  | _, .imp f₁ f₂, hb, xs => by
+      have hq : numQ (f₁.imp f₂) = numQ f₁ + numQ f₂ := rfl
+      rw [hq] at hb
+      exact imp_congr (realize_star_iff hUV f₁ (by omega) xs)
+        (realize_star_iff hUV f₂ (by omega) xs)
+  | _, .all f, hb, xs => by
+      have hq : numQ f.all = numQ f + 1 := rfl
+      rw [hq] at hb
+      exact forall_congr' fun x =>
+        realize_star_iff hUV f (by omega) (Fin.snoc xs x)
+  | n, .qx f, hb, xs => by
+      haveI := Classical.decEq E
+      have hq : numQ (qx f) = numQ f + 1 := rfl
+      rw [hq] at hb
+      have hIH : ∀ b, ((star f).Realize U V (Fin.snoc xs b) ↔
+          f.Realize U V (Fin.snoc xs b)) := fun b =>
+        realize_star_iff hUV f (by omega) (Fin.snoc xs b)
+      have hstar : (star (qx f)).Realize U V xs ↔
+          ∀ b, ¬ V b → (∀ i, b ≠ xs i) → f.Realize U V (Fin.snoc xs b) := by
+        show (∀ b, ((QFormula.isV (Fin.last n)).or
+          ((eqAny n).or (star f))).Realize U V (Fin.snoc xs b)) ↔ _
+        refine forall_congr' fun b => ?_
+        rw [realize_or, realize_or, realize_eqAny, hIH b]
+        simp only [Realize, Fin.snoc_last, Fin.snoc_castSucc]
+        constructor
+        · rintro (hv | ⟨i, hi⟩ | hf) hnv hne
+          · exact absurd hv hnv
+          · exact absurd hi (hne i)
+          · exact hf
+        · intro h
+          by_cases hv : V b
+          · exact Or.inl hv
+          · by_cases hex : ∃ i, b = xs i
+            · exact Or.inr (Or.inl hex)
+            · push_neg at hex
+              exact Or.inr (Or.inr (h hv hex))
+      rw [hstar]
+      show _ ↔ 2 * Set.ncard {a | f.Realize U V (Fin.snoc xs a)} > Fintype.card E
+      have hrange : Set.ncard (Set.range xs) ≤ n := by
+        rw [← Set.image_univ]
+        refine le_trans (Set.ncard_image_le (Set.toFinite _)) ?_
+        simp [Set.ncard_univ]
+      have hunion : Set.ncard ({x : E | V x} ∪ Set.range xs)
+          ≤ Set.ncard {x : E | V x} + n :=
+        le_trans (Set.ncard_union_le _ _) (by omega)
+      have hcomplsum : Set.ncard ({x : E | V x} ∪ Set.range xs)
+          + Set.ncard (({x : E | V x} ∪ Set.range xs)ᶜ) = Fintype.card E := by
+        rw [← Nat.card_eq_fintype_card]
+        exact Set.ncard_add_ncard_compl _
+      constructor
+      · intro hall
+        have hsub : ({x : E | V x} ∪ Set.range xs)ᶜ
+            ⊆ {a | f.Realize U V (Fin.snoc xs a)} := by
+          intro x hx
+          simp only [Set.mem_compl_iff, Set.mem_union, Set.mem_setOf_eq,
+            Set.mem_range, not_or, not_exists] at hx
+          exact hall x hx.1 fun i h => hx.2 i h.symm
+        have h3 := Set.ncard_le_ncard hsub (Set.toFinite _)
+        omega
+      · intro hmaj b hnv hne
+        have hwit : ∃ b₀, f.Realize U V (Fin.snoc xs b₀) ∧ ¬ V b₀ ∧
+            ∀ i, b₀ ≠ xs i := by
+          by_contra hno
+          push_neg at hno
+          have hsub : {a | f.Realize U V (Fin.snoc xs a)}
+              ⊆ {x : E | V x} ∪ Set.range xs := by
+            intro a ha
+            by_cases hv : V a
+            · exact Or.inl hv
+            · obtain ⟨i, hi⟩ := hno a ha hv
+              exact Or.inr ⟨i, hi.symm⟩
+          have h3 := Set.ncard_le_ncard hsub (Set.toFinite _)
+          omega
+        obtain ⟨b₀, hf₀, hnv₀, hne₀⟩ := hwit
+        have hUσ : ∀ x, U (Equiv.swap b₀ b x) ↔ U x := by
+          intro x
+          rcases eq_or_ne x b₀ with rfl | h1
+          · rw [Equiv.swap_apply_left]
+            exact iff_of_false (fun h => hnv (hUV _ h)) (fun h => hnv₀ (hUV _ h))
+          rcases eq_or_ne x b with rfl | h2
+          · rw [Equiv.swap_apply_right]
+            exact iff_of_false (fun h => hnv₀ (hUV _ h)) (fun h => hnv (hUV _ h))
+          · rw [Equiv.swap_apply_of_ne_of_ne h1 h2]
+        have hVσ : ∀ x, V (Equiv.swap b₀ b x) ↔ V x := by
+          intro x
+          rcases eq_or_ne x b₀ with rfl | h1
+          · rw [Equiv.swap_apply_left]
+            exact iff_of_false hnv hnv₀
+          rcases eq_or_ne x b with rfl | h2
+          · rw [Equiv.swap_apply_right]
+            exact iff_of_false hnv₀ hnv
+          · rw [Equiv.swap_apply_of_ne_of_ne h1 h2]
+        have hsnoc : Fin.snoc xs b = Equiv.swap b₀ b ∘ Fin.snoc xs b₀ := by
+          funext p
+          induction p using Fin.lastCases with
+          | last =>
+            simp only [Fin.snoc_last, Function.comp_apply,
+              Equiv.swap_apply_left]
+          | cast p =>
+            simp only [Fin.snoc_castSucc, Function.comp_apply]
+            rw [Equiv.swap_apply_of_ne_of_ne (Ne.symm (hne₀ p))
+              (Ne.symm (hne p))]
+        rw [hsnoc]
+        exact (realize_equivMap _ hUσ hVσ f _).mpr hf₀
+
+end QFormula
+
+/-- **C13** ([barwise-cooper-1981], Appendix C pp. 214–215): even with the
+unrelativized majority quantifier `Qx[·]` ("more than half of all things")
+available, no sentence of `L(Q)` is true in exactly the finite models where
+more than half the V's are U's. The relativized quantifier is not definable
+from the unrelativized one: *most* must be treated as a determiner, not a
+quantifier. (B&C credit a related unpublished 1965 theorem to David Kaplan.) -/
+theorem more_than_half_not_Q_definable :
+    ¬ ∃ φ : QFormula 0, ∀ (E : Type) [Fintype E] (U V : E → Prop),
+      (φ.Realize U V default ↔
+        2 * Set.ncard {x | U x ∧ V x} > Set.ncard {x | V x}) := by
+  rintro ⟨φ, hφ⟩
+  set m := QFormula.numQ φ + 1 with hm
+  set k := 2 * (2 * m + QFormula.numQ φ) with hk2
+  have hk : 3 * m ≤ k := by omega
+  have hcardV : Set.ncard {x : Fin k | x.val < 2 * m} = 2 * m :=
+    ncard_val_lt k (2 * m) (by omega)
+  have hdef : ∀ v₁ v₂ : Fin 0 → Fin k, v₁ = v₂ := fun v₁ v₂ =>
+    funext fun i => i.elim0
+  have hcast : ∀ {U V : Fin k → Prop} (v₁ v₂ : Fin 0 → Fin k),
+      QFormula.Realize U V φ v₁ → QFormula.Realize U V φ v₂ := by
+    intro U V v₁ v₂ h
+    rwa [hdef v₁ v₂] at h
+  have h₁ := hφ (Fin k) (fun x => x.val < m) (fun x => x.val < 2 * m)
+  have hUV₁ : {x : Fin k | x.val < m ∧ x.val < 2 * m}
+      = {x : Fin k | x.val < m} := by
+    ext x
+    simp only [Set.mem_setOf_eq]
+    omega
+  have hfalse₁ : ¬ QFormula.Realize (fun x : Fin k => x.val < m)
+      (fun x => x.val < 2 * m) φ default := fun hr => by
+    have hcount := h₁.mp (hcast _ _ hr)
+    rw [hUV₁, ncard_val_lt k m (by omega), hcardV] at hcount
+    omega
+  have h₂ := hφ (Fin k) (fun x => x.val < m + 1) (fun x => x.val < 2 * m)
+  have hUV₂ : {x : Fin k | x.val < m + 1 ∧ x.val < 2 * m}
+      = {x : Fin k | x.val < m + 1} := by
+    ext x
+    simp only [Set.mem_setOf_eq]
+    omega
+  have htrue₂ : QFormula.Realize (fun x : Fin k => x.val < m + 1)
+      (fun x => x.val < 2 * m) φ default := hcast _ _ (h₂.mpr (by
+    rw [hUV₂, ncard_val_lt k (m + 1) (by omega), hcardV]
+    omega))
+  have hP₁ := QFormula.realize_star_iff (E := Fin k)
+    (U := fun x => x.val < m) (V := fun x => x.val < 2 * m)
+    (fun x hx => by omega) φ
+    (by rw [show {x : Fin k | x.val < 2 * m}.ncard = 2 * m from hcardV,
+      Fintype.card_fin]; omega) default
+  have hP₂ := QFormula.realize_star_iff (E := Fin k)
+    (U := fun x => x.val < m + 1) (V := fun x => x.val < 2 * m)
+    (fun x hx => by omega) φ
+    (by rw [show {x : Fin k | x.val < 2 * m}.ncard = 2 * m from hcardV,
+      Fintype.card_fin]; omega) default
+  have htrans := QFormula.qfree_realize_iff m k hk (QFormula.star φ)
+    (QFormula.qFree_star φ) (by rw [QFormula.numQ_star]; omega)
+    (a := default) (b := default)
+    ⟨fun i => i.elim0, fun i => i.elim0, fun i => i.elim0⟩
+  exact hfalse₁ (hP₁.mp (htrans.mpr (hP₂.mpr htrue₂)))
 
 end BarwiseCooper1981


### PR DESCRIPTION
Formalizes [barwise-cooper-1981] Appendix C, Theorems C12 and C13 (pp. 213–215), both sorry-free.

- **C12**: no first-order sentence over two unary predicates is true in exactly the finite models where more than half the V's are U's. Proof is the paper's own Fraïssé argument: models on `Fin k` (`3m ≤ k`) agreeing on all formulas below quantifier-count `m` (condition (6), with the "always enough room to extend" counting).
- **C13**: even adding the *unrelativized* majority quantifier `Qx[·]` ("more than half of all things"), the relativized "more than half the V's" remains undefinable over finite models — B&C's formal core for *most* being a determiner, not a quantifier. Via a deep-embedded `L(Q)` (`QFormula`), the `Q`-elimination translation `star`, property (P) (the automorphism-swamping argument), and C12's models.

The expressivity payoff of the composition-engine arc: theorems about the formula type itself, unstateable in shallow semantics, and the principled reason `compileFO`'s fragment excludes *most*.