### PR TITLE
feat(Core/Algebra): GL/CK duality for Δ^ρ; MCB 1.2.10 grading

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1869,6 +1869,7 @@ import Linglib.Core.Algebra.RootedTree.Coproduct.Defs
 import Linglib.Core.Algebra.RootedTree.Coproduct.Pruning
 import Linglib.Core.Algebra.RootedTree.Coproduct.Trace
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
+import Linglib.Core.Algebra.RootedTree.Coproduct.PruningDuality
 import Linglib.Core.Algebra.RootedTree.Coproduct.TraceNonplanar
 import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionNonplanar
 import Linglib.Core.Algebra.RootedTree.HopfAlgebraNonplanar
@@ -1887,6 +1888,7 @@ import Linglib.Core.Algebra.RootedTree.PreLie.Path
 import Linglib.Core.Algebra.RootedTree.PreLie.InsertionNodeDecomp
 import Linglib.Core.Algebra.RootedTree.BMinus
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonMonoid
+import Linglib.Core.Algebra.RootedTree.GrossmanLarsonSplit
 import Linglib.Core.LinearAlgebra.SymmetricAlgebra.Derivation
 import Linglib.Core.LinearAlgebra.SymmetricPower.Lift
 import Linglib.Core.LinearAlgebra.SymmetricPower.ToSymmetricAlgebra

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionNonplanar.lean
@@ -55,7 +55,7 @@ of MCB's `Δ^d = (id ⊗ Π_{d,p}) ∘ Δ^ρ` (since Π_{d,p} is identity here).
 Δ^d does **not** have a separate Bialgebra structure in this file. By
 the equivalence theorem, consumers wanting a Bialgebra should compose
 through `embedInlAlgHom` and use the Δ^ρ structure
