### PR TITLE
refactor(Core/Logic/Modal/QBSML): Prop IsNEFree, mem lemmas, naming

### DIFF
--- a/Linglib/Core/Logic/Modal/BSML/Defs.lean
+++ b/Linglib/Core/Logic/Modal/BSML/Defs.lean
@@ -244,21 +244,21 @@ lemma empty_supports_atom (M : BSMLModel W Atom) (p : Atom) :
 
     Defined via `Core.Logic.Team.IsIndisputable` to share substrate
     with QBSML and any other state-based logic. -/
-def BSMLModel.isIndisputable (M : BSMLModel W Atom) (t : Finset W) : Prop :=
+def BSMLModel.IsIndisputable (M : BSMLModel W Atom) (t : Finset W) : Prop :=
   Core.Logic.Team.IsIndisputable M.access t
 
 /-- State-based accessibility: every world in team has the team itself as
     accessible worlds. Strictly stronger than indisputability.
 
     Defined via `Core.Logic.Team.IsStateBased`. -/
-def BSMLModel.isStateBased (M : BSMLModel W Atom) (t : Finset W) : Prop :=
+def BSMLModel.IsStateBased (M : BSMLModel W Atom) (t : Finset W) : Prop :=
   Core.Logic.Team.IsStateBased M.access t
 
-instance (M : BSMLModel W Atom) (t : Finset W) : Decidable (M.isIndisputable t) := by
-  unfold BSMLModel.isIndisputable; infer_instance
+instance (M : BSMLModel W Atom) (t : Finset W) : Decidable (M.IsIndisputable t) := by
+  unfold BSMLModel.IsIndisputable; infer_instance
 
-instance (M : BSMLModel W Atom) (t : Finset W) : Decidable (M.isStateBased t) := by
-  unfold BSMLModel.isStateBased; infer_instance
+instance (M : BSMLModel W Atom) (t : Finset W) : Decidable (M.IsStateBased t) := by
+  unfold BSMLModel.IsStateBased; infer_instance
 
 -- ============================================================================
 -- §7: Semantic Relations

--- a/Linglib/Core/Logic/Modal/QBSML/Defs.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/Defs.lean
@@ -1,110 +1,84 @@
-import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Union
 import Mathlib.Data.Fintype.Basic
-import Mathlib.Data.Finset.Lattice.Union
 import Linglib.Core.Logic.Team.Algebra
 import Linglib.Core.Logic.Bilateral.Defs
 
 /-!
-# Quantified Bilateral State-based Modal Logic (QBSML) — Core Definitions
+# Quantified bilateral state-based modal logic (QBSML)
 
-[aloni-vanormondt-2023] [aloni-2022] [anttila-2021]
+Core definitions for QBSML, the first-order extension of BSML ([aloni-2022],
+[anttila-2021]) presented in [aloni-vanormondt-2023]: indices pair a world
+with a partial assignment, states are finite sets of indices, and the formula
+language adds predicates and quantifiers, the latter evaluated via state
+extensions. Bilateral evaluation, split disjunction (via
+`Core.Logic.Team.splitsAs`), and the `NE` atom carry over from BSML; frame
+conditions are inherited through the world projection `s↓`, so `support` fits
+the `Core.Logic.Team.isFlat_iff` template at the point type
+`Index W Var Domain` exactly as BSML's does at `W` (see
+`Core/Logic/Modal/QBSML/Properties.lean`).
 
-QBSML is the first-order extension of Aloni's BSML, presented in Aloni & van
-Ormondt 2023 (J Logic Lang Inf 32:539-567) "Modified Numerals and Split
-Disjunction: The First-Order Case".
+## Main declarations
 
-## What changes from BSML
+* `Assignment`, `Index`: partial variable assignments and world–assignment
+  pairs ([aloni-vanormondt-2023] Definition 4.2).
+* `State.extendIndividual`, `State.extendUniversal`, `State.extendFunctional`:
+  the state extensions `s[x/d]`, `s[x]`, `s[x/h]` interpreting quantifiers
+  ([aloni-vanormondt-2023] Definitions 4.5–4.7).
+* `State.modalLift`, `State.worldProj`: pairing accessible worlds with an
+  assignment, and the world projection `s↓`.
+* `QBSMLFormula`: the formula language ([aloni-vanormondt-2023]
+  Definition 4.1), with `□` derived as `QBSMLFormula.nec`.
+* `QBSMLFormula.IsNEFree`: the NE-free fragment.
+* `QBSMLModel`, `eval`, `support`, `antiSupport`: bilateral evaluation
+  ([aloni-vanormondt-2023] Definition 4.9).
+* `isBilateral`: `support`/`antiSupport` form a
+  `Core.Logic.Bilateral.IsBilateral` under `QBSMLFormula.neg`.
+* `QBSMLModel.IsStateBased`, `QBSMLModel.IsIndisputable`: frame conditions
+  via `s↓` ([aloni-vanormondt-2023] Definition 4.10).
 
-The propositional BSML (Aloni 2022) is recovered when assignments are empty.
-QBSML extends along three axes:
+## Implementation notes
 
-1. **Indices replace worlds**: `Index = W × Assignment` (Aloni & van Ormondt
-   §3, Definition 4.2). A state is `Finset Index` rather than `Finset W`.
-2. **Predicates with variables** (no constants for now; monadic predicates
-   sufficient for free-choice scenarios).
-3. **Quantifiers**: `∀x` and `∃x` evaluated via state extensions.
-
-## What stays the same
-
-Everything else carries over from BSML:
-- Bilateral evaluation (support + anti-support, polarity flip via negation)
-- Split disjunction via `Core.Logic.Team.splitsAs`
-- NE atom (`s ≠ ∅`)
-- Pragmatic enrichment recursion (NE conjuncts in each clause; deferred to a
-  follow-up file)
-- Frame conditions on accessibility (state-based, indisputable) via the `s↓`
-  projection — Aloni & van Ormondt Definition 4.10
-
-The point of this file is **substrate validation**: QBSML's `support` should
-fit into `Core.Logic.Team.flat_iff_downwardClosed_unionClosed_emptyTeam`'s
-shape exactly as BSML's does — same template, different `Point` type.
-
-## Scope
-
-This file: types, state operations, support relation. No Anttila 2.2.8 proofs
-(those go in `Properties.lean` to validate the substrate). No pragmatic
-enrichment (separate `Enrichment.lean`). No free-choice theorems (separate
-study files under `Studies/`).
-
-## Simplifications vs the paper
-
-- **Monadic predicates only**: `pred : Pred → Var → Formula`. The paper's
-  general `Pⁿ(t₁, ..., tₙ)` with arbitrary arity and term language (constants +
-  variables) is more general. Monadic suffices for Universal FC, Distribution,
-  Obviation. Higher arities and constants can be added later; the substrate
-  abstraction doesn't change.
-- **Single fixed domain `D`**: the paper's `M = ⟨W, D, R, I⟩` has D as part of
-  the model. We use `Domain : Type*` as a parameter on the model and require
-  `[Fintype Domain]` for the universal extension. Polymorphic + finite.
-- **Predicate interpretation is per-world**: `pInterp : Pred → W → Finset Domain`
-  — at world w, predicate p picks out a Finset of Domain elements. This is the
-  world-dependent (non-rigid) interpretation of [aloni-vanormondt-2023]
-  Definition 4.2 (`I(w)(Pⁿ) ⊆ Dⁿ`), specialised to monadic `P` and with the
-  constant-interpretation half of the paper's `I` dropped (no constants here).
+* Predicates are monadic (`pred : Pred → Var → QBSMLFormula Var Pred`) and
+  there is no term language: [aloni-vanormondt-2023] interprets `Pⁿ(t₁ … tₙ)`
+  for arbitrary arity over constants and variables. Monadic predicates over
+  variables suffice for the free-choice facts; higher arities and constants
+  can be added without changing the substrate abstraction.
+* The paper's domain `D` (part of `M = ⟨W, D, R, I⟩`) is a `Domain : Type*`
+  parameter, with `[Fintype Domain]` where the universal extension must range
+  over all of it. `QBSMLModel.pInterp` is the world-dependent (non-rigid)
+  predicate half of the paper's interpretation `I`.
+* The paper requires all indices in a state to share an assignment domain
+  (`dom gᵢ = dom gⱼ`); this is not enforced at the type level — the state
+  operations preserve it.
+* `□` is not primitive: the paper takes `□` primitive and derives `◇`; we
+  invert this, so `eval`'s `poss` clauses match the paper's derived
+  `◇`-clauses and `QBSMLFormula.nec` matches its primitive `□`.
 -/
 
 namespace Core.Logic.Modal.QBSML
 
--- ============================================================================
--- §1 Assignments and indices
--- ============================================================================
+variable {W Var Domain : Type*}
 
-/-- An assignment is a partial function from variables to domain values.
-    Aloni & van Ormondt §4 Definition 4.2: `gᵢ : V → D`. We use `Option D`
-    to represent the partiality.
+/-! ### Assignments and indices -/
 
-    The paper enforces that all indices in a state share the same domain
-    (`dom(gᵢ) = dom(gⱼ)`). We don't enforce this at the type level; instead,
-    state operations preserve the invariant. -/
+/-- A partial assignment of domain values to variables
+    ([aloni-vanormondt-2023] Definition 4.2: `gᵢ : V → D`); `Option D`
+    represents the partiality. -/
 abbrev Assignment (Var Domain : Type*) := Var → Option Domain
 
-/-- An index is a (world, assignment) pair. Aloni & van Ormondt §4 Definition
-    4.2: `i = ⟨wᵢ, gᵢ⟩`. -/
+/-- An index is a (world, assignment) pair ([aloni-vanormondt-2023]
+    Definition 4.2: `i = ⟨wᵢ, gᵢ⟩`). -/
 abbrev Index (W Var Domain : Type*) := W × Assignment Var Domain
 
 /-- The world component of an index. -/
-abbrev Index.world {W Var Domain : Type*} (i : Index W Var Domain) : W := i.1
+abbrev Index.world (i : Index W Var Domain) : W := i.1
 
 /-- The assignment component of an index. -/
-abbrev Index.assign {W Var Domain : Type*} (i : Index W Var Domain) :
-    Assignment Var Domain := i.2
+abbrev Index.assign (i : Index W Var Domain) : Assignment Var Domain := i.2
 
-/-- The "world projection" `s↓` of a state of indices: the set of worlds
-    appearing in some index. Aloni & van Ormondt §4 Definition 4.10:
-    `s↓ := {w | ∃g, (w, g) ∈ s}`.
+section Update
 
-    Frame conditions on `R` (state-based, indisputable) are defined relative
-    to `s↓` rather than `s`, so QBSML reuses BSML's notions via this
-    projection. -/
-def State.worldProj {W Var Domain : Type*} [DecidableEq W]
-    (s : Finset (Index W Var Domain)) : Finset W :=
-  s.image Prod.fst
-
--- ============================================================================
--- §2 Assignment update + state extension operations
--- ============================================================================
-
-variable {Var Domain : Type*} [DecidableEq Var] [Fintype Var]
+variable [DecidableEq Var]
 
 /-- Update an assignment at a single variable: `g[x/d](y) = d` if `y = x`,
     else `g(y)`. -/
@@ -112,133 +86,217 @@ def Assignment.update (g : Assignment Var Domain) (x : Var) (d : Domain) :
     Assignment Var Domain :=
   Function.update g x (some d)
 
