### PR TITLE
feat(Syntax/ConstructionGrammar): assemble networks, fix dangling links

### DIFF
--- a/Linglib/Phenomena/ArgumentStructure/TheoryComparison.lean
+++ b/Linglib/Phenomena/ArgumentStructure/TheoryComparison.lean
@@ -6,23 +6,15 @@ import Linglib.Syntax.DependencyGrammar.Basic
 # Cross-Theory Comparison: Resultative Argument Licensing
 
 Three syntactic theories predict the same argument frames for resultatives
-but differ on *how* arguments are licensed. This module formalizes the
-convergence and divergence.
+but differ on *how* arguments are licensed: Minimalism via the Theta
+Criterion, CxG via Full Argument Realization plus Semantic Coherence
+(the substrate predicates `ConstructionGrammar.Resultatives.farSatisfied`
+and `rolesCoherent`), and DG via valency saturation.
 
-## Theories compared
-
-1. **Minimalism**: Theta Criterion — each theta role assigned to exactly one argument
-2. **CxG**: FAR + Semantic Coherence — verb and construction args fuse when coherent
-3. **DG**: Valency satisfaction — verb's argument structure must be fully saturated
-
-## Key result
-
-All three theories predict the same surface argument frame for canonical
-resultatives like "She hammered the metal flat". They diverge on fake
-reflexives ("She laughed herself silly") where CxG handles the extra
-argument via construction-licensed roles while Minimalism requires
-special mechanisms.
-
+All three converge on canonical resultatives ("She hammered the metal
+flat") and diverge on fake reflexives ("She laughed herself silly"),
+where CxG licenses the extra argument constructionally while the verb's
+theta grid cannot.
 -/
 
 namespace TheoryComparison
@@ -34,17 +26,9 @@ open DepGrammar
 
 /-! ## §1. Three theories of argument licensing -/
 
-/-- Semantic role label (theory-neutral). -/
-inductive ArgRole where
-  | agent
-  | patient
-  | theme
-  | resultState
-  | path
-  deriving Repr, DecidableEq
-
-/-- A predicted argument frame: ordered list of roles. -/
-abbrev ArgFrame := List ArgRole
+/-- A predicted argument frame: ordered list of theta roles (the canonical
+`ThetaRole` vocabulary from the linking interface). -/
+abbrev ArgFrame := List ThetaRole
 
 /-! ### Minimalist argument licensing
 
@@ -69,49 +53,19 @@ def minimalistFrame (roles : ArgFrame) : List MergeTrigger :=
 /-- The theta criterion requires 1-to-1 mapping between roles and arguments.
     This is satisfied iff no duplicate roles appear. -/
 def thetaCriterionSatisfied (frame : ArgFrame) : Bool :=
-  frame.eraseDups.length == frame.length
+  frame.dedup.length == frame.length
 
 /-! ### CxG argument licensing
 
-In CxG, both the verb and the construction contribute argument roles.
-Shared roles fuse (FAR); fusion requires semantic coherence. -/
+In CxG, both the verb and the construction contribute argument roles;
+shared roles fuse. The substrate types this directly:
+`Resultatives.ArgSource` records each surface argument's source(s), FAR
+(`farSatisfied`) demands every argument have one, and Semantic Coherence
+(`rolesCoherent`/`semanticCoherenceSatisfied`) constrains fusion. -/
 
-/-- CxG frame: verb roles + construction roles, with fusion information. -/
-structure CxGFrame where
-  /-- Roles contributed by the verb -/
-  verbRoles : List ArgRole
-  /-- Roles contributed by the construction -/
-  constructionRoles : List ArgRole
-  /-- Which role pairs are fused -/
-  fusedPairs : List (ArgRole × ArgRole)
-  deriving Repr, BEq
-
-/-- The surface frame after fusion: construction roles with fused roles counted once. -/
-def CxGFrame.surfaceFrame (f : CxGFrame) : ArgFrame :=
-  let fusedConstructionRoles := f.fusedPairs.map (·.2)
-  let unfusedConstruction := f.constructionRoles.filter
-    (λ r => !fusedConstructionRoles.contains r)
-  f.verbRoles ++ unfusedConstruction
-
-/-- Check FAR: all verb roles and all construction roles are realized. -/
-def CxGFrame.farSatisfied (f : CxGFrame) : Bool :=
-  -- Every verb role must appear (either standalone or fused)
-  let fusedVerbRoles := f.fusedPairs.map (·.1)
-  f.verbRoles.all (λ r => fusedVerbRoles.contains r || f.verbRoles.contains r) &&
-  -- Every construction role must appear (either standalone or fused)
-  let fusedConRoles := f.fusedPairs.map (·.2)
-  f.constructionRoles.all (λ r => fusedConRoles.contains r || f.constructionRoles.contains r)
-
-/-- Map local ArgRole to ThetaRole for coherence checking.
-    `.resultState` and `.path` map to `.goal` — the closest
-    available role in the shared ThetaRole vocabulary. -/
-private def ArgRole.toTheta : ArgRole → ThetaRole
-  | .agent => .agent | .patient => .patient
-  | .theme => .theme | .resultState => .goal
-  | .path => .goal
-
-def CxGFrame.coherent (f : CxGFrame) : Bool :=
-  f.fusedPairs.all (λ ⟨rV, rC⟩ => rolesCoherent rV.toTheta rC.toTheta)
+/-- The roles a frame's verb contributes. -/
+def verbRoles (args : List ArgSource) : List ThetaRole :=
+  (args.filter (·.fromVerb)).map (·.role)
 
 /-! ### DG argument licensing
 
@@ -132,22 +86,21 @@ def DGFrame.allArgs (f : DGFrame) : List ArgSlot :=
 
 /-! ## §2. Convergence on canonical resultatives
 
-All three theories predict the same argument frame for "She hammered the metal flat":
-[Agent, Patient, ResultState]. -/
+All three theories predict the same argument frame for "She hammered the
+metal flat": agent, patient, and the result (mapped to `goal`, the
+substrate's resultGoal). -/
 
 /-- Minimalist prediction for "hammer the metal flat". -/
 def minimalist_hammer_flat : ArgFrame :=
-  [.agent, .patient, .resultState]
+  [.agent, .patient, .goal]
 
-/-- CxG prediction for "hammer the metal flat".
-
-    Verb "hammer" contributes {agent, patient}.
-    Construction contributes {agent, patient, resultState}.
-    Agent fuses with agent; patient fuses with patient. -/
-def cxg_hammer_flat : CxGFrame :=
-  { verbRoles := [.agent, .patient]
-  , constructionRoles := [.agent, .patient, .resultState]
-  , fusedPairs := [(.agent, .agent), (.patient, .patient)] }
+/-- CxG prediction for "hammer the metal flat": *hammer* contributes agent
+and patient (both fused with the construction's); the construction alone
+contributes the result. -/
+def cxg_hammer_flat : List ArgSource :=
+  [ ⟨.agent, true, true⟩
+  , ⟨.patient, true, true⟩
+  , ⟨.goal, false, true⟩ ]
 
 /-- DG prediction for "hammer the metal flat".
 
@@ -165,51 +118,50 @@ def dg_hammer_flat : DGFrame :=
     for "hammer flat": 3 (agent + patient + result). -/
 theorem convergence_hammer_flat_arg_count :
     minimalist_hammer_flat.length = 3 ∧
-    cxg_hammer_flat.surfaceFrame.length = 3 ∧
-    dg_hammer_flat.allArgs.length = 3 := by
-  constructor; rfl
-  constructor; decide
-  rfl
+    cxg_hammer_flat.length = 3 ∧
+    dg_hammer_flat.allArgs.length = 3 := ⟨rfl, rfl, rfl⟩
 
 /-- The theta criterion is satisfied for the canonical resultative. -/
 theorem theta_criterion_canonical :
-    thetaCriterionSatisfied minimalist_hammer_flat = true := by
+    thetaCriterionSatisfied minimalist_hammer_flat = true := by decide
+
+/-- FAR is satisfied for the canonical CxG resultative: every surface
+argument has a source. -/
+theorem far_canonical : farSatisfied cxg_hammer_flat = true := by decide
+
+/-- The canonical fusions are coherent: agent with agent, patient with
+patient (Semantic Coherence, Principle 44). -/
+theorem coherence_canonical :
+    semanticCoherenceSatisfied [(.agent, .agent), (.patient, .patient)] = true := by
   decide
 
-/-- FAR is satisfied for the canonical CxG resultative. -/
-theorem far_canonical :
-    cxg_hammer_flat.farSatisfied = true := by
-  decide
+/-- FAR is a real filter: an argument licensed by neither the verb nor
+the construction fails it. -/
+theorem far_rejects_unsourced :
+    farSatisfied [⟨.agent, true, true⟩, ⟨.patient, false, false⟩] = false := rfl
 
 /-! ## §3. Divergence on fake reflexives
 
 "She laughed herself silly" reveals the key difference between the theories.
 
-- **CxG**: "laugh" contributes {agent}; construction contributes {agent, patient, resultState};
-  agent fuses; "herself" fills the CONSTRUCTION's patient (not the verb's).
-- **Minimalism**: "laugh" is intransitive (assigns only one theta role);
-  "herself" needs a theta role but the verb can't provide one.
-- **DG**: "laugh" has valency {subj}; "herself" is an argument added by the
-  construction, not by the verb's subcategorization frame. -/
+- **CxG**: *laugh* contributes only the agent; the construction contributes
+  the patient ("herself") and the result.
+- **Minimalism**: *laugh* is intransitive (assigns only one theta role);
+  "herself" needs a theta role the verb cannot provide.
+- **DG**: *laugh* has valency {subj}; the construction adds the rest. -/
 
-/-- CxG analysis of "She laughed herself silly".
+/-- CxG analysis of "She laughed herself silly": only the agent is fused;
+the patient and result come from the construction alone. -/
+def cxg_laugh_silly : List ArgSource :=
+  [ ⟨.agent, true, true⟩
+  , ⟨.patient, false, true⟩
+  , ⟨.goal, false, true⟩ ]
 
-    The verb "laugh" is intransitive: only {agent}.
-    The construction adds {patient, resultState}.
-    Only agent fuses. "Herself" is the construction's patient. -/
-def cxg_laugh_silly : CxGFrame :=
-  { verbRoles := [.agent]
-  , constructionRoles := [.agent, .patient, .resultState]
-  , fusedPairs := [(.agent, .agent)] }
-
-/-- Minimalist analysis of "She laughed herself silly".
-
-    "laugh" assigns only one theta role (agent to subject).
-    "herself" needs a theta role, but the verb doesn't provide one.
-    The extra role must come from somewhere — requiring special mechanisms
-    (e.g., the small clause assigns a role). -/
+/-- Minimalist analysis: *laugh* assigns only one theta role. -/
 def minimalist_laugh_silly_verb_roles : ArgFrame := [.agent]
-def minimalist_laugh_silly_full : ArgFrame := [.agent, .patient, .resultState]
+
+/-- The surface frame the Minimalist analysis must somehow license. -/
+def minimalist_laugh_silly_full : ArgFrame := [.agent, .patient, .goal]
 
 /-- DG analysis of "She laughed herself silly".
 
@@ -223,18 +175,15 @@ def dg_laugh_silly : DGFrame :=
       , { depType := .amod, dir := .right, required := true
         , cat := some UD.UPOS.ADJ } ] }
 
