### PR TITLE
refactor(Core/Order): consolidate criteria-derived preorders

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2872,3 +2872,4 @@ import Linglib.Core.Logic.Modal.QBSML.StandardTranslation
 import Linglib.Core.Logic.Modal.QBSML.FreeChoice
 import Linglib.Studies.Yan2023
 import Linglib.Studies.TonhauserEtAl2013
+import Linglib.Core.Order.OfCriteria

--- a/Linglib/Core/Optimization/Evaluation.lean
+++ b/Linglib/Core/Optimization/Evaluation.lean
@@ -8,18 +8,16 @@ import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Algebra.Tropical.Basic
 
 /-!
-# Lexicographic and subset-inclusion orders on `Nat`-valued profiles
+# Lexicographic order on `Nat`-valued profiles
 
-Two comparison relations on lists / functions to `ℕ`:
-
-1. **Lexicographic** (`LexLE`): yields a total preorder on `List Nat`
-   and a `LinearOrder` on the fixed-length `Lex (Fin n → Nat)`.
-2. **Subset inclusion** (`SatLE`): yields a preorder where
-   incomparable elements are possible.
+Lexicographic comparison on lists / functions to `ℕ` (`LexLE`): a total
+preorder on `List Nat` and a `LinearOrder` on the fixed-length
+`Lex (Fin n → Nat)`. (The subset-inclusion order on satisfied criteria
+lives at `Preorder.ofCriteria` in `Core/Order/OfCriteria.lean`.)
 
 ## Architecture
 
-`LexLE`, `SatLE`, `LexLT` are decidable `Prop` relations defined by
+`LexLE`, `LexLT` are decidable `Prop` relations defined by
 structural recursion, delegating to standard combinators
 (`And.decidable`, `Or.decidable`). `LexMinProblem C n` packages a finite
 candidate set with a `Fin n → Nat`-valued score, exposing the
@@ -73,20 +71,6 @@ def LexLE : List Nat → List Nat → Prop
   | a :: as, [] => a = 0 ∧ LexLE as []
   | a :: as, b :: bs => a < b ∨ (a = b ∧ LexLE as bs)
 
-/-- Subset-inclusion ≤ on `List Nat`.
-
-    `SatLE a b` holds iff every coordinate at which `b` is `0`, `a` is also `0`. A
-    **preorder** (reflexive, transitive) but not a partial order on
-    `List Nat` — non-zero values are interchangeable (e.g., `SatLE [1] [2]`
-    and `SatLE [2] [1]` both hold). On binary `{0,1}` profiles it becomes
-    a partial order. Unlike `LexLE`, `SatLE` is not total. See
-    [kratzer-1991] for the linguistic application (ordering of worlds
-    relative to a premise set). -/
-def SatLE : List Nat → List Nat → Prop
-  | [], _ => True
-  | a :: as, [] => a = 0 ∧ SatLE as []
-  | a :: as, b :: bs => (b ≠ 0 ∨ a = 0) ∧ SatLE as bs
-
 /-- Strict lexicographic <. -/
 def LexLT (a b : List Nat) : Prop := LexLE a b ∧ ¬ LexLE b a
 
@@ -103,15 +87,6 @@ instance instDecidableLexLE : (a b : List Nat) → Decidable (LexLE a b)
     have : Decidable (LexLE as bs) := instDecidableLexLE as bs
     inferInstanceAs (Decidable (a < b ∨ (a = b ∧ LexLE as bs)))
 
-instance instDecidableSatLE : (a b : List Nat) → Decidable (SatLE a b)
-  | [], b => isTrue (by cases b <;> trivial)
-  | a :: as, [] =>
-    have : Decidable (SatLE as []) := instDecidableSatLE as []
-    inferInstanceAs (Decidable (a = 0 ∧ SatLE as []))
-  | a :: as, b :: bs =>
-    have : Decidable (SatLE as bs) := instDecidableSatLE as bs
-    inferInstanceAs (Decidable ((b ≠ 0 ∨ a = 0) ∧ SatLE as bs))
-
 instance instDecidableLexLT (a b : List Nat) : Decidable (LexLT a b) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
@@ -124,13 +99,7 @@ theorem lexLE_refl : (a : List Nat) → LexLE a a
   | [] => trivial
   | _ :: xs => .inr ⟨rfl, lexLE_refl xs⟩
 
