### PR TITLE
refactor(Syntax/ConstructionGrammar): audit cleanup, decide sweep

### DIFF
--- a/Linglib/Fragments/English/Binominals.lean
+++ b/Linglib/Fragments/English/Binominals.lean
@@ -348,12 +348,6 @@ construction — no dangling name-keyed links. -/
 theorem ofBinominalNetwork_wellFormed : ofBinominalNetwork.WellFormed := by
   decide
 
-/-- The network has 8 constructions (6 of-binominal + simple NP + AP). -/
-theorem network_size : ofBinominalNetwork.constructions.length = 8 := rfl
-
-/-- The network has 9 links (4 grammaticalization + 1 N+PP polysemy + 4 polysemy to NP/AP). -/
-theorem network_links : ofBinominalNetwork.links.length = 9 := rfl
-
 -- ═══════════════════════════════════════════════════════════════
 -- § 4: Per-Entry Verification
 -- ═══════════════════════════════════════════════════════════════
@@ -369,16 +363,16 @@ theorem idiot_evaluative_only : idiot.constructions = [.evaluative] := rfl
 
 /-- *beast* has no pseudo-partitive (typical for animate N₁ nouns). -/
 theorem beast_no_pseudopartitive :
-    beast.constructions.elem .pseudoPartitive = false := by native_decide
+    beast.constructions.elem .pseudoPartitive = false := by decide
 
 /-- *snake* is an exceptional animate noun with pseudo-partitive attestations. -/
-theorem snake_pseudopartitive : snake.constructions.elem .pseudoPartitive = true := by native_decide
+theorem snake_pseudopartitive : snake.constructions.elem .pseudoPartitive = true := by decide
 
 /-- All inanimate N₁ nouns develop pseudo-partitive readings. -/
-theorem cake_pseudopartitive : cake.constructions.elem .pseudoPartitive = true := by native_decide
-theorem nub_pseudopartitive : nub.constructions.elem .pseudoPartitive = true := by native_decide
-theorem breeze_pseudopartitive : breeze.constructions.elem .pseudoPartitive = true := by native_decide
-theorem husk_pseudopartitive : husk.constructions.elem .pseudoPartitive = true := by native_decide
+theorem cake_pseudopartitive : cake.constructions.elem .pseudoPartitive = true := by decide
+theorem nub_pseudopartitive : nub.constructions.elem .pseudoPartitive = true := by decide
+theorem breeze_pseudopartitive : breeze.constructions.elem .pseudoPartitive = true := by decide
+theorem husk_pseudopartitive : husk.constructions.elem .pseudoPartitive = true := by decide
 
 -- ═══════════════════════════════════════════════════════════════
 -- § 5: Cross-Linguistic Bridge (English ↔ Spanish)

--- a/Linglib/Phenomena/ArgumentStructure/TheoryComparison.lean
+++ b/Linglib/Phenomena/ArgumentStructure/TheoryComparison.lean
@@ -168,18 +168,18 @@ theorem convergence_hammer_flat_arg_count :
     cxg_hammer_flat.surfaceFrame.length = 3 ∧
     dg_hammer_flat.allArgs.length = 3 := by
   constructor; rfl
-  constructor; native_decide
+  constructor; decide
   rfl
 
 /-- The theta criterion is satisfied for the canonical resultative. -/
 theorem theta_criterion_canonical :
     thetaCriterionSatisfied minimalist_hammer_flat = true := by
-  native_decide
+  decide
 
 /-- FAR is satisfied for the canonical CxG resultative. -/
 theorem far_canonical :
     cxg_hammer_flat.farSatisfied = true := by
-  native_decide
+  decide
 
 /-! ## §3. Divergence on fake reflexives
 
@@ -227,14 +227,14 @@ def dg_laugh_silly : DGFrame :=
     The construction licenses the extra argument ("herself"). -/
 theorem cxg_construction_adds_patient :
     cxg_laugh_silly.verbRoles.length < cxg_laugh_silly.surfaceFrame.length := by
-  native_decide
+  decide
 
 /-- CxG handles fake reflexives without stipulation: the construction
     adds the patient role, and the verb's agent fuses with the
     construction's agent. FAR is satisfied. -/
 theorem cxg_fake_reflexive_far :
     cxg_laugh_silly.farSatisfied = true := by
-  native_decide
+  decide
 
 /-- The Minimalist verb alone cannot license the reflexive:
     the verb has only 1 theta role but the surface has 3 arguments.
@@ -244,7 +244,7 @@ theorem cxg_fake_reflexive_far :
 theorem minimalist_verb_deficit :
     minimalist_laugh_silly_verb_roles.length <
     minimalist_laugh_silly_full.length := by
-  native_decide
+  decide
 
 /-- DG: the construction adds 2 arguments to the verb's base valency of 1. -/
 theorem dg_construction_adds_args :
@@ -259,7 +259,7 @@ theorem convergence_fake_reflexive_count :
     cxg_laugh_silly.surfaceFrame.length = 3 ∧
     dg_laugh_silly.allArgs.length = 3 := by
   constructor; rfl
-  constructor; native_decide
+  constructor; decide
   rfl
 
 /-! ## §4. Semantic Coherence generalizes the Theta Criterion
@@ -294,8 +294,8 @@ theorem semanticCoherenceGeneralizesTheta :
     cxg_laugh_silly.farSatisfied = true ∧
     cxg_laugh_silly.verbRoles.length < cxg_laugh_silly.surfaceFrame.length := by
   constructor
-  · native_decide
-  · native_decide
+  · decide
+  · decide
 
 /-! ## Summary
 

--- a/Linglib/Phenomena/NullSubject/Basic.lean
+++ b/Linglib/Phenomena/NullSubject/Basic.lean
@@ -5,7 +5,7 @@ Framework-agnostic typological parameter: whether a language permits
 null thematic subjects (*pro*-drop) and whether the subject of an
 obligatory-control clause must be overt.
 
-This file is in `Core/` because the *parameter* is theory-neutral —
+This file is theory-neutral data because the *parameter* is theory-neutral —
 any syntactic framework (Minimalism, HPSG, LFG, Construction Grammar)
 must engage with it. Theory-laden *explanations* of the parameter
 (rich-agreement licensing, the EPP, topic drop, etc.) belong in

--- a/Linglib/Semantics/Causation/ProductionDependence.lean
+++ b/Linglib/Semantics/Causation/ProductionDependence.lean
@@ -183,7 +183,7 @@ theorem dependence_asserts_necessity :
 
 Thick causative manner verbs (break-class) are compatible with strong
 adjectival resultatives (*break open*, *burn clean*). This connects to
-the resultative infrastructure in ArgumentStructure/Studies/TheoryComparison.lean,
+the resultative infrastructure in Phenomena/ArgumentStructure/TheoryComparison.lean,
 where the constructional CAUSE uses `Causative.make`. -/
 
 /-- Causative manner verbs (thickManner) are compatible with strong ASR.

--- a/Linglib/Studies/Benz2025.lean
+++ b/Linglib/Studies/Benz2025.lean
@@ -111,7 +111,7 @@ theorem beobachtung_three_readings :
     (allBeobachtungReadings.any (·.reading == .complexEvent)) = true ∧
     (allBeobachtungReadings.any (·.reading == .simpleEntity)) = true ∧
     (allBeobachtungReadings.any (·.reading == .content)) = true := by
-  refine ⟨?_, ?_, ?_⟩ <;> native_decide
+  refine ⟨?_, ?_, ?_⟩ <;> decide
 
 -- ────────────────────────────────────────────────────
 -- § 2. Diagnostic Properties
@@ -340,7 +340,7 @@ def structurallyCompatible (outer inner : PreverbalElement) : Bool :=
 /-- The structural prediction matches Table 3's "Structure Predicts" column. -/
 theorem structural_prediction_matches :
     cooccurrenceTable.map (λ d => structurallyCompatible d.outer d.inner) =
-    cooccurrenceTable.map (λ d => d.structurePredicts) := by native_decide
+    cooccurrenceTable.map (λ d => d.structurePredicts) := by decide
 
 -- ────────────────────────────────────────────────────
 -- § 8. Interpretive Prediction: Result State Conflict
