### PR TITLE
refactor(Fragments): carrier enums as {Lang}.Gender.Value

### DIFF
--- a/Linglib/Fragments/Slavic/Russian/Gender.lean
+++ b/Linglib/Fragments/Slavic/Russian/Gender.lean
@@ -187,7 +187,7 @@ theorem declClass_ne_gender :
 
 /-- Russian's three controller genders — the carrier of its
     `Gender.System` ([corbett-1991]; [kramer-2015] ch. 7). -/
-inductive RussianGender where
+inductive Value where
   | masc
   | fem
   | neut
@@ -202,7 +202,7 @@ inductive PastConcord where
   deriving DecidableEq, Repr
 
 /-- Per-gender past-tense concord. -/
-def RussianGender.pastConcord : RussianGender → PastConcord
+def Value.pastConcord : Value → PastConcord
   | .masc => .zero
   | .fem  => .a
   | .neut => .o
@@ -211,7 +211,7 @@ def RussianGender.pastConcord : RussianGender → PastConcord
     labelling; neuter is the morphosyntactic default (plain-*n* roots
     like *vino* surface neuter — [kramer-2015]'s ch. 7 derivation,
     exercised at `Kramer2020.russian_licensing_vino`). -/
-def system : Gender.System RussianGender where
+def system : Gender.System Value where
   label := fun g => match g with
     | .masc => some .masculine
     | .fem  => some .feminine
@@ -219,7 +219,7 @@ def system : Gender.System RussianGender where
   default := .neut
 
 /-- Comparative label → controller gender (ingestion). -/
-def RussianGender.ofLabel : Gender → RussianGender
+def Value.ofLabel : Gender → Value
   | .feminine => .fem
   | .neuter   => .neut
   | _         => .masc
@@ -228,11 +228,11 @@ def RussianGender.ofLabel : Gender → RussianGender
     the hybrid *vrač* this is the morphological masculine; the
     female-referent agreement alternation lives in
     `Studies/Kramer2020.lean` §7. -/
-def RussianNoun.controllerGender (n : RussianNoun) : RussianGender :=
-  RussianGender.ofLabel n.attestedGender
+def RussianNoun.controllerGender (n : RussianNoun) : Value :=
+  Value.ofLabel n.attestedGender
 
 /-- The assigned system: every noun gets its controller gender. -/
-def assigned : Gender.System.Assigned RussianNoun RussianGender :=
+def assigned : Gender.System.Assigned RussianNoun Value :=
   { system with assign := RussianNoun.controllerGender }
 
 /-- The carrier is faithful to the past-tense concord evidence:
@@ -240,7 +240,7 @@ def assigned : Gender.System.Assigned RussianNoun RussianGender :=
     target. [corbett-1991]'s genders-are-agreement-classes criterion,
     discharged via `Gender.Faithful`. -/
 theorem faithful_pastConcord :
-    Gender.Faithful (fun (g : RussianGender) (_ : Unit) => g.pastConcord) := by decide
+    Gender.Faithful (fun (g : Value) (_ : Unit) => g.pastConcord) := by decide
 
 /-- Label ∘ assign recovers the attested gender across the inventory. -/
 theorem system_label_assign :
@@ -254,6 +254,6 @@ theorem system_label_assign :
 theorem assigned_semanticCore :
     assigned.SemanticCore {n | n.isNaturalGender = true}
       (·.attestedGender) := by
-  exact ⟨⟨mat', rfl⟩, fun a b _ _ h => congrArg RussianGender.ofLabel h⟩
+  exact ⟨⟨mat', rfl⟩, fun a b _ _ h => congrArg Value.ofLabel h⟩
 
 end Russian.Gender

--- a/Linglib/Fragments/Spanish/Gender.lean
+++ b/Linglib/Fragments/Spanish/Gender.lean
@@ -163,7 +163,7 @@ def sameRootNouns : List SameRootEntry :=
 
 /-- Spanish's two controller genders — the carrier of its `Gender.System`
     ([corbett-1991]; [kramer-2015]). -/
-inductive SpanishGender where
+inductive Value where
   | masc
   | fem
   deriving DecidableEq, Repr, Fintype