-/-- Satisfaction ≤ is reflexive. -/
-theorem satLE_refl : (a : List Nat) → SatLE a a
-  | [] => trivial
-  | x :: xs => ⟨if h : x = 0 then .inr h else .inl h, satLE_refl xs⟩
-
-/-- Lexicographic ≤ is total for equal-length profiles. Key difference
-    from `SatLE`. -/
+/-- Lexicographic ≤ is total for equal-length profiles. -/
 theorem lexLE_total (a b : List Nat) (h : a.length = b.length) :
     LexLE a b ∨ LexLE b a := by
   induction a generalizing b with
@@ -150,15 +119,6 @@ theorem lexLE_total (a b : List Nat) (h : a.length = b.length) :
           exact (ih ys hlen).elim
             (fun h => Or.inl (.inr ⟨rfl, h⟩))
             (fun h => Or.inr (.inr ⟨rfl, h⟩))
-
-/-- `SatLE` is NOT total: profiles can be incomparable when each is
-    nonzero where the other is zero, and vice versa. -/
-theorem satLE_not_total : ¬∀ (a b : List Nat), SatLE a b ∨ SatLE b a := by
-  intro h
-  have := h [0, 1] [1, 0]
-  cases this with
-  | inl h => exact absurd h (by decide)
-  | inr h => exact absurd h (by decide)
 
 -- ============================================================================
 -- § 3b: LexLE Structural Lemmas
@@ -292,70 +252,6 @@ theorem exists_lexLE_minimum {α : Type} (xs : List α) (hne : xs ≠ [])
           cases hy with
           | head => exact hma
           | tail _ h => exact hm_min y h⟩
-
--- ============================================================================
--- § 4e: SatLE Structural Lemmas
--- ============================================================================
-
-/-- `SatLE [] b` holds for any `b`: the empty profile vacuously
-    satisfies the inclusion condition. -/
-theorem satLE_nil (b : List Nat) : SatLE [] b := by
-  cases b <;> trivial
-
-/-- Characterization of `SatLE (x :: xs) []`: all entries must be zero. -/
-theorem satLE_cons_nil_iff (x : Nat) (xs : List Nat) :
-    SatLE (x :: xs) [] ↔ x = 0 ∧ SatLE xs [] :=
-  Iff.rfl
-
-/-- Characterization of `SatLE (x :: xs) (y :: ys)`: if `y` is satisfied
-    (zero) then `x` must also be satisfied, and the tails must be ordered. -/
-theorem satLE_cons_cons_iff (x y : Nat) (xs ys : List Nat) :
-    SatLE (x :: xs) (y :: ys) ↔ (y ≠ 0 ∨ x = 0) ∧ SatLE xs ys :=
-  Iff.rfl
-
--- ============================================================================
--- § 4f: SatLE Transitivity — Preorder
--- ============================================================================
-
-/-- If `SatLE a []` (all entries are zero), then `SatLE a c`
-    for any `c`. The all-zeros profile is the minimum under `SatLE`. -/
-theorem satLE_of_nil_right : ∀ (a : List Nat),
-    SatLE a [] → ∀ (c : List Nat), SatLE a c
-  | [], _, c => satLE_nil c
-  | _ :: xs, ⟨rfl, hxs⟩, c => by
-    cases c with
-    | nil => exact ⟨rfl, hxs⟩
-    | cons _ zs => exact ⟨.inr rfl, satLE_of_nil_right xs hxs zs⟩
-
-/-- Satisfaction ≤ is transitive. Together with `satLE_refl`, this
-    makes `SatLE` a **preorder**. Unlike `LexLE`,
-    `SatLE` is NOT antisymmetric on `List Nat` (see `satLE_not_antisymm`)
-    — it IS antisymmetric on binary {0,1} profiles, where it becomes a
-    partial order. -/
-theorem satLE_trans : ∀ (a b c : List Nat),
-    SatLE a b → SatLE b c → SatLE a c
-  | [], _, c, _, _ => satLE_nil c
-  | _ :: _, [], c, hab, _ => satLE_of_nil_right _ hab c
-  | _ :: xs, _ :: ys, [], ⟨hab1, hab2⟩, ⟨rfl, hbc2⟩ => by
-    refine ⟨?_, satLE_trans xs ys [] hab2 hbc2⟩
-    rcases hab1 with h | h
-    · exact absurd rfl h
-    · exact h
-  | _ :: xs, _ :: ys, _ :: zs, ⟨hab1, hab2⟩, ⟨hbc1, hbc2⟩ => by
-    refine ⟨?_, satLE_trans xs ys zs hab2 hbc2⟩
-    rcases hbc1 with hz | rfl
-    · exact .inl hz
-    · rcases hab1 with h | h
-      · exact absurd rfl h
-      · exact .inr h
-
-/-- `SatLE` is **not antisymmetric** on `List Nat`: non-zero values
-    are interchangeable since `SatLE` only distinguishes 0 from ≥1. -/
-theorem satLE_not_antisymm :
-    ¬∀ (a b : List Nat), SatLE a b → SatLE b a → a = b := by
-  intro h
-  exact absurd (h [1] [2] (by decide) (by decide)) (by decide)
-
 
 -- ============================================================================
 -- § 10: LexNatList — Variable-Length Lexicographic Preorder