@@ -358,7 +358,7 @@ def interpretivelyCompatible (outer inner : PreverbalElement) : Bool :=
 /-- The interpretive prediction matches Table 3's "Interpretation Predicts" column. -/
 theorem interpretive_prediction_matches :
     cooccurrenceTable.map (λ d => interpretivelyCompatible d.outer d.inner) =
-    cooccurrenceTable.map (λ d => d.interpretationPredicts) := by native_decide
+    cooccurrenceTable.map (λ d => d.interpretationPredicts) := by decide
 
 -- ────────────────────────────────────────────────────
 -- § 9. Combined Prediction
@@ -375,11 +375,11 @@ def predictedAllowed (outer inner : PreverbalElement) : Bool :=
 /-- The combined prediction matches Table 3's "Allowed" column. -/
 theorem combined_prediction_matches :
     cooccurrenceTable.map (λ d => predictedAllowed d.outer d.inner) =
-    cooccurrenceTable.map (λ d => d.allowed) := by native_decide
+    cooccurrenceTable.map (λ d => d.allowed) := by decide
 
 /-- PRT-pfx is the unique allowed combination. -/
 theorem prt_pfx_uniquely_allowed :
-    (cooccurrenceTable.filter (·.allowed)).length = 1 := by native_decide
+    (cooccurrenceTable.filter (·.allowed)).length = 1 := by decide
 
 -- ────────────────────────────────────────────────────
 -- § 10. German Resultative Data (§4.2)
@@ -431,7 +431,7 @@ theorem german_allows_non_unergative_M :
     (germanRSPData.any (·.verbClass == "obligatorily transitive")) = true ∧
     (germanRSPData.any (·.verbClass == "unaccusative")) = true ∧
     (germanRSPData.any (·.verbClass == "inherently reflexive")) = true := by
-  refine ⟨?_, ?_, ?_⟩ <;> native_decide
+  refine ⟨?_, ?_, ?_⟩ <;> decide
 
 -- ────────────────────────────────────────────────────
 -- § 11. RSP Co-occurrence Restriction Data (§4.1)
@@ -477,7 +477,7 @@ def rsp_pfx_contrasts : List (GermanResultativeDatum × GermanResultativeDatum) 
 theorem rsp_pfx_contrast_pattern :
     rsp_pfx_contrasts.all (fun (bad, good) =>
       bad.judgment == .unacceptable && good.judgment == .ok) = true := by
-  native_decide
+  decide
 
 /-- RSPs are also incompatible with particles.
     Ch. 4: adding an RSP to a particle verb is ungrammatical,
@@ -509,7 +509,7 @@ def rsp_prt_contrasts : List (GermanResultativeDatum × GermanResultativeDatum) 
 theorem rsp_prt_contrast_pattern :
     rsp_prt_contrasts.all (fun (bad, good) =>
       bad.judgment == .unacceptable && good.judgment == .ok) = true := by
-  native_decide
+  decide
 
 -- ════════════════════════════════════════════════════════════════════
 -- Part III: Allosemy and Locality (Ch. 2, Ch. 4)
@@ -573,7 +573,7 @@ theorem claim1_two_factors :
     -- Interpretation alone is insufficient
     (cooccurrenceTable.any (λ d =>
       d.interpretationPredicts && !d.structurePredicts && !d.allowed)) = true := by
-  constructor <;> native_decide
+  constructor <;> decide
 
 -- ════════════════════════════════════════════════════════════════════
 -- Part IV: Prefixes in Nominalizations (Ch. 5)

--- a/Linglib/Studies/GoldbergJackendoff2004.lean
+++ b/Linglib/Studies/GoldbergJackendoff2004.lean
@@ -123,7 +123,7 @@ theorem drinkSick_means : drinkSick.subeventRelation = .means := rfl
     RESULT is reserved for sound-emission and disappearance subconstructions. -/
 theorem all_core_entries_use_means :
     allEntries.all (·.subeventRelation == .means) = true := by
-  native_decide
+  decide
 
 -- Derived subevent structure: CAUSE follows from subconstruction
 
@@ -131,18 +131,18 @@ theorem all_core_entries_use_means :
 theorem causative_entries_have_cause :
     (allEntries.filter (·.subconstruction.isCausative)).all
       (·.dualSubevent.constructional.hasCause) = true := by
-  native_decide
+  decide
 
 /-- Noncausative entries lack CAUSE in their derived constructional subevent. -/
 theorem noncausative_entries_no_cause :
     (allEntries.filter (λ e => !e.subconstruction.isCausative)).all
       (λ e => !e.dualSubevent.constructional.hasCause) = true := by
-  native_decide
+  decide
 
 /-- All derived constructional subevents have BECOME. -/
 theorem all_constructional_have_become :
     allEntries.all (·.dualSubevent.constructional.hasBecome) = true := by
-  native_decide
+  decide
 
 -- Object selection: intransitive entries have no object selection
 
@@ -150,13 +150,13 @@ theorem all_constructional_have_become :
 theorem noncausative_no_object_selection :
     (allEntries.filter (λ e => !e.subconstruction.isCausative)).all
       (λ e => e.objectSelection == none) = true := by
-  native_decide
+  decide
 
 /-- All causative entries specify an object selection mode. -/
 theorem causative_have_object_selection :
     (allEntries.filter (·.subconstruction.isCausative)).all
       (λ e => e.objectSelection.isSome) = true := by
-  native_decide
+  decide
 
 -- Aspectual predictions
 
@@ -164,7 +164,7 @@ theorem causative_have_object_selection :
 theorem bounded_entries_telic :
     (allEntries.filter (·.rpBoundedness == .bounded)).all
       (λ e => (resultativeAspect e.rpBoundedness).telicity == .telic) = true := by
-  native_decide
+  decide
 
 /-! ### Theorems migrated from `Semantics.Causation.Resultatives`
 
@@ -175,14 +175,14 @@ therefore belong with the paper, not in the Theory layer. -/
 theorem causative_resultative_has_cause :
     (allEntries.filter (·.subconstruction.isCausative)).all
       (·.dualSubevent.constructional.hasCause) = true := by
-  native_decide
+  decide
 
 /-- MEANS-relation causative entries all have CAUSE. -/
 theorem causative_means_have_cause :
     (allEntries.filter (λ e =>
       e.subconstruction.isCausative && e.subeventRelation == .means
     )).all (·.dualSubevent.constructional.hasCause) = true := by
-  native_decide
+  decide
 
 /-- Activity verbs in the data with bounded RPs become accomplishments. -/
 theorem activity_entries_become_accomplishments :
@@ -191,12 +191,12 @@ theorem activity_entries_become_accomplishments :
     )).all (λ e =>
       resultativeVendlerClass e.rpBoundedness == .accomplishment
     ) = true := by
-  native_decide
+  decide
 
 /-- All resultative entries have BECOME. -/
 theorem all_have_become :
     allEntries.all (·.dualSubevent.constructional.hasBecome) = true := by
-  native_decide
+  decide
 
 /-! ## Per-entry verb class participation
 
@@ -208,21 +208,21 @@ roll/swing), and removing verbs (wipe). -/
 /-- All entries acquire CoS from the construction, regardless of verb class. -/
 theorem all_entries_fused_cos :
     allEntries.all (λ e => e.fusedMC.changeOfState) = true := by
-  native_decide
+  decide
 
 /-- All entries participate in the resultative alternation (none are instrument-spec). -/
 theorem all_entries_resultative_alternation :
     allEntries.all (λ e =>
       predictedAlternationInConstruction e.verbMC
         e.subconstruction.toConstruction .resultative) = true := by
-  native_decide
+  decide
 
 /-- Causative entries all acquire the causative alternation. -/
 theorem causative_entries_causative_alternation :
     (allEntries.filter (·.subconstruction.isCausative)).all (λ e =>
       predictedAlternationInConstruction e.verbMC
         e.subconstruction.toConstruction .causativeInchoative) = true := by
-  native_decide
+  decide
 
 /-- Noncausative entries do NOT acquire the causative alternation
     (unless the verb already has causation — freeze/otherCoS does). -/
