### PR TITLE
feat(Syntax/ConstructionGrammar): denotation-field inheritance

### DIFF
--- a/Linglib/Studies/GoldbergShirtz2025.lean
+++ b/Linglib/Studies/GoldbergShirtz2025.lean
@@ -27,6 +27,8 @@ confirmed conventional subtypes.
 - `GoldbergShirtz2025.pal_irreducible`: PAL is not fully compositional
 - `GoldbergShirtz2025.pal_load_bearing`: the network licenses
   phrase-in-word-slot tokens only through PAL
+- `GoldbergShirtz2025.subtypes_inherit_familiarity`: every conventional
+  subtype's familiarity presupposition is derived through the links
 - `GoldbergShirtz2025.palExamples`, `crossLinguisticPALs`: attested examples
 
 ## Experimental results
@@ -336,6 +338,43 @@ precisely for situation types that are not antecedently familiar
 reached by accommodation or pretense, not antecedent entailment. -/
 def palMeaning (W : Type*) (situationType headNoun : W → Prop) : PrProp W :=
   { presup := situationType, assertion := headNoun }
+
+/-! ### Typed pragmatics: familiarity inherits through the network
+
+The four subtype links' shared property — "lemma-like construal: presumed
+familiarity" — as a computed fact rather than a string: only PAL itself
+carries a pragmatic contribution (`palMeaning`); the conventional subtypes
+carry none of their own, and the network derives theirs by normal-mode
+inheritance through the links. Their at-issue increments ('simple' marks
+routine-ness, the interdiction of *Don't ⟨PAL⟩ me*, etc.) are not modeled;
+the presupposition component is the inherited content. -/
+
+/-- The links determine PAL's conventional subtypes. -/
+theorem pal_children :
+    palConstructicon.childrenOf "PAL" =
+      [ mustVerbConstruction, aSimplePALConstruction
+      , dontPALmeConstruction, theOldPALConstruction ] := by decide
+
+/-- Own pragmatic contributions for the Figure 5 network: only PAL itself
+carries one — the familiarity-presupposing meaning. -/
+def figure5Pragmatics (W : Type*) (situationType headNoun : W → Prop) :
+    Construction → Option (PrProp W) :=
+  λ c => if c.name == "PAL" then some (palMeaning W situationType headNoun)
+         else none
+
+/-- Every conventional subtype inherits the familiarity presupposition
+through the network: each child of PAL has a derived pragmatic
+contribution whose presupposition is the situation type. -/
+theorem subtypes_inherit_familiarity (W : Type*)
+    (situationType headNoun : W → Prop) :
+    ∀ c ∈ palConstructicon.childrenOf "PAL",
+      (palConstructicon.derivedField
+          (figure5Pragmatics W situationType headNoun) c).map (·.presup)
+        = some situationType := by
+  intro c hc
+  rw [pal_children] at hc
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at hc
+  rcases hc with rfl | rfl | rfl | rfl <;> rfl
 
 /-! ### Irreducibility -/
 

--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -135,7 +135,9 @@ This is a proxy for [mueller-2013]'s structural criterion (whether the
 construction can be analyzed as a sequence of headed binary combinations).
 The proxy works because fully abstract constructions without pragmatic
 functions have no idiosyncratic form–meaning pairings that would resist
-decomposition into the three universal schemata. -/
+decomposition into the three universal schemata. The Boolean approximates
+what [kay-michaelis-2019] survey as a continuum of constructional meaning
+contributions. -/
 def isFullyCompositional (c : Construction) : Bool :=
   c.specificity == .fullyAbstract && c.pragmaticFunction.isNone
 

--- a/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
@@ -33,6 +33,8 @@ formalized here.
 - `inheritField_of_isCompatible`: the two modes agree absent conflict
 - `Constructicon.parentsOf`, `derivedSpec`, `ResolvesAll`, `WellFormed`:
   inheritance computed through a constructicon's links
+- `inheritFieldUnique`, `Constructicon.derivedField`: inheritance for
+  fields without decidable equality (e.g. denotations)
 -/
 
 namespace ConstructionGrammar
