### PR TITLE
feat(Syntax/CCG): forward crossed composition, faithful Dutch clusters

### DIFF
--- a/Linglib/Studies/KuhlmannKollerSatta2015.lean
+++ b/Linglib/Studies/KuhlmannKollerSatta2015.lean
@@ -16,8 +16,9 @@ grammar (here, via the target restriction modelled in `Syntax/CCG/Classical`: ev
 fires only when the *target* of its primary input category is `S`). For lexicalized CCG
 *without* target restrictions they prove the power is strictly below TAG: such a CCG that
 covers `aⁿbⁿcⁿ` also admits extra permuted strings, so it cannot generate the language
-*exactly*. `Syntax/CCG/Basic`'s `CCG.DerivStep` models exactly that unrestricted variant,
-so this construction genuinely needs the restricted model `CCG.Classical`.
+*exactly*. `Syntax/CCG/Basic`'s `CCG.DerivStep` models a (rule-inventory) fragment of that
+unrestricted variant, so this construction genuinely needs the restricted model
+`CCG.Classical`.
 
 Atoms follow the paper (`A, B, C, S`); we realise them with the project's `CCG.Cat` atoms
 as `A = NP`, `B = N`, `C = PP`, `S = S` — abstract placeholders, the content is generative

--- a/Linglib/Studies/Mueller2013.lean
+++ b/Linglib/Studies/Mueller2013.lean
@@ -140,6 +140,7 @@ def classifyCCGDerivStep : CCG.DerivStep → Option CombinationKind
   | .bapp _ _ => some .headComplement
   | .fcomp _ _ => some .headFiller
   | .bcomp _ _ => some .headFiller
+  | .fcompx _ _ => some .headFiller
   | .lex _ => none
   | .ftr _ _ => none
   | .btr _ _ => none

--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -22,8 +22,8 @@ CCG predictions from [steedman-2000], one section per phenomenon:
   recovered from the type-raising directions a language's verb categories
   license.
 - **Cross-serial dependencies**: Dutch verb clusters ([bresnan-etal-1982])
