### PR TITLE
style(Data/Examples): canonical JSON format via gen_examples --fmt

### DIFF
--- a/Linglib/Data/Examples/Abusch1997.json
+++ b/Linglib/Data/Examples/Abusch1997.json
@@ -4,7 +4,10 @@
     "source": {"bibkey": "abusch-1997", "paperLabel": "(1)"},
     "language": "stan1293",
     "primaryText": "The defendant was actually watching the Simpsons at the time of the crime. According to the testimony of the first eye-witness, the jurors clearly believed that he was in the laboratory building.",
-    "discourseSegments": ["The defendant was actually watching the Simpsons at the time of the crime.", "According to the testimony of the first eye-witness, the jurors clearly believed that he was in the laboratory building."],
+    "discourseSegments": [
+      "The defendant was actually watching the Simpsons at the time of the crime.",
+      "According to the testimony of the first eye-witness, the jurors clearly believed that he was in the laboratory building."
+    ],
     "glossedTokens": [],
     "translation": "The defendant was actually watching the Simpsons at the time of the crime. According to the testimony of the first eye-witness, the jurors clearly believed that he was in the laboratory building.",
     "context": "Past-shifted (backward-shifted) reading: the embedded `was` (in 'he was in the laboratory') is anaphoric to the time of the crime introduced in the first sentence. Time of the defendant being in the laboratory precedes the jurors' believing time. Abusch's diagnostic for the Independent Theory's anaphoric account of embedded past tense.",
@@ -30,7 +33,7 @@
     "alternatives": [],
     "readings": [
       {"name": "simultaneous (raining at believing time)", "judgment": "acceptable"},
-      {"name": "past-shifted (raining before believing)",  "judgment": "acceptable"}
+      {"name": "past-shifted (raining before believing)", "judgment": "acceptable"}
     ],
     "comment": "Abusch 1997 ex (2), p. 3. Footnote 2 attributes the simultaneous-reading shape to Enç 1987 (cited as 'Eng 1987'). Standard past-under-past minimal example.",
     "metaLanguage": "stan1293",
@@ -41,15 +44,18 @@
     "source": {"bibkey": "abusch-1997", "paperLabel": "(3)"},
     "language": "stan1293",
     "primaryText": "John found an ostrich in his apartment yesterday. Just before he opened the door, he thought that a burglar attacked him.",
-    "discourseSegments": ["John found an ostrich in his apartment yesterday.", "Just before he opened the door, he thought that a burglar attacked him."],
+    "discourseSegments": [
+      "John found an ostrich in his apartment yesterday.",
+      "Just before he opened the door, he thought that a burglar attacked him."
+    ],
     "glossedTokens": [],
     "translation": "John found an ostrich in his apartment yesterday. Just before he opened the door, he thought that a burglar attacked him.",
     "context": "Upper Limit Constraint (ULC) foil. The Independent Theory would predict a forward-shifted reading (the attack co-temporal with the later opening, hence after the thinking) via anaphora to the previous sentence's time of opening, paraphrasable as 'When I open the door, a burglar will attack me'. This reading is UNAVAILABLE: embedded past cannot denote a time later than the matrix event. Motivates the §7 ULC.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "past-shifted (attack before thinking)",                                       "judgment": "acceptable"},
-      {"name": "forward-shifted (attack co-temporal with later opening, after thinking)",   "judgment": "ungrammatical"}
+      {"name": "past-shifted (attack before thinking)", "judgment": "acceptable"},
+      {"name": "forward-shifted (attack co-temporal with later opening, after thinking)", "judgment": "ungrammatical"}
     ],
     "comment": "Abusch 1997 ex (3), p. 4. The decisive counterexample to the pure Independent Theory: the predicted forward-shifted reading (paraphrased by ex (4) 'When I open the door, a burglar will attack me') is unavailable. Motivates the Upper Limit Constraint: embedded R cannot exceed matrix E.",
     "metaLanguage": "stan1293",

--- a/Linglib/Data/Examples/AghaJeretic2022.json
+++ b/Linglib/Data/Examples/AghaJeretic2022.json
@@ -1,43 +1,14 @@
 [
   {
     "id": "aghajeretic2022_should_pos_all",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(8)-(9) modal homogeneity"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(8)-(9) modal homogeneity"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "According to the rules, you should go.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "According",
-        "according"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "rules",
-        "rule.PL"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "should",
-        "should"
-      ],
-      [
-        "go",
-        "go"
-      ]
+      ["According", "according"], ["to", "to"], ["the", "DEF"], ["rules", "rule.PL"],
+      ["you", "2SG"], ["should", "should"], ["go", "go"]
     ],
     "translation": "According to the rules, you should go.",
     "context": "All best deontic worlds are go-worlds.",
@@ -45,18 +16,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "positive"
-      ],
-      [
-        "condition",
-        "ALL"
-      ],
-      [
-        "modal",
-        "should"
-      ]
+      ["polarity", "positive"],
+      ["condition", "ALL"],
+      ["modal", "should"]
     ],
     "comment": "UNVERIFIED paperLabel: example numbers carried from prior Lean file (Studies/AghaJeretic2022.lean shouldHomogeneity docstring), not checked against PDF. Migrated from shouldHomogeneity (positiveInAll = clearlyTrue): judged clearly true when all best worlds satisfy the prejacent.",
     "metaLanguage": "stan1293",
@@ -64,43 +26,14 @@
   },
   {
     "id": "aghajeretic2022_should_pos_none",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(8)-(9) modal homogeneity"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(8)-(9) modal homogeneity"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "According to the rules, you should go.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "According",
-        "according"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "rules",
-        "rule.PL"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "should",
-        "should"
-      ],
-      [
-        "go",
-        "go"
-      ]
+      ["According", "according"], ["to", "to"], ["the", "DEF"], ["rules", "rule.PL"],
+      ["you", "2SG"], ["should", "should"], ["go", "go"]
     ],
     "translation": "According to the rules, you should go.",
     "context": "No best deontic worlds are go-worlds.",
@@ -108,18 +41,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "positive"
-      ],
-      [
-        "condition",
-        "NONE"
-      ],
-      [
-        "modal",
-        "should"
-      ]
+      ["polarity", "positive"],
+      ["condition", "NONE"],
+      ["modal", "should"]
     ],
     "comment": "UNVERIFIED paperLabel: example numbers carried from prior Lean file, not checked against PDF. Migrated from shouldHomogeneity (positiveInNone = clearlyFalse): sentence is grammatical and felicitous but judged clearly FALSE when no best world satisfies the prejacent; the 5-level scale has no truth-value slot, so falsity is recorded here.",
     "metaLanguage": "stan1293",
@@ -127,43 +51,14 @@
   },
   {
     "id": "aghajeretic2022_should_pos_gap",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(8)-(9) modal homogeneity"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(8)-(9) modal homogeneity"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "According to the rules, you should go.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "According",
-        "according"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "rules",
-        "rule.PL"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "should",
-        "should"
-      ],
-      [
-        "go",
-        "go"
-      ]
+      ["According", "according"], ["to", "to"], ["the", "DEF"], ["rules", "rule.PL"],
+      ["you", "2SG"], ["should", "should"], ["go", "go"]
     ],
     "translation": "According to the rules, you should go.",
     "context": "Some but not all best deontic worlds are go-worlds.",
@@ -171,22 +66,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "positive"
-      ],
-      [
-        "condition",
-        "GAP"
-      ],
-      [
-        "modal",
-        "should"
-      ],
-      [
-        "gap_detected",
-        "true"
-      ]
+      ["polarity", "positive"],
+      ["condition", "GAP"],
+      ["modal", "should"],
+      ["gap_detected", "true"]
     ],
     "comment": "UNVERIFIED paperLabel: example numbers carried from prior Lean file, not checked against PDF. Migrated from shouldHomogeneity (positiveInGap = neitherTrueNorFalse): modal homogeneity gap — weak necessity, like a plural definite over worlds, is neither clearly true nor clearly false in a mixed domain.",
     "metaLanguage": "stan1293",
@@ -194,43 +77,14 @@
   },
   {
     "id": "aghajeretic2022_should_neg_all",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(8)-(9) modal homogeneity"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(8)-(9) modal homogeneity"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "According to the rules, you shouldn't go.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "According",
-        "according"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "rules",
-        "rule.PL"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "shouldn't",
-        "should.NEG"
-      ],
-      [
-        "go",
-        "go"
-      ]
+      ["According", "according"], ["to", "to"], ["the", "DEF"], ["rules", "rule.PL"],
+      ["you", "2SG"], ["shouldn't", "should.NEG"], ["go", "go"]
     ],
     "translation": "According to the rules, you shouldn't go.",
     "context": "All best deontic worlds are go-worlds.",
@@ -238,18 +92,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "negative"
-      ],
-      [
-        "condition",
-        "ALL"
-      ],
-      [
-        "modal",
-        "should"
-      ]
+      ["polarity", "negative"],
+      ["condition", "ALL"],
+      ["modal", "should"]
     ],
     "comment": "UNVERIFIED paperLabel: example numbers carried from prior Lean file, not checked against PDF. Migrated from shouldHomogeneity (negativeInAll = clearlyFalse): grammatical and felicitous but judged clearly FALSE when all best worlds satisfy the prejacent.",
     "metaLanguage": "stan1293",
@@ -257,43 +102,14 @@
   },
   {
     "id": "aghajeretic2022_should_neg_none",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(8)-(9) modal homogeneity"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(8)-(9) modal homogeneity"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "According to the rules, you shouldn't go.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "According",
-        "according"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "rules",
-        "rule.PL"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "shouldn't",
-        "should.NEG"
-      ],
-      [
-        "go",
-        "go"
-      ]
+      ["According", "according"], ["to", "to"], ["the", "DEF"], ["rules", "rule.PL"],
+      ["you", "2SG"], ["shouldn't", "should.NEG"], ["go", "go"]
     ],
     "translation": "According to the rules, you shouldn't go.",
     "context": "No best deontic worlds are go-worlds.",
@@ -301,18 +117,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "negative"
-      ],
-      [
-        "condition",
-        "NONE"
-      ],
-      [
-        "modal",
-        "should"
-      ]
+      ["polarity", "negative"],
+      ["condition", "NONE"],
+      ["modal", "should"]
     ],
     "comment": "UNVERIFIED paperLabel: example numbers carried from prior Lean file, not checked against PDF. Migrated from shouldHomogeneity (negativeInNone = clearlyTrue): judged clearly true when no best world satisfies the prejacent.",
     "metaLanguage": "stan1293",
@@ -320,43 +127,14 @@
   },
   {
     "id": "aghajeretic2022_should_neg_gap",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(8)-(9) modal homogeneity"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(8)-(9) modal homogeneity"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "According to the rules, you shouldn't go.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "According",
-        "according"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "rules",
-        "rule.PL"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "shouldn't",
-        "should.NEG"
-      ],
-      [
-        "go",
-        "go"
-      ]
+      ["According", "according"], ["to", "to"], ["the", "DEF"], ["rules", "rule.PL"],
+      ["you", "2SG"], ["shouldn't", "should.NEG"], ["go", "go"]
     ],
     "translation": "According to the rules, you shouldn't go.",
     "context": "Some but not all best deontic worlds are go-worlds.",
@@ -364,22 +142,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "negative"
-      ],
-      [
-        "condition",
-        "GAP"
-      ],
-      [
-        "modal",
-        "should"
-      ],
-      [
-        "gap_detected",
-        "true"
-      ]
+      ["polarity", "negative"],
+      ["condition", "GAP"],
+      ["modal", "should"],
+      ["gap_detected", "true"]
     ],
     "comment": "UNVERIFIED paperLabel: example numbers carried from prior Lean file, not checked against PDF. Migrated from shouldHomogeneity (negativeInGap = neitherTrueNorFalse): gap is symmetric under negation. Also carries the domain-restriction critique datum (Lean domainRestrictionFails): the existential followup 'but you are allowed to go' is empirically infelicitous (#) after negated should, contrary to what a bivalent not-all semantics predicts.",
     "metaLanguage": "stan1293",
@@ -387,47 +153,14 @@
   },
   {
     "id": "aghajeretic2022_haveTo_pos_gap",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(9b) strong necessity, no homogeneity"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(9b) strong necessity, no homogeneity"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "According to the rules, you have to go.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "According",
-        "according"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "rules",
-        "rule.PL"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "have",
-        "have"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "go",
-        "go"
-      ]
+      ["According", "according"], ["to", "to"], ["the", "DEF"], ["rules", "rule.PL"],
+      ["you", "2SG"], ["have", "have"], ["to", "to"], ["go", "go"]
     ],
     "translation": "According to the rules, you have to go.",
     "context": "Some but not all best deontic worlds are go-worlds.",
@@ -435,26 +168,11 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "positive"
-      ],
-      [
-        "condition",
-        "GAP"
-      ],
-      [
-        "modal",
-        "haveTo"
-      ],
-      [
-        "gap_detected",
-        "false"
-      ],
-      [
-        "classical_value",
-        "false"
-      ]
+      ["polarity", "positive"],
+      ["condition", "GAP"],
+      ["modal", "haveTo"],
+      ["gap_detected", "false"],
+      ["classical_value", "false"]
     ],
     "comment": "UNVERIFIED paperLabel: example number carried from prior Lean file (haveToNoHomogeneity docstring), not checked against PDF. Migrated from haveToNoHomogeneity (positiveInGap = clearlyFalse): strong necessity is bivalent — grammatical and felicitous but judged clearly FALSE in the mixed domain, no truth-value gap. The ALL and NONE cells of haveToNoHomogeneity are identical to the should rows (clearlyTrue/clearlyFalse) and are not duplicated here.",
     "metaLanguage": "stan1293",
@@ -462,51 +180,14 @@
   },
   {
     "id": "aghajeretic2022_haveTo_neg_gap",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(9b) strong necessity, no homogeneity"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(9b) strong necessity, no homogeneity"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "According to the rules, you don't have to go.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "According",
-        "according"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "rules",
-        "rule.PL"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "don't",
-        "do.NEG"
-      ],
-      [
-        "have",
-        "have"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "go",
-        "go"
-      ]
+      ["According", "according"], ["to", "to"], ["the", "DEF"], ["rules", "rule.PL"],
+      ["you", "2SG"], ["don't", "do.NEG"], ["have", "have"], ["to", "to"], ["go", "go"]
     ],
     "translation": "According to the rules, you don't have to go.",
     "context": "Some but not all best deontic worlds are go-worlds.",
@@ -514,26 +195,11 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "negative"
-      ],
-      [
-        "condition",
-        "GAP"
-      ],
-      [
-        "modal",
-        "haveTo"
-      ],
-      [
-        "gap_detected",
-        "false"
-      ],
-      [
-        "classical_value",
-        "true"
-      ]
+      ["polarity", "negative"],
+      ["condition", "GAP"],
+      ["modal", "haveTo"],
+      ["gap_detected", "false"],
+      ["classical_value", "true"]
     ],
     "comment": "UNVERIFIED paperLabel: example number carried from prior Lean file, not checked against PDF. Migrated from haveToNoHomogeneity (negativeInGap = clearlyTrue): the dominant reading is narrow-scope negation (not-required), judged clearly true in the mixed domain — compatible with the followup 'but you are allowed to go', unlike negated should.",
     "metaLanguage": "stan1293",
@@ -541,75 +207,27 @@
   },
   {
     "id": "aghajeretic2022_necessarily_removes_gap",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(14)-(15) homogeneity removal"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(14)-(15) homogeneity removal"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "According to the rules, you shouldn't necessarily go.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "According",
-        "according"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "rules",
-        "rule.PL"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "shouldn't",
-        "should.NEG"
-      ],
-      [
-        "necessarily",
-        "necessarily"
-      ],
-      [
-        "go",
-        "go"
-      ]
+      ["According", "according"], ["to", "to"], ["the", "DEF"], ["rules", "rule.PL"],
+      ["you", "2SG"], ["shouldn't", "should.NEG"], ["necessarily", "necessarily"], ["go", "go"]
     ],
     "translation": "According to the rules, you shouldn't necessarily go.",
     "context": "Some but not all best worlds are go-worlds.",
     "judgment": "acceptable",
     "alternatives": [
-      {
-        "form": "According to the rules, you shouldn't go.",
-        "judgment": "questionable"
-      }
+      {"form": "According to the rules, you shouldn't go.", "judgment": "questionable"}
     ],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "negative"
-      ],
-      [
-        "condition",
-        "GAP"
-      ],
-      [
-        "modal",
-        "should"
-      ],
-      [
-        "remover",
-        "necessarily"
-      ]
+      ["polarity", "negative"],
+      ["condition", "GAP"],
+      ["modal", "should"],
+      ["remover", "necessarily"]
     ],
     "comment": "UNVERIFIED paperLabel: example numbers carried from prior Lean file (necessarilyRemovesModalHomogeneity docstring), not checked against PDF. Migrated from necessarilyRemovesModalHomogeneity: 'necessarily' removes the gap, paralleling nominal 'all' — the bare variant (alternatives) is neither true nor false in the gap scenario, while the necessarily-variant gets a determinate truth value (Lean preciseJudgment = clearlyFalse; recorded as carried, the determinacy contrast is the migrated claim). Per the Lean section docstring, the necessarily-variant licenses the existential followup 'but you can go' that the bare variant blocks.",
     "metaLanguage": "stan1293",
@@ -617,55 +235,15 @@
   },
   {
     "id": "aghajeretic2022_should_exception_qud1",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(17) exception tolerance"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(17) exception tolerance"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "To get a perfect grade, you should do every exercise.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "To",
-        "to"
-      ],
-      [
-        "get",
-        "get"
-      ],
-      [
-        "a",
-        "INDEF"
-      ],
-      [
-        "perfect",
-        "perfect"
-      ],
-      [
-        "grade",
-        "grade"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "should",
-        "should"
-      ],
-      [
-        "do",
-        "do"
-      ],
-      [
-        "every",
-        "every"
-      ],
-      [
-        "exercise",
-        "exercise"
-      ]
+      ["To", "to"], ["get", "get"], ["a", "INDEF"], ["perfect", "perfect"], ["grade", "grade"],
+      ["you", "2SG"], ["should", "should"], ["do", "do"], ["every", "every"],
+      ["exercise", "exercise"]
     ],
     "translation": "To get a perfect grade, you should do every exercise.",
     "context": "One can get a perfect grade by doing most exercises; doing all gives extra credit. QUD: What is a way to get a perfect grade?",
@@ -673,18 +251,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "positive"
-      ],
-      [
-        "modal",
-        "should"
-      ],
-      [
-        "qud",
-        "way_to_perfect_grade"
-      ]
+      ["polarity", "positive"],
+      ["modal", "should"],
+      ["qud", "way_to_perfect_grade"]
     ],
     "comment": "UNVERIFIED paperLabel: example number carried from prior Lean file (shouldExceptionTolerance docstring), not checked against PDF. Migrated from shouldExceptionTolerance (acceptableUnderQUD1 = true): weak necessity tolerates QUD-irrelevant exceptions.",
     "metaLanguage": "stan1293",
@@ -692,55 +261,15 @@
   },
   {
     "id": "aghajeretic2022_should_exception_qud2",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(17) exception tolerance"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(17) exception tolerance"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "To get a perfect grade, you should do every exercise.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "To",
-        "to"
-      ],
-      [
-        "get",
-        "get"
-      ],
-      [
-        "a",
-        "INDEF"
-      ],
-      [
-        "perfect",
-        "perfect"
-      ],
-      [
-        "grade",
-        "grade"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "should",
-        "should"
-      ],
-      [
-        "do",
-        "do"
-      ],
-      [
-        "every",
-        "every"
-      ],
-      [
-        "exercise",
-        "exercise"
-      ]
+      ["To", "to"], ["get", "get"], ["a", "INDEF"], ["perfect", "perfect"], ["grade", "grade"],
+      ["you", "2SG"], ["should", "should"], ["do", "do"], ["every", "every"],
+      ["exercise", "exercise"]
     ],
     "translation": "To get a perfect grade, you should do every exercise.",
     "context": "One can get a perfect grade by doing most exercises; doing all gives extra credit. QUD: What are the minimal requirements to get a perfect grade?",
@@ -748,18 +277,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "positive"
-      ],
-      [
-        "modal",
-        "should"
-      ],
-      [
-        "qud",
-        "minimal_requirements"
-      ]
+      ["polarity", "positive"],
+      ["modal", "should"],
+      ["qud", "minimal_requirements"]
     ],
     "comment": "UNVERIFIED paperLabel: example number carried from prior Lean file, not checked against PDF. Migrated from shouldExceptionTolerance (acceptableUnderQUD2 = false): when the QUD makes the exceptions relevant, the exception-tolerant use is infelicitous.",
     "metaLanguage": "stan1293",
@@ -767,59 +287,15 @@
   },
   {
     "id": "aghajeretic2022_haveTo_exception_qud1",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(17) exception tolerance"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(17) exception tolerance"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "To get a perfect grade, you have to do every exercise.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "To",
-        "to"
-      ],
-      [
-        "get",
-        "get"
-      ],
-      [
-        "a",
-        "INDEF"
-      ],
-      [
-        "perfect",
-        "perfect"
-      ],
-      [
-        "grade",
-        "grade"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "have",
-        "have"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "do",
-        "do"
-      ],
-      [
-        "every",
-        "every"
-      ],
-      [
-        "exercise",
-        "exercise"
-      ]
+      ["To", "to"], ["get", "get"], ["a", "INDEF"], ["perfect", "perfect"], ["grade", "grade"],
+      ["you", "2SG"], ["have", "have"], ["to", "to"], ["do", "do"], ["every", "every"],
+      ["exercise", "exercise"]
     ],
     "translation": "To get a perfect grade, you have to do every exercise.",
     "context": "One can get a perfect grade by doing most exercises; doing all gives extra credit. QUD: What is a way to get a perfect grade?",
@@ -827,18 +303,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "positive"
-      ],
-      [
-        "modal",
-        "haveTo"
-      ],
-      [
-        "qud",
-        "way_to_perfect_grade"
-      ]
+      ["polarity", "positive"],
+      ["modal", "haveTo"],
+      ["qud", "way_to_perfect_grade"]
     ],
     "comment": "UNVERIFIED paperLabel: example number carried from prior Lean file (haveToExceptionTolerance docstring), not checked against PDF. Migrated from haveToExceptionTolerance (acceptableUnderQUD1 = false): strong necessity does not tolerate exceptions even when QUD-irrelevant.",
     "metaLanguage": "stan1293",
@@ -846,59 +313,15 @@
   },
   {
     "id": "aghajeretic2022_haveTo_exception_qud2",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(17) exception tolerance"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(17) exception tolerance"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "To get a perfect grade, you have to do every exercise.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "To",
-        "to"
-      ],
-      [
-        "get",
-        "get"
-      ],
-      [
-        "a",
-        "INDEF"
-      ],
-      [
-        "perfect",
-        "perfect"
-      ],
-      [
-        "grade",
-        "grade"
-      ],
-      [
-        "you",
-        "2SG"
-      ],
-      [
-        "have",
-        "have"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "do",
-        "do"
-      ],
-      [
-        "every",
-        "every"
-      ],
-      [
-        "exercise",
-        "exercise"
-      ]
+      ["To", "to"], ["get", "get"], ["a", "INDEF"], ["perfect", "perfect"], ["grade", "grade"],
+      ["you", "2SG"], ["have", "have"], ["to", "to"], ["do", "do"], ["every", "every"],
+      ["exercise", "exercise"]
     ],
     "translation": "To get a perfect grade, you have to do every exercise.",
     "context": "One can get a perfect grade by doing most exercises; doing all gives extra credit. QUD: What are the minimal requirements to get a perfect grade?",
@@ -906,18 +329,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "positive"
-      ],
-      [
-        "modal",
-        "haveTo"
-      ],
-      [
-        "qud",
-        "minimal_requirements"
-      ]
+      ["polarity", "positive"],
+      ["modal", "haveTo"],
+      ["qud", "minimal_requirements"]
     ],
     "comment": "UNVERIFIED paperLabel: example number carried from prior Lean file, not checked against PDF. Migrated from haveToExceptionTolerance (acceptableUnderQUD2 = false).",
     "metaLanguage": "stan1293",
@@ -925,63 +339,15 @@
   },
   {
     "id": "aghajeretic2022_should_indet_response",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(19) well-responses to indeterminate sentences"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(19) well-responses to indeterminate sentences"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "You should take the right door to go to the living room.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "You",
-        "2SG"
-      ],
-      [
-        "should",
-        "should"
-      ],
-      [
-        "take",
-        "take"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "right",
-        "right"
-      ],
-      [
-        "door",
-        "door"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "go",
-        "go"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "living",
-        "living"
-      ],
-      [
-        "room",
-        "room"
-      ]
+      ["You", "2SG"], ["should", "should"], ["take", "take"], ["the", "DEF"], ["right", "right"],
+      ["door", "door"], ["to", "to"], ["go", "go"], ["to", "to"], ["the", "DEF"],
+      ["living", "living"], ["room", "room"]
     ],
     "translation": "You should take the right door to go to the living room.",
     "context": "Two doors lead to the living room; both are equally good options.",
@@ -989,18 +355,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "positive"
-      ],
-      [
-        "condition",
-        "GAP"
-      ],
-      [
-        "modal",
-        "should"
-      ]
+      ["polarity", "positive"],
+      ["condition", "GAP"],
+      ["modal", "should"]
     ],
     "comment": "UNVERIFIED paperLabel: example number carried from prior Lean file (shouldIndeterminateResponse docstring), not checked against PDF. Migrated from shouldIndeterminateResponse: borderline (indeterminate) weak-necessity sentence — outright 'No' denial is infelicitous (noResponseFelicitous = false), a 'Well, ...' response is preferred (wellResponseFelicitous = true), paralleling plural definites.",
     "metaLanguage": "stan1293",
@@ -1008,63 +365,15 @@
   },
   {
     "id": "aghajeretic2022_must_indet_response",
-    "source": {
-      "bibkey": "agha-jeretic-2022",
-      "paperLabel": "(19) well-responses to indeterminate sentences"
-    },
+    "source": {"bibkey": "agha-jeretic-2022", "paperLabel": "(19) well-responses to indeterminate sentences"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "You must take the right door to go to the living room.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "You",
-        "2SG"
-      ],
-      [
-        "must",
-        "must"
-      ],
-      [
-        "take",
-        "take"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "right",
-        "right"
-      ],
-      [
-        "door",
-        "door"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "go",
-        "go"
-      ],
-      [
-        "to",
-        "to"
-      ],
-      [
-        "the",
-        "DEF"
-      ],
-      [
-        "living",
-        "living"
-      ],
-      [
-        "room",
-        "room"
-      ]
+      ["You", "2SG"], ["must", "must"], ["take", "take"], ["the", "DEF"], ["right", "right"],
+      ["door", "door"], ["to", "to"], ["go", "go"], ["to", "to"], ["the", "DEF"],
+      ["living", "living"], ["room", "room"]
     ],
     "translation": "You must take the right door to go to the living room.",
     "context": "Two doors lead to the living room; both are equally good options.",
@@ -1072,18 +381,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "polarity",
-        "positive"
-      ],
-      [
-        "condition",
-        "GAP"
-      ],
-      [
-        "modal",
-        "must"
-      ]
+      ["polarity", "positive"],
+      ["condition", "GAP"],
+      ["modal", "must"]
     ],
     "comment": "UNVERIFIED paperLabel: example number carried from prior Lean file, not checked against PDF. Migrated from mustIndeterminateResponse: strong necessity is bivalent — grammatical and felicitous but judged false in this scenario, so outright 'No' denial is felicitous (noResponseFelicitous = true) and a 'Well, ...' response is not (wellResponseFelicitous = false).",
     "metaLanguage": "stan1293",

--- a/Linglib/Data/Examples/AlonsoOvalleMoghiseh2025.json
+++ b/Linglib/Data/Examples/AlonsoOvalleMoghiseh2025.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "aom2025_rootUniqueness",
-    "source":     {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "root uniqueness, §2.4.2"},
+    "source": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "root uniqueness, §2.4.2"},
     "reportedIn": null,
     "language": "west2369",
     "primaryText": "yek-i az dānešju-hā umæd.",
@@ -29,7 +29,7 @@
   },
   {
     "id": "aom2025_deonticFreeChoice",
-    "source":     {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "deontic FC, §2.3.1"},
+    "source": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "deontic FC, §2.3.1"},
     "reportedIn": null,
     "language": "west2369",
     "primaryText": "mituni yek-i az in sib-ā-ro bardāri.",
@@ -59,7 +59,7 @@
   },
   {
     "id": "aom2025_deonticBooks",
-    "source":     {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "deontic FC, books variant"},
+    "source": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "deontic FC, books variant"},
     "reportedIn": null,
     "language": "west2369",
     "primaryText": "mituni yek-i az in ketāb-hā-ro bekhuni.",
@@ -88,14 +88,14 @@
   },
   {
     "id": "aom2025_epistemicModalVariation",
-    "source":     {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "epistemic modal variation, §2.3.2"},
+    "source": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "epistemic modal variation, §2.3.2"},
     "reportedIn": null,
     "language": "west2369",
     "primaryText": "yek-i az dānešju-hā ketāb-o dozid-e.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["yek-i", "one-INDF"], ["az", "of"], ["dānešju-hā", "student-PL"],
-      ["ketāb-o", "book-RA"], ["dozid-e", "stole-3SG"]
+      ["yek-i", "one-INDF"], ["az", "of"], ["dānešju-hā", "student-PL"], ["ketāb-o", "book-RA"],
+      ["dozid-e", "stole-3SG"]
     ],
     "translation": "One of the students (might have) stolen the book.",
     "context": "epistemic possibility (covert or pragmatic) over yek-i",
@@ -118,7 +118,7 @@
   },
   {
     "id": "aom2025_epistemicExplicit",
-    "source":     {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "explicit epistemic modal"},
+    "source": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "explicit epistemic modal"},
     "reportedIn": null,
     "language": "west2369",
     "primaryText": "momken-e yek-i az dānešju-hā biyād.",
@@ -146,7 +146,7 @@
   },
   {
     "id": "aom2025_deNegation",
-    "source":     {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "negation context"},
+    "source": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "negation context"},
     "reportedIn": null,
     "language": "west2369",
     "primaryText": "yek-i az dānešju-hā-ro nadid-æm.",
