### PR TITLE
refactor(Semantics/Causation): flatten namespace to Causation

### DIFF
--- a/Linglib/Core/Logic/Intensional/WorldTimeIndex.lean
+++ b/Linglib/Core/Logic/Intensional/WorldTimeIndex.lean
@@ -8,7 +8,7 @@ for intensional, dynamic, modal, and tense semantics. This is the
 Lewis/Kaplan-style "index of evaluation" with world and temporal
 coordinates only — *not* the full Kratzer parthood-structured situation
 (see `Core.Logic.Intensional.Situations`) and *not* the Pearl/Halpern
-partial valuation (see `Semantics.Causation.Situation`).
+partial valuation (see `Causation.Situation`).
 
 The name `WorldTimeIndex` is preferred over `Situation` to disambiguate
 from the two more substantive `Situation` types in those neighbouring

--- a/Linglib/Core/Order/Mereology.lean
+++ b/Linglib/Core/Order/Mereology.lean
@@ -201,7 +201,7 @@ theorem algClosure_idempotent {α : Type*} [SemilatticeSup α]
 
     The three axioms — extensive, monotone, idempotent — are grounded
     in Mathlib's `ClosureOperator`. (Compare with the causal-SEM
-    operator `Semantics.Causation.SEM.developDet`: that operator is
+    operator `Causation.SEM.developDet`: that operator is
     info-extensive but NOT order-monotone, per Schulz [schulz-2011]
     footnote 7, so it does NOT instantiate `ClosureOperator`. The
     mereological case is genuinely closure-operator-shaped.)

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -3382,7 +3382,7 @@ def VerbEntry.toWordPresPart (v : VerbEntry) : Word :=
 -- ════════════════════════════════════════════════════
 
 /-! These verify that the Fragment's causative annotations are consistent
