### PR TITLE
refactor(Semantics/Tense): prune dead code, fix cites, add Decidable

### DIFF
--- a/Linglib/Core/Order/Relation.lean
+++ b/Linglib/Core/Order/Relation.lean
@@ -7,8 +7,9 @@ The point analogue of `AllenRelation` (which operates on intervals).
 A `Relation` is a domain-flavored selector over the standard partition
 of pairs of times: before, after, overlapping, ≤, ≥, unrestricted.
 
-Used by tense (past/present/future via `Semantics.Tense.GramTense.toRelation`),
-evidential semantics (`EPCondition.toRelation`), and modal-base time
+Used by tense (`Semantics.Tense.GramTense.constrains` realizes the
+before/overlapping/after/notBefore cells), evidential semantics
+(`EPCondition.toRelation`), and modal-base time
 analyses (`MBTProfile.toRelation` in Huijsmans 2025) — each domain
 provides a name for one shape from the same partition.
 -/

--- a/Linglib/Features/Aktionsart.lean
+++ b/Linglib/Features/Aktionsart.lean
@@ -30,7 +30,7 @@ Sibling formalizations of competitor lexical-aspect frameworks:
 [bach-1986]; the event-token sort is this `Dynamicity` feature (`Event.sort`);
 [krifka-1989]/[krifka-1998] CUM/QUA/DIV in
 `Semantics/Events/CEM.lean`; [dowty-1979] SIP in
-`Semantics/Tense/Aspect/SubintervalProperty.lean`;
+`Semantics/Aspect/SubintervalProperty.lean`;
 [filip-2012] three-way refutation of binary telicity in
 `Studies/Filip2012.lean`.
 -/

--- a/Linglib/Fragments/English/TemporalExpressions.lean
+++ b/Linglib/Fragments/English/TemporalExpressions.lean
@@ -499,7 +499,7 @@ inductive DurationKind where
     `Determiners.lean`).
 
     Cross-references for *in years* (the NPI-gap entry):
-    - `Semantics/Tense/PTS.lean :: inYears` — Iatridou-Zeijlstra
+    - `Studies/IatridouZeijlstra2021.lean :: inYears` — Iatridou-Zeijlstra
       2021 boundary-adverbial projection (PTS-tradition apparatus).
     - `Fragments/English/PolarityItems.lean :: inYears` — polarity-theoretic
       projection (Israel 1996 / 2001 scalar model).

--- a/Linglib/Semantics/Aspect/AtomDist.lean
+++ b/Linglib/Semantics/Aspect/AtomDist.lean
@@ -15,7 +15,7 @@ Per the strata-theory unification ([champollion-2017]), this is
 the quantifier-level form of stratified reference at point-interval
 granularity along the time dimension — a sibling of the Bennett-Partee
 1972 strict subinterval property (`HasSubintervalProp` in
-`Semantics/Tense/Aspect/SubintervalProperty.lean`). The
+`Semantics/Aspect/SubintervalProperty.lean`). The
 bridge `EvQuant.ofPred` below lifts an event predicate to an event
 quantifier; the witness-universal and quantifier-restriction
 formulations live at the same parameter-space point but differ in

--- a/Linglib/Semantics/Attitudes/SituationDependent.lean
+++ b/Linglib/Semantics/Attitudes/SituationDependent.lean
@@ -283,7 +283,8 @@ For example, an attitude verb might impose:
 These constraints are what make sequence-of-tense work: they tie the
 embedded clause's temporal interpretation to the matrix event time.
 
-See `Semantics.Tense.SequenceOfTense` for the formal
+See `Semantics.Tense.Basic` (embedded frames) and
+`Semantics.Tense.SOT.Decomposition` for the formal
 connection between these temporal constraints and SOT readings.
 -/
 

--- a/Linglib/Semantics/Mood/Basic.lean
+++ b/Linglib/Semantics/Mood/Basic.lean
@@ -346,7 +346,7 @@ of the embedded clause from the default (speech time or matrix time) to a
 newly introduced temporal anchor.
 
 See `Semantics.Attitudes.SituationDependent` for the attitude side
-and `Semantics.Tense.SequenceOfTense` for the formal connection.
+and `Semantics.Tense.SOT.Decomposition` for the formal connection.
 -/
 
 section AttitudeTemporalAnchor

--- a/Linglib/Semantics/Tense/Basic.lean
+++ b/Linglib/Semantics/Tense/Basic.lean
@@ -3,119 +3,28 @@ import Linglib.Semantics.Tense.Reichenbach
 
 /-!
 # Tense Theory Infrastructure: Shared Types
-[abusch-1997] [deal-2020] [heim-kratzer-1998] [klecha-2016] [kratzer-1998] [ogihara-1996] [sharvit-2003] [von-stechow-2009] [wurmbrand-2014] [zeijlstra-2012] [banfield-1982] [comrie-1985] [egressy-2026] [ogihara-sharvit-2012] [schlenker-2003]
+[abusch-1997] [heim-1994-comments] [ogihara-1989] [partee-1973]
 
-Shared types and infrastructure for the tense theories formalized in
-`Semantics.Intensional/Tense/` and
-`Minimalism/Tense/`.
+Shared embedding infrastructure for the tense theories: embedded
+Reichenbach frames, the shifted/simultaneous reading split, the upper
+limit constraint, and the projections connecting `TensePronoun` to the
+SOT frame constructors.
 
-## Design Principle
+## Main declarations
 
