### PR TITLE
refactor(Semantics/Tense): migrate namespaces to root-level Tense

### DIFF
--- a/Linglib/Core/Order/Relation.lean
+++ b/Linglib/Core/Order/Relation.lean
@@ -7,7 +7,7 @@ The point analogue of `AllenRelation` (which operates on intervals).
 A `Relation` is a domain-flavored selector over the standard partition
 of pairs of times: before, after, overlapping, ≤, ≥, unrestricted.
 
-Used by tense (`Semantics.Tense.GramTense.constrains` realizes the
+Used by tense (`GramTense.constrains` realizes the
 before/overlapping/after/notBefore cells), evidential semantics
 (`EPCondition.toRelation`), and modal-base time
 analyses (`MBTProfile.toRelation` in Huijsmans 2025) — each domain

--- a/Linglib/Fragments/English/TemporalDeictic.lean
+++ b/Linglib/Fragments/English/TemporalDeictic.lean
@@ -10,7 +10,7 @@ Lexical entry for English temporal "then", typed by `ThenAdverb`.
 
 namespace English.TemporalDeictic
 
-open Semantics.Tense
+open Tense
 
 /-- English "then" -/
 def then_ : ThenAdverb where

--- a/Linglib/Fragments/English/TemporalExpressions.lean
+++ b/Linglib/Fragments/English/TemporalExpressions.lean
@@ -33,7 +33,7 @@ in `Determiners.lean`):
 namespace English.TemporalExpressions
 
 open Features
-open Semantics.Tense.TemporalAdverbials (AdverbialType)
+open Tense.TemporalAdverbials (AdverbialType)
 open Typology.PolarityItem (PolarityType)
 
 -- ============================================================================

--- a/Linglib/Fragments/English/Tense.lean
+++ b/Linglib/Fragments/English/Tense.lean
@@ -31,7 +31,7 @@ evidential constraints to Lakoff's false-tense diagnostic.
 
 namespace English.Tense
 
-open Semantics.Tense.Evidential
+open _root_.Tense.Evidential
 
 -- ════════════════════════════════════════════════════
 -- § 1. Table 20: Simple Past, Present Progressive, Future
@@ -93,7 +93,7 @@ def nonfutureEntries : List TAMEEntry :=
 -- § 4. Tense Perspective Entries ([lakoff-1970])
 -- ════════════════════════════════════════════════════
 
-open Semantics.Tense
+open _root_.Tense
 open Morphology.Tense
 
 /-- A tense paradigm entry enriched with Lakoff's perspective dimensions:
@@ -159,8 +159,8 @@ theorem goingTo_blocks_false : goingTo.allowsFalseTense = false := rfl
 -- § 6. Kratzer Decomposition ([kratzer-1998])
 -- ════════════════════════════════════════════════════
 
-open Semantics.Tense.SOT.Decomposition
-open Semantics.Tense
+open _root_.Tense.SOT.Decomposition
+open _root_.Tense
 
 /-- English simple past: Kratzer decomposition.
     Surface "V-ed" = PRESENT tense + PERFECT aspect.

--- a/Linglib/Fragments/German/TemporalDeictic.lean
+++ b/Linglib/Fragments/German/TemporalDeictic.lean
@@ -10,7 +10,7 @@ Lexical entry for German "damals" (back then), typed by `ThenAdverb`.
 
 namespace German.TemporalDeictic
 
-open Semantics.Tense
+open Tense
 
 /-- German "damals" (back-then) -/
 def damals : ThenAdverb where

--- a/Linglib/Fragments/German/Tense.lean
+++ b/Linglib/Fragments/German/Tense.lean
@@ -26,8 +26,8 @@ has a PRESENT tense head (indexical-compatible).
 
 namespace German.Tense
 
-open Semantics.Tense
-open Semantics.Tense.SOT.Decomposition
+open _root_.Tense
+open _root_.Tense.SOT.Decomposition
 
 -- ════════════════════════════════════════════════════
 -- § 1. Kratzer Decomposition Entries

--- a/Linglib/Fragments/Greek/StandardModern/TemporalDeictic.lean
+++ b/Linglib/Fragments/Greek/StandardModern/TemporalDeictic.lean
@@ -11,7 +11,7 @@ Cross-linguistic evidence for the then-present incompatibility.
 
 namespace Greek.StandardModern.TemporalDeictic
 
-open Semantics.Tense
+open Tense
 
 /-- Greek τότε "tóte" -/
 def tote : ThenAdverb where

--- a/Linglib/Fragments/Hebrew/TemporalDeictic.lean
+++ b/Linglib/Fragments/Hebrew/TemporalDeictic.lean
@@ -11,7 +11,7 @@ Cross-linguistic evidence for the then-present incompatibility.
 
 namespace Hebrew.TemporalDeictic
 
-open Semantics.Tense
+open Tense
 
 /-- Hebrew אז "az" -/
 def az : ThenAdverb where

--- a/Linglib/Fragments/Hungarian/TemporalDeictic.lean
+++ b/Linglib/Fragments/Hungarian/TemporalDeictic.lean
@@ -27,7 +27,7 @@ reading in bare TP complements.
 
 namespace Hungarian.TemporalDeictic
 
-open Semantics.Tense
+open Tense
 
 /-- Hungarian *akkor* 'then' — perspective-shifting temporal deictic.
     Part of the cross-linguistic "then"-present incompatibility

--- a/Linglib/Fragments/Italian/Tense.lean
+++ b/Linglib/Fragments/Italian/Tense.lean
@@ -33,10 +33,10 @@ PERF head morphologically transparent.
 
 namespace Italian.Tense
 
