### PR TITLE
refactor(Semantics/Lexical/Roots): Finset carrier, atom ClosureOperator

### DIFF
--- a/Linglib/Fragments/Mayan/Yukatek/Roots.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Roots.lean
@@ -64,22 +64,22 @@ namespace Yukatek.Roots
     feature in Yukatek (cf. `motion_roots_not_separate_class`); jumping
     qualifies as a manner-of-action irrespective of whether it
     incidentally involves displacement. -/
-def siit : Root := ⟨"siit'", [.hasManner "jumping"]⟩
+def siit : Root := ⟨"siit'", {.hasManner "jumping"}⟩
 
 /-- ¢'iib "write" — manner-of-action activity ([lucy-1994] p. 628). -/
-def tziib : Root := ⟨"tziib", [.hasManner "writing"]⟩
+def tziib : Root := ⟨"tziib", {.hasManner "writing"}⟩
 
 /-- mìis "sweep" — manner-of-action activity
     ([lucy-1994] agent-salient list). -/
-def miis : Root := ⟨"mìis", [.hasManner "sweeping"]⟩
+def miis : Root := ⟨"mìis", {.hasManner "sweeping"}⟩
 
 /-- ć'eh "shout" — manner-of-action activity
     ([lucy-1994] agent-salient list). -/
-def cheh : Root := ⟨"ć'eh", [.hasManner "shouting"]⟩
+def cheh : Root := ⟨"ć'eh", {.hasManner "shouting"}⟩
 
 /-- paak "weed" — manner-of-action activity
     ([lucy-1994] agent-salient list). -/
-def paak : Root := ⟨"paak", [.hasManner "weeding"]⟩
+def paak : Root := ⟨"paak", {.hasManner "weeding"}⟩
 
 -- ════════════════════════════════════════════════════
 -- § 2. Agent-Patient Salient Roots (manner + result, take `=∅`)
@@ -88,78 +88,78 @@ def paak : Root := ⟨"paak", [.hasManner "weeding"]⟩
 /-- kuč "carry" — action with patient affected ([lucy-1994] ex. 1b).
     Underived transitive; no derivation needed. -/
 def kuc : Root := ⟨"kuc",
-  [.hasManner "carrying", .becomesState "transported"]⟩
+  {.hasManner "carrying", .becomesState "transported"}⟩
 
 /-- p'is "measure" — action with patient affected ([lucy-1994] p. 629). -/
 def pis : Root := ⟨"pis",
-  [.hasManner "measuring", .becomesState "measured"]⟩
+  {.hasManner "measuring", .becomesState "measured"}⟩
 
 /-- lo'š "punch" — action with patient affected ([lucy-1994] p. 629).
     No `.contact` atom: contact is implicit in the manner of striking
     rather than a B&K-G feature in Lucy's typology. -/
 def los : Root := ⟨"los",
-  [.hasManner "striking", .becomesState "punched"]⟩
+  {.hasManner "striking", .becomesState "punched"}⟩
 
 -- ════════════════════════════════════════════════════
 -- § 3. Patient-Salient Roots (result only, take `=s`)
 -- ════════════════════════════════════════════════════
 
 /-- kíim "die" — spontaneous state change ([lucy-1994] ex. 1c, 2). -/
-def kiim : Root := ⟨"kiim", [.becomesState "dead"]⟩
+def kiim : Root := ⟨"kiim", {.becomesState "dead"}⟩
 
 /-- háan "stop, cease, heal" ([lucy-1994] patient-salient list,
     p. 630, ex. 2). High-tone vowel: distinct from `Yukatek.haanEat`
     "eat" (low-tone `hàan`), which is `inactive`-class but
     internally caused — see `Fragments/Mayan/Yukatek/VerbClasses.lean`
     and [bohnemeyer-2004] ex. (9). -/
-def haanCease : Root := ⟨"háan", [.becomesState "stopped"]⟩
+def haanCease : Root := ⟨"háan", {.becomesState "stopped"}⟩
 
 /-- lúub' "fall" ([lucy-1994] ex. 4, Table 4). A "motion verb" by
     any reasonable cross-linguistic notional taxonomy, but patterns
     morphologically with other patient-salient change-of-state roots
     in Yukatek. No `.motion` atom: motion is the *issue*, not a
     feature — see `motion_roots_not_separate_class`. -/
-def luub : Root := ⟨"luub'", [.becomesState "fallen"]⟩
+def luub : Root := ⟨"luub'", {.becomesState "fallen"}⟩
 
 /-- 'ok "enter, intrude" ([lucy-1994] ex. 4, Table 4). Another
     notional motion root that takes `=s` like patient-salient state
     changes. -/
-def ok : Root := ⟨"'ok", [.becomesState "inside"]⟩
+def ok : Root := ⟨"'ok", {.becomesState "inside"}⟩
 
 /-! Additional patient-salient roots from the page-630 list. -/
 
 /-- 'ah "wake" ([lucy-1994] patient-salient list). -/
-def ah : Root := ⟨"'ah", [.becomesState "awake"]⟩
+def ah : Root := ⟨"'ah", {.becomesState "awake"}⟩
 
 /-- wen "sleep" ([lucy-1994] patient-salient list). State change
     *into* sleep, not the activity of sleeping. -/
-def wen : Root := ⟨"wen", [.becomesState "asleep"]⟩
+def wen : Root := ⟨"wen", {.becomesState "asleep"}⟩
 
 /-- siih "be born" ([lucy-1994] patient-salient list). -/
-def siih : Root := ⟨"siih", [.becomesState "born"]⟩
+def siih : Root := ⟨"siih", {.becomesState "born"}⟩
 
 /-- tú'ub' "be forgotten" ([lucy-1994] patient-salient list). -/
-def tuub : Root := ⟨"tú'ub'", [.becomesState "forgotten"]⟩
+def tuub : Root := ⟨"tú'ub'", {.becomesState "forgotten"}⟩
 
 /-- k'a'ah "remember" ([lucy-1994] patient-salient list). -/
-def kaah : Root := ⟨"k'a'ah", [.becomesState "remembered"]⟩
+def kaah : Root := ⟨"k'a'ah", {.becomesState "remembered"}⟩
 
 /-- čú'un "begin" ([lucy-1994] patient-salient list). -/
-def chuun : Root := ⟨"čú'un", [.becomesState "begun"]⟩
+def chuun : Root := ⟨"čú'un", {.becomesState "begun"}⟩
 
 /-- č'en "stop, cease" ([lucy-1994] patient-salient list).
     Distinct from `haanCease` (Lucy lists them as separate entries). -/
-def chenCease : Root := ⟨"č'en", [.becomesState "ceased"]⟩
+def chenCease : Root := ⟨"č'en", {.becomesState "ceased"}⟩
 
 /-- hó'op' "begin" ([lucy-1994] patient-salient list). Doublet of
     `chuun`; both gloss as "begin" in the patient-salient list. -/
-def hoop : Root := ⟨"hó'op'", [.becomesState "started"]⟩
+def hoop : Root := ⟨"hó'op'", {.becomesState "started"}⟩
 
 /-- hé'el "rest" ([lucy-1994] patient-salient list). -/
-def heel : Root := ⟨"hé'el", [.becomesState "rested"]⟩
+def heel : Root := ⟨"hé'el", {.becomesState "rested"}⟩
 
 /-- p'át "remain" ([lucy-1994] patient-salient list). -/
-def paat : Root := ⟨"p'át", [.becomesState "remaining"]⟩
+def paat : Root := ⟨"p'át", {.becomesState "remaining"}⟩
 
 /-! Motion roots from [lucy-1994] Table 4. These pattern as
     patient-salient (`becomesState` only) — the central typological
@@ -167,21 +167,21 @@ def paat : Root := ⟨"p'át", [.becomesState "remaining"]⟩
     `motion_roots_predicted_patient`. -/
 
 /-- máan "pass" ([lucy-1994] Table 4). -/
-def maan : Root := ⟨"máan", [.becomesState "passed"]⟩
+def maan : Root := ⟨"máan", {.becomesState "passed"}⟩
 
 /-- tàal "come" ([lucy-1994] Table 4). -/
-def taal : Root := ⟨"tàal", [.becomesState "arrived"]⟩
+def taal : Root := ⟨"tàal", {.becomesState "arrived"}⟩
 
 /-- b'in "go" ([lucy-1994] Table 4). -/
-def bin : Root := ⟨"b'in", [.becomesState "departed"]⟩
+def bin : Root := ⟨"b'in", {.becomesState "departed"}⟩
 
 /-- nàak "ascend" ([lucy-1994] Table 4). Distinct from
     `Yukatek.naak` "ascend" in `VerbClasses.lean`, which encodes
     Bohnemeyer's stem-class data; both refer to the same Yukatek root. -/
-def naak : Root := ⟨"nàak", [.becomesState "ascended"]⟩
+def naak : Root := ⟨"nàak", {.becomesState "ascended"}⟩
 
 /-- lìik' "rise" ([lucy-1994] Table 4). -/
-def liik : Root := ⟨"lìik'", [.becomesState "risen"]⟩
+def liik : Root := ⟨"lìik'", {.becomesState "risen"}⟩
 
 -- ════════════════════════════════════════════════════
 -- § 4. Positional Roots (state only, take `-tal`)
@@ -189,11 +189,11 @@ def liik : Root := ⟨"lìik'", [.becomesState "risen"]⟩
 
 /-- čin "bow, bend down, bend over" ([lucy-1994] ex. 5, 7).
     Positional root; takes `-tal` (or `-lah`) for the inchoative stem. -/
