### PR TITLE
feat(Core/Algebra): Grossman-Larson associativity via Oudom-Guin

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1937,6 +1937,7 @@ import Linglib.Core.Algebra.RootedTree.PreLie.Insertion
 import Linglib.Core.Algebra.RootedTree.PreLie.Path
 import Linglib.Core.Algebra.RootedTree.PreLie.InsertionNodeDecomp
 import Linglib.Core.Algebra.RootedTree.BMinus
+import Linglib.Core.Algebra.RootedTree.GrossmanLarsonMonoid
 import Linglib.Core.LinearAlgebra.SymmetricAlgebra.Derivation
 import Linglib.Core.LinearAlgebra.SymmetricPower.Lift
 import Linglib.Core.LinearAlgebra.SymmetricPower.ToSymmetricAlgebra

--- a/Linglib/Core/Algebra/PreLie/OudomGuinCirc.lean
+++ b/Linglib/Core/Algebra/PreLie/OudomGuinCirc.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Core.Algebra.PreLie.GuinOudom
 import Linglib.Core.Algebra.PreLie.OudomGuinCircTotal
+import Linglib.Core.Algebra.PreLie.GuinOudom
 import Linglib.Core.RingTheory.Coalgebra.Convolution
 import Mathlib.LinearAlgebra.SymmetricAlgebra.Basic
 import Mathlib.RingTheory.Bialgebra.SymmetricAlgebra
@@ -84,8 +84,8 @@ namespace OudomGuinCirc
 open WithConv
 open scoped TensorProduct
 
-variable {R : Type} [CommRing R]
-variable {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+variable {R : Type*} [CommRing R]
+variable {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
 
 /-! ## §1: The `○` operation on `S(L) × S(L) → S(L)`
 
@@ -2254,7 +2254,7 @@ theorem oudomGuinStar_ι_split (X : SymmetricAlgebra R L) (T : L) :
     sum of tprods at the same `m` (via `oudomGuinCirc_algHomL_tprod_ι`),
     so Q3's m+1 case reduces to Q3 at m by linearity in C — no Sweedler
     cocomm bash needed at all. -/
-private theorem oudomGuinStar_mul_ι_split
+theorem oudomGuinStar_mul_ι_split
     (Z X : SymmetricAlgebra R L) (T : L) :
     oudomGuinStar Z (X * SymmetricAlgebra.ι R L T) =
       oudomGuinCirc (oudomGuinStar Z X) (SymmetricAlgebra.ι R L T) +

--- a/Linglib/Core/Algebra/PreLie/OudomGuinCircConstruct.lean
+++ b/Linglib/Core/Algebra/PreLie/OudomGuinCircConstruct.lean
@@ -34,12 +34,11 @@ the key fact making this descend to `Sym[R]^n L → L`.
 ## Main definitions
 
 * `circTMultilinear T n` — `T ○_(n) (·)` as a `MultilinearMap R (Fin n → L) L`.
-* `circT T n` — the lift to `Sym[R]^n L →ₗ[R] L` via `SymmetricPower.lift`,
   using `circTMultilinear_symm` (Lemma 2.5).
 
 ## Status
 
-**Q1b: `circT T n` sorry-free (2026-05-16).** Symmetry
+**Q1b sorry-free (2026-05-16).** Symmetry
 (`circTMultilinear_symm`) closed via three helpers:
 
 * `circTMultilinear_symm_interior` — swap of two `Fin.castSucc` indices;
@@ -70,7 +69,7 @@ namespace OudomGuinCircConstruct
 open Equiv Finset
 open scoped TensorProduct
 
-variable {R : Type} {L : Type}
+variable {R : Type*} {L : Type*}
 variable [CommRing R] [RightPreLieRing L] [RightPreLieAlgebra R L]
 
 /-! ## §1: The recursive multilinear `T ○_(n) (·)`
@@ -84,8 +83,8 @@ the formula above. -/
 
     Note: `R` is made explicit (rather than implicit) so that recursive
     calls within the definition can resolve typeclasses. -/
-noncomputable def circTMultilinear (R : Type) [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L] (T : L) :
+noncomputable def circTMultilinear (R : Type*) [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L] (T : L) :
     ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ L) L
   | 0 =>
     -- `Fin 0` is empty: the multilinear map is a constant `T`.
@@ -271,8 +270,8 @@ decomposition + algebraic symmetry); other pieces are structural. -/
     `circTMultilinear R T n` is symmetric under `Perm (Fin n)`, so the
     leading term `prev (Fin.init f) * f_last` and the residual sum
     (after reindexing by `k' = Equiv.swap i j k`) are both invariant. -/