@@ -173,7 +173,7 @@
   },
   {
     "id": "aom2025_deConditional",
-    "source":     {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "conditional antecedent"},
+    "source": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "conditional antecedent"},
     "reportedIn": null,
     "language": "west2369",
     "primaryText": "ægær yek-i az dānešju-hā biyād, xošhāl mišæm.",
@@ -200,15 +200,15 @@
   },
   {
     "id": "aom2025_embeddedUniqueness",
-    "source":     {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "embedded uniqueness contrast"},
+    "source": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "embedded uniqueness contrast"},
     "reportedIn": null,
     "language": "west2369",
     "primaryText": "mituni yek-i az in sib-ā-ro bardāri, #væli do-tā nemituni.",
     "discourseSegments": [],
     "glossedTokens": [
       ["mituni", "can.2SG"], ["yek-i", "one-INDF"], ["az", "of"], ["in", "this"],
-      ["sib-ā-ro", "apple-PL-RA"], ["bardāri", "pick.2SG"],
-      ["væli", "but"], ["do-tā", "two-CL"], ["nemituni", "NEG.can.2SG"]
+      ["sib-ā-ro", "apple-PL-RA"], ["bardāri", "pick.2SG"], ["væli", "but"], ["do-tā", "two-CL"],
+      ["nemituni", "NEG.can.2SG"]
     ],
     "translation": "You can pick one of these apples, #but not two.",
     "context": "deontic possibility, with continuation testing uniqueness",
@@ -231,7 +231,7 @@
   },
   {
     "id": "aom2025_contrast_irgendein",
-    "source":     {"bibkey": "kratzer-shimoyama-2002", "paperLabel": "irgendein root"},
+    "source": {"bibkey": "kratzer-shimoyama-2002", "paperLabel": "irgendein root"},
     "reportedIn": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "(1), Table 1"},
     "language": "stan1295",
     "primaryText": "Irgendjemand hat angerufen.",
@@ -259,7 +259,7 @@
   },
   {
     "id": "aom2025_contrast_yeki",
-    "source":     {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "yek-i root contrast, §2.4"},
+    "source": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "yek-i root contrast, §2.4"},
     "reportedIn": null,
     "language": "west2369",
     "primaryText": "Yek-i zæng zæd.",
@@ -287,7 +287,7 @@
   },
   {
     "id": "aom2025_contrast_vreun",
-    "source":     {"bibkey": "falaus-2014", "paperLabel": "p. 122 (cited at AOM 2025 ex. 4)"},
+    "source": {"bibkey": "falaus-2014", "paperLabel": "p. 122 (cited at AOM 2025 ex. 4)"},
     "reportedIn": {"bibkey": "alonso-ovalle-moghiseh-2025", "paperLabel": "(4), Table 1"},
     "language": "roma1327",
     "primaryText": "*Monica s-a întâlnit cu vreun prieten.",

--- a/Linglib/Data/Examples/AnandNevins2004.json
+++ b/Linglib/Data/Examples/AnandNevins2004.json
@@ -6,8 +6,8 @@
     "primaryText": "Hɛseni (mık-ra) va kɛ ɛz dɛwlɛtia.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Hɛseni", "Hesen.OBL"], ["(mık-ra)", "(I.OBL-to)"], ["va", "said"],
-      ["kɛ", "that"],           ["ɛz",      "I"],           ["dɛwlɛtia", "rich.be-PRES"]
+      ["Hɛseni", "Hesen.OBL"], ["(mık-ra)", "(I.OBL-to)"], ["va", "said"], ["kɛ", "that"],
+      ["ɛz", "I"], ["dɛwlɛtia", "rich.be-PRES"]
     ],
     "translation": "Hesen said that {I am, Hesen is} rich.",
     "context": "Zazaki: the embedded 1st-person `ɛz` can refer either to the utterance speaker OR to the attitude holder Hesen. Indexical shift is OPTIONAL under `vano` ('say'). Cornerstone first-person example.",
@@ -15,7 +15,7 @@
     "alternatives": [],
     "readings": [
       {"name": "indexical (ɛz = utterance speaker)", "judgment": "acceptable"},
-      {"name": "shifted (ɛz = Hesen)",                "judgment": "acceptable"}
+      {"name": "shifted (ɛz = Hesen)", "judgment": "acceptable"}
     ],
     "comment": "Anand & Nevins 2004 ex (4), SALT XIV p. 20. First of four examples (4)-(7) demonstrating that all four Zazaki indexicals (I, you, here, yesterday) can shift under `vano`. The pronominal-shift facts motivate the context-shifting operator OPv.",
     "metaLanguage": "stan1293",
@@ -28,10 +28,9 @@
     "primaryText": "Hefte nayeraraver, H. mı-ra va kɛ o vizeri Rojda paci kɛrd.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Hefte", "week"],         ["nayeraraver", "ago"],       [",", ","],
-      ["H.",    "Hesen"],        ["mı-ra",       "me-at"],     ["va", "said"],
-      ["kɛ",    "that"],          ["o",          "he"],         ["vizeri", "yesterday"],
-      ["Rojda", "Rojda"],         ["paci",       "kiss"],       ["kɛrd",   "did"]
+      ["Hefte", "week"], ["nayeraraver", "ago"], [",", ","], ["H.", "Hesen"], ["mı-ra", "me-at"],
+      ["va", "said"], ["kɛ", "that"], ["o", "he"], ["vizeri", "yesterday"], ["Rojda", "Rojda"],
+      ["paci", "kiss"], ["kɛrd", "did"]
     ],
     "translation": "A week ago, H. told me that he kissed Rojda {8 days ago, #yesterday}.",
     "context": "Zazaki temporal-indexical shift. `vizeri` ('yesterday') in the embedded clause can shift to the attitude-context's now (= the day before the saying, i.e. 8 days before utterance), but NOT remain anchored to utterance-yesterday. The unavailable utterance-anchored reading is the diagnostic — English allows only that reading.",
@@ -39,7 +38,7 @@
     "alternatives": [],
     "readings": [
       {"name": "shifted (yesterday = day-before-saying ≈ 8 days ago)", "judgment": "acceptable"},
-      {"name": "indexical (yesterday = utterance-yesterday)",          "judgment": "unacceptable"}
+      {"name": "indexical (yesterday = utterance-yesterday)", "judgment": "unacceptable"}
     ],
     "comment": "Anand & Nevins 2004 ex (7), p. 20. Fourth of four indexical-shift examples (4)-(7). Together with (4)-(6), motivates that ALL indexicals (I, you, here, yesterday) shift in Zazaki — not just pronouns. A&N analyze (7) as an *adverbial* shift (`vizeri` is a temporal adverbial), not a tense-pronoun shift — this distinguishes A&N's indexical-shift account from tense-pronoun analyses of cross-linguistic embedded-past.",
     "metaLanguage": "stan1293",

--- a/Linglib/Data/Examples/ArreguiKusumoto1998.json
+++ b/Linglib/Data/Examples/ArreguiKusumoto1998.json
@@ -11,8 +11,8 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "simultaneous (Junko sick at saying time)",   "judgment": "acceptable"},
-      {"name": "past-shifted (Junko sick before saying)",    "judgment": "acceptable"}
+      {"name": "simultaneous (Junko sick at saying time)", "judgment": "acceptable"},
+      {"name": "past-shifted (Junko sick before saying)", "judgment": "acceptable"}
     ],
     "comment": "Arregui & Kusumoto 1998 ex (1), SALT VIII p. 1. Originating discussion of this example shape is Enç 1987 (cited by A&K as [Eng 1987]; no enc-1987 bib entry yet).",
     "metaLanguage": "stan1293",
@@ -180,7 +180,7 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "upstairs (when = saying time)",            "judgment": "acceptable"},
+      {"name": "upstairs (when = saying time)", "judgment": "acceptable"},
       {"name": "downstairs (when = his leaving, per you)", "judgment": "acceptable"}
     ],
     "comment": "Arregui & Kusumoto 1998 ex (14), p. 7. Originally Geis 1970. (No geis-1970 bib entry; sourced via reportedIn = A&K.) Cornerstone Geis-ambiguity example — extraction from main clause vs embedded clause yields two readings.",
@@ -199,7 +199,7 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "veridical (plant died)",         "judgment": "acceptable"},
+      {"name": "veridical (plant died)", "judgment": "acceptable"},
       {"name": "non-veridical (plant didn't die)", "judgment": "acceptable"}
     ],
     "comment": "Arregui & Kusumoto 1998 ex (18a), p. 10. Diagnostic for the before/after veridicality asymmetry — citing Anscombe 1964, Landman 1991, Ogihara 1995.",

--- a/Linglib/Data/Examples/Charlow2014.json
+++ b/Linglib/Data/Examples/Charlow2014.json
@@ -1,14 +1,14 @@
 [
   {
     "id": "charlow2014_donkey1",
-    "source":     {"bibkey": "geach-1962",   "paperLabel": "ch. III, the donkey sentence"},
+    "source": {"bibkey": "geach-1962", "paperLabel": "ch. III, the donkey sentence"},
     "reportedIn": {"bibkey": "charlow-2014", "paperLabel": "Ch. 2 donkey case"},
     "language": "stan1293",
     "primaryText": "Every farmer who owns a donkey beats it.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Every", "every"], ["farmer", "farmer"], ["who",    "REL.ANIM"],   ["owns",  "own.PRS.3SG"],
-      ["a",     "INDEF"], ["donkey", "donkey"], ["beats",  "beat.PRS.3SG"], ["it",  "3SG.N"]
+      ["Every", "every"], ["farmer", "farmer"], ["who", "REL.ANIM"], ["owns", "own.PRS.3SG"],
+      ["a", "INDEF"], ["donkey", "donkey"], ["beats", "beat.PRS.3SG"], ["it", "3SG.N"]
     ],
     "translation": "Every farmer who owns a donkey beats it.",
     "context": "",

--- a/Linglib/Data/Examples/ChatzikyriakidisEtAl2025.json
+++ b/Linglib/Data/Examples/ChatzikyriakidisEtAl2025.json
@@ -1,25 +1,19 @@
 [
- {
-  "id": "chatzikyriakidisetal2025_hobNob",
-  "source": {
-   "bibkey": "geach-1967",
-   "paperLabel": "the Hob-Nob sentence"
-  },
-  "reportedIn": {
-   "bibkey": "chatzikyriakidis-etal-2025",
-   "paperLabel": "§2.3.2"
-  },
-  "language": "stan1293",
-  "primaryText": "Hob thinks a witch has blighted Bob's mare, and Nob wonders whether she (the same witch) killed Cob's sow.",
-  "discourseSegments": [],
-  "glossedTokens": [],
-  "translation": "Hob thinks a witch has blighted Bob's mare, and Nob wonders whether she (the same witch) killed Cob's sow.",
-  "context": "No witch need exist, and Hob and Nob need not be aware of each other's attitudes.",
-  "judgment": "acceptable",
-  "alternatives": [],
-  "readings": [],
-  "comment": "Geach's intentional identity puzzle: anaphoric relatedness across the belief states of different agents without a requirement that the kind of individual the agents believe in actually exist (Chatzikyriakidis et al. 2025, §2.3.2). The parenthetical '(the same witch)' is part of the sentence as the Element quotes it and forces the same-witch reading that constitutes the puzzle. Edelberg 1986's detective variants, whose conjuncts resist reversal, are the key additional data in this literature; not yet recorded here.",
-  "metaLanguage": "stan1293",
-  "lgrConformance": ""
- }
+  {
+    "id": "chatzikyriakidisetal2025_hobNob",
+    "source": {"bibkey": "geach-1967", "paperLabel": "the Hob-Nob sentence"},
+    "reportedIn": {"bibkey": "chatzikyriakidis-etal-2025", "paperLabel": "§2.3.2"},
+    "language": "stan1293",
+    "primaryText": "Hob thinks a witch has blighted Bob's mare, and Nob wonders whether she (the same witch) killed Cob's sow.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Hob thinks a witch has blighted Bob's mare, and Nob wonders whether she (the same witch) killed Cob's sow.",
+    "context": "No witch need exist, and Hob and Nob need not be aware of each other's attitudes.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "comment": "Geach's intentional identity puzzle: anaphoric relatedness across the belief states of different agents without a requirement that the kind of individual the agents believe in actually exist (Chatzikyriakidis et al. 2025, §2.3.2). The parenthetical '(the same witch)' is part of the sentence as the Element quotes it and forces the same-witch reading that constitutes the puzzle. Edelberg 1986's detective variants, whose conjuncts resist reversal, are the key additional data in this literature; not yet recorded here.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  }
 ]

--- a/Linglib/Data/Examples/ChungMascarenhas2024.json
+++ b/Linglib/Data/Examples/ChungMascarenhas2024.json
@@ -14,8 +14,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "The paper's centerpiece morphosyntactic argument. Korean realizes English-must as the transparent composition of (i) the evaluative predicate toy 'EVAL' as the measure function μ_R, (ii) the conditional 'if φ, EVAL' = condIf, (iii) the exhaustifier -(e)ya 'only-if'. Formalized in `mustCM_iff_korean_composition`.",
-    "paperFeatures": [["puzzle", "koreanComposition"], ["construction", "conditional-evaluative"]]
+    "paperFeatures": [
+      ["puzzle", "koreanComposition"],
+      ["construction", "conditional-evaluative"]
+    ],
+    "comment": "The paper's centerpiece morphosyntactic argument. Korean realizes English-must as the transparent composition of (i) the evaluative predicate toy 'EVAL' as the measure function μ_R, (ii) the conditional 'if φ, EVAL' = condIf, (iii) the exhaustifier -(e)ya 'only-if'. Formalized in `mustCM_iff_korean_composition`."
   },
   {
     "id": "cm2024_4_linda_original",
@@ -38,8 +41,11 @@
       {"form": "Linda is a bank teller and she is active in the feminist movement.", "judgment": "acceptable"}
     ],
     "readings": [],
-    "comment": "Original Tversky-Kahneman 1983 conjunction-fallacy stimulus. C&M propose a *modal* version (mc2024_29_modal_linda) and argue their semantics predicts the fallacy at the modal level via explanatory-value (sum of likelihoods).",
-    "paperFeatures": [["puzzle", "conjunctionFallacy"], ["empiricalDomain", "epistemic"]]
+    "paperFeatures": [
+      ["puzzle", "conjunctionFallacy"],
+      ["empiricalDomain", "epistemic"]
+    ],
+    "comment": "Original Tversky-Kahneman 1983 conjunction-fallacy stimulus. C&M propose a *modal* version (mc2024_29_modal_linda) and argue their semantics predicts the fallacy at the modal level via explanatory-value (sum of likelihoods)."
   },
   {
     "id": "cm2024_15a_minersBlockNeither",
@@ -54,8 +60,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "First clause of the Kolodny-MacFarlane miners triple. C&M's expected-utility analysis (formalized in `ought_blockNeither_at_threshold`) makes this true at any θ ∈ (5, 9).",
-    "paperFeatures": [["puzzle", "miners"], ["modalForce", "ought"]]
+    "paperFeatures": [
+      ["puzzle", "miners"],
+      ["modalForce", "ought"]
+    ],
+    "comment": "First clause of the Kolodny-MacFarlane miners triple. C&M's expected-utility analysis (formalized in `ought_blockNeither_at_threshold`) makes this true at any θ ∈ (5, 9)."
   },
   {
     "id": "cm2024_15b_minersBlockA",
@@ -70,8 +79,12 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Conditional clause of the miners triple. Together with (15a), it shows the Kratzerian ordering source cannot be information-insensitive. C&M's analysis formalized in `ought_under_minersInA_at_threshold` (eq. 24).",
-    "paperFeatures": [["puzzle", "miners"], ["modalForce", "ought"], ["conditional", "info-sensitive"]]
+    "paperFeatures": [
+      ["puzzle", "miners"],
+      ["modalForce", "ought"],
+      ["conditional", "info-sensitive"]
+    ],
+    "comment": "Conditional clause of the miners triple. Together with (15a), it shows the Kratzerian ordering source cannot be information-insensitive. C&M's analysis formalized in `ought_under_minersInA_at_threshold` (eq. 24)."
   },
   {
     "id": "cm2024_25a_minersMust",
@@ -89,8 +102,11 @@
       {"form": "We cannot block either path.", "judgment": "acceptable"}
     ],
     "readings": [],
-    "comment": "Must-variant of (15a). Paper judgment: (a) is questionable on intended reading because 'neither' triggers alternative-quantifier interference; the rephrasings in alternatives unambiguously target the intended reading.",
-    "paperFeatures": [["puzzle", "miners"], ["modalForce", "must"]]
+    "paperFeatures": [
+      ["puzzle", "miners"],
+      ["modalForce", "must"]
+    ],
+    "comment": "Must-variant of (15a). Paper judgment: (a) is questionable on intended reading because 'neither' triggers alternative-quantifier interference; the rephrasings in alternatives unambiguously target the intended reading."
   },
   {
     "id": "cm2024_25b_minersMustA",
@@ -104,8 +120,12 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Must-variant of (15b). With (26a)/(25b) both felicitous, the paper's threshold-shifting prediction follows: a single θ cannot validate both unconditional (5 < θ < 9) and conditional-on-A (9 < θ < 10) must-claims. Formalized in `must_miners_requires_threshold_shift`.",
-    "paperFeatures": [["puzzle", "miners"], ["modalForce", "must"], ["prediction", "thresholdShift"]]
+    "paperFeatures": [
+      ["puzzle", "miners"],
+      ["modalForce", "must"],
+      ["prediction", "thresholdShift"]
+    ],
+    "comment": "Must-variant of (15b). With (26a)/(25b) both felicitous, the paper's threshold-shifting prediction follows: a single θ cannot validate both unconditional (5 < θ < 9) and conditional-on-A (9 < θ < 10) must-claims. Formalized in `must_miners_requires_threshold_shift`."
   },
   {
     "id": "cm2024_29b_modal_linda",
@@ -121,8 +141,11 @@
       {"form": "Linda must be a bank teller.", "judgment": "questionable"}
     ],
     "readings": [],
-    "comment": "Paper-introduced 'modal conjunction fallacy': introspectively, the conjunctive must-claim sounds *better* than the bare. C&M's analysis predicts this via the explanatory-value (sum of likelihoods) gap: 0.5 vs 1.5 (paper eq. 32 / 33). Formalized at the operator level in `mustCM_predicts_fallacy_under_CM_conditionals`.",
-    "paperFeatures": [["puzzle", "modalConjunctionFallacy"], ["empiricalDomain", "epistemic"]]
+    "paperFeatures": [
+      ["puzzle", "modalConjunctionFallacy"],
+      ["empiricalDomain", "epistemic"]
+    ],
+    "comment": "Paper-introduced 'modal conjunction fallacy': introspectively, the conjunctive must-claim sounds *better* than the bare. C&M's analysis predicts this via the explanatory-value (sum of likelihoods) gap: 0.5 vs 1.5 (paper eq. 32 / 33). Formalized at the operator level in `mustCM_predicts_fallacy_under_CM_conditionals`."
   },
   {
     "id": "cm2024_35_jack_description",
@@ -137,8 +160,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Kahneman-Tversky 1973 base-rate-neglect stimulus. Subjects' engineer-probability judgment is unaffected by the 30/70 vs 70/30 prior split, signalling neglect of prior probabilities — the empirical phenomenon C&M's analysis predicts at the modal level.",
-    "paperFeatures": [["puzzle", "baseRateNeglect"], ["empiricalDomain", "epistemic"]]
+    "paperFeatures": [
+      ["puzzle", "baseRateNeglect"],
+      ["empiricalDomain", "epistemic"]
+    ],
+    "comment": "Kahneman-Tversky 1973 base-rate-neglect stimulus. Subjects' engineer-probability judgment is unaffected by the 30/70 vs 70/30 prior split, signalling neglect of prior probabilities — the empirical phenomenon C&M's analysis predicts at the modal level."
   },
   {
     "id": "cm2024_36_jack_must_engineer",
@@ -154,8 +180,11 @@
       {"form": "Jack must be a lawyer.", "judgment": "questionable"}
     ],
     "readings": [],
-    "comment": "Paper-introduced 'modal base-rate neglect': introspectively, the engineer-claim sounds appropriate regardless of the 30/70 vs 70/30 prior. C&M's explanatory-value analysis: EV(engineer) = 1.33 (paper eq. 39) > EV(lawyer) = 0.63 (eq. 40), prior-independent. Formalized in `mustCM_predicts_base_rate_neglect_under_CM_conditionals`.",
-    "paperFeatures": [["puzzle", "baseRateNeglect"], ["modalForce", "must"]]
+    "paperFeatures": [
+      ["puzzle", "baseRateNeglect"],
+      ["modalForce", "must"]
+    ],
+    "comment": "Paper-introduced 'modal base-rate neglect': introspectively, the engineer-claim sounds appropriate regardless of the 30/70 vs 70/30 prior. C&M's explanatory-value analysis: EV(engineer) = 1.33 (paper eq. 39) > EV(lawyer) = 0.63 (eq. 40), prior-independent. Formalized in `mustCM_predicts_base_rate_neglect_under_CM_conditionals`."
   },
   {
     "id": "cm2024_49a_cold",
@@ -174,8 +203,11 @@
       {"form": "#He must be dead.", "judgment": "unacceptable"}
     ],
     "readings": [],
-    "comment": "Dead-vs-cold contrast (paper §5, eq. 49a/b). The pure likelihood-based analysis incorrectly predicts must-dead acceptable (P(absent|dead)=1 ≫ P(absent|cold)). Motivates the §5 plausibility-floor patch (formalized as `mustCMWithPlausibility`).",
-    "paperFeatures": [["puzzle", "plausibilityFloor"], ["modalForce", "must"]]
+    "paperFeatures": [
+      ["puzzle", "plausibilityFloor"],
+      ["modalForce", "must"]
+    ],
+    "comment": "Dead-vs-cold contrast (paper §5, eq. 49a/b). The pure likelihood-based analysis incorrectly predicts must-dead acceptable (P(absent|dead)=1 ≫ P(absent|cold)). Motivates the §5 plausibility-floor patch (formalized as `mustCMWithPlausibility`)."
   },
   {
     "id": "cm2024_54a_grammatical_mistake",
@@ -189,8 +221,12 @@
     "judgment": "unacceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Deontic-domain instance of the §5 plausibility-floor requirement: the prejacent (never making any mistake) is implausible, infelicity follows. Extends the dead/cold contrast (cm2024_49a) from epistemic to deontic.",
-    "paperFeatures": [["puzzle", "plausibilityFloor"], ["modalForce", "must"], ["modalType", "deontic"]]
+    "paperFeatures": [
+      ["puzzle", "plausibilityFloor"],
+      ["modalForce", "must"],
+      ["modalType", "deontic"]
+    ],
+    "comment": "Deontic-domain instance of the §5 plausibility-floor requirement: the prejacent (never making any mistake) is implausible, infelicity follows. Extends the dead/cold contrast (cm2024_49a) from epistemic to deontic."
   },
   {
     "id": "cm2024_55a_bushwick_helicopter",
@@ -204,8 +240,12 @@
     "judgment": "unacceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Teleological-domain instance of the §5 plausibility-floor requirement: the prejacent (helicopter-taking) is implausible / impractical. Extends the dead/cold contrast (cm2024_49a) from epistemic to teleological.",
-    "paperFeatures": [["puzzle", "plausibilityFloor"], ["modalForce", "have-to"], ["modalType", "teleological"]]
+    "paperFeatures": [
+      ["puzzle", "plausibilityFloor"],
+      ["modalForce", "have-to"],
+      ["modalType", "teleological"]
+    ],
+    "comment": "Teleological-domain instance of the §5 plausibility-floor requirement: the prejacent (helicopter-taking) is implausible / impractical. Extends the dead/cold contrast (cm2024_49a) from epistemic to teleological."
   },
   {
     "id": "cm2024_60a_kim_marry_pat",
@@ -222,8 +262,11 @@
       {"form": "Kim must marry PAT in order to inherit. (with PAT focused)", "judgment": "unacceptable"}
     ],
     "readings": [],
-    "comment": "Focus contrast (§6 eq. 60). With neutral focus, the alternative-set is the polar negation of the prejacent (true / true-enough). With contrastive PAT-focus, the alternative-set is other people Kim might marry — making it false (any marriage works). C&M's evidence for alternative-sensitivity of must but not might.",
-    "paperFeatures": [["puzzle", "focusContrast"], ["modalForce", "must"]]
+    "paperFeatures": [
+      ["puzzle", "focusContrast"],
+      ["modalForce", "must"]
+    ],
+    "comment": "Focus contrast (§6 eq. 60). With neutral focus, the alternative-set is the polar negation of the prejacent (true / true-enough). With contrastive PAT-focus, the alternative-set is other people Kim might marry — making it false (any marriage works). C&M's evidence for alternative-sensitivity of must but not might."
   },
   {
     "id": "cm2024_63_billy_rain",
@@ -243,7 +286,11 @@
       {"form": "It is raining. (without 'must')", "judgment": "acceptable"}
     ],
     "readings": [],
-    "comment": "von Fintel-Gillies 2010 puzzle: epistemic must infelicitous with direct perceptual evidence. C&M §7 adopt Goodhue 2017's felicity condition: must φ requires φ not be known. Not formalized — awaits project-wide epistemic-knowledge substrate.",
-    "paperFeatures": [["puzzle", "vfgFelicity"], ["modalForce", "must"], ["modalType", "epistemic"]]
+    "paperFeatures": [
+      ["puzzle", "vfgFelicity"],
+      ["modalForce", "must"],
+      ["modalType", "epistemic"]
+    ],
+    "comment": "von Fintel-Gillies 2010 puzzle: epistemic must infelicitous with direct perceptual evidence. C&M §7 adopt Goodhue 2017's felicity condition: must φ requires φ not be known. Not formalized — awaits project-wide epistemic-knowledge substrate."
   }
 ]

