### PR TITLE
feat(Syntax/Minimalist/Phi): relativized probing substrate; derive PLC

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2192,6 +2192,7 @@ import Linglib.Syntax.Minimalist.CyclicAgree
 import Linglib.Syntax.Minimalist.NestedAgree
 import Linglib.Syntax.Minimalist.Phi.Geometry
 import Linglib.Syntax.Minimalist.Phi.Lattice
+import Linglib.Syntax.Minimalist.Phi.Probing
 import Linglib.Syntax.Minimalist.PConstraint
 import Linglib.Syntax.Minimalist.ObligatoryOperations
 import Linglib.Syntax.Case.Alignment

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -1,6 +1,5 @@
 import Linglib.Fragments.Mayan.Kaqchikel.AgentFocus
 import Linglib.Features.Case.Basic
-import Linglib.Features.Case.Basic
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 
@@ -12,8 +11,9 @@ agreement morphology: paradigm exponents, person-number cells, argument
 positions, and the empirical AF agreement table.
 
 The theory-laden apparatus that interprets this data — DM Vocabulary
-insertion, Phi.Geometry feature decomposition, the omnivorous
-hierarchy, the AgreeOutcome inductive — lives in
+insertion (`setAVocab`/`setBVocab`), Phi.Geometry feature
+decomposition (`IsParticipant`), and the two-probe choice rule
+(`afRank`, `afMarker`) — lives in
 `Studies/Preminger2014.lean`. Per the project
 Fragment-discipline rule (CLAUDE.md), fragments hold only consensus
 typological metadata; paper-specific apparatus is consumed in study
@@ -101,7 +101,10 @@ def setAExponent : ExponentTable :=
 /-- Set B (ABS) markers: preverbal markers on Infl/T cross-referencing
     the absolutive argument. The 3SG form (∅) is
     also the Elsewhere entry — the default when no more specific entry
-    matches, as in the failure case of obligatory agreement (Ch. 5). -/
+    matches, as in the failure case of obligatory agreement (Ch. 5).
+    Citation forms: 1SG and 2SG are *i(n)-* and *a(t)-*, whose
+    parenthesized segments drop in certain phonological contexts
+    (e.g., 1SG surfaces as *i-* in *x-i-tz'et-ö*). -/
 def setBExponent : ExponentTable :=
   [(.pn .first .Sing, "in-"), (.pn .second .Sing, "at-"), (.pn .third .Sing, "∅"),
    (.pn .first .Plur, "oj-"), (.pn .second .Plur, "ix-"), (.pn .third .Plur, "e-")]

--- a/Linglib/Morphology/DM/VocabSimple.lean
+++ b/Linglib/Morphology/DM/VocabSimple.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Minimalist.Agree
+import Linglib.Syntax.Agreement.Paradigm
 
 /-!
 # VocabSimple: Minimalist-specific Vocabulary Insertion
@@ -119,6 +120,11 @@ theorem empty_features_matches_any (entry : VocabEntry)
 -- ============================================================================
 -- § 4: Vocabulary Builders
 -- ============================================================================
+
+/-- The φ-feature list of a person-number cell, in the shape `makePersonVocab`
+    consumes. Shared by the Mayan agreement studies (Scott2023, Preminger2014). -/
+def _root_.Agreement.Cell.toPhiFeatures (c : Agreement.Cell) : List PhiFeature :=
+  [.person c.toPerson, .number (if c.isPlural then .plural else .singular)]
 
 /-- Build a Vocabulary from a paradigm cell type. For each cell `pn`, emits
     one VocabEntry whose features are `toPhi pn` lifted into valued

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -1,45 +1,54 @@
-import Linglib.Syntax.Minimalist.Agree
 import Linglib.Syntax.Minimalist.Phi.Geometry
+import Linglib.Syntax.Minimalist.Phi.Probing
+import Linglib.Syntax.Minimalist.ObligatoryOperations
 import Linglib.Morphology.DM.VocabSimple
 import Linglib.Fragments.Mayan.Kaqchikel.Agreement
 
 /-!
 # Preminger 2014 — Agreement and Its Failures [preminger-2014]
 [bejar-rezac-2003] [halle-marantz-1993] [harley-ritter-2002]
-[stiebels-2006] [halpert-2012]
+[nevins-2011] [stiebels-2006] [halpert-2012]
 
 [preminger-2014], *Agreement and Its Failures* (MIT Press, LI
-Monographs 68), applies [bejar-rezac-2003]'s relativized-probing
-mechanism (with the Person Licensing Condition) to the Kichean Agent
-Focus construction (Ch. 4) and uses the resulting failure cases to
-argue for an "obligatory operations" model of φ-Agree (Ch. 5). The
+Monographs 68), applies [bejar-rezac-2003]'s relativized probing
+(with the Person Licensing Condition) to the Kichean Agent Focus
+construction (Ch. 4) and uses the resulting failure cases to argue
+for an "obligatory operations" model of φ-Agree (Ch. 5). The
 fragment in `Fragments/Mayan/Kaqchikel/Agreement.lean` carries the
-typology-neutral data (paradigm exponents, person-number cells,
-argument positions, the empirical AF table); this file adds the
-analytical apparatus.
+theory-neutral data; this file adds the analytical apparatus.
+Section and example numbers below were verified against the
+monograph manuscript; page numbers are omitted (draft and published
+pagination differ).
 
 ## Attribution discipline
 
 Per Preminger's own framing:
 
 - The **feature geometry** [φ] → [PERSON] → [participant] → [author]
-  traces to [harley-ritter-2002]; [preminger-2014] adopts it.
+  traces to [harley-ritter-2002]; [preminger-2014] adopts a
+  simplified version.
 - The **relativized-probing mechanism** and the **Person Licensing
-  Condition (PLC)** are [bejar-rezac-2003]'s; Preminger §4.1 is
-  titled "Background: The Person Case Constraint, and Béjar and
-  Rezac's (2003) Account of It" and §4.4 is "Applying Béjar and
-  Rezac's (2003) Account to Kichean".
-- **DM Vocabulary insertion** for setAVocab/setBVocab follows
-  [halle-marantz-1993]'s Distributed Morphology framework.
-- What is **distinctively Preminger 2014**:
-  - Application of [bejar-rezac-2003] to Kichean AF specifically
-    (Ch 4), with a Kichean-specific structural priority of π⁰ over
-    #⁰ deriving the surface "overflow" pattern.
-  - Arguments against direct salience-hierarchy primitives (Ch 7),
-    targeted at [stiebels-2006] and similar accounts.
-  - The "obligatory operations" model of φ-Agree (Ch 5): φ-Agree is
-    obligatory but failure-tolerant; failed Agree surfaces as the
-    Elsewhere (3SG ∅) entry rather than crashing the derivation.
+  Condition (PLC)** are [bejar-rezac-2003]'s (§4.1, §4.4) — and so
+  is the derivational ordering of person before number probing,
+  which Preminger inherits (π⁰ is merged below #⁰ and probes
+  first; what surfaces is decided by a single morphological slot in
+  which a clitic beats out the exponence of π⁰/#⁰).
+- **Omnivorous agreement** as the name for the surface pattern is
+  [nevins-2011]'s term, which Preminger adopts.
+- **DM Vocabulary insertion** for `setAVocab`/`setBVocab` follows
+  [halle-marantz-1993]. The Elsewhere ∅ entry is this
+  formalization's DM rendering: Preminger's own statement is that
+  the absolutive paradigm has no overt 3rd-person-singular
+  exponence, so failed probing leaves the slot empty.
+- What is **distinctively Preminger 2014**: relativizing π⁰ to
+  [participant] and #⁰ to [plural] for Kichean AF (Ch. 4); the
+  "obligatory operations" model of φ-Agree (Ch. 5) — φ-Agree is
+  obligatory but failure-tolerant, with failed Agree surfacing as
+  default morphology rather than crashing the derivation; and the
+  Ch. 7 case against salience-hierarchy primitives (the Mayanist
+  hierarchy tradition: Dayley, Smith-Stark, Norman & Campbell,
+  Mondloch; and constraint-based recastings such as
+  [stiebels-2006]).
 
 ## Two-probe relativized probing
 
@@ -51,58 +60,56 @@ relativized probes:
 
 The single AF marker reflects π⁰'s output if it succeeds (clitic
 doubling of the [participant]-bearing argument); otherwise #⁰'s
