### PR TITLE
refactor(Syntax/Minimalist/Phi): unified Probe object with dot-notation

### DIFF
--- a/Linglib/Studies/BejarRezac2003.lean
+++ b/Linglib/Studies/BejarRezac2003.lean
@@ -26,7 +26,7 @@ in a [chomsky-2000] probe-goal system:
   dative absorbs — the PCC.
 
 Through `Phi/Probing.lean`, the [π]-probe is the **off-diagonal**
-licensing shape: visibility is total (`probeSearch ⊤` = closest goal),
+licensing shape: visibility is total (`pi.vis = ⊤` — closest goal),
 neediness is bearing [participant] — the same shape as Mam's Voice_TR
 (visible, halting, non-valuing intervener; `Studies/Scott2023.lean`)
 and Zulu's L⁰ (`Studies/Halpert2012.lean`). [preminger-2014] Ch. 4's
@@ -76,8 +76,12 @@ instance : DecidablePred Argument.IsParticipant := fun a =>
     activity as Caselessness but leaves open why same-projection
     Case valuation does not deactivate the French nominative for the
     second cycle; ¬F gives the right extension.) -/
+def pi : Probe Argument :=
+  { vis := fun _ => true, act := fun a => !a.fLicensed }
+
+/-- One cycle of [π]-Agree: `pi.agree` over the ordered goals. -/
 def piAgree (goals : List Argument) : Option Argument :=
-  probeAgree (fun _ => true) (fun a => !a.fLicensed) goals
+  pi.agree goals
 
 /-- The PLC over a derivation's [π]-Agree cycles: every interpretable
     1st/2nd person feature enters an Agree relation with a functional
@@ -107,7 +111,7 @@ instance (cycles : List (List Argument)) (args : List Argument) :
     from the PLC. -/
 theorem piAgree_absorbed (dat acc : Argument) (hd : dat.fLicensed = true) :
     piAgree [dat, acc] = none :=
-  probeAgree_eq_none_of_inactive rfl (by simp [hd])
+  Probe.agree_eq_none_of_inactive rfl (by simp [pi, hd])
 
 /-- Single-cycle collapse onto the substrate's `(needs, vis)`
     licensing shape: one [π]-cycle over the base order satisfies the
@@ -118,23 +122,23 @@ theorem piAgree_absorbed (dat acc : Argument) (hd : dat.fLicensed = true) :
     multi-cycle repairs ((16)–(17)) escape this signature entirely. -/
 theorem plcOk_singleCycle_iff_allLicensed (goals : List Argument) :
     PLCOk [goals] goals ↔