--- a/Linglib/Data/Examples/CondoravdiLauer2016.json
+++ b/Linglib/Data/Examples/CondoravdiLauer2016.json
@@ -11,8 +11,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Intend-variant of (1); supports the paper's argument that the antecedent need not be want — any intention-related predicate works.",
-    "paperFeatures": [["puzzle", "harlemBase"], ["desirePredicate", "intend"]]
+    "paperFeatures": [
+      ["puzzle", "harlemBase"],
+      ["desirePredicate", "intend"]
+    ],
+    "comment": "Intend-variant of (1); supports the paper's argument that the antecedent need not be want — any intention-related predicate works."
   },
   {
     "id": "cl2016_3_plan",
@@ -26,8 +29,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Plan-variant of (1).",
-    "paperFeatures": [["puzzle", "harlemBase"], ["desirePredicate", "plan"]]
+    "paperFeatures": [
+      ["puzzle", "harlemBase"],
+      ["desirePredicate", "plan"]
+    ],
+    "comment": "Plan-variant of (1)."
   },
   {
     "id": "cl2016_4_goal",
@@ -41,8 +47,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Goal-variant of (1). Together with (2)-(3), shows the antecedent desire-predicate is not lexically privileged.",
-    "paperFeatures": [["puzzle", "harlemBase"], ["desirePredicate", "goal"]]
+    "paperFeatures": [
+      ["puzzle", "harlemBase"],
+      ["desirePredicate", "goal"]
+    ],
+    "comment": "Goal-variant of (1). Together with (2)-(3), shows the antecedent desire-predicate is not lexically privileged."
   },
   {
     "id": "cl2016_5_chocolate",
@@ -56,8 +65,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Non-anankastic if-want conditional. Same surface form as (1) but conveys NOT 'thinking-about-something-else is necessary for chocolate' — it's advice to avoid. Shows surface form does not determine anankasticity; want gets a mere-desire construal here (paper § 7.2.1, formalized as cl2016_5_chocolate in the chocolate-LF contrast).",
-    "paperFeatures": [["puzzle", "nonAnankasticAntecedent"], ["reading", "mere-desire"]]
+    "paperFeatures": [
+      ["puzzle", "nonAnankasticAntecedent"],
+      ["reading", "mere-desire"]
+    ],
+    "comment": "Non-anankastic if-want conditional. Same surface form as (1) but conveys NOT 'thinking-about-something-else is necessary for chocolate' — it's advice to avoid. Shows surface form does not determine anankasticity; want gets a mere-desire construal here (paper § 7.2.1, formalized as cl2016_5_chocolate in the chocolate-LF contrast)."
   },
   {
     "id": "cl2016_19_chess",
@@ -74,8 +86,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Interacting-preferences scenario: unconditional necessity statements (a)/(b) are jointly inconsistent, but the corresponding conditionals (20) can be jointly true. Shows preferences must be resolved differently in conditional vs unconditional cases.",
-    "paperFeatures": [["puzzle", "interactingPreferences"], ["modalForce", "unconditionalNec"]]
+    "paperFeatures": [
+      ["puzzle", "interactingPreferences"],
+      ["modalForce", "unconditionalNec"]
+    ],
+    "comment": "Interacting-preferences scenario: unconditional necessity statements (a)/(b) are jointly inconsistent, but the corresponding conditionals (20) can be jointly true. Shows preferences must be resolved differently in conditional vs unconditional cases."
   },
   {
     "id": "cl2016_20_chess_conditional",
@@ -92,8 +107,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Conditionalized version of (19); both conditionals can be true even though their unconditional counterparts cannot. Tests interacting-preferences resolution.",
-    "paperFeatures": [["puzzle", "interactingPreferences"], ["modalForce", "conditionalNec"]]
+    "paperFeatures": [
+      ["puzzle", "interactingPreferences"],
+      ["modalForce", "conditionalNec"]
+    ],
+    "comment": "Conditionalized version of (19); both conditionals can be true even though their unconditional counterparts cannot. Tests interacting-preferences resolution."
   },
   {
     "id": "cl2016_28_invite",
@@ -107,8 +125,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Near-anankastic: conveys precondition (seating 20+ is necessary FOR being able to seat everyone) rather than means-of. Used to argue the analysis must generalize beyond means-of.",
-    "paperFeatures": [["puzzle", "nearAnankastic"], ["relationType", "precondition"]]
+    "paperFeatures": [
+      ["puzzle", "nearAnankastic"],
+      ["relationType", "precondition"]
+    ],
+    "comment": "Near-anankastic: conveys precondition (seating 20+ is necessary FOR being able to seat everyone) rather than means-of. Used to argue the analysis must generalize beyond means-of."
   },
   {
     "id": "cl2016_29a_vaccine_safe",
@@ -122,8 +143,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Near-anankastic with overt purpose clause 'to be safe'.",
-    "paperFeatures": [["puzzle", "nearAnankastic"], ["relationType", "strengthened-goal"]]
+    "paperFeatures": [
+      ["puzzle", "nearAnankastic"],
+      ["relationType", "strengthened-goal"]
+    ],
+    "comment": "Near-anankastic with overt purpose clause 'to be safe'."
   },
   {
     "id": "cl2016_29b_vaccine",
@@ -137,8 +161,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Near-anankastic without overt purpose clause; the strengthened goal (safe travel) must be supplied by context. Paper argues Huitink's strong-antecedent analysis predicts this false on its strongest reading.",
-    "paperFeatures": [["puzzle", "nearAnankastic"], ["relationType", "implicit-strengthened-goal"]]
+    "paperFeatures": [
+      ["puzzle", "nearAnankastic"],
+      ["relationType", "implicit-strengthened-goal"]
+    ],
+    "comment": "Near-anankastic without overt purpose clause; the strengthened goal (safe travel) must be supplied by context. Paper argues Huitink's strong-antecedent analysis predicts this false on its strongest reading."
   },
   {
     "id": "cl2016_31_disneyworld",
@@ -152,8 +179,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Near-anankastic about teleological CONSEQUENCES: spending five days is a consequence of (optimally) going to Disneyworld, not a precondition. Raises the same compositionality problem as canonical anankastics.",
-    "paperFeatures": [["puzzle", "nearAnankastic"], ["relationType", "teleological-consequence"]]
+    "paperFeatures": [
+      ["puzzle", "nearAnankastic"],
+      ["relationType", "teleological-consequence"]
+    ],
+    "comment": "Near-anankastic about teleological CONSEQUENCES: spending five days is a consequence of (optimally) going to Disneyworld, not a precondition. Raises the same compositionality problem as canonical anankastics."
   },
   {
     "id": "cl2016_38_exemption",
@@ -167,8 +197,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Near-anankastic with DEONTIC inner modal (rather than teleological). Conveys: actually taking the exemption forces higher taxes — not that wanting it does. The vacuity-of-want is contingent on the actualization assumption (paper § 7.2.2).",
-    "paperFeatures": [["puzzle", "nearAnankastic"], ["modalType", "deontic"]]
+    "paperFeatures": [
+      ["puzzle", "nearAnankastic"],
+      ["modalType", "deontic"]
+    ],
+    "comment": "Near-anankastic with DEONTIC inner modal (rather than teleological). Conveys: actually taking the exemption forces higher taxes — not that wanting it does. The vacuity-of-want is contingent on the actualization assumption (paper § 7.2.2)."
   },
   {
     "id": "cl2016_39a_disaster",
@@ -182,8 +215,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "'What-kind-of' near-anankastic: the prejacent ENTAILS the antecedent goal (going-quickly entails going). Tests against purpose-clause analyses that can't paraphrase such conditionals.",
-    "paperFeatures": [["puzzle", "nearAnankastic"], ["relationType", "what-kind-of"]]
+    "paperFeatures": [
+      ["puzzle", "nearAnankastic"],
+      ["relationType", "what-kind-of"]
+    ],
+    "comment": "'What-kind-of' near-anankastic: the prejacent ENTAILS the antecedent goal (going-quickly entails going). Tests against purpose-clause analyses that can't paraphrase such conditionals."
   },
   {
     "id": "cl2016_40a_dress",
@@ -197,8 +233,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "'What-kind-of' near-anankastic.",
-    "paperFeatures": [["puzzle", "nearAnankastic"], ["relationType", "what-kind-of"]]
+    "paperFeatures": [
+      ["puzzle", "nearAnankastic"],
+      ["relationType", "what-kind-of"]
+    ],
+    "comment": "'What-kind-of' near-anankastic."
   },
   {
     "id": "cl2016_46_neg_letter_grade",
@@ -212,8 +251,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Negation in the antecedent: scopes over want (= 'absence of preference'), not over the complement. Tests that want interacts with embedding operators normally. Defeats 'vacuous want' analyses.",
-    "paperFeatures": [["puzzle", "nearAnankastic"], ["scope", "negation-over-want"]]
+    "paperFeatures": [
+      ["puzzle", "nearAnankastic"],
+      ["scope", "negation-over-want"]
+    ],
+    "comment": "Negation in the antecedent: scopes over want (= 'absence of preference'), not over the complement. Tests that want interacts with embedding operators normally. Defeats 'vacuous want' analyses."
   },
   {
     "id": "cl2016_52_picnic_hiking",
@@ -227,8 +269,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Levinson-style example: two incompatible wants coherently asserted. Argues mere-desire reading of want (not effective-preference) does not validate Conjunction Introduction.",
-    "paperFeatures": [["puzzle", "conjunctionIntroduction"], ["reading", "mere-desire"]]
+    "paperFeatures": [
+      ["puzzle", "conjunctionIntroduction"],
+      ["reading", "mere-desire"]
+    ],
+    "comment": "Levinson-style example: two incompatible wants coherently asserted. Argues mere-desire reading of want (not effective-preference) does not validate Conjunction Introduction."
   },
   {
     "id": "cl2016_55_chess_incompat",
@@ -244,8 +289,11 @@
       {"form": "John would like to move in with his girlfriend, but he would also like to keep living alone. He can't make up his mind.", "judgment": "acceptable"}
     ],
     "readings": [],
-    "comment": "Intend-variant of (53). The intend-version sounds contradictory / attributes irrationality; the would-like-to variant (alternative) is coherent. Argues intend = effective preference is subject to a consistency constraint that mere desires lack.",
-    "paperFeatures": [["puzzle", "conjunctionIntroduction"], ["reading", "effective-preference"]]
+    "paperFeatures": [
+      ["puzzle", "conjunctionIntroduction"],
+      ["reading", "effective-preference"]
+    ],
+    "comment": "Intend-variant of (53). The intend-version sounds contradictory / attributes irrationality; the would-like-to variant (alternative) is coherent. Argues intend = effective preference is subject to a consistency constraint that mere desires lack."
   },
   {
     "id": "cl2016_61_concorde",
@@ -265,8 +313,11 @@
     "readings": [
       {"name": "upward-entailment-fails", "judgment": "acceptable"}
     ],
-    "comment": "Tests Upward Entailment for want. Asher/Levinson claim (a) true but (b) false despite the entailment; C&L argue (b) can be true on a sub-property reading (Condoravdi et al. 2001, Zimmermann 2006 — quantification over sub-concepts).",
-    "paperFeatures": [["puzzle", "upwardEntailment"], ["reading", "effective-preference"]]
+    "paperFeatures": [
+      ["puzzle", "upwardEntailment"],
+      ["reading", "effective-preference"]
+    ],
+    "comment": "Tests Upward Entailment for want. Asher/Levinson claim (a) true but (b) false despite the entailment; C&L argue (b) can be true on a sub-property reading (Condoravdi et al. 2001, Zimmermann 2006 — quantification over sub-concepts)."
   },
   {
     "id": "cl2016_63_poodle_dog",
@@ -282,8 +333,10 @@
       {"form": "John wants to get a dog. So he would be happy to get a poodle.", "judgment": "questionable"}
     ],
     "readings": [],
-    "comment": "Upward Entailment for want: poodle-getting entails dog-getting; the inference goes through. Pair with the alternative (which goes the wrong direction) to show want is UE not DE.",
-    "paperFeatures": [["puzzle", "upwardEntailment"]]
+    "paperFeatures": [
+      ["puzzle", "upwardEntailment"]
+    ],
+    "comment": "Upward Entailment for want: poodle-getting entails dog-getting; the inference goes through. Pair with the alternative (which goes the wrong direction) to show want is UE not DE."
   },
   {
     "id": "cl2016_82a_dog_tax",
@@ -299,8 +352,11 @@
       {"form": "But if John loses his eyesight and gets a dog, he will not have to pay more taxes.", "judgment": "acceptable"}
     ],
     "readings": [],
-    "comment": "Defeasible obligation pair. Both true on the double-modal analysis (outer NEC restricts to typical worlds where John keeps his eyesight; inner MUST quantifies over best worlds in those). Argues for stereotypical outer ordering source on overt deontic modals.",
-    "paperFeatures": [["puzzle", "defeasibleObligation"], ["modalType", "deontic"]]
+    "paperFeatures": [
+      ["puzzle", "defeasibleObligation"],
+      ["modalType", "deontic"]
+    ],
+    "comment": "Defeasible obligation pair. Both true on the double-modal analysis (outer NEC restricts to typical worlds where John keeps his eyesight; inner MUST quantifies over best worlds in those). Argues for stereotypical outer ordering source on overt deontic modals."
   },
   {
     "id": "cl2016_92_vladivostok",
@@ -315,8 +371,10 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Conditional anankastic with a COMPATIBLE secondary preference (comfort) that influences the prediction. Truth depends on whether comfort is taken to be an effective preference; vF&I 2005 report judgment variability — C&L attribute to contextual variability of effective-preference set, not grammatical variability.",
-    "paperFeatures": [["puzzle", "compatibleSecondaryPreference"]]
+    "paperFeatures": [
+      ["puzzle", "compatibleSecondaryPreference"]
+    ],
+    "comment": "Conditional anankastic with a COMPATIBLE secondary preference (comfort) that influences the prediction. Truth depends on whether comfort is taken to be an effective preference; vF&I 2005 report judgment variability — C&L attribute to contextual variability of effective-preference set, not grammatical variability."
   },
   {
     "id": "cl2016_91a_virus_no",
@@ -335,8 +393,11 @@
       {"form": "But if he wanted to go to Harlem today, he would have to take the A train.", "judgment": "acceptable"}
     ],
     "readings": [],
-    "comment": "Indicative anankastic infelicitous when speaker knows the hypothetical EP is incompatible with actual; subjunctive variant is fine. The paper's evidence that the indicative imposes 'antecedent is epistemically possible' — same constraint as ordinary indicative conditionals.",
-    "paperFeatures": [["puzzle", "informationalAsymmetry"], ["mood", "indicative-vs-subjunctive"]]
+    "paperFeatures": [
+      ["puzzle", "informationalAsymmetry"],
+      ["mood", "indicative-vs-subjunctive"]
+    ],
+    "comment": "Indicative anankastic infelicitous when speaker knows the hypothetical EP is incompatible with actual; subjunctive variant is fine. The paper's evidence that the indicative imposes 'antecedent is epistemically possible' — same constraint as ordinary indicative conditionals."
   },
   {
     "id": "cl2016_112a_inclined_harlem",
@@ -351,7 +412,9 @@
     "judgment": "marginal",
     "alternatives": [],
     "readings": [],
-    "comment": "Weak antecedent (inclined, would-like-to, etc.). Generally not ananakastic — predicates that can only express mere desires can't target effective preferences. Becomes anankastic only in contexts where the mere desire would be acted on. Originally due to Weatherson (p.c.) via vF&I 2006 slides; here cited from the vF&I 2005 ms-companion.",
-    "paperFeatures": [["puzzle", "weakAntecedent"]]
+    "paperFeatures": [
+      ["puzzle", "weakAntecedent"]
+    ],
+    "comment": "Weak antecedent (inclined, would-like-to, etc.). Generally not ananakastic — predicates that can only express mere desires can't target effective preferences. Becomes anankastic only in contexts where the mere desire would be acted on. Originally due to Weatherson (p.c.) via vF&I 2006 slides; here cited from the vF&I 2005 ms-companion."
   }
 ]

--- a/Linglib/Data/Examples/Declerck1991.json
+++ b/Linglib/Data/Examples/Declerck1991.json
@@ -20,7 +20,10 @@
     "source": {"bibkey": "declerck-1991-grammar", "paperLabel": "ch. 3 ex (1b)"},
     "language": "stan1293",
     "primaryText": "Suddenly the phone rang. Jill stood up from her chair, went over to the telephone and picked up the receiver.",
-    "discourseSegments": ["Suddenly the phone rang.", "Jill stood up from her chair, went over to the telephone and picked up the receiver."],
+    "discourseSegments": [
+      "Suddenly the phone rang.",
+      "Jill stood up from her chair, went over to the telephone and picked up the receiver."
+    ],
     "glossedTokens": [],
     "translation": "Suddenly the phone rang. Jill stood up from her chair, went over to the telephone and picked up the receiver.",
     "context": "Declerck's example of domain shift via absolute preterites. Each clause uses an absolute past tense — no relative tense forms like past perfect (anteriority) or conditional (posteriority). Temporal ordering recovered from clause order alone, not from tense composition.",
@@ -36,7 +39,10 @@
     "source": {"bibkey": "declerck-1991-grammar", "paperLabel": "ch. 3 ex (3a)"},
     "language": "stan1293",
     "primaryText": "The soldier got seriously wounded. He died shortly afterwards.",
-    "discourseSegments": ["The soldier got seriously wounded.", "He died shortly afterwards."],
+    "discourseSegments": [
+      "The soldier got seriously wounded.",
+      "He died shortly afterwards."
+    ],
     "glossedTokens": [],
     "translation": "The soldier got seriously wounded. He died shortly afterwards.",
     "context": "Declerck's example (3a): domain shift with `died` as absolute preterite. Temporal posteriority of dying relative to wounding comes from the adverbial `shortly afterwards`, not from any relative tense form.",

--- a/Linglib/Data/Examples/DelPinal2015.json
+++ b/Linglib/Data/Examples/DelPinal2015.json
@@ -4,7 +4,9 @@
     "source": {"bibkey": "delpinal-2015", "paperLabel": "(17)"},
     "language": "stan1293",
     "primaryText": "fake gun",
-    "glossedTokens": [["fake", "fake"], ["gun", "gun"]],
+    "glossedTokens": [
+      ["fake", "fake"], ["gun", "gun"]
+    ],
     "translation": "fake gun",
     "context": "Paper eq. 17 worked composition: fake gun's E-structure asserts ¬gun(x), ¬made-as-gun, ∃e[MAKING(e) ∧ GOAL(e, perceptual-gun(x))]. C-structure: TELIC negated (not for shooting), FORMAL preserved (looks like gun), AGENTIVE = made-to-look-like-gun. The canonical privative.",
     "judgment": "acceptable",
@@ -18,7 +20,9 @@
     "source": {"bibkey": "delpinal-2015", "paperLabel": "(11)"},
     "language": "stan1293",
     "primaryText": "counterfeit Rolex",
-    "glossedTokens": [["counterfeit", "counterfeit"], ["Rolex", "Rolex"]],
+    "glossedTokens": [
+      ["counterfeit", "counterfeit"], ["Rolex", "Rolex"]
+    ],
     "translation": "counterfeit Rolex",
     "context": "Paper eq. 11: counterfeit differs from fake in TELIC. A counterfeit Rolex is made to BOTH look AND function like a Rolex (GOAL includes Q_F AND Q_T); a fake Rolex would only need to look like one.",
     "judgment": "acceptable",
@@ -32,7 +36,9 @@
     "source": {"bibkey": "delpinal-2015", "paperLabel": "(12)"},
     "language": "stan1293",
     "primaryText": "artificial heart",
-    "glossedTokens": [["artificial", "artificial"], ["heart", "heart"]],
+    "glossedTokens": [
+      ["artificial", "artificial"], ["heart", "heart"]
+    ],
     "translation": "artificial heart",
     "context": "Paper eq. 12: artificial differs from fake in NOT negating FORMAL. An artificial heart need not look like a heart but is made with the intention that it function like a heart (GOAL = Q_T, not Q_F). Some find ¬Q_E itself unstable for 'artificial' (paper notes mixed intuitions about whether artificial legs are 'really' legs).",
     "judgment": "acceptable",
@@ -49,7 +55,9 @@
     "source": {"bibkey": "delpinal-2015", "paperLabel": "fn. 12"},
     "language": "stan1293",
     "primaryText": "fake Chanel handbag",
-    "glossedTokens": [["fake", "fake"], ["Chanel", "Chanel"], ["handbag", "handbag"]],
+    "glossedTokens": [
+      ["fake", "fake"], ["Chanel", "Chanel"], ["handbag", "handbag"]
+    ],
     "translation": "fake Chanel handbag",
     "context": "Paper footnote 12: structural-scope ambiguity diagnostic. (i) [fake [Chanel handbag]]: a counterfeit Chanel handbag (negates AGENTIVE of 'Chanel handbag' = the brand-source quale). (ii) [[fake Chanel] handbag]: a handbag whose 'Chanel' attribution is fake (could be a real handbag, falsely branded). Distinguishes DC from coarser noun-coercion accounts that don't distinguish the two scopes.",
     "judgment": "acceptable",

--- a/Linglib/Data/Examples/Hofmann2025.json
+++ b/Linglib/Data/Examples/Hofmann2025.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "hofmann2025_veridical_basic",
-    "source":     {"bibkey": "hofmann-2025", "paperLabel": "(1a)"},
+    "source": {"bibkey": "hofmann-2025", "paperLabel": "(1a)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Mary owns a car. It is red.",
@@ -21,7 +21,7 @@
   },
   {
     "id": "hofmann2025_negated_basic",
-    "source":     {"bibkey": "hofmann-2025", "paperLabel": "(1b)"},
+    "source": {"bibkey": "hofmann-2025", "paperLabel": "(1b)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Mary doesn't own a car. It is red.",
@@ -41,7 +41,7 @@
   },
   {
     "id": "hofmann2025_double_negation",
-    "source":     {"bibkey": "krahmer-muskens-1995", "paperLabel": "(5)"},
+    "source": {"bibkey": "krahmer-muskens-1995", "paperLabel": "(5)"},
     "reportedIn": {"bibkey": "hofmann-2025", "paperLabel": "(2a)/(42a)"},
     "language": "stan1293",
     "primaryText": "It's not true that there isn't a bathroom. It is upstairs.",
@@ -61,7 +61,7 @@
   },
   {
     "id": "hofmann2025_modal_subordination",
-    "source":     {"bibkey": "frank-1996", "paperLabel": "(8a)"},
+    "source": {"bibkey": "frank-1996", "paperLabel": "(8a)"},
     "reportedIn": {"bibkey": "hofmann-2025", "paperLabel": "(2d)/(42d)"},
     "language": "stan1293",
     "primaryText": "Fred didn't buy a microwave oven. He wouldn't know what to do with it.",
@@ -81,7 +81,7 @@
   },
   {
     "id": "hofmann2025_counterfactual_modal",
-    "source":     {"bibkey": "hofmann-2025", "paperLabel": "(6b)"},
+    "source": {"bibkey": "hofmann-2025", "paperLabel": "(6b)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Mary doesn't own a car. It would be parked outside.",

--- a/Linglib/Data/Examples/IppolitoKissWilliams2025.json
+++ b/Linglib/Data/Examples/IppolitoKissWilliams2025.json
@@ -11,7 +11,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "declarative"], ["position", "right"], ["particle", "only"]],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["position", "right"],
+      ["particle", "only"]
+    ],
     "comment": "The paper's basic English discourse-only example; repeated as (4) and (17)."
   },
   {
@@ -19,14 +23,21 @@
     "source": {"bibkey": "ippolito-kiss-williams-2025", "paperLabel": "(6a)"},
     "language": "stan1293",
     "primaryText": "Is this house beautiful? #Only it's expensive.",
-    "discourseSegments": ["Is this house beautiful?", "#Only it's expensive."],
+    "discourseSegments": [
+      "Is this house beautiful?",
+      "#Only it's expensive."
+    ],
     "glossedTokens": [],
     "translation": "Is this house beautiful? Only it's expensive.",
     "context": "",
     "judgment": "unacceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "canonicalPolarQ"], ["position", "left"], ["particle", "only"]],
+    "paperFeatures": [
+      ["clauseType", "canonicalPolarQ"],
+      ["position", "left"],
+      ["particle", "only"]
+    ],
     "comment": "Canonical info-seeking polar question as left argument: # in the paper. The speaker believes no answer, so S cannot support any QUD answer."
   },
   {
@@ -34,14 +45,22 @@
     "source": {"bibkey": "ippolito-kiss-williams-2025", "paperLabel": "(6b)"},
     "language": "stan1293",
     "primaryText": "Isn't this house beautiful? Only it's expensive.",
-    "discourseSegments": ["Isn't this house beautiful?", "Only it's expensive."],
+    "discourseSegments": [
+      "Isn't this house beautiful?",
+      "Only it's expensive."
+    ],
     "glossedTokens": [],
     "translation": "Isn't this house beautiful? Only it's expensive.",
     "context": "",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "highNegPolarQ"], ["position", "left"], ["particle", "only"], ["interpretation", "committed"]],
+    "paperFeatures": [
+      ["clauseType", "highNegPolarQ"],
+      ["position", "left"],
+      ["particle", "only"],
+      ["interpretation", "committed"]
+    ],
     "comment": "Repeated as (21). Felicitous because this high-negation polar question is interpreted rhetorically: the speaker is fully committed to the house being beautiful. Contrast (22)."
   },
   {
@@ -49,14 +68,21 @@
     "source": {"bibkey": "ippolito-kiss-williams-2025", "paperLabel": "(6c)"},
     "language": "stan1293",
     "primaryText": "When was this house renovated? #Only it's expensive.",
-    "discourseSegments": ["When was this house renovated?", "#Only it's expensive."],
+    "discourseSegments": [
+      "When was this house renovated?",
+      "#Only it's expensive."
+    ],
     "glossedTokens": [],
     "translation": "When was this house renovated? Only it's expensive.",
     "context": "",
     "judgment": "unacceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "canonicalWhQ"], ["position", "left"], ["particle", "only"]],
+    "paperFeatures": [
+      ["clauseType", "canonicalWhQ"],
+      ["position", "left"],
+      ["particle", "only"]
+    ],
     "comment": "Canonical info-seeking wh-question as left argument: # in the paper."
   },
   {
@@ -64,14 +90,22 @@
     "source": {"bibkey": "ippolito-kiss-williams-2025", "paperLabel": "(6d)"},
     "language": "stan1293",
     "primaryText": "Who wouldn't want this beautiful house? Only it's expensive.",
-    "discourseSegments": ["Who wouldn't want this beautiful house?", "Only it's expensive."],
+    "discourseSegments": [
+      "Who wouldn't want this beautiful house?",
+      "Only it's expensive."
+    ],
     "glossedTokens": [],
     "translation": "Who wouldn't want this beautiful house? Only it's expensive.",
     "context": "",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "negRhetoricalWhQ"], ["position", "left"], ["particle", "only"], ["interpretation", "committed"]],
+    "paperFeatures": [
+      ["clauseType", "negRhetoricalWhQ"],
+      ["position", "left"],
+      ["particle", "only"],
+      ["interpretation", "committed"]
+    ],
     "comment": "Repeated as (20). The speaker takes it to be true that everyone would want the house, so S supports an answer to the QUD."
   },
   {
@@ -79,14 +113,23 @@
     "source": {"bibkey": "ippolito-kiss-williams-2025", "paperLabel": "(6e)"},
     "language": "stan1293",
     "primaryText": "Stop saying that I have financial difficulties. After all, who bought this house? Only I don't advertize it.",
-    "discourseSegments": ["Stop saying that I have financial difficulties.", "After all, who bought this house?", "Only I don't advertize it."],
+    "discourseSegments": [
+      "Stop saying that I have financial difficulties.",
+      "After all, who bought this house?",
+      "Only I don't advertize it."
+    ],
     "glossedTokens": [],
     "translation": "Stop saying that I have financial difficulties. After all, who bought this house? Only I don't advertize it.",
     "context": "",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "posRhetoricalWhQ"], ["position", "left"], ["particle", "only"], ["interpretation", "committed"]],
+    "paperFeatures": [
+      ["clauseType", "posRhetoricalWhQ"],
+      ["position", "left"],
+      ["particle", "only"],
+      ["interpretation", "committed"]
+    ],
     "comment": "Rhetorical question suggesting a positive answer ('I did'); the speaker is committed to that answer."
   },
   {
@@ -94,14 +137,22 @@
     "source": {"bibkey": "ippolito-kiss-williams-2025", "paperLabel": "(22)"},
     "language": "stan1293",
     "primaryText": "Isn't the door open? #Only it's stifling inside.",
-    "discourseSegments": ["Isn't the door open?", "#Only it's stifling inside."],
+    "discourseSegments": [
+      "Isn't the door open?",
+      "#Only it's stifling inside."
+    ],
     "glossedTokens": [],
     "translation": "Isn't the door open? Only it's stifling inside.",
     "context": "",
     "judgment": "unacceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "highNegPolarQ"], ["position", "left"], ["particle", "only"], ["interpretation", "infoSeeking"]],
+    "paperFeatures": [
+      ["clauseType", "highNegPolarQ"],
+      ["position", "left"],
+      ["particle", "only"],
+      ["interpretation", "infoSeeking"]
+    ],
     "comment": "A genuinely biased but still information-seeking high-negation polar question (Romero & Han 2002 type). Bias short of full speaker commitment does not license the left-argument position; minimal pair with (21) = (6b)."
   },
   {
@@ -116,7 +167,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "declarative"], ["position", "right"], ["particle", "solo che"]],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["position", "right"],
+      ["particle", "solo che"]
+    ],
     "comment": ""
   },
   {
@@ -131,7 +186,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "declarative"], ["position", "right"], ["particle", "tol'ko"]],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["position", "right"],
+      ["particle", "tol'ko"]
+    ],
     "comment": ""
   },
   {
@@ -146,7 +205,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "declarative"], ["position", "right"], ["particle", "csak"]],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["position", "right"],
+      ["particle", "csak"]
+    ],
     "comment": ""
   },
   {
@@ -161,7 +224,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "declarative"], ["position", "right"], ["particle", "zhǐshì"]],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["position", "right"],
+      ["particle", "zhǐshì"]
+    ],
     "comment": ""
   },
   {
@@ -176,7 +243,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "canonicalPolarQ"], ["position", "right"], ["particle", "tol'ko"]],
+    "paperFeatures": [
+      ["clauseType", "canonicalPolarQ"],
+      ["position", "right"],
+      ["particle", "tol'ko"]
+    ],
     "comment": ""
   },
   {
@@ -191,7 +262,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "highNegPolarQ"], ["position", "right"], ["particle", "tol'ko"]],
+    "paperFeatures": [
+      ["clauseType", "highNegPolarQ"],
+      ["position", "right"],
+      ["particle", "tol'ko"]
+    ],
     "comment": ""
   },
   {
@@ -206,7 +281,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "canonicalWhQ"], ["position", "right"], ["particle", "tol'ko"]],
+    "paperFeatures": [
+      ["clauseType", "canonicalWhQ"],
+      ["position", "right"],
+      ["particle", "tol'ko"]
+    ],
     "comment": ""
   },
   {
@@ -221,7 +300,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "negRhetoricalWhQ"], ["position", "right"], ["particle", "tol'ko"]],
+    "paperFeatures": [
+      ["clauseType", "negRhetoricalWhQ"],
+      ["position", "right"],
+      ["particle", "tol'ko"]
+    ],
     "comment": "Rhetorical: the speaker is committed to the answer 'nobody', so the prejacent supports the negative QUD answer rather than failing to support anything."
   },
   {
@@ -236,7 +319,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "imperative"], ["position", "right"], ["particle", "tol'ko"]],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["position", "right"],
+      ["particle", "tol'ko"]
+    ],
     "comment": ""
   },
   {
@@ -244,14 +331,21 @@
     "source": {"bibkey": "ippolito-kiss-williams-2025", "paperLabel": "(30f)"},
     "language": "russ1263",
     "primaryText": "Kakoj krasivyj dom! Tol'ko vot rajon uzhasnyj!",
-    "discourseSegments": ["Kakoj krasivyj dom!", "Tol'ko vot rajon uzhasnyj!"],
+    "discourseSegments": [
+      "Kakoj krasivyj dom!",
+      "Tol'ko vot rajon uzhasnyj!"
+    ],
     "glossedTokens": [],
     "translation": "What a beautiful house! Only, what a terrible neighborhood!",
     "context": "Plausible QUD: Should we buy the house?",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "exclamative"], ["position", "right"], ["particle", "tol'ko"]],
+    "paperFeatures": [
+      ["clauseType", "exclamative"],
+      ["position", "right"],
+      ["particle", "tol'ko"]
+    ],
     "comment": ""
   },
   {
@@ -268,7 +362,11 @@
       {"form": "Szép ez a ház, csakhogy fel van újítva?", "judgment": "ungrammatical"}
     ],
     "readings": [],
-    "paperFeatures": [["clauseType", "canonicalPolarQ"], ["position", "right"], ["particle", "csak"]],
+    "paperFeatures": [
+      ["clauseType", "canonicalPolarQ"],
+      ["position", "right"],
+      ["particle", "csak"]
+    ],
     "comment": "Csakhogy alternative constructed per the paper's section 7 prose ('unacceptable in any of the example sentences in (31)'); the substituted form is not printed in the paper."
   },
   {
@@ -285,7 +383,11 @@
       {"form": "Szép ez a ház, csakhogy nem ezt adták el az előbb?", "judgment": "ungrammatical"}
     ],
     "readings": [],
-    "paperFeatures": [["clauseType", "highNegPolarQ"], ["position", "right"], ["particle", "csak"]],
+    "paperFeatures": [
+      ["clauseType", "highNegPolarQ"],
+      ["position", "right"],
+      ["particle", "csak"]
+    ],
     "comment": "Csakhogy alternative constructed per the paper's section 7 prose ('unacceptable in any of the example sentences in (31)'); the substituted form is not printed in the paper."
   },
   {
@@ -302,7 +404,11 @@
       {"form": "Szép ez a ház, csakhogy mikor lett felújítva?", "judgment": "ungrammatical"}
     ],
     "readings": [],
-    "paperFeatures": [["clauseType", "canonicalWhQ"], ["position", "right"], ["particle", "csak"]],
+    "paperFeatures": [
+      ["clauseType", "canonicalWhQ"],
+      ["position", "right"],
+      ["particle", "csak"]
+    ],
     "comment": "Csakhogy alternative constructed per the paper's section 7 prose ('unacceptable in any of the example sentences in (31)'); the substituted form is not printed in the paper."
   },
   {
@@ -319,7 +425,11 @@
       {"form": "Szép ez a ház, csakhogy ki fizetne érte 2 milliót?", "judgment": "ungrammatical"}
     ],
     "readings": [],
