### PR TITLE
refactor(Semantics/Entailment): lattice-general property family

### DIFF
--- a/Linglib/Semantics/Entailment/AntiAdditivity.lean
+++ b/Linglib/Semantics/Entailment/AntiAdditivity.lean
@@ -1,8 +1,3 @@
-/-
-The DE < Anti-Additive < Anti-Morphic hierarchy.
-Reference: [chierchia-2013] section 1.4.3, [ladusaw-1980].
--/
-
 import Mathlib.Order.Monotone.Defs
 import Mathlib.Order.Hom.BoundedLattice
 import Mathlib.Order.Heyting.Hom
@@ -13,6 +8,33 @@ import Linglib.Core.Logic.NaturalLogic
 import Linglib.Semantics.Entailment.Basic
 import Linglib.Semantics.Entailment.Polarity
 
+/-!
+# The DE < anti-additive < anti-morphic hierarchy
+
+[icard-2012]'s function classes (his Definition 1.7, after [hoeksema-1983]
+and Zwarts; cf. [chierchia-2013] §1.4.3, [ladusaw-1980]): additive,
+multiplicative, anti-additive, and anti-multiplicative functions, stated in
+equational form over semilattices and instantiated at context functions
+(`Set W → Set W'`) and generalized quantifiers (`Set E → Prop`). Following
+Icard, the plain properties are the binary equations; the `IsCompletely*`
+refinements add his unit conditions (adopted for non-trivial linguistic
+domains, his §1.1).
+
+## Main declarations
+
+- `IsAdditive`, `IsMultiplicative`, `IsAntiAdditive`, `IsAntiMultiplicative`:
+  the four classes, with `Monotone`/`Antitone` consequence lemmas;
+- `IsAntiMorphic`: anti-additive and anti-multiplicative (Zwarts's class for
+  superstrong NPIs);
+- `IsCompletely*`: Icard's "completely P" refinements (unit conditions);
+- `isAntiAdditive_iff_mem`, `isAntiAdditive_iff_gq`: pointwise bridges for
+  the `Set`- and GQ-typed instances;
+- `licensesWeakNPI`, `licensesStrongNPI`, `licensesSuperstrongNPI`: the
+  Zwarts licensing thresholds ([icard-2012] §4);
+- toy-`World` witnesses: `pnot` (anti-morphic), `no_student` (anti-additive),
+  `atMost1_student` (DE but not anti-additive — the strictness witness).
+-/
+
 namespace Semantics.Entailment.AntiAdditivity
 
 open Core.NaturalLogic (DEStrength UEStrength strengthSufficient)
@@ -20,73 +42,187 @@ open Semantics.Entailment
 open Semantics.Entailment.Polarity
 open List (Sublist)
 
+/-! ### The property family ([icard-2012] Definition 1.7) -/
 
-section Definitions
+section PropertyFamily
 
 variable {α β : Type*}
 
-/-- Anti-additive: `f(A ∪ B) = f(A) ∩ f(B)` (pointwise iff form).
+/-- Additive: `f (p ⊔ q) = f p ⊔ f q`. -/
+def IsAdditive [SemilatticeSup α] [SemilatticeSup β] (f : α → β) : Prop :=
+  ∀ p q, f (p ⊔ q) = f p ⊔ f q
 
-Polymorphic in domain and codomain — this is needed e.g. for
-[hoeksema-1983]'s S-comparative, which is anti-additive as a
-function `Set Degree → Set Individual`. -/
-def IsAntiAdditive (f : Set α → Set β) : Prop :=
-  ∀ p q : Set α, ∀ x, f (p ∪ q) x ↔ f p x ∧ f q x
+/-- Multiplicative: `f (p ⊓ q) = f p ⊓ f q`. -/
+def IsMultiplicative [SemilatticeInf α] [SemilatticeInf β] (f : α → β) : Prop :=
+  ∀ p q, f (p ⊓ q) = f p ⊓ f q
 