-open Semantics.Tense.Evidential
-open Semantics.Tense.SOT.Decomposition
-open Semantics.Tense
-open Semantics.Tense
+open _root_.Tense.Evidential
+open _root_.Tense.SOT.Decomposition
+open _root_.Tense
+open _root_.Tense
 open Morphology.Tense
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Fragments/Japanese/TemporalDeictic.lean
+++ b/Linglib/Fragments/Japanese/TemporalDeictic.lean
@@ -10,7 +10,7 @@ Lexical entry for Japanese その時 "sono-toki" (that time), typed by `ThenAdve
 
 namespace Japanese.TemporalDeictic
 
-open Semantics.Tense
+open Tense
 
 /-- Japanese その時 "sono-toki" -/
 def sonotoki : ThenAdverb where

--- a/Linglib/Fragments/Korean/Evidentials.lean
+++ b/Linglib/Fragments/Korean/Evidentials.lean
@@ -21,7 +21,7 @@ This EP/UP factorization is verified in `Studies/Cumming2026.lean`.
 
 namespace Korean.Evidentials
 
-open Semantics.Tense.Evidential
+open Tense.Evidential
 
 -- ════════════════════════════════════════════════════
 -- § 1. Korean -te (Table 18)

--- a/Linglib/Fragments/Mandarin/TemporalDeictic.lean
+++ b/Linglib/Fragments/Mandarin/TemporalDeictic.lean
@@ -10,7 +10,7 @@ Lexical entry for Mandarin 那时 "nà-shí" (that time), typed by `ThenAdverb`.
 
 namespace Mandarin.TemporalDeictic
 
-open Semantics.Tense
+open Tense
 
 /-- Mandarin 那时 "nà-shí" -/
 def nashi : ThenAdverb where

--- a/Linglib/Fragments/Slavic/Bulgarian/Evidentials.lean
+++ b/Linglib/Fragments/Slavic/Bulgarian/Evidentials.lean
@@ -18,7 +18,7 @@ Table 17. The -l participle interacts with tense to encode evidential perspectiv
 
 namespace Bulgarian.Evidentials
 
-open Semantics.Tense.Evidential
+open Tense.Evidential
 
 /-- Bulgarian NFUT + -l: T ≤ A (downstream), T ≤ S (nonfuture). -/
 def nfutL : TAMEEntry where

--- a/Linglib/Fragments/Slavic/Russian/TemporalDeictic.lean
+++ b/Linglib/Fragments/Slavic/Russian/TemporalDeictic.lean
@@ -11,7 +11,7 @@ Cross-linguistic evidence for the then-present incompatibility.
 
 namespace Russian.TemporalDeictic
 
-open Semantics.Tense
+open Tense
 
 /-- Russian тогда "togda" -/
 def togda : ThenAdverb where

--- a/Linglib/Phenomena/TemporalConnectives/Compare.lean
+++ b/Linglib/Phenomena/TemporalConnectives/Compare.lean
@@ -43,7 +43,7 @@ scenario/connective combinations (Table 1 of [rett-2020]). They diverge on:
 
 namespace Phenomena.TemporalConnectives.Compare
 
-open Semantics.Tense.TemporalConnectives
+open Tense.TemporalConnectives
 open English.TemporalExpressions
 
 -- ============================================================================

--- a/Linglib/Semantics/Attitudes/SituationDependent.lean
+++ b/Linglib/Semantics/Attitudes/SituationDependent.lean
@@ -47,9 +47,8 @@ abbrev BAgentAccessRel (W E : Type*) := AccessRel W E
 -- § Core Types
 -- ════════════════════════════════════════════════════════════════
 
--- Situation-dependent proposition type (von Stechow's s(it), Prop-valued).
--- Re-exported from `Semantics.Tense` (the canonical definition).
-export Semantics.Tense (SitProp)
+-- Situation-dependent proposition type (von Stechow's s(it), Prop-valued):
+-- `SitProp` (root-level, defined in `Semantics/Tense/GramTense.lean`).
 
 /-- Situation-dependent accessibility relation: Dox_y(w,t) = {(w',t') |...}.
 
@@ -283,8 +282,8 @@ For example, an attitude verb might impose:
 These constraints are what make sequence-of-tense work: they tie the
 embedded clause's temporal interpretation to the matrix event time.
 
-See `Semantics.Tense.Basic` (embedded frames) and
-`Semantics.Tense.SOT.Decomposition` for the formal
+See `Tense.Basic` (embedded frames) and
+`Tense.SOT.Decomposition` for the formal
 connection between these temporal constraints and SOT readings.
 -/
 

--- a/Linglib/Semantics/Conditionals/Restrictor.lean
+++ b/Linglib/Semantics/Conditionals/Restrictor.lean
@@ -164,7 +164,7 @@ theorem conditional_K (f : ModalBase W) (g : OrderingSource W)
 
 /-! ## Prop-level bridge -/
 
-open Semantics.Tense.ConditionalShift (domainRestrictedConditional)
+open Tense.ConditionalShift (domainRestrictedConditional)
 
 /-- `conditionalNecessity` (with empty ordering source) corresponds to
     `domainRestrictedConditional` at the Prop level. -/

--- a/Linglib/Semantics/Context/Basic.lean
+++ b/Linglib/Semantics/Context/Basic.lean
@@ -86,7 +86,7 @@ def KContext.shiftWorldTime {W E P T : Type*} (c : KContext W E P T)
     default, [kiparsky-2002]); R and E are supplied per clause. -/
 def KContext.toReichenbachFrame {W E P T : Type*}
     (c : KContext W E P T) (R Ev : T) :
-    Semantics.Tense.Reichenbach.ReichenbachFrame T where
+    ReichenbachFrame T where
   speechTime := c.time
   perspectiveTime := c.time  -- root clause default: P = S
   referenceTime := R

--- a/Linglib/Semantics/Degree/Bounds.lean
+++ b/Linglib/Semantics/Degree/Bounds.lean
@@ -208,7 +208,7 @@ def IsMaxDetermined {α : Type*} (R : α → α → Prop) (f : Set α → Prop) 
     Each per-construction ambidirectionality theorem in the library is an
     instance of this template — they prove the shared-bound side condition
     for a specific `f` and a class of `B`'s, then this lemma packages the
-    result. See `Semantics.Tense.TemporalConnectives.before_preEvent_ambidirectional`
+    result. See `Tense.TemporalConnectives.before_preEvent_ambidirectional`
     for the canonical instance. -/
 theorem ambidirectional_of_shared_max {α : Type*} {R : α → α → Prop}
     (f : Set α → Prop) (hf : IsMaxDetermined R f) (B : Set α)

--- a/Linglib/Semantics/Dynamic/Core/ContextFilter.lean
+++ b/Linglib/Semantics/Dynamic/Core/ContextFilter.lean
@@ -19,7 +19,7 @@ filter — see `sep_isContextFilter` below, a thin restatement of
 This file also hosts `SitContext` — the carrier of situation-variable
 dynamic semantics — and `dynRelation`, the workhorse filter behind
 temporal trichotomy (`<`/`=`/`>` on `.time`, used to define
-`Semantics.Tense.dynPAST`/`dynPRES`/`dynFUT`).
+`Tense.dynPAST`/`dynPRES`/`dynFUT`).
 -/
 
 namespace Semantics.Dynamic.Core
@@ -86,7 +86,7 @@ holds between the two projected `WorldTimeIndex` values. The two
 common specializations are:
 
 - `dynRelation` (both projections look up bound variables `gs.1 v₁`,
-  `gs.1 v₂`) — used by `Semantics.Tense.dynPAST`/`dynPRES`/`dynFUT`.
+  `gs.1 v₂`) — used by `Tense.dynPAST`/`dynPRES`/`dynFUT`.
 - `Semantics.Mood.dynIND` (one projection is the entry's current
   situation `gs.2`, the other is a bound variable `gs.1 v`).
 
@@ -139,7 +139,7 @@ theorem dynRelationOn_contradictory {W Time : Type*}
 Filter a context by a binary relation on two situation-variable lookups.
 
 The "two bound variables" specialization of `dynRelationOn`. All temporal
-constraints (`Semantics.Tense.dynPAST`, `dynPRES`, `dynFUT`) are instances
+constraints (`Tense.dynPAST`, `dynPRES`, `dynFUT`) are instances
 of `dynRelation` with the appropriate ordering on `.time`.
 -/
 def dynRelation {W Time : Type*}

--- a/Linglib/Semantics/Modality/Exclusion.lean
+++ b/Linglib/Semantics/Modality/Exclusion.lean
@@ -62,8 +62,8 @@ open Semantics.Context (KContext ContextTower ContextShift RichContext
 open HistoricalAlternatives (historicalBase)
 open Semantics.Mood (subjShift)
 open Semantics.Reference.Kaplan (opActually_access opActually_shift_invariant)
-open Semantics.Tense (upperLimitConstraint)
-open Semantics.Tense.ConditionalShift (domainRestrictedConditional
+open Tense (upperLimitConstraint)
+open Tense.ConditionalShift (domainRestrictedConditional
   trivialConsequent nonTrivialConsequent
   trivial_domainRestricted expansion_resolves_triviality
   nontrivial_conditional_excludes)
@@ -404,7 +404,7 @@ theorem oMarking_hpShift_expanding
     (D : Set W) (h_domain : D ⊆ history ⟨w₀, t₀⟩) :
     D ⊆ history ⟨w₀, t'⟩ :=
   Set.Subset.trans h_domain
-    (Semantics.Tense.ConditionalShift.history_monotone_set
+    (Tense.ConditionalShift.history_monotone_set
       history h_bc ⟨w₀, t₀⟩ t' h_earlier)
 
 /-- The O-marking triviality problem: without domain expansion, the

--- a/Linglib/Semantics/Modality/ModalBaseKind.lean
+++ b/Linglib/Semantics/Modality/ModalBaseKind.lean
@@ -18,7 +18,6 @@ phenomena-layer study files. It depends only on `GramTense` from Core.
 
 namespace Semantics.Modality
 
-open Semantics.Tense (GramTense)
 
 /-- Classification of modal base temporal character.
     [klecha-2016] (35): DOX returns actual histories 𝒜_t, CIR returns

--- a/Linglib/Semantics/Mood/Basic.lean
+++ b/Linglib/Semantics/Mood/Basic.lean
@@ -60,7 +60,7 @@ abbrev SitPred (W Time : Type*) := WorldTimeIndex W Time → WorldTimeIndex W Ti
 The `sameWorld` kernel: two situations share their world coordinate.
 
 This is the modal counterpart of the temporal kernels
-(`Semantics.Tense.precedes`/`coincides`/`follows`). The static `IND`
+(`Tense.precedes`/`coincides`/`follows`). The static `IND`
 operator and its dynamic lift `Semantics.Mood.dynIND` both call this
 kernel; they share *the same modal constraint*, lifted from a static
 situation predicate to a context filter via
@@ -346,7 +346,7 @@ of the embedded clause from the default (speech time or matrix time) to a
 newly introduced temporal anchor.
 
 See `Semantics.Attitudes.SituationDependent` for the attitude side
-and `Semantics.Tense.SOT.Decomposition` for the formal connection.
+and `Tense.SOT.Decomposition` for the formal connection.
 -/
 
 section AttitudeTemporalAnchor

--- a/Linglib/Semantics/Tense/Basic.lean
+++ b/Linglib/Semantics/Tense/Basic.lean
@@ -20,10 +20,6 @@ SOT frame constructors.
 - `AttitudeTemporalSemantics`: how an attitude verb shifts eval time
 -/
 
-namespace Semantics.Tense
-
-open Semantics.Tense.Reichenbach
-
 /-! ### AttitudeTemporalSemantics -/
 
 /-- How an attitude verb shifts the evaluation time for its complement.
@@ -39,6 +35,22 @@ structure AttitudeTemporalSemantics (Time : Type*) where
   /-- The temporal constraint imposed on the embedded clause:
       embeddedRefTime must stand in this relation to the shifted eval time. -/
   embeddedConstraint : Time → Time → Prop
+
+/-- The two available readings for embedded past under past.
+
+    When past tense appears in the complement of a past-tense attitude verb,
+    the embedded past can be interpreted as:
+    - **shifted**: the embedded event occurred BEFORE the matrix event
+      (R' < P' = E_matrix)
+    - **simultaneous**: the embedded event occurred AT the matrix event time
+      (R' = P' = E_matrix), via SOT deletion ([ogihara-1989], §11.2 (83)) -/
+inductive EmbeddedTenseReading where
+  | shifted       -- embedded event BEFORE matrix event (back-shifted)
+  | simultaneous  -- embedded event AT matrix event time (SOT deletion)
+  deriving DecidableEq, Repr, Inhabited
+
+namespace Tense
+
 
 /-- Standard eval time shift: embedded eval time = matrix event time.
     This is the default across all six theories. -/
@@ -66,19 +78,6 @@ def embeddedFrame {Time : Type*} (matrixFrame : ReichenbachFrame Time)
 
 
 /-! ### Embedded Tense Readings -/
-
-/-- The two available readings for embedded past under past.
-
-    When past tense appears in the complement of a past-tense attitude verb,
-    the embedded past can be interpreted as:
-    - **shifted**: the embedded event occurred BEFORE the matrix event
-      (R' < P' = E_matrix)
-    - **simultaneous**: the embedded event occurred AT the matrix event time
-      (R' = P' = E_matrix), via SOT deletion ([ogihara-1989], §11.2 (83)) -/
-inductive EmbeddedTenseReading where
-  | shifted       -- embedded event BEFORE matrix event (back-shifted)
-  | simultaneous  -- embedded event AT matrix event time (SOT deletion)
-  deriving DecidableEq, Repr, Inhabited
 
 /-- Available readings depend on the SOT parameter of the language.
 
@@ -240,7 +239,7 @@ theorem simultaneous_satisfies_ulc {Time : Type*} [Preorder Time]
 /-!
 ### TensePronoun Projections onto SOT Frames
 
-The `TensePronoun` type in `Semantics.Tense` unifies the five views of tense.
+The `TensePronoun` type in `Tense` unifies the five views of tense.
 The following theorems show that `simultaneousFrame` and `shiftedFrame`
 are projections of specific tense pronouns — a bound present pronoun gives
 the simultaneous reading; a free past pronoun gives the shifted reading.
@@ -280,7 +279,7 @@ theorem shiftedFrame_from_tense_pronoun {Time : Type*}
 /-- Double-access: present-under-past requires the complement
     to hold at BOTH speech time AND matrix event time.
 
-    This bridges the `doubleAccess` definition from `Semantics.Tense` to the
+    This bridges the `doubleAccess` definition from `Tense` to the
     SOT analysis: the present-under-past frame's R = P (simultaneous),
     and the speech time is independently accessible via indexical rigidity. -/
 theorem doubleAccess_present_under_past {Time : Type*} [LinearOrder Time]
@@ -319,4 +318,4 @@ structure ThenAdverb where
   deriving Repr, DecidableEq
 
 
-end Semantics.Tense
+end Tense

--- a/Linglib/Semantics/Tense/Compositional.lean
+++ b/Linglib/Semantics/Tense/Compositional.lean
@@ -14,11 +14,10 @@ Following [partee-1973], tenses are pronoun-like: they retrieve temporal
 reference points rather than quantify over all times.
 -/
 
-namespace Semantics.Tense
+namespace Tense
 
 open Core (WorldTimeIndex)
 
-open Semantics.Tense.Reichenbach
 
 
 /--
@@ -277,4 +276,4 @@ example : FUT (raining Unit) ⟨(), 1⟩ ⟨(), 0⟩ := by
 
 end Examples
 
-end Semantics.Tense
+end Tense

--- a/Linglib/Semantics/Tense/ConditionalShift.lean
+++ b/Linglib/Semantics/Tense/ConditionalShift.lean
@@ -30,11 +30,11 @@ while preserving the Context of Thought θ (= `tower.origin`).
 
 -/
 
-namespace Semantics.Tense.ConditionalShift
+namespace Tense.ConditionalShift
 
 open Core (WorldTimeIndex)
 
-open Semantics.Tense
+open Tense
 open Semantics.Context (RichContext KContext ContextTower ContextShift
   hpShift DomainExpanding)
 open HistoricalAlternatives
@@ -255,4 +255,4 @@ theorem subj_subsumes_hp_expansion
 
 end SubjBridge
 
-end Semantics.Tense.ConditionalShift
+end Tense.ConditionalShift

--- a/Linglib/Semantics/Tense/DeRe.lean
+++ b/Linglib/Semantics/Tense/DeRe.lean
@@ -46,7 +46,7 @@ live in `Studies/Abusch1997.lean`.
   `isAcquaintedWith`. The temporal-de-re reading is the
   `Idx := KContext, Res := T` instance of the same acquaintance machinery
   PLA uses for individual de re (`Semantics/Dynamic/PLA/Belief.lean`).
-- `Semantics.Tense.TensePronoun.fullPresupposition` — the value-level
+- `TensePronoun.fullPresupposition` — the value-level
   shadow this file connects to (the deleted `TemporalDeRe` triple was a
   shadow of *this* shadow; see the `isFelicitousWith_iff_…` theorem
   below for the bridge).
@@ -97,12 +97,11 @@ live in `Studies/Abusch1997.lean`.
   `Studies/Abusch1997.lean`.
 -/
 
-namespace Semantics.Tense.DeRe
+namespace Tense.DeRe
 
 open Core (Intension WorldTimeIndex)
 open Semantics.Context (KContext)
 open HistoricalAlternatives (actualHistoryBase)
-open Semantics.Tense (TensePronoun GramTense TemporalAssignment)
 
 
 /-! ### Time-concepts and entity-concepts -/
@@ -319,4 +318,4 @@ theorem actualRes_isTemporallyAcquaintedWith
 
 end TemporalDeReReading
 
-end Semantics.Tense.DeRe
+end Tense.DeRe

--- a/Linglib/Semantics/Tense/Domain.lean
+++ b/Linglib/Semantics/Tense/Domain.lean
@@ -32,7 +32,7 @@ or sector classification. `Domain` is the substrate; the
 domain-shaped theories build on top.
 -/
 
-namespace Semantics.Tense
+namespace Tense
 
 
 /-! ### Times of Orientation -/
@@ -202,4 +202,4 @@ def ofReichenbachPoints (S P R E : Time) : Domain Time Orientation where
 
 end Domain
 
-end Semantics.Tense
+end Tense

--- a/Linglib/Semantics/Tense/Dynamic.lean
+++ b/Linglib/Semantics/Tense/Dynamic.lean
@@ -67,7 +67,7 @@ realization pattern for SUBJ/IND). Used by
 Subordinate Future.
 -/
 
-namespace Semantics.Tense
+namespace Tense
 
 open _root_.Core (Assignment WorldTimeIndex)
 open Semantics.Dynamic.Core
@@ -184,4 +184,4 @@ theorem dynPAST_transitive {W Time : Type*} [Preorder Time]
     (R₃ := fun s₁ s₂ => s₁.time < s₂.time)
     (fun _ _ _ h1 h2 => lt_trans h1 h2) e r s c gs h
 
-end Semantics.Tense
+end Tense

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -52,11 +52,10 @@ classification in `Features.Evidentiality`. `EPCondition.IsNonfuture` and
 
 -/
 
-namespace Semantics.Tense.Evidential
+namespace Tense.Evidential
 
 open Core.Order
-open Semantics.Tense.Reichenbach
-open Semantics.Tense
+open Tense
 open Features.Evidentiality
 open Features.Mirativity
 open Semantics.Presupposition
@@ -321,4 +320,4 @@ theorem downstream_preserved_by_nondecreasing_shift [Preorder T]
 
 end TowerEvidential
 
-end Semantics.Tense.Evidential
+end Tense.Evidential

--- a/Linglib/Semantics/Tense/GramTense.lean
+++ b/Linglib/Semantics/Tense/GramTense.lean
@@ -36,10 +36,7 @@ and `Attitudes/` theories build on. The temporal primitives it imports
 
 -/
 
-namespace Semantics.Tense
-
 open Core.Order
-open Semantics.Tense.Reichenbach
 open Core.ReferentialMode (ReferentialMode)
 open Core (Assignment WorldTimeIndex)
 
@@ -151,6 +148,8 @@ abbrev TenseInterpretation := Core.ReferentialMode.ReferentialMode
     The temporal analogue of H&K's `Assignment` (`ℕ → Entity`). -/
 abbrev TemporalAssignment (Time : Type*) := Assignment Time
 
+namespace Tense
+
 /-- Modified temporal assignment `g[n ↦ t]`. Specializes `Function.update`. -/
 abbrev updateTemporal {Time : Type*} (g : TemporalAssignment Time)
     (n : ℕ) (t : Time) : TemporalAssignment Time :=
@@ -192,6 +191,10 @@ theorem zeroTense_receives_binder_time {Time : Type*}
     interpTense n (updateTemporal g n binderTime) = binderTime :=
   Function.update_self n binderTime g
 
+
+end Tense
+
+open Tense
 
 /-! ### SitProp (Prop-valued) -/
 
@@ -283,6 +286,8 @@ def TensePronoun.fullPresupposition {Time : Type*} [LinearOrder Time]
     (tp : TensePronoun) (g : TemporalAssignment Time) : Prop :=
   tp.constraint.constrains (tp.resolve g) (tp.evalTime g)
 
+namespace Tense
+
 /-- When evalTimeIndex = 0 and g(0) = speechTime, the evaluation time is speech time.
     This is the root-clause default: tense is checked against speech time. -/
 theorem evalTime_root_is_speech {Time : Type*}
@@ -300,6 +305,8 @@ theorem evalTime_shifts_under_embedding {Time : Type*}
   show interpTense tp.evalTimeIndex
     (updateTemporal g tp.evalTimeIndex matrixEventTime) = matrixEventTime
   exact zeroTense_receives_binder_time g tp.evalTimeIndex matrixEventTime
+
+end Tense
 
 /-- Resolving a bound tense under binding yields the binder time. -/
 theorem TensePronoun.bound_resolve_eq_binder {Time : Type*}
@@ -319,12 +326,16 @@ theorem TensePronoun.bound_present_simultaneous {Time : Type*}
   simp only [TensePronoun.toFrame, ReichenbachFrame.isPresent]
   exact hBind
 
+namespace Tense
+
 /-- Double-access: present-under-past requires the complement
     to hold at BOTH speech time (indexical rigidity) AND matrix event time
     (attitude accessibility). -/
 def doubleAccess {Time : Type*} (p : Time → Prop)
     (speechTime matrixEventTime : Time) : Prop :=
   p speechTime ∧ p matrixEventTime
+
+end Tense
 
 /-- An indexical present tense presupposes resolution to speech time. -/
 theorem TensePronoun.indexical_present_at_speech {Time : Type*} [LinearOrder Time]
@@ -397,6 +408,8 @@ into the tower: when the temporal assignment encodes tower time coordinates
   agrees with `AccessPattern.resolve`
 - `tense_root_bridge` — root clause: `evalTimeIndex = 0` means origin time
 - `von_stechow_tower` — pushing a temporal shift = Von Stechow's perspective shift -/
+
+namespace Tense
 
 section TemporalBridge
 
@@ -498,4 +511,4 @@ theorem von_stechow_tower_innermost
 
 end TemporalBridge
 
-end Semantics.Tense
+end Tense

--- a/Linglib/Semantics/Tense/LexicalType.lean
+++ b/Linglib/Semantics/Tense/LexicalType.lean
@@ -33,7 +33,7 @@ The cross-linguistic typology ((98), (99)) lives in
 `Studies/Sharvit2014.lean`.
 -/
 
-namespace Semantics.Tense
+namespace Tense
 
 /-- [sharvit-2014]'s two semantic types for tense lexical items
     ((30), p. 274). -/
@@ -80,4 +80,4 @@ theorem quantificationalPast_mono {Time : Type*} [LT Time]
   rintro ⟨t', htK, hlt, hp⟩
   exact ⟨t', htK, hlt, h _ hp⟩
 
-end Semantics.Tense
+end Tense

--- a/Linglib/Semantics/Tense/Orientation.lean
+++ b/Linglib/Semantics/Tense/Orientation.lean
@@ -32,7 +32,7 @@ Declerck → {utterance, situation, perspective, sub n}) live with the
 respective framework files.
 -/
 
-namespace Semantics.Tense
+namespace Tense
 
 /-- The universal vocabulary of orientation times in modern tense theory.
     See the module docstring for the framework-mapping and citations. -/
@@ -52,4 +52,4 @@ inductive Orientation where
   | sub (n : Nat)
   deriving DecidableEq, Repr, Inhabited
 
-end Semantics.Tense
+end Tense

--- a/Linglib/Semantics/Tense/Perspective.lean
+++ b/Linglib/Semantics/Tense/Perspective.lean
@@ -36,12 +36,11 @@ Tenses are presupposition triggers anchored to π:
 
 -/
 
-namespace Semantics.Tense.Perspective
+namespace Tense.Perspective
 
-open Semantics.Tense.Reichenbach
 open Semantics.Presupposition
 open Semantics.Context (KContext)
-open Semantics.Tense
+open Tense
 
 
 /-! ### Tense Presuppositions -/
@@ -258,4 +257,4 @@ theorem InterpParams.shiftPerspective_matches_opPi {W E P T : Type*}
   simp only [opPi, InterpParams.shiftPerspective]
 
 
-end Semantics.Tense.Perspective
+end Tense.Perspective

--- a/Linglib/Semantics/Tense/Reichenbach.lean
+++ b/Linglib/Semantics/Tense/Reichenbach.lean
@@ -20,7 +20,7 @@ Tense relates R to P; Aspect relates E to R.
 
 `ReichenbachFrame` is the four-slot point-time record used throughout
 linglib's tense modules. The `toDomain` builder lifts it to a generic
-`Semantics.Tense.Domain` (central = S, sub-TOs = [P, R, E], all as point
+`Tense.Domain` (central = S, sub-TOs = [P, R, E], all as point
 intervals via `TO.pure`). The `*_iff_relatedByName` bridge theorems
 re-express each predicate (`isPast`, `isPerfect`, …) as a
 `Domain.relatedByName` query against named atom-sets from the Allen
@@ -31,8 +31,7 @@ existing four-field record — downstream call sites continue to use
 work with `f.toDomain` and `relatedByName`.
 -/
 
-namespace Semantics.Tense.Reichenbach
-
+open Tense (Domain Orientation TO)
 open AllenRelation (precedesSet equalSet)
 
 /--
@@ -331,5 +330,3 @@ instance reichenbachFrame_aspectSystem {Time : Type*} [LinearOrder Time] :
   toDomain := ReichenbachFrame.toDomain
   event := .situation
   reference := .topic
-
-end Semantics.Tense.Reichenbach

--- a/Linglib/Semantics/Tense/SOT/Ambiguity.lean
+++ b/Linglib/Semantics/Tense/SOT/Ambiguity.lean
@@ -21,7 +21,7 @@ it; theories that don't share Ogihara's ambiguity thesis simply don't
 import this file.
 -/
 
-namespace Semantics.Tense.SOT.Ambiguity
+namespace Tense.SOT.Ambiguity
 
 
 /-- Two readings of past morphology in embedded contexts (Ogihara). -/
@@ -43,4 +43,4 @@ theorem genuinePast_ne_zeroTense :
     PastReading.genuinePast ≠ PastReading.zeroTense := nofun
 
 
-end Semantics.Tense.SOT.Ambiguity
+end Tense.SOT.Ambiguity

--- a/Linglib/Semantics/Tense/SOT/Decomposition.lean
+++ b/Linglib/Semantics/Tense/SOT/Decomposition.lean
@@ -40,10 +40,9 @@ and simultaneous readings) but differ on what "past" means:
 
 -/
 
-namespace Semantics.Tense.SOT.Decomposition
+namespace Tense.SOT.Decomposition
 
-open Semantics.Tense
-open Semantics.Tense.Reichenbach
+open Tense
 
 
 /-! ### SOT Deletion -/
@@ -160,7 +159,7 @@ discourse-salient temporal antecedent. This explains the striking contrast:
   German: #"Ich schaltete den Herd nicht aus." ✗ (needs narrative context)
   German: "Ich habe den Herd nicht ausgeschaltet." ✓ (present perfect ok) -/
 
-open Semantics.Tense.TenseAspectComposition
+open Tense.TenseAspectComposition
 open Semantics.Aspect
 
 /-- Kratzer's English simple past = PRESENT tense + PERFECT aspect.
@@ -230,7 +229,7 @@ uniformly to pronouns and tenses:
   - Persian: zero PRONOUNS (locally bound by Agr) but NOT zero TENSE
     (tense is in C, outside the local domain of Agr in Infl)
 
-The distribution of overt vs. zero follows from `Semantics.Tense.Overtness`. -/
+The distribution of overt vs. zero follows from `Overtness`. -/
 
 /-- Zero tense: a bound present tense in a local agreement domain.
 
@@ -249,7 +248,7 @@ def kratzerZeroTense (n : ℕ) : TensePronoun where
 theorem zero_tense_is_present (n : ℕ) :
     (kratzerZeroTense n).constraint = .present := rfl
 
-/-- Zero tense surfaces as zero (from Semantics.Tense.Overtness). -/
+/-- Zero tense surfaces as zero (from Overtness). -/
 theorem zero_tense_overtness (n : ℕ) :
     Overtness.fromBinding (kratzerZeroTense n).mode true = .zero := rfl
 
@@ -291,4 +290,4 @@ theorem english_indexical_always_overt (localDomain : Bool) :
   cases localDomain <;> rfl
 
 
-end Semantics.Tense.SOT.Decomposition
+end Tense.SOT.Decomposition

--- a/Linglib/Semantics/Tense/System.lean
+++ b/Linglib/Semantics/Tense/System.lean
@@ -7,7 +7,7 @@ import Linglib.Semantics.Tense.Domain
 Type classes that abstract over specific tense and aspect frameworks.
 `TenseSystem α Time Role` says "the type `α` is a way of describing
 tense over a `Time` line, using `Role` as its TO vocabulary"; it
-commits to (i) how to lift `α` into a `Semantics.Tense.Domain` and (ii)
+commits to (i) how to lift `α` into a `Tense.Domain` and (ii)
 which two roles its tense operators target (the *anchor* and
 *situation* TOs). `AspectSystem α Time Role` is the analogous
 abstraction for the event/reference relation.
@@ -29,7 +29,7 @@ is the main parameter; `Time` and `Role` are `outParam`s, so writing
 TenseSystem interpretation per schema type.
 -/
 
-namespace Semantics.Tense
+open Tense (Domain)
 
 universe u v w
 
@@ -39,7 +39,7 @@ universe u v w
     relative to a discourse anchor.
 
     Each instance commits to:
-    - `toDomain`: how to lift the schema into a `Semantics.Tense.Domain`
+    - `toDomain`: how to lift the schema into a `Tense.Domain`
     - `anchor`: the role of the *anchor* TO (the TO that tense locates
       the situation against). For [reichenbach-1947] (extended with
       Kiparsky's P) this is `.perspective`; for [declerck-1991] the
@@ -67,7 +67,7 @@ class TenseSystem (α : Type u)
     reference (situation) time.
 
     Each instance commits to:
-    - `toDomain`: how to lift the schema into a `Semantics.Tense.Domain`
+    - `toDomain`: how to lift the schema into a `Tense.Domain`
     - `event`: the role of the event TO (Reichenbach: `.situation` (E);
       Declerck: `.situation` (TS))
     - `reference`: the role of the reference TO (Reichenbach: `.topic`
@@ -84,5 +84,3 @@ class AspectSystem (α : Type u)
   event : Role
   /-- The role of the reference TO. -/
   reference : Role
-
-end Semantics.Tense

--- a/Linglib/Semantics/Tense/TemporalAdverbials.lean
+++ b/Linglib/Semantics/Tense/TemporalAdverbials.lean
@@ -29,11 +29,11 @@ restriction on LB values, which feeds directly into `PERF_XN`.
 
 import Linglib.Semantics.Tense.TenseAspectComposition
 
-namespace Semantics.Tense.TemporalAdverbials
+namespace Tense.TemporalAdverbials
 
-open Core.Order Semantics.Tense
+open Core.Order Tense
 open Semantics.Aspect
-open Semantics.Tense.TenseAspectComposition
+open Tense.TenseAspectComposition
 
 variable {W Time : Type*} [LinearOrder Time]
 
@@ -170,4 +170,4 @@ theorem inclusive_no_u_license (V : W → Event Time → Prop) (tc : Time) (w : 
     presPerfProgXN V Set.univ tc w ↔ simplePresent V tc w :=
   broad_focus_equiv V tc w
 
-end Semantics.Tense.TemporalAdverbials
+end Tense.TemporalAdverbials

--- a/Linglib/Semantics/Tense/TemporalConnectives/Basic.lean
+++ b/Linglib/Semantics/Tense/TemporalConnectives/Basic.lean
@@ -24,7 +24,7 @@ Level 1: Set Time (point sets)
 
 -/
 
-namespace Semantics.Tense.TemporalConnectives
+namespace Tense.TemporalConnectives
 
 open NonemptyInterval
 
@@ -102,4 +102,4 @@ theorem timeTrace_accomplishmentDenotation (i : NonemptyInterval Time) :
   · rintro ⟨hs, hf⟩
     exact ⟨i, rfl, hs, hf⟩
 
-end Semantics.Tense.TemporalConnectives
+end Tense.TemporalConnectives

--- a/Linglib/Semantics/Tense/TemporalConnectives/Before.lean
+++ b/Linglib/Semantics/Tense/TemporalConnectives/Before.lean
@@ -34,9 +34,9 @@ existential), so its body in `before^{B&C}` is constant in `t` and IPF
 does not arise.
 -/
 
-namespace Semantics.Tense.TemporalConnectives.Before
+namespace Tense.TemporalConnectives.Before
 
-open Semantics.Tense (LexicalType quantificationalPast)
+open Tense (LexicalType quantificationalPast)
 
 variable {Time : Type*} [LinearOrder Time]
 
@@ -84,4 +84,4 @@ def triggersIPFInBefore : LexicalType → Bool
     triggersIPFInBefore τ = false ↔ τ = .pronominal := by
   cases τ <;> simp [triggersIPFInBefore]
 
-end Semantics.Tense.TemporalConnectives.Before
+end Tense.TemporalConnectives.Before

--- a/Linglib/Semantics/Tense/TemporalConnectives/EventBridge.lean
+++ b/Linglib/Semantics/Tense/TemporalConnectives/EventBridge.lean
@@ -29,7 +29,7 @@ and point-level theories (Anscombe).
 
 -/
 
-namespace Semantics.Tense.TemporalConnectives
+namespace Tense.TemporalConnectives
 
 open NonemptyInterval
 
@@ -100,4 +100,4 @@ theorem eventDenotation_sub_stative (i : NonemptyInterval Time) (P : Event Time 
   rw [← hj]
   exact hP e he
 
-end Semantics.Tense.TemporalConnectives
+end Tense.TemporalConnectives

--- a/Linglib/Semantics/Tense/TenseAspectComposition.lean
+++ b/Linglib/Semantics/Tense/TenseAspectComposition.lean
@@ -36,7 +36,7 @@ The eval* operators instantiate the situation (fixing world and time).
 import Linglib.Semantics.Aspect.Basic
 import Linglib.Semantics.Tense.Compositional
 
-namespace Semantics.Tense.TenseAspectComposition
+namespace Tense.TenseAspectComposition
 
 open Core (WorldTimeIndex)
 
@@ -260,4 +260,4 @@ theorem earlier_lb_not_weaker_impf :
   simp only [LB, Event.τ] at hLB hS1
   omega
 
-end Semantics.Tense.TenseAspectComposition
+end Tense.TenseAspectComposition

--- a/Linglib/Studies/Abusch1997.lean
+++ b/Linglib/Studies/Abusch1997.lean
@@ -23,13 +23,13 @@ Two derivation styles coexist in this file:
 
 2. **Centered-world substrate** (`abusch_derives_*_via_acquaintance` /
    `_full` / `_full_metaphysical` against
-   `Semantics.Tense.DeRe.TemporalDeReReading`): `Intension (KContext)
+   `Tense.DeRe.TemporalDeReReading`): `Intension (KContext)
    Time` time-concept + holder-context base anchor + modal-alternative
    quantification over a `Set (WorldTimeIndex W Time)`. The Abusch §3 +
    def. 13 architecture, faithful to the [lewis-1979-attitudes] /
    [cresswell-vonstechow-1982] centered-world reduction of de re.
    The two styles are bridged by
