### PR TITLE
feat(Syntax/ConstructionGrammar): network inheritance and licensing

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2179,6 +2179,7 @@ import Linglib.Syntax.ConstructionGrammar.ArgumentStructure
 import Linglib.Syntax.ConstructionGrammar.GrammarDist
 import Linglib.Syntax.ConstructionGrammar.IdiomTypology
 import Linglib.Syntax.ConstructionGrammar.Inheritance
+import Linglib.Syntax.ConstructionGrammar.Licensing
 import Linglib.Studies.Dunn2025
 import Linglib.Syntax.ConstructionGrammar.Resultatives
 import Linglib.Studies.GoldbergJackendoff2004

--- a/Linglib/Fragments/English/Binominals.lean
+++ b/Linglib/Fragments/English/Binominals.lean
@@ -1,6 +1,7 @@
 import Linglib.Semantics.Quantification.BinominalDefs
 import Linglib.Semantics.Quantification.Binominal
 import Linglib.Syntax.ConstructionGrammar.Basic
+import Linglib.Syntax.ConstructionGrammar.Inheritance
 
 /-!
 # English Binominal Noun Phrases [ten-wolde-2023]
@@ -340,6 +341,12 @@ def ofBinominalNetwork : Constructicon where
         sharedProperties := ["intensifier function"]
         overriddenProperties := ["[N of a] → degree intensifier in AdjP"] }
     ]
+
+
+/-- Every link in the *of*-binominal network resolves to a member
+construction — no dangling name-keyed links. -/
+theorem ofBinominalNetwork_wellFormed : ofBinominalNetwork.WellFormed := by
+  decide
 
 /-- The network has 8 constructions (6 of-binominal + simple NP + AP). -/
 theorem network_size : ofBinominalNetwork.constructions.length = 8 := rfl

--- a/Linglib/Studies/Benz2025.lean
+++ b/Linglib/Studies/Benz2025.lean
@@ -1,4 +1,5 @@
 import Linglib.Morphology.DM.Allosemy
+import Linglib.Syntax.ConstructionGrammar.Basic
 import Linglib.Features.Acceptability
 import Linglib.Fragments.German.Predicates
 
@@ -731,6 +732,48 @@ def incorporationAllowed (outer inner : SynLevel) : Bool :=
   | .phrase, .head   => true   -- normal complementation
   | .head,   .phrase => false  -- *phrasal incorporation
   | .phrase, .phrase => false  -- *phrase stacking inside a word
+
+/-! #### Cross-framework contrast: the phrase-in-word-slot cell
+
+`ConstructionGrammar.Slot.IsPhraseInWordSlot` — a phrasal filler in a
+zero-level position — is the configuration of phrasal compounds and the
+PAL construction ([goldberg-shirtz-2025]; contemporaneous with this
+dissertation, neither cites the other). In this file's terms that
+configuration is exactly the banned phrasal-incorporation cell: lexical
+integrity rejects what the constructionist analysis licenses (cf.
+`GoldbergShirtz2025.pal_load_bearing`). -/
+
+/-- A CxG bar level in `SynLevel` terms: zero-level positions are head
+sites; bar- and phrase-level positions are phrasal. -/
+def SynLevel.ofBarLevel : ConstructionGrammar.BarLevel → SynLevel
+  | .zero => .head
+  | .bar => .phrase
+  | .phrase => .phrase
+
+/-- The `SynLevel` of a CxG slot filler: word fillers are heads, phrasal
+fillers (with or without a fixed head) are phrases; SEM+ fillers are
+level-unspecified. -/
+def _root_.ConstructionGrammar.SlotFiller.synLevel :
+    ConstructionGrammar.SlotFiller String → Option SynLevel
+  | .fixed _ => some .head
+  | .open_ _ => some .head
+  | .headed _ _ => some .phrase
+  | .phrasal => some .phrase
+  | .semantic _ => none
+
+/-- A phrase in a word-level slot occupies the banned cell: its site is a
+head, its filler a phrase, and `incorporationAllowed` rejects the pair.
+The standing counterexample class is the PAL construction, which licenses
+exactly this configuration. -/
+theorem phraseInWordSlot_incorporation_banned
+    (s : ConstructionGrammar.Slot String) (h : s.IsPhraseInWordSlot) :
+    ∃ site filler,
+      s.level.map SynLevel.ofBarLevel = some site ∧
+      s.filler.synLevel = some filler ∧
+      incorporationAllowed site filler = false := by
+  obtain ⟨hf, hl⟩ := h
+  refine ⟨.head, .phrase, ?_, ?_, rfl⟩ <;>
+    simp [hl, hf, SynLevel.ofBarLevel, ConstructionGrammar.SlotFiller.synLevel]
 
 -- ────────────────────────────────────────────────────
 -- § 19. Abstract Interpretive Dimension: Result State Specification