-    "paperFeatures": [["clauseType", "negRhetoricalWhQ"], ["position", "right"], ["particle", "csak"]],
+    "paperFeatures": [
+      ["clauseType", "negRhetoricalWhQ"],
+      ["position", "right"],
+      ["particle", "csak"]
+    ],
     "comment": "Rhetorical: the speaker is committed to the answer 'nobody'. Csakhogy alternative constructed per the paper's section 7 prose ('unacceptable in any of the example sentences in (31)'); the substituted form is not printed in the paper."
   },
   {
@@ -336,7 +446,11 @@
       {"form": "Vidd el a bérletem, csakhogy ne hagyd el!", "judgment": "ungrammatical"}
     ],
     "readings": [],
-    "paperFeatures": [["clauseType", "imperative"], ["position", "right"], ["particle", "csak"]],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["position", "right"],
+      ["particle", "csak"]
+    ],
     "comment": "Csakhogy alternative constructed per the paper's section 7 prose ('unacceptable in any of the example sentences in (31)'); the substituted form is not printed in the paper."
   },
   {
@@ -344,7 +458,10 @@
     "source": {"bibkey": "ippolito-kiss-williams-2025", "paperLabel": "(31f)"},
     "language": "hung1274",
     "primaryText": "Milyen szép ház! Csak micsoda környék!",
-    "discourseSegments": ["Milyen szép ház!", "Csak micsoda környék!"],
+    "discourseSegments": [
+      "Milyen szép ház!",
+      "Csak micsoda környék!"
+    ],
     "glossedTokens": [],
     "translation": "What a beautiful house! Only what a terrible neighborhood!",
     "context": "Plausible QUD: Should we buy the house?",
@@ -353,7 +470,11 @@
       {"form": "Milyen szép ház! Csakhogy micsoda környék!", "judgment": "ungrammatical"}
     ],
     "readings": [],
-    "paperFeatures": [["clauseType", "exclamative"], ["position", "right"], ["particle", "csak"]],
+    "paperFeatures": [
+      ["clauseType", "exclamative"],
+      ["position", "right"],
+      ["particle", "csak"]
+    ],
     "comment": "Csakhogy alternative constructed per the paper's section 7 prose ('unacceptable in any of the example sentences in (31)'); the substituted form is not printed in the paper."
   },
   {
@@ -368,7 +489,11 @@
     "judgment": "marginal",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "canonicalPolarQ"], ["position", "right"], ["particle", "zhǐshì"]],
+    "paperFeatures": [
+      ["clauseType", "canonicalPolarQ"],
+      ["position", "right"],
+      ["particle", "zhǐshì"]
+    ],
     "comment": "The paper marks the prejacent with % (speaker-variable acceptability); the five-level Judgment scale has no dialect-variation case, so % is encoded as marginal."
   },
   {
@@ -383,7 +508,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "highNegPolarQ"], ["position", "right"], ["particle", "zhǐshì"]],
+    "paperFeatures": [
+      ["clauseType", "highNegPolarQ"],
+      ["position", "right"],
+      ["particle", "zhǐshì"]
+    ],
     "comment": ""
   },
   {
@@ -398,7 +527,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "canonicalWhQ"], ["position", "right"], ["particle", "zhǐshì"]],
+    "paperFeatures": [
+      ["clauseType", "canonicalWhQ"],
+      ["position", "right"],
+      ["particle", "zhǐshì"]
+    ],
     "comment": "Parenthesized shì and ne are the paper's own optionality marks."
   },
   {
@@ -413,7 +546,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "negRhetoricalWhQ"], ["position", "right"], ["particle", "zhǐshì"]],
+    "paperFeatures": [
+      ["clauseType", "negRhetoricalWhQ"],
+      ["position", "right"],
+      ["particle", "zhǐshì"]
+    ],
     "comment": "Rhetorical: the speaker is committed to the answer 'nobody'. Parenthesized yǒu is the paper's optionality mark."
   },
   {
@@ -428,7 +565,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "imperative"], ["position", "right"], ["particle", "zhǐshì"]],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["position", "right"],
+      ["particle", "zhǐshì"]
+    ],
     "comment": ""
   },
   {
@@ -436,14 +577,21 @@
     "source": {"bibkey": "ippolito-kiss-williams-2025", "paperLabel": "(32f)"},
     "language": "mand1415",
     "primaryText": "Duōme piàoliang de fángzi a! #Zhǐshì nàme chà de shèqū huánjìng!",
-    "discourseSegments": ["Duōme piàoliang de fángzi a!", "#Zhǐshì nàme chà de shèqū huánjìng!"],
+    "discourseSegments": [
+      "Duōme piàoliang de fángzi a!",
+      "#Zhǐshì nàme chà de shèqū huánjìng!"
+    ],
     "glossedTokens": [],
     "translation": "What a beautiful house! Only, what a terrible neighborhood!",
     "context": "Plausible QUD: Should we buy the house?",
     "judgment": "unacceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "exclamative"], ["position", "right"], ["particle", "zhǐshì"]],
+    "paperFeatures": [
+      ["clauseType", "exclamative"],
+      ["position", "right"],
+      ["particle", "zhǐshì"]
+    ],
     "comment": "# in the paper: pragmatic anomaly. Mandarin zhǐshì uniquely blocks exclamative prejacents in the four-language sample."
   },
   {
@@ -458,7 +606,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "declarative"], ["position", "right"], ["particle", "solo che"]],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["position", "right"],
+      ["particle", "solo che"]
+    ],
     "comment": ""
   },
   {
@@ -473,7 +625,11 @@
     "judgment": "ungrammatical",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "canonicalPolarQ"], ["position", "right"], ["particle", "solo che"]],
+    "paperFeatures": [
+      ["clauseType", "canonicalPolarQ"],
+      ["position", "right"],
+      ["particle", "solo che"]
+    ],
     "comment": "* in the paper. Italian solo che obligatorily cooccurs with the wired-in declarative complementizer che, which blocks all non-declarative prejacents (section 7)."
   },
   {
@@ -488,7 +644,11 @@
     "judgment": "ungrammatical",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "canonicalWhQ"], ["position", "right"], ["particle", "solo che"]],
+    "paperFeatures": [
+      ["clauseType", "canonicalWhQ"],
+      ["position", "right"],
+      ["particle", "solo che"]
+    ],
     "comment": "* in the paper; see (33b)."
   },
   {
@@ -503,7 +663,11 @@
     "judgment": "ungrammatical",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "imperative"], ["position", "right"], ["particle", "solo che"]],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["position", "right"],
+      ["particle", "solo che"]
+    ],
     "comment": "* in the paper; see (33b)."
   },
   {
@@ -518,7 +682,11 @@
     "judgment": "ungrammatical",
     "alternatives": [],
     "readings": [],
-    "paperFeatures": [["clauseType", "exclamative"], ["position", "right"], ["particle", "solo che"]],
+    "paperFeatures": [
+      ["clauseType", "exclamative"],
+      ["position", "right"],
+      ["particle", "solo che"]
+    ],
     "comment": "* in the paper; see (33b)."
   }
 ]

--- a/Linglib/Data/Examples/Klecha2016.json
+++ b/Linglib/Data/Examples/Klecha2016.json
@@ -11,8 +11,8 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "simultaneous (pregnancy at thinking)",     "judgment": "acceptable"},
-      {"name": "shifted (pregnancy before thinking)",       "judgment": "acceptable"},
+      {"name": "simultaneous (pregnancy at thinking)", "judgment": "acceptable"},
+      {"name": "shifted (pregnancy before thinking)", "judgment": "acceptable"},
       {"name": "future-shifted (pregnancy after thinking)", "judgment": "ungrammatical"}
     ],
     "comment": "Klecha 2016 ex (1), Semantics & Pragmatics 9(10) p. 9:1. Opening example introducing ULC; both deictic-tense and relative-tense theories are surveyed in his §1 against this datum. The DOX modal base under `think` blocks future-shifted reading, which is Klecha's central explanatory move.",

--- a/Linglib/Data/Examples/Kratzer1998.json
+++ b/Linglib/Data/Examples/Kratzer1998.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "kratzer1998_ex01",
-    "source":     {"bibkey": "abusch-1988",  "paperLabel": "WCCFL 7 SOT example"},
+    "source": {"bibkey": "abusch-1988", "paperLabel": "WCCFL 7 SOT example"},
     "reportedIn": {"bibkey": "kratzer-1998", "paperLabel": "(1)"},
     "language": "stan1293",
     "primaryText": "John decided a week ago that in ten days he would say to his mother that they were having their last meal together.",
@@ -12,7 +12,7 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "uninterpreted-past (SOT)",       "judgment": "acceptable"}
+      {"name": "uninterpreted-past (SOT)", "judgment": "acceptable"}
     ],
     "comment": "Kratzer's plot example (1). The point: a past tense morpheme can fail to make any semantic contribution beyond agreeing with a higher past. Section 1, p. 1.",
     "metaLanguage": "stan1293",
@@ -20,7 +20,7 @@
   },
   {
     "id": "kratzer1998_ex02",
-    "source":     {"bibkey": "ogihara-1989",  "paperLabel": "dissertation SOT example"},
+    "source": {"bibkey": "ogihara-1989", "paperLabel": "dissertation SOT example"},
     "reportedIn": {"bibkey": "kratzer-1998", "paperLabel": "(2)"},
     "language": "stan1293",
     "primaryText": "John said he would buy a fish that was still alive.",
@@ -31,8 +31,8 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "alive-at-buying (later-than-saying)",  "judgment": "acceptable"},
-      {"name": "alive-at-saying",                      "judgment": "acceptable"}
+      {"name": "alive-at-buying (later-than-saying)", "judgment": "acceptable"},
+      {"name": "alive-at-saying", "judgment": "acceptable"}
     ],
     "comment": "Kratzer's plot example (2), reported from Ogihara 1989. Ambiguity highlights non-pronominal use of past. Section 1, p. 1.",
     "metaLanguage": "stan1293",
@@ -86,8 +86,8 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "de se (John self-locates at 10)",     "judgment": "acceptable"},
-      {"name": "indexical (John thinks 11 is 10)",    "judgment": "marginal"}
+      {"name": "de se (John self-locates at 10)", "judgment": "acceptable"},
+      {"name": "indexical (John thinks 11 is 10)", "judgment": "marginal"}
     ],
     "comment": "Kratzer's temporal de se example (29), Section 5, p. 11. Attributed to v. Stechow 1982.",
     "metaLanguage": "stan1293",
@@ -123,8 +123,8 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "simultaneous (alive-at-buying, zero tense in RC)",      "judgment": "acceptable"},
-      {"name": "independent past (alive-before-buying, past in RC)",   "judgment": "acceptable"}
+      {"name": "simultaneous (alive-at-buying, zero tense in RC)", "judgment": "acceptable"},
+      {"name": "independent past (alive-before-buying, past in RC)", "judgment": "acceptable"}
     ],
     "comment": "Kratzer's example (32a), Section 5, p. 13. RC tense is structurally optional in a way SOT complement-tense is not.",
     "metaLanguage": "stan1293",
@@ -142,8 +142,8 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "RC zero-tense (alive-at-buying)",     "judgment": "acceptable"},
-      {"name": "RC past-tense (alive-at-saying)",     "judgment": "acceptable"}
+      {"name": "RC zero-tense (alive-at-buying)", "judgment": "acceptable"},
+      {"name": "RC past-tense (alive-at-saying)", "judgment": "acceptable"}
     ],
     "comment": "Kratzer's example (33a), Section 5, p. 13. Two LFs for the RC tense — zero-tense bound at the buying time, or genuine past bound at the saying time.",
     "metaLanguage": "stan1293",
@@ -179,7 +179,7 @@
     "judgment": "ungrammatical",
     "alternatives": [],
     "readings": [
-      {"name": "sickness-at-thought-time",  "judgment": "ungrammatical"}
+      {"name": "sickness-at-thought-time", "judgment": "ungrammatical"}
     ],
     "comment": "Kratzer's example (35a), Section 5, p. 13. Star is Kratzer's. Illustrates the minimal de re vs SOT contrast.",
     "metaLanguage": "stan1293",
@@ -197,7 +197,7 @@
     "judgment": "marginal",
     "alternatives": [],
     "readings": [
-      {"name": "de re on present state",   "judgment": "marginal"}
+      {"name": "de re on present state", "judgment": "marginal"}
     ],
     "comment": "Kratzer's example (36a), Section 6, p. 14. \"Marginal for many speakers\" per Kratzer; some speakers accept readily.",
     "metaLanguage": "stan1293",
@@ -250,8 +250,9 @@
       "Borromini baute diese Kirche."
     ],
     "glossedTokens": [
-      ["Wer", "who"],          ["baute", "build.PST.3SG"], ["diese", "DEM.ACC.SG.F"], ["Kirche", "church"],
-      ["Borromini", "Borromini"], ["baute", "build.PST.3SG"], ["diese", "DEM.ACC.SG.F"], ["Kirche", "church"]
+      ["Wer", "who"], ["baute", "build.PST.3SG"], ["diese", "DEM.ACC.SG.F"], ["Kirche", "church"],
+      ["Borromini", "Borromini"], ["baute", "build.PST.3SG"], ["diese", "DEM.ACC.SG.F"],
+      ["Kirche", "church"]
     ],
     "translation": "Who built this church? Borromini built this church.",
     "context": "Looking at churches in Italy, no previous discourse. German simple past (Präteritum) infelicitous out of the blue.",
@@ -272,8 +273,9 @@
       "Borromini hat diese Kirche gebaut."
     ],
     "glossedTokens": [
-      ["Wer", "who"],            ["hat", "have.AUX.PRS.3SG"], ["diese", "DEM.ACC.SG.F"], ["Kirche", "church"], ["gebaut", "build.PTCP"],
-      ["Borromini", "Borromini"], ["hat", "have.AUX.PRS.3SG"], ["diese", "DEM.ACC.SG.F"], ["Kirche", "church"], ["gebaut", "build.PTCP"]
+      ["Wer", "who"], ["hat", "have.AUX.PRS.3SG"], ["diese", "DEM.ACC.SG.F"], ["Kirche", "church"],
+      ["gebaut", "build.PTCP"], ["Borromini", "Borromini"], ["hat", "have.AUX.PRS.3SG"],
+      ["diese", "DEM.ACC.SG.F"], ["Kirche", "church"], ["gebaut", "build.PTCP"]
     ],
     "translation": "Who has this church built? Borromini has this church built.",
     "context": "Same out-of-the-blue Italy-church scenario. Standard German Perfekt is felicitous where simple past is not.",
@@ -307,8 +309,9 @@
     "primaryText": "Wir werden jeden Brief beantworten, den wir bekamen.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Wir", "we"],           ["werden", "will.AUX.PRS.1PL"], ["jeden", "every.ACC.SG.M"], ["Brief", "letter"],
-      ["beantworten", "answer.INF"], ["den", "REL.ACC.SG.M"],     ["wir", "we"],            ["bekamen", "receive.PST.1PL"]
+      ["Wir", "we"], ["werden", "will.AUX.PRS.1PL"], ["jeden", "every.ACC.SG.M"],
+      ["Brief", "letter"], ["beantworten", "answer.INF"], ["den", "REL.ACC.SG.M"], ["wir", "we"],
+      ["bekamen", "receive.PST.1PL"]
     ],
     "translation": "We will answer every letter that we received.",
     "context": "Same content as (41a) in Standard German Präteritum. Needs a contextually salient past time to be acceptable.",
@@ -326,8 +329,9 @@
     "primaryText": "Wir werden jeden Brief beantworten, den wir bekommen haben.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Wir", "we"],              ["werden", "will.AUX.PRS.1PL"], ["jeden", "every.ACC.SG.M"], ["Brief", "letter"],
-      ["beantworten", "answer.INF"], ["den", "REL.ACC.SG.M"],     ["wir", "we"],            ["bekommen", "receive.PTCP"], ["haben", "have.AUX.PRS.1PL"]
+      ["Wir", "we"], ["werden", "will.AUX.PRS.1PL"], ["jeden", "every.ACC.SG.M"],
+      ["Brief", "letter"], ["beantworten", "answer.INF"], ["den", "REL.ACC.SG.M"], ["wir", "we"],
+      ["bekommen", "receive.PTCP"], ["haben", "have.AUX.PRS.1PL"]
     ],
     "translation": "We will answer every letter that we have received.",
     "context": "Same content as (41a/b) but with German Perfekt in the RC. Felicitous without a salient past time.",
@@ -350,7 +354,7 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "anaphoric (caught-before-dreaming)",     "judgment": "acceptable"},
+      {"name": "anaphoric (caught-before-dreaming)", "judgment": "acceptable"},
       {"name": "backward-shifted (caught-before-eating)", "judgment": "acceptable"}
     ],
     "comment": "Kratzer's example (42a), Section 7, p. 16-17. Per Kratzer: \"Underlined past tense does not have to be anaphoric.\"",
@@ -364,16 +368,16 @@
     "primaryText": "Hans träumte davon, einen Fisch zu essen, den er selber fing.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Hans", "Hans"],            ["träumte", "dream.PST.3SG"], ["davon", "R.of"],          ["einen", "INDEF.ACC.SG.M"],
-      ["Fisch", "fish"],           ["zu", "INF.PRT"],            ["essen", "eat.INF"],       ["den", "REL.ACC.SG.M"],
-      ["er", "he"],                ["selber", "INTENS"],         ["fing", "catch.PST.3SG"]
+      ["Hans", "Hans"], ["träumte", "dream.PST.3SG"], ["davon", "R.of"],
+      ["einen", "INDEF.ACC.SG.M"], ["Fisch", "fish"], ["zu", "INF.PRT"], ["essen", "eat.INF"],
+      ["den", "REL.ACC.SG.M"], ["er", "he"], ["selber", "INTENS"], ["fing", "catch.PST.3SG"]
     ],
     "translation": "Hans dreamed about eating a fish that he himself caught.",
     "context": "Same content as (42a) with German Präteritum in the RC. Per Kratzer, the past tense must be anaphoric (no backward-shifted reading).",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "anaphoric (caught-at-dreaming-time)",     "judgment": "acceptable"},
+      {"name": "anaphoric (caught-at-dreaming-time)", "judgment": "acceptable"},
       {"name": "backward-shifted (caught-before-eating)", "judgment": "unacceptable"}
     ],
     "comment": "Kratzer's example (42b), Section 7, p. 16-17. Per Kratzer: \"Underlined past tense must be anaphoric.\" The backward-shifted reading is an interpretation gap (unavailable LF), not a string ill-formedness — hence `unacceptable` rather than `ungrammatical`.",
@@ -387,9 +391,10 @@
     "primaryText": "Hans träumte davon, einen Fisch zu essen, den er selber gefangen hatte.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Hans", "Hans"],            ["träumte", "dream.PST.3SG"], ["davon", "R.of"],          ["einen", "INDEF.ACC.SG.M"],
-      ["Fisch", "fish"],           ["zu", "INF.PRT"],            ["essen", "eat.INF"],       ["den", "REL.ACC.SG.M"],
-      ["er", "he"],                ["selber", "INTENS"],         ["gefangen", "catch.PTCP"], ["hatte", "have.AUX.PST.3SG"]
+      ["Hans", "Hans"], ["träumte", "dream.PST.3SG"], ["davon", "R.of"],
+      ["einen", "INDEF.ACC.SG.M"], ["Fisch", "fish"], ["zu", "INF.PRT"], ["essen", "eat.INF"],
+      ["den", "REL.ACC.SG.M"], ["er", "he"], ["selber", "INTENS"], ["gefangen", "catch.PTCP"],
+      ["hatte", "have.AUX.PST.3SG"]
     ],
     "translation": "Hans dreamed about eating a fish that he had caught himself.",
     "context": "To recover the backward-shifted reading in German, the past perfect (Plusquamperfekt) is required.",

--- a/Linglib/Data/Examples/Kriz2015.json
+++ b/Linglib/Data/Examples/Kriz2015.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "kriz2015_switches_pos_gap",
-    "source":     {"bibkey": "kriz-2015", "paperLabel": "canonical switches homogeneity item"},
+    "source": {"bibkey": "kriz-2015", "paperLabel": "canonical switches homogeneity item"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "The switches are on.",
@@ -15,8 +15,8 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["polarity",     "positive"],
-      ["condition",    "GAP"],
+      ["polarity", "positive"],
+      ["condition", "GAP"],
       ["gap_detected", "true"]
     ],
     "comment": "Migrated from Phenomena/Plurals/Homogeneity.lean switchesExample (positiveInGap = neitherTrueNorFalse): homogeneity gap — neither clearly true nor clearly false when some but not all switches are on. The Lean source also cites kriz-chemla-2015 for this item. The ALL cell (all 10 on: positive clearly true, negative clearly false) and NONE cell (none on: positive clearly false, negative clearly true) are recorded in the same Lean datum.",
@@ -25,13 +25,14 @@
   },
   {
     "id": "kriz2015_switches_neg_gap",
-    "source":     {"bibkey": "kriz-2015", "paperLabel": "canonical switches homogeneity item, negated"},
+    "source": {"bibkey": "kriz-2015", "paperLabel": "canonical switches homogeneity item, negated"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "The switches are not on.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["The", "DEF"], ["switches", "switch.PL"], ["are", "be.PRS.PL"], ["not", "NEG"], ["on", "on"]
+      ["The", "DEF"], ["switches", "switch.PL"], ["are", "be.PRS.PL"], ["not", "NEG"],
+      ["on", "on"]
     ],
     "translation": "The switches are not on.",
     "context": "Ten switches; 5 of the 10 switches are on.",
@@ -41,8 +42,8 @@
     ],
     "readings": [],
     "paperFeatures": [
-      ["polarity",     "negative"],
-      ["condition",    "GAP"],
+      ["polarity", "negative"],
+      ["condition", "GAP"],
       ["gap_detected", "true"]
     ],
     "comment": "Migrated from Phenomena/Plurals/Homogeneity.lean switchesExample (negativeInGap = neitherTrueNorFalse): the gap is symmetric under negation. The sentential-negation variant in alternatives is carried from the Lean source's inline comment on negativeSentence.",
@@ -51,13 +52,14 @@
   },
   {
     "id": "kriz2015_switches_nonmax_existential",
-    "source":     {"bibkey": "kriz-2015", "paperLabel": "(11) switches non-maximality"},
+    "source": {"bibkey": "kriz-2015", "paperLabel": "(11) switches non-maximality"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Oh no, the switches are on!",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Oh", "oh"], ["no", "no"], ["the", "DEF"], ["switches", "switch.PL"], ["are", "be.PRS.PL"], ["on", "on"]
+      ["Oh", "oh"], ["no", "no"], ["the", "DEF"], ["switches", "switch.PL"], ["are", "be.PRS.PL"],
+      ["on", "on"]
     ],
     "translation": "Oh no, the switches are on!",
     "context": "Fire risk if any switch is on; 2 of the 10 switches are on. Implicit question: Are any of the switches on?",
@@ -67,9 +69,9 @@
     ],
     "readings": [],
     "paperFeatures": [
-      ["polarity",  "positive"],
+      ["polarity", "positive"],
       ["condition", "GAP"],
-      ["issue",     "existential"]
+      ["issue", "existential"]
     ],
     "comment": "UNVERIFIED paperLabel: dissertation example number carried from prior Lean file (Phenomena/Plurals/NonMaximality.lean switchesNonMaximality, 'dissertation (11)'), not checked against PDF. Non-maximal reading acceptable when the all/some distinction is irrelevant to the issue (acceptableInNonMaximalContext = true). The 'all the switches' alternative is migrated from switchesAllBlocks ('dissertation (17)' per the prior Lean file, equally unverified): 'all' blocks non-maximality even in this permissive context (allAcceptable = false).",
     "metaLanguage": "stan1293",
@@ -77,13 +79,14 @@
   },
   {
     "id": "kriz2015_switches_nonmax_universal",
-    "source":     {"bibkey": "kriz-2015", "paperLabel": "(11) switches non-maximality"},
+    "source": {"bibkey": "kriz-2015", "paperLabel": "(11) switches non-maximality"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Oh no, the switches are on!",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Oh", "oh"], ["no", "no"], ["the", "DEF"], ["switches", "switch.PL"], ["are", "be.PRS.PL"], ["on", "on"]
+      ["Oh", "oh"], ["no", "no"], ["the", "DEF"], ["switches", "switch.PL"], ["are", "be.PRS.PL"],
+      ["on", "on"]
     ],
     "translation": "Oh no, the switches are on!",
     "context": "Fire risk only if all 10 switches are on; 2 of the 10 switches are on. Implicit question: Are all the switches on?",
@@ -91,9 +94,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["polarity",  "positive"],
+      ["polarity", "positive"],
       ["condition", "GAP"],
-      ["issue",     "universal"]
+      ["issue", "universal"]
     ],
     "comment": "UNVERIFIED paperLabel: dissertation example number carried from prior Lean file (Phenomena/Plurals/NonMaximality.lean switchesNonMaximality), not checked against PDF. Same sentence and scenario as the existential-issue row, but with the all/some distinction relevant the non-maximal use is misleading (acceptableInMaximalContext = false, Lean inline comment 'misleading').",
     "metaLanguage": "stan1293",

--- a/Linglib/Data/Examples/KrizChemla2015.json
+++ b/Linglib/Data/Examples/KrizChemla2015.json
@@ -1,27 +1,28 @@
 [
   {
     "id": "krizchemla2015_every_C2_gap",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C2, (19) E-every+GAP"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C2, (19) E-every+GAP"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Every boy found his presents.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Every", "every"], ["boy", "boy"], ["found", "find.PST"], ["his", "3SG.M.POSS"], ["presents", "present.PL"]
+      ["Every", "every"], ["boy", "boy"], ["found", "find.PST"], ["his", "3SG.M.POSS"],
+      ["presents", "present.PL"]
     ],
     "translation": "Every boy found his presents.",
     "context": "Four boys, each with nine presents to find; every boy found some but not all of his.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "strong/maximal",     "judgment": "acceptable"},
-      {"name": "weak/non-maximal",   "judgment": "marginal"}
+      {"name": "strong/maximal", "judgment": "acceptable"},
+      {"name": "weak/non-maximal", "judgment": "marginal"}
     ],
     "paperFeatures": [
-      ["operator",     "every"],
-      ["embedding",    "E-every"],
-      ["condition",    "GAP"],
-      ["experiment",   "C2"],
+      ["operator", "every"],
+      ["embedding", "E-every"],
+      ["condition", "GAP"],
+      ["experiment", "C2"],
       ["gap_detected", "true"]
     ],
     "comment": "C2 target condition. All three gap diagnostics significant (Table 9): Diag.1 β=6.7 χ²=26.7 p<10⁻⁶; Diag.2 β=7.7 χ²=35.1 p<10⁻⁸; Diag.3 β=4.9 χ²=4.0 p=.046. The 'weak/non-maximal' reading would interpret the sentence as 'every boy found some of his presents'; the paper finds this reading is marginal-to-rare in target-stimulus presentation, motivating the gap finding.",
@@ -30,13 +31,14 @@
   },
   {
     "id": "krizchemla2015_no_C2_gap",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C2, (20) E-no+GAP"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C2, (20) E-no+GAP"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "No boy found his presents.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["No", "no"], ["boy", "boy"], ["found", "find.PST"], ["his", "3SG.M.POSS"], ["presents", "present.PL"]
+      ["No", "no"], ["boy", "boy"], ["found", "find.PST"], ["his", "3SG.M.POSS"],
+      ["presents", "present.PL"]
     ],
     "translation": "No boy found his presents.",
     "context": "Four boys, each with nine presents; some boys found some of their presents, but no boy found all of his.",
@@ -44,15 +46,15 @@
     "alternatives": [],
     "readings": [
       {"name": "strong/no-any", "judgment": "acceptable"},
-      {"name": "weak/no-all",   "judgment": "marginal"}
+      {"name": "weak/no-all", "judgment": "marginal"}
     ],
     "paperFeatures": [
-      ["operator",     "no"],
-      ["embedding",    "E-no"],
-      ["condition",    "GAP"],
-      ["experiment",   "C2"],
+      ["operator", "no"],
+      ["embedding", "E-no"],
+      ["condition", "GAP"],
+      ["experiment", "C2"],
       ["gap_detected", "true"],
-      ["gap_size",     "small_but_robust"]
+      ["gap_size", "small_but_robust"]
     ],
     "comment": "C2 corrects the apparent null result from A2/B2 (which used the accidentally-ungrammatical 'In none of the cells...' stimulus, per fn. 10 and fn. 14). C2's grammatical 'No boy found his presents.' yields a small-but-robust gap on all three diagnostics (Table 9): Diag.1 β=1.3 χ²=8.2 p=.004; Diag.2 β=1.1 χ²=5.2 p=.022; Diag.3 β=1.6 χ²=7.8 p=.005. Quoting §5.2.3: 'this time, E-no does show a gap, which, albeit small, is robust.' This is the empirical finding the file records — not the pre-C2 null.",
     "metaLanguage": "stan1293",
@@ -60,28 +62,28 @@
   },
   {
     "id": "krizchemla2015_exactlyTwo_C3_gap",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C3, (24) E-exactly+GAP"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C3, (24) E-exactly+GAP"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Exactly 2 of the 4 boys found their presents.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Exactly", "exactly"], ["2", "two"], ["of", "of"], ["the", "DEF"], ["4", "four"], ["boys", "boy.PL"],
-      ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
+      ["Exactly", "exactly"], ["2", "two"], ["of", "of"], ["the", "DEF"], ["4", "four"],
+      ["boys", "boy.PL"], ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
     ],
     "translation": "Exactly 2 of the 4 boys found their presents.",
     "context": "Four boys; exactly two of them found at least some of their presents, but in at most one of those two cells did the boy find all of his presents.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "exactly/maximal",     "judgment": "acceptable"},
+      {"name": "exactly/maximal", "judgment": "acceptable"},
       {"name": "exactly/non-maximal", "judgment": "marginal"}
     ],
     "paperFeatures": [
-      ["operator",     "exactlyTwo"],
-      ["embedding",    "E-exactly"],
-      ["condition",    "GAP"],
-      ["experiment",   "C3"],
+      ["operator", "exactlyTwo"],
+      ["embedding", "E-exactly"],
+      ["condition", "GAP"],
+      ["experiment", "C3"],
       ["gap_detected", "true"]
     ],
     "comment": "C3 proper-GAP condition: target stimulus designed so that the literal exactly-2-found-all reading and the exactly-2-found-some reading yield different truth values, isolating homogeneity projection in the non-monotonic embedded scope. All three gap diagnostics significant (Table 10): Diag.1 β=3.9 χ²=21.0 p<10⁻⁵; Diag.2 β=7.7 χ²=38.8 p<10⁻⁹; Diag.3 β=6.6 χ²=13.5 p=.0002.",
