### PR TITLE
feat(Semantics/Tense): generic TenseSystem predicates, laws, located role

### DIFF
--- a/Linglib/Semantics/Tense/Domain.lean
+++ b/Linglib/Semantics/Tense/Domain.lean
@@ -159,7 +159,69 @@ def relatedByName [DecidableEq Role] (d : Domain Time Role)
   ∃ (i j : TO Time), d.find? rI = some i ∧ d.find? rJ = some j ∧
     relatedBy S i j
 
+@[simp] theorem all_def (d : Domain Time Role) :
+    d.all = d.central :: d.subTOs := rfl
+
+/-- Characterize `relatedByName` once the two role lookups are known:
+    it reduces to `relatedBy` on the found TOs. Collapses the
+    existential bookkeeping that every per-predicate bridge proof would
+    otherwise repeat. -/
+theorem relatedByName_iff [DecidableEq Role] {d : Domain Time Role}
+    {rI rJ : Role} {i j : TO Time} (S : List AllenRelation)
+    (hi : d.find? rI = some i) (hj : d.find? rJ = some j) :
+    d.relatedByName S rI rJ ↔ relatedBy S i j := by
+  refine ⟨fun ⟨i', j', hi', hj', h⟩ => ?_, fun h => ⟨i, j, hi, hj, h⟩⟩
+  rw [hi] at hi'
+  rw [hj] at hj'
+  obtain rfl := Option.some.inj hi'
+  obtain rfl := Option.some.inj hj'
+  exact h
+
 end Domain
+
+/-! ### Allen relations on point TOs
+
+For degenerate (point) intervals the Allen algebra collapses: only
+`precedes`, `equal`, and `precededBy` are satisfiable. The positive
+lemmas characterize the two used by the tense predicates; the negative
+lemma is the formal content of "Klein's imperfective (TT ⊂ TSit) is
+unrepresentable on point times". -/
+
+namespace TO
+
+variable {Time : Type*} [LinearOrder Time]
+
+/-- Point TOs: `precedesSet` holds iff the underlying times are `<`-related. -/
+theorem pure_precedes_iff (s t : Time) :
+    AllenRelation.holdsIn AllenRelation.precedesSet (TO.pure s) (TO.pure t) ↔
+    s < t := by
+  unfold AllenRelation.precedesSet
+  rw [AllenRelation.holdsIn_singleton]
+  rfl
+
+/-- Point TOs: `equalSet` holds iff the underlying times are equal. -/
+theorem pure_equal_iff (s t : Time) :
+    AllenRelation.holdsIn AllenRelation.equalSet (TO.pure s) (TO.pure t) ↔
+    s = t := by
+  unfold AllenRelation.equalSet
+  rw [AllenRelation.holdsIn_singleton]
+  exact ⟨fun ⟨h, _⟩ => h, fun h => ⟨h, h⟩⟩
+
+/-- No point TO is properly contained in another: each of `starts`,
+    `finishes`, `during` needs a strict endpoint inequality that a
+    degenerate interval cannot supply. -/
+theorem not_pure_properContainment (s t : Time) :
+    ¬ AllenRelation.holdsIn AllenRelation.properContainmentSet
+      (TO.pure s) (TO.pure t) := by
+  rintro ⟨r, hr, h⟩
+  simp only [AllenRelation.properContainmentSet, List.mem_cons,
+             List.not_mem_nil, or_false] at hr
+  rcases hr with rfl | rfl | rfl
+  · exact ne_of_lt h.2 h.1
+  · exact ne_of_lt h.1 h.2.symm
+  · exact lt_asymm h.1 h.2
+
+end TO
 
 /-! ### Builders for the Common Reichenbach Role-Set -/
 

--- a/Linglib/Semantics/Tense/Reichenbach.lean
+++ b/Linglib/Semantics/Tense/Reichenbach.lean
@@ -115,12 +115,14 @@ consumers can close concrete goals with `decide` and rewrite with
 @[simp] theorem isPast_def (f : ReichenbachFrame Time) :
     f.isPast ↔ f.referenceTime < f.perspectiveTime := Iff.rfl
 
