### PR TITLE
feat(Core/Algebra): close the NIM keystone and B⁻ cocycle chain

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1949,6 +1949,8 @@ import Linglib.Core.Algebra.RootedTree.PreLie.Insert
 import Linglib.Core.Algebra.RootedTree.PreLie.InsertSum
 import Linglib.Core.Algebra.RootedTree.PreLie.Insertion
 import Linglib.Core.Algebra.RootedTree.PreLie.Path
+import Linglib.Core.Algebra.RootedTree.PreLie.InsertionNodeDecomp
+import Linglib.Core.Algebra.RootedTree.BMinus
 import Linglib.Core.LinearAlgebra.SymmetricAlgebra.Derivation
 import Linglib.Core.LinearAlgebra.SymmetricPower.Lift
 import Linglib.Core.LinearAlgebra.SymmetricPower.ToSymmetricAlgebra

--- a/Linglib/Core/Algebra/PreLie/OudomGuinCirc.lean
+++ b/Linglib/Core/Algebra/PreLie/OudomGuinCirc.lean
@@ -169,9 +169,9 @@ scoped infix:75 " ○ " => fun A B => oudomGuinCirc A B
 /-! ## §2: Defining equations (Prop 2.7)
 
 Oudom-Guin's Proposition 2.7 states that the three equations below
-uniquely characterize `○`. We state each as a theorem. With the
-construction sorry-fenced, these are also sorry-fenced (they witness
-that the construction satisfies the defining equations). -/
+uniquely characterize `○`. We state each as a theorem witnessing that
+the construction satisfies the defining equations. (The uniqueness
+clause of Prop 2.7 is not yet formalized.) -/
 
 /-- **Prop 2.7 (i)**: right unit. `A ○ 1 = A` for all `A ∈ S(L)`.
 
@@ -1346,13 +1346,13 @@ private theorem algebraMapInv_circ_mul'_comul_aux
   rw [TensorProduct.map_smul_left, LinearMap.smul_apply, map_smul,
       mul'_map_algebraMapInv_comul, smul_eq_mul]
 
-/-- **Prop 3.9 (iv)** of Oudom-Guin (2008) — generalization of `circ_T_mul`
+/-- **Prop 2.8 (iv)** of Oudom-Guin (2008) — generalization of `circ_T_mul`
     (Prop 2.7.ii) from `A = ι T` to arbitrary `A ∈ S(L)`:
 
     `A ○ (B · ι X) = (A ○ B) ○ ι X - A ○ (B ○ ι X)` for all `A, B ∈ S(L)`, `X ∈ L`.
 
     This is the key ingredient for closing Q2 (`circ_assoc_via_comul`,
-    Prop 3.9.v) by induction on `C`.
+    Prop 2.8.v) by induction on `C`.
 
     Proof by `SymmetricAlgebra.induction` on `A`:
 
@@ -1579,7 +1579,7 @@ private theorem compat_mul_circ_mul_ι
                LinearMap.add_apply, ihy₁, ihy₂]
     ring
 
-/-- **Per-tprod form** of Prop 3.9 (v). Proves
+/-- **Per-tprod form** of Prop 2.8 (v). Proves
     `(A ○ B) ○ algHomL (tprod_m a) = A ○ ((mul' ∘ TP.map (○B) id)(comul (algHomL (tprod_m a))))`
     by induction on `m`.
 
@@ -1646,7 +1646,7 @@ private theorem circ_assoc_via_comul_tprod
       show (SymmetricAlgebra.algHom R L) _ = _
       rw [map_mul]; rfl
     rw [h_algHomL_split]
-    -- Apply Prop 3.9.iv at `(A ○ B, D, X)` to LHS.
+    -- Apply Prop 2.8.iv at `(A ○ B, D, X)` to LHS.
     rw [circ_general_mul_ι (oudomGuinCirc (R := R) A B)
           (OudomGuinCircConstruct.algHomL
             (TensorAlgebra.tprod R L m (Fin.init a)))
@@ -1657,7 +1657,7 @@ private theorem circ_assoc_via_comul_tprod
     -- where `D = algHomL (tprod_m (Fin.init a))`, `X = a (Fin.last m)`,
     --       `Y_D = (mul' ∘ TP.map (○B) id)(comul D)`.
     --
-    -- Apply Prop 3.9.iv rearranged at `(A, Y_D, X)` to convert
+    -- Apply Prop 2.8.iv rearranged at `(A, Y_D, X)` to convert
     -- `(A ○ Y_D) ○ ι X = A ○ (Y_D * ι X) + A ○ (Y_D ○ ι X)`.
     have h_AYD_ιX :
         oudomGuinCirc (R := R)
@@ -1723,7 +1723,7 @@ private theorem circ_assoc_via_comul_tprod
     simp only [map_add, map_sub] at h_compat_A
     exact h_compat_A.symm
 
-/-- **Prop 3.9 (v)** of Oudom-Guin (2008). The inductive key for Lemma
+/-- **Prop 2.8 (v)** of Oudom-Guin (2008). The inductive key for Lemma
     2.10's proof of `★` associativity.
 
     `(A ○ B) ○ C = A ○ ((B ○ C₍₁₎) · C₍₂₎)`, Sweedler-summed over the

--- a/Linglib/Core/Algebra/RootedTree/BMinus.lean
+++ b/Linglib/Core/Algebra/RootedTree/BMinus.lean
@@ -5,6 +5,8 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
+import Linglib.Core.Algebra.RootedTree.PreLie.InsertionNodeDecomp
+import Linglib.Core.Algebra.ConnesKreimer.Shuffle
 import Mathlib.Tactic.Ring
 
 set_option autoImplicit false
@@ -368,21 +370,63 @@ The hard case reduces to the substrate lemma:
 product). This is `singleton_node_a_insertion_eq_bPlus_gl_mul` below.
 -/
 
+/-- `Multiset.bind` as a mapped sum (`join` is definitionally `sum`). -/
+private theorem bind_eq_map_sum {γ δ : Type*} (s : Multiset γ)
+    (f : γ → Multiset δ) : s.bind f = (s.map f).sum := rfl
+
+/-- The `true`-bucket of a zip over `Quotient.out` representatives has
+    the nonplanar `true`-bucket as its `mk`-image. -/
+private theorem filterMap_zip_out_mk_t (l : List (Nonplanar α)) (assn : List Bool) :
+    (((l.map Quotient.out).zip assn).filterMap
+        (fun p => if p.2 then some p.1 else none)).map Nonplanar.mk =
+      (l.zip assn).filterMap (fun p => if p.2 then some p.1 else none) := by
+  induction l generalizing assn with
+  | nil => rfl
+  | cons x l ih =>
+    cases assn with
+    | nil => rfl
+    | cons b assn =>
+      cases b with
+      | true =>
+        show Nonplanar.mk (Quotient.out x) ::
+            ((((l.map Quotient.out).zip assn).filterMap _).map Nonplanar.mk) = _
+        have hx : Nonplanar.mk (Quotient.out x) = x := Quotient.out_eq x
+        rw [hx, ih]
+        rfl
+      | false => exact ih assn
+
+/-- The `false`-bucket analog of `filterMap_zip_out_mk_t`. -/
+private theorem filterMap_zip_out_mk_f (l : List (Nonplanar α)) (assn : List Bool) :
+    (((l.map Quotient.out).zip assn).filterMap
+        (fun p => if p.2 then none else some p.1)).map Nonplanar.mk =
+      (l.zip assn).filterMap (fun p => if p.2 then none else some p.1) := by
+  induction l generalizing assn with
+  | nil => rfl
+  | cons x l ih =>
+    cases assn with
+    | nil => rfl
+    | cons b assn =>
+      cases b with
+      | true => exact ih assn
+      | false =>
+        show Nonplanar.mk (Quotient.out x) ::
+            ((((l.map Quotient.out).zip assn).filterMap _).map Nonplanar.mk) = _
+        have hx : Nonplanar.mk (Quotient.out x) = x := Quotient.out_eq x
+        rw [hx, ih]
+        rfl
+
 /-- **NIM-level keystone**: at the Nonplanar multi-insertion level, grafting
     `B` into the singleton host `{node a A'}` decomposes by partitioning
     B's grafting positions into "at the root vertex" (becomes new
     children) vs "in A's subtrees" (recursive NIM).
 
