### PR TITLE
feat(Syntax/ConstructionGrammar): inheritance-mode semantics

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2179,6 +2179,7 @@ import Linglib.Syntax.ConstructionGrammar.Studies.FillmoreKayOConnor1988
 import Linglib.Syntax.ConstructionGrammar.ArgumentStructure
 import Linglib.Syntax.ConstructionGrammar.Slot
 import Linglib.Syntax.ConstructionGrammar.GrammarDist
+import Linglib.Syntax.ConstructionGrammar.Inheritance
 import Linglib.Studies.Dunn2025
 import Linglib.Syntax.ConstructionGrammar.Resultatives
 import Linglib.Studies.GoldbergJackendoff2004

--- a/Linglib/Studies/GoldbergShirtz2025.lean
+++ b/Linglib/Studies/GoldbergShirtz2025.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.ConstructionGrammar.ArgumentStructure
+import Linglib.Syntax.ConstructionGrammar.Inheritance
 import Linglib.Semantics.Presupposition.Basic
 
 /-!
@@ -18,6 +19,8 @@ confirmed conventional subtypes.
 ## Main declarations
 
 - `GoldbergShirtz2025.palConstruction`, `palConstructicon`: the Figure 5 network
+- `GoldbergShirtz2025.nn_adjN_incompatible`, `pal_resolves`, `palSpec_eq`:
+  the paper's two-mothers argument for normal-mode inheritance, derived
 - `GoldbergShirtz2025.palMeaning`: familiarity presupposition + head-noun assertion
 - `GoldbergShirtz2025.pal_irreducible`: PAL is not fully compositional
 - `GoldbergShirtz2025.palExamples`, `crossLinguisticPALs`: attested examples
@@ -158,6 +161,74 @@ def palConstructicon : Constructicon :=
         , mode := .normal
         , sharedProperties := ["lemma-like construal: presumed familiarity"]
         , overriddenProperties := ["head N optional; PAL may serve as head"] } ] }
+
+/-! ### Two mothers force normal-mode inheritance (§6)
+
+The paper's argument for normal-mode over complete inheritance, derived
+with the `CxnSpec` algebra from `ConstructionGrammar.Inheritance`: PAL's
+two mothers conflict — the NN compound construction yields an N⁰ with
+modifier-internal stress, adjectival modification an N′ with head stress —
+so strict unification of the parents is impossible
+(`nn_adjN_incompatible`), and the network is well-formed only because the
+PAL construction's own specification legislates exactly the conflicting
+fields (`pal_resolves`). The rest is genuinely inherited: the prenominal
+modifier slot from both mothers, non-self-embedding from Adj+N
+(`palSpec_eq`). -/
+
+/-- NN compound specification: zero-level output, prenominal modifier,
+compound stress within the modifier. -/
+def nnCompoundSpec : CxnSpec :=
+  { level := some .zero
+  , modPosition := some .prenominal
+  , stress := some .modifier }
+
+/-- Adj+N modification specification: N′ output, prenominal modifier,
+phrasal (head) stress; per §6, "like Adj + N combinations, the PAL N
+construction cannot be recursively embedded within another PAL N
+construction", so Adj+N carries the non-self-embedding value PAL
+inherits. -/
+def adjNSpec : CxnSpec :=
+  { level := some .bar
+  , modPosition := some .prenominal
+  , stress := some .head
+  , selfEmbedding := some .banned }
+
+/-- The PAL construction's own specification: exactly the two fields its
+mothers conflict on, resolved as the paper describes — N′ output (with
+Adj+N, against the compound) and PAL-internal stress (with the compound,
+against Adj+N). -/
+def palOwnSpec : CxnSpec :=
+  { level := some .bar
+  , stress := some .modifier }
+
+/-- PAL's full specification, by normal-mode inheritance from its two
+mothers. -/
+def palSpec : CxnSpec := palOwnSpec.inherit [nnCompoundSpec, adjNSpec]
+
+/-- The two mothers conflict (bar level and stress), so complete-mode
+inheritance cannot relate PAL to both parents — the formal content of §6's
+observation that complete inheritance "is unsuitable whenever a node is
+allowed more than a single mother, since specifications in two mother
+nodes may conflict with one another". -/
+theorem nn_adjN_incompatible :
+    ¬ CxnSpec.IsCompatible nnCompoundSpec adjNSpec := by decide
+
+/-- The Figure 5 network is normal-mode well-formed: PAL's own
+specification legislates every field its mothers conflict on. Delete
+either field of `palOwnSpec` and this fails. -/
+theorem pal_resolves :
+    CxnSpec.Resolves palOwnSpec [nnCompoundSpec, adjNSpec] := by decide
+
+/-- The derived PAL specification, computed rather than stipulated: the
+prenominal slot is inherited from both mothers (they agree),
+non-self-embedding is inherited from Adj+N alone, and N′-hood and
+PAL-internal stress come from PAL's own conflict resolutions. -/
+theorem palSpec_eq :
+    palSpec =
+      { level := some .bar
+      , modPosition := some .prenominal
+      , stress := some .modifier
+      , selfEmbedding := some .banned } := by decide
 
 /-! ### Lemma-like meaning -/
 