-def cin : Root := ⟨"cin", [.hasState "bent"]⟩
+def cin : Root := ⟨"cin", {.hasState "bent"}⟩
 
 /-- kul "sit" — positional root (cf. [lucy-1994] ex. 8c on
     relational positional semantics: "x is-seated [on y]"). -/
-def kul : Root := ⟨"kul", [.hasState "seated"]⟩
+def kul : Root := ⟨"kul", {.hasState "seated"}⟩
 
 /-! ### Per-root feature signatures -/
 

--- a/Linglib/Fragments/Mayan/Yukatek/Roots.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Roots.lean
@@ -272,7 +272,7 @@ theorem kul_signature :
 
 /-! ### Per-root closed feature signatures -/
 
-/-! The collocational closure (`FeatureSignature.close`) adds `.state`
+/-! The collocational closure (`Root.FeatureSignature.close`) adds `.state`
     to any signature containing `.result`, and `.result` + `.state` to
     any containing `.cause`. No Yukatek root here carries a `.cause`
     atom, so only the result→state edge fires. Closure does *not*

--- a/Linglib/Morphology/RootTypology.lean
+++ b/Linglib/Morphology/RootTypology.lean
@@ -362,7 +362,7 @@ theorem result_roots_witness_against_bifurcation :
 theorem pc_roots_consistent_with_bifurcation :
     RootType.entailsChange .propertyConcept = false := rfl
 
-/-- **B&[beavers-koontz-garboden-2020] strengthened bifurcation failure via `FeatureSignature`.**
+/-- **B&[beavers-koontz-garboden-2020] strengthened bifurcation failure via `Root.FeatureSignature`.**
 
     [beavers-etal-2021] show roots can entail CHANGE (one templatic notion).
     B&[beavers-koontz-garboden-2020] show roots can entail CHANGE, CAUSATION, and MANNER —
@@ -371,16 +371,16 @@ theorem pc_roots_consistent_with_bifurcation :
     roots encoding manner+cause (√GUILLOTINE, √HAND) violate bifurcation
     on three separate dimensions simultaneously.
 
-    Witness: `FeatureSignature.fullSpec` carries all four kinds. -/
+    Witness: `Root.FeatureSignature.fullSpec` carries all four kinds. -/
 theorem bkg_bifurcation_fails_all_dimensions :
     -- Roots can entail change (result kind)
-    LexKind.result ∈ FeatureSignature.fullSpec ∧
+    LexKind.result ∈ Root.FeatureSignature.fullSpec ∧
     -- Roots can entail causation (cause kind)
-    LexKind.cause ∈ FeatureSignature.fullSpec ∧
+    LexKind.cause ∈ Root.FeatureSignature.fullSpec ∧
     -- Roots can entail manner (manner kind)
-    LexKind.manner ∈ FeatureSignature.fullSpec ∧
+    LexKind.manner ∈ Root.FeatureSignature.fullSpec ∧
     -- All at once — not just one dimension
-    LexKind.state ∈ FeatureSignature.fullSpec := by decide
+    LexKind.state ∈ Root.FeatureSignature.fullSpec := by decide
 
 /-- Multiple Levin classes witness the stronger bifurcation failure. -/
 theorem bkg_bifurcation_multiple_witnesses :
@@ -597,7 +597,7 @@ theorem RootDen.pc_respects {Entity State Event : Type}
     (RootDen.pc sp : RootDen Entity State Event).denotationViolatesMRC = false := rfl
 
 /-- **Bridge: denotation-level MRC → signature-level MRC
-    (`FeatureSignature.HasMannerAndResult`).**
+    (`Root.FeatureSignature.HasMannerAndResult`).**
     MRC violation requires BOTH conditions — having manner alone
     (if such a constructor existed) would not be a violation. -/
 theorem RootDen.mrc_requires_both {Entity State Event : Type}
@@ -1431,7 +1431,7 @@ theorem same_change_same_morphosyntax (r₁ r₂ : RootClassification)
     positions give 32 theoretical cells, of which 7 are attested and
     the rest are principled gaps. -/
 structure FullRootSpec where
-  entailments : FeatureSignature
+  entailments : Root.FeatureSignature
   position : Root.Position
   deriving DecidableEq
 
@@ -1467,29 +1467,29 @@ instance (s : FullRootSpec) : Decidable s.WellFormed :=
 
 /-- √FLAT: +S −M −R −C, complement. Property concept root. -/
 def FullRootSpec.flat : FullRootSpec :=
-  ⟨FeatureSignature.propertyConcept, .complement⟩
+  ⟨Root.FeatureSignature.propertyConcept, .complement⟩
 
 /-- √BLOSSOM: +S −M +R −C, complement. Pure result root. -/
 def FullRootSpec.blossom : FullRootSpec :=
-  ⟨FeatureSignature.pureResult, .complement⟩
+  ⟨Root.FeatureSignature.pureResult, .complement⟩
 
 /-- √CRACK: +S −M +R +C, complement. Causative result root. -/
 def FullRootSpec.crack : FullRootSpec :=
-  ⟨FeatureSignature.causativeResult, .complement⟩
+  ⟨Root.FeatureSignature.causativeResult, .complement⟩
 
 /-- √JOG: −S +M −R −C, adjoined. Pure manner root. -/
 def FullRootSpec.jog : FullRootSpec :=
-  ⟨FeatureSignature.pureManner, .adjoined⟩
+  ⟨Root.FeatureSignature.pureManner, .adjoined⟩
 
 /-- √DROWN: +S +M +R +C, complement. Manner+result in complement position —
     the manner restricts HOW the state is caused. -/
 def FullRootSpec.drown : FullRootSpec :=
-  ⟨FeatureSignature.fullSpec, .complement⟩
+  ⟨Root.FeatureSignature.fullSpec, .complement⟩
 
 /-- √TOSS: +S +M +R +C, adjoined. Manner+result in adjunct position —
     the manner is the primary event that happens to cause a state change. -/
 def FullRootSpec.toss : FullRootSpec :=