-/-- Anti-morphic (AM): Anti-additive + distributes ∩ to ∪. -/
-def IsAntiMorphic (f : Set α → Set β) : Prop :=
-  IsAntiAdditive f ∧
-  (∀ p q : Set α, ∀ x, f (p ∩ q) x ↔ f p x ∨ f q x)
+/-- Anti-additive: `f (p ⊔ q) = f p ⊓ f q`. Polymorphic in domain and
+codomain — needed e.g. for [hoeksema-1983]'s S-comparative, anti-additive as
+a function `Set Degree → Set Individual`. -/
+def IsAntiAdditive [SemilatticeSup α] [SemilatticeInf β] (f : α → β) : Prop :=
+  ∀ p q, f (p ⊔ q) = f p ⊓ f q
 
+/-- Anti-multiplicative: `f (p ⊓ q) = f p ⊔ f q`. -/
+def IsAntiMultiplicative [SemilatticeInf α] [SemilatticeSup β] (f : α → β) : Prop :=
+  ∀ p q, f (p ⊓ q) = f p ⊔ f q
 
-/-- Anti-additive implies antitone ([hoeksema-1983] Fact 4: the
-    polarity-environment classification of anti-additive operators as
-    downward-entailing). Codomain need not be `Set World`. -/
-theorem IsAntiAdditive.antitone {f : Set α → Set β} (hAA : IsAntiAdditive f) :
-    Antitone f := by
-  intro p q hpq x hfq
-  have hu : p ∪ q = q := Set.union_eq_right.mpr hpq
-  have := (hAA p q x).mp (by rw [hu]; exact hfq)
-  exact this.1
+/-- Anti-morphic: anti-additive and anti-multiplicative — Zwarts's class of
+sentential negation, the superstrong-NPI licensors. -/
+def IsAntiMorphic [Lattice α] [Lattice β] (f : α → β) : Prop :=
+  IsAntiAdditive f ∧ IsAntiMultiplicative f
+
+/-! ### Completely-variants ([icard-2012] Definition 1.7)
+
+Icard: "by P we mean completely P" for linguistic application — the unit
+conditions amount to assuming non-trivial domains. -/
+
+/-- Completely additive: additive and `f ⊤ = ⊤`. -/
+def IsCompletelyAdditive [SemilatticeSup α] [OrderTop α]
+    [SemilatticeSup β] [OrderTop β] (f : α → β) : Prop :=
+  IsAdditive f ∧ f ⊤ = ⊤
+
+/-- Completely multiplicative: multiplicative and `f ⊥ = ⊥`. -/
+def IsCompletelyMultiplicative [SemilatticeInf α] [OrderBot α]
+    [SemilatticeInf β] [OrderBot β] (f : α → β) : Prop :=
+  IsMultiplicative f ∧ f ⊥ = ⊥
+
+/-- Completely anti-additive: anti-additive and `f ⊤ = ⊥`. -/
+def IsCompletelyAntiAdditive [SemilatticeSup α] [OrderTop α]
+    [SemilatticeInf β] [OrderBot β] (f : α → β) : Prop :=
+  IsAntiAdditive f ∧ f ⊤ = ⊥
+
+/-- Completely anti-multiplicative: anti-multiplicative and `f ⊥ = ⊤`. -/
+def IsCompletelyAntiMultiplicative [SemilatticeInf α] [OrderBot α]
+    [SemilatticeSup β] [OrderTop β] (f : α → β) : Prop :=
+  IsAntiMultiplicative f ∧ f ⊥ = ⊤
+
+/-! ### Monotonicity consequences
+
+Each class refines monotonicity or antitonicity ([icard-2012] Def. 1.7's
+closing remark). -/
+
+/-- Additive implies monotone. -/
+theorem IsAdditive.monotone [SemilatticeSup α] [SemilatticeSup β]
+    {f : α → β} (h : IsAdditive f) : Monotone f := by
+  intro p q hpq
+  calc f p ≤ f p ⊔ f q := le_sup_left
+    _ = f (p ⊔ q) := (h p q).symm
+    _ = f q := by rw [sup_eq_right.mpr hpq]
+
+/-- Multiplicative implies monotone. -/
+theorem IsMultiplicative.monotone [SemilatticeInf α] [SemilatticeInf β]
+    {f : α → β} (h : IsMultiplicative f) : Monotone f := by
+  intro p q hpq
+  calc f p = f (p ⊓ q) := by rw [inf_eq_left.mpr hpq]
+    _ = f p ⊓ f q := h p q
+    _ ≤ f q := inf_le_right
+
+/-- Anti-additive implies antitone ([hoeksema-1983] Fact 4). -/
+theorem IsAntiAdditive.antitone [SemilatticeSup α] [SemilatticeInf β]
+    {f : α → β} (h : IsAntiAdditive f) : Antitone f := by
+  intro p q hpq
+  calc f q = f (p ⊔ q) := by rw [sup_eq_right.mpr hpq]
+    _ = f p ⊓ f q := h p q
+    _ ≤ f p := inf_le_left
+
+/-- Anti-multiplicative implies antitone. -/
+theorem IsAntiMultiplicative.antitone [SemilatticeInf α] [SemilatticeSup β]
+    {f : α → β} (h : IsAntiMultiplicative f) : Antitone f := by
+  intro p q hpq
+  calc f q ≤ f p ⊔ f q := le_sup_right
+    _ = f (p ⊓ q) := (h p q).symm
+    _ = f p := by rw [inf_eq_left.mpr hpq]
 
 /-- Anti-morphic implies anti-additive. -/