-/-- CxG: the verb contributes fewer roles than the surface frame.
-    The construction licenses the extra argument ("herself"). -/
+/-- CxG: the verb contributes fewer roles than the surface frame; the
+construction licenses the extra arguments. -/
 theorem cxg_construction_adds_patient :
-    cxg_laugh_silly.verbRoles.length < cxg_laugh_silly.surfaceFrame.length := by
-  decide
+    (verbRoles cxg_laugh_silly).length < cxg_laugh_silly.length := by decide
 
-/-- CxG handles fake reflexives without stipulation: the construction
-    adds the patient role, and the verb's agent fuses with the
-    construction's agent. FAR is satisfied. -/
+/-- The fake reflexive satisfies FAR: every argument is sourced — the
+agent by fusion, the patient and result by the construction alone. -/
 theorem cxg_fake_reflexive_far :
-    cxg_laugh_silly.farSatisfied = true := by
-  decide
+    farSatisfied cxg_laugh_silly = true := by decide
 
 /-- The Minimalist verb alone cannot license the reflexive:
     the verb has only 1 theta role but the surface has 3 arguments.
@@ -243,70 +192,32 @@ theorem cxg_fake_reflexive_far :
     add roles, while the theta criterion requires the verb to provide them. -/
 theorem minimalist_verb_deficit :
     minimalist_laugh_silly_verb_roles.length <