--- a/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
@@ -1,0 +1,224 @@
+import Mathlib.Data.List.Dedup
+
+/-!
+# Construction Grammar: Inheritance Modes
+
+Computational content for the two modes of constructional inheritance
+distinguished by [goldberg-1995] §3.3.1 (the `InheritanceMode` enum in
+`ConstructionGrammar.Basic`), following [diessel-2023]'s Table 2: in the
+**complete mode**, "high- and low-level representations are fully
+compatible with each other" — the unification-based regime [kay-fillmore-1999]
+built their formal CxG on and [sag-2012]'s SBCG inherits from HPSG — while
+in the **default mode** "low-level representations override high-level
+representations if there is a conflict", with formal semantics in the
+default-unification tradition ([lascarides-copestake-1999]). Complete mode
+is defined exactly on `IsCompatible` inputs; default mode (`inheritField`)
+lets the child win, and under **multiple inheritance** (a child with two or
+more schematic parents, [diessel-2023] §2.2.2) leaves a field unspecified
+when the parents conflict and the child does not legislate
+(`ResolvesField`).
+
+[diessel-2023]'s other axis — impoverished vs. full *entry model*, i.e.
+whether shared information is stored once or redundantly at every level —
+is a storage claim orthogonal to the inheritance algebra and is not
+formalized here.
+
+## Main declarations
+
+- `IsCompatible`: two partial field values can strictly unify
+- `HasConflict`, `inheritField`, `ResolvesField`: normal-mode field semantics
+- `CxnSpec`: a partial constructional specification (bar level, modifier position, stress locus, self-embedding)
+- `CxnSpec.inherit`, `CxnSpec.IsCompatible`, `CxnSpec.Resolves`: componentwise lifts
+- `inheritField_of_isCompatible`: the two modes agree absent conflict
+-/
+
+namespace ConstructionGrammar
+
+/-! ### Field algebra
+
+A specification field is an `Option`-valued partial value: `none` is
+"unspecified", and inheritance fills unspecified fields from parents. -/
+
+section FieldAlgebra
+
+variable {α : Type*} [DecidableEq α]
+
+/-- Two partial field values are compatible — able to strictly unify: at
+most one is defined, or both agree. Complete-mode inheritance
+([diessel-2023] Table 2: representations "fully compatible with each
+other") is defined exactly on compatible values. -/
+def IsCompatible (p q : Option α) : Prop :=
+  p = none ∨ q = none ∨ p = q
+
+instance (p q : Option α) : Decidable (IsCompatible p q) :=
+  inferInstanceAs (Decidable (_ ∨ _ ∨ _))
+
+/-- The distinct values a family of parents determines for a field. -/
+def determinedValues (parents : List (Option α)) : List α :=
+  (parents.filterMap id).dedup
+
+/-- A parent family conflicts on a field when it determines two or more
+distinct values. -/
+def HasConflict (parents : List (Option α)) : Prop :=
+  1 < (determinedValues parents).length
+
+instance (parents : List (Option α)) : Decidable (HasConflict parents) :=
+  inferInstanceAs (Decidable (_ < _))
+
+/-- Normal-mode (default) inheritance for one field ([goldberg-1995]
+§3.3.1; [diessel-2023] Table 2: "low-level representations override
+high-level representations if there is a conflict";
+[lascarides-copestake-1999]): the inheriting construction's own value wins;
+an unspecified field takes the unique value its parents agree on; a
+parental conflict the child does not legislate leaves the field
+unspecified. -/
+def inheritField (own : Option α) (parents : List (Option α)) : Option α :=
+  match own, determinedValues parents with
+  | some x, _ => some x
+  | none, [x] => some x
+  | none, _ => none
+
+/-- The child legislates wherever its parents conflict — [goldberg-1995]'s
+normal mode: "conflicts are addressed by the inheriting construction, which
+specifies its own constraints". -/
+def ResolvesField (own : Option α) (parents : List (Option α)) : Prop :=
+  HasConflict parents → own ≠ none
+
+instance (own : Option α) (parents : List (Option α)) :
+    Decidable (ResolvesField own parents) := by
+  unfold ResolvesField; infer_instance
+
+@[simp]
+theorem inheritField_some (x : α) (parents : List (Option α)) :
+    inheritField (some x) parents = some x := rfl
+
+@[simp]
+theorem inheritField_nil (own : Option α) : inheritField own [] = own := by
+  cases own <;> rfl
+
+/-- Absent conflict, normal-mode inheritance agrees with strict
+(complete-mode) unification: with compatible parents the inherited value is
+the priority union of child and parents. Normal mode departs from complete
+inheritance only at genuine conflicts. -/
+theorem inheritField_of_isCompatible (own : Option α) {p q : Option α}
+    (h : IsCompatible p q) :
+    inheritField own [p, q] = (own.or p).or q := by
+  rcases h with h | h | h
+  · subst h; cases own <;> cases q <;> rfl
+  · subst h; cases own <;> cases p <;> rfl
+  · subst h
+    cases own <;> cases p <;>
+      simp [inheritField, determinedValues, List.dedup_cons_of_mem,
+        List.dedup_cons_of_notMem]
+
+/-- Compatible parents impose no resolution burden on the child. -/
+theorem resolvesField_of_isCompatible (own : Option α) {p q : Option α}
+    (h : IsCompatible p q) : ResolvesField own [p, q] := by
+  intro hc
+  rcases h with h | h | h <;> subst h <;>
+    first
+      | (cases q <;>
+          simp [HasConflict, determinedValues, List.dedup_cons_of_notMem] at hc)
+      | (cases p <;>
+          simp [HasConflict, determinedValues, List.dedup_cons_of_notMem] at hc)
+
+end FieldAlgebra
+
+/-! ### Constructional specification vocabulary
+
+Typed values for the inheritable form-side properties at issue in
+nominal-modification networks ([goldberg-1995] §3.3;
+[goldberg-shirtz-2025] §6). -/
+
+/-- X-bar level of a construction's output category. -/
+inductive BarLevel where
+  | zero    -- X⁰
+  | bar     -- X′
+  | phrase  -- XP
+  deriving DecidableEq, Repr
+
+/-- Locus of primary stress in a modification construction: compound
+stress falls within the modifier (*BLACKbird*), phrasal modification
+stresses the head (*black BIRD*). -/
+inductive StressLocus where
+  | modifier
+  | head
+  deriving DecidableEq, Repr
+
+/-- Position of the modifier slot relative to the head. -/
+inductive ModPosition where
+  | prenominal
+  | postnominal
+  deriving DecidableEq, Repr
+
+/-- Whether a construction's output can recur inside the construction's own
+open slot. -/
+inductive SelfEmbedding where
+  | allowed
+  | banned
+  deriving DecidableEq, Repr
+
+/-- A partial constructional specification: the inheritable form-side
+properties of a (nominal-modification) construction. `none` means the
+construction does not legislate the field; inheritance fills unspecified
+fields from parents. -/
+structure CxnSpec where
+  /-- X-bar level of the construction's output -/
+  level : Option BarLevel := none
+  /-- Position of the modifier slot -/
+  modPosition : Option ModPosition := none
+  /-- Locus of primary stress -/
+  stress : Option StressLocus := none
+  /-- Whether the construction self-embeds -/
+  selfEmbedding : Option SelfEmbedding := none
+  deriving DecidableEq, Repr
+
+namespace CxnSpec
+
+/-- Componentwise compatibility: complete-mode inheritance
+([goldberg-1995]'s complete mode; the regime of [sag-2012]'s type
+hierarchy) is defined exactly on compatible specifications. -/
+def IsCompatible (p q : CxnSpec) : Prop :=
+  ConstructionGrammar.IsCompatible p.level q.level ∧
+  ConstructionGrammar.IsCompatible p.modPosition q.modPosition ∧
+  ConstructionGrammar.IsCompatible p.stress q.stress ∧
+  ConstructionGrammar.IsCompatible p.selfEmbedding q.selfEmbedding
+
+instance (p q : CxnSpec) : Decidable (IsCompatible p q) :=
+  inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ _))
+
+/-- Normal-mode inheritance from a family of parent specifications,
+componentwise. -/
+def inherit (own : CxnSpec) (parents : List CxnSpec) : CxnSpec :=
+  { level := inheritField own.level (parents.map (·.level))
+  , modPosition := inheritField own.modPosition (parents.map (·.modPosition))
+  , stress := inheritField own.stress (parents.map (·.stress))
+  , selfEmbedding := inheritField own.selfEmbedding (parents.map (·.selfEmbedding)) }
+
+/-- The child's own specification legislates every field its parents
+conflict on — well-formedness of a normal-mode multi-mother node. -/
+def Resolves (own : CxnSpec) (parents : List CxnSpec) : Prop :=
+  ResolvesField own.level (parents.map (·.level)) ∧
+  ResolvesField own.modPosition (parents.map (·.modPosition)) ∧
+  ResolvesField own.stress (parents.map (·.stress)) ∧
+  ResolvesField own.selfEmbedding (parents.map (·.selfEmbedding))
+
+instance (own : CxnSpec) (parents : List CxnSpec) :
+    Decidable (Resolves own parents) :=
+  inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ _))
+
+@[simp]
+theorem inherit_nil (own : CxnSpec) : own.inherit [] = own := by
+  simp [inherit]
+
+/-- Compatible parents impose no resolution burden: any child — including
+one with no constraints of its own — is well-formed below them. Normal
+mode only demands child-side legislation at genuine conflicts. -/
+theorem resolves_of_isCompatible (own : CxnSpec) {p q : CxnSpec}
+    (h : IsCompatible p q) : Resolves own [p, q] :=
+  ⟨resolvesField_of_isCompatible _ h.1, resolvesField_of_isCompatible _ h.2.1,
+   resolvesField_of_isCompatible _ h.2.2.1, resolvesField_of_isCompatible _ h.2.2.2⟩
+
+end CxnSpec
+
+end ConstructionGrammar

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -9973,10 +9973,22 @@
   title     = {Tense in English: Its Structure and Use in Discourse},
   publisher = {Routledge},
   address   = {London},