@@ -90,28 +92,28 @@
   },
   {
     "id": "krizchemla2015_exactlyTwo_C3_gap_q",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C3, (24) E-exactly+GAP?"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C3, (24) E-exactly+GAP?"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Exactly 2 of the 4 boys found their presents.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Exactly", "exactly"], ["2", "two"], ["of", "of"], ["the", "DEF"], ["4", "four"], ["boys", "boy.PL"],
-      ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
+      ["Exactly", "exactly"], ["2", "two"], ["of", "of"], ["the", "DEF"], ["4", "four"],
+      ["boys", "boy.PL"], ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
     ],
     "translation": "Exactly 2 of the 4 boys found their presents.",
     "context": "Four boys; one boy found all his presents; two boys each found some (not all) of theirs; one boy found none.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "exactly/maximal",      "judgment": "questionable"},
-      {"name": "at-least-2/some",      "judgment": "acceptable"}
+      {"name": "exactly/maximal", "judgment": "questionable"},
+      {"name": "at-least-2/some", "judgment": "acceptable"}
     ],
     "paperFeatures": [
-      ["operator",     "exactlyTwo"],
-      ["embedding",    "E-exactly"],
-      ["condition",    "GAP?"],
-      ["experiment",   "C3"],
+      ["operator", "exactlyTwo"],
+      ["embedding", "E-exactly"],
+      ["condition", "GAP?"],
+      ["experiment", "C3"],
       ["gap_detected", "false"],
       ["interpretation", "at_least_reading_emerges"]
     ],
@@ -121,28 +123,28 @@
   },
   {
     "id": "krizchemla2015_exactlyTwo_C4_gap_qq",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C4, (24) E-exactly+GAP??"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C4, (24) E-exactly+GAP??"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Exactly 2 of the 4 boys found their presents.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Exactly", "exactly"], ["2", "two"], ["of", "of"], ["the", "DEF"], ["4", "four"], ["boys", "boy.PL"],
-      ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
+      ["Exactly", "exactly"], ["2", "two"], ["of", "of"], ["the", "DEF"], ["4", "four"],
+      ["boys", "boy.PL"], ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
     ],
     "translation": "Exactly 2 of the 4 boys found their presents.",
     "context": "Four boys; exactly two boys each found all their presents; a third boy found some (not all) of his; the fourth found none. The at-least-reading is false here (since three boys found some), so the only way to judge 'true' is via the homogeneity-bridged exactly-reading.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "exactly/maximal",      "judgment": "marginal"},
-      {"name": "at-least-2/some",      "judgment": "unacceptable"}
+      {"name": "exactly/maximal", "judgment": "marginal"},
+      {"name": "at-least-2/some", "judgment": "unacceptable"}
     ],
     "paperFeatures": [
-      ["operator",     "exactlyTwo"],
-      ["embedding",    "E-exactly"],
-      ["condition",    "GAP??"],
-      ["experiment",   "C4"],
+      ["operator", "exactlyTwo"],
+      ["embedding", "E-exactly"],
+      ["condition", "GAP??"],
+      ["experiment", "C4"],
       ["gap_detected", "true"]
     ],
     "comment": "C4 extends the C3 GAP? configuration to one where the at-least reading is false, ruling out the explanation that nulled GAP?. All three gap diagnostics significant (Table 11): Diag.1 β=4.4 χ²=13.4 p=.0002; Diag.2 β=7.6 χ²=49.4 p<10⁻¹¹; Diag.3 β=7.0 χ²=11.5 p=.0007. Combined with the GAP? null, this confirms that homogeneity *does* project from under 'exactly N', but only in configurations the at-least reading cannot rescue.",
@@ -151,7 +153,7 @@
   },
   {
     "id": "krizchemla2015_books_pos_all",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books)"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Ann liked the books.",
@@ -165,7 +167,7 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["polarity",  "positive"],
+      ["polarity", "positive"],
       ["condition", "ALL"],
       ["embedding", "unembedded"]
     ],
@@ -175,7 +177,7 @@
   },
   {
     "id": "krizchemla2015_books_pos_none",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books)"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Ann liked the books.",
@@ -189,7 +191,7 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["polarity",  "positive"],
+      ["polarity", "positive"],
       ["condition", "NONE"],
       ["embedding", "unembedded"]
     ],
@@ -199,7 +201,7 @@
   },
   {
     "id": "krizchemla2015_books_pos_gap",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books)"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Ann liked the books.",
@@ -213,9 +215,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["polarity",     "positive"],
-      ["condition",    "GAP"],
-      ["embedding",    "unembedded"],
+      ["polarity", "positive"],
+      ["condition", "GAP"],
+      ["embedding", "unembedded"],
       ["gap_detected", "true"]
     ],
     "comment": "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (positiveInGap = neitherTrueNorFalse): homogeneity gap — neither clearly true nor clearly false in the some-but-not-all scenario.",
@@ -224,13 +226,14 @@
   },
   {
     "id": "krizchemla2015_books_neg_all",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books, negated)"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books, negated)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Ann didn't like the books.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Ann", "Ann"], ["didn't", "do.PST.NEG"], ["like", "like"], ["the", "DEF"], ["books", "book.PL"]
+      ["Ann", "Ann"], ["didn't", "do.PST.NEG"], ["like", "like"], ["the", "DEF"],
+      ["books", "book.PL"]
     ],
     "translation": "Ann didn't like the books.",
     "context": "Six shortlisted books; Ann liked all 6 shortlisted books.",
@@ -238,7 +241,7 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["polarity",  "negative"],
+      ["polarity", "negative"],
       ["condition", "ALL"],
       ["embedding", "unembedded"]
     ],
@@ -248,13 +251,14 @@
   },
   {
     "id": "krizchemla2015_books_neg_none",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books, negated)"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books, negated)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Ann didn't like the books.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Ann", "Ann"], ["didn't", "do.PST.NEG"], ["like", "like"], ["the", "DEF"], ["books", "book.PL"]
+      ["Ann", "Ann"], ["didn't", "do.PST.NEG"], ["like", "like"], ["the", "DEF"],
+      ["books", "book.PL"]
     ],
     "translation": "Ann didn't like the books.",
     "context": "Six shortlisted books; Ann liked none of the 6 shortlisted books.",
@@ -262,7 +266,7 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["polarity",  "negative"],
+      ["polarity", "negative"],
       ["condition", "NONE"],
       ["embedding", "unembedded"]
     ],
@@ -272,13 +276,14 @@
   },
   {
     "id": "krizchemla2015_books_neg_gap",
-    "source":     {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books, negated)"},
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books, negated)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Ann didn't like the books.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Ann", "Ann"], ["didn't", "do.PST.NEG"], ["like", "like"], ["the", "DEF"], ["books", "book.PL"]
+      ["Ann", "Ann"], ["didn't", "do.PST.NEG"], ["like", "like"], ["the", "DEF"],
+      ["books", "book.PL"]
     ],
     "translation": "Ann didn't like the books.",
     "context": "Six shortlisted books; Ann liked 3 of the 6 shortlisted books.",
@@ -286,9 +291,9 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["polarity",     "negative"],
-      ["condition",    "GAP"],
-      ["embedding",    "unembedded"],
+      ["polarity", "negative"],
+      ["condition", "GAP"],
+      ["embedding", "unembedded"],
       ["gap_detected", "true"]
     ],
     "comment": "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (negativeInGap = neitherTrueNorFalse): homogeneity gap — neither clearly true nor clearly false in the some-but-not-all scenario.",

--- a/Linglib/Data/Examples/LoGuercio2025.json
+++ b/Linglib/Data/Examples/LoGuercio2025.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "loguercio2025_outOfBlue_epithet",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(epithet OOTB)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(epithet OOTB)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "John arrived late.",
@@ -21,7 +21,7 @@
   },
   {
     "id": "loguercio2025_priorMention_epithet",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(20a)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(20a)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "John arrived first, then that bastard Pedro arrived.",
@@ -45,7 +45,7 @@
   },
   {
     "id": "loguercio2025_subconstituent_epithet",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(epithet subconstituent)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(epithet subconstituent)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Yesterday, John met with that bastard Pedro.",
@@ -66,14 +66,13 @@
   },
   {
     "id": "loguercio2025_outOfBlue_honorific",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(Spanish honorific OOTB)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(Spanish honorific OOTB)"},
     "reportedIn": null,
     "language": "stan1288",
     "primaryText": "Diego entró.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Diego", "Diego"],
-      ["entró", "enter.PST.3SG"]
+      ["Diego", "Diego"], ["entró", "enter.PST.3SG"]
     ],
     "translation": "Diego entered.",
     "context": "Out-of-the-blue Spanish utterance; no prior contextual relevance of *don/doña*.",
@@ -90,7 +89,7 @@
   },
   {
     "id": "loguercio2025_contrastive_honorific",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(22a)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(22a)"},
     "reportedIn": null,
     "language": "stan1288",
     "primaryText": "Primero entró Donato. Después entró Don Pedro.",
@@ -99,13 +98,8 @@
       "Después entró Don Pedro."
     ],
     "glossedTokens": [
-      ["Primero", "first"],
-      ["entró", "enter.PST.3SG"],
-      ["Donato", "Donato"],
-      ["Después", "afterwards"],
-      ["entró", "enter.PST.3SG"],
-      ["Don", "HON.M"],
-      ["Pedro", "Pedro"]
+      ["Primero", "first"], ["entró", "enter.PST.3SG"], ["Donato", "Donato"],
+      ["Después", "afterwards"], ["entró", "enter.PST.3SG"], ["Don", "HON.M"], ["Pedro", "Pedro"]
     ],
     "translation": "First Donato entered. Afterwards Don Pedro entered.",
     "context": "Two-segment discourse; the second segment uses honorific *Don* while the first uses bare name *Donato*.",
@@ -123,7 +117,7 @@
   },
   {
     "id": "loguercio2025_outOfBlue_appositive",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(31a)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(31a)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Diego recommended an aspirin.",
@@ -143,7 +137,7 @@
   },
   {
     "id": "loguercio2025_priorMention_appositive",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(31b)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(31b)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Diego recommended an aspirin. Laura, a doctor, recommended an antibiotic.",
@@ -167,7 +161,7 @@
   },
   {
     "id": "loguercio2025_outOfBlue_suppAdverb",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(33a)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(33a)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Juan signed up for the tournament.",
@@ -187,7 +181,7 @@
   },
   {
     "id": "loguercio2025_priorMention_suppAdverb",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(supp-adv prior mention)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(supp-adv prior mention)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Juan signed up for the tournament and luckily, Pedro signed up for the tournament.",
@@ -211,7 +205,7 @@
   },
   {
     "id": "loguercio2025_priorMention_emotiveMarker",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(38a)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(38a)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Juan signed up for the tournament, and Alas, Pedro signed up too.",
@@ -235,7 +229,7 @@
   },
   {
     "id": "loguercio2025_registerBlocking",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(28a)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(28a)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "That bastard John is late.",
@@ -256,7 +250,7 @@
   },
   {
     "id": "loguercio2025_disjunction_independent_of_assertion",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(50)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(50)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Juan called María or that bastard Pedro.",
@@ -277,7 +271,7 @@
   },
   {
     "id": "loguercio2025_DE_aci_survives",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(DE-embedding)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(DE-embedding)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "I doubt that Juan or that bastard Pedro passed the exam.",
@@ -298,7 +292,7 @@
   },
   {
     "id": "loguercio2025_cancellation",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(ACI cancellation)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(ACI cancellation)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Juan arrived first. Then that bastard Pedro arrived. By the way, Juan is also a bastard.",
@@ -321,7 +315,7 @@
   },
   {
     "id": "loguercio2025_reinforcement",
-    "source":     {"bibkey": "lo-guercio-2025", "paperLabel": "(ACI reinforcement)"},
+    "source": {"bibkey": "lo-guercio-2025", "paperLabel": "(ACI reinforcement)"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Juan arrived first. That bastard Pedro arrived second. By the way, Juan is not a bastard.",

--- a/Linglib/Data/Examples/Marsan2026.json
+++ b/Linglib/Data/Examples/Marsan2026.json
@@ -1,26 +1,13 @@
 [
   {
     "id": "tr_001a",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_001a"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_001a"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "Fatma ev-e gel-di.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Fatma",
-        "Fatma"
-      ],
-      [
-        "ev-e",
-        "home-DAT"
-      ],
-      [
-        "gel-di.",
-        "come-DI"
-      ]
+      ["Fatma", "Fatma"], ["ev-e", "home-DAT"], ["gel-di.", "come-DI"]
     ],
     "translation": "Fatma came home",
     "context": "",
@@ -28,42 +15,22 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "DI"
-      ],
-      [
-        "ET_ST",
-        "ET < ST"
-      ]
+      ["tam", "DI"],
+      ["ET_ST", "ET < ST"]
     ],
     "comment": "baseline DI",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_001b",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_001b"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_001b"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "Fatma ev-e gel-miş.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Fatma",
-        "Fatma"
-      ],
-      [
-        "ev-e",
-        "home-DAT"
-      ],
-      [
-        "gel-miş.",
-        "come-MIS"
-      ]
+      ["Fatma", "Fatma"], ["ev-e", "home-DAT"], ["gel-miş.", "come-MIS"]
     ],
     "translation": "Fatma apparently came home",
     "context": "",
@@ -71,46 +38,23 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "MIS"
-      ],
-      [
-        "ET_ST",
-        "ET < ST"
-      ],
-      [
-        "EAT_ET",
-        "ET < EAT"
-      ]
+      ["tam", "MIS"],
+      ["ET_ST", "ET < ST"],
+      ["EAT_ET", "ET < EAT"]
     ],
     "comment": "baseline MIS",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_002",
-    "source": {
-      "bibkey": "smirnova-2013",
-      "paperLabel": "tr_002"
-    },
+    "source": {"bibkey": "smirnova-2013", "paperLabel": "tr_002"},
+    "reportedIn": {"bibkey": "marsan-2026", "paperLabel": "tr_002"},
     "language": "stan1290",
     "primaryText": "Çok fena yağ-dı.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Çok",
-        "very"
-      ],
-      [
-        "fena",
-        "heavily"
-      ],
-      [
-        "yağ-dı.",
-        "fall-DI"
-      ]
+      ["Çok", "very"], ["fena", "heavily"], ["yağ-dı.", "fall-DI"]
     ],
     "translation": "It rained very heavily.",
     "context": "10 years ago the area where you live was devastated by a historic rainfall and the consequent\nflood. You weren’t in your hometown then but you know that the aftermaths were catastrophic. Your\nhouse was flooded, and the government announced the state of emergency in your area.\nNow you say about that event:",
@@ -118,61 +62,25 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "DI"
-      ],
-      [
-        "ET_ST",
-        "ET < ST"
-      ],
-      [
-        "EAT_ET",
-        "ET < EAT"
-      ],
-      [
-        "evidence_type",
-        "indirect"
-      ]
+      ["tam", "DI"],
+      ["ET_ST", "ET < ST"],
+      ["EAT_ET", "ET < EAT"],
+      ["evidence_type", "indirect"]
     ],
     "comment": "",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_002"
-    }
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_003",
-    "source": {
-      "bibkey": "smirnova-2013",
-      "paperLabel": "tr_003"
-    },
+    "source": {"bibkey": "smirnova-2013", "paperLabel": "tr_003"},
+    "reportedIn": {"bibkey": "marsan-2026", "paperLabel": "tr_003"},
     "language": "stan1290",
     "primaryText": "Maria kitap yaz-ıyor-muş / yaz-acak-mış.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Maria",
-        "Maria"
-      ],
-      [
-        "kitap",
-        "book"
-      ],
-      [
-        "yaz-ıyor-muş",
-        "write-IPFV-MIS"
-      ],
-      [
-        "/",
-        "/"
-      ],
-      [
-        "yaz-acak-mış.",
-        "write-PROSP-MIS"
-      ]
+      ["Maria", "Maria"], ["kitap", "book"], ["yaz-ıyor-muş", "write-IPFV-MIS"], ["/", "/"],
+      ["yaz-acak-mış.", "write-PROSP-MIS"]
     ],
     "translation": "Maria is writing a book, [I will hear]",
     "context": "You suspect that Maria is writing a book, but you have no evidence. Next week you have\na meeting with Maria’s sister, a good friend of yours. You plan to ask her weather Maria is writing a\nbook. Today, when someone asks you what Maria does, you say:",
@@ -180,61 +88,24 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "MIS"
-      ],
-      [
-        "EAT_ET",
-        "ET < EAT"
-      ],
-      [
-        "evidence_type",
-        "indirect"
-      ]
+      ["tam", "MIS"],
+      ["EAT_ET", "ET < EAT"],
+      ["evidence_type", "indirect"]
     ],
     "comment": "ST < EAT, Abusch upper limit constraint",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_003"
-    }
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_004a",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_004a"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_004a"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "Maria iki gün sonra Sofya'ya gid-ecek-miş.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Maria",
-        "Maria"
-      ],
-      [
-        "iki",
-        "two"
-      ],
-      [
-        "gün",
-        "day"
-      ],
-      [
-        "sonra",
-        "later"
-      ],
-      [
-        "Sofya'ya",
-        "Sofia-DAT"
-      ],
-      [
-        "gid-ecek-miş.",
-        "go-PROSP-MIS"
-      ]
+      ["Maria", "Maria"], ["iki", "two"], ["gün", "day"], ["sonra", "later"],
+      ["Sofya'ya", "Sofia-DAT"], ["gid-ecek-miş.", "go-PROSP-MIS"]
     ],
     "translation": "Maria will go to Sofia two days from now [I heard]",
     "context": "Ivan tells you today that Maria will travel to Sofia two days from now. You share this with\na friend of yours:",
@@ -242,66 +113,26 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "DI"
-      ],
-      [
-        "ET_ST",
-        "ST < ET"
-      ],
-      [
-        "EAT_ET",
-        "EAT < ET"
-      ],
-      [
-        "evidence_type",
-        "indirect"
-      ],
-      [
-        "evidential_context",
-        "reportative"
-      ]
+      ["tam", "DI"],
+      ["ET_ST", "ST < ET"],
+      ["EAT_ET", "EAT < ET"],
+      ["evidence_type", "indirect"],
+      ["evidential_context", "reportative"]
     ],
     "comment": "",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_004b",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_004b"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_004b"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "Maria iki gün sonra Sofya'ya gid-ecek-miş.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Maria",
-        "Maria"
-      ],
-      [
-        "iki",
-        "two"
-      ],
-      [
-        "gün",
-        "day"
-      ],
-      [
-        "sonra",
-        "later"
-      ],
-      [
-        "Sofya'ya",
-        "Sofia-DAT"
-      ],
-      [
-        "gid-ecek-miş.",
-        "go-PROSP-MIS"
-      ]
+      ["Maria", "Maria"], ["iki", "two"], ["gün", "day"], ["sonra", "later"],
+      ["Sofya'ya", "Sofia-DAT"], ["gid-ecek-miş.", "go-PROSP-MIS"]
     ],
     "translation": "Maria will go to Sofia two days from now [I inferred]",
     "context": "You see a ticket to Sofia for the day after tomorrow on Maria’s desk. You share this with a\nfriend:",
@@ -309,50 +140,25 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "MIS"
-      ],
-      [
-        "ET_ST",
-        "ST < ET"
-      ],
-      [
-        "EAT_ET",
-        "EAT < ET"
-      ],
-      [
-        "evidence_type",
-        "indirect"
-      ],
-      [
-        "evidential_context",
-        "inferential"
-      ]
+      ["tam", "MIS"],
+      ["ET_ST", "ST < ET"],
+      ["EAT_ET", "EAT < ET"],
+      ["evidence_type", "indirect"],
+      ["evidential_context", "inferential"]
     ],
     "comment": "",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_005",
-    "source": {
-      "bibkey": "smirnova-2012",
-      "paperLabel": "tr_005"
-    },
+    "source": {"bibkey": "smirnova-2012", "paperLabel": "tr_005"},
+    "reportedIn": {"bibkey": "marsan-2026", "paperLabel": "tr_005"},
     "language": "stan1290",
     "primaryText": "Yemek piş-miş.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Yemek",
-        "dish"
-      ],
-      [
-        "piş-miş.",
-        "cook-MIS"
-      ]
+      ["Yemek", "dish"], ["piş-miş.", "cook-MIS"]
     ],
     "translation": "The dish is/has been cooked.",
     "context": "You and your friends are cooking dinner together. According to the recipe, the dish should\ncook for 20 more minutes. However, when you taste the dish, you realize that it is ready. You say:",
@@ -360,53 +166,25 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "MIS"
-      ],
-      [
-        "ET_ST",
-        "ET < ST"
-      ],
-      [
-        "EAT_ET",
-        "ET < EAT"
-      ],
-      [
-        "evidence_type",
-        "direct"
-      ],
-      [
-        "evidential_context",
-        "inferential"
-      ]
+      ["tam", "MIS"],
+      ["ET_ST", "ET < ST"],
+      ["EAT_ET", "ET < EAT"],
+      ["evidence_type", "direct"],
+      ["evidential_context", "inferential"]
     ],
     "comment": "Smirnova takes this to be ET = EAT = ST",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_005"
-    }
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_006a",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_006a"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_006a"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "Yemek piş-miş.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Yemek",
-        "dish"
-      ],
-      [
-        "piş-miş.",
-        "cook-MIS"
-      ]
+      ["Yemek", "dish"], ["piş-miş.", "cook-MIS"]
     ],
     "translation": "The dish is/has been cooked.",
     "context": "You and your friends are cooking dinner together. According to the recipe, the dish should\ncook for 20 more minutes and is supposed to bubble when it is done. To your surprise, it starts bubbling\nas you watch and stir it. You say:",
@@ -414,46 +192,24 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "MIS"
-      ],
-      [
-        "ET_ST",
-        "ET = ST"
-      ],
-      [
-        "EAT_ET",
-        "ET = EAT"
-      ],
-      [
-        "evidence_type",
-        "direct"
-      ]
+      ["tam", "MIS"],
+      ["ET_ST", "ET = ST"],
+      ["EAT_ET", "ET = EAT"],
+      ["evidence_type", "direct"]
     ],
     "comment": "",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_006b",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_006b"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_006b"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "Yemek piş-miş.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Yemek",
-        "dish"
-      ],
-      [
-        "piş-miş.",
-        "cook-MIS"
-      ]
+      ["Yemek", "dish"], ["piş-miş.", "cook-MIS"]
     ],
     "translation": "The dish is/has been cooked.",
     "context": "You and your friends are cooking dinner together. According to the recipe, the dish should\ncook for 20 more minutes and is supposed to bubble when it is done. You check it every five minutes.\nThe last time you checked, it was not done yet, but now, to your surprise, it is bubbling. You say:",
@@ -461,54 +217,25 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "MIS"
-      ],
-      [
-        "ET_ST",
-        "ET < ST"
-      ],
-      [
-        "EAT_ET",
-        "ET < EAT"
-      ],
-      [
-        "evidence_type",
-        "direct"
-      ],
-      [
-        "evidential_context",
-        "inferential"
-      ]
+      ["tam", "MIS"],
+      ["ET_ST", "ET < ST"],
+      ["EAT_ET", "ET < EAT"],
+      ["evidence_type", "direct"],
+      ["evidential_context", "inferential"]
     ],
     "comment": "",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_007a",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_007a"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_007a"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "Venüs balık ye-me-di.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Venüs",
-        "Venus"
-      ],
-      [
-        "balık",
-        "fish"
-      ],
-      [
-        "ye-me-di.",
-        "eat-NEG-DI"
-      ]
+      ["Venüs", "Venus"], ["balık", "fish"], ["ye-me-di.", "eat-NEG-DI"]
     ],
     "translation": "Venus didn't eat fish.",
     "context": "",
@@ -516,46 +243,22 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "DI"
-      ],
-      [
-        "ET_ST",
-        "ET < ST"
-      ]
+      ["tam", "DI"],
+      ["ET_ST", "ET < ST"]
     ],
     "comment": "",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_007b",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_007b"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_007b"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "Venüs balık ye-di değil.",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Venüs",
-        "Venus"
-      ],
-      [
-        "balık",
-        "fish"
-      ],
-      [
-        "ye-di",
-        "eat-DI"
-      ],
-      [
-        "değil.",
-        "NEG"
-      ]
+      ["Venüs", "Venus"], ["balık", "fish"], ["ye-di", "eat-DI"], ["değil.", "NEG"]
     ],
     "translation": "It is not the case that Venüs ate fish.",
     "context": "",
@@ -563,54 +266,23 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "DI"
-      ],
-      [
-        "ET_ST",
-        "ET < ST"
-      ]
+      ["tam", "DI"],
+      ["ET_ST", "ET < ST"]
     ],
     "comment": "Outer negation is not compatible with DI.",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_008a",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_008a"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_008a"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "İlk set-i bizim takım önde bitir-di",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "İlk",
-        "first"
-      ],
-      [
-        "set-i",
-        "set-ACC"
-      ],
-      [
-        "bizim",
-        "our"
-      ],
-      [
-        "takım",
-        "team"
-      ],
-      [
-        "önde",
-        "ahead"
-      ],
-      [
-        "bitir-di",
-        "end-DI"
-      ]
+      ["İlk", "first"], ["set-i", "set-ACC"], ["bizim", "our"], ["takım", "team"],
+      ["önde", "ahead"], ["bitir-di", "end-DI"]
     ],
     "translation": "Our team ended the first set ahead.",
     "context": "You follow a live volleyball game by listening to a radio commentator’s play-by-play\ndescription. You have no direct visual or auditory access to the game itself. The next day, you report\non the match:",
@@ -618,62 +290,25 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "DI"
-      ],
-      [
-        "ET_ST",
-        "ET < ST"
-      ],
-      [
-        "EAT_ET",
-        "ET = EAT"
-      ],
-      [
-        "evidence_type",
-        "indirect"
-      ]
+      ["tam", "DI"],
+      ["ET_ST", "ET < ST"],
+      ["EAT_ET", "ET = EAT"],
+      ["evidence_type", "indirect"]
     ],
     "comment": "",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_008b",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_008b"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_008b"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "İlk set-i bizim takım önde bitir-miş",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "İlk",
-        "first"
-      ],
-      [
-        "set-i",
-        "set-ACC"
-      ],
-      [
-        "bizim",
-        "our"
-      ],
-      [
-        "takım",
-        "team"
-      ],
-      [
-        "önde",
-        "ahead"
-      ],
-      [
-        "bitir-miş",
-        "end-MIS"
-      ]
+      ["İlk", "first"], ["set-i", "set-ACC"], ["bizim", "our"], ["takım", "team"],
+      ["önde", "ahead"], ["bitir-miş", "end-MIS"]
     ],
     "translation": "Our team ended the first set ahead.",
     "context": "You follow a live volleyball game by listening to a radio commentator’s play-by-play\ndescription. You have no direct visual or auditory access to the game itself. The next day, you report\non the match:",
@@ -681,62 +316,25 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "MIS"
-      ],
-      [
-        "ET_ST",
-        "ET < ST"
-      ],
-      [
-        "EAT_ET",
-        "ET < EAT"
-      ],
-      [
-        "evidence_type",
-        "indirect"
-      ]
+      ["tam", "MIS"],
+      ["ET_ST", "ET < ST"],
+      ["EAT_ET", "ET < EAT"],
+      ["evidence_type", "indirect"]
     ],
     "comment": "",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_008c",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_008c"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_008c"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "İlk set-i bizim takım önde bitir-miş",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "İlk",
-        "first"
-      ],
-      [
-        "set-i",
-        "set-ACC"
-      ],
-      [
-        "bizim",
-        "our"
-      ],
-      [
-        "takım",
-        "team"
-      ],
-      [
-        "önde",
-        "ahead"
-      ],
-      [
-        "bitir-miş",
-        "end-MIS"
-      ]
+      ["İlk", "first"], ["set-i", "set-ACC"], ["bizim", "our"], ["takım", "team"],
+      ["önde", "ahead"], ["bitir-miş", "end-MIS"]
     ],
     "translation": "Our team ended the first set ahead.",
     "context": "Following (tr_008a-b), due to a lost signal, you learn of the second set only from a summary during\na later break. The next day, you say:",
@@ -744,58 +342,25 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "MIS"
-      ],
-      [
-        "ET_ST",
-        "ET < ST"
-      ],
-      [
-        "EAT_ET",
-        "ET < EAT"
-      ],
-      [
-        "evidence_type",
-        "indirect"
-      ],
-      [
-        "evidential_context",
-        "reportative"
-      ]
+      ["tam", "MIS"],
+      ["ET_ST", "ET < ST"],
+      ["EAT_ET", "ET < EAT"],
+      ["evidence_type", "indirect"],
+      ["evidential_context", "reportative"]
     ],
     "comment": "",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_009a",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_009a"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_009a"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "Ivan spor salonu-na git-ti-miş",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Ivan",
-        "Ivan"
-      ],
-      [
-        "spor",
-        "sport"
-      ],
-      [
-        "salonu-na",
-        "hall-DAT"
-      ],
-      [
-        "git-ti-miş",
-        "go-DI-MIS"
-      ]
+      ["Ivan", "Ivan"], ["spor", "sport"], ["salonu-na", "hall-DAT"], ["git-ti-miş", "go-DI-MIS"]
     ],
     "translation": "Ivan went to the gym.",
     "context": "",
