### PR TITLE
feat(Core/Logic/Modal/QBSML): constants, Kripke layer, full Prop 4.1

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2871,3 +2871,4 @@ import Linglib.Studies.KeenanStavi1986
 import Linglib.Core.Logic.FirstOrder.Binders
 import Linglib.Studies.ChatzikyriakidisLuo2017
 import Linglib.Core.Logic.FirstOrder.Kripke
+import Linglib.Core.Logic.Modal.QBSML.StandardTranslation

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2870,3 +2870,4 @@ import Linglib.Studies.Thomas2026
 import Linglib.Studies.KeenanStavi1986
 import Linglib.Core.Logic.FirstOrder.Binders
 import Linglib.Studies.ChatzikyriakidisLuo2017
+import Linglib.Core.Logic.FirstOrder.Kripke

--- a/Linglib/Core/Logic/FirstOrder/Kripke.lean
+++ b/Linglib/Core/Logic/FirstOrder/Kripke.lean
@@ -1,0 +1,191 @@
+import Mathlib.ModelTheory.Semantics
+import Linglib.Core.Logic.FirstOrder.Binders
+
+/-!
+# Constant-domain first-order Kripke structures and modal formulas
+
+Mathlib's `ModelTheory` is classical: one structure, no accessibility. A
+`KripkeStructure L W M` is a `W`-indexed family of `L`-structures on a
+constant domain `M` together with `Finset`-valued accessibility — the shape
+`Semantics/Composition/Model.lean` (without accessibility) and
+`Core/Logic/Modal/QBSML/Defs.lean` already instantiate. On top,
+`ModalFormula L α` layers `□` and named quantifiers over embedded classical
+`L.Formula`s, and `ModalFormula.Realize` is Kripke satisfaction
+`K, w ⊨_v φ`. Upstream candidates.
+
+## Main declarations
+
+* `KripkeStructure` — accessibility plus a world-indexed family of
+  first-order structures on a constant domain.
+* `KripkeStructure.RealizeAt` — classical satisfaction at a world, with the
+  transported `Formula.realize_*` simp set.
+* `ModalFormula`, `ModalFormula.Realize` — modal formulas over embedded
+  classical formulas, and Kripke satisfaction; `ModalFormula.dia` is the
+  derived `◇ := ¬□¬`.
+
+## Implementation notes
+
+* Structures are carried as **terms**, not instances — a world-indexed
+  family cannot be instance-based — so interfacing with instance-based
+  mathlib API (`Formula.Realize`) threads `letI := K.interp w`.
+* Accessibility is `Finset`-valued (computability-first, matching the
+  team-semantics consumers); generalize to a `Prop`-valued relation when a
+  consumer needs infinite branching.
+* `ModalFormula` quantifiers bind **named** variables with
+  `Function.update` semantics (the `Formula.all₁` / `ex₁` convention of
+  `Core/Logic/FirstOrder/Binders.lean`), not de Bruijn indices: the modal
+  layer's consumers carry named variables, and the embedding of classical
+  formulas via `ofFormula` makes satisfaction commute by construction
+  (`ModalFormula.realize_ofFormula` is `Iff.rfl`).
+-/
+
+universe u v
+
+namespace FirstOrder.Language
+
+variable {L : Language.{u, v}} {W M : Type*} {α : Type*}
+
+/-- A constant-domain first-order Kripke structure: `Finset`-valued
+    accessibility plus a `W`-indexed family of `L`-structures on the
+    domain `M`. -/
+structure KripkeStructure (L : Language.{u, v}) (W : Type*) (M : Type*) where
+  /-- Accessibility relation (per-world set of accessible worlds). -/
+  access : W → Finset W
+  /-- World-indexed interpretation of the signature. -/
+  interp : W → L.Structure M
+
+namespace KripkeStructure
+
+/-- Classical first-order satisfaction at a world — `K, w ⊨_v ψ`, mathlib's
+    `Formula.Realize` in the structure the Kripke structure carries
+    at `w`. -/
+def RealizeAt (K : KripkeStructure L W M) (w : W) (ψ : L.Formula α)
+    (v : α → M) : Prop :=
+  @Formula.Realize _ _ (K.interp w) _ ψ v
+
+@[simp] theorem realizeAt_not (K : KripkeStructure L W M) (w : W)
+    (ψ : L.Formula α) (v : α → M) :
+    K.RealizeAt w ψ.not v ↔ ¬ K.RealizeAt w ψ v := by
+  letI := K.interp w
+  exact Formula.realize_not
+
+@[simp] theorem realizeAt_inf (K : KripkeStructure L W M) (w : W)
+    (ψ₁ ψ₂ : L.Formula α) (v : α → M) :
+    K.RealizeAt w (ψ₁ ⊓ ψ₂) v ↔
+      K.RealizeAt w ψ₁ v ∧ K.RealizeAt w ψ₂ v := by
+  letI := K.interp w
+  exact Formula.realize_inf
+
+@[simp] theorem realizeAt_sup (K : KripkeStructure L W M) (w : W)
+    (ψ₁ ψ₂ : L.Formula α) (v : α → M) :
+    K.RealizeAt w (ψ₁ ⊔ ψ₂) v ↔
+      K.RealizeAt w ψ₁ v ∨ K.RealizeAt w ψ₂ v := by
+  letI := K.interp w
+  exact Formula.realize_sup
+
+section Binders
+
+variable [DecidableEq α]
+
+@[simp] theorem realizeAt_all₁ (K : KripkeStructure L W M) (w : W) (x : α)
+    (ψ : L.Formula α) (v : α → M) :
+    K.RealizeAt w (Formula.all₁ x ψ) v ↔
+      ∀ d : M, K.RealizeAt w ψ (Function.update v x d) := by
+  letI := K.interp w
+  exact Formula.realize_all₁
+
+@[simp] theorem realizeAt_ex₁ (K : KripkeStructure L W M) (w : W) (x : α)
+    (ψ : L.Formula α) (v : α → M) :
+    K.RealizeAt w (Formula.ex₁ x ψ) v ↔
+      ∃ d : M, K.RealizeAt w ψ (Function.update v x d) := by
+  letI := K.interp w
+  exact Formula.realize_ex₁
+
+end Binders
+
+end KripkeStructure
+
+/-- Modal formulas over `L` with named free variables `α`: classical
+    `L.Formula`s embedded wholesale via `ofFormula`, closed under the
+    connectives, `□`, and named quantifiers (`◇` is derived —
+    `ModalFormula.dia`). -/
+inductive ModalFormula (L : Language.{u, v}) (α : Type*) where
+  /-- An embedded classical (modal-free) formula. -/
+  | ofFormula : L.Formula α → ModalFormula L α
+  /-- Negation. -/
+  | not : ModalFormula L α → ModalFormula L α
+  /-- Conjunction. -/
+  | inf : ModalFormula L α → ModalFormula L α → ModalFormula L α
+  /-- Disjunction. -/
+  | sup : ModalFormula L α → ModalFormula L α → ModalFormula L α
+  /-- Necessity. -/
+  | box : ModalFormula L α → ModalFormula L α
+  /-- Universal quantification of a named variable. -/
+  | all : α → ModalFormula L α → ModalFormula L α
+  /-- Existential quantification of a named variable. -/
+  | ex : α → ModalFormula L α → ModalFormula L α
+
+namespace ModalFormula
+
+/-- Possibility, derived: `◇φ := ¬□¬φ`. -/
+def dia (φ : ModalFormula L α) : ModalFormula L α :=
+  .not (.box (.not φ))
+
+variable [DecidableEq α]
+
+/-- Kripke satisfaction `K, w ⊨_v φ`: classical formulas evaluate at the
+    world's structure, `□` quantifies over accessible worlds, and named
+    quantifiers update the valuation. -/
+def Realize (K : KripkeStructure L W M) :
+    W → ModalFormula L α → (α → M) → Prop
+  | w, .ofFormula ψ, v => K.RealizeAt w ψ v
+  | w, .not φ, v => ¬ Realize K w φ v
+  | w, .inf φ ψ, v => Realize K w φ v ∧ Realize K w ψ v
+  | w, .sup φ ψ, v => Realize K w φ v ∨ Realize K w ψ v
+  | w, .box φ, v => ∀ w' ∈ K.access w, Realize K w' φ v
+  | w, .all x φ, v => ∀ d : M, Realize K w φ (Function.update v x d)
+  | w, .ex x φ, v => ∃ d : M, Realize K w φ (Function.update v x d)
+
+variable (K : KripkeStructure L W M) (w : W) (v : α → M)
+
+/-- Embedded classical formulas realize classically — by construction. -/
+@[simp] theorem realize_ofFormula (ψ : L.Formula α) :
+    (ofFormula ψ : ModalFormula L α).Realize K w v ↔ K.RealizeAt w ψ v :=
+  Iff.rfl
+
+@[simp] theorem realize_not (φ : ModalFormula L α) :
+    (ModalFormula.not φ).Realize K w v ↔ ¬ φ.Realize K w v :=
+  Iff.rfl
+
+@[simp] theorem realize_inf (φ ψ : ModalFormula L α) :
+    (ModalFormula.inf φ ψ).Realize K w v ↔
+      φ.Realize K w v ∧ ψ.Realize K w v :=
+  Iff.rfl
+
+@[simp] theorem realize_sup (φ ψ : ModalFormula L α) :
+    (ModalFormula.sup φ ψ).Realize K w v ↔
+      φ.Realize K w v ∨ ψ.Realize K w v :=
+  Iff.rfl
+
+@[simp] theorem realize_box (φ : ModalFormula L α) :
+    (ModalFormula.box φ).Realize K w v ↔
+      ∀ w' ∈ K.access w, φ.Realize K w' v :=
+  Iff.rfl
+
+@[simp] theorem realize_all (x : α) (φ : ModalFormula L α) :
+    (ModalFormula.all x φ).Realize K w v ↔
+      ∀ d : M, φ.Realize K w (Function.update v x d) :=
+  Iff.rfl
+
+@[simp] theorem realize_ex (x : α) (φ : ModalFormula L α) :
+    (ModalFormula.ex x φ).Realize K w v ↔
+      ∃ d : M, φ.Realize K w (Function.update v x d) :=
+  Iff.rfl
+
+@[simp] theorem realize_dia (φ : ModalFormula L α) :
+    (dia φ).Realize K w v ↔ ∃ w' ∈ K.access w, φ.Realize K w' v := by
+  simp only [dia, realize_not, realize_box, not_forall, not_not, exists_prop]
+
+end ModalFormula
+
+end FirstOrder.Language

--- a/Linglib/Core/Logic/Modal/QBSML/Defs.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/Defs.lean
@@ -1,6 +1,6 @@
 import Mathlib.Data.Finset.Union
 import Mathlib.Data.Fintype.Basic
-import Mathlib.ModelTheory.Basic
+import Linglib.Core.Logic.FirstOrder.Kripke
 import Linglib.Core.Logic.Team.Algebra
 import Linglib.Core.Logic.Bilateral.Defs
 
@@ -32,12 +32,14 @@ the `Core.Logic.Team.isFlat_iff` template at the point type
 * `QBSMLFormula.IsNEFree`: the NE-free fragment.
 * `monadicLang`, `monadicStructure`: the monadic first-order signature on
   `Const` and `Pred` and its structures, as a mathlib `FirstOrder.Language`.
-* `QBSMLModel`, `eval`, `support`, `antiSupport`: bilateral evaluation
+* `QBSMLModel` (an abbreviation for `FirstOrder.Language.KripkeStructure`
+  over `monadicLang`), `eval`, `support`, `antiSupport`: bilateral evaluation
   ([aloni-vanormondt-2023] Definition 4.9), with the interpretation carried
   as a world-indexed family of mathlib structures.
 * `isBilateral`: `support`/`antiSupport` form a
   `Core.Logic.Bilateral.IsBilateral` under `QBSMLFormula.neg`.
-* `QBSMLModel.IsStateBased`, `QBSMLModel.IsIndisputable`: frame conditions
+* `KripkeStructure.IsStateBased`, `KripkeStructure.IsIndisputable`: frame
+  conditions
   via `s↓` ([aloni-vanormondt-2023] Definition 4.10).
 
 ## Implementation notes
@@ -50,10 +52,10 @@ the `Core.Logic.Team.isFlat_iff` template at the point type
 * The paper's domain `D` (part of `M = ⟨W, D, R, I⟩`) is a `Domain : Type*`
   parameter, with `[Fintype Domain]` where the universal extension must range
   over all of it. The interpretation `I` is a world-indexed family of mathlib
-  first-order structures (`QBSMLModel.interp`, the
-  `Semantics.Composition.Model` pattern); `QBSMLModel.pInterp` and
-  `QBSMLModel.cInterp` read the world-dependent (non-rigid) predicate and
-  constant denotations off `Structure.RelMap` / `Structure.funMap`.
+  first-order structures: `QBSMLModel` is `FirstOrder.Language.KripkeStructure`
+  over the monadic signature, and `KripkeStructure.pInterp` /
+  `KripkeStructure.cInterp` read the world-dependent (non-rigid) predicate
+  and constant denotations off `Structure.RelMap` / `Structure.funMap`.
 * The paper requires all indices in a state to share an assignment domain
   (`dom gᵢ = dom gⱼ`); this is not enforced at the type level — the state
   operations preserve it.
@@ -269,6 +271,11 @@ def State.modalLift (X : Finset W) (g : Assignment Var Domain) :
   · rintro ⟨h, rfl⟩
     exact Finset.mem_image.mpr ⟨i.world, h, rfl⟩
 
+@[simp] theorem State.modalLift_singleton (w : W)
+    (g : Assignment Var Domain) :
+    State.modalLift {w} g = {(w, g)} :=
+  Finset.image_singleton ..
+
 @[simp] theorem State.worldProj_modalLift (X : Finset W)
     (g : Assignment Var Domain) :
     State.worldProj (State.modalLift X g) = X := by
@@ -410,25 +417,21 @@ abbrev monadicRel {Const Pred : Type*} (P : Pred) :
   rfl
 
 /-- A QBSML model ([aloni-vanormondt-2023] Definition 4.2:
-    `M = ⟨W, D, R, I⟩`), with the domain as a type parameter, accessibility
-    as a per-world `Finset`, and the interpretation `I` as a world-indexed
-    family of mathlib first-order structures on the domain — the pattern of
-    `Semantics.Composition.Model`. Structures are carried as terms, not
-    instances: a world-indexed family cannot be instance-based, so interfacing
-    with instance-based mathlib API (`Formula.Realize`) threads
-    `letI := M.interp w`. -/
-structure QBSMLModel (W : Type*) (Domain : Type*) (Const : Type*)
-    (Pred : Type*) where
-  /-- Accessibility relation (per-world set of accessible worlds). -/
-  access : W → Finset W
-  /-- World-indexed interpretation of the monadic signature. -/
-  interp : W → (monadicLang Const Pred).Structure Domain
+    `M = ⟨W, D, R, I⟩`) **is** a constant-domain first-order Kripke
+    structure over the monadic signature: accessibility `R` plus the
+    world-indexed interpretation `I`, carried as a family of mathlib
+    structures (`FirstOrder.Language.KripkeStructure`) — true by
+    construction, not by bridge. -/
+abbrev QBSMLModel (W : Type*) (Domain : Type*) (Const : Type*)
+    (Pred : Type*) :=
+  FirstOrder.Language.KripkeStructure (monadicLang Const Pred) W Domain
 
 /-- The predicate denotation at a world, read off the model's structure
     family via `Structure.RelMap` — the world-relativized `I(w)(Pⁿ)` of
     [aloni-vanormondt-2023] Definition 4.2, specialised to monadic `P`
     (cf. `Semantics.Composition.Model.pred₁ext`). -/
-def QBSMLModel.pInterp {W Domain Const Pred : Type*}
+def _root_.FirstOrder.Language.KripkeStructure.pInterp
+    {W Domain Const Pred : Type*}
     (M : QBSMLModel W Domain Const Pred) (P : Pred) (w : W) (d : Domain) :
     Prop :=
   (M.interp w).RelMap (monadicRel P) (fun _ => d)
@@ -436,24 +439,25 @@ def QBSMLModel.pInterp {W Domain Const Pred : Type*}
 /-- The constant denotation at a world — the world-relative `I(w)(c)` of
     [aloni-vanormondt-2023] Definitions 4.2 and 4.8, read off
     `Structure.funMap` (cf. `Semantics.Composition.Model.const`). -/
-def QBSMLModel.cInterp {W Domain Const Pred : Type*}
+def _root_.FirstOrder.Language.KripkeStructure.cInterp
+    {W Domain Const Pred : Type*}
     (M : QBSMLModel W Domain Const Pred) (c : Const) (w : W) : Domain :=
   (M.interp w).funMap (monadicConst c) default
 
-@[simp] theorem QBSMLModel.pInterp_monadicStructure
+@[simp] theorem _root_.FirstOrder.Language.KripkeStructure.pInterp_monadicStructure
     {W Domain Const Pred : Type*} (access : W → Finset W)
     (κ : W → Const → Domain) (V : W → Pred → Domain → Prop) (P : Pred)
     (w : W) (d : Domain) :
-    QBSMLModel.pInterp ⟨access, fun w => monadicStructure (κ w) (V w)⟩ P w d ↔
-      V w P d :=
+    FirstOrder.Language.KripkeStructure.pInterp
+      ⟨access, fun w => monadicStructure (κ w) (V w)⟩ P w d ↔ V w P d :=
   Iff.rfl
 
-@[simp] theorem QBSMLModel.cInterp_monadicStructure
+@[simp] theorem _root_.FirstOrder.Language.KripkeStructure.cInterp_monadicStructure
     {W Domain Const Pred : Type*} (access : W → Finset W)
     (κ : W → Const → Domain) (V : W → Pred → Domain → Prop) (c : Const)
     (w : W) :