+omit [LinearOrder Time] in
 @[simp] theorem isPresent_def (f : ReichenbachFrame Time) :
     f.isPresent ↔ f.referenceTime = f.perspectiveTime := Iff.rfl
 
 @[simp] theorem isFuture_def (f : ReichenbachFrame Time) :
     f.isFuture ↔ f.perspectiveTime < f.referenceTime := Iff.rfl
 
+omit [LinearOrder Time] in
 @[simp] theorem isSimpleCase_def (f : ReichenbachFrame Time) :
     f.isSimpleCase ↔ f.perspectiveTime = f.speechTime := Iff.rfl
 
@@ -130,6 +132,7 @@ consumers can close concrete goals with `decide` and rewrite with
 @[simp] theorem defaultER_def (f : ReichenbachFrame Time) :
     f.defaultER ↔ f.eventTime ≤ f.referenceTime := Iff.rfl
 
+omit [LinearOrder Time] in
 @[simp] theorem isPerfective_def (f : ReichenbachFrame Time) :
     f.isPerfective ↔ f.eventTime = f.referenceTime := Iff.rfl
 
@@ -201,94 +204,43 @@ def toDomain (f : ReichenbachFrame Time) : Domain Time Orientation :=
 @[simp] theorem toDomain_findSituation (f : ReichenbachFrame Time) :
     f.toDomain.find? .situation = some (TO.pure f.eventTime) := rfl
 
--- ──── Predicate bridges: each Boolean predicate as a `relatedByName` query ────
-
-/-- Helper: for point intervals at times `s` and `t`, `precedesSet`
-    holds iff `s < t`. -/
-private theorem point_precedes_iff (s t : Time) :
-    AllenRelation.holdsIn precedesSet (TO.pure s) (TO.pure t) ↔ s < t := by
-  unfold precedesSet
-  rw [AllenRelation.holdsIn_singleton]
-  rfl
-
-/-- Helper: for point intervals at times `s` and `t`, `equalSet`
-    holds iff `s = t`. -/
-private theorem point_equal_iff (s t : Time) :
-    AllenRelation.holdsIn equalSet (TO.pure s) (TO.pure t) ↔ s = t := by
-  unfold equalSet
-  rw [AllenRelation.holdsIn_singleton]
-  refine ⟨fun ⟨h, _⟩ => h, fun h => ⟨h, h⟩⟩
+-- ──── Predicate bridges: each predicate as a `relatedByName` query ────
 
 /-- `isPast` is exactly `topic precedes perspective` in the Allen
     algebra against the domain — the Reichenbach predicate grounded by
     construction in the Allen projection function on point intervals. -/
 theorem isPast_iff_relatedByName (f : ReichenbachFrame Time) :
     f.isPast ↔ f.toDomain.relatedByName precedesSet .topic .perspective := by
-  unfold isPast Domain.relatedByName Domain.relatedBy
-  refine ⟨fun h => ?_, fun ⟨i, j, hi, hj, hrel⟩ => ?_⟩
-  · refine ⟨TO.pure f.referenceTime, TO.pure f.perspectiveTime,
-            toDomain_findTopic f, toDomain_findPerspective f, ?_⟩
-    exact (point_precedes_iff _ _).mpr h
-  · rw [toDomain_findTopic] at hi; rw [toDomain_findPerspective] at hj
-    obtain ⟨rfl⟩ := Option.some.inj hi
-    obtain ⟨rfl⟩ := Option.some.inj hj
-    exact (point_precedes_iff _ _).mp hrel
+  rw [Domain.relatedByName_iff precedesSet (toDomain_findTopic f) (toDomain_findPerspective f)]
+  exact (TO.pure_precedes_iff _ _).symm
 
 /-- `isFuture` is exactly `perspective precedes topic` in the Allen
     algebra against the domain. -/
 theorem isFuture_iff_relatedByName (f : ReichenbachFrame Time) :
     f.isFuture ↔ f.toDomain.relatedByName precedesSet .perspective .topic := by