-/-- Update an index's assignment. Aloni & van Ormondt §4 Definition 4.4:
-    `i[x/d] := ⟨wᵢ, gᵢ[x/d]⟩`. -/
-def Index.update {W : Type*} (i : Index W Var Domain) (x : Var) (d : Domain) :
+/-- Update an index's assignment ([aloni-vanormondt-2023] Definition 4.4:
+    `i[x/d] := ⟨wᵢ, gᵢ[x/d]⟩`). -/
+def Index.update (i : Index W Var Domain) (x : Var) (d : Domain) :
     Index W Var Domain :=
   (i.world, i.assign.update x d)
 
-variable {W : Type*} [DecidableEq W] [DecidableEq Domain]
+end Update
 
-/-- DecidableEq on assignments follows from Fintype on the variable space
-    plus DecidableEq on the codomain (Option Domain via Domain). -/
-instance : DecidableEq (Assignment Var Domain) :=
-  fun _ _ => decEq _ _
+/-! ### The world projection -/
 
-/-- DecidableEq on indices: pair of decidable types. -/
-instance : DecidableEq (Index W Var Domain) :=
-  inferInstance
+section WorldProj
 
-/-- **Individual extension** `s[x/d]`: assign x to d in every index.
-    Aloni & van Ormondt §4 Definition 4.5: `s[x/d] := {i[x/d] | i ∈ s}`. -/
+variable [DecidableEq W]
+
+/-- The world projection `s↓` of a state of indices: the set of worlds
+    appearing in some index ([aloni-vanormondt-2023] Definition 4.10:
+    `s↓ := {w | ∃g, (w, g) ∈ s}`). Frame conditions on accessibility are
+    stated relative to `s↓`, so QBSML reuses BSML's notions via this
+    projection. -/
+def State.worldProj (s : Finset (Index W Var Domain)) : Finset W :=
+  s.image Index.world
+
+@[simp] theorem State.mem_worldProj {s : Finset (Index W Var Domain)} {w : W} :
+    w ∈ State.worldProj s ↔ ∃ i ∈ s, i.world = w :=
+  Finset.mem_image
+
+theorem State.worldProj_mono {s t : Finset (Index W Var Domain)} (h : s ⊆ t) :
+    State.worldProj s ⊆ State.worldProj t :=
+  Finset.image_subset_image h
+
+theorem State.worldProj_nonempty {s : Finset (Index W Var Domain)}
+    (h : s.Nonempty) : (State.worldProj s).Nonempty :=
+  h.image _
+
+end WorldProj
+
+/-! ### State extensions -/
+
+section State
+
+variable [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain]
+
+/-- **Individual extension** `s[x/d]`: assign `x` to `d` in every index
+    ([aloni-vanormondt-2023] Definition 4.5: `s[x/d] := {i[x/d] | i ∈ s}`). -/
 def State.extendIndividual (s : Finset (Index W Var Domain))
     (x : Var) (d : Domain) : Finset (Index W Var Domain) :=
   s.image (fun i => i.update x d)
 
-/-- **Universal extension** `s[x]`: extend with every domain value at x.
-    Aloni & van Ormondt §4 Definition 4.6: `s[x] := {i[x/d] | i ∈ s, d ∈ D}`.
-
+/-- **Universal extension** `s[x]`: extend with every domain value at `x`
+    ([aloni-vanormondt-2023] Definition 4.6: `s[x] := {i[x/d] | i ∈ s, d ∈ D}`).
     Requires `[Fintype Domain]` to range over the entire domain. -/
 def State.extendUniversal [Fintype Domain] (s : Finset (Index W Var Domain))
     (x : Var) : Finset (Index W Var Domain) :=
   Finset.univ.biUnion (fun d : Domain => State.extendIndividual s x d)
 
-/-- **Functional extension** `s[x/h]`: for each i in s, extend with d's drawn
-    from `h(i)` (a non-empty subset of D).
-    Aloni & van Ormondt §4 Definition 4.7: `s[x/h] := {i[x/d] | i ∈ s,
-    d ∈ h(i)}`.
-
-    Used to interpret existential quantification: `∃x φ` iff `M, s[x/h] ⊨ φ`
-    for some functional `h`. -/
+/-- **Functional extension** `s[x/h]`: for each `i ∈ s`, extend with values
+    drawn from `h i` ([aloni-vanormondt-2023] Definition 4.7:
+    `s[x/h] := {i[x/d] | i ∈ s, d ∈ h(i)}`). Interprets existential
+    quantification: `∃x φ` iff `M, s[x/h] ⊨ φ` for some functional `h`. -/
 def State.extendFunctional (s : Finset (Index W Var Domain))
     (x : Var) (h : Index W Var Domain → Finset Domain) :
     Finset (Index W Var Domain) :=
   s.biUnion (fun i => (h i).image (fun d => i.update x d))
 
+/-! ### Membership characterisations -/
+
+@[simp] theorem State.mem_extendIndividual {s : Finset (Index W Var Domain)}
+    {x : Var} {d : Domain} {j : Index W Var Domain} :
+    j ∈ State.extendIndividual s x d ↔ ∃ i ∈ s, i.update x d = j :=
+  Finset.mem_image
+
+@[simp] theorem State.mem_extendUniversal [Fintype Domain]
+    {s : Finset (Index W Var Domain)} {x : Var} {j : Index W Var Domain} :
+    j ∈ State.extendUniversal s x ↔ ∃ d, ∃ i ∈ s, i.update x d = j := by
+  simp only [State.extendUniversal, Finset.mem_biUnion, Finset.mem_univ,
+    true_and, State.mem_extendIndividual]
+
+@[simp] theorem State.mem_extendFunctional {s : Finset (Index W Var Domain)}
+    {x : Var} {h : Index W Var Domain → Finset Domain} {j : Index W Var Domain} :
+    j ∈ State.extendFunctional s x h ↔ ∃ i ∈ s, ∃ d ∈ h i, i.update x d = j := by
+  simp only [State.extendFunctional, Finset.mem_biUnion, Finset.mem_image]
+
+/-! ### Extension algebra -/
+
+theorem State.extendIndividual_empty (x : Var) (d : Domain) :
+    State.extendIndividual (∅ : Finset (Index W Var Domain)) x d = ∅ :=
+  Finset.image_empty _
+
+theorem State.extendIndividual_union (s t : Finset (Index W Var Domain))
+    (x : Var) (d : Domain) :
+    State.extendIndividual (s ∪ t) x d =
+      State.extendIndividual s x d ∪ State.extendIndividual t x d :=
+  Finset.image_union ..
+
+theorem State.extendIndividual_mono {s t : Finset (Index W Var Domain)}
+    (x : Var) (d : Domain) (hsub : s ⊆ t) :
+    State.extendIndividual s x d ⊆ State.extendIndividual t x d :=
+  Finset.image_subset_image hsub
+
+theorem State.extendUniversal_empty [Fintype Domain] (x : Var) :
+    State.extendUniversal (∅ : Finset (Index W Var Domain)) x = ∅ := by
+  ext j
+  simp
+
+theorem State.extendUniversal_union [Fintype Domain]
+    (s t : Finset (Index W Var Domain)) (x : Var) :
+    State.extendUniversal (s ∪ t) x =
+      State.extendUniversal s x ∪ State.extendUniversal t x := by
+  simp only [State.extendUniversal, State.extendIndividual_union,
+    Finset.biUnion_union]
+
+theorem State.extendUniversal_mono [Fintype Domain]
+    {s t : Finset (Index W Var Domain)} (x : Var) (hsub : s ⊆ t) :
+    State.extendUniversal s x ⊆ State.extendUniversal t x :=
+  Finset.biUnion_mono fun d _ => State.extendIndividual_mono x d hsub
+
+theorem State.extendFunctional_empty (x : Var)
+    (h : Index W Var Domain → Finset Domain) :
+    State.extendFunctional (∅ : Finset (Index W Var Domain)) x h = ∅ :=
+  Finset.biUnion_empty
+
+theorem State.extendFunctional_union (s t : Finset (Index W Var Domain))
+    (x : Var) (h : Index W Var Domain → Finset Domain) :
+    State.extendFunctional (s ∪ t) x h =
+      State.extendFunctional s x h ∪ State.extendFunctional t x h :=
+  Finset.union_biUnion
+
+theorem State.extendFunctional_mono {s t : Finset (Index W Var Domain)}
+    (x : Var) (h : Index W Var Domain → Finset Domain) (hsub : s ⊆ t) :
+    State.extendFunctional s x h ⊆ State.extendFunctional t x h :=
+  Finset.biUnion_subset_biUnion_of_subset_left _ hsub
+
+/-- The universal extension is the functional extension with the constant
+    full-domain functional. -/
+theorem State.extendUniversal_eq_extendFunctional [Fintype Domain]
+    (s : Finset (Index W Var Domain)) (x : Var) :
+    State.extendUniversal s x =
+      State.extendFunctional s x (fun _ => Finset.univ) := by
+  ext j
+  simp only [State.mem_extendUniversal, State.mem_extendFunctional,
+    Finset.mem_univ, true_and]
+  tauto
+
+end State
+
+/-! ### Modal pairing -/
+
+section ModalLift
+
+variable [DecidableEq W] [Fintype Var] [DecidableEq Domain]
+
 /-- **Modal pairing** `R(wᵢ)[gᵢ]`: pair each accessible world with the
     assignment of the original index. Used in modal evaluation
-    (Aloni & van Ormondt §4 Definition 4.9). -/
+    ([aloni-vanormondt-2023] Definition 4.9). -/
 def State.modalLift (X : Finset W) (g : Assignment Var Domain) :
     Finset (Index W Var Domain) :=
   X.image (fun v => (v, g))
 
--- ============================================================================
--- §2b State-extension distributive lemmas
--- ============================================================================
-
-/-- Universal extension of empty team is empty. -/
-theorem State.extendUniversal_empty [Fintype Domain] (x : Var) :
-    State.extendUniversal (∅ : Finset (Index W Var Domain)) x = ∅ := by
-  unfold State.extendUniversal State.extendIndividual
-  ext; simp
-
-/-- Functional extension of empty team is empty. -/
-theorem State.extendFunctional_empty (x : Var)
-    (h : Index W Var Domain → Finset Domain) :
-    State.extendFunctional (∅ : Finset (Index W Var Domain)) x h = ∅ := by
-  unfold State.extendFunctional
-  simp
-
-/-- Universal extension is monotone in the team. -/
-theorem State.extendUniversal_subset_mono [Fintype Domain]
-    {s t : Finset (Index W Var Domain)} (x : Var) (hsub : s ⊆ t) :
-    State.extendUniversal s x ⊆ State.extendUniversal t x := by
-  unfold State.extendUniversal State.extendIndividual
-  intro i hi
-  simp only [Finset.mem_biUnion, Finset.mem_image, Finset.mem_univ, true_and] at hi ⊢
-  obtain ⟨d, j, hj, hupd⟩ := hi
-  exact ⟨d, j, hsub hj, hupd⟩
-
-/-- Universal extension distributes over union. -/
-theorem State.extendUniversal_union_distrib [Fintype Domain]
-    (s t : Finset (Index W Var Domain)) (x : Var) :
-    State.extendUniversal (s ∪ t) x =
-      State.extendUniversal s x ∪ State.extendUniversal t x := by
-  unfold State.extendUniversal State.extendIndividual
-  ext i
-  simp only [Finset.mem_biUnion, Finset.mem_union, Finset.mem_image,
-             Finset.mem_univ, true_and]
+@[simp] theorem State.mem_modalLift {X : Finset W} {g : Assignment Var Domain}
+    {i : Index W Var Domain} :
+    i ∈ State.modalLift X g ↔ i.world ∈ X ∧ i.assign = g := by
   constructor