-  ⟨FeatureSignature.fullSpec, .adjoined⟩
+  ⟨Root.FeatureSignature.fullSpec, .adjoined⟩
 
 /-- √HAND: same entailments + position as √TOSS. The difference is in
     the ditransitive layer (DitransitiveRootClass.causedPossession vs
@@ -1498,7 +1498,7 @@ abbrev FullRootSpec.hand : FullRootSpec := FullRootSpec.toss
 
 /-- √EXIST: −S −M −R −C, complement. Minimal stative root. -/
 def FullRootSpec.exist : FullRootSpec :=
-  ⟨FeatureSignature.minimal, .complement⟩
+  ⟨Root.FeatureSignature.minimal, .complement⟩
 
 -- All attested types are well-formed
 theorem flat_wf : FullRootSpec.flat.WellFormed := by decide
@@ -1548,7 +1548,7 @@ inductive TemplateHead where
     - +manner alone → no v_act (manner without causation doesn't entail
       activity — √JOG specifies jogging manner but v_act still provides
       the activity frame) -/
-def FeatureSignature.entailedHeads (s : FeatureSignature) : List TemplateHead :=
+def Root.FeatureSignature.entailedHeads (s : Root.FeatureSignature) : List TemplateHead :=
   (if LexKind.result ∈ s then [.vBecome] else []) ++
   (if LexKind.cause ∈ s then [.vCause] else []) ++
   (if LexKind.manner ∈ s ∧ LexKind.cause ∈ s then [.vAct] else [])
@@ -1569,51 +1569,51 @@ def DitransitiveRootClass.additionalHeads : DitransitiveRootClass → List Templ
     The root specifies jogging manner, but v_act still provides
     the activity frame — the root doesn't make it redundant. -/
 theorem jog_no_heads :
-    FeatureSignature.pureManner.entailedHeads = [] := by decide
+    Root.FeatureSignature.pureManner.entailedHeads = [] := by decide
 
 /-- √FLAT (propertyConcept): no template heads entailed.
     The root names a state, but doesn't entail change or cause. -/
 theorem flat_no_heads :
-    FeatureSignature.propertyConcept.entailedHeads = [] := by decide
+    Root.FeatureSignature.propertyConcept.entailedHeads = [] := by decide
 
 /-- √BLOSSOM (pureResult): v_become entailed.
     The root entails change — v_become's contribution is redundant. -/
 theorem blossom_heads :
-    FeatureSignature.pureResult.entailedHeads = [.vBecome] := by decide
+    Root.FeatureSignature.pureResult.entailedHeads = [.vBecome] := by decide
 
 /-- √CRACK (causativeResult): v_become + v_cause entailed.
     The root entails change AND causation. -/
 theorem crack_heads :
-    FeatureSignature.causativeResult.entailedHeads = [.vBecome, .vCause] := by
+    Root.FeatureSignature.causativeResult.entailedHeads = [.vBecome, .vCause] := by
   decide
 
 /-- √DROWN (fullSpec): v_become + v_cause + v_act entailed.
     The root entails change, causation, AND activity (manner that causes). -/
 theorem drown_heads :
-    FeatureSignature.fullSpec.entailedHeads = [.vBecome, .vCause, .vAct] := by
+    Root.FeatureSignature.fullSpec.entailedHeads = [.vBecome, .vCause, .vAct] := by
   decide
 
 /-- √TOSS (fullSpec + ballistic): v_become + v_cause + v_act + P_loc.
     Verbal heads from entailments + P_loc from ditransitive class. -/
 theorem toss_heads :
-    FeatureSignature.fullSpec.entailedHeads ++
+    Root.FeatureSignature.fullSpec.entailedHeads ++
     DitransitiveRootClass.additionalHeads .ballisticMotion =
     [.vBecome, .vCause, .vAct, .pLoc] := by decide
 
 /-- √HAND (fullSpec + causedPossession): all 5 heads.
     Verbal heads from entailments + P_loc + P_have from ditransitive class. -/
 theorem hand_heads :
-    FeatureSignature.fullSpec.entailedHeads ++
+    Root.FeatureSignature.fullSpec.entailedHeads ++
     DitransitiveRootClass.additionalHeads .causedPossession =
     [.vBecome, .vCause, .vAct, .pLoc, .pHave] := by decide
 
 /-- Monotonicity: more root entailments → weakly more heads entailed.
     Pure result ⊂ causative result ⊂ full spec (by inclusion). -/
 theorem heads_monotone :
-    FeatureSignature.pureResult.entailedHeads.length ≤
-    FeatureSignature.causativeResult.entailedHeads.length ∧
-    FeatureSignature.causativeResult.entailedHeads.length ≤
-    FeatureSignature.fullSpec.entailedHeads.length := ⟨by decide, by decide⟩
+    Root.FeatureSignature.pureResult.entailedHeads.length ≤
+    Root.FeatureSignature.causativeResult.entailedHeads.length ∧
+    Root.FeatureSignature.causativeResult.entailedHeads.length ≤
+    Root.FeatureSignature.fullSpec.entailedHeads.length := ⟨by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
 -- § 19. Gap Predictions (B&[beavers-koontz-garboden-2020] §5.4.1, Table 12)
@@ -1649,19 +1649,19 @@ B&KG (§5.4.1) identify three principled gap types:
 
 /-- Gap type 1: adjoined position requires manner. -/
 theorem gap_adjoined_no_manner :
-    ¬ (FullRootSpec.mk FeatureSignature.propertyConcept .adjoined).PositionLicensed := by
+    ¬ (FullRootSpec.mk Root.FeatureSignature.propertyConcept .adjoined).PositionLicensed := by
   decide
 
 theorem gap_adjoined_result :
-    ¬ (FullRootSpec.mk FeatureSignature.pureResult .adjoined).PositionLicensed := by
+    ¬ (FullRootSpec.mk Root.FeatureSignature.pureResult .adjoined).PositionLicensed := by
   decide
 
 theorem gap_adjoined_causativeResult :
-    ¬ (FullRootSpec.mk FeatureSignature.causativeResult .adjoined).PositionLicensed := by
+    ¬ (FullRootSpec.mk Root.FeatureSignature.causativeResult .adjoined).PositionLicensed := by
   decide
 
 theorem gap_adjoined_minimal :
-    ¬ (FullRootSpec.mk FeatureSignature.minimal .adjoined).PositionLicensed := by
+    ¬ (FullRootSpec.mk Root.FeatureSignature.minimal .adjoined).PositionLicensed := by
   decide
 
 /-- Gap type 2: +manner +state −result −cause is incoherent. -/
@@ -1675,10 +1675,10 @@ theorem gap_manner_state_no_result_adj :
 
 /-- Gap type 3: well-formedness violations. -/
 theorem gap_result_no_state :
-    ¬ ({.result} : FeatureSignature).WellFormed := by decide
+    ¬ ({.result} : Root.FeatureSignature).WellFormed := by decide
 
 theorem gap_cause_no_result :
-    ¬ ({.state, .cause} : FeatureSignature).WellFormed := by decide
+    ¬ ({.state, .cause} : Root.FeatureSignature).WellFormed := by decide
 
 /-! ### Attested cells are well-formed and recognized -/
 
@@ -1696,7 +1696,7 @@ theorem exist_attested : FullRootSpec.exist.IsAttestedCell := by decide
     without external causation. Left as NOT attested per Table 12,
     pending further research. -/
 theorem mannerResult_complement_unattested :
-    ¬ (FullRootSpec.mk FeatureSignature.mannerResult .complement).IsAttestedCell := by
+    ¬ (FullRootSpec.mk Root.FeatureSignature.mannerResult .complement).IsAttestedCell := by
   decide
 
 /-- The complement/adjoined split for fullSpec roots is the only

--- a/Linglib/Semantics/ArgumentStructure/Affectedness/Profile.lean
+++ b/Linglib/Semantics/ArgumentStructure/Affectedness/Profile.lean
@@ -61,7 +61,7 @@ representation in the codebase:
 
 - `EntailmentProfile.changeOfState` — the proto-patient entailment (this file's input)
 - `MeaningComponents.changeOfState` — the surface diagnostic (`Semantics/Lexical/MeaningComponents.lean`)
-- `LexKind.result` membership in a root's `FeatureSignature` — whether the root itself entails change (`Semantics/Lexical/Roots/Signature.lean`)
+- `LexKind.result` membership in a root's `Root.FeatureSignature` — whether the root itself entails change (`Semantics/Lexical/Roots/Signature.lean`)
 
 These are NOT the same concept. [beavers-koontz-garboden-2020] show
 that surface CoS can come from either the root or the template. The

--- a/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
@@ -10,7 +10,7 @@ import Linglib.Semantics.Lexical.LevinClassProfiles
 The derivational chain from root content to argument structure, made
 explicit as composed functions:
 
-    FeatureSignature → Template → ArgTemplate → ThetaRole
+    Root.FeatureSignature → Template → ArgTemplate → ThetaRole
 
 Each step exists in the literature: [beavers-koontz-garboden-2020]
 define root entailments; [rappaport-hovav-levin-1998] define event
@@ -51,7 +51,7 @@ open Semantics.Lexical
 open Semantics.Lexical.EventStructure (Template)
 open Features.LevinClassProfiles
 open Semantics.ArgumentStructure.EntailmentProfile
-open FeatureSignature
+open Root.FeatureSignature
 
 -- ════════════════════════════════════════════════════
 -- § 1. Root-Template Compatibility
@@ -75,18 +75,18 @@ open FeatureSignature
       BECOME to apply to (template adds the change)
     - **accomplishment** `[[x ACT] CAUSE [BECOME [y STATE]]]`: root
       provides state for the caused result -/
-def RootLicensesTemplate (re : FeatureSignature) : Template → Prop
+def RootLicensesTemplate (re : Root.FeatureSignature) : Template → Prop
   | .state         => .state ∈ re
   | .activity      => .manner ∈ re
   | .achievement   => .state ∈ re
   | .accomplishment => .state ∈ re
 
-instance (re : FeatureSignature) (t : Template) :
+instance (re : Root.FeatureSignature) (t : Template) :
     Decidable (RootLicensesTemplate re t) := by
   cases t <;> unfold RootLicensesTemplate <;> infer_instance
 
 /-- All templates licensed by a root (captures alternation). -/
-def licensedTemplates (re : FeatureSignature) : List Template :=
+def licensedTemplates (re : Root.FeatureSignature) : List Template :=
   [.state, .activity, .achievement, .accomplishment].filter
     (λ t => decide (RootLicensesTemplate re t))
 
@@ -194,7 +194,7 @@ def templateArgTemplate (t : Template) : ArgTemplate where
     | causativeResult (BREAK) | accomplishment |
     | pureManner (JOG) | activity |
     | fullSpec (CUT) | accomplishment | -/
-def primaryTemplate (re : FeatureSignature) : Option Template :=
+def primaryTemplate (re : Root.FeatureSignature) : Option Template :=
   if .cause ∈ re then some .accomplishment
   else if .result ∈ re then some .achievement
   else if .manner ∈ re then some .activity
@@ -234,14 +234,14 @@ theorem primary_licensed_canonical :
 
 /-- The full derivational pipeline: root entailments → primary
     template → template-level ArgTemplate. -/
-def derivePrimary (re : FeatureSignature) : Option ArgTemplate :=
+def derivePrimary (re : Root.FeatureSignature) : Option ArgTemplate :=
   (primaryTemplate re).map templateArgTemplate
 
 /-- All ArgTemplates derivable from a root (one per licensed template).
     Multiple entries represent alternation possibilities:
     e.g., a causativeResult root derives both an accomplishment
     ArgTemplate (transitive) and a state ArgTemplate (bare stative). -/
-def deriveAll (re : FeatureSignature) : List ArgTemplate :=
+def deriveAll (re : Root.FeatureSignature) : List ArgTemplate :=
   (licensedTemplates re).map templateArgTemplate
 
 -- § 4a. Pipeline produces non-trivial results
@@ -290,7 +290,7 @@ def activityObjectProfile (mc : MeaningComponents) : Option EntailmentProfile :=
     For other templates, the template's own profiles are used directly.
 
     Returns `none` for roots with no structural entailments (minimal). -/
-def deriveEnriched (re : FeatureSignature) (mc : MeaningComponents) : Option ArgTemplate :=
+def deriveEnriched (re : Root.FeatureSignature) (mc : MeaningComponents) : Option ArgTemplate :=
   match primaryTemplate re with
   | none => none
   | some t =>
@@ -526,7 +526,7 @@ theorem caused_result_full :
     consequence of downward closure under the collocational order —
     not a per-signature stipulation. -/
 theorem root_typology_hierarchy :
-    ∀ s : FeatureSignature, s.WellFormed →
+    ∀ s : Root.FeatureSignature, s.WellFormed →
       (.cause ∈ s → .result ∈ s) ∧ (.result ∈ s → .state ∈ s) := by decide
 
 /-- PC and result roots differ in licensing predictions:
@@ -568,7 +568,7 @@ directedMotion, and minimal-rootEntailments classes need overrides.
 The full derivational chain:
 
     Root entailments → Template → Template profiles → Root enrichment → Class override
-    (FeatureSignature)  (primary)  (templateArg)     (deriveEnriched)   (LevinClass.argTemplate)
+    (Root.FeatureSignature)  (primary)  (templateArg)     (deriveEnriched)   (LevinClass.argTemplate)
 -/
 
 end Semantics.ArgumentStructure.ArgDerivation

--- a/Linglib/Semantics/Lexical/LevinClassProfiles.lean
+++ b/Linglib/Semantics/Lexical/LevinClassProfiles.lean
@@ -177,7 +177,7 @@ end Semantics.Lexical
 namespace Features.LevinClassProfiles
 open Semantics.Lexical
 open Semantics.ArgumentStructure.EntailmentProfile
-open FeatureSignature
+open Root.FeatureSignature
 
 -- ════════════════════════════════════════════════════
 -- § 5. Verification: templates match existing canonical profiles
@@ -243,14 +243,14 @@ theorem directedMotion_subject_role :
     directedMotion.subjectProfile.toRole = none := by native_decide
 
 -- ════════════════════════════════════════════════════
--- § 7. FeatureSignature → ArgTemplate (the missing derivation)
+-- § 7. Root.FeatureSignature → ArgTemplate (the missing derivation)
 -- ════════════════════════════════════════════════════
 
 /-! Root feature signatures determine argument templates — this is the
 field consensus ([beavers-koontz-garboden-2020], [rappaport-hovav-levin-2024]).
 The derivational direction runs:
 
-    FeatureSignature → Template → ArgTemplate → ThetaRole labels
+    Root.FeatureSignature → Template → ArgTemplate → ThetaRole labels
 
 `toArgTemplate` formalizes the default derivation. It
 captures the majority pattern: causative roots produce agent subjects
@@ -285,7 +285,7 @@ These overrides are documented and verified below. -/
     (causativeResult): both produce the same default ArgTemplate.
     The manner flag restricts HOW the cause proceeds (cutting vs.
     breaking), not WHETHER there's an agent. -/
-def toArgTemplate (re : FeatureSignature) : Option ArgTemplate :=
+def toArgTemplate (re : Root.FeatureSignature) : Option ArgTemplate :=
   if .cause ∈ re then
     some resultChange
   else if .result ∈ re then

--- a/Linglib/Semantics/Lexical/LevinTheory.lean
+++ b/Linglib/Semantics/Lexical/LevinTheory.lean
@@ -14,7 +14,7 @@ The `LevinClass` enum and its classification data (`MeaningComponents`,
 `meaningComponents`, `predictsUnaccusative`, `isVerbOfCreation`) are
 defined in `Core/Lexical/VerbClass.lean`.
 
-This file provides the theoretical content that depends on `FeatureSignature`:
+This file provides the theoretical content that depends on `Root.FeatureSignature`:
 root signature mapping, root–MC bridge enums, and universal consistency
 theorems.
 
@@ -36,7 +36,7 @@ components, plus universal consistency theorems.
 
 section LevinClassMethods
 open Semantics.Lexical
-open FeatureSignature
+open Root.FeatureSignature
 namespace Semantics.Lexical
 
 /-- Root feature signature for each Levin class.
@@ -51,7 +51,7 @@ namespace Semantics.Lexical
 
     Classes marked (default) use `minimal` as a conservative placeholder
     pending detailed study under B&KG's framework. -/
-def LevinClass.rootEntailments : LevinClass → FeatureSignature
+def LevinClass.rootEntailments : LevinClass → Root.FeatureSignature
   -- §9 Putting: template provides CAUSE+BECOME; root content varies
   | .put => minimal                -- (default)
   | .funnel => pureManner          -- manner of channeling
@@ -368,7 +368,7 @@ theorem break_manner_none :
 
 /-- Root structural contribution to meaning components.
     Maps result → changeOfState and manner → mannerSpec. -/
-def _root_.FeatureSignature.structuralMC (re : FeatureSignature) : MeaningComponents :=
+def _root_.Root.FeatureSignature.structuralMC (re : Root.FeatureSignature) : MeaningComponents :=
   { changeOfState := decide (.result ∈ re)
   , contact := false
   , motion := false

--- a/Linglib/Semantics/Lexical/MeaningComponents.lean
+++ b/Linglib/Semantics/Lexical/MeaningComponents.lean
@@ -21,7 +21,7 @@ substrate.
 The 4-feature decomposition is [levin-1993]'s diagnostic apparatus.
 [beavers-koontz-garboden-2020] argue these are SURFACE behaviors,
 not root-level entailments — root-level structural features live in
-`Semantics/Lexical/Roots/Signature.lean::FeatureSignature`
+`Semantics/Lexical/Roots/Signature.lean::Root.FeatureSignature`
 (state/manner/result/cause). The two carve-ups are NOT equivalent:
 e.g., `causation` here is what diathesis alternations diagnose, while
 B&KG's `cause` is a root entailment.
@@ -62,7 +62,7 @@ namespace Semantics.Lexical
 
     These describe **surface** verb behavior, not root-level entailments.
     [beavers-koontz-garboden-2020] argue that surface CoS and causation
-    can come from either the template or the root; see `FeatureSignature`
+    can come from either the template or the root; see `Root.FeatureSignature`
     in `Semantics/Lexical/Roots/Signature.lean` for the
     root-level decomposition.
 

--- a/Linglib/Semantics/Lexical/Roots/Basic.lean
+++ b/Linglib/Semantics/Lexical/Roots/Basic.lean
@@ -8,7 +8,7 @@ the events it describes and the participants in those events.
 Following [beavers-koontz-garboden-2020], we treat these as
 *structured atoms* rather than as a fixed feature vector: a **root**
 is a finite collection of such atoms, and its feature signature
-(`FeatureSignature`) is the *derived* set of kinds its atoms realize —
+(`Root.FeatureSignature`) is the *derived* set of kinds its atoms realize —
 exposing the Bifurcation Thesis of Roots and Manner/Result
 Complementarity as testable conjectures rather than architectural
 commitments.
@@ -84,7 +84,7 @@ namespace Root
 
 /-- The derived feature signature of a root: the set of kinds its
     atoms realize. -/
-def featureSignature (r : Root) : FeatureSignature :=
+def featureSignature (r : Root) : Root.FeatureSignature :=
   (r.entailments.filterMap (·.kind)).toFinset
 
 theorem mem_featureSignature {r : Root} {k : LexKind} :

--- a/Linglib/Semantics/Lexical/Roots/Basic.lean
+++ b/Linglib/Semantics/Lexical/Roots/Basic.lean
@@ -69,27 +69,28 @@ end LexEntailment
 
 /-! ### Roots -/
 
-/-- A verbal root: a name and a list of atomic entailments it imposes.
+/-- A verbal root: a name and a finite set of atomic entailments it
+    imposes.
 
-    The list is the root's *base* entailment set — the atoms asserted
+    The set is the root's *base* entailment set — the atoms asserted
     directly. A closure operation (B&K-G's networks of entailments
     where one atom may entail another) is layered on top in
     `Roots/Closure.lean`. -/
 structure Root where
   name : String
-  entailments : List LexEntailment
-  deriving DecidableEq, Repr
+  entailments : Finset LexEntailment
+  deriving DecidableEq
 
 namespace Root
 
 /-- The derived feature signature of a root: the set of kinds its
     atoms realize. -/
 def featureSignature (r : Root) : Root.FeatureSignature :=
-  (r.entailments.filterMap (·.kind)).toFinset
+  Finset.univ.filter (fun k => ∃ a ∈ r.entailments, a.kind = some k)
 
 theorem mem_featureSignature {r : Root} {k : LexKind} :
     k ∈ r.featureSignature ↔ ∃ a ∈ r.entailments, a.kind = some k := by
-  simp [featureSignature, List.mem_filterMap]
+  simp [featureSignature]
 
 /-- The root entails attribution of some state. -/
 def HasState (r : Root) : Prop := .state ∈ r.featureSignature

--- a/Linglib/Semantics/Lexical/Roots/Closure.lean
+++ b/Linglib/Semantics/Lexical/Roots/Closure.lean
@@ -8,21 +8,21 @@ entailments, where some atoms entail others, and state two
 collocational restrictions as definitional: +result entails +state,
 and +cause entails +result.
 
-Two levels of closure:
+Two levels of closure, each a mathlib `ClosureOperator`:
 
 * **Kind level** (canonical): `Root.closedFeatureSignature` is the
-  collocational closure `Root.FeatureSignature.close` of the root's derived
-  signature. Both book restrictions hold of closed signatures by
-  construction (`closedFeatureSignature_wellFormed`).
+  collocational closure `Root.FeatureSignature.close` of the root's
+  derived signature. Both book restrictions hold of closed signatures
+  by construction (`closedFeatureSignature_wellFormed`).
 * **Atom level** (label-tracking): `Root.closedEntailments` closes the
-  labeled atom list under `bkgRules` (`becomesState s ⇒ hasState s`).
-  Only the result→state edge is expressible here — `hasCause` is
-  nullary, so cause→result lives at kind level only
-  (`kind_closedEntailments_le`).
+  labeled atom set under `bkgRules` (`becomesState s ⇒ hasState s`),
+  packaged as `bkgCloseOp`. Only the result→state edge is expressible
+  here — `hasCause` is nullary, so cause→result lives at kind level
+  only (`kind_closedEntailments_le`).
 
 ## Main declarations
 
-* `bkgRules`, `bkgClosure`, `Root.closedEntailments`
+* `bkgRules`, `bkgClose`, `bkgCloseOp`, `Root.closedEntailments`
 * `Root.closedFeatureSignature`
 * `mem_kind_closedEntailments` — the atom/kind bridge
 -/
@@ -35,9 +35,9 @@ Two levels of closure:
     cause→result restriction is not expressible at atom level
     (`hasCause` carries no label) and is handled by
     `Root.FeatureSignature.close`. -/
-def bkgRules : LexEntailment → List LexEntailment
-  | .becomesState s => [.hasState s]
-  | _ => []
+def bkgRules : LexEntailment → Finset LexEntailment
+  | .becomesState s => {.hasState s}
+  | _ => ∅
 
 /-- Every atom produced by `bkgRules` is a state atom, produced from a
     result atom. -/
@@ -46,17 +46,51 @@ theorem bkgRules_kind {a b : LexEntailment} (h : a ∈ bkgRules b) :
   cases b <;> simp [bkgRules] at h
   subst h; exact ⟨rfl, rfl⟩
 
-/-- Close an atom list under `bkgRules`: adjoin everything the rules
-    fire from a member. One step is a fixpoint, since rule outputs
-    (state atoms) trigger no rules. -/
-def bkgClosure (atoms : List LexEntailment) : List LexEntailment :=
-  atoms ++ atoms.flatMap bkgRules
+/-- Rule outputs trigger no further rules: the closure stabilizes in
+    one step. -/
+theorem bkgRules_output_inert {a b : LexEntailment} (h : a ∈ bkgRules b) :
+    bkgRules a = ∅ := by
+  cases b <;> simp [bkgRules] at h
+  subst h; rfl
+
+/-- Close an atom set under `bkgRules`: adjoin everything the rules
+    fire from a member. -/
+def bkgClose (atoms : Finset LexEntailment) : Finset LexEntailment :=
+  atoms ∪ atoms.biUnion bkgRules
+
+theorem le_bkgClose (atoms : Finset LexEntailment) :
+    atoms ≤ bkgClose atoms :=
+  Finset.subset_union_left
+
+theorem bkgClose_mono {s t : Finset LexEntailment} (h : s ≤ t) :
+    bkgClose s ≤ bkgClose t :=
+  Finset.union_subset_union h
+    (Finset.biUnion_subset_biUnion_of_subset_left _ h)
+
+theorem bkgClose_idem (s : Finset LexEntailment) :
+    bkgClose (bkgClose s) = bkgClose s := by
+  refine le_antisymm (fun a ha => ?_) (le_bkgClose _)
+  rcases Finset.mem_union.mp ha with h | h
+  · exact h
+  · obtain ⟨b, hb, hab⟩ := Finset.mem_biUnion.mp h
+    rcases Finset.mem_union.mp hb with hb' | hb'
+    · exact Finset.mem_union_right _ (Finset.mem_biUnion.mpr ⟨b, hb', hab⟩)
+    · obtain ⟨c, hc, hbc⟩ := Finset.mem_biUnion.mp hb'
+      rw [bkgRules_output_inert hbc] at hab
+      exact absurd hab (Finset.notMem_empty a)
+
+/-- The atom-level closure as a mathlib `ClosureOperator`. -/
+def bkgCloseOp : ClosureOperator (Finset LexEntailment) where
+  toFun := bkgClose
+  monotone' _ _ h := bkgClose_mono h
+  le_closure' := le_bkgClose
+  idempotent' := bkgClose_idem
 
 namespace Root
 
 /-- The B&K-G closure of the root's base entailments. -/
-def closedEntailments (r : Root) : List LexEntailment :=
-  bkgClosure r.entailments
+def closedEntailments (r : Root) : Finset LexEntailment :=
+  bkgClose r.entailments
 
 /-! ### Kind-level closure -/
 
@@ -88,10 +122,9 @@ theorem closed_violatesBifurcation_iff (r : Root) :
 /-- Kinds realized by the atom-level closure: the base kinds plus a
     `state` kind whenever a result atom is present. -/
 theorem mem_kind_closedEntailments {r : Root} {k : LexKind} :
-    k ∈ (r.closedEntailments.filterMap (·.kind)).toFinset ↔
+    (∃ a ∈ r.closedEntailments, a.kind = some k) ↔
       k ∈ r.featureSignature ∨ (k = .state ∧ r.HasResult) := by
-  simp only [List.mem_toFinset, List.mem_filterMap, closedEntailments, bkgClosure,
-    List.mem_append, List.mem_flatMap]
+  simp only [closedEntailments, bkgClose, Finset.mem_union, Finset.mem_biUnion]
   constructor
   · rintro ⟨a, ha | ⟨b, hb, hab⟩, hk⟩
     · exact .inl (Root.mem_featureSignature.mpr ⟨a, ha, hk⟩)
@@ -110,12 +143,12 @@ theorem mem_kind_closedEntailments {r : Root} {k : LexKind} :
     kind-level closure (strictly fewer when a root carries `cause`
     without a result atom — the cause→result edge is kind-level
     only). -/
-theorem kind_closedEntailments_le (r : Root) :
-    ((r.closedEntailments.filterMap (·.kind)).toFinset : Root.FeatureSignature)
-      ≤ r.closedFeatureSignature := by
-  intro k hk
-  rcases mem_kind_closedEntailments.mp hk with h | ⟨rfl, hres⟩
-  · exact featureSignature_le_closed r h
-  · exact (Root.FeatureSignature.mem_close_iff _ _).mpr ⟨.result, hres, by decide⟩
+theorem kind_closedEntailments_le (r : Root) {k : LexKind}
+    (h : ∃ a ∈ r.closedEntailments, a.kind = some k) :
+    k ∈ r.closedFeatureSignature := by
+  rcases mem_kind_closedEntailments.mp h with hk | ⟨rfl, hres⟩
+  · exact featureSignature_le_closed r hk
+  · exact (Root.FeatureSignature.mem_close_iff _ _).mpr
+      ⟨.result, hres, by decide⟩
 
 end Root

--- a/Linglib/Semantics/Lexical/Roots/Closure.lean
+++ b/Linglib/Semantics/Lexical/Roots/Closure.lean
@@ -11,7 +11,7 @@ and +cause entails +result.
 Two levels of closure:
 
 * **Kind level** (canonical): `Root.closedFeatureSignature` is the
-  collocational closure `FeatureSignature.close` of the root's derived
+  collocational closure `Root.FeatureSignature.close` of the root's derived
   signature. Both book restrictions hold of closed signatures by
   construction (`closedFeatureSignature_wellFormed`).
 * **Atom level** (label-tracking): `Root.closedEntailments` closes the
@@ -34,7 +34,7 @@ Two levels of closure:
     the resulting state attribution `s`, label preserved). The
     cause→result restriction is not expressible at atom level
     (`hasCause` carries no label) and is handled by
-    `FeatureSignature.close`. -/
+    `Root.FeatureSignature.close`. -/
 def bkgRules : LexEntailment → List LexEntailment
   | .becomesState s => [.hasState s]
   | _ => []
@@ -63,7 +63,7 @@ def closedEntailments (r : Root) : List LexEntailment :=
 /-- The closed feature signature: the collocational closure of the
     derived signature. Captures both book restrictions (result→state
     and cause→result). -/
-def closedFeatureSignature (r : Root) : FeatureSignature :=
+def closedFeatureSignature (r : Root) : Root.FeatureSignature :=
   r.featureSignature.close
 
 /-- The closed signature satisfies the collocational constraints by
@@ -71,17 +71,17 @@ def closedFeatureSignature (r : Root) : FeatureSignature :=
     is a theorem of closure. -/
 theorem closedFeatureSignature_wellFormed (r : Root) :
     r.closedFeatureSignature.WellFormed :=
-  FeatureSignature.close_wellFormed _
+  Root.FeatureSignature.close_wellFormed _
 
 theorem featureSignature_le_closed (r : Root) :
     r.featureSignature ≤ r.closedFeatureSignature :=
-  FeatureSignature.le_close _
+  Root.FeatureSignature.le_close _
 
 /-- Both theses are insensitive to the closure edges: a root violates
     Bifurcation iff its closed signature does. -/
 theorem closed_violatesBifurcation_iff (r : Root) :
     r.closedFeatureSignature.ViolatesBifurcation ↔ r.ViolatesBifurcation :=
-  FeatureSignature.violatesBifurcation_close_iff _
+  Root.FeatureSignature.violatesBifurcation_close_iff _
 
 /-! ### The atom/kind bridge -/
 
@@ -111,11 +111,11 @@ theorem mem_kind_closedEntailments {r : Root} {k : LexKind} :
     without a result atom — the cause→result edge is kind-level
     only). -/
 theorem kind_closedEntailments_le (r : Root) :
-    ((r.closedEntailments.filterMap (·.kind)).toFinset : FeatureSignature)
+    ((r.closedEntailments.filterMap (·.kind)).toFinset : Root.FeatureSignature)
       ≤ r.closedFeatureSignature := by
   intro k hk
   rcases mem_kind_closedEntailments.mp hk with h | ⟨rfl, hres⟩
   · exact featureSignature_le_closed r h
-  · exact (FeatureSignature.mem_close_iff _ _).mpr ⟨.result, hres, by decide⟩
+  · exact (Root.FeatureSignature.mem_close_iff _ _).mpr ⟨.result, hres, by decide⟩
 
 end Root

--- a/Linglib/Semantics/Lexical/Roots/Profile.lean
+++ b/Linglib/Semantics/Lexical/Roots/Profile.lean
@@ -8,7 +8,7 @@ force, robustness, instrument, dimensionality, agent properties. A
 multi-paper synthesis ([talmy-1988], [talmy-2000], [dowty-1991],
 [majid-boster-bowerman-2008], [spalek-mcnally-2026]); no single paper
 carries this profile. Structural entailments (state, manner, result,
-cause) are the separate `FeatureSignature` (`Roots/Signature.lean`).
+cause) are the separate `Root.FeatureSignature` (`Roots/Signature.lean`).
 
 ## Main declarations
 
@@ -175,7 +175,7 @@ open Profile (Range)
 /-- Within-class root content profile.
 
     Captures **quality** dimensions of root content — force, robustness,
-    agent properties — as opposed to `FeatureSignature`, which captures
+    agent properties — as opposed to `Root.FeatureSignature`, which captures
     **structural** entailments (state, manner, result, cause).
 
     Each dimension is a `Range` of acceptable values; `none` means the

--- a/Linglib/Semantics/Lexical/Roots/SalienceClass.lean
+++ b/Linglib/Semantics/Lexical/Roots/SalienceClass.lean
@@ -46,73 +46,73 @@ transitivisers respect the diagnostic. They appear directly as the
 operator-applicability ↔ salience-class connection true *by
 construction* rather than only provable per-case. -/
 
-namespace FeatureSignature
+namespace Root.FeatureSignature
 
 /-- Agent-salient: manner without result (intransitive activity that
     requires =t to transitivise; [lucy-1994]). -/
-def IsAgentSalient (s : FeatureSignature) : Prop :=
+def IsAgentSalient (s : Root.FeatureSignature) : Prop :=
   .manner ∈ s ∧ .result ∉ s
 
-instance (s : FeatureSignature) : Decidable s.IsAgentSalient :=
+instance (s : Root.FeatureSignature) : Decidable s.IsAgentSalient :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-- Agent-patient salient: manner *and* result (already lexically
     transitive; [lucy-1994]). -/
-def IsAgentPatientSalient (s : FeatureSignature) : Prop :=
+def IsAgentPatientSalient (s : Root.FeatureSignature) : Prop :=
   .manner ∈ s ∧ .result ∈ s
 
-instance (s : FeatureSignature) : Decidable s.IsAgentPatientSalient :=
+instance (s : Root.FeatureSignature) : Decidable s.IsAgentPatientSalient :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-- Patient-salient: result without manner (intransitive change-of-state
     that requires =s to transitivise; [lucy-1994]). -/
-def IsPatientSalient (s : FeatureSignature) : Prop :=
+def IsPatientSalient (s : Root.FeatureSignature) : Prop :=
   .manner ∉ s ∧ .result ∈ s
 
-instance (s : FeatureSignature) : Decidable s.IsPatientSalient :=
+instance (s : Root.FeatureSignature) : Decidable s.IsPatientSalient :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-- Positional: pure stative root — state without manner, result, or
     cause (requires `-tal` for the inchoative; [lucy-1994]). -/
-def IsPositional (s : FeatureSignature) : Prop :=
+def IsPositional (s : Root.FeatureSignature) : Prop :=
   s = {.state}
 
-instance (s : FeatureSignature) : Decidable s.IsPositional :=
+instance (s : Root.FeatureSignature) : Decidable s.IsPositional :=
   inferInstanceAs (Decidable (_ = _))
 
-end FeatureSignature
+end Root.FeatureSignature
 
 /-! Per-root convenience versions, lifted via `featureSignature`. -/
 
 namespace Root
 
-/-- Agent-salient root (cf. `FeatureSignature.IsAgentSalient`). -/
+/-- Agent-salient root (cf. `Root.FeatureSignature.IsAgentSalient`). -/
 def IsAgentSalient (r : Root) : Prop :=
   r.featureSignature.IsAgentSalient
 
 instance (r : Root) : Decidable r.IsAgentSalient :=
-  inferInstanceAs (Decidable (FeatureSignature.IsAgentSalient _))
+  inferInstanceAs (Decidable (Root.FeatureSignature.IsAgentSalient _))
 
 /-- Agent-patient salient root. -/
 def IsAgentPatientSalient (r : Root) : Prop :=
   r.featureSignature.IsAgentPatientSalient
 
 instance (r : Root) : Decidable r.IsAgentPatientSalient :=
-  inferInstanceAs (Decidable (FeatureSignature.IsAgentPatientSalient _))
+  inferInstanceAs (Decidable (Root.FeatureSignature.IsAgentPatientSalient _))
 
 /-- Patient-salient root. -/
 def IsPatientSalient (r : Root) : Prop :=
   r.featureSignature.IsPatientSalient
 
 instance (r : Root) : Decidable r.IsPatientSalient :=
-  inferInstanceAs (Decidable (FeatureSignature.IsPatientSalient _))
+  inferInstanceAs (Decidable (Root.FeatureSignature.IsPatientSalient _))
 
 /-- Positional root. -/
 def IsPositional (r : Root) : Prop :=
   r.featureSignature.IsPositional
 
 instance (r : Root) : Decidable r.IsPositional :=
-  inferInstanceAs (Decidable (FeatureSignature.IsPositional _))
+  inferInstanceAs (Decidable (Root.FeatureSignature.IsPositional _))
 
 end Root
 
@@ -125,7 +125,7 @@ end Root
     requires the pure-state signature: positional roots are stative
     configurations (orientation, posture, location) with no causing
     event. -/
-def classOfSignature (s : FeatureSignature) : Option SalienceClass :=
+def classOfSignature (s : Root.FeatureSignature) : Option SalienceClass :=
   if s.IsAgentSalient then some .agent
   else if s.IsAgentPatientSalient then some .agentPatient
   else if s.IsPatientSalient then some .patient
@@ -152,7 +152,7 @@ theorem predictedSalience_depends_only_on_signature
     no-manner-no-result signatures other than `{state}` fall outside
     all four; see `classOfSignature_eq_none_iff`.) -/
 theorem classes_pairwise_disjoint :
