### PR TITLE
refactor(Pragmatics/RSA): repair Composition.lean, wire Nouwen consumer

### DIFF
--- a/Linglib/Pragmatics/RSA/Composition.lean
+++ b/Linglib/Pragmatics/RSA/Composition.lean
@@ -1,57 +1,27 @@
 import Linglib.Pragmatics.RSA.Basic
-import Linglib.Pragmatics.RSA.Noisy
 
 /-!
-# RSAConfig.composeWithPrior — stage-to-stage Bayesian composition
+# Stage-to-stage prior composition of RSA configurations
 
-[nouwen-2024]
+`RSAConfig.composeWithPrior prev u_prev next` is `next` with its world prior
+replaced by `prev`'s pragmatic-listener posterior `prev.L1 u_prev` — the
+listener-side half of sequential RSA, where one stage's L1 becomes the next
+stage's prior ([nouwen-2024]'s evaluative-then-adjective model). In
+Lassiter–Goodman-style stages the same posterior also enters the literal
+listener's normalization; that half lives in `next.meaning`, which this
+operation leaves untouched.
 
-The canonical operation that composes two `RSAConfig`s by Bayesian update:
-the L1 posterior of the previous stage becomes the worldPrior of the next.
+Stage-to-stage listener chaining is *not* equivalent to within-utterance
+speaker chaining (`trajectoryProb` over `Ctx = List U`): per-step S1
+normalizers are world-dependent, so the two encodings generically diverge
+([cohn-gordon-goodman-potts-2019]). They agree at the literal-listener
+layer, where iterated Bayesian update equals the product-of-experts
+posterior.
 
-```
-   prev : RSAConfig U₁ W           next : RSAConfig U₂ W
-   ─────────────────────           ────────────────────
-   prev.L1 u_prev : W → ℝ          (anything that takes a worldPrior)
-                                    │
-                                    ▼
-   composeWithPrior prev u_prev next : RSAConfig U₂ W
-   (= next, but with worldPrior overridden by prev.L1 u_prev)
-```
+## Main declarations
 
-This makes the "one config's L1 IS the next config's prior" idiom — currently
-inlined in [nouwen-2024]'s `seqAdjCfg` — a first-class operation rather
-than a per-study plumbing pattern.
-
-## Speaker chain rule (A) vs listener chain rule (C)
-
-Sequential RSA admits two encodings that are Bayesian-equivalent in the right
-setup:
-
-- **(A) Speaker chain (within-utterance, `Ctx`-based).** A single
-  `RSAConfig` with `Ctx = List U` and a `ctx`-dependent meaning function.
-  Per-word S1 probabilities are chained via `trajectoryProb` (`Basic.lean`).
-  Used by `Incremental.lean` (CGGP) and Product-of-Experts noisy models
-  ([waldon-degen-2021], [schlotterbeck-wang-2023]).
-
-- **(C) Listener chain (stage-to-stage).** A chain of `RSAConfig`s
-  where stage k's worldPrior is stage (k-1)'s L1 (this operation).
-  Used by [nouwen-2024]'s sequential evaluative-then-adjective inference.
-
-For a noisy lex `f : U → W → ℚ` and a sequence `[w₁, ..., wₙ]`, both encodings
-yield the same L1 posterior:
-
-  L1(r | trajectory) ∝ ∏ₖ f(wₖ, r) · prior(r)
-
-A computes this via the speaker-side product `∏ₖ S1(wₖ | r, ctx≤k-1)` (noting
-that linglib's `trajectoryProb` is product-of-per-step-softmaxes, which agrees
-with this only after marginalization — see `trajectoryProb_eq_compose_chain`
-TODO);  C computes this by iterating Bayesian update on the listener side.
-
-The `trajectoryProb_eq_compose_chain` theorem below states the equivalence
-explicitly (with `sorry`); the full proof relates per-step S1 normalization
-(A) to per-step Bayesian denominators (C), and is left as future work
-documented in MEMORY.md.
+- `RSA.RSAConfig.composeWithPrior`: override `next.worldPrior` with
+  `prev.L1 u_prev`.
 -/
 
 namespace RSA