-  · rintro ⟨d, j, hj, hupd⟩
-    cases hj with
-    | inl hjs => exact Or.inl ⟨d, j, hjs, hupd⟩
-    | inr hjt => exact Or.inr ⟨d, j, hjt, hupd⟩
-  · rintro (⟨d, j, hjs, hupd⟩ | ⟨d, j, hjt, hupd⟩)
-    · exact ⟨d, j, Or.inl hjs, hupd⟩
-    · exact ⟨d, j, Or.inr hjt, hupd⟩
+  · intro h
+    obtain ⟨v, hv, rfl⟩ := Finset.mem_image.mp h
+    exact ⟨hv, rfl⟩
+  · rintro ⟨h, rfl⟩
+    exact Finset.mem_image.mpr ⟨i.world, h, rfl⟩
 
-/-- Functional extension distributes over union of teams. -/
-theorem State.extendFunctional_union_distrib (s t : Finset (Index W Var Domain))
-    (x : Var) (h : Index W Var Domain → Finset Domain) :
-    State.extendFunctional (s ∪ t) x h =
-      State.extendFunctional s x h ∪ State.extendFunctional t x h := by
-  unfold State.extendFunctional
-  exact Finset.union_biUnion
+@[simp] theorem State.worldProj_modalLift (X : Finset W)
+    (g : Assignment Var Domain) :
+    State.worldProj (State.modalLift X g) = X := by
+  ext w
+  simp only [State.mem_worldProj, State.mem_modalLift]
+  constructor
+  · rintro ⟨i, ⟨hX, -⟩, rfl⟩
+    exact hX
+  · exact fun hw => ⟨(w, g), ⟨hw, rfl⟩, rfl⟩
 
-/-- Functional extension is monotone in the team (for fixed `h`). -/
-theorem State.extendFunctional_subset_mono {s t : Finset (Index W Var Domain)}
-    (x : Var) (h : Index W Var Domain → Finset Domain) (hsub : s ⊆ t) :
-    State.extendFunctional s x h ⊆ State.extendFunctional t x h := by
-  unfold State.extendFunctional
-  exact Finset.biUnion_subset_biUnion_of_subset_left _ hsub
+/-- A state contained in a modal pairing is recovered by projecting its
+    worlds and pairing them back with the same assignment: every index of
+    `s ⊆ State.modalLift X g` carries the assignment `g`. -/
+theorem State.modalLift_worldProj_of_subset {s : Finset (Index W Var Domain)}
+    {X : Finset W} {g : Assignment Var Domain}
+    (h : s ⊆ State.modalLift X g) :
+    State.modalLift (State.worldProj s) g = s := by
+  ext i
+  simp only [State.mem_modalLift, State.mem_worldProj]
+  constructor
+  · rintro ⟨⟨j, hjs, hjw⟩, hig⟩
+    have : i = j :=
+      Prod.ext hjw.symm (hig.trans (State.mem_modalLift.mp (h hjs)).2.symm)
+    exact this ▸ hjs
+  · intro his
+    exact ⟨⟨i, his, rfl⟩, (State.mem_modalLift.mp (h his)).2⟩
 
-end Core.Logic.Modal.QBSML
+theorem State.worldProj_subset_of_subset_modalLift
+    {s : Finset (Index W Var Domain)} {X : Finset W}
+    {g : Assignment Var Domain} (h : s ⊆ State.modalLift X g) :
+    State.worldProj s ⊆ X := by
+  rw [← State.worldProj_modalLift X g]
+  exact State.worldProj_mono h
 
--- ============================================================================
--- §3 Formula language
--- ============================================================================
+end ModalLift
 
-namespace Core.Logic.Modal.QBSML
+/-! ### The formula language -/
 
-/-- QBSML formula language (Aloni & van Ormondt §4 Definition 4.1).
+variable {Pred : Type*}
 
-    Parameterized over variable type `Var` and predicate type `Pred`. We use
-    monadic predicates (`Pred → Var → Formula`) — sufficient for free-choice
-    scenarios. Higher arities (`Pred → List Var → Formula`) and a term
-    language (constants + variables) can be added without changing the
-    substrate abstraction.
-
-    □ is NOT primitive — defined as `□φ := ¬◇¬φ` (`QBSMLFormula.nec`). -/
+/-- QBSML formula language ([aloni-vanormondt-2023] Definition 4.1),
+    parameterized over variable type `Var` and (monadic) predicate type
+    `Pred`. `□` is not primitive — see `QBSMLFormula.nec`. -/
 inductive QBSMLFormula (Var : Type*) (Pred : Type*) where
   /-- Monadic predicate application. -/
   | pred : Pred → Var → QBSMLFormula Var Pred
@@ -258,74 +316,51 @@ inductive QBSMLFormula (Var : Type*) (Pred : Type*) where
   | univ : Var → QBSMLFormula Var Pred → QBSMLFormula Var Pred
   deriving Repr
 
-variable {Var Pred : Type*}
-
-/-- □φ := ¬◇¬φ — necessity as an abbreviation, mirroring BSML.
-    [aloni-vanormondt-2023] takes `□` primitive and `◇ := ¬□¬` derived; we
-    invert this (`poss` primitive), so our `poss` clauses match the paper's
-    *derived* `◇`-clauses (Definition 4.9) and `nec` here matches its primitive `□`. -/
+/-- Necessity, derived: `□φ := ¬◇¬φ`. [aloni-vanormondt-2023] takes `□`
+    primitive and `◇ := ¬□¬` derived; we invert this, so `eval`'s `poss`
+    clauses match the paper's derived `◇`-clauses and `nec` matches its
+    primitive `□`. -/
 def QBSMLFormula.nec (φ : QBSMLFormula Var Pred) : QBSMLFormula Var Pred :=
   .neg (.poss (.neg φ))
 
-/-- A formula is NE-free if it does not contain the NE atom.
-    For NE-free formulas, QBSML reduces to classical first-order modal logic
-    on singleton states (Aloni & van Ormondt analogue of Anttila Proposition
-    2.2.16). -/
-def QBSMLFormula.isNEFree : QBSMLFormula Var Pred → Bool
-  | .pred _ _ => true
-  | .ne => false
-  | .neg φ => φ.isNEFree
-  | .conj φ ψ => φ.isNEFree && ψ.isNEFree
-  | .disj φ ψ => φ.isNEFree && ψ.isNEFree
-  | .poss φ => φ.isNEFree
-  | .exi _ φ => φ.isNEFree
-  | .univ _ φ => φ.isNEFree
+/-- The NE-free fragment: formulas not containing the `NE` atom. On this
+    fragment QBSML reduces to classical first-order modal logic
+    ([aloni-vanormondt-2023] analogue of [anttila-2021]
+    Proposition 2.2.16); see `Core/Logic/Modal/QBSML/Properties.lean`. -/
+inductive QBSMLFormula.IsNEFree : QBSMLFormula Var Pred → Prop
+  | pred (P : Pred) (x : Var) : IsNEFree (.pred P x)
+  | neg {φ : QBSMLFormula Var Pred} : IsNEFree φ → IsNEFree (.neg φ)
+  | conj {φ ψ : QBSMLFormula Var Pred} :
+      IsNEFree φ → IsNEFree ψ → IsNEFree (.conj φ ψ)
+  | disj {φ ψ : QBSMLFormula Var Pred} :
+      IsNEFree φ → IsNEFree ψ → IsNEFree (.disj φ ψ)
+  | poss {φ : QBSMLFormula Var Pred} : IsNEFree φ → IsNEFree (.poss φ)
+  | exi (x : Var) {φ : QBSMLFormula Var Pred} : IsNEFree φ → IsNEFree (.exi x φ)
+  | univ (x : Var) {φ : QBSMLFormula Var Pred} : IsNEFree φ → IsNEFree (.univ x φ)
 
-end Core.Logic.Modal.QBSML
+/-! ### Models -/
 
--- ============================================================================
--- §4 Models
--- ============================================================================
-
-namespace Core.Logic.Modal.QBSML
-
-/-- A QBSML model. Aloni & van Ormondt §4 Definition 4.2: `M = ⟨W, D, R, I⟩`.
-
-    We use `Domain : Type*` as a parameter and `[Fintype Domain]` for the
-    universal extension. The interpretation function is split: accessibility
-    `R : W → Finset W` and predicate interpretation
-    `pInterp : Pred → W → Finset Domain`. -/
-structure QBSMLModel (W : Type*) (Domain : Type*) (Pred : Type*)
-    [DecidableEq W] [Fintype W] where
+/-- A QBSML model ([aloni-vanormondt-2023] Definition 4.2:
+    `M = ⟨W, D, R, I⟩`), with the domain as a type parameter and the
+    interpretation split into accessibility and predicate interpretation. -/
+structure QBSMLModel (W : Type*) (Domain : Type*) (Pred : Type*) where
   /-- Accessibility relation (per-world set of accessible worlds). -/
   access : W → Finset W
   /-- Predicate interpretation: at world `w`, predicate `p` picks out the
-      Finset of domain elements satisfying it. -/
+      `Finset` of domain elements satisfying it. -/
   pInterp : Pred → W → Finset Domain
 
-end Core.Logic.Modal.QBSML
+/-! ### Bilateral evaluation -/
 
--- ============================================================================
--- §5 Bilateral evaluation
--- ============================================================================
+section Evaluation
 
-namespace Core.Logic.Modal.QBSML
+variable [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain]
+variable [Fintype Domain]
 
-variable {W Var Domain Pred : Type*}
-variable [DecidableEq W] [Fintype W]
-variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
-
-/-- Bilateral evaluation of QBSML formulas. Aloni & van Ormondt §4 Definition 4.9.
-
-    `eval M true φ s` is support (`M, s ⊨ φ`); `eval M false φ s` is
-    anti-support (`M, s ⊧ φ`). Negation flips polarity, making DNE
-    definitional.
-
-    Key shape: `Bool → Form → Finset Index → Prop` — exactly the template
-    `Core.Logic.Team.flat_iff_downwardClosed_unionClosed_emptyTeam` is
-    parameterized over (with `Point := Index W Var Domain`). The substrate
-    test is whether the property + flatness theorems compose identically
-    to BSML's. -/
+/-- Bilateral evaluation of QBSML formulas ([aloni-vanormondt-2023]
+    Definition 4.9): `eval M true φ s` is support (`M, s ⊨ φ`),
+    `eval M false φ s` anti-support (`M, s ⊧ φ`). Negation flips the
+    polarity, making double-negation elimination definitional. -/
 def eval (M : QBSMLModel W Domain Pred) :
     Bool → QBSMLFormula Var Pred → Finset (Index W Var Domain) → Prop
   | true,  .pred P x, s =>
@@ -366,18 +401,6 @@ abbrev antiSupport (M : QBSMLModel W Domain Pred) (φ : QBSMLFormula Var Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   eval M false φ s
 
--- ============================================================================
--- §6 DNE and basic unfolding lemmas
--- ============================================================================
-
-theorem dne_support (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain)) :
-    support M (.neg (.neg φ)) s ↔ support M φ s := Iff.rfl
-
-theorem dne_antiSupport (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain)) :
-    antiSupport M (.neg (.neg φ)) s ↔ antiSupport M φ s := Iff.rfl
-
 @[simp] lemma support_neg (M : QBSMLModel W Domain Pred)
     (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain)) :
     support M (.neg φ) s ↔ antiSupport M φ s := Iff.rfl
