### PR TITLE
refactor(Morphology/Nanosyntax): Prop-valued spellout predicates

### DIFF
--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -5,37 +5,34 @@ import Linglib.Core.Order.Branching
 # Nanosyntax: Tree-Based Spellout
 [taraldsen-et-al-2018] [caha-2009] [starke-2009]
 
-Extension of rank-based nanosyntax (`Core.lean`) to tree-structured
-spellout. Implements the Superset Principle (SP) for trees:
-a lexical entry M ↔ S' can spell out syntactic target S if S'
-structurally contains S. Among matching entries, the Elsewhere
+Extension of rank-based nanosyntax (`Basic.lean`) to tree-structured
+spellout. Implements the Superset Principle (SP) for trees: a lexical
+entry M ↔ S' can spell out syntactic target S if S' structurally
+contains S (`NanoTree.Contains`). Among matching entries, the Elsewhere
 Condition selects the smallest (by tree size).
 
-The SP on trees is a consequence of [starke-2009]'s Matching
-relation (formalized in [taraldsen-et-al-2018] as (35)):
-M matches S iff there exists a node N in M's stored tree such that
-S and N have the same root label and mutually matching daughters.
-For the right-branching single-daughter trees used in Bantu class
-prefix analysis, structural containment (`NanoTree.contains`) and
-bidirectional Matching coincide. The implementation uses containment
-as the simpler equivalent formulation.
+The SP on trees is a consequence of [starke-2009]'s Matching relation
+(formalized in [taraldsen-et-al-2018] as (35)): M matches S iff there
+exists a node N in M's stored tree such that S and N have the same root
+label and mutually matching daughters. For the right-branching
+single-daughter trees used in Bantu class prefix analysis, structural
+containment and bidirectional Matching coincide; the implementation
+uses containment as the simpler equivalent formulation.
 
