### PR TITLE
feat(Syntax/Minimalist/Phi): probe specifications denote via toProbe

### DIFF
--- a/Linglib/Studies/Deal2024.lean
+++ b/Linglib/Studies/Deal2024.lean
@@ -47,9 +47,11 @@ This study file connects [deal-2024]'s framework to both:
 The licitness function is *run*, not tabulated: `runProbe` walks the
 goal sequence with interaction, satisfaction, and dynamic narrowing
 as state transitions (`step`), with `step_int_mono` ("dynamic
-interaction only narrows") and `step_of_satisfied` (a satisfied
-probe is inert) as the probe-state laws; `isLicit` and the (1)-table
-theorems are derived from runs.
+interaction only narrows"), `probe_vis_antitone` (its `Probe`-level
+form: the state-indexed probe family `ProbeState.probe` only sees
+less over time), and `step_of_satisfied` (a satisfied probe is
+inert) as the probe-state laws; `isLicit` and the (1)-table theorems
+are derived from runs.
 
 -/
 
@@ -178,6 +180,13 @@ structure ProbeState where
 /-- Initial state: [INT:φ], unsatisfied, nothing agreed. -/
 def ProbeState.initial : ProbeState := ⟨.phi, false, []⟩
 
+/-- The static `Probe` a state denotes: visibility = bearing the
+    current INT condition. Deal's dynamic probe is a *state-indexed
+    family* of static probes — `step`'s interaction check is
+    literally `st.probe.vis`. -/
+def ProbeState.probe (st : ProbeState) : Minimalist.Probe Person :=
+  .ofVis (fun p => dpBears p st.int)
+
 /-- The dynamic-interaction target a goal contributes (her §5):
     `[F]↑` narrows INT to [F] when the interacted goal bears [F];
     in the combined setting `[SPKR]↑` takes priority. -/
@@ -201,7 +210,7 @@ def narrowTarget (d : DynInteraction) (p : Person) : Option PersonFeature :=
     by construction. -/
 def step (g : DealGrammar) (st : ProbeState) (t : Person × Nat) : ProbeState :=
   if st.satisfied then st
-  else if dpBears t.1 st.int then
+  else if st.probe.vis t.1 then
     { int :=
         match narrowTarget g.dynInteraction t.1 with
         | some f => if st.int ≤ f then f else st.int
@@ -234,6 +243,21 @@ theorem step_int_mono (g : DealGrammar) (st : ProbeState)
         · exact le_refl _
       · exact le_refl _
     · exact le_refl _
+
+/-- Bearing a more specific feature entails bearing a less specific
+    one — the (7) geometry, as monotonicity of `dpBears`. -/
+theorem dpBears_antitone {f g : PersonFeature} (hfg : f ≤ g) (p : Person)
+    (h : dpBears p g = true) : dpBears p f = true := by
+  revert hfg h
+  cases f <;> cases g <;> cases p <;> decide
+
+/-- The state-indexed probe family only narrows: anything visible to
+    a later state's probe was visible to an earlier state's —
+    `step_int_mono` at the `Probe` level. -/
+theorem probe_vis_antitone (g : DealGrammar) (st : ProbeState)
+    (t : Person × Nat) (a : Person)
+    (h : ((step g st t).probe).vis a = true) : st.probe.vis a = true :=
+  dpBears_antitone (step_int_mono g st t) a h
 
 /-- A satisfied probe is inert: satisfaction halts all further
     interaction (her (8b)). -/

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -246,11 +246,12 @@ theorem ch4_relativization_contrast :
         List (ArgPosition × Agreement.Cell)) := by
   decide
 
-/-- π⁰: the person probe, relativized to [participant]. -/
-def piProbe : Probe Agreement.Cell := .ofVis (·.visibleTo .participant)
+/-- π⁰: the person probe — the denotation of the substrate's
+    `ProbeTarget.participant` specification. -/
+def piProbe : Probe Agreement.Cell := ProbeTarget.participant.toProbe
 