@@ -386,38 +409,44 @@ theorem dne_antiSupport (M : QBSMLModel W Domain Pred)
     (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain)) :
     antiSupport M (.neg φ) s ↔ support M φ s := Iff.rfl
 
-/-- QBSML's `support` and `antiSupport` form a paraconsistent bilateral
-    logic (`Core.Logic.Bilateral.IsBilateral`) under `QBSMLFormula.neg`.
-    Same shape as BSML's `isBilateral`, lifted to `Index W Var Domain` —
-    point-polymorphism at work. The `of_iff` helper resolves the
-    metavariables that previously required explicit `Form/Result`
-    annotations. -/
+/-- `support` and `antiSupport` form a paraconsistent bilateral logic
+    (`Core.Logic.Bilateral.IsBilateral`) under `QBSMLFormula.neg`, like
+    BSML's `isBilateral` at the point type `Index W Var Domain`. -/
 theorem isBilateral (M : QBSMLModel W Domain Pred) :
-    Core.Logic.Bilateral.IsBilateral
-      (Form := QBSMLFormula Var Pred)
-      (Result := Finset (Index W Var Domain) → Prop)
+    Core.Logic.Bilateral.IsBilateral (Form := QBSMLFormula Var Pred)
       (support M) (antiSupport M) QBSMLFormula.neg :=
   Core.Logic.Bilateral.IsBilateral.of_iff (support_neg M) (antiSupport_neg M)
 
--- ============================================================================
--- §7 Frame conditions via s↓ projection
--- ============================================================================
+end Evaluation
 
-/-- QBSML's `isStateBased`: defined via the `s↓` projection composed with
-    `Core.Logic.Team.IsStateBased`. The same Core function as BSML uses,
-    just applied to the world-set of the team rather than the team itself.
+/-! ### Frame conditions via the world projection -/
 
