### PR TITLE
feat(Syntax/Minimalist/Phi): articulation order; bundle probe laws

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2145,6 +2145,7 @@ import Linglib.Syntax.Minimalist.NestedAgree
 import Linglib.Syntax.Minimalist.Phi.Geometry
 import Linglib.Syntax.Minimalist.Phi.Lattice
 import Linglib.Syntax.Minimalist.Phi.Probing
+import Linglib.Syntax.Minimalist.Phi.Articulation
 import Linglib.Syntax.Minimalist.PConstraint
 import Linglib.Syntax.Minimalist.ObligatoryOperations
 import Linglib.Syntax.Case.Alignment

--- a/Linglib/Studies/CoonKeine2021.lean
+++ b/Linglib/Studies/CoonKeine2021.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Minimalist.Phi.Probing
+import Linglib.Syntax.Minimalist.Phi.Articulation
 import Linglib.Syntax.Minimalist.CyclicAgree
 import Linglib.Syntax.Minimalist.PConstraint
 import Linglib.Studies.BejarRezac2003
@@ -42,8 +43,15 @@ prose; `pccViolation` states its upshot, gluttony itself.
 
 Universal predictions (§3.4.2): no probe bans [PART]>3 or 3>3
 (`direct_never_banned` — the geometry makes such gluttony
-impossible), and for well-articulated probes a [PART]>[PART] ban
-entails a 3>[PART] ban (`ban_part_part_implies_ban_three_part`).
+impossible); for [uPERS]-rooted probes a [PART]>[PART] ban entails a
+3>[PART] ban (`ban_part_part_implies_ban_three_part`, bundled as
+`ArticulatedProbe.ban_part_part`); a single-segment probe never
+gluttons (`not_gluttonous_single_segment`, their fn. 21). The
+articulation laws themselves — downward closure along the geometry,
+the (40) probe-specification hierarchy — live in
+`Phi/Articulation.lean` (`IsArticulated`, `ArticulatedProbe`,
+`ProbeStage`); `meFirstProbe_not_articulated` is their fn. 22 made
+formal.
 
 ## Rival accounts (their §2, comparisons drawn by the paper)
 
@@ -335,22 +343,41 @@ theorem direct_never_banned (P : Probe) (io : Person) :
   subst this
   cases io <;> decide
 
-/-- Probes articulated along the geometry (their (13)/(39a,b)/(i)):
-    rooted in [uPERS], downward-closed. `meFirstProbe` violates this
-    (their fn. 22: missing intermediates are "not innocuous"). -/
-def WellArticulated (P : Probe) : Prop :=
-  Segment.pi ∈ P ∧
-  (Segment.speaker ∈ P → Segment.participant ∈ P) ∧
-  (Segment.addressee ∈ P → Segment.participant ∈ P)
+/-- Their fn. 22, formal: the Me-First probe (39c) is not articulated
+    — [uSPKR] without [uPART] is not downward-closed along the
+    geometry (`IsArticulated`, `Phi/Articulation.lean`). The
+    branching Strong probe of fn. 22 (i) is. -/
+theorem meFirstProbe_not_articulated :
+    ¬ IsArticulated meFirstProbe ∧ IsArticulated branchingStrongProbe := by
+  decide
 