-  unfold isFuture Domain.relatedByName Domain.relatedBy
-  refine ⟨fun h => ?_, fun ⟨i, j, hi, hj, hrel⟩ => ?_⟩
-  · refine ⟨TO.pure f.perspectiveTime, TO.pure f.referenceTime,
-            toDomain_findPerspective f, toDomain_findTopic f, ?_⟩
-    exact (point_precedes_iff _ _).mpr h
-  · rw [toDomain_findPerspective] at hi; rw [toDomain_findTopic] at hj
-    obtain ⟨rfl⟩ := Option.some.inj hi
-    obtain ⟨rfl⟩ := Option.some.inj hj
-    exact (point_precedes_iff _ _).mp hrel
+  rw [Domain.relatedByName_iff precedesSet (toDomain_findPerspective f) (toDomain_findTopic f)]
+  exact (TO.pure_precedes_iff _ _).symm
 
 /-- `isPresent` is exactly `topic equal perspective` in the Allen
     algebra against the domain. -/
 theorem isPresent_iff_relatedByName (f : ReichenbachFrame Time) :
     f.isPresent ↔ f.toDomain.relatedByName equalSet .topic .perspective := by
-  unfold isPresent Domain.relatedByName Domain.relatedBy
-  refine ⟨fun h => ?_, fun ⟨i, j, hi, hj, hrel⟩ => ?_⟩
-  · refine ⟨TO.pure f.referenceTime, TO.pure f.perspectiveTime,
-            toDomain_findTopic f, toDomain_findPerspective f, ?_⟩
-    exact (point_equal_iff _ _).mpr h
-  · rw [toDomain_findTopic] at hi; rw [toDomain_findPerspective] at hj
-    obtain ⟨rfl⟩ := Option.some.inj hi
-    obtain ⟨rfl⟩ := Option.some.inj hj
-    exact (point_equal_iff _ _).mp hrel
+  rw [Domain.relatedByName_iff equalSet (toDomain_findTopic f) (toDomain_findPerspective f)]
+  exact (TO.pure_equal_iff _ _).symm
 
 /-- `isPerfect` is exactly `situation precedes topic` in the Allen
     algebra against the domain. -/
 theorem isPerfect_iff_relatedByName (f : ReichenbachFrame Time) :
     f.isPerfect ↔ f.toDomain.relatedByName precedesSet .situation .topic := by
-  unfold isPerfect Domain.relatedByName Domain.relatedBy
-  refine ⟨fun h => ?_, fun ⟨i, j, hi, hj, hrel⟩ => ?_⟩
-  · refine ⟨TO.pure f.eventTime, TO.pure f.referenceTime,
-            toDomain_findSituation f, toDomain_findTopic f, ?_⟩
-    exact (point_precedes_iff _ _).mpr h
-  · rw [toDomain_findSituation] at hi; rw [toDomain_findTopic] at hj
-    obtain ⟨rfl⟩ := Option.some.inj hi
-    obtain ⟨rfl⟩ := Option.some.inj hj
-    exact (point_precedes_iff _ _).mp hrel
+  rw [Domain.relatedByName_iff precedesSet (toDomain_findSituation f) (toDomain_findTopic f)]
+  exact (TO.pure_precedes_iff _ _).symm
 
 /-- `isProspective` is exactly `topic precedes situation` in the Allen
     algebra against the domain. -/
 theorem isProspective_iff_relatedByName (f : ReichenbachFrame Time) :
     f.isProspective ↔ f.toDomain.relatedByName precedesSet .topic .situation := by