-    Aloni & van Ormondt §4 Definition 4.10: `R is state-based on (M, s)` iff
-    `R(w) = s↓` for all `w ∈ s↓`. Specialization-via-composition exemplifies
-    the foundational mathlib pattern: same Core definition, different
-    instantiation via projection. -/
-def QBSMLModel.isStateBased (M : QBSMLModel W Domain Pred)
+section FrameConditions
+
+variable [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain]
+
+/-- `R` is state-based on `(M, s)`: every world in `s↓` sees exactly `s↓`
+    ([aloni-vanormondt-2023] Definition 4.10). Defined via
+    `Core.Logic.Team.IsStateBased` applied to `State.worldProj s`, sharing
+    BSML's frame-condition substrate. -/
+def QBSMLModel.IsStateBased (M : QBSMLModel W Domain Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Core.Logic.Team.IsStateBased M.access (State.worldProj s)
 
-/-- QBSML's `isIndisputable`: same Core function, applied to `s↓`. -/
-def QBSMLModel.isIndisputable (M : QBSMLModel W Domain Pred)
+/-- `R` is indisputable on `(M, s)`: all worlds in `s↓` see the same
+    accessible set ([aloni-vanormondt-2023] Definition 4.10). -/
+def QBSMLModel.IsIndisputable (M : QBSMLModel W Domain Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Core.Logic.Team.IsIndisputable M.access (State.worldProj s)
+
+instance [Fintype W] (M : QBSMLModel W Domain Pred)
+    (s : Finset (Index W Var Domain)) : Decidable (M.IsStateBased s) := by
+  unfold QBSMLModel.IsStateBased; infer_instance
+
+instance [Fintype W] (M : QBSMLModel W Domain Pred)
+    (s : Finset (Index W Var Domain)) : Decidable (M.IsIndisputable s) := by
+  unfold QBSMLModel.IsIndisputable; infer_instance
+
+end FrameConditions
 
 end Core.Logic.Modal.QBSML

--- a/Linglib/Core/Logic/Modal/QBSML/Enrichment.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/Enrichment.lean
@@ -25,7 +25,8 @@ participants systematically ignore empty configurations when interpreting,
 so each clause must witness a non-empty state. Combined with split
 disjunction, this derives ignorance, distribution, free choice, and the
 behaviour-under-negation pattern — the QBSML free-choice facts proved in
-`QBSML/FreeChoice.lean` (`narrowScopeFC_Q`, `negationStrip_Q`).
+`Studies/AloniVanOrmondt2023/FreeChoice.lean` (`narrowScopeFC_Q`,
+`negationStrip_Q`).
 
 ## Main declarations
 
@@ -34,7 +35,7 @@ behaviour-under-negation pattern — the QBSML free-choice facts proved in
   formula is non-empty (the `NE` conjunct guards every clause).
 * `antiSupport_strip_ne`, `antiSupport_conj_ne_iff` — anti-support of
   `φ ∧ NE` reduces to anti-support of `φ`; the workhorse of the free-choice
-  derivations in `QBSML/FreeChoice.lean`.
+  derivations in `Studies/AloniVanOrmondt2023/FreeChoice.lean`.
 
 ## Implementation notes
 
@@ -69,7 +70,7 @@ def QBSMLFormula.enrich : QBSMLFormula Var Pred → QBSMLFormula Var Pred
 /-! ### Enriched support forces non-emptiness -/
 
 variable {W Domain : Type*}
-variable [DecidableEq W] [Fintype W]
+variable [DecidableEq W]
 variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
 
 /-- A QBSML state supporting an enriched formula must be non-empty. The NE
@@ -87,7 +88,8 @@ theorem enriched_support_implies_nonempty (M : QBSMLModel W Domain Pred)
 /-- Anti-support of `φ ∧ NE` implies anti-support of `φ`. The split partitions
     the state as `t₁ ∪ t₂` with `antiSupport NE t₂` forcing `t₂ = ∅`, hence
     `t₁ = s`. The QBSML analogue of `BSML/Enrichment`'s `antiSupport_strip_ne`;
-    the workhorse of the free-choice derivations in `QBSML/FreeChoice.lean`. -/
+    the workhorse of the free-choice derivations in
+    `Studies/AloniVanOrmondt2023/FreeChoice.lean`. -/
 theorem antiSupport_strip_ne (M : QBSMLModel W Domain Pred)
     (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
     (h : antiSupport M (.conj φ .ne) s) :

--- a/Linglib/Core/Logic/Modal/QBSML/Properties.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/Properties.lean
@@ -3,48 +3,35 @@ import Linglib.Core.Logic.Team.Closure
 import Linglib.Core.Logic.Team.Definability
 
 /-!
-# QBSML formula properties — Anttila 2021 Proposition 2.2.8 (substrate test)
+# QBSML formula properties
 
 [aloni-vanormondt-2023] [anttila-2021]
 
-**Substrate test**: prove the three structural properties from Anttila 2021
-Proposition 2.2.8 for QBSML's `support` relation, using the SAME
-`Core.Logic.Team.flat_iff_downwardClosed_unionClosed_emptyTeam` template that
-BSML uses (via `Core/Logic/Modal/BSML/Properties.lean`).
+The QBSML instances of the closure properties of [anttila-2021]
+Proposition 2.2.8: NE-free formulas have downward-closed, sup-closed,
+empty-team support, hence flat support, via the same
+`Core.Logic.Team.isFlat_iff` template as
+`Core/Logic/Modal/BSML/Properties.lean`.
 
-The substrate composes for first-order team semantics: the bilateral mutual
-induction pattern from BSML carries over directly, with additional cases for
-quantifiers `exi` and `univ` using
-`State.extendUniversal_union_distrib`, `State.extendUniversal_subset_mono`,
-`State.extendFunctional_union_distrib`, `State.extendFunctional_subset_mono`
-from `Defs.lean`.
+## Main declarations
 
-## Why one big joint induction (not two)
+* `support_empty_of_isNEFree`, `isLowerSet_support_of_isNEFree`,
+  `supClosed_support_of_isNEFree` — the three closure properties.
+* `isFlat_support_of_isNEFree` — flatness of the NE-free fragment
+  ([anttila-2021] Proposition 2.2.16, QBSML specialisation).
+* `soundFor_flat_neFree` — the NE-free fragment is sound for the flat cell
+  of `Team/Definability.lean`.
 
-BSML splits the proof into separate joint inductions per property
-(unionClosed standalone, downwardClosed standalone, emptyTeam standalone).
-That works because BSML's `unionClosed` is unconditional — no operator in
-BSML needs `downwardClosed` of its subformula to establish union closure.
+## Implementation notes
 
-QBSML's `exi` (and dually antiSupport `univ`) is different. The union case
-of support `exi x ψ` constructs a witness `h_st` from the witnesses on `s`
-and `t`, leaving an `(t \ s).extendFunctional x h_t` term that has to be
-weakened to `t.extendFunctional x h_t` via `State.extendFunctional_subset_mono`
-plus downward closure of ψ. So the proof of UC needs DC of ψ as IH —
-which only works if both properties are proved in a single joint induction.
-
-This narrows the result: QBSML's `unionClosed` requires NE-free (BSML's
-doesn't). The flat corollary still composes, since flat consumers use
+BSML proves the closure properties in separate inductions; QBSML cannot.
+The union case of support for `exi` (dually, anti-support for `univ`)
+weakens `(t \ s).extendFunctional x h_t` to `t.extendFunctional x h_t` via
+`State.extendFunctional_mono` plus downward closure of the subformula, so
+union closure and downward closure must live in one joint induction — and
+union closure holds only on the NE-free fragment, whereas BSML's is
+unconditional. The flatness corollary is unaffected: flat consumers use
 NE-free anyway.
-
-## Status
-
-- `emptyTeam_support_of_isNEFree`: **fully proved** (joint bilateral induction
-  over all 8 QBSMLFormula constructors).
-- `unionClosed_support_of_isNEFree`, `downwardClosed_support_of_isNEFree`:
-  **fully proved** via single 4-property joint bilateral induction.
-- `flat_support_of_isNEFree` corollary: derives via
-  `Core.Logic.Team.flat_of_downwardClosed_unionClosed_emptyTeam`.
 -/
 
 namespace Core.Logic.Modal.QBSML
@@ -52,7 +39,7 @@ namespace Core.Logic.Modal.QBSML
 open Core.Logic.Team
 
 variable {W Var Domain Pred : Type*}
-variable [DecidableEq W] [Fintype W]
+variable [DecidableEq W]
 variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
 
 /-! ### Empty-team property for NE-free formulas -/
@@ -60,96 +47,67 @@ variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
 /-- Joint empty-team property: NE-free QBSML formulas have BOTH support and
     anti-support on the empty team. The bilateral mutual induction handles
     the negation case (where support flips to antiSupport). All quantifier
-    cases use `State.extendUniversal_empty` and `State.extendFunctional_empty`. -/
+    cases use `State.extendUniversal_empty` and
+    `State.extendFunctional_empty`. -/
 private theorem support_and_antiSupport_empty_of_isNEFree
-    (φ : QBSMLFormula Var Pred) (hNE : φ.isNEFree = true)
+    {φ : QBSMLFormula Var Pred} (hNE : φ.IsNEFree)
     (M : QBSMLModel W Domain Pred) :
     support M φ (∅ : Finset (Index W Var Domain)) ∧
     antiSupport M φ (∅ : Finset (Index W Var Domain)) := by
-  induction φ with
+  induction hNE with
   | pred P x =>
-    refine ⟨?_, ?_⟩
-    · intro i hi; exact absurd hi (by simp)
-    · intro i hi; exact absurd hi (by simp)
-  | ne => simp [QBSMLFormula.isNEFree] at hNE
-  | neg ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [QBSMLFormula.isNEFree] at hNE; exact hNE
-    have ⟨hs, ha⟩ := ih hψ
+    exact ⟨fun i hi => absurd hi (by simp), fun i hi => absurd hi (by simp)⟩
+  | neg _ ih =>
     -- support (¬ψ) = antiSupport ψ; antiSupport (¬ψ) = support ψ
-    exact ⟨ha, hs⟩
-  | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
-    have ⟨hs₁, ha₁⟩ := ih₁ h₁
-    have ⟨hs₂, ha₂⟩ := ih₂ h₂
-    refine ⟨⟨hs₁, hs₂⟩, ?_⟩
+    exact ⟨ih.2, ih.1⟩
+  | conj _ _ ih₁ ih₂ =>
+    refine ⟨⟨ih₁.1, ih₂.1⟩, ?_⟩
     -- antiSupport (φ₁ ∧ φ₂) ∅: split (∅, ∅)
-    refine ⟨∅, ∅, ?_, ha₁, ha₂⟩
+    refine ⟨∅, ∅, ?_, ih₁.2, ih₂.2⟩
     show ∅ ∪ ∅ = ∅
     simp
-  | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
-    have ⟨hs₁, ha₁⟩ := ih₁ h₁
-    have ⟨hs₂, ha₂⟩ := ih₂ h₂
-    refine ⟨?_, ⟨ha₁, ha₂⟩⟩
-    refine ⟨∅, ∅, ?_, hs₁, hs₂⟩
+  | disj _ _ ih₁ ih₂ =>
+    refine ⟨?_, ih₁.2, ih₂.2⟩
+    refine ⟨∅, ∅, ?_, ih₁.1, ih₂.1⟩
     show ∅ ∪ ∅ = ∅
     simp
-  | poss ψ _ih =>
+  | poss _ _ =>
+    exact ⟨fun i hi => absurd hi (by simp), fun i hi => absurd hi (by simp)⟩
+  | @exi x ψ _ ih =>
     refine ⟨?_, ?_⟩
-    · intro i hi; exact absurd hi (by simp)
-    · intro i hi; exact absurd hi (by simp)
-  | exi x ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [QBSMLFormula.isNEFree] at hNE; exact hNE
-    have ⟨hs, ha⟩ := ih hψ
-    refine ⟨?_, ?_⟩
-    · -- support (∃x ψ) ∅: take h := fun _ => Finset.univ; vacuous nonempty
-      -- Note: this requires Domain to be nonempty for h to be nonempty,
-      -- but vacuously holds since there are no i ∈ ∅.
-      refine ⟨fun _ => ∅, fun i hi => absurd hi (by simp), ?_⟩
-      -- support ψ (∅.extendFunctional x (fun _ => ∅)) = support ψ ∅
-      rw [State.extendFunctional_empty]
-      exact hs
-    · -- antiSupport (∃x ψ) ∅ = antiSupport ψ (∅.extendUniversal x) = antiSupport ψ ∅
-      show antiSupport M ψ (State.extendUniversal (∅ : Finset (Index W Var Domain)) x)
-      rw [State.extendUniversal_empty]
-      exact ha
-  | univ x ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [QBSMLFormula.isNEFree] at hNE; exact hNE
-    have ⟨hs, ha⟩ := ih hψ
-    refine ⟨?_, ?_⟩
-    · -- support (∀x ψ) ∅ = support ψ (∅.extendUniversal x) = support ψ ∅
-      show support M ψ (State.extendUniversal (∅ : Finset (Index W Var Domain)) x)
-      rw [State.extendUniversal_empty]
-      exact hs
-    · -- antiSupport (∀x ψ) ∅: take h := fun _ => ∅; vacuous nonempty
+    · -- support (∃x ψ) ∅: any functional works vacuously; take fun _ => ∅
       refine ⟨fun _ => ∅, fun i hi => absurd hi (by simp), ?_⟩
       rw [State.extendFunctional_empty]
-      exact ha
+      exact ih.1
+    · show antiSupport M ψ
+        (State.extendUniversal (∅ : Finset (Index W Var Domain)) x)
+      rw [State.extendUniversal_empty]
+      exact ih.2
+  | @univ x ψ _ ih =>
+    refine ⟨?_, ?_⟩
+    · show support M ψ
+        (State.extendUniversal (∅ : Finset (Index W Var Domain)) x)
+      rw [State.extendUniversal_empty]
+      exact ih.1
+    · refine ⟨fun _ => ∅, fun i hi => absurd hi (by simp), ?_⟩
+      rw [State.extendFunctional_empty]
+      exact ih.2
 
 /-- NE-free QBSML formulas are supported on the empty team. -/
 theorem support_empty_of_isNEFree {φ : QBSMLFormula Var Pred}
-    (hNE : φ.isNEFree = true) (M : QBSMLModel W Domain Pred) :
+    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Pred) :
     support M φ ∅ :=
-  (support_and_antiSupport_empty_of_isNEFree φ hNE M).1
+  (support_and_antiSupport_empty_of_isNEFree hNE M).1
 
 /-! ### Joint downward + sup closure for NE-free formulas -/
 
 /-- Joint statement of all four closure properties for both polarities of an
     NE-free QBSML formula. The union case of `exi` (and antiSupport `univ`)
-    needs the IH's downward closure for ψ to weaken
+    needs the IH's downward closure for the subformula to weaken
     `t.extendFunctional x h_t` to `(t \ s).extendFunctional x h_t`, so all
     four properties have to live inside one induction. -/
 private theorem support_and_antiSupport_dc_uc_of_isNEFree
-    (φ : QBSMLFormula Var Pred) (hNE : φ.isNEFree = true)
+    {φ : QBSMLFormula Var Pred} (hNE : φ.IsNEFree)
     (M : QBSMLModel W Domain Pred) :
     -- (1) DC support
     (∀ s t : Finset (Index W Var Domain), t ⊆ s → support M φ s → support M φ t) ∧
@@ -162,7 +120,7 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
     -- (4) UC antiSupport
     (∀ s t : Finset (Index W Var Domain),
       antiSupport M φ s → antiSupport M φ t → antiSupport M φ (s ∪ t)) := by
-  induction φ with
+  induction hNE with
   | pred P x =>
     refine ⟨?_, ?_, ?_, ?_⟩
     · intro s t hsub hsupp i hi; exact hsupp i (hsub hi)
@@ -175,20 +133,13 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
       cases hi with
       | inl h => exact hs i h
       | inr h => exact ht i h
-  | ne => simp [QBSMLFormula.isNEFree] at hNE
-  | neg ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [QBSMLFormula.isNEFree] at hNE; exact hNE
-    have ⟨ihdc_s, ihuc_s, ihdc_a, ihuc_a⟩ := ih hψ
+  | neg _ ih =>
+    obtain ⟨ihdc_s, ihuc_s, ihdc_a, ihuc_a⟩ := ih
     -- support (¬ψ) = antiSupport ψ; antiSupport (¬ψ) = support ψ
     exact ⟨ihdc_a, ihuc_a, ihdc_s, ihuc_s⟩
-  | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
-    have ⟨ihdc_s₁, ihuc_s₁, ihdc_a₁, ihuc_a₁⟩ := ih₁ h₁
-    have ⟨ihdc_s₂, ihuc_s₂, ihdc_a₂, ihuc_a₂⟩ := ih₂ h₂
+  | conj _ _ ih₁ ih₂ =>
+    obtain ⟨ihdc_s₁, ihuc_s₁, ihdc_a₁, ihuc_a₁⟩ := ih₁
+    obtain ⟨ihdc_s₂, ihuc_s₂, ihdc_a₂, ihuc_a₂⟩ := ih₂
     refine ⟨?_, ?_, ?_, ?_⟩
     · -- DC support: conj of two supports
       intro s t hsub ⟨hs₁, hs₂⟩
@@ -218,13 +169,9 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
         rw [h1, h2]
       · exact ihuc_a₁ s₁ t₁ ha_s₁ ha_t₁
       · exact ihuc_a₂ s₂ t₂ ha_s₂ ha_t₂
-  | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
-    have ⟨ihdc_s₁, ihuc_s₁, ihdc_a₁, ihuc_a₁⟩ := ih₁ h₁
-    have ⟨ihdc_s₂, ihuc_s₂, ihdc_a₂, ihuc_a₂⟩ := ih₂ h₂
+  | disj _ _ ih₁ ih₂ =>
+    obtain ⟨ihdc_s₁, ihuc_s₁, ihdc_a₁, ihuc_a₁⟩ := ih₁
+    obtain ⟨ihdc_s₂, ihuc_s₂, ihdc_a₂, ihuc_a₂⟩ := ih₂
     refine ⟨?_, ?_, ?_, ?_⟩
     · -- DC support: ∃ split (t₁,t₂) of s; intersect with t
       intro s t hsub ⟨t₁, t₂, hsplit, hs₁, hs₂⟩
@@ -254,7 +201,7 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
     · -- UC antiSupport: conj of two antiSupports
       intro s t ⟨ha₁, ha₂⟩ ⟨ht₁, ht₂⟩
       exact ⟨ihuc_a₁ s t ha₁ ht₁, ihuc_a₂ s t ha₂ ht₂⟩
-  | poss ψ _ih =>
+  | poss _ _ =>
     refine ⟨?_, ?_, ?_, ?_⟩
     · intro s t hsub hsupp i hi; exact hsupp i (hsub hi)
     · intro s t hs ht i hi; simp [Finset.mem_union] at hi
@@ -266,16 +213,13 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
       cases hi with
       | inl h => exact hs i h
       | inr h => exact ht i h
-  | exi x ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [QBSMLFormula.isNEFree] at hNE; exact hNE
-    have ⟨ihdc_s, ihuc_s, ihdc_a, ihuc_a⟩ := ih hψ
+  | @exi x ψ _ ih =>
+    obtain ⟨ihdc_s, ihuc_s, ihdc_a, ihuc_a⟩ := ih
     refine ⟨?_, ?_, ?_, ?_⟩
-    · -- DC support exi: same h works on subteam (via extendFunctional_subset_mono + IH DC)
+    · -- DC support exi: same h works on subteam (via extendFunctional_mono + IH DC)
       intro s t hsub ⟨h, hne, hsupp⟩
       refine ⟨h, fun i hi => hne i (hsub hi), ?_⟩
-      exact ihdc_s _ _
-        (State.extendFunctional_subset_mono x h hsub) hsupp
+      exact ihdc_s _ _ (State.extendFunctional_mono x h hsub) hsupp
     · -- UC support exi: combine h_s, h_t into h_st via if-then-else
       intro s t ⟨h_s, hne_s, hsupp_s⟩ ⟨h_t, hne_t, hsupp_t⟩
       classical
@@ -294,7 +238,7 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
                      State.extendFunctional (t \ s) x h_t := by
           have decomp : s ∪ t = s ∪ (t \ s) := by
             ext y; simp [Finset.mem_union]
-          rw [decomp, State.extendFunctional_union_distrib]
+          rw [decomp, State.extendFunctional_union]
           congr 1
           · unfold State.extendFunctional
             apply Finset.biUnion_congr rfl
@@ -309,36 +253,33 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
         -- support ψ on extendFunctional (t \ s) x h_t — by IH DC of ψ
         have h_ext : support M ψ (State.extendFunctional (t \ s) x h_t) :=
           ihdc_s _ _
-            (State.extendFunctional_subset_mono x h_t Finset.sdiff_subset) hsupp_t
+            (State.extendFunctional_mono x h_t Finset.sdiff_subset) hsupp_t
         exact ihuc_s _ _ hsupp_s h_ext
     · -- DC antiSupport exi: extendUniversal t x ⊆ extendUniversal s x + IH DC
       intro s t hsub hsupp
       show antiSupport M ψ (State.extendUniversal t x)
-      exact ihdc_a _ _ (State.extendUniversal_subset_mono x hsub) hsupp
+      exact ihdc_a _ _ (State.extendUniversal_mono x hsub) hsupp
     · -- UC antiSupport exi: extendUniversal distributes + IH UC
       intro s t hs ht
       show antiSupport M ψ (State.extendUniversal (s ∪ t) x)
-      rw [State.extendUniversal_union_distrib]
+      rw [State.extendUniversal_union]
       exact ihuc_a _ _ hs ht
-  | univ x ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [QBSMLFormula.isNEFree] at hNE; exact hNE
-    have ⟨ihdc_s, ihuc_s, ihdc_a, ihuc_a⟩ := ih hψ
+  | @univ x ψ _ ih =>
+    obtain ⟨ihdc_s, ihuc_s, ihdc_a, ihuc_a⟩ := ih
     refine ⟨?_, ?_, ?_, ?_⟩
     · -- DC support univ: extendUniversal t x ⊆ extendUniversal s x + IH DC
       intro s t hsub hsupp
       show support M ψ (State.extendUniversal t x)
-      exact ihdc_s _ _ (State.extendUniversal_subset_mono x hsub) hsupp
+      exact ihdc_s _ _ (State.extendUniversal_mono x hsub) hsupp
     · -- UC support univ: extendUniversal distributes + IH UC
       intro s t hs ht
       show support M ψ (State.extendUniversal (s ∪ t) x)
-      rw [State.extendUniversal_union_distrib]
+      rw [State.extendUniversal_union]
       exact ihuc_s _ _ hs ht
     · -- DC antiSupport univ: same h works on subteam (mirror of DC support exi)
       intro s t hsub ⟨h, hne, hsupp⟩
       refine ⟨h, fun i hi => hne i (hsub hi), ?_⟩
-      exact ihdc_a _ _
-        (State.extendFunctional_subset_mono x h hsub) hsupp
+      exact ihdc_a _ _ (State.extendFunctional_mono x h hsub) hsupp
     · -- UC antiSupport univ: combine h_s, h_t (mirror of UC support exi)
       intro s t ⟨h_s, hne_s, hsupp_s⟩ ⟨h_t, hne_t, hsupp_t⟩
       classical
@@ -355,7 +296,7 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
                      State.extendFunctional (t \ s) x h_t := by
           have decomp : s ∪ t = s ∪ (t \ s) := by
             ext y; simp [Finset.mem_union]
-          rw [decomp, State.extendFunctional_union_distrib]
+          rw [decomp, State.extendFunctional_union]
           congr 1
           · unfold State.extendFunctional
             apply Finset.biUnion_congr rfl
@@ -368,61 +309,60 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
         rw [eq1]
         have h_ext : antiSupport M ψ (State.extendFunctional (t \ s) x h_t) :=
           ihdc_a _ _
-            (State.extendFunctional_subset_mono x h_t Finset.sdiff_subset) hsupp_t
+            (State.extendFunctional_mono x h_t Finset.sdiff_subset) hsupp_t
         exact ihuc_a _ _ hsupp_s h_ext
 
-/-- NE-free QBSML formulas are downward-closed (Anttila 2.2.8 part 1
-    extended to first-order). -/
+/-- NE-free QBSML formulas are downward-closed ([anttila-2021]
+    Proposition 2.2.8 part 1, extended to first-order). -/
 theorem isLowerSet_support_of_isNEFree {φ : QBSMLFormula Var Pred}
-    (hNE : φ.isNEFree = true) (M : QBSMLModel W Domain Pred) :
+    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Pred) :
     IsLowerSet { t : Finset (Index W Var Domain) | support M φ t } :=
   fun _ _ hab hb =>
-    (support_and_antiSupport_dc_uc_of_isNEFree φ hNE M).1 _ _ hab hb
+    (support_and_antiSupport_dc_uc_of_isNEFree hNE M).1 _ _ hab hb
 
 /-- NE-free QBSML formulas have sup-closed support.
 
     NB: BSML's `supClosed_support` needs no NE-free hypothesis, but
-    QBSML's `exi` UC case needs downward closure of ψ as IH (see file
-    docstring), so the QBSML version narrows to NE-free. The downstream
-    flat corollary consumes NE-free anyway. -/
+    QBSML's `exi` UC case needs downward closure of the subformula as IH
+    (see the module docstring), so the QBSML version narrows to NE-free.
+    The downstream flat corollary consumes NE-free anyway. -/
 theorem supClosed_support_of_isNEFree {φ : QBSMLFormula Var Pred}