@@ -231,7 +231,7 @@ theorem noncausative_entries_no_new_causation :
       predictedAlternationInConstruction e.verbMC
         e.subconstruction.toConstruction .causativeInchoative
       = e.verbMC.predictedAlternation .causativeInchoative) = true := by
-  native_decide
+  decide
 
 /-- Hammer (hit-class): no CoS or causation alone → both added by causative construction. -/
 theorem hammer_gains_cos_causation :
@@ -239,25 +239,25 @@ theorem hammer_gains_cos_causation :
     hammerFlat.verbMC.causation = false ∧
     hammerFlat.fusedMC.changeOfState = true ∧
     hammerFlat.fusedMC.causation = true := by
-  constructor; native_decide
-  constructor; native_decide
-  constructor <;> native_decide
+  constructor; decide
+  constructor; decide
+  constructor <;> decide
 
 /-- Freeze (otherCoS): already has CoS + causation → construction doesn't change profile. -/
 theorem freeze_already_has_cos :
     freezeSolid.verbMC.changeOfState = true ∧
     freezeSolid.verbMC.causation = true ∧
     freezeSolid.fusedMC = freezeSolid.verbMC := by
-  constructor; native_decide
-  constructor <;> native_decide
+  constructor; decide
+  constructor <;> decide
 
 /-- Roll (manner-of-motion): gains CoS from construction; no causation (noncausative). -/
 theorem roll_gains_cos_only :
     rollIntoField.verbMC.changeOfState = false ∧
     rollIntoField.fusedMC.changeOfState = true ∧
     rollIntoField.fusedMC.causation = false := by
-  constructor; native_decide
-  constructor <;> native_decide
+  constructor; decide
+  constructor <;> decide
 
 /-- Laugh (performance): pure manner verb — construction adds CoS + causation. -/
 theorem laugh_gains_cos_causation :
@@ -265,17 +265,17 @@ theorem laugh_gains_cos_causation :
     laughSilly.verbMC.causation = false ∧
     laughSilly.fusedMC.changeOfState = true ∧
     laughSilly.fusedMC.causation = true := by
-  constructor; native_decide
-  constructor; native_decide
-  constructor <;> native_decide
+  constructor; decide
+  constructor; decide
+  constructor <;> decide
 
 /-- Wipe (wipe-class): already has full profile — construction is redundant. -/
 theorem wipe_already_has_everything :
     wipeClean.verbMC.changeOfState = true ∧
     wipeClean.verbMC.causation = true ∧
     wipeClean.fusedMC = wipeClean.verbMC := by
-  constructor; native_decide
-  constructor <;> native_decide
+  constructor; decide
+  constructor <;> decide
 
 /-! ## Empirical data: grammaticality judgments
 
@@ -485,35 +485,35 @@ theorem has_all_resultative_types :
     (allExamples.any (·.resType == .noncausativeProperty)) = true ∧
     (allExamples.any (·.resType == .noncausativePath)) = true ∧
     (allExamples.any (·.resType == .fakeReflexive)) = true := by
-  constructor; native_decide
-  constructor; native_decide
-  constructor; native_decide
-  constructor; native_decide
-  native_decide
+  constructor; decide
+  constructor; decide
+  constructor; decide
+  constructor; decide
+  decide
 
 /-- Both grammatical and ungrammatical examples are represented. -/
 theorem has_both_judgments :
     (allExamples.any (·.judgment == .ok)) = true ∧
     (allExamples.any (·.judgment == .unacceptable)) = true := by
-  constructor; native_decide
-  native_decide
+  constructor; decide
+  decide
 
 /-- The aspectual contrast data includes both in- and for-adverbials. -/
 theorem aspectual_both_adverbials :
     (aspectualContrasts.any (·.adverbialType == "in-adverbial")) = true ∧
     (aspectualContrasts.any (·.adverbialType == "for-adverbial")) = true := by
-  constructor; native_decide
-  native_decide
+  constructor; decide
+  decide
 
 /-- Telic resultatives accept in-adverbials and reject for-adverbials. -/
 theorem telic_adverbial_pattern :
     hammer_flat_in.judgment == .ok ∧
     hammer_flat_for.judgment == .unacceptable := by
-  constructor <;> native_decide
+  constructor <;> decide
 
 /-- Atelic bare activities accept for-adverbials. -/
 theorem atelic_adverbial_pattern :
     hammer_bare_for.judgment == .ok := by
-  native_decide
+  decide
 
 end GoldbergJackendoff2004

--- a/Linglib/Studies/KayFillmore1999.lean
+++ b/Linglib/Studies/KayFillmore1999.lean
@@ -34,10 +34,6 @@ namespace KayFillmore1999
 open FillmoreKayOConnor1988
 open Features (Acceptability)
 
-/-- Check if a string contains a substring. -/
-def containsSubstr (s : String) (sub : String) : Bool :=
-  (s.splitOn sub).length > 1
-
 /-! ## Reading type -/
 
 /-- The available readings of a WXDY sentence. -/
@@ -239,25 +235,18 @@ theorem has_both_readings :
     (allExamples.any (·.reading == .literal)) = true ∧
     (allExamples.any (·.reading == .incredulity)) = true ∧
     (allExamples.any (·.reading == .ambiguous)) = true := by
-  constructor; native_decide
-  constructor; native_decide
-  native_decide
+  constructor; decide
+  constructor; decide
+  decide
 
 /-- All judgment types are represented. -/
 theorem has_all_judgment_types :
     (allExamples.any (·.judgment == .ok)) = true ∧
     (allExamples.any (·.judgment == .unacceptable)) = true ∧
     (allExamples.any (·.judgment == .marginal)) = true := by
-  constructor; native_decide
-  constructor; native_decide
-  native_decide
-
-/-- All grammatical WXDY examples with incredulity reading have progressive. -/
-theorem progressive_is_required :
-    (allExamples.filter (λ d =>
-      d.judgment == .ok && d.reading != .literal
-    )).all (λ d => containsSubstr d.sentence "doing" || containsSubstr d.sentence "is doing") = true := by
-  native_decide
+  constructor; decide
+  constructor; decide
+  decide
 
 end KayFillmore1999
 
@@ -600,20 +589,13 @@ theorem wxdy_requires_progressive_aspect (c : VendlerClass) :
 -- L. Per-datum verification
 -- ============================================================================
 
-/-- All grammatical WXDY examples use progressive *doing*. -/
-theorem progressive_required_all :
-    (allExamples.filter (λ d : WXDYDatum =>
-      d.judgment == .ok && d.reading != .literal
-    )).all (λ d : WXDYDatum => containsSubstr d.sentence "doing" || containsSubstr d.sentence "is doing") = true := by
-  native_decide
-
 /-- The data contains all three reading types. -/
 theorem all_readings_attested :
     (allExamples.any (λ d : WXDYDatum => d.reading == .literal)) = true ∧
     (allExamples.any (λ d : WXDYDatum => d.reading == .incredulity)) = true ∧
     (allExamples.any (λ d : WXDYDatum => d.reading == .ambiguous)) = true := by
-  constructor; native_decide
-  constructor; native_decide
-  native_decide
+  constructor; decide
+  constructor; decide
+  decide
 
 end ConstructionGrammar.Studies.KayFillmore1999

--- a/Linglib/Studies/KayMichaelis2019.lean
+++ b/Linglib/Studies/KayMichaelis2019.lean
@@ -169,8 +169,8 @@ def demoLex : String → Option (Den E)
 /-- Rule assignment for the demo network. -/
 def demoRules : Construction → Option (CompositionRule (Den E)) :=
   λ c =>
-    if c.name == "Intersective modification" then some (intersectiveRule E)
-    else if c.name == "Operator modification" then some (operatorRule E)
+    if c = intersectiveModification then some (intersectiveRule E)
+    else if c = operatorModification then some (operatorRule E)
     else none
 
 /-- *Purple plum* has exactly one reading: the intersection. The operator

--- a/Linglib/Studies/Levin2026.lean
+++ b/Linglib/Studies/Levin2026.lean
@@ -105,7 +105,7 @@ def intrPushOpenClasses : List LevinClass := [.pushPull, .hit]
 theorem all_classes_no_causative_alternation :
     intrPushOpenClasses.all
       (! ·.participatesIn .causativeInchoative) = true := by