-    `(letI : DecidableEq (Nonplanar α) := Classical.decEq _`
-    ` Nonplanar.insertionMultiset {Nonplanar.node a A'} B) =`
-    `(B.powerset.bind (fun B₁ =>`
-    `  (Nonplanar.insertionMultiset A' B₁).map`
-    `    (fun F' => ({Nonplanar.node a (F' + (B - B₁))} : Forest _))))`
-
-    Sorry-fenced — the planar-level partition (via
-    `vertices_multiGraft_decomp` + assignment-bucketing) underlies
-    this. Singleton-host-with-fixed-root-label case of A3.3-style
-    reasoning. -/
+    Descent through the quotient: the singleton host's canonical planar
+    representative is `PlanarEquiv`-swapped for a visible planar node,
+    `Planar.Pathed.insertion_node_split` provides the root-vs-subtree
+    mask decomposition, and the mask enumeration is converted to the
+    powerset bind via `listChoices_bridge_powerset_paired` plus the
+    powerset partition involution (the mask convention has `true` =
+    root guests, while the powerset bind runs over the subtree bucket). -/
 private theorem nim_singleton_node_a_decomp
     (a : α) (A' B : Forest (Nonplanar α)) :
     Nonplanar.insertionMultiset
@@ -391,7 +435,158 @@ private theorem nim_singleton_node_a_decomp
        B.powerset.bind fun B₁ =>
          (Nonplanar.insertionMultiset A' B₁).map fun F' =>
            ({Nonplanar.node a (F' + (B - B₁))} : Forest (Nonplanar α))) := by
-  sorry
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  -- §1: the canonical planar representative of the host is equivalent to
+  -- the visible node on A''s canonical children list.
+  have h_mk2 : Nonplanar.mk (Planar.node a (A'.toList.map Quotient.out)) =
+      Nonplanar.node a A' := by
+    rw [← Nonplanar.node_mk_planar_list]
+    congr 1
+    rw [List.map_map,
+        show A'.toList.map (Nonplanar.mk ∘ Quotient.out) = A'.toList from
+          (List.map_congr_left fun x _ => Quotient.out_eq x).trans
+            (List.map_id _)]
+    exact A'.coe_toList
+  have h_equiv : Planar.PlanarEquiv
+      (Quotient.out (Nonplanar.node a A'))
+      (Planar.node a (A'.toList.map Quotient.out)) :=
+    Nonplanar.mk_eq_mk_iff.mp
+      (((Nonplanar.node a A').out_eq).trans h_mk2.symm)
+  -- §2: unfold NIM; the host list is the singleton of the canonical rep.
+  unfold Nonplanar.insertionMultiset
+  rw [show (({Nonplanar.node a A'} : Forest (Nonplanar α)).toList.map
+        Quotient.out : List (Planar α))
+      = [Quotient.out (Nonplanar.node a A')] from by
+    rw [Multiset.toList_singleton]
+    rfl]
+  -- §3: swap the host representative under the msform map.
+  have h_host := Planar.Pathed.insertionForest_planarEquiv_host
+    (B.toList.map Quotient.out) (List.Forall₂.cons h_equiv List.Forall₂.nil)
+  have h_host' :
+      (Planar.Pathed.insertionForest [Quotient.out (Nonplanar.node a A')]
+          (B.toList.map Quotient.out)).map
+        (fun L => (Multiset.ofList (L.map Nonplanar.mk) :
+          Multiset (Nonplanar α))) =
+      (Planar.Pathed.insertionForest
+          [Planar.node a (A'.toList.map Quotient.out)]
+          (B.toList.map Quotient.out)).map
+        (fun L => Multiset.ofList (L.map Nonplanar.mk)) := by
+    have h2 := congrArg
+      (Multiset.map (fun l : List (Nonplanar α) =>
+        (Multiset.ofList l : Multiset (Nonplanar α)))) h_host
+    rw [Multiset.map_map, Multiset.map_map] at h2
+    exact h2
+  rw [h_host']
+  -- §4: singleton-forest reduction + the node-split engine.
+  rw [Planar.Pathed.insertionForest_singleton, Multiset.map_map,
+      Planar.Pathed.insertion_node_split, Multiset.map_bind]
+  -- §5: convert the RHS powerset bind to the mask enumeration. The mask
+  -- convention has `true` = root guests, so the powerset bind (over the
+  -- subtree bucket B₁) is first flipped by the partition involution.
+  have h_rhs : (B.powerset.bind fun B₁ =>
+        (Nonplanar.insertionMultiset A' B₁).map fun F' =>
+          ({Nonplanar.node a (F' + (B - B₁))} : Forest (Nonplanar α))) =
+      (Multiset.ofList
+          (Planar.Pathed.listChoices [true, false] B.toList.length)).bind
+        (fun assn =>
+          (Nonplanar.insertionMultiset A'
+              (((B.toList.zip assn).filterMap
+                fun p => if p.2 then none else some p.1 : List (Nonplanar α)) :
+                Multiset (Nonplanar α))).map
+            fun F' => ({Nonplanar.node a (F' +
+              (((B.toList.zip assn).filterMap
+                fun p => if p.2 then some p.1 else none : List (Nonplanar α)) :
+                Multiset (Nonplanar α)))} : Forest (Nonplanar α))) := by
+    -- Step A: flip the partition so the bind variable is the root bucket.
+    rw [bind_eq_map_sum]
+    rw [Multiset.powerset_partition_swap B
+      (fun B₁ rest => (Nonplanar.insertionMultiset A' B₁).map fun F' =>
+        ({Nonplanar.node a (F' + rest)} : Forest (Nonplanar α)))]
+    -- Step B: pair form + the powerset↔mask bridge.
+    rw [show (B.powerset.map fun s =>
+          (Nonplanar.insertionMultiset A' (B - s)).map fun F' =>
+            ({Nonplanar.node a (F' + s)} : Forest (Nonplanar α))) =
+        ((B.powerset.map fun s => (s, B - s)).map
+          fun pr => (Nonplanar.insertionMultiset A' pr.2).map fun F' =>
+            ({Nonplanar.node a (F' + pr.1)} : Forest (Nonplanar α))) from by
+      rw [Multiset.map_map]
+      rfl]
+    rw [show (B.powerset.map fun s => (s, B - s)) =
+        (Multiset.ofList
+            (Planar.Pathed.listChoices [true, false] B.toList.length)).map
+          (fun assn =>
+            ((((B.toList.zip assn).filterMap
+                fun p => if p.2 then some p.1 else none : List (Nonplanar α)) :
+                Multiset (Nonplanar α)),
+             (((B.toList.zip assn).filterMap
+                fun p => if p.2 then none else some p.1 : List (Nonplanar α)) :
+                Multiset (Nonplanar α)))) from by
+      conv_lhs => rw [show B = (↑(B.toList) : Multiset (Nonplanar α)) from
+        B.coe_toList.symm]
+      rw [← Planar.Pathed.listChoices_bridge_powerset_paired (l := B.toList)]]
+    rw [Multiset.map_map, ← bind_eq_map_sum]
+    rfl
+  refine Eq.trans ?_ h_rhs.symm
+  -- §6: per-mask congruence. Align mask lengths, then reduce each mask.
+  rw [List.length_map]
+  refine Multiset.bind_congr fun assn h_assn => ?_
+  -- Named buckets: planar (out-rep) and nonplanar (canonical) per side.
+  set gs_t : List (Planar α) := ((B.toList.map Quotient.out).zip assn).filterMap
+    (fun p => if p.2 then some p.1 else none) with hgs_t
+  set gs_f : List (Planar α) := ((B.toList.map Quotient.out).zip assn).filterMap
+    (fun p => if p.2 then none else some p.1) with hgs_f
+  set s_t : Multiset (Nonplanar α) := Multiset.ofList
+    ((B.toList.zip assn).filterMap
+      (fun p => if p.2 then some p.1 else none)) with hs_t
+  set s_f : Multiset (Nonplanar α) := Multiset.ofList
+    ((B.toList.zip assn).filterMap
+      (fun p => if p.2 then none else some p.1)) with hs_f
+  -- mk-image facts for the two planar buckets.
+  have h_t_mk : Multiset.ofList (gs_t.map Nonplanar.mk) = s_t := by
+    rw [hgs_t, filterMap_zip_out_mk_t, hs_t]
+  have h_f_perm : (gs_f.map Nonplanar.mk).Perm
+      ((s_f.toList.map Quotient.out).map Nonplanar.mk) := by
+    apply Multiset.coe_eq_coe.mp
+    rw [hgs_f, filterMap_zip_out_mk_f, List.map_map,
+        show s_f.toList.map (Nonplanar.mk ∘ Quotient.out) = s_f.toList from
+          (List.map_congr_left fun x _ => Quotient.out_eq x).trans
+            (List.map_id _),
+        Multiset.coe_toList, hs_f]
+  have h_guests := Planar.Pathed.insertionForest_msform_invariance_guests
+    (A'.toList.map Quotient.out) h_f_perm
+  -- Assemble: fuse post-maps, factor through msform, swap guests, recombine.
+  rw [Multiset.map_map]
+  calc (Planar.Pathed.insertionForest (A'.toList.map Quotient.out) gs_f).map
+        ((((fun L => (Multiset.ofList (L.map Nonplanar.mk) :
+            Multiset (Nonplanar α))) ∘ fun T' => [T']))
+          ∘ (fun cs' => Planar.node a (gs_t ++ cs')))
+      = ((Planar.Pathed.insertionForest (A'.toList.map Quotient.out) gs_f).map
+          (fun L => (Multiset.ofList (L.map Nonplanar.mk) :
+            Multiset (Nonplanar α)))).map
+        (fun M => ({Nonplanar.node a (s_t + M)} : Forest (Nonplanar α))) := by
+        rw [Multiset.map_map]
+        refine Multiset.map_congr rfl fun cs' _ => ?_
+        show ({Nonplanar.mk (Planar.node a (gs_t ++ cs'))} :
+          Forest (Nonplanar α)) = _
+        congr 1
+        rw [← Nonplanar.node_mk_planar_list]
+        congr 1
+        rw [List.map_append, ← Multiset.coe_add, h_t_mk]
+    _ = ((Planar.Pathed.insertionForest (A'.toList.map Quotient.out)
+            (s_f.toList.map Quotient.out)).map
+          (fun L => (Multiset.ofList (L.map Nonplanar.mk) :
+            Multiset (Nonplanar α)))).map
+        (fun M => ({Nonplanar.node a (s_t + M)} : Forest (Nonplanar α))) := by
+        rw [h_guests]
+    _ = (Nonplanar.insertionMultiset A' s_f).map
+        (fun F' => ({Nonplanar.node a (F' + s_t)} : Forest (Nonplanar α))) := by
+        unfold Nonplanar.insertionMultiset
+        rw [Multiset.map_map, Multiset.map_map]
+        refine Multiset.map_congr rfl fun L _ => ?_
+        show ({Nonplanar.node a (s_t + Multiset.ofList (L.map Nonplanar.mk))} :
+          Forest (Nonplanar α)) = _
+        rw [add_comm]
+        rfl
 
 /-- **Key combinatorial substrate**: grafting `of' B` into the
     singleton-a-rooted host `{node a A'}` equals the a-rooting (via
@@ -754,6 +949,75 @@ private lemma sum_powerset_diff_zero_indicator
     rw [h_cond_eq]
     exact ih (fun B₁' => f (T ::ₘ B₁'))
 
+/-- **Helper for the non-singleton-a sub-case**: when `A` is not of the
+    form `{node a A'}` and `A ≠ 0`, every forest of the form
+    `F' + (B - B₁)` (for `F' ∈ NIM A B₁`, `B₁ ⊆ B`) is also not of the
+    form `{node a G}`, so `bMinusBasis a (F' + (B - B₁)) = 0`.
+
+    Cardinality of `F' + (B - B₁)` is `|A| + |B - B₁|` (since
+    `F'.card = A.card` via `insertionMultiset_card_eq`).
+    * If `|A| ≥ 2`: total ≥ 2, not a singleton.
+    * If `|A| + |B - B₁| ≥ 2`: not a singleton.
+    * If `|A| = 1, |B - B₁| = 0`: `F'` is a singleton, but its root label
+      equals `A`'s root label (which is ≠ a since `A` is not singleton-a-rooted),
+      so still not of form `{node a G}`. Uses
+      `Nonplanar.insertionMultiset_singleton_rootLabel`. -/
+private theorem bMinusBasis_nim_add_eq_zero (a : α)
+    (A B₁ B' F' : Forest (Nonplanar α))
+    (hA_ne : A ≠ 0)
+    (hA : ¬ ∃ G' : Forest (Nonplanar α), A = ({Nonplanar.node a G'} : Forest _))
+    (hF' : F' ∈ Nonplanar.insertionMultiset A B₁) :
+    bMinusBasis (R := R) a (F' + B') = 0 := by
+  letI : DecidableEq (Forest (Nonplanar α)) := Classical.decEq _
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  apply bMinusBasis_eq_zero_of_not_singleton_a
+  rintro ⟨G, hG⟩
+  -- (F' + B').card = |A| + |B'|; must equal 1.
+  have hcard_F' : F'.card = A.card :=
+    Nonplanar.insertionMultiset_card_eq A B₁ hF'
+  have h_total_card : (F' + B').card = 1 := by
+    rw [hG]; exact Multiset.card_singleton _
+  rw [Multiset.card_add, hcard_F'] at h_total_card
+  -- A.card ≥ 1 since A ≠ 0.
+  have hA_card_pos : 1 ≤ A.card := by
+    have : A.card ≠ 0 := fun h => hA_ne (Multiset.card_eq_zero.mp h)
+    omega
+  -- So A.card = 1 and B'.card = 0.
+  have hA_card : A.card = 1 := by omega
+  have hB'_card : B'.card = 0 := by omega
+  have hB' : B' = 0 := Multiset.card_eq_zero.mp hB'_card
+  subst hB'
+  -- F' + 0 = F', and F' has card 1, F' = {T'} with T' = node a G.
+  rw [add_zero] at hG
+  -- Now F' ∈ NIM A B₁ with A.card = 1; A = {T} for some T with T.rootLabel ≠ a.
+  -- Goal: derive contradiction from F' = {node a G} via root preservation.
+  have hF'_card : F'.card = 1 := by rw [hcard_F', hA_card]
+  -- A is a singleton (card 1): A = {T_A} for some T_A.
+  obtain ⟨T_A, hT_A⟩ : ∃ T_A : Nonplanar α, A = {T_A} := by
+    rcases Multiset.card_eq_one.mp hA_card with ⟨T_A, hT_A⟩
+    exact ⟨T_A, hT_A⟩
+  -- T_A.rootLabel ≠ a (otherwise A = {node a (rootChildren T_A)} via node_eta).
+  have hT_A_lab : T_A.rootLabel ≠ a := by
+    intro h_lab
+    apply hA
+    refine ⟨Nonplanar.rootChildren T_A, ?_⟩
+    rw [hT_A]
+    congr 1
+    rw [← h_lab, Nonplanar.node_eta]
+  -- Apply NIM singleton root preservation.
+  subst hT_A
+  obtain ⟨T', hF'_eq, hT'_lab⟩ :=
+    Nonplanar.insertionMultiset_singleton_rootLabel T_A B₁ hF'
+  -- F' = {T'} with T'.rootLabel = T_A.rootLabel ≠ a.
+  -- But hG says F' = {node a G}, so T' = node a G.
+  rw [hF'_eq] at hG
+  have hT'_eq_node : T' = Nonplanar.node a G := Multiset.singleton_inj.mp hG
+  -- Then T'.rootLabel = a, contradicting hT'_lab + hT_A_lab.
+  have hT'_lab_a : T'.rootLabel = a := by
+    rw [hT'_eq_node, Nonplanar.rootLabel_node]
+  rw [hT'_lab_a] at hT'_lab
+  exact hT_A_lab hT'_lab.symm
+
 /-- **Phase C basis case**: for basis `x = of' A, y = of' B`, the OG
     identity holds. Case-analyzes on `A`:
     * `A = 0`: counit = 1, both sides equal `bMinusLin a (of' B)`.
@@ -943,15 +1207,108 @@ private theorem bMinusLin_gl_mul_basis (a : α) (A B : Forest (Nonplanar α)) :
       exact GrossmanLarson.one_mul _
     · rw [counit_of'_eq, if_neg hA0, zero_smul]
       -- LHS = 0; A ≠ 0 and A is not singleton-a-rooted.
-      -- Approach: expand of' A *_GL of' B via mul_of'_sum_form; each
-      -- summand has form `op (unop X * unop Y)` with X = insertion-output
-      -- (whose support is forests of cardinality |A|), Y = of'(B - B₁).
-      -- Applied to bMinusLin a, summands are 0 because output forests
-      -- aren't singleton-a-rooted (cardinality = |A| + |B-B₁|).
-      -- Wiring is non-trivial (unop push through Multiset.sum, bMinusLin
-      -- push through Multiset.sum, then the per-summand analysis).
-      -- Deferred — depends on substrate moves; sorry-fenced.
-      sorry
+      -- Expand of' A *_GL of' B via productForest = powerset-sum.
+      change bMinusLin (R := R) a
+          (GrossmanLarson.product
+            (GrossmanLarson.of' (R := R) A)
+            (GrossmanLarson.of' B)) = 0
+      rw [show GrossmanLarson.product
+              (GrossmanLarson.of' (R := R) A) (GrossmanLarson.of' B) =
+            GrossmanLarson.productForest (GrossmanLarson.of' (R := R) A) B from
+          GrossmanLarson.of'_mul_of' _ _]
+      unfold GrossmanLarson.productForest
+      -- Push bMinusLin a through Multiset.sum.
+      have h_push_sum : ∀ s : Multiset (ConnesKreimer R (Nonplanar α)),
+          bMinusLin (R := R) a s.sum = (s.map (bMinusLin (R := R) a)).sum := by
+        intro s
+        induction s using Multiset.induction with
+        | empty => simp
+        | cons head rest ih => simp [ih]
+      -- Treat the GrossmanLarson-typed sum as a CK-typed sum (defeq).
+      have h_push : bMinusLin (R := R) a
+          (B.powerset.map fun B₁ =>
+            GrossmanLarson.op
+              (GrossmanLarson.unop
+                  (GrossmanLarson.insertion (R := R)
+                    (GrossmanLarson.of' A) (GrossmanLarson.of' B₁)) *
+                GrossmanLarson.unop (GrossmanLarson.of' (B - B₁)))).sum =
+          (B.powerset.map fun B₁ =>
+            bMinusLin (R := R) a
+              (GrossmanLarson.op
+                (GrossmanLarson.unop
+                    (GrossmanLarson.insertion (R := R)
+                      (GrossmanLarson.of' A) (GrossmanLarson.of' B₁)) *
+                  GrossmanLarson.unop
+                    (GrossmanLarson.of' (B - B₁))) :
+                ConnesKreimer R (Nonplanar α))).sum := by
+        have h := h_push_sum (B.powerset.map fun B₁ =>
+            (GrossmanLarson.op
+              (GrossmanLarson.unop
+                  (GrossmanLarson.insertion (R := R)
+                    (GrossmanLarson.of' A) (GrossmanLarson.of' B₁)) *
+                GrossmanLarson.unop (GrossmanLarson.of' (B - B₁))) :
+              ConnesKreimer R (Nonplanar α)))
+        rw [Multiset.map_map] at h
+        exact h
+      rw [h_push]
+      -- Now: (B.powerset.map (bMinusLin a ∘ (B₁ => op (unop (insertion ...) * of'(B-B₁))))).sum
+      -- Each summand: bMinusLin a (op (unop X * unop Y)) = bMinusLin a (X * Y) (op/unop are id).
+      -- where X = insertion (of' A) (of' B₁) = Σ_{F' ∈ NIM A B₁} of' F'
+      --       Y = of' (B - B₁)
+      -- So X * Y = Σ of' F' * of' (B-B₁) = Σ of' (F' + (B-B₁))
+      -- and bMinusLin a of that sum = Σ bMinusBasis a (F' + (B-B₁)) = 0 by helper.
+      -- Reduce each summand to 0.
+      apply Multiset.sum_eq_zero
+      intro x hx
+      rw [Multiset.mem_map] at hx
+      obtain ⟨B₁, _hB₁_mem, hx_eq⟩ := hx
+      subst hx_eq
+      -- Per-B₁ closure: bMinusLin a (op (unop (insertion (of' A) (of' B₁)) * unop (of' (B-B₁)))) = 0
+      -- op/unop are identity; reduce to CK level. The `op` outer is a
+      -- no-op on the underlying carrier; the goal already has CK as the
+      -- ambient bMinusLin argument.
+      have h_step : bMinusLin (R := R) a
+          (((GrossmanLarson.unop
+              (GrossmanLarson.insertion (R := R)
+                (GrossmanLarson.of' A) (GrossmanLarson.of' B₁)) :
+              ConnesKreimer R (Nonplanar α)) *
+            GrossmanLarson.unop (GrossmanLarson.of' (B - B₁)))) = 0 := by
+        -- Unfold insertion (of' A) (of' B₁) = insertionBasis A B₁.
+        rw [show (GrossmanLarson.unop
+              (GrossmanLarson.insertion (R := R)
+                (GrossmanLarson.of' A) (GrossmanLarson.of' B₁)) :
+              ConnesKreimer R (Nonplanar α)) =
+            GrossmanLarson.insertionBasis A B₁ from by
+          rw [GrossmanLarson.insertion_of'_of']; rfl]
+        unfold GrossmanLarson.insertionBasis
+        -- Now: bMinusLin a (((NIM A B₁).map of').sum * unop (of' (B-B₁))) = 0.
+        show bMinusLin (R := R) a
+            ((((Nonplanar.insertionMultiset A B₁).map fun F' =>
+                ConnesKreimer.of' (R := R) F').sum :
+              ConnesKreimer R (Nonplanar α)) *
+              ConnesKreimer.of' (R := R) (B - B₁)) = 0
+        -- Distribute * over the sum (right distributivity).
+        rw [← Multiset.sum_map_mul_right]
+        -- Push bMinusLin a through Multiset.sum.
+        rw [h_push_sum, Multiset.map_map]
+        -- Show every summand is 0.
+        apply Multiset.sum_eq_zero
+        intro y hy
+        rw [Multiset.mem_map] at hy
+        obtain ⟨F', hF'_mem, hy_eq⟩ := hy
+        subst hy_eq
+        -- of' F' * of' (B - B₁) = of' (F' + (B - B₁)), then bMinusLin a (of' ...) = bMinusBasis a ...
+        show bMinusLin (R := R) a
+            ((ConnesKreimer.of' (R := R) F' : ConnesKreimer R (Nonplanar α)) *
+              ConnesKreimer.of' (R := R) (B - B₁)) = 0
+        rw [← ConnesKreimer.of'_add]
+        rw [show bMinusLin (R := R) a
+              (ConnesKreimer.of' (R := R) (F' + (B - B₁)) :
+                ConnesKreimer R (Nonplanar α)) =
+            bMinusBasis (R := R) a (F' + (B - B₁)) from
+          bMinusLin_of' a _]
+        exact bMinusBasis_nim_add_eq_zero a A B₁ (B - B₁) F' hA0 hA hF'_mem
+      exact h_step
 
 /-- **Phase C main theorem (OG-style)**: `bMinusLin a` is a 1-cocycle
     with respect to the GL product:

--- a/Linglib/Core/Algebra/RootedTree/BMinus.lean
+++ b/Linglib/Core/Algebra/RootedTree/BMinus.lean
@@ -601,8 +601,8 @@ private theorem nim_singleton_node_a_decomp
     the GL sum, a-rooted via `bPlusLin a`, yields a corresponding tree
     in the NIM enumeration.
 
-    This is the singleton-a-rooted-host case of A3.3 keystone reasoning.
-    Sorry-fenced; needed for Phase C / Sub-case B1. -/
+    This is the singleton-a-rooted-host case of A3.3 keystone reasoning,
+    proved from the NIM-level decomposition `nim_singleton_node_a_decomp`. -/
 private theorem singleton_node_a_insertion_eq_bPlus_gl_mul
     (a : α) (A' B : Forest (Nonplanar α)) :
     GrossmanLarson.insertion (R := R)
@@ -1315,8 +1315,7 @@ private theorem bMinusLin_gl_mul_basis (a : α) (A B : Forest (Nonplanar α)) :
     `B-_a (x *_GL y) = ε(x) • B-_a y + B-_a x *_GL y`.
 
     Reduces by `Finsupp.induction_linear` (twice) to the basis case
-    `bMinusLin_gl_mul_basis`. Deferred — mechanical bilinearity wiring
-    once the basis case is closed. -/
+    `bMinusLin_gl_mul_basis`. -/
 theorem bMinusLin_gl_mul (a : α)
     (x y : ConnesKreimer R (Nonplanar α)) :
     bMinusLin (R := R) a

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -53,9 +53,11 @@ work (B+ is not a Hochschild 1-cocycle for Δ^c; see CHANGELOG entry
 
 ## Status
 
-`[UPSTREAM]` candidate. Skeleton API only. All proofs `sorry`. Builds
-on R.5 GL substrate (sorry'd `mul_assoc`) and R.6 pairing substrate
-(sorry'd everywhere). Proper proofs land once R.5 + R.6 are sorry-free.
+`[UPSTREAM]` candidate. Most proofs landed; two `sorry`s remain: the
+GL/Δ^c duality identity `pairing_gl_eq_pairing_coproduct_C` and the
+grading half of `mcb_lemma_1_2_10`. The R.6 pairing substrate
+(`GrossmanLarsonPairing.lean`, `Aut.lean`) is sorry-free; the R.5 GL
+substrate still has `mul_assoc_basis` open.
 -/
 
 namespace RootedTree
@@ -1491,8 +1493,8 @@ theorem counit_lTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
     `Bialgebra.ofAlgHom` with `comulCAlgHomN τ` as the coproduct and the
     inherited `counit` from CK. Depends on:
     * `comulCAlgHomN_coassoc_algHom` (closed structurally).
-    * `counit_rTensor_comulCAlgHomN` (sorry).
-    * `counit_lTensor_comulCAlgHomN` (sorry). -/
+    * `counit_rTensor_comulCAlgHomN` (proved).
+    * `counit_lTensor_comulCAlgHomN` (proved). -/
 noncomputable instance instBialgebraC
     [CharZero R'] [NoZeroDivisors R'] (τ : Nonplanar (α' ⊕ β') → β') :
     Bialgebra R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))) :=

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
@@ -57,14 +57,11 @@ torsion subtleties when |Aut(F)| = 0 or non-invertible).
 
 ## Status
 
-`[UPSTREAM]` candidate. Open `sorry`s: `pairing` definition,
-`pairing_of'_of'` evaluation, `pairing_symm`, `pairing_nondegenerate`.
+`[UPSTREAM]` candidate. Sorry-free, including `pairing_nondegenerate`.
 The aut-cardinality substrate `Nonplanar.autCard` /
 `Nonplanar.forestAutCard` lives in
 `Linglib/Core/Combinatorics/RootedTree/Aut.lean` (re-exported here as
-`treeAutCard` / `forestAutCard`) — it has its own `sorry` for the
-implementation, which doesn't block proving the pairing's API
-properties.
+`treeAutCard` / `forestAutCard`), also sorry-free.
 -/
 
 namespace RootedTree

--- a/Linglib/Core/Algebra/RootedTree/PreLie/BMinusSL.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/BMinusSL.lean
@@ -36,9 +36,8 @@ The operator is built on the tensor algebra degree by degree and descended to
   of [oudom-guin-2008].
 * `bMinusLin_SL_oudomGuinStar`: the cocycle identity
   `B⁻_a (A ★ B) = ε(A) • B⁻_a B + B⁻_a A ★ B` from the proof of Prop 3.2 of
-  [oudom-guin-2008] (the `mul` case is incomplete).
-* `bMinusLin_ckIso` (incomplete): transport of `B⁻_a` along
-  `ckIsoSymmetricAlgebra`.
+  [oudom-guin-2008].
+* `bMinusLin_ckIso`: transport of `B⁻_a` along `ckIsoSymmetricAlgebra`.
 
 `[UPSTREAM]` candidate.
 
@@ -1985,10 +1984,7 @@ private theorem bMinusLin_SL_star_eq (a : α) (A B : SL) :
 
     `bMinusLin_SL a (A ★ B) = ε(A) • bMinusLin_SL a B + bMinusLin_SL a A ★ B`
 
-    SL-side analog of the Connes-Kreimer-side `bMinusLin_gl_mul`.
-
-    TODO: the `mul` case is incomplete; it needs associativity of `★`
-    (Lemma 2.10 of [oudom-guin-2008]). -/
+    SL-side analog of the Connes-Kreimer-side `bMinusLin_gl_mul`. -/
 theorem bMinusLin_SL_oudomGuinStar [DecidableEq (Nonplanar α)]
     (a : α) (A B : SL) :
     bMinusLin_SL a (oudomGuinStar A B) =

--- a/Linglib/Core/Algebra/RootedTree/PreLie/BMinusSL.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/BMinusSL.lean
@@ -11,50 +11,40 @@ import Linglib.Core.Combinatorics.RootedTree.Nonplanar
 import Mathlib.LinearAlgebra.SymmetricAlgebra.Basic
 import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 
-set_option autoImplicit false
-
 /-!
-# B⁻ operator on `SymmetricAlgebra ℤ (InsertionAlgebra α)`
-[oudom-guin-2008]
+# The B⁻ operator on the symmetric algebra of the insertion algebra
 
-The SL-side analog of `bMinusLin` (defined on the CK side in `BMinus.lean`).
-On a single `ι(ofTree t)` basis element of `SL = SymmetricAlgebra ℤ
-(InsertionAlgebra α)`:
+For each color `a : α`, this file constructs the linear operator `B⁻_a` on
+`SL = SymmetricAlgebra ℤ (InsertionAlgebra α)` from [oudom-guin-2008]: on a
+generator `ι (ofTree t)` it returns the product
+`∏ c ∈ rootChildren t, ι (ofTree c)` if `rootLabel t = a` and `0` otherwise,
+and it vanishes on scalars and on products of two or more generators. It is
+the SL-side analog of `bMinusLin` on the Connes-Kreimer side (`BMinus.lean`).
 
-```
-bMinusLin_SL a (ι(ofTree t)) =
-  if rootLabel t = a then
-    ∏ c ∈ rootChildren t, ι(ofTree c)
-  else 0
-```
+The operator is built on the tensor algebra degree by degree and descended to
+`SL` through `SymmetricAlgebra.algHom`.
 
-and vanishes on length-0 (scalars) and length-≥2 (products of two or more
-ι's) elements of `SL`. This is the SL-side `B⁻_a` operator from Oudom-Guin
-paper §3 (page 10).
+## Main definitions
 
-## Headline result (downstream)
+* `RootedTree.SymAlg.bMinusLin_SL`: the operator `B⁻_a : SL →ₗ[ℤ] SL`.
 
-The cocycle identity `B⁻_a(A ★ B) = ε(A) • B⁻_a(B) + B⁻_a(A) ★ B`
-(OG Prop 3.2) — to be proved in a sibling file (Piece C of the
-option-(ii) plan). This file provides the operator (Piece A) and the
-ckIso-transport identity (Piece B).
+## Main results
 
-## Construction (TA-descent recipe)
+* `bMinusLin_SL_ιTree`: the defining values on embedded trees.
+* `iotaTree_node_via_circ`: every tree is the circle product of its singleton
+  root with its children-forest, the root-grafting identity displayed in §3.1
+  of [oudom-guin-2008].
+* `bMinusLin_SL_oudomGuinStar`: the cocycle identity
+  `B⁻_a (A ★ B) = ε(A) • B⁻_a B + B⁻_a A ★ B` from the proof of Prop 3.2 of
+  [oudom-guin-2008] (the `mul` case is incomplete).
+* `bMinusLin_ckIso` (incomplete): transport of `B⁻_a` along
+  `ckIsoSymmetricAlgebra`.
 
-Mirrors `OudomGuinCircConstruct.circByT_total` (`OudomGuinCircTotal.lean:518`):
+`[UPSTREAM]` candidate.
 
-1. `psiA_basis a : Nonplanar α → SL` — per-tree assignment (children-prod or 0)
-2. `psiA_L a : LL →ₗ[ℤ] SL` — linear extension via `Finsupp.linearCombination`
-3. `psiA_multi a n : MultilinearMap (Fin n → LL) SL` — vanishes outside n=1
-4. `psiA_pi a n : ⨂[ℤ]^n LL →ₗ[ℤ] SL` via `PiTensorProduct.lift`
-5. `psiA_graded a : (⨁ n, ⨂[ℤ]^n LL) →ₗ[ℤ] SL` via `DirectSum.toModule`
-6. `psiA_tensor a : TA LL →ₗ[ℤ] SL` via `TensorAlgebra.equivDirectSum`
-7. Kernel vanishing: `algHomL.ker ≤ psiA_tensor.ker` — trivial because
-   psiA_tensor is 0 on grade ≥ 2, so any `r · (ιX·ιY) · d` (grade ≥ 2)
-   maps to 0 regardless of X, Y order
-8. Descend via `Submodule.liftQ` + `LinearMap.quotKerEquivOfSurjective`
+## References
 
-`[UPSTREAM]` candidate (joint with the sibling Prop-3.2 file).
+* [oudom-guin-2008]
 -/
 
 namespace RootedTree
@@ -65,37 +55,29 @@ open TensorProduct
 open scoped DirectSum
 open PreLie.OudomGuinCirc
 
-/-! ## §1: Per-tree basis assignment
-
-For each color `a : α` and tree `t : Nonplanar α`, define the "children
-as SL-product if a-rooted, else 0" assignment at the basis level. -/
+/-! ### Per-tree basis assignment -/
 
 variable {α : Type}
 
-/-- Local abbreviations for readability. Use `LL` (not `L`) for
-    `InsertionAlgebra α` to avoid clashing with the named argument
-    `(LL := ...)` in `algHomL`. -/
+/-- `LL` (not `L`) avoids clashing with the named argument `(LL := ...)` in
+    `algHomL`. -/
 local notation "LL" => InsertionAlgebra α
 local notation "SL" => SymmetricAlgebra ℤ LL
 
-/-- The `ι(ofTree)` map `Nonplanar α → SL`: embed a single tree into SL
-    via the InsertionAlgebra's basis embedding `ofTree`, then via SL's
-    canonical `ι`. -/
+/-- Embedding of a single tree into `SL`: `SymmetricAlgebra.ι` applied to
+    `InsertionAlgebra.ofTree`. -/
 noncomputable def ιTree (t : Nonplanar α) : SL :=
   SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofTree t)
 
-/-- The per-tree basis assignment for `B⁻_a`. On `t : Nonplanar α`:
-    returns the SL-product of `ι(ofTree c)` over each child
-    `c ∈ rootChildren t` if `rootLabel t = a`, else 0.
-
-    Local `Classical.dec` provides decidability for `rootLabel t = a`. -/
+/-- The value of `B⁻_a` on a tree `t`: the SL-product of `ι (ofTree c)` over
+    the root's children if `rootLabel t = a`, else `0`. -/
 noncomputable def psiA_basis (a : α) (t : Nonplanar α) : SL :=
   letI : Decidable (Nonplanar.rootLabel t = a) := Classical.dec _
   if Nonplanar.rootLabel t = a then
     ((Nonplanar.rootChildren t).map (fun c => ιTree c)).prod
   else 0
 
-/-! ## §2: Linearize over `L = Nonplanar α →₀ ℤ` -/
+/-! ### Linear extension to the insertion algebra -/
 
 /-- The `psiA` operator on `L`: linear extension of `psiA_basis` via
     `Finsupp.lift`. -/
@@ -107,29 +89,15 @@ noncomputable def psiA_L (a : α) : LL →ₗ[ℤ] SL :=
   show Finsupp.lift SL ℤ (Nonplanar α) _ (Finsupp.single t 1) = _
   rw [Finsupp.lift_apply, Finsupp.sum_single_index] <;> simp
 
-/-! ## §3: Per-degree multilinear maps
+/-! ### Per-degree multilinear maps
 
-Length-graded structure: `psiA_multi a n` is the `Fin n → LL` multilinear
-map that vanishes on `n ≠ 1` and applies `psiA_L a` to the single
-argument when `n = 1`. -/
+`psiA_multi a n` is the `Fin n → LL` multilinear map that vanishes on
+`n ≠ 1` and applies `psiA_L a` to the single argument when `n = 1`. -/
 
-/-- The `n = 1` multilinear case: apply `psiA_L` to the single argument.
-
-    Multilinearity is trivial since `Fin 1` has only one index, and
-    `psiA_L` is already linear in that argument. -/
+/-- The `n = 1` multilinear case: apply `psiA_L` to the single argument. -/
 private noncomputable def psiA_multi_one (a : α) :
     MultilinearMap ℤ (fun _ : Fin 1 ↦ LL) SL :=
-  MultilinearMap.mk' (fun f => psiA_L a (f 0))
-    (fun m i x y => by
-      have hi : i = (0 : Fin 1) := Subsingleton.elim _ _
-      subst hi
-      simp only [Function.update_self]
-      exact (psiA_L a).map_add x y)
-    (fun m i c x => by
-      have hi : i = (0 : Fin 1) := Subsingleton.elim _ _
-      subst hi
-      simp only [Function.update_self]
-      exact (psiA_L a).map_smul c x)
+  MultilinearMap.ofSubsingleton ℤ LL SL 0 (psiA_L a)
 
 @[simp] theorem psiA_multi_one_apply (a : α) (f : Fin 1 → LL) :
     psiA_multi_one a f = psiA_L a (f 0) := rfl
@@ -150,10 +118,9 @@ noncomputable def psiA_multi (a : α) :
 @[simp] theorem psiA_multi_succ_succ (a : α) (n : ℕ) :
     psiA_multi a (n + 2) = 0 := rfl
 
-/-! ## §4: Per-degree lift to `⨂[ℤ]^n L` via `PiTensorProduct.lift` -/
+/-! ### Lifts to tensor powers -/
 
-/-- Per-degree lift of `psiA_multi a n` to `⨂[ℤ]^n L`. Mirrors
-    `OudomGuinCircConstruct.circTPi`. -/
+/-- Per-degree lift of `psiA_multi a n` to the `n`-th tensor power. -/
 noncomputable def psiA_pi (a : α) (n : ℕ) : (⨂[ℤ]^n LL) →ₗ[ℤ] SL :=
   PiTensorProduct.lift (psiA_multi a n)
 
@@ -161,28 +128,24 @@ noncomputable def psiA_pi (a : α) (n : ℕ) : (⨂[ℤ]^n LL) →ₗ[ℤ] SL :=
     psiA_pi a n (PiTensorProduct.tprod ℤ g) = psiA_multi a n g := by
   rw [psiA_pi, PiTensorProduct.lift.tprod]
 
-/-! ## §5: Assembly across degrees via `DirectSum.toModule` -/
+/-! ### Assembly across degrees -/
 
-/-- Assembly of all `psiA_pi a n` into a linear map from the direct sum
-    of all tensor powers. Mirrors `OudomGuinCircConstruct.circTGraded`. -/
+/-- The maps `psiA_pi a n` assembled into a linear map from the direct sum
+    of all tensor powers. -/
 noncomputable def psiA_graded (a : α) :
     (⨁ n : ℕ, ⨂[ℤ]^n LL) →ₗ[ℤ] SL :=
   DirectSum.toModule ℤ ℕ SL (fun n => psiA_pi a n)
 
 @[simp] theorem psiA_graded_of (a : α) (n : ℕ) (x : ⨂[ℤ]^n LL) :
     psiA_graded a (DirectSum.of (fun n : ℕ => ⨂[ℤ]^n LL) n x) =
-      psiA_pi a n x := by
-  unfold psiA_graded
-  show DirectSum.toModule ℤ ℕ SL (fun n => psiA_pi a n)
-        (DirectSum.lof ℤ ℕ _ n x) = _
-  exact DirectSum.toModule_lof (R := ℤ) (ι := ℕ) (M := fun n => ⨂[ℤ]^n LL)
+      psiA_pi a n x :=
+  DirectSum.toModule_lof (R := ℤ) (ι := ℕ) (M := fun n => ⨂[ℤ]^n LL)
     (N := SL) (φ := fun n => psiA_pi a n) n x
 
-/-! ## §6: Composition with `TensorAlgebra.equivDirectSum` -/
+/-! ### The tensor-algebra-level operator -/
 
 /-- The TA-side `psiA` operator, assembled from per-degree `psiA_pi` via
-    mathlib's `TensorAlgebra ≃ₐ ⨁_n ⨂[ℤ]^n LL`. Mirrors
-    `OudomGuinCircConstruct.circTTensor`. -/
+    `TensorAlgebra.equivDirectSum`. -/
 noncomputable def psiA_tensor (a : α) : TensorAlgebra ℤ LL →ₗ[ℤ] SL :=
   (psiA_graded a).comp
     (TensorAlgebra.equivDirectSum (R := ℤ) (M := InsertionAlgebra α)).toLinearMap
@@ -201,17 +164,39 @@ noncomputable def psiA_tensor (a : α) : TensorAlgebra ℤ LL →ₗ[ℤ] SL :=
   -- psiA_pi on tprod = psiA_multi.
   rw [psiA_pi_tprod]
 
-/-! ## §7: Kernel vanishing
-
-`psiA_tensor a` vanishes on `ker algHomL`. Easier than `circTTensor`'s
-kernel-vanishing because psiA_tensor is 0 on every tprod of degree ≥ 2:
-any wrapped `r * (ι X * ι Y) * d` element has degree ≥ 2 (the X·Y factor
-alone contributes 2), so both swap-orderings map to 0. -/
+/-! ### Definitional bridges -/
 
 open PreLie.OudomGuinCircConstruct in
-/-- Inlined helper: `(tprod_m a) * (ι X * ι Y) * (tprod_n b)` equals
-    a single tprod of grade `m + 2 + n`. Mirrors the private
-    `tprod_mul_ι_pair_mul_tprod` in `OudomGuinCircTotal.lean`. -/
+/-- `algHomL` is `SymmetricAlgebra.algHom` as a linear map (definitional). -/
+@[simp] private theorem algHomL_apply (z : TensorAlgebra ℤ LL) :
+    algHomL (R := ℤ) (L := LL) z = SymmetricAlgebra.algHom ℤ LL z := rfl
+
+/-- `SymmetricAlgebra.algHom` sends generators to generators (definitional). -/
+@[simp] private theorem algHom_ι (x : LL) :
+    SymmetricAlgebra.algHom ℤ LL (TensorAlgebra.ι ℤ x) =
+      SymmetricAlgebra.ι ℤ LL x := rfl
+
+open PreLie.OudomGuinCircConstruct in
+/-- `algHomL` sends generators to generators (definitional). -/
+private theorem algHomL_ι (x : LL) :
+    algHomL (R := ℤ) (L := LL) (TensorAlgebra.ι ℤ x) =
+      SymmetricAlgebra.ι ℤ LL x := rfl
+
+/-- The empty tensor product is `1`. -/
+private theorem tprod_zero (f : Fin 0 → LL) :
+    TensorAlgebra.tprod ℤ LL 0 f = (1 : TensorAlgebra ℤ LL) := by
+  rw [TensorAlgebra.tprod_apply]
+  simp [List.ofFn_zero]
+
+/-! ### Kernel vanishing
+
+`psiA_tensor a` vanishes on `ker algHomL`: it is `0` on every tprod of
+degree ≥ 2, and any wrapped `r * (ι X * ι Y) * d` element has degree ≥ 2,
+so both swap-orderings map to `0`. -/
+
+open PreLie.OudomGuinCircConstruct in
+/-- A product `tprod m r' * (ι X * ι Y) * tprod n d'` is a single tprod of
+    grade `m + 2 + n`. -/
 private theorem tprod_mul_ι_pair_mul_tprod_inline
     (m n : ℕ) (r' : Fin m → InsertionAlgebra α)
     (d' : Fin n → InsertionAlgebra α) (X Y : InsertionAlgebra α) :
@@ -225,16 +210,15 @@ private theorem tprod_mul_ι_pair_mul_tprod_inline
   rw [ι_eq_tprod_one X, ι_eq_tprod_one Y]
   rw [tprod_mul_tprod 1 1, tprod_mul_tprod m (1 + 1), tprod_mul_tprod (m + 2) n]
 
-/-- Helper: for any `k ≥ 2`, `psiA_multi a k` is the zero map. -/
-private lemma psiA_multi_eq_zero_of_ge_two (a : α) {k : ℕ} (hk : k ≥ 2) :
+/-- For `k ≥ 2`, `psiA_multi a k` is the zero map. -/
+private theorem psiA_multi_eq_zero_of_ge_two (a : α) {k : ℕ} (hk : 2 ≤ k) :
     psiA_multi a k = 0 := by
   obtain ⟨j, rfl⟩ : ∃ j, k = j + 2 := ⟨k - 2, by omega⟩
   exact psiA_multi_succ_succ a j
 
-/-- `psiA_tensor` vanishes on any `r * (ι X * ι Y) * d` regardless of X, Y
-    order, because the result is grade ≥ 2 and `psiA_multi a n = 0` for
-    `n ≥ 2`. -/
-private lemma psiA_tensor_grade_ge_two_vanish (a : α)
+/-- `psiA_tensor a` vanishes on any `r * (ι X * ι Y) * d`: the result has
+    grade ≥ 2. -/
+private theorem psiA_tensor_grade_ge_two_vanish (a : α)
     {m n : ℕ} (r' : Fin m → InsertionAlgebra α)
     (d' : Fin n → InsertionAlgebra α) (X Y : InsertionAlgebra α) :
     psiA_tensor a
@@ -243,69 +227,36 @@ private lemma psiA_tensor_grade_ge_two_vanish (a : α)
           (TensorAlgebra.tprod ℤ (InsertionAlgebra α) n d')) = 0 := by
   rw [tprod_mul_ι_pair_mul_tprod_inline, psiA_tensor_tprod]
   -- psiA_multi a (m + 2 + n) is the zero map since m + 2 + n ≥ 2.
-  rw [psiA_multi_eq_zero_of_ge_two a (by omega : m + 2 + n ≥ 2)]
+  rw [psiA_multi_eq_zero_of_ge_two a (by omega : 2 ≤ m + 2 + n)]
   rfl
 
 open PreLie.OudomGuinCircConstruct in
-/-- Swap-respect for `psiA_tensor` (bilinear-extension version): for any
-    `r d : TA LL` and `X Y : LL`, the swap of X, Y inside `r * (ι X · ι Y) * d`
-    leaves `psiA_tensor a` invariant. Trivial since both sides are 0. -/
-private lemma psiA_tensor_swap_general (a : α) (X Y : LL) (r d : TensorAlgebra ℤ LL) :
-    psiA_tensor a (r * (TensorAlgebra.ι ℤ X * TensorAlgebra.ι ℤ Y) * d) =
-    psiA_tensor a (r * (TensorAlgebra.ι ℤ Y * TensorAlgebra.ι ℤ X) * d) := by
-  -- Extend over r and d bilinearly.
-  -- For each pair (r, d) of tprods, both sides reduce to
-  -- psiA_tensor (tprod (concat)) = 0 by grade-vanishing.
-  suffices h_fixed_d : ∀ d' : TensorAlgebra ℤ LL,
-      (psiA_tensor a).comp ((LinearMap.mulRight ℤ d').comp
-        (LinearMap.mulRight ℤ (TensorAlgebra.ι ℤ X * TensorAlgebra.ι ℤ Y))) =
-      (psiA_tensor a).comp ((LinearMap.mulRight ℤ d').comp
-        (LinearMap.mulRight ℤ (TensorAlgebra.ι ℤ Y * TensorAlgebra.ι ℤ X))) by
-    have := congrArg (fun f : TensorAlgebra ℤ LL →ₗ[ℤ] SL => f r) (h_fixed_d d)
-    simp only [LinearMap.comp_apply, LinearMap.mulRight_apply] at this
-    exact this
-  intro d'
-  apply TA_linearMap_ext_tprod
-  intro m r'
-  -- Goal: f (tprod m r') = g (tprod m r') with f, g compositions of psiA_tensor + mulRight.
-  show psiA_tensor a (TensorAlgebra.tprod ℤ LL m r' *
-        (TensorAlgebra.ι ℤ X * TensorAlgebra.ι ℤ Y) * d') =
-      psiA_tensor a (TensorAlgebra.tprod ℤ LL m r' *
-        (TensorAlgebra.ι ℤ Y * TensorAlgebra.ι ℤ X) * d')
-  -- Both sides will become wrappings of grade ≥ 2 around different orderings;
-  -- both reduce to 0 by psiA_tensor_grade_ge_two_vanish. But the d' side is
-  -- not yet a tprod, so extend over d' too.
-  suffices h_at_tprod_r : ∀ d'' : TensorAlgebra ℤ LL,
-      psiA_tensor a (TensorAlgebra.tprod ℤ LL m r' *
-          (TensorAlgebra.ι ℤ X * TensorAlgebra.ι ℤ Y) * d'') =
-      psiA_tensor a (TensorAlgebra.tprod ℤ LL m r' *
-          (TensorAlgebra.ι ℤ Y * TensorAlgebra.ι ℤ X) * d'') by
-    exact h_at_tprod_r d'
-  intro d''
-  -- Extend over d'' via TA_linearMap_ext_tprod.
-  suffices h_eq : (psiA_tensor a).comp
-      ((LinearMap.mulLeft ℤ (TensorAlgebra.tprod ℤ LL m r' *
-          (TensorAlgebra.ι ℤ X * TensorAlgebra.ι ℤ Y)))) =
-    (psiA_tensor a).comp
-      ((LinearMap.mulLeft ℤ (TensorAlgebra.tprod ℤ LL m r' *
-          (TensorAlgebra.ι ℤ Y * TensorAlgebra.ι ℤ X)))) by
-    have := congrArg (fun f : TensorAlgebra ℤ LL →ₗ[ℤ] SL => f d'') h_eq
-    simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply] at this
-    exact this
-  apply TA_linearMap_ext_tprod
-  intro n d_tprod
-  show psiA_tensor a (TensorAlgebra.tprod ℤ LL m r' *
-        (TensorAlgebra.ι ℤ X * TensorAlgebra.ι ℤ Y) *
-        TensorAlgebra.tprod ℤ LL n d_tprod) =
-      psiA_tensor a (TensorAlgebra.tprod ℤ LL m r' *
-        (TensorAlgebra.ι ℤ Y * TensorAlgebra.ι ℤ X) *
-        TensorAlgebra.tprod ℤ LL n d_tprod)
-  rw [psiA_tensor_grade_ge_two_vanish a r' d_tprod X Y,
-      psiA_tensor_grade_ge_two_vanish a r' d_tprod Y X]
+/-- `psiA_tensor a` kills any `r * (ι X * ι Y) * d`: bilinear extension of
+    `psiA_tensor_grade_ge_two_vanish` over `r` and `d`. -/
+private theorem psiA_tensor_mul_ι_pair_mul (a : α) (X Y : LL)
+    (r d : TensorAlgebra ℤ LL) :
+    psiA_tensor a (r * (TensorAlgebra.ι ℤ X * TensorAlgebra.ι ℤ Y) * d) = 0 := by
+  have h_d : ∀ m (r' : Fin m → LL),
+      (psiA_tensor a).comp (LinearMap.mulLeft ℤ (TensorAlgebra.tprod ℤ LL m r' *
+        (TensorAlgebra.ι ℤ X * TensorAlgebra.ι ℤ Y))) = 0 := fun m r' =>
+    TA_linearMap_ext_tprod fun n d' => psiA_tensor_grade_ge_two_vanish a r' d' X Y
+  have h_r : (psiA_tensor a).comp ((LinearMap.mulRight ℤ d).comp
+      (LinearMap.mulRight ℤ (TensorAlgebra.ι ℤ X * TensorAlgebra.ι ℤ Y))) = 0 :=
+    TA_linearMap_ext_tprod fun m r' => LinearMap.congr_fun (h_d m r') d
+  exact LinearMap.congr_fun h_r r
 
-/-- `psiA_tensor a` respects `Rel SymRel` (after wrapping). Same induction
-    pattern as `circTTensor_resp_Rel_strong`. -/
-private lemma psiA_tensor_resp_Rel_strong (a : α) :
+/-- `psiA_tensor a` is invariant under swapping `X` and `Y` inside
+    `r * (ι X * ι Y) * d`: both sides vanish. -/
+private theorem psiA_tensor_swap_general (a : α) (X Y : LL)
+    (r d : TensorAlgebra ℤ LL) :
+    psiA_tensor a (r * (TensorAlgebra.ι ℤ X * TensorAlgebra.ι ℤ Y) * d) =
+    psiA_tensor a (r * (TensorAlgebra.ι ℤ Y * TensorAlgebra.ι ℤ X) * d) :=
+  (psiA_tensor_mul_ι_pair_mul a X Y r d).trans
+    (psiA_tensor_mul_ι_pair_mul a Y X r d).symm
+
+/-- `psiA_tensor a` respects the symmetrizing relation under arbitrary
+    wrapping. -/
+private theorem psiA_tensor_resp_Rel_strong (a : α) :
     ∀ {z₁ z₂ : TensorAlgebra ℤ LL},
     RingQuot.Rel (TensorAlgebra.SymRel ℤ LL) z₁ z₂ →
     ∀ r d : TensorAlgebra ℤ LL,
@@ -337,13 +288,13 @@ private lemma psiA_tensor_resp_Rel_strong (a : α) :
     rw [hL, hR]
     exact ih (r * a') d
 
-private lemma psiA_tensor_resp_Rel (a : α) {z₁ z₂ : TensorAlgebra ℤ LL}
+private theorem psiA_tensor_resp_Rel (a : α) {z₁ z₂ : TensorAlgebra ℤ LL}
     (h : RingQuot.Rel (TensorAlgebra.SymRel ℤ LL) z₁ z₂) :
     psiA_tensor a z₁ = psiA_tensor a z₂ := by
   have := psiA_tensor_resp_Rel_strong a h 1 1
   simpa using this
 
-private lemma psiA_tensor_resp_EqvGen (a : α) {z₁ z₂ : TensorAlgebra ℤ LL}
+private theorem psiA_tensor_resp_EqvGen (a : α) {z₁ z₂ : TensorAlgebra ℤ LL}
     (h : Relation.EqvGen (RingQuot.Rel (TensorAlgebra.SymRel ℤ LL)) z₁ z₂) :
     psiA_tensor a z₁ = psiA_tensor a z₂ := by
   induction h with
@@ -353,8 +304,7 @@ private lemma psiA_tensor_resp_EqvGen (a : α) {z₁ z₂ : TensorAlgebra ℤ LL
   | trans _ _ _ _ _ ih₁ ih₂ => exact ih₁.trans ih₂
 
 open PreLie.OudomGuinCircConstruct in
-/-- `psiA_tensor a` vanishes on `ker algHomL`. Mirror of
-    `circTTensor_vanishes_on_ker`. -/
+/-- `psiA_tensor a` vanishes on the kernel of `algHomL`. -/
 private theorem psiA_tensor_vanishes_on_ker (a : α) :
     LinearMap.ker (algHomL (R := ℤ) (L := InsertionAlgebra α)) ≤
       LinearMap.ker (psiA_tensor a) := by
@@ -377,141 +327,89 @@ private theorem psiA_tensor_vanishes_on_ker (a : α) :
   have := psiA_tensor_resp_EqvGen a h_eqv
   rw [this, (psiA_tensor a).map_zero]
 
-/-! ## §8: Descent to `SymmetricAlgebra` via `Submodule.liftQ` -/
+/-! ### Descent to the symmetric algebra -/
 
 open PreLie.OudomGuinCircConstruct in
-/-- **The SL-side B⁻ operator** `B⁻_a : SL →ₗ[ℤ] SL`. Built via
-    `Submodule.liftQ` from `psiA_tensor a` + the kernel-vanishing lemma,
-    composed with the surjective-algHom-induced equivalence
-    `SL ≃ TA / ker algHomL`. Mirrors `circByT_total`. -/
+/-- The `B⁻_a` operator on `SL` ([oudom-guin-2008]), descended from
+    `psiA_tensor a` through `algHomL` via `Submodule.liftQ`. -/
 noncomputable def bMinusLin_SL (a : α) : SL →ₗ[ℤ] SL :=
   (Submodule.liftQ _ (psiA_tensor a) (psiA_tensor_vanishes_on_ker a)).comp
     (LinearMap.quotKerEquivOfSurjective algHomL algHomL_surjective).symm.toLinearMap
 
-/-! ## §9: Basic identities
-
-`bMinusLin_SL a` factors through `algHomL`: for any `z : TA L`, applying
-`bMinusLin_SL a` after `algHomL` equals applying `psiA_tensor a` directly.
-This is the key lemma for computing `bMinusLin_SL` on specific elements
-(by lifting them through `algHomL`). -/
+/-! ### Basic identities -/
 
 open PreLie.OudomGuinCircConstruct in
-/-- **Factorization through algHomL**: `bMinusLin_SL a (algHomL z) =
-    psiA_tensor a z` for all `z : TA L`. -/
+/-- `bMinusLin_SL a` factors through `algHomL`:
+    `bMinusLin_SL a (algHomL z) = psiA_tensor a z`. -/
 theorem bMinusLin_SL_algHomL (a : α) (z : TensorAlgebra ℤ LL) :
     bMinusLin_SL a (algHomL z) = psiA_tensor a z := by
-  -- bMinusLin_SL = (liftQ ...).comp quotKerEquivOfSurjective.symm.
-  -- Strategy: compute (quotKerEquivOfSurjective).symm (algHomL z) = Submodule.Quotient.mk z,
-  -- then apply Submodule.liftQ_apply.
-  unfold bMinusLin_SL
-  rw [LinearMap.comp_apply]
-  -- Convert symm.toLinearMap to symm-apply form.
   show (Submodule.liftQ (LinearMap.ker (algHomL (R := ℤ) (L := InsertionAlgebra α)))
         (psiA_tensor a) (psiA_tensor_vanishes_on_ker a))
       ((LinearMap.quotKerEquivOfSurjective algHomL algHomL_surjective).symm
         (algHomL z)) = _
-  -- Establish: (.symm) (algHomL z) = mk z. Use that quotKerEquivOfSurjective sends
-  -- mk z to algHomL z (by quotKerEquivOfSurjective_apply_mk or similar).
-  have h_eq : (LinearMap.quotKerEquivOfSurjective
+  rw [show (LinearMap.quotKerEquivOfSurjective
         (algHomL (R := ℤ) (L := InsertionAlgebra α)) algHomL_surjective).symm
         (algHomL z) =
       (Submodule.Quotient.mk z : TensorAlgebra ℤ LL ⧸
-        LinearMap.ker (algHomL (R := ℤ) (L := InsertionAlgebra α))) := by
-    apply (LinearMap.quotKerEquivOfSurjective
-      (algHomL (R := ℤ) (L := InsertionAlgebra α)) algHomL_surjective).injective
-    rw [LinearEquiv.apply_symm_apply]
-    rfl
-  rw [h_eq]
+        LinearMap.ker (algHomL (R := ℤ) (L := InsertionAlgebra α))) from
+    (LinearEquiv.symm_apply_eq _).mpr rfl]
   exact Submodule.liftQ_apply _ (psiA_tensor a) _
 
-/-- **B⁻_a applied to ι(x)**: equals `psiA_L a x`. -/
-theorem bMinusLin_SL_ι (a : α) (x : InsertionAlgebra α) :
+/-- `bMinusLin_SL a (ι x) = psiA_L a x`. -/
+@[simp] theorem bMinusLin_SL_ι (a : α) (x : InsertionAlgebra α) :
     bMinusLin_SL a (SymmetricAlgebra.ι ℤ LL x) = psiA_L a x := by
-  -- SymmetricAlgebra.ι R L = algHom R L ∘ₗ TensorAlgebra.ι R (by definition).
-  have h_factor : SymmetricAlgebra.ι ℤ LL x =
-      PreLie.OudomGuinCircConstruct.algHomL (TensorAlgebra.ι ℤ x) := rfl
-  rw [h_factor, bMinusLin_SL_algHomL]
-  -- Now: psiA_tensor a (TA.ι ℤ x) = psiA_L a x.
-  -- TA.ι ℤ x = tprod 1 (fun _ => x); psiA_tensor on tprod 1 = psiA_multi a 1.
-  rw [PreLie.OudomGuinCircConstruct.ι_eq_tprod_one, psiA_tensor_tprod]
+  rw [← algHomL_ι x, bMinusLin_SL_algHomL,
+      PreLie.OudomGuinCircConstruct.ι_eq_tprod_one, psiA_tensor_tprod]
   rfl
 
-/-- **B⁻_a applied to ιTree t**: equals `psiA_basis a t`. -/
-theorem bMinusLin_SL_ιTree (a : α) (t : Nonplanar α) :
+/-- `bMinusLin_SL a (ιTree t) = psiA_basis a t`. -/
+@[simp] theorem bMinusLin_SL_ιTree (a : α) (t : Nonplanar α) :
     bMinusLin_SL a (ιTree t) = psiA_basis a t := by
   show bMinusLin_SL a (SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofTree t)) = _
   rw [bMinusLin_SL_ι, psiA_L_ofTree]
 
-/-- **B⁻_a applied to 1**: equals 0 (scalars have length 0; B⁻ vanishes). -/
+/-- `B⁻_a` vanishes on `1`. -/
 @[simp] theorem bMinusLin_SL_one (a : α) :
     bMinusLin_SL a (1 : SL) = 0 := by
-  -- 1 = algHomL 1 (algHom preserves 1).
-  have h_one : (1 : SL) = PreLie.OudomGuinCircConstruct.algHomL (1 : TensorAlgebra ℤ LL) := by
-    show (1 : SL) = (SymmetricAlgebra.algHom ℤ LL).toLinearMap 1
-    show (1 : SL) = SymmetricAlgebra.algHom ℤ LL 1
-    rw [map_one]
-  rw [h_one, bMinusLin_SL_algHomL]
-  -- psiA_tensor a 1 = psiA_tensor a (tprod 0 _) — but 1 isn't directly a tprod 0.
-  -- Easier route: 1 = algebraMap ℤ 1; psiA_tensor on algebraMap... actually use
-  -- the TA grade structure: 1 = TA.tprod 0 (the empty function).
-  have h_one_tprod : (1 : TensorAlgebra ℤ LL) =
-      TensorAlgebra.tprod ℤ LL 0 Fin.elim0 := by
-    rw [TensorAlgebra.tprod_apply]
-    simp [List.ofFn_zero]
-  rw [h_one_tprod, psiA_tensor_tprod, psiA_multi_zero]
+  rw [show (1 : SL) = PreLie.OudomGuinCircConstruct.algHomL (1 : TensorAlgebra ℤ LL) by
+        rw [algHomL_apply, map_one],
+      bMinusLin_SL_algHomL, ← tprod_zero Fin.elim0, psiA_tensor_tprod, psiA_multi_zero]
   rfl
 
-/-! ### §9.5: Length-vanishing substrate for the ι case of Piece C
+/-! ### Length-one extraction
 
-The cocycle ι case (`bMinusLin_SL_oudomGuinStar` at `A = ι Y`) reduces — via
-Sweedler bashing on `cm B` — to the property that `bMinusLin_SL` extracts only
-the length-1 component. We package this as two private lemmas:
+`bMinusLin_SL` extracts only the length-one component:
 
-- `bMinusLin_SL_ι_mul_ι`: `bMinusLin_SL a (ι Z · ι W) = 0`. Grade-2 vanishing
-  via the TA-side `psiA_multi_succ_succ`.
-- `bMinusLin_SL_ι_mul_eps`: `bMinusLin_SL a (ι Z · Y) = ε(Y) • bMinusLin_SL a (ι Z)`.
-  The "B⁻ extracts the length-1 part" statement. Lifted from TA via
-  `algHomL_surjective` + `TA_linearMap_ext_tprod`.
-- `bMinusLin_SL_ι_star`: `bMinusLin_SL a (ι Y ★ B) = psiA_L a (circByT_total Y B)`.
-  The length-argument identity for the ι case of OG Prop 3.2.
+- `bMinusLin_SL_ι_mul_ι`: vanishing on products of two generators.
+- `bMinusLin_SL_ι_mul_eps`:
+  `bMinusLin_SL a (ι Z * Y) = ε(Y) • bMinusLin_SL a (ι Z)`.
+- `bMinusLin_SL_ι_star`:
+  `bMinusLin_SL a (ι Y ★ B) = psiA_L a (circByT_total Y B)`.
 -/
 
-/-- **Grade-2 vanishing**: `bMinusLin_SL a (ι Z · ι W) = 0`. Direct from
-    `psiA_multi_succ_succ` (psiA_tensor vanishes on grade ≥ 2 tprods). -/
+/-- `B⁻_a` vanishes on a product of two generators. -/
 private theorem bMinusLin_SL_ι_mul_ι (a : α) (Z W : LL) :
     bMinusLin_SL a (SymmetricAlgebra.ι ℤ LL Z * SymmetricAlgebra.ι ℤ LL W) = 0 := by
   -- ι Z * ι W = algHom (ι_TA Z * ι_TA W). Push to TA side.
   have h_alg : SymmetricAlgebra.ι ℤ LL Z * SymmetricAlgebra.ι ℤ LL W =
       PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := LL)
         (TensorAlgebra.ι ℤ Z * TensorAlgebra.ι ℤ W) := by
-    show _ = (SymmetricAlgebra.algHom ℤ LL).toLinearMap _
-    show _ = SymmetricAlgebra.algHom ℤ LL (TensorAlgebra.ι ℤ Z * TensorAlgebra.ι ℤ W)
-    rw [map_mul]
-    rfl
-  rw [h_alg, bMinusLin_SL_algHomL]
-  -- ι_TA Z * ι_TA W = tprod 1 ![Z] * tprod 1 ![W] = tprod 2 (![Z] ++ ![W]).
-  rw [PreLie.OudomGuinCircConstruct.ι_eq_tprod_one Z,
-      PreLie.OudomGuinCircConstruct.ι_eq_tprod_one W]
-  rw [PreLie.OudomGuinCircConstruct.tprod_mul_tprod]
-  -- psiA_tensor (tprod 2 ...) = psiA_multi 2 ... = 0.
-  rw [psiA_tensor_tprod, psiA_multi_succ_succ]
+    rw [algHomL_apply, map_mul, algHom_ι, algHom_ι]
+  rw [h_alg, bMinusLin_SL_algHomL,
+      PreLie.OudomGuinCircConstruct.ι_eq_tprod_one Z,
+      PreLie.OudomGuinCircConstruct.ι_eq_tprod_one W,
+      PreLie.OudomGuinCircConstruct.tprod_mul_tprod,
+      psiA_tensor_tprod, psiA_multi_succ_succ]
   rfl
 
-/-- Helper: `algebraMapInv ∘ algHomL` vanishes on positive-grade tprods.
-    `algHom (tprod (n+1) f) = ∏ ι(f i)` is a product of `n+1` ι-elements;
-    `algebraMapInv` of any ι is 0, so the product is 0 (for n+1 ≥ 1). -/
-private lemma algebraMapInv_algHom_tprod_succ (n : ℕ) (f : Fin (n+1) → LL) :
+/-- `algebraMapInv ∘ algHomL` vanishes on positive-grade tprods: the image is
+    a product of `n + 1` ι-elements, each killed by `algebraMapInv`. -/
+private theorem algebraMapInv_algHom_tprod_succ (n : ℕ) (f : Fin (n+1) → LL) :
     SymmetricAlgebra.algebraMapInv (M := LL) (R := ℤ)
         ((SymmetricAlgebra.algHom ℤ LL) (TensorAlgebra.tprod ℤ LL (n+1) f)) = 0 := by
   rw [TensorAlgebra.tprod_apply, _root_.map_list_prod, List.map_ofFn,
       _root_.map_list_prod, List.map_ofFn]
-  -- Goal: (List.ofFn (algebraMapInv ∘ algHom ∘ fun i => ι (f i))).prod = 0.
-  -- Each composed function maps to 0: algHom (ι x) = ι_SL x; algebraMapInv (ι_SL x) = 0.
-  simp only [Function.comp_def,
-             show ∀ x, SymmetricAlgebra.algHom ℤ LL (TensorAlgebra.ι ℤ x) =
-                 SymmetricAlgebra.ι ℤ LL x from fun _ => rfl,
-             SymmetricAlgebra.algebraMapInv_ι]
-  -- Goal: (List.ofFn (fun _ : Fin (n+1) => (0 : ℤ))).prod = 0.
+  simp only [Function.comp_def, algHom_ι, SymmetricAlgebra.algebraMapInv_ι]
   rw [List.ofFn_const, List.prod_replicate]
   exact zero_pow (Nat.succ_ne_zero n)
 
@@ -525,42 +423,29 @@ private theorem bMinusLin_SL_ι_mul_algHom_tprod (a : α) (Z : LL)
         ((SymmetricAlgebra.algHom ℤ LL) (TensorAlgebra.tprod ℤ LL n f)) •
         bMinusLin_SL a (SymmetricAlgebra.ι ℤ LL Z) := by
   -- ι Z = algHom (ι_TA Z); push mul through algHom.
-  rw [show SymmetricAlgebra.ι ℤ LL Z =
-        (SymmetricAlgebra.algHom ℤ LL) (TensorAlgebra.ι ℤ Z) from rfl]
-  rw [← _root_.map_mul,
+  rw [← algHom_ι Z, ← _root_.map_mul,
       PreLie.OudomGuinCircConstruct.ι_eq_tprod_one Z,
-      PreLie.OudomGuinCircConstruct.tprod_mul_tprod]
-  show bMinusLin_SL a (PreLie.OudomGuinCircConstruct.algHomL
-        (TensorAlgebra.tprod ℤ LL (1+n) (Fin.append (fun _ => Z) f))) = _
-  rw [bMinusLin_SL_algHomL, psiA_tensor_tprod]
+      PreLie.OudomGuinCircConstruct.tprod_mul_tprod,
+      ← algHomL_apply, bMinusLin_SL_algHomL, psiA_tensor_tprod]
   cases n with
   | zero =>
-    -- LHS: psiA_multi a 1 (Fin.append ![Z] _) = psiA_L a Z (since (1+0 = 1) by rfl).
-    -- RHS: algebraMapInv (algHom (tprod 0 f)) • bMinusLin_SL (algHom (tprod 1 ![Z])) = 1 • bMinusLin_SL (ι Z).
     show psiA_multi a 1 (Fin.append (fun _ : Fin 1 => Z) f) = _
     rw [psiA_multi_one_eq, psiA_multi_one_apply,
         show (Fin.append (fun _ : Fin 1 => Z) f) 0 = Z from rfl]
-    rw [show (TensorAlgebra.tprod ℤ LL 0 f : TensorAlgebra ℤ LL) = 1 from by
-      rw [TensorAlgebra.tprod_apply]; simp [List.ofFn_zero]]
-    rw [_root_.map_one, _root_.map_one, one_smul]
+    rw [tprod_zero f, _root_.map_one, _root_.map_one, one_smul]
     -- Convert RHS (algHom (tprod 1 ![Z])) back to (ι Z) and apply bMinusLin_SL_ι.
-    simp only [← PreLie.OudomGuinCircConstruct.ι_eq_tprod_one]
+    simp only [← PreLie.OudomGuinCircConstruct.ι_eq_tprod_one, algHom_ι]
     exact (bMinusLin_SL_ι a Z).symm
   | succ k =>
-    -- LHS: psiA_multi a (1+(k+1)) (...) = 0 (grade ≥ 2 vanishing).
-    -- RHS: algebraMapInv (algHom (tprod (k+1) _)) • _ = 0 • _ = 0 (positive grade).
+    -- Both sides vanish: grade ≥ 2 on the left, positive grade on the right.
     have h_multi_zero : psiA_multi a (1 + (k+1)) = 0 :=
       psiA_multi_eq_zero_of_ge_two a (by omega)
     rw [h_multi_zero]
     show (0 : SL) = _
     rw [algebraMapInv_algHom_tprod_succ k f, zero_smul]
 
-/-- **B⁻ extracts the length-1 part of a left ι-multiplication**: for any
-    `Z ∈ L` and `Y ∈ SL`, `bMinusLin_SL a (ι Z · Y) = ε(Y) • bMinusLin_SL a (ι Z)`.
-
-    Proof: lift `Y = algHomL z` via `algHomL_surjective`. Reduce to a
-    TA-level LinearMap equality `F = G` via `TA_linearMap_ext_tprod`. Each
-    `tprod n f` case is handled by `bMinusLin_SL_ι_mul_algHom_tprod`. -/
+/-- `B⁻_a` extracts the length-one part of a left ι-multiplication:
+    `bMinusLin_SL a (ι Z * Y) = ε(Y) • bMinusLin_SL a (ι Z)`. -/
 private theorem bMinusLin_SL_ι_mul_eps (a : α) (Z : LL) (Y : SL) :
     bMinusLin_SL a (SymmetricAlgebra.ι ℤ LL Z * Y) =
       SymmetricAlgebra.algebraMapInv (M := LL) Y •
@@ -575,25 +460,60 @@ private theorem bMinusLin_SL_ι_mul_eps (a : α) (Z : LL) (Y : SL) :
         (((SymmetricAlgebra.algebraMapInv (M := LL) (R := ℤ)).toLinearMap).comp
           (PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := LL)))
         (bMinusLin_SL a (SymmetricAlgebra.ι ℤ LL Z)) by
-    have := LinearMap.congr_fun h_eq z
-    simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
-               LinearMap.smulRight_apply, AlgHom.toLinearMap_apply] at this
-    exact this
+    simpa only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
+      LinearMap.smulRight_apply, AlgHom.toLinearMap_apply]
+      using LinearMap.congr_fun h_eq z
   apply PreLie.OudomGuinCircConstruct.TA_linearMap_ext_tprod
   intro n f
   simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
              LinearMap.smulRight_apply, AlgHom.toLinearMap_apply]
   exact bMinusLin_SL_ι_mul_algHom_tprod a Z n f
 
-/-- **Length-argument lemma** (the ι case of Piece C reduces to this): for
-    `Y ∈ L` and `B ∈ SL`,
-    `bMinusLin_SL a (ι Y ★ B) = psiA_L a (circByT_total Y B)`.
+/-- Counit-Leibniz rule for `B⁻_a`: since `B⁻_a` extracts the length-one
+    component, it is an `ε`-twisted derivation on `*`. -/
+private theorem bMinusLin_SL_mul_eps (a : α) (X Y : SL) :
+    bMinusLin_SL a (X * Y) =
+      SymmetricAlgebra.algebraMapInv (M := LL) X • bMinusLin_SL a Y +
+      SymmetricAlgebra.algebraMapInv (M := LL) Y • bMinusLin_SL a X := by
+  induction X using SymmetricAlgebra.induction generalizing Y with
+  | algebraMap r =>
+    -- X = r • 1; B⁻_a((r • 1) * Y) = r • B⁻_a Y.
+    rw [Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, map_smul,
+        map_smul, map_smul, bMinusLin_SL_one, map_one, smul_zero, smul_zero,
+        add_zero, smul_eq_mul, mul_one]
+  | ι Z =>
+    -- ε(ι Z) = 0, reduces to `bMinusLin_SL_ι_mul_eps`.
+    rw [bMinusLin_SL_ι_mul_eps, SymmetricAlgebra.algebraMapInv_ι, zero_smul, zero_add]
+  | mul X₁ X₂ ih₁ ih₂ =>
+    -- Reassociate, apply ih₁ at Y' = X₂ * Y, then ih₂ at Y' = Y.
+    rw [mul_assoc, ih₁ (X₂ * Y), ih₂ Y, ih₁ X₂, map_mul, mul_smul, smul_add,
+        smul_comm (SymmetricAlgebra.algebraMapInv (M := LL) X₁)
+          (SymmetricAlgebra.algebraMapInv (M := LL) Y),
+        smul_comm (SymmetricAlgebra.algebraMapInv (M := LL) X₂)
+          (SymmetricAlgebra.algebraMapInv (M := LL) Y),
+        smul_add, show (SymmetricAlgebra.algebraMapInv (M := LL) (X₁ * X₂)) =
+          SymmetricAlgebra.algebraMapInv (M := LL) X₁ *
+            SymmetricAlgebra.algebraMapInv (M := LL) X₂ from map_mul _ _ _,
+        mul_smul]
+    abel
+  | add X₁ X₂ ih₁ ih₂ =>
+    -- Linearity in X.
+    rw [add_mul, map_add, map_add, map_add, ih₁ Y, ih₂ Y]
+    simp only [add_smul, smul_add]
+    abel
 
-    Proof: unfold `★` via Def 2.9 to get a sum over Sweedler of
-    `(ι Y ○ B₁) · B₂ = ι(circByT_total Y B₁) · B₂`. Apply `bMinusLin_SL_ι_mul_eps`
-    to each summand: only the length-0 component of `B₂` contributes (giving
-    `ε(B₂) • bMinusLin_SL (ι(circByT_total Y B₁))`). Sum collapses via the
-    counit-comul triangle to `psiA_L a (circByT_total Y B)`. -/
+/-- `oudomGuinCirc (ι T) B = ι (circByT_total T B)` (definitional through
+    `circHom`). -/
+private theorem oudomGuinCirc_ι_apply (T : LL) (B : SL) :
+    oudomGuinCirc (R := ℤ) (SymmetricAlgebra.ι ℤ LL T) B =
+      SymmetricAlgebra.ι ℤ LL
+        (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ) T B) := by
+  rw [oudomGuinCirc_eq_ofConv, circHom_ι]
+  rfl
+
+/-- `bMinusLin_SL a (ι Y ★ B) = psiA_L a (circByT_total Y B)`. Unfolds `★`
+    (Def 2.9 of [oudom-guin-2008]) and collapses the Sweedler sum via the
+    counit-comul triangle. -/
 private theorem bMinusLin_SL_ι_star (a : α) (Y : LL) (B : SL) :
     bMinusLin_SL a (oudomGuinStar (SymmetricAlgebra.ι ℤ LL Y) B) =
       psiA_L a
@@ -613,10 +533,7 @@ private theorem bMinusLin_SL_ι_star (a : α) (Y : LL) (B : SL) :
               (SymmetricAlgebra.algebraMapInv (M := LL) (R := ℤ)).toLinearMap))) := by
     apply TensorProduct.ext'
     intro b₁ b₂
-    -- Compute LHS = bMinusLin_SL a (oudomGuinCirc (ι Y) b₁ * b₂)
-    --         = bMinusLin_SL a (ι (circByT_total Y b₁) * b₂)
-    --         = ε(b₂) • bMinusLin_SL a (ι (circByT_total Y b₁))
-    --         = ε(b₂) • psiA_L a (circByT_total Y b₁).
+    -- LHS reduces to ε(b₂) • psiA_L a (circByT_total Y b₁).
     have h_LHS :
         ((bMinusLin_SL a).comp ((LinearMap.mul' ℤ SL).comp
           (TensorProduct.map
@@ -626,16 +543,9 @@ private theorem bMinusLin_SL_ι_star (a : α) (Y : LL) (B : SL) :
           psiA_L a (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ) Y b₁) := by
       show (bMinusLin_SL a) ((LinearMap.mul' ℤ SL)
             (((oudomGuinCirc (R := ℤ) (SymmetricAlgebra.ι ℤ LL Y)) b₁) ⊗ₜ[ℤ] b₂)) = _
-      rw [LinearMap.mul'_apply]
-      -- Goal: bMinusLin_SL a (oudomGuinCirc (ι Y) b₁ * b₂) = ε(b₂) • psiA_L a (circByT_total Y b₁)
-      conv_lhs => rw [show oudomGuinCirc (R := ℤ) (SymmetricAlgebra.ι ℤ LL Y) b₁ =
-                          SymmetricAlgebra.ι ℤ LL
-                            (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ) Y b₁)
-                      from by rw [oudomGuinCirc_eq_ofConv, circHom_ι]; rfl]
-      rw [bMinusLin_SL_ι_mul_eps, bMinusLin_SL_ι]
-    -- Compute RHS = psiA_L a (circByT_total Y (b₁ * algebraMap (ε b₂)))
-    --         = psiA_L a (circByT_total Y (ε(b₂) • b₁))
-    --         = ε(b₂) • psiA_L a (circByT_total Y b₁).
+      rw [LinearMap.mul'_apply, oudomGuinCirc_ι_apply,
+          bMinusLin_SL_ι_mul_eps, bMinusLin_SL_ι]
+    -- RHS reduces to the same value.
     have h_RHS :
         (((psiA_L a).comp
           (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ) (L := LL) Y)).comp
@@ -664,10 +574,9 @@ private theorem bMinusLin_SL_ι_star (a : α) (Y : LL) (B : SL) :
   -- LHS of goal ≡ h_at_B's LHS (definitionally via oudomGuinStar_def + comulAlgHom.toLinearMap = comul).
   -- Reduce RHS of h_at_B to RHS of goal via counit triangle.
   refine h_at_B.trans ?_
-  -- Goal: psiA_L a (circByT_total Y (mul' (map id (algebraMap ∘ counit) cmB)))
-  --     = psiA_L a (circByT_total Y B)
-  -- Reduce inner: mul' (map id (algebraMap ∘ counit) cmB) = B via counit triangle.
-  -- Force CoalgebraStruct on the unfolded type via the Bialgebra instance directly.
+  -- Reduce mul' (map id (algebraMap ∘ counit) cmB) = B via the counit triangle.
+  -- The `letI`s force the `CoalgebraStruct` on the unfolded type; without them
+  -- instance synthesis fails on the `Coalgebra.comul` occurrences below.
   letI inst_B : Bialgebra ℤ (SymmetricAlgebra ℤ LL) := SymmetricAlgebra.instBialgebra ℤ LL
   letI inst_Co : Coalgebra ℤ (SymmetricAlgebra ℤ LL) := inst_B.toCoalgebra
   letI inst_C : CoalgebraStruct ℤ (SymmetricAlgebra ℤ LL) := inst_Co.toCoalgebraStruct
@@ -712,23 +621,23 @@ private theorem bMinusLin_SL_ι_star (a : α) (Y : LL) (B : SL) :
             cmB))) = _
   rw [h_inner]
 
-/-! ## §10: ckIso transport for `bMinusLin_SL`
+/-! ### Transport along `ckIsoSymmetricAlgebra`
 
-The transport identity `bMinusLin a (ckIso X) = ckIso (bMinusLin_SL a X)`
-for all X ∈ SL. The substantial work is the per-tprod-n induction over TA;
-the n ≥ 2 case uses CK ε-Leibniz (a symmetric ε-twisted Leibniz rule for
-the disjoint-union product on CK), which is proved separately. -/
+The transport identity `bMinusLin a (ckIso X) = ckIso (bMinusLin_SL a X)`,
+via an ε-twisted Leibniz rule for the disjoint-union product on the
+Connes-Kreimer side. -/
+
+section CKTransport
 
 open ConnesKreimer (counit counit_of' of'_add)
 open GrossmanLarson (of' bMinusBasis bMinusBasis_zero bMinusBasis_singleton_node
   bMinusBasis_eq_zero_of_not_singleton_a bMinusLin bMinusLin_of')
 
-/-! ### §10a: CK ε-Leibniz at basis level
+/-! ### Counit-Leibniz rule on forests
 
 `bMinusBasis a (F + G)` splits according to which of `F`, `G` is empty:
-- F = ∅: equals bMinusBasis a G
-- G = ∅: equals bMinusBasis a F
-- Both nonempty: equals 0 (F+G has card ≥ 2, not a singleton). -/
+it equals `bMinusBasis a G` when `F` is empty, `bMinusBasis a F` when `G`
+is empty, and `0` when both are nonempty. -/
 
 private theorem bMinusBasis_add (a : α)
     (F G : Forest (Nonplanar α)) :
@@ -761,13 +670,12 @@ private theorem bMinusBasis_add (a : α)
       have h2 : G.card ≥ 1 := Nat.one_le_iff_ne_zero.mpr hG
       omega
 
-/-! ### §10b: CK ε-Leibniz at basis-of'-of' level -/
+/-! ### Counit-Leibniz rule on forest products -/
 
-/-- CK ε-Leibniz on basis: for `of'(F) * of'(G) = of'(F + G)` (CK product),
-    the bMinusLin splits according to which side is empty.
-
-    Uses `ConnesKreimer.of'` (NOT `GrossmanLarson.of'`) and CK's `*`
-    (disjoint-union product, NOT GL's `productForest`). -/
+/-- The ε-twisted Leibniz rule on basis elements: under
+    `of' F * of' G = of' (F + G)`, `bMinusLin` splits according to which side
+    is empty. Uses `ConnesKreimer.of'` (not `GrossmanLarson.of'`) and the
+    disjoint-union product (not `productForest`). -/
 private theorem bMinusLin_of'_mul_of' (a : α) (F G : Forest (Nonplanar α)) :
     bMinusLin (R := ℤ) a
         ((ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α)) *
@@ -790,155 +698,420 @@ private theorem bMinusLin_of'_mul_of' (a : α) (F G : Forest (Nonplanar α)) :
     counit (ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α)) • bMinusBasis a G +
     counit (ConnesKreimer.of' G : ConnesKreimer ℤ (Nonplanar α)) • bMinusBasis a F
   rw [counit_of', counit_of', bMinusBasis_add]
-  by_cases hF : F.card = 0
-  · by_cases hG : G.card = 0
-    · simp [hF, hG]
-    · simp [hF, hG]
-  · by_cases hG : G.card = 0
-    · simp [hF, hG]
-    · simp [hF, hG]
+  by_cases hF : F.card = 0 <;> by_cases hG : G.card = 0 <;> simp [hF, hG]
 
-/-! ### §10c: Main transport identity (partial — see TODO)
+/-! ### The transport identity
 
-`bMinusLin a (ckIso X) = ckIso (bMinusLin_SL a X)` for all `X ∈ SL`.
+`bMinusLin a (ckIso X) = ckIso (bMinusLin_SL a X)` for all `X : SL`. The
+proof inducts on `X` via `SymmetricAlgebra.induction`. Two private helpers
+are added in service of the `mul` case: a CK-side counit-Leibniz rule
+(`bMinusLin_mul_eps`, bilinear extension of `bMinusLin_of'_mul_of'`) and a
+bridge identifying `counit ∘ ckIso` with `algebraMapInv` (`counit_ckIso`).
 
-**Status (2026-05-18)**: stated with `sorry`. Closure requires:
+Relocation candidates: `bMinusLin_mul_eps` belongs in `BMinus.lean` (CK
+substrate); deferred to avoid concurrent edits. -/
 
-1. **Full CK ε-Leibniz** (bilinear extension of `bMinusLin_of'_mul_of'`):
-   for general `X, Y : ConnesKreimer ℤ (Nonplanar α)`,
-   `bMinusLin a (X * Y) = counit X • bMinusLin a Y + counit Y • bMinusLin a X`.
-   Estimated 50-80 LOC via `Finsupp.induction_linear` on Y, then X.
-   Subtlety: type-alias discipline between `ConnesKreimer ℤ (Nonplanar α)`
-   and `Forest (Nonplanar α) →₀ ℤ`; explicit `show` casts needed.
+/-- CK-side counit-Leibniz for `bMinusLin`: bilinear extension of
+    `bMinusLin_of'_mul_of'` from `of' F`-basis elements to arbitrary CK
+    elements. Disjoint-union product (NOT GL); proof: realize both sides
+    as `R`-bilinear maps that agree on basis pairs. Relocation candidate
+    to `BMinus.lean`. -/
+private theorem bMinusLin_mul_eps [DecidableEq (Nonplanar α)] (a : α)
+    (X Y : ConnesKreimer ℤ (Nonplanar α)) :
+    bMinusLin (R := ℤ) a (X * Y) =
+      counit X • bMinusLin (R := ℤ) a Y +
+      counit Y • bMinusLin (R := ℤ) a X := by
+  -- Build the difference (LHS - RHS) as a bilinear map and show it vanishes on
+  -- basis pairs (of' F, of' G), hence on all (X, Y) by `mk₂`-extension.
+  -- Set L (X, Y) := bMinusLin a (X * Y) - counit X • bMinusLin a Y -
+  --                                       counit Y • bMinusLin a X.
+  -- L extends as a ℤ-bilinear map and vanishes on basis pairs by
+  -- `bMinusLin_of'_mul_of'`. Conclude `L X Y = 0`.
+  -- For concreteness we prove the difference is zero via Finsupp double
+  -- induction; each step uses only ℤ-linearity laws.
+  -- Reduce to a LinearMap-on-(X⊗Y) equality, then apply `mk₂` ext.
+  let CK : Type := ConnesKreimer ℤ (Nonplanar α)
+  -- Build the two sides as ℤ-bilinear maps `CK →ₗ[ℤ] CK →ₗ[ℤ] CK`.
+  -- LHS(X,Y) = bMinusLin a (X*Y); RHS(X,Y) = counit X • bMinusLin a Y +
+  --                                          counit Y • bMinusLin a X.
+  suffices h : ∀ F : Forest (Nonplanar α),
+      ∀ Z : ConnesKreimer ℤ (Nonplanar α),
+        bMinusLin (R := ℤ) a (ConnesKreimer.of' F * Z) =
+          counit (ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α)) •
+            bMinusLin (R := ℤ) a Z +
+          counit Z • bMinusLin (R := ℤ) a (ConnesKreimer.of' F) by
+    -- Bilinear extension: extend over X via Finsupp.induction_linear on X.
+    induction X using Finsupp.induction_linear with
+    | zero =>
+      -- LHS: bMinusLin a (0 * Y) = bMinusLin a 0 = 0.
+      -- RHS: counit 0 • _ + counit Y • bMinusLin a 0 = 0 • _ + counit Y • 0 = 0.
+      show bMinusLin (R := ℤ) a
+              ((0 : ConnesKreimer ℤ (Nonplanar α)) * Y) = _
+      rw [zero_mul, LinearMap.map_zero]
+      show (0 : ConnesKreimer ℤ (Nonplanar α)) =
+           counit (0 : ConnesKreimer ℤ (Nonplanar α)) • bMinusLin a Y +
+           counit Y • bMinusLin a (0 : ConnesKreimer ℤ (Nonplanar α))
+      rw [map_zero, zero_smul, zero_add, LinearMap.map_zero, smul_zero]
+    | add X₁ X₂ ih₁ ih₂ =>
+      -- After Finsupp.induction_linear, X₁ X₂ have type Forest →₀ ℤ; coerce
+      -- to CK by an opaque alias bound to the same term.
+      let X₁' : ConnesKreimer ℤ (Nonplanar α) := X₁
+      let X₂' : ConnesKreimer ℤ (Nonplanar α) := X₂
+      show bMinusLin (R := ℤ) a ((X₁' + X₂') * Y) =
+           counit (X₁' + X₂') • bMinusLin a Y +
+           counit Y • bMinusLin a (X₁' + X₂')
+      rw [add_mul, LinearMap.map_add, _root_.map_add, add_smul,
+          LinearMap.map_add, smul_add]
+      show bMinusLin (R := ℤ) a (X₁' * Y) + bMinusLin (R := ℤ) a (X₂' * Y) =
+        counit X₁' • bMinusLin a Y + counit X₂' • bMinusLin a Y +
+        (counit Y • bMinusLin a X₁' + counit Y • bMinusLin a X₂')
+      rw [ih₁, ih₂]
+      abel
+    | single F r =>
+      -- Reduce single F r = r • of' F, then apply h on of' F.
+      have hX : (Finsupp.single F r : ConnesKreimer ℤ (Nonplanar α)) =
+                r • ConnesKreimer.of' F := by
+        show Finsupp.single F r = r • Finsupp.single F (1 : ℤ)
+        rw [Finsupp.smul_single, smul_eq_mul, mul_one]
+      rw [hX]
+      show bMinusLin (R := ℤ) a ((r • ConnesKreimer.of' F) * Y) =
+           counit ((r • ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α))) •
+             bMinusLin a Y +
+           counit Y • bMinusLin a (r • ConnesKreimer.of' F)
+      rw [show ((r • ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α)) * Y) =
+              r • (ConnesKreimer.of' F * Y) from smul_mul_assoc r _ Y,
+          LinearMap.map_smul, h F Y, _root_.map_smul,
+          LinearMap.map_smul, smul_smul, mul_comm (counit Y) r, ← smul_smul,
+          smul_add]
+      congr 1
+      rw [smul_smul, smul_eq_mul]
+  -- Now prove h: for fixed of' F, the identity holds for all Z.
+  intro F Z
+  induction Z using Finsupp.induction_linear with
+  | zero =>
+    show bMinusLin (R := ℤ) a
+          (ConnesKreimer.of' F * (0 : ConnesKreimer ℤ (Nonplanar α))) = _
+    rw [mul_zero, LinearMap.map_zero]
+    show (0 : ConnesKreimer ℤ (Nonplanar α)) =
+         counit (ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α)) •
+           bMinusLin a (0 : ConnesKreimer ℤ (Nonplanar α)) +
+         counit (0 : ConnesKreimer ℤ (Nonplanar α)) •
+           bMinusLin a (ConnesKreimer.of' F)
+    rw [LinearMap.map_zero, smul_zero, map_zero, zero_smul, zero_add]
+  | add Z₁ Z₂ ih₁ ih₂ =>
+    let Z₁' : ConnesKreimer ℤ (Nonplanar α) := Z₁
+    let Z₂' : ConnesKreimer ℤ (Nonplanar α) := Z₂
+    show bMinusLin (R := ℤ) a (ConnesKreimer.of' F * (Z₁' + Z₂')) =
+      counit (ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α)) •
+        bMinusLin a (Z₁' + Z₂') +
+      counit (Z₁' + Z₂') • bMinusLin a (ConnesKreimer.of' F)
+    rw [mul_add, LinearMap.map_add]
+    show bMinusLin (R := ℤ) a (ConnesKreimer.of' F * Z₁') +
+         bMinusLin (R := ℤ) a (ConnesKreimer.of' F * Z₂') =
+         counit (ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α)) •
+           bMinusLin a (Z₁' + Z₂') +
+         counit (Z₁' + Z₂') • bMinusLin a (ConnesKreimer.of' F)
+    rw [ih₁, ih₂, LinearMap.map_add, smul_add, _root_.map_add, add_smul]
+    abel
+  | single G s =>
+    have hY : (Finsupp.single G s : ConnesKreimer ℤ (Nonplanar α)) =
+              s • ConnesKreimer.of' G := by
+      show Finsupp.single G s = s • Finsupp.single G (1 : ℤ)
+      rw [Finsupp.smul_single, smul_eq_mul, mul_one]
+    rw [hY]
+    show bMinusLin (R := ℤ) a
+            (ConnesKreimer.of' F * s • ConnesKreimer.of' G) =
+         counit (ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α)) •
+           bMinusLin a (s • ConnesKreimer.of' G) +
+         counit (s • ConnesKreimer.of' G :
+           ConnesKreimer ℤ (Nonplanar α)) •
+           bMinusLin a (ConnesKreimer.of' F)
+    -- LHS: mul_smul_comm + LinearMap.map_smul + basis identity + smul_add.
+    rw [mul_smul_comm s (ConnesKreimer.of' F) (ConnesKreimer.of' G),
+        LinearMap.map_smul, bMinusLin_of'_mul_of', smul_add]
+    -- RHS: LinearMap.map_smul on first, _root_.map_smul on second.
+    rw [LinearMap.map_smul, _root_.map_smul]
+    -- Goal: s • (counit (of' F) • bMinusLin a (of' G) + counit (of' G) • bMinusLin a (of' F))
+    --     decomposed via smul_add becomes
+    --   s • counit (of' F) • bMinusLin a (of' G) +
+    --   s • counit (of' G) • bMinusLin a (of' F)
+    -- = counit (of' F) • s • bMinusLin a (of' G) +
+    --   (s • counit (of' G)) • bMinusLin a (of' F)
+    congr 1
+    · rw [smul_comm s (counit (ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α)))]
+    · rw [smul_smul, smul_eq_mul]
 
-2. **TA-side per-tprod-n induction**: via `algHomL_surjective` +
-   `TA_linearMap_ext_tprod` + induction on `n`. For `n = 0` and `n = 1`
-   direct; for `n ≥ 2`, CK ε-Leibniz reduces to `0 = 0` because both
-   factor counits vanish (`ε(ckIso(SL.ι _)) = ε(SL.ι _) = 0` via
-   `SymmetricAlgebra.algebraMapInv_ι`).
+/-- Bridge: the CK counit pulled back along `ckIsoSymmetricAlgebra` equals
+    the SL counit `SymmetricAlgebra.algebraMapInv`. Both sides are AlgHoms
+    `SL →ₐ[ℤ] ℤ`; agree on `ι (single t 1)`. -/
+private theorem counit_ckIso [DecidableEq (Nonplanar α)] (X : SL) :
+    counit (ckIsoSymmetricAlgebra X) =
+    SymmetricAlgebra.algebraMapInv (M := InsertionAlgebra α) X := by
+  -- Show the AlgHoms are equal pointwise.
+  suffices h : (counit (R := ℤ) (T := Nonplanar α)).comp
+      ckIsoSymmetricAlgebra.toAlgHom =
+      SymmetricAlgebra.algebraMapInv (M := InsertionAlgebra α) (R := ℤ) by
+    exact congrArg (fun (φ : SL →ₐ[ℤ] ℤ) => φ X) h
+  -- Both AlgHoms on SL; the structure of SL = SymAlg ℤ LL gives us a
+  -- universal property via `SymmetricAlgebra.lift`. Use `algHom_ext`.
+  apply SymmetricAlgebra.algHom_ext
+  ext x
+  -- Goal: (counit ∘ₗ ckIso ∘ₗ ι) x = (algebraMapInv ∘ₗ ι) x.
+  -- Both are linear maps `LL →ₗ[ℤ] ℤ`; reduce via Finsupp.induction_linear on x.
+  refine Finsupp.induction_linear x ?_ ?_ ?_
+  · -- x = 0: both sides are 0 by linearity.
+    show counit (ckIsoSymmetricAlgebra (SymmetricAlgebra.ι ℤ LL 0)) =
+         SymmetricAlgebra.algebraMapInv
+           (M := InsertionAlgebra α) (SymmetricAlgebra.ι ℤ LL 0)
+    have h₀ : (SymmetricAlgebra.ι ℤ LL : LL →ₗ[ℤ] SL) 0 = (0 : SL) :=
+      LinearMap.map_zero _
+    rw [h₀, _root_.map_zero, _root_.map_zero, _root_.map_zero]
+  · intro x₁ x₂ ih₁ ih₂
+    -- ih₁, ih₂ are stated via `LinearMap.ext`'s composition. Unfold first.
+    have ih₁' : counit (ckIsoSymmetricAlgebra (SymmetricAlgebra.ι ℤ LL x₁)) =
+                SymmetricAlgebra.algebraMapInv
+                  (M := InsertionAlgebra α) (SymmetricAlgebra.ι ℤ LL x₁) := ih₁
+    have ih₂' : counit (ckIsoSymmetricAlgebra (SymmetricAlgebra.ι ℤ LL x₂)) =
+                SymmetricAlgebra.algebraMapInv
+                  (M := InsertionAlgebra α) (SymmetricAlgebra.ι ℤ LL x₂) := ih₂
+    show counit (ckIsoSymmetricAlgebra (SymmetricAlgebra.ι ℤ LL (x₁ + x₂))) =
+         SymmetricAlgebra.algebraMapInv
+           (M := InsertionAlgebra α) (SymmetricAlgebra.ι ℤ LL (x₁ + x₂))
+    have h_add : (SymmetricAlgebra.ι ℤ LL : LL →ₗ[ℤ] SL) (x₁ + x₂) =
+                  SymmetricAlgebra.ι ℤ LL x₁ + SymmetricAlgebra.ι ℤ LL x₂ :=
+      LinearMap.map_add _ _ _
+    rw [h_add, _root_.map_add, _root_.map_add, _root_.map_add, ih₁', ih₂']
+  · intro t r
+    have h_single : (Finsupp.single t r : InsertionAlgebra α) =
+        r • (Finsupp.single t 1 : InsertionAlgebra α) := by
+      rw [Finsupp.smul_single, smul_eq_mul, mul_one]
+    show counit (ckIsoSymmetricAlgebra
+            (SymmetricAlgebra.ι ℤ LL (Finsupp.single t r))) =
+         SymmetricAlgebra.algebraMapInv
+           (M := InsertionAlgebra α)
+           (SymmetricAlgebra.ι ℤ LL (Finsupp.single t r))
+    rw [h_single]
+    -- Push smul: ι (r • single t 1) = r • ι (single t 1).
+    rw [show (SymmetricAlgebra.ι ℤ LL (r • Finsupp.single t (1 : ℤ)) : SL) =
+            r • SymmetricAlgebra.ι ℤ LL (Finsupp.single t 1) from
+          LinearMap.map_smul (SymmetricAlgebra.ι ℤ LL) r _]
+    rw [_root_.map_smul, _root_.map_smul,
+        ckIsoSymmetricAlgebra_ι_single, counit_of', Multiset.card_singleton,
+        if_neg (by decide : ¬(1 : ℕ) = 0), smul_zero, _root_.map_smul,
+        SymmetricAlgebra.algebraMapInv_ι, smul_zero]
 
-   Estimated 80-120 LOC.
+/-- Product of `ιTree c` over a multiset `M` in SL, transported through
+    `ckIso`, equals `of' M` in CK. Used in the `ι x` case of
+    `bMinusLin_ckIso` to identify `ckIso (psiA_basis a t)` with
+    `bMinusBasis a {t}` when `rootLabel t = a`. -/
+private theorem ckIso_prod_ιTree [DecidableEq (Nonplanar α)]
+    (M : Multiset (Nonplanar α)) :
+    ckIsoSymmetricAlgebra ((M.map (fun c => ιTree c)).prod) =
+    (ConnesKreimer.of' M : ConnesKreimer ℤ (Nonplanar α)) := by
+  induction M using Multiset.induction with
+  | empty =>
+    simp only [Multiset.map_zero, Multiset.prod_zero, map_one]
+    exact (ConnesKreimer.of'_zero (R := ℤ) (T := Nonplanar α)).symm
+  | cons c M ih =>
+    simp only [Multiset.map_cons, Multiset.prod_cons, map_mul]
+    rw [ih]
+    -- Now: ckIso (ιTree c) * of' M = of' (c ::ₘ M)
+    show ckIsoSymmetricAlgebra
+            (SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofTree c)) *
+         (ConnesKreimer.of' M : ConnesKreimer ℤ (Nonplanar α)) =
+         ConnesKreimer.of' (c ::ₘ M)
+    show ckIsoSymmetricAlgebra
+            (SymmetricAlgebra.ι ℤ LL (Finsupp.single c (1 : ℤ))) *
+         (ConnesKreimer.of' M : ConnesKreimer ℤ (Nonplanar α)) =
+         ConnesKreimer.of' (c ::ₘ M)
+    rw [ckIsoSymmetricAlgebra_ι_single]
+    show (ConnesKreimer.of' ({c} : Multiset (Nonplanar α))
+            : ConnesKreimer ℤ (Nonplanar α)) *
+         ConnesKreimer.of' M = ConnesKreimer.of' (c ::ₘ M)
+    rw [← of'_add]
+    show ConnesKreimer.of' (({c} : Multiset (Nonplanar α)) + M) =
+         ConnesKreimer.of' (c ::ₘ M)
+    rw [Multiset.singleton_add]
 
-Total for closure: ~150-200 LOC additional. Targeted for the next session
-on this Piece. -/
-
-/-- **TODO**: The transport identity (Piece B). See header comment for
-    closure plan. -/
+/-- Transport of `B⁻_a` along `ckIsoSymmetricAlgebra`:
+    `bMinusLin a (ckIso X) = ckIso (bMinusLin_SL a X)`. Induction on `X`
+    via `SymmetricAlgebra.induction`: the `algebraMap`/`add` cases are
+    linearity, the `ι x` case routes through `ckIsoSymmetricAlgebra_ι_single`
+    + `ckIso_prod_ιTree`, and the `mul` case combines `bMinusLin_SL_mul_eps`
+    (SL side) with `bMinusLin_mul_eps` + `counit_ckIso` (CK side). -/
 theorem bMinusLin_ckIso [DecidableEq (Nonplanar α)] (a : α) (X : SL) :
     bMinusLin (R := ℤ) a (ckIsoSymmetricAlgebra X) =
     ckIsoSymmetricAlgebra (bMinusLin_SL a X) := by
-  sorry
+  induction X using SymmetricAlgebra.induction with
+  | algebraMap r =>
+    -- X = algebraMap r; ckIso commutes with algebraMap, bMinusLin_SL kills algebraMap.
+    -- LHS: bMinusLin (ckIso (algebraMap r)) = bMinusLin (algebraMap r) = r • bMinusLin 1 = 0.
+    -- RHS: ckIso (bMinusLin_SL (algebraMap r)) = ckIso 0 = 0.
+    have h_LHS : bMinusLin (R := ℤ) a
+        (ckIsoSymmetricAlgebra (algebraMap ℤ SL r)) = 0 := by
+      rw [ckIsoSymmetricAlgebra.commutes, Algebra.algebraMap_eq_smul_one,
+          LinearMap.map_smul]
+      show r • bMinusLin (R := ℤ) a (1 : ConnesKreimer ℤ (Nonplanar α)) = 0
+      -- bMinusLin a 1 = bMinusLin a (GL.of' 0) = bMinusBasis a 0 = 0.
+      -- Bridge ConnesKreimer.of'/GrossmanLarson.of' via `show` (def-eq).
+      rw [show (1 : ConnesKreimer ℤ (Nonplanar α)) =
+              ConnesKreimer.of' (0 : Forest (Nonplanar α)) from
+            (ConnesKreimer.of'_zero (R := ℤ) (T := Nonplanar α)).symm]
+      show r • bMinusLin (R := ℤ) a (GrossmanLarson.of' (0 : Forest (Nonplanar α))) = 0
+      rw [bMinusLin_of', bMinusBasis_zero, smul_zero]
+    have h_RHS : ckIsoSymmetricAlgebra (bMinusLin_SL a (algebraMap ℤ SL r)) = 0 := by
+      rw [Algebra.algebraMap_eq_smul_one]
+      show ckIsoSymmetricAlgebra (bMinusLin_SL a (r • (1 : SL))) = 0
+      rw [LinearMap.map_smul, bMinusLin_SL_one, smul_zero, _root_.map_zero]
+    rw [h_LHS, h_RHS]
+  | ι x =>
+    -- ι x case: reduce by Finsupp.induction_linear on x.
+    refine Finsupp.induction_linear x ?_ ?_ ?_
+    · -- x = 0; both sides 0.
+      show bMinusLin (R := ℤ) a (ckIsoSymmetricAlgebra
+              (SymmetricAlgebra.ι ℤ LL 0)) =
+           ckIsoSymmetricAlgebra (bMinusLin_SL a (SymmetricAlgebra.ι ℤ LL 0))
+      have h₀ : (SymmetricAlgebra.ι ℤ LL : LL →ₗ[ℤ] SL) 0 = (0 : SL) :=
+        LinearMap.map_zero _
+      rw [h₀, _root_.map_zero, _root_.map_zero, LinearMap.map_zero,
+          _root_.map_zero]
+    · -- x = x₁ + x₂; linearity.
+      intro x₁ x₂ ih₁ ih₂
+      show bMinusLin (R := ℤ) a (ckIsoSymmetricAlgebra
+              (SymmetricAlgebra.ι ℤ LL (x₁ + x₂))) =
+           ckIsoSymmetricAlgebra (bMinusLin_SL a
+              (SymmetricAlgebra.ι ℤ LL (x₁ + x₂)))
+      have h_add : (SymmetricAlgebra.ι ℤ LL : LL →ₗ[ℤ] SL) (x₁ + x₂) =
+                    SymmetricAlgebra.ι ℤ LL x₁ + SymmetricAlgebra.ι ℤ LL x₂ :=
+        LinearMap.map_add _ _ _
+      rw [h_add, _root_.map_add, LinearMap.map_add, LinearMap.map_add,
+          _root_.map_add, ih₁, ih₂]
+    · -- x = single t r.
+      intro t r
+      have h_single : (Finsupp.single t r : InsertionAlgebra α) =
+          r • (Finsupp.single t 1 : InsertionAlgebra α) := by
+        rw [Finsupp.smul_single, smul_eq_mul, mul_one]
+      show bMinusLin (R := ℤ) a (ckIsoSymmetricAlgebra
+              (SymmetricAlgebra.ι ℤ LL (Finsupp.single t r))) =
+           ckIsoSymmetricAlgebra (bMinusLin_SL a
+              (SymmetricAlgebra.ι ℤ LL (Finsupp.single t r)))
+      rw [h_single,
+          show (SymmetricAlgebra.ι ℤ LL (r • Finsupp.single t (1 : ℤ)) : SL) =
+              r • SymmetricAlgebra.ι ℤ LL (Finsupp.single t 1) from
+            LinearMap.map_smul (SymmetricAlgebra.ι ℤ LL) r _,
+          _root_.map_smul, LinearMap.map_smul, LinearMap.map_smul,
+          _root_.map_smul,
+          ckIsoSymmetricAlgebra_ι_single, bMinusLin_SL_ι]
+      -- Goal: r • bMinusLin a (of'{t}) = r • ckIso ((psiA_L a) (single t 1)).
+      -- Finsupp.single t 1 = InsertionAlgebra.ofTree t (definitionally).
+      show r • bMinusLin (R := ℤ) a
+              (ConnesKreimer.of' ({t} : Multiset (Nonplanar α))) =
+           r • ckIsoSymmetricAlgebra
+                (psiA_L a (InsertionAlgebra.ofTree t))
+      rw [psiA_L_ofTree]
+      -- Goal: r • bMinusLin a (of'{t}) = r • ckIso (psiA_basis a t)
+      congr 1
+      -- bMinusLin a (of'{t}) = bMinusBasis a {t}; case on rootLabel t = a.
+      show bMinusLin (R := ℤ) a (GrossmanLarson.of' ({t} : Forest (Nonplanar α))) =
+           ckIsoSymmetricAlgebra (psiA_basis a t)
+      rw [bMinusLin_of']
+      -- Split on rootLabel t = a.
+      letI : Decidable (Nonplanar.rootLabel t = a) := Classical.dec _
+      unfold psiA_basis
+      by_cases hlab : Nonplanar.rootLabel t = a
+      · -- rootLabel t = a: t = node a (rootChildren t); both sides = of'(rootChildren t).
+        rw [if_pos hlab]
+        rw [show t = Nonplanar.node a (Nonplanar.rootChildren t) by
+              rw [← hlab, Nonplanar.node_eta]]
+        rw [bMinusBasis_singleton_node, Nonplanar.rootChildren_node]
+        -- RHS: ckIso (∏ c, ιTree c) over rootChildren (node a (rootChildren t)).
+        -- After substitution, rootChildren (node a F) = F, so we get
+        -- ckIso (∏ c ∈ F, ιTree c) = of' F.
+        exact (ckIso_prod_ιTree _).symm
+      · -- rootLabel t ≠ a; both sides 0.
+        rw [if_neg hlab]
+        rw [show bMinusBasis (R := ℤ) a ({t} : Forest (Nonplanar α)) = 0 from by
+              apply bMinusBasis_eq_zero_of_not_singleton_a
+              rintro ⟨G', hG⟩
+              apply hlab
+              have hT : t = Nonplanar.node a G' := Multiset.singleton_inj.mp hG
+              rw [hT, Nonplanar.rootLabel_node]]
+        rw [_root_.map_zero]
+  | mul X Y ihX ihY =>
+    -- CK side: bMinusLin (ckIso (X*Y)) = bMinusLin (ckIso X * ckIso Y)
+    --        = counit (ckIso X) • bMinusLin (ckIso Y)
+    --        + counit (ckIso Y) • bMinusLin (ckIso X)
+    rw [_root_.map_mul, bMinusLin_mul_eps, counit_ckIso, counit_ckIso,
+        ihX, ihY]
+    -- SL side: bMinusLin_SL (X*Y) = ε X • bMinusLin_SL Y + ε Y • bMinusLin_SL X.
+    rw [bMinusLin_SL_mul_eps, _root_.map_add, _root_.map_smul, _root_.map_smul]
+  | add X Y ihX ihY =>
+    simp only [_root_.map_add]
+    rw [ihX, ihY]
 
-/-! ## §11: Piece D — tree decomposition `ι(node a A') = ι(•_a) ○ (∏ ι child)`
+end CKTransport
 
-OG paper §3 Prop 3.1 (page 9): for the free pre-Lie algebra of rooted
-trees `PL(X)`, the universal property gives the identity
+/-! ### Trees as circle products of root and children
+
+The root-grafting identity displayed in §3.1 of [oudom-guin-2008]: in the
+free pre-Lie algebra of rooted trees,
 
 ```
 • ∘ T₁ ... T_n  =  [tree with root • and children T₁, ..., T_n]
 ```
 
-In our setup (`InsertionAlgebra α` is the free pre-Lie algebra on `α`,
-generated by `ofTree (leaf a)` for a ∈ α), this lifts via `circ_ι_ι` and
-the Multiset.induction on A' (the children-multiset).
+Here `InsertionAlgebra α` is the free pre-Lie algebra on `α`, and the
+identity takes the form
+`ι (ofTree (node a A')) = ι (ofTree (leaf a)) ○ ∏ c ∈ A', ι (ofTree c)`
+(`iotaTree_node_via_circ`). -/
 
-Used in Piece C (OG Prop 3.2 proof) to write an arbitrary single tree
-in the canonical `singleton ○ children` form. -/
-
-/-- Helper: `leaf a = node a 0` in `Nonplanar α`. The singleton-vertex
-    tree is the empty-children node. -/
+/-- `leaf a = node a 0`: the singleton-vertex tree is the empty-children
+    node. -/
 theorem leaf_eq_node_zero (a : α) :
-    (Nonplanar.leaf a : Nonplanar α) = Nonplanar.node a 0 := by
-  show Nonplanar.mk (Planar.leaf a) =
-    Nonplanar.node a (Multiset.ofList [])
-  show Nonplanar.mk (Planar.node a []) = Nonplanar.node a (Multiset.ofList [])
-  -- node a (↑[]) = mk (.node a ([].map Quotient.out)) = mk (.node a [])
-  show Nonplanar.mk (Planar.node a []) =
-    Nonplanar.mk (Planar.node a (([] : List (Nonplanar α)).map Quotient.out))
-  rfl
+    (Nonplanar.leaf a : Nonplanar α) = Nonplanar.node a 0 := rfl
 
-/-! ### §11.A: Substrate helpers for the cancellation argument -/
+/-! ### Helpers for the cancellation argument -/
 
-/-- **Notation 2.2** (Oudom-Guin): Leibniz formula for `oudomGuinCirc · (ι X)`
-    applied to a multiset product. For any `f : β → SL` and `M : Multiset β`:
+/-- Leibniz formula for `○ ι X` over a multiset product (Notation 2.2 of
+    [oudom-guin-2008]):
 
-    `(M.map f).prod ○ ι X = Σ_{s ∈ M} ((M.erase s).map f).prod · (f s ○ ι X)`
+    `(M.map f).prod ○ ι X = Σ_{s ∈ M} ((M.erase s).map f).prod * (f s ○ ι X)`
 
-    Each summand "pulls out" the factor `f s`, applies `○ ι X` to it, and keeps
-    the rest of the product as-is. With duplicates in `M`: `erase` removes one
-    copy, so the multinomial coefficient is implicit in iterating `Multiset.map`.
-
-    Proof structure: `Multiset.induction` on `M`. Base case: `1 ○ ι X = 0 =
-    empty sum` via `one_circ` + `algebraMapInv_ι` (since `ι X` has zero scalar
-    part). Cons case `t ::ₘ M`: apply `oudomGuinCirc_mul_ι` (Leibniz form,
-    Prop 2.7.iii specialization), apply IH, then equate per-summand via
-    `Multiset.map_congr` (handling `(t::M).erase s = t :: M.erase s` for `s≠t`
-    and `(t::M).erase t = M` for `s = t` from `cons_erase`). -/
-private theorem prod_oudomGuinCirc_ι_aux {β : Type*} [DecidableEq β]
+    Each summand pulls out one factor `f s`, applies `○ ι X` to it, and keeps
+    the rest of the product. -/
+private theorem prod_oudomGuinCirc_ι {β : Type*} [DecidableEq β]
     (f : β → SL) (M : Multiset β) (X : LL) :
     oudomGuinCirc (R := ℤ) (M.map f).prod (SymmetricAlgebra.ι ℤ LL X) =
       (M.map (fun s => ((M.erase s).map f).prod *
         oudomGuinCirc (R := ℤ) (f s) (SymmetricAlgebra.ι ℤ LL X))).sum := by
   induction M using Multiset.induction with
   | empty =>
-    -- LHS: oudomGuinCirc 1 (ι X) = algebraMapInv (ι X) • 1 = 0 (since ι X has 0 scalar part)
-    -- RHS: empty sum = 0
     simp only [Multiset.map_zero, Multiset.prod_zero, Multiset.sum_zero]
     rw [one_circ, SymmetricAlgebra.algebraMapInv_ι]
     exact zero_smul _ _
   | cons t M ih =>
-    -- LHS: (f t * (M.map f).prod) ○ ι X
-    --    = (f t ○ ι X) * (M.map f).prod + f t * ((M.map f).prod ○ ι X)  [Leibniz]
-    --    = (f t ○ ι X) * (M.map f).prod + f t * (M.map g).sum  [by IH]
-    --      where g(s) = ((M.erase s).map f).prod * (f s ○ ι X)
-    -- RHS: ((t ::ₘ M).map g').sum where g'(s) = ((t ::ₘ M).erase s).map f).prod * (f s ○ ι X)
-    --    = g'(t) + (M.map g').sum
-    --    = (M.map f).prod * (f t ○ ι X) + (M.map g').sum  [erase_cons_head]
-    -- We need: (M.map g').sum = f t * (M.map g).sum.
-    -- For each s ∈ M: g'(s) = ((t ::ₘ M).erase s).map f).prod * (f s ○ ι X).
-    --   If s = t (t ∈ M): erase_cons_head → ((t ::ₘ M).erase t = M),
-    --     so g'(t) = (M.map f).prod * (f t ○ ι X) = (t ::ₘ M.erase t).map f).prod * (f t ○ ι X)
-    --     = f t * (M.erase t).map f).prod * (f t ○ ι X) = f t * g(t).  ✓
-    --   If s ≠ t: erase_cons_tail → ((t ::ₘ M).erase s = t ::ₘ M.erase s),
-    --     so g'(s) = (t ::ₘ M.erase s).map f).prod * (f s ○ ι X)
-    --     = f t * (M.erase s).map f).prod * (f s ○ ι X) = f t * g(s).  ✓
+    -- Leibniz on the head factor, IH on the tail; match termwise on s = t.
     rw [Multiset.map_cons, Multiset.prod_cons, oudomGuinCirc_mul_ι, ih]
     rw [Multiset.map_cons, Multiset.sum_cons, Multiset.erase_cons_head]
     rw [mul_comm ((M.map f).prod) (oudomGuinCirc (f t) _)]
     congr 1
-    -- Goal: f t * (M.map g).sum = (M.map g').sum where g/g' per above.
     rw [← Multiset.sum_map_mul_left]
     apply congrArg Multiset.sum
     apply Multiset.map_congr rfl
     intro s hs
-    -- Per-s: f t * (((M.erase s).map f).prod * (f s ○ ι X)) =
-    --        ((t ::ₘ M).erase s).map f).prod * (f s ○ ι X)
-    -- Split on s = t vs s ≠ t.
     by_cases hst : s = t
-    · -- s = t case: subst eliminates t, replacing with s.
-      subst hst
-      -- After subst: Context has M : Multiset β, s : β, hs : s ∈ M
-      -- Goal: f s * ((M.erase s).map f).prod * (f s ○ X) =
-      --       ((s ::ₘ M).erase s).map f).prod * (f s ○ X)
+    · subst hst
       have hM : M = s ::ₘ M.erase s := (Multiset.cons_erase hs).symm
       rw [Multiset.erase_cons_head]
-      -- Goal: f s * ((M.erase s).map f).prod * (f s ○ X) = (M.map f).prod * (f s ○ X)
       conv_rhs => rw [hM, Multiset.map_cons, Multiset.prod_cons]
       ring
-    · -- s ≠ t case. (t :: M).erase s = t :: M.erase s
-      have h_ne : t ≠ s := Ne.symm hst
+    · have h_ne : t ≠ s := Ne.symm hst
       rw [Multiset.erase_cons_tail (s := M) h_ne, Multiset.map_cons,
           Multiset.prod_cons]
       ring
 
-/-! ### Substrate for `insertSum_node_decompose`
-
-The decomposition uses two helpers: a Multiset cons/+ swap and a
-prefix-generalized list-induction lemma. -/
-
-/-- Multiset identity: `B + (x ::ₘ C) = (x ::ₘ B) + C`. A single cons can
-    swap from "right of +" to "left of +". -/
-private lemma cons_add_swap {β : Type*} (x : β) (B C : Multiset β) :
+/-- Multiset identity: `B + (x ::ₘ C) = (x ::ₘ B) + C`. -/
+private theorem cons_add_swap {β : Type*} (x : β) (B C : Multiset β) :
     B + (x ::ₘ C) = (x ::ₘ B) + C := by
   rw [Multiset.add_cons, ← Multiset.cons_add]
 
@@ -1011,12 +1184,9 @@ private theorem insertSumList_bind_lift_aux [DecidableEq (Nonplanar α)]
         rw [Multiset.erase_cons_tail (s := ↑(cs'.map Nonplanar.mk)) hne]
         exact (cons_add_swap (Nonplanar.mk e) pre _).symm
 
-/-- **Nonplanar.insertSum node decomposition** (Multiset.bind form): grafting
-    `c` at each vertex of `node a A''` splits into one root-graft summand
-    `node a (c ::ₘ A'')` plus a bind over `A''` of subtree-grafts at each
-    child `d ∈ A''`. Proof: descend through planar representatives, apply
-    `Planar.insertSum_node` then bridge to the bind via the prefix-generalized
-    `insertSumList_bind_lift_aux`. -/
+/-- Grafting `c` at each vertex of `node a A''` splits into the root-graft
+    summand `node a (c ::ₘ A'')` plus a bind over `A''` of subtree-grafts at
+    each child `d ∈ A''`. -/
 private theorem insertSum_node_decompose [DecidableEq (Nonplanar α)]
     (a : α) (A'' : Multiset (Nonplanar α)) (c : Nonplanar α) :
     Nonplanar.insertSum (Nonplanar.node a A'') c =
@@ -1078,8 +1248,7 @@ private theorem insertSum_node_decompose [DecidableEq (Nonplanar α)]
       simp only [Multiset.cons_add, Multiset.zero_add]
     rw [hLHS_eq, insertSumList_bind_lift_aux (α := α) a 0 cs c_pl, hRHS_eq]
 
-/-- Linearity of `ι ∘ ofMultiset`: `ι(ofMultiset M) = Σ_{t ∈ M} ι(ofTree t)`.
-    Mechanical Multiset.induction on M. -/
+/-- `ι (ofMultiset M) = Σ_{t ∈ M} ι (ofTree t)`. -/
 private theorem iota_ofMultiset (M : Multiset (Nonplanar α)) :
     SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofMultiset M) =
       (M.map (fun t => SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofTree t))).sum := by
@@ -1091,25 +1260,16 @@ private theorem iota_ofMultiset (M : Multiset (Nonplanar α)) :
     rw [InsertionAlgebra.ofMultiset_cons, map_add, ih,
         Multiset.map_cons, Multiset.sum_cons]
 
-/-! ### §11.B: Main theorem — `iotaTree_node_via_circ` via strong cardinality
-induction -/
+/-! ### The tree-decomposition identity -/
 
-/-- **Piece D**: every nonplanar tree is the OG circ-product of its
-    singleton-vertex root with its children-forest.
+/-- Every nonplanar tree is the circle product of its singleton-vertex root
+    with its children-forest:
 
-    `ι(ofTree (node a A')) = ι(ofTree (leaf a)) ○ (∏ c ∈ A', ι(ofTree c))`
+    `ι (ofTree (node a A')) = ι (ofTree (leaf a)) ○ ∏ c ∈ A', ι (ofTree c)`
 
-    OG paper §3 Prop 3.1 (page 9): for the free pre-Lie algebra of rooted
-    trees, the universal property gives this identity.
-
-    **Proof strategy**: strong induction on `A'.card`. The cancellation
-    argument requires the IH at multisets of cardinality `n - 1` of the
-    form `d' ::ₘ A''.erase d` where `d ∈ A''`, `d' ∈ insertSum d c` — these
-    have `card = 1 + (n - 2) = n - 1 < n`. NB: weight is NOT a valid
-    induction measure: weight is conserved exactly under subtree-grafting
-    (weight `node a (d' ::ₘ A''.erase d) = 1 + weight(c) + weight(A'') =
-    weight(node a (c ::ₘ A''))`); only cardinality of the children-multiset
-    strictly decreases. -/
+    This is the root-grafting identity displayed in §3.1 of
+    [oudom-guin-2008]. The induction is on the children-multiset cardinality;
+    weight is conserved by subtree grafting and is not a valid measure. -/
 theorem iotaTree_node_via_circ (a : α) (A' : Multiset (Nonplanar α)) :
     SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofTree (Nonplanar.node a A')) =
     oudomGuinCirc
@@ -1215,35 +1375,22 @@ theorem iotaTree_node_via_circ (a : α) (A' : Multiset (Nonplanar α)) :
                 (Nonplanar.insertSum d c).map (fun d' =>
                   oudomGuinCirc (R := ℤ) ιa
                     (((d' ::ₘ A''.erase d).map f).prod))) from ?_]
-      · -- Now LHS: ιa ○ Qιc. RHS: bind-of-IH-applied sum.
-        -- Compute LHS via Notation 2.2 + ι linearity.
+      · -- Compute the LHS via the Leibniz formula + ι linearity.
         show oudomGuinCirc (R := ℤ) ιa Qιc = _
-        -- Unfold Qιc := oudomGuinCirc Q (ι c).
         show oudomGuinCirc (R := ℤ) ιa
           (oudomGuinCirc (R := ℤ) Q
             (SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofTree c))) = _
-        -- Q = (A''.map f).prod. Apply Notation 2.2 on Q ○ ι c.
         rw [show Q = (A''.map f).prod from rfl,
-            prod_oudomGuinCirc_ι_aux f A'' (InsertionAlgebra.ofTree c)]
-        -- Inner: Q ○ ι c = (A''.map (fun d => (A''.erase d).map f).prod * (f d ○ ι c))).sum.
-        -- Apply ιa ○ _ linearity to distribute over the outer sum.
+            prod_oudomGuinCirc_ι f A'' (InsertionAlgebra.ofTree c)]
         rw [map_multiset_sum, Multiset.map_map]
-        -- LHS: (A''.map (ιa ○ ·) ∘ (fun d => ...)).sum.
-        -- Rewrite per d: ιa ○ ((A''.erase d).map f).prod * (f d ○ ι c)) = (per d sum).
-        -- The RHS is a bind: Σ_{d ∈ A''} (insertSum d c).map (...).sum.
-        -- Reformulate the RHS using Multiset.sum_bind:
         rw [Multiset.sum_bind]
-        -- Now both sides are sums over A''. Show termwise equality.
+        -- Both sides are sums over A''; match termwise.
         apply congrArg Multiset.sum
         apply Multiset.map_congr rfl
         intro d hd
         simp only [Function.comp_apply]
-        -- Per-d goal: ιa ○ (Md * (f d ○ ι c)) =
-        --   (insertSum d c).map (fun d' => ιa ○ ((d' ::ₘ A''.erase d).map f).prod).sum
-        -- where Md = ((A''.erase d).map f).prod.
-        -- Step 1: convert (d' ::ₘ A''.erase d).map f).prod = f d' * Md
         simp only [Multiset.map_cons, Multiset.prod_cons]
-        -- Step 2: replace f d ○ ι c = ι(d * c) = ι(ofMultiset (insertSum d c))
+        -- f d ○ ι c = ι (ofMultiset (insertSum d c)).
         have h_fd_circ : oudomGuinCirc (R := ℤ) (f d)
             (SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofTree c)) =
             SymmetricAlgebra.ι ℤ LL
@@ -1254,11 +1401,9 @@ theorem iotaTree_node_via_circ (a : α) (A' : Multiset (Nonplanar α)) :
             (SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofTree c)) = _
           rw [circ_ι_ι, InsertionAlgebra.ofTree_mul_ofTree]
         rw [h_fd_circ]
-        -- Step 3: distribute ιa ○ (Md * ι(ofMultiset (insertSum d c)))
-        -- via iota_ofMultiset and linearity.
         rw [iota_ofMultiset, ← Multiset.sum_map_mul_left, map_multiset_sum,
             Multiset.map_map]
-        -- Both sides are sums over (insertSum d c). Match termwise.
+        -- Both sides are sums over (insertSum d c); match termwise.
         apply congrArg Multiset.sum
         apply Multiset.map_congr rfl
         intro d' _
@@ -1271,24 +1416,13 @@ theorem iotaTree_node_via_circ (a : α) (A' : Multiset (Nonplanar α)) :
         intro d' hd'
         exact h_inner d hd d' hd'
 
-/-! ### §11.C: Helpers for the ι case of OG Prop 3.2 (`psiA_L_circByT_total_eq`)
+/-! ### The circle-product identity for `psiA_L`
 
-Three helpers and the main identity, all consumed by `bMinusLin_SL_oudomGuinStar`'s
-ι branch (§12). Stated separately so each helper's proof can be inspected
-independently:
+`psiA_L_circByT_total_eq`:
+`psiA_L a (circByT_total Y B) = oudomGuinStar (psiA_L a Y) B`, consumed by
+the `ι` case of `bMinusLin_SL_oudomGuinStar`. -/
 
-- `psiA_L_ofMultiset`: linearity over multiset sums.
-- `psiA_L_mul_eq` (L-side cocycle): bilinear extension to the basis case;
-  substantive math via `insertSum_node_decompose` + `prod_oudomGuinCirc_ι_aux`.
-- `psiA_L_circByT_leaf_eq_id` (key lemma): TA-descent + n-induction;
-  cancellation via `oudomGuinCirc_algHomL_tprod_ι`.
-- `psiA_L_circByT_leaf_eq_zero` (a' ≠ a analog): same descent, IH ≡ 0.
-- `psiA_L_circByT_total_eq`: main identity; uses Piece D
-  (`iotaTree_node_via_circ`) + 2.8.v (`circ_assoc_via_comul`) +
-  `bMinusLin_SL_ι` bridge + Helper 2/3 case split. -/
-
-/-- Linearity of `psiA_L` over `ofMultiset`: `psiA_L a (ofMultiset M) =
-    sum of psiA_basis a applied termwise`. Direct multiset induction. -/
+/-- `psiA_L a (ofMultiset M) = (M.map (psiA_basis a)).sum`. -/
 private theorem psiA_L_ofMultiset (a : α) (M : Multiset (Nonplanar α)) :
     psiA_L a (InsertionAlgebra.ofMultiset M) =
       (M.map (psiA_basis a)).sum := by
@@ -1300,29 +1434,25 @@ private theorem psiA_L_ofMultiset (a : α) (M : Multiset (Nonplanar α)) :
     rw [InsertionAlgebra.ofMultiset_cons, map_add, ih,
         Multiset.map_cons, Multiset.sum_cons, psiA_L_ofTree]
 
-/-- Closed-form for `psiA_basis a (node a A)` (self-color case):
-    `((A.map ιTree).prod)`. -/
-private lemma psiA_basis_node_self (a : α) (A : Multiset (Nonplanar α)) :
+/-- Closed form for `psiA_basis a (node a A)` (self-color case):
+    `(A.map ιTree).prod`. -/
+private theorem psiA_basis_node_self (a : α) (A : Multiset (Nonplanar α)) :
     psiA_basis a (Nonplanar.node a A) =
       (A.map (fun c => ιTree c)).prod := by
   unfold psiA_basis
   rw [Nonplanar.rootLabel_node, Nonplanar.rootChildren_node]
   exact if_pos rfl
 
-/-- Closed-form for `psiA_basis a (node a' A)` (off-color case): `0`. -/
-private lemma psiA_basis_node_neq (a a' : α) (h : a' ≠ a)
+/-- Closed form for `psiA_basis a (node a' A)` (off-color case): `0`. -/
+private theorem psiA_basis_node_ne (a a' : α) (h : a' ≠ a)
     (A : Multiset (Nonplanar α)) :
     psiA_basis a (Nonplanar.node a' A) = 0 := by
   unfold psiA_basis
   rw [Nonplanar.rootLabel_node]
   exact if_neg h
 
-/-- **L-side cocycle for `psiA_L`** (Helper 1 of `psiA_L_circByT_total_eq`):
-    `psiA_L a (Y * Z) = (psiA_L a Y) ○ ι Z + (psiA_L a Y) · ι Z` for `Y, Z ∈ L`.
-
-    Proof: bilinear extension to basis case `(Y, Z) = (ofTree t, ofTree s)`,
-    decomposed via `insertSum_node_decompose`; LHS bind-sum matches
-    `Q ○ ι(ofTree s)` via `prod_oudomGuinCirc_ι_aux` + `iota_ofMultiset`. -/
+/-- Cocycle rule for `psiA_L` on the insertion algebra:
+    `psiA_L a (Y * Z) = (psiA_L a Y) ○ ι Z + psiA_L a Y * ι Z`. -/
 private theorem psiA_L_mul_eq [DecidableEq (Nonplanar α)]
     (a : α) (Y Z : LL) :
     psiA_L a (Y * Z) =
@@ -1365,46 +1495,17 @@ private theorem psiA_L_mul_eq [DecidableEq (Nonplanar α)]
            oudomGuinCirc (R := ℤ) (psiA_L a Y')
              (SymmetricAlgebra.ι ℤ LL Z) +
            psiA_L a Y' * SymmetricAlgebra.ι ℤ LL Z
-      have hY : Y' = r • InsertionAlgebra.ofTree t :=
-        (Finsupp.smul_single_one t r).symm
-      rw [hY]
-      have h_psi_smul :
-          psiA_L a (r • InsertionAlgebra.ofTree t) =
-            r • psiA_L a (InsertionAlgebra.ofTree t) :=
-        map_smul _ _ _
-      have h_LHS_eq :
-          psiA_L a ((r • InsertionAlgebra.ofTree t) * Z) =
-            r • psiA_L a (InsertionAlgebra.ofTree t * Z) := by
-        rw [smul_mul_assoc, map_smul]
-      have h_oudom_smul :
-          oudomGuinCirc (R := ℤ) (psiA_L a (r • InsertionAlgebra.ofTree t))
-              (SymmetricAlgebra.ι ℤ LL Z) =
-            r • oudomGuinCirc (R := ℤ) (psiA_L a (InsertionAlgebra.ofTree t))
-              (SymmetricAlgebra.ι ℤ LL Z) := by
-        rw [h_psi_smul]
-        rw [show oudomGuinCirc (R := ℤ)
+      rw [show Y' = r • InsertionAlgebra.ofTree t from
+            (Finsupp.smul_single_one t r).symm,
+          smul_mul_assoc, map_smul, map_smul,
+          show oudomGuinCirc (R := ℤ)
               (r • psiA_L a (InsertionAlgebra.ofTree t))
               (SymmetricAlgebra.ι ℤ LL Z) =
-              r • oudomGuinCirc (R := ℤ)
-                (psiA_L a (InsertionAlgebra.ofTree t))
-                (SymmetricAlgebra.ι ℤ LL Z) from by
-          have := LinearMap.congr_fun
-            ((oudomGuinCirc (R := ℤ)).map_smul r
-              (psiA_L a (InsertionAlgebra.ofTree t)))
-            (SymmetricAlgebra.ι ℤ LL Z)
-          simp only [LinearMap.smul_apply] at this
-          exact this]
-      have h_RHS_mul :
-          psiA_L a (r • InsertionAlgebra.ofTree t) *
-              SymmetricAlgebra.ι ℤ LL Z =
-            r • (psiA_L a (InsertionAlgebra.ofTree t) *
-                  SymmetricAlgebra.ι ℤ LL Z) := by
-        rw [h_psi_smul, smul_mul_assoc]
-      rw [h_LHS_eq, h_oudom_smul, h_RHS_mul, ← smul_add]
+            r • oudomGuinCirc (R := ℤ) (psiA_L a (InsertionAlgebra.ofTree t))
+              (SymmetricAlgebra.ι ℤ LL Z) from
+            LinearMap.congr_fun ((oudomGuinCirc (R := ℤ)).map_smul r _) _,
+          smul_mul_assoc, ← smul_add]
       congr 1
-      -- Clear the Z-dependent helper hypotheses so the inner induction's IHs
-      -- don't get cluttered with preconditions.
-      clear h_LHS_eq h_oudom_smul h_RHS_mul h_psi_smul hY
       -- Inner Z-extension via Finsupp.induction_linear.
       induction Z using Finsupp.induction_linear with
       | zero =>
@@ -1436,24 +1537,10 @@ private theorem psiA_L_mul_eq [DecidableEq (Nonplanar α)]
                (SymmetricAlgebra.ι ℤ LL Z') +
              psiA_L a (InsertionAlgebra.ofTree t) *
                SymmetricAlgebra.ι ℤ LL Z'
-        have hZ : Z' = u • InsertionAlgebra.ofTree s :=
-          (Finsupp.smul_single_one s u).symm
-        rw [hZ]
-        have h_RHS_circ :
-            oudomGuinCirc (R := ℤ) (psiA_L a (InsertionAlgebra.ofTree t))
-              (SymmetricAlgebra.ι ℤ LL (u • InsertionAlgebra.ofTree s)) =
-            u • oudomGuinCirc (R := ℤ) (psiA_L a (InsertionAlgebra.ofTree t))
-              (SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofTree s)) := by
-          rw [map_smul]
-          exact (oudomGuinCirc (R := ℤ)
-            (psiA_L a (InsertionAlgebra.ofTree t))).map_smul u _
-        have h_RHS_mul :
-            psiA_L a (InsertionAlgebra.ofTree t) *
-                SymmetricAlgebra.ι ℤ LL (u • InsertionAlgebra.ofTree s) =
-              u • (psiA_L a (InsertionAlgebra.ofTree t) *
-                    SymmetricAlgebra.ι ℤ LL (InsertionAlgebra.ofTree s)) := by
-          rw [map_smul, mul_smul_comm]
-        rw [mul_smul_comm, map_smul, h_RHS_circ, h_RHS_mul, ← smul_add]
+        rw [show Z' = u • InsertionAlgebra.ofTree s from
+              (Finsupp.smul_single_one s u).symm,
+            mul_smul_comm, map_smul, map_smul, map_smul, mul_smul_comm,
+            ← smul_add]
         congr 1
         exact h_basis t s
   -- Basis case.
@@ -1478,7 +1565,7 @@ private theorem psiA_L_mul_eq [DecidableEq (Nonplanar α)]
     rw [add_comm (oudomGuinCirc (R := ℤ) Q ιs) (Q * ιs)]
     congr 1
     -- Need: bind-sum = Q ○ ιs.
-    rw [hQ, prod_oudomGuinCirc_ι_aux (fun c => ιTree c) A'
+    rw [hQ, prod_oudomGuinCirc_ι (fun c => ιTree c) A'
           (InsertionAlgebra.ofTree s)]
     rw [Multiset.map_bind]
     rw [show A'.bind (fun d =>
@@ -1513,7 +1600,7 @@ private theorem psiA_L_mul_eq [DecidableEq (Nonplanar α)]
     ring
   · -- Case a' ≠ a.
     have h_zero : ∀ (B : Multiset (Nonplanar α)),
-        psiA_basis a (Nonplanar.node a' B) = 0 := psiA_basis_node_neq a a' ha
+        psiA_basis a (Nonplanar.node a' B) = 0 := psiA_basis_node_ne a a' ha
     -- Show LHS = 0 and RHS = 0 separately.
     have h_LHS_zero : psiA_basis a (Nonplanar.node a' (s ::ₘ A')) +
         ((A'.bind (fun d =>
@@ -1548,155 +1635,108 @@ private theorem psiA_L_mul_eq [DecidableEq (Nonplanar α)]
           zero_mul, add_zero]
     rw [h_LHS_zero, h_RHS_zero]
 
-/-- **Key lemma** (Helper 2 of `psiA_L_circByT_total_eq`): for `X ∈ SL`,
-    `psiA_L a (circByT_total (leaf a) X) = X`.
+open PreLie.OudomGuinCircConstruct in
+/-- Peel the last factor of a tprod through `algHomL`:
+    `algHomL (tprod (n+1) f) = algHomL (tprod n (init f)) * ι (f (last n))`. -/
+private theorem algHomL_tprod_succ (n : ℕ) (f : Fin (n + 1) → LL) :
+    algHomL (R := ℤ) (L := LL) (TensorAlgebra.tprod ℤ LL (n + 1) f) =
+      algHomL (R := ℤ) (L := LL) (TensorAlgebra.tprod ℤ LL n (Fin.init f)) *
+        SymmetricAlgebra.ι ℤ LL (f (Fin.last n)) := by
+  have h_tprod_succ :
+      TensorAlgebra.tprod ℤ LL (n + 1) f =
+      TensorAlgebra.tprod ℤ LL n (Fin.init f) *
+        TensorAlgebra.ι ℤ (f (Fin.last n)) := by
+    conv_lhs => rw [show f = Fin.snoc (Fin.init f) (f (Fin.last n)) from
+      (Fin.snoc_init_self f).symm]
+    rw [Fin.snoc_eq_append, ι_eq_tprod_one, ← tprod_mul_tprod]
+    congr 1
+  rw [h_tprod_succ, algHomL_apply, map_mul]
+  rfl
 
-    TA-descent + induction on `n`. n+1 case: apply `psiA_L_mul_eq` to the
-    leading term of `circTMultilinear_succ`, then `oudomGuinCirc_algHomL_tprod_ι`
-    cancels the negative sum. -/
+/-- TA-descent for `psiA_L a ∘ circByT_total T`: its value on `X : SL` is
+    `g X` once the per-tprod values match `g ∘ₗ algHomL`. -/
+private theorem psiA_L_circByT_eq_of_per_tprod (a : α) (T : LL)
+    (g : SL →ₗ[ℤ] SL)
+    (h : ∀ (n : ℕ) (f : Fin n → LL),
+      psiA_L a (PreLie.OudomGuinCircConstruct.circTMultilinear ℤ T n f) =
+      g (PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := LL)
+          (TensorAlgebra.tprod ℤ LL n f)))
+    (X : SL) :
+    psiA_L a
+        (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ) T X) = g X := by
+  obtain ⟨z, rfl⟩ := PreLie.OudomGuinCircConstruct.algHomL_surjective X
+  have h_eq :
+      (psiA_L a).comp
+        ((PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ) T).comp
+          (PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := LL))) =
+      g.comp (PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := LL)) := by
+    apply PreLie.OudomGuinCircConstruct.TA_linearMap_ext_tprod
+    intro n f
+    simp only [LinearMap.comp_apply]
+    have h_tot := LinearMap.congr_fun
+      (PreLie.OudomGuinCircConstruct.circByT_total_comp_algHomL (R := ℤ) T)
+      (TensorAlgebra.tprod ℤ LL n f)
+    simp only [LinearMap.comp_apply] at h_tot
+    rw [h_tot, PreLie.OudomGuinCircConstruct.circTTensor_tprod]
+    exact h n f
+  exact LinearMap.congr_fun h_eq z
+
+/-- `psiA_L a` inverts grafting onto an `a`-colored leaf:
+    `psiA_L a (circByT_total (leaf a) X) = X`. -/
 private theorem psiA_L_circByT_leaf_eq_id [DecidableEq (Nonplanar α)]
     (a : α) (X : SL) :
     psiA_L a (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ)
       (InsertionAlgebra.ofTree (Nonplanar.leaf a)) X) = X := by
   classical
-  obtain ⟨z, rfl⟩ := PreLie.OudomGuinCircConstruct.algHomL_surjective X
-  suffices h_per_tprod : ∀ (n : ℕ) (f : Fin n → LL),
+  have h : ∀ (n : ℕ) (f : Fin n → LL),
       psiA_L a (PreLie.OudomGuinCircConstruct.circTMultilinear ℤ
         (InsertionAlgebra.ofTree (Nonplanar.leaf a)) n f) =
       PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := LL)
-        (TensorAlgebra.tprod ℤ LL n f) by
-    have h_eq :
-        (psiA_L a).comp
-          ((PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ)
-            (InsertionAlgebra.ofTree (Nonplanar.leaf a))).comp
-          (PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := LL))) =
-        PreLie.OudomGuinCircConstruct.algHomL := by
-      apply PreLie.OudomGuinCircConstruct.TA_linearMap_ext_tprod
-      intro n f
-      simp only [LinearMap.comp_apply]
-      have h_tot := LinearMap.congr_fun
-        (PreLie.OudomGuinCircConstruct.circByT_total_comp_algHomL (R := ℤ)
-          (InsertionAlgebra.ofTree (Nonplanar.leaf a)))
-        (TensorAlgebra.tprod ℤ LL n f)
-      simp only [LinearMap.comp_apply] at h_tot
-      rw [h_tot, PreLie.OudomGuinCircConstruct.circTTensor_tprod]
-      exact h_per_tprod n f
-    exact LinearMap.congr_fun h_eq z
-  intro n
-  induction n with
-  | zero =>
-    intro f
-    rw [PreLie.OudomGuinCircConstruct.circTMultilinear_zero, psiA_L_ofTree]
-    rw [leaf_eq_node_zero, psiA_basis_node_self]
-    rw [Multiset.map_zero, Multiset.prod_zero]
-    rw [show TensorAlgebra.tprod ℤ LL 0 f = (1 : TensorAlgebra ℤ LL) from by
-          rw [TensorAlgebra.tprod_apply]; simp [List.ofFn_zero]]
-    show (1 : SL) = (SymmetricAlgebra.algHom ℤ LL).toLinearMap 1
-    show (1 : SL) = SymmetricAlgebra.algHom ℤ LL 1
-    rw [map_one]
-  | succ n IH =>
-    intro f
-    rw [PreLie.OudomGuinCircConstruct.circTMultilinear_succ]
-    rw [map_sub, map_sum, psiA_L_mul_eq, IH (Fin.init f)]
-    rw [oudomGuinCirc_algHomL_tprod_ι (f (Fin.last n)) n (Fin.init f)]
-    rw [show ∑ i, psiA_L a (PreLie.OudomGuinCircConstruct.circTMultilinear ℤ
-                (InsertionAlgebra.ofTree (Nonplanar.leaf a)) n
-                (Function.update (Fin.init f) i (Fin.init f i * f (Fin.last n)))) =
-            ∑ i, PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := LL)
-              (TensorAlgebra.tprod ℤ LL n
-                (Function.update (Fin.init f) i (Fin.init f i * f (Fin.last n))))
-          from Finset.sum_congr rfl (fun i _ => IH _)]
-    rw [add_sub_cancel_left]
-    rw [show PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := LL)
-              (TensorAlgebra.tprod ℤ LL (n + 1) f) =
-            PreLie.OudomGuinCircConstruct.algHomL
-              (TensorAlgebra.tprod ℤ LL n (Fin.init f)) *
-              SymmetricAlgebra.ι ℤ LL (f (Fin.last n))
-        from by
-      have h_f_eq : f = Fin.snoc (Fin.init f) (f (Fin.last n)) :=
-        (Fin.snoc_init_self f).symm
-      have h_tprod_succ :
-          TensorAlgebra.tprod ℤ LL (n + 1) f =
-          TensorAlgebra.tprod ℤ LL n (Fin.init f) *
-            TensorAlgebra.ι ℤ (f (Fin.last n)) := by
-        conv_lhs => rw [h_f_eq]
-        rw [Fin.snoc_eq_append,
-            PreLie.OudomGuinCircConstruct.ι_eq_tprod_one,
-            ← PreLie.OudomGuinCircConstruct.tprod_mul_tprod]
-        congr 1
-      rw [h_tprod_succ]
-      show (SymmetricAlgebra.algHom ℤ LL).toLinearMap _ = _
-      show (SymmetricAlgebra.algHom ℤ LL) _ = _
-      rw [map_mul]
-      rfl]
+        (TensorAlgebra.tprod ℤ LL n f) := by
+    intro n
+    induction n with
+    | zero =>
+      intro f
+      rw [PreLie.OudomGuinCircConstruct.circTMultilinear_zero, psiA_L_ofTree,
+          leaf_eq_node_zero, psiA_basis_node_self, Multiset.map_zero,
+          Multiset.prod_zero, tprod_zero, algHomL_apply, map_one]
+    | succ n IH =>
+      intro f
+      rw [PreLie.OudomGuinCircConstruct.circTMultilinear_succ, map_sub,
+          map_sum, psiA_L_mul_eq, IH (Fin.init f),
+          oudomGuinCirc_algHomL_tprod_ι (f (Fin.last n)) n (Fin.init f)]
+      simp only [IH]
+      rw [add_sub_cancel_left, algHomL_tprod_succ]
+  exact psiA_L_circByT_eq_of_per_tprod a _ LinearMap.id (fun n f => h n f) X
 
-/-- **Vanishing key lemma** (Helper 3 of `psiA_L_circByT_total_eq`): for
-    `a' ≠ a` and `X ∈ SL`,
-    `psiA_L a (circByT_total (leaf a') X) = 0`.
-
-    Same TA-descent as Helper 2. n+1 step: IH gives 0 in both the leading
-    term and the negative sum, so no cancellation needed. -/
+/-- `psiA_L a` kills grafting onto an off-color leaf: for `a' ≠ a`,
+    `psiA_L a (circByT_total (leaf a') X) = 0`. -/
 private theorem psiA_L_circByT_leaf_eq_zero [DecidableEq (Nonplanar α)]
     (a a' : α) (h : a' ≠ a) (X : SL) :
     psiA_L a (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ)
       (InsertionAlgebra.ofTree (Nonplanar.leaf a')) X) = 0 := by
   classical
-  obtain ⟨z, rfl⟩ := PreLie.OudomGuinCircConstruct.algHomL_surjective X
-  suffices h_per_tprod : ∀ (n : ℕ) (f : Fin n → LL),
+  have h_per : ∀ (n : ℕ) (f : Fin n → LL),
       psiA_L a (PreLie.OudomGuinCircConstruct.circTMultilinear ℤ
-        (InsertionAlgebra.ofTree (Nonplanar.leaf a')) n f) = 0 by
-    have h_eq :
-        (psiA_L a).comp
-          ((PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ)
-            (InsertionAlgebra.ofTree (Nonplanar.leaf a'))).comp
-          (PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := LL))) =
-        0 := by
-      apply PreLie.OudomGuinCircConstruct.TA_linearMap_ext_tprod
-      intro n f
-      simp only [LinearMap.comp_apply, LinearMap.zero_apply]
-      have h_tot := LinearMap.congr_fun
-        (PreLie.OudomGuinCircConstruct.circByT_total_comp_algHomL (R := ℤ)
-          (InsertionAlgebra.ofTree (Nonplanar.leaf a')))
-        (TensorAlgebra.tprod ℤ LL n f)
-      simp only [LinearMap.comp_apply] at h_tot
-      rw [h_tot, PreLie.OudomGuinCircConstruct.circTTensor_tprod]
-      exact h_per_tprod n f
-    exact LinearMap.congr_fun h_eq z
-  intro n
-  induction n with
-  | zero =>
-    intro f
-    rw [PreLie.OudomGuinCircConstruct.circTMultilinear_zero, psiA_L_ofTree,
-        leaf_eq_node_zero, psiA_basis_node_neq a a' h]
-  | succ n IH =>
-    intro f
-    rw [PreLie.OudomGuinCircConstruct.circTMultilinear_succ]
-    rw [map_sub, map_sum, psiA_L_mul_eq, IH (Fin.init f)]
-    -- IH gives 0 for leading-term Y. So 0 ○ ι _ + 0 * ι _ = 0.
-    rw [LinearMap.map_zero, LinearMap.zero_apply, zero_add, zero_mul]
-    -- Σᵢ IH = Σᵢ 0 = 0. Then 0 - 0 = 0.
-    rw [show ∑ i, psiA_L a (PreLie.OudomGuinCircConstruct.circTMultilinear ℤ
-                (InsertionAlgebra.ofTree (Nonplanar.leaf a')) n
-                (Function.update (Fin.init f) i (Fin.init f i * f (Fin.last n)))) =
-            (0 : SL) from by
-      rw [show (0 : SL) = ∑ _ : Fin n, (0 : SL) from
-            (Finset.sum_const_zero).symm]
-      exact Finset.sum_congr rfl (fun i _ => IH _)]
-    rw [sub_zero]
+        (InsertionAlgebra.ofTree (Nonplanar.leaf a')) n f) = 0 := by
+    intro n
+    induction n with
+    | zero =>
+      intro f
+      rw [PreLie.OudomGuinCircConstruct.circTMultilinear_zero, psiA_L_ofTree,
+          leaf_eq_node_zero, psiA_basis_node_ne a a' h]
+    | succ n IH =>
+      intro f
+      rw [PreLie.OudomGuinCircConstruct.circTMultilinear_succ, map_sub,
+          map_sum, psiA_L_mul_eq, IH (Fin.init f)]
+      -- IH gives 0 for leading-term Y. So 0 ○ ι _ + 0 * ι _ = 0.
+      rw [LinearMap.map_zero, LinearMap.zero_apply, zero_add, zero_mul]
+      simp only [IH, Finset.sum_const_zero, sub_zero]
+  exact psiA_L_circByT_eq_of_per_tprod a _ 0 (fun n f => h_per n f) X
 
-/-- **Substantive identity** for the ι case of Piece C: for `Y ∈ L` and `B ∈ SL`,
-    `psiA_L a (circByT_total Y B) = (psiA_L a Y) ★ B`.
-
-    **Proof**: Reduce Y via `Finsupp.induction_linear` to `Y = ofTree t`.
-    By `Nonplanar.node_eta`, `t = node a' A'`. Apply `iotaTree_node_via_circ`
-    (Piece D) to factor `ι(ofTree(node a' A')) = ι(leaf a') ○ Q` where
-    `Q = ∏_{c ∈ A'} ι(ofTree c)`; then `circ_assoc_via_comul` (Prop 2.8.v)
-    converts `(ι(leaf a') ○ Q) ○ B` to `ι(leaf a') ○ (Q ★ B) =
-    ι(circByT_total (leaf a') (Q ★ B))`. Bridge via `bMinusLin_SL_ι`:
-    `psiA_L a (circByT_total (node a' A') B) =
-     psiA_L a (circByT_total (leaf a') (Q ★ B))`. Case-split:
-    - `a' = a`: Helper 2 gives `Q ★ B`, matching RHS.
-    - `a' ≠ a`: Helper 3 gives 0; `psiA_basis a (node a' _) = 0` makes RHS 0. -/
+/-- `psiA_L a (circByT_total Y B) = oudomGuinStar (psiA_L a Y) B`. Factors a
+    basis tree as root ○ children (`iotaTree_node_via_circ`) and reassociates
+    via Prop 2.8.v of [oudom-guin-2008] (`circ_assoc_via_comul`). -/
 private theorem psiA_L_circByT_total_eq [DecidableEq (Nonplanar α)]
     (a : α) (Y : LL) (B : SL) :
     psiA_L a
@@ -1763,66 +1803,192 @@ private theorem psiA_L_circByT_total_eq [DecidableEq (Nonplanar α)]
         SymmetricAlgebra.ι ℤ LL
           (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ)
             (InsertionAlgebra.ofTree (Nonplanar.leaf a')) (oudomGuinStar Q B)) := by
-      have h_LHS_circ :
-          SymmetricAlgebra.ι ℤ LL
-              (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ)
-                (InsertionAlgebra.ofTree (Nonplanar.node a' A')) B) =
-          oudomGuinCirc (R := ℤ) (SymmetricAlgebra.ι ℤ LL
-            (InsertionAlgebra.ofTree (Nonplanar.node a' A'))) B := by
-        rw [oudomGuinCirc_eq_ofConv, circHom_ι]
-        rfl
-      have h_RHS_circ :
-          SymmetricAlgebra.ι ℤ LL
-              (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ)
-                (InsertionAlgebra.ofTree (Nonplanar.leaf a')) (oudomGuinStar Q B)) =
-          oudomGuinCirc (R := ℤ) (SymmetricAlgebra.ι ℤ LL
-            (InsertionAlgebra.ofTree (Nonplanar.leaf a'))) (oudomGuinStar Q B) := by
-        rw [oudomGuinCirc_eq_ofConv, circHom_ι]
-        rfl
-      rw [h_LHS_circ, h_RHS_circ, iotaTree_node_via_circ a' A',
-          circ_assoc_via_comul]
+      rw [← oudomGuinCirc_ι_apply, ← oudomGuinCirc_ι_apply,
+          iotaTree_node_via_circ a' A', circ_assoc_via_comul]
       rfl
     have h_psi_eq :
         psiA_L a (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ)
           (InsertionAlgebra.ofTree (Nonplanar.node a' A')) B) =
         psiA_L a (PreLie.OudomGuinCircConstruct.circByT_total (R := ℤ)
           (InsertionAlgebra.ofTree (Nonplanar.leaf a')) (oudomGuinStar Q B)) := by
-      have := congrArg (bMinusLin_SL a) h_circ_node
-      simp only [bMinusLin_SL_ι] at this
-      exact this
+      simpa only [bMinusLin_SL_ι] using congrArg (bMinusLin_SL a) h_circ_node
     rw [h_psi_eq, psiA_L_ofTree]
     by_cases ha : a' = a
     · subst ha
       rw [psiA_L_circByT_leaf_eq_id, psiA_basis_node_self]
       rfl
     · rw [psiA_L_circByT_leaf_eq_zero a a' ha,
-          psiA_basis_node_neq a a' ha, oudomGuinStar_zero_left]
+          psiA_basis_node_ne a a' ha, oudomGuinStar_zero_left]
 
-/-! ## §12: Piece C — OG Prop 3.2 on SL
+/-! ### Helpers for the cocycle `mul` case -/
 
-`bMinusLin_SL a (A ★ B) = ε(A) • bMinusLin_SL a B + bMinusLin_SL a A ★ B`
+/-- Reformulation of `B⁻_a(A ★ B)` via `B⁻_a` and `○`:
 
-OG paper page 10 proof, adapted:
+    `B⁻_a(A ★ B) = ε(A) • B⁻_a B + B⁻_a(A ○ B)`.
 
-By SymmetricAlgebra.induction on A:
-1. **`algebraMap r`** (scalar): A ★ B = r • B (via 1 ★ _ = _ + scalar
-   compatibility). LHS = r • bMinusLin_SL B. RHS: ε(r) = r, bMinusLin_SL r = 0.
-   So ε(A) • bMinusLin_SL B + 0 ★ B = r • bMinusLin_SL B. ✓
-2. **`ι x`** (substantive): use Piece D to write x's image as
-   `ι(leaf rootLabel) ○ children`, then OG paper's chain via 2.8.v.
-3. **`mul A₁ A₂`** (substantive): use IH on A₁ and A₂.
-4. **`add A₁ A₂`** (linearity): trivial.
+    Follows from counit-Leibniz on `B⁻_a` (`bMinusLin_SL_mul_eps`) applied to
+    the Sweedler expansion `A ★ B = mul' ((TP.map (○A) id)(cm B))`, then the
+    counit-comul triangle on both summands. -/
+private theorem bMinusLin_SL_star_eq (a : α) (A B : SL) :
+    bMinusLin_SL a (oudomGuinStar A B) =
+      SymmetricAlgebra.algebraMapInv (M := LL) A • bMinusLin_SL a B +
+      bMinusLin_SL a (oudomGuinCirc (R := ℤ) A B) := by
+  -- Apply counit-Leibniz pointwise on the Sweedler expansion of A ★ B,
+  -- then collapse via the two counit-comul triangles.
+  letI inst_B : Bialgebra ℤ (SymmetricAlgebra ℤ LL) := SymmetricAlgebra.instBialgebra ℤ LL
+  letI inst_Co : Coalgebra ℤ (SymmetricAlgebra ℤ LL) := inst_B.toCoalgebra
+  letI inst_C : CoalgebraStruct ℤ (SymmetricAlgebra ℤ LL) := inst_Co.toCoalgebraStruct
+  set cmB : SL ⊗[ℤ] SL :=
+    (Bialgebra.comulAlgHom ℤ (SymmetricAlgebra ℤ LL)).toLinearMap B with hcmB
+  -- Step 1: LinearMap identity F = F₁ + F₂ on `SL ⊗ SL → SL` where
+  --   F   = B⁻_a ∘ mul' ∘ (TP.map (○A) id)              [evaluated at cm B = A ★ B]
+  --   F₁  = ε(A) • B⁻_a ∘ mul' ∘ (TP.map (η∘ε) id)      [collapses to ε(A) • B⁻_a B]
+  --   F₂  = B⁻_a ∘ (○A) ∘ mul' ∘ (TP.map id (η∘ε))      [collapses to B⁻_a(A○B)]
+  set η : ℤ →ₗ[ℤ] SL := Algebra.linearMap ℤ SL with hη_def
+  set εL : SL →ₗ[ℤ] ℤ :=
+    (SymmetricAlgebra.algebraMapInv (M := LL) (R := ℤ)).toLinearMap with hεL_def
+  -- The "left" projection: F₁(b₁ ⊗ b₂) = ε(A)·ε(b₁)·B⁻_a b₂.
+  set F₁ : SL ⊗[ℤ] SL →ₗ[ℤ] SL :=
+    SymmetricAlgebra.algebraMapInv (M := LL) A •
+      ((bMinusLin_SL a).comp ((LinearMap.mul' ℤ SL).comp
+        (TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL))))
+    with hF₁_def
+  -- The "right" projection: F₂(b₁ ⊗ b₂) = ε(b₂)·B⁻_a(A○b₁).
+  set F₂ : SL ⊗[ℤ] SL →ₗ[ℤ] SL :=
+    (bMinusLin_SL a).comp
+      ((oudomGuinCirc (R := ℤ) A).comp ((LinearMap.mul' ℤ SL).comp
+        (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL))))
+    with hF₂_def
+  have h_lm :
+      (bMinusLin_SL a).comp ((LinearMap.mul' ℤ SL).comp
+          (TensorProduct.map (oudomGuinCirc (R := ℤ) A)
+            (LinearMap.id : SL →ₗ[ℤ] SL))) = F₁ + F₂ := by
+    apply TensorProduct.ext'
+    intro b₁ b₂
+    -- LHS at b₁⊗b₂: B⁻_a((A○b₁)·b₂) = ε(A○b₁)·B⁻_a b₂ + ε(b₂)·B⁻_a(A○b₁)
+    --                              = ε(A)·ε(b₁)·B⁻_a b₂ + ε(b₂)·B⁻_a(A○b₁)
+    -- F₁ at b₁⊗b₂: ε(A) • B⁻_a((η(ε b₁))·b₂) = ε(A)·ε(b₁)·B⁻_a b₂
+    -- F₂ at b₁⊗b₂: B⁻_a(A ○ (b₁ · η(ε b₂))) = B⁻_a(A ○ (ε(b₂)·b₁)) = ε(b₂)·B⁻_a(A○b₁)
+    show bMinusLin_SL a ((oudomGuinCirc (R := ℤ) A b₁) * b₂) =
+        SymmetricAlgebra.algebraMapInv (M := LL) A •
+          bMinusLin_SL a (algebraMap ℤ SL
+            (SymmetricAlgebra.algebraMapInv (M := LL) b₁) * b₂) +
+        bMinusLin_SL a (oudomGuinCirc (R := ℤ) A
+          (b₁ * algebraMap ℤ SL (SymmetricAlgebra.algebraMapInv (M := LL) b₂)))
+    -- LHS reduction by counit-Leibniz on B⁻_a + counit_circ.
+    rw [bMinusLin_SL_mul_eps, counit_circ]
+    -- F₁ reduction: ε(A) • B⁻_a((algMap r)·b₂) = ε(A) • (r • B⁻_a b₂).
+    have hF₁_pt : bMinusLin_SL a (algebraMap ℤ SL
+            (SymmetricAlgebra.algebraMapInv (M := LL) b₁) * b₂) =
+          SymmetricAlgebra.algebraMapInv (M := LL) b₁ • bMinusLin_SL a b₂ := by
+      rw [Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, map_smul]
+    rw [hF₁_pt]
+    -- F₂ reduction: B⁻_a(A ○ (b₁·algMap r)) = B⁻_a(A ○ (r • b₁)) = r • B⁻_a(A ○ b₁).
+    have hF₂_inner : b₁ * algebraMap ℤ SL
+            (SymmetricAlgebra.algebraMapInv (M := LL) b₂) =
+          SymmetricAlgebra.algebraMapInv (M := LL) b₂ • b₁ := by
+      rw [Algebra.algebraMap_eq_smul_one, mul_smul_comm, mul_one]; rfl
+    rw [hF₂_inner, map_smul, map_smul]
+    -- Goal: ε(A)·ε(b₁) • B⁻_a b₂ + ε(b₂) • B⁻_a(A○b₁) = ε(A) • ε(b₁) • B⁻_a b₂ + ε(b₂) • B⁻_a(A○b₁).
+    rw [mul_smul]
+  -- Apply at cmB.
+  have h_at_B := LinearMap.congr_fun h_lm cmB
+  simp only [LinearMap.comp_apply] at h_at_B
+  -- Goal LHS = B⁻_a(A ★ B) ≡ B⁻_a(mul'(TP.map (○A) id (cmB))) (by oudomGuinStar_def
+  -- + cmB defeq with Coalgebra.comul B).
+  change bMinusLin_SL a ((LinearMap.mul' ℤ SL)
+        ((TensorProduct.map (oudomGuinCirc (R := ℤ) A) LinearMap.id) cmB)) = _
+  refine h_at_B.trans ?_
+  show (F₁ + F₂) cmB = _
+  rw [hF₁_def, hF₂_def]
+  -- Now we have: F₁(cmB) + F₂(cmB) on LHS.
+  -- Step A: F₁(cmB) = ε(A) • B⁻_a B (via rTensor counit triangle).
+  have h_F₁_eval :
+      SymmetricAlgebra.algebraMapInv (M := LL) A •
+        ((bMinusLin_SL a).comp ((LinearMap.mul' ℤ SL).comp
+          (TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL)))) cmB =
+      SymmetricAlgebra.algebraMapInv (M := LL) A • bMinusLin_SL a B := by
+    congr 1
+    -- Reduce: B⁻_a(mul'(TP.map (η∘ε) id (cmB))) = B⁻_a B.
+    have h_rTensor_at_cmB :
+        (TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL)) cmB =
+          (1 : SL) ⊗ₜ[ℤ] B := by
+      rw [hcmB]
+      show (TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL))
+              (Coalgebra.comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B) = _
+      rw [show TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL) =
+              (TensorProduct.map η (LinearMap.id : SL →ₗ[ℤ] SL)).comp
+                (TensorProduct.map εL (LinearMap.id : SL →ₗ[ℤ] SL)) from by
+            rw [← TensorProduct.map_comp, LinearMap.id_comp]]
+      rw [LinearMap.comp_apply]
+      -- εL = Coalgebra.counit, and TP.map counit id = counit.rTensor.
+      have h_εL_eq : (TensorProduct.map εL (LinearMap.id : SL →ₗ[ℤ] SL))
+                       (Coalgebra.comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B) =
+                     (1 : ℤ) ⊗ₜ[ℤ] B := by
+        rw [hεL_def]
+        exact Coalgebra.rTensor_counit_comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B
+      rw [h_εL_eq, TensorProduct.map_tmul, hη_def]
+      show (algebraMap ℤ SL 1 : SL) ⊗ₜ[ℤ] (LinearMap.id : SL →ₗ[ℤ] SL) B =
+            (1 : SL) ⊗ₜ[ℤ] B
+      rw [map_one]
+      rfl
+    simp only [LinearMap.comp_apply, h_rTensor_at_cmB, LinearMap.mul'_apply, one_mul]
+  -- Step B: F₂(cmB) = B⁻_a(A ○ B) (via lTensor counit triangle).
+  have h_F₂_eval :
+      ((bMinusLin_SL a).comp
+        ((oudomGuinCirc (R := ℤ) A).comp ((LinearMap.mul' ℤ SL).comp
+          (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL))))) cmB =
+        bMinusLin_SL a (oudomGuinCirc (R := ℤ) A B) := by
+    have h_lTensor_at_cmB :
+        (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL)) cmB =
+          B ⊗ₜ[ℤ] (1 : SL) := by
+      rw [hcmB]
+      show (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL))
+              (Coalgebra.comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B) = _
+      rw [show TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL) =
+              (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) η).comp
+                (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) εL) from by
+            rw [← TensorProduct.map_comp, LinearMap.id_comp]]
+      rw [LinearMap.comp_apply]
+      have h_εL_eq : (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) εL)
+                       (Coalgebra.comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B) =
+                     B ⊗ₜ[ℤ] (1 : ℤ) := by
+        rw [hεL_def]
+        exact Coalgebra.lTensor_counit_comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B
+      rw [h_εL_eq, TensorProduct.map_tmul, hη_def]
+      show (LinearMap.id : SL →ₗ[ℤ] SL) B ⊗ₜ[ℤ] (algebraMap ℤ SL 1 : SL) =
+            B ⊗ₜ[ℤ] (1 : SL)
+      rw [map_one]
+      rfl
+    -- Reduce: B⁻_a(○A(mul'(TP.map id (η∘ε) cmB))) = B⁻_a(○A(mul'(B⊗1))) = B⁻_a(○A(B·1)) = B⁻_a(○A B).
+    rw [show ((bMinusLin_SL a).comp
+          ((oudomGuinCirc (R := ℤ) A).comp ((LinearMap.mul' ℤ SL).comp
+            (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL))))) cmB =
+        bMinusLin_SL a (oudomGuinCirc (R := ℤ) A ((LinearMap.mul' ℤ SL)
+          ((TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL)) cmB))) from rfl,
+        h_lTensor_at_cmB, LinearMap.mul'_apply, mul_one]
+  -- Substitute back.
+  show (SymmetricAlgebra.algebraMapInv (M := LL) A •
+          ((bMinusLin_SL a).comp ((LinearMap.mul' ℤ SL).comp
+            (TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL))))) cmB +
+        ((bMinusLin_SL a).comp
+          ((oudomGuinCirc (R := ℤ) A).comp ((LinearMap.mul' ℤ SL).comp
+            (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL))))) cmB =
+        SymmetricAlgebra.algebraMapInv (M := LL) A • bMinusLin_SL a B +
+        bMinusLin_SL a (oudomGuinCirc (R := ℤ) A B)
+  rw [LinearMap.smul_apply, h_F₁_eval, h_F₂_eval]
 
-**Status**: stated with `sorry` pending Piece D + ε-Leibniz machinery. -/
+/-! ### The cocycle identity -/
 
-/-- **Piece C**: OG Prop 3.2 (cocycle identity for `B⁻_SL_a` w.r.t. `★`).
+/-- The cocycle identity for `B⁻_a` with respect to `★`, from the proof of
+    Prop 3.2 of [oudom-guin-2008]:
 
     `bMinusLin_SL a (A ★ B) = ε(A) • bMinusLin_SL a B + bMinusLin_SL a A ★ B`
 
-    SL-side analog of CK's `bMinusLin_gl_mul`. Proved via OG paper's
-    page-10 argument (see header comment). The substantive case
-    (`A = ι x`) uses `iotaTree_node_via_circ` (Piece D) + `circ_assoc_via_comul`
-    (Prop 2.8.v, sorry-free in OudomGuinCirc.lean). -/
+    SL-side analog of the Connes-Kreimer-side `bMinusLin_gl_mul`.
+
+    TODO: the `mul` case is incomplete; it needs associativity of `★`
+    (Lemma 2.10 of [oudom-guin-2008]). -/
 theorem bMinusLin_SL_oudomGuinStar [DecidableEq (Nonplanar α)]
     (a : α) (A B : SL) :
     bMinusLin_SL a (oudomGuinStar A B) =
@@ -1831,30 +1997,208 @@ theorem bMinusLin_SL_oudomGuinStar [DecidableEq (Nonplanar α)]
       oudomGuinStar (bMinusLin_SL a A) B := by
   induction A using SymmetricAlgebra.induction with
   | algebraMap r =>
-    -- A = algebraMap r = r • 1. (r • 1) ★ B = r • (1 ★ B) = r • B.
-    -- bMinusLin_SL (r • 1) = r • bMinusLin_SL 1 = 0. ε(algebraMap r) = r.
-    -- LHS = bMinusLin_SL (r • B) = r • bMinusLin_SL B.
-    -- RHS = r • bMinusLin_SL B + 0 ★ B = r • bMinusLin_SL B + 0.
     rw [Algebra.algebraMap_eq_smul_one, oudomGuinStar_smul_left,
         oudomGuinStar_one_left]
     simp only [map_smul, map_one, bMinusLin_SL_one, smul_zero,
                oudomGuinStar_zero_left, add_zero, smul_eq_mul, mul_one]
   | ι x =>
-    -- The substantive case. ε(ι x) = 0 (primitive), so RHS collapses to
-    -- (bMinusLin_SL (ι x)) ★ B = (psiA_L a x) ★ B.
-    -- LHS reduces via length-argument (bMinusLin_SL_ι_star) to
-    -- psiA_L a (circByT_total x B). Equality via psiA_L_circByT_total_eq
-    -- (the substantive OG combinatorial identity, currently `sorry`).
+    -- ε(ι x) = 0, so the RHS collapses; reduce the LHS via
+    -- bMinusLin_SL_ι_star and psiA_L_circByT_total_eq.
     rw [SymmetricAlgebra.algebraMapInv_ι, zero_smul, zero_add,
         bMinusLin_SL_ι_star a x B, psiA_L_circByT_total_eq a x B,
         bMinusLin_SL_ι]
   | mul A₁ A₂ ih₁ ih₂ =>
-    -- A = A₁ * A₂. (A₁ · A₂) ★ B has its own associativity (Lemma 2.10:
-    -- ★ on S(L) is associative + makes (S(L), ★, Δ) a Hopf algebra).
-    -- Reduce via ih₁, ih₂ on the appropriate sub-products.
-    sorry
+    -- Key derived fact: B⁻_a(A_i ○ B) = (B⁻_a A_i) ★ B (from IH_i + star_eq).
+    have hAi : ∀ Aᵢ : SL,
+        (bMinusLin_SL a (oudomGuinStar Aᵢ B) =
+          SymmetricAlgebra.algebraMapInv (M := InsertionAlgebra α) Aᵢ •
+            bMinusLin_SL a B + oudomGuinStar (bMinusLin_SL a Aᵢ) B) →
+        bMinusLin_SL a (oudomGuinCirc (R := ℤ) Aᵢ B) =
+          oudomGuinStar (bMinusLin_SL a Aᵢ) B := by
+      intro Aᵢ hCocycle
+      -- B⁻_a(Aᵢ ★ B) = ε(Aᵢ)·B⁻_a B + B⁻_a(Aᵢ ○ B)         [star_eq]
+      -- B⁻_a(Aᵢ ★ B) = ε(Aᵢ)·B⁻_a B + (B⁻_a Aᵢ) ★ B          [hCocycle]
+      -- So B⁻_a(Aᵢ ○ B) = (B⁻_a Aᵢ) ★ B by add_left_cancel.
+      have h_star_eq := bMinusLin_SL_star_eq a Aᵢ B
+      rw [hCocycle] at h_star_eq
+      exact (add_left_cancel h_star_eq).symm
+    have h₁ : bMinusLin_SL a (oudomGuinCirc (R := ℤ) A₁ B) =
+              oudomGuinStar (bMinusLin_SL a A₁) B := hAi A₁ ih₁
+    have h₂ : bMinusLin_SL a (oudomGuinCirc (R := ℤ) A₂ B) =
+              oudomGuinStar (bMinusLin_SL a A₂) B := hAi A₂ ih₂
+    -- Step 1: rewrite LHS via star_eq.
+    rw [bMinusLin_SL_star_eq]
+    -- Goal: ε(A₁A₂)·B⁻_a B + B⁻_a((A₁A₂)○B) =
+    --       ε(A₁A₂)·B⁻_a B + (B⁻_a(A₁A₂))★B
+    congr 1
+    -- Step 2: rewrite (A₁A₂)○B via Prop 2.7.iii.
+    -- (A₁A₂)○B = mul'(TP.map (○A₁) (○A₂) (cm B)).
+    -- Apply B⁻_a-counit-Leibniz pointwise + counit_circ + counit-comul triangles
+    -- → B⁻_a((A₁A₂)○B) = ε(A₁)·B⁻_a(A₂○B) + ε(A₂)·B⁻_a(A₁○B).
+    have h_circ_decomp :
+        bMinusLin_SL a (oudomGuinCirc (R := ℤ) (A₁ * A₂) B) =
+          SymmetricAlgebra.algebraMapInv (M := LL) A₁ •
+            bMinusLin_SL a (oudomGuinCirc (R := ℤ) A₂ B) +
+          SymmetricAlgebra.algebraMapInv (M := LL) A₂ •
+            bMinusLin_SL a (oudomGuinCirc (R := ℤ) A₁ B) := by
+      -- LinearMap equality on SL ⊗ SL applied to cm B, mirrors star_eq proof.
+      letI inst_B : Bialgebra ℤ (SymmetricAlgebra ℤ LL) := SymmetricAlgebra.instBialgebra ℤ LL
+      letI inst_Co : Coalgebra ℤ (SymmetricAlgebra ℤ LL) := inst_B.toCoalgebra
+      letI inst_C : CoalgebraStruct ℤ (SymmetricAlgebra ℤ LL) := inst_Co.toCoalgebraStruct
+      set cmB : SL ⊗[ℤ] SL :=
+        (Bialgebra.comulAlgHom ℤ (SymmetricAlgebra ℤ LL)).toLinearMap B with hcmB
+      set η : ℤ →ₗ[ℤ] SL := Algebra.linearMap ℤ SL with hη_def
+      set εL : SL →ₗ[ℤ] ℤ :=
+        (SymmetricAlgebra.algebraMapInv (M := LL) (R := ℤ)).toLinearMap with hεL_def
+      -- (A₁A₂) ○ B = mul'(TP.map (○A₁) (○A₂) (cm B)) by Prop 2.7.iii.
+      -- B⁻_a applied: pointwise Leibniz → ε(A₁○B₁)·B⁻_a(A₂○B₂) + ε(A₂○B₂)·B⁻_a(A₁○B₁).
+      -- Linear-map identity:
+      --   B⁻_a ∘ mul' ∘ TP.map (○A₁) (○A₂) =
+      --     ε(A₁) • B⁻_a ∘ ○A₂ ∘ mul' ∘ TP.map (η∘ε) id +
+      --     ε(A₂) • B⁻_a ∘ ○A₁ ∘ mul' ∘ TP.map id (η∘ε)
+      -- Wait: I want B⁻_a((A₁○B₁)·(A₂○B₂)) = ε(A₁)·ε(B₁)·B⁻_a(A₂○B₂) + ε(A₂)·ε(B₂)·B⁻_a(A₁○B₁).
+      -- = ε(A₁) • (B⁻_a ∘ ○A₂ ∘ μ ∘ (TP.map η id ∘ TP.map ε id))(b₁ ⊗ b₂)  [where b₁⊗b₂ = cm B]
+      --     -- Here ε(b₁) replaces b₁, then mul'(algMap ε(b₁) ⊗ b₂) = ε(b₁)·b₂, then ○A₂ acts.
+      -- ALTERNATIVELY: apply star_eq directly to oudomGuinCirc... wait, star_eq is about ★, not ○.
+      have h_lm :
+          (bMinusLin_SL a).comp ((LinearMap.mul' ℤ SL).comp
+              (TensorProduct.map (oudomGuinCirc (R := ℤ) A₁)
+                (oudomGuinCirc (R := ℤ) A₂))) =
+            (SymmetricAlgebra.algebraMapInv (M := LL) A₁ •
+              ((bMinusLin_SL a).comp ((oudomGuinCirc (R := ℤ) A₂).comp
+                ((LinearMap.mul' ℤ SL).comp
+                  (TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL)))))) +
+            (SymmetricAlgebra.algebraMapInv (M := LL) A₂ •
+              ((bMinusLin_SL a).comp ((oudomGuinCirc (R := ℤ) A₁).comp
+                ((LinearMap.mul' ℤ SL).comp
+                  (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL)))))) := by
+        apply TensorProduct.ext'
+        intro b₁ b₂
+        -- LHS at b₁⊗b₂: B⁻_a((A₁○b₁)·(A₂○b₂))
+        --             = ε(A₁○b₁)·B⁻_a(A₂○b₂) + ε(A₂○b₂)·B⁻_a(A₁○b₁)    [Leibniz]
+        --             = ε(A₁)·ε(b₁)·B⁻_a(A₂○b₂) + ε(A₂)·ε(b₂)·B⁻_a(A₁○b₁)
+        -- RHS₁ at b₁⊗b₂: ε(A₁) • B⁻_a(A₂ ○ (algMap(ε(b₁)) · b₂)) = ε(A₁) • ε(b₁) • B⁻_a(A₂ ○ b₂)
+        -- RHS₂ at b₁⊗b₂: ε(A₂) • B⁻_a(A₁ ○ (b₁ · algMap(ε(b₂)))) = ε(A₂) • ε(b₂) • B⁻_a(A₁ ○ b₁)
+        show bMinusLin_SL a ((oudomGuinCirc (R := ℤ) A₁ b₁) *
+              (oudomGuinCirc (R := ℤ) A₂ b₂)) = _
+        rw [bMinusLin_SL_mul_eps, counit_circ, counit_circ]
+        -- LHS: ε(A₁)·ε(b₁)·B⁻_a(A₂○b₂) + ε(A₂)·ε(b₂)·B⁻_a(A₁○b₁)
+        show (SymmetricAlgebra.algebraMapInv (M := LL) A₁ *
+              SymmetricAlgebra.algebraMapInv (M := LL) b₁) •
+              bMinusLin_SL a (oudomGuinCirc (R := ℤ) A₂ b₂) +
+            (SymmetricAlgebra.algebraMapInv (M := LL) A₂ *
+              SymmetricAlgebra.algebraMapInv (M := LL) b₂) •
+              bMinusLin_SL a (oudomGuinCirc (R := ℤ) A₁ b₁) =
+          SymmetricAlgebra.algebraMapInv (M := LL) A₁ •
+            bMinusLin_SL a (oudomGuinCirc (R := ℤ) A₂
+              ((LinearMap.mul' ℤ SL)
+                (algebraMap ℤ SL (SymmetricAlgebra.algebraMapInv (M := LL) b₁) ⊗ₜ[ℤ] b₂))) +
+          SymmetricAlgebra.algebraMapInv (M := LL) A₂ •
+            bMinusLin_SL a (oudomGuinCirc (R := ℤ) A₁
+              ((LinearMap.mul' ℤ SL)
+                (b₁ ⊗ₜ[ℤ] algebraMap ℤ SL (SymmetricAlgebra.algebraMapInv (M := LL) b₂))))
+        rw [LinearMap.mul'_apply, LinearMap.mul'_apply]
+        rw [show algebraMap ℤ SL (SymmetricAlgebra.algebraMapInv (M := LL) b₁) * b₂ =
+              SymmetricAlgebra.algebraMapInv (M := LL) b₁ • b₂ from by
+            rw [Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul]; rfl]
+        rw [show b₁ * algebraMap ℤ SL (SymmetricAlgebra.algebraMapInv (M := LL) b₂) =
+              SymmetricAlgebra.algebraMapInv (M := LL) b₂ • b₁ from by
+            rw [Algebra.algebraMap_eq_smul_one, mul_smul_comm, mul_one]; rfl]
+        rw [map_smul, map_smul, map_smul, map_smul, mul_smul, mul_smul]
+      -- Apply at cmB.
+      have h_at_B := LinearMap.congr_fun h_lm cmB
+      simp only [LinearMap.comp_apply] at h_at_B
+      -- LHS of h_at_B: B⁻_a(mul'(TP.map (○A₁) (○A₂) cmB)) = B⁻_a((A₁A₂)○B).
+      -- by `circ_mul_distrib_via_comul` (Prop 2.7.iii).
+      have h_LHS_eq :
+          bMinusLin_SL a (oudomGuinCirc (R := ℤ) (A₁ * A₂) B) =
+            bMinusLin_SL a ((LinearMap.mul' ℤ SL)
+              ((TensorProduct.map (oudomGuinCirc (R := ℤ) A₁)
+                (oudomGuinCirc (R := ℤ) A₂)) cmB)) := by
+        congr 1
+        rw [circ_mul_distrib_via_comul, hcmB]
+        rfl
+      rw [h_LHS_eq]
+      refine h_at_B.trans ?_
+      -- Now: RHS₁ = ε(A₁) • B⁻_a(A₂○(mul'(TP.map (η∘ε) id cmB))) = ε(A₁) • B⁻_a(A₂○B)
+      --   via rTensor counit triangle (mul'(1⊗B) = B).
+      -- And RHS₂ = ε(A₂) • B⁻_a(A₁○(mul'(TP.map id (η∘ε) cmB))) = ε(A₂) • B⁻_a(A₁○B)
+      --   via lTensor counit triangle (mul'(B⊗1) = B).
+      have h_rT : (LinearMap.mul' ℤ SL)
+              ((TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL)) cmB) = B := by
+        have h_rTensor_at_cmB :
+            (TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL)) cmB =
+              (1 : SL) ⊗ₜ[ℤ] B := by
+          rw [hcmB]
+          show (TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL))
+                  (Coalgebra.comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B) = _
+          rw [show TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL) =
+                  (TensorProduct.map η (LinearMap.id : SL →ₗ[ℤ] SL)).comp
+                    (TensorProduct.map εL (LinearMap.id : SL →ₗ[ℤ] SL)) from by
+                rw [← TensorProduct.map_comp, LinearMap.id_comp]]
+          rw [LinearMap.comp_apply]
+          have h_εL_eq : (TensorProduct.map εL (LinearMap.id : SL →ₗ[ℤ] SL))
+                          (Coalgebra.comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B) =
+                         (1 : ℤ) ⊗ₜ[ℤ] B := by
+            rw [hεL_def]
+            exact Coalgebra.rTensor_counit_comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B
+          rw [h_εL_eq, TensorProduct.map_tmul, hη_def]
+          show (algebraMap ℤ SL 1 : SL) ⊗ₜ[ℤ] (LinearMap.id : SL →ₗ[ℤ] SL) B =
+                (1 : SL) ⊗ₜ[ℤ] B
+          rw [map_one]
+          rfl
+        rw [h_rTensor_at_cmB, LinearMap.mul'_apply, one_mul]
+      have h_lT : (LinearMap.mul' ℤ SL)
+              ((TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL)) cmB) = B := by
+        have h_lTensor_at_cmB :
+            (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL)) cmB =
+              B ⊗ₜ[ℤ] (1 : SL) := by
+          rw [hcmB]
+          show (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL))
+                  (Coalgebra.comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B) = _
+          rw [show TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL) =
+                  (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) η).comp
+                    (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) εL) from by
+                rw [← TensorProduct.map_comp, LinearMap.id_comp]]
+          rw [LinearMap.comp_apply]
+          have h_εL_eq : (TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) εL)
+                          (Coalgebra.comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B) =
+                         B ⊗ₜ[ℤ] (1 : ℤ) := by
+            rw [hεL_def]
+            exact Coalgebra.lTensor_counit_comul (R := ℤ) (A := SymmetricAlgebra ℤ LL) B
+          rw [h_εL_eq, TensorProduct.map_tmul, hη_def]
+          show (LinearMap.id : SL →ₗ[ℤ] SL) B ⊗ₜ[ℤ] (algebraMap ℤ SL 1 : SL) =
+                B ⊗ₜ[ℤ] (1 : SL)
+          rw [map_one]
+          rfl
+        rw [h_lTensor_at_cmB, LinearMap.mul'_apply, mul_one]
+      -- Unfold the LinearMap-composition form and substitute h_rT/h_lT.
+      show SymmetricAlgebra.algebraMapInv (M := LL) A₁ •
+            bMinusLin_SL a (oudomGuinCirc (R := ℤ) A₂
+              ((LinearMap.mul' ℤ SL)
+                ((TensorProduct.map (η.comp εL) (LinearMap.id : SL →ₗ[ℤ] SL)) cmB))) +
+          SymmetricAlgebra.algebraMapInv (M := LL) A₂ •
+            bMinusLin_SL a (oudomGuinCirc (R := ℤ) A₁
+              ((LinearMap.mul' ℤ SL)
+                ((TensorProduct.map (LinearMap.id : SL →ₗ[ℤ] SL) (η.comp εL)) cmB))) = _
+      rw [h_rT, h_lT]
+    rw [h_circ_decomp, h₁, h₂]
+    -- Goal: ε(A₁)·(B⁻_a A₂)★B + ε(A₂)·(B⁻_a A₁)★B =
+    --       (B⁻_a(A₁A₂))★B
+    -- = (ε(A₁)·B⁻_a A₂ + ε(A₂)·B⁻_a A₁)★B
+    -- = ε(A₁)·(B⁻_a A₂)★B + ε(A₂)·(B⁻_a A₁)★B
+    rw [bMinusLin_SL_mul_eps, oudomGuinStar_add_left]
+    -- Goal: ε(A₁) • ((B⁻_a A₂) ★ B) + ε(A₂) • ((B⁻_a A₁) ★ B) =
+    --       (ε(A₁) • B⁻_a A₂) ★ B + (ε(A₂) • B⁻_a A₁) ★ B
+    rw [show ((SymmetricAlgebra.algebraMapInv (M := LL) A₁ • bMinusLin_SL a A₂) :
+              SL) ★ B =
+          SymmetricAlgebra.algebraMapInv (M := LL) A₁ • (bMinusLin_SL a A₂ ★ B) from
+            oudomGuinStar_smul_left _ _ _,
+        show ((SymmetricAlgebra.algebraMapInv (M := LL) A₂ • bMinusLin_SL a A₁) :
+              SL) ★ B =
+          SymmetricAlgebra.algebraMapInv (M := LL) A₂ • (bMinusLin_SL a A₁ ★ B) from
+            oudomGuinStar_smul_left _ _ _]
   | add A₁ A₂ ih₁ ih₂ =>
-    -- Linearity: ★ left-linear, bMinusLin_SL linear, ε linear.
     rw [oudomGuinStar_add_left, map_add, map_add, map_add,
         oudomGuinStar_add_left, ih₁, ih₂, add_smul]
     abel

--- a/Linglib/Core/Algebra/RootedTree/PreLie/InsertionNodeDecomp.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/InsertionNodeDecomp.lean
@@ -1,0 +1,816 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Algebra.RootedTree.PreLie.Insertion
+import Linglib.Core.Algebra.RootedTree.PreLie.InsertionAddHost
+
+/-!
+# Node-host decomposition of the multi-graft insertion
+
+For a single-tree host `node a cs`, the vertex set splits as
+`{root} ⊔ vertices(cs)`, so the simultaneous multi-graft `insertion`
+decomposes by which guests land at the root (they are prepended as new
+children) versus inside the child forest (a recursive `insertionForest`).
+This is the node-level analog of `insertionMultiset_add_host`'s
+forest-append bucketing (`InsertionAddHost.lean`).
+
+## Main results
+
+* `listChoices_alphabet_split`: choices over an appended alphabet
+  `ys ++ zs` enumerate as a boolean mask plus per-bucket choices,
+  recombined by `mergeMask`.
+* `insertionForest_eq_multiGraftChildren_choices`: the vertex-choice form
+  of `insertionForest` — grafting into a host forest `cs` is the sum over
+  `verticesAux 0 cs`-choices of `multiGraftChildren`.
+* `insertion_node_split`: the headline planar decomposition of
+  `insertion (node a cs) gs` by root-vs-subtree guest masks.
+
+All three statements are validated computationally on concrete trees
+(multi-vertex hosts, repeated guests, empty edge cases) prior to proof.
+-/
+
+namespace RootedTree
+
+namespace Planar
+
+namespace Pathed
+
+variable {α : Type*}
+
+/-! ### `mergeMask` — interleave two bucket lists along a boolean mask -/
+
+/-- Interleave `us` (used at `true` positions) and `ws` (used at `false`
+    positions) along the mask `m`. Off-length inputs truncate. -/
+def mergeMask {X : Type*} : List Bool → List X → List X → List X
+  | [], _, _ => []
+  | true :: m, u :: us, ws => u :: mergeMask m us ws
+  | true :: _, [], _ => []
+  | false :: m, us, w :: ws => w :: mergeMask m us ws
+  | false :: _, _, [] => []
+
+@[simp] theorem mergeMask_nil {X : Type*} (us ws : List X) :
+    mergeMask [] us ws = [] := rfl
+
+@[simp] theorem mergeMask_true_cons {X : Type*} (m : List Bool)
+    (u : X) (us ws : List X) :
+    mergeMask (true :: m) (u :: us) ws = u :: mergeMask m us ws := rfl
+
+@[simp] theorem mergeMask_false_cons {X : Type*} (m : List Bool)
+    (us : List X) (w : X) (ws : List X) :
+    mergeMask (false :: m) us (w :: ws) = w :: mergeMask m us ws := rfl
+
+/-! ### Alphabet split for `listChoices` -/
+
+/-- A length-`(k+1)` enumeration unfolds to a head bind. -/
+private theorem ofList_listChoices_succ {Y : Type*} (xs : List Y) (k : ℕ) :
+    (Multiset.ofList (listChoices xs (k + 1)) : Multiset (List Y)) =
+      (Multiset.ofList xs).bind fun v =>
+        (Multiset.ofList (listChoices xs k)).map (v :: ·) := by
+  rw [listChoices_succ, ← Multiset.coe_bind]
+  rfl
+
+/-- Choices over an appended alphabet enumerate as: a boolean mask over
+    the positions, a choice vector over `ys` for the `true` positions,
+    and a choice vector over `zs` for the `false` positions, recombined
+    by `mergeMask`. -/
+theorem listChoices_alphabet_split {X γ : Type*} (ys zs : List X)
+    (n : ℕ) (g : List X → Multiset γ) :
+    (Multiset.ofList (listChoices (ys ++ zs) n)).bind g =
+      (Multiset.ofList (listChoices [true, false] n)).bind fun m =>
+        (Multiset.ofList (listChoices ys (m.count true))).bind fun u =>
+          (Multiset.ofList (listChoices zs (m.count false))).bind fun w =>
+            g (mergeMask m u w) := by
+  induction n generalizing g with
+  | zero =>
+    simp only [listChoices_zero]
+    rw [show (Multiset.ofList ([[]] : List (List X)) : Multiset (List X)) =
+          {[]} from rfl,
+        show (Multiset.ofList ([[]] : List (List Bool)) : Multiset (List Bool)) =
+          {[]} from rfl,
+        Multiset.singleton_bind, Multiset.singleton_bind]
+    simp only [List.count_nil, listChoices_zero]
+    rw [show (Multiset.ofList ([[]] : List (List X)) : Multiset (List X)) =
+          {[]} from rfl,
+        Multiset.singleton_bind, Multiset.singleton_bind]
+    rfl
+  | succ n ih =>
+    -- Abbreviate the mask-indexed RHS body.
+    set R : List Bool → Multiset γ := fun m =>
+      (Multiset.ofList (listChoices ys (m.count true))).bind fun u =>
+        (Multiset.ofList (listChoices zs (m.count false))).bind fun w =>
+          g (mergeMask m u w) with hR
+    -- Each alphabet half equals a (mask, head)-bind in normal form.
+    have ys_half : (Multiset.ofList ys).bind (fun v =>
+          ((Multiset.ofList (listChoices (ys ++ zs) n)).map (v :: ·)).bind g) =
+        (Multiset.ofList (listChoices [true, false] n)).bind fun m =>
+          (Multiset.ofList ys).bind fun v =>
+            (Multiset.ofList (listChoices ys (m.count true))).bind fun u =>
+              (Multiset.ofList (listChoices zs (m.count false))).bind fun w =>
+                g (v :: mergeMask m u w) := by
+      rw [← Multiset.bind_bind]
+      refine Multiset.bind_congr fun v _ => ?_
+      rw [Multiset.bind_map]
+      exact ih (fun ch => g (v :: ch))
+    have zs_half : (Multiset.ofList zs).bind (fun v =>
+          ((Multiset.ofList (listChoices (ys ++ zs) n)).map (v :: ·)).bind g) =
+        (Multiset.ofList (listChoices [true, false] n)).bind fun m =>
+          (Multiset.ofList zs).bind fun v =>
+            (Multiset.ofList (listChoices ys (m.count true))).bind fun u =>
+              (Multiset.ofList (listChoices zs (m.count false))).bind fun w =>
+                g (v :: mergeMask m u w) := by
+      rw [← Multiset.bind_bind]
+      refine Multiset.bind_congr fun v _ => ?_
+      rw [Multiset.bind_map]
+      exact ih (fun ch => g (v :: ch))
+    -- The true-mask half reduces to the ys normal form.
+    have true_half :
+        ((Multiset.ofList (listChoices [true, false] n)).map (true :: ·)).bind R =
+          (Multiset.ofList (listChoices [true, false] n)).bind fun m =>
+            (Multiset.ofList ys).bind fun v =>
+              (Multiset.ofList (listChoices ys (m.count true))).bind fun u =>
+                (Multiset.ofList (listChoices zs (m.count false))).bind fun w =>
+                  g (v :: mergeMask m u w) := by
+      rw [Multiset.bind_map]
+      refine Multiset.bind_congr fun m _ => ?_
+      rw [hR]
+      show (Multiset.ofList (listChoices ys ((true :: m).count true))).bind
+            (fun u => (Multiset.ofList
+              (listChoices zs ((true :: m).count false))).bind fun w =>
+                g (mergeMask (true :: m) u w)) = _
+      rw [List.count_cons_self, List.count_cons_of_ne (by decide),
+          ofList_listChoices_succ ys, Multiset.bind_assoc]
+      refine Multiset.bind_congr fun v _ => ?_
+      rw [Multiset.bind_map]
+      rfl
+    -- The false-mask half reduces to the zs normal form (after commuting
+    -- the guest bind past the ys-choice bind).
+    have false_half :
+        ((Multiset.ofList (listChoices [true, false] n)).map (false :: ·)).bind R =
+          (Multiset.ofList (listChoices [true, false] n)).bind fun m =>
+            (Multiset.ofList zs).bind fun v =>
+              (Multiset.ofList (listChoices ys (m.count true))).bind fun u =>
+                (Multiset.ofList (listChoices zs (m.count false))).bind fun w =>
+                  g (v :: mergeMask m u w) := by
+      rw [Multiset.bind_map]
+      refine Multiset.bind_congr fun m _ => ?_
+      rw [hR]
+      show (Multiset.ofList (listChoices ys ((false :: m).count true))).bind
+            (fun u => (Multiset.ofList
+              (listChoices zs ((false :: m).count false))).bind fun w =>
+                g (mergeMask (false :: m) u w)) = _
+      rw [List.count_cons_of_ne (by decide), List.count_cons_self]
+      simp only [ofList_listChoices_succ zs, Multiset.bind_assoc,
+                 Multiset.bind_map]
+      rw [Multiset.bind_bind]
+      rfl
+    -- Assemble.
+    rw [ofList_listChoices_succ (ys ++ zs) n, Multiset.bind_assoc,
+        show (Multiset.ofList (ys ++ zs) : Multiset X) =
+          Multiset.ofList ys + Multiset.ofList zs from by
+            rw [← Multiset.coe_add],
+        Multiset.add_bind, ys_half, zs_half,
+        ofList_listChoices_succ [true, false] n, Multiset.bind_assoc,
+        show (Multiset.ofList [true, false] : Multiset Bool) =
+          true ::ₘ {false} from rfl,
+        Multiset.cons_bind, Multiset.singleton_bind, true_half, false_half,
+        ← Multiset.bind_add]
+
+/-- Choices over a singleton alphabet: the constant vector. -/
+theorem listChoices_singleton {X : Type*} (x : X) (n : ℕ) :
+    listChoices [x] n = [List.replicate n x] := by
+  induction n with
+  | zero => rfl
+  | succ n ih =>
+    rw [listChoices_succ, ih]
+    rfl
+
+/-- The `true`-bucket of a mask-zip has length `m.count true`. -/
+private theorem length_filterMap_zip_true {X : Type*}
+    (gs : List X) (m : List Bool) (hg : gs.length = m.length) :
+    ((gs.zip m).filterMap
+      fun p => if p.2 then some p.1 else none).length = m.count true := by
+  induction m generalizing gs with
+  | nil =>
+    rw [List.length_eq_zero_iff.mp hg]
+    rfl
+  | cons b m ih =>
+    obtain ⟨g, gs, rfl⟩ : ∃ g gs', gs = g :: gs' := by
+      cases gs with
+      | nil => simp at hg
+      | cons g gs' => exact ⟨g, gs', rfl⟩
+    rw [List.zip_cons_cons, List.filterMap_cons]
+    cases b with
+    | true =>
+      simp [List.count_cons, ih gs (by simpa using hg)]
+    | false =>
+      simp [List.count_cons, ih gs (by simpa using hg)]
+
+/-- The `false`-bucket of a mask-zip has length `m.count false`. -/
+private theorem length_filterMap_zip_false {X : Type*}
+    (gs : List X) (m : List Bool) (hg : gs.length = m.length) :
+    ((gs.zip m).filterMap
+      fun p => if p.2 then none else some p.1).length = m.count false := by
+  induction m generalizing gs with
+  | nil =>
+    rw [List.length_eq_zero_iff.mp hg]
+    rfl
+  | cons b m ih =>
+    obtain ⟨g, gs, rfl⟩ : ∃ g gs', gs = g :: gs' := by
+      cases gs with
+      | nil => simp at hg
+      | cons g gs' => exact ⟨g, gs', rfl⟩
+    rw [List.zip_cons_cons, List.filterMap_cons]
+    cases b with
+    | true =>
+      simp [List.count_cons, ih gs (by simpa using hg)]
+    | false =>
+      simp [List.count_cons, ih gs (by simpa using hg)]
+
+/-- A replicate-`[]` bucket zipped against its guests root-prepends
+    exactly those guests. -/
+private theorem filterMap_zip_replicate_root {X : Type*} (gs : List X) :
+    ((List.replicate gs.length ([] : Path)).zip gs).filterMap
+        (fun p => some p.2) = gs := by
+  induction gs with
+  | nil => rfl
+  | cons g gs ih =>
+    rw [List.length_cons, List.replicate_succ, List.zip_cons_cons,
+        List.filterMap_cons]
+    exact congrArg (g :: ·) ih
+
+/-- `multiGraftChildren` depends on its pair list only through the two
+    child filters. -/
+private theorem multiGraftChildren_congr {cs : List (Planar α)}
+    {pairs₁ pairs₂ : List (Path × Planar α)}
+    (h₁ : pairs₁.filterMap headChildFilter = pairs₂.filterMap headChildFilter)
+    (h₂ : pairs₁.filterMap tailChildFilter = pairs₂.filterMap tailChildFilter) :
+    multiGraftChildren cs pairs₁ = multiGraftChildren cs pairs₂ := by
+  cases cs with
+  | nil => rfl
+  | cons c cs =>
+    rw [multiGraftChildren_cons_cs, multiGraftChildren_cons_cs, h₁, h₂]
+
+/-! ### Index shift for `verticesAux` -/
+
+/-- Increment the head index of a path (identity on the empty path). -/
+private def bumpHead : Path → Path
+  | [] => []
+  | h :: q => (h + 1) :: q
+
+/-- `verticesAux` shifts uniformly at the list level. -/
+private theorem verticesAux_succ_list (cs : List (Planar α)) (i : ℕ) :
+    verticesAux (i + 1) cs = (verticesAux i cs).map bumpHead := by
+  induction cs generalizing i with
+  | nil => rfl
+  | cons c cs ih =>
+    rw [verticesAux_cons, verticesAux_cons, List.map_append, List.map_map,
+        ih (i + 1)]
+    rfl
+
+/-- Paths enumerated by `verticesAux` are nonempty. -/
+private theorem ne_nil_of_mem_verticesAux {p : Path} {i : ℕ}
+    {cs : List (Planar α)} (hp : p ∈ verticesAux i cs) : p ≠ [] := by
+  induction cs generalizing i with
+  | nil => simp at hp
+  | cons c cs ih =>
+    rw [verticesAux_cons, List.mem_append] at hp
+    rcases hp with hp | hp
+    · obtain ⟨q, -, rfl⟩ := List.mem_map.mp hp
+      exact List.cons_ne_nil i q
+    · exact ih hp
+
+/-! ### `filterMap` plumbing through `mergeMask`-zips
+
+`multiGraft`'s three pair filters (`rootPrependFilter`,
+`headChildFilter`, `tailChildFilter`) each kill all pairs from one
+bucket of a `mergeMask`-interleaved choice vector; the surviving bucket
+zips against its own guests. -/
+
+/-- If `F` kills every `ws`-pair, the filterMap over a merged zip
+    reduces to the `us`-bucket zipped with the `true`-position guests. -/
+private theorem filterMap_zip_mergeMask_left {X Z : Type*}
+    (F : Path × X → Option Z) (m : List Bool) (us ws : List Path)
+    (gs : List X) (hu : us.length = m.count true)
+    (hw : ws.length = m.count false) (hg : gs.length = m.length)
+    (hkill : ∀ p ∈ ws, ∀ g, F (p, g) = none) :
+    ((mergeMask m us ws).zip gs).filterMap F =
+      (us.zip ((gs.zip m).filterMap
+        fun p => if p.2 then some p.1 else none)).filterMap F := by
+  induction m generalizing us ws gs with
+  | nil =>
+    have hus : us = [] := List.length_eq_zero_iff.mp (by simpa using hu)
+    have hgs : gs = [] := List.length_eq_zero_iff.mp (by simpa using hg)
+    subst hus; subst hgs; rfl
+  | cons b m ih =>
+    obtain ⟨g, gs, rfl⟩ : ∃ g gs', gs = g :: gs' := by
+      cases gs with
+      | nil => simp at hg
+      | cons g gs' => exact ⟨g, gs', rfl⟩
+    cases b with
+    | true =>
+      obtain ⟨u, us, rfl⟩ : ∃ u us', us = u :: us' := by
+        cases us with
+        | nil => simp [List.count_cons] at hu
+        | cons u us' => exact ⟨u, us', rfl⟩
+      show ((u :: mergeMask m us ws).zip (g :: gs)).filterMap F =
+        ((u :: us).zip (g :: (gs.zip m).filterMap
+          fun p => if p.2 then some p.1 else none)).filterMap F
+      rw [List.zip_cons_cons, List.zip_cons_cons, List.filterMap_cons,
+          List.filterMap_cons,
+          ih us ws gs (by simpa [List.count_cons] using hu)
+            (by simpa [List.count_cons] using hw) (by simpa using hg) hkill]
+    | false =>
+      obtain ⟨w, ws, rfl⟩ : ∃ w ws', ws = w :: ws' := by
+        cases ws with
+        | nil => simp [List.count_cons] at hw
+        | cons w ws' => exact ⟨w, ws', rfl⟩
+      show ((w :: mergeMask m us ws).zip (g :: gs)).filterMap F =
+        (us.zip ((gs.zip m).filterMap
+          fun p => if p.2 then some p.1 else none)).filterMap F
+      rw [List.zip_cons_cons, List.filterMap_cons,
+          hkill w List.mem_cons_self g]
+      exact ih us ws gs (by simpa [List.count_cons] using hu)
+        (by simpa [List.count_cons] using hw) (by simpa using hg)
+        (fun p hp => hkill p (List.mem_cons_of_mem w hp))
+
+/-- If `F` kills every `us`-pair, the filterMap over a merged zip
+    reduces to the `ws`-bucket zipped with the `false`-position guests. -/
+private theorem filterMap_zip_mergeMask_right {X Z : Type*}
+    (F : Path × X → Option Z) (m : List Bool) (us ws : List Path)
+    (gs : List X) (hu : us.length = m.count true)
+    (hw : ws.length = m.count false) (hg : gs.length = m.length)
+    (hkill : ∀ p ∈ us, ∀ g, F (p, g) = none) :
+    ((mergeMask m us ws).zip gs).filterMap F =
+      (ws.zip ((gs.zip m).filterMap
+        fun p => if p.2 then none else some p.1)).filterMap F := by
+  induction m generalizing us ws gs with
+  | nil =>
+    have hws : ws = [] := List.length_eq_zero_iff.mp (by simpa using hw)
+    have hgs : gs = [] := List.length_eq_zero_iff.mp (by simpa using hg)
+    subst hws; subst hgs; rfl
+  | cons b m ih =>
+    obtain ⟨g, gs, rfl⟩ : ∃ g gs', gs = g :: gs' := by
+      cases gs with
+      | nil => simp at hg
+      | cons g gs' => exact ⟨g, gs', rfl⟩
+    cases b with
+    | true =>
+      obtain ⟨u, us, rfl⟩ : ∃ u us', us = u :: us' := by
+        cases us with
+        | nil => simp [List.count_cons] at hu
+        | cons u us' => exact ⟨u, us', rfl⟩
+      show ((u :: mergeMask m us ws).zip (g :: gs)).filterMap F =
+        (ws.zip ((gs.zip m).filterMap
+          fun p => if p.2 then none else some p.1)).filterMap F
+      rw [List.zip_cons_cons, List.filterMap_cons,
+          hkill u List.mem_cons_self g]
+      exact ih us ws gs (by simpa [List.count_cons] using hu)
+        (by simpa [List.count_cons] using hw) (by simpa using hg)
+        (fun p hp => hkill p (List.mem_cons_of_mem u hp))
+    | false =>
+      obtain ⟨w, ws, rfl⟩ : ∃ w ws', ws = w :: ws' := by
+        cases ws with
+        | nil => simp [List.count_cons] at hw
+        | cons w ws' => exact ⟨w, ws', rfl⟩
+      show ((w :: mergeMask m us ws).zip (g :: gs)).filterMap F =
+        ((w :: ws).zip (g :: (gs.zip m).filterMap
+          fun p => if p.2 then none else some p.1)).filterMap F
+      rw [List.zip_cons_cons, List.zip_cons_cons, List.filterMap_cons,
+          List.filterMap_cons,
+          ih us ws gs (by simpa [List.count_cons] using hu)
+            (by simpa [List.count_cons] using hw) (by simpa using hg) hkill]
+
+/-! ### Vertex-choice form of `insertionForest` -/
+
+/-- `0`-prefixed paths zipped with guests pass through `headChildFilter`
+    intact (with the leading `0` stripped). -/
+private theorem filterMap_zip_zeroCons_headChild :
+    ∀ (us : List Path) (gs : List (Planar α)),
+    ((us.map (List.cons 0)).zip gs).filterMap headChildFilter = us.zip gs := by
+  intro us gs
+  induction us generalizing gs with
+  | nil => rfl
+  | cons u us ih =>
+    cases gs with
+    | nil => rfl
+    | cons g gs =>
+      show (((0 :: u) :: us.map (List.cons 0)).zip (g :: gs)).filterMap
+            headChildFilter = (u :: us).zip (g :: gs)
+      rw [List.zip_cons_cons, List.zip_cons_cons, List.filterMap_cons,
+          headChildFilter_of_zero_cons, ih gs]
+
+/-- `bumpHead`-shifted nonempty paths zipped with guests pass through
+    `tailChildFilter` intact (undoing the bump). -/
+private theorem filterMap_zip_bumpHead_tailChild :
+    ∀ (ws : List Path) (gs : List (Planar α)),
+    (∀ p ∈ ws, p ≠ []) →
+    ((ws.map bumpHead).zip gs).filterMap tailChildFilter = ws.zip gs := by
+  intro ws gs hne
+  induction ws generalizing gs with
+  | nil => rfl
+  | cons w ws ih =>
+    cases gs with
+    | nil => rfl
+    | cons g gs =>
+      have hw : w ≠ [] := hne w List.mem_cons_self
+      obtain ⟨h, q, rfl⟩ : ∃ h q, w = h :: q := by
+        cases w with
+        | nil => exact absurd rfl hw
+        | cons h q => exact ⟨h, q, rfl⟩
+      show (((bumpHead (h :: q)) :: ws.map bumpHead).zip (g :: gs)).filterMap
+            tailChildFilter = (h :: q, g) :: ws.zip gs
+      rw [show bumpHead (h :: q) = (h + 1) :: q from rfl]
+      rw [List.zip_cons_cons, List.filterMap_cons,
+          tailChildFilter_of_succ_cons,
+          ih gs (fun p hp => hne p (List.mem_cons_of_mem _ hp))]
+
+/-- Replicate-`[]` zipped with guests passes through `rootPrependFilter`
+    intact (the empty paths give `some snd`). -/
+private theorem filterMap_zip_replicate_rootPrepend (gs : List (Planar α)) :
+    ((List.replicate gs.length ([] : Path)).zip gs).filterMap
+        rootPrependFilter = gs := by
+  induction gs with
+  | nil => rfl
+  | cons g gs ih =>
+    rw [List.length_cons, List.replicate_succ, List.zip_cons_cons,
+        List.filterMap_cons, rootPrependFilter_of_nil]
+    exact congrArg (g :: ·) ih
+
+/-- `bumpHead`-shifted nonempty paths zipped with guests are killed by
+    `rootPrependFilter` (every path is nonempty after bumping). -/
+private theorem filterMap_zip_bumpHead_rootPrepend
+    (ws : List Path) (gs : List (Planar α))
+    (hne : ∀ p ∈ ws, p ≠ []) :
+    ((ws.map bumpHead).zip gs).filterMap rootPrependFilter = [] := by
+  induction ws generalizing gs with
+  | nil => rfl
+  | cons w ws ih =>
+    cases gs with
+    | nil => rfl
+    | cons g gs =>
+      have hw : w ≠ [] := hne w List.mem_cons_self
+      obtain ⟨h, q, rfl⟩ : ∃ h q, w = h :: q := by
+        cases w with
+        | nil => exact absurd rfl hw
+        | cons h q => exact ⟨h, q, rfl⟩
+      show (((bumpHead (h :: q)) :: ws.map bumpHead).zip (g :: gs)).filterMap
+            rootPrependFilter = []
+      rw [show bumpHead (h :: q) = (h + 1) :: q from rfl,
+          List.zip_cons_cons, List.filterMap_cons, rootPrependFilter_of_cons]
+      exact ih gs (fun p hp => hne p (List.mem_cons_of_mem _ hp))
+
+/-- `0`-prefixed paths zipped with guests are killed by `tailChildFilter`
+    (every path has leading index `0`, not `k+1`). -/
+private theorem filterMap_zip_zeroCons_tailChild
+    (us : List Path) (gs : List (Planar α)) :
+    ((us.map (List.cons 0)).zip gs).filterMap tailChildFilter = [] := by
+  induction us generalizing gs with
+  | nil => rfl
+  | cons u us ih =>
+    cases gs with
+    | nil => rfl
+    | cons g gs =>
+      show (((0 :: u) :: us.map (List.cons 0)).zip (g :: gs)).filterMap
+            tailChildFilter = []
+      rw [List.zip_cons_cons, List.filterMap_cons, tailChildFilter_of_zero_cons]
+      exact ih gs
+
+/-- `[]`-paths zipped with guests are killed by `headChildFilter` (the empty
+    path has no leading index to strip). -/
+private theorem filterMap_zip_replicate_headChild (gs : List (Planar α)) :
+    ((List.replicate gs.length ([] : Path)).zip gs).filterMap
+        headChildFilter = [] := by
+  induction gs with
+  | nil => rfl
+  | cons g gs ih =>
+    rw [List.length_cons, List.replicate_succ, List.zip_cons_cons,
+        List.filterMap_cons, headChildFilter_of_nil]
+    exact ih
+
+/-- `[]`-paths zipped with guests are killed by `tailChildFilter`. -/
+private theorem filterMap_zip_replicate_tailChild (gs : List (Planar α)) :
+    ((List.replicate gs.length ([] : Path)).zip gs).filterMap
+        tailChildFilter = [] := by
+  induction gs with
+  | nil => rfl
+  | cons g gs ih =>
+    rw [List.length_cons, List.replicate_succ, List.zip_cons_cons,
+        List.filterMap_cons, tailChildFilter_of_nil]
+    exact ih
+
+/-- Grafting a guest list into a host forest, in vertex-choice form:
+    `insertionForest cs gs` is the sum over assignments of each guest to
+    a forest vertex (a `verticesAux 0 cs` path) of the simultaneous
+    `multiGraftChildren`. -/
+theorem insertionForest_eq_multiGraftChildren_choices
+    (cs gs : List (Planar α)) :
+    insertionForest cs gs =
+      Multiset.ofList ((listChoices (verticesAux 0 cs) gs.length).map
+        fun ch => multiGraftChildren cs (ch.zip gs)) := by
+  induction cs generalizing gs with
+  | nil =>
+    -- verticesAux 0 [] = [], so listChoices [] gs.length = []
+    -- unless gs.length = 0 in which case it's [[]].
+    cases gs with
+    | nil =>
+      rw [insertionForest_nil_nil]
+      show ({[]} : Multiset (List (Planar α))) = _
+      rfl
+    | cons g gs =>
+      rw [insertionForest_empty_host_nonempty_guests]
+      show (0 : Multiset (List (Planar α))) = _
+      rw [verticesAux_nil, show (g :: gs).length = gs.length + 1 from rfl,
+          listChoices_succ]
+      simp
+  | cons c cs ih =>
+    -- LHS = bind over masks m of insertion c (gs_t).bind T' =>
+    --         (insertionForest cs (gs_f)).map (T' :: ·)
+    rw [insertionForest_cons_assignment]
+    -- RHS = via verticesAux_cons, listChoices_alphabet_split, listChoices_map
+    -- Move RHS map to bind-singleton form
+    rw [show (Multiset.ofList ((listChoices (verticesAux 0 (c :: cs)) gs.length).map
+            fun ch => multiGraftChildren (c :: cs) (ch.zip gs)) :
+            Multiset (List (Planar α))) =
+          (Multiset.ofList (listChoices (verticesAux 0 (c :: cs)) gs.length)).bind
+            fun ch => ({multiGraftChildren (c :: cs) (ch.zip gs)} : Multiset _) from by
+        rw [← Multiset.map_coe]
+        rw [show ((listChoices (verticesAux 0 (c :: cs)) gs.length) :
+                Multiset (List Path)) =
+              Multiset.ofList (listChoices (verticesAux 0 (c :: cs)) gs.length) from rfl]
+        exact (Multiset.bind_singleton _ _).symm]
+    -- Now use verticesAux_cons + listChoices_alphabet_split
+    rw [verticesAux_cons]
+    rw [listChoices_alphabet_split ((vertices c).map (List.cons 0))
+          (verticesAux 1 cs) gs.length]
+    -- Per-mask congruence
+    refine Multiset.bind_congr fun m hm => ?_
+    -- Get m.length = gs.length
+    have hm' : m ∈ listChoices [true, false] gs.length := by
+      rwa [Multiset.mem_coe] at hm
+    have hmlen : m.length = gs.length :=
+      mem_listChoices_length [true, false] gs.length m hm'
+    -- LHS per-m: (insertion c gs_t).bind T' => (insertionForest cs gs_f).map (T' :: ·)
+    -- Set abbreviations for the buckets
+    set gs_t : List (Planar α) := (gs.zip m).filterMap
+      fun p => if p.snd then some p.fst else none with hgst
+    set gs_f : List (Planar α) := (gs.zip m).filterMap
+      fun p => if p.snd then none else some p.fst with hgsf
+    -- Lengths: gs_t.length = m.count true (and similarly for false)
+    have hglen : gs.length = m.length := hmlen.symm
+    have hgst_len : gs_t.length = m.count true := by
+      rw [hgst]; exact length_filterMap_zip_true gs m hglen
+    have hgsf_len : gs_f.length = m.count false := by
+      rw [hgsf]; exact length_filterMap_zip_false gs m hglen
+    -- RHS per-m: bind u': bind w': {multiGraftChildren (c::cs) ((mergeMask m u w).zip gs)}
+    -- where u in listChoices ((vertices c).map (0::·)) (m.count true)
+    --   and w in listChoices (verticesAux 1 cs) (m.count false)
+    -- Convert the u-bind via listChoices_map: 0-prefixed choices over (vertices c)
+    rw [listChoices_map (List.cons 0) (vertices c) (m.count true)]
+    rw [show (Multiset.ofList ((listChoices (vertices c) (m.count true)).map
+              (List.map (List.cons 0))) : Multiset (List Path)) =
+            (Multiset.ofList (listChoices (vertices c) (m.count true))).map
+              (List.map (List.cons 0)) from rfl]
+    rw [Multiset.bind_map]
+    -- Convert the w-bind via verticesAux_succ_list + listChoices_map
+    have h_vAux1 : verticesAux 1 cs = (verticesAux 0 cs).map bumpHead :=
+      verticesAux_succ_list cs 0
+    rw [h_vAux1, listChoices_map bumpHead (verticesAux 0 cs) (m.count false)]
+    rw [show (Multiset.ofList ((listChoices (verticesAux 0 cs) (m.count false)).map
+            (List.map bumpHead)) : Multiset (List Path)) =
+          (Multiset.ofList (listChoices (verticesAux 0 cs) (m.count false))).map
+            (List.map bumpHead) from rfl]
+    conv_rhs =>
+      rhs; ext u'
+      rw [Multiset.bind_map]
+    -- Now per (u', w'): compute multiGraftChildren (c::cs) ((mergeMask m (u'.map (0::·)) (w'.map bumpHead)).zip gs)
+    -- The head filter: 0-prefixed → strip; bumpHead → kill. Use filterMap_zip_mergeMask_left.
+    -- The tail filter: 0-prefixed → kill; bumpHead → strip. Use filterMap_zip_mergeMask_right.
+    -- Need ne_nil for w' entries: paths in verticesAux 0 cs are nonempty.
+    -- Now rewrite LHS to match — first compute insertion c gs_t and insertionForest cs gs_f
+    rw [insertion_def]
+    -- insertion c gs_t = ofList ((listChoices (vertices c) gs_t.length).map ...)
+    rw [hgst_len]
+    -- Convert this ofList.map to ofList.bind singleton
+    rw [show (Multiset.ofList ((listChoices (vertices c) (m.count true)).map
+            (fun ch => multiGraft c (ch.zip gs_t))) : Multiset (Planar α)) =
+          (Multiset.ofList (listChoices (vertices c) (m.count true))).bind
+            (fun u' => ({multiGraft c (u'.zip gs_t)} : Multiset _)) from by
+        rw [← Multiset.map_coe]
+        rw [show ((listChoices (vertices c) (m.count true)) :
+                Multiset (List Path)) =
+              Multiset.ofList (listChoices (vertices c) (m.count true)) from rfl]
+        exact (Multiset.bind_singleton _ _).symm]
+    rw [Multiset.bind_assoc]
+    -- Now apply IH to insertionForest cs gs_f
+    refine Multiset.bind_congr fun u' hu' => ?_
+    rw [ih gs_f]
+    rw [hgsf_len]
+    rw [show (Multiset.ofList ((listChoices (verticesAux 0 cs) (m.count false)).map
+            (fun ch => multiGraftChildren cs (ch.zip gs_f))) :
+            Multiset (List (Planar α))) =
+          (Multiset.ofList (listChoices (verticesAux 0 cs) (m.count false))).bind
+            (fun w' => ({multiGraftChildren cs (w'.zip gs_f)} : Multiset _)) from by
+        rw [← Multiset.map_coe]
+        rw [show ((listChoices (verticesAux 0 cs) (m.count false)) :
+                Multiset (List Path)) =
+              Multiset.ofList (listChoices (verticesAux 0 cs) (m.count false)) from rfl]
+        exact (Multiset.bind_singleton _ _).symm]
+    rw [Multiset.singleton_bind, Multiset.map_bind]
+    refine Multiset.bind_congr fun w' hw' => ?_
+    rw [Multiset.map_singleton]
+    -- Get u' ∈ listChoices (vertices c) (m.count true)
+    have hu'len : u'.length = m.count true := by
+      have hu'' : u' ∈ listChoices (vertices c) (m.count true) := by
+        rwa [Multiset.mem_coe] at hu'
+      exact mem_listChoices_length (vertices c) (m.count true) u' hu''
+    -- Get w' ∈ listChoices (verticesAux 0 cs) (m.count false)
+    have hw'mem : w' ∈ listChoices (verticesAux 0 cs) (m.count false) := by
+      rwa [Multiset.mem_coe] at hw'
+    have hw'len : w'.length = m.count false :=
+      mem_listChoices_length (verticesAux 0 cs) (m.count false) w' hw'mem
+    -- ne_nil for entries of w'
+    have hw'ne : ∀ p ∈ w', p ≠ [] := fun p hp =>
+      ne_nil_of_mem_verticesAux
+        (mem_of_mem_listChoices (verticesAux 0 cs) (m.count false) w' hw'mem p hp)
+    -- Lengths for bumpHead/0-cons-mapped lists
+    have hu'map_len : (u'.map (List.cons 0)).length = m.count true := by
+      rw [List.length_map]; exact hu'len
+    have hw'map_len : (w'.map bumpHead).length = m.count false := by
+      rw [List.length_map]; exact hw'len
+    -- ne_nil for w'.map bumpHead entries (all are (h+1) :: q)
+    have hw'bump_ne : ∀ p ∈ w'.map bumpHead, ∀ (g : Planar α),
+        headChildFilter (p, g) = none := by
+      intro p hp g
+      obtain ⟨q, hq, rfl⟩ := List.mem_map.mp hp
+      have : q ≠ [] := hw'ne q hq
+      cases q with
+      | nil => exact absurd rfl this
+      | cons h r =>
+        show headChildFilter (bumpHead (h :: r), g) = none
+        rw [show bumpHead (h :: r) = (h + 1) :: r from rfl]
+        exact headChildFilter_of_succ_cons h r g
+    have hu'zero_ne : ∀ p ∈ u'.map (List.cons 0), ∀ (g : Planar α),
+        tailChildFilter (p, g) = none := by
+      intro p hp g
+      obtain ⟨q, _, rfl⟩ := List.mem_map.mp hp
+      exact tailChildFilter_of_zero_cons q g
+    -- Compute the head-child filtered zip
+    have hhead :
+        ((mergeMask m (u'.map (List.cons 0)) (w'.map bumpHead)).zip gs).filterMap
+            headChildFilter =
+          u'.zip gs_t := by
+      rw [filterMap_zip_mergeMask_left headChildFilter m _ _ gs
+            hu'map_len hw'map_len hglen hw'bump_ne]
+      rw [filterMap_zip_zeroCons_headChild]
+    have htail :
+        ((mergeMask m (u'.map (List.cons 0)) (w'.map bumpHead)).zip gs).filterMap
+            tailChildFilter =
+          w'.zip gs_f := by
+      rw [filterMap_zip_mergeMask_right tailChildFilter m _ _ gs
+            hu'map_len hw'map_len hglen hu'zero_ne]
+      rw [filterMap_zip_bumpHead_tailChild w' _ hw'ne]
+    -- Now compute multiGraftChildren (c::cs) ((mergeMask ...).zip gs)
+    rw [show multiGraftChildren (c :: cs)
+          ((mergeMask m (u'.map (List.cons 0)) (w'.map bumpHead)).zip gs) =
+        multiGraft c (u'.zip gs_t) :: multiGraftChildren cs (w'.zip gs_f) from by
+      rw [multiGraftChildren_cons_cs, hhead, htail]]
+
+/-! ### The node-host decomposition -/
+
+/-- **Node-host decomposition** of the simultaneous multi-graft: guests
+    split by a boolean mask into root-guests (prepended as new children,
+    in guest order) and subtree-guests (an `insertionForest` into the
+    child forest). -/
+theorem insertion_node_split (a : α) (cs gs : List (Planar α)) :
+    insertion (Planar.node a cs) gs =
+      (Multiset.ofList (listChoices [true, false] gs.length)).bind fun m =>
+        (insertionForest cs ((gs.zip m).filterMap
+            fun p => if p.2 then none else some p.1)).map
+          fun cs' => Planar.node a
+            (((gs.zip m).filterMap
+              fun p => if p.2 then some p.1 else none) ++ cs') := by
+  rw [insertion_def, vertices_node]
+  -- vertices (node a cs) = [] :: verticesAux 0 cs = [[]] ++ verticesAux 0 cs
+  rw [show ([] : Path) :: verticesAux 0 cs = ([[]] : List Path) ++ verticesAux 0 cs
+        from rfl]
+  -- Convert LHS map to bind-singleton form
+  rw [show (Multiset.ofList ((listChoices ([[]] ++ verticesAux 0 cs) gs.length).map
+          fun choice => multiGraft (Planar.node a cs) (choice.zip gs)) :
+          Multiset (Planar α)) =
+        (Multiset.ofList (listChoices ([[]] ++ verticesAux 0 cs) gs.length)).bind
+          (fun choice => ({multiGraft (Planar.node a cs) (choice.zip gs)}
+            : Multiset _)) from by
+      rw [← Multiset.map_coe]
+      rw [show ((listChoices ([[]] ++ verticesAux 0 cs) gs.length) :
+              Multiset (List Path)) =
+            Multiset.ofList (listChoices ([[]] ++ verticesAux 0 cs) gs.length) from rfl]
+      exact (Multiset.bind_singleton _ _).symm]
+  -- Apply alphabet split with ys = [[]], zs = verticesAux 0 cs
+  rw [listChoices_alphabet_split ([[]] : List Path) (verticesAux 0 cs) gs.length]
+  -- Per-mask congruence
+  refine Multiset.bind_congr fun m hm => ?_
+  -- Get m.length = gs.length
+  have hm' : m ∈ listChoices [true, false] gs.length := by
+    rwa [Multiset.mem_coe] at hm
+  have hmlen : m.length = gs.length :=
+    mem_listChoices_length [true, false] gs.length m hm'
+  have hglen : gs.length = m.length := hmlen.symm
+  -- Collapse u-bind via listChoices_singleton
+  rw [listChoices_singleton ([] : Path) (m.count true)]
+  rw [show (Multiset.ofList ([List.replicate (m.count true) ([] : Path)]) :
+            Multiset (List Path)) =
+          ({List.replicate (m.count true) ([] : Path)} : Multiset _) from rfl]
+  rw [Multiset.singleton_bind]
+  -- Set abbreviations for buckets
+  set gs_t : List (Planar α) := (gs.zip m).filterMap
+    fun p => if p.snd then some p.fst else none with hgst
+  set gs_f : List (Planar α) := (gs.zip m).filterMap
+    fun p => if p.snd then none else some p.fst with hgsf
+  have hgst_len : gs_t.length = m.count true :=
+    length_filterMap_zip_true gs m hglen
+  have hgsf_len : gs_f.length = m.count false :=
+    length_filterMap_zip_false gs m hglen
+  -- Length of replicate (m.count true) []
+  have hreplen : (List.replicate (m.count true) ([] : Path)).length = m.count true := by
+    rw [List.length_replicate]
+  -- ne_nil hypotheses for the kill-lemmas
+  -- replicate-side ([]-paths): headChildFilter/tailChildFilter kill.
+  have hrep_hcf_ne : ∀ p ∈ List.replicate (m.count true) ([] : Path), ∀ (g : Planar α),
+      headChildFilter (p, g) = none := by
+    intro p hp g
+    rw [List.mem_replicate] at hp
+    rcases hp with ⟨_, rfl⟩
+    exact headChildFilter_of_nil g
+  have hrep_tcf_ne : ∀ p ∈ List.replicate (m.count true) ([] : Path), ∀ (g : Planar α),
+      tailChildFilter (p, g) = none := by
+    intro p hp g
+    rw [List.mem_replicate] at hp
+    rcases hp with ⟨_, rfl⟩
+    exact tailChildFilter_of_nil g
+  -- Rewrite the RHS map to bind-singleton form via L3
+  rw [insertionForest_eq_multiGraftChildren_choices cs gs_f]
+  rw [Multiset.map_coe, hgsf_len, List.map_map]
+  -- LHS form: bind w over listChoices (verticesAux 0 cs) (m.count false) of
+  --   {multiGraft (node a cs) ((mergeMask m (replicate (m.count true) []) w).zip gs)}
+  -- RHS form: ofList ((listChoices ... (m.count false)).map (fun ch => node a (gs_t ++ multiGraftChildren cs (ch.zip gs_f))))
+  -- Convert RHS to bind-singleton form
+  rw [show (Multiset.ofList ((listChoices (verticesAux 0 cs) (m.count false)).map
+            ((fun cs' => Planar.node a (gs_t ++ cs')) ∘
+              fun ch => multiGraftChildren cs (ch.zip gs_f))) :
+            Multiset (Planar α)) =
+          (Multiset.ofList (listChoices (verticesAux 0 cs) (m.count false))).bind
+            (fun w => ({Planar.node a
+              (gs_t ++ multiGraftChildren cs (w.zip gs_f))} : Multiset _)) from by
+      rw [← Multiset.map_coe]
+      rw [show ((listChoices (verticesAux 0 cs) (m.count false)) :
+              Multiset (List Path)) =
+            Multiset.ofList (listChoices (verticesAux 0 cs) (m.count false)) from rfl]
+      exact (Multiset.bind_singleton _ _).symm]
+  -- Per-w congruence
+  refine Multiset.bind_congr fun w hw => ?_
+  have hwmem : w ∈ listChoices (verticesAux 0 cs) (m.count false) := by
+    rwa [Multiset.mem_coe] at hw
+  have hwlen : w.length = m.count false :=
+    mem_listChoices_length (verticesAux 0 cs) (m.count false) w hwmem
+  have hwne : ∀ p ∈ w, p ≠ [] := fun p hp =>
+    ne_nil_of_mem_verticesAux
+      (mem_of_mem_listChoices (verticesAux 0 cs) (m.count false) w hwmem p hp)
+  -- w-side (nonempty paths): rootPrependFilter kills.
+  have hw_rpf_ne : ∀ p ∈ w, ∀ (g : Planar α), rootPrependFilter (p, g) = none := by
+    intro p hp g
+    have : p ≠ [] := hwne p hp
+    cases p with
+    | nil => exact absurd rfl this
+    | cons h r => exact rootPrependFilter_of_cons h r g
+  -- Compute rootPrependFilter on the merged zip → gives gs_t
+  have h_rpf :
+      ((mergeMask m (List.replicate (m.count true) ([] : Path)) w).zip gs).filterMap
+          rootPrependFilter = gs_t := by
+    rw [filterMap_zip_mergeMask_left rootPrependFilter m _ _ gs
+          hreplen hwlen hglen hw_rpf_ne]
+    rw [show (List.replicate (m.count true) ([] : Path)) =
+        List.replicate gs_t.length ([] : Path) from by rw [hgst_len]]
+    exact filterMap_zip_replicate_rootPrepend gs_t
+  -- Compute multiGraftChildren on the merged zip via multiGraftChildren_congr
+  have h_mgc :
+      multiGraftChildren cs
+          ((mergeMask m (List.replicate (m.count true) ([] : Path)) w).zip gs) =
+        multiGraftChildren cs (w.zip gs_f) := by
+    apply multiGraftChildren_congr
+    · -- headChildFilter
+      rw [filterMap_zip_mergeMask_right headChildFilter m _ _ gs
+            hreplen hwlen hglen hrep_hcf_ne]
+    · -- tailChildFilter
+      rw [filterMap_zip_mergeMask_right tailChildFilter m _ _ gs
+            hreplen hwlen hglen hrep_tcf_ne]
+  -- Now combine: multiGraft (node a cs) ((mergeMask ...).zip gs)
+  --            = node a (gs_t ++ multiGraftChildren cs (w.zip gs_f))
+  rw [multiGraft_node, h_rpf, h_mgc]
+
+end Pathed
+
+end Planar
+
+end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/PreLie/InsertionNodeDecomp.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/InsertionNodeDecomp.lean
@@ -228,18 +228,6 @@ private theorem length_filterMap_zip_false {X : Type*}
     | false =>
       simp [List.count_cons, ih gs (by simpa using hg)]
 
-/-- A replicate-`[]` bucket zipped against its guests root-prepends
-    exactly those guests. -/
-private theorem filterMap_zip_replicate_root {X : Type*} (gs : List X) :
-    ((List.replicate gs.length ([] : Path)).zip gs).filterMap
-        (fun p => some p.2) = gs := by
-  induction gs with
-  | nil => rfl
-  | cons g gs ih =>
-    rw [List.length_cons, List.replicate_succ, List.zip_cons_cons,
-        List.filterMap_cons]
-    exact congrArg (g :: ·) ih
-
 /-- `multiGraftChildren` depends on its pair list only through the two
     child filters. -/
 private theorem multiGraftChildren_congr {cs : List (Planar α)}
@@ -437,68 +425,6 @@ private theorem filterMap_zip_replicate_rootPrepend (gs : List (Planar α)) :
     rw [List.length_cons, List.replicate_succ, List.zip_cons_cons,
         List.filterMap_cons, rootPrependFilter_of_nil]
     exact congrArg (g :: ·) ih
-
-/-- `bumpHead`-shifted nonempty paths zipped with guests are killed by
-    `rootPrependFilter` (every path is nonempty after bumping). -/
-private theorem filterMap_zip_bumpHead_rootPrepend
-    (ws : List Path) (gs : List (Planar α))
-    (hne : ∀ p ∈ ws, p ≠ []) :
-    ((ws.map bumpHead).zip gs).filterMap rootPrependFilter = [] := by
-  induction ws generalizing gs with
-  | nil => rfl
-  | cons w ws ih =>
-    cases gs with
-    | nil => rfl
-    | cons g gs =>
-      have hw : w ≠ [] := hne w List.mem_cons_self
-      obtain ⟨h, q, rfl⟩ : ∃ h q, w = h :: q := by
-        cases w with
-        | nil => exact absurd rfl hw
-        | cons h q => exact ⟨h, q, rfl⟩
-      show (((bumpHead (h :: q)) :: ws.map bumpHead).zip (g :: gs)).filterMap
-            rootPrependFilter = []
-      rw [show bumpHead (h :: q) = (h + 1) :: q from rfl,
-          List.zip_cons_cons, List.filterMap_cons, rootPrependFilter_of_cons]
-      exact ih gs (fun p hp => hne p (List.mem_cons_of_mem _ hp))
-
-/-- `0`-prefixed paths zipped with guests are killed by `tailChildFilter`
-    (every path has leading index `0`, not `k+1`). -/
-private theorem filterMap_zip_zeroCons_tailChild
-    (us : List Path) (gs : List (Planar α)) :
-    ((us.map (List.cons 0)).zip gs).filterMap tailChildFilter = [] := by
-  induction us generalizing gs with
-  | nil => rfl
-  | cons u us ih =>
-    cases gs with
-    | nil => rfl
-    | cons g gs =>
-      show (((0 :: u) :: us.map (List.cons 0)).zip (g :: gs)).filterMap
-            tailChildFilter = []
-      rw [List.zip_cons_cons, List.filterMap_cons, tailChildFilter_of_zero_cons]
-      exact ih gs
-
-/-- `[]`-paths zipped with guests are killed by `headChildFilter` (the empty
-    path has no leading index to strip). -/
-private theorem filterMap_zip_replicate_headChild (gs : List (Planar α)) :
-    ((List.replicate gs.length ([] : Path)).zip gs).filterMap
-        headChildFilter = [] := by
-  induction gs with
-  | nil => rfl
-  | cons g gs ih =>
-    rw [List.length_cons, List.replicate_succ, List.zip_cons_cons,
-        List.filterMap_cons, headChildFilter_of_nil]
-    exact ih
-
-/-- `[]`-paths zipped with guests are killed by `tailChildFilter`. -/
-private theorem filterMap_zip_replicate_tailChild (gs : List (Planar α)) :
-    ((List.replicate gs.length ([] : Path)).zip gs).filterMap
-        tailChildFilter = [] := by
-  induction gs with
-  | nil => rfl
-  | cons g gs ih =>
-    rw [List.length_cons, List.replicate_succ, List.zip_cons_cons,
-        List.filterMap_cons, tailChildFilter_of_nil]
-    exact ih
 
 /-- Grafting a guest list into a host forest, in vertex-choice form:
     `insertionForest cs gs` is the sum over assignments of each guest to

--- a/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridge.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridge.lean
@@ -932,8 +932,8 @@ private theorem ckIso_circ_intertwine_insertion
     The OG-faithful route is now the active plan; see
     `[[feedback-substrate2-not-og]]` and `[[project-q5c-architecture]]`.
     Substrate infrastructure required for the new route:
-    - `GrossmanLarsonPairing.lean` (currently sorry-fenced).
-    - `Nonplanar.autCard` (Aut.lean, sorry).
+    - `GrossmanLarsonPairing.lean` (sorry-free, incl. nondegeneracy).
+    - `Nonplanar.autCard` (Aut.lean, sorry-free).
     - `Δ^ρ` cocycle (PruningNonplanar.lean, sorry-free) — REUSED.
     - `B+_a` operator (PruningNonplanar.lean, sorry-free) — REUSED.
 
@@ -1048,15 +1048,14 @@ theorem gl_product_eq_oudomGuinStar
 
 /-! ## §3: Q6 — `mul_assoc_basis` for `R = ℤ` via Q3 + Q5
 
-Combining `oudomGuinStar_assoc` (Q3, currently sorry-fenced at line 1895
-of `OudomGuinCirc.lean`) with `gl_product_eq_oudomGuinStar` (Q5c, also
+Combining `oudomGuinStar_assoc` (Q3, proved sorry-free in
+`OudomGuinCirc.lean`) with `gl_product_eq_oudomGuinStar` (Q5c,
 sorry-fenced above) closes `mul_assoc_basis` for `R = ℤ`. -/
 
 /-- **Q6 (for R = ℤ)**: associativity of the Grossman-Larson product on basis.
 
-    Doubly sorry-fenced: depends on Q3 (`oudomGuinStar_assoc`'s mul case)
-    + Q5c (`gl_product_eq_oudomGuinStar`). Verifies the structural path
-    works once both are closed. -/
+    Q3 (`oudomGuinStar_assoc`) is proved; the remaining gate is Q5c
+    (`gl_product_eq_oudomGuinStar`). -/
 theorem GrossmanLarson.mul_assoc_basis_via_oudom_guin_pbw
     (F₁ F₂ F₃ : Forest (Nonplanar α)) :
     ((GrossmanLarson.of' F₁ : GrossmanLarson ℤ α) *
@@ -1071,10 +1070,10 @@ theorem GrossmanLarson.mul_assoc_basis_via_oudom_guin_pbw
     ((GrossmanLarson.unop (GrossmanLarson.of' F₂ : GrossmanLarson ℤ α)))
   set X₃ := ckIsoSymmetricAlgebra.symm
     ((GrossmanLarson.unop (GrossmanLarson.of' F₃ : GrossmanLarson ℤ α)))
-  have h := oudomGuinStar_assoc X₁ X₂ X₃   -- Q3 (sorry-fenced)
+  have h := oudomGuinStar_assoc X₁ X₂ X₃   -- Q3 (proved)
   -- Apply ckIsoSymmetricAlgebra to both sides and use Q5c to transport.
   have := congrArg (ckIsoSymmetricAlgebra (α := α)) h
   -- The (★ ↔ GL.product) intertwining (Q5c, sorry-fenced) gives the result.
-  sorry  -- Q5c + Q3 + simp closure; ~5-20 LOC once both are sorry-free
+  sorry  -- TODO: Q5c + simp closure; ~5-20 LOC once Q5c is sorry-free
 
 end RootedTree

--- a/Linglib/Core/Combinatorics/RootedTree/Aut.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Aut.lean
@@ -44,45 +44,182 @@ top-level multiset of constituent trees.
 ## Implementation status
 
 `[UPSTREAM]` candidate. Eventual mathlib home would be
-`Mathlib.Combinatorics.RootedTree.Aut`.
+`Mathlib.Combinatorics.RootedTree.Aut`. **Sorry-free.**
 
-`Nonplanar.autCard` is currently `sorry` — implementation requires
-mutual recursion through the children-multiset structure (with a
-`DecidableEq (Nonplanar α)` from `Classical`), descended from a planar
-implementation. Fully writing it out is ~80-150 LOC of mutual
-recursion + invariance-under-`PlanarStep` proofs, deferred until the
-GL pairing scaffold consumes it.
+`Nonplanar.autCard` descends from `Planar.autCard`, defined by mutual
+structural recursion through the children list (`autCardList`
+aggregator). `PlanarStep`-invariance is established via the standard
+swap/recurse case split, and the lift to `Nonplanar` uses
+`Nonplanar.lift`. `autCard_node` bridges to the
+`forestAutCard`-as-Finset-product form via `Finset.prod_multiset_map_count`
+(turning the all-children prod into a `∏ distinct, c ^ count`-form) +
+`Finset.prod_mul_distrib`.
 
-`forestAutCard` IS defined in terms of `autCard` (no extra sorry beyond
-what flows from `autCard`'s sorry).
+`forestAutCard` is defined in terms of `autCard`.
 -/
 
 namespace RootedTree
 
 variable {α : Type*}
 
+/-! ## §1: Planar substrate -/
+
+namespace Planar
+
+/-- Symmetry-factor at one node: `∏_{distinct c ∈ M} (M.count c)!`. Uses
+    `Classical.decEq` for `Multiset.toFinset` and `Multiset.count`. -/
+noncomputable def multinomialFactor (M : Multiset (Nonplanar α)) : ℕ :=
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  M.toFinset.prod fun t => Nat.factorial (M.count t)
+
+mutual
+/-- Planar version of `Nonplanar.autCard`. Defined by mutual structural
+    recursion on the planar tree (with `autCardList` aggregating the
+    children product), using `multinomialFactor` on the multiset of
+    nonplanar-mk children to count "symmetric" rearrangements; the
+    `autCardList cs` factor is the product over all children with
+    multiplicity (which equals
+    `∏ distinct c, autCard c ^ count c` by
+    `Finset.prod_multiset_map_count`). -/
+noncomputable def autCard : Planar α → ℕ
+  | .node _ cs =>
+      autCardList cs *
+        multinomialFactor (Multiset.ofList (cs.map Nonplanar.mk))
+/-- Mutual aux: product of `autCard` over a children list. -/
+noncomputable def autCardList : List (Planar α) → ℕ
+  | []      => 1
+  | c :: cs => autCard c * autCardList cs
+end
+
+@[simp] theorem autCard_node_planar (a : α) (cs : List (Planar α)) :
+    autCard (Planar.node a cs) =
+      autCardList cs *
+        multinomialFactor (Multiset.ofList (cs.map Nonplanar.mk)) := rfl
+
+@[simp] theorem autCardList_nil :
+    autCardList ([] : List (Planar α)) = 1 := rfl
+
+@[simp] theorem autCardList_cons (c : Planar α) (cs : List (Planar α)) :
+    autCardList (c :: cs) = autCard c * autCardList cs := rfl
+
+/-- `autCardList cs = (cs.map autCard).prod` — bridge to mathlib's
+    `List.prod` over a `List.map`. -/
+theorem autCardList_eq_prod_map (cs : List (Planar α)) :
+    autCardList cs = (cs.map autCard).prod := by
+  induction cs with
+  | nil => rfl
+  | cons c cs ih => rw [autCardList_cons, List.map_cons, List.prod_cons, ih]
+
+/-! ### `autCard` is `PlanarEquiv`-invariant -/
+
+/-- `autCardList` is invariant under list permutation (it is `List.prod`
+    of `List.map autCard` up to `autCardList_eq_prod_map`). -/
+private theorem autCardList_perm {cs ds : List (Planar α)}
+    (h : List.Perm cs ds) :
+    autCardList cs = autCardList ds := by
+  rw [autCardList_eq_prod_map, autCardList_eq_prod_map]
+  exact (h.map autCard).prod_eq
+
+/-- The mk-multiset is invariant under list permutation. -/
+private theorem mk_multiset_perm {cs ds : List (Planar α)} (h : List.Perm cs ds) :
+    (Multiset.ofList (cs.map Nonplanar.mk) :
+        Multiset (Nonplanar α)) = Multiset.ofList (ds.map Nonplanar.mk) :=
+  Multiset.coe_eq_coe.mpr (h.map _)
+
+/-- `Planar.autCard` is invariant under `PlanarStep`. -/
+private theorem autCard_planarStep {t s : Planar α} (h : PlanarStep t s) :
+    autCard t = autCard s := by
+  induction h with
+  | @swapAtRoot a l r pre post =>
+    -- Children lists are permutations: same `autCardList` and same mk-multiset.
+    rw [autCard_node_planar, autCard_node_planar]
+    have hperm : List.Perm (pre ++ l :: r :: post) (pre ++ r :: l :: post) :=
+      List.Perm.append_left pre (List.Perm.swap r l post)
+    rw [autCardList_perm hperm, mk_multiset_perm hperm]
+  | @recurse a pre old new post _hstep ih =>
+    -- Children lists agree componentwise except at the spot where old → new.
+    have hmk : (Nonplanar.mk old : Nonplanar α) = Nonplanar.mk new :=
+      Nonplanar.mk_eq_mk_iff.mpr (PlanarEquiv.of_step _hstep)
+    -- autCardList legs match by ih.
+    have hlist : autCardList (pre ++ old :: post)
+               = autCardList (pre ++ new :: post) := by
+      rw [autCardList_eq_prod_map, autCardList_eq_prod_map]
+      rw [List.map_append, List.map_append, List.map_cons, List.map_cons,
+          List.prod_append, List.prod_append, List.prod_cons, List.prod_cons, ih]
+    have hmsmk : (Multiset.ofList ((pre ++ old :: post).map Nonplanar.mk) :
+                    Multiset (Nonplanar α)) =
+                 Multiset.ofList ((pre ++ new :: post).map Nonplanar.mk) := by
+      rw [List.map_append, List.map_cons, List.map_append, List.map_cons, hmk]
+    rw [autCard_node_planar, autCard_node_planar, hlist, hmsmk]
+
+/-- `Planar.autCard` is invariant under `PlanarEquiv`. -/
+theorem autCard_planarEquiv {t s : Planar α} (h : PlanarEquiv t s) :
+    autCard t = autCard s := by
+  induction h with
+  | rel _ _ hstep => exact autCard_planarStep hstep
+  | refl _ => rfl
+  | symm _ _ _ ih => exact ih.symm
+  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+
+/-! ### Positivity of `Planar.autCard` -/
+
+/-- Every factor in `multinomialFactor M` is positive (each is a factorial). -/
+private theorem multinomialFactor_pos (M : Multiset (Nonplanar α)) :
+    0 < multinomialFactor M := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  unfold multinomialFactor
+  exact Finset.prod_pos fun _ _ => Nat.factorial_pos _
+
+mutual
+/-- `Planar.autCard` is positive. By structural induction: a node's
+    autCard is `autCardList * multinomialFactor`; the second factor
+    is positive (factorials), and the first is positive iff every child's
+    autCard is positive (IH). -/
+theorem autCard_pos_planar : ∀ (t : Planar α), 0 < autCard t
+  | .node _ cs => by
+    rw [autCard_node_planar]
+    exact Nat.mul_pos (autCardList_pos cs) (multinomialFactor_pos _)
+/-- Mutual aux: `autCardList` is positive. -/
+theorem autCardList_pos : ∀ (cs : List (Planar α)), 0 < autCardList cs
+  | []      => by rw [autCardList_nil]; exact Nat.one_pos
+  | c :: cs => by
+    rw [autCardList_cons]
+    exact Nat.mul_pos (autCard_pos_planar c) (autCardList_pos cs)
+end
+
+end Planar
+
+/-! ## §2: Nonplanar `autCard` via lift -/
+
 namespace Nonplanar
 
 /-- The cardinality `|Aut(t)|` of the automorphism group of a rooted
     nonplanar tree `t`.
 
-    Recursive structure: for `t = node a M` with children-multiset `M`:
-    ```
-    autCard t = ∏_{distinct c ∈ M} (M.count c)! · (autCard c)^(M.count c)
-    ```
-    A leaf has `autCard = 1`. **TODO**: implementation. -/
-noncomputable def autCard : Nonplanar α → ℕ := sorry
+    Recursive structure: for `t = node a M` with children-multiset `M`,
+    `autCard t = ∏ distinct c ∈ M, (M.count c)! * (autCard c)^(M.count c)`
+    (see `autCard_node`). A leaf has `autCard = 1` (`autCard_leaf`).
+
+    Defined by lifting `Planar.autCard` through the `PlanarEquiv`
+    quotient. -/
+noncomputable def autCard : Nonplanar α → ℕ :=
+  Nonplanar.lift Planar.autCard (fun _ _ h => Planar.autCard_planarEquiv h)
+
+@[simp] theorem autCard_mk (t : Planar α) : autCard (mk t) = Planar.autCard t := rfl
 
 /-- A leaf has trivial aut group. -/
 @[simp] theorem autCard_leaf (a : α) : autCard (Nonplanar.leaf a : Nonplanar α) = 1 := by
-  sorry
+  show Planar.autCard (Planar.leaf a) = 1
+  unfold Planar.leaf
+  rw [Planar.autCard_node_planar, Planar.autCardList_nil]
+  simp [Planar.multinomialFactor]
 
 /-- The automorphism group of any tree is non-trivial (contains identity).
-    Stated as positivity of the cardinality. **TODO**: implementation —
-    depends on `autCard` being properly defined; currently `sorry`-consistent
-    with `autCard` itself. -/
+    Stated as positivity of the cardinality. Descends from
+    `Planar.autCard_pos_planar` via the quotient. -/
 theorem autCard_pos (t : Nonplanar α) : 0 < autCard t := by
-  sorry
+  induction t using Quotient.inductionOn with
+  | h p => exact Planar.autCard_pos_planar p
 
 /-- The cardinality `|Aut(F)|` of the automorphism group of a forest
     `F` (multiset of nonplanar trees), defined as the product over
@@ -117,11 +254,72 @@ theorem forestAutCard_pos (F : Multiset (Nonplanar α)) : 0 < forestAutCard F :=
   exact Finset.prod_pos fun t _ =>
     Nat.mul_pos (Nat.factorial_pos _) (pow_pos (autCard_pos t) _)
 
+/-- The "all children with multiplicity" prod factor in `autCard`, in
+    nonplanar form. -/
+private theorem autCardList_qout_eq (lst : List (Nonplanar α)) :
+    Planar.autCardList (lst.map Quotient.out) =
+      (lst.map autCard).prod := by
+  induction lst with
+  | nil => rfl
+  | cons x xs ih =>
+    -- ((x :: xs).map Quotient.out) = Quotient.out x :: xs.map Quotient.out
+    -- autCardList (Q.out x :: rest.map Q.out) = autCard (Q.out x) * autCardList rest
+    rw [show (x :: xs).map autCard = autCard x :: xs.map autCard from rfl,
+        List.prod_cons]
+    rw [show ((x :: xs).map Quotient.out : List (Planar α)) =
+              Quotient.out x :: xs.map Quotient.out from rfl,
+        Planar.autCardList_cons, ih]
+    -- Goal: Planar.autCard (Q.out x) * (xs.map autCard).prod = autCard x * (xs.map autCard).prod
+    congr 1
+    -- autCard x = autCard (mk (Q.out x)) = Planar.autCard (Q.out x).
+    conv_rhs => rw [← x.out_eq]
+    rfl
+
+/-- The mk-multiset of `Q.out`-lifted list of nonplanar trees equals the
+    original list. -/
+private theorem ofList_map_mk_qout (lst : List (Nonplanar α)) :
+    (Multiset.ofList (((lst.map Quotient.out).map Nonplanar.mk)) :
+        Multiset (Nonplanar α)) = Multiset.ofList lst := by
+  rw [List.map_map]
+  congr 1
+  exact (List.map_congr_left (fun x _ => x.out_eq)).trans (List.map_id lst)
+
 /-- `autCard` on the smart `node` constructor: the recursive definition.
-    **TODO**: depends on `autCard` being properly defined. -/
+    Proof: induct on `F` to get a list rep `lst`; unfold `node`, then
+    `Planar.autCard` on the planar node; the autCardList factor lifts to
+    `(lst.map autCard).prod`; the multinomialFactor factor lifts to
+    `multinomialFactor F`. Combine via `Finset.prod_multiset_map_count`
+    (to express `(F.map autCard).prod` as a Finset prod over
+    `F.toFinset`) and `Finset.prod_mul_distrib` (to recombine the two
+    legs into `forestAutCard F`). -/
 @[simp] theorem autCard_node (a : α) (F : Multiset (Nonplanar α)) :
     autCard (Nonplanar.node a F) = forestAutCard F := by
-  sorry
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  induction F using Quotient.inductionOn with
+  | h lst =>
+    -- Convert `Quotient.mk _ lst` to `Multiset.ofList lst` (definitionally equal).
+    show Planar.autCard (Planar.node a (lst.map Quotient.out)) =
+        forestAutCard (Multiset.ofList lst)
+    rw [Planar.autCard_node_planar, autCardList_qout_eq lst, ofList_map_mk_qout lst]
+    -- LHS: (lst.map autCard).prod * multinomialFactor (Multiset.ofList lst).
+    -- RHS: forestAutCard (Multiset.ofList lst) =
+    --      (Multiset.ofList lst).toFinset.prod fun t => (count t)! * autCard t ^ count t.
+    unfold forestAutCard Planar.multinomialFactor
+    -- (lst.map autCard).prod = ((Multiset.ofList lst).map autCard).prod
+    --                       = ∏ t ∈ toFinset, autCard t ^ count t.
+    have hprod_lst : ((Multiset.ofList lst).map autCard).prod
+                  = ((Multiset.ofList lst).toFinset).prod
+                      fun t => autCard t ^ (Multiset.ofList lst).count t :=
+      Finset.prod_multiset_map_count (Multiset.ofList lst) autCard
+    -- Massage LHS prod via Multiset coercion: (lst.map autCard).prod = Multiset.prod ↑(...).
+    have hcoe : (lst.map autCard).prod = ((Multiset.ofList lst).map autCard).prod := rfl
+    rw [hcoe, hprod_lst]
+    -- Combine the two Finset prods via Finset.prod_mul_distrib.
+    rw [← Finset.prod_mul_distrib]
+    -- Match summands: pow * factorial = factorial * pow.
+    apply Finset.prod_congr rfl
+    intro t _
+    ring
 
 end Nonplanar
 

--- a/Linglib/Core/Combinatorics/RootedTree/Nonplanar.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Nonplanar.lean
@@ -540,27 +540,72 @@ example {α : Type*} (a b c : α) :
   have := node_mk_planar_list a [Planar.leaf b, Planar.leaf c]
   simpa [leaf] using this
 
-/-! ### Root label and children (parallel-session API stubs)
+/-! ### Root label and children
 
-Referenced by `Core/Algebra/RootedTree/BMinus.lean`. Stubbed with
-`sorry` to unblock the build; proper implementation requires lifting
-`Planar.label` (via `planarEquiv_label_eq`) and `Planar.children` (via
-`planarEquiv_root_perm`) through the `PlanarEquiv` quotient. -/
+Root-level projections, lifted through the quotient: `Planar.label` is
+`PlanarEquiv`-invariant on the nose (`planarEquiv_label_eq`), and the
+mk-image of `Planar.children` is invariant as a *multiset* (root swaps
+permute the list; recursive steps rewrite a child within its `mk`-class). -/
+
+/-- The mk-image of the root children, as a multiset, is preserved by a
+    single `PlanarStep`. -/
+private theorem planarStep_children_multiset_eq {t s : Planar α}
+    (h : Planar.PlanarStep t s) :
+    Multiset.ofList (t.children.map mk) = Multiset.ofList (s.children.map mk) := by
+  cases h with
+  | @swapAtRoot a l r pre post =>
+    simp only [Planar.children_node]
+    exact Multiset.coe_eq_coe.mpr
+      (((List.Perm.swap r l post).append_left pre).map mk)
+  | @recurse a pre old new post hstep =>
+    simp only [Planar.children_node, List.map_append, List.map_cons]
+    rw [mk_step hstep]
+
+/-- The mk-image of the root children, as a multiset, is preserved by
+    `PlanarEquiv`. -/
+theorem planarEquiv_children_multiset_eq {t s : Planar α}
+    (h : Planar.PlanarEquiv t s) :
+    Multiset.ofList (t.children.map mk) = Multiset.ofList (s.children.map mk) := by
+  induction h with
+  | rel _ _ hstep => exact planarStep_children_multiset_eq hstep
+  | refl _ => rfl
+  | symm _ _ _ ih => exact ih.symm
+  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
 
 /-- The root label of a nonplanar tree. -/
-noncomputable def rootLabel : Nonplanar α → α := sorry
+def rootLabel : Nonplanar α → α :=
+  Nonplanar.lift Planar.label (fun _ _ h => Planar.planarEquiv_label_eq h)
 
 /-- The multiset of root children of a nonplanar tree. -/
-noncomputable def rootChildren : Nonplanar α → Multiset (Nonplanar α) := sorry
+def rootChildren : Nonplanar α → Multiset (Nonplanar α) :=
+  Nonplanar.lift (fun t => Multiset.ofList (t.children.map mk))
+    (fun _ _ h => planarEquiv_children_multiset_eq h)
+
+@[simp] theorem rootLabel_mk (t : Planar α) : rootLabel (mk t) = t.label := rfl
+
+@[simp] theorem rootChildren_mk (t : Planar α) :
+    rootChildren (mk t) = Multiset.ofList (t.children.map mk) := rfl
 
 @[simp] theorem rootLabel_node (a : α) (F : Multiset (Nonplanar α)) :
-    rootLabel (node a F) = a := sorry
+    rootLabel (node a F) = a := by
+  induction F using Quotient.inductionOn with
+  | h lst => rfl
 
 @[simp] theorem rootChildren_node (a : α) (F : Multiset (Nonplanar α)) :
-    rootChildren (node a F) = F := sorry
+    rootChildren (node a F) = F := by
+  induction F using Quotient.inductionOn with
+  | h lst =>
+    show Multiset.ofList (((lst.map Quotient.out).map mk)) = Multiset.ofList lst
+    rw [List.map_map]
+    congr 1
+    exact (List.map_congr_left (fun x _ => Quotient.out_eq x)).trans (List.map_id lst)
 
 /-- Eta law: every tree is the `node` of its root label and root children. -/
-theorem node_eta (t : Nonplanar α) : node (rootLabel t) (rootChildren t) = t := sorry
+theorem node_eta (t : Nonplanar α) : node (rootLabel t) (rootChildren t) = t := by
+  induction t using Quotient.inductionOn with
+  | h p =>
+    cases p with
+    | node a cs => exact node_mk_planar_list a cs
 
 end Nonplanar
 

--- a/Linglib/Core/Combinatorics/RootedTree/Nonplanar/Insertion.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Nonplanar/Insertion.lean
@@ -123,11 +123,126 @@ theorem toList_map_quotientOut_add_perm (M N : Multiset (Nonplanar α)) :
   rw [← List.map_append]
   exact (Multiset.toList_add_perm M N).map _
 
+/-- Planar substrate for `insertionMultiset_card_eq`: every output list in
+    `insertionForest host guests` has length equal to the host length.
+    `insertionForest` produces `T' :: F'` lists by recursion on the host;
+    each step prepends one tree and recurses on the tail. -/
+private theorem _root_.RootedTree.Planar.Pathed.insertionForest_length
+    {α : Type*} :
+    ∀ (host guests : List (Planar α)) {L : List (Planar α)},
+      L ∈ Planar.Pathed.insertionForest host guests → L.length = host.length
+  | [],     [],         L, hL => by
+    rw [Planar.Pathed.insertionForest_nil_nil] at hL
+    rw [Multiset.mem_singleton.mp hL]
+  | [],     _ :: _,     L, hL => by
+    rw [Planar.Pathed.insertionForest_empty_host_nonempty_guests] at hL
+    exact absurd hL (Multiset.notMem_zero L)
+  | T :: F, [],         L, hL => by
+    rw [Planar.Pathed.insertionForest_cons_host_nil_guests] at hL
+    rw [Multiset.mem_singleton.mp hL]
+  | T :: F, T_g :: Ts,  L, hL => by
+    rw [Planar.Pathed.insertionForest_cons_cons] at hL
+    -- L ∈ bind of bind of map; unfold mem step by step.
+    rw [Multiset.mem_bind] at hL
+    obtain ⟨assignment, _hass, hL⟩ := hL
+    rw [Multiset.mem_bind] at hL
+    obtain ⟨T', _hT', hL⟩ := hL
+    rw [Multiset.mem_map] at hL
+    obtain ⟨F', hF'mem, hL_eq⟩ := hL
+    -- L = T' :: F', with F' from the inner insertionForest F (sub-guests).
+    have hF'len : F'.length = F.length :=
+      Planar.Pathed.insertionForest_length F _ hF'mem
+    rw [← hL_eq, List.length_cons, hF'len, List.length_cons]
+  termination_by host _ => host.length
+
 /-- The insertion multiset preserves cardinality: every forest in
-    `insertionMultiset A B` has the same cardinality as `A`. Stub. -/
+    `insertionMultiset A B` has the same cardinality as `A`.
+
+    Proof: `insertionMultiset A B` is built from
+    `insertionForest (A.toList.map Q.out) (B.toList.map Q.out)`; every
+    output list `L` has `L.length = (A.toList.map Q.out).length = A.card`
+    (via `Planar.Pathed.insertionForest_length`); and the cardinality of
+    the lifted `Multiset.ofList (L.map mk)` equals `L.length`. -/
 theorem insertionMultiset_card_eq {α : Type*} (A B : Multiset (Nonplanar α))
     {F' : Multiset (Nonplanar α)} (hF' : F' ∈ insertionMultiset A B) :
-    F'.card = A.card := sorry
+    F'.card = A.card := by
+  unfold insertionMultiset at hF'
+  rw [Multiset.mem_map] at hF'
+  obtain ⟨L, hL_mem, hL_eq⟩ := hF'
+  have hLlen : L.length = (A.toList.map Quotient.out).length :=
+    Planar.Pathed.insertionForest_length _ _ hL_mem
+  rw [← hL_eq]
+  -- F'.card = (Multiset.ofList (L.map mk)).card = (L.map mk).length = L.length.
+  show (Multiset.ofList (L.map Nonplanar.mk)).card = A.card
+  rw [Multiset.coe_card, List.length_map, hLlen, List.length_map]
+  exact Multiset.length_toList A
+
+/-! ## §3: Root-label preservation for singleton hosts
+
+When the host forest is a single tree `{T}`, every output forest of
+`insertionMultiset {T} B` is a singleton `{T'}` and `T'.rootLabel =
+T.rootLabel`: grafting guests into a tree only modifies its subtrees,
+never its root label.
+
+The proof descends through the planar substrate using
+`Planar.Pathed.insertionForest_singleton` and `multiGraft_node` (which
+preserves the head label by structure). -/
+
+/-- **Planar root preservation**: `Planar.label (multiGraft T pairs) =
+    Planar.label T`. Follows directly from `multiGraft_node`, which
+    rebuilds the root with the same label `a`. -/
+private theorem _root_.RootedTree.Planar.label_multiGraft
+    (T : Planar α) (pairs : List (Planar.Pathed.Path × Planar α)) :
+    (Planar.Pathed.multiGraft T pairs).label = T.label := by
+  cases T with
+  | node a cs => rw [Planar.Pathed.multiGraft_node, Planar.label_node, Planar.label_node]
+
+/-- **Singleton-host root preservation**: every forest in
+    `insertionMultiset {T} B` is a singleton `{T'}` and `T'.rootLabel =
+    T.rootLabel`. Descends through `insertionForest_singleton` +
+    `Planar.label_multiGraft`. -/
+theorem insertionMultiset_singleton_rootLabel
+    (T : Nonplanar α) (B : Multiset (Nonplanar α))
+    {F' : Multiset (Nonplanar α)} (hF' : F' ∈ insertionMultiset {T} B) :
+    ∃ T' : Nonplanar α, F' = ({T'} : Multiset (Nonplanar α)) ∧
+      T'.rootLabel = T.rootLabel := by
+  unfold insertionMultiset at hF'
+  rw [Multiset.mem_map] at hF'
+  obtain ⟨L, hL_mem, hL_eq⟩ := hF'
+  -- ({T} : Multiset _).toList = [T] via `Multiset.toList_singleton`.
+  have h_toList : ({T} : Multiset (Nonplanar α)).toList.map Quotient.out =
+      [Quotient.out T] := by
+    rw [Multiset.toList_singleton]; rfl
+  rw [h_toList] at hL_mem
+  -- Use `insertionForest_singleton`.
+  rw [Planar.Pathed.insertionForest_singleton] at hL_mem
+  rw [Multiset.mem_map] at hL_mem
+  obtain ⟨T'_pl, hT'_pl_mem, hT'_pl_eq⟩ := hL_mem
+  -- T'_pl ∈ insertion (Q.out T) gs, so T'_pl = multiGraft (Q.out T) (choice.zip gs)
+  -- for some choice. Hence label T'_pl = label (Q.out T) = T.rootLabel.
+  refine ⟨Nonplanar.mk T'_pl, ?_, ?_⟩
+  · -- F' = {Nonplanar.mk T'_pl}: L = [T'_pl], so F' = ofList [mk T'_pl] = {mk T'_pl}.
+    rw [← hL_eq, ← hT'_pl_eq]
+    show (Multiset.ofList (([T'_pl] : List (Planar α)).map Nonplanar.mk) :
+            Multiset (Nonplanar α)) = {Nonplanar.mk T'_pl}
+    rfl
+  · -- Root label preservation through the planar substrate.
+    -- T'_pl ∈ insertion T.out (...): T'_pl = multiGraft T.out pairs for some pairs.
+    rw [Nonplanar.rootLabel_mk]
+    -- Unfold `insertion` to extract the choice and reduce label-equality.
+    rw [Planar.Pathed.insertion_def, Multiset.mem_coe, List.mem_map] at hT'_pl_mem
+    obtain ⟨choice, _hchoice_mem, hchoice_eq⟩ := hT'_pl_mem
+    rw [← hchoice_eq]
+    -- Now: label (multiGraft T.out (choice.zip ...)) = T.rootLabel
+    rw [Planar.label_multiGraft]
+    -- label T.out = rootLabel T via `rootLabel_mk T.out_eq`.
+    -- (Quotient.out T).label = (mk (Quotient.out T)).rootLabel by `rootLabel_mk`;
+    -- mk (Quotient.out T) = T by `T.out_eq`.
+    show (Quotient.out T).label = T.rootLabel
+    have h_eq : Nonplanar.mk (Quotient.out T) = T := T.out_eq
+    calc (Quotient.out T).label
+        = (Nonplanar.mk (Quotient.out T)).rootLabel := (Nonplanar.rootLabel_mk _).symm
+      _ = T.rootLabel := by rw [h_eq]
 
 end Nonplanar
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -3624,6 +3624,20 @@
   role      = {cited},
   validated = {true},
   sources   = {Linglib/Core/Combinatorics/RootedTree/Decorated.lean}
+}% REF: Oudom, J.-M. & D. Guin (2008). On the Lie enveloping algebra of a pre-Lie algebra. J. K-Theory 2(1), 147–167. Constructs an associative product on the symmetric module of a pre-Lie algebra making it a Hopf algebra isomorphic to the enveloping algebra of the associated Lie algebra; applied to rooted trees this yields the Grossman-Larson Hopf algebra, dual to Connes-Kreimer.
+@article{oudom-guin-2008,
+  author    = {Oudom, Jean-Michel and Guin, Daniel},
+  year      = {2008},
+  title     = {On the {L}ie enveloping algebra of a pre-{L}ie algebra},
+  journal   = {Journal of K-Theory},
+  volume    = {2},
+  number    = {1},
+  pages     = {147--167},
+  doi       = {10.1017/is008001011jkt037},
+  subfield  = {algebra/hopf-algebras},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Linglib/Core/Algebra/PreLie/GuinOudom.lean; Linglib/Core/Algebra/PreLie/OudomGuinCirc.lean; Linglib/Core/Algebra/RootedTree/PreLie/BMinusSL.lean}
 }% REF: Foley, W. A. & R. D. Van Valin, Jr. (1984). Functional Syntax and Universal Grammar. Cambridge University Press.
 @book{foley-r-d-van-valin-1984,
   author    = {Gulstad, Daniel E. and Foley, William A. and van Valin, Robert D.},


### PR DESCRIPTION
Proves `nim_singleton_node_a_decomp` (the singleton-host insertion partition) via a new fully-proved planar engine (`PreLie/InsertionNodeDecomp.lean`: alphabet-split enumeration, vertex-choice form of `insertionForest`, node-host decomposition), closing the CK-side Oudom-Guin Prop 3.2 cocycle `bMinusLin_gl_mul` kernel-clean.

- also closes: `Nonplanar.rootLabel`/`rootChildren`/`node_eta` stubs, `autCard` (4), `insertionMultiset_card_eq`, both BMinusSL sorries (SL cocycle `mul` case + `bMinusLin_ckIso`), and the `bMinusLin_gl_mul_basis` subcase — 16 sorries total, all statements computationally validated before proof
- registers the now-sorry-free `BMinus`/`InsertionNodeDecomp` in `Linglib.lean`; adds the verified `oudom-guin-2008` bib entry; fixes stale status docstrings (incl. mislabeled "Prop 3.9" → Prop 2.8, verified against the paper)