-  unfold isProspective Domain.relatedByName Domain.relatedBy
-  refine ⟨fun h => ?_, fun ⟨i, j, hi, hj, hrel⟩ => ?_⟩
-  · refine ⟨TO.pure f.referenceTime, TO.pure f.eventTime,
-            toDomain_findTopic f, toDomain_findSituation f, ?_⟩
-    exact (point_precedes_iff _ _).mpr h
-  · rw [toDomain_findTopic] at hi; rw [toDomain_findSituation] at hj
-    obtain ⟨rfl⟩ := Option.some.inj hi
-    obtain ⟨rfl⟩ := Option.some.inj hj
-    exact (point_precedes_iff _ _).mp hrel
+  rw [Domain.relatedByName_iff precedesSet (toDomain_findTopic f) (toDomain_findSituation f)]
+  exact (TO.pure_precedes_iff _ _).symm
 
 /-- `isPerfective` is exactly `situation equal topic` in the Allen
     algebra against the domain. (For the point-time approximation; the
@@ -296,15 +248,8 @@ theorem isProspective_iff_relatedByName (f : ReichenbachFrame Time) :
     `Semantics/Lexical/Verb/ViewpointAspect.lean`.) -/
 theorem isPerfective_iff_relatedByName (f : ReichenbachFrame Time) :
     f.isPerfective ↔ f.toDomain.relatedByName equalSet .situation .topic := by
-  unfold isPerfective Domain.relatedByName Domain.relatedBy
-  refine ⟨fun h => ?_, fun ⟨i, j, hi, hj, hrel⟩ => ?_⟩
-  · refine ⟨TO.pure f.eventTime, TO.pure f.referenceTime,
-            toDomain_findSituation f, toDomain_findTopic f, ?_⟩
-    exact (point_equal_iff _ _).mpr h
-  · rw [toDomain_findSituation] at hi; rw [toDomain_findTopic] at hj
-    obtain ⟨rfl⟩ := Option.some.inj hi
-    obtain ⟨rfl⟩ := Option.some.inj hj
-    exact (point_equal_iff _ _).mp hrel
+  rw [Domain.relatedByName_iff equalSet (toDomain_findSituation f) (toDomain_findTopic f)]
+  exact (TO.pure_equal_iff _ _).symm
 
 end ReichenbachFrame
 
@@ -323,10 +268,65 @@ instance reichenbachFrame_tenseSystem {Time : Type*} [LinearOrder Time] :
     TenseSystem (ReichenbachFrame Time) Time Orientation where
   toDomain := ReichenbachFrame.toDomain
   anchor := .perspective
-  situation := .topic
+  located := .topic
+  anchor_mem := fun f => by
+    rw [ReichenbachFrame.toDomain_labels]
+    decide
 
 instance reichenbachFrame_aspectSystem {Time : Type*} [LinearOrder Time] :
     AspectSystem (ReichenbachFrame Time) Time Orientation where
   toDomain := ReichenbachFrame.toDomain
   event := .situation
   reference := .topic