--- a/Linglib/Studies/GoldbergShirtz2025.lean
+++ b/Linglib/Studies/GoldbergShirtz2025.lean
@@ -353,11 +353,11 @@ theorem pal_form_phrase_in_word_slot :
     ∃ s ∈ palConstruction.form, s.IsPhraseInWordSlot := by decide
 
 -- Cross-framework note: this configuration is exactly the cell
--- lexicalist incorporation accounts ban (`Benz2025.incorporationAllowed`
--- rejects a phrasal inner element at a head-level site, following Baker's
--- Lexical Integrity); CxG licenses it via the lemma-like construal. A
--- formal contrast theorem awaits settling the chronological order of the
--- two 2025 sources.
+-- lexicalist incorporation accounts ban — see
+-- `Benz2025.phraseInWordSlot_incorporation_banned` (hosted there because
+-- the ban is that file's apparatus; the two 2025 sources are
+-- contemporaneous and neither cites the other). CxG licenses the cell via
+-- the lemma-like construal (`pal_load_bearing` below).
 
 /-! ### Attested distribution
 

--- a/Linglib/Studies/GoldbergShirtz2025.lean
+++ b/Linglib/Studies/GoldbergShirtz2025.lean
@@ -1,5 +1,6 @@
 import Linglib.Syntax.ConstructionGrammar.ArgumentStructure
 import Linglib.Syntax.ConstructionGrammar.Inheritance
+import Linglib.Syntax.ConstructionGrammar.Licensing
 import Linglib.Semantics.Presupposition.Basic
 
 /-!
@@ -19,10 +20,13 @@ confirmed conventional subtypes.
 ## Main declarations
 
 - `GoldbergShirtz2025.palConstruction`, `palConstructicon`: the Figure 5 network
-- `GoldbergShirtz2025.nn_adjN_incompatible`, `pal_resolves`, `palSpec_eq`:
-  the paper's two-mothers argument for normal-mode inheritance, derived
+- `GoldbergShirtz2025.nn_adjN_incompatible`, `pal_resolves`, `palSpec_eq`,
+  `palConstructicon_resolvesAll`: the paper's two-mothers argument for
+  normal-mode inheritance, computed through the network's links
 - `GoldbergShirtz2025.palMeaning`: familiarity presupposition + head-noun assertion
 - `GoldbergShirtz2025.pal_irreducible`: PAL is not fully compositional
+- `GoldbergShirtz2025.pal_load_bearing`: the network licenses
+  phrase-in-word-slot tokens only through PAL
 - `GoldbergShirtz2025.palExamples`, `crossLinguisticPALs`: attested examples
 
 ## Experimental results
@@ -218,9 +222,35 @@ def palOwnSpec : CxnSpec :=
   { level := some .bar
   , stress := some .modifier }
 