-    minimalist_laugh_silly_full.length := by
-  decide
+    minimalist_laugh_silly_full.length := by decide
 
 /-- DG: the construction adds 2 arguments to the verb's base valency of 1. -/
 theorem dg_construction_adds_args :
     dg_laugh_silly.verbArgs.length = 1 ∧
-    dg_laugh_silly.constructionArgs.length = 2 := by
-  constructor <;> rfl
+    dg_laugh_silly.constructionArgs.length = 2 := ⟨rfl, rfl⟩
 
 /-- Despite the different licensing mechanisms, all three theories predict
     the same surface argument count for the fake reflexive: 3. -/
 theorem convergence_fake_reflexive_count :
     minimalist_laugh_silly_full.length = 3 ∧
-    cxg_laugh_silly.surfaceFrame.length = 3 ∧
-    dg_laugh_silly.allArgs.length = 3 := by
-  constructor; rfl
-  constructor; decide
-  rfl
+    cxg_laugh_silly.length = 3 ∧
+    dg_laugh_silly.allArgs.length = 3 := ⟨rfl, rfl, rfl⟩
 
-/-! ## §4. Semantic Coherence generalizes the Theta Criterion
+/-! ## §4. Construction licensing generalizes the theta grid
 
-The Theta Criterion is the special case of FAR + Semantic Coherence where
-the verb and construction have identical role sets (i.e., every role fuses).
+CxG's system is strictly more permissive than verb-driven theta
+assignment: there are frames that satisfy FAR in which the verb's own
+roles undergenerate the surface arguments — exactly the fake reflexives.
+The theta criterion alone cannot license these without extra machinery. -/
 
-When the sets differ (as in fake reflexives), CxG's system is more general:
-it allows the construction to ADD roles the verb lacks. -/
-
-/-- The theta criterion requires a 1-to-1 mapping between roles and arguments.
-    This is equivalent to FAR when verb roles = construction roles
-    (all roles fuse, no construction-only roles). -/
-theorem theta_criterion_is_full_fusion :
-    ∀ (roles : ArgFrame),
-    thetaCriterionSatisfied roles = true →
-    roles.eraseDups.length = roles.length := by
-  intro roles h
-  simp [thetaCriterionSatisfied] at h
-  exact h
-
-/-- CxG's system is strictly more general: it handles cases where
-    verb roles ⊂ construction roles (fake reflexives). The theta
-    criterion alone cannot handle this without extra machinery.
-
-    Formally: there exists a CxG frame where FAR is satisfied but the
-    verb alone does not provide enough theta roles. -/
-theorem semanticCoherenceGeneralizesTheta :
-    -- There exists a CxG frame where:
-    -- 1. FAR is satisfied (all roles are realized)
-    -- 2. But the verb contributes fewer roles than the surface needs
-    cxg_laugh_silly.farSatisfied = true ∧
-    cxg_laugh_silly.verbRoles.length < cxg_laugh_silly.surfaceFrame.length := by
-  constructor
-  · decide
-  · decide
-
-/-! ## Summary
-
-| Theory | Canonical ("hammer flat") | Fake reflexive ("laugh silly") |
-|--------|---------------------------|-------------------------------|
-| Minimalism | Theta assigns 3 roles | Verb has only 1 role → deficit |
-| CxG | Verb + construction fuse | Construction adds patient |
-| DG | Verb + construction deps | Construction adds obj + compl |
-
-All three predict the same surface frame [Agent, V, Patient, Result],
-but CxG handles argument augmentation via construction-licensed roles
-while Minimalism requires special mechanisms for fake reflexives. -/
+/-- The fake reflexive is FAR-licensed while the verb undergenerates:
+construction-licensed roles are doing real work. -/
+theorem construction_licensing_generalizes_theta :
+    farSatisfied cxg_laugh_silly = true ∧
+    (verbRoles cxg_laugh_silly).length < cxg_laugh_silly.length := by
+  exact ⟨by decide, by decide⟩
 
 end TheoryComparison