-      AllLicensed (fun a => decide a.IsParticipant && !a.fLicensed)
-        (fun _ => true) goals := by
-  unfold PLCOk AllLicensed
+      (Probe.indiscriminate (α := Argument)).AllLicensed
+        (fun a => decide a.IsParticipant && !a.fLicensed) goals := by
+  unfold PLCOk Probe.AllLicensed
   constructor
   · intro h a ha hneeds
     simp only [Bool.and_eq_true, decide_eq_true_eq, Bool.not_eq_true'] at hneeds
     rcases h a ha hneeds.1 with hF' | ⟨gs, hgs, hag⟩
     · exact nomatch hneeds.2.symm.trans hF'
     · rw [List.mem_singleton.mp hgs] at hag
-      exact (probeAgree_eq_some_iff.mp hag).1
+      exact (Probe.agree_eq_some_iff.mp hag).1
   · intro h a ha hpart
     cases hF : a.fLicensed with
     | true => exact Or.inl rfl
     | false =>
       refine Or.inr ⟨goals, List.mem_singleton_self _, ?_⟩
-      exact probeAgree_eq_some_iff.mpr
-        ⟨h a ha (by simp [hpart, hF]), by simp [hF]⟩
+      exact (Probe.agree_eq_some_iff (p := pi)).mpr
+        ⟨h a ha (by simp [hpart, hF]), by simp [pi, hF]⟩
 
 /-- **The PCC** (their (1)/(7), generalized): in a double-object
     configuration — dative over accusative, one [π]-Agree cycle on

--- a/Linglib/Studies/CoonKeine2021.lean
+++ b/Linglib/Studies/CoonKeine2021.lean
@@ -157,36 +157,32 @@ def Goal.visibleSegs (g : Goal) : List Segment :=
 
 /-! ### Probes and segment-based Agree (their (13), (14), (39)) -/
 
-/-- A probe: its unvalued segments (their (13)) — the same object as
-    `CyclicAgree.ProbeArticulation`, since both descend from
-    [bejar-rezac-2009]. -/
-abbrev Probe := ProbeArticulation
 
 /-- Their (39a): [uPERS [uPART]] — Weak PCC (Catalan). Identical to
     [bejar-rezac-2009]'s partial probe (`CyclicAgree.partialProbe`),
     by construction. -/
-def weakProbe : Probe := CyclicAgree.partialProbe
+def weakProbe : ProbeArticulation := CyclicAgree.partialProbe
 
 /-- Their (39b): [uPERS [uPART [uSPKR]]] — Ultrastrong PCC.
     Identical to [bejar-rezac-2009]'s full probe under the standard
     geometry (`CyclicAgree.fullProbeStd`). -/
-def ultrastrongProbe : Probe := CyclicAgree.fullProbeStd
+def ultrastrongProbe : ProbeArticulation := CyclicAgree.fullProbeStd
 
 /-- Their (39c): [uPERS [uSPKR]] — Me-First PCC (missing
     intermediate segment; see their fn. 22). -/
-def meFirstProbe : Probe := [.pi, .speaker]
+def meFirstProbe : ProbeArticulation := [.pi, .speaker]
 
 /-- Their fn. 22 (i): [uPERS [uPART [uSPKR][uADDR]]] — Strong PCC
     with φ-transparent datives. -/
-def branchingStrongProbe : Probe := [.pi, .participant, .speaker, .addressee]
+def branchingStrongProbe : ProbeArticulation := [.pi, .participant, .speaker, .addressee]
 
 /-- Agree, their (14), generic in the segment type ((11) person,
     (12) number): a segment agrees with the closest accessible goal
-    bearing it — `probeSearch` over position-indexed tokens (two
+    bearing it — `Probe.search` over position-indexed tokens (two
     same-φ arguments remain distinct agreed-with tokens). -/
 def segGoalOn {σ : Type*} (bears : σ → Goal → Bool) (s : σ)
     (goals : List Goal) : Option (Goal × Nat) :=
-  probeSearch (fun t => bears s t.1) goals.zipIdx
+  (Probe.ofVis fun t => bears s t.1).search goals.zipIdx
 
 /-- Feature gluttony (their (15)–(16)), generic in the segment type:
     two segments of one probe agree with distinct DPs. Not itself
@@ -212,10 +208,10 @@ def segGoal (s : Segment) (goals : List Goal) : Option (Goal × Nat) :=
   segGoalOn personBears s goals
 
 /-- Person-probe gluttony. -/
-def Gluttonous (P : Probe) (goals : List Goal) : Prop :=
+def Gluttonous (P : ProbeArticulation) (goals : List Goal) : Prop :=
   GluttonousOn personBears P goals
 
-instance (P : Probe) (goals : List Goal) : Decidable (Gluttonous P goals) :=
+instance (P : ProbeArticulation) (goals : List Goal) : Decidable (Gluttonous P goals) :=
   inferInstanceAs (Decidable (GluttonousOn personBears P goals))
 
 /-! ### Gluttony is limited to inverse configurations -/
@@ -237,17 +233,19 @@ private theorem segGoal_pair (s : Segment) (hi lo : Goal) :
     exposes is also borne by the higher goal, no probe is
     gluttonous over them — direct (17)–(18) and balanced (19)–(20)
     configurations are safe. -/
-theorem gluttonous_only_inverse (P : Probe) {hi lo : Goal}
+theorem gluttonous_only_inverse (P : ProbeArticulation) {hi lo : Goal}
     (hsub : ∀ s, s ∈ lo.visibleSegs → s ∈ hi.visibleSegs) :
     ¬ Gluttonous P [hi, lo] := by
   rintro ⟨s₁, _, s₂, _, t₁, _, t₂, _, h₁, h₂, hne⟩
   have hkey : ∀ s, ∀ t : Goal × Nat, segGoal s [hi, lo] = some t → t.2 = 0 := by
     intro s t ht
     rw [show segGoal s [hi, lo] =
-          probeSearch (fun t => decide (s ∈ t.1.visibleSegs)) [(hi, 0), (lo, 1)]
+          (Probe.ofVis fun t => decide (s ∈ t.1.visibleSegs)).search
+            [(hi, 0), (lo, 1)]
         from rfl,
-      probeSearch_pair_of_imp (a := (hi, 0)) (b := (lo, 1))
-        (by simpa using hsub s)] at ht
+      Probe.search_pair_of_imp (a := (hi, 0)) (b := (lo, 1))
+        (by simpa [Probe.ofVis] using hsub s)] at ht
+    simp only [Probe.ofVis] at ht
     by_cases hhi : decide (s ∈ hi.visibleSegs) = true
     · rw [if_pos hhi] at ht
       exact Option.some.inj ht ▸ rfl
@@ -262,10 +260,10 @@ theorem gluttonous_only_inverse (P : Probe) {hi lo : Goal}
     host; under gluttony this is jointly unsatisfiable (one-at-a-time
     violates (30) mid-derivation, simultaneous violates binary
     Merge), so gluttony here IS the predicted ban. -/
-def pccViolation (P : Probe) (ioOpaque : Bool) (io do_ : Person) : Prop :=
+def pccViolation (P : ProbeArticulation) (ioOpaque : Bool) (io do_ : Person) : Prop :=
   Gluttonous P [{ person := io, kOpaque := ioOpaque }, dp do_]
 
-instance (P : Probe) (b : Bool) (io do_ : Person) :
+instance (P : ProbeArticulation) (b : Bool) (io do_ : Person) :
     Decidable (pccViolation P b io do_) :=
   inferInstanceAs (Decidable (Gluttonous _ _))
 
@@ -332,7 +330,7 @@ theorem basque_dat_abs_contrast :
     goal's geometry, so gluttony is impossible — "the gluttony
     account therefore derives the fact that no such PCC pattern
     exists". -/
-theorem direct_never_banned (P : Probe) (io : Person) :
+theorem direct_never_banned (P : ProbeArticulation) (io : Person) :
     ¬ pccViolation P false io .third := by
   apply gluttonous_only_inverse
   intro s hs
@@ -376,7 +374,7 @@ theorem not_gluttonous_single_segment {σ : Type*} (bears : σ → Goal → Bool
     fortiori, while [uPERS] still lands on the IO. (Rootedness — the
     one property every probe of their (13)/(39) has — suffices; full
     downward closure is not needed.) -/
-theorem ban_part_part_implies_ban_three_part (P : Probe)
+theorem ban_part_part_implies_ban_three_part (P : ProbeArticulation)
     (hpi : Segment.pi ∈ P)
     (h : pccViolation P false .second .first) :
     pccViolation P false .third .first := by
@@ -486,7 +484,7 @@ are interspeaker-variable. -/
 
 /-- The values a probe acquires: the visible geometry of each
     distinct goal token some segment agreed with (their (16)). -/
-def acquiredValues (P : Probe) (goals : List Goal) : List (List Segment) :=
+def acquiredValues (P : ProbeArticulation) (goals : List Goal) : List (List Segment) :=
   (goals.zipIdx.filter
     (fun t => P.any (fun s => segGoal s goals == some t))).map
     (fun t => t.1.visibleSegs)
@@ -494,7 +492,7 @@ def acquiredValues (P : Probe) (goals : List Goal) : List (List Segment) :=
 /-- One DP agreeing with many probes is not gluttony (their (86):
     Icelandic multiple participle agreement): a single goal can never
     yield two distinct tokens. -/
-theorem not_gluttonous_singleton (P : Probe) (g : Goal) :
+theorem not_gluttonous_singleton (P : ProbeArticulation) (g : Goal) :
     ¬ Gluttonous P [g] := by
   rintro ⟨s₁, _, s₂, _, t₁, ht₁m, t₂, ht₂m, _, _, hne⟩
   cases ht₁m with
@@ -618,7 +616,7 @@ theorem german_copula :
       MorphOk germanPastSg false
         (acquiredValues weakProbe [dp .third, dp .first])) ∧
     -- nonfinite: no probe, no gluttony
-    ¬ Gluttonous ([] : Probe) [dp .third, dp .second] := by
+    ¬ Gluttonous ([] : ProbeArticulation) [dp .third, dp .second] := by
   decide
 
 /-! ### The number probe and the missing "Number Case Constraint"
@@ -656,7 +654,7 @@ def numProbe : List NumSeg := [.num, .pl]
 /-- Clitic doubling renders the doubled DP invisible to subsequent
     probing (their §3.2): the tokens π agreed with are removed from
     #'s search space (their (42)). -/
-def afterCliticDoubling (piP : Probe) (goals : List Goal) : List Goal :=
+def afterCliticDoubling (piP : ProbeArticulation) (goals : List Goal) : List Goal :=
   (goals.zipIdx.filter
     (fun t => ! piP.any (fun s => segGoal s goals == some t))).map (·.1)
 
@@ -704,7 +702,7 @@ theorem reverse_pcc_diagnoses_strong :
 /-! ### PCC repairs (§3.5) -/
 
 /-- An empty search space is never gluttonous. -/
-theorem not_gluttonous_nil (P : Probe) : ¬ Gluttonous P [] := by
+theorem not_gluttonous_nil (P : ProbeArticulation) : ¬ Gluttonous P [] := by
   rintro ⟨_, _, _, _, t, htm, _⟩
   exact nomatch htm
 
@@ -718,7 +716,7 @@ theorem not_gluttonous_nil (P : Probe) : ¬ Gluttonous P [] := by
     displacement around π (their (50)). Last-resort uses of these
     structures (Rezac's ᑬ) translate as: extra structure is
     sanctioned iff the probe would otherwise glutton. -/
-theorem repairs_shield_goals (P : Probe) (g : Goal) :
+theorem repairs_shield_goals (P : ProbeArticulation) (g : Goal) :
     ¬ Gluttonous P [g] ∧ ¬ Gluttonous P [] :=
   ⟨not_gluttonous_singleton P g, not_gluttonous_nil P⟩
 

--- a/Linglib/Studies/Halpert2012.lean
+++ b/Linglib/Studies/Halpert2012.lean
@@ -18,10 +18,10 @@ failure-tolerance, adopted by [preminger-2014] Ch. 6 as the second
 case study in tolerated failed agreement.
 
 Formalized through `Phi/Probing.lean`: L⁰ is the **indiscriminate**
-instance of `probeSearch` (`vis = ⊤`, so bare minimality delivers
+instance of `Probe.search` (`Probe.indiscriminate`, so bare minimality delivers
 `List.head?`; augmented nominals intervene, her Chomsky-2000-style
 intervention), and the licensing condition is the off-diagonal
-`AllLicensed needs ⊤` with `needs` = augmentless. Contrast Kichean
+`Probe.AllLicensed` with `needs` = augmentless. Contrast Kichean
 ([preminger-2014] Ch. 4): the diagonal case, π⁰ relativized to
 exactly the needy, hence omnivorous and position-insensitive.
 
@@ -50,11 +50,13 @@ structure Nominal where
     don't (while still intervening for L⁰). -/
 def needsL (n : Nominal) : Bool := !n.augmented
 
-/-- L⁰'s goal in a vP: an indiscriminate `probeSearch` — every
-    element is visible, so bare minimality delivers the structurally
-    highest one. -/
+/-- L⁰ itself: the indiscriminate probe — every element is visible,
+    so bare minimality delivers the structurally highest one. -/
+def L : Probe Nominal := Probe.indiscriminate
+
+/-- L⁰'s goal in a vP. -/
 def lGoal (vp : List Nominal) : Option Nominal :=
-  probeSearch (fun _ => true) vp
+  L.search vp
 
 /-- Bare minimality, as a theorem: the indiscriminate search takes
     the head of the sequence. -/
@@ -64,14 +66,14 @@ theorem lGoal_eq_head? (vp : List Nominal) : lGoal vp = vp.head? := by
 /-- The licensing condition on a simplex vP: every augmentless
     nominal is licensed by L⁰'s single search. -/
 def LicensingOk (vp : List Nominal) : Prop :=
-  AllLicensed needsL (fun _ => true) vp
+  L.AllLicensed needsL vp
 
 instance (vp : List Nominal) : Decidable (LicensingOk vp) :=
-  inferInstanceAs (Decidable (AllLicensed needsL (fun _ => true) vp))
+  inferInstanceAs (Decidable (L.AllLicensed needsL vp))
 
 /-- L⁰'s probing outcome: valued iff the vP has any overt content. -/
 def lOutcome (vp : List Nominal) : ProbeOutcome :=
-  searchOutcome (fun _ => true) vp
+  L.outcome vp
 
 /-- The conjoint/disjoint marker (present tense) as the spellout of
     L⁰: conjoint ∅- when L⁰ found a goal, disjoint *ya-* when it
@@ -101,11 +103,11 @@ theorem disjoint_iff_empty (vp : List Nominal) :
 
 /-- An augmentless nominal is licensed iff it is the structurally
     highest element of its vP — her ch. 3: L "licenses the highest
-    element in vP". Instance of `allLicensed_const_true_iff`. -/
+    element in vP". Instance of `Probe.indiscriminate_allLicensed_iff`. -/
 theorem licensingOk_iff_highest (vp : List Nominal) :
     LicensingOk vp ↔
       ∀ n ∈ vp, needsL n = true → vp.head? = some n :=
-  allLicensed_const_true_iff
+  Probe.indiscriminate_allLicensed_iff
 
 /-- At most one augmentless nominal per simplex vP (her transitive
     and intransitive LP schemas): L⁰'s single Agree relation licenses

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -68,7 +68,7 @@ relativized probes:
 The single AF marker reflects π⁰'s output if it succeeds (clitic
 doubling of the [participant]-bearing argument); otherwise #⁰'s
 output (the 3PL marker *e-* by direct exponence); otherwise the slot
-is empty (∅). This slot competition is `cascadeSearch` over the two
+is empty (∅). This slot competition is `Probe.cascade` over the two
 probes, definitionally: `afAgreementTarget` IS the cascade, the ∅
 row is failed Agree realized by the DM Elsewhere entry, and the rank
 comparison is the derived form (`afAgreementTarget_eq_rank`).
@@ -108,7 +108,7 @@ gives five arguments against hierarchy accounts:
 
 - `Syntax/Minimalist/Phi/Geometry.lean` — `decomposePerson`,
   `probeVisible`, `probeResolutionRank`.
-- `Syntax/Minimalist/Phi/Probing.lean` — `probeSearch`, `Licensed`,
+- `Syntax/Minimalist/Phi/Probing.lean` — `Probe`, `Probe.Licensed`,
   `PLC`: the search-and-licensing layer the derivations below
   consume.
 - `Syntax/Minimalist/ObligatoryOperations.lean` — the Ch. 5 model
@@ -213,13 +213,13 @@ instance : DecidableRel PersonRestrictionOk := fun subj obj =>
     patient as π⁰'s goal tokens, the PLC holds iff at most one bears
     [+participant]. A [+participant] argument requires an Agree
     relation with π⁰ to be licensed; π⁰'s single search licenses at
-    most one token (`allLicensed_iff`), so two [+participant]
+    most one token (`Probe.allLicensed_iff`), so two [+participant]
     arguments cannot both be licensed and the derivation crashes. -/
 theorem personRestrictionOk_iff_plc (s o : Agreement.Cell) :
     PersonRestrictionOk s o ↔
       PLC Prod.snd ([(.A, s), (.P, o)] : List (ArgPosition × Agreement.Cell)) := by
   unfold PersonRestrictionOk PLC
-  rw [allLicensed_iff]
+  rw [Probe.allLicensed_iff]
   constructor
   · intro h a ha b hb hva hvb
     rcases List.mem_pair.mp ha with rfl | rfl <;>
@@ -246,11 +246,16 @@ theorem ch4_relativization_contrast :
         List (ArgPosition × Agreement.Cell)) := by
   decide
 
+/-- π⁰: the person probe, relativized to [participant]. -/
+def piProbe : Probe Agreement.Cell := .ofVis (·.visibleTo .participant)
+
+/-- #⁰: the number probe, relativized to [plural]. -/
+def numProbe : Probe Agreement.Cell := .ofVis (·.visibleTo .plural)
+
 /-- The two AF probes in slot order: π⁰'s clitic output beats #⁰'s
     direct exponence in the single morphological slot
     ([preminger-2014] §4.4). -/
-def afProbes : List (Agreement.Cell → Bool) :=
-  [(·.visibleTo .participant), (·.visibleTo .plural)]
+def afProbes : List (Probe Agreement.Cell) := [piProbe, numProbe]
 
 /-- The AF agreement target, by probe cascade: π⁰'s goal if it finds
     one, else #⁰'s, else `none` — both probes failed (3SG × 3SG) and
@@ -259,7 +264,7 @@ def afProbes : List (Agreement.Cell → Bool) :=
     winning probe it takes the closer one (the subject) — immaterial
     for the marker (`afMarker_comm`). -/
 def afAgreementTarget (subj obj : Agreement.Cell) : Option Agreement.Cell :=
-  cascadeSearch afProbes [subj, obj]
+  Probe.cascade afProbes [subj, obj]
 
 /-- The AF agreement marker: the Set B exponent of the cascade's
     target; the Elsewhere ∅ via DM insertion from the unvalued bundle
@@ -349,11 +354,11 @@ theorem personRestrictionOk_comm (s o : Agreement.Cell) :
 /-- π⁰'s outcome on the AF clause's goal pair: each probe is
     independently obligatory ([preminger-2014] Ch. 5). -/
 def piOutcome (subj obj : Agreement.Cell) : ProbeOutcome :=
-  searchOutcome (·.visibleTo .participant) [subj, obj]
+  piProbe.outcome [subj, obj]
 
 /-- #⁰'s outcome on the AF clause's goal pair. -/
 def numOutcome (subj obj : Agreement.Cell) : ProbeOutcome :=
-  searchOutcome (·.visibleTo .plural) [subj, obj]
+  numProbe.outcome [subj, obj]
 
 /-- Joint outcome of the AF probes: `unvalued` only when both probes
     fail (i.e., both arguments are 3SG). -/
@@ -373,8 +378,8 @@ theorem afAgreementTarget_eq_none_iff (subj obj : Agreement.Cell) :
     cases piOutcome subj obj <;> cases numOutcome subj obj <;> decide
   rw [hmatch]
   unfold afAgreementTarget piOutcome numOutcome
-  rw [cascadeSearch_eq_none_iff, searchOutcome_eq_unvalued_iff,
-      searchOutcome_eq_unvalued_iff]
+  rw [Probe.cascade_eq_none_iff, Probe.outcome_eq_unvalued_iff,
+      Probe.outcome_eq_unvalued_iff]
   simp [afProbes]
 
 /-- Failed Agree is tolerated, not crashing ([preminger-2014] Ch. 5):
@@ -439,10 +444,10 @@ theorem ch7_arg4_form_distinctness :
 /-- [preminger-2014] Ch. 7 arg 5 (§7.2, via Ch. 6): [halpert-2012]'s
     Zulu runs the same search-and-licensing substrate over a
     salience-irrelevant contrast. Kichean is the diagonal instance
-    (`AllLicensed vis vis`: π⁰ relativized to exactly the
+    (diagonal `Probe.AllLicensed`: π⁰ relativized to exactly the
     licensing-needy [participant] cells), so a needy argument is
     licensed even from object position — the probe skips non-bearers.
-    Zulu's L⁰ is the off-diagonal instance (`AllLicensed needs ⊤`:
+    Zulu's L⁰ is the off-diagonal instance (`Probe.indiscriminate`:
     indiscriminate probe, augmentless = needy), so an augmented
     subject intervenes and a lower augmentless nominal goes
     unlicensed. Same machinery, opposite skippability — and there is

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -546,7 +546,7 @@ theorem satisfaction_matches_fragment :
 /-! ### Deriving the probe table from relativized search (`Phi/Probing.lean`)
 
 The `agreeProbe` table stipulates which head agrees with which
-position. Here it is DERIVED: each probe runs `probeSearch` over the
+position. Here it is DERIVED: each probe runs `Probe.search` over the
 goal sequence of its clause, relativized to its satisfaction
 condition. `.P => none` falls out of Voice_TR halting Infl's search
 before any DP (`infl_truncated_at_voiceTR`) plus Voice's own search
@@ -573,15 +573,18 @@ structure Encounter where
 def halts (cond : SatisfactionCond) (e : Encounter) : Bool :=
   cond.isSatisfied e.feats e.cat
 
-/-- The argument position a probe φ-agrees with: `probeAgree`
-    relativized to the satisfaction condition, with feature-copying
-    as the activity condition — the probe agrees with the found
-    element only if satisfaction copied features (feature match, not
-    head encounter). -/
+/-- A satisfaction-conditioned probe as a `Probe` over encounters:
+    visibility = halting ([deal-2024] interaction), activity =
+    feature copying. -/
+def satProbe (cond : SatisfactionCond) : Probe Encounter :=
+  { vis := halts cond, act := fun e => cond.copiedFeatures e.feats e.cat }
+
+/-- The argument position a probe φ-agrees with: `(satProbe cond).agree`
+    — the probe agrees with the found element only if satisfaction
+    copied features (feature match, not head encounter). -/
 def agreesWith (cond : SatisfactionCond) (goals : List Encounter) :
     Option ArgPosition :=
-  (probeAgree (halts cond)
-    (fun e => cond.copiedFeatures e.feats e.cat) goals).bind (·.pos)
+  ((satProbe cond).agree goals).bind (·.pos)
 
 /-- Transitive Voice as an encounter: a head of category `.v`, no
     φ-features visible to the probe. -/
@@ -628,8 +631,8 @@ theorem infl_finds_S (φS : FeatureBundle)
     agreesWith mamInflSatisfaction [dpGoal .S φS] = some .S := by
   have h1 : halts mamInflSatisfaction ⟨some .S, φS, none⟩ = true := by
     simp [halts, mamInflSatisfaction_isSatisfied, hS]
-  simp [agreesWith, probeAgree, probeSearch, Option.filter_some, dpGoal, h1,
-    mamInflSatisfaction_copiedFeatures, hS]
+  simp [agreesWith, satProbe, Probe.agree, Probe.search, Option.filter_some,
+    dpGoal, h1, mamInflSatisfaction_copiedFeatures, hS]
 
 /-- Voice's search finds the agent (closest goal), provided A bears
     person. -/
@@ -639,11 +642,11 @@ theorem voice_finds_A (φA φP : FeatureBundle)
   have h1 : halts (.featureMatch (.phi (.person .third)))
       ⟨some .A, φA, none⟩ = true := by
     simp [halts, SatisfactionCond.isSatisfied, hA]
-  simp [agreesWith, probeAgree, probeSearch, Option.filter_some, dpGoal,
-    voiceSat, h1, SatisfactionCond.copiedFeatures, hA]
+  simp [agreesWith, satProbe, Probe.agree, Probe.search, Option.filter_some,
+    dpGoal, voiceSat, h1, SatisfactionCond.copiedFeatures, hA]
 
 /-- DERIVED probe table: which head φ-agrees with position `p`,
-    computed by running each probe's `probeSearch` over the goal
+    computed by running each probe's `Probe.search` over the goal
     sequence of the clause containing `p`. -/
 def derivedAgreeProbe (φA φP φS : FeatureBundle) (p : ArgPosition) :
     Option Cat :=
@@ -677,7 +680,7 @@ theorem agreeProbe_eq_derived_3sg :
 
 /-- φ-valuation outcome of a probe with a satisfaction condition:
     valued iff the search found a goal AND satisfaction copied
-    features. NOTE: this is NOT `searchOutcome (halts cond)` — a
+    features. NOTE: this is NOT `(satProbe cond).outcome` — a
     head-encounter halt satisfies the search but leaves the probe
     φ-unvalued. -/
 def valuationOutcome (cond : SatisfactionCond) (goals : List Encounter) :
@@ -693,12 +696,12 @@ theorem transitive_unvalued_elsewhere (rest : List Encounter) :
     (valuationOutcome mamInflSatisfaction (voiceTR :: rest)).pfRealization
       = .elsewhere := ⟨rfl, rfl⟩
 
-/-- Contrast: `searchOutcome` relativized to the satisfaction condition
+/-- Contrast: `Probe.outcome` relativized to the satisfaction condition
     reports `.valued` in the transitive — the search DID find a halting
     element. The valuation/satisfaction distinction is exactly
     [deal-2024]'s interaction-vs-satisfaction split. -/
 theorem searchOutcome_valued_but_unvalued (rest : List Encounter) :
-    searchOutcome (halts mamInflSatisfaction) (voiceTR :: rest) = .valued ∧
+    (satProbe mamInflSatisfaction).outcome (voiceTR :: rest) = .valued ∧
     valuationOutcome mamInflSatisfaction (voiceTR :: rest) = .unvalued :=
   ⟨rfl, rfl⟩
 

--- a/Linglib/Syntax/Minimalist/CyclicAgree.lean
+++ b/Linglib/Syntax/Minimalist/CyclicAgree.lean
@@ -353,12 +353,16 @@ def goalTokens (ea ia : Person) : List (Controller × Person) :=
 def segVisible (geom : Geometry) (s : Segment) (t : Controller × Person) : Bool :=
   (personSpec geom t.2).contains s
 
+/-- A probe segment as a `Probe` over argument tokens. -/
+def segProbe (geom : Geometry) (s : Segment) : Probe (Controller × Person) :=
+  .ofVis (segVisible geom s)
+
 /-- The goal a single probe segment Agrees with: the first argument in
     cyclic order whose specification bears the segment — a flat
-    relativized `probeSearch`. -/
+    relativized `Probe.search`. -/
 def segmentGoal (geom : Geometry) (ea ia : Person) (s : Segment) :
     Option (Controller × Person) :=
-  probeSearch (segVisible geom s) (goalTokens ea ia)
+  (segProbe geom s).search (goalTokens ea ia)
 
 /-- A segment finds the EA token iff the IA bypasses it (leaving it as
     active residue) and the EA bears it — cycle-II Agree. -/
@@ -366,7 +370,7 @@ theorem segmentGoal_eq_ea_iff (geom : Geometry) (ea ia : Person) (s : Segment) :
     segmentGoal geom ea ia s = some (.ea, ea) ↔
       (personSpec geom ia).contains s = false ∧
       (personSpec geom ea).contains s = true := by
-  simp only [segmentGoal, probeSearch, goalTokens, segVisible, List.find?]
+  simp only [segmentGoal, segProbe, Probe.ofVis, Probe.search, goalTokens, segVisible, List.find?]
   cases h1 : (personSpec geom ia).contains s <;>
     cases h2 : (personSpec geom ea).contains s <;> simp
 
@@ -374,7 +378,7 @@ theorem segmentGoal_eq_ea_iff (geom : Geometry) (ea ia : Person) (s : Segment) :
 theorem segmentGoal_eq_ia_iff (geom : Geometry) (ea ia : Person) (s : Segment) :
     segmentGoal geom ea ia s = some (.ia, ia) ↔
       (personSpec geom ia).contains s = true := by
-  simp only [segmentGoal, probeSearch, goalTokens, segVisible, List.find?]
+  simp only [segmentGoal, segProbe, Probe.ofVis, Probe.search, goalTokens, segVisible, List.find?]
   cases h1 : (personSpec geom ia).contains s <;>
     cases h2 : (personSpec geom ea).contains s <;> simp
 
@@ -393,12 +397,12 @@ theorem eaAgrees_iff_exists (geom : Geometry) (probe : ProbeArticulation)
     exact ⟨s, ⟨hs, by simpa using hia⟩, by simpa using hea⟩
 
 /-- **Main bridge**: the EA is person-licensed (`eaIsLicensed`) iff some
-    probe segment's flat relativized search (`Probing.Licensed`) over
+    probe segment's flat relativized search (`Probe.Licensed`) over
     the cyclically ordered token list finds the EA token. -/
 theorem eaIsLicensed_iff_segment_licensed (geom : Geometry)
     (probe : ProbeArticulation) (ea ia : Person) :
     eaIsLicensed geom probe ea ia = true ↔
-      ∃ s ∈ probe, Licensed (segVisible geom s) (goalTokens ea ia) (.ea, ea) := by
+      ∃ s ∈ probe, (segProbe geom s).Licensed (goalTokens ea ia) (.ea, ea) := by
   rw [eaIsLicensed, eaAgrees_iff_exists]
   exact exists_congr fun s => and_congr_right fun _ =>
     (segmentGoal_eq_ea_iff geom ea ia s).symm
@@ -409,7 +413,7 @@ theorem eaIsLicensed_iff_segment_licensed (geom : Geometry)
 theorem plc_violation_iff_no_segment_licensed (geom : Geometry)
     (probe : ProbeArticulation) (ea ia : Person) :
     isInverseContext geom probe ea ia = true ↔
-      ∀ s ∈ probe, ¬ Licensed (segVisible geom s) (goalTokens ea ia) (.ea, ea) := by
+      ∀ s ∈ probe, ¬ (segProbe geom s).Licensed (goalTokens ea ia) (.ea, ea) := by
   rw [← plc_violation_iff_inverse, Bool.eq_false_iff, Ne,
     eaIsLicensed_iff_segment_licensed]
   simp only [not_exists, not_and]
@@ -417,7 +421,7 @@ theorem plc_violation_iff_no_segment_licensed (geom : Geometry)
 /-- Cycle decomposition through the search: cycle-I segments are those
     whose search finds the IA token; cycle-II segments those whose
     search finds the EA token. Second-cycle effects also factor through
-    `probeSearch`. -/
+    `Probe.search`. -/
 theorem cycleSegments_eq_segmentGoal_filters (geom : Geometry)
     (probe : ProbeArticulation) (ea ia : Person) :
     cycleSegments geom probe ea ia =

--- a/Linglib/Syntax/Minimalist/Phi/Geometry.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Geometry.lean
@@ -74,7 +74,7 @@ The `probeResolutionRank` function below assigns rank 2 to
 [+participant] DPs, rank 1 to [+plural, −participant] DPs, and
 rank 0 elsewhere — the *surface effect* of the two-probe (π⁰
 before #⁰) system on a single DP. Its derived status is a theorem:
-target resolution is `cascadeSearch` over the two probes
+target resolution is `Probe.cascade` over the two probes
 (`Phi/Probing.lean`), and the rank comparison agrees with the
 cascade on the φ-cell inventory
 (`Preminger2014.afAgreementTarget_eq_rank`). It is not a salience

--- a/Linglib/Syntax/Minimalist/Phi/Probing.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Probing.lean
@@ -1,48 +1,54 @@
+import Mathlib.Order.UpperLower.Basic
 import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Syntax.Minimalist.Phi.Geometry
 import Linglib.Syntax.Minimalist.ObligatoryOperations
 
 /-!
-# Relativized probing over a goal sequence
+# Probes: relativized search over a goal sequence
 [bejar-rezac-2003] [preminger-2014]
 
 The derivational middle layer between DP-level probe visibility
 (`probeVisible`, `Phi/Geometry.lean`) and PF-level outcomes
-(`ProbeOutcome`, `ObligatoryOperations.lean`): a relativized probe
-walks an ordered goal sequence, skips invisible goals, and returns
-the first visible one. Licensing is being the goal found — from
-which the Person Licensing Condition's effects derive: one search
-licenses at most one goal (`allLicensed_iff`).
+(`ProbeOutcome`, `ObligatoryOperations.lean`). A `Probe` bundles what
+it *sees* (`vis` — interaction/halting: the search stops at the first
+visible goal) and what it can *value* there (`act` — activity: a
+visible but inactive goal absorbs the probe without valuing it,
+[bejar-rezac-2003]'s inactive dative, [deal-2024]-style interaction
+vs. satisfaction). Licensing is being the goal the search reaches —
+from which the Person Licensing Condition's effects derive: one
+search licenses at most one goal (`Probe.allLicensed_iff`).
 
-The search is stated for any goal type `α` with a `Bool` visibility
-predicate; the φ-instantiation (`Agreement.Cell.visibleTo`, `PLC`)
-specializes it to the participant-relativized person probe of
-[preminger-2014]'s Kichean analysis. Relativization is Preminger's
-addition (§4.2, recalling [rizzi-1990]): [bejar-rezac-2003]'s own
-π-probe is *unrelativized* — the closest goal matches and can
-absorb it without valuing (`probeAgree`; `Studies/BejarRezac2003.lean`)
-— and the unrelativized, bare-minimality instance (`vis = ⊤`, goal
-= `List.head?`) is also [halpert-2012]'s Zulu L⁰
+Relativization is [preminger-2014]'s addition (§4.2, recalling
+[rizzi-1990]): the φ-instantiation (`Agreement.Cell.visibleTo`,
+`PLC`) specializes `vis` to his participant-relativized person probe.
+[bejar-rezac-2003]'s own π-probe is *unrelativized* — the closest
+goal matches and can absorb it (`Studies/BejarRezac2003.lean`) — and
+the unrelativized, bare-minimality probe (`Probe.indiscriminate`,
+goal = `List.head?`) is [halpert-2012]'s Zulu L⁰
 (`Studies/Halpert2012.lean`, the cross-linguistic point of
-[preminger-2014] Ch. 7). [bejar-rezac-2009]'s articulated probe is a *family* of
-these searches, one per probe segment over the cyclically ordered
-token list — see `CyclicAgree.eaIsLicensed_iff_segment_licensed`.
-For probe *horizons* (what terminates search across domains, Keine)
-see `Syntax/Minimalist/Probe.lean`; for conditional feature-acquiring
+[preminger-2014] Ch. 7). [bejar-rezac-2009]'s articulated probe is a
+*family* of these searches, one per probe segment over the cyclically
+ordered token list — see `CyclicAgree.eaIsLicensed_iff_segment_licensed`,
+and `Phi/Articulation.lean` for the laws of articulation. For probe
+*horizons* (what terminates search across domains, Keine) see
+`Syntax/Minimalist/Probe.lean`; for conditional feature-acquiring
 re-probing see `Syntax/Minimalist/Probing/DefectiveCircumvention.lean`.
 
 ## Main declarations
 