-/-- For well-articulated probes, banning [PART]>[PART] entails
-    banning 3>[PART] (their §3.4.2 implicational universal,
-    instantiated at 2>1 ⇒ 3>1): the only segment a 1st-person DO
-    can win against a 2nd-person IO is [uSPKR], and it wins against
-    a 3rd-person IO a fortiori, while [uPERS] still lands on the
-    IO. -/
+/-- Their fn. 21: a single-segment (unarticulated) probe never
+    gluttons — a language whose object probe is bare [uφ] is
+    predicted to lack PCC effects altogether. -/
+theorem not_gluttonous_single_segment {σ : Type*} (bears : σ → Goal → Bool)
+    (s : σ) (goals : List Goal) :
+    ¬ GluttonousOn bears [s] goals := by
+  rintro ⟨s₁, hs₁, s₂, hs₂, t₁, _, t₂, _, h₁, h₂, hne⟩
+  have e1 : s₁ = s := by
+    cases hs₁ with
+    | head => rfl
+    | tail _ h => exact nomatch h
+  have e2 : s₂ = s := by
+    cases hs₂ with
+    | head => rfl
+    | tail _ h => exact nomatch h
+  subst e1; subst e2
+  exact hne (congrArg Prod.snd (Option.some.inj (h₁.symm.trans h₂)))
+
+/-- For [uPERS]-rooted probes, banning [PART]>[PART] entails banning
+    3>[PART] (their §3.4.2 implicational universal, instantiated at
+    2>1 ⇒ 3>1): the only segment a 1st-person DO can win against a
+    2nd-person IO is [uSPKR], and it wins against a 3rd-person IO a
+    fortiori, while [uPERS] still lands on the IO. (Rootedness — the
+    one property every probe of their (13)/(39) has — suffices; full
+    downward closure is not needed.) -/
 theorem ban_part_part_implies_ban_three_part (P : Probe)
-    (hwf : WellArticulated P)
+    (hpi : Segment.pi ∈ P)
     (h : pccViolation P false .second .first) :
     pccViolation P false .third .first := by
   obtain ⟨s₁, hs₁, s₂, hs₂, t₁, ht₁m, t₂, ht₂m, h₁, h₂, hne⟩ := h
@@ -373,9 +400,17 @@ theorem ban_part_part_implies_ban_three_part (P : Probe)
     · exact spk_of s₁ h₁ ▸ hs₁
     · exact absurd rfl hne
   -- with [uPERS] and [uSPKR] both on the probe, 3>1 is gluttonous
-  exact ⟨.pi, hwf.1, .speaker, hspk,
+  exact ⟨.pi, hpi, .speaker, hspk,
     (dp .third, 0), by decide, (dp .first, 1), by decide,
     by decide, by decide, by decide⟩
+
+/-- The bundled form: an `ArticulatedProbe` (`Phi/Articulation.lean`)
+    carries [uPERS]-rootedness as a law, so the implicational
+    universal needs no side condition. -/
+theorem ArticulatedProbe.ban_part_part (P : ArticulatedProbe)
+    (h : pccViolation P.segments false .second .first) :
+    pccViolation P.segments false .third .first :=
+  ban_part_part_implies_ban_three_part P.segments P.rooted h
 
 /-! ### Rival accounts (their §2) -/
 