-theorem IsAntiMorphic.antiAdditive {f : Set α → Set β} (hAM : IsAntiMorphic f) :
-    IsAntiAdditive f := hAM.1
+theorem IsAntiMorphic.antiAdditive [Lattice α] [Lattice β]
+    {f : α → β} (h : IsAntiMorphic f) : IsAntiAdditive f := h.1
+
+/-- Anti-morphic implies anti-multiplicative. -/
+theorem IsAntiMorphic.antiMultiplicative [Lattice α] [Lattice β]
+    {f : α → β} (h : IsAntiMorphic f) : IsAntiMultiplicative f := h.2
 
 /-- Anti-morphic implies antitone. -/
-theorem IsAntiMorphic.antitone {f : Set α → Set β} (hAM : IsAntiMorphic f) :
-    Antitone f := hAM.antiAdditive.antitone
+theorem IsAntiMorphic.antitone [Lattice α] [Lattice β]
+    {f : α → β} (h : IsAntiMorphic f) : Antitone f :=
+  h.1.antitone
 
+end PropertyFamily
 
-/-- Any function of the form `fun X y => ∀ x ∈ X, P x y` is anti-additive in `X`.
+/-! ### Pointwise bridges
 
-    `npComparative` and `sComparative` ([hoeksema-1983]) instantiate this
-    with `P x y := μ x < μ y` and `P d y := d < μ y` respectively. -/
-theorem isAntiAdditive_forall_mem (P : α → β → Prop) :
+The equational properties at the `Set` and GQ instances, in the membership
+forms consumers destructure. -/
+
+section Bridges
+
+variable {γ δ : Type*}
+
+theorem isAntiAdditive_iff_mem {f : Set γ → Set δ} :
+    IsAntiAdditive f ↔ ∀ p q x, x ∈ f (p ∪ q) ↔ x ∈ f p ∧ x ∈ f q := by
+  constructor
+  · intro h p q x
+    have hpq : f (p ∪ q) = f p ∩ f q := h p q
+    rw [hpq]
+    exact Set.mem_inter_iff x (f p) (f q)
+  · intro h p q
+    show f (p ∪ q) = f p ∩ f q
+    ext x
+    exact (h p q x).trans (Set.mem_inter_iff x (f p) (f q)).symm
+
+theorem isAntiMultiplicative_iff_mem {f : Set γ → Set δ} :
+    IsAntiMultiplicative f ↔ ∀ p q x, x ∈ f (p ∩ q) ↔ x ∈ f p ∨ x ∈ f q := by
+  constructor
+  · intro h p q x
+    have hpq : f (p ∩ q) = f p ∪ f q := h p q
+    rw [hpq]
+    exact Set.mem_union x (f p) (f q)
+  · intro h p q
+    show f (p ∩ q) = f p ∪ f q
+    ext x
+    exact (h p q x).trans (Set.mem_union x (f p) (f q)).symm
+
+/-- The GQ-typed instance (`f : Set γ → Prop`, `Prop` as a complete
+lattice): anti-additivity is the familiar `f (p ∪ q) ↔ f p ∧ f q`. -/
+theorem isAntiAdditive_iff_gq {f : Set γ → Prop} :
+    IsAntiAdditive f ↔ ∀ p q, f (p ∪ q) ↔ f p ∧ f q := by
+  constructor
+  · intro h p q
+    have hpq : f (p ∪ q) = (f p ∧ f q) := h p q
+    exact iff_of_eq hpq
+  · intro h p q
+    show f (p ∪ q) = (f p ∧ f q)
+    exact propext (h p q)
+
+end Bridges
+
+/-! ### Toy-`World` witnesses and NPI licensing thresholds -/
+
+section ToyWitnesses
+
+/-- Any function of the form `fun X y => ∀ x ∈ X, P x y` is anti-additive in
+`X`. `npComparative` and `sComparative` ([hoeksema-1983]) instantiate this
+with `P x y := μ x < μ y` and `P d y := d < μ y` respectively. -/
+theorem isAntiAdditive_forall_mem {α β : Type*} (P : α → β → Prop) :
     IsAntiAdditive (fun (X : Set α) (y : β) => ∀ x ∈ X, P x y) := by