-    (hNE : φ.isNEFree = true) (M : QBSMLModel W Domain Pred) :
+    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Pred) :
     SupClosed { t : Finset (Index W Var Domain) | support M φ t } :=
   fun _ ha _ hb =>
-    (support_and_antiSupport_dc_uc_of_isNEFree φ hNE M).2.1 _ _ ha hb
+    (support_and_antiSupport_dc_uc_of_isNEFree hNE M).2.1 _ _ ha hb
 
 /-! ### Flatness corollary -/
 
-/-- **Anttila Proposition 2.2.16 (QBSML specialisation)**: NE-free QBSML
-    formulas are flat. Derived from Anttila 2.2.2
+/-- **[anttila-2021] Proposition 2.2.16 (QBSML specialisation)**: NE-free
+    QBSML formulas are flat. Derived from [anttila-2021] Proposition 2.2.2
     (`Core.Logic.Team.isFlat_iff`) applied to the three closure properties
     above. -/
 theorem isFlat_support_of_isNEFree {φ : QBSMLFormula Var Pred}
-    (hNE : φ.isNEFree = true) (M : QBSMLModel W Domain Pred) :
+    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Pred) :
     IsFlat { t : Finset (Index W Var Domain) | support M φ t } :=
   isFlat_of_isLowerSet_supClosed_empty
     (isLowerSet_support_of_isNEFree hNE M)
     (supClosed_support_of_isNEFree hNE M)
     (support_empty_of_isNEFree hNE M)
 
-/-! ### Soundness for the closure cell (Definability bridge) -/
+/-! ### Soundness for the flat cell (Definability bridge) -/
 
 /-- **The NE-free fragment of QBSML is sound for the flat cell**: every team
     property definable by an NE-free QBSML formula is flat (downward-closed,
-    union-closed, empty-team). This restates [aloni-vanormondt-2023]
-    Proposition 4.1 / Fact 2 — NE-free QBSML reduces to classical first-order
-    modal logic, whose support is flat — in the `Team/Definability.lean`
-    vocabulary.
+    union-closed, empty-team). This restates [aloni-vanormondt-2023]'s
+    observation that NE-free QBSML reduces to classical first-order modal
+    logic, whose support is flat, in the `Team/Definability.lean` vocabulary.
 
-    The restriction to the NE-free fragment is essential, not incidental: NE is
-    the only source of non-classical behaviour (op. cit. Fact 1), and union
-    closure of `exi` already needs downward closure of the subformula as IH (see
-    the file docstring), which NE breaks. So QBSML has no unconditional
-    all-formula cell — unlike BSML, whose NE-bearing formulas still land in the
-    convex, union-closed cell. -/
+    The restriction to the NE-free fragment is essential, not incidental: NE
+    is the only source of non-classical behaviour, and union closure of `exi`
+    already needs downward closure of the subformula as IH (see the module
+    docstring), which NE breaks. So QBSML has no unconditional all-formula
+    cell — unlike BSML, whose NE-bearing formulas still land in the convex,
+    union-closed cell. -/
 theorem soundFor_flat_neFree (M : QBSMLModel W Domain Pred) :
     definableClassWhere (support M)
-      (fun φ : QBSMLFormula Var Pred => φ.isNEFree = true) ⊆ flatProperties := by
+      (fun φ : QBSMLFormula Var Pred => φ.IsNEFree) ⊆ flatProperties := by
   unfold flatProperties
   exact definableClassWhere_subset (C := IsFlat)
     fun _φ hφ => isFlat_support_of_isNEFree hφ M

--- a/Linglib/Studies/Aloni2022.lean
+++ b/Linglib/Studies/Aloni2022.lean
@@ -138,16 +138,16 @@ def plainDisj : BSMLFormula FCAtom :=
 -- ============================================================================
 
 theorem deonticModel_indisputable_on_team :
-    deonticModel.isIndisputable freeChoiceTeam := by decide
+    deonticModel.IsIndisputable freeChoiceTeam := by decide
 
 theorem stateBasedModel_state_based_on_team :
-    stateBasedModel.isStateBased freeChoiceTeam := by decide
+    stateBasedModel.IsStateBased freeChoiceTeam := by decide
 
 theorem deonticModel_not_state_based_on_team :
-    ¬ deonticModel.isStateBased freeChoiceTeam := by decide
+    ¬ deonticModel.IsStateBased freeChoiceTeam := by decide
 
 theorem looseDeonticModel_not_indisputable_on_team :
-    ¬ looseDeonticModel.isIndisputable freeChoiceTeam := by decide
+    ¬ looseDeonticModel.IsIndisputable freeChoiceTeam := by decide
 
 -- ============================================================================
 -- §5 Fact 4 (Narrow Scope FC) at `deonticModel`