--- a/Linglib/Syntax/Minimalist/Phi/Articulation.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Articulation.lean
@@ -1,0 +1,164 @@
+import Mathlib.Order.UpperLower.Basic
+import Linglib.Syntax.Minimalist.CyclicAgree
+
+/-!
+# Probe articulation: the segment order and its laws
+[bejar-rezac-2009] [coon-keine-2021] [harley-ritter-2002]
+
+The φ-feature geometry ([harley-ritter-2002]; [coon-keine-2021]'s
+(11)) is a partial order on `CyclicAgree.Segment`: [π] is bottom and
+[speaker]/[addressee] are the maximal leaves, with `s ≤ t` read as
+"bearing `t` entails bearing `s`". Two laws of probe systems then
+become order theory:
+
+- **Articulation** ([bejar-rezac-2009]; [coon-keine-2021] (13)): a
+  probe's segments are downward-closed along the geometry —
+  `IsArticulated`, equivalent to mathlib's `IsLowerSet`
+  (`isArticulated_iff_isLowerSet`). Goal specifications are also
+  lower sets (`personSpec_isArticulated`): that is the geometric
+  containment (author ⊂ participant ⊂ π) as order theory.
+  [coon-keine-2021]'s fn. 22 flags probes with missing intermediate
+  segments (their Me-First probe) as non-innocuous — here, they are
+  exactly the non-lower-set probes. `ArticulatedProbe` bundles the
+  laws.
+- **The probe-specification hierarchy** ([coon-keine-2021] (40)):
+  `[uφ] → [uπ] → [uπ ▷ u#] → [uπ ▷ u# ▷ uΓ]`. `ProbeStage` carries
+  the hierarchy as a type: a number probe without a person probe is
+  unrepresentable, which is how the account derives the missing
+  "Number Case Constraint" (see `Studies/CoonKeine2021.lean`,
+  `no_number_case_constraint`).
+
+## Main declarations
+
+- `Segment.below`, the `PartialOrder Segment` instance — the geometry.
+- `IsArticulated` — downward-closure of a segment list; decidable.
+- `ArticulatedProbe` — segments + rootedness in [π] + closure.
+- `ProbeStage` — the (40) hierarchy, with `number_requires_person` /
+  `gender_requires_number` as theorems.
+-/
+
+namespace Minimalist
+
+open CyclicAgree (Segment)
+
+/-! ### The segment order -/
+
+instance : Fintype Segment :=
+  ⟨⟨([.pi, .participant, .speaker, .addressee] : List Segment), by decide⟩,
+   fun s => by cases s <;> decide⟩
+
+/-- The downward closure of a single segment in the geometry
+    ([coon-keine-2021] (11)): everything bearing this segment also
+    bears these. -/
+def CyclicAgree.Segment.below : Segment → List Segment
+  | .pi => [.pi]
+  | .participant => [.pi, .participant]
+  | .speaker => [.pi, .participant, .speaker]
+  | .addressee => [.pi, .participant, .addressee]
+
+/-- The entailment order: `s ≤ t` iff bearing `t` entails bearing
+    `s`. [π] is bottom; [speaker] and [addressee] are incomparable
+    maximal leaves. -/
+instance : PartialOrder Segment where
+  le s t := s ∈ t.below
+  le_refl s := by cases s <;> decide
+  le_trans s t u hst htu := by
+    revert hst htu; cases s <;> cases t <;> cases u <;> decide
+  le_antisymm s t hst hts := by
+    revert hst hts
+    cases s <;> cases t <;> decide
+
+instance : DecidableRel (α := Segment) (· ≤ ·) := fun s t =>
+  inferInstanceAs (Decidable (s ∈ t.below))
+
+instance : OrderBot Segment where
+  bot := .pi
+  bot_le s := by cases s <;> decide
+
+/-! ### Articulation as downward closure -/
+
+/-- A segment list is articulated iff it is downward-closed along
+    the geometry ([bejar-rezac-2009]'s articulated probes;
+    [coon-keine-2021] (13)). Goal specifications are articulated
+    too — geometric containment and probe articulation are the same
+    order-theoretic fact. -/
+def IsArticulated (P : List Segment) : Prop :=
+  ∀ s ∈ P, ∀ t, t ≤ s → t ∈ P
+
+instance (P : List Segment) : Decidable (IsArticulated P) :=
+  inferInstanceAs (Decidable (∀ s ∈ P, ∀ t, t ≤ s → t ∈ P))
+
+/-- Articulation is mathlib's `IsLowerSet`, on the membership set. -/
+theorem isArticulated_iff_isLowerSet (P : List Segment) :
+    IsArticulated P ↔ IsLowerSet {s | s ∈ P} :=
+  ⟨fun h _ _ hba ha => h _ ha _ hba, fun h s hs t hts => h hts hs⟩
+
+/-- Person specifications are articulated, for both geometries: the
+    [harley-ritter-2002] containment as a lower-set fact. -/
+theorem personSpec_isArticulated (geom : CyclicAgree.Geometry) (p : Person) :
+    IsArticulated (CyclicAgree.personSpec geom p) := by
+  cases geom <;> cases p <;> decide
+
+/-- [bejar-rezac-2009]'s named probes are all articulated. -/
+theorem namedProbes_isArticulated :
+    IsArticulated CyclicAgree.flatProbe ∧
+    IsArticulated CyclicAgree.partialProbe ∧
+    IsArticulated CyclicAgree.fullProbeStd ∧
+    IsArticulated CyclicAgree.fullProbeAddr := by
+  decide
+
+/-- A bundled articulated probe: segments rooted in [uπ] (every
+    probe of [coon-keine-2021]'s (13)/(39) contains [uPERS]) and
+    downward-closed along the geometry. Probes with missing
+    intermediate segments — [coon-keine-2021]'s Me-First (39c),
+    flagged in their fn. 22 — fail `lower` and cannot be bundled. -/
+structure ArticulatedProbe where
+  segments : CyclicAgree.ProbeArticulation
+  rooted : Segment.pi ∈ segments
+  lower : IsArticulated segments
+
+/-! ### The probe-specification hierarchy ([coon-keine-2021] (40)) -/
+
+/-- The (40) hierarchy as a type:
+    `[uφ] → [uπ] → [uπ ▷ u#] → [uπ ▷ u# ▷ uΓ]`. A φ-probe system is
+    one of these four stages; unattested inventories — a number probe
+    without a person probe, a gender probe without a number probe —
+    are unrepresentable. The universal ordering (π probes before #,
+    # before Γ) is carried by the stage itself. -/
+inductive ProbeStage where
+  /-- A single unsplit [uφ] probe. -/
+  | unsplit
+  /-- A person probe only. -/
+  | personOnly
+  /-- Person and number probes, π ▷ #. -/
+  | personNumber
+  /-- Person, number, and gender probes, π ▷ # ▷ Γ. -/
+  | personNumberGender
+  deriving DecidableEq, Repr
+
+/-- Does the stage have a dedicated person probe? -/
+def ProbeStage.hasPersonProbe : ProbeStage → Bool
+  | .unsplit => false
+  | _ => true
+
+/-- Does the stage have a number probe? -/
+def ProbeStage.hasNumberProbe : ProbeStage → Bool
+  | .personNumber | .personNumberGender => true
+  | _ => false
+
+/-- Does the stage have a gender probe? -/
+def ProbeStage.hasGenderProbe : ProbeStage → Bool
+  | .personNumberGender => true
+  | _ => false
+
+/-- (40), first law: a number probe entails a person probe. -/
+theorem ProbeStage.number_requires_person (st : ProbeStage) :
+    st.hasNumberProbe = true → st.hasPersonProbe = true := by
+  cases st <;> decide
+
+/-- (40), second law: a gender probe entails a number probe. -/
+theorem ProbeStage.gender_requires_number (st : ProbeStage) :
+    st.hasGenderProbe = true → st.hasNumberProbe = true := by
+  cases st <;> decide
+
+end Minimalist


### PR DESCRIPTION
The law-bearing probe structure the arc has been building toward.

- `Phi/Articulation.lean`: the φ-geometry as a `PartialOrder` on `CyclicAgree.Segment` ([π] bottom, [speaker]/[addressee] maximal leaves); articulation = downward closure (`IsArticulated` ↔ mathlib `IsLowerSet`); goal specifications proven lower sets (`personSpec_isArticulated` — H&R containment as order theory); `ArticulatedProbe` bundles rootedness + closure; `ProbeStage` carries C&K's (40) hierarchy as a type (number-without-person unrepresentable, the two implication laws as theorems).
- CoonKeine2021 rewired: fn. 22 formal (`meFirstProbe_not_articulated` — the Me-First probe is exactly a non-lower-set); fn. 21 formal (`not_gluttonous_single_segment` — unarticulated probes never glutton); the §3.4.2 implicational universal restated with the honest minimal hypothesis (rootedness — bundling exposed that closure was never used) plus the bundled `ArticulatedProbe.ban_part_part`.