-  native_decide
+  decide
 
 /-- Cross-reference: the existing alternation data in
     `DiathesisAlternations.Data` already records that *hit* (§18.1) is
@@ -113,7 +113,7 @@ theorem all_classes_no_causative_alternation :
 theorem agrees_with_diathesis_data :
     Phenomena.ArgumentStructure.DiathesisAlternations.Data.ci_hit.result
       == .blocked := by
-  native_decide
+  decide
 
 /-- All core classes are pure manner roots
     ([beavers-koontz-garboden-2020]): they encode no state, no result,
@@ -121,7 +121,7 @@ theorem agrees_with_diathesis_data :
 theorem all_classes_pure_manner :
     intrPushOpenClasses.all
       (·.rootEntailments == Root.FeatureSignature.pureManner) = true := by
-  native_decide
+  decide
 
 /-- All core classes encode contact and motion but NOT change of state
     and NOT causation. This is why they don't show the causative alternation
@@ -131,7 +131,7 @@ theorem all_classes_no_cos_no_causation :
       let mc := c.meaningComponents
       mc.contact && mc.motion && !mc.changeOfState && !mc.causation
     ) = true := by
-  native_decide
+  decide
 
 /-- Fragment verb entries confirm the classification. -/
 theorem push_is_pushPull : push.levinClass = some .pushPull := rfl
@@ -156,7 +156,7 @@ intr-*push open* resultatives." -/
 /-- PushPull alone: no causative alternation. -/
 theorem pushPull_alone_no_alternation :
     LevinClass.pushPull.meaningComponents.predictedAlternation
-      .causativeInchoative = false := by native_decide
+      .causativeInchoative = false := by decide
 
 /-- PushPull in the resultative: causative alternation predicted.
     The construction adds CoS + causation → the composed meaning
@@ -164,25 +164,25 @@ theorem pushPull_alone_no_alternation :
 theorem pushPull_alternates_in_resultative :
     predictedAlternationInConstruction
       LevinClass.pushPull.meaningComponents
-      resultative .causativeInchoative = true := by native_decide
+      resultative .causativeInchoative = true := by decide
 
 /-- Hit alone: no causative alternation. -/
 theorem hit_alone_no_alternation :
     LevinClass.hit.meaningComponents.predictedAlternation
-      .causativeInchoative = false := by native_decide
+      .causativeInchoative = false := by decide
 
 /-- Hit in the resultative: causative alternation predicted. -/
 theorem hit_alternates_in_resultative :
     predictedAlternationInConstruction
       LevinClass.hit.meaningComponents
-      resultative .causativeInchoative = true := by native_decide
+      resultative .causativeInchoative = true := by decide
 
 /-- All core intr-push-open classes alternate in the resultative. -/
 theorem all_classes_alternate_in_resultative :
     intrPushOpenClasses.all (λ c =>
       predictedAlternationInConstruction
         c.meaningComponents resultative .causativeInchoative
-    ) = true := by native_decide
+    ) = true := by decide
 
 /-! ### Event structure shift (bridge to `EventStructure`)
 
@@ -247,14 +247,14 @@ which comes from the resultative construction, not the verb. -/
 /-- Hit-class verbs (including *pound*) cannot enter the middle alone. -/
 theorem hit_no_middle_alone :
     LevinClass.hit.meaningComponents.predictedAlternation .middle = false := by
-  native_decide
+  decide
 
 /-- Hit-class verbs CAN enter the middle inside the resultative.
     This derives the paper's observation (18b) from the same mechanism. -/
 theorem hit_middle_in_resultative :
     predictedAlternationInConstruction
       LevinClass.hit.meaningComponents resultative .middle = true := by
-  native_decide
+  decide
 
 -- ════════════════════════════════════════════════════
 -- § 2. Adjective set: spatially instantiated states
@@ -283,7 +283,7 @@ abbrev SpatialAdjType := Semantics.Gradability.SpatialConfigType
 theorem all_attested_adjs_spatial :
     [open_, closed_, shut, free_, loose, flat].all
       (·.spatialConfigType |>.isSome) = true := by
-  native_decide
+  decide
 
 /-- All attested adjectives are closed-scale (absolute) in
     [kennedy-2007]'s terms. Spatially instantiated states have
@@ -291,7 +291,7 @@ theorem all_attested_adjs_spatial :
 theorem all_attested_adjs_closed_scale :
     [open_, closed_, shut, free_, loose, flat].all
       (·.scaleType == .closed) = true := by
-  native_decide
+  decide
 
 /-! Adjectives in senses that are NOT spatially instantiated do not
 appear in intr-*push open* resultatives, even when they occur in
@@ -406,7 +406,7 @@ theorem all_verbs_from_predicted_classes :
     alternationPairs.all (λ d =>
       intrPushOpenClasses.contains d.verbClass ||
       d.verbClass == .wipe) = true := by
-  native_decide
+  decide
 
 /-- Each core-class pair (pushPull, hit) is blocked alone but gains the
     causative alternation inside the resultative construction.
@@ -418,7 +418,7 @@ theorem per_pair_alternation_core :
       !p.verbClass.participatesIn .causativeInchoative &&
       predictedAlternationInConstruction
         p.verbClass.meaningComponents resultative .causativeInchoative
-    ) = true := by native_decide
+    ) = true := by decide
 
 /-- Each pair's `adjType` agrees with the Fragment entry's `spatialConfigType`. -/
 theorem push_open_adj_agrees : open_.spatialConfigType = some push_open.adjType := rfl
@@ -687,7 +687,7 @@ def directedMotionData : List DirectedMotionDatum :=
     paralleling intr-*push open*. -/
 theorem directed_motion_themes_autonomous :
     directedMotionData.all (canBeIntrPushOpenSubject ·.themeType) = true := by
-  native_decide
+  decide
 
 /-! Natural forces (*storm*, *wind*) are attested as directed motion
 subjects — (85b) "The storm swept through the valley" — but NOT in
@@ -720,28 +720,28 @@ def isLicensed (verbClass : LevinClass) (adj : AdjectivalPredicateEntry)
 /-- "The door pushed open" in a recoverable-cause context is licensed. -/
 theorem door_pushed_open_licensed :
     isLicensed .pushPull open_ .recoverableInContext .projectile = true := by
-  native_decide
+  decide
 
 /-- "The door pushed open" in a cause-unknown context is licensed. -/
 theorem door_pushed_open_licensed_unknown :
     isLicensed .pushPull open_ .identityUnknown .projectile = true := by
-  native_decide
+  decide
 
 /-- Blocked: cause not recoverable. -/
 theorem blocked_no_context :
     isLicensed .pushPull open_ .notRecoverable .projectile = false := by
-  native_decide
+  decide
 
 /-- Blocked: theme requires continuous force (PCC). -/
 theorem blocked_continuous_force :
     isLicensed .pushPull open_ .recoverableInContext
       .requiresContinuousForce = false := by
-  native_decide
+  decide
 
 /-- Blocked: verb class wrong (break is a CoS verb, not force). -/
 theorem blocked_wrong_verb_class :
     isLicensed .break_ open_ .recoverableInContext .projectile = false := by
-  native_decide
+  decide
 
 /-- Blocked: adjective not spatially instantiated (*red* has no spatial config). -/
 private def red_ : AdjectivalPredicateEntry where
@@ -749,7 +749,7 @@ private def red_ : AdjectivalPredicateEntry where
 
 theorem blocked_wrong_adjective :
     isLicensed .pushPull red_ .recoverableInContext .projectile = false := by
-  native_decide
+  decide
 
 /-! ### End-to-end: the full argument chain
 