-/-- #⁰: the number probe, relativized to [plural]. -/
-def numProbe : Probe Agreement.Cell := .ofVis (·.visibleTo .plural)
+/-- #⁰: the number probe — the denotation of `ProbeTarget.plural`. -/
+def numProbe : Probe Agreement.Cell := ProbeTarget.plural.toProbe
 
 /-- The two AF probes in slot order: π⁰'s clitic output beats #⁰'s
     direct exponence in the single morphological slot

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -573,18 +573,20 @@ structure Encounter where
 def halts (cond : SatisfactionCond) (e : Encounter) : Bool :=
   cond.isSatisfied e.feats e.cat
 
-/-- A satisfaction-conditioned probe as a `Probe` over encounters:
-    visibility = halting ([deal-2024] interaction), activity =
-    feature copying. -/
-def satProbe (cond : SatisfactionCond) : Probe Encounter :=
+/-- The probe a `SatisfactionCond` specification denotes, over
+    encounters: visibility = halting ([deal-2024] interaction),
+    activity = feature copying. The canonical
+    specification-to-`Probe` map for satisfaction conditions. -/
+def _root_.Minimalist.SatisfactionCond.toProbe (cond : SatisfactionCond) :
+    Probe Encounter :=
   { vis := halts cond, act := fun e => cond.copiedFeatures e.feats e.cat }
 
-/-- The argument position a probe φ-agrees with: `(satProbe cond).agree`
+/-- The argument position a probe φ-agrees with: `cond.toProbe.agree`
     — the probe agrees with the found element only if satisfaction
     copied features (feature match, not head encounter). -/
 def agreesWith (cond : SatisfactionCond) (goals : List Encounter) :
     Option ArgPosition :=
-  ((satProbe cond).agree goals).bind (·.pos)
+  (cond.toProbe.agree goals).bind (·.pos)
 
 /-- Transitive Voice as an encounter: a head of category `.v`, no
     φ-features visible to the probe. -/
@@ -631,7 +633,7 @@ theorem infl_finds_S (φS : FeatureBundle)
     agreesWith mamInflSatisfaction [dpGoal .S φS] = some .S := by
   have h1 : halts mamInflSatisfaction ⟨some .S, φS, none⟩ = true := by
     simp [halts, mamInflSatisfaction_isSatisfied, hS]