-  intro A B y
+  refine isAntiAdditive_iff_mem.mpr (fun A B y => ?_)
   refine ⟨fun h => ⟨fun x hx => h x (Or.inl hx), fun x hx => h x (Or.inr hx)⟩, ?_⟩
   rintro ⟨hA, hB⟩ x (hx | hx)
   · exact hA x hx
   · exact hB x hx
 
 /-- Negation is anti-additive. -/
-theorem pnot_isAntiAdditive : IsAntiAdditive pnot := by
-  intro p q w
-  show (p ∪ q)ᶜ w ↔ pᶜ w ∧ qᶜ w
-  rw [Set.compl_union]; rfl
+theorem pnot_isAntiAdditive : IsAntiAdditive pnot := fun p q => by
+  show (p ∪ q)ᶜ = pᶜ ∩ qᶜ
+  exact Set.compl_union p q
 
-/-- Negation satisfies the conjunction-to-disjunction property. -/
-theorem pnot_distributes_and :
-    ∀ p q : Set World, ∀ w, pnot (pand p q) w ↔ pnot p w ∨ pnot q w := by
-  intro p q w
-  show (p ∩ q)ᶜ w ↔ pᶜ w ∨ qᶜ w
-  rw [Set.compl_inter]; rfl
+/-- Negation is anti-multiplicative. -/
+theorem pnot_isAntiMultiplicative : IsAntiMultiplicative pnot := fun p q => by
+  show (p ∩ q)ᶜ = pᶜ ∪ qᶜ
+  exact Set.compl_inter p q
 
 /-- Negation is anti-morphic. -/
 theorem pnot_isAntiMorphic : IsAntiMorphic pnot :=
-  ⟨pnot_isAntiAdditive, pnot_distributes_and⟩
-
+  ⟨pnot_isAntiAdditive, pnot_isAntiMultiplicative⟩
 
 /-- "No A is B" = ∀x. A(x) → ¬B(x). -/
 def no' (restr : Set World) (scope : Set World) : Set World :=
@@ -97,7 +233,7 @@ def no_student : Set World → Set World := no' p01
 
 /-- "No" is anti-additive in scope. -/
 theorem no_isAntiAdditive_scope : IsAntiAdditive no_student := by