-(`PruningNonplanar.instBialgebraRho`). MCB's Lemma 1.2.12 (Δ^d weak
+(`PruningDuality.instBialgebraRho`). MCB's Lemma 1.2.12 (Δ^d weak
 coassoc with distance-≤-1 multiplicity discrepancy) is specific to the
 binary `Π_{d,p}` step which is identity in our setting; in our n-ary
 substrate Δ^d ≡ Δ^ρ (modulo the embedding) has strict coassoc.

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -1,0 +1,696 @@
+import Linglib.Core.Algebra.RootedTree.BMinus
+import Linglib.Core.Algebra.RootedTree.GrossmanLarsonSplit
+import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridgePairing
+
+set_option autoImplicit false
+
+/-!
+# GL/CK duality for Δ^ρ and coassociativity of the pruning coproduct
+[foissy-2002] [oudom-guin-2008] [marcolli-chomsky-berwick-2025]
+
+The duality theorem `pairing_gl_eq_pairing_coproduct_Rho`:
+
+  `⟨x ⋆ y, z⟩ = pairing₂ (y ⊗ x) (Δ^ρ z)`
+
+pairing the Grossman-Larson product against the pruning coproduct
+through the symmetry-weighted pairing, and its consequence: Δ^ρ
+coassociativity (`comulRhoN_coassoc`) and the
+`Bialgebra R (ConnesKreimer R (Nonplanar α))` instance
+(`instBialgebraRho`), both transported from `GrossmanLarson.mul_assoc`.
+
+## Orientation
+
+The tensor slots are **crossed**: linglib's GL product `x ⋆ y` grafts
+`y`'s trees into the host `x` (so `x` carries the root structure, cf.
+`bMinusLin_gl_mul` placing `B⁻` on `x`), while `Δ^ρ` puts the pruned
+crown in the first tensor slot and the root trunk in the second
+(`comulTreeN`). Hence `y` pairs against crowns and `x` against trunks.
+An earlier sorry-fenced statement of this theorem used the uncrossed
+orientation `pairing₂ (x ⊗ y) (Δ^ρ z)`, which is **false** (e.g.
+`x = {•_p}`, `y = {•_q}`, `z` the 2-chain `p–q`: LHS `1`, RHS `0`).
+Both orientations were checked against the exhaustive planar simulation
+battery in `scratch/validate_duality.lean` (V1): the crossed form holds
+on all weight-matched triples of forests of weight ≤ 3 and on targeted
+weight-4 duplicate-tree traps; the uncrossed form fails on 72 of them.
+
+This file lives downstream of `BMinus.lean` (whose `B⁻` calculus drives
+the single-tree induction step), so the duality theorem and its
+consumers were moved here from `Coproduct/PruningNonplanar.lean`.
+
+## Proof architecture (weight induction on `z`)
+
+Reduce to basis forests `z = of' C` by linearity; strong induction on
+total weight of `C`:
+
+* `C = 0`: both sides are counits — `counit_gl_mul`.
+* `C = {T}`, `T = B⁺_a W`: `⟨x ⋆ y, B⁺_a W⟩` unfolds via
+  `pairing_apply_bPlus_gl_mul` (B⁺/B⁻ adjoint + the OG cocycle
+  `bMinusLin_gl_mul`); `pairing₂ (y ⊗ x) (Δ^ρ B⁺_a W)` unfolds via the
+  Hochschild cocycle `comulTreeN_node_cocycle` + the adjoint moved
+  through the second tensor slot. The two recurrences match
+  summand-wise; the `T ⊗ 1` term is the adjoint identity itself.
+* `C = T ::ₘ C'` (`C' ≠ 0`): split `of' C = ofTree T * of' C'`; apply
+  `pairing_product_of'_mul_of'` (LHS) and the tensor-square of
+  `pairing_of'_mul` (RHS, via `Δ^ρ` multiplicativity); the two
+  `antidiagonal`-indexed sums match termwise under the induction
+  hypothesis at `ofTree T` and `of' C'`.
+-/
+
+namespace RootedTree
+
+namespace ConnesKreimer
+
+open scoped TensorProduct
+
+variable {R : Type*} [CommSemiring R] {α : Type*}
+
+/-! ### Adjoint through the second tensor slot -/
+
+/-- `B⁺_a` on the second tensor factor dualizes to `B⁻_a` on the second
+    pairing slot: `pairing₂ (u ⊗ v) ((id ⊗ B⁺_a) V) =
+    pairing₂ (u ⊗ B⁻_a v) V`. `TensorProduct.induction_on` +
+    `bMinusLin_pairing_adjoint`. -/
+private lemma pairing₂_lTensor_bPlusLin (a : α)
+    (u v : ConnesKreimer R (Nonplanar α))
+    (V : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
+    pairing₂ (R := R) (u ⊗ₜ[R] v)
+        ((LinearMap.lTensor _ (bPlusLin (R := R) a)) V) =
+      pairing₂ (R := R) (u ⊗ₜ[R] (GrossmanLarson.bMinusLin (R := R) a v)) V := by
+  induction V using TensorProduct.induction_on with
+  | zero => simp
+  | tmul p q =>
+    rw [LinearMap.lTensor_tmul, pairing₂_tmul_tmul, pairing₂_tmul_tmul,
+        ← GrossmanLarson.bMinusLin_pairing_adjoint]
+  | add V₁ V₂ ih₁ ih₂ => simp only [map_add, ih₁, ih₂]
+
+/-! ### Pairing against the unit -/
+
+/-- `⟨w, 1⟩ = ε(w)`: pairing against the empty forest extracts the
+    counit (the coefficient of the empty forest). -/
+private lemma pairing_apply_one (w : ConnesKreimer R (Nonplanar α)) :
+    GrossmanLarson.pairing (R := R) w (1 : ConnesKreimer R (Nonplanar α)) =
+      (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) w := by
+  refine Finsupp.induction_linear w ?_ ?_ ?_
+  · show GrossmanLarson.pairing (R := R)
+        (0 : ConnesKreimer R (Nonplanar α)) 1 =
+      (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
+        (0 : ConnesKreimer R (Nonplanar α))
+    rw [GrossmanLarson.pairing_zero_left, map_zero]
+  · intro a b iha ihb
+    let a' : ConnesKreimer R (Nonplanar α) := a
+    let b' : ConnesKreimer R (Nonplanar α) := b
+    show GrossmanLarson.pairing (R := R) (a' + b') 1 =
+      (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) (a' + b')
+    rw [map_add, LinearMap.add_apply, map_add]
+    exact congrArg₂ (· + ·) iha ihb
+  · intro F r
+    let w' : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+    have hsingle : w' = r • (ConnesKreimer.of' (R := R) F) := by
+      show (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
+          r • (Finsupp.single F 1 : ConnesKreimer R (Nonplanar α))
+      exact (Finsupp.smul_single_one F r).symm
+    show GrossmanLarson.pairing (R := R) w' 1 =
+      (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) w'
+    rw [hsingle, map_smul, LinearMap.smul_apply, map_smul, smul_eq_mul,
+        smul_eq_mul]
+    congr 1
+    show GrossmanLarson.pairing (R := R) (ConnesKreimer.of' F)
+        (ConnesKreimer.of' (0 : Forest (Nonplanar α))) = _
+    rw [GrossmanLarson.pairing_of'_of', ConnesKreimer.counit_of']
+    by_cases h : F = (0 : Forest (Nonplanar α))
+    · subst h
+      rw [if_pos rfl, if_pos Multiset.card_zero]
+      show ((Nonplanar.forestAutCard (0 : Forest (Nonplanar α)) : ℕ) : R) = 1
+      rw [Nonplanar.forestAutCard_zero, Nat.cast_one]
+    · rw [if_neg h, if_neg (by simpa [Multiset.card_eq_zero] using h)]
+
+/-! ### Tensor-square of the pairing product rule -/
+
+/-- The pairing product rule through both slots of `pairing₂`: for basis
+    second components, multiplying the second argument decomposes over
+    independent antidiagonal splits of the two basis forests. Tensor
+    counterpart of `GrossmanLarson.pairing_of'_mul`, aligned with the
+    index order of `GrossmanLarson.pairing_product_of'_mul_of'`. -/
+private lemma pairing₂_of'_of'_mul (A B : Forest (Nonplanar α))
+    (U V : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
+    pairing₂ (R := R) (ConnesKreimer.of' B ⊗ₜ[R] ConnesKreimer.of' A) (U * V) =
+      ((Multiset.antidiagonal A ×ˢ Multiset.antidiagonal B).map (fun pq =>
+        pairing₂ (R := R)
+            (ConnesKreimer.of' pq.2.1 ⊗ₜ[R] ConnesKreimer.of' pq.1.1) U *
+        pairing₂ (R := R)
+            (ConnesKreimer.of' pq.2.2 ⊗ₜ[R] ConnesKreimer.of' pq.1.2) V)).sum := by
+  induction U using TensorProduct.induction_on with
+  | zero =>
+    rw [zero_mul, map_zero]
+    symm
+    refine Multiset.sum_eq_zero fun r hr => ?_
+    obtain ⟨pq, _, rfl⟩ := Multiset.mem_map.mp hr
+    rw [map_zero, zero_mul]
+  | add U₁ U₂ ih₁ ih₂ =>
+    rw [add_mul, map_add, ih₁, ih₂, ← Multiset.sum_map_add]
+    refine congrArg Multiset.sum (Multiset.map_congr rfl fun pq _ => ?_)
+    rw [map_add, add_mul]
+  | tmul u₁ u₂ =>
+    induction V using TensorProduct.induction_on with
+    | zero =>
+      rw [mul_zero, map_zero]
+      symm
+      refine Multiset.sum_eq_zero fun r hr => ?_
+      obtain ⟨pq, _, rfl⟩ := Multiset.mem_map.mp hr
+      rw [map_zero, mul_zero]
+    | add V₁ V₂ ih₁ ih₂ =>
+      rw [mul_add, map_add, ih₁, ih₂, ← Multiset.sum_map_add]
+      refine congrArg Multiset.sum (Multiset.map_congr rfl fun pq _ => ?_)
+      rw [map_add, mul_add]
+    | tmul v₁ v₂ =>
+      rw [Algebra.TensorProduct.tmul_mul_tmul, pairing₂_tmul_tmul,
+          GrossmanLarson.pairing_of'_mul B u₁ v₁,
+          GrossmanLarson.pairing_of'_mul A u₂ v₂]
+      rw [show ((Multiset.antidiagonal A ×ˢ Multiset.antidiagonal B).map (fun pq =>
+            pairing₂ (R := R)
+                (ConnesKreimer.of' pq.2.1 ⊗ₜ[R] ConnesKreimer.of' pq.1.1)
+                (u₁ ⊗ₜ[R] u₂) *
+            pairing₂ (R := R)
+                (ConnesKreimer.of' pq.2.2 ⊗ₜ[R] ConnesKreimer.of' pq.1.2)
+                (v₁ ⊗ₜ[R] v₂))) =
+          ((Multiset.antidiagonal A ×ˢ Multiset.antidiagonal B).map (fun pq =>
+            (GrossmanLarson.pairing (R := R)
+                (ConnesKreimer.of' pq.1.1) u₂ *
+             GrossmanLarson.pairing (R := R)
+                (ConnesKreimer.of' pq.1.2) v₂) *
+            (GrossmanLarson.pairing (R := R)
+                (ConnesKreimer.of' pq.2.1) u₁ *
+             GrossmanLarson.pairing (R := R)
+                (ConnesKreimer.of' pq.2.2) v₁))) from
+        Multiset.map_congr rfl fun pq _ => by
+          rw [pairing₂_tmul_tmul, pairing₂_tmul_tmul]; ring]
+      rw [GrossmanLarson.sum_map_product_mul (Multiset.antidiagonal A)
+          (Multiset.antidiagonal B)
+          (fun pa => GrossmanLarson.pairing (R := R)
+              (ConnesKreimer.of' pa.1) u₂ *
+            GrossmanLarson.pairing (R := R) (ConnesKreimer.of' pa.2) v₂)
+          (fun pb => GrossmanLarson.pairing (R := R)
+              (ConnesKreimer.of' pb.1) u₁ *
+            GrossmanLarson.pairing (R := R) (ConnesKreimer.of' pb.2) v₁)]
+      ring
+
+/-! ### CK-typed linearity of the GL product in its first slot
+
+`GrossmanLarson.product` is a `LinearMap` at the `GrossmanLarson` carrier;
+these restate first-slot linearity with all terms ascribed at
+`ConnesKreimer` (definitionally equal carriers, syntactically different
+instances), so they can be used as rewrite rules in CK-typed goals. -/
+
+private lemma pairing_product_zero_left (y w : ConnesKreimer R (Nonplanar α)) :
+    GrossmanLarson.pairing (R := R)
+      (GrossmanLarson.product (0 : ConnesKreimer R (Nonplanar α)) y) w = 0 := by
+  have h1 : (GrossmanLarson.product (R := R) (α := α)
+      (0 : ConnesKreimer R (Nonplanar α)) y :
+      ConnesKreimer R (Nonplanar α)) = 0 :=
+    LinearMap.map_zero₂ (GrossmanLarson.product (R := R) (α := α)) y
+  exact (congrArg (fun u => GrossmanLarson.pairing (R := R) u w) h1).trans
+    (GrossmanLarson.pairing_zero_left w)
+
+private lemma pairing_product_add_left (a b y w : ConnesKreimer R (Nonplanar α)) :
+    GrossmanLarson.pairing (R := R) (GrossmanLarson.product (a + b) y) w =
+      GrossmanLarson.pairing (R := R) (GrossmanLarson.product a y) w +
+      GrossmanLarson.pairing (R := R) (GrossmanLarson.product b y) w := by
+  have h1 : (GrossmanLarson.product (R := R) (α := α) (a + b) y :
+      ConnesKreimer R (Nonplanar α)) =
+      ((GrossmanLarson.product a y : ConnesKreimer R (Nonplanar α)) +
+       (GrossmanLarson.product b y : ConnesKreimer R (Nonplanar α)) :
+        ConnesKreimer R (Nonplanar α)) :=
+    LinearMap.map_add₂ (GrossmanLarson.product (R := R) (α := α)) a b y
+  exact (congrArg (fun u => GrossmanLarson.pairing (R := R) u w) h1).trans
+    (LinearMap.congr_fun
+      (map_add (GrossmanLarson.pairing (R := R) (α := α)) _ _) w)
+
+private lemma pairing_product_smul_left (r : R)
+    (a y w : ConnesKreimer R (Nonplanar α)) :
+    GrossmanLarson.pairing (R := R) (GrossmanLarson.product (r • a) y) w =
+      r • GrossmanLarson.pairing (R := R) (GrossmanLarson.product a y) w := by
+  have h1 : (GrossmanLarson.product (R := R) (α := α) (r • a) y :
+      ConnesKreimer R (Nonplanar α)) =
+      (r • (GrossmanLarson.product a y : ConnesKreimer R (Nonplanar α)) :
+        ConnesKreimer R (Nonplanar α)) :=
+    LinearMap.map_smul₂ (GrossmanLarson.product (R := R) (α := α)) r a y
+  exact (congrArg (fun u => GrossmanLarson.pairing (R := R) u w) h1).trans
+    (LinearMap.congr_fun
+      (map_smul (GrossmanLarson.pairing (R := R) (α := α)) r _) w)
+
+private lemma pairing_product_zero_right (x w : ConnesKreimer R (Nonplanar α)) :
+    GrossmanLarson.pairing (R := R)
+      (GrossmanLarson.product x (0 : ConnesKreimer R (Nonplanar α))) w = 0 := by
+  have h1 : (GrossmanLarson.product (R := R) (α := α) x
+      (0 : ConnesKreimer R (Nonplanar α)) :
+      ConnesKreimer R (Nonplanar α)) = 0 :=
+    map_zero (GrossmanLarson.product (R := R) (α := α) x)
+  exact (congrArg (fun u => GrossmanLarson.pairing (R := R) u w) h1).trans
+    (GrossmanLarson.pairing_zero_left w)
+
+private lemma pairing_product_add_right (x a b w : ConnesKreimer R (Nonplanar α)) :
+    GrossmanLarson.pairing (R := R) (GrossmanLarson.product x (a + b)) w =
+      GrossmanLarson.pairing (R := R) (GrossmanLarson.product x a) w +
+      GrossmanLarson.pairing (R := R) (GrossmanLarson.product x b) w := by
+  have h1 : (GrossmanLarson.product (R := R) (α := α) x (a + b) :
+      ConnesKreimer R (Nonplanar α)) =
+      ((GrossmanLarson.product x a : ConnesKreimer R (Nonplanar α)) +
+       (GrossmanLarson.product x b : ConnesKreimer R (Nonplanar α)) :
+        ConnesKreimer R (Nonplanar α)) :=
+    map_add (GrossmanLarson.product (R := R) (α := α) x) a b
+  exact (congrArg (fun u => GrossmanLarson.pairing (R := R) u w) h1).trans
+    (LinearMap.congr_fun
+      (map_add (GrossmanLarson.pairing (R := R) (α := α)) _ _) w)
+
+private lemma pairing_product_smul_right (r : R)
+    (x a w : ConnesKreimer R (Nonplanar α)) :
+    GrossmanLarson.pairing (R := R) (GrossmanLarson.product x (r • a)) w =
+      r • GrossmanLarson.pairing (R := R) (GrossmanLarson.product x a) w := by
+  have h1 : (GrossmanLarson.product (R := R) (α := α) x (r • a) :
+      ConnesKreimer R (Nonplanar α)) =
+      (r • (GrossmanLarson.product x a : ConnesKreimer R (Nonplanar α)) :
+        ConnesKreimer R (Nonplanar α)) :=
+    map_smul (GrossmanLarson.product (R := R) (α := α) x) r a
+  exact (congrArg (fun u => GrossmanLarson.pairing (R := R) u w) h1).trans
+    (LinearMap.congr_fun
+      (map_smul (GrossmanLarson.pairing (R := R) (α := α)) r _) w)
+
+/-! ### The duality theorem -/
+
+/-- **GL/CK duality for Δ^ρ** ([foissy-2002]): the GL `⋆` product and
+    the pruning coproduct Δ^ρ are adjoint under the symmetry-weighted
+    pairing, with crossed tensor slots (see module docstring):
+
+    `⟨x ⋆ y, z⟩ = pairing₂ (y ⊗ x) (Δ^ρ z)`
+
+    (`y` against pruned crowns, `x` against root trunks). -/
+theorem pairing_gl_eq_pairing_coproduct_Rho
+    (x y z : ConnesKreimer R (Nonplanar α)) :
+    GrossmanLarson.pairing
+        (GrossmanLarson.product x y) z =
+      pairing₂ (R := R)
+        (y ⊗ₜ[R] x)
+        (comulAlgHomN (R := R) z) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  -- Core statement at basis `z = of' C`, strong induction on total weight.
+  suffices core : ∀ (n : ℕ) (C : Forest (Nonplanar α)),
+      (C.map Nonplanar.weight).sum = n →
+      ∀ x y : ConnesKreimer R (Nonplanar α),
+      GrossmanLarson.pairing (R := R)
+          (GrossmanLarson.product x y) (ConnesKreimer.of' C) =
+        pairing₂ (R := R) (y ⊗ₜ[R] x)
+          (comulAlgHomN (R := R) (ConnesKreimer.of' C)) by
+    refine Finsupp.induction_linear z ?_ ?_ ?_
+    · show GrossmanLarson.pairing (R := R) (GrossmanLarson.product x y)
+          (0 : ConnesKreimer R (Nonplanar α)) =
+        pairing₂ (R := R) (y ⊗ₜ[R] x)
+          (comulAlgHomN (R := R) (0 : ConnesKreimer R (Nonplanar α)))
+      rw [map_zero, map_zero, map_zero]
+    · intro a b iha ihb
+      let a' : ConnesKreimer R (Nonplanar α) := a
+      let b' : ConnesKreimer R (Nonplanar α) := b
+      show GrossmanLarson.pairing (R := R) (GrossmanLarson.product x y)
+          (a' + b') =
+        pairing₂ (R := R) (y ⊗ₜ[R] x) (comulAlgHomN (R := R) (a' + b'))
+      rw [map_add, map_add, map_add]
+      exact congrArg₂ (· + ·) iha ihb
+    · intro C r
+      let z' : ConnesKreimer R (Nonplanar α) := Finsupp.single C r
+      have hsingle : z' = r • (ConnesKreimer.of' (R := R) C) := by
+        show (Finsupp.single C r : ConnesKreimer R (Nonplanar α)) =
+            r • (Finsupp.single C 1 : ConnesKreimer R (Nonplanar α))
+        exact (Finsupp.smul_single_one C r).symm
+      show GrossmanLarson.pairing (R := R) (GrossmanLarson.product x y) z' =
+        pairing₂ (R := R) (y ⊗ₜ[R] x) (comulAlgHomN (R := R) z')
+      rw [hsingle, map_smul, map_smul, map_smul]
+      exact congrArg (r • ·) (core _ C rfl x y)
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n IH =>
+    intro C hC x y
+    rcases Multiset.empty_or_exists_mem C with hC0 | ⟨T, hT⟩
+    · -- Base: C = 0, both sides are counits.
+      subst hC0
+      rw [ConnesKreimer.of'_zero,
+          show comulAlgHomN (R := R) (1 : ConnesKreimer R (Nonplanar α)) = 1 from
+            map_one _,
+          show (1 : ConnesKreimer R (Nonplanar α) ⊗[R]
+              ConnesKreimer R (Nonplanar α)) =
+            (1 : ConnesKreimer R (Nonplanar α)) ⊗ₜ[R]
+              (1 : ConnesKreimer R (Nonplanar α)) from
+            Algebra.TensorProduct.one_def,
+          pairing₂_tmul_tmul, pairing_apply_one, pairing_apply_one,
+          pairing_apply_one]
+      rw [show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
+            (GrossmanLarson.product x y) =
+          (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
+            (GrossmanLarson.unop
+              ((GrossmanLarson.op x : GrossmanLarson R α) *
+                GrossmanLarson.op y)) from rfl,
+          GrossmanLarson.counit_gl_mul]
+      exact mul_comm _ _
+    · obtain ⟨C', rfl⟩ := Multiset.exists_cons_of_mem hT
+      rcases Multiset.empty_or_exists_mem C' with hC'0 | ⟨T₂, hT₂⟩
+      · -- Single tree: C = {T}, T = B⁺_a W; the B⁻ recurrences match.
+        subst hC'0
+        -- Weight bookkeeping: (rootChildren T) is one lighter than T.
+        have hwT : ((T ::ₘ (0 : Forest (Nonplanar α))).map
+            Nonplanar.weight).sum = T.weight := by
+          rw [Multiset.map_cons, Multiset.map_zero, Multiset.sum_cons,
+              Multiset.sum_zero]
+          omega
+        have hTn : T.weight = n := by rw [← hwT, hC]
+        have hwW : T.weight =
+            1 + ((Nonplanar.rootChildren T).map Nonplanar.weight).sum := by
+          conv_lhs => rw [← Nonplanar.node_eta T]
+          rw [Nonplanar.weight_node]
+        have hWlt : ((Nonplanar.rootChildren T).map Nonplanar.weight).sum < n := by
+          omega
+        -- Convert `of' {T}` to `B⁺_a (of' W)`.
+        have hofT : (ConnesKreimer.of' (R := R) (T ::ₘ (0 : Forest (Nonplanar α))) :
+            ConnesKreimer R (Nonplanar α)) =
+            bPlusLin (R := R) (Nonplanar.rootLabel T)
+              (ConnesKreimer.of' (Nonplanar.rootChildren T)) := by
+          rw [bPlusLin_of', Nonplanar.node_eta]
+          rfl
+        rw [hofT]
+        -- LHS: the B⁺/B⁻ recurrence.
+        rw [show GrossmanLarson.pairing (R := R)
+              (GrossmanLarson.product x y)
+              (bPlusLin (R := R) (Nonplanar.rootLabel T)
+                (ConnesKreimer.of' (Nonplanar.rootChildren T))) =
+            GrossmanLarson.pairing (R := R) (GrossmanLarson.unop
+              ((GrossmanLarson.op x : GrossmanLarson R α) * GrossmanLarson.op y))
+              (bPlusLin (R := R) (Nonplanar.rootLabel T)
+                (ConnesKreimer.of' (Nonplanar.rootChildren T))) from rfl]
+        rw [GrossmanLarson.pairing_apply_bPlus_gl_mul]
+        -- RHS: the Hochschild cocycle + adjoint.
+        rw [show comulAlgHomN (R := R)
+              (bPlusLin (R := R) (Nonplanar.rootLabel T)
+                (ConnesKreimer.of' (Nonplanar.rootChildren T))) =
+            comulTreeN (R := R)
+              (Nonplanar.node (Nonplanar.rootLabel T)
+                (Nonplanar.rootChildren T)) from by
+          rw [bPlusLin_of', comulAlgHomN_apply_ofTree]]
+        rw [comulTreeN_node_cocycle, map_add, pairing₂_tmul_tmul,
+            pairing₂_lTensor_bPlusLin]
+        -- Term 1: adjoint identity; Term 2: induction hypothesis.
+        rw [show comulForestN (R := R) (Nonplanar.rootChildren T) =
+            comulAlgHomN (R := R)
+              (ConnesKreimer.of' (Nonplanar.rootChildren T)) from
+          (comulAlgHomN_apply_of' _).symm]
+        rw [← IH _ hWlt (Nonplanar.rootChildren T) rfl
+            (GrossmanLarson.bMinusLin (R := R) (Nonplanar.rootLabel T) x) y]
+        rw [show (ConnesKreimer.ofTree (R := R)
+              (Nonplanar.node (Nonplanar.rootLabel T)
+                (Nonplanar.rootChildren T)) :
+              ConnesKreimer R (Nonplanar α)) =
+            bPlusLin (R := R) (Nonplanar.rootLabel T)
+              (ConnesKreimer.of' (Nonplanar.rootChildren T)) from
+          (bPlusLin_of' _ _).symm]
+        rw [← GrossmanLarson.bMinusLin_pairing_adjoint, pairing_apply_one]
+        rw [show GrossmanLarson.pairing (R := R)
+              (GrossmanLarson.product
+                (GrossmanLarson.bMinusLin (R := R) (Nonplanar.rootLabel T) x) y)
+              (ConnesKreimer.of' (Nonplanar.rootChildren T)) =
+            GrossmanLarson.pairing (R := R) (GrossmanLarson.unop
+              ((GrossmanLarson.op (GrossmanLarson.bMinusLin (R := R)
+                  (Nonplanar.rootLabel T) x) : GrossmanLarson R α) *
+                GrossmanLarson.op y))
+              (ConnesKreimer.of' (Nonplanar.rootChildren T)) from rfl]
+        ring
+      · -- Multi-tree: C = T ::ₘ C' with C' ≠ 0; split and use both
+        -- product rules + the induction hypothesis at both factors.
+        -- Weight bookkeeping.
+        have hsum : T.weight + (C'.map Nonplanar.weight).sum = n := by
+          rw [← hC, Multiset.map_cons, Multiset.sum_cons]
+        have hT2pos : 0 < Nonplanar.weight T₂ := Nonplanar.weight_pos T₂
+        have hC'ge : Nonplanar.weight T₂ ≤ (C'.map Nonplanar.weight).sum :=
+          Multiset.single_le_sum (fun _ _ => Nat.zero_le _) _
+            (Multiset.mem_map_of_mem _ hT₂)
+        have hTpos : 0 < T.weight := Nonplanar.weight_pos T
+        have hTlt : ((({T} : Forest (Nonplanar α))).map Nonplanar.weight).sum < n := by
+          rw [Multiset.map_singleton, Multiset.sum_singleton]
+          omega
+        have hC'lt : (C'.map Nonplanar.weight).sum < n := by omega
+        -- Reduce x, y to basis vectors (both sides are bilinear in (x, y)).
+        refine Finsupp.induction_linear x ?_ ?_ ?_
+        · show GrossmanLarson.pairing (R := R)
+              (GrossmanLarson.product (0 : ConnesKreimer R (Nonplanar α)) y)
+              (ConnesKreimer.of' (T ::ₘ C')) = pairing₂ (R := R)
+              (y ⊗ₜ[R] (0 : ConnesKreimer R (Nonplanar α)))
+              (comulAlgHomN (R := R) (ConnesKreimer.of' (T ::ₘ C')))
+          simp only [pairing_product_zero_left, TensorProduct.tmul_zero,
+              map_zero, LinearMap.zero_apply]
+        · intro a b iha ihb
+          let a' : ConnesKreimer R (Nonplanar α) := a
+          let b' : ConnesKreimer R (Nonplanar α) := b
+          show GrossmanLarson.pairing (R := R)
+              (GrossmanLarson.product (a' + b') y)
+              (ConnesKreimer.of' (T ::ₘ C')) = pairing₂ (R := R)
+              (y ⊗ₜ[R] (a' + b'))
+              (comulAlgHomN (R := R) (ConnesKreimer.of' (T ::ₘ C')))
+          simp only [pairing_product_add_left, TensorProduct.tmul_add,
+              map_add, LinearMap.add_apply]
+          exact congrArg₂ (· + ·) iha ihb
+        · intro A rA
+          let xA : ConnesKreimer R (Nonplanar α) := Finsupp.single A rA
+          have hxA : xA = rA • (ConnesKreimer.of' (R := R) A) := by
+            show (Finsupp.single A rA : ConnesKreimer R (Nonplanar α)) =
+                rA • (Finsupp.single A 1 : ConnesKreimer R (Nonplanar α))
+            exact (Finsupp.smul_single_one A rA).symm
+          show GrossmanLarson.pairing (R := R)
+              (GrossmanLarson.product xA y)
+              (ConnesKreimer.of' (T ::ₘ C')) = pairing₂ (R := R)
+              (y ⊗ₜ[R] xA)
+              (comulAlgHomN (R := R) (ConnesKreimer.of' (T ::ₘ C')))
+          rw [hxA]
+          simp only [pairing_product_smul_left, TensorProduct.tmul_smul,
+              map_smul, LinearMap.smul_apply]
+          refine congrArg (rA • ·) ?_
+          refine Finsupp.induction_linear y ?_ ?_ ?_
+          · show GrossmanLarson.pairing (R := R)
+                (GrossmanLarson.product (ConnesKreimer.of' A)
+                  (0 : ConnesKreimer R (Nonplanar α)))
+                (ConnesKreimer.of' (T ::ₘ C')) = pairing₂ (R := R)
+                ((0 : ConnesKreimer R (Nonplanar α)) ⊗ₜ[R] ConnesKreimer.of' A)
+                (comulAlgHomN (R := R) (ConnesKreimer.of' (T ::ₘ C')))
+            simp only [pairing_product_zero_right, TensorProduct.zero_tmul,
+                map_zero, LinearMap.zero_apply]
+          · intro a b iha ihb
+            let a' : ConnesKreimer R (Nonplanar α) := a
+            let b' : ConnesKreimer R (Nonplanar α) := b
+            show GrossmanLarson.pairing (R := R)
+                (GrossmanLarson.product (ConnesKreimer.of' A) (a' + b'))
+                (ConnesKreimer.of' (T ::ₘ C')) = pairing₂ (R := R)
+                ((a' + b') ⊗ₜ[R] ConnesKreimer.of' A)
+                (comulAlgHomN (R := R) (ConnesKreimer.of' (T ::ₘ C')))
+            simp only [pairing_product_add_right, TensorProduct.add_tmul,
+                map_add, LinearMap.add_apply]
+            exact congrArg₂ (· + ·) iha ihb
+          · intro B rB
+            let yB : ConnesKreimer R (Nonplanar α) := Finsupp.single B rB
+            have hyB : yB = rB • (ConnesKreimer.of' (R := R) B) := by
+              show (Finsupp.single B rB : ConnesKreimer R (Nonplanar α)) =
+                  rB • (Finsupp.single B 1 : ConnesKreimer R (Nonplanar α))
+              exact (Finsupp.smul_single_one B rB).symm
+            show GrossmanLarson.pairing (R := R)
+                (GrossmanLarson.product (ConnesKreimer.of' A) yB)
+                (ConnesKreimer.of' (T ::ₘ C')) = pairing₂ (R := R)
+                (yB ⊗ₜ[R] ConnesKreimer.of' A)
+                (comulAlgHomN (R := R) (ConnesKreimer.of' (T ::ₘ C')))
+            rw [hyB]
+            simp only [pairing_product_smul_right, ← TensorProduct.smul_tmul',
+                map_smul, LinearMap.smul_apply]
+            refine congrArg (rB • ·) ?_
+            -- Basis case: split off the head tree and use both product rules.
+            have hsplit : (ConnesKreimer.of' (R := R) (T ::ₘ C') :
+                ConnesKreimer R (Nonplanar α)) =
+                ConnesKreimer.of' ({T} : Forest (Nonplanar α)) *
+                  ConnesKreimer.of' C' := by
+              rw [← ConnesKreimer.of'_add, Multiset.singleton_add]
+            rw [hsplit, GrossmanLarson.pairing_product_of'_mul_of',
+                map_mul, pairing₂_of'_of'_mul]
+            refine congrArg Multiset.sum (Multiset.map_congr rfl fun pq _ => ?_)
+            rw [IH _ hTlt ({T} : Forest (Nonplanar α)) rfl
+                  (ConnesKreimer.of' pq.1.1) (ConnesKreimer.of' pq.2.1),
+                IH _ hC'lt C' rfl
+                  (ConnesKreimer.of' pq.1.2) (ConnesKreimer.of' pq.2.2)]
+
+/-! ### Coassoc LinearMaps + chain lemmas via the duality -/
+
+/-- The LHS LinearMap of Δ^ρ coassoc:
+    `assoc ∘ (Δ^ρ ⊗ id) ∘ Δ^ρ : CK →ₗ CK ⊗ (CK ⊗ CK)`. -/
+private noncomputable def coassocLHSLinRho :
+    ConnesKreimer R (Nonplanar α) →ₗ[R]
+      ConnesKreimer R (Nonplanar α) ⊗[R]
+        (ConnesKreimer R (Nonplanar α) ⊗[R]
+          ConnesKreimer R (Nonplanar α)) :=
+  (TensorProduct.assoc R _ _ _).toLinearMap ∘ₗ
+    (comulAlgHomN (R := R)).toLinearMap.rTensor _ ∘ₗ
+    (comulAlgHomN (R := R)).toLinearMap
+
+/-- The RHS LinearMap of Δ^ρ coassoc:
+    `(id ⊗ Δ^ρ) ∘ Δ^ρ : CK →ₗ CK ⊗ (CK ⊗ CK)`. -/
+private noncomputable def coassocRHSLinRho :
+    ConnesKreimer R (Nonplanar α) →ₗ[R]
+      ConnesKreimer R (Nonplanar α) ⊗[R]
+        (ConnesKreimer R (Nonplanar α) ⊗[R]
+          ConnesKreimer R (Nonplanar α)) :=
+  (comulAlgHomN (R := R)).toLinearMap.lTensor _ ∘ₗ
+    (comulAlgHomN (R := R)).toLinearMap
+
+/-- Intermediate: `assoc + rTensor (Δ^ρ) + pairing₃` via one application
+    of the duality. Note the crossed orientation: the inner coproduct
+    expansion produces the GL product `y ⋆ x`. -/
+private lemma pairing₃_assoc_rTensor_comul_rho
+    (x y z' : ConnesKreimer R (Nonplanar α))
+    (V : ConnesKreimer R (Nonplanar α) ⊗[R]
+          ConnesKreimer R (Nonplanar α)) :
+    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
+        ((TensorProduct.assoc R _ _ _)
+          ((comulAlgHomN (R := R)).toLinearMap.rTensor _ V)) =
+      pairing₂ (R := R) (GrossmanLarson.product y x ⊗ₜ[R] z') V := by
+  induction V using TensorProduct.induction_on with
+  | zero => simp
+  | tmul a b =>
+    rw [LinearMap.rTensor_tmul, AlgHom.toLinearMap_apply, pairing₃_assoc_tmul,
+        ← pairing_gl_eq_pairing_coproduct_Rho y x a, pairing₂_tmul_tmul]
+  | add V₁ V₂ ih₁ ih₂ =>
+    rw [map_add, map_add, map_add, ih₁, ih₂, map_add]
+
+/-- Intermediate: `lTensor (Δ^ρ) + pairing₃` via one application of the
+    duality (crossed orientation: produces `z' ⋆ y`). -/
+private lemma pairing₃_lTensor_comul_rho
+    (x y z' : ConnesKreimer R (Nonplanar α))
+    (W : ConnesKreimer R (Nonplanar α) ⊗[R]
+          ConnesKreimer R (Nonplanar α)) :
+    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
+        ((comulAlgHomN (R := R)).toLinearMap.lTensor _ W) =
+      pairing₂ (R := R) (x ⊗ₜ[R] GrossmanLarson.product z' y) W := by
+  induction W using TensorProduct.induction_on with
+  | zero => simp
+  | tmul a b =>
+    rw [LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, pairing₃_tmul_apply,
+        ← pairing_gl_eq_pairing_coproduct_Rho z' y b, pairing₂_tmul_tmul]
+  | add W₁ W₂ ih₁ ih₂ =>
+    rw [map_add, map_add, ih₁, ih₂, map_add]
+
+/-- **LHS chain via the duality (twice)**: pairing the LHS coassoc
+    expression against a pure triple tensor reduces to pairing the
+    GL product `z' ⋆ (y ⋆ x)` against `z`. -/
+theorem pairing₃_coassocLHSLinRho
+    (x y z' z : ConnesKreimer R (Nonplanar α)) :
+    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z')) (coassocLHSLinRho (R := R) z) =
+      GrossmanLarson.pairing
+        (GrossmanLarson.product z' (GrossmanLarson.product y x)) z := by
+  show pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
+        ((TensorProduct.assoc R _ _ _)
+          ((comulAlgHomN (R := R)).toLinearMap.rTensor _
+            ((comulAlgHomN (R := R)).toLinearMap z))) = _
+  rw [AlgHom.toLinearMap_apply, pairing₃_assoc_rTensor_comul_rho]
+  exact (pairing_gl_eq_pairing_coproduct_Rho z'
+          (GrossmanLarson.product y x) z).symm
+
+/-- **RHS chain via the duality (twice)**: pairing the RHS coassoc
+    expression against a pure triple tensor reduces to pairing the
+    GL product `(z' ⋆ y) ⋆ x` against `z`. -/
+theorem pairing₃_coassocRHSLinRho
+    (x y z' z : ConnesKreimer R (Nonplanar α)) :
+    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z')) (coassocRHSLinRho (R := R) z) =
+      GrossmanLarson.pairing
+        (GrossmanLarson.product (GrossmanLarson.product z' y) x) z := by
+  show pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
+        ((comulAlgHomN (R := R)).toLinearMap.lTensor _
+          ((comulAlgHomN (R := R)).toLinearMap z)) = _
+  rw [AlgHom.toLinearMap_apply, pairing₃_lTensor_comul_rho]
+  exact (pairing_gl_eq_pairing_coproduct_Rho
+          (GrossmanLarson.product z' y) x z).symm
+
+/-! ### Coassociativity of Δ^ρ via GL/CK duality (LinearMap form)
+
+Specialized to `[CommRing R]` (rather than `[CommSemiring R]`) since the
+proof uses subtraction (via `sub_eq_zero` in `pairing₃_unique`), which
+requires `R` to be a Ring (so `CK R T` has `AddCommGroup`). -/
+
+section CoassocCommRingRho
+variable {R' : Type*} [CommRing R'] {α' : Type*}
+
+/-- **Coassociativity of `comulAlgHomN`** (LinearMap form), via GL/CK
+    duality. Parallel to `TraceNonplanar.comulCN_coassoc` for Δ^c.
+
+    Derived via the chain:
+    1. `ext z`: reduce to pointwise `LHS z = RHS z`.
+    2. `pairing₃_unique`: reduce to `∀ t, pairing₃ t (LHS z) = pairing₃ t (RHS z)`.
+    3. `TensorProduct.induction_on` thrice: reduce `t` to pure triple
+       tensors `x ⊗ (y ⊗ z')`.
+    4. `pairing₃_coassocLHSLinRho` / `pairing₃_coassocRHSLinRho`: reduce
+       both sides to GL products against `z` (two duality applications
+       each).
+    5. `GrossmanLarson.mul_assoc z' y x` closes. -/
+theorem comulRhoN_coassoc [CharZero R'] [NoZeroDivisors R'] :
+    (TensorProduct.assoc R'
+        (ConnesKreimer R' (Nonplanar α'))
+        (ConnesKreimer R' (Nonplanar α'))
+        (ConnesKreimer R' (Nonplanar α'))).toLinearMap ∘ₗ
+      (comulAlgHomN (R := R')).toLinearMap.rTensor _ ∘ₗ
+      (comulAlgHomN (R := R')).toLinearMap =
+    (comulAlgHomN (R := R')).toLinearMap.lTensor _ ∘ₗ
+      (comulAlgHomN (R := R')).toLinearMap := by
+  letI : AddCommGroup (ConnesKreimer R' (Nonplanar α')) :=
+    ConnesKreimer.addCommGroupOf
+  ext z
+  apply pairing₃_unique
+  intro t
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | tmul x rest =>
+    induction rest using TensorProduct.induction_on with
+    | zero => simp
+    | tmul y z' =>
+      show pairing₃ (x ⊗ₜ[R'] (y ⊗ₜ[R'] z')) (coassocLHSLinRho z) =
+           pairing₃ (x ⊗ₜ[R'] (y ⊗ₜ[R'] z')) (coassocRHSLinRho z)
+      rw [pairing₃_coassocLHSLinRho, pairing₃_coassocRHSLinRho,
+          ← GrossmanLarson.mul_def, ← GrossmanLarson.mul_def,
+          ← GrossmanLarson.mul_def, ← GrossmanLarson.mul_def,
+          GrossmanLarson.mul_assoc]
+    | add a b iha ihb =>
+      simp only [TensorProduct.tmul_add, map_add, LinearMap.add_apply,
+                 iha, ihb]
+  | add a b iha ihb =>
+    simp only [map_add, LinearMap.add_apply, iha, ihb]
+
+/-- **AlgHom-form coassociativity** of `comulAlgHomN`. Follows from
+    `comulRhoN_coassoc` (LinearMap form) by AlgHom extensionality, the
+    same one-liner pattern as `TraceNonplanar.comulCAlgHomN_coassoc_algHom`. -/
+theorem comulAlgHomN_coassoc_algHom [CharZero R'] [NoZeroDivisors R'] :
+    (Algebra.TensorProduct.assoc R' R' R'
+        (ConnesKreimer R' (Nonplanar α'))
+        (ConnesKreimer R' (Nonplanar α'))
+        (ConnesKreimer R' (Nonplanar α'))).toAlgHom.comp
+      ((Algebra.TensorProduct.map (comulAlgHomN (R := R') (α := α'))
+        (AlgHom.id R' _)).comp comulAlgHomN) =
+    (Algebra.TensorProduct.map (AlgHom.id R' _) comulAlgHomN).comp comulAlgHomN := by
+  apply AlgHom.toLinearMap_injective
+  exact comulRhoN_coassoc
+
+end CoassocCommRingRho
+
+/-! ### `Bialgebra` instance
+
+Built via `Bialgebra.ofAlgHom` from `comulAlgHomN_coassoc_algHom` (GL/CK
+duality) and the two counit AlgHom laws. The duality-based coassoc proof
+forces `[CommRing R] [CharZero R] [NoZeroDivisors R]`; the counit laws
+hold over `[CommSemiring R]` and are automatically satisfied. -/
+
+noncomputable instance instBialgebraRho
+    {R' : Type*} [CommRing R'] [CharZero R'] [NoZeroDivisors R'] {α' : Type*} :
+    Bialgebra R' (ConnesKreimer R' (Nonplanar α')) :=
+  Bialgebra.ofAlgHom comulAlgHomN counit
+    comulAlgHomN_coassoc_algHom
+    counit_rTensor_comulAlgHomN
+    counit_lTensor_comulAlgHomN
+
+end ConnesKreimer
+
+end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
@@ -22,18 +22,18 @@ established, `Nonplanar.lift` produces `cutSummandsN`, which extends to
 
 ## Status
 
-`[UPSTREAM]` candidate. The Bialgebra structure depends on one Foissy
-axiom (`pairing_gl_eq_pairing_coproduct_Rho`, GL/CK duality identity,
-classical result of [foissy-2002]); the rest is sorry-free. Covers:
-the descent (`comulAlgHomN`), the Hochschild 1-cocycle
-(`comulTreeN_node_cocycle`, `comulAlgHomN_bPlusLin_cocycle`),
-coassociativity via GL/CK duality (`comulRhoN_coassoc` →
-`comulAlgHomN_coassoc_algHom`), the counit laws
-(`counit_rTensor_comulAlgHomN`, `counit_lTensor_comulAlgHomN`), and the
-`Bialgebra (ConnesKreimer R (Nonplanar α))` instance over
-`[CommRing R] [CharZero R] [NoZeroDivisors R]`.
+`[UPSTREAM]` candidate. Sorry-free. Covers: the descent
+(`comulAlgHomN`), the Hochschild 1-cocycle (`comulTreeN_node_cocycle`,
+`comulAlgHomN_bPlusLin_cocycle`), and the counit laws
+(`counit_rTensor_comulAlgHomN`, `counit_lTensor_comulAlgHomN`).
 
-The full `HopfAlgebra` instance (with antipode) lives in the sibling
+The GL/CK duality theorem (`pairing_gl_eq_pairing_coproduct_Rho`,
+classical result of [foissy-2002]), coassociativity
+(`comulRhoN_coassoc` → `comulAlgHomN_coassoc_algHom`), and the
+`Bialgebra (ConnesKreimer R (Nonplanar α))` instance live downstream in
+`Coproduct/PruningDuality.lean` (the duality proof needs the B⁻
+calculus of `BMinus.lean`, which imports this file). The full
+`HopfAlgebra` instance (with antipode) lives in the sibling
 `HopfAlgebraNonplanar.lean` (Phase A.8).
 
 ## Architecture
@@ -1254,218 +1254,12 @@ theorem counit_lTensor_comulAlgHomN :
        (Algebra.TensorProduct.rid R R (ConnesKreimer R (Nonplanar α))).symm (of' F)
   rw [comulAlgHomN_apply_of', Algebra.TensorProduct.rid_symm_apply]
   exact comulForestN_counit_lTensor F (fun T _ => comulTreeN_counit_lTensor T)
+/-! ### Δ^ρ coassoc and Bialgebra instance: moved
 
-/-! ### Δ^ρ coassoc via GL/CK duality
-
-Mirrors the Δ^c structure in `TraceNonplanar.lean`: prove `comulAlgHomN`
-coassoc via duality with `GrossmanLarson.mul_assoc`, using the
-symmetry-weighted pairing as a bridge. A single GL-duality framework
-subsumes both Δ^ρ and Δ^c coassoc (see
-`memory/project_mcb_unification_rationale.md`).
-
-The Foissy axiom `pairing_gl_eq_pairing_coproduct_Rho` is the GL/CK
-duality identity at the level of pairing + cut summands for Δ^ρ; this
-is the classical result of [foissy-2002]. Formalization deferred
-(parallel to `pairing_gl_eq_pairing_coproduct_C` for Δ^c). -/
-
-/-- **GL/CK duality for Δ^ρ** ([foissy-2002]): the GL `★` product
-    and Δ^ρ coproduct are paired via the symmetry-weighted pairing:
-
-    `pairing (gl x y) z = pairing₂ (x ⊗ y) (Δ^ρ z)`
-
-    Trace-free version of `pairing_gl_eq_pairing_coproduct_C`. Both
-    Foissy axioms encode the same combinatorial duality with different
-    cut-extraction policies (Δ^ρ enumerates pruning cuts directly;
-    Δ^c routes through the trace-decorated `α ⊕ β` carrier).
-
-    **Formalization status (2026-05-19)**: `sorry`-fenced as a top-level
-    axiom, parallel to its Δ^c sibling. Combinatorial proof is the
-    classical CK/GL duality identity. -/
-theorem pairing_gl_eq_pairing_coproduct_Rho
-    (x y z : ConnesKreimer R (Nonplanar α)) :
-    GrossmanLarson.pairing
-        (GrossmanLarson.product x y) z =
-      pairing₂ (R := R)
-        (x ⊗ₜ[R] y)
-        (comulAlgHomN (R := R) z) := by
-  sorry
-
-/-! ### Coassoc LinearMaps + chain lemmas via Δ^ρ-Foissy -/
-
-/-- The LHS LinearMap of Δ^ρ coassoc:
-    `assoc ∘ (Δ^ρ ⊗ id) ∘ Δ^ρ : CK →ₗ CK ⊗ (CK ⊗ CK)`. -/
-private noncomputable def coassocLHSLinRho :
-    ConnesKreimer R (Nonplanar α) →ₗ[R]
-      ConnesKreimer R (Nonplanar α) ⊗[R]
-        (ConnesKreimer R (Nonplanar α) ⊗[R]
-          ConnesKreimer R (Nonplanar α)) :=
-  (TensorProduct.assoc R _ _ _).toLinearMap ∘ₗ
-    (comulAlgHomN (R := R)).toLinearMap.rTensor _ ∘ₗ
-    (comulAlgHomN (R := R)).toLinearMap
-
-/-- The RHS LinearMap of Δ^ρ coassoc:
-    `(id ⊗ Δ^ρ) ∘ Δ^ρ : CK →ₗ CK ⊗ (CK ⊗ CK)`. -/
-private noncomputable def coassocRHSLinRho :
-    ConnesKreimer R (Nonplanar α) →ₗ[R]
-      ConnesKreimer R (Nonplanar α) ⊗[R]
-        (ConnesKreimer R (Nonplanar α) ⊗[R]
-          ConnesKreimer R (Nonplanar α)) :=
-  (comulAlgHomN (R := R)).toLinearMap.lTensor _ ∘ₗ
-    (comulAlgHomN (R := R)).toLinearMap
-
-/-- Intermediate: `assoc + rTensor (Δ^ρ) + pairing₃` via one application
-    of the Δ^ρ Foissy axiom. Reuses the generic `pairing₃_assoc_tmul`
-    helper from `TraceNonplanar.lean`. -/
-private lemma pairing₃_assoc_rTensor_comul_rho
-    (x y z' : ConnesKreimer R (Nonplanar α))
-    (V : ConnesKreimer R (Nonplanar α) ⊗[R]
-          ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
-        ((TensorProduct.assoc R _ _ _)
-          ((comulAlgHomN (R := R)).toLinearMap.rTensor _ V)) =
-      pairing₂ (R := R) (GrossmanLarson.product x y ⊗ₜ[R] z') V := by
-  induction V using TensorProduct.induction_on with
-  | zero => simp
-  | tmul a b =>
-    rw [LinearMap.rTensor_tmul, AlgHom.toLinearMap_apply, pairing₃_assoc_tmul,
-        ← pairing_gl_eq_pairing_coproduct_Rho x y a, pairing₂_tmul_tmul]
-  | add V₁ V₂ ih₁ ih₂ =>
-    rw [map_add, map_add, map_add, ih₁, ih₂, map_add]
-
-/-- Intermediate: `lTensor (Δ^ρ) + pairing₃` via one application of the
-    Δ^ρ Foissy axiom. Reuses the generic `pairing₃_tmul_apply` helper. -/
-private lemma pairing₃_lTensor_comul_rho
-    (x y z' : ConnesKreimer R (Nonplanar α))
-    (W : ConnesKreimer R (Nonplanar α) ⊗[R]
-          ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
-        ((comulAlgHomN (R := R)).toLinearMap.lTensor _ W) =
-      pairing₂ (R := R) (x ⊗ₜ[R] GrossmanLarson.product y z') W := by
-  induction W using TensorProduct.induction_on with
-  | zero => simp
-  | tmul a b =>
-    rw [LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, pairing₃_tmul_apply,
-        ← pairing_gl_eq_pairing_coproduct_Rho y z' b, pairing₂_tmul_tmul]
-  | add W₁ W₂ ih₁ ih₂ =>
-    rw [map_add, map_add, ih₁, ih₂, map_add]
-
-/-- **LHS chain via Δ^ρ-Foissy (twice)**: pairing the LHS coassoc
-    expression against a pure triple tensor reduces to pairing the
-    left-associated GL product against `z`. -/
-theorem pairing₃_coassocLHSLinRho
-    (x y z' z : ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z')) (coassocLHSLinRho (R := R) z) =
-      GrossmanLarson.pairing
-        (GrossmanLarson.product (GrossmanLarson.product x y) z') z := by
-  show pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
-        ((TensorProduct.assoc R _ _ _)
-          ((comulAlgHomN (R := R)).toLinearMap.rTensor _
-            ((comulAlgHomN (R := R)).toLinearMap z))) = _
-  rw [AlgHom.toLinearMap_apply, pairing₃_assoc_rTensor_comul_rho]
-  exact (pairing_gl_eq_pairing_coproduct_Rho
-          (GrossmanLarson.product x y) z' z).symm
-
-/-- **RHS chain via Δ^ρ-Foissy (twice)**: pairing the RHS coassoc
-    expression against a pure triple tensor reduces to pairing the
-    right-associated GL product against `z`. -/
-theorem pairing₃_coassocRHSLinRho
-    (x y z' z : ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z')) (coassocRHSLinRho (R := R) z) =
-      GrossmanLarson.pairing
-        (GrossmanLarson.product x (GrossmanLarson.product y z')) z := by
-  show pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
-        ((comulAlgHomN (R := R)).toLinearMap.lTensor _
-          ((comulAlgHomN (R := R)).toLinearMap z)) = _
-  rw [AlgHom.toLinearMap_apply, pairing₃_lTensor_comul_rho]
-  exact (pairing_gl_eq_pairing_coproduct_Rho x
-          (GrossmanLarson.product y z') z).symm
-
-/-! ### Coassociativity of Δ^ρ via GL/CK duality (LinearMap form)
-
-Specialized to `[CommRing R]` (rather than `[CommSemiring R]`) since the
-proof uses subtraction (via `sub_eq_zero` in `pairing₃_unique`), which
-requires `R` to be a Ring (so `CK R T` has `AddCommGroup`). -/
-
-section CoassocCommRingRho
-variable {R' : Type*} [CommRing R'] {α' : Type*}
-
-/-- **Coassociativity of `comulAlgHomN`** (LinearMap form), via GL/CK
-    duality. Parallel to `TraceNonplanar.comulCN_coassoc` for Δ^c.
-
-    Derived via the chain:
-    1. `ext z`: reduce to pointwise `LHS z = RHS z`.
-    2. `pairing₃_unique`: reduce to `∀ t, pairing₃ t (LHS z) = pairing₃ t (RHS z)`.
-    3. `TensorProduct.induction_on` thrice: reduce `t` to pure triple
-       tensors `x ⊗ (y ⊗ z')`.
-    4. `pairing₃_coassocLHSLinRho` / `pairing₃_coassocRHSLinRho`: reduce
-       both sides to `GrossmanLarson.pairing (gl ... ...) z` (two Foissy
-       applications each).
-    5. `GrossmanLarson.mul_assoc x y z'` closes.
-
-    Sorry-fenced substrate: just `pairing_gl_eq_pairing_coproduct_Rho`
-    (the Foissy axiom, parallel to the Δ^c version). -/
-theorem comulRhoN_coassoc [CharZero R'] [NoZeroDivisors R'] :
-    (TensorProduct.assoc R'
-        (ConnesKreimer R' (Nonplanar α'))
-        (ConnesKreimer R' (Nonplanar α'))
-        (ConnesKreimer R' (Nonplanar α'))).toLinearMap ∘ₗ
-      (comulAlgHomN (R := R')).toLinearMap.rTensor _ ∘ₗ
-      (comulAlgHomN (R := R')).toLinearMap =
-    (comulAlgHomN (R := R')).toLinearMap.lTensor _ ∘ₗ
-      (comulAlgHomN (R := R')).toLinearMap := by
-  letI : AddCommGroup (ConnesKreimer R' (Nonplanar α')) :=
-    ConnesKreimer.addCommGroupOf
-  ext z
-  apply pairing₃_unique
-  intro t
-  induction t using TensorProduct.induction_on with
-  | zero => simp
-  | tmul x rest =>
-    induction rest using TensorProduct.induction_on with
-    | zero => simp
-    | tmul y z' =>
-      show pairing₃ (x ⊗ₜ[R'] (y ⊗ₜ[R'] z')) (coassocLHSLinRho z) =
-           pairing₃ (x ⊗ₜ[R'] (y ⊗ₜ[R'] z')) (coassocRHSLinRho z)
-      rw [pairing₃_coassocLHSLinRho, pairing₃_coassocRHSLinRho,
-          ← GrossmanLarson.mul_def, ← GrossmanLarson.mul_def,
-          ← GrossmanLarson.mul_def, ← GrossmanLarson.mul_def,
-          GrossmanLarson.mul_assoc]
-    | add a b iha ihb =>
-      simp only [TensorProduct.tmul_add, map_add, LinearMap.add_apply,
-                 iha, ihb]
-  | add a b iha ihb =>
-    simp only [map_add, LinearMap.add_apply, iha, ihb]
-
-/-- **AlgHom-form coassociativity** of `comulAlgHomN`. Follows from
-    `comulRhoN_coassoc` (LinearMap form) by AlgHom extensionality, the
-    same one-liner pattern as `TraceNonplanar.comulCAlgHomN_coassoc_algHom`. -/
-theorem comulAlgHomN_coassoc_algHom [CharZero R'] [NoZeroDivisors R'] :
-    (Algebra.TensorProduct.assoc R' R' R'
-        (ConnesKreimer R' (Nonplanar α'))
-        (ConnesKreimer R' (Nonplanar α'))
-        (ConnesKreimer R' (Nonplanar α'))).toAlgHom.comp
-      ((Algebra.TensorProduct.map (comulAlgHomN (R := R') (α := α'))
-        (AlgHom.id R' _)).comp comulAlgHomN) =
-    (Algebra.TensorProduct.map (AlgHom.id R' _) comulAlgHomN).comp comulAlgHomN := by
-  apply AlgHom.toLinearMap_injective
-  exact comulRhoN_coassoc
-
-end CoassocCommRingRho
-
-/-! ### `Bialgebra` instance
-
-Built via `Bialgebra.ofAlgHom` from `comulAlgHomN_coassoc_algHom` (GL/CK
-duality) and the two counit AlgHom laws. The duality-based coassoc proof
-forces `[CommRing R] [CharZero R] [NoZeroDivisors R]`; the counit laws
-hold over `[CommSemiring R]` and are automatically satisfied. -/
-
-noncomputable instance instBialgebraRho
-    {R' : Type*} [CommRing R'] [CharZero R'] [NoZeroDivisors R'] {α' : Type*} :
-    Bialgebra R' (ConnesKreimer R' (Nonplanar α')) :=
-  Bialgebra.ofAlgHom comulAlgHomN counit
-    comulAlgHomN_coassoc_algHom
-    counit_rTensor_comulAlgHomN
-    counit_lTensor_comulAlgHomN
+The GL/CK duality theorem (`pairing_gl_eq_pairing_coproduct_Rho`), the
+coassociativity of `comulAlgHomN`, and the `Bialgebra` instance live in
+`Coproduct/PruningDuality.lean`, downstream of `BMinus.lean` (whose B⁻
+calculus drives the duality proof). -/
 
 end ConnesKreimer
 

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonAssoc.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonAssoc.lean
@@ -1076,7 +1076,7 @@ Each helper expresses one stage of the LHS or RHS expansion. -/
 /-- Basis-form rewrite: `(of' F₁) * (of' F₂)` as a sum of basis vectors `of' (X + (F₂ - B₁))`
     indexed by `B₁ ⊆ F₂` and `X ∈ NIM F₁ B₁`. Uses `mul_of'_sum_form` then
     `insertion_of'_of'` and `of'_add` to collapse to a forest sum. -/
-private theorem of'_mul_of'_nim_form (F₁ F₂ : Forest (Nonplanar α)) :
+theorem of'_mul_of'_nim_form (F₁ F₂ : Forest (Nonplanar α)) :
     (of' F₁ : GrossmanLarson R α) * of' F₂ =
       (letI : DecidableEq (Nonplanar α) := Classical.decEq _
        F₂.powerset.bind fun B₁ =>

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
@@ -244,6 +244,258 @@ theorem pairing_nondegenerate
   · exact hx
   · exact absurd hx hauts_ne
 
+/-! ### Product rule
+
+Pairing against a CK product decomposes over the two-sided sub-multiset
+splits of the first argument (`Multiset.antidiagonal`) — the
+symmetry-weighted pairing turns CK multiplication into the split
+coproduct. The combinatorial heart is the multinomial identity
+`Nonplanar.forestAutCard_add` (`Aut.lean`). Computationally validated
+(`scratch/validate_duality.lean`, V2 battery). -/
+
+/-- **Pairing product rule** (basis form):
+    `⟨W, C₁ · C₂⟩ = Σ_{W = W₁ + W₂} ⟨W₁, C₁⟩ · ⟨W₂, C₂⟩`.
+
+    Only the split `(C₁, C₂)` survives the diagonal pairing, with
+    multiplicity `count (C₁,C₂) (antidiagonal W)`; the autCard weights
+    recombine via `Nonplanar.forestAutCard_add`. -/
+theorem pairing_of'_mul_of' (W C₁ C₂ : Forest (Nonplanar α)) :
+    pairing (R := R) (ConnesKreimer.of' W)
+        (ConnesKreimer.of' C₁ * ConnesKreimer.of' C₂) =
+      ((Multiset.antidiagonal W).map (fun p =>
+        pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+        pairing (R := R) (ConnesKreimer.of' p.2) (ConnesKreimer.of' C₂))).sum := by
+  letI : DecidableEq (Forest (Nonplanar α)) := Classical.decEq _
+  -- Step 1: collapse `of' C₁ * of' C₂` to `of' (C₁ + C₂)`, then evaluate
+  -- the pairing on the diagonal.
+  rw [← ConnesKreimer.of'_add, pairing_of'_of']
+  -- Step 2: simplify each term on the RHS via `pairing_of'_of'`.
+  have h_rhs_simp :
+      ((Multiset.antidiagonal W).map (fun p =>
+          pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+          pairing (R := R) (ConnesKreimer.of' p.2) (ConnesKreimer.of' C₂))).sum =
+      ((Multiset.antidiagonal W).map (fun p =>
+          (if p.1 = C₁ then (forestAutCard p.1 : R) else 0) *
+          (if p.2 = C₂ then (forestAutCard p.2 : R) else 0))).sum := by
+    congr 1
+    refine Multiset.map_congr rfl ?_
+    intro p _
+    rw [pairing_of'_of', pairing_of'_of']
+  rw [h_rhs_simp]
+  -- Step 3: split on whether `W = C₁ + C₂` using `split_ifs` to handle the
+  -- Classical.dec instance baked into `pairing_of'_of'`.
+  by_cases hW : W = C₁ + C₂
+  · -- W = C₁ + C₂. LHS = forestAutCard W.
+    rw [if_pos hW]
+    -- Use `filter_eq'` to extract the (C₁, C₂) summand.
+    -- Each term: nonzero only when p = (C₁, C₂).
+    -- Rewrite via filter (· = (C₁,C₂)) + filter (· ≠ ...).
+    have h_partition :
+        ((Multiset.antidiagonal W).map (fun p =>
+            (if p.1 = C₁ then (forestAutCard p.1 : R) else 0) *
+            (if p.2 = C₂ then (forestAutCard p.2 : R) else 0))).sum =
+        ((((Multiset.antidiagonal W).filter (· = (C₁, C₂))).map (fun p =>
+            (if p.1 = C₁ then (forestAutCard p.1 : R) else 0) *
+            (if p.2 = C₂ then (forestAutCard p.2 : R) else 0))).sum) +
+        ((((Multiset.antidiagonal W).filter (· ≠ (C₁, C₂))).map (fun p =>
+            (if p.1 = C₁ then (forestAutCard p.1 : R) else 0) *
+            (if p.2 = C₂ then (forestAutCard p.2 : R) else 0))).sum) := by
+      rw [← Multiset.sum_add, ← Multiset.map_add]
+      congr 1
+      rw [Multiset.filter_add_not]
+    rw [h_partition]
+    -- Vanishing piece: every p ≠ (C₁, C₂) in antidiagonal W gives a 0 term.
+    have h_vanish :
+        ((((Multiset.antidiagonal W).filter (· ≠ (C₁, C₂))).map (fun p =>
+            (if p.1 = C₁ then (forestAutCard p.1 : R) else 0) *
+            (if p.2 = C₂ then (forestAutCard p.2 : R) else 0))).sum) = 0 := by
+      rw [show ((((Multiset.antidiagonal W).filter (· ≠ (C₁, C₂))).map (fun p =>
+              (if p.1 = C₁ then (forestAutCard p.1 : R) else 0) *
+              (if p.2 = C₂ then (forestAutCard p.2 : R) else 0))).sum)
+            = ((((Multiset.antidiagonal W).filter (· ≠ (C₁, C₂))).map (fun _ =>
+              (0 : R))).sum) from ?_]
+      · simp
+      refine congr_arg _ (Multiset.map_congr rfl ?_)
+      intro p hp
+      rw [Multiset.mem_filter] at hp
+      obtain ⟨hp_mem, hp_ne⟩ := hp
+      have hp_sum : p.1 + p.2 = W := Multiset.mem_antidiagonal.mp hp_mem
+      -- If p.1 = C₁ then p.1 + p.2 = W = C₁ + C₂, so p.2 = C₂, contradicting `p ≠ (C₁, C₂)`.
+      by_cases h1 : p.1 = C₁
+      · have h2 : p.2 = C₂ := by
+          have heq : p.1 + p.2 = C₁ + C₂ := hp_sum.trans hW
+          rw [h1] at heq
+          exact add_left_cancel heq
+        exact absurd (Prod.ext h1 h2) hp_ne
+      · rw [if_neg h1, zero_mul]
+    rw [h_vanish, add_zero]
+    -- Surviving piece: `filter (· = (C₁,C₂)) (antidiagonal W) = replicate (count ...) (C₁,C₂)`.
+    subst hW
+    rw [Multiset.filter_eq']
+    rw [Multiset.map_replicate, Multiset.sum_replicate]
+    -- Goal: forestAutCard (C₁+C₂) = count • ((if True then ... else 0) * (if True then ... else 0))
+    simp only [↓reduceIte]
+    rw [nsmul_eq_mul]
+    -- Goal: ↑(forestAutCard (C₁+C₂)) = ↑(count ...) * (↑(forestAutCard C₁) * ↑(forestAutCard C₂))
+    -- Use S1 cast to R.
+    have hS1 := Nonplanar.forestAutCard_add C₁ C₂
+    have hcast := congr_arg (Nat.cast (R := R)) hS1
+    push_cast at hcast
+    -- hcast : ↑count * (↑forestAutCard C₁ * ↑forestAutCard C₂) = ↑forestAutCard (C₁+C₂)
+    -- `forestAutCard` here is the GL re-export of `Nonplanar.forestAutCard`.
+    show (Nonplanar.forestAutCard (C₁ + C₂) : R) =
+        ((Multiset.count (C₁, C₂) (Multiset.antidiagonal (C₁ + C₂)) : ℕ) : R) *
+          ((Nonplanar.forestAutCard C₁ : R) * (Nonplanar.forestAutCard C₂ : R))
+    -- Decidable instances on Forest = Multiset (Nonplanar α) are unique up to
+    -- propositional equality; `convert` closes the residual.
+    convert hcast.symm using 4
+  · -- W ≠ C₁ + C₂. LHS = 0. The if uses Classical.dec (from `pairing_of'_of'`'s `letI`).
+    simp only [if_neg hW]
+    -- Every p ∈ antidiagonal W has p.1 + p.2 = W ≠ C₁ + C₂. So at every p, the term is 0.
+    symm
+    -- Rewrite the map via map_congr so each term becomes 0; then sum of all-zeros = 0.
+    have h_each_zero :
+        ((Multiset.antidiagonal W).map (fun p =>
+            (if p.1 = C₁ then (forestAutCard p.1 : R) else 0) *
+            (if p.2 = C₂ then (forestAutCard p.2 : R) else 0))).sum =
+          ((Multiset.antidiagonal W).map (fun _ => (0 : R))).sum := by
+      congr 1
+      refine Multiset.map_congr rfl ?_
+      intro p hp_mem
+      have hp_sum : p.1 + p.2 = W := Multiset.mem_antidiagonal.mp hp_mem
+      by_cases h1 : p.1 = C₁
+      · by_cases h2 : p.2 = C₂
+        · exfalso
+          apply hW
+          rw [← hp_sum, h1, h2]
+        · rw [if_pos h1, if_neg h2, mul_zero]
+      · rw [if_neg h1, zero_mul]
+    rw [h_each_zero]
+    -- Sum of all-zeros = 0.
+    simp [Multiset.map_const']
+
+/-- **Pairing product rule** (bilinear form): pairing a basis vector
+    against a product decomposes over the antidiagonal splits of the
+    basis forest. Bilinear extension of `pairing_of'_mul_of'`. -/
+theorem pairing_of'_mul (W : Forest (Nonplanar α))
+    (z₁ z₂ : ConnesKreimer R (Nonplanar α)) :
+    pairing (R := R) (ConnesKreimer.of' W) (z₁ * z₂) =
+      ((Multiset.antidiagonal W).map (fun p =>
+        pairing (R := R) (ConnesKreimer.of' p.1) z₁ *
+        pairing (R := R) (ConnesKreimer.of' p.2) z₂)).sum := by
+  -- First extend in z₂ at basis z₁, then in z₁.
+  have aux : ∀ (C₁ : Forest (Nonplanar α))
+      (z₂ : ConnesKreimer R (Nonplanar α)),
+      pairing (R := R) (ConnesKreimer.of' W)
+          (ConnesKreimer.of' C₁ * z₂) =
+        ((Multiset.antidiagonal W).map (fun p =>
+          pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+          pairing (R := R) (ConnesKreimer.of' p.2) z₂)).sum := by
+    intro C₁ z₂
+    refine Finsupp.induction_linear z₂ ?_ ?_ ?_
+    · show pairing (R := R) (ConnesKreimer.of' W)
+          (ConnesKreimer.of' C₁ * (0 : ConnesKreimer R (Nonplanar α))) =
+        ((Multiset.antidiagonal W).map (fun p =>
+          pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+          pairing (R := R) (ConnesKreimer.of' p.2)
+            (0 : ConnesKreimer R (Nonplanar α)))).sum
+      rw [mul_zero, map_zero]
+      symm
+      refine Multiset.sum_eq_zero fun r hr => ?_
+      obtain ⟨p, _, rfl⟩ := Multiset.mem_map.mp hr
+      rw [map_zero, mul_zero]
+    · intro a b iha ihb
+      let a' : ConnesKreimer R (Nonplanar α) := a
+      let b' : ConnesKreimer R (Nonplanar α) := b
+      show pairing (R := R) (ConnesKreimer.of' W)
+          (ConnesKreimer.of' C₁ * (a' + b')) =
+        ((Multiset.antidiagonal W).map (fun p =>
+          pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+          pairing (R := R) (ConnesKreimer.of' p.2) (a' + b'))).sum
+      rw [mul_add, map_add]
+      rw [show pairing (R := R) (ConnesKreimer.of' W)
+            (ConnesKreimer.of' C₁ * a') = _ from iha,
+          show pairing (R := R) (ConnesKreimer.of' W)
+            (ConnesKreimer.of' C₁ * b') = _ from ihb,
+          ← Multiset.sum_map_add]
+      refine congrArg Multiset.sum (Multiset.map_congr rfl fun p _ => ?_)
+      show pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+            pairing (R := R) (ConnesKreimer.of' p.2) a' +
+          pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+            pairing (R := R) (ConnesKreimer.of' p.2) b' = _
+      rw [map_add, mul_add]
+    · intro G s
+      let g' : ConnesKreimer R (Nonplanar α) := Finsupp.single G s
+      have hsingle : g' = s • (ConnesKreimer.of' (R := R) G) := by
+        show (Finsupp.single G s : ConnesKreimer R (Nonplanar α)) =
+            s • (Finsupp.single G 1 : ConnesKreimer R (Nonplanar α))
+        exact (Finsupp.smul_single_one G s).symm
+      show pairing (R := R) (ConnesKreimer.of' W)
+          (ConnesKreimer.of' C₁ * g') =
+        ((Multiset.antidiagonal W).map (fun p =>
+          pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+          pairing (R := R) (ConnesKreimer.of' p.2) g')).sum
+      rw [hsingle, mul_smul_comm, map_smul, smul_eq_mul,
+          pairing_of'_mul_of' W C₁ G]
+      rw [show ((Multiset.antidiagonal W).map (fun p =>
+            pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+            pairing (R := R) (ConnesKreimer.of' p.2)
+              (s • ConnesKreimer.of' (R := R) G))) =
+          ((Multiset.antidiagonal W).map (fun p => s *
+            (pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+             pairing (R := R) (ConnesKreimer.of' p.2) (ConnesKreimer.of' G)))) from
+        Multiset.map_congr rfl fun p _ => by rw [map_smul, smul_eq_mul]; ring]
+      rw [Multiset.sum_map_mul_left]
+  refine Finsupp.induction_linear z₁ ?_ ?_ ?_
+  · show pairing (R := R) (ConnesKreimer.of' W)
+        ((0 : ConnesKreimer R (Nonplanar α)) * z₂) =
+      ((Multiset.antidiagonal W).map (fun p =>
+        pairing (R := R) (ConnesKreimer.of' p.1)
+          (0 : ConnesKreimer R (Nonplanar α)) *
+        pairing (R := R) (ConnesKreimer.of' p.2) z₂)).sum
+    rw [zero_mul, map_zero]
+    symm
+    refine Multiset.sum_eq_zero fun r hr => ?_
+    obtain ⟨p, _, rfl⟩ := Multiset.mem_map.mp hr
+    rw [map_zero, zero_mul]
+  · intro a b iha ihb
+    let a' : ConnesKreimer R (Nonplanar α) := a
+    let b' : ConnesKreimer R (Nonplanar α) := b
+    show pairing (R := R) (ConnesKreimer.of' W) ((a' + b') * z₂) =
+      ((Multiset.antidiagonal W).map (fun p =>
+        pairing (R := R) (ConnesKreimer.of' p.1) (a' + b') *
+        pairing (R := R) (ConnesKreimer.of' p.2) z₂)).sum
+    rw [add_mul, map_add]
+    rw [show pairing (R := R) (ConnesKreimer.of' W) (a' * z₂) = _ from iha,
+        show pairing (R := R) (ConnesKreimer.of' W) (b' * z₂) = _ from ihb,
+        ← Multiset.sum_map_add]
+    refine congrArg Multiset.sum (Multiset.map_congr rfl fun p _ => ?_)
+    show pairing (R := R) (ConnesKreimer.of' p.1) a' *
+          pairing (R := R) (ConnesKreimer.of' p.2) z₂ +
+        pairing (R := R) (ConnesKreimer.of' p.1) b' *
+          pairing (R := R) (ConnesKreimer.of' p.2) z₂ = _
+    rw [map_add, add_mul]
+  · intro F r
+    let f' : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+    have hsingle : f' = r • (ConnesKreimer.of' (R := R) F) := by
+      show (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
+          r • (Finsupp.single F 1 : ConnesKreimer R (Nonplanar α))
+      exact (Finsupp.smul_single_one F r).symm
+    show pairing (R := R) (ConnesKreimer.of' W) (f' * z₂) =
+      ((Multiset.antidiagonal W).map (fun p =>
+        pairing (R := R) (ConnesKreimer.of' p.1) f' *
+        pairing (R := R) (ConnesKreimer.of' p.2) z₂)).sum
+    rw [hsingle, smul_mul_assoc, map_smul, smul_eq_mul, aux F z₂]
+    rw [show ((Multiset.antidiagonal W).map (fun p =>
+          pairing (R := R) (ConnesKreimer.of' p.1)
+            (r • ConnesKreimer.of' (R := R) F) *
+          pairing (R := R) (ConnesKreimer.of' p.2) z₂)) =
+        ((Multiset.antidiagonal W).map (fun p => r *
+          (pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' F) *
+           pairing (R := R) (ConnesKreimer.of' p.2) z₂))) from
+      Multiset.map_congr rfl fun p _ => by rw [map_smul, smul_eq_mul]; ring]
+    rw [Multiset.sum_map_mul_left]
+
 end GrossmanLarson
 
 end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonSplit.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonSplit.lean
@@ -1,0 +1,1043 @@
+import Linglib.Core.Algebra.RootedTree.GrossmanLarsonAssoc
+import Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing
+
+set_option autoImplicit false
+
+/-!
+# The split coproduct side of GL/CK duality
+[foissy-2002] [oudom-guin-2008]
+
+Two combinatorial laws connecting the Grossman-Larson product to the
+sub-multiset ("split") decomposition of forests, the substrate for the
+GL/CK duality theorem `pairing_gl_eq_pairing_coproduct_Rho`
+(`Coproduct/PruningDuality.lean`):
+
+* `Nonplanar.insertionMultiset_antidiagonal` — splits of a multi-graft
+  output factor through splits of host and guests (each guest follows
+  its host component). The multi-graft counterpart of
+  `insertionMultiset_add_host`, from which it is proved by induction
+  on the host.
+* `pairing_product_of'_mul_of'` — the GL-product/CK-product duality at
+  the pairing level: `⟨A ⋆ B, C₁ · C₂⟩` decomposes over independent
+  splits of `A` and `B`. Combines the insertion split law with the
+  pairing product rule `pairing_of'_mul` (`GrossmanLarsonPairing.lean`).
+
+Both statements are computationally validated against the planar
+simulation harness (`scratch/validate_duality.lean`, V3/V3b batteries,
+exhaustive over forests of weight ≤ 3 plus duplicate-tree traps).
+-/
+
+namespace RootedTree
+
+namespace GrossmanLarson
+
+open ConnesKreimer
+
+variable {R : Type*} [CommSemiring R] {α : Type*}
+
+/-! ### Helper lemmas
+
+A few small multiset/insertion building blocks used by both targets below.
+-/
+
+/-- `Multiset.antidiagonal` of a singleton: `antidiag {a} = {(0, {a}), ({a}, 0)}`.
+    Follows from `antidiagonal_cons` + `antidiagonal_zero`. -/
+private theorem antidiagonal_singleton {β : Type*} (a : β) :
+    Multiset.antidiagonal ({a} : Multiset β) =
+      ({(0, {a}), ({a}, 0)} : Multiset (Multiset β × Multiset β)) := by
+  show Multiset.antidiagonal (a ::ₘ (0 : Multiset β)) = _
+  rw [Multiset.antidiagonal_cons, Multiset.antidiagonal_zero]
+  simp [Multiset.map_singleton, Prod.map]
+
+/-- A `NIM {T} G` output is always a singleton forest (card 1). This is the
+    `Nonplanar.insertionMultiset_card_eq` specialization to a singleton host. -/
+private theorem insertionMultiset_singleton_host_singleton
+    (T : Nonplanar α) (G : Multiset (Nonplanar α))
+    {X : Multiset (Nonplanar α)} (hX : X ∈ Nonplanar.insertionMultiset {T} G) :
+    ∃ T' : Nonplanar α, X = {T'} := by
+  have hcard : X.card = ({T} : Multiset (Nonplanar α)).card :=
+    Nonplanar.insertionMultiset_card_eq {T} G hX
+  rw [Multiset.card_singleton] at hcard
+  exact Multiset.card_eq_one.mp hcard
+
+/-- **Triple-partition reindexing** (`[UPSTREAM]` candidate): two equivalent
+    enumerations of ordered triple-partitions of a multiset `G`. The
+    "powerset-then-antidiagonal" enumeration (pick `G₁ ⊆ G`, then split
+    `G - G₁`) equals the "antidiagonal-then-powerset" enumeration (split
+    `G`, then pick `G₂ ⊆` second part of the split), under the bijection
+    `(G₁, pg'.1, pg'.2) ↔ (pg.1, G₂, pg.2 - G₂)` where `G₂ = G₁`,
+    `pg.1 = pg'.1`, `pg.2 = G₁ + pg'.2`.
+
+    Reduces to `Multiset.powerset_powerset_pair_swap` (Shuffle.lean) after
+    converting both `antidiagonal` factors to `powerset.map` form via
+    `antidiagonal_eq_map_powerset` and identifying the inner bind as `f`
+    applied to the implicit third-part `G - G₁ - S`.
+
+    Used by `insertionMultiset_antidiagonal` to align the LHS structure
+    (one host tree peeled, free guest split, A' substructure split) with
+    the RHS structure (A split, G split, free guest sub-split). -/
+private theorem triple_partition_reindex {β γ : Type*} [DecidableEq β]
+    (G : Multiset β)
+    (f : Multiset β → Multiset β → Multiset β → Multiset γ) :
+    (G.powerset.bind fun G₁ =>
+        (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+          f G₁ pg'.1 pg'.2) =
+      (Multiset.antidiagonal G).bind fun pg =>
+        pg.2.powerset.bind fun G₂ =>
+          f G₂ pg.1 (pg.2 - G₂) := by
+  -- Step 1: Reformulate LHS as a `(pair-enum).bind h` where `h (a, b) := f a (G - a - b) b`.
+  -- Use `antidiagonal_eq_map_powerset` to turn `antidiag (G - G₁)` into
+  -- `(G - G₁).powerset.map (S ↦ ((G - G₁) - S, S))`.
+  set h : Multiset β × Multiset β → Multiset γ :=
+    fun p => f p.1 (G - p.1 - p.2) p.2 with h_def
+  have h_lhs : (G.powerset.bind fun G₁ =>
+            (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+              f G₁ pg'.1 pg'.2) =
+        (G.powerset.bind fun G₁ =>
+          (G - G₁).powerset.map (fun B => (G₁, B))).bind h := by
+    rw [Multiset.bind_assoc]
+    refine Multiset.bind_congr fun G₁ _ => ?_
+    rw [Multiset.antidiagonal_eq_map_powerset, Multiset.bind_map, Multiset.bind_map]
+  -- Step 2: Reformulate RHS similarly.
+  have h_rhs : (Multiset.antidiagonal G).bind (fun pg =>
+            pg.2.powerset.bind (fun G₂ =>
+              f G₂ pg.1 (pg.2 - G₂))) =
+        (G.powerset.bind fun F₁ =>
+          F₁.powerset.map (fun A => (A, F₁ - A))).bind h := by
+    -- RHS uses antidiag G, the second coord pg.2 indexes the bind. By antidiag_eq_map_powerset
+    -- with t ↦ (G - t, t), pg = (G - pg.2, pg.2). Set T = pg.2. Then pg.1 = G - T.
+    rw [Multiset.antidiagonal_eq_map_powerset, Multiset.bind_map]
+    rw [Multiset.bind_assoc]
+    refine Multiset.bind_congr fun T hT => ?_
+    rw [Multiset.bind_map]
+    refine Multiset.bind_congr fun G₂ hG₂ => ?_
+    -- Goal: f G₂ (G - T) (T - G₂) = h (G₂, T - G₂) = f G₂ (G - G₂ - (T - G₂)) (T - G₂).
+    -- Need: G - G₂ - (T - G₂) = G - T. Since G₂ ⊆ T ⊆ G, use tsub_tsub + add identities.
+    have hG₂_le : G₂ ≤ T := Multiset.mem_powerset.mp hG₂
+    have hT_le : T ≤ G := Multiset.mem_powerset.mp hT
+    show f G₂ (G - T) (T - G₂) = f G₂ (G - G₂ - (T - G₂)) (T - G₂)
+    congr 1
+    -- G - G₂ - (T - G₂) = G - (G₂ + (T - G₂)) = G - T (using G₂ + (T - G₂) = T from add_tsub_cancel_of_le).
+    rw [tsub_tsub, add_tsub_cancel_of_le hG₂_le]
+  rw [h_lhs, h_rhs, Multiset.powerset_powerset_pair_swap]
+
+/-- **Triple-partition reindexing (flipped)**: variant of
+    `triple_partition_reindex` where the second-level powerset goes through
+    the *first* coordinate of the antidiagonal instead of the second.
+
+    Bijection: `(G₁, pg'.1, pg'.2) ↔ (G₂, pg.1 - G₂, pg.2)` where `G₂ = G₁`,
+    `pg.1 = G₁ + pg'.1`, `pg.2 = pg'.2`.
+
+    Derived from `triple_partition_reindex` via `Multiset.antidiagonal_swap`. -/
+private theorem triple_partition_reindex_flip {β γ : Type*} [DecidableEq β]
+    (G : Multiset β)
+    (f : Multiset β → Multiset β → Multiset β → Multiset γ) :
+    (G.powerset.bind fun G₁ =>
+        (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+          f G₁ pg'.1 pg'.2) =
+      (Multiset.antidiagonal G).bind fun pg =>
+        pg.1.powerset.bind fun G₂ =>
+          f G₂ (pg.1 - G₂) pg.2 := by
+  -- Reindex the inner `antidiag (G - G₁)` via `antidiagonal_swap` to switch pg'.1 ↔ pg'.2,
+  -- then apply `triple_partition_reindex` with f's arguments shifted.
+  -- LHS = G.powerset.bind (G₁ ↦ ((antidiag (G - G₁)).map swap).bind (pg' ↦ f G₁ pg'.2 pg'.1))
+  --     [using antidiag_swap to expose pg.swap]
+  -- = G.powerset.bind (G₁ ↦ antidiag (G - G₁).bind (pg' ↦ f G₁ pg'.2 pg'.1))
+  --     [the swap.bind absorbed into pg'.swap]
+  -- Now apply triple_partition_reindex with f' G₁ x y := f G₁ y x.
+  -- Define helper function with swapped 2nd/3rd args.
+  set g : Multiset β → Multiset β → Multiset β → Multiset γ :=
+    fun a b c => f a c b with g_def
+  -- LHS: original form (using f).
+  -- Goal: ... = antidiag G.bind (pg ↦ pg.1.powerset.bind (G₂ ↦ f G₂ (pg.1 - G₂) pg.2))
+  -- Rewrite LHS as g G₁ pg'.2 pg'.1 (= f G₁ pg'.1 pg'.2 by def of g).
+  have h_lhs : (G.powerset.bind fun G₁ =>
+            (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+              f G₁ pg'.1 pg'.2) =
+        G.powerset.bind fun G₁ =>
+          ((Multiset.antidiagonal (G - G₁)).map Prod.swap).bind fun pg' =>
+            g G₁ pg'.1 pg'.2 := by
+    refine Multiset.bind_congr fun G₁ _ => ?_
+    rw [Multiset.bind_map]
+    refine Multiset.bind_congr fun pg' _ => ?_
+    rfl
+  rw [h_lhs]
+  -- Use antidiag_swap to absorb the .map Prod.swap.
+  simp_rw [Multiset.antidiagonal_swap]
+  -- Now LHS is `G.powerset.bind (G₁ ↦ antidiag (G - G₁).bind (pg' ↦ g G₁ pg'.1 pg'.2))`.
+  rw [triple_partition_reindex G g]
+  -- Goal: antidiag G.bind (pg ↦ pg.2.powerset.bind (G₂ ↦ g G₂ pg.1 (pg.2 - G₂)))
+  --     = antidiag G.bind (pg ↦ pg.1.powerset.bind (G₂ ↦ f G₂ (pg.1 - G₂) pg.2))
+  -- g G₂ pg.1 (pg.2 - G₂) = f G₂ (pg.2 - G₂) pg.1. Use antidiag_swap to flip pg.
+  conv_lhs => rw [show Multiset.antidiagonal G =
+      (Multiset.antidiagonal G).map Prod.swap from (Multiset.antidiagonal_swap G).symm]
+  rw [Multiset.bind_map]
+  refine Multiset.bind_congr fun pg _ => ?_
+  -- After swap: (Prod.swap pg).2 = pg.1, (Prod.swap pg).1 = pg.2. So:
+  --   g G₂ (Prod.swap pg).1 ((Prod.swap pg).2 - G₂) = g G₂ pg.2 (pg.1 - G₂)
+  --                                                 = f G₂ (pg.1 - G₂) pg.2.
+  rfl
+
+/-- Antidiagonal of `(X_T + X_A')` where `X_T` is a singleton multiset
+    `{T'}`: by `antidiagonal_add` + `antidiagonal_singleton`, the result
+    splits into two summands "T' joins right" + "T' joins left". -/
+private theorem antidiagonal_singleton_add {β : Type*} (T' : β) (Y : Multiset β) :
+    Multiset.antidiagonal (({T'} : Multiset β) + Y) =
+      (Multiset.antidiagonal Y).map (fun pA' => (pA'.1, ({T'} : Multiset β) + pA'.2)) +
+      (Multiset.antidiagonal Y).map (fun pA' => (({T'} : Multiset β) + pA'.1, pA'.2)) := by
+  letI : DecidableEq β := Classical.decEq _
+  rw [Multiset.antidiagonal_add, antidiagonal_singleton]
+  show ({(0, {T'}), ({T'}, 0)} :
+            Multiset (Multiset β × Multiset β)).bind (fun pT =>
+        (Multiset.antidiagonal Y).map (fun pA' => (pT.1 + pA'.1, pT.2 + pA'.2))) = _
+  -- {(0,{T'}), ({T'},0)}.bind f = f (0,{T'}) + f ({T'},0)
+  rw [show ({(0, {T'}), ({T'}, 0)} : Multiset (Multiset β × Multiset β)) =
+        (0, ({T'} : Multiset β)) ::ₘ (({T'} : Multiset β), 0) ::ₘ 0 from rfl,
+      Multiset.cons_bind, Multiset.cons_bind, Multiset.zero_bind, add_zero]
+  -- Now compute each .map by 0 + x = x.
+  congr 1
+  · apply Multiset.map_congr rfl
+    intro pA' _
+    show ((0 : Multiset β) + pA'.1, ({T'} : Multiset β) + pA'.2) =
+         (pA'.1, ({T'} : Multiset β) + pA'.2)
+    rw [zero_add]
+  · apply Multiset.map_congr rfl
+    intro pA' _
+    show (({T'} : Multiset β) + pA'.1, (0 : Multiset β) + pA'.2) =
+         (({T'} : Multiset β) + pA'.1, pA'.2)
+    rw [zero_add]
+
+/-! ### Split law for multi-graft outputs -/
+
+/-- **Splits of an insertion output factor through splits of host and
+    guests.** Each component of a multi-graft output `X ∈ NIM(A, G)` is
+    one host component of `A` carrying the guests grafted into it, so a
+    sub-multiset split of `X` induces a split of `A` and a split of `G`
+    (guests follow their host), and the correspondence is
+    multiplicity-faithful:
+
+    `Σ_{X ∈ NIM(A,G)} Σ_{X = X₁ + X₂} (X₁, X₂)
+       = Σ_{A = A₁+A₂} Σ_{G = G₁+G₂} NIM(A₁,G₁) ×ˢ NIM(A₂,G₂)`.
+
+    Proved by induction on `A` from `insertionMultiset_add_host`
+    (peeling one host tree; `NIM({T}, G)` outputs are singleton
+    forests, whose antidiagonal is the trivial two-way split). -/
+theorem _root_.RootedTree.Nonplanar.insertionMultiset_antidiagonal
+    (A G : Forest (Nonplanar α)) :
+    (Nonplanar.insertionMultiset A G).bind Multiset.antidiagonal =
+      (Multiset.antidiagonal A).bind (fun pa =>
+        (Multiset.antidiagonal G).bind (fun pg =>
+          (Nonplanar.insertionMultiset pa.1 pg.1) ×ˢ
+            (Nonplanar.insertionMultiset pa.2 pg.2))) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  induction A using Multiset.induction_on generalizing G with
+  | empty =>
+    -- A = 0. Case on G.
+    rw [Multiset.antidiagonal_zero, Multiset.singleton_bind]
+    by_cases hG : G = 0
+    · -- G = 0: NIM 0 0 = {0}, antidiag 0 = {(0,0)}. RHS = NIM 0 0 ×ˢ NIM 0 0 = {(0,0)}.
+      subst hG
+      rw [Nonplanar.insertionMultiset_zero_right, Multiset.singleton_bind,
+          Multiset.antidiagonal_zero, Multiset.singleton_bind,
+          Nonplanar.insertionMultiset_zero_right]
+      rfl
+    · -- G ≠ 0: LHS = (NIM 0 G).bind antidiag = 0.bind = 0. RHS: each pg has at least one nonzero side.
+      rw [Nonplanar.insertionMultiset_zero_left_of_ne_zero G hG, Multiset.zero_bind]
+      -- RHS: prove the bind is 0 by showing each summand is 0.
+      symm
+      have h_rhs_eq :
+          (Multiset.antidiagonal G).bind (fun pg =>
+              (Nonplanar.insertionMultiset 0 pg.1) ×ˢ
+              (Nonplanar.insertionMultiset 0 pg.2)) =
+          (Multiset.antidiagonal G).bind (fun _ => (0 : Multiset (Multiset (Nonplanar α) ×
+            Multiset (Nonplanar α)))) := by
+        refine Multiset.bind_congr fun pg hpg => ?_
+        have hpg_sum : pg.1 + pg.2 = G := Multiset.mem_antidiagonal.mp hpg
+        by_cases h1 : pg.1 = 0
+        · -- pg.1 = 0 ⇒ pg.2 = G ≠ 0.
+          have h2 : pg.2 ≠ 0 := by
+            intro h2eq
+            apply hG
+            rw [← hpg_sum, h1, h2eq]; rfl
+          rw [Nonplanar.insertionMultiset_zero_left_of_ne_zero pg.2 h2,
+              Multiset.product_zero]
+        · rw [Nonplanar.insertionMultiset_zero_left_of_ne_zero pg.1 h1,
+              Multiset.zero_product]
+      rw [h_rhs_eq, Multiset.bind_zero]
+  | cons T A' ih =>
+    -- A = T ::ₘ A' = {T} + A'.
+    have h_cons_eq : (T ::ₘ A' : Multiset (Nonplanar α)) = ({T} : Multiset _) + A' := by
+      rw [Multiset.singleton_add]
+    -- Step 1: Rewrite LHS via insertionMultiset_add_host.
+    rw [h_cons_eq, Nonplanar.insertionMultiset_add_host {T} A' G]
+    -- LHS = (G.powerset.bind (G₁ ↦ (NIM {T} G₁ ×ˢ NIM A' (G-G₁)).map (·.1+·.2))).bind antidiag
+    rw [Multiset.bind_assoc]
+    -- LHS = G.powerset.bind (G₁ ↦ ((NIM {T} G₁ ×ˢ NIM A' (G-G₁)).map (·.1+·.2)).bind antidiag)
+    -- Step 2: Push antidiag through the .map ↦ bind, expand antidiag (X_T + X_A')
+    -- via antidiagonal_singleton_add (since X_T is a singleton).
+    have h_lhs_inner : ∀ G₁ : Multiset (Nonplanar α),
+        (((Nonplanar.insertionMultiset {T} G₁) ×ˢ
+            (Nonplanar.insertionMultiset A' (G - G₁))).map
+            (fun p => p.1 + p.2)).bind Multiset.antidiagonal =
+        ((Nonplanar.insertionMultiset {T} G₁).bind fun X_T =>
+            (Nonplanar.insertionMultiset A' (G - G₁)).bind fun X_A' =>
+              (Multiset.antidiagonal X_A').map
+                  (fun pA' => (pA'.1, X_T + pA'.2)) +
+              (Multiset.antidiagonal X_A').map
+                  (fun pA' => (X_T + pA'.1, pA'.2))) := by
+      intro G₁
+      -- LHS_inner: bind . map = map then bind = ... apply antidiagonal_singleton_add per X_T.
+      rw [Multiset.bind_map]
+      -- Goal: (NIM {T} G₁ ×ˢ NIM A' (G-G₁)).bind (p ↦ antidiag (p.1 + p.2)) = (NIM {T} G₁).bind ...
+      -- Unfold ×ˢ as bind.
+      show ((Nonplanar.insertionMultiset {T} G₁).bind (fun X_T =>
+              (Nonplanar.insertionMultiset A' (G - G₁)).map (Prod.mk X_T))).bind
+                (fun p => Multiset.antidiagonal (p.1 + p.2)) = _
+      rw [Multiset.bind_assoc]
+      refine Multiset.bind_congr fun X_T hX_T => ?_
+      rw [Multiset.bind_map]
+      refine Multiset.bind_congr fun X_A' hX_A' => ?_
+      -- Each X_T is a singleton {T'}. Apply antidiagonal_singleton_add.
+      obtain ⟨T', hT'⟩ := insertionMultiset_singleton_host_singleton T G₁ hX_T
+      subst hT'
+      exact antidiagonal_singleton_add T' X_A'
+    rw [show (G.powerset.bind fun G₁ =>
+            (((Nonplanar.insertionMultiset {T} G₁) ×ˢ
+                (Nonplanar.insertionMultiset A' (G - G₁))).map
+                (fun p => p.1 + p.2)).bind Multiset.antidiagonal) =
+          G.powerset.bind fun G₁ =>
+            ((Nonplanar.insertionMultiset {T} G₁).bind fun X_T =>
+                (Nonplanar.insertionMultiset A' (G - G₁)).bind fun X_A' =>
+                  (Multiset.antidiagonal X_A').map
+                      (fun pA' => (pA'.1, X_T + pA'.2)) +
+                  (Multiset.antidiagonal X_A').map
+                      (fun pA' => (X_T + pA'.1, pA'.2)))
+        from Multiset.bind_congr (fun G₁ _ => h_lhs_inner G₁)]
+    -- Step 3: Split LHS into two summands (T-right + T-left) using bind_add via map_add and sum_add.
+    -- Strategy: each inner sum splits via bind_congr.
+    have h_split_inner : ∀ G₁ : Multiset (Nonplanar α),
+        ((Nonplanar.insertionMultiset {T} G₁).bind fun X_T =>
+            (Nonplanar.insertionMultiset A' (G - G₁)).bind fun X_A' =>
+              (Multiset.antidiagonal X_A').map
+                  (fun pA' => (pA'.1, X_T + pA'.2)) +
+              (Multiset.antidiagonal X_A').map
+                  (fun pA' => (X_T + pA'.1, pA'.2))) =
+        ((Nonplanar.insertionMultiset {T} G₁).bind fun X_T =>
+            (Nonplanar.insertionMultiset A' (G - G₁)).bind fun X_A' =>
+              (Multiset.antidiagonal X_A').map
+                  (fun pA' => (pA'.1, X_T + pA'.2))) +
+        ((Nonplanar.insertionMultiset {T} G₁).bind fun X_T =>
+            (Nonplanar.insertionMultiset A' (G - G₁)).bind fun X_A' =>
+              (Multiset.antidiagonal X_A').map
+                  (fun pA' => (X_T + pA'.1, pA'.2))) := by
+      intro G₁
+      -- Split each X_A' bind summand and each X_T bind summand.
+      rw [← Multiset.bind_add]
+      refine Multiset.bind_congr fun X_T _ => ?_
+      rw [← Multiset.bind_add]
+    rw [show (G.powerset.bind fun G₁ =>
+            (Nonplanar.insertionMultiset {T} G₁).bind fun X_T =>
+              (Nonplanar.insertionMultiset A' (G - G₁)).bind fun X_A' =>
+                (Multiset.antidiagonal X_A').map
+                    (fun pA' => (pA'.1, X_T + pA'.2)) +
+                (Multiset.antidiagonal X_A').map
+                    (fun pA' => (X_T + pA'.1, pA'.2))) =
+          (G.powerset.bind fun G₁ =>
+            (Nonplanar.insertionMultiset {T} G₁).bind fun X_T =>
+              (Nonplanar.insertionMultiset A' (G - G₁)).bind fun X_A' =>
+                (Multiset.antidiagonal X_A').map
+                    (fun pA' => (pA'.1, X_T + pA'.2))) +
+          (G.powerset.bind fun G₁ =>
+            (Nonplanar.insertionMultiset {T} G₁).bind fun X_T =>
+              (Nonplanar.insertionMultiset A' (G - G₁)).bind fun X_A' =>
+                (Multiset.antidiagonal X_A').map
+                    (fun pA' => (X_T + pA'.1, pA'.2)))
+        from by
+      rw [← Multiset.bind_add]
+      exact Multiset.bind_congr (fun G₁ _ => h_split_inner G₁)]
+    -- Step 4: Now rewrite RHS via antidiagonal_cons split into T-right + T-left summands.
+    rw [show (Multiset.antidiagonal ({T} + A' : Multiset (Nonplanar α))) =
+            Multiset.antidiagonal (T ::ₘ A') from by rw [← h_cons_eq],
+        Multiset.antidiagonal_cons]
+    -- RHS: antidiag (T ::ₘ A') = antidiag A'.map (Prod.map id (cons T)) + antidiag A'.map (Prod.map (cons T) id)
+    rw [Multiset.add_bind]
+    -- RHS = RHS_T_right_old + RHS_T_left_old
+    -- The two map-binds become bind-(after rebrand).
+    rw [Multiset.bind_map, Multiset.bind_map]
+    -- Goal: (LHS_T_right + LHS_T_left) = (RHS_T_right + RHS_T_left)
+    -- We'll match LHS_T_right ↔ RHS_T_right (T on right side of pair) and similarly for left.
+    congr 1
+    · -- Match T-right: pair has X_T on .2.
+      -- Strategy: massage both LHS_T_right and RHS_T_right into a common form
+      --   "antidiag A'.bind (pa' ↦ (NIM A').bind X_A' ↦ antidiag X_A' .bind (...) ...)"
+      -- via IH on the LHS and `insertionMultiset_add_host` on the RHS, then apply
+      -- `triple_partition_reindex` to align the G-indexing.
+      -- 1) Reorder LHS_T_right using bind_map_comm to expose `antidiag (NIM A' (G-G₁)).bind`.
+      rw [show (G.powerset.bind fun G₁ =>
+              (Nonplanar.insertionMultiset {T} G₁).bind fun X_T =>
+                (Nonplanar.insertionMultiset A' (G - G₁)).bind fun X_A' =>
+                  (Multiset.antidiagonal X_A').map (fun pA' => (pA'.1, X_T + pA'.2))) =
+            (G.powerset.bind fun G₁ =>
+              ((Nonplanar.insertionMultiset A' (G - G₁)).bind Multiset.antidiagonal).bind
+                fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                  fun X_T => (pA'.1, X_T + pA'.2)) from by
+        refine Multiset.bind_congr fun G₁ _ => ?_
+        rw [Multiset.bind_assoc]
+        rw [Multiset.bind_bind]
+        refine Multiset.bind_congr fun X_A' _ => ?_
+        rw [Multiset.bind_map_comm]]
+      -- 2) Apply IH on (NIM A' (G - G₁)).bind antidiag.
+      rw [show (G.powerset.bind fun G₁ =>
+              ((Nonplanar.insertionMultiset A' (G - G₁)).bind Multiset.antidiagonal).bind
+                fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                  fun X_T => (pA'.1, X_T + pA'.2)) =
+            (G.powerset.bind fun G₁ =>
+              ((Multiset.antidiagonal A').bind fun pa' =>
+                (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+                  (Nonplanar.insertionMultiset pa'.1 pg'.1) ×ˢ
+                    (Nonplanar.insertionMultiset pa'.2 pg'.2)).bind
+                fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                  fun X_T => (pA'.1, X_T + pA'.2)) from by
+        refine Multiset.bind_congr fun G₁ _ => ?_
+        rw [ih (G - G₁)]]
+      -- 3) Pull the binds inside via bind_assoc.
+      rw [show (G.powerset.bind fun G₁ =>
+              ((Multiset.antidiagonal A').bind fun pa' =>
+                (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+                  (Nonplanar.insertionMultiset pa'.1 pg'.1) ×ˢ
+                    (Nonplanar.insertionMultiset pa'.2 pg'.2)).bind
+                fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                  fun X_T => (pA'.1, X_T + pA'.2)) =
+            (G.powerset.bind fun G₁ =>
+              (Multiset.antidiagonal A').bind fun pa' =>
+                (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+                  ((Nonplanar.insertionMultiset pa'.1 pg'.1) ×ˢ
+                      (Nonplanar.insertionMultiset pa'.2 pg'.2)).bind
+                    fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                      fun X_T => (pA'.1, X_T + pA'.2)) from by
+        refine Multiset.bind_congr fun G₁ _ => ?_
+        rw [Multiset.bind_assoc]
+        refine Multiset.bind_congr fun pa' _ => ?_
+        rw [Multiset.bind_assoc]]
+      -- 4) Reorder G₁ and pa' binds (swap G.powerset and antidiag A').
+      rw [show (G.powerset.bind fun G₁ =>
+              (Multiset.antidiagonal A').bind fun pa' =>
+                (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+                  ((Nonplanar.insertionMultiset pa'.1 pg'.1) ×ˢ
+                      (Nonplanar.insertionMultiset pa'.2 pg'.2)).bind
+                    fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                      fun X_T => (pA'.1, X_T + pA'.2)) =
+            (Multiset.antidiagonal A').bind fun pa' =>
+              G.powerset.bind fun G₁ =>
+                (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+                  ((Nonplanar.insertionMultiset pa'.1 pg'.1) ×ˢ
+                      (Nonplanar.insertionMultiset pa'.2 pg'.2)).bind
+                    fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                      fun X_T => (pA'.1, X_T + pA'.2)
+        from Multiset.bind_bind _ _]
+      -- 5) Apply triple_partition_reindex on the G.powerset / antidiag (G - G₁) layer.
+      refine Multiset.bind_congr fun pa' _ => ?_
+      rw [triple_partition_reindex G
+        (fun G₁ x y =>
+          ((Nonplanar.insertionMultiset pa'.1 x) ×ˢ
+              (Nonplanar.insertionMultiset pa'.2 y)).bind
+            (fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+              fun X_T => (pA'.1, X_T + pA'.2)))]
+      -- 6) Now LHS form matches RHS form (with bind_bind for G₂/X_T to T ::ₘ pa'.2 NIM).
+      -- The RHS form (after bind_map): antidiag G.bind (pg ↦
+      --   NIM pa'.1 pg.1 ×ˢ NIM (T ::ₘ pa'.2) pg.2).
+      -- Compare with our current LHS form: antidiag G.bind (pg ↦ pg.2.powerset.bind (G₂ ↦ ...))
+      refine Multiset.bind_congr fun pg _ => ?_
+      -- RHS at this position: NIM pa'.1 pg.1 ×ˢ NIM (T ::ₘ pa'.2) pg.2 (after Prod.map id (cons T)).
+      -- The Prod.map id (cons T) pa' has fst = pa'.1 and snd = T ::ₘ pa'.2 = {T} + pa'.2.
+      -- Apply insertionMultiset_add_host on the RHS to peel {T} from the second argument.
+      have h_prod_map_id : (Prod.map (id : Multiset (Nonplanar α) → _) (Multiset.cons T) pa') =
+          (pa'.1, T ::ₘ pa'.2) := rfl
+      rw [h_prod_map_id]
+      show (pg.2.powerset.bind fun G₂ =>
+              ((Nonplanar.insertionMultiset pa'.1 pg.1) ×ˢ
+                  (Nonplanar.insertionMultiset pa'.2 (pg.2 - G₂))).bind
+                (fun pA' => (Nonplanar.insertionMultiset {T} G₂).map
+                  fun X_T => (pA'.1, X_T + pA'.2))) =
+            (Nonplanar.insertionMultiset pa'.1 pg.1) ×ˢ
+              (Nonplanar.insertionMultiset (T ::ₘ pa'.2) pg.2)
+      -- Apply insertionMultiset_add_host to NIM (T ::ₘ pa'.2) pg.2.
+      rw [show (T ::ₘ pa'.2 : Multiset (Nonplanar α)) = ({T} : Multiset _) + pa'.2 from
+            (Multiset.singleton_add T pa'.2).symm,
+          Nonplanar.insertionMultiset_add_host {T} pa'.2 pg.2]
+      -- RHS: NIM pa'.1 pg.1 ×ˢ (pg.2.powerset.bind (G₂ ↦ (NIM {T} G₂ ×ˢ NIM pa'.2 (pg.2-G₂)).map (·.1+·.2)))
+      -- Need: pg.2.powerset.bind LHS_inner = NIM pa'.1 pg.1 ×ˢ (pg.2.powerset.bind RHS_inner_form).
+      -- Use s ×ˢ (t.bind f) = t.bind (b ↦ s ×ˢ f b).
+      rw [show ∀ s : Multiset (Multiset (Nonplanar α)),
+              ∀ tt : Multiset (Nonplanar α) → Multiset (Multiset (Nonplanar α)),
+                s ×ˢ (pg.2.powerset.bind tt) =
+                  pg.2.powerset.bind (fun G₂ => s ×ˢ tt G₂) from ?_]
+      · refine Multiset.bind_congr fun G₂ _ => ?_
+        -- Goal: ((NIM pa'.1 pg.1) ×ˢ NIM pa'.2 (pg.2-G₂)).bind (pA' ↦ NIM {T} G₂.map (X_T ↦ (pA'.1, X_T + pA'.2)))
+        --     = NIM pa'.1 pg.1 ×ˢ ((NIM {T} G₂ ×ˢ NIM pa'.2 (pg.2-G₂)).map (·.1+·.2))
+        -- Both sides describe pairs (Y₁, X_T + Y₂) for (Y₁, Y₂, X_T) ∈
+        -- NIM pa'.1 pg.1 × NIM pa'.2 (pg.2-G₂) × NIM {T} G₂.
+        -- Unfold ×ˢ as bind on both sides.
+        show ((Nonplanar.insertionMultiset pa'.1 pg.1).bind (fun Y₁ =>
+              (Nonplanar.insertionMultiset pa'.2 (pg.2 - G₂)).map (Prod.mk Y₁))).bind
+                (fun pA' => (Nonplanar.insertionMultiset {T} G₂).map
+                  fun X_T => (pA'.1, X_T + pA'.2)) =
+              (Nonplanar.insertionMultiset pa'.1 pg.1).bind (fun Y₁ =>
+                (((Nonplanar.insertionMultiset {T} G₂).bind fun X_T =>
+                  (Nonplanar.insertionMultiset pa'.2 (pg.2 - G₂)).map (Prod.mk X_T)).map
+                    (fun p => p.1 + p.2)).map (Prod.mk Y₁))
+        rw [Multiset.bind_assoc]
+        refine Multiset.bind_congr fun Y₁ _ => ?_
+        rw [Multiset.bind_map]
+        -- Compose the outer (Prod.mk Y₁) and (·.1+·.2) maps + push through bind.
+        rw [Multiset.map_map, Multiset.map_bind]
+        -- Inside each X_T, compose Prod.mk X_T with (Y₁, ·.1+·.2): Y₂ ↦ (Y₁, X_T + Y₂).
+        rw [show ((Nonplanar.insertionMultiset {T} G₂).bind fun X_T =>
+                Multiset.map ((Prod.mk Y₁) ∘
+                    fun p : Multiset (Nonplanar α) × Multiset (Nonplanar α) => p.1 + p.2)
+                  (Multiset.map (Prod.mk X_T)
+                    (Nonplanar.insertionMultiset pa'.2 (pg.2 - G₂)))) =
+              ((Nonplanar.insertionMultiset {T} G₂).bind fun X_T =>
+                (Nonplanar.insertionMultiset pa'.2 (pg.2 - G₂)).map
+                  (fun Y₂ => (Y₁, X_T + Y₂))) from by
+          refine Multiset.bind_congr fun X_T _ => ?_
+          rw [Multiset.map_map]
+          rfl]
+        -- Both sides now: bind/bind ⇒ bind_map_comm.
+        exact Multiset.bind_map_comm _ _
+      · -- Prove the helper: s ×ˢ (t.bind f) = t.bind (b ↦ s ×ˢ f b).
+        intros s tt
+        show s.bind (fun a => (pg.2.powerset.bind tt).map (Prod.mk a)) =
+            pg.2.powerset.bind (fun G₂ => s.bind (fun a => (tt G₂).map (Prod.mk a)))
+        rw [Multiset.bind_bind]
+        refine Multiset.bind_congr fun G₂ _ => ?_
+        rw [Multiset.map_bind]
+    · -- Match T-left: pair has X_T on .1. Symmetric to T-right by mirror argument.
+      -- Same proof scheme as T-right but with X_T joining the first coord of the pair.
+      rw [show (G.powerset.bind fun G₁ =>
+              (Nonplanar.insertionMultiset {T} G₁).bind fun X_T =>
+                (Nonplanar.insertionMultiset A' (G - G₁)).bind fun X_A' =>
+                  (Multiset.antidiagonal X_A').map (fun pA' => (X_T + pA'.1, pA'.2))) =
+            (G.powerset.bind fun G₁ =>
+              ((Nonplanar.insertionMultiset A' (G - G₁)).bind Multiset.antidiagonal).bind
+                fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                  fun X_T => (X_T + pA'.1, pA'.2)) from by
+        refine Multiset.bind_congr fun G₁ _ => ?_
+        rw [Multiset.bind_assoc]
+        rw [Multiset.bind_bind]
+        refine Multiset.bind_congr fun X_A' _ => ?_
+        rw [Multiset.bind_map_comm]]
+      rw [show (G.powerset.bind fun G₁ =>
+              ((Nonplanar.insertionMultiset A' (G - G₁)).bind Multiset.antidiagonal).bind
+                fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                  fun X_T => (X_T + pA'.1, pA'.2)) =
+            (G.powerset.bind fun G₁ =>
+              ((Multiset.antidiagonal A').bind fun pa' =>
+                (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+                  (Nonplanar.insertionMultiset pa'.1 pg'.1) ×ˢ
+                    (Nonplanar.insertionMultiset pa'.2 pg'.2)).bind
+                fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                  fun X_T => (X_T + pA'.1, pA'.2)) from by
+        refine Multiset.bind_congr fun G₁ _ => ?_
+        rw [ih (G - G₁)]]
+      rw [show (G.powerset.bind fun G₁ =>
+              ((Multiset.antidiagonal A').bind fun pa' =>
+                (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+                  (Nonplanar.insertionMultiset pa'.1 pg'.1) ×ˢ
+                    (Nonplanar.insertionMultiset pa'.2 pg'.2)).bind
+                fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                  fun X_T => (X_T + pA'.1, pA'.2)) =
+            (G.powerset.bind fun G₁ =>
+              (Multiset.antidiagonal A').bind fun pa' =>
+                (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+                  ((Nonplanar.insertionMultiset pa'.1 pg'.1) ×ˢ
+                      (Nonplanar.insertionMultiset pa'.2 pg'.2)).bind
+                    fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                      fun X_T => (X_T + pA'.1, pA'.2)) from by
+        refine Multiset.bind_congr fun G₁ _ => ?_
+        rw [Multiset.bind_assoc]
+        refine Multiset.bind_congr fun pa' _ => ?_
+        rw [Multiset.bind_assoc]]
+      rw [show (G.powerset.bind fun G₁ =>
+              (Multiset.antidiagonal A').bind fun pa' =>
+                (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+                  ((Nonplanar.insertionMultiset pa'.1 pg'.1) ×ˢ
+                      (Nonplanar.insertionMultiset pa'.2 pg'.2)).bind
+                    fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                      fun X_T => (X_T + pA'.1, pA'.2)) =
+            (Multiset.antidiagonal A').bind fun pa' =>
+              G.powerset.bind fun G₁ =>
+                (Multiset.antidiagonal (G - G₁)).bind fun pg' =>
+                  ((Nonplanar.insertionMultiset pa'.1 pg'.1) ×ˢ
+                      (Nonplanar.insertionMultiset pa'.2 pg'.2)).bind
+                    fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+                      fun X_T => (X_T + pA'.1, pA'.2)
+        from Multiset.bind_bind _ _]
+      -- For T-left RHS: antidiag G.bind (pg ↦ NIM (T ::ₘ pa'.1) pg.1 ×ˢ NIM pa'.2 pg.2).
+      -- Symmetry: T attaches to the *first* host part. Apply triple_partition_reindex_flip.
+      refine Multiset.bind_congr fun pa' _ => ?_
+      rw [triple_partition_reindex_flip G
+        (fun G₁ x y =>
+          ((Nonplanar.insertionMultiset pa'.1 x) ×ˢ
+              (Nonplanar.insertionMultiset pa'.2 y)).bind
+            (fun pA' => (Nonplanar.insertionMultiset {T} G₁).map
+              fun X_T => (X_T + pA'.1, pA'.2)))]
+      refine Multiset.bind_congr fun pg _ => ?_
+      have h_prod_map_id : (Prod.map (Multiset.cons T) (id : Multiset (Nonplanar α) → _) pa') =
+          (T ::ₘ pa'.1, pa'.2) := rfl
+      rw [h_prod_map_id]
+      show (pg.1.powerset.bind fun G₂ =>
+              ((Nonplanar.insertionMultiset pa'.1 (pg.1 - G₂)) ×ˢ
+                  (Nonplanar.insertionMultiset pa'.2 pg.2)).bind
+                (fun pA' => (Nonplanar.insertionMultiset {T} G₂).map
+                  fun X_T => (X_T + pA'.1, pA'.2))) =
+            (Nonplanar.insertionMultiset (T ::ₘ pa'.1) pg.1) ×ˢ
+              (Nonplanar.insertionMultiset pa'.2 pg.2)
+      -- Apply insertionMultiset_add_host on NIM (T ::ₘ pa'.1) pg.1.
+      rw [show (T ::ₘ pa'.1 : Multiset (Nonplanar α)) = ({T} : Multiset _) + pa'.1 from
+            (Multiset.singleton_add T pa'.1).symm,
+          Nonplanar.insertionMultiset_add_host {T} pa'.1 pg.1]
+      -- RHS: (pg.1.powerset.bind (G₂ ↦ (NIM {T} G₂ ×ˢ NIM pa'.1 (pg.1-G₂)).map (·.1+·.2))) ×ˢ NIM pa'.2 pg.2
+      -- Use (s.bind f) ×ˢ t = s.bind (a ↦ f a ×ˢ t).
+      rw [show ∀ s : Multiset (Multiset (Nonplanar α)),
+              ∀ tt : Multiset (Nonplanar α) → Multiset (Multiset (Nonplanar α)),
+                (pg.1.powerset.bind tt) ×ˢ s =
+                  pg.1.powerset.bind (fun G₂ => tt G₂ ×ˢ s) from ?_]
+      · refine Multiset.bind_congr fun G₂ _ => ?_
+        -- Goal: ((NIM pa'.1 (pg.1-G₂)) ×ˢ NIM pa'.2 pg.2).bind (pA' ↦ NIM {T} G₂.map (X_T ↦ (X_T + pA'.1, pA'.2)))
+        --     = ((NIM {T} G₂ ×ˢ NIM pa'.1 (pg.1-G₂)).map (·.1+·.2)) ×ˢ NIM pa'.2 pg.2
+        -- Unfold ×ˢ everywhere.
+        show ((Nonplanar.insertionMultiset pa'.1 (pg.1 - G₂)).bind (fun Y₁ =>
+              (Nonplanar.insertionMultiset pa'.2 pg.2).map (Prod.mk Y₁))).bind
+                (fun pA' => (Nonplanar.insertionMultiset {T} G₂).map
+                  fun X_T => (X_T + pA'.1, pA'.2)) =
+            (Multiset.map (fun p : Multiset (Nonplanar α) × Multiset (Nonplanar α) => p.1 + p.2)
+                ((Nonplanar.insertionMultiset {T} G₂).bind (fun X_T =>
+                  (Nonplanar.insertionMultiset pa'.1 (pg.1 - G₂)).map (Prod.mk X_T)))).bind
+              (fun first => (Nonplanar.insertionMultiset pa'.2 pg.2).map (Prod.mk first))
+        -- Reformulate LHS: bind, bind_map, bind.
+        rw [Multiset.bind_assoc]
+        -- Goal: NIM pa'.1 (pg.1-G₂).bind (Y₁ ↦ ((NIM pa'.2 pg.2).map (Prod.mk Y₁)).bind (pA' ↦ NIM {T} G₂.map (...)))
+        rw [show ((Nonplanar.insertionMultiset pa'.1 (pg.1 - G₂)).bind (fun Y₁ =>
+                ((Nonplanar.insertionMultiset pa'.2 pg.2).map (Prod.mk Y₁)).bind
+                  (fun pA' => (Nonplanar.insertionMultiset {T} G₂).map
+                    fun X_T => (X_T + pA'.1, pA'.2)))) =
+              (Nonplanar.insertionMultiset pa'.1 (pg.1 - G₂)).bind (fun Y₁ =>
+                (Nonplanar.insertionMultiset pa'.2 pg.2).bind (fun Y₂ =>
+                  (Nonplanar.insertionMultiset {T} G₂).map
+                    fun X_T => (X_T + Y₁, Y₂))) from by
+          refine Multiset.bind_congr fun Y₁ _ => ?_
+          rw [Multiset.bind_map]]
+        -- RHS: Push map p.1+p.2 through inner bind, then bind outer.
+        rw [show (Multiset.map (fun p : Multiset (Nonplanar α) × Multiset (Nonplanar α) =>
+                  p.1 + p.2)
+                ((Nonplanar.insertionMultiset {T} G₂).bind (fun X_T =>
+                  (Nonplanar.insertionMultiset pa'.1 (pg.1 - G₂)).map (Prod.mk X_T)))).bind
+              (fun first => (Nonplanar.insertionMultiset pa'.2 pg.2).map (Prod.mk first)) =
+              ((Nonplanar.insertionMultiset {T} G₂).bind fun X_T =>
+                (Nonplanar.insertionMultiset pa'.1 (pg.1 - G₂)).bind fun Y₁ =>
+                  (Nonplanar.insertionMultiset pa'.2 pg.2).map (fun Y₂ => (X_T + Y₁, Y₂)))
+            from by
+          rw [Multiset.map_bind, Multiset.bind_assoc]
+          refine Multiset.bind_congr fun X_T _ => ?_
+          rw [Multiset.map_map, Multiset.bind_map]
+          refine Multiset.bind_congr fun Y₁ _ => ?_
+          rfl]
+        -- Now LHS: NIM pa'.1.bind (Y₁ ↦ NIM pa'.2.bind (Y₂ ↦ NIM {T} G₂.map (X_T ↦ (X_T + Y₁, Y₂))))
+        -- RHS: NIM {T} G₂.bind (X_T ↦ NIM pa'.1.bind (Y₁ ↦ NIM pa'.2.map (Y₂ ↦ (X_T + Y₁, Y₂))))
+        -- Step a: Apply bind_map_comm to swap Y₂ and X_T inside Y₁.
+        rw [show ((Nonplanar.insertionMultiset pa'.1 (pg.1 - G₂)).bind fun Y₁ =>
+              (Nonplanar.insertionMultiset pa'.2 pg.2).bind (fun Y₂ =>
+                (Nonplanar.insertionMultiset {T} G₂).map fun X_T => (X_T + Y₁, Y₂))) =
+            ((Nonplanar.insertionMultiset pa'.1 (pg.1 - G₂)).bind fun Y₁ =>
+              (Nonplanar.insertionMultiset {T} G₂).bind (fun X_T =>
+                (Nonplanar.insertionMultiset pa'.2 pg.2).map fun Y₂ => (X_T + Y₁, Y₂)))
+            from by
+          refine Multiset.bind_congr fun Y₁ _ => ?_
+          rw [Multiset.bind_map_comm]]
+        -- Step b: Swap Y₁ and X_T via bind_bind.
+        rw [Multiset.bind_bind]
+      · -- Prove the helper: (s.bind f) ×ˢ t = s.bind (a ↦ f a ×ˢ t).
+        intros s tt
+        show (pg.1.powerset.bind tt).bind (fun a => s.map (Prod.mk a)) =
+            pg.1.powerset.bind (fun G₂ => (tt G₂).bind (fun a => s.map (Prod.mk a)))
+        rw [Multiset.bind_assoc]
+
+/-! ### Generic sum/product plumbing -/
+
+/-- Sum of a product-indexed multiset of products factors. -/
+theorem sum_map_product_mul {β γ : Type*} (s : Multiset β) (t : Multiset γ)
+    (f : β → R) (g : γ → R) :
+    ((s ×ˢ t).map (fun p => f p.1 * g p.2)).sum = (s.map f).sum * (t.map g).sum := by
+  induction s using Multiset.induction_on with
+  | empty => simp only [Multiset.zero_product, Multiset.map_zero, Multiset.sum_zero,
+      zero_mul]
+  | cons a s ih =>
+    rw [Multiset.cons_product, Multiset.map_add, Multiset.sum_add, ih,
+        Multiset.map_map, Multiset.map_cons, Multiset.sum_cons, add_mul]
+    congr 1
+    rw [show ((fun p : β × γ => f p.1 * g p.2) ∘ Prod.mk a) = fun b => f a * g b from rfl,
+        Multiset.sum_map_mul_left]
+
+/-- `(s ×ˢ t).bind F = s.bind (a ↦ t.bind (b ↦ F (a, b)))`. -/
+private theorem product_bind {β γ δ : Type*} (s : Multiset β) (t : Multiset γ)
+    (F : β × γ → Multiset δ) :
+    (s ×ˢ t).bind F = s.bind (fun a => t.bind (fun b => F (a, b))) := by
+  show (s.bind (fun a => t.map (Prod.mk a))).bind F = _
+  rw [Multiset.bind_assoc]
+  exact Multiset.bind_congr fun a _ => Multiset.bind_map t F (Prod.mk a)
+
+/-- `(s.bind f) ×ˢ t = s.bind (a ↦ f a ×ˢ t)`. -/
+private theorem bind_product_left {β γ δ : Type*} (s : Multiset β)
+    (f : β → Multiset γ) (t : Multiset δ) :
+    (s.bind f) ×ˢ t = s.bind (fun a => f a ×ˢ t) := by
+  show (s.bind f).bind (fun a => t.map (Prod.mk a)) = _
+  rw [Multiset.bind_assoc]
+  rfl
+
+/-- `s ×ˢ (t.bind g) = t.bind (b ↦ s ×ˢ g b)`. -/
+private theorem product_bind_right {β γ δ : Type*} (s : Multiset β)
+    (t : Multiset γ) (g : γ → Multiset δ) :
+    s ×ˢ (t.bind g) = t.bind (fun b => s ×ˢ g b) := by
+  show s.bind (fun a => (t.bind g).map (Prod.mk a)) = _
+  rw [show (fun a => (t.bind g).map (Prod.mk a)) =
+      fun a => t.bind (fun b => (g b).map (Prod.mk a)) from
+    funext fun a => Multiset.map_bind t g (Prod.mk a)]
+  rw [Multiset.bind_bind]
+  rfl
+
+/-- `(s.map f) ×ˢ (t.map g) = (s ×ˢ t).map (Prod.map f g)`. -/
+private theorem map_product_map {β γ β' γ' : Type*} (s : Multiset β) (t : Multiset γ)
+    (f : β → β') (g : γ → γ') :
+    (s.map f) ×ˢ (t.map g) = (s ×ˢ t).map (Prod.map f g) := by
+  show (s.map f).bind (fun a => (t.map g).map (Prod.mk a)) = _
+  rw [Multiset.bind_map]
+  show (s.bind fun a => (t.map g).map (Prod.mk (f a))) = _
+  rw [show (fun a => (t.map g).map (Prod.mk (f a))) =
+      fun a => t.map (fun b => (f a, g b)) from
+    funext fun a => by rw [Multiset.map_map]; rfl]
+  show _ = ((s.bind fun a => t.map (Prod.mk a)).map (Prod.map f g))
+  rw [Multiset.map_bind]
+  refine Multiset.bind_congr fun a _ => ?_
+  rw [Multiset.map_map]
+  rfl
+
+/-- Boundary conversion: a powerset-with-complement bind equals an
+    antidiagonal bind (second slot = chosen sub-multiset). -/
+private theorem powerset_bind_eq_antidiagonal_bind {β γ : Type*} [DecidableEq β]
+    (B : Multiset β) (m : Multiset β → Multiset β → Multiset γ) :
+    B.powerset.bind (fun B₁ => m B₁ (B - B₁)) =
+      (Multiset.antidiagonal B).bind (fun pb => m pb.2 pb.1) := by
+  rw [Multiset.antidiagonal_eq_map_powerset, Multiset.bind_map]
+
+/-! ### quadBind (from dev_quad.lean) -/
+
+private def quadBind {β γ : Type*} (B : Multiset β)
+    (g : Multiset β → Multiset β → Multiset β → Multiset β → Multiset γ) :
+    Multiset γ :=
+  (Multiset.antidiagonal B).bind (fun p =>
+    (Multiset.antidiagonal p.1).bind (fun u =>
+      (Multiset.antidiagonal p.2).bind (fun v => g u.1 u.2 v.1 v.2)))
+
+private theorem quadBind_zero {β γ : Type*}
+    (g : Multiset β → Multiset β → Multiset β → Multiset β → Multiset γ) :
+    quadBind 0 g = g 0 0 0 0 := by
+  simp only [quadBind, Multiset.antidiagonal_zero, Multiset.singleton_bind]
+
+private theorem quadBind_cons {β γ : Type*} (x : β) (B : Multiset β)
+    (g : Multiset β → Multiset β → Multiset β → Multiset β → Multiset γ) :
+    quadBind (x ::ₘ B) g =
+      quadBind B (fun a b c d => g (x ::ₘ a) b c d) +
+      quadBind B (fun a b c d => g a (x ::ₘ b) c d) +
+      quadBind B (fun a b c d => g a b (x ::ₘ c) d) +
+      quadBind B (fun a b c d => g a b c (x ::ₘ d)) := by
+  have h2 : (((Multiset.antidiagonal B).map (Prod.map id (x ::ₘ ·))).bind
+        (fun p => (Multiset.antidiagonal p.1).bind (fun u =>
+          (Multiset.antidiagonal p.2).bind (fun v => g u.1 u.2 v.1 v.2)))) =
+      quadBind B (fun a b c d => g a b c (x ::ₘ d)) +
+      quadBind B (fun a b c d => g a b (x ::ₘ c) d) := by
+    rw [Multiset.bind_map]
+    have step : ∀ p ∈ Multiset.antidiagonal B,
+        ((Multiset.antidiagonal (Prod.map id (x ::ₘ ·) p).1).bind (fun u =>
+          (Multiset.antidiagonal (Prod.map id (x ::ₘ ·) p).2).bind (fun v =>
+            g u.1 u.2 v.1 v.2))) =
+        ((Multiset.antidiagonal p.1).bind (fun u =>
+          (Multiset.antidiagonal p.2).bind (fun v => g u.1 u.2 v.1 (x ::ₘ v.2)))) +
+        ((Multiset.antidiagonal p.1).bind (fun u =>
+          (Multiset.antidiagonal p.2).bind (fun v => g u.1 u.2 (x ::ₘ v.1) v.2))) := by
+      intro p _
+      have inner : ∀ u : Multiset β × Multiset β,
+          ((Multiset.antidiagonal (x ::ₘ p.2)).bind (fun v => g u.1 u.2 v.1 v.2)) =
+          ((Multiset.antidiagonal p.2).bind (fun v => g u.1 u.2 v.1 (x ::ₘ v.2))) +
+          ((Multiset.antidiagonal p.2).bind (fun v => g u.1 u.2 (x ::ₘ v.1) v.2)) := by
+        intro u
+        rw [Multiset.antidiagonal_cons, Multiset.add_bind, Multiset.bind_map,
+            Multiset.bind_map]
+        rfl
+      show ((Multiset.antidiagonal p.1).bind (fun u =>
+          (Multiset.antidiagonal (x ::ₘ p.2)).bind (fun v => g u.1 u.2 v.1 v.2))) = _
+      rw [Multiset.bind_congr (fun u _ => inner u), Multiset.bind_add]
+    rw [Multiset.bind_congr step, Multiset.bind_add]
+    rfl
+  have h1 : (((Multiset.antidiagonal B).map (Prod.map (x ::ₘ ·) id)).bind
+        (fun p => (Multiset.antidiagonal p.1).bind (fun u =>
+          (Multiset.antidiagonal p.2).bind (fun v => g u.1 u.2 v.1 v.2)))) =
+      quadBind B (fun a b c d => g a (x ::ₘ b) c d) +
+      quadBind B (fun a b c d => g (x ::ₘ a) b c d) := by
+    rw [Multiset.bind_map]
+    have step : ∀ p ∈ Multiset.antidiagonal B,
+        ((Multiset.antidiagonal (Prod.map (x ::ₘ ·) id p).1).bind (fun u =>
+          (Multiset.antidiagonal (Prod.map (x ::ₘ ·) id p).2).bind (fun v =>
+            g u.1 u.2 v.1 v.2))) =
+        ((Multiset.antidiagonal p.1).bind (fun u =>
+          (Multiset.antidiagonal p.2).bind (fun v => g u.1 (x ::ₘ u.2) v.1 v.2))) +
+        ((Multiset.antidiagonal p.1).bind (fun u =>
+          (Multiset.antidiagonal p.2).bind (fun v => g (x ::ₘ u.1) u.2 v.1 v.2))) := by
+      intro p _
+      show ((Multiset.antidiagonal (x ::ₘ p.1)).bind (fun u =>
+          (Multiset.antidiagonal p.2).bind (fun v => g u.1 u.2 v.1 v.2))) = _
+      rw [Multiset.antidiagonal_cons, Multiset.add_bind, Multiset.bind_map,
+          Multiset.bind_map]
+      rfl
+    rw [Multiset.bind_congr step, Multiset.bind_add]
+    rfl
+  show ((Multiset.antidiagonal (x ::ₘ B)).bind (fun p =>
+      (Multiset.antidiagonal p.1).bind (fun u =>
+        (Multiset.antidiagonal p.2).bind (fun v => g u.1 u.2 v.1 v.2)))) = _
+  rw [Multiset.antidiagonal_cons, Multiset.add_bind, h2, h1]
+  abel
+
+private theorem quadBind_middle_swap {β γ : Type*} (B : Multiset β)
+    (g : Multiset β → Multiset β → Multiset β → Multiset β → Multiset γ) :
+    quadBind B g = quadBind B (fun a b c d => g a c b d) := by
+  induction B using Multiset.induction_on generalizing g with
+  | empty => rw [quadBind_zero, quadBind_zero]
+  | cons x B ih =>
+    rw [quadBind_cons, quadBind_cons]
+    rw [← ih (fun a b c d => g (x ::ₘ a) b c d),
+        ← ih (fun a b c d => g a b (x ::ₘ c) d),
+        ← ih (fun a b c d => g a (x ::ₘ b) c d),
+        ← ih (fun a b c d => g a b c (x ::ₘ d))]
+    abel
+
+/-! ### The product index multiset -/
+
+/-- Index multiset of GL-product outputs: forests `X + (B' − H)` over
+    `H ⊆ B'` and `X ∈ NIM(A', H)`. `product (of' A') (of' B')` is the
+    formal sum of `of'` over this multiset (`of'_mul_of'_nim_form`). -/
+private noncomputable def productIdx (A' B' : Forest (Nonplanar α)) :
+    Multiset (Forest (Nonplanar α)) :=
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  B'.powerset.bind (fun H =>
+    (Nonplanar.insertionMultiset A' H).map (fun X => X + (B' - H)))
+
+/-- Antidiagonal form of `productIdx`. -/
+private theorem productIdx_eq_antidiagonal (A' B' : Forest (Nonplanar α)) :
+    productIdx A' B' =
+      (Multiset.antidiagonal B').bind (fun u =>
+        (Nonplanar.insertionMultiset A' u.2).map (fun X => X + u.1)) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  unfold productIdx
+  exact powerset_bind_eq_antidiagonal_bind B'
+    (fun H Bf => (Nonplanar.insertionMultiset A' H).map (fun X => X + Bf))
+
+/-- `pairing (product (of' A') (of' B')) z` as a `productIdx`-indexed sum. -/
+private theorem pairing_product_of'_expand (A' B' : Forest (Nonplanar α))
+    (z : ConnesKreimer R (Nonplanar α)) :
+    pairing (R := R) (product (ConnesKreimer.of' A') (ConnesKreimer.of' B')) z =
+      ((productIdx A' B').map (fun W =>
+        pairing (R := R) (ConnesKreimer.of' W) z)).sum := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  have hexp : product (ConnesKreimer.of' (R := R) A') (ConnesKreimer.of' B') =
+      (((productIdx A' B').map (fun W => ConnesKreimer.of' (R := R) W)).sum :
+        ConnesKreimer R (Nonplanar α)) := by
+    show ((of' (R := R) A' : GrossmanLarson R α) * of' B' : GrossmanLarson R α) = _
+    rw [of'_mul_of'_nim_form]
+    show (((B'.powerset.bind fun H =>
+        (Nonplanar.insertionMultiset A' H).map fun X =>
+          ConnesKreimer.of' (R := R) (X + (B' - H))).sum :
+        ConnesKreimer R (Nonplanar α))) = _
+    unfold productIdx
+    rw [Multiset.map_bind]
+    congr 1
+    refine Multiset.bind_congr fun H _ => ?_
+    rw [Multiset.map_map]
+    rfl
+  rw [show pairing (R := R) (product (ConnesKreimer.of' A') (ConnesKreimer.of' B')) z =
+      (pairing (R := R)).flip z (product (ConnesKreimer.of' A') (ConnesKreimer.of' B'))
+    from rfl]
+  rw [hexp, map_multiset_sum, Multiset.map_map]
+  rfl
+
+/-! ### The index identity -/
+
+/-- **Index identity**: the cut-split index multiset of `A ⋆ B` against a
+    two-factor product equals the doubly-split product index. The multiset
+    backbone of `pairing_product_of'_mul_of'`. -/
+private theorem productIdx_mul_split (A B : Forest (Nonplanar α)) :
+    (letI : DecidableEq (Nonplanar α) := Classical.decEq _
+     B.powerset.bind (fun B₁ =>
+       (Nonplanar.insertionMultiset A B₁).bind (fun X =>
+         Multiset.antidiagonal (X + (B - B₁))))) =
+      (Multiset.antidiagonal A ×ˢ Multiset.antidiagonal B).bind (fun pq =>
+        productIdx pq.1.1 pq.2.1 ×ˢ productIdx pq.1.2 pq.2.2) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  -- Step A+B+C+D: inner antidiagonal split + Lemma G, per B₁.
+  have stepACD : ∀ B₁ ∈ B.powerset,
+      ((Nonplanar.insertionMultiset A B₁).bind (fun X =>
+        Multiset.antidiagonal (X + (B - B₁)))) =
+      (Multiset.antidiagonal A).bind (fun pa =>
+        (Multiset.antidiagonal B₁).bind (fun pH =>
+          (Multiset.antidiagonal (B - B₁)).bind (fun q =>
+            (Nonplanar.insertionMultiset pa.1 pH.1 ×ˢ
+              Nonplanar.insertionMultiset pa.2 pH.2).map
+              (fun pX => (pX.1 + q.1, pX.2 + q.2))))) := by
+    intro B₁ _
+    have h1 : ((Nonplanar.insertionMultiset A B₁).bind (fun X =>
+          Multiset.antidiagonal (X + (B - B₁)))) =
+        ((Nonplanar.insertionMultiset A B₁).bind Multiset.antidiagonal).bind
+          (fun p => (Multiset.antidiagonal (B - B₁)).map
+            (fun q => (p.1 + q.1, p.2 + q.2))) := by
+      rw [Multiset.bind_assoc]
+      refine Multiset.bind_congr fun X _ => ?_
+      exact Multiset.antidiagonal_add X (B - B₁)
+    rw [h1, Nonplanar.insertionMultiset_antidiagonal, Multiset.bind_assoc]
+    refine Multiset.bind_congr fun pa _ => ?_
+    rw [Multiset.bind_assoc]
+    refine Multiset.bind_congr fun pH _ => ?_
+    -- (NIMprod).bind (pX ↦ (antidiag Bf).map h) = (antidiag Bf).bind (q ↦ NIMprod.map ...)
+    exact Multiset.bind_map_comm _ _
+  rw [Multiset.bind_congr stepACD]
+  -- Step E: pull the antidiagonal-A bind out front.
+  rw [Multiset.bind_bind]
+  -- Step F+G+H: per pa, reorganize the B-part into quadBind form and swap.
+  have stepB : ∀ pa : Forest (Nonplanar α) × Forest (Nonplanar α),
+      (B.powerset.bind (fun B₁ =>
+        (Multiset.antidiagonal B₁).bind (fun pH =>
+          (Multiset.antidiagonal (B - B₁)).bind (fun q =>
+            (Nonplanar.insertionMultiset pa.1 pH.1 ×ˢ
+              Nonplanar.insertionMultiset pa.2 pH.2).map
+              (fun pX => (pX.1 + q.1, pX.2 + q.2)))))) =
+      (Multiset.antidiagonal B).bind (fun pb =>
+        productIdx pa.1 pb.1 ×ˢ productIdx pa.2 pb.2) := by
+    intro pa
+    -- Boundary: powerset + complement → antidiagonal.
+    rw [powerset_bind_eq_antidiagonal_bind B (fun B₁ Bf =>
+      (Multiset.antidiagonal B₁).bind (fun pH =>
+        (Multiset.antidiagonal Bf).bind (fun q =>
+          (Nonplanar.insertionMultiset pa.1 pH.1 ×ˢ
+            Nonplanar.insertionMultiset pa.2 pH.2).map
+            (fun pX => (pX.1 + q.1, pX.2 + q.2)))))]
+    -- Commute the two inner antidiagonal binds to reach quadBind shape.
+    have hcomm : ∀ pb : Forest (Nonplanar α) × Forest (Nonplanar α),
+        ((Multiset.antidiagonal pb.2).bind (fun pH =>
+          (Multiset.antidiagonal pb.1).bind (fun q =>
+            (Nonplanar.insertionMultiset pa.1 pH.1 ×ˢ
+              Nonplanar.insertionMultiset pa.2 pH.2).map
+              (fun pX => (pX.1 + q.1, pX.2 + q.2))))) =
+        ((Multiset.antidiagonal pb.1).bind (fun q =>
+          (Multiset.antidiagonal pb.2).bind (fun pH =>
+            (Nonplanar.insertionMultiset pa.1 pH.1 ×ˢ
+              Nonplanar.insertionMultiset pa.2 pH.2).map
+              (fun pX => (pX.1 + q.1, pX.2 + q.2))))) := by
+      intro pb
+      exact Multiset.bind_bind _ _
+    rw [Multiset.bind_congr (fun pb _ => hcomm pb)]
+    -- Now: quadBind B (fun q₁ q₂ H₁ H₂ => k H₁ H₂ q₁ q₂); middle-swap it.
+    rw [show ((Multiset.antidiagonal B).bind (fun pb =>
+        (Multiset.antidiagonal pb.1).bind (fun q =>
+          (Multiset.antidiagonal pb.2).bind (fun pH =>
+            (Nonplanar.insertionMultiset pa.1 pH.1 ×ˢ
+              Nonplanar.insertionMultiset pa.2 pH.2).map
+              (fun pX => (pX.1 + q.1, pX.2 + q.2)))))) =
+      quadBind B (fun a b c d =>
+        (Nonplanar.insertionMultiset pa.1 c ×ˢ
+          Nonplanar.insertionMultiset pa.2 d).map
+          (fun pX => (pX.1 + a, pX.2 + b))) from rfl]
+    rw [quadBind_middle_swap]
+    -- Unfold back and match against productIdx ×ˢ productIdx.
+    show ((Multiset.antidiagonal B).bind (fun pb =>
+        (Multiset.antidiagonal pb.1).bind (fun u =>
+          (Multiset.antidiagonal pb.2).bind (fun v =>
+            (Nonplanar.insertionMultiset pa.1 u.2 ×ˢ
+              Nonplanar.insertionMultiset pa.2 v.2).map
+              (fun pX => (pX.1 + u.1, pX.2 + v.1)))))) = _
+    refine Multiset.bind_congr fun pb _ => ?_
+    rw [productIdx_eq_antidiagonal, productIdx_eq_antidiagonal,
+        bind_product_left]
+    refine Multiset.bind_congr fun u _ => ?_
+    rw [product_bind_right]
+    refine Multiset.bind_congr fun v _ => ?_
+    rw [map_product_map]
+    rfl
+  rw [Multiset.bind_congr (fun pa _ => stepB pa)]
+  -- Outer product-bind unfolding on the RHS.
+  rw [product_bind]
+
+/-! ### The fused product rule for the GL product -/
+
+/-- **GL-product/CK-product pairing duality** (basis form): pairing a GL
+    product against a CK product decomposes over independent splits of
+    the two GL factors:
+
+    `⟨A ⋆ B, C₁ · C₂⟩ =
+       Σ_{A = A₁+A₂} Σ_{B = B₁+B₂} ⟨A₁ ⋆ B₁, C₁⟩ · ⟨A₂ ⋆ B₂, C₂⟩`.
+
+    This is the multiplicative-structure compatibility making the GL
+    basis dual to the CK polynomial algebra: combines
+    `pairing_of'_mul` (pairing product rule, one application per output
+    forest of `A ⋆ B`) with `insertionMultiset_antidiagonal` (routing
+    splits of grafted outputs) and the powerset/antidiagonal
+    bookkeeping for the non-grafted guest components.
+
+    Proof: reduce both sides to sums of the diagonal pairing over the
+    index multiset `productIdx`; the multiset backbone is
+    `productIdx_mul_split`, whose combinatorial heart is the middle-four
+    interchange `quadBind_middle_swap`. -/
+theorem pairing_product_of'_mul_of' (A B C₁ C₂ : Forest (Nonplanar α)) :
+    pairing (R := R)
+        (product (ConnesKreimer.of' A) (ConnesKreimer.of' B))
+        (ConnesKreimer.of' C₁ * ConnesKreimer.of' C₂) =
+      ((Multiset.antidiagonal A ×ˢ Multiset.antidiagonal B).map (fun pq =>
+        pairing (R := R)
+            (product (ConnesKreimer.of' pq.1.1) (ConnesKreimer.of' pq.2.1))
+            (ConnesKreimer.of' C₁) *
+        pairing (R := R)
+            (product (ConnesKreimer.of' pq.1.2) (ConnesKreimer.of' pq.2.2))
+            (ConnesKreimer.of' C₂))).sum := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  -- φ evaluates a split pair against (C₁, C₂).
+  set φ : Forest (Nonplanar α) × Forest (Nonplanar α) → R :=
+    fun p => pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
+      pairing (R := R) (ConnesKreimer.of' p.2) (ConnesKreimer.of' C₂) with hφ
+  -- LHS = sum of φ over the cut-split index multiset.
+  have hLHS : pairing (R := R)
+        (product (ConnesKreimer.of' A) (ConnesKreimer.of' B))
+        (ConnesKreimer.of' C₁ * ConnesKreimer.of' C₂) =
+      (((B.powerset.bind (fun B₁ =>
+        (Nonplanar.insertionMultiset A B₁).bind (fun X =>
+          Multiset.antidiagonal (X + (B - B₁)))))).map φ).sum := by
+    rw [pairing_product_of'_expand]
+    unfold productIdx
+    rw [Multiset.map_bind, Multiset.map_bind, Multiset.sum_bind, Multiset.sum_bind]
+    congr 1
+    refine Multiset.map_congr rfl fun B₁ _ => ?_
+    rw [Multiset.map_map, Multiset.map_bind, Multiset.sum_bind]
+    congr 1
+    refine Multiset.map_congr rfl fun X _ => ?_
+    show pairing (R := R) (ConnesKreimer.of' (X + (B - B₁)))
+        (ConnesKreimer.of' C₁ * ConnesKreimer.of' C₂) = _
+    rw [pairing_of'_mul]
+  rw [hLHS, productIdx_mul_split, Multiset.map_bind, Multiset.sum_bind]
+  congr 1
+  refine Multiset.map_congr rfl fun pq _ => ?_
+  show ((productIdx pq.1.1 pq.2.1 ×ˢ productIdx pq.1.2 pq.2.2).map φ).sum = _
+  rw [hφ]
+  rw [sum_map_product_mul (productIdx pq.1.1 pq.2.1) (productIdx pq.1.2 pq.2.2)
+      (fun W => pairing (R := R) (ConnesKreimer.of' W) (ConnesKreimer.of' C₁))
+      (fun W => pairing (R := R) (ConnesKreimer.of' W) (ConnesKreimer.of' C₂))]
+  rw [← pairing_product_of'_expand, ← pairing_product_of'_expand]
+
+end GrossmanLarson
+
+end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/HopfAlgebraNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/HopfAlgebraNonplanar.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
+import Linglib.Core.Algebra.RootedTree.Coproduct.PruningDuality
 import Mathlib.RingTheory.HopfAlgebra.Basic
 import Mathlib.RingTheory.HopfAlgebra.TensorProduct
 import Mathlib.RingTheory.Coalgebra.Convolution

--- a/Linglib/Core/Algebra/RootedTree/InsertionLieDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/InsertionLieDuality.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
+import Linglib.Core.Algebra.RootedTree.Coproduct.PruningDuality
 import Mathlib.RingTheory.Coalgebra.Convolution
 
 set_option autoImplicit false

--- a/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridgePairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridgePairing.lean
@@ -57,7 +57,7 @@ open PreLie.OudomGuinCirc
 
 namespace GrossmanLarson
 
-variable {α : Type*} [DecidableEq (Nonplanar α)]
+variable {R : Type*} [CommSemiring R] {α : Type*} [DecidableEq (Nonplanar α)]
 
 /-! ### ε is multiplicative for the GL product
 
@@ -70,11 +70,11 @@ The cardinality preservation lemma `Nonplanar.insertionMultiset_card_eq`
     For non-zero host A: every NIM output has cardinality |A| ≥ 1, so ε = 0.
     For host A = 0: NIM(0, B) = {0} iff B = 0, else empty. -/
 private theorem counit_insertionBasis (A B : Forest (Nonplanar α)) :
-    (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+    (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
         (GrossmanLarson.unop
-          (GrossmanLarson.insertionBasis (R := ℤ) A B)) =
-      (counit (ConnesKreimer.of' A : ConnesKreimer ℤ (Nonplanar α))) *
-        (counit (ConnesKreimer.of' B : ConnesKreimer ℤ (Nonplanar α))) := by
+          (GrossmanLarson.insertionBasis (R := R) A B)) =
+      (counit (ConnesKreimer.of' A : ConnesKreimer R (Nonplanar α))) *
+        (counit (ConnesKreimer.of' B : ConnesKreimer R (Nonplanar α))) := by
   -- Unfold insertionBasis: sum over NIM(A, B) of of' F'.
   -- ε of sum = sum of ε. ε(of' F') = if F'.card = 0 then 1 else 0.
   -- Case on A:
@@ -83,22 +83,22 @@ private theorem counit_insertionBasis (A B : Forest (Nonplanar α)) :
   unfold GrossmanLarson.insertionBasis
   -- Goal: counit (unop ((NIM A B).map (fun F' => of' F')).sum) =
   --        counit (of' A) * counit (of' B)
-  show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+  show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
       ((Nonplanar.insertionMultiset A B).map
-        fun F' => ConnesKreimer.of' (R := ℤ) F').sum =
+        fun F' => ConnesKreimer.of' (R := R) F').sum =
     _
   -- counit (Σ ...) = Σ counit (...).
   rw [show ((Nonplanar.insertionMultiset A B).map
-        fun F' => ConnesKreimer.of' (R := ℤ) F').sum =
+        fun F' => ConnesKreimer.of' (R := R) F').sum =
       ((Nonplanar.insertionMultiset A B).map
-        fun F' => ConnesKreimer.of' (R := ℤ) F').sum from rfl]
+        fun F' => ConnesKreimer.of' (R := R) F').sum from rfl]
   -- Use additivity of counit through Multiset.sum.
-  rw [show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+  rw [show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
         ((Nonplanar.insertionMultiset A B).map
-          (fun F' => ConnesKreimer.of' (R := ℤ) F')).sum =
+          (fun F' => ConnesKreimer.of' (R := R) F')).sum =
       ((Nonplanar.insertionMultiset A B).map
-        (fun F' => (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
-          (ConnesKreimer.of' (R := ℤ) F'))).sum from ?_]
+        (fun F' => (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
+          (ConnesKreimer.of' (R := R) F'))).sum from ?_]
   swap
   · -- counit preserves Multiset.sum via additivity.
     induction Nonplanar.insertionMultiset A B using Multiset.induction with
@@ -147,31 +147,31 @@ private theorem counit_insertionBasis (A B : Forest (Nonplanar α)) :
       i.e. `B₁ = B`; then `ε(unop(insertion(of' A)(of' B))) = ε(of' A) · ε(of' B) = 0`
       via `counit_insertionBasis`. -/
 private theorem counit_gl_mul_basis (A B : Forest (Nonplanar α)) :
-    (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+    (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
         (GrossmanLarson.unop
-          ((GrossmanLarson.of' (R := ℤ) A : GrossmanLarson ℤ α) *
+          ((GrossmanLarson.of' (R := R) A : GrossmanLarson R α) *
             GrossmanLarson.of' B)) =
-      (counit (ConnesKreimer.of' A : ConnesKreimer ℤ (Nonplanar α))) *
-        (counit (ConnesKreimer.of' B : ConnesKreimer ℤ (Nonplanar α))) := by
+      (counit (ConnesKreimer.of' A : ConnesKreimer R (Nonplanar α))) *
+        (counit (ConnesKreimer.of' B : ConnesKreimer R (Nonplanar α))) := by
   by_cases hB : B = 0
   · subst hB
     -- of' A *_GL of' 0 = of' A *_GL 1 = of' A.
-    have h_of_zero : (GrossmanLarson.of' (R := ℤ) (0 : Forest (Nonplanar α)) :
-          GrossmanLarson ℤ α) = 1 := GrossmanLarson.of'_zero
+    have h_of_zero : (GrossmanLarson.of' (R := R) (0 : Forest (Nonplanar α)) :
+          GrossmanLarson R α) = 1 := GrossmanLarson.of'_zero
     rw [h_of_zero, GrossmanLarson.mul_one]
-    show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+    show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
         (ConnesKreimer.of' A) =
-      (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+      (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           (ConnesKreimer.of' A) *
-        (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+        (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           (ConnesKreimer.of' (0 : Forest (Nonplanar α)))
     rw [show (ConnesKreimer.of' (0 : Forest (Nonplanar α)) :
-            ConnesKreimer ℤ (Nonplanar α)) = 1 from
+            ConnesKreimer R (Nonplanar α)) = 1 from
         ConnesKreimer.of'_zero, map_one]
     ring
   · -- B ≠ 0: counit(of' B) = 0, RHS = counit(of' A) * 0 = 0.
     have hBcard : B.card ≠ 0 := fun hc => hB (Multiset.card_eq_zero.mp hc)
-    have hCBzero : (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+    have hCBzero : (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
         (ConnesKreimer.of' B) = 0 := by
       rw [ConnesKreimer.counit_of', if_neg hBcard]
     rw [hCBzero, mul_zero]
@@ -183,14 +183,14 @@ private theorem counit_gl_mul_basis (A B : Forest (Nonplanar α)) :
     -- so the sum is 0.
     -- Helper: per-summand (CK product after unop) identity.
     have h_summand : ∀ B₁ : Forest (Nonplanar α),
-        (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+        (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           ((GrossmanLarson.unop
-              (GrossmanLarson.insertion (R := ℤ) (GrossmanLarson.of' A)
-                (GrossmanLarson.of' B₁)) : ConnesKreimer ℤ (Nonplanar α)) *
-            ConnesKreimer.of' (R := ℤ) (B - B₁)) =
-        (counit (ConnesKreimer.of' A : ConnesKreimer ℤ (Nonplanar α))) *
-          (counit (ConnesKreimer.of' (R := ℤ) (B₁ + (B - B₁)) :
-            ConnesKreimer ℤ (Nonplanar α))) := by
+              (GrossmanLarson.insertion (R := R) (GrossmanLarson.of' A)
+                (GrossmanLarson.of' B₁)) : ConnesKreimer R (Nonplanar α)) *
+            ConnesKreimer.of' (R := R) (B - B₁)) =
+        (counit (ConnesKreimer.of' A : ConnesKreimer R (Nonplanar α))) *
+          (counit (ConnesKreimer.of' (R := R) (B₁ + (B - B₁)) :
+            ConnesKreimer R (Nonplanar α))) := by
       intro B₁
       -- counit (X *_CK Y) = counit X * counit Y (algebra hom).
       rw [map_mul]
@@ -200,32 +200,32 @@ private theorem counit_gl_mul_basis (A B : Forest (Nonplanar α)) :
       rw [counit_insertionBasis A B₁]
       -- counit (of' (B₁ + (B - B₁))) = counit (of' B₁ * of'(B - B₁))
       --                              = counit (of' B₁) * counit (of'(B - B₁)).
-      rw [show (ConnesKreimer.of' (R := ℤ) (B₁ + (B - B₁)) :
-              ConnesKreimer ℤ (Nonplanar α)) =
-            ConnesKreimer.of' (R := ℤ) B₁ * ConnesKreimer.of' (R := ℤ) (B - B₁) from
+      rw [show (ConnesKreimer.of' (R := R) (B₁ + (B - B₁)) :
+              ConnesKreimer R (Nonplanar α)) =
+            ConnesKreimer.of' (R := R) B₁ * ConnesKreimer.of' (R := R) (B - B₁) from
           ConnesKreimer.of'_add B₁ (B - B₁)]
       rw [map_mul]
       ring
     -- Outer: expand (of' A) * (of' B) via productForest, push counit through sum.
     -- Generic helper: push counit (algebra hom) ∘ unop through Multiset.sum.
     -- (unop is identity coercion, so this reduces to map_multiset_sum on counit.)
-    have h_push_counit_unop_sum : ∀ s : Multiset (GrossmanLarson ℤ α),
-        (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+    have h_push_counit_unop_sum : ∀ s : Multiset (GrossmanLarson R α),
+        (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
             (GrossmanLarson.unop s.sum) =
           (s.map (fun x =>
-            (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+            (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
               (GrossmanLarson.unop x))).sum :=
-      fun s => map_multiset_sum (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) s
+      fun s => map_multiset_sum (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) s
     -- Each summand of the productForest sum reduces to 0 after counit ∘ unop:
     -- op (unop(insertion (of' A) (of' B₁)) * unop(of'(B-B₁))) — after unop on the outer,
     -- becomes the inner CK product. counit applied via h_summand: = 0 for B₁ ⊆ B.
     have h_each_zero : ∀ x ∈ B.powerset.map (fun B₁ =>
         GrossmanLarson.op
           ((GrossmanLarson.unop
-              (GrossmanLarson.insertion (R := ℤ) (GrossmanLarson.of' A)
-                (GrossmanLarson.of' B₁)) : ConnesKreimer ℤ (Nonplanar α)) *
+              (GrossmanLarson.insertion (R := R) (GrossmanLarson.of' A)
+                (GrossmanLarson.of' B₁)) : ConnesKreimer R (Nonplanar α)) *
             GrossmanLarson.unop (GrossmanLarson.of' (B - B₁)))),
-        (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+        (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           (GrossmanLarson.unop x) = 0 := by
       intro x hx
       rw [Multiset.mem_map] at hx
@@ -234,16 +234,16 @@ private theorem counit_gl_mul_basis (A B : Forest (Nonplanar α)) :
       have hB₁add : B₁ + (B - B₁) = B := by
         rw [add_comm]; exact Multiset.sub_add_cancel hB₁le
       rw [← hx_eq]
-      show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+      show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           ((GrossmanLarson.unop
-              (GrossmanLarson.insertion (R := ℤ) (GrossmanLarson.of' A)
-                (GrossmanLarson.of' B₁)) : ConnesKreimer ℤ (Nonplanar α)) *
+              (GrossmanLarson.insertion (R := R) (GrossmanLarson.of' A)
+                (GrossmanLarson.of' B₁)) : ConnesKreimer R (Nonplanar α)) *
             GrossmanLarson.unop (GrossmanLarson.of' (B - B₁))) = 0
-      show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+      show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           ((GrossmanLarson.unop
-              (GrossmanLarson.insertion (R := ℤ) (GrossmanLarson.of' A)
-                (GrossmanLarson.of' B₁)) : ConnesKreimer ℤ (Nonplanar α)) *
-            ConnesKreimer.of' (R := ℤ) (B - B₁)) = 0
+              (GrossmanLarson.insertion (R := R) (GrossmanLarson.of' A)
+                (GrossmanLarson.of' B₁)) : ConnesKreimer R (Nonplanar α)) *
+            ConnesKreimer.of' (R := R) (B - B₁)) = 0
       rw [h_summand B₁, hB₁add, hCBzero, mul_zero]
     -- Now compute LHS via productForest expansion.
     rw [GrossmanLarson.of'_mul_of']
@@ -260,160 +260,160 @@ private theorem counit_gl_mul_basis (A B : Forest (Nonplanar α)) :
 
 /-- The counit `ε` on CK is multiplicative for the GL product.
     Bilinear extension of `counit_gl_mul_basis`. -/
-theorem counit_gl_mul (x y : ConnesKreimer ℤ (Nonplanar α)) :
-    (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+theorem counit_gl_mul (x y : ConnesKreimer R (Nonplanar α)) :
+    (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
         (GrossmanLarson.unop
-          ((GrossmanLarson.op x : GrossmanLarson ℤ α) * GrossmanLarson.op y)) =
+          ((GrossmanLarson.op x : GrossmanLarson R α) * GrossmanLarson.op y)) =
       (counit x) * (counit y) := by
   refine Finsupp.induction_linear x ?_ ?_ ?_
   · -- x = 0
-    change (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+    change (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
         (GrossmanLarson.unop
-          ((0 : GrossmanLarson ℤ α) * GrossmanLarson.op y)) =
-      (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) 0 *
-        (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) y
+          ((0 : GrossmanLarson R α) * GrossmanLarson.op y)) =
+      (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) 0 *
+        (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) y
     rw [GrossmanLarson.zero_mul_gl,
-        show GrossmanLarson.unop (0 : GrossmanLarson ℤ α) =
-            (0 : ConnesKreimer ℤ (Nonplanar α)) from rfl,
+        show GrossmanLarson.unop (0 : GrossmanLarson R α) =
+            (0 : ConnesKreimer R (Nonplanar α)) from rfl,
         map_zero, zero_mul]
   · -- x = x₁ + x₂
     intro x₁ x₂ ih₁ ih₂
-    let x₁' : ConnesKreimer ℤ (Nonplanar α) := x₁
-    let x₂' : ConnesKreimer ℤ (Nonplanar α) := x₂
-    show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+    let x₁' : ConnesKreimer R (Nonplanar α) := x₁
+    let x₂' : ConnesKreimer R (Nonplanar α) := x₂
+    show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
         (GrossmanLarson.unop
-          ((GrossmanLarson.op (x₁' + x₂') : GrossmanLarson ℤ α) *
+          ((GrossmanLarson.op (x₁' + x₂') : GrossmanLarson R α) *
             GrossmanLarson.op y)) =
-      (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) (x₁' + x₂') *
-        (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) y
-    rw [show (GrossmanLarson.op (x₁' + x₂') : GrossmanLarson ℤ α) =
+      (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) (x₁' + x₂') *
+        (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) y
+    rw [show (GrossmanLarson.op (x₁' + x₂') : GrossmanLarson R α) =
           GrossmanLarson.op x₁' + GrossmanLarson.op x₂' from rfl,
         add_mul,
         show GrossmanLarson.unop
-              ((GrossmanLarson.op x₁' : GrossmanLarson ℤ α) * GrossmanLarson.op y +
+              ((GrossmanLarson.op x₁' : GrossmanLarson R α) * GrossmanLarson.op y +
                 GrossmanLarson.op x₂' * GrossmanLarson.op y) =
             GrossmanLarson.unop
-                ((GrossmanLarson.op x₁' : GrossmanLarson ℤ α) * GrossmanLarson.op y) +
+                ((GrossmanLarson.op x₁' : GrossmanLarson R α) * GrossmanLarson.op y) +
               GrossmanLarson.unop
                 (GrossmanLarson.op x₂' * GrossmanLarson.op y) from rfl,
-        show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+        show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
               (GrossmanLarson.unop
-                  ((GrossmanLarson.op x₁' : GrossmanLarson ℤ α) * GrossmanLarson.op y) +
+                  ((GrossmanLarson.op x₁' : GrossmanLarson R α) * GrossmanLarson.op y) +
                 GrossmanLarson.unop
                   (GrossmanLarson.op x₂' * GrossmanLarson.op y)) =
             counit (GrossmanLarson.unop
-                  ((GrossmanLarson.op x₁' : GrossmanLarson ℤ α) * GrossmanLarson.op y)) +
+                  ((GrossmanLarson.op x₁' : GrossmanLarson R α) * GrossmanLarson.op y)) +
               counit (GrossmanLarson.unop
                 (GrossmanLarson.op x₂' * GrossmanLarson.op y)) from
           map_add _ _ _]
-    rw [ih₁, ih₂, map_add (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) x₁' x₂']
+    rw [ih₁, ih₂, map_add (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) x₁' x₂']
     ring
   · -- x = single F r
     intro F r
     refine Finsupp.induction_linear y ?_ ?_ ?_
     · -- y = 0
-      let x_single : ConnesKreimer ℤ (Nonplanar α) := Finsupp.single F r
-      change (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+      change (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           (GrossmanLarson.unop
-            ((GrossmanLarson.op x_single : GrossmanLarson ℤ α) *
-              (0 : GrossmanLarson ℤ α))) =
-        (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) x_single *
-          (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) 0
+            ((GrossmanLarson.op x_single : GrossmanLarson R α) *
+              (0 : GrossmanLarson R α))) =
+        (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) x_single *
+          (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) 0
       rw [GrossmanLarson.mul_zero_gl,
-          show GrossmanLarson.unop (0 : GrossmanLarson ℤ α) =
-              (0 : ConnesKreimer ℤ (Nonplanar α)) from rfl,
+          show GrossmanLarson.unop (0 : GrossmanLarson R α) =
+              (0 : ConnesKreimer R (Nonplanar α)) from rfl,
           map_zero, mul_zero]
     · -- y = y₁ + y₂
       intro y₁ y₂ ih₁ ih₂
-      let x_single : ConnesKreimer ℤ (Nonplanar α) := Finsupp.single F r
-      let y₁' : ConnesKreimer ℤ (Nonplanar α) := y₁
-      let y₂' : ConnesKreimer ℤ (Nonplanar α) := y₂
-      show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+      let y₁' : ConnesKreimer R (Nonplanar α) := y₁
+      let y₂' : ConnesKreimer R (Nonplanar α) := y₂
+      show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           (GrossmanLarson.unop
-            ((GrossmanLarson.op x_single : GrossmanLarson ℤ α) *
+            ((GrossmanLarson.op x_single : GrossmanLarson R α) *
               GrossmanLarson.op (y₁' + y₂'))) =
-        (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) x_single *
-          (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) (y₁' + y₂')
-      rw [show (GrossmanLarson.op (y₁' + y₂') : GrossmanLarson ℤ α) =
+        (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) x_single *
+          (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) (y₁' + y₂')
+      rw [show (GrossmanLarson.op (y₁' + y₂') : GrossmanLarson R α) =
             GrossmanLarson.op y₁' + GrossmanLarson.op y₂' from rfl,
           mul_add,
           show GrossmanLarson.unop
-              ((GrossmanLarson.op x_single : GrossmanLarson ℤ α) * GrossmanLarson.op y₁' +
+              ((GrossmanLarson.op x_single : GrossmanLarson R α) * GrossmanLarson.op y₁' +
                 GrossmanLarson.op x_single * GrossmanLarson.op y₂') =
             GrossmanLarson.unop
-                ((GrossmanLarson.op x_single : GrossmanLarson ℤ α) * GrossmanLarson.op y₁') +
+                ((GrossmanLarson.op x_single : GrossmanLarson R α) * GrossmanLarson.op y₁') +
               GrossmanLarson.unop
                 (GrossmanLarson.op x_single * GrossmanLarson.op y₂') from rfl,
-          show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+          show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
                 (GrossmanLarson.unop
-                    ((GrossmanLarson.op x_single : GrossmanLarson ℤ α) *
+                    ((GrossmanLarson.op x_single : GrossmanLarson R α) *
                       GrossmanLarson.op y₁') +
                   GrossmanLarson.unop
                     (GrossmanLarson.op x_single * GrossmanLarson.op y₂')) =
               counit (GrossmanLarson.unop
-                    ((GrossmanLarson.op x_single : GrossmanLarson ℤ α) *
+                    ((GrossmanLarson.op x_single : GrossmanLarson R α) *
                       GrossmanLarson.op y₁')) +
                 counit (GrossmanLarson.unop
                   (GrossmanLarson.op x_single * GrossmanLarson.op y₂')) from
             map_add _ _ _]
-      rw [ih₁, ih₂, map_add (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) y₁' y₂']
+      rw [ih₁, ih₂, map_add (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) y₁' y₂']
       ring
     · -- y = single G s: factor r, s, apply counit_gl_mul_basis F G
       intro G s
-      let x_single : ConnesKreimer ℤ (Nonplanar α) := Finsupp.single F r
-      let y_single : ConnesKreimer ℤ (Nonplanar α) := Finsupp.single G s
-      show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+      let y_single : ConnesKreimer R (Nonplanar α) := Finsupp.single G s
+      show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           (GrossmanLarson.unop
-            ((GrossmanLarson.op x_single : GrossmanLarson ℤ α) *
+            ((GrossmanLarson.op x_single : GrossmanLarson R α) *
               GrossmanLarson.op y_single)) =
-        (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) x_single *
-          (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) y_single
-      have hx : x_single = r • (ConnesKreimer.of' (R := ℤ) F) := by
-        show (Finsupp.single F r : ConnesKreimer ℤ (Nonplanar α)) =
-            r • (Finsupp.single F (1 : ℤ) : ConnesKreimer ℤ (Nonplanar α))
+        (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) x_single *
+          (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) y_single
+      have hx : x_single = r • (ConnesKreimer.of' (R := R) F) := by
+        show (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
+            r • (Finsupp.single F (1 : R) : ConnesKreimer R (Nonplanar α))
         exact (Finsupp.smul_single_one F r).symm
-      have hy : y_single = s • (ConnesKreimer.of' (R := ℤ) G) := by
-        show (Finsupp.single G s : ConnesKreimer ℤ (Nonplanar α)) =
-            s • (Finsupp.single G (1 : ℤ) : ConnesKreimer ℤ (Nonplanar α))
+      have hy : y_single = s • (ConnesKreimer.of' (R := R) G) := by
+        show (Finsupp.single G s : ConnesKreimer R (Nonplanar α)) =
+            s • (Finsupp.single G (1 : R) : ConnesKreimer R (Nonplanar α))
         exact (Finsupp.smul_single_one G s).symm
       rw [hx, hy]
       -- Pull r, s through op and *.
-      rw [show (GrossmanLarson.op (r • ConnesKreimer.of' (R := ℤ) F) :
-            GrossmanLarson ℤ α) =
-          r • GrossmanLarson.op (ConnesKreimer.of' (R := ℤ) F) from rfl,
-          show (GrossmanLarson.op (s • ConnesKreimer.of' (R := ℤ) G) :
-            GrossmanLarson ℤ α) =
-          s • GrossmanLarson.op (ConnesKreimer.of' (R := ℤ) G) from rfl,
+      rw [show (GrossmanLarson.op (r • ConnesKreimer.of' (R := R) F) :
+            GrossmanLarson R α) =
+          r • GrossmanLarson.op (ConnesKreimer.of' (R := R) F) from rfl,
+          show (GrossmanLarson.op (s • ConnesKreimer.of' (R := R) G) :
+            GrossmanLarson R α) =
+          s • GrossmanLarson.op (ConnesKreimer.of' (R := R) G) from rfl,
           GrossmanLarson.smul_mul_gl, GrossmanLarson.mul_smul_gl]
       -- unop is linear (rfl), counit is linear → pull r, s out.
       rw [show GrossmanLarson.unop (r • s • ((GrossmanLarson.op
-              (ConnesKreimer.of' (R := ℤ) F) : GrossmanLarson ℤ α) *
-                GrossmanLarson.op (ConnesKreimer.of' (R := ℤ) G))) =
+              (ConnesKreimer.of' (R := R) F) : GrossmanLarson R α) *
+                GrossmanLarson.op (ConnesKreimer.of' (R := R) G))) =
             r • s • GrossmanLarson.unop ((GrossmanLarson.op
-                (ConnesKreimer.of' (R := ℤ) F) : GrossmanLarson ℤ α) *
-                GrossmanLarson.op (ConnesKreimer.of' (R := ℤ) G)) from rfl,
-          show (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+                (ConnesKreimer.of' (R := R) F) : GrossmanLarson R α) *
+                GrossmanLarson.op (ConnesKreimer.of' (R := R) G)) from rfl,
+          show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
               (r • s • GrossmanLarson.unop ((GrossmanLarson.op
-                  (ConnesKreimer.of' (R := ℤ) F) : GrossmanLarson ℤ α) *
-                  GrossmanLarson.op (ConnesKreimer.of' (R := ℤ) G))) =
-            r • s • (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+                  (ConnesKreimer.of' (R := R) F) : GrossmanLarson R α) *
+                  GrossmanLarson.op (ConnesKreimer.of' (R := R) G))) =
+            r • s • (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
               (GrossmanLarson.unop ((GrossmanLarson.op
-                  (ConnesKreimer.of' (R := ℤ) F) : GrossmanLarson ℤ α) *
-                  GrossmanLarson.op (ConnesKreimer.of' (R := ℤ) G))) from by
-          rw [map_smul (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ),
-              map_smul (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)]]
+                  (ConnesKreimer.of' (R := R) F) : GrossmanLarson R α) *
+                  GrossmanLarson.op (ConnesKreimer.of' (R := R) G))) from by
+          rw [map_smul (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R),
+              map_smul (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)]]
       -- Apply counit_gl_mul_basis F G via `change` to bridge op (CK.of' _) → GL.of' _.
-      change r • s • (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
+      change r • s • (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           (GrossmanLarson.unop
-            ((GrossmanLarson.of' (R := ℤ) F : GrossmanLarson ℤ α) *
+            ((GrossmanLarson.of' (R := R) F : GrossmanLarson R α) *
               GrossmanLarson.of' G)) =
-        (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
-            (r • ConnesKreimer.of' (R := ℤ) F) *
-          (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)
-            (s • ConnesKreimer.of' (R := ℤ) G)
+        (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
+            (r • ConnesKreimer.of' (R := R) F) *
+          (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
+            (s • ConnesKreimer.of' (R := R) G)
       rw [counit_gl_mul_basis F G,
-          map_smul (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ),
-          map_smul (counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ)]
+          map_smul (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R),
+          map_smul (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)]
       -- Now both sides are r • s • (counit_F * counit_G) (with coefficient gymnastics).
       simp only [smul_eq_mul]
       ring
@@ -426,35 +426,35 @@ theorem counit_gl_mul (x y : ConnesKreimer ℤ (Nonplanar α)) :
     Specifically:
     `⟨unop (op X * op Y), B+_a z⟩ = ε(X) · ⟨B-_a Y, z⟩ + ⟨unop (op (B-_a X) * op Y), z⟩`. -/
 theorem pairing_apply_bPlus_gl_mul (a : α)
-    (X Y z : ConnesKreimer ℤ (Nonplanar α)) :
-    pairing (R := ℤ) (GrossmanLarson.unop
-        ((GrossmanLarson.op X : GrossmanLarson ℤ α) * GrossmanLarson.op Y))
-      (ConnesKreimer.bPlusLin (R := ℤ) a z) =
-      (counit X) * pairing (R := ℤ) (bMinusLin (R := ℤ) a Y) z +
-      pairing (R := ℤ) (GrossmanLarson.unop
-          ((GrossmanLarson.op (bMinusLin (R := ℤ) a X) : GrossmanLarson ℤ α) *
+    (X Y z : ConnesKreimer R (Nonplanar α)) :
+    pairing (R := R) (GrossmanLarson.unop
+        ((GrossmanLarson.op X : GrossmanLarson R α) * GrossmanLarson.op Y))
+      (ConnesKreimer.bPlusLin (R := R) a z) =
+      (counit X) * pairing (R := R) (bMinusLin (R := R) a Y) z +
+      pairing (R := R) (GrossmanLarson.unop
+          ((GrossmanLarson.op (bMinusLin (R := R) a X) : GrossmanLarson R α) *
             GrossmanLarson.op Y)) z := by
   -- Step 1: B+/B- adjoint: ⟨W, B+_a z⟩ = ⟨B-_a W, z⟩ with W = unop(op X * op Y).
   rw [← bMinusLin_pairing_adjoint a (GrossmanLarson.unop
-        ((GrossmanLarson.op X : GrossmanLarson ℤ α) * GrossmanLarson.op Y)) z]
+        ((GrossmanLarson.op X : GrossmanLarson R α) * GrossmanLarson.op Y)) z]
   -- Step 2: Phase C identity: B-_a (unop (op X * op Y)) = ε(X) • B-_a Y + unop (op (B-_a X) * op Y).
   have hC := bMinusLin_gl_mul a X Y
   -- Express LHS bMinusLin a (op X * op Y).unop in form matching hC's LHS.
-  have hLHS_form : bMinusLin (R := ℤ) a
+  have hLHS_form : bMinusLin (R := R) a
       (GrossmanLarson.unop
-        ((GrossmanLarson.op X : GrossmanLarson ℤ α) * GrossmanLarson.op Y)) =
-    bMinusLin (R := ℤ) a
-      ((GrossmanLarson.op X : GrossmanLarson ℤ α) * GrossmanLarson.op Y) := rfl
+        ((GrossmanLarson.op X : GrossmanLarson R α) * GrossmanLarson.op Y)) =
+    bMinusLin (R := R) a
+      ((GrossmanLarson.op X : GrossmanLarson R α) * GrossmanLarson.op Y) := rfl
   rw [hLHS_form, hC]
   -- Step 3: pairing is additive in first arg.
   rw [LinearMap.map_add, LinearMap.add_apply]
   -- Step 4: pairing pulls out ε(X) scalar from the first summand.
-  rw [show pairing (R := ℤ)
-        (((counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) X) •
-          bMinusLin (R := ℤ) a Y) =
-      ((counit : ConnesKreimer ℤ (Nonplanar α) →ₐ[ℤ] ℤ) X) •
-        pairing (R := ℤ) (bMinusLin a Y) from
-      LinearMap.map_smul (pairing : ConnesKreimer ℤ _ →ₗ[ℤ] _) _ _]
+  rw [show pairing (R := R)
+        (((counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) X) •
+          bMinusLin (R := R) a Y) =
+      ((counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) X) •
+        pairing (R := R) (bMinusLin a Y) from
+      LinearMap.map_smul (pairing : ConnesKreimer R _ →ₗ[R] _) _ _]
   rw [LinearMap.smul_apply]
   -- Goal: (counit X) • pairing (B-_a Y) z + pairing (unop (op (B-_a X) * op Y)) z
   --     = (counit X) * pairing (B-_a Y) z + pairing (unop (op (B-_a X) * op Y)) z

--- a/Linglib/Core/Combinatorics/RootedTree/Aut.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Aut.lean
@@ -5,8 +5,11 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Combinatorics.RootedTree.Nonplanar
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset.Piecewise
 import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Finset
+import Mathlib.Data.Multiset.Antidiagonal
 import Mathlib.Data.Multiset.Basic
+import Mathlib.Data.Nat.Choose.Basic
 import Mathlib.Data.Nat.Factorial.Basic
 
 set_option autoImplicit false
@@ -320,6 +323,323 @@ private theorem ofList_map_mk_qout (lst : List (Nonplanar α)) :
     apply Finset.prod_congr rfl
     intro t _
     ring
+
+/-! ### Multinomial split identity
+
+The automorphism count of a disjoint union `F + G` factors through any
+fixed split: `|Aut(F+G)| = N · |Aut F| · |Aut G|` where `N` counts the
+occurrences of the ordered pair `(F, G)` among the two-sided sub-multiset
+splits of `F + G` (`Multiset.antidiagonal`). Per distinct tree `t`, this
+is `(m₁ + m₂)! = C(m₁ + m₂, m₁) · m₁! · m₂!` with `mᵢ` the
+multiplicities in `F`, `G` — `Nat.add_choose_mul_factorial_mul_factorial`
+aggregated over `(F + G).toFinset`. The adjoint role: this is exactly
+what makes the symmetry-weighted pairing turn CK multiplication into the
+sub-multiset split coproduct (`GrossmanLarsonPairing.pairing_of'_mul`).
+
+Computationally validated (`scratch/validate_duality.lean`, V2 battery,
+exhaustive over forests of weight ≤ 3 plus duplicate-tree traps). -/
+
+/-- Count of an ordered split `(F, G)` in `antidiagonal (F + G)` equals the
+    count of `G` in `powerset (F + G)`: `antidiagonal_eq_map_powerset`
+    expresses the antidiagonal as the powerset mapped through the injective
+    `t ↦ (s - t, t)`, and the second coordinate `G` is in the image at
+    exactly one preimage. -/
+private theorem count_antidiagonal_eq_count_powerset
+    (F G : Multiset (Nonplanar α)) :
+    letI : DecidableEq (Nonplanar α) := Classical.decEq _
+    Multiset.count (F, G) (Multiset.antidiagonal (F + G)) =
+      Multiset.count G (Multiset.powerset (F + G)) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  rw [Multiset.antidiagonal_eq_map_powerset]
+  -- Map is `fun t => (F + G - t, t)`, which is injective in `t` (second coord).
+  have hinj : Function.Injective
+      (fun t : Multiset (Nonplanar α) => (F + G - t, t)) := by
+    intro t₁ t₂ h
+    exact ((Prod.mk.injEq _ _ _ _).mp h).2
+  -- `(F, G) = (F + G - G, G)` because `F + G - G = F`.
+  have hpair : ((F + G - G, G) : Multiset (Nonplanar α) × _) = (F, G) := by
+    rw [Multiset.add_sub_cancel_right]
+  rw [← hpair]
+  exact Multiset.count_map_eq_count' _ _ hinj _
+
+/-- Pascal-style aggregation helper used inside `count_powerset_eq_prod_choose`.
+    At every element of `H'.toFinset`, the per-element identity
+    `H'.count t.choose ((a ::ₘ F').count t) + H'.count t.choose (F'.count t)
+      = (a ::ₘ H').count t.choose ((a ::ₘ F').count t)` collapses two
+    `H'.count t`-indexed products into one `(a ::ₘ H').count t`-indexed product,
+    using `Nat.choose_succ_succ'` at `t = a` and matching `cons`-counts elsewhere. -/
+private theorem pascal_choose_sum_aux
+    (F' H' : Multiset (Nonplanar α)) (a : Nonplanar α)
+    (ha_in_H' : a ∈ H') :
+    letI : DecidableEq (Nonplanar α) := Classical.decEq _
+    H'.toFinset.prod (fun t => (H'.count t).choose ((a ::ₘ F').count t)) +
+        H'.toFinset.prod (fun t => (H'.count t).choose (F'.count t)) =
+      H'.toFinset.prod
+        (fun t => ((a ::ₘ H').count t).choose ((a ::ₘ F').count t)) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  -- Pull `a` out of each Finset prod via `prod_eq_prod_diff_singleton_mul`.
+  have ha_toFin : a ∈ H'.toFinset := Multiset.mem_toFinset.mpr ha_in_H'
+  rw [Finset.prod_eq_prod_diff_singleton_mul ha_toFin
+        (f := fun t => (H'.count t).choose ((a ::ₘ F').count t)),
+      Finset.prod_eq_prod_diff_singleton_mul ha_toFin
+        (f := fun t => (H'.count t).choose (F'.count t)),
+      Finset.prod_eq_prod_diff_singleton_mul ha_toFin
+        (f := fun t => ((a ::ₘ H').count t).choose ((a ::ₘ F').count t))]
+  -- At each `t ∈ H'.toFinset \ {a}`, the three products agree (count_cons on a t ≠ a).
+  have h_diff_LHS1 :
+      (H'.toFinset \ {a}).prod (fun t => (H'.count t).choose ((a ::ₘ F').count t))
+        = (H'.toFinset \ {a}).prod (fun t => (H'.count t).choose (F'.count t)) := by
+    refine Finset.prod_congr rfl ?_
+    intro t ht
+    have ht_ne_a : t ≠ a := by
+      rw [Finset.mem_sdiff, Finset.mem_singleton] at ht
+      exact ht.2
+    rw [Multiset.count_cons_of_ne ht_ne_a]
+  have h_diff_RHS :
+      (H'.toFinset \ {a}).prod
+          (fun t => ((a ::ₘ H').count t).choose ((a ::ₘ F').count t))
+        = (H'.toFinset \ {a}).prod (fun t => (H'.count t).choose (F'.count t)) := by
+    refine Finset.prod_congr rfl ?_
+    intro t ht
+    have ht_ne_a : t ≠ a := by
+      rw [Finset.mem_sdiff, Finset.mem_singleton] at ht
+      exact ht.2
+    rw [Multiset.count_cons_of_ne ht_ne_a,
+        Multiset.count_cons_of_ne ht_ne_a]
+  rw [h_diff_LHS1, h_diff_RHS]
+  -- Now: P * x + P * y = P * z (where P = diff prod common factor).
+  rw [← mul_add]
+  congr 1
+  -- Normalize counts at `a` via `count_cons_self`.
+  simp only [Multiset.count_cons_self]
+  -- Goal:
+  --   H'.count a.choose (F'.count a + 1) + H'.count a.choose (F'.count a)
+  --   = (H'.count a + 1).choose (F'.count a + 1)
+  -- Pascal: `(n+1).choose (k+1) = n.choose k + n.choose (k+1)`.
+  rw [Nat.choose_succ_succ', add_comm]
+
+/-- The count of `F` in `powerset H` is the product over distinct elements
+    of `H` of `(H.count t).choose (F.count t)`, provided `F ≤ H`. Proved by
+    induction on `H`: at `H = a ::ₘ H'`, split `powerset (a ::ₘ H')` via
+    Pascal's rule and case on `a ∈ F`. -/
+private theorem count_powerset_eq_prod_choose
+    (F H : Multiset (Nonplanar α)) (hFH : F ≤ H) :
+    letI : DecidableEq (Nonplanar α) := Classical.decEq _
+    Multiset.count F (Multiset.powerset H) =
+      H.toFinset.prod (fun t => (H.count t).choose (F.count t)) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  induction H using Multiset.induction_on generalizing F with
+  | empty =>
+    -- `F ≤ 0` forces `F = 0`. RHS is empty product = 1.
+    have hF : F = 0 := Multiset.le_zero.mp hFH
+    subst hF
+    simp [Multiset.powerset_zero, Multiset.toFinset_zero]
+  | cons a H' ih =>
+    rw [Multiset.powerset_cons, Multiset.count_add]
+    -- `cons a` is injective.
+    have h_inj : Function.Injective (Multiset.cons a) := fun _ _ h =>
+      (Multiset.cons_inj_right a).mp h
+    by_cases ha_in_F : a ∈ F
+    · -- `a ∈ F`: F = a ::ₘ F' with F' ≤ H'.
+      obtain ⟨F', hF_eq⟩ := Multiset.exists_cons_of_mem ha_in_F
+      subst hF_eq
+      have hF'_le : F' ≤ H' := (Multiset.cons_le_cons_iff a).mp hFH
+      -- Second summand = count F' (powerset H'); rewrite via `count_map_eq_count'`.
+      have h_second :
+          Multiset.count (a ::ₘ F')
+              ((Multiset.powerset H').map (Multiset.cons a)) =
+            Multiset.count F' (Multiset.powerset H') :=
+        Multiset.count_map_eq_count' _ _ h_inj F'
+      by_cases ha_in_H' : a ∈ H'
+      · -- a ∈ H'. Sub-case on whether `a ::ₘ F' ≤ H'` (i.e. `count a F' < count a H'`).
+        have ha_pos : 1 ≤ Multiset.count a H' :=
+          Multiset.one_le_count_iff_mem.mpr ha_in_H'
+        have h_aH'_toFinset : (a ::ₘ H').toFinset = H'.toFinset := by
+          rw [Multiset.toFinset_cons]
+          exact Finset.insert_eq_of_mem (Multiset.mem_toFinset.mpr ha_in_H')
+        -- F'.count a ≤ H'.count a (from F' ≤ H').
+        have h_cF'_le_cH' : Multiset.count a F' ≤ Multiset.count a H' :=
+          Multiset.le_iff_count.mp hF'_le a
+        by_cases h_strict : Multiset.count a F' + 1 ≤ Multiset.count a H'
+        · -- A1: `a ::ₘ F' ≤ H'`. Apply ih to both `a ::ₘ F'` and `F'`.
+          have h_le' : a ::ₘ F' ≤ H' := by
+            rw [Multiset.le_iff_count]
+            intro b
+            have h_master := Multiset.le_iff_count.mp hFH b
+            by_cases hb : b = a
+            · rw [hb, Multiset.count_cons_self, Multiset.count_cons_self] at h_master
+              rw [hb, Multiset.count_cons_self]; omega
+            · rw [Multiset.count_cons_of_ne hb, Multiset.count_cons_of_ne hb] at h_master
+              rw [Multiset.count_cons_of_ne hb]; exact h_master
+          rw [ih (a ::ₘ F') h_le', h_second, ih F' hF'_le]
+          rw [h_aH'_toFinset]
+          exact pascal_choose_sum_aux F' H' a ha_in_H'
+        · -- A2: `count a F' + 1 > count a H'`. Combined with `count a F' ≤ count a H'`,
+          -- forces `count a F' = count a H'`. So `a ::ₘ F' ≰ H'`, first summand = 0.
+          have h_eq : Multiset.count a F' = Multiset.count a H' := by omega
+          have h_first_zero :
+              Multiset.count (a ::ₘ F') (Multiset.powerset H') = 0 := by
+            rw [Multiset.count_eq_zero, Multiset.mem_powerset]
+            intro h_le_H'
+            have := Multiset.le_iff_count.mp h_le_H' a
+            rw [Multiset.count_cons_self] at this
+            omega
+          rw [h_first_zero, Nat.zero_add, h_second, ih F' hF'_le]
+          rw [h_aH'_toFinset]
+          -- Goal: ∏ t ∈ H'.toFinset, H'.count t.choose F'.count t
+          --     = ∏ t ∈ H'.toFinset, (a ::ₘ H').count t.choose (a ::ₘ F').count t.
+          refine Finset.prod_congr rfl ?_
+          intro t _
+          by_cases ht_eq : t = a
+          · -- At t = a: H'.count a.choose F'.count a on LHS;
+            -- (H'.count a + 1).choose (F'.count a + 1) on RHS.
+            -- Using h_eq, F'.count a = H'.count a, so LHS = n.choose n = 1 and
+            -- RHS = (n+1).choose (n+1) = 1.
+            subst ht_eq
+            rw [Multiset.count_cons_self, Multiset.count_cons_self, h_eq]
+            simp
+          · rw [Multiset.count_cons_of_ne ht_eq, Multiset.count_cons_of_ne ht_eq]
+      · -- a ∉ H': first summand is 0 (a ::ₘ F' ≰ H').
+        have h_first_zero : Multiset.count (a ::ₘ F') (Multiset.powerset H') = 0 := by
+          rw [Multiset.count_eq_zero, Multiset.mem_powerset]
+          intro h_le_H'
+          have := Multiset.le_iff_count.mp h_le_H' a
+          rw [Multiset.count_cons_self, Multiset.count_eq_zero.mpr ha_in_H'] at this
+          omega
+        rw [h_first_zero, Nat.zero_add, h_second, ih F' hF'_le]
+        rw [Multiset.toFinset_cons]
+        have h_a_notin : a ∉ H'.toFinset := fun h =>
+          ha_in_H' (Multiset.mem_toFinset.mp h)
+        rw [Finset.prod_insert h_a_notin]
+        rw [Multiset.count_cons_self, Multiset.count_cons_self,
+            Multiset.count_eq_zero.mpr ha_in_H']
+        -- `F'.count a = 0` since `F' ≤ H'` and `a ∉ H'`.
+        have h_count_aF' : Multiset.count a F' = 0 := by
+          rw [Multiset.count_eq_zero]
+          intro h_mem
+          exact ha_in_H' (Multiset.subset_of_le hF'_le h_mem)
+        rw [h_count_aF']
+        simp only [Nat.zero_add, Nat.choose_self, one_mul]
+        refine Finset.prod_congr rfl ?_
+        intro t ht
+        have ht_ne_a : t ≠ a := fun h => h_a_notin (h ▸ ht)
+        rw [Multiset.count_cons_of_ne ht_ne_a, Multiset.count_cons_of_ne ht_ne_a]
+    · -- a ∉ F: F ≤ H'.
+      have hF_le' : F ≤ H' := by
+        rw [Multiset.le_iff_count]
+        intro b
+        by_cases hb : b = a
+        · subst hb
+          rw [Multiset.count_eq_zero.mpr ha_in_F]
+          exact Nat.zero_le _
+        · have h_master := Multiset.le_iff_count.mp hFH b
+          rw [Multiset.count_cons_of_ne hb] at h_master
+          exact h_master
+      -- Second summand is 0 (F doesn't contain `a`).
+      have h_second_zero :
+          Multiset.count F ((Multiset.powerset H').map (Multiset.cons a)) = 0 := by
+        rw [Multiset.count_eq_zero, Multiset.mem_map]
+        rintro ⟨S, _, hS⟩
+        have : a ∈ F := hS ▸ Multiset.mem_cons_self a S
+        exact ha_in_F this
+      rw [h_second_zero, Nat.add_zero, ih F hF_le']
+      rw [Multiset.toFinset_cons]
+      by_cases ha_in_H' : a ∈ H'
+      · rw [Finset.insert_eq_of_mem (Multiset.mem_toFinset.mpr ha_in_H')]
+        refine Finset.prod_congr rfl ?_
+        intro t _
+        by_cases ht_eq : t = a
+        · subst ht_eq
+          rw [Multiset.count_cons_self, Multiset.count_eq_zero.mpr ha_in_F]
+          simp [Nat.choose_zero_right]
+        · rw [Multiset.count_cons_of_ne ht_eq]
+      · have h_a_notin : a ∉ H'.toFinset :=
+          fun h => ha_in_H' (Multiset.mem_toFinset.mp h)
+        rw [Finset.prod_insert h_a_notin]
+        rw [Multiset.count_cons_self, Multiset.count_eq_zero.mpr ha_in_H',
+            Multiset.count_eq_zero.mpr ha_in_F]
+        simp only [Nat.zero_add, Nat.choose_zero_right, one_mul]
+        refine Finset.prod_congr rfl ?_
+        intro t ht
+        have ht_ne_a : t ≠ a := fun h => h_a_notin (h ▸ ht)
+        rw [Multiset.count_cons_of_ne ht_ne_a]
+
+/-- Per-element multinomial: at every distinct tree `t`,
+    `((F+G).count t).choose (G.count t) * (F.count t)! * (G.count t)!
+      = ((F+G).count t)!`. This is
+    `Nat.add_choose_mul_factorial_mul_factorial` with
+    `i = F.count t`, `j = G.count t`, after rewriting
+    `(F+G).count t = F.count t + G.count t`. -/
+private theorem pointwise_factorial_split
+    (F G : Multiset (Nonplanar α)) (t : Nonplanar α) :
+    letI : DecidableEq (Nonplanar α) := Classical.decEq _
+    ((F + G).count t).choose (G.count t) *
+        Nat.factorial (F.count t) * Nat.factorial (G.count t) =
+      Nat.factorial ((F + G).count t) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  rw [Multiset.count_add]
+  exact Nat.add_choose_mul_factorial_mul_factorial _ _
+
+/-- **Multinomial split identity** for `forestAutCard`:
+    `count (F,G) (antidiagonal (F+G)) · |Aut F| · |Aut G| = |Aut (F+G)|`. -/
+theorem forestAutCard_add (F G : Multiset (Nonplanar α)) :
+    (letI : DecidableEq (Nonplanar α) := Classical.decEq _
+     Multiset.count (F, G) (Multiset.antidiagonal (F + G))) *
+      (forestAutCard F * forestAutCard G) = forestAutCard (F + G) := by
+  letI : DecidableEq (Nonplanar α) := Classical.decEq _
+  rw [count_antidiagonal_eq_count_powerset]
+  rw [count_powerset_eq_prod_choose G (F + G) (Multiset.le_add_left G F)]
+  -- Unfold forestAutCard in three places.
+  unfold forestAutCard
+  -- Extend `F.toFinset`/`G.toFinset` prods to `(F+G).toFinset` prods
+  -- (extension by factors equal to 1).
+  set S := (F + G).toFinset with hS_def
+  have hF_sub : F.toFinset ⊆ S := by
+    intro t ht
+    rw [hS_def, Multiset.mem_toFinset] at *
+    exact Multiset.subset_of_le (Multiset.le_add_right F G) ht
+  have hG_sub : G.toFinset ⊆ S := by
+    intro t ht
+    rw [hS_def, Multiset.mem_toFinset] at *
+    exact Multiset.subset_of_le (Multiset.le_add_left G F) ht
+  have hF_ext : F.toFinset.prod
+      (fun t => Nat.factorial (F.count t) * autCard t ^ F.count t) =
+      S.prod (fun t => Nat.factorial (F.count t) * autCard t ^ F.count t) := by
+    refine Finset.prod_subset hF_sub ?_
+    intro t _ htF
+    have h_cF : F.count t = 0 := Multiset.count_eq_zero.mpr (fun h_mem =>
+      htF (Multiset.mem_toFinset.mpr h_mem))
+    rw [h_cF]; simp
+  have hG_ext : G.toFinset.prod
+      (fun t => Nat.factorial (G.count t) * autCard t ^ G.count t) =
+      S.prod (fun t => Nat.factorial (G.count t) * autCard t ^ G.count t) := by
+    refine Finset.prod_subset hG_sub ?_
+    intro t _ htG
+    have h_cG : G.count t = 0 := Multiset.count_eq_zero.mpr (fun h_mem =>
+      htG (Multiset.mem_toFinset.mpr h_mem))
+    rw [h_cG]; simp
+  rw [hF_ext, hG_ext]
+  -- Combine into a single `Finset.prod` over `S`.
+  rw [← Finset.prod_mul_distrib, ← Finset.prod_mul_distrib]
+  refine Finset.prod_congr rfl ?_
+  intro t _
+  -- Per-element identity:
+  --   choose(G.count t) * ((F.count t! * a^F.count t) * (G.count t! * a^G.count t))
+  -- = (F.count t + G.count t)! * a^(F.count t + G.count t)
+  -- where a = autCard t. Use `pointwise_factorial_split` and `pow_add`.
+  have h_fact := pointwise_factorial_split F G t
+  rw [Multiset.count_add] at h_fact
+  rw [Multiset.count_add, pow_add]
+  -- Goal: choose(m₂) * ((m₁! * a^m₁) * (m₂! * a^m₂)) = (m₁+m₂)! * (a^m₁ * a^m₂)
+  -- where m₁ = F.count t, m₂ = G.count t.
+  set m₁ := F.count t
+  set m₂ := G.count t
+  set a := autCard t
+  -- h_fact : (m₁ + m₂).choose m₂ * m₁! * m₂! = (m₁ + m₂)!
+  calc (m₁ + m₂).choose m₂ * (m₁.factorial * a ^ m₁ * (m₂.factorial * a ^ m₂))
+      = ((m₁ + m₂).choose m₂ * m₁.factorial * m₂.factorial) *
+          (a ^ m₁ * a ^ m₂) := by ring
+    _ = (m₁ + m₂).factorial * (a ^ m₁ * a ^ m₂) := by rw [h_fact]
 
 end Nonplanar
 

--- a/Linglib/Core/Combinatorics/RootedTree/Nonplanar.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Nonplanar.lean
@@ -2,7 +2,10 @@ import Linglib.Core.Combinatorics.RootedTree.Planar
 import Mathlib.Data.List.Perm.Basic
 import Mathlib.Data.List.Forall2
 import Mathlib.Logic.Relation
+import Mathlib.Algebra.BigOperators.Group.Multiset.Defs
+import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Data.Multiset.Basic
+import Mathlib.Data.Multiset.MapFold
 
 set_option autoImplicit false
 
@@ -606,6 +609,40 @@ theorem node_eta (t : Nonplanar α) : node (rootLabel t) (rootChildren t) = t :=
   | h p =>
     cases p with
     | node a cs => exact node_mk_planar_list a cs
+
+/-! ### Weight of a `node` -/
+
+private theorem weightList_eq_sum_map (cs : List (Planar α)) :
+    Planar.weightList cs = (cs.map Planar.weight).sum := by
+  induction cs with
+  | nil => rfl
+  | cons c cs ih =>
+    show Planar.weight c + Planar.weightList cs = _
+    rw [List.map_cons, List.sum_cons, ih]
+
+/-- Every tree has at least one vertex (the root). -/
+theorem weight_pos (t : Nonplanar α) : 0 < t.weight := by
+  refine Quotient.inductionOn t fun p => ?_
+  cases p with
+  | node a cs =>
+    show 0 < Planar.weight (.node a cs)
+    show 0 < 1 + Planar.weightList cs
+    omega
+
+/-- Weight of a smart-constructor `node`: one (the root) plus the total
+    weight of the children multiset. -/
+@[simp] theorem weight_node (a : α) (F : Multiset (Nonplanar α)) :
+    (node a F).weight = 1 + (F.map weight).sum := by
+  refine Quotient.inductionOn F fun lst => ?_
+  show (mk (.node a (lst.map Quotient.out))).weight = _
+  rw [weight_mk]
+  show 1 + Planar.weightList (lst.map Quotient.out) = _
+  rw [weightList_eq_sum_map, List.map_map]
+  simp only [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.sum_coe]
+  congr 1
+  refine congrArg List.sum (List.map_congr_left fun t _ => ?_)
+  show (mk (Quotient.out t)).weight = weight t
+  exact congrArg weight (Quotient.out_eq t)
 
 end Nonplanar
 


### PR DESCRIPTION
Closes the Foissy axiom `pairing_gl_eq_pairing_coproduct_Rho` with a structured proof, making `comulRhoN_coassoc`, `instBialgebraRho`, and MCB Lemma 1.7.3 kernel-clean (no sorryAx), and fully proves MCB Lemma 1.2.10 (edge grading of Δ^c, both conjuncts).

- The previously sorried Δ^ρ duality statement had its tensor slots crossed and was false; the corrected orientation `⟨x ⋆ y, z⟩ = pairing₂ (y ⊗ x) (Δ^ρ z)` is validated exhaustively at weight ≤ 3 and proved by weight induction via the B⁺/B⁻ calculus, a pairing/antidiagonal product rule (multinomial core `forestAutCard_add`), and a GL middle-four interchange (`GrossmanLarsonSplit.lean`). The theorem and its Bialgebra consumers move to the new `Coproduct/PruningDuality.lean`; `OudomGuinBridgePairing` is generalized ℤ → CommSemiring.
- The Δ^c duality sibling is **false in every slot orientation** (trace markers are never produced by grafting) and is removed; Δ^c coassociativity is moreover false for marker-sensitive encoders, so `comulCN_coassoc` is restated under a new `TraceCoherent` hypothesis (sole remaining sorry) and `instBialgebraC` becomes `def bialgebraC`. Counterexamples validated computationally.
- MCB 1.2.10 grading: trace markers preserve edge count exactly (`cutSummandsG_weight` mutual induction + descent), homogeneous tensor spans multiply additively.