-    QBSMLModel.cInterp ⟨access, fun w => monadicStructure (κ w) (V w)⟩ c w =
-      κ w c :=
+    FirstOrder.Language.KripkeStructure.cInterp
+      ⟨access, fun w => monadicStructure (κ w) (V w)⟩ c w = κ w c :=
   rfl
 
 /-! ### Bilateral evaluation -/
@@ -539,23 +543,25 @@ variable [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain]
     ([aloni-vanormondt-2023] Definition 4.10). Defined via
     `Core.Logic.Team.IsStateBased` applied to `State.worldProj s`, sharing
     BSML's frame-condition substrate. -/
-def QBSMLModel.IsStateBased (M : QBSMLModel W Domain Const Pred)
+def _root_.FirstOrder.Language.KripkeStructure.IsStateBased
+    (M : QBSMLModel W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Core.Logic.Team.IsStateBased M.access (State.worldProj s)
 
 /-- `R` is indisputable on `(M, s)`: all worlds in `s↓` see the same
     accessible set ([aloni-vanormondt-2023] Definition 4.10). -/
-def QBSMLModel.IsIndisputable (M : QBSMLModel W Domain Const Pred)
+def _root_.FirstOrder.Language.KripkeStructure.IsIndisputable
+    (M : QBSMLModel W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Core.Logic.Team.IsIndisputable M.access (State.worldProj s)
 
 instance [Fintype W] (M : QBSMLModel W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Decidable (M.IsStateBased s) := by
-  unfold QBSMLModel.IsStateBased; infer_instance
+  unfold FirstOrder.Language.KripkeStructure.IsStateBased; infer_instance
 
 instance [Fintype W] (M : QBSMLModel W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Decidable (M.IsIndisputable s) := by
-  unfold QBSMLModel.IsIndisputable; infer_instance
+  unfold FirstOrder.Language.KripkeStructure.IsIndisputable; infer_instance
 
 end FrameConditions
 

--- a/Linglib/Core/Logic/Modal/QBSML/Defs.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/Defs.lean
@@ -31,7 +31,7 @@ the `Core.Logic.Team.isFlat_iff` template at the point type
   Definition 4.1), with `□` derived as `QBSMLFormula.nec`.
 * `QBSMLFormula.IsNEFree`: the NE-free fragment.
 * `monadicLang`, `monadicStructure`: the monadic first-order signature on
-  `Pred` and its structures, as a mathlib `FirstOrder.Language`.
+  `Const` and `Pred` and its structures, as a mathlib `FirstOrder.Language`.
 * `QBSMLModel`, `eval`, `support`, `antiSupport`: bilateral evaluation
   ([aloni-vanormondt-2023] Definition 4.9), with the interpretation carried
   as a world-indexed family of mathlib structures.
@@ -42,17 +42,18 @@ the `Core.Logic.Team.isFlat_iff` template at the point type
 
 ## Implementation notes
 
-* Predicates are monadic (`pred : Pred → Var → QBSMLFormula Var Pred`) and
-  there is no term language: [aloni-vanormondt-2023] interprets `Pⁿ(t₁ … tₙ)`
-  for arbitrary arity over constants and variables. Monadic predicates over
-  variables suffice for the free-choice facts; higher arities and constants
-  can be added without changing the substrate abstraction.
+* Predicates are monadic and the paper's terms `t := c | x` appear as the
+  two atom constructors `pred` (variable) and `predc` (constant), so there is
+  no separate term type: [aloni-vanormondt-2023] interprets `Pⁿ(t₁ … tₙ)` for
+  arbitrary arity; higher arities can be added without changing the substrate
+  abstraction.
 * The paper's domain `D` (part of `M = ⟨W, D, R, I⟩`) is a `Domain : Type*`
   parameter, with `[Fintype Domain]` where the universal extension must range
   over all of it. The interpretation `I` is a world-indexed family of mathlib
   first-order structures (`QBSMLModel.interp`, the
-  `Semantics.Composition.Model` pattern); `QBSMLModel.pInterp` reads the
-  world-dependent (non-rigid) predicate denotations off `Structure.RelMap`.
+  `Semantics.Composition.Model` pattern); `QBSMLModel.pInterp` and
+  `QBSMLModel.cInterp` read the world-dependent (non-rigid) predicate and
+  constant denotations off `Structure.RelMap` / `Structure.funMap`.
 * The paper requires all indices in a state to share an assignment domain
   (`dom gᵢ = dom gⱼ`); this is not enforced at the type level — the state
   operations preserve it.
@@ -306,81 +307,107 @@ end ModalLift
 
 /-! ### The formula language -/
 
-variable {Pred : Type*}
+variable {Const Pred : Type*}
 
 /-- QBSML formula language ([aloni-vanormondt-2023] Definition 4.1),
-    parameterized over variable type `Var` and (monadic) predicate type
-    `Pred`. `□` is not primitive — see `QBSMLFormula.nec`. -/
-inductive QBSMLFormula (Var : Type*) (Pred : Type*) where
-  /-- Monadic predicate application. -/
-  | pred : Pred → Var → QBSMLFormula Var Pred
+    parameterized over variable type `Var`, constant type `Const`, and
+    (monadic) predicate type `Pred`. The paper's terms `t := c | x` appear
+    as the two atom constructors. `□` is not primitive — see
+    `QBSMLFormula.nec`. -/
+inductive QBSMLFormula (Var : Type*) (Const : Type*) (Pred : Type*) where
+  /-- Monadic predicate applied to a variable. -/
+  | pred : Pred → Var → QBSMLFormula Var Const Pred
+  /-- Monadic predicate applied to an individual constant. -/
+  | predc : Pred → Const → QBSMLFormula Var Const Pred
   /-- Non-emptiness atom: state is non-empty. -/
-  | ne : QBSMLFormula Var Pred
+  | ne : QBSMLFormula Var Const Pred
   /-- Bilateral negation: swap support/anti-support. -/
-  | neg : QBSMLFormula Var Pred → QBSMLFormula Var Pred
+  | neg : QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
   /-- Conjunction. -/
-  | conj : QBSMLFormula Var Pred → QBSMLFormula Var Pred → QBSMLFormula Var Pred
+  | conj : QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred →
+      QBSMLFormula Var Const Pred
   /-- Split (tensor) disjunction. -/
-  | disj : QBSMLFormula Var Pred → QBSMLFormula Var Pred → QBSMLFormula Var Pred
+  | disj : QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred →
+      QBSMLFormula Var Const Pred
   /-- Possibility modal. -/
-  | poss : QBSMLFormula Var Pred → QBSMLFormula Var Pred
+  | poss : QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
   /-- Existential quantifier. -/
-  | exi : Var → QBSMLFormula Var Pred → QBSMLFormula Var Pred
+  | exi : Var → QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
   /-- Universal quantifier. -/
-  | univ : Var → QBSMLFormula Var Pred → QBSMLFormula Var Pred
+  | univ : Var → QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
   deriving Repr
 
 /-- Necessity, derived: `□φ := ¬◇¬φ`. [aloni-vanormondt-2023] takes `□`
     primitive and `◇ := ¬□¬` derived; we invert this, so `eval`'s `poss`
     clauses match the paper's derived `◇`-clauses and `nec` matches its
     primitive `□`. -/
-def QBSMLFormula.nec (φ : QBSMLFormula Var Pred) : QBSMLFormula Var Pred :=
+def QBSMLFormula.nec (φ : QBSMLFormula Var Const Pred) : QBSMLFormula Var Const Pred :=
   .neg (.poss (.neg φ))
 
 /-- The NE-free fragment: formulas not containing the `NE` atom. On this
     fragment QBSML reduces to classical first-order modal logic
     ([aloni-vanormondt-2023] analogue of [anttila-2021]
     Proposition 2.2.16); see `Core/Logic/Modal/QBSML/Properties.lean`. -/
-inductive QBSMLFormula.IsNEFree : QBSMLFormula Var Pred → Prop
+inductive QBSMLFormula.IsNEFree : QBSMLFormula Var Const Pred → Prop
   | pred (P : Pred) (x : Var) : IsNEFree (.pred P x)
-  | neg {φ : QBSMLFormula Var Pred} : IsNEFree φ → IsNEFree (.neg φ)
-  | conj {φ ψ : QBSMLFormula Var Pred} :
+  | predc (P : Pred) (c : Const) : IsNEFree (.predc P c)
+  | neg {φ : QBSMLFormula Var Const Pred} : IsNEFree φ → IsNEFree (.neg φ)
+  | conj {φ ψ : QBSMLFormula Var Const Pred} :
       IsNEFree φ → IsNEFree ψ → IsNEFree (.conj φ ψ)
-  | disj {φ ψ : QBSMLFormula Var Pred} :
+  | disj {φ ψ : QBSMLFormula Var Const Pred} :
       IsNEFree φ → IsNEFree ψ → IsNEFree (.disj φ ψ)
-  | poss {φ : QBSMLFormula Var Pred} : IsNEFree φ → IsNEFree (.poss φ)
-  | exi (x : Var) {φ : QBSMLFormula Var Pred} : IsNEFree φ → IsNEFree (.exi x φ)
-  | univ (x : Var) {φ : QBSMLFormula Var Pred} : IsNEFree φ → IsNEFree (.univ x φ)
+  | poss {φ : QBSMLFormula Var Const Pred} : IsNEFree φ → IsNEFree (.poss φ)
+  | exi (x : Var) {φ : QBSMLFormula Var Const Pred} : IsNEFree φ → IsNEFree (.exi x φ)
+  | univ (x : Var) {φ : QBSMLFormula Var Const Pred} : IsNEFree φ → IsNEFree (.univ x φ)
 
 /-! ### The monadic signature and models -/
 
-/-- The monadic relational signature on `Pred`: one unary relation symbol per
-    predicate, no constants or function symbols ([aloni-vanormondt-2023]
-    Definition 4.1's signature, minus individual constants). -/
-def monadicLang.{u} (Pred : Type u) : FirstOrder.Language where
-  Functions := fun _ => PEmpty.{u + 1}
+/-- The monadic signature on `Const` and `Pred`: one individual constant per
+    `Const`, one unary relation symbol per `Pred` — [aloni-vanormondt-2023]
+    Definition 4.1's signature (terms `t := c | x`, monadic relations). -/
+def monadicLang.{u, v} (Const : Type u) (Pred : Type v) :
+    FirstOrder.Language where
+  Functions := fun n => match n with
+    | 0 => Const
+    | _ => PEmpty
   Relations := fun n => match n with
     | 1 => Pred
     | _ => PEmpty
 
-/-- A predicate as a relation symbol of the monadic signature (defeq; the
-    parametric analogue of mathlib's per-symbol abbreviations, cf.
+/-- A constant as a symbol of the monadic signature (defeq; the parametric
+    analogue of mathlib's per-symbol abbreviations, cf.
     `Fragments/English/Toy.lean`). -/
-abbrev monadicRel {Pred : Type*} (P : Pred) : (monadicLang Pred).Relations 1 := P
+abbrev monadicConst {Const Pred : Type*} (c : Const) :
+    (monadicLang Const Pred).Constants := c
 
-/-- The `monadicLang Pred` structure a predicate valuation induces. -/
-@[reducible] def monadicStructure {Pred Domain : Type*}
-    (V : Pred → Domain → Prop) : (monadicLang Pred).Structure Domain where
-  funMap := fun f _ => f.elim
+/-- A predicate as a relation symbol of the monadic signature (defeq). -/
+abbrev monadicRel {Const Pred : Type*} (P : Pred) :
+    (monadicLang Const Pred).Relations 1 := P
+
+/-- The `monadicLang Const Pred` structure a constant interpretation and a
+    predicate valuation induce. -/
+@[reducible] def monadicStructure {Const Pred Domain : Type*}
+    (κ : Const → Domain) (V : Pred → Domain → Prop) :
+    (monadicLang Const Pred).Structure Domain where
+  funMap := fun {n} f => match n, f with
+    | 0, c => fun _ => κ c
+    | _ + 1, f => f.elim
   RelMap := fun {n} r => match n, r with
     | 1, P => fun v => V P (v 0)
     | 0, r => r.elim
     | _ + 2, r => r.elim
 
-@[simp] theorem monadicStructure_relMap {Pred Domain : Type*}
-    (V : Pred → Domain → Prop) (P : Pred) (v : Fin 1 → Domain) :
-    (monadicStructure V).RelMap (monadicRel P) v ↔ V P (v 0) :=
+@[simp] theorem monadicStructure_relMap {Const Pred Domain : Type*}
+    (κ : Const → Domain) (V : Pred → Domain → Prop) (P : Pred)
+    (v : Fin 1 → Domain) :
+    (monadicStructure κ V).RelMap (monadicRel P) v ↔ V P (v 0) :=
   Iff.rfl
+
+@[simp] theorem monadicStructure_funMap {Const Pred Domain : Type*}
+    (κ : Const → Domain) (V : Pred → Domain → Prop) (c : Const)
+    (v : Fin 0 → Domain) :
+    (monadicStructure κ V).funMap (monadicConst (Pred := Pred) c) v = κ c :=
+  rfl
 
 /-- A QBSML model ([aloni-vanormondt-2023] Definition 4.2:
     `M = ⟨W, D, R, I⟩`), with the domain as a type parameter, accessibility
@@ -390,26 +417,44 @@ abbrev monadicRel {Pred : Type*} (P : Pred) : (monadicLang Pred).Relations 1 := 
     instances: a world-indexed family cannot be instance-based, so interfacing
     with instance-based mathlib API (`Formula.Realize`) threads
     `letI := M.interp w`. -/
-structure QBSMLModel (W : Type*) (Domain : Type*) (Pred : Type*) where
+structure QBSMLModel (W : Type*) (Domain : Type*) (Const : Type*)
+    (Pred : Type*) where
   /-- Accessibility relation (per-world set of accessible worlds). -/
   access : W → Finset W
   /-- World-indexed interpretation of the monadic signature. -/
-  interp : W → (monadicLang Pred).Structure Domain
+  interp : W → (monadicLang Const Pred).Structure Domain
 
 /-- The predicate denotation at a world, read off the model's structure
     family via `Structure.RelMap` — the world-relativized `I(w)(Pⁿ)` of
     [aloni-vanormondt-2023] Definition 4.2, specialised to monadic `P`
     (cf. `Semantics.Composition.Model.pred₁ext`). -/
-def QBSMLModel.pInterp {W Domain Pred : Type*} (M : QBSMLModel W Domain Pred)
-    (P : Pred) (w : W) (d : Domain) : Prop :=
+def QBSMLModel.pInterp {W Domain Const Pred : Type*}
+    (M : QBSMLModel W Domain Const Pred) (P : Pred) (w : W) (d : Domain) :
+    Prop :=
   (M.interp w).RelMap (monadicRel P) (fun _ => d)
 
-@[simp] theorem QBSMLModel.pInterp_monadicStructure {W Domain Pred : Type*}
-    (access : W → Finset W) (V : W → Pred → Domain → Prop) (P : Pred) (w : W)
-    (d : Domain) :
-    QBSMLModel.pInterp ⟨access, fun w => monadicStructure (V w)⟩ P w d ↔
+/-- The constant denotation at a world — the world-relative `I(w)(c)` of
+    [aloni-vanormondt-2023] Definitions 4.2 and 4.8, read off
+    `Structure.funMap` (cf. `Semantics.Composition.Model.const`). -/
+def QBSMLModel.cInterp {W Domain Const Pred : Type*}
+    (M : QBSMLModel W Domain Const Pred) (c : Const) (w : W) : Domain :=
+  (M.interp w).funMap (monadicConst c) default
+
+@[simp] theorem QBSMLModel.pInterp_monadicStructure
+    {W Domain Const Pred : Type*} (access : W → Finset W)
+    (κ : W → Const → Domain) (V : W → Pred → Domain → Prop) (P : Pred)
+    (w : W) (d : Domain) :
+    QBSMLModel.pInterp ⟨access, fun w => monadicStructure (κ w) (V w)⟩ P w d ↔
       V w P d :=
   Iff.rfl
+
+@[simp] theorem QBSMLModel.cInterp_monadicStructure
+    {W Domain Const Pred : Type*} (access : W → Finset W)
+    (κ : W → Const → Domain) (V : W → Pred → Domain → Prop) (c : Const)
+    (w : W) :
+    QBSMLModel.cInterp ⟨access, fun w => monadicStructure (κ w) (V w)⟩ c w =
+      κ w c :=
+  rfl
 
 /-! ### Bilateral evaluation -/
 
@@ -422,12 +467,16 @@ variable [Fintype Domain]
     Definition 4.9): `eval M true φ s` is support (`M, s ⊨ φ`),
     `eval M false φ s` anti-support (`M, s ⫤ φ`). Negation flips the
     polarity, making double-negation elimination definitional. -/
-def eval (M : QBSMLModel W Domain Pred) :
-    Bool → QBSMLFormula Var Pred → Finset (Index W Var Domain) → Prop
+def eval (M : QBSMLModel W Domain Const Pred) :
+    Bool → QBSMLFormula Var Const Pred → Finset (Index W Var Domain) → Prop
   | true,  .pred P x, s =>
       ∀ i ∈ s, ∃ d, i.assign x = some d ∧ M.pInterp P i.world d
   | false, .pred P x, s =>
       ∀ i ∈ s, ∃ d, i.assign x = some d ∧ ¬ M.pInterp P i.world d
+  | true,  .predc P c, s =>
+      ∀ i ∈ s, M.pInterp P i.world (M.cInterp c i.world)
+  | false, .predc P c, s =>
+      ∀ i ∈ s, ¬ M.pInterp P i.world (M.cInterp c i.world)
   | true,  .ne, s => s.Nonempty
   | false, .ne, s => s = ∅
   | true,  .neg ψ, s => eval M false ψ s
@@ -453,28 +502,28 @@ def eval (M : QBSMLModel W Domain Pred) :
   | false, .exi x ψ, s => eval M false ψ (State.extendUniversal s x)
 
 /-- Support: positive evaluation. -/
-abbrev support (M : QBSMLModel W Domain Pred) (φ : QBSMLFormula Var Pred)
+abbrev support (M : QBSMLModel W Domain Const Pred) (φ : QBSMLFormula Var Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   eval M true φ s
 
 /-- Anti-support: negative evaluation. -/
-abbrev antiSupport (M : QBSMLModel W Domain Pred) (φ : QBSMLFormula Var Pred)
+abbrev antiSupport (M : QBSMLModel W Domain Const Pred) (φ : QBSMLFormula Var Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   eval M false φ s
 
-@[simp] lemma support_neg (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain)) :
+@[simp] lemma support_neg (M : QBSMLModel W Domain Const Pred)
+    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain)) :
     support M (.neg φ) s ↔ antiSupport M φ s := Iff.rfl
 
-@[simp] lemma antiSupport_neg (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain)) :
+@[simp] lemma antiSupport_neg (M : QBSMLModel W Domain Const Pred)
+    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain)) :
     antiSupport M (.neg φ) s ↔ support M φ s := Iff.rfl
 
 /-- `support` and `antiSupport` form a paraconsistent bilateral logic
     (`Core.Logic.Bilateral.IsBilateral`) under `QBSMLFormula.neg`, like
     BSML's `isBilateral` at the point type `Index W Var Domain`. -/
