### PR TITLE
fix(Semantics/Lexical/Roots): salience via root arity, not manner+result

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2467,6 +2467,7 @@ import Linglib.Semantics.Lexical.LevinClassProfiles
 import Linglib.Semantics.Lexical.EventStructure
 import Linglib.Semantics.ArgumentStructure.ArgDerivation
 import Linglib.Semantics.Lexical.Roots.Signature
+import Linglib.Semantics.Lexical.Roots.Arity
 import Linglib.Semantics.Lexical.Roots.Basic
 import Linglib.Semantics.Lexical.Roots.Template
 import Linglib.Semantics.Lexical.Roots.Typology

--- a/Linglib/Fragments/Chuj/VerbBuilding.lean
+++ b/Linglib/Fragments/Chuj/VerbBuilding.lean
@@ -30,11 +30,11 @@ Consequences for the nature of roots."
 
 ## Modeling Notes
 
-**RootArity captures complement projection, not semantic type.**
+**Root.Arity captures complement projection, not semantic type.**
 Coon's semantic types (3) group {√TV, √ITV} together as ⟨e, ⟨s,t⟩⟩ — both
 compose with an entity argument per [davis-1997]. But syntactically, only
 √TV projects a complement DP that persists across voice alternations; √ITV's
-entity argument becomes the subject. Our `RootArity.selectsTheme` captures
+entity argument becomes the subject. Our `Root.Arity.selectsTheme` captures
 the syntactic complement projection, giving {√TV} vs {√ITV, √POS, √NOM}.
 This matches the -aj diagnostic: -aj marks implicit arguments, and only √TV
 stems show -aj (the theme can be implicit), not √ITV.

--- a/Linglib/Fragments/Mayan/Yukatek/Operators.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Operators.lean
@@ -20,13 +20,16 @@ or `=s` is required to form a transitive stem from an underived root:
 | Required suffix | Lucy's class           | Lexical content of root                                    |
 |-----------------|------------------------|------------------------------------------------------------|
 | `=t` (AFCT)     | agent-salient          | activity / manner-of-action; one (agent) argument salient  |
-| `=∅` (root)     | agent-patient salient  | both arguments already salient → transitive without deriv. |
+| `=∅` (root)     | agent-patient salient  | lexically transitive ("require two arguments")            |
 | `=s` (CAUS)     | patient-salient        | spontaneous state change; one (patient) argument salient   |
 
-This translates directly into B&K-G feature conditions: agent-salient
-roots have manner without result; agent-patient salient roots have
-both manner and result; patient-salient roots have result without
-manner. Spelt out structurally below.
+The structural conditions are over (B&K-G feature signature × Coon
+arity): zero derivation tracks root transitivity
+(`Root.Arity.selectsTheme`); the two intransitive transitivisers split
+by signature (manner vs result). Each condition is the corresponding
+named predicate of `Roots/SalienceClass.lean` applied to the root's
+signature and the fragment's `arity` assignment, so operator
+applicability matches predicted salience by construction.
 -/
 
 namespace Yukatek.Operators
@@ -34,9 +37,7 @@ namespace Yukatek.Operators
 open Morphology.Derivation
 open Yukatek.Roots
 
--- ════════════════════════════════════════════════════
--- § 1. The Four Operators
--- ════════════════════════════════════════════════════
+/-! ### The four operators -/
 
 /-- Affective `=t`: forms a transitive stem from an *agent-salient*
     root by adding a patient argument. Per [lucy-1994], applies
@@ -45,17 +46,18 @@ open Yukatek.Roots
     without inherent result. -/
 def affectiveT : DerivOp :=
   { name := "=t"
-  , applies := Root.IsAgentSalient
+  , applies := fun r => IsAgentSalient r.featureSignature (arity r)
   , decApplies := inferInstance }
 
 /-- Zero derivation `=∅`: signals that the root is already lexically
-    transitive — both an agent and a patient are salient in the
-    underived form. Per [lucy-1994], these roots "refer to events
-    involving the action of one entity on another", so the root must
-    encode both manner (the action) and result (its effect). -/
+    transitive — it "require[s] two arguments and refer[s] to events
+    involving the action of one entity on another" ([lucy-1994]).
+    The condition is root transitivity (`Root.Arity.selectsTheme`),
+    not any feature configuration: root transitives like *p'is*
+    'measure' entail no change of state. -/
 def zeroDeriv : DerivOp :=
   { name := "=∅"
-  , applies := Root.IsAgentPatientSalient
+  , applies := fun r => IsAgentPatientSalient (arity r)
   , decApplies := inferInstance }
 
 /-- Causative `=s`: forms a transitive stem from a *patient-salient*
@@ -65,7 +67,7 @@ def zeroDeriv : DerivOp :=
     result without specified manner. -/
 def causativeS : DerivOp :=
   { name := "=s"
-  , applies := Root.IsPatientSalient
+  , applies := fun r => IsPatientSalient r.featureSignature (arity r)
   , decApplies := inferInstance }
 
 /-- Positional inchoative `-tal` (allomorph `-lah`): forms a positional stem from a
