### PR TITLE
feat(Studies/Halpert2012): Zulu L⁰ via probing substrate; Ch.7 arg 5

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1589,6 +1589,7 @@ import Linglib.Studies.ZwickyPullum1983
 import Linglib.Studies.KalinBjorkmanEtAl2026
 import Linglib.Studies.Baker1985
 import Linglib.Studies.HalleMarantz1993
+import Linglib.Studies.Halpert2012
 import Linglib.Studies.McNallyDeSwart2011
 import Linglib.Studies.BickelNichols2013
 import Linglib.Studies.AckermanMalouf2013

--- a/Linglib/Studies/Halpert2012.lean
+++ b/Linglib/Studies/Halpert2012.lean
@@ -1,0 +1,147 @@
+import Linglib.Syntax.Minimalist.Phi.Probing
+
+/-!
+# Halpert 2012 — Argument Licensing and Agreement in Zulu [halpert-2012]
+
+[halpert-2012] (MIT dissertation): the familiar structural licensers
+(T⁰, v⁰, P⁰) are not licensers in Zulu; instead a Licensing head L⁰
+above vP licenses the highest element within vP, and the **augment**
+vowel on a nominal is itself an intrinsic case licenser. Augmentless
+nominals therefore need L⁰: they must be vP-internal, structurally
+highest there, and at most one occurs per simplex clause. The
+**conjoint/disjoint** alternation on the verb (present tense:
+conjoint ∅- vs. disjoint *ya-*) is the morphological spellout of L⁰
+itself (her ch. 4): "the disjoint appears when L fails to find a
+goal", and "the derivation converges even if a probe fails to find a
+goal" — failure-tolerance, adopted by [preminger-2014] Ch. 6 as the
+second case study in tolerated failed agreement.
+
+Formalized through `Phi/Probing.lean`: L⁰ is the **indiscriminate**
+instance of `probeSearch` (`vis = ⊤`, so bare minimality delivers
+`List.head?`; augmented nominals intervene, her Chomsky-2000-style
+intervention), and the licensing condition is the off-diagonal
+`AllLicensed needs ⊤` with `needs` = augmentless. Contrast Kichean
+([preminger-2014] Ch. 4): the diagonal case, π⁰ relativized to
+exactly the needy, hence omnivorous and position-insensitive.
+
+Scope: simplex clauses only — the dissertation's second licensing
+route (V⁰ together with specifier-taking CAUS/APPL heads, licensing
+one additional augmentless nominal; her LP schemas in ch. 3) is not
+modeled.
+-/
+
+namespace Halpert2012
+
+open Minimalist
+
+/-- A vP-internal nominal: noun class + augment status. Class numbers
+    follow the standard Bantu numbering Halpert uses (1 *muntu*
+    'person', 5 *qanda* 'egg', ...). -/
+structure Nominal where
+  nounClass : Nat
+  augmented : Bool
+  deriving DecidableEq, Repr
+
+/-- Does a nominal need licensing by L⁰? Augmentless nominals do; the
+    augment is an intrinsic case licenser, so augmented nominals
+    don't (while still intervening for L⁰). -/
+def needsL (n : Nominal) : Bool := !n.augmented
+
+/-- L⁰'s goal in a vP: an indiscriminate `probeSearch` — every
+    element is visible, so bare minimality delivers the structurally
+    highest one. -/
+def lGoal (vp : List Nominal) : Option Nominal :=
+  probeSearch (fun _ => true) vp
+
+/-- The licensing condition on a simplex vP: every augmentless
+    nominal is licensed by L⁰'s single search. -/
+def LicensingOk (vp : List Nominal) : Prop :=
+  AllLicensed needsL (fun _ => true) vp
+
+instance (vp : List Nominal) : Decidable (LicensingOk vp) :=
+  inferInstanceAs (Decidable (AllLicensed needsL (fun _ => true) vp))
+
+/-- L⁰'s probing outcome: valued iff the vP has any overt content. -/
+def lOutcome (vp : List Nominal) : ProbeOutcome :=
+  searchOutcome (fun _ => true) vp
+
+/-- The conjoint/disjoint marker (present tense) as the spellout of
+    L⁰: conjoint ∅- when L⁰ found a goal, disjoint *ya-* when it
+    failed. A marked pattern — the overt member realizes FAILED
+    valuation ([preminger-2014] Ch. 6 notes the parallel with English
+    non-past -Ø vs. *-z*). -/
+def lSpellout (vp : List Nominal) : String :=
+  match (lOutcome vp).pfRealization with
+  | .agreement => "∅-"
+  | .elsewhere => "ya-"
+
+/-! ### The conjoint/disjoint distribution -/
+
+/-- Disjoint iff vP is empty: the conjoint requires overt postverbal
+    material — L⁰'s indiscriminate search is sensitive even to
+    non-arguments, which is the learner's evidence that L⁰ is
+    unrelativized ([preminger-2014] Ch. 7's locative-modifier
+    point). -/
+theorem disjoint_iff_empty (vp : List Nominal) :
+    lSpellout vp = "ya-" ↔ vp = [] := by
+  cases vp with
+  | nil => exact ⟨fun _ => rfl, fun _ => rfl⟩
+  | cons a t =>
+    have hne : ("∅-" : String) ≠ "ya-" := by decide
+    exact ⟨fun h => absurd h hne, fun h => nomatch h⟩
+
+/-! ### Licensing: highest-only and at-most-one -/
+
+/-- An augmentless nominal is licensed iff it is the structurally
+    highest element of its vP — her ch. 3: L "licenses the highest
+    element in vP". Instance of `allLicensed_const_true_iff`. -/
+theorem licensingOk_iff_highest (vp : List Nominal) :
+    LicensingOk vp ↔
+      ∀ n ∈ vp, needsL n = true → vp.head? = some n :=
+  allLicensed_const_true_iff
+
+/-- At most one augmentless nominal per simplex vP (her transitive
+    and intransitive LP schemas): L⁰'s single Agree relation licenses
+    at most one goal. -/
+theorem at_most_one_augmentless {vp : List Nominal} (h : LicensingOk vp) :
+    ∀ n ∈ vp, ∀ m ∈ vp, needsL n = true → needsL m = true → n = m :=
+  fun n hn m hm hn' hm' => (h n hn hn').unique (h m hm hm')
+
+/-! ### The negative-existential VS(O) paradigm -/
+
+/-- The augmentless distribution in negative existentials (her ch. 3
+    paradigm; reproduced as [preminger-2014] (128)): an augmentless
+    nominal is fine alone or above an augmented object; blocked in
+    pairs (single Agree relation) and below an augmented subject
+    (intervention). Tokens: *muntu* '1person', *qanda* '5egg'. -/
+theorem augmentless_distribution :
+    -- ✔ VS with augmentless S
+    LicensingOk [⟨1, false⟩] ∧
+    -- ✔ VSO: augmentless S over augmented O
+    LicensingOk [⟨1, false⟩, ⟨5, true⟩] ∧
+    -- ✗ VSO: two augmentless nominals
+    ¬ LicensingOk [⟨1, false⟩, ⟨5, false⟩] ∧
+    -- ✗ VSO: augmentless O below augmented S
+    ¬ LicensingOk [⟨1, true⟩, ⟨5, false⟩] := by
+  decide
+
+/-! ### Tolerated failed agreement -/
+
+/-- Failure-tolerance, in her own terms ("the derivation converges
+    even if a probe fails to find a goal"; "when L fails to find a
+    goal, the derivation records this failure in the morphological
+    spell-out"): an empty vP leaves L⁰ unvalued, the derivation
+    converges under the obligatory-operations model, and PF realizes
+    the failure as the overt disjoint *ya-*. With any goal — even a
+    licensing-indifferent augmented one — L⁰ is valued and the
+    conjoint ∅- surfaces. -/
+theorem failed_agree_spells_disjoint :
+    lOutcome [] = .unvalued ∧
+    derivationConverges .obligatoryNocrash (lOutcome []) = true ∧
+    (lOutcome []).pfRealization = .elsewhere ∧
+    lSpellout [] = "ya-" ∧
+    lOutcome [⟨5, true⟩] = .valued ∧
+    lSpellout [⟨5, true⟩] = "∅-" := by
+  decide
+
+end Halpert2012

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -3,6 +3,7 @@ import Linglib.Syntax.Minimalist.Phi.Probing
 import Linglib.Syntax.Minimalist.ObligatoryOperations
 import Linglib.Morphology.DM.VocabSimple
 import Linglib.Fragments.Mayan.Kaqchikel.Agreement
+import Linglib.Studies.Halpert2012
 
 /-!
 # Preminger 2014 — Agreement and Its Failures [preminger-2014]
@@ -94,7 +95,7 @@ gives five arguments against hierarchy accounts:
 5. **Zulu parallel** (§7.2): [halpert-2012]'s analysis of Zulu
    augmentless nominals uses the same machinery over
    augmented/augmentless — categories with no plausible "salience"
-   reading (prose only — needs a Zulu fragment).
+   reading (`ch7_arg5_zulu_parallel`, via `Studies/Halpert2012.lean`).
 
 ## Cross-references
 
@@ -412,6 +413,32 @@ theorem ch7_arg4_form_distinctness :
            .pn .first .Plur, .pn .second .Plur],
       setBExponent.realize c ≠ setBExponent.realize (.pn .third .Plur) ∧
       setBExponent.realize c ≠ setBExponent.realize (.pn .third .Sing) := by