-    ∀ s : FeatureSignature,
+    ∀ s : Root.FeatureSignature,
       ¬ (s.IsAgentSalient ∧ s.IsAgentPatientSalient) ∧
       ¬ (s.IsAgentSalient ∧ s.IsPatientSalient) ∧
       ¬ (s.IsAgentSalient ∧ s.IsPositional) ∧
@@ -166,7 +166,7 @@ theorem classes_pairwise_disjoint :
     no-manner-no-result signatures other than pure `{state}` are
     unclassified by Lucy's Yukatek diagnostic. -/
 theorem classOfSignature_eq_none_iff :
-    ∀ s : FeatureSignature,
+    ∀ s : Root.FeatureSignature,
       classOfSignature s = none ↔
         ¬ s.IsAgentSalient ∧ ¬ s.IsAgentPatientSalient ∧
         ¬ s.IsPatientSalient ∧ ¬ s.IsPositional := by

--- a/Linglib/Semantics/Lexical/Roots/Signature.lean
+++ b/Linglib/Semantics/Lexical/Roots/Signature.lean
@@ -30,14 +30,14 @@ substrate.
 ## Main declarations
 
 * `LexKind`, with its collocational `PartialOrder`
-* `FeatureSignature := Finset LexKind`
-* `FeatureSignature.close`, `FeatureSignature.closeOp`,
-  `FeatureSignature.WellFormed`
+* `Root.FeatureSignature := Finset LexKind`
+* `Root.FeatureSignature.close`, `Root.FeatureSignature.closeOp`,
+  `Root.FeatureSignature.WellFormed`
 * canonical signatures (`propertyConcept`, `pureResult`,
   `causativeResult`, `pureManner`, `mannerResult`, `fullSpec`,
   `minimal`)
