### PR TITLE
refactor(Semantics): PrProp → PartialProp, PrValue → PartialValue

### DIFF
--- a/Linglib/Fragments/ASL/Height.lean
+++ b/Linglib/Fragments/ASL/Height.lean
@@ -41,7 +41,7 @@ set_option autoImplicit false
 
 namespace ASL.Height
 
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Vertical Height Scale
@@ -129,7 +129,7 @@ def heightToDDRP {E : Type*} (zone : E → VerticalHeight) : HeightDDRP E where
     This uses `Mereology.Atom` from `Core/Order/Mereology.lean`. The at-issue
     content is the identity — arc contributes only a presupposition, not
     assertoric content. -/
-def arcPresup (E : Type*) [PartialOrder E] : PrProp E where
+def arcPresup (E : Type*) [PartialOrder E] : PartialProp E where
   presup := λ x => ¬ Mereology.Atom x
   assertion := λ _ => True
 
@@ -149,7 +149,7 @@ def arcPresup (E : Type*) [PartialOrder E] : PrProp E where
       extreme domain restriction. The presupposition is maximally
       restrictive: the domain collapses to a single individual. -/
 def domainPresup {E : Type*} [PartialOrder E] (C : E → Prop) :
-    VerticalHeight → PrProp E
+    VerticalHeight → PartialProp E
   | .high => { presup := λ x => (∀ y, C y → y ≤ x) ∧ ∃ y, y ≤ x ∧ ¬ C y
                assertion := λ _ => True }
   | .neutral => { presup := λ x => ∀ y, y ≤ x → C y
@@ -162,7 +162,7 @@ def domainPresup {E : Type*} [PartialOrder E] (C : E → Prop) :
 
     ⟦[IX_i]-arc-height⟧ = ιz: ¬Atom(z) ∧ domainPresup(height). (z = g(i)) -/
 def ixArcHeightPresup {E : Type*} [PartialOrder E] (C : E → Prop)
-    (h : VerticalHeight) : PrProp E where
+    (h : VerticalHeight) : PartialProp E where
   presup := λ x => (arcPresup E).presup x ∧ (domainPresup C h).presup x
   assertion := λ _ => True
 

--- a/Linglib/Fragments/Shan/Definiteness.lean
+++ b/Linglib/Fragments/Shan/Definiteness.lean
@@ -37,7 +37,7 @@ situation) and add spatial content to the presupposition filter.
 namespace Shan.Definiteness
 
 open Features.Definiteness
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open Semantics.Kinds
 
 -- ============================================================================
@@ -180,11 +180,11 @@ theorem dem_refines_bare {E : Type} (domain : List E)
     congr 1; funext e'; exact Bool.and_comm _ _
   rw [this, hBare]; simp [hSpatial]
 
-/-- Lift a referent selector to a `PrProp Unit` via the canonical
+/-- Lift a referent selector to a `PartialProp Unit` via the canonical
     `presupOfReferent` combinator. The presupposition is referent
     definedness; the assertion is the scope applied to the referent. -/
-def liftToPrProp {E : Type} (selector : Option E) (scope : E → Bool) :
-    PrProp Unit :=
-  PrProp.presupOfReferent (fun _ : Unit => selector) (fun e _ => scope e = true)
+def liftToPartialProp {E : Type} (selector : Option E) (scope : E → Bool) :
+    PartialProp Unit :=
+  PartialProp.presupOfReferent (fun _ : Unit => selector) (fun e _ => scope e = true)
 
 end Shan.Definiteness

--- a/Linglib/Phenomena/Presupposition/Basic.lean
+++ b/Linglib/Phenomena/Presupposition/Basic.lean
@@ -61,7 +61,7 @@ This sentence has:
 - No presupposition (trivially true)
 - Assertion: the king exists
 -/