-/-- PAL's full specification, by normal-mode inheritance from its two
-mothers. -/
-def palSpec : CxnSpec := palOwnSpec.inherit [nnCompoundSpec, adjNSpec]
+/-- Own-specification assignment for the Figure 5 network: the two
+mothers carry their specifications, PAL legislates exactly its mothers'
+conflicts, and the conventional subtypes add no form-side constraints of
+their own. -/
+def figure5Spec (c : Construction) : CxnSpec :=
+  if c.name == "NN compound" then nnCompoundSpec
+  else if c.name == "Adj+N modification" then adjNSpec
+  else if c.name == "PAL" then palOwnSpec
+  else {}
+
+/-- PAL's full specification, computed through the network's links by
+normal-mode inheritance. -/
+def palSpec : CxnSpec :=
+  palConstructicon.derivedSpec figure5Spec palConstruction
+
+/-- No dangling links: every Figure 5 link endpoint names a construction
+of the network. -/
+theorem palConstructicon_wellFormed : palConstructicon.WellFormed := by
+  decide
+
+/-- The links, not a hand-written list, determine PAL's mothers. -/
+theorem pal_parents :
+    palConstructicon.parentsOf "PAL" = [nnCompound, adjNModification] := by
+  decide
+
+/-- The whole network is normal-mode well-formed: every construction
+legislates every field its parents conflict on. -/
+theorem palConstructicon_resolvesAll :
+    palConstructicon.ResolvesAll figure5Spec := by decide
 
 /-- The two mothers conflict (bar level and stress), so complete-mode
 inheritance cannot relate PAL to both parents — the formal content of §6's
@@ -246,6 +276,52 @@ theorem palSpec_eq :
       , modPosition := some .prenominal
       , stress := some .modifier
       , selfEmbedding := some .banned } := by decide
+
+/-! ### Licensing: PAL is load-bearing
+
+A minimal demonstration with the network's licensing relation
+(`Constructicon.Licenses`): the attested "a must-do task" (the paper's
+ex. (1b), determiner elided) parses as a phrase-daughter in the modifier
+slot plus a head noun. The network licenses it through the PAL
+construction, and rejects it when PAL is removed — the
+phrase-in-word-slot configuration has no other license. -/
+
+/-- Toy POS lexicon for the licensing demonstration. -/
+def demoLexicon : String → Option UD.UPOS
+  | "do" => some .VERB
+  | "task" => some .NOUN
+  | _ => none
+
+/-- The internal syntax of the *must-do* PAL: must-V
+(cf. `mustVerbConstruction`, which is the full prenominal construction). -/
+def mustVCore : Construction :=
+  { name := "must-V core"
+  , form :=
+      [ { filler := .fixed "must" }
+      , { filler := .open_ .VERB, role := some "predicate", isHead := true } ]
+  , meaning := "obligatory V-ing" }
+
+/-- The Figure 5 network plus the must-V-internal construction. -/
+def demoNetwork : Constructicon :=
+  { constructions := mustVCore :: palConstructicon.constructions
+  , links := palConstructicon.links }
+
+/-- "must-do task" (ex. (1b), determiner elided): the PAL phrase as a
+constituent daughter in the word-level modifier slot. -/
+def mustDoTask : Token :=
+  .node [.node [.word "must", .word "do"], .word "task"]
+
+/-- The network licenses the PAL token. -/
+theorem demo_licenses_mustDoTask :
+    demoNetwork.Licenses demoLexicon mustDoTask := by decide
+
+/-- Remove the PAL construction and the token is rejected: nothing else
+licenses a phrase in a word-level modifier slot. PAL is load-bearing. -/
+theorem pal_load_bearing :
+    ¬ ({ demoNetwork with
+         constructions :=
+           demoNetwork.constructions.filter (·.name != "PAL") }
+        : Constructicon).Licenses demoLexicon mustDoTask := by decide
 
 /-! ### Lemma-like meaning -/
 
@@ -275,6 +351,13 @@ content of "phrase-as-lemma". The NN compound's modifier slot is the
 minimal contrast: same zero-level position, word filler. -/
 theorem pal_form_phrase_in_word_slot :
     ∃ s ∈ palConstruction.form, s.IsPhraseInWordSlot := by decide
+
+-- Cross-framework note: this configuration is exactly the cell
+-- lexicalist incorporation accounts ban (`Benz2025.incorporationAllowed`
+-- rejects a phrasal inner element at a head-level site, following Baker's
+-- Lexical Integrity); CxG licenses it via the lemma-like construal. A
+-- formal contrast theorem awaits settling the chronological order of the
+-- two 2025 sources.
 
 /-! ### Attested distribution
 

--- a/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
@@ -31,6 +31,8 @@ formalized here.
 - `CxnSpec`: a partial constructional specification (bar level, modifier position, stress locus, self-embedding)
 - `CxnSpec.inherit`, `CxnSpec.IsCompatible`, `CxnSpec.Resolves`: componentwise lifts
 - `inheritField_of_isCompatible`: the two modes agree absent conflict