-* `FeatureSignature.ViolatesBifurcation`,
-  `FeatureSignature.HasMannerAndResult`
+* `Root.FeatureSignature.ViolatesBifurcation`,
+  `Root.FeatureSignature.HasMannerAndResult`
 -/
 
 /-! ### Lexical entailment kinds -/
@@ -81,33 +81,33 @@ end LexKind
 
 /-- A root feature signature: the set of entailment kinds carried.
     `≤` (= `⊆`) and the lattice operations come from `Finset`. -/
-abbrev FeatureSignature := Finset LexKind
+abbrev Root.FeatureSignature := Finset LexKind
 
-namespace FeatureSignature
+namespace Root.FeatureSignature
 
 /-- The collocational closure: a signature carrying `cause` is
     completed with `result` and `state`; one carrying `result` is
     completed with `state`. This is the lower closure under the
     `LexKind` order (`mem_close_iff`). -/
-def close (s : FeatureSignature) : FeatureSignature :=
+def close (s : Root.FeatureSignature) : Root.FeatureSignature :=
   s ∪ (if .cause ∈ s then {.result, .state} else ∅)
     ∪ (if .result ∈ s then {.state} else ∅)
 
-theorem le_close : ∀ s : FeatureSignature, s ≤ close s := by decide
+theorem le_close : ∀ s : Root.FeatureSignature, s ≤ close s := by decide
 
