### PR TITLE
refactor(Semantics/Lexical/Roots): FeatureSignature as Finset LexKind

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -171,7 +171,7 @@ import Linglib.Semantics.Causation.SEM.Defs
 import Linglib.Semantics.Causation.SEM.Basic
 import Linglib.Semantics.Causation.SEM.Bool
 import Linglib.Semantics.Causation.SEM.Counterfactual
-import Linglib.Semantics.Lexical.Roots.RootFeatures
+import Linglib.Semantics.Lexical.Roots.Profile
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
 import Linglib.Features.Causation
@@ -2464,6 +2464,7 @@ import Linglib.Semantics.Lexical.LevinTheory
 import Linglib.Semantics.Lexical.LevinClassProfiles
 import Linglib.Semantics.Lexical.EventStructure
 import Linglib.Semantics.ArgumentStructure.ArgDerivation
+import Linglib.Semantics.Lexical.Roots.Signature
 import Linglib.Semantics.Lexical.Roots.Basic
 import Linglib.Semantics.Lexical.Roots.Template
 import Linglib.Semantics.Lexical.Roots.Typology

--- a/Linglib/Fragments/Dargwa/ComplexPredicates.lean
+++ b/Linglib/Fragments/Dargwa/ComplexPredicates.lean
@@ -39,7 +39,6 @@ Under vVPE, the light verb (v head) survives while the nominal root
 
 namespace Dargwa.ComplexPredicates
 
-open Semantics.Lexical.Roots
 
 -- ============================================================================
 -- § 1: Light Verb Inventory

--- a/Linglib/Fragments/Indonesian/Predicates.lean
+++ b/Linglib/Fragments/Indonesian/Predicates.lean
@@ -49,7 +49,6 @@ a reflexive reading arises even for obviative roots.
 namespace Indonesian.Predicates
 
 open Semantics.Lexical
-open Semantics.Lexical.Roots
 open Typology.Voice
 open Indonesian.Morphophonology
 

--- a/Linglib/Fragments/Mayan/Yukatek/Operators.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Operators.lean
@@ -31,7 +31,6 @@ manner. Spelt out structurally below.
 
 namespace Yukatek.Operators
 
-open Semantics.Lexical.Roots
 open Morphology.Derivation
 open Yukatek.Roots
 

--- a/Linglib/Fragments/Mayan/Yukatek/Roots.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Roots.lean
@@ -54,8 +54,6 @@ identifier use; original orthography is preserved in docstrings.
 
 namespace Yukatek.Roots
 
-open Semantics.Lexical.Roots
-
 -- ════════════════════════════════════════════════════
 -- § 1. Agent-Salient Roots (manner only, take `=t`)
 -- ════════════════════════════════════════════════════
@@ -197,125 +195,126 @@ def cin : Root := ⟨"cin", [.hasState "bent"]⟩
     relational positional semantics: "x is-seated [on y]"). -/
 def kul : Root := ⟨"kul", [.hasState "seated"]⟩
 
--- ════════════════════════════════════════════════════
--- § 5. Per-Root Feature Signatures
--- ════════════════════════════════════════════════════
+/-! ### Per-root feature signatures -/
 
-/-! Agent-salient roots → `⟨false, true, false, false⟩`. -/
+/-! Agent-salient roots → `{.manner}`. -/
 
 theorem siit_signature :
-    siit.featureSignature = ⟨false, true, false, false⟩ := rfl
+    siit.featureSignature = {.manner} := by decide
 theorem tziib_signature :
-    tziib.featureSignature = ⟨false, true, false, false⟩ := rfl
+    tziib.featureSignature = {.manner} := by decide
 theorem miis_signature :
-    miis.featureSignature = ⟨false, true, false, false⟩ := rfl
+    miis.featureSignature = {.manner} := by decide
 theorem cheh_signature :
-    cheh.featureSignature = ⟨false, true, false, false⟩ := rfl
+    cheh.featureSignature = {.manner} := by decide
 theorem paak_signature :
-    paak.featureSignature = ⟨false, true, false, false⟩ := rfl
+    paak.featureSignature = {.manner} := by decide
 
-/-! Agent-patient salient roots → `⟨false, true, true, false⟩`. -/
+/-! Agent-patient salient roots → `{.manner, .result}`. -/
 
 theorem kuc_signature :
-    kuc.featureSignature = ⟨false, true, true, false⟩ := rfl
+    kuc.featureSignature = {.manner, .result} := by decide
 theorem pis_signature :
-    pis.featureSignature = ⟨false, true, true, false⟩ := rfl
+    pis.featureSignature = {.manner, .result} := by decide
 theorem los_signature :
-    los.featureSignature = ⟨false, true, true, false⟩ := rfl
+    los.featureSignature = {.manner, .result} := by decide
 
-/-! Patient-salient roots → `⟨false, false, true, false⟩`. -/
+/-! Patient-salient roots → `{.result}`. -/
 
 theorem kiim_signature :
-    kiim.featureSignature = ⟨false, false, true, false⟩ := rfl
+    kiim.featureSignature = {.result} := by decide
 theorem haanCease_signature :
-    haanCease.featureSignature = ⟨false, false, true, false⟩ := rfl
+    haanCease.featureSignature = {.result} := by decide
 theorem luub_signature :
-    luub.featureSignature = ⟨false, false, true, false⟩ := rfl
+    luub.featureSignature = {.result} := by decide
 theorem ok_signature :
-    ok.featureSignature = ⟨false, false, true, false⟩ := rfl
+    ok.featureSignature = {.result} := by decide
 theorem ah_signature :
-    ah.featureSignature = ⟨false, false, true, false⟩ := rfl
+    ah.featureSignature = {.result} := by decide
 theorem wen_signature :
-    wen.featureSignature = ⟨false, false, true, false⟩ := rfl
+    wen.featureSignature = {.result} := by decide
 theorem siih_signature :
-    siih.featureSignature = ⟨false, false, true, false⟩ := rfl
+    siih.featureSignature = {.result} := by decide
 theorem tuub_signature :
-    tuub.featureSignature = ⟨false, false, true, false⟩ := rfl
+    tuub.featureSignature = {.result} := by decide
 theorem kaah_signature :
-    kaah.featureSignature = ⟨false, false, true, false⟩ := rfl
+    kaah.featureSignature = {.result} := by decide
 theorem chuun_signature :
-    chuun.featureSignature = ⟨false, false, true, false⟩ := rfl
+    chuun.featureSignature = {.result} := by decide
 theorem chenCease_signature :
-    chenCease.featureSignature = ⟨false, false, true, false⟩ := rfl
+    chenCease.featureSignature = {.result} := by decide
 theorem hoop_signature :
-    hoop.featureSignature = ⟨false, false, true, false⟩ := rfl
+    hoop.featureSignature = {.result} := by decide
 theorem heel_signature :
-    heel.featureSignature = ⟨false, false, true, false⟩ := rfl
+    heel.featureSignature = {.result} := by decide
 theorem paat_signature :
-    paat.featureSignature = ⟨false, false, true, false⟩ := rfl
+    paat.featureSignature = {.result} := by decide
 
-/-! Motion roots (also patient-salient) → `⟨false, false, true, false⟩`. -/
+/-! Motion roots (also patient-salient) → `{.result}`. -/
 
 theorem maan_signature :
-    maan.featureSignature = ⟨false, false, true, false⟩ := rfl
+    maan.featureSignature = {.result} := by decide
 theorem taal_signature :
-    taal.featureSignature = ⟨false, false, true, false⟩ := rfl
+    taal.featureSignature = {.result} := by decide
 theorem bin_signature :
-    bin.featureSignature = ⟨false, false, true, false⟩ := rfl
+    bin.featureSignature = {.result} := by decide
 theorem naak_signature :
-    naak.featureSignature = ⟨false, false, true, false⟩ := rfl
+    naak.featureSignature = {.result} := by decide
 theorem liik_signature :
-    liik.featureSignature = ⟨false, false, true, false⟩ := rfl
+    liik.featureSignature = {.result} := by decide
 
-/-! Positional roots → `⟨true, false, false, false⟩`. -/
+/-! Positional roots → `{.state}`. -/
 
 theorem cin_signature :
-    cin.featureSignature = ⟨true, false, false, false⟩ := rfl
+    cin.featureSignature = {.state} := by decide
 theorem kul_signature :
-    kul.featureSignature = ⟨true, false, false, false⟩ := rfl
+    kul.featureSignature = {.state} := by decide
 
--- ════════════════════════════════════════════════════
--- § 6. Per-Root Closed Feature Signatures
--- ════════════════════════════════════════════════════
+/-! ### Per-root closed feature signatures -/
 
-/-! Closure under `bkgRules` (currently `becomesState s ⇒ hasState s`)
-    promotes change-of-state roots to `state = true`. This does *not*
-    change the Lucy 1994 salience class predicted by `classOfSignature`,
-    because the agent / agentPatient / patient arms ignore the `state`
-    field, and the positional arm requires `result = false`. -/
+/-! The collocational closure (`FeatureSignature.close`) adds `.state`
+    to any signature containing `.result`, and `.result` + `.state` to
+    any containing `.cause`. No Yukatek root here carries a `.cause`
+    atom, so only the result→state edge fires. Closure does *not*
+    change the Lucy 1994 salience class predicted by
+    `classOfSignature` for these roots: the agent / agentPatient /
+    patient arms ignore `.state` membership, and the positional arm
+    (signature exactly `{.state}`) is never produced by closure from a
+    non-positional base without `.cause`
+    (cf. `Lucy1994.predictedClass_closure_invariant`). -/
 
 theorem siit_closed_signature :
-    siit.closedFeatureSignature = ⟨false, true, false, false⟩ := rfl
+    siit.closedFeatureSignature = {.manner} := by decide
 
 theorem tziib_closed_signature :
-    tziib.closedFeatureSignature = ⟨false, true, false, false⟩ := rfl
+    tziib.closedFeatureSignature = {.manner} := by decide
 
 theorem kuc_closed_signature :
-    kuc.closedFeatureSignature = ⟨true, true, true, false⟩ := rfl
+    kuc.closedFeatureSignature = {.state, .manner, .result} := by decide
 
 theorem pis_closed_signature :
-    pis.closedFeatureSignature = ⟨true, true, true, false⟩ := rfl
+    pis.closedFeatureSignature = {.state, .manner, .result} := by decide
 
 theorem los_closed_signature :
-    los.closedFeatureSignature = ⟨true, true, true, false⟩ := rfl
+    los.closedFeatureSignature = {.state, .manner, .result} := by decide
 
 theorem kiim_closed_signature :
-    kiim.closedFeatureSignature = ⟨true, false, true, false⟩ := rfl
+    kiim.closedFeatureSignature = {.state, .result} := by decide
 
 theorem haanCease_closed_signature :
-    haanCease.closedFeatureSignature = ⟨true, false, true, false⟩ := rfl
+    haanCease.closedFeatureSignature = {.state, .result} := by decide
 
 theorem luub_closed_signature :
-    luub.closedFeatureSignature = ⟨true, false, true, false⟩ := rfl
+    luub.closedFeatureSignature = {.state, .result} := by decide
 
 theorem ok_closed_signature :
-    ok.closedFeatureSignature = ⟨true, false, true, false⟩ := rfl
+    ok.closedFeatureSignature = {.state, .result} := by decide
 
 theorem cin_closed_signature :
-    cin.closedFeatureSignature = ⟨true, false, false, false⟩ := rfl
+    cin.closedFeatureSignature = {.state} := by decide
 
 theorem kul_closed_signature :
-    kul.closedFeatureSignature = ⟨true, false, false, false⟩ := rfl
+    kul.closedFeatureSignature = {.state} := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 7. Class Lists

--- a/Linglib/Fragments/Mayan/Yukatek/VerbClasses.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/VerbClasses.lean
@@ -229,8 +229,6 @@ theorem eventType_consistent (c : VerbStemClass) :
 -- § 5.5. Bridge to [lucy-1994] Salience Classes
 -- ════════════════════════════════════════════════════
 
-open Semantics.Lexical.Roots (SalienceClass)
-
 /-- Map [bohnemeyer-2004]'s 5-way Yukatek stem classification to
     [lucy-1994]'s 4-way salience cut. The 5-way is a refinement:
     `inchoative` and `positional` both pattern as Lucy's `positional`

--- a/Linglib/Morphology/ConsonantalRoot.lean
+++ b/Linglib/Morphology/ConsonantalRoot.lean
@@ -18,10 +18,10 @@ separate matter, parameterized at the study level.
 
 `Morphology.Root` (this file): a *consonantal* melody, a morphological
 primitive (the underlying form of a morpheme).
-`Semantics.Lexical.Roots.Root` (`Semantics/Lexical/Roots/Basic.lean`):
+The root-level `Root` (`Semantics/Lexical/Roots/Basic.lean`):
 a bundle of `LexEntailment` atoms in the [beavers-koontz-garboden-2020]
 sense — same English word, different concept.
-`Core.Lexical.RootFeatures` (`Core/Lexical/RootFeatures.lean`): semantic
+`Root.Profile` (`Semantics/Lexical/Roots/Profile.lean`): semantic
 quality dimensions on a verb root — orthogonal to both.
 -/
 

--- a/Linglib/Morphology/Derivation.lean
+++ b/Linglib/Morphology/Derivation.lean
@@ -21,8 +21,6 @@ architectural primitives.
 
 namespace Morphology.Derivation
 
-open Semantics.Lexical.Roots (Root)
-
 /-! ### Operators and inventories -/
 
 /-- A morphological operator: a name and a structural condition on

--- a/Linglib/Morphology/RootTypology.lean
+++ b/Linglib/Morphology/RootTypology.lean
@@ -2,6 +2,7 @@ import Linglib.Semantics.Lexical.EventStructure
 import Linglib.Semantics.Aspect.ChangeOfState
 import Linglib.Semantics.Lexical.LevinTheory
 import Linglib.Semantics.Lexical.Roots.Template
+import Linglib.Semantics.Lexical.Roots.Profile
 
 open Semantics.Lexical
 
@@ -62,7 +63,6 @@ you nothing about whether it entails change, and vice versa.
 open Semantics.Lexical.EventStructure
 open Semantics.ArgumentStructure.EntailmentProfile
 open Features.ChangeOfState
-open Semantics.Lexical.Roots
 open Features
 
 -- ════════════════════════════════════════════════════
@@ -164,7 +164,7 @@ structure RootClassification where
       roots have been annotated. -/
   denotationType : Option RootDenotationType := none
   /-- Within-class quality dimensions ([spalek-mcnally-2026]) -/
-  profile : RootProfile := {}
+  profile : Root.Profile := {}
   /-- Verb class membership -/
   levinClass : Option LevinClass := none
   deriving BEq, Repr
@@ -362,7 +362,7 @@ theorem result_roots_witness_against_bifurcation :
 theorem pc_roots_consistent_with_bifurcation :
     RootType.entailsChange .propertyConcept = false := rfl
 
-/-- **B&[beavers-koontz-garboden-2020] strengthened bifurcation failure via RootEntailments.**
+/-- **B&[beavers-koontz-garboden-2020] strengthened bifurcation failure via `FeatureSignature`.**
 
     [beavers-etal-2021] show roots can entail CHANGE (one templatic notion).
     B&[beavers-koontz-garboden-2020] show roots can entail CHANGE, CAUSATION, and MANNER —
@@ -371,23 +371,23 @@ theorem pc_roots_consistent_with_bifurcation :
     roots encoding manner+cause (√GUILLOTINE, √HAND) violate bifurcation
     on three separate dimensions simultaneously.
 
-    Witness: `RootEntailments.fullSpec` has all four features true. -/
+    Witness: `FeatureSignature.fullSpec` carries all four kinds. -/
 theorem bkg_bifurcation_fails_all_dimensions :
-    -- Roots can entail change (result = true)
-    RootEntailments.fullSpec.result = true ∧
-    -- Roots can entail causation (cause = true)
-    RootEntailments.fullSpec.cause = true ∧
-    -- Roots can entail manner (manner = true)
-    RootEntailments.fullSpec.manner = true ∧
+    -- Roots can entail change (result kind)
+    LexKind.result ∈ FeatureSignature.fullSpec ∧
+    -- Roots can entail causation (cause kind)
+    LexKind.cause ∈ FeatureSignature.fullSpec ∧
+    -- Roots can entail manner (manner kind)
+    LexKind.manner ∈ FeatureSignature.fullSpec ∧
     -- All at once — not just one dimension
-    RootEntailments.fullSpec.state = true := ⟨rfl, rfl, rfl, rfl⟩
+    LexKind.state ∈ FeatureSignature.fullSpec := by decide
 
 /-- Multiple Levin classes witness the stronger bifurcation failure. -/
 theorem bkg_bifurcation_multiple_witnesses :
-    (LevinClass.rootEntailments .cut).result = true ∧
-    (LevinClass.rootEntailments .cut).manner = true ∧
-    (LevinClass.rootEntailments .give).cause = true ∧
-    (LevinClass.rootEntailments .give).manner = true := ⟨rfl, rfl, rfl, rfl⟩
+    LexKind.result ∈ LevinClass.rootEntailments .cut ∧
+    LexKind.manner ∈ LevinClass.rootEntailments .cut ∧
+    LexKind.cause ∈ LevinClass.rootEntailments .give ∧
+    LexKind.manner ∈ LevinClass.rootEntailments .give := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 6. The Markedness Generalization (§8, eq. 44)
@@ -596,7 +596,8 @@ theorem RootDen.pc_respects {Entity State Event : Type}
     (sp : Entity → State → Prop) :
     (RootDen.pc sp : RootDen Entity State Event).denotationViolatesMRC = false := rfl
 
-/-- **Bridge: denotation-level MRC → Boolean RootEntailments MRC.**
+/-- **Bridge: denotation-level MRC → signature-level MRC
+    (`FeatureSignature.HasMannerAndResult`).**
     MRC violation requires BOTH conditions — having manner alone
     (if such a constructor existed) would not be a violation. -/
 theorem RootDen.mrc_requires_both {Entity State Event : Type}
@@ -852,20 +853,20 @@ theorem break_no_MRC_violation : breakDiagnostics.showsMRCViolation = false := r
 theorem hit_no_MRC_violation : hitDiagnostics.showsMRCViolation = false := rfl
 theorem drown_MRC_violation : drownDiagnostics.showsMRCViolation = true := rfl
 
-/-- Cut is MRC-violating by BOTH diagnostics AND RootEntailments. -/
+/-- Cut is MRC-violating by BOTH diagnostics AND feature signature. -/
 theorem cut_diagnostics_match_entailments :
     cutDiagnostics.showsMRCViolation = true ↔
-    (LevinClass.rootEntailments .cut).ViolatesMRC := by decide
+    (LevinClass.rootEntailments .cut).HasMannerAndResult := by decide
 
-/-- Break is MRC-respecting by BOTH diagnostics AND RootEntailments. -/
+/-- Break is MRC-respecting by BOTH diagnostics AND feature signature. -/
 theorem break_diagnostics_match_entailments :
     breakDiagnostics.showsMRCViolation = true ↔
-    (LevinClass.rootEntailments .break_).ViolatesMRC := by decide
+    (LevinClass.rootEntailments .break_).HasMannerAndResult := by decide
 
-/-- Hit is MRC-respecting by BOTH diagnostics AND RootEntailments. -/
+/-- Hit is MRC-respecting by BOTH diagnostics AND feature signature. -/
 theorem hit_diagnostics_match_entailments :
     hitDiagnostics.showsMRCViolation = true ↔
-    (LevinClass.rootEntailments .hit).ViolatesMRC := by decide
+    (LevinClass.rootEntailments .hit).HasMannerAndResult := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 8. Bridge to EntailmentProfile.changeOfState (ProtoRoles §8)
@@ -1430,52 +1431,65 @@ theorem same_change_same_morphosyntax (r₁ r₂ : RootClassification)
     positions give 32 theoretical cells, of which 7 are attested and
     the rest are principled gaps. -/
 structure FullRootSpec where
-  entailments : RootEntailments
+  entailments : FeatureSignature
   position : Root.Position
-  deriving DecidableEq, Repr
+  deriving DecidableEq
 
 /-- Adjoined position requires +manner: a root in adjunct position
     must specify a manner of action. Without manner, there is nothing
     to adjoin — the adjunct slot expects an action modifier. -/
-def FullRootSpec.positionLicensed (s : FullRootSpec) : Bool :=
-  match s.position with
-  | .adjoined => s.entailments.manner
-  | .complement => true
+def FullRootSpec.PositionLicensed (s : FullRootSpec) : Prop :=
+  s.position = .adjoined → LexKind.manner ∈ s.entailments
+
+instance (s : FullRootSpec) : Decidable s.PositionLicensed :=
+  inferInstanceAs (Decidable (_ → _))
 
 /-- +manner +state −result −cause is semantically incoherent (B&KG §5.4.1):
     the root would specify both a manner of action and a state, but with
     no result or cause linking them. What would such a verb mean?
     "Perform manner M while in state S" — with no causal connection. -/
-def FullRootSpec.semanticallyCoherent (s : FullRootSpec) : Bool :=
-  !(s.entailments.manner && s.entailments.state &&
-    !s.entailments.result && !s.entailments.cause)
+def FullRootSpec.SemanticallyCoherent (s : FullRootSpec) : Prop :=
+  ¬ (LexKind.manner ∈ s.entailments ∧ LexKind.state ∈ s.entailments ∧
+     LexKind.result ∉ s.entailments ∧ LexKind.cause ∉ s.entailments)
+
+instance (s : FullRootSpec) : Decidable s.SemanticallyCoherent :=
+  inferInstanceAs (Decidable (¬ _))
 
 /-- Full well-formedness: entailment constraints + position licensing +
     semantic coherence. -/
-def FullRootSpec.wellFormed (s : FullRootSpec) : Bool :=
-  decide s.entailments.WellFormed && s.positionLicensed && s.semanticallyCoherent
+def FullRootSpec.WellFormed (s : FullRootSpec) : Prop :=
+  s.entailments.WellFormed ∧ s.PositionLicensed ∧ s.SemanticallyCoherent
+
+instance (s : FullRootSpec) : Decidable s.WellFormed :=
+  inferInstanceAs (Decidable (_ ∧ _ ∧ _))
 
 /-! ### Attested cells of Table 12 -/
 
 /-- √FLAT: +S −M −R −C, complement. Property concept root. -/
