### PR TITLE
refactor: move MinimalPairs from Phenomena to Features

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -624,7 +624,7 @@ import Linglib.Tactics.ENNRealArith
 import Linglib.Processing.VisualWorld
 import Linglib.Processing.SelfPacedReading
 import Linglib.Morphology.WugTest
-import Linglib.Phenomena.MinimalPairs
+import Linglib.Features.MinimalPairs
 import Linglib.Studies.SprouseEtAl2012
 -- Fragments
 import Linglib.Fragments.Arabic.ModernStandard.Negation

--- a/Linglib/Features/Acceptability.lean
+++ b/Linglib/Features/Acceptability.lean
@@ -20,7 +20,7 @@ this is why the type is a labeled enum rather than a Likert-style ordinal.
 acceptability scale, ordered worst-to-last so that "rated worse than"
 comparisons come from the derived `Ord`. It is the judgment type carried
 by `Linglib/Data/Examples/Schema.lean`'s `LinguisticExample` and by the
-minimal-pair vocabulary in `Linglib/Phenomena/MinimalPairs.lean`. For
+minimal-pair vocabulary in `Linglib/Features/MinimalPairs.lean`. For
 factorial-design machinery over experimental ratings (difference-in-
 differences scores etc.), see `Linglib/Studies/SprouseEtAl2012.lean`.
 -/

--- a/Linglib/Features/MinimalPairs.lean
+++ b/Linglib/Features/MinimalPairs.lean
@@ -18,14 +18,14 @@ Two parallel families:
   `List Word`, requiring feature specifications. Used by analyses
   that operate on parsed/featural representations (HPSG, DG, Minimalism).
 * **String-based** (`SentencePair`, `StringPhenomenonData`): sentences
-  are raw strings, parseable by any theory. Used by phenomenon data
-  files that should remain free of theoretical commitments.
+  are raw strings, parseable by any theory. Used by data files that
+  should remain free of theoretical commitments.
 
 Judgments use the five-level `Features.Judgment` scale
 (`Linglib/Features/Acceptability.lean`).
 -/
 
-namespace Phenomena.MinimalPairs
+namespace Features.MinimalPairs
 
 open Features
 
@@ -101,7 +101,7 @@ structure SentencePair where
 
 /-- String-based phenomenon data for theory-neutral representation.
 
-    This is the string-based analogue of `PhenomenonData`. Phenomena files
+    This is the string-based analogue of `PhenomenonData`. Data files
     should use this type so that empirical data is decoupled from any
     particular grammatical theory's representation. -/
 structure StringPhenomenonData where
@@ -113,4 +113,4 @@ structure StringPhenomenonData where
   generalization : String
   deriving Repr
 
-end Phenomena.MinimalPairs
+end Features.MinimalPairs

--- a/Linglib/Phenomena/ArgumentStructure/Passive.lean
+++ b/Linglib/Phenomena/ArgumentStructure/Passive.lean
@@ -1,6 +1,6 @@
-import Linglib.Phenomena.MinimalPairs
+import Linglib.Features.MinimalPairs
 
-open Phenomena.MinimalPairs
+open Features.MinimalPairs
 
 /-!
 # The Passive Construction

--- a/Linglib/Phenomena/ArgumentStructure/Subcategorization.lean
+++ b/Linglib/Phenomena/ArgumentStructure/Subcategorization.lean
@@ -21,9 +21,9 @@ Verbs select for a specific number and type of arguments.
   (3c) *John gives the book. ✗ ditransitive with one object
 -/
 
-import Linglib.Phenomena.MinimalPairs
+import Linglib.Features.MinimalPairs
 
-open Phenomena.MinimalPairs
+open Features.MinimalPairs
 
 namespace Phenomena.ArgumentStructure.Subcategorization
 

--- a/Linglib/Phenomena/Modality/EpistemicEvidentiality.lean
+++ b/Linglib/Phenomena/Modality/EpistemicEvidentiality.lean
@@ -1,7 +1,7 @@
 import Linglib.Features.Evidentiality
-import Linglib.Phenomena.MinimalPairs
+import Linglib.Features.MinimalPairs
 
-open Phenomena.MinimalPairs
+open Features.MinimalPairs
 
 /-!
 # Epistemic Evidentiality — Empirical Data

