### PR TITLE
fix(Syntax/Minimalist/Phi): audit corrections; probeAgree graduation

### DIFF
--- a/Linglib/Studies/BejarRezac2003.lean
+++ b/Linglib/Studies/BejarRezac2003.lean
@@ -39,9 +39,11 @@ nominative over the dative, whereupon the projection of T introduces
 a fresh [π]-probe and a *second Agree cycle* finds the nominative
 first. Icelandic, where the dative itself satisfies the EPP and stays
 highest, keeps the PCC in dative-nominative constructions (their
-(12)). The second-cycle mechanism is the seed of [bejar-rezac-2009]'s
-cyclic Agree (`Syntax/Minimalist/CyclicAgree.lean`). Modeled here as
-a list of probe cycles, each an ordered goal sequence.
+(12)). Modeled here as a list of probe cycles, each an ordered goal
+sequence. The second-cycle mechanism prefigures [bejar-rezac-2009]'s
+cyclic Agree (see `CyclicAgree.lean`), but the two are formally
+distinct: 2003 varies the goal *order* under one probe; 2009 varies
+the *relativization* (per-segment) over one order.
 -/
 
 namespace BejarRezac2003
@@ -67,17 +69,26 @@ instance : DecidablePred Argument.IsParticipant := fun a =>
   inferInstanceAs (Decidable ((decomposePerson a.person).hasParticipant = true))
 
 /-- One cycle of [π]-Agree over an ordered goal sequence: the probe
-    matches the closest goal (every NP bears [π], so visibility is
-    total — `probeSearch ⊤`) and Agrees with it only if it is still
-    active (Case not yet valued, ¬F). An inactive match absorbs the
-    probe without valuing it (their (9)). -/
+    matches the closest goal (every NP bears [π], per their (8), so
+    visibility is total) and Agrees with it only if it is active —
+    not licensed by its own φ-bearing F. An inactive match absorbs
+    the probe without valuing it (their (9)). (The paper glosses
+    activity as Caselessness but leaves open why same-projection
+    Case valuation does not deactivate the French nominative for the
+    second cycle; ¬F gives the right extension.) -/
 def piAgree (goals : List Argument) : Option Argument :=
-  (probeSearch (fun _ => true) goals).bind
-    (fun a => if a.fLicensed then none else some a)
+  probeAgree (fun _ => true) (fun a => !a.fLicensed) goals
 
 /-- The PLC over a derivation's [π]-Agree cycles: every interpretable
     1st/2nd person feature enters an Agree relation with a functional
-    category — its own F, or some cycle's [π]-probe. -/
+    category — its own F, or some cycle's [π]-probe. Intended
+    invariant (not enforced): each cycle is a reordering of `args`
+    (the French repair re-probes the *same* two arguments in reversed
+    order). Differs from the substrate `Minimalist.PLC` — Preminger's
+    single-cycle, search-only, probe-relativized rendering — by the
+    paper's F-licensing disjunct and the multiplicity of cycles; the
+    single-cycle case collapses onto the substrate shape
+    (`plcOk_singleCycle_iff_allLicensed`). -/
 def PLCOk (cycles : List (List Argument)) (args : List Argument) : Prop :=
   ∀ a ∈ args, a.IsParticipant →
     (a.fLicensed = true ∨ ∃ goals ∈ cycles, piAgree goals = some a)
@@ -95,8 +106,35 @@ instance (cycles : List (List Argument)) (args : List Argument) :
     a crash (cf. `ObligatoryOperations`); ungrammaticality comes only
     from the PLC. -/
 theorem piAgree_absorbed (dat acc : Argument) (hd : dat.fLicensed = true) :