-   `Semantics.Tense.DeRe.TemporalDeReReading.isFelicitousWith_iff_tensePronoun_fullPresupposition`.
+   `Tense.DeRe.TemporalDeReReading.isFelicitousWith_iff_tensePronoun_fullPresupposition`.
 
 The substrate is modal-base-agnostic and holder-now-honest:
 `holderContext.time` is the holder's now (per §7 ULC), and
@@ -40,7 +40,7 @@ constructors). See `Tense/DeRe.lean` docstring for what's deferred
 
 ## Core Mechanisms
 
-1. **Tense as pronoun**: `TensePronoun` (in `Semantics.Tense`) with
+1. **Tense as pronoun**: `TensePronoun` (in `Tense`) with
    variable index, constraint, and binding mode.
 2. **Upper Limit Constraint (ULC)**: stated by [abusch-1997] §7
    ("the now of an epistemic alternative is an upper limit for the
@@ -58,7 +58,7 @@ constructors). See `Tense/DeRe.lean` docstring for what's deferred
    acquaintance-relation machinery (Lewis 1979 / Cresswell-von Stechow
    1982) is not formalized here.
 4. **Eval-time shift via attitude embedding**: the substrate primitives
-   are `Semantics.Tense.evalTime_shifts_under_embedding` and
+   are `Tense.evalTime_shifts_under_embedding` and
    `updateTemporal`. Abusch's "relation transmission" (feature passing
    of relation variables PAST/PRES across embedding) is *not* what this
    file currently captures — we only model the value-level eval-time