--- a/Linglib/Studies/Dunn2025.lean
+++ b/Linglib/Studies/Dunn2025.lean
@@ -75,7 +75,7 @@ instance of this pattern. -/
 
 /-- WXDY's typed form, from its owning study file. -/
 private def wxdyForm : TypedForm String :=
-  ConstructionGrammar.Studies.KayFillmore1999.wxdyConstruction.form
+  KayFillmore1999.wxdyConstruction.form
 
 /-- Coinstantiation construction ([kay-fillmore-1999], Figure 13, §4.2).
 
@@ -93,7 +93,7 @@ def coinstantiationForm : TypedForm String :=
 theorem wxdy_abstraction :
     abstractionLevel wxdyForm = 2 / 5 := by
   norm_num [abstractionLevel, wxdyForm,
-    ConstructionGrammar.Studies.KayFillmore1999.wxdyConstruction,
+    KayFillmore1999.wxdyConstruction,
     List.filter, SlotFiller.isOpen]
 
 /-- WXDY is partiallyOpen: mix of open, headed, and fixed slots. -/

--- a/Linglib/Studies/FillmoreKayOConnor1988.lean
+++ b/Linglib/Studies/FillmoreKayOConnor1988.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.ConstructionGrammar.ArgumentStructure
+import Linglib.Syntax.ConstructionGrammar.Inheritance
 import Linglib.Features.Acceptability
 import Linglib.Features.Polarity
 import Linglib.Typology.PolarityItem
@@ -248,6 +249,17 @@ def npiTriggerToContext : LetAloneNPITrigger → LicensingContext
   | .failureVerb            => .negation              -- "fail" ≈ implicit negation
   | .anyoneWhod             => .universalRestrictor
 
+/-- The garden-variety coordination construction *let alone* is measured
+against (§2.2.1): two like-category conjuncts joined by a coordinating
+conjunction. Present as the parent node of the inheritance link below. -/
+def coordinationConstruction : Construction :=
+  { name := "Coordinating conjunction"
+  , form :=
+      [ { filler := .phrasal, role := some "conjunct₁" }
+      , { filler := .open_ .CCONJ }
+      , { filler := .phrasal, role := some "conjunct₂" } ]
+  , meaning := "joins two like-category constituents" }
+
 /-- *Let alone* against the coordination diagnostics of §2.2.1 (p. 514–517).
 Shared with coordinating conjunctions: joins like categories, right node
 raising, gapping. Overridden: no VP ellipsis (exx. 39–41), no IT-clefting
@@ -268,6 +280,14 @@ def letAloneInheritance : InheritanceLink :=
       , "second conjunct is a sentence fragment, not full clause"
       , "requires scalar relationship between conjuncts"
       , "is a negative polarity item" ] }
+
+/-- The §2.2.1 comparison as a two-node network. -/
+def letAloneNetwork : Constructicon :=
+  { constructions := [coordinationConstruction, letAloneConstruction]
+  , links := [letAloneInheritance] }
+
+/-- The link resolves: no dangling parent. -/
+theorem letAloneNetwork_wellFormed : letAloneNetwork.WellFormed := by decide
 
 /-! ### Other constructions of §1 -/
 

--- a/Linglib/Studies/KayFillmore1999.lean
+++ b/Linglib/Studies/KayFillmore1999.lean
@@ -10,23 +10,30 @@ import Linglib.Syntax.ConstructionGrammar.IdiomTypology
 import Linglib.Phenomena.TenseAspect.Diagnostics
 
 /-!
-# [kay-fillmore-1999]: *What's X Doing Y?* — Empirical Data
-[kay-fillmore-1999]
+# [kay-fillmore-1999]: *What's X Doing Y?*
 
-Theory-neutral judgment data from "Grammatical Constructions and Linguistic
-Generalizations: The *What's X doing Y?* Construction" (Language 75(1):1–33).
+"Grammatical Constructions and Linguistic Generalizations: The *What's X
+doing Y?* Construction" (Language 75(1):1–33). WXDY has interrogative
+*form* but expressive *function* on the incredulity reading; the
+form–function mismatch is derived rather than stipulated: the literal
+reading is a genuine question (speaker-ignorance satisfies the PerspP
+presupposition), the incredulity reading a blocked one (speaker knowledge
+contradicts it), with the presupposed proposition and the
+unexpectedness CI typed via `PrProp`/`TwoDimProp`.
 
-## Phenomena covered
+The paper's own inheritance hierarchy — WXDY inheriting from the
+left-isolation, subject–aux-inversion, and wh-interrogative constructions
+of its unification-based grammar — is recorded here only as prose;
+assembling it as a checked network awaits verification of the paper's
+figures.
 
-1. **Incredulity reading**: "What's this fly doing in my soup?" (speaker knows the answer)
-2. **Literal question reading**: "What's John doing in the kitchen?" (genuine information-seeking)
-3. **Progressive requirement**: WXDY requires progressive *doing*; bare infinitive is out
-4. **Subject referentiality**: referential subjects OK; non-referential degraded
-5. **Complement types**: locative PP, participial VP, instrumental PP
-6. **Ambiguity**: sentences admitting both readings
-7. **Embedding / CI projection**: WXDY meaning under embedding predicates
-8. **FKO1988 comparison**: relation to Incredulity Response construction
+## Main declarations
 