@@ -803,42 +368,21 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "DI, MIS"
-      ]
+      ["tam", "DI, MIS"]
     ],
     "comment": "DI + MIS is not a licensed form",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   },
   {
     "id": "tr_009b",
-    "source": {
-      "bibkey": "marsan-2026",
-      "paperLabel": "tr_009b"
-    },
+    "source": {"bibkey": "marsan-2026", "paperLabel": "tr_009b"},
+    "reportedIn": null,
     "language": "stan1290",
     "primaryText": "Ivan spor salonu-na git-miş-ti",
     "discourseSegments": [],
     "glossedTokens": [
-      [
-        "Ivan",
-        "Ivan"
-      ],
-      [
-        "spor",
-        "sport"
-      ],
-      [
-        "salonu-na",
-        "hall-DAT"
-      ],
-      [
-        "git-miş-ti",
-        "go-MIS-DI"
-      ]
+      ["Ivan", "Ivan"], ["spor", "sport"], ["salonu-na", "hall-DAT"], ["git-miş-ti", "go-MIS-DI"]
     ],
     "translation": "Ivan went to the gym.",
     "context": "",
@@ -846,14 +390,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      [
-        "tam",
-        "DI, MIS"
-      ]
+      ["tam", "DI, MIS"]
     ],
     "comment": "MS + DI is licensed",
     "metaLanguage": "stan1293",
-    "lgrConformance": "MORPHEME_ALIGNED",
-    "reportedIn": null
+    "lgrConformance": "MORPHEME_ALIGNED"
   }
 ]

--- a/Linglib/Data/Examples/MunozPerez2026.json
+++ b/Linglib/Data/Examples/MunozPerez2026.json
@@ -6,8 +6,8 @@
     "primaryText": "Se me rompió la radio.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"],
-      ["rompió", "break.PST.3SG"], ["la", "DEF.F.SG"], ["radio", "radio"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["rompió", "break.PST.3SG"], ["la", "DEF.F.SG"],
+      ["radio", "radio"]
     ],
     "translation": "The radio broke on me.",
     "context": "Chilean Spanish anticausative with SE + affected-dative.",
@@ -15,7 +15,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "romper"], ["pattern", "se-cl"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "romper"],
+      ["pattern", "se-cl"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (7a). First member of the three-way synonymy for `romper`: SE + affected-dative pattern.",
     "metaLanguage": "stan1293",
@@ -28,8 +31,8 @@
     "primaryText": "Me le rompió la radio.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Me",  "1SG.DAT"], ["le",     "STYL"],
-      ["rompió", "break.PST.3SG"], ["la", "DEF.F.SG"], ["radio", "radio"]
+      ["Me", "1SG.DAT"], ["le", "STYL"], ["rompió", "break.PST.3SG"], ["la", "DEF.F.SG"],
+      ["radio", "radio"]
     ],
     "translation": "The radio broke on me.",
     "context": "Chilean Spanish stylistic-LE applicative without overt SE.",
@@ -37,7 +40,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "romper"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "romper"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (7b). Second member of the three-way synonymy for `romper`: stylistic-LE pattern; SE is non-overt because Fission outputs DAT/REFL-syncretic 1SG `me` that satisfies the anticausative PF check.",
     "metaLanguage": "stan1293",
@@ -50,8 +56,8 @@
     "primaryText": "Se me le rompió la radio.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"], ["le",     "STYL"],
-      ["rompió", "break.PST.3SG"], ["la", "DEF.F.SG"], ["radio", "radio"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["le", "STYL"], ["rompió", "break.PST.3SG"],
+      ["la", "DEF.F.SG"], ["radio", "radio"]
     ],
     "translation": "The radio broke on me.",
     "context": "Chilean Spanish stylistic-LE applicative WITH overt SE.",
@@ -59,7 +65,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "romper"], ["pattern", "se-cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "romper"],
+      ["pattern", "se-cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (7c). Third member of the three-way synonymy for `romper`: SE + stylistic-LE pattern. Synonymy across (7a)/(7b)/(7c) is the central evidence against a reflexive-of-causative analysis of SE.",
     "metaLanguage": "stan1293",
@@ -72,8 +81,8 @@
     "primaryText": "Se me hundió el bote.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"],
-      ["hundió", "sink.PST.3SG"], ["el", "DEF.M.SG"], ["bote", "boat"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["hundió", "sink.PST.3SG"], ["el", "DEF.M.SG"],
+      ["bote", "boat"]
     ],
     "translation": "The boat sank on me.",
     "context": "Chilean Spanish anticausative with SE + affected-dative; `hundir` parallel to `romper`.",
@@ -81,7 +90,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "hundir"], ["pattern", "se-cl"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "hundir"],
+      ["pattern", "se-cl"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (8a). Extends the three-way synonymy to a second verb; the SE-bearing variant.",
     "metaLanguage": "stan1293",
@@ -94,8 +106,8 @@
     "primaryText": "Me le hundió el bote.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Me",  "1SG.DAT"], ["le",     "STYL"],
-      ["hundió", "sink.PST.3SG"], ["el", "DEF.M.SG"], ["bote", "boat"]
+      ["Me", "1SG.DAT"], ["le", "STYL"], ["hundió", "sink.PST.3SG"], ["el", "DEF.M.SG"],
+      ["bote", "boat"]
     ],
     "translation": "The boat sank on me.",
     "context": "Chilean Spanish stylistic-LE applicative for `hundir`.",
@@ -103,7 +115,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "hundir"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "hundir"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (8b). Stylistic-LE variant for `hundir`.",
     "metaLanguage": "stan1293",
@@ -116,8 +131,8 @@
     "primaryText": "Se me le hundió el bote.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"], ["le",     "STYL"],
-      ["hundió", "sink.PST.3SG"], ["el", "DEF.M.SG"], ["bote", "boat"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["le", "STYL"], ["hundió", "sink.PST.3SG"],
+      ["el", "DEF.M.SG"], ["bote", "boat"]
     ],
     "translation": "The boat sank on me.",
     "context": "Chilean Spanish stylistic-LE applicative WITH overt SE for `hundir`.",
@@ -125,7 +140,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "hundir"], ["pattern", "se-cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "hundir"],
+      ["pattern", "se-cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (8c). Completes the three-way synonymy for `hundir`.",
     "metaLanguage": "stan1293",
@@ -138,8 +156,8 @@
     "primaryText": "Se me cayeron las llaves.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"],
-      ["cayeron", "fall.PST.3PL"], ["las", "DEF.F.PL"], ["llaves", "keys"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["cayeron", "fall.PST.3PL"], ["las", "DEF.F.PL"],
+      ["llaves", "keys"]
     ],
     "translation": "The keys fell on me / I dropped the keys.",
     "context": "Chilean Spanish anticausative; `caer` is a textbook unaccusative. 3PL agreement reflects plural theme.",
@@ -147,7 +165,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "caer"], ["pattern", "se-cl"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "caer"],
+      ["pattern", "se-cl"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (9a). Unaccusative motion verb in the SE-pattern.",
     "metaLanguage": "stan1293",
@@ -160,8 +181,8 @@
     "primaryText": "Me le cayeron las llaves.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Me",  "1SG.DAT"], ["le",     "STYL"],
-      ["cayeron", "fall.PST.3PL"], ["las", "DEF.F.PL"], ["llaves", "keys"]
+      ["Me", "1SG.DAT"], ["le", "STYL"], ["cayeron", "fall.PST.3PL"], ["las", "DEF.F.PL"],
+      ["llaves", "keys"]
     ],
     "translation": "The keys fell on me / I dropped the keys.",
     "context": "Chilean Spanish stylistic-LE applicative for `caer`.",
@@ -169,7 +190,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "caer"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "caer"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (9b). Stylistic-LE variant for `caer`.",
     "metaLanguage": "stan1293",
@@ -182,8 +206,8 @@
     "primaryText": "Se me le cayeron las llaves.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"], ["le",     "STYL"],
-      ["cayeron", "fall.PST.3PL"], ["las", "DEF.F.PL"], ["llaves", "keys"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["le", "STYL"], ["cayeron", "fall.PST.3PL"],
+      ["las", "DEF.F.PL"], ["llaves", "keys"]
     ],
     "translation": "The keys fell on me / I dropped the keys.",
     "context": "Chilean Spanish stylistic-LE applicative WITH overt SE for `caer`.",
@@ -191,7 +215,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "caer"], ["pattern", "se-cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "caer"],
+      ["pattern", "se-cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (9c). Completes the three-way synonymy for `caer`.",
     "metaLanguage": "stan1293",
@@ -204,8 +231,8 @@
     "primaryText": "Se me murió la planta.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"],
-      ["murió", "die.PST.3SG"], ["la", "DEF.F.SG"], ["planta", "plant"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["murió", "die.PST.3SG"], ["la", "DEF.F.SG"],
+      ["planta", "plant"]
     ],
     "translation": "The plant died on me / I unintentionally killed the plant.",
     "context": "Chilean Spanish anticausative; canonical affected-causer example with `morir`.",
@@ -213,7 +240,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "morir"], ["pattern", "se-cl"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "morir"],
+      ["pattern", "se-cl"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (10a). Unaccusative `morir` in the SE-pattern with affected-causer interpretation.",
     "metaLanguage": "stan1293",
@@ -226,8 +256,8 @@
     "primaryText": "Me le murió la planta.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Me",  "1SG.DAT"], ["le",     "STYL"],
-      ["murió", "die.PST.3SG"], ["la", "DEF.F.SG"], ["planta", "plant"]
+      ["Me", "1SG.DAT"], ["le", "STYL"], ["murió", "die.PST.3SG"], ["la", "DEF.F.SG"],
+      ["planta", "plant"]
     ],
     "translation": "The plant died on me / I unintentionally killed the plant.",
     "context": "Chilean Spanish stylistic-LE applicative for `morir`.",
@@ -235,7 +265,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "morir"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "morir"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (10b). Stylistic-LE variant for `morir`.",
     "metaLanguage": "stan1293",
@@ -248,8 +281,8 @@
     "primaryText": "Se me le murió la planta.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"], ["le",     "STYL"],
-      ["murió", "die.PST.3SG"], ["la", "DEF.F.SG"], ["planta", "plant"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["le", "STYL"], ["murió", "die.PST.3SG"],
+      ["la", "DEF.F.SG"], ["planta", "plant"]
     ],
     "translation": "The plant died on me / I unintentionally killed the plant.",
     "context": "Chilean Spanish stylistic-LE applicative WITH overt SE for `morir`.",
@@ -257,7 +290,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "morir"], ["pattern", "se-cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "morir"],
+      ["pattern", "se-cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (10c). Completes the three-way synonymy for `morir`.",
     "metaLanguage": "stan1293",
@@ -270,8 +306,7 @@
     "primaryText": "Se me olvidó eso.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"],
-      ["olvidó", "forget.PST.3SG"], ["eso", "that.N"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["olvidó", "forget.PST.3SG"], ["eso", "that.N"]
     ],
     "translation": "I forgot that.",
     "context": "Chilean Spanish psych-verb; the three-way synonymy extends to non-physical change-of-state predicates.",
@@ -279,7 +314,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "olvidar"], ["pattern", "se-cl"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "olvidar"],
+      ["pattern", "se-cl"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (11a). Psych verb in the SE-pattern; shows the three-way synonymy is not restricted to physical CoS.",
     "metaLanguage": "stan1293",
@@ -292,8 +330,7 @@
     "primaryText": "Me le olvidó eso.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Me",  "1SG.DAT"], ["le",     "STYL"],
-      ["olvidó", "forget.PST.3SG"], ["eso", "that.N"]
+      ["Me", "1SG.DAT"], ["le", "STYL"], ["olvidó", "forget.PST.3SG"], ["eso", "that.N"]
     ],
     "translation": "I forgot that.",
     "context": "Chilean Spanish stylistic-LE applicative for psych verb `olvidar`.",
@@ -301,7 +338,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "olvidar"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "olvidar"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (11b). Stylistic-LE variant for `olvidar`.",
     "metaLanguage": "stan1293",
@@ -314,8 +354,8 @@
     "primaryText": "Se me le olvidó eso.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"], ["le",     "STYL"],
-      ["olvidó", "forget.PST.3SG"], ["eso", "that.N"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["le", "STYL"], ["olvidó", "forget.PST.3SG"],
+      ["eso", "that.N"]
     ],
     "translation": "I forgot that.",
     "context": "Chilean Spanish stylistic-LE applicative WITH overt SE for `olvidar`.",
@@ -323,7 +363,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "olvidar"], ["pattern", "se-cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "olvidar"],
+      ["pattern", "se-cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (11c). Completes the three-way synonymy for `olvidar`.",
     "metaLanguage": "stan1293",
@@ -336,8 +379,8 @@
     "primaryText": "Se me ocurrió una idea.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"],
-      ["ocurrió", "occur.PST.3SG"], ["una", "INDF.F.SG"], ["idea", "idea"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["ocurrió", "occur.PST.3SG"], ["una", "INDF.F.SG"],
+      ["idea", "idea"]
     ],
     "translation": "An idea occurred to me.",
     "context": "Chilean Spanish psych-verb; second psych entry showing the three-way synonymy extends to mental-event predicates.",
@@ -345,7 +388,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "ocurrir"], ["pattern", "se-cl"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "ocurrir"],
+      ["pattern", "se-cl"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (12a). Psych verb `ocurrir` in the SE-pattern.",
     "metaLanguage": "stan1293",
@@ -358,8 +404,8 @@
     "primaryText": "Me le ocurrió una idea.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Me",  "1SG.DAT"], ["le",     "STYL"],
-      ["ocurrió", "occur.PST.3SG"], ["una", "INDF.F.SG"], ["idea", "idea"]
+      ["Me", "1SG.DAT"], ["le", "STYL"], ["ocurrió", "occur.PST.3SG"], ["una", "INDF.F.SG"],
+      ["idea", "idea"]
     ],
     "translation": "An idea occurred to me.",
     "context": "Chilean Spanish stylistic-LE applicative for psych verb `ocurrir`.",
@@ -367,7 +413,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "ocurrir"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "ocurrir"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (12b). Stylistic-LE variant for `ocurrir`.",
     "metaLanguage": "stan1293",
@@ -380,8 +429,8 @@
     "primaryText": "Se me le ocurrió una idea.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Se",  "SE"],    ["me",     "1SG.DAT"], ["le",     "STYL"],
-      ["ocurrió", "occur.PST.3SG"], ["una", "INDF.F.SG"], ["idea", "idea"]
+      ["Se", "SE"], ["me", "1SG.DAT"], ["le", "STYL"], ["ocurrió", "occur.PST.3SG"],
+      ["una", "INDF.F.SG"], ["idea", "idea"]
     ],
     "translation": "An idea occurred to me.",
     "context": "Chilean Spanish stylistic-LE applicative WITH overt SE for `ocurrir`.",
@@ -389,7 +438,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "ocurrir"], ["pattern", "se-cl-le"], ["dativePerson", "1SG"], ["block", "three-way-synonymy"]
+      ["verb", "ocurrir"],
+      ["pattern", "se-cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "three-way-synonymy"]
     ],
     "comment": "Muñoz Pérez 2026 (12c). Completes the three-way synonymy for `ocurrir`.",
     "metaLanguage": "stan1293",
@@ -402,8 +454,7 @@
     "primaryText": "Cosmo se me quejó.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Cosmo", "Cosmo"], ["se",   "REFL.3"], ["me",   "1SG.DAT"],
-      ["quejó", "complain.PST.3SG"]
+      ["Cosmo", "Cosmo"], ["se", "REFL.3"], ["me", "1SG.DAT"], ["quejó", "complain.PST.3SG"]
     ],
     "translation": "Cosmo complained to me.",
     "context": "Positive control: `quejarse` is inherently reflexive and surfaces with SE plus an argumental dative without stylistic LE.",
@@ -411,7 +462,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "quejarse"], ["pattern", "se-cl"], ["dativePerson", "1SG"], ["block", "se-positive-control"]
+      ["verb", "quejarse"],
+      ["pattern", "se-cl"],
+      ["dativePerson", "1SG"],
+      ["block", "se-positive-control"]
     ],
     "comment": "Muñoz Pérez 2026 (13a). Positive baseline for the (13b) negative control: shows the SE+dative pattern is acceptable as long as no stylistic LE is added.",
     "metaLanguage": "stan1293",
@@ -424,8 +478,8 @@
     "primaryText": "*Cosmo me le quejó (a mí).",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Cosmo", "Cosmo"], ["me",   "1SG.DAT"], ["le",   "STYL"],
-      ["quejó", "complain.PST.3SG"], ["a", "DAT"], ["mí", "1SG.STRONG"]
+      ["Cosmo", "Cosmo"], ["me", "1SG.DAT"], ["le", "STYL"], ["quejó", "complain.PST.3SG"],
+      ["a", "DAT"], ["mí", "1SG.STRONG"]
     ],
     "translation": "*Cosmo complained on me.",
     "context": "Negative control: `quejarse` is inherently reflexive (no non-thematic Voice projection) and rejects the stylistic-LE pattern even with the doubled strong pronoun.",
@@ -433,7 +487,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "quejarse"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "negative-controls"]
+      ["verb", "quejarse"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "negative-controls"]
     ],
     "comment": "Muñoz Pérez 2026 (13b). Demonstrates that stylistic LE depends on marked-anticausative structure, not phonological adjacency: an inherently reflexive verb (vP without non-thematic Voice) cannot host stylistic LE.",
     "metaLanguage": "stan1293",
@@ -446,7 +503,7 @@
     "primaryText": "*Cosmo se me le quejó (a mí).",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Cosmo", "Cosmo"], ["se",   "REFL.3"], ["me",   "1SG.DAT"], ["le",   "STYL"],
+      ["Cosmo", "Cosmo"], ["se", "REFL.3"], ["me", "1SG.DAT"], ["le", "STYL"],
       ["quejó", "complain.PST.3SG"], ["a", "DAT"], ["mí", "1SG.STRONG"]
     ],
     "translation": "*Cosmo complained on me.",
@@ -455,7 +512,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "quejarse"], ["pattern", "se-cl-le"], ["dativePerson", "1SG"], ["block", "negative-controls"]
+      ["verb", "quejarse"],
+      ["pattern", "se-cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "negative-controls"]
     ],
     "comment": "Muñoz Pérez 2026 (13c). Adding overt SE does not rescue the stylistic-LE form: confirms LE is parasitic on anticausative non-thematic Voice, not on the surface presence of SE.",
     "metaLanguage": "stan1293",
@@ -468,8 +528,8 @@
     "primaryText": "No se me dio ni un peso.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["No", "NEG"], ["se",   "IMPRS"], ["me",   "1SG.DAT"],
-      ["dio", "give.PST.3SG"], ["ni", "NPI"], ["un", "INDF.M.SG"], ["peso", "peso"]
+      ["No", "NEG"], ["se", "IMPRS"], ["me", "1SG.DAT"], ["dio", "give.PST.3SG"], ["ni", "NPI"],
+      ["un", "INDF.M.SG"], ["peso", "peso"]
     ],
     "translation": "I wasn't given a single peso.",
     "context": "Positive control: impersonal SE + argumental dative is acceptable without stylistic LE.",
@@ -477,7 +537,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "dar"], ["pattern", "se-cl"], ["dativePerson", "1SG"], ["block", "se-positive-control"]
+      ["verb", "dar"],
+      ["pattern", "se-cl"],
+      ["dativePerson", "1SG"],
+      ["block", "se-positive-control"]
     ],
     "comment": "Muñoz Pérez 2026 (14a). Positive baseline for the (14b) negative control: shows the impersonal-SE form is grammatical when no stylistic LE is added.",
     "metaLanguage": "stan1293",
@@ -490,8 +553,8 @@
     "primaryText": "*No me le dio ni un peso.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["No",  "NEG"], ["me",   "1SG.DAT"], ["le",   "STYL"],
-      ["dio", "give.PST.3SG"], ["ni", "NPI"], ["un", "INDF.M.SG"], ["peso", "peso"]
+      ["No", "NEG"], ["me", "1SG.DAT"], ["le", "STYL"], ["dio", "give.PST.3SG"], ["ni", "NPI"],
+      ["un", "INDF.M.SG"], ["peso", "peso"]
     ],
     "translation": "*I wasn't given a single peso.",
     "context": "Negative control: impersonal SE + argumental dative also rejects stylistic LE.",
@@ -499,7 +562,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "dar"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "negative-controls"]
+      ["verb", "dar"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "negative-controls"]
     ],
     "comment": "Muñoz Pérez 2026 (14b). Second negative control: impersonal SE (a different SE-flavor) does not license stylistic LE either, sharpening the claim that LE is parasitic on anticausative non-thematic Voice specifically.",
     "metaLanguage": "stan1293",
@@ -512,8 +578,8 @@
     "primaryText": "*No se me le dio ni un peso.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["No", "NEG"], ["se",   "IMPRS"], ["me",   "1SG.DAT"], ["le",   "STYL"],
-      ["dio", "give.PST.3SG"], ["ni", "NPI"], ["un", "INDF.M.SG"], ["peso", "peso"]
+      ["No", "NEG"], ["se", "IMPRS"], ["me", "1SG.DAT"], ["le", "STYL"], ["dio", "give.PST.3SG"],
+      ["ni", "NPI"], ["un", "INDF.M.SG"], ["peso", "peso"]
     ],
     "translation": "*I wasn't given a single peso.",
     "context": "Negative control: overt impersonal-SE + STYL cluster is still ungrammatical.",
@@ -521,7 +587,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "dar"], ["pattern", "se-cl-le"], ["dativePerson", "1SG"], ["block", "negative-controls"]
+      ["verb", "dar"],
+      ["pattern", "se-cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "negative-controls"]
     ],
     "comment": "Muñoz Pérez 2026 (14c). Confirms LE is not rescued by any SE-flavor in the absence of non-thematic anticausative Voice.",
     "metaLanguage": "stan1293",
@@ -534,8 +603,8 @@
     "primaryText": "Me le cerró la ventana.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Me",  "1SG.DAT"], ["le",     "STYL"],
-      ["cerró", "close.PST.3SG"], ["la", "DEF.F.SG"], ["ventana", "window"]
+      ["Me", "1SG.DAT"], ["le", "STYL"], ["cerró", "close.PST.3SG"], ["la", "DEF.F.SG"],
+      ["ventana", "window"]
     ],
     "translation": "The window closed on me.",
     "context": "Person-paradigm cornerstone: stylistic LE is licit with a 1SG dative clitic.",
@@ -543,7 +612,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "cerrar"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "person-restriction"]
+      ["verb", "cerrar"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "person-restriction"]
     ],
     "comment": "Muñoz Pérez 2026 (15b). First of five person-paradigm examples (15–19) anchoring the [+PART, +SING] restriction.",
     "metaLanguage": "stan1293",
@@ -556,8 +628,8 @@
     "primaryText": "Te le cerró la ventana.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Te",  "2SG.DAT"], ["le",     "STYL"],
-      ["cerró", "close.PST.3SG"], ["la", "DEF.F.SG"], ["ventana", "window"]
+      ["Te", "2SG.DAT"], ["le", "STYL"], ["cerró", "close.PST.3SG"], ["la", "DEF.F.SG"],
+      ["ventana", "window"]
     ],
     "translation": "The window closed on you.",
     "context": "Person paradigm: stylistic LE is licit with a 2SG dative clitic.",
@@ -565,7 +637,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "cerrar"], ["pattern", "cl-le"], ["dativePerson", "2SG"], ["block", "person-restriction"]
+      ["verb", "cerrar"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "2SG"],
+      ["block", "person-restriction"]
     ],
     "comment": "Muñoz Pérez 2026 (16b). 2SG: the second [+PART, +SING] case.",
     "metaLanguage": "stan1293",
@@ -578,8 +653,8 @@
     "primaryText": "*Le le cerró la ventana.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Le",  "3SG.DAT"], ["le",     "STYL"],
-      ["cerró", "close.PST.3SG"], ["la", "DEF.F.SG"], ["ventana", "window"]
+      ["Le", "3SG.DAT"], ["le", "STYL"], ["cerró", "close.PST.3SG"], ["la", "DEF.F.SG"],
+      ["ventana", "window"]
     ],
     "translation": "*The window closed on her/him.",
     "context": "Person paradigm: stylistic LE is BLOCKED with a 3SG dative clitic (third-person fails [+PART]).",
@@ -587,7 +662,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "cerrar"], ["pattern", "cl-le"], ["dativePerson", "3SG"], ["block", "person-restriction"]
+      ["verb", "cerrar"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "3SG"],
+      ["block", "person-restriction"]
     ],
     "comment": "Muñoz Pérez 2026 (17b). 3SG blocks Fission: third person lacks [+PART].",
     "metaLanguage": "stan1293",
@@ -600,8 +678,8 @@
     "primaryText": "*Nos le cerró la ventana.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Nos", "1PL.DAT"], ["le",     "STYL"],
-      ["cerró", "close.PST.3SG"], ["la", "DEF.F.SG"], ["ventana", "window"]
+      ["Nos", "1PL.DAT"], ["le", "STYL"], ["cerró", "close.PST.3SG"], ["la", "DEF.F.SG"],
+      ["ventana", "window"]
     ],
     "translation": "*The window closed on us.",
     "context": "Person paradigm: stylistic LE is BLOCKED with a 1PL dative clitic (plural fails [+SING]).",
@@ -609,7 +687,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "cerrar"], ["pattern", "cl-le"], ["dativePerson", "1PL"], ["block", "person-restriction"]
+      ["verb", "cerrar"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1PL"],
+      ["block", "person-restriction"]
     ],
     "comment": "Muñoz Pérez 2026 (18b). 1PL blocks Fission: plural lacks [+SING].",
     "metaLanguage": "stan1293",
@@ -622,8 +703,8 @@
     "primaryText": "*Les le cerró la ventana.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Les", "3PL.DAT"], ["le",     "STYL"],
-      ["cerró", "close.PST.3SG"], ["la", "DEF.F.SG"], ["ventana", "window"]
+      ["Les", "3PL.DAT"], ["le", "STYL"], ["cerró", "close.PST.3SG"], ["la", "DEF.F.SG"],
+      ["ventana", "window"]
     ],
     "translation": "*The window closed on them.",
     "context": "Person paradigm: stylistic LE is BLOCKED with a 3PL dative clitic.",
@@ -631,7 +712,10 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "cerrar"], ["pattern", "cl-le"], ["dativePerson", "3PL"], ["block", "person-restriction"]
+      ["verb", "cerrar"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "3PL"],
+      ["block", "person-restriction"]
     ],
     "comment": "Muñoz Pérez 2026 (19b). 3PL blocks Fission on both [+PART] AND [+SING].",
     "metaLanguage": "stan1293",
@@ -644,8 +728,8 @@
     "primaryText": "Me le quebró el florero.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Me",  "1SG.DAT"], ["le",     "STYL"],
-      ["quebró", "break.PST.3SG"], ["el", "DEF.M.SG"], ["florero", "vase"]
+      ["Me", "1SG.DAT"], ["le", "STYL"], ["quebró", "break.PST.3SG"], ["el", "DEF.M.SG"],
+      ["florero", "vase"]
     ],
     "translation": "The vase broke on me.",
     "context": "Marking restriction: `quebrar` is marked-anticausative (obligatory SE in its non-LE form) and licenses stylistic LE.",
@@ -653,7 +737,11 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "quebrar"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "marking-restriction"], ["marking", "marked"]
+      ["verb", "quebrar"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "marking-restriction"],
+      ["marking", "marked"]
     ],
     "comment": "Muñoz Pérez 2026 (39b). Marked-anticausative verb licenses stylistic LE.",
     "metaLanguage": "stan1293",
@@ -666,8 +754,8 @@
     "primaryText": "*Me le mejoró el sueldo.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Me",  "1SG.DAT"], ["le",     "STYL"],
-      ["mejoró", "improve.PST.3SG"], ["el", "DEF.M.SG"], ["sueldo", "salary"]
+      ["Me", "1SG.DAT"], ["le", "STYL"], ["mejoró", "improve.PST.3SG"], ["el", "DEF.M.SG"],
+      ["sueldo", "salary"]
     ],
     "translation": "*My salary went up (on me).",
     "context": "Marking restriction: `mejorar` is an unmarked anticausative (alternates without SE) and BLOCKS stylistic LE.",
@@ -675,7 +763,11 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "mejorar"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "marking-restriction"], ["marking", "unmarked"]
+      ["verb", "mejorar"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "marking-restriction"],
+      ["marking", "unmarked"]
     ],
     "comment": "Muñoz Pérez 2026 (40b). Unmarked-anticausative verb BLOCKS stylistic LE; key counterexample against Koontz-Garboden (2009)'s prediction that every alternating verb has SE.",
     "metaLanguage": "stan1293",
@@ -688,8 +780,8 @@
     "primaryText": "Me le hirvió el agua.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Me",  "1SG.DAT"], ["le",     "STYL"],
-      ["hirvió", "boil.PST.3SG"], ["el", "DEF.M.SG"], ["agua", "water"]
+      ["Me", "1SG.DAT"], ["le", "STYL"], ["hirvió", "boil.PST.3SG"], ["el", "DEF.M.SG"],
+      ["agua", "water"]
     ],
     "translation": "The water boiled on me.",
     "context": "Marking restriction: `hervir` is optionally SE-marked and still licenses stylistic LE.",
@@ -697,7 +789,11 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["verb", "hervir"], ["pattern", "cl-le"], ["dativePerson", "1SG"], ["block", "marking-restriction"], ["marking", "optional"]
+      ["verb", "hervir"],
+      ["pattern", "cl-le"],
+      ["dativePerson", "1SG"],
+      ["block", "marking-restriction"],
+      ["marking", "optional"]
     ],
     "comment": "Muñoz Pérez 2026 (44a). Optionally-marked anticausative still licenses stylistic LE, confirming that the relevant condition is non-thematic Voice availability, not obligatoriness of overt SE.",
     "metaLanguage": "stan1293",

--- a/Linglib/Data/Examples/Ogihara1996.json
+++ b/Linglib/Data/Examples/Ogihara1996.json
@@ -6,8 +6,8 @@
     "primaryText": "Taroo-wa Hanako-ga byooki-da to it-ta.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Taroo-wa", "Taro-TOP"],     ["Hanako-ga", "Hanako-NOM"],
-      ["byooki-da", "be.sick-PRES"], ["to", "COMP"],          ["it-ta", "say-PAST"]
+      ["Taroo-wa", "Taro-TOP"], ["Hanako-ga", "Hanako-NOM"], ["byooki-da", "be.sick-PRES"],
+      ["to", "COMP"], ["it-ta", "say-PAST"]
     ],
     "translation": "Taro said that Hanako was sick [at that time].",
     "context": "Past matrix + PRESENT embedded → simultaneous reading. In non-SOT Japanese, the embedded clause uses present (`-da`) to express simultaneity with the saying time; the embedded clause's tense is interpreted relative to speech time, so PRESENT here is anchored to the saying time via attitude-context shift, not to speech time.",