+  decide
+
+/-- [preminger-2014] Ch. 7 arg 5 (§7.2, via Ch. 6): [halpert-2012]'s
+    Zulu runs the same search-and-licensing substrate over a
+    salience-irrelevant contrast. Kichean is the diagonal instance
+    (`AllLicensed vis vis`: π⁰ relativized to exactly the
+    licensing-needy [participant] cells), so a needy argument is
+    licensed even from object position — the probe skips non-bearers.
+    Zulu's L⁰ is the off-diagonal instance (`AllLicensed needs ⊤`:
+    indiscriminate probe, augmentless = needy), so an augmented
+    subject intervenes and a lower augmentless nominal goes
+    unlicensed. Same machinery, opposite skippability — and no
+    salience reading of augmented/augmentless is available, which
+    undermines the cognitive-salience grounding of hierarchy
+    accounts. Both systems realize failed probing as default
+    morphology (Kichean covert ∅, Zulu overt *ya-*). -/
+theorem ch7_arg5_zulu_parallel :
+    -- Kichean: π⁰ skips a 3SG subject and licenses a 1SG object
+    PLC Prod.snd ([(.A, .pn .third .Sing), (.P, .pn .first .Sing)] :
+      List (ArgPosition × Agreement.Cell)) ∧
+    -- Zulu: an augmented subject intervenes; the augmentless object
+    -- is unlicensed
+    ¬ Halpert2012.LicensingOk [⟨1, true⟩, ⟨5, false⟩] ∧
+    -- both probes' failures converge with default morphology
+    afMarker (.pn .third .Sing) (.pn .third .Sing) = some "∅" ∧
+    Halpert2012.lSpellout [] = "ya-" := by
   decide
 
 end Preminger2014