@@ -76,12 +78,10 @@ def causativeS : DerivOp :=
     result, or cause atoms. -/
 def positionalTal : DerivOp :=
   { name := "-tal"
-  , applies := Root.IsPositional
+  , applies := fun r => IsPositional r.featureSignature (arity r)
   , decApplies := inferInstance }
 
--- ════════════════════════════════════════════════════
--- § 2. The Inventory
--- ════════════════════════════════════════════════════
+/-! ### The inventory -/
 
 /-- [lucy-1994]'s diagnostic transitiviser inventory. Order is
     chosen to match the presentation in [lucy-1994] ex. (1):

--- a/Linglib/Fragments/Mayan/Yukatek/Roots.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Roots.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Lexical.Roots.Closure
+import Linglib.Semantics.Lexical.Roots.Arity
 
 /-!
 # Yukatek Maya Roots as B&K-G Entailment Sets
@@ -19,9 +20,9 @@ inventory in `Operators.lean` and the orbit-derivation in
 |-----------------|-----------|--------------------|----------------------|------------------------|
 | ex. (1a)        | `siit'`     | "jump"             | manner               | agent-salient          |
 | (text p. 628)   | `tziib`     | "write"            | manner               | agent-salient          |
-| ex. (1b)        | `kuc`       | "carry"            | manner + result      | agent-patient salient  |
-| (text p. 629)   | `pis`       | "measure"          | manner + result      | agent-patient salient  |
-| (text p. 629)   | `los`       | "punch"            | manner + result      | agent-patient salient  |
+| ex. (1b)        | `kuc`       | "carry"            | manner, root transitive | agent-patient salient |
+| (text p. 629)   | `pis`       | "measure"          | manner, root transitive | agent-patient salient |
+| (text p. 629)   | `los`       | "punch"            | manner, root transitive | agent-patient salient |
 | ex. (1c) / (2)  | `kiim`      | "die"              | result               | patient-salient        |
 | ex. (2)         | `haanCease` | "stop, cease, heal" | result              | patient-salient        |
 | ex. (4)         | `luub`      | "fall"             | result               | patient-salient        |
@@ -81,24 +82,32 @@ def cheh : Root := ⟨"ć'eh", {.hasManner "shouting"}⟩
     ([lucy-1994] agent-salient list). -/
 def paak : Root := ⟨"paak", {.hasManner "weeding"}⟩
 
--- ════════════════════════════════════════════════════
--- § 2. Agent-Patient Salient Roots (manner + result, take `=∅`)
--- ════════════════════════════════════════════════════
+/-! ### Agent-patient salient roots (root transitives, take `=∅`)
 
-/-- kuč "carry" — action with patient affected ([lucy-1994] ex. 1b).
-    Underived transitive; no derivation needed. -/
-def kuc : Root := ⟨"kuc",
-  {.hasManner "carrying", .becomesState "transported"}⟩
+These roots "require two arguments and refer to events involving the
+action of one entity on another" ([lucy-1994]) — their distinguishing
+property is *root transitivity* (`Root.Arity.selectsTheme`, recorded
+in `arity` below), not any B&K-G feature configuration. They carry no
+`becomesState` atom: 'measure' and 'punch' entail no change of state
+(B&K-G class *hit*-type surface-contact verbs as manner-only), so
+classing them by `manner + result` would wrongly make every Yukatek
+root transitive a Manner/Result-Complementarity violator. -/
 
-/-- p'is "measure" — action with patient affected ([lucy-1994] p. 629). -/
-def pis : Root := ⟨"pis",
-  {.hasManner "measuring", .becomesState "measured"}⟩
+/-- kuč "carry" — manner-of-action, lexically transitive
+    ([lucy-1994] ex. 1b). Underived transitive; no derivation
+    needed. -/
+def kuc : Root := ⟨"kuc", {.hasManner "carrying"}⟩
 
-/-- lo'š "punch" — action with patient affected ([lucy-1994] p. 629).
-    No `.contact` atom: contact is implicit in the manner of striking
-    rather than a B&K-G feature in Lucy's typology. -/
-def los : Root := ⟨"los",
-  {.hasManner "striking", .becomesState "punched"}⟩
+/-- p'is "measure" — manner-of-action, lexically transitive
+    ([lucy-1994] p. 629). No entailed change of state. -/
+def pis : Root := ⟨"pis", {.hasManner "measuring"}⟩
+
+/-- lo'š "punch" — manner-of-action, lexically transitive
+    ([lucy-1994] p. 629). Surface-contact manner without entailed
+    result, like B&K-G's *hit*-type. No `.contact` atom: contact is
+    implicit in the manner of striking rather than a B&K-G feature in
+    Lucy's typology. -/
+def los : Root := ⟨"los", {.hasManner "striking"}⟩
 
 -- ════════════════════════════════════════════════════
 -- § 3. Patient-Salient Roots (result only, take `=s`)
@@ -195,6 +204,18 @@ def cin : Root := ⟨"cin", {.hasState "bent"}⟩
     relational positional semantics: "x is-seated [on y]"). -/
 def kul : Root := ⟨"kul", {.hasState "seated"}⟩
 