-def FullRootSpec.flat : FullRootSpec := ⟨.propertyConcept, .complement⟩
+def FullRootSpec.flat : FullRootSpec :=
+  ⟨FeatureSignature.propertyConcept, .complement⟩
 
 /-- √BLOSSOM: +S −M +R −C, complement. Pure result root. -/
-def FullRootSpec.blossom : FullRootSpec := ⟨.pureResult, .complement⟩
+def FullRootSpec.blossom : FullRootSpec :=
+  ⟨FeatureSignature.pureResult, .complement⟩
 
 /-- √CRACK: +S −M +R +C, complement. Causative result root. -/
-def FullRootSpec.crack : FullRootSpec := ⟨.causativeResult, .complement⟩
+def FullRootSpec.crack : FullRootSpec :=
+  ⟨FeatureSignature.causativeResult, .complement⟩
 
 /-- √JOG: −S +M −R −C, adjoined. Pure manner root. -/
-def FullRootSpec.jog : FullRootSpec := ⟨.pureManner, .adjoined⟩
+def FullRootSpec.jog : FullRootSpec :=
+  ⟨FeatureSignature.pureManner, .adjoined⟩
 
 /-- √DROWN: +S +M +R +C, complement. Manner+result in complement position —
     the manner restricts HOW the state is caused. -/
-def FullRootSpec.drown : FullRootSpec := ⟨.fullSpec, .complement⟩
+def FullRootSpec.drown : FullRootSpec :=
+  ⟨FeatureSignature.fullSpec, .complement⟩
 
 /-- √TOSS: +S +M +R +C, adjoined. Manner+result in adjunct position —
     the manner is the primary event that happens to cause a state change. -/