+- `KayFillmore1999.wxdyConstruction`: the construction, typed form per
+  Figure 12
+- `KayFillmore1999.allExamples`: judgment data
+- `KayFillmore1999.perspP_disambiguates_wxdy`: the two readings derived
+- `KayFillmore1999.wxdyPresup`, `wxdyTwoDim`: typed pragmatics
 -/
 
 namespace KayFillmore1999
@@ -248,57 +255,9 @@ theorem has_all_judgment_types :
   constructor; decide
   decide
 
-end KayFillmore1999
-
-/-! ## Bridge content (merged from CxG_KayFillmore1999Bridge.lean) -/
-
-/-!
-# [kay-fillmore-1999]: *What's X Doing Y?* Construction
-[kay-fillmore-1999] [dayal-2025] [potts-2005]
-
-Formalization of "Grammatical Constructions and Linguistic Generalizations:
-The *What's X doing Y?* Construction" (Language 75(1):1–33).
-
-## Key insight
-
-WXDY has interrogative *form* but expressive *function* on the incredulity
-reading. This form–function mismatch is precisely what the existing
-LeftPeriphery + Expressives + Presupposition infrastructure can derive:
-
-- **Interrogative form**: +WH feature, wh-fronting, subject-aux inversion
-- **Expressive function**: CI content (unexpectedness), presupposed proposition
-
-The two readings are distinguished by the PerspectiveP layer:
-- **Literal**: speaker is ignorant → PerspP satisfied → genuine question
-- **Incredulity**: speaker knows the answer → PerspP blocked → not a real question
-
-## Bridge targets (10 modules)
-
-| # | Module | Bridge |
-|---|--------|--------|
-| 1 | `Core/Presupposition` | WXDY presupposes the embedded proposition |
-| 2 | `Expressives/Basic` | Incredulity is CI content (projects through negation) |
-| 3 | `Semantics.Questions/Hamblin` | Literal = standard `which`; incredulity = degenerate Q |
-| 4 | `Semantics.ArgumentStructure.Linking/LeftPeriphery` | PerspP disambiguates the two readings |
-| 5 | `Core/CommonGround` | Presupposition requires CommonGround entailment |
-| 6 | `Verb/Aspect` | Progressive requirement (durative ∧ dynamic) |
-| 7 | `Focus/DomainWidening` | Incongruity = normative expectation violation |
-| 8 | `Semantics.Questions/Polarity` | Incredulity = rhetorical question |
-| 9 | `FKO1988` | WXDY is a formal idiom; sibling to Incredulity Response |
-| 10 | `Phenomena/KayFillmore1999` | Per-datum verification |
-
--/
-
-open KayFillmore1999
-open FillmoreKayOConnor1988
-
-namespace ConstructionGrammar.Studies.KayFillmore1999
+/-! ### The construction -/
 
 open ConstructionGrammar
-
--- ============================================================================
--- A. Construction definition
--- ============================================================================
 
 /-- The WXDY construction as a `Construction`.
 
@@ -326,9 +285,7 @@ def wxdyConstruction : Construction :=
   , meaning := "Incredulity: speaker presupposes embedded prop, expresses surprise; Literal: genuine activity question"
   , pragmaticFunction := "presupposes situation; CI: speaker finds it unexpected/inappropriate" }
 
--- ============================================================================
--- B. FKO1988 idiom classification bridge
--- ============================================================================
+/-! ### FKO1988 idiom classification bridge -/
 
 /-- WXDY is a formal idiom in FKO1988's typology: encoding (must learn the
 incredulity convention), grammatical (fills proper grammatical slots),
@@ -350,58 +307,7 @@ theorem wxdy_is_formal_idiom :
     wxdyConstruction.specificity = .partiallyOpen ∧
     wxdyConstruction.pragmaticFunction.isSome := ⟨rfl, rfl, rfl⟩
 
