### PR TITLE
feat(Semantics/Tense): bridge rival pronominal-past and earliest operators

### DIFF
--- a/Linglib/Semantics/Tense/LexicalType.lean
+++ b/Linglib/Semantics/Tense/LexicalType.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.Set.Basic
+import Linglib.Semantics.Tense.GramTense
 
 /-!
 # Tense as a typed lexical object [sharvit-2014]
@@ -66,6 +67,19 @@ theorem pronominalLookup_eq_some_iff {Time : Type*} [LT Time]
     pronominalLookup g j k = some t ↔ g k < g j ∧ g k = t := by
   unfold pronominalLookup
   by_cases h : g k < g j <;> simp [h, eq_comm]
+
+/-- Sharvit's pronominal past ((30a)) and the `TensePronoun` architecture
+    are the same object: `pronominalLookup g j k` is defined with value `t`
+    iff the past-constraint tense pronoun with referential index `k` and
+    evaluation index `j` satisfies its full presupposition and resolves to
+    `t`. The codebase's two formalizations of [partee-1973]-style
+    pronominal tense provably coincide (in any binding `mode`). -/
+theorem pronominalLookup_eq_some_iff_tensePronoun {Time : Type*} [LinearOrder Time]
+    (g : TemporalAssignment Time) (j k : ℕ) (t : Time) (mode : TenseInterpretation) :
+    pronominalLookup g j k = some t ↔
+      (TensePronoun.mk k .past mode j).fullPresupposition g ∧
+      (TensePronoun.mk k .past mode j).resolve g = t :=
+  pronominalLookup_eq_some_iff g j k t
 
 /-- [sharvit-2014] (30b), p. 274: quantificational past. The
     contextual restrictor `K` constrains the domain of quantification. -/

--- a/Linglib/Semantics/Tense/TemporalConnectives.lean
+++ b/Linglib/Semantics/Tense/TemporalConnectives.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Tense.TemporalConnectives.Basic
+import Linglib.Semantics.Tense.TemporalConnectives.Before
 import Linglib.Semantics.Tense.TemporalConnectives.EventBridge
 
 /-!
@@ -16,6 +17,7 @@ analyses live in `Studies/`:
 ## Submodules
 
 - `Basic.lean`: Shared types (SentDenotation, timeTrace, denotation patterns)
+- `Before.lean`: B&C `before` presuppositions (`hasEarliest`, IPF)
 - `EventBridge.lean`: The eventDenotation projection (Level 3 → Level 2)
 
 -/

--- a/Linglib/Semantics/Tense/TenseAspectComposition.lean
+++ b/Linglib/Semantics/Tense/TenseAspectComposition.lean
@@ -35,6 +35,7 @@ The eval* operators instantiate the situation (fixing world and time).
 
 import Linglib.Semantics.Aspect.Basic
 import Linglib.Semantics.Tense.Compositional
+import Linglib.Semantics.Tense.LexicalType
 
 namespace Tense.TenseAspectComposition
 
@@ -61,6 +62,15 @@ def evalPast (p : PointPred W Time) (tc : Time) (w : W) : Prop :=
     FUT: ∃t > tc, p(w)(t). -/
 def evalFut (p : PointPred W Time) (tc : Time) (w : W) : Prop :=
   ∃ t : Time, t > tc ∧ p ⟨w, t⟩
+
+/-- The pipeline's existential past is [sharvit-2014]'s quantificational
+    past with trivial restrictor: `evalPast` = `quantificationalPast` over
+    `Set.univ`. Together with `pronominalLookup_eq_some_iff_tensePronoun`
+    (in `LexicalType.lean`), this places both of Sharvit's tense lexical
+    types over the operators the rest of the codebase already uses. -/
+theorem evalPast_iff_quantificationalPast (p : PointPred W Time) (tc : Time) (w : W) :
+    evalPast p tc w ↔ quantificationalPast Set.univ (λ t => p ⟨w, t⟩) tc := by
+  simp [evalPast, quantificationalPast]
 
 /-! ### Composed Tense–Aspect Forms -/
 

--- a/Linglib/Studies/BeaverCondoravdi2003.lean
+++ b/Linglib/Studies/BeaverCondoravdi2003.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Tense.TemporalConnectives.Basic
+import Linglib.Semantics.Tense.TemporalConnectives.Before
 import Linglib.Semantics.Modality.HistoricalAlternatives
 import Linglib.Semantics.Degree.Bounds
 