-    piAgree [dat, acc] = none := by
-  simp [piAgree, probeSearch, List.find?, hd]
+    piAgree [dat, acc] = none :=
+  probeAgree_eq_none_of_inactive rfl (by simp [hd])
+
+/-- Single-cycle collapse onto the substrate's `(needs, vis)`
+    licensing shape: one [π]-cycle over the base order satisfies the
+    PLC iff `AllLicensed` holds with neediness "participant and not
+    F-licensed" and total visibility. The recoding is lossy by
+    design: it folds the F-licensing route into ¬needy, whereas the
+    paper counts F-licensing as itself an Agree relation; and the
+    multi-cycle repairs ((16)–(17)) escape this signature entirely. -/
+theorem plcOk_singleCycle_iff_allLicensed (goals : List Argument) :
+    PLCOk [goals] goals ↔
+      AllLicensed (fun a => decide a.IsParticipant && !a.fLicensed)
+        (fun _ => true) goals := by
+  unfold PLCOk AllLicensed
+  constructor
+  · intro h a ha hneeds
+    simp only [Bool.and_eq_true, decide_eq_true_eq, Bool.not_eq_true'] at hneeds
+    rcases h a ha hneeds.1 with hF' | ⟨gs, hgs, hag⟩
+    · exact nomatch hneeds.2.symm.trans hF'
+    · rw [List.mem_singleton.mp hgs] at hag
+      exact (probeAgree_eq_some_iff.mp hag).1
+  · intro h a ha hpart
+    cases hF : a.fLicensed with
+    | true => exact Or.inl rfl
+    | false =>
+      refine Or.inr ⟨goals, List.mem_singleton_self _, ?_⟩
+      exact probeAgree_eq_some_iff.mpr
+        ⟨h a ha (by simp [hpart, hF]), by simp [hF]⟩
 
 /-- **The PCC** (their (1)/(7), generalized): in a double-object
     configuration — dative over accusative, one [π]-Agree cycle on
@@ -109,7 +147,7 @@ theorem strong_pcc (dat acc : Argument)
   constructor
   · intro h hacc
     rcases h acc (List.mem_pair.mpr (Or.inr rfl)) hacc with hF | ⟨gs, hgs, hag⟩
-    · exact absurd hF (by simp [ha])
+    · exact nomatch ha.symm.trans hF
     · rw [List.mem_singleton.mp hgs, piAgree_absorbed dat acc hd] at hag
       exact nomatch hag
   · intro hacc a ha' hpart
@@ -138,12 +176,14 @@ theorem pp_repair :
   decide
 
 /-- The dative-nominative split (their (12) vs. (13)/(16)–(17)):
-    Icelandic datives satisfy the EPP and stay highest, so the single
+    Icelandic datives satisfy the EPP and stay highest, so the
     [π]-cycle is absorbed and a 1st/2nd nominative violates the PLC
-    (*þið*, their (12)). In French the nominative raises over the
-    dative and T's projection opens a second [π]-cycle over the
-    reversed order, which finds the now-highest active nominative —
-    PCC obviated (their (13)). -/
+    (*þið*, their (12)). (Modeled as a single cycle; per their (25c)
+    Icelandic also projects a second one, but the dative still
+    intervenes — extensionally the same.) In French the nominative
+    raises over the dative and T's projection opens a second
+    [π]-cycle over the reversed order, which finds the now-highest
+    active nominative — PCC obviated (their (13)). -/
 theorem dnc_split :
     -- Icelandic: one cycle, dative highest — 2nd-person nominative out
     ¬ PLCOk [[⟨.third, true⟩, ⟨.second, false⟩]]

--- a/Linglib/Studies/Halpert2012.lean
+++ b/Linglib/Studies/Halpert2012.lean
@@ -12,9 +12,10 @@ highest there, and at most one occurs per simplex clause. The
 **conjoint/disjoint** alternation on the verb (present tense:
 conjoint ∅- vs. disjoint *ya-*) is the morphological spellout of L⁰
 itself (her ch. 4): "the disjoint appears when L fails to find a
-goal", and "the derivation converges even if a probe fails to find a
-goal" — failure-tolerance, adopted by [preminger-2014] Ch. 6 as the
-second case study in tolerated failed agreement.
+goal", and "As long as probing is attempted, the derivation will
+still converge even if a probe fails to find a goal" —
+failure-tolerance, adopted by [preminger-2014] Ch. 6 as the second
+case study in tolerated failed agreement.
 
 Formalized through `Phi/Probing.lean`: L⁰ is the **indiscriminate**
 instance of `probeSearch` (`vis = ⊤`, so bare minimality delivers
@@ -27,7 +28,9 @@ exactly the needy, hence omnivorous and position-insensitive.
 Scope: simplex clauses only — the dissertation's second licensing
 route (V⁰ together with specifier-taking CAUS/APPL heads, licensing
 one additional augmentless nominal; her LP schemas in ch. 3) is not
-modeled.
+modeled. `Nominal` also under-populates L⁰'s search space: her L⁰
+targets any vP-internal XP (locatives, adverbs), so a conjoint fed
+by a non-nominal is not representable here.
 -/
 
 namespace Halpert2012
@@ -53,6 +56,11 @@ def needsL (n : Nominal) : Bool := !n.augmented
 def lGoal (vp : List Nominal) : Option Nominal :=
   probeSearch (fun _ => true) vp
 
+/-- Bare minimality, as a theorem: the indiscriminate search takes
+    the head of the sequence. -/
+theorem lGoal_eq_head? (vp : List Nominal) : lGoal vp = vp.head? := by
+  cases vp <;> rfl
+
 /-- The licensing condition on a simplex vP: every augmentless
     nominal is licensed by L⁰'s single search. -/
 def LicensingOk (vp : List Nominal) : Prop :=
@@ -77,18 +85,17 @@ def lSpellout (vp : List Nominal) : String :=
 
 /-! ### The conjoint/disjoint distribution -/
 
-/-- Disjoint iff vP is empty: the conjoint requires overt postverbal
-    material — L⁰'s indiscriminate search is sensitive even to
-    non-arguments, which is the learner's evidence that L⁰ is
-    unrelativized ([preminger-2014] Ch. 7's locative-modifier
-    point). -/
+/-- Disjoint iff vP is empty (after A-movement): the conjoint
+    requires overt vP-internal material — L⁰'s indiscriminate search
+    is sensitive even to non-arguments, which is the learner's
+    evidence that L⁰ is unrelativized ([preminger-2014] Ch. 6
+    §6.1.3's locative-modifier point). -/
 theorem disjoint_iff_empty (vp : List Nominal) :
     lSpellout vp = "ya-" ↔ vp = [] := by
   cases vp with
-  | nil => exact ⟨fun _ => rfl, fun _ => rfl⟩
+  | nil => exact iff_of_true rfl rfl
   | cons a t =>
-    have hne : ("∅-" : String) ≠ "ya-" := by decide
-    exact ⟨fun h => absurd h hne, fun h => nomatch h⟩
+    exact iff_of_false (show ("∅-" : String) ≠ "ya-" by decide) (nomatch ·)
 
 /-! ### Licensing: highest-only and at-most-one -/
 
@@ -107,10 +114,11 @@ theorem at_most_one_augmentless {vp : List Nominal} (h : LicensingOk vp) :
     ∀ n ∈ vp, ∀ m ∈ vp, needsL n = true → needsL m = true → n = m :=
   fun n hn m hm hn' hm' => (h n hn hn').unique (h m hm hm')
 
-/-! ### The negative-existential VS(O) paradigm -/
+/-! ### The negated-expletive VS(O) paradigm -/
 
-/-- The augmentless distribution in negative existentials (her ch. 3
-    paradigm; reproduced as [preminger-2014] (128)): an augmentless
+/-- The augmentless distribution in negated transitive-expletive
+    clauses — augmentless nominals are NPIs in these contexts (her
+    ch. 3 paradigm, (127); reproduced as [preminger-2014] (128)): an augmentless
     nominal is fine alone or above an augmented object; blocked in
     pairs (single Agree relation) and below an augmented subject
     (intervention). Tokens: *muntu* '1person', *qanda* '5egg'. -/
@@ -127,9 +135,10 @@ theorem augmentless_distribution :
 
 /-! ### Tolerated failed agreement -/
 
-/-- Failure-tolerance, in her own terms ("the derivation converges
-    even if a probe fails to find a goal"; "when L fails to find a
-    goal, the derivation records this failure in the morphological
+/-- Failure-tolerance, in her own terms ("As long as probing is
+    attempted, the derivation will still converge even if a probe
+    fails to find a goal"; "When L fails to find a goal, the
+    derivation records this failure in the morphological
     spell-out"): an empty vP leaves L⁰ unvalued, the derivation
     converges under the obligatory-operations model, and PF realizes
     the failure as the overt disjoint *ya-*. With any goal — even a

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -4,6 +4,7 @@ import Linglib.Syntax.Minimalist.ObligatoryOperations
 import Linglib.Morphology.DM.VocabSimple
 import Linglib.Fragments.Mayan.Kaqchikel.Agreement
 import Linglib.Studies.Halpert2012
+import Linglib.Studies.BejarRezac2003
 
 /-!
 # Preminger 2014 — Agreement and Its Failures [preminger-2014]
@@ -11,8 +12,9 @@ import Linglib.Studies.Halpert2012
 [nevins-2011] [stiebels-2006] [halpert-2012]
 
 [preminger-2014], *Agreement and Its Failures* (MIT Press, LI
-Monographs 68), applies [bejar-rezac-2003]'s relativized probing
-(with the Person Licensing Condition) to the Kichean Agent Focus
+Monographs 68), applies [bejar-rezac-2003]'s split-probe system and
+Person Licensing Condition — with relativized probing, Preminger's
+own addition (§4.2) — to the Kichean Agent Focus
 construction (Ch. 4) and uses the resulting failure cases to argue
 for an "obligatory operations" model of φ-Agree (Ch. 5). The
 fragment in `Fragments/Mayan/Kaqchikel/Agreement.lean` carries the
@@ -28,12 +30,16 @@ Per Preminger's own framing:
 - The **feature geometry** [φ] → [PERSON] → [participant] → [author]
   traces to [harley-ritter-2002]; [preminger-2014] adopts a
   simplified version.
-- The **relativized-probing mechanism** and the **Person Licensing
-  Condition (PLC)** are [bejar-rezac-2003]'s (§4.1, §4.4) — and so
-  is the derivational ordering of person before number probing,
-  which Preminger inherits (π⁰ is merged below #⁰ and probes
-  first; what surfaces is decided by a single morphological slot in
-  which a clitic beats out the exponence of π⁰/#⁰).
+- The **split π/# probes** (person probing first) and the **Person
+  Licensing Condition (PLC)** are [bejar-rezac-2003]'s (§4.1, §4.4).
+  **Relativized probing** is Preminger's own addition (§4.2,
+  recalling [rizzi-1990]) — B&R's π-probe is explicitly NOT
+  relativized (see `Studies/BejarRezac2003.lean` and
+  `ch4_relativization_contrast`). The separate-heads implementation
+  (π⁰ merged below #⁰, probing first; B&R put both probes on one
+  head) is also Preminger's; what surfaces is decided by a single
+  morphological slot in which a clitic beats out the exponence of
+  π⁰/#⁰.
 - **Omnivorous agreement** as the name for the surface pattern is
   [nevins-2011]'s term, which Preminger adopts.
 - **DM Vocabulary insertion** for `setAVocab`/`setBVocab` follows
@@ -87,7 +93,8 @@ gives five arguments against hierarchy accounts:
    two-probe + PLC account derives both the agreement pattern and
    the restriction; the hierarchy derives only the former
    (`ch7_arg3_participant_vs_plural_asymmetry`).
-4. **Morphophonology of the markers** ("perhaps strongest", §3.4):
+4. **Morphophonology of the markers** ("perhaps strongest" per
+   §7.1; the morphophonology is detailed in §3.4):
    1st/2nd ABS markers stand in the relation `<agreement marker> =
    <strong pronoun> − <initial approximant>` (149) — a
    clitic-doubling signature that 3rd-person markers lack
@@ -224,6 +231,20 @@ theorem personRestrictionOk_iff_plc (s o : Agreement.Cell) :
   · rintro h ⟨hs, ho⟩
     exact nomatch congrArg Prod.fst
       (h (.A, s) (.head _) (.P, o) (.tail _ (.head _)) hs ho)
+
+/-- [preminger-2014] Ch. 4's move (§4.2), made formal:
+    [bejar-rezac-2003]'s ⊤-visible π-probe is absorbed by an
+    F-licensed 3rd-person dative, stranding a participant below it —
+    the PCC. The Kichean π⁰, relativized to [participant], skips the
+    same 3rd-person goal and licenses the lower participant.
+    Relativization to exactly the licensing-needy class is what
+    converts absorption into omnivorous licensing. -/
+theorem ch4_relativization_contrast :
+    ¬ BejarRezac2003.PLCOk [[⟨.third, true⟩, ⟨.first, false⟩]]
+        [⟨.third, true⟩, ⟨.first, false⟩] ∧
+    PLC Prod.snd ([(.A, .pn .third .Sing), (.P, .pn .first .Sing)] :
+        List (ArgPosition × Agreement.Cell)) := by
+  decide
 
 /-- The two AF probes in slot order: π⁰'s clitic output beats #⁰'s
     direct exponence in the single morphological slot
@@ -424,11 +445,12 @@ theorem ch7_arg4_form_distinctness :
     Zulu's L⁰ is the off-diagonal instance (`AllLicensed needs ⊤`:
     indiscriminate probe, augmentless = needy), so an augmented
     subject intervenes and a lower augmentless nominal goes
-    unlicensed. Same machinery, opposite skippability — and no
-    salience reading of augmented/augmentless is available, which
-    undermines the cognitive-salience grounding of hierarchy
-    accounts. Both systems realize failed probing as default
-    morphology (Kichean covert ∅, Zulu overt *ya-*). -/
+    unlicensed. Same machinery, opposite skippability — and there is
+    little plausible salience grounding for augmented/augmentless,
+    a contrast sensitive to purely structural relations such as
+    c-command, undermining the cognitive-salience grounding of
+    hierarchy accounts. Both systems realize failed probing as
+    default morphology (Kichean covert ∅, Zulu overt *ya-*). -/
 theorem ch7_arg5_zulu_parallel :
     -- Kichean: π⁰ skips a 3SG subject and licenses a 1SG object
     PLC Prod.snd ([(.A, .pn .third .Sing), (.P, .pn .first .Sing)] :

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -573,14 +573,15 @@ structure Encounter where
 def halts (cond : SatisfactionCond) (e : Encounter) : Bool :=
   cond.isSatisfied e.feats e.cat
 
-/-- The argument position a probe φ-agrees with: run `probeSearch`
-    relativized to the satisfaction condition; the probe agrees with
-    the found element only if satisfaction copied features (feature
-    match, not head encounter). -/
+/-- The argument position a probe φ-agrees with: `probeAgree`
+    relativized to the satisfaction condition, with feature-copying
+    as the activity condition — the probe agrees with the found
+    element only if satisfaction copied features (feature match, not
+    head encounter). -/
 def agreesWith (cond : SatisfactionCond) (goals : List Encounter) :
     Option ArgPosition :=
-  (probeSearch (halts cond) goals).bind
-    (fun e => if cond.copiedFeatures e.feats e.cat then e.pos else none)
+  (probeAgree (halts cond)
+    (fun e => cond.copiedFeatures e.feats e.cat) goals).bind (·.pos)
 
 /-- Transitive Voice as an encounter: a head of category `.v`, no
     φ-features visible to the probe. -/
@@ -627,7 +628,8 @@ theorem infl_finds_S (φS : FeatureBundle)
     agreesWith mamInflSatisfaction [dpGoal .S φS] = some .S := by
   have h1 : halts mamInflSatisfaction ⟨some .S, φS, none⟩ = true := by
     simp [halts, mamInflSatisfaction_isSatisfied, hS]
-  simp [agreesWith, probeSearch, dpGoal, h1, mamInflSatisfaction_copiedFeatures, hS]
+  simp [agreesWith, probeAgree, probeSearch, Option.filter_some, dpGoal, h1,
+    mamInflSatisfaction_copiedFeatures, hS]
 
 /-- Voice's search finds the agent (closest goal), provided A bears
     person. -/
@@ -637,8 +639,8 @@ theorem voice_finds_A (φA φP : FeatureBundle)
   have h1 : halts (.featureMatch (.phi (.person .third)))
       ⟨some .A, φA, none⟩ = true := by
     simp [halts, SatisfactionCond.isSatisfied, hA]
-  simp [agreesWith, probeSearch, dpGoal, voiceSat, h1,
-    SatisfactionCond.copiedFeatures, hA]
+  simp [agreesWith, probeAgree, probeSearch, Option.filter_some, dpGoal,
+    voiceSat, h1, SatisfactionCond.copiedFeatures, hA]
 
 /-- DERIVED probe table: which head φ-agrees with position `p`,
     computed by running each probe's `probeSearch` over the goal

--- a/Linglib/Syntax/Minimalist/CyclicAgree.lean
+++ b/Linglib/Syntax/Minimalist/CyclicAgree.lean
@@ -335,7 +335,12 @@ per segment, over the cyclically ordered token list: B&R's segments
 match independently, so cyclic expansion at the whole-probe level is
 first-visible-goal search at the per-segment level. The residue-based
 definitions above remain definitional — they are the paper's
-mechanism; the factorization is a *result* about it. -/
+mechanism; the factorization is a *result* about it.
+
+Cf. `Studies/BejarRezac2003.lean` for the 2003 precursor's
+second-cycle repair: formally distinct mechanisms — 2003 varies the
+goal *order* under one probe; cyclic expansion here varies the
+*relativization* (per segment) over one order. -/
 
 /-- The two arguments as φ-bearing goal tokens, in cyclic search order:
     the IA precedes the EA (cycle I before cycle II). -/

--- a/Linglib/Syntax/Minimalist/Phi/Geometry.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Geometry.lean
@@ -12,26 +12,32 @@ implies the next:
     [φ] → [NUMBER] → [plural]
 
 This decomposition drives **relativized probing**
-([bejar-rezac-2003]): a probe seeking [participant] skips DPs
-that lack it (3rd person), targeting only 1st/2nd person DPs. A
-separate probe seeking [plural] skips DPs that lack it (singulars),
-targeting only plurals.
+([preminger-2014] §4.2, recalling [rizzi-1990]'s Relativized
+Minimality): a probe seeking [participant] skips DPs that lack it
+(3rd person), targeting only 1st/2nd person DPs. A separate probe
+seeking [plural] skips DPs that lack it (singulars), targeting
+only plurals.
 
-[bejar-rezac-2003] apply this two-probe mechanism to derive
-the Person Case Constraint; [bejar-rezac-2009] formalize it as
-Cyclic Agree. [preminger-2014] §4.4 applies the same B&R 2003
-mechanism to Kichean Agent Focus — explicitly reframing earlier
-"omnivorous hierarchy" accounts in terms of two independently
-relativized probes π⁰ ([participant]) and #⁰ ([plural]). [preminger-2014] Ch. 7 then argues against
+[bejar-rezac-2003] introduce the split π/# probes (person probing
+first) and the Person Licensing Condition, deriving the Person
+Case Constraint with an *unrelativized* π-probe — the dative
+matches it and absorbs it (see `Studies/BejarRezac2003.lean`);
+[bejar-rezac-2009] develop the system into Cyclic Agree.
+[preminger-2014] §4.4 ports the split-probe + PLC system to
+Kichean Agent Focus, *adding* the relativization of π⁰ to
+[participant] and #⁰ to [plural] — reframing earlier "omnivorous
+hierarchy" accounts. [preminger-2014] Ch. 7 then argues against
 direct hierarchy/scale primitives like
-`[+participant] > [+plural] > default`, on four grounds:
+`[+participant] > [+plural] > default`, on five grounds:
 restrictedness of "salience" effects to AF, K'ichee' formal
 addressee *la* (a 2nd-person form patterning as 3rd-person under
 AF), the AF person restriction (1+2 blocked but 3pl+3pl licit),
-and the morphophonological 1st/2nd vs 3rd asymmetry (clitic
+the morphophonological 1st/2nd vs 3rd asymmetry (clitic
 doubling vs direct exponence, [preminger-2014] §3.4 and
-§4.4). The relativized-probing mechanism derives the same surface
-patterns without committing to a salience scale.
+§4.4), and the Zulu parallel ([halpert-2012]: the same machinery
+over augmented/augmentless). The relativized-probing mechanism
+derives the same surface patterns without committing to a salience
+scale.
 
 ## Extended Geometry: [±proximate]
 

--- a/Linglib/Syntax/Minimalist/Phi/Probing.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Probing.lean
@@ -16,11 +16,15 @@ licenses at most one goal (`allLicensed_iff`).
 
 The search is stated for any goal type `α` with a `Bool` visibility
 predicate; the φ-instantiation (`Agreement.Cell.visibleTo`, `PLC`)
-specializes it to [bejar-rezac-2003]'s person probe. The
-*unrelativized* instance (`vis = ⊤`, bare minimality: the goal is
-`List.head?`) is [halpert-2012]'s Zulu L⁰ — see
-`Studies/Halpert2012.lean` and the cross-linguistic point of
-[preminger-2014] Ch. 7. [bejar-rezac-2009]'s articulated probe is a *family* of
+specializes it to the participant-relativized person probe of
+[preminger-2014]'s Kichean analysis. Relativization is Preminger's
+addition (§4.2, recalling [rizzi-1990]): [bejar-rezac-2003]'s own
+π-probe is *unrelativized* — the closest goal matches and can
+absorb it without valuing (`probeAgree`; `Studies/BejarRezac2003.lean`)
+— and the unrelativized, bare-minimality instance (`vis = ⊤`, goal
+= `List.head?`) is also [halpert-2012]'s Zulu L⁰
+(`Studies/Halpert2012.lean`, the cross-linguistic point of
+[preminger-2014] Ch. 7). [bejar-rezac-2009]'s articulated probe is a *family* of
 these searches, one per probe segment over the cyclically ordered
 token list — see `CyclicAgree.eaIsLicensed_iff_segment_licensed`.
 For probe *horizons* (what terminates search across domains, Keine)
@@ -30,9 +34,13 @@ re-probing see `Syntax/Minimalist/Probing/DefectiveCircumvention.lean`.
 ## Main declarations
 
 - `probeSearch` — first goal visible to the probe, in structural order.
+- `probeAgree` — search then Agree: the found goal, if it passes the
+  activity condition (match without valuation absorbs the probe).
 - `searchOutcome` — the `ProbeOutcome` of an obligatory probing operation.
-- `Licensed`, `AllLicensed` — licensing as being found by the search.
-- `allLicensed_iff` — all visible goals licensed ↔ visible goals subsingleton.
+- `Licensed`, `AllLicensed needs vis` — every licensing-needy goal is
+  found by the search; diagonal characterization `allLicensed_iff`
+  (visible goals subsingleton), off-diagonal
+  `allLicensed_const_true_iff` (every needy goal is the closest).
 - `cascadeSearch` — ordered probe sequence: first probe with output wins
   (the single-slot morphological competition).
 - `PLC` — the Person Licensing Condition over φ-bearing goal tokens.
@@ -40,17 +48,27 @@ re-probing see `Syntax/Minimalist/Probing/DefectiveCircumvention.lean`.
 
 namespace Minimalist
 
+variable {α : Type*}
+
 /-! ### Relativized search -/
 
 section Search
 
-variable {α : Type*}
-
-/-- The goal a relativized probe finds in an ordered goal sequence:
-    the first goal visible to it, skipping invisible ones
-    ([bejar-rezac-2003] relativized probing). -/
+/-- The goal a probe finds in an ordered goal sequence: the first
+    goal visible to it, skipping invisible ones (relativized probing,
+    [preminger-2014] §4.2; an unrelativized probe — `vis = ⊤` — takes
+    the closest goal outright). -/
 def probeSearch (vis : α → Bool) (goals : List α) : Option α :=
   goals.find? vis
+
+/-- Search then Agree: the goal the search finds, if it passes the
+    activity condition `act` — the match vs. Agree distinction. The
+    closest visible goal can absorb the probe without valuing it
+    ([bejar-rezac-2003]'s inactive dative, `Studies/BejarRezac2003.lean`;
+    [deal-2024]-style interaction vs. satisfaction,
+    `Studies/Scott2023.lean`). -/
+def probeAgree (vis act : α → Bool) (goals : List α) : Option α :=
+  (probeSearch vis goals).filter act
 
 variable {vis : α → Bool} {goals : List α}
 
@@ -70,13 +88,33 @@ theorem visible_of_probeSearch_eq_some {a : α}
     (h : probeSearch vis goals = some a) : vis a = true :=
   List.find?_some h
 
+/-- The probe Agrees with `a` iff the search finds `a` and `a` is
+    active. -/
+theorem probeAgree_eq_some_iff {act : α → Bool} {a : α} :
+    probeAgree vis act goals = some a ↔
+      probeSearch vis goals = some a ∧ act a = true := by
+  cases h : probeSearch vis goals with
+  | none => simp [probeAgree, h]
+  | some b =>
+    simp only [probeAgree, h, Option.filter_some, Option.ite_none_right_eq_some,
+      Option.some.injEq]
+    constructor
+    · rintro ⟨hb, rfl⟩
+      exact ⟨rfl, hb⟩
+    · rintro ⟨hb, ha⟩
+      exact ⟨hb ▸ ha, hb.symm ▸ rfl⟩
+
+/-- An inactive closest goal absorbs the probe: match without Agree. -/
+theorem probeAgree_eq_none_of_inactive {act : α → Bool} {a : α}
+    (h : probeSearch vis goals = some a) (ha : act a = false) :
+    probeAgree vis act goals = none := by
+  simp [probeAgree, h, Option.filter_some, ha]
+
 end Search
 
 /-! ### Probe outcomes ([preminger-2014] Ch. 5) -/
 
 section Outcome
-
-variable {α : Type*}
 
 /-- The outcome of an obligatory probing operation over a goal
     sequence: `valued` iff the search finds a goal. -/
@@ -118,8 +156,6 @@ end Outcome
 
 section Licensing
 
-variable {α : Type*}
-
 /-- A goal is licensed by a probe iff the probe's single search
     reaches it ([bejar-rezac-2003]: licensing is an Agree relation
     with the probe). -/
@@ -143,7 +179,9 @@ theorem Licensed.unique {a b : α}
 theorem licensed_const_true_iff {a : α} :
     Licensed (fun _ => true) goals a ↔ goals.head? = some a := by
   unfold Licensed probeSearch
-  cases goals <;> simp
+  cases goals <;>
+    simp only [List.find?_nil, List.find?_cons_of_pos, List.head?_nil,
+      List.head?_cons]
 
 /-- Every goal that needs licensing is licensed by the probe's
     search. Which goals *need* licensing (`needs`) and which the
@@ -161,9 +199,10 @@ instance [DecidableEq α] (needs vis : α → Bool) (goals : List α) :
 
 /-- On the diagonal (probe relativized to exactly the needy), all
     needy goals are licensed iff the visible goals are subsingleton:
-    one search, one Agree relation, at most one licensee. The general
-    fact behind person-restriction effects ([bejar-rezac-2003]'s PCC,
-    [preminger-2014]'s AF restriction). -/
+    one search, one Agree relation, at most one licensee — the fact
+    behind [preminger-2014]'s AF person restriction. (The off-diagonal
+    variant of the same one-licensee engine drives
+    [bejar-rezac-2003]'s PCC — `Studies/BejarRezac2003.lean`.) -/
 theorem allLicensed_iff :
     AllLicensed vis vis goals ↔
       ∀ a ∈ goals, ∀ b ∈ goals, vis a = true → vis b = true → a = b := by
@@ -200,8 +239,6 @@ end Licensing
 /-! ### Probe cascades -/
 
 section Cascade
-
-variable {α : Type*}
 
 /-- The goal an ordered sequence of probes delivers: the first probe's
     finding, else the next's, and so on — `probeSearch` at the goal
@@ -253,12 +290,18 @@ def _root_.Agreement.Cell.visibleTo (c : Agreement.Cell) (t : ProbeTarget) : Boo
     [preminger-2014] (40)/(75)): every [participant]-bearing goal
     token must be licensed by the person probe's search. Goal tokens
     have type `α` with a φ-cell projection, so two arguments with
-    identical φ remain distinct licensees. -/
-def PLC {α : Type*} (cellOf : α → Agreement.Cell) (goals : List α) : Prop :=
+    identical φ remain distinct licensees.
+
+    This is [preminger-2014]'s single-cycle, search-only, diagonal
+    rendering of the condition: it omits [bejar-rezac-2003]'s
+    F-licensing route (a nominal's own φ-bearing P/dative/focus head
+    counts as a licensing Agree relation) and multi-cycle repairs —
+    for the paper's own condition see `BejarRezac2003.PLCOk`. -/
+def PLC (cellOf : α → Agreement.Cell) (goals : List α) : Prop :=
   AllLicensed (λ a => (cellOf a).visibleTo .participant)
     (λ a => (cellOf a).visibleTo .participant) goals
 
-instance {α : Type*} [DecidableEq α] (cellOf : α → Agreement.Cell) (goals : List α) :
+instance [DecidableEq α] (cellOf : α → Agreement.Cell) (goals : List α) :
     Decidable (PLC cellOf goals) :=
   inferInstanceAs (Decidable (AllLicensed _ _ goals))
 


### PR DESCRIPTION
Four-agent audit of the probing arc, applied: source-verified corrections plus the search-then-Agree graduation.

- Attribution fixed in three files: relativized probing is Preminger's (§4.2, recalling Rizzi 1990) — B&R 2003's π-probe is explicitly unrelativized; their contribution is split π/# probing + the PLC. Halpert quote corrected to her exact sentence; locative point is Ch. 6 not Ch. 7; (127) relabeled negated-expletive/NPI; Geometry's "four grounds" → five.
- `probeAgree` (search + activity filter) graduates to substrate; `BejarRezac2003.piAgree` and `Scott2023.agreesWith` now consume it. New `plcOk_singleCycle_iff_allLicensed` collapse lemma and `Preminger2014.ch4_relativization_contrast` (absorbs vs. skips) discharge the typology claims formally.
- PLC/PLCOk relationship documented both ways; 2003-second-cycle vs 2009-cyclic-expansion disanalogy stated in both files; dead `lGoal` earned via `lGoal_eq_head?`; proof golf per review.