### PR TITLE
feat(Phenomena/Clarification): ClarifyRule contract, sharp vs soft gates

### DIFF
--- a/Linglib/Phenomena/Clarification/Basic.lean
+++ b/Linglib/Phenomena/Clarification/Basic.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Agent.DecisionTheory
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Data.Real.Basic
 
 /-!
 # Clarification: When to Ask vs. When to Act
@@ -20,6 +21,15 @@ interaction is the core empirical finding shared by both papers.
 EVPI is the maximum possible `questionUtility` ([van-rooy-2003]):
 it equals `questionUtility` on the identity partition, where each world
 is its own cell. Any specific clarification question yields at most EVPI.
+
+## The shared decision-rule contract
+
+Both accounts decide clarification from the same net value-of-information
+signal but through different rules: [dong-etal-2026] clarifies exactly when
+value exceeds cost (`sharpRule`, a threshold), while [tsvilodub-etal-2026]
+passes the margin through a logistic gate (a soft threshold; see
+`TsvilodubEtAl2026.softGateRule`). `ClarifyRule` is the contract both
+instantiate, exposing sharp vs. soft as a formal decision-rule choice.
 -/
 
 namespace Phenomena.Clarification
@@ -82,5 +92,45 @@ theorem evpi_nonneg {W A : Type*} [Fintype W] [DecidableEq W]
   unfold bestUtilityAt
   rw [dif_pos hne]
   exact Finset.le_sup' _ ha