--- a/Linglib/Syntax/Minimalist/Phi/Probing.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Probing.lean
@@ -16,10 +16,11 @@ licenses at most one goal (`allLicensed_iff`).
 
 The search is stated for any goal type `α` with a `Bool` visibility
 predicate; the φ-instantiation (`Agreement.Cell.visibleTo`, `PLC`)
-specializes it to [bejar-rezac-2003]'s person probe. The same
-search relativized to other features yields [halpert-2012]'s Zulu
-augment probing — the cross-linguistic point of [preminger-2014]
-Ch. 7. [bejar-rezac-2009]'s articulated probe is a *family* of
+specializes it to [bejar-rezac-2003]'s person probe. The
+*unrelativized* instance (`vis = ⊤`, bare minimality: the goal is
+`List.head?`) is [halpert-2012]'s Zulu L⁰ — see
+`Studies/Halpert2012.lean` and the cross-linguistic point of
+[preminger-2014] Ch. 7. [bejar-rezac-2009]'s articulated probe is a *family* of
 these searches, one per probe segment over the cyclically ordered
 token list — see `CyclicAgree.eaIsLicensed_iff_segment_licensed`.
 For probe *horizons* (what terminates search across domains, Keine)
@@ -136,21 +137,35 @@ theorem Licensed.unique {a b : α}
     (ha : Licensed vis goals a) (hb : Licensed vis goals b) : a = b :=
   Option.some.inj (ha.symm.trans hb)
 
-/-- Every goal visible to the probe is licensed by it — the shape of
-    a licensing condition over one probe's search. -/
-def AllLicensed (vis : α → Bool) (goals : List α) : Prop :=
-  ∀ a ∈ goals, vis a = true → Licensed vis goals a
+/-- Licensing by an unrelativized probe (`vis = ⊤`) is being the
+    structurally closest goal — bare minimality, [halpert-2012]'s
+    indiscriminate L⁰. -/
+theorem licensed_const_true_iff {a : α} :
+    Licensed (fun _ => true) goals a ↔ goals.head? = some a := by
+  unfold Licensed probeSearch
+  cases goals <;> simp
 