-  intro p q _w
+  refine isAntiAdditive_iff_mem.mpr (fun p q _w => ?_)
   show (∀ x ∈ allWorlds, ¬ (p01 x ∧ (p ∪ q) x)) ↔
        (∀ x ∈ allWorlds, ¬ (p01 x ∧ p x)) ∧
        (∀ x ∈ allWorlds, ¬ (p01 x ∧ q x))
@@ -114,7 +250,6 @@ theorem no_isAntiAdditive_scope : IsAntiAdditive no_student := by
 /-- "No" is DE in scope. -/
 theorem no_isDE_scope : IsDE no_student :=
   no_isAntiAdditive_scope.antitone
-
 
 /-- "At most n A's are B" - true if at most n worlds satisfy both.
     Uses an existential over a sublist witness so the def is decidable
@@ -152,13 +287,16 @@ theorem atMost1_isDE_scope : IsDE atMost1_student := by
   intro p q hpq _w h
   exact atMost_mono 1 p01 p q (fun _ hp => hpq hp) h
 
-/-- "At most n" is not anti-additive (counterexample). -/
+/-- "At most n" is not anti-additive (counterexample): the strictness
+witness for DE ⊊ anti-additive. -/
 theorem atMost_not_antiAdditive :
     ¬IsAntiAdditive atMost1_student := by
-  intro h
+  intro hAA
+  have h := isAntiAdditive_iff_mem.mp hAA
   let qProp : Set World := λ w => w = .w1
   have key : atMost1_student (por p0 qProp) .w0 ↔
-             atMost1_student p0 .w0 ∧ atMost1_student qProp .w0 := h _ _ _
+             atMost1_student p0 .w0 ∧ atMost1_student qProp .w0 :=
+    h p0 qProp World.w0
   -- p0 has just w0 as a witness; ≤ 1 ✓
   have hp : atMost1_student p0 .w0 := by
     intro ws hnd hall
@@ -207,87 +345,35 @@ theorem atMost_not_antiAdditive :
     simp at this
   exact hcontr (key.mpr ⟨hp, hq⟩)
 
-
-
 /-- Weak NPI licensing: requires DE. -/
 def licensesWeakNPI (f : Set World → Set World) : Prop := IsDownwardEntailing f
 
-/-- Strong NPI licensing: requires Anti-Additive. -/
+/-- Strong NPI licensing: requires anti-additivity. -/
 def licensesStrongNPI (f : Set World → Set World) : Prop := IsAntiAdditive f
+
+/-- Superstrong NPI licensing ([icard-2012] §4, after Zwarts): requires
+anti-morphicity — *a tad bit* under *not* but not under *no*. -/
+def licensesSuperstrongNPI (f : Set World → Set World) : Prop := IsAntiMorphic f
 
 example : licensesWeakNPI pnot := pnot_isDownwardEntailing
 example : licensesStrongNPI pnot := pnot_isAntiAdditive
+example : licensesSuperstrongNPI pnot := pnot_isAntiMorphic
 
 example : licensesWeakNPI no_student := no_isDE_scope
 example : licensesStrongNPI no_student := no_isAntiAdditive_scope
 
 example : licensesWeakNPI atMost2_student := atMost_isDE_scope
 
-
 /-!
-## `DEStrength` ↔ Proof Hierarchy
-[icard-2012]
+### `DEStrength` ↔ proof hierarchy ([icard-2012] §4)
 
-| `DEStrength` | Proof Predicate | Example Licensor |
+| `DEStrength` | Proof predicate | Example licensor |
 |--------------|-----------------|------------------|
 | `.weak` | `IsDE` | few, at most n |
 | `.antiAdditive` | `IsAntiAdditive` | no, nobody, without |
 | `.antiMorphic` | `IsAntiMorphic` | not, never |
 -/
 