--- ============================================================================
--- C. CxG inheritance network
--- ============================================================================
-
-/-- WXDY inherits from wh-questions: wh-fronting, +WH feature,
-subject-aux inversion. Overrides: question semantics (on the incredulity
-reading, it's not a genuine information-seeking question). -/
-def wxdyInheritanceFromWhQ : InheritanceLink :=
-  { parent := "Wh-question"
-  , child := "What's X doing Y?"
-  , mode := .normal
-  , sharedProperties :=
-      [ "wh-fronting"
-      , "+WH feature on C"
-      , "subject-aux inversion" ]
-  , overriddenProperties :=
-      [ "question semantics (incredulity reading is not info-seeking)" ] }
-
-/-- WXDY inherits progressive morphology from the progressive construction:
-*doing* carries -ing morphology. -/
-def wxdyInheritanceFromProgressive : InheritanceLink :=
-  { parent := "Progressive"
-  , child := "What's X doing Y?"
-  , mode := .normal
-  , sharedProperties :=
-      [ "-ing morphology on main verb"
-      , "selects durative dynamic predicates" ]
-  , overriddenProperties :=
-      [ "progressive semantics (doing is frozen, not compositional progressive)" ] }
-
-/-- WXDY and FKO1988's Incredulity Response ("Him be a doctor?") are
-siblings in the "rhetorical question family" — both express incredulity
-via non-standard question forms. -/
-def wxdyInheritanceFromIncredulity : InheritanceLink :=
-  { parent := "Rhetorical question family"
-  , child := "What's X doing Y?"
-  , mode := .normal
-  , sharedProperties :=
-      [ "interrogative form"
-      , "expressive function (speaker incredulity)"
-      , "speaker knows/presupposes the answer" ]
-  , overriddenProperties :=
-      [ "WXDY uses standard syntax; IR uses accusative subject + bare stem" ] }
-
-/-- WXDY and the Incredulity Response share the same expressive family. -/
-theorem wxdy_same_class_as_incredulity_response :
-    wxdyInheritanceFromIncredulity.parent =
-    "Rhetorical question family" := rfl
-
--- ============================================================================
--- D. Presupposition bridge (Core/Presupposition.lean)
--- ============================================================================
+/-! ### Presupposition bridge (Core/Presupposition.lean) -/
 
 open Semantics.Presupposition
 
@@ -420,9 +326,7 @@ theorem wxdy_presup_projects_neg {W : Type*} (embeddedProp : W → Prop) :
     ∀ w, (PrProp.neg (wxdyPresup embeddedProp)).presup w ↔
          embeddedProp w := fun _ => Iff.rfl
 
--- ============================================================================
--- E. Two-dimensional semantics bridge (Expressives/Basic.lean)
--- ============================================================================
+/-! ### Two-dimensional semantics bridge (Expressives/Basic.lean) -/
 
 open Pragmatics.Expressives
 
@@ -467,9 +371,7 @@ theorem wxdy_ci_independent {W : Type*}
       (wxdyTwoDim embeddedProp unexpectedness).ci w) := by
   exact ⟨λ _ => h_ci, λ _ => h_ci⟩
 
--- ============================================================================
--- F. Hamblin question semantics bridge (Semantics/Questions/Hamblin.lean substrate)
--- ============================================================================
+/-! ### Hamblin question semantics bridge (Semantics/Questions/Hamblin.lean substrate) -/
 
 open Question
 
@@ -502,9 +404,7 @@ theorem literal_is_genuine_question {W E : Type*}
     (activities : Set E) (pred : E → Set W) :
     wxdyLiteralQ activities pred = which activities pred := rfl
 
--- ============================================================================
--- G. Left Periphery bridge (Semantics.ArgumentStructure.Linking/LeftPeriphery.lean) — DEEPEST BRIDGE
--- ============================================================================
+/-! ### Left Periphery bridge (Semantics.ArgumentStructure.Linking/LeftPeriphery.lean) — DEEPEST BRIDGE -/
 
 open Syntax.Minimalist.LeftPeriphery
 
@@ -551,9 +451,7 @@ theorem perspP_disambiguates_wxdy {W : Type*}
     perspPPresupComp ignorantModel q w = true :=
   ⟨wxdy_incredulity_blocks_perspP q w, wxdy_literal_allows_perspP q w⟩
 
--- ============================================================================
--- H. Common ground bridge (Core/CommonGround.lean)
--- ============================================================================
+/-! ### Common ground bridge (Core/CommonGround.lean) -/
 
 open CommonGround
 
@@ -566,9 +464,7 @@ theorem wxdy_presup_requires_cg {W : Type*}
     (wxdyPresup embeddedProp).presup w :=
   h hw
 
--- ============================================================================
--- I. Aspect bridge (Semantics.Montague/Verb/Aspect.lean + Diagnostics)
--- ============================================================================
+/-! ### Aspect bridge (Semantics.Montague/Verb/Aspect.lean + Diagnostics) -/
 
 open Features
 open Semantics.Lexical
@@ -585,17 +481,4 @@ theorem wxdy_requires_progressive_aspect (c : VendlerClass) :
     (c.duration = .durative ∧ c.dynamicity = .dynamic) :=
   progressive_accepts_durative_dynamic c
 
--- ============================================================================
--- L. Per-datum verification
--- ============================================================================
-
-/-- The data contains all three reading types. -/
-theorem all_readings_attested :
-    (allExamples.any (λ d : WXDYDatum => d.reading == .literal)) = true ∧
-    (allExamples.any (λ d : WXDYDatum => d.reading == .incredulity)) = true ∧
-    (allExamples.any (λ d : WXDYDatum => d.reading == .ambiguous)) = true := by
-  constructor; decide
-  constructor; decide
-  decide
-
-end ConstructionGrammar.Studies.KayFillmore1999
+end KayFillmore1999

--- a/Linglib/Studies/OsborneGross2012/Data.lean
+++ b/Linglib/Studies/OsborneGross2012/Data.lean
@@ -212,45 +212,18 @@ def theMoreTheFatter : DepTree :=
              ⟨7, 6, .nsubj⟩, ⟨7, 5, .xcomp⟩, ⟨5, 4, .det⟩]
     rootIdx := 7 }
 
-end OsborneGross2012
+/-! ## The paper's claims
 