@@ -15,7 +15,7 @@
     "alternatives": [],
     "readings": [
       {"name": "simultaneous (Hanako sick at saying time)", "judgment": "acceptable"},
-      {"name": "shifted (Hanako sick before saying)",       "judgment": "ungrammatical"}
+      {"name": "shifted (Hanako sick before saying)", "judgment": "ungrammatical"}
     ],
     "comment": "Ogihara 1996 ex (2a), Chapter 1 §1.2 p. 11. Half of the minimal pair (2a)/(2b) — the embedded PRESENT form. Together with (2b) below, motivates Ogihara's analysis: embedded tense in Japanese is absolute, so PRESENT delivers simultaneity (via attitude shift) and PAST delivers strict backward shift.",
     "metaLanguage": "stan1293",
@@ -28,15 +28,15 @@
     "primaryText": "Taroo-wa Hanako-ga byookidat-ta to it-ta.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Taroo-wa", "Taro-TOP"],         ["Hanako-ga", "Hanako-NOM"],
-      ["byookidat-ta", "be.sick-PAST"], ["to", "COMP"],         ["it-ta", "say-PAST"]
+      ["Taroo-wa", "Taro-TOP"], ["Hanako-ga", "Hanako-NOM"], ["byookidat-ta", "be.sick-PAST"],
+      ["to", "COMP"], ["it-ta", "say-PAST"]
     ],
     "translation": "Taro said that Hanako had been sick.",
     "context": "Past matrix + PAST embedded → ONLY shifted reading. Hanako's sickness strictly precedes the saying. No simultaneous reading is available — sharply diagnostic of non-SOT Japanese vs SOT English.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "shifted (Hanako sick before saying)",       "judgment": "acceptable"},
+      {"name": "shifted (Hanako sick before saying)", "judgment": "acceptable"},
       {"name": "simultaneous (Hanako sick at saying time)", "judgment": "ungrammatical"}
     ],
     "comment": "Ogihara 1996 ex (2b), Chapter 1 §1.2 p. 11. The other half of the minimal pair. With English-style SOT, the embedded past should admit a simultaneous reading; its unavailability here is Ogihara's main empirical hook.",

--- a/Linglib/Data/Examples/Pancheva2003.json
+++ b/Linglib/Data/Examples/Pancheva2003.json
@@ -66,7 +66,7 @@
     "alternatives": [],
     "readings": [
       {"name": "experiential (running at some past time)", "judgment": "acceptable"},
-      {"name": "resultative",                               "judgment": "ungrammatical"}
+      {"name": "resultative", "judgment": "ungrammatical"}
     ],
     "comment": "Pancheva 2003 §2 ex (5a). Diagnostic for the telic-only restriction on Resultative reading.",
     "metaLanguage": "stan1293",
@@ -84,7 +84,7 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "experiential (lost at some past time)",  "judgment": "acceptable"},
+      {"name": "experiential (lost at some past time)", "judgment": "acceptable"},
       {"name": "resultative (lost + still missing now)", "judgment": "acceptable"}
     ],
     "comment": "Pancheva 2003 §2 ex (6a). The telic contrast partner to (5a). Demonstrates that telic predicates license both readings; atelic predicates only EXP.",

--- a/Linglib/Data/Examples/Partee2010.json
+++ b/Linglib/Data/Examples/Partee2010.json
@@ -5,8 +5,8 @@
     "language": "stan1293",
     "primaryText": "A fake gun is not a gun.",
     "glossedTokens": [
-      ["A", "INDEF"], ["fake", "fake"], ["gun", "gun"], ["is", "be.PRS.3SG"],
-      ["not", "NEG"], ["a", "INDEF"], ["gun", "gun"]
+      ["A", "INDEF"], ["fake", "fake"], ["gun", "gun"], ["is", "be.PRS.3SG"], ["not", "NEG"],
+      ["a", "INDEF"], ["gun", "gun"]
     ],
     "translation": "A fake gun is not a gun.",
     "context": "Cited as an apparently-true privative entailment (the prima facie evidence for the privative class).",
@@ -22,8 +22,8 @@
     "language": "stan1293",
     "primaryText": "Is that gun real or fake?",
     "glossedTokens": [
-      ["Is", "be.PRS.3SG"], ["that", "DEM"], ["gun", "gun"],
-      ["real", "real"], ["or", "or"], ["fake", "fake"]
+      ["Is", "be.PRS.3SG"], ["that", "DEM"], ["gun", "gun"], ["real", "real"], ["or", "or"],
+      ["fake", "fake"]
     ],
     "translation": "Is that gun real or fake?",
     "context": "The 'gun puzzle': for this question to be well-formed, 'gun' must include both real and fake guns. Direct evidence that the noun's denotation coerces to include the adjective's extension.",
@@ -40,9 +40,8 @@
     "language": "poli1260",
     "primaryText": "Kelnerki rozmawiały o przystojnym chłopcu.",
     "glossedTokens": [
-      ["Kelnerki", "waitress.NOM.PL"], ["rozmawiały", "talk.PST.3PL.F"],
-      ["o", "about"], ["przystojnym", "handsome.LOC.SG.M"],
-      ["chłopcu", "boy.LOC.SG"]
+      ["Kelnerki", "waitress.NOM.PL"], ["rozmawiały", "talk.PST.3PL.F"], ["o", "about"],
+      ["przystojnym", "handsome.LOC.SG.M"], ["chłopcu", "boy.LOC.SG"]
     ],
     "translation": "The waitresses talked about a handsome boy.",
     "context": "Unmarked NP-internal word order; Adj+N adjacent within the PP.",
@@ -59,9 +58,8 @@
     "language": "poli1260",
     "primaryText": "O przystojnym kelnerki rozmawiały chłopcu.",
     "glossedTokens": [
-      ["O", "about"], ["przystojnym", "handsome.LOC.SG.M"],
-      ["kelnerki", "waitress.NOM.PL"], ["rozmawiały", "talk.PST.3PL.F"],
-      ["chłopcu", "boy.LOC.SG"]
+      ["O", "about"], ["przystojnym", "handsome.LOC.SG.M"], ["kelnerki", "waitress.NOM.PL"],
+      ["rozmawiały", "talk.PST.3PL.F"], ["chłopcu", "boy.LOC.SG"]
     ],
     "translation": "The waitresses talked about a handsome BOY.",
     "context": "NP-split: preposition + adjective in sentence-initial position, head noun sentence-final. Topic-focus structure highlights the noun.",
@@ -78,8 +76,8 @@
     "language": "poli1260",
     "primaryText": "Do doliny weszliśmy rozległej.",
     "glossedTokens": [
-      ["Do", "to"], ["doliny", "valley.GEN.SG"],
-      ["weszliśmy", "enter.PST.1PL"], ["rozległej", "large.GEN.SG.F"]
+      ["Do", "to"], ["doliny", "valley.GEN.SG"], ["weszliśmy", "enter.PST.1PL"],
+      ["rozległej", "large.GEN.SG.F"]
     ],
     "translation": "We entered a LARGE valley.",
     "context": "NP-split with intersective adjective 'rozległy' (large). The split succeeds, as expected for intersective Adj+N.",
@@ -96,8 +94,8 @@
     "language": "poli1260",
     "primaryText": "Z prezydentem rozmawiała byłym.",
     "glossedTokens": [
-      ["Z", "with"], ["prezydentem", "president.INS.SG"],
-      ["rozmawiała", "talk.PST.3SG.F"], ["byłym", "former.INS.SG.M"]
+      ["Z", "with"], ["prezydentem", "president.INS.SG"], ["rozmawiała", "talk.PST.3SG.F"],
+      ["byłym", "former.INS.SG.M"]
     ],
     "translation": "She talked with the FORMER president.",
     "context": "Attempted NP-split with non-subsective modal adjective 'były' (former). The split is ungrammatical.",
@@ -113,7 +111,9 @@
     "reportedIn": {"bibkey": "partee-2010", "paperLabel": "(15b),(16a)"},
     "language": "poli1260",
     "primaryText": "biedny",
-    "glossedTokens": [["biedny", "poor.NOM.SG.M"]],
+    "glossedTokens": [
+      ["biedny", "poor.NOM.SG.M"]
+    ],
     "translation": "poor / pitiful (lexically ambiguous)",
     "context": "Polish 'biedny' is lexically ambiguous between an intersective reading 'not rich' (15b: can split in NP-split construction) and a non-subsective reading 'pitiful' (16a: cannot split). The splitting diagnostic tracks the READING, not the lexical form.",
     "judgment": "acceptable",
@@ -132,8 +132,8 @@
     "primaryText": "I don't care whether that fur is fake or real.",
     "glossedTokens": [
       ["I", "1SG"], ["don't", "do.PRS.NEG"], ["care", "care"], ["whether", "whether"],
-      ["that", "DEM"], ["fur", "fur"], ["is", "be.PRS.3SG"],
-      ["fake", "fake"], ["or", "or"], ["real", "real"]
+      ["that", "DEM"], ["fur", "fur"], ["is", "be.PRS.3SG"], ["fake", "fake"], ["or", "or"],
+      ["real", "real"]
     ],
     "translation": "I don't care whether that fur is fake or real.",
     "context": "Generalization of the (10b) gun-puzzle to 'fur'. The polar disjunction 'fake or real' presupposes that 'fur' covers both fake and real fur; otherwise 'real' would be redundant. Direct evidence of NVP-licensed coercion of the noun extension.",
@@ -183,9 +183,8 @@
     "language": "stan1293",
     "primaryText": "How many poets are buried in Amherst?",
     "glossedTokens": [
-      ["How", "how"], ["many", "many"], ["poets", "poet.PL"],
-      ["are", "be.PRS.3PL"], ["buried", "bury.PASS.PTCP"],
-      ["in", "in"], ["Amherst", "Amherst"]
+      ["How", "how"], ["many", "many"], ["poets", "poet.PL"], ["are", "be.PRS.3PL"],
+      ["buried", "bury.PASS.PTCP"], ["in", "in"], ["Amherst", "Amherst"]
     ],
     "translation": "How many poets are buried in Amherst?",
     "context": "Demonstrates context-shift of the noun 'poet' independent of any adjective. With predicate 'buried', 'poets' presupposes dead poets; with 'live in' or similar present-tense, 'poets' presupposes living poets. Shows N's extension is itself adjustable, supporting the coercion mechanism Partee invokes for privatives.",
@@ -202,8 +201,8 @@
     "language": "poli1260",
     "primaryText": "Włamano się do nowego sklepu.",
     "glossedTokens": [
-      ["Włamano", "break.in-NEUT.SG"], ["się", "REFL"],
-      ["do", "to"], ["nowego", "new.GEN.SG.M"], ["sklepu", "store.GEN.SG"]
+      ["Włamano", "break.in-NEUT.SG"], ["się", "REFL"], ["do", "to"], ["nowego", "new.GEN.SG.M"],
+      ["sklepu", "store.GEN.SG"]
     ],
     "translation": "Someone broke into the new store.",
     "context": "Unmarked NP-internal order; baseline for the split in (12b).",
@@ -220,8 +219,7 @@
     "language": "poli1260",
     "primaryText": "Do sklepu włamano się nowego.",
     "glossedTokens": [
-      ["Do", "to"], ["sklepu", "store.GEN.SG"],
-      ["włamano", "break.in-NEUT.SG"], ["się", "REFL"],
+      ["Do", "to"], ["sklepu", "store.GEN.SG"], ["włamano", "break.in-NEUT.SG"], ["się", "REFL"],
       ["nowego", "new.GEN.SG.M"]
     ],
     "translation": "Someone broke into the NEW store.",
@@ -239,8 +237,8 @@
     "language": "poli1260",
     "primaryText": "Do rozległej weszliśmy doliny.",
     "glossedTokens": [
-      ["Do", "to"], ["rozległej", "large.GEN.SG.F"],
-      ["weszliśmy", "enter.PST.1PL"], ["doliny", "valley.GEN.SG"]
+      ["Do", "to"], ["rozległej", "large.GEN.SG.F"], ["weszliśmy", "enter.PST.1PL"],
+      ["doliny", "valley.GEN.SG"]
     ],
     "translation": "We entered a large VALLEY.",
     "context": "Alternate split order: preposition + adjective initial, noun final. Pair-mate of (13b).",
@@ -257,8 +255,8 @@
     "language": "poli1260",
     "primaryText": "Z byłym rozmawiała prezydentem.",
     "glossedTokens": [
-      ["Z", "with"], ["byłym", "former.INS.SG.M"],
-      ["rozmawiała", "talk.PST.3SG.F"], ["prezydentem", "president.INS.SG"]
+      ["Z", "with"], ["byłym", "former.INS.SG.M"], ["rozmawiała", "talk.PST.3SG.F"],
+      ["prezydentem", "president.INS.SG"]
     ],
     "translation": "She talked with the former PRESIDENT.",
     "context": "Attempted NP-split with non-subsective 'były' (former). Ungrammatical regardless of split order; pair-mate of (14b).",
@@ -275,8 +273,8 @@
     "primaryText": "I don't care whether that fur is fake fur or real fur.",
     "glossedTokens": [
       ["I", "1SG"], ["don't", "do.PRS.NEG"], ["care", "care"], ["whether", "whether"],
-      ["that", "DEM"], ["fur", "fur"], ["is", "be.PRS.3SG"],
-      ["fake", "fake"], ["fur", "fur"], ["or", "or"], ["real", "real"], ["fur", "fur"]
+      ["that", "DEM"], ["fur", "fur"], ["is", "be.PRS.3SG"], ["fake", "fake"], ["fur", "fur"],
+      ["or", "or"], ["real", "real"], ["fur", "fur"]
     ],
     "translation": "I don't care whether that fur is fake fur or real fur.",
     "context": "Explicit form of the fur disjunction, with both 'fake fur' and 'real fur' as full NPs. The acceptability shows the noun 'fur' uncontroversially covers both extensions.",
@@ -310,8 +308,8 @@
     "language": "stan1293",
     "primaryText": "This is a sharp knife.",
     "glossedTokens": [
-      ["This", "DEM"], ["is", "be.PRS.3SG"], ["a", "INDEF"],
-      ["sharp", "sharp"], ["knife", "knife"]
+      ["This", "DEM"], ["is", "be.PRS.3SG"], ["a", "INDEF"], ["sharp", "sharp"],
+      ["knife", "knife"]
     ],
     "translation": "This is a sharp knife.",
     "context": "Episodic predication mate of the generic (21b). Both can be true together; 'sharp' is not redundant in (21a) because NVP requires the local domain of knives to contain both sharp and non-sharp instances.",
@@ -327,9 +325,8 @@
     "language": "stan1293",
     "primaryText": "How many poets are there in Amherst?",
     "glossedTokens": [
-      ["How", "how"], ["many", "many"], ["poets", "poet.PL"],
-      ["are", "be.PRS.3PL"], ["there", "EXIST"],
-      ["in", "in"], ["Amherst", "Amherst"]
+      ["How", "how"], ["many", "many"], ["poets", "poet.PL"], ["are", "be.PRS.3PL"],
+      ["there", "EXIST"], ["in", "in"], ["Amherst", "Amherst"]
     ],
     "translation": "How many poets are there in Amherst?",
     "context": "Existential predicate companion of (22b). With 'are there', 'poets' presupposes living poets, contrasting with (22b) where 'are buried' presupposes dead poets. Same noun, context-shifted extension.",

--- a/Linglib/Data/Examples/README.md
+++ b/Linglib/Data/Examples/README.md
@@ -8,8 +8,17 @@ file is a top-level JSON array of example objects mirroring the
 ## Generator
 
 ```bash
-python3 scripts/gen_examples.py <AuthorYear>
+python3 scripts/gen_examples.py <AuthorYear>   # generate one paper's module
+python3 scripts/gen_examples.py --all          # regenerate every paper
+python3 scripts/gen_examples.py --check        # verify modules match JSON (CI)
+python3 scripts/gen_examples.py --fmt          # rewrite JSON in canonical format
 ```
+
+JSON files use the canonical format emitted by `--fmt` (2-space indent,
+schema key order, gloss pairs packed onto wrapped lines, one
+feature/alternative/reading per line). Run `--fmt` after hand-editing or
+script-editing a JSON file; it refuses to write if reformatting would
+change the parsed data.
 
 Reads `Linglib/Data/Examples/<AuthorYear>.json` and writes a standalone
 auto-generated module at `Linglib/Data/Examples/<AuthorYear>.lean`

--- a/Linglib/Data/Examples/Schlenker2004.json
+++ b/Linglib/Data/Examples/Schlenker2004.json
@@ -11,7 +11,7 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "FID (CT/CU split)",   "judgment": "acceptable"},
+      {"name": "FID (CT/CU split)", "judgment": "acceptable"},
       {"name": "literal-contradiction", "judgment": "ungrammatical"}
     ],
     "comment": "Schlenker 2004 ex (1), Mind & Language 19(3) p. 280. Literary source via Banfield 1982 p. 98 (a D.H. Lawrence novel; specific novel attribution unverified). Cornerstone of Schlenker's CT vs CU framework: in FID, indexical/tense items split between two contexts.",
@@ -31,7 +31,7 @@
     "alternatives": [],
     "readings": [
       {"name": "HP (CT/CU split, CT shifted back 58y)", "judgment": "acceptable"},
-      {"name": "literal-contradiction",                  "judgment": "ungrammatical"}
+      {"name": "literal-contradiction", "judgment": "ungrammatical"}
     ],
     "comment": "Schlenker 2004 ex (2), p. 280. The Historical Present companion to (1)'s FID. Both motivate the same CT/CU split: when temporal indexicals and tense morphology disagree on which context anchors them, FID/HP are the diagnostics.",
     "metaLanguage": "stan1293",

--- a/Linglib/Data/Examples/Sharvit2003.json
+++ b/Linglib/Data/Examples/Sharvit2003.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "sharvit2003_ex1",
-    "source":     {"bibkey": "abusch-1997",  "paperLabel": "inspiration"},
+    "source": {"bibkey": "abusch-1997", "paperLabel": "inspiration"},
     "reportedIn": {"bibkey": "sharvit-2003", "paperLabel": "(1)"},
     "language": "stan1293",
     "primaryText": "A week ago, John decided that in ten days, at breakfast, he would tell his mother that he missed her.",
@@ -12,7 +12,7 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "nonpast (missing overlaps telling)",     "judgment": "acceptable"},
+      {"name": "nonpast (missing overlaps telling)", "judgment": "acceptable"},
       {"name": "anteriority (missing precedes telling)", "judgment": "acceptable"}
     ],
     "comment": "Sharvit 2003 ex (1), LI 34(4) p. 669. Inspired by Abusch 1997. Cornerstone SOT phenomenon — nonpast/anteriority ambiguity of multiply-embedded past.",
@@ -31,7 +31,7 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "nonpast (pregnancy at believing)",         "judgment": "acceptable"},
+      {"name": "nonpast (pregnancy at believing)", "judgment": "acceptable"},
       {"name": "anteriority (pregnancy before believing)", "judgment": "acceptable"}
     ],
     "comment": "Sharvit 2003 ex (2), p. 669. Sharvit cites Enç 1987 as a prior user of this example shape. (No enc-1987 bib entry yet; sourced to Sharvit directly.) Standard past-under-past with both readings — diagnostic for SOT.",
@@ -51,7 +51,7 @@
     "alternatives": [],
     "readings": [
       {"name": "double access (pregnancy spans believing + utterance)", "judgment": "acceptable"},
-      {"name": "nonpast (pregnancy at believing only)",                 "judgment": "ungrammatical"}
+      {"name": "nonpast (pregnancy at believing only)", "judgment": "ungrammatical"}
     ],
     "comment": "Sharvit 2003 ex (3), p. 670. Cornerstone present-under-past example. Motivates the Embeddability Principle: every well-formed matrix LF must be embeddable; the syntactic means differ by language.",
     "metaLanguage": "stan1293",
@@ -100,15 +100,11 @@
     "primaryText": "Lifney shavua, Dan hexlit she be'od asara yamim, bizman aruxat ha-boker, hu yomar le-imo she hu mitga'agea ele-ha.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Lifney",       "before"],          ["shavua",   "week"],
-      ["Dan",          "Dan"],             ["hexlit",   "decide-PAST"],
-      ["she",          "that"],            ["be'od",    "in"],
-      ["asara",        "ten"],             ["yamim",    "days"],
-      ["bizman",       "at-time"],         ["aruxat",   "meal-CST"],
-      ["ha-boker",     "the-morning"],     ["hu",       "he"],
-      ["yomar",        "will.tell-FUT"],   ["le-imo",   "to-his.mother"],
-      ["she",          "that"],            ["hu",       "he"],
-      ["mitga'agea",   "miss-PRES"],       ["ele-ha",   "to-her"]
+      ["Lifney", "before"], ["shavua", "week"], ["Dan", "Dan"], ["hexlit", "decide-PAST"],
+      ["she", "that"], ["be'od", "in"], ["asara", "ten"], ["yamim", "days"], ["bizman", "at-time"],
+      ["aruxat", "meal-CST"], ["ha-boker", "the-morning"], ["hu", "he"],
+      ["yomar", "will.tell-FUT"], ["le-imo", "to-his.mother"], ["she", "that"], ["hu", "he"],
+      ["mitga'agea", "miss-PRES"], ["ele-ha", "to-her"]
     ],
     "translation": "A week ago, Dan decided that in ten days, at breakfast, he would tell his mother that he misses her.",
     "context": "Hebrew non-SOT: embedded PRESENT (`mitga'agea`) delivers the nonpast reading. Hebrew lacks the SOT rule but its present-tense morpheme is not matrix-indexical, so it can be bound as a zero tense.",
@@ -128,23 +124,19 @@
     "primaryText": "Lifney shavua, Dan hexlit she be'od asara yamim, bizman aruxat ha-boker, hu yomar le-imo she hu hitga'agea ele-ha.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Lifney",       "before"],          ["shavua",   "week"],
-      ["Dan",          "Dan"],             ["hexlit",   "decide-PAST"],
-      ["she",          "that"],            ["be'od",    "in"],
-      ["asara",        "ten"],             ["yamim",    "days"],
-      ["bizman",       "at-time"],         ["aruxat",   "meal-CST"],
-      ["ha-boker",     "the-morning"],     ["hu",       "he"],
-      ["yomar",        "will.tell-FUT"],   ["le-imo",   "to-his.mother"],
-      ["she",          "that"],            ["hu",       "he"],
-      ["hitga'agea",   "miss-PAST"],       ["ele-ha",   "to-her"]
+      ["Lifney", "before"], ["shavua", "week"], ["Dan", "Dan"], ["hexlit", "decide-PAST"],
+      ["she", "that"], ["be'od", "in"], ["asara", "ten"], ["yamim", "days"], ["bizman", "at-time"],
+      ["aruxat", "meal-CST"], ["ha-boker", "the-morning"], ["hu", "he"],
+      ["yomar", "will.tell-FUT"], ["le-imo", "to-his.mother"], ["she", "that"], ["hu", "he"],
+      ["hitga'agea", "miss-PAST"], ["ele-ha", "to-her"]
     ],
     "translation": "A week ago, Dan decided that in ten days, at breakfast, he would tell his mother that he missed her.",
     "context": "Hebrew non-SOT: embedded PAST (`hitga'agea`) delivers ONLY the anteriority reading. In Hebrew (vs English), embedded past cannot be SOT-deleted to give the nonpast reading.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "anteriority (missing before telling)",     "judgment": "acceptable"},
-      {"name": "nonpast (missing at telling)",             "judgment": "ungrammatical"}
+      {"name": "anteriority (missing before telling)", "judgment": "acceptable"},
+      {"name": "nonpast (missing at telling)", "judgment": "ungrammatical"}
     ],
     "comment": "Sharvit 2003 ex (6), p. 670. Minimal pair partner of (5) — same surface meaning, embedded PAST vs PRES. The asymmetry diagnostics Hebrew as non-SOT.",
     "metaLanguage": "stan1293",

--- a/Linglib/Data/Examples/Steedman2000.json
+++ b/Linglib/Data/Examples/Steedman2000.json
@@ -1,34 +1,21 @@
 [
   {
     "id": "steedman2000_96",
-    "source": {
-      "bibkey": "steedman-2000",
-      "paperLabel": "(96)"
-    },
+    "source": {"bibkey": "steedman-2000", "paperLabel": "(96)"},
     "language": "stan1295",
     "primaryText": "(Weil) irgendjemand auf jeden gespannt ist.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["(Weil)", "(since)"],
-      ["irgendjemand", "someone"],
-      ["auf", "on"],
-      ["jeden", "everybody"],
-      ["gespannt", "curious"],
-      ["ist", "is"]
+      ["(Weil)", "(since)"], ["irgendjemand", "someone"], ["auf", "on"], ["jeden", "everybody"],
+      ["gespannt", "curious"], ["ist", "is"]
     ],
     "translation": "Since someone is curious about everybody.",
     "context": "German verb-final subordinate clause; the quantified PP precedes the predicate-tense cluster.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {
-        "name": "surface",
-        "judgment": "acceptable"
-      },
-      {
-        "name": "inverse",
-        "judgment": "acceptable"
-      }
+      {"name": "surface", "judgment": "acceptable"},
+      {"name": "inverse", "judgment": "acceptable"}
     ],
     "paperFeatures": [
       ["wordOrder", "verbRaising"]
@@ -38,34 +25,21 @@
   },
   {
     "id": "steedman2000_97",
-    "source": {
-      "bibkey": "steedman-2000",
-      "paperLabel": "(97)"
-    },
+    "source": {"bibkey": "steedman-2000", "paperLabel": "(97)"},
     "language": "stan1295",
     "primaryText": "(Weil) jemand versucht hat jeden reinzulegen.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["(Weil)", "(since)"],
-      ["jemand", "someone"],
-      ["versucht", "tried"],
-      ["hat", "has"],
-      ["jeden", "everyone"],
-      ["reinzulegen", "cheat"]
+      ["(Weil)", "(since)"], ["jemand", "someone"], ["versucht", "tried"], ["hat", "has"],
+      ["jeden", "everyone"], ["reinzulegen", "cheat"]
     ],
     "translation": "Since someone has tried to cheat everyone.",
     "context": "German verb-final subordinate clause; the quantified object follows the matrix verb cluster.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {
-        "name": "surface",
-        "judgment": "acceptable"
-      },
-      {
-        "name": "inverse",
-        "judgment": "unacceptable"
-      }
+      {"name": "surface", "judgment": "acceptable"},
+      {"name": "inverse", "judgment": "unacceptable"}
     ],
     "paperFeatures": [
       ["wordOrder", "verbProjectionRaising"]
@@ -75,35 +49,21 @@
   },
   {
     "id": "steedman2000_98a",
-    "source": {
-      "bibkey": "steedman-2000",
-      "paperLabel": "(98a)"
-    },
+    "source": {"bibkey": "steedman-2000", "paperLabel": "(98a)"},
     "language": "vlaa1240",
     "primaryText": "(da) Jan vee boeken hee willen lezen",
     "discourseSegments": [],
     "glossedTokens": [
-      ["(da)", "(that)"],
-      ["Jan", "Jan"],
-      ["vee", "many"],
-      ["boeken", "books"],
-      ["hee", "has"],
-      ["willen", "wanted"],
-      ["lezen", "read"]
+      ["(da)", "(that)"], ["Jan", "Jan"], ["vee", "many"], ["boeken", "books"], ["hee", "has"],
+      ["willen", "wanted"], ["lezen", "read"]
     ],
     "translation": "that Jan wanted to read many books",
     "context": "West Flemish subordinate clause in the verb-raising word order.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {
-        "name": "surface",
-        "judgment": "acceptable"
-      },
-      {
-        "name": "inverse",
-        "judgment": "acceptable"
-      }
+      {"name": "surface", "judgment": "acceptable"},
+      {"name": "inverse", "judgment": "acceptable"}
     ],
     "paperFeatures": [
       ["wordOrder", "verbRaising"]
@@ -113,35 +73,21 @@
   },
   {
     "id": "steedman2000_98b",
-    "source": {
-      "bibkey": "steedman-2000",
-      "paperLabel": "(98b)"
-    },
+    "source": {"bibkey": "steedman-2000", "paperLabel": "(98b)"},
     "language": "vlaa1240",
     "primaryText": "(da) Jan hee willen vee boeken lezen",
     "discourseSegments": [],
     "glossedTokens": [
-      ["(da)", "(that)"],
-      ["Jan", "Jan"],
-      ["hee", "has"],
-      ["willen", "wanted"],
-      ["vee", "many"],
-      ["boeken", "books"],
-      ["lezen", "read"]
+      ["(da)", "(that)"], ["Jan", "Jan"], ["hee", "has"], ["willen", "wanted"], ["vee", "many"],
+      ["boeken", "books"], ["lezen", "read"]
     ],
     "translation": "that Jan wanted to read many books",
     "context": "West Flemish subordinate clause in the verb-projection-raising word order.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {
-        "name": "surface",
-        "judgment": "acceptable"
-      },
-      {
-        "name": "inverse",
-        "judgment": "unacceptable"
-      }
+      {"name": "surface", "judgment": "acceptable"},
+      {"name": "inverse", "judgment": "unacceptable"}
     ],
     "paperFeatures": [
       ["wordOrder", "verbProjectionRaising"]
@@ -151,35 +97,21 @@
   },
   {
     "id": "steedman2000_99a",
-    "source": {
-      "bibkey": "steedman-2000",
-      "paperLabel": "(99a)"
-    },
+    "source": {"bibkey": "steedman-2000", "paperLabel": "(99a)"},
     "language": "dutc1256",
     "primaryText": "(omdat) Jan veel liederen probeert te zingen",
     "discourseSegments": [],
     "glossedTokens": [
-      ["(omdat)", "(because)"],
-      ["Jan", "Jan"],
-      ["veel", "many"],
-      ["liederen", "songs"],
-      ["probeert", "tries"],
-      ["te", "to"],
-      ["zingen", "sing"]
+      ["(omdat)", "(because)"], ["Jan", "Jan"], ["veel", "many"], ["liederen", "songs"],
+      ["probeert", "tries"], ["te", "to"], ["zingen", "sing"]
     ],
     "translation": "because Jan tries to sing many songs",
     "context": "Dutch subordinate clause with an equi verb, verb-raising word order.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {
-        "name": "surface",
-        "judgment": "acceptable"
-      },
-      {
-        "name": "inverse",
-        "judgment": "acceptable"
-      }
+      {"name": "surface", "judgment": "acceptable"},
+      {"name": "inverse", "judgment": "acceptable"}
     ],
     "paperFeatures": [
       ["wordOrder", "verbRaising"]
@@ -189,35 +121,21 @@
   },
   {
     "id": "steedman2000_99b",
-    "source": {
-      "bibkey": "steedman-2000",
-      "paperLabel": "(99b)"
-    },
+    "source": {"bibkey": "steedman-2000", "paperLabel": "(99b)"},
     "language": "dutc1256",
     "primaryText": "(omdat) Jan probeert veel liederen te zingen",
     "discourseSegments": [],
     "glossedTokens": [
-      ["(omdat)", "(because)"],
-      ["Jan", "Jan"],
-      ["probeert", "tries"],
-      ["veel", "many"],
-      ["liederen", "songs"],
-      ["te", "to"],
-      ["zingen", "sing"]
+      ["(omdat)", "(because)"], ["Jan", "Jan"], ["probeert", "tries"], ["veel", "many"],
+      ["liederen", "songs"], ["te", "to"], ["zingen", "sing"]
     ],
     "translation": "because Jan tries to sing many songs",
     "context": "Dutch subordinate clause with an equi verb, verb-projection-raising word order.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {
-        "name": "surface",
-        "judgment": "acceptable"
-      },
-      {
-        "name": "inverse",
-        "judgment": "unacceptable"
-      }
+      {"name": "surface", "judgment": "acceptable"},
+      {"name": "inverse", "judgment": "unacceptable"}
     ],
     "paperFeatures": [
       ["wordOrder", "verbProjectionRaising"]
@@ -227,35 +145,21 @@
   },
   {
     "id": "steedman2000_100a",
-    "source": {
-      "bibkey": "steedman-2000",
-      "paperLabel": "(100a)"
-    },
+    "source": {"bibkey": "steedman-2000", "paperLabel": "(100a)"},
     "language": "dutc1256",
     "primaryText": "(omdat) iemand alle liederen probeert te zingen",
     "discourseSegments": [],
     "glossedTokens": [
-      ["(omdat)", "(because)"],
-      ["iemand", "someone"],
-      ["alle", "every"],
-      ["liederen", "song"],
-      ["probeert", "tries"],
-      ["te", "to"],
-      ["zingen", "sing"]
+      ["(omdat)", "(because)"], ["iemand", "someone"], ["alle", "every"], ["liederen", "song"],
+      ["probeert", "tries"], ["te", "to"], ["zingen", "sing"]
     ],
     "translation": "because someone tries to sing every song",
     "context": "Dutch subordinate clause, verb-raising word order, two quantified arguments.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {
-        "name": "surface",
-        "judgment": "acceptable"
-      },
-      {
-        "name": "inverse",
-        "judgment": "acceptable"
-      }
+      {"name": "surface", "judgment": "acceptable"},
+      {"name": "inverse", "judgment": "acceptable"}
     ],
     "paperFeatures": [
       ["wordOrder", "verbRaising"]
@@ -265,35 +169,21 @@
   },
   {
     "id": "steedman2000_100b",
-    "source": {
-      "bibkey": "steedman-2000",
-      "paperLabel": "(100b)"
-    },
+    "source": {"bibkey": "steedman-2000", "paperLabel": "(100b)"},
     "language": "dutc1256",
     "primaryText": "(omdat) iemand probeert alle liederen te zingen",
     "discourseSegments": [],
     "glossedTokens": [
-      ["(omdat)", "(because)"],
-      ["iemand", "someone"],
-      ["probeert", "tries"],
-      ["alle", "every"],
-      ["liederen", "song"],
-      ["te", "to"],
-      ["zingen", "sing"]
+      ["(omdat)", "(because)"], ["iemand", "someone"], ["probeert", "tries"], ["alle", "every"],
+      ["liederen", "song"], ["te", "to"], ["zingen", "sing"]
     ],
     "translation": "because someone tries to sing every song",
     "context": "Dutch subordinate clause, verb-projection-raising word order, two quantified arguments.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {
-        "name": "surface",
-        "judgment": "acceptable"
-      },
-      {
-        "name": "inverse",
-        "judgment": "unacceptable"
-      }
+      {"name": "surface", "judgment": "acceptable"},
+      {"name": "inverse", "judgment": "unacceptable"}
     ],
     "paperFeatures": [
       ["wordOrder", "verbProjectionRaising"]

--- a/Linglib/Data/Examples/TieuEtAl2020.json
+++ b/Linglib/Data/Examples/TieuEtAl2020.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "tieuetal2020_fed_giraffes_pos",
-    "source":     {"bibkey": "tieu-etal-2020", "paperLabel": ""},
+    "source": {"bibkey": "tieu-etal-2020", "paperLabel": ""},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Emily fed giraffes",
@@ -15,7 +15,7 @@
       {"name": "multiplicity (>1)", "judgment": "acceptable"}
     ],
     "paperFeatures": [
-      ["polarity",               "positive"],
+      ["polarity", "positive"],
       ["multiplicity_inference", "present"]
     ],
     "comment": "Core multiplicity datum, positive (upward-entailing) form: interpreted as 'Emily fed more than one giraffe'. Migrated from Phenomena/Plurals/Multiplicity.lean `fedGiraffes` (multiplicityInPositive = true); no example number asserted by the Lean source, so paperLabel is left empty.",
@@ -24,7 +24,7 @@
   },
   {
     "id": "tieuetal2020_fed_giraffes_neg",
-    "source":     {"bibkey": "tieu-etal-2020", "paperLabel": ""},
+    "source": {"bibkey": "tieu-etal-2020", "paperLabel": ""},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Emily didn't feed giraffes",
@@ -38,7 +38,7 @@
       {"name": "multiplicity (>1)", "judgment": "unacceptable"}
     ],
     "paperFeatures": [
-      ["polarity",               "negative"],
+      ["polarity", "negative"],
       ["multiplicity_inference", "absent"]
     ],
     "comment": "Core multiplicity datum, negative (downward-entailing) form: interpreted as 'Emily didn't feed any giraffes', NOT 'Emily didn't feed more than one giraffe' — the multiplicity reading is unavailable under negation. Migrated from Phenomena/Plurals/Multiplicity.lean `fedGiraffes` (multiplicityInNegative = false); no example number asserted by the Lean source, so paperLabel is left empty.",
@@ -47,7 +47,7 @@
   },
   {
     "id": "tieuetal2020_exp1_positive",
-    "source":     {"bibkey": "tieu-etal-2020", "paperLabel": "Exp. 1"},
+    "source": {"bibkey": "tieu-etal-2020", "paperLabel": "Exp. 1"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Emily fed pigs",
@@ -58,14 +58,14 @@
     "judgment": "questionable",
     "alternatives": [],
     "readings": [
-      {"name": "multiplicity (>1)",        "judgment": "acceptable"},
-      {"name": "inclusive (one or more)",  "judgment": "marginal"}
+      {"name": "multiplicity (>1)", "judgment": "acceptable"},
+      {"name": "inclusive (one or more)", "judgment": "marginal"}
     ],
     "paperFeatures": [
-      ["experiment",                          "1"],
-      ["polarity",                            "positive"],
-      ["n_acted_on",                          "one"],
-      ["acceptance_indicates_multiplicity",   "false"]
+      ["experiment", "1"],
+      ["polarity", "positive"],
+      ["n_acted_on", "one"],
+      ["acceptance_indicates_multiplicity", "false"]
     ],
     "comment": "TVJ trial, upward-entailing condition. Rejecting = computing multiplicity (one pig is not 'more than one'). Sentence-level judgment 'questionable' encodes the group-split TVJ outcome recorded qualitatively in the Lean source (exp1Results): adults' multiplicity rate high (predominantly reject in this one-pig context), children's low (largely accept on the inclusive reading). Reading judgments encode availability for adults: multiplicity dominant, inclusive residual. Migrated from Studies/TieuEtAl2020.lean `exp1_positive`. UNVERIFIED paperLabel: 'Exp. 1' is asserted by the Lean docstring, not checked against the paper.",
     "metaLanguage": "stan1293",
@@ -73,7 +73,7 @@
   },
   {
     "id": "tieuetal2020_exp1_negative",
-    "source":     {"bibkey": "tieu-etal-2020", "paperLabel": "Exp. 1"},
+    "source": {"bibkey": "tieu-etal-2020", "paperLabel": "Exp. 1"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Emily didn't feed giraffes",
@@ -87,10 +87,10 @@
       {"name": "multiplicity (>1) local under negation", "judgment": "marginal"}
     ],
     "paperFeatures": [
-      ["experiment",                          "1"],
-      ["polarity",                            "negative"],
-      ["n_acted_on",                          "one"],
-      ["acceptance_indicates_multiplicity",   "true"]
+      ["experiment", "1"],
+      ["polarity", "negative"],
+      ["n_acted_on", "one"],
+      ["acceptance_indicates_multiplicity", "true"]
     ],
     "comment": "TVJ trial, downward-entailing condition. Accepting = computing multiplicity locally under negation (interpreting as 'Emily didn't feed more than one giraffe'); on the inclusive reading the sentence is literally false (she fed one). Sentence-level judgment 'questionable' encodes the mixed TVJ outcome recorded qualitatively in the Lean source (exp1Results): adults' negative-condition multiplicity rate moderate, children's low. Reading judgment 'marginal' encodes that moderate adult availability. Migrated from Studies/TieuEtAl2020.lean `exp1_negative`. UNVERIFIED paperLabel: 'Exp. 1' is asserted by the Lean docstring, not checked against the paper.",
     "metaLanguage": "stan1293",
@@ -98,7 +98,7 @@
   },
   {
     "id": "tieuetal2020_exp3_positive_plural",
-    "source":     {"bibkey": "tieu-etal-2020", "paperLabel": "Exp. 3"},
+    "source": {"bibkey": "tieu-etal-2020", "paperLabel": "Exp. 3"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Koala bought pears",
@@ -110,11 +110,11 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["experiment",        "3"],
-      ["polarity",          "positive"],
-      ["n_acted_on",        "one"],
-      ["task",              "ternary_reward"],
-      ["preferred_reward",  "intermediate"]
+      ["experiment", "3"],
+      ["polarity", "positive"],
+      ["n_acted_on", "one"],
+      ["task", "ternary_reward"],
+      ["preferred_reward", "intermediate"]
     ],
     "comment": "Experiment 3 ternary judgment task (small/medium/large strawberry for false/neither/true), adults on Amazon Mechanical Turk, singular context. Literally true (bought one or more) but with a false multiplicity implicature — misleading. Adults' preferred reward: intermediate; judgment 'marginal' maps that intermediate ternary outcome onto the 5-level scale. Migrated from Studies/TieuEtAl2020.lean `exp3_positive_plural`. UNVERIFIED paperLabel: 'Exp. 3' is asserted by the Lean docstring, not checked against the paper.",
     "metaLanguage": "stan1293",
@@ -122,7 +122,7 @@
   },
   {
     "id": "tieuetal2020_exp3_negative_plural",
-    "source":     {"bibkey": "tieu-etal-2020", "paperLabel": "Exp. 3"},
+    "source": {"bibkey": "tieu-etal-2020", "paperLabel": "Exp. 3"},
     "reportedIn": null,
     "language": "stan1293",
     "primaryText": "Koala didn't buy pears",
@@ -134,11 +134,11 @@
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
-      ["experiment",        "3"],
-      ["polarity",          "negative"],
-      ["n_acted_on",        "one"],
-      ["task",              "ternary_reward"],
-      ["preferred_reward",  "minimal"]
+      ["experiment", "3"],
+      ["polarity", "negative"],
+      ["n_acted_on", "one"],
+      ["task", "ternary_reward"],
+      ["preferred_reward", "minimal"]
     ],
     "comment": "Experiment 3 ternary judgment task, singular context, negative sentence. Literally false (Koala did buy one or more pears); adults' preferred reward: minimal; judgment 'unacceptable' maps that minimal ternary outcome onto the 5-level scale. The positive/negative asymmetry with exp3_positive_plural confirms the implicature approach's singular-context prediction. Migrated from Studies/TieuEtAl2020.lean `exp3_negative_plural`. UNVERIFIED paperLabel: 'Exp. 3' is asserted by the Lean docstring, not checked against the paper.",
     "metaLanguage": "stan1293",

--- a/Linglib/Data/Examples/VonFintelIatridou2005.json
+++ b/Linglib/Data/Examples/VonFintelIatridou2005.json
@@ -11,8 +11,10 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "The canonical Harlem Sentence; the paper's central example.",
-    "paperFeatures": [["puzzle", "harlemBase"]]
+    "paperFeatures": [
+      ["puzzle", "harlemBase"]
+    ],
+    "comment": "The canonical Harlem Sentence; the paper's central example."
   },
   {
     "id": "vFI2005_2_sugarWaiter",
@@ -27,8 +29,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Anankastic reading: asking the waiter is a means to having sugar. Same surface form as (3) but different reading — surface form does not determine anankasticity.",
-    "paperFeatures": [["puzzle", "hareMinimalPair"], ["reading", "anankastic"]]
+    "paperFeatures": [
+      ["puzzle", "hareMinimalPair"],
+      ["reading", "anankastic"]
+    ],
+    "comment": "Anankastic reading: asking the waiter is a means to having sugar. Same surface form as (3) but different reading — surface form does not determine anankasticity."
   },
   {
     "id": "vFI2005_3_sugarDiabetes",
@@ -43,8 +48,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "NON-anankastic reading: getting tested is not a means to having sugar. Pair with (2) to show that surface form does not determine anankasticity.",
-    "paperFeatures": [["puzzle", "hareMinimalPair"], ["reading", "non-anankastic"]]
+    "paperFeatures": [
+      ["puzzle", "hareMinimalPair"],
+      ["reading", "non-anankastic"]
+    ],
+    "comment": "NON-anankastic reading: getting tested is not a means to having sugar. Pair with (2) to show that surface form does not determine anankasticity."
   },
   {
     "id": "vFI2005_4_harlemPurpose",
@@ -58,8 +66,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Purpose-clause near-equivalent of (1); vF&I treat the purpose variant as the primary form for their designated-goal analysis.",
-    "paperFeatures": [["puzzle", "harlemBase"], ["clauseType", "purpose"]]
+    "paperFeatures": [
+      ["puzzle", "harlemBase"],
+      ["clauseType", "purpose"]
+    ],
+    "comment": "Purpose-clause near-equivalent of (1); vF&I treat the purpose variant as the primary form for their designated-goal analysis."
   },
   {
     "id": "vFI2005_11_hoboken",
@@ -73,8 +84,10 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "The Hoboken Problem. Defeats the obvious analysis: if the if-clause merely added 'you want Harlem' to the modal base, the best goal-achievement at the actual world would be PATH (since the actual goal is Hoboken).",
-    "paperFeatures": [["puzzle", "hoboken"]]
+    "paperFeatures": [
+      ["puzzle", "hoboken"]
+    ],
+    "comment": "The Hoboken Problem. Defeats the obvious analysis: if the if-clause merely added 'you want Harlem' to the modal base, the best goal-achievement at the actual world would be PATH (since the actual goal is Hoboken)."
   },
   {
     "id": "vFI2005_13_hobokenSaebo",
@@ -88,8 +101,10 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Sæbø 2001's analysis predicts this false (best worlds equally split between PATH and A train); intuition says true. Defeats the if-clause-modifies-ordering-source analysis.",
-    "paperFeatures": [["puzzle", "conflictingGoals"]]
+    "paperFeatures": [
+      ["puzzle", "conflictingGoals"]
+    ],
+    "comment": "Sæbø 2001's analysis predicts this false (best worlds equally split between PATH and A train); intuition says true. Defeats the if-clause-modifies-ordering-source analysis."
   },
   {
     "id": "vFI2005_22_mayorPub",
@@ -104,8 +119,10 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Conflicting jointly-satisfiable goals. The if-clause's goal must override the actual conflicting goal, not merely augment the ordering source.",
-    "paperFeatures": [["puzzle", "conflictingGoals"]]
+    "paperFeatures": [
+      ["puzzle", "conflictingGoals"]
+    ],
+    "comment": "Conflicting jointly-satisfiable goals. The if-clause's goal must override the actual conflicting goal, not merely augment the ordering source."
   },
   {
     "id": "vFI2005_p12_vanNistelrooy",
@@ -120,8 +137,10 @@
     "judgment": "unacceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Both routes achieve Harlem; van Nistelrooy preference makes A optimal under naive lifting, but speakers report reluctance to judge the have-to sentence true on this scenario.",
-    "paperFeatures": [["puzzle", "correlatedIrrelevant"]]
+    "paperFeatures": [
+      ["puzzle", "correlatedIrrelevant"]
+    ],
+    "comment": "Both routes achieve Harlem; van Nistelrooy preference makes A optimal under naive lifting, but speakers report reluctance to judge the have-to sentence true on this scenario."
   },
   {
     "id": "vFI2005_36_pedroMartinez",
@@ -136,8 +155,10 @@
     "judgment": "ungrammatical",
     "alternatives": [],
     "readings": [],
-    "comment": "Kissing Pedro is not an essential part of any way of achieving Harlem; sentence is absurd despite the correlation. Motivates vF&I's 'essential part of a way of achieving' refinement (their (42)).",
-    "paperFeatures": [["puzzle", "nonCausalCoincidence"]]
+    "paperFeatures": [
+      ["puzzle", "nonCausalCoincidence"]
+    ],
+    "comment": "Kissing Pedro is not an essential part of any way of achieving Harlem; sentence is absurd despite the correlation. Motivates vF&I's 'essential part of a way of achieving' refinement (their (42))."
   },
   {
     "id": "vFI2005_34c_harlemBreathe",
@@ -152,8 +173,11 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "vF&I accept as true though unhelpful. Chung & Mascarenhas 2024 §5 needs a plausibility-requirement patch to rule out analogous epistemic cases (#He must be dead).",
-    "paperFeatures": [["puzzle", "triviallyTrue"], ["modal", "have-to"]]
+    "paperFeatures": [
+      ["puzzle", "triviallyTrue"],
+      ["modal", "have-to"]
+    ],
+    "comment": "vF&I accept as true though unhelpful. Chung & Mascarenhas 2024 §5 needs a plausibility-requirement patch to rule out analogous epistemic cases (#He must be dead)."
   },
   {
     "id": "vFI2005_35_harlemBreatheOught",
@@ -167,8 +191,11 @@
     "judgment": "questionable",
     "alternatives": [],
     "readings": [],
-    "comment": "Less acceptable than the have-to variant. vF&I derive this from have-to entailing ought-to, so ought-to signals there are alternatives — false for breathing.",
-    "paperFeatures": [["puzzle", "triviallyTrue"], ["modal", "ought-to"]]
+    "paperFeatures": [
+      ["puzzle", "triviallyTrue"],
+      ["modal", "ought-to"]
+    ],
+    "comment": "Less acceptable than the have-to variant. vF&I derive this from have-to entailing ought-to, so ought-to signals there are alternatives — false for breathing."
   },
   {
     "id": "vFI2005_23_slomanOughtNot",
@@ -183,8 +210,10 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Felicitous because ought says what is best while have-to picks out the only candidate.",
-    "paperFeatures": [["puzzle", "oughtVsHaveTo"]]
+    "paperFeatures": [
+      ["puzzle", "oughtVsHaveTo"]
+    ],
+    "comment": "Felicitous because ought says what is best while have-to picks out the only candidate."
   },
   {
     "id": "vFI2005_p13_londonByNoon",
@@ -197,10 +226,14 @@
     "translation": "If you want to get to London by noon, then you ought to go by train.",
     "context": "Train is the best option but not the only one.",
     "judgment": "acceptable",
-    "alternatives": [{"form": "If you want to get to London by noon, then you have to go by train.", "judgment": "unacceptable"}],
+    "alternatives": [
+      {"form": "If you want to get to London by noon, then you have to go by train.", "judgment": "unacceptable"}
+    ],
     "readings": [],
-    "comment": "Sloman: 'picks out the best means without excluding the possibility of others.' Contrast with the have-to variant implying no other means exists.",
-    "paperFeatures": [["puzzle", "oughtVsHaveTo"]]
+    "paperFeatures": [
+      ["puzzle", "oughtVsHaveTo"]
+    ],
+    "comment": "Sloman: 'picks out the best means without excluding the possibility of others.' Contrast with the have-to variant implying no other means exists."
   },
   {
     "id": "vFI2005_29_vladivostokHave",
@@ -215,8 +248,12 @@
     "judgment": "marginal",
     "alternatives": [],
     "readings": [],
-    "comment": "Klein-type speakers accept (comfort is implicitly part of the designated goal); Percus-type speakers reject. Documents real speaker variation.",
-    "paperFeatures": [["puzzle", "vladivostokOughtHave"], ["modal", "have-to"], ["speakerVariation", "Klein-vs-Percus"]]
+    "paperFeatures": [
+      ["puzzle", "vladivostokOughtHave"],
+      ["modal", "have-to"],
+      ["speakerVariation", "Klein-vs-Percus"]
+    ],
+    "comment": "Klein-type speakers accept (comfort is implicitly part of the designated goal); Percus-type speakers reject. Documents real speaker variation."
   },
   {
     "id": "vFI2005_30_vladivostokOught",
@@ -230,23 +267,33 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
-    "comment": "Ought-to accepts without controversy because comfort considerations rank the Chinese train above the Russian.",
-    "paperFeatures": [["puzzle", "vladivostokOughtHave"], ["modal", "ought-to"]]
+    "paperFeatures": [
+      ["puzzle", "vladivostokOughtHave"],
+      ["modal", "ought-to"]
+    ],
+    "comment": "Ought-to accepts without controversy because comfort considerations rank the Chinese train above the Russian."
   },
   {
     "id": "vFI2005_28_burdicks",
     "source": {"bibkey": "vonfintel-iatridou-2005", "paperLabel": "(28)"},
     "language": "stan1293",
     "primaryText": "A: I'm going to Harvard Square tomorrow. B: You have to have some hot chocolate at Burdick's.",
-    "discourseSegments": ["I'm going to Harvard Square tomorrow.", "You have to have some hot chocolate at Burdick's."],
+    "discourseSegments": [
+      "I'm going to Harvard Square tomorrow.",
+      "You have to have some hot chocolate at Burdick's."
+    ],
     "glossedTokens": [],
     "translation": "Same.",
     "context": "A announces an itinerary; no to-clause or if-clause overtly supplies a goal.",
     "judgment": "acceptable",
-    "alternatives": [{"form": "You ought to have some hot chocolate at Burdick's.", "judgment": "acceptable"}],
+    "alternatives": [
+      {"form": "You ought to have some hot chocolate at Burdick's.", "judgment": "acceptable"}
+    ],
     "readings": [],
-    "comment": "Designated goal supplied by context (something like 'have a good Harvard Square experience'), not by overt syntax. Motivates vF&I §6.4.",
-    "paperFeatures": [["puzzle", "contextualDesignation"]]
+    "paperFeatures": [
+      ["puzzle", "contextualDesignation"]
+    ],
+    "comment": "Designated goal supplied by context (something like 'have a good Harvard Square experience'), not by overt syntax. Motivates vF&I §6.4."
   },
   {
     "id": "vFI2005_20_weinerJoe",
@@ -259,8 +306,13 @@
     "context": "Joe has been considering buying a used car in Harlem. If he hasn't bought it yet, the A train is his only way to Harlem; if he has bought it, he can drive or take the A train. The only reason Joe would want Harlem is to buy the car (so if he wants Harlem, he hasn't bought it).",
     "judgment": "acceptable",
     "alternatives": [],
-    "readings": [{"name": "epistemic", "judgment": "marginal"}, {"name": "anankastic", "judgment": "acceptable"}],
-    "comment": "On the anankastic reading: true in all cases. On Weiner's intended epistemic reading: true only if Joe hasn't bought the car. vF&I admit the epistemic reading is sometimes available; tests the must-can-be-epistemic-in-anankastic-shell hypothesis.",
-    "paperFeatures": [["puzzle", "weinerJoe"]]
+    "readings": [
+      {"name": "epistemic", "judgment": "marginal"},
+      {"name": "anankastic", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["puzzle", "weinerJoe"]
+    ],
+    "comment": "On the anankastic reading: true in all cases. On Weiner's intended epistemic reading: true only if Joe hasn't bought the car. vF&I admit the epistemic reading is sometimes available; tests the must-can-be-epistemic-in-anankastic-shell hypothesis."
   }
 ]

--- a/scripts/gen_examples.py
+++ b/scripts/gen_examples.py
@@ -437,12 +437,116 @@ def process(author_year: str, check: bool) -> bool:
     return True
 
 
+# Canonical JSON formatting: 2-space indent, schema key order, and compact
+# leaf collections (gloss pairs packed onto wrapped lines; one feature pair /
+# alternative / reading per line) so a python round-trip never explodes them.
+
+KEY_ORDER = [
+    "id", "source", "reportedIn", "language", "primaryText",
+    "discourseSegments", "glossedTokens", "translation", "context",
+    "judgment", "alternatives", "readings", "paperFeatures", "comment",
+    "metaLanguage", "lgrConformance",
+]
+
+MAX_WIDTH = 98
+
+
+def _j(v) -> str:
+    return json.dumps(v, ensure_ascii=False)
+
+
+def _fmt_inline_list(items: list[str], indent: str) -> str:
+    """Render pre-serialized items inside [...], packing them onto lines of
+    at most MAX_WIDTH characters."""
+    if not items:
+        return "[]"
+    lines, cur = [], ""
+    for it in items:
+        cand = it if not cur else f"{cur}, {it}"
+        if cur and len(indent) + 2 + len(cand) > MAX_WIDTH:
+            lines.append(cur + ",")
+            cur = it
+        else:
+            cur = cand
+    lines.append(cur)
+    body = "\n".join(f"{indent}  {l}" for l in lines)
+    return f"[\n{body}\n{indent}]"
+
+
+def _fmt_per_line_list(items: list[str], indent: str) -> str:
+    """Render pre-serialized items inside [...], one per line."""
+    if not items:
+        return "[]"
+    body = ",\n".join(f"{indent}  {it}" for it in items)
+    return f"[\n{body}\n{indent}]"
+
+
+def _fmt_obj_inline(o: dict) -> str:
+    return "{" + ", ".join(f"{_j(k)}: {_j(v)}" for k, v in o.items()) + "}"
+
+
+def _fmt_value(key: str, v, indent: str) -> str:
+    if v is None or isinstance(v, (str, int, float, bool)):
+        return _j(v)
+    if isinstance(v, dict):
+        return _fmt_obj_inline(v)
+    if isinstance(v, list):
+        if key == "glossedTokens":
+            return _fmt_inline_list([_j(x) for x in v], indent)
+        if key in ("paperFeatures", "alternatives", "readings"):
+            items = [
+                _fmt_obj_inline(x) if isinstance(x, dict) else _j(x) for x in v
+            ]
+            return _fmt_per_line_list(items, indent)
+        if key == "discourseSegments":
+            return _fmt_per_line_list([_j(x) for x in v], indent)
+        return _j(v)
+    return _j(v)
+
+
+def format_examples(examples: list) -> str:
+    """Canonical text for a per-paper JSON file."""
+    out = ["["]
+    for i, ex in enumerate(examples):
+        out.append("  {")
+        keys = [k for k in KEY_ORDER if k in ex]
+        keys += [k for k in ex if k not in KEY_ORDER]  # never drop unknown keys
+        for j, k in enumerate(keys):
+            comma = "," if j < len(keys) - 1 else ""
+            out.append(f"    {_j(k)}: {_fmt_value(k, ex[k], '    ')}{comma}")
+        out.append("  }," if i < len(examples) - 1 else "  }")
+    out.append("]")
+    return "\n".join(out) + "\n"
+
+
+def fmt(author_year: str) -> bool:
+    """Rewrite a JSON file in canonical format. Refuses to write (and
+    returns False) if the formatted text does not parse back to the
+    identical data."""
+    json_path = JSON_DIR / f"{author_year}.json"
+    with open(json_path, encoding="utf-8") as f:
+        examples = json.load(f)
+    text = format_examples(examples)
+    if json.loads(text) != examples:
+        sys.stderr.write(
+            f"[fmt] REFUSING {json_path.relative_to(ROOT)}: round-trip mismatch\n"
+        )
+        return False
+    if json_path.read_text(encoding="utf-8") == text:
+        sys.stdout.write(f"[fmt] {json_path.relative_to(ROOT)} unchanged\n")
+    else:
+        json_path.write_text(text, encoding="utf-8")
+        sys.stdout.write(f"[fmt] {json_path.relative_to(ROOT)} reformatted\n")
+    return True
+
+
 def main():
     args = sys.argv[1:]
     check = "--check" in args
-    args = [a for a in args if a != "--check"]
+    do_fmt = "--fmt" in args
+    args = [a for a in args if a not in ("--check", "--fmt")]
 
-    if args == ["--all"] or (not args and check):
+    if args == ["--all"] or (not args and (check or do_fmt)):
         papers = sorted(p.stem for p in JSON_DIR.glob("*.json"))
     elif len(args) == 1 and not args[0].startswith("-"):
         papers = [args[0]]
@@ -450,11 +554,18 @@ def main():
         sys.stderr.write(
             "Usage: python3 scripts/gen_examples.py <AuthorYear> | --all\n"
             "       python3 scripts/gen_examples.py --check [<AuthorYear>]\n"
+            "       python3 scripts/gen_examples.py --fmt [<AuthorYear>]\n"
             "  --all    regenerate every Linglib/Data/Examples/*.json\n"
             "  --check  verify generated modules match JSON (no writes); "
             "exit 1 on drift\n"
+            "  --fmt    rewrite JSON in canonical format (data-preserving)\n"
         )
         sys.exit(1)
+
+    if do_fmt:
+        if not all([fmt(p) for p in papers]):
+            sys.exit(1)
+        return
 
     ok = all([process(p, check) for p in papers])
     if not ok:


### PR DESCRIPTION
Adds a data-preserving `--fmt` mode to gen_examples.py (2-space indent, schema key order, gloss pairs packed onto wrapped lines instead of one string per line, one feature/alternative/reading per line; refuses to write on round-trip mismatch) and applies it to all 28 affected JSON files (−724 lines). Generated modules unchanged (`--check` clean).