@@ -230,6 +232,12 @@ def Constructicon.parentsOf (cx : Constructicon) (name : String) :
   (cx.links.filter (·.child == name)).filterMap
     (λ l => cx.constructions.find? (·.name == l.parent))
 
+/-- The constructions a network's links name as children of `name`. -/
+def Constructicon.childrenOf (cx : Constructicon) (name : String) :
+    List Construction :=
+  (cx.links.filter (·.parent == name)).filterMap
+    (λ l => cx.constructions.find? (·.name == l.child))
+
 /-- Every link endpoint resolves to a construction in the network — no
 dangling name-keyed links. -/
 def Constructicon.WellFormed (cx : Constructicon) : Prop :=
@@ -258,5 +266,31 @@ def Constructicon.ResolvesAll (cx : Constructicon)
 instance (cx : Constructicon) (own : Construction → CxnSpec) :
     Decidable (cx.ResolvesAll own) :=
   inferInstanceAs (Decidable (∀ c ∈ _, _))
+
+/-! ### Inheritance of denotation-valued fields
+
+Denotations (e.g. `PrProp`-valued pragmatic contributions) have no
+decidable equality, so agreeing parents cannot be deduplicated as in
+`inheritField`. `inheritFieldUnique` inherits when exactly one parent
+supplies a value — sufficient for single-mother inheritance, the
+configuration of conventional-subtype links. -/
+
+/-- Normal-mode inheritance for one field without decidable equality:
+the child's own value wins; an unspecified field takes the value of the
+unique supplying parent; multiple suppliers (which `inheritField` could
+reconcile when they agree) yield `none`. -/
+def inheritFieldUnique {α : Type*} (own : Option α)
+    (parents : List (Option α)) : Option α :=
+  match own, parents.filterMap id with
+  | some x, _ => some x
+  | none, [x] => some x
+  | none, _ => none
+
+/-- Derived value of a denotation-valued field for `c` in the network:
+`c`'s own value wins; otherwise the value of the unique supplying
+parent. -/
+def Constructicon.derivedField {α : Type*} (cx : Constructicon)
+    (own : Construction → Option α) (c : Construction) : Option α :=
+  inheritFieldUnique (own c) ((cx.parentsOf c.name).map own)
 
 end ConstructionGrammar

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -17296,6 +17296,21 @@
   validated = {true},
   role      = {cited},
   sources   = {Syntax/ConstructionGrammar/Inheritance.lean;Syntax/ConstructionGrammar/Licensing.lean}
+}
+@incollection{kay-michaelis-2019,
+  author    = {Kay, Paul and Michaelis, Laura A.},
+  year      = {2019},
+  title     = {Constructional Meaning and Compositionality},
+  booktitle = {Semantics -- Interfaces},
+  editor    = {Maienborn, Claudia and von Heusinger, Klaus and Portner, Paul},
+  publisher = {De Gruyter Mouton},
+  address   = {Berlin},
+  pages     = {293--324},
+  doi       = {10.1515/9783110589849-009},
+  subfield  = {syntax},
+  validated = {true},
+  role      = {cited},
+  sources   = {Syntax/ConstructionGrammar/ArgumentStructure.lean}
 }% ══════════════════════════════════════════════════════════════════════════════
 @article{burnett-2019,
   author    = {Burnett, Heather},


### PR DESCRIPTION
Stage 4 of the CxG API rework: typed pragmatic contributions inherit through the network.

- `inheritFieldUnique`/`Constructicon.derivedField`/`childrenOf` (Inheritance.lean): normal-mode inheritance for fields without decidable equality (denotations), inheriting from a unique supplying parent.
- G&S study: only PAL carries an own pragmatic contribution (`palMeaning`); `subtypes_inherit_familiarity` derives every conventional subtype's familiarity presupposition through the links — the four subtype links' "presumed familiarity" sharedProperty as a computed fact rather than a string (the theorem the original audit found missing).

Depends on #287.