@@ -91,9 +91,7 @@ constructors). See `Tense/DeRe.lean` docstring for what's deferred
 
 namespace Abusch1997
 
-open Semantics.Tense
-open Semantics.Tense.Reichenbach
-open Semantics.Tense
+open Tense
 open Data.Examples (LinguisticExample)
 
 -- BEGIN GENERATED EXAMPLES
@@ -266,7 +264,7 @@ theorem abusch_derives_temporal_de_re {Time : Type*} [LinearOrder Time]
     not required for the value-level shadow. -/
 theorem abusch_derives_temporal_de_re_via_acquaintance
     {W E P Time : Type*} [LinearOrder Time]
-    (dr : Semantics.Tense.DeRe.TemporalDeReReading W E P Time)
+    (dr : Tense.DeRe.TemporalDeReReading W E P Time)
     (hBefore : dr.actualRes < dr.holderContext.time) :
     dr.isFelicitousWith .past := hBefore
 
@@ -284,13 +282,13 @@ theorem abusch_derives_temporal_de_re_via_acquaintance
     free" when the res is identified by a name-like rigid concept. -/
 theorem abusch_derives_temporal_de_re_full
     {W E P Time : Type*} [LinearOrder Time]
-    (dr : Semantics.Tense.DeRe.TemporalDeReReading W E P Time)
+    (dr : Tense.DeRe.TemporalDeReReading W E P Time)
     (hRigid : Core.Intension.IsRigid dr.concept)
     (alternatives : Set (Core.WorldTimeIndex W Time))
     (hBefore : dr.actualRes < dr.holderContext.time) :
     dr.isAbuschFelicitous alternatives .past := by
   refine ⟨hBefore, ?_⟩