@@ -834,22 +834,22 @@ def pushOpen_filled : FilledResultative :=
   { verbClass := .pushPull
   , adjective := open_
   , construction := resultative
-  , alternationPredicted := by native_decide
-  , adjSpatial := by native_decide }
+  , alternationPredicted := by decide
+  , adjSpatial := by decide }
 
 def pullFree_filled : FilledResultative :=
   { verbClass := .pushPull
   , adjective := free_
   , construction := resultative
-  , alternationPredicted := by native_decide
-  , adjSpatial := by native_decide }
+  , alternationPredicted := by decide
+  , adjSpatial := by decide }
 
 def slamShut_filled : FilledResultative :=
   { verbClass := .hit
   , adjective := shut
   , construction := resultative
-  , alternationPredicted := by native_decide
-  , adjSpatial := by native_decide }
+  , alternationPredicted := by decide
+  , adjSpatial := by decide }
 
 /-! ### FilledResultative → licensing
 
@@ -876,24 +876,24 @@ theorem filled_implies_licensed (fr : FilledResultative)
 theorem pushOpen_filled_licensed :
     isLicensed pushOpen_filled.verbClass pushOpen_filled.adjective
       .recoverableInContext .projectile = true := by
-  native_decide
+  decide
 
 /-- The anticausative of `pushOpen_filled` is licensed in the right
     discourse context. -/
 theorem pushOpen_anticausative_licensed :
     pushOpen_filled.canAnticausativize .recoverableInContext .projectile = true := by
-  native_decide
+  decide
 
 /-- The anticausative is blocked when the cause is not recoverable. -/
 theorem pushOpen_anticausative_blocked_no_context :
     pushOpen_filled.canAnticausativize .notRecoverable .projectile = false := by
-  native_decide
+  decide
 
 /-- The anticausative is blocked when the theme requires continuous force. -/
 theorem pushOpen_anticausative_blocked_continuous :
     pushOpen_filled.canAnticausativize .recoverableInContext
       .requiresContinuousForce = false := by
-  native_decide
+  decide
 
 /-! ### FilledResultative ↔ end-to-end chain
 
@@ -988,7 +988,7 @@ completion are stated via the canonical `BoolSEM.causallySufficientOn` /
 structural theorems via `unfold + rfl`.
 
 Per-scenario inductive `V` enums give `Fintype + DecidableEq + Repr`
-so `developDetOn` reduces structurally without `native_decide`. -/
+so `developDetOn` reduces structurally without `decide`. -/
 
 section Scenarios
 open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM

--- a/Linglib/Studies/Mueller2013.lean
+++ b/Linglib/Studies/Mueller2013.lean
@@ -365,7 +365,7 @@ analogue of Internal Merge and the Head-Filler Schema. -/
 theorem dg_nonproj_is_filler_gap :
     -- A tree with crossing arcs has filler-gap dependencies
     DepGrammar.hasFillerGap DepGrammar.nonProjectiveTree = true := by
-  native_decide
+  decide
 
 /-! ## §5. Coordination Diagnostic (§1, §2.2)
 

--- a/Linglib/Studies/OsborneGross2012/Data.lean
+++ b/Linglib/Studies/OsborneGross2012/Data.lean
@@ -11,8 +11,8 @@ Construction Grammar meets Dependency Grammar" (*Cognitive Linguistics*
 23(1):165–216).
 
 Each tree is a concrete linguistic example analyzed with dependency
-structure. The catena proofs connecting these trees to the paper's
-theoretical claims are in `DG_OsborneGross2012Bridge.lean`.
+structure; the catena proofs connecting the trees to the paper's
+theoretical claims follow below.
 
 ## Construction Types
 
@@ -258,50 +258,50 @@ open DepGrammar.CatenalConstruction
 -- ============================================================================
 
 theorem spillTheBeans_catena :
-    isCatena spillTheBeans.deps [0, 2] = true := by native_decide
+    isCatena spillTheBeans.deps [0, 2] = true := by decide
 
 theorem spillTheBeans_not_constituent :
-    isConstituent spillTheBeans.deps 3 [0, 2] = false := by native_decide
+    isConstituent spillTheBeans.deps 3 [0, 2] = false := by decide
 
 theorem giveTheSack_catena :
-    isCatena giveTheSack.deps [0, 2] = true := by native_decide
+    isCatena giveTheSack.deps [0, 2] = true := by decide
 
 theorem giveTheSack_not_constituent :
-    isConstituent giveTheSack.deps 3 [0, 2] = false := by native_decide
+    isConstituent giveTheSack.deps 3 [0, 2] = false := by decide
 
 theorem kickTheBucket_catena :
-    isCatena kickTheBucket.deps [0, 2] = true := by native_decide
+    isCatena kickTheBucket.deps [0, 2] = true := by decide
 
 theorem kickTheBucket_not_constituent :
-    isConstituent kickTheBucket.deps 3 [0, 2] = false := by native_decide
+    isConstituent kickTheBucket.deps 3 [0, 2] = false := by decide
 
 theorem pullSomeStrings_catena :
-    isCatena pullSomeStrings.deps [0, 2] = true := by native_decide
+    isCatena pullSomeStrings.deps [0, 2] = true := by decide
 
 theorem pullSomeStrings_not_constituent :
-    isConstituent pullSomeStrings.deps 3 [0, 2] = false := by native_decide
+    isConstituent pullSomeStrings.deps 3 [0, 2] = false := by decide
 
 -- ============================================================================
 -- §2: Per-Datum Catena Verification — LVCs
 -- ============================================================================
 
 theorem takeABath_catena :
-    isCatena takeABath.deps [0, 2] = true := by native_decide
+    isCatena takeABath.deps [0, 2] = true := by decide
 
 theorem takeABath_not_constituent :
-    isConstituent takeABath.deps 3 [0, 2] = false := by native_decide
+    isConstituent takeABath.deps 3 [0, 2] = false := by decide
 
 theorem haveALook_catena :
-    isCatena haveALook.deps [0, 2] = true := by native_decide
+    isCatena haveALook.deps [0, 2] = true := by decide
 
 theorem haveALook_not_constituent :
-    isConstituent haveALook.deps 3 [0, 2] = false := by native_decide
+    isConstituent haveALook.deps 3 [0, 2] = false := by decide
 
 theorem giveAYell_catena :
-    isCatena giveAYell.deps [0, 2] = true := by native_decide
+    isCatena giveAYell.deps [0, 2] = true := by decide
 
 theorem giveAYell_not_constituent :
-    isConstituent giveAYell.deps 3 [0, 2] = false := by native_decide
+    isConstituent giveAYell.deps 3 [0, 2] = false := by decide
 
 -- ============================================================================
 -- §3: Per-Datum Catena Verification — Verb Chains
@@ -309,35 +309,35 @@ theorem giveAYell_not_constituent :
 
 /-- 3-element chain {will, have, helped} = {1,2,3}. -/
 theorem verbChain3_catena :
-    isCatena heWillHaveHelped.deps [1, 2, 3] = true := by native_decide
+    isCatena heWillHaveHelped.deps [1, 2, 3] = true := by decide
 
 theorem verbChain3_not_constituent :
-    isConstituent heWillHaveHelped.deps 4 [1, 2, 3] = false := by native_decide
+    isConstituent heWillHaveHelped.deps 4 [1, 2, 3] = false := by decide
 
 /-- 4-element chain {will, have, been, doing} = {1,2,3,4}. -/
 theorem verbChain4_catena :
-    isCatena sheWillHaveBeenDoingIt.deps [1, 2, 3, 4] = true := by native_decide
+    isCatena sheWillHaveBeenDoingIt.deps [1, 2, 3, 4] = true := by decide
 
 theorem verbChain4_not_constituent :
-    isConstituent sheWillHaveBeenDoingIt.deps 6 [1, 2, 3, 4] = false := by native_decide
+    isConstituent sheWillHaveBeenDoingIt.deps 6 [1, 2, 3, 4] = false := by decide
 
 /-- The full VP {will, have, been, doing, it} = {1,2,3,4,5} is a catena but
     not a constituent — the subject "she" prevents it. -/
 theorem fullVP_catena :
-    isCatena sheWillHaveBeenDoingIt.deps [1, 2, 3, 4, 5] = true := by native_decide
+    isCatena sheWillHaveBeenDoingIt.deps [1, 2, 3, 4, 5] = true := by decide
 
 theorem fullVP_not_constituent :