-/-! ## Bridge content (merged from DG_OsborneGross2012Bridge.lean) -/
-
-/-!
-# Bridge: Osborne & Groß (2012) DG Catenae → CxG Constructions
-[fillmore-kay-oconnor-1988] [osborne-gross-2012]
-
-Connects the dependency trees from `Studies/OsborneGross2012/Data.lean`
-to the catena theory from `Catena.lean` and the CxG types from
-`ConstructionGrammar.Basic` and `FillmoreKayOConnor1988`.
-
-## Verified Claims
-
-**Claim 1** (p. 176): Every construction type — idioms, LVCs, verb chains,
-displacement, comparative correlatives — corresponds to a catena. All 10
-example trees are verified. All non-trivial constructions are non-constituent
-catenae, demonstrating that the catena concept is needed.
-
-**Claim 2** (p. 176): When a more fixed construct (idiom, LVC) is broken up
-by a less fixed one (NP), **both** form catenae. Verified for all 7
-V-det-N examples and the CC's two clauses.
-
-## CxG ↔ DG Bridge
-
-Four `CatenalCx` instances covering the full specificity spectrum
-(lexicallySpecified → partiallyOpen → fullyAbstract), connecting CxG
-`Construction` descriptions to DG catena witnesses.
-
-FKO1988 `IdiomType` classification is bridged to catena verification:
-substantive decoding idioms ("kick the bucket") and formal idioms
-(the comparative correlative) are both catenae.
-
--/
-
-namespace OsborneGross2012.Bridge
+**Claim 1** (p. 176): every construction type — idioms, LVCs, verb chains,
+displacement, comparative correlatives — corresponds to a catena; the
+non-trivial ones are non-constituent catenae, demonstrating that the
+catena concept is needed. **Claim 2** (p. 176): when a more fixed
+construct (idiom, LVC) is broken up by a less fixed one (NP), *both* form
+catenae. `CatenalCx` instances span the specificity spectrum, and
+[fillmore-kay-oconnor-1988]'s idiom typology classifies the catena-verified
+constructions. -/
 
 open DepGrammar DepGrammar.Catena ConstructionGrammar
-open OsborneGross2012
 open DepGrammar.CatenalConstruction
 
 -- ============================================================================
@@ -566,4 +539,4 @@ theorem cc_matches_fko1988 :
     isCatena theMoreTheFatter.deps [4, 5, 6, 7] = true := by
   refine ⟨rfl, rfl, ?_, ?_⟩ <;> decide
 
-end OsborneGross2012.Bridge
+end OsborneGross2012

--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.ConstructionGrammar.Basic
+import Linglib.Syntax.ConstructionGrammar.Inheritance
 import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
 import Linglib.Data.UD.Basic
 
@@ -66,9 +67,10 @@ def ditransitive : ArgStructureConstruction :=
   , hasHead := by decide }
 
 /-- Caused-motion construction: [Subj V Obj Obl].
-"X CAUSES Y to MOVE to Z" (e.g., "She sneezed the napkin off the table").
-Contributes motion + causation: verbs that lexicalize neither (like *sneeze*)
-acquire both from the construction ([goldberg-1995] p. 152–179). -/
+"X CAUSES Y to MOVE Z", Z a directional ("Pat sneezed the napkin off the
+table", p. 3). Contributes motion + causation: verbs that lexicalize
+neither (like *sneeze*) acquire both from the construction
+([goldberg-1995] p. 152–179). -/
 def causedMotion : ArgStructureConstruction :=
   { construction :=
       { name := "Caused-motion"
@@ -77,7 +79,7 @@ def causedMotion : ArgStructureConstruction :=
           , { filler := .open_ .VERB, role := some "predicate", isHead := true }
           , { filler := .open_ .NOUN, role := some "theme" }
           , { filler := .open_ .ADP, role := some "goal" } ]
-      , meaning := "X CAUSES Y to MOVE to Z" }
+      , meaning := "X CAUSES Y to MOVE Z" }
   , hasHead := by decide
   , semanticContribution :=
       { changeOfState := false, contact := false, motion := true, causation := true } }
@@ -236,7 +238,12 @@ ditransitive's syntactic form [Subj V Obj Obj₂] but differs in the
 semantic relation between the event participants. -/
 
 /-- The ditransitive polysemy family: six senses sharing one argument
-frame ([goldberg-1995] pp. 75–77). -/
+frame ([goldberg-1995] pp. 75–77; verb classes per Figure 2.2, p. 38).
+The extension labels are the formalizer's — Goldberg numbers the senses
+and calls the Intended extension "the benefactive construction" (Figure
+3.2). Her warrant for the shared frame is exactly what `PolysemyFamily`
+enforces definitionally: "The syntactic specifications of the central
+sense are inherited by the extensions" (p. 75). -/
 def ditransitiveFamily : PolysemyFamily :=
   { name := "Ditransitive"
   , slots := ditransitive.slots
@@ -264,15 +271,16 @@ def ditransitivePolysemy : List InheritanceLink :=
   ditransitiveFamily.polysemyLinks
 
 /-- Subpart link (I_S) from caused-motion to intransitive motion
-([goldberg-1995] p. 78): the intransitive motion construction is a
-proper subpart of the caused-motion construction. -/
+([goldberg-1995] p. 78, link annotated "I_S: cause"): the intransitive
+motion construction is a proper subpart of the caused-motion construction.
+The cause role is *absent* in the subpart, not overridden — I_S relates a
+proper subpart, so the override slot stays empty. -/
 def causedMotionSubpart : InheritanceLink :=
   { parent := "Caused-motion"
   , child := "Intransitive-motion"
   , mode := .normal
   , linkType := some .subpart
-  , sharedProperties := ["MOVE predicate", "theme role", "path/goal role"]
-  , overriddenProperties := ["no external causer"] }
+  , sharedProperties := ["MOVE predicate", "theme role", "path/goal role"] }
 
 /-- Metaphorical extension link (I_M) from caused-motion to resultative
 ([goldberg-1995] pp. 81–84): the resultative is a metaphorical