-  exact Semantics.Tense.DeRe.TemporalDeReReading.IsRigidAcrossAlternatives_of_concept_isRigid
+  exact Tense.DeRe.TemporalDeReReading.IsRigidAcrossAlternatives_of_concept_isRigid
     dr hRigid alternatives
 
 /-- **Metaphysical-instantiation specialization** of
@@ -300,7 +298,7 @@ theorem abusch_derives_temporal_de_re_full
     compatibility with Klecha 2016 DOX-shaped reasoning. -/
 theorem abusch_derives_temporal_de_re_full_metaphysical
     {W E P Time : Type*} [LinearOrder Time]
-    (dr : Semantics.Tense.DeRe.TemporalDeReReading W E P Time)
+    (dr : Tense.DeRe.TemporalDeReReading W E P Time)
     (hRigid : Core.Intension.IsRigid dr.concept)
     (history : HistoricalAlternatives W Time)
     (hBefore : dr.actualRes < dr.holderContext.time) :
@@ -404,7 +402,7 @@ theorem abusch_derives_embeddedSickSimultaneous :
 theorem abusch_derives_embeddedSickShifted :
     embeddedSickShifted.isPast := by
   simp only [ReichenbachFrame.isPast, embeddedSickShifted, shiftedFrame,
-    Semantics.Tense.embeddedFrame, matrixSaid]; omega
+    Tense.embeddedFrame, matrixSaid]; omega
 
 /-- The matrix "said" frame is perfective (E = R). -/
 theorem matrixSaid_is_perfective : matrixSaid.isPerfective := rfl

--- a/Linglib/Studies/AlstottAravind2026TemporalConnectives.lean
+++ b/Linglib/Studies/AlstottAravind2026TemporalConnectives.lean
@@ -53,7 +53,7 @@ INCHOAT / COMPLET Fragment.triggeredCoercion
 namespace AlstottAravind2026TemporalConnectives
 
 open Features
-open Semantics.Tense.TemporalConnectives
+open Tense.TemporalConnectives
 open English.TemporalExpressions
 open Phenomena.TemporalConnectives.AspectInteractionData
 open Core.Order

--- a/Linglib/Studies/AnandNevins2004.lean
+++ b/Linglib/Studies/AnandNevins2004.lean
@@ -222,7 +222,7 @@ theorem fid_time_eq_direct :
 -- ============================================================================
 
 /-! Bridge from [anand-nevins-2004]'s shifty-operator framework to
-    `Semantics.Tense.DeRe.EntityConcept` — the substrate's
+    `Tense.DeRe.EntityConcept` — the substrate's
     individual-side de re intension. The existing FIDProfile-based
     formalization above and the substrate's `EntityConcept`-based
     formalization are two perspectives on the same phenomenon; the
@@ -239,7 +239,7 @@ theorem fid_time_eq_direct :
     `entityConcept_and_timeConcept_share_isRigid_substrate` theorem
     below makes that claim kernel-checked. -/
 
-open Semantics.Tense.DeRe (EntityConcept TimeConcept)
+open Tense.DeRe (EntityConcept TimeConcept)
 
 /-- **Kaplan-compliant "I"** as a rigid `EntityConcept`.
 

--- a/Linglib/Studies/Anscombe1964.lean
+++ b/Linglib/Studies/Anscombe1964.lean
@@ -21,7 +21,7 @@ of the veridicality contrast.
 
 -/
 
-namespace Semantics.Tense.TemporalConnectives
+namespace Tense.TemporalConnectives
 
 
 variable {Time : Type*} [LinearOrder Time]