-    isConstituent sheWillHaveBeenDoingIt.deps 6 [1, 2, 3, 4, 5] = false := by native_decide
+    isConstituent sheWillHaveBeenDoingIt.deps 6 [1, 2, 3, 4, 5] = false := by decide
 
 -- ============================================================================
 -- §4: Per-Datum Catena Verification — Displacement
 -- ============================================================================
 
 theorem displacement_catena :
-    isCatena beansSheSpilled.deps [0, 2] = true := by native_decide
+    isCatena beansSheSpilled.deps [0, 2] = true := by decide
 
 theorem displacement_not_constituent :
-    isConstituent beansSheSpilled.deps 3 [0, 2] = false := by native_decide
+    isConstituent beansSheSpilled.deps 3 [0, 2] = false := by decide
 
 -- ============================================================================
 -- §5: Per-Datum Catena Verification — Comparative Correlative
@@ -345,24 +345,24 @@ theorem displacement_not_constituent :
 
 /-- Protasis = {the, more, you, eat} = {0,1,2,3}. -/
 theorem cc_protasis_catena :
-    isCatena theMoreTheFatter.deps [0, 1, 2, 3] = true := by native_decide
+    isCatena theMoreTheFatter.deps [0, 1, 2, 3] = true := by decide
 
 /-- Apodosis = {the, fatter, you, get} = {4,5,6,7}. -/
 theorem cc_apodosis_catena :
-    isCatena theMoreTheFatter.deps [4, 5, 6, 7] = true := by native_decide
+    isCatena theMoreTheFatter.deps [4, 5, 6, 7] = true := by decide
 
 theorem cc_apodosis_not_constituent :
-    isConstituent theMoreTheFatter.deps 8 [4, 5, 6, 7] = false := by native_decide
+    isConstituent theMoreTheFatter.deps 8 [4, 5, 6, 7] = false := by decide
 
 /-- Protasis IS a constituent (subtree of eat = {eat, you, more, the}). -/
 theorem cc_protasis_is_constituent :
-    isConstituent theMoreTheFatter.deps 8 [0, 1, 2, 3] = true := by native_decide
+    isConstituent theMoreTheFatter.deps 8 [0, 1, 2, 3] = true := by decide
 
 /-- Degree markers {the, more} and {the, fatter} each form catenae. -/
 theorem cc_degree_markers_catenae :
     isCatena theMoreTheFatter.deps [0, 1] = true ∧
     isCatena theMoreTheFatter.deps [4, 5] = true := by
-  constructor <;> native_decide
+  constructor <;> decide
 
 -- ============================================================================
 -- §6: Claim 1 — Constructions Are Catenae (p. 176)
@@ -389,7 +389,7 @@ theorem claim1_constructions_are_catenae :
     -- Comparative correlative (2 clauses)
     isCatena theMoreTheFatter.deps [0, 1, 2, 3] = true ∧
     isCatena theMoreTheFatter.deps [4, 5, 6, 7] = true := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
 
 /-- All non-constituent constructions: these require the catena concept —
     a constituent-based framework cannot represent any of them. -/
@@ -410,7 +410,7 @@ theorem all_constructions_not_constituent :
     isConstituent beansSheSpilled.deps 3 [0, 2] = false ∧
     -- CC apodosis
     isConstituent theMoreTheFatter.deps 8 [4, 5, 6, 7] = false := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
 
 -- ============================================================================
 -- §7: Claim 2 — Interleaving Preserves Catena-hood (p. 176)
@@ -457,7 +457,7 @@ theorem claim2_interleaving_preserves_catenae :
     isCatena theMoreTheFatter.deps [0, 1, 2, 3] = true ∧
     isCatena theMoreTheFatter.deps [4, 5, 6, 7] = true := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-    <;> native_decide
+    <;> decide
 
 -- ============================================================================
 -- §8: CxG ↔ DG Bridge — CatenalCx Instances
@@ -476,7 +476,7 @@ def idiomCx : CatenalCx :=
         meaning := "divulge secret information" }
     tree := spillTheBeans
     nodes := [0, 2]
-    catena := by native_decide }
+    catena := by decide }
 
 def lvcCx : CatenalCx :=
   { construction :=
@@ -488,7 +488,7 @@ def lvcCx : CatenalCx :=
         meaning := "perform the action denoted by N" }
     tree := takeABath
     nodes := [0, 2]
-    catena := by native_decide }
+    catena := by decide }
 
 def verbChainCx : CatenalCx :=
   { construction :=
@@ -499,7 +499,7 @@ def verbChainCx : CatenalCx :=
         meaning := "tense–aspect–mood composition" }
     tree := heWillHaveHelped
     nodes := [1, 2, 3]
-    catena := by native_decide }
+    catena := by decide }
 
 def displacementCx : CatenalCx :=
   { construction :=
@@ -511,7 +511,7 @@ def displacementCx : CatenalCx :=
         pragmaticFunction := "topic–comment articulation" }
     tree := beansSheSpilled
     nodes := [0, 2]
-    catena := by native_decide }
+    catena := by decide }
 
 /-- CatenalCx instances cover the full specificity spectrum. -/
 theorem catenal_specificity_coverage :
@@ -553,7 +553,7 @@ theorem fko1988_idiom_types_are_catenae :
     -- Formal idiom: CC protasis
     ccIdiomType.formality = .formal ∧
     isCatena theMoreTheFatter.deps [0, 1, 2, 3] = true := by
-  refine ⟨rfl, ?_, rfl, ?_⟩ <;> native_decide
+  refine ⟨rfl, ?_, rfl, ?_⟩ <;> decide
 
 /-- Bridge to FKO1988 CC: the `comparativeCorrelative` construction from
     FKO1988 matches the CC tree verified here. Both describe the same
@@ -564,6 +564,6 @@ theorem cc_matches_fko1988 :
     comparativeCorrelative.specificity = .partiallyOpen ∧
     isCatena theMoreTheFatter.deps [0, 1, 2, 3] = true ∧
     isCatena theMoreTheFatter.deps [4, 5, 6, 7] = true := by
-  refine ⟨rfl, rfl, ?_, ?_⟩ <;> native_decide
+  refine ⟨rfl, rfl, ?_, ?_⟩ <;> decide
 
 end OsborneGross2012.Bridge

--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -79,7 +79,8 @@ def causedMotion : ArgStructureConstruction :=
           , { filler := .open_ .ADP, role := some "goal" } ]
       , meaning := "X CAUSES Y to MOVE to Z" }
   , hasHead := by decide
-  , semanticContribution := ⟨false, false, true, true, false, false⟩ }
+  , semanticContribution :=
+      { changeOfState := false, contact := false, motion := true, causation := true } }
 
 /-- Resultative construction: [Subj V Obj Pred].
 "X CAUSES Y to BECOME Z" (e.g., "She hammered the metal flat").
@@ -97,7 +98,8 @@ def resultative : ArgStructureConstruction :=
           , { filler := .open_ .ADJ, role := some "result" } ]
       , meaning := "X CAUSES Y to BECOME Z" }
   , hasHead := by decide
-  , semanticContribution := ⟨true, false, false, true, false, false⟩ }
+  , semanticContribution :=
+      { changeOfState := true, contact := false, motion := false, causation := true } }
 
 /-- Intransitive motion construction: [Subj V Obl].
 "X MOVES to Y" (e.g., "The ball rolled down the hill"). -/
@@ -237,11 +239,7 @@ semantic relation between the event participants. -/
 frame ([goldberg-1995] pp. 75–77). -/
 def ditransitiveFamily : PolysemyFamily :=
   { name := "Ditransitive"
-  , slots :=
-      [ { filler := .open_ .NOUN, role := some "agent" }
-      , { filler := .open_ .VERB, role := some "predicate", isHead := true }
-      , { filler := .open_ .NOUN, role := some "recipient" }
-      , { filler := .open_ .NOUN, role := some "theme" } ]
+  , slots := ditransitive.slots
   , hasHead := by decide
   , centralMeaning := "X CAUSES Y TO RECEIVE Z"
   , extensions :=
@@ -260,10 +258,6 @@ def ditransitiveFamily : PolysemyFamily :=
       , ("Future",
          "X ACTS TO CAUSE Y TO RECEIVE Z at some future point in time",
          ["transfer deferred to future"]) ] }