+/-! ### Root arity -/
+
+/-- The root transitives of this sample — [lucy-1994]'s `=∅` class
+    ("some 500 roots form a transitive in this way"; here the three
+    sampled members). -/
+def rootTransitives : List Root := [kuc, pis, los]
+
+/-- Coon arity for the sampled roots: the `=∅` class selects a theme
+    ([coon-2019]'s √TV); every other sampled root is intransitive. -/
+def arity (r : Root) : Root.Arity :=
+  if r ∈ rootTransitives then .selectsTheme else .noTheme
+
 /-! ### Per-root feature signatures -/
 
 /-! Agent-salient roots → `{.manner}`. -/
@@ -210,14 +231,14 @@ theorem cheh_signature :
 theorem paak_signature :
     paak.featureSignature = {.manner} := by decide
 
-/-! Agent-patient salient roots → `{.manner, .result}`. -/
+/-! Agent-patient salient (root-transitive) roots → `{.manner}`. -/
 
 theorem kuc_signature :
-    kuc.featureSignature = {.manner, .result} := by decide
+    kuc.featureSignature = {.manner} := by decide
 theorem pis_signature :
-    pis.featureSignature = {.manner, .result} := by decide
+    pis.featureSignature = {.manner} := by decide
 theorem los_signature :
-    los.featureSignature = {.manner, .result} := by decide
+    los.featureSignature = {.manner} := by decide
 
 /-! Patient-salient roots → `{.result}`. -/
 
@@ -276,10 +297,10 @@ theorem kul_signature :
     to any signature containing `.result`, and `.result` + `.state` to
     any containing `.cause`. No Yukatek root here carries a `.cause`
     atom, so only the result→state edge fires. Closure does *not*
-    change the Lucy 1994 salience class predicted by
-    `classOfSignature` for these roots: the agent / agentPatient /
-    patient arms ignore `.state` membership, and the positional arm
-    (signature exactly `{.state}`) is never produced by closure from a
+    change the Lucy 1994 salience class predicted by `classOf` for
+    these roots: arity is closure-invariant, the agent / patient arms
+    ignore `.state` membership, and the positional arm (signature
+    exactly `{.state}`) is never produced by closure from a
     non-positional base without `.cause`
     (cf. `Lucy1994.predictedClass_closure_invariant`). -/
 
@@ -290,13 +311,13 @@ theorem tziib_closed_signature :
     tziib.closedFeatureSignature = {.manner} := by decide
 
 theorem kuc_closed_signature :
-    kuc.closedFeatureSignature = {.state, .manner, .result} := by decide
+    kuc.closedFeatureSignature = {.manner} := by decide
 
 theorem pis_closed_signature :
-    pis.closedFeatureSignature = {.state, .manner, .result} := by decide
+    pis.closedFeatureSignature = {.manner} := by decide
 
 theorem los_closed_signature :
-    los.closedFeatureSignature = {.state, .manner, .result} := by decide
+    los.closedFeatureSignature = {.manner} := by decide
 
 theorem kiim_closed_signature :
     kiim.closedFeatureSignature = {.state, .result} := by decide

--- a/Linglib/Morphology/DM/Categorizer.lean
+++ b/Linglib/Morphology/DM/Categorizer.lean
@@ -647,7 +647,7 @@ theorem complement_selection_at_root_level (r : RootClassification) (c1 c2 : Cat
 theorem theme_selecting_root_always_selects (r : RootClassification) (c : Categorizer)
     (h : r.arity = .selectsTheme) :
     (CategorizedRoot.mk r c).root.arity.hasInternalArg = true := by
-  simp [h, RootArity.hasInternalArg]
+  simp [h, Root.Arity.hasInternalArg]
 
 -- ============================================================================
 -- § 4: Layered Derivation (Denominal, Deadjectival, Deverbal)

--- a/Linglib/Morphology/RootTypology.lean
+++ b/Linglib/Morphology/RootTypology.lean
@@ -2,6 +2,7 @@ import Linglib.Semantics.Lexical.EventStructure
 import Linglib.Semantics.Aspect.ChangeOfState
 import Linglib.Semantics.Lexical.LevinTheory
 import Linglib.Semantics.Lexical.Roots.Template
+import Linglib.Semantics.Lexical.Roots.Arity
 import Linglib.Semantics.Lexical.Roots.Profile
 
 open Semantics.Lexical
@@ -95,21 +96,6 @@ def RootType.entailsChange : RootType → Bool
   | .propertyConcept => false
   | .result => true
 
-/-- Whether a root selects an internal (theme) argument.
-
-    [coon-2019]: the central division of labor is that **roots determine
-    internal arguments** while **functional heads (v/Voice⁰) determine
-    external arguments**. This is orthogonal to change entailment. -/
-inductive RootArity where
-  | selectsTheme  -- root obligatorily takes internal argument (Coon's √TV)
-  | noTheme       -- no internal argument selection (Coon's √ITV, √NOM, √POS)
-  deriving DecidableEq, Repr
-
-/-- Does this root arity entail an obligatory internal argument? -/
-def RootArity.hasInternalArg : RootArity → Bool
-  | .selectsTheme => true
-  | .noTheme => false
-
 /-- The semantic denotation domain of a root ([coon-2019], (3);
     extended by [hanink-koontz-garboden-2025]).
 
@@ -157,7 +143,7 @@ def RootDenotationType.hasIndivArg : RootDenotationType → Bool
     √POS = noTheme + measureFn, √NOM = noTheme + entityPred. -/
 structure RootClassification where
   /-- Does this root select an internal argument? -/
-  arity : RootArity
+  arity : Root.Arity
   /-- Does this root lexically entail prior change? -/
   changeType : RootType
   /-- Semantic denotation domain ([coon-2019], (3)). Optional — not all
@@ -1402,7 +1388,7 @@ theorem change_does_not_determine_arity :
     the derived verb. No functional head modifies it. -/
 theorem theme_persistence (r : RootClassification) (h : r.arity = .selectsTheme) :
     r.arity.hasInternalArg = true := by
-  simp [h, RootArity.hasInternalArg]
+  simp [h, Root.Arity.hasInternalArg]
 
 /-- Change entailment determines markedness in the unified Root. -/
 theorem root_markedness_from_change (r : RootClassification) :

--- a/Linglib/Semantics/Lexical/Roots/Arity.lean
+++ b/Linglib/Semantics/Lexical/Roots/Arity.lean
@@ -1,0 +1,37 @@
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# Root Arity
+
+[coon-2019]: the central division of labor in Mayan root typology is
+that **roots determine internal arguments** while **functional heads
+(v/Voice⁰) determine external arguments**. Root arity — whether a root
+obligatorily projects a theme — is orthogonal to change entailment and
+to the B&K-G feature signature, and is the dimension behind the Mayan
+"root transitive" class: [coon-2019]'s √TV for Chuj, [lucy-1994]'s
+agent-patient salient (`=∅`) class for Yucatec ("these roots require
+two arguments and refer to events involving the action of one entity
+on another").
+
+Arity captures complement *projection*, not semantic type: an
+unaccusative's sole argument is semantically theme-like, but the root
+does not project it as a complement.
+
+## Main declarations
+
+* `Root.Arity` — `selectsTheme` (√TV) vs `noTheme`
+-/
+
+/-- Root-level argument selection ([coon-2019]): does the root
+    obligatorily take an internal (theme) argument? `selectsTheme` is
+    Coon's √TV — the Mayan root-transitive class; `noTheme` covers
+    √ITV, √NOM, √POS. -/
+inductive Root.Arity where
+  | selectsTheme
+  | noTheme
+  deriving DecidableEq, Fintype, Repr
+
+/-- Does this root arity entail an obligatory internal argument? -/
+def Root.Arity.hasInternalArg : Root.Arity → Bool
+  | .selectsTheme => true
+  | .noTheme => false

--- a/Linglib/Semantics/Lexical/Roots/SalienceClass.lean
+++ b/Linglib/Semantics/Lexical/Roots/SalienceClass.lean
@@ -1,23 +1,39 @@
 import Linglib.Semantics.Lexical.Roots.Typology
+import Linglib.Semantics.Lexical.Roots.Arity
 
 /-!
 # Lexical Salience Classes
 
 [lucy-1994]'s classification of verbal roots by which argument(s) the
 underived root form makes "salient" (default case-role assignment at
-the propositional level): a 3-way salience cut (agent, agent-patient,
-patient, by required transitiviser) plus the separately-derived
-positional class, systematized here as one enum. The characterization
-of each class by B&K-G feature signature is a cross-framework
-reconstruction ([lucy-1994] predates the feature vocabulary of
+the propositional level): a 3-way salience cut by required
+transitiviser — agent (`=t`), agent-patient (`=∅`), patient (`=s`) —
+plus the separately-derived positional class (`-tal`), systematized
+here as one enum.
+
+The structural characterization of each class needs **two**
+dimensions. Agent-patient salience is *root transitivity*: these roots
+"require two arguments and refer to events involving the action of one
+entity on another" ([lucy-1994]) — `Root.Arity.selectsTheme`, the
+Mayan root-transitive class of [coon-2019]. It is NOT a B&K-G feature
+configuration: *p'is* 'measure' and *lo'š* 'punch' are manner roots
+with no entailed change of state. The two intransitive classes are
+then separated by the signature (manner vs result), matching the
+Sapir/Perlmutter unaccusativity split [lucy-1994] cites. This
+two-dimensional characterization is a cross-framework reconstruction
+([lucy-1994] predates both [coon-2019] and
 [beavers-koontz-garboden-2020]), not Lucy's own formulation.
 
-This file lifts the classification out of any specific empirical
-study so that other Fragment / Theory modules can refer to it
-(e.g., the Yukatek 5-way verb stem classification, which refines
-this cut). The full [lucy-1994] analysis — operator applicability,
+The full [lucy-1994] analysis — operator applicability,
 motion-roots-non-class theorem, per-root verifications — lives in
 `Studies/Lucy1994.lean`.
+
+## Main declarations
+
+* `SalienceClass`
+* `IsAgentSalient`, `IsAgentPatientSalient`, `IsPatientSalient`,
+  `IsPositional` — conditions over (signature × arity)
+* `classOf` — the salience classifier
 -/
 
 /-- Salience classification of verbal roots ([lucy-1994]): the 3-way
@@ -35,139 +51,94 @@ inductive SalienceClass where
   | positional
   deriving DecidableEq, Repr
 
-/-! ### Named class predicates
+/-! ### Named class conditions
 
-Named structural conditions characterising membership in each
-[lucy-1994] salience class. These predicates are language-independent:
-the same conditions characterise the class in any inventory whose
-transitivisers respect the diagnostic. They appear directly as the
-`applies` field of each Yukatek operator in
-`Fragments/Mayan/Yukatek/Operators.lean`, making the
-operator-applicability ↔ salience-class connection true *by
+Structural conditions characterising membership in each [lucy-1994]
+salience class, over the pair (B&K-G feature signature × Coon arity).
+These conditions are language-independent: the same conditions
+characterise the class in any inventory whose transitivisers respect
+the diagnostic. They appear directly as the `applies` field of each
+Yukatek operator in `Fragments/Mayan/Yukatek/Operators.lean`, making
+the operator-applicability ↔ salience-class connection true *by
 construction* rather than only provable per-case. -/
 
-namespace Root.FeatureSignature
+/-- Agent-salient: intransitive manner-of-action root (requires `=t`
+    to transitivise; [lucy-1994]: "actions or activities that some
+    entity undertakes"). -/
+def IsAgentSalient (s : Root.FeatureSignature) (ar : Root.Arity) : Prop :=
+  ar = .noTheme ∧ .manner ∈ s ∧ .result ∉ s
 
-/-- Agent-salient: manner without result (intransitive activity that
-    requires =t to transitivise; [lucy-1994]). -/
-def IsAgentSalient (s : Root.FeatureSignature) : Prop :=
-  .manner ∈ s ∧ .result ∉ s
-
-instance (s : Root.FeatureSignature) : Decidable s.IsAgentSalient :=
+instance (s : Root.FeatureSignature) (ar : Root.Arity) :
+    Decidable (IsAgentSalient s ar) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
-/-- Agent-patient salient: manner *and* result (already lexically
-    transitive; [lucy-1994]). -/
-def IsAgentPatientSalient (s : Root.FeatureSignature) : Prop :=
-  .manner ∈ s ∧ .result ∈ s
+/-- Agent-patient salient: the root is lexically transitive — it
+    "require[s] two arguments" ([lucy-1994]), i.e. selects a theme
+    ([coon-2019]'s √TV). Signature-independent: root transitives need
+    not entail any change of state (*p'is* 'measure'). -/
+def IsAgentPatientSalient (ar : Root.Arity) : Prop :=
+  ar = .selectsTheme
 
-instance (s : Root.FeatureSignature) : Decidable s.IsAgentPatientSalient :=
-  inferInstanceAs (Decidable (_ ∧ _))
-
-/-- Patient-salient: result without manner (intransitive change-of-state
-    that requires =s to transitivise; [lucy-1994]). -/
-def IsPatientSalient (s : Root.FeatureSignature) : Prop :=
-  .manner ∉ s ∧ .result ∈ s
-
-instance (s : Root.FeatureSignature) : Decidable s.IsPatientSalient :=
-  inferInstanceAs (Decidable (_ ∧ _))
-
-/-- Positional: pure stative root — state without manner, result, or
-    cause (requires `-tal` for the inchoative; [lucy-1994]). -/
-def IsPositional (s : Root.FeatureSignature) : Prop :=
-  s = {.state}
-
-instance (s : Root.FeatureSignature) : Decidable s.IsPositional :=
+instance (ar : Root.Arity) : Decidable (IsAgentPatientSalient ar) :=
   inferInstanceAs (Decidable (_ = _))
 
-end Root.FeatureSignature
+/-- Patient-salient: intransitive change-of-state root (requires `=s`
+    to transitivise; [lucy-1994]: "state changes that some entity
+    undergoes more or less spontaneously"). -/
+def IsPatientSalient (s : Root.FeatureSignature) (ar : Root.Arity) : Prop :=
+  ar = .noTheme ∧ .manner ∉ s ∧ .result ∈ s
 
-/-! Per-root convenience versions, lifted via `featureSignature`. -/
+instance (s : Root.FeatureSignature) (ar : Root.Arity) :
+    Decidable (IsPatientSalient s ar) :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
-namespace Root
+/-- Positional: pure stative configurational root (requires `-tal`
+    for the inchoative; [lucy-1994]). -/
+def IsPositional (s : Root.FeatureSignature) (ar : Root.Arity) : Prop :=
+  ar = .noTheme ∧ s = {.state}
 
-/-- Agent-salient root (cf. `Root.FeatureSignature.IsAgentSalient`). -/
-def IsAgentSalient (r : Root) : Prop :=
-  r.featureSignature.IsAgentSalient
-
-instance (r : Root) : Decidable r.IsAgentSalient :=
-  inferInstanceAs (Decidable (Root.FeatureSignature.IsAgentSalient _))
-
-/-- Agent-patient salient root. -/
-def IsAgentPatientSalient (r : Root) : Prop :=
-  r.featureSignature.IsAgentPatientSalient
-
-instance (r : Root) : Decidable r.IsAgentPatientSalient :=
-  inferInstanceAs (Decidable (Root.FeatureSignature.IsAgentPatientSalient _))
-
-/-- Patient-salient root. -/
-def IsPatientSalient (r : Root) : Prop :=
-  r.featureSignature.IsPatientSalient
-
-instance (r : Root) : Decidable r.IsPatientSalient :=
-  inferInstanceAs (Decidable (Root.FeatureSignature.IsPatientSalient _))
-
-/-- Positional root. -/
-def IsPositional (r : Root) : Prop :=
-  r.featureSignature.IsPositional
-
-instance (r : Root) : Decidable r.IsPositional :=
-  inferInstanceAs (Decidable (Root.FeatureSignature.IsPositional _))
-
-end Root
+instance (s : Root.FeatureSignature) (ar : Root.Arity) :
+    Decidable (IsPositional s ar) :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
 /-! ### Salience classifier -/
 
-/-- Map a B&K-G feature signature to its salience class
-    ([lucy-1994]) by dispatching on the four named predicates, which
-    align with operator applicability conditions in
-    `Fragments/Mayan/Yukatek/Operators.lean`. The positional arm
-    requires the pure-state signature: positional roots are stative
-    configurations (orientation, posture, location) with no causing
-    event. -/
-def classOfSignature (s : Root.FeatureSignature) : Option SalienceClass :=
-  if s.IsAgentSalient then some .agent
-  else if s.IsAgentPatientSalient then some .agentPatient
-  else if s.IsPatientSalient then some .patient
-  else if s.IsPositional then some .positional
+/-- Map a (B&K-G feature signature × Coon arity) pair to its salience
+    class ([lucy-1994]) by dispatching on the four named conditions,
+    which align with operator applicability conditions in
+    `Fragments/Mayan/Yukatek/Operators.lean`. -/
+def classOf (s : Root.FeatureSignature) (ar : Root.Arity) :
+    Option SalienceClass :=
+  if IsAgentPatientSalient ar then some .agentPatient
+  else if IsAgentSalient s ar then some .agent
+  else if IsPatientSalient s ar then some .patient
+  else if IsPositional s ar then some .positional
   else none
 
-/-- A root's predicted salience class is `classOfSignature` of its
-    feature signature. -/
-def Root.predictedSalience (r : Root) : Option SalienceClass :=
-  classOfSignature r.featureSignature
+/-! ### Pairwise disjointness of class conditions -/
 
-/-- Two roots with the same B&K-G feature signature get the same
-    salience class. -/
-theorem predictedSalience_depends_only_on_signature
-    (r₁ r₂ : Root) (h : r₁.featureSignature = r₂.featureSignature) :
-    r₁.predictedSalience = r₂.predictedSalience := by
-  unfold Root.predictedSalience
-  rw [h]
-
-/-! ### Pairwise disjointness of class predicates -/
-
-/-- The four named predicates are pairwise disjoint: at most one fires
-    on any given signature. (They are *jointly* not exhaustive — the
-    no-manner-no-result signatures other than `{state}` fall outside
-    all four; see `classOfSignature_eq_none_iff`.) -/
+/-- The four named conditions are pairwise disjoint: at most one fires
+    on any (signature, arity) pair. (They are *jointly* not exhaustive
+    — intransitive signatures with neither manner nor result that are
+    not pure `{state}` fall outside all four; see
+    `classOf_eq_none_iff`.) -/
 theorem classes_pairwise_disjoint :
-    ∀ s : Root.FeatureSignature,
-      ¬ (s.IsAgentSalient ∧ s.IsAgentPatientSalient) ∧
-      ¬ (s.IsAgentSalient ∧ s.IsPatientSalient) ∧
-      ¬ (s.IsAgentSalient ∧ s.IsPositional) ∧
-      ¬ (s.IsAgentPatientSalient ∧ s.IsPatientSalient) ∧
-      ¬ (s.IsAgentPatientSalient ∧ s.IsPositional) ∧
-      ¬ (s.IsPatientSalient ∧ s.IsPositional) := by
+    ∀ (s : Root.FeatureSignature) (ar : Root.Arity),
+      ¬ (IsAgentSalient s ar ∧ IsAgentPatientSalient ar) ∧
+      ¬ (IsAgentSalient s ar ∧ IsPatientSalient s ar) ∧
+      ¬ (IsAgentSalient s ar ∧ IsPositional s ar) ∧
+      ¬ (IsAgentPatientSalient ar ∧ IsPatientSalient s ar) ∧
+      ¬ (IsAgentPatientSalient ar ∧ IsPositional s ar) ∧
+      ¬ (IsPatientSalient s ar ∧ IsPositional s ar) := by
   decide
 
-/-- `classOfSignature s = none` iff `s` falls outside all four named
-    predicates. Characterises the gap in the diagnostic: the
-    no-manner-no-result signatures other than pure `{state}` are
-    unclassified by Lucy's Yukatek diagnostic. -/
-theorem classOfSignature_eq_none_iff :
-    ∀ s : Root.FeatureSignature,
-      classOfSignature s = none ↔
-        ¬ s.IsAgentSalient ∧ ¬ s.IsAgentPatientSalient ∧
-        ¬ s.IsPatientSalient ∧ ¬ s.IsPositional := by
+/-- `classOf s ar = none` iff the pair falls outside all four named
+    conditions. Characterises the gap in the diagnostic: intransitive
+    roots with neither a manner nor a result kind, other than pure
+    `{state}`, are unclassified by Lucy's Yukatek diagnostic. -/
+theorem classOf_eq_none_iff :
+    ∀ (s : Root.FeatureSignature) (ar : Root.Arity),
+      classOf s ar = none ↔
+        ¬ IsAgentSalient s ar ∧ ¬ IsAgentPatientSalient ar ∧
+        ¬ IsPatientSalient s ar ∧ ¬ IsPositional s ar := by
   decide

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -30,13 +30,17 @@ via `-tal` (allomorph `-lah`) for the positional inchoative.
 Here we recast the salience cut as a derived equivalence on roots
 under the operator inventory in `Fragments/Mayan/Yukatek/Operators.lean`:
 two roots have the same salience class iff the same operator(s) apply
-to them. The 3-way classification then *falls out* of (B&K-G feature
-signature) × (operator applicability conditions) — it is not stipulated.
+to them. The classification then *falls out* of (B&K-G feature
+signature × Coon root arity) × (operator applicability conditions) —
+it is not stipulated. Arity carries the agent-patient class (Lucy's
+`=∅` roots "require two arguments"; *p'is* 'measure' and *lo'š*
+'punch' entail no change of state, so no feature configuration could
+carry it); the signature separates the two intransitive classes.
 
-The structural theorem `class_depends_only_on_signature` makes this
-precise: salience class depends only on the feature signature, not on
+The structural theorem `class_depends_only_on_signature_and_arity`
+makes this precise: salience class depends only on the pair, not on
 the specific root identity. The per-root checks then degenerate to
-finite signature lookups.
+finite lookups.
 -/
 
 namespace Lucy1994
@@ -47,56 +51,58 @@ open Yukatek.Operators
 
 /-! ### Salience classes (re-exported from theory) -/
 
-/-! `SalienceClass` and `classOfSignature` live in
+/-! `SalienceClass` and `classOf` live in
     `Semantics/Lexical/Roots/SalienceClass.lean`. This file
     provides the full [lucy-1994] analysis on top of them:
-    operator-applicability characterizations and per-root sanity checks.
+    operator-applicability characterizations and per-root sanity checks. -/
 
-    Local short alias `predictedClass = Root.predictedSalience`. -/
-
-/-- A root's predicted salience class. Alias for
-    `Root.predictedSalience` (`SalienceClass.lean`). -/
+/-- A root's predicted salience class: the substrate classifier
+    applied to its signature and the fragment's arity assignment. -/
 abbrev predictedClass (r : Root) : Option SalienceClass :=
-  r.predictedSalience
+  classOf r.featureSignature (arity r)
 
-theorem class_depends_only_on_signature
-    (r₁ r₂ : Root) (h : r₁.featureSignature = r₂.featureSignature) :
-    predictedClass r₁ = predictedClass r₂ :=
-  predictedSalience_depends_only_on_signature r₁ r₂ h
+theorem class_depends_only_on_signature_and_arity
+    (r₁ r₂ : Root) (h : r₁.featureSignature = r₂.featureSignature)
+    (h' : arity r₁ = arity r₂) :
+    predictedClass r₁ = predictedClass r₂ := by
+  unfold predictedClass
+  rw [h, h']
 
 /-! ### Predicted class agrees with operator applicability -/
 
 /-! Both `predictedClass` and the inventory's applicability profile
-    factor through the root's feature signature, a `Finset LexKind`
-    drawn from a 16-element fintype. Each characterisation therefore
-    reduces — after rewriting the profile to signature level
-    (`applicableNames_eq_profile`) and generalising the signature — to
-    a statement over all signatures that `decide` checks. The local
-    macro `lucy_applicable` packages the reduction. -/
+    factor through the pair (feature signature × arity), drawn from a
+    32-element fintype. Each characterisation therefore reduces —
+    after rewriting the profile to pair level
+    (`applicableNames_eq_profile`) and generalising the pair — to a
+    statement over all pairs that `decide` checks. The local macro
+    `lucy_applicable` packages the reduction. -/
 
-/-- The inventory's applicability profile as a function of the feature
-    signature. The four operator conditions are pairwise disjoint
-    (`classes_pairwise_disjoint`), so at most one name appears. -/
+/-- The inventory's applicability profile as a function of the
+    (signature × arity) pair. The four operator conditions are
+    pairwise disjoint (`classes_pairwise_disjoint`), so at most one
+    name appears. -/
 private theorem applicableNames_eq_profile (r : Root) :
     inventory.applicableNames r =
-      (if r.featureSignature.IsAgentSalient then ["=t"] else []) ++
-      (if r.featureSignature.IsAgentPatientSalient then ["=∅"] else []) ++
-      (if r.featureSignature.IsPatientSalient then ["=s"] else []) ++
-      (if r.featureSignature.IsPositional then ["-tal"] else []) := by
+      (if IsAgentSalient r.featureSignature (arity r) then ["=t"] else []) ++
+      (if IsAgentPatientSalient (arity r) then ["=∅"] else []) ++
+      (if IsPatientSalient r.featureSignature (arity r) then ["=s"] else []) ++
+      (if IsPositional r.featureSignature (arity r) then ["-tal"] else []) := by
   simp only [inventory, Inventory.applicableNames, affectiveT, zeroDeriv,
     causativeS, positionalTal, List.filter_cons, List.filter_nil,
-    decide_eq_true_eq, Root.IsAgentSalient, Root.IsAgentPatientSalient,
-    Root.IsPatientSalient, Root.IsPositional]
+    decide_eq_true_eq]
   generalize r.featureSignature = s
-  revert s
+  generalize arity r = a
+  revert s a
   decide
 
 local macro "lucy_applicable " r:term : tactic =>
   `(tactic|
     (rw [applicableNames_eq_profile]
-     unfold predictedClass Root.predictedSalience
+     unfold predictedClass
      generalize ($r).featureSignature = s
-     revert s
+     generalize arity $r = a
+     revert s a
      decide))
 
 /-- The `=t`-only applicability profile characterises agent-salient roots. -/
@@ -134,10 +140,12 @@ theorem applicableNames_eq_iff_predictedClass_eq (r₁ r₂ : Root) :
     inventory.applicableNames r₁ = inventory.applicableNames r₂ ↔
       predictedClass r₁ = predictedClass r₂ := by
   rw [applicableNames_eq_profile, applicableNames_eq_profile]
-  unfold predictedClass Root.predictedSalience
+  unfold predictedClass
   generalize r₁.featureSignature = s₁
+  generalize arity r₁ = a₁
   generalize r₂.featureSignature = s₂
-  revert s₁ s₂
+  generalize arity r₂ = a₂
+  revert s₁ a₁ s₂ a₂
   decide
 
 /-! ### Per-root sanity checks -/
@@ -198,31 +206,45 @@ theorem motion_roots_not_separate_class :
 theorem positional_distinct_from_motion :
     predictedClass cin ≠ predictedClass luub := by decide
 
+/-! ### Root transitivity is not MRC violation -/
+
+/-- Lucy's root transitives are manner-only roots in B&K-G terms —
+    lexical transitivity does not entail a result. Under the previous
+    schema (agent-patient salience as `manner + result`) every Yukatek
+    root transitive came out violating Manner/Result Complementarity,
+    contradicting [beavers-koontz-garboden-2020]'s finding that
+    manner+result roots are a restricted, special class; *hit*-type
+    surface-contact roots like *lo'š* 'punch' are their parade
+    manner-without-result examples. -/
+theorem rootTransitives_respect_mrc :
+    ∀ r ∈ rootTransitives, r.RespectsMannerResultComplementarity := by
+  decide
+
 /-! ### Closure robustness -/
 
 /-- The class predicted from a root's *closed* feature signature
     (the collocational closure `Root.FeatureSignature.close` of the derived
-    signature). -/
+    signature). Arity is closure-invariant. -/
 def closedPredictedClass (r : Root) : Option SalienceClass :=
-  classOfSignature r.closedFeatureSignature
+  classOf r.closedFeatureSignature (arity r)
 
 /-- For cause-free roots, collocational closure does not change the
-    Lucy 1994 salience classification: the only closure edge that can
-    fire is result→state, the agent / agentPatient / patient arms
-    ignore `.state` membership, and a base that gains `.state` from
-    closure carries `.result` and so is already excluded from the
-    positional arm. The hypothesis is necessary: a root carrying
-    `.cause` but not `.result` is unclassified at base yet
+    Lucy 1994 salience classification: arity is untouched, the only
+    closure edge that can fire is result→state, the agent / patient
+    arms ignore `.state` membership, and a base that gains `.state`
+    from closure carries `.result` and so is already excluded from the
+    positional arm. The hypothesis is necessary: an intransitive root
+    carrying `.cause` but not `.result` is unclassified at base yet
     patient-salient after closure, since the cause→result closure edge
     introduces `.result`. -/
 theorem predictedClass_closure_invariant (r : Root) (h : ¬ r.HasCause) :
     closedPredictedClass r = predictedClass r := by
   unfold Root.HasCause at h
-  unfold closedPredictedClass predictedClass Root.predictedSalience
-    Root.closedFeatureSignature
+  unfold closedPredictedClass predictedClass Root.closedFeatureSignature
   revert h
   generalize r.featureSignature = s
-  revert s
+  generalize arity r = a
+  revert s a
   decide
 
 /-! ### Bridge to Bohnemeyer's 5-way verb stem classes -/


### PR DESCRIPTION
Repairs the SalienceClass schema error found in the Roots audit: Lucy 1994's agent-patient (=∅) class is *root transitivity* ("these roots require two arguments", p. 629 — verified against the paper), not a manner+result feature configuration. Adds `Root.Arity` substrate (Coon 2019's √TV/√ITV, moved from Morphology/RootTypology), reworks the salience conditions and classifier over (signature × arity), removes the reverse-engineered `becomesState` atoms from Yukatek *kuč/p'is/lo'š*, and proves `rootTransitives_respect_mrc` — the claim the old schema falsified.