-theorem close_idem : ∀ s : FeatureSignature, close (close s) = close s := by
+theorem close_idem : ∀ s : Root.FeatureSignature, close (close s) = close s := by
   decide
 
-theorem close_mono : ∀ {s t : FeatureSignature}, s ≤ t → close s ≤ close t := by
+theorem close_mono : ∀ {s t : Root.FeatureSignature}, s ≤ t → close s ≤ close t := by
   decide
 
 /-- `close` is the lower closure under the collocational order:
     `k` is in the closure iff some kind in `s` dominates it. -/
-theorem mem_close_iff : ∀ (s : FeatureSignature) (k : LexKind),
+theorem mem_close_iff : ∀ (s : Root.FeatureSignature) (k : LexKind),
     k ∈ close s ↔ ∃ j ∈ s, k ≤ j := by decide
 
 /-- The collocational closure as a mathlib `ClosureOperator`. -/
-def closeOp : ClosureOperator FeatureSignature where
+def closeOp : ClosureOperator Root.FeatureSignature where
   toFun := close
   monotone' _ _ := close_mono
   le_closure' := le_close
@@ -115,13 +115,13 @@ def closeOp : ClosureOperator FeatureSignature where
 
 /-- A signature is well-formed iff it already satisfies the
     collocational constraints (it is a fixed point of `close`). -/