@@ -176,7 +176,7 @@ inductive Concord where
   deriving DecidableEq, Repr
 
 /-- Per-gender adjectival concord. -/
-def SpanishGender.concord : SpanishGender → Concord
+def Value.concord : Value → Concord
   | .masc => .o
   | .fem  => .a
 
@@ -184,23 +184,23 @@ def SpanishGender.concord : SpanishGender → Concord
     labelling; masculine is the morphosyntactic default (plain-*n* roots
     surface masculine — [kramer-2015]'s Set-1 derivation, exercised at
     `Kramer2020.set1_plain_n_masculine`). -/
-def system : Gender.System SpanishGender where
+def system : Gender.System Value where
   label := fun g => match g with
     | .masc => some .masculine
     | .fem  => some .feminine
   default := .masc
 
 /-- Comparative label → controller gender (ingestion). -/
-def SpanishGender.ofLabel : Gender → SpanishGender
+def Value.ofLabel : Gender → Value
   | .feminine => .fem
   | _         => .masc
 
 /-- Controller gender of a noun, from the attested agreement fact. -/
-def SpanishNoun.controllerGender (n : SpanishNoun) : SpanishGender :=
-  SpanishGender.ofLabel n.attestedGender
+def SpanishNoun.controllerGender (n : SpanishNoun) : Value :=
+  Value.ofLabel n.attestedGender
 
 /-- The assigned system: every noun gets its controller gender. -/
-def assigned : Gender.System.Assigned SpanishNoun SpanishGender :=
+def assigned : Gender.System.Assigned SpanishNoun Value :=
   { system with assign := SpanishNoun.controllerGender }
 
 /-- The carrier is faithful to the adjectival concord evidence: *-o* vs
@@ -208,7 +208,7 @@ def assigned : Gender.System.Assigned SpanishNoun SpanishGender :=
     genders-are-agreement-classes criterion, discharged via
     `Gender.Faithful`. -/
 theorem faithful_concord :
-    Gender.Faithful (fun (g : SpanishGender) (_ : Unit) => g.concord) := by decide
+    Gender.Faithful (fun (g : Value) (_ : Unit) => g.concord) := by decide
 
 /-- Label ∘ assign recovers the attested gender across the inventory:
     the system view and the per-noun data agree. -/
@@ -225,6 +225,6 @@ theorem system_label_assign :
 theorem assigned_semanticCore :
     assigned.SemanticCore {n | n.isNaturalGender = true}
       (·.attestedGender) := by
-  exact ⟨⟨mujer, rfl⟩, fun a b _ _ h => congrArg SpanishGender.ofLabel h⟩
+  exact ⟨⟨mujer, rfl⟩, fun a b _ _ h => congrArg Value.ofLabel h⟩
 
 end Spanish.Gender

--- a/Linglib/Studies/Kramer2020.lean
+++ b/Linglib/Studies/Kramer2020.lean
@@ -926,7 +926,7 @@ theorem spanish_surface_genders_consistent :
     controller-gender count the [corbett-1991] study records: the count
     is `Fintype.card` of the carrier, not a stipulation. -/
 theorem spanish_carrier_card :
-    Fintype.card Spanish.Gender.SpanishGender =
+    Fintype.card Spanish.Gender.Value =
       Corbett1991.spanish.rawCount := by decide
 
 /-- For Spanish, the n-inventory has 4 structural heads mapping to 2 surface
@@ -1063,7 +1063,7 @@ theorem russian_surface_genders_consistent :
 /-- The fragment's `Gender.System` carrier has exactly the
     controller-gender count the [corbett-1991] study records. -/
 theorem russian_carrier_card :
-    Fintype.card Russian.Gender.RussianGender =
+    Fintype.card Russian.Gender.Value =
       Corbett1991.russian.rawCount := by decide
 
 /-- Russian has u-features → `semanticAndFormal` assignment, consistent


### PR DESCRIPTION
Renames the `Gender.System` carrier enums from `Spanish.Gender.SpanishGender` / `Russian.Gender.RussianGender` (namespace stutter) to `{Lang}.Gender.Value` — Corbett's own term (gender *values*), matching the Hausa fragment's no-stutter convention. Follow-up to #273 (the rename commit missed its merge).