-end Definitions
-
-
--- ============================================================================
--- Section: Upward Entailing Duals ([icard-2012])
--- ============================================================================
-
-section UEDuals
-
-variable {α β : Type*}
-
-/-- Additive: `f(A ∪ B) = f(A) ∪ f(B)` and `f(⊤) = ⊤`. -/
-def IsAdditive (f : Set α → Set β) : Prop :=
-  (∀ p q : Set α, ∀ x, f (p ∪ q) x ↔ f p x ∨ f q x) ∧
-  (∀ x, f Set.univ x)
-
-/-- Multiplicative: `f(A ∩ B) = f(A) ∩ f(B)` and `f(⊥) = ⊥`. -/
-def IsMultiplicative (f : Set α → Set β) : Prop :=
-  (∀ p q : Set α, ∀ x, f (p ∩ q) x ↔ f p x ∧ f q x) ∧
-  (∀ x, ¬ f ∅ x)
-
-/-- Anti-multiplicative: `f(A ∩ B) = f(A) ∪ f(B)` and `f(⊥) = ⊤`. -/
-def IsAntiMultiplicative (f : Set α → Set β) : Prop :=
-  (∀ p q : Set α, ∀ x, f (p ∩ q) x ↔ f p x ∨ f q x) ∧
-  (∀ x, f ∅ x)
-
-/-- Additive implies monotone. -/
-theorem IsAdditive.monotone {f : Set α → Set β} (hAdd : IsAdditive f) :
-    Monotone f := by
-  intro p q hpq x hfp
-  have hu : p ∪ q = q := Set.union_eq_right.mpr hpq
-  have h := (hAdd.1 p q x).mpr (Or.inl hfp)
-  rw [hu] at h
-  exact h
-
-/-- Multiplicative implies monotone. -/
-theorem IsMultiplicative.monotone {f : Set α → Set β} (hMult : IsMultiplicative f) :
-    Monotone f := by
-  intro p q hpq x hfp
-  have hi : p ∩ q = p := Set.inter_eq_left.mpr hpq
-  have hfpand : f (p ∩ q) x := by rw [hi]; exact hfp
-  exact ((hMult.1 p q x).mp hfpand).2
-
-/-- Anti-multiplicative implies antitone. -/
-theorem IsAntiMultiplicative.antitone {f : Set α → Set β} (hAM : IsAntiMultiplicative f) :
-    Antitone f := by
-  intro p q hpq x hfq
-  have hi : p ∩ q = p := Set.inter_eq_left.mpr hpq
-  have h := (hAM.1 p q x).mpr (Or.inr hfq)
-  rw [hi] at h
-  exact h
-
-end UEDuals
-
+end ToyWitnesses
 
 end Semantics.Entailment.AntiAdditivity

--- a/Linglib/Semantics/Entailment/Intolerance.lean
+++ b/Linglib/Semantics/Entailment/Intolerance.lean
@@ -15,6 +15,11 @@ to make Appendix 2's hierarchy `AA ⊆ DE + Intolerant ⊆ DE` work cleanly:
 the trivial case is included by stipulation so that the AA inclusion is
 not blocked by trivially-true functions.
 