--- a/Linglib/Core/Order/Normality.lean
+++ b/Linglib/Core/Order/Normality.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.Set.Basic
+import Linglib.Core.Order.OfCriteria
 
 /-!
 # Normality Orderings
@@ -275,18 +276,23 @@ theorem respects_no_domination (no : NormalityOrder W) (φ : W → Prop)
 
 -- ═══ Construction from Propositions ═══
 
+/-- Repackage a `Preorder` as a `NormalityOrder`. -/
+def ofPreorder (p : Preorder W) : NormalityOrder W where
+  le := p.le
+  le_refl := p.le_refl
+  le_trans u v w := p.le_trans u v w
+
 /-- Construct a normality ordering from a list of propositions.
-    w ≤ v iff every proposition satisfied by v is also satisfied by w.
+    w ≤ v iff every proposition satisfied by v is also satisfied by w —
+    the criteria-derived preorder `Preorder.ofCriteria` with the ordering
+    source as criteria, repackaged.
 
     This is [kratzer-1981]'s ordering source construction:
     {p ∈ A : v ∈ p} ⊆ {p ∈ A : w ∈ p}.
-
-    Equivalent to `atLeastAsGoodAs` in `Modality/Kratzer.lean` (computable)
-    and `kratzerPlausibility` in `BeliefRevision.lean` (with smoothness). -/
-def fromProps (props : List (W → Prop)) : NormalityOrder W where
-  le w v := ∀ p ∈ props, p v → p w
-  le_refl _ _ _ h := h
-  le_trans _ _ _ huv hvw p hp hpw := huv p hp (hvw p hp hpw)
+    `Semantics.Modality.Kratzer.kratzerNormality` is definitionally this;
+    `kratzerPlausibility` in `BeliefRevision.lean` adds smoothness. -/
+def fromProps (props : List (W → Prop)) : NormalityOrder W :=
+  ofPreorder (Preorder.ofCriteria (fun w p => p w) {p | p ∈ props})
 
 /-- The empty ordering source gives the total ordering. -/
 theorem fromProps_nil {w v : W} : (fromProps ([] : List (W → Prop))).le w v :=