-output (the 3PL marker *e-* by direct exponence); otherwise the
-Elsewhere (3SG ∅) entry. Person and number probes are applied
-*independently* — there is no salience scale.
+output (the 3PL marker *e-* by direct exponence); otherwise the slot
+is empty (∅). There is no salience scale —
+`afAgreementTarget_eq_twoProbe` proves the rank-comparison encoding
+is derived from the two-probe mechanism, not primitive, and
+`personRestrictionOk_iff_plc` derives the person restriction from
+the PLC via `Phi/Probing.lean`'s search-licensing substrate.
 
 ## Why not a hierarchy
 
 A surface-equivalent hierarchy `[+participant] > [+plural] > default`
-would predict the same outputs on the table-(22) cells, but Ch 7
-provides **five** arguments against it (§7.3 summary, p. 127):
+would predict the same outputs on the table-(22) cells, but Ch. 7
+gives five arguments against hierarchy accounts:
 
-1. **Restrictedness** (§7.1, p. 124): "salience" effects surface
-   nowhere else in the language — cognitive salience would predict
-   them in regular transitives too.
-2. **K'ichee' formal addressee *la*** (p. 124–125): a 2nd-person
-   pronoun that behaves morphosyntactically as 3rd person under
-   AF, contrary to a hierarchy that ranks 2nd ≫ 3rd.
-3. **AF person restriction asymmetry** (p. 125): hierarchies don't
-   predict why two 1st/2nd persons are blocked but two 3rd plurals
-   are licit.
-4. **Morphophonological 1st/2nd vs 3rd asymmetry** ("perhaps
-   strongest", §3.4 + p. 125–126, table (148)): 1st/2nd ABS markers
-   stand in the relation `<agreement marker> = <strong pronoun>
-   – <initial approximant>` (eq. 149) — a clitic-doubling signature.
-   3rd-person markers don't. A hierarchy can't capture this.
-5. **Zulu cross-linguistic parallel** (§7.2, p. 127):
-   [halpert-2012]'s analysis of Zulu augmentless nominals uses
-   the same machinery, but operating over augmented/augmentless
-   instead of person/number — substantively different categories
-   that have no plausible "salience" interpretation. The same
-   logic applying to a salience-irrelevant feature contrast
-   undermines the cognitive-salience grounding entirely.
-
-Theorems below verify (3) on the fragment data; (4) is encoded as
-a smoke check (the fragment carries ABS markers but not strong
-pronouns, so the genuine eq.-149 relation cannot be verified
-without extending the fragment); (1), (2), (5) are documented in
-prose and would require additional fragment data (regular
-transitives + K'ichee' fragment + Zulu fragment) to formalize.
+1. **Restrictedness** (§7.1): "salience" effects surface nowhere
+   else in the language (prose only — needs regular-transitive data).
+2. **K'ichee' formal addressee *la***: a 2nd-person pronoun that is
+   morphosyntactically 3rd person under AF, contrary to 2 ≫ 3
+   (prose only — needs a K'ichee' fragment).
+3. **Co-occurrence asymmetry**: a hierarchy is silent on
+   co-occurrence — nothing about it explains why two 1st/2nd-person
+   arguments cannot co-occur while two 3rd-plurals can. The
+   two-probe + PLC account derives both the agreement pattern and
+   the restriction; the hierarchy derives only the former
+   (`ch7_arg3_participant_vs_plural_asymmetry`).
+4. **Morphophonology of the markers** ("perhaps strongest", §3.4):
+   1st/2nd ABS markers stand in the relation `<agreement marker> =
+   <strong pronoun> − <initial approximant>` (149) — a
+   clitic-doubling signature that 3rd-person markers lack
+   (smoke check only — the fragment lacks strong-pronoun forms).
+5. **Zulu parallel** (§7.2): [halpert-2012]'s analysis of Zulu
+   augmentless nominals uses the same machinery over
+   augmented/augmentless — categories with no plausible "salience"
+   reading (prose only — needs a Zulu fragment).
 
 ## Cross-references
 
-- `Syntax/Minimalist/Phi/Geometry.lean` — the substrate:
-  `decomposePerson`, `probeResolutionRank`, multi-cited
-  ([harley-ritter-2002], [bejar-rezac-2003],
-  [preminger-2014], [pancheva-zubizarreta-2018]).
-- `Morphology/DM/VocabSimple.lean` —
-  the substrate: `Vocabulary`, `VocabEntry`, `makePersonVocab`.
-- `Studies/Scott2023.lean` — parallel
-  application of the same DM/Agree machinery to Mam (where Infl's
-  φ-probe is blocked in transitives).
-- `Studies/CoonMateoPedroPreminger2014.lean` —
-  Voice/case-flavor side of the same author cluster's Mayan work.
+- `Syntax/Minimalist/Phi/Geometry.lean` — `decomposePerson`,
+  `probeVisible`, `probeResolutionRank`.
+- `Syntax/Minimalist/Phi/Probing.lean` — `probeSearch`, `Licensed`,
+  `PLC`: the search-and-licensing layer the derivations below
+  consume.
+- `Syntax/Minimalist/ObligatoryOperations.lean` — the Ch. 5 model
+  (`AgreementModel`, `ProbeOutcome`, `PFRealization`), consumed
+  below for the failed-Agree theorems.
+- `Morphology/DM/VocabSimple.lean` — `Vocabulary`,
+  `Agreement.Cell.toPhiFeatures`, `makePersonVocab`, `spellout`.
+- `Studies/Scott2023.lean` — the same DM/Agree machinery applied to
+  Mam (where Infl's φ-probe is blocked in transitives).
+- `Studies/CoonMateoPedroPreminger2014.lean` — Voice/case-flavor
+  side of the same author cluster's Mayan work.
 -/
 
 namespace Preminger2014
@@ -111,17 +118,16 @@ open Kaqchikel
 open Minimalist
 open Agreement
 
--- ============================================================================
--- § 1: Feature Decomposition (grounded in Phi/Geometry.lean)
--- ============================================================================
+/-! ### Feature decomposition (grounded in `Phi/Geometry.lean`) -/
 
-/-- Bears [+participant]? Derived from [harley-ritter-2002]'s
-    feature geometry via `decomposePerson` (Phi/Geometry.lean). -/
+/-- Bears [+participant]? Visibility to π⁰ under relativized probing
+    ([bejar-rezac-2003] via `Agreement.Cell.visibleTo`); derives from
+    [harley-ritter-2002]'s feature geometry through `decomposePerson`. -/
 def IsParticipant (c : Agreement.Cell) : Prop :=
-  (decomposePerson c.toPerson).hasParticipant = true
+  c.visibleTo .participant = true
 
 instance : DecidablePred IsParticipant := fun c =>
-  inferInstanceAs (Decidable ((decomposePerson c.toPerson).hasParticipant = true))
+  inferInstanceAs (Decidable (c.visibleTo .participant = true))
 
 /-- Bears [+author]? -/
 def IsAuthor (c : Agreement.Cell) : Prop :=
@@ -130,58 +136,99 @@ def IsAuthor (c : Agreement.Cell) : Prop :=
 instance : DecidablePred IsAuthor := fun c =>
   inferInstanceAs (Decidable ((decomposePerson c.toPerson).hasAuthor = true))
 
-/-- Convert a person-number cell to a PhiFeature list for the Agree
-    infrastructure. -/
-def toPhiFeatures (c : Agreement.Cell) : List PhiFeature :=
-  [.person c.toPerson, .number (if c.isPlural then .plural else .singular)]
+/-- [author] entails [participant]: the [harley-ritter-2002] geometric
+    containment, inherited from `decomposePerson`. -/
+theorem isParticipant_of_isAuthor (c : Agreement.Cell) :
+    IsAuthor c → IsParticipant c := by
+  unfold IsAuthor IsParticipant Agreement.Cell.visibleTo
+  simp only [probeVisible]
+  cases c.toPerson <;> decide
 
--- ============================================================================
--- § 2: DM Vocabulary Insertion ([halle-marantz-1993])
--- ============================================================================
+/-! ### DM Vocabulary insertion ([halle-marantz-1993]) -/
+
+/-- The valued feature bundle a probe carries after agreeing with a
+    DP in cell `c`. -/
+private def cellBundle (c : Agreement.Cell) : FeatureBundle :=
+  c.toPhiFeatures.map (λ p => .valued (.phi p))
 
 /-- Set A as DM Vocabulary entries, contextualized to Voice/v.
-    Built via the shared `makePersonVocab` helper. -/
+    All six cells have overt exponents. -/
 def setAVocab : Vocabulary :=
-  makePersonVocab Agreement.Cell.pnCells toPhiFeatures
+  makePersonVocab Agreement.Cell.pnCells Agreement.Cell.toPhiFeatures
     (fun c => (setAExponent.realize c).getD "") (some .v)
 
-/-- Set B as DM Vocabulary entries, contextualized to Infl/T. -/
+/-- Set B as DM Vocabulary entries, contextualized to Infl/T: specific
+    entries for the five overt cells, plus the Elsewhere ∅ entry
+    realizing 3SG and failed agreement (see the module docstring on
+    this DM rendering vs. Preminger's own formulation). -/
 def setBVocab : Vocabulary :=
-  makePersonVocab Agreement.Cell.pnCells toPhiFeatures
-    (fun c => (setBExponent.realize c).getD "") (some .T)
+  makePersonVocab (Agreement.Cell.pnCells.filter (· != .pn .third .Sing))
+    Agreement.Cell.toPhiFeatures
+    (fun c => (setBExponent.realize c).getD "") (some .T) ++
+  [{ features := [], exponent := "∅", context := some .T }]
 
--- ============================================================================
--- § 3: Two-Probe Relativized Probing ([bejar-rezac-2003], applied per §4.4)
--- ============================================================================
+/-- Vocabulary insertion recovers the fragment's paradigms: spelling
+    out each cell's valued bundle yields the fragment's exponent — for
+    Set B, the 3SG cell via the Elsewhere entry, the rest via their
+    specific entries. -/
+theorem spellout_matches_paradigm :
+    ∀ c ∈ Agreement.Cell.pnCells,
+      spellout setAVocab (cellBundle c) (some .v) = setAExponent.realize c ∧
+      spellout setBVocab (cellBundle c) (some .T) = setBExponent.realize c := by
+  decide
+
+/-! ### Two-probe relativized probing ([bejar-rezac-2003], applied per §4.4) -/
 
 /-- Probe-resolution rank for a Kaqchikel person-number cell under the
-    two-probe (π⁰ ≫ #⁰) system. Computed via `probeResolutionRank`
+    two-probe (π⁰ before #⁰) system. Computed via `probeResolutionRank`
     on the cell's person + number features. NOT a salience scale —
-    see module docstring. -/
+    `afAgreementTarget_eq_twoProbe` derives it from the probes. -/
 def afRank (c : Agreement.Cell) : Nat :=
   probeResolutionRank c.toPerson c.isPlural
 
 /-- Person restriction ([preminger-2014] (25)): at most one core
-    argument can bear [+participant]. Derives from the Person
-    Licensing Condition (PLC, [bejar-rezac-2003]; cf.
-    [preminger-2014] §4.4 (75)): a [+participant] argument
-    requires an Agree relation with π⁰ to be licensed. Two
-    [+participant] arguments compete for π⁰'s single Agree relation;
-    only one can be licensed; the derivation crashes if both occur.
-    This is the syntactic licensing story, not the morphological
-    clitic-slot competition. -/
+    argument can bear [+participant]. The empirical generalization;
+    it DERIVES from the Person Licensing Condition — see
+    `personRestrictionOk_iff_plc`. This is the syntactic licensing
+    story, not the morphological clitic-slot competition. -/
 def PersonRestrictionOk (subj obj : Agreement.Cell) : Prop :=
   ¬(IsParticipant subj ∧ IsParticipant obj)
 
-instance (subj obj : Agreement.Cell) : Decidable (PersonRestrictionOk subj obj) :=
-  inferInstanceAs (Decidable (¬(IsParticipant subj ∧ IsParticipant obj)))
+instance : DecidableRel PersonRestrictionOk := fun subj obj =>
+  inferInstanceAs (Decidable ¬(IsParticipant subj ∧ IsParticipant obj))
+
+/-- The person restriction derives from the PLC ([bejar-rezac-2003];
+    [preminger-2014] §4.4 (75)): with the AF clause's agent and
+    patient as π⁰'s goal tokens, the PLC holds iff at most one bears
+    [+participant]. A [+participant] argument requires an Agree
+    relation with π⁰ to be licensed; π⁰'s single search licenses at
+    most one token (`allLicensed_iff`), so two [+participant]
+    arguments cannot both be licensed and the derivation crashes. -/
+theorem personRestrictionOk_iff_plc (s o : Agreement.Cell) :
+    PersonRestrictionOk s o ↔
+      PLC Prod.snd ([(.A, s), (.P, o)] : List (ArgPosition × Agreement.Cell)) := by
+  unfold PersonRestrictionOk PLC
+  rw [allLicensed_iff]
+  constructor
+  · intro h a ha b hb hva hvb
+    rcases List.mem_pair.mp ha with rfl | rfl <;>
+      rcases List.mem_pair.mp hb with rfl | rfl
+    · rfl
+    · exact absurd ⟨hva, hvb⟩ h
+    · exact absurd ⟨hvb, hva⟩ h
+    · rfl
+  · rintro h ⟨hs, ho⟩
+    exact nomatch congrArg Prod.fst
+      (h (.A, s) (.head _) (.P, o) (.tail _ (.head _)) hs ho)
 
 /-- Compute the AF agreement target: the higher-ranked argument under
     the two-probe system. When both have equal rank, the subject is
-    chosen (yielding the same marker either way). Returns `none` if
-    the person restriction is violated. -/
+    chosen (yielding the same marker either way). Returns `none` —
+    the derivation crashes — when the PLC fails on the clause's goal
+    tokens (equivalently, when the surface person restriction is
+    violated: `personRestrictionOk_iff_plc`). -/
 def afAgreementTarget (subj obj : Agreement.Cell) : Option Agreement.Cell :=
-  if PersonRestrictionOk subj obj then
+  if PLC Prod.snd ([(.A, subj), (.P, obj)] : List (ArgPosition × Agreement.Cell)) then
     if afRank subj ≥ afRank obj then some subj else some obj
   else none
 
@@ -191,46 +238,62 @@ def afAgreementTarget (subj obj : Agreement.Cell) : Option Agreement.Cell :=
 def afMarker (subj obj : Agreement.Cell) : Option String :=
   (afAgreementTarget subj obj).bind setBExponent.realize
 
--- ============================================================================
--- § 4: Verification — Grounding in Phi.Geometry
--- ============================================================================
+/-- The DP a relativized probe finds among the two core arguments:
+    `probeSearch` (`Phi/Probing.lean`) specialized to the AF clause's
+    two-goal sequence. (Which argument the probe reaches first is
+    immaterial for the AF marker — see `afMarker_comm`.) -/
+def probeGoal (t : ProbeTarget) (subj obj : Agreement.Cell) : Option Agreement.Cell :=
+  probeSearch (·.visibleTo t) [subj, obj]
 
-/-- Compact grounding check covering the four key cells of
-    feature-decomposition + probe-rank + author-implies-participant.
-    Replaces what would otherwise be ~6 separate single-cell rfl
-    theorems (per-cell-rfl-inflation anti-pattern). -/
-theorem feature_decomposition_correct :
-    -- IsParticipant matches H&R 2002 + B&R 2003 expectations
+/-- The rank comparison inside `afAgreementTarget` is derived, not
+    primitive: on the φ-cell inventory it coincides with genuinely
+    two-probe resolution — π⁰'s goal if any, else #⁰'s, else the
+    default 3SG cell. This discharges formally the claim that
+    `afRank` is a convenience encoding of [bejar-rezac-2003]'s
+    mechanism rather than a salience scale. -/
+theorem afAgreementTarget_eq_twoProbe :
+    ∀ s ∈ Agreement.Cell.pnCells, ∀ o ∈ Agreement.Cell.pnCells,
+      afAgreementTarget s o =
+        if PersonRestrictionOk s o then
+          (probeGoal .participant s o <|> probeGoal .plural s o <|>
+            some (.pn .third .Sing))
+        else none := by
+  decide
+
+/-! ### Verification: grounding in `Phi.Geometry` -/
+
+/-- Smoke check: feature decomposition and probe ranks on the key
+    cells match the [harley-ritter-2002] + [bejar-rezac-2003]
+    expectations — [+participant] → rank 2, [+plural, −participant]
+    → rank 1, 3SG → rank 0. -/
+theorem feature_decomposition_cells :
     IsParticipant (.pn .first .Sing) ∧
     IsParticipant (.pn .second .Sing) ∧
     ¬IsParticipant (.pn .third .Sing) ∧
     ¬IsParticipant (.pn .third .Plur) ∧
-    -- author entails participant (H&R 2002 containment)
-    (∀ c ∈ Agreement.Cell.pnCells, IsAuthor c → IsParticipant c) ∧
-    -- two-probe ranks: [+participant] → 2, [+plural,−participant] → 1, 3SG → 0
     afRank (.pn .first .Sing) = 2 ∧ afRank (.pn .second .Sing) = 2 ∧
     afRank (.pn .third .Plur) = 1 ∧ afRank (.pn .third .Sing) = 0 := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, rfl, rfl, rfl, rfl⟩
-  all_goals decide
+  decide
 
--- ============================================================================
--- § 5: Verification — AF Paradigm ([preminger-2014] table (22))
--- ============================================================================
+/-! ### Verification: AF paradigm ([preminger-2014] table (22)) -/
 
-/-- The full AF paradigm (table 22) is correctly predicted: each
+/-- The full AF paradigm (table (22)) is correctly predicted: each
     empirical datum in the fragment's `afParadigm` matches `afMarker`. -/
 theorem af_paradigm_correct :
-    afParadigm.all (λ d => afMarker d.subject d.object == d.marker) = true := by
+    ∀ d ∈ afParadigm, afMarker d.subject d.object = d.marker := by
   decide
 
 /-- AF agreement is commutative: swapping subject and object yields
-    the same marker for ALL person-number combinations
-    ([preminger-2014] §3.3, (67)). Falls out of two-probe
-    relativized probing — the probes see both arguments
-    symmetrically. -/
-theorem af_commutative :
-    Agreement.Cell.pnCells.all (λ s => Agreement.Cell.pnCells.all (λ o =>
-      afMarker s o == afMarker o s)) = true := by
+    the same marker (empirical statement: §3.2, table (22), which
+    pools subject/object φ as unordered sets; derived as a prediction
+    of the clitic-doubling account in §4.4, representative pair
+    (67a–b)). Of the 36 ordered pairs, the 11 unordered cells of
+    table (22) are empirical; pairs of two participants are
+    unattestable for independent binding-theoretic reasons and are
+    vacuously symmetric (both orders yield `none`). -/
+theorem afMarker_comm :
+    ∀ s ∈ Agreement.Cell.pnCells, ∀ o ∈ Agreement.Cell.pnCells,
+      afMarker s o = afMarker o s := by
   decide
 
 /-- π⁰ output suppresses #⁰ when both have a target: when one
@@ -241,36 +304,68 @@ theorem participant_over_plural :
     afMarker (.pn .third .Plur) (.pn .second .Sing) = some "at-" :=
   ⟨rfl, rfl⟩
 
-/-- PLC violation: two [+participant] arguments are blocked. Default
-    3SG: when both arguments are 3SG, both probes fail to find a
-    target and the Elsewhere entry (∅) surfaces — the empirical
-    signature of obligatory-but-failure-tolerant Agree
-    ([preminger-2014] Ch. 5). -/
+/-- PLC violation: two [+participant] arguments are blocked, in
+    either order. Both arguments 3SG: both probes fail to find a
+    target and the default ∅ surfaces (see
+    `failed_agree_tolerated` for the Ch. 5 reading). -/
 theorem restriction_and_default :
     afMarker (.pn .first .Sing) (.pn .second .Sing) = none ∧
     afMarker (.pn .second .Sing) (.pn .first .Sing) = none ∧
     afMarker (.pn .third .Sing) (.pn .third .Sing) = some "∅" :=
   ⟨rfl, rfl, rfl⟩
 
-/-- Person restriction is symmetric on the cells. -/
-theorem person_restriction_symmetric (s o : Agreement.Cell) :
-    PersonRestrictionOk s o ↔ PersonRestrictionOk o s := by
-  unfold PersonRestrictionOk
-  exact ⟨fun h ⟨h₁, h₂⟩ => h ⟨h₂, h₁⟩, fun h ⟨h₁, h₂⟩ => h ⟨h₂, h₁⟩⟩
+/-- The person restriction is symmetric. -/
+theorem personRestrictionOk_comm (s o : Agreement.Cell) :
+    PersonRestrictionOk s o ↔ PersonRestrictionOk o s :=
+  not_congr and_comm
 
--- ============================================================================
--- § 6: Verification — Ch 7 Anti-Hierarchy Arguments (3 of 5)
--- ============================================================================
+/-! ### Obligatory operations ([preminger-2014] Ch. 5) -/
 
-/-- [preminger-2014] Ch 7 arg 3 (p. 125): a salience hierarchy
-    `[+participant] > [+plural] > default` predicts symmetric
-    blocking — if 1+2 (two participants) is bad, then 3pl+3pl (two
-    plurals) should also be bad by the same logic. The data shows
-    1+2 IS blocked (PLC violation) but 3pl+3pl is FINE. The
-    two-probe + PLC analysis derives this asymmetry: π⁰ targets
-    [participant] under PLC (single Agree relation → restriction);
-    #⁰ targets [plural] without a parallel licensing condition (no
-    competition for 3pl+3pl). -/
+/-- π⁰'s outcome on the AF clause's goal pair: each probe is
+    independently obligatory ([preminger-2014] Ch. 5). -/
+def piOutcome (subj obj : Agreement.Cell) : ProbeOutcome :=
+  searchOutcome (·.visibleTo .participant) [subj, obj]
+
+/-- #⁰'s outcome on the AF clause's goal pair. -/
+def numOutcome (subj obj : Agreement.Cell) : ProbeOutcome :=
+  searchOutcome (·.visibleTo .plural) [subj, obj]
+
+/-- Joint outcome of the AF probes: `unvalued` only when both probes
+    fail (i.e., both arguments are 3SG). -/
+def afProbeOutcome (subj obj : Agreement.Cell) : ProbeOutcome :=
+  match piOutcome subj obj, numOutcome subj obj with
+  | .unvalued, .unvalued => .unvalued
+  | _, _ => .valued
+
+/-- Failed Agree is tolerated, not crashing ([preminger-2014] Ch. 5):
+    when both probes find no goal (3SG × 3SG), each probe ends
+    unvalued, the derivation converges under the
+    obligatory-operations model, PF realizes the Elsewhere entry, and
+    the observed marker is ∅ — recovered by Vocabulary insertion from
+    the unvalued (empty) bundle. Contrast the PLC case in
+    `restriction_and_default`: failed *licensing* crashes (`none`);
+    failed *Agree* does not. -/
+theorem failed_agree_tolerated :
+    piOutcome (.pn .third .Sing) (.pn .third .Sing) = .unvalued ∧
+    numOutcome (.pn .third .Sing) (.pn .third .Sing) = .unvalued ∧
+    afProbeOutcome (.pn .third .Sing) (.pn .third .Sing) = .unvalued ∧
+    derivationConverges .obligatoryNocrash
+      (afProbeOutcome (.pn .third .Sing) (.pn .third .Sing)) = true ∧
+    (afProbeOutcome (.pn .third .Sing) (.pn .third .Sing)).pfRealization
+      = .elsewhere ∧
+    spellout setBVocab [] (some .T) = some "∅" ∧
+    afMarker (.pn .third .Sing) (.pn .third .Sing) = some "∅" := by
+  decide
+
+/-! ### Verification: Ch. 7 anti-hierarchy arguments (3 of 5) -/
+
+/-- [preminger-2014] Ch. 7 arg 3: a salience hierarchy
+    `[+participant] > [+plural] > default` is silent on co-occurrence
+    — nothing about it explains why two 1st/2nd-person arguments
+    cannot co-occur while two 3rd plurals can. The two-probe + PLC
+    analysis derives both: π⁰ targets [participant] under the PLC
+    (single Agree relation → restriction); #⁰ targets [plural] with
+    no parallel licensing condition (no competition for 3PL + 3PL). -/
 theorem ch7_arg3_participant_vs_plural_asymmetry :
     -- 1+2 is blocked (PLC violation)
     afMarker (.pn .first .Sing) (.pn .second .Sing) = none ∧
@@ -278,30 +373,26 @@ theorem ch7_arg3_participant_vs_plural_asymmetry :
     afMarker (.pn .third .Plur) (.pn .third .Plur) = some "e-" :=
   ⟨rfl, rfl⟩
 
-/-- [preminger-2014] Ch 7 arg 4 smoke-check (p. 125–126,
-    table (148), eq. (149)): 1st/2nd ABS markers stand in the
-    relation `<agreement marker> = <strong pronoun> – <initial
-    approximant>` (e.g., 1sg `i(n)-` from *yïn*, 1pl `oj-` from
-    *röj*). 3rd-person markers don't have this property — pointing
-    to clitic doubling for 1st/2nd vs direct exponence for 3rd.
+/-- [preminger-2014] Ch. 7 arg 4 smoke check (§3.4, table (148),
+    relation (149)): 1st/2nd ABS markers stand in the relation
+    `<agreement marker> = <strong pronoun> − <initial approximant>`
+    (e.g., 1sg `i(n)-` from *yïn*, 1pl `oj-` from *röj*; the
+    observation traces to Kaufman 1977). 3rd-person markers lack
+    this property — pointing to clitic doubling for 1st/2nd vs.
+    direct exponence for 3rd.
 
-    UNVERIFIED: this theorem only checks that 1st/2nd and 3rd ABS
-    markers are *distinct in form*, which is necessary but not
-    sufficient for arg 4. The genuine eq.-(149) relation requires
-    strong-pronoun forms (yïn, rat, röj, rïx, rja', rje') which the
-    fragment does not currently carry. A faithful arg-4 theorem
-    awaits extending the fragment with strong pronouns and a
-    suffix-stripping bridge function. -/
-theorem ch7_arg4_form_distinctness_smoke_check :
-    setBExponent.realize (.pn .first .Sing) = some "in-" ∧
-    setBExponent.realize (.pn .second .Sing) = some "at-" ∧
-    setBExponent.realize (.pn .first .Plur) = some "oj-" ∧
-    setBExponent.realize (.pn .second .Plur) = some "ix-" ∧
-    setBExponent.realize (.pn .third .Plur) = some "e-" ∧
-    setBExponent.realize (.pn .first .Sing) ≠ setBExponent.realize (.pn .third .Plur) ∧
-    setBExponent.realize (.pn .second .Sing) ≠ setBExponent.realize (.pn .third .Plur) ∧
-    setBExponent.realize (.pn .first .Plur) ≠ setBExponent.realize (.pn .third .Plur) ∧
-    setBExponent.realize (.pn .second .Plur) ≠ setBExponent.realize (.pn .third .Plur) :=
-  ⟨rfl, rfl, rfl, rfl, rfl, by decide, by decide, by decide, by decide⟩
+    UNVERIFIED: this theorem only checks that 1st/2nd ABS markers
+    are *distinct in form* from the 3rd-person ones, which is
+    necessary but not sufficient for arg 4. The genuine
+    relation (149) requires strong-pronoun forms (yïn, rat, röj,
+    rïx, rja', rje') which the fragment does not currently carry.
+    A faithful arg-4 theorem awaits extending the fragment with
+    strong pronouns and a suffix-stripping bridge function. -/
+theorem ch7_arg4_form_distinctness :
+    ∀ c ∈ [Agreement.Cell.pn .first .Sing, .pn .second .Sing,
+           .pn .first .Plur, .pn .second .Plur],
+      setBExponent.realize c ≠ setBExponent.realize (.pn .third .Plur) ∧
+      setBExponent.realize c ≠ setBExponent.realize (.pn .third .Sing) := by
+  decide
 
 end Preminger2014

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -2,6 +2,7 @@ import Linglib.Syntax.Case.Dependent
 import Linglib.Syntax.Case.Alignment
 import Linglib.Syntax.Minimalist.Voice
 import Linglib.Syntax.Minimalist.Agree
+import Linglib.Syntax.Minimalist.Phi.Probing
 import Linglib.Syntax.Minimalist.ObligatoryOperations
 import Linglib.Morphology.DM.VocabSimple
 import Linglib.Morphology.DM.Impoverishment
@@ -176,15 +177,11 @@ open Agreement
     person × number → string tables; here they are parameterized by
     `FeatureBundle` and `Cat` for use with `spellout`. -/
 
-/-- PhiFeature list per Mam person-number cell. -/
-def mamToPhiFeatures (c : Agreement.Cell) : List PhiFeature :=
-  [.person c.toPerson, .number (if c.isPlural then .plural else .singular)]
-
 /-- Set A (ERG) vocabulary entries: φ-features on Voice (.v)
     yield the morphological exponent ([scott-2023] Table 2.8).
     All six cells have specific entries. -/
 def setAVocab : Vocabulary :=
-  makePersonVocab Agreement.Cell.pnCells mamToPhiFeatures
+  makePersonVocab Agreement.Cell.pnCells Agreement.Cell.toPhiFeatures
     (fun c => (setAExponent.realize c).getD "") (some .v)
 
 /-- Set B (ABS) vocabulary entries: φ-features on Infl (.T)
@@ -194,7 +191,7 @@ def setAVocab : Vocabulary :=
     (no features, tz'=) which surfaces when no specific entry
     matches — also catching the blocked-Infl-probe case in transitives. -/
 def setBVocab : Vocabulary :=
-  makePersonVocab setBSpecificCells mamToPhiFeatures
+  makePersonVocab setBSpecificCells Agreement.Cell.toPhiFeatures
     (fun c => (setBExponent.realize c).getD "") (some .T) ++
     [{ features := [], exponent := defaultSetB, context := some .T }]
 
@@ -349,7 +346,9 @@ theorem setB_transitive_ignores_object :
     This mechanism replaces the older
     "closest-goal intervention" account: it is NOT that the agent
     intervenes between Infl and the object, but that the probe is
-    STOPPED by the VoiceP phase boundary. -/
+    halted by head-encounter satisfaction at transitive Voice
+    ([deal-2024]-style [SAT: φ or Voice_TR]; see the derived probe
+    table below for the search-level statement). -/
 theorem probe_restriction_yields_default :
     -- Transitive: probe blocked → empty → Elsewhere
     spellout setBVocab ([] : FeatureBundle) (some .T) = some "tz'=" ∧
@@ -543,6 +542,163 @@ theorem satisfaction_matches_fragment :
   refine ⟨?_, ?_⟩
   · constructor <;> intro h <;> first | (native_decide) | trivial
   · exact ⟨fun _ => trivial, fun _ => by native_decide⟩
+
+/-! ### Deriving the probe table from relativized search (`Phi/Probing.lean`)
+
+The `agreeProbe` table stipulates which head agrees with which
+position. Here it is DERIVED: each probe runs `probeSearch` over the
+goal sequence of its clause, relativized to its satisfaction
+condition. `.P => none` falls out of Voice_TR halting Infl's search
+before any DP (`infl_truncated_at_voiceTR`) plus Voice's own search
+stopping at the closer agent (`voice_finds_A`). The stipulation moves
+from the conclusion (the table) to independently motivated premises:
+`mamInflSatisfaction` (`Agree.lean`) and the clause spine's encounter
+order (Infl > Voice_TR > A > P). The goal lists are stipulated
+linearizations per clause type, not computed from a `SyntacticObject`
+— the tree-geometric derivation exists in `Agree.lean` but is
+`native_decide`-bound; this level matches `Probing.lean`'s altitude. -/
+
+/-- An element a probe encounters while walking its search domain:
+    the argument position it realizes (`none` for non-DP heads like
+    Voice_TR), its feature bundle, and its head category (`none` for
+    DP goals). The `(FeatureBundle, Option Cat)` pair is exactly the
+    argument signature of `SatisfactionCond.isSatisfied`. -/
+structure Encounter where
+  pos : Option ArgPosition
+  feats : FeatureBundle
+  cat : Option Cat
+
+/-- Visibility of an encounter to a probe with satisfaction condition
+    `cond`: the encounter halts the search ([deal-2024] interaction). -/
+def halts (cond : SatisfactionCond) (e : Encounter) : Bool :=
+  cond.isSatisfied e.feats e.cat
+
+/-- The argument position a probe φ-agrees with: run `probeSearch`
+    relativized to the satisfaction condition; the probe agrees with
+    the found element only if satisfaction copied features (feature
+    match, not head encounter). -/
+def agreesWith (cond : SatisfactionCond) (goals : List Encounter) :
+    Option ArgPosition :=
+  (probeSearch (halts cond) goals).bind
+    (fun e => if cond.copiedFeatures e.feats e.cat then e.pos else none)
+
+/-- Transitive Voice as an encounter: a head of category `.v`, no
+    φ-features visible to the probe. -/
+def voiceTR : Encounter := ⟨none, [], some .v⟩
+
+/-- A DP goal realizing position `p` with φ-bundle `φ`. -/
+def dpGoal (p : ArgPosition) (φ : FeatureBundle) : Encounter := ⟨some p, φ, none⟩
+
+/-- Voice's probe: standard φ feature-match (no head-encounter disjunct). -/
+def voiceSat : SatisfactionCond := .featureMatch (.phi (.person .third))
+
+/-- A probe over an empty search space agrees with nothing. -/
+theorem agreesWith_nil (cond : SatisfactionCond) :
+    agreesWith cond [] = none := rfl
+
+/-- Voice's goal sequence in the clause containing position `p`:
+    Voice probes only in transitives; the agent is closest. -/
+def voiceGoals (φA φP : FeatureBundle) : ArgPosition → List Encounter
+  | .A | .P => [dpGoal .A φA, dpGoal .P φP]
+  | _ => []
+
+/-- Infl's goal sequence in the clause containing position `p`. In a
+    transitive clause Infl c-commands VoiceP, so the FIRST element its
+    downward search encounters is the Voice_TR head, before either DP.
+    In an intransitive there is no transitive Voice; the search reaches
+    S directly. -/
+def inflGoals (φA φP φS : FeatureBundle) : ArgPosition → List Encounter
+  | .A | .P => [voiceTR, dpGoal .A φA, dpGoal .P φP]
+  | .S => [dpGoal .S φS]
+  | .R | .T => []
+
+/-- **The key derivation**: Infl's search over ANY transitive goal
+    sequence (Voice_TR first) yields no agreement target — by `rfl`,
+    for arbitrary material below Voice. The search halts at Voice_TR
+    (head encounter satisfies), no features are copied, so no DP is
+    agreed with. -/
+theorem infl_truncated_at_voiceTR (rest : List Encounter) :
+    agreesWith mamInflSatisfaction (voiceTR :: rest) = none := rfl
+
+/-- In an intransitive, Infl's search finds S and copies its features,
+    provided S bears person. -/
+theorem infl_finds_S (φS : FeatureBundle)
+    (hS : hasValuedFeature φS (.phi (.person .third)) = true) :
+    agreesWith mamInflSatisfaction [dpGoal .S φS] = some .S := by
+  have h1 : halts mamInflSatisfaction ⟨some .S, φS, none⟩ = true := by
+    simp [halts, mamInflSatisfaction_isSatisfied, hS]
+  simp [agreesWith, probeSearch, dpGoal, h1, mamInflSatisfaction_copiedFeatures, hS]
+
+/-- Voice's search finds the agent (closest goal), provided A bears
+    person. -/
+theorem voice_finds_A (φA φP : FeatureBundle)
+    (hA : hasValuedFeature φA (.phi (.person .third)) = true) :
+    agreesWith voiceSat [dpGoal .A φA, dpGoal .P φP] = some .A := by
+  have h1 : halts (.featureMatch (.phi (.person .third)))
+      ⟨some .A, φA, none⟩ = true := by
+    simp [halts, SatisfactionCond.isSatisfied, hA]
+  simp [agreesWith, probeSearch, dpGoal, voiceSat, h1,
+    SatisfactionCond.copiedFeatures, hA]
+
+/-- DERIVED probe table: which head φ-agrees with position `p`,
+    computed by running each probe's `probeSearch` over the goal
+    sequence of the clause containing `p`. -/
+def derivedAgreeProbe (φA φP φS : FeatureBundle) (p : ArgPosition) :
+    Option Cat :=
+  if agreesWith voiceSat (voiceGoals φA φP p) = some p then some .v
+  else if agreesWith mamInflSatisfaction (inflGoals φA φP φS p) = some p
+    then some .T
+  else none
+
+/-- The stipulated table coincides with the derivation, for any clause
+    whose A and S bear person features. -/
+theorem agreeProbe_eq_derived (φA φP φS : FeatureBundle)
+    (hA : hasValuedFeature φA (.phi (.person .third)) = true)
+    (hS : hasValuedFeature φS (.phi (.person .third)) = true) :
+    ∀ p, agreeProbe p = derivedAgreeProbe φA φP φS p := by
+  intro p
+  cases p with
+  | A => simp [agreeProbe, derivedAgreeProbe, voiceGoals,
+      voice_finds_A φA φP hA]
+  | P => simp [agreeProbe, derivedAgreeProbe, voiceGoals, inflGoals,
+      voice_finds_A φA φP hA, infl_truncated_at_voiceTR]
+  | S => simp [agreeProbe, derivedAgreeProbe, voiceGoals, inflGoals,
+      infl_finds_S φS hS, agreesWith_nil]
+  | R => rfl
+  | T => rfl
+
+/-- Concrete instantiation (3SG transitive + 3SG intransitive),
+    kernel-checked end to end. -/
+theorem agreeProbe_eq_derived_3sg :
+    ∀ p, agreeProbe p = derivedAgreeProbe dp3sg dp3sg dp3sg p := by
+  intro p; cases p <;> rfl
+
+/-- φ-valuation outcome of a probe with a satisfaction condition:
+    valued iff the search found a goal AND satisfaction copied
+    features. NOTE: this is NOT `searchOutcome (halts cond)` — a
+    head-encounter halt satisfies the search but leaves the probe
+    φ-unvalued. -/
+def valuationOutcome (cond : SatisfactionCond) (goals : List Encounter) :
+    ProbeOutcome :=
+  if (agreesWith cond goals).isSome then .valued else .unvalued
+
+/-- Transitive Infl: search halts at Voice_TR, probe stays unvalued,
+    and converges with Elsewhere morphology — the §11 facts, now
+    derived from the goal sequence rather than from a stipulated
+    empty bundle. -/
+theorem transitive_unvalued_elsewhere (rest : List Encounter) :
+    valuationOutcome mamInflSatisfaction (voiceTR :: rest) = .unvalued ∧
+    (valuationOutcome mamInflSatisfaction (voiceTR :: rest)).pfRealization
+      = .elsewhere := ⟨rfl, rfl⟩
+
+/-- Contrast: `searchOutcome` relativized to the satisfaction condition
+    reports `.valued` in the transitive — the search DID find a halting
+    element. The valuation/satisfaction distinction is exactly
+    [deal-2024]'s interaction-vs-satisfaction split. -/
+theorem searchOutcome_valued_but_unvalued (rest : List Encounter) :
+    searchOutcome (halts mamInflSatisfaction) (voiceTR :: rest) = .valued ∧
+    valuationOutcome mamInflSatisfaction (voiceTR :: rest) = .unvalued :=
+  ⟨rfl, rfl⟩
 
 -- The former §13 (Unified Agree — bridging Scott 2023's φ-Agree pipeline
 -- with Elkins-Torrence-Brown 2026's oblique-Agree pipeline) violated the

--- a/Linglib/Syntax/Minimalist/Agree.lean
+++ b/Linglib/Syntax/Minimalist/Agree.lean
@@ -624,4 +624,20 @@ theorem mam_intransitive_copies :
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
       none = true := by rfl
 
+/-- Infl's satisfaction condition, unfolded: φ-match or Voice_TR encounter. -/
+theorem mamInflSatisfaction_isSatisfied (fb : FeatureBundle) (ctx : Option Cat) :
+    mamInflSatisfaction.isSatisfied fb ctx
+      = (hasValuedFeature fb (.phi (.person .third)) || ctx == some Cat.v) := by
+  simp [mamInflSatisfaction, SatisfactionCond.isSatisfied, atomicSatisfied]
+
+/-- Head-encounter satisfaction never copies: Infl copies features iff
+    they are there to copy, whatever the context. -/
+theorem mamInflSatisfaction_copiedFeatures (fb : FeatureBundle) (ctx : Option Cat) :
+    mamInflSatisfaction.copiedFeatures fb ctx
+      = hasValuedFeature fb (.phi (.person .third)) := by
+  cases hv : hasValuedFeature fb (.phi (.person .third)) <;>
+    cases hc : ctx == some Cat.v <;>
+      simp [mamInflSatisfaction, SatisfactionCond.copiedFeatures, atomicSatisfied,
+        List.find?, hv, hc]
+
 end Minimalist

--- a/Linglib/Syntax/Minimalist/CyclicAgree.lean
+++ b/Linglib/Syntax/Minimalist/CyclicAgree.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Minimalist.Phi.Geometry
+import Linglib.Syntax.Minimalist.Phi.Probing
 
 /-!
 # Cyclic Agree [bejar-rezac-2009]
@@ -326,6 +327,105 @@ theorem plc_violation_iff_inverse (geom : Geometry) (probe : ProbeArticulation)
     eaIsLicensed geom probe ea ia = false ↔
     isInverseContext geom probe ea ia = true := by
   simp [eaIsLicensed, isInverseContext]
+
+/-! ### Grounding in relativized search (`Phi/Probing.lean`)
+
+An articulated probe is a *family* of flat relativized searches, one
+per segment, over the cyclically ordered token list: B&R's segments
+match independently, so cyclic expansion at the whole-probe level is
+first-visible-goal search at the per-segment level. The residue-based
+definitions above remain definitional — they are the paper's
+mechanism; the factorization is a *result* about it. -/
+
+/-- The two arguments as φ-bearing goal tokens, in cyclic search order:
+    the IA precedes the EA (cycle I before cycle II). -/
+def goalTokens (ea ia : Person) : List (Controller × Person) :=
+  [(.ia, ia), (.ea, ea)]
+
+/-- Visibility of an argument token to a probe segment `s`: the
+    argument's person specification bears `s` (feature-relativized
+    locality). -/
+def segVisible (geom : Geometry) (s : Segment) (t : Controller × Person) : Bool :=
+  (personSpec geom t.2).contains s
+
+/-- The goal a single probe segment Agrees with: the first argument in
+    cyclic order whose specification bears the segment — a flat
+    relativized `probeSearch`. -/
+def segmentGoal (geom : Geometry) (ea ia : Person) (s : Segment) :
+    Option (Controller × Person) :=
+  probeSearch (segVisible geom s) (goalTokens ea ia)
+
+/-- A segment finds the EA token iff the IA bypasses it (leaving it as
+    active residue) and the EA bears it — cycle-II Agree. -/
+theorem segmentGoal_eq_ea_iff (geom : Geometry) (ea ia : Person) (s : Segment) :
+    segmentGoal geom ea ia s = some (.ea, ea) ↔
+      (personSpec geom ia).contains s = false ∧
+      (personSpec geom ea).contains s = true := by
+  simp only [segmentGoal, probeSearch, goalTokens, segVisible, List.find?]
+  cases h1 : (personSpec geom ia).contains s <;>
+    cases h2 : (personSpec geom ea).contains s <;> simp
+
+/-- A segment finds the IA token iff the IA bears it — cycle-I Agree. -/
+theorem segmentGoal_eq_ia_iff (geom : Geometry) (ea ia : Person) (s : Segment) :
+    segmentGoal geom ea ia s = some (.ia, ia) ↔
+      (personSpec geom ia).contains s = true := by
+  simp only [segmentGoal, probeSearch, goalTokens, segVisible, List.find?]
+  cases h1 : (personSpec geom ia).contains s <;>
+    cases h2 : (personSpec geom ea).contains s <;> simp
+
+/-- Existential characterization of the residue-based `eaAgrees`. -/
+theorem eaAgrees_iff_exists (geom : Geometry) (probe : ProbeArticulation)
+    (ea ia : Person) :
+    eaAgrees geom probe ea ia = true ↔
+      ∃ s ∈ probe, (personSpec geom ia).contains s = false ∧
+        (personSpec geom ea).contains s = true := by
+  simp only [eaAgrees, activeResidue, decide_eq_true_eq,
+    List.length_filter_lt_length_iff_exists, List.mem_filter]
+  constructor
+  · rintro ⟨s, ⟨hs, hia⟩, hea⟩
+    exact ⟨s, hs, by simpa using hia, by simpa using hea⟩
+  · rintro ⟨s, hs, hia, hea⟩
+    exact ⟨s, ⟨hs, by simpa using hia⟩, by simpa using hea⟩
+
+/-- **Main bridge**: the EA is person-licensed (`eaIsLicensed`) iff some
+    probe segment's flat relativized search (`Probing.Licensed`) over
+    the cyclically ordered token list finds the EA token. -/
+theorem eaIsLicensed_iff_segment_licensed (geom : Geometry)
+    (probe : ProbeArticulation) (ea ia : Person) :
+    eaIsLicensed geom probe ea ia = true ↔
+      ∃ s ∈ probe, Licensed (segVisible geom s) (goalTokens ea ia) (.ea, ea) := by
+  rw [eaIsLicensed, eaAgrees_iff_exists]
+  exact exists_congr fun s => and_congr_right fun _ =>
+    (segmentGoal_eq_ea_iff geom ea ia s).symm
+
+/-- PLC violation ↔ no segment's search licenses the EA token — the
+    inverse-context characterization restated through the search
+    substrate. -/
+theorem plc_violation_iff_no_segment_licensed (geom : Geometry)
+    (probe : ProbeArticulation) (ea ia : Person) :
+    isInverseContext geom probe ea ia = true ↔
+      ∀ s ∈ probe, ¬ Licensed (segVisible geom s) (goalTokens ea ia) (.ea, ea) := by
+  rw [← plc_violation_iff_inverse, Bool.eq_false_iff, Ne,
+    eaIsLicensed_iff_segment_licensed]
+  simp only [not_exists, not_and]
+
+/-- Cycle decomposition through the search: cycle-I segments are those
+    whose search finds the IA token; cycle-II segments those whose
+    search finds the EA token. Second-cycle effects also factor through
+    `probeSearch`. -/
+theorem cycleSegments_eq_segmentGoal_filters (geom : Geometry)
+    (probe : ProbeArticulation) (ea ia : Person) :
+    cycleSegments geom probe ea ia =
+      (probe.filter (fun s => segmentGoal geom ea ia s == some (.ia, ia)),
+       probe.filter (fun s => segmentGoal geom ea ia s == some (.ea, ea))) := by
+  simp only [cycleSegments, activeResidue, List.filter_filter, Prod.mk.injEq]
+  refine ⟨?_, ?_⟩
+  · exact List.filter_congr fun s _ => by
+      rw [Bool.eq_iff_iff, beq_iff_eq, segmentGoal_eq_ia_iff]
+  · exact List.filter_congr fun s _ => by
+      rw [Bool.eq_iff_iff, beq_iff_eq, segmentGoal_eq_ea_iff]
+      cases h1 : (personSpec geom ia).contains s <;>
+        cases h2 : (personSpec geom ea).contains s <;> simp_all
 
 -- ============================================================================
 -- § 10: Repair Strategies

--- a/Linglib/Syntax/Minimalist/Phi/Geometry.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Geometry.lean
@@ -145,7 +145,8 @@ def decomposePerson : Person → DecomposedPerson
     - **π⁰** seeks [participant]: targets 1st/2nd person DPs
     - **#⁰** seeks [plural]: targets plural DPs
 
-    π⁰ structurally outranks #⁰ (person probing > number probing). -/
+    π⁰ is merged below #⁰ and probes first — person-before-number
+    probing, inherited from [bejar-rezac-2003]. -/
 inductive ProbeTarget where
   /-- π⁰: person probe, seeks [participant]. -/
   | participant
@@ -176,10 +177,11 @@ def probeVisible (target : ProbeTarget) (person : Person) (isPlural : Bool) : Bo
     - Rank 0: invisible to both probes (3SG default)
 
     Derived from the probing mechanism ([bejar-rezac-2003]),
-    not stipulated as a salience scale: π⁰ takes priority over #⁰
-    by virtue of being structurally higher and earlier in the
-    derivation, and each probe targets any DP bearing the sought
-    feature. The rank captures the combined effect on a single DP.
+    not stipulated as a salience scale: π⁰ is merged below #⁰ and
+    probes earlier in the derivation, its clitic output beats other
+    exponence in the single morphological slot, and each probe
+    targets any DP bearing the sought feature. The rank captures
+    the combined effect on a single DP.
     See module docstring for why this is a convenience encoding,
     not an endorsement of the salience-scale analyses
     [preminger-2014] Ch. 7 argues against. -/

--- a/Linglib/Syntax/Minimalist/Phi/Probing.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Probing.lean
@@ -1,0 +1,192 @@
+import Linglib.Syntax.Agreement.Paradigm
+import Linglib.Syntax.Minimalist.Phi.Geometry
+import Linglib.Syntax.Minimalist.ObligatoryOperations
+
+/-!
+# Relativized probing over a goal sequence
+[bejar-rezac-2003] [preminger-2014]
+
+The derivational middle layer between DP-level probe visibility
+(`probeVisible`, `Phi/Geometry.lean`) and PF-level outcomes
+(`ProbeOutcome`, `ObligatoryOperations.lean`): a relativized probe
+walks an ordered goal sequence, skips invisible goals, and returns
+the first visible one. Licensing is being the goal found — from
+which the Person Licensing Condition's effects derive: one search
+licenses at most one goal (`allLicensed_iff`).
+
+The search is stated for any goal type `α` with a `Bool` visibility
+predicate; the φ-instantiation (`Agreement.Cell.visibleTo`, `PLC`)
+specializes it to [bejar-rezac-2003]'s person probe. The same
+search relativized to other features yields [halpert-2012]'s Zulu
+augment probing — the cross-linguistic point of [preminger-2014]
+Ch. 7. [bejar-rezac-2009]'s articulated probe is a *family* of
+these searches, one per probe segment over the cyclically ordered
+token list — see `CyclicAgree.eaIsLicensed_iff_segment_licensed`.
+For probe *horizons* (what terminates search across domains, Keine)
+see `Syntax/Minimalist/Probe.lean`; for conditional feature-acquiring
+re-probing see `Syntax/Minimalist/Probing/DefectiveCircumvention.lean`.
+
+## Main declarations
+
+- `probeSearch` — first goal visible to the probe, in structural order.
+- `searchOutcome` — the `ProbeOutcome` of an obligatory probing operation.
+- `Licensed`, `AllLicensed` — licensing as being found by the search.
+- `allLicensed_iff` — all visible goals licensed ↔ visible goals subsingleton.
+- `PLC` — the Person Licensing Condition over φ-bearing goal tokens.
+-/
+
+namespace Minimalist
+
+/-! ### Relativized search -/
+
+section Search
+
+variable {α : Type*}
+
+/-- The goal a relativized probe finds in an ordered goal sequence:
+    the first goal visible to it, skipping invisible ones
+    ([bejar-rezac-2003] relativized probing). -/
+def probeSearch (vis : α → Bool) (goals : List α) : Option α :=
+  goals.find? vis
+
+variable {vis : α → Bool} {goals : List α}
+
+/-- A probe finds nothing iff no goal is visible to it. -/
+@[simp]
+theorem probeSearch_eq_none_iff :
+    probeSearch vis goals = none ↔ ∀ a ∈ goals, vis a = false := by
+  simp [probeSearch, List.find?_eq_none]
+
+/-- The found goal is a member of the sequence. -/
+theorem mem_of_probeSearch_eq_some {a : α}
+    (h : probeSearch vis goals = some a) : a ∈ goals :=
+  List.mem_of_find?_eq_some h
+
+/-- The found goal is visible to the probe. -/
+theorem visible_of_probeSearch_eq_some {a : α}
+    (h : probeSearch vis goals = some a) : vis a = true :=
+  List.find?_some h
+
+end Search
+
+/-! ### Probe outcomes ([preminger-2014] Ch. 5) -/
+
+section Outcome
+
+variable {α : Type*}
+
+/-- The outcome of an obligatory probing operation over a goal
+    sequence: `valued` iff the search finds a goal. -/
+def searchOutcome (vis : α → Bool) (goals : List α) : ProbeOutcome :=
+  if (probeSearch vis goals).isSome then .valued else .unvalued
+
+variable {vis : α → Bool} {goals : List α}
+
+/-- The probe is valued iff the search finds a goal. -/
+theorem searchOutcome_eq_valued_iff_isSome :
+    searchOutcome vis goals = .valued ↔ (probeSearch vis goals).isSome := by
+  rw [searchOutcome]
+  cases (probeSearch vis goals).isSome <;> decide
+
+/-- The probe ends unvalued iff the search comes back empty. -/
+theorem searchOutcome_eq_unvalued_iff_eq_none :
+    searchOutcome vis goals = .unvalued ↔ probeSearch vis goals = none := by
+  rw [searchOutcome]
+  cases probeSearch vis goals <;>
+    simp only [Option.isSome_none, Option.isSome_some, Bool.false_eq_true,
+      if_false, if_true, reduceCtorEq]
+
+/-- The probe is valued iff some goal is visible to it. -/
+@[simp]
+theorem searchOutcome_eq_valued_iff :
+    searchOutcome vis goals = .valued ↔ ∃ a ∈ goals, vis a = true :=
+  searchOutcome_eq_valued_iff_isSome.trans List.find?_isSome
+
+/-- The probe ends unvalued iff no goal is visible to it. -/
+@[simp]
+theorem searchOutcome_eq_unvalued_iff :
+    searchOutcome vis goals = .unvalued ↔ ∀ a ∈ goals, vis a = false := by
+  rw [searchOutcome_eq_unvalued_iff_eq_none]
+  exact probeSearch_eq_none_iff
+
+end Outcome
+
+/-! ### Licensing -/
+
+section Licensing
+
+variable {α : Type*}
+
+/-- A goal is licensed by a probe iff the probe's single search
+    reaches it ([bejar-rezac-2003]: licensing is an Agree relation
+    with the probe). -/
+def Licensed (vis : α → Bool) (goals : List α) (a : α) : Prop :=
+  probeSearch vis goals = some a
+
+instance [DecidableEq α] (vis : α → Bool) (goals : List α) (a : α) :
+    Decidable (Licensed vis goals a) :=
+  inferInstanceAs (Decidable (probeSearch vis goals = some a))
+
+variable {vis : α → Bool} {goals : List α}
+
+/-- One search licenses at most one goal. -/
+theorem Licensed.unique {a b : α}
+    (ha : Licensed vis goals a) (hb : Licensed vis goals b) : a = b :=
+  Option.some.inj (ha.symm.trans hb)
+
+/-- Every goal visible to the probe is licensed by it — the shape of
+    a licensing condition over one probe's search. -/
+def AllLicensed (vis : α → Bool) (goals : List α) : Prop :=
+  ∀ a ∈ goals, vis a = true → Licensed vis goals a
+
+instance [DecidableEq α] (vis : α → Bool) (goals : List α) :
+    Decidable (AllLicensed vis goals) :=
+  inferInstanceAs (Decidable (∀ a ∈ goals, vis a = true → Licensed vis goals a))
+
+/-- All visible goals are licensed iff the visible goals are
+    subsingleton: one search, one Agree relation, at most one
+    licensee. The general fact behind person-restriction effects
+    ([bejar-rezac-2003]'s PCC, [preminger-2014]'s AF restriction). -/
+theorem allLicensed_iff :
+    AllLicensed vis goals ↔
+      ∀ a ∈ goals, ∀ b ∈ goals, vis a = true → vis b = true → a = b := by
+  constructor
+  · intro h a ha b hb hva hvb
+    exact (h a ha hva).unique (h b hb hvb)
+  · intro h a ha hva
+    obtain ⟨b, hb⟩ := Option.isSome_iff_exists.mp
+      (List.find?_isSome.mpr ⟨a, ha, hva⟩)
+    have hba := h b (mem_of_probeSearch_eq_some hb) a ha
+      (visible_of_probeSearch_eq_some hb) hva
+    exact hba ▸ hb
+
+/-- `allLicensed_iff` in `Set.Subsingleton` form, for mathlib-API
+    discoverability. -/
+theorem allLicensed_iff_subsingleton :
+    AllLicensed vis goals ↔ {a | a ∈ goals ∧ vis a = true}.Subsingleton := by
+  rw [allLicensed_iff]
+  exact ⟨fun h a ha b hb => h a ha.1 b hb.1 ha.2 hb.2,
+         fun h a ha b hb hva hvb => h ⟨ha, hva⟩ ⟨hb, hvb⟩⟩
+
+end Licensing
+
+/-! ### φ-probes -/
+
+/-- Visibility of a φ-cell to a relativized probe: the cell bears the
+    feature the probe seeks (`probeVisible`, `Phi/Geometry.lean`). -/
+def _root_.Agreement.Cell.visibleTo (c : Agreement.Cell) (t : ProbeTarget) : Bool :=
+  probeVisible t c.toPerson c.isPlural
+
+/-- The Person Licensing Condition ([bejar-rezac-2003];
+    [preminger-2014] (40)/(75)): every [participant]-bearing goal
+    token must be licensed by the person probe's search. Goal tokens
+    have type `α` with a φ-cell projection, so two arguments with
+    identical φ remain distinct licensees. -/
+def PLC {α : Type*} (cellOf : α → Agreement.Cell) (goals : List α) : Prop :=
+  AllLicensed (λ a => (cellOf a).visibleTo .participant) goals
+
+instance {α : Type*} [DecidableEq α] (cellOf : α → Agreement.Cell) (goals : List α) :
+    Decidable (PLC cellOf goals) :=
+  inferInstanceAs (Decidable (AllLicensed _ goals))
+
+end Minimalist

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -30190,6 +30190,22 @@
   sources   = {Phenomena/Phonology/Studies/SandeClemDabkowski2026.lean}
 }
 
+% REF: Nevins (2011). Multiple agree with clitics: person complementarity
+% vs. omnivorous number. NLLT 29:939-971. Verified against the Preminger
+% 2014 monograph bibliography (incl. DOI).
+@article{nevins-2011,
+  author    = {Nevins, Andrew},
+  year      = {2011},
+  title     = {Multiple agree with clitics: person complementarity vs.\ omnivorous number},
+  journal   = {Natural Language \& Linguistic Theory},
+  volume    = {29},
+  pages     = {939--971},
+  doi       = {10.1007/s11049-011-9150-4},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/Preminger2014.lean}
+}
+
 % REF: Nevins (2010). Locality in vowel harmony. MIT Press.
 @book{nevins-2010,
   author    = {Nevins, Andrew},


### PR DESCRIPTION
Adds `Phi/Probing.lean` — the search-and-licensing layer between DP-level probe visibility and PF-level outcomes — and wires its consumers.

- `probeSearch`/`Licensed`/`allLicensed_iff` + token-typed `PLC`; Preminger2014's person restriction now derives from the PLC (`personRestrictionOk_iff_plc`), and `afAgreementTarget` guards on it directly.
- B&R 2009's articulated probe factors into per-segment flat searches (`CyclicAgree.eaIsLicensed_iff_segment_licensed`); Scott2023's `agreeProbe` table is derived from satisfaction-relativized search (`infl_truncated_at_voiceTR`).
- Preminger2014 audit against the monograph: docstring corrections (omnivorous agreement, B&R-inherited probe ordering, Ch. 7 arg framing), DM Set B Elsewhere wiring, `Agreement.Cell.toPhiFeatures` graduated to VocabSimple.