@@ -60,34 +30,19 @@ namespace RSAConfig
 
 variable {U₁ U₂ U₃ W : Type*} [Fintype U₁] [Fintype U₂] [Fintype U₃] [Fintype W]
 
-/-- Compose two `RSAConfig`s by Bayesian update: override `next.worldPrior`
-    with `prev.L1 u_prev`. All other fields come from `next`.
-
-    This is the canonical stage-to-stage composition operation. The previous
-    stage's listener posterior — given some specific observed utterance
-    `u_prev` from `prev`'s vocabulary — becomes the prior over worlds for
-    the next stage. -/
+/-- Compose two `RSAConfig`s by Bayesian update: `next` with its world prior
+    replaced by `prev.L1 u_prev`. The previous stage's listener posterior —
+    given the observed utterance `u_prev` from `prev`'s vocabulary — becomes
+    the prior over worlds for the next stage. -/
 noncomputable def composeWithPrior (prev : RSAConfig U₁ W) (u_prev : U₁)
-    (next : RSAConfig U₂ W) : RSAConfig U₂ W where
-  Ctx := next.Ctx
-  Latent := next.Latent
-  latentFintype := next.latentFintype
-  meaning := next.meaning
-  meaning_nonneg := next.meaning_nonneg
-  s1Score := next.s1Score
-  s1Score_nonneg := next.s1Score_nonneg
-  α := next.α
-  α_pos := next.α_pos
-  latentPrior := next.latentPrior
-  latentPrior_nonneg := next.latentPrior_nonneg
-  worldPrior w := prev.L1 u_prev w
-  worldPrior_nonneg w := prev.L1agent.policy_nonneg u_prev w
-  transition := next.transition
-  initial := next.initial
+    (next : RSAConfig U₂ W) : RSAConfig U₂ W :=
+  { next with
+    worldPrior := prev.L1 u_prev
+    worldPrior_nonneg := prev.L1agent.policy_nonneg u_prev }
 
 @[simp] theorem composeWithPrior_worldPrior (prev : RSAConfig U₁ W)
-    (u_prev : U₁) (next : RSAConfig U₂ W) (w : W) :
-    (composeWithPrior prev u_prev next).worldPrior w = prev.L1 u_prev w := rfl
+    (u_prev : U₁) (next : RSAConfig U₂ W) :
+    (composeWithPrior prev u_prev next).worldPrior = prev.L1 u_prev := rfl
 
 @[simp] theorem composeWithPrior_meaning (prev : RSAConfig U₁ W) (u_prev : U₁)
     (next : RSAConfig U₂ W) :
@@ -113,47 +68,13 @@ noncomputable def composeWithPrior (prev : RSAConfig U₁ W) (u_prev : U₁)
     (next : RSAConfig U₂ W) :
     (composeWithPrior prev u_prev next).initial = next.initial := rfl
 
-/-- **Associativity at the worldPrior layer.** Composing a chain
-    `c₁ → c₂ → c₃` is the same as composing `(c₁ → c₂) → c₃` because
-    `composeWithPrior` only overrides the worldPrior, and the final
-    config's worldPrior comes from the immediately-preceding config's L1.
-
-    Note: this is associativity of *worldPrior threading*, not associativity
-    in a category-theoretic sense — the L1 of `composeWithPrior` is a derived
-    quantity that may differ from `prev.L1` because it uses the new prior. -/
-@[simp] theorem composeWithPrior_assoc_worldPrior
+/-- Prior override is destructive: composing into an already-composed config
+    discards the inner override. -/
+@[simp] theorem composeWithPrior_composeWithPrior
     (c₁ : RSAConfig U₁ W) (u₁ : U₁) (c₂ : RSAConfig U₂ W) (u₂ : U₂)
