### PR TITLE
feat(Studies): TsvilodubEtAl2026 layered regret model, off rsa_predict

### DIFF
--- a/Linglib/Studies/TsvilodubEtAl2026.lean
+++ b/Linglib/Studies/TsvilodubEtAl2026.lean
@@ -1,241 +1,526 @@
-import Linglib.Tactics.RSAPredict
-import Linglib.Pragmatics.RSA.Basic
+import Linglib.Pragmatics.RSA.Canonical
+import Linglib.Phenomena.Clarification.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 
 /-!
-# Tsvilodub, Mulligan, Snider, Hawkins & Franke (2026)
-[tsvilodub-etal-2026]
+# [tsvilodub-etal-2026] — Act or Clarify? Uncertainty and cost in communication
 
-Act or Clarify? Modeling Sensitivity to Uncertainty and Cost in Communication.
+When should an agent ask a clarification question (CQ) rather than act under
+uncertainty? [tsvilodub-etal-2026] predict and confirm that CQ rates depend
+on contextual uncertainty (ε) about the interlocutor's goal and the cost (δ)
+of safe actions, interacting: uncertainty matters most when acting
+incorrectly is costly.
 
-## Overview
+The paper's computational model is **layered decision theory, not RSA**: a
+decision problem `⟨G, P, R, U⟩` with `P(g₂) = ε` and exhaustive-answer
+utility `1 − δ`; a behavioral policy `π = SoftMax(α · EU)` over the
+**goal-marginal** expected utility `EU(r) = Σ_g P(g)·U(g,r)`; and a CQ gate
+`P(r_cq) = Logistic(τ · (ExpRegret(r*) − c))`, where `ExpRegret(r*)` is the
+expected regret of the best action — the expected value of perfect
+information ([raiffa-schlaifer-1961]). This file formalises all three
+layers, building on `Core.DecisionTheory.DecisionProblem` and
+`Phenomena.Clarification.evpi` (whose docstring already identifies the
+paper's ExpRegret with EVPI).
 
-When should an agent ask a clarification question (CQ) vs. act under
-uncertainty? This paper predicts and confirms that the decision depends on
-both **uncertainty** (ε) about the interlocutor's goals and the **cost** (δ)
-of available actions. The interaction is captured by **expected regret**
-(= EVPI, [raiffa-schlaifer-1961]).
+## Main statements
 
-## Two-layer model
+* `evpi_eq_min` — for the paper's decision problem the expected regret of
+  the best action has the closed form `min ε δ`: the uncertainty/cost
+  interaction in one equation.
+* `policy_prefers_exh_of_uncertain` / `policy_prefers_ms1_of_confident` —
+  the behavioral policy flips from the matching mention-some to the safe
+  exhaustive answer as uncertainty crosses cost (`δ < ε`).
+* `tl_justAsk`, `noNeedToAsk`, `worthAsking`,
+  `uncertainty_matters_most_when_costly` — the gate-level predictions, for
+  *every* `τ > 0` and threshold `c` (`noNeedToAsk` is an exact equality,
+  the paper's null prediction).
+* `reaction` — the layered mixture: clarify with the gate probability,
+  otherwise act by `policy`.
+* `L1_exh_transmits_prior` etc. — an **RSA reinterpretation** (this file's
+  extension, *not* the paper's model): the goal-conditioned speaker — the
+  ε → 0 / post-clarification limit of `π`, [hawkins-etal-2025]'s
+  action-utility respondent R₁ at β = 1, w_c = 0 — inverted by a Bayesian
+  listener. The paper's model contains no listener.
 
-The paper's model is a direct softmax over expected utility (NOT RSA):
+## Implementation notes
 
-1. **CQ gate**: `P(CQ) = Logistic(τ · (ExpRegret(r*) − c))` — when to clarify
-2. **Behavioral policy**: `π(r) = SoftMax(α · EU(r))` — what to say
-
-We reinterpret the behavioral policy through RSA, connecting it to
-[hawkins-etal-2025]'s action-utility scoring.
-
-## Connection to [hawkins-etal-2025]
-
-The behavioral policy π corresponds to [hawkins-etal-2025]'s
-respondent R₁ at β = 1, w_c = 0: **pure action utility**. R₁ scores
-responses by:
-
-    (1 − β) · log L0(w|r) + β · E_D[V(D, r)] − w_c · C(r)
-
-At β = 1, w_c = 0 this reduces to `V(D, r)` — the action value. For the
-bartender, V(g, r) = U(g, r) is the paper's utility table: 1 for matching
-mention-some, 0 for mismatching, 1−δ for exhaustive.
-
-The L0 gate (`if L0 = 0 then 0`) ensures truth-conditional consistency:
-S1 never recommends a response that doesn't apply to the goal. This is
-structurally identical to [hawkins-etal-2025]'s `responseTruth` gate.
-
-## Action utility and δ-sensitivity
-
-With action-utility scoring, S1 preferences are **δ-sensitive**: the
-exhaustive response's S1 score is `exp(α · (1−δ))`, which decreases
-with δ. At high δ (large option space), S1 strongly prefers targeted
-responses over exh. At low δ (small option space), exh is nearly as
-good as targeted — S1's preference weakens.
-
-This connects to the paper's experimental predictions (Exp 1: TL;JUSTASK,
-NONEEDTOASK, JUSTLISTTHEMALL, TOOMANYTOLIST; Exp 2: WORTHASKING, etc.)
-through the S1 behavioral policy:
-- At high δ, exh is expensive → S1 concentrates on targeted responses
-  → commitment under uncertainty is riskier → more to gain from clarifying
-- At low δ, exh is cheap → S1 assigns near-equal weight to exh and targeted
-  → safe to commit even under uncertainty → less need to clarify
+Parameter provenance (Bayesian posterior means fitted to Exp 1): δ_L = 0.32,
+δ_S = 0.11 (large/small option space), ε_H = 0.49, ε_L = 0.17 (high/low
+uncertainty), τ = 3.60, c = 0.18. The gate-level prediction theorems hold
+for all `τ > 0` and `c`, so the fitted values matter only through the
+orderings `δ_S < ε_L < δ_L < ε_H ≤ 1/2`. In the RSA section `exhVal = 1 − δ`
+and the priors 83 : 17 and 51 : 49 are `(1 − ε) : ε`; α = 1 there is this
+file's choice (the paper's α has prior N(5, 1)) — the strict-preference
+theorems are stated for any α > 0.
 -/
+
+set_option autoImplicit false
 
 namespace TsvilodubEtAl2026
 
--- ============================================================================
--- §1. Types
--- ============================================================================
+open scoped ENNReal NNReal
+open Core.DecisionTheory Phenomena.Clarification
 
-/-- The questioner's latent goal (e.g., preferred drink category). -/
+/-! ### The decision problem ⟨G, P, R, U⟩ -/
+
+/-- The questioner's latent goal. -/
 inductive Goal where | g₁ | g₂
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Fintype
 
-instance : Fintype Goal where
-  elems := {.g₁, .g₂}
-  complete x := by cases x <;> simp
-
-/-- Available non-CQ responses. -/
+/-- Available non-CQ responses: targeted mention-some answers and the safe
+exhaustive answer. -/
 inductive Response where
-  | ms1  -- mention-some matching g₁
-  | ms2  -- mention-some matching g₂
-  | exh  -- exhaustive (safe but costly)
+  | ms1 | ms2
+  | exh  -- reliable but costly
+  deriving DecidableEq, Repr, Fintype
+
+instance : Nonempty Response := ⟨.exh⟩
+
+/-- The paper's parameterized decision problem: `P(g₂) = ε` (uncertainty),
+matching mention-some worth 1, mismatching 0, exhaustive `1 − δ` (cost). -/
+def dp (ε δ : ℚ) : DecisionProblem Goal Response where
+  utility
+    | .g₁, .ms1 => 1
+    | .g₁, .ms2 => 0
+    | .g₂, .ms1 => 0
+    | .g₂, .ms2 => 1
+    | _, .exh => 1 - δ
+  prior
+    | .g₁ => 1 - ε
+    | .g₂ => ε
+
+private theorem sum_goal (f : Goal → ℚ) : (∑ g : Goal, f g) = f .g₁ + f .g₂ := by
+  rw [show (Finset.univ : Finset Goal) = {.g₁, .g₂} from by decide,
+      Finset.sum_insert (by decide), Finset.sum_singleton]
+
+theorem eu_ms1 (ε δ : ℚ) : expectedUtility (dp ε δ) .ms1 = 1 - ε := by
+  simp only [expectedUtility, sum_goal, dp]; ring
+
+theorem eu_ms2 (ε δ : ℚ) : expectedUtility (dp ε δ) .ms2 = ε := by
+  simp only [expectedUtility, sum_goal, dp]; ring
+
+theorem eu_exh (ε δ : ℚ) : expectedUtility (dp ε δ) .exh = 1 - δ := by
+  simp only [expectedUtility, sum_goal, dp]; ring
+
+/-! ### The behavioral policy π = SoftMax(α · EU)
+
+The paper's π softmaxes the goal-*marginal* expected utility — the agent
+acts under its own uncertainty. Instantiated as the canonical softmax
+speaker over the `(ε, δ)`-indexed state space. -/
+
+/-- Score for the canonical speaker: `α · EU(r)` at condition `(ε, δ)`. -/
+noncomputable def policyScore (α : ℝ) (p : ℚ × ℚ) (r : Response) : EReal :=
+  ((α * (expectedUtility (dp p.1 p.2) r : ℝ) : ℝ) : EReal)
+
+instance (α : ℝ) : RSA.Canonical.ViableSpeaker (policyScore α) where
+  no_top _ _ := EReal.coe_ne_top _
+  some_finite _ := ⟨.exh, EReal.coe_ne_bot _⟩
+
+/-- The paper's behavioral policy `π(r) = SoftMax(α · EU(r))`. -/
+noncomputable def policy (α : ℝ) (ε δ : ℚ) : PMF Response :=
+  RSA.Canonical.S1 (policyScore α) (ε, δ)
+
+private theorem policy_lt_policy {α : ℝ} (hα : 0 < α) {ε δ : ℚ} {r₁ r₂ : Response}
+    (h : expectedUtility (dp ε δ) r₁ < expectedUtility (dp ε δ) r₂) :
+    policy α ε δ r₁ < policy α ε δ r₂ := by
+  rw [policy, RSA.Canonical.S1_prefers_iff]
+  exact EReal.coe_lt_coe (mul_lt_mul_of_pos_left (by exact_mod_cast h) hα)
+
+/-- **The uncertainty flip**: once uncertainty exceeds the exhaustive cost
+(`δ < ε ≤ 1/2`), the safe exhaustive answer beats both targeted answers —
+the paper's "act safe under uncertainty" effect (fitted:
+δ_L = 0.32 < ε_H = 0.49). -/
+theorem policy_prefers_exh_of_uncertain {α : ℝ} (hα : 0 < α) {ε δ : ℚ}
+    (h₁ : δ < ε) (h₂ : ε ≤ 1/2) :
+    policy α ε δ .ms1 < policy α ε δ .exh ∧ policy α ε δ .ms2 < policy α ε δ .exh :=
+  ⟨policy_lt_policy hα (by rw [eu_ms1, eu_exh]; linarith),
+   policy_lt_policy hα (by rw [eu_ms2, eu_exh]; linarith)⟩
+
+/-- Under low uncertainty (`ε < δ`, `ε < 1/2`) the matching mention-some
+wins (fitted: ε_L = 0.17 < δ_L = 0.32). -/
+theorem policy_prefers_ms1_of_confident {α : ℝ} (hα : 0 < α) {ε δ : ℚ}
+    (h₁ : ε < δ) (h₂ : ε < 1/2) :
+    policy α ε δ .exh < policy α ε δ .ms1 ∧ policy α ε δ .ms2 < policy α ε δ .ms1 :=
+  ⟨policy_lt_policy hα (by rw [eu_exh, eu_ms1]; linarith),
+   policy_lt_policy hα (by rw [eu_ms2, eu_ms1]; linarith)⟩
+
+/-! ### Expected regret of the best action: EVPI = min ε δ -/
+
+private theorem bestUtilityAt_eq_one {ε δ : ℚ} (hδ0 : 0 ≤ δ) (g : Goal) :
+    bestUtilityAt (dp ε δ) Finset.univ g = 1 := by
+  rw [bestUtilityAt, dif_pos Finset.univ_nonempty]
+  refine le_antisymm (Finset.sup'_le _ _ fun r _ => ?_) ?_
+  · cases g <;> cases r <;> simp [dp] <;> linarith
+  · cases g
+    · exact Finset.le_sup' (α := ℚ) ((dp ε δ).utility .g₁) (Finset.mem_univ .ms1)
+    · exact Finset.le_sup' (α := ℚ) ((dp ε δ).utility .g₂) (Finset.mem_univ .ms2)
+
+private theorem oracleValue_eq_one {ε δ : ℚ} (hδ0 : 0 ≤ δ) :
+    oracleValue (dp ε δ) Finset.univ = 1 := by
+  rw [oracleValue, sum_goal, bestUtilityAt_eq_one hδ0, bestUtilityAt_eq_one hδ0]
+  show (1 - ε) * 1 + ε * 1 = 1
+  ring
+
+private theorem dpValue_eq {ε δ : ℚ} (hε : ε ≤ 1/2) :
+    dpValue (dp ε δ) Finset.univ = 1 - min ε δ := by
+  rw [dpValue, dif_pos Finset.univ_nonempty]
+  refine le_antisymm (Finset.sup'_le _ _ fun r _ => ?_) ?_
+  · have h₁ := min_le_left ε δ
+    have h₂ := min_le_right ε δ
+    cases r
+    · rw [eu_ms1]; linarith
+    · rw [eu_ms2]; linarith
+    · rw [eu_exh]; linarith
+  · rcases min_cases ε δ with ⟨hmin, _⟩ | ⟨hmin, _⟩
+    · calc 1 - min ε δ = expectedUtility (dp ε δ) Response.ms1 := by rw [eu_ms1, hmin]
+        _ ≤ _ := Finset.le_sup' _ (Finset.mem_univ Response.ms1)
+    · calc 1 - min ε δ = expectedUtility (dp ε δ) Response.exh := by rw [eu_exh, hmin]
+        _ ≤ _ := Finset.le_sup' _ (Finset.mem_univ Response.exh)
+
+/-- **The interaction in closed form**: for the paper's decision problem,
+the expected regret of the best action — `ExpRegret(r*)`, i.e. the expected
+value of perfect information ([raiffa-schlaifer-1961],
+`Phenomena.Clarification.evpi`) — is `min ε δ`. Regret is bounded by the
+uncertainty *and* by the cost of the safe action, so uncertainty raises
+regret only while it stays below the cost: the paper's headline claim that
+uncertainty matters most when acting incorrectly is costly. -/
+theorem evpi_eq_min {ε δ : ℚ} (hε : ε ≤ 1/2) (hδ0 : 0 ≤ δ) :
+    evpi (dp ε δ) Finset.univ = min ε δ := by
+  rw [evpi, oracleValue_eq_one hδ0, dpValue_eq hε]
+  ring
+
+/-! ### The CQ gate `P(r_cq) = Logistic(τ · (ExpRegret(r*) − c))` -/
+
+/-- The logistic CQ gate over the regret signal `x`. -/
+noncomputable def cqGate (τ c x : ℝ) : ℝ :=
+  (1 + Real.exp (-(τ * (x - c))))⁻¹
+
+theorem cqGate_pos (τ c x : ℝ) : 0 < cqGate τ c x := by
+  rw [cqGate]
+  positivity
+
+theorem cqGate_le_one (τ c x : ℝ) : cqGate τ c x ≤ 1 := by
+  rw [cqGate]
+  rw [inv_le_one_iff₀]
+  right
+  linarith [Real.exp_pos (-(τ * (x - c)))]
+
+/-- The gate is strictly increasing in expected regret (for `τ > 0`):
+more to lose from acting → more clarification. -/
+theorem cqGate_strictMono {τ : ℝ} (hτ : 0 < τ) (c : ℝ) : StrictMono (cqGate τ c) := by
+  intro x y hxy
+  rw [cqGate, cqGate]
+  have hexp : Real.exp (-(τ * (y - c))) < Real.exp (-(τ * (x - c))) := by
+    apply Real.exp_lt_exp.mpr
+    nlinarith
+  exact (inv_lt_inv₀ (by positivity) (by positivity)).mpr (by linarith)
+
+/-- The paper's CQ probability at condition `(ε, δ)`: the logistic gate
+applied to the expected regret of the best action. -/
+noncomputable def cqProb (τ c : ℝ) (ε δ : ℚ) : ℝ :=
+  cqGate τ c ((evpi (dp ε δ) Finset.univ : ℚ) : ℝ)
+
+/-! ### Gate-level Experiment 1 predictions
+
+Fitted condition parameters (Bayesian posterior means): ε_L = 0.17,
+ε_H = 0.49 (low/high uncertainty), δ_S = 0.11, δ_L = 0.32 (small/large
+option space). The predictions hold for every `τ > 0` and threshold `c`;
+only the orderings `δ_S < ε_L < δ_L` and `ε_L < ε_H ≤ 1/2` matter. -/
+
+def epsLow : ℚ := 17/100
+def epsHigh : ℚ := 49/100
+def deltaSmall : ℚ := 11/100
+def deltaLarge : ℚ := 32/100
+
+/-- **TL;JustAsk** (prediction 1): with a large option space, more
+clarification under high uncertainty. -/
+theorem tl_justAsk {τ : ℝ} (hτ : 0 < τ) (c : ℝ) :
+    cqProb τ c epsLow deltaLarge < cqProb τ c epsHigh deltaLarge := by
+  rw [cqProb, cqProb,
+      evpi_eq_min (by norm_num [epsLow]) (by norm_num [deltaLarge]),
+      evpi_eq_min (by norm_num [epsHigh]) (by norm_num [deltaLarge]),
+      show min epsLow deltaLarge = 17/100 from by norm_num [min_def, epsLow, deltaLarge],
+      show min epsHigh deltaLarge = 32/100 from by norm_num [min_def, epsHigh, deltaLarge]]
+  exact cqGate_strictMono hτ c (by norm_num)
+
+/-- **NoNeedToAsk** (prediction 2): with a small option space, *no*
+difference in clarification between high and low uncertainty — an exact
+equality: the regret signal is capped at `δ_S` in both conditions. -/
+theorem noNeedToAsk (τ c : ℝ) :
+    cqProb τ c epsLow deltaSmall = cqProb τ c epsHigh deltaSmall := by
+  rw [cqProb, cqProb,
+      evpi_eq_min (by norm_num [epsLow]) (by norm_num [deltaSmall]),
+      evpi_eq_min (by norm_num [epsHigh]) (by norm_num [deltaSmall]),
+      show min epsLow deltaSmall = 11/100 from by norm_num [min_def, epsLow, deltaSmall],
+      show min epsHigh deltaSmall = 11/100 from by norm_num [min_def, epsHigh, deltaSmall]]
+
+/-- **WorthAsking** (the cost effect; Exp 2's prediction 7 at the model
+level): clarification is more likely when the safe action is costlier, at
+either uncertainty level. The model is fitted to Exp 1, where δ is its only
+cost knob. -/
+theorem worthAsking {τ : ℝ} (hτ : 0 < τ) (c : ℝ) {ε : ℚ} (hε : ε ≤ 1/2)
+    (h : deltaSmall < ε) :
+    cqProb τ c ε deltaSmall < cqProb τ c ε deltaLarge := by
+  rw [cqProb, cqProb, evpi_eq_min hε (by norm_num [deltaSmall]),
+      evpi_eq_min hε (by norm_num [deltaLarge]),
+      show min ε deltaSmall = deltaSmall from min_eq_right h.le]
+  refine cqGate_strictMono hτ c ?_
+  exact_mod_cast lt_min h (by norm_num [deltaSmall, deltaLarge])
+
+/-- **The interaction** (the paper's headline): uncertainty raises
+clarification when the safe action is costly (large option space) and has
+*no* effect when it is cheap (small option space). -/
+theorem uncertainty_matters_most_when_costly {τ : ℝ} (hτ : 0 < τ) (c : ℝ) :
+    cqProb τ c epsLow deltaSmall = cqProb τ c epsHigh deltaSmall ∧
+    cqProb τ c epsLow deltaLarge < cqProb τ c epsHigh deltaLarge :=
+  ⟨noNeedToAsk τ c, tl_justAsk hτ c⟩
+
+/-! ### The layered reaction policy -/
+
+/-- A reaction: clarify, or commit to a direct response. -/
+inductive Reaction where
+  | cq
+  | act (r : Response)
   deriving DecidableEq, Repr
 
-instance : Fintype Response where
-  elems := {.ms1, .ms2, .exh}
-  complete x := by cases x <;> simp
+/-- The paper's layered mixture: clarify with probability `q`, otherwise
+act according to the behavioral policy. -/
+noncomputable def layered (q : ℝ≥0) (hq : q ≤ 1) (pol : PMF Response) : PMF Reaction :=
+  (PMF.bernoulli q hq).bind fun ask => if ask then PMF.pure .cq else pol.map .act
 
--- ============================================================================
--- §2. Meaning and Action Utility
--- ============================================================================
+theorem layered_apply_cq (q : ℝ≥0) (hq : q ≤ 1) (pol : PMF Response) :
+    layered q hq pol .cq = q := by
+  rw [layered, PMF.bind_apply, tsum_bool]
+  simp [PMF.bernoulli_apply, PMF.map_apply,
+    show ∀ r : Response, Reaction.cq ≠ .act r from fun r => by simp]
 
-/-- Boolean applicability: does response r address goal g?
-    Parallel to [hawkins-etal-2025]'s `responseTruth`. -/
+theorem layered_apply_act (q : ℝ≥0) (hq : q ≤ 1) (pol : PMF Response) (r : Response) :
+    layered q hq pol (.act r) = (1 - (q : ℝ≥0∞)) * pol r := by
+  rw [layered, PMF.bind_apply, tsum_bool]
+  have hmap : pol.map Reaction.act (.act r) = pol r := by
+    rw [PMF.map_apply]
+    simp only [Reaction.act.injEq]
+    exact (tsum_eq_single r fun r' hne => if_neg fun h => hne h.symm).trans (if_pos rfl)
+  simp [PMF.bernoulli_apply, hmap]
+
+/-- The full reaction policy at condition `(ε, δ)`: gate by the logistic of
+the expected regret, then act by the softmax policy. -/
+noncomputable def reaction (τ c α : ℝ) (ε δ : ℚ) : PMF Reaction :=
+  layered (Real.toNNReal (cqProb τ c ε δ))
+    (by
+      rw [← Real.toNNReal_one]
+      exact Real.toNNReal_mono (cqGate_le_one _ _ _))
+    (policy α ε δ)
+
+/-! ### RSA reinterpretation: the post-clarification speaker and a listener
+
+Everything below is this file's **extension**, not the paper's model. The
+goal-*conditioned* speaker — softmax of `U(g, ·)` with inapplicable
+responses gated to `⊥` — is the ε → 0 / post-clarification limit of `π`,
+and coincides with [hawkins-etal-2025]'s action-utility respondent R₁ at
+β = 1, w_c = 0 (their `responseTruth` gate). Inverting it with a Bayesian
+listener connects the model to the canonical RSA pipeline; the paper itself
+has no listener. -/
+
+/-- Does response `r` address goal `g`? ([hawkins-etal-2025]'s `responseTruth`.) -/
 def respApplies : Response → Goal → Bool
   | .ms1, .g₁ => true
   | .ms2, .g₂ => true
   | .exh, _   => true
-  | _, _      => false
+  | _,    _   => false
 
--- ============================================================================
--- §3. RSAConfig with Action Utility
--- ============================================================================
+/-- Action value `U(g, r)` as a real: 1 for matching mention-some,
+`exhVal = 1 − δ` for exhaustive, 0 for a mismatch. -/
+def actVal (exhVal : ℝ) : Response → Goal → ℝ
+  | .ms1, .g₁ => 1
+  | .ms2, .g₂ => 1
+  | .exh, _   => exhVal
+  | _,    _   => 0
 
-open RSA Real in
-/-- Bartender RSA with action-utility scoring.
+/-- Goal-conditioned speaker utility: `α · U(g, r)` on applicable
+responses, `⊥` (softmax weight 0) otherwise. -/
+noncomputable def util (exhVal α : ℝ) : Goal → Response → EReal :=
+  fun g r => if respApplies r g then ((α * actVal exhVal r g : ℝ) : EReal) else (⊥ : EReal)
 
-    Parameterized by `exhVal` = 1 − δ (utility of exhaustive response)
-    and goal prior weights.
-
-    s1Score(L0, α, g, r) =
-      if L0(g|r) = 0 then 0
-      else exp(α · U(g, r))
-
-    This is [hawkins-etal-2025]'s `priorPQScore` at β = 1, w_c = 0:
-    pure action utility. The L0 gate ensures truth-conditional consistency.
-
-    Note: the paper's α has prior N(5, 1); we use α = 1 here. The
-    qualitative predictions (all `>` theorems below) hold for any α > 0. -/
-noncomputable def mkBartenderRSA (exhVal prior_g1 prior_g2 : ℝ)
-    (hExh : 0 ≤ exhVal) (h1 : 0 ≤ prior_g1) (h2 : 0 ≤ prior_g2) :
-    RSAConfig Response Goal where
-  meaning _ _ r g := if respApplies r g then 1 else 0
-  meaning_nonneg _ _ _ _ := by split <;> norm_num
-  s1Score l0 α _ w u :=
-    if l0 u w = 0 then 0
-    else exp (α * match u, w with
-      | .ms1, .g₁ => (1 : ℝ)
-      | .ms2, .g₂ => 1
-      | .exh, _   => exhVal
-      | _, _      => 0)
-  s1Score_nonneg l0 α _ _ u _ _ := by
-    show 0 ≤ (if l0 u _ = 0 then (0 : ℝ) else exp _)
+instance instViable (exhVal α : ℝ) : RSA.Canonical.ViableSpeaker (util exhVal α) where
+  no_top g r := by
+    unfold util
     split
-    · exact le_refl 0
-    · exact le_of_lt (exp_pos _)
-  α := 1
-  α_pos := by norm_num
-  worldPrior g := match g with
-    | .g₁ => prior_g1
-    | .g₂ => prior_g2
-  worldPrior_nonneg g := by cases g <;> assumption
-  latentPrior_nonneg _ _ := by norm_num
+    · exact EReal.coe_ne_top _
+    · exact bot_ne_top
+  some_finite g := ⟨.exh, by
+    unfold util
+    rw [if_pos (show respApplies .exh g = true by cases g <;> rfl)]
+    exact EReal.coe_ne_bot _⟩
 
--- ============================================================================
--- §3a. Concrete Configs
--- ============================================================================
+/-- The goal-conditioned (post-clarification) speaker. -/
+noncomputable def speaker (exhVal α : ℝ) : Goal → PMF Response :=
+  RSA.Canonical.S1 (util exhVal α)
 
--- Fitted parameters (Bayesian posterior means):
--- δ_L = 0.32 → exhVal = 0.68, δ_S = 0.11 → exhVal = 0.89
--- ε_H = 0.49 → prior (51, 49), ε_L = 0.17 → prior (83, 17)
+private theorem util_applies {exhVal α : ℝ} {r : Response} {g : Goal}
+    (h : respApplies r g = true) :
+    util exhVal α g r = ((α * actVal exhVal r g : ℝ) : EReal) := by
+  unfold util; rw [if_pos h]
 
-/-- Large option space (δ = 0.32), low uncertainty (ε = 0.17). -/
-noncomputable def cfgLargeLow :=
-  mkBartenderRSA (68/100) 83 17 (by norm_num) (by norm_num) (by norm_num)
+private theorem util_inapplies {exhVal α : ℝ} {r : Response} {g : Goal}
+    (h : respApplies r g = false) : util exhVal α g r = ⊥ := by
+  unfold util; rw [if_neg (by simp [h])]
 
-/-- Large option space (δ = 0.32), high uncertainty (ε = 0.49). -/
-noncomputable def cfgLargeHigh :=
-  mkBartenderRSA (68/100) 51 49 (by norm_num) (by norm_num) (by norm_num)
+private theorem speaker_ne_zero {exhVal α : ℝ} {g : Goal} {r : Response}
+    (h : respApplies r g = true) : speaker exhVal α g r ≠ 0 :=
+  RSA.Canonical.S1_ne_zero (util exhVal α)
+    (by rw [util_applies h]; exact EReal.coe_ne_bot _)
 
-/-- Small option space (δ = 0.11), low uncertainty (ε = 0.17). -/
-noncomputable def cfgSmallLow :=
-  mkBartenderRSA (89/100) 83 17 (by norm_num) (by norm_num) (by norm_num)
+private theorem speaker_eq_zero {exhVal α : ℝ} {g : Goal} {r : Response}
+    (h : respApplies r g = false) : speaker exhVal α g r = 0 := by
+  have hbot : util exhVal α g r = ⊥ := util_inapplies h
+  unfold speaker RSA.Canonical.S1
+  rw [PMF.apply_eq_zero_iff, PMF.support_softmax]
+  simp [hbot]
 
-/-- Small option space (δ = 0.11), high uncertainty (ε = 0.49). -/
-noncomputable def cfgSmallHigh :=
-  mkBartenderRSA (89/100) 51 49 (by norm_num) (by norm_num) (by norm_num)
+/-- Knowing the goal, the speaker prefers the targeted answer over the
+exhaustive one whenever the exhaustive answer carries any cost
+(`exhVal < 1`), for any α > 0. -/
+theorem S1_g1_prefers_ms1 {exhVal α : ℝ} (hα : 0 < α) (hv : exhVal < 1) :
+    speaker exhVal α .g₁ .exh < speaker exhVal α .g₁ .ms1 := by
+  rw [speaker, RSA.Canonical.S1_prefers_iff,
+      util_applies (show respApplies .exh .g₁ = true from rfl),
+      util_applies (show respApplies .ms1 .g₁ = true from rfl)]
+  exact EReal.coe_lt_coe (by simp only [actVal]; nlinarith)
 
--- ============================================================================
--- §4. S1 Predictions (Speaker Behavior)
--- ============================================================================
+/-- The speaker never produces a mismatching answer: its utility is `⊥`. -/
+theorem S1_g1_avoids_ms2 (exhVal α : ℝ) :
+    speaker exhVal α .g₁ .ms2 < speaker exhVal α .g₁ .ms1 := by
+  rw [speaker, RSA.Canonical.S1_prefers_iff,
+      util_inapplies (show respApplies .ms2 .g₁ = false by decide),
+      util_applies (show respApplies .ms1 .g₁ = true from rfl)]
+  exact EReal.bot_lt_coe _
 
-/-! S1 captures the behavioral policy: how the responder acts when they know
-the goal. With action-utility scoring, S1 preferences are δ-sensitive:
-the exhaustive response scores `exp(α · (1−δ))`, which drops with δ. -/
+/-! The cross-condition δ-sensitivity of the exhaustive answer
+(`S1(exh | g₁, δ_S) > S1(exh | g₁, δ_L)`: exhaustive answers are more
+viable when the option space is small) is Exp 1's option-space cost effect
+(predictions 3–4; the credible negative effect of space size on exhaustive
+rates). It is a cross-model comparison outside the single-distribution
+`S1_prefers_iff` vocabulary; at the policy level the same effect is `eu_exh`
+monotone in δ. -/
 
-/-- S1 facing g₁ prefers ms1 over exh in the large option space.
-    U(g₁, ms1) = 1 > U(g₁, exh) = 0.68. -/
-theorem S1_large_g1_prefers_ms1 :
-    cfgLargeLow.S1 () .g₁ .ms1 > cfgLargeLow.S1 () .g₁ .exh := by
-  rsa_predict
+/-- The questioner's prior over goals, `(1 − ε) : ε`, normalised. -/
+noncomputable def priorWeight (pg1 pg2 : ℝ) : Goal → ℝ≥0∞
+  | .g₁ => ENNReal.ofReal pg1
+  | .g₂ => ENNReal.ofReal pg2
 
-/-- S1 facing g₁ prefers ms1 over exh in the small option space too.
-    U(g₁, ms1) = 1 > U(g₁, exh) = 0.89. The gap is smaller than large δ. -/
-theorem S1_small_g1_prefers_ms1 :
-    cfgSmallLow.S1 () .g₁ .ms1 > cfgSmallLow.S1 () .g₁ .exh := by
-  rsa_predict
+private theorem priorWeight_tsum (pg1 pg2 : ℝ) :
+    (∑' g, priorWeight pg1 pg2 g) = ENNReal.ofReal pg1 + ENNReal.ofReal pg2 := by
+  rw [tsum_fintype, show (Finset.univ : Finset Goal) = {Goal.g₁, Goal.g₂} from by decide,
+      Finset.sum_insert (by decide), Finset.sum_singleton]
+  rfl
 
-/-- S1 facing g₁ never produces ms2 (mismatching response).
-    L0(g₁|ms2) = 0, so the L0 gate zeros the score. -/
-theorem S1_g1_avoids_ms2 :
-    cfgLargeLow.S1 () .g₁ .ms1 > cfgLargeLow.S1 () .g₁ .ms2 := by
-  rsa_predict
+/-- The world prior, normalised to a PMF. -/
+noncomputable def worldPrior (pg1 pg2 : ℝ) (h1 : 0 < pg1) (_h2 : 0 < pg2) : PMF Goal :=
+  PMF.normalize (priorWeight pg1 pg2)
+    (by rw [priorWeight_tsum]
+        exact ((ENNReal.ofReal_pos.mpr h1).trans_le le_self_add).ne')
+    (by rw [priorWeight_tsum]
+        exact ENNReal.add_ne_top.mpr ⟨ENNReal.ofReal_ne_top, ENNReal.ofReal_ne_top⟩)
 
--- ============================================================================
--- §4a. Cross-Config S1: δ-Sensitivity
--- ============================================================================
+private theorem worldPrior_ne_zero {pg1 pg2 : ℝ} (h1 : 0 < pg1) (h2 : 0 < pg2) (g : Goal) :
+    worldPrior pg1 pg2 h1 h2 g ≠ 0 := by
+  rw [worldPrior, PMF.normalize_apply]
+  refine mul_ne_zero ?_ (ENNReal.inv_ne_zero.mpr ?_)
+  · cases g
+    · exact (ENNReal.ofReal_pos.mpr h1).ne'
+    · exact (ENNReal.ofReal_pos.mpr h2).ne'
+  · rw [priorWeight_tsum]
+    exact ENNReal.add_ne_top.mpr ⟨ENNReal.ofReal_ne_top, ENNReal.ofReal_ne_top⟩
 
-/-! The key RSA prediction: exh is relatively more viable in the small
-option space (δ = 0.11) than the large (δ = 0.32). This captures the
-EVPI effect through action utility: when the safe response is cheap,
-there's less need to clarify. -/
+/-- The questioner as Bayesian listener (this file's extension): the
+posterior over goals given the response. -/
+noncomputable def listener (exhVal pg1 pg2 α : ℝ) (h1 : 0 < pg1) (h2 : 0 < pg2)
+    (r : Response)
+    (h : PMF.marginal (speaker exhVal α) (worldPrior pg1 pg2 h1 h2) r ≠ 0) :
+    PMF Goal :=
+  PMF.posterior (speaker exhVal α) (worldPrior pg1 pg2 h1 h2) r h
 
-/-- **WorthAsking** at S1 level: exh is more viable in small option space.
-    S1(exh|g₁, small) > S1(exh|g₁, large) because exp(0.89α) > exp(0.68α). -/
-theorem S1_small_exh_more_viable :
-    cfgSmallLow.S1 () .g₁ .exh > cfgLargeLow.S1 () .g₁ .exh := by
-  rsa_predict
+private theorem marginal_ne_zero_at {exhVal pg1 pg2 α : ℝ} (h1 : 0 < pg1) (h2 : 0 < pg2)
+    (g : Goal) {r : Response} (hr : respApplies r g = true) :
+    PMF.marginal (speaker exhVal α) (worldPrior pg1 pg2 h1 h2) r ≠ 0 :=
+  PMF.marginal_ne_zero _ _ _ (worldPrior_ne_zero h1 h2 g) (speaker_ne_zero hr)
 
--- ============================================================================
--- §5. L1 Predictions (Listener Inference)
--- ============================================================================
-
-/-! Targeted responses (ms1, ms2) are fully informative: S1 never produces
-ms1 for g₂ (L0 gate), so L1(g₁|ms1) = 1 regardless of prior or δ.
-
-Exhaustive response transmits the prior: S1(exh|g₁) = S1(exh|g₂) (symmetric
-utility), so L1(g|exh) ∝ P(g). Under asymmetric prior (ε < 0.5), exh
-reveals the listener's prior belief about the goal. -/
-
-/-- L1 hearing ms1 infers g₁ with certainty. -/
+/-- The listener hearing ms1 infers g₁ with certainty (ms1 is never
+produced for g₂). Prior 83 : 17 = (1 − ε_L) : ε_L. -/
 theorem L1_ms1_infers_g1 :
-    cfgLargeLow.L1 .ms1 .g₁ > cfgLargeLow.L1 .ms1 .g₂ := by
-  rsa_predict
+    listener (68/100) 83 17 1 (by norm_num) (by norm_num) .ms1
+        (marginal_ne_zero_at (by norm_num) (by norm_num) .g₁ rfl) .g₂
+      < listener (68/100) 83 17 1 (by norm_num) (by norm_num) .ms1
+        (marginal_ne_zero_at (by norm_num) (by norm_num) .g₁ rfl) .g₁ := by
+  rw [listener, PMF.posterior_lt_iff_score_lt,
+      speaker_eq_zero (show respApplies .ms1 .g₂ = false by decide), mul_zero]
+  exact pos_iff_ne_zero.mpr
+    (mul_ne_zero (worldPrior_ne_zero (by norm_num) (by norm_num) .g₁)
+      (speaker_ne_zero rfl))
 
-/-- L1 hearing ms2 infers g₂ (symmetric). -/
-theorem L1_ms2_infers_g2 :
-    cfgLargeLow.L1 .ms2 .g₂ > cfgLargeLow.L1 .ms2 .g₁ := by
-  rsa_predict
-
-/-- L1 hearing exh leans toward g₁ (prior = 83:17).
-    Since S1(exh|g₁) = S1(exh|g₂), L1(g|exh) ∝ P(g) — exh transmits
-    the prior rather than being uninformative. -/
-theorem L1_exh_transmits_prior :
-    cfgLargeLow.L1 .exh .g₁ > cfgLargeLow.L1 .exh .g₂ := by
-  rsa_predict
-
-/-- Targeted responses remain fully informative at high uncertainty. -/
+/-- Targeted responses stay fully informative even at high uncertainty
+(prior 51 : 49 = (1 − ε_H) : ε_H). -/
 theorem L1_high_ms1_still_certain :
-    cfgLargeHigh.L1 .ms1 .g₁ > cfgLargeHigh.L1 .ms1 .g₂ := by
-  rsa_predict
+    listener (68/100) 51 49 1 (by norm_num) (by norm_num) .ms1
+        (marginal_ne_zero_at (by norm_num) (by norm_num) .g₁ rfl) .g₂
+      < listener (68/100) 51 49 1 (by norm_num) (by norm_num) .ms1
+        (marginal_ne_zero_at (by norm_num) (by norm_num) .g₁ rfl) .g₁ := by
+  rw [listener, PMF.posterior_lt_iff_score_lt,
+      speaker_eq_zero (show respApplies .ms1 .g₂ = false by decide), mul_zero]
+  exact pos_iff_ne_zero.mpr
+    (mul_ne_zero (worldPrior_ne_zero (by norm_num) (by norm_num) .g₁)
+      (speaker_ne_zero rfl))
+
+/-- The speaker's exhaustive-answer probability is goal-symmetric: the
+utility multisets at g₁ and g₂ coincide under the ms1 ↔ ms2 swap. -/
+private theorem speaker_exh_symm (exhVal α : ℝ) :
+    speaker exhVal α .g₁ .exh = speaker exhVal α .g₂ .exh := by
+  unfold speaker RSA.Canonical.S1
+  rw [PMF.softmax_apply, PMF.softmax_apply]
+  congr 1
+  rw [show (Finset.univ : Finset Response) = {.ms1, .ms2, .exh} from by decide,
+      Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+      Finset.sum_singleton, Finset.sum_insert (by decide),
+      Finset.sum_insert (by decide), Finset.sum_singleton,
+      PMF.softmaxWeight_apply, PMF.softmaxWeight_apply, PMF.softmaxWeight_apply,
+      PMF.softmaxWeight_apply, PMF.softmaxWeight_apply, PMF.softmaxWeight_apply,
+      util_applies (show respApplies .ms1 .g₁ = true from rfl),
+      util_inapplies (show respApplies .ms2 .g₁ = false by decide),
+      util_applies (show respApplies .exh .g₁ = true from rfl),
+      util_inapplies (show respApplies .ms1 .g₂ = false by decide),
+      util_applies (show respApplies .ms2 .g₂ = true from rfl),
+      util_applies (show respApplies .exh .g₂ = true from rfl)]
+  show EReal.exp _ + (EReal.exp ⊥ + EReal.exp _)
+    = EReal.exp ⊥ + (EReal.exp _ + EReal.exp _)
+  have hms : actVal exhVal .ms1 .g₁ = actVal exhVal .ms2 .g₂ := rfl
+  have hexh : actVal exhVal .exh .g₁ = actVal exhVal .exh .g₂ := rfl
+  rw [hms, hexh]
+  ring
+
+/-- The exhaustive answer transmits the prior: `S1(exh | ·)` is
+goal-symmetric, so the listener's posterior given exh is the prior,
+83 : 17. -/
+theorem L1_exh_transmits_prior :
+    listener (68/100) 83 17 1 (by norm_num) (by norm_num) .exh
+        (marginal_ne_zero_at (by norm_num) (by norm_num) .g₁ (by decide)) .g₂
+      < listener (68/100) 83 17 1 (by norm_num) (by norm_num) .exh
+        (marginal_ne_zero_at (by norm_num) (by norm_num) .g₁ (by decide)) .g₁ := by
+  rw [listener, PMF.posterior_lt_iff_score_lt, ← speaker_exh_symm]
+  rw [mul_comm (worldPrior 83 17 _ _ .g₂), mul_comm (worldPrior 83 17 _ _ .g₁)]
+  refine (ENNReal.mul_lt_mul_iff_right
+    (speaker_ne_zero (show respApplies .exh .g₁ = true from rfl))
+    (PMF.apply_ne_top _ _)).mpr ?_
+  rw [worldPrior, PMF.normalize_apply, PMF.normalize_apply]
+  refine (ENNReal.mul_lt_mul_iff_left
+    (ENNReal.inv_ne_zero.mpr (by
+      rw [priorWeight_tsum]
+      exact ENNReal.add_ne_top.mpr ⟨ENNReal.ofReal_ne_top, ENNReal.ofReal_ne_top⟩))
+    (ENNReal.inv_ne_top.mpr (by
+      rw [priorWeight_tsum]
+      exact ((ENNReal.ofReal_pos.mpr (by norm_num : (0:ℝ) < 83)).trans_le
+        le_self_add).ne'))).mpr ?_
+  show ENNReal.ofReal 17 < ENNReal.ofReal 83
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
 
 end TsvilodubEtAl2026


### PR DESCRIPTION
Reformalizes the act-or-clarify study with the paper's full layered model and retires its rsa_predict/RSAConfig usage. Audited against arXiv 2602.02843v3 (model equations, fitted parameters, and prediction attributions verified; all numerics independently recomputed).

- formalizes all three layers: the decision problem on `Core.DecisionTheory.DecisionProblem`, the goal-marginal softmax policy π (canonical `RSA.Canonical.S1`), and the logistic expected-regret CQ gate with the layered mixture
- `evpi_eq_min`: the expected regret of the best action is `min ε δ` (via `Phenomena.Clarification.evpi`), giving the gate-level Exp 1 predictions for every τ > 0 — `noNeedToAsk` as an exact equality, and the headline uncertainty×cost interaction
- the RSA section is reframed as this file's extension (goal-conditioned speaker = post-clarification limit of π; the paper has no listener), with parameter provenance restored and the former sorry closed by goal-symmetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)