-
-/-- The family's slots match the standalone `ditransitive` definition. -/
-theorem ditransitiveFamily_matches :
-    ditransitiveFamily.centralConstruction.slots = ditransitive.slots := rfl
 
 /-- Derived polysemy links. -/
 def ditransitivePolysemy : List InheritanceLink :=
@@ -292,34 +286,14 @@ def causedMotionToResultative : InheritanceLink :=
   , sharedProperties := ["X CAUSES Y to undergo change", "causal structure"]
   , overriddenProperties := ["motion → change of state", "location → property"] }
 
-/-- All polysemy links have link type I_P. -/
-theorem polysemy_links_typed :
-    ditransitivePolysemy.all (·.linkType == some .polysemy) = true := by
-  decide
-
-/-- Subpart link has link type I_S. -/
-theorem subpart_link_typed :
-    causedMotionSubpart.linkType = some .subpart := rfl
-
-/-- Metaphorical link has link type I_M. -/
-theorem metaphorical_link_typed :
-    causedMotionToResultative.linkType = some .metaphorical := rfl
-
-/-- All four link types are instantiated across the network. -/
-theorem all_link_types_instantiated :
-    -- I_P: polysemy (ditransitive senses)
-    (ditransitivePolysemy.any (·.linkType == some .polysemy) = true) ∧
-    -- I_M: metaphorical (caused-motion → resultative)
-    (causedMotionToResultative.linkType = some .metaphorical) ∧
-    -- I_S: subpart (caused-motion → intransitive motion)
-    (causedMotionSubpart.linkType = some .subpart) ∧
-    -- I_I: instance (resultative subconstructions, in GoldbergJackendoff2004)
-    True := by
-  exact ⟨by decide, rfl, rfl, trivial⟩
-
--- ════════════════════════════════════════════════════
--- Constructional fusion ([goldberg-1995])
--- ════════════════════════════════════════════════════
+/-- Every link a polysemy family derives is an I_P link — a fact about the
+construction, not about one table. -/
+theorem PolysemyFamily.polysemyLinks_typed (f : PolysemyFamily) :
+    ∀ l ∈ f.polysemyLinks, l.linkType = some .polysemy := by
+  intro l hl
+  simp only [PolysemyFamily.polysemyLinks, List.mem_map] at hl
+  obtain ⟨ext, _, rfl⟩ := hl
+  rfl
 
 /-! ## Verb–construction fusion
 
@@ -384,7 +358,7 @@ fires on the fused result. -/
 
 /-- A pure manner verb (no CoS, no causation) cannot alternate alone. -/
 theorem manner_verb_no_alternation (mc : MeaningComponents)
-    (hCoS : mc.changeOfState = false) (hCaus : mc.causation = false) :
+    (hCoS : mc.changeOfState = false) (_hCaus : mc.causation = false) :
     mc.predictedAlternation .causativeInchoative = false := by
   simp [MeaningComponents.predictedAlternation, hCoS]
 
@@ -398,13 +372,11 @@ theorem manner_verb_alternates_in_resultative (mc : MeaningComponents)
 
 /-- Concrete instance: hit-class components + resultative → causative alternation. -/
 theorem hit_alternates_in_resultative :
-    predictedAlternationInConstruction .hit resultative .causativeInchoative = true := by
-  native_decide
+    predictedAlternationInConstruction .hit resultative .causativeInchoative = true := rfl
 
 /-- Concrete instance: hit-class components alone → no causative alternation. -/
 theorem hit_no_alternation_alone :
-    MeaningComponents.hit.predictedAlternation .causativeInchoative = false := by
-  native_decide
+    MeaningComponents.hit.predictedAlternation .causativeInchoative = false := rfl
 
 /-! ### Multiple alternation flips from a single construction
 

--- a/Linglib/Syntax/ConstructionGrammar/Basic.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Basic.lean
@@ -1,5 +1,6 @@
 import Linglib.Data.UD.Basic
 import Mathlib.Algebra.Order.Ring.Rat
+import Mathlib.Algebra.Order.Field.Basic
 
 /-!
 # Construction Grammar: Core Types
@@ -101,7 +102,7 @@ filler type of phrasal compounds and PAL constructions. -/
 
 Parameterized over `Lex` (the lexeme type) so the same representation
 works for strings, morphemes, or phonological forms. -/
-inductive SlotFiller (Lex : Type) where
+inductive SlotFiller (Lex : Type*) where
   /-- A specific word form (LEX level): `fixed "must"` -/
   | fixed : Lex → SlotFiller Lex
   /-- Any word of a given POS category (SYN level): `open_ .VERB` -/
@@ -124,7 +125,7 @@ inductive SlotFiller (Lex : Type) where
 `open_` (SYN), `semantic` (SEM+), and `phrasal` slots count as open for
 abstraction-level computation. `headed` slots do not: they fix the head
 lexeme even though the phrase is open. -/
-def SlotFiller.isOpen {Lex : Type} : SlotFiller Lex → Bool
+def SlotFiller.isOpen {Lex : Type*} : SlotFiller Lex → Bool
   | .fixed _ => false
   | .open_ _ => true
   | .headed _ _ => false
@@ -158,7 +159,7 @@ headedness, and the bar level of the position itself. Fixed slots (like
 "let" in *let alone*) have `role := none` since they carry no independent
 semantic role. `level := none` leaves the position's bar level
 unspecified. -/
-structure Slot (Lex : Type) where
+structure Slot (Lex : Type*) where
   /-- What fills this slot -/
   filler : SlotFiller Lex
   /-- Semantic role label (agent, theme, etc.), if any -/
@@ -176,23 +177,23 @@ structure Slot (Lex : Type) where
   deriving DecidableEq, Repr
 
 /-- A typed form: the form side of a construction as a sequence of slots. -/
-abbrev TypedForm (Lex : Type) := List (Slot Lex)
+abbrev TypedForm (Lex : Type*) := List (Slot Lex)
 
 /-- A phrase in a word-level slot: phrasal filler, zero-level position.
 The defining configuration of phrasal compounds and the PAL construction
 ([goldberg-shirtz-2025]) — and the cell lexical-integrity hypotheses rule
 out. -/
-def Slot.IsPhraseInWordSlot {Lex : Type} (s : Slot Lex) : Prop :=
+def Slot.IsPhraseInWordSlot {Lex : Type*} (s : Slot Lex) : Prop :=
   s.filler = .phrasal ∧ s.level = some .zero
 
-instance {Lex : Type} [DecidableEq Lex] (s : Slot Lex) :
+instance {Lex : Type*} [DecidableEq Lex] (s : Slot Lex) :
     Decidable s.IsPhraseInWordSlot :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-! ### Abstraction level and derived specificity -/
 
 section AbstractionLevel
-variable {Lex : Type}
+variable {Lex : Type*}
 
 /-- Proportion of open slots: a continuous [0,1] measure of abstraction.
 
@@ -228,7 +229,67 @@ def hasConstraint (form : TypedForm Lex) (c : SlotConstraint) : Bool :=
 
 /-- Count of distinct coreference groups in a form. -/
 def refGroupCount (form : TypedForm Lex) : Nat :=
