### PR TITLE
refactor(Semantics): K&L follow-ups: polymorphic DE, Fine 1975 bridge

### DIFF
--- a/Linglib/Semantics/Entailment/Polarity.lean
+++ b/Linglib/Semantics/Entailment/Polarity.lean
@@ -1,39 +1,19 @@
-/-
-# Grounded Context Polarity
-
-Semantic grounding for `ContextPolarity` (defined in `Core.NaturalLogic`)
-via Mathlib's `Monotone`/`Antitone` infrastructure.
-
-## Contents
-
-1. Re-export of `ContextPolarity` from `Core.NaturalLogic`
-2. IsUpwardEntailing/IsDownwardEntailing - Mathlib-based formal definitions
-3. Decidable test functions - For verification on finite models
-4. GroundedPolarity - Context + polarity + proof
-5. Monotonicity theorems - Negation, conditionals, quantifiers
-
-## Integration with Mathlib
-
-We use Mathlib's order-theoretic infrastructure:
-- `Monotone f` (from `Mathlib.Order.Monotone.Basic`): `∀ a b, a ≤ b → f a ≤ f b`
-- `Antitone f`: `∀ a b, a ≤ b → f b ≤ f a`
-
-For `Set World = World → Prop`, the ordering is pointwise: `p ≤ q ↔ ∀ w, p w → q w`.
-
-Mathlib provides composition lemmas for free:
-- `Monotone.comp`: UE ∘ UE = UE
-- `Antitone.comp_antitone`: DE ∘ DE = UE (the "double negation" rule!)
-- `Monotone.comp_antitone`: UE ∘ DE = DE
-- `Antitone.comp`: DE ∘ UE = DE
-
-The polarity composition rules are a homomorphic image of the
-`EntailmentSig` monoid — see `EntailmentSig.toContextPolarity_compose`.
-
--/
-
 import Mathlib.Order.Monotone.Defs
 import Linglib.Core.Logic.NaturalLogic
 import Linglib.Semantics.Entailment.Basic
+
+/-!
+# Grounded context polarity
+
+Semantic grounding for `ContextPolarity` (defined in `Core.NaturalLogic`) via
+mathlib's `Monotone`/`Antitone` infrastructure: `IsUpwardEntailing`/
+`IsDownwardEntailing` abbreviate `Monotone`/`Antitone` on `Set α → Set β`,
+so the composition rules (UE ∘ UE = UE, DE ∘ DE = UE, mixed = DE) are
+`Monotone.comp`/`Antitone.comp` and friends. The polarity composition rules
+are a homomorphic image of the `EntailmentSig` monoid — see
+`EntailmentSig.toContextPolarity_compose`. `GroundedPolarity` bundles a
+context function with its monotonicity proof on the toy `World` model.
+-/
 
 namespace Semantics.Entailment.Polarity
 
@@ -41,24 +21,16 @@ export Core.NaturalLogic (ContextPolarity)
 
 open Semantics.Entailment
 
-/--
-IsUpwardEntailing is an abbreviation for `Monotone`.
+/-- A context function is upward entailing if it preserves entailment:
+`Monotone` on sets of worlds. -/
+abbrev IsUpwardEntailing {α β : Type*} (f : Set α → Set β) := Monotone f
 
-A context function `f : Set World → Set World` is upward entailing if
-it preserves the ordering: If p ≤ q, then f(p) ≤ f(q).
--/
-abbrev IsUpwardEntailing (f : Set World → Set World) := Monotone f
+/-- A context function is downward entailing if it reverses entailment:
+`Antitone` on sets of worlds. -/
+abbrev IsDownwardEntailing {α β : Type*} (f : Set α → Set β) := Antitone f
 
-/--
-IsDownwardEntailing is an abbreviation for `Antitone`.
-
-A context function `f : Set World → Set World` is downward entailing if
-it reverses the ordering: If p ≤ q, then f(q) ≤ f(p).
--/
-abbrev IsDownwardEntailing (f : Set World → Set World) := Antitone f
-
-abbrev IsUE := IsUpwardEntailing
-abbrev IsDE := IsDownwardEntailing
+abbrev IsUE {α β : Type*} (f : Set α → Set β) := IsUpwardEntailing f
+abbrev IsDE {α β : Type*} (f : Set α → Set β) := IsDownwardEntailing f
 
 
 /-- Identity is UE. -/