@@ -232,7 +232,7 @@ theorem npi_licensing_from_monotonicity (A B B' : SentDenotation Time) :
     (timeTrace B ⊆ timeTrace B' → Anscombe.after A B → Anscombe.after A B') :=
   ⟨Anscombe.before_complement_DE A B B', Anscombe.after_complement_UE A B B'⟩
 
-end Semantics.Tense.TemporalConnectives
+end Tense.TemporalConnectives
 
 /-!
 # Event-Level Temporal Connectives
@@ -270,7 +270,7 @@ while the event-level version requires entire-runtime precedence (`-precedence).
 
 -/
 
-namespace Semantics.Tense.TemporalConnectives
+namespace Tense.TemporalConnectives
 
 open NonemptyInterval
 
@@ -431,4 +431,4 @@ theorem anscombe_after_not_implies_event :
   obtain ⟨e₁, e₂, rfl, rfl, hprec⟩ := host
   simp [precedes, Event.τ, eP, eQ] at hprec
 
-end Semantics.Tense.TemporalConnectives
+end Tense.TemporalConnectives

--- a/Linglib/Studies/ArreguiKusumoto1998.lean
+++ b/Linglib/Studies/ArreguiKusumoto1998.lean
@@ -58,7 +58,6 @@ example.
 
 namespace ArreguiKusumoto1998
 
-open Semantics.Tense.Reichenbach
 open Data.Examples (LinguisticExample)
 
 -- BEGIN GENERATED EXAMPLES

--- a/Linglib/Studies/BeaverCondoravdi2003.lean
+++ b/Linglib/Studies/BeaverCondoravdi2003.lean
@@ -43,7 +43,7 @@ across historical alternatives.
 
 -/
 
-namespace Semantics.Tense.TemporalConnectives.BeaverCondoravdi
+namespace Tense.TemporalConnectives.BeaverCondoravdi
 
 open Semantics.Degree (maxOnScale)
 variable {W T : Type*} [LinearOrder T]
@@ -384,4 +384,4 @@ theorem histAlt_subset_altIE_trivial
   rw [altIE, Set.mem_setOf_eq, equivIE_trivial_iff_agree]
   exact hIBP w t w' hw'
 
-end Semantics.Tense.TemporalConnectives.BeaverCondoravdi
+end Tense.TemporalConnectives.BeaverCondoravdi

--- a/Linglib/Studies/Cumming2026.lean
+++ b/Linglib/Studies/Cumming2026.lean
@@ -27,7 +27,7 @@ predictions.
 
 namespace Cumming2026
 
-open Semantics.Tense.Evidential
+open Tense.Evidential
 open English.Tense
 open Korean.Evidentials
 open Bulgarian.Evidentials

--- a/Linglib/Studies/Declerck1991.lean
+++ b/Linglib/Studies/Declerck1991.lean
@@ -32,8 +32,7 @@ companion volume, [declerck-1991-grammar].
 
 namespace Declerck1991
 
-open Semantics.Tense.Reichenbach
-open Semantics.Tense (shiftedFrame)
+open Tense (shiftedFrame)
 open Data.Examples (LinguisticExample)
 
 -- BEGIN GENERATED EXAMPLES
@@ -213,7 +212,7 @@ end Examples
 namespace TOChain
 
 open Core.Order (Relation)
-open Semantics.Tense (Domain NamedTO Orientation)
+open Tense (Domain NamedTO Orientation)
 
 /-! ### Time-spheres -/
 
@@ -234,7 +233,7 @@ inductive TimeSphere where
 
 /-! ### TO-chain architecture -/
 
-/-- A single link in a TO chain: a `Semantics.Tense.Orientation`-labelled
+/-- A single link in a TO chain: a `Tense.Orientation`-labelled
 time of orientation related to the next TO inward by a temporal relation.
 
 Example: in the past perfect schema `TS simul TO_sit before TO₂ before TO₁`,
@@ -598,10 +597,10 @@ theorem conditionalPerfect_tower_depth (t0 to2 to3 toSit : Time) {E P : Type*}
 
 end TowerBridge
 
-/-! ### Domain bridge: TO-chain as `Semantics.Tense.Domain`
+/-! ### Domain bridge: TO-chain as `Tense.Domain`
 
 Re-express `DeclercianSchema` via the framework-agnostic
-`Semantics.Tense.Domain` substrate (central TO + list of sub-TOs, with
+`Tense.Domain` substrate (central TO + list of sub-TOs, with
 Allen relations computed on demand from the underlying linear order).
 Additive: the schema structure and named-tense constructors stay
 unchanged; domain-level tooling can work uniformly with
@@ -612,7 +611,7 @@ section DomainBridge
 
 variable {Time : Type*} [LinearOrder Time]
 
-/-- The schema as a `Semantics.Tense.Domain` over the universal
+/-- The schema as a `Tense.Domain` over the universal
 `Orientation` role vocabulary: central = `.utterance` (t₀), sub-TOs =
 `.perspective` (TO₁) followed by every chain link as a point interval.
 
@@ -744,13 +743,13 @@ always holds, so "event precedes reference" can never hold and the
 perfect lives in the chain structure instead. Exactly Declerck's claim. -/
 
 instance declercianSchema_tenseSystem {Time : Type*} [LinearOrder Time] :
-    Semantics.Tense.TenseSystem (DeclercianSchema Time) Time Orientation where
+    TenseSystem (DeclercianSchema Time) Time Orientation where
   toDomain := DeclercianSchema.toDomain
   anchor := .perspective
   situation := .situation
 
 instance declercianSchema_aspectSystem {Time : Type*} [LinearOrder Time] :
-    Semantics.Tense.AspectSystem (DeclercianSchema Time) Time Orientation where
+    AspectSystem (DeclercianSchema Time) Time Orientation where
   toDomain := DeclercianSchema.toDomain
   event := .situation
   reference := .situation

--- a/Linglib/Studies/Egressy2026.lean
+++ b/Linglib/Studies/Egressy2026.lean
@@ -40,8 +40,7 @@ and temporal adverb diagnostics.
 
 namespace Egressy2026
 
-open Semantics.Tense
-open Semantics.Tense.Reichenbach
+open Tense
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -221,7 +220,7 @@ theorem all_tp_simultaneous :
 -- ════════════════════════════════════════════════════════════════
 
 open Minimalist (ComplementSize fValue Cat)
-open Semantics.Tense (EmbeddedTenseReading availableReadings)
+open Tense (availableReadings)
 open Hungarian.Predicates
 open Hungarian.FunctionWords
 open Hungarian.TemporalDeictic

--- a/Linglib/Studies/Giannakidou2002.lean
+++ b/Linglib/Studies/Giannakidou2002.lean
@@ -69,7 +69,7 @@ namespace Giannakidou2002
 open Core.Order
 open NonemptyInterval
 open Semantics.Aspect
-open Semantics.Tense.TemporalConnectives
+open Tense.TemporalConnectives
 
 variable {Time : Type*} [LinearOrder Time]
 

--- a/Linglib/Studies/GokselKerslake2005.lean
+++ b/Linglib/Studies/GokselKerslake2005.lean
@@ -27,7 +27,7 @@ framework applied to Turkish.
 
 namespace GokselKerslake2005
 
-open Semantics.Tense.Evidential
+open Tense.Evidential
 open Turkish.TAM
 
 -- ============================================================================

--- a/Linglib/Studies/HeimComments1994.lean
+++ b/Linglib/Studies/HeimComments1994.lean
@@ -83,7 +83,7 @@ namespace HeimComments1994
 
 open Core (Intension WorldTimeIndex)
 open Semantics.Context (KContext)
-open Semantics.Tense.DeRe (TemporalDeReReading)
+open Tense.DeRe (TemporalDeReReading)
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -93,7 +93,7 @@ open Semantics.Tense.DeRe (TemporalDeReReading)
 /-- [heim-1994-comments] (p. 155): "By a 'time-concept' I mean
     a function from world-time pairs to times." This is the Lewis-style
     centered-world intension at one coordinate less than the substrate's
-    `Semantics.Tense.DeRe.TimeConcept` (which adds a Speas-Tenny agent
+    `Tense.DeRe.TimeConcept` (which adds a Speas-Tenny agent
     slot). Definitionally `Intension (WorldTimeIndex W T) T`. -/
 abbrev TimeConcept (W T : Type*) := Intension (WorldTimeIndex W T) T
 
@@ -110,7 +110,7 @@ abbrev TimeConcept (W T : Type*) := Intension (WorldTimeIndex W T) T
     from the substrate's `precomp`/`IsRigid.precomp`/`IsRigidOn.precomp`
     closure lemmas (`Core/Logic/Intensional/Rigidity.lean`). -/
 def toSubstrate {W E P T : Type*} (c : TimeConcept W T) :
-    Semantics.Tense.DeRe.TimeConcept W E P T :=
+    Tense.DeRe.TimeConcept W E P T :=
   Intension.precomp KContext.toSituation c
 
 /-- **Pullback preserves rigidity**: a rigid Heim time-concept lifts to
@@ -158,7 +158,7 @@ theorem toSubstrate_isRigidOn {W E P T : Type*}
     degenerate). -/
 theorem toSubstrate_factors_iff_agent_blind {W E P T : Type*}
     [Nonempty E] [Nonempty P]
-    (k : Semantics.Tense.DeRe.TimeConcept W E P T) :
+    (k : Tense.DeRe.TimeConcept W E P T) :
     (∃ c : TimeConcept W T, k = toSubstrate c) ↔
     (∀ c₁ c₂ : KContext W E P T,
       c₁.toSituation = c₂.toSituation → k c₁ = k c₂) := by
@@ -182,7 +182,7 @@ theorem toSubstrate_factors_iff_agent_blind {W E P T : Type*}
     [[α_i]]^g,c is only defined if `g(i)` does-not-follow `g(0)`."
     Heim's presuppositional construal of [abusch-1997]'s Upper
     Limit Constraint is already encoded in the substrate as
-    `Semantics.Tense.upperLimitConstraint` (typed `[LE Time]`,
+    `Tense.upperLimitConstraint` (typed `[LE Time]`,
     anchored to [heim-1994-comments] in its docstring). This
     bridge theorem projects the substrate's `TemporalDeReReading`
     `isFelicitousWith .past` (strict `<`) onto the substrate's ULC
@@ -197,7 +197,7 @@ theorem isFelicitousWith_past_imp_upperLimitConstraint
     {W E P T : Type*} [LinearOrder T]
     (dr : TemporalDeReReading W E P T)
     (h : dr.isFelicitousWith .past) :
-    Semantics.Tense.upperLimitConstraint
+    Tense.upperLimitConstraint
       dr.actualRes dr.holderContext.time :=
   le_of_lt h
 

--- a/Linglib/Studies/Huijsmans2025.lean
+++ b/Linglib/Studies/Huijsmans2025.lean
@@ -43,7 +43,7 @@ combine `Modal.flavor` with `Semantics.Modality.Kratzer.necessity`.
 
 namespace Huijsmans2025
 
-open Semantics.Tense.Evidential (EPCondition EvidentialFrame)
+open Tense.Evidential (EPCondition EvidentialFrame)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Stimulus: temporal anchors testable by both analyses

--- a/Linglib/Studies/IatridouZeijlstra2021.lean
+++ b/Linglib/Studies/IatridouZeijlstra2021.lean
@@ -49,10 +49,10 @@ framework but has not been line-by-line cross-checked against IZ
 
 namespace IatridouZeijlstra2021
 
-open Core.Order Semantics.Tense
+open Core.Order Tense
 open Semantics.Aspect
 open Semantics.Aspect.SubintervalProperty
-open Semantics.Tense.TemporalAdverbials (PTSConstraint AdverbialType)
+open Tense.TemporalAdverbials (PTSConstraint AdverbialType)
 open IatridouEtAl2001 (BoundaryKind)
 open Kiparsky2002 (PerfectReading)
 

--- a/Linglib/Studies/Izvorski1997.lean
+++ b/Linglib/Studies/Izvorski1997.lean
@@ -165,7 +165,7 @@ theorem all_evidentialSurvives :
 open Semantics.Modality.Kratzer
 open Semantics.Presupposition
 open Features.Evidentiality
-open Semantics.Tense.Evidential
+open Tense.Evidential
 open Bulgarian.Evidentials
 
 abbrev World := Fin 4

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -865,7 +865,7 @@ at t but not at any complement time t'.
 The paper identifies BEFORE as the single most widespread EN trigger
 (50 languages), consistent with its transparent dual-inference structure. -/
 
-open Semantics.Tense.TemporalConnectives
+open Tense.TemporalConnectives
   (SentDenotation timeTrace Anscombe.before Karttunen.notUntil)
 
 /-- BEFORE entails a temporal witness for p (the main clause event

--- a/Linglib/Studies/Karttunen1974.lean
+++ b/Linglib/Studies/Karttunen1974.lean
@@ -40,7 +40,7 @@ punctual form is morphologically *before*, confirming Karttunen's analysis.
 
 -/
 
-namespace Semantics.Tense.TemporalConnectives
+namespace Tense.TemporalConnectives
 
 open NonemptyInterval
 
@@ -423,4 +423,4 @@ theorem whenever_not_symmetric :
   simp only [Set.mem_singleton_iff] at hi; subst hi
   omega
 
-end Semantics.Tense.TemporalConnectives
+end Tense.TemporalConnectives

--- a/Linglib/Studies/Kiparsky2002.lean
+++ b/Linglib/Studies/Kiparsky2002.lean
@@ -61,7 +61,6 @@ files consume it). Verified against the Kiparsky 2002 PDF: the
 namespace Kiparsky2002
 
 open Core.Order
-open Semantics.Tense.Reichenbach
 open Features
 open Semantics.Aspect
 open Semantics.Aspect.SubeventStructure

--- a/Linglib/Studies/Klecha2016.lean
+++ b/Linglib/Studies/Klecha2016.lean
@@ -67,8 +67,7 @@ open Semantics.Modality.TemporalConstraint (attitudeTemporalConstraint
   attitudeTemporalConstraint_derived_doxastic
   attitudeTemporalConstraint_derived_circumstantial)
 open English.Predicates.Verbal (think believe hope pray)
-open Semantics.Tense (upperLimitConstraint)
-open Semantics.Tense (GramTense)
+open Tense (upperLimitConstraint)
 open Semantics.Modality (ModalFlavor)
 open Data.Examples (LinguisticExample)
 
@@ -867,9 +866,9 @@ theorem klecha_covers_hope_future_oriented_reading
     kernel-checked (provable by `rfl`). -/
 theorem klecha_actualHistoryBase_eq_substrate_metaphysicalAlternatives
     {W : Type*} (history : HistoricalAlternatives W ℤ)
-    (concept : Semantics.Tense.DeRe.TimeConcept W Unit Unit ℤ)
+    (concept : Tense.DeRe.TimeConcept W Unit Unit ℤ)
     (matrix : Semantics.Context.KContext W Unit Unit ℤ) :
-    let dr : Semantics.Tense.DeRe.TemporalDeReReading W Unit Unit ℤ :=
+    let dr : Tense.DeRe.TemporalDeReReading W Unit Unit ℤ :=
       ⟨concept, matrix⟩
     dr.metaphysicalAlternatives history =
     actualHistoryBase history matrix.toSituation := rfl

--- a/Linglib/Studies/Koev2017.lean
+++ b/Linglib/Studies/Koev2017.lean
@@ -167,7 +167,7 @@ while the assertion commits the speaker to p via DECL (72).
 
 open Core.Order
 open Semantics.Presupposition
-open Semantics.Tense.Evidential
+open Tense.Evidential
 open Bulgarian.Evidentials
 
 /-! ### Spatiotemporal distance △ substrate (inlined) -/

--- a/Linglib/Studies/Kratzer1998.lean
+++ b/Linglib/Studies/Kratzer1998.lean
@@ -52,8 +52,8 @@ judgment.
 
 namespace Kratzer1998
 
-open Semantics.Tense.SOT.Decomposition
-open Semantics.Tense
+open Tense.SOT.Decomposition
+open Tense
 open Data.Examples (LinguisticExample)
 
 -- BEGIN GENERATED EXAMPLES
@@ -518,7 +518,7 @@ theorem german_perfekt_chain :
     theorem just binds them locally for cross-reference. -/
 theorem zero_tense_chain :
     (kratzerZeroTense 1).constraint = GramTense.present ∧
-    Semantics.Tense.Overtness.fromBinding (kratzerZeroTense 1).mode true = .zero :=
+    Overtness.fromBinding (kratzerZeroTense 1).mode true = .zero :=
   ⟨zero_tense_is_present 1, zero_tense_overtness 1⟩
 
 end KratzerChain

--- a/Linglib/Studies/Lakoff1970.lean
+++ b/Linglib/Studies/Lakoff1970.lean
@@ -206,8 +206,8 @@ theorem false_periphrastic_ungrammatical :
 -- § 7. Participant-Perspective Frame
 -- ════════════════════════════════════════════════════
 
-open Semantics.Tense.Evidential
-open Semantics.Tense
+open Tense.Evidential
+open Tense
 
 /-- Lakoff's participant-sensitive tense frame. Extends [cumming-2026]'s
     `EvidentialFrame` (which extends `ReichenbachFrame` with acquisition

--- a/Linglib/Studies/Mendes2025.lean
+++ b/Linglib/Studies/Mendes2025.lean
@@ -40,7 +40,7 @@ namespace Mendes2025
 open Core (Assignment WorldTimeIndex)
 open HistoricalAlternatives
 open Semantics.Dynamic.Core
-open Semantics.Tense
+open Tense
 open Semantics.Mood
 
 

--- a/Linglib/Studies/Ogihara1996.lean
+++ b/Linglib/Studies/Ogihara1996.lean
@@ -23,7 +23,7 @@ the two predictions, and records the contrast with [kratzer-1998]
    genuine past (temporal precedence) vs zero tense (bound variable).
 2. **Zero tense = bound variable**: receives binder time via lambda
    abstraction. The substrate primitive
-   `Semantics.Tense.zeroTense_receives_binder_time` proves the bound
+   `Tense.zeroTense_receives_binder_time` proves the bound
    variable resolves to the binder.
 3. **SOT = zero tense**: the simultaneous reading is the zero-tense
    reading.
@@ -44,10 +44,9 @@ puzzle (where they actually diverge).
 
 namespace Ogihara1996
 
-open Semantics.Tense
-open Semantics.Tense.Reichenbach
-open Semantics.Tense
-open Semantics.Tense.SOT.Ambiguity (PastReading)
+open Tense
+open Tense
+open Tense.SOT.Ambiguity (PastReading)
 open Data.Examples (LinguisticExample)
 
 -- BEGIN GENERATED EXAMPLES
@@ -129,7 +128,7 @@ end Examples
     operation, no ambiguity). -/
 theorem ogihara_ambiguity_vs_deletion :
     PastReading.genuinePast ≠ PastReading.zeroTense :=
-  Semantics.Tense.SOT.Ambiguity.genuinePast_ne_zeroTense
+  Tense.SOT.Ambiguity.genuinePast_ne_zeroTense
 
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/OgiharaST2024.lean
+++ b/Linglib/Studies/OgiharaST2024.lean
@@ -192,7 +192,7 @@ def after_oddity_enter : VeridicalityDatum where
   complementEntailed := true
   gloss := "after(enter, win) — pragmatically odd: entering presupposes not yet having won"
 
-open Semantics.Tense.TemporalConnectives.BeaverCondoravdi
+open Tense.TemporalConnectives.BeaverCondoravdi
 
 -- ════════════════════════════════════════════════════════════════
 -- § 6: Counterexamples to B&C (O&[ogihara-steinert-threlkeld-2024], §5)
@@ -397,7 +397,7 @@ theorem logical_property_asymmetry :
 -- Bridge content (merged from Bridge.lean)
 -- ════════════════════════════════════════════════════════════════
 
-open Semantics.Tense.TemporalConnectives
+open Tense.TemporalConnectives
 open English.TemporalExpressions
 
 -- ════════════════════════════════════════════════════════════════
@@ -968,7 +968,7 @@ namespace OgiharaST2024.VeridicalityBridge
 
 open Core.Order
 open NonemptyInterval
-open Semantics.Tense.TemporalConnectives
+open Tense.TemporalConnectives
 open English.TemporalExpressions
 open OgiharaST2024
 
@@ -1098,7 +1098,7 @@ theorem negation_preserves_presup :
 -- § 23: B&C's Three Readings of *Before* and Presupposition
 -- ============================================================================
 
-open Semantics.Tense.TemporalConnectives.BeaverCondoravdi (BeforeReading)
+open Tense.TemporalConnectives.BeaverCondoravdi (BeforeReading)
 
 /-- All three readings are compatible with `complementVeridical = false`. -/
 theorem all_before_readings_nonveridical :

--- a/Linglib/Studies/Partee1973.lean
+++ b/Linglib/Studies/Partee1973.lean
@@ -12,7 +12,7 @@ interpretive ambiguity as pronouns — indexical, anaphoric, and bound-variable
 — and share the same formal mechanisms (assignment functions, variable
 lookup, lambda abstraction).
 
-The unifying type for all five views of tense is `Semantics.Tense.TensePronoun`: a variable index + a presupposed temporal constraint + a
+The unifying type for all five views of tense is `TensePronoun`: a variable index + a presupposed temporal constraint + a
 binding mode + an eval time index. The bridges in this file —
 `referential_past_decomposition`, `indexical_tense_matches_opNow`,
 `toSitVarStatus` — are projections of `TensePronoun` onto specific
@@ -57,8 +57,7 @@ referential mechanism operates over different domains.
 
 namespace Partee1973
 
-open Semantics.Tense (TenseInterpretation TemporalAssignment
-  interpTense temporalLambdaAbs updateTemporal situationToTemporal PAST SitProp)
+open Tense (interpTense temporalLambdaAbs updateTemporal situationToTemporal PAST)
 open Semantics.Reference.KaplanLD (opNow)
 open Core.SitVarStatus (SitVarStatus)
 open Core (WorldTimeIndex)
@@ -224,8 +223,7 @@ This explains why Persian has zero PRONOUNS but NOT zero TENSE
 `Overtness.fromBinding` (Core/Tense.lean) formalizes this as a function
 from `(ReferentialMode × localDomain)` to `Overtness`. -/
 
-open Semantics.Tense.SOT.Decomposition
-open Semantics.Tense (Overtness)
+open Tense.SOT.Decomposition
 
 /-- The four-way classification: all three referential modes produce
     overt forms except bound+local, which produces zero.
@@ -249,7 +247,7 @@ theorem overtness_classification :
 
 /-- The zero tense under SOT is bound + local → zero, just as
     a reflexive pronoun is bound + local → reduced/zero.
-    This connects Kratzer's zero tense analysis to `Semantics.Tense.Overtness`. -/
+    This connects Kratzer's zero tense analysis to `Overtness`. -/
 theorem zero_tense_parallels_reflexive (n : ℕ) :
     -- Zero tense: bound + local = zero
     (kratzerZeroTense n).isBound ∧

--- a/Linglib/Studies/Percus2000.lean
+++ b/Linglib/Studies/Percus2000.lean
@@ -175,12 +175,12 @@ theorem sitVar_other_unaffected {W Time : Type*}
 -- ════════════════════════════════════════════════════════════════
 
 def toTemporalAssignment {W Time : Type*}
-    (g : SituationAssignment W Time) : Semantics.Tense.TemporalAssignment Time :=
+    (g : SituationAssignment W Time) : TemporalAssignment Time :=
   λ n => (g n).time
 
 theorem temporal_projection_commutes {W Time : Type*}
     (g : SituationAssignment W Time) (n : ℕ) :
-    Semantics.Tense.interpTense n (toTemporalAssignment g) = (interpSitVar n g).time :=
+    Tense.interpTense n (toTemporalAssignment g) = (interpSitVar n g).time :=
   rfl
 
 

--- a/Linglib/Studies/Rett2020.lean
+++ b/Linglib/Studies/Rett2020.lean
@@ -41,7 +41,7 @@ linguistically. *after* and *while* are not ambidirectional.
 
 -/
 
-namespace Semantics.Tense.TemporalConnectives
+namespace Tense.TemporalConnectives
 
 open Core.Order
 open NonemptyInterval
@@ -324,7 +324,7 @@ theorem while_not_ambidirectional [Inhabited Time] :
   have rhs := this.mp lhs (default : Time) rfl
   exact absurd rfl rhs
 
-end Semantics.Tense.TemporalConnectives
+end Tense.TemporalConnectives
 
 -- ============================================================================
 -- Concrete Scenario Verification (from original study file)
@@ -363,7 +363,7 @@ namespace Rett2020.Examples
 
 open Core.Order
 open NonemptyInterval
-open Semantics.Tense.TemporalConnectives
+open Tense.TemporalConnectives
 
 -- ============================================================================
 -- § 1: Concrete Intervals

--- a/Linglib/Studies/Rett2026.lean
+++ b/Linglib/Studies/Rett2026.lean
@@ -335,19 +335,19 @@ def ENConstruction.isAmbidirectional : ENConstruction → Bool
 
 /-- Cross-references the entry `isAmbidirectional .before = true` to
     its witness. The structural anchor is
-    `Semantics.Tense.TemporalConnectives.before_preEvent_ambidirectional`,
+    `Tense.TemporalConnectives.before_preEvent_ambidirectional`,
     which proves the iff for any closed event interval. -/
 theorem before_isAmbidirectional_witness :
     ENConstruction.before.isAmbidirectional = true := rfl
 
 /-- Cross-references `isAmbidirectional .after = false` to
-    `Semantics.Tense.TemporalConnectives.after_not_ambidirectional`,
+    `Tense.TemporalConnectives.after_not_ambidirectional`,
     which exhibits a counter-witness. -/
 theorem after_isAmbidirectional_witness :
     ENConstruction.after.isAmbidirectional = false := rfl
 
 /-- Cross-references `isAmbidirectional .while_ = false` to
-    `Semantics.Tense.TemporalConnectives.while_not_ambidirectional`. -/
+    `Tense.TemporalConnectives.while_not_ambidirectional`. -/
 theorem while_isAmbidirectional_witness :
     ENConstruction.while_.isAmbidirectional = false := rfl
 

--- a/Linglib/Studies/Schlenker2004.lean
+++ b/Linglib/Studies/Schlenker2004.lean
@@ -287,7 +287,7 @@ open Abusch1997 in
 theorem schlenker_origin_supports_abusch_double_access
     (p : ℤ → Prop) (h_speech : p (presentAccess.resolve sotTower))
     (h_matrix : p matrixSaid.eventTime) :
-    Semantics.Tense.doubleAccess p
+    Tense.doubleAccess p
       (presentAccess.resolve sotTower) matrixSaid.eventTime :=
   ⟨h_speech, h_matrix⟩
 
@@ -333,7 +333,7 @@ theorem schlenker_origin_supports_abusch_double_access
     contexts (Schlenker eqs. 38, 40) generalizing Abusch's ULC to
     mood; that's also out of scope for the current substrate bridge. -/
 
-open Semantics.Tense.DeRe (TimeConcept TemporalDeReReading)
+open Tense.DeRe (TimeConcept TemporalDeReReading)
 
 /-- [schlenker-2004-sot]'s **`presentAccess` (origin reading)
     as a rigid `TimeConcept`**: the Kaplan-stable origin reading IS
@@ -412,10 +412,10 @@ open Abusch1997 in
     agreement apparatus and Abusch's res-movement make different
     predictions — not yet substrate-formalized. -/
 theorem schlenker_abusch_agree_on_simultaneous_value
-    (tp : Semantics.Tense.TensePronoun)
-    (g : Semantics.Tense.TemporalAssignment ℤ) :
+    (tp : TensePronoun)
+    (g : TemporalAssignment ℤ) :
     shiftedAccess.resolve sotTower =
-    tp.resolve (Semantics.Tense.updateTemporal g tp.varIndex matrixSaid.eventTime) := by
+    tp.resolve (Tense.updateTemporal g tp.varIndex matrixSaid.eventTime) := by
   show matrixSaid.eventTime = _
   exact (Abusch1997.abusch_derives_simultaneous_via_binding
     tp g matrixSaid).symm

--- a/Linglib/Studies/Sharvit2003.lean
+++ b/Linglib/Studies/Sharvit2003.lean
@@ -44,8 +44,7 @@ contrast as separate Lean defs would be vacuous.
 
 namespace Sharvit2003
 
-open Semantics.Tense.Reichenbach
-open Semantics.Tense
+open Tense
 open Data.Examples (LinguisticExample)
 
 -- BEGIN GENERATED EXAMPLES

--- a/Linglib/Studies/Sharvit2014.lean
+++ b/Linglib/Studies/Sharvit2014.lean
@@ -87,8 +87,8 @@ and corrects locator hallucinations ("table 98" → "(98)", "eq 105" →
 
 namespace Sharvit2014
 
-open Semantics.Tense (LexicalType)
-open Semantics.Tense.TemporalConnectives.Before
+open Tense (LexicalType)
+open Tense.TemporalConnectives.Before
 
 /-! ### §1. The parameter space (Sharvit's numbered example (98)) -/
 
@@ -321,7 +321,7 @@ theorem english_predicts_simultaneous :
     both produce a tense-stripped embedded clause. -/
 theorem english_sot_matches_kratzer :
     english.hasSOT = true ∧
-    Semantics.Tense.SOT.Decomposition.sotDeletionApplicable .past .past = true :=
+    Tense.SOT.Decomposition.sotDeletionApplicable .past .past = true :=
   ⟨rfl, rfl⟩
 
 end Sharvit2014

--- a/Linglib/Studies/TsiliaZhao2026.lean
+++ b/Linglib/Studies/TsiliaZhao2026.lean
@@ -58,9 +58,8 @@ which is why English ⌈then⌉ is compatible with it.
 
 namespace TsiliaZhao2026
 
-open Semantics.Tense.Reichenbach
-open Semantics.Tense
-open Semantics.Tense.Perspective
+open Tense
+open Tense.Perspective
 
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/VonStechow2009.lean
+++ b/Linglib/Studies/VonStechow2009.lean
@@ -31,7 +31,7 @@ file has no concept-file companion in `Semantics/Tense/`.
 [von-stechow-2009]'s contribution is *terminological* — the
 "feature checking" name for what is structurally `GramTense.constrains`
 applied at a `embeddedFrame`-shifted eval time. The substrate lives
-entirely in `Semantics.Tense` and `Semantics.Tense.Basic`; this file
+entirely in `Tense` and `Tense.Basic`; this file
 collects the paper-attributed theorems.
 
 ## Advantages Over Abusch
@@ -45,9 +45,8 @@ collects the paper-attributed theorems.
 
 namespace VonStechow2009
 
-open Semantics.Tense
-open Semantics.Tense.Reichenbach
-open Semantics.Tense
+open Tense
+open Tense
 
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Wurmbrand2014.lean
+++ b/Linglib/Studies/Wurmbrand2014.lean
@@ -42,9 +42,8 @@ study-local below; the empirical examples are generated from
 
 namespace Wurmbrand2014
 
-open Semantics.Tense
-open Semantics.Tense.Reichenbach
-open Semantics.Tense
+open Tense
+open Tense
 open Data.Examples (LinguisticExample)
 open Minimalist (InfinitivalTenseClass ComplementSize)
 

--- a/Linglib/Studies/Zeijlstra2012.lean
+++ b/Linglib/Studies/Zeijlstra2012.lean
@@ -42,7 +42,7 @@ reversing its c-command direction.
   fn. 9 `[uPAST]`-as-non-future route.
 * Zeijlstra's parameter — whether embedded `T` may carry `[uPAST]` — is the
   substrate `SOTParameter`; that SOT languages (`relative`) license the
-  simultaneous reading is `Semantics.Tense.sot_simultaneous_available`.
+  simultaneous reading is `Tense.sot_simultaneous_available`.
 
 ## Todo
 
@@ -51,9 +51,8 @@ reversing its c-command direction.
 
 namespace Zeijlstra2012
 
-open Semantics.Tense
-open Semantics.Tense.Reichenbach
-open Semantics.Tense
+open Tense
+open Tense
 open Minimalist (FeatureVal GramFeature Interpretability)
 
 /-! ### Tense feature interpretability -/

--- a/Linglib/Studies/Zhao2025ThenPresent.lean
+++ b/Linglib/Studies/Zhao2025ThenPresent.lean
@@ -39,9 +39,8 @@ reference ("during then"), the presuppositions clash.
 
 namespace Zhao2025ThenPresent
 
-open Semantics.Tense.Reichenbach
-open Semantics.Tense
-open Semantics.Tense.Perspective
+open Tense
+open Tense.Perspective
 
 
 -- ════════════════════════════════════════════════════


### PR DESCRIPTION
Namespace migration from the Tense API audit (mechanical, no logic changes). `Semantics.Tense.*` → `Tense.*` throughout; headline types hoisted to root per the Event/CommonGround precedent: `ReichenbachFrame` (+ API, dissolving the stuttering `Tense.Reichenbach`), `GramTense`, `TensePronoun`, `TemporalAssignment`, `SOTParameter`, `WilliamsCycleStage`, `TenseInterpretation`, `SitProp`, `Overtness`, `AttitudeTemporalSemantics`, `EmbeddedTenseReading`, `TenseSystem`, `AspectSystem`. Generic-named substrate (`Domain`, `TO`, `NamedTO`, `Orientation`) and free operators (`PAST`/`PRES`/`FUT`, kernel, `embeddedFrame`, …) stay under `Tense`. Fragment files with `.Tense`-suffixed namespaces use `open _root_.Tense` to avoid self-shadowing. File paths unchanged.