-with the formal semantics in `Semantics.Causation`.
+with the formal semantics in `Causation`.
 
 The semantic-dispatch grounding theorems (e.g., `make_semantics`,
 `cause_semantics`, `prevent_semantics`, `sufficiency_verbs_share_truth_conditions`,
@@ -3538,7 +3538,7 @@ theorems above remain intact. -/
 
 namespace V2
 
-open Semantics.Causation (SEM CausalGraph Valuation DecidableValuation)
+open Causation (SEM CausalGraph Valuation DecidableValuation)
 open Features
 
 variable {V : Type*} {α : V → Type*}
@@ -3548,17 +3548,17 @@ variable {V : Type*} {α : V → Type*}
 /-- V2 "make" → `Sufficiency.makeSem` (polymorphic). -/
 theorem make_semantics :
     make.causative.map (Causative.toSemantics M) =
-    some (Semantics.Causation.Sufficiency.makeSem M) := rfl
+    some (Causation.Sufficiency.makeSem M) := rfl
 
 /-- V2 "cause" → `Necessity.causeSem` (polymorphic). -/
 theorem cause_semantics :
     cause.causative.map (Causative.toSemantics M) =
-    some (Semantics.Causation.Necessity.causeSem M) := rfl
+    some (Causation.Necessity.causeSem M) := rfl
 
 /-- V2 "prevent" → `Prevention.preventSem` (polymorphic). -/
 theorem prevent_semantics :
     prevent.causative.map (Causative.toSemantics M) =
-    some (Semantics.Causation.Prevention.preventSem M) := rfl
+    some (Causation.Prevention.preventSem M) := rfl
 
 /-- V2: make/force/let/have/get share `Sufficiency.makeSem` truth conditions. -/
 theorem sufficiency_verbs_share_truth_conditions :
@@ -3582,12 +3582,12 @@ theorem lexical_causatives_match_make :
 /-- "manage" → polymorphic `Implicative.manageSem`. -/
 theorem manage_semantics_implicative :
     manage.implicative.map (Implicative.toSemantics M) =
-    some (Semantics.Causation.Implicative.manageSem M) := rfl
+    some (Causation.Implicative.manageSem M) := rfl
 
 /-- "fail" → polymorphic `Implicative.failSem`. -/
 theorem fail_semantics_implicative :
     fail.implicative.map (Implicative.toSemantics M) =
-    some (Semantics.Causation.Implicative.failSem M) := rfl
+    some (Causation.Implicative.failSem M) := rfl
 
 end V2
 

--- a/Linglib/Fragments/Finnish/Predicates.lean
+++ b/Linglib/Fragments/Finnish/Predicates.lean
@@ -175,7 +175,7 @@ theorem finnish_is_active_passive :
     The structure extends `FinnishVerb` with implicative fields. -/
 
 open Features (Implicative)
-open Semantics.Causation.Implicative (Directionality Prerequisite ImplicativeClass)
+open Causation.Implicative (Directionality Prerequisite ImplicativeClass)
 
 /-- A Finnish implicative verb entry, extending the base verb with
     implicative classification from [nadathur-2023-implicatives]. -/

--- a/Linglib/Fragments/Mandarin/Resultatives.lean
+++ b/Linglib/Fragments/Mandarin/Resultatives.lean
@@ -4,7 +4,7 @@ import Linglib.Semantics.Causation.Resultatives
 # Mandarin Resultative Compound Fragment
 
 Lexical entries for Mandarin V-V resultative compounds and phase complements,
-parameterized by cross-linguistic types from `Semantics.Causation.Resultatives`.
+parameterized by cross-linguistic types from `Causation.Resultatives`.
 
 ## Compound data
 
@@ -20,7 +20,7 @@ dǎo 倒, wán 完, hǎo 好, diào 掉, zhù 住.
 
 ## Cross-Module Connections
 
-- `Semantics.Causation.Resultatives`: `ResultativeRealization`,
+- `Causation.Resultatives`: `ResultativeRealization`,
   `ResultOrientation`
 - `Semantics.Aspect.ChangeOfState`: `CoSType`
 - `Tay2024`: thesis-specific theorems and analysis that import this Fragment
@@ -29,12 +29,12 @@ dǎo 倒, wán 完, hǎo 好, diào 掉, zhù 住.
 than in `Theories/`: it enumerates Mandarin-specific morphemes
 (dǎo/wán/hǎo/diào/zhù), so the data is Mandarin-anchored. Cross-linguistic
 typological parameters (`ResultativeRealization`, `ResultOrientation`)
-remain in `Semantics.Causation.Resultatives`.
+remain in `Causation.Resultatives`.
 -/
 
 namespace Mandarin.Resultatives
 
-open Semantics.Causation.Resultatives (ResultativeRealization ResultOrientation)
+open Causation.Resultatives (ResultativeRealization ResultOrientation)
 open Features.ChangeOfState (CoSType)
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Fragments/Sinhala/Verbs.lean
+++ b/Linglib/Fragments/Sinhala/Verbs.lean
@@ -39,7 +39,7 @@ predictive engine of B&Z's analysis.
 
 namespace Sinhala.Verbs
 
-open Semantics.Causation
+open Causation
 
 /-- A Colloquial Sinhala verb root.
 

--- a/Linglib/Fragments/Urdu/CausativeSystem.lean
+++ b/Linglib/Fragments/Urdu/CausativeSystem.lean
@@ -57,7 +57,7 @@ The discourse production study confirms key patterns:
 
 namespace Urdu.CausativeSystem
 
-open Semantics.Causation.Morphological
+open Causation.Morphological
 
 -- ════════════════════════════════════════════════════
 -- § 1. Construction Definitions

--- a/Linglib/Pragmatics/DecisionTheoretic/Also.lean
+++ b/Linglib/Pragmatics/DecisionTheoretic/Also.lean
@@ -434,11 +434,11 @@ enforces presuppositional independence of the antecedent ("Kim fell"),
 removing the default causal reading that plain "and" would carry
 ("Kim fell and [as a result] broke her arm").
 
-This connects to `Semantics.Causation` — the causal reading arises from
+This connects to `Causation` — the causal reading arises from
 non-independence of the conjuncts, and "also" explicitly marks the
 antecedent as presupposed (hence independent).
 
--- TODO: Formalize using `Semantics.Causation.SEM` (`BoolSEM` / `develop`). -/
+-- TODO: Formalize using `Causation.SEM` (`BoolSEM` / `develop`). -/
 
 end Theorems
 

--- a/Linglib/Semantics/ArgumentStructure/VoiceSemantics.lean
+++ b/Linglib/Semantics/ArgumentStructure/VoiceSemantics.lean
@@ -135,7 +135,7 @@ theorem berSemG_eq_suppressArg {E W : Type} {τ : Ty} (n : ℕ)
     *ber-* targets arguments other than causers and so doesn't need
     the U_I restriction. -/
 def causerSuppress {E W : Type} {τ : Ty}
-    (s : Semantics.Causation.CauserSort)
+    (s : Causation.CauserSort)
     (_h : s.admitsIndividual)
     (z : E) (vp : Denot E W (.e ⇒ τ)) : Denot E W τ :=
   suppressArg z vp
@@ -144,7 +144,7 @@ def causerSuppress {E W : Type} {τ : Ty}
     `suppressArg`: the truth conditions are identical, the
     restriction lives only at the type level. -/
 theorem causerSuppress_eq_suppressArg {E W : Type} {τ : Ty}
-    (s : Semantics.Causation.CauserSort)
+    (s : Causation.CauserSort)
     (h : s.admitsIndividual)
     (z : E) (vp : Denot E W (.e ⇒ τ)) :
     causerSuppress s h z vp = suppressArg z vp := rfl

--- a/Linglib/Semantics/Aspect/SubeventStructure.lean
+++ b/Linglib/Semantics/Aspect/SubeventStructure.lean
@@ -228,7 +228,7 @@ theorem prfv_phasePred {Time : Type*} [LinearOrder Time]
     The reference [3, 7] is properly inside the activity [0, 10], but
     entirely before the result [15, 20].
 
-    See also `Semantics.Causation.Progressive.progressive_not_entails_perfective`
+    See also `Causation.Progressive.progressive_not_entails_perfective`
     for the causal explanation: the initiator is type-level sufficient
     (progressive holds) but an intervening event can prevent token-level
     completion (perfective fails). -/

--- a/Linglib/Semantics/Attitudes/Doxastic.lean
+++ b/Linglib/Semantics/Attitudes/Doxastic.lean
@@ -188,11 +188,11 @@ This asymmetry DERIVES the gap from independent causal-cognitive principles.
 -/
 
 -- ============================================================================
--- Causal Model Infrastructure (via Semantics.Causation)
+-- Causal Model Infrastructure (via Causation)
 -- ============================================================================
 
 /-!
-The belief formation causal model uses `Semantics.Causation` — the V2 SEM
+The belief formation causal model uses `Causation` — the V2 SEM
 substrate (PMF-canonical Mechanism, BoolSEM specialization for the
 deterministic-binary case). The PLC predicate is defined via
 `SEM.developDetOn` with an explicit vertex list so kernel reduction
@@ -200,7 +200,7 @@ works structurally (no `native_decide`; mathlib-quality `rfl`/`decide`
 proofs).
 -/
 
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
+open Causation Causation.Mechanism Causation.SEM
 
 -- ============================================================================
 -- Belief Formation Causal Model (Roberts & Özyıldız 2025)

--- a/Linglib/Semantics/Causation/BayesNet.lean
+++ b/Linglib/Semantics/Causation/BayesNet.lean
@@ -18,7 +18,7 @@ distributions with conditional probability, independence, and correlation.
 
 -/
 
-namespace Semantics.Causation.BayesNet
+namespace Causation.BayesNet
 
 -- Causal Relations
 
@@ -243,4 +243,4 @@ theorem bayes_theorem (w : WorldState) (hA : 0 < w.pA) (hC : 0 < w.pC) :
 
 end WorldState
 
-end Semantics.Causation.BayesNet
+end Causation.BayesNet

--- a/Linglib/Semantics/Causation/CCSelection.lean
+++ b/Linglib/Semantics/Causation/CCSelection.lean
@@ -20,9 +20,9 @@ The legacy `CausalDynamics`-based `completesForEffect`,
 The polymorphic V2 versions are promoted to canonical here.
 -/
 
-namespace Semantics.Causation.CCSelection
+namespace Causation.CCSelection
 
-open Semantics.Causation (SEM CausalGraph Valuation DecidableValuation)
+open Causation (SEM CausalGraph Valuation DecidableValuation)
 
 /-- How a causative construction selects its cause from a causal model. -/
 inductive CCSelectionMode where
@@ -52,7 +52,7 @@ noncomputable instance {V : Type*} {α : V → Type*}
     `developDetOn` computations (cause-on develops the effect true;
     cause-off develops it false). The computations close by `decide`. -/
 theorem completesForEffect_of_developDetOn {V : Type*} [Fintype V] [DecidableEq V]
-    {M : Semantics.Causation.BoolSEM V} [CausalGraph.IsDAG M.graph]
+    {M : Causation.BoolSEM V} [CausalGraph.IsDAG M.graph]
     [SEM.IsDeterministic M]
     {bg : Valuation (fun _ : V => Bool)} {c e : V} (vs : List V) (n : ℕ)
     (h1 : (SEM.developDetOn M vs n (bg.extend c true)).hasValue e true)
@@ -67,7 +67,7 @@ theorem completesForEffect_of_developDetOn {V : Type*} [Fintype V] [DecidableEq 
 /-- Bool-model bridge, negative: the sufficiency half fails — the cause-on
     development reaches the effect `false`, so no completion. -/
 theorem not_completesForEffect_of_developDetOn {V : Type*} [Fintype V] [DecidableEq V]
-    {M : Semantics.Causation.BoolSEM V} [CausalGraph.IsDAG M.graph]
+    {M : Causation.BoolSEM V} [CausalGraph.IsDAG M.graph]
     [SEM.IsDeterministic M]
     {bg : Valuation (fun _ : V => Bool)} {c e : V} (vs : List V) (n : ℕ)
     (h1 : (SEM.developDetOn M vs n (bg.extend c true)).hasValue e false) :
@@ -78,4 +78,4 @@ theorem not_completesForEffect_of_developDetOn {V : Type*} [Fintype V] [Decidabl
   have h1'' : (M.developDet (bg.extend c true)).get e = some false := h1'
   exact Bool.noConfusion (Option.some.inj (hs'.symm.trans h1''))
 
-end Semantics.Causation.CCSelection
+end Causation.CCSelection

--- a/Linglib/Semantics/Causation/CauserSort.lean
+++ b/Linglib/Semantics/Causation/CauserSort.lean
@@ -25,7 +25,7 @@ requires `event`. Both predictions follow from `≤`-checks on the
 lattice rather than from stipulated lexical exceptions.
 -/
 
-namespace Semantics.Causation
+namespace Causation
 
 /-- The three irreducible sorts (atoms) a causer position may resolve
     to. Used as the underlying Finset of `CauserSort`; not intended
@@ -151,4 +151,4 @@ abbrev admitsVolitive (s : CauserSort) : Prop := event ≤ s
 
 end CauserSort
 
-end Semantics.Causation
+end Causation

--- a/Linglib/Semantics/Causation/CoerciveImplication.lean
+++ b/Linglib/Semantics/Causation/CoerciveImplication.lean
@@ -13,9 +13,9 @@ examples were deleted in Phase D-H. The polymorphic V2
 `hasCoerciveImplication` is promoted to canonical here.
 -/
 
-namespace Semantics.Causation.CoerciveImplication
+namespace Causation.CoerciveImplication
 
-open Semantics.Causation (SEM CausalGraph Valuation DecidableValuation)
+open Causation (SEM CausalGraph Valuation DecidableValuation)
 
 /-- Action volitionality (volitional/non-volitional/ambiguous). -/
 inductive ActionType
@@ -50,4 +50,4 @@ noncomputable instance {V : Type*} {α : V → Type*}
     (effect : V) (xE : α effect) :
     Decidable (hasCoerciveImplication M bg causer xC vol effect xE) := Classical.dec _
 
-end Semantics.Causation.CoerciveImplication
+end Causation.CoerciveImplication

--- a/Linglib/Semantics/Causation/Graph/Basic.lean
+++ b/Linglib/Semantics/Causation/Graph/Basic.lean
@@ -16,7 +16,7 @@ intermediate adapter); consumers can use mathlib's existing API for
 reflexive-transitive closures.
 -/
 
-namespace Semantics.Causation.CausalGraph
+namespace Causation.CausalGraph
 
 variable {V : Type*}
 
@@ -82,4 +82,4 @@ theorem IsDAG.of_depth (G : CausalGraph V) (depth : V → ℕ)
     exact Subrelation.wf (fun {a b} => hsub a b)
       (InvImage.wf depth Nat.lt_wfRel.wf)
 
-end Semantics.Causation.CausalGraph
+end Causation.CausalGraph

--- a/Linglib/Semantics/Causation/Graph/Defs.lean
+++ b/Linglib/Semantics/Causation/Graph/Defs.lean
@@ -15,7 +15,7 @@ because Pearl SEM API consumes parent enumerations directly (mechanisms
 fold over `parents v`).
 -/
 
-namespace Semantics.Causation
+namespace Causation
 
 /-- A directed graph over `V` represented by parent finsets. The graph
     structure is value-type-agnostic: mechanisms and values layer on top
@@ -54,4 +54,4 @@ def children (G : CausalGraph V) [DecidableEq V] [Fintype V] (v : V) : Finset V 
 
 end CausalGraph
 
-end Semantics.Causation
+end Causation

--- a/Linglib/Semantics/Causation/Implicative.lean
+++ b/Linglib/Semantics/Causation/Implicative.lean
@@ -39,11 +39,11 @@ were deleted in Phase D-H. The polymorphic V2 versions
 dispatch) are promoted to canonical here.
 -/
 
-namespace Semantics.Causation.Implicative
+namespace Causation.Implicative
 
 open Features (Implicative)
 open Features
-open Semantics.Causation (SEM CausalGraph Valuation DecidableValuation)
+open Causation (SEM CausalGraph Valuation DecidableValuation)
 
 -- ════════════════════════════════════════════════════
 -- § Prerequisite Types ([nadathur-2023-implicatives])
@@ -356,21 +356,21 @@ theorem specific_vs_bleached :
     (ImplicativeClass.manage.prerequisite.bind (some ·.isSpecific)) = some false := by
   exact ⟨rfl, rfl⟩
 
-end Semantics.Causation.Implicative
+end Causation.Implicative
 
 -- ════════════════════════════════════════════════════
 -- § `Features.Implicative.toSemantics` dispatch (V2 polymorphic)
 -- ════════════════════════════════════════════════════
 
 /-! Lives here rather than in `Features/Causation.lean` because the
-dispatch needs `Semantics.Causation.SEM` + the `Implicative.manageSem`/`failSem`
+dispatch needs `Causation.SEM` + the `Implicative.manageSem`/`failSem`
 machinery defined above; `Features/Causation.lean` is kept import-free.
 Standard mathlib pattern: methods on a type may live in a sibling
 file via `namespace TypeName` block when import weight matters. -/
 
 namespace Features.Implicative
 
-open Semantics.Causation (SEM CausalGraph Valuation DecidableValuation)
+open Causation (SEM CausalGraph Valuation DecidableValuation)
 
 /-- V2 dispatch: map an `Implicative` polarity to its V2 polymorphic
     semantic function. -/
@@ -378,7 +378,7 @@ noncomputable def toSemantics {V : Type*} {α : V → Type*}
     [Fintype V] [DecidableEq V] [DecidableValuation α]
     (M : SEM V α) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M] :
     Implicative → Valuation α → ∀ p : V, α p → ∀ c : V, α c → Prop
-  | .positive => Semantics.Causation.Implicative.manageSem M
-  | .negative => Semantics.Causation.Implicative.failSem M
+  | .positive => Causation.Implicative.manageSem M
+  | .negative => Causation.Implicative.failSem M
 
 end Features.Implicative

--- a/Linglib/Semantics/Causation/Interpretation.lean
+++ b/Linglib/Semantics/Causation/Interpretation.lean
@@ -46,7 +46,7 @@ disagreement is theorem-provable.
 -- ════════════════════════════════════════════════════
 
 /-! Methods on `Features.Causative` that depend on heavy semantic
-machinery (`Semantics.Causation.SEM`, `CausalGraph`, the `Necessity`/
+machinery (`Causation.SEM`, `CausalGraph`, the `Necessity`/
 `Sufficiency`/`Prevention` modules) live here rather than in
 `Features/Causation.lean`, which is kept import-free per the
 "Features/ stays lightweight" convention. The `namespace
@@ -55,8 +55,8 @@ distributing methods on a type across files based on import weight. -/
 
 namespace Features.Causative
 
-open Semantics.Causation.CCSelection
-open Semantics.Causation (SEM CausalGraph Valuation DecidableValuation)
+open Causation.CCSelection
+open Causation (SEM CausalGraph Valuation DecidableValuation)
 
 /-- The CC-selection mode associated with each variant.
 
@@ -75,11 +75,11 @@ noncomputable def toSemantics {V : Type*} {α : V → Type*}
     [Fintype V] [DecidableEq V] [DecidableValuation α] [∀ v, Fintype (α v)]
     (M : SEM V α) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M] :
     Causative → Valuation α → ∀ c : V, α c → ∀ e : V, α e → Prop
-  | .cause => Semantics.Causation.Necessity.causeSem M
-  | .make => Semantics.Causation.Sufficiency.makeSem M
-  | .force => Semantics.Causation.Sufficiency.makeSem M
-  | .enable => Semantics.Causation.Sufficiency.makeSem M
-  | .prevent => Semantics.Causation.Prevention.preventSem M
+  | .cause => Causation.Necessity.causeSem M
+  | .make => Causation.Sufficiency.makeSem M
+  | .force => Causation.Sufficiency.makeSem M
+  | .enable => Causation.Sufficiency.makeSem M
+  | .prevent => Causation.Prevention.preventSem M
 
 end Features.Causative
 
@@ -87,7 +87,7 @@ end Features.Causative
 -- § Derivation theorems (substrate-independent)
 -- ════════════════════════════════════════════════════
 
-namespace Semantics.Causation.Interpretation
+namespace Causation.Interpretation
 
 open Semantics.Lexical
 open Features
@@ -121,4 +121,4 @@ theorem sufficiency_selects_completion (b : Causative)
 theorem necessity_selects_member :
     Causative.cause.selectionMode = .memberOfSufficientSet := rfl
 
-end Semantics.Causation.Interpretation
+end Causation.Interpretation

--- a/Linglib/Semantics/Causation/Mechanism/Defs.lean
+++ b/Linglib/Semantics/Causation/Mechanism/Defs.lean
@@ -29,7 +29,7 @@ when they need to extract the deterministic function (mirroring
 `IsMarkovKernel` in `Mathlib/Probability/Kernel/Defs.lean`).
 -/
 
-namespace Semantics.Causation
+namespace Causation
 
 variable {V : Type*}
 
@@ -60,4 +60,4 @@ class IsDeterministic (m : Mechanism G α v) where
 
 end Mechanism
 
-end Semantics.Causation
+end Causation

--- a/Linglib/Semantics/Causation/Mechanism/Deterministic.lean
+++ b/Linglib/Semantics/Causation/Mechanism/Deterministic.lean
@@ -9,7 +9,7 @@ is built as a Dirac PMF — the exact mathlib pattern from
 `Kernel.deterministic (f) := dirac ∘ f`.
 -/
 
-namespace Semantics.Causation.Mechanism
+namespace Causation.Mechanism
 
 variable {V : Type*} {α : V → Type*} {G : CausalGraph V} {v : V}
 
@@ -47,4 +47,4 @@ noncomputable def const (x : α v) : Mechanism G α v := deterministic (fun _ =>
 instance (x : α v) : IsDeterministic (const (G := G) x) :=
   inferInstanceAs (IsDeterministic (deterministic _))
 
-end Semantics.Causation.Mechanism
+end Causation.Mechanism

--- a/Linglib/Semantics/Causation/Morphological.lean
+++ b/Linglib/Semantics/Causation/Morphological.lean
@@ -71,9 +71,9 @@ the external cause entirely, yielding monoeventive structure.
   intransitives but absent from anticausatives
 -/
 
-namespace Semantics.Causation.Morphological
+namespace Causation.Morphological
 
-open Semantics.Causation.Psych (CausalSource)
+open Causation.Psych (CausalSource)
 open Semantics.ArgumentStructure.AgentivityLattice (AgentivityNode)
 
 -- ════════════════════════════════════════════════════
@@ -530,4 +530,4 @@ def krejciLanguages : List CausativizabilityData :=
 theorem krejci_hierarchy_holds :
     krejciLanguages.all (·.respectsHierarchy) = true := by native_decide
 
-end Semantics.Causation.Morphological
+end Causation.Morphological

--- a/Linglib/Semantics/Causation/Necessity.lean
+++ b/Linglib/Semantics/Causation/Necessity.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Causation.SEM.Counterfactual
 [nadathur-2023-implicatives] [nadathur-lauer-2020] [schulz-2011]
 
 Causal necessity semantics for the verb "cause." The core definition
-`causallyNecessary` (in `Semantics.Causation.SEM`) implements
+`causallyNecessary` (in `Causation.SEM`) implements
 [nadathur-2023-implicatives] Definition 10b (supersituation necessity:
 precondition + achievability + but-for), superseding the simple but-for
 test from [nadathur-lauer-2020] Definition 24.
@@ -28,9 +28,9 @@ The legacy `CausalDynamics`-based `causeSem`/`isINUSCause`/
 are promoted to canonical here.
 -/
 
-namespace Semantics.Causation.Necessity
+namespace Causation.Necessity
 
-open Semantics.Causation (SEM CausalGraph Valuation DecidableValuation)
+open Causation (SEM CausalGraph Valuation DecidableValuation)
 
 /-- V2 causal-necessity semantics for "cause": setting cause to xC
     develops effect to xE AND cause-as-xC is causally necessary
@@ -84,4 +84,4 @@ noncomputable instance {V : Type*} {α : V → Type*}
     (s : Valuation α) (cause : V) (xC : α cause) (effect : V) (xE : α effect) :
     Decidable (actuallyCaused M s cause xC effect xE) := Classical.dec _
 
-end Semantics.Causation.Necessity
+end Causation.Necessity

--- a/Linglib/Semantics/Causation/Prevention.lean
+++ b/Linglib/Semantics/Causation/Prevention.lean
@@ -21,9 +21,9 @@ arity-uniform with `causallySufficient`/`causeSem` so `Causative.toSemantics`
 dispatches uniformly across all five force-dynamic variants.
 -/
 
-namespace Semantics.Causation.Prevention
+namespace Causation.Prevention
 
-open Semantics.Causation (SEM CausalGraph Valuation DecidableValuation)
+open Causation (SEM CausalGraph Valuation DecidableValuation)
 
 /-- V2 prevention semantics: preventer-as-`xPrev` blocks effect-from-
     being-`xE`, AND there exists some alternative preventer value that
@@ -46,4 +46,4 @@ noncomputable instance {V : Type*} {α : V → Type*}
     (effect : V) (xE : α effect) :
     Decidable (preventSem M bg preventer xP effect xE) := Classical.dec _
 
-end Semantics.Causation.Prevention
+end Causation.Prevention

--- a/Linglib/Semantics/Causation/ProductionDependence.lean
+++ b/Linglib/Semantics/Causation/ProductionDependence.lean
@@ -33,7 +33,7 @@ d-causes without producing anything.
 
 -/
 
-namespace Semantics.Causation.ProductionDependence
+namespace Causation.ProductionDependence
 
 open Core (WorldTimeIndex)
 
@@ -261,7 +261,7 @@ P-CAUSE (production) → completion (the cause directly completes a
 sufficient set). D-CAUSE (dependence) → membership (any necessary
 condition qualifies). -/
 
-open Semantics.Causation.CCSelection
+open Causation.CCSelection
 
 /-- Map causation type to CC-selection mode.
 
@@ -288,4 +288,4 @@ The three encodings (CausationType, CCSelectionMode, Causative) remain
 consistent at the enum level (`production_selects_completion` etc.); the
 semantic-dispatch consistency follows from the V2 hub structure. -/
 
-end Semantics.Causation.ProductionDependence
+end Causation.ProductionDependence

--- a/Linglib/Semantics/Causation/Progressive.lean
+++ b/Linglib/Semantics/Causation/Progressive.lean
@@ -33,10 +33,10 @@ checks type-level sufficiency (`BoolSEM.causallySufficient`);
 (`CCSelection.completesForEffect`).
 -/
 
-namespace Semantics.Causation.Progressive
+namespace Causation.Progressive
 
 open Core (WorldTimeIndex)
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
+open Causation Causation.Mechanism Causation.SEM
 
 -- ════════════════════════════════════════════════════
 -- § 1. Causal Process (V2)
@@ -287,4 +287,4 @@ structure CausallyGroundedEvent (V : Type*) [Fintype V] [DecidableEq V]
   /-- The causal trajectory is viable: initiator is type-level sufficient. -/
   causallyViable : @CausalProcess.typeLevelHolds V _ _ process dagInst detInst
 
-end Semantics.Causation.Progressive
+end Causation.Progressive

--- a/Linglib/Semantics/Causation/Psych.lean
+++ b/Linglib/Semantics/Causation/Psych.lean
@@ -26,7 +26,7 @@ chain; its incompatibility with an overt Cause follows from the Onset Condition.
 
 -/
 
-namespace Semantics.Causation.Psych
+namespace Causation.Psych
 
 /-- Source of causation for psych causatives ([kim-2024] UPH).
 
@@ -176,4 +176,4 @@ theorem source_determines_stimulus_properties :
     (CausalSource.toStimulusType .internal).conflictsWithCause = true :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
 
-end Semantics.Causation.Psych
+end Causation.Psych

--- a/Linglib/Semantics/Causation/PsychLink.lean
+++ b/Linglib/Semantics/Causation/PsychLink.lean
@@ -34,9 +34,9 @@ The fourth uses `universalCounterfactual` from `Counterfactual.lean`.
 
 -/
 
-namespace Semantics.Causation.PsychLink
+namespace Causation.PsychLink
 
-open Semantics.Causation.Psych (CausalSource)
+open Causation.Psych (CausalSource)
 open Core.Order (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 
@@ -265,4 +265,4 @@ theorem maintenance_three_properties {Time : Type*} [LinearOrder Time] :
     (maintenanceLink Time).involvesTransition = false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
-end Semantics.Causation.PsychLink
+end Causation.PsychLink

--- a/Linglib/Semantics/Causation/Resultatives.lean
+++ b/Linglib/Semantics/Causation/Resultatives.lean
@@ -37,7 +37,7 @@ Sections:
    `Mandarin.Resultatives`.
 -/
 
-namespace Semantics.Causation.Resultatives
+namespace Causation.Resultatives
 
 open ConstructionGrammar
 open ConstructionGrammar.Resultatives
@@ -45,8 +45,8 @@ open Features
 open Semantics.Lexical
 open Features.ChangeOfState
 open Features (Causative)
-open Semantics.Causation.ProductionDependence
-open Semantics.Causation.CCSelection
+open Causation.ProductionDependence
+open Causation.CCSelection
 
 /-! ## Agreement with Boolean flags -/
 
@@ -219,4 +219,4 @@ inductive ResultOrientation where
   | subjectOriented
   deriving DecidableEq, Repr
 
-end Semantics.Causation.Resultatives
+end Causation.Resultatives

--- a/Linglib/Semantics/Causation/SEM/Basic.lean
+++ b/Linglib/Semantics/Causation/SEM/Basic.lean
@@ -42,7 +42,7 @@ computable variants. Structural simp lemmas let proofs unfold via
 rewriting rather than runtime evaluation.
 -/
 
-namespace Semantics.Causation.SEM
+namespace Causation.SEM
 
 variable {V : Type*} {α : V → Type*}
 
@@ -875,4 +875,4 @@ DAG give the same PMF. Provable via `PMF.bind_comm` + a lemma showing
 ready. Not load-bearing for current consumers; deferred until a study
 needs to reason about `develop` against a hand-picked vertex order. -/
 
-end Semantics.Causation.SEM
+end Causation.SEM

--- a/Linglib/Semantics/Causation/SEM/Bool.lean
+++ b/Linglib/Semantics/Causation/SEM/Bool.lean
@@ -9,11 +9,11 @@ where every vertex has value type `Bool`). Lives in its own file so the
 core `SEM/Defs.lean` stays focused on the general API.
 -/
 
-namespace Semantics.Causation
+namespace Causation
 
 /-- A `BoolSEM V` is the SBH-style binary substrate: every vertex's
     value is `Bool`. Convenience abbreviation for consumers that don't
     need multi-valued variables. -/
 abbrev BoolSEM (V : Type*) := SEM V (fun _ => Bool)
 
-end Semantics.Causation
+end Causation

--- a/Linglib/Semantics/Causation/SEM/Counterfactual.lean
+++ b/Linglib/Semantics/Causation/SEM/Counterfactual.lean
@@ -48,7 +48,7 @@ with `entails_iff` a one-line per-model instantiation of
 `causallyEntails_iff_fuel`.
 -/
 
-namespace Semantics.Causation.SEM
+namespace Causation.SEM
 
 variable {V : Type*} {α : V → Type*}
 variable [Fintype V] [DecidableEq V] [DecidableValuation α]
@@ -261,21 +261,21 @@ theorem whetherCause_eq_indicator_of_deterministic
   · simp [h]
   · simp [h]
 
-end Semantics.Causation.SEM
+end Causation.SEM
 
 -- ════════════════════════════════════════════════════
 -- § BoolSEM specializations (legacy SBH-style binary semantics)
 -- ════════════════════════════════════════════════════
 
-namespace Semantics.Causation.BoolSEM
+namespace Causation.BoolSEM
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
-open Semantics.Causation (SEM Valuation BoolSEM)
-open Semantics.Causation.SEM (developsToValue causallySufficient)
+open Causation (SEM Valuation BoolSEM)
+open Causation.SEM (developsToValue causallySufficient)
 
 /-- `BoolSEM`-flavored `causallySufficient`: setting `cause = true` develops
-    `effect = true`. Matches old `Semantics.Causation.causallySufficient` semantics. -/
+    `effect = true`. Matches old `Causation.causallySufficient` semantics. -/
 abbrev causallySufficient (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
     [SEM.IsDeterministic M] (s : Valuation (fun _ : V => Bool)) (cause effect : V) : Prop :=
   SEM.causallySufficient M s cause true effect true
@@ -355,9 +355,9 @@ theorem not_manipulates_of_developDetOn_eq (M : BoolSEM V)
   rw [h1', h2']
   exact fun h => h rfl
 
-end Semantics.Causation.BoolSEM
+end Causation.BoolSEM
 
-namespace Semantics.Causation.SEM
+namespace Causation.SEM
 
 variable {V : Type*} {α : V → Type*}
 
@@ -670,13 +670,13 @@ theorem causallyNecessary_iff_fuel [Fintype V] [DecidableEq V] [DecidableValuati
       (forall_congr' fun s' => imp_congr_right fun _ => imp_congr_right fun _ =>
         imp_congr (hpt s' effect xE) (hpt s' cause xC)))
 
-end Semantics.Causation.SEM
+end Causation.SEM
 
-namespace Semantics.Causation.BoolSEM
+namespace Causation.BoolSEM
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
-open Semantics.Causation (SEM Valuation BoolSEM)
+open Causation (SEM Valuation BoolSEM)
 
 /-- `BoolSEM`-flavored `causallyNecessary`: setting `cause = true` is
     necessary (Def 10b) for `effect = true`. -/
@@ -689,4 +689,4 @@ noncomputable instance (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
     [SEM.IsDeterministic M] (s : Valuation _) (cause effect : V) :
     Decidable (causallyNecessary M s cause effect) := Classical.dec _
 
-end Semantics.Causation.BoolSEM
+end Causation.BoolSEM

--- a/Linglib/Semantics/Causation/SEM/Defs.lean
+++ b/Linglib/Semantics/Causation/SEM/Defs.lean
@@ -18,7 +18,7 @@ Phase A scope: structure + mixins only. Forward propagation, intervention,
 and counterfactual queries live in `SEM/Basic.lean`.
 -/
 
-namespace Semantics.Causation
+namespace Causation
 
 /-- A **structural equation model**: a causal graph with a mechanism at
     every vertex over a per-vertex value type `α`.
@@ -48,4 +48,4 @@ instance (M : SEM V α) [h : IsDeterministic M] (v : V) :
 end SEM
 
 
-end Semantics.Causation
+end Causation

--- a/Linglib/Semantics/Causation/SEM/Deterministic.lean
+++ b/Linglib/Semantics/Causation/SEM/Deterministic.lean
@@ -59,7 +59,7 @@ For 5-vertex SEMs, ~5 layers of unfolding suffice. No `Fintype` reasoning;
 no opaque `Multiset.toList`.
 -/
 
-namespace Semantics.Causation.SEM
+namespace Causation.SEM
 
 variable {V : Type*} {α : V → Type*}
 
@@ -352,4 +352,4 @@ theorem developDetVtx?_eq_of_fuel
 
 end FuelBridge
 
-end Semantics.Causation.SEM
+end Causation.SEM

--- a/Linglib/Semantics/Causation/SEM/Interventional.lean
+++ b/Linglib/Semantics/Causation/SEM/Interventional.lean
@@ -36,7 +36,7 @@ it to a {0,1} indicator under `IsDeterministic` via
 `develop_eq_pure_of_deterministic` (Basic.lean). Sorry-free.
 -/
 
-namespace Semantics.Causation.SEM
+namespace Causation.SEM
 
 variable {V : Type*} {α : V → Type*} [Fintype V] [DecidableEq V] [DecidableValuation α]
 
@@ -71,4 +71,4 @@ theorem probabilisticSuf_of_deterministic
   · simp [h]
   · simp [h]
 
-end Semantics.Causation.SEM
+end Causation.SEM

--- a/Linglib/Semantics/Causation/Strength.lean
+++ b/Linglib/Semantics/Causation/Strength.lean
@@ -21,7 +21,7 @@ These definitions are theory-layer infrastructure imported by study files
 (e.g., `KonukEtAl2026`, `BellerGerstenberg2025`).
 -/
 
-namespace Semantics.Causation.Strength
+namespace Causation.Strength
 
 /-! ## Sampling Propensity
 
@@ -78,4 +78,4 @@ theorem nsm_mono_suf (pC nec : ℚ) (hpC : 0 ≤ pC) (s₁ s₂ : ℚ) (h : s₁
     nsm pC s₁ nec ≤ nsm pC s₂ nec := by
   unfold nsm; linarith [mul_le_mul_of_nonneg_left h hpC]
 
-end Semantics.Causation.Strength
+end Causation.Strength

--- a/Linglib/Semantics/Causation/Sufficiency.lean
+++ b/Linglib/Semantics/Causation/Sufficiency.lean
@@ -26,9 +26,9 @@ qualitative claims are recoverable via concrete `BoolSEM` models in
 study files (e.g., `Levin2026.HammerFlat`).
 -/
 
-namespace Semantics.Causation.Sufficiency
+namespace Causation.Sufficiency
 
-open Semantics.Causation (SEM CausalGraph Valuation DecidableValuation)
+open Causation (SEM CausalGraph Valuation DecidableValuation)
 
 /-- V2 sufficiency for "make" ([nadathur-lauer-2020] Definition 23, both
     clauses, over the strict T_D development):
@@ -56,4 +56,4 @@ noncomputable instance {V : Type*} {α : V → Type*} [Fintype V] [DecidableEq V
     (cause : V) (xC : α cause) (effect : V) (xE : α effect) :
     Decidable (makeSem M background cause xC effect xE) := Classical.dec _
 
-end Semantics.Causation.Sufficiency
+end Causation.Sufficiency

--- a/Linglib/Semantics/Causation/Valuation.lean
+++ b/Linglib/Semantics/Causation/Valuation.lean
@@ -16,7 +16,7 @@ A `DecidableValuation` aggregator typeclass bundles
 `∀ v, DecidableEq (α v)` for use throughout the API.
 -/
 
-namespace Semantics.Causation
+namespace Causation
 
 /-- Partial valuation: each vertex `v` either has a value of type `α v`
     (encoded `some x`) or is undetermined (`none`). Generalizes the old
@@ -119,4 +119,4 @@ theorem hasValue_empty_iff (v : V) (x : α v) :
 
 end Valuation
 
-end Semantics.Causation
+end Causation

--- a/Linglib/Semantics/Probabilistic/ConditionalAssertability.lean
+++ b/Linglib/Semantics/Probabilistic/ConditionalAssertability.lean
@@ -21,7 +21,7 @@ import Mathlib.Data.Rat.Defs
 
 namespace Semantics.Probabilistic.ConditionalAssertability
 
-open Semantics.Causation.BayesNet
+open Causation.BayesNet
 
 -- Conditional Probability
 

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -13,7 +13,7 @@ open Features
 open Semantics.Lexical
 open Features.ChangeOfState
 open Core.NaturalLogic (EntailmentSig)
-open Semantics.Causation.Psych (CausalSource)
+open Causation.Psych (CausalSource)
 open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Semantics.Aspect.Incremental (VerbIncClass)

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -46,7 +46,7 @@ open Features
 open Semantics.Lexical
 open Features.ChangeOfState
 open Core.NaturalLogic (EntailmentSig)
-open Semantics.Causation.Psych (CausalSource)
+open Causation.Psych (CausalSource)
 open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Semantics.Aspect.Incremental (VerbIncClass)

--- a/Linglib/Studies/BarAsherSiegal2026.lean
+++ b/Linglib/Studies/BarAsherSiegal2026.lean
@@ -44,7 +44,7 @@ as study-file constraint."
 
 namespace BarAsherSiegal2026
 
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
+open Causation Causation.Mechanism Causation.SEM
 
 /-- Six-vertex door scenario. Inductive enum so `Fintype.elems`
     gives a fixed canonical order and `developDet` reduces structurally. -/
@@ -159,7 +159,7 @@ instance : CausalGraph.IsDAG manualModel.graph :=
 def unlocked : Valuation (fun _ : V => Bool) :=
   Valuation.empty.extend .lock false
 
-open Semantics.Causation.CCSelection in
+open Causation.CCSelection in
 /-- **Manual-only model**: handle completes the sufficient set for
     doorOpens (full *open* and *cause* felicity, per [bar-asher-siegal-2026]).
     Both completion and member modes succeed because there's no
@@ -168,7 +168,7 @@ theorem handle_completes_manual :
     completesForEffect manualModel unlocked .handle true false .doorOpens true :=
   completesForEffect_of_developDetOn varList 1 (by decide) (by decide)
 
-open Semantics.Causation.CCSelection in
+open Causation.CCSelection in
 /-- **Full model with handle alone**: handle completes the manual
     sufficient set, satisfying *open*-style completion CC-selection.
     The automatic pathway doesn't fire because button=false in `unlocked`. -/
@@ -176,7 +176,7 @@ theorem handle_completes_full :
     completesForEffect fullModel unlocked .handle true false .doorOpens true :=
   completesForEffect_of_developDetOn varList 2 (by decide) (by decide)
 
-open Semantics.Causation.CCSelection in
+open Causation.CCSelection in
 /-- **Overdetermination in the full model**: when both pathways are
     independently activated (button=true, electricity=true alongside
     handle=true), removing handle still leaves doorOpens true via the

--- a/Linglib/Studies/BeaversZubair2013.lean
+++ b/Linglib/Studies/BeaversZubair2013.lean
@@ -85,7 +85,7 @@ around (71)).
 
 namespace BeaversZubair2013
 
-open Semantics.Causation
+open Causation
 open Sinhala.Verbs
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/BellerGerstenberg2025.lean
+++ b/Linglib/Studies/BellerGerstenberg2025.lean
@@ -496,11 +496,11 @@ theorem exp3_full_best :
 -- Section 11: Bridge to Structural Causal Models
 -- ============================================================================
 
-/-! ## Bridge to Semantics.Causation
+/-! ## Bridge to Causation
 
 Beller & Gerstenberg's W, H, S dimensions can be COMPUTED from structural
 causal models, grounding the primitive Boolean features in the counterfactual
-reasoning machinery of `Semantics.Causation`.
+reasoning machinery of `Causation`.
 
 | B&G aspect | Structural definition |
 |------------|---------------------|
@@ -516,8 +516,8 @@ For simple causal models, the two coincide.
 
 section StructuralBridge
 
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
-open Semantics.Causation.BoolSEM (causallySufficient causallyNecessary hasDirectLaw)
+open Causation Causation.Mechanism Causation.SEM
+open Causation.BoolSEM (causallySufficient causallyNecessary hasDirectLaw)
 
 /-- Vertex enum for B&G's bridge models.
     `cause`, `alt`, `effect`, `intermediate` — covers solo, overdetermination, chain. -/
@@ -692,16 +692,16 @@ These are the deepest integration points: a change to `normalDevelopment`,
 
 section EndToEnd
 
-open Semantics.Causation
-open Semantics.Causation.ProductionDependence (causationType)
+open Causation
+open Causation.ProductionDependence (causationType)
 
 /-! End-to-end pipeline theorems linking V2 BoolSEM models to RSA S1
     predictions. `causationType` (from `ProductionDependence.lean`)
     takes plain Bools, so its inputs are computed with the SEM
     predicates and passed through. -/
 
-open Semantics.Causation Semantics.Causation.SEM
-open Semantics.Causation.BoolSEM (causallySufficient causallyNecessary hasDirectLaw)
+open Causation Causation.SEM
+open Causation.BoolSEM (causallySufficient causallyNecessary hasDirectLaw)
 
 private lemma bgDepth_lt_solo :
     ∀ {u v : BGVar}, u ∈ soloGraph.parents v → bgDepth u < bgDepth v := by

--- a/Linglib/Studies/Benz2025.lean
+++ b/Linglib/Studies/Benz2025.lean
@@ -554,7 +554,7 @@ means event can be concurrent with the change.
 The End Theme Postulate links the Theme of the complex event to the
 end state: End(e₁, s) & Theme(e₁, x) |= Theme(s, x).
 
-See also `Semantics.Causation.Resultatives` for the complementary analysis
+See also `Causation.Resultatives` for the complementary analysis
 via causal dynamics, structural sufficiency, and CC-selection. -/
 
 -- ────────────────────────────────────────────────────

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -48,10 +48,10 @@ import Linglib.Semantics.Causation.Interpretation
 namespace CaoWhiteLassiter2025
 
 open Core (WorldTimeIndex)
-open Semantics.Causation (BoolSEM CausalGraph Valuation Mechanism)
-open Semantics.Causation.Mechanism (const)
-open Semantics.Causation.SEM (probabilisticSuf probabilisticSuf_of_deterministic)
-open Semantics.Causation.CoerciveImplication (ActionType)
+open Causation (BoolSEM CausalGraph Valuation Mechanism)
+open Causation.Mechanism (const)
+open Causation.SEM (probabilisticSuf probabilisticSuf_of_deterministic)
+open Causation.CoerciveImplication (ActionType)
 open Features (Causative)
 open Features
 
@@ -84,10 +84,10 @@ that recovers this special case from the canonical PMF form. -/
     `IsDeterministic`. -/
 noncomputable def deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
-    [Semantics.Causation.SEM.IsDeterministic M]
+    [Causation.SEM.IsDeterministic M]
     (background : Valuation (fun _ : V => Bool))
     (cause effect : V) : ENNReal :=
-  if Semantics.Causation.BoolSEM.causallySufficient M background cause effect then 1 else 0
+  if Causation.BoolSEM.causallySufficient M background cause effect then 1 else 0
 
 /-- **Grounding theorem**: under `IsDeterministic`, the canonical PMF-valued
     `probabilisticSuf` collapses to the deterministic {0,1} indicator.
@@ -95,13 +95,13 @@ noncomputable def deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     a parallel definition. -/
 theorem probabilisticSuf_eq_deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
-    [Semantics.Causation.SEM.IsDeterministic M]
+    [Causation.SEM.IsDeterministic M]
     (bg : Valuation (fun _ : V => Bool)) (c e : V)
     (hc : bg.get c = none) :
     probabilisticSuf M bg c true e true = deterministicSuf M bg c e := by
   unfold deterministicSuf
   rw [probabilisticSuf_of_deterministic]
-  rw [Semantics.Causation.SEM.developDet_intervene_eq_developDet_extend M bg c true hc]
+  rw [Causation.SEM.developDet_intervene_eq_developDet_extend M bg c true hc]
   congr 1
 
 /-! ## ALT → ActionType Bridge

--- a/Linglib/Studies/Comrie1989.lean
+++ b/Linglib/Studies/Comrie1989.lean
@@ -33,7 +33,7 @@ grammatical domains:
   The AH positions (Subject > DO > IO > OBL) mirror the GR hierarchy
   that governs causee demotion.
 - **Causatives** (Ch 8): Morphological complexity correlates with semantic
-  directness (`Semantics.Causation.Morphological`); causee
+  directness (`Causation.Morphological`); causee
   marking follows the GR hierarchy (`CauseeSlot`).
 
 The shared infrastructure in `Features.Prominence` ensures the animacy
@@ -330,7 +330,7 @@ theorem dyirbal_syntacticErg_converges :
 -- § 4: Causative Hierarchies
 -- ============================================================================
 
-open Semantics.Causation.Morphological
+open Causation.Morphological
     (CausativeComplexity CausativeConstruction Mediation comrie_monotone
      CauseeSlot causeeDemotion)
 
@@ -394,7 +394,7 @@ accessibility (Ch 7):
 
     Subject > Direct Object > Indirect Object > Oblique
 
-`CauseeSlot` (in `Semantics.Causation.Morphological`) and
+`CauseeSlot` (in `Causation.Morphological`) and
 `AHPosition` (in `Typology.RelativeClause.Basic`) encode overlapping
 portions of this hierarchy independently. The bridge function
 `causeeToAH` maps causee slots to their corresponding AH positions,

--- a/Linglib/Studies/Creissels2025.lean
+++ b/Linglib/Studies/Creissels2025.lean
@@ -33,7 +33,7 @@ This study file bridges [creissels-2025]'s framework (formalized in
 namespace Creissels2025
 
 open Syntax.ArgumentStructure.Alternation
-open Semantics.Causation.Morphological
+open Causation.Morphological
   (IntransitivizationType CausativeComplexity CausativeConstruction
    CausativizabilityData)
 open Typology (VoiceSystemProfile VoiceSystemSymmetry VoiceEntry PivotTarget)

--- a/Linglib/Studies/Cruse1973.lean
+++ b/Linglib/Studies/Cruse1973.lean
@@ -44,7 +44,7 @@ and is marginal for others.
 namespace Cruse1973
 
 open Semantics.ArgumentStructure
-open Semantics.Causation.CoerciveImplication
+open Causation.CoerciveImplication
 open Features (Causative)
 open Features
 open Semantics.Lexical

--- a/Linglib/Studies/Everdell2024.lean
+++ b/Linglib/Studies/Everdell2024.lean
@@ -721,7 +721,7 @@ theorem refined_agrees_on_nonexceptional (v : OdamVerb)
     predicts the exceptional transitive class.
 
     The hierarchy data and implicational validation are formalized in
-    `Semantics.Causation.Morphological` (§11). -/
+    `Causation.Morphological` (§11). -/
 
 -- ════════════════════════════════════════════════════
 -- § 16. Bridge to Pylkkänen 2008 (High/Low Typology)

--- a/Linglib/Studies/Glass2023.lean
+++ b/Linglib/Studies/Glass2023.lean
@@ -38,7 +38,7 @@ needed.
 
 namespace Glass2023
 
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
+open Causation Causation.Mechanism Causation.SEM
 
 /-! ## Local vs Global Sufficiency / Necessity (defs 8–11)
 
@@ -119,7 +119,7 @@ implicature. -/
 abbrev causeSemGlass {V : Type*} [Fintype V] [DecidableEq V]
     (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
     (bg : Valuation (fun _ : V => Bool)) (cause effect : V) : Prop :=
-  Semantics.Causation.BoolSEM.causallySufficient M bg cause effect
+  Causation.BoolSEM.causallySufficient M bg cause effect
 
 /-- Glass's *cause* is truth-conditionally identical to N&L's *make*
     (`causallySufficient`). The difference is pragmatic. -/
@@ -127,7 +127,7 @@ theorem glass_cause_is_causallySufficient {V : Type*} [Fintype V] [DecidableEq V
     (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
     (bg : Valuation (fun _ : V => Bool)) (cause effect : V) :
     causeSemGlass M bg cause effect ↔
-      Semantics.Causation.BoolSEM.causallySufficient M bg cause effect := Iff.rfl
+      Causation.BoolSEM.causallySufficient M bg cause effect := Iff.rfl
 
 /-- **Glass vs N&L diverge on the Bus scenario**: "Ava's training caused
     Lia to take the bus" is true on Glass's sufficiency-based *cause* but

--- a/Linglib/Studies/GoldbergJackendoff2004.lean
+++ b/Linglib/Studies/GoldbergJackendoff2004.lean
@@ -166,7 +166,7 @@ theorem bounded_entries_telic :
       (λ e => (resultativeAspect e.rpBoundedness).telicity == .telic) = true := by
   decide
 
-/-! ### Theorems migrated from `Semantics.Causation.Resultatives`
+/-! ### Theorems migrated from `Causation.Resultatives`
 
 These theorems quantify over `allEntries` (paper-specific data) and
 therefore belong with the paper, not in the Theory layer. -/

--- a/Linglib/Studies/GrusdtLassiterFranke2022.lean
+++ b/Linglib/Studies/GrusdtLassiterFranke2022.lean
@@ -68,11 +68,11 @@ set_option autoImplicit false
 
 namespace GrusdtLassiterFranke2022
 
-open Semantics.Causation
-open Semantics.Causation.BayesNet
+open Causation
+open Causation.BayesNet
 open Semantics.Probabilistic.ConditionalAssertability
-open Semantics.Causation.Sufficiency
-open Semantics.Causation.Necessity
+open Causation.Sufficiency
+open Causation.Necessity
 
 
 -- ============================================================================

--- a/Linglib/Studies/HardingGerstenbergIcard2025.lean
+++ b/Linglib/Studies/HardingGerstenbergIcard2025.lean
@@ -64,7 +64,7 @@ predictions:
 
 namespace HardingGerstenbergIcard2025
 
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
+open Causation Causation.Mechanism Causation.SEM
 open BoolSEM (manipulates)
 
 /-! ## §3 Substrate: ExplanationGame -/

--- a/Linglib/Studies/HartshorneEtAl2016.lean
+++ b/Linglib/Studies/HartshorneEtAl2016.lean
@@ -287,8 +287,8 @@ theorem class_type_alignment :
 -- § Bridge: SemanticType ↔ CausalSource
 -- ════════════════════════════════════════════════════
 
-open Semantics.Causation.Psych (CausalSource)
-open Semantics.Causation.PsychLink (PsychCausalLink eventiveLink maintenanceLink
+open Causation.Psych (CausalSource)
+open Causation.PsychLink (PsychCausalLink eventiveLink maintenanceLink
   CausalSource.toLink)
 
 /-- Map Hartshorne et al.'s semantic type to Kim's CausalSource.

--- a/Linglib/Studies/Karttunen1971.lean
+++ b/Linglib/Studies/Karttunen1971.lean
@@ -50,12 +50,12 @@ Key differences from the modern analysis:
 
 namespace Karttunen1971
 
-open Semantics.Causation.Implicative
+open Causation.Implicative
 open Features (Causative)
 open English.Predicates.Verbal
 open English.Predicates.Copular (beAble)
 open Semantics.Lexical
-open Semantics.Causation
+open Causation
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Karttunen's Four-Cell Classification (§§9–11)

--- a/Linglib/Studies/Kim2024.lean
+++ b/Linglib/Studies/Kim2024.lean
@@ -43,7 +43,7 @@ verb's event provides CON(e), just like an attitude verb's event does.
 
 namespace Kim2024
 
-open Semantics.Causation.Psych
+open Causation.Psych
 open Semantics.Modality.EventRelativity
 open Semantics.Modality (ModalFlavor)
 

--- a/Linglib/Studies/Kim2024_UPH.lean
+++ b/Linglib/Studies/Kim2024_UPH.lean
@@ -52,8 +52,8 @@ verified per-verb (§ 2), and then used to DERIVE consequences (§§ 3–7).
 namespace Kim2024_UPH
 
 open Minimalist
-open Semantics.Causation.Psych
-open Semantics.Causation.PsychLink
+open Causation.Psych
+open Causation.PsychLink
 open English.Predicates.Verbal
 open Pesetsky1995.PsychVerbs
 open SolstadBott2022
@@ -333,7 +333,7 @@ theorem external_implies_extensional :
     These theorems verify that each verb's derived stimulus type
     predicts the correct PP frame and Cause-cooccurrence behavior. -/
 
-open Semantics.Causation.Psych (StimulusType CausalSource.toStimulusType)
+open Causation.Psych (StimulusType CausalSource.toStimulusType)
 
 /-- Derive a verb's stimulus type from its causal source. -/
 def derivedStimulusType (v : VerbEntry) : Option StimulusType :=

--- a/Linglib/Studies/KonukEtAl2026.lean
+++ b/Linglib/Studies/KonukEtAl2026.lean
@@ -41,8 +41,8 @@ with the explicit vertex list.
 
 namespace KonukEtAl2026
 
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
-open Semantics.Causation.Strength (nsm samplingPropensity)
+open Causation Causation.Mechanism Causation.SEM
+open Causation.Strength (nsm samplingPropensity)
 
 -- ════════════════════════════════════════════════════
 -- § Vertex enum (combines both experiments)

--- a/Linglib/Studies/KoontzGarboden2009.lean
+++ b/Linglib/Studies/KoontzGarboden2009.lean
@@ -152,7 +152,7 @@ inchoatives have CAUSE.
 namespace KoontzGarboden2009
 
 open Spanish.Predicates
-open Semantics.Causation.Morphological
+open Causation.Morphological
 open Semantics.Lexical.EventStructure
 open KoontzGarboden2009.Monotonicity
 open Minimalist (VerbHead)

--- a/Linglib/Studies/Krejci2012.lean
+++ b/Linglib/Studies/Krejci2012.lean
@@ -49,7 +49,7 @@ namespace Krejci2012
 
 open Semantics.Lexical
 open Root.FeatureSignature
-open Semantics.Causation.Morphological
+open Causation.Morphological
 open Semantics.Lexical.EventStructure
 open Semantics.ArgumentStructure.ArgDerivation
 

--- a/Linglib/Studies/Levin2026.lean
+++ b/Linglib/Studies/Levin2026.lean
@@ -49,7 +49,7 @@ isolation.
 
 This study connects four existing layers:
 - `Core.Lexical.LevinClass`: verb classes lack causative alternation (§12, §18)
-- `Semantics.Causation.Resultatives`: construction adds CAUSE;
+- `Causation.Resultatives`: construction adds CAUSE;
   PCC maps onto the independent-source/tightness infrastructure
 - `English.Predicates`: verb and adjective entries
 - `Data.Examples.Levin1993`: alternation judgment rows
@@ -69,7 +69,7 @@ open LevinClass (pushPull hit wipe)
 open English.Predicates.Verbal (push pull kick)
 open English.Predicates.Adjectival (open_ closed_ shut free_ loose flat
   AdjectivalPredicateEntry)
-open Semantics.Causation.Resultatives (resultativeCausativeBuilder)
+open Causation.Resultatives (resultativeCausativeBuilder)
 open Features.ChangeOfState (CoSType)
 open ConstructionGrammar (resultative composedMeaning predictedAlternationInConstruction
   ArgStructureConstruction)
@@ -495,8 +495,8 @@ a lexically noncausative.
 Per-scenario causal models for these contrasts live below in §7
 (`HammerFlat`, `KickIntoField`, `FreezeSolid`, etc.) on the `BoolSEM`
 substrate, using `BoolSEM.causallySufficient` from
-`Semantics.Causation.SEM.Counterfactual` and `CCSelection.completesForEffect`
-from `Semantics.Causation.CCSelection`. -/
+`Causation.SEM.Counterfactual` and `CCSelection.completesForEffect`
+from `Causation.CCSelection`. -/
 
 /-- *Freeze* independently shows the causative alternation;
     *push* does not. This confirms the classification: *freeze solid*
@@ -963,7 +963,7 @@ theorem mandarin_tui_kai_is_cognate :
 -- ════════════════════════════════════════════════════
 
 open English.Predicates.Verbal (make cause)
-open Semantics.Causation.Resultatives (resultativeCausativeBuilder)
+open Causation.Resultatives (resultativeCausativeBuilder)
 
 /-- Resultative CAUSE matches the Fragment entry for "make". -/
 theorem resultative_cause_matches_make_verb :
@@ -990,8 +990,8 @@ Per-scenario inductive `V` enums give `Fintype + DecidableEq + Repr`
 so the `developDetOn` computations close by `decide`. -/
 
 section Scenarios
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
-open Semantics.Causation.CCSelection (completesForEffect completesForEffect_of_developDetOn)
+open Causation Causation.Mechanism Causation.SEM
+open Causation.CCSelection (completesForEffect completesForEffect_of_developDetOn)
 
 namespace HammerFlat
 

--- a/Linglib/Studies/Lewis1973.lean
+++ b/Linglib/Studies/Lewis1973.lean
@@ -53,7 +53,7 @@ strictly stronger. Bridge theorems comparing the two belong in
 namespace Lewis1973
 
 open Core (WorldTimeIndex)
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
+open Causation Causation.Mechanism Causation.SEM
 
 -- ════════════════════════════════════════════════════
 -- § 1. Lewis's Counterfactual Predicates (V2)

--- a/Linglib/Studies/MartinRoseNichols2025.lean
+++ b/Linglib/Studies/MartinRoseNichols2025.lean
@@ -30,7 +30,7 @@ four binary properties:
 namespace MartinRoseNichols2025.ThickThin
 
 open Semantics.Lexical
-open Semantics.Causation.ProductionDependence
+open Causation.ProductionDependence
 open English.Predicates.Verbal (VerbEntry)
 namespace V
   -- Re-export Fragment verb entries under a short alias to avoid name clashes
@@ -265,7 +265,7 @@ namespace MartinRoseNichols2025.Compare
 
 open Minimalist
 open Semantics.Lexical.EventStructure
-open Semantics.Causation.ProductionDependence
+open Causation.ProductionDependence
 open MartinRoseNichols2025.ThickThin
 
 -- § 1: Template ↔ Syntactic Structure

--- a/Linglib/Studies/Nadathur2023.lean
+++ b/Linglib/Studies/Nadathur2023.lean
@@ -8,7 +8,7 @@ The Dreyfus scenario of [nadathur-2023-implicatives] (§6.1.1, Figure 3;
 introduced in [nadathur-2019] ch. 3 as "the modified Dreyfus scenario",
 adapted from [baglini-francez-2016]): an eight-vertex structural causal
 model discriminating where two-way *dare* is felicitous. The felicity
-theorems are stated through `Semantics.Causation.Implicative.manageSem` /
+theorems are stated through `Causation.Implicative.manageSem` /
 `failSem` — the substrate formalization of this paper's prerequisite
 account (Proposal 32) — so they instantiate the same sufficiency predicate
 the rest of the codebase attributes to implicative verbs.
@@ -42,8 +42,8 @@ fn. 21); `manageSem` currently takes a single prerequisite vertex.
 
 namespace Nadathur2023
 
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
-open Semantics.Causation.Implicative (manageSem failSem ImplicativeClass Prerequisite)
+open Causation Causation.Mechanism Causation.SEM
+open Causation.Implicative (manageSem failSem ImplicativeClass Prerequisite)
 
 /-- Dreyfus scenario vertices ([nadathur-2023-implicatives] §6.1.1, Figure 3):
     INT (Dreyfus intends to spy), NRV (he has the nerve), LST (a German is
@@ -236,7 +236,7 @@ with `Nadathur2023.no_msg_without_nerve`. -/
 
 namespace Karttunen1971
 
-open Semantics.Causation.Implicative
+open Causation.Implicative
 
 /-- Convert `KarttunenClass` to `ImplicativeClass`
     ([nadathur-2023-implicatives]). `aspectGoverned` is always false

--- a/Linglib/Studies/NadathurLauer2020.lean
+++ b/Linglib/Studies/NadathurLauer2020.lean
@@ -66,9 +66,9 @@ that file's `Overdetermination` namespace is *symmetric* overdetermination
 
 namespace NadathurLauer2020
 
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
-open Semantics.Causation.Sufficiency (makeSem)
-open Semantics.Causation.Necessity (causeSem)
+open Causation Causation.Mechanism Causation.SEM
+open Causation.Sufficiency (makeSem)
+open Causation.Necessity (causeSem)
 
 -- ════════════════════════════════════════════════════
 -- § §3.6.1 Fire scenario (necessary but insufficient)

--- a/Linglib/Studies/Pesetsky1995.lean
+++ b/Linglib/Studies/Pesetsky1995.lean
@@ -188,7 +188,7 @@ end Pesetsky1995.PsychVerbs
 namespace Pesetsky1995
 
 open Minimalist
-open Semantics.Causation.Psych
+open Causation.Psych
 open Pesetsky1995.PsychVerbs
 open English.Predicates.Verbal
 

--- a/Linglib/Studies/SlomanBarbeyHotaling2009.lean
+++ b/Linglib/Studies/SlomanBarbeyHotaling2009.lean
@@ -57,7 +57,7 @@ hubs. Structural predicates avoid the `develop` noncomputable cascade.
 
 namespace SlomanBarbeyHotaling2009
 
-open Semantics.Causation (BoolSEM CausalGraph)
+open Causation (BoolSEM CausalGraph)
 
 variable {V : Type*}
 

--- a/Linglib/Studies/Song1996.lean
+++ b/Linglib/Studies/Song1996.lean
@@ -391,7 +391,7 @@ theorem morphological_dominates :
 -- Bridge: Song's Typology ↔ Comrie's Complexity Scale
 -- ============================================================================
 
-open Semantics.Causation.Morphological (CausativeComplexity)
+open Causation.Morphological (CausativeComplexity)
 
 /-- Song's construction types map to [comrie-1989]'s complexity scale.
 

--- a/Linglib/Studies/Tay2024.lean
+++ b/Linglib/Studies/Tay2024.lean
@@ -37,7 +37,7 @@ arguments but **none** of V1's.  This predicts:
 ## Architecture
 
 Connects:
-- `Semantics.Causation.Resultatives`: causal dynamics, CC-selection,
+- `Causation.Resultatives`: causal dynamics, CC-selection,
   tightness, cross-linguistic parameters (`ResultativeRealization`,
   `ResultOrientation`, `PhaseComplement`)
 - `Morphology.Core.WordStructure`: `MorphWord.compound` for V-V
@@ -50,7 +50,7 @@ namespace Tay2024
 
 open Core (WorldTimeIndex)
 
-open Semantics.Causation.Resultatives
+open Causation.Resultatives
 open Morphology.WordStructure
 open Features.ChangeOfState (CoSType priorStatePresup)
 open Mandarin.Resultatives
@@ -345,10 +345,10 @@ Each V-V compound maps to a 2-vertex BoolSEM where V1 directly causes V2.
 Direct causation = single edge, no intermediate with an independent
 energy source. This is the same tightness constraint identified for
 English resultatives by [levin-2019] — formalized via the canonical
-`completesForEffect` predicate from `Semantics.Causation.CCSelection`. -/
+`completesForEffect` predicate from `Causation.CCSelection`. -/
 
-open Semantics.Causation Semantics.Causation.Mechanism Semantics.Causation.SEM
-open Semantics.Causation.CCSelection (completesForEffect completesForEffect_of_developDetOn)
+open Causation Causation.Mechanism Causation.SEM
+open Causation.CCSelection (completesForEffect completesForEffect_of_developDetOn)
 
 namespace Dasi
 


### PR DESCRIPTION
`Semantics.Causation.*` → `Causation.*` (MeasureTheory-style domain namespace): the family's names (`Valuation`, `Mechanism`, `SEM`) are generic, so they stay namespaced rather than going bare-root (root `Valuation` would collide with mathlib's ring-theoretic one); consumers now `open Causation` once for the whole API. Pure rename — 70 files, 192+/192−, module paths and imports unchanged.

Depends on #360 (stacked branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)