-  with cross-serial NP-verb bindings (the substrate direction-flips the
-  book's crossed-composition analysis — see the section header).
+  with cross-serial NP-verb bindings, via the book's leftward argument
+  categories and forward crossed composition.
 - **Verb clusters and quantifier scope** (§6.8): verb-raising orders are
   scope-ambiguous, verb-projection-raising orders surface-only; predictions
   are computed via `CCG.Scope.analyzeDerivation` and checked against the
@@ -219,11 +219,10 @@ end Gapping
 /-! ### Cross-serial dependencies
 
 Dutch verb clusters ([bresnan-etal-1982]) with cross-serial NP-verb
-bindings. Caveat: the book's analysis gives the cluster verbs leftward NP
-slots and composes them by forward *crossed* composition; the substrate
-derivations in `CCG.CrossSerial` flip the NP slots rightward so plain
-B/B² suffice (flagged there as not matching Dutch surface order). The
-binding permutation — the empirical target — is unaffected. -/
+bindings, using the surface-faithful derivations of `CCG.CrossSerial`:
+cluster verbs carry leftward NP slots and the cluster composes by forward
+crossed composition, per the book's own Dutch fragment, so the yield
+matches the attested word order. -/
 
 section CrossSerial
 
@@ -245,22 +244,21 @@ structure AnnotatedDerivation where
   deriving Repr
 
 /-- "Jan Piet zag zwemmen" with cross-serial bindings: Jan is the subject
-of "zag", Piet the argument picked up by "zwemmen". -/
+of "zag", Piet the argument bound into the cluster. -/
 def dutch_jan_piet_zag_zwemmen : AnnotatedDerivation :=
   { n := 2
-  , deriv := jan_zag_zwemmen_piet
+  , deriv := jan_piet_zag_zwemmen_sub
   , words := ["Jan", "Piet", "zag", "zwemmen"]
   , binding := VerbClusterBinding.identity 2
   }
 
-/-- "Jan Piet Marie zag helpen zwemmen": the verb cluster composes into a
-3-place predicate absorbing Marie (outermost slot → zwemmen), Piet
-(inner slot → helpen), and Jan (subject → zag) — the cross-serial
-binding pattern. (Direction-flipped from the book's crossed-composition
-analysis; see the section header.) -/
+/-- "Jan Piet Marie zag helpen zwemmen": `zag >B× (helpen zwemmen)` makes
+the cluster a leftward-seeking 3-place predicate; Marie binds `helpen`'s
+slot, Piet `zag`'s object slot, Jan the subject — the cross-serial
+binding pattern, in the attested word order. -/
 def dutch_jan_piet_marie_zag_helpen_zwemmen : AnnotatedDerivation :=
   { n := 3
-  , deriv := jan_piet_marie_zag_helpen_zwemmen_deriv
+  , deriv := jan_piet_marie_zag_helpen_zwemmen_sub
   , words := ["Jan", "Piet", "Marie", "zag", "helpen", "zwemmen"]
   , binding := VerbClusterBinding.identity 3
   }
@@ -272,6 +270,15 @@ theorem dutch_jan_piet_zag_zwemmen_binding :
 theorem dutch_jan_piet_marie_zag_helpen_zwemmen_binding :
     dutch_jan_piet_marie_zag_helpen_zwemmen.binding = dutch_3np_3v.binding := rfl
 
+/-- The derivations spell out exactly the annotated surface words. -/
+theorem dutch_jan_piet_zag_zwemmen_yield :
+    dutch_jan_piet_zag_zwemmen.deriv.yield = dutch_jan_piet_zag_zwemmen.words := by
+  decide
+
+theorem dutch_jan_piet_marie_zag_helpen_zwemmen_yield :
+    dutch_jan_piet_marie_zag_helpen_zwemmen.deriv.yield
+      = dutch_jan_piet_marie_zag_helpen_zwemmen.words := by decide
+
 end CrossSerial
 
 /-! ### Verb clusters and quantifier scope (§6.8)
@@ -280,9 +287,11 @@ Scope tracks word order: in the verb-raising order the cluster forms by
 composition, so a quantified argument combines with a function containing
 the tensed verb and can take scope over it; in the verb-projection-raising
 order it combines with the embedded verb alone. The derivations below are
-schematic `DerivStep` trees (the toy `Cat` lacks the crossed composition
-real Dutch clusters need); they capture the composed-cluster vs.
-applied-cluster contrast driving the account. -/
+category-checked `DerivStep` trees: the verb-raising cluster forms by
+forward crossed composition (`CCG.forwardCompX`), the
+verb-projection-raising order by plain application — the composed-cluster
+vs. applied-cluster contrast driving the account. (The toy `Cat` still
+drops the book's features, e.g. the `VP₋SUB` restriction on `>B×`.) -/
 
 section Quantification
 
@@ -296,15 +305,15 @@ inductive VerbOrder where
   | verbProjectionRaising
   deriving DecidableEq, Repr, Inhabited
 
-/-- Verb-raising order, schematized on Dutch (99a): the cluster
-*probeert te zingen* forms by composition before taking the object. -/
+/-- Verb-raising order, Dutch (99a): the cluster *probeert te zingen*
+forms by crossed composition before taking the object to its left. -/
 def verbRaisingDeriv : DerivStep :=
   .bapp (.lex ⟨"veel liederen", NP⟩)
-    (.fcomp (.lex ⟨"probeert", IV / IV⟩) (.lex ⟨"te zingen", IV \ NP⟩))
+    (.fcompx (.lex ⟨"probeert", IV / IV⟩) (.lex ⟨"te zingen", IV \ NP⟩))
 
-/-- Verb-projection-raising order, schematized on Dutch (99b): the matrix
-verb applies to an already-saturated embedded VP, so the quantified
-object never combines with a function containing the tensed verb. -/
+/-- Verb-projection-raising order, Dutch (99b): the matrix verb applies to
+an already-saturated embedded VP, so the quantified object never combines
+with a function containing the tensed verb. -/
 def verbProjectionRaisingDeriv : DerivStep :=
   .fapp (.lex ⟨"probeert", IV / IV⟩)
     (.bapp (.lex ⟨"veel liederen", NP⟩) (.lex ⟨"te zingen", IV \ NP⟩))
@@ -313,6 +322,12 @@ def verbProjectionRaisingDeriv : DerivStep :=
 def schematicDeriv : VerbOrder → DerivStep
   | .verbRaising => verbRaisingDeriv
   | .verbProjectionRaising => verbProjectionRaisingDeriv
+
+/-- Both derivations are category-valid and derive the same category. -/
+theorem verbRaisingDeriv_cat : verbRaisingDeriv.cat = some IV := rfl
+
+theorem verbProjectionRaisingDeriv_cat :
+    verbProjectionRaisingDeriv.cat = some IV := rfl
 
 theorem analyzeDerivation_verbRaisingDeriv :
     analyzeDerivation verbRaisingDeriv = .composed := rfl

--- a/Linglib/Syntax/CCG/Basic.lean
+++ b/Linglib/Syntax/CCG/Basic.lean
@@ -79,13 +79,26 @@ def backwardComp : Cat → Cat → Option Cat
     if y == y' then some (.lslash x z) else none
   | _, _ => none
 
+/-- Forward crossed composition (>B×): X/Y Y\Z => X\Z.
+
+In [steedman-2000] this rule is language-specific and restricted (for Dutch,
+to `Y = VP₋SUB`; ch. 6 appendix) — unrestricted crossed composition licenses
+scrambling. The toy `Cat` carries no features, so the rule is stated
+unrestricted here; the rule-restricted variant lives in
+`CCG.Classical.fcompX1`. -/
+def forwardCompX : Cat → Cat → Option Cat
+  | .rslash x y, .lslash y' z =>
+    if y == y' then some (.lslash x z) else none
+  | _, _ => none
+
 /-- Try to combine two categories using all available rules. -/
 def combine : Cat → Cat → Option Cat
   | c1, c2 =>
     forwardApp c1 c2 <|>
     backwardApp c1 c2 <|>
     forwardComp c1 c2 <|>
-    backwardComp c1 c2
+    backwardComp c1 c2 <|>
+    forwardCompX c1 c2
 
 end CombinatoryRules
 
@@ -137,6 +150,7 @@ inductive DerivStep where
   | bapp : DerivStep → DerivStep → DerivStep   -- backward app
   | fcomp : DerivStep → DerivStep → DerivStep  -- forward comp
   | bcomp : DerivStep → DerivStep → DerivStep  -- backward comp
+  | fcompx : DerivStep → DerivStep → DerivStep -- forward crossed comp
   | ftr : DerivStep → Cat → DerivStep          -- forward type-raise to target
   | btr : DerivStep → Cat → DerivStep          -- backward type-raise to target
   | coord : DerivStep → DerivStep → DerivStep  -- coordination (X and X ⇒ X)
@@ -161,6 +175,10 @@ def DerivStep.cat : DerivStep → Option Cat
     let c1 ← d1.cat
     let c2 ← d2.cat
     backwardComp c1 c2
+  | .fcompx d1 d2 => do
+    let c1 ← d1.cat
+    let c2 ← d2.cat
+    forwardCompX c1 c2
   | .ftr d t => do
     let x ← d.cat
     some (forwardTypeRaise x t)
@@ -184,6 +202,7 @@ def DerivStep.yield : DerivStep → List String
   | .bapp d1 d2 => d1.yield ++ d2.yield
   | .fcomp d1 d2 => d1.yield ++ d2.yield
   | .bcomp d1 d2 => d1.yield ++ d2.yield
+  | .fcompx d1 d2 => d1.yield ++ d2.yield
   | .ftr d _ => d.yield
   | .btr d _ => d.yield
   | .coord d1 d2 => d1.yield ++ d2.yield
@@ -227,6 +246,7 @@ def DerivStep.opCount : DerivStep → Nat
   | .bapp d1 d2 => 1 + d1.opCount + d2.opCount
   | .fcomp d1 d2 => 2 + d1.opCount + d2.opCount   -- composition is "harder"
   | .bcomp d1 d2 => 2 + d1.opCount + d2.opCount
+  | .fcompx d1 d2 => 2 + d1.opCount + d2.opCount
   | .ftr d _ => 1 + d.opCount                     -- type-raising has cost
   | .btr d _ => 1 + d.opCount
   | .coord d1 d2 => 1 + d1.opCount + d2.opCount
@@ -238,6 +258,7 @@ def DerivStep.depth : DerivStep → Nat
   | .bapp d1 d2 => 1 + max d1.depth d2.depth
   | .fcomp d1 d2 => 1 + max d1.depth d2.depth
   | .bcomp d1 d2 => 1 + max d1.depth d2.depth
+  | .fcompx d1 d2 => 1 + max d1.depth d2.depth
   | .ftr d _ => 1 + d.depth
   | .btr d _ => 1 + d.depth
   | .coord d1 d2 => 1 + max d1.depth d2.depth

--- a/Linglib/Syntax/CCG/CrossSerial.lean
+++ b/Linglib/Syntax/CCG/CrossSerial.lean
@@ -22,10 +22,13 @@ Every step has primary target `S`, so each is a valid rule instance of `CCG.Clas
 
 ## Implementation notes
 
-The derivation tree's `yield` does **not** match Dutch surface order — see
-`jan_zag_zwemmen_piet_yield`. The categories here encode the cross-serial *binding*
-pattern (which NP binds which verb) but not the linear order; a surface-order-faithful
-construction would type-raise the preverbal NPs.
+Two constructions are given. The *verb-raising* derivations (rightward `/NP`
+slots, harmonic `B`/`B²`) encode the cross-serial binding pattern but their
+`yield` does **not** match Dutch surface order — see
+`jan_zag_zwemmen_piet_yield`. The *surface-faithful* derivations (leftward
+`\NP` slots, forward crossed composition `fcompX1`, following the book's own
+Dutch fragment) get both the binding and the attested word order — see
+`two_np_sub_yield` / `three_np_sub_yield`.
 -/
 
 namespace CCG.CrossSerial
@@ -44,9 +47,6 @@ def ControlV : Cat := VP / VP
 /-- Perception verb: `(S\NP)/(S\NP)` (e.g. "zag" = saw). -/
 def PercV : Cat := (S \ NP) / VP
 
-/-- Infinitival transitive `VP/NP`. -/
-def InfTV : Cat := VP / NP
-
 /-- Infinitival verb needing its (raised) subject: `(S\NP)/NP`. In Dutch verb-raising the
 infinitive's subject surfaces in an object-like position, picked up via composition. -/
 def InfSubj : Cat := (S \ NP) / NP
@@ -59,12 +59,24 @@ what threads multiple argument slots through a 3+-verb cluster:
 - `zag     : (S\NP)/(S\NP)`       — matrix: standard perception verb -/
 def ControlVR : Cat := ((S \ NP) / NP) / (S \ NP)
 
+/-- Subordinate-clause perception verb `((S\NP)\NP)/VP`: infinitival
+complement to the right, object and subject NPs to the left (book:
+`zag := ((S₊SUB\NP)\NP)/VP₋SUB`; the toy `Cat` drops the features).
+`Sub` = subordinate-clause head — contrast `InfSubj`, whose `/NP` is a
+raised-subject slot. -/
+def PercVSub : Cat := ((S \ NP) \ NP) / VP
+
+/-- Infinitival head with a raised object, `(VP\NP)/VP` (book:
+`zien := (VP\NP)/VP₋SUB`). -/
+def InfHeadSub : Cat := (VP \ NP) / VP
+
 /-- The Dutch lexicon (reference; the derivations below select specific entries). -/
 def dutchLexicon : List LexEntry := [
   ⟨"Jan", NP⟩, ⟨"Piet", NP⟩, ⟨"Marie", NP⟩, ⟨"Karel", NP⟩,
-  ⟨"zag", PercV⟩,
+  ⟨"zag", PercV⟩, ⟨"zag", PercVSub⟩,
   ⟨"helpen", ControlV⟩, ⟨"laten", ControlV⟩,
   ⟨"helpen", ControlVR⟩, ⟨"laten", ControlVR⟩,
+  ⟨"helpen", InfHeadSub⟩,
   ⟨"zwemmen", VP⟩, ⟨"zwemmen", InfSubj⟩
 ]
 
@@ -124,10 +136,57 @@ theorem verb_cluster_cat :
 
     **This does not match Dutch surface order** ("Jan Piet zag zwemmen"): the verb-cluster
     category `(S\NP)/NP` looks rightward for its arguments, so the derivation tree spells
-    out "Jan zag zwemmen Piet". A surface-order-faithful cross-serial derivation requires
-    type-raising the preverbal NPs; the categories here capture the cross-serial *binding*
-    pattern but not the *linear order*. -/
+    out "Jan zag zwemmen Piet". The categories here capture the cross-serial *binding*
+    pattern but not the *linear order*; the surface-faithful derivations below get both. -/
 theorem jan_zag_zwemmen_piet_yield :
     jan_zag_zwemmen_piet.yield = ["Jan", "zag", "zwemmen", "Piet"] := by decide
+
+/-! ### Surface-faithful derivations (leftward argument categories)
+
+[steedman-2000]'s own analysis (ch. 6; appendix summary of the Dutch
+fragment) gives subordinate-clause cluster verbs *leftward* NP slots and
+composes the cluster by forward **crossed** composition (`fcompX1`), so the
+NPs precede the whole cluster and the yield is the attested
+"Jan Piet (Marie) zag (helpen) zwemmen". -/
+
+def zag_sub : Derivation := .lex PercVSub "zag"
+def helpen_sub : Derivation := .lex InfHeadSub "helpen"
+def zwemmen_bare : Derivation := .lex VP "zwemmen"
+
+/-- "(dat) Jan Piet zag zwemmen": `zag` applies to bare `zwemmen` and the
+NPs attach leftward — the 2-verb cluster needs no composition. -/
+def jan_piet_zag_zwemmen_sub : Derivation :=
+  .ba jan_lex (.ba piet_lex (.fa zag_sub zwemmen_bare))
+
+/-- "(dat) Jan Piet Marie zag helpen zwemmen": `helpen zwemmen : VP\NP`
+forms by application, `zag >B× (helpen zwemmen)` crosses the rightward
+`/VP` into a leftward-seeking cluster `((S\NP)\NP)\NP`, and the three NPs
+attach leftward — Marie to `helpen`'s slot, Piet to `zag`'s object slot,
+Jan as subject: the cross-serial binding falls out of the category
+threading. -/
+def jan_piet_marie_zag_helpen_zwemmen_sub : Derivation :=
+  .ba jan_lex (.ba piet_lex (.ba marie_lex
+    (.fcx1 zag_sub (.fa helpen_sub zwemmen_bare))))
+
+theorem two_np_sub_derives_S :
+    jan_piet_zag_zwemmen_sub.cat = some S := by decide
+
+theorem three_np_sub_derives_S :
+    jan_piet_marie_zag_helpen_zwemmen_sub.cat = some S := by decide
+
+/-- The crossed cluster is a leftward-seeking 3-place predicate. -/
+theorem crossed_cluster_cat :
+    (Derivation.fcx1 zag_sub (.fa helpen_sub zwemmen_bare)).cat
+      = some (((S \ NP) \ NP) \ NP) := by decide
+
+/-- The surface-faithful derivations spell out the attested word order
+(contrast `jan_zag_zwemmen_piet_yield`). -/
+theorem two_np_sub_yield :
+    jan_piet_zag_zwemmen_sub.yield = ["Jan", "Piet", "zag", "zwemmen"] := by
+  decide
+
+theorem three_np_sub_yield :
+    jan_piet_marie_zag_helpen_zwemmen_sub.yield
+      = ["Jan", "Piet", "Marie", "zag", "helpen", "zwemmen"] := by decide
 
 end CCG.CrossSerial

--- a/Linglib/Syntax/CCG/GenerativeCapacity.lean
+++ b/Linglib/Syntax/CCG/GenerativeCapacity.lean
@@ -34,9 +34,9 @@ A fully-proven construction of a rule-restricted (classical) CCG that generates 
 is therefore *not* expressible over `DerivStep`; it lives in
 `Studies/KuhlmannKollerSatta2015` (`ccg_generates_anbnc`), which models the target
 restriction explicitly. The concrete Dutch derivations in `CCG.CrossSerial` are 2- and
-3-verb instances and are *not* surface-order-faithful (their categories encode the
-cross-serial binding but not the linear order; see
-`CCG.CrossSerial.jan_zag_zwemmen_piet_yield`), so they do not establish a capacity claim.
+3-verb instances — surface-faithful via crossed composition (see
+`CCG.CrossSerial.three_np_sub_yield`) — but finitely many instances do not establish a
+capacity claim.
 -/
 
 namespace CCG.GenerativeCapacity

--- a/Linglib/Syntax/CCG/Interface.lean
+++ b/Linglib/Syntax/CCG/Interface.lean
@@ -143,6 +143,19 @@ def DerivStep.interp {E W : Type} (d : DerivStep) (lex : SemLexicon E W)
           else none
       | _, _ => none
 
+  | .fcompx d1 d2 => do
+      -- Forward crossed composition: X/Y + Y\Z → X\Z, semantically B (f ∘ g)
+      let ⟨c1, m1⟩ ← d1.interp lex
+      let ⟨c2, m2⟩ ← d2.interp lex
+      match c1, c2 with
+      | .rslash x y1, .lslash y2 z =>
+          if h : y1 = y2 then
+            let m2' : Denot E W (catToTy z ⇒ catToTy y1) :=
+              h ▸ m2
+            some ⟨x \ z, B m1 m2'⟩
+          else none
+      | _, _ => none
+
   | .ftr d t => do
       -- Forward type-raising: X → T/(T\X), semantically T (λf. f x)
       let ⟨x, m⟩ ← d.interp lex

--- a/Linglib/Syntax/CCG/Scope.lean
+++ b/Linglib/Syntax/CCG/Scope.lean
@@ -47,6 +47,7 @@ def analyzeDerivation : DerivStep → DerivationType
     | _, _ => .directApp
   | .fcomp _ _ => .composed
   | .bcomp _ _ => .composed
+  | .fcompx _ _ => .composed
   | .ftr _ _ => .typeRaised
   | .btr _ _ => .typeRaised
   | .coord d1 d2 =>


### PR DESCRIPTION
Add >B× (`forwardCompX`/`DerivStep.fcompx`) to the toy CCG engine, with cases threaded through `cat`/`yield`/`interp`/`analyzeDerivation`/Mueller's classifier. Surface-faithful Dutch cross-serial derivations via the existing `Classical.fcompX1` and the book's leftward argument categories — `yield` now matches attested word order; Steedman 2000's §6.8 scope derivations become category-checked (`.cat = some IV` by `rfl`).