+Anti-additivity and DE-ness of GQ-typed functions are the
+`Set α → Prop` instances of the lattice-general
+`Semantics.Entailment.AntiAdditivity.IsAntiAdditive` and mathlib's
+`Antitone` (`Prop` is a complete lattice).
+
 ## Examples
 
 - `no` is Intolerant: `#Few of my friends are linguists and few of them
@@ -33,6 +38,8 @@ function that is DE + Intolerant but not AA.
 
 namespace Semantics.Entailment.Intolerance
 
+open Semantics.Entailment.AntiAdditivity (IsAntiAdditive isAntiAdditive_iff_gq)
+
 /-- A GQ-typed function is **trivial** if it is constantly true or
     constantly false. -/
 def IsTrivial {α : Type*} (f : Set α → Prop) : Prop :=
@@ -48,46 +55,21 @@ def IsTrivial {α : Type*} (f : Set α → Prop) : Prop :=
 def IsIntolerant {α : Type*} (f : Set α → Prop) : Prop :=
   IsTrivial f ∨ ∀ x : Set α, ¬ f x ∨ ¬ f xᶜ
 
-/-- A GQ-typed AA function (`f : Set α → Prop` with `f (p ∪ q) ↔ f p ∧ f q`). -/
-def IsAntiAdditiveGQ {α : Type*} (f : Set α → Prop) : Prop :=
-  ∀ p q : Set α, f (p ∪ q) ↔ f p ∧ f q
-
-/-- A GQ-typed DE function. -/
-def IsDownwardEntailingGQ {α : Type*} (f : Set α → Prop) : Prop :=
-  ∀ p q : Set α, p ⊆ q → f q → f p
-
-/-- AA-GQ implies DE-GQ. Standard. -/
-theorem isAntiAdditiveGQ_implies_isDEGQ {α : Type*} (f : Set α → Prop)
-    (hAA : IsAntiAdditiveGQ f) : IsDownwardEntailingGQ f := by
-  intro p q hpq hfq
-  -- Show f p from f q via p ⊆ q ⇒ q = p ∪ q ⇒ f q ↔ f p ∧ f q ⇒ f p
-  have hUnion : p ∪ q = q := by
-    ext x; constructor
-    · rintro (h | h)
-      · exact hpq h
-      · exact h
-    · intro h; exact Or.inr h
-  have : f (p ∪ q) := by rw [hUnion]; exact hfq
-  exact ((hAA p q).mp this).1
-
-/-- [gajewski-2011] Appendix 2 (p. 143): AA implies Intolerant.
+/-- [gajewski-2011] Appendix 2 (p. 143): an anti-additive GQ is Intolerant.
 
     Proof sketch (Gajewski's): suppose `f` is AA and not trivial. For
     arbitrary `a`, suppose `f a = True` and `f aᶜ = True`. Then
     `f (a ∪ aᶜ) ↔ f a ∧ f aᶜ` gives `f Set.univ = True`. Since AA
     implies DE, every `y ⊆ Set.univ` has `f y = True` — contradicting
     non-triviality. So either `¬f a` or `¬f aᶜ`. -/
-theorem antiAdditiveGQ_implies_intolerant {α : Type*} (f : Set α → Prop)
-    (hAA : IsAntiAdditiveGQ f) : IsIntolerant f := by
-  -- Use classical reasoning on whether f is trivial
+theorem antiAdditive_implies_intolerant {α : Type*} (f : Set α → Prop)
+    (hAA : IsAntiAdditive f) : IsIntolerant f := by
   by_cases hTriv : IsTrivial f
-  · -- Trivial case: trivially Intolerant by Or.inl
-    exact Or.inl hTriv
-  · -- Non-trivial case: prove ∀ x, ¬f x ∨ ¬f xᶜ
-    refine Or.inr ?_
+  · exact Or.inl hTriv
+  · refine Or.inr ?_
     intro x
     by_contra hNeither
-    push_neg at hNeither
+    push Not at hNeither
     obtain ⟨hfx, hfxc⟩ := hNeither
     -- Now f x = True and f xᶜ = True. Show f Set.univ = True via AA.
     have hUnion : x ∪ xᶜ = Set.univ := by
@@ -96,14 +78,12 @@ theorem antiAdditiveGQ_implies_intolerant {α : Type*} (f : Set α → Prop)
       exact Classical.em (y ∈ x)
     have hfUniv : f Set.univ := by
       rw [← hUnion]
-      exact (hAA x xᶜ).mpr ⟨hfx, hfxc⟩
-    -- By DE (which AA implies), every y has f y
-    have hDE := isAntiAdditiveGQ_implies_isDEGQ f hAA
-    -- Contradicts non-triviality: ∃ y, ¬ f y (since f isn't constantly false:
-    -- f Set.univ holds; and not constantly true since not trivial)
+      exact (isAntiAdditive_iff_gq.mp hAA x xᶜ).mpr ⟨hfx, hfxc⟩
+    -- By DE (which AA implies), every y has f y — contradicting
+    -- non-triviality.
     apply hTriv
     left
     intro y
-    exact hDE y Set.univ (fun _ _ => trivial) hfUniv
+    exact hAA.antitone (Set.subset_univ y) hfUniv
 
 end Semantics.Entailment.Intolerance

--- a/Linglib/Semantics/Entailment/StrawsonEntailment.lean
+++ b/Linglib/Semantics/Entailment/StrawsonEntailment.lean
@@ -127,7 +127,7 @@ theorem antiAdditive_implies_strawsonAA {α β : Type*} (f : Set α → Set β)
     (hAA : IsAntiAdditive f) (defined : Set α → β → Prop) :
     IsStrawsonAntiAdditive f defined := by
   intro p q w _ _
-  exact hAA p q w
+  exact isAntiAdditive_iff_mem.mp hAA p q w
 
 /-- Strawson-AA ⇒ Strawson-DE.
 
@@ -566,7 +566,7 @@ theorem conditional_antecedent_strawsonDE {W : Type*} (domain : W → Set W)
     distributes appropriately. -/
 theorem condNecessity_isAntiAdditive {W : Type*} (domain : W → Set W) (β : Set W) :
     IsAntiAdditive (fun α => condNecessity domain α β) := by
-  intro p q w
+  refine isAntiAdditive_iff_mem.mpr (fun p q w => ?_)
   constructor
   · intro h
     exact ⟨fun w' hw' hp => h w' hw' (Or.inl hp),

--- a/Linglib/Studies/Gajewski2011.lean
+++ b/Linglib/Studies/Gajewski2011.lean
@@ -206,9 +206,10 @@ Intolerance comes from [horn-1989]: a function is intolerant if it
 does not map both `x` and `xᶜ` to truth — i.e., it "locates" itself on
 one side of the midpoint of its scale.
 
-The substrate-level definitions (`IsTrivial`, `IsIntolerant`,
-`IsAntiAdditiveGQ`, `IsDownwardEntailingGQ`) and the Appendix 2 proof
-(`antiAdditiveGQ_implies_intolerant`) live in
+The substrate-level definitions (`IsTrivial`, `IsIntolerant`; GQ-typed
+anti-additivity and DE-ness are the `Set α → Prop` instances of
+`IsAntiAdditive` and `Antitone`) and the Appendix 2 proof
+(`antiAdditive_implies_intolerant`) live in
 `Semantics/Entailment/Intolerance.lean`.
 
 The reverse strict inclusion (`AA ⊊ DE + Intolerant`, ex. 84) — i.e.
@@ -219,9 +220,9 @@ Gajewski but not proved; would need a witness function. Open.
 /-- Re-export the substrate Appendix 2 result for paper-citation indexing. -/
 theorem gaj2011_appendix2_AA_implies_intolerant {α : Type*}
     (f : Set α → Prop)
-    (hAA : Semantics.Entailment.Intolerance.IsAntiAdditiveGQ f) :
+    (hAA : Semantics.Entailment.AntiAdditivity.IsAntiAdditive f) :
     Semantics.Entailment.Intolerance.IsIntolerant f :=
-  Semantics.Entailment.Intolerance.antiAdditiveGQ_implies_intolerant f hAA
+  Semantics.Entailment.Intolerance.antiAdditive_implies_intolerant f hAA
 
 /-! ## §4.1 Conjecture (eq. 48): DE scalar item is AA iff endpoint of scale
 


### PR DESCRIPTION
Layer 1 of the polarity-API plan (scratch/polarity/api-spec.md). Definitions verified against the Icard 2012 PDF (Def. 1.7).

- restate `Is{Anti}Additive`/`Is{Anti}Multiplicative` in equational form over semilattices, instantiated at `Set W → Set W'` and `Set E → Prop`; plain binary equations as primitives, Icard's unit conditions as separate `IsCompletely*` refinements (fixes the prior inconsistency where three of four classes bundled units)
- delete the GQ-typed duplicates (`IsAntiAdditiveGQ`, `IsDownwardEntailingGQ`) — they are the `Prop`-lattice instances; `isAntiAdditive_iff_mem`/`_iff_gq` bridges recover the pointwise forms
- `IsAntiMorphic` := anti-additive ∧ anti-multiplicative; add `licensesSuperstrongNPI`