-This generalization is needed for [taraldsen-et-al-2018]'s
-analysis of Bantu class prefixes, where lexical entries store
-phrasal trees [# Nx] rather than scalar ranks on a case fseq.
+## Main declarations
 
-## Bridge to rank-based spellout
-
-For right-branching chains (single-daughter trees), tree-based
-spellout reduces to rank-based spellout. A chain of depth n is
-isomorphic to a rank-n `LexEntry` from `Core.lean`.
+- `NanoTree`: feature trees; `NanoTree.Contains`: sub-constituency
+- `TreeLexEntry`: a stored tree paired with an exponent; `TreeLexEntry.Matches`
+- `treeSpellout`: Superset Principle + Elsewhere Condition
+- `FootConditionMet`: [taraldsen-et-al-2018]'s constraint on backtracking
+- `chain_contains_iff_le`: for right-branching chains, tree containment
+  reduces to rank comparison — tree-based spellout generalizes (not
+  replaces) rank-based spellout
 -/
 
 namespace Morphology.Nanosyntax
 
--- ============================================================================
--- §1: NanoTree
--- ============================================================================
+/-! ### NanoTree -/
 
 /-- A nanosyntactic feature tree. Simpler than `Syntax` — no
     traces, no binding, no category/word split. Just labeled nodes
@@ -43,53 +40,51 @@ namespace Morphology.Nanosyntax
 
     `leaf f` = a terminal feature.
     `node f children` = feature f dominating daughters. -/
-inductive NanoTree (F : Type) where
+inductive NanoTree (F : Type*) where
   | leaf : F → NanoTree F
   | node : F → List (NanoTree F) → NanoTree F
   deriving Repr
 
 namespace NanoTree
 
-variable {F : Type}
+variable {F : Type*}
 
--- ============================================================================
--- §2: BEq (transparent, for proof reasoning)
--- ============================================================================
+/-! ### Decidable equality
 
-/-- Structural equality for nanosyntactic trees. Defined manually
-    (not via `deriving BEq`) so that equations are transparent and
-    available for `rfl`/`simp` proofs. -/
-def beq [BEq F] : NanoTree F → NanoTree F → Bool
-  | .leaf f, .leaf g => f == g
-  | .node f cs, .node g ds => f == g && beq.beqList cs ds
-  | _, _ => false
+Defined by structural recursion (not `deriving DecidableEq`, which routes
+the nested `List` through well-founded recursion and does not kernel-reduce;
+`decide`-style spellout evaluations need the structural form). -/
+
+/-- Structural decidable equality on trees. -/
+protected def decEq [DecidableEq F] : (s t : NanoTree F) → Decidable (s = t)
+  | .leaf f, .leaf g =>
+    if h : f = g then .isTrue (h ▸ rfl)
+    else .isFalse fun he => by cases he; exact h rfl
+  | .leaf _, .node _ _ => .isFalse nofun
+  | .node _ _, .leaf _ => .isFalse nofun
+  | .node f cs, .node g ds =>
+    if h : f = g then
+      match NanoTree.decEq.decEqList cs ds with
+      | .isTrue hl => .isTrue (h ▸ hl ▸ rfl)
+      | .isFalse hl => .isFalse fun he => by cases he; exact hl rfl
+    else .isFalse fun he => by cases he; exact h rfl
 where
-  beqList : List (NanoTree F) → List (NanoTree F) → Bool
-    | [], [] => true
-    | a :: as, b :: bs => NanoTree.beq a b && beqList as bs
-    | _, _ => false
+  /-- Structural decidable equality on daughter lists. -/
+  decEqList [DecidableEq F] : (cs ds : List (NanoTree F)) → Decidable (cs = ds)
+    | [], [] => .isTrue rfl
+    | [], _ :: _ => .isFalse nofun
+    | _ :: _, [] => .isFalse nofun
+    | c :: cs, d :: ds =>
+      match NanoTree.decEq c d with
+      | .isTrue h =>
+        match NanoTree.decEq.decEqList cs ds with
+        | .isTrue hl => .isTrue (h ▸ hl ▸ rfl)
+        | .isFalse hl => .isFalse fun he => by cases he; exact hl rfl
+      | .isFalse h => .isFalse fun he => by cases he; exact h rfl
 
-instance [BEq F] : BEq (NanoTree F) := ⟨NanoTree.beq⟩
+instance [DecidableEq F] : DecidableEq (NanoTree F) := NanoTree.decEq
 
-@[simp] theorem beq_leaf_leaf [BEq F] (f g : F) :
-    ((.leaf f : NanoTree F) == .leaf g) = (f == g) := rfl
-@[simp] theorem beq_leaf_node [BEq F] (f g : F) (cs : List (NanoTree F)) :
-    ((.leaf f : NanoTree F) == .node g cs) = false := rfl
-@[simp] theorem beq_node_leaf [BEq F] (f : F) (cs : List (NanoTree F)) (g : F) :
-    ((.node f cs : NanoTree F) == .leaf g) = false := rfl
-@[simp] theorem beq_node_node [BEq F] (f g : F) (cs ds : List (NanoTree F)) :
-    ((.node f cs : NanoTree F) == .node g ds) =
-    (f == g && NanoTree.beq.beqList cs ds) := rfl
-@[simp] theorem beqList_nil [BEq F] :
-    (NanoTree.beq.beqList ([] : List (NanoTree F)) []) = true := rfl
-@[simp] theorem beqList_cons [BEq F] (a b : NanoTree F)
-    (as bs : List (NanoTree F)) :
-    NanoTree.beq.beqList (a :: as) (b :: bs) =
-    (a == b && NanoTree.beq.beqList as bs) := rfl
-
--- ============================================================================
--- §3: Size
--- ============================================================================
+/-! ### Size -/
 
 /-- Number of nodes in the tree. Used by the Elsewhere Condition
     to select the smallest matching entry. -/
@@ -101,33 +96,77 @@ where
     | [] => 0
     | t :: ts => t.size + sizeList ts
 
--- ============================================================================
--- §4: Containment (Superset Principle on trees)
--- ============================================================================
+/-! ### Containment (Superset Principle on trees) -/
 
-/-- Does `self` contain `target` as a sub-constituent?
-    Implements the tree-generalized Superset Principle
-    ([caha-2009] §2.2, [taraldsen-et-al-2018] (36)):
-    entry M matches target S if M's stored tree contains S.
+/-- `Contains self target`: `target` occurs in `self` as a sub-constituent.
+    Implements the tree-generalized Superset Principle ([caha-2009] §2.2,
+    [taraldsen-et-al-2018] (36)): entry M matches target S if M's stored
+    tree contains S.
 
-    For right-branching single-daughter trees (all Bantu class
-    prefix structures), this is equivalent to the bidirectional
-    Matching relation ([taraldsen-et-al-2018] (35)).
+    For right-branching single-daughter trees (all Bantu class prefix
+    structures), this is equivalent to the bidirectional Matching
+    relation ([taraldsen-et-al-2018] (35)).
 
-    For 1D chains: a chain of depth n contains all chains of
-    depth k <= n, matching `LexEntry.matches`. -/
-def contains [BEq F] : NanoTree F → NanoTree F → Bool
-  | .leaf f, target => .leaf f == target
-  | .node f children, target =>
-      .node f children == target || containsList children target
+    For 1D chains: a chain of depth n contains all chains of depth
+    k ≤ n, matching `LexEntry.matches` (`chain_contains_iff_le`). -/
+inductive Contains : NanoTree F → NanoTree F → Prop
+  | refl (t : NanoTree F) : Contains t t
+  | child {f : F} {cs : List (NanoTree F)} {c target : NanoTree F} :
+      c ∈ cs → Contains c target → Contains (.node f cs) target
+
+@[simp] theorem contains_leaf_iff {f : F} {t : NanoTree F} :
+    Contains (.leaf f) t ↔ (.leaf f : NanoTree F) = t :=
+  ⟨fun h => by cases h; rfl, fun h => h ▸ .refl _⟩
+
+theorem contains_node_iff {f : F} {cs : List (NanoTree F)} {t : NanoTree F} :
+    Contains (.node f cs) t ↔
+      (.node f cs : NanoTree F) = t ∨ ∃ c ∈ cs, Contains c t := by
+  constructor
+  · rintro (_ | ⟨hmem, hc⟩)
+    · exact .inl rfl
+    · exact .inr ⟨_, hmem, hc⟩
+  · rintro (h | ⟨c, hmem, hc⟩)
+    · exact h ▸ .refl _
+    · exact .child hmem hc
+
+/-- Structural decision procedure for containment (kernel-reducible). -/
+protected def decContains [DecidableEq F] :
+    (s t : NanoTree F) → Decidable (Contains s t)
+  | .leaf f, t =>
+    if h : (.leaf f : NanoTree F) = t then .isTrue (h ▸ .refl _)
+    else .isFalse fun hc => h (by cases hc; rfl)
+  | .node f cs, t =>
+    if h : (.node f cs : NanoTree F) = t then .isTrue (h ▸ .refl _)
+    else
+      match NanoTree.decContains.decAny cs t with
+      | .isTrue hex => .isTrue (have ⟨_, hmem, hc⟩ := hex; .child hmem hc)
+      | .isFalse hno => .isFalse fun hc => by
+          cases hc with
+          | refl => exact h rfl
+          | child hmem hc => exact hno ⟨_, hmem, hc⟩
 where
-  containsList [BEq F] : List (NanoTree F) → NanoTree F → Bool
-    | [], _ => false
-    | c :: cs, target => c.contains target || containsList cs target
+  /-- Does some member of `cs` contain `t`? -/
+  decAny [DecidableEq F] :
+      (cs : List (NanoTree F)) → (t : NanoTree F) →
+        Decidable (∃ c ∈ cs, Contains c t)
+    | [], _ => .isFalse fun ⟨_, hmem, _⟩ => by cases hmem
+    | c :: cs, t =>
+      match NanoTree.decContains c t with
+      | .isTrue hc => .isTrue ⟨c, List.mem_cons_self .., hc⟩
+      | .isFalse hc =>
+        match NanoTree.decContains.decAny cs t with
+        | .isTrue hex =>
+          .isTrue (have ⟨d, hmem, hd⟩ := hex;
+            ⟨d, List.mem_cons_of_mem _ hmem, hd⟩)
+        | .isFalse hno => .isFalse fun ⟨d, hmem, hd⟩ => by
+            cases hmem with
+            | head => exact hc hd
+            | tail _ hmem => exact hno ⟨d, hmem, hd⟩
 
--- ============================================================================
--- §5: Foot
--- ============================================================================
+instance [DecidableEq F] (s t : NanoTree F) : Decidable (Contains s t) :=
+  NanoTree.decContains s t
+
+/-! ### Foot -/
 
 /-- The foot of a tree: the feature at the bottom of the leftmost
     spine. For right-branching chains [Fn [... [F0]]], the foot
@@ -139,47 +178,48 @@ def foot : NanoTree F → F
 
 end NanoTree
 
--- ============================================================================
--- §6: Tree Lexical Entry
--- ============================================================================
+/-! ### Tree lexical entry -/
 
-/-- A nanosyntactic lexical entry storing a tree rather than a
-    scalar rank. The tree encodes the full feature geometry that
-    the morpheme lexicalizes.
+/-- A nanosyntactic lexical entry storing a tree rather than a scalar
+    rank, paired with an exponent of type `α` (`String` in concrete
+    fragments). The tree encodes the full feature geometry that the
+    morpheme lexicalizes.
 
-    Contrast with `LexEntry` (Core.lean) which stores only a
-    rank (depth on a 1D functional sequence). -/
-structure TreeLexEntry (F : Type) where
+    Contrast with `LexEntry` (`Basic.lean`) which stores only a rank
+    (depth on a 1D functional sequence). -/
+structure TreeLexEntry (F : Type*) (α : Type*) where
   /-- The stored feature tree. -/
   tree : NanoTree F
-  /-- The phonological exponent. -/
-  exponent : String
+  /-- The exponent. -/
+  exponent : α
   /-- Morphological type (suffix or prefix). -/
   morphType : MorphType := .suffix
   deriving Repr
 
-/-- Does a tree-based entry match a target under the Superset
-    Principle? The entry matches if its tree contains the target
-    as a sub-constituent. -/
-def TreeLexEntry.matches {F : Type} [BEq F]
-    (entry : TreeLexEntry F) (target : NanoTree F) : Bool :=
-  entry.tree.contains target
+variable {F : Type*} {α : Type*}
 
--- ============================================================================
--- §7: Tree Spellout (Elsewhere Condition)
--- ============================================================================
+/-- A tree-based entry matches a target under the Superset Principle
+    iff its stored tree contains the target as a sub-constituent. -/
+def TreeLexEntry.Matches (entry : TreeLexEntry F α) (target : NanoTree F) :
+    Prop :=
+  entry.tree.Contains target
+
+instance [DecidableEq F] (entry : TreeLexEntry F α) (target : NanoTree F) :
+    Decidable (entry.Matches target) :=
+  inferInstanceAs (Decidable (NanoTree.Contains _ _))
+
+/-! ### Tree spellout (Elsewhere Condition) -/
 
 /-- Phrasal spellout via the tree-generalized Superset Principle:
     among entries whose tree contains the target, select the one
     with the smallest tree (most specific match).
 
-    Parallels `spellout` from `Core.lean`, but the matching
-    relation is tree containment instead of rank comparison, and
-    the specificity metric is tree size instead of rank. -/
-def treeSpellout {F : Type} [BEq F]
-    (entries : List (TreeLexEntry F)) (target : NanoTree F) :
-    Option String :=
-  let matching := entries.filter (·.matches target)
+    Parallels `spellout` from `Basic.lean`, but the matching relation
+    is tree containment instead of rank comparison, and the
+    specificity metric is tree size instead of rank. -/
+def treeSpellout [DecidableEq F] (entries : List (TreeLexEntry F α))
+    (target : NanoTree F) : Option α :=
+  let matching := entries.filter fun e => decide (e.Matches target)
   (matching.foldl (init := none) fun acc entry =>
     match acc with
     | none => some entry
@@ -188,26 +228,26 @@ def treeSpellout {F : Type} [BEq F]
       else some prev
   ).map (·.exponent)
 
--- ============================================================================
--- §8: Foot Condition
--- ============================================================================
+/-! ### Foot Condition -/
 
-/-- The Foot Condition ([taraldsen-et-al-2018]): the foot
-    of a lexical entry's stored tree must be present as a feature
-    in the syntactic structure being spelled out.
+/-- The Foot Condition ([taraldsen-et-al-2018]): the foot of a lexical
+    entry's stored tree must be present as a feature in the syntactic
+    structure being spelled out.
 
-    If entry M stores [X [...[Z]]], the Foot Condition requires
-    that Z appear in the structure. This constrains backtracking:
-    when spellout fails and the derivation splits the target into
-    specifier + complement, only entries whose foot matches a
-    feature in the remaining structure are eligible. -/
-def footConditionMet {F : Type} [BEq F]
-    (entry : TreeLexEntry F) (syntacticTree : NanoTree F) : Bool :=
-  syntacticTree.contains (.leaf (entry.tree.foot))
+    If entry M stores [X [...[Z]]], the Foot Condition requires that Z
+    appear in the structure. This constrains backtracking: when spellout
+    fails and the derivation splits the target into specifier +
+    complement, only entries whose foot matches a feature in the
+    remaining structure are eligible. -/
+def FootConditionMet (entry : TreeLexEntry F α) (syntacticTree : NanoTree F) :
+    Prop :=
+  syntacticTree.Contains (.leaf entry.tree.foot)
 
--- ============================================================================
--- §9: Chain trees (bridge to 1D)
--- ============================================================================
+instance [DecidableEq F] (entry : TreeLexEntry F α) (tree : NanoTree F) :
+    Decidable (FootConditionMet entry tree) :=
+  inferInstanceAs (Decidable (NanoTree.Contains _ _))
+
+/-! ### Chain trees (bridge to 1D) -/
 
 /-- Build a right-branching chain tree of depth n.
     `chainTree feat 0 = leaf (feat 0)`
@@ -216,16 +256,17 @@ def footConditionMet {F : Type} [BEq F]
 
     A chain of depth n is isomorphic to a rank-n `LexEntry` in
     the 1D nanosyntax. -/
-def chainTree {F : Type} (feat : Nat → F) : Nat → NanoTree F
+def chainTree (feat : Nat → F) : Nat → NanoTree F
   | 0 => .leaf (feat 0)
   | n + 1 => .node (feat (n + 1)) [chainTree feat n]
 
--- ============================================================================
--- §10: Bridge theorems
--- ============================================================================
+/-! ### Bridge theorems -/
+
+theorem chainTree_succ (feat : Nat → F) (n : Nat) :
+    chainTree feat (n + 1) = .node (feat (n + 1)) [chainTree feat n] := rfl
 
 /-- Chain tree size is n + 1 (one node per feature level). -/
-theorem chainTree_size {F : Type} (feat : Nat → F) (n : Nat) :
+theorem chainTree_size (feat : Nat → F) (n : Nat) :
     (chainTree feat n).size = n + 1 := by
   induction n with
   | zero => rfl
@@ -235,89 +276,66 @@ theorem chainTree_size {F : Type} (feat : Nat → F) (n : Nat) :
 
 /-- The foot of a chain tree is always feat 0 — the bottom of
     the functional sequence. -/
-theorem chainTree_foot {F : Type} (feat : Nat → F) (n : Nat) :
+theorem chainTree_foot (feat : Nat → F) (n : Nat) :
     (chainTree feat n).foot = feat 0 := by
   induction n with
   | zero => rfl
   | succ n ih => simp only [chainTree, NanoTree.foot, ih]
 
-/-- `decide p || decide q = decide r` when `p ∨ q ↔ r`. -/
-private theorem decide_or_iff {p q r : Prop} [Decidable p] [Decidable q]
-    [Decidable r] (h : p ∨ q ↔ r) : (decide p || decide q) = decide r := by
-  cases hp : decide p <;> cases hq : decide q <;> simp_all
+/-- Chains of distinct depths are distinct trees, regardless of the
+    feature assignment — depth alone separates them. -/
+theorem chainTree_injective (feat : Nat → F) :
+    Function.Injective (chainTree feat) := fun n m h => by
+  have hs := congrArg NanoTree.size h
+  rwa [chainTree_size, chainTree_size, Nat.add_right_cancel_iff] at hs
 
-/-- BEq of chain trees with injective features equals `decide`
-    on the depth index. -/
-private theorem chainTree_beq_eq_decide {F : Type} [DecidableEq F]
-    (feat : Nat → F) (hInj : Function.Injective feat) (n m : Nat) :
-    (chainTree feat n == chainTree feat m) = decide (n = m) := by
-  induction n generalizing m with
-  | zero =>
-    cases m with
-    | zero => simp [chainTree]
-    | succ m => simp [chainTree]
-  | succ n ih =>
-    cases m with
-    | zero => simp [chainTree]
-    | succ m =>
-      simp only [chainTree, NanoTree.beq_node_node, NanoTree.beqList_cons,
-        NanoTree.beqList_nil, Bool.and_true]
-      rw [ih m]
-      by_cases h : n = m
-      · subst h; simp
-      · have hfne : feat (n + 1) ≠ feat (m + 1) :=
-          fun hfe => (by omega : n + 1 ≠ m + 1) (hInj hfe)
-        have h1 : (feat (n + 1) == feat (m + 1)) = false :=
-          show decide _ = false from decide_eq_false hfne
-        simp [h1, decide_eq_false h]
-
-/-- For right-branching chains with injective features, tree
-    containment reduces to rank comparison: a chain of depth re
-    contains a chain of depth r iff re >= r.
-
-    This is exactly the matching condition of the rank-based
+/-- For right-branching chains, tree containment reduces to rank
+    comparison: a chain of depth re contains a chain of depth r iff
+    r ≤ re. This is exactly the matching condition of the rank-based
     `LexEntry.matches`, establishing that tree-based spellout
-    generalizes (not replaces) rank-based spellout. -/
-theorem chain_contains_iff_ge {F : Type} [DecidableEq F] (feat : Nat → F)
-    (hInj : Function.Injective feat) (re r : Nat) :
-    (chainTree feat re).contains (chainTree feat r) = decide (re ≥ r) := by
+    generalizes (not replaces) rank-based spellout.
+
+    Unlike the previous Bool formulation, no injectivity of `feat` is
+    needed: chain depth alone drives both directions. -/
+theorem chain_contains_iff_le (feat : Nat → F) (re r : Nat) :
+    (chainTree feat re).Contains (chainTree feat r) ↔ r ≤ re := by
   induction re generalizing r with
   | zero =>
+    rw [chainTree, NanoTree.contains_leaf_iff]
     cases r with
-    | zero => simp [chainTree, NanoTree.contains]
-    | succ r => simp [chainTree, NanoTree.contains]
+    | zero => simp [chainTree]
+    | succ r => simp [chainTree]
   | succ n ih =>
-    simp only [chainTree, NanoTree.contains, NanoTree.contains.containsList, Bool.or_false]
-    rw [ih r]
-    rw [show (NanoTree.node (feat (n + 1)) [chainTree feat n] == chainTree feat r)
-        = (chainTree feat (n + 1) == chainTree feat r) from rfl]
-    rw [chainTree_beq_eq_decide feat hInj]
-    exact decide_or_iff (by omega)
+    rw [chainTree_succ, NanoTree.contains_node_iff, ← chainTree_succ,
+      (chainTree_injective feat).eq_iff]
+    simp only [List.mem_singleton, exists_eq_left, ih]
+    omega
 
 end Morphology.Nanosyntax
 
 /-! ### Rose-tree interface instances
 
 `NanoTree` joins the `Core.Order.Branching` tower. The structural
-`size`/`beq`/`contains` above remain the kernel-computable
+`size`/`decEq`/`decContains` above remain the kernel-computable
 specializations ([file-level generality discipline]: WF-derived
-generics do not kernel-reduce, so `rfl`-style spell-out evaluations
+generics do not kernel-reduce, so `decide`-style spell-out evaluations
 need the structural forms). -/
 
 namespace Morphology.Nanosyntax.NanoTree
 
-instance {F : Type} : Core.Order.Branching (NanoTree F) where
+instance {F : Type*} : Core.Order.Branching (NanoTree F) where
   children
     | .leaf _ => []
     | .node _ cs => cs
 
-@[simp] theorem branching_children_leaf {F : Type} (f : F) :
+@[simp] theorem branching_children_leaf {F : Type*} (f : F) :
     Core.Order.Branching.children (NanoTree.leaf f) = [] := rfl
 
-@[simp] theorem branching_children_node {F : Type} (f : F) (cs : List (NanoTree F)) :
+@[simp] theorem branching_children_node {F : Type*} (f : F)
+    (cs : List (NanoTree F)) :
     Core.Order.Branching.children (NanoTree.node f cs) = cs := rfl
 
-instance {F : Type} : Core.Order.IsFiniteBranching (NanoTree F) :=
+instance {F : Type*} : Core.Order.IsFiniteBranching (NanoTree F) :=
   .ofMeasure sizeOf fun {c t} hc => by
     cases t with
     | leaf _ => simp at hc

--- a/Linglib/Studies/TaraldsenEtAl2018.lean
+++ b/Linglib/Studies/TaraldsenEtAl2018.lean
@@ -71,7 +71,7 @@ which is how Shona double plurals like *ma-mi-sha* arise (§4.3). -/
 
 /-- Xhosa singular class-prefix entries: each lexicalizes a bare classifier
     [Nₓ]. See the table in the section docstring for per-entry sources. -/
-def xhosaSg : Xhosa.Gender → TreeLexEntry NCFeature
+def xhosaSg : Xhosa.Gender → TreeLexEntry NCFeature String
   | .genderA => ⟨.leaf (.cls 1), "m", .prefix⟩
   | .genderB => ⟨.leaf (.cls 3), "m", .prefix⟩
   | .genderC => ⟨.leaf (.cls 5), "li", .prefix⟩
@@ -81,7 +81,7 @@ def xhosaSg : Xhosa.Gender → TreeLexEntry NCFeature
 /-- Xhosa plural class-prefix entries: each lexicalizes [# Nₓ]. Genders A, D,
     E share their N with the singular; B and C contain distinct Ns (N₄ ≠ N₃,
     N₆ ≠ N₅) — the §2 conjoined-agreement finding. -/
-def xhosaPl : Xhosa.Gender → TreeLexEntry NCFeature
+def xhosaPl : Xhosa.Gender → TreeLexEntry NCFeature String
   | .genderA => ⟨.node .num [.leaf (.cls 1)], "ba", .prefix⟩
   | .genderB => ⟨.node .num [.leaf (.cls 4)], "mi", .prefix⟩
   | .genderC => ⟨.node .num [.leaf (.cls 6)], "ma", .prefix⟩
@@ -93,7 +93,7 @@ def xhosaGenders : List Xhosa.Gender :=
   [.genderA, .genderB, .genderC, .genderD, .genderE]
 
 /-- The full Xhosa class-prefix lexicon. -/
-def xhosaPrefixes : List (TreeLexEntry NCFeature) :=
+def xhosaPrefixes : List (TreeLexEntry NCFeature String) :=
   xhosaGenders.map xhosaSg ++ xhosaGenders.map xhosaPl
 
 /-! ### The Changana/Rhonga lexicon
@@ -118,7 +118,7 @@ inductive RhongaGender where
   deriving DecidableEq, Repr
 
 /-- Changana/Rhonga singular class-prefix entries ((76), (79a), (80a)). -/
-def rhongaSg : RhongaGender → TreeLexEntry NCFeature
+def rhongaSg : RhongaGender → TreeLexEntry NCFeature String
   | .gA => ⟨.leaf (.cls 1), "mu", .prefix⟩
   | .gB => ⟨.leaf (.cls 3), "mu", .prefix⟩
   | .gC => ⟨.leaf (.cls 5), "rhi", .prefix⟩
@@ -126,7 +126,7 @@ def rhongaSg : RhongaGender → TreeLexEntry NCFeature
   | .gE => ⟨.leaf (.cls 9), "yi", .prefix⟩
 
 /-- Changana/Rhonga plural class-prefix entries ((77), (79b), (80b)). -/
-def rhongaPl : RhongaGender → TreeLexEntry NCFeature
+def rhongaPl : RhongaGender → TreeLexEntry NCFeature String
   | .gA => ⟨.node .num [.leaf (.cls 1)], "va", .prefix⟩
   | .gB => ⟨.node .num [.leaf (.cls 4)], "mi", .prefix⟩
   | .gC => ⟨.node .num [.leaf (.cls 6)], "ma", .prefix⟩
@@ -146,7 +146,7 @@ def rhongaPlN : RhongaGender → Nat
 def rhongaGenders : List RhongaGender := [.gA, .gB, .gC, .gD, .gE]
 
 /-- The full Changana/Rhonga class-prefix lexicon. -/
-def rhongaPrefixes : List (TreeLexEntry NCFeature) :=
+def rhongaPrefixes : List (TreeLexEntry NCFeature String) :=
   rhongaGenders.map rhongaSg ++ rhongaGenders.map rhongaPl
 
 /-! ### Spellout sanity checks -/
@@ -178,7 +178,7 @@ the same N as X's prefix. -/
 
 /-- Whether a singular and a plural prefix entry contain the same classifier
     N — the N at the foot of each stored tree. -/
-def SharesClassifierN (sg pl : TreeLexEntry NCFeature) : Prop :=
+def SharesClassifierN (sg pl : TreeLexEntry NCFeature String) : Prop :=
   sg.tree.foot = pl.tree.foot
 
 instance : DecidableRel SharesClassifierN :=
@@ -213,12 +213,12 @@ theorem xhosa_genderC_not_sharesClassifierN :
 /-- Rhonga *mi* ↔ [# N₄] cannot spell out [# N₃]: its foot N₄ is absent from
     the target (the Foot Condition). -/
 theorem rhonga_mi_foot_not_met :
-    footConditionMet (rhongaPl .gB) (.node .num [.leaf (.cls 3)]) = false := by
+    ¬ FootConditionMet (rhongaPl .gB) (.node .num [.leaf (.cls 3)]) := by
   decide
 
 /-- Rhonga *va* ↔ [# N₁] can spell out [# N₁]: its foot N₁ is present. -/
 theorem rhonga_va_foot_met :
-    footConditionMet (rhongaPl .gA) (.node .num [.leaf (.cls 1)]) = true := by
+    FootConditionMet (rhongaPl .gA) (.node .num [.leaf (.cls 1)]) := by
   decide
 
 /-- No Rhonga entry spells out [# N₃] — the lexicalization failure that
@@ -265,7 +265,7 @@ instance : DecidablePred PluralizationResult.IsStacked
     spellout calculus: the paper attributes prefix–noun pairing to semantic
     compatibility with the silent N or to idiom listing (§5.3, §5.5), so
     `plN` is a parameter here. -/
-def derivePlural (entries : List (TreeLexEntry NCFeature)) (baseN plN : Nat) :
+def derivePlural (entries : List (TreeLexEntry NCFeature String)) (baseN plN : Nat) :
     Option PluralizationResult :=
   match treeSpellout entries (.node .num [.leaf (.cls baseN)]) with
   | some pfx => some (.direct pfx)
@@ -279,7 +279,7 @@ def derivePlural (entries : List (TreeLexEntry NCFeature)) (baseN plN : Nat) :
     with the root directly, so the built structure and the backtrack target
     coincide. Xhosa takes this option in preference to stacking; the Tsonga
     languages cannot. -/
-def derivePluralFirstMerge (entries : List (TreeLexEntry NCFeature))
+def derivePluralFirstMerge (entries : List (TreeLexEntry NCFeature String))
     (plN : Nat) : Option PluralizationResult :=
   derivePlural entries plN plN
 
@@ -329,7 +329,7 @@ theorem xhosa_rhonga_contrast :
 /-! ### Stacking iff distinct Ns -/
 
 private theorem isStacked_iff_spellout_eq_none
-    {entries : List (TreeLexEntry NCFeature)} {baseN plN : Nat}
+    {entries : List (TreeLexEntry NCFeature String)} {baseN plN : Nat}
     {r : PluralizationResult}
     (hr : derivePlural entries baseN plN = some r) :
     r.IsStacked ↔
@@ -353,7 +353,7 @@ private theorem isStacked_iff_spellout_eq_none
     stacks iff the Ns are distinct. Instantiated per gender below with
     `hDirect` discharged by `decide`. -/
 theorem isStacked_iff_not_sharesClassifierN
-    {entries : List (TreeLexEntry NCFeature)} {sg pl : TreeLexEntry NCFeature}
+    {entries : List (TreeLexEntry NCFeature String)} {sg pl : TreeLexEntry NCFeature String}
     {baseN plN : Nat} {r : PluralizationResult}
     (hDirect : treeSpellout entries (.node .num [.leaf (.cls baseN)]) = none ↔
       ¬ SharesClassifierN sg pl)
@@ -366,7 +366,7 @@ theorem isStacked_iff_not_sharesClassifierN
     lexicalize either: stacking is underivable. This is the paper's account
     of why Xhosa never stacks. -/
 theorem not_isStacked_of_firstMerge
-    {entries : List (TreeLexEntry NCFeature)} {plN : Nat}
+    {entries : List (TreeLexEntry NCFeature String)} {plN : Nat}
     {r : PluralizationResult}
     (hr : derivePluralFirstMerge entries plN = some r) : ¬ r.IsStacked := by
   unfold derivePluralFirstMerge derivePlural at hr


### PR DESCRIPTION
Prop-ifies the TreeSpellout predicate triple — `NanoTree.Contains` (inductive), `TreeLexEntry.Matches`, `FootConditionMet` — with structurally-recursive (kernel-reducible) Decidable instances, replacing the custom `beq` + six simp lemmas with a structural `DecidableEq`. Also `Type*` universes and an exponent type parameter on `TreeLexEntry` (`String` at use sites).

- `chain_contains_iff_le` is now an iff and drops the `Function.Injective feat` hypothesis — chain depth alone drives both directions
- sole consumer `Studies/TaraldsenEtAl2018.lean` updated (Foot Condition theorems become Props)