### PR TITLE
refactor(Syntax/Minimalist): probe specs into the Probe namespace

### DIFF
--- a/Linglib/Studies/AissenPolian2025.lean
+++ b/Linglib/Studies/AissenPolian2025.lean
@@ -89,7 +89,7 @@ alongside Tz'utujil, Chickasaw, Sinitic double-unaccusative).
 - `JudgmentType` from `Discourse/InformationStructure.lean`
 - `GramFunction`, `absPosition` from `Fragments/Mayan/Tseltalan.lean`
 - `ABSPosition` from `Fragments/Mayan/Params.lean`
-- `ProbeProfile`, `closestGoalB`, `behindHorizonB`, `liftFM` from
+- `Probe.Profile`, `closestGoalB`, `behindHorizonB`, `liftFM` from
   `Syntax/Minimalist/{Agree, Basic}.lean`
 -/
 
@@ -220,16 +220,16 @@ instance : Decidable CanĀSubextract := by unfold CanĀSubextract; infer_instanc
 theorem subextraction_impossible : ¬ CanĀSubextract := fun h => h trivial
 
 -- ────────────────────────────────────────────────────────────────
--- ProbeType ↔ ProbeProfile bridge
+-- ProbeType ↔ Probe.Profile bridge
 -- ────────────────────────────────────────────────────────────────
 
-/-- Convert a `ProbeType` to a `ProbeProfile` from [keine-2019].
+/-- Convert a `ProbeType` to a `Probe.Profile` from [keine-2019].
 
     - `dProbe` (A-movement, on T°/Appl°) maps to an A-probe on T°
       with horizon C — the same profile as `keineAProbe`.
     - `whProbe` (Ā-movement, on D°/C°) maps to an Ā-probe on C°
       with no horizon — the same profile as `keineĀProbe`. -/
-def ProbeType.toProfile : ProbeType → Minimalist.ProbeProfile
+def ProbeType.toProfile : ProbeType → Minimalist.Probe.Profile
   | .dProbe  => Minimalist.keineAProbe
   | .whProbe => Minimalist.keineĀProbe
 

--- a/Linglib/Studies/Amato2025.lean
+++ b/Linglib/Studies/Amato2025.lean
@@ -104,7 +104,7 @@ private def aWhObj : LIToken := ⟨LexicalItem.simple .D [], 3⟩
 /-- C's probe with C-area horizon. Both `[*wh*]` and `[•wh•]` use
     this profile; the Agree-vs-Merge distinction is at the consumer
     interpretive layer, not at the abstract `NestedAgreeConfig` level. -/
-private def cProbe : ProbeProfile := ⟨.C, none⟩
+private def cProbe : Probe.Profile := ⟨.C, none⟩
 
 /-- Bulgarian multi-wh configuration at the relevant derivational
     step (post-Multiple-Agree, pre-movement). Pre-movement tree:

--- a/Linglib/Studies/Amato2025Agreement.lean
+++ b/Linglib/Studies/Amato2025Agreement.lean
@@ -92,7 +92,7 @@ private def aDPnom : LIToken := ⟨LexicalItem.simple .D [], 3⟩
 /-- T's probe with C horizon. The two orderings use the same probe
     profile twice; the ordering distinction is captured by `goalHead`
     and `validGoal` in the two configs below. -/
-private def tProbe : ProbeProfile := ⟨.T, some .C⟩
+private def tProbe : Probe.Profile := ⟨.T, some .C⟩
 
 /-! ### Configuration A — agreement with the nominative -/
 
@@ -240,7 +240,7 @@ private def aAbs : LIToken := ⟨LexicalItem.simple .D [], 3⟩
 /-- Asp's probe with C horizon. Both `[*Infl:perf*]` and `[*π:_*]`
     use the same profile; the Nested Agree ordering is captured by
     list position, the shared goal by `goalHead`. -/
-private def aspProbe : ProbeProfile := ⟨.T, some .C⟩
+private def aspProbe : Probe.Profile := ⟨.T, some .C⟩
 
 /-- The Lak perfective configuration. Tree: `Asp [Erg [v Abs]]`,
     goal = v. v is reachable (c-commanded by Asp) and phi-active

--- a/Linglib/Studies/Amato2025Auxiliary.lean
+++ b/Linglib/Studies/Amato2025Auxiliary.lean
@@ -321,7 +321,7 @@ private def aV : LIToken := ⟨LexicalItem.simple .V [], 1⟩
 private def aDPsubj : LIToken := ⟨LexicalItem.simple .D [], 2⟩
 private def aDPobj : LIToken := ⟨LexicalItem.simple .D [], 3⟩
 
-private def perfProbe : ProbeProfile := ⟨.T, some .C⟩
+private def perfProbe : Probe.Profile := ⟨.T, some .C⟩
 
 /-- Translate an Amato clause to an abstract `NestedAgreeConfig` over
     a Minimalist `SyntacticObject`, using `NestedAgree.standardConfig`.
@@ -375,7 +375,7 @@ theorem personAgree_iff_runStack_hits (c : RestructuringClauseAmato) :
   · intro h
     refine ⟨?_, ?_⟩
     · -- length = stack.length = 2 > 1: structural after unfold.
-      show 1 < ([⟨.T, some .C⟩, ⟨.T, some .C⟩] : List ProbeProfile).length
+      show 1 < ([⟨.T, some .C⟩, ⟨.T, some .C⟩] : List Probe.Profile).length
       decide
     · -- goalHead ∈ searchDomain 1 = daughters; reflexively in its
       -- own daughters when phi-active.

--- a/Linglib/Studies/CoonKeine2021.lean
+++ b/Linglib/Studies/CoonKeine2021.lean
@@ -45,12 +45,12 @@ Universal predictions (§3.4.2): no probe bans [PART]>3 or 3>3
 (`direct_never_banned` — the geometry makes such gluttony
 impossible); for [uPERS]-rooted probes a [PART]>[PART] ban entails a
 3>[PART] ban (`ban_part_part_implies_ban_three_part`, bundled as
-`ArticulatedProbe.ban_part_part`); a single-segment probe never
+`Probe.Articulated.ban_part_part`); a single-segment probe never
 gluttons (`not_gluttonous_single_segment`, their fn. 21). The
 articulation laws themselves — downward closure along the geometry,
 the (40) probe-specification hierarchy — live in
-`Phi/Articulation.lean` (`IsArticulated`, `ArticulatedProbe`,
-`ProbeStage`); `meFirstProbe_not_articulated` is their fn. 22 made
+`Phi/Articulation.lean` (`IsArticulated`, `Probe.Articulated`,
+`Probe.Stage`); `meFirstProbe_not_articulated` is their fn. 22 made
 formal.
 
 ## Rival accounts (their §2, comparisons drawn by the paper)
@@ -104,7 +104,7 @@ displacement all shrink the probe's search space below two.
 namespace CoonKeine2021
 
 open Minimalist
-open Minimalist.CyclicAgree (Segment ProbeArticulation)
+open Minimalist.CyclicAgree (Segment)
 
 /-! ### Feature geometry and goals (their (11), §3.4.1) -/
 
@@ -161,20 +161,20 @@ def Goal.visibleSegs (g : Goal) : List Segment :=
 /-- Their (39a): [uPERS [uPART]] — Weak PCC (Catalan). Identical to
     [bejar-rezac-2009]'s partial probe (`CyclicAgree.partialProbe`),
     by construction. -/
-def weakProbe : ProbeArticulation := CyclicAgree.partialProbe
+def weakProbe : Probe.Articulation := CyclicAgree.partialProbe
 
 /-- Their (39b): [uPERS [uPART [uSPKR]]] — Ultrastrong PCC.
     Identical to [bejar-rezac-2009]'s full probe under the standard
     geometry (`CyclicAgree.fullProbeStd`). -/
-def ultrastrongProbe : ProbeArticulation := CyclicAgree.fullProbeStd
+def ultrastrongProbe : Probe.Articulation := CyclicAgree.fullProbeStd
 
 /-- Their (39c): [uPERS [uSPKR]] — Me-First PCC (missing
     intermediate segment; see their fn. 22). -/
-def meFirstProbe : ProbeArticulation := [.pi, .speaker]
+def meFirstProbe : Probe.Articulation := [.pi, .speaker]
 
 /-- Their fn. 22 (i): [uPERS [uPART [uSPKR][uADDR]]] — Strong PCC
     with φ-transparent datives. -/
-def branchingStrongProbe : ProbeArticulation := [.pi, .participant, .speaker, .addressee]
+def branchingStrongProbe : Probe.Articulation := [.pi, .participant, .speaker, .addressee]
 
 /-- Agree, their (14), generic in the segment type ((11) person,
     (12) number): a segment agrees with the closest accessible goal
@@ -208,10 +208,10 @@ def segGoal (s : Segment) (goals : List Goal) : Option (Goal × Nat) :=
   segGoalOn personBears s goals
 
 /-- Person-probe gluttony. -/
-def Gluttonous (P : ProbeArticulation) (goals : List Goal) : Prop :=
+def Gluttonous (P : Probe.Articulation) (goals : List Goal) : Prop :=
   GluttonousOn personBears P goals
 
-instance (P : ProbeArticulation) (goals : List Goal) : Decidable (Gluttonous P goals) :=
+instance (P : Probe.Articulation) (goals : List Goal) : Decidable (Gluttonous P goals) :=
   inferInstanceAs (Decidable (GluttonousOn personBears P goals))
 
 /-! ### Gluttony is limited to inverse configurations -/
@@ -233,7 +233,7 @@ private theorem segGoal_pair (s : Segment) (hi lo : Goal) :
     exposes is also borne by the higher goal, no probe is
     gluttonous over them — direct (17)–(18) and balanced (19)–(20)
     configurations are safe. -/
-theorem gluttonous_only_inverse (P : ProbeArticulation) {hi lo : Goal}
+theorem gluttonous_only_inverse (P : Probe.Articulation) {hi lo : Goal}
     (hsub : ∀ s, s ∈ lo.visibleSegs → s ∈ hi.visibleSegs) :
     ¬ Gluttonous P [hi, lo] := by
   rintro ⟨s₁, _, s₂, _, t₁, _, t₂, _, h₁, h₂, hne⟩
@@ -260,10 +260,10 @@ theorem gluttonous_only_inverse (P : ProbeArticulation) {hi lo : Goal}
     host; under gluttony this is jointly unsatisfiable (one-at-a-time
     violates (30) mid-derivation, simultaneous violates binary
     Merge), so gluttony here IS the predicted ban. -/
-def pccViolation (P : ProbeArticulation) (ioOpaque : Bool) (io do_ : Person) : Prop :=
+def pccViolation (P : Probe.Articulation) (ioOpaque : Bool) (io do_ : Person) : Prop :=
   Gluttonous P [{ person := io, kOpaque := ioOpaque }, dp do_]
 