+
+/-! ### Generic-predicate specializations
+
+The generic `TenseSystem`/`AspectSystem` predicates agree with the
+concrete `ReichenbachFrame` predicates — the frame is the point-time
+specialization of the interval-native generic layer. -/
+
+section GenericSpecialization
+
+variable {Time : Type*} [LinearOrder Time]
+
+@[simp] theorem tenseSystem_isPast_iff (f : ReichenbachFrame Time) :
+    TenseSystem.isPast f ↔ f.isPast :=
+  (ReichenbachFrame.isPast_iff_relatedByName f).symm
+
+@[simp] theorem tenseSystem_isPresent_iff (f : ReichenbachFrame Time) :
+    TenseSystem.isPresent f ↔ f.isPresent :=
+  (ReichenbachFrame.isPresent_iff_relatedByName f).symm
+
+@[simp] theorem tenseSystem_isFuture_iff (f : ReichenbachFrame Time) :
+    TenseSystem.isFuture f ↔ f.isFuture :=
+  (ReichenbachFrame.isFuture_iff_relatedByName f).symm
+
+@[simp] theorem aspectSystem_isPerfect_iff (f : ReichenbachFrame Time) :
+    AspectSystem.isPerfect f ↔ f.isPerfect :=
+  (ReichenbachFrame.isPerfect_iff_relatedByName f).symm
+
+@[simp] theorem aspectSystem_isPerfective_iff (f : ReichenbachFrame Time) :
+    AspectSystem.isPerfective f ↔ f.isPerfective :=
+  (ReichenbachFrame.isPerfective_iff_relatedByName f).symm
+
+@[simp] theorem aspectSystem_isProspective_iff (f : ReichenbachFrame Time) :
+    AspectSystem.isProspective f ↔ f.isProspective :=
+  (ReichenbachFrame.isProspective_iff_relatedByName f).symm
+
+/-- **Point frames cannot be imperfective.** [klein-1994]'s imperfective
+    (TT properly inside TSit) requires a non-degenerate interval, and
+    every `ReichenbachFrame` TO is a point. The audit-level claim that
+    "the imperfective is unrepresentable in the point-frame core" is
+    here a theorem, not a docstring. -/
+theorem ReichenbachFrame.not_aspectSystem_isImperfective
+    (f : ReichenbachFrame Time) : ¬ AspectSystem.isImperfective f := by
+  rintro ⟨i, j, hi, hj, hrel⟩
+  have hi' : f.toDomain.find? .topic = some i := hi
+  have hj' : f.toDomain.find? .situation = some j := hj
+  rw [ReichenbachFrame.toDomain_findTopic] at hi'
+  rw [ReichenbachFrame.toDomain_findSituation] at hj'
+  obtain rfl := Option.some.inj hi'
+  obtain rfl := Option.some.inj hj'
+  exact TO.not_pure_properContainment _ _ hrel
+
+end GenericSpecialization

--- a/Linglib/Semantics/Tense/System.lean
+++ b/Linglib/Semantics/Tense/System.lean
@@ -58,8 +58,19 @@ class TenseSystem (α : Type u)
   toDomain : α → Domain Time Role
   /-- The role of the anchor TO. -/
   anchor : Role
-  /-- The role of the situation TO. -/
-  situation : Role
+  /-- The role of the **located** TO — the TO that tense locates
+      relative to the anchor. For Reichenbach this is `.topic` (R);
+      for Declerck it is `.situation` (TO_sit). Named `located` rather
+      than `situation` because it does *not* generally denote the
+      situation time E (`Orientation.situation`): for Reichenbach it
+      is R, not E. -/
+  located : Role
+  /-- Law: the anchor role is present in every lifted domain. (No
+      analogous law for `located`: Declercian schemas with an empty
+      TO-chain lift to domains whose labels are just
+      `[utterance, perspective]`, so the located role can be absent —
+      a real asymmetry between the two instances, visible here.) -/
+  anchor_mem : ∀ a : α, anchor ∈ (toDomain a).labels
 
 /-! ### Aspect System -/
 
@@ -84,3 +95,71 @@ class AspectSystem (α : Type u)
   event : Role
   /-- The role of the reference TO. -/
   reference : Role