-Verdicts are **derived from compositional semantics**, not stipulated.
-Each theory file proves derivation theorems for the phenomena it handles;
-the comparison matrix (`Comparisons/TenseTheories.lean`) is assembled
-from what's been proven. There is no `TheoryVerdict` enum — whether a
-theory "handles" a phenomenon is witnessed by the existence (or absence)
-of a derivation theorem in that theory's file.
-
-## Key Types
-
-- `TensePhenomenon`: the 23 temporal phenomena that distinguish theories
+- `embeddedFrame`: the frame of a clause embedded under an attitude verb
+  (P' = matrix E); `simultaneousFrame` and `shiftedFrame` specialize it
+- `EmbeddedTenseReading`, `availableReadings`: the SOT-parameterized
+  shifted/simultaneous split
+- `upperLimitConstraint`: [abusch-1997]'s ULC, presuppositional construal
 - `AttitudeTemporalSemantics`: how an attitude verb shifts eval time
-
 -/
 
 namespace Semantics.Tense
 
-open Semantics.Tense
 open Semantics.Tense.Reichenbach
 
-
--- ════════════════════════════════════════════════════════════════
--- § TensePhenomenon
--- ════════════════════════════════════════════════════════════════
-
-/-- The 24 temporal phenomena that distinguish tense theories.
-
-    Each phenomenon represents an empirical domain where theories
-    make different predictions or use different mechanisms. The
-    comparison matrix is built from which derivation theorems each
-    theory proves for each phenomenon.
-
-    The first 11 are the core comparison set. The next 7 are eventual
-    targets documented with data frames. The final 6 are added for
-    [zeijlstra-2012], [wurmbrand-2014], [sharvit-2003], and
-    [tsilia-zhao-2026] coverage. -/
-inductive TensePhenomenon where
-  -- Core comparison set (11)
-  /-- "John said Mary was sick" — shifted reading (sick before saying) -/
-  | pastUnderPast_shifted
-  /-- "John said Mary was sick" — simultaneous reading (sick at saying) -/
-  | pastUnderPast_simultaneous
-  /-- "John said Mary is sick" — double-access reading -/
-  | presentUnderPast_doubleAccess
-  /-- "John said Mary would leave" — embedded future -/
-  | futureUnderPast
-  /-- English (SOT) vs Japanese (non-SOT) parametric variation -/
-  | sotVsNonSOT
-  /-- Abusch's upper limit constraint: no forward-shifted readings -/
-  | upperLimitConstraint
-  /-- "the man who was tall" — relative clause tense interpretation -/
-  | relativeClauseTense
-  /-- "John might have left" — modal scoping over past -/
-  | modalTenseInteraction
-  /-- "If John were here..." — past morphology, non-temporal -/
-  | counterfactualTense
-  /-- "John believed it was raining" — de re temporal reference -/
-  | temporalDeRe
-  /-- Kratzer (deletion) vs Ogihara (zero tense ambiguity) debate -/
-  | deletionVsAmbiguity
-  -- Eventual targets (7)
-  /-- "John asked who was sick" — SOT in indirect questions -/
-  | sotInIndirectQuestions
-  /-- "She walked to the window. The garden was beautiful." — FID
-      perspective shift without attitude verb -/
-  | freeIndirectDiscourse
-  /-- "Napoleon enters the room. He sees..." — present tense, past reference -/
-  | historicalPresent
-  /-- "John said Mary had been sick" — pluperfect disambiguates to shifted only -/
-  | perfectTenseInteraction
-  /-- "John wanted/planned to leave" — future-oriented complements
-      without standard SOT -/
-  | futureOrientedComplements
-  /-- "Before John left, Mary was happy" — tense in temporal adjuncts -/
-  | adjunctClauseTense
-  /-- Amharic/Zazaki: tense shifts under attitudes paralleling pronoun shift -/
-  | indexicalTenseShift
-  -- Additional phenomena (5) — Sharvit, Zeijlstra, Wurmbrand coverage
-  /-- "John will say Mary is sick" — present under future, simultaneous
-      with future saying time -/
-  | embeddedPresentPuzzle
-  /-- "Aristotle was a philosopher" — past tense ↔ subject no longer
-      exists implication ([musan-1995]/1997) -/
-  | lifetimeEffects
-  /-- "If John were taller..." — past morphology, non-past semantics
-      ([iatridou-2000], beyond Deal's counterfactual tense) -/
-  | fakePast
-  /-- Hebrew-type optional SOT: "John said Mary {was/is} sick" —
-      both possible with different readings -/
-  | optionalSOT
-  /-- [wurmbrand-2014]: three-way classification of infinitival tense
-      (future irrealis / propositional / restructuring) -/
-  | dependentVsIndependentTense
-  /-- Temporal "then" is incompatible with shifted present but compatible
-      with deleted tense — derived from tense presuppositions anchored to π -/
-  | thenPresentIncompatibility
-  /-- Hungarian-type size-sensitive SOT: simultaneous reading available in
-      TP complements but blocked in CP complements. Clause size determines
-      whether [uPAST] can Agree upward across the complement boundary -/
-  | sizeSensitiveSOT
-  deriving DecidableEq, Repr, Inhabited
-
-
--- ════════════════════════════════════════════════════════════════
--- § AttitudeTemporalSemantics
--- ════════════════════════════════════════════════════════════════
+/-! ### AttitudeTemporalSemantics -/
 
 /-- How an attitude verb shifts the evaluation time for its complement.
 
@@ -137,79 +46,8 @@ def standardShift {Time : Type*} : AttitudeTemporalSemantics Time where
   shiftEvalTime := λ f => f.eventTime
   embeddedConstraint := λ _embR _evalT => True
 
-/-- Standard shift gives matrix event time. -/
-theorem standardShift_is_eventTime {Time : Type*} (f : ReichenbachFrame Time) :
-    (standardShift (Time := Time)).shiftEvalTime f = f.eventTime := rfl
 
-
--- ════════════════════════════════════════════════════════════════
--- § Phenomenon Classification
--- ════════════════════════════════════════════════════════════════
-
-/-- A phenomenon is a core SOT phenomenon if all theories handle it. -/
-def TensePhenomenon.IsCoreSOT : TensePhenomenon → Prop
-  | .pastUnderPast_shifted => True
-  | .pastUnderPast_simultaneous => True
-  | .presentUnderPast_doubleAccess => True
-  | .sotVsNonSOT => True
-  | _ => False
-
-instance : DecidablePred TensePhenomenon.IsCoreSOT := fun p => by
-  cases p <;> unfold TensePhenomenon.IsCoreSOT <;> infer_instance
-
-/-- A phenomenon is a distinguishing phenomenon if theories diverge on it. -/
-def TensePhenomenon.IsDistinguishing : TensePhenomenon → Prop
-  | .relativeClauseTense => True
-  | .modalTenseInteraction => True
-  | .counterfactualTense => True
-  | .temporalDeRe => True
-  | .deletionVsAmbiguity => True
-  | _ => False
-
-instance : DecidablePred TensePhenomenon.IsDistinguishing := fun p => by
-  cases p <;> unfold TensePhenomenon.IsDistinguishing <;> infer_instance
-
-/-- A phenomenon is an eventual target — documented with data but not yet
-    connected to derivation theorems in the theory files. -/
-def TensePhenomenon.IsEventualTarget : TensePhenomenon → Prop
-  | .sotInIndirectQuestions => True
-  | .freeIndirectDiscourse => True
-  | .historicalPresent => True
-  | .perfectTenseInteraction => True
-  | .futureOrientedComplements => True
-  | .adjunctClauseTense => True
-  | .indexicalTenseShift => True
-  | _ => False
-
-instance : DecidablePred TensePhenomenon.IsEventualTarget := fun p => by
-  cases p <;> unfold TensePhenomenon.IsEventualTarget <;> infer_instance
-
-/-- A phenomenon is in the extended set added for Zeijlstra/Wurmbrand/Sharvit. -/
-def TensePhenomenon.IsExtended : TensePhenomenon → Prop
-  | .embeddedPresentPuzzle => True
-  | .lifetimeEffects => True
-  | .fakePast => True
-  | .optionalSOT => True
-  | .dependentVsIndependentTense => True
-  | .thenPresentIncompatibility => True
-  | .sizeSensitiveSOT => True
-  | _ => False
-
-instance : DecidablePred TensePhenomenon.IsExtended := fun p => by
-  cases p <;> unfold TensePhenomenon.IsExtended <;> infer_instance
-
-/-- Every phenomenon falls into exactly one of the five categories. -/
-theorem phenomenon_coverage (p : TensePhenomenon) :
-    p.IsCoreSOT ∨ p.IsDistinguishing ∨
-    p.IsEventualTarget ∨ p.IsExtended ∨
-    p = .futureUnderPast ∨ p = .upperLimitConstraint := by
-  cases p <;> simp [TensePhenomenon.IsCoreSOT, TensePhenomenon.IsDistinguishing,
-    TensePhenomenon.IsEventualTarget, TensePhenomenon.IsExtended]
-
-
--- ════════════════════════════════════════════════════════════════
--- § Embedded Frames
--- ════════════════════════════════════════════════════════════════
+/-! ### Embedded Frames -/
 
 /-- Construct the Reichenbach frame for an embedded clause under an attitude verb.
 
@@ -227,9 +65,7 @@ def embeddedFrame {Time : Type*} (matrixFrame : ReichenbachFrame Time)
   eventTime := embeddedE
 
 
--- ════════════════════════════════════════════════════════════════
--- § Embedded Tense Readings
--- ════════════════════════════════════════════════════════════════
+/-! ### Embedded Tense Readings -/
 
 /-- The two available readings for embedded past under past.
 
@@ -254,38 +90,31 @@ def availableReadings (param : SOTParameter) : List EmbeddedTenseReading :=
   | .absolute => [.shifted]
 
 
--- ════════════════════════════════════════════════════════════════
--- § Reading-Specific Frames
--- ════════════════════════════════════════════════════════════════
+/-! ### Reading-Specific Frames -/
 
 /-- The simultaneous reading: embedded R = matrix E.
 
     "John said Mary was sick" (she was sick AT THE TIME of saying).
     The embedded reference time equals the matrix event time,
-    so embedded tense = PRESENT relative to embedded P. -/
+    so embedded tense = PRESENT relative to embedded P.
+    `embeddedFrame` with R' = E_matrix. -/
 def simultaneousFrame {Time : Type*} (matrixFrame : ReichenbachFrame Time)
-    (embeddedE : Time) : ReichenbachFrame Time where
-  speechTime := matrixFrame.speechTime
-  perspectiveTime := matrixFrame.eventTime
-  referenceTime := matrixFrame.eventTime  -- R' = P' = E_matrix
-  eventTime := embeddedE
+    (embeddedE : Time) : ReichenbachFrame Time :=
+  embeddedFrame matrixFrame matrixFrame.eventTime embeddedE
 
 /-- The shifted reading: embedded R < matrix E.
 
     "John said Mary had been sick" (she was sick BEFORE the saying).
     The embedded reference time precedes the matrix event time,
-    so embedded tense = PAST relative to embedded P. -/
+    so embedded tense = PAST relative to embedded P.
+    Definitionally `embeddedFrame`; the inequality R' < E_matrix is a
+    hypothesis at use sites, not enforced by the constructor. -/
 def shiftedFrame {Time : Type*} (matrixFrame : ReichenbachFrame Time)
-    (embeddedR embeddedE : Time) : ReichenbachFrame Time where
-  speechTime := matrixFrame.speechTime
-  perspectiveTime := matrixFrame.eventTime
-  referenceTime := embeddedR  -- R' < P' = E_matrix for shifted
-  eventTime := embeddedE
+    (embeddedR embeddedE : Time) : ReichenbachFrame Time :=
+  embeddedFrame matrixFrame embeddedR embeddedE
 
 
--- ════════════════════════════════════════════════════════════════
--- § Perspective Shift Derivations
--- ════════════════════════════════════════════════════════════════
+/-! ### Perspective Shift Derivations -/
 
 /-- In a past-under-past configuration with the shifted reading,
     the embedded reference time is past relative to speech time.
@@ -323,30 +152,13 @@ theorem past_under_past_simultaneous_is_past {Time : Type*} [LinearOrder Time]
     _ < P := h_matrix_past
     _ = S := h_root
 
-/-- Present-under-past with the simultaneous reading: embedded R = matrix E. -/
-theorem present_under_past_simultaneous {Time : Type*}
-    (matrixFrame : ReichenbachFrame Time) :
-    (simultaneousFrame matrixFrame matrixFrame.eventTime).referenceTime =
-    (simultaneousFrame matrixFrame matrixFrame.eventTime).perspectiveTime := by
-  rfl
-
 /-- The simultaneous frame satisfies PRESENT (R = P) relative to embedded P. -/
-theorem simultaneousFrame_is_present {Time : Type*}
+theorem simultaneousFrame_isPresent {Time : Type*}
     (matrixFrame : ReichenbachFrame Time) (embeddedE : Time) :
-    (simultaneousFrame matrixFrame embeddedE).isPresent := by
-  unfold ReichenbachFrame.isPresent simultaneousFrame
-  rfl
-
-/-- The simultaneousFrame satisfies the time-equality R = P. -/
-theorem simultaneousFrame_satisfies_time_eq {Time : Type*}
-    (matrixFrame : ReichenbachFrame Time) (embeddedE : Time) :
-    (simultaneousFrame matrixFrame embeddedE).referenceTime =
-    (simultaneousFrame matrixFrame embeddedE).perspectiveTime := by rfl
+    (simultaneousFrame matrixFrame embeddedE).isPresent := rfl
 
 
--- ════════════════════════════════════════════════════════════════
--- § Available Readings Theorems
--- ════════════════════════════════════════════════════════════════
+/-! ### Available Readings Theorems -/
 
 /-- In SOT languages, the simultaneous reading is available. -/
 theorem sot_simultaneous_available :
@@ -369,12 +181,8 @@ theorem nonSOT_no_simultaneous :
   simp [availableReadings]
 
 
--- ════════════════════════════════════════════════════════════════
--- § Upper Limit Constraint ([abusch-1997])
--- ════════════════════════════════════════════════════════════════
-
 /-!
-### [abusch-1997]'s Upper Limit Constraint
+### Upper Limit Constraint ([abusch-1997])
 
 The Upper Limit Constraint is stated by [abusch-1997] §7
 (p. 25): "the now of an epistemic alternative is an upper limit for
@@ -429,10 +237,6 @@ theorem simultaneous_satisfies_ulc {Time : Type*} [Preorder Time]
   le_of_eq h
 
 
--- ════════════════════════════════════════════════════════════════
--- § TensePronoun ↔ SOT Frames
--- ════════════════════════════════════════════════════════════════
-
 /-!
 ### TensePronoun Projections onto SOT Frames
 
@@ -454,7 +258,8 @@ theorem simultaneousFrame_from_tense_pronoun {Time : Type*}
     (hResolve : interpTense n g = matrixFrame.eventTime) :
     tp.toFrame g matrixFrame.speechTime matrixFrame.eventTime embeddedE =
     simultaneousFrame matrixFrame embeddedE := by
-  simp [TensePronoun.toFrame, TensePronoun.resolve, simultaneousFrame, hIdx, hResolve]
+  simp [TensePronoun.toFrame, TensePronoun.resolve, simultaneousFrame, embeddedFrame,
+        hIdx, hResolve]
 
 /-- The shifted reading = free past tense pronoun.
     A past-constraint tense pronoun whose variable resolves to some R' < P
@@ -469,7 +274,8 @@ theorem shiftedFrame_from_tense_pronoun {Time : Type*}
     (hResolve : interpTense n g = embeddedR) :
     tp.toFrame g matrixFrame.speechTime matrixFrame.eventTime embeddedE =
     shiftedFrame matrixFrame embeddedR embeddedE := by
-  simp [TensePronoun.toFrame, TensePronoun.resolve, shiftedFrame, hIdx, hResolve]
+  simp [TensePronoun.toFrame, TensePronoun.resolve, shiftedFrame, embeddedFrame,
+        hIdx, hResolve]
 
 /-- Double-access: present-under-past requires the complement
     to hold at BOTH speech time AND matrix event time.
@@ -496,9 +302,7 @@ theorem bound_tense_simultaneous {Time : Type*} [LinearOrder Time]
   ⟨zeroTense_receives_binder_time g n matrixFrame.eventTime, rfl⟩
 
 
--- ════════════════════════════════════════════════════════════════
--- § ThenAdverb
--- ════════════════════════════════════════════════════════════════
+/-! ### ThenAdverb -/
 
 /-- A "then"-type temporal adverb.
     Cross-linguistically, "then" shifts the perspective time P away

--- a/Linglib/Semantics/Tense/Compositional.lean
+++ b/Linglib/Semantics/Tense/Compositional.lean
@@ -1,32 +1,18 @@
-/-
-# Tense Semantics
-
-Semantic operators for grammatical tense (PAST, PRES, FUT).
-
-## Core Idea
-
-Tense operators impose temporal constraints on propositions:
-- **PAST**: Event time precedes reference time (τ(s) < τ(s'))
-- **PRES**: Event time equals reference time (τ(s) = τ(s'))
-- **FUT**: Event time follows reference time (τ(s) > τ(s'))
-
-Following [heim-kratzer-1998], tenses are like pronouns for times:
-they introduce or retrieve temporal reference points.
-
-## Two Frameworks
-
-1. **Reichenbach-style**: Tense relates R to S
-   - PAST: R < S
-   - PRESENT: R = S (or R ◦ S)
-   - FUTURE: S < R
-
-2. **Situation-semantic** (Kratzer/Mendes):
-   - Tense operators take a situation argument and constrain its time
-   - τ(s) is the temporal trace of situation s
-
--/
-
 import Linglib.Semantics.Tense.GramTense
+
+/-!
+# Compositional Tense Operators
+[mendes-2025] [partee-1973]
+
+Semantic operators for grammatical tense (PAST, PRES, FUT), in two styles:
+Reichenbach-style (tense relates R to P on a frame, `applyTense`) and
+situation-semantic ([mendes-2025]: operators constrain the temporal
+coordinate of a situation argument). Both are driven by the shared
+temporal-relation kernel (`precedes`/`coincides`/`follows`), which is also
+the source of truth for the dynamic counterparts in `Tense/Dynamic.lean`.
+Following [partee-1973], tenses are pronoun-like: they retrieve temporal
+reference points rather than quantify over all times.
+-/
 
 namespace Semantics.Tense
 
@@ -45,9 +31,7 @@ A tense operator takes:
 -/
 abbrev TenseOp (W Time : Type*) := SitProp W Time → WorldTimeIndex W Time → WorldTimeIndex W Time → Prop
 
--- ════════════════════════════════════════════════════════════════
--- § Temporal-relation kernel
--- ════════════════════════════════════════════════════════════════
+/-! ### Temporal-relation kernel -/
 
 /-!
 The temporal constraint of each tense, factored out as a pure relation
@@ -200,44 +184,16 @@ def applyTense {Time : Type*} [LinearOrder Time] (t : GramTense) (f : Reichenbac
   | .future => f.referenceTime > f.perspectiveTime
   | .nonpast => f.referenceTime ≥ f.perspectiveTime
 
-/--
-Check if a Reichenbach frame satisfies a given tense.
-Tense locates R relative to P (perspective time).
--/
-def satisfiesTense {Time : Type*} [LinearOrder Time] [DecidableEq Time]
-    [DecidableRel (α := Time) (· < ·)]
-    (t : GramTense) (f : ReichenbachFrame Time) : Bool :=
+instance {Time : Type*} [LinearOrder Time] (t : GramTense) (f : ReichenbachFrame Time) :
+    Decidable (applyTense t f) :=
   match t with
-  | .past => f.referenceTime < f.perspectiveTime
-  | .present => f.referenceTime == f.perspectiveTime
-  | .future => f.referenceTime > f.perspectiveTime
-  | .nonpast => f.referenceTime >= f.perspectiveTime
+  | .past => inferInstanceAs (Decidable (_ < _))
+  | .present => inferInstanceAs (Decidable (_ = _))
+  | .future => inferInstanceAs (Decidable (_ > _))
+  | .nonpast => inferInstanceAs (Decidable (_ ≥ _))
 
 
-/--
-Sequence of tenses (for embedded tense in reported speech, etc.)
-
-"John said that Mary left" - past under past
--/
-def composeTense : GramTense → GramTense → GramTense
-  | .past, .past => .past      -- Past of past is past (in English)
-  | .past, .present => .past   -- Present of past is past
-  | .past, .future => .past    -- Future of past... complex (would)
-  | .past, .nonpast => .past   -- Nonpast of past is past
-  | .present, t => t           -- Present is transparent
-  | .nonpast, .past => .past    -- Past of nonpast is past
-  | .nonpast, .present => .nonpast -- Present is transparent (right)
-  | .nonpast, .future => .future -- Future of nonpast is future
-  | .nonpast, .nonpast => .nonpast -- Nonpast is idempotent
-  | .future, .past => .future  -- Past of future... complex
-  | .future, .present => .future
-  | .future, .future => .future
-  | .future, .nonpast => .future
-
-
--- ════════════════════════════════════════════════════════════════
--- § applyTense ↔ GramTense.constrains Bridge
--- ════════════════════════════════════════════════════════════════
+/-! ### applyTense ↔ GramTense.constrains Bridge -/
 
 /-- `applyTense` is the Reichenbach-frame projection of `GramTense.constrains`:
     applying a tense to a frame is equivalent to the tense's temporal constraint
@@ -320,45 +276,5 @@ example : FUT (raining Unit) ⟨(), 1⟩ ⟨(), 0⟩ := by
   · trivial
 
 end Examples
-
--- ════════════════════════════════════════════════════════════════
--- § composeTense Properties
--- ════════════════════════════════════════════════════════════════
-
-/-!
-### composeTense Properties
-[kiparsky-2002]
-
-`composeTense` is a stipulative function defining how surface tenses compose
-under embedding. The following theorems establish its algebraic properties.
-
-For the DERIVED version — showing that composeTense matches the Reichenbach
-analysis with perspective shifting — see
-`Semantics.Tense` (in `IS/Tense/Basic.lean`) and the TC↔IS bridge
-in `Semantics.Tense.SequenceOfTense`.
--/
-
-/-- Present is transparent under composition (left):
-    composing with matrix present always yields the embedded tense.
-    This reflects present's semantics: R = P, so tense relative to
-    a present perspective is unchanged. -/
-theorem composeTense_present_left (t : GramTense) :
-    composeTense .present t = t := by cases t <;> rfl
-
-/-- Present is transparent under composition (right):
-    embedding present under any tense yields the matrix tense.
-    Embedded present = "at the matrix event time" = same tense
-    relative to speech time. -/
-theorem composeTense_present_right (t : GramTense) :
-    composeTense t .present = t := by cases t <;> rfl
-
-/-- Tense composition is idempotent for past: embedding past
-    arbitrarily deep under past still yields past. -/
-theorem composeTense_past_idempotent :
-    composeTense .past .past = .past := rfl
-
-/-- Tense composition is idempotent for future. -/
-theorem composeTense_future_idempotent :
-    composeTense .future .future = .future := rfl
 
 end Semantics.Tense

--- a/Linglib/Semantics/Tense/ConditionalShift.lean
+++ b/Linglib/Semantics/Tense/ConditionalShift.lean
@@ -40,9 +40,7 @@ open Semantics.Context (RichContext KContext ContextTower ContextShift
 open HistoricalAlternatives
 open Semantics.Mood
 
--- ════════════════════════════════════════════════════════════════
--- § Anderson Conditional
--- ════════════════════════════════════════════════════════════════
+/-! ### Anderson Conditional -/
 
 section AndersonConditional
 
@@ -78,9 +76,7 @@ theorem anderson_shifted_time {W E P T : Type*}
     (rc : RichContext W E P T) :
     ((hpShift (E := E) (P := P) hpTime expandedDomain).apply rc).time = hpTime := rfl
 
--- ════════════════════════════════════════════════════════════════
--- § HP Achieves Expansion (Mizuno's Argument)
--- ════════════════════════════════════════════════════════════════
+/-! ### HP Achieves Expansion (Mizuno's Argument) -/
 
 section Expansion
 
@@ -132,9 +128,7 @@ theorem historicalBase_monotone
 
 end Expansion
 
--- ════════════════════════════════════════════════════════════════
--- § Conditional Triviality and Domain Expansion
--- ════════════════════════════════════════════════════════════════
+/-! ### Conditional Triviality and Domain Expansion -/
 
 section Triviality
 
@@ -237,9 +231,7 @@ theorem trivial_monotone
 
 end Triviality
 
--- ════════════════════════════════════════════════════════════════
--- § Bridge: SUBJ as Domain-Expanding Shift
--- ════════════════════════════════════════════════════════════════
+/-! ### Bridge: SUBJ as Domain-Expanding Shift -/
 
 section SubjBridge
 

--- a/Linglib/Semantics/Tense/DeRe.lean
+++ b/Linglib/Semantics/Tense/DeRe.lean
@@ -105,9 +105,7 @@ open HistoricalAlternatives (actualHistoryBase)
 open Semantics.Tense (TensePronoun GramTense TemporalAssignment)
 
 
--- ════════════════════════════════════════════════════════════════
--- § Time-concepts and entity-concepts
--- ════════════════════════════════════════════════════════════════
+/-! ### Time-concepts and entity-concepts -/
 
 /-- A **time-concept**: an intension from a centered Kaplanian context
     to a time. The temporal specialization of [abusch-1997]'s
@@ -125,9 +123,7 @@ abbrev TimeConcept (W E P T : Type*) := Intension (KContext W E P T) T
 abbrev EntityConcept (W E P T : Type*) := Intension (KContext W E P T) E
 
 
--- ════════════════════════════════════════════════════════════════
--- § Temporal de re reading
--- ════════════════════════════════════════════════════════════════
+/-! ### Temporal de re reading -/
 
 /-- A **temporal de re reading** ([abusch-1997] §3): a time-concept
     paired with the **attitude holder's centered context**. The actual
@@ -168,9 +164,7 @@ theorem baseCoherent (dr : TemporalDeReReading W E P T) :
     dr.concept dr.holderContext = dr.actualRes := rfl
 
 
--- ════════════════════════════════════════════════════════════════
--- § Felicity and the value-level shadow
--- ════════════════════════════════════════════════════════════════
+/-! ### Felicity and the value-level shadow -/
 
 /-- Felicity of a temporal de re reading under a tense constraint:
     the actual res-time stands in the constraint's relation to the
@@ -201,9 +195,7 @@ theorem isFelicitousWith_iff_tensePronoun_fullPresupposition
   simp only [isFelicitousWith, TensePronoun.fullPresupposition, hRes, hEval]
 
 
--- ════════════════════════════════════════════════════════════════
--- § Modal-alternative quantification (Abusch §3)
--- ════════════════════════════════════════════════════════════════
+/-! ### Modal-alternative quantification (Abusch §3) -/
 
 /-- **Modal rigidity**: the time-concept evaluates to the same time at
     every world-time pair in a supplied alternative set, when that
@@ -275,9 +267,7 @@ theorem isFelicitousWith_of_isAbuschFelicitous [LinearOrder T]
     dr.isFelicitousWith constraint := h.1
 
 
--- ════════════════════════════════════════════════════════════════
--- § Alternative-set constructors (modal-base instantiations)
--- ════════════════════════════════════════════════════════════════
+/-! ### Alternative-set constructors (modal-base instantiations) -/
 
 /-- **Metaphysical** alternative-set instantiation ([klecha-2016]
     DOX): the worlds sharing the holder's actual world's history up to
@@ -301,9 +291,7 @@ def doxasticAlternatives
   { s' | dox dr.holderContext.agent dr.holderContext.world s' }
 
 
--- ════════════════════════════════════════════════════════════════
--- § Acquaintance: instantiating the polymorphic substrate
--- ════════════════════════════════════════════════════════════════
+/-! ### Acquaintance: instantiating the polymorphic substrate -/
 
 /-- The Aloni cover for time-concepts: a set of `TimeConcept`s
     representing the believer's available "ways of identifying" a time.

--- a/Linglib/Semantics/Tense/Domain.lean
+++ b/Linglib/Semantics/Tense/Domain.lean
@@ -35,9 +35,7 @@ domain-shaped theories build on top.
 namespace Semantics.Tense
 
 
--- ════════════════════════════════════════════════════
--- § Times of Orientation
--- ════════════════════════════════════════════════════
+/-! ### Times of Orientation -/
 
 /-- A **time of orientation** (TO, [declerck-2006]): a temporal
     anchor used by tense/aspect frameworks. Realized as
@@ -84,9 +82,7 @@ def ofPoint (name : Role) (t : Time) : NamedTO Time Role where
 
 end NamedTO
 
--- ════════════════════════════════════════════════════
--- § Domain
--- ════════════════════════════════════════════════════
+/-! ### Domain -/
 
 /-- A **temporal domain** ([declerck-2006]): a central time of
     orientation (the *binding TO* of the domain) together with a list
@@ -165,9 +161,7 @@ def relatedByName [DecidableEq Role] (d : Domain Time Role)
 
 end Domain
 
--- ════════════════════════════════════════════════════
--- § Builders for the Common Reichenbach Role-Set
--- ════════════════════════════════════════════════════
+/-! ### Builders for the Common Reichenbach Role-Set -/
 
 /-! Convenience constructors for the canonical Reichenbach role-set,
     using `Orientation` as the universal `Role` type:

--- a/Linglib/Semantics/Tense/Dynamic.lean
+++ b/Linglib/Semantics/Tense/Dynamic.lean
@@ -96,9 +96,7 @@ def dynFUT {W Time : Type*} [LT Time]
   dynRelation (follows (W := W) (Time := Time)) eventVar refVar
 
 
--- ════════════════════════════════════════════════════════════════
--- § Definitional bridges: dynamic operators ARE dynRelation
--- ════════════════════════════════════════════════════════════════
+/-! ### Definitional bridges: dynamic operators ARE dynRelation -/
 
 theorem dynPAST_eq_dynRelation_precedes {W Time : Type*} [LT Time]
     (e r : SVar) (c : SitContext W Time) :
@@ -113,9 +111,7 @@ theorem dynFUT_eq_dynRelation_follows {W Time : Type*} [LT Time]
     dynFUT e r c = dynRelation follows e r c := rfl
 
 
--- ════════════════════════════════════════════════════════════════
--- § Static realization: dynamic IS the eliminative update of static
--- ════════════════════════════════════════════════════════════════
+/-! ### Static realization: dynamic IS the eliminative update of static -/
 
 /-!
 For each tense, the static operator (with the trivial propositional
@@ -146,9 +142,7 @@ theorem dynFUT_iff_FUT_with_true {W Time : Type*} [LT Time]
   ⟨fun h => ⟨h.1, h.2, trivial⟩, fun ⟨hc, hp, _⟩ => ⟨hc, hp⟩⟩
 
 
--- ════════════════════════════════════════════════════════════════
--- § Temporal algebra (derived from kernel + dynRelation)
--- ════════════════════════════════════════════════════════════════
+/-! ### Temporal algebra (derived from kernel + dynRelation) -/
 
 /-- PAST ∪ PRES ∪ FUT = identity. Derived from `lt_trichotomy` via the
 shared `precedes`/`coincides`/`follows` kernel. -/

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -39,8 +39,8 @@ design where paradigm entries stored opaque lambdas.
 ## Connection to Modal Evidentiality
 
 The tense evidential constraint parallels [von-fintel-gillies-2010]
-`kernelMust` presupposition: both require non-direct evidence. The bridge
-between these two phenomena is formalized in `Comparisons/TenseModalEvidentiality.lean`.
+`kernelMust` presupposition: both require non-direct evidence. (A formal
+bridge between the two phenomena has not been built.)
 
 ## Connection to Features.Evidentiality
 
@@ -61,9 +61,7 @@ open Features.Evidentiality
 open Features.Mirativity
 open Semantics.Presupposition
 
--- ════════════════════════════════════════════════════
--- § 1. Evidential Frame
--- ════════════════════════════════════════════════════
+/-! ### Evidential Frame -/
 
 /-- Cumming's (S, A, T) frame. Extends Reichenbach with an evidence-acquisition
     time A. S = speechTime, T = eventTime, A = acquisitionTime. The existing
@@ -73,9 +71,7 @@ structure EvidentialFrame (Time : Type*) extends ReichenbachFrame Time where
       grounding the assertion. -/
   acquisitionTime : Time
 
--- ════════════════════════════════════════════════════
--- § 2. EP Constraint Enum
--- ════════════════════════════════════════════════════
+/-! ### EP Constraint Enum -/
 
 /-- Evidential perspective constraint shapes attested across English, Korean,
     and Bulgarian ([cumming-2026], Tables 17–22). Each value corresponds to a
@@ -146,9 +142,7 @@ instance : DecidablePred EPCondition.IsNonfuture :=
 @[simp] theorem EPCondition.toEvidentialPerspective_unconstrained :
     EPCondition.toEvidentialPerspective .unconstrained = none := rfl
 
--- ════════════════════════════════════════════════════
--- § 3. UP Constraint Enum
--- ════════════════════════════════════════════════════
+/-! ### UP Constraint Enum -/
 
 /-- Utterance perspective constraint shapes attested across the three
     languages. Each value corresponds to a distinct ordering
@@ -174,9 +168,7 @@ def UPCondition.toConstraint : UPCondition → EvidentialFrame ℤ → Prop
   | .nonfuture => λ f => f.eventTime ≤ f.speechTime
   | .unconstrained => λ _ => True
 
--- ════════════════════════════════════════════════════
--- § 4. Tense-Evidential Paradigm
--- ════════════════════════════════════════════════════
+/-! ### Tense-Evidential Paradigm -/
 
 /-- A row in a tense-aspect-mood-evidentiality paradigm table.
     Generalizes [cumming-2026]'s tense-evidential paradigm (Tables 17–22)
@@ -216,18 +208,14 @@ def TAMEEntry.upConstraint (p : TAMEEntry) :
     EvidentialFrame ℤ → Prop :=
   p.up.toConstraint
 
--- ════════════════════════════════════════════════════
--- § 5. Core Predicates
--- ════════════════════════════════════════════════════
+/-! ### Core Predicates -/
 
 /-- Cumming's constraint (10): evidence is downstream of the event.
     T ≤ A — the event precedes (or coincides with) evidence acquisition. -/
 def downstreamEvidence (f : EvidentialFrame ℤ) : Prop :=
   f.eventTime ≤ f.acquisitionTime
 
--- ════════════════════════════════════════════════════
--- § 6. Generic Downstream Lemma
--- ════════════════════════════════════════════════════
+/-! ### Generic Downstream Lemma -/
 
 /-- Any nonfuture EP constraint entails downstream evidence (T ≤ A).
     One proof, six cases — the three nonfuture cases follow from ≤, <, =
@@ -244,9 +232,7 @@ theorem EPCondition.nonfuture_implies_downstream
   | prospective => exact absurd h_nf (by decide)
   | unconstrained => exact absurd h_nf (by decide)
 
--- ════════════════════════════════════════════════════
--- § 7. Presuppositional Nonfuture Meaning
--- ════════════════════════════════════════════════════
+/-! ### Presuppositional Nonfuture Meaning -/
 
 /-- Nonfuture meaning as a presuppositional proposition:
     the presupposition is that evidence is downstream (T ≤ A); the assertion
@@ -263,9 +249,7 @@ def nonfutureMeaning {W : Type*} (f : EvidentialFrame ℤ) (p : Bool) : PrProp W
 theorem nonfutureMeaning_presup {W : Type*} (f : EvidentialFrame ℤ) (p : Bool) (w : W) :
     (nonfutureMeaning f p).presup w = decide (f.eventTime ≤ f.acquisitionTime) := rfl
 
--- ════════════════════════════════════════════════════════════════
--- § 8. Tower Integration: Evidential Shift
--- ════════════════════════════════════════════════════════════════
+/-! ### Tower Integration: Evidential Shift -/
 
 /-!
 ### Evidential Shift as Tower Push

--- a/Linglib/Semantics/Tense/GramTense.lean
+++ b/Linglib/Semantics/Tense/GramTense.lean
@@ -8,10 +8,13 @@ import Linglib.Semantics.Context.Shifts
 
 /-!
 # Unified Tense Pronoun Architecture
-[abusch-1997] [heim-kratzer-1998] [kratzer-1998] [partee-1973] [von-stechow-2009] [ogihara-1989]
+[abusch-1997] [heim-1994-comments] [kratzer-1998] [partee-1973] [von-stechow-2009] [ogihara-1989]
 
-[abusch-1997]'s insight: a tense morpheme is a **temporal pronoun** — a variable with a presupposed temporal constraint (Prior, reinterpreted) and
-a binding mode (indexical/anaphoric/bound). This single concept projects onto
+[partee-1973]'s insight: a tense morpheme is a **temporal pronoun** — a
+variable with a temporal constraint and a binding mode
+(indexical/anaphoric/bound). The constraint-as-presupposition formulation
+follows [heim-1994-comments] (commenting on [abusch-1997]) and
+[kratzer-1998]. This single concept projects onto
 five representations of temporal reference in the codebase:
 
 1. **Priorean operators** (PAST/PRES/FUT): `constraint.constrains`
@@ -41,9 +44,7 @@ open Core.ReferentialMode (ReferentialMode)
 open Core (Assignment WorldTimeIndex)
 
 
--- ════════════════════════════════════════════════════════════════
--- § GramTense
--- ════════════════════════════════════════════════════════════════
+/-! ### GramTense -/
 
 /--
 Grammatical tense: a temporal relation imposed by tense morphology.
@@ -66,20 +67,6 @@ inductive GramTense where
 
 namespace GramTense
 
-/-- Convert tense to its corresponding temporal relation -/
-def toRelation : GramTense → Core.Order.Relation
-  | .past => .before
-  | .present => .overlapping
-  | .future => .after
-  | .nonpast => .notBefore
-
-/-- The inverse relation (for "backwards" reference) -/
-def inverseRelation : GramTense → Core.Order.Relation
-  | .past => .after
-  | .present => .overlapping
-  | .future => .before
-  | .nonpast => .notAfter
-
 /-- The temporal constraint imposed by a grammatical tense.
     Past: ref < perspective. Present: ref = perspective. Future: ref > perspective.
     Nonpast: ref ≥ perspective ([klecha-2016]).
@@ -93,12 +80,18 @@ def constrains {Time : Type*} [LinearOrder Time]
   | .future => refTime > perspTime
   | .nonpast => refTime ≥ perspTime
 
+instance {Time : Type*} [LinearOrder Time] (t : GramTense) (r p : Time) :
+    Decidable (t.constrains r p) :=
+  match t with
+  | .past => inferInstanceAs (Decidable (r < p))
+  | .present => inferInstanceAs (Decidable (r = p))
+  | .future => inferInstanceAs (Decidable (r > p))
+  | .nonpast => inferInstanceAs (Decidable (r ≥ p))
+
 end GramTense
 
 
--- ════════════════════════════════════════════════════════════════
--- § SOTParameter
--- ════════════════════════════════════════════════════════════════
+/-! ### SOTParameter -/
 
 /--
 Sequence of Tenses (SOT) parameter.
@@ -138,9 +131,7 @@ def WilliamsCycleStage.ofSOTParameter : SOTParameter → WilliamsCycleStage
   | .relative => .fullSOT
 
 
--- ════════════════════════════════════════════════════════════════
--- § TenseInterpretation
--- ════════════════════════════════════════════════════════════════
+/-! ### TenseInterpretation -/
 
 /-- Tense interpretation modes.
     Tenses parallel pronouns: indexical (deictic), anaphoric
@@ -151,9 +142,7 @@ def WilliamsCycleStage.ofSOTParameter : SOTParameter → WilliamsCycleStage
     applies to both pronouns and tenses. -/
 abbrev TenseInterpretation := Core.ReferentialMode.ReferentialMode
 
--- ════════════════════════════════════════════════════════════════
--- § Temporal Variable Infrastructure ([partee-1973])
--- ════════════════════════════════════════════════════════════════
+/-! ### Temporal Variable Infrastructure ([partee-1973]) -/
 
 /-! Temporal assignment functions are the temporal instantiation of
 `Core.Assignment` (`Assignment Time = ℕ → Time`). All update laws are mathlib's `Function.update` lemmas. -/
@@ -204,9 +193,7 @@ theorem zeroTense_receives_binder_time {Time : Type*}
   Function.update_self n binderTime g
 
 
--- ════════════════════════════════════════════════════════════════
--- § SitProp (Prop-valued)
--- ════════════════════════════════════════════════════════════════
+/-! ### SitProp (Prop-valued) -/
 
 /--
 Type of situation-level propositions (Prop-valued, for proof-level
@@ -220,9 +207,7 @@ This is what tense operators modify. Re-exported by
 abbrev SitProp (W Time : Type*) := WorldTimeIndex W Time → Prop
 
 
--- ════════════════════════════════════════════════════════════════
--- § TensePronoun ([abusch-1997])
--- ════════════════════════════════════════════════════════════════
+/-! ### TensePronoun ([abusch-1997]) -/
 
 /-- [abusch-1997]'s unified tense denotation.
 
@@ -281,9 +266,7 @@ instance (tp : TensePronoun) : Decidable tp.isBound :=
 end TensePronoun
 
 
--- ════════════════════════════════════════════════════════════════
--- § TensePronoun Bridge Theorems
--- ════════════════════════════════════════════════════════════════
+/-! ### TensePronoun Bridge Theorems -/
 
 /-- Resolve the evaluation time from the assignment.
     In root clauses (evalTimeIndex = 0, g(0) = speech time), this is speech time.
@@ -353,11 +336,9 @@ theorem TensePronoun.indexical_present_at_speech {Time : Type*} [LinearOrder Tim
   exact hPresup
 
 
--- ════════════════════════════════════════════════════════════════
--- § Overtness ([heim-kratzer-1998])
--- ════════════════════════════════════════════════════════════════
+/-! ### Overtness ([kratzer-1998]) -/
 
-/-- Phonological overtness of a referential expression ([heim-kratzer-1998] §3).
+/-- Phonological overtness of a referential expression ([kratzer-1998] §3).
 
     Applies uniformly to pronouns and tenses: English has zero tense
     under SOT (bound present surfaces as ∅); Japanese has zero pronouns
@@ -403,9 +384,7 @@ theorem Overtness.bound_nonlocal_is_overt :
     Overtness.fromBinding .bound false = .overt := rfl
 
 
--- ════════════════════════════════════════════════════════════════
--- § Temporal Tower Bridge ([abusch-1997] ↔ ContextTower)
--- ════════════════════════════════════════════════════════════════
+/-! ### Temporal Tower Bridge ([abusch-1997] ↔ ContextTower) -/
 
 /-! The key bridge showing that [abusch-1997]'s De Bruijn temporal indexing is already
 tower-style depth access. `TensePronoun.evalTimeIndex` is a depth-relative index

--- a/Linglib/Semantics/Tense/ParticipantPerspective.lean
+++ b/Linglib/Semantics/Tense/ParticipantPerspective.lean
@@ -40,9 +40,7 @@ namespace Semantics.Tense.ParticipantPerspective
 open Semantics.Tense.Evidential
 open Semantics.Tense
 
--- ════════════════════════════════════════════════════
--- § 1. Tense Perspective Frame
--- ════════════════════════════════════════════════════
+/-! ### Tense Perspective Frame -/
 
 /-- Lakoff's participant-sensitive tense frame. Extends `EvidentialFrame`
     (which already extends `ReichenbachFrame`) with two psychological dimensions:
@@ -56,9 +54,7 @@ structure TensePerspective (Time : Type*) extends EvidentialFrame Time where
   /-- Is the propositional content new to the hearer? -/
   hearerNovelty : Bool
 
--- ════════════════════════════════════════════════════
--- § 2. Lakoff Predicates
--- ════════════════════════════════════════════════════
+/-! ### Lakoff Predicates -/
 
 /-- **False past** (Lakoff §1): past tense applied to a present-time event
     because the speaker no longer finds it salient.
@@ -102,9 +98,7 @@ def perfectRequiresSalience (f : TensePerspective ℤ) : Prop :=
 def willDeletion (f : TensePerspective ℤ) : Prop :=
   f.speechTime < f.eventTime ∧ f.speakerSalience = true
 
--- ════════════════════════════════════════════════════
--- § 3. True vs False Tense Classification
--- ════════════════════════════════════════════════════
+/-! ### True vs False Tense Classification -/
 
 open Morphology.Tense in
 
@@ -138,9 +132,7 @@ def falseTenseRequiresSynthetic (use : TenseUse) (form : TenseFormType) : Bool :
   | .trueTense  => true   -- true tense is fine with any form
   | .falseTense => form == .synthetic  -- false tense needs synthetic
 
--- ════════════════════════════════════════════════════
--- § 4. Bridge Theorems
--- ════════════════════════════════════════════════════
+/-! ### Bridge Theorems -/
 
 /-- When `falsePast` holds, the UP present-tense constraint (T = S) is satisfied.
     The event IS at speech time, despite the past surface tense — the mismatch

--- a/Linglib/Semantics/Tense/Perspective.lean
+++ b/Linglib/Semantics/Tense/Perspective.lean
@@ -44,9 +44,7 @@ open Semantics.Context (KContext)
 open Semantics.Tense
 
 
--- ════════════════════════════════════════════════════════════════
--- § 1. Tense Presuppositions
--- ════════════════════════════════════════════════════════════════
+/-! ### Tense Presuppositions -/
 
 /-- PRES presupposes g(n) ○ π: the temporal reference overlaps the perspective.
     Point approximation: R = P. -/
@@ -68,9 +66,7 @@ theorem pastPresup_iff_isPast {Time : Type*} [LinearOrder Time]
     pastPresup f ↔ f.isPast := Iff.rfl
 
 
--- ════════════════════════════════════════════════════════════════
--- § 2. OP_π: Perspective-Shifting Operator
--- ════════════════════════════════════════════════════════════════
+/-! ### OP_π: Perspective-Shifting Operator -/
 
 /-- OP_π shifts the perspective time to a new value.
     ⟦OP_π φ⟧^{c,π,g} = λi_κ. ⟦φ⟧^{c,i_t,g}(i) -/
@@ -90,9 +86,7 @@ theorem opPi_eq_embeddedFrame {Time : Type*}
   simp only [opPi, embeddedFrame]
 
 
--- ════════════════════════════════════════════════════════════════
--- § 3. ⌈then⌉ Presupposition
--- ════════════════════════════════════════════════════════════════
+/-! ### ⌈then⌉ Presupposition -/
 
 /-- ⌈then⌉ presupposes ¬(g(n) ○ π): its temporal reference is disjoint
     from the perspective. Point approximation: thenRef ≠ π.
@@ -105,9 +99,7 @@ def thenPresup {Time : Type*} (thenRef perspective : Time) : Prop :=
   thenRef ≠ perspective
 
 
--- ════════════════════════════════════════════════════════════════
--- § 4. Core Clash Theorems
--- ════════════════════════════════════════════════════════════════
+/-! ### Core Clash Theorems -/
 
 /-- The ⌈then⌉-present clash. Three ingredients produce the contradiction:
     1. PRES presupposes presRef = π (overlap with perspective)
@@ -132,15 +124,16 @@ theorem then_perspective_clash {Time : Type*}
     : False := hThen hOP
 
 
--- ════════════════════════════════════════════════════════════════
--- § 5. Deleted vs. Shifted Tense
--- ════════════════════════════════════════════════════════════════
+/-! ### Deleted vs. Shifted Tense -/
 
 /-- Status of an embedded tense morpheme. -/
 inductive EmbeddedTenseStatus where
   /-- Tense interpreted with presupposition anchored to shifted π -/
   | shifted
-  /-- Tense deleted by SOT; no temporal presupposition -/
+  /-- Tense deleted by SOT; imposes no temporal presupposition at all
+      (there is no definedness condition to state, which is why
+      `then_deleted_tense_compatible` below needs no presupposition
+      hypothesis). -/
   | deleted
   deriving DecidableEq, Repr
 
@@ -148,9 +141,6 @@ inductive EmbeddedTenseStatus where
 def shiftedTensePresup {Time : Type*} [LT Time]
     (f : ReichenbachFrame Time) (isPres : Bool) : Prop :=
   if isPres then presPresup f else pastPresup f
-
-/-- A deleted tense has no temporal presupposition — trivially satisfied. -/
-theorem deletedTensePresup : True := trivial
 
 /-- ⌈then⌉ + deleted tense → compatible.
     Deleted tense has no presupposition anchoring it to π, so there is no
@@ -173,9 +163,7 @@ theorem then_shifted_present_clash {Time : Type*}
   then_present_clash presRef thenRef shiftedPi hPres hDuring hThen
 
 
--- ════════════════════════════════════════════════════════════════
--- § 6. Bridge to PrProp
--- ════════════════════════════════════════════════════════════════
+/-! ### Bridge to PrProp -/
 
 /-- Wrap PRES presupposition as a `PrProp`, showing how tense presuppositions
     compose with the existing presupposition projection system. -/
@@ -191,9 +179,7 @@ theorem presAsPrProp_defined_iff {Time : Type*} [DecidableEq Time]
   simp [presAsPrProp]
 
 
--- ════════════════════════════════════════════════════════════════
--- § 7. Interpretation Parameters: c and π
--- ════════════════════════════════════════════════════════════════
+/-! ### Interpretation Parameters: c and π -/
 
 /-- The interpretation parameter tuple ⟨c, π⟩ from ⟦·⟧^{c,π,g}.
 
@@ -272,9 +258,7 @@ theorem InterpParams.shiftPerspective_matches_opPi {W E P T : Type*}
   simp only [opPi, InterpParams.shiftPerspective]
 
 
--- ════════════════════════════════════════════════════════════════
--- § 9. Cross-Linguistic Tense Shift Typology
--- ════════════════════════════════════════════════════════════════
+/-! ### Cross-Linguistic Tense Shift Typology -/
 
 /-- Cross-linguistic tense shift profile, encoding Tables 1 & 2.
 
@@ -362,9 +346,7 @@ theorem relative_shift_implies_attitude_shift :
     simp_all [greekProfile, hebrewProfile, russianProfile, japaneseProfile, englishProfile]
 
 
--- ════════════════════════════════════════════════════════════════
--- § 10. WOLL Decomposition
--- ════════════════════════════════════════════════════════════════
+/-! ### WOLL Decomposition -/
 
 /-- will = WOLL + PRES. WOLL is an intensional modal operator that:
     1. Quantifies over accessible future indices (∀i' ∈ ACC(i)(t). i'_t > t)

--- a/Linglib/Semantics/Tense/Reichenbach.lean
+++ b/Linglib/Semantics/Tense/Reichenbach.lean
@@ -22,7 +22,7 @@ Tense relates R to P; Aspect relates E to R.
 linglib's tense modules. The `toDomain` builder lifts it to a generic
 `Semantics.Tense.Domain` (central = S, sub-TOs = [P, R, E], all as point
 intervals via `TO.pure`). The `*_iff_relatedByName` bridge theorems
-re-express each Boolean predicate (`isPast`, `isPerfect`, …) as a
+re-express each predicate (`isPast`, `isPerfect`, …) as a
 `Domain.relatedByName` query against named atom-sets from the Allen
 algebra. This grounds the Reichenbach predicates in the Allen
 projection function (`NonemptyInterval.allenRel`) without changing the
@@ -95,7 +95,7 @@ theorem isPast_simpleCase (f : ReichenbachFrame Time) (h : f.isSimpleCase) :
 /-- Perfective: E ⊆ R (event contained in reference).
     Simplified to E = R for point-based times.
     TODO: proper interval-based perfective/imperfective distinction
-    lives in `Semantics/Lexical/Verb/ViewpointAspect.lean`. -/
+    lives in `Semantics/Aspect/Basic.lean` (`ViewpointAspectB`). -/
 def isPerfective (f : ReichenbachFrame Time) : Prop :=
   f.eventTime = f.referenceTime
 
@@ -107,9 +107,67 @@ def isPerfect (f : ReichenbachFrame Time) : Prop :=
 def isProspective (f : ReichenbachFrame Time) : Prop :=
   f.referenceTime < f.eventTime
 
--- ════════════════════════════════════════════════════
--- § Domain Bridge
--- ════════════════════════════════════════════════════
+/-! ### Unfolding lemmas and decidability
+
+One `_def` simp lemma and one `Decidable` instance per predicate, so
+consumers can close concrete goals with `decide` and rewrite with
+`simp only [isPast_def]` instead of unfolding definitions by hand. -/
+
+@[simp] theorem isPast_def (f : ReichenbachFrame Time) :
+    f.isPast ↔ f.referenceTime < f.perspectiveTime := Iff.rfl
+
+@[simp] theorem isPresent_def (f : ReichenbachFrame Time) :
+    f.isPresent ↔ f.referenceTime = f.perspectiveTime := Iff.rfl
+
+@[simp] theorem isFuture_def (f : ReichenbachFrame Time) :
+    f.isFuture ↔ f.perspectiveTime < f.referenceTime := Iff.rfl
+
+@[simp] theorem isSimpleCase_def (f : ReichenbachFrame Time) :
+    f.isSimpleCase ↔ f.perspectiveTime = f.speechTime := Iff.rfl
+
+@[simp] theorem defaultPR_def (f : ReichenbachFrame Time) :
+    f.defaultPR ↔ f.perspectiveTime ≤ f.referenceTime := Iff.rfl
+
+@[simp] theorem defaultER_def (f : ReichenbachFrame Time) :
+    f.defaultER ↔ f.eventTime ≤ f.referenceTime := Iff.rfl
+
+@[simp] theorem isPerfective_def (f : ReichenbachFrame Time) :
+    f.isPerfective ↔ f.eventTime = f.referenceTime := Iff.rfl
+
+@[simp] theorem isPerfect_def (f : ReichenbachFrame Time) :
+    f.isPerfect ↔ f.eventTime < f.referenceTime := Iff.rfl
+
+@[simp] theorem isProspective_def (f : ReichenbachFrame Time) :
+    f.isProspective ↔ f.referenceTime < f.eventTime := Iff.rfl
+
+instance (f : ReichenbachFrame Time) : Decidable f.isPast :=
+  inferInstanceAs (Decidable (f.referenceTime < f.perspectiveTime))
+
+instance (f : ReichenbachFrame Time) : Decidable f.isPresent :=
+  inferInstanceAs (Decidable (f.referenceTime = f.perspectiveTime))
+
+instance (f : ReichenbachFrame Time) : Decidable f.isFuture :=
+  inferInstanceAs (Decidable (f.perspectiveTime < f.referenceTime))
+
+instance (f : ReichenbachFrame Time) : Decidable f.isSimpleCase :=
+  inferInstanceAs (Decidable (f.perspectiveTime = f.speechTime))
+
+instance (f : ReichenbachFrame Time) : Decidable f.defaultPR :=
+  inferInstanceAs (Decidable (f.perspectiveTime ≤ f.referenceTime))
+
+instance (f : ReichenbachFrame Time) : Decidable f.defaultER :=
+  inferInstanceAs (Decidable (f.eventTime ≤ f.referenceTime))
+
+instance (f : ReichenbachFrame Time) : Decidable f.isPerfective :=
+  inferInstanceAs (Decidable (f.eventTime = f.referenceTime))
+
+instance (f : ReichenbachFrame Time) : Decidable f.isPerfect :=
+  inferInstanceAs (Decidable (f.eventTime < f.referenceTime))
+
+instance (f : ReichenbachFrame Time) : Decidable f.isProspective :=
+  inferInstanceAs (Decidable (f.referenceTime < f.eventTime))
+
+/-! ### Domain Bridge -/
 
 /-- The Reichenbach frame as a generic temporal `Domain` over the
     universal `Orientation` role vocabulary: central = utterance
@@ -251,9 +309,7 @@ theorem isPerfective_iff_relatedByName (f : ReichenbachFrame Time) :
 
 end ReichenbachFrame
 
--- ════════════════════════════════════════════════════
--- § TenseSystem and AspectSystem Instances
--- ════════════════════════════════════════════════════
+/-! ### TenseSystem and AspectSystem Instances -/
 
 /-! Reichenbach as a `TenseSystem` (anchor = P, situation = R)
     and `AspectSystem` (event = E, reference = R) instance.

--- a/Linglib/Semantics/Tense/SOT/Decomposition.lean
+++ b/Linglib/Semantics/Tense/SOT/Decomposition.lean
@@ -47,9 +47,7 @@ open Semantics.Tense.Reichenbach
 open Semantics.Tense
 
 
--- ════════════════════════════════════════════════════════════════
--- § SOT Deletion
--- ════════════════════════════════════════════════════════════════
+/-! ### SOT Deletion -/
 
 /-- Kratzer's SOT deletion: when embedded tense morphology is identical
     to matrix tense morphology, the embedded tense can be optionally
@@ -82,9 +80,7 @@ def applyDeletion {Time : Type*}
   eventTime := matrixFrame.eventTime
 
 
--- ════════════════════════════════════════════════════════════════
--- § Derivation Theorems
--- ════════════════════════════════════════════════════════════════
+/-! ### Derivation Theorems -/
 
 /-- Kratzer derives the simultaneous reading via SOT deletion.
     When deletion applies, R' = E_matrix, giving the PRESENT relation. -/
@@ -110,9 +106,7 @@ theorem kratzer_deletion_yields_simultaneous {Time : Type*}
     (applyDeletion matrixFrame).referenceTime = matrixFrame.eventTime :=
   rfl
 
--- ════════════════════════════════════════════════════════════════
--- § Tense Decomposition Structure
--- ════════════════════════════════════════════════════════════════
+/-! ### Tense Decomposition Structure -/
 
 /-- Kratzer's decomposition of surface tense morphology into
     underlying tense head + optional aspect head ([heim-kratzer-1998] §4).
@@ -145,9 +139,7 @@ def KratzerDecomposition.tenseOvertness (d : KratzerDecomposition)
   Overtness.fromBinding d.tensePronoun.mode localDomain
 
 
--- ════════════════════════════════════════════════════════════════
--- § Aspect Decomposition: English Simple Past = PRES + PERF
--- ════════════════════════════════════════════════════════════════
+/-! ### Aspect Decomposition: English Simple Past = PRES + PERF -/
 
 /-! Kratzer (1998 §4): English "simple past" is morphologically fused but
 semantically decomposes into PRESENT tense + PERFECT aspect. The tense head
@@ -221,9 +213,7 @@ theorem german_preterit_eq_simplePast {W Time : Type*} [LinearOrder Time]
     ∃ t : Time, t < tc ∧ PRFV V w (NonemptyInterval.pure t) := Iff.rfl
 
 
--- ════════════════════════════════════════════════════════════════
--- § Zero Tense and Locality
--- ════════════════════════════════════════════════════════════════
+/-! ### Zero Tense and Locality -/
 
 /-! Kratzer (1998 §3): zero (phonologically empty) referential expressions
 arise when a bound variable is in a local agreement domain. This applies
@@ -265,9 +255,7 @@ theorem past_never_zero :
     (kratzerZeroTense 1).constraint = .present := rfl
 
 
--- ════════════════════════════════════════════════════════════════
--- § Reflexive ↔ Simultaneous Parallel
--- ════════════════════════════════════════════════════════════════
+/-! ### Reflexive ↔ Simultaneous Parallel -/
 
 /-! Kratzer (1998 §3) draws an explicit structural parallel between
 reflexive binding and simultaneous tense:

--- a/Linglib/Semantics/Tense/System.lean
+++ b/Linglib/Semantics/Tense/System.lean
@@ -33,9 +33,7 @@ namespace Semantics.Tense
 
 universe u v w
 
--- ════════════════════════════════════════════════════
--- § Tense System
--- ════════════════════════════════════════════════════
+/-! ### Tense System -/
 
 /-- A **tense system**: a framework for locating situations in time
     relative to a discourse anchor.
@@ -63,9 +61,7 @@ class TenseSystem (α : Type u)
   /-- The role of the situation TO. -/
   situation : Role
 
--- ════════════════════════════════════════════════════
--- § Aspect System
--- ════════════════════════════════════════════════════
+/-! ### Aspect System -/
 
 /-- An **aspect system**: a framework for relating event time to
     reference (situation) time.

--- a/Linglib/Semantics/Tense/TemporalAdverbials.lean
+++ b/Linglib/Semantics/Tense/TemporalAdverbials.lean
@@ -37,9 +37,7 @@ open Semantics.Tense.TenseAspectComposition
 
 variable {W Time : Type*} [LinearOrder Time]
 
--- ════════════════════════════════════════════════════
--- § PTS Constraints
--- ════════════════════════════════════════════════════
+/-! ### PTS Constraints -/
 
 /-- A constraint on the Perfect Time Span.
     Adverbials restrict which PTS intervals are admissible. -/
@@ -53,9 +51,7 @@ inductive AdverbialType where
   | inclusive   -- does not specify LB
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § Concrete Adverbials
--- ════════════════════════════════════════════════════
+/-! ### Concrete Adverbials -/
 
 /-- "ever since t₀": PTS must start at t₀.
     E.g., "has been running since Monday" → PTS.fst = Monday. -/
@@ -77,9 +73,7 @@ def always : PTSConstraint Time :=
 def before : PTSConstraint Time :=
   λ _ => True
 
--- ════════════════════════════════════════════════════
--- § LB Domain Extraction
--- ════════════════════════════════════════════════════
+/-! ### LB Domain Extraction -/
 
 /-- Convert a PTS constraint to a domain of compatible LB values,
     given that the right boundary is fixed at tc.
@@ -89,9 +83,7 @@ def before : PTSConstraint Time :=
 def PTSConstraint.toLBDomain (adv : PTSConstraint Time) (tc : Time) : Set Time :=
   { tLB | tLB ≤ tc ∧ ∀ (h : tLB ≤ tc), adv ⟨⟨tLB, tc⟩, h⟩ }
 
--- ════════════════════════════════════════════════════
--- § PERF with Adverbial
--- ════════════════════════════════════════════════════
+/-! ### PERF with Adverbial -/
 
 /-- Perfect with adverbial constraint: PERF_ADV(p, adv).
     Combines PERF with an adverbial constraint on the PTS.
@@ -99,9 +91,7 @@ def PTSConstraint.toLBDomain (adv : PTSConstraint Time) (tc : Time) : Set Time :
 def PERF_ADV (p : IntervalPred W Time) (adv : PTSConstraint Time) : PointPred W Time :=
   λ s => ∃ pts : NonemptyInterval Time, RB pts s.time ∧ adv pts ∧ p s.world pts
 
--- ════════════════════════════════════════════════════
--- § Adverbial Type Properties
--- ════════════════════════════════════════════════════
+/-! ### Adverbial Type Properties -/
 
 /-- Does this adverbial type specify the left boundary?
     Durative adverbials pin the LB; inclusive adverbials leave it free. -/
@@ -109,9 +99,7 @@ def AdverbialType.specifiesLB : AdverbialType → Bool
   | .durative => true
   | .inclusive => false
 
--- ════════════════════════════════════════════════════
--- § Bridge Theorems
--- ════════════════════════════════════════════════════
+/-! ### Bridge Theorems -/
 
 /-- PERF_ADV is equivalent to PERF_XN with the adverbial's derived LB domain.
 

--- a/Linglib/Semantics/Tense/TemporalConnectives/Basic.lean
+++ b/Linglib/Semantics/Tense/TemporalConnectives/Basic.lean
@@ -30,9 +30,7 @@ open NonemptyInterval
 
 variable {Time : Type*} [LinearOrder Time]
 
--- ============================================================================
--- § 1: Sentence Denotations as NonemptyInterval Sets
--- ============================================================================
+/-! ### Sentence Denotations as NonemptyInterval Sets -/
 
 /-- A sentence denotes a set of temporal intervals (its "run-times").
     Statives denote homogeneous interval sets; accomplishments denote singletons. -/
@@ -54,9 +52,7 @@ def stativeDenotation (i : NonemptyInterval Time) : SentDenotation Time :=
 def accomplishmentDenotation (i : NonemptyInterval Time) : SentDenotation Time :=
   { j | j = i }
 
--- ============================================================================
--- § 2: Basic Properties
--- ============================================================================
+/-! ### Basic Properties -/
 
 /-- Stative denotations are closed under subintervals (the subinterval property).
     This connects to Krifka's CUM (cumulative reference): if an interval is in

--- a/Linglib/Semantics/Tense/TemporalConnectives/EventBridge.lean
+++ b/Linglib/Semantics/Tense/TemporalConnectives/EventBridge.lean
@@ -35,9 +35,7 @@ open NonemptyInterval
 
 variable {Time : Type*} [LinearOrder Time]
 
--- ============================================================================
--- § 1: The Projection
--- ============================================================================
+/-! ### The Projection -/
 
 /-- The τ-image projection: the set of runtime intervals of events satisfying P.
 
@@ -48,9 +46,7 @@ variable {Time : Type*} [LinearOrder Time]
 def eventDenotation (P : Event Time → Prop) : SentDenotation Time :=
   { i | ∃ e, P e ∧ e.τ = i }
 
--- ============================================================================
--- § 2: Basic Properties
--- ============================================================================
+/-! ### Basic Properties -/
 
 /-- Empty predicate gives empty denotation. -/
 theorem eventDenotation_empty :
@@ -62,9 +58,7 @@ theorem eventDenotation_nonempty (P : Event Time → Prop) (e : Event Time) (he 
     e.τ ∈ eventDenotation P :=
   ⟨e, he, rfl⟩
 
--- ============================================================================
--- § 3: Time Trace Factoring
--- ============================================================================
+/-! ### Time Trace Factoring -/
 
 /-- The time trace of an event denotation factors through τ:
     a time is in the trace iff some event satisfying P has a runtime
@@ -82,9 +76,7 @@ theorem timeTrace_eventDenotation (P : Event Time → Prop) :
   · rintro ⟨e, he, hi⟩
     exact ⟨e.τ, ⟨e, he, rfl⟩, hi⟩
 
--- ============================================================================
--- § 4: Relationship to Canonical Denotation Patterns
--- ============================================================================
+/-! ### Relationship to Canonical Denotation Patterns -/
 
 /-- A singleton event predicate (exactly one event with runtime i) gives an
     accomplishment denotation. -/

--- a/Linglib/Semantics/Tense/TenseAspectComposition.lean
+++ b/Linglib/Semantics/Tense/TenseAspectComposition.lean
@@ -45,9 +45,7 @@ open Semantics.Aspect
 
 variable {W Time : Type*} [LinearOrder Time]
 
--- ════════════════════════════════════════════════════
--- § Tense Evaluation Operators
--- ════════════════════════════════════════════════════
+/-! ### Tense Evaluation Operators -/
 
 /-- Evaluate a point predicate at speech time (PRESENT).
     PRES: p holds at tc in world w. -/
@@ -64,9 +62,7 @@ def evalPast (p : PointPred W Time) (tc : Time) (w : W) : Prop :=
 def evalFut (p : PointPred W Time) (tc : Time) (w : W) : Prop :=
   ∃ t : Time, t > tc ∧ p ⟨w, t⟩
 
--- ════════════════════════════════════════════════════
--- § Composed Tense–Aspect Forms
--- ════════════════════════════════════════════════════
+/-! ### Composed Tense–Aspect Forms -/
 
 /-- **Simple present**: PRES(IMPF(V).atPoint).
     "John runs" = at speech time, ∃e with tc ⊂ τ(e) and V(e).
@@ -101,9 +97,7 @@ def presPerfProgXN (V : W → Event Time → Prop) (tᵣ : Set Time) (tc : Time)
 def pastPerfProg (V : W → Event Time → Prop) (tc : Time) (w : W) : Prop :=
   evalPast (PERF (IMPF V)) tc w
 
--- ════════════════════════════════════════════════════
--- § Unfold Theorems
--- ════════════════════════════════════════════════════
+/-! ### Unfold Theorems -/
 
 /-- Simple present unfolds to: ∃e, [tc,tc] ⊂ τ(e) ∧ V(w)(e). -/
 theorem simplePresent_unfold (V : W → Event Time → Prop) (tc : Time) (w : W) :
@@ -120,9 +114,7 @@ theorem presPerfProgXN_unfold (V : W → Event Time → Prop) (tᵣ : Set Time)
       LB tLB pts ∧ RB pts tc ∧ IMPF V w pts := by
   rfl
 
--- ════════════════════════════════════════════════════
--- § [knick-sharf-2026] Core Results
--- ════════════════════════════════════════════════════
+/-! ### [knick-sharf-2026] Core Results -/
 
 /-- **Theorem 3** ([knick-sharf-2026]): U-perf(tᵣ) entails simple present.
 

--- a/Linglib/Studies/Abusch1997.lean
+++ b/Linglib/Studies/Abusch1997.lean
@@ -404,7 +404,7 @@ theorem abusch_derives_embeddedSickSimultaneous :
 theorem abusch_derives_embeddedSickShifted :
     embeddedSickShifted.isPast := by
   simp only [ReichenbachFrame.isPast, embeddedSickShifted, shiftedFrame,
-    matrixSaid]; omega
+    Semantics.Tense.embeddedFrame, matrixSaid]; omega
 
 /-- The matrix "said" frame is perfective (E = R). -/
 theorem matrixSaid_is_perfective : matrixSaid.isPerfective := rfl

--- a/Linglib/Studies/Zhao2025.lean
+++ b/Linglib/Studies/Zhao2025.lean
@@ -26,7 +26,7 @@ level. The substrate-side treatment lives in `Core/Time/AtomDist.lean`
 (`AtomDist τ V`, with `EvQuant.ofPred` bridging from event predicates
 to event quantifiers); for the witness-universal subinterval form on
 event predicates, see `HasSubintervalProp` in
-`Semantics/Tense/Aspect/SubintervalProperty.lean`. The
+`Semantics/Aspect/SubintervalProperty.lean`. The
 unification: Zhao 2025's particle-licensing condition is the
 quantifier-level atomic-granularity stativity test along the time
 dimension. Bridging Fragment Bool fields to substrate `Prop`s for

--- a/Linglib/Syntax/Minimalist/Aspect.lean
+++ b/Linglib/Syntax/Minimalist/Aspect.lean
@@ -25,7 +25,7 @@ unchanged.
 
 ## What does NOT live here
 
-- The viewpoint-aspect denotation (`Semantics/Tense/Aspect/Core.lean`
+- The viewpoint-aspect denotation (`Semantics/Aspect/Basic.lean`
   `ViewpointType`). Travis, MacDonald, Tsai disagree on AspO denotation, so
   "AspP_outer hosts viewpoint aspect" is *not* a uniform substrate identity.
   Per-morpheme bridges live in the relevant Fragment files (e.g.,


### PR DESCRIPTION
Hygiene pass from the five-agent Tense API audit: 86 box banners → `### ` headers across 17 files; delete dead code (TensePhenomenon block, composeTense/satisfiesTense, GramTense.toRelation/inverseRelation, deletedTensePresup, duplicate frame constructors → delegations to embeddedFrame); fix bib-key confusion (kratzer-1998 vs heim-kratzer-1998, Partee vs Abusch on pronominal tense); remove six ghost-file references and four stale paths elsewhere; add `_def` simp lemmas + Decidable instances for the nine ReichenbachFrame predicates, GramTense.constrains, and applyTense.