+  isbn      = {0415061512},
   subfield  = {semantics/tense},
   role      = {cited},
   validated = {true},
-  sources   = {Phenomena/TenseAspect/Data.lean;Semantics/Tense/TOChain.lean}
+  sources   = {Studies/Declerck1991.lean;Semantics/Tense/System.lean}
+}% REF: Declerck, R. (1991). *A Comprehensive Descriptive Grammar of English*. Kaitakusha.
+@book{declerck-1991-grammar,
+  author    = {Declerck, Renaat},
+  year      = {1991},
+  title     = {A Comprehensive Descriptive Grammar of English},
+  publisher = {Kaitakusha},
+  address   = {Tokyo},
+  subfield  = {semantics/tense},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/Declerck1991.lean;Data/Examples/Declerck1991.json}
 }% REF: Pustejovsky, J. (1991). The syntax of event structure.
 @book{bybee-perkins-pagliuca-1994,
   author    = {Bybee, Joan and Perkins, Revere and Pagliuca, William},
@@ -10080,7 +10092,7 @@
   subfield  = {semantics/tense},
   role      = {cited},
   validated = {true},
-  sources   = {Phenomena/TenseAspect/Data.lean;Semantics/Tense/TOChain.lean}
+  sources   = {Semantics/Tense/Orientation.lean;Semantics/Tense/Domain.lean}
 }% REF: Beavers, John. (2010). The structure of lexical meaning: Why semantics really matters. Language 86(4), 821-864.
 @misc{beavers-2023-sag-lectures,
   author    = {Beavers, John},
@@ -17229,6 +17241,48 @@
   validated = {true},
   role      = {cited},
   sources   = {Studies/GoldbergShirtz2025.lean}
+}
+@article{lascarides-copestake-1999,
+  author    = {Lascarides, Alex and Copestake, Ann},
+  year      = {1999},
+  title     = {Default Representation in Constraint-Based Frameworks},
+  journal   = {Computational Linguistics},
+  volume    = {25},
+  number    = {1},
+  pages     = {55--105},
+  url       = {https://aclanthology.org/J99-1002/},
+  subfield  = {syntax},
+  validated = {true},
+  role      = {cited},
+  sources   = {Syntax/ConstructionGrammar/Inheritance.lean}
+}
+@book{diessel-2023,
+  author    = {Diessel, Holger},
+  year      = {2023},
+  title     = {The Constructicon: Taxonomies and Networks},
+  series    = {Elements in Construction Grammar},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  doi       = {10.1017/9781009327848},
+  subfield  = {syntax},
+  validated = {true},
+  role      = {cited},
+  sources   = {Syntax/ConstructionGrammar/Inheritance.lean}
+}
+@incollection{sag-2012,
+  author    = {Sag, Ivan A.},
+  year      = {2012},
+  title     = {Sign-Based Construction Grammar: An Informal Synopsis},
+  booktitle = {Sign-Based Construction Grammar},
+  editor    = {Boas, Hans C. and Sag, Ivan A.},
+  publisher = {CSLI Publications},
+  address   = {Stanford, CA},
+  pages     = {69--202},
+  url       = {http://web.stanford.edu/group/cslipublications/cslipublications/pdf/BoasSag-sag-chapter.pdf},
+  subfield  = {syntax},
+  validated = {true},
+  role      = {cited},
+  sources   = {Syntax/ConstructionGrammar/Inheritance.lean}
 }% ══════════════════════════════════════════════════════════════════════════════
 @article{burnett-2019,
   author    = {Burnett, Heather},


### PR DESCRIPTION
Gives Goldberg's normal-vs-complete inheritance modes computational content over partial constructional specifications (`CxnSpec`, field algebra per Diessel 2023 Table 2 / Lascarides & Copestake 1999), and derives Goldberg & Shirtz's §6 argument: PAL's two mothers strictly conflict (`nn_adjN_incompatible`), the network is well-formed only via child-side resolution (`pal_resolves`), and PAL's full spec is computed, not stipulated (`palSpec_eq`).

Depends on #276 (builds on the consolidated Studies/GoldbergShirtz2025.lean).