-  (form.filterMap (·.refIdx)).eraseDups.length
+  (form.filterMap (·.refIdx)).dedup.length
+
+/-! ### Characterization lemmas -/
+
+@[simp]
+theorem abstractionLevel_nil : abstractionLevel ([] : TypedForm Lex) = 0 := rfl
+
+theorem abstractionLevel_nonneg (form : TypedForm Lex) :
+    0 ≤ abstractionLevel form := by
+  simp only [abstractionLevel]
+  split
+  · exact le_refl 0
+  · exact div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+
+theorem abstractionLevel_le_one (form : TypedForm Lex) :
+    abstractionLevel form ≤ 1 := by
+  simp only [abstractionLevel]
+  split
+  · exact zero_le_one
+  · exact div_le_one_of_le₀ (by exact_mod_cast List.length_filter_le _ _)
+      (Nat.cast_nonneg _)
+
+/-- A form is fully abstract exactly when every slot is open (vacuously so
+for the empty form). -/
+theorem derivedSpecificity_eq_fullyAbstract_iff (form : TypedForm Lex) :
+    derivedSpecificity form = .fullyAbstract ↔
+      ∀ s ∈ form, s.filler.isOpen = true := by
+  refine Iff.trans ?_
+    (List.length_filter_eq_length_iff (p := fun s : Slot Lex => s.filler.isOpen)
+      (l := form))
+  simp only [derivedSpecificity]
+  split_ifs with h1 h2 <;> simp [h1]
+
+/-- A form is lexically specified exactly when it is nonempty and no slot
+is open. -/
+theorem derivedSpecificity_eq_lexicallySpecified_iff (form : TypedForm Lex) :
+    derivedSpecificity form = .lexicallySpecified ↔
+      form ≠ [] ∧ ∀ s ∈ form, s.filler.isOpen = false := by
+  have hzero : (form.filter (·.filler.isOpen)) = [] ↔
+      ∀ s ∈ form, s.filler.isOpen = false := by
+    rw [List.filter_eq_nil_iff]; simp
+  simp only [derivedSpecificity]
+  split_ifs with h1 h2
+  · constructor
+    · intro h; cases h
+    · rintro ⟨hnil, hall⟩
+      rcases List.exists_mem_of_ne_nil form hnil with ⟨s, hs⟩
+      have hopen := List.length_filter_eq_length_iff.mp h1 s hs
+      have := hall s hs
+      simp_all
+  · constructor
+    · intro _
+      constructor
+      · rintro rfl; exact h1 (by simp)
+      · rw [List.length_eq_zero_iff] at h2
+        exact hzero.mp h2
+    · intro _; rfl
+  · constructor
+    · intro h; cases h
+    · rintro ⟨hnil, hall⟩
+      exact absurd (by rw [List.length_eq_zero_iff]; exact hzero.mpr hall) h2
 
 end AbstractionLevel
 
@@ -261,7 +322,7 @@ structure InheritanceLink where
   linkType : Option LinkType := none
   sharedProperties : List String
   overriddenProperties : List String := []
-  deriving Repr, BEq
+  deriving Repr, DecidableEq
 
 /-- A constructicon: a network of constructions connected by inheritance links. -/
 structure Constructicon where

--- a/Linglib/Syntax/ConstructionGrammar/Licensing.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Licensing.lean
@@ -48,15 +48,42 @@ end
 
 instance : BEq Token := ⟨Token.beq⟩
 
+mutual
+
+theorem Token.beq_iff_eq : ∀ a b : Token, (Token.beq a b = true) ↔ a = b
+  | .word a, .word b => by simp [Token.beq]
+  | .word _, .node _ => by simp [Token.beq]
+  | .node _, .word _ => by simp [Token.beq]
+  | .node as, .node bs => by
+      simp only [Token.beq, Token.node.injEq]
+      exact Token.beqList_iff_eq as bs
+
+theorem Token.beqList_iff_eq : ∀ as bs : List Token,
+    (Token.beqList as bs = true) ↔ as = bs
+  | [], [] => by simp [Token.beqList]
+  | [], _ :: _ => by simp [Token.beqList]
+  | _ :: _, [] => by simp [Token.beqList]
+  | a :: as, b :: bs => by
+      simp [Token.beqList, Token.beq_iff_eq a b, Token.beqList_iff_eq as bs]
+
+end
+
+instance : LawfulBEq Token where
+  eq_of_beq h := (Token.beq_iff_eq _ _).mp h
+  rfl := (Token.beq_iff_eq _ _).mpr rfl
+
+instance : DecidableEq Token := fun a b => decidable_of_iff _ (Token.beq_iff_eq a b)
+
 /-- Does a token satisfy a slot filler, relative to a POS lexicon?
 `semantic` constraints are not checkable at this level and match any
-token; `headed` requires the head word as an immediate daughter. -/
+token; `headed` requires the head word as an immediate daughter, of the
+required category. -/
 def SlotFiller.matches (pos : String → Option UD.UPOS) :
     SlotFiller String → Token → Bool
   | .fixed w, .word w' => w == w'
   | .open_ cat, .word w => pos w == some cat
   | .phrasal, .node _ => true
-  | .headed h _, .node ts => ts.contains (.word h)
+  | .headed h cat, .node ts => ts.contains (.word h) && pos h == some cat
   | .semantic _, _ => true
   | _, _ => false
 

--- a/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
@@ -622,24 +622,24 @@ def resultativeInheritance : List InheritanceLink :=
 /-- All inheritance links point to the same parent. -/
 theorem all_inherit_from_resultative :
     resultativeInheritance.all (·.parent == "Resultative") = true := by
-  native_decide
+  decide
 
 /-- All four subconstructions are fully abstract (decomposable). -/
 theorem all_subconstructions_abstract :
     resultativeFamily.all (λ c => c.construction.specificity == .fullyAbstract) = true := by
-  native_decide
+  decide
 
 /-- Causative subconstructions are transitive (4 slots);
     noncausative are intransitive (3 slots). -/
 theorem causative_are_transitive :
     causativePropertyConstruction.slots.length = 4 ∧
     causativePathConstruction.slots.length = 4 := by
-  constructor <;> native_decide
+  constructor <;> decide
 
 theorem noncausative_are_intransitive :
     noncausativePropertyConstruction.slots.length = 3 ∧
     noncausativePathConstruction.slots.length = 3 := by
-  constructor <;> native_decide
+  constructor <;> decide
 
 /-! Schema-decomposition theorems for the subconstruction family
 (`causative_decompose_like_parent`, `noncausative_fewer_steps`) live with
@@ -678,13 +678,13 @@ theorem manner_verb_no_alternation_in_noncausative (mc : MeaningComponents)
 theorem hit_alternates_in_causativeProperty :
     predictedAlternationInConstruction .hit
       causativePropertyConstruction .causativeInchoative = true := by
-  native_decide
+  decide
 
 /-- Concrete: hit-class verb in noncausativeProperty → no alternation. -/
 theorem hit_no_alternation_in_noncausativeProperty :
     predictedAlternationInConstruction .hit
       noncausativePropertyConstruction .causativeInchoative = false := by
-  native_decide
+  decide
 
 /-- The composed meaning in a causative subconstruction matches the
     composed meaning in the parent `resultative` construction. -/

--- a/Linglib/Syntax/DependencyGrammar/Formal/CatenalConstruction.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/CatenalConstruction.lean
@@ -2,7 +2,7 @@ import Linglib.Syntax.ConstructionGrammar.Basic
 import Linglib.Syntax.DependencyGrammar.Formal.Catena
 
 /-!
-# Catenal Construction: CxG ↔ DG Bridge Type
+# Catenal Construction
 
 The fundamental bridge type connecting Construction Grammar and Dependency
 Grammar ([osborne-gross-2012]): a `CatenalCx` pairs a CxG `Construction`


### PR DESCRIPTION
Mechanical pass from the full CxG API-conformance audit (no design changes).

- Correctness: `SlotFiller.matches` now checks the `headed` filler's category (was silently discarded); `Token` gains `LawfulBEq`/`DecidableEq`; `abstractionLevel`/`derivedSpecificity` get bounds and iff-characterization lemmas resolving the empty-form corner.
- All 149 `native_decide`s in the CxG cone downgrade to kernel `decide` — zero failures. The only casualties are two kernel-hostile substring-search theorems in KayFillmore1999 (one a verbatim duplicate of the other) whose content is already typed by the `headed "doing" .VERB` slot; deleted per the audit, along with the now-dead `containsSubstr`.
- Stub/aggregate deletions: `all_link_types_instantiated`'s `True` conjunct, the `ditransitiveFamily` slot duplication, Binominals' count theorems; the data-specific polysemy-link check becomes a general theorem about `PolysemyFamily`.
- Hygiene: `Type*` for `Lex`, `dedup` over `eraseDups`, `DecidableEq` over `BEq` on `InheritanceLink`, named `MeaningComponents` literals, value-keyed `demoRules`, four stale docstring pointers.

Depends on #290.