-theorem isBilateral (M : QBSMLModel W Domain Pred) :
-    Core.Logic.Bilateral.IsBilateral (Form := QBSMLFormula Var Pred)
+theorem isBilateral (M : QBSMLModel W Domain Const Pred) :
+    Core.Logic.Bilateral.IsBilateral (Form := QBSMLFormula Var Const Pred)
       (support M) (antiSupport M) QBSMLFormula.neg :=
   Core.Logic.Bilateral.IsBilateral.of_iff (support_neg M) (antiSupport_neg M)
 
@@ -490,21 +539,21 @@ variable [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain]
     ([aloni-vanormondt-2023] Definition 4.10). Defined via
     `Core.Logic.Team.IsStateBased` applied to `State.worldProj s`, sharing
     BSML's frame-condition substrate. -/
-def QBSMLModel.IsStateBased (M : QBSMLModel W Domain Pred)
+def QBSMLModel.IsStateBased (M : QBSMLModel W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Core.Logic.Team.IsStateBased M.access (State.worldProj s)
 
 /-- `R` is indisputable on `(M, s)`: all worlds in `s↓` see the same
     accessible set ([aloni-vanormondt-2023] Definition 4.10). -/
-def QBSMLModel.IsIndisputable (M : QBSMLModel W Domain Pred)
+def QBSMLModel.IsIndisputable (M : QBSMLModel W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Core.Logic.Team.IsIndisputable M.access (State.worldProj s)
 
-instance [Fintype W] (M : QBSMLModel W Domain Pred)
+instance [Fintype W] (M : QBSMLModel W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Decidable (M.IsStateBased s) := by
   unfold QBSMLModel.IsStateBased; infer_instance
 
-instance [Fintype W] (M : QBSMLModel W Domain Pred)
+instance [Fintype W] (M : QBSMLModel W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Decidable (M.IsIndisputable s) := by
   unfold QBSMLModel.IsIndisputable; infer_instance
 

--- a/Linglib/Core/Logic/Modal/QBSML/Enrichment.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/Enrichment.lean
@@ -42,7 +42,7 @@ behaviour-under-negation pattern — the QBSML free-choice facts proved in
 `enrich` is total on `QBSMLFormula` for definitional convenience, but `[·]⁺`
 is defined only on the NE-free fragment in both papers, so the `.ne` case is
 a filler convention. The construction is structurally identical to BSML's
-`Core/Logic/Modal/BSML/Enrichment.lean` but operates on `QBSMLFormula Var Pred`
+`Core/Logic/Modal/BSML/Enrichment.lean` but operates on `QBSMLFormula Var Const Pred`
 (quantifiers, predicate atoms) rather than `BSMLFormula Atom`. The two are
 kept parallel rather than unified: a shared "team-semantic formula language
 with an `NE` constructor" abstraction awaits a third instance, per the family
@@ -51,14 +51,15 @@ roadmap in `Core/Logic/Team/Algebra.lean`.
 
 namespace Core.Logic.Modal.QBSML
 
-variable {Var Pred : Type*}
+variable {Var Const Pred : Type*}
 
 /-! ### The enrichment function -/
 
 /-- Pragmatic enrichment `[·]⁺` for QBSML formulas ([aloni-vanormondt-2023]
     Definition 4.13). Recursively conjoins `NE` to every clause. -/
-def QBSMLFormula.enrich : QBSMLFormula Var Pred → QBSMLFormula Var Pred
+def QBSMLFormula.enrich : QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
   | .pred P x   => .conj (.pred P x) .ne
+  | .predc P c  => .conj (.predc P c) .ne
   | .ne         => .ne  -- totality filler; enrichment is defined only on the NE-free fragment
   | .neg φ      => .conj (.neg φ.enrich) .ne
   | .conj φ ψ   => .conj (.conj φ.enrich ψ.enrich) .ne
@@ -76,8 +77,8 @@ variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
 /-- A QBSML state supporting an enriched formula must be non-empty. The NE
     conjunct guards every clause of `enrich φ`, forcing the witnessing state
     to satisfy `Nonempty`. -/
-theorem enriched_support_implies_nonempty (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
+theorem enriched_support_implies_nonempty (M : QBSMLModel W Domain Const Pred)
+    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
     (h : support M φ.enrich s) : s.Nonempty := by
   cases φ with
   | ne => exact h
@@ -90,8 +91,8 @@ theorem enriched_support_implies_nonempty (M : QBSMLModel W Domain Pred)
     `t₁ = s`. The QBSML analogue of `BSML/Enrichment`'s `antiSupport_strip_ne`;
     the workhorse of the free-choice derivations in
     `Studies/AloniVanOrmondt2023.lean`. -/
-theorem antiSupport_strip_ne (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
+theorem antiSupport_strip_ne (M : QBSMLModel W Domain Const Pred)
+    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
     (h : antiSupport M (.conj φ .ne) s) :
     antiSupport M φ s := by
   obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := h
@@ -102,15 +103,15 @@ theorem antiSupport_strip_ne (M : QBSMLModel W Domain Pred)
 
 /-- Anti-support of `φ` implies anti-support of `φ ∧ NE` via the trivial
     split `(s, ∅)`. The reverse direction of `antiSupport_strip_ne`. -/
-theorem antiSupport_conj_ne_of_antiSupport (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
+theorem antiSupport_conj_ne_of_antiSupport (M : QBSMLModel W Domain Const Pred)
+    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
     (h : antiSupport M φ s) :
     antiSupport M (.conj φ .ne) s :=
   ⟨s, ∅, Core.Logic.Team.splitsAs_self_empty s, h, rfl⟩
 
 /-- Anti-support of `φ ∧ NE` ↔ anti-support of `φ`. -/
-theorem antiSupport_conj_ne_iff (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain)) :
+theorem antiSupport_conj_ne_iff (M : QBSMLModel W Domain Const Pred)
+    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain)) :
     antiSupport M (.conj φ .ne) s ↔ antiSupport M φ s :=
   ⟨antiSupport_strip_ne M φ s, antiSupport_conj_ne_of_antiSupport M φ s⟩
 

--- a/Linglib/Core/Logic/Modal/QBSML/Properties.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/Properties.lean
@@ -23,10 +23,15 @@ empty-team support, hence flat support, via the same
   ([anttila-2021] Proposition 2.2.16, QBSML specialisation).
 * `soundFor_flat_neFree` — the NE-free fragment is sound for the flat cell
   of `Team/Definability.lean`.
-* `QBSMLModel.RealizeAt`, `QBSMLFormula.toFormula?`,
-  `support_iff_forall_realizeAt` — the quantifier- and modal-free case of
+* `QBSMLFormula.toFormula?`,
+  `support_iff_forall_realizeAt` — the modal-free case of
   [aloni-vanormondt-2023] Proposition 4.1: support of a translatable formula
   is mathlib `Formula.Realize` at every index.
+* `QBSMLFormula.toModal?`, `support_iff_forall_realize` — the **full**
+  Proposition 4.1: the NE-free fragment (modals included) translates into
+  `ModalFormula` over `Core/Logic/FirstOrder/Kripke.lean`, and support is
+  Kripke satisfaction at every index; the translation is total on exactly
+  the NE-free fragment (`exists_toModal?_of_isNEFree`).
 
 ## Implementation notes
 
@@ -472,15 +477,9 @@ bridge: their right-hand side is classical *modal* logic, which mathlib's
 
 open FirstOrder Language
 
-/-- Classical first-order satisfaction at a world — `M, w ⊨_v ψ`, mathlib's
-    `Formula.Realize` in the structure the model carries at `w`. The
-    right-hand side of [aloni-vanormondt-2023] Proposition 4.1. -/
-def QBSMLModel.RealizeAt (M : QBSMLModel W Domain Const Pred) (w : W)
-    (ψ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) : Prop :=
-  @Formula.Realize _ _ (M.interp w) _ ψ v
-
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_rel₁ (M : QBSMLModel W Domain Const Pred)
+@[simp] theorem _root_.FirstOrder.Language.KripkeStructure.realizeAt_rel₁
+    (M : QBSMLModel W Domain Const Pred)
     (P : Pred) (x : Var) (w : W) (v : Var → Domain) :
     M.RealizeAt w ((monadicRel P).formula₁ (Term.var x)) v ↔
       M.pInterp P w (v x) := by
@@ -493,7 +492,7 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
   exact Iff.rfl
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_rel₁_const
+@[simp] theorem _root_.FirstOrder.Language.KripkeStructure.realizeAt_rel₁_const
     (M : QBSMLModel W Domain Const Pred) (P : Pred) (c : Const) (w : W)
     (v : Var → Domain) :
     M.RealizeAt w
@@ -509,43 +508,6 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
     exact Term.realize_constants
   rw [Formula.realize_rel₁, hfun]
   exact Iff.rfl
-
-omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_not (M : QBSMLModel W Domain Const Pred)
-    (w : W) (ψ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) :
-    M.RealizeAt w ψ.not v ↔ ¬ M.RealizeAt w ψ v := by
-  letI := M.interp w
-  exact Formula.realize_not
-
-omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_inf (M : QBSMLModel W Domain Const Pred)
-    (w : W) (ψ₁ ψ₂ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) :
-    M.RealizeAt w (ψ₁ ⊓ ψ₂) v ↔ M.RealizeAt w ψ₁ v ∧ M.RealizeAt w ψ₂ v := by
-  letI := M.interp w
-  exact Formula.realize_inf
-
-omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_sup (M : QBSMLModel W Domain Const Pred)
-    (w : W) (ψ₁ ψ₂ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) :
-    M.RealizeAt w (ψ₁ ⊔ ψ₂) v ↔ M.RealizeAt w ψ₁ v ∨ M.RealizeAt w ψ₂ v := by
-  letI := M.interp w
-  exact Formula.realize_sup
-
-omit [DecidableEq W] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_all₁ (M : QBSMLModel W Domain Const Pred)
-    (w : W) (x : Var) (ψ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) :
-    M.RealizeAt w (Formula.all₁ x ψ) v ↔
-      ∀ d : Domain, M.RealizeAt w ψ (Function.update v x d) := by
-  letI := M.interp w
-  exact Formula.realize_all₁
-
-omit [DecidableEq W] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_ex₁ (M : QBSMLModel W Domain Const Pred)
-    (w : W) (x : Var) (ψ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) :
-    M.RealizeAt w (Formula.ex₁ x ψ) v ↔
-      ∃ d : Domain, M.RealizeAt w ψ (Function.update v x d) := by
-  letI := M.interp w
-  exact Formula.realize_ex₁
 
 /-- Translate the modal-free fragment of QBSML into mathlib first-order
     formulas over the monadic signature: quantifiers via the computable named
@@ -641,7 +603,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
         some ((monadicRel P).formula₁ (Term.var x)) from rfl,
       Option.some.injEq] at hψ
     subst hψ
-    rw [QBSMLModel.realizeAt_rel₁]
+    rw [KripkeStructure.realizeAt_rel₁]
     constructor
     · constructor
       · intro h
@@ -669,7 +631,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
         from rfl,
       Option.some.injEq] at hψ
     subst hψ
-    rw [QBSMLModel.realizeAt_rel₁_const]
+    rw [KripkeStructure.realizeAt_rel₁_const]
     constructor
     · constructor
       · intro h
@@ -695,9 +657,9 @@ private theorem support_and_antiSupport_singleton_realizeAt
       subst hψ
       obtain ⟨ihs, iha⟩ := ih hφ hv
       constructor
-      · rw [QBSMLModel.realizeAt_not]
+      · rw [KripkeStructure.realizeAt_not]
         exact iha
-      · rw [QBSMLModel.realizeAt_not, not_not]
+      · rw [KripkeStructure.realizeAt_not, not_not]
         exact ihs
   | conj φ₁ φ₂ ih₁ ih₂ =>
     intro ψ hψ i v hv
@@ -713,9 +675,9 @@ private theorem support_and_antiSupport_singleton_realizeAt
         obtain ⟨ih₁s, ih₁a⟩ := ih₁ hφ₁ hv
         obtain ⟨ih₂s, ih₂a⟩ := ih₂ hφ₂ hv
         constructor
-        · rw [QBSMLModel.realizeAt_inf]
+        · rw [KripkeStructure.realizeAt_inf]
           exact and_congr ih₁s ih₂s
-        · rw [QBSMLModel.realizeAt_inf, not_and_or]
+        · rw [KripkeStructure.realizeAt_inf, not_and_or]
           constructor
           · rintro ⟨t₁, t₂, hsplit, h₁, h₂⟩
             have hsub₁ : t₁ ⊆ ({i} : Finset (Index W Var Domain)) :=
@@ -750,7 +712,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
         obtain ⟨ih₁s, ih₁a⟩ := ih₁ hφ₁ hv
         obtain ⟨ih₂s, ih₂a⟩ := ih₂ hφ₂ hv
         constructor
-        · rw [QBSMLModel.realizeAt_sup]
+        · rw [KripkeStructure.realizeAt_sup]
           constructor
           · rintro ⟨t₁, t₂, hsplit, h₁, h₂⟩
             have hsub₁ : t₁ ⊆ ({i} : Finset (Index W Var Domain)) :=
@@ -771,7 +733,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
                 (support_and_antiSupport_empty_of_isNEFree
                   (isNEFree_of_toFormula? hφ₁) M).1,
                 ih₂s.mpr h⟩
-        · rw [QBSMLModel.realizeAt_sup, not_or]
+        · rw [KripkeStructure.realizeAt_sup, not_or]
           exact and_congr ih₁a ih₂a
   | exi x φ ih =>
     intro ψ hψ i v hv
@@ -783,7 +745,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
       subst hψ
       have hNE : φ.IsNEFree := isNEFree_of_toFormula? hφ
       constructor
-      · rw [QBSMLModel.realizeAt_ex₁]
+      · rw [KripkeStructure.realizeAt_ex₁]
         constructor
         · rintro ⟨h, hne, hsupp⟩
           have hsupp' := (support_iff_forall_singleton hNE M _).mp hsupp
@@ -801,7 +763,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
           subst hd'
           subst hupd
           exact ((ih hφ (update_refines hv x d')).1).mpr hd
-      · rw [QBSMLModel.realizeAt_ex₁, not_exists]
+      · rw [KripkeStructure.realizeAt_ex₁, not_exists]
         show antiSupport M φ (State.extendUniversal {i} x) ↔ _
         rw [antiSupport_iff_forall_singleton hNE]
         constructor
@@ -825,7 +787,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
       subst hψ
       have hNE : φ.IsNEFree := isNEFree_of_toFormula? hφ
       constructor
-      · rw [QBSMLModel.realizeAt_all₁]
+      · rw [KripkeStructure.realizeAt_all₁]
         show support M φ (State.extendUniversal {i} x) ↔ _
         rw [support_iff_forall_singleton hNE]
         constructor
@@ -839,7 +801,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
           subst hi'
           subst hupd
           exact ((ih hφ (update_refines hv x d)).1).mpr (h d)
-      · rw [QBSMLModel.realizeAt_all₁, not_forall]
+      · rw [KripkeStructure.realizeAt_all₁, not_forall]
         constructor
         · rintro ⟨h, hne, hanti⟩
           have hanti' := (antiSupport_iff_forall_singleton hNE M _).mp hanti
@@ -893,5 +855,435 @@ theorem support_iff_forall_realizeAt (M : QBSMLModel W Domain Const Pred)
   rw [support_iff_forall_singleton (isNEFree_of_toFormula? hψ)]
   exact forall₂_congr fun i hi =>
     support_singleton_iff_realizeAt M hψ (hv i hi)
+
+/-! ### Classicality II: the full modal bridge
+
+The complete [aloni-vanormondt-2023] Proposition 4.1: `QBSMLFormula.toModal?`
+translates the **whole NE-free fragment** — modals included — into
+`ModalFormula` over the monadic signature
+(`Core/Logic/FirstOrder/Kripke.lean`), and support is Kripke satisfaction at
+every index. The translation is total on exactly the NE-free fragment. -/
+
+/-- Translate QBSML into modal formulas over the monadic signature: atoms
+    embed as classical formulas, `◇` becomes the derived `ModalFormula.dia`,
+    quantifiers become named binders; only `NE` returns `none`. -/
+def QBSMLFormula.toModal? :
+    QBSMLFormula Var Const Pred →
+      Option (ModalFormula (monadicLang Const Pred) Var)
+  | .pred P x => some (.ofFormula ((monadicRel P).formula₁ (Term.var x)))
+  | .predc P c =>
+      some (.ofFormula ((monadicRel P).formula₁
+        (Constants.term (monadicConst c))))
+  | .ne => none
+  | .neg φ => φ.toModal?.map .not
+  | .conj φ ψ =>
+      φ.toModal?.bind fun α => ψ.toModal?.map (ModalFormula.inf α ·)
+  | .disj φ ψ =>
+      φ.toModal?.bind fun α => ψ.toModal?.map (ModalFormula.sup α ·)
+  | .poss φ => φ.toModal?.map ModalFormula.dia
+  | .exi x φ => φ.toModal?.map (ModalFormula.ex x ·)
+  | .univ x φ => φ.toModal?.map (ModalFormula.all x ·)
+
+omit [DecidableEq W] [Fintype Var] in
+/-- Modally translatable formulas are NE-free. -/
+theorem isNEFree_of_toModal? :
+    ∀ {φ : QBSMLFormula Var Const Pred}
+      {τ : ModalFormula (monadicLang Const Pred) Var},
+      φ.toModal? = some τ → φ.IsNEFree := by
+  intro φ
+  induction φ with
+  | pred P x => exact fun _ => .pred P x
+  | predc P c => exact fun _ => .predc P c
+  | neg φ ih =>
+    intro τ hτ
+    cases hφ : φ.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | some α => exact .neg (ih hφ)
+  | conj φ₁ φ₂ ih₁ ih₂ =>
+    intro τ hτ
+    cases hφ₁ : φ₁.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ₁] at hτ
+    | some α =>
+      cases hφ₂ : φ₂.toModal? with
+      | none => simp [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+      | some β => exact .conj (ih₁ hφ₁) (ih₂ hφ₂)
+  | disj φ₁ φ₂ ih₁ ih₂ =>
+    intro τ hτ
+    cases hφ₁ : φ₁.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ₁] at hτ
+    | some α =>
+      cases hφ₂ : φ₂.toModal? with
+      | none => simp [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+      | some β => exact .disj (ih₁ hφ₁) (ih₂ hφ₂)
+  | poss φ ih =>
+    intro τ hτ
+    cases hφ : φ.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | some α => exact .poss (ih hφ)
+  | exi x φ ih =>
+    intro τ hτ
+    cases hφ : φ.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | some α => exact .exi x (ih hφ)
+  | univ x φ ih =>
+    intro τ hτ
+    cases hφ : φ.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | some α => exact .univ x (ih hφ)
+  | ne => intro τ hτ; simp [QBSMLFormula.toModal?] at hτ
+
+omit [DecidableEq W] [Fintype Var] in
+/-- The modal translation is total on the NE-free fragment: together with
+    `isNEFree_of_toModal?`, the translatable and NE-free fragments
+    coincide. -/
+theorem exists_toModal?_of_isNEFree :
+    ∀ {φ : QBSMLFormula Var Const Pred}, φ.IsNEFree →
+      ∃ τ, φ.toModal? = some τ := by
+  intro φ h
+  induction h with
+  | pred P x => exact ⟨_, rfl⟩
+  | predc P c => exact ⟨_, rfl⟩
+  | neg _ ih =>
+    obtain ⟨τ, hτ⟩ := ih
+    exact ⟨.not τ, by simp [QBSMLFormula.toModal?, hτ]⟩
+  | conj _ _ ih₁ ih₂ =>
+    obtain ⟨τ₁, hτ₁⟩ := ih₁
+    obtain ⟨τ₂, hτ₂⟩ := ih₂
+    exact ⟨.inf τ₁ τ₂, by simp [QBSMLFormula.toModal?, hτ₁, hτ₂]⟩
+  | disj _ _ ih₁ ih₂ =>
+    obtain ⟨τ₁, hτ₁⟩ := ih₁
+    obtain ⟨τ₂, hτ₂⟩ := ih₂
+    exact ⟨.sup τ₁ τ₂, by simp [QBSMLFormula.toModal?, hτ₁, hτ₂]⟩
+  | poss _ ih =>
+    obtain ⟨τ, hτ⟩ := ih
+    exact ⟨τ.dia, by simp [QBSMLFormula.toModal?, hτ]⟩
+  | @exi x _ _ ih =>
+    obtain ⟨τ, hτ⟩ := ih
+    exact ⟨.ex x τ, by simp [QBSMLFormula.toModal?, hτ]⟩
+  | @univ x _ _ ih =>
+    obtain ⟨τ, hτ⟩ := ih
+    exact ⟨.all x τ, by simp [QBSMLFormula.toModal?, hτ]⟩
+
+/-- Joint singleton bridge for the **full** NE-free fragment: support of a
+    modally translatable formula at `{i}` is Kripke satisfaction at
+    `i.world`, and anti-support its negation. The modal case decomposes the
+    accessible lift pointwise via flatness: a nonempty witnessing subteam
+    collapses to a single accessible world. -/
+private theorem support_and_antiSupport_singleton_realize
+    (M : QBSMLModel W Domain Const Pred) :
+    ∀ {φ : QBSMLFormula Var Const Pred}
+      {τ : ModalFormula (monadicLang Const Pred) Var},
+      φ.toModal? = some τ →
+      ∀ {i : Index W Var Domain} {v : Var → Domain},
+        (∀ y, i.assign y = some (v y)) →
+        (support M φ {i} ↔ τ.Realize M i.world v) ∧
+        (antiSupport M φ {i} ↔ ¬ τ.Realize M i.world v) := by
+  intro φ
+  induction φ with
+  | pred P x =>
+    intro τ hτ i v hv
+    rw [show (QBSMLFormula.pred P x).toModal? =
+        some (.ofFormula ((monadicRel P).formula₁ (Term.var x))) from rfl,
+      Option.some.injEq] at hτ
+    subst hτ
+    rw [ModalFormula.realize_ofFormula, KripkeStructure.realizeAt_rel₁]
+    constructor
+    · constructor
+      · intro h
+        obtain ⟨d, hd, hP⟩ := h i (Finset.mem_singleton_self i)
+        rw [hv x, Option.some.injEq] at hd
+        rw [hd]
+        exact hP
+      · intro h j hj
+        rw [Finset.mem_singleton] at hj
+        subst hj
+        exact ⟨v x, hv x, h⟩
+    · constructor
+      · intro h hP
+        obtain ⟨d, hd, hnP⟩ := h i (Finset.mem_singleton_self i)
+        rw [hv x, Option.some.injEq] at hd
+        exact hnP (hd ▸ hP)
+      · intro h j hj
+        rw [Finset.mem_singleton] at hj
+        subst hj
+        exact ⟨v x, hv x, h⟩
+  | predc P c =>
+    intro τ hτ i v hv
+    rw [show (QBSMLFormula.predc P c).toModal? =
+        some (.ofFormula ((monadicRel P).formula₁
+          (Constants.term (monadicConst c)))) from rfl,
+      Option.some.injEq] at hτ
+    subst hτ
+    rw [ModalFormula.realize_ofFormula, KripkeStructure.realizeAt_rel₁_const]
+    constructor
+    · constructor
+      · intro h
+        exact h i (Finset.mem_singleton_self i)
+      · intro h j hj
+        rw [Finset.mem_singleton] at hj
+        subst hj
+        exact h
+    · constructor
+      · intro h
+        exact h i (Finset.mem_singleton_self i)
+      · intro h j hj
+        rw [Finset.mem_singleton] at hj
+        subst hj
+        exact h
+  | neg φ ih =>
+    intro τ hτ i v hv
+    cases hφ : φ.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | some α =>
+      simp only [QBSMLFormula.toModal?, hφ] at hτ
+      rw [Option.map_some, Option.some.injEq] at hτ
+      subst hτ
+      obtain ⟨ihs, iha⟩ := ih hφ hv
+      constructor
+      · rw [ModalFormula.realize_not]
+        exact iha
+      · rw [ModalFormula.realize_not, not_not]
+        exact ihs
+  | conj φ₁ φ₂ ih₁ ih₂ =>
+    intro τ hτ i v hv
+    cases hφ₁ : φ₁.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ₁] at hτ
+    | some α =>
+      cases hφ₂ : φ₂.toModal? with
+      | none => simp [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+      | some β =>
+        simp only [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+        rw [Option.bind_some, Option.map_some, Option.some.injEq] at hτ
+        subst hτ
+        obtain ⟨ih₁s, ih₁a⟩ := ih₁ hφ₁ hv
+        obtain ⟨ih₂s, ih₂a⟩ := ih₂ hφ₂ hv
+        constructor
+        · rw [ModalFormula.realize_inf]
+          exact and_congr ih₁s ih₂s
+        · rw [ModalFormula.realize_inf, not_and_or]
+          constructor
+          · rintro ⟨t₁, t₂, hsplit, h₁, h₂⟩
+            have hsub₁ : t₁ ⊆ ({i} : Finset (Index W Var Domain)) :=
+              hsplit ▸ Finset.subset_union_left
+            rcases Finset.subset_singleton_iff.mp hsub₁ with ht₁ | ht₁
+            · have ht₂ : t₂ = {i} := by
+                subst ht₁
+                have h' : (∅ ∪ t₂ : Finset (Index W Var Domain)) = {i} :=
+                  hsplit
+                simpa using h'
+              exact Or.inr (ih₂a.mp (ht₂ ▸ h₂))
+            · exact Or.inl (ih₁a.mp (ht₁ ▸ h₁))
+          · rintro (h | h)
+            · exact ⟨{i}, ∅, Core.Logic.Team.splitsAs_self_empty _,
+                ih₁a.mpr h,
+                (support_and_antiSupport_empty_of_isNEFree
+                  (isNEFree_of_toModal? hφ₂) M).2⟩
+            · exact ⟨∅, {i}, Core.Logic.Team.splitsAs_empty_self _,
+                (support_and_antiSupport_empty_of_isNEFree
+                  (isNEFree_of_toModal? hφ₁) M).2,
+                ih₂a.mpr h⟩
+  | disj φ₁ φ₂ ih₁ ih₂ =>
+    intro τ hτ i v hv
+    cases hφ₁ : φ₁.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ₁] at hτ
+    | some α =>
+      cases hφ₂ : φ₂.toModal? with
+      | none => simp [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+      | some β =>
+        simp only [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+        rw [Option.bind_some, Option.map_some, Option.some.injEq] at hτ
+        subst hτ
+        obtain ⟨ih₁s, ih₁a⟩ := ih₁ hφ₁ hv
+        obtain ⟨ih₂s, ih₂a⟩ := ih₂ hφ₂ hv
+        constructor
+        · rw [ModalFormula.realize_sup]
+          constructor
+          · rintro ⟨t₁, t₂, hsplit, h₁, h₂⟩
+            have hsub₁ : t₁ ⊆ ({i} : Finset (Index W Var Domain)) :=
+              hsplit ▸ Finset.subset_union_left
+            rcases Finset.subset_singleton_iff.mp hsub₁ with ht₁ | ht₁
+            · have ht₂ : t₂ = {i} := by
+                subst ht₁
+                have h' : (∅ ∪ t₂ : Finset (Index W Var Domain)) = {i} :=
+                  hsplit
+                simpa using h'
+              exact Or.inr (ih₂s.mp (ht₂ ▸ h₂))
+            · exact Or.inl (ih₁s.mp (ht₁ ▸ h₁))
+          · rintro (h | h)
+            · exact ⟨{i}, ∅, Core.Logic.Team.splitsAs_self_empty _,
+                ih₁s.mpr h,
+                (support_and_antiSupport_empty_of_isNEFree
+                  (isNEFree_of_toModal? hφ₂) M).1⟩
+            · exact ⟨∅, {i}, Core.Logic.Team.splitsAs_empty_self _,
+                (support_and_antiSupport_empty_of_isNEFree
+                  (isNEFree_of_toModal? hφ₁) M).1,
+                ih₂s.mpr h⟩
+        · rw [ModalFormula.realize_sup, not_or]
+          exact and_congr ih₁a ih₂a
+  | poss φ ih =>
+    intro τ hτ i v hv
+    cases hφ : φ.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | some α =>
+      simp only [QBSMLFormula.toModal?, hφ] at hτ
+      rw [Option.map_some, Option.some.injEq] at hτ
+      subst hτ
+      have hNE : φ.IsNEFree := isNEFree_of_toModal? hφ
+      constructor
+      · rw [ModalFormula.realize_dia]
+        constructor
+        · intro h
+          obtain ⟨X, hX, ⟨w', hw'⟩, hsupp⟩ :=
+            h i (Finset.mem_singleton_self i)
+          have hs := (support_iff_forall_singleton hNE M _).mp hsupp
+            (w', i.assign) (State.mem_modalLift.mpr ⟨hw', rfl⟩)
+          exact ⟨w', hX hw', ((ih hφ (i := (w', i.assign)) hv).1).mp hs⟩
+        · rintro ⟨w', hw', hreal⟩ j hj
+          rw [Finset.mem_singleton] at hj
+          subst hj
+          refine ⟨{w'}, Finset.singleton_subset_iff.mpr hw',
+            Finset.singleton_nonempty _, ?_⟩
+          rw [State.modalLift_singleton]
+          exact ((ih hφ (i := (w', j.assign)) hv).1).mpr hreal
+      · constructor
+        · intro h hex
+          rw [ModalFormula.realize_dia] at hex
+          obtain ⟨w', hw', hreal⟩ := hex
+          have hanti := (antiSupport_iff_forall_singleton hNE M _).mp
+            (h i (Finset.mem_singleton_self i)) (w', i.assign)
+            (State.mem_modalLift.mpr ⟨hw', rfl⟩)
+          exact ((ih hφ (i := (w', i.assign)) hv).2).mp hanti hreal
+        · intro h j hj
+          rw [Finset.mem_singleton] at hj
+          subst hj
+          refine (antiSupport_iff_forall_singleton hNE M _).mpr ?_
+          intro k hk
+          obtain ⟨hkw, hka⟩ := State.mem_modalLift.mp hk
+          refine ((ih hφ (i := k) fun y => by rw [hka]; exact hv y).2).mpr ?_
+          intro hreal
+          exact h ((ModalFormula.realize_dia M j.world v α).mpr
+            ⟨k.world, hkw, hreal⟩)
+  | exi x φ ih =>
+    intro τ hτ i v hv
+    cases hφ : φ.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | some α =>
+      simp only [QBSMLFormula.toModal?, hφ] at hτ
+      rw [Option.map_some, Option.some.injEq] at hτ
+      subst hτ
+      have hNE : φ.IsNEFree := isNEFree_of_toModal? hφ
+      constructor
+      · rw [ModalFormula.realize_ex]
+        constructor
+        · rintro ⟨h, hne, hsupp⟩
+          have hsupp' := (support_iff_forall_singleton hNE M _).mp hsupp
+          obtain ⟨d, hd⟩ := hne i (Finset.mem_singleton_self i)
+          exact ⟨d, ((ih hφ (update_refines hv x d)).1).mp
+            (hsupp' (i.update x d) (State.mem_extendFunctional.mpr
+              ⟨i, Finset.mem_singleton_self i, d, hd, rfl⟩))⟩
+        · rintro ⟨d, hd⟩
+          refine ⟨fun _ => {d}, fun j _ => Finset.singleton_nonempty d,
+            (support_iff_forall_singleton hNE M _).mpr ?_⟩
+          intro j hj
+          obtain ⟨i', hi', d', hd', hupd⟩ := State.mem_extendFunctional.mp hj
+          rw [Finset.mem_singleton] at hi' hd'
+          subst hi'
+          subst hd'
+          subst hupd
+          exact ((ih hφ (update_refines hv x d')).1).mpr hd
+      · rw [ModalFormula.realize_ex, not_exists]
+        show antiSupport M φ (State.extendUniversal {i} x) ↔ _
+        rw [antiSupport_iff_forall_singleton hNE]
+        constructor
+        · intro h d
+          exact ((ih hφ (update_refines hv x d)).2).mp
+            (h (i.update x d) (State.mem_extendUniversal.mpr
+              ⟨d, i, Finset.mem_singleton_self i, rfl⟩))
+        · intro h j hj
+          obtain ⟨d, i', hi', hupd⟩ := State.mem_extendUniversal.mp hj
+          rw [Finset.mem_singleton] at hi'
+          subst hi'
+          subst hupd
+          exact ((ih hφ (update_refines hv x d)).2).mpr (h d)
+  | univ x φ ih =>
+    intro τ hτ i v hv
+    cases hφ : φ.toModal? with
+    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | some α =>
+      simp only [QBSMLFormula.toModal?, hφ] at hτ
+      rw [Option.map_some, Option.some.injEq] at hτ
+      subst hτ
+      have hNE : φ.IsNEFree := isNEFree_of_toModal? hφ
+      constructor
+      · rw [ModalFormula.realize_all]
+        show support M φ (State.extendUniversal {i} x) ↔ _
+        rw [support_iff_forall_singleton hNE]
+        constructor
+        · intro h d
+          exact ((ih hφ (update_refines hv x d)).1).mp
+            (h (i.update x d) (State.mem_extendUniversal.mpr
+              ⟨d, i, Finset.mem_singleton_self i, rfl⟩))
+        · intro h j hj
+          obtain ⟨d, i', hi', hupd⟩ := State.mem_extendUniversal.mp hj
+          rw [Finset.mem_singleton] at hi'
+          subst hi'
+          subst hupd
+          exact ((ih hφ (update_refines hv x d)).1).mpr (h d)
+      · rw [ModalFormula.realize_all, not_forall]
+        constructor
+        · rintro ⟨h, hne, hanti⟩
+          have hanti' := (antiSupport_iff_forall_singleton hNE M _).mp hanti
+          obtain ⟨d, hd⟩ := hne i (Finset.mem_singleton_self i)
+          exact ⟨d, ((ih hφ (update_refines hv x d)).2).mp
+            (hanti' (i.update x d) (State.mem_extendFunctional.mpr
+              ⟨i, Finset.mem_singleton_self i, d, hd, rfl⟩))⟩
+        · rintro ⟨d, hd⟩
+          refine ⟨fun _ => {d}, fun j _ => Finset.singleton_nonempty d,
+            (antiSupport_iff_forall_singleton hNE M _).mpr ?_⟩
+          intro j hj
+          obtain ⟨i', hi', d', hd', hupd⟩ := State.mem_extendFunctional.mp hj
+          rw [Finset.mem_singleton] at hi' hd'
+          subst hi'
+          subst hd'
+          subst hupd
+          exact ((ih hφ (update_refines hv x d')).2).mpr hd
+  | ne => intro τ hτ; simp [QBSMLFormula.toModal?] at hτ
+
+/-- **[aloni-vanormondt-2023] Proposition 4.1, singleton case** (full
+    NE-free fragment): support of a modally translatable formula at a
+    singleton state is Kripke satisfaction at that index's world. -/
+theorem support_singleton_iff_realize (M : QBSMLModel W Domain Const Pred)
+    {φ : QBSMLFormula Var Const Pred}
+    {τ : ModalFormula (monadicLang Const Pred) Var}
+    (hτ : φ.toModal? = some τ) {i : Index W Var Domain}
+    {v : Var → Domain} (hv : ∀ y, i.assign y = some (v y)) :
+    support M φ {i} ↔ τ.Realize M i.world v :=
+  (support_and_antiSupport_singleton_realize M hτ hv).1
+
+/-- Anti-support of a modally translatable formula at a singleton state is
+    classical modal falsity. -/
+theorem antiSupport_singleton_iff_realize (M : QBSMLModel W Domain Const Pred)
+    {φ : QBSMLFormula Var Const Pred}
+    {τ : ModalFormula (monadicLang Const Pred) Var}
+    (hτ : φ.toModal? = some τ) {i : Index W Var Domain}
+    {v : Var → Domain} (hv : ∀ y, i.assign y = some (v y)) :
+    antiSupport M φ {i} ↔ ¬ τ.Realize M i.world v :=
+  (support_and_antiSupport_singleton_realize M hτ hv).2
+
+/-- **[aloni-vanormondt-2023] Proposition 4.1** (full NE-free fragment):
+    an NE-free formula is supported by a state iff its modal translation is
+    classically satisfied at every index — `M, s ⊨ φ(x̄)` iff
+    `M, w ⊨_g φ(x̄)` for all `⟨w, g⟩ ∈ s`, the right-hand side Kripke
+    satisfaction over mathlib structures. -/
+theorem support_iff_forall_realize (M : QBSMLModel W Domain Const Pred)
+    {φ : QBSMLFormula Var Const Pred}
+    {τ : ModalFormula (monadicLang Const Pred) Var}
+    (hτ : φ.toModal? = some τ) (s : Finset (Index W Var Domain))
+    (v : Index W Var Domain → Var → Domain)
+    (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
+    support M φ s ↔ ∀ i ∈ s, τ.Realize M i.world (v i) := by
+  rw [support_iff_forall_singleton (isNEFree_of_toModal? hτ)]
+  exact forall₂_congr fun i hi =>
+    support_singleton_iff_realize M hτ (hv i hi)
 
 end Core.Logic.Modal.QBSML

--- a/Linglib/Core/Logic/Modal/QBSML/Properties.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/Properties.lean
@@ -44,7 +44,7 @@ namespace Core.Logic.Modal.QBSML
 
 open Core.Logic.Team
 
-variable {W Var Domain Pred : Type*}
+variable {W Var Domain Const Pred : Type*}
 variable [DecidableEq W]
 variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
 
@@ -56,12 +56,14 @@ variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
     cases use `State.extendUniversal_empty` and
     `State.extendFunctional_empty`. -/
 private theorem support_and_antiSupport_empty_of_isNEFree
-    {φ : QBSMLFormula Var Pred} (hNE : φ.IsNEFree)
-    (M : QBSMLModel W Domain Pred) :
+    {φ : QBSMLFormula Var Const Pred} (hNE : φ.IsNEFree)
+    (M : QBSMLModel W Domain Const Pred) :
     support M φ (∅ : Finset (Index W Var Domain)) ∧
     antiSupport M φ (∅ : Finset (Index W Var Domain)) := by
   induction hNE with
   | pred P x =>
+    exact ⟨fun i hi => absurd hi (by simp), fun i hi => absurd hi (by simp)⟩
+  | predc P c =>
     exact ⟨fun i hi => absurd hi (by simp), fun i hi => absurd hi (by simp)⟩
   | neg _ ih =>
     -- support (¬ψ) = antiSupport ψ; antiSupport (¬ψ) = support ψ
@@ -100,8 +102,8 @@ private theorem support_and_antiSupport_empty_of_isNEFree
       exact ih.2
 
 /-- NE-free QBSML formulas are supported on the empty team. -/
-theorem support_empty_of_isNEFree {φ : QBSMLFormula Var Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Pred) :
+theorem support_empty_of_isNEFree {φ : QBSMLFormula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred) :
     support M φ ∅ :=
   (support_and_antiSupport_empty_of_isNEFree hNE M).1
 
@@ -115,8 +117,8 @@ theorem support_empty_of_isNEFree {φ : QBSMLFormula Var Pred}
     `t.extendFunctional x h_t` to `(t \ s).extendFunctional x h_t`, so all
     four properties have to live inside one induction. -/
 private theorem support_and_antiSupport_dc_uc_of_isNEFree
-    {φ : QBSMLFormula Var Pred} (hNE : φ.IsNEFree)
-    (M : QBSMLModel W Domain Pred) :
+    {φ : QBSMLFormula Var Const Pred} (hNE : φ.IsNEFree)
+    (M : QBSMLModel W Domain Const Pred) :
     -- (1) DC support
     (∀ s t : Finset (Index W Var Domain), t ⊆ s → support M φ s → support M φ t) ∧
     -- (2) UC support
@@ -130,6 +132,18 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
       antiSupport M φ s → antiSupport M φ t → antiSupport M φ (s ∪ t)) := by
   induction hNE with
   | pred P x =>
+    refine ⟨?_, ?_, ?_, ?_⟩
+    · intro s t hsub hsupp i hi; exact hsupp i (hsub hi)
+    · intro s t hs ht i hi; simp [Finset.mem_union] at hi
+      cases hi with
+      | inl h => exact hs i h
+      | inr h => exact ht i h
+    · intro s t hsub hsupp i hi; exact hsupp i (hsub hi)
+    · intro s t hs ht i hi; simp [Finset.mem_union] at hi
+      cases hi with
+      | inl h => exact hs i h
+      | inr h => exact ht i h
+  | predc P c =>
     refine ⟨?_, ?_, ?_, ?_⟩
     · intro s t hsub hsupp i hi; exact hsupp i (hsub hi)
     · intro s t hs ht i hi; simp [Finset.mem_union] at hi
@@ -322,8 +336,8 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
 
 /-- NE-free QBSML formulas are downward-closed ([anttila-2021]
     Proposition 2.2.8 part 1, extended to first-order). -/
-theorem isLowerSet_support_of_isNEFree {φ : QBSMLFormula Var Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Pred) :
+theorem isLowerSet_support_of_isNEFree {φ : QBSMLFormula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred) :
     IsLowerSet { t : Finset (Index W Var Domain) | support M φ t } :=
   fun _ _ hab hb =>
     (support_and_antiSupport_dc_uc_of_isNEFree hNE M).1 _ _ hab hb
@@ -334,8 +348,8 @@ theorem isLowerSet_support_of_isNEFree {φ : QBSMLFormula Var Pred}
     QBSML's `exi` UC case needs downward closure of the subformula as IH
     (see the module docstring), so the QBSML version narrows to NE-free.
     The downstream flat corollary consumes NE-free anyway. -/
-theorem supClosed_support_of_isNEFree {φ : QBSMLFormula Var Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Pred) :
+theorem supClosed_support_of_isNEFree {φ : QBSMLFormula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred) :
     SupClosed { t : Finset (Index W Var Domain) | support M φ t } :=
   fun _ ha _ hb =>
     (support_and_antiSupport_dc_uc_of_isNEFree hNE M).2.1 _ _ ha hb
@@ -346,8 +360,8 @@ theorem supClosed_support_of_isNEFree {φ : QBSMLFormula Var Pred}
     QBSML formulas are flat. Derived from [anttila-2021] Proposition 2.2.2
     (`Core.Logic.Team.isFlat_iff`) applied to the three closure properties
     above. -/
-theorem isFlat_support_of_isNEFree {φ : QBSMLFormula Var Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Pred) :
+theorem isFlat_support_of_isNEFree {φ : QBSMLFormula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred) :
     IsFlat { t : Finset (Index W Var Domain) | support M φ t } :=
   isFlat_of_isLowerSet_supClosed_empty
     (isLowerSet_support_of_isNEFree hNE M)
@@ -368,9 +382,9 @@ theorem isFlat_support_of_isNEFree {φ : QBSMLFormula Var Pred}
     docstring), which NE breaks. So QBSML has no unconditional all-formula
     cell — unlike BSML, whose NE-bearing formulas still land in the convex,
     union-closed cell. -/
-theorem soundFor_flat_neFree (M : QBSMLModel W Domain Pred) :
+theorem soundFor_flat_neFree (M : QBSMLModel W Domain Const Pred) :
     definableClassWhere (support M)
-      (fun φ : QBSMLFormula Var Pred => φ.IsNEFree) ⊆ flatProperties := by
+      (fun φ : QBSMLFormula Var Const Pred => φ.IsNEFree) ⊆ flatProperties := by
   unfold flatProperties
   exact definableClassWhere_subset (C := IsFlat)
     fun _φ hφ => isFlat_support_of_isNEFree hφ M
@@ -385,7 +399,7 @@ arranged in De Morgan pairs — so each is `Iff.rfl`. -/
 
 section Fact1
 
-variable (M : QBSMLModel W Domain Pred) (φ ψ : QBSMLFormula Var Pred)
+variable (M : QBSMLModel W Domain Const Pred) (φ ψ : QBSMLFormula Var Const Pred)
   (x : Var) (s : Finset (Index W Var Domain))
 
 /-- Double negation elimination ([aloni-vanormondt-2023] Fact 1). -/
@@ -428,16 +442,16 @@ end Fact1
 
 /-- Flat (NE-free) support is pointwise: a team supports `φ` iff each of its
     singletons does (`Core.Logic.Team.IsFlat` unfolded at the support set). -/
-theorem support_iff_forall_singleton {φ : QBSMLFormula Var Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Pred)
+theorem support_iff_forall_singleton {φ : QBSMLFormula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred)
     (s : Finset (Index W Var Domain)) :
     support M φ s ↔ ∀ i ∈ s, support M φ {i} :=
   isFlat_support_of_isNEFree hNE M s
 
 /-- Anti-support of an NE-free formula is likewise pointwise: flatness of the
     bilateral negation. -/
-theorem antiSupport_iff_forall_singleton {φ : QBSMLFormula Var Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Pred)
+theorem antiSupport_iff_forall_singleton {φ : QBSMLFormula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred)
     (s : Finset (Index W Var Domain)) :
     antiSupport M φ s ↔ ∀ i ∈ s, antiSupport M φ {i} :=
   support_iff_forall_singleton (.neg hNE) M s
@@ -447,7 +461,7 @@ theorem antiSupport_iff_forall_singleton {φ : QBSMLFormula Var Pred}
 [aloni-vanormondt-2023] Proposition 4.1 reduces the NE-free fragment to
 classical quantified modal logic. The modal-free part of that reduction is
 stated against mathlib first-order satisfaction: `QBSMLFormula.toFormula?`
-translates the fragment into `(monadicLang Pred).Formula Var` — quantifiers
+translates the fragment into `(monadicLang Const Pred).Formula Var` — quantifiers
 via the computable named binders `Formula.all₁` / `Formula.ex₁` of
 `Core/Logic/FirstOrder/Binders.lean` — support at a singleton state is
 `Formula.Realize` in the structure the model carries at that world
@@ -461,12 +475,12 @@ open FirstOrder Language
 /-- Classical first-order satisfaction at a world — `M, w ⊨_v ψ`, mathlib's
     `Formula.Realize` in the structure the model carries at `w`. The
     right-hand side of [aloni-vanormondt-2023] Proposition 4.1. -/
-def QBSMLModel.RealizeAt (M : QBSMLModel W Domain Pred) (w : W)
-    (ψ : (monadicLang Pred).Formula Var) (v : Var → Domain) : Prop :=
+def QBSMLModel.RealizeAt (M : QBSMLModel W Domain Const Pred) (w : W)
+    (ψ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) : Prop :=
   @Formula.Realize _ _ (M.interp w) _ ψ v
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_rel₁ (M : QBSMLModel W Domain Pred)
+@[simp] theorem QBSMLModel.realizeAt_rel₁ (M : QBSMLModel W Domain Const Pred)
     (P : Pred) (x : Var) (w : W) (v : Var → Domain) :
     M.RealizeAt w ((monadicRel P).formula₁ (Term.var x)) v ↔
       M.pInterp P w (v x) := by
@@ -479,37 +493,55 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
   exact Iff.rfl
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_not (M : QBSMLModel W Domain Pred)
-    (w : W) (ψ : (monadicLang Pred).Formula Var) (v : Var → Domain) :
+@[simp] theorem QBSMLModel.realizeAt_rel₁_const
+    (M : QBSMLModel W Domain Const Pred) (P : Pred) (c : Const) (w : W)
+    (v : Var → Domain) :
+    M.RealizeAt w
+      ((monadicRel P).formula₁ (Constants.term (monadicConst c))) v ↔
+      M.pInterp P w (M.cInterp c w) := by
+  letI := M.interp w
+  show ((monadicRel P).formula₁ (Constants.term (monadicConst c))).Realize v
+    ↔ _
+  have hfun : (![(Constants.term (monadicConst (Pred := Pred) c)).realize v] :
+      Fin 1 → Domain) = fun _ => M.cInterp c w := by
+    funext j
+    rw [Matrix.cons_val_fin_one]
+    exact Term.realize_constants
+  rw [Formula.realize_rel₁, hfun]
+  exact Iff.rfl
+
+omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
+@[simp] theorem QBSMLModel.realizeAt_not (M : QBSMLModel W Domain Const Pred)
+    (w : W) (ψ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) :
     M.RealizeAt w ψ.not v ↔ ¬ M.RealizeAt w ψ v := by
   letI := M.interp w
   exact Formula.realize_not
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_inf (M : QBSMLModel W Domain Pred)
-    (w : W) (ψ₁ ψ₂ : (monadicLang Pred).Formula Var) (v : Var → Domain) :
+@[simp] theorem QBSMLModel.realizeAt_inf (M : QBSMLModel W Domain Const Pred)
+    (w : W) (ψ₁ ψ₂ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) :
     M.RealizeAt w (ψ₁ ⊓ ψ₂) v ↔ M.RealizeAt w ψ₁ v ∧ M.RealizeAt w ψ₂ v := by
   letI := M.interp w
   exact Formula.realize_inf
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_sup (M : QBSMLModel W Domain Pred)
-    (w : W) (ψ₁ ψ₂ : (monadicLang Pred).Formula Var) (v : Var → Domain) :
+@[simp] theorem QBSMLModel.realizeAt_sup (M : QBSMLModel W Domain Const Pred)
+    (w : W) (ψ₁ ψ₂ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) :
     M.RealizeAt w (ψ₁ ⊔ ψ₂) v ↔ M.RealizeAt w ψ₁ v ∨ M.RealizeAt w ψ₂ v := by
   letI := M.interp w
   exact Formula.realize_sup
 
 omit [DecidableEq W] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_all₁ (M : QBSMLModel W Domain Pred)
-    (w : W) (x : Var) (ψ : (monadicLang Pred).Formula Var) (v : Var → Domain) :
+@[simp] theorem QBSMLModel.realizeAt_all₁ (M : QBSMLModel W Domain Const Pred)
+    (w : W) (x : Var) (ψ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) :
     M.RealizeAt w (Formula.all₁ x ψ) v ↔
       ∀ d : Domain, M.RealizeAt w ψ (Function.update v x d) := by
   letI := M.interp w
   exact Formula.realize_all₁
 
 omit [DecidableEq W] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem QBSMLModel.realizeAt_ex₁ (M : QBSMLModel W Domain Pred)
-    (w : W) (x : Var) (ψ : (monadicLang Pred).Formula Var) (v : Var → Domain) :
+@[simp] theorem QBSMLModel.realizeAt_ex₁ (M : QBSMLModel W Domain Const Pred)
+    (w : W) (x : Var) (ψ : (monadicLang Const Pred).Formula Var) (v : Var → Domain) :
     M.RealizeAt w (Formula.ex₁ x ψ) v ↔
       ∃ d : Domain, M.RealizeAt w ψ (Function.update v x d) := by
   letI := M.interp w
@@ -520,8 +552,9 @@ omit [DecidableEq W] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
     binders `Formula.all₁` / `Formula.ex₁` (`none` on `NE` and modal
     formulas). -/
 def QBSMLFormula.toFormula? :
-    QBSMLFormula Var Pred → Option ((monadicLang Pred).Formula Var)
+    QBSMLFormula Var Const Pred → Option ((monadicLang Const Pred).Formula Var)
   | .pred P x => some ((monadicRel P).formula₁ (Term.var x))
+  | .predc P c => some ((monadicRel P).formula₁ (Constants.term (monadicConst c)))
   | .neg φ => φ.toFormula?.map (·.not)
   | .conj φ ψ => φ.toFormula?.bind fun α => ψ.toFormula?.map (α ⊓ ·)
   | .disj φ ψ => φ.toFormula?.bind fun α => ψ.toFormula?.map (α ⊔ ·)
@@ -532,11 +565,12 @@ def QBSMLFormula.toFormula? :
 omit [DecidableEq W] [Fintype Var] in
 /-- Translatable formulas are NE-free. -/
 theorem isNEFree_of_toFormula? :
-    ∀ {φ : QBSMLFormula Var Pred} {ψ : (monadicLang Pred).Formula Var},
+    ∀ {φ : QBSMLFormula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var},
       φ.toFormula? = some ψ → φ.IsNEFree := by
   intro φ
   induction φ with
   | pred P x => exact fun _ => .pred P x
+  | predc P c => exact fun _ => .predc P c
   | neg φ ih =>
     intro ψ hψ
     cases hφ : φ.toFormula? with
@@ -592,8 +626,8 @@ private lemma update_refines {i : Index W Var Domain} {v : Var → Domain}
     pointwise via flatness and apply the IH at the updated index and
     valuation. -/
 private theorem support_and_antiSupport_singleton_realizeAt
-    (M : QBSMLModel W Domain Pred) :
-    ∀ {φ : QBSMLFormula Var Pred} {ψ : (monadicLang Pred).Formula Var},
+    (M : QBSMLModel W Domain Const Pred) :
+    ∀ {φ : QBSMLFormula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var},
       φ.toFormula? = some ψ →
       ∀ {i : Index W Var Domain} {v : Var → Domain},
         (∀ y, i.assign y = some (v y)) →
@@ -628,6 +662,29 @@ private theorem support_and_antiSupport_singleton_realizeAt
         rw [Finset.mem_singleton] at hj
         subst hj
         exact ⟨v x, hv x, h⟩
+  | predc P c =>
+    intro ψ hψ i v hv
+    rw [show (QBSMLFormula.predc P c).toFormula? =
+        some ((monadicRel P).formula₁ (Constants.term (monadicConst c)))
+        from rfl,
+      Option.some.injEq] at hψ
+    subst hψ
+    rw [QBSMLModel.realizeAt_rel₁_const]
+    constructor
+    · constructor
+      · intro h
+        exact h i (Finset.mem_singleton_self i)
+      · intro h j hj
+        rw [Finset.mem_singleton] at hj
+        subst hj
+        exact h
+    · constructor
+      · intro h
+        exact h i (Finset.mem_singleton_self i)
+      · intro h j hj
+        rw [Finset.mem_singleton] at hj
+        subst hj
+        exact h
   | neg φ ih =>
     intro ψ hψ i v hv
     cases hφ : φ.toFormula? with
@@ -807,8 +864,8 @@ private theorem support_and_antiSupport_singleton_realizeAt
     fragment): support of a translatable formula at a singleton state is
     classical first-order satisfaction at that index's world, for any total
     valuation the index's partial assignment refines. -/
-theorem support_singleton_iff_realizeAt (M : QBSMLModel W Domain Pred)
-    {φ : QBSMLFormula Var Pred} {ψ : (monadicLang Pred).Formula Var}
+theorem support_singleton_iff_realizeAt (M : QBSMLModel W Domain Const Pred)
+    {φ : QBSMLFormula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var}
     (hψ : φ.toFormula? = some ψ) {i : Index W Var Domain}
     {v : Var → Domain} (hv : ∀ y, i.assign y = some (v y)) :
     support M φ {i} ↔ M.RealizeAt i.world ψ v :=
@@ -816,8 +873,8 @@ theorem support_singleton_iff_realizeAt (M : QBSMLModel W Domain Pred)
 
 /-- Anti-support of a translatable formula at a singleton state is the
     classical falsity of its translation. -/
-theorem antiSupport_singleton_iff_realizeAt (M : QBSMLModel W Domain Pred)
-    {φ : QBSMLFormula Var Pred} {ψ : (monadicLang Pred).Formula Var}
+theorem antiSupport_singleton_iff_realizeAt (M : QBSMLModel W Domain Const Pred)
+    {φ : QBSMLFormula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var}
     (hψ : φ.toFormula? = some ψ) {i : Index W Var Domain}
     {v : Var → Domain} (hv : ∀ y, i.assign y = some (v y)) :
     antiSupport M φ {i} ↔ ¬ M.RealizeAt i.world ψ v :=
@@ -827,8 +884,8 @@ theorem antiSupport_singleton_iff_realizeAt (M : QBSMLModel W Domain Pred)
     translatable formula is supported by a state iff it is classically
     satisfied at every index — `M, s ⊨ φ(x̄)` iff `M, w ⊨_g φ(x̄)` for all
     `⟨w, g⟩ ∈ s`, with the right-hand side mathlib's `Formula.Realize`. -/
-theorem support_iff_forall_realizeAt (M : QBSMLModel W Domain Pred)
-    {φ : QBSMLFormula Var Pred} {ψ : (monadicLang Pred).Formula Var}
+theorem support_iff_forall_realizeAt (M : QBSMLModel W Domain Const Pred)
+    {φ : QBSMLFormula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var}
     (hψ : φ.toFormula? = some ψ) (s : Finset (Index W Var Domain))
     (v : Index W Var Domain → Var → Domain)
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :

--- a/Linglib/Core/Logic/Modal/QBSML/StandardTranslation.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/StandardTranslation.lean
@@ -1,0 +1,504 @@
+import Linglib.Core.Logic.Modal.QBSML.Properties
+
+/-!
+# The standard translation for monadic quantified modal logic
+
+[blackburn-derijke-venema-2001] [aloni-vanormondt-2023]
+
+The standard translation of modal logic into first-order logic
+([blackburn-derijke-venema-2001]), for the monadic signature: modal formulas
+over `monadicLang Const Pred` translate into plain mathlib first-order
+formulas over `stLang Const Pred` — accessibility as a binary relation,
+predicates world-relativized to binary relations, constants world-indexed to
+unary functions, and an individual-sort predicate — interpreted on the
+two-sorted-as-one carrier `W ⊕ M`. `realize_st?` is satisfaction
+preservation; composed with Proposition 4.1, the support relation of NE-free
+QBSML bottoms out in single-structure mathlib first-order satisfaction
+(`support_singleton_iff_st`).
+
+## Main declarations
+
+* `stLang` — the target signature; `KripkeStructure.stStructure` — the
+  `W ⊕ M` encoding of a Kripke structure as one mathlib structure.
+* `ModalFormula.st?` — the standard translation, with the current world as
+  the free variable `Sum.inr k` and box introducing the fresh world
+  variable `Sum.inr (k + 1)` (partial: embedded classical formulas
+  translate when atomic, which covers all `toModal?` images).
+* `realize_st?` — satisfaction preservation: Kripke satisfaction at `w` is
+  first-order realization over `stStructure` at any sorted valuation
+  pinning `Sum.inr k` to `w`.
+* `support_singleton_iff_st` — NE-free QBSML support is first-order
+  realization of the standard translation, via Proposition 4.1.
+
+## Implementation notes
+
+* The valuation in `realize_st?` is an arbitrary `val : Var ⊕ ℕ → W ⊕ M`
+  constrained only at individual variables and at the current world index —
+  quantifiers in the translation range over the full mixed carrier, with
+  off-sort values discharged by the relational guards, so no
+  `Sum.elim`-update commutation is needed in the induction.
+* Freshness of world variables is by increment: each `box` shifts the
+  current index from `k` to `k + 1`, and the constraint set of the theorem
+  pins only index `k`, so no freshness side conditions arise.
+* Compactness and Löwenheim–Skolem transfer along this translation
+  (sentence-level closure bookkeeping as in
+  `Semantics/Composition/Reduction.lean`) are the natural next step.
+-/
+
+universe u v
+
+namespace Core.Logic.Modal.QBSML
+
+open FirstOrder Language
+
+variable {W M Var Const Pred : Type*}
+
+/-! ### The target signature and the encoded structure -/
+
+/-- The standard-translation target signature: world-indexed constants as
+    unary functions, an individual-sort predicate (unary), and
+    world-relativized monadic predicates plus accessibility (binary). -/
+def stLang (Const : Type u) (Pred : Type v) : FirstOrder.Language where
+  Functions := fun n => match n with
+    | 1 => Const
+    | _ => PEmpty
+  Relations := fun n => match n with
+    | 1 => PUnit
+    | 2 => Pred ⊕ PUnit
+    | _ => PEmpty
+
+/-- A constant as a unary function symbol of the target signature. -/
+abbrev stConst {Const Pred : Type*} (c : Const) :
+    (stLang Const Pred).Functions 1 := c
+
+/-- The individual-sort predicate. -/
+abbrev stIndiv {Const Pred : Type*} : (stLang Const Pred).Relations 1 :=
+  PUnit.unit
+
+/-- A predicate as a world-relativized binary relation symbol. -/
+abbrev stRel {Const Pred : Type*} (P : Pred) :
+    (stLang Const Pred).Relations 2 := Sum.inl P
+
+/-- The accessibility relation symbol. -/
+abbrev stAcc {Const Pred : Type*} : (stLang Const Pred).Relations 2 :=
+  Sum.inr PUnit.unit
+
+/-- The `W ⊕ M` encoding of a Kripke structure over the monadic signature
+    as a single mathlib structure: worlds and individuals share the carrier,
+    sorted by `stIndiv`; relational guards make all off-sort atoms false. -/
+@[reducible] def _root_.FirstOrder.Language.KripkeStructure.stStructure
+    (K : KripkeStructure (monadicLang Const Pred) W M) :
+    (stLang Const Pred).Structure (W ⊕ M) where
+  funMap := fun {n} f => match n, f with
+    | 1, c => fun z => match z 0 with
+      | Sum.inl w => Sum.inr (K.cInterp c w)
+      | Sum.inr d => Sum.inr d
+    | 0, f => f.elim
+    | _ + 2, f => f.elim
+  RelMap := fun {n} r => match n, r with
+    | 1, _ => fun z => ∃ d : M, z 0 = Sum.inr d
+    | 2, Sum.inl P => fun z =>
+        ∃ w d, z 0 = Sum.inl w ∧ z 1 = Sum.inr d ∧ K.pInterp P w d
+    | 2, Sum.inr _ => fun z =>
+        ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁
+    | 0, r => r.elim
+    | _ + 3, r => r.elim
+
+theorem stStructure_relMap_rel (K : KripkeStructure (monadicLang Const Pred) W M)
+    (P : Pred) (z : Fin 2 → W ⊕ M) :
+    (K.stStructure).RelMap (stRel P) z ↔
+      ∃ w d, z 0 = Sum.inl w ∧ z 1 = Sum.inr d ∧ K.pInterp P w d :=
+  Iff.rfl
+
+theorem stStructure_relMap_acc (K : KripkeStructure (monadicLang Const Pred) W M)
+    (z : Fin 2 → W ⊕ M) :
+    (K.stStructure).RelMap (stAcc (Const := Const)) z ↔
+      ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁ :=
+  Iff.rfl
+
+theorem stStructure_relMap_indiv (K : KripkeStructure (monadicLang Const Pred) W M)
+    (z : Fin 1 → W ⊕ M) :
+    (K.stStructure).RelMap (stIndiv (Const := Const)) z ↔
+      ∃ d : M, z 0 = Sum.inr d :=
+  Iff.rfl
+
+theorem stStructure_funMap_inl (K : KripkeStructure (monadicLang Const Pred) W M)
+    (c : Const) (w : W) (z : Fin 1 → W ⊕ M) (hz : z 0 = Sum.inl w) :
+    (K.stStructure).funMap (stConst (Pred := Pred) c) z =
+      Sum.inr (K.cInterp c w) := by
+  show (match z 0 with
+    | Sum.inl w' => Sum.inr (K.cInterp c w')
+    | Sum.inr d => Sum.inr d) = _
+  rw [hz]
+
+/-! ### The translation -/
+
+variable [DecidableEq Var]
+
+/-- Translate a monadic term: variables stay, constants become their unary
+    function applied to the current world variable. -/
+def stTerm (k : ℕ) :
+    (monadicLang Const Pred).Term (Var ⊕ Fin 0) →
+      (stLang Const Pred).Term (Var ⊕ ℕ)
+  | .var (Sum.inl x) => Term.var (Sum.inl x)
+  | .var (Sum.inr i) => i.elim0
+  | @Term.func _ _ l f _ => match l, f with
+    | 0, c => Term.func (stConst c) ![Term.var (Sum.inr k)]
+    | _ + 1, f => f.elim
+
+/-- Translate an embedded classical formula when it is a monadic atom
+    (`none` otherwise — which never arises from `QBSMLFormula.toModal?`
+    images, whose embedded formulas are exactly the atoms). -/
+def stAtom? (k : ℕ) :
+    (monadicLang Const Pred).Formula Var →
+      Option ((stLang Const Pred).Formula (Var ⊕ ℕ))
+  | @BoundedFormula.rel _ _ _ l R ts => match l, R, ts with
+    | 1, P, ts =>
+        some ((stRel P).formula₂ (Term.var (Sum.inr k)) (stTerm k (ts 0)))
+    | 0, r, _ => r.elim
+    | _ + 2, r, _ => r.elim
+  | _ => none
+
+/-- The standard translation `ST_k` ([blackburn-derijke-venema-2001]): the
+    current world is the free variable `Sum.inr k`; `box` relativizes a
+    fresh world variable `Sum.inr (k + 1)` along accessibility; quantifiers
+    relativize to the individual sort. -/
+def _root_.FirstOrder.Language.ModalFormula.st? (k : ℕ) :
+    ModalFormula (monadicLang Const Pred) Var →
+      Option ((stLang Const Pred).Formula (Var ⊕ ℕ))
+  | .ofFormula χ => stAtom? k χ
+  | .not φ => (φ.st? k).map (·.not)
+  | .inf φ ψ => (φ.st? k).bind fun a => (ψ.st? k).map (a ⊓ ·)
+  | .sup φ ψ => (φ.st? k).bind fun a => (ψ.st? k).map (a ⊔ ·)
+  | .box φ => (φ.st? (k + 1)).map fun a =>
+      Formula.all₁ (Sum.inr (k + 1))
+        ((stAcc.formula₂ (Term.var (Sum.inr k))
+          (Term.var (Sum.inr (k + 1)))).imp a)
+  | .all x φ => (φ.st? k).map fun a =>
+      Formula.all₁ (Sum.inl x)
+        ((stIndiv.formula₁ (Term.var (Sum.inl x))).imp a)
+  | .ex x φ => (φ.st? k).map fun a =>
+      Formula.ex₁ (Sum.inl x)
+        (stIndiv.formula₁ (Term.var (Sum.inl x)) ⊓ a)
+
+/-! ### Satisfaction preservation -/
+
+omit [DecidableEq Var] in
+/-- Satisfaction preservation for embedded atoms. -/
+private theorem realize_stAtom? (K : KripkeStructure (monadicLang Const Pred) W M)
+    {k : ℕ} {χ : (monadicLang Const Pred).Formula Var}
+    {ψ : (stLang Const Pred).Formula (Var ⊕ ℕ)}
+    (hψ : stAtom? k χ = some ψ) {val : Var ⊕ ℕ → W ⊕ M} {w : W}
+    {v : Var → M} (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
+    (hw : val (Sum.inr k) = Sum.inl w) :
+    K.RealizeAt w χ v ↔ (letI := K.stStructure; ψ.Realize val) := by
+  letI := K.stStructure
+  cases χ with
+  | falsum => simp [stAtom?] at hψ
+  | equal t₁ t₂ => simp [stAtom?] at hψ
+  | imp χ₁ χ₂ => simp [stAtom?] at hψ
+  | all χ' => simp [stAtom?] at hψ
+  | @rel _ l R ts =>
+    match l, R with
+    | 0, r => exact r.elim
+    | (n + 2), r => exact r.elim
+    | 1, (P : Pred) =>
+      rw [show stAtom? k (.rel (monadicRel P) ts) =
+          some ((stRel P).formula₂ (Term.var (Sum.inr k)) (stTerm k (ts 0)))
+          from rfl, Option.some.injEq] at hψ
+      subst hψ
+      cases hts : ts 0 with
+      | var s =>
+        cases s with
+        | inl x =>
+          have hLHS : K.RealizeAt w (.rel (monadicRel P) ts) v ↔
+              K.pInterp P w (v x) := by
+            letI := K.interp w
+            show (K.interp w).RelMap (monadicRel P)
+                (fun i => (ts i).realize (Sum.elim v (default : Fin 0 → M)))
+              ↔ _
+            have hfun : (fun i : Fin 1 => (ts i).realize
+                (Sum.elim v (default : Fin 0 → M))) = fun _ => v x := by
+              funext i
+              rw [Subsingleton.elim i 0, hts]
+              rfl
+            rw [hfun]
+            exact Iff.rfl
+          rw [hLHS, Formula.realize_rel₂,
+            show (stTerm k (.var (Sum.inl x)) :
+                (stLang Const Pred).Term (Var ⊕ ℕ)) =
+              Term.var (Sum.inl x) from rfl,
+            stStructure_relMap_rel]
+          simp only [Term.realize_var, hw, hind]
+          constructor
+          · intro h
+            exact ⟨w, v x, rfl, rfl, h⟩
+          · rintro ⟨w', d, hw', hd, h⟩
+            obtain rfl : w = w' := Sum.inl.inj hw'
+            obtain rfl : v x = d := Sum.inr.inj hd
+            exact h
+        | inr i => exact i.elim0
+      | @func l' f args =>
+        cases l' with
+        | succ m => exact f.elim
+        | zero =>
+          have hLHS : K.RealizeAt w (.rel (monadicRel P) ts) v ↔
+              K.pInterp P w (K.cInterp f w) := by
+            letI := K.interp w
+            show (K.interp w).RelMap (monadicRel P)
+                (fun i => (ts i).realize (Sum.elim v (default : Fin 0 → M)))
+              ↔ _
+            have hfun : (fun i : Fin 1 => (ts i).realize
+                (Sum.elim v (default : Fin 0 → M))) =
+                fun _ => K.cInterp f w := by
+              funext i
+              rw [Subsingleton.elim i 0, hts]
+              show (K.interp w).funMap f
+                  (fun j => (args j).realize (Sum.elim v default)) = _
+              have hargs : (fun j : Fin 0 => (args j).realize
+                  (Sum.elim v (default : Fin 0 → M))) = default :=
+                funext fun j => j.elim0
+              rw [hargs]
+              rfl
+            rw [hfun]
+            exact Iff.rfl
+          rw [hLHS, Formula.realize_rel₂,
+            show (stTerm k (.func f args) :
+                (stLang Const Pred).Term (Var ⊕ ℕ)) =
+              Term.func (stConst f) ![Term.var (Sum.inr k)] from rfl,
+            stStructure_relMap_rel]
+          have hcv : (Term.func (stConst f)
+              ![Term.var (Sum.inr k)] :
+              (stLang Const Pred).Term (Var ⊕ ℕ)).realize val
+              = Sum.inr (K.cInterp f w) :=
+            stStructure_funMap_inl K f w _ hw
+          constructor
+          · intro h
+            exact ⟨w, K.cInterp f w, hw, hcv, h⟩
+          · rintro ⟨w', d, hw', hd, h⟩
+            have hww : val (Sum.inr k) = Sum.inl w' := hw'
+            obtain rfl : w = w' := Sum.inl.inj (hw.symm.trans hww)
+            have hdd : Sum.inr (K.cInterp f w) = Sum.inr d :=
+              hcv.symm.trans hd
+            obtain rfl : K.cInterp f w = d := Sum.inr.inj hdd
+            exact h
+
+/-- **Satisfaction preservation for the standard translation**: Kripke
+    satisfaction at `w` is first-order realization over `stStructure`, for
+    any valuation that is individual-sorted on `Var` and pins the current
+    world variable `Sum.inr k` to `w`. Off-sort quantifier instances are
+    discharged by the relational guards, and `box`'s fresh world variable
+    `k + 1` leaves the pinned index untouched. -/
+theorem realize_st? (K : KripkeStructure (monadicLang Const Pred) W M) :
+    ∀ {φ : ModalFormula (monadicLang Const Pred) Var} {k : ℕ}
+      {ψ : (stLang Const Pred).Formula (Var ⊕ ℕ)},
+      φ.st? k = some ψ →
+      ∀ {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M},
+        (∀ x, val (Sum.inl x) = Sum.inr (v x)) →
+        val (Sum.inr k) = Sum.inl w →
+        (φ.Realize K w v ↔ (letI := K.stStructure; ψ.Realize val)) := by
+  intro φ
+  induction φ with
+  | ofFormula χ =>
+    intro k ψ hψ val w v hind hw
+    exact realize_stAtom? K hψ hind hw
+  | not φ ih =>
+    intro k ψ hψ val w v hind hw
+    rw [show (ModalFormula.not φ).st? k = (φ.st? k).map (·.not) from rfl] at hψ
+    cases hφ : φ.st? k with
+    | none => rw [hφ] at hψ; simp at hψ
+    | some a =>
+      rw [hφ, Option.map_some, Option.some.injEq] at hψ
+      subst hψ
+      letI := K.stStructure
+      rw [ModalFormula.realize_not, Formula.realize_not]
+      exact not_congr (ih hφ hind hw)
+  | inf φ₁ φ₂ ih₁ ih₂ =>
+    intro k ψ hψ val w v hind hw
+    rw [show (ModalFormula.inf φ₁ φ₂).st? k =
+        (φ₁.st? k).bind (fun a => (φ₂.st? k).map (a ⊓ ·)) from rfl] at hψ
+    cases hφ₁ : φ₁.st? k with
+    | none => rw [hφ₁] at hψ; simp at hψ
+    | some a =>
+      cases hφ₂ : φ₂.st? k with
+      | none =>
+        rw [hφ₁, Option.bind_some, hφ₂] at hψ
+        simp at hψ
+      | some b =>
+        rw [hφ₁, Option.bind_some, hφ₂, Option.map_some,
+          Option.some.injEq] at hψ
+        subst hψ
+        letI := K.stStructure
+        rw [ModalFormula.realize_inf, Formula.realize_inf]
+        exact and_congr (ih₁ hφ₁ hind hw) (ih₂ hφ₂ hind hw)
+  | sup φ₁ φ₂ ih₁ ih₂ =>
+    intro k ψ hψ val w v hind hw
+    rw [show (ModalFormula.sup φ₁ φ₂).st? k =
+        (φ₁.st? k).bind (fun a => (φ₂.st? k).map (a ⊔ ·)) from rfl] at hψ
+    cases hφ₁ : φ₁.st? k with
+    | none => rw [hφ₁] at hψ; simp at hψ
+    | some a =>
+      cases hφ₂ : φ₂.st? k with
+      | none =>
+        rw [hφ₁, Option.bind_some, hφ₂] at hψ
+        simp at hψ
+      | some b =>
+        rw [hφ₁, Option.bind_some, hφ₂, Option.map_some,
+          Option.some.injEq] at hψ
+        subst hψ
+        letI := K.stStructure
+        rw [ModalFormula.realize_sup, Formula.realize_sup]
+        exact or_congr (ih₁ hφ₁ hind hw) (ih₂ hφ₂ hind hw)
+  | box φ ih =>
+    intro k ψ hψ val w v hind hw
+    rw [show (ModalFormula.box φ).st? k = (φ.st? (k + 1)).map (fun a =>
+        Formula.all₁ (Sum.inr (k + 1))
+          ((stAcc.formula₂ (Term.var (Sum.inr k))
+            (Term.var (Sum.inr (k + 1)))).imp a)) from rfl] at hψ
+    cases hφ : φ.st? (k + 1) with
+    | none => rw [hφ] at hψ; simp at hψ
+    | some a =>
+      rw [hφ, Option.map_some, Option.some.injEq] at hψ
+      subst hψ
+      letI := K.stStructure
+      rw [ModalFormula.realize_box, Formula.realize_all₁]
+      constructor
+      · intro h z
+        rw [Formula.realize_imp, Formula.realize_rel₂]
+        simp only [Term.realize_var, Function.update_of_ne
+          (by simp : (Sum.inr k : Var ⊕ ℕ) ≠ Sum.inr (k + 1)),
+          Function.update_self, hw]
+        rintro ⟨w₁, w₂, hw₁, hw₂, hmem⟩
+        obtain rfl : w = w₁ := Sum.inl.inj hw₁
+        subst hw₂
+        refine (ih hφ ?_ ?_).mp (h w₂ hmem)
+        · intro x
+          rw [Function.update_of_ne (by simp), hind]
+        · rw [Function.update_self]
+      · intro h w' hw'
+        have hz := h (Sum.inl w')
+        rw [Formula.realize_imp, Formula.realize_rel₂] at hz
+        simp only [Term.realize_var, Function.update_of_ne
+          (by simp : (Sum.inr k : Var ⊕ ℕ) ≠ Sum.inr (k + 1)),
+          Function.update_self, hw] at hz
+        refine (ih hφ ?_ ?_).mpr (hz ⟨w, w', rfl, rfl, hw'⟩)
+        · intro x
+          rw [Function.update_of_ne (by simp), hind]
+        · rw [Function.update_self]
+  | all x φ ih =>
+    intro k ψ hψ val w v hind hw
+    rw [show (ModalFormula.all x φ).st? k = (φ.st? k).map (fun a =>
+        Formula.all₁ (Sum.inl x)
+          ((stIndiv.formula₁ (Term.var (Sum.inl x))).imp a)) from rfl] at hψ
+    cases hφ : φ.st? k with
+    | none => rw [hφ] at hψ; simp at hψ
+    | some a =>
+      rw [hφ, Option.map_some, Option.some.injEq] at hψ
+      subst hψ
+      letI := K.stStructure
+      rw [ModalFormula.realize_all, Formula.realize_all₁]
+      constructor
+      · intro h z
+        rw [Formula.realize_imp, Formula.realize_rel₁]
+        intro hsort
+        obtain ⟨d, hd⟩ : ∃ d : M,
+            Function.update val (Sum.inl x) z (Sum.inl x) = Sum.inr d := by
+          simpa using hsort
+        rw [Function.update_self] at hd
+        subst hd
+        refine (ih hφ ?_ ?_).mp (h d)
+        · intro y
+          by_cases hy : y = x
+          · subst hy
+            rw [Function.update_self, Function.update_self]
+          · rw [Function.update_of_ne (by simpa using hy),
+              Function.update_of_ne hy, hind]
+        · rw [Function.update_of_ne (by simp)]
+          exact hw
+      · intro h d
+        have hz := h (Sum.inr d)
+        rw [Formula.realize_imp, Formula.realize_rel₁] at hz
+        refine (ih hφ ?_ ?_).mpr (hz ?_)
+        · intro y
+          by_cases hy : y = x
+          · subst hy
+            rw [Function.update_self, Function.update_self]
+          · rw [Function.update_of_ne (by simpa using hy),
+              Function.update_of_ne hy, hind]
+        · rw [Function.update_of_ne (by simp)]
+          exact hw
+        · show ∃ d' : M, _ = Sum.inr d'
+          refine ⟨d, ?_⟩
+          show Function.update val (Sum.inl x) (Sum.inr d) (Sum.inl x) = _
+          rw [Function.update_self]
+  | ex x φ ih =>
+    intro k ψ hψ val w v hind hw
+    rw [show (ModalFormula.ex x φ).st? k = (φ.st? k).map (fun a =>
+        Formula.ex₁ (Sum.inl x)
+          (stIndiv.formula₁ (Term.var (Sum.inl x)) ⊓ a)) from rfl] at hψ
+    cases hφ : φ.st? k with
+    | none => rw [hφ] at hψ; simp at hψ
+    | some a =>
+      rw [hφ, Option.map_some, Option.some.injEq] at hψ
+      subst hψ
+      letI := K.stStructure
+      rw [ModalFormula.realize_ex, Formula.realize_ex₁]
+      constructor
+      · rintro ⟨d, hd⟩
+        refine ⟨Sum.inr d, ?_⟩
+        rw [Formula.realize_inf, Formula.realize_rel₁]
+        refine ⟨⟨d, ?_⟩, ?_⟩
+        · show Function.update val (Sum.inl x) (Sum.inr d) (Sum.inl x) = _
+          rw [Function.update_self]
+        · refine (ih hφ ?_ ?_).mp hd
+          · intro y
+            by_cases hy : y = x
+            · subst hy
+              rw [Function.update_self, Function.update_self]
+            · rw [Function.update_of_ne (by simpa using hy),
+                Function.update_of_ne hy, hind]
+          · rw [Function.update_of_ne (by simp)]
+            exact hw
+      · rintro ⟨z, hz⟩
+        rw [Formula.realize_inf, Formula.realize_rel₁] at hz
+        obtain ⟨hsort, hreal⟩ := hz
+        obtain ⟨d, hd⟩ : ∃ d : M,
+            Function.update val (Sum.inl x) z (Sum.inl x) = Sum.inr d := by
+          simpa using hsort
+        rw [Function.update_self] at hd
+        subst hd
+        refine ⟨d, (ih hφ ?_ ?_).mpr hreal⟩
+        · intro y
+          by_cases hy : y = x
+          · subst hy
+            rw [Function.update_self, Function.update_self]
+          · rw [Function.update_of_ne (by simpa using hy),
+              Function.update_of_ne hy, hind]
+        · rw [Function.update_of_ne (by simp)]
+          exact hw
+
+/-! ### Proposition 4.1, composed: QBSML support is first-order realization -/
+
+variable {Domain : Type*}
+variable [DecidableEq W] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
+
+/-- **NE-free QBSML support is single-structure first-order satisfaction**:
+    [aloni-vanormondt-2023] Proposition 4.1 composed with the standard
+    translation. Support at a singleton state is mathlib `Formula.Realize`
+    of the standard translation over `stStructure` — the link along which
+    classical model theory (compactness, Löwenheim–Skolem) transfers to the
+    NE-free fragment. -/
+theorem support_singleton_iff_st (M : QBSMLModel W Domain Const Pred)
+    {φ : QBSMLFormula Var Const Pred}
+    {τ : ModalFormula (monadicLang Const Pred) Var} {k : ℕ}
+    {ψ : (stLang Const Pred).Formula (Var ⊕ ℕ)}
+    (hτ : φ.toModal? = some τ) (hψ : τ.st? k = some ψ)
+    {i : Index W Var Domain} {v : Var → Domain} (u : ℕ → W)
+    (hv : ∀ y, i.assign y = some (v y)) (hu : u k = i.world) :
+    support M φ {i} ↔
+      (letI := M.stStructure
+       ψ.Realize (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ u))) :=
+  (support_singleton_iff_realize M hτ hv).trans
+    (realize_st? M hψ (fun _ => rfl) (by rw [Sum.elim_inr, Function.comp_apply, hu]))
+
+end Core.Logic.Modal.QBSML

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -26,12 +26,15 @@ The framework's central facts (paper §5):
 | 9   | `[∀x◇(Px ∨ Qx)]⁺ ⊨ ∀x◇Px ∧ ∀x◇Qx` (universal FC; [chemla-2009]) |
 | 10  | `[¬(Pa ∨ Pb)]⁺ ⊨ ¬Pa ∧ ¬Pb` (negation behaviour; ignorance disappears) |
 
-Facts 5–10 are proved here as universal substrate theorems over arbitrary
-QBSML models and instantiated at a concrete model (`avoModel`); Fact 4 is
-the paper's Fig. 14 countermodel; Facts 1–2 and Proposition 4.1 live with
-the framework substrate in `Core/Logic/Modal/QBSML/Properties.lean` (the
-modal-free Proposition 4.1 against mathlib `Formula.Realize` is
-instantiated here at `avoModel`, the translation discharged by `rfl`).
+Facts 3 and 5–10 are proved here as universal substrate theorems over
+arbitrary QBSML models, the unconditional ones instantiated at a concrete
+model (`avoModel`); Fact 4 is the paper's Fig. 14 countermodel; Facts 1–2
+and Proposition 4.1 live with the framework substrate in
+`Core/Logic/Modal/QBSML/Properties.lean` (the modal-free Proposition 4.1
+against mathlib `Formula.Realize` is instantiated here at `avoModel`, the
+translation discharged by `rfl`). Fact 3 needs the individual constants of
+[aloni-vanormondt-2023] Definition 4.1 — `QBSMLFormula.predc` atoms,
+interpreted world-relatively via `QBSMLModel.cInterp`.
 
 ## Proof architecture (mirrors `BSML/FreeChoice.lean`)
 
@@ -54,10 +57,6 @@ the paper's primitive `[□φ]⁺ = □[φ]⁺ ∧ NE`.
 
 ## What is deferred
 
-- **Ignorance (Fact 3)**: its proof evaluates the closed atoms `Pa`, `Pb`
-  across indices carrying *different* assignments, which the constant-free
-  monadic language cannot express (with a free variable in place of `a`
-  the statement is false); needs individual constants in the term language.
 - **`Decidable` instance for `QBSML.eval`**: well-defined, but of limited
   use — the split-disjunction clauses quantify over pairs of subteams of
   the index space (`2^12 × 2^12` already at this file's model sizes), so
@@ -77,7 +76,7 @@ open Core.Logic.Modal.QBSML
 open FirstOrder Language
 open Phenomena.FreeChoice (FCAtom PowerSet2World)
 
-variable {W Var Domain Pred : Type*}
+variable {W Var Domain Const Pred : Type*}
 variable [DecidableEq W]
 variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
 
@@ -93,8 +92,8 @@ variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
     All quantifier cases use `antiSupport_strip_ne` to peel the `NE`
     conjunct, then `extendUniversal` / `extendFunctional` to apply the IH
     on the extended state. -/
-private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Pred)
-    {φ : QBSMLFormula Var Pred} (hNE : φ.IsNEFree) :
+private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Const Pred)
+    {φ : QBSMLFormula Var Const Pred} (hNE : φ.IsNEFree) :
     (∀ s : Finset (Index W Var Domain), support M φ.enrich s → support M φ s) ∧
     (∀ s : Finset (Index W Var Domain),
         antiSupport M φ.enrich s → antiSupport M φ s) := by
@@ -103,6 +102,10 @@ private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Pred)
     refine ⟨?_, ?_⟩
     · intro s h; exact h.1
     · intro s h; exact antiSupport_strip_ne M (.pred P x) s h
+  | predc P c =>
+    refine ⟨?_, ?_⟩
+    · intro s h; exact h.1
+    · intro s h; exact antiSupport_strip_ne M (.predc P c) s h
   | @neg ψ _ ih =>
     obtain ⟨ih_s, ih_a⟩ := ih
     refine ⟨?_, ?_⟩
@@ -171,20 +174,61 @@ private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Pred)
 /-- **Enrichment strengthens (support direction)** — [aloni-2022] Fact 1
     extended to QBSML. For NE-free `φ`, supporting the enriched form implies
     supporting the original. -/
-theorem enrichment_strengthens_support (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
+theorem enrichment_strengthens_support (M : QBSMLModel W Domain Const Pred)
+    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
     (hNE : φ.IsNEFree)
     (h : support M φ.enrich s) :
     support M φ s :=
   (enrichment_strengthens_both M hNE).1 s h
 
 /-- **Enrichment strengthens (anti-support direction)**. -/
-theorem enrichment_strengthens_antiSupport (M : QBSMLModel W Domain Pred)
-    (φ : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
+theorem enrichment_strengthens_antiSupport (M : QBSMLModel W Domain Const Pred)
+    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
     (hNE : φ.IsNEFree)
     (h : antiSupport M φ.enrich s) :
     antiSupport M φ s :=
   (enrichment_strengthens_both M hNE).2 s h
+
+/-- **Fact 3 (ignorance)** of [aloni-vanormondt-2023]: on epistemic models
+    (state-based `R`),
+
+    `[Pc₁ ∨ Qc₂]⁺ ⊨_epi ◇Pc₁ ∧ ◇Qc₂`.
+
+    Stated for constant atoms, as in the paper's `Pa ∨ Pb`: the proof
+    transplants each split-half's worlds to every index via state-basedness,
+    which is sound only because constant atoms are *assignment-invariant* —
+    with a free variable in place of the constant the statement is false
+    (the transplanted indices carry the wrong assignments). -/
+theorem ignorance_Q (M : QBSMLModel W Domain Const Pred)
+    (P Q : Pred) (c₁ c₂ : Const) (s : Finset (Index W Var Domain))
+    (hSB : M.IsStateBased s)
+    (h : support M
+      (QBSMLFormula.enrich (.disj (.predc P c₁) (.predc Q c₂))) s) :
+    support M (.poss (.predc P c₁)) s ∧
+    support M (.poss (.predc Q c₂)) s := by
+  have hSB' : ∀ w ∈ State.worldProj s, M.access w = State.worldProj s := hSB
+  obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := h.1
+  have ht₁s : t₁ ⊆ s := hunion ▸ Finset.subset_union_left
+  have ht₂s : t₂ ⊆ s := hunion ▸ Finset.subset_union_right
+  constructor
+  · intro i hi
+    refine ⟨State.worldProj t₁, ?_, State.worldProj_nonempty h₁.2, ?_⟩
+    · rw [hSB' i.world (State.mem_worldProj.mpr ⟨i, hi, rfl⟩)]
+      exact State.worldProj_mono ht₁s
+    · intro k hk
+      obtain ⟨hkw, -⟩ := State.mem_modalLift.mp hk
+      obtain ⟨j, hj, hjw⟩ := State.mem_worldProj.mp hkw
+      rw [← hjw]
+      exact h₁.1 j hj
+  · intro i hi
+    refine ⟨State.worldProj t₂, ?_, State.worldProj_nonempty h₂.2, ?_⟩
+    · rw [hSB' i.world (State.mem_worldProj.mpr ⟨i, hi, rfl⟩)]
+      exact State.worldProj_mono ht₂s
+    · intro k hk
+      obtain ⟨hkw, -⟩ := State.mem_modalLift.mp hk
+      obtain ⟨j, hj, hjw⟩ := State.mem_worldProj.mp hkw
+      rw [← hjw]
+      exact h₂.1 j hj
 
 /-! ### Negation behaviour (Fact 10) -/
 
@@ -200,8 +244,8 @@ theorem enrichment_strengthens_antiSupport (M : QBSMLModel W Domain Pred)
     Negation cancels ignorance (paper §5.5): the `Nonempty` hypothesis is
     discharged by the three NE-strips, leaving classical anti-support on
     each disjunct. -/
-theorem negationStrip_Q (M : QBSMLModel W Domain Pred)
-    (α β : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
+theorem negationStrip_Q (M : QBSMLModel W Domain Const Pred)
+    (α β : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
     (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (.neg (.disj α β))) s) :
     support M (.neg α) s ∧ support M (.neg β) s := by
@@ -225,8 +269,8 @@ theorem negationStrip_Q (M : QBSMLModel W Domain Pred)
     each piece from its world projection, which serves as the `Finset W`
     witness, and `enrichment_strengthens_support` discharges the enrichment
     to plain support of α, β. -/
-private theorem diamond_split (M : QBSMLModel W Domain Pred)
-    {α β : QBSMLFormula Var Pred} (hα : α.IsNEFree) (hβ : β.IsNEFree)
+private theorem diamond_split (M : QBSMLModel W Domain Const Pred)
+    {α β : QBSMLFormula Var Const Pred} (hα : α.IsNEFree) (hβ : β.IsNEFree)
     {X : Finset W} {g : Assignment Var Domain}
     (hsupp : support M (QBSMLFormula.disj α β).enrich (State.modalLift X g)) :
     (∃ Y, Y ⊆ X ∧ Y.Nonempty ∧ support M α (State.modalLift Y g)) ∧
@@ -252,8 +296,8 @@ private theorem diamond_split (M : QBSMLModel W Domain Pred)
 
 /-- Per-index form of the core: a state whose every index sees an enriched
     split disjunction supports both diamonds (shared by Facts 8 and 9). -/
-private theorem possFC_on (M : QBSMLModel W Domain Pred)
-    {α β : QBSMLFormula Var Pred} (hα : α.IsNEFree) (hβ : β.IsNEFree)
+private theorem possFC_on (M : QBSMLModel W Domain Const Pred)
+    {α β : QBSMLFormula Var Const Pred} (hα : α.IsNEFree) (hβ : β.IsNEFree)
     {t : Finset (Index W Var Domain)}
     (h : support M (.poss (QBSMLFormula.disj α β).enrich) t) :
     support M (.poss α) t ∧ support M (.poss β) t := by
@@ -272,8 +316,8 @@ private theorem possFC_on (M : QBSMLModel W Domain Pred)
 
     Projects the diamond clause of the enrichment and applies the per-index
     core `possFC_on` at `s`. -/
-theorem narrowScopeFC_Q (M : QBSMLModel W Domain Pred)
-    (α β : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
+theorem narrowScopeFC_Q (M : QBSMLModel W Domain Const Pred)
+    (α β : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
     (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (.poss (.disj α β))) s) :
     support M (.poss α) s ∧ support M (.poss β) s :=
@@ -287,8 +331,8 @@ theorem narrowScopeFC_Q (M : QBSMLModel W Domain Pred)
     The enriched premise evaluates the enriched diamond at the universal
     extension `s[x]`, so the conclusion is `possFC_on` at `s[x]` — the same
     per-index argument as Fact 8, one extension up. -/
-theorem universalFC_Q (M : QBSMLModel W Domain Pred)
-    (α β : QBSMLFormula Var Pred) (x : Var) (s : Finset (Index W Var Domain))
+theorem universalFC_Q (M : QBSMLModel W Domain Const Pred)
+    (α β : QBSMLFormula Var Const Pred) (x : Var) (s : Finset (Index W Var Domain))
     (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (.univ x (.poss (.disj α β)))) s) :
     support M (.univ x (.poss α)) s ∧ support M (.univ x (.poss β)) s :=
@@ -304,8 +348,8 @@ theorem universalFC_Q (M : QBSMLModel W Domain Pred)
     NE-strips flip the doubly-negated diamond into support of the enriched
     disjunction on each index's full accessible lift `R(wᵢ)[gᵢ]`, and
     `diamond_split` produces the witnesses. -/
-theorem boxFC_Q (M : QBSMLModel W Domain Pred)
-    (α β : QBSMLFormula Var Pred) (s : Finset (Index W Var Domain))
+theorem boxFC_Q (M : QBSMLModel W Domain Const Pred)
+    (α β : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
     (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (QBSMLFormula.nec (.disj α β))) s) :
     support M (.poss α) s ∧ support M (.poss β) s := by
@@ -332,7 +376,7 @@ theorem boxFC_Q (M : QBSMLModel W Domain Pred)
     functional `h` sending the (unique) index to the domain values whose
     extensions land in `t` reconstructs `t` exactly. The engine of Fact 5. -/
 private lemma exi_of_subset_extendUniversal_singleton
-    (M : QBSMLModel W Domain Pred) {γ : QBSMLFormula Var Pred}
+    (M : QBSMLModel W Domain Const Pred) {γ : QBSMLFormula Var Const Pred}
     {i : Index W Var Domain} {x : Var} {t : Finset (Index W Var Domain)}
     (htsub : t ⊆ State.extendUniversal {i} x) (htne : t.Nonempty)
     (hsupp : support M γ t) :
@@ -375,8 +419,8 @@ private lemma exi_of_subset_extendUniversal_singleton
     non-empty parts supporting the enriched disjuncts; because the state is
     a singleton, every part extends the *same* index, so each part is the
     image of a functional extension witnessing the existential. -/
-theorem distribution_Q (M : QBSMLModel W Domain Pred)
-    (α β : QBSMLFormula Var Pred) (x : Var) (i : Index W Var Domain)
+theorem distribution_Q (M : QBSMLModel W Domain Const Pred)
+    (α β : QBSMLFormula Var Const Pred) (x : Var) (i : Index W Var Domain)
     (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (.univ x (.disj α β))) {i}) :
     support M (.exi x α) {i} ∧ support M (.exi x β) {i} := by
@@ -397,7 +441,7 @@ theorem distribution_Q (M : QBSMLModel W Domain Pred)
     `i₀.world` in every index's accessible set, so the singleton
     `{i₀.world}` witnesses each diamond. The engine of Fact 6. -/
 private lemma exi_poss_atom_of_subset_extendUniversal
-    (M : QBSMLModel W Domain Pred) {P : Pred} {x : Var}
+    (M : QBSMLModel W Domain Const Pred) {P : Pred} {x : Var}
     {s t : Finset (Index W Var Domain)}
     (hSB : M.IsStateBased s)
     (htsub : t ⊆ State.extendUniversal s x) (htne : t.Nonempty)
@@ -445,7 +489,7 @@ private lemma exi_poss_atom_of_subset_extendUniversal
     pointwise at a single transplanted world; the paper notes the result
     "can easily be generalised", which for arbitrary NE-free formulas would
     route through flatness). -/
-theorem distributionEpi_Q (M : QBSMLModel W Domain Pred)
+theorem distributionEpi_Q (M : QBSMLModel W Domain Const Pred)
     (P Q : Pred) (x : Var) (s : Finset (Index W Var Domain))
     (hSB : M.IsStateBased s)
     (h : support M
@@ -496,41 +540,41 @@ instance : Fintype QVar where
 
     Universal access (`access _ = univ`) means R is indisputable on every
     state but **not** state-based — same shape as `Aloni2022.deonticModel`. -/
-def avoModel : QBSMLModel PowerSet2World FCAtom QPred where
+def avoModel : QBSMLModel PowerSet2World FCAtom FCAtom QPred where
   access := λ _ => Finset.univ
-  interp := λ w => monadicStructure (λ _ d => w.holds d)
+  interp := λ w => monadicStructure id (λ _ d => w.holds d)
 
 /-! ### Formulas -/
 
 /-- The atomic formula `Px`. -/
-def Px : QBSMLFormula QVar QPred := .pred .P .x
+def Px {Const : Type*} : QBSMLFormula QVar Const QPred := .pred .P .x
 
 /-- The atomic formula `Qx`. -/
-def Qx : QBSMLFormula QVar QPred := .pred .Q .x
+def Qx {Const : Type*} : QBSMLFormula QVar Const QPred := .pred .Q .x
 
 /-- Disjunction `Px ∨ Qx` — paper's `Pa ∨ Pb`-shape with two distinct
     predicate-instances. -/
-def PxOrQx : QBSMLFormula QVar QPred := .disj Px Qx
+def PxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := .disj Px Qx
 
 /-- The negation premise `¬(Px ∨ Qx)` corresponding to the paper's
     `¬(Pa ∨ Pb)` schema. -/
-def negPxOrQx : QBSMLFormula QVar QPred := .neg PxOrQx
+def negPxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := .neg PxOrQx
 
 /-- The narrow-scope FC premise `◇(Px ∨ Qx)` corresponding to the paper's
     `◇(Pa ∨ Pb)` schema. -/
-def possPxOrQx : QBSMLFormula QVar QPred := .poss PxOrQx
+def possPxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := .poss PxOrQx
 
 /-- The □-FC premise `□(Px ∨ Qx)` (paper's Fact 7 schema; `□` derived). -/
-def necPxOrQx : QBSMLFormula QVar QPred := PxOrQx.nec
+def necPxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := PxOrQx.nec
 
 /-- The universal-FC premise `∀x◇(Px ∨ Qx)` (paper's Fact 9 schema). -/
-def univPossPxOrQx : QBSMLFormula QVar QPred := .univ .x possPxOrQx
+def univPossPxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := .univ .x possPxOrQx
 
 /-- The distribution premise `∀x(Px ∨ Qx)` (paper's Facts 4–6 schema). -/
-def univPxOrQx : QBSMLFormula QVar QPred := .univ .x PxOrQx
+def univPxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := .univ .x PxOrQx
 
-theorem Px_isNEFree : Px.IsNEFree := .pred _ _
-theorem Qx_isNEFree : Qx.IsNEFree := .pred _ _
+theorem Px_isNEFree {Const : Type*} : (Px (Const := Const)).IsNEFree := .pred _ _
+theorem Qx_isNEFree {Const : Type*} : (Qx (Const := Const)).IsNEFree := .pred _ _
 
 /-! ### Fact 10 (negation): `[¬(Pa ∨ Pb)]⁺ ⊨ ¬Pa ∧ ¬Pb` -/
 
@@ -620,9 +664,10 @@ theorem univPxOrQx_classical
     - State-based: every w ∈ s↓ sees exactly s↓ (R(w) = s↓).
 
     State-basedness is strictly stronger and is the precondition for the
-    epistemic facts: Fact 3 (ignorance), Fact 6 (epistemic distribution).
-    Facts 7, 8 and 10 (formalised above) need no frame condition at all —
-    they hold on every model. -/
+    epistemic facts: Fact 3 (`ignorance_Q`) and Fact 6 (`distributionEpi_Q`),
+    which therefore stay substrate-level (universal access is not
+    state-based). Facts 7, 8 and 10 need no frame condition at all — they
+    hold on every model. -/
 theorem avoModel_indisputable
     (s : Finset (Index PowerSet2World QVar FCAtom)) :
     avoModel.IsIndisputable s := by
@@ -656,9 +701,9 @@ def fig14V (w : PowerSet2World) : QPred → Fig14Atom → Prop
   | .Q, d => d = .b ∧ w.holds .b
 
 /-- The Fig. 14 model: reflexive-only access at the `both` world. -/
-def fig14Model : QBSMLModel PowerSet2World Fig14Atom QPred where
+def fig14Model : QBSMLModel PowerSet2World Fig14Atom Fig14Atom QPred where
   access := λ _ => {PowerSet2World.both}
-  interp := λ w => monadicStructure (fig14V w)
+  interp := λ w => monadicStructure id (fig14V w)
 
 /-- The Fig. 14 index: the `both` world with the empty assignment. -/
 def fig14Index : Index PowerSet2World QVar Fig14Atom :=
@@ -719,7 +764,7 @@ theorem fig14_conclusion_fails :
     `[∀x(Px ∨ Qx)]⁺ ⊭ ∀x(◇Px ∧ ◇Qx)`, witnessed by the Fig. 14
     countermodel. -/
 theorem fact4_obviation :
-    ∃ (M : QBSMLModel PowerSet2World Fig14Atom QPred)
+    ∃ (M : QBSMLModel PowerSet2World Fig14Atom Fig14Atom QPred)
       (s : Finset (Index PowerSet2World QVar Fig14Atom)),
       support M univPxOrQx.enrich s ∧
       ¬ support M (.univ .x (.conj (.poss Px) (.poss Qx))) s :=

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -653,6 +653,23 @@ theorem univPxOrQx_classical
             (monadicRel QPred.Q).formula₁ (Term.var QVar.x))) (v i) :=
   support_iff_forall_realizeAt avoModel rfl s v hv
 
+/-- The narrow-scope FC premise `◇(Px ∨ Qx)` translates into the modal layer
+    over the monadic signature, and its support is Kripke satisfaction at
+    every index — the **full** [aloni-vanormondt-2023] Proposition 4.1
+    (modals included) at `avoModel`, the translation discharged by `rfl`. -/
+theorem possPxOrQx_classical
+    (s : Finset (Index PowerSet2World QVar FCAtom))
+    (v : Index PowerSet2World QVar FCAtom → QVar → FCAtom)
+    (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
+    support avoModel possPxOrQx s ↔
+      ∀ i ∈ s,
+        (ModalFormula.dia
+          (.sup (.ofFormula ((monadicRel QPred.P).formula₁ (Term.var QVar.x)))
+            (.ofFormula
+              ((monadicRel QPred.Q).formula₁ (Term.var QVar.x))))).Realize
+          avoModel i.world (v i) :=
+  support_iff_forall_realize avoModel rfl s v hv
+
 /-! ### Frame condition: avoModel is indisputable on every state -/
 
 /-- `avoModel`'s universal accessibility makes R indisputable on every state


### PR DESCRIPTION
Completes the AvO 2023 formalization and extends the model-theory layer with modals.

- **Individual constants** ([aloni-vanormondt-2023] Definition 4.1's `t := c | x`): `monadicLang Const Pred` gains nullary function symbols, `QBSMLModel.cInterp` reads world-relative `I(w)(c)` off `Structure.funMap`, new `QBSMLFormula.predc` atom; **Fact 3** proved (`ignorance_Q`, sound precisely because constant atoms are assignment-invariant). All ten paper facts now formalized.
- **`Core/Logic/FirstOrder/Kripke.lean`** (upstream candidate): constant-domain `KripkeStructure L W M` (world-indexed mathlib structure families + accessibility), the transported `RealizeAt` simp set, and `ModalFormula L α` — classical formulas embedded wholesale, `□` primitive, `◇` derived, named-binder quantifiers — with Kripke satisfaction `ModalFormula.Realize`. `QBSMLModel` is now an *abbreviation* of `KripkeStructure` over the monadic signature.
- **Full Proposition 4.1**: `toModal?` translates the entire NE-free fragment (modals included; total on exactly that fragment), and `support_iff_forall_realize` is the paper's statement — team support is Kripke satisfaction at every index. Demo at `avoModel` with the translation discharged by `rfl`.
- **Standard translation** ([blackburn-derijke-venema-2001]): `ModalFormula.st?` into plain mathlib FO over `stLang` (accessibility + world-relativized predicates + world-indexed constants + individual sort) on the `W ⊕ M` carrier; `realize_st?` is satisfaction preservation (off-sort quantifier instances discharged by relational guards; box-freshness by index increment); `support_singleton_iff_st` chains Prop 4.1 so NE-free QBSML support bottoms out in single-structure `Formula.Realize` — the link along which compactness/Löwenheim–Skolem transfer.