+
+/-! ### The clarify-or-commit decision rule -/
+
+/-- A clarify-or-commit decision rule: clarification propensity as a
+monotone `[0, 1]`-valued function of the net value-of-information signal
+(value minus cost). The shared contract of [dong-etal-2026]'s sharp
+threshold and [tsvilodub-etal-2026]'s logistic gate. -/
+structure ClarifyRule where
+  /-- Clarification propensity given the net value signal. -/
+  propensity : ℝ → ℝ
+  mono : Monotone propensity
+  nonneg : ∀ x, 0 ≤ propensity x
+  le_one : ∀ x, propensity x ≤ 1
+
+/-- The sharp-threshold rule: clarify exactly when the net value is
+positive ([dong-etal-2026]'s `worthAsking`). -/
+noncomputable def sharpRule : ClarifyRule where
+  propensity x := if 0 < x then 1 else 0
+  mono x y hxy := by
+    show (if 0 < x then (1 : ℝ) else 0) ≤ if 0 < y then 1 else 0
+    by_cases hx : 0 < x
+    · rw [if_pos hx, if_pos (hx.trans_le hxy)]
+    · rw [if_neg hx]
+      split <;> norm_num
+  nonneg x := by split <;> norm_num
+  le_one x := by split <;> norm_num
+
+theorem sharpRule_apply_of_pos {x : ℝ} (h : 0 < x) : sharpRule.propensity x = 1 :=
+  if_pos h
+
+theorem sharpRule_apply_of_nonpos {x : ℝ} (h : ¬ 0 < x) : sharpRule.propensity x = 0 :=
+  if_neg h
+
+/-- The sharp rule is binary — the formal signature of a threshold process,
+against which soft gates contrast (`TsvilodubEtAl2026.softGateRule_apply_zero`). -/
+theorem sharpRule_binary (x : ℝ) :
+    sharpRule.propensity x = 0 ∨ sharpRule.propensity x = 1 := by
+  by_cases hx : 0 < x
+  · exact Or.inr (sharpRule_apply_of_pos hx)
+  · exact Or.inl (sharpRule_apply_of_nonpos hx)
 
 end Phenomena.Clarification

--- a/Linglib/Studies/DongEtAl2026PMF.lean
+++ b/Linglib/Studies/DongEtAl2026PMF.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Probability.Posterior
+import Linglib.Phenomena.Clarification.Basic
 
 /-!
 # [dong-etal-2026]: the Value-of-Information clarify-or-commit model
@@ -69,10 +70,6 @@ clarify-or-commit data lives in `Phenomena/Clarification/Basic.lean`.
   `eig_nonneg_of_convex` (bridging the `ℝ≥0∞`-on-`PMF` and `ℝ`-on-`Fintype`
   carriers) so the two statements of "information has nonnegative value" become
   one fact.
-* Lift a shared "clarify when value exceeds cost" `Predict` predicate into the
-  `Phenomena/Clarification` hub that this account and a rival soft-gate
-  (logistic) account both instantiate, exposing sharp-threshold vs. soft-gate
-  as a formal decision-rule choice.
 -/
 
 set_option autoImplicit false
@@ -318,5 +315,27 @@ theorem revealing_worth_asking :
 theorem revealing_worth_asking_medical :
     worthAsking 0 ((10 : ℝ≥0∞) • correctnessUtility) uniformBelief revealingQuestion :=
   medical_worth_asking_of_animal 0 _ _ _ revealing_worth_asking
+
+/-! ### The hub decision-rule instance: a sharp threshold -/
+
+/-- The account instantiates `Phenomena.Clarification.sharpRule`: asking is
+worth its cost exactly when the sharp-threshold rule fires on the net
+(real-valued) value signal. The soft-gate rival is
+`TsvilodubEtAl2026.softGateRule`. -/
+theorem worthAsking_iff_sharpRule {c : ℝ≥0∞} (hc : c ≠ ∞) (U : Θ → A → ℝ≥0∞)
+    (b : PMF Θ) (κ : Θ → PMF Y) (hV : VoI U b κ ≠ ∞) :
+    worthAsking c U b κ ↔
+      Phenomena.Clarification.sharpRule.propensity
+        ((VoI U b κ).toReal - c.toReal) = 1 := by
+  rw [worthAsking]
+  constructor
+  · intro h
+    exact Phenomena.Clarification.sharpRule_apply_of_pos
+      (sub_pos.mpr ((ENNReal.toReal_lt_toReal hc hV).mpr h))
+  · intro h
+    by_contra hlt
+    rw [Phenomena.Clarification.sharpRule_apply_of_nonpos (not_lt.mpr
+      (sub_nonpos.mpr ((ENNReal.toReal_le_toReal hV hc).mpr (not_lt.mp hlt))))] at h
+    norm_num at h
 
 end DongEtAl2026

--- a/Linglib/Studies/TsvilodubEtAl2026.lean
+++ b/Linglib/Studies/TsvilodubEtAl2026.lean
@@ -275,6 +275,39 @@ theorem uncertainty_matters_most_when_costly {τ : ℝ} (hτ : 0 < τ) (c : ℝ)
     cqProb τ c epsLow deltaLarge < cqProb τ c epsHigh deltaLarge :=
   ⟨noNeedToAsk τ c, tl_justAsk hτ c⟩
 
+/-! ### The hub decision-rule instance: a soft gate
+
+The logistic gate instantiates `Phenomena.Clarification.ClarifyRule` as a
+*soft* threshold, against [dong-etal-2026]'s sharp
+`Phenomena.Clarification.sharpRule`: it is never binary — at zero net value
+it clarifies with probability 1/2 (`softGateRule_apply_zero`, vs
+`sharpRule_binary`). Cf. the paper's Exp 2 contrast between binarized CQ
+rates and gradient action rates. -/
+
+/-- The logistic gate as a hub `ClarifyRule` over the net regret signal. -/
+noncomputable def softGateRule {τ : ℝ} (hτ : 0 < τ) :
+    Phenomena.Clarification.ClarifyRule where
+  propensity := cqGate τ 0
+  mono := (cqGate_strictMono hτ 0).monotone
+  nonneg x := (cqGate_pos τ 0 x).le
+  le_one x := cqGate_le_one τ 0 x
+
+/-- `cqProb` is the soft rule applied to the net signal `ExpRegret − c`. -/
+theorem cqProb_eq_softGateRule {τ : ℝ} (hτ : 0 < τ) (c : ℝ) (ε δ : ℚ) :
+    cqProb τ c ε δ
+      = (softGateRule hτ).propensity (((evpi (dp ε δ) Finset.univ : ℚ) : ℝ) - c) := by
+  show cqGate τ c _ = cqGate τ 0 _
+  rw [cqGate, cqGate]
+  norm_num
+
+/-- Unlike the sharp rule, the soft gate is never binary: at zero net value
+it clarifies with probability 1/2. -/
+theorem softGateRule_apply_zero {τ : ℝ} (hτ : 0 < τ) :
+    (softGateRule hτ).propensity 0 = 1/2 := by
+  show cqGate τ 0 0 = 1/2
+  rw [cqGate]
+  norm_num [Real.exp_zero]
+
 /-! ### The layered reaction policy -/
 
 /-- A reaction: clarify, or commit to a direct response. -/


### PR DESCRIPTION
Discharges DongEtAl2026PMF's Todo: lifts the shared clarify-when-value-exceeds-cost decision rule into the Clarification hub as `ClarifyRule` (monotone [0,1] propensity over the net value-of-information signal), instantiated by both accounts — Dong's `worthAsking` ↔ the sharp threshold firing, Tsvilodub's `cqProb` = the logistic soft gate at `EVPI − c` — with the formal contrast (`sharpRule_binary` vs `softGateRule_apply_zero` = ½ at threshold). Also normalizes the hub file's stray CRLF line endings (whitespace-only beyond the +50 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)