-def WellFormed (s : FeatureSignature) : Prop := close s = s
+def WellFormed (s : Root.FeatureSignature) : Prop := close s = s
 
-instance (s : FeatureSignature) : Decidable s.WellFormed :=
+instance (s : Root.FeatureSignature) : Decidable s.WellFormed :=
   inferInstanceAs (Decidable (_ = _))
 
 /-- Well-formedness is downward-closedness in the `LexKind` order. -/
-theorem wellFormed_iff_isLowerSet (s : FeatureSignature) :
+theorem wellFormed_iff_isLowerSet (s : Root.FeatureSignature) :
     s.WellFormed ↔ IsLowerSet (↑s : Set LexKind) := by
   constructor
   · intro hwf a b hba ha
@@ -135,7 +135,7 @@ theorem wellFormed_iff_isLowerSet (s : FeatureSignature) :
 
 /-- Closure output is always well-formed — the collocational
     constraints hold of closed signatures *by construction*. -/
-theorem close_wellFormed : ∀ s : FeatureSignature, (close s).WellFormed :=
+theorem close_wellFormed : ∀ s : Root.FeatureSignature, (close s).WellFormed :=
   close_idem
 
 /-! ### Canonical signatures
@@ -146,12 +146,12 @@ ch. 5 (their example display (12), §5.4). -/
 /-- +S −M −R −C: property concept roots (√FLAT, √DRY).
     Deadjectival COS verbs — the root names the result state.
     Complement position. -/
-def propertyConcept : FeatureSignature := {.state}
+def propertyConcept : Root.FeatureSignature := {.state}
 
 /-- +S −M +R −C: internally caused result roots (√BLOSSOM, √RUST).
     Root entails both a state and a change to that state, but not
     external causation. Complement position. -/
-def pureResult : FeatureSignature := {.state, .result}
+def pureResult : Root.FeatureSignature := {.state, .result}
 
 /-- +S −M +R +C: externally caused result roots (√CRACK, √BREAK).
     Root entails a state, change, AND causation. If roots subdivide by
@@ -159,32 +159,32 @@ def pureResult : FeatureSignature := {.state, .result}
     (1995) externally vs internally caused change-of-state distinction
     ([beavers-koontz-garboden-2020], hedged as a possibility).
     Complement position. -/
-def causativeResult : FeatureSignature := {.state, .result, .cause}
+def causativeResult : Root.FeatureSignature := {.state, .result, .cause}
 
 /-- −S +M −R −C: pure manner roots (√JOG, √RUN, √SWIM).
     Root specifies action manner without entailing any state.
     Adjoined position. -/
-def pureManner : FeatureSignature := {.manner}
+def pureManner : Root.FeatureSignature := {.manner}
 
 /-- +S +M +R −C: manner + result without cause. Well-formed per the
     constraints; [beavers-koontz-garboden-2020] leave its attestation
     an open question ("whether a change and a manner can exist together
     in a single meaning without causation"), with candidate witnesses
     *slide* and motion-in-sound-emission *buzz*. -/
-def mannerResult : FeatureSignature := {.state, .manner, .result}
+def mannerResult : Root.FeatureSignature := {.state, .manner, .result}
 
 /-- +S +M +R +C: fully specified roots (√HAND adjoined, √DROWN and the
     other manner-of-killing roots in complement position;
     [beavers-koontz-garboden-2020] chs. 3–4). These are the attested
     MRC violators. The adjoined/complement contrast is carried by
     `Root.Position`, not by the signature. -/
-def fullSpec : FeatureSignature := {.state, .manner, .result, .cause}
+def fullSpec : Root.FeatureSignature := {.state, .manner, .result, .cause}
 
 /-- −S −M −R −C: minimal roots — no structural entailments.
     Conservative default for classes not yet studied under B&KG's
     framework. Not a row in B&KG's typology (which only lists roots
     with at least one positive feature). -/
-def minimal : FeatureSignature := ∅
+def minimal : Root.FeatureSignature := ∅
 
 /-- Every canonical signature is well-formed. -/
 theorem canonical_wellFormed :
@@ -197,52 +197,52 @@ theorem canonical_wellFormed :
 
 /-- The ontological kinds — all the Bifurcation Thesis allows a root
     to carry. -/
-def ontological : FeatureSignature := {.state, .manner}
+def ontological : Root.FeatureSignature := {.state, .manner}
 
 /-- A signature violates the Bifurcation Thesis ([embick-2009]; the
     assumption of [arad-2005]) iff it carries templatic (eventive)
     content — it is not bounded by `ontological`. -/
-def ViolatesBifurcation (s : FeatureSignature) : Prop := ¬ s ≤ ontological
+def ViolatesBifurcation (s : Root.FeatureSignature) : Prop := ¬ s ≤ ontological
 
-instance (s : FeatureSignature) : Decidable s.ViolatesBifurcation :=
+instance (s : Root.FeatureSignature) : Decidable s.ViolatesBifurcation :=
   inferInstanceAs (Decidable (¬ _ ≤ _))
 
 /-- Violation is carrying a `result` or `cause` kind. -/
 theorem violatesBifurcation_iff :
-    ∀ s : FeatureSignature,
+    ∀ s : Root.FeatureSignature,
       s.ViolatesBifurcation ↔ .result ∈ s ∨ .cause ∈ s := by decide
 
 /-- Bifurcation violation is monotone: adding entailments cannot
     repair a violation. (Equivalently, the thesis carves out a lower
     set of the signature lattice.) -/
 theorem violatesBifurcation_mono :
-    ∀ {s t : FeatureSignature}, s ≤ t →
+    ∀ {s t : Root.FeatureSignature}, s ≤ t →
       s.ViolatesBifurcation → t.ViolatesBifurcation := by decide
 
 /-- A signature has both manner and result — the configuration
     Manner/Result Complementarity ([rappaport-hovav-levin-2010])
     claims no root realizes. -/
-def HasMannerAndResult (s : FeatureSignature) : Prop :=
+def HasMannerAndResult (s : Root.FeatureSignature) : Prop :=
   {LexKind.manner, LexKind.result} ≤ s
 
-instance (s : FeatureSignature) : Decidable s.HasMannerAndResult :=
+instance (s : Root.FeatureSignature) : Decidable s.HasMannerAndResult :=
   inferInstanceAs (Decidable (_ ≤ _))
 
 /-- MRC violation is monotone in the signature order. -/
 theorem hasMannerAndResult_mono :
-    ∀ {s t : FeatureSignature}, s ≤ t →
+    ∀ {s t : Root.FeatureSignature}, s ≤ t →
       s.HasMannerAndResult → t.HasMannerAndResult := by decide
 
 /-- Both theses are invariant under collocational closure: `close`
     only adds `state`/`result` kinds forced by `cause`, never `manner`,
     and a closed signature violates Bifurcation iff its base does. -/
 theorem violatesBifurcation_close_iff :
-    ∀ s : FeatureSignature,
+    ∀ s : Root.FeatureSignature,
       (close s).ViolatesBifurcation ↔ s.ViolatesBifurcation := by decide
 
 theorem hasMannerAndResult_close_iff :
-    ∀ s : FeatureSignature,
+    ∀ s : Root.FeatureSignature,
       (close s).HasMannerAndResult ↔
         s.HasMannerAndResult ∨ (.manner ∈ s ∧ .cause ∈ s) := by decide
 
-end FeatureSignature
+end Root.FeatureSignature

--- a/Linglib/Semantics/Lexical/Roots/Template.lean
+++ b/Linglib/Semantics/Lexical/Roots/Template.lean
@@ -72,7 +72,6 @@ structure EventStructure where
   heads : List TemplaticHead
   root : Root
   position : Root.Position
-  deriving Repr
 
 namespace EventStructure
 

--- a/Linglib/Semantics/Lexical/Roots/Typology.lean
+++ b/Linglib/Semantics/Lexical/Roots/Typology.lean
@@ -11,7 +11,7 @@ stated for roots by delegation to the signature level
   [arad-2005]): meaning introduced by a functional head — change,
   cause — can never be part of a root's meaning. As an order
   statement: every root's signature lies below
-  `FeatureSignature.ontological`.
+  `Root.FeatureSignature.ontological`.
 - **Manner/Result Complementarity** ([rappaport-hovav-levin-2010]): a
   single root entails a manner *or* a result, never both. As an order
   statement: no root's signature lies above `{manner, result}`.
@@ -29,7 +29,7 @@ namespace Root
 
 /-- A root *violates* Bifurcation iff it itself carries templatic
     (eventive) meaning — change of state or cause
