### PR TITLE
feat(Semantics/Polarity): derive NPI licensing from Zwarts strength

### DIFF
--- a/Linglib/Semantics/Polarity/Licensing.lean
+++ b/Linglib/Semantics/Polarity/Licensing.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Logic.NaturalLogic
 import Linglib.Features.LicensingContext
+import Linglib.Typology.PolarityItem
 
 /-!
 # Semantics.Polarity.Licensing
@@ -248,6 +249,24 @@ def contextProperties : LicensingContext → ContextProperties
       , prototype := "The tallest student who saw anyone..."
       , citations := ["UNVERIFIED-bib-missing:herdan-sharvit", "von-fintel-1999"]
       , classicalSignature := none }
+
+/-- Zwarts-strength licensing, derived ([zwarts-1998], [gajewski-2011]):
+the context's Strawson-operative row supplies at least the item's required
+strength (`PolarityItemEntry.strength`, itself derived from
+`polarityType`). `false` when either side is not strength-keyed — those
+items/contexts license via mechanism (`LicensingMechanism`), not
+signature. -/
+def strengthLicenses (e : Typology.PolarityItem.PolarityItemEntry)
+    (c : LicensingContext) : Bool :=
+  match (contextProperties c).strawsonSignature.toDEStrength, e.strength with
+  | some supplied, some required =>
+      Core.NaturalLogic.strengthSufficient supplied required
+  | _, _ => false
+
+/-- `strengthLicenses` as a proposition. -/
+abbrev LicensedBySignature (e : Typology.PolarityItem.PolarityItemEntry)
+    (c : LicensingContext) : Prop :=
+  strengthLicenses e c = true
 
 /-- A context is **Strawson-only** when no classical signature row holds
 ([von-fintel-1999]): only-focus, adversatives, temporal *since*,

--- a/Linglib/Studies/Gajewski2011.lean
+++ b/Linglib/Studies/Gajewski2011.lean
@@ -425,9 +425,11 @@ context. The substrate makes this `decide`-checkable.
 -/
 
 open Typology.PolarityItem (PolarityType LicensingContext)
-open Semantics.Polarity.Licensing (contextProperties IsStrawsonOnly)
+open Semantics.Polarity.Licensing
+  (contextProperties IsStrawsonOnly LicensedBySignature)
 open English.PolarityItems
-  (liftAFinger budgeAnInch inYears until_ either_npi)
+  (any ever yet anymore atAll inTheLeast aSingle whatsoever
+   liftAFinger budgeAnInch inYears until_ either_npi)
 
 /-- [gajewski-2011] headline made registry-checkable: no strong
     NPI in the English Fragment is licensed in any Strawson-only
@@ -445,5 +447,30 @@ theorem gaj2011_strongNPIs_excluded_from_strawson_only_contexts :
   intro ctx hStrawson
   cases ctx <;> simp_all [IsStrawsonOnly, liftAFinger, budgeAnInch, inYears,
     until_, either_npi, contextProperties]
+
+/-- The registry agrees with signature-derived licensing on the strong
+NPIs: every context a strong NPI lists supplies anti-additive strength
+(`strengthSufficient` of the row's Strawson DE strength against the
+item's derived [zwarts-1998] class). -/
+theorem gaj2011_strong_npis_licensedBySignature :
+    ∀ e ∈ [liftAFinger, budgeAnInch, inYears, until_, either_npi],
+      ∀ c ∈ e.licensingContexts, LicensedBySignature e c := by decide
+
+/-- Same agreement for the weak NPIs, gated to the strength-keyed
+mechanisms: the FC and entropy rows in *any*'s list are licensed by their
+mechanism, not by DE strength. -/
+theorem gaj2011_weak_npis_licensedBySignature :
+    ∀ e ∈ [any, ever, yet, anymore, atAll, inTheLeast, aSingle, whatsoever],
+      ∀ c ∈ e.licensingContexts,
+        ((contextProperties c).mechanism = .byStrengthening ∨
+         (contextProperties c).mechanism = .byStrawsonDE) →
+        LicensedBySignature e c := by decide
+
+-- The strength cut as a derived prediction (Gajewski's few-contrast):
+-- *few* (weak DE) licenses *any* but not *in years*; *nobody*
+-- (anti-additive) licenses both.
+example : LicensedBySignature any .few := by decide
+example : ¬ LicensedBySignature inYears .few := by decide
+example : LicensedBySignature inYears .nobody := by decide
 
 end Gajewski2011

--- a/Linglib/Typology/PolarityItem.lean
+++ b/Linglib/Typology/PolarityItem.lean
@@ -1,5 +1,6 @@
 import Linglib.Features.LicensingContext
 import Linglib.Typology.NegativeConcord
+import Linglib.Core.Logic.NaturalLogic
 
 /-!
 # Typology.PolarityItem
@@ -291,6 +292,21 @@ structure PolarityItemEntry where
 -- ════════════════════════════════════════════════════
 -- § 8. Predicates
 -- ════════════════════════════════════════════════════
+
+/-- The [zwarts-1998] strength class an item requires of its licensor,
+    derived from `polarityType`: weak NPIs (and the NPI face of dual
+    NPI/FCIs) need weak DE, strong NPIs need anti-additivity; FCIs and
+    PPIs are not strength-keyed. The superstrong class (*a tad bit*,
+    anti-morphic) has no registry items yet — extend `PolarityType`
+    when one lands. -/
+def PolarityItemEntry.strength (e : PolarityItemEntry) :
+    Option Core.NaturalLogic.DEStrength :=
+  match e.polarityType with
+  | .npiWeak => some .weak
+  | .npiFci => some .weak
+  | .npiStrong => some .antiAdditive
+  | .fci => none
+  | .ppi => none
 
 /-- Check if a context licenses a polarity item.
 


### PR DESCRIPTION
Layer F (final) of the polarity-API plan (scratch/polarity/api-spec.md).

- `PolarityItemEntry.strength : Option DEStrength`, *derived* from `polarityType` rather than added as a field (weak/npiFci → weak, strong → anti-additive; FCI/PPI not strength-keyed) — no new stipulation, no Fragment sweep
- `strengthLicenses`/`LicensedBySignature`: a context licenses an item when its Strawson-operative row's DE strength meets the item's class (`strengthSufficient`, which existed unused since the Zwarts hierarchy landed)
- Gajewski2011 drift sentries: the English registry's hand-curated `licensingContexts` agree with the derived prediction — exactly on strong NPIs, mechanism-gated on weak NPIs (FC/entropy rows license by mechanism, not strength); the few-contrast (`any` ✓ / `in years` ✗ under *few*) falls out as a derived prediction