+- `Constructicon.parentsOf`, `derivedSpec`, `ResolvesAll`, `WellFormed`:
+  inheritance computed through a constructicon's links
 -/
 
 namespace ConstructionGrammar
@@ -214,5 +216,47 @@ theorem resolves_of_isCompatible (own : CxnSpec) {p q : CxnSpec}
    resolvesField_of_isCompatible _ h.2.2.1, resolvesField_of_isCompatible _ h.2.2.2⟩
 
 end CxnSpec
+
+/-! ### Inheritance through a constructicon
+
+A specification assignment maps each construction to its *own*
+(conflict-resolving) specification; the network then computes each
+construction's full specification by normal-mode inheritance from the
+parents its links name. -/
+
+/-- The constructions a network's links name as parents of `name`. -/
+def Constructicon.parentsOf (cx : Constructicon) (name : String) :
+    List Construction :=
+  (cx.links.filter (·.child == name)).filterMap
+    (λ l => cx.constructions.find? (·.name == l.parent))
+
+/-- Every link endpoint resolves to a construction in the network — no
+dangling name-keyed links. -/
+def Constructicon.WellFormed (cx : Constructicon) : Prop :=
+  ∀ l ∈ cx.links,
+    (∃ c ∈ cx.constructions, c.name = l.parent) ∧
+    (∃ c ∈ cx.constructions, c.name = l.child)
+
+instance (cx : Constructicon) : Decidable cx.WellFormed :=
+  inferInstanceAs (Decidable (∀ l ∈ _, _ ∧ _))
+
+/-- Normal-mode derived specification of `c` in the network: `c`'s own
+specification wins; fields it leaves open are filled by the unique value
+its parents agree on ([diessel-2023] Table 2's default mode, computed
+over the links rather than stipulated per node). -/
+def Constructicon.derivedSpec (cx : Constructicon)
+    (own : Construction → CxnSpec) (c : Construction) : CxnSpec :=
+  (own c).inherit ((cx.parentsOf c.name).map own)
+
+/-- Normal-mode well-formedness of the whole network: every construction
+legislates every field its parents conflict on
+(`CxnSpec.Resolves`, at each node). -/
+def Constructicon.ResolvesAll (cx : Constructicon)
+    (own : Construction → CxnSpec) : Prop :=
+  ∀ c ∈ cx.constructions, (own c).Resolves ((cx.parentsOf c.name).map own)
+
+instance (cx : Constructicon) (own : Construction → CxnSpec) :
+    Decidable (cx.ResolvesAll own) :=
+  inferInstanceAs (Decidable (∀ c ∈ _, _))
 
 end ConstructionGrammar