-    (`FeatureSignature.violatesBifurcation_iff`). The Bifurcation
+    (`Root.FeatureSignature.violatesBifurcation_iff`). The Bifurcation
     Thesis ([embick-2009]; [arad-2005]) is the universal claim that no
     root does. (The ditransitive prepositional heads P_loc and P_have,
     which [beavers-koontz-garboden-2020] also treat as templatic, are
@@ -38,7 +38,7 @@ def ViolatesBifurcation (r : Root) : Prop :=
   r.featureSignature.ViolatesBifurcation
 
 instance (r : Root) : Decidable r.ViolatesBifurcation :=
-  inferInstanceAs (Decidable (FeatureSignature.ViolatesBifurcation _))
+  inferInstanceAs (Decidable (Root.FeatureSignature.ViolatesBifurcation _))
 
 /-- Negation of `ViolatesBifurcation`: the root carries only
     ontological entailments (state, manner). -/
@@ -52,7 +52,7 @@ instance (r : Root) : Decidable r.RespectsBifurcation :=
     its signature is bounded by the ontological kinds. -/
 theorem respectsBifurcation_iff_le {r : Root} :
     r.RespectsBifurcation ↔
-      r.featureSignature ≤ FeatureSignature.ontological :=
+      r.featureSignature ≤ Root.FeatureSignature.ontological :=
   not_not
 
 /-- A root has both manner and result entailments — Manner/Result
@@ -62,7 +62,7 @@ def HasMannerAndResult (r : Root) : Prop :=
   r.featureSignature.HasMannerAndResult
 
 instance (r : Root) : Decidable r.HasMannerAndResult :=
-  inferInstanceAs (Decidable (FeatureSignature.HasMannerAndResult _))
+  inferInstanceAs (Decidable (Root.FeatureSignature.HasMannerAndResult _))
 
 /-- Negation of `HasMannerAndResult`. -/
 def RespectsMannerResultComplementarity (r : Root) : Prop :=

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -23,7 +23,7 @@ The +state cells of √blossom, √crack, √hand, √drown are *derived*:
 the book's typology values are the collocational closures
 (`Root.closedFeatureSignature`) of the base atom kinds, and each
 closed signature is one of the canonical typology rows
-(`FeatureSignature.pureResult`, `causativeResult`, `fullSpec`).
+(`Root.FeatureSignature.pureResult`, `causativeResult`, `fullSpec`).
 √blossom falsifies Bifurcation on its own, since change of state is
 templatic (`v_become`) content. √hand and √drown additionally falsify
 Manner/Result Complementarity; they differ only in root position
@@ -94,25 +94,25 @@ theorem drown_featureSignature :
     drown.featureSignature = {.manner, .result, .cause} := by decide
 
 theorem flat_closedFeatureSignature :
-    flat.closedFeatureSignature = FeatureSignature.propertyConcept := by
+    flat.closedFeatureSignature = Root.FeatureSignature.propertyConcept := by
   decide
 
 theorem jog_closedFeatureSignature :
-    jog.closedFeatureSignature = FeatureSignature.pureManner := by decide
+    jog.closedFeatureSignature = Root.FeatureSignature.pureManner := by decide
 
 theorem blossom_closedFeatureSignature :
-    blossom.closedFeatureSignature = FeatureSignature.pureResult := by
+    blossom.closedFeatureSignature = Root.FeatureSignature.pureResult := by
   decide
 
 theorem crack_closedFeatureSignature :
-    crack.closedFeatureSignature = FeatureSignature.causativeResult := by
+    crack.closedFeatureSignature = Root.FeatureSignature.causativeResult := by
   decide
 
 theorem hand_closedFeatureSignature :
-    hand.closedFeatureSignature = FeatureSignature.fullSpec := by decide
+    hand.closedFeatureSignature = Root.FeatureSignature.fullSpec := by decide
 
 theorem drown_closedFeatureSignature :
-    drown.closedFeatureSignature = FeatureSignature.fullSpec := by decide
+    drown.closedFeatureSignature = Root.FeatureSignature.fullSpec := by decide
 
 /-! ### Falsifying the Bifurcation Thesis -/
 

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -42,32 +42,32 @@ namespace BeaversKoontzGarboden2020
 /-! ### The six representative roots -/
 
 /-- √flat — pure state. -/
-def flat : Root := ⟨"flat", [.hasState "flat"]⟩
+def flat : Root := ⟨"flat", {.hasState "flat"}⟩
 
 /-- √jog — pure manner of motion. -/
-def jog : Root := ⟨"jog", [.hasManner "jogging-gait", .motion]⟩
+def jog : Root := ⟨"jog", {.hasManner "jogging-gait", .motion}⟩
 
 /-- √blossom — result with no specified manner or cause (an
     internally caused change of state). -/
-def blossom : Root := ⟨"blossom", [.becomesState "flowering"]⟩
+def blossom : Root := ⟨"blossom", {.becomesState "flowering"}⟩
 
 /-- √crack — caused result without specified manner. -/
-def crack : Root := ⟨"crack", [.becomesState "fissured", .hasCause]⟩
+def crack : Root := ⟨"crack", {.becomesState "fissured", .hasCause}⟩
 
 /-- √hand — manner + cause + result, adjoined position. The
     possession result is non-cancelable ("#Mary handed John the book,
     but he never got it"), so it is root-entailed rather than
     implicated ([beavers-koontz-garboden-2020] ch. 3). -/
 def hand : Root := ⟨"hand",
-  [.hasManner "by-hand-transfer",
+  {.hasManner "by-hand-transfer",
    .becomesState "in-recipient-possession",
-   .hasCause]⟩
+   .hasCause}⟩
 
 /-- √drown — manner of killing (Levin 1993's *crucify, drown, hang,
     electrocute* class; [beavers-koontz-garboden-2020] ch. 4):
     manner + cause + result, complement position. -/
 def drown : Root := ⟨"drown",
-  [.hasManner "submersion-in-liquid", .becomesState "dead", .hasCause]⟩
+  {.hasManner "submersion-in-liquid", .becomesState "dead", .hasCause}⟩
 
 /-! ### Feature signatures
 

--- a/Linglib/Studies/HaninkKoontzGarboden2025.lean
+++ b/Linglib/Studies/HaninkKoontzGarboden2025.lean
@@ -56,7 +56,7 @@ Property concept (PC) roots in Wá·šiw come in two semantic types:
   inside the verbal categorizer's denotation.
 - Against [menon-pancheva-2014]'s universalist claim: not all PC
   roots have the same meaning.
-- All Wá·šiw PC roots are `FeatureSignature.propertyConcept` (+S −M −R −C)
+- All Wá·šiw PC roots are `Root.FeatureSignature.propertyConcept` (+S −M −R −C)
   per [beavers-koontz-garboden-2020] — the variation is in *semantic
   type*, not in structural entailments.
 -/

--- a/Linglib/Studies/Krejci2012.lean
+++ b/Linglib/Studies/Krejci2012.lean
@@ -48,7 +48,7 @@ Texas at Austin.
 namespace Krejci2012
 
 open Semantics.Lexical
-open FeatureSignature
+open Root.FeatureSignature
 open Semantics.Causation.Morphological
 open Semantics.Lexical.EventStructure
 open Semantics.ArgumentStructure.ArgDerivation
@@ -227,7 +227,7 @@ theorem dress_same_form : dress.lexicalCausative = none := rfl
 -- ════════════════════════════════════════════════════
 
 /-! [krejci-2012]'s claim that eat and dress have causative event
-    structure aligns with their `FeatureSignature` classification:
+    structure aligns with their `Root.FeatureSignature` classification:
     both are `causativeResult` ({state, result, cause}), meaning the
     root itself entails external causation. -/
 

--- a/Linglib/Studies/Levin2026.lean
+++ b/Linglib/Studies/Levin2026.lean
@@ -120,7 +120,7 @@ theorem agrees_with_diathesis_data :
     no causation. The result and causation come from the construction. -/
 theorem all_classes_pure_manner :
     intrPushOpenClasses.all
-      (·.rootEntailments == FeatureSignature.pureManner) = true := by
+      (·.rootEntailments == Root.FeatureSignature.pureManner) = true := by
   native_decide
 
 /-- All core classes encode contact and motion but NOT change of state
@@ -767,7 +767,7 @@ theorem blocked_wrong_adjective :
 theorem end_to_end_push_open :
     -- Step 1-2: verb class blocks alternation alone
     LevinClass.pushPull.participatesIn .causativeInchoative = false ∧
-    LevinClass.rootEntailments .pushPull == FeatureSignature.pureManner ∧
+    LevinClass.rootEntailments .pushPull == Root.FeatureSignature.pureManner ∧
     -- Step 3: fusion — construction adds CoS + causation → alternation predicted
     predictedAlternationInConstruction
       LevinClass.pushPull.meaningComponents

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -201,7 +201,7 @@ theorem positional_distinct_from_motion :
 /-! ### Closure robustness -/
 
 /-- The class predicted from a root's *closed* feature signature
-    (the collocational closure `FeatureSignature.close` of the derived
+    (the collocational closure `Root.FeatureSignature.close` of the derived
     signature). -/
 def closedPredictedClass (r : Root) : Option SalienceClass :=
   classOfSignature r.closedFeatureSignature


### PR DESCRIPTION
Completes the Roots API plan: `Root.entailments : List → Finset LexEntailment` (membership was the only consumed semantics), atom-level closure packaged as a mathlib `ClosureOperator` (`bkgCloseOp`) with honest idempotence instead of the up-to-List.any hedge, and `FeatureSignature` namespaced under `Root` (bare name was too generic at root level). Root drops `Repr` (`Finset.instRepr` is unsafe).