--- a/Linglib/Studies/Chomsky1981.lean
+++ b/Linglib/Studies/Chomsky1981.lean
@@ -3,7 +3,7 @@ import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Pronouns
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Fragments.English.FunctionWords
-import Linglib.Phenomena.MinimalPairs
+import Linglib.Features.MinimalPairs
 
 /-!
 # Chomsky (1981) — Binding Principles A/B/C [chomsky-1981]
@@ -36,7 +36,7 @@ tables.
 
 namespace Chomsky1981
 
-open Phenomena.MinimalPairs
+open Features.MinimalPairs
 open Minimalist.Coreference
 
 private abbrev john := English.Nouns.john.toWordSg

--- a/Linglib/Studies/Hudson1990.lean
+++ b/Linglib/Studies/Hudson1990.lean
@@ -1,9 +1,9 @@
 import Linglib.Syntax.DependencyGrammar.Coreference
 import Linglib.Syntax.DependencyGrammar.Nominal
 import Linglib.Studies.Chomsky1981
-import Linglib.Phenomena.MinimalPairs
+import Linglib.Features.MinimalPairs
 
-open Phenomena.MinimalPairs
+open Features.MinimalPairs
 
 /-!
 # Dependency Grammar d-command binding → Coreference Phenomena

--- a/Linglib/Studies/Ross1967.lean
+++ b/Linglib/Studies/Ross1967.lean
@@ -1,7 +1,7 @@
-import Linglib.Phenomena.MinimalPairs
+import Linglib.Features.MinimalPairs
 import Linglib.Phenomena.Islands.Basic
 
-open Phenomena.MinimalPairs
+open Features.MinimalPairs
 
 set_option autoImplicit false
 

--- a/Linglib/Studies/SagWasowBender2003.lean
+++ b/Linglib/Studies/SagWasowBender2003.lean
@@ -3,7 +3,7 @@ import Linglib.Studies.Chomsky1981
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Pronouns
 import Linglib.Fragments.English.Predicates.Verbal
-import Linglib.Phenomena.MinimalPairs
+import Linglib.Features.MinimalPairs
 
 /-!
 # Sag, Wasow & Bender (2003) — HPSG Binding Theory [sag-wasow-bender-2003]
@@ -21,12 +21,12 @@ Both pronouns and R-expressions are `[MODE ref]`, so Principle B subsumes
 Principle C. See `Syntax/HPSG/Coreference.lean` for the
 implementation; this file verifies it against the [chomsky-1981]
 minimal-pair paradigm in `Studies/Chomsky1981.lean` via the
-`Phenomena.MinimalPairs` vocabulary.
+`Features.MinimalPairs` vocabulary.
 -/
 
 namespace SagWasowBender2003
 
-open Phenomena.MinimalPairs
+open Features.MinimalPairs
 open HPSG.Coreference
 open Chomsky1981 (reflexiveCoreferenceData pronominalDisjointReferenceData
   complementaryDistributionData reciprocalCoreferenceData)

--- a/Linglib/Studies/SprouseEtAl2012.lean
+++ b/Linglib/Studies/SprouseEtAl2012.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Tactic.NormNum
-import Linglib.Phenomena.MinimalPairs
+import Linglib.Features.MinimalPairs
 
 /-!
 # Sprouse, Wagers & Phillips (2012) — Factorial Acceptability Designs
@@ -27,7 +27,7 @@ shape of output a theory must produce*; bridge theorems in downstream
 * `AccountPredictions`: an n-cell prediction tuple from a theoretical
   account, with a decidable `Matches` comparator.
 * `SentencePair.toFactorial`: the pre-experimental minimal-pair datum
-  (`Linglib/Phenomena/MinimalPairs.lean`) as the degenerate 1×2 case of
+  (`Linglib/Features/MinimalPairs.lean`) as the degenerate 1×2 case of
   a factorial design.
 
 ## Out of scope
@@ -43,7 +43,7 @@ shape of output a theory must produce*; bridge theorems in downstream
 namespace SprouseEtAl2012
 
 open Features
-open Phenomena.MinimalPairs
+open Features.MinimalPairs
 
 /-! ### Factorial conditions -/
 


### PR DESCRIPTION
Phenomena→Data migration: the minimal-pair judgment vocabulary (MinimalPair/PhenomenonData + capture combinators) is substrate, not phenomena content — moved to Features/ with namespace Features.MinimalPairs; 8 importers rewired. Touched cone built clean locally (1811 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)