-instance (P : ProbeArticulation) (b : Bool) (io do_ : Person) :
+instance (P : Probe.Articulation) (b : Bool) (io do_ : Person) :
     Decidable (pccViolation P b io do_) :=
   inferInstanceAs (Decidable (Gluttonous _ _))
 
@@ -330,7 +330,7 @@ theorem basque_dat_abs_contrast :
     goal's geometry, so gluttony is impossible — "the gluttony
     account therefore derives the fact that no such PCC pattern
     exists". -/
-theorem direct_never_banned (P : ProbeArticulation) (io : Person) :
+theorem direct_never_banned (P : Probe.Articulation) (io : Person) :
     ¬ pccViolation P false io .third := by
   apply gluttonous_only_inverse
   intro s hs
@@ -374,7 +374,7 @@ theorem not_gluttonous_single_segment {σ : Type*} (bears : σ → Goal → Bool
     fortiori, while [uPERS] still lands on the IO. (Rootedness — the
     one property every probe of their (13)/(39) has — suffices; full
     downward closure is not needed.) -/
-theorem ban_part_part_implies_ban_three_part (P : ProbeArticulation)
+theorem ban_part_part_implies_ban_three_part (P : Probe.Articulation)
     (hpi : Segment.pi ∈ P)
     (h : pccViolation P false .second .first) :
     pccViolation P false .third .first := by
@@ -402,10 +402,10 @@ theorem ban_part_part_implies_ban_three_part (P : ProbeArticulation)
     (dp .third, 0), by decide, (dp .first, 1), by decide,
     by decide, by decide, by decide⟩
 
-/-- The bundled form: an `ArticulatedProbe` (`Phi/Articulation.lean`)
+/-- The bundled form: an `Probe.Articulated` (`Phi/Articulation.lean`)
     carries [uPERS]-rootedness as a law, so the implicational
     universal needs no side condition. -/
-theorem ArticulatedProbe.ban_part_part (P : ArticulatedProbe)
+theorem Probe.Articulated.ban_part_part (P : Probe.Articulated)
     (h : pccViolation P.segments false .second .first) :
     pccViolation P.segments false .third .first :=
   ban_part_part_implies_ban_three_part P.segments P.rooted h
@@ -484,7 +484,7 @@ are interspeaker-variable. -/
 
 /-- The values a probe acquires: the visible geometry of each
     distinct goal token some segment agreed with (their (16)). -/
-def acquiredValues (P : ProbeArticulation) (goals : List Goal) : List (List Segment) :=
+def acquiredValues (P : Probe.Articulation) (goals : List Goal) : List (List Segment) :=
   (goals.zipIdx.filter
     (fun t => P.any (fun s => segGoal s goals == some t))).map
     (fun t => t.1.visibleSegs)
@@ -492,7 +492,7 @@ def acquiredValues (P : ProbeArticulation) (goals : List Goal) : List (List Segm
 /-- One DP agreeing with many probes is not gluttony (their (86):
     Icelandic multiple participle agreement): a single goal can never
     yield two distinct tokens. -/
-theorem not_gluttonous_singleton (P : ProbeArticulation) (g : Goal) :
+theorem not_gluttonous_singleton (P : Probe.Articulation) (g : Goal) :
     ¬ Gluttonous P [g] := by
   rintro ⟨s₁, _, s₂, _, t₁, ht₁m, t₂, ht₂m, _, _, hne⟩
   cases ht₁m with
@@ -616,7 +616,7 @@ theorem german_copula :
       MorphOk germanPastSg false
         (acquiredValues weakProbe [dp .third, dp .first])) ∧
     -- nonfinite: no probe, no gluttony
-    ¬ Gluttonous ([] : ProbeArticulation) [dp .third, dp .second] := by
+    ¬ Gluttonous ([] : Probe.Articulation) [dp .third, dp .second] := by
   decide
 
 /-! ### The number probe and the missing "Number Case Constraint"
@@ -654,7 +654,7 @@ def numProbe : List NumSeg := [.num, .pl]
 /-- Clitic doubling renders the doubled DP invisible to subsequent
     probing (their §3.2): the tokens π agreed with are removed from
     #'s search space (their (42)). -/
-def afterCliticDoubling (piP : ProbeArticulation) (goals : List Goal) : List Goal :=
+def afterCliticDoubling (piP : Probe.Articulation) (goals : List Goal) : List Goal :=
   (goals.zipIdx.filter
     (fun t => ! piP.any (fun s => segGoal s goals == some t))).map (·.1)
 
@@ -702,7 +702,7 @@ theorem reverse_pcc_diagnoses_strong :
 /-! ### PCC repairs (§3.5) -/
 
 /-- An empty search space is never gluttonous. -/
-theorem not_gluttonous_nil (P : ProbeArticulation) : ¬ Gluttonous P [] := by
+theorem not_gluttonous_nil (P : Probe.Articulation) : ¬ Gluttonous P [] := by
   rintro ⟨_, _, _, _, t, htm, _⟩
   exact nomatch htm
 
@@ -716,7 +716,7 @@ theorem not_gluttonous_nil (P : ProbeArticulation) : ¬ Gluttonous P [] := by
     displacement around π (their (50)). Last-resort uses of these
     structures (Rezac's ᑬ) translate as: extra structure is
     sanctioned iff the probe would otherwise glutton. -/
-theorem repairs_shield_goals (P : ProbeArticulation) (g : Goal) :
+theorem repairs_shield_goals (P : Probe.Articulation) (g : Goal) :
     ¬ Gluttonous P [g] ∧ ¬ Gluttonous P [] :=
   ⟨not_gluttonous_singleton P g, not_gluttonous_nil P⟩
 

--- a/Linglib/Studies/Halpert2012.lean
+++ b/Linglib/Studies/Halpert2012.lean
@@ -72,7 +72,7 @@ instance (vp : List Nominal) : Decidable (LicensingOk vp) :=
   inferInstanceAs (Decidable (L.AllLicensed needsL vp))
 
 /-- L⁰'s probing outcome: valued iff the vP has any overt content. -/
-def lOutcome (vp : List Nominal) : ProbeOutcome :=
+def lOutcome (vp : List Nominal) : Probe.Outcome :=
   L.outcome vp
 
 /-- The conjoint/disjoint marker (present tense) as the spellout of

--- a/Linglib/Studies/Keine2019.lean
+++ b/Linglib/Studies/Keine2019.lean
@@ -55,7 +55,7 @@ Key refinements in [keine-2020]:
 
 ## Architecture
 
-The theory-layer infrastructure (`ProbeProfile`, `transparentTo`,
+The theory-layer infrastructure (`Probe.Profile`, `transparentTo`,
 `transparentToLabel`, `upward_entailment`, `height_locality_connection`)
 lives in `Syntax/Minimalism/Probe.lean`. This file
 imports those definitions and verifies the paper's empirical predictions
@@ -64,7 +64,7 @@ as concrete theorems using the simplified fValue model.
 
 namespace Keine2019
 
-open Minimalist (ProbeProfile keinePhiProbe keineAProbe keineWhLicensing
+open Minimalist (Probe.Profile keinePhiProbe keineAProbe keineWhLicensing
   keineĀProbe fValue ClauseSpine Cat)
 
 -- ============================================================================

--- a/Linglib/Studies/Keine2020.lean
+++ b/Linglib/Studies/Keine2020.lean
@@ -72,14 +72,14 @@ on probe-specific *horizons* and *bilateral labeling*.
 
 ## Architecture
 
-This file imports `Probe.lean` (for `ProbeProfile`, `LanguageProbeConfig`,
+This file imports `Probe.lean` (for `Probe.Profile`, `LanguageProbeConfig`,
 `transparentToLabel`) and `ClauseSpine.lean` (for clause spines with
 bilateral labels). It verifies the book's predictions as theorems.
 -/
 
 namespace Keine2020
 
-open Minimalist (ProbeProfile LanguageProbeConfig ClauseSpine Cat fValue english_extr
+open Minimalist (Probe.Profile LanguageProbeConfig ClauseSpine Cat fValue english_extr
   lubukusuAProbe)
 
 -- ============================================================================
@@ -227,7 +227,7 @@ theorem german_rel_transparent_vP :
 
 -- Note: German rel uses the wh field with horizon Force (same structural
 -- position C⁰). For relativization specifically (horizon C), we test directly:
-private def germanRelProbe : ProbeProfile := ⟨.C, some .C⟩
+private def germanRelProbe : Probe.Profile := ⟨.C, some .C⟩
 
 theorem german_rel_transparent_tP :
     germanRelProbe.transparentToLabel tPLabel = true := by decide
@@ -300,12 +300,12 @@ theorem hindi_finite_selective_opacity :
 /-- Hindi φ and A probes use the default horizon: probe on T⁰ with
     horizon T (= its own head). -/
 theorem hindi_phi_uses_default :
-    hindiCfg.phi = ProbeProfile.defaultHorizon .T := rfl
+    hindiCfg.phi = Probe.Profile.defaultHorizon .T := rfl
 
 /-- German scrambling probe uses the default horizon: probe on T⁰
     with horizon T. -/
 theorem german_scr_uses_default :
-    germanCfg.phi = ProbeProfile.defaultHorizon .T := rfl
+    germanCfg.phi = Probe.Profile.defaultHorizon .T := rfl
 
 -- ============================================================================
 -- § 7: Four Distinct Locality Types (Hindi)
@@ -314,7 +314,7 @@ theorem german_scr_uses_default :
 /-- Hindi exhibits four distinct locality types — one per operation.
     Using bilateral labeling, each probe produces a unique 4-tuple
     of transparency values across (vP, TP, NmlzP, CP). -/
-def hindiProfile (p : ProbeProfile) : Bool × Bool × Bool × Bool :=
+def hindiProfile (p : Probe.Profile) : Bool × Bool × Bool × Bool :=
   ( p.transparentToLabel vPLabel,
     p.transparentToLabel tPLabel,
     p.transparentToLabel nmlzPLabel,
@@ -370,11 +370,11 @@ of C⁰ is TP, whose label `[V, Appl, v, Voice, T]` contains T. -/
 
 /-- Standard vacuous examples: C⁰ ⊣ T, C⁰ ⊣ v, C⁰ ⊣ V are all vacuous. -/
 theorem vacuous_C_with_T :
-    (ProbeProfile.mk .C (some .T)).isVacuous = true := by decide
+    (Probe.Profile.mk .C (some .T)).isVacuous = true := by decide
 theorem vacuous_C_with_v :
-    (ProbeProfile.mk .C (some .v)).isVacuous = true := by decide
+    (Probe.Profile.mk .C (some .v)).isVacuous = true := by decide
 theorem vacuous_C_with_V :
-    (ProbeProfile.mk .C (some .V)).isVacuous = true := by decide
+    (Probe.Profile.mk .C (some .V)).isVacuous = true := by decide
 
 /-- Hindi Ā (C⁰ ⊣ Nmlz) is NOT vacuous: Nmlz is not in TP's label. -/
 theorem hindi_ābar_not_vacuous :
@@ -416,15 +416,15 @@ theorem hindi_hlt_C_probes :
     hindiCfg.wh.isVacuous = false ∧
     hindiCfg.ābar.isVacuous = false ∧
     -- Unattested alternatives would be vacuous
-    (ProbeProfile.mk .C (some .T)).isVacuous = true ∧
-    (ProbeProfile.mk .C (some .v)).isVacuous = true := by decide
+    (Probe.Profile.mk .C (some .T)).isVacuous = true ∧
+    (Probe.Profile.mk .C (some .v)).isVacuous = true := by decide
 
 /-- HLT (279b) for Hindi: φ and A probes use T⁰ ⊣ T (nonvacuous),
     but ⊣ T on C⁰ or Force⁰ would be vacuous. -/
 theorem hindi_hlt_T_horizon :
     hindiCfg.phi.isVacuous = false ∧
-    (ProbeProfile.mk .C (some .T)).isVacuous = true ∧
-    (ProbeProfile.mk .Force (some .T)).isVacuous = true := by decide
+    (Probe.Profile.mk .C (some .T)).isVacuous = true ∧
+    (Probe.Profile.mk .Force (some .T)).isVacuous = true := by decide
 
 -- ============================================================================
 -- § 12: Ban on Improper Movement ([keine-2020] §3.4.1–3.4.2)
@@ -492,7 +492,7 @@ theorem english_extr_more_local :
 
 /-- Extraposition uses the default horizon for T⁰. -/
 theorem english_extr_is_default :
-    english_extr = ProbeProfile.defaultHorizon .T := rfl
+    english_extr = Probe.Profile.defaultHorizon .T := rfl
 
 -- ============================================================================
 -- § 15: Movement–Agreement Mismatches ([keine-2020] §3.4.5)

--- a/Linglib/Studies/LiuYip2026.lean
+++ b/Linglib/Studies/LiuYip2026.lean
@@ -57,7 +57,7 @@ import Linglib.Fragments.Cantonese.ResultativeComplements
   bilateral label* ([keine-2020] horizon opacity). The two coincide on
   the Type II / Type III contrast but make distinct predictions on featural
   mismatch. The `defectiveIntervention` predicate below uses
-  head-as-intervener; it does *not* call `ProbeProfile.transparentToLabel`.
+  head-as-intervener; it does *not* call `Probe.Profile.transparentToLabel`.
 
 - **Aspect-lowering and *-faan*-lowering are parallel, not the same.** Both
   involve matrix-AspP_outer Agree across a vP boundary, but the empirical
@@ -85,7 +85,7 @@ explicit in §10 as a refutation theorem candidate.
 
 namespace LiuYip2026
 
-open Minimalist (AspFlavor AspHead ProbeProfile ClauseSpine ComplementSize Cat fValue)
+open Minimalist (AspFlavor AspHead Probe.Profile ClauseSpine ComplementSize Cat fValue)
 open Typology.Complementation (CTPClass ComplementClauseStructure)
 
 -- ============================================================================
@@ -218,7 +218,7 @@ theorem restructure_decreases (s : ClauseSpine) :
     same-or-compatible selectional spec.
 
     This predicate deliberately does NOT call
-    `ProbeProfile.transparentToLabel` — head-as-intervener and label-as-locus
+    `Probe.Profile.transparentToLabel` — head-as-intervener and label-as-locus
     diverge on featurally-mismatched probes. -/
 def intervenes (matrixProbe : AspHead) (embeddedHead : AspHead) : Bool :=
   -- Same flavor + featurally compatible (or both indifferent)

--- a/Linglib/Studies/Newman2024.lean
+++ b/Linglib/Studies/Newman2024.lean
@@ -698,7 +698,7 @@ theorem voice_hasD_ne_assignsTheta :
 def cmhFeatureModel : AgreementModel := .obligatoryNocrash
 
 /-- Under Feature Failure, unchecked Merge features do not crash. -/
-theorem feature_failure_converges (outcome : ProbeOutcome) :
+theorem feature_failure_converges (outcome : Probe.Outcome) :
     derivationConverges cmhFeatureModel outcome = true :=
   obligatory_always_converges outcome
 

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -112,7 +112,7 @@ gives five arguments against hierarchy accounts:
   `PLC`: the search-and-licensing layer the derivations below
   consume.
 - `Syntax/Minimalist/ObligatoryOperations.lean` — the Ch. 5 model
-  (`AgreementModel`, `ProbeOutcome`, `PFRealization`), consumed
+  (`AgreementModel`, `Probe.Outcome`, `PFRealization`), consumed
   below for the failed-Agree theorems.
 - `Morphology/DM/VocabSimple.lean` — `Vocabulary`,
   `Agreement.Cell.toPhiFeatures`, `makePersonVocab`, `spellout`.
@@ -247,11 +247,11 @@ theorem ch4_relativization_contrast :
   decide
 
 /-- π⁰: the person probe — the denotation of the substrate's
-    `ProbeTarget.participant` specification. -/
-def piProbe : Probe Agreement.Cell := ProbeTarget.participant.toProbe
+    `Probe.Target.participant` specification. -/
+def piProbe : Probe Agreement.Cell := Probe.Target.participant.toProbe
 
-/-- #⁰: the number probe — the denotation of `ProbeTarget.plural`. -/
-def numProbe : Probe Agreement.Cell := ProbeTarget.plural.toProbe
+/-- #⁰: the number probe — the denotation of `Probe.Target.plural`. -/
+def numProbe : Probe Agreement.Cell := Probe.Target.plural.toProbe
 
 /-- The two AF probes in slot order: π⁰'s clitic output beats #⁰'s
     direct exponence in the single morphological slot
@@ -354,16 +354,16 @@ theorem personRestrictionOk_comm (s o : Agreement.Cell) :
 
 /-- π⁰'s outcome on the AF clause's goal pair: each probe is
     independently obligatory ([preminger-2014] Ch. 5). -/
-def piOutcome (subj obj : Agreement.Cell) : ProbeOutcome :=
+def piOutcome (subj obj : Agreement.Cell) : Probe.Outcome :=
   piProbe.outcome [subj, obj]
 
 /-- #⁰'s outcome on the AF clause's goal pair. -/
-def numOutcome (subj obj : Agreement.Cell) : ProbeOutcome :=
+def numOutcome (subj obj : Agreement.Cell) : Probe.Outcome :=
   numProbe.outcome [subj, obj]
 
 /-- Joint outcome of the AF probes: `unvalued` only when both probes
     fail (i.e., both arguments are 3SG). -/
-def afProbeOutcome (subj obj : Agreement.Cell) : ProbeOutcome :=
+def afProbe.Outcome (subj obj : Agreement.Cell) : Probe.Outcome :=
   match piOutcome subj obj, numOutcome subj obj with
   | .unvalued, .unvalued => .unvalued
   | _, _ => .valued
@@ -372,10 +372,10 @@ def afProbeOutcome (subj obj : Agreement.Cell) : ProbeOutcome :=
     is `unvalued` — Agree-level failure and outcome-level failure are
     the same fact, for arbitrary φ-cells. -/
 theorem afAgreementTarget_eq_none_iff (subj obj : Agreement.Cell) :
-    afAgreementTarget subj obj = none ↔ afProbeOutcome subj obj = .unvalued := by
-  have hmatch : afProbeOutcome subj obj = .unvalued ↔
+    afAgreementTarget subj obj = none ↔ afProbe.Outcome subj obj = .unvalued := by
+  have hmatch : afProbe.Outcome subj obj = .unvalued ↔
       piOutcome subj obj = .unvalued ∧ numOutcome subj obj = .unvalued := by
-    unfold afProbeOutcome
+    unfold afProbe.Outcome
     cases piOutcome subj obj <;> cases numOutcome subj obj <;> decide
   rw [hmatch]
   unfold afAgreementTarget piOutcome numOutcome
@@ -395,10 +395,10 @@ theorem failed_agree_tolerated :
     afAgreementTarget (.pn .third .Sing) (.pn .third .Sing) = none ∧
     piOutcome (.pn .third .Sing) (.pn .third .Sing) = .unvalued ∧
     numOutcome (.pn .third .Sing) (.pn .third .Sing) = .unvalued ∧
-    afProbeOutcome (.pn .third .Sing) (.pn .third .Sing) = .unvalued ∧
+    afProbe.Outcome (.pn .third .Sing) (.pn .third .Sing) = .unvalued ∧
     derivationConverges .obligatoryNocrash
-      (afProbeOutcome (.pn .third .Sing) (.pn .third .Sing)) = true ∧
-    (afProbeOutcome (.pn .third .Sing) (.pn .third .Sing)).pfRealization
+      (afProbe.Outcome (.pn .third .Sing) (.pn .third .Sing)) = true ∧
+    (afProbe.Outcome (.pn .third .Sing) (.pn .third .Sing)).pfRealization
       = .elsewhere ∧
     spellout setBVocab [] (some .T) = some "∅" ∧
     afMarker (.pn .third .Sing) (.pn .third .Sing) = some "∅" := by

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -475,7 +475,7 @@ theorem different_probe_heads :
 /-- The transitive Set B default is an instance of Preminger's probe failure:
     Infl's probe searches an empty domain (blocked by Voice_TR) and finds no
     DP with matching φ-features. `attemptAgree` maps the `none` result from
-    `applyAgree` to `ProbeOutcome.unvalued`. -/
+    `applyAgree` to `Probe.Outcome.unvalued`. -/
 theorem transitive_is_probe_failure :
     attemptAgree inflProbe [] (.phi (.person .third)) = .unvalued := by
   native_decide
@@ -491,11 +491,11 @@ theorem intransitive_is_real_agreement :
 /-- Under Preminger's obligatory-no-crash model, probe failure converges
     and produces Elsewhere morphology — exactly the Set B "tz'=" we observe
     in Mam transitives. This connects the abstract failure model to the
-    concrete spellout: `ProbeOutcome.unvalued` → `PFRealization.elsewhere`
+    concrete spellout: `Probe.Outcome.unvalued` → `PFRealization.elsewhere`
     → the Elsewhere Vocabulary entry → "tz'=". -/
 theorem probe_failure_converges_with_elsewhere :
     derivationConverges .obligatoryNocrash .unvalued = true ∧
-    ProbeOutcome.unvalued.pfRealization = .elsewhere := ⟨rfl, rfl⟩
+    Probe.Outcome.unvalued.pfRealization = .elsewhere := ⟨rfl, rfl⟩
 
 -- ============================================================================
 -- § 12: Deriving Probe Blocking from SatisfactionCond ([deal-2024])
@@ -686,7 +686,7 @@ theorem agreeProbe_eq_derived_3sg :
     head-encounter halt satisfies the search but leaves the probe
     φ-unvalued. -/
 def valuationOutcome (cond : SatisfactionCond) (goals : List Encounter) :
-    ProbeOutcome :=
+    Probe.Outcome :=
   if (agreesWith cond goals).isSome then .valued else .unvalued
 
 /-- Transitive Infl: search halts at Voice_TR, probe stays unvalued,

--- a/Linglib/Syntax/Minimalist/Aspect.lean
+++ b/Linglib/Syntax/Minimalist/Aspect.lean
@@ -125,7 +125,7 @@ def AspFlavor.defaultFLevel : AspFlavor → Nat
 /-- An aspect head, parallel to `VoiceHead`.
 
     Carries: (a) which flavor (outer/inner), (b) optional selectional
-    requirement on the complement's dynamicity, (c) optional `ProbeProfile`
+    requirement on the complement's dynamicity, (c) optional `Probe.Profile`
     when the head is itself an Agree probe ([liu-yip-2026] analyzes
     Mandarin *you* and Cantonese -faan as probe-bearing AspO heads),
     (d) any Agree-relevant features (e.g., `[+EXP]` on the experiential
@@ -147,7 +147,7 @@ structure AspHead where
   /-- Optional probe profile: populated when the head triggers Agree.
       The probe's `probeHead` is conventionally `.Asp`; the flavor field on
       `AspHead` disambiguates outer-vs-inner at the analytical level. -/
-  probe : Option ProbeProfile := none
+  probe : Option Probe.Profile := none
   /-- Agree-relevant features on the head (e.g., `[+EXP]` for experiential AspO,
       `[uD]` for the AspO that triggers *you*-movement). -/
   features : FeatureBundle := []

--- a/Linglib/Syntax/Minimalist/CyclicAgree.lean
+++ b/Linglib/Syntax/Minimalist/CyclicAgree.lean
@@ -141,20 +141,20 @@ def mostSpecified : Geometry → Person
     - Flat [u-3]: no PH sensitivity (e.g., Swahili, Abkhaz)
     - Partial [u-3-2]: distinguishes SAP from 3P (e.g., Basque, Georgian)
     - Full [u-3-2-1]: distinguishes all persons (e.g., Nishnaabemwin, Mohawk) -/
-abbrev ProbeArticulation := List Segment
+abbrev _root_.Minimalist.Probe.Articulation := List Segment
 
 /-- Flat probe: [uπ]. Any DP fully matches. -/
-def flatProbe : ProbeArticulation := [.pi]
+def flatProbe : Probe.Articulation := [.pi]
 
 /-- Partial probe: [uπ, uParticipant]. Distinguishes SAP from 3P.
     Geometry-independent: [participant] is the same in both geometries. -/
-def partialProbe : ProbeArticulation := [.pi, .participant]
+def partialProbe : Probe.Articulation := [.pi, .participant]
 
 /-- Full probe in standard geometry: [uπ, uParticipant, uSpeaker]. -/
-def fullProbeStd : ProbeArticulation := [.pi, .participant, .speaker]
+def fullProbeStd : Probe.Articulation := [.pi, .participant, .speaker]
 
 /-- Full probe in addressee geometry: [uπ, uParticipant, uAddressee]. -/
-def fullProbeAddr : ProbeArticulation := [.pi, .participant, .addressee]
+def fullProbeAddr : Probe.Articulation := [.pi, .participant, .addressee]
 
 -- ============================================================================
 -- § 4: Agreement System (Language Parameterization)
@@ -168,7 +168,7 @@ def fullProbeAddr : ProbeArticulation := [.pi, .participant, .addressee]
     geometry (standard uses [speaker], addressee uses [addressee]). -/
 structure AgreementSystem where
   geometry : Geometry
-  probe : ProbeArticulation
+  probe : Probe.Articulation
   deriving DecidableEq, Repr
 
 /-- Swahili/Abkhaz: flat probe, no PH sensitivity. -/
@@ -193,7 +193,7 @@ def nishnaabemwin : AgreementSystem := ⟨.addressee, fullProbeAddr⟩
 
     This is the core operation of [bejar-rezac-2009]: partial
     matching of articulated probes drives agreement displacement. -/
-def activeResidue (probe : ProbeArticulation) (goal : List Segment) : ProbeArticulation :=
+def activeResidue (probe : Probe.Articulation) (goal : List Segment) : Probe.Articulation :=
   probe.filter (fun s => !goal.contains s)
 
 -- ============================================================================
@@ -210,7 +210,7 @@ inductive Controller where
 
     Returns `true` iff the EA matches at least one segment that the
     IA left unmatched. -/
-def eaAgrees (geom : Geometry) (probe : ProbeArticulation)
+def eaAgrees (geom : Geometry) (probe : Probe.Articulation)
     (ea ia : Person) : Bool :=
   let residue := activeResidue probe (personSpec geom ia)
   let residueAfterEA := activeResidue residue (personSpec geom ea)
@@ -222,12 +222,12 @@ def eaAgrees (geom : Geometry) (probe : ProbeArticulation)
     probe Agrees with EA. EA controls iff it matches any residue
     segment; otherwise IA controls (either it fully checked the
     probe, or it left residue the EA couldn't match). -/
-def agreementController (geom : Geometry) (probe : ProbeArticulation)
+def agreementController (geom : Geometry) (probe : Probe.Articulation)
     (ea ia : Person) : Controller :=
   if eaAgrees geom probe ea ia then .ea else .ia
 
 /-- The person value that the core agreement slot realizes. -/
-def agreementValue (geom : Geometry) (probe : ProbeArticulation)
+def agreementValue (geom : Geometry) (probe : Probe.Articulation)
     (ea ia : Person) : Person :=
   match agreementController geom probe ea ia with
   | .ea => ea
@@ -256,8 +256,8 @@ def AgreementSystem.value (sys : AgreementSystem)
     vs *-aa* (default/cycle I only).
 
     Returns `(cycleI, cycleII)` — the segments deactivated on each cycle. -/
-def cycleSegments (geom : Geometry) (probe : ProbeArticulation)
-    (ea ia : Person) : ProbeArticulation × ProbeArticulation :=
+def cycleSegments (geom : Geometry) (probe : Probe.Articulation)
+    (ea ia : Person) : Probe.Articulation × Probe.Articulation :=
   let iaSpec := personSpec geom ia
   let cycleI := probe.filter (fun s => iaSpec.contains s)
   let residue := activeResidue probe iaSpec
@@ -270,7 +270,7 @@ def cycleSegments (geom : Geometry) (probe : ProbeArticulation)
     True when both the IA (cycle I) and EA (cycle II) matched at least
     one segment. This is the configuration that creates second-cycle
     morphological effects in languages like Georgian and Nishnaabemwin. -/
-def hasSecondCycleEffect (geom : Geometry) (probe : ProbeArticulation)
+def hasSecondCycleEffect (geom : Geometry) (probe : Probe.Articulation)
     (ea ia : Person) : Bool :=
   let (c1, c2) := cycleSegments geom probe ea ia
   !c1.isEmpty && !c2.isEmpty
@@ -285,12 +285,12 @@ def hasSecondCycleEffect (geom : Geometry) (probe : ProbeArticulation)
     no residue, or (b) residue exists but the EA cannot match any of it.
     Inverse contexts trigger PLC violations on the EA's π-features,
     requiring repair strategies (added probe or R-Case). -/
-def isInverseContext (geom : Geometry) (probe : ProbeArticulation)
+def isInverseContext (geom : Geometry) (probe : Probe.Articulation)
     (ea ia : Person) : Bool :=
   !eaAgrees geom probe ea ia
 
 /-- Direct context: the EA Agrees with at least one residue segment. -/
-def isDirectContext (geom : Geometry) (probe : ProbeArticulation)
+def isDirectContext (geom : Geometry) (probe : Probe.Articulation)
     (ea ia : Person) : Bool :=
   eaAgrees geom probe ea ia
 
@@ -315,14 +315,14 @@ def AgreementSystem.isInverse (sys : AgreementSystem)
 
     Returns `true` if the EA is person-licensed (its π-features were
     checked by the core probe on cycle II). -/
-def eaIsLicensed (geom : Geometry) (probe : ProbeArticulation)
+def eaIsLicensed (geom : Geometry) (probe : Probe.Articulation)
     (ea ia : Person) : Bool :=
   eaAgrees geom probe ea ia
 
 /-- PLC violation: EA is NOT person-licensed. Exactly characterizes
     inverse contexts — this is the paper's key insight connecting
     syntactic derivation to morphological repair. -/
-theorem plc_violation_iff_inverse (geom : Geometry) (probe : ProbeArticulation)
+theorem plc_violation_iff_inverse (geom : Geometry) (probe : Probe.Articulation)
     (ea ia : Person) :
     eaIsLicensed geom probe ea ia = false ↔
     isInverseContext geom probe ea ia = true := by
@@ -383,7 +383,7 @@ theorem segmentGoal_eq_ia_iff (geom : Geometry) (ea ia : Person) (s : Segment) :
     cases h2 : (personSpec geom ea).contains s <;> simp
 
 /-- Existential characterization of the residue-based `eaAgrees`. -/
-theorem eaAgrees_iff_exists (geom : Geometry) (probe : ProbeArticulation)
+theorem eaAgrees_iff_exists (geom : Geometry) (probe : Probe.Articulation)
     (ea ia : Person) :
     eaAgrees geom probe ea ia = true ↔
       ∃ s ∈ probe, (personSpec geom ia).contains s = false ∧
@@ -400,7 +400,7 @@ theorem eaAgrees_iff_exists (geom : Geometry) (probe : ProbeArticulation)
     probe segment's flat relativized search (`Probe.Licensed`) over
     the cyclically ordered token list finds the EA token. -/
 theorem eaIsLicensed_iff_segment_licensed (geom : Geometry)
-    (probe : ProbeArticulation) (ea ia : Person) :
+    (probe : Probe.Articulation) (ea ia : Person) :
     eaIsLicensed geom probe ea ia = true ↔
       ∃ s ∈ probe, (segProbe geom s).Licensed (goalTokens ea ia) (.ea, ea) := by
   rw [eaIsLicensed, eaAgrees_iff_exists]
@@ -411,7 +411,7 @@ theorem eaIsLicensed_iff_segment_licensed (geom : Geometry)
     inverse-context characterization restated through the search
     substrate. -/
 theorem plc_violation_iff_no_segment_licensed (geom : Geometry)
-    (probe : ProbeArticulation) (ea ia : Person) :
+    (probe : Probe.Articulation) (ea ia : Person) :
     isInverseContext geom probe ea ia = true ↔
       ∀ s ∈ probe, ¬ (segProbe geom s).Licensed (goalTokens ea ia) (.ea, ea) := by
   rw [← plc_violation_iff_inverse, Bool.eq_false_iff, Ne,
@@ -423,7 +423,7 @@ theorem plc_violation_iff_no_segment_licensed (geom : Geometry)
     search finds the EA token. Second-cycle effects also factor through
     `Probe.search`. -/
 theorem cycleSegments_eq_segmentGoal_filters (geom : Geometry)
-    (probe : ProbeArticulation) (ea ia : Person) :
+    (probe : Probe.Articulation) (ea ia : Person) :
     cycleSegments geom probe ea ia =
       (probe.filter (fun s => segmentGoal geom ea ia s == some (.ia, ia)),
        probe.filter (fun s => segmentGoal geom ea ia s == some (.ea, ea))) := by
@@ -639,7 +639,7 @@ theorem nish_2_1_cycle_segments :
     when applied with the same goal: if some segments survive matching
     against personSpec(p), applying the same filter again removes nothing,
     so `eaAgrees` returns false. -/
-theorem same_person_ia_controls (geom : Geometry) (probe : ProbeArticulation)
+theorem same_person_ia_controls (geom : Geometry) (probe : Probe.Articulation)
     (p : Person) :
     agreementController geom probe p p = .ia := by
   simp only [agreementController]
@@ -677,7 +677,7 @@ theorem most_specified_controls_vs_third_addr :
 
 /-- The direct/inverse split exhaustively partitions the paradigm:
     every EA→IA combination is either direct or inverse, never both. -/
-theorem direct_inverse_exhaustive (geom : Geometry) (probe : ProbeArticulation)
+theorem direct_inverse_exhaustive (geom : Geometry) (probe : Probe.Articulation)
     (ea ia : Person) :
     (isDirectContext geom probe ea ia = true) ≠
     (isInverseContext geom probe ea ia = true) := by

--- a/Linglib/Syntax/Minimalist/NestedAgree.lean
+++ b/Linglib/Syntax/Minimalist/NestedAgree.lean
@@ -79,7 +79,7 @@ namespace Minimalist.NestedAgree
 
 /-- An ordered list of probes on a single head. The list order encodes
     the feature-checking order: head of list = first probe. -/
-abbrev OrderedProbeStack : Type := List ProbeProfile
+abbrev OrderedProbeStack : Type := List Probe.Profile
 
 -- ============================================================================
 -- § 2: Configuration
@@ -244,7 +244,7 @@ Consumers vary in:
   `terminal` in Icelandic/Bulgarian)
 - The `validGoal` predicate
 
-The common shape — a single ProbeProfile used twice, a 4-leaf linear
+The common shape — a single Probe.Profile used twice, a 4-leaf linear
 tree, the 2-probe stack — is captured by `standardConfig`. -/
 
 /-- Standard 4-leaf linear-Spec tree:
@@ -259,7 +259,7 @@ def standardLinearTree (probeHd intervener midNode terminal : LIToken) :
 /-- A `NestedAgreeConfig` over the standard linear tree, with a
     2-probe stack on `probeHd`. The `goalHd` selects which leaf
     serves as the shared goal under maximized matching. -/
-def standardConfig (probeProfile : ProbeProfile)
+def standardConfig (probeProfile : Probe.Profile)
     (probeHd intervener midNode terminal : LIToken)
     (goalHd : LIToken) (vg : SyntacticObject → Bool) :
     NestedAgreeConfig where
@@ -291,7 +291,7 @@ private def aV : LIToken := ⟨LexicalItem.simple .V [], 1⟩
 private def aDPsubj : LIToken := ⟨LexicalItem.simple .D [], 2⟩
 private def aDPobj : LIToken := ⟨LexicalItem.simple .D [], 3⟩
 
-private def perfProbe : ProbeProfile := ⟨.T, some .C⟩
+private def perfProbe : Probe.Profile := ⟨.T, some .C⟩
 
 /-- Italian-style 2-probe configuration constructed via `standardConfig`. -/
 def italianAuxExample : NestedAgreeConfig :=

--- a/Linglib/Syntax/Minimalist/ObligatoryOperations.lean
+++ b/Linglib/Syntax/Minimalist/ObligatoryOperations.lean
@@ -89,7 +89,7 @@ inductive AgreementModel where
     - **unvalued**: the probe attempted but found no suitable goal.
       In the crash model, this crashes. In the obligatory-no-crash
       model, the derivation continues with default morphology. -/
-inductive ProbeOutcome where
+inductive Probe.Outcome where
   /-- Probe successfully agreed with a goal. -/
   | valued
   /-- Probe attempted but found no suitable goal. -/
@@ -103,14 +103,14 @@ inductive ProbeOutcome where
 /-- Does the derivation converge given a probe outcome?
     In the crash model: only if the probe was valued.
     In the obligatory-no-crash model: always. -/
-def derivationConverges (model : AgreementModel) (outcome : ProbeOutcome) : Bool :=
+def derivationConverges (model : AgreementModel) (outcome : Probe.Outcome) : Bool :=
   match model, outcome with
   | .crashOnFailure, .unvalued => false
   | _, _ => true
 
 /-- Does this outcome yield default morphology?
     Only unvalued probes produce the default (Elsewhere entry). -/
-def ProbeOutcome.yieldsDefault : ProbeOutcome → Bool
+def Probe.Outcome.yieldsDefault : Probe.Outcome → Bool
   | .valued => false
   | .unvalued => true
 
@@ -133,7 +133,7 @@ inductive PFRealization where
   deriving DecidableEq, Repr
 
 /-- Map a probe outcome to its PF realization. -/
-def ProbeOutcome.pfRealization : ProbeOutcome → PFRealization
+def Probe.Outcome.pfRealization : Probe.Outcome → PFRealization
   | .valued => .agreement
   | .unvalued => .elsewhere
 
@@ -153,30 +153,30 @@ theorem models_diverge_on_failure :
     derivationConverges .obligatoryNocrash .unvalued = true := ⟨rfl, rfl⟩
 
 /-- The crash model requires success for convergence. -/
-theorem crash_requires_success (outcome : ProbeOutcome) :
+theorem crash_requires_success (outcome : Probe.Outcome) :
     derivationConverges .crashOnFailure outcome = true ↔
     outcome = .valued := by
   cases outcome <;> simp [derivationConverges]
 
 /-- The obligatory-no-crash model always converges. -/
-theorem obligatory_always_converges (outcome : ProbeOutcome) :
+theorem obligatory_always_converges (outcome : Probe.Outcome) :
     derivationConverges .obligatoryNocrash outcome = true := by
   cases outcome <;> rfl
 
 /-- Failed probes yield default morphology (the Elsewhere entry). -/
 theorem failed_yields_default :
-    ProbeOutcome.unvalued.yieldsDefault = true := rfl
+    Probe.Outcome.unvalued.yieldsDefault = true := rfl
 
 /-- Successful probes do NOT yield default morphology. -/
 theorem success_no_default :
-    ProbeOutcome.valued.yieldsDefault = false := rfl
+    Probe.Outcome.valued.yieldsDefault = false := rfl
 
 /-- In the obligatory-no-crash model, failed agreement produces the
     Elsewhere PF realization — not a crash. This is Preminger's
     central empirical prediction (Ch. 5). -/
 theorem failure_produces_elsewhere :
     derivationConverges .obligatoryNocrash .unvalued = true ∧
-    ProbeOutcome.unvalued.pfRealization = .elsewhere := ⟨rfl, rfl⟩
+    Probe.Outcome.unvalued.pfRealization = .elsewhere := ⟨rfl, rfl⟩
 
 -- ============================================================================
 -- § 6: Obligatoriness vs. Optionality
@@ -188,7 +188,7 @@ theorem failure_produces_elsewhere :
     probe fails — not whether it can be absent. -/
 inductive ProbePresence where
   /-- Probe is present (functional head projected). -/
-  | present : ProbeOutcome → ProbePresence
+  | present : Probe.Outcome → ProbePresence
   /-- No probe (functional head not projected). -/
   | absent
   deriving DecidableEq, Repr
@@ -218,7 +218,7 @@ theorem present_unvalued_vs_absent :
 /-- Run an Agree attempt and return the outcome.
 
     This bridges the Agree mechanism (`applyAgree`) with the failure model
-    (`ProbeOutcome`): if valuation succeeds, the probe was valued; otherwise
+    (`Probe.Outcome`): if valuation succeeds, the probe was valued; otherwise
     it attempted but failed. This is the missing link between the Agree
     operation (which returns `Option FeatureBundle`) and Preminger's
     obligatory-but-failable model (which distinguishes valued from unvalued).
@@ -227,7 +227,7 @@ theorem present_unvalued_vs_absent :
     doesn't decide what happens on failure — that's the job of the
     `AgreementModel`. This function extracts the binary outcome so the
     model can decide convergence. -/
-def attemptAgree (probeFeats goalFeats : FeatureBundle) (ftype : FeatureVal) : ProbeOutcome :=
+def attemptAgree (probeFeats goalFeats : FeatureBundle) (ftype : FeatureVal) : Probe.Outcome :=
   match applyAgree probeFeats goalFeats ftype with
   | some _ => .valued
   | none => .unvalued

--- a/Linglib/Syntax/Minimalist/Phi/Articulation.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Articulation.lean
@@ -19,10 +19,10 @@ become order theory:
   containment (author ⊂ participant ⊂ π) as order theory.
   [coon-keine-2021]'s fn. 22 flags probes with missing intermediate
   segments (their Me-First probe) as non-innocuous — here, they are
-  exactly the non-lower-set probes. `ArticulatedProbe` bundles the
+  exactly the non-lower-set probes. `Probe.Articulated` bundles the
   laws.
 - **The probe-specification hierarchy** ([coon-keine-2021] (40)):
-  `[uφ] → [uπ] → [uπ ▷ u#] → [uπ ▷ u# ▷ uΓ]`. `ProbeStage` carries
+  `[uφ] → [uπ] → [uπ ▷ u#] → [uπ ▷ u# ▷ uΓ]`. `Probe.Stage` carries
   the hierarchy as a type: a number probe without a person probe is
   unrepresentable, which is how the account derives the missing
   "Number Case Constraint" (see `Studies/CoonKeine2021.lean`,
@@ -32,8 +32,8 @@ become order theory:
 
 - `Segment.below`, the `PartialOrder Segment` instance — the geometry.
 - `IsArticulated` — downward-closure of a segment list; decidable.
-- `ArticulatedProbe` — segments + rootedness in [π] + closure.
-- `ProbeStage` — the (40) hierarchy, with `number_requires_person` /
+- `Probe.Articulated` — segments + rootedness in [π] + closure.
+- `Probe.Stage` — the (40) hierarchy, with `number_requires_person` /
   `gender_requires_number` as theorems.
 -/
 
@@ -112,8 +112,8 @@ theorem namedProbes_isArticulated :
     downward-closed along the geometry. Probes with missing
     intermediate segments — [coon-keine-2021]'s Me-First (39c),
     flagged in their fn. 22 — fail `lower` and cannot be bundled. -/
-structure ArticulatedProbe where
-  segments : CyclicAgree.ProbeArticulation
+structure Probe.Articulated where
+  segments : Probe.Articulation
   rooted : Segment.pi ∈ segments
   lower : IsArticulated segments
 
@@ -123,7 +123,7 @@ structure ArticulatedProbe where
     articulated probe is a *specification*; this is its canonical
     map into the `Probe` carrier — one-to-many, which is why the
     relationship is denotation, not extension. -/
-def ArticulatedProbe.toProbes {α : Type*} (P : ArticulatedProbe)
+def Probe.Articulated.toProbes {α : Type*} (P : Probe.Articulated)
     (bears : Segment → α → Bool) : List (Probe α) :=
   P.segments.map (fun s => .ofVis (bears s))
 
@@ -135,7 +135,7 @@ def ArticulatedProbe.toProbes {α : Type*} (P : ArticulatedProbe)
     without a person probe, a gender probe without a number probe —
     are unrepresentable. The universal ordering (π probes before #,
     # before Γ) is carried by the stage itself. -/
-inductive ProbeStage where
+inductive Probe.Stage where
   /-- A single unsplit [uφ] probe. -/
   | unsplit
   /-- A person probe only. -/
@@ -147,27 +147,27 @@ inductive ProbeStage where
   deriving DecidableEq, Repr
 
 /-- Does the stage have a dedicated person probe? -/
-def ProbeStage.hasPersonProbe : ProbeStage → Bool
+def Probe.Stage.hasPersonProbe : Probe.Stage → Bool
   | .unsplit => false
   | _ => true
 
 /-- Does the stage have a number probe? -/
-def ProbeStage.hasNumberProbe : ProbeStage → Bool
+def Probe.Stage.hasNumberProbe : Probe.Stage → Bool
   | .personNumber | .personNumberGender => true
   | _ => false
 
 /-- Does the stage have a gender probe? -/
-def ProbeStage.hasGenderProbe : ProbeStage → Bool
+def Probe.Stage.hasGenderProbe : Probe.Stage → Bool
   | .personNumberGender => true
   | _ => false
 
 /-- (40), first law: a number probe entails a person probe. -/
-theorem ProbeStage.number_requires_person (st : ProbeStage) :
+theorem Probe.Stage.number_requires_person (st : Probe.Stage) :
     st.hasNumberProbe = true → st.hasPersonProbe = true := by
   cases st <;> decide
 
 /-- (40), second law: a gender probe entails a number probe. -/
-theorem ProbeStage.gender_requires_number (st : ProbeStage) :
+theorem Probe.Stage.gender_requires_number (st : Probe.Stage) :
     st.hasGenderProbe = true → st.hasNumberProbe = true := by
   cases st <;> decide
 

--- a/Linglib/Syntax/Minimalist/Phi/Geometry.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Geometry.lean
@@ -153,7 +153,7 @@ def decomposePerson : Person → DecomposedPerson
 
     π⁰ is merged below #⁰ and probes first — person-before-number
     probing, inherited from [bejar-rezac-2003]. -/
-inductive ProbeTarget where
+inductive Probe.Target where
   /-- π⁰: person probe, seeks [participant]. -/
   | participant
   /-- #⁰: number probe, seeks [plural]. -/
@@ -165,7 +165,7 @@ inductive ProbeTarget where
 
     A DP with person value `person` and number `isPlural` is visible
     to the probe iff it bears the probe's target feature. -/
-def probeVisible (target : ProbeTarget) (person : Person) (isPlural : Bool) : Bool :=
+def probeVisible (target : Probe.Target) (person : Person) (isPlural : Bool) : Bool :=
   match target with
   | .participant => (decomposePerson person).hasParticipant
   | .plural => isPlural

--- a/Linglib/Syntax/Minimalist/Phi/Probing.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Probing.lean
@@ -9,7 +9,7 @@ import Linglib.Syntax.Minimalist.ObligatoryOperations
 
 The derivational middle layer between DP-level probe visibility
 (`probeVisible`, `Phi/Geometry.lean`) and PF-level outcomes
-(`ProbeOutcome`, `ObligatoryOperations.lean`). A `Probe` bundles what
+(`Probe.Outcome`, `ObligatoryOperations.lean`). A `Probe` bundles what
 it *sees* (`vis` — interaction/halting: the search stops at the first
 visible goal) and what it can *value* there (`act` — activity: a
 visible but inactive goal absorbs the probe without valuing it,
@@ -40,7 +40,7 @@ re-probing see `Syntax/Minimalist/Probing/DefectiveCircumvention.lean`.
   `Probe.indiscriminate` constructors.
 - `Probe.search` — first visible goal, in structural order.
 - `Probe.agree` — search then Agree: the found goal, if active.
-- `Probe.outcome` — the `ProbeOutcome` of an obligatory probing
+- `Probe.outcome` — the `Probe.Outcome` of an obligatory probing
   operation.
 - `Probe.Licensed`, `Probe.AllLicensed needs` — every licensing-needy
   goal is found by the search; diagonal characterization
@@ -56,8 +56,8 @@ re-probing see `Syntax/Minimalist/Probing/DefectiveCircumvention.lean`.
 Theory-side probe descriptions relate to `Probe` by *denotation*
 (canonical `toProbe`-maps), not extension — the relationship is
 one-to-many for articulated probes and state-indexed for dynamic
-ones: `ProbeTarget.toProbe` (here), `SatisfactionCond.toProbe`
-(`Studies/Scott2023.lean`), `ArticulatedProbe.toProbes`
+ones: `Probe.Target.toProbe` (here), `SatisfactionCond.toProbe`
+(`Studies/Scott2023.lean`), `Probe.Articulated.toProbes`
 (`Phi/Articulation.lean`, the per-segment family),
 `CyclicAgree.segProbe` (per segment and geometry), and
 `Deal2024.ProbeState.probe` (the state-indexed family whose
@@ -165,7 +165,7 @@ theorem agree_eq_none_of_inactive {a : α}
 
 /-- The outcome of an obligatory probing operation over a goal
     sequence: `valued` iff the search finds a goal. -/
-def outcome (p : Probe α) (goals : List α) : ProbeOutcome :=
+def outcome (p : Probe α) (goals : List α) : Probe.Outcome :=
   if (p.search goals).isSome then .valued else .unvalued
 
 /-- The probe is valued iff the search finds a goal. -/
@@ -317,15 +317,15 @@ end Probe
 
 /-- Visibility of a φ-cell to a relativized probe: the cell bears the
     feature the probe seeks (`probeVisible`, `Phi/Geometry.lean`). -/
-def _root_.Agreement.Cell.visibleTo (c : Agreement.Cell) (t : ProbeTarget) : Bool :=
+def _root_.Agreement.Cell.visibleTo (c : Agreement.Cell) (t : Probe.Target) : Bool :=
   probeVisible t c.toPerson c.isPlural
 
-/-- The probe a `ProbeTarget` specification denotes: relativized to
+/-- The probe a `Probe.Target` specification denotes: relativized to
     the sought feature, over φ-cells. The canonical
     specification-to-`Probe` map for the substrate's probe enum —
-    [preminger-2014]'s π⁰ is `ProbeTarget.participant.toProbe`, his
-    #⁰ is `ProbeTarget.plural.toProbe`. -/
-def ProbeTarget.toProbe (t : ProbeTarget) : Probe Agreement.Cell :=
+    [preminger-2014]'s π⁰ is `Probe.Target.participant.toProbe`, his
+    #⁰ is `Probe.Target.plural.toProbe`. -/
+def Probe.Target.toProbe (t : Probe.Target) : Probe Agreement.Cell :=
   .ofVis (·.visibleTo t)
 
 /-- The Person Licensing Condition ([bejar-rezac-2003];

--- a/Linglib/Syntax/Minimalist/Probe.lean
+++ b/Linglib/Syntax/Minimalist/Probe.lean
@@ -56,7 +56,7 @@ namespace Minimalist
     The A/Ā distinction is correlated with probe height but not
     strictly derived from it: probes on the same head can have
     different horizons ([keine-2020] §3.6). -/
-structure ProbeProfile where
+structure Probe.Profile where
   /-- The head that hosts this probe (T⁰, C⁰, etc.) -/
   probeHead : Cat
   /-- The category that terminates this probe's search.
@@ -66,12 +66,12 @@ structure ProbeProfile where
 
 /-- Is this an A-probe? A-probes sit at or below T (fValue ≤ 2).
     [keine-2020] §3: A-movement lands in Spec,TP (fValue 2). -/
-def ProbeProfile.isAProbe (p : ProbeProfile) : Bool :=
+def Probe.Profile.isAProbe (p : Probe.Profile) : Bool :=
   fValue p.probeHead ≤ 2
 
 /-- Is this an Ā-probe? Ā-probes sit at or above C (fValue ≥ 6).
     [keine-2020] §3: Ā-movement lands in Spec,CP (fValue 6). -/
-def ProbeProfile.isĀProbe (p : ProbeProfile) : Bool :=
+def Probe.Profile.isĀProbe (p : Probe.Profile) : Bool :=
   fValue p.probeHead ≥ 6
 
 -- ============================================================================
@@ -93,7 +93,7 @@ def ProbeProfile.isĀProbe (p : ProbeProfile) : Bool :=
     NmlzP's label `[V, v, T, Nmlz]` does not contain C (transparent to
     wh with horizon C), while CP's label `[V, v, T, C]` does not contain
     Nmlz (transparent to Ā with horizon Nmlz in Hindi). -/
-def ProbeProfile.transparentToLabel (p : ProbeProfile) (label : List Cat) : Bool :=
+def Probe.Profile.transparentToLabel (p : Probe.Profile) (label : List Cat) : Bool :=
   match p.horizon with
   | none => true
   | some h => !(label.any (· == h))
@@ -117,7 +117,7 @@ def ProbeProfile.transparentToLabel (p : ProbeProfile) (label : List Cat) : Bool
     - The probe has a horizon: the clause's highest head is strictly
       below the probe head in the functional sequence
       (`fValue clauseHead < fValue probeHead`). -/
-def ProbeProfile.transparentTo (p : ProbeProfile) (clauseHead : Cat) : Bool :=
+def Probe.Profile.transparentTo (p : Probe.Profile) (clauseHead : Cat) : Bool :=
   if p.horizon.isSome then fValue clauseHead < fValue p.probeHead else true
 
 -- ============================================================================
@@ -133,21 +133,21 @@ def ProbeProfile.transparentTo (p : ProbeProfile) (clauseHead : Cat) : Bool :=
     Can search into vP but not TP or CP clauses.
     Note: this is the [keine-2019] article setting; the book
     refines Hindi φ to have horizon T ([keine-2020] (219)). -/
-def keinePhiProbe : ProbeProfile := ⟨.T, some .C⟩
+def keinePhiProbe : Probe.Profile := ⟨.T, some .C⟩
 
 /-- A-movement probe (EPP on T⁰): sits on T⁰, horizon is C.
     Same locality as φ-agreement — both are on T⁰. -/
-def keineAProbe : ProbeProfile := ⟨.T, some .C⟩
+def keineAProbe : Probe.Profile := ⟨.T, some .C⟩
 
 /-- Wh-licensing probe: sits on C⁰, horizon is C.
     Can search into vP and TP but not CP clauses. -/
-def keineWhLicensing : ProbeProfile := ⟨.C, some .C⟩
+def keineWhLicensing : Probe.Profile := ⟨.C, some .C⟩
 
 /-- Ā-movement probe from [keine-2019]: sits on C⁰, no horizon.
     The 2019 article treated Ā as having no horizon.
     [keine-2020] (219) refines this: Hindi Ā has horizon Nmlz,
     English Ā has horizon C, German topicalization has no horizon. -/
-def keineĀProbe : ProbeProfile := ⟨.C, none⟩
+def keineĀProbe : Probe.Profile := ⟨.C, none⟩
 
 -- ────────────────────────────────────────────────────────────────
 -- Derived properties of the article probes
@@ -167,25 +167,25 @@ theorem ābar_is_Ā : keineĀProbe.isĀProbe = true := by decide
 [deal-2026] argues that Nez Perce relative-embedding (RE) clauses contain
 an internal Ā-dependency *from a high functional projection above TP*. The
 unification target — Deal's "Ā-dependency" — is realised here as a subtype
-of `ProbeProfile` rather than as a parallel new structure: any Probe with
+of `Probe.Profile` rather than as a parallel new structure: any Probe with
 `isĀProbe = true` IS an Ā-dependency primitive in Deal's sense.
 
-This avoids cascade: existing consumers of `ProbeProfile` (wh-licensing in
+This avoids cascade: existing consumers of `Probe.Profile` (wh-licensing in
 `Questions.lean`, the keine probes here, language-specific configurations)
 remain unchanged, and `AbarDep` is a thin wrapper providing only the predicate
 `isĀProbe = true` as a proof-relevant invariant. -/
 
-/-- An Ā-probe: a `ProbeProfile` carrying a proof that it is Ā-positioned
+/-- An Ā-probe: a `Probe.Profile` carrying a proof that it is Ā-positioned
     (probeHead at or above C, fValue ≥ 6).
 
     [deal-2026] consumes this to express the Nez Perce RE structure:
     each RE-taker selects a CP whose internal probe is an `AbarDep`. By
     contrast, simplex-embedding verbs (Nez Perce *neki* 'think', *hi* 'say',
     *cuukwe* 'know') select bare CPs with no internal `AbarDep`. -/
-def AbarDep := { p : ProbeProfile // p.isĀProbe = true }
+def AbarDep := { p : Probe.Profile // p.isĀProbe = true }
 
 /-- An `AbarDep` projects back to its underlying probe. -/
-def AbarDep.toProbe (a : AbarDep) : ProbeProfile := a.val
+def AbarDep.toProbe (a : AbarDep) : Probe.Profile := a.val
 
 /-- The keine Ā-probe is an `AbarDep` (lifted from `ābar_is_Ā`). -/
 def keineĀDep : AbarDep := ⟨keineĀProbe, ābar_is_Ā⟩
@@ -219,13 +219,13 @@ theorem keineWhDep_isHigh : keineWhDep.isHigh = true := by decide
     tables: φ-agreement, A-movement, wh-licensing, and Ā-movement. -/
 structure LanguageProbeConfig where
   /-- φ-agreement probe -/
-  phi : ProbeProfile
+  phi : Probe.Profile
   /-- A-movement probe -/
-  aMove : ProbeProfile
+  aMove : Probe.Profile
   /-- wh-licensing probe -/
-  wh : ProbeProfile
+  wh : Probe.Profile
   /-- Ā-movement / topicalization probe -/
-  ābar : ProbeProfile
+  ābar : Probe.Profile
   deriving Repr
 
 /-- Hindi probe settings ([keine-2020] (219)).
@@ -267,7 +267,7 @@ def LanguageProbeConfig.english : LanguageProbeConfig :=
 
     Extraposition is more local than A-movement: it cannot cross
     even TP boundaries. This is the default horizon for T⁰. -/
-def english_extr : ProbeProfile := ⟨.T, some .T⟩
+def english_extr : Probe.Profile := ⟨.T, some .T⟩
 
 /-- German probe settings ([keine-2020] (367)).
 
@@ -372,7 +372,7 @@ chain (305). -/
 
 /-- Lubukusu A-probe: no horizon — hyperraising out of finite clauses.
     [keine-2020] (300a). -/
-def lubukusuAProbe : ProbeProfile := ⟨.T, none⟩
+def lubukusuAProbe : Probe.Profile := ⟨.T, none⟩
 
 /-- The three A-movement settings form an entailment chain:
     Lubukusu (⊣ ∅) is strictly more permissive than English (⊣ C),
@@ -405,15 +405,15 @@ theorem a_movement_typology :
     horizon is X itself. This is the maximally restrictive setting that
     is not vacuous — the probe can search into domains smaller than its
     own projection but not into domains of the same size or larger. -/
-def ProbeProfile.defaultHorizon (probeHead : Cat) : ProbeProfile :=
+def Probe.Profile.defaultHorizon (probeHead : Cat) : Probe.Profile :=
   ⟨probeHead, some probeHead⟩
 
 /-- A probe with the default horizon can search into domains strictly
     below its own F-level but not at or above it (in the fValue model). -/
 theorem default_horizon_restrictive (head c : Cat)
     (h : fValue c ≥ fValue head) :
-    (ProbeProfile.defaultHorizon head).transparentTo c = false := by
-  simp [ProbeProfile.defaultHorizon, ProbeProfile.transparentTo, Option.isSome]
+    (Probe.Profile.defaultHorizon head).transparentTo c = false := by
+  simp [Probe.Profile.defaultHorizon, Probe.Profile.transparentTo, Option.isSome]
   omega
 
 -- ============================================================================
@@ -438,7 +438,7 @@ Each row is a strict superset of the one above it. -/
 /-- Horizon entailment: ⊣ v ⊂ ⊣ T ⊂ ⊣ C ⊂ ⊣ ∅ (for a probe on C⁰).
     Each step adds exactly one more transparent clause type. -/
 theorem locality_profile_entailment :
-    let onC (hz : Option Cat) := ProbeProfile.mk .C hz
+    let onC (hz : Option Cat) := Probe.Profile.mk .C hz
     -- ⊣ v: only VP transparent (but v is vacuous on C⁰, so untestable)
     -- ⊣ T: also vacuous on C⁰
     -- ⊣ C: TP, vP transparent; CP opaque
@@ -450,7 +450,7 @@ theorem locality_profile_entailment :
 /-- Horizon entailment for probes on T⁰: ⊣ T ⊂ ⊣ C ⊂ ⊣ ∅.
     This is the empirically relevant case (A-movement, φ-agreement). -/
 theorem locality_profile_entailment_T :
-    let onT (hz : Option Cat) := ProbeProfile.mk .T hz
+    let onT (hz : Option Cat) := Probe.Profile.mk .T hz
     -- ⊣ T (default): only vP transparent
     (onT (some .T)).transparentToLabel ClauseSpine.vP.projectedHeads = true ∧
     (onT (some .T)).transparentToLabel ClauseSpine.tP.projectedHeads = false ∧
@@ -473,23 +473,23 @@ theorem locality_profile_entailment_T :
     horizon appears in the smaller label, it appears in the larger one too.
 
     This theorem proves it for the simplified fValue model. -/
-theorem upward_entailment (p : ProbeProfile) (c₁ c₂ : Cat)
+theorem upward_entailment (p : Probe.Profile) (c₁ c₂ : Cat)
     (h_opaque : p.transparentTo c₁ = false)
     (h_larger : fValue c₁ ≤ fValue c₂) :
     p.transparentTo c₂ = false := by
-  simp only [ProbeProfile.transparentTo] at *
+  simp only [Probe.Profile.transparentTo] at *
   cases h_eq : p.horizon <;> simp_all [Option.isSome]
   omega
 
 /-- Upward Entailment for bilateral labeling: if a label L₁ ⊆ L₂
     (every head in L₁ also appears in L₂), then opacity to L₁ implies
     opacity to L₂. -/
-theorem upward_entailment_label (p : ProbeProfile)
+theorem upward_entailment_label (p : Probe.Profile)
     (L₁ L₂ : List Cat)
     (h_sub : ∀ c, c ∈ L₁ → c ∈ L₂)
     (h_opaque : p.transparentToLabel L₁ = false) :
     p.transparentToLabel L₂ = false := by
-  simp only [ProbeProfile.transparentToLabel] at *
+  simp only [Probe.Profile.transparentToLabel] at *
   cases h_hz : p.horizon with
   | none => simp_all
   | some h =>
@@ -516,12 +516,12 @@ theorem upward_entailment_label (p : ProbeProfile)
 
     Note: the HLC is a "connection" not an isomorphism — probes on the
     same head can differ in locality ([keine-2020] §3.6). -/
-theorem height_locality_connection (p₁ p₂ : ProbeProfile) (c : Cat)
+theorem height_locality_connection (p₁ p₂ : Probe.Profile) (c : Cat)
     (h_higher : fValue p₁.probeHead ≤ fValue p₂.probeHead)
     (h_horizon : p₁.horizon = none → p₂.horizon = none)
     (h_transparent : p₁.transparentTo c = true) :
     p₂.transparentTo c = true := by
-  simp only [ProbeProfile.transparentTo] at *
+  simp only [Probe.Profile.transparentTo] at *
   cases h₁ : p₁.horizon <;> cases h₂ : p₂.horizon <;>
     simp_all [Option.isSome]
   omega
@@ -538,16 +538,16 @@ theorem height_locality_connection (p₁ p₂ : ProbeProfile) (c : Cat)
     determines which labels trigger search termination. This theorem
     is an artifact of the fValue approximation. -/
 theorem horizon_category_irrelevant_fvalue (head : Cat) (h₁ h₂ : Cat) (c : Cat) :
-    (ProbeProfile.mk head (some h₁)).transparentTo c =
-    (ProbeProfile.mk head (some h₂)).transparentTo c := by
-  simp [ProbeProfile.transparentTo]
+    (Probe.Profile.mk head (some h₁)).transparentTo c =
+    (Probe.Profile.mk head (some h₂)).transparentTo c := by
+  simp [Probe.Profile.transparentTo]
 
 /-- Under bilateral labeling, horizon category DOES matter.
     Example: wh (horizon C) finds NmlzP transparent, but Ā (horizon Nmlz)
     finds NmlzP opaque. Both probes are on C⁰ — only the horizon differs. -/
 theorem horizon_category_relevant_label :
-    let whProbe := (⟨.C, some .C⟩ : ProbeProfile)
-    let āProbe := (⟨.C, some .Nmlz⟩ : ProbeProfile)
+    let whProbe := (⟨.C, some .C⟩ : Probe.Profile)
+    let āProbe := (⟨.C, some .Nmlz⟩ : Probe.Profile)
     let nmlzLabel := [Cat.V, .v, .T, .Nmlz]
     whProbe.transparentToLabel nmlzLabel = true ∧
     āProbe.transparentToLabel nmlzLabel = false := by decide
@@ -568,7 +568,7 @@ theorem horizon_category_relevant_label :
 
     This is the general check; `isVacuous` below specializes it
     to the standard verbal spine. -/
-def ProbeProfile.isVacuousFor (p : ProbeProfile) (sisterLabel : List Cat) : Bool :=
+def Probe.Profile.isVacuousFor (p : Probe.Profile) (sisterLabel : List Cat) : Bool :=
   match p.horizon with
   | none => false
   | some _ => p.transparentToLabel sisterLabel = false
@@ -587,7 +587,7 @@ def ProbeProfile.isVacuousFor (p : ProbeProfile) (sisterLabel : List Cat) : Bool
     therefore undetectable. The Height-Locality Theorem (279)
     emerges because only nonvacuous probes produce observable
     dependencies. -/
-def ProbeProfile.isVacuous (p : ProbeProfile) : Bool :=
+def Probe.Profile.isVacuous (p : Probe.Profile) : Bool :=
   match p.horizon with
   | none => false
   | some _ =>
@@ -601,8 +601,8 @@ def ProbeProfile.isVacuous (p : ProbeProfile) : Bool :=
 /-- A probe with no horizon is never vacuous — it can always
     search into any domain. -/
 theorem no_horizon_not_vacuous (head : Cat) :
-    (ProbeProfile.mk head none).isVacuous = false := by
-  simp [ProbeProfile.isVacuous]
+    (Probe.Profile.mk head none).isVacuous = false := by
+  simp [Probe.Profile.isVacuous]
 
 /-- The four article probes are all nonvacuous. -/
 theorem keine_probes_nonvacuous :
@@ -636,29 +636,29 @@ theorem english_probes_nonvacuous :
     vacuous for T⁰ and C⁰: the sister label does not contain the
     probe's own head. -/
 theorem default_horizon_not_vacuous_T :
-    (ProbeProfile.defaultHorizon .T).isVacuous = false := by decide
+    (Probe.Profile.defaultHorizon .T).isVacuous = false := by decide
 theorem default_horizon_not_vacuous_C :
-    (ProbeProfile.defaultHorizon .C).isVacuous = false := by decide
+    (Probe.Profile.defaultHorizon .C).isVacuous = false := by decide
 
 /-- Example vacuous probes from [keine-2020] (278):
     a probe on C⁰ with horizon T, v, or V is vacuous — the sister
     TP's bilateral label contains all three. -/
 theorem vacuous_examples :
-    (ProbeProfile.mk .C (some .T)).isVacuous = true ∧
-    (ProbeProfile.mk .C (some .v)).isVacuous = true ∧
-    (ProbeProfile.mk .C (some .V)).isVacuous = true := by decide
+    (Probe.Profile.mk .C (some .T)).isVacuous = true ∧
+    (Probe.Profile.mk .C (some .v)).isVacuous = true ∧
+    (Probe.Profile.mk .C (some .V)).isVacuous = true := by decide
 
 /-- Hindi Ā (C⁰ ⊣ Nmlz) is NOT vacuous: TP's bilateral label
     does not contain Nmlz. -/
 theorem hindi_ābar_not_vacuous :
-    (ProbeProfile.mk .C (some .Nmlz)).isVacuous = false := by decide
+    (Probe.Profile.mk .C (some .Nmlz)).isVacuous = false := by decide
 
 /-- A probe vacuous for a given sister label cannot search past
     that sister — the sister itself is opaque. -/
-theorem vacuousFor_means_opaque (p : ProbeProfile) (label : List Cat)
+theorem vacuousFor_means_opaque (p : Probe.Profile) (label : List Cat)
     (hv : p.isVacuousFor label = true) :
     p.transparentToLabel label = false := by
-  simp only [ProbeProfile.isVacuousFor] at hv
+  simp only [Probe.Profile.isVacuousFor] at hv
   cases hHz : p.horizon <;> simp_all
 
 -- ============================================================================
@@ -667,7 +667,7 @@ theorem vacuousFor_means_opaque (p : ProbeProfile) (label : List Cat)
 
 /-- The transparency profile of a probe: which of the three standard
     clause sizes (vP, TP, CP) are transparent to it. -/
-def ProbeProfile.profile (p : ProbeProfile) : Bool × Bool × Bool :=
+def Probe.Profile.profile (p : Probe.Profile) : Bool × Bool × Bool :=
   (p.transparentTo .v, p.transparentTo .T, p.transparentTo .C)
 
 /-- The four article probes produce exactly three distinct transparency
@@ -696,12 +696,12 @@ theorem three_locality_types :
 -- ============================================================================
 
 /-- A complement's transparency to a given probe: delegates to
-    `ProbeProfile.transparentTo` on the complement's highest head.
+    `Probe.Profile.transparentTo` on the complement's highest head.
 
     This unifies the phase-based (`transparentToTenseAgree`) and
     horizon-based ([keine-2019]) transparency models into a
     single parameterized function. -/
-def ComplementSize.transparentTo (cs : ComplementSize) (p : ProbeProfile) : Bool :=
+def ComplementSize.transparentTo (cs : ComplementSize) (p : Probe.Profile) : Bool :=
   p.transparentTo cs.highestHead
 
 /-- Tense-Agree probe: sits on C⁰ with horizon C.
@@ -711,14 +711,14 @@ def ComplementSize.transparentTo (cs : ComplementSize) (p : ProbeProfile) : Bool
     This is the probe implicit in [egressy-2026]'s phase-based
     `transparentToTenseAgree`: any complement smaller than CP is
     transparent. -/
-def tenseAgreeProbe : ProbeProfile := ⟨.C, some .C⟩
+def tenseAgreeProbe : Probe.Profile := ⟨.C, some .C⟩
 
 /-- `transparentToTenseAgree` is the special case of `transparentTo`
     parameterized by `tenseAgreeProbe`. -/
 theorem transparentToTenseAgree_eq_transparentTo (cs : ComplementSize) :
     cs.transparentToTenseAgree = cs.transparentTo tenseAgreeProbe := by
   simp [ComplementSize.transparentToTenseAgree, ComplementSize.transparentTo,
-        ProbeProfile.transparentTo, tenseAgreeProbe, ComplementSize.fLevel]
+        Probe.Profile.transparentTo, tenseAgreeProbe, ComplementSize.fLevel]
 
 /-- `tenseAgreeProbe` has the same profile as `keineWhLicensing`. -/
 theorem tenseAgreeProbe_eq_whLicensing :
@@ -737,7 +737,7 @@ theorem tenseAgreeProbe_eq_whLicensing :
 theorem complementSize_matches_wh_not_phi (cs : ComplementSize) :
     cs.transparentToTenseAgree = keineWhLicensing.transparentTo cs.highestHead := by
   simp [ComplementSize.transparentToTenseAgree, ComplementSize.fLevel,
-        ProbeProfile.transparentTo, keineWhLicensing]
+        Probe.Profile.transparentTo, keineWhLicensing]
 
 /-- The divergence: TP complements are transparent under the
     phase-based model but opaque under Keine's φ-probe. -/
@@ -785,32 +785,32 @@ C⁰ or Force⁰ (vacuous). It can be on T⁰ (default horizon). -/
     are NOT vacuous (TP's label lacks these). -/
 theorem hlt_279a_C :
     -- Vacuous horizons for C⁰
-    (ProbeProfile.mk .C (some .T)).isVacuous = true ∧
-    (ProbeProfile.mk .C (some .v)).isVacuous = true ∧
-    (ProbeProfile.mk .C (some .V)).isVacuous = true ∧
+    (Probe.Profile.mk .C (some .T)).isVacuous = true ∧
+    (Probe.Profile.mk .C (some .v)).isVacuous = true ∧
+    (Probe.Profile.mk .C (some .V)).isVacuous = true ∧
     -- Nonvacuous horizons for C⁰
-    (ProbeProfile.mk .C (some .C)).isVacuous = false ∧
-    (ProbeProfile.mk .C (some .Nmlz)).isVacuous = false ∧
-    (ProbeProfile.mk .C (some .Force)).isVacuous = false := by decide
+    (Probe.Profile.mk .C (some .C)).isVacuous = false ∧
+    (Probe.Profile.mk .C (some .Nmlz)).isVacuous = false ∧
+    (Probe.Profile.mk .C (some .Force)).isVacuous = false := by decide
 
 /-- HLT (279a): Probes on T⁰ with horizons v, V are vacuous
     (vP's bilateral label contains both). Horizon T is NOT vacuous. -/
 theorem hlt_279a_T :
-    (ProbeProfile.mk .T (some .v)).isVacuous = true ∧
-    (ProbeProfile.mk .T (some .V)).isVacuous = true ∧
-    (ProbeProfile.mk .T (some .T)).isVacuous = false := by decide
+    (Probe.Profile.mk .T (some .v)).isVacuous = true ∧
+    (Probe.Profile.mk .T (some .V)).isVacuous = true ∧
+    (Probe.Profile.mk .T (some .T)).isVacuous = false := by decide
 
 /-- HLT (279b): A probe ⊣ T cannot be nonvacuously located on
     C⁰ or Force⁰ — both have T in their sister label. But ⊣ T
     on T⁰ is the default horizon (nonvacuous). -/
 theorem hlt_279b_T :
-    (ProbeProfile.mk .C (some .T)).isVacuous = true ∧
-    (ProbeProfile.mk .Force (some .T)).isVacuous = true ∧
-    (ProbeProfile.mk .T (some .T)).isVacuous = false := by decide
+    (Probe.Profile.mk .C (some .T)).isVacuous = true ∧
+    (Probe.Profile.mk .Force (some .T)).isVacuous = true ∧
+    (Probe.Profile.mk .T (some .T)).isVacuous = false := by decide
 
 /-- The HLT derives the HLC: for nonvacuous probes, higher probes
     can search into at least as many clause types (fValue model). -/
-theorem hlt_derives_hlc (p₁ p₂ : ProbeProfile) (c : Cat)
+theorem hlt_derives_hlc (p₁ p₂ : Probe.Profile) (c : Cat)
     (h_higher : fValue p₁.probeHead ≤ fValue p₂.probeHead)
     (h_horizon : p₁.horizon = none → p₂.horizon = none)
     (h_transparent : p₁.transparentTo c = true) :


### PR DESCRIPTION
Pure rename: the probe-owned specification types move into the `Probe` namespace, mathlib-style (`Filter.NeBot` pattern) — `ProbeTarget` → `Probe.Target`, `ProbeOutcome` → `Probe.Outcome`, `ProbeArticulation` → `Probe.Articulation` (hoisted from CyclicAgree's namespace to `Minimalist.Probe`), `ProbeStage` → `Probe.Stage`, `ArticulatedProbe` → `Probe.Articulated`, `ProbeProfile` → `Probe.Profile`. Deal's `ProbeState` deliberately stays `Deal2024.ProbeState`: study-local apparatus graduates to a substrate `Probe.State` only when a second stateful-probe account lands. 20 files, 204/204 lines.