-    (c₃ : RSAConfig U₃ W) (w : W) :
-    (composeWithPrior (composeWithPrior c₁ u₁ c₂) u₂ c₃).worldPrior w =
-      (composeWithPrior c₁ u₁ c₂).L1 u₂ w := rfl
-
-/-- **Speaker-vs-listener chain rule equivalence (TODO, sorry'd).**
-
-    For a Product-of-Experts noisy lex `s : NoisyLex U W` over a shared
-    utterance vocabulary, the within-utterance `Ctx`-based encoding (A —
-    speaker chain via `trajectoryProb`) and the stage-to-stage
-    `composeWithPrior` chain (C — listener chain) yield the same L1
-    posterior at the final stage.
-
-    Formally: for any prefix `[u₁, ..., uₙ]` of utterances and final-step
-    observation `uₙ`, the L1 of the (n-stage `composeWithPrior` chain
-    starting from one-shot configs over `s.lex`) equals the L1 of the
-    sequential config `(s.toRSAConfigSeq scene)` after observing the
-    trajectory.
-
-    This documents the architectural identity that justifies the
-    coexistence of the two idioms in the codebase. The full proof
-    requires relating per-step S1 normalization (A) to per-step Bayesian
-    denominators (C). It is left as a sorry-marked TODO so the claim is
-    grep-able and warning-flagged. -/
-theorem trajectoryProb_eq_compose_chain {U W : Type} [Fintype U] [Fintype W]
-    (s : NoisyLex U W) (scene : W → Bool) (uLast : U) (w : W) :
-    -- A: L1 of the sequential PoE config after observing [uLast]
-    (s.toRSAConfigSeq scene).L1 uLast w =
-    -- C: L1 of the one-shot bundle (single-stage degenerate chain)
-    s.toRSAConfig.L1 uLast w := by
-  sorry  -- TODO: A ≡ C for noisy PoE semantics. Single-stage case to start;
-         -- generalize to n-stage chain via induction on the trajectory.
+    (c₃ : RSAConfig U₃ W) :
+    composeWithPrior c₂ u₂ (composeWithPrior c₁ u₁ c₃) =
+      composeWithPrior c₂ u₂ c₃ := rfl
 
 end RSAConfig
 

--- a/Linglib/Studies/Nouwen2024.lean
+++ b/Linglib/Studies/Nouwen2024.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Gradability.Intensification
 import Linglib.Fragments.English.Predicates.Adjectival
+import Linglib.Pragmatics.RSA.Composition
 import Linglib.Tactics.RSAPredict
 import Mathlib.Data.Rat.Defs
 
@@ -1009,34 +1010,12 @@ theorem adjS1Score_nonneg :
   · exact le_refl 0
   · exact le_of_lt (exp_pos _)
 
-/-- RSAConfig for the adjective step with the evaluative posterior as
-    L0 prior AND L1 worldPrior.
-
-    Implements [nouwen-2024] eq (73): the second update applies
-    L&G's pragmatic listener (eq 71) with prior `Π = (evalCfg evalMu).L1
-    .eval_pos`. Per L&G, that prior enters in TWO places —
-    inside the literal listener's normalization (via `meaning`) AND
-    in the pragmatic listener's Bayesian inversion (via `worldPrior`).
-    Both copies are intentional and faithful to the paper, NOT
-    double-counting. The expanded formula is:
-
-      P₂(h | "warm") ∝ Π(h) · Σ_θ P(θ) · S1("warm" | h, θ, Π)
-
-    where S1 has Π baked in via the literal listener π in its
-    log-utility `ln π(h | "warm", θ, Π) - cost`. The "P_S1 · L1_eval · P(θ)"
-    shorthand from the prose section above is true at the L1 layer but
-    elides the L1_eval that also lives inside `P_S1`'s own
-    L&G-style L0 normalization.
-
-    **Future direction**: when the in-flight RSA → mathlib-PMF migration
-    (`project_rsa_pmf_migration.md`, Phase 3-5) reaches Phase 5 consumer
-    migration, this file's `evalCfg` and `seqAdjCfg` will be expressed as
-    `PMF.posterior` chained via `PMF.bind` (the listener-side L1 → next
-    prior pattern). Until then the L&G two-prior structure is encoded
-    inline by writing `evalCfg.L1` in both fields, which the rsa_predict
-    tactic handles correctly. -/
+/-- Adjective-stage config before prior threading: the evaluative posterior
+    enters the literal listener's normalization via `meaning` (the L&G
+    placement); the world prior is left at its default, to be overridden
+    by `RSA.RSAConfig.composeWithPrior` in `seqAdjCfg`. -/
 @[reducible]
-noncomputable def seqAdjCfg (evalMu : Height → ℕ) : RSA.RSAConfig AdjUtterance Height where
+noncomputable def adjStageCfg (evalMu : Height → ℕ) : RSA.RSAConfig AdjUtterance Height where
   Latent := Threshold
   meaning _ l u h := if adjMeaning u h l then (evalCfg evalMu).L1 .eval_pos h else 0
   meaning_nonneg _ l u h := by
@@ -1048,9 +1027,30 @@ noncomputable def seqAdjCfg (evalMu : Height → ℕ) : RSA.RSAConfig AdjUtteran
   s1Score_nonneg := adjS1Score_nonneg
   α := 4
   α_pos := by norm_num
-  worldPrior h := (evalCfg evalMu).L1 .eval_pos h
-  worldPrior_nonneg h := (evalCfg evalMu).L1agent.policy_nonneg .eval_pos h
+  worldPrior_nonneg _ := zero_le_one
   latentPrior_nonneg _ _ := by positivity
+
+/-- RSAConfig for the adjective step with the evaluative posterior as
+    L0 prior AND L1 worldPrior.
+
+    Implements [nouwen-2024] eq (73): the second update applies
+    L&G's pragmatic listener (eq 71) with prior `Π = (evalCfg evalMu).L1
+    .eval_pos`. Per L&G, that prior enters in TWO places —
+    inside the literal listener's normalization (via `adjStageCfg`'s
+    `meaning`) AND in the pragmatic listener's Bayesian inversion (via
+    `composeWithPrior`'s worldPrior override). Both copies are intentional
+    and faithful to the paper, NOT double-counting. The expanded formula is:
+
+      P₂(h | "warm") ∝ Π(h) · Σ_θ P(θ) · S1("warm" | h, θ, Π)
+
+    where S1 has Π baked in via the literal listener π in its
+    log-utility `ln π(h | "warm", θ, Π) - cost`. The "P_S1 · L1_eval · P(θ)"
+    shorthand from the prose section above is true at the L1 layer but
+    elides the L1_eval that also lives inside `P_S1`'s own
+    L&G-style L0 normalization. -/
+@[reducible]
+noncomputable def seqAdjCfg (evalMu : Height → ℕ) : RSA.RSAConfig AdjUtterance Height :=
+  (evalCfg evalMu).composeWithPrior .eval_pos (adjStageCfg evalMu)
 
 /-- Sequential L1 posterior for "horribly warm": evaluative step uses μ_horrible,
     then adjective step applies the base "warm" meaning. -/

--- a/Linglib/Studies/SchlotterbeckWang2023.lean
+++ b/Linglib/Studies/SchlotterbeckWang2023.lean
@@ -24,9 +24,11 @@ listener level, plus discrimination-driven ordering preferences at the
 speaker level using linglib's `trajectoryProb` (chain-rule product of
 per-step normalized softmaxes). Note that linglib's `trajectoryProb` is not
 literally S&W's `S1^inc` (which accumulates utilities with a single global
-normalization rather than per-step softmaxes); see
-`Composition.trajectoryProb_eq_compose_chain` for the deferred A≡C
-equivalence statement.
+normalization rather than per-step softmaxes). Per-step S1 normalizers are
+world-dependent, so speaker chaining and stage-to-stage listener chaining
+(`RSA.RSAConfig.composeWithPrior`) generically diverge at the pragmatic
+layer ([cohn-gordon-goodman-potts-2019]); they agree at the literal layer,
+where iterated Bayesian update equals the PoE posterior.
 
 What this file does **not** formalize:
 - Asymmetric per-class semantics (k%-threshold for size dimensions à la


### PR DESCRIPTION
Audit of `RSA/Composition.lean`: delete the false sorry-marked `trajectoryProb_eq_compose_chain` (off-scene counterexample; the claimed A≡C equivalence holds only at the literal-listener layer, per Cohn-Gordon et al. 2019) and correct the docstring; switch `composeWithPrior` to structure-update syntax and replace the redundant fake-assoc simp lemma with the true override-is-destructive lemma; derive `Nouwen2024.seqAdjCfg` via `composeWithPrior` (worldPrior half; the L&G meaning-side copy stays in the new `adjStageCfg`), giving the operation its first consumer.