--- a/Linglib/Studies/Aloni2022/FreeChoice.lean
+++ b/Linglib/Studies/Aloni2022/FreeChoice.lean
@@ -108,7 +108,7 @@ so s_a ⊆ R[w], yielding ◇α at every world. Symmetrically for β.
 theorem wideScopeFC (M : BSMLModel W Atom)
     (α β : BSMLFormula Atom) (t : Finset W)
     (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
-    (hInd : M.isIndisputable t)
+    (hInd : M.IsIndisputable t)
     (h : support M (enrich (.disj (.poss α) (.poss β))) t) :
     support M (.poss α) t ∧ support M (.poss β) t := by
   obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := h.1
@@ -148,7 +148,7 @@ a non-empty subset of R[w], yielding ◇α and ◇β.
 theorem modalDisjunction (M : BSMLModel W Atom)
     (α β : BSMLFormula Atom) (t : Finset W)
     (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
-    (hSB : M.isStateBased t)
+    (hSB : M.IsStateBased t)
     (h : support M (enrich (.disj α β)) t) :
     support M (.poss α) t ∧ support M (.poss β) t := by
   -- Unpack enriched disjunction: t = t₁ ∪ t₂ with enriched support

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -144,8 +144,8 @@ def possPxOrQx : QBSMLFormula QVar QPred := .poss PxOrQx
 -- §4 Substrate facts: Px, Qx are NE-free
 -- ============================================================================
 
-theorem Px_isNEFree : Px.isNEFree = true := rfl
-theorem Qx_isNEFree : Qx.isNEFree = true := rfl
+theorem Px_isNEFree : Px.IsNEFree := .pred _ _
+theorem Qx_isNEFree : Qx.IsNEFree := .pred _ _
 
 -- ============================================================================
 -- §5 Fact 10 (Negation): `[¬(Pa ∨ Pb)]⁺ ⊨ ¬Pa ∧ ¬Pb`
@@ -198,7 +198,7 @@ theorem fact8_narrowScopeFC
     they hold on every model. -/
 theorem avoModel_indisputable
     (s : Finset (Index PowerSet2World QVar FCAtom)) :
-    avoModel.isIndisputable s := by
+    avoModel.IsIndisputable s := by
   intro _ _ _ _; rfl
 
 end AloniVanOrmondt2023

--- a/Linglib/Studies/AloniVanOrmondt2023/FreeChoice.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023/FreeChoice.lean
@@ -6,36 +6,32 @@ import Linglib.Core.Logic.Modal.QBSML.Enrichment
 [aloni-vanormondt-2023] [aloni-2022]
 
 The first-order analogues of `BSML/FreeChoice.lean`'s theorems. Pragmatic
-enrichment (Aloni & van Ormondt 2023 Definition 4.13) combined with split
-disjunction (§3.1) and bilateral evaluation (§4) derives ignorance,
-free-choice, distribution, obviation, and behaviour-under-negation
-inferences as universal substrate facts — applicable to any QBSML model
-satisfying the relevant frame conditions.
+enrichment ([aloni-vanormondt-2023] Definition 4.13) combined with split
+disjunction and bilateral evaluation derives ignorance, free-choice,
+distribution, obviation, and behaviour-under-negation inferences as
+universal substrate facts — applicable to any QBSML model satisfying the
+relevant frame conditions.
 
 ## Status
 
-This file currently lands the **negation fact (Fact 10)** as a universal
-substrate theorem, plus the `enrichment_strengthens_*` engine that powers
-the rest of the §5 facts. Future additions:
-- `narrowScopeFC_Q` (Fact 8) — needs world-projection lemmas for
-  `State.modalLift`
-- `universalFC_Q` (Fact 9) — needs `State.extendUniversal` lemmas + the
-  modal pattern from `narrowScopeFC_Q`
-- `modalDisjunction_Q` (Fact 3) — needs state-based frame condition handling
-- The wide-scope variants
+Lands **Fact 10 (negation)** and **Fact 8 (narrow-scope FC)** as universal
+substrate theorems, plus the `enrichment_strengthens_*` engine that powers
+the rest of the §5 facts. Future additions: `universalFC_Q` (Fact 9, needs
+the modal pattern over `State.extendUniversal`), `modalDisjunction_Q`
+(Fact 3, needs state-based frame condition handling), and the wide-scope
+variants.
 
-The negation fact is the cleanest standalone result — it requires no frame
-condition on `R` (Aloni & van Ormondt 2023 page 564 proof: "We assume that
-M, s ⊨ [¬(Pa ∨ Pb)]⁺. This means that s ≠ ∅ and M, s ⊧ [Pa ∨ Pb]⁺. ..."
-— frame conditions on `R` are not invoked).
+The negation fact requires no frame condition on `R` ([aloni-vanormondt-2023]
+page 564 proof: "We assume that M, s ⊨ [¬(Pa ∨ Pb)]⁺. This means that s ≠ ∅
+and M, s ⊧ [Pa ∨ Pb]⁺. ..." — frame conditions on `R` are not invoked).
 
 ## Proof architecture (mirrors `BSML/FreeChoice.lean`)
 
 1. **Joint enrichment-strengthens** (`enrichment_strengthens_both`):
-   simultaneous induction on QBSMLFormula proving both
-   `support enrich φ → support φ` and `antiSupport enrich φ → antiSupport φ`
-   for NE-free `φ`. The mutual structure handles negation: `support (¬ψ) =
-   antiSupport ψ`, so the two directions interleave.
+   simultaneous induction on the NE-free derivation proving both
+   `support enrich φ → support φ` and `antiSupport enrich φ → antiSupport φ`.
+   The mutual structure handles negation: `support (¬ψ) = antiSupport ψ`, so
+   the two directions interleave.
 
 2. **Negation strip** (`negationStrip_Q`): for NE-free α, β,
    `[¬(α ∨ β)]⁺ ⊨ ¬α ∧ ¬β`. Composes `antiSupport_strip_ne` (in
@@ -48,38 +44,33 @@ namespace AloniVanOrmondt2023
 open Core.Logic.Modal.QBSML
 
 variable {W Var Domain Pred : Type*}
-variable [DecidableEq W] [Fintype W]
+variable [DecidableEq W]
 variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
 
--- ============================================================================
--- §1 Enrichment strengthens (joint bilateral induction)
--- ============================================================================
+/-! ### Enrichment strengthens (joint bilateral induction) -/
 
 /-- Both directions of "enrichment strengthens" (Fact 1 of [aloni-2022]
     extended to QBSML). For NE-free `φ`:
     - `support M (enrich φ) s → support M φ s`
     - `antiSupport M (enrich φ) s → antiSupport M φ s`
 
-    Joint bilateral induction over `QBSMLFormula`. The negation case
+    Joint bilateral induction over the NE-free derivation. The negation case
     interleaves the two directions (support of `¬ψ` is anti-support of `ψ`).
     All quantifier cases use `antiSupport_strip_ne` to peel the `NE`
     conjunct, then `extendUniversal` / `extendFunctional` to apply the IH
     on the extended state. -/
 private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (hNE : φ.isNEFree = true) :
+    {φ : QBSMLFormula Var Pred} (hNE : φ.IsNEFree) :
     (∀ s : Finset (Index W Var Domain), support M φ.enrich s → support M φ s) ∧
     (∀ s : Finset (Index W Var Domain),
         antiSupport M φ.enrich s → antiSupport M φ s) := by
-  induction φ with
-  | ne => simp [QBSMLFormula.isNEFree] at hNE
+  induction hNE with
   | pred P x =>
     refine ⟨?_, ?_⟩
     · intro s h; exact h.1
     · intro s h; exact antiSupport_strip_ne M (.pred P x) s h
-  | neg ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [QBSMLFormula.isNEFree] at hNE; exact hNE
-    have ⟨ih_s, ih_a⟩ := ih hψ
+  | @neg ψ _ ih =>
+    obtain ⟨ih_s, ih_a⟩ := ih
     refine ⟨?_, ?_⟩
     · -- support (¬ψ).enrich s = support ((¬ψ.enrich) ∧ NE) s = antiSupport ψ.enrich s ∧ NE
       intro s h
@@ -88,29 +79,20 @@ private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Pred)
     · -- antiSupport (¬ψ).enrich s; strip the outer NE; reduces to support ψ.enrich s
       intro s h
       have h' := antiSupport_strip_ne M (.neg ψ.enrich) s h
-      -- h' : antiSupport M (.neg ψ.enrich) s = support M ψ.enrich s
       show support M ψ s
       exact ih_s s h'
-  | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have hψ₁ : ψ₁.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have hψ₂ : ψ₂.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
-    have ⟨ih₁_s, ih₁_a⟩ := ih₁ hψ₁
-    have ⟨ih₂_s, ih₂_a⟩ := ih₂ hψ₂
+  | @conj ψ₁ ψ₂ _ _ ih₁ ih₂ =>
+    obtain ⟨ih₁_s, ih₁_a⟩ := ih₁
+    obtain ⟨ih₂_s, ih₂_a⟩ := ih₂
     refine ⟨?_, ?_⟩
     · intro s h; exact ⟨ih₁_s s h.1.1, ih₂_s s h.1.2⟩
     · intro s h
       have h' := antiSupport_strip_ne M (.conj ψ₁.enrich ψ₂.enrich) s h
       obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := h'
       exact ⟨t₁, t₂, hunion, ih₁_a t₁ h₁, ih₂_a t₂ h₂⟩
-  | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have hψ₁ : ψ₁.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have hψ₂ : ψ₂.isNEFree = true := by
-      simp only [QBSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
-    have ⟨ih₁_s, ih₁_a⟩ := ih₁ hψ₁
-    have ⟨ih₂_s, ih₂_a⟩ := ih₂ hψ₂
+  | @disj ψ₁ ψ₂ _ _ ih₁ ih₂ =>
+    obtain ⟨ih₁_s, ih₁_a⟩ := ih₁
+    obtain ⟨ih₂_s, ih₂_a⟩ := ih₂
     refine ⟨?_, ?_⟩
     · intro s h
       obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := h.1
@@ -118,10 +100,8 @@ private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Pred)
     · intro s h
       have h' := antiSupport_strip_ne M (.disj ψ₁.enrich ψ₂.enrich) s h
       exact ⟨ih₁_a s h'.1, ih₂_a s h'.2⟩
-  | poss ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [QBSMLFormula.isNEFree] at hNE; exact hNE
-    have ⟨ih_s, ih_a⟩ := ih hψ
+  | @poss ψ _ ih =>
+    obtain ⟨ih_s, ih_a⟩ := ih
     refine ⟨?_, ?_⟩
     · intro s h i hi
       obtain ⟨X, hX, hne, hsupp⟩ := h.1 i hi
@@ -129,10 +109,8 @@ private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Pred)
     · intro s h
       have h' := antiSupport_strip_ne M (.poss ψ.enrich) s h
       exact fun i hi => ih_a _ (h' i hi)
-  | exi x ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [QBSMLFormula.isNEFree] at hNE; exact hNE
-    have ⟨ih_s, ih_a⟩ := ih hψ
+  | @exi x ψ _ ih =>
+    obtain ⟨ih_s, ih_a⟩ := ih
     refine ⟨?_, ?_⟩
     · -- support (.exi x ψ).enrich s = (∃ h, ... support ψ.enrich (s.extendFunctional x h)) ∧ NE
       intro s h
@@ -143,10 +121,8 @@ private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Pred)
       have h' := antiSupport_strip_ne M (.exi x ψ.enrich) s h
       show antiSupport M ψ (State.extendUniversal s x)
       exact ih_a _ h'
-  | univ x ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [QBSMLFormula.isNEFree] at hNE; exact hNE
-    have ⟨ih_s, ih_a⟩ := ih hψ
+  | @univ x ψ _ ih =>
+    obtain ⟨ih_s, ih_a⟩ := ih
     refine ⟨?_, ?_⟩
     · -- support (.univ x ψ).enrich s = support ψ.enrich (s.extendUniversal x) ∧ NE
       intro s h
@@ -158,91 +134,25 @@ private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Pred)
       obtain ⟨h_fn, hne, hsupp⟩ := h'
       exact ⟨h_fn, hne, ih_a _ hsupp⟩
 
-/-- **Enrichment strengthens (support direction)** — Aloni 2022 Fact 1
+/-- **Enrichment strengthens (support direction)** — [aloni-2022] Fact 1
     extended to QBSML. For NE-free `φ`, supporting the enriched form implies
     supporting the original. -/
 theorem enrichment_strengthens_support (M : QBSMLModel W Domain Pred)
     (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
-    (hNE : φ.isNEFree = true)
+    (hNE : φ.IsNEFree)
     (h : support M φ.enrich s) :
     support M φ s :=
-  (enrichment_strengthens_both M φ hNE).1 s h
+  (enrichment_strengthens_both M hNE).1 s h
 
 /-- **Enrichment strengthens (anti-support direction)**. -/
 theorem enrichment_strengthens_antiSupport (M : QBSMLModel W Domain Pred)
     (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
-    (hNE : φ.isNEFree = true)
+    (hNE : φ.IsNEFree)
     (h : antiSupport M φ.enrich s) :
     antiSupport M φ s :=
-  (enrichment_strengthens_both M φ hNE).2 s h
+  (enrichment_strengthens_both M hNE).2 s h
 
--- ============================================================================
--- §2 Helper: modalLift world-projection (for narrow-scope FC)
--- ============================================================================
-
-/-- For any state `s` contained in `State.modalLift X g`, the world-projection
-    of `s` lifted back via `modalLift` recovers `s` exactly. The key fact:
-    `modalLift X g` produces only indices of the form `(v, g)` for `v ∈ X`,
-    so every index in `s` has assignment `g`, and projecting-then-lifting
-    is the identity. -/
-private lemma modalLift_image_fst_subset {s : Finset (Index W Var Domain)}
-    {X : Finset W} {g : Assignment Var Domain}
-    (h : s ⊆ State.modalLift X g) :
-    State.modalLift (s.image Prod.fst) g = s := by
-  -- Every i ∈ s has snd = g (since s ⊆ modalLift X g and modalLift produces (?, g)).
-  have hsnd : ∀ i ∈ s, i.snd = g := by
-    intro i hi
-    have himodal : i ∈ State.modalLift X g := h hi
-    simp only [State.modalLift, Finset.mem_image] at himodal
-    obtain ⟨w, _, hw⟩ := himodal
-    rw [← hw]
-  ext i
-  simp only [State.modalLift, Finset.mem_image]
-  constructor
-  · rintro ⟨v, ⟨j, hjs, hjv⟩, hvi⟩
-    -- j ∈ s, j.fst = v, (v, g) = i. Show i = j.
-    have hjeq : j = (v, g) := Prod.ext hjv (hsnd j hjs)
-    -- (v, g) = i, j = (v, g) → j = i
-    rwa [hjeq, hvi] at hjs
-  · intro hi
-    -- i ∈ s. Witness v = i.fst; (i.fst, g) = i because i.snd = g (by hsnd).
-    refine ⟨i.fst, ⟨i, hi, rfl⟩, ?_⟩
-    -- Goal: (i.fst, g) = i. Use Prod.ext: fst trivial, snd = g via hsnd.
-    exact Prod.ext rfl (hsnd i hi).symm
-
-/-- The world projection of `modalLift X g` is `X` itself. -/
-private lemma modalLift_image_fst (X : Finset W) (g : Assignment Var Domain) :
-    (State.modalLift X g).image Prod.fst = X := by
-  unfold State.modalLift
-  ext v
-  simp only [Finset.mem_image]
-  constructor
-  · rintro ⟨_, ⟨w, hwX, hw⟩, hwv⟩
-    rw [← hw] at hwv
-    simp at hwv
-    rwa [← hwv]
-  · intro hvX
-    exact ⟨(v, g), ⟨v, hvX, rfl⟩, rfl⟩
-
-/-- World-projection of a subset of `modalLift X g` is itself a subset of `X`. -/
-private lemma image_fst_subset_of_subset_modalLift
-    {s : Finset (Index W Var Domain)} {X : Finset W}
-    {g : Assignment Var Domain}
-    (h : s ⊆ State.modalLift X g) :
-    s.image Prod.fst ⊆ X := by
-  intro v hv
-  obtain ⟨j, hjs, hjv⟩ := Finset.mem_image.mp hv
-  have hjmodal := h hjs
-  obtain ⟨w, hwX, hw⟩ := by
-    simp only [State.modalLift, Finset.mem_image] at hjmodal
-    exact hjmodal
-  rw [← hw] at hjv
-  simp at hjv
-  rwa [← hjv]
-
--- ============================================================================
--- §3 Negation behaviour (Fact 10)
--- ============================================================================
+/-! ### Negation behaviour (Fact 10) -/
 
 /-- **Fact 10 (negation behaviour)** of [aloni-vanormondt-2023]:
 
@@ -258,7 +168,7 @@ private lemma image_fst_subset_of_subset_modalLift
     each disjunct. -/
 theorem negationStrip_Q (M : QBSMLModel W Domain Pred)
     (α β : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
-    (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
+    (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (.neg (.disj α β))) s) :
     support M (.neg α) s ∧ support M (.neg β) s := by
   -- Outer: enrich (¬(α ∨ β)) = (¬enrich (α ∨ β)) ∧ NE; project outer NE.
@@ -272,9 +182,7 @@ theorem negationStrip_Q (M : QBSMLModel W Domain Pred)
   exact ⟨enrichment_strengthens_antiSupport M α s hα hL,
          enrichment_strengthens_antiSupport M β s hβ hR⟩
 
--- ============================================================================
--- §4 Narrow-scope free choice (Fact 8)
--- ============================================================================
+/-! ### Narrow-scope free choice (Fact 8) -/
 
 /-- **Fact 8 (◇-free choice / narrow-scope FC)** of [aloni-vanormondt-2023]
     (the first-order analogue of [aloni-2022] Fact 4):
@@ -283,13 +191,13 @@ theorem negationStrip_Q (M : QBSMLModel W Domain Pred)
 
     Per-index `i ∈ s`: the enriched `◇` provides a non-empty `X ⊆ R(i.world)`
     with split `t₁ ∪ t₂ = modalLift X i.assign`, each part supporting the
-    enriched disjunct on its piece. Project each piece's worlds back via
-    `s.image Prod.fst` and use `modalLift_image_fst_subset` to recover
-    a Finset W witness. `enrichment_strengthens_support` discharges the
+    enriched disjunct on its piece. `State.modalLift_worldProj_of_subset`
+    recovers each piece from its world projection, which serves as the
+    `Finset W` witness; `enrichment_strengthens_support` discharges the
     enrichment to plain support of α, β. -/
 theorem narrowScopeFC_Q (M : QBSMLModel W Domain Pred)
     (α β : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
-    (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
+    (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (.poss (.disj α β))) s) :
     support M (.poss α) s ∧ support M (.poss β) s := by
   -- Outer: enrich (◇φ) = (◇enrich φ) ∧ NE; project the diamond clause.
@@ -297,39 +205,27 @@ theorem narrowScopeFC_Q (M : QBSMLModel W Domain Pred)
   refine ⟨?_, ?_⟩
   · intro i hi
     obtain ⟨X, hX, _, hsupp⟩ := hPoss i hi
-    -- hsupp : support M ((.disj α β).enrich) (modalLift X i.assign)
-    --        = support M (.conj (.disj α.enrich β.enrich) .ne) (modalLift X i.assign)
-    -- Project: support of the inner disj on modalLift X i.assign
+    -- hsupp : support of the enriched disjunction on modalLift X i.assign;
+    -- project its split and keep the α piece t₁.
     obtain ⟨t₁, t₂, hunion, h₁, _h₂⟩ := hsupp.1
-    -- h₁ : support α.enrich t₁; need ◇α at i with witness t₁'s world projection.
     have ht₁_sub : t₁ ⊆ State.modalLift X i.assign :=
       hunion ▸ Finset.subset_union_left
-    have ht₁_modal : State.modalLift (t₁.image Prod.fst) i.assign = t₁ :=
-      modalLift_image_fst_subset ht₁_sub
-    have ht₁_subX : t₁.image Prod.fst ⊆ X :=
-      image_fst_subset_of_subset_modalLift ht₁_sub
-    refine ⟨t₁.image Prod.fst, ht₁_subX.trans hX, ?_, ?_⟩
-    · -- t₁.image Prod.fst is nonempty: t₁ is nonempty (by enrichment NE) so its image is.
-      have ht₁_ne : t₁.Nonempty :=
-        enriched_support_implies_nonempty M α t₁ h₁
-      exact ht₁_ne.image _
-    · -- support α (modalLift (t₁.image Prod.fst) i.assign) = support α t₁
-      rw [ht₁_modal]
-      exact enrichment_strengthens_support M α t₁ hα h₁
+    refine ⟨State.worldProj t₁,
+      (State.worldProj_subset_of_subset_modalLift ht₁_sub).trans hX,
+      State.worldProj_nonempty (enriched_support_implies_nonempty M α t₁ h₁),
+      ?_⟩
+    rw [State.modalLift_worldProj_of_subset ht₁_sub]
+    exact enrichment_strengthens_support M α t₁ hα h₁
   · intro i hi
     obtain ⟨X, hX, _, hsupp⟩ := hPoss i hi
     obtain ⟨t₁, t₂, hunion, _h₁, h₂⟩ := hsupp.1
     have ht₂_sub : t₂ ⊆ State.modalLift X i.assign :=
       hunion ▸ Finset.subset_union_right
-    have ht₂_modal : State.modalLift (t₂.image Prod.fst) i.assign = t₂ :=
-      modalLift_image_fst_subset ht₂_sub
-    have ht₂_subX : t₂.image Prod.fst ⊆ X :=
-      image_fst_subset_of_subset_modalLift ht₂_sub
-    refine ⟨t₂.image Prod.fst, ht₂_subX.trans hX, ?_, ?_⟩
-    · have ht₂_ne : t₂.Nonempty :=
-        enriched_support_implies_nonempty M β t₂ h₂
-      exact ht₂_ne.image _
-    · rw [ht₂_modal]
-      exact enrichment_strengthens_support M β t₂ hβ h₂
+    refine ⟨State.worldProj t₂,
+      (State.worldProj_subset_of_subset_modalLift ht₂_sub).trans hX,
+      State.worldProj_nonempty (enriched_support_implies_nonempty M β t₂ h₂),
+      ?_⟩
+    rw [State.modalLift_worldProj_of_subset ht₂_sub]
+    exact enrichment_strengthens_support M β t₂ hβ h₂
 
 end AloniVanOrmondt2023

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -6803,6 +6803,19 @@
   validated = {true},
   role      = {referenced}
 }
+@mastersthesis{anttila-2021,
+  author    = {Anttila, Aleksi},
+  year      = {2021},
+  title     = {The Logic of Free Choice: Axiomatizations of State-based Modal Logics},
+  school    = {Universiteit van Amsterdam, Institute for Logic, Language and Computation},
+  type      = {{MSc} thesis, {MoL} series},
+  number    = {MoL-2021-03},
+  url       = {https://msclogic.illc.uva.nl/theses/archive/publication/4941/The-Logic-of-Free-Choice-Axiomatizations-of-State-based-Modal-Logics},
+  subfield  = {semantics/modality},
+  validated = {true},
+  role      = {formalized},
+  sources   = {Core/Logic/Modal/BSML/Properties.lean;Core/Logic/Modal/QBSML/Properties.lean;Core/Logic/Team/Algebra.lean}
+}
 @phdthesis{anttila-2025,
   author    = {Anttila, Aleksi},
   year      = {2025},


### PR DESCRIPTION
Bring `QBSML/Defs.lean` to mathlib file conventions (multi-agent audit of a randomly sampled file).

- `isNEFree : Bool` → inductive `IsNEFree : … → Prop` (ModelTheory `IsQF` pattern); joint inductions in Properties/FreeChoice now induct on the derivation. `@[simp] mem_*` API for the state extensions; `_union_distrib`/`_subset_mono` → `_union`/`_mono`; `unfold`+`ext` proofs collapse to mathlib one-liners.
- Drop unused `[DecidableEq W] [Fintype W]` binders on `QBSMLModel` (+ two redundant `DecidableEq` instances, dead `dne_*` twins); `isStateBased`/`isIndisputable` → `IsStateBased`/`IsIndisputable` in QBSML and BSML, with `Decidable` instances for QBSML; single namespace block, `/-! ### -/` headers, terse module docstring.
- Promote `worldProj`/`modalLift` lemmas from private duplicates in `Studies/AloniVanOrmondt2023/FreeChoice.lean`; add verified `anttila-2021` bib entry (MoL-2021-03) for an unresolved `[key]`; fix fossil lemma names and stale file paths in docstrings.