-instance [DecidableEq α] (vis : α → Bool) (goals : List α) :
-    Decidable (AllLicensed vis goals) :=
-  inferInstanceAs (Decidable (∀ a ∈ goals, vis a = true → Licensed vis goals a))
+/-- Every goal that needs licensing is licensed by the probe's
+    search. Which goals *need* licensing (`needs`) and which the
+    probe *sees* (`vis`) come apart in general: [halpert-2012]'s Zulu
+    L⁰ sees every goal (augmented nominals intervene) while only
+    augmentless nominals need it. Feature-relativized probes are the
+    diagonal `AllLicensed vis vis` — the probe sees exactly the needy
+    ([bejar-rezac-2003]'s π⁰). -/
+def AllLicensed (needs vis : α → Bool) (goals : List α) : Prop :=
+  ∀ a ∈ goals, needs a = true → Licensed vis goals a
 
-/-- All visible goals are licensed iff the visible goals are
-    subsingleton: one search, one Agree relation, at most one
-    licensee. The general fact behind person-restriction effects
-    ([bejar-rezac-2003]'s PCC, [preminger-2014]'s AF restriction). -/
+instance [DecidableEq α] (needs vis : α → Bool) (goals : List α) :
+    Decidable (AllLicensed needs vis goals) :=
+  inferInstanceAs (Decidable (∀ a ∈ goals, needs a = true → Licensed vis goals a))
+
+/-- On the diagonal (probe relativized to exactly the needy), all
+    needy goals are licensed iff the visible goals are subsingleton:
+    one search, one Agree relation, at most one licensee. The general
+    fact behind person-restriction effects ([bejar-rezac-2003]'s PCC,
+    [preminger-2014]'s AF restriction). -/
 theorem allLicensed_iff :
-    AllLicensed vis goals ↔
+    AllLicensed vis vis goals ↔
       ∀ a ∈ goals, ∀ b ∈ goals, vis a = true → vis b = true → a = b := by
   constructor
   · intro h a ha b hb hva hvb
@@ -165,10 +180,20 @@ theorem allLicensed_iff :
 /-- `allLicensed_iff` in `Set.Subsingleton` form, for mathlib-API
     discoverability. -/
 theorem allLicensed_iff_subsingleton :
-    AllLicensed vis goals ↔ {a | a ∈ goals ∧ vis a = true}.Subsingleton := by
+    AllLicensed vis vis goals ↔ {a | a ∈ goals ∧ vis a = true}.Subsingleton := by
   rw [allLicensed_iff]
   exact ⟨fun h a ha b hb => h a ha.1 b hb.1 ha.2 hb.2,
          fun h a ha b hb hva hvb => h ⟨ha, hva⟩ ⟨hb, hvb⟩⟩
+
+/-- Off the diagonal, licensing by an unrelativized probe pins every
+    needy goal to the head of the sequence — the highest-element
+    condition ([halpert-2012]: an augmentless nominal must be the
+    highest nominal in its vP). -/
+theorem allLicensed_const_true_iff {needs : α → Bool} :
+    AllLicensed needs (fun _ => true) goals ↔
+      ∀ a ∈ goals, needs a = true → goals.head? = some a :=
+  forall_congr' fun _ => imp_congr_right fun _ => imp_congr_right fun _ =>
+    licensed_const_true_iff
 
 end Licensing
 
@@ -230,10 +255,11 @@ def _root_.Agreement.Cell.visibleTo (c : Agreement.Cell) (t : ProbeTarget) : Boo
     have type `α` with a φ-cell projection, so two arguments with
     identical φ remain distinct licensees. -/
 def PLC {α : Type*} (cellOf : α → Agreement.Cell) (goals : List α) : Prop :=
-  AllLicensed (λ a => (cellOf a).visibleTo .participant) goals
+  AllLicensed (λ a => (cellOf a).visibleTo .participant)
+    (λ a => (cellOf a).visibleTo .participant) goals
 
 instance {α : Type*} [DecidableEq α] (cellOf : α → Agreement.Cell) (goals : List α) :
     Decidable (PLC cellOf goals) :=
-  inferInstanceAs (Decidable (AllLicensed _ goals))
+  inferInstanceAs (Decidable (AllLicensed _ _ goals))
 
 end Minimalist


### PR DESCRIPTION
Formalizes Halpert 2012's Zulu argument licensing as the unrelativized instance of `probeSearch`, turning Preminger Ch. 7's fifth anti-hierarchy argument from prose into a theorem.

- `AllLicensed` generalizes to `(needs, vis)` — who needs licensing and what the probe sees come apart: Zulu's indiscriminate L⁰ is the off-diagonal (`vis = ⊤`, bare minimality = `List.head?`, augmented nominals intervene), Kichean's relativized π⁰ the diagonal.
- `Studies/Halpert2012.lean` (verified against the dissertation): conjoint/disjoint as L⁰'s spellout (disjoint *ya-* = failed Agree, converging), highest-only and at-most-one augmentless derived, negative-existential VS(O) paradigm checked.
- `Preminger2014.ch7_arg5_zulu_parallel`: same machinery, opposite skippability, salience-irrelevant categories.