-- `probeSearch` — first goal visible to the probe, in structural order.
-- `probeAgree` — search then Agree: the found goal, if it passes the
-  activity condition (match without valuation absorbs the probe).
-- `searchOutcome` — the `ProbeOutcome` of an obligatory probing operation.
-- `Licensed`, `AllLicensed needs vis` — every licensing-needy goal is
-  found by the search; diagonal characterization `allLicensed_iff`
-  (visible goals subsingleton), off-diagonal
-  `allLicensed_const_true_iff` (every needy goal is the closest).
-- `cascadeSearch` — ordered probe sequence: first probe with output wins
-  (the single-slot morphological competition).
+- `Probe` — the bundled object: `vis` + `act`; `Probe.ofVis`,
+  `Probe.indiscriminate` constructors.
+- `Probe.search` — first visible goal, in structural order.
+- `Probe.agree` — search then Agree: the found goal, if active.
+- `Probe.outcome` — the `ProbeOutcome` of an obligatory probing
+  operation.
+- `Probe.Licensed`, `Probe.AllLicensed needs` — every licensing-needy
+  goal is found by the search; diagonal characterization
+  `Probe.allLicensed_iff` (visible goals subsingleton), indiscriminate
+  characterization `Probe.indiscriminate_allLicensed_iff` (every needy
+  goal is the closest).
+- `Probe.cascade` — ordered probe sequence: first probe with output
+  wins (the single-slot morphological competition).
 - `PLC` — the Person Licensing Condition over φ-bearing goal tokens.
 -/
 