+
+/-! ### Generic tense and aspect predicates
+
+Defined once over the classes via `Domain.relatedByName` with Allen
+atom-sets, so any tense framework that instantiates `TenseSystem` /
+`AspectSystem` gets them for free — and rival frameworks can agree or
+disagree about a single predicate instead of each defining its own.
+Because `Domain` is interval-native, these are interval-correct;
+point-based schemas (Reichenbach) satisfy them in the degenerate
+point-collapse of the Allen algebra (see the `ReichenbachFrame`
+specialization lemmas), and `isImperfective` is *unsatisfiable* there
+(`ReichenbachFrame.not_aspectSystem_isImperfective`). -/
+
+namespace TenseSystem
+
+variable {α : Type u} {Time : Type v} {Role : Type w}
+  [LinearOrder Time] [DecidableEq Role] [TenseSystem α Time Role]
+
+/-- Generic PAST: the located TO precedes the anchor TO. -/
+def isPast (a : α) : Prop :=
+  (toDomain a).relatedByName AllenRelation.precedesSet
+    (located (α := α)) (anchor (α := α))
+
+/-- Generic PRESENT: the located TO equals the anchor TO. (Point
+    approximation of present-as-overlap; an interval instance wanting
+    overlap semantics should use `AllenRelation.overlapSet` directly.) -/
+def isPresent (a : α) : Prop :=
+  (toDomain a).relatedByName AllenRelation.equalSet
+    (located (α := α)) (anchor (α := α))
+
+/-- Generic FUTURE: the anchor TO precedes the located TO. -/
+def isFuture (a : α) : Prop :=
+  (toDomain a).relatedByName AllenRelation.precedesSet
+    (anchor (α := α)) (located (α := α))
+
+end TenseSystem
+
+namespace AspectSystem
+
+variable {α : Type u} {Time : Type v} {Role : Type w}
+  [LinearOrder Time] [DecidableEq Role] [AspectSystem α Time Role]
+
+/-- Generic PERFECT: the event TO precedes the reference TO. -/
+def isPerfect (a : α) : Prop :=
+  (toDomain a).relatedByName AllenRelation.precedesSet
+    (event (α := α)) (reference (α := α))
+
+/-- Generic PERFECTIVE: the event TO equals the reference TO
+    (point approximation of E ⊆ R). -/
+def isPerfective (a : α) : Prop :=
+  (toDomain a).relatedByName AllenRelation.equalSet
+    (event (α := α)) (reference (α := α))
+
+/-- Generic PROSPECTIVE: the reference TO precedes the event TO. -/
+def isProspective (a : α) : Prop :=
+  (toDomain a).relatedByName AllenRelation.precedesSet
+    (reference (α := α)) (event (α := α))
+
+/-- Generic IMPERFECTIVE ([klein-1994]): the reference TO (topic time)
+    is properly contained in the event TO (situation time) — TT ⊂ TSit.
+    Genuinely interval-level: unsatisfiable when both TOs are points
+    (`TO.not_pure_properContainment`), which is the formal statement of
+    why point-based frames cannot represent the imperfective. -/
+def isImperfective (a : α) : Prop :=
+  (toDomain a).relatedByName AllenRelation.properContainmentSet
+    (reference (α := α)) (event (α := α))
+
+end AspectSystem

--- a/Linglib/Studies/Declerck1991.lean
+++ b/Linglib/Studies/Declerck1991.lean
@@ -746,7 +746,10 @@ instance declercianSchema_tenseSystem {Time : Type*} [LinearOrder Time] :
     TenseSystem (DeclercianSchema Time) Time Orientation where
   toDomain := DeclercianSchema.toDomain
   anchor := .perspective
-  situation := .situation
+  located := .situation
+  anchor_mem := fun s => by
+    rw [DeclercianSchema.toDomain_labels]
+    exact List.mem_cons_of_mem _ List.mem_cons_self
 
 instance declercianSchema_aspectSystem {Time : Type*} [LinearOrder Time] :
     AspectSystem (DeclercianSchema Time) Time Orientation where


### PR DESCRIPTION
The TenseSystem-laws PR from the Tense audit. `Domain.relatedByName_iff` collapses the six hand-written Reichenbach bridge proofs to two lines each; point-TO Allen lemmas (`TO.pure_precedes_iff`/`pure_equal_iff`/`not_pure_properContainment`) are now public Domain API. `TenseSystem.situation` is renamed to `located` (it held `.topic` = R for Reichenbach while `situation` means E everywhere else — the audit's role bug), and the class gains the `anchor_mem` membership law (with a docstring noting why `located` admits no such law: Declercian empty-chain schemas). Generic interval-native predicates `TenseSystem.isPast/isPresent/isFuture` and `AspectSystem.isPerfect/isPerfective/isProspective/isImperfective` are defined once over the classes; `ReichenbachFrame` gets simp specialization lemmas, and `ReichenbachFrame.not_aspectSystem_isImperfective` turns the audit's 'Klein's imperfective is unrepresentable on point frames' claim into a theorem.