@@ -284,7 +292,40 @@ def causedMotionToResultative : InheritanceLink :=
   , mode := .normal
   , linkType := some .metaphorical
   , sharedProperties := ["X CAUSES Y to undergo change", "causal structure"]
-  , overriddenProperties := ["motion → change of state", "location → property"] }
+  , overriddenProperties := ["motion → change of state", "location → state"] }
+
+/-! ## The book's network as a constructicon
+
+[goldberg-1995] draws no single master figure; the network below assembles
+the per-link analyses under the book's own framing of "the entire
+collection of constructions as forming a lattice, with individual
+constructions related by specific types of asymmetric normal mode
+inheritance links" (pp. 99–100): the ditransitive polysemy family
+(pp. 75–77), the caused-motion → intransitive-motion subpart link (p. 78),
+and the caused-motion → resultative metaphorical link (§3.4.1, the
+"Change of State as Change of Location" metaphor). The conative appears in
+the book's construction inventory (p. 4) but participates in no
+inheritance link — it is a node without edges, and linking it would be
+invention. -/
+
+/-- The ch. 2–3 constructional network. -/
+def goldberg1995Network : Constructicon :=
+  { constructions :=
+      ditransitiveFamily.allConstructions.map (·.construction) ++
+        [ causedMotion.construction, intransitiveMotion.construction
+        , resultative.construction, conative.construction ]
+  , links :=
+      ditransitivePolysemy ++ [causedMotionSubpart, causedMotionToResultative] }
+
+/-- Every link of the network resolves to a member construction. -/
+theorem goldberg1995Network_wellFormed : goldberg1995Network.WellFormed := by
+  decide
+
+/-- The links, not hand-listed parents, determine the resultative's mother:
+the caused-motion construction, via the metaphorical link. -/
+theorem resultative_parent :
+    goldberg1995Network.parentsOf "Resultative" = [causedMotion.construction] := by
+  decide
 
 /-- Every link a polysemy family derives is an I_P link — a fact about the
 construction, not about one table. -/

--- a/Linglib/Syntax/ConstructionGrammar/Basic.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Basic.lean
@@ -52,8 +52,10 @@ inductive Specificity where
   Allows subregularities and exceptions. The only mode used in
   [goldberg-1995]'s system.
 - **Complete**: all information from dominating nodes is inherited strictly;
-  no conflicts allowed. Used in unification-based grammars (HPSG, GPSG)
-  but not exploited in [goldberg-1995]'s constructional analysis.
+  no conflicts allowed. The mode "normally assumed in unification-based
+  grammars" (p. 74, citing Kay 1984 and Fillmore & Kay 1993); the
+  normal/complete distinction follows Flickinger, Pollard & Wasow (1985).
+  Not exploited in [goldberg-1995]'s constructional analysis.
 
 Computational semantics for both modes: `ConstructionGrammar.Inheritance`. -/
 inductive InheritanceMode where

--- a/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
@@ -619,6 +619,24 @@ def resultativeInheritance : List InheritanceLink :=
   [ResultativeSubconstruction.causativeProperty,
    .causativePath, .noncausativeProperty, .noncausativePath].map (·.inheritanceLink)
 
+/-- The [goldberg-jackendoff-2004] resultative family as a constructicon:
+the parent construction plus its four derived subconstructions and
+inheritance links. -/
+def resultativeNetwork : Constructicon :=
+  { constructions :=
+      resultative.construction :: resultativeFamily.map (·.construction)
+  , links := resultativeInheritance }
+
+/-- Every derived link resolves to a member construction. -/
+theorem resultativeNetwork_wellFormed : resultativeNetwork.WellFormed := by
+  decide
+
+/-- The links determine each subconstruction's mother: the resultative. -/
+theorem subconstruction_parent (sc : ResultativeSubconstruction) :
+    resultativeNetwork.parentsOf sc.toConstruction.construction.name =
+      [resultative.construction] := by
+  cases sc <;> decide
+
 /-- All inheritance links point to the same parent. -/
 theorem all_inherit_from_resultative :
     resultativeInheritance.all (·.parent == "Resultative") = true := by


### PR DESCRIPTION
PR B from the CxG audit: everything the network layer couldn't see is now assembled and checked, with the Goldberg 1995 claims verified against the book PDF.

- `goldberg1995Network` (ArgumentStructure.lean): the ch. 2–3 lattice — ditransitive polysemy family, subpart and metaphorical links — with `WellFormed` and `resultative_parent` by `decide`. The conative stays an unlinked node (the book links it to nothing). Verified fixes: "Pat sneezed the napkin off the table" (p. 3), "location → state" (p. 83), "MOVE Z" not "MOVE to Z", complete-mode attribution per p. 73–74, subpart cause-role absent-not-overridden.
- `resultativeNetwork` (Resultatives.lean, GJ2004's apparatus kept separate from the 1995 network) and `letAloneNetwork` (FKO, with a typed coordination parent) — both `WellFormed`; KF99's three unverifiable links demoted to docstring prose pending the paper's actual hierarchy.
- Legacy dual namespace + bridge meta-commentary consolidated in KayFillmore1999.lean (duplicate theorems deleted, Dunn2025 rewired) and OsborneGross2012/Data.lean.
- TheoryComparison.lean rebuilt on the substrate: the tautological `CxGFrame.farSatisfied` and shadow `ArgRole` enum are gone; the CxG side now runs `Resultatives.ArgSource`/`farSatisfied`/`rolesCoherent`, with a negative FAR sentry.