--- a/Linglib/Core/Order/OfCriteria.lean
+++ b/Linglib/Core/Order/OfCriteria.lean
@@ -1,0 +1,70 @@
+import Mathlib.Data.Set.Basic
+import Mathlib.Order.Defs.PartialOrder
+
+/-!
+# The criteria-derived preorder
+
+`Preorder.ofCriteria sat criteria` orders a carrier by inclusion of
+satisfied criteria: `a ≤ b` iff every criterion in `criteria` that `b`
+satisfies, `a` satisfies too. This is [kratzer-1981]'s ordering-source
+construction at full generality — the pullback of `⊇` along the
+satisfied-set map (`ofCriteria_le_iff_subset`; `Core.Order.PullbackPreorder`
+is the bundled, decidability-carrying form of the same pattern).
+
+One construction, several instantiations across the library:
+
+- `Semantics.Modality.Kratzer.kratzerPreorder` / `atLeastAsGoodAs` —
+  worlds ordered by an ordering source.
+- `Core.Order.NormalityOrder.fromProps` — the same order repackaged as a
+  `NormalityOrder` for the default-reasoning infrastructure.
+- `Semantics.Attitudes.Desire.worldAtLeastAsGood` — worlds ordered by
+  desires (via `atLeastAsGoodAs`).
+- `Core.Order.SatisfactionOrdering.ofCriteria` — the bundled
+  `Bool`-valued/`List`-criteria specialization with decidable `≤`
+  (`SatisfactionOrdering.le_iff_ofCriteria`).
+-/
+
+namespace Preorder
+
+variable {α C : Type*}
+
+/-- **The criteria-derived preorder**: `a ≤ b` iff every criterion in
+    `criteria` that `b` satisfies, `a` satisfies too —
+    [kratzer-1981]'s ordering-source construction
+    `{c ∈ A : sat b c} ⊆ {c ∈ A : sat a c}` at full generality. -/
+@[reducible] def ofCriteria (sat : α → C → Prop) (criteria : Set C) :
+    Preorder α where
+  le a b := ∀ c ∈ criteria, sat b c → sat a c
+  le_refl _ _ _ h := h
+  le_trans _ _ _ hab hbc c hc h := hab c hc (hbc c hc h)
+
+/-- Unfolding lemma for the criteria-derived order. Not `@[simp]` —
+    unfolding is opt-in. -/
+theorem ofCriteria_le_iff (sat : α → C → Prop) (criteria : Set C) (a b : α) :
+    (ofCriteria sat criteria).le a b ↔ ∀ c ∈ criteria, sat b c → sat a c :=
+  Iff.rfl
+
+/-- The criteria-derived order is the pullback of `⊇` along the
+    satisfied-set map `a ↦ {c ∈ criteria | sat a c}` — the
+    `Core.Order.PullbackPreorder` pattern with target `(Set C)ᵒᵈ`. -/
+theorem ofCriteria_le_iff_subset (sat : α → C → Prop) (criteria : Set C)
+    (a b : α) :
+    (ofCriteria sat criteria).le a b ↔
+      {c ∈ criteria | sat b c} ⊆ {c ∈ criteria | sat a c} := by
+  constructor
+  · intro h c hc
+    obtain ⟨hcrit, hsat⟩ := Set.mem_sep_iff.mp hc
+    exact Set.mem_sep_iff.mpr ⟨hcrit, h c hcrit hsat⟩
+  · intro h c hc hsat
+    exact (Set.mem_sep_iff.mp (h (Set.mem_sep_iff.mpr ⟨hc, hsat⟩))).2
+
+/-- Fewer criteria, coarser order: dominance over a criteria set transfers
+    to any subset. The general form of "adding a proposition to the
+    ordering source refines it". -/
+theorem ofCriteria_le_of_subset {sat : α → C → Prop}
+    {criteria criteria' : Set C} (hsub : criteria ⊆ criteria') {a b : α}
+    (h : (ofCriteria sat criteria').le a b) :
+    (ofCriteria sat criteria).le a b :=
+  fun c hc => h c (hsub hc)
+
+end Preorder

--- a/Linglib/Core/Order/PullbackPreorder.lean
+++ b/Linglib/Core/Order/PullbackPreorder.lean
@@ -13,6 +13,10 @@ This is mathlib's `Preorder.lift` packaged with the witnessing
 projection and decidability of `≤`. It is the common pattern behind
 several constructions in linglib:
 
+- `Preorder.ofCriteria` (`Core/Order/OfCriteria.lean`) — the general
+  criteria-derived preorder; its `≤` is the pullback of `⊇` along the
+  satisfied-set map (`Preorder.ofCriteria_le_iff_subset`), without the
+  bundled decidability.
 - `Core.Order.SatisfactionOrdering α Criterion` — the projection is the
   satisfied criterion set, the target is `(Finset Criterion)ᵒᵈ` (or
   equivalently, the violated set with standard ⊆).

--- a/Linglib/Core/Order/Satisfaction.lean
+++ b/Linglib/Core/Order/Satisfaction.lean
@@ -71,6 +71,24 @@ def ofCriteria (satisfies : α → Criterion → Bool) (criteria : List Criterio
       show Decidable (∀ p ∈ criteria.filter (satisfies a'), satisfies a p = true) by
         infer_instance }
 
+/-- The bundled construction agrees with the general criteria-derived
+    preorder `Preorder.ofCriteria` (Prop-valued satisfaction, `Set`
+    criteria): same order, with the `List.filter` membership unfolded.
+    `SatisfactionOrdering` is the decidable/bundled specialization. -/
+theorem le_iff_ofCriteria (satisfies : α → Criterion → Bool)
+    (criteria : List Criterion) (a a' : α) :
+    (SatisfactionOrdering.ofCriteria satisfies criteria).le a a' ↔
+      (Preorder.ofCriteria (fun x c => satisfies x c = true)
+        {c | c ∈ criteria}).le a a' := by
+  show (∀ p ∈ criteria.filter (satisfies a'), satisfies a p = true) ↔
+    ∀ c ∈ criteria, satisfies a' c = true → satisfies a c = true
+  constructor
+  · intro h c hc hsat
+    exact h c (List.mem_filter.mpr ⟨hc, hsat⟩)
+  · intro h c hc
+    obtain ⟨hc', hsat⟩ := List.mem_filter.mp hc
+    exact h c hc' hsat
+
 /-! ## Domain-friendly aliases
 
 These let study files use names that match the source literature
@@ -116,10 +134,8 @@ theorem equivalent_trans (o : SatisfactionOrdering α Criterion) {a b c : α}
 /-- The induced `NormalityOrder`: connects satisfaction-based orderings
     (Kratzer modal semantics, Phillips-Brown desire) to the default reasoning
     infrastructure (`optimal`, `refine`, `respects`, CR1–CR4). -/
-def toNormalityOrder (o : SatisfactionOrdering α Criterion) : NormalityOrder α where
-  le := o.le
-  le_refl := o.le_refl
-  le_trans := o.le_trans
+def toNormalityOrder (o : SatisfactionOrdering α Criterion) : NormalityOrder α :=
+  .ofPreorder o.toPreorder
 
 /-! ## Maxima and undominated elements -/
 

--- a/Linglib/Semantics/Attitudes/Desire.lean
+++ b/Linglib/Semantics/Attitudes/Desire.lean
@@ -68,10 +68,10 @@ reduces to von Fintel's standard semantics — see
 (comparative-belief) is *not* formalized here; the no-go theorem
 `wantVF_no_simultaneous_pq_and_negpq` covers von Fintel only.
 
-The world ordering used by `wantVF` is structurally identical to
-[kratzer-1981]'s ordering (every desire satisfied at z is also
-satisfied at w); see `worldAtLeastAsGood_iff_kratzer_atLeastAsGoodAs`
-for the bridge.
+The world ordering used by `wantVF` is [kratzer-1981]'s ordering over
+the projected desire propositions (every desire satisfied at z is also
+satisfied at w) — definitionally, not by bridge: `worldAtLeastAsGood`
+calls `Kratzer.atLeastAsGoodAs` directly.
 -/
 
 namespace Semantics.Attitudes.Desire
@@ -170,30 +170,40 @@ instance (belS : Set W) [DecidablePred belS]
 
 `wantVF` evaluates to "every undominated belief-world is a p-world",
 where the world ordering is induced by which desires each world
-satisfies. Structurally identical to [kratzer-1981]'s
-`atLeastAsGoodAs`; see the bridge theorem
-`worldAtLeastAsGood_iff_kratzer`. -/
+satisfies — [kratzer-1981]'s `atLeastAsGoodAs` over the projected
+desires, by definition. -/
 
 /-- World ordering induced by a desire list: `w ≤ z` iff every desire
-    in `GS` satisfied at `z` is also satisfied at `w`. Decidable
-    version (each `p.prop` carries its own `DecidablePred` witness). -/
+    in `GS` satisfied at `z` is also satisfied at `w` — [kratzer-1981]'s
+    `atLeastAsGoodAs` over the projected proposition list, by definition.
+    Decidability is transported from the per-`DecProp` witnesses via
+    `worldAtLeastAsGood_iff_decProp`. -/
 def worldAtLeastAsGood (GS : List (DecProp W)) (w z : W) : Prop :=
-  ∀ p ∈ GS, p.prop z → p.prop w
+  Semantics.Modality.Kratzer.atLeastAsGoodAs (GS.map (·.prop)) w z
+
+omit [Fintype W] [DecidableEq W] in
+/-- The ordering in its `DecProp`-quantified form, where each desire
+    carries its decidability witness. -/
+theorem worldAtLeastAsGood_iff_decProp (GS : List (DecProp W)) (w z : W) :
+    worldAtLeastAsGood GS w z ↔ ∀ p ∈ GS, p.prop z → p.prop w := by
+  show (∀ p ∈ GS.map (·.prop), p z → p w) ↔ _
+  simp only [List.mem_map]
+  refine ⟨fun h a ha hpz => h a.prop ⟨a, ha, rfl⟩ hpz,
+          fun h _ ⟨a, ha, hap⟩ hpz => hap ▸ h a ha (hap ▸ hpz)⟩
 
 instance (GS : List (DecProp W)) (w z : W) :
     Decidable (worldAtLeastAsGood GS w z) :=
-  inferInstanceAs (Decidable (∀ _ ∈ _, _))
+  decidable_of_iff _ (worldAtLeastAsGood_iff_decProp GS w z).symm
 
 omit [Fintype W] [DecidableEq W] in
 /-- The desire-induced world ordering coincides with Kratzer's ordering
-    over the projected proposition list. -/
+    over the projected proposition list — definitional since
+    `worldAtLeastAsGood` calls `atLeastAsGoodAs` directly; kept for
+    discoverability. -/
 theorem worldAtLeastAsGood_iff_kratzer (GS : List (DecProp W)) (w z : W) :
     worldAtLeastAsGood GS w z ↔
-      Semantics.Modality.Kratzer.atLeastAsGoodAs (GS.map (·.prop)) w z := by
-  unfold worldAtLeastAsGood Semantics.Modality.Kratzer.atLeastAsGoodAs
-  simp only [List.mem_map]
-  refine ⟨fun h _ ⟨a, ha, hap⟩ hpz => hap ▸ h a ha (hap ▸ hpz),
-          fun h a ha hpz => h a.prop ⟨a, ha, rfl⟩ hpz⟩
+      Semantics.Modality.Kratzer.atLeastAsGoodAs (GS.map (·.prop)) w z :=
+  Iff.rfl
 
 /-- Standard von Fintel [von-fintel-1999] semantics: every undominated
     belS-world is a p-world. The `[DecidablePred]` hypotheses are not
@@ -349,7 +359,8 @@ belS-worlds), then a direct two-direction `iff` proof. -/
 private theorem singleton_le_iff_world (GS : List (DecProp W)) (w z : W) :
     (propositionOrdering GS).le (mkDec (· = w)) (mkDec (· = z)) ↔
       worldAtLeastAsGood GS w z := by
-  unfold propositionOrdering worldAtLeastAsGood SatisfactionOrdering.ofCriteria
+  rw [worldAtLeastAsGood_iff_decProp]
+  unfold propositionOrdering SatisfactionOrdering.ofCriteria
   show (∀ q ∈ GS.filter (fun q => decide (propEntails (mkDec (· = z)).prop q.prop)),
           decide (propEntails (mkDec (· = w)).prop q.prop) = true) ↔
        (∀ q ∈ GS, q.prop z → q.prop w)

--- a/Linglib/Semantics/Modality/Kratzer/Ordering.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Ordering.lean
@@ -14,6 +14,7 @@ All types are polymorphic over the world type `W`. Propositions are
 
 import Linglib.Semantics.Modality.Kratzer.ConversationalBackground
 import Linglib.Core.Order.Normality
+import Linglib.Core.Order.OfCriteria
 import Mathlib.Order.Basic
 import Mathlib.Data.Set.Basic
 
@@ -42,7 +43,17 @@ noncomputable def satisfiedPropositions (A : List (W → Prop)) (w : W) : List (
   A.filter (fun p => p w)
 
 /--
-Kratzer's ordering relation: w ≤_A z
+Kratzer's world ordering as a `Preorder` on worlds — the criteria-derived
+preorder (`Preorder.ofCriteria`) with the ordering source `A` as criteria
+set and truth-at-a-world as satisfaction. The induced order is `≤[A]`.
+Used by Phillips-Brown desire semantics and other consumers via
+`letI := kratzerPreorder A`.
+-/
+@[reducible] def kratzerPreorder (A : List (W → Prop)) : Preorder W :=
+  Preorder.ofCriteria (fun w p => p w) {p | p ∈ A}
+
+/--
+Kratzer's ordering relation: w ≤_A z — the `le` of `kratzerPreorder`.
 
 [kratzer-1981]: `w ≤_A z` iff every ideal proposition `p ∈ A` that
 holds at `z` also holds at `w`. Intuitively: `w` is at least as good as
@@ -53,10 +64,15 @@ UNVERIFIED page reference (p. 39 quoted in earlier version, not checked
 against the original).
 -/
 def atLeastAsGoodAs (A : List (W → Prop)) (w z : W) : Prop :=
-  ∀ p ∈ A, p z → p w
+  (kratzerPreorder A).le w z
 
 @[inherit_doc]
 notation:50 w " ≤[" A "] " z => atLeastAsGoodAs A w z
+
+/-- Unfolding lemma: the ordering in its pointwise form. Definitional. -/
+theorem atLeastAsGoodAs_iff (A : List (W → Prop)) (w z : W) :
+    (w ≤[A] z) ↔ ∀ p ∈ A, p z → p w :=
+  Iff.rfl
 
 /--
 Strict ordering: w <_A z iff w ≤_A z but not z ≤_A w.
@@ -72,32 +88,21 @@ notation:50 w " <[" A "] " z => strictlyBetter A w z
 /-- Reflexivity. -/
 theorem ordering_reflexive (A : List (W → Prop)) (w : W) :
     atLeastAsGoodAs A w w :=
-  fun _ _ hp => hp
+  (kratzerPreorder A).le_refl w
 
 /-- Transitivity. -/
 theorem ordering_transitive (A : List (W → Prop)) (u v w : W)
     (huv : atLeastAsGoodAs A u v)
     (hvw : atLeastAsGoodAs A v w) :
     atLeastAsGoodAs A u w :=
-  fun p hp hpw => huv p hp (hvw p hp hpw)
+  (kratzerPreorder A).le_trans u v w huv hvw
 
-/--
-Kratzer's world ordering as a `Preorder` on worlds.
-
-The induced order is `≤[A]`. Used by Phillips-Brown desire semantics
-and other consumers via `letI := kratzerPreorder A`.
--/
-@[reducible] def kratzerPreorder (A : List (W → Prop)) : Preorder W where
-  le := atLeastAsGoodAs A
-  le_refl := ordering_reflexive A
-  le_trans u v w := ordering_transitive A u v w
-
-/-- Kratzer's ordering as a `NormalityOrder`: connects to default reasoning
-    infrastructure (`optimal`, `refine`, `respects`, CR1–CR4). -/
-def kratzerNormality (A : List (W → Prop)) : Core.Order.NormalityOrder W where
-  le := atLeastAsGoodAs A
-  le_refl := ordering_reflexive A
-  le_trans u v w := ordering_transitive A u v w
+/-- Kratzer's ordering as a `NormalityOrder` — definitionally
+    `NormalityOrder.fromProps` (the same `Preorder.ofCriteria` order
+    repackaged); connects to default reasoning infrastructure
+    (`optimal`, `refine`, `respects`, CR1–CR4). -/
+def kratzerNormality (A : List (W → Prop)) : Core.Order.NormalityOrder W :=
+  Core.Order.NormalityOrder.fromProps A
 
 /-- Equivalence under the ordering. -/
 def orderingEquiv (A : List (W → Prop)) (w z : W) : Prop :=

--- a/Linglib/Semantics/Modality/ProbabilityOrdering.lean
+++ b/Linglib/Semantics/Modality/ProbabilityOrdering.lean
@@ -61,6 +61,7 @@ lemma higher_prob_dominates {W : Type*} [Fintype W]
     {prob : ProbAssignment W} {w1 w2 wEval : W}
     (hOrd : prob w1 ≥ prob w2) :
     atLeastAsGoodAs ((probToOrdering prob) wEval) w1 w2 := by
+  rw [atLeastAsGoodAs_iff]
   intro p hp
   rw [probToOrdering, List.mem_map] at hp
   obtain ⟨v, _, rfl⟩ := hp


### PR DESCRIPTION
One construction, four consumers-by-instantiation: new `Preorder.ofCriteria` (`Core/Order/OfCriteria.lean`, [kratzer-1981]'s ordering-source order at full generality, grounded in the `PullbackPreorder` pattern). `Kratzer.atLeastAsGoodAs`, `NormalityOrder.fromProps`, and `Desire.worldAtLeastAsGood` were three byte-identical implementations connected only by after-the-fact bridge lemmas; all three are now defeq-preserving calls (`worldAtLeastAsGood_iff_kratzer` is `Iff.rfl`), `kratzerNormality := fromProps`, `SatisfactionOrdering` connected as the bundled/decidable specialization (`le_iff_ofCriteria`), and the consumer-less third copy `SatLE` deleted.