### PR TITLE
feat(Semantics/Entailment): Strawson-relativized soundness

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2399,6 +2399,7 @@ import Linglib.Semantics.Entailment.Basic
 import Linglib.Semantics.Entailment.Intolerance
 import Linglib.Semantics.Entailment.Soundness
 import Linglib.Semantics.Entailment.PositionProfile
+import Linglib.Semantics.Entailment.StrawsonSoundness
 import Linglib.Phenomena.Entailment.NegationTests
 import Linglib.Studies.Montague1973
 import Linglib.Semantics.Entailment.PresuppositionLicensing

--- a/Linglib/Semantics/Entailment/StrawsonSoundness.lean
+++ b/Linglib/Semantics/Entailment/StrawsonSoundness.lean
@@ -1,0 +1,196 @@
+import Linglib.Semantics.Entailment.Soundness
+import Linglib.Semantics.Entailment.StrawsonEntailment
+
+/-!
+# Strawson-relativized soundness
+
+[von-fintel-1999]'s Strawson move, at signature level: a projection row
+holds *modulo presuppositions* when the projected relation holds on the
+region where the arguments' presuppositions are satisfied.
+`NLRelation.HoldsOn D` relativizes the lattice content of a relation to a
+region `D`; `EntailmentSig.StrawsonSoundFor σ f defined` is `SoundFor`
+with every projected relation read on `defined x ⊓ defined y` — the
+symmetric definedness gate of [gajewski-2011]'s Strawson
+anti-additivity. Classical soundness is the trivial-definedness case
+(`strawsonSoundFor_top_iff`) and implies the Strawson form at any
+definedness (`EntailmentSig.SoundFor.strawsonSoundFor`).
+
+The operator instances are the semantic content of the
+`classicalSignature = none` rows of
+`Semantics.Polarity.Licensing.contextProperties`: `onlyFull`,
+`sorryFull`, `superlativeAssert`, and `sinceFull` realize the `.anti` row
+Strawson-ly while failing it classically.
+
+## Main declarations
+
+- `NLRelation.HoldsOn`: relation content relativized to a region;
+- `EntailmentSig.StrawsonSoundFor`: row soundness modulo presupposition;
+- `strawsonSoundFor_top_iff`, `EntailmentSig.SoundFor.strawsonSoundFor`:
+  the classical ↔ Strawson bridges;
+- `strawsonSoundFor_anti_of_isStrawsonDE` and the four operator instances.
+
+Composing definedness along a path is presupposition projection and is
+deliberately not attempted here — its home is a bridge to
+`Semantics/Presupposition/`, not an ad-hoc operator.
+-/
+
+namespace Core.NaturalLogic
+
+open Semantics.Entailment.StrawsonEntailment
+
+/-- The lattice content of a relation, relativized to a region `D` (the
+worlds where the relevant presuppositions are satisfied). At `D = ⊤` this
+is `NLRelation.Holds` (`holdsOn_top`). -/
+def NLRelation.HoldsOn {β : Type*} [Lattice β] [BoundedOrder β] (D : β) :
+    NLRelation → β → β → Prop
+  | .equiv => fun u v => u ⊓ D = v ⊓ D
+  | .forward => fun u v => u ⊓ D ≤ v
+  | .reverse => fun u v => v ⊓ D ≤ u
+  | .negation => fun u v => u ⊓ v ⊓ D = ⊥ ∧ D ≤ u ⊔ v
+  | .alternation => fun u v => u ⊓ v ⊓ D = ⊥
+  | .cover => fun u v => D ≤ u ⊔ v
+  | .independent => fun _ _ => True
+
+section HoldsOn
+
+variable {β : Type*} [Lattice β] [BoundedOrder β]
+
+/-- At trivial definedness, relativized content is plain content. -/
+theorem NLRelation.holdsOn_top {R : NLRelation} {u v : β} :
+    R.HoldsOn ⊤ u v ↔ R.Holds u v := by
+  cases R with
+  | equiv =>
+      show u ⊓ ⊤ = v ⊓ ⊤ ↔ u = v
+      rw [inf_top_eq, inf_top_eq]
+  | forward =>
+      show u ⊓ ⊤ ≤ v ↔ u ≤ v
+      rw [inf_top_eq]
+  | reverse =>
+      show v ⊓ ⊤ ≤ u ↔ v ≤ u
+      rw [inf_top_eq]
+  | negation =>
+      show (u ⊓ v ⊓ ⊤ = ⊥ ∧ ⊤ ≤ u ⊔ v) ↔ (u ⊓ v = ⊥ ∧ u ⊔ v = ⊤)
+      rw [inf_top_eq, top_le_iff]
+  | alternation =>
+      show u ⊓ v ⊓ ⊤ = ⊥ ↔ u ⊓ v = ⊥
+      rw [inf_top_eq]
+  | cover =>
+      show ⊤ ≤ u ⊔ v ↔ u ⊔ v = ⊤
+      exact top_le_iff
+  | independent => exact Iff.rfl
+
+/-- Plain content implies relativized content on any region. -/
+theorem NLRelation.Holds.holdsOn {R : NLRelation} {u v : β} (D : β)
+    (h : R.Holds u v) : R.HoldsOn D u v := by
+  cases R with
+  | equiv =>
+      have h' : u = v := h
+      subst h'
+      exact rfl
+  | forward => exact le_trans inf_le_left h
+  | reverse => exact le_trans inf_le_left h
+  | negation =>
+      obtain ⟨h1, h2⟩ := h
+      refine ⟨?_, ?_⟩
+      · show u ⊓ v ⊓ D = ⊥
+        rw [(h1 : u ⊓ v = ⊥), bot_inf_eq]
+      · exact le_trans le_top (le_of_eq h2.symm)
+  | alternation =>
+      show u ⊓ v ⊓ D = ⊥
+      rw [(h : u ⊓ v = ⊥), bot_inf_eq]
+  | cover => exact le_trans le_top (le_of_eq h.symm)
+  | independent => trivial
+
+end HoldsOn
+
+section StrawsonSoundFor
+
+variable {α β : Type*} [Lattice α] [BoundedOrder α] [Lattice β] [BoundedOrder β]
+
+/-- σ's row is **Strawson-sound** for `f` relative to `defined`: every
+projected relation holds on the region where both arguments'
+presuppositions are satisfied — the symmetric gate of [gajewski-2011]'s
+`IsStrawsonAntiAdditive`. -/
+def EntailmentSig.StrawsonSoundFor (σ : EntailmentSig) (f : α → β)
+    (defined : α → β) : Prop :=
+  ∀ (R : NLRelation) (x y : α), R.Holds x y →
+    (EntailmentSig.project R σ).HoldsOn (defined x ⊓ defined y) (f x) (f y)
+
+/-- Classical soundness implies Strawson soundness at any definedness. -/
+theorem EntailmentSig.SoundFor.strawsonSoundFor {σ : EntailmentSig}
+    {f : α → β} (h : σ.SoundFor f) (defined : α → β) :
+    σ.StrawsonSoundFor f defined :=
+  fun R x y hR => (h R x y hR).holdsOn _
+
+/-- Strawson soundness at trivial definedness is classical soundness. -/
+theorem strawsonSoundFor_top_iff {σ : EntailmentSig} {f : α → β} :
+    σ.StrawsonSoundFor f (fun _ => ⊤) ↔ σ.SoundFor f := by
+  constructor
+  · intro h R x y hR
+    have h2 : (EntailmentSig.project R σ).HoldsOn (⊤ : β) (f x) (f y) := by
+      simpa [inf_idem] using h R x y hR
+    exact NLRelation.holdsOn_top.mp h2
+  · intro h
+    exact h.strawsonSoundFor _
+
+end StrawsonSoundFor
+
+/-! ### The Strawson-DE operator zoo, at signature level -/
+
+section SetInstances
+
+variable {W W' : Type*}
+
+/-- [von-fintel-1999]'s Strawson-DE, at signature level: a Strawson-DE
+operator realizes the `.anti` row relative to its definedness. -/
+theorem strawsonSoundFor_anti_of_isStrawsonDE {f : Set W → Set W'}
+    {defined : Set W → W' → Prop} (h : IsStrawsonDE f defined) :
+    EntailmentSig.StrawsonSoundFor .anti f (fun p => {w | defined p w}) := by
+  intro R x y hR
+  cases R with
+  | equiv =>
+      have h' : x = y := hR
+      subst h'
+      exact rfl
+  | forward =>
+      rintro w ⟨hfy, hdx, _⟩
+      exact h x y hR w hdx hfy
+  | reverse =>
+      rintro w ⟨hfx, _, hdy⟩
+      exact h y x hR w hdy hfx
+  | negation | alternation | cover | independent => trivial
+
+/-- `only` realizes the `.anti` row Strawson-ly (definedness = its
+existence presupposition) while failing it classically
+(`onlyFull_not_de`). -/
+theorem onlyFull_strawsonSoundFor_anti (x : W → Prop) :
+    EntailmentSig.StrawsonSoundFor .anti (onlyFull x)
+      (fun scope => {w | ∃ w', x w' ∧ scope w'}) :=
+  strawsonSoundFor_anti_of_isStrawsonDE (onlyFull_isStrawsonDE x)
+
+/-- Adversatives (*sorry*, *regret*, *surprised*) realize the `.anti` row
+Strawson-ly (definedness = doxastic factivity) while failing it
+classically (`sorryFull_not_de`). -/
+theorem sorryFull_strawsonSoundFor_anti (dox bestOf : W → Set W) :
+    EntailmentSig.StrawsonSoundFor .anti (sorryFull dox bestOf)
+      (fun p => {w | ∀ w' ∈ dox w, p w'}) :=
+  strawsonSoundFor_anti_of_isStrawsonDE (sorryFull_isStrawsonDE dox bestOf)
+
+/-- Superlatives realize the `.anti` row Strawson-ly in their restriction
+(definedness = the designated-subject presupposition). -/
+theorem superlativeAssert_strawsonSoundFor_anti (a : W) :
+    EntailmentSig.StrawsonSoundFor .anti (superlativeAssert a)
+      (fun restriction => {w | superlativePresup a restriction w}) :=
+  strawsonSoundFor_anti_of_isStrawsonDE (superlative_isStrawsonDE a)
+
+/-- Temporal *since* realizes the `.anti` row Strawson-ly (definedness =
+the past-event presupposition). -/
+theorem sinceFull_strawsonSoundFor_anti (pastEvent sinceWindow : W → Set W) :
+    EntailmentSig.StrawsonSoundFor .anti (sinceFull pastEvent sinceWindow)
+      (fun p => {w | ∃ w' ∈ pastEvent w, p w'}) :=
+  strawsonSoundFor_anti_of_isStrawsonDE
+    (sinceFull_isStrawsonDE pastEvent sinceWindow)
+
+end SetInstances
+
+end Core.NaturalLogic

--- a/Linglib/Semantics/Polarity/Licensing.lean
+++ b/Linglib/Semantics/Polarity/Licensing.lean
@@ -115,27 +115,25 @@ inductive LicensingMechanism where
     `KadmonLandman1993.klExplanation`) are derivations from `contextProperties`,
     not parallel stipulations. -/
 structure ContextProperties where
-  /-- Icard signature: locates the context in the natural-logic lattice. -/
-  signature : Core.NaturalLogic.EntailmentSig
+  /-- Icard signature modulo presuppositions ([von-fintel-1999]'s
+      Strawson reading): the row a Strawson-relativized soundness
+      statement (`EntailmentSig.StrawsonSoundFor`) realizes. Coincides
+      with the classical row for presupposition-free contexts. -/
+  strawsonSignature : Core.NaturalLogic.EntailmentSig
   /-- K&L mechanism: how this context licenses NPIs. -/
   mechanism : LicensingMechanism
   /-- A canonical English example. -/
   prototype : String
   /-- BibTeX keys for the works that established this classification. -/
   citations : List String
-  /-- Strawson-DE flag ([von-fintel-1999]): when `true`, the
-      `signature` field over-promises classical DE — the context is in
-      fact only DE under presupposition (Strawson-DE), not classically.
-      Default `false` (the signature stands as a classical claim).
-
-      Examples requiring this flag: `.onlyFocus`, `.adversative`,
-      `.sinceTemporal` — classical-DE-on-paper but shown by
-      [von-fintel-1999] to be only Strawson-DE. The
-      `byStrawsonDE` mechanism case is for items whose licensing
-      *primarily* comes from Strawson-DE (e.g., superlative);
-      `isStrawsonOnly` is for cases where the signature *also* needs
-      qualification. -/
-  isStrawsonOnly : Bool := false
+  /-- Classical (presupposition-free) signature row, when one holds.
+      `none` for the contexts [von-fintel-1999] showed to be only
+      Strawson-DE — only-focus, adversatives, temporal *since*,
+      superlatives: no `EntailmentSig` row is classically sound for
+      them. Defaults to the Strawson row (the presupposition-free
+      case). -/
+  classicalSignature : Option Core.NaturalLogic.EntailmentSig :=
+    some strawsonSignature
   deriving Repr
 
 /-- Canonical map from licensing contexts to their theoretical properties.
@@ -147,48 +145,48 @@ structure ContextProperties where
     to a specific source. -/
 def contextProperties : LicensingContext → ContextProperties
   | .negation =>
-      { signature := .antiAddMult, mechanism := .byStrengthening
+      { strawsonSignature := .antiAddMult, mechanism := .byStrengthening
       , prototype := "Mary didn't see anyone."
       , citations := ["ladusaw-1979", "kadmon-landman-1993", "zwarts-1998"] }
   | .nobody =>
-      { signature := .antiAdd, mechanism := .byStrengthening
+      { strawsonSignature := .antiAdd, mechanism := .byStrengthening
       , prototype := "Nobody saw anyone."
       , citations := ["ladusaw-1979", "zwarts-1998"] }
   | .withoutClause =>
-      { signature := .antiAdd, mechanism := .byStrengthening
+      { strawsonSignature := .antiAdd, mechanism := .byStrengthening
       , prototype := "She left without saying anything."
       , citations := ["ladusaw-1979", "zwarts-1998"] }
   | .denyVerb =>
-      { signature := .antiAdd, mechanism := .byStrengthening
+      { strawsonSignature := .antiAdd, mechanism := .byStrengthening
       , prototype := "She denied seeing anyone."
       , citations := ["zwarts-1998"] }
   | .universalRestrictor =>
-      { signature := .antiAdd, mechanism := .byStrengthening
+      { strawsonSignature := .antiAdd, mechanism := .byStrengthening
       , prototype := "Everyone who saw anyone was questioned."
       , citations := ["ladusaw-1979", "UNVERIFIED-bib-missing:partee-westerstaahl"] }
   | .few =>
-      { signature := .anti, mechanism := .byStrengthening
+      { strawsonSignature := .anti, mechanism := .byStrengthening
       , prototype := "Few students saw anyone."
       , citations := ["ladusaw-1979"] }
   | .atMost =>
-      { signature := .anti, mechanism := .byStrengthening
+      { strawsonSignature := .anti, mechanism := .byStrengthening
       , prototype := "At most three students saw anyone."
       , citations := ["ladusaw-1979"] }
   | .conditionalAntecedent =>
-      { signature := .anti, mechanism := .byStrengthening
+      { strawsonSignature := .anti, mechanism := .byStrengthening
       , prototype := "If anyone calls, take a message."
       , citations := ["ladusaw-1979", "kadmon-landman-1993"] }
   | .beforeClause =>
-      { signature := .anti, mechanism := .byStrengthening
+      { strawsonSignature := .anti, mechanism := .byStrengthening
       , prototype := "She left before anyone arrived."
       , citations := ["ladusaw-1979"] }
   | .onlyFocus =>
-      { signature := .anti, mechanism := .byStrengthening
+      { strawsonSignature := .anti, mechanism := .byStrengthening
       , prototype := "Only Mary saw anyone."
       , citations := ["horn-1996", "von-fintel-1999"]
-      , isStrawsonOnly := true }
+      , classicalSignature := none }
   | .tooTo =>
-      { signature := .anti, mechanism := .byStrengthening
+      { strawsonSignature := .anti, mechanism := .byStrengthening
       , prototype := "He was too tired to say anything."
       , citations := ["ladusaw-1979"] }
   | .comparativeNP =>
@@ -198,55 +196,71 @@ def contextProperties : LicensingContext → ContextProperties
       -- ([bhatt-pancheva-2004], [heim-2006]) reduce surface
       -- "than NP" with NPI to a covert clausal source — those NPIs are
       -- licensed by `.comparativeS`, not by this slot.
-      { signature := .mono, mechanism := .strengtheningFails
+      { strawsonSignature := .mono, mechanism := .strengtheningFails
       , prototype := "Surface NP-comparative; no NPI licensing under genuine NP reading."
       , citations := ["hoeksema-1983", "bhatt-pancheva-2004", "heim-2006"] }
   | .comparativeS =>
-      { signature := .antiAdd, mechanism := .byStrengthening
+      { strawsonSignature := .antiAdd, mechanism := .byStrengthening
       , prototype := "Mary is taller than anyone is."
       , citations := ["ladusaw-1979", "hoeksema-1983", "bhatt-pancheva-2004"] }
   | .adversative =>
-      { signature := .anti, mechanism := .byStrengthening
+      { strawsonSignature := .anti, mechanism := .byStrengthening
       , prototype := "I'm sorry I said anything."
       , citations := ["kadmon-landman-1993", "von-fintel-1999"]
-      , isStrawsonOnly := true }
+      , classicalSignature := none }
   | .sinceTemporal =>
-      { signature := .anti, mechanism := .byStrengthening
+      { strawsonSignature := .anti, mechanism := .byStrengthening
       , prototype := "It's been five years since anyone visited."
       , citations := ["iatridou-2000", "von-fintel-1999"]
-      , isStrawsonOnly := true }
+      , classicalSignature := none }
   | .doubtVerb =>
-      { signature := .anti, mechanism := .byStrengthening
+      { strawsonSignature := .anti, mechanism := .byStrengthening
       , prototype := "I doubt anyone came."
       , citations := ["zwarts-1998"] }
   | .modalPossibility =>
-      { signature := .mono, mechanism := .byGenericIndefinite
+      { strawsonSignature := .mono, mechanism := .byGenericIndefinite
       , prototype := "You may take any cookie."
       , citations := ["kadmon-landman-1993", "dayal-1996"] }
   | .modalNecessity =>
-      { signature := .mono, mechanism := .byGenericIndefinite
+      { strawsonSignature := .mono, mechanism := .byGenericIndefinite
       , prototype := "Anyone can solve this."
       , citations := ["dayal-1996"] }
   | .imperative =>
-      { signature := .mono, mechanism := .byGenericIndefinite
+      { strawsonSignature := .mono, mechanism := .byGenericIndefinite
       , prototype := "Pick any card."
       , citations := ["kadmon-landman-1993"] }
   | .generic =>
-      { signature := .mono, mechanism := .byGenericIndefinite
+      { strawsonSignature := .mono, mechanism := .byGenericIndefinite
       , prototype := "Any owl hunts mice."
       , citations := ["kadmon-landman-1993", "dayal-1996"] }
   | .freeRelative =>
-      { signature := .mono, mechanism := .byGenericIndefinite
+      { strawsonSignature := .mono, mechanism := .byGenericIndefinite
       , prototype := "Pick whichever you like."
       , citations := ["dayal-1996"] }
   | .question =>
-      { signature := .mono, mechanism := .byEntropy
+      { strawsonSignature := .mono, mechanism := .byEntropy
       , prototype := "Did anyone call?"
       , citations := ["van-rooy-2003"] }
   | .superlative =>
-      { signature := .mono, mechanism := .byStrawsonDE
+      -- Strawson row `.anti` per [von-fintel-1999]
+      -- (`superlative_isStrawsonDE`); previously a `.mono` placeholder.
+      { strawsonSignature := .anti, mechanism := .byStrawsonDE
       , prototype := "The tallest student who saw anyone..."
       , citations := ["UNVERIFIED-bib-missing:herdan-sharvit", "von-fintel-1999"]
-      , isStrawsonOnly := true }
+      , classicalSignature := none }
+
+/-- A context is **Strawson-only** when no classical signature row holds
+([von-fintel-1999]): only-focus, adversatives, temporal *since*,
+superlatives. -/
+def IsStrawsonOnly (c : LicensingContext) : Prop :=
+  (contextProperties c).classicalSignature = none
+
+/-- When a classical row exists it coincides with the Strawson row:
+presupposition-free contexts carry a single signature. -/
+theorem classicalSignature_eq_strawson (c : LicensingContext) :
+    (contextProperties c).classicalSignature = none ∨
+    (contextProperties c).classicalSignature =
+      some (contextProperties c).strawsonSignature := by
+  cases c <;> decide
 
 end Semantics.Polarity.Licensing

--- a/Linglib/Studies/BhattPancheva2004.lean
+++ b/Linglib/Studies/BhattPancheva2004.lean
@@ -190,8 +190,8 @@ theorem npGQ_principal_eq_sComp_thanClause
     Hoeksema's two registry theorems so that any future change to
     either signature surfaces here as a recompile failure. -/
 theorem reduction_preserves_polarity_signatures :
-    (contextProperties .comparativeNP).signature = .mono ∧
-    (contextProperties .comparativeS).signature = .antiAdd :=
+    (contextProperties .comparativeNP).strawsonSignature = .mono ∧
+    (contextProperties .comparativeS).strawsonSignature = .antiAdd :=
   ⟨comparativeNP_signature_monotone, comparativeS_signature_anti_additive⟩
 
 /- ## Note on the Bresnan 1973 contrast (B&P §1.1.1 fn. 4)

--- a/Linglib/Studies/Gajewski2011.lean
+++ b/Linglib/Studies/Gajewski2011.lean
@@ -416,16 +416,16 @@ Fragment registry encodes this through:
   `budgeAnInch`, `inYears`, `until_`, `either_npi`) all list
   `licensingContexts := [.negation, .nobody]` — i.e., classical-AA
   contexts only.
-- `Core/Lexical/PolarityItem.lean::ContextProperties.isStrawsonOnly`:
-  the four Strawson-only contexts (`.onlyFocus`, `.adversative`,
-  `.sinceTemporal`, `.superlative`) carry `isStrawsonOnly := true`.
+- `Semantics/Polarity/Licensing.lean::IsStrawsonOnly`: the four
+  Strawson-only contexts (`.onlyFocus`, `.adversative`,
+  `.sinceTemporal`, `.superlative`) carry `classicalSignature := none`.
 
-Gajewski's prediction: no strong NPI lists any `isStrawsonOnly`
+Gajewski's prediction: no strong NPI lists any Strawson-only
 context. The substrate makes this `decide`-checkable.
 -/
 
 open Typology.PolarityItem (PolarityType LicensingContext)
-open Semantics.Polarity.Licensing (contextProperties)
+open Semantics.Polarity.Licensing (contextProperties IsStrawsonOnly)
 open English.PolarityItems
   (liftAFinger budgeAnInch inYears until_ either_npi)
 
@@ -436,14 +436,14 @@ open English.PolarityItems
     `.withoutClause`), excluding `.onlyFocus`, `.adversative`,
     `.sinceTemporal`, `.superlative`. -/
 theorem gaj2011_strongNPIs_excluded_from_strawson_only_contexts :
-    ∀ ctx : LicensingContext, (contextProperties ctx).isStrawsonOnly = true →
+    ∀ ctx : LicensingContext, IsStrawsonOnly ctx →
       ctx ∉ liftAFinger.licensingContexts ∧
       ctx ∉ budgeAnInch.licensingContexts ∧
       ctx ∉ inYears.licensingContexts ∧
       ctx ∉ until_.licensingContexts ∧
       ctx ∉ either_npi.licensingContexts := by
   intro ctx hStrawson
-  cases ctx <;> simp_all [liftAFinger, budgeAnInch, inYears, until_, either_npi,
-    contextProperties]
+  cases ctx <;> simp_all [IsStrawsonOnly, liftAFinger, budgeAnInch, inYears,
+    until_, either_npi, contextProperties]
 
 end Gajewski2011

--- a/Linglib/Studies/Hoeksema1983.lean
+++ b/Linglib/Studies/Hoeksema1983.lean
@@ -333,12 +333,12 @@ theorem npComparativeGQ_principal_eq_sComparative_singleton
     Hoeksema's central asymmetry: the NP-comparative is monotone
     *increasing* and therefore not an NPI environment. -/
 theorem comparativeNP_signature_monotone :
-    (contextProperties .comparativeNP).signature = .mono := rfl
+    (contextProperties .comparativeNP).strawsonSignature = .mono := rfl
 
 /-- The `.comparativeS` registry slot is anti-additive, matching
     `sComparative_isAntiAdditive`. -/
 theorem comparativeS_signature_anti_additive :
-    (contextProperties .comparativeS).signature = .antiAdd := rfl
+    (contextProperties .comparativeS).strawsonSignature = .antiAdd := rfl
 
 /-- Both registry slots cite Hoeksema 1983, anchoring the registry's
     classification to this study file. -/

--- a/Linglib/Studies/KadmonLandman1993.lean
+++ b/Linglib/Studies/KadmonLandman1993.lean
@@ -98,9 +98,11 @@ Each context's entailment signature and licensing mechanism are projected
 from the canonical `Semantics.Polarity.Licensing.contextProperties` table, so
 this file's classification cannot drift from the substrate's. -/
 
-/-- A licensing context's entailment signature in [icard-2012]'s lattice. -/
+/-- A licensing context's entailment signature in [icard-2012]'s lattice —
+the Strawson-operative row, matching K&L's own convention of checking the
+DE pattern modulo factive presuppositions. -/
 abbrev contextEntailmentSig (c : LicensingContext) : EntailmentSig :=
-  (Semantics.Polarity.Licensing.contextProperties c).signature
+  (Semantics.Polarity.Licensing.contextProperties c).strawsonSignature
 
 /-- A context guarantees K&L strengthening iff its entailment signature is on
 the DE side. Contexts with `.mono` or higher signatures are licensed by other
@@ -116,8 +118,8 @@ example : ∀ c ∈ [LicensingContext.negation, .nobody, .withoutClause, .few,
     GuaranteesStrengthening c := by decide
 
 -- Non-DE contexts do not guarantee strengthening via DE.
-example : ∀ c ∈ [LicensingContext.question, .superlative, .modalPossibility,
-    .generic], ¬ GuaranteesStrengthening c := by decide
+example : ∀ c ∈ [LicensingContext.question, .modalPossibility, .generic],
+    ¬ GuaranteesStrengthening c := by decide
 
 /-- A licensing context's K&L mechanism, projected from `contextProperties`:
 *why* the context licenses, not merely *that* it does. -/
@@ -137,12 +139,16 @@ K&L's classification refines [ladusaw-1979]'s: every Ladusaw-DE context is a
 strengthening context, but K&L additionally explain adversative predicates
 (DE on a constant perspective) and conditionals with implicit restrictions. -/
 
-/-- Ladusaw-DE contexts are always K&L strengthening contexts: Ladusaw
-describes *where* NPIs occur, K&L explain *why*. -/
+/-- Ladusaw-DE contexts are K&L strengthening contexts — or, where the DE
+status is itself only Strawson (superlatives, per the later
+[von-fintel-1999]), the Strawson refinement of strengthening. Ladusaw
+describes *where* NPIs occur; K&L and the Strawson tradition explain
+*why*. -/
 theorem ladusaw_de_is_kl_strengthening (ctx : LicensingContext)
     (hDE : licensingStrength ctx = .antiAdditive ∨
            licensingStrength ctx = .downwardEntailing) :
-    klExplanation ctx = .byStrengthening := by
+    klExplanation ctx = .byStrengthening ∨
+    klExplanation ctx = .byStrawsonDE := by
   revert hDE; cases ctx <;> decide
 
 /-! ### Adversative predicates: *sorry* vs *glad*

--- a/Linglib/Studies/Ladusaw1979.lean
+++ b/Linglib/Studies/Ladusaw1979.lean
@@ -65,7 +65,7 @@ def LicensingStrength.ofDEStrength : Option Core.NaturalLogic.DEStrength → Lic
     classification is a coarsening of the Icard signature lattice. -/
 def licensingStrength (c : LicensingContext) : LicensingStrength :=
   LicensingStrength.ofDEStrength
-    (Semantics.Polarity.Licensing.contextProperties c).signature.toDEStrength
+    (Semantics.Polarity.Licensing.contextProperties c).strawsonSignature.toDEStrength
 
 -- ============================================================================
 -- §2. GQ monotonicity → NPI licensing (the Ladusaw bridge)


### PR DESCRIPTION
Layer 4 of the polarity-API plan (scratch/polarity/api-spec.md).

- `NLRelation.HoldsOn` + `EntailmentSig.StrawsonSoundFor`: row soundness modulo presuppositions (symmetric definedness gate, matching Gajewski's Strawson-AA); classical soundness is the trivial-definedness case and implies the Strawson form; `onlyFull`/`sorryFull`/`superlativeAssert`/`sinceFull` realize the `.anti` row Strawson-ly via the existing zoo
- `ContextProperties`: replace `signature` + `isStrawsonOnly : Bool` with `strawsonSignature` + `classicalSignature : Option EntailmentSig` (`none` = Strawson-only, with a decide-checked coincidence law); fixes the `superlative` row's `.mono` placeholder to its true Strawson row `.anti`
- consumers updated: Ladusaw's `licensingStrength` projects the Strawson row (his pre-Strawson DE concept); K&L's Ladusaw bridge honestly weakens to `byStrengthening ∨ byStrawsonDE` (superlatives joined the DE inventory via von Fintel 1999, not K&L); Gajewski's strong-NPI exclusion restated over `IsStrawsonOnly`