@@ -76,25 +48,25 @@ theorem pnot_pnot_isUpwardEntailing : IsUpwardEntailing (pnot ∘ pnot) :=
 
 
 /-- UE ∘ UE = UE -/
-theorem ue_comp_ue {f g : Set World → Set World}
+theorem ue_comp_ue {α β γ : Type*} {f : Set β → Set γ} {g : Set α → Set β}
     (hf : IsUpwardEntailing f) (hg : IsUpwardEntailing g) :
     IsUpwardEntailing (f ∘ g) :=
   hf.comp hg
 
 /-- DE ∘ DE = UE (double negation). -/
-theorem de_comp_de {f g : Set World → Set World}
+theorem de_comp_de {α β γ : Type*} {f : Set β → Set γ} {g : Set α → Set β}
     (hf : IsDownwardEntailing f) (hg : IsDownwardEntailing g) :
     IsUpwardEntailing (f ∘ g) :=
   hf.comp hg
 
 /-- UE ∘ DE = DE -/
-theorem ue_comp_de {f g : Set World → Set World}
+theorem ue_comp_de {α β γ : Type*} {f : Set β → Set γ} {g : Set α → Set β}
     (hf : IsUpwardEntailing f) (hg : IsDownwardEntailing g) :
     IsDownwardEntailing (f ∘ g) :=
   hf.comp_antitone hg
 
 /-- DE ∘ UE = DE -/
-theorem de_comp_ue {f g : Set World → Set World}
+theorem de_comp_ue {α β γ : Type*} {f : Set β → Set γ} {g : Set α → Set β}
     (hf : IsDownwardEntailing f) (hg : IsUpwardEntailing g) :
     IsDownwardEntailing (f ∘ g) :=
   hf.comp_monotone hg

--- a/Linglib/Semantics/Entailment/StrawsonEntailment.lean
+++ b/Linglib/Semantics/Entailment/StrawsonEntailment.lean
@@ -554,12 +554,6 @@ theorem conditional_antecedent_antitone {W : Type*} (domain : W → Set W)
   intro α₁ α₂ hle w h w' hw'_mem hw'_α₁
   exact h w' hw'_mem (hle hw'_α₁)
 
-/-- Specialization of `conditional_antecedent_antitone` to the toy
-    `World` for use with the `IsDownwardEntailing` abbrev. -/
-theorem conditional_antecedent_DE (domain : World → Set World) (β : Set World) :
-    IsDownwardEntailing (fun α => condNecessity domain α β) :=
-  conditional_antecedent_antitone domain β
-
 /-- Conditional antecedents are *a fortiori* Strawson-DE. -/
 theorem conditional_antecedent_strawsonDE {W : Type*} (domain : W → Set W)
     (β : Set W) (defined : Set W → W → Prop) :
@@ -624,7 +618,8 @@ theorem atMost2_isStrawsonDE (defined : Set World → World → Prop) :
 /-- Strawson-DE is *strictly* weaker than DE: `onlyFull` is the canonical
     witness — Strawson-DE without classical DE. -/
 theorem strawsonDE_strictly_weaker_than_DE :
-    ∃ f defined, IsStrawsonDE f defined ∧ ¬ IsDownwardEntailing f :=
+    ∃ (f : Set World → Set World) (defined : Set World → World → Prop),
+      IsStrawsonDE f defined ∧ ¬ IsDownwardEntailing f :=
   ⟨onlyFull (· = World.w0),
    fun scope _w => ∃ w', (w' = World.w0) ∧ scope w',
    onlyFull_isStrawsonDE _,