-def FullRootSpec.toss : FullRootSpec := ⟨.fullSpec, .adjoined⟩
+def FullRootSpec.toss : FullRootSpec :=
+  ⟨FeatureSignature.fullSpec, .adjoined⟩
 
 /-- √HAND: same entailments + position as √TOSS. The difference is in
     the ditransitive layer (DitransitiveRootClass.causedPossession vs
@@ -1483,25 +1497,25 @@ def FullRootSpec.toss : FullRootSpec := ⟨.fullSpec, .adjoined⟩
 abbrev FullRootSpec.hand : FullRootSpec := FullRootSpec.toss
 
 /-- √EXIST: −S −M −R −C, complement. Minimal stative root. -/
-def FullRootSpec.exist : FullRootSpec := ⟨.minimal, .complement⟩
+def FullRootSpec.exist : FullRootSpec :=
+  ⟨FeatureSignature.minimal, .complement⟩
 
 -- All attested types are well-formed
-theorem flat_wf : FullRootSpec.flat.wellFormed = true := rfl
-theorem blossom_wf : FullRootSpec.blossom.wellFormed = true := rfl
-theorem crack_wf : FullRootSpec.crack.wellFormed = true := rfl
-theorem jog_wf : FullRootSpec.jog.wellFormed = true := rfl
-theorem drown_wf : FullRootSpec.drown.wellFormed = true := rfl
-theorem toss_wf : FullRootSpec.toss.wellFormed = true := rfl
-theorem hand_wf : FullRootSpec.hand.wellFormed = true := rfl
-theorem exist_wf : FullRootSpec.exist.wellFormed = true := rfl
+theorem flat_wf : FullRootSpec.flat.WellFormed := by decide
+theorem blossom_wf : FullRootSpec.blossom.WellFormed := by decide
+theorem crack_wf : FullRootSpec.crack.WellFormed := by decide
+theorem jog_wf : FullRootSpec.jog.WellFormed := by decide
+theorem drown_wf : FullRootSpec.drown.WellFormed := by decide
+theorem toss_wf : FullRootSpec.toss.WellFormed := by decide
+theorem hand_wf : FullRootSpec.hand.WellFormed := by decide
+theorem exist_wf : FullRootSpec.exist.WellFormed := by decide
 
 /-- √DROWN and √TOSS have identical entailments but different positions. -/
 theorem drown_toss_same_entailments :
     FullRootSpec.drown.entailments = FullRootSpec.toss.entailments := rfl
 
 theorem drown_toss_diff_position :
-    FullRootSpec.drown.position ≠ FullRootSpec.toss.position := by
-  simp [FullRootSpec.drown, FullRootSpec.toss]
+    FullRootSpec.drown.position ≠ FullRootSpec.toss.position := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 18. Root → Templatic Head Prediction (B&[beavers-koontz-garboden-2020] Table 13)
@@ -1524,8 +1538,6 @@ inductive TemplateHead where
   | pHave    -- P_have: possession preposition (ditransitive transfer)
   deriving DecidableEq, Repr
 
-namespace Semantics.Lexical.Roots
-
 /-- Which template heads a root's entailments make redundant (Table 13).
 
     The mapping is monotone: more root entailments → more heads entailed.
@@ -1536,12 +1548,10 @@ namespace Semantics.Lexical.Roots
     - +manner alone → no v_act (manner without causation doesn't entail
       activity — √JOG specifies jogging manner but v_act still provides
       the activity frame) -/
-def RootEntailments.entailedHeads (r : RootEntailments) : List TemplateHead :=
-  (if r.result then [.vBecome] else []) ++
-  (if r.cause then [.vCause] else []) ++
-  (if r.manner && r.cause then [.vAct] else [])
-
-end Semantics.Lexical.Roots
+def FeatureSignature.entailedHeads (s : FeatureSignature) : List TemplateHead :=
+  (if LexKind.result ∈ s then [.vBecome] else []) ++
+  (if LexKind.cause ∈ s then [.vCause] else []) ++
+  (if LexKind.manner ∈ s ∧ LexKind.cause ∈ s then [.vAct] else [])
 
 /-- For ditransitive roots, additional prepositional heads beyond
     the verbal heads predicted by `entailedHeads`. -/
@@ -1559,69 +1569,68 @@ def DitransitiveRootClass.additionalHeads : DitransitiveRootClass → List Templ
     The root specifies jogging manner, but v_act still provides
     the activity frame — the root doesn't make it redundant. -/
 theorem jog_no_heads :
-    RootEntailments.pureManner.entailedHeads = [] := rfl
+    FeatureSignature.pureManner.entailedHeads = [] := by decide
 
 /-- √FLAT (propertyConcept): no template heads entailed.
     The root names a state, but doesn't entail change or cause. -/
 theorem flat_no_heads :
-    RootEntailments.propertyConcept.entailedHeads = [] := rfl
+    FeatureSignature.propertyConcept.entailedHeads = [] := by decide
 
 /-- √BLOSSOM (pureResult): v_become entailed.
     The root entails change — v_become's contribution is redundant. -/
 theorem blossom_heads :
-    RootEntailments.pureResult.entailedHeads = [.vBecome] := rfl
+    FeatureSignature.pureResult.entailedHeads = [.vBecome] := by decide
 
 /-- √CRACK (causativeResult): v_become + v_cause entailed.
     The root entails change AND causation. -/
 theorem crack_heads :
-    RootEntailments.causativeResult.entailedHeads = [.vBecome, .vCause] := rfl
+    FeatureSignature.causativeResult.entailedHeads = [.vBecome, .vCause] := by
+  decide
 
 /-- √DROWN (fullSpec): v_become + v_cause + v_act entailed.
     The root entails change, causation, AND activity (manner that causes). -/
 theorem drown_heads :
-    RootEntailments.fullSpec.entailedHeads = [.vBecome, .vCause, .vAct] := rfl
+    FeatureSignature.fullSpec.entailedHeads = [.vBecome, .vCause, .vAct] := by
+  decide
 
 /-- √TOSS (fullSpec + ballistic): v_become + v_cause + v_act + P_loc.
     Verbal heads from entailments + P_loc from ditransitive class. -/
 theorem toss_heads :
-    RootEntailments.fullSpec.entailedHeads ++
+    FeatureSignature.fullSpec.entailedHeads ++
     DitransitiveRootClass.additionalHeads .ballisticMotion =
-    [.vBecome, .vCause, .vAct, .pLoc] := rfl
+    [.vBecome, .vCause, .vAct, .pLoc] := by decide
 
 /-- √HAND (fullSpec + causedPossession): all 5 heads.
     Verbal heads from entailments + P_loc + P_have from ditransitive class. -/
 theorem hand_heads :
-    RootEntailments.fullSpec.entailedHeads ++
+    FeatureSignature.fullSpec.entailedHeads ++
     DitransitiveRootClass.additionalHeads .causedPossession =
-    [.vBecome, .vCause, .vAct, .pLoc, .pHave] := rfl
+    [.vBecome, .vCause, .vAct, .pLoc, .pHave] := by decide
 
 /-- Monotonicity: more root entailments → weakly more heads entailed.
     Pure result ⊂ causative result ⊂ full spec (by inclusion). -/
 theorem heads_monotone :
-    RootEntailments.pureResult.entailedHeads.length ≤
-    RootEntailments.causativeResult.entailedHeads.length ∧
-    RootEntailments.causativeResult.entailedHeads.length ≤
-    RootEntailments.fullSpec.entailedHeads.length := ⟨by decide, by decide⟩
+    FeatureSignature.pureResult.entailedHeads.length ≤
+    FeatureSignature.causativeResult.entailedHeads.length ∧
+    FeatureSignature.causativeResult.entailedHeads.length ≤
+    FeatureSignature.fullSpec.entailedHeads.length := ⟨by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
 -- § 19. Gap Predictions (B&[beavers-koontz-garboden-2020] §5.4.1, Table 12)
 -- ════════════════════════════════════════════════════
 
+/-- The attested cells of B&KG's Table 12: five complement types
+    (√FLAT, √BLOSSOM, √CRACK, √DROWN, √EXIST) and two adjoined types
+    (√JOG, √TOSS/√HAND). -/
+def FullRootSpec.attestedCells : List FullRootSpec :=
+  [.flat, .blossom, .crack, .drown, .exist, .jog, .toss]
+
 /-- Whether a FullRootSpec cell is attested in B&KG's Table 12. -/
-def FullRootSpec.isAttestedCell (s : FullRootSpec) : Bool :=
-  s.wellFormed &&
-  match s.entailments, s.position with
-  -- Attested complement types
-  | ⟨true, false, false, false⟩, .complement => true   -- √FLAT
-  | ⟨true, false, true, false⟩,  .complement => true   -- √BLOSSOM
-  | ⟨true, false, true, true⟩,   .complement => true   -- √CRACK
-  | ⟨true, true, true, true⟩,    .complement => true   -- √DROWN
-  | ⟨false, false, false, false⟩, .complement => true   -- √EXIST
-  -- Attested adjoined types
-  | ⟨false, true, false, false⟩, .adjoined => true      -- √JOG
-  | ⟨true, true, true, true⟩,    .adjoined => true      -- √TOSS/√HAND
-  -- Everything else is a gap
-  | _, _ => false
+def FullRootSpec.IsAttestedCell (s : FullRootSpec) : Prop :=
+  s.WellFormed ∧ s ∈ FullRootSpec.attestedCells
+
+instance (s : FullRootSpec) : Decidable s.IsAttestedCell :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
 /-! ### Gap explanations
 
@@ -1640,40 +1649,46 @@ B&KG (§5.4.1) identify three principled gap types:
 
 /-- Gap type 1: adjoined position requires manner. -/
 theorem gap_adjoined_no_manner :
-    (FullRootSpec.mk .propertyConcept .adjoined).positionLicensed = false := rfl
+    ¬ (FullRootSpec.mk FeatureSignature.propertyConcept .adjoined).PositionLicensed := by
+  decide
 
 theorem gap_adjoined_result :
-    (FullRootSpec.mk .pureResult .adjoined).positionLicensed = false := rfl
+    ¬ (FullRootSpec.mk FeatureSignature.pureResult .adjoined).PositionLicensed := by
+  decide
 
 theorem gap_adjoined_causativeResult :
-    (FullRootSpec.mk .causativeResult .adjoined).positionLicensed = false := rfl
+    ¬ (FullRootSpec.mk FeatureSignature.causativeResult .adjoined).PositionLicensed := by
+  decide
 
 theorem gap_adjoined_minimal :
-    (FullRootSpec.mk .minimal .adjoined).positionLicensed = false := rfl
+    ¬ (FullRootSpec.mk FeatureSignature.minimal .adjoined).PositionLicensed := by
+  decide
 
 /-- Gap type 2: +manner +state −result −cause is incoherent. -/
 theorem gap_manner_state_no_result :
-    (FullRootSpec.mk ⟨true, true, false, false⟩ .complement).semanticallyCoherent = false := rfl
+    ¬ (FullRootSpec.mk {.state, .manner} .complement).SemanticallyCoherent := by
+  decide
 
 theorem gap_manner_state_no_result_adj :
-    (FullRootSpec.mk ⟨true, true, false, false⟩ .adjoined).semanticallyCoherent = false := rfl
+    ¬ (FullRootSpec.mk {.state, .manner} .adjoined).SemanticallyCoherent := by
+  decide
 
 /-- Gap type 3: well-formedness violations. -/
 theorem gap_result_no_state :
-    ¬ (RootEntailments.mk false false true false).WellFormed := by decide
+    ¬ ({.result} : FeatureSignature).WellFormed := by decide
 
 theorem gap_cause_no_result :
-    ¬ (RootEntailments.mk true false false true).WellFormed := by decide
+    ¬ ({.state, .cause} : FeatureSignature).WellFormed := by decide
 
 /-! ### Attested cells are well-formed and recognized -/
 
-theorem flat_attested : FullRootSpec.flat.isAttestedCell = true := rfl
-theorem blossom_attested : FullRootSpec.blossom.isAttestedCell = true := rfl
-theorem crack_attested : FullRootSpec.crack.isAttestedCell = true := rfl
-theorem jog_attested : FullRootSpec.jog.isAttestedCell = true := rfl
-theorem drown_attested : FullRootSpec.drown.isAttestedCell = true := rfl
-theorem toss_attested : FullRootSpec.toss.isAttestedCell = true := rfl
-theorem exist_attested : FullRootSpec.exist.isAttestedCell = true := rfl
+theorem flat_attested : FullRootSpec.flat.IsAttestedCell := by decide
+theorem blossom_attested : FullRootSpec.blossom.IsAttestedCell := by decide
+theorem crack_attested : FullRootSpec.crack.IsAttestedCell := by decide
+theorem jog_attested : FullRootSpec.jog.IsAttestedCell := by decide
+theorem drown_attested : FullRootSpec.drown.IsAttestedCell := by decide
+theorem toss_attested : FullRootSpec.toss.IsAttestedCell := by decide
+theorem exist_attested : FullRootSpec.exist.IsAttestedCell := by decide
 
 /-- The open question: +S +M +R −C (mannerResult without cause) in
     complement position. B&KG note this cell may be inhabited by
@@ -1681,12 +1696,14 @@ theorem exist_attested : FullRootSpec.exist.isAttestedCell = true := rfl
     without external causation. Left as NOT attested per Table 12,
     pending further research. -/
 theorem mannerResult_complement_unattested :
-    (FullRootSpec.mk .mannerResult .complement).isAttestedCell = false := rfl
+    ¬ (FullRootSpec.mk FeatureSignature.mannerResult .complement).IsAttestedCell := by
+  decide
 
 /-- The complement/adjoined split for fullSpec roots is the only
     case where position differentiates otherwise identical entailments. -/
 theorem fullSpec_both_positions :
-    FullRootSpec.drown.isAttestedCell = true ∧
-    FullRootSpec.toss.isAttestedCell = true ∧
-    FullRootSpec.drown.entailments = FullRootSpec.toss.entailments := ⟨rfl, rfl, rfl⟩
+    FullRootSpec.drown.IsAttestedCell ∧
+    FullRootSpec.toss.IsAttestedCell ∧
+    FullRootSpec.drown.entailments = FullRootSpec.toss.entailments :=
+  ⟨by decide, by decide, rfl⟩
 

--- a/Linglib/Semantics/ArgumentStructure/Affectedness/Profile.lean
+++ b/Linglib/Semantics/ArgumentStructure/Affectedness/Profile.lean
@@ -61,7 +61,7 @@ representation in the codebase:
 
 - `EntailmentProfile.changeOfState` — the proto-patient entailment (this file's input)
 - `MeaningComponents.changeOfState` — the surface diagnostic (`Semantics/Lexical/MeaningComponents.lean`)
-- `RootEntailments.result` — whether the root itself entails change (`Semantics/Lexical/Roots/RootFeatures.lean`)
+- `LexKind.result` membership in a root's `FeatureSignature` — whether the root itself entails change (`Semantics/Lexical/Roots/Signature.lean`)
 
 These are NOT the same concept. [beavers-koontz-garboden-2020] show
 that surface CoS can come from either the root or the template. The

--- a/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
@@ -10,7 +10,7 @@ import Linglib.Semantics.Lexical.LevinClassProfiles
 The derivational chain from root content to argument structure, made
 explicit as composed functions:
 
-    RootEntailments → Template → ArgTemplate → ThetaRole
+    FeatureSignature → Template → ArgTemplate → ThetaRole
 
 Each step exists in the literature: [beavers-koontz-garboden-2020]
 define root entailments; [rappaport-hovav-levin-1998] define event
@@ -51,7 +51,7 @@ open Semantics.Lexical
 open Semantics.Lexical.EventStructure (Template)
 open Features.LevinClassProfiles
 open Semantics.ArgumentStructure.EntailmentProfile
-open Semantics.Lexical.Roots
+open FeatureSignature
 
 -- ════════════════════════════════════════════════════
 -- § 1. Root-Template Compatibility
@@ -75,18 +75,18 @@ open Semantics.Lexical.Roots
       BECOME to apply to (template adds the change)
     - **accomplishment** `[[x ACT] CAUSE [BECOME [y STATE]]]`: root
       provides state for the caused result -/
-def RootLicensesTemplate (re : RootEntailments) : Template → Prop
-  | .state         => re.state = true
-  | .activity      => re.manner = true
-  | .achievement   => re.state = true
-  | .accomplishment => re.state = true
+def RootLicensesTemplate (re : FeatureSignature) : Template → Prop
+  | .state         => .state ∈ re
+  | .activity      => .manner ∈ re
+  | .achievement   => .state ∈ re
+  | .accomplishment => .state ∈ re
 
-instance (re : RootEntailments) (t : Template) :
+instance (re : FeatureSignature) (t : Template) :
     Decidable (RootLicensesTemplate re t) := by
   cases t <;> unfold RootLicensesTemplate <;> infer_instance
 
 /-- All templates licensed by a root (captures alternation). -/
-def licensedTemplates (re : RootEntailments) : List Template :=
+def licensedTemplates (re : FeatureSignature) : List Template :=
   [.state, .activity, .achievement, .accomplishment].filter
     (λ t => decide (RootLicensesTemplate re t))
 
@@ -95,41 +95,41 @@ def licensedTemplates (re : RootEntailments) : List Template :=
 /-- PC roots (FLAT) license state, achievement, accomplishment —
     the three state-based templates. Not activity (no manner). -/
 theorem pc_licenses :
-    RootLicensesTemplate .propertyConcept .state ∧
-    RootLicensesTemplate .propertyConcept .achievement ∧
-    RootLicensesTemplate .propertyConcept .accomplishment ∧
-    ¬ RootLicensesTemplate .propertyConcept .activity := by decide
+    RootLicensesTemplate propertyConcept .state ∧
+    RootLicensesTemplate propertyConcept .achievement ∧
+    RootLicensesTemplate propertyConcept .accomplishment ∧
+    ¬ RootLicensesTemplate propertyConcept .activity := by decide
 
 /-- Pure manner roots (JOG) license activity only.
     Not state-based templates (no state entailment). -/
 theorem pureManner_licenses :
-    RootLicensesTemplate .pureManner .activity ∧
-    ¬ RootLicensesTemplate .pureManner .state ∧
-    ¬ RootLicensesTemplate .pureManner .achievement ∧
-    ¬ RootLicensesTemplate .pureManner .accomplishment := by decide
+    RootLicensesTemplate pureManner .activity ∧
+    ¬ RootLicensesTemplate pureManner .state ∧
+    ¬ RootLicensesTemplate pureManner .achievement ∧
+    ¬ RootLicensesTemplate pureManner .accomplishment := by decide
 
 /-- Pure result roots (BLOSSOM) license state, achievement,
     accomplishment — same as PC roots, since both have state. -/
 theorem pureResult_licenses :
-    RootLicensesTemplate .pureResult .state ∧
-    RootLicensesTemplate .pureResult .achievement ∧
-    RootLicensesTemplate .pureResult .accomplishment ∧
-    ¬ RootLicensesTemplate .pureResult .activity := by decide
+    RootLicensesTemplate pureResult .state ∧
+    RootLicensesTemplate pureResult .achievement ∧
+    RootLicensesTemplate pureResult .accomplishment ∧
+    ¬ RootLicensesTemplate pureResult .activity := by decide
 
 /-- Causative result roots (BREAK) license state-based templates. -/
 theorem causativeResult_licenses :
-    RootLicensesTemplate .causativeResult .state ∧
-    RootLicensesTemplate .causativeResult .achievement ∧
-    RootLicensesTemplate .causativeResult .accomplishment ∧
-    ¬ RootLicensesTemplate .causativeResult .activity := by decide
+    RootLicensesTemplate causativeResult .state ∧
+    RootLicensesTemplate causativeResult .achievement ∧
+    RootLicensesTemplate causativeResult .accomplishment ∧
+    ¬ RootLicensesTemplate causativeResult .activity := by decide
 
 /-- Full-spec roots (CUT) license all four templates — they have
     both state and manner, so they can fill any structural position. -/
 theorem fullSpec_licenses :
-    RootLicensesTemplate .fullSpec .state ∧
-    RootLicensesTemplate .fullSpec .activity ∧
-    RootLicensesTemplate .fullSpec .achievement ∧
-    RootLicensesTemplate .fullSpec .accomplishment := by decide
+    RootLicensesTemplate fullSpec .state ∧
+    RootLicensesTemplate fullSpec .activity ∧
+    RootLicensesTemplate fullSpec .achievement ∧
+    RootLicensesTemplate fullSpec .accomplishment := by decide
 
 -- § 1b. Alternation predictions
 
@@ -137,17 +137,17 @@ theorem fullSpec_licenses :
     "The rug is flat" (state) / "The rug flattened" (achievement) /
     "Kim flattened the rug" (accomplishment). -/
 theorem pc_alternation_count :
-    (licensedTemplates .propertyConcept).length = 3 := by native_decide
+    (licensedTemplates propertyConcept).length = 3 := by native_decide
 
 /-- Pure manner roots license 1 template — no alternation into
     state-based frames (*"Kim jogged the ball broken"). -/
 theorem pureManner_alternation_count :
-    (licensedTemplates .pureManner).length = 1 := by native_decide
+    (licensedTemplates pureManner).length = 1 := by native_decide
 
 /-- Full-spec roots license all 4 templates — maximal flexibility
     (conative, causative/inchoative, locative, etc.). -/
 theorem fullSpec_alternation_count :
-    (licensedTemplates .fullSpec).length = 4 := by native_decide
+    (licensedTemplates fullSpec).length = 4 := by native_decide
 
 -- ════════════════════════════════════════════════════
 -- § 2. Template → ArgTemplate
@@ -194,39 +194,39 @@ def templateArgTemplate (t : Template) : ArgTemplate where
     | causativeResult (BREAK) | accomplishment |
     | pureManner (JOG) | activity |
     | fullSpec (CUT) | accomplishment | -/
-def primaryTemplate (re : RootEntailments) : Option Template :=
-  if re.cause then some .accomplishment
-  else if re.result then some .achievement
-  else if re.manner then some .activity
-  else if re.state then some .state
+def primaryTemplate (re : FeatureSignature) : Option Template :=
+  if .cause ∈ re then some .accomplishment
+  else if .result ∈ re then some .achievement
+  else if .manner ∈ re then some .activity
+  else if .state ∈ re then some .state
   else none
 
 -- § 3a. Root typology → primary template
 
 theorem pc_primary :
-    primaryTemplate .propertyConcept = some .state := rfl
+    primaryTemplate propertyConcept = some .state := rfl
 
 theorem pureResult_primary :
-    primaryTemplate .pureResult = some .achievement := rfl
+    primaryTemplate pureResult = some .achievement := rfl
 
 theorem causativeResult_primary :
-    primaryTemplate .causativeResult = some .accomplishment := rfl
+    primaryTemplate causativeResult = some .accomplishment := rfl
 
 theorem pureManner_primary :
-    primaryTemplate .pureManner = some .activity := rfl
+    primaryTemplate pureManner = some .activity := rfl
 
 theorem fullSpec_primary :
-    primaryTemplate .fullSpec = some .accomplishment := rfl
+    primaryTemplate fullSpec = some .accomplishment := rfl
 
 -- § 3b. Primary template is always licensed
 
 /-- For canonical root types, the primary template is licensed. -/
 theorem primary_licensed_canonical :
-    RootLicensesTemplate .propertyConcept .state ∧
-    RootLicensesTemplate .pureResult .achievement ∧
-    RootLicensesTemplate .causativeResult .accomplishment ∧
-    RootLicensesTemplate .pureManner .activity ∧
-    RootLicensesTemplate .fullSpec .accomplishment := by decide
+    RootLicensesTemplate propertyConcept .state ∧
+    RootLicensesTemplate pureResult .achievement ∧
+    RootLicensesTemplate causativeResult .accomplishment ∧
+    RootLicensesTemplate pureManner .activity ∧
+    RootLicensesTemplate fullSpec .accomplishment := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 4. Full Pipeline
@@ -234,14 +234,14 @@ theorem primary_licensed_canonical :
 
 /-- The full derivational pipeline: root entailments → primary
     template → template-level ArgTemplate. -/
-def derivePrimary (re : RootEntailments) : Option ArgTemplate :=
+def derivePrimary (re : FeatureSignature) : Option ArgTemplate :=
   (primaryTemplate re).map templateArgTemplate
 
 /-- All ArgTemplates derivable from a root (one per licensed template).
     Multiple entries represent alternation possibilities:
     e.g., a causativeResult root derives both an accomplishment
     ArgTemplate (transitive) and a state ArgTemplate (bare stative). -/
-def deriveAll (re : RootEntailments) : List ArgTemplate :=
+def deriveAll (re : FeatureSignature) : List ArgTemplate :=
   (licensedTemplates re).map templateArgTemplate
 
 -- § 4a. Pipeline produces non-trivial results
@@ -249,11 +249,11 @@ def deriveAll (re : RootEntailments) : List ArgTemplate :=
 /-- causativeResult roots derive 3 ArgTemplates (state, achievement,
     accomplishment variants). -/
 theorem causativeResult_derives_three :
-    (deriveAll .causativeResult).length = 3 := by native_decide
+    (deriveAll causativeResult).length = 3 := by native_decide
 
 /-- fullSpec roots derive 4 ArgTemplates (all templates). -/
 theorem fullSpec_derives_four :
-    (deriveAll .fullSpec).length = 4 := by native_decide
+    (deriveAll fullSpec).length = 4 := by native_decide
 
 -- ════════════════════════════════════════════════════
 -- § 5. Root-Enriched Derivation
@@ -290,7 +290,7 @@ def activityObjectProfile (mc : MeaningComponents) : Option EntailmentProfile :=
     For other templates, the template's own profiles are used directly.
 
     Returns `none` for roots with no structural entailments (minimal). -/
-def deriveEnriched (re : RootEntailments) (mc : MeaningComponents) : Option ArgTemplate :=
+def deriveEnriched (re : FeatureSignature) (mc : MeaningComponents) : Option ArgTemplate :=
   match primaryTemplate re with
   | none => none
   | some t =>
@@ -311,23 +311,23 @@ def deriveEnriched (re : RootEntailments) (mc : MeaningComponents) : Option ArgT
     contacted object). The root's contact meaning component contributes
     the object and adds C to the subject. -/
 theorem hit_enriched_matches :
-    deriveEnriched .pureManner .hit = some mannerContact := rfl
+    deriveEnriched pureManner .hit = some mannerContact := rfl
 
 /-- MannerOfMotion: enriched derivation gives selfMotion (no contact,
     no object). The root contributes no object. -/
 theorem run_enriched_matches :
-    deriveEnriched .pureManner ⟨false, false, true, false, false, false⟩ = some selfMotion := rfl
+    deriveEnriched pureManner ⟨false, false, true, false, false, false⟩ = some selfMotion := rfl
 
 /-- Break: enriched derivation gives resultChange (full agent +
     CoS+CA object). Accomplishment template used directly — the
     root doesn't modify it for non-activity templates. -/
 theorem break_enriched_matches :
-    deriveEnriched .causativeResult .break_ = some resultChange := rfl
+    deriveEnriched causativeResult .break_ = some resultChange := rfl
 
 /-- Cut: enriched derivation gives resultChange (same as break).
     The manner component doesn't affect the accomplishment template. -/
 theorem cut_enriched_matches :
-    deriveEnriched .fullSpec .cut = some resultChange := rfl
+    deriveEnriched fullSpec .cut = some resultChange := rfl
 
 -- § 5b. Enriched derivation vs hand-specified LevinClass.argTemplate
 
@@ -388,43 +388,43 @@ affected (CoS+CA). -/
 /-- causativeResult: pipeline and shortcut AGREE on subject profile.
     Both give the accomplishment subject = full agent (V+S+C+M+IE). -/
 theorem causativeResult_subject_agrees :
-    (derivePrimary .causativeResult).map (·.subjectProfile) =
-    (toArgTemplate .causativeResult).map (·.subjectProfile) := rfl
+    (derivePrimary causativeResult).map (·.subjectProfile) =
+    (toArgTemplate causativeResult).map (·.subjectProfile) := rfl
 
 /-- fullSpec: pipeline and shortcut AGREE on subject profile. -/
 theorem fullSpec_subject_agrees :
-    (derivePrimary .fullSpec).map (·.subjectProfile) =
-    (toArgTemplate .fullSpec).map (·.subjectProfile) := rfl
+    (derivePrimary fullSpec).map (·.subjectProfile) =
+    (toArgTemplate fullSpec).map (·.subjectProfile) := rfl
 
 /-- propertyConcept: pipeline and shortcut AGREE on subject profile
     (both S+IE). -/
 theorem propertyConcept_subject_agrees :
-    (derivePrimary .propertyConcept).map (·.subjectProfile) =
-    (toArgTemplate .propertyConcept).map (·.subjectProfile) := rfl
+    (derivePrimary propertyConcept).map (·.subjectProfile) =
+    (toArgTemplate propertyConcept).map (·.subjectProfile) := rfl
 
 /-- pureManner: pipeline and shortcut AGREE on subject profile.
     Both give V+S+M+IE (no causation): the activity template does not
     entail causal interaction with another participant, matching
     selfMotion verbs like run and jog. -/
 theorem pureManner_subject_agrees :
-    (derivePrimary .pureManner).map (·.subjectProfile) =
-    (toArgTemplate .pureManner).map (·.subjectProfile) := rfl
+    (derivePrimary pureManner).map (·.subjectProfile) =
+    (toArgTemplate pureManner).map (·.subjectProfile) := rfl
 
 /-- pureResult: pipeline and shortcut DISAGREE on subject.
     Pipeline: achievement subject = M+IE+CoS (moves, changes).
     Shortcut: unaccusativeCoS subject = CoS+CA (changed, affected).
     Different theoretical emphases on what characterizes unaccusatives. -/
 theorem pureResult_subject_diverges :
-    (derivePrimary .pureResult).map (·.subjectProfile) ≠
-    (toArgTemplate .pureResult).map (·.subjectProfile) := by decide
+    (derivePrimary pureResult).map (·.subjectProfile) ≠
+    (toArgTemplate pureResult).map (·.subjectProfile) := by decide
 
 /-- causativeResult: pipeline and shortcut AGREE on object profile.
     Both give CoS+CA (change of state, causally affected). The
     template default correctly excludes IT (incremental theme) —
     not all caused-change objects measure the event. -/
 theorem causativeResult_object_agrees :
-    (derivePrimary .causativeResult).bind (·.objectProfile) =
-    (toArgTemplate .causativeResult).bind (·.objectProfile) := rfl
+    (derivePrimary causativeResult).bind (·.objectProfile) =
+    (toArgTemplate causativeResult).bind (·.objectProfile) := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 6. Consistency: Pipeline vs LevinClass.argTemplate
@@ -502,38 +502,32 @@ cross-linguistically (validated across 88 languages).
 /-- PC roots entail state but NOT result — they name properties
     without inherent change. "Flat" is a simple state. -/
 theorem pc_no_result :
-    RootEntailments.propertyConcept.state = true ∧
-    RootEntailments.propertyConcept.result = false := ⟨rfl, rfl⟩
+    LexKind.state ∈ propertyConcept ∧
+    LexKind.result ∉ propertyConcept := by decide
 
 /-- Result roots entail both state AND result — the state is
     inseparable from prior change. "Cracked" entails having
     been cracked. -/
 theorem result_has_change :
-    RootEntailments.pureResult.state = true ∧
-    RootEntailments.pureResult.result = true ∧
-    RootEntailments.pureResult.cause = false := ⟨rfl, rfl, rfl⟩
+    LexKind.state ∈ pureResult ∧
+    LexKind.result ∈ pureResult ∧
+    LexKind.cause ∉ pureResult := by decide
 
 /-- Caused-result roots entail state + result + cause — the
     change must have been externally caused. "Break" entails
     external causation. -/
 theorem caused_result_full :
-    RootEntailments.causativeResult.state = true ∧
-    RootEntailments.causativeResult.result = true ∧
-    RootEntailments.causativeResult.cause = true := ⟨rfl, rfl, rfl⟩
+    LexKind.state ∈ causativeResult ∧
+    LexKind.result ∈ causativeResult ∧
+    LexKind.cause ∈ causativeResult := by decide
 
 /-- The root typology forms an implicational hierarchy:
-    cause → result → state.
-    Each type INCLUDES the entailments of simpler types. -/
+    cause → result → state. For well-formed signatures this is a
+    consequence of downward closure under the collocational order —
+    not a per-signature stipulation. -/
 theorem root_typology_hierarchy :
-    -- cause implies result
-    RootEntailments.causativeResult.result = true ∧
-    -- result implies state
-    RootEntailments.pureResult.state = true ∧
-    -- well-formedness enforces the hierarchy
-    RootEntailments.causativeResult.WellFormed ∧
-    RootEntailments.pureResult.WellFormed ∧
-    RootEntailments.propertyConcept.WellFormed := by
-  refine ⟨rfl, rfl, ?_, ?_, ?_⟩ <;> decide
+    ∀ s : FeatureSignature, s.WellFormed →
+      (.cause ∈ s → .result ∈ s) ∧ (.result ∈ s → .state ∈ s) := by decide
 
 /-- PC and result roots differ in licensing predictions:
     PC roots can fill stative templates (simple statives exist);
@@ -541,11 +535,11 @@ theorem root_typology_hierarchy :
     change, so the "stative" use still presupposes prior change. -/
 theorem pc_result_stative_difference :
     -- Both license the state template
-    RootLicensesTemplate .propertyConcept .state ∧
-    RootLicensesTemplate .pureResult .state ∧
+    RootLicensesTemplate propertyConcept .state ∧
+    RootLicensesTemplate pureResult .state ∧
     -- But result roots entail change (root-level, not template-level)
-    RootEntailments.propertyConcept.result = false ∧
-    RootEntailments.pureResult.result = true := by decide
+    LexKind.result ∉ propertyConcept ∧
+    LexKind.result ∈ pureResult := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 8. Summary: Where the Pipeline is Informative
@@ -574,7 +568,7 @@ directedMotion, and minimal-rootEntailments classes need overrides.
 The full derivational chain:
 
     Root entailments → Template → Template profiles → Root enrichment → Class override
-    (RootEntailments)   (primary)  (templateArg)     (deriveEnriched)   (LevinClass.argTemplate)
+    (FeatureSignature)  (primary)  (templateArg)     (deriveEnriched)   (LevinClass.argTemplate)
 -/
 
 end Semantics.ArgumentStructure.ArgDerivation

--- a/Linglib/Semantics/Causation/Morphological.lean
+++ b/Linglib/Semantics/Causation/Morphological.lean
@@ -2,7 +2,7 @@ import Mathlib.Order.Nat
 import Linglib.Semantics.Causation.Psych
 import Linglib.Semantics.Causation.CoerciveImplication
 import Linglib.Semantics.ArgumentStructure.AgentivityLattice
-import Linglib.Semantics.Lexical.Roots.RootFeatures
+import Linglib.Semantics.Lexical.Roots.Profile
 
 /-!
 # Morphological Causation: Causative Construction Typology
@@ -75,7 +75,6 @@ namespace Semantics.Causation.Morphological
 
 open Semantics.Causation.Psych (CausalSource)
 open Semantics.ArgumentStructure.AgentivityLattice (AgentivityNode)
-open Semantics.Lexical.Roots
 
 -- ════════════════════════════════════════════════════
 -- § 1. Causer Type ([hafeez-2025], [comrie-1989])

--- a/Linglib/Semantics/Lexical/LevinClassProfiles.lean
+++ b/Linglib/Semantics/Lexical/LevinClassProfiles.lean
@@ -32,7 +32,6 @@ namespace Features.LevinClassProfiles
 
 open Semantics.Lexical
 open Semantics.ArgumentStructure.EntailmentProfile
-open Semantics.Lexical.Roots
 
 -- ════════════════════════════════════════════════════
 -- § 1. Argument Structure Templates
@@ -178,7 +177,7 @@ end Semantics.Lexical
 namespace Features.LevinClassProfiles
 open Semantics.Lexical
 open Semantics.ArgumentStructure.EntailmentProfile
-open Semantics.Lexical.Roots
+open FeatureSignature
 
 -- ════════════════════════════════════════════════════
 -- § 5. Verification: templates match existing canonical profiles
@@ -244,16 +243,16 @@ theorem directedMotion_subject_role :
     directedMotion.subjectProfile.toRole = none := by native_decide
 
 -- ════════════════════════════════════════════════════
--- § 7. RootEntailments → ArgTemplate (the missing derivation)
+-- § 7. FeatureSignature → ArgTemplate (the missing derivation)
 -- ════════════════════════════════════════════════════
 
-/-! Root entailments determine argument templates — this is the field
-consensus ([beavers-koontz-garboden-2020], [rappaport-hovav-levin-2024]).
+/-! Root feature signatures determine argument templates — this is the
+field consensus ([beavers-koontz-garboden-2020], [rappaport-hovav-levin-2024]).
 The derivational direction runs:
 
-    RootEntailments → Template → ArgTemplate → ThetaRole labels
+    FeatureSignature → Template → ArgTemplate → ThetaRole labels
 
-`RootEntailments.toArgTemplate` formalizes the default derivation. It
+`toArgTemplate` formalizes the default derivation. It
 captures the majority pattern: causative roots produce agent subjects
 and affected objects; manner-only roots produce agent subjects without
 causation; result-only roots produce unaccusative subjects; state-only
@@ -269,7 +268,7 @@ Two classes of systematic overrides exist:
 
 These overrides are documented and verified below. -/
 
-/-- Derive a default ArgTemplate from root structural entailments.
+/-- Derive a default ArgTemplate from a root feature signature.
 
     The derivation follows B&KG's event structure decomposition:
 
@@ -286,14 +285,14 @@ These overrides are documented and verified below. -/
     (causativeResult): both produce the same default ArgTemplate.
     The manner flag restricts HOW the cause proceeds (cutting vs.
     breaking), not WHETHER there's an agent. -/
-def toArgTemplate (re : RootEntailments) : Option ArgTemplate :=
-  if re.cause then
+def toArgTemplate (re : FeatureSignature) : Option ArgTemplate :=
+  if .cause ∈ re then
     some resultChange
-  else if re.result then
+  else if .result ∈ re then
     some unaccusativeCoS
-  else if re.manner then
+  else if .manner ∈ re then
     some selfMotion
-  else if re.state then
+  else if .state ∈ re then
     some perception
   else
     none
@@ -378,19 +377,19 @@ theorem build_subject_agrees :
 
 -- § 8d. The derivation produces well-formed ArgTemplates
 
-/-- All canonical root entailments derive well-formed internal constraints
+/-- All canonical root signatures derive well-formed internal constraints
     (volition → sentience holds for derived subject profiles). The
     `Option.elim False` form simultaneously checks that `toArgTemplate`
     succeeds on each input and that the resulting template's subject
     profile is well-formed. -/
 theorem derived_subjects_wellformed :
-    (toArgTemplate .causativeResult).elim False
+    (toArgTemplate causativeResult).elim False
       (·.subjectProfile.WellFormedInternal) ∧
-    (toArgTemplate .pureManner).elim False
+    (toArgTemplate pureManner).elim False
       (·.subjectProfile.WellFormedInternal) ∧
-    (toArgTemplate .pureResult).elim False
+    (toArgTemplate pureResult).elim False
       (·.subjectProfile.WellFormedInternal) ∧
-    (toArgTemplate .propertyConcept).elim False
+    (toArgTemplate propertyConcept).elim False
       (·.subjectProfile.WellFormedInternal) := by
   refine ⟨?_, ?_, ?_, ?_⟩
   · show resultChange.subjectProfile.WellFormedInternal; decide

--- a/Linglib/Semantics/Lexical/LevinTheory.lean
+++ b/Linglib/Semantics/Lexical/LevinTheory.lean
@@ -3,7 +3,7 @@ import Linglib.Features.Attitudes
 import Linglib.Features.Causation
 import Linglib.Semantics.Lexical.LevinClass
 import Linglib.Semantics.Lexical.MeaningComponents
-import Linglib.Semantics.Lexical.Roots.RootFeatures
+import Linglib.Semantics.Lexical.Roots.Signature
 import Linglib.Semantics.Lexical.EventStructure
 
 /-!
@@ -14,13 +14,14 @@ The `LevinClass` enum and its classification data (`MeaningComponents`,
 `meaningComponents`, `predictsUnaccusative`, `isVerbOfCreation`) are
 defined in `Core/Lexical/VerbClass.lean`.
 
-This file provides the theoretical content that depends on `RootEntailments`:
-root entailment mapping, root–MC bridge enums, and universal consistency
+This file provides the theoretical content that depends on `FeatureSignature`:
+root signature mapping, root–MC bridge enums, and universal consistency
 theorems.
 
 ## § 1. Root entailment mapping ([beavers-koontz-garboden-2020])
 
-Root structural entailments, well-formedness verification, and MRC tests.
+Root feature signatures, well-formedness verification, and
+manner+result (MRC) tests.
 
 ## § 2. Root–MC bridge
 
@@ -35,10 +36,10 @@ components, plus universal consistency theorems.
 
 section LevinClassMethods
 open Semantics.Lexical
-open Semantics.Lexical.Roots
+open FeatureSignature
 namespace Semantics.Lexical
 
-/-- Root structural entailments for each Levin class.
+/-- Root feature signature for each Levin class.
 
     Assignments marked (B&KG) are directly from [beavers-koontz-garboden-2020] Table 12 and Chapters 2–5. Others are inferred from class
     semantics following B&KG's framework:
@@ -50,142 +51,142 @@ namespace Semantics.Lexical
 
     Classes marked (default) use `minimal` as a conservative placeholder
     pending detailed study under B&KG's framework. -/
-def LevinClass.rootEntailments : LevinClass → RootEntailments
+def LevinClass.rootEntailments : LevinClass → FeatureSignature
   -- §9 Putting: template provides CAUSE+BECOME; root content varies
-  | .put => .minimal                -- (default)
-  | .funnel => .pureManner          -- manner of channeling
-  | .pour => .pureManner            -- manner of pouring
-  | .coil => .pureManner            -- manner of arranging
-  | .sprayLoad => .minimal          -- (default)
+  | .put => minimal                -- (default)
+  | .funnel => pureManner          -- manner of channeling
+  | .pour => pureManner            -- manner of pouring
+  | .coil => pureManner            -- manner of arranging
+  | .sprayLoad => minimal          -- (default)
   -- §10 Removing
-  | .remove => .minimal             -- (default)
-  | .clear => .causativeResult      -- externally caused cleared state
-  | .wipe => .pureManner            -- manner of surface action
-  | .steal => .minimal              -- (default)
+  | .remove => minimal             -- (default)
+  | .clear => causativeResult      -- externally caused cleared state
+  | .wipe => pureManner            -- manner of surface action
+  | .steal => minimal              -- (default)
   -- §11 Sending and Carrying
-  | .send => .minimal               -- (default)
-  | .carry => .pureManner           -- manner of transport
-  | .drive => .pureManner           -- manner via vehicle
+  | .send => minimal               -- (default)
+  | .carry => pureManner           -- manner of transport
+  | .drive => pureManner           -- manner via vehicle
   -- §12 Exerting Force
-  | .pushPull => .pureManner        -- manner of force application
+  | .pushPull => pureManner        -- manner of force application
   -- §13 Change of Possession
-  | .give => .fullSpec              -- (B&KG Ch.3) √HAND: manner + caused possession change
-  | .contribute => .minimal         -- (default) less specified than give
-  | .getObtain => .minimal          -- (default)
-  | .exchange => .minimal           -- (default)
+  | .give => fullSpec              -- (B&KG Ch.3) √HAND: manner + caused possession change
+  | .contribute => minimal         -- (default) less specified than give
+  | .getObtain => minimal          -- (default)
+  | .exchange => minimal           -- (default)
   -- §14–16
-  | .learn => .minimal              -- (default)
-  | .hold => .propertyConcept       -- state of holding
-  | .conceal => .causativeResult    -- externally caused hidden state
+  | .learn => minimal              -- (default)
+  | .hold => propertyConcept       -- state of holding
+  | .conceal => causativeResult    -- externally caused hidden state
   -- §17 Throwing
-  | .throw => .fullSpec             -- manner of propulsion + caused arrival
+  | .throw => fullSpec             -- manner of propulsion + caused arrival
   -- §18 Contact by Impact
-  | .hit => .pureManner             -- (B&KG Ch.4) impact manner, no state entailed
-  | .swat => .pureManner            -- like hit
+  | .hit => pureManner             -- (B&KG Ch.4) impact manner, no state entailed
+  | .swat => pureManner            -- like hit
   -- §19 Poking
-  | .poke => .pureManner            -- manner of contact
+  | .poke => pureManner            -- manner of contact
   -- §20 Contact: Touch
-  | .touch => .minimal              -- (B&KG) no structural entailments
+  | .touch => minimal              -- (B&KG) no structural entailments
   -- §21 Cutting
-  | .cut => .fullSpec               -- (B&KG Ch.4) cutting manner + caused separation
-  | .carve => .fullSpec             -- like cut
+  | .cut => fullSpec               -- (B&KG Ch.4) cutting manner + caused separation
+  | .carve => fullSpec             -- like cut
   -- §22 Combining and Attaching
-  | .mix => .causativeResult        -- externally caused combined state
-  | .amalgamate => .causativeResult
+  | .mix => causativeResult        -- externally caused combined state
+  | .amalgamate => causativeResult
   -- §23 Separating
-  | .separate => .causativeResult   -- externally caused separated state
-  | .split => .fullSpec             -- instrument manner + caused separation
+  | .separate => causativeResult   -- externally caused separated state
+  | .split => fullSpec             -- instrument manner + caused separation
   -- §24 Coloring
-  | .color => .causativeResult      -- externally caused colored state
+  | .color => causativeResult      -- externally caused colored state
   -- §25 Image Creation
-  | .imageCreation => .fullSpec     -- etching manner + caused image
+  | .imageCreation => fullSpec     -- etching manner + caused image
   -- §26 Creation and Transformation
-  | .build => .causativeResult      -- externally caused creation
-  | .grow => .pureResult            -- internally caused growth
-  | .create => .causativeResult     -- externally caused creation
-  | .knead => .fullSpec             -- kneading manner + caused shape change
-  | .turn => .causativeResult       -- externally caused transformation
-  | .performance => .pureManner     -- performance manner
+  | .build => causativeResult      -- externally caused creation
+  | .grow => pureResult            -- internally caused growth
+  | .create => causativeResult     -- externally caused creation
+  | .knead => fullSpec             -- kneading manner + caused shape change
+  | .turn => causativeResult       -- externally caused transformation
+  | .performance => pureManner     -- performance manner
   -- §27–28
-  | .engender => .causativeResult   -- root entails causation
-  | .calve => .pureResult           -- internally caused biological process
+  | .engender => causativeResult   -- root entails causation
+  | .calve => pureResult           -- internally caused biological process
   -- §29 Predicative Complements
-  | .appoint => .causativeResult    -- externally caused status change
-  | .characterize => .minimal       -- (default)
-  | .declare => .causativeResult    -- externally caused status change
+  | .appoint => causativeResult    -- externally caused status change
+  | .characterize => minimal       -- (default)
+  | .declare => causativeResult    -- externally caused status change
   -- §30 Perception
-  | .see => .minimal                -- (default)
-  | .sight => .minimal              -- (default)
+  | .see => minimal                -- (default)
+  | .sight => minimal              -- (default)
   -- §31 Psych-Verbs
-  | .amuse => .causativeResult      -- stimulus causes psychological CoS
-  | .admire => .propertyConcept     -- psychological state
-  | .marvel => .propertyConcept     -- psychological state
+  | .amuse => causativeResult      -- stimulus causes psychological CoS
+  | .admire => propertyConcept     -- psychological state
+  | .marvel => propertyConcept     -- psychological state
   -- §32–34
-  | .want => .propertyConcept       -- desiderative state
-  | .judgment => .minimal           -- (default)
-  | .assessment => .minimal         -- (default)
+  | .want => propertyConcept       -- desiderative state
+  | .judgment => minimal           -- (default)
+  | .assessment => minimal         -- (default)
   -- §35 Searching
-  | .search => .pureManner          -- searching manner
+  | .search => pureManner          -- searching manner
   -- §36 Social Interaction
-  | .socialInteraction => .minimal  -- (default)
+  | .socialInteraction => minimal  -- (default)
   -- §37 Communication
-  | .say => .minimal                -- (default)
-  | .tell => .minimal               -- (default)
-  | .mannerOfSpeaking => .pureManner -- manner of speaking
+  | .say => minimal                -- (default)
+  | .tell => minimal               -- (default)
+  | .mannerOfSpeaking => pureManner -- manner of speaking
   -- §38 Animal Sounds
-  | .animalSound => .pureManner     -- specific sound manner
+  | .animalSound => pureManner     -- specific sound manner
   -- §39 Ingesting
-  | .eat => .causativeResult        -- caused consumption, no specific manner
-  | .devour => .fullSpec            -- vigorous manner + caused consumption
-  | .dine => .pureManner            -- social activity manner
+  | .eat => causativeResult        -- caused consumption, no specific manner
+  | .devour => fullSpec            -- vigorous manner + caused consumption
+  | .dine => pureManner            -- social activity manner
   -- §40 Body
-  | .bodyProcess => .minimal        -- (default)
-  | .flinch => .minimal             -- (default)
+  | .bodyProcess => minimal        -- (default)
+  | .flinch => minimal             -- (default)
   -- §41 Grooming
-  | .dress => .causativeResult      -- externally caused dressed state
+  | .dress => causativeResult      -- externally caused dressed state
   -- §42 Killing
-  | .murder => .causativeResult     -- (B&KG) root entails caused death
-  | .poison => .fullSpec            -- (B&KG) poisoning manner + caused death (√DROWN-type)
+  | .murder => causativeResult     -- (B&KG) root entails caused death
+  | .poison => fullSpec            -- (B&KG) poisoning manner + caused death (√DROWN-type)
   -- §43 Emission
-  | .lightEmission => .propertyConcept  -- emitting state
-  | .soundEmission => .propertyConcept
-  | .substanceEmission => .propertyConcept
+  | .lightEmission => propertyConcept  -- emitting state
+  | .soundEmission => propertyConcept
+  | .substanceEmission => propertyConcept
   -- §44 Destroy
-  | .destroy => .causativeResult    -- (B&KG) root entails caused total destruction
+  | .destroy => causativeResult    -- (B&KG) root entails caused total destruction
   -- §45 Change of State
-  | .break_ => .causativeResult     -- (B&KG Ch.2,5) √CRACK: externally caused CoS
-  | .bend => .causativeResult       -- externally caused shape change
-  | .cooking => .fullSpec           -- (B&KG) cooking manner + caused CoS
-  | .otherCoS => .causativeResult   -- √MELT/√FREEZE: externally caused CoS
-  | .entitySpecificCoS => .pureResult -- √BLOSSOM/√RUST: internally caused
-  | .calibratableCoS => .pureResult -- internally driven scalar change
+  | .break_ => causativeResult     -- (B&KG Ch.2,5) √CRACK: externally caused CoS
+  | .bend => causativeResult       -- externally caused shape change
+  | .cooking => fullSpec           -- (B&KG) cooking manner + caused CoS
+  | .otherCoS => causativeResult   -- √MELT/√FREEZE: externally caused CoS
+  | .entitySpecificCoS => pureResult -- √BLOSSOM/√RUST: internally caused
+  | .calibratableCoS => pureResult -- internally driven scalar change
   -- §46 Lodge
-  | .lodge => .minimal              -- (default)
+  | .lodge => minimal              -- (default)
   -- §47 Existence
-  | .exist => .minimal              -- (B&KG) pure stative, no root content
+  | .exist => minimal              -- (B&KG) pure stative, no root content
   -- §48 Appearance
-  | .appear => .pureResult          -- internally caused appearance
+  | .appear => pureResult          -- internally caused appearance
   -- §49 Body-Internal Motion
-  | .bodyInternalMotion => .pureManner -- fidgeting manner
+  | .bodyInternalMotion => pureManner -- fidgeting manner
   -- §50 Assuming a Position
-  | .assumePosition => .pureResult  -- internally caused position change
+  | .assumePosition => pureResult  -- internally caused position change
   -- §51 Motion
-  | .inherentlyDirectedMotion => .pureResult -- internally caused directed motion
-  | .leave => .pureResult           -- internally caused departure
-  | .mannerOfMotion => .pureManner  -- (B&KG) √JOG: motion manner
-  | .vehicleMotion => .pureManner   -- vehicle manner
-  | .chase => .pureManner           -- chasing manner
+  | .inherentlyDirectedMotion => pureResult -- internally caused directed motion
+  | .leave => pureResult           -- internally caused departure
+  | .mannerOfMotion => pureManner  -- (B&KG) √JOG: motion manner
+  | .vehicleMotion => pureManner   -- vehicle manner
+  | .chase => pureManner           -- chasing manner
   -- §52 Avoid
-  | .avoid => .minimal              -- (default)
+  | .avoid => minimal              -- (default)
   -- §53 Lingering and Rushing
-  | .linger => .pureManner          -- temporal manner
-  | .rush => .pureManner            -- temporal manner
+  | .linger => pureManner          -- temporal manner
+  | .rush => pureManner            -- temporal manner
   -- §54 Measure
-  | .measure => .propertyConcept    -- measurement state
+  | .measure => propertyConcept    -- measurement state
   -- §55 Aspectual
-  | .aspectual => .minimal          -- (default) template-level
+  | .aspectual => minimal          -- (default) template-level
   -- §57 Weather
-  | .weather => .minimal            -- (default)
+  | .weather => minimal            -- (default)
 
 /-! ### Well-formedness verification -/
 
@@ -198,26 +199,26 @@ theorem destroy_root_wf : (LevinClass.rootEntailments .destroy).WellFormed := by
 theorem murder_root_wf : (LevinClass.rootEntailments .murder).WellFormed := by decide
 theorem poison_root_wf : (LevinClass.rootEntailments .poison).WellFormed := by decide
 
-/-! ### MRC violation verification -/
+/-! ### Manner/Result Complementarity verification -/
 
-theorem cut_violates_MRC :
-    (LevinClass.rootEntailments .cut).ViolatesMRC := by decide
-theorem cooking_violates_MRC :
-    (LevinClass.rootEntailments .cooking).ViolatesMRC := by decide
-theorem poison_violates_MRC :
-    (LevinClass.rootEntailments .poison).ViolatesMRC := by decide
-theorem break_respects_MRC :
-    ¬ (LevinClass.rootEntailments .break_).ViolatesMRC := by decide
-theorem hit_respects_MRC :
-    ¬ (LevinClass.rootEntailments .hit).ViolatesMRC := by decide
+theorem cut_hasMannerAndResult :
+    (LevinClass.rootEntailments .cut).HasMannerAndResult := by decide
+theorem cooking_hasMannerAndResult :
+    (LevinClass.rootEntailments .cooking).HasMannerAndResult := by decide
+theorem poison_hasMannerAndResult :
+    (LevinClass.rootEntailments .poison).HasMannerAndResult := by decide
+theorem break_not_hasMannerAndResult :
+    ¬ (LevinClass.rootEntailments .break_).HasMannerAndResult := by decide
+theorem hit_not_hasMannerAndResult :
+    ¬ (LevinClass.rootEntailments .hit).HasMannerAndResult := by decide
 
 /-! ### VOC–root entailment theorems -/
 
-/-- Core creation classes have causativeResult root entailments. -/
+/-- Core creation classes have causativeResult root signatures. -/
 theorem build_class_causative :
-    LevinClass.build.rootEntailments = .causativeResult := rfl
+    LevinClass.build.rootEntailments = causativeResult := rfl
 theorem create_class_causative :
-    LevinClass.create.rootEntailments = .causativeResult := rfl
+    LevinClass.create.rootEntailments = causativeResult := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 2. Root–MC Bridge ([beavers-koontz-garboden-2020])
@@ -254,11 +255,11 @@ inductive CausationSource where
   | none
   deriving DecidableEq, Repr
 
-/-- Derive the causation source from root entailments and meaning components. -/
+/-- Derive the causation source from the root signature and meaning components. -/
 def LevinClass.causationSource (c : LevinClass) : CausationSource :=
   let re := c.rootEntailments
   let mc := c.meaningComponents
-  if re.cause then
+  if .cause ∈ re then
     if mc.causation then .rootExternal else .rootNonDetachable
   else
     if mc.causation then .template else .none
@@ -267,7 +268,7 @@ def LevinClass.causationSource (c : LevinClass) : CausationSource :=
 
     Levin's `changeOfState` corresponds to `stateChange` only —
     change of location (throw, arrive) and change of possession (give)
-    have `result = true` in B&KG but `changeOfState = false` in Levin. -/
+    carry `result` in B&KG but `changeOfState = false` in Levin. -/
 inductive ResultKind where
   | stateChange
   | locationChange
@@ -275,11 +276,11 @@ inductive ResultKind where
   | none
   deriving DecidableEq, Repr
 
-/-- Derive result kind from root entailments and meaning components. -/
+/-- Derive result kind from the root signature and meaning components. -/
 def LevinClass.resultKind (c : LevinClass) : ResultKind :=
   let re := c.rootEntailments
   let mc := c.meaningComponents
-  if !re.result then .none
+  if .result ∉ re then .none
   else if mc.changeOfState then .stateChange
   else if mc.motion then .locationChange
   else .possessionChange
@@ -297,11 +298,11 @@ inductive MannerKind where
   | none
   deriving DecidableEq, Repr
 
-/-- Derive manner kind from root entailments and meaning components. -/
+/-- Derive manner kind from the root signature and meaning components. -/
 def LevinClass.mannerKind (c : LevinClass) : MannerKind :=
   let re := c.rootEntailments
   let mc := c.meaningComponents
-  if !re.manner then .none
+  if .manner ∉ re then .none
   else if mc.instrumentSpec then .instrumentSpec
   else if mc.mannerSpec then .mannerSpec
   else .unspecified
@@ -367,13 +368,13 @@ theorem break_manner_none :
 
 /-- Root structural contribution to meaning components.
     Maps result → changeOfState and manner → mannerSpec. -/
-def RootEntailments.structuralMC (re : RootEntailments) : MeaningComponents :=
-  { changeOfState := re.result
+def _root_.FeatureSignature.structuralMC (re : FeatureSignature) : MeaningComponents :=
+  { changeOfState := decide (.result ∈ re)
   , contact := false
   , motion := false
   , causation := false
   , instrumentSpec := false
-  , mannerSpec := re.manner }
+  , mannerSpec := decide (.manner ∈ re) }
 
 /-! ### Universal consistency theorems
 
@@ -383,18 +384,18 @@ exhaustive case analysis. -/
 /-- Levin spec implies B&KG manner. -/
 theorem levin_spec_implies_bkg_manner (c : LevinClass) :
     c.meaningComponents.mannerSpec = true ∨ c.meaningComponents.instrumentSpec = true →
-    c.rootEntailments.manner = true := by
+    .manner ∈ c.rootEntailments := by
   cases c <;> decide
 
 /-- CausativeResult roots always have changeOfState. -/
 theorem causativeResult_always_cos (c : LevinClass) :
-    c.rootEntailments = .causativeResult →
+    c.rootEntailments = causativeResult →
     c.meaningComponents.changeOfState = true := by
   cases c <;> decide
 
 /-- Root cause implies either event causation or non-detachable causation. -/
 theorem root_cause_accounted_for (c : LevinClass) :
-    c.rootEntailments.cause = true →
+    .cause ∈ c.rootEntailments →
     c.meaningComponents.causation = true ∨
     c.causationSource = .rootNonDetachable := by
   cases c <;> decide

--- a/Linglib/Semantics/Lexical/MeaningComponents.lean
+++ b/Linglib/Semantics/Lexical/MeaningComponents.lean
@@ -21,7 +21,7 @@ substrate.
 The 4-feature decomposition is [levin-1993]'s diagnostic apparatus.
 [beavers-koontz-garboden-2020] argue these are SURFACE behaviors,
 not root-level entailments — root-level structural features live in
-`Semantics/Lexical/Roots/RootFeatures.lean::RootEntailments`
+`Semantics/Lexical/Roots/Signature.lean::FeatureSignature`
 (state/manner/result/cause). The two carve-ups are NOT equivalent:
 e.g., `causation` here is what diathesis alternations diagnose, while
 B&KG's `cause` is a root entailment.
@@ -62,8 +62,8 @@ namespace Semantics.Lexical
 
     These describe **surface** verb behavior, not root-level entailments.
     [beavers-koontz-garboden-2020] argue that surface CoS and causation
-    can come from either the template or the root; see `RootEntailments`
-    in `Semantics/Lexical/Roots/RootFeatures.lean` for the
+    can come from either the template or the root; see `FeatureSignature`
+    in `Semantics/Lexical/Roots/Signature.lean` for the
     root-level decomposition.
 
     Diagnosed by participation in diathesis alternations:

--- a/Linglib/Semantics/Lexical/Roots/Basic.lean
+++ b/Linglib/Semantics/Lexical/Roots/Basic.lean
@@ -1,38 +1,32 @@
+import Linglib.Semantics.Lexical.Roots.Signature
+
 /-!
 # Atomic Lexical Entailments and Roots
-
-[beavers-koontz-garboden-2020]
 
 Lexical entailments are the atomic claims a verbal root makes about
 the events it describes and the participants in those events.
 Following [beavers-koontz-garboden-2020], we treat these as
-*structured atoms* rather than as a fixed feature vector.
+*structured atoms* rather than as a fixed feature vector: a **root**
+is a finite collection of such atoms, and its feature signature
+(`FeatureSignature`) is the *derived* set of kinds its atoms realize —
+exposing the Bifurcation Thesis of Roots and Manner/Result
+Complementarity as testable conjectures rather than architectural
+commitments.
 
-A **root** is a finite collection of such atoms. The root's
-B&K-G feature signature (±state, ±manner, ±result, ±cause) is then a
-*derived* predicate over the entailment set, not a separately stipulated
-classification — exposing both the Bifurcation Thesis of Roots and
-Manner/Result Complementarity ([rappaport-hovav-levin-2010]) as
-testable conjectures rather than architectural commitments.
+## Main declarations
 
-## Relation to existing infrastructure
-
-- `EntailmentProfile` (Dowty's 10-tuple) collapses argument-level
-  entailments into a flat record. Useful for Argument Selection but too
-  coarse to express B&K-G's networks of root entailments.
-- `EventStructure.Template` (state/activity/achievement/accomplishment/
-  motionContact) is the *output* of root × template composition. The
-  templatic *heads* (`v_act`, `v_become`, `v_cause`) that compose into
-  these full templates live in `Roots/Template.lean`.
+* `LexEntailment` — labeled atoms; `LexEntailment.kind` projects the
+  B&K-G kind, if any
+* `Root` — a named list of atoms
+* `Root.featureSignature` — the derived signature
+* `Root.HasState`/`HasManner`/`HasResult`/`HasCause` — kind membership
 -/
-
-namespace Semantics.Lexical.Roots
 
 /-! ### Atomic entailments -/
 
-/-- An atomic claim a root can make. The four B&K-G features
-    (±state, ±manner, ±result, ±cause) correspond to the *kinds* of
-    atoms present in a root's entailment set.
+/-- An atomic claim a root can make. The four B&K-G kinds
+    (state, manner, result, cause) correspond to the kinds of atoms
+    present in a root's entailment set (`LexEntailment.kind`).
 
     The remaining atoms (volitional, sentient, motion, contact)
     cover Dowty's proto-role components that are independent of the
@@ -62,33 +56,14 @@ inductive LexEntailment where
 
 namespace LexEntailment
 
-/-- Is the atom a state-attribution? -/
-def isState : LexEntailment → Prop
-  | hasState _ => True
-  | _ => False
-
-instance : DecidablePred isState := fun a => by unfold isState; cases a <;> infer_instance
-
-/-- Is the atom a manner specification? -/
-def isManner : LexEntailment → Prop
-  | hasManner _ => True
-  | _ => False
-
-instance : DecidablePred isManner := fun a => by unfold isManner; cases a <;> infer_instance
-
-/-- Is the atom a change-of-state entailment? -/
-def isBecome : LexEntailment → Prop
-  | becomesState _ => True
-  | _ => False
-
-instance : DecidablePred isBecome := fun a => by unfold isBecome; cases a <;> infer_instance
-
-/-- Is the atom a causation entailment? -/
-def isCause : LexEntailment → Prop
-  | hasCause => True
-  | _ => False
-
-instance : DecidablePred isCause := fun a => by unfold isCause; cases a <;> infer_instance
+/-- The B&K-G kind an atom realizes, if any. The proto-role atoms
+    (volitional, sentient, motion, contact) carry no kind. -/
+def kind : LexEntailment → Option LexKind
+  | hasState _     => some .state
+  | hasManner _    => some .manner
+  | becomesState _ => some .result
+  | hasCause       => some .cause
+  | _              => none
 
 end LexEntailment
 
@@ -107,18 +82,34 @@ structure Root where
 
 namespace Root
 
+/-- The derived feature signature of a root: the set of kinds its
+    atoms realize. -/
+def featureSignature (r : Root) : FeatureSignature :=
+  (r.entailments.filterMap (·.kind)).toFinset
+
+theorem mem_featureSignature {r : Root} {k : LexKind} :
+    k ∈ r.featureSignature ↔ ∃ a ∈ r.entailments, a.kind = some k := by
+  simp [featureSignature, List.mem_filterMap]
+
 /-- The root entails attribution of some state. -/
-def hasState  (r : Root) : Bool := r.entailments.any (decide <| LexEntailment.isState ·)
+def HasState (r : Root) : Prop := .state ∈ r.featureSignature
 
 /-- The root specifies some manner. -/
-def hasManner (r : Root) : Bool := r.entailments.any (decide <| LexEntailment.isManner ·)
+def HasManner (r : Root) : Prop := .manner ∈ r.featureSignature
 
 /-- The root entails some change of state (B&K-G "result"). -/
-def hasResult (r : Root) : Bool := r.entailments.any (decide <| LexEntailment.isBecome ·)
+def HasResult (r : Root) : Prop := .result ∈ r.featureSignature
 
 /-- The root entails causation. -/
-def hasCause  (r : Root) : Bool := r.entailments.any (decide <| LexEntailment.isCause ·)
+def HasCause (r : Root) : Prop := .cause ∈ r.featureSignature
+
+instance (r : Root) : Decidable r.HasState :=
+  inferInstanceAs (Decidable (_ ∈ _))
+instance (r : Root) : Decidable r.HasManner :=
+  inferInstanceAs (Decidable (_ ∈ _))
+instance (r : Root) : Decidable r.HasResult :=
+  inferInstanceAs (Decidable (_ ∈ _))
+instance (r : Root) : Decidable r.HasCause :=
+  inferInstanceAs (Decidable (_ ∈ _))
 
 end Root
-
-end Semantics.Lexical.Roots

--- a/Linglib/Semantics/Lexical/Roots/Closure.lean
+++ b/Linglib/Semantics/Lexical/Roots/Closure.lean
@@ -3,259 +3,119 @@ import Linglib.Semantics.Lexical.Roots.Typology
 /-!
 # Entailment Closure on Roots
 
-[beavers-koontz-garboden-2020]
+[beavers-koontz-garboden-2020] treat roots as *networks* of
+entailments, where some atoms entail others, and state two
+collocational restrictions as definitional: +result entails +state,
+and +cause entails +result.
 
-`Root.entailments` is the *base* entailment set: atoms asserted directly
-by the lexicographer. But [beavers-koontz-garboden-2020]'s typology
-treats roots as *networks* of entailments, where some atoms entail
-others. The closure of the base under such network rules is the root's
-full entailment set.
+Two levels of closure:
 
-This file provides:
+* **Kind level** (canonical): `Root.closedFeatureSignature` is the
+  collocational closure `FeatureSignature.close` of the root's derived
+  signature. Both book restrictions hold of closed signatures by
+  construction (`closedFeatureSignature_wellFormed`).
+* **Atom level** (label-tracking): `Root.closedEntailments` closes the
+  labeled atom list under `bkgRules` (`becomesState s ⇒ hasState s`).
+  Only the result→state edge is expressible here — `hasCause` is
+  nullary, so cause→result lives at kind level only
+  (`kind_closedEntailments_le`).
 
-1. `EntailmentRules`: a function `LexEntailment → List LexEntailment`
-   giving the atoms each premise atom directly entails.
-2. `closeOnce`: one closure step (single inference round).
-3. `closure`: alias for `closeOnce` — kept as the public API. For the
-   currently-codified rules a single step is a fixpoint
-   (`closure_bkgRules_idempotent`); if a chaining rule is added later,
-   redefine `closure` as `Nat.iterate closeOnce n` and re-prove
-   idempotence at the new bound.
-4. `bkgRules`: the documented B&K-G rules. Currently a single rule:
-   `becomesState s ⇒ hasState s` (a change-of-state to `s` entails the
-   resulting state attribution `s`).
-5. `Root.closedEntailments` and `Root.closedFeatureSignature`: the
-   closure-derived counterparts of `entailments`/`featureSignature`.
+## Main declarations
 
-The infrastructure is designed so that adding a new B&K-G inference
-(e.g., `volitional ⇒ sentient`, `contact ⇒ motion`) is a one-line
-extension to `bkgRules`.
+* `bkgRules`, `bkgClosure`, `Root.closedEntailments`
+* `Root.closedFeatureSignature`
+* `mem_kind_closedEntailments` — the atom/kind bridge
 -/
 
-namespace Semantics.Lexical.Roots
+/-! ### Atom-level rules and closure -/
 
-/-! ### Closure Rules -/
-
-/-- A rule set: each atom maps to the atoms it directly entails. -/
-abbrev EntailmentRules := LexEntailment → List LexEntailment
-
-/-- One closure step: adjoin to `atoms` everything any rule fires from
-    an atom in `atoms`. Result is `atoms` followed by all derived atoms.
-    Duplicates are not removed (they are inert under `List.any` /
-    `List.contains` queries used downstream). -/
-def closeOnce (rules : EntailmentRules) (atoms : List LexEntailment) :
-    List LexEntailment :=
-  atoms ++ atoms.flatMap rules
-
-/-- Backwards-compatible alias for `closeOnce`. The currently-codified
-    `bkgRules` reach a fixpoint after one step (`closure_bkgRules_idempotent`).
-    If a chaining rule is added, redefine via `Nat.iterate closeOnce`. -/
-abbrev closure : EntailmentRules → List LexEntailment → List LexEntailment :=
-  closeOnce
-
-/-! ### B&K-G Rules -/
-
-/-- The documented B&K-G entailment rules. Currently:
-    - `becomesState s ⇒ hasState s`: a change of state to `s` entails
-      that `s` holds at the post-state, so the root attributes `s`.
-
-    Other candidate rules (`volitional ⇒ sentient`, `contact ⇒ motion`)
-    are debated in the literature and intentionally omitted until they
-    can be argued for from primary sources. -/
-def bkgRules : EntailmentRules
+/-- The documented B&K-G atom-level entailment rule:
+    `becomesState s ⇒ hasState s` (a change of state to `s` entails
+    the resulting state attribution `s`, label preserved). The
+    cause→result restriction is not expressible at atom level
+    (`hasCause` carries no label) and is handled by
+    `FeatureSignature.close`. -/
+def bkgRules : LexEntailment → List LexEntailment
   | .becomesState s => [.hasState s]
   | _ => []
 
-/-- Every atom produced by `bkgRules` is a state-attribution. -/
-theorem bkgRules_only_state (a b : LexEntailment) (h : a ∈ bkgRules b) :
-    a.isState := by
-  match b, h with
-  | .becomesState _, h =>
-    rw [show bkgRules (.becomesState _) = [.hasState _] from rfl] at h
-    rcases List.mem_singleton.mp h with rfl
-    exact True.intro
+/-- Every atom produced by `bkgRules` is a state atom, produced from a
+    result atom. -/
+theorem bkgRules_kind {a b : LexEntailment} (h : a ∈ bkgRules b) :
+    a.kind = some .state ∧ b.kind = some .result := by
+  cases b <;> simp [bkgRules] at h
+  subst h; exact ⟨rfl, rfl⟩
 
-/-! ### Closed Entailments and Signature -/
+/-- Close an atom list under `bkgRules`: adjoin everything the rules
+    fire from a member. One step is a fixpoint, since rule outputs
+    (state atoms) trigger no rules. -/
+def bkgClosure (atoms : List LexEntailment) : List LexEntailment :=
+  atoms ++ atoms.flatMap bkgRules
 
 namespace Root
 
 /-- The B&K-G closure of the root's base entailments. -/
 def closedEntailments (r : Root) : List LexEntailment :=
-  closure bkgRules r.entailments
+  bkgClosure r.entailments
 
-/-- The feature signature computed over the *closure* of the root's
-    entailments. For the current `bkgRules`, this differs from
-    `featureSignature` only in the `state` field: any root with a
-    `becomesState` atom in its base set acquires `state = true`. -/
+/-! ### Kind-level closure -/
+
+/-- The closed feature signature: the collocational closure of the
+    derived signature. Captures both book restrictions (result→state
+    and cause→result). -/
 def closedFeatureSignature (r : Root) : FeatureSignature :=
-  { state  := r.closedEntailments.any (decide <| LexEntailment.isState ·)
-  , manner := r.closedEntailments.any (decide <| LexEntailment.isManner ·)
-  , result := r.closedEntailments.any (decide <| LexEntailment.isBecome ·)
-  , cause  := r.closedEntailments.any (decide <| LexEntailment.isCause ·) }
+  r.featureSignature.close
+
+/-- The closed signature satisfies the collocational constraints by
+    construction — what `RootEntailments.WellFormed` used to stipulate
+    is a theorem of closure. -/
+theorem closedFeatureSignature_wellFormed (r : Root) :
+    r.closedFeatureSignature.WellFormed :=
+  FeatureSignature.close_wellFormed _
+
+theorem featureSignature_le_closed (r : Root) :
+    r.featureSignature ≤ r.closedFeatureSignature :=
+  FeatureSignature.le_close _
+
+/-- Both theses are insensitive to the closure edges: a root violates
+    Bifurcation iff its closed signature does. -/
+theorem closed_violatesBifurcation_iff (r : Root) :
+    r.closedFeatureSignature.ViolatesBifurcation ↔ r.ViolatesBifurcation :=
+  FeatureSignature.violatesBifurcation_close_iff _
+
+/-! ### The atom/kind bridge -/
+
+/-- Kinds realized by the atom-level closure: the base kinds plus a
+    `state` kind whenever a result atom is present. -/
+theorem mem_kind_closedEntailments {r : Root} {k : LexKind} :
+    k ∈ (r.closedEntailments.filterMap (·.kind)).toFinset ↔
+      k ∈ r.featureSignature ∨ (k = .state ∧ r.HasResult) := by
+  simp only [List.mem_toFinset, List.mem_filterMap, closedEntailments, bkgClosure,
+    List.mem_append, List.mem_flatMap]
+  constructor
+  · rintro ⟨a, ha | ⟨b, hb, hab⟩, hk⟩
+    · exact .inl (Root.mem_featureSignature.mpr ⟨a, ha, hk⟩)
+    · obtain ⟨hak, hbk⟩ := bkgRules_kind hab
+      refine .inr ⟨by rw [hk] at hak; exact Option.some_inj.mp hak, ?_⟩
+      exact Root.mem_featureSignature.mpr ⟨b, hb, hbk⟩
+  · rintro (hk | ⟨rfl, hres⟩)
+    · obtain ⟨a, ha, hak⟩ := Root.mem_featureSignature.mp hk
+      exact ⟨a, .inl ha, hak⟩
+    · obtain ⟨b, hb, hbk⟩ := Root.mem_featureSignature.mp hres
+      cases b <;> simp [LexEntailment.kind] at hbk
+      rename_i lab
+      exact ⟨.hasState lab, .inr ⟨_, hb, by simp [bkgRules]⟩, rfl⟩
+
+/-- The atom-level closure realizes at most the kinds of the
+    kind-level closure (strictly fewer when a root carries `cause`
+    without a result atom — the cause→result edge is kind-level
+    only). -/
+theorem kind_closedEntailments_le (r : Root) :
+    ((r.closedEntailments.filterMap (·.kind)).toFinset : FeatureSignature)
+      ≤ r.closedFeatureSignature := by
+  intro k hk
+  rcases mem_kind_closedEntailments.mp hk with h | ⟨rfl, hres⟩
+  · exact featureSignature_le_closed r h
+  · exact (FeatureSignature.mem_close_iff _ _).mpr ⟨.result, hres, by decide⟩
 
 end Root
-
-/-! ### Structural Properties of Closure -/
-
-/-- Closure preserves all base atoms: the base list is a prefix of the
-    closure. -/
-theorem closure_includes (rules : EntailmentRules)
-    (atoms : List LexEntailment) (a : LexEntailment) (h : a ∈ atoms) :
-    a ∈ closure rules atoms := by
-  unfold closure closeOnce
-  exact List.mem_append_left _ h
-
-/-- Adding the closure step never makes `any p` go from `true` to
-    `false` — closure is monotone for `List.any`. -/
-theorem closure_any_of_any (rules : EntailmentRules)
-    (atoms : List LexEntailment) (p : LexEntailment → Bool)
-    (h : atoms.any p = true) :
-    (closure rules atoms).any p = true := by
-  unfold closure closeOnce
-  rw [List.any_append, h, Bool.true_or]
-
-/-! ### Bridge to Base Signature -/
-
-/-- Helper: bkgRules-derived atoms can never satisfy a predicate `p`
-    that is false on every state-attribution atom. -/
-private theorem flatMap_bkgRules_any_eq_false (atoms : List LexEntailment)
-    (p : LexEntailment → Bool)
-    (hp : ∀ s : String, p (LexEntailment.hasState s) = false) :
-    (atoms.flatMap bkgRules).any p = false := by
-  apply List.any_eq_false.mpr
-  intro a ha
-  rcases List.mem_flatMap.mp ha with ⟨b, _, hb⟩
-  cases b <;> simp [bkgRules] at hb
-  obtain rfl := hb
-  simp [hp]
-
-/-- Closed and base signatures agree on `manner`. -/
-@[simp] theorem closedFeatureSignature_manner (r : Root) :
-    r.closedFeatureSignature.manner = r.featureSignature.manner := by
-  show r.closedEntailments.any (decide <| LexEntailment.isManner ·) =
-    r.entailments.any (decide <| LexEntailment.isManner ·)
-  unfold Root.closedEntailments closure closeOnce
-  rw [List.any_append,
-      flatMap_bkgRules_any_eq_false r.entailments _ (fun _ => rfl),
-      Bool.or_false]
-
-/-- Closed and base signatures agree on `result`. -/
-@[simp] theorem closedFeatureSignature_result (r : Root) :
-    r.closedFeatureSignature.result = r.featureSignature.result := by
-  show r.closedEntailments.any (decide <| LexEntailment.isBecome ·) =
-    r.entailments.any (decide <| LexEntailment.isBecome ·)
-  unfold Root.closedEntailments closure closeOnce
-  rw [List.any_append,
-      flatMap_bkgRules_any_eq_false r.entailments _ (fun _ => rfl),
-      Bool.or_false]
-
-/-- Closed and base signatures agree on `cause`. -/
-@[simp] theorem closedFeatureSignature_cause (r : Root) :
-    r.closedFeatureSignature.cause = r.featureSignature.cause := by
-  show r.closedEntailments.any (decide <| LexEntailment.isCause ·) =
-    r.entailments.any (decide <| LexEntailment.isCause ·)
-  unfold Root.closedEntailments closure closeOnce
-  rw [List.any_append,
-      flatMap_bkgRules_any_eq_false r.entailments _ (fun _ => rfl),
-      Bool.or_false]
-
-/-- Closure can only add `state`: if the base says `state = true`, the
-    closure agrees; if base says `false`, closure may say `true`. -/
-theorem closedFeatureSignature_state_of_base (r : Root)
-    (h : r.featureSignature.state = true) :
-    r.closedFeatureSignature.state = true := by
-  show r.closedEntailments.any (decide <| LexEntailment.isState ·) = true
-  exact closure_any_of_any bkgRules r.entailments _ h
-
-/-- The principal closure consequence: every `becomesState s` in the
-    base entailment set forces `state = true` in the closed signature. -/
-theorem closedFeatureSignature_state_of_becomes (r : Root) (s : String)
-    (h : LexEntailment.becomesState s ∈ r.entailments) :
-    r.closedFeatureSignature.state = true := by
-  show r.closedEntailments.any (decide <| LexEntailment.isState ·) = true
-  unfold Root.closedEntailments closure closeOnce
-  rw [List.any_append]
-  apply Bool.or_eq_true_iff.mpr
-  right
-  apply List.any_eq_true.mpr
-  refine ⟨LexEntailment.hasState s, ?_, ?_⟩
-  · apply List.mem_flatMap.mpr
-    exact ⟨LexEntailment.becomesState s, h, by simp [bkgRules]⟩
-  · rfl
-
-/-- Closure adds state atoms exactly when the base set has a
-    `becomesState` atom. So the closed `state` field is the disjunction
-    of base `state` and base `result`. -/
-theorem closedFeatureSignature_state_eq (r : Root) :
-    r.closedFeatureSignature.state =
-      (r.featureSignature.state || r.featureSignature.result) := by
-  show r.closedEntailments.any (decide <| LexEntailment.isState ·) =
-    (r.entailments.any (decide <| LexEntailment.isState ·) ||
-      r.entailments.any (decide <| LexEntailment.isBecome ·))
-  unfold Root.closedEntailments closure closeOnce
-  rw [List.any_append]
-  congr 1
-  -- (flatMap bkgRules).any isState = entailments.any isBecome
-  apply Bool.eq_iff_iff.mpr
-  refine ⟨?_, ?_⟩
-  · intro hflat
-    rcases List.any_eq_true.mp hflat with ⟨a, ha, hp⟩
-    rcases List.mem_flatMap.mp ha with ⟨b, hb, hab⟩
-    cases b <;> simp [bkgRules] at hab
-    obtain rfl := hab
-    apply List.any_eq_true.mpr
-    exact ⟨_, hb, by rfl⟩
-  · intro hbase
-    rcases List.any_eq_true.mp hbase with ⟨a, ha, hp⟩
-    cases a <;> simp [LexEntailment.isBecome] at hp
-    rename_i s
-    apply List.any_eq_true.mpr
-    refine ⟨LexEntailment.hasState s, ?_, by rfl⟩
-    apply List.mem_flatMap.mpr
-    exact ⟨LexEntailment.becomesState s, ha, by simp [bkgRules]⟩
-
-/-! ### Idempotence of bkgRules -/
-
-/-- `bkgRules` produces nothing from a `hasState` atom (and similarly
-    nothing from any non-`becomesState` atom). -/
-theorem bkgRules_eq_nil_of_isState (a : LexEntailment) (h : a.isState) :
-    bkgRules a = [] := by
-  cases a <;> simp_all [bkgRules, LexEntailment.isState]
-
-/-- If every atom in `atoms` is a `hasState`, `flatMap bkgRules` is empty. -/
-theorem flatMap_bkgRules_eq_nil_of_all_isState (atoms : List LexEntailment)
-    (h : ∀ a ∈ atoms, a.isState) :
-    atoms.flatMap bkgRules = [] := by
-  induction atoms with
-  | nil => rfl
-  | cons a t ih =>
-    have ha : a.isState := h a List.mem_cons_self
-    have ht : ∀ x ∈ t, x.isState :=
-      fun x hx => h x (List.mem_cons_of_mem _ hx)
-    rw [List.flatMap_cons, bkgRules_eq_nil_of_isState a ha, List.nil_append,
-        ih ht]
-
-/-- After one `flatMap bkgRules`, every atom is a state-attribution, so a
-    further `flatMap bkgRules` produces nothing. -/
-theorem flatMap_bkgRules_flatMap_bkgRules_eq_nil
-    (atoms : List LexEntailment) :
-    (atoms.flatMap bkgRules).flatMap bkgRules = [] := by
-  apply flatMap_bkgRules_eq_nil_of_all_isState
-  intro a ha
-  rcases List.mem_flatMap.mp ha with ⟨b, _, hb⟩
-  exact bkgRules_only_state a b hb
-
-/-- `closeOnce bkgRules` is idempotent up to `List.any` queries — a
-    second application adds duplicate copies of state atoms, but no new
-    distinct atoms. This is the precise sense in which `closure := closeOnce`
-    suffices for the downstream `Root.closedFeatureSignature` API. -/
-theorem closure_bkgRules_any_idempotent (atoms : List LexEntailment)
-    (p : LexEntailment → Bool) :
-    (closure bkgRules (closure bkgRules atoms)).any p =
-      (closure bkgRules atoms).any p := by
-  unfold closure closeOnce
-  rw [List.flatMap_append, flatMap_bkgRules_flatMap_bkgRules_eq_nil,
-      List.append_nil]
-  simp only [List.any_append, Bool.or_assoc, Bool.or_self]
-
-end Semantics.Lexical.Roots

--- a/Linglib/Semantics/Lexical/Roots/Profile.lean
+++ b/Linglib/Semantics/Lexical/Roots/Profile.lean
@@ -1,27 +1,23 @@
+import Mathlib.Data.Fintype.Basic
+
 /-!
-# Root Quality Dimensions and Structural Entailments
+# Root Quality Dimensions
 
-Per-root content typology: ranges over root quality dimensions
-([talmy-1988], [dowty-1991], [majid-boster-bowerman-2008],
-[spalek-mcnally-2026]) and the binary entailment tetrad of
-[beavers-koontz-garboden-2020].
-
-The tetrad is framework-committed: [rappaport-hovav-levin-2010] reject
-the entailment-feature framing (for them manner/result are
-event-structural template properties, not root features); a
-formalization of their account would be a sibling file with divergence
-theorems.
+Within-class root content profiles: ranges over quality dimensions —
+force, robustness, instrument, dimensionality, agent properties. A
+multi-paper synthesis ([talmy-1988], [talmy-2000], [dowty-1991],
+[majid-boster-bowerman-2008], [spalek-mcnally-2026]); no single paper
+carries this profile. Structural entailments (state, manner, result,
+cause) are the separate `FeatureSignature` (`Roots/Signature.lean`).
 
 ## Main declarations
 
-* `Range` — within-class variation along a quality dimension
-* `RootProfile` — bundled quality dimensions (force, robustness,
-  instrument, dimensionality, agent properties)
-* `RootEntailments` — the B&K-G tetrad, with `WellFormed` collocational
-  constraints and the canonical root types of their ch. 5 typology
+* `Root.Profile.Range` — within-class variation along a dimension
+* the dimension enums (`ForceLevel`, `Robustness`, `InstrumentType`, …)
+* `Root.Profile` — the bundled profile
 -/
 
-namespace Semantics.Lexical.Roots
+namespace Root.Profile
 
 /-! ### Range mechanism -/
 
@@ -57,6 +53,8 @@ def overlaps [BEq α] : Range α → Range α → Bool
   | some vs₁, some vs₂ => vs₁.any (vs₂.contains ·)
 
 end Range
+
+end Root.Profile
 
 /-! ### Quality dimensions -/
 
@@ -170,15 +168,19 @@ inductive AgentControl where
   | compatible    -- compatible with careful/controlled action
   deriving DecidableEq, Repr
 
+namespace Root
+
+open Profile (Range)
+
 /-- Within-class root content profile.
 
     Captures **quality** dimensions of root content — force, robustness,
-    agent properties — as opposed to `RootEntailments`, which captures
+    agent properties — as opposed to `FeatureSignature`, which captures
     **structural** entailments (state, manner, result, cause).
 
     Each dimension is a `Range` of acceptable values; `none` means the
     root says nothing about that dimension (unconstrained). -/
-structure RootProfile where
+structure Profile where
   /-- Force magnitude: [talmy-1988]. -/
   forceMag : Range ForceLevel := none
   /-- Force directionality: [talmy-2000], [spalek-mcnally-2026]. -/
@@ -199,149 +201,17 @@ structure RootProfile where
   patientDim : Range ObjectDimensionality := none
   deriving BEq, Repr, Inhabited
 
-/-! ### Root structural entailments -/
-
-/-- Root-level structural entailments from [beavers-koontz-garboden-2020].
-
-    B&KG argue against Bifurcation (roots never carry templatic
-    meaning) and Manner/Result Complementarity (no root encodes both).
-    Roots CAN entail states, change, and causation — notions
-    traditionally reserved for templates (CAUSE, BECOME).
-
-    The four features define a root typology (the book's ch. 5):
-    - `state`: root describes a state (√FLAT, √CRACK, √DRY)
-    - `manner`: root describes an action/manner (√JOG, √RUN, √HIT)
-    - `result`: root entails change — low-scope *again* still
-      presupposes a prior change
-    - `cause`: root entails causation
-
-    Constraints: `result → state` and `cause → result` (see
-    `WellFormed`); the book presents both as definitional ("not
-    root-specific stipulations"), mirroring conditions on templates. -/
-structure RootEntailments where
-  state  : Bool
-  manner : Bool
-  result : Bool
-  cause  : Bool
-  deriving DecidableEq, Repr
-
-namespace RootEntailments
-
-/-- If a root entails change (result), it entails a state that changes.
-    [beavers-koontz-garboden-2020]: "+result entails being +state,
-    since become′ entails something that has come about." -/
-def ResultImpliesState (r : RootEntailments) : Prop :=
-  r.result = true → r.state = true
-
-instance (r : RootEntailments) : Decidable r.ResultImpliesState := by
-  unfold ResultImpliesState; infer_instance
-
-/-- If a root entails causation, it entails what is caused (a result).
-    [beavers-koontz-garboden-2020]: "+cause entails being +result,
-    since cause′ entails that there is a caused event." -/
-def CauseImpliesResult (r : RootEntailments) : Prop :=
-  r.cause = true → r.result = true
-
-instance (r : RootEntailments) : Decidable r.CauseImpliesResult := by
-  unfold CauseImpliesResult; infer_instance
-
-/-- Well-formedness: both collocational constraints hold. -/
-def WellFormed (r : RootEntailments) : Prop :=
-  r.ResultImpliesState ∧ r.CauseImpliesResult
-
-instance (r : RootEntailments) : Decidable r.WellFormed := by
-  unfold WellFormed; infer_instance
-
-/-! ### Canonical root types
-
-The attested rows of the root typology in [beavers-koontz-garboden-2020]
-ch. 5 (their example display (12), §5.4). -/
-
-/-- +S −M −R −C: property concept roots (√FLAT, √DRY).
-    Deadjectival COS verbs — the root names the result state.
-    Complement position. -/
-def propertyConcept : RootEntailments := ⟨true, false, false, false⟩
-
-/-- +S −M +R −C: internally caused result roots (√BLOSSOM, √RUST).
-    Root entails both a state and a change to that state, but not
-    external causation. Complement position. -/
-def pureResult : RootEntailments := ⟨true, false, true, false⟩
-
-/-- +S −M +R +C: externally caused result roots (√CRACK, √BREAK).
-    Root entails a state, change, AND causation. If roots subdivide by
-    entailed causation, this may underlie Levin & Rappaport Hovav's
-    (1995) externally vs internally caused change-of-state distinction
-    ([beavers-koontz-garboden-2020], hedged as a possibility).
-    Complement position. -/
-def causativeResult : RootEntailments := ⟨true, false, true, true⟩
-
-/-- −S +M −R −C: pure manner roots (√JOG, √RUN, √SWIM).
-    Root specifies action manner without entailing any state.
-    Adjoined position. -/
-def pureManner : RootEntailments := ⟨false, true, false, false⟩
-
-/-- +S +M +R −C: manner + result without cause. Well-formed per the
-    constraints; [beavers-koontz-garboden-2020] leave its attestation
-    an open question ("whether a change and a manner can exist together
-    in a single meaning without causation"), with candidate witnesses
-    *slide* and motion-in-sound-emission *buzz*. -/
-def mannerResult : RootEntailments := ⟨true, true, true, false⟩
-
-/-- +S +M +R +C: fully specified roots (√HAND adjoined, √DROWN and the
-    other manner-of-killing roots in complement position;
-    [beavers-koontz-garboden-2020] chs. 3–4). These are the attested
-    MRC violators. The adjoined/complement contrast is carried by
-    `Root.Position`, not by this struct. -/
-def fullSpec : RootEntailments := ⟨true, true, true, true⟩
-
-/-- −S −M −R −C: minimal roots — no structural entailments.
-    Conservative default for classes not yet studied under B&KG's
-    framework. Not a row in B&KG's typology (which only lists roots
-    with at least one positive feature). -/
-def minimal : RootEntailments := ⟨false, false, false, false⟩
-
-/-! ### Canonical type well-formedness -/
-
-theorem propertyConcept_wf : propertyConcept.WellFormed := by decide
-theorem pureResult_wf : pureResult.WellFormed := by decide
-theorem causativeResult_wf : causativeResult.WellFormed := by decide
-theorem pureManner_wf : pureManner.WellFormed := by decide
-theorem mannerResult_wf : mannerResult.WellFormed := by decide
-theorem fullSpec_wf : fullSpec.WellFormed := by decide
-theorem minimal_wf : minimal.WellFormed := by decide
-
-/-! ### MRC violation detection -/
-
-/-- Does this root violate Manner/Result Complementarity?
-    [beavers-koontz-garboden-2020] ch. 4: some roots encode both manner
-    and result. [rappaport-hovav-levin-2010] dispute this; the framing
-    "violates MRC" presupposes MRC as a baseline norm — itself a
-    framework commitment. -/
-def ViolatesMRC (r : RootEntailments) : Prop :=
-  r.manner = true ∧ r.result = true
-
-instance (r : RootEntailments) : Decidable r.ViolatesMRC := by
-  unfold ViolatesMRC; infer_instance
-
-theorem fullSpec_violates_MRC : fullSpec.ViolatesMRC := by decide
-theorem mannerResult_violates_MRC : mannerResult.ViolatesMRC := by decide
-theorem pureResult_respects_MRC : ¬ pureResult.ViolatesMRC := by decide
-theorem pureManner_respects_MRC : ¬ pureManner.ViolatesMRC := by decide
-theorem causativeResult_respects_MRC : ¬ causativeResult.ViolatesMRC := by decide
-
-end RootEntailments
-
-/-! ### Derived properties -/
+namespace Profile
 
 /-- Does a root profile constrain patient properties? -/
-def RootProfile.constrainsPatient (rp : RootProfile) : Prop :=
+def constrainsPatient (rp : Profile) : Prop :=
   rp.patientRob.isConstrained = true
 
-instance (rp : RootProfile) : Decidable rp.constrainsPatient :=
+instance (rp : Profile) : Decidable rp.constrainsPatient :=
   inferInstanceAs (Decidable (_ = true))
 
 /-- Do two root profiles overlap (share at least one compatible event)? -/
-def RootProfile.overlaps (rp₁ rp₂ : RootProfile) : Prop :=
+def overlaps (rp₁ rp₂ : Profile) : Prop :=
   rp₁.forceMag.overlaps rp₂.forceMag = true ∧
   rp₁.forceDir.overlaps rp₂.forceDir = true ∧
   rp₁.patientRob.overlaps rp₂.patientRob = true ∧
@@ -349,7 +219,9 @@ def RootProfile.overlaps (rp₁ rp₂ : RootProfile) : Prop :=
   rp₁.agentVolition.overlaps rp₂.agentVolition = true ∧
   rp₁.agentControl.overlaps rp₂.agentControl = true
 
-instance (rp₁ rp₂ : RootProfile) : Decidable (rp₁.overlaps rp₂) :=
+instance (rp₁ rp₂ : Profile) : Decidable (rp₁.overlaps rp₂) :=
   inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ _ ∧ _ ∧ _))
 
-end Semantics.Lexical.Roots
+end Profile
+
+end Root

--- a/Linglib/Semantics/Lexical/Roots/SalienceClass.lean
+++ b/Linglib/Semantics/Lexical/Roots/SalienceClass.lean
@@ -3,8 +3,6 @@ import Linglib.Semantics.Lexical.Roots.Typology
 /-!
 # Lexical Salience Classes
 
-[lucy-1994]
-
 [lucy-1994]'s classification of verbal roots by which argument(s) the
 underived root form makes "salient" (default case-role assignment at
 the propositional level): a 3-way salience cut (agent, agent-patient,
@@ -17,12 +15,10 @@ reconstruction ([lucy-1994] predates the feature vocabulary of
 This file lifts the classification out of any specific empirical
 study so that other Fragment / Theory modules can refer to it
 (e.g., the Yukatek 5-way verb stem classification, which refines
-this 4-way cut). The full [lucy-1994] analysis — operator
-orbits, motion-roots-non-class theorem, per-root verifications —
-lives in `Studies/Lucy1994.lean`.
+this cut). The full [lucy-1994] analysis — operator applicability,
+motion-roots-non-class theorem, per-root verifications — lives in
+`Studies/Lucy1994.lean`.
 -/
-
-namespace Semantics.Lexical.Roots
 
 /-- Salience classification of verbal roots ([lucy-1994]): the 3-way
     transitiviser cut plus the positional class. "Salience" is shorthand
@@ -39,105 +35,102 @@ inductive SalienceClass where
   | positional
   deriving DecidableEq, Repr
 
-/-! ### Named class predicates -/
+/-! ### Named class predicates
 
-/-! Named structural conditions characterising membership in each
-    [lucy-1994] salience class. These predicates are language-
-    independent: the same conditions characterise the class in any
-    inventory whose transitivisers respect the diagnostic. They appear
-    directly as the `applies` field of each Yukatek operator in
-    `Fragments/Mayan/Yukatek/Operators.lean`, making the
-    operator-applicability ↔ salience-class connection true *by
-    construction* rather than only provable per-case. -/
+Named structural conditions characterising membership in each
+[lucy-1994] salience class. These predicates are language-independent:
+the same conditions characterise the class in any inventory whose
+transitivisers respect the diagnostic. They appear directly as the
+`applies` field of each Yukatek operator in
+`Fragments/Mayan/Yukatek/Operators.lean`, making the
+operator-applicability ↔ salience-class connection true *by
+construction* rather than only provable per-case. -/
+
+namespace FeatureSignature
 
 /-- Agent-salient: manner without result (intransitive activity that
     requires =t to transitivise; [lucy-1994]). -/
-def FeatureSignature.IsAgentSalient (s : FeatureSignature) : Prop :=
-  s.manner = true ∧ s.result = false
+def IsAgentSalient (s : FeatureSignature) : Prop :=
+  .manner ∈ s ∧ .result ∉ s
 
-instance (s : FeatureSignature) : Decidable s.IsAgentSalient := by
-  unfold FeatureSignature.IsAgentSalient; infer_instance
+instance (s : FeatureSignature) : Decidable s.IsAgentSalient :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
 /-- Agent-patient salient: manner *and* result (already lexically
     transitive; [lucy-1994]). -/
-def FeatureSignature.IsAgentPatientSalient (s : FeatureSignature) : Prop :=
-  s.manner = true ∧ s.result = true
+def IsAgentPatientSalient (s : FeatureSignature) : Prop :=
+  .manner ∈ s ∧ .result ∈ s
 
-instance (s : FeatureSignature) : Decidable s.IsAgentPatientSalient := by
-  unfold FeatureSignature.IsAgentPatientSalient; infer_instance
+instance (s : FeatureSignature) : Decidable s.IsAgentPatientSalient :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
 /-- Patient-salient: result without manner (intransitive change-of-state
     that requires =s to transitivise; [lucy-1994]). -/
-def FeatureSignature.IsPatientSalient (s : FeatureSignature) : Prop :=
-  s.manner = false ∧ s.result = true
+def IsPatientSalient (s : FeatureSignature) : Prop :=
+  .manner ∉ s ∧ .result ∈ s
 
-instance (s : FeatureSignature) : Decidable s.IsPatientSalient := by
-  unfold FeatureSignature.IsPatientSalient; infer_instance
+instance (s : FeatureSignature) : Decidable s.IsPatientSalient :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
 /-- Positional: pure stative root — state without manner, result, or
     cause (requires `-tal` for the inchoative; [lucy-1994]). -/
-def FeatureSignature.IsPositional (s : FeatureSignature) : Prop :=
-  s.state = true ∧ s.manner = false ∧ s.result = false ∧ s.cause = false
+def IsPositional (s : FeatureSignature) : Prop :=
+  s = {.state}
 
-instance (s : FeatureSignature) : Decidable s.IsPositional := by
-  unfold FeatureSignature.IsPositional; infer_instance
+instance (s : FeatureSignature) : Decidable s.IsPositional :=
+  inferInstanceAs (Decidable (_ = _))
+
+end FeatureSignature
 
 /-! Per-root convenience versions, lifted via `featureSignature`. -/
 
-/-- Agent-salient root (lifted to roots; cf. `FeatureSignature.IsAgentSalient`). -/
-def Root.IsAgentSalient (r : Root) : Prop :=
+namespace Root
+
+/-- Agent-salient root (cf. `FeatureSignature.IsAgentSalient`). -/
+def IsAgentSalient (r : Root) : Prop :=
   r.featureSignature.IsAgentSalient
 
-instance (r : Root) : Decidable r.IsAgentSalient := by
-  unfold Root.IsAgentSalient; infer_instance
+instance (r : Root) : Decidable r.IsAgentSalient :=
+  inferInstanceAs (Decidable (FeatureSignature.IsAgentSalient _))
 
 /-- Agent-patient salient root. -/
-def Root.IsAgentPatientSalient (r : Root) : Prop :=
+def IsAgentPatientSalient (r : Root) : Prop :=
   r.featureSignature.IsAgentPatientSalient
 
-instance (r : Root) : Decidable r.IsAgentPatientSalient := by
-  unfold Root.IsAgentPatientSalient; infer_instance
+instance (r : Root) : Decidable r.IsAgentPatientSalient :=
+  inferInstanceAs (Decidable (FeatureSignature.IsAgentPatientSalient _))
 
 /-- Patient-salient root. -/
-def Root.IsPatientSalient (r : Root) : Prop :=
+def IsPatientSalient (r : Root) : Prop :=
   r.featureSignature.IsPatientSalient
 
-instance (r : Root) : Decidable r.IsPatientSalient := by
-  unfold Root.IsPatientSalient; infer_instance
+instance (r : Root) : Decidable r.IsPatientSalient :=
+  inferInstanceAs (Decidable (FeatureSignature.IsPatientSalient _))
 
 /-- Positional root. -/
-def Root.IsPositional (r : Root) : Prop :=
+def IsPositional (r : Root) : Prop :=
   r.featureSignature.IsPositional
 
-instance (r : Root) : Decidable r.IsPositional := by
-  unfold Root.IsPositional; infer_instance
+instance (r : Root) : Decidable r.IsPositional :=
+  inferInstanceAs (Decidable (FeatureSignature.IsPositional _))
+
+end Root
 
 /-! ### Salience classifier -/
 
 /-- Map a B&K-G feature signature to its salience class
-    ([lucy-1994]). The arms align with operator applicability
-    conditions in `Fragments/Mayan/Yukatek/Operators.lean`:
-
-    | (state, manner, result, cause) | predicted class    |
-    |--------------------------------|--------------------|
-    | (_, true, false, _)            | agent              |
-    | (_, true, true, _)             | agentPatient       |
-    | (_, false, true, _)            | patient            |
-    | (true, false, false, false)    | positional         |
-    | otherwise                      | none               |
-
-    The positional row requires `cause = false`: positional roots are
-    pure stative configurations (orientation, posture, location) with
-    no causing event. The four arms equivalently dispatch on the four
-    named predicates `IsAgentSalient`, `IsAgentPatientSalient`,
-    `IsPatientSalient`, `IsPositional` — see `classOfSignature_eq_dispatch`. -/
+    ([lucy-1994]) by dispatching on the four named predicates, which
+    align with operator applicability conditions in
+    `Fragments/Mayan/Yukatek/Operators.lean`. The positional arm
+    requires the pure-state signature: positional roots are stative
+    configurations (orientation, posture, location) with no causing
+    event. -/
 def classOfSignature (s : FeatureSignature) : Option SalienceClass :=
-  match s.manner, s.result, s.state, s.cause with
-  | true,  false, _,    _     => some .agent
-  | true,  true,  _,    _     => some .agentPatient
-  | false, true,  _,    _     => some .patient
-  | false, false, true, false => some .positional
-  | false, false, _,    _     => none
+  if s.IsAgentSalient then some .agent
+  else if s.IsAgentPatientSalient then some .agentPatient
+  else if s.IsPatientSalient then some .patient
+  else if s.IsPositional then some .positional
+  else none
 
 /-- A root's predicted salience class is `classOfSignature` of its
     feature signature. -/
@@ -152,51 +145,29 @@ theorem predictedSalience_depends_only_on_signature
   unfold Root.predictedSalience
   rw [h]
 
-/-! ### Equivalence with predicate dispatch -/
-
-/-- The `classOfSignature` table is equivalent to dispatching on the
-    four named predicates. Establishes that the classifier really *is*
-    the disjunction of the named conditions — not an arbitrary table. -/
-theorem classOfSignature_eq_dispatch (s : FeatureSignature) :
-    classOfSignature s =
-      (if s.IsAgentSalient        then some .agent
-       else if s.IsAgentPatientSalient then some .agentPatient
-       else if s.IsPatientSalient  then some .patient
-       else if s.IsPositional      then some .positional
-       else none) := by
-  obtain ⟨st, m, r, c⟩ := s
-  unfold classOfSignature FeatureSignature.IsAgentSalient
-    FeatureSignature.IsAgentPatientSalient FeatureSignature.IsPatientSalient
-    FeatureSignature.IsPositional
-  cases m <;> cases r <;> cases st <;> cases c <;> simp_all
-
 /-! ### Pairwise disjointness of class predicates -/
 
 /-- The four named predicates are pairwise disjoint: at most one fires
     on any given signature. (They are *jointly* not exhaustive — the
-    ⟨false, false, _, _⟩ rows that the positional arm doesn't catch
-    fall outside all four; see `classOfSignature_eq_none_iff`.) -/
-theorem classes_pairwise_disjoint (s : FeatureSignature) :
-    ¬ (s.IsAgentSalient ∧ s.IsAgentPatientSalient) ∧
-    ¬ (s.IsAgentSalient ∧ s.IsPatientSalient) ∧
-    ¬ (s.IsAgentSalient ∧ s.IsPositional) ∧
-    ¬ (s.IsAgentPatientSalient ∧ s.IsPatientSalient) ∧
-    ¬ (s.IsAgentPatientSalient ∧ s.IsPositional) ∧
-    ¬ (s.IsPatientSalient ∧ s.IsPositional) := by
-  obtain ⟨st, m, r, c⟩ := s
-  cases m <;> cases r <;> cases st <;> cases c <;>
-    decide
+    no-manner-no-result signatures other than `{state}` fall outside
+    all four; see `classOfSignature_eq_none_iff`.) -/
+theorem classes_pairwise_disjoint :
+    ∀ s : FeatureSignature,
+      ¬ (s.IsAgentSalient ∧ s.IsAgentPatientSalient) ∧
+      ¬ (s.IsAgentSalient ∧ s.IsPatientSalient) ∧
+      ¬ (s.IsAgentSalient ∧ s.IsPositional) ∧
+      ¬ (s.IsAgentPatientSalient ∧ s.IsPatientSalient) ∧
+      ¬ (s.IsAgentPatientSalient ∧ s.IsPositional) ∧
+      ¬ (s.IsPatientSalient ∧ s.IsPositional) := by
+  decide
 
 /-- `classOfSignature s = none` iff `s` falls outside all four named
     predicates. Characterises the gap in the diagnostic: the
-    `(¬manner, ¬result)` rows that lack the positional configuration
-    (state ∧ ¬cause) are unclassified by Lucy's Yukatek diagnostic. -/
-theorem classOfSignature_eq_none_iff (s : FeatureSignature) :
-    classOfSignature s = none ↔
-      ¬ s.IsAgentSalient ∧ ¬ s.IsAgentPatientSalient ∧
-      ¬ s.IsPatientSalient ∧ ¬ s.IsPositional := by
-  obtain ⟨st, m, r, c⟩ := s
-  cases m <;> cases r <;> cases st <;> cases c <;>
-    decide
-
-end Semantics.Lexical.Roots
+    no-manner-no-result signatures other than pure `{state}` are
+    unclassified by Lucy's Yukatek diagnostic. -/
+theorem classOfSignature_eq_none_iff :
+    ∀ s : FeatureSignature,
+      classOfSignature s = none ↔
+        ¬ s.IsAgentSalient ∧ ¬ s.IsAgentPatientSalient ∧
+        ¬ s.IsPatientSalient ∧ ¬ s.IsPositional := by
+  decide

--- a/Linglib/Semantics/Lexical/Roots/Signature.lean
+++ b/Linglib/Semantics/Lexical/Roots/Signature.lean
@@ -1,0 +1,248 @@
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Powerset
+import Mathlib.Tactic.DeriveFintype
+import Mathlib.Order.UpperLower.Basic
+import Mathlib.Order.Closure
+
+/-!
+# Root Feature Signatures
+
+The four-feature vocabulary of [beavers-koontz-garboden-2020]'s root
+typology (ch. 5): a root's **feature signature** records which *kinds*
+of lexical entailment it carries — state, manner, result, cause — as a
+`Finset LexKind`, so signatures inherit the Boolean lattice of finite
+sets (`≤` is "carries at most these kinds").
+
+`LexKind` carries the book's collocational order (`state < result <
+cause`, with `manner` isolated): "+result entails being +state, since
+become′ entails something that has come about… +cause entails being
++result, since cause′ entails that there is a caused event. These are
+not root-specific stipulations." Well-formedness of a signature is
+downward-closedness in this order, and `close` — the induced lower
+closure, packaged as a mathlib `ClosureOperator` — repairs any
+signature to a well-formed one.
+
+This file is `Root`-free: consumers that map other objects to
+signatures (e.g. Levin classes) can import it without the root
+substrate.
+
+## Main declarations
+
+* `LexKind`, with its collocational `PartialOrder`
+* `FeatureSignature := Finset LexKind`
+* `FeatureSignature.close`, `FeatureSignature.closeOp`,
+  `FeatureSignature.WellFormed`
+* canonical signatures (`propertyConcept`, `pureResult`,
+  `causativeResult`, `pureManner`, `mannerResult`, `fullSpec`,
+  `minimal`)
+* `FeatureSignature.ViolatesBifurcation`,
+  `FeatureSignature.HasMannerAndResult`
+-/
+
+/-! ### Lexical entailment kinds -/
+
+/-- The four kinds of lexical entailment of
+    [beavers-koontz-garboden-2020]'s root typology. -/
+inductive LexKind where
+  | state
+  | manner
+  | result
+  | cause
+  deriving DecidableEq, Fintype, Repr
+
+namespace LexKind
+
+/-- Boolean table for the collocational order. -/
+private def leB : LexKind → LexKind → Bool
+  | .state,  .state  => true
+  | .state,  .result => true
+  | .state,  .cause  => true
+  | .result, .result => true
+  | .result, .cause  => true
+  | .cause,  .cause  => true
+  | .manner, .manner => true
+  | _,       _       => false
+
+/-- The collocational order of [beavers-koontz-garboden-2020]:
+    `state < result < cause` (a cause presupposes a result, a result
+    presupposes a state), with `manner` incomparable to the chain. -/
+instance : PartialOrder LexKind where
+  le a b := leB a b = true
+  le_refl a := by cases a <;> rfl
+  le_trans a b c := by revert a b c; decide
+  le_antisymm a b := by revert a b; decide
+
+instance : DecidableLE LexKind := fun _ _ => inferInstanceAs (Decidable (_ = true))
+
+end LexKind
+
+/-! ### Feature signatures -/
+
+/-- A root feature signature: the set of entailment kinds carried.
+    `≤` (= `⊆`) and the lattice operations come from `Finset`. -/
+abbrev FeatureSignature := Finset LexKind
+
+namespace FeatureSignature
+
+/-- The collocational closure: a signature carrying `cause` is
+    completed with `result` and `state`; one carrying `result` is
+    completed with `state`. This is the lower closure under the
+    `LexKind` order (`mem_close_iff`). -/
+def close (s : FeatureSignature) : FeatureSignature :=
+  s ∪ (if .cause ∈ s then {.result, .state} else ∅)
+    ∪ (if .result ∈ s then {.state} else ∅)
+
+theorem le_close : ∀ s : FeatureSignature, s ≤ close s := by decide
+
+theorem close_idem : ∀ s : FeatureSignature, close (close s) = close s := by
+  decide
+
+theorem close_mono : ∀ {s t : FeatureSignature}, s ≤ t → close s ≤ close t := by
+  decide
+
+/-- `close` is the lower closure under the collocational order:
+    `k` is in the closure iff some kind in `s` dominates it. -/
+theorem mem_close_iff : ∀ (s : FeatureSignature) (k : LexKind),
+    k ∈ close s ↔ ∃ j ∈ s, k ≤ j := by decide
+
+/-- The collocational closure as a mathlib `ClosureOperator`. -/
+def closeOp : ClosureOperator FeatureSignature where
+  toFun := close
+  monotone' _ _ := close_mono
+  le_closure' := le_close
+  idempotent' := close_idem
+
+/-- A signature is well-formed iff it already satisfies the
+    collocational constraints (it is a fixed point of `close`). -/
+def WellFormed (s : FeatureSignature) : Prop := close s = s
+
+instance (s : FeatureSignature) : Decidable s.WellFormed :=
+  inferInstanceAs (Decidable (_ = _))
+
+/-- Well-formedness is downward-closedness in the `LexKind` order. -/
+theorem wellFormed_iff_isLowerSet (s : FeatureSignature) :
+    s.WellFormed ↔ IsLowerSet (↑s : Set LexKind) := by
+  constructor
+  · intro hwf a b hba ha
+    have hb : b ∈ close s := (mem_close_iff s b).mpr ⟨a, Finset.mem_coe.mp ha, hba⟩
+    rw [hwf] at hb
+    exact Finset.mem_coe.mpr hb
+  · intro h
+    refine le_antisymm (fun k hk => ?_) (le_close s)
+    obtain ⟨j, hj, hkj⟩ := (mem_close_iff s k).mp hk
+    exact Finset.mem_coe.mp (h hkj (Finset.mem_coe.mpr hj))
+
+/-- Closure output is always well-formed — the collocational
+    constraints hold of closed signatures *by construction*. -/
+theorem close_wellFormed : ∀ s : FeatureSignature, (close s).WellFormed :=
+  close_idem
+
+/-! ### Canonical signatures
+
+The attested rows of the root typology of [beavers-koontz-garboden-2020]
+ch. 5 (their example display (12), §5.4). -/
+
+/-- +S −M −R −C: property concept roots (√FLAT, √DRY).
+    Deadjectival COS verbs — the root names the result state.
+    Complement position. -/
+def propertyConcept : FeatureSignature := {.state}
+
+/-- +S −M +R −C: internally caused result roots (√BLOSSOM, √RUST).
+    Root entails both a state and a change to that state, but not
+    external causation. Complement position. -/
+def pureResult : FeatureSignature := {.state, .result}
+
+/-- +S −M +R +C: externally caused result roots (√CRACK, √BREAK).
+    Root entails a state, change, AND causation. If roots subdivide by
+    entailed causation, this may underlie Levin & Rappaport Hovav's
+    (1995) externally vs internally caused change-of-state distinction
+    ([beavers-koontz-garboden-2020], hedged as a possibility).
+    Complement position. -/
+def causativeResult : FeatureSignature := {.state, .result, .cause}
+
+/-- −S +M −R −C: pure manner roots (√JOG, √RUN, √SWIM).
+    Root specifies action manner without entailing any state.
+    Adjoined position. -/
+def pureManner : FeatureSignature := {.manner}
+
+/-- +S +M +R −C: manner + result without cause. Well-formed per the
+    constraints; [beavers-koontz-garboden-2020] leave its attestation
+    an open question ("whether a change and a manner can exist together
+    in a single meaning without causation"), with candidate witnesses
+    *slide* and motion-in-sound-emission *buzz*. -/
+def mannerResult : FeatureSignature := {.state, .manner, .result}
+
+/-- +S +M +R +C: fully specified roots (√HAND adjoined, √DROWN and the
+    other manner-of-killing roots in complement position;
+    [beavers-koontz-garboden-2020] chs. 3–4). These are the attested
+    MRC violators. The adjoined/complement contrast is carried by
+    `Root.Position`, not by the signature. -/
+def fullSpec : FeatureSignature := {.state, .manner, .result, .cause}
+
+/-- −S −M −R −C: minimal roots — no structural entailments.
+    Conservative default for classes not yet studied under B&KG's
+    framework. Not a row in B&KG's typology (which only lists roots
+    with at least one positive feature). -/
+def minimal : FeatureSignature := ∅
+
+/-- Every canonical signature is well-formed. -/
+theorem canonical_wellFormed :
+    propertyConcept.WellFormed ∧ pureResult.WellFormed ∧
+    causativeResult.WellFormed ∧ pureManner.WellFormed ∧
+    mannerResult.WellFormed ∧ fullSpec.WellFormed ∧ minimal.WellFormed := by
+  decide
+
+/-! ### The two theses, at signature level -/
+
+/-- The ontological kinds — all the Bifurcation Thesis allows a root
+    to carry. -/
+def ontological : FeatureSignature := {.state, .manner}
+
+/-- A signature violates the Bifurcation Thesis ([embick-2009]; the
+    assumption of [arad-2005]) iff it carries templatic (eventive)
+    content — it is not bounded by `ontological`. -/
+def ViolatesBifurcation (s : FeatureSignature) : Prop := ¬ s ≤ ontological
+
+instance (s : FeatureSignature) : Decidable s.ViolatesBifurcation :=
+  inferInstanceAs (Decidable (¬ _ ≤ _))
+
+/-- Violation is carrying a `result` or `cause` kind. -/
+theorem violatesBifurcation_iff :
+    ∀ s : FeatureSignature,
+      s.ViolatesBifurcation ↔ .result ∈ s ∨ .cause ∈ s := by decide
+
+/-- Bifurcation violation is monotone: adding entailments cannot
+    repair a violation. (Equivalently, the thesis carves out a lower
+    set of the signature lattice.) -/
+theorem violatesBifurcation_mono :
+    ∀ {s t : FeatureSignature}, s ≤ t →
+      s.ViolatesBifurcation → t.ViolatesBifurcation := by decide
+
+/-- A signature has both manner and result — the configuration
+    Manner/Result Complementarity ([rappaport-hovav-levin-2010])
+    claims no root realizes. -/
+def HasMannerAndResult (s : FeatureSignature) : Prop :=
+  {LexKind.manner, LexKind.result} ≤ s
+
+instance (s : FeatureSignature) : Decidable s.HasMannerAndResult :=
+  inferInstanceAs (Decidable (_ ≤ _))
+
+/-- MRC violation is monotone in the signature order. -/
+theorem hasMannerAndResult_mono :
+    ∀ {s t : FeatureSignature}, s ≤ t →
+      s.HasMannerAndResult → t.HasMannerAndResult := by decide
+
+/-- Both theses are invariant under collocational closure: `close`
+    only adds `state`/`result` kinds forced by `cause`, never `manner`,
+    and a closed signature violates Bifurcation iff its base does. -/
+theorem violatesBifurcation_close_iff :
+    ∀ s : FeatureSignature,
+      (close s).ViolatesBifurcation ↔ s.ViolatesBifurcation := by decide
+
+theorem hasMannerAndResult_close_iff :
+    ∀ s : FeatureSignature,
+      (close s).HasMannerAndResult ↔
+        s.HasMannerAndResult ∨ (.manner ∈ s ∧ .cause ∈ s) := by decide
+
+end FeatureSignature

--- a/Linglib/Semantics/Lexical/Roots/Template.lean
+++ b/Linglib/Semantics/Lexical/Roots/Template.lean
@@ -19,10 +19,8 @@ ch. 3 are not modeled.
 
 * `TemplaticHead` — the three primitive heads
 * `Root.Position` — complement vs adjoined attachment
-* `EventStructure` — heads composed with a positioned root
+* `Root.EventStructure` — heads composed with a positioned root
 -/
-
-namespace Semantics.Lexical.Roots
 
 /-! ### Templatic heads -/
 
@@ -58,6 +56,8 @@ inductive Root.Position where
   deriving DecidableEq, Repr
 
 /-! ### Composed event structures -/
+
+namespace Root
 
 /-- An event structure: a list of templatic heads (outermost first)
     composed with a root in a specific structural position.
@@ -108,4 +108,4 @@ def achievementOf (r : Root) : EventStructure :=
 def accomplishmentOf (r : Root) : EventStructure :=
   ⟨[.v_cause, .v_become], r, .complement⟩
 
-end Semantics.Lexical.Roots
+end Root

--- a/Linglib/Semantics/Lexical/Roots/Typology.lean
+++ b/Linglib/Semantics/Lexical/Roots/Typology.lean
@@ -1,94 +1,74 @@
 import Linglib.Semantics.Lexical.Roots.Basic
 
 /-!
-# B&K-G Typology, Bifurcation, and Manner/Result Complementarity
+# Bifurcation and Manner/Result Complementarity for Roots
 
-The four-feature classification of roots (±state, ±manner, ±result,
-±cause) of [beavers-koontz-garboden-2020], *derived* from
-`Root.entailments` rather than stipulated as a separate enum, together
-with the two conjectures the book argues against:
+The two conjectures [beavers-koontz-garboden-2020] argue against,
+stated for roots by delegation to the signature level
+(`Roots/Signature.lean`):
 
 - **Bifurcation Thesis of Roots** ([embick-2009]; the assumption of
   [arad-2005]): meaning introduced by a functional head — change,
-  cause — can never be part of a root's meaning.
+  cause — can never be part of a root's meaning. As an order
+  statement: every root's signature lies below
+  `FeatureSignature.ontological`.
 - **Manner/Result Complementarity** ([rappaport-hovav-levin-2010]): a
-  single root entails a manner *or* a result, never both.
+  single root entails a manner *or* a result, never both. As an order
+  statement: no root's signature lies above `{manner, result}`.
 
 Falsifying witnesses live in `Studies/BeaversKoontzGarboden2020.lean`.
 
 ## Main declarations
 
-* `FeatureSignature`, `Root.featureSignature`
 * `Root.ViolatesBifurcation`, `Root.HasMannerAndResult`, and their
   negations `Root.RespectsBifurcation`,
   `Root.RespectsMannerResultComplementarity`
 -/
 
-namespace Semantics.Lexical.Roots
-
-/-! ### Feature signature -/
-
-/-- The four-feature classification of a root (the root typology of
-    [beavers-koontz-garboden-2020] ch. 5). All four features are
-    *derived* from `Root.entailments`, so the 16-cell typology falls
-    out of which kinds of atoms a root carries. -/
-structure FeatureSignature where
-  state  : Bool
-  manner : Bool
-  result : Bool
-  cause  : Bool
-  deriving DecidableEq, Repr
-
 namespace Root
 
-/-- The B&K-G feature signature of a root, derived from its
-    entailment list. -/
-def featureSignature (r : Root) : FeatureSignature :=
-  { state  := r.hasState
-  , manner := r.hasManner
-  , result := r.hasResult
-  , cause  := r.hasCause }
-
-end Root
-
-/-! ### Bifurcation Thesis of Roots -/
-
 /-- A root *violates* Bifurcation iff it itself carries templatic
-    (eventive) meaning — change of state or cause. The Bifurcation
+    (eventive) meaning — change of state or cause
+    (`FeatureSignature.violatesBifurcation_iff`). The Bifurcation
     Thesis ([embick-2009]; [arad-2005]) is the universal claim that no
     root does. (The ditransitive prepositional heads P_loc and P_have,
     which [beavers-koontz-garboden-2020] also treat as templatic, are
     not modeled here.) -/
-def Root.ViolatesBifurcation (r : Root) : Prop :=
-  r.hasResult = true ∨ r.hasCause = true
+def ViolatesBifurcation (r : Root) : Prop :=
+  r.featureSignature.ViolatesBifurcation
 
-instance (r : Root) : Decidable r.ViolatesBifurcation := by
-  unfold Root.ViolatesBifurcation; infer_instance
+instance (r : Root) : Decidable r.ViolatesBifurcation :=
+  inferInstanceAs (Decidable (FeatureSignature.ViolatesBifurcation _))
 
 /-- Negation of `ViolatesBifurcation`: the root carries only
     ontological entailments (state, manner). -/
-def Root.RespectsBifurcation (r : Root) : Prop :=
+def RespectsBifurcation (r : Root) : Prop :=
   ¬ r.ViolatesBifurcation
 
-instance (r : Root) : Decidable r.RespectsBifurcation := by
-  unfold Root.RespectsBifurcation; infer_instance
+instance (r : Root) : Decidable r.RespectsBifurcation :=
+  inferInstanceAs (Decidable (¬ _))
 
-/-! ### Manner/Result Complementarity -/
+/-- The thesis as an order statement: a root respects Bifurcation iff
+    its signature is bounded by the ontological kinds. -/
+theorem respectsBifurcation_iff_le {r : Root} :
+    r.RespectsBifurcation ↔
+      r.featureSignature ≤ FeatureSignature.ontological :=
+  not_not
 
 /-- A root has both manner and result entailments — Manner/Result
     Complementarity ([rappaport-hovav-levin-2010]) is the universal
     claim that no root does. -/
-def Root.HasMannerAndResult (r : Root) : Prop :=
-  r.hasManner = true ∧ r.hasResult = true
+def HasMannerAndResult (r : Root) : Prop :=
+  r.featureSignature.HasMannerAndResult
 
-instance (r : Root) : Decidable r.HasMannerAndResult := by
-  unfold Root.HasMannerAndResult; infer_instance
+instance (r : Root) : Decidable r.HasMannerAndResult :=
+  inferInstanceAs (Decidable (FeatureSignature.HasMannerAndResult _))
 
 /-- Negation of `HasMannerAndResult`. -/
-def Root.RespectsMannerResultComplementarity (r : Root) : Prop :=
+def RespectsMannerResultComplementarity (r : Root) : Prop :=
   ¬ r.HasMannerAndResult
 
-instance (r : Root) : Decidable r.RespectsMannerResultComplementarity := by
-  unfold Root.RespectsMannerResultComplementarity; infer_instance
+instance (r : Root) : Decidable r.RespectsMannerResultComplementarity :=
+  inferInstanceAs (Decidable (¬ _))
 
-end Semantics.Lexical.Roots
+end Root

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -11,7 +11,6 @@ is computed here, not stipulated as enum fields on `Verb`.
 open Semantics.Presupposition
 open Features
 open Semantics.Lexical
-open Semantics.Lexical.Roots
 open Features.ChangeOfState
 open Core.NaturalLogic (EntailmentSig)
 open Semantics.Causation.Psych (CausalSource)

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -13,6 +13,7 @@ import Linglib.Semantics.Causation.Psych
 import Linglib.Semantics.Aspect.DegreeAchievement
 import Linglib.Semantics.Aspect.Incremental
 import Linglib.Semantics.Lexical.LevinClassProfiles
+import Linglib.Semantics.Lexical.Roots.Profile
 
 /-! # Verb entry — core type
 
@@ -43,7 +44,6 @@ primitive fields in `Semantics/Verb/Basic.lean`, not stipulated as an enum.
 open Semantics.Presupposition
 open Features
 open Semantics.Lexical
-open Semantics.Lexical.Roots
 open Features.ChangeOfState
 open Core.NaturalLogic (EntailmentSig)
 open Semantics.Causation.Psych (CausalSource)
@@ -260,7 +260,7 @@ structure Root where
   /-- [levin-1993] verb class (§§ 9–57). -/
   levinClass : Option LevinClass := none
   /-- Root-specific quality dimensions (within-class variation). -/
-  rootProfile : Option RootProfile := none
+  rootProfile : Option _root_.Root.Profile := none
   deriving Repr, BEq
 
 end Verb

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -20,11 +20,12 @@ the falsification of the Bifurcation Thesis of Roots ([embick-2009];
 | √drown   |   ✓    |   ✓   |   ✓    |   ✓   | complement |
 
 The +state cells of √blossom, √crack, √hand, √drown are *derived*:
-a `becomesState` atom yields the corresponding `hasState` atom under
-entailment closure (`Root.closedFeatureSignature`); the base
-`featureSignature` records only the atoms. √blossom falsifies
-Bifurcation on its own, since change of state is templatic
-(`v_become`) content. √hand and √drown additionally falsify
+the book's typology values are the collocational closures
+(`Root.closedFeatureSignature`) of the base atom kinds, and each
+closed signature is one of the canonical typology rows
+(`FeatureSignature.pureResult`, `causativeResult`, `fullSpec`).
+√blossom falsifies Bifurcation on its own, since change of state is
+templatic (`v_become`) content. √hand and √drown additionally falsify
 Manner/Result Complementarity; they differ only in root position
 (adjoined vs complement), the contrast carrying the book's account of
 which root types are attested.
@@ -37,8 +38,6 @@ which root types are attested.
 -/
 
 namespace BeaversKoontzGarboden2020
-
-open Semantics.Lexical.Roots
 
 /-! ### The six representative roots -/
 
@@ -72,76 +71,64 @@ def drown : Root := ⟨"drown",
 
 /-! ### Feature signatures
 
-Base signatures record the atoms; closed signatures additionally
-derive `state` from `becomesState` atoms. The book's typology values
-are the closed ones. -/
+Base signatures record the atom kinds; closed signatures are their
+collocational closures, and coincide with the canonical rows of the
+book's typology. -/
 
-theorem flat_featureSignature :
-    flat.featureSignature =
-      { state := true, manner := false, result := false, cause := false } :=
-  rfl
+theorem flat_featureSignature : flat.featureSignature = {.state} := by
+  decide
 
-theorem jog_featureSignature :
-    jog.featureSignature =
-      { state := false, manner := true, result := false, cause := false } :=
-  rfl
+theorem jog_featureSignature : jog.featureSignature = {.manner} := by
+  decide
 
 theorem blossom_featureSignature :
-    blossom.featureSignature =
-      { state := false, manner := false, result := true, cause := false } :=
-  rfl
+    blossom.featureSignature = {.result} := by decide
 
 theorem crack_featureSignature :
-    crack.featureSignature =
-      { state := false, manner := false, result := true, cause := true } :=
-  rfl
+    crack.featureSignature = {.result, .cause} := by decide
 
 theorem hand_featureSignature :
-    hand.featureSignature =
-      { state := false, manner := true, result := true, cause := true } :=
-  rfl
+    hand.featureSignature = {.manner, .result, .cause} := by decide
 
 theorem drown_featureSignature :
-    drown.featureSignature =
-      { state := false, manner := true, result := true, cause := true } :=
-  rfl
+    drown.featureSignature = {.manner, .result, .cause} := by decide
+
+theorem flat_closedFeatureSignature :
+    flat.closedFeatureSignature = FeatureSignature.propertyConcept := by
+  decide
+
+theorem jog_closedFeatureSignature :
+    jog.closedFeatureSignature = FeatureSignature.pureManner := by decide
 
 theorem blossom_closedFeatureSignature :
-    blossom.closedFeatureSignature =
-      { state := true, manner := false, result := true, cause := false } :=
-  rfl
+    blossom.closedFeatureSignature = FeatureSignature.pureResult := by
+  decide
 
 theorem crack_closedFeatureSignature :
-    crack.closedFeatureSignature =
-      { state := true, manner := false, result := true, cause := true } :=
-  rfl
+    crack.closedFeatureSignature = FeatureSignature.causativeResult := by
+  decide
 
 theorem hand_closedFeatureSignature :
-    hand.closedFeatureSignature =
-      { state := true, manner := true, result := true, cause := true } :=
-  rfl
+    hand.closedFeatureSignature = FeatureSignature.fullSpec := by decide
 
 theorem drown_closedFeatureSignature :
-    drown.closedFeatureSignature =
-      { state := true, manner := true, result := true, cause := true } :=
-  rfl
+    drown.closedFeatureSignature = FeatureSignature.fullSpec := by decide
 
 /-! ### Falsifying the Bifurcation Thesis -/
 
 /-- √blossom entails change of state — templatic (`v_become`) content
     in the root — falsifying Bifurcation without any manner or cause
     entailment. -/
-theorem blossom_violatesBifurcation : blossom.ViolatesBifurcation :=
-  .inl rfl
+theorem blossom_violatesBifurcation : blossom.ViolatesBifurcation := by
+  decide
 
-theorem crack_violatesBifurcation : crack.ViolatesBifurcation :=
-  .inl rfl
+theorem crack_violatesBifurcation : crack.ViolatesBifurcation := by
+  decide
 
-theorem hand_violatesBifurcation : hand.ViolatesBifurcation :=
-  .inl rfl
+theorem hand_violatesBifurcation : hand.ViolatesBifurcation := by decide
 
-theorem drown_violatesBifurcation : drown.ViolatesBifurcation :=
-  .inl rfl
+theorem drown_violatesBifurcation : drown.ViolatesBifurcation := by
+  decide
 
 /-- Some root carries templatic content. -/
 theorem exists_violatesBifurcation : ∃ r : Root, r.ViolatesBifurcation :=
@@ -156,11 +143,11 @@ theorem bifurcation_thesis_false :
 
 /-- √hand entails both a manner (by-hand transfer) and a result
     (recipient possession). -/
-theorem hand_hasMannerAndResult : hand.HasMannerAndResult := ⟨rfl, rfl⟩
+theorem hand_hasMannerAndResult : hand.HasMannerAndResult := by decide
 
 /-- √drown entails both a manner (submersion) and a result (death);
     it differs from √hand in root position. -/
-theorem drown_hasMannerAndResult : drown.HasMannerAndResult := ⟨rfl, rfl⟩
+theorem drown_hasMannerAndResult : drown.HasMannerAndResult := by decide
 
 /-- Some root entails both a manner and a result. -/
 theorem exists_hasMannerAndResult : ∃ r : Root, r.HasMannerAndResult :=
@@ -173,7 +160,8 @@ theorem manner_result_complementarity_false :
 
 /-! ### Roots respecting each constraint -/
 
-/-- √flat (pure state) respects Bifurcation. -/
+/-- √flat (pure state) respects Bifurcation: its signature is bounded
+    by the ontological kinds. -/
 theorem flat_respectsBifurcation : flat.RespectsBifurcation := by decide
 
 /-- √jog (pure manner) respects Bifurcation. -/

--- a/Linglib/Studies/HaninkKoontzGarboden2025.lean
+++ b/Linglib/Studies/HaninkKoontzGarboden2025.lean
@@ -56,7 +56,7 @@ Property concept (PC) roots in Wá·šiw come in two semantic types:
   inside the verbal categorizer's denotation.
 - Against [menon-pancheva-2014]'s universalist claim: not all PC
   roots have the same meaning.
-- All Wá·šiw PC roots are `RootEntailments.propertyConcept` (+S −M −R −C)
+- All Wá·šiw PC roots are `FeatureSignature.propertyConcept` (+S −M −R −C)
   per [beavers-koontz-garboden-2020] — the variation is in *semantic
   type*, not in structural entailments.
 -/

--- a/Linglib/Studies/Krejci2012.lean
+++ b/Linglib/Studies/Krejci2012.lean
@@ -48,7 +48,7 @@ Texas at Austin.
 namespace Krejci2012
 
 open Semantics.Lexical
-open Semantics.Lexical.Roots
+open FeatureSignature
 open Semantics.Causation.Morphological
 open Semantics.Lexical.EventStructure
 open Semantics.ArgumentStructure.ArgDerivation
@@ -227,23 +227,23 @@ theorem dress_same_form : dress.lexicalCausative = none := rfl
 -- ════════════════════════════════════════════════════
 
 /-! [krejci-2012]'s claim that eat and dress have causative event
-    structure aligns with their `RootEntailments` classification:
-    both are `causativeResult` (state + result + cause), meaning the
+    structure aligns with their `FeatureSignature` classification:
+    both are `causativeResult` ({state, result, cause}), meaning the
     root itself entails external causation. -/
 
 /-- eat roots are causativeResult: the root entails caused consumption. -/
 theorem eat_is_causativeResult :
-    LevinClass.rootEntailments .eat = .causativeResult := rfl
+    LevinClass.rootEntailments .eat = causativeResult := rfl
 
 /-- dress roots are causativeResult: the root entails caused dressed state. -/
 theorem dress_is_causativeResult :
-    LevinClass.rootEntailments .dress = .causativeResult := rfl
+    LevinClass.rootEntailments .dress = causativeResult := rfl
 
-/-- causativeResult roots entail cause — consistent with
+/-- causativeResult roots carry the `cause` kind — consistent with
     [krejci-2012]'s analysis that these verbs have CAUSE in their
     simple forms. -/
 theorem causativeResult_entails_cause :
-    RootEntailments.causativeResult.cause = true := rfl
+    LexKind.cause ∈ causativeResult := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 6. Bridge to ArgDerivation

--- a/Linglib/Studies/Levin2026.lean
+++ b/Linglib/Studies/Levin2026.lean
@@ -120,7 +120,7 @@ theorem agrees_with_diathesis_data :
     no causation. The result and causation come from the construction. -/
 theorem all_classes_pure_manner :
     intrPushOpenClasses.all
-      (·.rootEntailments == .pureManner) = true := by
+      (·.rootEntailments == FeatureSignature.pureManner) = true := by
   native_decide
 
 /-- All core classes encode contact and motion but NOT change of state
@@ -767,7 +767,7 @@ theorem blocked_wrong_adjective :
 theorem end_to_end_push_open :
     -- Step 1-2: verb class blocks alternation alone
     LevinClass.pushPull.participatesIn .causativeInchoative = false ∧
-    LevinClass.rootEntailments .pushPull == .pureManner ∧
+    LevinClass.rootEntailments .pushPull == FeatureSignature.pureManner ∧
     -- Step 3: fusion — construction adds CoS + causation → alternation predicted
     predictedAlternationInConstruction
       LevinClass.pushPull.meaningComponents

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -33,7 +33,7 @@ two roots have the same salience class iff the same operator(s) apply
 to them. The 3-way classification then *falls out* of (B&K-G feature
 signature) × (operator applicability conditions) — it is not stipulated.
 
-The structural theorem `salienceClass_from_signature` makes this
+The structural theorem `class_depends_only_on_signature` makes this
 precise: salience class depends only on the feature signature, not on
 the specific root identity. The per-root checks then degenerate to
 finite signature lookups.
@@ -41,14 +41,11 @@ finite signature lookups.
 
 namespace Lucy1994
 
-open Semantics.Lexical.Roots
 open Morphology.Derivation
 open Yukatek.Roots
 open Yukatek.Operators
 
--- ════════════════════════════════════════════════════
--- § 1. Salience Classes (re-exported from Theory)
--- ════════════════════════════════════════════════════
+/-! ### Salience classes (re-exported from theory) -/
 
 /-! `SalienceClass` and `classOfSignature` live in
     `Semantics/Lexical/Roots/SalienceClass.lean`. This file
@@ -67,30 +64,40 @@ theorem class_depends_only_on_signature
     predictedClass r₁ = predictedClass r₂ :=
   predictedSalience_depends_only_on_signature r₁ r₂ h
 
--- ════════════════════════════════════════════════════
--- § 4. Predicted Class Agrees with Operator Applicability
--- ════════════════════════════════════════════════════
+/-! ### Predicted class agrees with operator applicability -/
 
-/-! Each of the four applicability characterisations follows the same
-    pattern: unfold the applicability profile and the named class predicates, then
-    case-split on the four B&K-G feature bits and let `simp_all`
-    discharge each cell of the 16-row truth table. The local macro
-    `lucy_applicable` packages this so the four theorems differ only in
-    which class label appears on the LHS. -/
+/-! Both `predictedClass` and the inventory's applicability profile
+    factor through the root's feature signature, a `Finset LexKind`
+    drawn from a 16-element fintype. Each characterisation therefore
+    reduces — after rewriting the profile to signature level
+    (`applicableNames_eq_profile`) and generalising the signature — to
+    a statement over all signatures that `decide` checks. The local
+    macro `lucy_applicable` packages the reduction. -/
+
+/-- The inventory's applicability profile as a function of the feature
+    signature. The four operator conditions are pairwise disjoint
+    (`classes_pairwise_disjoint`), so at most one name appears. -/
+private theorem applicableNames_eq_profile (r : Root) :
+    inventory.applicableNames r =
+      (if r.featureSignature.IsAgentSalient then ["=t"] else []) ++
+      (if r.featureSignature.IsAgentPatientSalient then ["=∅"] else []) ++
+      (if r.featureSignature.IsPatientSalient then ["=s"] else []) ++
+      (if r.featureSignature.IsPositional then ["-tal"] else []) := by
+  simp only [inventory, Inventory.applicableNames, affectiveT, zeroDeriv,
+    causativeS, positionalTal, List.filter_cons, List.filter_nil,
+    decide_eq_true_eq, Root.IsAgentSalient, Root.IsAgentPatientSalient,
+    Root.IsPatientSalient, Root.IsPositional]
+  generalize r.featureSignature = s
+  revert s
+  decide
 
 local macro "lucy_applicable " r:term : tactic =>
   `(tactic|
-    (unfold predictedClass Root.predictedSalience classOfSignature
-       inventory Inventory.applicableNames
-       affectiveT zeroDeriv causativeS positionalTal
-       Root.IsAgentSalient Root.IsAgentPatientSalient
-       Root.IsPatientSalient Root.IsPositional
-       FeatureSignature.IsAgentSalient FeatureSignature.IsAgentPatientSalient
-       FeatureSignature.IsPatientSalient FeatureSignature.IsPositional
-       Root.featureSignature
-     simp only [List.filter_cons, List.filter_nil, decide_eq_true_eq]
-     cases hm : ($r).hasManner <;> cases hr : ($r).hasResult <;>
-       cases hs : ($r).hasState <;> cases hc : ($r).hasCause <;> simp_all))
+    (rw [applicableNames_eq_profile]
+     unfold predictedClass Root.predictedSalience
+     generalize ($r).featureSignature = s
+     revert s
+     decide))
 
 /-- The `=t`-only applicability profile characterises agent-salient roots. -/
 theorem agent_iff_applicable_t (r : Root) :
@@ -112,9 +119,9 @@ theorem positional_iff_applicable_tal (r : Root) :
     predictedClass r = some .positional ↔ inventory.applicableNames r = ["-tal"] := by
   lucy_applicable r
 
-/-- An empty applicability profile characterises roots outside [lucy-1994]'s
-    diagnostic gap (`(¬manner, ¬result)` rows that lack the positional
-    configuration `state ∧ ¬cause`). -/
+/-- An empty applicability profile characterises roots in [lucy-1994]'s
+    diagnostic gap (the no-manner, no-result signatures other than the
+    pure positional configuration `{.state}`). -/
 theorem none_iff_applicable_empty (r : Root) :
     predictedClass r = none ↔ inventory.applicableNames r = [] := by
   lucy_applicable r
@@ -126,23 +133,14 @@ theorem none_iff_applicable_empty (r : Root) :
 theorem applicableNames_eq_iff_predictedClass_eq (r₁ r₂ : Root) :
     inventory.applicableNames r₁ = inventory.applicableNames r₂ ↔
       predictedClass r₁ = predictedClass r₂ := by
-  unfold predictedClass Root.predictedSalience classOfSignature
-    inventory Inventory.applicableNames
-    affectiveT zeroDeriv causativeS positionalTal
-    Root.IsAgentSalient Root.IsAgentPatientSalient
-    Root.IsPatientSalient Root.IsPositional
-    FeatureSignature.IsAgentSalient FeatureSignature.IsAgentPatientSalient
-    FeatureSignature.IsPatientSalient FeatureSignature.IsPositional
-    Root.featureSignature
-  simp only [List.filter_cons, List.filter_nil, decide_eq_true_eq]
-  cases r₁.hasManner <;> cases r₁.hasResult <;>
-    cases r₁.hasState <;> cases r₁.hasCause <;>
-    cases r₂.hasManner <;> cases r₂.hasResult <;>
-      cases r₂.hasState <;> cases r₂.hasCause <;> simp_all
+  rw [applicableNames_eq_profile, applicableNames_eq_profile]
+  unfold predictedClass Root.predictedSalience
+  generalize r₁.featureSignature = s₁
+  generalize r₂.featureSignature = s₂
+  revert s₁ s₂
+  decide
 
--- ════════════════════════════════════════════════════
--- § 5. Per-Root Sanity Checks
--- ════════════════════════════════════════════════════
+/-! ### Per-root sanity checks -/
 
 /-! Agent-salient. -/
 theorem siit_agent  : predictedClass siit  = some .agent := rfl
@@ -183,9 +181,7 @@ theorem liik_patient : predictedClass liik = some .patient := rfl
 theorem cin_positional : predictedClass cin = some .positional := rfl
 theorem kul_positional : predictedClass kul = some .positional := rfl
 
--- ════════════════════════════════════════════════════
--- § 6. The "Motion Verbs" Non-Class
--- ════════════════════════════════════════════════════
+/-! ### The "motion verbs" non-class -/
 
 /-- [lucy-1994]'s central typological point: "motion" verbs
     (`luub` "fall", `ok` "enter") are not in their own salience class
@@ -202,37 +198,34 @@ theorem motion_roots_not_separate_class :
 theorem positional_distinct_from_motion :
     predictedClass cin ≠ predictedClass luub := by decide
 
--- ════════════════════════════════════════════════════
--- § 7. Closure Robustness
--- ════════════════════════════════════════════════════
+/-! ### Closure robustness -/
 
 /-- The class predicted from a root's *closed* feature signature
-    (`bkgRules` applied to the base entailments). -/
+    (the collocational closure `FeatureSignature.close` of the derived
+    signature). -/
 def closedPredictedClass (r : Root) : Option SalienceClass :=
   classOfSignature r.closedFeatureSignature
 
-/-- Closure under `bkgRules` does not change the Lucy 1994 salience
-    classification: agent / agentPatient / patient classes ignore the
-    `state` field, and the positional class requires `result = false`,
-    which closure does not affect (`closedFeatureSignature_result`).
-    The only way closure can flip `state` from `false` to `true` is if
-    the base set has a `becomesState` atom (so `result = true`) — in
-    which case the positional arm is already excluded by `result`. -/
-theorem predictedClass_closure_invariant (r : Root) :
+/-- For cause-free roots, collocational closure does not change the
+    Lucy 1994 salience classification: the only closure edge that can
+    fire is result→state, the agent / agentPatient / patient arms
+    ignore `.state` membership, and a base that gains `.state` from
+    closure carries `.result` and so is already excluded from the
+    positional arm. The hypothesis is necessary: a root carrying
+    `.cause` but not `.result` is unclassified at base yet
+    patient-salient after closure, since the cause→result closure edge
+    introduces `.result`. -/
+theorem predictedClass_closure_invariant (r : Root) (h : ¬ r.HasCause) :
     closedPredictedClass r = predictedClass r := by
+  unfold Root.HasCause at h
   unfold closedPredictedClass predictedClass Root.predictedSalience
-    classOfSignature
-  rw [closedFeatureSignature_manner, closedFeatureSignature_result,
-      closedFeatureSignature_cause, closedFeatureSignature_state_eq]
-  rcases hm : r.featureSignature.manner with _ | _ <;>
-    rcases hr : r.featureSignature.result with _ | _ <;>
-    rcases hc : r.featureSignature.cause with _ | _ <;>
-    rcases hs : r.featureSignature.state with _ | _ <;>
-    simp_all
+    Root.closedFeatureSignature
+  revert h
+  generalize r.featureSignature = s
+  revert s
+  decide
 
--- ════════════════════════════════════════════════════
--- § 8. Bridge to Bohnemeyer's 5-Way Verb Stem Classes
--- ════════════════════════════════════════════════════
+/-! ### Bridge to Bohnemeyer's 5-way verb stem classes -/
 
 /-! [bohnemeyer-2004] refines [lucy-1994]'s 4-way salience
     cut into a 5-way stem classification (`active`, `inactive`,

--- a/Linglib/Studies/MajidBosterBowerman2008.lean
+++ b/Linglib/Studies/MajidBosterBowerman2008.lean
@@ -36,7 +36,7 @@ they carve and where they place boundaries.
 
 ## Integration with linglib
 
-The 4 dimensions project onto existing `RootProfile` features:
+The 4 dimensions project onto existing `Root.Profile` features:
 
 | Dimension | Projects onto |
 |-----------|--------------|
@@ -54,7 +54,7 @@ Bridge theorems connect to `LevinClass` and `MeaningComponents`:
 ## Design
 
 `SeparationEvent` is a **point** in the same feature space that
-`RootProfile` defines **regions** over. A verb is compatible with an
+`Root.Profile` defines **regions** over. A verb is compatible with an
 event iff the event's feature values fall within the verb root's ranges.
 This captures the many-to-many mapping between events and verbs that
 varies across languages.
@@ -63,7 +63,6 @@ varies across languages.
 namespace MajidBosterBowerman2008
 
 open Semantics.Lexical
-open Semantics.Lexical.Roots
 open Features
 open InstrumentType ObjectDimensionality Robustness ResultType
      ForceLevel ForceDirection
@@ -78,7 +77,7 @@ open InstrumentType ObjectDimensionality Robustness ResultType
     This is the **stimulus level**: each value is a specific point,
     not a range. Corresponds to a single video clip in the experiment.
     Verb roots select *ranges* over these same dimensions
-    (via `RootProfile`). -/
+    (via `Root.Profile`). -/
 structure SeparationEvent where
   /-- Instrument used to effect separation. -/
   instrument : InstrumentType
@@ -260,7 +259,7 @@ def SeparationEvent.isPokingHole (e : SeparationEvent) : Bool :=
   e.result == .surfaceBreach && e.objectDim == .twoD && e.objectRob == .flimsy
 
 -- ════════════════════════════════════════════════════
--- § 4. Compatibility with RootProfile
+-- § 4. Compatibility with Root.Profile
 -- ════════════════════════════════════════════════════
 
 /-- Is a separation event compatible with a verb root's profile?
@@ -268,7 +267,7 @@ def SeparationEvent.isPokingHole (e : SeparationEvent) : Bool :=
     An event is compatible iff each of its feature values falls within
     the root's range for that dimension. Unconstrained dimensions
     (range = none) accept any value. -/
-def SeparationEvent.compatibleWith (e : SeparationEvent) (r : RootProfile) : Bool :=
+def SeparationEvent.compatibleWith (e : SeparationEvent) (r : Root.Profile) : Bool :=
   r.forceMag.isCompatible e.force &&
   r.forceDir.isCompatible e.forceDir &&
   r.patientRob.isCompatible e.objectRob &&
@@ -507,7 +506,7 @@ theorem cut_break_same_template :
 
 open English.Predicates.Verbal in
 /-- Extract the root profile from a Fragment verb entry. -/
-private def fragmentProfile (v : VerbEntry) : RootProfile :=
+private def fragmentProfile (v : VerbEntry) : Root.Profile :=
   v.rootProfile.getD {}
 
 open English.Predicates.Verbal

--- a/Linglib/Studies/SpalekMcNally2026.lean
+++ b/Linglib/Studies/SpalekMcNally2026.lean
@@ -94,8 +94,8 @@ theorem agent_control_differs :
     where both verbs are applicable. This overlap zone is where they
     function as translation equivalents (§4.2, Table 1). -/
 theorem roots_overlap :
-    (tear_.rootProfile.get!).overlaps (rasgar.rootProfile.get!) = true := by
-  native_decide
+    (tear_.rootProfile.get!).overlaps (rasgar.rootProfile.get!) := by
+  decide
 
 -- ════════════════════════════════════════════════════
 -- § 4. Translation Data (§4.2, Tables 1–2)

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -891,9 +891,8 @@ theorem largeVase_score_le_one :
     bundles of lexical entailments
     (`Semantics/Lexical/Roots/Basic.lean`). Their classification
     of √crack is `[.becomesState "fissured", .hasCause]` — the
-    "result + cause, no manner" base four-feature signature
-    `⟨hasState=false, hasManner=false, hasResult=true, hasCause=true⟩`
-    (`BeaversKoontzGarboden2020.crack`).
+    "result + cause, no manner" base feature signature
+    `{.result, .cause}` (`BeaversKoontzGarboden2020.crack`).
 
     Tham §5.1 (the (45) examples — cracked pumpkin, dented helmet
     model, scratched decal) is in tension with strict result-state
@@ -905,17 +904,15 @@ theorem largeVase_score_le_one :
     yet the adjectival side `Tham2025.crack.adjEntailsPrecedingChange`
     is false. -/
 
-/-- B&KG's `crack` root has `hasResult = true` (the `becomesState
-    "fissured"` entailment provides it), but Tham's deverbal adjective
+/-- B&KG's `crack` root has a result entailment (the `becomesState
+    "fissured"` atom provides it), but Tham's deverbal adjective
     *cracked* does NOT entail a preceding CoS event. Strict result-
     state inheritance from root to deverbal adjective is refuted at
     substrate level. -/
 theorem cracked_adj_refutes_bkg_crack_root_inheritance :
-    Semantics.Lexical.Roots.Root.hasResult
-      BeaversKoontzGarboden2020.crack
-      = true ∧
-    crack.adjEntailsPrecedingChange = false := by
-  refine ⟨rfl, rfl⟩
+    BeaversKoontzGarboden2020.crack.HasResult ∧
+    crack.adjEntailsPrecedingChange = false :=
+  ⟨by decide, rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 15. Cross-paper engagement: Waldon et al. 2023 contrast

--- a/Linglib/Syntax/Minimalist/Ellipsis/DeletionDomain.lean
+++ b/Linglib/Syntax/Minimalist/Ellipsis/DeletionDomain.lean
@@ -50,7 +50,6 @@ generically for all `DeletionSpine` instances.
 
 namespace Minimalist.Ellipsis
 
-open Semantics.Lexical.Roots
 
 -- ════════════════════════════════════════════════════
 -- § 0. Generic Deletion Spine


### PR DESCRIPTION
Unifies the two root-typology towers on one order-theoretic signature type and flattens the namespace to root level (Event precedent).

- New `Roots/Signature.lean`: `LexKind` with the book's collocational partial order, `FeatureSignature := Finset LexKind`, `close` as a mathlib `ClosureOperator`, `WellFormed ↔ IsLowerSet`, canonical typology rows, theses as order statements (`ViolatesBifurcation := ¬ s ≤ ontological`)
- `RootEntailments` dissolved (RootFeatures.lean → `Roots/Profile.lean` with `Root.Profile`); Levin tower, RootTypology, Verb facet, Yukatek/Lucy1994 all retyped to the one signature type; ex-`WellFormed` stipulation is now a theorem of closure

Depends on #259 (substrate corrections this builds on)