--- a/Linglib/Syntax/ConstructionGrammar/Licensing.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Licensing.lean
@@ -1,0 +1,101 @@
+import Linglib.Syntax.ConstructionGrammar.Basic
+
+/-!
+# Construction Grammar: Licensing
+
+The licensing model of constructional grammar ([sag-2012]; [goldberg-1995]):
+an utterance token is grammatical iff every constituent in it instantiates
+some construction of the network. `Constructicon.licenses` is the
+recognizer — a constituent's daughters must match some construction's
+typed form slot-by-slot (`formMatches`), and each daughter must itself be
+licensed; words are licensed lexically.
+
+Matching is relative to a POS lexicon `String → Option UD.UPOS`. `headed`
+fillers are checked against immediate daughters (a flat approximation of
+headedness), and `semantic` constraints are not checkable at this level
+and match any token.
+
+## Main declarations
+
+- `Token`: utterance tokens (words and constituents)
+- `SlotFiller.matches`, `formMatches`: slot/daughter matching
+- `Constructicon.Licenses`: the licensing relation, via the recognizer
+-/
+
+namespace ConstructionGrammar
+
+/-- An utterance token: a word or a constituent with daughter tokens. -/
+inductive Token where
+  | word : String → Token
+  | node : List Token → Token
+
+mutual
+
+/-- Boolean equality on tokens (hand-rolled: `Token` is a nested
+inductive, outside the deriving handlers' fragment). -/
+def Token.beq : Token → Token → Bool
+  | .word a, .word b => a == b
+  | .node as, .node bs => Token.beqList as bs
+  | _, _ => false
+
+/-- Boolean equality on token lists. -/
+def Token.beqList : List Token → List Token → Bool
+  | [], [] => true
+  | a :: as, b :: bs => Token.beq a b && Token.beqList as bs
+  | _, _ => false
+
+end
+
+instance : BEq Token := ⟨Token.beq⟩
+
+/-- Does a token satisfy a slot filler, relative to a POS lexicon?
+`semantic` constraints are not checkable at this level and match any
+token; `headed` requires the head word as an immediate daughter. -/
+def SlotFiller.matches (pos : String → Option UD.UPOS) :
+    SlotFiller String → Token → Bool
+  | .fixed w, .word w' => w == w'
+  | .open_ cat, .word w => pos w == some cat
+  | .phrasal, .node _ => true
+  | .headed h _, .node ts => ts.contains (.word h)
+  | .semantic _, _ => true
+  | _, _ => false
+
+/-- A daughter sequence instantiates a typed form: same arity, and each
+daughter matches its slot's filler. -/
+def formMatches (pos : String → Option UD.UPOS)
+    (form : TypedForm String) (ts : List Token) : Bool :=
+  form.length == ts.length &&
+  (form.zip ts).all (λ ⟨s, t⟩ => s.filler.matches pos t)
+
+mutual
+
+/-- The licensing recognizer: words are licensed lexically; a constituent
+is licensed iff its daughters instantiate some construction of the network
+and are each licensed themselves. -/
+def Constructicon.licenses (cx : Constructicon)
+    (pos : String → Option UD.UPOS) : Token → Bool
+  | .word _ => true
+  | .node ts =>
+      cx.constructions.any (λ c => formMatches pos c.form ts) &&
+      cx.licensesList pos ts
+
+/-- All tokens in a list are licensed. -/
+def Constructicon.licensesList (cx : Constructicon)
+    (pos : String → Option UD.UPOS) : List Token → Bool
+  | [] => true
+  | t :: ts => cx.licenses pos t && cx.licensesList pos ts
+
+end
+
+/-- `cx` licenses token `t` (relative to a POS lexicon): every constituent
+instantiates some construction of the network. Defined via the
+`licenses` recognizer, so concrete cases are kernel-decidable. -/
+def Constructicon.Licenses (cx : Constructicon)
+    (pos : String → Option UD.UPOS) (t : Token) : Prop :=
+  cx.licenses pos t = true
+
+instance (cx : Constructicon) (pos : String → Option UD.UPOS) (t : Token) :
+    Decidable (cx.Licenses pos t) :=
+  inferInstanceAs (Decidable (_ = true))
+
+end ConstructionGrammar

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -17295,7 +17295,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {cited},
-  sources   = {Syntax/ConstructionGrammar/Inheritance.lean}
+  sources   = {Syntax/ConstructionGrammar/Inheritance.lean;Syntax/ConstructionGrammar/Licensing.lean}
 }% ══════════════════════════════════════════════════════════════════════════════
 @article{burnett-2019,
   author    = {Burnett, Heather},


### PR DESCRIPTION
Stage 3 of the CxG API rework: the constructicon becomes a computing graph.

- `Constructicon.parentsOf`/`derivedSpec`/`ResolvesAll`/`WellFormed` (Inheritance.lean): specs inherit through the network's links; G&S's `palSpec` is now computed from the Figure 5 graph (`pal_parents` proves the links determine the mothers), the whole network is proved normal-mode well-formed, and both existing constructicons get no-dangling-links theorems.
- `Licensing.lean` (new, [sag-2012]'s licensing model): `Token`, slot/daughter matching, and the `Constructicon.Licenses` recognizer via mutual structural recursion, so concrete cases are kernel-decidable. Payoff in the G&S study: the network licenses the attested "must-do task" and provably rejects it when PAL is removed (`pal_load_bearing`).
- `Benz2025.phraseInWordSlot_incorporation_banned`: the lexical-integrity contrast — `Slot.IsPhraseInWordSlot` maps to exactly the banned phrasal-incorporation cell. Hosted in Benz2025 (the ban is her apparatus); the two 2025 sources are contemporaneous and neither cites the other (verified against the dissertation PDF).