-private theorem circTMultilinear_symm_interior (R : Type) [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+private theorem circTMultilinear_symm_interior (R : Type*) [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
     (T : L) (n : ℕ) (i j : Fin n)
     (ih : ∀ τ : Perm (Fin n),
       (circTMultilinear R T n).domDomCongr τ = circTMultilinear R T n) :
@@ -386,8 +385,8 @@ Proved as a substrate lemma here for use in the exterior swap invariance
 /-- Helper: split the inner sum `∑_j prev (update (update a i (a_i * W)) j (… * Z))`
     into a diagonal term `j = i` (uses `update_idem`) and an off-diagonal sum
     `j ≠ i` (uses `update_of_ne` + `update_comm` to put the W-update outside). -/
-private lemma split_inner_sum_at_diag (R : Type) [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+private lemma split_inner_sum_at_diag (R : Type*) [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
     {n : ℕ} (prev : MultilinearMap R (fun _ : Fin n ↦ L) L)
     (a : Fin n → L) (W Z : L) (i : Fin n) :
     (∑ j : Fin n, prev (Function.update (Function.update a i (a i * W)) j
@@ -416,8 +415,8 @@ private lemma split_inner_sum_at_diag (R : Type) [CommRing R]
     `split_inner_sum_at_diag`; the diagonal differences cancel via pre-Lie
     on L (applied with `MultilinearMap.map_update_sub`), the off-diagonal
     sums are equal by relabeling `(i, j) ↔ (j, i)`. -/
-private theorem prev_action_pre_lie_identity (R : Type) [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+private theorem prev_action_pre_lie_identity (R : Type*) [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
     {n : ℕ} (prev : MultilinearMap R (fun _ : Fin n ↦ L) L)
     (a : Fin n → L) (X Y : L) :
     (∑ i : Fin n, prev (Function.update a i (a i * (X * Y)))) -
@@ -508,8 +507,8 @@ for the inner-sum terms. -/
     as an explicit polynomial in `(prev, A, X, Y)`.
 
     Per OG 2008 Lemma 2.5 proof on page 5. -/
-private noncomputable def sixTerm {R : Type} [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+private noncomputable def sixTerm {R : Type*} [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
     {n : ℕ} (prev : MultilinearMap R (fun _ : Fin n ↦ L) L)
     (A : Fin n → L) (X Y : L) : L :=
   prev A * X * Y
@@ -531,8 +530,8 @@ private noncomputable def sixTerm {R : Type} [CommRing R]
       to `B + C = A + D`).
     - **Pair 3** `(Σ p(…·X))·Y + (Σ p(…·Y))·X` ↔ same with X ↔ Y:
       `add_comm` (the two summands literally swap roles). -/
-private lemma sixTerm_symm {R : Type} [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+private lemma sixTerm_symm {R : Type*} [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
     {n : ℕ} (prev : MultilinearMap R (fun _ : Fin n ↦ L) L)
     (A : Fin n → L) (X Y : L) :
     sixTerm prev A X Y = sixTerm prev A Y X := by
@@ -643,8 +642,8 @@ private lemma sixTerm_symm {R : Type} [CommRing R]
     `circT (m+2)` and the inner summands all unfold via Def 2.4). The
     `Fin.snoc` form makes the `Fin.init` / `Fin.last` simplifications
     clean (`Fin.init_snoc`, `Fin.snoc_last`, `Fin.snoc_castSucc`). -/
-private lemma circT_succ_succ_snoc_eval (R : Type) [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+private lemma circT_succ_succ_snoc_eval (R : Type*) [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
     (T : L) (m : ℕ) (A : Fin (m + 1) → L) (X Y : L) :
     circTMultilinear R T (m + 3) (Fin.snoc (Fin.snoc A X) Y) =
       sixTerm (circTMultilinear R T (m + 1)) A X Y := by
@@ -739,8 +738,8 @@ plain hypothesis rather than mutually-recursing inside the dispatcher. -/
     terms three ways: (1)-(5) via L's pre-Lie identity, (4)+(6) via
     `prev_action_pre_lie_identity` (the per-degree OG identity 2.3),
     (2)+(3) trivially by `X ↔ Y` symmetry. -/
-private theorem circTMultilinear_symm_exterior_adj (R : Type) [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+private theorem circTMultilinear_symm_exterior_adj (R : Type*) [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
     (T : L) (m : ℕ)
     (_ih : ∀ τ : Perm (Fin (m + 2)),
       (circTMultilinear R T (m + 2)).domDomCongr τ =
@@ -859,8 +858,8 @@ private theorem circTMultilinear_symm_exterior_adj (R : Type) [CommRing R]
     `sixTerm_symm` (algebraic symmetry).
 
     Reference: [oudom-guin-2008] Lemma 2.5 proof, p. 5. -/
-private theorem circTMultilinear_symm_exterior (R : Type) [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+private theorem circTMultilinear_symm_exterior (R : Type*) [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
     (T : L) (n : ℕ) (i : Fin n)
     (ih : ∀ τ : Perm (Fin n),
       (circTMultilinear R T n).domDomCongr τ = circTMultilinear R T n) :
@@ -957,8 +956,8 @@ private theorem circTMultilinear_symm_exterior (R : Type) [CommRing R]
 /-- **Lemma 2.5 — Any-swap invariance**: combines interior and exterior
     cases via a case-split on whether either of `x, y : Fin (n+1)` is
     `Fin.last n`. -/
-private theorem circTMultilinear_symm_swap (R : Type) [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+private theorem circTMultilinear_symm_swap (R : Type*) [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
     (T : L) (n : ℕ) (x y : Fin (n + 1)) (hxy : x ≠ y)
     (ih : ∀ τ : Perm (Fin n),
       (circTMultilinear R T n).domDomCongr τ = circTMultilinear R T n) :
@@ -981,8 +980,8 @@ private theorem circTMultilinear_symm_swap (R : Type) [CommRing R]
       exact circTMultilinear_symm_interior R T n i' j' ih
 
 /-- **OG Lemma 2.5**: `T ○_(n) (·)` is symmetric in its `n` arguments. -/
-theorem circTMultilinear_symm (R : Type) [CommRing R]
-    {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+theorem circTMultilinear_symm (R : Type*) [CommRing R]
+    {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
     (T : L) (n : ℕ) (σ : Perm (Fin n)) :
     (circTMultilinear R T n).domDomCongr σ =
       circTMultilinear R T n := by
@@ -1002,28 +1001,6 @@ theorem circTMultilinear_symm (R : Type) [CommRing R]
       rw [MultilinearMap.domDomCongr_mul, ih_τ]
       exact circTMultilinear_symm_swap R T n x y hxy ih
 
-/-! ## §3: Lift to `Sym[R]^n L → L`
-
-Using `SymmetricPower.lift` (Q1b.0a) and `circTMultilinear_symm` (Lemma 2.5),
-we obtain the OG operation on each symmetric power. -/
-
-/-- **OG `T ○_(n) (·)`** lifted to `Sym[R]^n L →ₗ[R] L` via the universal
-    property of the symmetric power. -/
-noncomputable def circT (T : L) (n : ℕ) :
-    Sym[R] (Fin n) L →ₗ[R] L :=
-  SymmetricPower.lift (circTMultilinear R T n) (circTMultilinear_symm R T n)
-
-@[simp]
-theorem circT_tprod (T : L) (n : ℕ) (f : Fin n → L) :
-    circT (R := R) T n (SymmetricPower.tprod R f) =
-      circTMultilinear R T n f := by
-  rw [circT, SymmetricPower.lift_tprod]
-
-/-- For `n = 0`: `circT T 0` sends the unit `tprod R Fin.elim0` to `T`. -/
-@[simp]
-theorem circT_zero_tprod (T : L) (f : Fin 0 → L) :
-    circT (R := R) T 0 (SymmetricPower.tprod R f) = T := by
-  rw [circT_tprod, circTMultilinear_zero]
 
 end OudomGuinCircConstruct
 

--- a/Linglib/Core/Algebra/PreLie/OudomGuinCircTotal.lean
+++ b/Linglib/Core/Algebra/PreLie/OudomGuinCircTotal.lean
@@ -72,8 +72,8 @@ namespace OudomGuinCircConstruct
 open TensorProduct
 open scoped DirectSum
 
-variable {R : Type} [CommRing R]
-variable {L : Type} [RightPreLieRing L] [RightPreLieAlgebra R L]
+variable {R : Type*} [CommRing R]
+variable {L : Type*} [RightPreLieRing L] [RightPreLieAlgebra R L]
 
 /-! ## §1: Per-degree lift via `PiTensorProduct.lift` -/
 
@@ -333,7 +333,7 @@ then uses `DirectSum.linearMap_ext` (per-summand check) and
 `PiTensorProduct.ext` (per-tprod check) — both `@[ext]` lemmas in mathlib.
 -/
 
-lemma TA_linearMap_ext_tprod {N : Type} [AddCommMonoid N] [Module R N]
+lemma TA_linearMap_ext_tprod {N : Type*} [AddCommMonoid N] [Module R N]
     {f g : TensorAlgebra R L →ₗ[R] N}
     (h : ∀ n (a : Fin n → L),
       f (TensorAlgebra.tprod R L n a) = g (TensorAlgebra.tprod R L n a)) :

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Algebra.RootedTree.Coproduct.Trace
 import Linglib.Core.Algebra.RootedTree.GrossmanLarson
+import Linglib.Core.Algebra.RootedTree.GrossmanLarsonMonoid
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing
 import Mathlib.RingTheory.Bialgebra.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Basis
@@ -57,7 +58,7 @@ work (B+ is not a Hochschild 1-cocycle for Δ^c; see CHANGELOG entry
 GL/Δ^c duality identity `pairing_gl_eq_pairing_coproduct_C` and the
 grading half of `mcb_lemma_1_2_10`. The R.6 pairing substrate
 (`GrossmanLarsonPairing.lean`, `Aut.lean`) is sorry-free; the R.5 GL
-substrate still has `mul_assoc_basis` open.
+substrate is closed (`GrossmanLarson.mul_assoc`, `GrossmanLarsonMonoid.lean`).
 -/
 
 namespace RootedTree
@@ -1299,14 +1300,16 @@ per-tree sorries that capture the `cutSummandsCN` substrate work
     `cutSummandsCN_filter_empty` to show the filter yields exactly `{(0, T)}`. -/
 private theorem counit_rTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β')
     (T : Nonplanar (α' ⊕ β')) :
-    (Algebra.TensorProduct.map (ConnesKreimer.counit (R := R'))
+    (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
         (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β')))))
       (comulCTreeN τ T) = (1 : R') ⊗ₜ ConnesKreimer.ofTree T := by
   -- Expand comulCTreeN τ T.
   unfold comulCTreeN
   rw [map_add]
   -- First summand: (counit ⊗ id)(ofTree T ⊗ 1) = counit(ofTree T) ⊗ 1 = 0 ⊗ 1 = 0.
-  rw [show (Algebra.TensorProduct.map (ConnesKreimer.counit (R := R'))
+  rw [show (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
               (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β')))))
             (ConnesKreimer.ofTree T ⊗ₜ[R']
               (1 : ConnesKreimer R' (Nonplanar (α' ⊕ β')))) = 0 from by
@@ -1315,19 +1318,22 @@ private theorem counit_rTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β'
   rw [zero_add]
   -- Distribute (counit ⊗ id) through the multiset sum.
   rw [map_multiset_sum
-        (Algebra.TensorProduct.map (ConnesKreimer.counit (R := R'))
+        (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
           (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β')))))]
   simp only [Multiset.map_map]
   -- Each summand: (counit ⊗ id)(of' p.1 ⊗ ofTree p.2) =
   --   (if p.1.card = 0 then 1 else 0) ⊗ ofTree p.2.
-  rw [show ((Algebra.TensorProduct.map (ConnesKreimer.counit (R := R'))
+  rw [show ((Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
               (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))))) ∘
             (fun p : Forest (Nonplanar (α' ⊕ β')) × Nonplanar (α' ⊕ β') =>
               ConnesKreimer.of' (R := R') p.1 ⊗ₜ[R'] ConnesKreimer.ofTree p.2)) =
             (fun p => (if p.1.card = 0 then (1 : R') else 0) ⊗ₜ[R']
                        ConnesKreimer.ofTree p.2) from by
     funext p
-    show (Algebra.TensorProduct.map (ConnesKreimer.counit (R := R'))
+    show (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
             (AlgHom.id R' _))
           (ConnesKreimer.of' (R := R') p.1 ⊗ₜ[R'] ConnesKreimer.ofTree p.2) = _
     rw [Algebra.TensorProduct.map_tmul, AlgHom.id_apply, ConnesKreimer.counit_of']]
@@ -1355,14 +1361,16 @@ private theorem counit_rTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β'
 private theorem counit_lTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β')
     (T : Nonplanar (α' ⊕ β')) :
     (Algebra.TensorProduct.map (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))))
-        (ConnesKreimer.counit (R := R')))
+        ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R'))
       (comulCTreeN τ T) = ConnesKreimer.ofTree T ⊗ₜ (1 : R') := by
   unfold comulCTreeN
   rw [map_add]
   -- First summand: (id ⊗ counit)(ofTree T ⊗ 1) = ofTree T ⊗ counit(1) = ofTree T ⊗ 1.
   rw [show (Algebra.TensorProduct.map
               (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))))
-              (ConnesKreimer.counit (R := R')))
+              ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R'))
             (ConnesKreimer.ofTree T ⊗ₜ[R']
               (1 : ConnesKreimer R' (Nonplanar (α' ⊕ β')))) =
           ConnesKreimer.ofTree T ⊗ₜ[R'] (1 : R') from by
@@ -1370,19 +1378,22 @@ private theorem counit_lTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β'
   -- Second summand: distribute via map_multiset_sum, then show the entire sum is 0.
   rw [map_multiset_sum
         (Algebra.TensorProduct.map (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))))
-          (ConnesKreimer.counit (R := R')))]
+          ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R'))]
   simp only [Multiset.map_map]
   -- Each summand: (id ⊗ counit)(of' p.1 ⊗ ofTree p.2) = of' p.1 ⊗ counit(ofTree p.2)
   --              = of' p.1 ⊗ 0 = 0.
   rw [show ((Algebra.TensorProduct.map
               (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))))
-              (ConnesKreimer.counit (R := R'))) ∘
+              ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')) ∘
             (fun p : Forest (Nonplanar (α' ⊕ β')) × Nonplanar (α' ⊕ β') =>
               ConnesKreimer.of' (R := R') p.1 ⊗ₜ[R'] ConnesKreimer.ofTree p.2)) =
             (fun _ => (0 : ConnesKreimer R' (Nonplanar (α' ⊕ β')) ⊗[R'] R')) from by
     funext p
     show (Algebra.TensorProduct.map
-            (AlgHom.id R' _) (ConnesKreimer.counit (R := R')))
+            (AlgHom.id R' _) ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R'))
           (ConnesKreimer.of' (R := R') p.1 ⊗ₜ[R'] ConnesKreimer.ofTree p.2) = _
     rw [Algebra.TensorProduct.map_tmul, AlgHom.id_apply, ConnesKreimer.counit_ofTree,
         TensorProduct.tmul_zero]]
@@ -1399,10 +1410,12 @@ private theorem counit_lTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β'
     Mirrors `PruningNonplanar.comulForestN_counit_rTensor`. -/
 private theorem counit_rTensor_comulCForestN (τ : Nonplanar (α' ⊕ β') → β')
     (F : Forest (Nonplanar (α' ⊕ β')))
-    (hF : ∀ T ∈ F, (Algebra.TensorProduct.map (ConnesKreimer.counit (R := R'))
+    (hF : ∀ T ∈ F, (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
         (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β')))))
         (comulCTreeN τ T) = (1 : R') ⊗ₜ ConnesKreimer.ofTree T) :
-    (Algebra.TensorProduct.map (ConnesKreimer.counit (R := R'))
+    (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
         (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β')))))
       (comulCForestN (R := R') τ F) = (1 : R') ⊗ₜ ConnesKreimer.of' F := by
   induction F using Multiset.induction with
@@ -1430,10 +1443,12 @@ private theorem counit_lTensor_comulCForestN (τ : Nonplanar (α' ⊕ β') → �
     (F : Forest (Nonplanar (α' ⊕ β')))
     (hF : ∀ T ∈ F, (Algebra.TensorProduct.map
         (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))))
-        (ConnesKreimer.counit (R := R')))
+        ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R'))
         (comulCTreeN τ T) = ConnesKreimer.ofTree T ⊗ₜ (1 : R')) :
     (Algebra.TensorProduct.map (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))))
-        (ConnesKreimer.counit (R := R')))
+        ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R'))
       (comulCForestN (R := R') τ F) = ConnesKreimer.of' F ⊗ₜ (1 : R') := by
   induction F using Multiset.induction with
   | empty =>
@@ -1456,13 +1471,15 @@ private theorem counit_lTensor_comulCForestN (τ : Nonplanar (α' ⊕ β') → �
 
 /-- **Right counit law** (CLOSED via per-tree + forest helpers): `(counit ⊗ id) ∘ Δ^c = lid⁻¹`. -/
 theorem counit_rTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
-    (Algebra.TensorProduct.map (ConnesKreimer.counit (R := R'))
+    (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
         (AlgHom.id R' _)).comp (comulCAlgHomN (R := R') τ) =
       (Algebra.TensorProduct.lid R'
         (ConnesKreimer R' (Nonplanar (α' ⊕ β')))).symm.toAlgHom := by
   apply AddMonoidAlgebra.algHom_ext
   intro F
-  show (Algebra.TensorProduct.map (ConnesKreimer.counit (R := R'))
+  show (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
           (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β')))))
         (comulCAlgHomN (R := R') τ (ConnesKreimer.of' F)) =
        (Algebra.TensorProduct.lid R'
@@ -1473,13 +1490,15 @@ theorem counit_rTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
 /-- **Left counit law** (CLOSED via per-tree + forest helpers): `(id ⊗ counit) ∘ Δ^c = rid⁻¹`. -/
 theorem counit_lTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
     (Algebra.TensorProduct.map (AlgHom.id R' _)
-        (ConnesKreimer.counit (R := R'))).comp (comulCAlgHomN (R := R') τ) =
+        ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')).comp (comulCAlgHomN (R := R') τ) =
       (Algebra.TensorProduct.rid R' R'
         (ConnesKreimer R' (Nonplanar (α' ⊕ β')))).symm.toAlgHom := by
   apply AddMonoidAlgebra.algHom_ext
   intro F
   show (Algebra.TensorProduct.map (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))))
-          (ConnesKreimer.counit (R := R')))
+          ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R'))
         (comulCAlgHomN (R := R') τ (ConnesKreimer.of' F)) =
        (Algebra.TensorProduct.rid R' R'
         (ConnesKreimer R' (Nonplanar (α' ⊕ β')))).symm (ConnesKreimer.of' F)
@@ -1498,7 +1517,8 @@ theorem counit_lTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
 noncomputable instance instBialgebraC
     [CharZero R'] [NoZeroDivisors R'] (τ : Nonplanar (α' ⊕ β') → β') :
     Bialgebra R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))) :=
-  Bialgebra.ofAlgHom (comulCAlgHomN (R := R') τ) (ConnesKreimer.counit (R := R'))
+  Bialgebra.ofAlgHom (comulCAlgHomN (R := R') τ) ((ConnesKreimer.counit (R := R')) :
+          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
     (comulCAlgHomN_coassoc_algHom τ)
     (counit_rTensor_comulCAlgHomN τ)
     (counit_lTensor_comulCAlgHomN τ)

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarson.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarson.lean
@@ -88,12 +88,15 @@ underlying carrier, different multiplication.
 ## Status
 
 `[UPSTREAM]` candidate. Skeleton API (basis embeddings, single-tree
-insertion, multi-tree `insertion`, GL product, Mul instance), with
-`mul_one` and `one_mul` proved and `mul_assoc` reduced (via triple
-`Finsupp.addHom_ext`) to the basis-vector lemma `mul_assoc_basis`,
-which carries the remaining `sorry`. The `Semigroup`/`Monoid`
-typeclass instances for the GL product are NOT registered until
-`mul_assoc_basis` lands — only the forwarding `theorem`s are stated.
+insertion, multi-tree `insertion`, GL product, `Mul` instance), with
+`mul_one` and `one_mul` proved in-file.
+
+`mul_assoc_basis` and `mul_assoc` (R-generic, `α : Type*`) live in
+`GrossmanLarsonMonoid.lean`, proved sorry-free via the OudomGuin / PBW
+bridge in `OudomGuinBridge.lean`
+(`mul_assoc_basis_via_oudom_guin_pbw`) lifted to arbitrary
+`CommSemiring R` by multiset-coefficient extraction. The `Semigroup`
+and `Monoid` typeclass instances are registered there.
 -/
 
 namespace RootedTree
@@ -454,12 +457,9 @@ noncomputable def product :
 
 /-! ### Multiplicative structure
 
-The `Mul` instance is registered now. The `Semigroup`/`Monoid` instances
-are intentionally NOT registered until associativity is proved
-(registering them prematurely would silently propagate the open `sorry`
-through any `[Semigroup]`-using consumer). The forwarding `theorem`s
-`mul_one`, `one_mul`, `mul_assoc` are stated for downstream convenience
-but carry the same `sorry`s. -/
+The `Mul` instance is registered here; `Semigroup`/`Monoid` are
+registered in `GrossmanLarsonMonoid.lean` once associativity is in
+hand. -/
 
 noncomputable instance instMul : Mul (GrossmanLarson R α) where
   mul x y := product x y
@@ -755,176 +755,14 @@ theorem one_mul (F : GrossmanLarson R α) : (1 : GrossmanLarson R α) * F = F :=
         Finsupp.single G_basis r
     rw [Finsupp.smul_single, smul_eq_mul, _root_.mul_one]
 
-/-- **Basis-level associativity**. The combinatorial heart of GL
-    associativity: with all three arguments basis vectors, the product
-    formula's nested powersets need a Fubini-style re-indexing to match.
-    Foissy 2018 §4.2 establishes this via Guin-Oudom + PBW; we bypass
-    PBW with a direct combinatorial bijection on `insertionMultiset`.
-    **TODO**: proof. -/
-private theorem mul_assoc_basis (F₁ F₂ F₃ : Forest (Nonplanar α)) :
-    ((of' F₁ : GrossmanLarson R α) * of' F₂) * of' F₃ =
-      of' F₁ * (of' F₂ * of' F₃) := by
-  sorry
+/-! ### Associativity
 
-/-! ### Bilinearity reduction for `mul_assoc`
-
-The full statement of `mul_assoc` is reduced to the basis-vector case
-`mul_assoc_basis` via three nested `Finsupp.addHom_ext` invocations. Each
-side of `F₁ * F₂ * F₃ = F₁ * (F₂ * F₃)` is presented as an `AddMonoidHom`
-in one of the three variables (the other two held fixed), the two
-`AddMonoidHom`s are shown equal by checking on `Finsupp.single F r`
-basis elements, and the singleton case reduces via scalar pull-out
-(through `LinearMap.map_smul` on `product`) to the basis-vector
-`mul_assoc_basis` statement.
-
-This avoids fighting the `GrossmanLarson R α := ConnesKreimer R (Nonplanar α)`
-def-opacity issues that bite `Finsupp.induction_linear` on GL elements:
-all the heavy lifting happens at the underlying `Finsupp` level. -/
-
-/-- Right multiplication by `y` as an `AddMonoidHom`, additive in `x`.
-    Bilinearity of `product` (which is a LinearMap) gives the additive
-    structure for free. -/
-private noncomputable def mulRightHom (y : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α where
-  toFun x := x * y
-  map_zero' := by
-    show product 0 y = 0
-    rw [product.map_zero, LinearMap.zero_apply]
-  map_add' x₁ x₂ := by
-    show product (x₁ + x₂) y = product x₁ y + product x₂ y
-    rw [product.map_add, LinearMap.add_apply]
-
-/-- Left multiplication by `x` as an `AddMonoidHom`, additive in `y`. -/
-private noncomputable def mulLeftHom (x : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α where
-  toFun y := x * y
-  map_zero' := by
-    show product x 0 = 0
-    exact (product x).map_zero
-  map_add' y₁ y₂ := by
-    show product x (y₁ + y₂) = product x y₁ + product x y₂
-    exact (product x).map_add y₁ y₂
-
-@[simp] private theorem mulRightHom_apply (x y : GrossmanLarson R α) :
-    mulRightHom y x = x * y := rfl
-
-@[simp] private theorem mulLeftHom_apply (x y : GrossmanLarson R α) :
-    mulLeftHom x y = x * y := rfl
-
-/-- Scalar pull-out on the LEFT factor: `(c • x) * y = c • (x * y)`. -/
-private theorem smul_mul_left (c : R) (x y : GrossmanLarson R α) :
-    ((c • x : GrossmanLarson R α) * y) = c • (x * y) := by
-  show product (c • x) y = c • product x y
-  rw [product.map_smul, LinearMap.smul_apply]
-
-/-- Scalar pull-out on the RIGHT factor: `x * (c • y) = c • (x * y)`. -/
-private theorem mul_smul_right (c : R) (x y : GrossmanLarson R α) :
-    (x * (c • y : GrossmanLarson R α)) = c • (x * y) := by
-  show product x (c • y) = c • product x y
-  exact (product x).map_smul c y
-
-/-- AddMonoidHom for `x ↦ x * y * z`, additive in `x`. -/
-private noncomputable def assocLHSHom (y z : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  (mulRightHom z).comp (mulRightHom y)
-
-/-- AddMonoidHom for `x ↦ x * (y * z)`, additive in `x`. -/
-private noncomputable def assocRHSHom (y z : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  mulRightHom (y * z)
-
-@[simp] private theorem assocLHSHom_apply (x y z : GrossmanLarson R α) :
-    assocLHSHom y z x = x * y * z := rfl
-
-@[simp] private theorem assocRHSHom_apply (x y z : GrossmanLarson R α) :
-    assocRHSHom y z x = x * (y * z) := rfl
-
-/-- AddMonoidHom for `y ↦ x * y * z`, additive in `y` (with `x, z` fixed). -/
-private noncomputable def assocLHSHomY (x z : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  (mulRightHom z).comp (mulLeftHom x)
-
-/-- AddMonoidHom for `y ↦ x * (y * z)`, additive in `y` (with `x, z` fixed). -/
-private noncomputable def assocRHSHomY (x z : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  (mulLeftHom x).comp (mulRightHom z)
-
-@[simp] private theorem assocLHSHomY_apply (x y z : GrossmanLarson R α) :
-    assocLHSHomY x z y = x * y * z := rfl
-
-@[simp] private theorem assocRHSHomY_apply (x y z : GrossmanLarson R α) :
-    assocRHSHomY x z y = x * (y * z) := by
-  show (mulLeftHom x) ((mulRightHom z) y) = x * (y * z)
-  rfl
-
-/-- AddMonoidHom for `z ↦ x * y * z`, additive in `z` (with `x, y` fixed). -/
-private noncomputable def assocLHSHomZ (x y : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  (mulLeftHom (x * y))
-
-/-- AddMonoidHom for `z ↦ x * (y * z)`, additive in `z` (with `x, y` fixed). -/
-private noncomputable def assocRHSHomZ (x y : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  (mulLeftHom x).comp (mulLeftHom y)
-
-@[simp] private theorem assocLHSHomZ_apply (x y z : GrossmanLarson R α) :
-    assocLHSHomZ x y z = x * y * z := rfl
-
-@[simp] private theorem assocRHSHomZ_apply (x y z : GrossmanLarson R α) :
-    assocRHSHomZ x y z = x * (y * z) := by
-  show (mulLeftHom x) ((mulLeftHom y) z) = x * (y * z)
-  rfl
-
-/-- **Associativity**. Proved by triple bilinearity reduction
-    (`Finsupp.addHom_ext` thrice) to `mul_assoc_basis`. The combinatorial
-    heart of associativity lives in `mul_assoc_basis`; this proof just
-    handles the linear-extension boilerplate. -/
-theorem mul_assoc (F₁ F₂ F₃ : GrossmanLarson R α) :
-    F₁ * F₂ * F₃ = F₁ * (F₂ * F₃) := by
-  -- Reduce F₁ to single via addHom_ext on F₁ (the LHS factor of `(F₁ * F₂) * F₃`).
-  have h₁ : assocLHSHom F₂ F₃ = assocRHSHom F₂ F₃ := by
-    refine Finsupp.addHom_ext fun T₁ a₁ => ?_
-    -- Goal: assocLHSHom F₂ F₃ (single T₁ a₁) = assocRHSHom F₂ F₃ (single T₁ a₁)
-    set s₁ : GrossmanLarson R α := Finsupp.single T₁ a₁ with s₁_def
-    show assocLHSHom F₂ F₃ s₁ = assocRHSHom F₂ F₃ s₁
-    rw [assocLHSHom_apply, assocRHSHom_apply]
-    -- Reduce F₂ to single via addHom_ext on F₂.
-    have h₂ : assocLHSHomY s₁ F₃ = assocRHSHomY s₁ F₃ := by
-      refine Finsupp.addHom_ext fun T₂ a₂ => ?_
-      set s₂ : GrossmanLarson R α := Finsupp.single T₂ a₂ with s₂_def
-      show assocLHSHomY s₁ F₃ s₂ = assocRHSHomY s₁ F₃ s₂
-      rw [assocLHSHomY_apply, assocRHSHomY_apply]
-      -- Reduce F₃ to single via addHom_ext on F₃.
-      have h₃ : assocLHSHomZ s₁ s₂ = assocRHSHomZ s₁ s₂ := by
-        refine Finsupp.addHom_ext fun T₃ a₃ => ?_
-        set s₃ : GrossmanLarson R α := Finsupp.single T₃ a₃ with s₃_def
-        show assocLHSHomZ s₁ s₂ s₃ = assocRHSHomZ s₁ s₂ s₃
-        rw [assocLHSHomZ_apply, assocRHSHomZ_apply]
-        -- Convert each sᵢ from `single Tᵢ aᵢ` to `aᵢ • of' Tᵢ`.
-        rw [show s₁ = a₁ • (of' T₁ : GrossmanLarson R α) from
-              (Finsupp.smul_single_one T₁ a₁).symm,
-            show s₂ = a₂ • (of' T₂ : GrossmanLarson R α) from
-              (Finsupp.smul_single_one T₂ a₂).symm,
-            show s₃ = a₃ • (of' T₃ : GrossmanLarson R α) from
-              (Finsupp.smul_single_one T₃ a₃).symm]
-        -- Pull out scalars from both sides via the bilinearity lemmas. Both
-        -- sides normalize to `a₃ • a₂ • a₁ • (...)` (simp pulls scalars out
-        -- innermost-first). The remaining basis-vector product on each side
-        -- is closed by `mul_assoc_basis`.
-        simp only [smul_mul_left, mul_smul_right]
-        rw [mul_assoc_basis T₁ T₂ T₃]
-      -- Apply h₃ at F₃ to get the F₂-singleton statement.
-      have h₃App := DFunLike.congr_fun h₃ F₃
-      rw [assocLHSHomZ_apply, assocRHSHomZ_apply] at h₃App
-      exact h₃App
-    -- Apply h₂ at F₂ to get the F₁-singleton statement.
-    have h₂App := DFunLike.congr_fun h₂ F₂
-    rw [assocLHSHomY_apply, assocRHSHomY_apply] at h₂App
-    exact h₂App
-  -- Apply h₁ at F₁ to conclude.
-  have h₁App := DFunLike.congr_fun h₁ F₁
-  rw [assocLHSHom_apply, assocRHSHom_apply] at h₁App
-  exact h₁App
+`mul_assoc_basis` and `mul_assoc` (both R-generic, `α : Type*`) are
+proved sorry-free in `GrossmanLarsonMonoid.lean` via the Oudom-Guin
+/ PBW route — see `OudomGuinBridge.lean`'s
+`mul_assoc_basis_via_oudom_guin_pbw` (Q6 for `R = ℤ`), lifted to arbitrary
+`CommSemiring R` via multiset-coefficient extraction. The
+`Semigroup`/`Monoid` instances are registered there. -/
 
 end GrossmanLarson
 

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonAssoc.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonAssoc.lean
@@ -5,69 +5,43 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Algebra.RootedTree.GrossmanLarson
 import Linglib.Core.Algebra.RootedTree.PreLie.InsertionAddHost
+import Linglib.Core.Algebra.RootedTree.PreLie.InsertionCompose
 import Linglib.Core.Algebra.ConnesKreimer.Shuffle
 
 set_option autoImplicit false
 
 /-!
-# Associativity of the Grossman-Larson product via Oudom-Guin 2004 Lemma 2.10
+# Basis-level substrate for the Grossman-Larson product
 [oudom-guin-2008]
 [foissy-typed-decorated-rooted-trees-2018]
 
-Closes `GrossmanLarson.mul_assoc_basis` (and thus `mul_assoc`) via the
-direct algebraic argument of Oudom-Guin (arXiv:math/0404457) §2,
-Lemma 2.10 — the canonical paragraph-1 construction in pre-Lie / Hopf
-algebra theory. **Does not require PBW.**
+Combinatorial substrate connecting the Grossman-Larson product on
+`ConnesKreimer R (Nonplanar α)` to `Nonplanar.insertionMultiset` (NIM):
+host distributivity, single-guest associativity, representative
+invariance, and the powerset sum forms consumed by the associativity
+proof in `GrossmanLarsonMonoid.lean` (which derives `mul_assoc` from the
+abstract Oudom-Guin `★`-associativity via the `ckIsoSymmetricAlgebra`
+bridge).
 
-## Structure
+## Main results
 
-The proof reduces to two algebraic identities on `H = ConnesKreimer R (Nonplanar α)`
-(viewed as the symmetric algebra `S(L)` where `L = InsertionAlgebra`):
+* `Nonplanar.insertionMultiset_add_host` (Prop 2.7.iii substrate): NIM
+  into a disjoint-union host decomposes over guest partitions.
+* `Nonplanar.insertionMultiset_eq_of_reps`: NIM computes on any planar
+  representatives.
+* `Nonplanar.insertionMultiset_singleton_assoc`: iterated single-guest
+  grafting equals simultaneous grafting plus guest-nested grafting.
+* `insertion_mul_distrib` (Prop 2.7.iii of [oudom-guin-2008] at basis
+  level).
+* `product_of'_sum_form` / `mul_of'_sum_form` / `lhs_quadruple_form` /
+  `rhs_quintuple_form`: powerset sum forms of (iterated) GL products.
 
-* **`insertion_mul_distrib`** (Prop 2.7.iii): `(AB) ∘ C = (A ∘ C_(1))(B ∘ C_(2))` —
-  multi-graft distributes over the disjoint-union product via the shuffle coproduct.
+The deprecated direct combinatorial route to associativity (the A3.3
+campaign: `insertionMultiset_assoc`, `insertion_assoc_shuffled`, the
+Lemma-2.10 chain) was deleted on 2026-06-12 when the bridge route
+closed; see `GrossmanLarsonMonoid.lean`.
 
-* **`insertion_assoc_shuffled`** (Prop 2.7.v): `(A ∘ B) ∘ C = A ∘ ((B ∘ C_(1)) C_(2))` —
-  multi-graft is "associative" up to shuffle re-indexing.
-
-Both are stated in basis form using `Multiset.powerset` (the explicit form of the
-shuffle Δ on each summand). Lemma 2.10's chain then closes
-`mul_assoc_basis` in a few rewrites + cocommutativity of the powerset sum.
-
-## Why this approach
-
-The Oudom-Guin construction gives an associative product on `S(L)` for ANY
-pre-Lie algebra L. The proof is purely algebraic — no PBW, no
-combinatorial bijection at the `insertionMultiset` level. Closing
-`mul_assoc_basis` this way produces upstream-worthy substrate (currently
-absent from mathlib's pre-Lie module).
-
-## Status
-
-**DEPRECATED 2026-05-16** as the active path. See
-`scratch/pivot_to_prelie_pbw.md` and `Linglib/Core/Algebra/PreLie/
-OudomGuinCirc.lean`. The basis-level chain `mul_assoc_basis_via_oudom_guin`
-attempts to prove Prop 2.7.iii / 2.7.v combinatorially over forests; the
-pivoted approach proves them at the abstract `S(L)` level (where Prop
-2.7.iii is by definition and Prop 2.7.v is a 10-line induction), then
-specializes.
-
-Files in this layer that remain useful:
-* `§1 insertion_mul_distrib` (Prop 2.7.iii at basis level) — proven and
-  reusable as a sanity check or specialization target for the abstract
-  result.
-* `§3` cocommutativity helpers — generic, reusable.
-
-Files DEPRECATED (sorries here are NOT on the GL-associativity critical
-path under the pivot):
-* `§2 insertion_assoc_shuffled` — reduces to `insertionMultiset_assoc`
-  (A3.3 sorry). Will be derived from abstract Prop 2.7.v after the
-  pivot's Q1-Q5 lands.
-* `§4b mul_assoc_basis_via_oudom_guin` — the chain proof. Replaced by
-  `mul_assoc_basis_via_prelie_pbw` (future, derived from
-  `OudomGuinCirc.oudomGuinStar_assoc` + Q5 bridge).
-
-`[UPSTREAM]` candidate via the pivoted route, not this file.
+`[UPSTREAM]` candidate (jointly with the OudomGuinCirc layer).
 -/
 
 namespace RootedTree
@@ -385,6 +359,306 @@ theorem _root_.RootedTree.Nonplanar.insertionMultiset_add_host
        ↑(a.map Nonplanar.mk) + ↑(b.map Nonplanar.mk)
   rw [List.map_append, Multiset.coe_add]
 
+/-- Generic lift of a `mk`-image `Perm` to a planar `Perm` plus a list with
+    matching `mk`-image. Inline copy of `Planar.Pathed.perm_lift_through_map`
+    (private there) — pure list/Perm lemma, no rooted-tree content. -/
+private theorem perm_lift_mk {l₂ l₁ : List (Planar α)}
+    (h : (l₁.map Nonplanar.mk).Perm (l₂.map Nonplanar.mk)) :
+    ∃ l_mid : List (Planar α),
+      l₁.Perm l_mid ∧ l_mid.map Nonplanar.mk = l₂.map Nonplanar.mk := by
+  induction l₂ generalizing l₁ with
+  | nil =>
+    rw [List.map_nil] at h
+    have h_eq : l₁.map Nonplanar.mk = [] := h.eq_nil
+    have hl₁ : l₁ = [] := List.map_eq_nil_iff.mp h_eq
+    exact ⟨[], hl₁ ▸ List.Perm.refl _, by simp⟩
+  | cons b l₂_rest ih =>
+    have hfb_mem : Nonplanar.mk b ∈ l₁.map Nonplanar.mk := by
+      apply h.symm.subset
+      rw [List.map_cons]
+      exact List.mem_cons_self
+    obtain ⟨a, ha_mem, hfa_eq⟩ := List.mem_map.mp hfb_mem
+    letI : DecidableEq (Planar α) := Classical.decEq _
+    have hperm_l₁ : l₁.Perm (a :: l₁.erase a) := List.perm_cons_erase ha_mem
+    have h' : ((a :: l₁.erase a).map Nonplanar.mk).Perm
+        ((b :: l₂_rest).map Nonplanar.mk) :=
+      (hperm_l₁.map Nonplanar.mk).symm.trans h
+    rw [List.map_cons, List.map_cons] at h'
+    rw [hfa_eq] at h'
+    have h_inner : ((l₁.erase a).map Nonplanar.mk).Perm
+        (l₂_rest.map Nonplanar.mk) := h'.cons_inv
+    obtain ⟨l_mid_rest, hperm_rest, hmap_rest⟩ := ih h_inner
+    refine ⟨a :: l_mid_rest, ?_, ?_⟩
+    · exact hperm_l₁.trans (hperm_rest.cons a)
+    · rw [List.map_cons, List.map_cons, hfa_eq, hmap_rest]
+
+/-- A `mk`-equality on lists `l₁.map mk = l₂.map mk` lifts to componentwise
+    `Forall₂ PlanarEquiv l₁ l₂`. -/
+private theorem forall2_planarEquiv_of_map_mk_eq :
+    ∀ {l₁ l₂ : List (Planar α)},
+      l₁.map Nonplanar.mk = l₂.map Nonplanar.mk →
+      List.Forall₂ Planar.PlanarEquiv l₁ l₂
+  | [], [], _ => List.Forall₂.nil
+  | [], _ :: _, h => by simp at h
+  | _ :: _, [], h => by simp at h
+  | x :: xs, y :: ys, h => by
+    rw [List.map_cons, List.map_cons, List.cons.injEq] at h
+    exact List.Forall₂.cons
+      (Nonplanar.mk_eq_mk_iff.mp h.1)
+      (forall2_planarEquiv_of_map_mk_eq h.2)
+
+/-- `Forall₂ PlanarEquiv` is symmetric (componentwise symmetry of `PlanarEquiv`). -/
+private theorem forall2_planarEquiv_symm :
+    ∀ {l₁ l₂ : List (Planar α)},
+      List.Forall₂ Planar.PlanarEquiv l₁ l₂ →
+      List.Forall₂ Planar.PlanarEquiv l₂ l₁
+  | [], [], _ => List.Forall₂.nil
+  | x :: xs, y :: ys, h => by
+    cases h with
+    | cons hd tl => exact List.Forall₂.cons hd.symm (forall2_planarEquiv_symm tl)
+
+/-- **Representative invariance for NIM**: `Nonplanar.insertionMultiset F G`
+    can be computed on ANY planar representative lists `hosts`, `guests`
+    whose `mk`-image multisets are `F` and `G` respectively — not just the
+    canonical `toList.map Quotient.out` reps.
+
+    This is the workhorse for descents that need to swap canonical reps for
+    a convenient planar list (e.g. `Q.out v :: B.toList.map Q.out` standing
+    in for `(B + {v}).toList.map Q.out`). -/
+theorem _root_.RootedTree.Nonplanar.insertionMultiset_eq_of_reps
+    (F G : Forest (Nonplanar α)) (hosts guests : List (Planar α))
+    (h_hosts : (Multiset.ofList (hosts.map Nonplanar.mk) :
+      Multiset (Nonplanar α)) = F)
+    (h_guests : (Multiset.ofList (guests.map Nonplanar.mk) :
+      Multiset (Nonplanar α)) = G) :
+    Nonplanar.insertionMultiset F G =
+      (Planar.Pathed.insertionForest hosts guests).map
+        (fun L => Multiset.ofList (L.map Nonplanar.mk)) := by
+  -- §1: Canonical reps' mk-images recover the multiset's toList.
+  have h_canon_hosts_mk :
+      (F.toList.map Quotient.out).map Nonplanar.mk = F.toList := by
+    induction F.toList with
+    | nil => rfl
+    | cons hd tl ih =>
+      show Nonplanar.mk (Quotient.out hd) ::
+          ((tl.map Quotient.out).map Nonplanar.mk) = hd :: tl
+      rw [ih]
+      congr 1
+      exact hd.out_eq
+  have h_canon_guests_mk :
+      (G.toList.map Quotient.out).map Nonplanar.mk = G.toList := by
+    induction G.toList with
+    | nil => rfl
+    | cons hd tl ih =>
+      show Nonplanar.mk (Quotient.out hd) ::
+          ((tl.map Quotient.out).map Nonplanar.mk) = hd :: tl
+      rw [ih]
+      congr 1
+      exact hd.out_eq
+  -- §2: Perm of mk-images at the host and guest level.
+  have h_hosts_perm :
+      (hosts.map Nonplanar.mk).Perm
+        ((F.toList.map Quotient.out).map Nonplanar.mk) := by
+    apply Multiset.coe_eq_coe.mp
+    rw [h_hosts, h_canon_hosts_mk]
+    exact F.coe_toList.symm
+  -- §3: Lift the host mk-Perm to a planar Perm + Forall₂ PlanarEquiv bridge.
+  obtain ⟨hosts_mid, h_hosts_planar_perm, h_hosts_map_eq⟩ :=
+    perm_lift_mk h_hosts_perm
+  have h_hosts_forall :
+      List.Forall₂ Planar.PlanarEquiv hosts_mid (F.toList.map Quotient.out) :=
+    forall2_planarEquiv_of_map_mk_eq h_hosts_map_eq
+  -- §4: Unfold NIM (canonical reps) and bridge via host-Perm + host-PlanarEquiv.
+  unfold Nonplanar.insertionMultiset
+  -- Bridge from `(canon_hosts) gs_canon` back to `(hosts) guests`:
+  --   canon_hosts ←(Forall₂ PlanarEquiv, symm)← hosts_mid ←(Perm, symm)← hosts
+  -- For guests, use `insertionForest_msform_invariance_guests` directly.
+  have h_guests_perm_mk :
+      (guests.map Nonplanar.mk).Perm
+        ((G.toList.map Quotient.out).map Nonplanar.mk) := by
+    apply Multiset.coe_eq_coe.mp
+    rw [h_guests, h_canon_guests_mk]
+    exact G.coe_toList.symm
+  -- Swap canonical hosts for `hosts_mid` (PlanarEquiv host invariance).
+  have h_step1 :
+      (Planar.Pathed.insertionForest (F.toList.map Quotient.out)
+          (G.toList.map Quotient.out)).map
+        (fun L => Multiset.ofList (L.map Nonplanar.mk)) =
+      (Planar.Pathed.insertionForest hosts_mid
+          (G.toList.map Quotient.out)).map
+        (fun L => Multiset.ofList (L.map Nonplanar.mk)) := by
+    have h2 := congrArg
+      (Multiset.map (fun l : List (Nonplanar α) =>
+        (Multiset.ofList l : Multiset (Nonplanar α))))
+      (Planar.Pathed.insertionForest_planarEquiv_host
+        (G.toList.map Quotient.out) (forall2_planarEquiv_symm h_hosts_forall))
+    -- h2 : map (ofList) (iF mid gs .map (List.map mk)) = map (ofList) (iF canon gs .map (List.map mk))
+    -- Collapse the inner map composition.
+    rw [Multiset.map_map, Multiset.map_map] at h2
+    -- h2 : map (ofList ∘ List.map mk) (iF mid gs) = map (ofList ∘ List.map mk) (iF canon gs)
+    -- Goal uses `fun L => ofList (L.map mk)`. These are eta-equal; use `show`.
+    show (Planar.Pathed.insertionForest (F.toList.map Quotient.out)
+          (G.toList.map Quotient.out)).map
+        ((fun l : List (Nonplanar α) => (Multiset.ofList l : Multiset (Nonplanar α)))
+          ∘ List.map Nonplanar.mk) =
+      (Planar.Pathed.insertionForest hosts_mid
+          (G.toList.map Quotient.out)).map
+        ((fun l : List (Nonplanar α) => (Multiset.ofList l : Multiset (Nonplanar α)))
+          ∘ List.map Nonplanar.mk)
+    exact h2
+  -- Swap `hosts_mid` for `hosts` (planar Perm of hosts).
+  have h_step2 :
+      (Planar.Pathed.insertionForest hosts_mid
+          (G.toList.map Quotient.out)).map
+        (fun L => Multiset.ofList (L.map Nonplanar.mk)) =
+      (Planar.Pathed.insertionForest hosts
+          (G.toList.map Quotient.out)).map
+        (fun L => Multiset.ofList (L.map Nonplanar.mk)) :=
+    Planar.Pathed.insertionForest_perm_host_msform
+      h_hosts_planar_perm.symm (G.toList.map Quotient.out)
+  -- Swap canonical guests for `guests` (mk-Perm of guests via the guest lemma).
+  have h_step3 :
+      (Planar.Pathed.insertionForest hosts
+          (G.toList.map Quotient.out)).map
+        (fun L => Multiset.ofList (L.map Nonplanar.mk)) =
+      (Planar.Pathed.insertionForest hosts guests).map
+        (fun L => Multiset.ofList (L.map Nonplanar.mk)) :=
+    (Planar.Pathed.insertionForest_msform_invariance_guests hosts
+      h_guests_perm_mk).symm
+  exact h_step1.trans (h_step2.trans h_step3)
+
+/-- **Deep substrate**: NIM-level singleton-guest associativity.
+
+    `(NIM A B).bind (X ↦ NIM X {v}) = NIM A (B + {v}) + (NIM B {v}).bind (X' ↦ NIM A X')`
+
+    Proved by descent from the raw planar identity
+    `Planar.Pathed.insertionForest_bind_singleton`. The descent uses the
+    representative-invariance lemma
+    `Nonplanar.insertionMultiset_eq_of_reps` per-output to swap NIM applied
+    to a planar output `msform L` for the planar engine applied to `L`. -/
+theorem _root_.RootedTree.Nonplanar.insertionMultiset_singleton_assoc
+    (A B : Forest (Nonplanar α)) (v : Nonplanar α) :
+    (Nonplanar.insertionMultiset A B).bind
+        (fun X => Nonplanar.insertionMultiset X {v}) =
+      Nonplanar.insertionMultiset A (B + {v}) +
+      (Nonplanar.insertionMultiset B {v}).bind
+        (fun X' => Nonplanar.insertionMultiset A X') := by
+  -- Canonical planar reps.
+  set A_pl : List (Planar α) := A.toList.map Quotient.out with hA_pl
+  set B_pl : List (Planar α) := B.toList.map Quotient.out with hB_pl
+  set ov : Planar α := Quotient.out v with hov
+  -- Abbreviation for the msform post-map (`List (Planar α) → Forest (Nonplanar α)`).
+  set msform : List (Planar α) → Forest (Nonplanar α) :=
+    fun L => Multiset.ofList (L.map Nonplanar.mk) with hmsform
+  -- Key fact: for any planar list `L`, `(L.map mk : Multiset _) = msform L`.
+  -- (Used to discharge rep-lemma hypotheses for inner NIMs.)
+  have h_msform_eq : ∀ L : List (Planar α),
+      (Multiset.ofList (L.map Nonplanar.mk) : Multiset (Nonplanar α)) = msform L :=
+    fun L => rfl
+  -- §1: LHS = ((iF A_pl B_pl).bind (fun L => iF L [ov])).map msform.
+  -- Step 1a: unfold the outer NIM, then push bind through the outer .map msform.
+  have h_lhs_outer : Nonplanar.insertionMultiset A B =
+      (Planar.Pathed.insertionForest A_pl B_pl).map msform := rfl
+  -- Step 1b: per planar host output L, NIM (msform L) {v} = (iF L [ov]).map msform.
+  have h_inner_NIM : ∀ L : List (Planar α),
+      Nonplanar.insertionMultiset (msform L) {v} =
+        (Planar.Pathed.insertionForest L [ov]).map msform := by
+    intro L
+    apply Nonplanar.insertionMultiset_eq_of_reps
+    · -- hosts hyp: ofList (L.map mk) = msform L
+      rfl
+    · -- guests hyp: ofList ([ov].map mk) = {v}.
+      show (Multiset.ofList ([Nonplanar.mk ov]) : Multiset (Nonplanar α)) = ({v} : Multiset _)
+      rw [hov, show Nonplanar.mk (Quotient.out v) = v from Quotient.out_eq v]
+      rfl
+  -- Step 1c: collapse the LHS.
+  have h_lhs :
+      (Nonplanar.insertionMultiset A B).bind
+        (fun X => Nonplanar.insertionMultiset X {v}) =
+      ((Planar.Pathed.insertionForest A_pl B_pl).bind
+        (fun L => Planar.Pathed.insertionForest L [ov])).map msform := by
+    rw [h_lhs_outer, Multiset.bind_map]
+    -- Goal: (iF A_pl B_pl).bind (fun L => NIM (msform L) {v})
+    --     = ((iF A_pl B_pl).bind (fun L => iF L [ov])).map msform
+    rw [Multiset.map_bind]
+    refine Multiset.bind_congr fun L _ => ?_
+    exact h_inner_NIM L
+  -- §2: Apply the planar engine and split via Multiset.map_add.
+  rw [h_lhs, Planar.Pathed.insertionForest_bind_singleton, Multiset.map_add]
+  -- Now the goal has two summands matching the RHS shape. Prove each.
+  congr 1
+  · -- Summand 1: (iF A_pl (ov :: B_pl)).map msform = NIM A (B + {v}).
+    symm
+    apply Nonplanar.insertionMultiset_eq_of_reps
+    · -- hosts hyp: ofList (A_pl.map mk) = A.
+      show (Multiset.ofList ((A.toList.map Quotient.out).map Nonplanar.mk) :
+            Multiset (Nonplanar α)) = A
+      rw [List.map_map]
+      have h_id : A.toList.map (Nonplanar.mk ∘ Quotient.out) = A.toList :=
+        (List.map_congr_left fun x _ => Quotient.out_eq x).trans (List.map_id _)
+      rw [h_id]
+      exact A.coe_toList
+    · -- guests hyp: ofList ((ov :: B_pl).map mk) = B + {v}.
+      show (Multiset.ofList ((Quotient.out v :: B.toList.map Quotient.out).map Nonplanar.mk) :
+            Multiset (Nonplanar α)) = B + {v}
+      rw [List.map_cons, List.map_map]
+      have h_id_B : B.toList.map (Nonplanar.mk ∘ Quotient.out) = B.toList :=
+        (List.map_congr_left fun x _ => Quotient.out_eq x).trans (List.map_id _)
+      rw [h_id_B]
+      show ((Nonplanar.mk (Quotient.out v) :: B.toList : List (Nonplanar α)) :
+            Multiset (Nonplanar α)) = B + {v}
+      rw [show Nonplanar.mk (Quotient.out v) = v from Quotient.out_eq v]
+      -- (↑(v :: B.toList) : Multiset _) = v ::ₘ ↑B.toList = v ::ₘ B
+      rw [show ((v :: B.toList : List (Nonplanar α)) : Multiset (Nonplanar α)) =
+          v ::ₘ (↑B.toList : Multiset (Nonplanar α)) from rfl, B.coe_toList]
+      -- Goal: v ::ₘ B = B + {v}.
+      rw [add_comm B, Multiset.singleton_add]
+  · -- Summand 2: ((iF B_pl [ov]).bind (fun B' => iF A_pl B')).map msform
+    --          = (NIM B {v}).bind (NIM A ·)
+    -- Push msform through the outer bind, then apply rep lemma per B'.
+    rw [Multiset.map_bind]
+    -- Goal: (iF B_pl [ov]).bind (fun B' => (iF A_pl B').map msform) = ...
+    -- Per B', (iF A_pl B').map msform = NIM A (msform B') by rep lemma.
+    have h_inner_NIM_A : ∀ B' : List (Planar α),
+        (Planar.Pathed.insertionForest A_pl B').map msform =
+          Nonplanar.insertionMultiset A (msform B') := by
+      intro B'
+      symm
+      apply Nonplanar.insertionMultiset_eq_of_reps
+      · -- hosts hyp: ofList (A_pl.map mk) = A.
+        show (Multiset.ofList ((A.toList.map Quotient.out).map Nonplanar.mk) :
+              Multiset (Nonplanar α)) = A
+        rw [List.map_map]
+        have h_id : A.toList.map (Nonplanar.mk ∘ Quotient.out) = A.toList :=
+          (List.map_congr_left fun x _ => Quotient.out_eq x).trans (List.map_id _)
+        rw [h_id]
+        exact A.coe_toList
+      · -- guests hyp: ofList (B'.map mk) = msform B'.
+        rfl
+    -- RHS: (NIM B {v}).bind (NIM A ·). Outer NIM B {v} unfolds to (iF B_pl [ov]).map msform
+    -- via the rep lemma at the canonical reps for B (canonical) and [ov] for {v}.
+    have h_outer_NIM_B :
+        Nonplanar.insertionMultiset B {v} =
+          (Planar.Pathed.insertionForest B_pl [ov]).map msform := by
+      apply Nonplanar.insertionMultiset_eq_of_reps
+      · -- hosts hyp: ofList (B_pl.map mk) = B.
+        show (Multiset.ofList ((B.toList.map Quotient.out).map Nonplanar.mk) :
+              Multiset (Nonplanar α)) = B
+        rw [List.map_map]
+        have h_id : B.toList.map (Nonplanar.mk ∘ Quotient.out) = B.toList :=
+          (List.map_congr_left fun x _ => Quotient.out_eq x).trans (List.map_id _)
+        rw [h_id]
+        exact B.coe_toList
+      · -- guests hyp: ofList ([ov].map mk) = {v}.
+        show (Multiset.ofList ([Nonplanar.mk (Quotient.out v)]) :
+              Multiset (Nonplanar α)) = ({v} : Multiset _)
+        rw [show Nonplanar.mk (Quotient.out v) = v from Quotient.out_eq v]
+        rfl
+    rw [h_outer_NIM_B, Multiset.bind_map]
+    -- Now both sides are (iF B_pl [ov]).bind (something). Use bind_congr.
+    refine Multiset.bind_congr fun B' _ => ?_
+    exact h_inner_NIM_A B'
+
 /-- **Prop 2.7.iii** (Oudom-Guin 2004): for basis forests A, B, C, the
     multi-graft of `(A · B)` (disjoint-union product) into `C` distributes
     as a sum over partitions of C, with each part inserted into A vs B
@@ -447,217 +721,6 @@ theorem insertion_mul_distrib (A B C : Forest (Nonplanar α)) :
     rw [ih]
     -- Goal: of' a * S_B + (s.map of').sum * S_B = (of' a + (s.map of').sum) * S_B
     rw [add_mul]
-
-/-! ### §2: Prop 2.7.v — `∘` "associativity" up to shuffle Δ
-
-The headline combinatorial identity: when grafting `C` into `(A ∘ B)`,
-each tree of `C` can land at an `A`-vertex (preserved) or a `B`-vertex
-(from the inserted B). This splits C into "going into B" (which becomes
-guests of B in a recursive multi-graft) vs "going directly to A as
-siblings of B" (after B has been multi-grafted).
--/
-
-/-- **Deep substrate**: the combinatorial heart of Prop 2.7.v at the
-    basis level. Iterated multi-graft `NIM(NIM(A,B), C)` re-indexes as
-    a triple-bind over partitions of `C`.
-
-    `(NIM A B).bind (X ↦ NIM X C) =`
-    `  C.powerset.bind (C₁ ↦ (NIM B C₁).bind (X' ↦ NIM A (X' + (C - C₁))))`
-
-    Each tree of `C` either lands at an `A`-vertex (in the
-    "sibling-of-B" piece `C - C₁`) or at a `B`-vertex (in the
-    "guest-of-B" piece `C₁`, after `B` has been multi-grafted with that
-    piece). The triple-bind structure on the RHS sums over the
-    partition `C₁ + (C - C₁) = C`, then over multi-grafted-`B`-trees
-    `X' ∈ NIM B C₁`, then over the `A`-side insertions of the resulting
-    forest `X' + (C - C₁)`.
-
-    **TODO**: prove by descent from `Planar.Pathed.insertionForest`'s
-    associativity (Foissy 2021 §5), lifted through `Nonplanar.mk` + Perm
-    invariance. Major substrate, parallel to `insertionMultiset_add_host`. -/
-theorem _root_.RootedTree.Nonplanar.insertionMultiset_assoc
-    (A B C : Forest (Nonplanar α)) :
-    (letI : DecidableEq (Nonplanar α) := Classical.decEq _
-     (Nonplanar.insertionMultiset A B).bind
-        (fun X => Nonplanar.insertionMultiset X C)) =
-      (letI : DecidableEq (Nonplanar α) := Classical.decEq _
-       C.powerset.bind fun C₁ =>
-         (Nonplanar.insertionMultiset B C₁).bind fun X' =>
-           Nonplanar.insertionMultiset A (X' + (C - C₁))) := by
-  sorry
-
-/-- **Prop 2.7.v** (Oudom-Guin 2004): for basis forests A, B, C,
-
-    `(A ∘ B) ∘ C = A ∘ Σ_{C₁ ⊆ C} (B ∘ C₁) · (C - C₁)`
-
-    The substantive combinatorial heart. Restates the multi-graft
-    "associativity": grafting C into (A with B grafted in) equals
-    grafting "B with the going-into-B portion of C grafted in, alongside
-    the going-directly-to-A portion of C" into A.
-
-    Proved from `insertionMultiset_assoc` (the NIM-level triple-bind
-    identity) + bilinearity of `insertion` and `of'_add`. -/
-theorem insertion_assoc_shuffled (A B C : Forest (Nonplanar α)) :
-    insertion (R := R) (insertion (of' A) (of' B)) (of' C) =
-      insertion (R := R) (of' A)
-        ((letI : DecidableEq (Nonplanar α) := Classical.decEq _
-          C.powerset.map fun C₁ =>
-          op (unop (insertion (of' B) (of' C₁)) *
-              unop (of' (C - C₁)))).sum) := by
-  letI : DecidableEq (Nonplanar α) := Classical.decEq _
-  -- Reduce LHS to NIM form: `insertion (of' X) (of' Y) = insertionBasis X Y`.
-  -- The inner `insertion (of' A) (of' B) = ((NIM A B).map of').sum`.
-  -- Outer insertion is linear in the first argument; pushing through gives
-  -- `((NIM A B).bind (fun X => NIM X C).map of').sum`.
-  have hLHS : insertion (R := R) (insertion (of' A) (of' B)) (of' C) =
-      (((Nonplanar.insertionMultiset A B).bind
-        (fun X => Nonplanar.insertionMultiset X C)).map
-          (fun F' => (of' (R := R) F' : GrossmanLarson R α))).sum := by
-    rw [insertion_of'_of']
-    show insertion (R := R) (((Nonplanar.insertionMultiset A B).map
-            (fun F' => of' (R := R) F')).sum) (of' C) = _
-    -- Push `insertion · (of' C)` (linear in first arg) through the sum.
-    rw [Multiset.map_bind, Multiset.sum_bind]
-    -- Goal: insertion ((map of').sum) (of' C) = (bind (map of') ).sum  =  (map (sum ...)).sum
-    -- linearity in first arg of insertion: push sum out.
-    have hSumApp : ∀ (s : Multiset (GrossmanLarson R α)),
-        (insertion (R := R)).flip (of' C) s.sum = (s.map (fun x =>
-            (insertion (R := R)).flip (of' C) x)).sum := by
-      intro s
-      induction s using Multiset.induction with
-      | empty =>
-        rw [Multiset.sum_zero, Multiset.map_zero, Multiset.sum_zero]
-        exact LinearMap.map_zero _
-      | cons a s ih =>
-        rw [Multiset.sum_cons, Multiset.map_cons, Multiset.sum_cons,
-            LinearMap.map_add, ih]
-    rw [show insertion (R := R)
-          (((Nonplanar.insertionMultiset A B).map
-            (fun F' => of' (R := R) F')).sum) (of' C) =
-        (insertion (R := R)).flip (of' C)
-          (((Nonplanar.insertionMultiset A B).map
-            (fun F' => of' (R := R) F')).sum) from rfl]
-    rw [hSumApp]
-    rw [Multiset.map_map]
-    congr 1
-    apply Multiset.map_congr rfl
-    intros X _
-    show (insertion (R := R)).flip (of' C) (of' X) = _
-    rw [LinearMap.flip_apply, insertion_of'_of']
-    rfl
-  -- Reduce RHS to the same NIM form via `insertionMultiset_assoc`.
-  -- RHS: `insertion (of' A) (Σ_{C₁} op (unop (B ∘ C₁) * of' (C - C₁)))`.
-  -- The inner sum expands to `Σ_{C₁} Σ_{X' ∈ NIM(B, C₁)} of' (X' + (C-C₁))`,
-  -- which is `(C.powerset.bind (C₁ ↦ (NIM B C₁).map (X' ↦ X' + (C-C₁)))).map of').sum`.
-  -- Then `insertion (of' A) · ` (linear in second arg) pushes through to a
-  -- triple-bind, which equals `((NIM A B).bind (X ↦ NIM X C)).map of').sum` by
-  -- `insertionMultiset_assoc`.
-  have hRHS : insertion (R := R) (of' A)
-        ((C.powerset.map fun C₁ =>
-          op (unop (insertion (of' B) (of' C₁)) *
-              unop (of' (C - C₁)))).sum) =
-      ((C.powerset.bind fun C₁ =>
-          (Nonplanar.insertionMultiset B C₁).bind fun X' =>
-            Nonplanar.insertionMultiset A (X' + (C - C₁))).map
-              (fun F' => (of' (R := R) F' : GrossmanLarson R α))).sum := by
-    -- Push linearity (second arg) of insertion through the C₁-sum.
-    have hSumApp : ∀ (s : Multiset (GrossmanLarson R α)),
-        insertion (R := R) (of' A) s.sum = (s.map (fun x =>
-            insertion (R := R) (of' A) x)).sum := by
-      intro s
-      induction s using Multiset.induction with
-      | empty =>
-        rw [Multiset.sum_zero, Multiset.map_zero, Multiset.sum_zero]
-        exact LinearMap.map_zero _
-      | cons a s ih =>
-        rw [Multiset.sum_cons, Multiset.map_cons, Multiset.sum_cons,
-            LinearMap.map_add, ih]
-    rw [hSumApp, Multiset.map_map]
-    -- Now: ((C.powerset.map (fun C₁ => insertion (of' A) (op (...)))).sum.
-    -- For each C₁: insertion (of' A) (op (unop (B ∘ C₁) * of' (C - C₁))).
-    -- We need to expand `op (unop (B ∘ C₁) * of' (C - C₁))` as
-    -- ((NIM B C₁).map (fun X' => of' (X' + (C-C₁)))).sum (in GL).
-    -- Then push the inner insertion through that sum (linear in second arg).
-    -- Finally, the inner `insertion (of' A) (of' (X' + (C-C₁))) =
-    --   insertionBasis A (X' + (C-C₁)) = ((NIM A (X' + (C-C₁))).map of').sum`.
-    -- Result: ((C.powerset.bind (...)).map of').sum.
-    rw [show (C.powerset.bind fun C₁ =>
-          (Nonplanar.insertionMultiset B C₁).bind fun X' =>
-            Nonplanar.insertionMultiset A (X' + (C - C₁))).map
-              (fun F' => (of' (R := R) F' : GrossmanLarson R α))
-        = C.powerset.bind (fun C₁ =>
-            ((Nonplanar.insertionMultiset B C₁).bind fun X' =>
-              Nonplanar.insertionMultiset A (X' + (C - C₁))).map
-                (fun F' => (of' (R := R) F' : GrossmanLarson R α))) from
-      Multiset.map_bind _ _ _]
-    rw [Multiset.sum_bind]
-    congr 1
-    apply Multiset.map_congr rfl
-    intros C₁ _
-    -- Inner equality at fixed C₁.
-    -- LHS_inner: ((Function.comp ...) C₁) = insertion (of' A) (op (unop (B ∘ C₁) * of' (C - C₁)))
-    -- RHS_inner: (((NIM B C₁).bind (X' ↦ NIM A (X' + (C-C₁)))).map of').sum
-    -- Step 1: unfold the op (unop _ * unop _) as a sum of of' (X' + (C-C₁)).
-    have h_op_unop_eq :
-        op (unop (insertion (R := R) (of' B) (of' C₁)) *
-            unop (of' (R := R) (C - C₁) : GrossmanLarson R α))
-        = ((Nonplanar.insertionMultiset B C₁).map
-            (fun X' => (of' (R := R) (X' + (C - C₁)) : GrossmanLarson R α))).sum := by
-      rw [insertion_of'_of']
-      -- LHS = op (unop (((NIM B C₁).map of').sum) * unop (of' (C - C₁)))
-      -- unop is identity; the * is CK multiplication. Push * through sum on the left.
-      show (((Nonplanar.insertionMultiset B C₁).map
-              (fun F' => (ConnesKreimer.of' (R := R) F' :
-                ConnesKreimer R (Nonplanar α)))).sum *
-            (ConnesKreimer.of' (R := R) (C - C₁) :
-                ConnesKreimer R (Nonplanar α)) :
-              ConnesKreimer R (Nonplanar α)) =
-          ((Nonplanar.insertionMultiset B C₁).map
-            (fun X' => (ConnesKreimer.of' (R := R) (X' + (C - C₁)) :
-              ConnesKreimer R (Nonplanar α)))).sum
-      rw [← Multiset.sum_map_mul_right]
-      apply congr_arg Multiset.sum
-      apply Multiset.map_congr rfl
-      intros X' _
-      show (ConnesKreimer.of' (R := R) X' : ConnesKreimer R (Nonplanar α)) *
-            ConnesKreimer.of' (R := R) (C - C₁) =
-          ConnesKreimer.of' (R := R) (X' + (C - C₁))
-      rw [ConnesKreimer.of'_add]
-    show insertion (R := R) (of' A)
-          (op (unop (insertion (R := R) (of' B) (of' C₁)) *
-               unop (of' (R := R) (C - C₁) : GrossmanLarson R α))) = _
-    rw [h_op_unop_eq]
-    -- Now LHS = insertion (of' A) (((NIM B C₁).map (X' ↦ of' (X' + (C-C₁)))).sum)
-    -- Push insertion through the X'-sum.
-    have hSumApp' : ∀ (s : Multiset (GrossmanLarson R α)),
-        insertion (R := R) (of' A) s.sum = (s.map (fun x =>
-            insertion (R := R) (of' A) x)).sum := by
-      intro s
-      induction s using Multiset.induction with
-      | empty =>
-        rw [Multiset.sum_zero, Multiset.map_zero, Multiset.sum_zero]
-        exact LinearMap.map_zero _
-      | cons a s ih =>
-        rw [Multiset.sum_cons, Multiset.map_cons, Multiset.sum_cons,
-            LinearMap.map_add, ih]
-    rw [hSumApp', Multiset.map_map]
-    -- LHS = ((NIM B C₁).map (X' ↦ insertion (of' A) (of' (X' + (C-C₁))))).sum
-    -- For each X': insertion (of' A) (of' (X' + (C-C₁))) = ((NIM A (X' + (C-C₁))).map of').sum.
-    rw [show ((Nonplanar.insertionMultiset B C₁).bind fun X' =>
-          Nonplanar.insertionMultiset A (X' + (C - C₁))).map
-            (fun F' => (of' (R := R) F' : GrossmanLarson R α))
-        = (Nonplanar.insertionMultiset B C₁).bind (fun X' =>
-            (Nonplanar.insertionMultiset A (X' + (C - C₁))).map
-              (fun F' => (of' (R := R) F' : GrossmanLarson R α))) from
-      Multiset.map_bind _ _ _]
-    rw [Multiset.sum_bind]
-    apply congr_arg Multiset.sum
-    apply Multiset.map_congr rfl
-    intros X' _
-    show insertion (R := R) (of' A) (of' (R := R) (X' + (C - C₁))) = _
-    rw [insertion_of'_of']
-    rfl
-  rw [hLHS, hRHS, Nonplanar.insertionMultiset_assoc]
 
 /-! ### §3: Cocommutativity of the shuffle sum
 
@@ -987,87 +1050,6 @@ theorem insertion_mul_distrib_gen
             unop (insertion (of' (R := R) Y) (of' (C - C₁))))
     rw [smul_mul_assoc]; rfl
 
-/-- Generalized `insertion_assoc_shuffled`: the LEFT factor of the outer
-    iterated `insertion` may be ANY GL element. Reduces by linearity to
-    the basis case. -/
-theorem insertion_assoc_shuffled_gen
-    (X : GrossmanLarson R α) (B C : Forest (Nonplanar α)) :
-    insertion (R := R) (insertion X (of' B)) (of' C) =
-      insertion (R := R) X
-        ((letI : DecidableEq (Nonplanar α) := Classical.decEq _
-          C.powerset.map fun C₁ =>
-          op (unop (insertion (of' B) (of' C₁)) *
-              unop (of' (C - C₁)))).sum) := by
-  letI : DecidableEq (Nonplanar α) := Classical.decEq _
-  -- Abbreviate the RHS-inner sum for brevity.
-  set rhsSum : GrossmanLarson R α :=
-    (C.powerset.map fun C₁ =>
-      op (unop (insertion (of' B) (of' C₁)) *
-          unop (of' (C - C₁)))).sum with rhsSum_def
-  refine Finsupp.induction_linear X ?_ ?_ ?_
-  · -- X = 0 case. Use bilinearity of insertion in both args.
-    -- LHS: insertion (insertion 0 (of' B)) (of' C). Use flip on insertion to
-    -- treat first arg as the linear argument.
-    show ((insertion : GrossmanLarson R α →ₗ[R]
-              GrossmanLarson R α →ₗ[R] GrossmanLarson R α).flip (of' C))
-              (((insertion : GrossmanLarson R α →ₗ[R]
-                  GrossmanLarson R α →ₗ[R] GrossmanLarson R α).flip
-                  (of' B)) 0) =
-        ((insertion : GrossmanLarson R α →ₗ[R]
-              GrossmanLarson R α →ₗ[R] GrossmanLarson R α).flip rhsSum) 0
-    rw [LinearMap.map_zero, LinearMap.map_zero, LinearMap.map_zero]
-  · -- additive
-    intro X₁ X₂ ih₁ ih₂
-    -- Goal: insertion (insertion (X₁+X₂) (of' B)) (of' C) = insertion (X₁+X₂) rhsSum
-    have h_inner_split : insertion (R := R) (X₁ + X₂) (of' B) =
-        insertion (R := R) X₁ (of' B) + insertion (R := R) X₂ (of' B) := by
-      have := ((insertion : GrossmanLarson R α →ₗ[R]
-        GrossmanLarson R α →ₗ[R] GrossmanLarson R α).flip (of' B)).map_add X₁ X₂
-      exact this
-    rw [h_inner_split]
-    have h_outer_split : insertion (R := R)
-        (insertion (R := R) X₁ (of' B) + insertion (R := R) X₂ (of' B)) (of' C) =
-        insertion (R := R) (insertion X₁ (of' B)) (of' C) +
-        insertion (R := R) (insertion X₂ (of' B)) (of' C) := by
-      have := ((insertion : GrossmanLarson R α →ₗ[R]
-        GrossmanLarson R α →ₗ[R] GrossmanLarson R α).flip (of' C)).map_add
-          (insertion X₁ (of' B)) (insertion X₂ (of' B))
-      exact this
-    rw [h_outer_split]
-    have h_rhs_split : insertion (R := R) (X₁ + X₂) rhsSum =
-        insertion (R := R) X₁ rhsSum + insertion (R := R) X₂ rhsSum := by
-      have := ((insertion : GrossmanLarson R α →ₗ[R]
-        GrossmanLarson R α →ₗ[R] GrossmanLarson R α).flip rhsSum).map_add X₁ X₂
-      exact this
-    rw [h_rhs_split, ih₁, ih₂]
-  · -- single basis case
-    intro A c
-    rw [show (Finsupp.single A c : GrossmanLarson R α) = c • (of' A : GrossmanLarson R α)
-        from (Finsupp.smul_single_one A c).symm]
-    -- Inner: insertion (c • of' A) (of' B) = c • insertion (of' A) (of' B)
-    have h_inner_smul : insertion (R := R) (c • (of' A : GrossmanLarson R α)) (of' B) =
-        c • insertion (R := R) (of' A) (of' B) := by
-      have := ((insertion : GrossmanLarson R α →ₗ[R]
-        GrossmanLarson R α →ₗ[R] GrossmanLarson R α).flip (of' B)).map_smul c (of' A)
-      exact this
-    rw [h_inner_smul]
-    -- Outer LHS
-    have h_outer_smul : insertion (R := R)
-        (c • insertion (R := R) (of' A) (of' B)) (of' C) =
-        c • insertion (R := R) (insertion (R := R) (of' A) (of' B)) (of' C) := by
-      have := ((insertion : GrossmanLarson R α →ₗ[R]
-        GrossmanLarson R α →ₗ[R] GrossmanLarson R α).flip (of' C)).map_smul c
-          (insertion (R := R) (of' A) (of' B))
-      exact this
-    rw [h_outer_smul]
-    -- RHS
-    have h_rhs_smul : insertion (R := R) (c • (of' A : GrossmanLarson R α)) rhsSum =
-        c • insertion (R := R) (of' A) rhsSum := by
-      have := ((insertion : GrossmanLarson R α →ₗ[R]
-        GrossmanLarson R α →ₗ[R] GrossmanLarson R α).flip rhsSum).map_smul c (of' A)
-      exact this
-    rw [h_rhs_smul, insertion_assoc_shuffled A B C]
-
 /-! ### §4b: Lemma 2.10's chain — `mul_assoc_basis` proved
 
 The chain expands `(of'A * of'B) * of'C` step-by-step:
@@ -1151,8 +1133,10 @@ private theorem sum_mul_of' (s : Multiset (GrossmanLarson R α))
 
 /-- Basis-form rewrite of LHS `((of' F₁) * of' F₂) * of' F₃` as a quadruple-bind
     sum. The outer two binds come from the Foissy-form expansion; the inner
-    two come from `insertionMultiset_add_host` applied to `NIM (X + (F₂-B₁)) C₁`. -/
-private theorem lhs_quadruple_form (F₁ F₂ F₃ : Forest (Nonplanar α)) :
+    two come from `insertionMultiset_add_host` applied to `NIM (X + (F₂-B₁)) C₁`.
+    Public: consumed by `GrossmanLarsonMonoid.lean` to identify the
+    associativity LHS / RHS at the multiset-indexing level (R-generic). -/
+theorem lhs_quadruple_form (F₁ F₂ F₃ : Forest (Nonplanar α)) :
     ((of' F₁ : GrossmanLarson R α) * of' F₂) * of' F₃ =
       (letI : DecidableEq (Nonplanar α) := Classical.decEq _
        F₂.powerset.bind fun B₁ =>
@@ -1217,8 +1201,10 @@ private theorem lhs_quadruple_form (F₁ F₂ F₃ : Forest (Nonplanar α)) :
 
     Σ_{C₁' ⊆ F₃, Z ∈ NIM F₂ C₁', P_Z ⊆ Z, P_F ⊆ F₃-C₁', W ∈ NIM F₁ (P_Z+P_F)}
       of' (W + (Z - P_Z) + ((F₃-C₁') - P_F))
--/
-private theorem rhs_quintuple_form (F₁ F₂ F₃ : Forest (Nonplanar α)) :
+
+    Public: consumed by `GrossmanLarsonMonoid.lean`, paired with
+    `lhs_quadruple_form` to derive R-generic associativity. -/
+theorem rhs_quintuple_form (F₁ F₂ F₃ : Forest (Nonplanar α)) :
     (of' F₁ : GrossmanLarson R α) * (of' F₂ * of' F₃) =
       (letI : DecidableEq (Nonplanar α) := Classical.decEq _
        F₃.powerset.bind fun C₁' =>
@@ -1281,180 +1267,6 @@ private theorem rhs_quintuple_form (F₁ F₂ F₃ : Forest (Nonplanar α)) :
   have h_sub : (Z + (F₃ - C₁')) - (P_Z + P_F) = (Z - P_Z) + ((F₃ - C₁') - P_F) :=
     (tsub_add_tsub_comm hP_Z_le hP_F_le).symm
   rw [h_sub]
-
-/-- Bridge form: LHS expressed as a 5-fold sum after applying
-    `insertionMultiset_assoc F₁ B₁ D` to the inner `(NIM F₁ B₁).bind (X => NIM X D)`.
-
-    Σ_{B₁⊆F₂, C₁⊆F₃, D⊆C₁, D₁⊆D, X'∈NIM B₁ D₁, YA∈NIM F₁ (X'+(D-D₁)), YB∈NIM (F₂-B₁) (C₁-D)}
-      of' (YA + YB + (F₃-C₁))
--/
-private theorem lhs_after_assoc (F₁ F₂ F₃ : Forest (Nonplanar α)) :
-    ((of' F₁ : GrossmanLarson R α) * of' F₂) * of' F₃ =
-      (letI : DecidableEq (Nonplanar α) := Classical.decEq _
-       F₂.powerset.bind fun B₁ =>
-        F₃.powerset.bind fun C₁ =>
-          C₁.powerset.bind fun D =>
-            D.powerset.bind fun D₁ =>
-              (Nonplanar.insertionMultiset B₁ D₁).bind fun X' =>
-                ((Nonplanar.insertionMultiset F₁ (X' + (D - D₁))) ×ˢ
-                  (Nonplanar.insertionMultiset (F₂ - B₁) (C₁ - D))).map
-                    fun p => (of' (R := R) (p.1 + p.2 + (F₃ - C₁)) :
-                      GrossmanLarson R α)).sum := by
-  letI : DecidableEq (Nonplanar α) := Classical.decEq _
-  rw [lhs_quadruple_form]
-  -- Reorder bind: (NIM F₁ B₁).bind (X => F₃.powerset.bind (C₁ => C₁.powerset.bind (D => ...)))
-  -- needs to become F₃.powerset.bind (C₁ => C₁.powerset.bind (D => (NIM F₁ B₁).bind (X => ...))).
-  -- Step 1: pull out F₃.powerset and C₁.powerset binds via Multiset.bind_bind (swap).
-  apply congr_arg Multiset.sum
-  apply Multiset.bind_congr
-  intros B₁ _
-  -- Goal: (NIM F₁ B₁).bind (X => F₃.powerset.bind (C₁ => C₁.powerset.bind (D => (NIM X D ×ˢ M_YB).map ...)))
-  --     = F₃.powerset.bind (C₁ => C₁.powerset.bind (D => D.powerset.bind (D₁ => (NIM B₁ D₁).bind (X' => ...))))
-  -- Step 2: swap the OUTER (NIM F₁ B₁).bind with F₃.powerset.bind.
-  rw [Multiset.bind_bind
-        (Nonplanar.insertionMultiset F₁ B₁) F₃.powerset]
-  -- Now LHS is F₃.powerset.bind (C₁ => (NIM F₁ B₁).bind (X => C₁.powerset.bind (D => ...))).
-  apply Multiset.bind_congr
-  intros C₁ _
-  rw [Multiset.bind_bind
-        (Nonplanar.insertionMultiset F₁ B₁) C₁.powerset]
-  apply Multiset.bind_congr
-  intros D _
-  -- Now: (NIM F₁ B₁).bind (X => (NIM X D ×ˢ M_YB).map ...)
-  --    = D.powerset.bind (D₁ => (NIM B₁ D₁).bind (X' => (NIM F₁ (X' + (D-D₁)) ×ˢ M_YB).map ...))
-  set M_YB : Multiset (Forest (Nonplanar α)) :=
-    Nonplanar.insertionMultiset (F₂ - B₁) (C₁ - D) with hM_YB
-  set f : Forest (Nonplanar α) → Multiset (GrossmanLarson R α) :=
-    fun YA => M_YB.map fun YB => (of' (R := R) (YA + YB + (F₃ - C₁)) :
-      GrossmanLarson R α) with hf
-  -- Show: (NIM F₁ B₁).bind (X => (NIM X D ×ˢ M_YB).map ...) = (NIM F₁ B₁).bind (X => (NIM X D).bind f).
-  rw [show (Nonplanar.insertionMultiset F₁ B₁).bind (fun X =>
-        ((Nonplanar.insertionMultiset X D) ×ˢ M_YB).map
-          (fun p => (of' (R := R) (p.1 + p.2 + (F₃ - C₁)) :
-            GrossmanLarson R α))) =
-      (Nonplanar.insertionMultiset F₁ B₁).bind (fun X =>
-        (Nonplanar.insertionMultiset X D).bind f) from by
-    apply Multiset.bind_congr
-    intros X _
-    show ((Nonplanar.insertionMultiset X D).bind (fun a => M_YB.map (Prod.mk a))).map _ =
-      (Nonplanar.insertionMultiset X D).bind (fun YA =>
-        M_YB.map (fun YB => (of' (R := R) (YA + YB + (F₃ - C₁)) :
-          GrossmanLarson R α)))
-    rw [Multiset.map_bind]
-    apply Multiset.bind_congr
-    intros YA _
-    rw [Multiset.map_map]
-    rfl]
-  -- Apply bind-bind associativity: bind (bind a b) c = bind a (fun x => bind (b x) c).
-  -- Goal: (NIM F₁ B₁).bind (X => (NIM X D).bind f) = ((NIM F₁ B₁).bind (X => NIM X D)).bind f.
-  rw [show (Nonplanar.insertionMultiset F₁ B₁).bind
-            (fun X => (Nonplanar.insertionMultiset X D).bind f) =
-          ((Nonplanar.insertionMultiset F₁ B₁).bind
-            (fun X => Nonplanar.insertionMultiset X D)).bind f from by
-    rw [Multiset.bind_assoc]]
-  -- Apply insertionMultiset_assoc.
-  rw [Nonplanar.insertionMultiset_assoc]
-  -- Goal: (D.powerset.bind (D₁ => (NIM B₁ D₁).bind (X' => NIM F₁ (X' + (D-D₁))))).bind f
-  --     = D.powerset.bind (D₁ => (NIM B₁ D₁).bind (X' => (NIM F₁ (X' + (D-D₁)) ×ˢ M_YB).map ...))
-  rw [Multiset.bind_assoc]
-  apply Multiset.bind_congr
-  intros D₁ _
-  rw [Multiset.bind_assoc]
-  apply Multiset.bind_congr
-  intros X' _
-  -- Goal: (NIM F₁ (X' + (D-D₁))).bind f = ((NIM F₁ (X'+(D-D₁))) ×ˢ M_YB).map ...
-  rw [hf]
-  rw [show ((Nonplanar.insertionMultiset F₁ (X' + (D - D₁))) ×ˢ M_YB).map
-        (fun p => (of' (R := R) (p.1 + p.2 + (F₃ - C₁)) :
-          GrossmanLarson R α)) =
-      (Nonplanar.insertionMultiset F₁ (X' + (D - D₁))).bind (fun YA =>
-        M_YB.map (fun YB => (of' (R := R) (YA + YB + (F₃ - C₁)) :
-          GrossmanLarson R α))) from by
-    show ((Nonplanar.insertionMultiset F₁ (X' + (D - D₁))).bind
-            (fun a => M_YB.map (Prod.mk a))).map _ = _
-    rw [Multiset.map_bind]
-    apply Multiset.bind_congr
-    intros YA _
-    rw [Multiset.map_map]
-    rfl]
-
-/-! #### Bridge between LHS and RHS NIM forms
-
-After `lhs_after_assoc` + `rhs_quintuple_form`, both sides are NIM-bind sums
-over partitions of F₂ and F₃. The bridge uses the **labeled host
-decomposition lemma**: summing over `(B₁ ⊆ F₂, X' ∈ NIM B₁ D', YB ∈ NIM (F₂-B₁) (C₁'-D'))`
-gives a multiset of `(X', YB)` pairs that matches `(Z, P_Z) ↦ (P_Z, Z-P_Z)`
-for `Z ∈ NIM F₂ C₁'`.
-
-This is essentially `insertionMultiset_add_host` "labeled" — it tracks not just
-which trees of `Z` came from grafting into B₁ vs F₂-B₁ at the multiset-quotient
-level, but as a labeled structure.
-
-The bijection works because each tree of `Z = X' + YB ∈ NIM F₂ C₁'` corresponds
-to a unique tree of F₂ (via the multi-graft semantics), so picking `P_Z ⊆ Z`
-determines `B₁ ⊆ F₂` (the corresponding sub-multiset) uniquely.
--/
-
-/-- **Labeled host decomposition** for `Nonplanar.insertionMultiset`. Strengthens
-    `insertionMultiset_add_host` by tracking the (X', YB) pair separately rather
-    than just `X' + YB`. Summing over all sub-host choices `B₁ ⊆ F₂` and all
-    sub-guest choices `D' ⊆ C₁'` gives the same multiset of pairs as enumerating
-    `Z ∈ NIM F₂ C₁'` paired with all sub-multiset choices `P_Z ⊆ Z`.
-
-    The "missing" labeled-decomposition substrate that bridges
-    `lhs_after_assoc` to `rhs_quintuple_form` in Oudom-Guin's chain. Proved by
-    descent through `Planar.Pathed.insertionForest`'s host-tree-correspondence
-    structure.
-
-    **TODO** (deep substrate, parallel to `insertionMultiset_add_host`/_assoc).
-    Full proof requires the planar host-bijection from `MultiGraftNonplanar.lean`. -/
-private theorem _root_.RootedTree.Nonplanar.insertionMultiset_labeled_decomp
-    (F₂ C₁' : Forest (Nonplanar α)) :
-    (letI : DecidableEq (Nonplanar α) := Classical.decEq _
-     F₂.powerset.bind fun B₁ =>
-      C₁'.powerset.bind fun D' =>
-        ((Nonplanar.insertionMultiset B₁ D') ×ˢ
-          (Nonplanar.insertionMultiset (F₂ - B₁) (C₁' - D')))) =
-      (letI : DecidableEq (Nonplanar α) := Classical.decEq _
-       (Nonplanar.insertionMultiset F₂ C₁').bind fun Z =>
-        Z.powerset.map fun P_Z => (P_Z, Z - P_Z)) := by
-  sorry
-
-theorem mul_assoc_basis_via_oudom_guin (F₁ F₂ F₃ : Forest (Nonplanar α)) :
-    ((of' F₁ : GrossmanLarson R α) * of' F₂) * of' F₃ =
-      of' F₁ * (of' F₂ * of' F₃) := by
-  letI : DecidableEq (Nonplanar α) := Classical.decEq _
-  -- The proof reduces both sides to a common quadruple-`bind` form over
-  -- partitions of F₂ and F₃ and `Nonplanar.insertionMultiset` (NIM) bind
-  -- chains. The bridge between them uses
-  -- `Nonplanar.insertionMultiset_add_host` (host distributivity),
-  -- `Nonplanar.insertionMultiset_assoc` (NIM-bind associativity), and
-  -- `Nonplanar.insertionMultiset_labeled_decomp` (labeled host decomposition),
-  -- all present as substrate sorries lower in this file or above.
-  --
-  -- LHS structure (after `lhs_after_assoc`):
-  -- Σ_{B₁⊆F₂, C₁⊆F₃, D⊆C₁, D₁⊆D, X'∈NIM B₁ D₁, YA∈NIM F₁ (X'+(D-D₁)),
-  --   YB∈NIM (F₂-B₁) (C₁-D)} of' (YA + YB + (F₃-C₁))
-  --
-  -- RHS structure (after `rhs_quintuple_form`):
-  -- Σ_{C₁'⊆F₃, Z∈NIM F₂ C₁', P_Z⊆Z, P_F⊆F₃-C₁', W∈NIM F₁ (P_Z+P_F)}
-  --   of' (W + (Z-P_Z) + ((F₃-C₁')-P_F))
-  --
-  -- Bridge bijection (B₁, C₁, D, D₁, X', YA, YB) ↔ (C₁', Z, P_Z, P_F, W):
-  --   C₁' = D₁ + (C₁-D),  P_F = D - D₁
-  --   Z = X' + YB,  P_Z = X',  W = YA.
-  --   Inverse: (C₁', P_F, P_Z) gives (D₁ = "P_Z's host part of C₁'",
-  --     D = D₁ + P_F, C₁ = D + (C₁'-D₁) = P_F + C₁').
-  --
-  -- The (B₁, X', YB) ↔ (Z, P_Z) decomposition uses the labeled NIM bridge.
-  -- The (C₁, D, D₁) ↔ (C₁', P_F, D₁) is a `Multiset.powerset_add`-style reindex.
-  rw [lhs_after_assoc, rhs_quintuple_form]
-  -- Below we'd apply `Multiset.powerset_add`, swap binds, and apply
-  -- `insertionMultiset_labeled_decomp` to bridge.
-  -- The combinatorial identity is genuine (verified by examples), but its full
-  -- formalization requires ~200+ LOC of multiset manipulation plus the
-  -- labeled-decomp substrate. Deferred as scaffolding for future work.
-  sorry
 
 end GrossmanLarson
 

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonMonoid.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonMonoid.lean
@@ -1,0 +1,375 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Algebra.RootedTree.GrossmanLarson
+import Linglib.Core.Algebra.RootedTree.GrossmanLarsonAssoc
+import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridge
+
+set_option autoImplicit false
+
+/-!
+# Grossman-Larson monoid structure
+[grossman-larson-1989] [foissy-2021] [oudom-guin-2008]
+
+Completes the multiplicative structure of `GrossmanLarson R α` (defined in
+`GrossmanLarson.lean`) by lifting the integer-case associativity
+`GrossmanLarson.mul_assoc_basis_via_oudom_guin_pbw` (proved sorry-free in
+`OudomGuinBridge.lean` via Oudom-Guin + PBW) to arbitrary
+`CommSemiring R`, then registering `Semigroup`/`Monoid` instances.
+
+## Architecture
+
+The lift uses the R-generic, basis-form closed expressions
+`lhs_quadruple_form` and `rhs_quintuple_form` (in `GrossmanLarsonAssoc.lean`),
+which present both sides of `(of' F₁) * (of' F₂) * (of' F₃) = (of' F₁) *
+((of' F₂) * (of' F₃))` as `(M.map of').sum` for R-independent multisets `M
+: Multiset (Forest (Nonplanar α))`. The integer case implies the indexing
+multisets are equal (via `Finsupp` coefficient extraction + Nat→ℤ
+injectivity), and that R-free equality re-applies for any R.
+
+## Main results (all `α : Type*`-generic)
+
+* `mul_assoc_basis` (R-generic) : `(of' F₁ * of' F₂) * of' F₃ =
+  of' F₁ * (of' F₂ * of' F₃)` on basis vectors.
+* `mul_assoc` (R-generic) : full associativity, by triple
+  `Finsupp.addHom_ext`.
+* `instSemigroup`, `instMonoid` instances.
+
+## Status
+
+`[UPSTREAM]` candidate. All results sorry-free.
+-/
+
+namespace RootedTree
+
+namespace GrossmanLarson
+
+variable {α : Type*}
+
+/-! ### `(M.map of').sum` coefficient extraction (multiset injectivity) -/
+
+/-- Coefficient of `((M.map of').sum)` at `H` is `M.count H`, mapped from
+    Nat to R. Holds for any `CommSemiring R`. Used to extract multiset
+    equality from sum equality at `R = ℤ`. -/
+private theorem sum_of'_apply
+    {R : Type*} [CommSemiring R] [DecidableEq (Nonplanar α)]
+    (M : Multiset (Forest (Nonplanar α))) (H : Forest (Nonplanar α)) :
+    (((M.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum :
+        GrossmanLarson R α) H : R) = (M.count H : R) := by
+  induction M using Multiset.induction with
+  | empty =>
+    rw [Multiset.map_zero, Multiset.sum_zero, Multiset.count_zero, Nat.cast_zero]
+    rfl
+  | cons F M ih =>
+    rw [Multiset.map_cons, Multiset.sum_cons, Multiset.count_cons]
+    -- Step 1: split + through FunLike (Finsupp.add_apply).
+    show ((of' (R := R) F : GrossmanLarson R α) +
+            (M.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum) H =
+          ((M.count H + (if H = F then 1 else 0) : ℕ) : R)
+    rw [show ((of' (R := R) F : GrossmanLarson R α) +
+              (M.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum) H =
+            (of' (R := R) F : GrossmanLarson R α) H +
+            ((M.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum) H
+          from Finsupp.add_apply _ _ _]
+    rw [ih]
+    -- Step 2: of' F = Finsupp.single F 1.
+    show (Finsupp.single F (1 : R)) H + (M.count H : R) =
+          ((M.count H + (if H = F then 1 else 0) : ℕ) : R)
+    rw [Finsupp.single_apply]
+    -- Goal: (if F = H then (1 : R) else 0) + (M.count H : R)
+    --     = ((M.count H + (if H = F then 1 else 0) : ℕ) : R)
+    rw [Nat.cast_add, Nat.cast_ite, Nat.cast_one, Nat.cast_zero]
+    by_cases hFH : F = H
+    · rw [if_pos hFH, if_pos hFH.symm, add_comm]
+    · rw [if_neg hFH, if_neg (fun h => hFH h.symm), add_comm]
+
+/-- Multiset equality at `R = ℤ` from sum equality. -/
+private theorem multiset_eq_of_sum_eq_int [DecidableEq (Nonplanar α)]
+    (M₁ M₂ : Multiset (Forest (Nonplanar α)))
+    (h : ((M₁.map (fun F => (of' (R := ℤ) F : GrossmanLarson ℤ α))).sum :
+          GrossmanLarson ℤ α) =
+         (M₂.map (fun F => (of' (R := ℤ) F : GrossmanLarson ℤ α))).sum) :
+    M₁ = M₂ := by
+  apply Multiset.ext.mpr
+  intro H
+  have h1 := sum_of'_apply (R := ℤ) M₁ H
+  have h2 := sum_of'_apply (R := ℤ) M₂ H
+  -- From h: the sums are equal as GL ℤ α, so their FunLike values at H agree.
+  have heq : ((((M₁.map (fun F => (of' (R := ℤ) F : GrossmanLarson ℤ α))).sum :
+                GrossmanLarson ℤ α) H : ℤ)) =
+             (((M₂.map (fun F => (of' (R := ℤ) F : GrossmanLarson ℤ α))).sum :
+                GrossmanLarson ℤ α) H : ℤ) := by
+    rw [h]
+  rw [h1, h2] at heq
+  exact_mod_cast heq
+
+/-- Map-then-sum of `of'` is preserved under multiset equality (R-generic). -/
+private theorem sum_of'_congr
+    {R : Type*} [CommSemiring R]
+    {M₁ M₂ : Multiset (Forest (Nonplanar α))} (h : M₁ = M₂) :
+    ((M₁.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum :
+      GrossmanLarson R α) =
+    (M₂.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum := by
+  rw [h]
+
+/-! ### `mul_assoc_basis` (R-generic) via the ℤ-case + multiset lift -/
+
+/-- The LHS indexing multiset for `(of' F₁ * of' F₂) * of' F₃`.
+    R-independent; abstracts `lhs_quadruple_form`'s closed form. -/
+private noncomputable def lhsMultiset
+    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
+    Multiset (Forest (Nonplanar α)) :=
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  F₂.powerset.bind fun B₁ =>
+    (Nonplanar.insertionMultiset F₁ B₁).bind fun X =>
+      F₃.powerset.bind fun C₁ =>
+        C₁.powerset.bind fun D =>
+          ((Nonplanar.insertionMultiset X D) ×ˢ
+            (Nonplanar.insertionMultiset (F₂ - B₁) (C₁ - D))).map
+              fun p => p.1 + p.2 + (F₃ - C₁)
+
+/-- The RHS indexing multiset for `of' F₁ * (of' F₂ * of' F₃)`. -/
+private noncomputable def rhsMultiset
+    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
+    Multiset (Forest (Nonplanar α)) :=
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  F₃.powerset.bind fun C₁' =>
+    (Nonplanar.insertionMultiset F₂ C₁').bind fun Z =>
+      Z.powerset.bind fun P_Z =>
+        (F₃ - C₁').powerset.bind fun P_F =>
+          (Nonplanar.insertionMultiset F₁ (P_Z + P_F)).map
+            fun W => W + ((Z - P_Z) + ((F₃ - C₁') - P_F))
+
+/-- LHS = sum-of-`of'` over `lhsMultiset` (R-generic). -/
+private theorem lhs_eq_sum_of'
+    {R : Type*} [CommSemiring R]
+    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
+    ((of' F₁ : GrossmanLarson R α) * of' F₂) * of' F₃ =
+      (((lhsMultiset F₁ F₂ F₃).map
+          (fun F => (of' (R := R) F : GrossmanLarson R α))).sum :
+        GrossmanLarson R α) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  rw [lhs_quadruple_form]
+  -- Goal: nested-bind sum with `of'` inside = (lhsMultiset.map of').sum
+  -- Push `map of'` outside by induction over the binds.
+  unfold lhsMultiset
+  -- The inner-most layer: `(...).map fun p => of' (p.1+p.2+(F₃-C₁))`
+  --  vs. `((...).map fun p => p.1+p.2+(F₃-C₁)).map of'` — Multiset.map_map.
+  -- We turn the nested binds into one bind via Multiset.map_bind on each layer.
+  -- Equivalent: rewrite `(A.bind f).map g = A.bind (fun a => (f a).map g)`.
+  simp only [Multiset.map_bind, Multiset.map_map, Function.comp]
+
+/-- RHS = sum-of-`of'` over `rhsMultiset` (R-generic). -/
+private theorem rhs_eq_sum_of'
+    {R : Type*} [CommSemiring R]
+    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
+    (of' F₁ : GrossmanLarson R α) * (of' F₂ * of' F₃) =
+      (((rhsMultiset F₁ F₂ F₃).map
+          (fun F => (of' (R := R) F : GrossmanLarson R α))).sum :
+        GrossmanLarson R α) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  rw [rhs_quintuple_form]
+  unfold rhsMultiset
+  simp only [Multiset.map_bind, Multiset.map_map, Function.comp]
+
+/-- The LHS and RHS indexing multisets are equal (R-free). Proved by
+    invoking the closed integer case `mul_assoc_basis_via_oudom_guin_pbw`
+    and pulling out the multiset equality via `Finsupp` coefficient
+    extraction. -/
+private theorem lhsMultiset_eq_rhsMultiset [DecidableEq (Nonplanar α)]
+    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
+    lhsMultiset F₁ F₂ F₃ = rhsMultiset F₁ F₂ F₃ := by
+  apply multiset_eq_of_sum_eq_int
+  -- Reduce to associativity equation at ℤ.
+  rw [← lhs_eq_sum_of' (R := ℤ), ← rhs_eq_sum_of' (R := ℤ)]
+  exact mul_assoc_basis_via_oudom_guin_pbw F₁ F₂ F₃
+
+/-- **Basis-level associativity** (R-generic, `α : Type*`). Lifts the
+    integer case `mul_assoc_basis_via_oudom_guin_pbw` (Q6, proved
+    sorry-free in `OudomGuinBridge.lean`) to arbitrary
+    `CommSemiring R` via R-free multiset identification. -/
+theorem mul_assoc_basis {R : Type*} [CommSemiring R]
+    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
+    ((of' F₁ : GrossmanLarson R α) * of' F₂) * of' F₃ =
+      of' F₁ * (of' F₂ * of' F₃) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  rw [lhs_eq_sum_of' (R := R), rhs_eq_sum_of' (R := R),
+      sum_of'_congr (lhsMultiset_eq_rhsMultiset F₁ F₂ F₃)]
+
+/-! ### Full `mul_assoc` via triple `Finsupp.addHom_ext` -/
+
+/-- Right multiplication by `y` as an `AddMonoidHom`, additive in `x`. -/
+private noncomputable def mulRightHom
+    {R : Type*} [CommSemiring R] (y : GrossmanLarson R α) :
+    GrossmanLarson R α →+ GrossmanLarson R α where
+  toFun x := x * y
+  map_zero' := by
+    show product 0 y = 0
+    rw [product.map_zero, LinearMap.zero_apply]
+  map_add' x₁ x₂ := by
+    show product (x₁ + x₂) y = product x₁ y + product x₂ y
+    rw [product.map_add, LinearMap.add_apply]
+
+/-- Left multiplication by `x` as an `AddMonoidHom`, additive in `y`. -/
+private noncomputable def mulLeftHom
+    {R : Type*} [CommSemiring R] (x : GrossmanLarson R α) :
+    GrossmanLarson R α →+ GrossmanLarson R α where
+  toFun y := x * y
+  map_zero' := by
+    show product x 0 = 0
+    exact (product x).map_zero
+  map_add' y₁ y₂ := by
+    show product x (y₁ + y₂) = product x y₁ + product x y₂
+    exact (product x).map_add y₁ y₂
+
+@[simp] private theorem mulRightHom_apply
+    {R : Type*} [CommSemiring R] (x y : GrossmanLarson R α) :
+    mulRightHom y x = x * y := rfl
+
+@[simp] private theorem mulLeftHom_apply
+    {R : Type*} [CommSemiring R] (x y : GrossmanLarson R α) :
+    mulLeftHom x y = x * y := rfl
+
+/-- Scalar pull-out on the LEFT factor: `(c • x) * y = c • (x * y)`. -/
+private theorem smul_mul_left
+    {R : Type*} [CommSemiring R] (c : R) (x y : GrossmanLarson R α) :
+    ((c • x : GrossmanLarson R α) * y) = c • (x * y) := by
+  show product (c • x) y = c • product x y
+  rw [product.map_smul, LinearMap.smul_apply]
+
+/-- Scalar pull-out on the RIGHT factor: `x * (c • y) = c • (x * y)`. -/
+private theorem mul_smul_right
+    {R : Type*} [CommSemiring R] (c : R) (x y : GrossmanLarson R α) :
+    (x * (c • y : GrossmanLarson R α)) = c • (x * y) := by
+  show product x (c • y) = c • product x y
+  exact (product x).map_smul c y
+
+/-- AddMonoidHom for `x ↦ x * y * z`, additive in `x`. -/
+private noncomputable def assocLHSHom
+    {R : Type*} [CommSemiring R] (y z : GrossmanLarson R α) :
+    GrossmanLarson R α →+ GrossmanLarson R α :=
+  (mulRightHom z).comp (mulRightHom y)
+
+/-- AddMonoidHom for `x ↦ x * (y * z)`, additive in `x`. -/
+private noncomputable def assocRHSHom
+    {R : Type*} [CommSemiring R] (y z : GrossmanLarson R α) :
+    GrossmanLarson R α →+ GrossmanLarson R α :=
+  mulRightHom (y * z)
+
+@[simp] private theorem assocLHSHom_apply
+    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
+    assocLHSHom y z x = x * y * z := rfl
+
+@[simp] private theorem assocRHSHom_apply
+    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
+    assocRHSHom y z x = x * (y * z) := rfl
+
+/-- AddMonoidHom for `y ↦ x * y * z`, additive in `y`. -/
+private noncomputable def assocLHSHomY
+    {R : Type*} [CommSemiring R] (x z : GrossmanLarson R α) :
+    GrossmanLarson R α →+ GrossmanLarson R α :=
+  (mulRightHom z).comp (mulLeftHom x)
+
+/-- AddMonoidHom for `y ↦ x * (y * z)`, additive in `y`. -/
+private noncomputable def assocRHSHomY
+    {R : Type*} [CommSemiring R] (x z : GrossmanLarson R α) :
+    GrossmanLarson R α →+ GrossmanLarson R α :=
+  (mulLeftHom x).comp (mulRightHom z)
+
+@[simp] private theorem assocLHSHomY_apply
+    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
+    assocLHSHomY x z y = x * y * z := rfl
+
+@[simp] private theorem assocRHSHomY_apply
+    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
+    assocRHSHomY x z y = x * (y * z) := by
+  show (mulLeftHom x) ((mulRightHom z) y) = x * (y * z)
+  rfl
+
+/-- AddMonoidHom for `z ↦ x * y * z`, additive in `z`. -/
+private noncomputable def assocLHSHomZ
+    {R : Type*} [CommSemiring R] (x y : GrossmanLarson R α) :
+    GrossmanLarson R α →+ GrossmanLarson R α :=
+  (mulLeftHom (x * y))
+
+/-- AddMonoidHom for `z ↦ x * (y * z)`, additive in `z`. -/
+private noncomputable def assocRHSHomZ
+    {R : Type*} [CommSemiring R] (x y : GrossmanLarson R α) :
+    GrossmanLarson R α →+ GrossmanLarson R α :=
+  (mulLeftHom x).comp (mulLeftHom y)
+
+@[simp] private theorem assocLHSHomZ_apply
+    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
+    assocLHSHomZ x y z = x * y * z := rfl
+
+@[simp] private theorem assocRHSHomZ_apply
+    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
+    assocRHSHomZ x y z = x * (y * z) := by
+  show (mulLeftHom x) ((mulLeftHom y) z) = x * (y * z)
+  rfl
+
+/-- **Associativity** (R-generic, `α : Type*`). Triple bilinearity
+    reduction to `mul_assoc_basis`. -/
+theorem mul_assoc {R : Type*} [CommSemiring R]
+    (F₁ F₂ F₃ : GrossmanLarson R α) :
+    F₁ * F₂ * F₃ = F₁ * (F₂ * F₃) := by
+  have h₁ : assocLHSHom F₂ F₃ = assocRHSHom F₂ F₃ := by
+    refine Finsupp.addHom_ext fun T₁ a₁ => ?_
+    set s₁ : GrossmanLarson R α := Finsupp.single T₁ a₁ with s₁_def
+    show assocLHSHom F₂ F₃ s₁ = assocRHSHom F₂ F₃ s₁
+    rw [assocLHSHom_apply, assocRHSHom_apply]
+    have h₂ : assocLHSHomY s₁ F₃ = assocRHSHomY s₁ F₃ := by
+      refine Finsupp.addHom_ext fun T₂ a₂ => ?_
+      set s₂ : GrossmanLarson R α := Finsupp.single T₂ a₂ with s₂_def
+      show assocLHSHomY s₁ F₃ s₂ = assocRHSHomY s₁ F₃ s₂
+      rw [assocLHSHomY_apply, assocRHSHomY_apply]
+      have h₃ : assocLHSHomZ s₁ s₂ = assocRHSHomZ s₁ s₂ := by
+        refine Finsupp.addHom_ext fun T₃ a₃ => ?_
+        set s₃ : GrossmanLarson R α := Finsupp.single T₃ a₃ with s₃_def
+        show assocLHSHomZ s₁ s₂ s₃ = assocRHSHomZ s₁ s₂ s₃
+        rw [assocLHSHomZ_apply, assocRHSHomZ_apply]
+        rw [show s₁ = a₁ • (of' T₁ : GrossmanLarson R α) from
+              (Finsupp.smul_single_one T₁ a₁).symm,
+            show s₂ = a₂ • (of' T₂ : GrossmanLarson R α) from
+              (Finsupp.smul_single_one T₂ a₂).symm,
+            show s₃ = a₃ • (of' T₃ : GrossmanLarson R α) from
+              (Finsupp.smul_single_one T₃ a₃).symm]
+        simp only [smul_mul_left, mul_smul_right]
+        rw [mul_assoc_basis T₁ T₂ T₃]
+      have h₃App := DFunLike.congr_fun h₃ F₃
+      rw [assocLHSHomZ_apply, assocRHSHomZ_apply] at h₃App
+      exact h₃App
+    have h₂App := DFunLike.congr_fun h₂ F₂
+    rw [assocLHSHomY_apply, assocRHSHomY_apply] at h₂App
+    exact h₂App
+  have h₁App := DFunLike.congr_fun h₁ F₁
+  rw [assocLHSHom_apply, assocRHSHom_apply] at h₁App
+  exact h₁App
+
+/-! ### `Semigroup` and `Monoid` instances
+
+With associativity proved, register the typeclass instances. The
+underlying `Mul` is the existing `instMul` from `GrossmanLarson.lean`
+(so no `Semigroup.mul`-vs-`instMul` diamond). `One` is forwarded from
+`ConnesKreimer` via `instOne` (also in `GrossmanLarson.lean`). -/
+
+/- Low priority: `GrossmanLarson` is a semireducible alias of `ConnesKreimer`,
+so these instances can capture `ConnesKreimer`-goals carrying metavariables
+(hijacking the meta via alias unfolding). Low priority keeps CK-native
+instances winning first. -/
+noncomputable instance (priority := 50) instSemigroup {R : Type*} [CommSemiring R] :
+    Semigroup (GrossmanLarson R α) where
+  mul := (· * ·)
+  mul_assoc := mul_assoc
+
+noncomputable instance (priority := 50) instMonoid {R : Type*} [CommSemiring R] :
+    Monoid (GrossmanLarson R α) where
+  one := 1
+  one_mul := one_mul
+  mul_one := mul_one
+
+end GrossmanLarson
+
+end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/PreLie/BMinusSL.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/BMinusSL.lean
@@ -56,7 +56,7 @@ open PreLie.OudomGuinCirc
 
 /-! ### Per-tree basis assignment -/
 
-variable {α : Type}
+variable {α : Type*}
 
 /-- `LL` (not `L`) avoids clashing with the named argument `(LL := ...)` in
     `algHomL`. -/
@@ -729,7 +729,7 @@ private theorem bMinusLin_mul_eps [DecidableEq (Nonplanar α)] (a : α)
   -- For concreteness we prove the difference is zero via Finsupp double
   -- induction; each step uses only ℤ-linearity laws.
   -- Reduce to a LinearMap-on-(X⊗Y) equality, then apply `mk₂` ext.
-  let CK : Type := ConnesKreimer ℤ (Nonplanar α)
+  let CK : Type _ := ConnesKreimer ℤ (Nonplanar α)
   -- Build the two sides as ℤ-bilinear maps `CK →ₗ[ℤ] CK →ₗ[ℤ] CK`.
   -- LHS(X,Y) = bMinusLin a (X*Y); RHS(X,Y) = counit X • bMinusLin a Y +
   --                                          counit Y • bMinusLin a X.

--- a/Linglib/Core/Algebra/RootedTree/PreLie/Graft.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/Graft.lean
@@ -1630,9 +1630,9 @@ step, checking at each level that the input path's head matches the
 expected `rootPrependCount`-offsetted descent index. Recursion is
 structural on `e`.
 
-Consumer (§11.5, `composePairs_planarEquiv_partition`): the partition
-of inner paths into "lifted at outer[k]" buckets vs "root vertices of
-the extended tree" uses `stripLiftMulti` as the filter discriminator. -/
+Original consumer was the deprecated `composePairs` partition theorem
+(deleted 2026-06-12 with the A3.3 route); kept as generic vertex
+bookkeeping substrate. -/
 
 /-- Auxiliary walker: structural recursion on the prefix path. -/
 def stripLiftMultiAux : Path → ℕ → List (Path × Planar α) → Path → Option Path
@@ -4132,9 +4132,9 @@ classifies each inner path into one of:
 `(q, c)` (stripped paths). `rootInner outer inner` collects the
 preserved/sourceSelf inner pairs as `(v, c)` (untransported paths).
 
-The partition theorem `composePairs_planarEquiv_partition` lives in
-`Insertion.lean` §5.6 (uses `Nonplanar.mk` from
-`Linglib.Core.Combinatorics.RootedTree.Nonplanar`).
+The deprecated `composePairs` partition theorem that consumed these was
+deleted on 2026-06-12 with the A3.3 route; the collectors remain as
+generic substrate.
 
 **Consumer status (2026-05-16)**: deprecated. The original consumer
 (`InsertionAssoc.lean` §1.11.11 T-bucket bridges) has been deleted as

--- a/Linglib/Core/Algebra/RootedTree/PreLie/Insertion.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/Insertion.lean
@@ -739,45 +739,6 @@ theorem listChoices_bind_insertion_inner_split
   exact insertion_cons_pair_at_multiGraft_bind_at_choice T Ts choice
     (Multiset.mem_coe.mp h_choice) c filter_t (K choice)
 
-/-! ## §5.7: `composePairs_planarEquiv_partition` — partition of composePairs result
-
-The PE-level partition theorem for `composePairs` (defined in `Graft.lean` §11).
-For an outer pair list and inner pair list (with inner paths valid in
-`mG T outer`), applying `multiGraft T` to `composePairs outer inner` is
-PE-equivalent (at `Nonplanar.mk` level) to applying `multiGraft T` to:
-
-- For each `k : Fin outer.length`: outer[k] modified to have its `.snd`
-  multi-grafted with `liftedInnerAt outer inner k` (the inner pairs lifted
-  into outer[k]'s subtree, with paths stripped via `stripLiftMulti`).
-- Plus `rootInner outer inner`: the preserved/sourceSelf inner pairs with
-  paths untransported back to T-coordinates via `untransport`.
-
-**DEPRECATED 2026-05-16** as critical-path substrate. Off the GL
-associativity path under the abstract OG pivot
-(`scratch/pivot_to_prelie_pbw.md`,
-`Linglib/Core/Algebra/PreLie/OudomGuinCirc.lean`). Sorry remains; the
-helpers `liftedInnerAt`/`rootInner` are kept as generic
-vertex-decomposition primitives. -/
-
-/-- **Partition assembly**: applying `multiGraft T` to `composePairs outer inner`
-    is PE-equivalent (at Nonplanar level) to applying `multiGraft T` to the
-    assembled per-outer-k sub-multiGrafts plus untransported root inner. -/
-theorem composePairs_planarEquiv_partition
-    (T : Planar α) (outer inner : List (Path × Planar α))
-    (_h_outer_valid : ∀ p ∈ outer, IsValidPath p.fst T)
-    (_h_inner_valid : ∀ p ∈ inner, IsValidPath p.fst (multiGraft T outer)) :
-    Nonplanar.mk (multiGraft T (composePairs outer inner)) =
-    Nonplanar.mk (multiGraft T
-      (((List.finRange outer.length).map fun k =>
-          (outer[k.val].fst,
-            multiGraft outer[k.val].snd (liftedInnerAt outer inner k))) ++
-        rootInner outer inner)) := by
-  -- TODO Session 19+: prove the partition. Requires substrate identifying
-  -- composePairs behavior per inner pair class (preserved/sourceSelf via
-  -- untransport-derivable T-coordinates; lifted via stripLiftMulti at outer[k]).
-  -- Plan: foldr induction on inner with case analysis on the head's class.
-  sorry
-
 /-! ## §6: Host invariance via path-swap bijection
 
 `insertion T Ts` is `mk`-invariant under `PlanarEquiv` of the host: the

--- a/Linglib/Core/Algebra/RootedTree/PreLie/InsertionCompose.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/InsertionCompose.lean
@@ -1,0 +1,969 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Algebra.RootedTree.PreLie.Graft
+import Linglib.Core.Algebra.RootedTree.PreLie.Insertion
+import Linglib.Core.Algebra.RootedTree.PreLie.InsertionAddHost
+
+/-!
+# Singleton-guest composition of the multi-graft insertion
+
+Inserting one further guest `v` into the outputs of a simultaneous
+multi-graft decomposes as: `v` lands at an original host vertex
+(extending the simultaneous graft), or inside one of the grafted guest
+copies (pre-grafting that guest). This is the single-guest case of the
+multi-graft associativity (Oudom-Guin Prop 2.7.v at the basis level)
+and the combinatorial content of the Grossman-Larson guest-splitting
+identity `GL_product_split_mul_ι`.
+
+## Main results
+
+* `insertion_multiGraft_singleton`: per grafted output, the two-class
+  decomposition of single-guest insertion, via `multiGraft_cons_pair`
+  (original vertices) and `multiGraft_split_lifted_aux` (guest copies).
+* `insertion_bind_singleton`: tree-host form,
+  `(insertion T B).bind (insertion · [v]) =
+     insertion T (v :: B) + (insertionForest B [v]).bind (insertion T ·)`.
+* `insertionForest_bind_singleton`: forest-host form of the same.
+
+All statements are validated computationally on concrete trees,
+including the raw (planar multiset, not quotient-level) forms of the
+last two.
+-/
+
+namespace RootedTree
+
+namespace Planar
+
+namespace Pathed
+
+variable {α : Type*}
+
+/-! ### Two-class form of the grafted-vertex decomposition -/
+
+/-- The vertex multiset of a grafted tree: transported originals plus
+    lifted guest vertices. Collapses the three classes of
+    `vertices_multiGraft_decomp` (`preserveMulti` is `transport` off
+    `pairSources`). -/
+theorem vertices_multiGraft_transport_lift (T : Planar α)
+    (pairs : List (Path × Planar α))
+    (h_valid : ∀ pair ∈ pairs, IsValidPath pair.fst T) :
+    ((vertices (multiGraft T pairs) : List Path) : Multiset Path) =
+      ((vertices T : List Path) : Multiset Path).map (transport pairs) +
+      (Multiset.ofList (List.finRange pairs.length)).bind
+        (fun k => ((vertices pairs[k].snd : List Path) : Multiset Path).map
+          (liftMulti pairs k)) := by
+  rw [vertices_multiGraft_decomp T pairs h_valid,
+      preserved_add_sourceSelf_eq_vertices_map_transport pairs
+        ((vertices T : List Path) : Multiset Path)]
+
+/-! ### Single-guest insertion as a vertex sum -/
+
+/-- A single graft is an `insertAt`. -/
+private theorem multiGraft_single_pair (W : Planar α) (p : Path) (v : Planar α) :
+    multiGraft W [(p, v)] = insertAt p v W := by
+  rw [multiGraft_cons_pair, multiGraft_nil, transport_empty_pairs]
+
+/-- Single-guest insertion grafts the guest at each host vertex. -/
+theorem insertion_singleton_guest (W v : Planar α) :
+    insertion W [v] =
+      ((vertices W : List Path) : Multiset Path).map
+        (fun p => insertAt p v W) := by
+  rw [insertion_def,
+      show listChoices (vertices W) ([v] : List (Planar α)).length =
+          (vertices W).map (fun p => [p]) from by
+        rw [show ([v] : List (Planar α)).length = 1 from rfl, listChoices_succ]
+        simp only [listChoices_zero, List.map_cons, List.map_nil]
+        induction vertices W with
+        | nil => rfl
+        | cons p ps ih =>
+          rw [List.flatMap_cons, List.map_cons, ← ih]
+          rfl,
+      List.map_map]
+  rw [show ((((vertices W).map
+        ((fun choice => multiGraft W (choice.zip [v])) ∘ fun p => [p])) :
+        List (Planar α)) : Multiset (Planar α)) =
+      ((vertices W : List Path) : Multiset Path).map
+        ((fun choice => multiGraft W (choice.zip [v])) ∘ fun p => [p]) from rfl]
+  refine Multiset.map_congr rfl fun p _ => ?_
+  show multiGraft W [(p, v)] = insertAt p v W
+  exact multiGraft_single_pair W p v
+
+/-! ### Per-output decomposition -/
+
+/-- Inserting one guest `v` into a multi-graft output: `v` lands at an
+    original vertex (prepend the pair) or inside the `k`-th grafted
+    guest (pre-graft that guest). -/
+theorem insertion_multiGraft_singleton (T : Planar α)
+    (pairs : List (Path × Planar α)) (v : Planar α)
+    (h_valid : ∀ pair ∈ pairs, IsValidPath pair.fst T) :
+    insertion (multiGraft T pairs) [v] =
+      ((vertices T : List Path) : Multiset Path).map
+        (fun u => multiGraft T ((u, v) :: pairs)) +
+      (Multiset.ofList (List.finRange pairs.length)).bind
+        (fun k => ((vertices pairs[k].snd : List Path) : Multiset Path).map
+          (fun q => multiGraft T
+            (pairs.set k.val (pairs[k].fst, insertAt q v pairs[k].snd)))) := by
+  rw [insertion_singleton_guest,
+      vertices_multiGraft_transport_lift T pairs h_valid,
+      Multiset.map_add, Multiset.map_map, Multiset.map_bind]
+  congr 1
+  · refine Multiset.map_congr rfl fun u _ => ?_
+    show insertAt (transport pairs u) v (multiGraft T pairs) =
+      multiGraft T ((u, v) :: pairs)
+    exact (multiGraft_cons_pair T pairs u v).symm
+  · refine Multiset.bind_congr fun k _ => ?_
+    rw [Multiset.map_map]
+    refine Multiset.map_congr rfl fun q _ => ?_
+    show insertAt (liftMulti pairs k q) v (multiGraft T pairs) =
+      multiGraft T (pairs.set k.val (pairs[k].fst, insertAt q v pairs[k].snd))
+    exact multiGraft_split_lifted_aux T pairs k q v
+
+/-! ### Singleton-guest associativity -/
+
+/-- Local reproof of `InsertionNodeDecomp.ofList_listChoices_succ`
+    (private upstream). A length-`(k+1)` enumeration unfolds to a head
+    bind. -/
+private theorem ofList_listChoices_succ_local {Y : Type*} (xs : List Y) (k : ℕ) :
+    (Multiset.ofList (listChoices xs (k + 1)) : Multiset (List Y)) =
+      (Multiset.ofList xs).bind fun v =>
+        (Multiset.ofList (listChoices xs k)).map (v :: ·) := by
+  rw [listChoices_succ, ← Multiset.coe_bind]
+  rfl
+
+/-- For `c.length = B.length`, `c.zip (B.set k w)` equals
+    `(c.zip B).set k (c[k], w)`. -/
+private theorem zip_set_eq_set_zip {β γ : Type*}
+    (c : List β) (B : List γ) (k : ℕ) (w : γ) (hk : k < B.length)
+    (hlen : c.length = B.length) :
+    c.zip (B.set k w) =
+      (c.zip B).set k (c[k]'(by rw [hlen]; exact hk), w) := by
+  induction c generalizing B k with
+  | nil =>
+    simp at hlen
+    rw [← hlen] at hk
+    exact absurd hk (Nat.not_lt_zero _)
+  | cons ch cs ih =>
+    cases B with
+    | nil => simp at hlen
+    | cons bh bs =>
+      cases k with
+      | zero => simp
+      | succ k' =>
+        simp only [List.zip_cons_cons, List.set_cons_succ, List.getElem_cons_succ]
+        have hk' : k' < bs.length := by
+          simp [List.length_cons] at hk; omega
+        have hlen' : cs.length = bs.length := by
+          simp [List.length_cons] at hlen; omega
+        rw [ih bs k' hk' hlen']
+
+/-- Decomposition of `insertionForest B [v]`: insert `v` into each
+    position of each tree of `B`. De-privatized 2026-06-12 for
+    `GL_T2_reindexing_key` (Q5c) which needs length-preservation of
+    single-guest insertion outputs. -/
+theorem insertionForest_singleton_guest_set (B : List (Planar α))
+    (v : Planar α) :
+    insertionForest B [v] =
+      (Multiset.ofList (List.finRange B.length)).bind
+        (fun k => ((vertices B[k] : List Path) : Multiset Path).map
+          (fun q => B.set k.val (insertAt q v B[k]))) := by
+  induction B with
+  | nil =>
+    show insertionForest ([] : List (Planar α)) [v] = _
+    rw [insertionForest_empty_host_nonempty_guests]
+    show (0 : Multiset _) =
+      (Multiset.ofList (List.finRange ([] : List (Planar α)).length)).bind _
+    rfl
+  | cons b B' ih =>
+    rw [insertionForest_cons_assignment]
+    -- listChoices [t,f] 1 = [[true],[false]]
+    rw [show ([v] : List (Planar α)).length = 1 from rfl]
+    rw [show (Multiset.ofList (listChoices [true, false] 1) : Multiset (List Bool)) =
+            [true] ::ₘ [false] ::ₘ 0 from rfl,
+        Multiset.cons_bind, Multiset.cons_bind, Multiset.zero_bind, add_zero]
+    -- True branch: insertion b [v], insertionForest B' [], bucket = [B']
+    -- Each zip+filterMap reduces by rfl
+    show (insertion b [v]).bind
+            (fun T' => Multiset.map (fun F' => T' :: F') (insertionForest B' [])) +
+          (insertion b []).bind
+            (fun T' => Multiset.map (fun F' => T' :: F') (insertionForest B' [v])) = _
+    rw [insertionForest_nil_guests B']
+    rw [show insertion b ([] : List (Planar α)) = ({b} : Multiset (Planar α)) from by
+          rw [insertion_def]
+          show (Multiset.ofList [multiGraft b []] : Multiset (Planar α)) = {b}
+          rw [multiGraft_nil]; rfl]
+    rw [Multiset.singleton_bind]
+    rw [show (fun T' => Multiset.map (fun F' => T' :: F') ({B'} : Multiset (List (Planar α)))) =
+            (fun T' => ({T' :: B'} : Multiset (List (Planar α)))) from by
+          funext T'; rfl]
+    rw [Multiset.bind_singleton]
+    rw [insertion_singleton_guest]
+    rw [ih]
+    -- Push the outer maps inside
+    rw [Multiset.map_map, Multiset.map_bind]
+    -- Now each bind body has Multiset.map (b :: ·) inside; push that through too
+    conv_lhs =>
+      rhs; rhs; ext k
+      rw [Multiset.map_map]
+    -- Reassemble with finRange_succ. Use Eq.symm and show form to avoid motive issues.
+    symm
+    show (Multiset.ofList (List.finRange (b :: B').length)).bind
+            (fun k => ((vertices (b :: B')[k.val] : List Path) : Multiset Path).map
+              (fun q => (b :: B').set k.val (insertAt q v (b :: B')[k.val]))) = _
+    -- Use show to normalize (b :: B').length to B'.length + 1
+    show (Multiset.ofList (List.finRange (B'.length + 1))).bind
+            (fun k => ((vertices (b :: B')[k.val] : List Path) : Multiset Path).map
+              (fun q => (b :: B').set k.val (insertAt q v (b :: B')[k.val]))) = _
+    rw [List.finRange_succ]
+    show ((0 : Fin (B'.length + 1)) ::ₘ
+            ((Multiset.ofList (List.finRange B'.length)).map Fin.succ)).bind _ = _
+    rw [Multiset.cons_bind, Multiset.bind_map]
+    -- Head simplification
+    have head_lhs :
+        (((vertices ((b :: B')[(0 : Fin (B'.length + 1)).val])) : List Path) :
+            Multiset Path).map (fun q => (b :: B').set (0 : Fin (B'.length + 1)).val
+              (insertAt q v ((b :: B')[(0 : Fin (B'.length + 1)).val]))) =
+        ((vertices b : List Path) : Multiset Path).map
+          (fun q => insertAt q v b :: B') := by
+      show ((vertices b : List Path) : Multiset Path).map
+            (fun q => (b :: B').set 0 (insertAt q v b)) = _
+      refine Multiset.map_congr rfl fun q _ => rfl
+    have tail_lhs : (Multiset.ofList (List.finRange B'.length)).bind
+            (fun x : Fin B'.length =>
+              ((vertices ((b :: B')[(Fin.succ x).val]) : List Path) :
+              Multiset Path).map
+                (fun q => (b :: B').set (Fin.succ x).val
+                  (insertAt q v ((b :: B')[(Fin.succ x).val])))) =
+        (Multiset.ofList (List.finRange B'.length)).bind
+          (fun k => ((vertices B'[k.val] : List Path) : Multiset Path).map
+            (fun q => b :: B'.set k.val (insertAt q v B'[k.val]))) := by
+      refine Multiset.bind_congr fun k _ => ?_
+      show ((vertices B'[k.val] : List Path) : Multiset Path).map
+              (fun q => (b :: B').set (k.val + 1) (insertAt q v B'[k.val])) = _
+      refine Multiset.map_congr rfl fun q _ => rfl
+    rw [head_lhs, tail_lhs]
+    -- LHS = head + bind, RHS = head_composed + bind_composed
+    -- Both are pointwise equal; compose maps are defeq
+    rfl
+
+/-- Tree-host singleton-guest associativity: grafting `B` then one more
+    guest `v` equals grafting `v :: B` simultaneously plus grafting `B`
+    with `v` nested into one of its trees. Raw planar multiset equality. -/
+theorem insertion_bind_singleton (T : Planar α) (B : List (Planar α))
+    (v : Planar α) :
+    (insertion T B).bind (fun W => insertion W [v]) =
+      insertion T (v :: B) +
+      (insertionForest B [v]).bind (fun B' => insertion T B') := by
+  -- LHS: unfold insertion T B
+  rw [insertion_def T B]
+  rw [show ((Multiset.ofList ((listChoices (vertices T) B.length).map
+              fun choice => multiGraft T (choice.zip B))) :
+            Multiset (Planar α)) =
+          (Multiset.ofList (listChoices (vertices T) B.length)).map
+            (fun choice => multiGraft T (choice.zip B)) from rfl,
+      Multiset.bind_map]
+  -- Per c: apply C3
+  rw [Multiset.bind_congr (g := fun c =>
+        ((vertices T : List Path) : Multiset Path).map
+          (fun u => multiGraft T ((u, v) :: c.zip B)) +
+        (Multiset.ofList (List.finRange (c.zip B).length)).bind
+          (fun k => ((vertices (c.zip B)[k].snd : List Path) : Multiset Path).map
+            (fun q => multiGraft T
+              ((c.zip B).set k.val ((c.zip B)[k].fst,
+                insertAt q v (c.zip B)[k].snd)))))
+        (fun c hc => insertion_multiGraft_singleton T (c.zip B) v
+          (forall_zip_isValidPath_of_listChoices T B c (by rwa [Multiset.mem_coe] at hc)))]
+  rw [Multiset.bind_add]
+  congr 1
+  · -- Original class: bind c, (vertices T).map (u => mG T ((u,v) :: c.zip B))
+    --                = insertion T (v :: B)
+    rw [insertion_def T (v :: B), show (v :: B).length = B.length + 1 from rfl]
+    rw [show ((Multiset.ofList ((listChoices (vertices T) (B.length + 1)).map
+              fun choice => multiGraft T (choice.zip (v :: B)))) :
+            Multiset (Planar α)) =
+          (Multiset.ofList (listChoices (vertices T) (B.length + 1))).map
+            (fun choice => multiGraft T (choice.zip (v :: B))) from rfl]
+    rw [ofList_listChoices_succ_local (vertices T) B.length, Multiset.map_bind]
+    -- RHS = bind u ∈ vertices T, (listChoices ... B.length).map (u::·).map (mG T ∘ (·.zip (v::B)))
+    -- Push the second map through: (·.map (u::·)).map(f) = ·.map(f ∘ (u::·))
+    rw [show (fun u : Path =>
+            Multiset.map (fun choice : List Path => multiGraft T (choice.zip (v :: B)))
+              ((Multiset.ofList (listChoices (vertices T) B.length)).map (u :: ·))) =
+          (fun u : Path =>
+            (Multiset.ofList (listChoices (vertices T) B.length)).map
+              fun c => multiGraft T ((u, v) :: c.zip B)) from by
+        funext u
+        rw [Multiset.map_map]
+        rfl]
+    -- Swap bind/map ordering: bind u (map c) = bind c (map u)
+    -- Use bind_singleton form on both
+    rw [show (fun u : Path =>
+            (Multiset.ofList (listChoices (vertices T) B.length)).map
+              fun c => multiGraft T ((u, v) :: c.zip B)) =
+          (fun u : Path =>
+            (Multiset.ofList (listChoices (vertices T) B.length)).bind
+              fun c => ({multiGraft T ((u, v) :: c.zip B)} : Multiset (Planar α))) from by
+        funext u
+        rw [Multiset.bind_singleton]]
+    -- Bind swap via Multiset.bind_bind
+    rw [show ((((vertices T : List Path) : Multiset Path)).bind fun u =>
+            (Multiset.ofList (listChoices (vertices T) B.length)).bind
+              fun c => ({multiGraft T ((u, v) :: c.zip B)} : Multiset (Planar α))) =
+          ((Multiset.ofList (listChoices (vertices T) B.length)).bind fun c =>
+            (((vertices T : List Path) : Multiset Path)).bind fun u =>
+              ({multiGraft T ((u, v) :: c.zip B)} : Multiset (Planar α))) from by
+        rw [Multiset.bind_bind]]
+    refine Multiset.bind_congr fun c _ => ?_
+    rw [Multiset.bind_singleton]
+  · -- Nested class: bind c, (finRange (c.zip B).length).bind k => (vertices (c.zip B)[k].snd).map (q => mG T ((c.zip B).set k (...)))
+    -- RHS: (insertionForest B [v]).bind (insertion T)
+    rw [insertionForest_singleton_guest_set B v]
+    rw [Multiset.bind_assoc]
+    -- Per-k: rewrite map-then-bind via bind_map
+    conv_rhs =>
+      rhs; ext k
+      rw [Multiset.bind_map]
+    -- Per-k per-q: unfold insertion T (B.set k _) into map form
+    have h_insertion_set : ∀ (k : Fin B.length) (q : Path),
+        insertion T (B.set k.val (insertAt q v B[k])) =
+        (Multiset.ofList (listChoices (vertices T) B.length)).map
+          (fun choice => multiGraft T
+            (choice.zip (B.set k.val (insertAt q v B[k])))) := by
+      intro k q
+      rw [insertion_def, List.length_set]
+      rfl
+    conv_rhs =>
+      rhs; ext k; rhs; ext q
+      rw [h_insertion_set]
+    -- Convert each inner map to bind {·} using Multiset.bind_singleton (in reverse)
+    conv_rhs =>
+      rhs; ext k; rhs; ext q
+      rw [← Multiset.bind_singleton (f := fun choice : List Path =>
+            multiGraft T (choice.zip (B.set k.val (insertAt q v B[k]))))]
+    -- Swap inner bind q with bind choice via Multiset.bind_bind (innermost first)
+    conv_rhs =>
+      rhs; ext k
+      rw [Multiset.bind_bind]
+    -- Now swap outer bind k with bind choice
+    conv_rhs =>
+      rw [Multiset.bind_bind]
+    refine Multiset.bind_congr fun c hc => ?_
+    have hc_mem : c ∈ listChoices (vertices T) B.length := by
+      rwa [Multiset.mem_coe] at hc
+    have hc_len : c.length = B.length :=
+      mem_listChoices_length (vertices T) B.length c hc_mem
+    have hzip_len : (c.zip B).length = B.length := by
+      rw [List.length_zip, hc_len, min_self]
+    -- Inside the c-bind: need
+    --   bind k ∈ finRange B.length, bind q ∈ vertices B[k], {mG T (c.zip (B.set k (insertAt q v B[k])))}
+    -- = bind k ∈ finRange (c.zip B).length, map q ∈ vertices (c.zip B)[k].snd, mG T ((c.zip B).set k ((c.zip B)[k].fst, insertAt q v (c.zip B)[k].snd))
+    -- Use hzip_len for finRange equality, zip_set for the set transformation, getElem of zip for projections.
+    -- Convert RHS inner map back to bind {·}
+    rw [show ((Multiset.ofList (List.finRange (c.zip B).length)).bind
+            fun k : Fin (c.zip B).length =>
+              ((vertices (c.zip B)[k].snd : List Path) : Multiset Path).map
+                (fun q => multiGraft T
+                  ((c.zip B).set k.val ((c.zip B)[k].fst,
+                    insertAt q v (c.zip B)[k].snd)))) =
+          ((Multiset.ofList (List.finRange (c.zip B).length)).bind
+            fun k : Fin (c.zip B).length =>
+              ((vertices (c.zip B)[k].snd : List Path) : Multiset Path).bind
+                (fun q =>
+                  ({multiGraft T
+                    ((c.zip B).set k.val ((c.zip B)[k].fst,
+                      insertAt q v (c.zip B)[k].snd))} : Multiset (Planar α)))) from by
+        refine Multiset.bind_congr fun k _ => ?_
+        rw [← Multiset.bind_singleton]]
+    -- Now LHS: bind k ∈ finRange B.length, bind q ∈ vertices B[k], {mG T (c.zip (B.set k ...))}
+    -- RHS: bind k ∈ finRange (c.zip B).length, bind q ∈ vertices (c.zip B)[k].snd, {mG T ((c.zip B).set k ...)}
+    -- Bridge finRange (c.zip B).length to finRange B.length via Fin.cast
+    -- We show RHS = LHS by congruence at each k after recognizing (c.zip B)[k] = (c[k], B[k]).
+    symm
+    -- Cast finRange index using hzip_len: finRange (c.zip B).length = (finRange B.length).map (Fin.cast hzip_len.symm)
+    rw [show (Multiset.ofList (List.finRange (c.zip B).length) : Multiset (Fin (c.zip B).length)) =
+            (Multiset.ofList (List.finRange B.length)).map (Fin.cast hzip_len.symm) from by
+        show (Multiset.ofList (List.finRange (c.zip B).length) : Multiset (Fin (c.zip B).length)) =
+              Multiset.ofList ((List.finRange B.length).map (Fin.cast hzip_len.symm))
+        congr 1
+        apply List.ext_getElem
+        · rw [List.length_map, List.length_finRange, List.length_finRange, hzip_len]
+        · intro n h1 h2
+          rw [List.getElem_map, List.getElem_finRange, List.getElem_finRange]
+          rfl]
+    rw [Multiset.bind_map]
+    refine Multiset.bind_congr fun k _ => ?_
+    -- Per k: (c.zip B)[k] = (c[k], B[k]) elementwise. Use show to normalize
+    -- Fin.cast hzip_len.symm k indexing back to k.val.
+    have hk_lt_c : k.val < c.length := by rw [hc_len]; exact k.isLt
+    have hk_lt_zip : k.val < (c.zip B).length := by rw [hzip_len]; exact k.isLt
+    -- The Fin.cast indexing reduces by defeq to k.val indexing
+    show ((vertices B[k] : List Path) : Multiset Path).bind
+            (fun a => ({multiGraft T (c.zip (B.set k.val (insertAt a v B[k])))} :
+              Multiset (Planar α))) =
+          (((vertices ((c.zip B)[k.val]'hk_lt_zip).snd : List Path) : Multiset Path)).bind
+            fun q => ({multiGraft T ((c.zip B).set k.val
+              (((c.zip B)[k.val]'hk_lt_zip).fst, insertAt q v ((c.zip B)[k.val]'hk_lt_zip).snd))} :
+                Multiset (Planar α))
+    have hzip_get : (c.zip B)[k.val]'hk_lt_zip = (c[k.val]'hk_lt_c, B[k.val]'k.isLt) := by
+      rw [List.getElem_zip]
+    rw [hzip_get]
+    refine Multiset.bind_congr fun q _ => ?_
+    have h_set : c.zip (B.set k.val (insertAt q v B[k.val])) =
+        (c.zip B).set k.val (c[k.val]'hk_lt_c, insertAt q v B[k.val]) :=
+      zip_set_eq_set_zip c B k.val (insertAt q v B[k.val]) k.isLt hc_len
+    show ({multiGraft T (c.zip (B.set k.val (insertAt q v B[k.val])))} : Multiset _) =
+          ({multiGraft T ((c.zip B).set k.val
+            (c[k.val]'hk_lt_c, insertAt q v B[k.val]))} : Multiset _)
+    rw [h_set]
+
+/-- Single-guest insertion on a cons-forest splits into the v→head and
+    v→tail branches. Specialization of `insertionForest_cons_assignment`
+    at guests `[v]`, collapsing the [true]/[false] mask enumeration via
+    `insertion_nil_guests` and `insertionForest_nil_guests`. -/
+private theorem insertionForest_cons_singleton (T : Planar α)
+    (F : List (Planar α)) (v : Planar α) :
+    insertionForest (T :: F) [v] =
+      (insertion T [v]).map (fun T' => T' :: F) +
+      (insertionForest F [v]).map (fun F' => T :: F') := by
+  rw [insertionForest_cons_assignment]
+  rw [show ([v] : List (Planar α)).length = 1 from rfl]
+  rw [show (Multiset.ofList (listChoices [true, false] 1) : Multiset (List Bool)) =
+          [true] ::ₘ [false] ::ₘ 0 from rfl,
+      Multiset.cons_bind, Multiset.cons_bind, Multiset.zero_bind, add_zero]
+  -- True branch: zip [v] [true] = [(v, true)], filterMap true→Some, false→None
+  -- → T-bucket = [v], F-bucket = [].
+  -- False branch: zip [v] [false] = [(v, false)] → T-bucket = [], F-bucket = [v].
+  show (insertion T [v]).bind
+          (fun T' => (insertionForest F []).map (fun F' => T' :: F')) +
+        (insertion T []).bind
+          (fun T' => (insertionForest F [v]).map (fun F' => T' :: F')) = _
+  rw [insertionForest_nil_guests F, insertion_nil_guests T]
+  rw [Multiset.singleton_bind]
+  -- True branch: (insertion T [v]).bind (T' => {F}.map (T' :: ·)) = (insertion T [v]).map (· :: F)
+  rw [show (fun T' : Planar α =>
+            ({F} : Multiset (List (Planar α))).map (fun F' => T' :: F')) =
+          (fun T' : Planar α => ({T' :: F} : Multiset (List (Planar α)))) from by
+        funext T'; rw [Multiset.map_singleton]]
+  rw [show (fun T' : Planar α => ({T' :: F} : Multiset (List (Planar α)))) =
+          (fun T' : Planar α => ({(fun T'' => T'' :: F) T'} : Multiset _)) from rfl]
+  rw [Multiset.bind_singleton (f := fun T' => T' :: F)]
+
+/-- Bucketing lemma: single-guest insertion `insertionForest B [v]`
+    modifies exactly one position of `B`, so after partitioning each
+    output `B'` into a t-bucket and f-bucket according to a fixed mask
+    `m` (of length `B.length`), the modification appears in exactly one
+    of the two buckets. The factored form, summing over a general
+    consumer `G`, lets us instantiate `G` to the cons-assignment body
+    in `insertionForest_bind_singleton`.
+
+    De-privatized 2026-06-12 for `GL_product_split_mul_ι` (Q5c per-tprod
+    induction): the same bucket-split, after descent through the
+    `listChoices_bridge_powerset_paired` translation, supplies the
+    reindexing for `T2 = F * insertion (op G) (op of'{v})` against the
+    powerset-of-B sum produced by `mul_of'_sum_form` + Leibniz on the
+    other terms. -/
+theorem insertionForest_singleton_bucket_split
+    {γ : Type*} (B : List (Planar α)) (m : List Bool) (v : Planar α)
+    (G : List (Planar α) → List (Planar α) → Multiset γ)
+    (hlen : m.length = B.length) :
+    (insertionForest B [v]).bind (fun B' =>
+        G ((B'.zip m).filterMap (fun p => if p.snd then some p.fst else none))
+          ((B'.zip m).filterMap (fun p => if p.snd then none else some p.fst))) =
+      (insertionForest
+          ((B.zip m).filterMap (fun p => if p.snd then some p.fst else none))
+          [v]).bind (fun W =>
+        G W ((B.zip m).filterMap (fun p => if p.snd then none else some p.fst))) +
+      (insertionForest
+          ((B.zip m).filterMap (fun p => if p.snd then none else some p.fst))
+          [v]).bind (fun W' =>
+        G ((B.zip m).filterMap (fun p => if p.snd then some p.fst else none)) W') := by
+  induction B generalizing m G with
+  | nil =>
+    -- B = [] → insertionForest [] [v] = 0, both buckets = []; LHS = 0.bind = 0.
+    -- RHS: insertionForest ([].filterMap ...) [v] = insertionForest [] [v] = 0 on both sides.
+    rw [insertionForest_empty_host_nonempty_guests, Multiset.zero_bind]
+    have hm : m = [] := by
+      cases m with
+      | nil => rfl
+      | cons _ _ => simp at hlen
+    subst hm
+    simp only [List.zip_nil_left, List.filterMap_nil,
+               insertionForest_empty_host_nonempty_guests,
+               Multiset.zero_bind, add_zero]
+  | cons b B' ih =>
+    -- m has the form b' :: m' with m'.length = B'.length.
+    cases m with
+    | nil => simp at hlen
+    | cons b' m' =>
+      have hm' : m'.length = B'.length := by
+        simp only [List.length_cons, Nat.add_right_cancel_iff] at hlen
+        exact hlen
+      -- Stage 0 expansion of insertionForest (b :: B') [v].
+      rw [insertionForest_cons_singleton b B' v, Multiset.add_bind]
+      -- Reduce zip & filterMap on the cons.
+      cases b' with
+      | true =>
+        -- m head = true: head b goes into t-bucket.
+        -- zip (b :: B') (true :: m') = (b, true) :: B'.zip m'
+        -- t-bucket = b :: (B'.zip m').filterMap tpick
+        -- f-bucket = (B'.zip m').filterMap fpick
+        show ((insertion b [v]).map (fun T' => T' :: B')).bind
+                (fun B'' =>
+                  G ((B''.zip (true :: m')).filterMap
+                      (fun p => if p.snd then some p.fst else none))
+                    ((B''.zip (true :: m')).filterMap
+                      (fun p => if p.snd then none else some p.fst))) +
+              ((insertionForest B' [v]).map (fun F' => b :: F')).bind
+                (fun B'' =>
+                  G ((B''.zip (true :: m')).filterMap
+                      (fun p => if p.snd then some p.fst else none))
+                    ((B''.zip (true :: m')).filterMap
+                      (fun p => if p.snd then none else some p.fst))) = _
+        rw [Multiset.bind_map, Multiset.bind_map]
+        -- Inside each bind: zip with true at head.
+        -- (T' :: B').zip (true :: m') = (T', true) :: B'.zip m'
+        -- filterMap tpick = T' :: (B'.zip m').filterMap tpick
+        -- filterMap fpick = (B'.zip m').filterMap fpick
+        -- (b :: F').zip (true :: m') = (b, true) :: F'.zip m'
+        -- filterMap tpick = b :: (F'.zip m').filterMap tpick
+        -- filterMap fpick = (F'.zip m').filterMap fpick
+        -- For the second part, apply IH at m'.
+        have hl1 :
+            ((insertion b [v]).bind fun T' =>
+              G (T' :: (B'.zip m').filterMap (fun p => if p.snd then some p.fst else none))
+                ((B'.zip m').filterMap (fun p => if p.snd then none else some p.fst))) =
+            (insertion b [v]).bind fun T' =>
+              G ((((T' :: B').zip (true :: m')).filterMap
+                  (fun p => if p.snd then some p.fst else none)))
+                ((((T' :: B').zip (true :: m')).filterMap
+                  (fun p => if p.snd then none else some p.fst))) := by
+          refine Multiset.bind_congr fun T' _ => ?_
+          show G (T' :: _) _ = G _ _
+          rfl
+        have hl2 :
+            ((insertionForest B' [v]).bind fun F' =>
+              G (b :: (F'.zip m').filterMap (fun p => if p.snd then some p.fst else none))
+                ((F'.zip m').filterMap (fun p => if p.snd then none else some p.fst))) =
+            (insertionForest B' [v]).bind fun F' =>
+              G ((((b :: F').zip (true :: m')).filterMap
+                  (fun p => if p.snd then some p.fst else none)))
+                ((((b :: F').zip (true :: m')).filterMap
+                  (fun p => if p.snd then none else some p.fst))) := by
+          refine Multiset.bind_congr fun F' _ => ?_
+          show G (b :: _) _ = G _ _
+          rfl
+        rw [← hl1, ← hl2]
+        -- Apply IH to the second summand at m' with `G_b := fun W W' => G (b :: W) W'`.
+        -- This rewrites it into the t-bucket+f-bucket form (relative to `B'`).
+        have hIH := ih (m := m') (G := fun W W' => G (b :: W) W') hm'
+        rw [hIH]
+        -- RHS: insertionForest (b :: tT) [v] decomposes via Stage 0 into
+        --   (insertion b [v]).map (· :: tT) + (insertionForest tT [v]).map (b :: ·)
+        -- which after binding with G(·, fT) splits into exactly the first two LHS summands.
+        show _ + (_ + _) = _ + _
+        -- Show RHS first term equals first + middle of LHS.
+        have h_rhs_t :
+            ((((b :: B').zip (true :: m')).filterMap
+                (fun p => if p.snd then some p.fst else none))) =
+            b :: ((B'.zip m').filterMap (fun p => if p.snd then some p.fst else none)) := rfl
+        have h_rhs_f :
+            ((((b :: B').zip (true :: m')).filterMap
+                (fun p => if p.snd then none else some p.fst))) =
+            ((B'.zip m').filterMap (fun p => if p.snd then none else some p.fst)) := rfl
+        rw [h_rhs_t, h_rhs_f]
+        rw [insertionForest_cons_singleton b _ v]
+        rw [Multiset.add_bind, Multiset.bind_map, Multiset.bind_map]
+        rw [add_assoc]
+      | false =>
+        -- m head = false: head b goes into f-bucket.
+        -- zip (b :: B') (false :: m') = (b, false) :: B'.zip m'
+        -- t-bucket = (B'.zip m').filterMap tpick
+        -- f-bucket = b :: (B'.zip m').filterMap fpick
+        show ((insertion b [v]).map (fun T' => T' :: B')).bind
+                (fun B'' =>
+                  G ((B''.zip (false :: m')).filterMap
+                      (fun p => if p.snd then some p.fst else none))
+                    ((B''.zip (false :: m')).filterMap
+                      (fun p => if p.snd then none else some p.fst))) +
+              ((insertionForest B' [v]).map (fun F' => b :: F')).bind
+                (fun B'' =>
+                  G ((B''.zip (false :: m')).filterMap
+                      (fun p => if p.snd then some p.fst else none))
+                    ((B''.zip (false :: m')).filterMap
+                      (fun p => if p.snd then none else some p.fst))) = _
+        rw [Multiset.bind_map, Multiset.bind_map]
+        have hl1 :
+            ((insertion b [v]).bind fun T' =>
+              G ((B'.zip m').filterMap (fun p => if p.snd then some p.fst else none))
+                (T' :: (B'.zip m').filterMap (fun p => if p.snd then none else some p.fst))) =
+            (insertion b [v]).bind fun T' =>
+              G ((((T' :: B').zip (false :: m')).filterMap
+                  (fun p => if p.snd then some p.fst else none)))
+                ((((T' :: B').zip (false :: m')).filterMap
+                  (fun p => if p.snd then none else some p.fst))) := by
+          refine Multiset.bind_congr fun T' _ => ?_
+          show G _ (T' :: _) = G _ _
+          rfl
+        have hl2 :
+            ((insertionForest B' [v]).bind fun F' =>
+              G ((F'.zip m').filterMap (fun p => if p.snd then some p.fst else none))
+                (b :: (F'.zip m').filterMap (fun p => if p.snd then none else some p.fst))) =
+            (insertionForest B' [v]).bind fun F' =>
+              G ((((b :: F').zip (false :: m')).filterMap
+                  (fun p => if p.snd then some p.fst else none)))
+                ((((b :: F').zip (false :: m')).filterMap
+                  (fun p => if p.snd then none else some p.fst))) := by
+          refine Multiset.bind_congr fun F' _ => ?_
+          show G _ (b :: _) = G _ _
+          rfl
+        rw [← hl1, ← hl2]
+        -- Apply IH at m' with G_b := fun W W' => G W (b :: W').
+        have hIH := ih (m := m') (G := fun W W' => G W (b :: W')) hm'
+        rw [hIH]
+        show _ + (_ + _) = _ + _
+        have h_rhs_t :
+            ((((b :: B').zip (false :: m')).filterMap
+                (fun p => if p.snd then some p.fst else none))) =
+            ((B'.zip m').filterMap (fun p => if p.snd then some p.fst else none)) := rfl
+        have h_rhs_f :
+            ((((b :: B').zip (false :: m')).filterMap
+                (fun p => if p.snd then none else some p.fst))) =
+            b :: ((B'.zip m').filterMap (fun p => if p.snd then none else some p.fst)) := rfl
+        rw [h_rhs_t, h_rhs_f]
+        rw [insertionForest_cons_singleton b _ v]
+        rw [Multiset.add_bind, Multiset.bind_map, Multiset.bind_map]
+        -- LHS = A + (X + Y), RHS = X' + (A' + Y')
+        -- where A = (insertion b [v]).bind (T' => G tT (T' :: fT))
+        --       X = (insertionForest tT [v]).bind (W => G W (b :: fT))
+        --       Y = (insertionForest fT [v]).bind (W' => G tT (b :: W'))
+        --       X' = (insertionForest tT [v]).bind (W => G W (b :: fT))  [same as X]
+        --       A' = (insertion b [v]).bind (T' => G tT (T' :: fT))      [same as A]
+        --       Y' = (insertionForest fT [v]).bind (W' => G tT (b :: W'))  [same as Y]
+        -- So LHS = A + X + Y, RHS = X + A + Y, equal by add_left_comm.
+        rw [← add_assoc, ← add_assoc, add_comm
+              ((insertion b [v]).bind _)
+              ((insertionForest _ [v]).bind _)]
+
+/-- Forest-host singleton-guest associativity. Raw planar multiset
+    equality; the nonplanar `insertionMultiset` form follows by the
+    standard quotient descent. -/
+theorem insertionForest_bind_singleton (A B : List (Planar α))
+    (v : Planar α) :
+    (insertionForest A B).bind (fun X => insertionForest X [v]) =
+      insertionForest A (v :: B) +
+      (insertionForest B [v]).bind (fun B' => insertionForest A B') := by
+  induction A generalizing B with
+  | nil =>
+    -- LHS: (insertionForest [] B).bind = either {[]}.bind (when B = []) or 0.bind (when B nonempty)
+    -- RHS: insertionForest [] (v::B) = 0 (since v::B is nonempty), plus the second term.
+    cases B with
+    | nil =>
+      -- LHS = {[]}.bind (insertionForest · [v]) = insertionForest [] [v] = 0
+      rw [insertionForest_nil_nil, Multiset.singleton_bind,
+          insertionForest_empty_host_nonempty_guests]
+      -- RHS = insertionForest [] [v] + (insertionForest [] [v]).bind ... = 0 + 0.bind = 0
+      rw [Multiset.zero_bind, add_zero]
+    | cons b B' =>
+      -- LHS = 0.bind = 0
+      rw [insertionForest_empty_host_nonempty_guests, Multiset.zero_bind]
+      -- RHS: insertionForest [] (v::b::B') + (insertionForest (b::B') [v]).bind (insertionForest [] ·)
+      rw [insertionForest_empty_host_nonempty_guests, zero_add]
+      -- (insertionForest (b::B') [v]).bind (insertionForest [] ·): each output forest is non-empty
+      -- so insertionForest [] of nonempty list = 0; bind sums to 0.
+      rw [insertionForest_singleton_guest_set]
+      rw [Multiset.bind_assoc]
+      -- Goal: bind k, (map q ...).bind (insertionForest [] ·) = 0
+      rw [show (fun k : Fin (b :: B').length =>
+              (((vertices (b :: B')[k] : List Path) : Multiset Path).map
+                (fun q => (b :: B').set k.val (insertAt q v (b :: B')[k]))).bind
+              (insertionForest ([] : List (Planar α)))) =
+            (fun _ : Fin (b :: B').length => (0 : Multiset (List (Planar α)))) from by
+          funext k
+          rw [Multiset.bind_map]
+          -- Each inner: insertionForest [] (b::B').set k _ — nonempty because set preserves cons-shape
+          -- Show: bind q ∈ vertices, 0 = 0 via bind_zero
+          have set_cons_form : ∀ (xs : List (Planar α)) (n : ℕ) (w : Planar α),
+              ∃ x' xs', ((b :: xs).set n w : List (Planar α)) = x' :: xs' := by
+            intro xs n w
+            cases n with
+            | zero => exact ⟨w, xs, rfl⟩
+            | succ n' => exact ⟨b, xs.set n' w, rfl⟩
+          have : ∀ q,
+              insertionForest ([] : List (Planar α))
+                ((b :: B').set k.val (insertAt q v (b :: B')[k])) = 0 := by
+            intro q
+            obtain ⟨x', xs', hxs⟩ := set_cons_form B' k.val (insertAt q v (b :: B')[k])
+            rw [hxs]
+            exact insertionForest_empty_host_nonempty_guests x' xs'
+          rw [show ((vertices (b :: B')[k] : List Path) : Multiset Path).bind
+                (fun q => insertionForest ([] : List (Planar α))
+                  ((b :: B').set k.val (insertAt q v (b :: B')[k]))) =
+                  ((vertices (b :: B')[k] : List Path) : Multiset Path).bind
+                  (fun _ => (0 : Multiset (List (Planar α)))) from by
+                refine Multiset.bind_congr fun q _ => ?_
+                exact this q]
+          rw [Multiset.bind_zero]]
+      rw [Multiset.bind_zero]
+  | cons T A' ih =>
+    -- See `scratch/validate_s5.lean` for the computational validation of this
+    -- statement.  Strategy (writing tpick/fpick for the bucket filterMaps):
+    --
+    --   LHS expansion: expand `insertionForest (T::A') B` via cons_assignment,
+    --   push the outer `(· .bind insertionForest · [v])` through the bind chain,
+    --   apply Stage 0 (`insertionForest_cons_singleton`) to the inner
+    --   `insertionForest (T'::F') [v]`, then distribute via `bind_add`:
+    --     LHS = Σ_m [L1(m) + L2(m)]
+    --   where (with B_t := (B.zip m).tpick, B_f := (B.zip m).fpick)
+    --     L1(m) = (insertion T B_t).bind (T' =>
+    --              (insertionForest A' B_f).bind (F' =>
+    --                (insertion T' [v]).map (· :: F')))
+    --     L2(m) = (insertion T B_t).bind (T' =>
+    --              (insertionForest A' B_f).bind (F' =>
+    --                (insertionForest F' [v]).map (T' :: ·)))
+    --
+    --   For L1(m), swap the F'-bind and T''-bind via `bind_bind`, fold via
+    --   `bind_assoc`, then apply C4 (`insertion_bind_singleton`) to
+    --   `(insertion T B_t).bind (T' => insertion T' [v])`:
+    --     L1(m) = L1a(m) + L1b(m)
+    --   with
+    --     L1a(m) = (insertion T (v :: B_t)).bind (T'' =>
+    --                (insertionForest A' B_f).map (T'' :: ·))
+    --     L1b(m) = (insertionForest B_t [v]).bind (Bt' =>
+    --                (insertion T Bt').bind (T'' =>
+    --                  (insertionForest A' B_f).map (T'' :: ·)))
+    --
+    --   For L2(m), unfold the inner map to a bind-then-singleton, swap the F'-
+    --   and singleton-binds via `bind_assoc`, apply the IH to
+    --   `(insertionForest A' B_f).bind (F' => insertionForest F' [v])`, then
+    --   redistribute via `bind_add` and refold to a map:
+    --     L2(m) = L2a(m) + L2b(m)
+    --   with
+    --     L2a(m) = (insertion T B_t).bind (T' =>
+    --                (insertionForest A' (v :: B_f)).map (T' :: ·))
+    --     L2b(m) = (insertion T B_t).bind (T' =>
+    --                ((insertionForest B_f [v]).bind (insertionForest A')).map (T' :: ·))
+    --
+    --   RHS expansion. RHS term 1 = `insertionForest (T::A') (v::B)` via cons_assignment
+    --   over guests `v::B` (length B.length + 1). Peel the v-decision via
+    --   `ofList_listChoices_succ_local`: the b=true branch gives Σ_m L1a, the b=false
+    --   branch gives Σ_m L2a. RHS term 2 = (insertionForest B [v]).bind (B' =>
+    --   insertionForest (T::A') B'); expand the inner cons_assignment, swap outer
+    --   B'-bind with mask-bind, then for each mask apply Stage 6
+    --   (`insertionForest_singleton_bucket_split`) with consumer
+    --   `G Bt Bf = (insertion T Bt).bind (T' => (insertionForest A' Bf).map (T' :: ·))`.
+    --   That gives Σ_m [L1b + L2b].
+    --
+    --   Stage 7 (assemble): Σ_m [L1a + L1b + L2a + L2b] = (Σ_m L1a + Σ_m L2a)
+    --     + (Σ_m L1b + Σ_m L2b) by bind_add + add_assoc/comm.
+    --
+    -- Canonical sum-of-four form, parameterized by mask. Both LHS and RHS reduce to
+    --   Σ_m [L1a + L1b + L2a + L2b]
+    -- where (with B_t := (B.zip m).filterMap tp, B_f := (B.zip m).filterMap fp):
+    --   L1a m = (insertion T (v :: B_t)).bind (T' => (insertionForest A' B_f).map (T' :: ·))
+    --   L1b m = ((insertionForest B_t [v]).bind (insertion T)).bind (T'' => (insertionForest A' B_f).map (T'' :: ·))
+    --   L2a m = (insertion T B_t).bind (T' => (insertionForest A' (v :: B_f)).map (T' :: ·))
+    --   L2b m = (insertion T B_t).bind (T' => ((insertionForest B_f [v]).bind (insertionForest A')).map (T' :: ·))
+    set tp : Planar α × Bool → Option (Planar α) :=
+      fun p => if p.snd then some p.fst else none with htp_def
+    set fp : Planar α × Bool → Option (Planar α) :=
+      fun p => if p.snd then none else some p.fst with hfp_def
+    set L1a : List Bool → Multiset (List (Planar α)) := fun m =>
+      (insertion T (v :: (B.zip m).filterMap tp)).bind fun T' =>
+        (insertionForest A' ((B.zip m).filterMap fp)).map (T' :: ·) with hL1a_def
+    set L1b : List Bool → Multiset (List (Planar α)) := fun m =>
+      ((insertionForest ((B.zip m).filterMap tp) [v]).bind
+        fun Bt' => insertion T Bt').bind fun T'' =>
+          (insertionForest A' ((B.zip m).filterMap fp)).map (T'' :: ·) with hL1b_def
+    set L2a : List Bool → Multiset (List (Planar α)) := fun m =>
+      (insertion T ((B.zip m).filterMap tp)).bind fun T' =>
+        (insertionForest A' (v :: (B.zip m).filterMap fp)).map (T' :: ·) with hL2a_def
+    set L2b : List Bool → Multiset (List (Planar α)) := fun m =>
+      (insertion T ((B.zip m).filterMap tp)).bind fun T' =>
+        ((insertionForest ((B.zip m).filterMap fp) [v]).bind
+          (fun B'' => insertionForest A' B'')).map (T' :: ·) with hL2b_def
+    -- LHS = canon.
+    have h_lhs : ((insertionForest (T :: A') B).bind fun X => insertionForest X [v]) =
+        (Multiset.ofList (listChoices [true, false] B.length)).bind fun m =>
+          L1a m + L1b m + L2a m + L2b m := by
+      rw [insertionForest_cons_assignment, Multiset.bind_assoc]
+      refine Multiset.bind_congr fun m _ => ?_
+      -- per-mask, the LHS body
+      --   = (insertion T B_t).bind (T' => (insertionForest A' B_f).map (T' :: ·)).bind (insertionForest · [v])
+      -- We show this equals L1a m + L1b m + L2a m + L2b m.
+      rw [Multiset.bind_assoc]
+      -- inner T'-body becomes (insertionForest A' B_f).map (T' :: ·) .bind (insertionForest · [v])
+      --                     = (insertionForest A' B_f).bind (F' => insertionForest (T' :: F') [v])  [bind_map]
+      conv_lhs =>
+        rhs; ext T'
+        rw [Multiset.bind_map]
+      -- Apply Stage 0 in the inner F'-body, distribute bind_add and map_add.
+      conv_lhs =>
+        rhs; ext T'; rhs; ext F'
+        rw [insertionForest_cons_singleton T' F' v]
+      conv_lhs =>
+        rhs; ext T'
+        rw [Multiset.bind_add]
+      rw [Multiset.bind_add]
+      -- LHS = (insertion T B_t).bind (T' => bind F' (insertion T' [v]).map (· :: F'))
+      --     + (insertion T B_t).bind (T' => bind F' (insertionForest F' [v]).map (T' :: ·))
+      --
+      -- First summand reshape: swap F'-bind with the (insertion T' [v]).map via converting
+      -- map → singleton-bind and Multiset.bind_bind.
+      have h1 :
+          ((insertion T ((B.zip m).filterMap tp)).bind fun T' =>
+            (insertionForest A' ((B.zip m).filterMap fp)).bind fun F' =>
+              (insertion T' [v]).map (fun T'' => T'' :: F')) =
+          L1a m + L1b m := by
+        -- Step 1: convert inner .map to bind {·}, swap binds, refold to map.
+        conv_lhs =>
+          rhs; ext T'; rhs; ext F'
+          rw [show (insertion T' [v]).map (fun T'' => T'' :: F') =
+                (insertion T' [v]).bind (fun T'' => ({T'' :: F'} : Multiset _)) from by
+              rw [Multiset.bind_singleton]]
+        conv_lhs =>
+          rhs; ext T'
+          rw [Multiset.bind_bind]
+        conv_lhs =>
+          rhs; ext T'; rhs; ext T''
+          rw [show ((insertionForest A' ((B.zip m).filterMap fp)).bind
+                    fun F' => ({T'' :: F'} : Multiset _)) =
+                (insertionForest A' ((B.zip m).filterMap fp)).map (T'' :: ·) from by
+              rw [Multiset.bind_singleton]]
+        -- Now: (insertion T B_t).bind (T' => (insertion T' [v]).bind (T'' => (insertionForest A' B_f).map (T'' :: ·)))
+        --    = ((insertion T B_t).bind (T' => insertion T' [v])).bind (T'' => ...)   [bind_assoc]
+        rw [← Multiset.bind_assoc]
+        -- Apply C4: (insertion T B_t).bind (T' => insertion T' [v]) = insertion T (v :: B_t) + (insertionForest B_t [v]).bind (insertion T)
+        rw [insertion_bind_singleton T ((B.zip m).filterMap tp) v]
+        rw [Multiset.add_bind]
+        -- = L1a m + L1b m by definitional unfolding of L1a, L1b (rw closes)
+      -- Second summand reshape: pull (insertionForest F' [v]) outside via map → bind {·} → bind_assoc → refold.
+      have h2 :
+          ((insertion T ((B.zip m).filterMap tp)).bind fun T' =>
+            (insertionForest A' ((B.zip m).filterMap fp)).bind fun F' =>
+              (insertionForest F' [v]).map (T' :: ·)) =
+          L2a m + L2b m := by
+        -- Step 1: For each T', the inner .bind F' .map (T' :: ·) = (bind F' (iF F' [v])).map (T' :: ·)
+        conv_lhs =>
+          rhs; ext T'
+          rw [show ((insertionForest A' ((B.zip m).filterMap fp)).bind fun F' =>
+                (insertionForest F' [v]).map (T' :: ·)) =
+                ((insertionForest A' ((B.zip m).filterMap fp)).bind fun F' =>
+                  insertionForest F' [v]).map (T' :: ·) from by
+              conv_lhs =>
+                rhs; ext F'
+                rw [show (insertionForest F' [v]).map (fun X => T' :: X) =
+                      (insertionForest F' [v]).bind (fun X => ({T' :: X} : Multiset _)) from by
+                    rw [Multiset.bind_singleton]]
+              rw [← Multiset.bind_assoc]
+              rw [show ((insertionForest A' ((B.zip m).filterMap fp)).bind fun F' =>
+                      insertionForest F' [v]).bind (fun X => ({T' :: X} : Multiset _)) =
+                    ((insertionForest A' ((B.zip m).filterMap fp)).bind fun F' =>
+                      insertionForest F' [v]).map (T' :: ·) from by
+                  rw [Multiset.bind_singleton]]]
+        -- Step 2: apply IH to inner double bind.
+        rw [show ((insertionForest A' ((B.zip m).filterMap fp)).bind fun F' =>
+                  insertionForest F' [v]) =
+              insertionForest A' (v :: (B.zip m).filterMap fp) +
+              (insertionForest ((B.zip m).filterMap fp) [v]).bind
+                fun B' => insertionForest A' B' from ih _]
+        -- Step 3: distribute .map over +, then T'-bind over +.
+        conv_lhs =>
+          rhs; ext T'
+          rw [Multiset.map_add]
+        rw [Multiset.bind_add]
+      rw [h1, h2, ← add_assoc]
+    rw [h_lhs]
+    -- Now goal: Σ_m [L1a + L1b + L2a + L2b] = insertionForest (T::A') (v::B) + (insertionForest B [v]).bind ...
+    -- We rewrite both RHS terms to the canonical form.
+    -- RHS term 1: insertionForest (T::A') (v::B) = Σ_m [L1a m + L2a m]
+    have h_rhs_term1 : insertionForest (T :: A') (v :: B) =
+        (Multiset.ofList (listChoices [true, false] B.length)).bind fun m => L1a m + L2a m := by
+      rw [insertionForest_cons_assignment T A' (v :: B)]
+      rw [show (v :: B).length = B.length + 1 from rfl,
+          ofList_listChoices_succ_local [true, false] B.length]
+      rw [Multiset.bind_assoc]
+      rw [show (Multiset.ofList [true, false] : Multiset Bool) =
+              true ::ₘ false ::ₘ 0 from rfl,
+          Multiset.cons_bind, Multiset.cons_bind, Multiset.zero_bind, add_zero]
+      rw [Multiset.bind_map, Multiset.bind_map]
+      rw [← Multiset.bind_add]
+      refine Multiset.bind_congr fun m _ => ?_
+      -- per-mask: body(true :: m) + body(false :: m) = L1a m + L2a m
+      -- body(b :: m) = (insertion T ((v::B).zip (b::m)).filterMap tp).bind (T' => (insertionForest A' (...filterMap fp)).map (T' :: ·))
+      -- For b = true: filterMap tp gives v :: B_t, filterMap fp gives B_f → L1a m.
+      -- For b = false: filterMap tp gives B_t, filterMap fp gives v :: B_f → L2a m.
+      show _ = L1a m + L2a m
+      rfl
+    rw [h_rhs_term1]
+    -- RHS term 2: (insertionForest B [v]).bind (insertionForest (T :: A')) = Σ_m [L1b m + L2b m]
+    have h_rhs_term2 :
+        ((insertionForest B [v]).bind fun B' => insertionForest (T :: A') B') =
+        (Multiset.ofList (listChoices [true, false] B.length)).bind fun m => L1b m + L2b m := by
+      -- Inside the outer bind, expand insertionForest (T :: A') B' via cons_assignment.
+      -- All B' in insertionForest B [v] have B'.length = B.length (by insertionForest_singleton_guest_set).
+      have hB'_len : ∀ B' ∈ insertionForest B [v], B'.length = B.length := by
+        intro B' hB'
+        rw [insertionForest_singleton_guest_set] at hB'
+        rw [Multiset.mem_bind] at hB'
+        obtain ⟨k, _, hk⟩ := hB'
+        rw [Multiset.mem_map] at hk
+        obtain ⟨_, _, hk'⟩ := hk
+        rw [← hk', List.length_set]
+      rw [Multiset.bind_congr (g := fun B' =>
+            (Multiset.ofList (listChoices [true, false] B.length)).bind fun m =>
+              (insertion T ((B'.zip m).filterMap tp)).bind fun T' =>
+                (insertionForest A' ((B'.zip m).filterMap fp)).map fun F' => T' :: F')
+            (by
+              intro B' hB'
+              rw [insertionForest_cons_assignment, hB'_len B' hB'])]
+      rw [Multiset.bind_bind]
+      refine Multiset.bind_congr fun m hm => ?_
+      -- For this m, apply Stage 6 (bucketing). Need m.length = B.length.
+      have hm_mem : m ∈ listChoices [true, false] B.length := by
+        rwa [Multiset.mem_coe] at hm
+      have hm_len : m.length = B.length :=
+        mem_listChoices_length [true, false] B.length m hm_mem
+      have hbucket := insertionForest_singleton_bucket_split B m v
+        (fun Bt Bf => (insertion T Bt).bind fun T' =>
+          (insertionForest A' Bf).map fun F' => T' :: F') hm_len
+      -- hbucket states:
+      --   (insertionForest B [v]).bind (B' => (insertion T B'_t).bind (T' => (iF A' B'_f).map (T' :: ·)))
+      --   = (insertionForest B_t [v]).bind (W => G W B_f) + (insertionForest B_f [v]).bind (W' => G B_t W')
+      -- with G Bt Bf := (insertion T Bt).bind (T' => (iF A' Bf).map (T' :: ·))
+      -- The first summand of the RHS is L1b m (need bind_assoc to refold), the second is L2b m.
+      rw [hbucket]
+      -- L1b m: refold ((insertionForest B_t [v]).bind (insertion T)).bind (T'' => ...) from
+      --   (insertionForest B_t [v]).bind (Bt' => (insertion T Bt').bind ...)
+      show (insertionForest ((B.zip m).filterMap tp) [v]).bind (fun W =>
+              (insertion T W).bind fun T' =>
+                (insertionForest A' ((B.zip m).filterMap fp)).map fun F' => T' :: F') +
+            (insertionForest ((B.zip m).filterMap fp) [v]).bind (fun W' =>
+              (insertion T ((B.zip m).filterMap tp)).bind fun T' =>
+                (insertionForest A' W').map fun F' => T' :: F') = L1b m + L2b m
+      rw [hL1b_def, hL2b_def]
+      simp only
+      congr 1
+      · -- L1b: ((iF B_t [v]).bind (insertion T)).bind (T'' => (iF A' B_f).map (T'' :: ·))
+        --    = (iF B_t [v]).bind (W => (insertion T W).bind (T' => (iF A' B_f).map (T' :: ·)))   [bind_assoc]
+        rw [Multiset.bind_assoc]
+      · -- L2b: (insertion T B_t).bind (T' => ((iF B_f [v]).bind (iF A')).map (T' :: ·))
+        --    = (iF B_f [v]).bind (W' => (insertion T B_t).bind (T' => (iF A' W').map (T' :: ·)))
+        -- Push the .map (T' :: ·) inside the bind via Multiset.map_bind, then swap binds.
+        conv_rhs =>
+          rhs; ext T'
+          rw [Multiset.map_bind]
+        rw [Multiset.bind_bind]
+    rw [h_rhs_term2]
+    -- Final: rearrange Σ_m [L1a + L1b + L2a + L2b] = Σ_m [L1a + L2a] + Σ_m [L1b + L2b]
+    rw [← Multiset.bind_add]
+    refine Multiset.bind_congr fun m _ => ?_
+    -- Pure rearrangement in an additive comm monoid (a + b + c + d = a + c + (b + d)).
+    abel
+
+end Pathed
+
+end Planar
+
+end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridge.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridge.lean
@@ -36,30 +36,28 @@ construction to the concrete Grossman-Larson product on
 ## Main theorems
 
 * `gl_product_eq_oudomGuinStar` (Q5c) : `★` transported via `ckIsoSymmetricAlgebra`
-  equals the Grossman-Larson product. Currently `sorry`-fenced.
+  equals the Grossman-Larson product. **Proved sorry-free** 2026-06-12.
 
 * `GrossmanLarson.mul_assoc_basis_via_oudom_guin_pbw` (Q6) : closure of
   `mul_assoc_basis` for `R = ℤ` using `oudomGuinStar_assoc` + Q5c.
-  Currently `sorry`-fenced (depends on Q3's mul case + Q5c).
+  **Proved sorry-free** 2026-06-12 (Q3 + Q5c both closed).
 
 ## Status
 
-This file is the **Option 2 exploration** for the
-`[[project-prelie-pbw-pivot]]`: verify the bridge structure works
-BEFORE committing to the ~600-950 LOC Sweedler bash for Q3's mul case.
-
-If Q5c proves tractable (~50-150 LOC), Q3's bash is worth the investment.
-If Q5c has its own obstacles, the project pivots elsewhere.
+Q3 + Q5c + Q6 chain fully proved. Grossman-Larson associativity over ℤ
+is now established via the OG `★` bridge.
+`#print axioms RootedTree.GrossmanLarson.mul_assoc_basis_via_oudom_guin_pbw`
+yields `[propext, Classical.choice, Quot.sound]` (no sorryAx).
 -/
 
 open PreLie.OudomGuinCirc
 
 namespace RootedTree
 
--- OG `oudomGuinStar` is declared with `variable {L : Type}` (universe 0).
--- Restrict `α : Type` so `Nonplanar α : Type`, `InsertionAlgebra α : Type`.
--- Universe-polymorphizing OG is deferred to mathlib-quality polish.
-variable {α : Type} [DecidableEq (Nonplanar α)]
+-- `α : Type*` since OG `oudomGuinStar` is now universe-polymorphic
+-- (Phase 1 of the GL-associativity arc; `circT` is the only Type-0-pinned
+-- exception, not used here).
+variable {α : Type*} [DecidableEq (Nonplanar α)]
 
 /-! ## §1: The carrier iso
 
@@ -918,33 +916,651 @@ private theorem ckIso_circ_intertwine_insertion
           ConnesKreimer.of' ({t} : Multiset _) from
         ckIsoSymmetricAlgebra_ι_single t]
 
-/-- **Substrate 2 for Q5c** — DEPRECATED (2026-05-17). This identity was
-    invented for the per-tprod induction strategy of `gl_product_eq_oudomGuinStar`.
-    Audit revealed:
+/-! ### Substrate 2: GL guest-splitting identity (OG Prop 2.7(ii) GL side)
 
-    1. The identity is the GL/CK transport of OG `oudomGuinStar_mul_ι_split`.
-    2. Reducing the basis case proves to require the singleton-{v} case of
-       `Nonplanar.insertionMultiset_assoc` (the A3.3 keystone sorry).
-    3. **OG paper §3.2 (Prop 3.2) does NOT use this identity.** OG proves
-       Q5c-equivalent via B+/B- duality with Δ^ρ: show `B-(A ∗ B) =
-       ε(A) B-(B) + B-(A) ∗ B` and conclude via pairing nondegeneracy.
+The four-term identity below is the GL-side analog of Oudom-Guin's
+splitting lemma (Prop 2.7(ii)). Originally flagged as "abandoned"
+during the 2026-05-17 audit because its singleton-`{v}` reduction
+needed `Nonplanar.insertionMultiset_assoc` (the A3.3 keystone), at
+that point unproved. With the singleton case
+`Nonplanar.insertionMultiset_singleton_assoc` since closed
+sorry-free, this is now the live route for the per-tprod `m+1`
+induction of `gl_product_eq_oudomGuinStar`. -/
 
-    The OG-faithful route is now the active plan; see
-    `[[feedback-substrate2-not-og]]` and `[[project-q5c-architecture]]`.
-    Substrate infrastructure required for the new route:
-    - `GrossmanLarsonPairing.lean` (sorry-free, incl. nondegeneracy).
-    - `Nonplanar.autCard` (Aut.lean, sorry-free).
-    - `Δ^ρ` cocycle (PruningNonplanar.lean, sorry-free) — REUSED.
-    - `B+_a` operator (PruningNonplanar.lean, sorry-free) — REUSED.
+/-- **Helper for substrate 2**: iterated single-guest insertion
+    `ins (ins F (of' C)) (op of'{v})` splits into a "single-shot"
+    `ins F (of' (C + {v}))` term plus a sum over `Y ∈ NIM C {v}`
+    of `ins F (of' Y)`. The basis case `F = of' A` follows directly
+    from `insertion_of'_of'` (twice) plus
+    `Nonplanar.insertionMultiset_singleton_assoc`. -/
+private theorem GL_iterated_insertion_singleton_v
+    (F : GrossmanLarson ℤ α) (C : Forest (Nonplanar α)) (v : Nonplanar α) :
+    GrossmanLarson.insertion
+        (GrossmanLarson.insertion F (ConnesKreimer.of' C))
+        (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+      GrossmanLarson.insertion F (ConnesKreimer.of' (C + {v})) +
+      ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
+        (fun Y => GrossmanLarson.insertion F (ConnesKreimer.of' Y))).sum := by
+  -- Define helper LinearMaps for cleaner manipulation.
+  set ins : GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α :=
+    GrossmanLarson.insertion with hins
+  -- Linearize F. Both sides are F-linear by bilinearity of `insertion`.
+  refine Finsupp.induction_linear F ?_ ?_ ?_
+  · -- F = 0: both sides reduce to 0.
+    show ins (ins 0 (ConnesKreimer.of' C))
+          (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+        ins 0 (ConnesKreimer.of' (C + {v})) +
+        ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
+          (fun Y => ins 0 (ConnesKreimer.of' Y))).sum
+    have h_ins_zero : ∀ Y : GrossmanLarson ℤ α, ins 0 Y = 0 := fun Y =>
+      (ins.flip Y).map_zero
+    rw [h_ins_zero, h_ins_zero, h_ins_zero, zero_add]
+    symm
+    apply Multiset.sum_eq_zero
+    intro x hx
+    rw [Multiset.mem_map] at hx
+    obtain ⟨Y, _, hY_eq⟩ := hx
+    rw [← hY_eq]
+    exact h_ins_zero _
+  · -- F = F₁ + F₂: by linearity in F on both sides.
+    intro F₁ F₂ ih₁ ih₂
+    let F₁' : GrossmanLarson ℤ α := F₁
+    let F₂' : GrossmanLarson ℤ α := F₂
+    show ins (ins (F₁' + F₂') (ConnesKreimer.of' C))
+          (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+        ins (F₁' + F₂') (ConnesKreimer.of' (C + {v})) +
+        ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
+          (fun Y => ins (F₁' + F₂') (ConnesKreimer.of' Y))).sum
+    -- Use a uniform "insertion respects + in first arg" helper:
+    have hins_add_left : ∀ (X Y : GrossmanLarson ℤ α) (Z : GrossmanLarson ℤ α),
+        ins (X + Y) Z = ins X Z + ins Y Z := fun X Y Z => by
+      rw [show ins (X + Y) = ins X + ins Y from ins.map_add X Y]
+      rfl
+    have hinner : ins (F₁' + F₂') (ConnesKreimer.of' C : GrossmanLarson ℤ α) =
+        ins F₁' (ConnesKreimer.of' C : GrossmanLarson ℤ α) +
+        ins F₂' (ConnesKreimer.of' C : GrossmanLarson ℤ α) :=
+      hins_add_left F₁' F₂' _
+    rw [show ins (F₁' + F₂') (ConnesKreimer.of' C) =
+            ins F₁' (ConnesKreimer.of' C : GrossmanLarson ℤ α) +
+            ins F₂' (ConnesKreimer.of' C : GrossmanLarson ℤ α) from hinner]
+    rw [hins_add_left]
+    rw [ih₁, ih₂]
+    rw [show ins (F₁' + F₂') (ConnesKreimer.of' (C + {v})) =
+            ins F₁' (ConnesKreimer.of' (C + {v}) : GrossmanLarson ℤ α) +
+            ins F₂' (ConnesKreimer.of' (C + {v}) : GrossmanLarson ℤ α) from
+        hins_add_left F₁' F₂' _]
+    have h_split_sum :
+        ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
+          (fun Y => ins (F₁' + F₂') (ConnesKreimer.of' Y : GrossmanLarson ℤ α))).sum =
+        ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
+          (fun Y => ins F₁' (ConnesKreimer.of' Y : GrossmanLarson ℤ α))).sum +
+        ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
+          (fun Y => ins F₂' (ConnesKreimer.of' Y : GrossmanLarson ℤ α))).sum := by
+      rw [← Multiset.sum_map_add]
+      apply congr_arg Multiset.sum
+      apply Multiset.map_congr rfl
+      intro Y _
+      exact hins_add_left F₁' F₂' _
+    rw [h_split_sum]
+    abel
+  · -- F = single A r — basis case.
+    intro A r
+    let F_single : GrossmanLarson ℤ α := Finsupp.single A r
+    show ins (ins F_single (ConnesKreimer.of' C))
+          (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+        ins F_single (ConnesKreimer.of' (C + {v})) +
+        ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
+          (fun Y => ins F_single (ConnesKreimer.of' Y))).sum
+    -- ins is bilinear; reduce F_single = r • of' A.
+    have hF : F_single = r • (GrossmanLarson.of' A : GrossmanLarson ℤ α) := by
+      show (Finsupp.single A r : GrossmanLarson ℤ α) =
+            r • (GrossmanLarson.of' A : GrossmanLarson ℤ α)
+      show (Finsupp.single A r : ConnesKreimer ℤ (Nonplanar α)) =
+            r • (ConnesKreimer.of' A : ConnesKreimer ℤ _)
+      rw [ConnesKreimer.of'_apply]
+      exact (Finsupp.smul_single_one A r).symm
+    rw [hF]
+    -- Helper: insertion respects smul in first arg.
+    have hins_smul_left : ∀ (X Z : GrossmanLarson ℤ α),
+        ins (r • X) Z = r • ins X Z := fun X Z => by
+      rw [show ins (r • X) = r • ins X from ins.map_smul r X]
+      rfl
+    rw [hins_smul_left]
+    -- Now LHS has `ins (r • ins (of'A) (of'C)) (op of'{v}) = r • ins (ins (of'A) (of'C)) (op of'{v})`
+    rw [show ins (r • ins (GrossmanLarson.of' A : GrossmanLarson ℤ α)
+                  (ConnesKreimer.of' C : GrossmanLarson ℤ α))
+              (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+            r • ins (ins (GrossmanLarson.of' A : GrossmanLarson ℤ α)
+                  (ConnesKreimer.of' C : GrossmanLarson ℤ α))
+              (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) from
+        hins_smul_left _ _]
+    rw [hins_smul_left]
+    -- Sum side: pull r out.
+    have h_smul_sum :
+        ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
+          (fun Y => ins (r • (GrossmanLarson.of' A : GrossmanLarson ℤ α))
+            (ConnesKreimer.of' Y : GrossmanLarson ℤ α))).sum =
+        r • ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
+          (fun Y => ins (GrossmanLarson.of' A : GrossmanLarson ℤ α)
+            (ConnesKreimer.of' Y : GrossmanLarson ℤ α))).sum := by
+      rw [Multiset.smul_sum, Multiset.map_map]
+      apply congr_arg Multiset.sum
+      apply Multiset.map_congr rfl
+      intro Y _
+      exact hins_smul_left _ _
+    rw [h_smul_sum, ← smul_add]
+    -- Reduce to basis identity at F = of' A.
+    congr 1
+    -- Basis identity: ins(ins(of'A)(of'C))(op of'{v}) = ins(of'A)(of'(C+{v})) +
+    --                                                  Σ_{Y ∈ NIM C {v}} ins(of'A)(of'Y)
+    rw [hins]
+    show GrossmanLarson.insertion
+        (GrossmanLarson.insertion (GrossmanLarson.of' A : GrossmanLarson ℤ α)
+          (GrossmanLarson.of' C : GrossmanLarson ℤ α))
+        (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α) = _
+    rw [GrossmanLarson.insertion_of'_of']
+    -- Inner: insertionBasis A C = (NIM A C).map of'.sum.
+    show GrossmanLarson.insertion
+        (((Nonplanar.insertionMultiset A C).map
+          fun F' => GrossmanLarson.of' (R := ℤ) F').sum)
+        (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α) = _
+    -- Push insertion through the sum via insertion_sum_left.
+    rw [GrossmanLarson.insertion_sum_left, Multiset.map_map]
+    -- Per X ∈ NIM A C, insertion (of' X) (of' {v}) = insertionBasis X {v}.
+    have h_per_X : ∀ X : Forest (Nonplanar α),
+        GrossmanLarson.insertion (GrossmanLarson.of' X)
+            (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α) =
+          ((Nonplanar.insertionMultiset X ({v} : Multiset _)).map
+            fun F' => GrossmanLarson.of' (R := ℤ) F').sum := by
+      intro X
+      rw [GrossmanLarson.insertion_of'_of']
+      rfl
+    -- Rewrite the inner expression. After Multiset.map_map, the goal's map function
+    -- has shape (fun X => insertion (of' X) (of'{v}) : GrossmanLarson ℤ α).
+    rw [show ((fun (Y : GrossmanLarson ℤ α) =>
+              GrossmanLarson.insertion Y
+                (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α)) ∘
+              fun (F' : Forest (Nonplanar α)) => GrossmanLarson.of' (R := ℤ) F') =
+          (fun X : Forest (Nonplanar α) =>
+            ((Nonplanar.insertionMultiset X ({v} : Multiset _)).map
+              fun F' => GrossmanLarson.of' (R := ℤ) F').sum) from by
+        funext X
+        exact h_per_X X]
+    -- Push the outer sum: ((bind).map of').sum form.
+    rw [show ((Nonplanar.insertionMultiset A C).map
+              (fun X => ((Nonplanar.insertionMultiset X ({v} : Multiset _)).map
+                fun F' => GrossmanLarson.of' (R := ℤ) F').sum)).sum =
+            (((Nonplanar.insertionMultiset A C).bind
+                fun X => Nonplanar.insertionMultiset X ({v} : Multiset _)).map
+              fun F' => GrossmanLarson.of' (R := ℤ) F').sum from by
+          rw [Multiset.map_bind, Multiset.sum_bind]]
+    -- Apply insertionMultiset_singleton_assoc.
+    rw [Nonplanar.insertionMultiset_singleton_assoc]
+    rw [Multiset.map_add, Multiset.sum_add]
+    congr 1
+    · -- Left: NIM A (C + {v}) → ins (of' A) (of' (C+{v})) = insertionBasis A (C+{v}).
+      rw [show GrossmanLarson.insertion (GrossmanLarson.of' A : GrossmanLarson ℤ α)
+                  (ConnesKreimer.of' (C + {v}) : GrossmanLarson ℤ α) =
+              GrossmanLarson.insertion (GrossmanLarson.of' A : GrossmanLarson ℤ α)
+                (GrossmanLarson.of' (C + {v}) : GrossmanLarson ℤ α) from rfl,
+          GrossmanLarson.insertion_of'_of']
+      rfl
+    · -- Right: (NIM C {v}).bind (NIM A ·) → Σ_{Y ∈ NIM C {v}} ins (of'A) (of'Y).
+      rw [Multiset.map_bind, Multiset.sum_bind]
+      apply congr_arg Multiset.sum
+      apply Multiset.map_congr rfl
+      intro Y _
+      rw [show (ConnesKreimer.of' Y : GrossmanLarson ℤ α) =
+              (GrossmanLarson.of' Y : GrossmanLarson ℤ α) from rfl,
+          GrossmanLarson.insertion_of'_of']
+      rfl
 
-    Substrate 2 is preserved as a sorry below to mark the abandoned path
-    and to let the per-tprod m+1 case (which references it) typecheck.
-    Closure via the deprecated combinatorial route is NOT recommended.
+/-- Generic "swap two outer sums" lemma. Used in `GL_T2_reindexing_key`. -/
+private theorem swap_sum_map_sum {β γ δ : Type*} [AddCommMonoid δ]
+    (s : Multiset β) (t : Multiset γ) (f : γ → β → δ) :
+    (s.map (fun b => (t.map (fun c => f c b)).sum)).sum =
+    (t.map (fun c => (s.map (fun b => f c b)).sum)).sum := by
+  induction s using Multiset.induction with
+  | empty =>
+    rw [Multiset.map_zero, Multiset.sum_zero]
+    -- RHS: (t.map (fun c => (0.map _).sum)).sum = (t.map (fun _ => 0)).sum = 0.
+    symm
+    apply Multiset.sum_eq_zero
+    intro x hx
+    rw [Multiset.mem_map] at hx
+    obtain ⟨c, _, hc_eq⟩ := hx
+    rw [← hc_eq, Multiset.map_zero, Multiset.sum_zero]
+  | cons a s ih =>
+    rw [Multiset.map_cons, Multiset.sum_cons, ih, ← Multiset.sum_map_add]
+    apply congr_arg Multiset.sum
+    apply Multiset.map_congr rfl
+    intro c _
+    rw [Multiset.map_cons, Multiset.sum_cons]
 
-    Original statement (additive, avoiding GL subtraction):
-    `F * op (G * of'({v})) + F * insertion (op G) (op (of'({v})))
-       = insertion (F * op G) (op (of'({v}))) + op (unop (F * op G) * of'({v}))`
--/
+/-- Sum of a bind of singletons equals the sum of the map. -/
+private theorem sum_bind_singleton {γ δ : Type*} [AddCommMonoid δ]
+    (s : Multiset γ) (f : γ → δ) :
+    (s.bind fun x => ({f x} : Multiset δ)).sum = (s.map f).sum := by
+  induction s using Multiset.induction with
+  | empty => rfl
+  | cons a s ih =>
+    rw [Multiset.cons_bind, Multiset.singleton_add, Multiset.sum_cons,
+        Multiset.map_cons, Multiset.sum_cons, ← ih]
+
+/-- Helper: `mk`-image of the t-bucket of a List (Planar α). -/
+private theorem zip_filter_t_map_mk (L : List (Planar α)) (m : List Bool) :
+    ((L.map Nonplanar.mk).zip m).filterMap
+        (fun p : Nonplanar α × Bool => if p.snd then some p.fst else none) =
+      ((L.zip m).filterMap
+        (fun p : Planar α × Bool => if p.snd then some p.fst else none)).map
+          Nonplanar.mk := by
+  induction L generalizing m with
+  | nil => rfl
+  | cons x L ih =>
+    cases m with
+    | nil => rfl
+    | cons b m =>
+      cases b with
+      | true =>
+        show Nonplanar.mk x :: (((L.map Nonplanar.mk).zip m).filterMap _) =
+          (x :: ((L.zip m).filterMap _)).map Nonplanar.mk
+        rw [ih m]; rfl
+      | false => exact ih m
+
+/-- Helper: `mk`-image of the f-bucket of a List (Planar α). -/
+private theorem zip_filter_f_map_mk (L : List (Planar α)) (m : List Bool) :
+    ((L.map Nonplanar.mk).zip m).filterMap
+        (fun p : Nonplanar α × Bool => if p.snd then none else some p.fst) =
+      ((L.zip m).filterMap
+        (fun p : Planar α × Bool => if p.snd then none else some p.fst)).map
+          Nonplanar.mk := by
+  induction L generalizing m with
+  | nil => rfl
+  | cons x L ih =>
+    cases m with
+    | nil => rfl
+    | cons b m =>
+      cases b with
+      | true => exact ih m
+      | false =>
+        show Nonplanar.mk x :: (((L.map Nonplanar.mk).zip m).filterMap _) =
+          (x :: ((L.zip m).filterMap _)).map Nonplanar.mk
+        rw [ih m]; rfl
+
+/-- **T2 reindexing key step**: the multiset-level reindexing that
+    expresses `F * insertion (op (of' B)) (op of'{v})` (expanded via
+    `mul_of'_sum_form` over `NIM B {v}`) as a sum over `B.powerset`.
+    This is the planar bucket-split lemma after descent through
+    `listChoices_bridge_powerset_paired`.
+
+    Stated abstractly to be reusable: for any consumer `g`, the LHS sum
+    (over `X' ∈ NIM B {v}`, then `D ⊆ X'`) equals the RHS sum (over
+    `C₁ ⊆ B`, splitting whether `v` lands in the powerset side or its
+    complement). -/
+private theorem GL_T2_reindexing_key
+    (B : Forest (Nonplanar α)) (v : Nonplanar α)
+    (g : Multiset (Nonplanar α) → Multiset (Nonplanar α) → GrossmanLarson ℤ α) :
+    letI : DecidableEq (Nonplanar α) := Classical.decEq _
+    ((Nonplanar.insertionMultiset B ({v} : Multiset _)).map (fun X' =>
+        (X'.powerset.map fun D => g D (X' - D)).sum)).sum =
+      (B.powerset.map fun C₁ =>
+        ((Nonplanar.insertionMultiset C₁ ({v} : Multiset _)).map
+            (fun Y => g Y (B - C₁))).sum +
+        ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
+            (fun Y' => g C₁ Y')).sum).sum := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  -- Canonical planar reps.
+  set B_pl : List (Planar α) := B.toList.map Quotient.out with hB_pl_def
+  set ov : Planar α := Quotient.out v with hov_def
+  -- Mask filterMaps (Planar α).
+  set tp : Planar α × Bool → Option (Planar α) :=
+    fun p => if p.snd then some p.fst else none with htp_def
+  set fp : Planar α × Bool → Option (Planar α) :=
+    fun p => if p.snd then none else some p.fst with hfp_def
+  -- msform : List (Planar α) → Multiset (Nonplanar α).
+  set msform : List (Planar α) → Multiset (Nonplanar α) :=
+    fun L => (↑(L.map Nonplanar.mk) : Multiset (Nonplanar α)) with hmsform_def
+  -- §0: every B' ∈ iF B_pl [ov] has length B_pl.length.
+  have hB'_len : ∀ B' ∈ Planar.Pathed.insertionForest B_pl [ov],
+      B'.length = B_pl.length := by
+    intro B' hB'
+    rw [Planar.Pathed.insertionForest_singleton_guest_set] at hB'
+    rw [Multiset.mem_bind] at hB'
+    obtain ⟨k, _, hk⟩ := hB'
+    rw [Multiset.mem_map] at hk
+    obtain ⟨_, _, hk'⟩ := hk
+    rw [← hk', List.length_set]
+  -- §0b: B_pl.map mk recovers B.toList; ↑B_pl.toList recovers B.
+  have h_B_pl_map_mk : B_pl.map Nonplanar.mk = B.toList := by
+    rw [hB_pl_def, List.map_map]
+    exact (List.map_congr_left fun x _ => Quotient.out_eq x).trans (List.map_id _)
+  have hB_eq_msform_Bpl : B = msform B_pl := by
+    show B = (↑(B_pl.map Nonplanar.mk) : Multiset (Nonplanar α))
+    rw [h_B_pl_map_mk]; exact B.coe_toList.symm
+  -- §1: rewrite NIM B {v} as the canonical planar bind.
+  have hNIM_B : Nonplanar.insertionMultiset B ({v} : Multiset _) =
+      (Planar.Pathed.insertionForest B_pl [ov]).map msform := by
+    apply Nonplanar.insertionMultiset_eq_of_reps
+    · show (Multiset.ofList ((B.toList.map Quotient.out).map Nonplanar.mk) :
+            Multiset (Nonplanar α)) = B
+      rw [← hB_pl_def, h_B_pl_map_mk]
+      exact B.coe_toList
+    · show (Multiset.ofList ([Nonplanar.mk (Quotient.out v)]) :
+            Multiset (Nonplanar α)) = ({v} : Multiset _)
+      rw [show Nonplanar.mk (Quotient.out v) = v from Quotient.out_eq v]; rfl
+  -- §2: per-B' powerset bridge: rewrite the inner powerset.map sum via masks.
+  have h_powerset_per_B' : ∀ B' ∈ Planar.Pathed.insertionForest B_pl [ov],
+      ((msform B').powerset.map (fun D => g D (msform B' - D))).sum =
+      ((Multiset.ofList (Planar.Pathed.listChoices [true, false] B_pl.length)).map
+        (fun assn => g (msform ((B'.zip assn).filterMap tp))
+                       (msform ((B'.zip assn).filterMap fp)))).sum := by
+    intro B' hB'
+    have hlen := hB'_len B' hB'
+    have h_len_mk : (B'.map Nonplanar.mk).length = B_pl.length := by
+      rw [List.length_map]; exact hlen
+    have h_bridge := Planar.Pathed.listChoices_bridge_powerset_paired
+      (l := B'.map Nonplanar.mk)
+    rw [h_len_mk] at h_bridge
+    have h_post := congr_arg
+      (Multiset.map (fun pr : Multiset (Nonplanar α) × Multiset (Nonplanar α) =>
+        g pr.1 pr.2)) h_bridge
+    rw [Multiset.map_map, Multiset.map_map] at h_post
+    -- h_post:
+    --   (lc).map (assn ↦ g (filter_t over mk-list) (filter_f over mk-list)) =
+    --   (↑(B'.map mk)).powerset.map (s ↦ g s (↑(B'.map mk) - s))
+    -- Take sums of both sides; the RHS unfolds to our (msform B').powerset.map sum.
+    have h_sum_eq := congr_arg Multiset.sum h_post
+    -- Goal LHS = h_sum_eq RHS (modulo defeq on msform B' = ↑(B'.map mk)).
+    -- So flip h_sum_eq.
+    show (((↑(B'.map Nonplanar.mk) : Multiset (Nonplanar α))).powerset.map
+            (fun D => g D ((↑(B'.map Nonplanar.mk) : Multiset (Nonplanar α)) - D))).sum =
+          ((Multiset.ofList (Planar.Pathed.listChoices [true, false] B_pl.length)).map
+            (fun assn => g (msform ((B'.zip assn).filterMap tp))
+                           (msform ((B'.zip assn).filterMap fp)))).sum
+    -- Reshape h_sum_eq RHS to use D : Multiset (Nonplanar α).
+    have h_sum_rhs :
+        (((↑(B'.map Nonplanar.mk) : Multiset (Nonplanar α))).powerset.map
+            (fun D => g D ((↑(B'.map Nonplanar.mk) : Multiset (Nonplanar α)) - D))).sum =
+        (((↑(B'.map Nonplanar.mk) : Multiset (Nonplanar α))).powerset.map
+          ((fun pr : Multiset (Nonplanar α) × Multiset (Nonplanar α) => g pr.1 pr.2) ∘
+            fun s => (s, (↑(B'.map Nonplanar.mk) : Multiset (Nonplanar α)) - s))).sum := by
+      rfl
+    rw [h_sum_rhs, ← h_sum_eq]
+    apply congr_arg Multiset.sum
+    apply Multiset.map_congr rfl
+    intro assn _
+    show g ((↑(((B'.map Nonplanar.mk).zip assn).filterMap
+              (fun p : Nonplanar α × Bool => if p.snd then some p.fst else none)) :
+              Multiset (Nonplanar α)))
+         ((↑(((B'.map Nonplanar.mk).zip assn).filterMap
+              (fun p : Nonplanar α × Bool => if p.snd then none else some p.fst)) :
+              Multiset (Nonplanar α))) =
+       g (msform ((B'.zip assn).filterMap tp)) (msform ((B'.zip assn).filterMap fp))
+    congr 1
+    · show (↑(((B'.map Nonplanar.mk).zip assn).filterMap
+            (fun p : Nonplanar α × Bool => if p.snd then some p.fst else none)) :
+            Multiset (Nonplanar α)) = msform ((B'.zip assn).filterMap tp)
+      rw [zip_filter_t_map_mk B' assn]
+    · show (↑(((B'.map Nonplanar.mk).zip assn).filterMap
+            (fun p : Nonplanar α × Bool => if p.snd then none else some p.fst)) :
+            Multiset (Nonplanar α)) = msform ((B'.zip assn).filterMap fp)
+      rw [zip_filter_f_map_mk B' assn]
+  -- §3: LHS = (iF B_pl [ov]).map (B' ↦ inner sum) |>.sum.
+  rw [hNIM_B, Multiset.map_map]
+  -- Now: ((iF B_pl [ov]).map ((fun X' => ...) ∘ msform)).sum
+  -- Equivalent (by composition unfolding): ((iF B_pl [ov]).map (fun B' => (msform B').powerset.map ...).sum)).sum
+  -- Use Multiset.map_congr with the composition-form lhs.
+  rw [show ((Planar.Pathed.insertionForest B_pl [ov]).map
+            ((fun X' => (X'.powerset.map fun D => g D (X' - D)).sum) ∘ msform)).sum =
+        ((Planar.Pathed.insertionForest B_pl [ov]).map
+          (fun B' => ((msform B').powerset.map (fun D => g D (msform B' - D))).sum)).sum
+      from rfl]
+  -- Per-B' rewrite via h_powerset_per_B'.
+  rw [show ((Planar.Pathed.insertionForest B_pl [ov]).map
+              (fun B' => ((msform B').powerset.map (fun D => g D (msform B' - D))).sum)).sum =
+            ((Planar.Pathed.insertionForest B_pl [ov]).map
+              (fun B' =>
+                ((Multiset.ofList (Planar.Pathed.listChoices [true, false] B_pl.length)).map
+                  (fun assn => g (msform ((B'.zip assn).filterMap tp))
+                                 (msform ((B'.zip assn).filterMap fp)))).sum)).sum
+        from by
+      apply congr_arg Multiset.sum
+      apply Multiset.map_congr rfl
+      intro B' hB'
+      exact h_powerset_per_B' B' hB']
+  -- §4: swap outer/inner sums.
+  rw [swap_sum_map_sum (Planar.Pathed.insertionForest B_pl [ov])
+    (Multiset.ofList (Planar.Pathed.listChoices [true, false] B_pl.length))
+    (fun assn B' => g (msform ((B'.zip assn).filterMap tp))
+                      (msform ((B'.zip assn).filterMap fp)))]
+  -- §5: per-mask, apply the bucket-split.
+  have h_per_mask : ∀ assn ∈
+      (Multiset.ofList (Planar.Pathed.listChoices [true, false] B_pl.length) :
+        Multiset (List Bool)),
+      ((Planar.Pathed.insertionForest B_pl [ov]).map
+          (fun B' => g (msform ((B'.zip assn).filterMap tp))
+                       (msform ((B'.zip assn).filterMap fp)))).sum =
+        ((Planar.Pathed.insertionForest ((B_pl.zip assn).filterMap tp) [ov]).map
+            (fun W => g (msform W) (msform ((B_pl.zip assn).filterMap fp)))).sum +
+        ((Planar.Pathed.insertionForest ((B_pl.zip assn).filterMap fp) [ov]).map
+            (fun W' => g (msform ((B_pl.zip assn).filterMap tp)) (msform W'))).sum := by
+    intro assn h_mem
+    have h_mem' : assn ∈ Planar.Pathed.listChoices [true, false] B_pl.length := by
+      rwa [Multiset.mem_coe] at h_mem
+    have hlen : assn.length = B_pl.length :=
+      Planar.Pathed.mem_listChoices_length [true, false] B_pl.length assn h_mem'
+    have hbucket := Planar.Pathed.insertionForest_singleton_bucket_split
+      B_pl assn ov
+      (fun L R => ({g (msform L) (msform R)} : Multiset (GrossmanLarson ℤ α))) hlen
+    have h_apply := congr_arg Multiset.sum hbucket
+    rw [Multiset.sum_add] at h_apply
+    rw [sum_bind_singleton, sum_bind_singleton, sum_bind_singleton] at h_apply
+    exact h_apply
+  rw [Multiset.map_congr rfl h_per_mask]
+  -- §6 SKIPPED: keep single mask sum (sum of A + B). We bridge both sides at once.
+  -- §7: now bridge each mask-sum to a powerset sum via `listChoices_bridge_powerset_paired`.
+  -- For both summands, we go from a function of `assn → ...` to a function of `(s_t, s_f) → ...`
+  -- via the bridge.
+  -- §7a: define the per-pair consumer FUN1 for the first mask sum.
+  set FUN1 : Multiset (Nonplanar α) × Multiset (Nonplanar α) → GrossmanLarson ℤ α :=
+    fun pr =>
+      letI : DecidableEq (Nonplanar α) := Classical.decEq _
+      ((Nonplanar.insertionMultiset pr.1 ({v} : Multiset _)).map
+        (fun Y => g Y pr.2)).sum with hFUN1_def
+  set FUN2 : Multiset (Nonplanar α) × Multiset (Nonplanar α) → GrossmanLarson ℤ α :=
+    fun pr =>
+      letI : DecidableEq (Nonplanar α) := Classical.decEq _
+      ((Nonplanar.insertionMultiset pr.2 ({v} : Multiset _)).map
+        (fun Y' => g pr.1 Y')).sum with hFUN2_def
+  -- §7b: rewrite each per-mask term as FUN1(pair) and FUN2(pair).
+  -- For mask assn:
+  --   First per-mask term = FUN1 (msform B_pl_t, msform B_pl_f) by rep lemma + msform expansion.
+  --   Second per-mask term = FUN2 (msform B_pl_t, msform B_pl_f) by rep lemma + msform expansion.
+  -- Then sum over masks = sum over (mskform * mskform) pairs = (via bridge) sum over (s, B-s) pairs.
+  -- We use `insertionMultiset_eq_of_reps` to recover NIM (msform L) {v} from (iF L [ov]).map msform.
+  have h_assn_to_FUN1 : ∀ assn,
+      ((Planar.Pathed.insertionForest ((B_pl.zip assn).filterMap tp) [ov]).map
+          (fun W => g (msform W) (msform ((B_pl.zip assn).filterMap fp)))).sum =
+        FUN1 (msform ((B_pl.zip assn).filterMap tp),
+              msform ((B_pl.zip assn).filterMap fp)) := by
+    intro assn
+    show ((Planar.Pathed.insertionForest ((B_pl.zip assn).filterMap tp) [ov]).map
+            (fun W => g (msform W) (msform ((B_pl.zip assn).filterMap fp)))).sum =
+        ((Nonplanar.insertionMultiset
+          (msform ((B_pl.zip assn).filterMap tp)) ({v} : Multiset _)).map
+            (fun Y => g Y (msform ((B_pl.zip assn).filterMap fp)))).sum
+    -- Use `insertionMultiset_eq_of_reps` to compute NIM(msform L_t) {v}.
+    rw [show Nonplanar.insertionMultiset
+          (msform ((B_pl.zip assn).filterMap tp)) ({v} : Multiset _) =
+          (Planar.Pathed.insertionForest ((B_pl.zip assn).filterMap tp) [ov]).map msform from by
+        apply Nonplanar.insertionMultiset_eq_of_reps
+        · rfl
+        · show (Multiset.ofList ([Nonplanar.mk ov]) : Multiset (Nonplanar α)) = ({v} : Multiset _)
+          rw [hov_def, show Nonplanar.mk (Quotient.out v) = v from Quotient.out_eq v]; rfl]
+    rw [Multiset.map_map]
+    rfl
+  have h_assn_to_FUN2 : ∀ assn,
+      ((Planar.Pathed.insertionForest ((B_pl.zip assn).filterMap fp) [ov]).map
+          (fun W' => g (msform ((B_pl.zip assn).filterMap tp)) (msform W'))).sum =
+        FUN2 (msform ((B_pl.zip assn).filterMap tp),
+              msform ((B_pl.zip assn).filterMap fp)) := by
+    intro assn
+    show ((Planar.Pathed.insertionForest ((B_pl.zip assn).filterMap fp) [ov]).map
+            (fun W' => g (msform ((B_pl.zip assn).filterMap tp)) (msform W'))).sum =
+        ((Nonplanar.insertionMultiset
+          (msform ((B_pl.zip assn).filterMap fp)) ({v} : Multiset _)).map
+            (fun Y' => g (msform ((B_pl.zip assn).filterMap tp)) Y')).sum
+    rw [show Nonplanar.insertionMultiset
+          (msform ((B_pl.zip assn).filterMap fp)) ({v} : Multiset _) =
+          (Planar.Pathed.insertionForest ((B_pl.zip assn).filterMap fp) [ov]).map msform from by
+        apply Nonplanar.insertionMultiset_eq_of_reps
+        · rfl
+        · show (Multiset.ofList ([Nonplanar.mk ov]) : Multiset (Nonplanar α)) = ({v} : Multiset _)
+          rw [hov_def, show Nonplanar.mk (Quotient.out v) = v from Quotient.out_eq v]; rfl]
+    rw [Multiset.map_map]
+    rfl
+  -- §7c: rewrite the mask-sums in this FUN1/FUN2 form.
+  rw [show
+      (((Multiset.ofList (Planar.Pathed.listChoices [true, false] B_pl.length)).map
+        (fun assn =>
+          ((Planar.Pathed.insertionForest ((B_pl.zip assn).filterMap tp) [ov]).map
+              (fun W => g (msform W) (msform ((B_pl.zip assn).filterMap fp)))).sum +
+          ((Planar.Pathed.insertionForest ((B_pl.zip assn).filterMap fp) [ov]).map
+              (fun W' => g (msform ((B_pl.zip assn).filterMap tp)) (msform W'))).sum))).sum =
+      ((Multiset.ofList (Planar.Pathed.listChoices [true, false] B_pl.length)).map
+        (fun assn =>
+          FUN1 (msform ((B_pl.zip assn).filterMap tp),
+                msform ((B_pl.zip assn).filterMap fp)) +
+          FUN2 (msform ((B_pl.zip assn).filterMap tp),
+                msform ((B_pl.zip assn).filterMap fp)))).sum
+        from by
+      apply congr_arg Multiset.sum
+      apply Multiset.map_congr rfl
+      intro assn _
+      rw [h_assn_to_FUN1 assn, h_assn_to_FUN2 assn]]
+  -- §8: bridge the mask sum to a powerset sum.
+  -- The mask `assn` maps to the pair `(msform ((B_pl.zip assn).filterMap tp), msform ((B_pl.zip assn).filterMap fp))`.
+  -- The bridge `listChoices_bridge_powerset_paired` applied to `l := B.toList` gives:
+  --   (lc).map (assn ↦ ((filter_t over B.toList), (filter_f over B.toList))) =
+  --   (↑B.toList).powerset.map (s ↦ (s, ↑B.toList - s)) = B.powerset.map (s ↦ (s, B - s))
+  -- since ↑B.toList = B.
+  -- BUT our per-mask function uses `(B_pl.zip assn).filterMap tp` (planar) — not `(B.toList.zip assn).filterMap tpN`.
+  -- We need to bridge between these.
+  -- `msform ((B_pl.zip assn).filterMap tp) = ↑(((B_pl.zip assn).filterMap tp).map mk)`
+  --                                      = ↑((B_pl.map mk).zip assn).filter_tN  [by zip_filter_t_map_mk reverse]
+  --                                      = ↑((B.toList.zip assn).filter_tN)      [by h_B_pl_map_mk]
+  -- So `msform ((B_pl.zip assn).filterMap tp) = ((B.toList.zip assn).filterMap (fun p => if p.snd then some p.fst else none) : Multiset (Nonplanar α))`.
+  -- This is exactly the first component of the bridge pair when applied to `l := B.toList`.
+  have h_to_BtoList_t : ∀ assn,
+      msform ((B_pl.zip assn).filterMap tp) =
+        (((B.toList.zip assn).filterMap
+          (fun p : Nonplanar α × Bool => if p.snd then some p.fst else none) :
+          List (Nonplanar α)) : Multiset (Nonplanar α)) := by
+    intro assn
+    show (↑(((B_pl.zip assn).filterMap tp).map Nonplanar.mk) : Multiset (Nonplanar α)) = _
+    rw [← zip_filter_t_map_mk B_pl assn, h_B_pl_map_mk]
+  have h_to_BtoList_f : ∀ assn,
+      msform ((B_pl.zip assn).filterMap fp) =
+        (((B.toList.zip assn).filterMap
+          (fun p : Nonplanar α × Bool => if p.snd then none else some p.fst) :
+          List (Nonplanar α)) : Multiset (Nonplanar α)) := by
+    intro assn
+    show (↑(((B_pl.zip assn).filterMap fp).map Nonplanar.mk) : Multiset (Nonplanar α)) = _
+    rw [← zip_filter_f_map_mk B_pl assn, h_B_pl_map_mk]
+  -- Rewrite the goal-LHS using h_to_BtoList_t, h_to_BtoList_f, and h_B_pl_map_mk to substitute B_pl.length = B.toList.length.
+  have hB_pl_len : B_pl.length = B.toList.length := by
+    show (B.toList.map Quotient.out).length = B.toList.length
+    rw [List.length_map]
+    rfl
+  rw [show
+      ((Multiset.ofList (Planar.Pathed.listChoices [true, false] B_pl.length)).map
+        (fun assn =>
+          FUN1 (msform ((B_pl.zip assn).filterMap tp),
+                msform ((B_pl.zip assn).filterMap fp)) +
+          FUN2 (msform ((B_pl.zip assn).filterMap tp),
+                msform ((B_pl.zip assn).filterMap fp)))).sum =
+      ((Multiset.ofList (Planar.Pathed.listChoices [true, false] B.toList.length)).map
+        (fun assn =>
+          FUN1 (((B.toList.zip assn).filterMap
+                  (fun p : Nonplanar α × Bool => if p.snd then some p.fst else none) :
+                  Multiset (Nonplanar α)),
+                ((B.toList.zip assn).filterMap
+                  (fun p : Nonplanar α × Bool => if p.snd then none else some p.fst) :
+                  Multiset (Nonplanar α))) +
+          FUN2 (((B.toList.zip assn).filterMap
+                  (fun p : Nonplanar α × Bool => if p.snd then some p.fst else none) :
+                  Multiset (Nonplanar α)),
+                ((B.toList.zip assn).filterMap
+                  (fun p : Nonplanar α × Bool => if p.snd then none else some p.fst) :
+                  Multiset (Nonplanar α))))).sum from by
+    rw [hB_pl_len]
+    apply congr_arg Multiset.sum
+    apply Multiset.map_congr rfl
+    intro assn _
+    rw [h_to_BtoList_t, h_to_BtoList_f]]
+  -- §9: now apply the bridge on `l := B.toList`. The bridge pair function is:
+  --   F(s_t, s_f) := FUN1(s_t, s_f) + FUN2(s_t, s_f).
+  have h_bridge := Planar.Pathed.listChoices_bridge_powerset_paired
+    (β := Nonplanar α) (l := B.toList)
+  -- Apply Multiset.map (uncurry of FUN1 + FUN2) to both sides.
+  have h_compose := congr_arg
+    (Multiset.map (fun pr : Multiset (Nonplanar α) × Multiset (Nonplanar α) =>
+      FUN1 pr + FUN2 pr)) h_bridge
+  rw [Multiset.map_map, Multiset.map_map] at h_compose
+  -- The composition `(fun pr => FUN1 pr + FUN2 pr) ∘ (fun assn => let ...; (s_t, s_f))`
+  -- is defeq to `fun assn => let ...; FUN1 (s_t, s_f) + FUN2 (s_t, s_f)`, but `rw` doesn't
+  -- auto-eta. Substitute via show.
+  have h_compose_sum := congr_arg Multiset.sum h_compose
+  show (((Multiset.ofList (Planar.Pathed.listChoices [true, false] B.toList.length)).map
+        ((fun pr : Multiset (Nonplanar α) × Multiset (Nonplanar α) =>
+            FUN1 pr + FUN2 pr) ∘
+          (fun assn : List Bool =>
+            let s_t : Multiset (Nonplanar α) :=
+              (B.toList.zip assn).filterMap
+                (fun p : Nonplanar α × Bool => if p.snd then some p.fst else none)
+            let s_f : Multiset (Nonplanar α) :=
+              (B.toList.zip assn).filterMap
+                (fun p : Nonplanar α × Bool => if p.snd then none else some p.fst)
+            (s_t, s_f)))).sum) = _
+  rw [h_compose_sum]
+  -- RHS goal form: (B.powerset.map (C₁ ↦ ...)).sum. Note ↑B.toList = B.
+  have hB_coe : (↑B.toList : Multiset (Nonplanar α)) = B := B.coe_toList
+  rw [hB_coe]
+  -- Now: (B.powerset.map (s ↦ FUN1(s, B - s) + FUN2(s, B - s))).sum = goal RHS.
+  apply congr_arg Multiset.sum
+  apply Multiset.map_congr rfl
+  intro C₁ _
+  show FUN1 (C₁, B - C₁) + FUN2 (C₁, B - C₁) =
+        ((Nonplanar.insertionMultiset C₁ ({v} : Multiset _)).map
+            (fun Y => g Y (B - C₁))).sum +
+        ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
+            (fun Y' => g C₁ Y')).sum
+  rfl
+
+/-- **Substrate 2 for Q5c** — REACTIVATED (2026-06-12). The GL-side
+    analog of OG Prop 2.7(ii)'s guest-splitting identity. Originally
+    flagged DEPRECATED on 2026-05-17 because its proof required the
+    singleton-`{v}` case of `Nonplanar.insertionMultiset_assoc` (then
+    the A3.3 keystone sorry). With the singleton case
+    `Nonplanar.insertionMultiset_singleton_assoc` since closed
+    sorry-free, this is now the live route for the per-tprod `m+1`
+    induction step of `gl_product_eq_oudomGuinStar`.
+
+    The four terms (T1 + T2 = T3 + T4):
+    * T1 = `F * op (G * of'{v})` — single-shot CK multiplication.
+    * T2 = `F * insertion (op G) (op of'{v})` — insert v into G first.
+    * T3 = `insertion (F * op G) (op of'{v})` — insert v into the
+      GL-product.
+    * T4 = `op (unop (F * op G) * of'{v})` — append v to the CK image
+      of the GL-product.
+
+    Strategy: linearize G to basis `of' B`, expand T1, T3, T4 via
+    `mul_of'_sum_form` over `Multiset.powerset_cons (v ::ₘ B)`. Apply
+    `GL_insertion_leibniz_left_singleton_guest` summand-wise to T3,
+    then `GL_iterated_insertion_singleton_v` to split each iterated
+    insertion. The match against T2 then uses `GL_T2_reindexing_key`
+    (a multiset reindexing identity proved by descent from the
+    planar bucket-split lemma `insertionForest_singleton_bucket_split`). -/
 private theorem GL_product_split_mul_ι
     (F : GrossmanLarson ℤ α)
     (G : ConnesKreimer ℤ (Nonplanar α))
@@ -956,7 +1572,546 @@ private theorem GL_product_split_mul_ι
         (GrossmanLarson.op (ConnesKreimer.of' {v})) +
       GrossmanLarson.op
         (GrossmanLarson.unop (F * GrossmanLarson.op G) * ConnesKreimer.of' {v}) := by
-  sorry
+  -- Step 0: classical Decidable for Multiset ops.
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  -- Step 1: linearize G to basis. Use the underlying ℤ-linearity of
+  -- both sides in G (each of T1, T2, T3, T4 is a ℤ-linear function of G).
+  -- This standard Finsupp.induction_linear pattern follows
+  -- `insertion_mul_distrib_gen`/`GL_insertion_leibniz_basis_right`.
+  refine Finsupp.induction_linear G ?_ ?_ ?_
+  · -- G = 0 case: T1=T2=T3=T4=0.
+    show F * GrossmanLarson.op
+        ((0 : ConnesKreimer ℤ (Nonplanar α)) * ConnesKreimer.of' {v}) +
+        F * GrossmanLarson.insertion
+              (GrossmanLarson.op (0 : ConnesKreimer ℤ (Nonplanar α)))
+              (GrossmanLarson.op (ConnesKreimer.of' {v})) =
+        GrossmanLarson.insertion (F * GrossmanLarson.op
+            (0 : ConnesKreimer ℤ (Nonplanar α)))
+          (GrossmanLarson.op (ConnesKreimer.of' {v})) +
+        GrossmanLarson.op
+          (GrossmanLarson.unop (F * GrossmanLarson.op
+            (0 : ConnesKreimer ℤ (Nonplanar α))) * ConnesKreimer.of' {v})
+    -- Rewrite step-by-step to avoid pattern-mismatch from compound rewrites.
+    rw [show GrossmanLarson.op (0 : ConnesKreimer ℤ (Nonplanar α)) =
+          (0 : GrossmanLarson ℤ α) from rfl]
+    rw [GrossmanLarson.mul_zero_gl]
+    rw [zero_mul, op_zero, GrossmanLarson.mul_zero_gl]
+    -- LHS: 0 + F * insertion 0 (op of'{v}); push insertion 0 = 0.
+    have h_ins_zero : GrossmanLarson.insertion (0 : GrossmanLarson ℤ α)
+        (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) = 0 :=
+      ((GrossmanLarson.insertion :
+          GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α).flip
+        (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _)))).map_zero
+    rw [h_ins_zero]
+    rw [GrossmanLarson.mul_zero_gl,
+        show GrossmanLarson.unop (0 : GrossmanLarson ℤ α) =
+          (0 : ConnesKreimer ℤ (Nonplanar α)) from rfl,
+        zero_mul, op_zero]
+  · -- G = G₁ + G₂ additive case.
+    intro G₁ G₂ ih₁ ih₂
+    -- Use let-bindings to cast Finsupp into ConnesKreimer.
+    let G₁' : ConnesKreimer ℤ (Nonplanar α) := G₁
+    let G₂' : ConnesKreimer ℤ (Nonplanar α) := G₂
+    show F * GrossmanLarson.op ((G₁' + G₂') * ConnesKreimer.of' {v}) +
+        F * GrossmanLarson.insertion (GrossmanLarson.op (G₁' + G₂'))
+            (GrossmanLarson.op (ConnesKreimer.of' {v})) =
+      GrossmanLarson.insertion (F * GrossmanLarson.op (G₁' + G₂'))
+        (GrossmanLarson.op (ConnesKreimer.of' {v})) +
+      GrossmanLarson.op
+        (GrossmanLarson.unop (F * GrossmanLarson.op (G₁' + G₂')) *
+          ConnesKreimer.of' {v})
+    -- Distribute (G₁' + G₂') through each operation. We rewrite each subterm
+    -- to a (G₁'-part + G₂'-part) form, then apply ih₁, ih₂.
+    -- T1: F * op((G₁'+G₂') * of'{v}) = F * op(G₁'*of'{v}) + F * op(G₂'*of'{v}).
+    have hT1 : F * GrossmanLarson.op
+          ((G₁' + G₂') * ConnesKreimer.of' ({v} : Multiset _)) =
+        F * GrossmanLarson.op (G₁' * ConnesKreimer.of' ({v} : Multiset _)) +
+        F * GrossmanLarson.op (G₂' * ConnesKreimer.of' ({v} : Multiset _)) := by
+      rw [add_mul,
+          show GrossmanLarson.op
+            (G₁' * ConnesKreimer.of' ({v} : Multiset _) +
+             G₂' * ConnesKreimer.of' ({v} : Multiset _)) =
+          GrossmanLarson.op (G₁' * ConnesKreimer.of' ({v} : Multiset _)) +
+          GrossmanLarson.op (G₂' * ConnesKreimer.of' ({v} : Multiset _)) from rfl]
+      exact (GrossmanLarson.product F).map_add _ _
+    rw [hT1]
+    -- T2: F * ins(op(G₁'+G₂'))(op of'{v}) = F * ins(opG₁')... + F * ins(opG₂')...
+    have hT2 : F * GrossmanLarson.insertion (GrossmanLarson.op (G₁' + G₂'))
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+        F * GrossmanLarson.insertion (GrossmanLarson.op G₁')
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) +
+        F * GrossmanLarson.insertion (GrossmanLarson.op G₂')
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) := by
+      rw [show GrossmanLarson.op (G₁' + G₂') =
+              GrossmanLarson.op G₁' + GrossmanLarson.op G₂' from rfl]
+      rw [show GrossmanLarson.insertion (GrossmanLarson.op G₁' + GrossmanLarson.op G₂')
+              (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+            GrossmanLarson.insertion (GrossmanLarson.op G₁')
+              (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) +
+            GrossmanLarson.insertion (GrossmanLarson.op G₂')
+              (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) from by
+        show ((GrossmanLarson.insertion :
+                GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α).flip
+              (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))))
+              (GrossmanLarson.op G₁' + GrossmanLarson.op G₂') = _
+        rw [LinearMap.map_add]; rfl]
+      exact (GrossmanLarson.product F).map_add _ _
+    rw [hT2]
+    -- T3: ins(F * op(G₁'+G₂'))(op of'{v}) = ins(F * opG₁')(...) + ins(F * opG₂')(...)
+    have hT3 : GrossmanLarson.insertion (F * GrossmanLarson.op (G₁' + G₂'))
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+        GrossmanLarson.insertion (F * GrossmanLarson.op G₁')
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) +
+        GrossmanLarson.insertion (F * GrossmanLarson.op G₂')
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) := by
+      rw [show GrossmanLarson.op (G₁' + G₂') =
+              GrossmanLarson.op G₁' + GrossmanLarson.op G₂' from rfl]
+      rw [show F * (GrossmanLarson.op G₁' + GrossmanLarson.op G₂') =
+              F * GrossmanLarson.op G₁' + F * GrossmanLarson.op G₂' from
+          (GrossmanLarson.product F).map_add _ _]
+      show ((GrossmanLarson.insertion :
+              GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α).flip
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))))
+            (F * GrossmanLarson.op G₁' + F * GrossmanLarson.op G₂') = _
+      rw [LinearMap.map_add]; rfl
+    rw [hT3]
+    -- T4: op (unop (F * op (G₁'+G₂')) * of'{v}) similarly.
+    have hT4 : GrossmanLarson.op
+            (GrossmanLarson.unop (F * GrossmanLarson.op (G₁' + G₂')) *
+              ConnesKreimer.of' ({v} : Multiset _)) =
+        GrossmanLarson.op
+            (GrossmanLarson.unop (F * GrossmanLarson.op G₁') *
+              ConnesKreimer.of' ({v} : Multiset _)) +
+        GrossmanLarson.op
+            (GrossmanLarson.unop (F * GrossmanLarson.op G₂') *
+              ConnesKreimer.of' ({v} : Multiset _)) := by
+      rw [show GrossmanLarson.op (G₁' + G₂') =
+              GrossmanLarson.op G₁' + GrossmanLarson.op G₂' from rfl]
+      rw [show F * (GrossmanLarson.op G₁' + GrossmanLarson.op G₂') =
+              F * GrossmanLarson.op G₁' + F * GrossmanLarson.op G₂' from
+          (GrossmanLarson.product F).map_add _ _]
+      rw [show GrossmanLarson.unop (F * GrossmanLarson.op G₁' + F * GrossmanLarson.op G₂') =
+              GrossmanLarson.unop (F * GrossmanLarson.op G₁') +
+              GrossmanLarson.unop (F * GrossmanLarson.op G₂') from rfl,
+          add_mul]
+      rfl
+    rw [hT4]
+    -- Use ih₁, ih₂ via specialized casts (G₁', G₂' are CK by let-binding).
+    have ih₁' :
+        F * GrossmanLarson.op (G₁' * ConnesKreimer.of' ({v} : Multiset _)) +
+        F * GrossmanLarson.insertion (GrossmanLarson.op G₁')
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+      GrossmanLarson.insertion (F * GrossmanLarson.op G₁')
+          (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) +
+      GrossmanLarson.op
+        (GrossmanLarson.unop (F * GrossmanLarson.op G₁') *
+          ConnesKreimer.of' ({v} : Multiset _)) := ih₁
+    have ih₂' :
+        F * GrossmanLarson.op (G₂' * ConnesKreimer.of' ({v} : Multiset _)) +
+        F * GrossmanLarson.insertion (GrossmanLarson.op G₂')
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+      GrossmanLarson.insertion (F * GrossmanLarson.op G₂')
+          (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) +
+      GrossmanLarson.op
+        (GrossmanLarson.unop (F * GrossmanLarson.op G₂') *
+          ConnesKreimer.of' ({v} : Multiset _)) := ih₂
+    -- Combine: the goal has the shape (A₁ + A₂) + (B₁ + B₂) = (C₁ + C₂) + (D₁ + D₂)
+    -- where Aᵢ + Bᵢ = Cᵢ + Dᵢ. Add ih₁' + ih₂' and re-permute.
+    -- Abel-rearrange LHS to (A₁ + B₁) + (A₂ + B₂); apply ih₁', ih₂'; abel back.
+    have hLHS_perm :
+        F * GrossmanLarson.op (G₁' * ConnesKreimer.of' ({v} : Multiset _)) +
+        F * GrossmanLarson.op (G₂' * ConnesKreimer.of' ({v} : Multiset _)) +
+        (F * GrossmanLarson.insertion (GrossmanLarson.op G₁')
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) +
+         F * GrossmanLarson.insertion (GrossmanLarson.op G₂')
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _)))) =
+      (F * GrossmanLarson.op (G₁' * ConnesKreimer.of' ({v} : Multiset _)) +
+        F * GrossmanLarson.insertion (GrossmanLarson.op G₁')
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _)))) +
+      (F * GrossmanLarson.op (G₂' * ConnesKreimer.of' ({v} : Multiset _)) +
+        F * GrossmanLarson.insertion (GrossmanLarson.op G₂')
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _)))) := by abel
+    rw [hLHS_perm, ih₁', ih₂']
+    abel
+  · -- G = single B r: scale out r, reduce to basis G = of' B.
+    intro B r
+    let G_single : ConnesKreimer ℤ (Nonplanar α) := Finsupp.single B r
+    show F * GrossmanLarson.op (G_single * ConnesKreimer.of' {v}) +
+        F * GrossmanLarson.insertion (GrossmanLarson.op G_single)
+            (GrossmanLarson.op (ConnesKreimer.of' {v})) =
+      GrossmanLarson.insertion (F * GrossmanLarson.op G_single)
+        (GrossmanLarson.op (ConnesKreimer.of' {v})) +
+      GrossmanLarson.op
+        (GrossmanLarson.unop (F * GrossmanLarson.op G_single) * ConnesKreimer.of' {v})
+    have hG : G_single = r • (ConnesKreimer.of' B : ConnesKreimer ℤ (Nonplanar α)) := by
+      show (Finsupp.single B r : ConnesKreimer ℤ (Nonplanar α)) =
+            r • (ConnesKreimer.of' B : ConnesKreimer ℤ _)
+      rw [ConnesKreimer.of'_apply]
+      exact (Finsupp.smul_single_one B r).symm
+    rw [hG]
+    -- Push r through each term using smul_mul_assoc, op_smul, etc.
+    have h_ins_smul_first :
+        GrossmanLarson.insertion (r • GrossmanLarson.op
+            (ConnesKreimer.of' B : ConnesKreimer ℤ _))
+          (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+        r • GrossmanLarson.insertion (GrossmanLarson.op
+            (ConnesKreimer.of' B : ConnesKreimer ℤ _))
+          (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) := by
+      show ((GrossmanLarson.insertion :
+              GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α).flip
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))))
+            (r • GrossmanLarson.op (ConnesKreimer.of' B : ConnesKreimer ℤ _)) = _
+      rw [LinearMap.map_smul]
+      rfl
+    have h_T3_smul :
+        GrossmanLarson.insertion (r • (F * GrossmanLarson.op
+            (ConnesKreimer.of' B : ConnesKreimer ℤ _)))
+          (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+        r • GrossmanLarson.insertion (F * GrossmanLarson.op
+            (ConnesKreimer.of' B : ConnesKreimer ℤ _))
+          (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) := by
+      show ((GrossmanLarson.insertion :
+              GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α).flip
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))))
+            (r • (F * GrossmanLarson.op (ConnesKreimer.of' B : ConnesKreimer ℤ _))) = _
+      rw [LinearMap.map_smul]
+      rfl
+    -- T1: (r•of'B) * of'{v} = r • (of'B * of'{v}); op_smul; F * r•x = r•(F*x).
+    rw [smul_mul_assoc, op_smul, GrossmanLarson.mul_smul_gl]
+    -- T2: op(r•of'B) = r•opof'B; insertion(r•_)_ = r•insertion__; F * r•x = r•(F*x).
+    rw [op_smul, h_ins_smul_first, GrossmanLarson.mul_smul_gl]
+    -- T3: F * r•opof'B = r•(F*opof'B); insertion(r•_)_ = r•insertion__.
+    rw [GrossmanLarson.mul_smul_gl, h_T3_smul]
+    -- T4: unop(r•x) = r•unop x; (r•_)*of'{v} = r•(_*of'{v}); op(r•_) = r•op _.
+    rw [show GrossmanLarson.unop (r • (F * GrossmanLarson.op
+            (ConnesKreimer.of' B : ConnesKreimer ℤ _))) =
+          r • GrossmanLarson.unop (F * GrossmanLarson.op
+            (ConnesKreimer.of' B : ConnesKreimer ℤ _)) from rfl,
+        smul_mul_assoc, op_smul]
+    rw [← smul_add, ← smul_add]
+    congr 1
+    -- ===== BASIS CASE G = of' B =====
+    -- T1 = F * op(of' B * of'{v}) = F * of'(B + {v}).
+    have hT1 : F * GrossmanLarson.op
+          ((ConnesKreimer.of' B : ConnesKreimer ℤ (Nonplanar α)) *
+            ConnesKreimer.of' ({v} : Multiset _)) =
+        F * (GrossmanLarson.of' (B + ({v} : Multiset _)) : GrossmanLarson ℤ α) := by
+      rw [← ConnesKreimer.of'_add]
+      rfl
+    rw [hT1]
+    -- op (of' B) = of' B, op (of' {v}) = of' {v} (definitionally).
+    have hopofB : GrossmanLarson.op
+        (ConnesKreimer.of' B : ConnesKreimer ℤ (Nonplanar α)) =
+        (GrossmanLarson.of' B : GrossmanLarson ℤ α) := rfl
+    rw [hopofB]
+    -- The basis case G = of' B has four terms aligned via:
+    -- T1 split via mul_of'_sum_form + powerset_cons (two halves: T1a, T1b)
+    -- T3 split via mul_of'_sum_form + insertion_sum_left + Leibniz + iterated split
+    --   (three pieces: T3-first, T3-residue, T3-second).
+    -- T4 expanded via mul_of'_sum_form + multiplicative bookkeeping.
+    -- T2 = T3-residue + T3-second's NIM expansion, matched via GL_T2_reindexing_key.
+    --
+    -- Cancellations:
+    --   T1a = T4 (both = Σ_C₁ g_F C₁ ((B-C₁) + {v}))
+    --   T1b = T3-first (both = Σ_C₁ g_F (C₁+{v}) (B-C₁))
+    --   T2 = T3-residue + T3-second (via GL_T2_reindexing_key).
+    --
+    -- Goal: F * of'(B+{v}) + F * insertion (of' B) (op of'{v}) =
+    --       insertion (F * of' B) (op of'{v}) + op(unop(F * of' B) * of'{v}).
+    -- Define the per-(D : Multiset _) summand of mul_of'_sum_form, shared
+    -- across T1, T3, T4 (the second slot varies, captured in T4 and T1a
+    -- by passing in the "appended {v}" version).
+    set g : Multiset (Nonplanar α) → Multiset (Nonplanar α) → GrossmanLarson ℤ α :=
+      fun s t => GrossmanLarson.op
+        (GrossmanLarson.unop (GrossmanLarson.insertion F (ConnesKreimer.of' s)) *
+          GrossmanLarson.unop (ConnesKreimer.of' (R := ℤ) t :
+            GrossmanLarson ℤ α)) with hg_def
+    -- Bridge `B + {v} = v ::ₘ B` (via singleton_add + add_comm).
+    have hB_add_v : B + ({v} : Multiset (Nonplanar α)) = v ::ₘ B := by
+      rw [add_comm, Multiset.singleton_add]
+    -- §A: T1 split via mul_of'_sum_form over (v ::ₘ B) and powerset_cons.
+    --     T1 = T1a + T1b where:
+    --     T1a = Σ_{C₁ ⊆ B} g C₁ (v ::ₘ (B - C₁))
+    --     T1b = Σ_{C₁ ⊆ B} g (v ::ₘ C₁) (B - C₁)
+    have hT1_split :
+        F * (GrossmanLarson.of' (B + ({v} : Multiset _)) : GrossmanLarson ℤ α) =
+        (B.powerset.map (fun C₁ => g C₁ (v ::ₘ (B - C₁)))).sum +
+        (B.powerset.map (fun C₁ => g (v ::ₘ C₁) (B - C₁))).sum := by
+      rw [show (GrossmanLarson.of' (B + ({v} : Multiset _)) : GrossmanLarson ℤ α) =
+              (GrossmanLarson.of' (v ::ₘ B) : GrossmanLarson ℤ α) by rw [hB_add_v],
+          GrossmanLarson.mul_of'_sum_form, Multiset.powerset_cons,
+          Multiset.map_add, Multiset.sum_add, Multiset.map_map]
+      congr 1
+      · -- "no v in C₁" half: C₁ ⊆ B, second slot = (v ::ₘ B) - C₁ = v ::ₘ (B - C₁).
+        apply congr_arg Multiset.sum
+        apply Multiset.map_congr rfl
+        intro C₁ hC₁
+        have hC₁_le : C₁ ≤ B := Multiset.mem_powerset.mp hC₁
+        show GrossmanLarson.op (GrossmanLarson.unop
+              (GrossmanLarson.insertion F (ConnesKreimer.of' C₁ : GrossmanLarson ℤ α)) *
+            GrossmanLarson.unop
+              (ConnesKreimer.of' ((v ::ₘ B) - C₁) : GrossmanLarson ℤ α)) =
+            g C₁ (v ::ₘ (B - C₁))
+        rw [show ((v ::ₘ B) - C₁) = v ::ₘ (B - C₁) from
+          Multiset.cons_sub_of_le v hC₁_le]
+      · -- "v in C₁" half: image is C₁ ↦ (v ::ₘ C₁), then second slot =
+        --   (v ::ₘ B) - (v ::ₘ C₁) = (v ::ₘ B).erase v - C₁ = B - C₁.
+        apply congr_arg Multiset.sum
+        apply Multiset.map_congr rfl
+        intro C₁ _hC₁
+        show GrossmanLarson.op (GrossmanLarson.unop
+              (GrossmanLarson.insertion F (ConnesKreimer.of' (v ::ₘ C₁) : GrossmanLarson ℤ α)) *
+            GrossmanLarson.unop
+              (ConnesKreimer.of' ((v ::ₘ B) - (v ::ₘ C₁)) : GrossmanLarson ℤ α)) =
+            g (v ::ₘ C₁) (B - C₁)
+        rw [show ((v ::ₘ B) - (v ::ₘ C₁)) = B - C₁ by
+          rw [Multiset.sub_cons, Multiset.erase_cons_head]]
+    rw [hT1_split]
+    -- Helpers: op/unop push through Multiset.sum on the powerset of B
+    -- (and on any multiset, by induction).
+    have h_unop_sum_gen :
+        ∀ (s : Multiset (GrossmanLarson ℤ α)),
+          GrossmanLarson.unop s.sum = (s.map GrossmanLarson.unop).sum := by
+      intro s
+      induction s using Multiset.induction with
+      | empty => rfl
+      | cons a s ih =>
+        rw [Multiset.sum_cons, Multiset.map_cons, Multiset.sum_cons, unop_add, ih]
+    have h_op_sum_gen :
+        ∀ (s : Multiset (ConnesKreimer ℤ (Nonplanar α))),
+          GrossmanLarson.op s.sum = (s.map GrossmanLarson.op).sum := by
+      intro s
+      induction s using Multiset.induction with
+      | empty => rfl
+      | cons a s ih =>
+        rw [Multiset.sum_cons, Multiset.map_cons, Multiset.sum_cons, op_add, ih]
+    -- Define the F-keyed CK-product family used as an intermediate.
+    let f_F : Multiset (Nonplanar α) → ConnesKreimer ℤ (Nonplanar α) := fun C₁ =>
+      GrossmanLarson.unop
+        (GrossmanLarson.insertion F (ConnesKreimer.of' C₁ : GrossmanLarson ℤ α))
+    -- §B: T4 = T1a, i.e. op(unop(F * of'B) * of'{v}) = Σ_{C₁ ⊆ B} g C₁ (v ::ₘ (B - C₁)).
+    have hT4_eq_T1a :
+        GrossmanLarson.op
+          (GrossmanLarson.unop (F * (GrossmanLarson.of' B : GrossmanLarson ℤ α)) *
+            ConnesKreimer.of' ({v} : Multiset _)) =
+        (B.powerset.map (fun C₁ => g C₁ (v ::ₘ (B - C₁)))).sum := by
+      rw [GrossmanLarson.mul_of'_sum_form]
+      -- LHS = op (unop ((Σ_C₁ op(...)).sum) * of'{v}).
+      -- Step 1: unop pushes through the sum (general op-sum lemma).
+      rw [h_unop_sum_gen, Multiset.map_map]
+      -- Now the sum is over (unop ∘ op (... CK product ...)), which definitionally
+      -- reduces to the CK product.
+      rw [show (GrossmanLarson.unop ∘ fun G₁ =>
+            GrossmanLarson.op
+              ((GrossmanLarson.insertion F (GrossmanLarson.of' G₁ : GrossmanLarson ℤ α)).unop *
+                (GrossmanLarson.of' (B - G₁) : GrossmanLarson ℤ α).unop)) =
+              fun G₁ => f_F G₁ * ConnesKreimer.of' (B - G₁) from rfl]
+      -- Step 2: push (* of'{v}) into the sum (CK comm-semiring distributivity).
+      rw [← Multiset.sum_map_mul_right]
+      -- Step 3: per-summand, B - C₁ + {v} = v ::ₘ (B - C₁); fold up via of'_add.
+      rw [show (B.powerset.map (fun C₁ : Multiset (Nonplanar α) =>
+                f_F C₁ * ConnesKreimer.of' (B - C₁) *
+                  ConnesKreimer.of' ({v} : Multiset _))) =
+              B.powerset.map (fun C₁ : Multiset (Nonplanar α) =>
+                f_F C₁ * ConnesKreimer.of' (v ::ₘ (B - C₁))) from by
+        apply Multiset.map_congr rfl
+        intro C₁ _
+        rw [mul_assoc, ← ConnesKreimer.of'_add]
+        rw [show B - C₁ + ({v} : Multiset (Nonplanar α)) = v ::ₘ (B - C₁) by
+          rw [add_comm, Multiset.singleton_add]]]
+      -- Step 4: push op into the sum.
+      rw [h_op_sum_gen, Multiset.map_map]
+      -- Step 5: per C₁, fold up to g.
+      apply congr_arg Multiset.sum
+      apply Multiset.map_congr rfl
+      intro C₁ _hC₁
+      rfl
+    rw [hT4_eq_T1a]
+    -- §C: T3 = Σ_{C₁ ⊆ B} [g(v ::ₘ C₁)(B - C₁) +
+    --                       Σ_{Y ∈ NIM C₁ {v}} g Y (B - C₁) +
+    --                       Σ_{Y' ∈ NIM (B - C₁) {v}} g C₁ Y']
+    --       = T1b + Σ_{C₁ ⊆ B} (T3-residue(C₁) + T3-second(C₁))
+    have hT3 :
+        GrossmanLarson.insertion (F * (GrossmanLarson.of' B : GrossmanLarson ℤ α))
+          (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+        (B.powerset.map (fun C₁ => g (v ::ₘ C₁) (B - C₁))).sum +
+        (B.powerset.map (fun C₁ =>
+          ((Nonplanar.insertionMultiset C₁ ({v} : Multiset _)).map
+            (fun Y => g Y (B - C₁))).sum +
+          ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
+            (fun Y' => g C₁ Y')).sum)).sum := by
+      rw [GrossmanLarson.mul_of'_sum_form]
+      -- LHS = insertion ((sum over C₁) g_F(C₁)(B-C₁)) (op of'{v}).
+      rw [GrossmanLarson.insertion_sum_left, Multiset.map_map]
+      -- Per C₁: apply Leibniz. The composed map function is
+      --   (fun X => insertion X (op of'{v})) ∘ (fun G₁ => op (unop(...) * unop(...))),
+      -- which beta-reduces to (fun G₁ => insertion (op (...)) (op of'{v})). We
+      -- match the post-beta form (h_per_C₁) and step through it summand-wise.
+      have h_per_C₁ : ∀ C₁ : Multiset (Nonplanar α),
+          GrossmanLarson.insertion
+            (GrossmanLarson.op
+              ((GrossmanLarson.insertion F (GrossmanLarson.of' C₁ :
+                  GrossmanLarson ℤ α)).unop *
+                (GrossmanLarson.of' (B - C₁) : GrossmanLarson ℤ α).unop))
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+          g (v ::ₘ C₁) (B - C₁) +
+          (((Nonplanar.insertionMultiset C₁ ({v} : Multiset _)).map
+            (fun Y => g Y (B - C₁))).sum +
+          ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
+            (fun Y' => g C₁ Y')).sum) := by
+        intro C₁
+        -- Apply GL_insertion_leibniz_left_singleton_guest with
+        --   A := unop(ins F (of' C₁)), B := of'(B - C₁) (as CK).
+        set A_arg : ConnesKreimer ℤ (Nonplanar α) :=
+          (GrossmanLarson.insertion F (GrossmanLarson.of' C₁ :
+            GrossmanLarson ℤ α)).unop with hA_arg
+        set B_arg : ConnesKreimer ℤ (Nonplanar α) :=
+          (GrossmanLarson.of' (B - C₁) : GrossmanLarson ℤ α).unop with hB_arg
+        have h_leibniz := GL_insertion_leibniz_left_singleton_guest A_arg B_arg v
+        rw [h_leibniz]
+        -- First Leibniz piece: op(unop(ins (op A_arg)(op of'{v})) * B_arg).
+        --   op A_arg = op (unop (ins F (of' C₁))) = ins F (of' C₁).
+        rw [show GrossmanLarson.op A_arg = GrossmanLarson.insertion F
+              (ConnesKreimer.of' C₁ : GrossmanLarson ℤ α) from
+          GrossmanLarson.op_unop _]
+        -- Apply GL_iterated_insertion_singleton_v.
+        rw [GL_iterated_insertion_singleton_v F C₁ v]
+        -- Second Leibniz piece: op(A_arg * unop(ins (op B_arg)(op of'{v}))).
+        --   op B_arg = of'(B - C₁).
+        rw [show GrossmanLarson.op B_arg =
+              (GrossmanLarson.of' (B - C₁) : GrossmanLarson ℤ α) from rfl]
+        rw [show GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _)) =
+              (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α) from rfl]
+        rw [GrossmanLarson.insertion_of'_of']
+        -- After Leibniz + iterated split + insertion_of'_of':
+        --   LHS = op(unop((ins F (of'(C₁+{v})) + Σ_Y ins F (of' Y))) * B_arg) +
+        --         op(A_arg * unop((Σ_Y' of' Y').sum))
+        rw [unop_add, add_mul, op_add]
+        -- The first piece becomes T1b summand: g(v ::ₘ C₁)(B-C₁).
+        rw [show C₁ + ({v} : Multiset (Nonplanar α)) = v ::ₘ C₁ by
+          rw [add_comm, Multiset.singleton_add]]
+        rw [add_assoc]
+        -- The first summand op(unop(ins F (of'(v::C₁))) * B_arg) reduces to
+        -- g (v::C₁) (B-C₁) definitionally; the congr 1 then leaves T3R+T3S = sum.
+        congr 1
+        -- Remaining goal: op(unop(Σ_Y ins F (of' Y)) * B_arg) +
+        --                 op(A_arg * unop((Σ_Y' of' Y').sum)) =
+        --                 Σ_Y g Y (B-C₁) + Σ_Y' g C₁ Y'
+        congr 1
+        · -- T3-residue: distribute * B_arg through the sum.
+          rw [h_unop_sum_gen, Multiset.map_map]
+          rw [show
+              (((Nonplanar.insertionMultiset C₁ ({v} : Multiset _)).map
+                (GrossmanLarson.unop ∘ fun Y : Multiset (Nonplanar α) =>
+                  GrossmanLarson.insertion F
+                    (ConnesKreimer.of' Y : GrossmanLarson ℤ α))).sum *
+                B_arg : ConnesKreimer ℤ (Nonplanar α)) =
+              ((Nonplanar.insertionMultiset C₁ ({v} : Multiset _)).map
+                (fun Y : Multiset (Nonplanar α) =>
+                  (GrossmanLarson.unop ∘ fun Y' : Multiset (Nonplanar α) =>
+                    GrossmanLarson.insertion F
+                      (ConnesKreimer.of' Y' : GrossmanLarson ℤ α)) Y *
+                  B_arg)).sum from Multiset.sum_map_mul_right.symm]
+          rw [h_op_sum_gen, Multiset.map_map]
+          apply congr_arg Multiset.sum
+          apply Multiset.map_congr rfl
+          intro Y _hY
+          rfl
+        · -- T3-second: unfold insertionBasis to a sum, then distribute A_arg *.
+          show GrossmanLarson.op (A_arg *
+              (GrossmanLarson.insertionBasis (B - C₁) ({v} : Multiset _)).unop) =
+              ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
+                (fun Y' => g C₁ Y')).sum
+          show GrossmanLarson.op (A_arg *
+              (((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
+                (fun F' => (GrossmanLarson.of' (R := ℤ) F' :
+                  GrossmanLarson ℤ α))).sum).unop) =
+              ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
+                (fun Y' => g C₁ Y')).sum
+          rw [h_unop_sum_gen, Multiset.map_map]
+          rw [show (A_arg *
+              ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
+                (GrossmanLarson.unop ∘ fun F' : Multiset (Nonplanar α) =>
+                  (GrossmanLarson.of' (R := ℤ) F' : GrossmanLarson ℤ α))).sum :
+              ConnesKreimer ℤ (Nonplanar α)) =
+              ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
+                (fun F' : Multiset (Nonplanar α) => A_arg *
+                  (GrossmanLarson.unop ∘ fun F'' : Multiset (Nonplanar α) =>
+                    (GrossmanLarson.of' (R := ℤ) F'' :
+                      GrossmanLarson ℤ α)) F')).sum from
+            Multiset.sum_map_mul_left.symm]
+          rw [h_op_sum_gen, Multiset.map_map]
+          apply congr_arg Multiset.sum
+          apply Multiset.map_congr rfl
+          intro Y' _hY'
+          rfl
+      -- Apply h_per_C₁ summand-wise, then split the resulting Σ(_ + _) sum.
+      apply Eq.trans
+      · apply congr_arg Multiset.sum
+        apply Multiset.map_congr rfl
+        intro C₁ _hC₁
+        -- The map function is (fun X => insertion X (op of'{v})) ∘ (fun G₁ => op (...))
+        -- which beta-reduces to insertion (op (...)) (op of'{v}) per C₁.
+        exact h_per_C₁ C₁
+      -- Split the Σ(_ + _) into two sums via Multiset.sum_map_add.
+      rw [← Multiset.sum_map_add]
+    rw [hT3]
+    -- §D: T2 = Σ_{C₁ ⊆ B} (T3-residue(C₁) + T3-second(C₁))
+    --    via GL_T2_reindexing_key with g_consumer = g.
+    have hT2 :
+        F * GrossmanLarson.insertion
+            (GrossmanLarson.of' B : GrossmanLarson ℤ α)
+            (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
+        (B.powerset.map (fun C₁ =>
+          ((Nonplanar.insertionMultiset C₁ ({v} : Multiset _)).map
+            (fun Y => g Y (B - C₁))).sum +
+          ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
+            (fun Y' => g C₁ Y')).sum)).sum := by
+      -- Rewrite insertion (of' B)(op of'{v}) = insertion (of' B)(of' {v})
+      -- (definitional: op = id on of'{v}), then = insertionBasis B {v}.
+      rw [show GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _)) =
+              (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α) from rfl,
+          GrossmanLarson.insertion_of'_of']
+      show F * ((Nonplanar.insertionMultiset B ({v} : Multiset _)).map
+              (fun F' : Multiset (Nonplanar α) =>
+                (GrossmanLarson.of' (R := ℤ) F' : GrossmanLarson ℤ α))).sum = _
+      -- Push F * through the sum (general bilinear distribution).
+      have h_F_mul_sum : ∀ s : Multiset (GrossmanLarson ℤ α),
+          F * s.sum = (s.map (fun X => F * X)).sum := by
+        intro s
+        induction s using Multiset.induction with
+        | empty =>
+          rw [Multiset.sum_zero, Multiset.map_zero, Multiset.sum_zero]
+          show GrossmanLarson.product F 0 = 0
+          exact (GrossmanLarson.product F).map_zero
+        | cons a s ih =>
+          rw [Multiset.sum_cons, Multiset.map_cons, Multiset.sum_cons]
+          show GrossmanLarson.product F (a + s.sum) = F * a + _
+          rw [(GrossmanLarson.product F).map_add]
+          show GrossmanLarson.product F a +
+              (F * s.sum) = F * a + _
+          rw [ih]
+          rfl
+      rw [h_F_mul_sum, Multiset.map_map]
+      -- Per Y' ∈ NIM B {v}: F * of' Y' = mul_of'_sum_form over Y'.
+      have h_per_Y : ∀ Y : Multiset (Nonplanar α),
+          F * (GrossmanLarson.of' Y : GrossmanLarson ℤ α) =
+            (Y.powerset.map (fun D => g D (Y - D))).sum := by
+        intro Y
+        rw [GrossmanLarson.mul_of'_sum_form]
+        apply congr_arg Multiset.sum
+        apply Multiset.map_congr rfl
+        intro D _hD
+        rfl
+      rw [show ((fun X : GrossmanLarson ℤ α => F * X) ∘
+                (fun F' : Multiset (Nonplanar α) =>
+                  (GrossmanLarson.of' (R := ℤ) F' : GrossmanLarson ℤ α))) =
+              (fun Y => (Y.powerset.map (fun D => g D (Y - D))).sum) from by
+        funext Y; exact h_per_Y Y]
+      exact GL_T2_reindexing_key B v g
+    rw [hT2]
+    -- §E: Combine. LHS = T1a + T1b + T2. RHS = T3 + T4 = T1b + Σ + T1a.
+    abel
 
 /-- **Per-tprod form** of Q5c (lifts to full Q5c via `algHomL_surjective`).
 
@@ -964,9 +2119,12 @@ private theorem GL_product_split_mul_ι
       `ckIso(X ★ algHomL(tprod m a)) = (op (ckIso X)) * (op (ckIso (algHomL (tprod m a))))`
 
     Proof by induction on m, using `oudomGuinStar_mul_ι_split` + IH +
-    `oudomGuinCirc_algHomL_tprod_ι` + the two substrate lemmas above.
-
-    Pending closure: depends on substrates above. -/
+    `oudomGuinCirc_algHomL_tprod_ι` + `ckIso_circ_intertwine_insertion` +
+    `GL_product_split_mul_ι`. The `m+1` case v-linearizes via
+    `Finsupp.induction_linear`; the basis case `v = ofTree t` chains all
+    substrate. Coercion discipline: work in CK (with the local
+    `AddCommGroup`) for additive rearrangements; transport to GL via
+    `op`/`unop` (which are the identity coercion). -/
 private theorem gl_product_eq_oudomGuinStar_tprod
     (X : SymmetricAlgebra ℤ (InsertionAlgebra α)) :
     ∀ (m : ℕ) (a : Fin m → InsertionAlgebra α),
@@ -998,21 +2156,482 @@ private theorem gl_product_eq_oudomGuinStar_tprod
     rfl
   | succ m ih =>
     intro a
-    -- Y = D · ι v, D = algHomL(tprod m init), v = a(last).
-    -- Uses oudomGuinStar_mul_ι_split + IH(D) + IH-summand-wise(D○ιv) +
-    -- ckIso_circ_intertwine_insertion + GL_product_split_mul_ι.
-    -- Detailed wiring deferred — substrate sorries above must close first.
-    sorry
+    -- Local AddCommGroup instance for CK to enable map_sub/map_neg.
+    letI : AddCommGroup (ConnesKreimer ℤ (Nonplanar α)) := ConnesKreimer.addCommGroupOf
+    -- ===== STAGE-BOUNDARY (target 2 partial closure) =====
+    -- Set up tprod (m+1) split + algHomL split.
+    have h_a_eq : a = Fin.snoc (Fin.init a) (a (Fin.last m)) :=
+      (Fin.snoc_init_self a).symm
+    have h_tprod_succ :
+        TensorAlgebra.tprod ℤ (InsertionAlgebra α) (m + 1) a =
+        TensorAlgebra.tprod ℤ (InsertionAlgebra α) m (Fin.init a) *
+          TensorAlgebra.ι ℤ (a (Fin.last m)) := by
+      conv_lhs => rw [h_a_eq]
+      rw [Fin.snoc_eq_append,
+          PreLie.OudomGuinCircConstruct.ι_eq_tprod_one,
+          ← PreLie.OudomGuinCircConstruct.tprod_mul_tprod]
+      congr 1
+    have h_algHomL_split :
+        PreLie.OudomGuinCircConstruct.algHomL (R := ℤ) (L := InsertionAlgebra α)
+            (TensorAlgebra.tprod ℤ (InsertionAlgebra α) (m + 1) a) =
+          PreLie.OudomGuinCircConstruct.algHomL
+              (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m (Fin.init a)) *
+            SymmetricAlgebra.ι ℤ (InsertionAlgebra α) (a (Fin.last m)) := by
+      rw [h_tprod_succ]
+      show (SymmetricAlgebra.algHom ℤ (InsertionAlgebra α)) _ = _
+      rw [map_mul]
+      show (SymmetricAlgebra.algHom ℤ (InsertionAlgebra α))
+            (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m (Fin.init a)) *
+            (SymmetricAlgebra.algHom ℤ (InsertionAlgebra α))
+              (TensorAlgebra.ι ℤ (a (Fin.last m))) =
+          PreLie.OudomGuinCircConstruct.algHomL
+              (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m (Fin.init a)) *
+            SymmetricAlgebra.ι ℤ (InsertionAlgebra α) (a (Fin.last m))
+      rfl
+    rw [h_algHomL_split]
+    -- Set up D = algHomL(tprod m init) and v-linearize.
+    set D : SymmetricAlgebra ℤ (InsertionAlgebra α) :=
+      PreLie.OudomGuinCircConstruct.algHomL
+        (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m (Fin.init a)) with hD
+    -- The claim parameterized over v : InsertionAlgebra α; we apply at
+    -- v = a (Fin.last m). Both sides are linear in v through ι.
+    suffices h_v_claim :
+        ∀ v : InsertionAlgebra α,
+          ((ckIsoSymmetricAlgebra
+              (oudomGuinStar X (D * SymmetricAlgebra.ι ℤ _ v)) :
+            ConnesKreimer ℤ (Nonplanar α)) : GrossmanLarson ℤ α) =
+          (GrossmanLarson.op (ckIsoSymmetricAlgebra X)) *
+            (GrossmanLarson.op (ckIsoSymmetricAlgebra
+              (D * SymmetricAlgebra.ι ℤ _ v))) by
+      exact h_v_claim (a (Fin.last m))
+    -- v-induction via Finsupp.induction_linear.
+    intro v
+    refine Finsupp.induction_linear v ?_ ?_ ?_
+    · -- v = 0: ι 0 = 0; D · 0 = 0; X ★ 0 = 0 (via star-linearity).
+      -- Goal: ckIso(X ★ (D * ι 0)) = op(ckIso X) * op(ckIso(D * ι 0))
+      -- Both sides reduce to 0 via map_zero cascades.
+      have h_LHS_zero : (ckIsoSymmetricAlgebra
+            (oudomGuinStar X (D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α) 0)) :
+          ConnesKreimer ℤ (Nonplanar α)) = 0 := by
+        have h1 : SymmetricAlgebra.ι ℤ (InsertionAlgebra α) (0 : InsertionAlgebra α) =
+            (0 : SymmetricAlgebra ℤ (InsertionAlgebra α)) :=
+          (SymmetricAlgebra.ι ℤ (InsertionAlgebra α)).map_zero
+        rw [h1, mul_zero]
+        rw [show oudomGuinStar (R := ℤ) X 0 = 0 from by
+          rw [← oudomGuinStarL_apply X 0]; exact (oudomGuinStarL X).map_zero]
+        exact map_zero _
+      have h_RHS_zero : GrossmanLarson.op (ckIsoSymmetricAlgebra X) *
+            GrossmanLarson.op (ckIsoSymmetricAlgebra
+              (D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α) 0)) =
+          (0 : GrossmanLarson ℤ α) := by
+        have h1 : SymmetricAlgebra.ι ℤ (InsertionAlgebra α) (0 : InsertionAlgebra α) =
+            (0 : SymmetricAlgebra ℤ (InsertionAlgebra α)) :=
+          (SymmetricAlgebra.ι ℤ (InsertionAlgebra α)).map_zero
+        rw [h1, mul_zero]
+        rw [show ckIsoSymmetricAlgebra (0 : SymmetricAlgebra ℤ (InsertionAlgebra α)) =
+              (0 : ConnesKreimer ℤ (Nonplanar α)) from map_zero _]
+        rw [op_zero, GrossmanLarson.mul_zero_gl]
+      exact h_LHS_zero.trans h_RHS_zero.symm
+    · -- v = v₁ + v₂: linearity in v through ι, mul, ★, ckIso, op, mul (GL).
+      intro v₁ v₂ ih₁ ih₂
+      have h_ι_add : SymmetricAlgebra.ι ℤ (InsertionAlgebra α) (v₁ + v₂) =
+            SymmetricAlgebra.ι ℤ (InsertionAlgebra α) v₁ +
+            SymmetricAlgebra.ι ℤ (InsertionAlgebra α) v₂ :=
+        (SymmetricAlgebra.ι ℤ (InsertionAlgebra α)).map_add _ _
+      have h_D_mul_add :
+          D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α) (v₁ + v₂) =
+            D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α) v₁ +
+            D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α) v₂ := by
+        rw [h_ι_add, mul_add]
+      have h_star_add :
+          oudomGuinStar (R := ℤ) X
+              (D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α) (v₁ + v₂)) =
+            oudomGuinStar (R := ℤ) X
+                (D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α) v₁) +
+            oudomGuinStar (R := ℤ) X
+                (D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α) v₂) := by
+        rw [h_D_mul_add, oudomGuinStar_add_right]
+      rw [h_star_add, map_add, h_D_mul_add, map_add, op_add, mul_add, ih₁, ih₂]
+      rfl
+    · -- v = single t r: factor scalar out, reduce to v = ofTree t basis case.
+      intro t r
+      -- Reduce single t r = r • ofTree t.
+      have hv_eq : (Finsupp.single t r : InsertionAlgebra α) =
+            r • InsertionAlgebra.ofTree t := by
+        show (Finsupp.single t r : InsertionAlgebra α) =
+              r • (Finsupp.single t 1 : InsertionAlgebra α)
+        exact (Finsupp.smul_single_one t r).symm
+      rw [hv_eq]
+      -- ι (r • ofTree t) = r • ι (ofTree t)
+      rw [(SymmetricAlgebra.ι ℤ (InsertionAlgebra α)).map_smul r _]
+      -- D * (r • ι ofTree t) = r • (D * ι ofTree t)
+      rw [mul_smul_comm]
+      -- X ★ (r • Y) = r • (X ★ Y)
+      rw [oudomGuinStar_smul_right X _ r]
+      -- ckIso (r • Y) = r • ckIso Y (twice) — via simp on map_smul.
+      simp only [_root_.map_smul]
+      -- op (r • Y) = r • op Y (only the inner one — RHS has op applied to (r • ...))
+      rw [show GrossmanLarson.op
+              (r • ckIsoSymmetricAlgebra
+                (D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α)
+                  (InsertionAlgebra.ofTree t))) =
+            r • GrossmanLarson.op (ckIsoSymmetricAlgebra
+                (D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α)
+                  (InsertionAlgebra.ofTree t))) from op_smul r _]
+      -- F * (r • Y) = r • (F * Y) — use linearity of GrossmanLarson.product.
+      have h_smul_right : GrossmanLarson.op (ckIsoSymmetricAlgebra X) *
+              (r • GrossmanLarson.op (ckIsoSymmetricAlgebra
+                (D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α)
+                  (InsertionAlgebra.ofTree t)))) =
+            r • (GrossmanLarson.op (ckIsoSymmetricAlgebra X) *
+              GrossmanLarson.op (ckIsoSymmetricAlgebra
+                (D * SymmetricAlgebra.ι ℤ (InsertionAlgebra α)
+                  (InsertionAlgebra.ofTree t)))) :=
+          (GrossmanLarson.product
+            (GrossmanLarson.op (ckIsoSymmetricAlgebra X))).map_smul r _
+      rw [h_smul_right]
+      congr 1
+      -- Basis case: v = ofTree t.
+      -- This is the heart of the proof.
+      -- Notation: F := op(ckIso X), G := ckIso D, T := of'{t}.
+      -- Goal: ckIso(X ★ (D · ι(ofTree t))) = F * op(ckIso D · ι(ofTree t)).
+      -- Step 1: Apply SL split (oudomGuinStar_mul_ι_split) on LHS:
+      --   X ★ (D · ι(ofTree t)) =
+      --     (X★D) ○ ι(ofTree t) + (X★D) · ι(ofTree t) - X ★ (D ○ ι(ofTree t))
+      have h_SL_split :
+          oudomGuinStar X (D * SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)) =
+            oudomGuinCirc (oudomGuinStar X D)
+                (SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)) +
+            oudomGuinStar X D * SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t) -
+            oudomGuinStar X (oudomGuinCirc D
+              (SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t))) :=
+        oudomGuinStar_mul_ι_split X D (InsertionAlgebra.ofTree t)
+      -- Step 2: Decompose D ○ ι(ofTree t) using oudomGuinCirc_algHomL_tprod_ι.
+      have h_DcircTV :
+          oudomGuinCirc D (SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)) =
+            ∑ i : Fin m,
+              PreLie.OudomGuinCircConstruct.algHomL
+                (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m
+                  (Function.update (Fin.init a) i
+                    (Fin.init a i * InsertionAlgebra.ofTree t))) := by
+        rw [hD]
+        exact oudomGuinCirc_algHomL_tprod_ι
+          (InsertionAlgebra.ofTree t) m (Fin.init a)
+      -- Step 3: IH at each summand (`update (init a) i (init a i * ofTree t)`).
+      -- This gives ckIso(X ★ algHomL(tprod m _)) = op(ckIso X) * op(ckIso(algHomL(...))).
+      -- Combined into a sum.
+      have h_star_sum : ∀ (Z : SymmetricAlgebra ℤ (InsertionAlgebra α))
+          (f : Fin m → SymmetricAlgebra ℤ (InsertionAlgebra α)),
+          oudomGuinStar Z (∑ i, f i) = ∑ i, oudomGuinStar Z (f i) := by
+        intro Z f
+        rw [← oudomGuinStarL_apply Z _, map_sum]
+        simp only [oudomGuinStarL_apply]
+      -- Apply IH summand-wise to X ★ (D ○ ι(ofTree t)).
+      have h_ih_sum :
+          ((ckIsoSymmetricAlgebra
+              (oudomGuinStar X
+                (oudomGuinCirc D
+                  (SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)))) :
+            ConnesKreimer ℤ (Nonplanar α)) : GrossmanLarson ℤ α) =
+            ∑ i : Fin m,
+              (GrossmanLarson.op (ckIsoSymmetricAlgebra X)) *
+              (GrossmanLarson.op (ckIsoSymmetricAlgebra
+                (PreLie.OudomGuinCircConstruct.algHomL
+                  (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m
+                    (Function.update (Fin.init a) i
+                      (Fin.init a i * InsertionAlgebra.ofTree t)))))) := by
+        rw [h_DcircTV, h_star_sum]
+        rw [show ckIsoSymmetricAlgebra (∑ i : Fin m,
+                  oudomGuinStar X
+                    (PreLie.OudomGuinCircConstruct.algHomL
+                      (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m
+                        (Function.update (Fin.init a) i
+                          (Fin.init a i * InsertionAlgebra.ofTree t))))) =
+                ∑ i : Fin m,
+                  ckIsoSymmetricAlgebra
+                    (oudomGuinStar X
+                      (PreLie.OudomGuinCircConstruct.algHomL
+                        (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m
+                          (Function.update (Fin.init a) i
+                            (Fin.init a i * InsertionAlgebra.ofTree t))))) from
+            map_sum ckIsoSymmetricAlgebra.toLinearEquiv.toLinearMap _ _]
+        -- Push (· : GL) through the sum: a CK sum coerces to GL by the same
+        -- definitional equality.
+        show (∑ i : Fin m, _ : ConnesKreimer ℤ (Nonplanar α)) =
+            ∑ i : Fin m, _
+        apply Finset.sum_congr rfl
+        intro i _
+        exact ih (Function.update (Fin.init a) i
+          (Fin.init a i * InsertionAlgebra.ofTree t))
+      -- Step 4: Apply ckIso to h_SL_split, split into +/- in CK, then transport
+      -- to GL. The LHS (X★D) ○ ι v term goes via ckIso_circ_intertwine_insertion.
+      -- Define F := op(ckIso X), G := ckIso D, T := of'{t} as a CK Multiset.
+      set F : GrossmanLarson ℤ α := GrossmanLarson.op (ckIsoSymmetricAlgebra X)
+        with hF
+      set G : ConnesKreimer ℤ (Nonplanar α) := ckIsoSymmetricAlgebra D with hG
+      -- ckIso(ι(ofTree t)) = of'{t}.
+      have h_ckIso_ι_ofTree :
+          ckIsoSymmetricAlgebra
+              (SymmetricAlgebra.ι ℤ (InsertionAlgebra α)
+                (InsertionAlgebra.ofTree t)) =
+            ConnesKreimer.of' ({t} : Multiset _) := by
+        show ckIsoSymmetricAlgebra
+              (SymmetricAlgebra.ι ℤ (InsertionAlgebra α)
+                (Finsupp.single t 1)) = _
+        exact ckIsoSymmetricAlgebra_ι_single t
+      -- Apply IH at init to get ckIso(X★D) = F * op(G).
+      have h_ih_init :
+          ((ckIsoSymmetricAlgebra (oudomGuinStar X D) :
+            ConnesKreimer ℤ (Nonplanar α)) : GrossmanLarson ℤ α) =
+            F * GrossmanLarson.op G := by
+        rw [hF, hG, hD]
+        exact ih (Fin.init a)
+      -- Rearrange SL split additively (CK has the local AddCommGroup).
+      -- h_SL_split (CK): X★(D·ιv) = (X★D)○ιv + (X★D)·ιv - X★(D○ιv).
+      -- Apply ckIso, rearrange to: ckIso(X★(D·ιv)) + ckIso(X★(D○ιv))
+      --                          = ckIso((X★D)○ιv) + ckIso((X★D)·ιv).
+      have h_SL_split_additive :
+          ckIsoSymmetricAlgebra
+              (oudomGuinStar X
+                (D * SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t))) +
+            ckIsoSymmetricAlgebra
+              (oudomGuinStar X
+                (oudomGuinCirc D
+                  (SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)))) =
+            ckIsoSymmetricAlgebra
+              (oudomGuinCirc (oudomGuinStar X D)
+                (SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t))) +
+            ckIsoSymmetricAlgebra
+              (oudomGuinStar X D *
+                SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)) := by
+        -- Apply ckIso to h_SL_split, then rearrange via AddCommGroup (CK side).
+        have h := congrArg ckIsoSymmetricAlgebra h_SL_split
+        -- h : ckIso (X★(D·ιv)) = ckIso ((X★D)○ιv + (X★D)·ιv - X★(D○ιv))
+        rw [map_sub, map_add] at h
+        -- h : ckIso(X★(D·ιv)) = (ckIso((X★D)○ιv) + ckIso((X★D)·ιv)) - ckIso(X★(D○ιv))
+        -- Rearrange a = b - c ↔ a + c = b via AddCommGroup tactics.
+        rw [h]
+        abel
+      -- GL split (additive form).
+      have h_GL_split := GL_product_split_mul_ι F G t
+      -- h_GL_split : F * op(G * of'{t}) + F * insertion(op G)(op of'{t})
+      --              = insertion(F * op G)(op of'{t}) + op(unop(F * op G) * of'{t})
+      -- Goal: ckIso(X★(D·ι(ofTree t))) = F * op(ckIso(D·ι(ofTree t)))
+      -- Rewrite ckIso(D · ι(ofTree t)) = G * of'{t}.
+      have h_ckIso_DιV :
+          ckIsoSymmetricAlgebra
+              (D * SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)) =
+            G * ConnesKreimer.of' ({t} : Multiset _) := by
+        rw [map_mul, h_ckIso_ι_ofTree]
+      rw [h_ckIso_DιV]
+      -- Now goal: ckIso(X★(D·ι(ofTree t))) = F * op(G * of'{t}).
+      -- The plan:
+      -- (A) Express the (X★D)○ιv term in GL: ckIso((X★D)○ιv) = insertion(op(ckIso(X★D)))(op of'{t}) [substrate 1]
+      --     and op(ckIso(X★D)) = F * op G [IH], so
+      --     ckIso((X★D)○ιv) = unop(insertion(F * op G)(op of'{t})).
+      -- (B) ckIso((X★D)·ιv) = ckIso(X★D) * of'{t} [ring hom + ι_single]
+      --                    = unop(F * op G) * of'{t} [IH] (in CK product).
+      -- (C) ckIso(X★(D○ιv)) = F * insertion(op G)(op of'{t}) [substrate via h_ih_sum + intertwine]
+      -- Combining (A)+(B) on RHS of h_SL_split_additive, and (C) for the third term:
+      -- LHS = ckIso(X★(D·ιv)) and RHS = ckIso((X★D)○ιv) + ckIso((X★D)·ιv) - ckIso(X★(D○ιv))
+      -- so:
+      --   ckIso(X★(D·ιv)) = unop(ins(F*opG)(op of'{t})) + (unop(F*opG)*of'{t}) - F*ins(opG)(op of'{t})
+      -- Using h_GL_split: F * op(G * of'{t}) = ins(F*opG)(...) + op(unop(F*opG) * of'{t}) - F * ins(op G)(...)
+      -- These should match modulo unop/op being identity.
+      --
+      -- Step (A): rewrite term (X★D)○ιv via substrate.
+      have h_term_A :
+          ckIsoSymmetricAlgebra
+              (oudomGuinCirc (oudomGuinStar X D)
+                (SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t))) =
+            GrossmanLarson.unop (GrossmanLarson.insertion
+              (F * GrossmanLarson.op G)
+              (GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset _)))) := by
+        rw [ckIso_circ_intertwine_insertion (oudomGuinStar X D)
+              (InsertionAlgebra.ofTree t)]
+        rw [h_ckIso_ι_ofTree]
+        -- Substitute op(ckIso(X★D)) = F * op G via h_ih_init.
+        rw [show GrossmanLarson.op (ckIsoSymmetricAlgebra (oudomGuinStar X D)) =
+              F * GrossmanLarson.op G from h_ih_init]
+      -- Step (B): rewrite term (X★D)·ιv via map_mul + ι_single + IH.
+      have h_term_B :
+          ckIsoSymmetricAlgebra
+              (oudomGuinStar X D *
+                SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)) =
+            GrossmanLarson.unop (F * GrossmanLarson.op G) *
+              ConnesKreimer.of' ({t} : Multiset _) := by
+        rw [map_mul, h_ckIso_ι_ofTree]
+        -- Need: ckIso(X★D) * of'{t} = unop(F * op G) * of'{t}.
+        -- h_ih_init says ckIso(X★D) = F * op G (as GL, but GL=CK by def).
+        -- unop(F * op G) = F * op G as CK element (unop is identity).
+        rw [show ckIsoSymmetricAlgebra (oudomGuinStar X D) =
+              GrossmanLarson.unop (F * GrossmanLarson.op G) from h_ih_init]
+      -- Step (C): rewrite term X★(D○ιv) via h_ih_sum.
+      have h_term_C :
+          ((ckIsoSymmetricAlgebra
+              (oudomGuinStar X
+                (oudomGuinCirc D
+                  (SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)))) :
+            ConnesKreimer ℤ (Nonplanar α)) : GrossmanLarson ℤ α) =
+            F * GrossmanLarson.insertion (GrossmanLarson.op G)
+              (GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset _))) := by
+        -- Rewrite LHS via direct chain: use the substrate intertwine on D ○ ι(ofTree t)
+        -- and IH-summand sum.
+        -- ckIso(D ○ ι(ofTree t)) = unop(insertion(op(ckIso D))(op of'{t}))
+        --                       = unop(insertion(op G)(op of'{t}))
+        -- so as a CK element, equals the GL `insertion(op G)(op of'{t})`.
+        -- Now we need ckIso(X ★ Z) where Z = ckIso(D ○ ι(ofTree t)) (as CK element).
+        -- We use h_ih_sum which expresses this as a sum, and the sum-form via
+        -- h_DcircTV (D ○ ι v = ∑ algHomL(...)) gives us the sum.
+        -- Final identification: F * insertion(op G)(op of'{t}) is in GL; the sum
+        -- of F * op(ckIso(algHomL ...)) equals F * op(ckIso(∑ algHomL ...))
+        -- (by map_sum + multiplication distributivity).
+        rw [h_ih_sum]
+        -- Goal: ∑ i, F * op(ckIso(algHomL(tprod _ ...))) = F * insertion(op G)(op of'{t})
+        -- Convert F * (...) to (GrossmanLarson.product F) (...) (definitionally).
+        show ∑ i : Fin m, (GrossmanLarson.product F)
+          (GrossmanLarson.op (ckIsoSymmetricAlgebra
+            (PreLie.OudomGuinCircConstruct.algHomL
+              (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m
+                (Function.update (Fin.init a) i
+                  (Fin.init a i * InsertionAlgebra.ofTree t)))))) =
+          F * GrossmanLarson.insertion (GrossmanLarson.op G)
+            (GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset _)))
+        -- Push F * out of the sum.
+        rw [← _root_.map_sum (GrossmanLarson.product F) _ Finset.univ]
+        -- Goal: GL.product F (∑ ...) = F * insertion(op G)(op of'{t})
+        show F * _ = _
+        congr 1
+        -- ∑ i, op(ckIso(algHomL(...))) = op(ckIso(∑ i, algHomL(...))) [op,ckIso linear].
+        -- op : CK → GL is additive. So ∑ op(f i) = op (∑ f i).
+        -- Use Finset.sum_congr + the fact that op is the identity coercion.
+        rw [show (∑ i : Fin m, GrossmanLarson.op (ckIsoSymmetricAlgebra
+                (PreLie.OudomGuinCircConstruct.algHomL
+                  (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m
+                    (Function.update (Fin.init a) i
+                      (Fin.init a i * InsertionAlgebra.ofTree t)))))) =
+              GrossmanLarson.op (∑ i : Fin m, ckIsoSymmetricAlgebra
+                (PreLie.OudomGuinCircConstruct.algHomL
+                  (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m
+                    (Function.update (Fin.init a) i
+                      (Fin.init a i * InsertionAlgebra.ofTree t))))) from
+          -- op is the identity on data, so both sides are equal as CK elements.
+          rfl]
+        rw [show ∑ i : Fin m,
+              ckIsoSymmetricAlgebra
+                (PreLie.OudomGuinCircConstruct.algHomL
+                  (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m
+                    (Function.update (Fin.init a) i
+                      (Fin.init a i * InsertionAlgebra.ofTree t)))) =
+            ckIsoSymmetricAlgebra (∑ i : Fin m,
+              PreLie.OudomGuinCircConstruct.algHomL
+                (TensorAlgebra.tprod ℤ (InsertionAlgebra α) m
+                  (Function.update (Fin.init a) i
+                    (Fin.init a i * InsertionAlgebra.ofTree t)))) from
+          (map_sum ckIsoSymmetricAlgebra.toLinearEquiv.toLinearMap _ _).symm]
+        rw [← h_DcircTV]
+        rw [ckIso_circ_intertwine_insertion D (InsertionAlgebra.ofTree t)]
+        rw [h_ckIso_ι_ofTree]
+        -- Goal: op(unop(insertion(op G)(op of'{t}))) = insertion(op G)(op of'{t})
+        rfl
+      -- Apply h_GL_split + the three step rewrites to close the goal.
+      -- h_SL_split_additive (in CK):
+      --   LHS_target + ckIso(X★(D○ιv)) = ckIso((X★D)○ιv) + ckIso((X★D)·ιv)
+      -- Substitute h_term_A, h_term_B, h_term_C (the latter two as
+      -- equations in GL, but since CK = GL by def, all live additively).
+      -- After substitution:
+      --   LHS_target + F*ins(op G)(op of'{t})
+      --     = unop(ins(F*opG)(op of'{t})) + (unop(F*opG) * of'{t})
+      -- Apply h_GL_split rearranged:
+      --   ins(F*opG)(op of'{t}) + op(unop(F*opG) * of'{t})
+      --     = F * op(G * of'{t}) + F * ins(op G)(op of'{t})
+      -- The unop/op identity pair turns this CK equality (via CK=GL=def) into:
+      --   unop(ins(F*opG)(op of'{t})) + unop(F*opG) * of'{t}
+      --     = F * op(G * of'{t}) + F * ins(op G)(op of'{t})
+      -- which combined with h_SL_split_additive gives the goal.
+      -- Concretely: derive goal by add_right_cancel on F*ins(op G)(op of'{t}).
+      -- Goal: LHS_target = F * op(G * of'{t}).
+      -- Approach: prove
+      --   LHS_target + F*ins(op G)(op of'{t}) = F*op(G*of'{t}) + F*ins(op G)(op of'{t})
+      -- and cancel.
+      -- Work in CK throughout for the `+` form (avoids GL HAdd mismatch).
+      -- Form ALL CK equations from substrates:
+      -- (C-as-CK): ckIso(X ★ (D○ι(ofTree t))) = unop(F * insertion(op G)(op of'{t}))
+      have h_term_C_CK :
+          ckIsoSymmetricAlgebra
+              (oudomGuinStar X
+                (oudomGuinCirc D
+                  (SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)))) =
+          GrossmanLarson.unop
+            (F * GrossmanLarson.insertion (GrossmanLarson.op G)
+              (GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset _)))) :=
+        h_term_C
+      -- Apply unop to h_GL_split to get a CK equation.
+      -- h_GL_split: F*op(G*of'{t}) + F*insertion(op G)(op of'{t})
+      --           = insertion(F*op G)(op of'{t}) + op(unop(F*op G) * of'{t})
+      -- Take unop of both sides (op_unop = id):
+      -- unop(F*op(G*of'{t})) + unop(F*insertion(op G)(op of'{t}))
+      --   = unop(insertion(F*op G)(op of'{t})) + (unop(F*op G) * of'{t})
+      have h_GL_split_CK :
+          GrossmanLarson.unop (F * GrossmanLarson.op
+              (G * ConnesKreimer.of' ({t} : Multiset _))) +
+            GrossmanLarson.unop (F * GrossmanLarson.insertion (GrossmanLarson.op G)
+              (GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset _)))) =
+            GrossmanLarson.unop (GrossmanLarson.insertion (F * GrossmanLarson.op G)
+              (GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset _)))) +
+            GrossmanLarson.unop (F * GrossmanLarson.op G) *
+              ConnesKreimer.of' ({t} : Multiset _) := by
+        have h := congrArg GrossmanLarson.unop h_GL_split
+        rw [unop_add, unop_add] at h
+        -- The last term has unop ∘ op = id (definitional).
+        convert h using 2
+      -- Now use h_SL_split_additive to combine.
+      -- h_SL_split_additive (CK):
+      --   ckIso(X★(D·ι(ofTree t))) + ckIso(X★(D○ι(ofTree t)))
+      --     = ckIso((X★D)○ι(ofTree t)) + ckIso((X★D)·ι(ofTree t))
+      -- Substitute the term_A/B/C-CK forms:
+      --   ckIso(X★(D·ι(ofTree t))) + unop(F * ins(op G)(op of'{t}))
+      --     = unop(ins(F*op G)(op of'{t})) + (unop(F*op G) * of'{t})
+      -- By h_GL_split_CK this equals:
+      --   unop(F*op(G*of'{t})) + unop(F*ins(op G)(op of'{t}))
+      -- Cancel the common unop(F*ins(op G)(op of'{t})) term.
+      have h_goal_CK :
+          ckIsoSymmetricAlgebra
+              (oudomGuinStar X
+                (D * SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t))) =
+            GrossmanLarson.unop (F * GrossmanLarson.op
+              (G * ConnesKreimer.of' ({t} : Multiset _))) := by
+        have h_LHS_plus_CK :
+            ckIsoSymmetricAlgebra
+                (oudomGuinStar X
+                  (D * SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t))) +
+              GrossmanLarson.unop
+                (F * GrossmanLarson.insertion (GrossmanLarson.op G)
+                  (GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset _)))) =
+              GrossmanLarson.unop (F * GrossmanLarson.op
+                (G * ConnesKreimer.of' ({t} : Multiset _))) +
+              GrossmanLarson.unop
+                (F * GrossmanLarson.insertion (GrossmanLarson.op G)
+                  (GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset _)))) := by
+          -- Apply ← h_term_C_CK ONLY on LHS, then chain rewrites on LHS.
+          conv_lhs => rw [← h_term_C_CK]
+          rw [h_SL_split_additive, h_term_A, h_term_B]
+          -- Now LHS is `unop(ins(F*op G)(...)) + (unop(F*op G) * of'{t})`
+          -- and RHS is `unop(F*op(G*of'{t})) + unop(F*ins(op G)(...))`.
+          -- These match h_GL_split_CK (with sides swapped).
+          exact h_GL_split_CK.symm
+        exact add_right_cancel h_LHS_plus_CK
+      -- The original goal is the GL form: ckIso(X★(D·ι(ofTree t))) = F * op(G*of'{t}).
+      -- h_goal_CK gives the same equation with unop on the GL RHS.
+      -- Since CK = GL definitionally and op/unop are identity, this is the goal.
+      exact h_goal_CK
 
 /-- **Q5c**: the OG `★` product, transported via `ckIsoSymmetricAlgebra`,
     equals the Grossman-Larson product on `ConnesKreimer ℤ (Nonplanar α)`.
 
     Lifted from `gl_product_eq_oudomGuinStar_tprod` via `algHomL_surjective`
     + `TA_linearMap_ext_tprod` for Y. Mirrors Q3's lifting pattern
-    (`oudomGuinStar_assoc`).
-
-    Pending: per-tprod m+1 case depends on `ckIso_circ_intertwine_insertion`
-    + `GL_product_split_mul_ι` substrate lemmas (sorry-fenced above). -/
+    (`oudomGuinStar_assoc`). Proved sorry-free 2026-06-12. -/
 theorem gl_product_eq_oudomGuinStar
     (X Y : SymmetricAlgebra ℤ (InsertionAlgebra α)) :
     ((ckIsoSymmetricAlgebra (oudomGuinStar X Y) : ConnesKreimer ℤ (Nonplanar α)) :
@@ -1065,15 +2684,40 @@ theorem GrossmanLarson.mul_assoc_basis_via_oudom_guin_pbw
   -- Lift `of' Fᵢ` back through `ckIsoSymmetricAlgebra⁻¹` to SymmetricAlgebra,
   -- apply oudomGuinStar_assoc there, transport back via Q5c.
   set X₁ := ckIsoSymmetricAlgebra.symm
-    ((GrossmanLarson.unop (GrossmanLarson.of' F₁ : GrossmanLarson ℤ α)))
+    ((GrossmanLarson.unop (GrossmanLarson.of' F₁ : GrossmanLarson ℤ α))) with hX₁
   set X₂ := ckIsoSymmetricAlgebra.symm
-    ((GrossmanLarson.unop (GrossmanLarson.of' F₂ : GrossmanLarson ℤ α)))
+    ((GrossmanLarson.unop (GrossmanLarson.of' F₂ : GrossmanLarson ℤ α))) with hX₂
   set X₃ := ckIsoSymmetricAlgebra.symm
-    ((GrossmanLarson.unop (GrossmanLarson.of' F₃ : GrossmanLarson ℤ α)))
-  have h := oudomGuinStar_assoc X₁ X₂ X₃   -- Q3 (proved)
-  -- Apply ckIsoSymmetricAlgebra to both sides and use Q5c to transport.
-  have := congrArg (ckIsoSymmetricAlgebra (α := α)) h
-  -- The (★ ↔ GL.product) intertwining (Q5c, sorry-fenced) gives the result.
-  sorry  -- TODO: Q5c + simp closure; ~5-20 LOC once Q5c is sorry-free
+    ((GrossmanLarson.unop (GrossmanLarson.of' F₃ : GrossmanLarson ℤ α))) with hX₃
+  -- ckIso X_i = unop(of' F_i) = of' F_i (since ckIso ∘ ckIso.symm = id).
+  have hckIsoX₁ : (ckIsoSymmetricAlgebra X₁ : ConnesKreimer ℤ (Nonplanar α)) =
+      GrossmanLarson.unop (GrossmanLarson.of' F₁ : GrossmanLarson ℤ α) := by
+    rw [hX₁]; exact ckIsoSymmetricAlgebra.apply_symm_apply _
+  have hckIsoX₂ : (ckIsoSymmetricAlgebra X₂ : ConnesKreimer ℤ (Nonplanar α)) =
+      GrossmanLarson.unop (GrossmanLarson.of' F₂ : GrossmanLarson ℤ α) := by
+    rw [hX₂]; exact ckIsoSymmetricAlgebra.apply_symm_apply _
+  have hckIsoX₃ : (ckIsoSymmetricAlgebra X₃ : ConnesKreimer ℤ (Nonplanar α)) =
+      GrossmanLarson.unop (GrossmanLarson.of' F₃ : GrossmanLarson ℤ α) := by
+    rw [hX₃]; exact ckIsoSymmetricAlgebra.apply_symm_apply _
+  -- Apply Q5c to peel ckIso ∘ ★ into op(ckIso) * op(ckIso) at each fold.
+  have h_LHS_step1 := gl_product_eq_oudomGuinStar (oudomGuinStar X₁ X₂) X₃
+  have h_LHS_step2 := gl_product_eq_oudomGuinStar X₁ X₂
+  have h_RHS_step1 := gl_product_eq_oudomGuinStar X₁ (oudomGuinStar X₂ X₃)
+  have h_RHS_step2 := gl_product_eq_oudomGuinStar X₂ X₃
+  -- Use Q3: (X₁ ★ X₂) ★ X₃ = X₁ ★ (X₂ ★ X₃).
+  have h_assoc : oudomGuinStar (oudomGuinStar X₁ X₂) X₃ =
+      oudomGuinStar X₁ (oudomGuinStar X₂ X₃) :=
+    oudomGuinStar_assoc X₁ X₂ X₃
+  -- Apply ckIso to h_assoc.
+  have h_iso_assoc : (ckIsoSymmetricAlgebra
+        (oudomGuinStar (oudomGuinStar X₁ X₂) X₃) : ConnesKreimer ℤ (Nonplanar α)) =
+      ckIsoSymmetricAlgebra (oudomGuinStar X₁ (oudomGuinStar X₂ X₃)) :=
+    congrArg _ h_assoc
+  -- Rewrite both sides via Q5c, then via hckIsoX₁/X₂/X₃ + op_unop.
+  rw [h_LHS_step1, h_LHS_step2, hckIsoX₁, hckIsoX₂, hckIsoX₃,
+      GrossmanLarson.op_unop, GrossmanLarson.op_unop, GrossmanLarson.op_unop] at h_iso_assoc
+  rw [h_RHS_step1, h_RHS_step2, hckIsoX₁, hckIsoX₂, hckIsoX₃,
+      GrossmanLarson.op_unop, GrossmanLarson.op_unop, GrossmanLarson.op_unop] at h_iso_assoc
+  exact h_iso_assoc
 
 end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridgePairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridgePairing.lean
@@ -57,7 +57,7 @@ open PreLie.OudomGuinCirc
 
 namespace GrossmanLarson
 
-variable {α : Type} [DecidableEq (Nonplanar α)]
+variable {α : Type*} [DecidableEq (Nonplanar α)]
 
 /-! ### ε is multiplicative for the GL product
 


### PR DESCRIPTION
Proves `GrossmanLarson.mul_assoc` (R-generic, `Type*`) with `Semigroup`/`Monoid` instances, completing the Oudom-Guin route: the singleton-guest insertion engine (new `PreLie/InsertionCompose.lean`), the NIM singleton associativity, the reactivated-and-proved GL guest-splitting identity (`GL_product_split_mul_ι`), the Q5c per-tprod bridge `gl_product_eq_oudomGuinStar`, and the ℤ→R multiset-coefficient lift (new `GrossmanLarsonMonoid.lean`). All endpoints kernel-clean.

- universe-polymorphizes the OudomGuinCirc chain (`Type` → `Type*`) and grounds the elaboration-fragile counit ascriptions in TraceNonplanar
- deletes the superseded A3.3 combinatorial route (`insertionMultiset_assoc` chain, `composePairs` partition, dead `circT` section) and refreshes stale status docstrings