-  simp [agreesWith, satProbe, Probe.agree, Probe.search, Option.filter_some,
+  simp [agreesWith, SatisfactionCond.toProbe, Probe.agree, Probe.search, Option.filter_some,
     dpGoal, h1, mamInflSatisfaction_copiedFeatures, hS]
 
 /-- Voice's search finds the agent (closest goal), provided A bears
@@ -642,7 +644,7 @@ theorem voice_finds_A (φA φP : FeatureBundle)
   have h1 : halts (.featureMatch (.phi (.person .third)))
       ⟨some .A, φA, none⟩ = true := by
     simp [halts, SatisfactionCond.isSatisfied, hA]
-  simp [agreesWith, satProbe, Probe.agree, Probe.search, Option.filter_some,
+  simp [agreesWith, SatisfactionCond.toProbe, Probe.agree, Probe.search, Option.filter_some,
     dpGoal, voiceSat, h1, SatisfactionCond.copiedFeatures, hA]
 
 /-- DERIVED probe table: which head φ-agrees with position `p`,
@@ -680,7 +682,7 @@ theorem agreeProbe_eq_derived_3sg :
 
 /-- φ-valuation outcome of a probe with a satisfaction condition:
     valued iff the search found a goal AND satisfaction copied
-    features. NOTE: this is NOT `(satProbe cond).outcome` — a
+    features. NOTE: this is NOT `cond.toProbe.outcome` — a
     head-encounter halt satisfies the search but leaves the probe
     φ-unvalued. -/
 def valuationOutcome (cond : SatisfactionCond) (goals : List Encounter) :
@@ -701,7 +703,7 @@ theorem transitive_unvalued_elsewhere (rest : List Encounter) :
     element. The valuation/satisfaction distinction is exactly
     [deal-2024]'s interaction-vs-satisfaction split. -/
 theorem searchOutcome_valued_but_unvalued (rest : List Encounter) :
-    (satProbe mamInflSatisfaction).outcome (voiceTR :: rest) = .valued ∧
+    (mamInflSatisfaction.toProbe).outcome (voiceTR :: rest) = .valued ∧
     valuationOutcome mamInflSatisfaction (voiceTR :: rest) = .unvalued :=
   ⟨rfl, rfl⟩
 

--- a/Linglib/Syntax/Minimalist/Phi/Articulation.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Articulation.lean
@@ -117,6 +117,16 @@ structure ArticulatedProbe where
   rooted : Segment.pi ∈ segments
   lower : IsArticulated segments
 
+/-- The family of search-level `Probe`s an articulated probe denotes,
+    given a bearing relation for the goal type: one probe per
+    segment ([bejar-rezac-2009]; [coon-keine-2021] (14)). An
+    articulated probe is a *specification*; this is its canonical
+    map into the `Probe` carrier — one-to-many, which is why the
+    relationship is denotation, not extension. -/
+def ArticulatedProbe.toProbes {α : Type*} (P : ArticulatedProbe)
+    (bears : Segment → α → Bool) : List (Probe α) :=
+  P.segments.map (fun s => .ofVis (bears s))
+
 /-! ### The probe-specification hierarchy ([coon-keine-2021] (40)) -/
 
 /-- The (40) hierarchy as a type:

--- a/Linglib/Syntax/Minimalist/Phi/Probing.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Probing.lean
@@ -50,6 +50,18 @@ re-probing see `Syntax/Minimalist/Probing/DefectiveCircumvention.lean`.
 - `Probe.cascade` — ordered probe sequence: first probe with output
   wins (the single-slot morphological competition).
 - `PLC` — the Person Licensing Condition over φ-bearing goal tokens.
+
+## Probe specifications
+
+Theory-side probe descriptions relate to `Probe` by *denotation*
+(canonical `toProbe`-maps), not extension — the relationship is
+one-to-many for articulated probes and state-indexed for dynamic
+ones: `ProbeTarget.toProbe` (here), `SatisfactionCond.toProbe`
+(`Studies/Scott2023.lean`), `ArticulatedProbe.toProbes`
+(`Phi/Articulation.lean`, the per-segment family),
+`CyclicAgree.segProbe` (per segment and geometry), and
+`Deal2024.ProbeState.probe` (the state-indexed family whose
+narrowing law is `probe_vis_antitone`).
 -/
 
 namespace Minimalist
@@ -307,6 +319,14 @@ end Probe
     feature the probe seeks (`probeVisible`, `Phi/Geometry.lean`). -/
 def _root_.Agreement.Cell.visibleTo (c : Agreement.Cell) (t : ProbeTarget) : Bool :=
   probeVisible t c.toPerson c.isPlural
+
+/-- The probe a `ProbeTarget` specification denotes: relativized to
+    the sought feature, over φ-cells. The canonical
+    specification-to-`Probe` map for the substrate's probe enum —
+    [preminger-2014]'s π⁰ is `ProbeTarget.participant.toProbe`, his
+    #⁰ is `ProbeTarget.plural.toProbe`. -/
+def ProbeTarget.toProbe (t : ProbeTarget) : Probe Agreement.Cell :=
+  .ofVis (·.visibleTo t)
 
 /-- The Person Licensing Condition ([bejar-rezac-2003];
     [preminger-2014] (40)/(75)): every [participant]-bearing goal


### PR DESCRIPTION
Ties the theory-side probe specifications to the `Probe` carrier by canonical denotation maps (the FilterBasis-pattern: specs keep their own laws, generate probes, never extend).

- `ProbeTarget.toProbe` (substrate): Preminger's `piProbe`/`numProbe` are now `.participant.toProbe`/`.plural.toProbe`.
- `SatisfactionCond.toProbe` (Scott2023, replacing `satProbe`): satisfaction conditions denote {halts, copies} probes.
- `ArticulatedProbe.toProbes bears` (Articulation): the one-to-many segment family — why the relationship is denotation, not extension.
- `Deal2024.ProbeState.probe`: the state-indexed family — `step` now literally consults `st.probe.vis`, with `dpBears_antitone` (geometric entailment as monotonicity) and `probe_vis_antitone` (the dynamic probe only sees less over time) as the new Probe-level laws.
- Probing's docstring gains a "Probe specifications" index of all five maps.