-def kingExists : PrProp KingWorld :=
+def kingExists : PartialProp KingWorld :=
   { presup := λ _ => True
   , assertion := λ w => match w with
       | .kingExists => True
@@ -75,7 +75,7 @@ This sentence has:
 - Presupposition: the king exists
 - Assertion: the king is bald (true when king exists)
 -/
-def kingBald : PrProp KingWorld :=
+def kingBald : PartialProp KingWorld :=
   { presup := λ w => match w with
       | .kingExists => True
       | .noKing => False
@@ -88,8 +88,8 @@ def kingBald : PrProp KingWorld :=
 Demonstrates presupposition filtering: the antecedent's assertion
 satisfies the consequent's presupposition.
 -/
-def ifKingThenBald : PrProp KingWorld :=
-  PrProp.impFilter kingExists kingBald
+def ifKingThenBald : PartialProp KingWorld :=
+  PartialProp.impFilter kingExists kingBald
 
 /--
 "If the king exists, the king is bald" has no presupposition.
@@ -98,16 +98,16 @@ This demonstrates presupposition filtering.
 -/
 theorem ifKingThenBald_no_presup : ifKingThenBald.presup = λ _ => True := by
   funext w
-  simp only [ifKingThenBald, PrProp.impFilter, kingExists, kingBald]
+  simp only [ifKingThenBald, PartialProp.impFilter, kingExists, kingBald]
   cases w <;> simp
 
 /--
 "The king isn't bald" — negation preserves presupposition.
 -/
-def kingNotBald : PrProp KingWorld := PrProp.neg kingBald
+def kingNotBald : PartialProp KingWorld := PartialProp.neg kingBald
 
 theorem kingNotBald_presupposes_existence :
-    kingNotBald.presup = kingBald.presup := PrProp.neg_presup kingBald
+    kingNotBald.presup = kingBald.presup := PartialProp.neg_presup kingBald
 
 
 /--
@@ -128,7 +128,7 @@ instance : Fintype RainWorld where
 /--
 "It's raining" — no presupposition.
 -/
-def raining : PrProp RainWorld :=
+def raining : PartialProp RainWorld :=
   { presup := λ _ => True
   , assertion := λ w => match w with
       | .rainingBelieved => True
@@ -142,7 +142,7 @@ def raining : PrProp RainWorld :=
 Presupposes: it's raining
 Asserts: John believes it's raining
 -/
-def johnKnowsRaining : PrProp RainWorld :=
+def johnKnowsRaining : PartialProp RainWorld :=
   { presup := λ w => match w with
       | .rainingBelieved => True
       | .rainingNotBelieved => True
@@ -156,11 +156,11 @@ def johnKnowsRaining : PrProp RainWorld :=
 /--
 "John doesn't know that it's raining" — negation preserves factive presupposition.
 -/
-def johnDoesntKnowRaining : PrProp RainWorld := PrProp.neg johnKnowsRaining
+def johnDoesntKnowRaining : PartialProp RainWorld := PartialProp.neg johnKnowsRaining
 
 theorem negation_preserves_factive :
     johnDoesntKnowRaining.presup = johnKnowsRaining.presup :=
-  PrProp.neg_presup johnKnowsRaining
+  PartialProp.neg_presup johnKnowsRaining
 
 
 /--
@@ -184,7 +184,7 @@ instance : Fintype SmokingWorld where
 Presupposes: John used to smoke
 Asserts: John no longer smokes
 -/
-def johnStoppedSmoking : PrProp SmokingWorld :=
+def johnStoppedSmoking : PartialProp SmokingWorld :=
   { presup := λ w => match w with
       | .usedToNowQuit => True
       | .usedToStillDoes => True
@@ -198,11 +198,11 @@ def johnStoppedSmoking : PrProp SmokingWorld :=
 /--
 "John didn't stop smoking" — preserves change-of-state presupposition.
 -/
-def johnDidntStopSmoking : PrProp SmokingWorld := PrProp.neg johnStoppedSmoking
+def johnDidntStopSmoking : PartialProp SmokingWorld := PartialProp.neg johnStoppedSmoking
 
 theorem negation_preserves_change_of_state :
     johnDidntStopSmoking.presup = johnStoppedSmoking.presup :=
-  PrProp.neg_presup johnStoppedSmoking
+  PartialProp.neg_presup johnStoppedSmoking
 
 
 /--
@@ -214,15 +214,15 @@ Right conjunct: John stopped smoking (presupposes he used to smoke)
 With filtering: left conjunct asserts smoking, right presupposes it was prior.
 This creates a pragmatically odd sentence (you can't currently smoke AND have stopped).
 -/
-def johnSmokesAndStopped : PrProp SmokingWorld :=
-  let johnSmokes : PrProp SmokingWorld :=
+def johnSmokesAndStopped : PartialProp SmokingWorld :=
+  let johnSmokes : PartialProp SmokingWorld :=
     { presup := λ _ => True
     , assertion := λ w => match w with
         | .usedToNowQuit => False
         | .usedToStillDoes => True
         | .neverSmoked => False
     }
-  PrProp.andFilter johnSmokes johnStoppedSmoking
+  PartialProp.andFilter johnSmokes johnStoppedSmoking
 
 
 /--

--- a/Linglib/Phenomena/Presupposition/Compare.lean
+++ b/Linglib/Phenomena/Presupposition/Compare.lean
@@ -54,13 +54,13 @@ variable {W : Type*}
 /-- The filtering prediction for "if A then know-C":
     the presupposition of the consequent (= C) is filtered by the antecedent.
     Result: conditional presupposes "A → C". -/
-def filteringPrediction_know (a c : W → Prop) : PrProp W :=
-  PrProp.impFilter (PrProp.ofProp a) (PrProp.condAssert c (fun _ => True))
+def filteringPrediction_know (a c : W → Prop) : PartialProp W :=
+  PartialProp.impFilter (PartialProp.ofProp a) (PartialProp.condAssert c (fun _ => True))
 
 /-- The filtering prediction for "if A then think-C":
     "think" has no presupposition, so filtering produces a trivial result. -/
-def filteringPrediction_think (a : W → Prop) : PrProp W :=
-  PrProp.impFilter (PrProp.ofProp a) PrProp.top
+def filteringPrediction_think (a : W → Prop) : PartialProp W :=
+  PartialProp.impFilter (PartialProp.ofProp a) PartialProp.top
 
 /-- **Filtering predicts non-trivial presupposition for "know"**:
     The presupposition of "if A then know-C" is ¬A ∨ C (= A → C),
@@ -70,7 +70,7 @@ theorem filtering_know_nontrivial (a c : W → Prop)
     ∃ w, ¬(filteringPrediction_know a c).presup w := by
   obtain ⟨w, ha, hc⟩ := h
   refine ⟨w, ?_⟩
-  simp only [filteringPrediction_know, PrProp.impFilter, PrProp.ofProp, PrProp.condAssert,
+  simp only [filteringPrediction_know, PartialProp.impFilter, PartialProp.ofProp, PartialProp.condAssert,
     not_and]
   intro _
   exact fun h_imp => hc (h_imp ha)
@@ -81,7 +81,7 @@ theorem filtering_know_nontrivial (a c : W → Prop)
 theorem filtering_think_trivial (a : W → Prop) :
     ∀ w, (filteringPrediction_think a).presup w := by
   intro w
-  simp only [filteringPrediction_think, PrProp.impFilter, PrProp.ofProp, PrProp.top]
+  simp only [filteringPrediction_think, PartialProp.impFilter, PartialProp.ofProp, PartialProp.top]
   exact ⟨trivial, fun _ => trivial⟩
 
 end Filtering

--- a/Linglib/Phenomena/Presupposition/ProjectiveContent.lean
+++ b/Linglib/Phenomena/Presupposition/ProjectiveContent.lean
@@ -225,7 +225,7 @@ def ProjectiveTrigger.toClass : ProjectiveTrigger → ProjectiveClass
 /--
 A projective content item, combining a trigger with its content.
 
-This extends the basic PrProp to track what kind of projective
+This extends the basic PartialProp to track what kind of projective
 content is involved.
 -/
 structure ProjectiveItem (W : Type*) where
@@ -241,12 +241,12 @@ structure ProjectiveItem (W : Type*) where
   atIssuenessDegree : Option ℚ := none
 
 /--
-Convert a ProjectiveItem to a PrProp.
+Convert a ProjectiveItem to a PartialProp.
 
 The projective content becomes the presupposition, and the
 at-issue content becomes the assertion.
 -/
-def ProjectiveItem.toPrProp {W : Type*} (pc : ProjectiveItem W) : PrProp W :=
+def ProjectiveItem.toPartialProp {W : Type*} (pc : ProjectiveItem W) : PartialProp W :=
   { presup := pc.content
   , assertion := pc.atIssue }
 

--- a/Linglib/Pragmatics/Expressives/Basic.lean
+++ b/Linglib/Pragmatics/Expressives/Basic.lean
@@ -429,10 +429,10 @@ This derives de re readings: when a presuppositional expression appears under
 an attitude verb, the presupposition can be evaluated against the common ground
 (CommonGround) rather than the attitude holder's beliefs, because it projects as CI content.
 
-### Bridge: PrProp ↔ TwoDimProp
+### Bridge: PartialProp ↔ TwoDimProp
 
 This provides a new cross-module connection between:
-- `Semantics.Presupposition.PrProp` (presupposition + assertion)
+- `Semantics.Presupposition.PartialProp` (presupposition + assertion)
 - `Pragmatics.Expressives.TwoDimProp` (at-issue + CI)
 
 -/

--- a/Linglib/Pragmatics/Expressives/Outlook.lean
+++ b/Linglib/Pragmatics/Expressives/Outlook.lean
@@ -19,7 +19,7 @@ is then a theorem about the structure rather than a stipulated flag.
 ## Main definitions
 
 * `Outlook` — prejacent + counterstance + outlook-relative `evaluation`.
-* `Outlook.toPrProp`, `Outlook.toTwoDimProp` — the presuppositional and (perspective-fixed)
+* `Outlook.toPartialProp`, `Outlook.toTwoDimProp` — the presuppositional and (perspective-fixed)
   two-dimensional projections.
 * `Outlook.IsRigid` — the evaluation ignores the outlook (the pure-expressive corner).
 * `Outlook.ofTwoDimProp` — a `TwoDimProp` as the constant (speaker-rigid) outlook family.
@@ -37,7 +37,7 @@ is then a theorem about the structure rather than a stipulated flag.
 
 namespace Pragmatics.Expressives
 
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 
 variable {W O : Type*}
 
@@ -56,7 +56,7 @@ namespace Outlook
 
 /-- Presuppositional projection: the counterstance is the presupposition, the prejacent the
 assertion. Outlook-independent. -/
-def toPrProp (m : Outlook W O) : PrProp W := ⟨m.counterstance, m.prejacent⟩
+def toPartialProp (m : Outlook W O) : PartialProp W := ⟨m.counterstance, m.prejacent⟩
 
 /-- Two-dimensional projection at an outlook `o`: an ordinary `TwoDimProp` recovered by
 fixing the perspective. -/
@@ -65,17 +65,17 @@ def toTwoDimProp (m : Outlook W O) (o : O) : TwoDimProp W := ⟨m.prejacent, m.e
 /-- The CI content attributed when the judge has outlook `o`. -/
 def ciFrom (m : Outlook W O) (o : O) : W → Prop := m.evaluation o
 
-@[simp] theorem toPrProp_presup (m : Outlook W O) : m.toPrProp.presup = m.counterstance := rfl
-@[simp] theorem toPrProp_assertion (m : Outlook W O) : m.toPrProp.assertion = m.prejacent := rfl
+@[simp] theorem toPartialProp_presup (m : Outlook W O) : m.toPartialProp.presup = m.counterstance := rfl
+@[simp] theorem toPartialProp_assertion (m : Outlook W O) : m.toPartialProp.assertion = m.prejacent := rfl
 @[simp] theorem toTwoDimProp_atIssue (m : Outlook W O) (o : O) :
     (m.toTwoDimProp o).atIssue = m.prejacent := rfl
 @[simp] theorem toTwoDimProp_ci (m : Outlook W O) (o : O) :
     (m.toTwoDimProp o).ci = m.evaluation o := rfl
 @[simp] theorem ciFrom_eq (m : Outlook W O) (o : O) : m.ciFrom o = m.evaluation o := rfl
 
-/-- The counterstance (presupposition) projects through negation — via `PrProp.neg`. -/
+/-- The counterstance (presupposition) projects through negation — via `PartialProp.neg`. -/
 theorem counterstance_projects_through_neg (m : Outlook W O) :
-    (PrProp.neg m.toPrProp).presup = m.counterstance := rfl
+    (PartialProp.neg m.toPartialProp).presup = m.counterstance := rfl
 
 /-- The CI tier projects through negation at a fixed outlook — via `TwoDimProp.neg`. -/
 theorem ci_projects_through_neg (m : Outlook W O) (o : O) :

--- a/Linglib/Pragmatics/Implicature/Diagnostics.lean
+++ b/Linglib/Pragmatics/Implicature/Diagnostics.lean
@@ -13,10 +13,10 @@ application is the BPS bridge in
 delivers two non-cancellability theorems for pex outputs: `bps_not_cancellable`
 (structural — assertion = `p.holds` makes content survive trivially)
 and `bps_neg_not_cancellable` (substantive — assertion = `p.neg.holds`
-makes content survive *because `PrProp.neg` projects*; the
+makes content survive *because `PartialProp.neg` projects*; the
 family-of-sentences test in [bassi-delpinal-sauerland-2021]'s
-sense). The substrate's projecting `PrProp.neg` is what makes the
-projection theorem work; swapping in non-projecting `PrProp.negExt`
+sense). The substrate's projecting `PartialProp.neg` is what makes the
+projection theorem work; swapping in non-projecting `PartialProp.negExt`
 would falsify it.
 
 ## The four classical tests
@@ -79,9 +79,9 @@ not in pex itself.
 
 **Delivered substantively** (`bps_neg_not_cancellable`): when assertion =
 `p.neg.holds` (i.e., the speaker negates the pex output), the inferred
-presup *still* survives — because `PrProp.neg` is constructed to project
+presup *still* survives — because `PartialProp.neg` is constructed to project
 the presupposition (`(neg p).presup := p.presup`). This is the family-of-
-sentences projection test in formal form. Falsifies for `PrProp.negExt`.
+sentences projection test in formal form. Falsifies for `PartialProp.negExt`.
 
 **Not delivered as cancellability failure:** Magri-style obligatory SI
 ([magri-2009]) is not non-cancellable in the Sadock sense, even
@@ -160,11 +160,11 @@ the assertion and contradicts "not all."
 Negation of `IsCancellable` is the load-bearing diagnostic for the
 [bassi-delpinal-sauerland-2021] *Presuppositional EXH* account:
 when pex outputs are wrapped as `Implicature W Prop` with
-`assertion := PrProp.holds · p` and `content := p.presup`, the
+`assertion := PartialProp.holds · p` and `content := p.presup`, the
 non-cancellability follows from `holds → presup` via
 `IsCancellable.false_of_assertion_implies_content`. The substantive
 content of "presuppositions fail cancellability" comes from the
-structural assertion-vs-presupposition split in `PrProp`, not from
+structural assertion-vs-presupposition split in `PartialProp`, not from
 stipulation. The bridge theorem `bps_not_cancellable` is in
 `Semantics/Exhaustification/Presuppositional.lean`.
 -/

--- a/Linglib/Semantics/Aspect/ChangeOfState.lean
+++ b/Linglib/Semantics/Aspect/ChangeOfState.lean
@@ -15,7 +15,7 @@ Each CoS predicate has:
 1. A **presupposition** about the prior state
 2. An **assertion** about the result state
 
-This maps directly to `PrProp` from `Semantics.Presupposition`:
+This maps directly to `PartialProp` from `Semantics.Presupposition`:
 - `presup`: the prior state condition
 - `assertion`: the result state condition
 
@@ -148,21 +148,21 @@ def resultStateAssertion (t : CoSType) (P : W → Prop) : W → Prop :=
 /--
 Combined semantics of a CoS predicate as a presuppositional proposition.
 
-Given an activity predicate P, returns a `PrProp` with:
+Given an activity predicate P, returns a `PartialProp` with:
 - presupposition: the expected prior state
 - assertion: the expected result state
 
 This is the core semantic contribution: CoS predicates are presupposition
 triggers that constrain both the prior and current states.
 -/
-def cosSemantics (t : CoSType) (P : W → Prop) : PrProp W :=
+def cosSemantics (t : CoSType) (P : W → Prop) : PartialProp W :=
   { presup := priorStatePresup t P
   , assertion := resultStateAssertion t P }
 
 /--
 Semantics for a lexical entry applied to an activity predicate.
 -/
-def entrySemantics (e : CoSEntry) (P : W → Prop) : PrProp W :=
+def entrySemantics (e : CoSEntry) (P : W → Prop) : PartialProp W :=
   cosSemantics e.cosType P
 
 -- Key Theorems
@@ -179,8 +179,8 @@ presupposition, not an entailment.
 -/
 theorem negation_preserves_presup (t : CoSType) (P : W → Prop) :
     (cosSemantics t P).presup =
-    (PrProp.neg (cosSemantics t P)).presup := by
-  simp only [PrProp.neg]
+    (PartialProp.neg (cosSemantics t P)).presup := by
+  simp only [PartialProp.neg]
 
 /--
 Cessation and inception have complementary presuppositions.
@@ -284,7 +284,7 @@ def hasSCF (_e : CoSEntry) : Bool := false
 ### Core Semantic Functions
 - `priorStatePresup t P`: What prior state is presupposed?
 - `resultStateAssertion t P`: What result state is asserted?
-- `cosSemantics t P`: Combined PrProp with both components
+- `cosSemantics t P`: Combined PartialProp with both components
 
 ### Results
 - `negation_preserves_presup`: Presupposition projects through negation

--- a/Linglib/Semantics/Attitudes/Desire.lean
+++ b/Linglib/Semantics/Attitudes/Desire.lean
@@ -76,7 +76,7 @@ for the bridge.
 
 namespace Semantics.Attitudes.Desire
 
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open Core.Order (SatisfactionOrdering)
 
 section Generic
@@ -309,15 +309,15 @@ instance (belS : Set W) [DecidablePred belS]
 The presupposition is the four-constraint definedness predicate; the
 assertion is the question-based truth condition. Both are
 world-independent because Q_c is contextually fixed prior to
-evaluation; we expose them as a `PrProp W` for uniformity with
+evaluation; we expose them as a `PartialProp W` for uniformity with
 linglib's presupposition infrastructure, with the world argument
 suppressed. -/
 
-/-- Question-based `want` as a partial proposition (`Core.PrProp`):
+/-- Question-based `want` as a partial proposition (`Core.PartialProp`):
     presupposition = full definedness; assertion = question-based truth. -/
-def wantPrProp (belS : Set W) [DecidablePred belS]
+def wantPartialProp (belS : Set W) [DecidablePred belS]
     (GS naturalProps answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
-    PrProp W where
+    PartialProp W where
   presup _ := wantDefined belS naturalProps answers p
   assertion _ := wantQuestionBased belS GS answers p
 

--- a/Linglib/Semantics/Attitudes/Doxastic.lean
+++ b/Linglib/Semantics/Attitudes/Doxastic.lean
@@ -11,10 +11,10 @@ Doxastic attitudes use Hintikka-style accessibility relations:
 - R(x, w, w') means w' is compatible with what x believes/knows in w
 - ⟦x believes p⟧(w) = ∀w'. R(x,w,w') → p(w')
 
-## PrProp Decomposition
+## PartialProp Decomposition
 
-`DoxasticPredicate.toPrProp` decomposes a doxastic predicate into a
-`PrProp` (partial proposition):
+`DoxasticPredicate.toPartialProp` decomposes a doxastic predicate into a
+`PartialProp` (partial proposition):
 - `presup` = veridicality check (for veridical verbs: p(w); otherwise: true)
 - `assertion` = universal modal (∀w'. R(x,w,w') → p(w'))
 
@@ -110,9 +110,9 @@ presuppositional profile — what they require of the Common Ground:
 - **Contrafactive** (hypothetical *contra*): would presuppose ¬p — UNATTESTED
 - **Weak contrafactive** (Mandarin yǐwéi): postsupposition ◇¬p — CommonGround compatible with ¬p
 
-The key insight: this classification is DERIVED from the `PrProp` produced by
-`DoxasticPredicate.toPrProp`, not stipulated as a separate type. The presup
-field of the PrProp determines the classification.
+The key insight: this classification is DERIVED from the `PartialProp` produced by
+`DoxasticPredicate.toPartialProp`, not stipulated as a separate type. The presup
+field of the PartialProp determines the classification.
 
 Postsuppositions (yǐwéi's ◇¬p) are output-context constraints, formalized
 separately in `Semantics.Dynamic.Postsupposition`.
@@ -121,8 +121,8 @@ separately in `Semantics.Dynamic.Postsupposition`.
 /--
 Classification of a doxastic verb's presuppositional profile.
 
-This emerges from the presup field of the `PrProp` produced by
-`DoxasticPredicate.toPrProp`. Not a primitive — a derived label.
+This emerges from the presup field of the `PartialProp` produced by
+`DoxasticPredicate.toPartialProp`. Not a primitive — a derived label.
 -/
 inductive PresupClass where
   | factive         -- presup = p (know: CommonGround must entail p)
@@ -490,44 +490,44 @@ instance DoxasticPredicate.holdsAt_decidable {W E : Type*}
   inferInstanceAs (Decidable (_ ∧ _))
 
 -- ============================================================================
--- PrProp Construction: Doxastic Predicates as Partial Propositions
+-- PartialProp Construction: Doxastic Predicates as Partial Propositions
 -- ============================================================================
 
 open Semantics.Presupposition
 
 /--
-Convert a doxastic predicate application to a `PrProp`.
+Convert a doxastic predicate application to a `PartialProp`.
 
 The decomposition makes the presuppositional structure explicit:
 - `presup` = veridicality check (for veridical: p(w); for non-veridical: true)
 - `assertion` = universal modal (∀w'. R(x,w,w') → p(w'))
 
-`holdsAt` computes `presup(w) && assertion(w)` — the same as `PrProp.holds`.
+`holdsAt` computes `presup(w) && assertion(w)` — the same as `PartialProp.holds`.
 -/
-def DoxasticPredicate.toPrProp {W E : Type*}
+def DoxasticPredicate.toPartialProp {W E : Type*}
     (V : DoxasticPredicate W E) (agent : E) (p : W → Prop)
-    (worlds : List W) : PrProp W :=
+    (worlds : List W) : PartialProp W :=
   { presup := λ w => veridicalityHolds V.veridicality p w
   , assertion := λ w => boxAt V.access agent w worlds p }
 
-/-- `toPrProp` decomposes `holdsAt`: the presup field is the veridicality
+/-- `toPartialProp` decomposes `holdsAt`: the presup field is the veridicality
     check and the assertion field is the modal. -/
-theorem DoxasticPredicate.toPrProp_presup {W E : Type*}
+theorem DoxasticPredicate.toPartialProp_presup {W E : Type*}
     (V : DoxasticPredicate W E) (agent : E) (p : W → Prop)
     (w : W) (worlds : List W) :
-    (V.toPrProp agent p worlds).presup w =
+    (V.toPartialProp agent p worlds).presup w =
     veridicalityHolds V.veridicality p w := rfl
 
-theorem DoxasticPredicate.toPrProp_assertion {W E : Type*}
+theorem DoxasticPredicate.toPartialProp_assertion {W E : Type*}
     (V : DoxasticPredicate W E) (agent : E) (p : W → Prop)
     (w : W) (worlds : List W) :
-    (V.toPrProp agent p worlds).assertion w =
+    (V.toPartialProp agent p worlds).assertion w =
     boxAt V.access agent w worlds p := rfl
 
-/-- PrProp for a hypothetical contrafactive verb: presupposes ¬p,
+/-- PartialProp for a hypothetical contrafactive verb: presupposes ¬p,
     asserts agent believes p. UNATTESTED — see [glass-2025]. -/
-def contrafactivePrProp {W E : Type*} (R : AccessRel W E) (agent : E)
-    (p : W → Prop) (worlds : List W) : PrProp W :=
+def contrafactivePartialProp {W E : Type*} (R : AccessRel W E) (agent : E)
+    (p : W → Prop) (worlds : List W) : PartialProp W :=
   { presup := λ w => ¬ p w
   , assertion := λ w => boxAt R agent w worlds p }
 

--- a/Linglib/Semantics/Conditionals/Presupposition.lean
+++ b/Linglib/Semantics/Conditionals/Presupposition.lean
@@ -79,11 +79,11 @@ def trivialCloser : W → W → W → Bool := fun _ _ _ => true
   p-worlds (contrast with K/P's LOCAL check)
 - **Assertion**: q holds at all CLOS-closest p-worlds
 
-When the antecedent p has no presupposition, use `PrProp.ofProp`.
+When the antecedent p has no presupposition, use `PartialProp.ofProp`.
 Requires `[DecidablePred p.assertion]` for `List.filter`. -/
 def ifPresup [DecidableEq W] (closer : W → W → W → Bool)
-    (restriction : List W) (p : PrProp W) (q : PrProp W)
-    [DecidablePred p.assertion] : PrProp W where
+    (restriction : List W) (p : PartialProp W) (q : PartialProp W)
+    [DecidablePred p.assertion] : PartialProp W where
   presup := fun w =>
     p.presup w ∧
     let closest := closB closer restriction
@@ -110,8 +110,8 @@ The difference from K/P* is entirely in the inner presupposition:
 K/P checks locally at w, K/P* checks globally via CLOS.
 Requires `[DecidablePred p.assertion]` for `List.filter`. -/
 def ifKP [DecidableEq W] (restriction : List W)
-    (p : PrProp W) (q : PrProp W)
-    [DecidablePred p.assertion] : PrProp W where
+    (p : PartialProp W) (q : PartialProp W)
+    [DecidablePred p.assertion] : PartialProp W where
   presup := fun w =>
     p.presup w ∧ (p.assertion w → q.presup w)
   assertion := fun _w =>
@@ -146,7 +146,7 @@ def orProperties {E : Type*} [DecidableEq (E → Bool)]
 
 Used in `orPresup`: the CLOS-based disjunction checks presuppositions at
 closest worlds where the OTHER disjunct is defined-and-false. -/
-def definedFalse (p : PrProp W) : Set W :=
+def definedFalse (p : PartialProp W) : Set W :=
   fun w => p.presup w ∧ ¬p.assertion w
 
 /-- K/P* presuppositional conjunction ([sharvit-2025], (127)).
@@ -160,8 +160,8 @@ The asymmetry mirrors K/P's `andFilter`, but uses CLOS-based rather than
 local presupposition checking.
 Requires `[DecidablePred p.assertion]` for `List.filter`. -/
 def andPresup [DecidableEq W] (closer : W → W → W → Bool)
-    (restriction : List W) (p q : PrProp W)
-    [DecidablePred p.assertion] : PrProp W where
+    (restriction : List W) (p q : PartialProp W)
+    [DecidablePred p.assertion] : PartialProp W where
   presup := fun w =>
     p.presup w ∧ q.presup w ∧
     let closest := closB closer restriction
@@ -190,10 +190,10 @@ connectives, (142)) which operates at the property level.
 Requires `[DecidablePred p.assertion] [DecidablePred q.assertion]` and
 decidability of `definedFalse` for `List.filter`. -/
 def orPresup [DecidableEq W] (closer : W → W → W → Bool)
-    (restriction : List W) (p q : PrProp W)
+    (restriction : List W) (p q : PartialProp W)
     [DecidablePred p.assertion] [DecidablePred q.assertion]
     [DecidablePred (definedFalse p)] [DecidablePred (definedFalse q)]
-    : PrProp W where
+    : PartialProp W where
   presup := fun w =>
     let closP := closB closer restriction
       (restriction.filter (fun w => decide (p.assertion w))) w
@@ -236,9 +236,9 @@ def clos (closer : W → W → W → Prop)
 
 This is Sharvit's observation that K/P's `or` does not distinguish
 left from right. -/
-theorem orPositive_symmetric (p q : PrProp W) (w : W) :
-    (PrProp.orPositive p q).presup w ↔ (PrProp.orPositive q p).presup w := by
-  simp only [PrProp.orPositive]
+theorem orPositive_symmetric (p q : PartialProp W) (w : W) :
+    (PartialProp.orPositive p q).presup w ↔ (PartialProp.orPositive q p).presup w := by
+  simp only [PartialProp.orPositive]
   tauto
 
 /-- K/P*'s inner presupposition (CLOS) entails K/P's inner presupposition
@@ -253,7 +253,7 @@ dominates any world. Without it, the theorem is false: a non-trivial
 ordering can exclude w from CLOS even when p(w). -/
 theorem kpstar_presup_implies_kp_presup [DecidableEq W]
     (closer : W → W → W → Bool) (restriction : List W)
-    (p : PrProp W) (q : PrProp W) (w : W)
+    (p : PartialProp W) (q : PartialProp W) (w : W)
     [DecidablePred p.assertion]
     (hp : p.assertion w)
     (hw : w ∈ closB closer restriction
@@ -270,7 +270,7 @@ Witness: w₀ where p is false and q.presup holds (K/P vacuously satisfied),
 but some p-world w₁ has q.presup = false (K/P* fails globally). -/
 theorem kp_presup_does_not_imply_kpstar :
     ∃ (W : Type) (_ : DecidableEq W) (restriction : List W)
-      (p : PrProp W) (q : PrProp W)
+      (p : PartialProp W) (q : PartialProp W)
       (_ : DecidablePred p.assertion)
       (w : W),
       (ifKP restriction p q).presup w ∧

--- a/Linglib/Semantics/ContentLayer.lean
+++ b/Linglib/Semantics/ContentLayer.lean
@@ -14,7 +14,7 @@ condition carries a label — `pr` (presupposition), `fr` (at-issue), or
 module extracts the layer system as a standalone type that unifies several
 existing linglib distinctions:
 
-- `PrProp` (presup + assertion) is the 2-layer special case (`pr` + `fr`)
+- `PartialProp` (presup + assertion) is the 2-layer special case (`pr` + `fr`)
 - `Challengeability` (directDenial vs hwamChallenge) identifies which layer
   is targeted by a discourse challenge
 - `AtIssueness` (atIssue vs notAtIssue) classifies content by whether it
@@ -32,7 +32,7 @@ existing linglib distinctions:
 
 ## Design Note
 
-`ContentLayer` lives in `Semantics/` because it generalizes `PrProp`.
+`ContentLayer` lives in `Semantics/` because it generalizes `PartialProp`.
 Bridges to `Discourse/AtIssueness` and `Phenomena/Presupposition/
 ProjectiveContent.Challengeability` live downstream in bridge files,
 preserving the independence of `Semantics/` and `Discourse/`.
@@ -90,8 +90,8 @@ inductive ContentLayer where
 
 /-- A full layered proposition: content at each layer.
 
-    Generalizes `PrProp` from 2 layers to 3. When `implicature` is trivially
-    true, a `LayeredProp` degenerates to a `PrProp`. -/
+    Generalizes `PartialProp` from 2 layers to 3. When `implicature` is trivially
+    true, a `LayeredProp` degenerates to a `PartialProp`. -/
 structure LayeredProp (W : Type*) where
   /-- Presuppositional content (must hold for definedness). -/
   presupposition : W → Bool
@@ -99,7 +99,7 @@ structure LayeredProp (W : Type*) where
   atIssue : W → Bool
   /-- Implicature content (enrichment beyond truth conditions). Trivially
       true by default: most utterances carry no relevant implicature, just
-      as `PrProp.ofProp` sets presupposition to `λ _ => True`. -/
+      as `PartialProp.ofProp` sets presupposition to `λ _ => True`. -/
   implicature : W → Bool := λ _ => true
 
 /-- Access a layer's content by its tag. -/
@@ -109,40 +109,40 @@ def LayeredProp.get {W : Type*} (lp : LayeredProp W) : ContentLayer → (W → B
   | .implicature => lp.implicature
 
 -- ════════════════════════════════════════════════════
--- § Bridge to PrProp
+-- § Bridge to PartialProp
 -- ════════════════════════════════════════════════════
 
 open Semantics.Presupposition in
-/-- Project a `LayeredProp` to a `PrProp` by discarding the implicature layer.
+/-- Project a `LayeredProp` to a `PartialProp` by discarding the implicature layer.
 
-    This is the canonical projection: `PrProp` is the 2-layer special case
+    This is the canonical projection: `PartialProp` is the 2-layer special case
     where implicature is invisible. -/
-def LayeredProp.toPrProp {W : Type*} (lp : LayeredProp W) : PrProp W :=
+def LayeredProp.toPartialProp {W : Type*} (lp : LayeredProp W) : PartialProp W :=
   { presup := fun w => lp.presupposition w = true
   , assertion := fun w => lp.atIssue w = true }
 
 open Semantics.Presupposition Classical in
-/-- Lift a `PrProp` to a `LayeredProp` with trivially true implicature.
+/-- Lift a `PartialProp` to a `LayeredProp` with trivially true implicature.
 
-    This is the canonical embedding: every `PrProp` is a `LayeredProp` with
+    This is the canonical embedding: every `PartialProp` is a `LayeredProp` with
     no implicature content. Noncomputable because Prop → Bool requires
     classical decidability. -/
-noncomputable def LayeredProp.ofPrProp {W : Type*} (p : PrProp W) : LayeredProp W :=
+noncomputable def LayeredProp.ofPartialProp {W : Type*} (p : PartialProp W) : LayeredProp W :=
   { presupposition := fun w => if p.presup w then true else false
   , atIssue := fun w => if p.assertion w then true else false
   , implicature := λ _ => true }
 
 open Semantics.Presupposition Classical in
-/-- The round-trip `PrProp → LayeredProp → PrProp` is the identity.
+/-- The round-trip `PartialProp → LayeredProp → PartialProp` is the identity.
 
-    This confirms that `PrProp` embeds faithfully into `LayeredProp`:
+    This confirms that `PartialProp` embeds faithfully into `LayeredProp`:
     no information is lost or added in the embedding. -/
-theorem LayeredProp.roundtrip_prprop {W : Type*} (p : PrProp W) :
-    (LayeredProp.ofPrProp p).toPrProp = p := by
+theorem LayeredProp.roundtrip_prprop {W : Type*} (p : PartialProp W) :
+    (LayeredProp.ofPartialProp p).toPartialProp = p := by
   ext w
-  · simp only [ofPrProp, toPrProp]
+  · simp only [ofPartialProp, toPartialProp]
     by_cases h : p.presup w <;> simp [h]
-  · simp only [ofPrProp, toPrProp]
+  · simp only [ofPartialProp, toPartialProp]
     by_cases h : p.assertion w <;> simp [h]
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Semantics/Definiteness/Basic.lean
+++ b/Linglib/Semantics/Definiteness/Basic.lean
@@ -15,8 +15,8 @@ the library. The denotational layer itself lives in two canonical pieces:
 
 - `Semantics.Definiteness.russellIotaList` (the per-context referent selector,
   Russellian iota over a `List E` filtered by a `Bool` predicate), and
-- `Semantics.Presupposition.PrProp.presupOfReferent` (the combinator lifting a
-  referent selector and a scope predicate into a `PrProp W`).
+- `Semantics.Presupposition.PartialProp.presupOfReferent` (the combinator lifting a
+  referent selector and a scope predicate into a `PartialProp W`).
 
 All variants — uniqueness-based, familiarity-based, anaphoric (ι^x),
 discourse-restricted, situation-relative — are obtained by composing these
@@ -44,7 +44,7 @@ namespace Semantics.Definiteness
 open Core.Logic.Intensional (Ty)
 open Semantics.Quantification.Quantifier (every_sem some_sem Ty.det)
 open Semantics.Composition.TypeShifting (iota lift)
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open Features.Definiteness (DefPresupType Definiteness)
 
 -- ============================================================================

--- a/Linglib/Semantics/Dynamic/Postsupposition.lean
+++ b/Linglib/Semantics/Dynamic/Postsupposition.lean
@@ -19,7 +19,7 @@ namespace Semantics.Dynamic.Postsupposition
 /-- A postsupposition: a constraint on the output context after a
     discourse update.
 
-    Unlike presuppositions (input-context constraints on `PrProp.presup`),
+    Unlike presuppositions (input-context constraints on `PartialProp.presup`),
     postsuppositions constrain what must hold of the context *after* the
     at-issue content updates it.
 

--- a/Linglib/Semantics/Entailment/PresuppositionLicensing.lean
+++ b/Linglib/Semantics/Entailment/PresuppositionLicensing.lean
@@ -40,7 +40,7 @@ namespace Semantics.Entailment.PresuppositionLicensing
 /-- A **Karttunen-Peters operator**: a function from an argument set to
     a presuppositional proposition (truth + presup). The presupposition
     may depend on the argument (per K&P 1979's heritage function). -/
-abbrev KPOperator (W : Type*) : Type _ := Set W → Semantics.Presupposition.PrProp W
+abbrev KPOperator (W : Type*) : Type _ := Set W → Semantics.Presupposition.PartialProp W
 
 /-- The truth-conditional projection of a K&P operator. -/
 def KPOperator.truth {W : Type*} (op : KPOperator W) : Set W → Set W :=

--- a/Linglib/Semantics/Entailment/PresuppositionPolarity.lean
+++ b/Linglib/Semantics/Entailment/PresuppositionPolarity.lean
@@ -47,7 +47,7 @@ This function captures that basic behavior.
 More complex interactions (e.g., presupposition strengthening under
 negation) would require extending this.
 -/
-def presupProjectsAt (_ctx : ContextPolarity) (p : PrProp W) : Set W :=
+def presupProjectsAt (_ctx : ContextPolarity) (p : PartialProp W) : Set W :=
   p.presup
 
 /--
@@ -60,16 +60,16 @@ doesn't depend on whether we're in a UE or DE context.
 The polarity-dependence enters only in which *alternatives* we consider
 for exhaustification, not in the projection algorithm itself.
 -/
-theorem impFilter_presup_polarity_independent (p q : PrProp W) :
-    presupProjectsAt .upward (PrProp.impFilter p q) =
-    presupProjectsAt .downward (PrProp.impFilter p q) := rfl
+theorem impFilter_presup_polarity_independent (p q : PartialProp W) :
+    presupProjectsAt .upward (PartialProp.impFilter p q) =
+    presupProjectsAt .downward (PartialProp.impFilter p q) := rfl
 
 /--
 Negation preserves presupposition regardless of polarity.
 -/
-theorem neg_presup_polarity_independent (p : PrProp W) :
-    presupProjectsAt .upward (PrProp.neg p) =
-    presupProjectsAt .downward (PrProp.neg p) := rfl
+theorem neg_presup_polarity_independent (p : PartialProp W) :
+    presupProjectsAt .upward (PartialProp.neg p) =
+    presupProjectsAt .downward (PartialProp.neg p) := rfl
 
 
 /--

--- a/Linglib/Semantics/Entailment/StrawsonEntailment.lean
+++ b/Linglib/Semantics/Entailment/StrawsonEntailment.lean
@@ -184,10 +184,10 @@ Von Fintel's key observation: `only` is NOT classically DE
 -/
 
 /--
-"Only x VP" as a `PrProp`: Horn's asymmetric decomposition.
+"Only x VP" as a `PartialProp`: Horn's asymmetric decomposition.
 -/
-def onlyPrProp {W : Type*} (x : W → Prop) (scope : Set W) :
-    Semantics.Presupposition.PrProp W where
+def onlyPartialProp {W : Type*} (x : W → Prop) (scope : Set W) :
+    Semantics.Presupposition.PartialProp W where
   presup := fun _ => ∃ y, x y ∧ scope y
   assertion := fun _ => ∀ y, x y ∨ ¬ scope y
 
@@ -195,15 +195,15 @@ def onlyPrProp {W : Type*} (x : W → Prop) (scope : Set W) :
 The full "only" meaning: presupposition + assertion combined.
 
 "Only x VP" is true at w iff x satisfies VP AND no one else does.
-By construction, `onlyFull x scope w ↔ (onlyPrProp x scope).presup w ∧
-(onlyPrProp x scope).assertion w` (`Iff.rfl`).
+By construction, `onlyFull x scope w ↔ (onlyPartialProp x scope).presup w ∧
+(onlyPartialProp x scope).assertion w` (`Iff.rfl`).
 -/
 def onlyFull {W : Type*} (x : W → Prop) (scope : Set W) : Set W :=
   fun _w => (∃ y, x y ∧ scope y) ∧ (∀ y, x y ∨ ¬ scope y)
 
 theorem onlyFull_eq_prprop {W : Type*} (x : W → Prop) (scope : Set W) (w : W) :
     onlyFull x scope w ↔
-    (onlyPrProp x scope).presup w ∧ (onlyPrProp x scope).assertion w :=
+    (onlyPartialProp x scope).presup w ∧ (onlyPartialProp x scope).assertion w :=
   Iff.rfl
 
 /--

--- a/Linglib/Semantics/Exhaustification/Presuppositional.lean
+++ b/Linglib/Semantics/Exhaustification/Presuppositional.lean
@@ -41,7 +41,7 @@ assertive from presuppositional content.
 ## Architecture
 
 `pexIEII` takes the same IE/II computation from `Operators.lean` and
-produces a `PrProp World` — a Prop-based partial proposition with separate
+produces a `PartialProp World` — a Prop-based partial proposition with separate
 assertive and presuppositional components. This directly integrates with
 the presupposition projection infrastructure in `Semantics.Presupposition`.
 
@@ -57,7 +57,7 @@ puzzles from §3–§5 — live in the study file
 namespace Exhaustification.Presuppositional
 
 open Exhaustification
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 
 variable {World : Type*}
 
@@ -120,13 +120,13 @@ all alternatives are relevant.
 /-- **pex^{IE+II}**: Presuppositional exhaustification with IE and II.
 
     Unlike `exhIEII` which returns `Set World` (flat, fully assertive),
-    `pexIEII` returns `PrProp World` (assertive + presuppositional).
+    `pexIEII` returns `PartialProp World` (assertive + presuppositional).
 
     - **assertion** = φ (the prejacent)
     - **presupposition** = (negation of relevant IE alternatives) ∧
                            (homogeneity of relevant II alternatives) -/
 def pexIEII (ALT : Set (Set World)) (φ : Set World)
-    (Rc : Set (Set World)) : PrProp World where
+    (Rc : Set (Set World)) : PartialProp World where
   assertion := φ
   presup := fun w =>
     -- (i) all relevant IE alternatives are false
@@ -135,7 +135,7 @@ def pexIEII (ALT : Set (Set World)) (φ : Set World)
     homogeneous {α ∈ II ALT φ | α ∈ Rc} w
 
 /-- pex with all alternatives relevant (the default case). -/
-def pexIEII_full (ALT : Set (Set World)) (φ : Set World) : PrProp World :=
+def pexIEII_full (ALT : Set (Set World)) (φ : Set World) : PartialProp World :=
   pexIEII ALT φ ALT
 
 -- ============================================================================
@@ -259,7 +259,7 @@ puzzles, see `Studies/DelPinalBassiSauerland2024.lean`.
 /-!
 ## Bridge: pex outputs as `Implicature W Prop`
 
-Wraps a `PrProp W` (the pex output type) as an `Implicature W Prop` whose
+Wraps a `PartialProp W` (the pex output type) as an `Implicature W Prop` whose
 `content` is the presupposed component, with mechanism
 `.bpsPresuppositional`.
 
@@ -276,11 +276,11 @@ formal content.
 **Substantive (`bps_neg_not_cancellable`).** With assertion =
 `p.neg.holds` (i.e., the *negation* of the pex output), non-cancellability
 still holds — because `(p.neg).presup = p.presup` by the projecting
-construction of `PrProp.neg`. This is the formal counterpart to BPS's
+construction of `PartialProp.neg`. This is the formal counterpart to BPS's
 *family-of-sentences* test for projection: the inferred content survives
-embedding under negation. Replacing `PrProp.neg` with a non-projecting
+embedding under negation. Replacing `PartialProp.neg` with a non-projecting
 alternative (e.g. `negExt`) breaks this theorem; it depends on the
-structural projection identity `PrProp.neg_presup`, not just on `And`.
+structural projection identity `PartialProp.neg_presup`, not just on `And`.
 
 Together these track the difference [bassi-delpinal-sauerland-2021]
 draws between "assertion entails inference" (cheap: also true of any
@@ -290,7 +290,7 @@ flat-EXH assertion paired with its consequence) and "inference projects"
 
 open Semantics.Presupposition
 
-/-- Wrap a `PrProp W` (e.g. a pex output) as an `Implicature W Prop` whose
+/-- Wrap a `PartialProp W` (e.g. a pex output) as an `Implicature W Prop` whose
 content is the presupposed component. Callers supply `kind` via record
 update (`{ bpsToImplicature alts p with kind := .freeChoice }`) — the
 default `.scalar` is rarely the right choice and forcing the update
@@ -298,7 +298,7 @@ prevents the incoherent `kind := .manner` case (manner implicatures are
 form-relative, never pex outputs). The `mechanism` is fixed to
 `.bpsPresuppositional`. -/
 def bpsToImplicature {W : Type*} (alts : Set (W → Prop))
-    (p : PrProp W) : Implicature W Prop where
+    (p : PartialProp W) : Implicature W Prop where
   kind      := .scalar
   content   := p.presup
   altsUsed  := alts
@@ -309,28 +309,28 @@ content = `p.presup`. The proof unfolds to the trivial direction of
 `holds := presup ∧ assertion`; the substantive content lives in the
 wrapper's choice to use `holds` (not `assertion`) as the assertion. -/
 theorem bps_not_cancellable {W : Type*}
-    (alts : Set (W → Prop)) (p : PrProp W) :
-    ¬ Implicature.IsCancellable (fun w => PrProp.holds w p)
+    (alts : Set (W → Prop)) (p : PartialProp W) :
+    ¬ Implicature.IsCancellable (fun w => PartialProp.holds w p)
                                 (bpsToImplicature alts p) :=
   Implicature.IsCancellable.false_of_assertion_implies_content (fun _ h => h.1)
 
 /-- **BPS non-cancellability — substantive form (projection through
 negation).** Even when the speaker asserts the negation of the pex
 output (`p.neg.holds`), the inferred content (`p.presup`) survives. The
-load-bearing step is `PrProp.neg_presup : (neg p).presup = p.presup` —
-a structural property of how `PrProp.neg` is constructed, not a logical
+load-bearing step is `PartialProp.neg_presup : (neg p).presup = p.presup` —
+a structural property of how `PartialProp.neg` is constructed, not a logical
 tautology. This formalizes the family-of-sentences projection test that
 BPS contrasts with flat-EXH grammaticalism: pex content projects through
-negation; flat-EXH content does not. Swapping `PrProp.neg` for the
-external Bochvar negation `PrProp.negExt` (which is also defined in the
+negation; flat-EXH content does not. Swapping `PartialProp.neg` for the
+external Bochvar negation `PartialProp.negExt` (which is also defined in the
 substrate) would falsify this theorem. -/
 theorem bps_neg_not_cancellable {W : Type*}
-    (alts : Set (W → Prop)) (p : PrProp W) :
-    ¬ Implicature.IsCancellable (fun w => PrProp.holds w p.neg)
+    (alts : Set (W → Prop)) (p : PartialProp W) :
+    ¬ Implicature.IsCancellable (fun w => PartialProp.holds w p.neg)
                                 (bpsToImplicature alts p) :=
   -- `h.1 : (p.neg).presup w` is definitionally `p.presup w` because
-  -- `PrProp.neg.presup := p.presup` (Semantics.Presupposition:185-186).
-  -- This is the projection identity `PrProp.neg_presup` in concrete form.
+  -- `PartialProp.neg.presup := p.presup` (Semantics.Presupposition:185-186).
+  -- This is the projection identity `PartialProp.neg_presup` in concrete form.
   Implicature.IsCancellable.false_of_assertion_implies_content (fun _ h => h.1)
 
 end Exhaustification.Presuppositional

--- a/Linglib/Semantics/Kinds/MeaningPreservation.lean
+++ b/Linglib/Semantics/Kinds/MeaningPreservation.lean
@@ -343,7 +343,7 @@ type-shift converts this intensional property into a different semantic type:
 
 These connect the abstract shift-selection machinery to Chierchia's `down`
 operator and the `Semantics.Definiteness.russellIotaList` /
-`Semantics.Presupposition.PrProp.presupOfReferent` canonical pieces consumed by
+`Semantics.Presupposition.PartialProp.presupOfReferent` canonical pieces consumed by
 `Semantics/Definiteness/Basic.lean`.
 -/
 

--- a/Linglib/Semantics/Modality/Kernel.lean
+++ b/Linglib/Semantics/Modality/Kernel.lean
@@ -408,26 +408,26 @@ theorem partition_implies_entailment [Fintype W] (k : Kernel W) (φ : (W → Pro
 /-! ## Modal operators ([von-fintel-gillies-2010] Defs 5–6) -/
 
 /-- ⟦must φ⟧: presupposes K doesn't settle φ; asserts B_K ⊆ ⟦φ⟧. -/
-def kernelMust (k : Kernel W) (φ : (W → Prop)) : PrProp W where
+def kernelMust (k : Kernel W) (φ : (W → Prop)) : PartialProp W where
   presup := λ _ => ¬ directlySettlesExplicit k φ
   assertion := λ _ => k.followsFrom φ
 
 /-- ⟦might φ⟧: presupposes K doesn't settle φ; asserts B_K ∩ ⟦φ⟧ ≠ ∅. -/
-def kernelMight (k : Kernel W) (φ : (W → Prop)) : PrProp W where
+def kernelMight (k : Kernel W) (φ : (W → Prop)) : PartialProp W where
   presup := λ _ => ¬ directlySettlesExplicit k φ
   assertion := λ _ => k.compatibleWith φ
 
 /-- ⟦can't φ⟧ = must(¬φ). -/
-def kernelCant (k : Kernel W) (φ : (W → Prop)) : PrProp W :=
+def kernelCant (k : Kernel W) (φ : (W → Prop)) : PartialProp W :=
   kernelMust k (λ w => ¬ φ w)
 
 /-- W-dependent ⟦must φ⟧. -/
-def kernelMustW (kb : KernelBackground W) (φ : (W → Prop)) : PrProp W where
+def kernelMustW (kb : KernelBackground W) (φ : (W → Prop)) : PartialProp W where
   presup := λ w => ¬ directlySettlesExplicit (kb w) φ
   assertion := λ w => (kb w).followsFrom φ
 
 /-- W-dependent ⟦might φ⟧. -/
-def kernelMightW (kb : KernelBackground W) (φ : (W → Prop)) : PrProp W where
+def kernelMightW (kb : KernelBackground W) (φ : (W → Prop)) : PartialProp W where
   presup := λ w => ¬ directlySettlesExplicit (kb w) φ
   assertion := λ w => (kb w).compatibleWith φ
 

--- a/Linglib/Semantics/Presupposition/Basic.lean
+++ b/Linglib/Semantics/Presupposition/Basic.lean
@@ -11,13 +11,13 @@ points. References: [heim-1983], [schlenker-2009], [von-fintel-1999],
 
 ## Main declarations
 
-* `PrProp W` — partial proposition with `presup, assertion : W → Prop`.
+* `PartialProp W` — partial proposition with `presup, assertion : W → Prop`.
   The canonical type for partial propositions. Fields are `Prop`-valued
   following the mathlib convention.
-* `PrValue W α` — presupposed value polymorphic in the at-issue content
+* `PartialValue W α` — presupposed value polymorphic in the at-issue content
   type (`α = ℚ` for degrees, `α = E` for entities). Presupposition is
   also `W → Prop`.
-* Connective families on `PrProp W`: classical (`and`, `or`, `imp`, `xor`),
+* Connective families on `PartialProp W`: classical (`and`, `or`, `imp`, `xor`),
   filtering / Karttunen (`andFilter`, `impFilter`, `orFilter`), K&P
   symmetric disjunction (`orKPSymmetric`), positive-antecedent
   disjunction (`orPositive`, a documented rival), Weak Kleene (`andWeak`,
@@ -35,8 +35,8 @@ points. References: [heim-1983], [schlenker-2009], [von-fintel-1999],
 
 ## Implementation notes
 
-`PrProp W` is parametric over the evaluation point. Common instantiations:
-`PrProp World` (classical possible worlds), `PrProp (Possibility W E)`
+`PartialProp W` is parametric over the evaluation point. Common instantiations:
+`PartialProp World` (classical possible worlds), `PartialProp (Possibility W E)`
 (dynamic world-assignment pairs).
 
 The choice of connective system (how gaps behave under ∧/∨) is orthogonal
@@ -52,10 +52,10 @@ idiom in logic-heavy files such as `Mathlib/Order/Filter/Basic.lean`.
 
 * Add a genuine Strong Kleene `orStrong`/`andStrong` (where `T ∨ #` is
   defined as `T`). The current `orWeak`/`andWeak` are Weak Kleene only.
-* `PrProp W = PrValue W Prop` unification: `PrValue` already generalizes
-  `PrProp` at the type level; unifying would let the connective zoo lift
+* `PartialProp W = PartialValue W Prop` unification: `PartialValue` already generalizes
+  `PartialProp` at the type level; unifying would let the connective zoo lift
   to arbitrary at-issue carriers.
-* `evalLift : (Truth3 → Truth3 → Truth3) → (PrProp W → PrProp W → PrProp W)`
+* `evalLift : (Truth3 → Truth3 → Truth3) → (PartialProp W → PartialProp W → PartialProp W)`
   would collapse `andWeak`, `orWeak`, `xor`, `andBelnap`, `orBelnap` into
   one definition each, with one bridge theorem instead of eight.
 -/
@@ -67,35 +67,35 @@ open Core.Duality
 /-- A presupposed value: a value that is only defined when its
 presupposition holds.
 
-`PrValue W α` generalizes presuppositional propositions: the
+`PartialValue W α` generalizes presuppositional propositions: the
 presupposition is `W → Prop`, and the at-issue content is any type — a
 truth value (`Bool`), a degree (`ℚ`), a measure, etc.
 
 Linguistic motivation: many presupposition triggers return non-boolean
 values. The revised *per* entry ([bale-schwarz-2022], eq. 43)
 returns a presupposed pure number (`ℚ`). Definite descriptions return
-presupposed entities. `PrValue` handles all of these uniformly. -/
-structure PrValue (W : Type*) (α : Type*) where
+presupposed entities. `PartialValue` handles all of these uniformly. -/
+structure PartialValue (W : Type*) (α : Type*) where
   /-- The presupposition (must hold for definedness). -/
   presup : W → Prop
   /-- The at-issue content (value). -/
   value : W → α
 
-namespace PrValue
+namespace PartialValue
 
 variable {W : Type*} {α : Type*}
 
 /-- A presupposed value is defined at w iff its presupposition holds. -/
-def defined (w : W) (pv : PrValue W α) : Prop := pv.presup w
+def defined (w : W) (pv : PartialValue W α) : Prop := pv.presup w
 
 /-- Create a presuppositionless value (always defined). -/
-def pure (a : W → α) : PrValue W α where
+def pure (a : W → α) : PartialValue W α where
   presup := fun _ => True
   value := a
 
-end PrValue
+end PartialValue
 
-/-! ### `PrProp`: Prop-based partial propositions -/
+/-! ### `PartialProp`: Prop-based partial propositions -/
 
 /-- A presuppositional proposition: assertion + presupposition.
 
@@ -103,13 +103,13 @@ end PrValue
     directly with `{ presup := ..., assertion := ... }`; for finite worlds
     with `DecidableEq`, the predicates are auto-decidable. -/
 @[ext]
-structure PrProp (W : Type*) where
+structure PartialProp (W : Type*) where
   /-- The presupposition (must hold for definedness). -/
   presup : W → Prop
   /-- The at-issue content (assertion). -/
   assertion : W → Prop
 
-namespace PrProp
+namespace PartialProp
 
 open Classical
 
@@ -118,26 +118,26 @@ variable {W : Type*}
 /-! ### Constructors -/
 
 /-- Create a presuppositionless proposition from a `W → Prop`. -/
-def ofProp (p : W → Prop) : PrProp W where
+def ofProp (p : W → Prop) : PartialProp W where
   presup := fun _ => True
   assertion := p
 
-/-- Convert a three-valued proposition to a PrProp.
-    Inverse of `PrProp.eval`: defined iff value ≠ indet,
+/-- Convert a three-valued proposition to a PartialProp.
+    Inverse of `PartialProp.eval`: defined iff value ≠ indet,
     assertion iff value = true. -/
-def ofProp3 (p : Prop3 W) : PrProp W where
+def ofProp3 (p : Prop3 W) : PartialProp W where
   presup := fun w => p w ≠ .indet
   assertion := fun w => p w = .true
 
-/-- Convert a presupposed Bool value (`PrValue W Bool`) to `PrProp W`. -/
-def ofPrValue (pv : PrValue W Bool) : PrProp W where
+/-- Convert a presupposed Bool value (`PartialValue W Bool`) to `PartialProp W`. -/
+def ofPartialValue (pv : PartialValue W Bool) : PartialProp W where
   presup := pv.presup
   assertion := fun w => pv.value w = true
 
-/-- Convert a `PrProp` to a `PrValue W Prop`. Computable — both the
+/-- Convert a `PartialProp` to a `PartialValue W Prop`. Computable — both the
     source and target store presuppositions and content as `Prop`-valued
     functions, so no `decide` plumbing is required. -/
-def toPrValue (p : PrProp W) : PrValue W Prop where
+def toPartialValue (p : PartialProp W) : PartialValue W Prop where
   presup := p.presup
   value := p.assertion
 
@@ -146,7 +146,7 @@ def toPrValue (p : PrProp W) : PrValue W Prop where
     Assertive_w iff A is true at w; what is asserted = B.
     [belnap-1970], (3): "(A/B) is assertive_w just in case
     A is true_w. (A/B)_w = B_w." -/
-def condAssert (A B : W → Prop) : PrProp W where
+def condAssert (A B : W → Prop) : PartialProp W where
   presup := A
   assertion := B
 
@@ -154,31 +154,31 @@ def condAssert (A B : W → Prop) : PrProp W where
 
 /-- Full satisfaction relation: both presupposition and assertion hold.
 
-    Argument order `(w : W) (p : PrProp W)` supports `updateFromSat`:
-    `updateFromSat PrProp.holds p` gives the full CCP (presupposition
+    Argument order `(w : W) (p : PartialProp W)` supports `updateFromSat`:
+    `updateFromSat PartialProp.holds p` gives the full CCP (presupposition
     test + assertion filter). -/
-def holds (w : W) (p : PrProp W) : Prop := p.presup w ∧ p.assertion w
+def holds (w : W) (p : PartialProp W) : Prop := p.presup w ∧ p.assertion w
 
 /-- Definedness relation: presupposition holds at the evaluation point.
 
-    Argument order `(w : W) (p : PrProp W)` supports `updateFromSat`:
-    `updateFromSat PrProp.defined p` gives the presupposition test CCP. -/
-def defined (w : W) (p : PrProp W) : Prop := p.presup w
+    Argument order `(w : W) (p : PartialProp W)` supports `updateFromSat`:
+    `updateFromSat PartialProp.defined p` gives the presupposition test CCP. -/
+def defined (w : W) (p : PartialProp W) : Prop := p.presup w
 
 /-! ### Constants -/
 
 /-- Create a tautological presupposition. -/
-def top : PrProp W where
+def top : PartialProp W where
   presup := fun _ => True
   assertion := fun _ => True
 
 /-- Create a contradictory presupposition. -/
-def bot : PrProp W where
+def bot : PartialProp W where
   presup := fun _ => True
   assertion := fun _ => False
 
 /-- Create a presupposition failure (never defined). -/
-def undefined : PrProp W where
+def undefined : PartialProp W where
   presup := fun _ => False
   assertion := fun _ => False
 
@@ -187,7 +187,7 @@ def undefined : PrProp W where
 /-- Evaluate a presuppositional proposition to three-valued truth.
     Noncomputable because it decides Prop-valued presupposition and
     assertion via classical logic. -/
-noncomputable def eval (p : PrProp W) : Prop3 W := fun w =>
+noncomputable def eval (p : PartialProp W) : Prop3 W := fun w =>
   if p.presup w then
     if p.assertion w then .true else .false
   else .indet
@@ -196,7 +196,7 @@ noncomputable def eval (p : PrProp W) : Prop3 W := fun w =>
 
 /-- Classical (internal / choice) negation: a hole.
     Lets the presupposition through unchanged. -/
-def neg (p : PrProp W) : PrProp W where
+def neg (p : PartialProp W) : PartialProp W where
   presup := p.presup
   assertion := fun w => ¬p.assertion w
 
@@ -205,7 +205,7 @@ def neg (p : PrProp W) : PrProp W where
     [karttunen-1973] §10 fn 18: `t(A)` has truth-table
     `T → T`, `F → F`, `# → F`. Composing classical negation with `t`
     yields external negation: `negExt p = neg (truthOp p)`. -/
-def truthOp (p : PrProp W) : PrProp W where
+def truthOp (p : PartialProp W) : PartialProp W where
   presup := fun _ => True
   assertion := fun w => p.presup w ∧ p.assertion w
 
@@ -213,20 +213,20 @@ def truthOp (p : PrProp W) : PrProp W where
     Always defined; true when `p` is false or undefined, false only when
     `p` is true. Equals `neg (truthOp p)` per [karttunen-1973] §10
     fn 18: `⌜¬A⌝ ≡ ⌜~t(A)⌝`. -/
-def negExt (p : PrProp W) : PrProp W := neg (truthOp p)
+def negExt (p : PartialProp W) : PartialProp W := neg (truthOp p)
 
 /-- Classical conjunction: both presuppositions must hold. -/
-def and (p q : PrProp W) : PrProp W where
+def and (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∧ q.presup w
   assertion := fun w => p.assertion w ∧ q.assertion w
 
 /-- Classical disjunction: both presuppositions must hold. -/
-def or (p q : PrProp W) : PrProp W where
+def or (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∧ q.presup w
   assertion := fun w => p.assertion w ∨ q.assertion w
 
 /-- Classical implication: both presuppositions must hold. -/
-def imp (p q : PrProp W) : PrProp W where
+def imp (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∧ q.presup w
   assertion := fun w => p.assertion w → q.assertion w
 
@@ -236,7 +236,7 @@ def imp (p q : PrProp W) : PrProp W where
     unconditionally (`xor_indet_iff`), so exclusive disjunction never
     filters presupposition failure from either disjunct.
     [wang-davidson-2026] -/
-def xor (p q : PrProp W) : PrProp W where
+def xor (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∧ q.presup w
   assertion := fun w => (p.assertion w ∧ ¬q.assertion w) ∨ (¬p.assertion w ∧ q.assertion w)
 
@@ -244,13 +244,13 @@ def xor (p q : PrProp W) : PrProp W where
 
 /-- Filtering conjunction ([karttunen-1973], [peters-1979]): the first
     conjunct can satisfy the second's presupposition. -/
-def andFilter (p q : PrProp W) : PrProp W where
+def andFilter (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∧ (p.assertion w → q.presup w)
   assertion := fun w => p.assertion w ∧ q.assertion w
 
 /-- Filtering implication ([karttunen-1973], [peters-1979]): the
     antecedent can satisfy the consequent's presupposition. -/
-def impFilter (p q : PrProp W) : PrProp W where
+def impFilter (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∧ (p.assertion w → q.presup w)
   assertion := fun w => p.assertion w → q.assertion w
 
@@ -263,7 +263,7 @@ def impFilter (p q : PrProp W) : PrProp W where
     Generalizes `disjFilterLeft` to a presuppositional first disjunct
     (`orFilter_ofProp`). The symmetric K&P variant is `orKPSymmetric`;
     the positive-antecedent variant is `orPositive`. -/
-def orFilter (p q : PrProp W) : PrProp W where
+def orFilter (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∧ (¬p.assertion w → q.presup w)
   assertion := fun w => p.assertion w ∨ q.assertion w
 
@@ -283,7 +283,7 @@ scoped infixl:60 " \\/' " => orFilter
     [sharvit-2025] identifies it as the root cause of K/P-style failure
     (`Studies/Sharvit2025.lean`), and [yagi-2025] §2.2 discusses the
     `Π(φ) ∨ Π(ψ)` conjunct as a candidate fix (`Studies/Yagi2025.lean`). -/
-def orPositive (p q : PrProp W) : PrProp W where
+def orPositive (p q : PartialProp W) : PartialProp W where
   presup := fun w =>
     (p.assertion w → q.presup w) ∧
     (q.assertion w → p.presup w) ∧
@@ -304,7 +304,7 @@ def orPositive (p q : PrProp W) : PrProp W where
     symmetrized variant standard in post-2021 literature, matching
     [yagi-2025] Definition 2 (cf. [kalomoiros-schwarz-2021] for
     experimental support of symmetry). -/
-def orKPSymmetric (p q : PrProp W) : PrProp W where
+def orKPSymmetric (p q : PartialProp W) : PartialProp W where
   presup := fun w => (q.assertion w ∨ p.presup w) ∧ (p.assertion w ∨ q.presup w)
   assertion := fun w => p.assertion w ∨ q.assertion w
 
@@ -314,12 +314,12 @@ def orKPSymmetric (p q : PrProp W) : PrProp W where
     Both disjuncts must be defined for the disjunction to be defined.
 
     [kleene-1952]: indet is absorbing for both ∧ and ∨. -/
-def orWeak (p q : PrProp W) : PrProp W where
+def orWeak (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∧ q.presup w
   assertion := fun w => p.assertion w ∨ q.assertion w
 
 /-- Weak Kleene conjunction. -/
-def andWeak (p q : PrProp W) : PrProp W where
+def andWeak (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∧ q.presup w
   assertion := fun w => p.assertion w ∧ q.assertion w
 
@@ -336,7 +336,7 @@ allows the disjunction to be false.
 
 Formally, this is the static counterpart of [yagi-2025]'s dynamic update.
 -/
-def orFlex (p q : PrProp W) : PrProp W where
+def orFlex (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∨ q.presup w
   assertion := fun w => (p.presup w ∧ p.assertion w) ∨ (q.presup w ∧ q.assertion w)
 
@@ -345,7 +345,7 @@ def orFlex (p q : PrProp W) : PrProp W where
 Each conjunct is evaluated only against worlds where its own presupposition
 holds. Undefined conjuncts are vacuously true (the identity element for ∧),
 so they don't constrain the result. Dual of `orFlex`. -/
-def andFlex (p q : PrProp W) : PrProp W where
+def andFlex (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∨ q.presup w
   assertion := fun w => (p.presup w → p.assertion w) ∧ (q.presup w → q.assertion w)
 
@@ -357,9 +357,9 @@ proposition asserts something at `w` (vs being nonassertive / silent). -/
 /-- Belnap conjunction: assertive iff at least one conjunct is assertive.
     What it asserts = conjunction of assertive conjuncts' content.
 
-    [belnap-1970], (8). Contrast with classical `PrProp.and` (both
-    must be defined) and filtering `PrProp.andFilter` (left-to-right). -/
-def andBelnap (p q : PrProp W) : PrProp W where
+    [belnap-1970], (8). Contrast with classical `PartialProp.and` (both
+    must be defined) and filtering `PartialProp.andFilter` (left-to-right). -/
+def andBelnap (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∨ q.presup w
   assertion := fun w =>
     (p.presup w → p.assertion w) ∧ (q.presup w → q.assertion w)
@@ -368,7 +368,7 @@ def andBelnap (p q : PrProp W) : PrProp W where
     What it asserts = disjunction of assertive disjuncts' content.
 
     [belnap-1970], (9). -/
-def orBelnap (p q : PrProp W) : PrProp W where
+def orBelnap (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∨ q.presup w
   assertion := fun w =>
     (p.presup w ∧ p.assertion w) ∨ (q.presup w ∧ q.assertion w)
@@ -376,7 +376,7 @@ def orBelnap (p q : PrProp W) : PrProp W where
 /-- **Belnap lift**: uniform construction for conditional assertion connectives.
 
     Given a binary Prop function `f` and its identity element `unit`,
-    constructs a PrProp connective where:
+    constructs a PartialProp connective where:
     - Defined (assertive) iff at least one operand is defined
     - Assertion applies `f` to each operand's content, substituting `unit`
       for undefined operands (making them "silent")
@@ -389,7 +389,7 @@ def orBelnap (p q : PrProp W) : PrProp W where
     - `belnapLift (· ∧ ·) True` = `andBelnap` = `andFlex` (True is identity for ∧)
     -/
 noncomputable def belnapLift (f : Prop → Prop → Prop) (unit : Prop)
-    (p q : PrProp W) : PrProp W where
+    (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∨ q.presup w
   assertion := fun w => f (if p.presup w then p.assertion w else unit)
                           (if q.presup w then q.assertion w else unit)
@@ -401,7 +401,7 @@ noncomputable def belnapLift (f : Prop → Prop → Prop) (unit : Prop)
     presupposition is a *premise* added to the entailment, not something
     the entailment delivers. Matches `Semantics.Dynamic.Bilateral.BUS`'s
     `strawsonEntails` (canonical Strawson). -/
-def strawsonEntails (p q : PrProp W) : Prop :=
+def strawsonEntails (p q : PartialProp W) : Prop :=
   ∀ w, p.presup w → q.presup w → p.assertion w → q.assertion w
 
 /-- Strong (Strawson-projecting) entailment: at every world where `p` is
@@ -410,11 +410,11 @@ def strawsonEntails (p q : PrProp W) : Prop :=
     presupposition projects from `p`'s satisfaction (so it embeds a
     presupposition-projection burden the canonical von Fintel form
     exempts). -/
-def strongEntails (p q : PrProp W) : Prop :=
+def strongEntails (p q : PartialProp W) : Prop :=
   ∀ w, p.presup w → p.assertion w → q.presup w ∧ q.assertion w
 
 /-- Strawson equivalence: mutual Strawson entailment. -/
-def strawsonEquiv (p q : PrProp W) : Prop :=
+def strawsonEquiv (p q : PartialProp W) : Prop :=
   strawsonEntails p q ∧ strawsonEntails q p
 
 /-! ### Genuineness / liveness ([zimmermann-2000], [geurts-2005], [katzir-singh-2012]) -/
@@ -426,7 +426,7 @@ def strawsonEquiv (p q : PrProp W) : Prop :=
     `{w}[φ] = {w}` for some `w ∈ s`. The disjunction-update side
     (`w ∈ s[φ ∨ ψ]`) is the additional constraint expressed by
     `genuineness` below. -/
-def liveness (p q : PrProp W) (s : Finset W) : Prop :=
+def liveness (p q : PartialProp W) (s : Finset W) : Prop :=
   (∃ w ∈ s, p.holds w) ∧
   (∃ w ∈ s, q.holds w)
 
@@ -451,14 +451,14 @@ def liveness (p q : PrProp W) (s : Finset W) : Prop :=
     framework-neutral; consumers supply the disjunction connective whose
     update they wish to test against (orFlex / orBelnap / classical or /
     Geurts modal split). -/
-def genuineness (p q : PrProp W) (s : Finset W) (disj : PrProp W) : Prop :=
+def genuineness (p q : PartialProp W) (s : Finset W) (disj : PartialProp W) : Prop :=
   (∃ w ∈ s, p.holds w ∧ disj.holds w) ∧
   (∃ w ∈ s, q.holds w ∧ disj.holds w)
 
 /-- Under `orFlex`, `liveness` implies `genuineness`: each witness for
     `p.holds`/`q.holds` automatically survives the disjunction's update,
     because `(orFlex p q).holds w` reduces to `p.holds w ∨ q.holds w`. -/
-theorem liveness_implies_genuineness_orFlex (p q : PrProp W) (s : Finset W)
+theorem liveness_implies_genuineness_orFlex (p q : PartialProp W) (s : Finset W)
     (h : liveness p q s) : genuineness p q s (orFlex p q) := by
   obtain ⟨⟨w, hw, hp⟩, ⟨w', hw', hq⟩⟩ := h
   refine ⟨⟨w, hw, hp, ?_⟩, ⟨w', hw', hq, ?_⟩⟩
@@ -468,40 +468,40 @@ theorem liveness_implies_genuineness_orFlex (p q : PrProp W) (s : Finset W)
 /-! ### Projections -/
 
 /-- Presupposition projection: get the presupposition as a `W → Prop`. -/
-def projectPresup (p : PrProp W) : W → Prop := p.presup
+def projectPresup (p : PartialProp W) : W → Prop := p.presup
 
 /-- Assertion extraction: get the assertion as a `W → Prop`. -/
-def projectAssertion (p : PrProp W) : W → Prop := p.assertion
+def projectAssertion (p : PartialProp W) : W → Prop := p.assertion
 
 /-! ### Negation theorems -/
 
 /-- Negation preserves presupposition. -/
-@[simp] theorem neg_presup (p : PrProp W) : (neg p).presup = p.presup := rfl
+@[simp] theorem neg_presup (p : PartialProp W) : (neg p).presup = p.presup := rfl
 
 /-- Presupposition projects through negation (by construction). -/
-theorem neg_presup_eq (p : PrProp W) (w : W) :
+theorem neg_presup_eq (p : PartialProp W) (w : W) :
     (neg p).presup w ↔ p.presup w := Iff.rfl
 
 /-- Double negation restores assertion (classical). -/
-theorem neg_neg_assertion (p : PrProp W) (w : W) :
+theorem neg_neg_assertion (p : PartialProp W) (w : W) :
     (neg (neg p)).assertion w ↔ p.assertion w := Classical.not_not
 
 /-- Double negation identity. -/
-@[simp] theorem neg_neg (p : PrProp W) : neg (neg p) = p :=
-  PrProp.ext rfl (funext fun _ => propext Classical.not_not)
+@[simp] theorem neg_neg (p : PartialProp W) : neg (neg p) = p :=
+  PartialProp.ext rfl (funext fun _ => propext Classical.not_not)
 
 /-- The truth operator is always defined (it's a plug). -/
-@[simp] theorem truthOp_presup (p : PrProp W) (w : W) :
+@[simp] theorem truthOp_presup (p : PartialProp W) (w : W) :
     (truthOp p).presup w := trivial
 
 /-- External negation is always defined (it's a plug). -/
-@[simp] theorem negExt_presup (p : PrProp W) (w : W) :
+@[simp] theorem negExt_presup (p : PartialProp W) (w : W) :
     (negExt p).presup w := trivial
 
 /-- Internal and external negation agree on assertion when the presupposition
     holds. They diverge only at presupposition failure: `neg p` is undefined,
     `negExt p` is true. [karttunen-1973] §10 fn 18. -/
-theorem neg_assertion_iff_negExt_assertion_when_defined (p : PrProp W) (w : W)
+theorem neg_assertion_iff_negExt_assertion_when_defined (p : PartialProp W) (w : W)
     (h : p.presup w) :
     (neg p).assertion w ↔ (negExt p).assertion w := by
   simp only [neg, negExt, truthOp, h, true_and]
@@ -509,12 +509,12 @@ theorem neg_assertion_iff_negExt_assertion_when_defined (p : PrProp W) (w : W)
 /-- External negation has the dual assertion to the truth operator at every
     world: `negExt = ¬truthOp` extensionally, by definition (negExt = neg ∘ truthOp
     and neg is `¬` on assertion). -/
-theorem negExt_assertion (p : PrProp W) (w : W) :
+theorem negExt_assertion (p : PartialProp W) (w : W) :
     (negExt p).assertion w ↔ ¬(truthOp p).assertion w := Iff.rfl
 
 /-- Karttunen §10 fn 18 truth table for external negation, presup-failure case:
     when `p`'s presupposition fails, `negExt p` is true (the plug behavior). -/
-theorem negExt_assertion_of_presup_failure (p : PrProp W) (w : W)
+theorem negExt_assertion_of_presup_failure (p : PartialProp W) (w : W)
     (h : ¬p.presup w) :
     (negExt p).assertion w := by
   simp only [negExt, neg, truthOp, h, false_and, not_false_eq_true]
@@ -522,14 +522,14 @@ theorem negExt_assertion_of_presup_failure (p : PrProp W) (w : W)
 /-! ### Filtering theorems -/
 
 /-- Filtering implication eliminates presupposition when antecedent entails it. -/
-theorem impFilter_eliminates_presup (p q : PrProp W)
+theorem impFilter_eliminates_presup (p q : PartialProp W)
     (h : ∀ w, p.assertion w → q.presup w) :
     (impFilter p q).presup = p.presup := by
   funext w; simp only [impFilter]
   exact propext ⟨fun ⟨hp, _⟩ => hp, fun hp => ⟨hp, h w⟩⟩
 
 /-- When A(p) = P(q), filtering implication has trivial presupposition. -/
-theorem impFilter_trivializes_presup (p q : PrProp W)
+theorem impFilter_trivializes_presup (p q : PartialProp W)
     (h : p.assertion = q.presup) :
     (impFilter p q).presup = p.presup :=
   impFilter_eliminates_presup p q (fun _ ha => h ▸ ha)
@@ -538,13 +538,13 @@ theorem impFilter_trivializes_presup (p q : PrProp W)
     This is the formal content of [karttunen-1973] §8: the filtering
     rules for *if A then B* and *A and B* coincide because both reduce to
     `p.presup ∧ (p.assertion → q.presup)`. -/
-theorem impFilter_presup_eq_andFilter_presup (p q : PrProp W) :
+theorem impFilter_presup_eq_andFilter_presup (p q : PartialProp W) :
     (impFilter p q).presup = (andFilter p q).presup := rfl
 
 /-! ### Evaluation theorems -/
 
 /-- Evaluation is defined iff presupposition holds. -/
-@[simp] theorem eval_isDefined (p : PrProp W) (w : W) :
+@[simp] theorem eval_isDefined (p : PartialProp W) (w : W) :
     (p.eval w).isDefined ↔ p.presup w := by
   simp only [eval]
   by_cases hp : p.presup w
@@ -555,7 +555,7 @@ theorem impFilter_presup_eq_andFilter_presup (p q : PrProp W) :
   · simp only [if_neg hp]; exact iff_of_false (by decide) hp
 
 /-- Negation evaluation. -/
-theorem eval_neg (p : PrProp W) (w : W) :
+theorem eval_neg (p : PartialProp W) (w : W) :
     (neg p).eval w = Truth3.neg (p.eval w) := by
   simp only [eval, neg]
   by_cases hp : p.presup w
@@ -566,7 +566,7 @@ theorem eval_neg (p : PrProp W) (w : W) :
   · simp [if_neg hp, Truth3.neg]
 
 /-- Classical conjunction evaluation (both defined). -/
-theorem eval_and (p q : PrProp W) (w : W)
+theorem eval_and (p q : PartialProp W) (w : W)
     (hp : p.presup w) (hq : q.presup w) :
     (and p q).eval w = p.eval w ⊓ q.eval w := by
   have hpq : p.presup w ∧ q.presup w := ⟨hp, hq⟩
@@ -575,7 +575,7 @@ theorem eval_and (p q : PrProp W) (w : W)
     simp [ha, hb]
 
 /-- Filtering implication when antecedent false: result is true. -/
-theorem eval_impFilter_antecedent_false (p q : PrProp W) (w : W)
+theorem eval_impFilter_antecedent_false (p q : PartialProp W) (w : W)
     (hp : p.presup w) (ha : ¬p.assertion w) :
     (impFilter p q).eval w = .true := by
   have hpresup : (impFilter p q).presup w := ⟨hp, fun h => absurd h ha⟩
@@ -583,7 +583,7 @@ theorem eval_impFilter_antecedent_false (p q : PrProp W) (w : W)
   simp only [eval, if_pos hpresup, if_pos hassert]
 
 /-- Filtering implication when antecedent true: depends on consequent. -/
-theorem eval_impFilter_antecedent_true (p q : PrProp W) (w : W)
+theorem eval_impFilter_antecedent_true (p q : PartialProp W) (w : W)
     (hp : p.presup w) (ha : p.assertion w) (hq : q.presup w) :
     (impFilter p q).eval w =
       if q.assertion w then .true else .false := by
@@ -595,7 +595,7 @@ theorem eval_impFilter_antecedent_true (p q : PrProp W) (w : W)
     simp only [eval, if_pos hpresup, if_neg hass, if_neg hqa]
 
 /-- Exclusive disjunction evaluation matches `Truth3.xor` when both defined. -/
-theorem eval_xor (p q : PrProp W) (w : W)
+theorem eval_xor (p q : PartialProp W) (w : W)
     (hp : p.presup w) (hq : q.presup w) :
     (xor p q).eval w = Truth3.xor (p.eval w) (q.eval w) := by
   have hpq : p.presup w ∧ q.presup w := ⟨hp, hq⟩
@@ -605,7 +605,7 @@ theorem eval_xor (p q : PrProp W) (w : W)
 
 /-- Exclusive disjunction never filters: when either presupposition fails,
     the result is undefined. [wang-davidson-2026] -/
-theorem eval_xor_no_filter (p q : PrProp W) (w : W)
+theorem eval_xor_no_filter (p q : PartialProp W) (w : W)
     (hq : ¬q.presup w) :
     (xor p q).eval w = .indet := by
   have : ¬(xor p q).presup w := fun ⟨_, hq'⟩ => hq hq'
@@ -616,7 +616,7 @@ theorem eval_xor_no_filter (p q : PrProp W) (w : W)
 /-- When presuppositions conflict at w, the symmetric K&P presupposition
     entails the assertion: defined → true, so the disjunction can never be
     both defined and false. [yagi-2025] §2.2 -/
-theorem orKPSymmetric_presup_entails_when_conflicting (p q : PrProp W) (w : W)
+theorem orKPSymmetric_presup_entails_when_conflicting (p q : PartialProp W) (w : W)
     (h_conflict : ¬(p.presup w ∧ q.presup w))
     (h_presup : (orKPSymmetric p q).presup w) :
     (orKPSymmetric p q).assertion w := by
@@ -638,24 +638,24 @@ theorem orKPSymmetric_presup_entails_when_conflicting (p q : PrProp W) (w : W)
     but the binary operator's truth table is identical — see [yagi-2025]
     §3.2 for the distinction between truth-conditional collapse and
     accommodation-theoretic divergence. -/
-theorem orFlex_eq_orBelnap (p q : PrProp W) : orFlex p q = orBelnap p q := rfl
+theorem orFlex_eq_orBelnap (p q : PartialProp W) : orFlex p q = orBelnap p q := rfl
 
 /-- Flexible accommodation conjunction and Belnap conjunction agree
     pointwise (extends `orFlex_eq_orBelnap`). The same caveat applies:
     truth-conditional collapse does not unify the two traditions'
     accommodation theories. -/
-theorem andFlex_eq_andBelnap (p q : PrProp W) : andFlex p q = andBelnap p q := rfl
+theorem andFlex_eq_andBelnap (p q : PartialProp W) : andFlex p q = andBelnap p q := rfl
 
 /-- `orWeak` agrees with `or` — they have the same definition for inclusive
     disjunction, since both require both presuppositions. -/
-theorem orWeak_eq_or (p q : PrProp W) : orWeak p q = or p q := rfl
+theorem orWeak_eq_or (p q : PartialProp W) : orWeak p q = or p q := rfl
 
 /-- `andWeak` agrees with `and` — they have the same definition for
     conjunction, since both require both presuppositions. -/
-theorem andWeak_eq_and (p q : PrProp W) : andWeak p q = and p q := rfl
+theorem andWeak_eq_and (p q : PartialProp W) : andWeak p q = and p q := rfl
 
 /-- orFlex reduces to standard disjunction when both presuppositions hold. -/
-theorem orFlex_eq_or_when_both_defined (p q : PrProp W) (w : W)
+theorem orFlex_eq_or_when_both_defined (p q : PartialProp W) (w : W)
     (hp : p.presup w) (hq : q.presup w) :
     (orFlex p q).assertion w ↔ (or p q).assertion w := by
   simp only [orFlex, or]
@@ -664,13 +664,13 @@ theorem orFlex_eq_or_when_both_defined (p q : PrProp W) (w : W)
   · rintro (ha | ha) <;> [exact Or.inl ⟨hp, ha⟩; exact Or.inr ⟨hq, ha⟩]
 
 /-- orFlex presupposition is weaker than or's (p ∨ q vs p ∧ q). -/
-theorem orFlex_presup_weaker (p q : PrProp W) (w : W)
+theorem orFlex_presup_weaker (p q : PartialProp W) (w : W)
     (h : (or p q).presup w) :
     (orFlex p q).presup w := by
   exact Or.inl h.1
 
 /-- andFlex reduces to standard conjunction when both presuppositions hold. -/
-theorem andFlex_eq_and_when_both_defined (p q : PrProp W) (w : W)
+theorem andFlex_eq_and_when_both_defined (p q : PartialProp W) (w : W)
     (hp : p.presup w) (hq : q.presup w) :
     (andFlex p q).assertion w ↔ (and p q).assertion w := by
   simp only [andFlex, and]
@@ -679,7 +679,7 @@ theorem andFlex_eq_and_when_both_defined (p q : PrProp W) (w : W)
   · intro ⟨h1, h2⟩; exact ⟨fun _ => h1, fun _ => h2⟩
 
 /-- andFlex presupposition is weaker than and's (p ∨ q vs p ∧ q). -/
-theorem andFlex_presup_weaker (p q : PrProp W) (w : W)
+theorem andFlex_presup_weaker (p q : PartialProp W) (w : W)
     (h : (and p q).presup w) :
     (andFlex p q).presup w := by
   exact Or.inl h.1
@@ -687,7 +687,7 @@ theorem andFlex_presup_weaker (p q : PrProp W) (w : W)
 /-! ### Eval: Weak Kleene / Belnap / Flex -/
 
 /-- `orWeak` evaluates to `Truth3.joinWeak` pointwise. -/
-theorem eval_orWeak (p q : PrProp W) (w : W) :
+theorem eval_orWeak (p q : PartialProp W) (w : W) :
     (orWeak p q).eval w = Truth3.joinWeak (p.eval w) (q.eval w) := by
   simp only [eval, orWeak, Truth3.joinWeak]
   by_cases hp : p.presup w <;> by_cases hq : q.presup w <;> simp [hp, hq] <;>
@@ -695,7 +695,7 @@ theorem eval_orWeak (p q : PrProp W) (w : W) :
     simp [ha, hb, Truth3.ofBool]
 
 /-- Belnap conjunction evaluates to `Truth3.meetBelnap` pointwise. -/
-theorem eval_andBelnap (p q : PrProp W) (w : W) :
+theorem eval_andBelnap (p q : PartialProp W) (w : W) :
     (andBelnap p q).eval w = Truth3.meetBelnap (p.eval w) (q.eval w) := by
   simp only [eval, andBelnap, Truth3.meetBelnap]
   by_cases hp : p.presup w <;> by_cases hq : q.presup w <;> simp [hp, hq] <;>
@@ -703,7 +703,7 @@ theorem eval_andBelnap (p q : PrProp W) (w : W) :
     simp [ha, hb, Truth3.ofBool]
 
 /-- Belnap disjunction evaluates to `Truth3.joinBelnap` pointwise. -/
-theorem eval_orBelnap (p q : PrProp W) (w : W) :
+theorem eval_orBelnap (p q : PartialProp W) (w : W) :
     (orBelnap p q).eval w = Truth3.joinBelnap (p.eval w) (q.eval w) := by
   simp only [eval, orBelnap, Truth3.joinBelnap]
   by_cases hp : p.presup w <;> by_cases hq : q.presup w <;> simp [hp, hq] <;>
@@ -712,47 +712,47 @@ theorem eval_orBelnap (p q : PrProp W) (w : W) :
 
 /-- `orFlex` evaluates to `Truth3.joinBelnap` pointwise.
     Corollary of `orFlex_eq_orBelnap` + `eval_orBelnap`. -/
-theorem eval_orFlex (p q : PrProp W) (w : W) :
+theorem eval_orFlex (p q : PartialProp W) (w : W) :
     (orFlex p q).eval w = Truth3.joinBelnap (p.eval w) (q.eval w) := by
   rw [orFlex_eq_orBelnap]; exact eval_orBelnap p q w
 
 /-- `andFlex` evaluates to `Truth3.meetBelnap` pointwise. -/
-theorem eval_andFlex (p q : PrProp W) (w : W) :
+theorem eval_andFlex (p q : PartialProp W) (w : W) :
     (andFlex p q).eval w = Truth3.meetBelnap (p.eval w) (q.eval w) := by
   rw [andFlex_eq_andBelnap]; exact eval_andBelnap p q w
 
 /-! ### Belnap lift: unification -/
 
 /-- `orBelnap` is the Belnap lift of `(· ∨ ·)` with identity `False`. -/
-theorem orBelnap_eq_belnapLift (p q : PrProp W) :
+theorem orBelnap_eq_belnapLift (p q : PartialProp W) :
     orBelnap p q = belnapLift (· ∨ ·) False p q :=
-  PrProp.ext rfl (funext fun w => by
+  PartialProp.ext rfl (funext fun w => by
     simp only [orBelnap, belnapLift]
     by_cases hp : p.presup w <;> by_cases hq : q.presup w <;> simp [hp, hq])
 
 /-- `andBelnap` is the Belnap lift of `(· ∧ ·)` with identity `True`. -/
-theorem andBelnap_eq_belnapLift (p q : PrProp W) :
+theorem andBelnap_eq_belnapLift (p q : PartialProp W) :
     andBelnap p q = belnapLift (· ∧ ·) True p q :=
-  PrProp.ext rfl (funext fun w => by
+  PartialProp.ext rfl (funext fun w => by
     simp only [andBelnap, belnapLift]
     by_cases hp : p.presup w <;> by_cases hq : q.presup w <;> simp [hp, hq])
 
 /-- `orFlex` is the Belnap lift of `(· ∨ ·)` with identity `False`.
     Corollary: flexible accommodation = conditional assertion = Belnap lift,
     all three for any binary connective. -/
-theorem orFlex_eq_belnapLift (p q : PrProp W) :
+theorem orFlex_eq_belnapLift (p q : PartialProp W) :
     orFlex p q = belnapLift (· ∨ ·) False p q :=
   orFlex_eq_orBelnap p q ▸ orBelnap_eq_belnapLift p q
 
 /-- `andFlex` is the Belnap lift of `(· ∧ ·)` with identity `True`. -/
-theorem andFlex_eq_belnapLift (p q : PrProp W) :
+theorem andFlex_eq_belnapLift (p q : PartialProp W) :
     andFlex p q = belnapLift (· ∧ ·) True p q :=
   andFlex_eq_andBelnap p q ▸ andBelnap_eq_belnapLift p q
 
 /-- Belnap lift reduces to the classical operation when both presuppositions hold.
     The identity element is never used — both operands contribute directly. -/
 theorem belnapLift_eq_classical (f : Prop → Prop → Prop) (unit : Prop)
-    (p q : PrProp W) (w : W)
+    (p q : PartialProp W) (w : W)
     (hp : p.presup w) (hq : q.presup w) :
     (belnapLift f unit p q).assertion w = f (p.assertion w) (q.assertion w) := by
   simp only [belnapLift, if_pos hp, if_pos hq]
@@ -761,7 +761,7 @@ theorem belnapLift_eq_classical (f : Prop → Prop → Prop) (unit : Prop)
     belnapLift returns the left operand's value: the right operand is
     invisible. -/
 theorem belnapLift_right_undefined (f : Prop → Prop → Prop) (unit : Prop)
-    (hunit : ∀ b, f b unit = b) (p q : PrProp W) (w : W)
+    (hunit : ∀ b, f b unit = b) (p q : PartialProp W) (w : W)
     (hp : p.presup w) (hq : ¬q.presup w) :
     (belnapLift f unit p q).assertion w = p.assertion w := by
   simp only [belnapLift, if_pos hp, if_neg hq, hunit]
@@ -769,16 +769,16 @@ theorem belnapLift_right_undefined (f : Prop → Prop → Prop) (unit : Prop)
 /-- When only the right operand is defined and `unit` is a left identity,
     belnapLift returns the right operand's value. -/
 theorem belnapLift_left_undefined (f : Prop → Prop → Prop) (unit : Prop)
-    (hunit : ∀ b, f unit b = b) (p q : PrProp W) (w : W)
+    (hunit : ∀ b, f unit b = b) (p q : PartialProp W) (w : W)
     (hp : ¬p.presup w) (hq : q.presup w) :
     (belnapLift f unit p q).assertion w = q.assertion w := by
   simp only [belnapLift, if_neg hp, if_pos hq, hunit]
 
 /-- belnapLift is commutative when `f` is commutative. -/
 theorem belnapLift_comm (f : Prop → Prop → Prop)
-    (hcomm : ∀ a b, f a b = f b a) (unit : Prop) (p q : PrProp W) :
+    (hcomm : ∀ a b, f a b = f b a) (unit : Prop) (p q : PartialProp W) :
     belnapLift f unit p q = belnapLift f unit q p :=
-  PrProp.ext
+  PartialProp.ext
     (funext fun _ => propext or_comm)
     (funext fun w => by simp only [belnapLift]; exact hcomm _ _)
 
@@ -787,7 +787,7 @@ theorem belnapLift_comm (f : Prop → Prop → Prop)
 /-- When both presuppositions hold at w, ALL disjunction connectives
     agree on assertion: classical = filtering = K&P = flex = Belnap.
     The theories diverge only when presuppositions conflict. -/
-theorem all_or_agree_when_both_defined (p q : PrProp W) (w : W)
+theorem all_or_agree_when_both_defined (p q : PartialProp W) (w : W)
     (hp : p.presup w) (hq : q.presup w) :
     ((or p q).assertion w ↔ (orFilter p q).assertion w) ∧
     ((or p q).assertion w ↔ (orPositive p q).assertion w) ∧
@@ -802,7 +802,7 @@ theorem all_or_agree_when_both_defined (p q : PrProp W) (w : W)
 /-- When both presuppositions hold at w, ALL conjunction connectives
     agree on assertion: classical = filtering = flex = Belnap.
     The theories diverge only when presuppositions conflict. -/
-theorem all_and_agree_when_both_defined (p q : PrProp W) (w : W)
+theorem all_and_agree_when_both_defined (p q : PartialProp W) (w : W)
     (hp : p.presup w) (hq : q.presup w) :
     ((and p q).assertion w ↔ (andFilter p q).assertion w) ∧
     ((and p q).assertion w ↔ (andFlex p q).assertion w) ∧
@@ -813,9 +813,9 @@ theorem all_and_agree_when_both_defined (p q : PrProp W) (w : W)
   · exact (andFlex_eq_and_when_both_defined p q w hp hq).symm
   · exact (andFlex_eq_and_when_both_defined p q w hp hq).symm
 
-/-! ### Round-trip: `Prop3` ↔ `PrProp` -/
+/-! ### Round-trip: `Prop3` ↔ `PartialProp` -/
 
-/-- `Prop3 → PrProp → Prop3` round-trip is the identity. -/
+/-- `Prop3 → PartialProp → Prop3` round-trip is the identity. -/
 theorem eval_ofProp3 (p : Prop3 W) : (ofProp3 p).eval = p := by
   funext w; simp only [eval, ofProp3]
   by_cases h1 : p w ≠ .indet
@@ -829,19 +829,19 @@ theorem eval_ofProp3 (p : Prop3 W) : (ofProp3 p).eval = p := by
 /-! ### Genuineness theorems -/
 
 /-- Liveness is symmetric. -/
-theorem liveness_comm (p q : PrProp W) (s : Finset W) :
+theorem liveness_comm (p q : PartialProp W) (s : Finset W) :
     liveness p q s ↔ liveness q p s := by
   simp only [liveness, and_comm]
 
 /-- Genuineness is symmetric whenever the supplied disjunction connective is
     symmetric in its operands. -/
-theorem genuineness_comm (p q : PrProp W) (s : Finset W) (disj : PrProp W) :
+theorem genuineness_comm (p q : PartialProp W) (s : Finset W) (disj : PartialProp W) :
     genuineness p q s disj ↔ genuineness q p s disj := by
   simp only [genuineness, and_comm]
 
 /-! ### Embedding combinators ([heim-1992], [karttunen-1973], [delpinal-bassi-sauerland-2024]) -/
 
-/-- Asymmetric filtering disjunction: plain proposition ∨ PrProp.
+/-- Asymmetric filtering disjunction: plain proposition ∨ PartialProp.
 
     For "A ∨ B_ψ" where only B carries a presupposition ψ, the overall
     presupposition is ¬A → ψ (Karttunen's generalization for disjunction).
@@ -849,15 +849,15 @@ theorem genuineness_comm (p q : PrProp W) (s : Finset W) (disj : PrProp W) :
 
     This is the standard projection rule for presuppositions in the second
     disjunct of a disjunction. [karttunen-1973], [heim-1983] -/
-def disjFilterLeft (firstDisjunct : W → Prop) (second : PrProp W) :
-    PrProp W where
+def disjFilterLeft (firstDisjunct : W → Prop) (second : PartialProp W) :
+    PartialProp W where
   assertion := fun w => firstDisjunct w ∨ second.assertion w
   presup := fun w => ¬firstDisjunct w → second.presup w
 
 /-- `orFilter` with a presuppositionless first disjunct is `disjFilterLeft`. -/
-theorem orFilter_ofProp (A : W → Prop) (q : PrProp W) :
+theorem orFilter_ofProp (A : W → Prop) (q : PartialProp W) :
     orFilter (ofProp A) q = disjFilterLeft A q :=
-  PrProp.ext (funext fun _ => propext (and_iff_right trivial)) rfl
+  PartialProp.ext (funext fun _ => propext (and_iff_right trivial)) rfl
 
 /-- Embedding under a negative factive (e.g., "is unaware that").
 
@@ -872,14 +872,14 @@ theorem orFilter_ofProp (A : W → Prop) (q : PrProp W) :
     but diverge when the complement contains its own embedded presupposition
     trigger (the case Del Pinal-Bassi-Sauerland use to handle presupposed
     free choice). -/
-def negFactive (complement : PrProp W)
-    (believes : (W → Prop) → (W → Prop)) : PrProp W where
+def negFactive (complement : PartialProp W)
+    (believes : (W → Prop) → (W → Prop)) : PartialProp W where
   assertion := fun w => ¬(believes complement.assertion w)
   presup := fun w => complement.holds w
 
 /-- When the first disjunct is false, `disjFilterLeft` recovers full
     satisfaction of the second disjunct. -/
-theorem disjFilterLeft_recovers (firstDisjunct : W → Prop) (sp : PrProp W)
+theorem disjFilterLeft_recovers (firstDisjunct : W → Prop) (sp : PartialProp W)
     (w : W) (hFirst : ¬firstDisjunct w)
     (hFiltered : (disjFilterLeft firstDisjunct sp).holds w) :
     sp.holds w := by
@@ -892,7 +892,7 @@ theorem disjFilterLeft_recovers (firstDisjunct : W → Prop) (sp : PrProp W)
     asymmetric disjunction filtering rule (24b), p. 181: "A or B" carries
     no residual presupposition from B when ¬A entails it. -/
 theorem disjFilterLeft_eliminates_presup_when_neg_entails
-    (A : W → Prop) (q : PrProp W)
+    (A : W → Prop) (q : PartialProp W)
     (h : ∀ w, ¬A w → q.presup w) :
     (disjFilterLeft A q).presup = fun _ => True := by
   funext w
@@ -900,14 +900,14 @@ theorem disjFilterLeft_eliminates_presup_when_neg_entails
   exact h w
 
 /-- Presupposition of `negFactive` is full satisfaction of the complement. -/
-theorem negFactive_presup_eq (complement : PrProp W)
+theorem negFactive_presup_eq (complement : PartialProp W)
     (believes : (W → Prop) → (W → Prop)) :
     (negFactive complement believes).presup = complement.holds := rfl
 
 /-- Universal presupposition projection: presuppositions project
     universally from the scope of a universal quantifier.
 
-    For ∀x ∈ S, φ(x) where φ(x) is a PrProp:
+    For ∀x ∈ S, φ(x) where φ(x) is a PartialProp:
     - asserts: ∀x ∈ S, assertion(φ(x))
     - presupposes: ∀x ∈ S, presup(φ(x))
 
@@ -915,7 +915,7 @@ theorem negFactive_presup_eq (complement : PrProp W)
     the scope of a universal quantifier tend to project universally.
     ([mayr-sauerland-2015] dissent: semantic projection is existential,
     pragmatically strengthened — cf. [spector-sudo-2017].) -/
-def forallPr {α : Type*} (S : α → Prop) (φ : α → PrProp W) : PrProp W where
+def forallPartial {α : Type*} (S : α → Prop) (φ : α → PartialProp W) : PartialProp W where
   presup := fun w => ∀ x, S x → (φ x).presup w
   assertion := fun w => ∀ x, S x → (φ x).assertion w
 
@@ -928,15 +928,15 @@ def forallPr {α : Type*} (S : α → Prop) (φ : α → PrProp W) : PrProp W wh
     default is empirically contested — see [spector-sudo-2017] for
     conditions under which a non-universal (existential) reading is
     preferred. Consumers committing to a projection theory should pick
-    `existsPrUniv` or `existsPrExist` explicitly. -/
-def existsPrUniv {α : Type*} (S : α → Prop) (φ : α → PrProp W) : PrProp W where
+    `existsPartialUniv` or `existsPartialExist` explicitly. -/
+def existsPartialUniv {α : Type*} (S : α → Prop) (φ : α → PartialProp W) : PartialProp W where
   presup := fun w => ∀ x, S x → (φ x).presup w
   assertion := fun w => ∃ x, S x ∧ (φ x).assertion w
 
 /-- Existential presupposition projection — existential presup, existential
-    assert. The non-universal alternative to `existsPrUniv`; see
+    assert. The non-universal alternative to `existsPartialUniv`; see
     [spector-sudo-2017] for the empirical debate. -/
-def existsPrExist {α : Type*} (S : α → Prop) (φ : α → PrProp W) : PrProp W where
+def existsPartialExist {α : Type*} (S : α → Prop) (φ : α → PartialProp W) : PartialProp W where
   presup := fun w => ∃ x, S x ∧ (φ x).presup w
   assertion := fun w => ∃ x, S x ∧ (φ x).assertion w
 
@@ -944,13 +944,13 @@ def existsPrExist {α : Type*} (S : α → Prop) (φ : α → PrProp W) : PrProp
 
     For ¬∃x ∈ S, φ(x): equivalent to ∀x ∈ S, ¬φ(x).
     Presuppositions project universally. -/
-def negExistsPr {α : Type*} (S : α → Prop) (φ : α → PrProp W) : PrProp W where
+def negExistsPartial {α : Type*} (S : α → Prop) (φ : α → PartialProp W) : PartialProp W where
   presup := fun w => ∀ x, S x → (φ x).presup w
   assertion := fun w => ¬∃ x, S x ∧ (φ x).assertion w
 
-/-- `forallPr` holds iff every member satisfies both presupposition and assertion. -/
-theorem forallPr_holds {α : Type*} (S : α → Prop) (φ : α → PrProp W) (w : W) :
-    (forallPr S φ).holds w ↔
+/-- `forallPartial` holds iff every member satisfies both presupposition and assertion. -/
+theorem forallPartial_holds {α : Type*} (S : α → Prop) (φ : α → PartialProp W) (w : W) :
+    (forallPartial S φ).holds w ↔
       (∀ x, S x → (φ x).presup w) ∧ (∀ x, S x → (φ x).assertion w) :=
   Iff.rfl
 
@@ -962,14 +962,14 @@ theorem forallPr_holds {α : Type*} (S : α → Prop) (φ : α → PrProp W) (w 
   each world (or `none` when no unique referent is determined),
 - `scope : E → W → Prop` — what is asserted of the chosen referent,
 
-build the `PrProp` that presupposes referent definedness and asserts the
+build the `PartialProp` that presupposes referent definedness and asserts the
 scope of the referent. This is the single source of truth for all definite
 denotations in the library: uniqueness-based (`russellIotaList domain R`),
 familiarity-based (`russellIotaList dc.salient R`), anaphoric
 (`russellIotaList domain (R ∧ Q)`), and Donnellan's attributive
 (`attributiveContent domain R`) all instantiate the selector slot. -/
 def presupOfReferent {E : Type*} (referent : W → Option E)
-    (scope : E → W → Prop) : PrProp W where
+    (scope : E → W → Prop) : PartialProp W where
   presup := fun w => (referent w).isSome
   assertion := fun w => match referent w with
     | some e => scope e w
@@ -994,6 +994,6 @@ theorem presupOfReferent_assertion_none {E : Type*}
     (presupOfReferent referent scope).assertion w = False := by
   simp only [presupOfReferent, h]
 
-end PrProp
+end PartialProp
 
 end Semantics.Presupposition

--- a/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
+++ b/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
@@ -115,7 +115,7 @@ def BeliefLocalCtx.atWorld (blc : BeliefLocalCtx W Agent) (w_star : W) : Context
 A presupposition projects globally (to speaker) from under belief
 iff it's not entailed by the belief local context at any global world.
 -/
-def presupProjectsFromBelief (blc : BeliefLocalCtx W Agent) (p : PrProp W) : Prop :=
+def presupProjectsFromBelief (blc : BeliefLocalCtx W Agent) (p : PartialProp W) : Prop :=
   ∃ w_star, blc.globalCtx w_star ∧ ¬ ContextSet.entails (blc.atWorld w_star) p.presup
 
 /--
@@ -125,7 +125,7 @@ by the local context at all global worlds.
 This is the OLE=yes case: the presupposition becomes part of the
 attitude holder's beliefs.
 -/
-def presupAttributedToHolder (blc : BeliefLocalCtx W Agent) (p : PrProp W) : Prop :=
+def presupAttributedToHolder (blc : BeliefLocalCtx W Agent) (p : PartialProp W) : Prop :=
   ∀ w_star, blc.globalCtx w_star → ContextSet.entails (blc.atWorld w_star) p.presup
 
 
@@ -181,7 +181,7 @@ def smokingDox : DoxasticAccessibility SmokingWorld SmokingAgent
 /--
 "Mary stopped smoking" — presupposes Mary used to smoke.
 -/
-def maryStoppedSmoking : PrProp SmokingWorld :=
+def maryStoppedSmoking : PartialProp SmokingWorld :=
   { presup := λ w => match w with
       | .maryUsedToSmoke_johnBelieves_maryQuit => true
       | .maryUsedToSmoke_johnBelieves_marySmokes => true
@@ -272,7 +272,7 @@ def beliefToLocalCtx (blc : BeliefLocalCtx W Agent) (w_star : W)
 The presupposition filtering condition is the same: a presupposition is
 filtered iff it's entailed by the local context.
 -/
-theorem belief_filtering_condition (blc : BeliefLocalCtx W Agent) (p : PrProp W)
+theorem belief_filtering_condition (blc : BeliefLocalCtx W Agent) (p : PartialProp W)
     (w_star : W) (_h : blc.globalCtx w_star) :
     presupFiltered (beliefToLocalCtx blc w_star _h) p ↔
     ContextSet.entails (blc.atWorld w_star) p.presup := by
@@ -327,7 +327,7 @@ theorem localCtx_sub_of_refinement (Rk Rb : AgentAccessRel W E)
     filtered under any belief embedding that refines knowledge. -/
 theorem knowledge_filtered_implies_belief_filtered
     (Rk Rb : AgentAccessRel W E) (ctx : ContextSet W) (i : E)
-    [IsBeliefRefinementOf (Rk i) (Rb i)] (p : PrProp W) (w_star : W) :
+    [IsBeliefRefinementOf (Rk i) (Rb i)] (p : PartialProp W) (w_star : W) :
     ContextSet.entails ((localCtxOf Rk ctx i).atWorld w_star) p.presup →
     ContextSet.entails ((localCtxOf Rb ctx i).atWorld w_star) p.presup := by
   intro h_know w h_bel
@@ -347,7 +347,7 @@ end BoolPropBridge
 presuppositions under attitude predicates:
 
 - **Transparent**: presupposition evaluated in the global context (speaker's
-  knowledge state). Implemented by `PrProp.negFactive`: the factive
+  knowledge state). Implemented by `PartialProp.negFactive`: the factive
   presupposes the complement holds in reality.
 
 - **Opaque**: presupposition attributed to the attitude holder's belief state.
@@ -368,18 +368,18 @@ variable {W : Type*} {Agent : Type*}
     the complement *holds* in the actual world.
 
     [delpinal-bassi-sauerland-2024] §3.2 -/
-def transparentProjection (globalCtx : ContextSet W) (p : PrProp W) : Prop :=
+def transparentProjection (globalCtx : ContextSet W) (p : PartialProp W) : Prop :=
   ContextSet.entails globalCtx p.presup
 
-/-- `PrProp.negFactive` subsumes transparent projection: its presupposition
+/-- `PartialProp.negFactive` subsumes transparent projection: its presupposition
     (complement holds = presup ∧ assertion) entails transparent projection of
     the complement's presupposition.
 
     This grounds the `negFactive` combinator in the projection theory.
     [heim-1992], [delpinal-bassi-sauerland-2024] §3.2 -/
-theorem negFactive_entails_transparent (complement : PrProp W)
+theorem negFactive_entails_transparent (complement : PartialProp W)
     (believes : Set W → Set W) (globalCtx : ContextSet W)
-    (h : ContextSet.entails globalCtx (PrProp.negFactive complement believes).presup) :
+    (h : ContextSet.entails globalCtx (PartialProp.negFactive complement believes).presup) :
     transparentProjection globalCtx complement := by
   intro w hw
   exact (h hw).1
@@ -391,7 +391,7 @@ theorem negFactive_entails_transparent (complement : PrProp W)
     worlds. What holds at all accessible worlds holds at the evaluation world.
     [hintikka-1962]: S5 knowledge is reflexive. -/
 theorem opaque_implies_transparent_when_reflexive
-    (blc : BeliefLocalCtx W Agent) (p : PrProp W)
+    (blc : BeliefLocalCtx W Agent) (p : PartialProp W)
     (hReflexive : ∀ w, blc.globalCtx w → blc.dox blc.agent w w)
     (hOpaque : presupAttributedToHolder blc p) :
     transparentProjection blc.globalCtx p := by

--- a/Linglib/Semantics/Presupposition/Context.lean
+++ b/Linglib/Semantics/Presupposition/Context.lean
@@ -5,7 +5,7 @@ import Linglib.Discourse.CommonGround
 # Presupposition–Context Bridge
 [stalnaker-1974] [heim-1983] [lewis-1979]
 
-Canonical operations connecting presuppositions (`PrProp W`) to contexts
+Canonical operations connecting presuppositions (`PartialProp W`) to contexts
 (`ContextSet W`). Before this module, every downstream file that needed
 both reimplemented the same bridge with different names:
 
@@ -48,7 +48,7 @@ variable {W : Type*}
     entails it: every world in the context satisfies the presupposition.
 
     This is Karttunen's filtering condition and Schlenker's local satisfaction. -/
-abbrev presupSatisfied (c : ContextSet W) (p : PrProp W) : Prop := c ⊆ p.presup
+abbrev presupSatisfied (c : ContextSet W) (p : PartialProp W) : Prop := c ⊆ p.presup
 
 /-- A presupposition is **satisfiable** (conceivable) in context `c` iff some
     world in the context satisfies it.
@@ -56,12 +56,12 @@ abbrev presupSatisfied (c : ContextSet W) (p : PrProp W) : Prop := c ⊆ p.presu
     This is Enguehard's conceivability condition: a singular indefinite's number
     presupposition is conceivable iff the common ground contains a world where
     the witness set has the right cardinality. -/
-abbrev presupSatisfiable (c : ContextSet W) (p : PrProp W) : Prop :=
+abbrev presupSatisfiable (c : ContextSet W) (p : PartialProp W) : Prop :=
   (c ∩ p.presup).Nonempty
 
 /-- A presupposition **projects** from context `c` iff it is NOT satisfied
     (not filtered). Projection is the complement of filtering. -/
-abbrev presupProjects (c : ContextSet W) (p : PrProp W) : Prop :=
+abbrev presupProjects (c : ContextSet W) (p : PartialProp W) : Prop :=
   ¬ presupSatisfied c p
 
 /-- **Accommodate** a presupposition: restrict the context to worlds where
@@ -85,17 +85,17 @@ abbrev accommodationConsistent (c : ContextSet W) (presup : Set W) : Prop :=
 -- ════════════════════════════════════════════════════════════════
 
 /-- Projection and filtering are complementary. -/
-theorem projects_iff_not_satisfied (c : ContextSet W) (p : PrProp W) :
+theorem projects_iff_not_satisfied (c : ContextSet W) (p : PartialProp W) :
     presupProjects c p ↔ ¬ presupSatisfied c p := Iff.rfl
 
 /-- Satisfaction implies satisfiability (when the context is non-empty). -/
-theorem satisfied_implies_satisfiable (c : ContextSet W) (p : PrProp W)
+theorem satisfied_implies_satisfiable (c : ContextSet W) (p : PartialProp W)
     (hne : c.Nonempty) (hsat : presupSatisfied c p) : presupSatisfiable c p := by
   obtain ⟨w, hw⟩ := hne
   exact ⟨w, hw, hsat hw⟩
 
 /-- If the presupposition is not even satisfiable, it projects. -/
-theorem not_satisfiable_implies_projects (c : ContextSet W) (p : PrProp W)
+theorem not_satisfiable_implies_projects (c : ContextSet W) (p : PartialProp W)
     (hne : c.Nonempty) (h : ¬ presupSatisfiable c p) : presupProjects c p :=
   fun hsat => h (satisfied_implies_satisfiable c p hne hsat)
 
@@ -116,13 +116,13 @@ theorem accommodate_strengthens (c : ContextSet W) (presup : Set W) :
   Set.inter_subset_left
 
 /-- Accommodation consistency = presupposition satisfiable in context. -/
-theorem accommodationConsistent_iff_satisfiable (c : ContextSet W) (p : PrProp W) :
+theorem accommodationConsistent_iff_satisfiable (c : ContextSet W) (p : PartialProp W) :
     accommodationConsistent c p.presup ↔ presupSatisfiable c p := Iff.rfl
 
-/-- Accommodation via `PrProp.defined`: accommodating `p.presup` restricts
+/-- Accommodation via `PartialProp.defined`: accommodating `p.presup` restricts
     to worlds where `p.defined` holds. -/
-theorem accommodate_eq_defined (c : ContextSet W) (p : PrProp W) (w : W) :
-    w ∈ accommodate c p.presup ↔ w ∈ c ∧ PrProp.defined w p :=
+theorem accommodate_eq_defined (c : ContextSet W) (p : PartialProp W) (w : W) :
+    w ∈ accommodate c p.presup ↔ w ∈ c ∧ PartialProp.defined w p :=
   Iff.rfl
 
 -- ════════════════════════════════════════════════════════════════
@@ -132,15 +132,15 @@ theorem accommodate_eq_defined (c : ContextSet W) (p : PrProp W) (w : W) :
 /-- Presupposition satisfied relative to any discourse state with a
     context set. Works with `CommonGround W`, `Commitment.CommitmentSlate W`,
     `LocalCtx W`, and any other state implementing `HasContextSet`. -/
-abbrev presupSatisfiedIn {S : Type*} [HasContextSet S W] (s : S) (p : PrProp W) : Prop :=
+abbrev presupSatisfiedIn {S : Type*} [HasContextSet S W] (s : S) (p : PartialProp W) : Prop :=
   presupSatisfied (HasContextSet.toContextSet s) p
 
 /-- Presupposition satisfiable (conceivable) relative to any discourse state. -/
-abbrev presupSatisfiableIn {S : Type*} [HasContextSet S W] (s : S) (p : PrProp W) : Prop :=
+abbrev presupSatisfiableIn {S : Type*} [HasContextSet S W] (s : S) (p : PartialProp W) : Prop :=
   presupSatisfiable (HasContextSet.toContextSet s) p
 
 /-- Presupposition projects from any discourse state. -/
-abbrev presupProjectsFrom {S : Type*} [HasContextSet S W] (s : S) (p : PrProp W) : Prop :=
+abbrev presupProjectsFrom {S : Type*} [HasContextSet S W] (s : S) (p : PartialProp W) : Prop :=
   presupProjects (HasContextSet.toContextSet s) p
 
 end Semantics.Presupposition.Context

--- a/Linglib/Semantics/Presupposition/LocalContext.lean
+++ b/Linglib/Semantics/Presupposition/LocalContext.lean
@@ -83,7 +83,7 @@ Local context for the consequent of a conditional.
 This is why "If the king exists, the king is bald" doesn't presuppose
 king exists: the local context at "the king is bald" already entails it.
 -/
-def localCtxConsequent (c : LocalCtx W) (antecedent : PrProp W) : LocalCtx W :=
+def localCtxConsequent (c : LocalCtx W) (antecedent : PartialProp W) : LocalCtx W :=
   { worlds := ContextSet.update c.worlds antecedent.assertion
   , position := c.position + 1
   , depth := c.depth }
@@ -93,7 +93,7 @@ Local context for the second conjunct.
 
 "P and Q" — the local context at Q is c + P.assertion
 -/
-def localCtxSecondConjunct (c : LocalCtx W) (first : PrProp W) : LocalCtx W :=
+def localCtxSecondConjunct (c : LocalCtx W) (first : PartialProp W) : LocalCtx W :=
   { worlds := ContextSet.update c.worlds first.assertion
   , position := c.position + 1
   , depth := c.depth }
@@ -114,7 +114,7 @@ Local context for each disjunct.
 "P or Q" — Schlenker: local context at Q is c + ¬P.assertion
 (and symmetrically for P)
 -/
-def localCtxSecondDisjunct (c : LocalCtx W) (first : PrProp W) : LocalCtx W :=
+def localCtxSecondDisjunct (c : LocalCtx W) (first : PartialProp W) : LocalCtx W :=
   { worlds := λ w => c.worlds w ∧ ¬first.assertion w
   , position := c.position + 1
   , depth := c.depth }
@@ -122,16 +122,16 @@ def localCtxSecondDisjunct (c : LocalCtx W) (first : PrProp W) : LocalCtx W :=
 
 /-- A presupposition projects at a local context if it's not entailed.
     Delegates to `Semantics.Presupposition.Context.presupProjects`. -/
-abbrev presupProjects (lc : LocalCtx W) (p : PrProp W) : Prop :=
+abbrev presupProjects (lc : LocalCtx W) (p : PartialProp W) : Prop :=
   Semantics.Presupposition.Context.presupProjects lc.worlds p
 
 /-- A presupposition is filtered (satisfied) at a local context if it IS entailed.
     Delegates to `Semantics.Presupposition.Context.presupSatisfied`. -/
-abbrev presupFiltered (lc : LocalCtx W) (p : PrProp W) : Prop :=
+abbrev presupFiltered (lc : LocalCtx W) (p : PartialProp W) : Prop :=
   Semantics.Presupposition.Context.presupSatisfied lc.worlds p
 
 /-- Projection and filtering are complementary. -/
-theorem projects_iff_not_filtered (lc : LocalCtx W) (p : PrProp W) :
+theorem projects_iff_not_filtered (lc : LocalCtx W) (p : PartialProp W) :
     presupProjects lc p ↔ ¬ presupFiltered lc p := Iff.rfl
 
 
@@ -141,7 +141,7 @@ entails the presupposition.
 
 This formalizes the core insight of filtering semantics.
 -/
-theorem conditional_filters_when_entailed (c : LocalCtx W) (p q : PrProp W)
+theorem conditional_filters_when_entailed (c : LocalCtx W) (p q : PartialProp W)
     (h : ∀ w, c.worlds w → p.assertion w → q.presup w) :
     presupFiltered (localCtxConsequent c p) q := by
   intro w hw
@@ -152,7 +152,7 @@ theorem conditional_filters_when_entailed (c : LocalCtx W) (p q : PrProp W)
 If antecedent assertion doesn't entail consequent presupposition,
 it projects.
 -/
-theorem conditional_projects_when_not_entailed (c : LocalCtx W) (p q : PrProp W)
+theorem conditional_projects_when_not_entailed (c : LocalCtx W) (p q : PartialProp W)
     (h : ∃ w, c.worlds w ∧ p.assertion w ∧ ¬q.presup w) :
     presupProjects (localCtxConsequent c p) q := by
   obtain ⟨w, hw_in, hp_true, hq_false⟩ := h
@@ -162,7 +162,7 @@ theorem conditional_projects_when_not_entailed (c : LocalCtx W) (p q : PrProp W)
 /--
 Negation doesn't filter presuppositions.
 -/
-theorem negation_preserves_projection (c : LocalCtx W) (p : PrProp W) :
+theorem negation_preserves_projection (c : LocalCtx W) (p : PartialProp W) :
     presupProjects c p ↔ presupProjects (localCtxNegation c) p := by
   simp [presupProjects, localCtxNegation]
 
@@ -180,7 +180,7 @@ inductive KingWorld' where
 /--
 "The king exists" — no presupposition.
 -/
-def kingExists' : PrProp KingWorld' :=
+def kingExists' : PartialProp KingWorld' :=
   { presup := λ _ => True
   , assertion := λ w => match w with
       | .kingExists => True
@@ -189,7 +189,7 @@ def kingExists' : PrProp KingWorld' :=
 /--
 "The king is bald" — presupposes king exists.
 -/
-def kingBald' : PrProp KingWorld' :=
+def kingBald' : PartialProp KingWorld' :=
   { presup := λ w => match w with
       | .kingExists => True
       | .noKing => False
@@ -221,21 +221,21 @@ This theorem shows the correspondence between:
 - the stipulated local context computation
 - the Karttunen filtering implication formula ([karttunen-1973], [peters-1979])
 -/
-theorem local_context_matches_impFilter (c : ContextSet W) (p q : PrProp W) :
-    (∀ w, c w → (PrProp.impFilter p q).presup w) ↔
+theorem local_context_matches_impFilter (c : ContextSet W) (p q : PartialProp W) :
+    (∀ w, c w → (PartialProp.impFilter p q).presup w) ↔
     (∀ w, c w → p.presup w ∧ (p.assertion w → q.presup w)) := by
   constructor
   · intro h w hw
     have h' := h w hw
-    simp only [PrProp.impFilter] at h'
+    simp only [PartialProp.impFilter] at h'
     exact h'
   · intro h w hw
     obtain ⟨hp, himp⟩ := h w hw
-    simp only [PrProp.impFilter]
+    simp only [PartialProp.impFilter]
     exact ⟨hp, himp⟩
 
 /-- Schlenker's local context at the second disjunct derives Karttunen's
-    asymmetric disjunction filter (`PrProp.disjFilterLeft`).
+    asymmetric disjunction filter (`PartialProp.disjFilterLeft`).
 
     For "A ∨ B_ψ" in context c:
     - Schlenker: local context at B is c ∧ ¬A; ψ filtered iff c ∧ ¬A ⊧ ψ
@@ -245,9 +245,9 @@ theorem local_context_matches_impFilter (c : ContextSet W) (p q : PrProp W) :
     Analogous to `local_context_matches_impFilter` for conditionals.
     [schlenker-2009], [karttunen-1973] -/
 theorem local_context_matches_disjFilterLeft (c : ContextSet W)
-    (firstDisjunct : PrProp W) (second : PrProp W) :
+    (firstDisjunct : PartialProp W) (second : PartialProp W) :
     presupFiltered (localCtxSecondDisjunct (initialLocalCtx c) firstDisjunct) second ↔
-    (∀ w, c w → (PrProp.disjFilterLeft firstDisjunct.assertion second).presup w) := by
+    (∀ w, c w → (PartialProp.disjFilterLeft firstDisjunct.assertion second).presup w) := by
   constructor
   · intro h w hc hn; exact h ⟨hc, hn⟩
   · intro h w ⟨hc, hn⟩; exact h w hc hn

--- a/Linglib/Semantics/Presupposition/PhiFeatures.lean
+++ b/Linglib/Semantics/Presupposition/PhiFeatures.lean
@@ -14,7 +14,7 @@ identity functions** on the entity domain, ordered by presuppositional
 strength via `Features.ContainmentPair.specLevel`.
 
 The core mathematical object is `phiPresup`: a single function that maps
-each `ContainmentPair` cell to a `PrProp`, using two predicates (innerP,
+each `ContainmentPair` cell to a `PartialProp`, using two predicates (innerP,
 outerP) corresponding to the inner and outer privative features. Since
 the three well-formed cells have 2, 1, and 0 marked features respectively,
 their presuppositions are automatically nested — more marked features =
@@ -51,7 +51,7 @@ namespace Semantics.Presupposition.PhiFeatures
 
 open Mereology (Atom)
 open Features (ContainmentPair ContainmentPairLike)
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 
 -- ============================================================================
 -- §1  Generic Presuppositional Denotations
@@ -59,7 +59,7 @@ open Semantics.Presupposition (PrProp)
 
 /-- Generic presuppositional denotation from a privative feature pair.
 
-    Maps each `ContainmentPair` cell to a `PrProp` using two predicates:
+    Maps each `ContainmentPair` cell to a `PartialProp` using two predicates:
     `innerP` for [±inner] and `outerP` for [±outer].
 
     | Cell         | outer | inner | Presupposition |
@@ -72,7 +72,7 @@ open Semantics.Presupposition (PrProp)
     implies `outerP`. So maximal's presupposition (innerP) is the
     strongest — no need to separately conjoin outerP. -/
 def phiPresup {E : Type*} (innerP outerP : E → Prop) :
-    ContainmentPair → PrProp E
+    ContainmentPair → PartialProp E
   | ⟨true, true⟩ => { presup := innerP, assertion := fun _ => True }
   | ⟨true, false⟩ => { presup := outerP, assertion := fun _ => True }
   | ⟨false, _⟩ => { presup := fun _ => True, assertion := fun _ => True }
@@ -94,7 +94,7 @@ theorem phiPresup_nesting {E : Type*}
     rcases ContainmentPair.classification c₂ hw₂ with rfl | rfl | rfl <;>
       simp_all [ContainmentPair.maximal, ContainmentPair.intermediate,
         ContainmentPair.minimal, ContainmentPair.specLevel, Bool.toNat,
-        phiPresup, PrProp.defined]
+        phiPresup, PartialProp.defined]
 
 /-- All `phiPresup` cells have the same (trivial) assertive content.
     This is the privative-geometric reason why φ-feature competition
@@ -113,20 +113,20 @@ theorem phiPresup_same_assertion {E : Type*}
 
 /-- ⟦Sg⟧: presupposes atomicity. The identity function restricted to
     atoms — defined only when the referent is an atom. -/
-def sgSem (E : Type*) [PartialOrder E] : PrProp E where
+def sgSem (E : Type*) [PartialOrder E] : PartialProp E where
   presup := Atom
   assertion := fun _ => True
 
 /-- ⟦Pl⟧: no inherent presupposition. The unrestricted identity function.
     Its distribution is constrained pragmatically by Maximize Presupposition,
     not by any semantic content. -/
-def plSem (E : Type*) : PrProp E where
+def plSem (E : Type*) : PartialProp E where
   presup := fun _ => True
   assertion := fun _ => True
 
 /-- ⟦Du⟧: presupposes minimality (no proper non-atomic subpart).
     The intermediate cell (specLevel 1). -/
-def dualSem {E : Type*} (minimalP : E → Prop) : PrProp E where
+def dualSem {E : Type*} (minimalP : E → Prop) : PartialProp E where
   presup := minimalP
   assertion := fun _ => True
 
@@ -172,19 +172,19 @@ variable {E : Type*} [PartialOrder E]
 
 /-- ⟦1st⟧: presupposes the referent includes the speaker.
     Maximal cell [+author, +participant] (specLevel 2). -/
-def firstSem (speaker : E) : PrProp E where
+def firstSem (speaker : E) : PartialProp E where
   presup := fun x => speaker ≤ x
   assertion := fun _ => True
 
 /-- ⟦2nd⟧: presupposes the referent includes a speech-act participant.
     Intermediate cell [−author, +participant] (specLevel 1). -/
-def secondSem (speaker addressee : E) : PrProp E where
+def secondSem (speaker addressee : E) : PartialProp E where
   presup := fun x => speaker ≤ x ∨ addressee ≤ x
   assertion := fun _ => True
 
 /-- ⟦3rd⟧: vacuous presupposition.
     Minimal cell [−author, −participant] (specLevel 0). -/
-def thirdSem : PrProp E where
+def thirdSem : PartialProp E where
   presup := fun _ => True
   assertion := fun _ => True
 
@@ -211,7 +211,7 @@ theorem secondSem_eq_phiPresup (speaker addressee : E) :
 theorem thirdSem_eq_phiPresup (speaker addressee : E) :
     phiPresup (fun x => speaker ≤ x)
               (fun x => speaker ≤ x ∨ addressee ≤ x)
-              .minimal = (thirdSem : PrProp E) := rfl
+              .minimal = (thirdSem : PartialProp E) := rfl
 
 /-- Person nesting is a corollary of `phiPresup_nesting` — the same
     theorem that derives number nesting also derives person nesting,
@@ -275,19 +275,19 @@ variable {E : Type*}
 
 /-- ⟦Neut⟧: presupposes the referent is inanimate.
     Maximal cell [+feminine, +neuter] (specLevel 2). -/
-def neutSem (isInanimate : E → Prop) : PrProp E where
+def neutSem (isInanimate : E → Prop) : PartialProp E where
   presup := isInanimate
   assertion := fun _ => True
 
 /-- ⟦Fem⟧: presupposes the referent is female.
     Intermediate cell [+feminine, −neuter] (specLevel 1). -/
-def femSem (isFemale : E → Prop) : PrProp E where
+def femSem (isFemale : E → Prop) : PartialProp E where
   presup := isFemale
   assertion := fun _ => True
 
 /-- ⟦Masc⟧: vacuous presupposition.
     Minimal cell [−feminine, −neuter] (specLevel 0). -/
-def mascSem : PrProp E where
+def mascSem : PartialProp E where
   presup := fun _ => True
   assertion := fun _ => True
 
@@ -303,7 +303,7 @@ def mascSem : PrProp E where
 
 /-- `mascSem` is `phiPresup` at the minimal cell. -/
 @[simp] theorem mascSem_eq_phiPresup (innerP outerP : E → Prop) :
-    phiPresup innerP outerP .minimal = (mascSem : PrProp E) := rfl
+    phiPresup innerP outerP .minimal = (mascSem : PartialProp E) := rfl
 
 -- ── Bridge to Features.Gender ─────
 
@@ -382,7 +382,7 @@ variable {E : Type*}
     or uniqueness condition. The predicate `familiar` is abstract —
     concretely it may be Heim's familiarity or Russell's uniqueness
     (cf. `Features.Definiteness.DefPresupType`). -/
-def defSem (familiar : E → Prop) : PrProp E where
+def defSem (familiar : E → Prop) : PartialProp E where
   presup := familiar
   assertion := fun _ => True
 
@@ -390,7 +390,7 @@ def defSem (familiar : E → Prop) : PrProp E where
     distribution is constrained pragmatically by Maximize Presupposition.
     Using an indefinite when a definite's presupposition is satisfied
     would violate MP!. -/
-def indefSem : PrProp E where
+def indefSem : PartialProp E where
   presup := fun _ => True
   assertion := fun _ => True
 
@@ -400,7 +400,7 @@ def indefSem : PrProp E where
 
 /-- `indefSem` is `phiPresup` at the minimal cell. -/
 @[simp] theorem indefSem_eq_phiPresup (innerP outerP : E → Prop) :
-    phiPresup innerP outerP .minimal = (indefSem : PrProp E) := rfl
+    phiPresup innerP outerP .minimal = (indefSem : PartialProp E) := rfl
 
 /-- Definiteness domain nesting: dom(DEF) ⊆ dom(INDEF). -/
 theorem def_domain_subset_indef (familiar : E → Prop) (x : E) :

--- a/Linglib/Semantics/Presupposition/TonhauserDerivation.lean
+++ b/Linglib/Semantics/Presupposition/TonhauserDerivation.lean
@@ -189,7 +189,7 @@ theorem belief_local_context_is_holder_beliefs
 "not pp'" has local context = global context at pp'.
 Therefore pp' projects (unless globally entailed).
 -/
-theorem negation_projects (c : ContextSet W) (p : PrProp W) :
+theorem negation_projects (c : ContextSet W) (p : PartialProp W) :
     presupProjects (localCtxNegation (initialLocalCtx c)) p ↔
     presupProjects (initialLocalCtx c) p := by
   exact negation_preserves_projection (initialLocalCtx c) p
@@ -199,7 +199,7 @@ theorem negation_projects (c : ContextSet W) (p : PrProp W) :
 
 "if p then qq'" — if p.assertion entails q.presup, it's filtered.
 -/
-theorem conditional_filters (c : LocalCtx W) (p q : PrProp W)
+theorem conditional_filters (c : LocalCtx W) (p q : PartialProp W)
     (h : ∀ w, c.worlds w → p.assertion w → q.presup w) :
     presupFiltered (localCtxConsequent c p) q :=
   conditional_filters_when_entailed c p q h
@@ -210,7 +210,7 @@ theorem conditional_filters (c : LocalCtx W) (p q : PrProp W)
 Under "x believes φ", the local context at φ is x's belief state.
 This derives OLE=yes behavior.
 -/
-theorem belief_derives_ole (blc : BeliefLocalCtx W Agent) (p : PrProp W)
+theorem belief_derives_ole (blc : BeliefLocalCtx W Agent) (p : PartialProp W)
     (h : presupAttributedToHolder blc p) (w_star : W) (hw : blc.globalCtx w_star) :
     presupFiltered (beliefToLocalCtx blc w_star hw) p :=
   h w_star hw

--- a/Linglib/Semantics/Presupposition/TriggerTypology.lean
+++ b/Linglib/Semantics/Presupposition/TriggerTypology.lean
@@ -91,7 +91,7 @@ Tracks presuppositions through the derivation, enabling:
 -/
 structure PresupDerivation (W : Type*) where
   /-- The underlying presuppositional proposition -/
-  meaning : PrProp W
+  meaning : PartialProp W
   /-- Presupposition triggers in the sentence -/
   triggers : List TriggerOccurrence
   /-- Current polarity context -/
@@ -111,11 +111,11 @@ integrating with the Exhaustivity module.
 -/
 structure ExhWithPresup (W : Type*) where
   /-- The base sentence -/
-  base : PrProp W
+  base : PartialProp W
   /-- Alternatives with their presuppositions -/
-  alternatives : List (PrProp W)
+  alternatives : List (PartialProp W)
   /-- The exhaustified meaning -/
-  exhaustified : PrProp W
+  exhaustified : PartialProp W
 
 
 -- ============================================================================

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -33,7 +33,7 @@ content (singularProp = false), but is used referentially.
 - `donnellanDivergence`: The two uses come apart when the description
   fails to apply to the intended referent
 - `definiteNominal`: Attributive semantics as a `NominalDenot` (selector =
-  the Russellian iota; `resolve` it for a `PrProp`)
+  the Russellian iota; `resolve` it for a `PartialProp`)
 
 -/
 
@@ -46,8 +46,8 @@ namespace Semantics.Reference.Donnellan
 
 open Core (Intension)
 open Core.Intension (rigid IsRigid rigid_isRigid)
-open Semantics.Presupposition (PrProp)
-open Semantics.Presupposition.PrProp (presupOfReferent)
+open Semantics.Presupposition (PartialProp)
+open Semantics.Presupposition.PartialProp (presupOfReferent)
 open Semantics.Reference.Basic
 open Semantics.Definiteness (russellIotaList)
 

--- a/Linglib/Semantics/Reference/Nominal.lean
+++ b/Linglib/Semantics/Reference/Nominal.lean
@@ -20,9 +20,9 @@ generalisation of this signature, to be added when a dynamic study needs it.
 * `NominalDenot Ctx W E` — intrinsic presupposition plus a partial referent
   selector.
 * `NominalDenot.resolve` — resolve a nominal against a scope, as
-  `PrProp.presupOfReferent` applied to the selector at a context. Existing
+  `PartialProp.presupOfReferent` applied to the selector at a context. Existing
   definite denotations *are* this, by `rfl` (see `Semantics.Reference.Donnellan`).
-* `NominalDenot.toPrProp` — the full denotation: `resolve` conjoined with the
+* `NominalDenot.toPartialProp` — the full denotation: `resolve` conjoined with the
   intrinsic presupposition, so a pronoun's φ-features project.
 
 ## Implementation notes
@@ -30,7 +30,7 @@ generalisation of this signature, to be added when a dynamic study needs it.
 `resolve` is deliberately *just* `presupOfReferent` applied to the selector at
 a context, so that the existing `presupOfReferent`-built definite denotations
 fold into a `NominalDenot` by `rfl` without migrating any consumer; the
-intrinsic presupposition is layered on separately in `toPrProp`.
+intrinsic presupposition is layered on separately in `toPartialProp`.
 
 ## Relation to the dynamic lookup interface
 
@@ -46,7 +46,7 @@ fiber, and bound pronouns share that selector with binding supplied externally
 Carrying the effect functor `M` *in this structure* (so `selector` is
 `Ctx → W → M (Option E)` and literally `iLookup`) is deliberately **not** done
 here: with only `Id` exercised it would be the same un-exercised generality
-PR1 removed, and a faithful `resolve`/`toPrProp` for `M ≠ Id` needs a
+PR1 removed, and a faithful `resolve`/`toPartialProp` for `M ≠ Id` needs a
 dynamic-semantic commitment (a nonempty-set / distribution presupposition) that
 belongs with the first dynamic consumer that requires it. Until then the seam
 lemma carries the connection.
@@ -56,7 +56,7 @@ set_option autoImplicit false
 
 namespace Semantics.Reference
 
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 
 /-- A presuppositional, context-relative individual denotation.
 
@@ -88,22 +88,22 @@ whose assertion applies `scope` to it. This is just `presupOfReferent` over
 `nd.selector c`, so any `presupOfReferent`-built denotation is a `resolve`, by
 `rfl`. -/
 def resolve (nd : NominalDenot Ctx W E) (scope : E → W → Prop)
-    (c : Ctx) : PrProp W :=
-  PrProp.presupOfReferent (nd.selector c) scope
+    (c : Ctx) : PartialProp W :=
+  PartialProp.presupOfReferent (nd.selector c) scope
 
 /-- An `ofReferent` resolved is exactly the canonical `presupOfReferent` — the
 bridge every definite denotation folds across. -/
 theorem ofReferent_resolve (referent : W → Option E) (scope : E → W → Prop) :
-    (ofReferent referent).resolve scope ⟨⟩ = PrProp.presupOfReferent referent scope :=
+    (ofReferent referent).resolve scope ⟨⟩ = PartialProp.presupOfReferent referent scope :=
   rfl
 
 /-- The full denotation: `resolve` conjoined with the intrinsic
 presupposition. For a definite the intrinsic presupposition is vacuous, so
-`toPrProp` and `resolve` agree; for a pronoun the conjoined presupposition is
+`toPartialProp` and `resolve` agree; for a pronoun the conjoined presupposition is
 where the φ-features project. -/
-def toPrProp (nd : NominalDenot Ctx W E) (scope : E → W → Prop)
-    (c : Ctx) : PrProp W :=
-  PrProp.and { presup := nd.presup c, assertion := fun _ => True }
+def toPartialProp (nd : NominalDenot Ctx W E) (scope : E → W → Prop)
+    (c : Ctx) : PartialProp W :=
+  PartialProp.and { presup := nd.presup c, assertion := fun _ => True }
     (nd.resolve scope c)
 
 end NominalDenot

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -26,7 +26,7 @@ and deictic uses (his §2.1.1); binding is the external β-operator
 ## Main definitions
 
 * `PersonalPronoun.phiPresup` — the conjoined φ-feature presupposition of an
-  entry (absent or featurally-uncovered values contribute `PrProp.top`).
+  entry (absent or featurally-uncovered values contribute `PartialProp.top`).
 * `PersonalPronoun.denote` — the pronoun's `NominalDenot` (static case).
 
 ## Implementation notes
@@ -39,7 +39,7 @@ bridges plus `ContainmentPairLike.toPair`, deferred until a study needs them.
 
 set_option autoImplicit false
 
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open Semantics.Presupposition.PhiFeatures
 open Semantics.Reference (NominalDenot)
 open Core (Assignment)
@@ -49,25 +49,25 @@ open Core.Logic.Intensional.Variables (interpPronoun DenotGS SitAssignment)
 domain `E`. The model supplies the entity-level predicates the cells need
 (`speaker`/`addressee` for person, `isFemale`/`isInanimate` for gender;
 number atomicity comes from the `PartialOrder`). A feature that is absent —
-or present but outside the cells' coverage — contributes `PrProp.top`. -/
+or present but outside the cells' coverage — contributes `PartialProp.top`. -/
 def PersonalPronoun.phiPresup {E : Type*} [PartialOrder E] (e : PersonalPronoun)
-    (speaker addressee : E) (isFemale isInanimate : E → Prop) : PrProp E :=
-  PrProp.and
+    (speaker addressee : E) (isFemale isInanimate : E → Prop) : PartialProp E :=
+  PartialProp.and
     (match e.person with
       | some .first  => firstSem speaker
       | some .second => secondSem speaker addressee
       | some .third  => thirdSem
-      | _            => PrProp.top)
-    (PrProp.and
+      | _            => PartialProp.top)
+    (PartialProp.and
       (match e.number with
         | some .singular => sgSem E
         | some .plural => plSem E
-        | _          => PrProp.top)
+        | _          => PartialProp.top)
       (match e.gender with
         | some .feminine  => femSem isFemale
         | some .neuter    => neutSem isInanimate
         | some .masculine => mascSem
-        | _               => PrProp.top))
+        | _               => PartialProp.top))
 
 /-- A pronoun's denotation as a `NominalDenot`: the selector is the canonical
 variable denotation `interpPronoun i` (always defined under a total
@@ -116,7 +116,7 @@ example {E : Type} [PartialOrder E] (g : Assignment E) (i : ℕ)
     (speaker addressee : E) (isFemale isInanimate : E → Prop)
     (scope : E → PUnit → Prop)
     (hFem : isFemale (g i)) :
-    ((ellas.denote i speaker addressee isFemale isInanimate).toPrProp scope g).presup ⟨⟩ := by
+    ((ellas.denote i speaker addressee isFemale isInanimate).toPartialProp scope g).presup ⟨⟩ := by
   refine ⟨⟨trivial, trivial, hFem⟩, ?_⟩
   rfl
 

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -240,7 +240,7 @@ theorem EPCondition.nonfuture_implies_downstream
     This captures the non-truth-conditional status of the evidential
     constraint: it is a felicity condition (presupposition), not part
     of what is asserted. Parameterized over an arbitrary world type `W`. -/
-def nonfutureMeaning {W : Type*} (f : EvidentialFrame ℤ) (p : Bool) : PrProp W where
+def nonfutureMeaning {W : Type*} (f : EvidentialFrame ℤ) (p : Bool) : PartialProp W where
   presup := λ _ => decide (f.eventTime ≤ f.acquisitionTime)
   assertion := λ _ => p
 

--- a/Linglib/Semantics/Tense/Perspective.lean
+++ b/Linglib/Semantics/Tense/Perspective.lean
@@ -162,20 +162,20 @@ theorem then_shifted_present_clash {Time : Type*}
   then_present_clash presRef thenRef shiftedPi hPres hDuring hThen
 
 
-/-! ### Bridge to PrProp -/
+/-! ### Bridge to PartialProp -/
 
-/-- Wrap PRES presupposition as a `PrProp`, showing how tense presuppositions
+/-- Wrap PRES presupposition as a `PartialProp`, showing how tense presuppositions
     compose with the existing presupposition projection system. -/
-def presAsPrProp {Time : Type*} [DecidableEq Time]
-    (f : ReichenbachFrame Time) : PrProp Unit where
+def presAsPartialProp {Time : Type*} [DecidableEq Time]
+    (f : ReichenbachFrame Time) : PartialProp Unit where
   presup := λ () => decide (f.referenceTime = f.perspectiveTime)
   assertion := λ () => true
 
-/-- The `PrProp` encoding is defined iff the PRES presupposition holds. -/
-theorem presAsPrProp_defined_iff {Time : Type*} [DecidableEq Time]
+/-- The `PartialProp` encoding is defined iff the PRES presupposition holds. -/
+theorem presAsPartialProp_defined_iff {Time : Type*} [DecidableEq Time]
     (f : ReichenbachFrame Time) :
-    (presAsPrProp f).presup () = true ↔ f.referenceTime = f.perspectiveTime := by
-  simp [presAsPrProp]
+    (presAsPartialProp f).presup () = true ↔ f.referenceTime = f.perspectiveTime := by
+  simp [presAsPartialProp]
 
 
 /-! ### Interpretation Parameters: c and π -/

--- a/Linglib/Semantics/TypeTheoretic/Discourse.lean
+++ b/Linglib/Semantics/TypeTheoretic/Discourse.lean
@@ -20,7 +20,7 @@ true backchannels live in `Pragmatics/Dialogue/KOS/`).
   bridge to CommonGround (§2.6).
 
 **Parametric Content**: Parametric bg/fg, PPpty, PQuant, PQuantDet, PRel2 (§4.2–4.3).
-  Bridge to Semantics.Presupposition.PrProp.
+  Bridge to Semantics.Presupposition.PartialProp.
 
 **Reference & Mental States**: HasNamed, NameContext, semPropNameP,
   TotalInfoState, AccommodationKind, Paderewski puzzle,
@@ -276,36 +276,36 @@ def Parametric.trivial {Content : Type*} (c : Content) : Parametric Content :=
 theorem Parametric.trivial_fg {Content : Type*} (c : Content) (u : Unit) :
     (Parametric.trivial c).fg u = c := rfl
 
-/-! ## Bridge: Parametric ↔ PrProp (presupposition/assertion) -/
+/-! ## Bridge: Parametric ↔ PartialProp (presupposition/assertion) -/
 
-/-- Convert a Parametric `(W → Prop)` to a PrProp. -/
-noncomputable def Parametric.toPrProp {W : Type*} (p : Parametric (W → Prop))
+/-- Convert a Parametric `(W → Prop)` to a PartialProp. -/
+noncomputable def Parametric.toPartialProp {W : Type*} (p : Parametric (W → Prop))
     (presupTest : W → Prop) [DecidablePred presupTest]
     (bgWitness : (w : W) → presupTest w → p.Bg) :
-    Semantics.Presupposition.PrProp W where
+    Semantics.Presupposition.PartialProp W where
   presup := presupTest
   assertion := λ w =>
     if h : presupTest w then p.fg (bgWitness w h) w else False
 
-/-- Convert a PrProp back to a Parametric. -/
-def _root_.Semantics.Presupposition.PrProp.toParametric {W : Type*}
-    (p : Semantics.Presupposition.PrProp W) :
+/-- Convert a PartialProp back to a Parametric. -/
+def _root_.Semantics.Presupposition.PartialProp.toParametric {W : Type*}
+    (p : Semantics.Presupposition.PartialProp W) :
     Parametric (Set W) where
   Bg := { w : W // p.presup w }
   fg := λ _ => p.assertion
 
-/-- Parametric ↔ PrProp roundtrip: the assertion component survives
+/-- Parametric ↔ PartialProp roundtrip: the assertion component survives
 when the presupposition holds. -/
-theorem toParametric_toPrProp_assertion {W : Type*} (p : Semantics.Presupposition.PrProp W) (w : W)
+theorem toParametric_toPartialProp_assertion {W : Type*} (p : Semantics.Presupposition.PartialProp W) (w : W)
     (hp : p.presup w) :
     p.toParametric.fg ⟨w, hp⟩ w ↔ p.assertion w := by
-  simp only [Semantics.Presupposition.PrProp.toParametric]
+  simp only [Semantics.Presupposition.PartialProp.toParametric]
 
-/-- When a Parametric has a Prop-valued background, it directly maps to PrProp. -/
-noncomputable def Parametric.toPrPropSimple {W : Type*}
+/-- When a Parametric has a Prop-valued background, it directly maps to PartialProp. -/
+noncomputable def Parametric.toPartialPropSimple {W : Type*}
     (presup : W → Prop) [DecidablePred presup]
     (assertion : (w : W) → presup w → Prop) :
-    Semantics.Presupposition.PrProp W where
+    Semantics.Presupposition.PartialProp W where
   presup := presup
   assertion := λ w => if h : presup w then assertion w h else False
 

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -80,7 +80,7 @@ Returns `some (cosSemantics t P)` if the verb has a CoS type,
 where `P` is the activity predicate (complement denotation).
 -/
 def Verb.getCoSSemantics {W : Type*} (v : Verb) (P : W → Prop) :
-    Option (PrProp W) :=
+    Option (PartialProp W) :=
   v.cosType.map λ t => cosSemantics t P
 
 /-- Does this verb presuppose its complement via factivity?

--- a/Linglib/Studies/BaleSchwarz2022.lean
+++ b/Linglib/Studies/BaleSchwarz2022.lean
@@ -52,7 +52,7 @@ namespace Phenomena.Quantification.BaleSchwarz2022
 open Semantics.Measurement
 open Features.Dimension (Dimension QuotientDimension quotient_components_distinct)
 open English.MeasurePhrases (gram kilo milliliter liter MeasureTermEntry)
-open Semantics.Presupposition (PrProp PrValue)
+open Semantics.Presupposition (PartialProp PartialValue)
 open Features (Acceptability)
 
 -- ============================================================================
@@ -414,17 +414,17 @@ theorem text_unit_sensitivity :
 -- § 10. Unit Sensitivity Presupposition (§7, eq. 43)
 -- ============================================================================
 
-/-- The revised lexical entry for *per* (eq. 43) as a `PrValue`:
+/-- The revised lexical entry for *per* (eq. 43) as a `PartialValue`:
 ⟦per⟧ = λq. λx: μ_{dim(q)}(x) ≥ q. μ_{dim(q)}(x) / q
 
 - **presup**: μ_{dim(q)}(x) ≥ q (unit sensitivity)
 - **value**: μ_{dim(q)}(x) / q (pure number)
 
-This is the canonical use case for `PrValue`: the at-issue content is
-a pure number (ℚ), not a truth value (Bool). `PrProp` cannot represent
+This is the canonical use case for `PartialValue`: the at-issue content is
+a pure number (ℚ), not a truth value (Bool). `PartialProp` cannot represent
 this directly — it only handles presupposed propositions. -/
 def perAnaphoricWithPresup {E : Type*} (μ : MeasureFn E) (q : ℚ)
-    (x : E) : PrValue Unit ℚ where
+    (x : E) : PartialValue Unit ℚ where
   presup := fun _ => μ.apply x ≥ q
   value := fun _ => perAnaphoric μ q x
 
@@ -440,10 +440,10 @@ theorem presup_satisfied_iff {E : Type*} (μ : MeasureFn E) (q : ℚ) (x : E) :
 theorem perValue_eq {E : Type*} (μ : MeasureFn E) (q : ℚ) (x : E) :
     (perAnaphoricWithPresup μ q x).value () = perAnaphoric μ q x := rfl
 
-/-- At the sentence level, `PrValue ℚ` composes with a measurement verb
-to produce a `PrProp` — presupposition projects, assertion is boolean. -/
+/-- At the sentence level, `PartialValue ℚ` composes with a measurement verb
+to produce a `PartialProp` — presupposition projects, assertion is boolean. -/
 def perSentenceWithPresup {E : Type*} (μ_wt μ_vol : MeasureFn E)
-    (perUnit : ℚ) (numeral : ℚ) (x : E) : PrProp Unit where
+    (perUnit : ℚ) (numeral : ℚ) (x : E) : PartialProp Unit where
   presup := fun _ => perPresup μ_vol perUnit x
   assertion := fun _ => measureVerbSem μ_wt (numeral * perAnaphoric μ_vol perUnit x) x
 

--- a/Linglib/Studies/Beaver2001/Basic.lean
+++ b/Linglib/Studies/Beaver2001/Basic.lean
@@ -22,7 +22,7 @@ then develops his own dynamic theory (PUL) in Part II:
 3. **Ch. 3 Cancellation and filtering**: Karttunen's heritage functions,
    Heim's CCP, the convergence of heritage/filtering/CCP (§3)
 4. **Ch. 4 Common ground**: Stalnaker's context sets, File Change Semantics,
-   DPL — all compute from `PrProp.presup` and `PrProp.assertion` (§4)
+   DPL — all compute from `PartialProp.presup` and `PartialProp.assertion` (§4)
 5. **Ch. 5 Accommodation**: Lewis 1979, van der Sandt 1992, Heim's
    global-preference synthesis, conditional presuppositions (§5-6)
 
@@ -33,21 +33,21 @@ then develops his own dynamic theory (PUL) in Part II:
 9. **Ch. 9 Accommodation in ABLE**: Accommodation within PUL
 10. **Ch. 10 Conclusion**: Summary and open problems
 
-## Structural Connection to PrProp
+## Structural Connection to PartialProp
 
 The central insight formalized here: Karttunen's heritage functions, Heim's
 filtering connectives, and CCP-based local contexts all compute projection
-from the same source — **PrProp.presup**.
+from the same source — **PartialProp.presup**.
 
 - Heritage function for `p → q` = `(impFilter p q).presup` (by construction)
-- Local context for q in `p → q` = `{ w ∈ c | p.assertion w }` (from PrProp)
+- Local context for q in `p → q` = `{ w ∈ c | p.assertion w }` (from PartialProp)
 - Accommodation operates on `p.presup` directly
 
-`PrProp` IS the two-dimensional representation of [karttunen-peters-1979]:
+`PartialProp` IS the two-dimensional representation of [karttunen-peters-1979]:
 `.presup` = their P-function, `.assertion` = their A-function. The filtering
 connectives resolve the "binding problem" (variables not linked between
 dimensions) by computing compound presuppositions from BOTH `.presup` and
-`.assertion` fields of the same `PrProp W` — the shared type parameter `W`
+`.assertion` fields of the same `PartialProp W` — the shared type parameter `W`
 ensures variables range over the same domain.
 
 No separate heritage type is needed. Filtering connectives ARE heritage
@@ -93,7 +93,7 @@ and **symmetry**: swapping φ and ψ does not change the projection.
 
 This uniformity is empirically too strong: "if p then q" presupposes
 π(p) ∧ (A(p) → π(q)), not π(p) ∧ π(q). The filtering connectives
-(`PrProp.impFilter`, etc.) capture this asymmetry. -/
+(`PartialProp.impFilter`, etc.) capture this asymmetry. -/
 
 /-- SK disjunction is symmetric for presupposition projection.
     [beaver-2001] Ch. 2: the correct empirical prediction. -/
@@ -110,40 +110,40 @@ theorem mk_disjunction_asymmetric :
 
 /-- Fact 2.1, negation: SK negation preserves presupposition.
     The presupposition of ¬φ is exactly π(φ). Re-export of
-    `PrProp.neg_presup`. -/
-theorem sk_neg_presup (p : PrProp W) :
-    (PrProp.neg p).presup = p.presup := PrProp.neg_presup p
+    `PartialProp.neg_presup`. -/
+theorem sk_neg_presup (p : PartialProp W) :
+    (PartialProp.neg p).presup = p.presup := PartialProp.neg_presup p
 
 /-- Fact 2.1, uniformity: all SK binary connectives produce the
     SAME presupposition — π(φ) ∧ π(ψ) — regardless of the connective.
     This is the hallmark of the SK approach: conjunction, disjunction,
     and implication are indistinguishable from the presupposition's
     perspective. -/
-theorem sk_binary_presup_uniform (p q : PrProp W) :
-    (PrProp.and p q).presup = (PrProp.or p q).presup ∧
-    (PrProp.or p q).presup = (PrProp.imp p q).presup := ⟨rfl, rfl⟩
+theorem sk_binary_presup_uniform (p q : PartialProp W) :
+    (PartialProp.and p q).presup = (PartialProp.or p q).presup ∧
+    (PartialProp.or p q).presup = (PartialProp.imp p q).presup := ⟨rfl, rfl⟩
 
 /-- Fact 2.1, symmetry: SK binary presuppositions are symmetric.
     Swapping φ and ψ does not change the presupposition. -/
-theorem sk_presup_symmetric (p q : PrProp W) :
-    (PrProp.and p q).presup = (PrProp.and q p).presup := by
-  funext w; simp only [PrProp.and]; exact propext And.comm
+theorem sk_presup_symmetric (p q : PartialProp W) :
+    (PartialProp.and p q).presup = (PartialProp.and q p).presup := by
+  funext w; simp only [PartialProp.and]; exact propext And.comm
 
 /-- Filtering presuppositions are NOT symmetric: there exist p, q where
     swapping the operands changes the presupposition. This is the empirically
     correct prediction — "if p then q" and "if q then p" have different
     presuppositions. -/
 theorem filtering_presup_not_symmetric :
-    ∃ (p q : PrProp Bool),
-      (PrProp.andFilter p q).presup ≠ (PrProp.andFilter q p).presup := by
+    ∃ (p q : PartialProp Bool),
+      (PartialProp.andFilter p q).presup ≠ (PartialProp.andFilter q p).presup := by
   refine ⟨⟨λ _ => True, λ _ => False⟩, ⟨λ _ => False, λ _ => True⟩, ?_⟩
   intro h
   have := congr_fun h false
-  simp only [PrProp.andFilter] at this
+  simp only [PartialProp.andFilter] at this
   exact (this.mp ⟨trivial, fun h => h.elim⟩).1
 
 -- ══════════════════════════════════════════════════════════
--- § 2. PrProp as Two-Dimensional Representation
+-- § 2. PartialProp as Two-Dimensional Representation
 -- ([beaver-2001] Ch. 2, §2.2; [karttunen-peters-1979])
 -- ══════════════════════════════════════════════════════════
 
@@ -151,10 +151,10 @@ theorem filtering_presup_not_symmetric :
 
 [karttunen-peters-1979] proposed parallel translation functions A(·)
 and P(·) that compute assertion and presupposition separately. This is
-structurally identical to `PrProp`:
+structurally identical to `PartialProp`:
 
-- `PrProp.assertion` = A(·) (assertion translation)
-- `PrProp.presup` = P(·) (presupposition translation)
+- `PartialProp.assertion` = A(·) (assertion translation)
+- `PartialProp.presup` = P(·) (presupposition translation)
 
 The **binding problem** ([beaver-2001] Ch. 2): in Karttunen & Peters'
 system, quantifier variables in the assertion dimension are not linked to
@@ -163,24 +163,24 @@ stopped smoking", the student bound by "every" in the assertion should be
 the same student bound in the presupposition — but the two translation
 functions compute independently.
 
-**PrProp resolves this by construction**: both `.presup` and `.assertion`
+**PartialProp resolves this by construction**: both `.presup` and `.assertion`
 are functions from the SAME type `W`. When `W` includes variable
 assignments (as in `W = World × Assignment`), the binding is shared. The
-filtering connectives explicitly reference both fields of a single PrProp,
+filtering connectives explicitly reference both fields of a single PartialProp,
 ensuring the variables agree across dimensions. -/
 
 /-- Filtering connectives reference BOTH `.presup` and `.assertion`,
     resolving the binding problem. The presupposition of `impFilter p q`
     depends on `p.assertion` (assertion of the antecedent) — linking
     the two dimensions. -/
-theorem filtering_links_dimensions (p q : PrProp W) (w : W) :
-    (PrProp.impFilter p q).presup w ↔
+theorem filtering_links_dimensions (p q : PartialProp W) (w : W) :
+    (PartialProp.impFilter p q).presup w ↔
     (p.presup w ∧ (p.assertion w → q.presup w)) := Iff.rfl
 
 /-- SK connectives do NOT link dimensions: they reference only `.presup`,
     ignoring `.assertion`. This means they cannot capture filtering. -/
-theorem sk_ignores_assertion (p q : PrProp W) (w : W) :
-    (PrProp.and p q).presup w ↔ (p.presup w ∧ q.presup w) := Iff.rfl
+theorem sk_ignores_assertion (p q : PartialProp W) (w : W) :
+    (PartialProp.and p q).presup w ↔ (p.presup w ∧ q.presup w) := Iff.rfl
 
 -- ══════════════════════════════════════════════════════════
 -- § 3. Heritage = Filtering (by construction)
@@ -193,34 +193,34 @@ this IS the `.presup` field — no separate heritage type needed.
 
 The convergence of heritage, filtering, and CCP is [beaver-2001]'s
 central result for Chs. 2-4. We show it holds by construction: all three
-read from the same `PrProp.presup` and `PrProp.assertion` fields. -/
+read from the same `PartialProp.presup` and `PartialProp.assertion` fields. -/
 
 /-- Heritage function for conditionals IS `.presup` of `impFilter`.
     [beaver-2001] Ch. 3: heritage, filtering, and CCP agree. -/
-example (p q : PrProp W) : (PrProp.impFilter p q).presup =
+example (p q : PartialProp W) : (PartialProp.impFilter p q).presup =
     (λ w => p.presup w ∧ (p.assertion w → q.presup w)) := rfl
 
 /-- Heritage function for conjunction IS `.presup` of `andFilter`. -/
-example (p q : PrProp W) : (PrProp.andFilter p q).presup =
+example (p q : PartialProp W) : (PartialProp.andFilter p q).presup =
     (λ w => p.presup w ∧ (p.assertion w → q.presup w)) := rfl
 
 /-- Heritage function for disjunction IS `.presup` of `orFilter`
     (asymmetric: the second disjunct's local context is the input
     updated with the negation of the first). -/
-example (p q : PrProp W) : (PrProp.orFilter p q).presup =
+example (p q : PartialProp W) : (PartialProp.orFilter p q).presup =
     (λ w => p.presup w ∧ (¬p.assertion w → q.presup w)) := rfl
 
 /-- Filtering vs SK: filtering conjunction is strictly weaker than SK
     conjunction in its presupposition requirements. When p's assertion
     entails q's presupposition, filtering drops q's presupposition
     entirely — SK never does. Re-uses
-    `PrProp.impFilter_presup_eq_andFilter_presup` to share the proof
+    `PartialProp.impFilter_presup_eq_andFilter_presup` to share the proof
     obligation with the conditional case. -/
-theorem filtering_weaker_than_sk (p q : PrProp W)
+theorem filtering_weaker_than_sk (p q : PartialProp W)
     (h : ∀ w, p.assertion w → q.presup w) :
-    (PrProp.andFilter p q).presup = p.presup := by
-  rw [← PrProp.impFilter_presup_eq_andFilter_presup]
-  exact PrProp.impFilter_eliminates_presup p q h
+    (PartialProp.andFilter p q).presup = p.presup := by
+  rw [← PartialProp.impFilter_presup_eq_andFilter_presup]
+  exact PartialProp.impFilter_eliminates_presup p q h
 
 -- ══════════════════════════════════════════════════════════
 -- § 4. Static ↔ Dynamic Agreement
@@ -228,8 +228,8 @@ theorem filtering_weaker_than_sk (p q : PrProp W)
 -- ══════════════════════════════════════════════════════════
 
 /-! The static filtering connectives and the dynamic CCP approach
-agree for conditionals. Both compute projection from PrProp.presup
-and PrProp.assertion — when the context entails p's presupposition,
+agree for conditionals. Both compute projection from PartialProp.presup
+and PartialProp.assertion — when the context entails p's presupposition,
 filtering holds iff the local context (from p.assertion) entails
 q's presupposition (from q.presup).
 
@@ -252,14 +252,14 @@ example (c : ContextSet W) (p : Set W) :
     ContextSet.update c p = λ w => c w ∧ p w := rfl
 
 /-- Static filtering = dynamic local context for conditionals.
-    Both derive from PrProp fields: `.presup` and `.assertion`.
+    Both derive from PartialProp fields: `.presup` and `.assertion`.
     This is the cornerstone theorem connecting three approaches:
     1. Static filtering ([karttunen-1973])
     2. Heim's CCP / File Change Semantics ([heim-1983])
     3. Local contexts ([schlenker-2009]) -/
 theorem static_dynamic_agreement (c : ContextSet W)
-    (p q : PrProp W) :
-    (∀ w, c w → (PrProp.impFilter p q).presup w) ↔
+    (p q : PartialProp W) :
+    (∀ w, c w → (PartialProp.impFilter p q).presup w) ↔
     (∀ w, c w → p.presup w ∧
                 (p.assertion w → q.presup w)) :=
   Semantics.Presupposition.LocalContext.local_context_matches_impFilter c p q
@@ -271,14 +271,14 @@ theorem static_dynamic_agreement (c : ContextSet W)
 
 /-! Heim's observation: global accommodation preference ≈ Gazdar cancellation.
 Accommodation operates on `p.presup` directly — the structural connection
-to PrProp is by construction. -/
+to PartialProp is by construction. -/
 
 open Semantics.Presupposition.Accommodation
 
 /-- Heim's synthesis: global preference selects global when consistent.
-    Accommodation input is `p.presup` — structurally connected to PrProp. -/
+    Accommodation input is `p.presup` — structurally connected to PartialProp. -/
 theorem heim_synthesis_projection (c : ContextSet W)
-    (p : PrProp W)
+    (p : PartialProp W)
     (h : ContextSet.nonEmpty
            (globalAccommodate c p.presup)) :
     heimSelect c p.presup = .global :=
@@ -287,7 +287,7 @@ theorem heim_synthesis_projection (c : ContextSet W)
 /-- Heim's synthesis: global preference selects local when inconsistent.
     This matches Gazdar's cancellation prediction. -/
 theorem heim_synthesis_cancellation (c : ContextSet W)
-    (p : PrProp W)
+    (p : PartialProp W)
     (h : ¬ContextSet.nonEmpty
            (globalAccommodate c p.presup)) :
     heimSelect c p.presup = .local :=
@@ -313,7 +313,7 @@ inductive SpiffWorld where
   deriving DecidableEq, Repr, Inhabited
 
 /-- "Spiff lands on Planet X" — no presupposition. -/
-def spiffLands : PrProp SpiffWorld where
+def spiffLands : PartialProp SpiffWorld where
   presup := λ _ => True
   assertion := λ w => match w with
     | .onPlanetX_heavy | .onPlanetX_light => True
@@ -321,7 +321,7 @@ def spiffLands : PrProp SpiffWorld where
 
 /-- "Spiff's weight is greater than on Earth" — presupposes being
     somewhere with weight (not in space). -/
-def weightGreater : PrProp SpiffWorld where
+def weightGreater : PartialProp SpiffWorld where
   presup := λ w => match w with
     | .inSpace => False
     | _ => True
@@ -350,9 +350,9 @@ def conditionalPresup : (SpiffWorld → Bool) :=
     prediction. Filtering predicts weight-is-defined; the conditional
     presupposition additionally requires weight > Earth. -/
 theorem conditional_presup_stronger_than_filtering :
-    ∃ w, (PrProp.impFilter spiffLands weightGreater).presup w ∧
+    ∃ w, (PartialProp.impFilter spiffLands weightGreater).presup w ∧
          conditionalPresup w = false := by
-  exact ⟨.onPlanetX_light, by simp [PrProp.impFilter, spiffLands, weightGreater],
+  exact ⟨.onPlanetX_light, by simp [PartialProp.impFilter, spiffLands, weightGreater],
          by simp [conditionalPresup]⟩
 
 -- ══════════════════════════════════════════════════════════
@@ -382,7 +382,7 @@ negation passes or fails the entire state.
 In Beaver's book, PUL updates are PARTIAL — presupposition failure
 causes the update to be undefined. Here we define the total operations
 (the defined cases). The presupposition check is modeled separately
-through `PrProp.presup`: a PUL update from a PrProp sentence p is
+through `PartialProp.presup`: a PUL update from a PartialProp sentence p is
 defined at context σ iff `∀ w, σ w → p.presup w = true`. -/
 
 /-- PUL atomic update: intersect context with proposition.

--- a/Linglib/Studies/Belnap1970.lean
+++ b/Linglib/Studies/Belnap1970.lean
@@ -23,7 +23,7 @@ semantic concepts per sentence A at world w (p. 3):
 3. A is **assertive_w** — whether A asserts anything at w
 4. **A_w** — what A asserts at w (a proposition = set of worlds)
 
-We formalize this via `PrProp` (presup = assertive, assertion = content),
+We formalize this via `PartialProp` (presup = assertive, assertion = content),
 showing that Belnap's system is isomorphic to linglib's existing partial
 proposition infrastructure.
 
@@ -71,25 +71,25 @@ set_option autoImplicit false
 
 namespace Belnap1970
 
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open Core.Duality (Truth3)
 open Aristotelian (Square SquareRelations)
 open Semantics.Quantification.Quantifier
 open Semantics.Montague (ToyEntity)
 
 -- ════════════════════════════════════════════════════════════════
--- §2–3. Conditional Assertion as PrProp
+-- §2–3. Conditional Assertion as PartialProp
 -- ════════════════════════════════════════════════════════════════
 
 /-- Belnap's (3): conditional assertion (A/B).
 
     "(A/B) is assertive_w just in case A is true_w.
      Provided (A/B) is assertive_w: (A/B)_w = B_w." -/
-abbrev condAssert {W : Type*} := @PrProp.condAssert W
+abbrev condAssert {W : Type*} := @PartialProp.condAssert W
 
 /-- Belnap's (6): atomic sentences are categorical — always assertive
     and always asserting the same proposition. -/
-abbrev atomic {W : Type*} := @PrProp.ofProp W
+abbrev atomic {W : Type*} := @PartialProp.ofProp W
 
 /-- Atomic sentences are assertive at every world (Belnap's (6)). -/
 theorem atomic_always_assertive {W : Type*} (p : W → Prop) (w : W) :
@@ -102,19 +102,19 @@ theorem atomic_always_assertive {W : Type*} (p : W → Prop) (w : W) :
 /-- Belnap's (7): negation preserves assertiveness and negates content.
 
     "~A is assertive_w just in case A is assertive_w. (~A)_w = ~(A_w)."
-    This is exactly `PrProp.neg`. -/
-theorem neg_preserves_assertiveness {W : Type*} (p : PrProp W) :
-    (PrProp.neg p).presup = p.presup := PrProp.neg_presup p
+    This is exactly `PartialProp.neg`. -/
+theorem neg_preserves_assertiveness {W : Type*} (p : PartialProp W) :
+    (PartialProp.neg p).presup = p.presup := PartialProp.neg_presup p
 
 /-- Belnap's (8): conjunction under conditional assertion is
-    `PrProp.andBelnap`, not classical `PrProp.and`.
+    `PartialProp.andBelnap`, not classical `PartialProp.and`.
 
     Classical conjunction requires BOTH operands to be defined.
     Belnap's requires only ONE — undefined conjuncts are skipped. -/
-abbrev belnapAnd {W : Type*} := @PrProp.andBelnap W
+abbrev belnapAnd {W : Type*} := @PartialProp.andBelnap W
 
 /-- Belnap's (9): disjunction under conditional assertion. -/
-abbrev belnapOr {W : Type*} := @PrProp.orBelnap W
+abbrev belnapOr {W : Type*} := @PartialProp.orBelnap W
 
 -- ════════════════════════════════════════════════════════════════
 -- §5. Restricted Quantification
@@ -128,7 +128,7 @@ abbrev belnapOr {W : Type*} := @PrProp.orBelnap W
     This derives restricted quantification from two independent mechanisms:
     conditional assertion (§2) and standard universal quantification (§4). -/
 def restrictedForall {E : Type} [Fintype E]
-    (C B : E → Bool) : PrProp Unit where
+    (C B : E → Bool) : PartialProp Unit where
   presup := λ _ => ∃ x : E, C x = true
   assertion := λ _ => ∀ x : E, C x = true → B x = true
 
@@ -137,7 +137,7 @@ def restrictedForall {E : Type} [Fintype E]
     ∃x(Cx/Bx) is assertive iff ∃xCx is true.
     What it asserts = disjunction of Bt for all t such that Ct is true. -/
 def restrictedExists {E : Type} [Fintype E]
-    (C B : E → Bool) : PrProp Unit where
+    (C B : E → Bool) : PartialProp Unit where
   presup := λ _ => ∃ x : E, C x = true
   assertion := λ _ => ∃ x : E, C x = true ∧ B x = true
 
@@ -183,7 +183,7 @@ theorem assertive_iff_restrictor_nonempty {E : Type} [Fintype E]
 
 /-- The **Belnap square**: the four Aristotelian forms as Belnap
     restricted quantification, packaged as a `Aristotelian.Square`
-    of partial propositions (`PrProp Unit`).
+    of partial propositions (`PartialProp Unit`).
 
     A: ∀x(Cx/Bx)   "All C are B"
     E: ∀x(Cx/¬Bx)  "No C are B"
@@ -193,7 +193,7 @@ theorem assertive_iff_restrictor_nonempty {E : Type} [Fintype E]
     Belnap: "semantic relations between these forms turn out to be
     pretty much a good old fashioned square of opposition!" -/
 def belnapSquare {E : Type} [Fintype E]
-    (C B : E → Bool) : Square (PrProp Unit) where
+    (C B : E → Bool) : Square (PartialProp Unit) where
   A := restrictedForall C B
   E := restrictedForall C (λ x => !B x)
   I := restrictedExists C B
@@ -210,7 +210,7 @@ theorem square_equiassertive {E : Type} [Fintype E]
 /-- The **content square**: extract the assertion-level content into a
     `Square (Unit → Bool)`, suitable for constructing `SquareRelations`.
 
-    Since `PrProp` assertions are now `Prop`-valued, we use `decide` to
+    Since `PartialProp` assertions are now `Prop`-valued, we use `decide` to
     convert back to `Bool` for compatibility with `SquareRelations`. -/
 def contentSquare {E : Type} [Fintype E] [DecidableEq E]
     (C B : E → Bool) : Square (Unit → Bool) where

--- a/Linglib/Studies/Buring2012.lean
+++ b/Linglib/Studies/Buring2012.lean
@@ -59,7 +59,7 @@ it, so the whole denotation lacks a defined value when the referent is not
 female. -/
 theorem she_undefined_of_non_female (scope : E → PUnit → Prop)
     (h : ¬ isFemale (g i)) :
-    ¬ ((she.denote i spk adr isFemale isInanimate).toPrProp scope g).presup ⟨⟩ :=
+    ¬ ((she.denote i spk adr isFemale isInanimate).toPartialProp scope g).presup ⟨⟩ :=
   fun hp => h hp.1.2.2
 
 /-- A bound pronoun has the same denotation as a free one: binding is the
@@ -76,7 +76,7 @@ denotation is defined of a referent regardless of gender — the structural
 correlate of *they*'s gender-neutrality, and the direct contrast with
 `she_undefined_of_non_female`. -/
 theorem they_defined_regardless_of_gender (scope : E → PUnit → Prop) :
-    ((they.denote i spk adr isFemale isInanimate).toPrProp scope g).presup ⟨⟩ := by
+    ((they.denote i spk adr isFemale isInanimate).toPartialProp scope g).presup ⟨⟩ := by
   refine ⟨⟨trivial, trivial, trivial⟩, ?_⟩
   rfl
 

--- a/Linglib/Studies/Cumming2026.lean
+++ b/Linglib/Studies/Cumming2026.lean
@@ -193,7 +193,7 @@ abbrev World := Fin 4
 def allWorlds : List World := [0, 1, 2, 3]
 
 open Semantics.Modality
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 
 -- ── § Raincoat scenario (parallel to Kernel.lean) ──
 

--- a/Linglib/Studies/DelPinalBassiSauerland2024.lean
+++ b/Linglib/Studies/DelPinalBassiSauerland2024.lean
@@ -39,7 +39,7 @@ set_option autoImplicit false
 
 namespace DelPinalBassiSauerland2024
 
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open CommonGround (ContextSet)
 open Exhaustification.Presuppositional
 open BarLevFox2020
@@ -83,7 +83,7 @@ Since ◇(p ∨ q) ∧ (◇p ↔ ◇q) entails ◇p ∧ ◇q, pex derives FC.
 -/
 
 /-- The pex output for free choice: pex^{IE+II}[◇(p ∨ q)]. -/
-def pexFC : PrProp FCWorld := pexIEII_full fcALT fcPrejacent
+def pexFC : PartialProp FCWorld := pexIEII_full fcALT fcPrejacent
 
 /-- FC via pex: when presupposition and assertion hold, we get ◇p ∧ ◇q.
 
@@ -119,7 +119,7 @@ theorem pex_fc :
   · exact ⟨hiff.mpr hB, hB⟩
 
 /-- Negation of pex FC: ¬pex^{IE+II}[◇(p ∨ q)]. -/
-def negPexFC : PrProp FCWorld := pexFC.neg
+def negPexFC : PartialProp FCWorld := pexFC.neg
 
 /-- Double prohibition: the negated pex output entails ¬◇p ∧ ¬◇q.
 
@@ -128,7 +128,7 @@ def negPexFC : PrProp FCWorld := pexFC.neg
 theorem pex_double_prohibition :
     ∀ w, negPexFC.holds w → ¬permA w ∧ ¬permB w := by
   intro w ⟨hpresup, hassert⟩
-  simp only [negPexFC, PrProp.neg,
+  simp only [negPexFC, PartialProp.neg,
              pexFC, pexIEII_full, pexIEII] at hpresup hassert
   -- hassert : ¬fcPrejacent w, i.e., ¬permAorB w
   -- ¬permAorB w → ¬permA w ∧ ¬permB w
@@ -247,16 +247,16 @@ so it projects independently.
     When pex(◇(p∨q)) is embedded under "unaware", the overall sentence
     *presupposes* ◇p ∧ ◇q (free choice as presupposition).
 
-    Uses `PrProp.negFactive` from `Semantics.Presupposition`. -/
+    Uses `PartialProp.negFactive` from `Semantics.Presupposition`. -/
 theorem fc_presupposed_under_neg_factive
     (believes : (FCWorld → Prop) → FCWorld → Prop) :
-    ∀ w, (PrProp.negFactive pexFC believes).presup w → permA w ∧ permB w :=
+    ∀ w, (PartialProp.negFactive pexFC believes).presup w → permA w ∧ permB w :=
   fun w hpresup => pex_fc w hpresup
 
 /-- The assertion of the negative factive embedding is about belief, not FC. -/
 theorem neg_factive_asserts_nonbelief
     (believes : (FCWorld → Prop) → FCWorld → Prop) :
-    ∀ w, (PrProp.negFactive pexFC believes).assertion w ↔
+    ∀ w, (PartialProp.negFactive pexFC believes).assertion w ↔
          ¬(believes fcPrejacent w) :=
   fun _ => Iff.rfl
 
@@ -298,19 +298,19 @@ meaning.
 
 /-- When the first disjunct is false, Karttunen filtering recovers full
     satisfaction of the second disjunct.
-    Uses `PrProp.disjFilterLeft` from `Semantics.Presupposition`. -/
+    Uses `PartialProp.disjFilterLeft` from `Semantics.Presupposition`. -/
 theorem filtering_recovers_pex {World : Type*}
-    (firstDisjunct : World → Prop) (sp : PrProp World)
+    (firstDisjunct : World → Prop) (sp : PartialProp World)
     (w : World) (hFirst : ¬firstDisjunct w)
-    (hFiltered : (PrProp.disjFilterLeft firstDisjunct sp).holds w) :
+    (hFiltered : (PartialProp.disjFilterLeft firstDisjunct sp).holds w) :
     sp.holds w :=
-  PrProp.disjFilterLeft_recovers firstDisjunct sp w hFirst hFiltered
+  PartialProp.disjFilterLeft_recovers firstDisjunct sp w hFirst hFiltered
 
 /-- Corollary: filtering FC for the concrete FCWorld case.
     When filtered pex holds and the first disjunct is false, FC follows. -/
 theorem filtering_fc (firstDisjunct : FCWorld → Prop) (w : FCWorld)
     (hFirst : ¬firstDisjunct w)
-    (hFiltered : (PrProp.disjFilterLeft firstDisjunct pexFC).holds w) :
+    (hFiltered : (PartialProp.disjFilterLeft firstDisjunct pexFC).holds w) :
     permA w ∧ permB w :=
   pex_fc w (filtering_recovers_pex firstDisjunct pexFC w hFirst hFiltered)
 
@@ -378,14 +378,14 @@ and the homogeneity ¬□L ↔ ¬□A combined with ¬□(L∧A) entails ¬□L 
     ¬□L ∧ ¬□A (negative free choice). -/
 theorem negative_fc_presupposed_under_neg_factive
     (believes : (FCWorld → Prop) → FCWorld → Prop) :
-    ∀ w, (PrProp.negFactive pexFC believes).presup w → notReqA w ∧ notReqB w :=
+    ∀ w, (PartialProp.negFactive pexFC believes).presup w → notReqA w ∧ notReqB w :=
   fun w hpresup => pex_negative_fc w hpresup
 
 /-- Filtering negative FC: when the first disjunct is false, the filtered
     presupposition of the second disjunct recovers negative FC. -/
 theorem filtering_negative_fc (firstDisjunct : FCWorld → Prop) (w : FCWorld)
     (hFirst : ¬firstDisjunct w)
-    (hFiltered : (PrProp.disjFilterLeft firstDisjunct pexFC).holds w) :
+    (hFiltered : (PartialProp.disjFilterLeft firstDisjunct pexFC).holds w) :
     notReqA w ∧ notReqB w :=
   pex_negative_fc w (filtering_recovers_pex firstDisjunct pexFC w hFirst hFiltered)
 
@@ -461,62 +461,62 @@ theorem existential_fc {Student : Type*}
     · exact ⟨hC, (hhomog x hx).mp hC⟩
     · exact ⟨(hhomog x hx).mpr hIC, hIC⟩⟩
 
-/-- Universal FC via `PrProp.forallPr`: when each student's pex output
+/-- Universal FC via `PartialProp.forallPartial`: when each student's pex output
     holds (presupposition projected universally + assertion holds),
     universal FC follows.
 
     This connects the abstract entailment theorems above to the concrete
-    `forallPr` combinator from `Semantics.Presupposition`. -/
-theorem forallPr_fc {Student W : Type*}
-    (S : Student → Prop) (pexPerStudent : Student → PrProp W) (w : W)
+    `forallPartial` combinator from `Semantics.Presupposition`. -/
+theorem forallPartial_fc {Student W : Type*}
+    (S : Student → Prop) (pexPerStudent : Student → PartialProp W) (w : W)
     (projA projB : Student → Set W)
     (hFC : ∀ x, S x → (pexPerStudent x).holds w →
       projA x w ∧ projB x w)
-    (hHolds : (PrProp.forallPr S pexPerStudent).holds w) :
+    (hHolds : (PartialProp.forallPartial S pexPerStudent).holds w) :
     (∀ x, S x → projA x w) ∧ (∀ x, S x → projB x w) := by
   obtain ⟨hPresup, hAssert⟩ := hHolds
   constructor
   · intro x hx; exact (hFC x hx ⟨hPresup x hx, hAssert x hx⟩).1
   · intro x hx; exact (hFC x hx ⟨hPresup x hx, hAssert x hx⟩).2
 
-/-- Existential FC via `PrProp.existsPrUniv`: with universal presupposition
+/-- Existential FC via `PartialProp.existsPartialUniv`: with universal presupposition
     projection from an existential quantifier, we get existential FC.
 
     This connects the existential entailment theorem to the concrete
-    `existsPrUniv` combinator from `Semantics.Presupposition`. -/
-theorem existsPrUniv_fc {Student W : Type*}
-    (S : Student → Prop) (pexPerStudent : Student → PrProp W) (w : W)
+    `existsPartialUniv` combinator from `Semantics.Presupposition`. -/
+theorem existsPartialUniv_fc {Student W : Type*}
+    (S : Student → Prop) (pexPerStudent : Student → PartialProp W) (w : W)
     (projA projB : Student → Set W)
     (hFC : ∀ x, S x → (pexPerStudent x).holds w →
       projA x w ∧ projB x w)
-    (hHolds : (PrProp.existsPrUniv S pexPerStudent).holds w) :
+    (hHolds : (PartialProp.existsPartialUniv S pexPerStudent).holds w) :
     ∃ x, S x ∧ projA x w ∧ projB x w := by
   obtain ⟨hPresup, ⟨x, hx, hAssert⟩⟩ := hHolds
   exact ⟨x, hx, hFC x hx ⟨hPresup x hx, hAssert⟩⟩
 
-/-- Universal negative FC via `PrProp.negExistsPr`: with universal
+/-- Universal negative FC via `PartialProp.negExistsPartial`: with universal
     presupposition projection and negated existential assertion,
     universal negative FC follows.
 
     This connects `universal_negative_fc` to the concrete
-    `negExistsPr` combinator from `Semantics.Presupposition`,
+    `negExistsPartial` combinator from `Semantics.Presupposition`,
     completing the set of quantifier bridges alongside
-    `forallPr_fc` and `existsPrUniv_fc`.
+    `forallPartial_fc` and `existsPartialUniv_fc`.
 
-    The shape differs from the positive bridges: `forallPr_fc` and
-    `existsPrUniv_fc` use `hFC : holds → projA ∧ projB` (assertion
+    The shape differs from the positive bridges: `forallPartial_fc` and
+    `existsPartialUniv_fc` use `hFC : holds → projA ∧ projB` (assertion
     decomposes to FC). Here, the assertion is *negated*, so we need:
     - `hAssertEq`: assertion ↔ reqA ∧ reqB (decomposition)
     - `hHomog`: presup → reqA ↔ reqB (homogeneity)
     These are exactly the inputs to `universal_negative_fc`. -/
-theorem negExistsPr_negative_fc {Student W : Type*}
-    (S : Student → Prop) (pexPerStudent : Student → PrProp W) (w : W)
+theorem negExistsPartial_negative_fc {Student W : Type*}
+    (S : Student → Prop) (pexPerStudent : Student → PartialProp W) (w : W)
     (reqA reqB : Student → Set W)
     (hAssertEq : ∀ x, S x → ((pexPerStudent x).assertion w ↔
       (reqA x w ∧ reqB x w)))
     (hHomog : ∀ x, S x → (pexPerStudent x).presup w →
       (reqA x w ↔ reqB x w))
-    (hHolds : (PrProp.negExistsPr S pexPerStudent).holds w) :
+    (hHolds : (PartialProp.negExistsPartial S pexPerStudent).holds w) :
     (¬∃ x, S x ∧ reqA x w) ∧ (¬∃ x, S x ∧ reqB x w) := by
   obtain ⟨hPresup, hNegAssert⟩ := hHolds
   exact universal_negative_fc S (fun x => reqA x w) (fun x => reqB x w)
@@ -647,7 +647,7 @@ def flatExhFC : Set FCWorld := exhIEII fcALT fcPrejacent
     - presupposes: the flat conjunction holds
     - asserts: S doesn't believe the flat conjunction -/
 def negFactiveOfFlatExh
-    (believes : (FCWorld → Prop) → FCWorld → Prop) : PrProp FCWorld where
+    (believes : (FCWorld → Prop) → FCWorld → Prop) : PartialProp FCWorld where
   presup := flatExhFC
   assertion := fun w => ¬(believes flatExhFC w)
 
@@ -663,7 +663,7 @@ theorem exh_factive_asserts_flat_conjunction
     prejacent — the correct content for S's doxastic state. -/
 theorem pex_factive_asserts_prejacent
     (believes : (FCWorld → Prop) → FCWorld → Prop) :
-    (PrProp.negFactive pexFC believes).assertion =
+    (PartialProp.negFactive pexFC believes).assertion =
       (fun w => ¬(believes fcPrejacent w)) := rfl
 
 /-- **Failure 2**: When flat exh is placed in a filtering disjunction,
@@ -672,14 +672,14 @@ theorem pex_factive_asserts_prejacent
 
     For "A ∨ exh(◇(p∨q))": the presupposition is trivial (True). -/
 theorem exh_filtering_no_presupposition (firstDisjunct : FCWorld → Prop) :
-    (PrProp.disjFilterLeft firstDisjunct (PrProp.ofProp flatExhFC)).presup =
+    (PartialProp.disjFilterLeft firstDisjunct (PartialProp.ofProp flatExhFC)).presup =
       (fun _ => True) := by
-  funext; simp [PrProp.disjFilterLeft, PrProp.ofProp]
+  funext; simp [PartialProp.disjFilterLeft, PartialProp.ofProp]
 
 /-- pex's filtering disjunction has a non-trivial presupposition (homogeneity
     conditioned on ¬firstDisjunct). -/
 theorem pex_filtering_has_presupposition (firstDisjunct : FCWorld → Prop) :
-    (PrProp.disjFilterLeft firstDisjunct pexFC).presup =
+    (PartialProp.disjFilterLeft firstDisjunct pexFC).presup =
       (fun w => ¬firstDisjunct w → pexFC.presup w) := rfl
 
 -- ============================================================================
@@ -727,8 +727,8 @@ formalized projection infrastructure:
 |---|---|---|
 | Filtering FC (§4) | `localCtxSecondDisjunct` | `local_context_matches_disjFilterLeft` |
 | Presupposed FC (§3) | `transparentProjection` | `negFactive_entails_transparent` |
-| Double prohibition (§2) | `negation_preserves_projection` | definitional (`PrProp.neg`) |
-| Quantificational FC (§5.1) | `forallPr`/`existsPrUniv`/`negExistsPr` | universal projection |
+| Double prohibition (§2) | `negation_preserves_projection` | definitional (`PartialProp.neg`) |
+| Quantificational FC (§5.1) | `forallPartial`/`existsPartialUniv`/`negExistsPartial` | universal projection |
 | Non-monotonic FC (§5.2) | universal homogeneity + cardinality | `exactly_one_fc` |
 | Accommodation (§4.4) | `heimSelect` | `accommodation_grounded_in_heim` |
 -/
@@ -737,13 +737,13 @@ variable {Agent : Type*}
 
 /-- Filtering FC is grounded in Schlenker's local context algorithm.
 
-    `filtering_fc` uses `PrProp.disjFilterLeft` as a combinator.
+    `filtering_fc` uses `PartialProp.disjFilterLeft` as a combinator.
     `local_context_matches_disjFilterLeft` proves this is equivalent to
     filtering at Schlenker's local context for the second disjunct:
     the presupposition ψ of the second disjunct is satisfied in
     the local context c ∧ ¬A iff ∀w∈c, ¬A(w) → ψ(w). -/
 theorem filtering_grounded_in_schlenker (c : ContextSet FCWorld)
-    (firstDisjunct : PrProp FCWorld) (w : FCWorld) (hc : c w)
+    (firstDisjunct : PartialProp FCWorld) (w : FCWorld) (hc : c w)
     (hFirst : ¬firstDisjunct.assertion w)
     (hSchlenkerFiltered : presupFiltered
       (localCtxSecondDisjunct (initialLocalCtx c) firstDisjunct) pexFC)
@@ -753,7 +753,7 @@ theorem filtering_grounded_in_schlenker (c : ContextSet FCWorld)
 
 /-- Presupposed FC is grounded in transparent projection.
 
-    `fc_presupposed_under_neg_factive` uses `PrProp.negFactive` as a
+    `fc_presupposed_under_neg_factive` uses `PartialProp.negFactive` as a
     combinator. Here we decompose this into two steps:
     1. `negFactive_entails_transparent`: negFactive's presupposition
        (complement holds) entails transparent projection of the presup.
@@ -766,7 +766,7 @@ theorem presupposed_fc_grounded_in_transparent
     (believes : (FCWorld → Prop) → FCWorld → Prop) (w : FCWorld)
     (hGlobal : globalCtx w)
     (hNegFactive : ∀ v, globalCtx v →
-      (PrProp.negFactive pexFC believes).presup v) :
+      (PartialProp.negFactive pexFC believes).presup v) :
     permA w ∧ permB w := by
   -- Step 1: negFactive → transparent projection (presup holds globally)
   have hTransparent : transparentProjection globalCtx pexFC :=
@@ -795,7 +795,7 @@ theorem opaque_fc_under_belief
 
 /-- Double prohibition is grounded in negation transparency.
 
-    `PrProp.neg` preserves presuppositions by construction (assertion negated,
+    `PartialProp.neg` preserves presuppositions by construction (assertion negated,
     presupposition unchanged). This matches `negation_preserves_projection`:
     Schlenker's local context under negation has the same world set as the
     parent context, so presuppositions project through negation unchanged. -/
@@ -817,7 +817,7 @@ theorem negation_grounding :
     this corresponds to the case where `heimSelect` falls back to local
     because global accommodation would be inconsistent. -/
 theorem accommodation_grounded_in_heim {W : Type*}
-    (c : ContextSet W) (pex_output : PrProp W)
+    (c : ContextSet W) (pex_output : PartialProp W)
     (h_consistent : ContextSet.nonEmpty
       (globalAccommodate c pex_output.presup)) :
     heimSelect c pex_output.presup = .global :=
@@ -828,7 +828,7 @@ theorem accommodation_grounded_in_heim {W : Type*}
     This models the ACC operator from §4.4 that prevents homogeneity
     from projecting in hostile environments. -/
 theorem enemy_territory_blocks_projection {W : Type*}
-    (c : ContextSet W) (pex_output : PrProp W)
+    (c : ContextSet W) (pex_output : PartialProp W)
     (h_inconsistent : ¬ContextSet.nonEmpty
       (globalAccommodate c pex_output.presup)) :
     heimSelect c pex_output.presup = .local :=
@@ -848,7 +848,7 @@ of `pexFC`. Two non-cancellability theorems are stated, tracking the
 structural-vs-substantive distinction documented at the
 `Presuppositional.lean` BPS bridge: `pexFC_not_cancellable` follows from
 the wrapper's choice to set assertion to `holds`; `pexFC_neg_not_cancellable`
-follows from projection of `pexFC.presup` through `PrProp.neg`, the
+follows from projection of `pexFC.presup` through `PartialProp.neg`, the
 formal counterpart to BPS's family-of-sentences test. -/
 
 open Exhaustification.Presuppositional
@@ -866,7 +866,7 @@ assertion is the full pex output (`pexFC.holds`), no continuation cancels
 the inferred content. This follows from `holds := presup ∧ assertion`
 trivially. -/
 theorem pexFC_not_cancellable :
-    ¬ Implicature.IsCancellable (fun w => PrProp.holds w pexFC)
+    ¬ Implicature.IsCancellable (fun w => PartialProp.holds w pexFC)
                                 fcImplicature := by
   -- the proof of bps_not_cancellable applies; fcImplicature differs from
   -- (bpsToImplicature fcALT pexFC) only in the `kind` field, which the
@@ -881,10 +881,10 @@ free-choice inference (`pexFC.presup`, which yields `permA w ∧ permB w`
 by `pex_fc`) survives. This is the formal counterpart to BPS's
 projection argument: the inference is not at-issue, so embedding under
 negation does not cancel it. The proof traces through
-`PrProp.neg_presup` — the structural projection identity — not just
+`PartialProp.neg_presup` — the structural projection identity — not just
 the trivial `holds → presup`. -/
 theorem pexFC_neg_not_cancellable :
-    ¬ Implicature.IsCancellable (fun w => PrProp.holds w pexFC.neg)
+    ¬ Implicature.IsCancellable (fun w => PartialProp.holds w pexFC.neg)
                                 fcImplicature := by
   apply Implicature.IsCancellable.false_of_assertion_implies_content
   intro _ h

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -64,8 +64,8 @@ namespace Elbourne2013
 
 open Core (WorldTimeIndex)
 
-open Semantics.Presupposition (PrProp)
-open Semantics.Presupposition.PrProp (presupOfReferent presupOfReferent_presup
+open Semantics.Presupposition (PartialProp)
+open Semantics.Presupposition.PartialProp (presupOfReferent presupOfReferent_presup
   presupOfReferent_assertion_some presupOfReferent_assertion_none)
 open Semantics.Definiteness (russellIotaList)
 open Features.Definiteness (DefPresupType)
@@ -137,7 +137,7 @@ The situation parameter `s` may be:
 def the_sit (F : SituationFrame) (domain : List F.Ent)
     (restrictor : F.Ent → F.Sit → Bool)
     (scope : F.Ent → F.Sit → Bool)
-    : PrProp F.Sit :=
+    : PartialProp F.Sit :=
   presupOfReferent (fun s => russellIotaList domain (fun e => restrictor e s))
                    (fun e s => scope e s = true)
 
@@ -145,7 +145,7 @@ def the_sit (F : SituationFrame) (domain : List F.Ent)
     Coincides with the canonical definite (`Donnellan.definiteNominal`
     resolved) — the same Russellian iota factored through `presupOfReferent`. -/
 def the_sit' {W E : Type} (domain : List E)
-    (restrictor : E → W → Bool) (scope : E → W → Bool) : PrProp W :=
+    (restrictor : E → W → Bool) (scope : E → W → Bool) : PartialProp W :=
   presupOfReferent (fun w => russellIotaList domain (fun e => restrictor e w))
                    (fun e w => scope e w = true)
 
@@ -155,7 +155,7 @@ def the_sit' {W E : Type} (domain : List E)
 -- ════════════════════════════════════════════════════════════════
 
 /-- `the_sit'` and the canonical definite (`definiteNominal` resolved) denote
-    the same `PrProp`: both factor through `presupOfReferent` applied to a
+    the same `PartialProp`: both factor through `presupOfReferent` applied to a
     Russellian iota over the domain. The two names reflect different lineages
     (Elbourne's situation semantics vs. Donnellan's attributive use); the
     denotation is one and the same. -/
@@ -303,7 +303,7 @@ structure PronounAsDefinite where
 
 /-- Pronoun denotation: ⟦it⟧ = ⟦the⟧ + NP-deletion. -/
 abbrev pronounDenot {W E : Type} (domain : List E)
-    (recoveredNP : E → W → Bool) (scope : E → W → Bool) : PrProp W :=
+    (recoveredNP : E → W → Bool) (scope : E → W → Bool) : PartialProp W :=
   the_sit' domain recoveredNP scope
 
 /-- Pronouns = definite articles. -/
@@ -490,7 +490,7 @@ def isInsane : Ent → Sit → Bool
   | .jones, _ => true
   | _, _ => false
 
-def theMurderer : PrProp Sit := the_sit' allEnts isMurderer isInsane
+def theMurderer : PartialProp Sit := the_sit' allEnts isMurderer isInsane
 
 theorem referential_presup :
     theMurderer.presup .sCourtroom := rfl
@@ -534,7 +534,7 @@ def isCoveredWithBooks : Ent → Sit → Bool
   | .table1, _ => true
   | _, _ => false
 
-def theTable : PrProp Sit := the_sit' allEnts isTable isCoveredWithBooks
+def theTable : PartialProp Sit := the_sit' allEnts isTable isCoveredWithBooks
 
 theorem incomplete_presup_office :
     theTable.presup .sOffice := rfl
@@ -606,7 +606,7 @@ def isBeaten : DkEnt → DkSit → Bool
   | .donkey_b, _ => true
   | _, _ => false
 
-def donkeyPronoun : PrProp DkSit := the_sit' dkEnts isDonkey isBeaten
+def donkeyPronoun : PartialProp DkSit := the_sit' dkEnts isDonkey isBeaten
 
 theorem donkey_presup_min1 :
     donkeyPronoun.presup .sMin1 := rfl
@@ -679,7 +679,7 @@ def isSpy : BEnt → BSit → Bool
   | .smith, _ => true
   | _, _ => false
 
-def thePresident : PrProp BSit := the_sit' bEnts isPresident isSpy
+def thePresident : PartialProp BSit := the_sit' bEnts isPresident isSpy
 
 theorem deRe_presup : thePresident.presup .actual := rfl
 theorem deRe_assertion : ¬ thePresident.assertion .actual := by
@@ -742,7 +742,7 @@ def isQuiet : GhostEnt → GhostSit → Bool
   | .ghost, _ => true
   | _, _ => false
 
-def theGhost : PrProp GhostSit := the_sit' ghostEnts isGhost isQuiet
+def theGhost : PartialProp GhostSit := the_sit' ghostEnts isGhost isQuiet
 
 theorem ghost_presup_belief :
     theGhost.presup .belief := rfl
@@ -770,7 +770,7 @@ end ExistenceEntailment
 
 section PronounAsDefiniteExample
 
-def itAsDonkey : PrProp DkSit :=
+def itAsDonkey : PartialProp DkSit :=
   pronounDenot dkEnts isDonkey isBeaten
 
 theorem pronoun_matches_definite_min1 :

--- a/Linglib/Studies/Enguehard2024.lean
+++ b/Linglib/Studies/Enguehard2024.lean
@@ -70,7 +70,7 @@ set_option autoImplicit false
 
 namespace Enguehard2024
 
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open Semantics.Presupposition.PhiFeatures
 
 -- ============================================================================
@@ -312,9 +312,9 @@ theorem mix_both_conceivable
 theorem conceivability_same_assertion {W : Type*}
     (witnessCard : W → Nat) (conceivable : W → Prop) (w : W) :
     (⟨fun _ => sgCardConceivable witnessCard conceivable,
-      fun _ => True⟩ : PrProp W).assertion w ↔
+      fun _ => True⟩ : PartialProp W).assertion w ↔
     (⟨fun _ => plCardConceivable witnessCard conceivable,
-      fun _ => True⟩ : PrProp W).assertion w :=
+      fun _ => True⟩ : PartialProp W).assertion w :=
   Iff.rfl
 
 -- ============================================================================
@@ -446,15 +446,15 @@ abstracts away from the actual entity.
 -/
 
 /-- The conceivability presupposition of a sg indefinite, packaged as
-    a `PrProp` that is constant across evaluation worlds. -/
+    a `PartialProp` that is constant across evaluation worlds. -/
 def sgIndefPresup {W : Type*} (witnessCard : W → Nat)
-    (conceivable : W → Prop) : PrProp W where
+    (conceivable : W → Prop) : PartialProp W where
   presup := fun _ => sgCardConceivable witnessCard conceivable
   assertion := fun _ => True
 
 /-- The conceivability presupposition of a pl indefinite. -/
 def plIndefPresup {W : Type*} (witnessCard : W → Nat)
-    (conceivable : W → Prop) : PrProp W where
+    (conceivable : W → Prop) : PartialProp W where
   presup := fun _ => plCardConceivable witnessCard conceivable
   assertion := fun _ => True
 
@@ -508,7 +508,7 @@ This explains the empirical asymmetry:
 ### Connection to pex infrastructure
 
 `pexIEII` (from `Presuppositional.lean`) produces a
-`PrProp` with:
+`PartialProp` with:
 - **assertion** = φ (the prejacent)
 - **presupposition** = ¬IE ∧ homog(II)
 

--- a/Linglib/Studies/Gajewski2011.lean
+++ b/Linglib/Studies/Gajewski2011.lean
@@ -66,7 +66,7 @@ with "DE + scalar endpoint" (Conjecture 48).
   `condition2_with_no_alts_iff_de`). `only`'s satisfaction of Cond 1, 2
   in the trivial limit cited below.
 - Conditions 3, 4 (eqs. 93, 94): formalized in PresuppositionLicensing.lean
-  via `KPOperator` over `PrProp`. `only` satisfies Cond 3 ✓, fails
+  via `KPOperator` over `PartialProp`. `only` satisfies Cond 3 ✓, fails
   Cond 4 ✗ (`gaj2011_only_condition3_yes_condition4_no`).
 
 ## What's still genuinely deferred
@@ -281,13 +281,13 @@ them to `only` and verify the empirical match: weak NPIs licensed
 -/
 
 open Semantics.Entailment.PresuppositionLicensing
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 
 /-- The K&P operator for `only x`: assertion = "no y ≠ x has scope",
     presupposition = "some y has x and scope" (Horn 1996). Built directly
-    from `onlyPrProp` in StrawsonEntailment. -/
+    from `onlyPartialProp` in StrawsonEntailment. -/
 def onlyKP (x : World → Prop) : KPOperator World :=
-  fun scope => onlyPrProp x scope
+  fun scope => onlyPartialProp x scope
 
 /-- Ex. 19a (p. 115) confirmed: `only` satisfies Condition 3 — its
     truth-conditional assertion is *classically DE* in the scope.

--- a/Linglib/Studies/Geurts2005.lean
+++ b/Linglib/Studies/Geurts2005.lean
@@ -44,10 +44,10 @@ as Modals* (Natural Language Semantics 13:383–410). Following
   `List.Pairwise`, and a binary specialisation used by the bridge theorems
   and Case #3).
 * `defaultBinding` — by default A = C (paper p.394).
-* `fromPrProp`, `fromPrProp_*_iff_orFlex`, `fromPrProp_*_iff_orBelnap` —
+* `fromPartialProp`, `fromPartialProp_*_iff_orFlex`, `fromPartialProp_*_iff_orBelnap` —
   specialisation to presuppositional propositions: when domain = presup and
   content = assertion, the Geurts disjunction coincides pointwise with
-  `PrProp.orFlex` = `PrProp.orBelnap` ([belnap-1970]).
+  `PartialProp.orFlex` = `PartialProp.orBelnap` ([belnap-1970]).
 * `exhaustivity_implies_uninformative` — used by
   `Studies/Yagi2025.lean` as the formal residue of
   [schlenker-2009]'s local-context-failure observation.
@@ -59,7 +59,7 @@ as Modals* (Natural Language Semantics 13:383–410). Following
   treats only ∃/∀; we route `weakNecessity` to the universal branch (every
   weak-necessity claim still quantifies universally over its refined
   best-worlds set).
-* The `fromPrProp_*_iff_*` lemmas are structural: `PrProp.orFlex.presup` is
+* The `fromPartialProp_*_iff_*` lemmas are structural: `PartialProp.orFlex.presup` is
   defined as the union of disjunct presuppositions, so the iff is
   unfolding, not stipulation. The architecture intentionally avoids the
   "stipulate then prove equivalence" anti-pattern.
@@ -213,44 +213,44 @@ theorem default_existential_holds_iff (C : Set W) (bs : List (Set W)) :
   · intro h b hb; exact h _ b hb rfl
   · rintro h _ b hb rfl; exact h b hb
 
-/-! ### Specialisation to PrProp
+/-! ### Specialisation to PartialProp
 
 When presuppositions conflict, modal domains coincide with presuppositional
-domains and Geurts's disjunction specialises to `PrProp.orFlex`. These
+domains and Geurts's disjunction specialises to `PartialProp.orFlex`. These
 lemmas are structural (the orFlex domain is defined as the union of
 disjunct presuppositions in `Semantics/Presupposition/Basic.lean`), not
 stipulated bridges. -/
 
 /-- Construct a Geurts possibility disjunction from two presuppositional
 propositions: domains = presuppositions, contents = assertions. -/
-def fromPrProp (p q : PrProp W) : MDisjunction W :=
+def fromPartialProp (p q : PartialProp W) : MDisjunction W :=
   [ { domain := p.presup, force := .possibility, content := p.assertion }
   , { domain := q.presup, force := .possibility, content := q.assertion } ]
 
-/-- The overall presupposition of a Geurts disjunction from PrProps coincides
-with `PrProp.orFlex.presup`: p.presup ∨ q.presup. -/
-theorem fromPrProp_presup_iff_orFlex (p q : PrProp W) (w : W) :
-    (∃ d ∈ fromPrProp p q, d.domain w) ↔ (PrProp.orFlex p q).presup w := by
-  simp [fromPrProp, PrProp.orFlex]
+/-- The overall presupposition of a Geurts disjunction from PartialProps coincides
+with `PartialProp.orFlex.presup`: p.presup ∨ q.presup. -/
+theorem fromPartialProp_presup_iff_orFlex (p q : PartialProp W) (w : W) :
+    (∃ d ∈ fromPartialProp p q, d.domain w) ↔ (PartialProp.orFlex p q).presup w := by
+  simp [fromPartialProp, PartialProp.orFlex]
 
-/-- The assertion side: Geurts cells = `PrProp.orFlex.assertion`. -/
-theorem fromPrProp_cell_iff_orFlex (p q : PrProp W) (w : W) :
-    (∃ d ∈ fromPrProp p q, d.cell w) ↔ (PrProp.orFlex p q).assertion w := by
-  simp only [fromPrProp, Disjunct.cell, PrProp.orFlex,
+/-- The assertion side: Geurts cells = `PartialProp.orFlex.assertion`. -/
+theorem fromPartialProp_cell_iff_orFlex (p q : PartialProp W) (w : W) :
+    (∃ d ∈ fromPartialProp p q, d.cell w) ↔ (PartialProp.orFlex p q).assertion w := by
+  simp only [fromPartialProp, Disjunct.cell, PartialProp.orFlex,
              List.mem_cons, List.not_mem_nil, or_false,
              exists_eq_or_imp, exists_eq_left]
   rfl
 
 /-- Transitivity via `orFlex_eq_orBelnap`: Geurts presupposition = orBelnap
 presupposition ([belnap-1970] conditional assertion). -/
-theorem fromPrProp_presup_iff_orBelnap (p q : PrProp W) (w : W) :
-    (∃ d ∈ fromPrProp p q, d.domain w) ↔ (PrProp.orBelnap p q).presup w := by
-  rw [fromPrProp_presup_iff_orFlex, ← PrProp.orFlex_eq_orBelnap]
+theorem fromPartialProp_presup_iff_orBelnap (p q : PartialProp W) (w : W) :
+    (∃ d ∈ fromPartialProp p q, d.domain w) ↔ (PartialProp.orBelnap p q).presup w := by
+  rw [fromPartialProp_presup_iff_orFlex, ← PartialProp.orFlex_eq_orBelnap]
 
 /-- Transitivity via `orFlex_eq_orBelnap`: Geurts cell = orBelnap assertion. -/
-theorem fromPrProp_cell_iff_orBelnap (p q : PrProp W) (w : W) :
-    (∃ d ∈ fromPrProp p q, d.cell w) ↔ (PrProp.orBelnap p q).assertion w := by
-  rw [fromPrProp_cell_iff_orFlex, ← PrProp.orFlex_eq_orBelnap]
+theorem fromPartialProp_cell_iff_orBelnap (p q : PartialProp W) (w : W) :
+    (∃ d ∈ fromPartialProp p q, d.cell w) ↔ (PartialProp.orBelnap p q).assertion w := by
+  rw [fromPartialProp_cell_iff_orFlex, ← PartialProp.orFlex_eq_orBelnap]
 
 /-- If Geurts's exhaustivity holds for C, the disjunction (orFlex/orBelnap)
 is already true throughout C — the disjunction is uninformative.
@@ -260,15 +260,15 @@ discussion: pragmatic conditions on local contexts force s₀ to contain only
 worlds where some disjunct is true, making the disjunction trivially
 satisfied. Geurts's Exhaustivity is the explicit form of that constraint.
 Consumed by `Studies/Yagi2025.lean`. -/
-theorem exhaustivity_implies_uninformative (p q : PrProp W)
-    (C : Set W) (h_exh : exhaustivity C (fromPrProp p q))
+theorem exhaustivity_implies_uninformative (p q : PartialProp W)
+    (C : Set W) (h_exh : exhaustivity C (fromPartialProp p q))
     (w : W) (hw : C w) :
-    (PrProp.orFlex p q).assertion w :=
-  (fromPrProp_cell_iff_orFlex p q w).mp (h_exh w hw)
+    (PartialProp.orFlex p q).assertion w :=
+  (fromPartialProp_cell_iff_orFlex p q w).mp (h_exh w hw)
 
 /-- When presuppositions conflict (p ∧ q = ⊥), the Geurts domains are
 automatically disjoint — Disjointness is satisfied for free. -/
-theorem conflicting_presups_disjoint (p q : PrProp W)
+theorem conflicting_presups_disjoint (p q : PartialProp W)
     (h_conflict : ∀ w, ¬(p.presup w ∧ q.presup w)) :
     disjointness₂
       { domain := p.presup, force := .possibility, content := p.assertion }

--- a/Linglib/Studies/Glass2025.lean
+++ b/Linglib/Studies/Glass2025.lean
@@ -32,8 +32,8 @@ Semantics and Pragmatics 18, Article 8: 1-17.
 
 ## Formalization Strategy
 
-Belief verb denotations are `PrProp W` values produced by
-`DoxasticPredicate.toPrProp`. The presup field captures the factive
+Belief verb denotations are `PartialProp W` values produced by
+`DoxasticPredicate.toPartialProp`. The presup field captures the factive
 presupposition (or lack thereof). yǐwéi's postsupposition is a separate
 `Semantics.Dynamic.Postsupposition` value. The `PresupClass` classification and PLC
 validation from `Doxastic.lean` derive the contrafactive gap.
@@ -76,7 +76,7 @@ private def neutralCtx : List MiniWorld := [.w0, .w1]
 private def contrafactiveCtx : List MiniWorld := [.w1]
 
 -- ============================================================================
--- §2. Belief Verb PrProps
+-- §2. Belief Verb PartialProps
 -- ============================================================================
 
 /-!
@@ -85,27 +85,27 @@ from veridicality, matching [glass-2025] Table 1.
 
 We define the presup fields directly (rather than instantiating full
 `DoxasticPredicate`s) to keep the model minimal. The connection to
-`DoxasticPredicate.toPrProp` is established by the classification
+`DoxasticPredicate.toPartialProp` is established by the classification
 theorems in §4.
 -/
 
 /-- *know*: presupposes p (factive). -/
-private def knowPresup : PrProp MiniWorld where
+private def knowPresup : PartialProp MiniWorld where
   presup := λ w => prop w = true
   assertion := λ _ => True
 
 /-- *think*: no presupposition (nonfactive). -/
-private def thinkPresup : PrProp MiniWorld where
+private def thinkPresup : PartialProp MiniWorld where
   presup := λ _ => True
   assertion := λ _ => True
 
 /-- Hypothetical *contra*: presupposes ¬p (strong contrafactive). -/
-private def contraPresup : PrProp MiniWorld where
+private def contraPresup : PartialProp MiniWorld where
   presup := λ w => prop w = false
   assertion := λ _ => True
 
-/-- yǐwéi: nonfactive PrProp + postsupposition ◇¬p. -/
-private def yiweiPresup : PrProp MiniWorld where
+/-- yǐwéi: nonfactive PartialProp + postsupposition ◇¬p. -/
+private def yiweiPresup : PartialProp MiniWorld where
   presup := λ _ => True
   assertion := λ _ => True
 

--- a/Linglib/Studies/GoldbergShirtz2025.lean
+++ b/Linglib/Studies/GoldbergShirtz2025.lean
@@ -336,7 +336,7 @@ than a hard definedness condition: speakers exploit the construction
 precisely for situation types that are not antecedently familiar
 (observational humor, sniglets), so common-ground satisfaction is typically
 reached by accommodation or pretense, not antecedent entailment. -/
-def palMeaning (W : Type*) (situationType headNoun : W → Prop) : PrProp W :=
+def palMeaning (W : Type*) (situationType headNoun : W → Prop) : PartialProp W :=
   { presup := situationType, assertion := headNoun }
 
 /-! ### Typed pragmatics: familiarity inherits through the network
@@ -358,7 +358,7 @@ theorem pal_children :
 /-- Own pragmatic contributions for the Figure 5 network: only PAL itself
 carries one — the familiarity-presupposing meaning. -/
 def figure5Pragmatics (W : Type*) (situationType headNoun : W → Prop) :
-    Construction → Option (PrProp W) :=
+    Construction → Option (PartialProp W) :=
   λ c => if c.name == "PAL" then some (palMeaning W situationType headNoun)
          else none
 

--- a/Linglib/Studies/Grove2022.lean
+++ b/Linglib/Studies/Grove2022.lean
@@ -37,7 +37,7 @@ plus attitude-verb examples (Part II).
 * `evalI` — evaluation `(·)^ž` (eq. 20)
 * `forallP` / `existsP` — presuppositional quantifiers (eq. 27)
 * `believe` — doxastic attitude verb (eq. 28)
-* Bridges to `Truth3`, `Prop3`, `PrProp`
+* Bridges to `Truth3`, `Prop3`, `PartialProp`
 
 ## Part II — Empirical predictions (Grove §3, §4.2)
 
@@ -77,7 +77,7 @@ set_option autoImplicit false
 namespace Grove2022
 
 open Core.Duality (Truth3 Prop3)
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 
 /-! ## Part I — Apparatus -/
 
@@ -255,7 +255,7 @@ end AttitudeVerbs
 
 /-! ### §6 Bridges to existing linglib types
 
-`Option Bool`, `Truth3`, and `PrProp W` are three representations of
+`Option Bool`, `Truth3`, and `PartialProp W` are three representations of
 possibly-undefined truth values. These conversions connect Grove's
 formalisation to the rest of the presupposition infrastructure. -/
 
@@ -319,20 +319,20 @@ proposition). -/
 def toProp3 {W : Type} (φ : Iₚ W Bool) : Prop3 W :=
   λ w => toTruth3 (φ w)
 
-/-- Convert `Iₚ W Bool` to `PrProp W`. The presupposition field is
+/-- Convert `Iₚ W Bool` to `PartialProp W`. The presupposition field is
 `isSome` (defined?), and the assertion is the Bool value (defaulting
 to `false` when undefined). -/
-def toPrProp {W : Type} (φ : Iₚ W Bool) : PrProp W :=
+def toPartialProp {W : Type} (φ : Iₚ W Bool) : PartialProp W :=
   { presup := λ w => (φ w).isSome
   , assertion := λ w => (φ w).getD false }
 
-theorem toPrProp_presup {W : Type} (φ : Iₚ W Bool) (w : W) :
-    (toPrProp φ).presup w = (φ w).isSome := rfl
+theorem toPartialProp_presup {W : Type} (φ : Iₚ W Bool) (w : W) :
+    (toPartialProp φ).presup w = (φ w).isSome := rfl
 
-theorem toPrProp_assertion {W : Type} (φ : Iₚ W Bool) (w : W) (v : Bool)
+theorem toPartialProp_assertion {W : Type} (φ : Iₚ W Bool) (w : W) (v : Bool)
     (h : φ w = some v) :
-    (toPrProp φ).assertion w = v := by
-  simp [toPrProp, h]
+    (toPartialProp φ).assertion w = v := by
+  simp [toPartialProp, h]
 
 end Bridges
 

--- a/Linglib/Studies/Heim1992Projection.lean
+++ b/Linglib/Studies/Heim1992Projection.lean
@@ -36,7 +36,7 @@ formalized; the substrate splits along the natural Phenomena boundary
 
 namespace Heim1992
 
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open CommonGround (ContextSet)
 open Core.Logic.Modal (IsSerial IsEuclidean IsS5Frame IsKD45Frame
   IsBeliefRefinementOf)
@@ -133,7 +133,7 @@ instance : IsBeliefRefinementOf (agentKnowsR .john) (agentBelievesR .john) :=
 
 /-- "Mary used to smoke" — the presupposition of "stop smoking".
     True at `believed`, false at `actual`. -/
-def presup : PrProp AttWorld :=
+def presup : PartialProp AttWorld :=
   { presup := fun w => match w with
       | .believed => True
       | .actual => False

--- a/Linglib/Studies/Izvorski1997.lean
+++ b/Linglib/Studies/Izvorski1997.lean
@@ -174,7 +174,7 @@ def allWorlds : List World := [0, 1, 2, 3]
 
 /-- Izvorski's EV operator (formalization of (17)–(19) + (8ii)). -/
 def izvorskiEv (f : ModalBase World) (g : OrderingSource World)
-    (p : World → Prop) : PrProp World where
+    (p : World → Prop) : PartialProp World where
   presup := λ w => (accessibleWorlds f w).Nonempty
   assertion := λ w => necessity f g p w
 
@@ -275,8 +275,8 @@ theorem izvorski_collapses_to_koev_when_realistic
     exact h
 
 theorem izvorski_projection (f : ModalBase World) (g : OrderingSource World) (p : World → Prop) :
-    (PrProp.neg (izvorskiEv f g p)).presup = (izvorskiEv f g p).presup :=
-  PrProp.neg_presup _
+    (PartialProp.neg (izvorskiEv f g p)).presup = (izvorskiEv f g p).presup :=
+  PartialProp.neg_presup _
 
 theorem nfutL_compatible_with_izvorski : nfutL.ep = .downstream := rfl
 

--- a/Linglib/Studies/Karttunen1973.lean
+++ b/Linglib/Studies/Karttunen1973.lean
@@ -164,20 +164,20 @@ inductive AttWorld where
 
 /-- "Mary used to smoke" — the presupposition of "stop smoking". True in
     `believed`, false in `actual`. -/
-def maryUsedToSmoke : PrProp AttWorld where
+def maryUsedToSmoke : PartialProp AttWorld where
   presup := fun _ => True
   assertion := fun w => w = .believed
 
 /-- The speaker-projection of a *plug*-treatment of *believe*: nothing of
     the complement projects. -/
-def plugSpeakerCommitment : PrProp AttWorld where
+def plugSpeakerCommitment : PartialProp AttWorld where
   presup := fun _ => True
   assertion := fun _ => True
 
 /-- The speaker-projection of K1973's flat *hole*-treatment of *believe*
     (pre-Heim 1992): the complement's presupposition projects unchanged
     to the speaker. -/
-def holeSpeakerCommitment : PrProp AttWorld := maryUsedToSmoke
+def holeSpeakerCommitment : PartialProp AttWorld := maryUsedToSmoke
 
 /-- The plug analysis predicts no speaker commitment to "Mary used to
     smoke" at the actual world; the hole analysis predicts the speaker
@@ -214,34 +214,34 @@ variable {W : Type*}
 
 /-- K1973 rule (13a), p. 178: the antecedent's presupposition always
     projects to "If A then B". -/
-theorem impFilter_presup_of_antecedent_undefined (p q : PrProp W) (w : W)
+theorem impFilter_presup_of_antecedent_undefined (p q : PartialProp W) (w : W)
     (hp : ¬p.presup w) :
-    ¬(PrProp.impFilter p q).presup w := by
-  simp only [PrProp.impFilter, hp, false_and, not_false_eq_true]
+    ¬(PartialProp.impFilter p q).presup w := by
+  simp only [PartialProp.impFilter, hp, false_and, not_false_eq_true]
 
 /-- K1973 rule (13b), p. 178: B's presupposition is filtered when A's
     assertion entails it. -/
-theorem impFilter_eliminates_presup_when_entailed (p q : PrProp W)
+theorem impFilter_eliminates_presup_when_entailed (p q : PartialProp W)
     (h : ∀ w, p.assertion w → q.presup w) :
-    (PrProp.impFilter p q).presup = p.presup :=
-  PrProp.impFilter_eliminates_presup p q h
+    (PartialProp.impFilter p q).presup = p.presup :=
+  PartialProp.impFilter_eliminates_presup p q h
 
 /-- K1973 rule (17), p. 179: filtering for *and* matches that for
     *if...then*. -/
-theorem andFilter_presup_eq_impFilter_presup (p q : PrProp W) :
-    (PrProp.andFilter p q).presup = (PrProp.impFilter p q).presup :=
-  (PrProp.impFilter_presup_eq_andFilter_presup p q).symm
+theorem andFilter_presup_eq_impFilter_presup (p q : PartialProp W) :
+    (PartialProp.andFilter p q).presup = (PartialProp.impFilter p q).presup :=
+  (PartialProp.impFilter_presup_eq_andFilter_presup p q).symm
 
 /-- K1973 rule (24b), p. 181 — paper-anchored alias for the substrate
-    `PrProp.disjFilterLeft_eliminates_presup_when_neg_entails`. Karttunen's
+    `PartialProp.disjFilterLeft_eliminates_presup_when_neg_entails`. Karttunen's
     asymmetric form: "A or B" carries no residual presupposition from B
     when ¬A entails it. The substrate carries the proof; Karttunen 1973
     is the paper that motivated it. -/
 theorem disjFilterLeft_eliminates_presup_when_neg_entails
-    (A : W → Prop) (q : PrProp W)
+    (A : W → Prop) (q : PartialProp W)
     (h : ∀ w, ¬A w → q.presup w) :
-    (PrProp.disjFilterLeft A q).presup = fun _ => True :=
-  PrProp.disjFilterLeft_eliminates_presup_when_neg_entails A q h
+    (PartialProp.disjFilterLeft A q).presup = fun _ => True :=
+  PartialProp.disjFilterLeft_eliminates_presup_when_neg_entails A q h
 
 -- ════════════════════════════════════════════════════════════════
 -- § 4. Cumulativity (K1973 §§5–7, Langendoen & Savin 1971)
@@ -249,10 +249,10 @@ theorem disjFilterLeft_eliminates_presup_when_neg_entails
 
 /-- K's "cumulative principle" (Langendoen & Savin 1971; named by Morgan
     1969 per K1973 §1): the presuppositions of a compound include those
-    of its constituents. For `PrProp.and` this is just the conjunction of
+    of its constituents. For `PartialProp.and` this is just the conjunction of
     presuppositions. -/
-theorem cumulativity_principle (p q : PrProp W) (w : W) :
-    (PrProp.and p q).presup w ↔ p.presup w ∧ q.presup w := Iff.rfl
+theorem cumulativity_principle (p q : PartialProp W) (w : W) :
+    (PartialProp.and p q).presup w ↔ p.presup w ∧ q.presup w := Iff.rfl
 
 -- ════════════════════════════════════════════════════════════════
 -- § 5. Classical-Logic Equivalence (K1973 §8)
@@ -270,19 +270,19 @@ theorem cumulativity_principle (p q : PrProp W) (w : W) :
     K's §8 argument relies on. -/
 
 /-- The presupposition functions of `if A then B` and `A and B` coincide. -/
-theorem if_and_share_presup_function (p q : PrProp W) :
-    (PrProp.impFilter p q).presup = (PrProp.andFilter p q).presup :=
-  PrProp.impFilter_presup_eq_andFilter_presup p q
+theorem if_and_share_presup_function (p q : PartialProp W) :
+    (PartialProp.impFilter p q).presup = (PartialProp.andFilter p q).presup :=
+  PartialProp.impFilter_presup_eq_andFilter_presup p q
 
-/-- Harman's principles, as facts about Core `PrProp` connectives:
+/-- Harman's principles, as facts about Core `PartialProp` connectives:
     (i) internal negation preserves presupposition; (ii) impFilter and
     andFilter share presupposition (the structural witness of
     "logical equivalents share presupposition" specialized to the De
     Morgan equivalence ⌜A ⊃ B⌝ ≡ ⌜~(A ∧ ~B)⌝). -/
 theorem harman_derivation_principles_hold :
-    (∀ p : PrProp W, (PrProp.neg p).presup = p.presup) ∧
-    (∀ p q : PrProp W, (PrProp.impFilter p q).presup = (PrProp.andFilter p q).presup) :=
-  ⟨PrProp.neg_presup, PrProp.impFilter_presup_eq_andFilter_presup⟩
+    (∀ p : PartialProp W, (PartialProp.neg p).presup = p.presup) ∧
+    (∀ p q : PartialProp W, (PartialProp.impFilter p q).presup = (PartialProp.andFilter p q).presup) :=
+  ⟨PartialProp.neg_presup, PartialProp.impFilter_presup_eq_andFilter_presup⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 6. Local-Context Bridge (K1973 §9 → CCP)
@@ -305,8 +305,8 @@ theorem harman_derivation_principles_hold :
     The forward direction is K's rule (13b) relativized; the backward
     direction is Schlenker's local-context derivation. -/
 theorem k1973_section9_local_context_correspondence
-    (c : ContextSet W) (p q : PrProp W) :
-    (∀ w, c w → (PrProp.impFilter p q).presup w) ↔
+    (c : ContextSet W) (p q : PartialProp W) :
+    (∀ w, c w → (PartialProp.impFilter p q).presup w) ↔
     (∀ w, c w → p.presup w ∧ (p.assertion w → q.presup w)) :=
   Semantics.Presupposition.LocalContext.local_context_matches_impFilter c p q
 
@@ -314,10 +314,10 @@ theorem k1973_section9_local_context_correspondence
     instance. K p. 185 frames (13b) as a degenerate case of the X-set
     machinery, which is what `LocalContext.lean` makes load-bearing for
     the general case. -/
-theorem rule13b_is_empty_X_instance (p q : PrProp W)
+theorem rule13b_is_empty_X_instance (p q : PartialProp W)
     (h : ∀ w, p.assertion w → q.presup w) :
-    (PrProp.impFilter p q).presup = p.presup :=
-  PrProp.impFilter_eliminates_presup p q h
+    (PartialProp.impFilter p q).presup = p.presup :=
+  PartialProp.impFilter_eliminates_presup p q h
 
 -- ════════════════════════════════════════════════════════════════
 -- § 7. Three-Valued Logic Comparison (K1973 §10)
@@ -338,18 +338,18 @@ theorem rule13b_is_empty_X_instance (p q : PrProp W)
     This motivates the §9 X-set / context-relative formulation that
     becomes CCP. -/
 
-/-- Bochvar internal conjunction = `PrProp.and` = cumulative principle.
+/-- Bochvar internal conjunction = `PartialProp.and` = cumulative principle.
     K1973 p. 187: "the internal Bochvar connectives are holes." -/
-theorem bochvar_internal_is_cumulative (p q : PrProp W) (w : W) :
-    (PrProp.and p q).presup w ↔ (p.presup w ∧ q.presup w) := Iff.rfl
+theorem bochvar_internal_is_cumulative (p q : PartialProp W) (w : W) :
+    (PartialProp.and p q).presup w ↔ (p.presup w ∧ q.presup w) := Iff.rfl
 
 /-- The filtering conjunction is strictly weaker than cumulative:
     `andFilter` can be defined when `q`'s presupposition fails (provided
     `p`'s assertion is false). -/
-theorem andFilter_presup_weaker_than_cumulative (p q : PrProp W) (w : W)
-    (h : (PrProp.and p q).presup w) :
-    (PrProp.andFilter p q).presup w := by
-  simp only [PrProp.and, PrProp.andFilter] at *
+theorem andFilter_presup_weaker_than_cumulative (p q : PartialProp W) (w : W)
+    (h : (PartialProp.and p q).presup w) :
+    (PartialProp.andFilter p q).presup w := by
+  simp only [PartialProp.and, PartialProp.andFilter] at *
   exact ⟨h.1, fun _ => h.2⟩
 
 -- ════════════════════════════════════════════════════════════════
@@ -364,24 +364,24 @@ theorem andFilter_presup_weaker_than_cumulative (p q : PrProp W) (w : W)
     > all of them." (p. 187)
 
     K defines `⌜¬A⌝ ≡ ⌜~t(A)⌝`. Both operators are now in
-    `Semantics.Presupposition`: `PrProp.neg` (internal/choice) and
-    `PrProp.negExt` (external/exclusion = `neg ∘ truthOp`). -/
+    `Semantics.Presupposition`: `PartialProp.neg` (internal/choice) and
+    `PartialProp.negExt` (external/exclusion = `neg ∘ truthOp`). -/
 
 /-- Internal negation preserves presupposition (it's a hole). -/
-theorem neg_preserves_presup (p : PrProp W) :
-    (PrProp.neg p).presup = p.presup := PrProp.neg_presup p
+theorem neg_preserves_presup (p : PartialProp W) :
+    (PartialProp.neg p).presup = p.presup := PartialProp.neg_presup p
 
 /-- External negation is always defined (it's a plug). -/
-theorem negExt_always_defined (p : PrProp W) (w : W) :
-    (PrProp.negExt p).presup w := PrProp.negExt_presup p w
+theorem negExt_always_defined (p : PartialProp W) (w : W) :
+    (PartialProp.negExt p).presup w := PartialProp.negExt_presup p w
 
 /-- Internal and external negation agree on assertion at worlds where
     the presupposition holds; they diverge only at presupposition failure
     (where `neg` is undefined and `negExt` is asserted true). -/
-theorem neg_agrees_with_negExt_when_defined (p : PrProp W) (w : W)
+theorem neg_agrees_with_negExt_when_defined (p : PartialProp W) (w : W)
     (h : p.presup w) :
-    (PrProp.neg p).assertion w ↔ (PrProp.negExt p).assertion w :=
-  PrProp.neg_assertion_iff_negExt_assertion_when_defined p w h
+    (PartialProp.neg p).assertion w ↔ (PartialProp.negExt p).assertion w :=
+  PartialProp.neg_assertion_iff_negExt_assertion_when_defined p w h
 
 -- ════════════════════════════════════════════════════════════════
 -- § 9. Geraldine X-Set Example (K1973 §9, ex 25–28)
@@ -412,7 +412,7 @@ inductive Geraldine where
   deriving DecidableEq, Repr
 
 /-- "Geraldine is a Mormon" — no presupposition. -/
-def isMormon : PrProp Geraldine where
+def isMormon : PartialProp Geraldine where
   presup := fun _ => True
   assertion := fun w => w = .mormon_worn ∨ w = .mormon_notWorn
 

--- a/Linglib/Studies/KayFillmore1999.lean
+++ b/Linglib/Studies/KayFillmore1999.lean
@@ -19,7 +19,7 @@ form–function mismatch is derived rather than stipulated: the literal
 reading is a genuine question (speaker-ignorance satisfies the PerspP
 presupposition), the incredulity reading a blocked one (speaker knowledge
 contradicts it), with the presupposed proposition and the
-unexpectedness CI typed via `PrProp`/`TwoDimProp`.
+unexpectedness CI typed via `PartialProp`/`TwoDimProp`.
 
 The paper's own inheritance hierarchy — WXDY inheriting from the
 left-isolation, subject–aux-inversion, and wh-interrogative constructions
@@ -316,14 +316,14 @@ open Semantics.Presupposition
 
 "What's this fly doing in my soup?" presupposes: there is a fly in the soup.
 The at-issue assertion is trivial — the point is to express the CI. -/
-def wxdyPresup {W : Type*} (embeddedProp : W → Prop) : PrProp W where
+def wxdyPresup {W : Type*} (embeddedProp : W → Prop) : PartialProp W where
   presup := embeddedProp
   assertion _ := True
 
 /-- Presupposition projects through negation: "It's not the case that
 [what's this fly doing in my soup]" still presupposes the fly is there. -/
 theorem wxdy_presup_projects_neg {W : Type*} (embeddedProp : W → Prop) :
-    ∀ w, (PrProp.neg (wxdyPresup embeddedProp)).presup w ↔
+    ∀ w, (PartialProp.neg (wxdyPresup embeddedProp)).presup w ↔
          embeddedProp w := fun _ => Iff.rfl
 
 /-! ### Two-dimensional semantics bridge (Expressives/Basic.lean) -/

--- a/Linglib/Studies/KeshetAbney2024.lean
+++ b/Linglib/Studies/KeshetAbney2024.lean
@@ -1117,7 +1117,7 @@ end DPLComparison
 /-!
 Presupposition projection bridges are in `PIP.Bridges`:
 - `pip_felicity_agrees_with_andFilter` — F(φ ∧ ψ) ↔ andFilter
-- `pip_felicity_agrees_with_neg` — F(¬φ) ↔ PrProp.neg
+- `pip_felicity_agrees_with_neg` — F(¬φ) ↔ PartialProp.neg
 - `pip_felicity_agrees_with_impFilter` — F(φ → ψ) ↔ impFilter
 - `pip_felicity_agrees_with_orFilter` — F(φ ∨ ψ) decomposition
 -/

--- a/Linglib/Studies/KeshetAbney2024/Bridges.lean
+++ b/Linglib/Studies/KeshetAbney2024/Bridges.lean
@@ -17,7 +17,7 @@ import Mathlib.Data.Fintype.Basic
 This file connects PIP to the rest of linglib, establishing correspondences
 between PIP's formulation and the standard treatments in:
 
-1. **Presupposition projection** — PIP's F operator ↔ `PrProp.andFilter`
+1. **Presupposition projection** — PIP's F operator ↔ `PartialProp.andFilter`
 2. **Generalized quantifiers** — PIP's EVERY/SOME ↔ `GQ`
 3. **Plural semantics** — PIP's SINGLE/PLURAL ↔ Link's Atom/properPlural
 4. **Modal logic** — PIP's must/might ↔ `Core.Logic.Intensional.box/diamond`
@@ -51,21 +51,21 @@ open Core.Logic.Modal.Logic (frameConditions)
 -- ============================================================
 
 /-!
-### Presupposition Projection: F ↔ PrProp connectives
+### Presupposition Projection: F ↔ PartialProp connectives
 
-PIP's F operator and `Semantics.Presupposition.PrProp` filtering connectives
+PIP's F operator and `Semantics.Presupposition.PartialProp` filtering connectives
 implement the same Karttunen conjunction clause ([karttunen-1973]).
 These theorems were previously in the study file; they belong in the
 theory layer because they establish a general correspondence.
 -/
 
 /--
-PIP's conjunction felicity agrees with `PrProp.andFilter`.
+PIP's conjunction felicity agrees with `PartialProp.andFilter`.
 
 **PIP Felicity** (`PIPExpr.felicitous` for `.conj φ ψ`):
   `φ.felicitous w && ((φ.truth w).not || ψ.felicitous w)`
 
-**PrProp.andFilter** (`Semantics.Presupposition`):
+**PartialProp.andFilter** (`Semantics.Presupposition`):
   `p.presup w && (!p.assertion w || q.presup w)`
 
 These are structurally identical when interpreting `truth` as `assertion`
@@ -74,24 +74,24 @@ and `felicitous` as `presup`.
 theorem pip_felicity_agrees_with_andFilter {W : Type*}
     (φ ψ : Felicity.PIPExpr W) (w : W) :
     (Felicity.PIPExpr.conj φ ψ).felicitous w ↔
-    (Semantics.Presupposition.PrProp.andFilter
-      (({ presup w := φ.felicitous w, assertion w := φ.truth w } : Semantics.Presupposition.PrProp _))
-      (({ presup w := ψ.felicitous w, assertion w := ψ.truth w } : Semantics.Presupposition.PrProp _))).presup w :=
+    (Semantics.Presupposition.PartialProp.andFilter
+      (({ presup w := φ.felicitous w, assertion w := φ.truth w } : Semantics.Presupposition.PartialProp _))
+      (({ presup w := ψ.felicitous w, assertion w := ψ.truth w } : Semantics.Presupposition.PartialProp _))).presup w :=
   Iff.rfl
 
 /--
-PIP's negation felicity agrees with `PrProp.neg`: both preserve the
+PIP's negation felicity agrees with `PartialProp.neg`: both preserve the
 presupposition/felicity of the negated expression unchanged.
 -/
 theorem pip_felicity_agrees_with_neg {W : Type*}
     (φ : Felicity.PIPExpr W) (w : W) :
     (Felicity.PIPExpr.neg φ).felicitous w ↔
-    (Semantics.Presupposition.PrProp.neg
-      (({ presup w := φ.felicitous w, assertion w := φ.truth w } : Semantics.Presupposition.PrProp _))).presup w :=
+    (Semantics.Presupposition.PartialProp.neg
+      (({ presup w := φ.felicitous w, assertion w := φ.truth w } : Semantics.Presupposition.PartialProp _))).presup w :=
   Iff.rfl
 
 /--
-PIP's implication felicity agrees with `PrProp.impFilter`.
+PIP's implication felicity agrees with `PartialProp.impFilter`.
 
   F(φ → ψ) = Fφ ∧ (φ → Fψ)
 
@@ -101,9 +101,9 @@ the antecedent can satisfy the consequent's presupposition.
 theorem pip_felicity_agrees_with_impFilter {W : Type*}
     (φ ψ : Felicity.PIPExpr W) (w : W) :
     (Felicity.PIPExpr.impl φ ψ).felicitous w ↔
-    (Semantics.Presupposition.PrProp.impFilter
-      (({ presup w := φ.felicitous w, assertion w := φ.truth w } : Semantics.Presupposition.PrProp _))
-      (({ presup w := ψ.felicitous w, assertion w := ψ.truth w } : Semantics.Presupposition.PrProp _))).presup w :=
+    (Semantics.Presupposition.PartialProp.impFilter
+      (({ presup w := φ.felicitous w, assertion w := φ.truth w } : Semantics.Presupposition.PartialProp _))
+      (({ presup w := ψ.felicitous w, assertion w := ψ.truth w } : Semantics.Presupposition.PartialProp _))).presup w :=
   Iff.rfl
 
 /--
@@ -113,9 +113,9 @@ PIP's disjunction felicity agrees with the filtering disjunction:
 theorem pip_felicity_agrees_with_orFilter {W : Type*}
     (φ ψ : Felicity.PIPExpr W) (w : W) :
     (Felicity.PIPExpr.disj φ ψ).felicitous w ↔
-    (Semantics.Presupposition.PrProp.orFilter
-      (({ presup w := φ.felicitous w, assertion w := φ.truth w } : Semantics.Presupposition.PrProp _))
-      (({ presup w := ψ.felicitous w, assertion w := ψ.truth w } : Semantics.Presupposition.PrProp _))).presup w :=
+    (Semantics.Presupposition.PartialProp.orFilter
+      (({ presup w := φ.felicitous w, assertion w := φ.truth w } : Semantics.Presupposition.PartialProp _))
+      (({ presup w := ψ.felicitous w, assertion w := ψ.truth w } : Semantics.Presupposition.PartialProp _))).presup w :=
   Iff.rfl
 
 

--- a/Linglib/Studies/Koev2017.lean
+++ b/Linglib/Studies/Koev2017.lean
@@ -252,22 +252,22 @@ theorem spatiotemporallyDistant_of_temporallyDisjoint
     The `learn` predicate is subscripted with **cs(k)** (the context set at
     discourse move k), not with the scope proposition p. This is the formal
     mechanism for not-at-issue status: the evidential contribution restricts
-    the *context set* directly (≈ presupposition in `PrProp.presup`), while
+    the *context set* directly (≈ presupposition in `PartialProp.presup`), while
     the assertion commits the speaker to p via DECL (72), which maps to
-    `PrProp.assertion`.
+    `PartialProp.assertion`.
 
     The mapping is:
-    - `learn_{cs(k)}(e_l, sp(k), p)` → `PrProp.presup` (restricts cs)
-    - `DECL(72): dc^sp(c) ⊆ p` → `PrProp.assertion` (commits to p)
+    - `learn_{cs(k)}(e_l, sp(k), p)` → `PartialProp.presup` (restricts cs)
+    - `DECL(72): dc^sp(c) ⊆ p` → `PartialProp.assertion` (commits to p)
 
     This explains why the evidential projects past negation (property 6iv):
-    `PrProp.neg` preserves `presup` while negating `assertion`.
+    `PartialProp.neg` preserves `presup` while negating `assertion`.
 
     ## What's Captured
 
     - The **event pair** (e, e_l) — the described event and the learning event
     - **△(e, e_l)** — spatiotemporal distance, via `isTemporallyDisjoint` /
-      `isSpatiotemporallyDistant` and bridge to `PrProp` via `toEvidentialProp`
+      `isSpatiotemporallyDistant` and bridge to `PartialProp` via `toEvidentialProp`
     - **The presup/assertion split** — cs(k) subscript → presup, DECL → assertion
 
     ## What's Not Captured (Future Work)
@@ -329,7 +329,7 @@ theorem LearningScenario.triangleTemporalB_iff (s : LearningScenario ℤ) :
     push_neg at hc
     exact h ⟨hc.1, hc.2⟩
 
-/-- Construct a PrProp from a learning scenario, making the
+/-- Construct a PartialProp from a learning scenario, making the
     cs(k) → presup mapping constructive.
 
     The presupposition is derived from the event structure (△ holds or not),
@@ -338,7 +338,7 @@ theorem LearningScenario.triangleTemporalB_iff (s : LearningScenario ℤ) :
     - `presup` := △(described, learning) — the evidential's cs(k) contribution
     - `assertion` := p — the scope proposition -/
 def LearningScenario.toEvidentialProp (s : LearningScenario ℤ)
-    {W : Type*} (p : W → Prop) : PrProp W where
+    {W : Type*} (p : W → Prop) : PartialProp W where
   presup := fun _ => s.triangleTemporalB
   assertion := p
 
@@ -442,9 +442,9 @@ theorem smoke_no_tense_ordering :
       derived from event structure via `triangleTemporalB`
     - **(ii) Speaker commitment**: assertion = p (non-modal, full commitment)
     - **(iii) Not at issue**: △ is in presup (cs restriction), not assertion
-    - **(iv) Projection**: PrProp.neg preserves presup → △ projects past ¬ -/
+    - **(iv) Projection**: PartialProp.neg preserves presup → △ projects past ¬ -/
 
-/-- Property (6i): the presupposition of the constructed PrProp IS the
+/-- Property (6i): the presupposition of the constructed PartialProp IS the
     △ condition, derived from the event structure. When △ holds (indirect
     evidence), the presupposition is satisfied at every world. -/
 theorem indirect_presup_satisfied {W : Type*} (p : W → Prop) (w : W) :
@@ -467,9 +467,9 @@ theorem direct_presup_fails {W : Type*} (p : W → Prop) (w : W) :
   simp only [Event.τ]
   decide
 
-/-- Property (6ii): the assertion of a scenario's PrProp IS the scope
+/-- Property (6ii): the assertion of a scenario's PartialProp IS the scope
     proposition. The speaker commits to p, not to a modalized version.
-    This holds by construction: DECL (72) maps to `PrProp.assertion`. -/
+    This holds by construction: DECL (72) maps to `PartialProp.assertion`. -/
 theorem assertion_is_scope (s : LearningScenario ℤ) {W : Type*} (p : W → Prop) :
     (s.toEvidentialProp p).assertion = p := rfl
 
@@ -479,7 +479,7 @@ theorem assertion_is_scope (s : LearningScenario ℤ) {W : Type*} (p : W → Pro
     This is a simplified stub; the full Kratzer-grounded version is
     `Izvorski1997.Bridge.izvorskiEv`, which uses `necessity f g p` as
     the assertion and `!(accessibleWorlds f w).isEmpty` as the presup. -/
-def modalEvidential {W : Type*} (evidence : Bool) (must_p : W → Prop) : PrProp W where
+def modalEvidential {W : Type*} (evidence : Bool) (must_p : W → Prop) : PartialProp W where
   presup := fun _ => evidence
   assertion := must_p
 
@@ -497,11 +497,11 @@ theorem modal_can_weaken :
 
 /-- Property (6iv): the evidential presupposition projects past negation.
     Negating the evidential negates the assertion (p → ¬p) but preserves
-    the presupposition (△). This follows from PrProp's general negation
+    the presupposition (△). This follows from PartialProp's general negation
     rule and captures the paper's formalization (78). -/
 theorem projection_past_negation (s : LearningScenario ℤ) {W : Type*} (p : W → Prop) :
-    (PrProp.neg (s.toEvidentialProp p)).presup = (s.toEvidentialProp p).presup :=
-  PrProp.neg_presup _
+    (PartialProp.neg (s.toEvidentialProp p)).presup = (s.toEvidentialProp p).presup :=
+  PartialProp.neg_presup _
 
 /-! ### Bridge to [cumming-2026]: △ → T ≤ A -/
 

--- a/Linglib/Studies/Kubota2026.lean
+++ b/Linglib/Studies/Kubota2026.lean
@@ -167,10 +167,10 @@ theorem expressive_rigid (t : TwoDimProp Unit) :
     (Outlook.ofTwoDimProp (O := Bool) t).IsRigid :=
   Outlook.ofTwoDimProp_isRigid t
 
-/-- The counterstance projects through negation (via `PrProp.neg`), and the CI tier projects
+/-- The counterstance projects through negation (via `PartialProp.neg`), and the CI tier projects
 at each outlook (via `TwoDimProp.neg`) — the dual presupposition/CI projection. -/
 theorem saltDenotation_projects (o : Bool) :
-    (Semantics.Presupposition.PrProp.neg saltDenotation.toPrProp).presup = saltDenotation.counterstance ∧
+    (Semantics.Presupposition.PartialProp.neg saltDenotation.toPartialProp).presup = saltDenotation.counterstance ∧
     (TwoDimProp.neg (saltDenotation.toTwoDimProp o)).ci = saltDenotation.evaluation o :=
   ⟨Outlook.counterstance_projects_through_neg _, Outlook.ci_projects_through_neg _ _⟩
 

--- a/Linglib/Studies/OgiharaST2024.lean
+++ b/Linglib/Studies/OgiharaST2024.lean
@@ -958,7 +958,7 @@ Connects three layers of the temporal connective formalization:
 1. **Fragment field**: `TemporalExprEntry.complementVeridical : Bool`
 2. **Theory proof**: e.g., `Anscombe.after A B → ∃ t, t ∈ timeTrace B`
 3. **Presupposition theory**: veridical connectives presuppose their complement
-   (modeled as `PrProp` with complement occurrence as presupposition)
+   (modeled as `PartialProp` with complement occurrence as presupposition)
 
 For each temporal connective, the Fragment's `complementVeridical` field is
 **grounded** in a theory-level proof, and matches the empirical data.
@@ -1080,19 +1080,19 @@ open Semantics.Presupposition
 /-- A temporal connective modeled as a presuppositional proposition.
     Veridical connectives presuppose their complement (like factives);
     non-veridical connectives carry no complement presupposition. -/
-def connPrProp (complementInstantiated : Bool) (connHolds : Bool) : PrProp Unit :=
+def connPartialProp (complementInstantiated : Bool) (connHolds : Bool) : PartialProp Unit :=
   { presup := fun _ => complementInstantiated
   , assertion := fun _ => connHolds }
 
 theorem veridical_presupposes_complement :
-    (connPrProp true true).presup () = true := rfl
+    (connPartialProp true true).presup () = true := rfl
 
 theorem nonveridical_no_presupposition :
-    (connPrProp false true).presup () = false := rfl
+    (connPartialProp false true).presup () = false := rfl
 
 /-- Negation preserves complement presupposition (projection through negation). -/
 theorem negation_preserves_presup :
-    (PrProp.neg (connPrProp true true)).presup () = true := rfl
+    (PartialProp.neg (connPartialProp true true)).presup () = true := rfl
 
 -- ============================================================================
 -- § 23: B&C's Three Readings of *Before* and Presupposition

--- a/Linglib/Studies/PaapeVasishth2026.lean
+++ b/Linglib/Studies/PaapeVasishth2026.lean
@@ -513,8 +513,8 @@ The argument chain:
 section UniquenessBridge
 
 open Semantics.Definiteness (modifierNecessary)
-open Semantics.Presupposition (PrProp)
-open Semantics.Presupposition.PrProp (presupOfReferent presupOfReferent_presup
+open Semantics.Presupposition (PartialProp)
+open Semantics.Presupposition.PartialProp (presupOfReferent presupOfReferent_presup
   presupOfReferent_assertion_some presupOfReferent_assertion_none)
 open Semantics.Definiteness (russellIotaList)
 
@@ -542,11 +542,11 @@ def rcModifier : DiscEntity → Bool
 /-- Trivial scope for the worked example. -/
 def toldScope : DiscEntity → Bool := fun _ => true
 
-/-- File-local convenience: the uniqueness-based definite as a `PrProp Unit`,
+/-- File-local convenience: the uniqueness-based definite as a `PartialProp Unit`,
     built from the canonical `presupOfReferent` combinator with
     `russellIotaList` as the per-context referent selector. -/
 private def thePresup (domain : List DiscEntity) (restrictor scope : DiscEntity → Bool) :
-    PrProp Unit :=
+    PartialProp Unit :=
   presupOfReferent (fun _ : Unit => russellIotaList domain restrictor)
                    (fun e _ => scope e = true)
 

--- a/Linglib/Studies/PhillipsBrown2025.lean
+++ b/Linglib/Studies/PhillipsBrown2025.lean
@@ -360,7 +360,7 @@ theorem finest_simulates_vf_not_lobster :
   wantQuestionBased_finestPartition_iff_wantVF belLobDie desNotDie
     allWorldsW allWorldsW_complete (fun w => ¬ nap w)
 
-/-! ## §9. Definedness via PrProp (paper §3.6) -/
+/-! ## §9. Definedness via PartialProp (paper §3.6) -/
 
 theorem nap_defined_in_qNapRest :
     wantDefined belNapRest naturalProps qNapRest nap := by decide
@@ -369,13 +369,13 @@ theorem fail_not_defined_in_qNapRest :
     ¬ wantDefined belNapRest naturalProps qNapRest fail := by decide
 
 theorem nap_prprop_holds :
-    (wantPrProp belNapRest desRest naturalProps qNapRest nap).presup .w0 ∧
-    (wantPrProp belNapRest desRest naturalProps qNapRest nap).assertion .w0 := by
-  refine ⟨?_, ?_⟩ <;> simp only [wantPrProp] <;> decide
+    (wantPartialProp belNapRest desRest naturalProps qNapRest nap).presup .w0 ∧
+    (wantPartialProp belNapRest desRest naturalProps qNapRest nap).assertion .w0 := by
+  refine ⟨?_, ?_⟩ <;> simp only [wantPartialProp] <;> decide
 
 theorem fail_prprop_undefined :
-    ¬(wantPrProp belNapRest desRest naturalProps qNapRest fail).presup .w0 := by
-  simp only [wantPrProp]; decide
+    ¬(wantPartialProp belNapRest desRest naturalProps qNapRest fail).presup .w0 := by
+  simp only [wantPartialProp]; decide
 
 /-! ## §10. Belief-sensitivity: William III / nuclear war (paper §4.2)
 

--- a/Linglib/Studies/RobertsSimons2024.lean
+++ b/Linglib/Studies/RobertsSimons2024.lean
@@ -304,14 +304,14 @@ end Filtering
 
 
 -- ═══════════════════════════════════════════════════════════════════════
--- §6. Bridge: EventPhase Precondition = PrProp Presupposition
+-- §6. Bridge: EventPhase Precondition = PartialProp Presupposition
 -- ═══════════════════════════════════════════════════════════════════════
 
 section Bridges
 
 variable {W : Type*}
 
-/-- For CoS verbs, EventPhase.precondition agrees with PrProp.presup.
+/-- For CoS verbs, EventPhase.precondition agrees with PartialProp.presup.
     This shows the two representations — the aboutness-based (R&S) and the
     trivalent (Heim) — agree on *what* projects, even though they disagree
     on *why* it projects. -/
@@ -413,7 +413,7 @@ theorem stop_end_to_end (P : W → Prop) (w : W) :
 
 /-- End-to-end for factives: know's complement truth is an ontological
     precondition, shares the same structural projection mechanism as
-    CoS verbs, and agrees with the PrProp representation. -/
+    CoS verbs, and agrees with the PartialProp representation. -/
 theorem know_end_to_end (BEL C : W → Prop) (w : W) :
     -- (1) Precondition = complement truth
     (knowAsEventPhase BEL C).precondition w = C w ∧

--- a/Linglib/Studies/Sauerland2003.lean
+++ b/Linglib/Studies/Sauerland2003.lean
@@ -55,7 +55,7 @@ open Mereology (Atom AlgClosure isMaximal CUM cum_maximal_unique algClosure_cum)
 open Semantics.Plurality.Algebra (star D)
 open Semantics.Plurality.Cover (IsFinCover algClosure_of_finCover)
 open Features (ContainmentPair ContainmentPairLike)
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open Phonology.Constraint.OT (NamedConstraint mkTableau)
 open Semantics.Presupposition.PhiFeatures
 open Semantics.Presupposition.MaximizePresupposition (phiMP phi_mp_selects_maximal)
@@ -310,7 +310,7 @@ open Semantics.Quantification.UnifiedUniversal (QForall dng_atoms)
     `Atom a ∧ a ≤ X`. -/
 def JE {E : Type*} [PartialOrder E]
     (X : E) (P : E → Prop) (domP : E → Prop := fun _ => True) :
-    PrProp E where
+    PartialProp E where
   presup := fun _ => ∀ a, Atom a → a ≤ X → domP a
   assertion := fun _ => ∀ a, Atom a → a ≤ X → P a
 
@@ -349,7 +349,7 @@ theorem je_total_trivial {E : Type*} [PartialOrder E]
     `⟦every⟧(R)(P)` = `⟦JE⟧(max(*R))(P)` -/
 def everySem {E : Type*} [PartialOrder E]
     (maxStarR : E) (P : E → Prop) (domP : E → Prop := fun _ => True) :
-    PrProp E :=
+    PartialProp E :=
   JE maxStarR P domP
 
 -- ── Mereological grounding of DER ──
@@ -432,7 +432,7 @@ with a sister, not that every boy has one.
     the domain of S. The assertion is that some R-individual satisfies S. -/
 def aSem {E : Type*}
     (R : E → Prop) (S : E → Prop) (domS : E → Prop := fun _ => True) :
-    PrProp E where
+    PartialProp E where
   presup := fun _ => ∃ x, R x ∧ domS x
   assertion := fun _ => ∃ x, R x ∧ S x
 

--- a/Linglib/Studies/Sharvit2025.lean
+++ b/Linglib/Studies/Sharvit2025.lean
@@ -72,7 +72,7 @@ instance : DecidablePred penniless
   | .proudNotLend | .proudLend => isFalse id
 
 /-- "Mia is proud of her money" — presupposes hasMoney. -/
-def proudOfMoney : PrProp W where
+def proudOfMoney : PartialProp W where
   presup := hasMoney
   assertion w := w = .proudNotLend ∨ w = .proudLend
 
@@ -80,18 +80,18 @@ instance proudOfMoney_decAssertion : DecidablePred proudOfMoney.assertion := by
   unfold proudOfMoney; intro w; infer_instance
 
 /-- "Sue shouldn't lend Mia any money" — presuppositionless. -/
-def shouldntLend : PrProp W where
+def shouldntLend : PartialProp W where
   presup _ := True
   assertion w := w = .pennyNotLend ∨ w = .proudNotLend
 
 instance shouldntLend_decAssertion : DecidablePred shouldntLend.assertion := by
   unfold shouldntLend; intro w; infer_instance
 
-/-- Presuppositionless version of penniless as PrProp. -/
-def pennilessPr : PrProp W := PrProp.ofProp penniless
+/-- Presuppositionless version of penniless as PartialProp. -/
+def pennilessPr : PartialProp W := PartialProp.ofProp penniless
 
 instance pennilessPr_decAssertion : DecidablePred pennilessPr.assertion := by
-  unfold pennilessPr PrProp.ofProp; intro w; infer_instance
+  unfold pennilessPr PartialProp.ofProp; intro w; infer_instance
 
 -- ════════════════════════════════════════════════════════════════
 -- § Structural properties
@@ -106,7 +106,7 @@ at penniless-worlds. This is the root cause of K/P's failure: `orPositive`'s
 filtering condition requires "proud of money" to be defined when
 "penniless" is true, but penniless entails ¬hasMoney. -/
 theorem orPositive_undefined_at_penny :
-    ¬(PrProp.orPositive pennilessPr proudOfMoney).presup W.pennyNotLend := by
+    ¬(PartialProp.orPositive pennilessPr proudOfMoney).presup W.pennyNotLend := by
   rintro ⟨h1, _, _⟩
   -- h1 : pennilessPr.assertion → proudOfMoney.presup
   -- pennilessPr.assertion W.pennyNotLend = penniless W.pennyNotLend = True
@@ -115,8 +115,8 @@ theorem orPositive_undefined_at_penny :
 
 /-- The disjunction IS defined at proud-worlds. -/
 theorem orPositive_defined_at_proud :
-    (PrProp.orPositive pennilessPr proudOfMoney).presup W.proudNotLend :=
-  ⟨fun h => absurd h (by simp [pennilessPr, PrProp.ofProp, penniless]),
+    (PartialProp.orPositive pennilessPr proudOfMoney).presup W.proudNotLend :=
+  ⟨fun h => absurd h (by simp [pennilessPr, PartialProp.ofProp, penniless]),
    fun _ => trivial,
    Or.inr trivial⟩
 
@@ -126,21 +126,21 @@ theorem orPositive_defined_at_proud :
 
 open Semantics.Conditionals.Presupposition
 
--- Decidable instances for compound PrProp assertions
+-- Decidable instances for compound PartialProp assertions
 
-instance orPositive_decAssertion : DecidablePred (PrProp.orPositive pennilessPr proudOfMoney).assertion := by
-  intro w; unfold PrProp.orPositive pennilessPr PrProp.ofProp proudOfMoney
+instance orPositive_decAssertion : DecidablePred (PartialProp.orPositive pennilessPr proudOfMoney).assertion := by
+  intro w; unfold PartialProp.orPositive pennilessPr PartialProp.ofProp proudOfMoney
   infer_instance
 
 -- § K/P fails: ∃-reading drops penniless-worlds
 
 /-- Under K/P, the ∃-reading uses `orPositive` for the antecedent disjunction. -/
-def existReading_KP : PrProp W :=
-  ifKP allWorlds (PrProp.orPositive pennilessPr proudOfMoney) shouldntLend
+def existReading_KP : PartialProp W :=
+  ifKP allWorlds (PartialProp.orPositive pennilessPr proudOfMoney) shouldntLend
 
 /-- Under K/P, the ∀-reading is the conjunction of two K/P conditionals. -/
-def forallReading_KP : PrProp W :=
-  PrProp.and (ifKP allWorlds pennilessPr shouldntLend)
+def forallReading_KP : PartialProp W :=
+  PartialProp.and (ifKP allWorlds pennilessPr shouldntLend)
              (ifKP allWorlds proudOfMoney shouldntLend)
 
 /-- K/P ∃-reading is UNDEFINED at penniless-worlds. -/
@@ -148,27 +148,27 @@ theorem kp_exist_undefined_at_penny :
     ¬existReading_KP.presup W.pennyNotLend ∧
     ¬existReading_KP.presup W.pennyLend := by
   refine ⟨?_, ?_⟩ <;>
-    (intro h; simp [existReading_KP, ifKP, PrProp.orPositive,
-      pennilessPr, PrProp.ofProp, penniless, proudOfMoney, hasMoney] at h)
+    (intro h; simp [existReading_KP, ifKP, PartialProp.orPositive,
+      pennilessPr, PartialProp.ofProp, penniless, proudOfMoney, hasMoney] at h)
 
 /-- K/P ∃-reading IS defined at proud-worlds. -/
 theorem kp_exist_defined_at_proud :
     existReading_KP.presup W.proudNotLend ∧
     existReading_KP.presup W.proudLend := by
   refine ⟨?_, ?_⟩ <;>
-    (simp [existReading_KP, ifKP, PrProp.orPositive, pennilessPr, PrProp.ofProp,
+    (simp [existReading_KP, ifKP, PartialProp.orPositive, pennilessPr, PartialProp.ofProp,
       penniless, proudOfMoney, hasMoney, shouldntLend, allWorlds])
 
 /-- K/P ∀-reading: the first conditional (if penniless, shouldntLend) is always defined. -/
 theorem kp_forall_first_cond_always_defined :
     ∀ w, (ifKP allWorlds pennilessPr shouldntLend).presup w := by
-  intro w; simp [ifKP, pennilessPr, PrProp.ofProp, shouldntLend]
+  intro w; simp [ifKP, pennilessPr, PartialProp.ofProp, shouldntLend]
 
 /-- K/P ∀-reading presup = hasMoney (from the second conditional). -/
 theorem kp_forall_presup_eq_hasMoney :
     ∀ w, forallReading_KP.presup w ↔ hasMoney w := by
   intro w; cases w <;>
-    simp [forallReading_KP, PrProp.and, ifKP, pennilessPr, PrProp.ofProp,
+    simp [forallReading_KP, PartialProp.and, ifKP, pennilessPr, PartialProp.ofProp,
           penniless, proudOfMoney, hasMoney, shouldntLend, allWorlds]
 
 /-- K/P ∃-reading assertion excludes penny-worlds from quantification. -/
@@ -180,23 +180,23 @@ theorem kp_exist_assertion_excludes_penny :
 -- § K/P* conditionals: CLOS-based filtering
 
 instance : DecidablePred (definedFalse pennilessPr) := by
-  intro w; unfold definedFalse pennilessPr PrProp.ofProp; infer_instance
+  intro w; unfold definedFalse pennilessPr PartialProp.ofProp; infer_instance
 
 instance : DecidablePred (definedFalse proudOfMoney) := by
   intro w; unfold definedFalse proudOfMoney; infer_instance
 
 /-- K/P* conditional: if penniless, shouldntLend. -/
-def cond_penniless : PrProp W :=
+def cond_penniless : PartialProp W :=
   ifPresup trivialCloser allWorlds pennilessPr shouldntLend
 
 /-- K/P* conditional: if proud-of-money, shouldntLend. -/
-def cond_proud : PrProp W :=
+def cond_proud : PartialProp W :=
   ifPresup trivialCloser allWorlds proudOfMoney shouldntLend
 
 /-- K/P* conditional with penniless: always defined. -/
 theorem kpstar_penniless_always_defined :
     ∀ w, cond_penniless.presup w := by
-  intro w; simp [cond_penniless, ifPresup, pennilessPr, PrProp.ofProp, penniless,
+  intro w; simp [cond_penniless, ifPresup, pennilessPr, PartialProp.ofProp, penniless,
                  shouldntLend, closB, trivialCloser, allWorlds]
 
 /-- K/P* conditional with proud-of-money: defined iff hasMoney. -/
@@ -216,29 +216,29 @@ instance cond_penniless_decAssertion : DecidablePred cond_penniless.assertion :=
 
 instance orPresup_decAssertion : DecidablePred
     (orPresup trivialCloser allWorlds pennilessPr proudOfMoney).assertion := by
-  intro w; unfold orPresup pennilessPr PrProp.ofProp proudOfMoney
+  intro w; unfold orPresup pennilessPr PartialProp.ofProp proudOfMoney
   infer_instance
 
 instance orPresup_defFalse_dec : DecidablePred
     (definedFalse (orPresup trivialCloser allWorlds pennilessPr proudOfMoney)) := by
-  intro w; unfold definedFalse orPresup pennilessPr PrProp.ofProp proudOfMoney
+  intro w; unfold definedFalse orPresup pennilessPr PartialProp.ofProp proudOfMoney
   infer_instance
 
 /-- K/P* ∃-reading. -/
-def existReading_KPstar : PrProp W :=
+def existReading_KPstar : PartialProp W :=
   ifPresup trivialCloser allWorlds
     (orPresup trivialCloser allWorlds pennilessPr proudOfMoney)
     shouldntLend
 
 /-- K/P* ∀-reading. -/
-def forallReading_KPstar : PrProp W :=
+def forallReading_KPstar : PartialProp W :=
   andPresup trivialCloser allWorlds cond_penniless cond_proud
 
 /-- Both K/P* readings have presupposition = hasMoney. -/
 theorem kpstar_exist_presup_eq :
     ∀ w, existReading_KPstar.presup w ↔ hasMoney w := by
   intro w; cases w <;>
-    simp [existReading_KPstar, ifPresup, orPresup, pennilessPr, PrProp.ofProp,
+    simp [existReading_KPstar, ifPresup, orPresup, pennilessPr, PartialProp.ofProp,
           penniless, proudOfMoney, hasMoney, shouldntLend, closB,
           trivialCloser, allWorlds, definedFalse]
 
@@ -246,7 +246,7 @@ theorem kpstar_forall_presup_eq :
     ∀ w, forallReading_KPstar.presup w ↔ hasMoney w := by
   intro w; cases w <;>
     simp [forallReading_KPstar, andPresup, cond_penniless, cond_proud,
-          ifPresup, pennilessPr, PrProp.ofProp, penniless, proudOfMoney,
+          ifPresup, pennilessPr, PartialProp.ofProp, penniless, proudOfMoney,
           hasMoney, shouldntLend, closB, trivialCloser, allWorlds]
 
 /-- Both K/P* readings have identical assertions. -/
@@ -254,13 +254,13 @@ theorem kpstar_assertions_agree :
     ∀ w, existReading_KPstar.assertion w ↔ forallReading_KPstar.assertion w := by
   intro w; cases w <;>
     simp [existReading_KPstar, forallReading_KPstar, ifPresup, andPresup,
-          orPresup, pennilessPr, PrProp.ofProp, penniless, proudOfMoney,
+          orPresup, pennilessPr, PartialProp.ofProp, penniless, proudOfMoney,
           hasMoney, shouldntLend, closB, trivialCloser, allWorlds,
           cond_penniless, cond_proud, definedFalse]
 
 /-- Strawson equivalence of ∃ and ∀ readings under K/P*. -/
 theorem kpstar_strawson_equiv :
-    PrProp.strawsonEquiv existReading_KPstar forallReading_KPstar := by
+    PartialProp.strawsonEquiv existReading_KPstar forallReading_KPstar := by
   refine ⟨fun w _ _ ha => ?_, fun w _ _ ha => ?_⟩
   · exact (kpstar_assertions_agree w).mp ha
   · exact (kpstar_assertions_agree w).mpr ha
@@ -270,11 +270,11 @@ theorem kpstar_strawson_equiv :
 theorem kp_exist_presup_eq :
     ∀ w, existReading_KP.presup w ↔ hasMoney w := by
   intro w; cases w <;>
-    simp [existReading_KP, ifKP, PrProp.orPositive, pennilessPr, PrProp.ofProp,
+    simp [existReading_KP, ifKP, PartialProp.orPositive, pennilessPr, PartialProp.ofProp,
           penniless, proudOfMoney, hasMoney, shouldntLend, allWorlds]
 
 theorem kp_orPositive_undefined_at_penny :
-    ¬(PrProp.orPositive pennilessPr proudOfMoney).presup W.pennyNotLend :=
+    ¬(PartialProp.orPositive pennilessPr proudOfMoney).presup W.pennyNotLend :=
   orPositive_undefined_at_penny
 
 end Sharvit2025

--- a/Linglib/Studies/SolstadBott2024.lean
+++ b/Linglib/Studies/SolstadBott2024.lean
@@ -419,7 +419,7 @@ theorem occasion_presup_projects {W : Type*}
     At "punishes" (antecedent): local context = global context.
     Presupposition "Peter did something wrong" is NOT entailed → projects. -/
 theorem heim_antecedent_projects {W : Type*}
-    (c : ContextSet W) (trigger _consequence : PrProp W)
+    (c : ContextSet W) (trigger _consequence : PartialProp W)
     (h : ∃ w, c w ∧ ¬trigger.presup w) :
     presupProjects (initialLocalCtx c) trigger := by
   obtain ⟨w, hw_in, hpresup_false⟩ := h
@@ -439,7 +439,7 @@ theorem heim_antecedent_projects {W : Type*}
     Symmetric local context at "punishes": c + [Peter was convicted].
     Presupposition "Peter did something wrong" IS entailed → filtered. -/
 def symmetricLocalCtxAntecedent {W : Type*}
-    (c : LocalCtx W) (consequent : PrProp W) : LocalCtx W :=
+    (c : LocalCtx W) (consequent : PartialProp W) : LocalCtx W :=
   { worlds := ContextSet.update c.worlds consequent.assertion
   , position := c.position
   , depth := c.depth }
@@ -447,7 +447,7 @@ def symmetricLocalCtxAntecedent {W : Type*}
 /-- When the consequent entails the occasion presupposition,
     symmetric filtering predicts the presupposition is filtered. -/
 theorem symmetric_filters_when_consequent_entails {W : Type*}
-    (c : LocalCtx W) (trigger consequent : PrProp W)
+    (c : LocalCtx W) (trigger consequent : PartialProp W)
     (h : ∀ w, c.worlds w → consequent.assertion w → trigger.presup w) :
     presupFiltered (symmetricLocalCtxAntecedent c consequent) trigger := by
   intro w hw

--- a/Linglib/Studies/StapsRooryck2024.lean
+++ b/Linglib/Studies/StapsRooryck2024.lean
@@ -496,7 +496,7 @@ theorem dynamic_follow_high :
 
 The paper's key semantic contribution: par and de share at-issue content
 (Initiator(x,e)) but carry complementary presuppositions about
-proto-agentivity. Formalized using `PrProp W` from
+proto-agentivity. Formalized using `PartialProp W` from
 `Semantics.Presupposition`. -/
 
 /-- Parameters for agentive preposition denotations (35a/35b).
@@ -512,14 +512,14 @@ variable {Entity Event W : Type}
 /-- ⟦par⟧_agentive (35a): λx.λe. Initiator(x,e);
     presup: HIGH proto-agentivity(x). -/
 def parAgentiveDenot (params : AgentivePrepParams Entity Event W)
-    (x : Entity) (e : Event) : PrProp W where
+    (x : Entity) (e : Event) : PartialProp W where
   presup := params.highProtoAgentivity x
   assertion := params.initiator x e
 
 /-- ⟦de⟧_agentive (35b): λx.λe. Initiator(x,e);
     presup: LOW proto-agentivity(x). -/
 def deAgentiveDenot (params : AgentivePrepParams Entity Event W)
-    (x : Entity) (e : Event) : PrProp W where
+    (x : Entity) (e : Event) : PartialProp W where
   presup w := ¬params.highProtoAgentivity x w
   assertion := params.initiator x e
 
@@ -593,7 +593,7 @@ def deCausalDenot (Situation Event W : Type)
     into a single function matching on `FrenchAgentPrep`. -/
 def FrenchAgentPrep.agentiveDenot (prep : FrenchAgentPrep)
     (params : AgentivePrepParams Entity Event W)
-    (x : Entity) (e : Event) : PrProp W :=
+    (x : Entity) (e : Event) : PartialProp W :=
   match prep with
   | .par => parAgentiveDenot params x e
   | .de  => deAgentiveDenot params x e

--- a/Linglib/Studies/Wang2023.lean
+++ b/Linglib/Studies/Wang2023.lean
@@ -412,7 +412,7 @@ theorem ihon_redundant_for_recruitment :
 ### Per-domain bridges
 
 Each recruitment strategy targets a specific phi-feature domain.
-The recruited cell (`.minimal`) corresponds to a specific `PrProp`
+The recruited cell (`.minimal`) corresponds to a specific `PartialProp`
 denotation from `PhiFeatures`: `plSem` (number), `thirdSem` (person),
 or `indefSem` (definiteness). All three are `phiPresup` at the minimal
 cell, which has a vacuous presupposition — this is WHY ToD selects them.
@@ -428,14 +428,14 @@ respective phi-feature domains.
 section DomainBridges
 
 /-- The plural recruitment strategy targets the minimal NUMBER cell,
-    which is `plSem` — the PrProp with vacuous presupposition.
+    which is `plSem` — the PartialProp with vacuous presupposition.
     `pl_is_minimal_cell` (PhiFeatures) proves `pluralF` maps to `.minimal`. -/
 theorem plural_strategy_is_plSem :
     honStrategyCell .plural = ContainmentPairLike.toPair Number.pluralF :=
   rfl
 
 /-- The 3rd-person strategy targets the minimal PERSON cell,
-    which is `thirdSem` — the PrProp with vacuous presupposition. -/
+    which is `thirdSem` — the PartialProp with vacuous presupposition. -/
 theorem thirdPerson_strategy_is_third :
     honStrategyCell .thirdPerson = ContainmentPairLike.toPair Person.thirdF :=
   rfl

--- a/Linglib/Studies/Wang2025.lean
+++ b/Linglib/Studies/Wang2025.lean
@@ -184,7 +184,7 @@ theorem additive_deRe_available : ye_deRe.accepted = true := rfl
 -- Constraint-based Formalization (was: Implicature/Constraints/Wang2025.lean)
 -- ============================================================================
 
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open CommonGround (ContextSet)
 
 /-- Local Bool-valued accessibility used by Wang2025 for `List.all` evaluation
@@ -239,8 +239,8 @@ assertion — the sentence is semantically defective.
 
 [wang-2025]: IC is NON-VIOLABLE.
 -/
-def satisfiesIC (p : PrProp W) : Prop :=
-  ∃ w, PrProp.holds w p
+def satisfiesIC (p : PartialProp W) : Prop :=
+  ∃ w, PartialProp.holds w p
 
 /--
 FP (Felicity Presupposition): the common ground entails the presupposition.
@@ -248,8 +248,8 @@ FP (Felicity Presupposition): the common ground entails the presupposition.
 Standard Stalnakerian presupposition satisfaction. When the CommonGround only partially
 entails the presupposition, FP is violated but may be tolerated.
 -/
-def satisfiesFP (cg : ContextSet W) (p : PrProp W) : Prop :=
-  ∀ w, cg w → PrProp.defined w p
+def satisfiesFP (cg : ContextSet W) (p : PartialProp W) : Prop :=
+  ∀ w, cg w → PartialProp.defined w p
 
 /--
 Partial FP satisfaction: the presupposition is compatible with the CommonGround
@@ -258,8 +258,8 @@ but not fully entailed.
 [wang-2025] Ch. 2-3: some triggers tolerate partial satisfaction (ye, you, reng)
 while others don't (jiu, zhidao).
 -/
-def partialFP (cg : ContextSet W) (p : PrProp W) : Prop :=
-  (∃ w, cg w ∧ PrProp.defined w p) ∧ ¬satisfiesFP cg p
+def partialFP (cg : ContextSet W) (p : PartialProp W) : Prop :=
+  (∃ w, cg w ∧ PartialProp.defined w p) ∧ ¬satisfiesFP cg p
 
 /--
 MP (Maximize Presupposition): prefer S_p over S when the presuppositional
@@ -268,7 +268,7 @@ form is more informative and the CommonGround supports its presupposition.
 MP is violated when the non-presuppositional alternative S is used despite
 the CommonGround supporting S_p's presupposition.
 -/
-def mpPrefers (cg : ContextSet W) (sp : PrProp W) : Prop :=
+def mpPrefers (cg : ContextSet W) (sp : PartialProp W) : Prop :=
   satisfiesFP cg sp ∧ satisfiesIC sp
 
 
@@ -339,8 +339,8 @@ theorem no_cg_blocks (alt : AltStructure) :
 /--
 IC satisfaction is necessary for felicity.
 -/
-def icNecessary (p : PrProp W) (h : satisfiesIC p) :
-    ∃ w, PrProp.holds w p := h
+def icNecessary (p : PartialProp W) (h : satisfiesIC p) :
+    ∃ w, PartialProp.holds w p := h
 
 
 -- ============================================================================
@@ -371,7 +371,7 @@ Input for Wang's felicity prediction: a trigger entry in a context.
 -/
 structure WangInput (W : Type*) where
   /-- The presuppositional sentence -/
-  sentence : PrProp W
+  sentence : PartialProp W
   /-- The trigger's alternative structure -/
   altStructure : AltStructure
   /-- Whether CommonGround fully entails the presupposition -/

--- a/Linglib/Studies/WangDavidson2026.lean
+++ b/Linglib/Studies/WangDavidson2026.lean
@@ -69,7 +69,7 @@ Type B (EXH¹).
 namespace WangDavidson2026
 
 open Core.Duality (Truth3 Prop3)
-open Semantics.Presupposition (PrProp)
+open Semantics.Presupposition (PartialProp)
 open Exhaustification (innocent predToFinset altsFromPreds)
 open Exhaustification.Trivalent
 
@@ -110,34 +110,34 @@ theorem sk_filtering_symmetric :
 
 
 -- ════════════════════════════════════════════════════════════════
--- § 1b. PrProp bridge: filtering vs non-filtering disjunction
+-- § 1b. PartialProp bridge: filtering vs non-filtering disjunction
 -- ════════════════════════════════════════════════════════════════
 
 /-!
-### PrProp exclusive disjunction
+### PartialProp exclusive disjunction
 
-`PrProp.xor` requires both presuppositions to hold — it never
+`PartialProp.xor` requires both presuppositions to hold — it never
 filters presupposition failure from either disjunct. This mirrors
 the SK XOR truth table (Figure 2 in the paper).
 
 Note: SK *inclusive* filtering (`Truth3.join .true .indet = .true`)
-is an emergent property of the SK truth table, not a `PrProp`
+is an emergent property of the SK truth table, not a `PartialProp`
 connective. The contrast is between `Truth3.join` (filters) and
 `Truth3.xor` (does not filter), verified in §1 above.
 -/
 
-section PrPropBridge
+section PartialPropBridge
 
 variable {W : Type*}
 
-/-- `PrProp.xor` does not filter: when q's presupposition fails,
+/-- `PartialProp.xor` does not filter: when q's presupposition fails,
     the result is always undefined regardless of p. -/
-theorem prprop_exclusive_no_filter (p q : PrProp W) (w : W)
+theorem prprop_exclusive_no_filter (p q : PartialProp W) (w : W)
     (hq : ¬q.presup w) :
-    (PrProp.xor p q).eval w = .indet :=
-  PrProp.eval_xor_no_filter p q w hq
+    (PartialProp.xor p q).eval w = .indet :=
+  PartialProp.eval_xor_no_filter p q w hq
 
-end PrPropBridge
+end PartialPropBridge
 
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Warstadt2022.lean
+++ b/Linglib/Studies/Warstadt2022.lean
@@ -108,19 +108,19 @@ def gcQUDProject (q : GCQUD) (w1 w2 : GCWorld) : Bool :=
 /-- Uniform world prior. -/
 def gcWorldPrior (_w : GCWorld) : ℚ := 1 / 3
 
-/-- PrProp decomposition of "green card": presupposes non-US, asserts has GC.
+/-- PartialProp decomposition of "green card": presupposes non-US, asserts has GC.
 
 This captures the traditional presupposition analysis. The paper's key
 contribution is showing that this presupposition structure EMERGES from
 RSA reasoning over Boolean truth conditions, without being stipulated. -/
-def greenCardPrProp : PrProp GCWorld where
+def greenCardPartialProp : PartialProp GCWorld where
   presup := λ w => match w with | .usCitizen => False | _ => True
   assertion := λ w => match w with | .gcHolder => True | _ => False
 
 /-- The Boolean meaning of "green card" decomposes as presupposition ∧ assertion. -/
 theorem gcMeaning_greenCard_eq_prprop (w : GCWorld) :
-    (gcMeaning .greenCard w = true) ↔ (greenCardPrProp.presup w ∧ greenCardPrProp.assertion w) := by
-  cases w <;> simp [gcMeaning, greenCardPrProp]
+    (gcMeaning .greenCard w = true) ↔ (greenCardPartialProp.presup w ∧ greenCardPartialProp.assertion w) := by
+  cases w <;> simp [gcMeaning, greenCardPartialProp]
 
 /-- "not green card" is Boolean negation of "green card". -/
 theorem gcMeaning_notGreenCard_eq_neg (w : GCWorld) :
@@ -259,7 +259,7 @@ theorem fgsWorldPrior_sum :
   native_decide
 
 -- ============================================================================
--- Part II: RSA Context Types and PrProp Connection
+-- Part II: RSA Context Types and PartialProp Connection
 -- ============================================================================
 
 
@@ -328,12 +328,12 @@ def allFGSQUDs : List FGSQUD := [.identity]
 def fgsQUDProjectBridge : FGSQUD → FGSWorld → FGSWorld → Bool
   | .identity, w1, w2 => fgsQUDProject w1 w2
 
-/-! ## PrProp Connection -/
+/-! ## PartialProp Connection -/
 
 /-- The Boolean meaning of "green card" decomposes as presupposition ∧ assertion. -/
 theorem greenCard_meaning_from_prprop (w : GCWorld) :
     (gcMeaning .greenCard w = true) ↔
-    (greenCardPrProp.presup w ∧ greenCardPrProp.assertion w) :=
+    (greenCardPartialProp.presup w ∧ greenCardPartialProp.assertion w) :=
   gcMeaning_greenCard_eq_prprop w
 
 /-- "not green card" is Boolean negation — no presupposition in the semantics. -/

--- a/Linglib/Studies/Yagi2025.lean
+++ b/Linglib/Studies/Yagi2025.lean
@@ -34,7 +34,7 @@ co-developer, but it is formalised separately at
 Yagi's example (8) — "Either baldness is not hereditary, or all of Bill's
 children are bald" ([karttunen-1974]) — appears in §2.2 as a
 counterexample to the K&P modification `Π(φ ∨ ψ) := Π(φ) ∨ Π(ψ)` (eq. 7).
-This formula is exactly what `PrProp.orFlex.presup` computes. The
+This formula is exactly what `PartialProp.orFlex.presup` computes. The
 flexible-accommodation framework Yagi defends in §3.2 evades the eq. (7)
 problem via the `χ = ω = ⊤` accommodation default, which we have not
 formalised here (we have only the static `orFlex` connective, not the
@@ -42,18 +42,18 @@ parametric dynamic update `s[χ][φ] ∪ s[ω][ψ]` of Yagi's eq. 13).
 
 The §3.2 discussion of how dynamic negation requires genuineness to hold
 within negation scope ("peculiar, given that we end up negating both
-disjuncts") motivated the strengthening of `PrProp.genuineness` from a
-singleton-survival check (now `PrProp.liveness`) to the two-conjunct
+disjuncts") motivated the strengthening of `PartialProp.genuineness` from a
+singleton-survival check (now `PartialProp.liveness`) to the two-conjunct
 definition with disjunction-update survival.
 
 ## Connective inventory used
 
 - `Truth3.join` (Strong Kleene): never false (`strong_kleene_never_false`)
-- `PrProp.or` (classical): never defined (`classical_never_defined`)
-- `PrProp.orPositive` (symmetric, positive-antecedent filtering of
+- `PartialProp.or` (classical): never defined (`classical_never_defined`)
+- `PartialProp.orPositive` (symmetric, positive-antecedent filtering of
   [kalomoiros-schwarz-2021]): wrong presupposition
   (`filter_wrong_at_kingOpens`)
-- `PrProp.orKPSymmetric` (symmetric, negative-antecedent K&P of Yagi Def 2):
+- `PartialProp.orKPSymmetric` (symmetric, negative-antecedent K&P of Yagi Def 2):
   presupposition entails assertion (`kp_presup_entails_assertion`)
 - `Geurts2005.exhaustivity_implies_uninformative`:
   the *consequence* (not the derivation) of [schlenker-2009] §2.4
@@ -61,17 +61,17 @@ definition with disjunction-update survival.
   (`truthset_uninformative_geurts_route`)
 - `Prop3.metaAssert`: allows falsity, no presupposition
   (`metaAssert_allows_falsity`, `metaAssert_no_gap`)
-- `PrProp.orFlex` = `PrProp.orBelnap` (substrate identity from
+- `PartialProp.orFlex` = `PartialProp.orBelnap` (substrate identity from
   `Semantics/Presupposition/Basic.lean`): correct (2a) and (2b), with a
   discriminating world `noHeadOfState` to prove the presupposition is
   non-trivial
-- `PrProp.orFlex.presup` overgenerates trivial-truth in eq. (7) shape:
+- `PartialProp.orFlex.presup` overgenerates trivial-truth in eq. (7) shape:
   `eq7_too_weak_for_ex8` exhibits the empirical mismatch at world `noChild`
 - For example (18), `orFlex` predicts non-projection only because the left
   disjunct is presuppositionless (`ex18_orFlex_no_projection_via_vacuous_left`,
   `ex18_unprincipled_in_right_presup_failure`); the principled K1973
   asymmetric route (`ex18_asymmetric_K1973_principled`) goes via
-  `PrProp.disjFilterLeft_eliminates_presup_when_neg_entails`
+  `PartialProp.disjFilterLeft_eliminates_presup_when_neg_entails`
 -/
 
 namespace Yagi2025
@@ -120,12 +120,12 @@ theorem presups_conflict : ∀ w, ¬(hasKing w ∧ hasPresident w) := by
   decide
 
 /-- φ_p: "The King is opening parliament" — presupposes `hasKing`. -/
-def kingOpensParl : PrProp W where
+def kingOpensParl : PartialProp W where
   presup := hasKing
   assertion w := w = .kingOpens
 
 /-- ψ_q: "The President is conducting the ceremony" — presupposes `hasPresident`. -/
-def presConductsCeremony : PrProp W where
+def presConductsCeremony : PartialProp W where
   presup := hasPresident
   assertion w := w = .presidentConducts
 
@@ -172,7 +172,7 @@ the table never reaches the 0 ∨ 0 = 0 row. -/
 theorem strong_kleene_never_false : ∀ w, skDisj w ≠ .false := by
   intro w
   cases w <;>
-    (simp [skDisj, PrProp.eval, kingOpensParl, presConductsCeremony,
+    (simp [skDisj, PartialProp.eval, kingOpensParl, presConductsCeremony,
       hasKing, hasPresident] <;> try decide)
 
 
@@ -180,31 +180,31 @@ theorem strong_kleene_never_false : ∀ w, skDisj w ≠ .false := by
 
 [karttunen-peters-1979], with [yagi-2025]'s symmetric Definition 2
 (per fn 2, citing [kalomoiros-schwarz-2021] for empirical support of
-symmetry). The substrate `PrProp.orKPSymmetric` matches Yagi's Def 2 directly:
+symmetry). The substrate `PartialProp.orKPSymmetric` matches Yagi's Def 2 directly:
 
   Π(φ ∨ ψ) = (¬A(ψ) → Π(φ)) ∧ (¬A(φ) → Π(ψ))
 
-`PrProp.orPositive` is a *different* symmetric variant with positive-antecedent
+`PartialProp.orPositive` is a *different* symmetric variant with positive-antecedent
 conditionals plus an extra `Π(φ) ∨ Π(ψ)` disjunct, which is **strictly
 stronger** than `orKPSymmetric` (worked counterexample: at a world with `A(φ)=⊤`,
 `A(ψ)=⊥`, `Π(φ)=⊤`, `Π(ψ)=⊥`, `orKPSymmetric` is defined, `orPositive` is not).
 The two are not predictionally equivalent, and neither is the asymmetric
-[karttunen-1973] rule (24b) used as `PrProp.disjFilterLeft` —
+[karttunen-1973] rule (24b) used as `PartialProp.disjFilterLeft` —
 see `Studies/Karttunen1973.lean`. -/
 
 /-- Classical disjunction requires both presuppositions: presup = `p ∧ q`. -/
-def classicalDisj : PrProp W := PrProp.or kingOpensParl presConductsCeremony
+def classicalDisj : PartialProp W := PartialProp.or kingOpensParl presConductsCeremony
 
-/-- `PrProp.or` is never defined when presuppositions conflict. -/
+/-- `PartialProp.or` is never defined when presuppositions conflict. -/
 theorem classical_never_defined : ∀ w, ¬classicalDisj.presup w := fun w h =>
   presups_conflict w h
 
 /-- The symmetric positive-antecedent filtering disjunction
-(`PrProp.orPositive`). Encodes
+(`PartialProp.orPositive`). Encodes
 `(A(φ) → Π(ψ)) ∧ (A(ψ) → Π(φ)) ∧ (Π(φ) ∨ Π(ψ))` — strictly stronger
 than `orKPSymmetric`. The conjunct `Π(φ) ∨ Π(ψ)` matches the eq. (7) modification
 discussed by [yagi-2025] §2.2 (after Def 3) as a candidate fix. -/
-def filterDisj : PrProp W := PrProp.orPositive kingOpensParl presConductsCeremony
+def filterDisj : PartialProp W := PartialProp.orPositive kingOpensParl presConductsCeremony
 
 /-- `orPositive` predicts presupposition failure at `kingOpens`, where the
 disjunction should clearly be true: the filtering condition demands the
@@ -220,15 +220,15 @@ theorem filter_wrong_at_kingOpens : ¬filterDisj.presup W.kingOpens := by
 theorem expected_satisfied_at_kingOpens : expectedPresup W.kingOpens := Or.inl trivial
 
 /-- K&P two-dimensional disjunction applied to the Buganda scenario. -/
-def kpDisj : PrProp W := PrProp.orKPSymmetric kingOpensParl presConductsCeremony
+def kpDisj : PartialProp W := PartialProp.orKPSymmetric kingOpensParl presConductsCeremony
 
 /-- K&P's presupposition entails the assertion when presuppositions conflict:
 whenever Π = 1, A = 1. Derived from the substrate
-`PrProp.orKPSymmetric_presup_entails_when_conflicting`. [yagi-2025] §2.2 (5)–(6). -/
+`PartialProp.orKPSymmetric_presup_entails_when_conflicting`. [yagi-2025] §2.2 (5)–(6). -/
 theorem kp_presup_entails_assertion :
     ∀ w, kpDisj.presup w → kpDisj.assertion w := by
   intro w h
-  exact PrProp.orKPSymmetric_presup_entails_when_conflicting _ _ w (presups_conflict w) h
+  exact PartialProp.orKPSymmetric_presup_entails_when_conflicting _ _ w (presups_conflict w) h
 
 
 /-! ## Failure 3: Update semantics ([yagi-2025] §2.3)
@@ -320,20 +320,20 @@ def truthSet : Set W := { W.kingOpens, W.presidentConducts }
 some disjunct's modal cell (`domain ∩ content` = `presup ∧ assertion`). -/
 theorem truthSet_exhausted :
     Geurts2005.exhaustivity truthSet
-      (Geurts2005.fromPrProp kingOpensParl presConductsCeremony) := by
+      (Geurts2005.fromPartialProp kingOpensParl presConductsCeremony) := by
   intro w hw
   rcases hw with rfl | rfl
   · -- Witness: the king-disjunct, with cell membership at `kingOpens`.
     refine ⟨{ domain := kingOpensParl.presup,
               force := .possibility,
               content := kingOpensParl.assertion },
-            by simp [Geurts2005.fromPrProp], ?_⟩
+            by simp [Geurts2005.fromPartialProp], ?_⟩
     exact ⟨trivial, rfl⟩
   · -- Witness: the president-disjunct, with cell membership at `presidentConducts`.
     refine ⟨{ domain := presConductsCeremony.presup,
               force := .possibility,
               content := presConductsCeremony.assertion },
-            by simp [Geurts2005.fromPrProp], ?_⟩
+            by simp [Geurts2005.fromPartialProp], ?_⟩
     exact ⟨trivial, rfl⟩
 
 /-- Truth-set uninformativity via Geurts (the *consequence* of Yagi §2.4,
@@ -344,7 +344,7 @@ would derive `s_0 ⊆ truthSet` from a `localContext` PUpdate operator we
 have not built. -/
 theorem truthset_uninformative_geurts_route :
     ∀ w ∈ truthSet,
-      (PrProp.orFlex kingOpensParl presConductsCeremony).assertion w := by
+      (PartialProp.orFlex kingOpensParl presConductsCeremony).assertion w := by
   intro w hw
   exact Geurts2005.exhaustivity_implies_uninformative
     kingOpensParl presConductsCeremony truthSet
@@ -378,7 +378,7 @@ noncomputable def metaAssertDisj : Prop3 W :=
 /-- Meta-assertion allows falsity (unlike Strong Kleene). Satisfies (2b). -/
 theorem metaAssert_allows_falsity :
     metaAssertDisj W.kingDoesnt = .false := by
-  simp [metaAssertDisj, PrProp.eval, kingOpensParl, presConductsCeremony,
+  simp [metaAssertDisj, PartialProp.eval, kingOpensParl, presConductsCeremony,
     hasKing, hasPresident]
 
 /-- Meta-assertion loses the presupposition: `𝒜φ_p` has no presupposition
@@ -386,25 +386,25 @@ theorem metaAssert_allows_falsity :
 only presupposes `¬𝒜ψ_q → p` per Yagi (11), not `p ∨ q`. -/
 theorem metaAssert_always_defined : ∀ w, (metaAssertDisj w).isDefined := by
   intro w; cases w <;>
-    simp [metaAssertDisj, PrProp.eval, kingOpensParl, presConductsCeremony,
+    simp [metaAssertDisj, PartialProp.eval, kingOpensParl, presConductsCeremony,
       hasKing, hasPresident, Truth3.isDefined]
 
 /-- The meta-assertion disjunction is bivalent — no gap, no presupposition
 via the standard gap mechanism. -/
 theorem metaAssert_no_gap : ∀ w, metaAssertDisj w ≠ .indet := by
   intro w; cases w <;>
-    simp [metaAssertDisj, PrProp.eval, kingOpensParl, presConductsCeremony,
+    simp [metaAssertDisj, PartialProp.eval, kingOpensParl, presConductsCeremony,
       hasKing, hasPresident]
 
 
 /-! ## Reaction 2: Flexible accommodation ([yagi-2025] §3.2,
 [geurts-2005], [aloni-2022])
 
-Uses the substrate `PrProp.orFlex`, with the discriminating world
+Uses the substrate `PartialProp.orFlex`, with the discriminating world
 `noHeadOfState` ensuring the (2a) test is non-trivial. -/
 
 /-- The flexible accommodation disjunction. -/
-def flexDisj : PrProp W := PrProp.orFlex kingOpensParl presConductsCeremony
+def flexDisj : PartialProp W := PartialProp.orFlex kingOpensParl presConductsCeremony
 
 /-- (2a) at the discriminating world: `flexDisj.presup` *fails* at
 `noHeadOfState`. Without this world, `expectedPresup` would be a
@@ -432,14 +432,14 @@ theorem flex_truth_table :
     flexDisj.eval W.presidentConducts = .true ∧
     flexDisj.eval W.presidentDoesnt = .false := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;>
-    simp [flexDisj, PrProp.orFlex, PrProp.eval, kingOpensParl, presConductsCeremony,
+    simp [flexDisj, PartialProp.orFlex, PartialProp.eval, kingOpensParl, presConductsCeremony,
       hasKing, hasPresident]
 
 /-- Flexible accommodation is undefined at the discriminating world
 `noHeadOfState`. -/
 theorem flex_undefined_at_no_head :
     flexDisj.eval W.noHeadOfState = .indet := by
-  simp [flexDisj, PrProp.orFlex, PrProp.eval, kingOpensParl, presConductsCeremony,
+  simp [flexDisj, PartialProp.orFlex, PartialProp.eval, kingOpensParl, presConductsCeremony,
     hasKing, hasPresident]
 
 /-- (2b): `flexDisj` is false at `kingDoesnt` (king present but not opening). -/
@@ -451,9 +451,9 @@ theorem flex_can_be_false : flexDisj.eval W.kingDoesnt = .false := flex_truth_ta
 [yagi-2025] Definition 8 (after [zimmermann-2000]): each
 disjunct must contribute a "live possibility" — there is `w ∈ s` with
 `{w}[φ] = {w}` AND `w ∈ s[φ ∨ ψ]`. The substrate
-`PrProp.genuineness p q s disj` parameterises on the disjunction
+`PartialProp.genuineness p q s disj` parameterises on the disjunction
 connective `disj` whose update we test against; the simpler
-singleton-survival check is now `PrProp.liveness`. Under `orFlex`,
+singleton-survival check is now `PartialProp.liveness`. Under `orFlex`,
 `liveness ⇒ genuineness` (`liveness_implies_genuineness_orFlex`), so
 discharging genuineness reduces to discharging liveness. -/
 
@@ -461,9 +461,9 @@ discharging genuineness reduces to discharging liveness. -/
 two-element witness state `{kingOpens, presConducts}`: each disjunct's
 witness world survives both its own update and the joint orFlex update. -/
 theorem flex_genuineness :
-    PrProp.genuineness kingOpensParl presConductsCeremony
+    PartialProp.genuineness kingOpensParl presConductsCeremony
       ⟨[W.kingOpens, W.presidentConducts], by simp⟩ flexDisj := by
-  apply PrProp.liveness_implies_genuineness_orFlex
+  apply PartialProp.liveness_implies_genuineness_orFlex
   exact ⟨⟨W.kingOpens, by simp, trivial, rfl⟩,
          ⟨W.presidentConducts, by simp, trivial, rfl⟩⟩
 
@@ -479,8 +479,8 @@ the substrate identity at the Buganda case for clarity. -/
 
 /-- Substrate identity at the Buganda case: `flexDisj = orBelnap`. -/
 theorem flexDisj_eq_orBelnap :
-    flexDisj = PrProp.orBelnap kingOpensParl presConductsCeremony :=
-  PrProp.orFlex_eq_orBelnap _ _
+    flexDisj = PartialProp.orBelnap kingOpensParl presConductsCeremony :=
+  PartialProp.orFlex_eq_orBelnap _ _
 
 
 /-! ### Negation interaction ([yagi-2025] §3.2 final paragraphs)
@@ -490,7 +490,7 @@ assertion. His *dynamic* negation `s[¬(φ_p ∨ ψ_q)] = s/(s[χ][φ_p] ∪ s[�
 requires genuineness to hold within the scope of negation, which Yagi
 calls "peculiar, given that we end up negating both disjuncts". The
 peculiarity surfaces only at the dynamic level — at the static
-`PrProp.neg` connective, the assertion just flips and presupposition is
+`PartialProp.neg` connective, the assertion just flips and presupposition is
 preserved (`neg_presup`); there is no genuineness check to violate.
 
 We do not formalise the dynamic version here because it would require
@@ -502,11 +502,11 @@ president-doesn't, where both disjuncts fail); Yagi's "peculiarity"
 diagnosis lives at the dynamic level above this static reduction. -/
 
 /-- Negation of the flexible accommodation disjunction. -/
-def negFlexDisj : PrProp W := PrProp.neg flexDisj
+def negFlexDisj : PartialProp W := PartialProp.neg flexDisj
 
 /-- Static negation preserves the presupposition (substrate `neg_presup`). -/
 theorem neg_flex_presup_preserved :
-    negFlexDisj.presup = flexDisj.presup := PrProp.neg_presup flexDisj
+    negFlexDisj.presup = flexDisj.presup := PartialProp.neg_presup flexDisj
 
 /-- Static negation gives the right truth values at the head-of-state worlds:
 true at king-doesn't and president-doesn't (both disjuncts false). -/
@@ -516,7 +516,7 @@ theorem neg_flex_truth_table :
     negFlexDisj.eval W.presidentConducts = .false ∧
     negFlexDisj.eval W.presidentDoesnt = .true := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;>
-    simp [negFlexDisj, PrProp.neg, flexDisj, PrProp.orFlex, PrProp.eval,
+    simp [negFlexDisj, PartialProp.neg, flexDisj, PartialProp.orFlex, PartialProp.eval,
       kingOpensParl, presConductsCeremony, hasKing, hasPresident]
 
 
@@ -524,7 +524,7 @@ theorem neg_flex_truth_table :
 
 [yagi-2025] §2.2 (between Def 3 and §2.3) considers a modification
 to K&P, `Π(φ ∨ ψ) := Π(φ) ∨ Π(ψ)` (eq. (7)). This formula IS what
-`PrProp.orFlex.presup` computes. Yagi shows it correctly predicts (1c)
+`PartialProp.orFlex.presup` computes. Yagi shows it correctly predicts (1c)
 Buganda but is "too weak" for (8) [karttunen-1974]: "Either baldness
 is not hereditary, or all of Bill's children are bald." Eq. (7) predicts
 the tautological presupposition `⊤ ∨ Π(ψ) = ⊤`, but the empirical
@@ -555,18 +555,18 @@ instance : DecidablePred billHasChild
   | .noChild => isFalse id
 
 /-- "Baldness is not hereditary" — no presupposition. -/
-def baldnessNotHereditary : PrProp W8 where
+def baldnessNotHereditary : PartialProp W8 where
   presup _ := True
   assertion _ := True
 
 /-- "All of Bill's children are bald" — factive on `billHasChild`. -/
-def allBillsChildrenBald : PrProp W8 where
+def allBillsChildrenBald : PartialProp W8 where
   presup := billHasChild
   assertion w := w = .hasChildAllBald
 
 /-- The static flex disjunction for (8) — assertion ignored, only the
 presup formula matters here. -/
-def ex8FlexDisj : PrProp W8 := PrProp.orFlex baldnessNotHereditary allBillsChildrenBald
+def ex8FlexDisj : PartialProp W8 := PartialProp.orFlex baldnessNotHereditary allBillsChildrenBald
 
 /-- The empirical presupposition Karttunen attributes to (8): "Bill has
 children". This is the predicate that any adequate theory of disjunctive
@@ -624,12 +624,12 @@ instance : DecidablePred solved
   | .notSolved => isFalse id
 
 /-- "Mary realized the problem is solved" — factive: presupposes problem is solved. -/
-def maryRealized : PrProp W18 where
+def maryRealized : PartialProp W18 where
   presup := solved
   assertion w := w = .solvedRealized
 
 /-- "John didn't solve the problem" — no presupposition. -/
-def johnDidntSolve : PrProp W18 where
+def johnDidntSolve : PartialProp W18 where
   presup _ := True
   assertion w := ¬solved w
 
@@ -637,7 +637,7 @@ def johnDidntSolve : PrProp W18 where
 predicts presupposition failure at `notSolved`, where the disjunction
 should be defined-and-true. -/
 theorem ex18_symmetric_orPositive_overgenerates :
-    ¬(PrProp.orPositive johnDidntSolve maryRealized).presup W18.notSolved := by
+    ¬(PartialProp.orPositive johnDidntSolve maryRealized).presup W18.notSolved := by
   rintro ⟨h, _, _⟩
   exact (h (fun (h' : solved W18.notSolved) => h') : solved W18.notSolved)
 
@@ -645,7 +645,7 @@ theorem ex18_symmetric_orPositive_overgenerates :
 through the LEFT disjunct of `Π(φ) ∨ Π(ψ)`: `johnDidntSolve.presup` is
 universally `True` (no presupposition). -/
 theorem ex18_orFlex_no_projection_via_vacuous_left :
-    (PrProp.orFlex johnDidntSolve maryRealized).presup W18.notSolved :=
+    (PartialProp.orFlex johnDidntSolve maryRealized).presup W18.notSolved :=
   Or.inl trivial
 
 /-- The structural reason for `ex18_orFlex_no_projection_via_vacuous_left`:
@@ -665,18 +665,18 @@ in (18), only the right disjunct does, so the left disjunct's vacuous
 `True` carries the prediction unilaterally. -/
 theorem ex18_unprincipled_in_right_presup_failure :
     ¬maryRealized.presup W18.notSolved ∧
-    (PrProp.orFlex johnDidntSolve maryRealized).presup W18.notSolved ∧
+    (PartialProp.orFlex johnDidntSolve maryRealized).presup W18.notSolved ∧
     (∀ w, johnDidntSolve.presup w) :=
   ⟨id, ex18_orFlex_no_projection_via_vacuous_left, ex18_left_presup_vacuous⟩
 
 /-- [karttunen-1973]'s asymmetric rule (24b) — formalised in
 `Studies/Karttunen1973.lean` as
-`PrProp.disjFilterLeft` — gives a *principled* derivation: `¬(¬solved) =
+`PartialProp.disjFilterLeft` — gives a *principled* derivation: `¬(¬solved) =
 solved` entails the factive presupposition, so it is filtered. We invoke
 the K1973 sibling theorem
 `Karttunen1973.disjFilterLeft_eliminates_presup_when_neg_entails`. -/
 theorem ex18_asymmetric_K1973_principled :
-    (PrProp.disjFilterLeft (fun w => ¬solved w) maryRealized).presup
+    (PartialProp.disjFilterLeft (fun w => ¬solved w) maryRealized).presup
       = fun _ => True := by
   apply Karttunen1973.disjFilterLeft_eliminates_presup_when_neg_entails
   intro w hw
@@ -699,10 +699,10 @@ theorem orFlex_satisfies_both :
 
 /-- The substrate-canonical orFlex / orBelnap / Geurts three-way
 identity, instantiated at the Buganda case. The substrate-side identity
-is `Semantics.Presupposition.PrProp.orFlex_eq_orBelnap` and
-`Geurts2005.fromPrProp_cell_iff_orBelnap`. -/
+is `Semantics.Presupposition.PartialProp.orFlex_eq_orBelnap` and
+`Geurts2005.fromPartialProp_cell_iff_orBelnap`. -/
 theorem orFlex_eq_orBelnap_at_buganda :
-    PrProp.orFlex (W := W) = PrProp.orBelnap :=
-  funext₂ PrProp.orFlex_eq_orBelnap
+    PartialProp.orFlex (W := W) = PartialProp.orBelnap :=
+  funext₂ PartialProp.orFlex_eq_orBelnap
 
 end Yagi2025

--- a/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
@@ -269,7 +269,7 @@ instance (cx : Constructicon) (own : Construction → CxnSpec) :
 
 /-! ### Inheritance of denotation-valued fields
 
-Denotations (e.g. `PrProp`-valued pragmatic contributions) have no
+Denotations (e.g. `PartialProp`-valued pragmatic contributions) have no
 decidable equality, so agreeing parents cannot be deduplicated as in
 `inheritField`. `inheritFieldUnique` inherits when exactly one parent
 supplies a value — sufficient for single-mother inheritance, the


### PR DESCRIPTION
Mechanical rename sweep (70 files): mathlib spells `Partial` out (`PartialEquiv`, `PartialHomeomorph`), and `Pr` reads as probability in a repo with probabilistic semantics. Also renames the combinators `forallPr`/`existsPrUniv`/`existsPrExist`/`negExistsPr` → `forallPartial`/`existsPartialUniv`/`existsPartialExist`/`negExistsPartial`. No semantic changes; prosodic-word `PrWd` untouched.