@@ -169,6 +170,34 @@ def instTimes (worlds : Set W) (B : Set (W × T)) : Set T :=
     [rett-2020] uses for her MAX₍<₎. -/
 def earliestAlt (alt : HistAlt W T) (B : Set (W × T)) (w : W) (t : T) : Set T :=
   maxOnScale (· < ·) (instTimes (alt w t) B)
+
+/-- Membership in `earliestAlt` is exactly mathlib's `IsLeast` on the
+    instantiation-times set: B&C's `earliest` operator is the least element
+    of `instTimes`, computed via `maxOnScale (· < ·)`. -/
+theorem mem_earliestAlt_iff_isLeast (alt : HistAlt W T) (B : Set (W × T))
+    (w : W) (t te : T) :
+    te ∈ earliestAlt alt B w t ↔ IsLeast (instTimes (alt w t) B) te := by
+  constructor
+  · rintro ⟨hmem, hmin⟩
+    refine ⟨hmem, λ y hy => ?_⟩
+    by_cases hy_eq : y = te
+    · exact le_of_eq hy_eq.symm
+    · exact le_of_lt (hmin y hy hy_eq)
+  · rintro ⟨hmem, hlb⟩
+    exact ⟨hmem, λ y hy hne => lt_of_le_of_ne (hlb hy) (Ne.symm hne)⟩
+
+/-- B&C's `earliest` is defined (nonempty) exactly when [sharvit-2014]'s
+    `EARLIEST` presupposition (`Before.hasEarliest`, with trivial restrictor)
+    holds of the instantiation times. This is the definedness condition that
+    `Before.ipf_quantificationalPast` shows to fail for quantificational
+    pasts on a dense time axis. -/
+theorem earliestAlt_nonempty_iff_hasEarliest (alt : HistAlt W T) (B : Set (W × T))
+    (w : W) (t : T) :
+    (earliestAlt alt B w t).Nonempty ↔
+    Before.hasEarliest Set.univ (· ∈ instTimes (alt w t) B) := by
+  unfold Before.hasEarliest
+  simp only [Set.Nonempty, mem_earliestAlt_iff_isLeast, Set.mem_univ, true_and,
+             Set.setOf_mem_eq]
 
 -- ============================================================================
 -- § 3: B&C's Truth Conditions

--- a/Linglib/Studies/Kratzer1998.lean
+++ b/Linglib/Studies/Kratzer1998.lean
@@ -523,6 +523,22 @@ theorem zero_tense_chain :
 
 end KratzerChain
 
+/-! ### Agreement with Ogihara on the simultaneous cell -/
+
+/-- Kratzer's SOT deletion and [ogihara-1996]'s zero-tense binding build
+    the **same embedded frame**: deletion yields exactly the
+    `simultaneousFrame` whose embedded event time is the matrix event time,
+    and that frame is PRESENT relative to the shifted perspective. The two
+    accounts provably agree on the core past-under-past simultaneous cell;
+    they differ in mechanism (deletion of a genuine PAST vs a bound zero
+    PRESENT — see `Tense.SOT.Ambiguity.PastReading` for the typed
+    mechanism-level divergence). -/
+theorem deletion_agrees_with_zero_tense_binding {Time : Type*}
+    (m : ReichenbachFrame Time) :
+    applyDeletion m = Tense.simultaneousFrame m m.eventTime ∧
+    (applyDeletion m).isPresent :=
+  ⟨applyDeletion_eq_simultaneousFrame m, kratzer_derives_simultaneous m⟩
+
 /-! ### Cross-paper bridge theorems (Phase F)
 
 The contrast theorems with Ogihara, Sharvit, von Stechow, Klecha are


### PR DESCRIPTION
The bridges PR from the Tense audit: `pronominalLookup_eq_some_iff_tensePronoun` proves Sharvit's (30a) pronominal past and the `TensePronoun` architecture coincide; `evalPast_iff_quantificationalPast` places the pipeline's existential past under Sharvit's quantificational type; `mem_earliestAlt_iff_isLeast` + `earliestAlt_nonempty_iff_hasEarliest` ground B&C's `earliest` in mathlib `IsLeast` and connect its definedness to `Before.hasEarliest` (earning `Before.lean` its second Studies consumer); `deletion_agrees_with_zero_tense_binding` states the Kratzer/Ogihara same-frame agreement in Kratzer1998; the TemporalConnectives hub now re-exports `Before`.