@@ -50,77 +56,86 @@ namespace Minimalist
 
 variable {α : Type*}
 
-/-! ### Relativized search -/
+/-- A probe over goals of type `α`: what it sees (`vis` — a visible
+    goal halts the search) and what it can value there (`act` — a
+    visible but inactive goal absorbs the probe without valuing it).
+    `act` defaults to always-active. -/
+structure Probe (α : Type*) where
+  vis : α → Bool
+  act : α → Bool := fun _ => true
 
-section Search
+namespace Probe
+
+/-- A probe with a visibility condition and no activity restriction. -/
+def ofVis (vis : α → Bool) : Probe α := { vis := vis }
+
+/-- The indiscriminate probe: sees every goal, so bare minimality
+    delivers the closest one ([halpert-2012]'s L⁰). -/
+def indiscriminate : Probe α := ofVis fun _ => true
+
+/-! ### Search -/
 
 /-- The goal a probe finds in an ordered goal sequence: the first
-    goal visible to it, skipping invisible ones (relativized probing,
-    [preminger-2014] §4.2; an unrelativized probe — `vis = ⊤` — takes
-    the closest goal outright). -/
-def probeSearch (vis : α → Bool) (goals : List α) : Option α :=
-  goals.find? vis
+    goal visible to it, skipping invisible ones. -/
+def search (p : Probe α) (goals : List α) : Option α :=
+  goals.find? p.vis
 
-/-- Search then Agree: the goal the search finds, if it passes the
-    activity condition `act` — the match vs. Agree distinction. The
-    closest visible goal can absorb the probe without valuing it
-    ([bejar-rezac-2003]'s inactive dative, `Studies/BejarRezac2003.lean`;
-    [deal-2024]-style interaction vs. satisfaction,
-    `Studies/Scott2023.lean`). -/
-def probeAgree (vis act : α → Bool) (goals : List α) : Option α :=
-  (probeSearch vis goals).filter act
+/-- Search then Agree: the found goal, if it passes the activity
+    condition. A visible inactive goal absorbs the probe. -/
+def agree (p : Probe α) (goals : List α) : Option α :=
+  (p.search goals).filter p.act
 
-variable {vis : α → Bool} {goals : List α}
+variable {p : Probe α} {goals : List α}
 
 /-- A probe finds nothing iff no goal is visible to it. -/
 @[simp]
-theorem probeSearch_eq_none_iff :
-    probeSearch vis goals = none ↔ ∀ a ∈ goals, vis a = false := by
-  simp [probeSearch, List.find?_eq_none]
+theorem search_eq_none_iff :
+    p.search goals = none ↔ ∀ a ∈ goals, p.vis a = false := by
+  simp [search, List.find?_eq_none]
 
 /-- The found goal is a member of the sequence. -/
-theorem mem_of_probeSearch_eq_some {a : α}
-    (h : probeSearch vis goals = some a) : a ∈ goals :=
+theorem mem_of_search_eq_some {a : α}
+    (h : p.search goals = some a) : a ∈ goals :=
   List.mem_of_find?_eq_some h
 
 /-- The found goal is visible to the probe. -/
-theorem visible_of_probeSearch_eq_some {a : α}
-    (h : probeSearch vis goals = some a) : vis a = true :=
+theorem visible_of_search_eq_some {a : α}
+    (h : p.search goals = some a) : p.vis a = true :=
   List.find?_some h
 
-/-- Over a two-goal sequence whose lower goal's visibility entails the
-    higher's, the search lands on the higher goal if anywhere — the
-    kernel of "gluttony/competition only in inverse configurations"
-    ([coon-keine-2021]) and of highest-only licensing
+/-- Over a two-goal sequence whose lower goal's visibility entails
+    the higher's, the search lands on the higher goal if anywhere —
+    the kernel of "gluttony/competition only in inverse
+    configurations" ([coon-keine-2021]) and of highest-only licensing
     ([halpert-2012]). -/
-theorem probeSearch_pair_of_imp {a b : α}
-    (h : vis b = true → vis a = true) :
-    probeSearch vis [a, b] = if vis a = true then some a else none := by
-  by_cases ha : vis a = true
+theorem search_pair_of_imp {a b : α}
+    (h : p.vis b = true → p.vis a = true) :
+    p.search [a, b] = if p.vis a = true then some a else none := by
+  by_cases ha : p.vis a = true
   · rw [if_pos ha]
-    show List.find? vis [a, b] = some a
+    show List.find? p.vis [a, b] = some a
     simp [List.find?, ha]
   · rw [if_neg ha]
-    have hb : vis b = false := by
-      cases hvb : vis b
+    have hb : p.vis b = false := by
+      cases hvb : p.vis b
       · rfl
       · exact absurd (h hvb) ha
-    have ha' : vis a = false := by
-      cases hva : vis a
+    have ha' : p.vis a = false := by
+      cases hva : p.vis a
       · rfl
       · exact absurd hva ha
-    show List.find? vis [a, b] = none
+    show List.find? p.vis [a, b] = none
     simp [List.find?, ha', hb]
 
 /-- The probe Agrees with `a` iff the search finds `a` and `a` is
     active. -/
-theorem probeAgree_eq_some_iff {act : α → Bool} {a : α} :
-    probeAgree vis act goals = some a ↔
-      probeSearch vis goals = some a ∧ act a = true := by
-  cases h : probeSearch vis goals with
-  | none => simp [probeAgree, h]
+theorem agree_eq_some_iff {a : α} :
+    p.agree goals = some a ↔
+      p.search goals = some a ∧ p.act a = true := by
+  cases h : p.search goals with
+  | none => simp [agree, h]
   | some b =>
-    simp only [probeAgree, h, Option.filter_some, Option.ite_none_right_eq_some,
+    simp only [agree, h, Option.filter_some, Option.ite_none_right_eq_some,
       Option.some.injEq]
     constructor
     · rintro ⟨hb, rfl⟩
@@ -129,106 +144,93 @@ theorem probeAgree_eq_some_iff {act : α → Bool} {a : α} :
       exact ⟨hb ▸ ha, hb.symm ▸ rfl⟩
 
 /-- An inactive closest goal absorbs the probe: match without Agree. -/
-theorem probeAgree_eq_none_of_inactive {act : α → Bool} {a : α}
-    (h : probeSearch vis goals = some a) (ha : act a = false) :
-    probeAgree vis act goals = none := by
-  simp [probeAgree, h, Option.filter_some, ha]
+theorem agree_eq_none_of_inactive {a : α}
+    (h : p.search goals = some a) (ha : p.act a = false) :
+    p.agree goals = none := by
+  simp [agree, h, Option.filter_some, ha]
 
-end Search
-
-/-! ### Probe outcomes ([preminger-2014] Ch. 5) -/
-
-section Outcome
+/-! ### Outcomes ([preminger-2014] Ch. 5) -/
 
 /-- The outcome of an obligatory probing operation over a goal
     sequence: `valued` iff the search finds a goal. -/
-def searchOutcome (vis : α → Bool) (goals : List α) : ProbeOutcome :=
-  if (probeSearch vis goals).isSome then .valued else .unvalued
-
-variable {vis : α → Bool} {goals : List α}
+def outcome (p : Probe α) (goals : List α) : ProbeOutcome :=
+  if (p.search goals).isSome then .valued else .unvalued
 
 /-- The probe is valued iff the search finds a goal. -/
-theorem searchOutcome_eq_valued_iff_isSome :
-    searchOutcome vis goals = .valued ↔ (probeSearch vis goals).isSome := by
-  rw [searchOutcome]
-  cases (probeSearch vis goals).isSome <;> decide
+theorem outcome_eq_valued_iff_isSome :
+    p.outcome goals = .valued ↔ (p.search goals).isSome := by
+  rw [outcome]
+  cases (p.search goals).isSome <;> decide
 
 /-- The probe ends unvalued iff the search comes back empty. -/
-theorem searchOutcome_eq_unvalued_iff_eq_none :
-    searchOutcome vis goals = .unvalued ↔ probeSearch vis goals = none := by
-  rw [searchOutcome]
-  cases probeSearch vis goals <;>
+theorem outcome_eq_unvalued_iff_eq_none :
+    p.outcome goals = .unvalued ↔ p.search goals = none := by
+  rw [outcome]
+  cases p.search goals <;>
     simp only [Option.isSome_none, Option.isSome_some, Bool.false_eq_true,
       if_false, if_true, reduceCtorEq]
 
 /-- The probe is valued iff some goal is visible to it. -/
 @[simp]
-theorem searchOutcome_eq_valued_iff :
-    searchOutcome vis goals = .valued ↔ ∃ a ∈ goals, vis a = true :=
-  searchOutcome_eq_valued_iff_isSome.trans List.find?_isSome
+theorem outcome_eq_valued_iff :
+    p.outcome goals = .valued ↔ ∃ a ∈ goals, p.vis a = true :=
+  outcome_eq_valued_iff_isSome.trans List.find?_isSome
 
 /-- The probe ends unvalued iff no goal is visible to it. -/
 @[simp]
-theorem searchOutcome_eq_unvalued_iff :
-    searchOutcome vis goals = .unvalued ↔ ∀ a ∈ goals, vis a = false := by
-  rw [searchOutcome_eq_unvalued_iff_eq_none]
-  exact probeSearch_eq_none_iff
-
-end Outcome
+theorem outcome_eq_unvalued_iff :
+    p.outcome goals = .unvalued ↔ ∀ a ∈ goals, p.vis a = false := by
+  rw [outcome_eq_unvalued_iff_eq_none]
+  exact search_eq_none_iff
 
 /-! ### Licensing -/
-
-section Licensing
 
 /-- A goal is licensed by a probe iff the probe's single search
     reaches it ([bejar-rezac-2003]: licensing is an Agree relation
     with the probe). -/
-def Licensed (vis : α → Bool) (goals : List α) (a : α) : Prop :=
-  probeSearch vis goals = some a
+def Licensed (p : Probe α) (goals : List α) (a : α) : Prop :=
+  p.search goals = some a
 
-instance [DecidableEq α] (vis : α → Bool) (goals : List α) (a : α) :
-    Decidable (Licensed vis goals a) :=
-  inferInstanceAs (Decidable (probeSearch vis goals = some a))
-
-variable {vis : α → Bool} {goals : List α}
+instance [DecidableEq α] (p : Probe α) (goals : List α) (a : α) :
+    Decidable (p.Licensed goals a) :=
+  inferInstanceAs (Decidable (p.search goals = some a))
 
 /-- One search licenses at most one goal. -/
 theorem Licensed.unique {a b : α}
-    (ha : Licensed vis goals a) (hb : Licensed vis goals b) : a = b :=
+    (ha : p.Licensed goals a) (hb : p.Licensed goals b) : a = b :=
   Option.some.inj (ha.symm.trans hb)
 
-/-- Licensing by an unrelativized probe (`vis = ⊤`) is being the
-    structurally closest goal — bare minimality, [halpert-2012]'s
-    indiscriminate L⁰. -/
-theorem licensed_const_true_iff {a : α} :
-    Licensed (fun _ => true) goals a ↔ goals.head? = some a := by
-  unfold Licensed probeSearch
+/-- Licensing by the indiscriminate probe is being the structurally
+    closest goal — bare minimality, [halpert-2012]'s L⁰. -/
+theorem indiscriminate_licensed_iff {a : α} :
+    (indiscriminate : Probe α).Licensed goals a ↔ goals.head? = some a := by
+  unfold Licensed search indiscriminate ofVis
   cases goals <;>
     simp only [List.find?_nil, List.find?_cons_of_pos, List.head?_nil,
       List.head?_cons]
 
 /-- Every goal that needs licensing is licensed by the probe's
     search. Which goals *need* licensing (`needs`) and which the
-    probe *sees* (`vis`) come apart in general: [halpert-2012]'s Zulu
-    L⁰ sees every goal (augmented nominals intervene) while only
+    probe *sees* (`p.vis`) come apart in general: [halpert-2012]'s
+    Zulu L⁰ sees every goal (augmented nominals intervene) while only
     augmentless nominals need it. Feature-relativized probes are the
-    diagonal `AllLicensed vis vis` — the probe sees exactly the needy
-    ([bejar-rezac-2003]'s π⁰). -/
-def AllLicensed (needs vis : α → Bool) (goals : List α) : Prop :=
-  ∀ a ∈ goals, needs a = true → Licensed vis goals a
+    diagonal `p.AllLicensed p.vis` — the probe sees exactly the needy
+    ([bejar-rezac-2003]'s π as relativized by [preminger-2014]). -/
+def AllLicensed (p : Probe α) (needs : α → Bool) (goals : List α) : Prop :=
+  ∀ a ∈ goals, needs a = true → p.Licensed goals a
 
-instance [DecidableEq α] (needs vis : α → Bool) (goals : List α) :
-    Decidable (AllLicensed needs vis goals) :=
-  inferInstanceAs (Decidable (∀ a ∈ goals, needs a = true → Licensed vis goals a))
+instance [DecidableEq α] (p : Probe α) (needs : α → Bool) (goals : List α) :
+    Decidable (p.AllLicensed needs goals) :=
+  inferInstanceAs (Decidable (∀ a ∈ goals, needs a = true → p.Licensed goals a))
 
 /-- On the diagonal (probe relativized to exactly the needy), all
     needy goals are licensed iff the visible goals are subsingleton:
     one search, one Agree relation, at most one licensee — the fact
-    behind [preminger-2014]'s AF person restriction. (The off-diagonal
-    variant of the same one-licensee engine drives
+    behind [preminger-2014]'s AF person restriction. (The
+    off-diagonal variant of the same one-licensee engine drives
     [bejar-rezac-2003]'s PCC — `Studies/BejarRezac2003.lean`.) -/
-theorem allLicensed_iff :
-    AllLicensed vis vis goals ↔
+theorem allLicensed_iff {vis : α → Bool} {goals : List α} :
+    (ofVis vis).AllLicensed vis goals ↔
       ∀ a ∈ goals, ∀ b ∈ goals, vis a = true → vis b = true → a = b := by
   constructor
   · intro h a ha b hb hva hvb
@@ -236,72 +238,68 @@ theorem allLicensed_iff :
   · intro h a ha hva
     obtain ⟨b, hb⟩ := Option.isSome_iff_exists.mp
       (List.find?_isSome.mpr ⟨a, ha, hva⟩)
-    have hba := h b (mem_of_probeSearch_eq_some hb) a ha
-      (visible_of_probeSearch_eq_some hb) hva
+    have hba := h b (mem_of_search_eq_some (p := ofVis vis) hb) a ha
+      (visible_of_search_eq_some (p := ofVis vis) hb) hva
     exact hba ▸ hb
 
 /-- `allLicensed_iff` in `Set.Subsingleton` form, for mathlib-API
     discoverability. -/
-theorem allLicensed_iff_subsingleton :
-    AllLicensed vis vis goals ↔ {a | a ∈ goals ∧ vis a = true}.Subsingleton := by
+theorem allLicensed_iff_subsingleton {vis : α → Bool} {goals : List α} :
+    (ofVis vis).AllLicensed vis goals ↔
+      {a | a ∈ goals ∧ vis a = true}.Subsingleton := by
   rw [allLicensed_iff]
   exact ⟨fun h a ha b hb => h a ha.1 b hb.1 ha.2 hb.2,
          fun h a ha b hb hva hvb => h ⟨ha, hva⟩ ⟨hb, hvb⟩⟩
 
-/-- Off the diagonal, licensing by an unrelativized probe pins every
-    needy goal to the head of the sequence — the highest-element
-    condition ([halpert-2012]: an augmentless nominal must be the
-    highest nominal in its vP). -/
-theorem allLicensed_const_true_iff {needs : α → Bool} :
-    AllLicensed needs (fun _ => true) goals ↔
+/-- Licensing by the indiscriminate probe pins every needy goal to
+    the head of the sequence — the highest-element condition
+    ([halpert-2012]: an augmentless nominal must be the highest
+    nominal in its vP). -/
+theorem indiscriminate_allLicensed_iff {needs : α → Bool} {goals : List α} :
+    (indiscriminate : Probe α).AllLicensed needs goals ↔
       ∀ a ∈ goals, needs a = true → goals.head? = some a :=
   forall_congr' fun _ => imp_congr_right fun _ => imp_congr_right fun _ =>
-    licensed_const_true_iff
+    indiscriminate_licensed_iff
 
-end Licensing
+/-! ### Cascades -/
 
-/-! ### Probe cascades -/
+/-- The goal an ordered sequence of probes delivers: the first
+    probe's finding, else the next's, and so on — `Probe.search` at
+    the goal level composed with `List.findSome?` at the probe level.
+    This is also the single-slot morphological competition: the first
+    probe with output wins the slot ([preminger-2014] §4.4: π⁰'s
+    clitic beats #⁰'s exponent beats nothing). -/
+def cascade (ps : List (Probe α)) (goals : List α) : Option α :=
+  ps.findSome? (·.search goals)
 
-section Cascade
-
-/-- The goal an ordered sequence of probes delivers: the first probe's
-    finding, else the next's, and so on — `probeSearch` at the goal
-    level composed with `List.findSome?` at the probe level. This is
-    also the single-slot morphological competition: the first probe
-    with output wins the slot ([preminger-2014] §4.4: π⁰'s clitic
-    beats #⁰'s exponent beats nothing). -/
-def cascadeSearch (probes : List (α → Bool)) (goals : List α) : Option α :=
-  probes.findSome? (probeSearch · goals)
-
-variable {probes : List (α → Bool)} {goals : List α}
+variable {ps : List (Probe α)}
 
 /-- A cascade delivers nothing iff no goal is visible to any probe. -/
 @[simp]
-theorem cascadeSearch_eq_none_iff :
-    cascadeSearch probes goals = none ↔
-      ∀ p ∈ probes, ∀ a ∈ goals, p a = false := by
-  simp [cascadeSearch, List.findSome?_eq_none_iff]
+theorem cascade_eq_none_iff :
+    cascade ps goals = none ↔
+      ∀ q ∈ ps, ∀ a ∈ goals, q.vis a = false := by
+  simp [cascade, List.findSome?_eq_none_iff]
 
 /-- Unfold one probe of the cascade. -/
-theorem cascadeSearch_cons {p : α → Bool} :
-    cascadeSearch (p :: probes) goals =
-      (probeSearch p goals <|> cascadeSearch probes goals) := by
-  rw [cascadeSearch, List.findSome?_cons]
-  cases probeSearch p goals <;> rfl
+theorem cascade_cons {q : Probe α} :
+    cascade (q :: ps) goals = (q.search goals <|> cascade ps goals) := by
+  rw [cascade, List.findSome?_cons]
+  cases q.search goals <;> rfl
 
 /-- The cascade's goal is licensed by one of its probes. -/
-theorem exists_licensed_of_cascadeSearch_eq_some {a : α}
-    (h : cascadeSearch probes goals = some a) :
-    ∃ p ∈ probes, Licensed p goals a :=
+theorem exists_licensed_of_cascade_eq_some {a : α}
+    (h : cascade ps goals = some a) :
+    ∃ q ∈ ps, q.Licensed goals a :=
   List.exists_of_findSome?_eq_some h
 
 /-- The cascade's goal is a member of the sequence. -/
-theorem mem_of_cascadeSearch_eq_some {a : α}
-    (h : cascadeSearch probes goals = some a) : a ∈ goals :=
-  let ⟨_, _, hp⟩ := exists_licensed_of_cascadeSearch_eq_some h
-  mem_of_probeSearch_eq_some hp
+theorem mem_of_cascade_eq_some {a : α}
+    (h : cascade ps goals = some a) : a ∈ goals :=
+  let ⟨_, _, hq⟩ := exists_licensed_of_cascade_eq_some h
+  mem_of_search_eq_some hq
 
-end Cascade
+end Probe
 
 /-! ### φ-probes -/
 
@@ -322,11 +320,11 @@ def _root_.Agreement.Cell.visibleTo (c : Agreement.Cell) (t : ProbeTarget) : Boo
     counts as a licensing Agree relation) and multi-cycle repairs —
     for the paper's own condition see `BejarRezac2003.PLCOk`. -/
 def PLC (cellOf : α → Agreement.Cell) (goals : List α) : Prop :=
-  AllLicensed (λ a => (cellOf a).visibleTo .participant)
-    (λ a => (cellOf a).visibleTo .participant) goals
+  (Probe.ofVis fun a => (cellOf a).visibleTo .participant).AllLicensed
+    (fun a => (cellOf a).visibleTo .participant) goals
 
 instance [DecidableEq α] (cellOf : α → Agreement.Cell) (goals : List α) :
     Decidable (PLC cellOf goals) :=
-  inferInstanceAs (Decidable (AllLicensed _ _ goals))
+  inferInstanceAs (Decidable (Probe.AllLicensed _ _ goals))
 
 end Minimalist


### PR DESCRIPTION
Everything probe-related now runs through one bundled `Probe α` object (`vis` + `act`, act defaulting to always-active) with a dot-notation namespace: `Probe.search`/`agree`/`outcome`/`Licensed`/`AllLicensed`/`cascade`, plus `Probe.ofVis` and `Probe.indiscriminate` constructors. The loose `probeSearch`/`probeAgree`/`searchOutcome`/`cascadeSearch`/`AllLicensed` functions are gone — no shims.

Every consumer now names its probe as an object: B&R 2003's `pi` ({⊤, ¬F}), Halpert's `L` (= `Probe.indiscriminate`), Preminger's `piProbe`/`numProbe` cascade, Scott 2023's `satProbe cond` ({halts, copies}), CyclicAgree's per-segment `segProbe geom s`, C&K's per-segment `ofVis (bears s)` (its local `Probe` abbrev for segment lists is dissolved into `ProbeArticulation`). All proofs transported; full build green.