--- a/Linglib/Semantics/Exhaustification/FreeChoice.lean
+++ b/Linglib/Semantics/Exhaustification/FreeChoice.lean
@@ -273,11 +273,10 @@ In a DE context, widening the domain of an indefinite *strengthens*
 the overall claim: C(∃x∈D', Px) ⊆ C(∃x∈D, Px) when D ⊆ D'.
 
 This is why NPIs are licensed in DE contexts: widening is informative. -/
-theorem widening_strengthens_in_de (C : Ctx World)
-    (hDE : ∀ (p q : Set World), (p ⊆ q) → (C q ⊆ C p))
+theorem widening_strengthens_in_de (C : Ctx World) (hDE : Antitone C)
     (D D' : Set Entity) (P : Entity → Set World) (h : D ⊆ D') :
     C (existsInDomain D' P) ⊆ C (existsInDomain D P) :=
-  hDE _ _ (wider_domain_weaker_existential D D' P h)
+  hDE (wider_domain_weaker_existential D D' P h)
 
 /-- **Theorem 3b (Widening weakens in UE).**
 
@@ -286,11 +285,10 @@ C(∃x∈D, Px) ⊆ C(∃x∈D', Px) when D ⊆ D'.
 
 This is why NPIs are *not* licensed in UE contexts: widening is
 uninformative (violates Maximize Strength). -/
-theorem widening_weakens_in_ue (C : Ctx World)
-    (hUE : ∀ (p q : Set World), (p ⊆ q) → (C p ⊆ C q))
+theorem widening_weakens_in_ue (C : Ctx World) (hUE : Monotone C)
     (D D' : Set Entity) (P : Entity → Set World) (h : D ⊆ D') :
     C (existsInDomain D P) ⊆ C (existsInDomain D' P) :=
-  hUE _ _ (wider_domain_weaker_existential D D' P h)
+  hUE (wider_domain_weaker_existential D D' P h)
 
 end DomainWidening
 

--- a/Linglib/Studies/KadmonLandman1993.lean
+++ b/Linglib/Studies/KadmonLandman1993.lean
@@ -49,7 +49,7 @@ open Semantics.Entailment.Polarity
 open Semantics.Entailment (World)
 open Semantics.Entailment.StrawsonEntailment
   (IsStrawsonDE sorryFull gladFull sorryFull_isStrawsonDE sorryFull_not_de
-   gladFull_isUE condNecessity conditional_antecedent_DE)
+   gladFull_isUE condNecessity conditional_antecedent_antitone)
 open Exhaustification.FreeChoice (Ctx existsInDomain
   widening_strengthens_in_de widening_weakens_in_ue)
 open Ladusaw1979 (licensingStrength)
@@ -76,7 +76,7 @@ reverses entailment. -/
 theorem de_satisfies_strengthening {World Entity : Type*} {C : Ctx World}
     (hDE : Antitone C) (D D' : Set Entity) (P : Entity → Set World)
     (hD : D ⊆ D') : Strengthening C D D' P :=
-  widening_strengthens_in_de C (λ _ _ h => hDE h) D D' P hD
+  widening_strengthens_in_de C hDE D D' P hD
 
 /-- In a UE (monotone) context, widening *weakens* — the opposite of
 strengthening. This is K&L's explanation for why *any* is out in plain
@@ -84,7 +84,7 @@ positive contexts. -/
 theorem ue_widening_weakens {World Entity : Type*} {C : Ctx World}
     (hUE : Monotone C) (D D' : Set Entity) (P : Entity → Set World)
     (hD : D ⊆ D') : C (existsInDomain D P) ⊆ C (existsInDomain D' P) :=
-  widening_weakens_in_ue C (λ _ _ h => hUE h) D D' P hD
+  widening_weakens_in_ue C hUE D D' P hD
 
 /-! ### Licensing contexts and entailment signatures
 
@@ -219,10 +219,10 @@ widening the antecedent domain strengthens the conditional. -/
 DE in its antecedent with the modal base held constant. K&L (143): "If John
 subscribes to any newspaper, he gets well informed" — widening *newspaper* to
 include unimportant newspapers strengthens the conditional. -/
-theorem conditional_satisfies_strengthening
-    (domain : World → Set World) (β : Set World) :
+theorem conditional_satisfies_strengthening {W : Type*}
+    (domain : W → Set W) (β : Set W) :
     IsDownwardEntailing (λ α => condNecessity domain α β) :=
-  conditional_antecedent_DE domain β
+  conditional_antecedent_antitone domain β
 
 /-- A conditional with an implicit restriction (K&L's (147)): true iff every
 relevant case satisfying the restriction and the antecedent satisfies the

--- a/Linglib/Studies/KadmonLandman1993.lean
+++ b/Linglib/Studies/KadmonLandman1993.lean
@@ -4,6 +4,7 @@ import Linglib.Typology.PolarityItem
 import Linglib.Semantics.Entailment.Polarity
 import Linglib.Semantics.Entailment.StrawsonEntailment
 import Linglib.Semantics.Exhaustification.FreeChoice
+import Linglib.Semantics.Supervaluation.Basic
 import Linglib.Studies.Ladusaw1979
 import Mathlib.Data.Set.Basic
 
@@ -37,7 +38,9 @@ not sufficient: *each* and comparative *more often than* are DE yet resist
 - `VagueRestriction`, `widenAlong`, `dimensionallyUniversal`: the
   domain-vagueness apparatus behind FC *any* and the *almost* test (K&L §4);
 - `domain_vague_allows_exceptions`: exception tolerance of generics from
-  domain vagueness.
+  domain vagueness;
+- `VagueRestriction.toSpecSpace`: the finite-case bridge to [fine-1975]'s
+  supervaluation — K&L's exception-tolerance zone is Fine's borderline zone.
 -/
 
 namespace KadmonLandman1993
@@ -53,6 +56,9 @@ open Semantics.Entailment.StrawsonEntailment
 open Exhaustification.FreeChoice (Ctx existsInDomain
   widening_strengthens_in_de widening_weakens_in_ue)
 open Ladusaw1979 (licensingStrength)
+open Semantics.Supervaluation (SpecSpace superTrue superTrue_true_iff
+  superTrue_indet_iff)
+open Core.Duality (Truth3)
 
 /-! ### The strengthening condition
 
@@ -360,9 +366,10 @@ K&L §4.1: *every owl* is **domain precise** — context determines a unique
 domain — while generic *an owl* is **domain vague**: the normalcy restriction
 is inherently underspecified, and different precisifications yield different
 domains. This is what lets generics tolerate exceptions ("a poodle gives live
-birth" survives male poodles). Cf. the supervaluation substrate
-(`Semantics/Supervaluation`, [fine-1975]); `SpecSpace` there is
-`Finset`-based, so the `Set`-based notions are stated locally. -/
+birth" survives male poodles). The `Set`-based notions are stated locally
+because the supervaluation substrate (`Semantics/Supervaluation`,
+[fine-1975]) is `Finset`-based for computability; the finite-case bridge is
+`VagueRestriction.toSpecSpace` below. -/
 
 /-- A vague restriction ⟨v₀, V⟩ (K&L §4.1): a precise part (properties known
 to hold) together with its consistent completions, each extending the precise
@@ -540,6 +547,68 @@ theorem domain_vagueness_explains_gen_exceptions {Property Entity : Type*}
   by_cases h : domainOf vg apply = domainOf v₁ apply
   · exact ⟨vg, hvgm, v₂, hv₂m, by rw [h]; exact hne, hvgt⟩
   · exact ⟨vg, hvgm, v₁, hv₁m, h, hvgt⟩
+
+/-! ### Grounding in Fine 1975 supervaluation
+
+When the precisification set is finite, K&L's truth notions are
+[fine-1975]'s: `genericSuperTrue` is super-truth on the induced
+specification space, and the exception-tolerance zone — sub-true but not
+super-true — is exactly Fine's borderline (`indet`) status. "A poodle gives
+live birth" is Fine-indefinite and K&L-assertable. -/
+
+/-- The specification space induced by a vague restriction whose
+precisifications are enumerated by a finset. Nonemptiness is K&L's axiom
+that the precise part is itself a precisification. -/
+def VagueRestriction.toSpecSpace {Property : Type*} (X : VagueRestriction Property)
+    (V : Finset (Set Property)) (hV : ↑V = X.precisifications) :
+    SpecSpace (Set Property) where
+  admissible := V
+  nonempty := ⟨X.precise, by rw [← Finset.mem_coe, hV]; exact X.precise_mem⟩
+
+theorem VagueRestriction.mem_toSpecSpace {Property : Type*}
+    {X : VagueRestriction Property} {V : Finset (Set Property)}
+    {hV : ↑V = X.precisifications} {v : Set Property} :
+    v ∈ (X.toSpecSpace V hV).admissible ↔ v ∈ X.precisifications := by
+  constructor
+  · intro h; rw [← hV]; exact Finset.mem_coe.mpr h
+  · intro h
+    show v ∈ V
+    rw [← Finset.mem_coe, hV]
+    exact h
+
+/-- On a finite precisification space, K&L's supervaluationist truth is
+[fine-1975]'s super-truth. -/
+theorem genericSuperTrue_iff_superTrue {Property Entity : Type*}
+    (X : VagueRestriction Property) (apply : Property → Set Entity)
+    (scope : Entity → Prop) [DecidablePred (genericTrue apply scope)]
+    (V : Finset (Set Property)) (hV : ↑V = X.precisifications) :
+    genericSuperTrue X apply scope ↔
+      superTrue (genericTrue apply scope) (X.toSpecSpace V hV) = Truth3.true := by
+  rw [superTrue_true_iff]
+  exact ⟨λ h v hv => h v (VagueRestriction.mem_toSpecSpace.mp hv),
+         λ h v hv => h v (VagueRestriction.mem_toSpecSpace.mpr hv)⟩
+
+/-- **K&L's exception-tolerance zone is Fine's borderline zone.** A generic
+that is subvaluationistically but not supervaluationistically true is
+exactly one whose supervaluation status is indefinite: assertable for K&L,
+borderline for [fine-1975]. -/
+theorem genericSubTrue_not_superTrue_iff_indet {Property Entity : Type*}
+    (X : VagueRestriction Property) (apply : Property → Set Entity)
+    (scope : Entity → Prop) [DecidablePred (genericTrue apply scope)]
+    (V : Finset (Set Property)) (hV : ↑V = X.precisifications) :
+    genericSubTrue X apply scope ∧ ¬genericSuperTrue X apply scope ↔
+      superTrue (genericTrue apply scope) (X.toSpecSpace V hV) = Truth3.indet := by
+  rw [superTrue_indet_iff]
+  constructor
+  · rintro ⟨⟨v, hv, hvt⟩, hns⟩
+    refine ⟨⟨v, VagueRestriction.mem_toSpecSpace.mpr hv, hvt⟩, ?_⟩
+    by_contra hno
+    exact hns (λ w hw => by
+      by_contra hwf
+      exact hno ⟨w, VagueRestriction.mem_toSpecSpace.mpr hw, hwf⟩)
+  · rintro ⟨⟨v, hv, hvt⟩, ⟨w, hw, hwf⟩⟩
+    exact ⟨⟨v, VagueRestriction.mem_toSpecSpace.mp hv, hvt⟩,
+           λ hall => hwf (hall w (VagueRestriction.mem_toSpecSpace.mp hw))⟩
 
 /-! ### The *almost* test
 

--- a/Linglib/Studies/VonFintel1999.lean
+++ b/Linglib/Studies/VonFintel1999.lean
@@ -354,7 +354,7 @@ in the substrate.
 theorem ex72_conditional_antecedent_DE
     (domain : World → Set World) (β : Set World) :
     IsDownwardEntailing (fun α => condNecessity domain α β) :=
-  conditional_antecedent_DE domain β
+  conditional_antecedent_antitone domain β
 
 /-- Restrictor-style conditional antecedents are *a fortiori* Strawson-DE
     (since classical DE implies Strawson-DE via `de_implies_strawsonDE`). -/


### PR DESCRIPTION
Follow-ups deferred from #306.

- generalize `IsUpwardEntailing`/`IsDownwardEntailing` and the composition lemmas from the toy `World` to `Set α → Set β`; state the FreeChoice widening lemmas with `Antitone`/`Monotone` hypotheses; drop the redundant `conditional_antecedent_DE` toy shim
- `VagueRestriction.toSpecSpace` + bridge theorems: on a finite precisification space, `genericSuperTrue` is [fine-1975] super-truth, and K&L's exception-tolerance zone (sub-true, not super-true) is Fine's borderline `indet` status. `SpecSpace` stays `Finset`-based: Kriz2016/Cobreros et al. depend on its decidability, so a `Set` generalization would fork the API for one consumer