### PR TITLE
feat(Semantics/Dynamic): PartialCCP — Heim partial updates via PFun

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2873,3 +2873,4 @@ import Linglib.Core.Logic.Modal.QBSML.FreeChoice
 import Linglib.Studies.Yan2023
 import Linglib.Studies.TonhauserEtAl2013
 import Linglib.Core.Order.OfCriteria
+import Linglib.Semantics.Dynamic.Connectives.PartialCCP

--- a/Linglib/Semantics/Dynamic/Connectives/PartialCCP.lean
+++ b/Linglib/Semantics/Dynamic/Connectives/PartialCCP.lean
@@ -1,0 +1,196 @@
+import Mathlib.Data.PFun
+import Linglib.Semantics.Dynamic.Connectives.CCP
+import Linglib.Semantics.Presupposition.Context
+
+/-!
+# Partial Context Change Potentials
+[karttunen-1974] [heim-1983]
+
+Heim's context change potentials are *partial* functions on contexts: the
+domain condition IS the presupposition ([heim-1983]'s "c admits φ",
+[karttunen-1974]'s "c satisfies-the-presuppositions-of φ").
+`PartialCCP P := InfoStateOf P →. InfoStateOf P` grounds this in mathlib's
+`PFun`: `Part.Dom` is admittance, and the satisfaction law for conjunction —
+"c admits φ∧ψ iff c admits φ and c[φ] admits ψ" — is the domain condition
+of partial-function composition, true by construction (`admits_pseq`).
+
+`ofPartialProp` sends a static partial proposition to its Heimian update:
+defined iff the context globally satisfies the presupposition (whole-state
+admittance, NOT per-world filtering), updating by intersecting with the
+assertion. Under this bridge the filtering connectives of
+`Presupposition/Basic.lean` stop being stipulations: `andFilter`,
+`impFilter`, and `orFilter` are *derived* as the admittance conditions of
+dynamic conjunction, conditional, and disjunction
+(`admits_pseq_ofPartialProp` etc.).
+
+## Main declarations
+
+- `PartialCCP`, `admits`, `ofCCP`, `ofPartialProp`
+- `pseq`, `pneg`, `pcond`, `pdisj` — the partial-update clauses
+  ([heim-1983] gives CCPs for *not/and/if*; the disjunction clause with
+  ¬φ local context follows [beaver-2001])
+- `admits_pseq` — the Karttunen satisfaction law, by construction
+- `admits_ofPartialProp_iff_presupSatisfied` — admittance is
+  `Context.presupSatisfied`
+- `admits_pseq_ofPartialProp`, `admits_pcond_ofPartialProp`,
+  `admits_pdisj_ofPartialProp` — the filtering connectives, derived
+-/
+
+namespace Semantics.Dynamic.Core
+
+open Semantics.Presupposition
+
+/-- A partial context change potential: a partial function on information
+    states. The domain condition is the presupposition; `Part.Dom` is
+    [heim-1983]'s admittance. -/
+abbrev PartialCCP (P : Type*) := InfoStateOf P →. InfoStateOf P
+
+namespace PartialCCP
+
+variable {P W : Type*}
+
+/-- `u.admits s`: the update is defined at `s` ([heim-1983]'s "s admits u",
+    [karttunen-1974]'s satisfaction). This is `Part.Dom`. -/
+def admits (u : PartialCCP P) (s : InfoStateOf P) : Prop := (u s).Dom
+
+/-- Total CCPs are partial CCPs with trivial presupposition. -/
+def ofCCP (φ : CCP P) : PartialCCP P := λ s => Part.some (φ s)
+
+@[simp] theorem admits_ofCCP (φ : CCP P) (s : InfoStateOf P) :
+    (ofCCP φ).admits s := trivial
+
+/-- The Heimian update of a static partial proposition: defined iff every
+    world of the input satisfies the presupposition, updating by
+    intersecting with the assertion.
+
+    The whole-state domain condition is what separates admittance from
+    per-world filtering (`updateFromSat`): a context containing a single
+    presupposition-failing world admits nothing, rather than silently
+    discarding the world. -/
+def ofPartialProp (p : PartialProp W) : PartialCCP W :=
+  λ s => ⟨∀ w ∈ s, p.presup w, λ _ => { w ∈ s | p.assertion w }⟩
+
+@[simp] theorem ofPartialProp_get (p : PartialProp W) (s : InfoStateOf W)
+    (h : ((ofPartialProp p) s).Dom) :
+    ((ofPartialProp p) s).get h = { w ∈ s | p.assertion w } := rfl
+
+/-! ### Connectives -/
+
+/-- Sequencing (dynamic conjunction): `s[φ ∧ ψ] = s[φ][ψ]`. This is
+    `PFun.comp`; the projection behavior of conjunction is the
+    composition law of partial functions. -/
+def pseq (φ ψ : PartialCCP P) : PartialCCP P := ψ.comp φ
+
+/-- Heim negation: `s[¬φ] = s \ s[φ]`, defined iff `s[φ]` is. -/
+def pneg (φ : PartialCCP P) : PartialCCP P := λ s => (φ s).map (s \ ·)
+
+/-- Heim conditional: `s[if φ, ψ] = s \ (s[φ] \ s[φ][ψ])`, defined iff
+    `s[φ]` and `s[φ][ψ]` are. -/
+def pcond (φ ψ : PartialCCP P) : PartialCCP P :=
+  λ s => (φ s).bind λ sφ => (ψ sφ).map λ sφψ => s \ (sφ \ sφψ)
+
+/-- Disjunction with ¬φ local context for the second disjunct
+    ([beaver-2001]; [heim-1983] gives CCPs only for *not/and/if*):
+    `s[φ ∨ ψ] = s[φ] ∪ (s \ s[φ])[ψ]`. -/
+def pdisj (φ ψ : PartialCCP P) : PartialCCP P :=
+  λ s => (φ s).bind λ sφ => (ψ (s \ sφ)).map λ sψ => sφ ∪ sψ
+
+/-! ### The satisfaction law -/
+
+/-- **The Karttunen satisfaction law** ([karttunen-1974]), by construction:
+    `s` admits `φ ∧ ψ` iff `s` admits `φ` and `s[φ]` admits `ψ`. The
+    statement is the domain condition of `Part.bind`. -/
+theorem admits_pseq (φ ψ : PartialCCP P) (s : InfoStateOf P) :
+    (pseq φ ψ).admits s ↔ ∃ h : φ.admits s, ψ.admits ((φ s).get h) :=
+  Iff.rfl
+
+/-- The satisfaction law, with admittance of the first conjunct given. -/
+theorem admits_pseq_iff (φ ψ : PartialCCP P) (s : InfoStateOf P)
+    (h : φ.admits s) :
+    (pseq φ ψ).admits s ↔ ψ.admits ((φ s).get h) :=
+  ⟨λ ⟨_, hb⟩ => hb, λ hb => ⟨h, hb⟩⟩
+
+/-- Negation projects: `s` admits `¬φ` iff `s` admits `φ`. -/
+@[simp] theorem admits_pneg (φ : PartialCCP P) (s : InfoStateOf P) :
+    (pneg φ).admits s ↔ φ.admits s :=
+  Iff.rfl
+
+/-- Conditional admittance: `s` admits `if φ, ψ` iff `s` admits `φ` and
+    `s[φ]` admits `ψ` — the same condition as conjunction
+    ([karttunen-1974]). -/
+theorem admits_pcond (φ ψ : PartialCCP P) (s : InfoStateOf P) :
+    (pcond φ ψ).admits s ↔ ∃ h : φ.admits s, ψ.admits ((φ s).get h) :=
+  Iff.rfl
+
+/-- Disjunction admittance: `s` admits `φ ∨ ψ` iff `s` admits `φ` and the
+    ¬φ local context `s \ s[φ]` admits `ψ`. -/
+theorem admits_pdisj (φ ψ : PartialCCP P) (s : InfoStateOf P) :
+    (pdisj φ ψ).admits s ↔
+      ∃ h : φ.admits s, ψ.admits (s \ (φ s).get h) :=
+  Iff.rfl
+
+/-! ### The Stalnaker bridge -/
+
+/-- Admittance of an atomic update is global presupposition satisfaction. -/
+theorem admits_ofPartialProp (p : PartialProp W) (s : InfoStateOf W) :
+    (ofPartialProp p).admits s ↔ ∀ w ∈ s, p.presup w :=
+  Iff.rfl
+
+/-- Admittance is the static layer's `Context.presupSatisfied`: the dynamic
+    definedness condition and the satisfaction-theoretic context condition
+    are one notion. -/
+theorem admits_ofPartialProp_iff_presupSatisfied (p : PartialProp W)
+    (c : CommonGround.ContextSet W) :
+    (ofPartialProp p).admits c ↔ Context.presupSatisfied c p :=
+  Iff.rfl
+
+/-! ### Filtering connectives, derived
+
+Under `ofPartialProp`, the admittance conditions of the dynamic
+connectives are pointwise exactly the presuppositions of the *filtering*
+connectives of `Presupposition/Basic.lean` — Karttunen filtering is the
+composition law of partial updates, not a stipulation. -/
+
+/-- Dynamic conjunction admits `s` iff `s` satisfies `andFilter`'s
+    presupposition pointwise. -/
+theorem admits_pseq_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
+    (pseq (ofPartialProp p) (ofPartialProp q)).admits s ↔
+      ∀ w ∈ s, (PartialProp.andFilter p q).presup w := by
+  constructor
+  · rintro ⟨hp, hq⟩ w hw
+    exact ⟨hp w hw, λ ha => hq w ⟨hw, ha⟩⟩
+  · intro h
+    exact ⟨λ w hw => (h w hw).1, λ w hw => (h w hw.1).2 hw.2⟩
+
+/-- Dynamic conditional admits `s` iff `s` satisfies `impFilter`'s
+    presupposition pointwise. -/
+theorem admits_pcond_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
+    (pcond (ofPartialProp p) (ofPartialProp q)).admits s ↔
+      ∀ w ∈ s, (PartialProp.impFilter p q).presup w := by
+  constructor
+  · rintro ⟨hp, hq⟩ w hw
+    exact ⟨hp w hw, λ ha => hq w ⟨hw, ha⟩⟩
+  · intro h
+    exact ⟨λ w hw => (h w hw).1, λ w hw => (h w hw.1).2 hw.2⟩
+
+/-- Dynamic disjunction admits `s` iff `s` satisfies `orFilter`'s
+    presupposition pointwise: the ¬φ local context is Karttunen's
+    negative-antecedent filtering. -/
+theorem admits_pdisj_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
+    (pdisj (ofPartialProp p) (ofPartialProp q)).admits s ↔
+      ∀ w ∈ s, (PartialProp.orFilter p q).presup w := by
+  constructor
+  · rintro ⟨hp, hq⟩ w hw
+    exact ⟨hp w hw, λ hna => hq w ⟨hw, λ hc => hna hc.2⟩⟩
+  · intro h
+    exact ⟨λ w hw => (h w hw).1,
+           λ w hw => (h w hw.1).2 (λ ha => hw.2 ⟨hw.1, ha⟩)⟩
+
+/-- Negation projects the atomic presupposition unchanged. -/
+theorem admits_pneg_ofPartialProp (p : PartialProp W) (s : InfoStateOf W) :
+    (pneg (ofPartialProp p)).admits s ↔ ∀ w ∈ s, p.presup w :=
+  Iff.rfl
+
+end PartialCCP
+
+end Semantics.Dynamic.Core

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Basic.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Basic.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Dynamic.Connectives.CCP
+import Linglib.Semantics.Dynamic.Connectives.PartialCCP
 
 /-!
 # Update Semantics
@@ -200,6 +201,24 @@ noncomputable def PUpdate.presup {W : Type*} (p φ : W → Prop) : PState W → 
       some (Update.prop φ s)
     else
       none
+
+/-- `PUpdate.presup` is the `Option`-valued shadow of
+    `Core.PartialCCP.ofPartialProp`: defined (≠ `none`) at `some s` exactly
+    when `s` admits the corresponding partial update. `PartialCCP` is the
+    canonical `Part`-based form; this clause survives for the
+    [yagi-2025] disjunction machinery below. -/
+theorem PUpdate.presup_ne_none_iff_admits {W : Type*} (p φ : W → Prop)
+    (s : State W) :
+    PUpdate.presup p φ (some s) ≠ none ↔
+      (Core.PartialCCP.ofPartialProp ⟨p, φ⟩).admits s := by
+  simp only [PUpdate.presup]
+  split_ifs with h
+  · refine ⟨fun _ w hw => ?_, fun _ => Option.some_ne_none _⟩
+    have hm : w ∈ Update.prop p s := h.symm ▸ hw
+    exact hm.2
+  · refine ⟨fun hne => absurd rfl hne, fun hadm => absurd ?_ h⟩
+    have hadm' : ∀ w ∈ s, p w := hadm
+    exact Set.ext fun w => ⟨fun hw => hw.1, fun hw => ⟨hw, hadm' w hw⟩⟩
 
 /-- Negation extended to PState: s[¬φ] = s/s[φ].
 

--- a/Linglib/Semantics/Presupposition/Basic.lean
+++ b/Linglib/Semantics/Presupposition/Basic.lean
@@ -20,10 +20,13 @@ points. References: [heim-1983], [schlenker-2009], [von-fintel-1999],
 * Connective families on `PartialProp W`: classical (`and`, `or`, `imp`, `xor`),
   filtering / Karttunen (`andFilter`, `impFilter`, `orFilter`), K&P
   symmetric disjunction (`orKPSymmetric`), positive-antecedent
-  disjunction (`orPositive`, a documented rival), and Belnap conditional
-  assertion (`andBelnap`, `orBelnap`; the flexible-accommodation
-  `andFlex`/`orFlex` are definitionally the same operators). Classical
-  `and`/`or` are simultaneously Weak Kleene.
+  disjunction (`orPositive`, a documented rival), Strong Kleene
+  (`andStrong`, `orStrong` — the `Truth3` lattice meet/join), and Belnap
+  conditional assertion (`andBelnap`, `orBelnap`; the
+  flexible-accommodation `andFlex`/`orFlex` are definitionally the same
+  operators). Classical `and`/`or` are simultaneously Weak Kleene; the
+  filtering connectives are Peters' middle Kleene ([peters-1979],
+  `eval_andFilter`/`eval_orFilter`).
 * `belnapLift` — unifier showing Belnap = flexible accommodation for any
   binary `Prop` operator with an identity.
 * `strawsonEntails`, `strongEntails` — entailment relations: the
@@ -51,8 +54,6 @@ idiom in logic-heavy files such as `Mathlib/Order/Filter/Basic.lean`.
 
 ## Todo
 
-* Add a genuine Strong Kleene `orStrong`/`andStrong` (where `T ∨ #` is
-  defined as `T`). The classical `or`/`and` are Weak Kleene only.
 * `PartialProp W = PartialValue W Prop` unification: `PartialValue` already generalizes
   `PartialProp` at the type level; unifying would let the connective zoo lift
   to arbitrary at-issue carriers.
@@ -294,6 +295,26 @@ def orPositive (p q : PartialProp W) : PartialProp W where
 def orKPSymmetric (p q : PartialProp W) : PartialProp W where
   presup := fun w => (q.assertion w ∨ p.presup w) ∧ (p.assertion w ∨ q.presup w)
   assertion := fun w => p.assertion w ∨ q.assertion w
+
+/-! ### Strong Kleene -/
+
+/-- Strong Kleene disjunction ([kleene-1952]): defined iff both disjuncts
+    are defined or either is defined-and-true (`T ∨ # = T`, `F ∨ # = #`).
+    This is the `Truth3` lattice join — see `eval_orStrong`. -/
+def orStrong (p q : PartialProp W) : PartialProp W where
+  presup := fun w => (p.presup w ∧ q.presup w) ∨
+    (p.presup w ∧ p.assertion w) ∨ (q.presup w ∧ q.assertion w)
+  assertion := fun w =>
+    (p.presup w ∧ p.assertion w) ∨ (q.presup w ∧ q.assertion w)
+
+/-- Strong Kleene conjunction: defined iff both conjuncts are defined or
+    either is defined-and-false (`F ∧ # = F`, `T ∧ # = #`). This is the
+    `Truth3` lattice meet — see `eval_andStrong`. -/
+def andStrong (p q : PartialProp W) : PartialProp W where
+  presup := fun w => (p.presup w ∧ q.presup w) ∨
+    (p.presup w ∧ ¬p.assertion w) ∨ (q.presup w ∧ ¬q.assertion w)
+  assertion := fun w =>
+    (p.presup w → p.assertion w) ∧ (q.presup w → q.assertion w)
 
 /-! ### Belnap conditional assertion ([belnap-1970])
 
@@ -545,6 +566,41 @@ theorem eval_impFilter_antecedent_true (p q : PartialProp W) (w : W)
     simp only [eval, if_pos hpresup, if_pos hass, if_pos hqa]
   · have hass : ¬(impFilter p q).assertion w := fun h => hqa (h ha)
     simp only [eval, if_pos hpresup, if_neg hass, if_neg hqa]
+
+/-- `orStrong` evaluates to the `Truth3` lattice join pointwise: Strong
+    Kleene disjunction is ⊔ in the `false < indet < true` order,
+    unconditionally. -/
+theorem eval_orStrong (p q : PartialProp W) (w : W) :
+    (orStrong p q).eval w = p.eval w ⊔ q.eval w := by
+  by_cases hp : p.presup w <;> by_cases hq : q.presup w <;>
+    by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
+    simp [eval, orStrong, hp, hq, ha, hb] <;> decide
+
+/-- `andStrong` evaluates to the `Truth3` lattice meet pointwise,
+    unconditionally. -/
+theorem eval_andStrong (p q : PartialProp W) (w : W) :
+    (andStrong p q).eval w = p.eval w ⊓ q.eval w := by
+  by_cases hp : p.presup w <;> by_cases hq : q.presup w <;>
+    by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
+    simp [eval, andStrong, hp, hq, ha, hb] <;> decide
+
+/-- **Karttunen filtering conjunction is Peters' middle Kleene**
+    ([peters-1979]): `andFilter` evaluates to the asymmetric
+    `Truth3.meetMiddle` on both dimensions, unconditionally. -/
+theorem eval_andFilter (p q : PartialProp W) (w : W) :
+    (andFilter p q).eval w = Truth3.meetMiddle (p.eval w) (q.eval w) := by
+  by_cases hp : p.presup w <;> by_cases hq : q.presup w <;>
+    by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
+    simp [eval, andFilter, Truth3.meetMiddle, hp, hq, ha, hb] <;> decide
+
+/-- **Karttunen filtering disjunction is Peters' middle Kleene**
+    ([peters-1979]): `orFilter` evaluates to the asymmetric
+    `Truth3.joinMiddle` on both dimensions, unconditionally. -/
+theorem eval_orFilter (p q : PartialProp W) (w : W) :
+    (orFilter p q).eval w = Truth3.joinMiddle (p.eval w) (q.eval w) := by
+  by_cases hp : p.presup w <;> by_cases hq : q.presup w <;>
+    by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
+    simp [eval, orFilter, Truth3.joinMiddle, hp, hq, ha, hb] <;> decide
 
 /-- Exclusive disjunction evaluation matches `Truth3.xor` when both defined. -/
 theorem eval_xor (p q : PartialProp W) (w : W)

--- a/Linglib/Studies/Heim1983.lean
+++ b/Linglib/Studies/Heim1983.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Presupposition.TriggerTypology
+import Linglib.Semantics.Dynamic.Connectives.PartialCCP
 import Linglib.Phenomena.Presupposition.Basic
 
 /-!
@@ -61,9 +62,43 @@ Filtering affects which triggers are relevant for SI.
 
 When a presupposition is filtered (locally satisfied), the corresponding
 trigger no longer contributes to global presupposition, and alternatives
-involving that trigger may behave differently.
+involving that trigger may behave differently. (The `triggers := []` entry
+is *derived* below: `conditional_admitted_everywhere` proves the filtering
+from the partial-CCP semantics rather than stipulating it.)
 -/
 theorem filtering_removes_trigger :
     ifKingThenBaldDerivation.triggers = [] := rfl
+
+/-! ### Filtering derived from partial CCPs
+
+[heim-1983]'s actual machinery: sentences denote *partial* context change
+potentials (`Semantics.Dynamic.Core.PartialCCP`), and admittance does the
+projection work. The conditional's CCP is admitted by every context — the
+antecedent's update satisfies the consequent's king-presupposition — while
+the bare consequent's CCP is not admitted by the full context. The
+filtering recorded in the trigger tables above is a theorem, not a table
+entry. -/
+
+open Semantics.Dynamic.Core in
+/-- Every context admits ⟦if the king exists, the king is bald⟧: the
+    antecedent's update filters the consequent's presupposition
+    ([heim-1983]'s conditional CCP). -/
+theorem conditional_admitted_everywhere (c : Set KingWorld) :
+    (PartialCCP.pcond (PartialCCP.ofPartialProp kingExists)
+      (PartialCCP.ofPartialProp kingBald)).admits c := by
+  refine ⟨fun w _ => trivial, ?_⟩
+  rintro w ⟨_, ha⟩
+  cases w
+  · trivial
+  · exact ha
+
+open Semantics.Dynamic.Core in
+/-- The bare consequent ⟦the king is bald⟧ is NOT admitted by the full
+    context: the `noKing` world fails the presupposition, which therefore
+    projects. -/
+theorem bare_consequent_not_admitted :
+    ¬ (PartialCCP.ofPartialProp kingBald).admits Set.univ := by
+  intro h
+  exact h .noKing trivial
 
 end Heim1983


### PR DESCRIPTION
Step 4 of the presupposition API audit: the dynamic definedness type, grounded in mathlib's `PFun`.

- `PartialCCP P := InfoStateOf P →. InfoStateOf P` with `admits` (= `Part.Dom`) and the Heim clauses `pseq`/`pneg`/`pcond`/`pdisj`; the Karttunen satisfaction law ("c admits φ∧ψ iff c admits φ and c[φ] admits ψ") is `Iff.rfl` — the domain condition of partial-function composition
- the filtering connectives `andFilter`/`impFilter`/`orFilter` are derived as the admittance conditions of the dynamic connectives; `admits` = `Context.presupSatisfied` (Stalnaker bridge); `Studies/Heim1983.lean` now derives its filtering table entries; `PUpdate.presup` bridged as the Option-valued shadow
- rides along: Strong Kleene `orStrong`/`andStrong` (= the `Truth3` lattice join/meet, `eval_orStrong`/`eval_andStrong`) and the Peters identification — filtering is middle Kleene (`eval_andFilter`/`eval_orFilter`, [peters-1979])