### PR TITLE
docs: retire Phenomena layer references; rename residual namespaces

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1154,7 +1154,7 @@ import Linglib.Fragments.Yoruba.TenseAspect
 import Linglib.Fragments.Thai.PolarityItems
 import Linglib.Fragments.Tagalog.PolarityItems
 import Linglib.Fragments.Swahili.PolarityItems
--- Phenomena
+-- Studies
 import Linglib.Studies.SlomanBarbeyHotaling2009
 import Linglib.Studies.SpalekMcNally2026
 import Linglib.Studies.AckemaNeeleman2018
@@ -1378,7 +1378,7 @@ import Linglib.Studies.Nouwen2024
 import Linglib.Studies.Nouwen2024PMF
 import Linglib.Studies.Partee2010
 import Linglib.Studies.Rett2015
--- Phenomena: Comparison (extracted from Gradability/)
+-- Comparison (extracted from Gradability/)
 import Linglib.Studies.Stassen2013Comparison
 import Linglib.Studies.Bresnan1973
 import Linglib.Studies.Kennedy1999
@@ -1401,11 +1401,11 @@ import Linglib.Studies.CondoravdiLauer2012
 import Linglib.Studies.Roberts2023
 import Linglib.Studies.RuytenbeekEtAl2017
 import Linglib.Studies.SumersEtAl2023
--- Phenomena: Implicit Causality (Solstad & Bott 2022)
+-- Implicit Causality (Solstad & Bott 2022)
 import Linglib.Studies.SolstadBott2022
--- Phenomena: Presupposition — Solstad & Bott 2024 (occasion verb projectivity)
+-- Presupposition — Solstad & Bott 2024 (occasion verb projectivity)
 import Linglib.Studies.SolstadBott2024
--- Phenomena: Imprecision (extracted from Gradability/)
+-- Imprecision (extracted from Gradability/)
 import Linglib.Studies.Haslinger2025
 import Linglib.Studies.SoltWaldon2019
 import Linglib.Studies.WoodinEtAl2024
@@ -1414,9 +1414,9 @@ import Linglib.Studies.BeltramaSchwarz2024
 import Linglib.Studies.BeltramaSoltBurnett2022
 import Linglib.Studies.LassiterGoodman2017PMF
 import Linglib.Studies.BumfordRett2021
--- Phenomena: Intonation (prosodic hierarchy, catathesis, cross-linguistic comparison)
+-- Intonation (prosodic hierarchy, catathesis, cross-linguistic comparison)
 import Linglib.Studies.BeckmanPierrehumbert1986
--- Phenomena: Iconicity (sign language classifier predicates, viewpoints)
+-- Iconicity (sign language classifier predicates, viewpoints)
 import Linglib.Studies.SchlenkerEtAl2026
 import Linglib.Studies.MajidBosterBowerman2008
 import Linglib.Studies.ZaslavskyEtAl2019
@@ -1668,7 +1668,7 @@ import Linglib.Fragments.Italian.Questions
 import Linglib.Studies.Zheng2025
 import Linglib.Studies.RomeroHan2004
 import Linglib.Studies.Romero2024
--- Phenomena: Verum (Höhle 1992 origin + cross-linguistic studies)
+-- Verum (Höhle 1992 origin + cross-linguistic studies)
 import Linglib.Studies.Hohle1992
 import Linglib.Studies.MartinezVera2026
 import Linglib.Studies.Holmberg2016
@@ -2518,7 +2518,7 @@ import Linglib.Semantics.Exhaustification.Tolerant
 import Linglib.Semantics.Exhaustification.Trivalent
 import Linglib.Semantics.Polarity.Operator
 import Linglib.Semantics.Presupposition.TriggerTypology
--- Phenomena studies depending on Implicature/Alternatives/Exhaustification
+-- Studies depending on Implicature/Alternatives/Exhaustification
 import Linglib.Studies.Rett2015Implicature
 import Linglib.Studies.BaleKhanjian2014
 import Linglib.Studies.BarLev2021

--- a/Linglib/Core/Logic/CylindricAlgebra/DynamicSemantics.lean
+++ b/Linglib/Core/Logic/CylindricAlgebra/DynamicSemantics.lean
@@ -114,8 +114,8 @@ end CDRT
 
 -- The Charlow 2019 bridges that previously lived here have been moved to
 -- `Linglib/Studies/Charlow2019.lean` (§ Cylindric algebra bridges).
--- A Core file cannot import from Studies — the substrate→Phenomena arrow
--- runs the other way. The DPL and CDRT bridges above are layering-legal
+-- A Core file cannot import from Studies — the dependency arrow runs
+-- substrate→Studies. The DPL and CDRT bridges above are layering-legal
 -- because their substrate lives in `Semantics/Dynamic/`.
 
 end Core.CylindricAlgebra

--- a/Linglib/Core/Probability/Finite.lean
+++ b/Linglib/Core/Probability/Finite.lean
@@ -25,7 +25,7 @@ which matches `ProbabilityTheory.cond`'s convention.
 A handful of lemmas (positivity, monotonicity, partition, complement,
 finite normalization) are provided for the patterns that recur in
 `Semantics/Questions/Probabilistic.lean` and the corresponding
-`Phenomena/.../Studies/` files. ENNReal arithmetic at consumer sites
+`Studies/` files. ENNReal arithmetic at consumer sites
 goes through `ennreal_arith` (see `Linglib.Tactics.ENNRealArith`).
 -/
 

--- a/Linglib/Core/Probability/Softmax.lean
+++ b/Linglib/Core/Probability/Softmax.lean
@@ -49,7 +49,7 @@ shape that doesn't reduce to softmax.
 
 ## Architectural role
 
-Substrate for RSA-style speaker constructions across `Phenomena/`:
+Substrate for RSA-style speaker constructions across `Studies/`:
 [frank-goodman-2012], [goodman-stuhlmuller-2013],
 [kao-etal-2014-metaphor], [lassiter-goodman-2017],
 [herbstritt-franke-2019], [yoon-etal-2020], etc. Replaces

--- a/Linglib/Data/Generalizations/HomogeneityProjection.lean
+++ b/Linglib/Data/Generalizations/HomogeneityProjection.lean
@@ -11,8 +11,8 @@ literature spans [lobner-2000], [gajewski-2005],
 [spector-2013], [magri-2014], [kriz-chemla-2015],
 [kriz-2016], [bar-lev-2021], [augurzky-etal-2023],
 [kriz-spector-2021], and [haslinger-2025-diss]; the empirical
-generalisation predates any one formal account, justifying a `Phenomena/`
-(theory-neutral) anchor.
+generalisation predates any one formal account, justifying a theory-neutral
+`Data/Generalizations/` anchor.
 
 ## Main declarations
 

--- a/Linglib/Data/UD/Basic.lean
+++ b/Linglib/Data/UD/Basic.lean
@@ -8,8 +8,8 @@ Universal part-of-speech tags (UPOS), morphological features, and dependency
 relations from UD v2.
 
 These provide theory-neutral lexical categories, morphological annotations,
-and grammatical relations that can be used in Phenomena/ and mapped to/from
-theory-specific categories (CCG.Cat, Minimalism features, DG trees, etc.).
+and grammatical relations that can be used throughout the library and mapped
+to/from theory-specific categories (CCG.Cat, Minimalism features, DG trees, etc.).
 
 Official site: <https://universaldependencies.org/>
 

--- a/Linglib/Discourse/KOS/RepriseContent.lean
+++ b/Linglib/Discourse/KOS/RepriseContent.lean
@@ -58,7 +58,7 @@ by what they query.
 
 This enum mirrors the `CRReading` enum in
 `Studies/Ginzburg2012.lean`. We declare it here so that
-`KOS/RepriseContent.lean` does not depend downstream on any Phenomena file. -/
+`KOS/RepriseContent.lean` does not import from `Studies/`. -/
 inductive RFReading where
   /-- "Are you asking/saying that p?" — confirms propositional content -/
   | clausalConfirmation

--- a/Linglib/Features/Coordination.lean
+++ b/Linglib/Features/Coordination.lean
@@ -2,7 +2,8 @@
 # Coordination Types
 
 Shared types for cross-linguistic coordination morphology, used by
-Fragment lexicons and Phenomena/Coordination studies.
+Fragment lexicons, `Typology/Coordination`, and coordination studies
+(e.g. `Studies/MitrovicSauerland2016`).
 
 ## CoordRole
 

--- a/Linglib/Features/Givenness.lean
+++ b/Linglib/Features/Givenness.lean
@@ -87,7 +87,7 @@ the right granularity.
 
 ## Layer position
 
-`Features/`. Importable from any Theories/, Phenomena/, or Fragments/
+`Features/`. Importable from any theory-layer, Fragments/, or Studies/
 consumer that needs to type a discourse referent's cognitive status.
 The Centering MEDIATED tier
 (`Discourse/Centering/Instances/InformationStatus.lean`) used

--- a/Linglib/Features/MinimalPairs.lean
+++ b/Linglib/Features/MinimalPairs.lean
@@ -84,8 +84,8 @@ def capturesPhenomenonData (pred : List Word → Bool) (phenom : PhenomenonData)
 
     Unlike `MinimalPair` which uses `List Word` (requiring feature
     specifications), this type uses raw strings that can be parsed by any
-    theory. This keeps empirical data in `Phenomena/` free from
-    theoretical commitments. -/
+    theory. This keeps empirical data free from theoretical
+    commitments. -/
 structure SentencePair where
   /-- The grammatical sentence -/
   grammatical : String

--- a/Linglib/Features/OntologicalCategory.lean
+++ b/Linglib/Features/OntologicalCategory.lean
@@ -9,12 +9,12 @@ The ontological-category axis of pro-forms: the categories [haspelmath-1997]'s
 "correlative pronoun" paradigm (his §3.1.3 Table 3.1) ranges over. The same axis is
 shared by interrogative, demonstrative, relative, and indefinite pronoun types and by
 their pronominal-adverb members (*where* / *when* / *how*), so it lives in `Features/`
-as substrate that both `Typology/` and `Phenomena/` can type their data by.
+as substrate that both `Typology/` and `Studies/` can type their data by.
 
 ## Provenance
 
-Promoted from the former `Phenomena.Questions.WhSemanticType` (a Phenomena-layer enum,
-hence unusable as substrate by `Typology/`). The wh-side `entity` case is split into
+Promoted from a former wh-question `WhSemanticType` enum, which lived too high in
+the import graph to serve as substrate for `Typology/`. The wh-side `entity` case is split into
 `person` / `thing` — the distinction [haspelmath-1997] notes is made "practically
 everywhere" (*who* vs *what*), and the one indefinite and negative pronouns turn on
 (*nobody* vs *nothing*). Renamings: `degree → amount`, `classificatory → property`,

--- a/Linglib/Features/Person/Decomposition.lean
+++ b/Linglib/Features/Person/Decomposition.lean
@@ -50,7 +50,7 @@ categories from Cysouw's paradigmatic framework. Three singular categories
 combinations of participants).
 
 The full paradigmatic structure machinery (morpheme classes, homophony types,
-language data) remains in `Phenomena/Agreement/PersonMarkingTypology.lean`.
+language data) lives in `Studies/Cysouw2009.lean`.
 
 -/
 

--- a/Linglib/Fragments/English/Auxiliaries.lean
+++ b/Linglib/Fragments/English/Auxiliaries.lean
@@ -46,8 +46,7 @@ the last audit):
   side, indirectly)
 
 To find every claim made about a particular entry, grep for
-`English.Auxiliaries.<entry>` across `Phenomena/` and
-`Theories/`.
+`English.Auxiliaries.<entry>` across the library.
 -/
 
 

--- a/Linglib/Fragments/English/Indefinites.lean
+++ b/Linglib/Fragments/English/Indefinites.lean
@@ -43,7 +43,7 @@ theorem english_paradigm_is_AAA : paradigm.syncretism = some .AAA := rfl
 /-- English's WALS F46A classification: derived from the paradigm's
     morphological-basis distribution (single basis `.genericNoun` →
     F46A `.genericNounBased`). Cross-check vs `F46A.allData` lives in
-    `Phenomena/Indefinites/Typology.lean`. -/
+    `Studies/Haspelmath1997.lean`. -/
 theorem english_paradigm_is_genericNounBased :
     paradigm.toWALS46A = some .genericNounBased := rfl
 

--- a/Linglib/Fragments/English/NumeralModifiers.lean
+++ b/Linglib/Fragments/English/NumeralModifiers.lean
@@ -138,7 +138,7 @@ Similar to "around" but more formal register.
 Interacts with roundness: "approximately 100" natural,
 "approximately 99" marked.
 
-Source: Phenomena/Gradability/Imprecision/Numerals.lean
+Source: `Studies/Haslinger2025.lean` (ApproximatelyDatum)
 -/
 def approximately : NumeralModifierEntry :=
   { form := "approximately"
@@ -198,7 +198,7 @@ def between : NumeralModifierEntry :=
 ⟦exactly n⟧ = λx. x = n
 Removes imprecision. Point signal.
 
-Source: Phenomena/Gradability/Imprecision/Numerals.lean (ExactlyModifierDatum)
+Source: `Studies/Haslinger2025.lean` (ExactlyModifierDatum)
 -/
 def exactly : NumeralModifierEntry :=
   { form := "exactly"

--- a/Linglib/Fragments/Japanese/Case.lean
+++ b/Linglib/Fragments/Japanese/Case.lean
@@ -66,8 +66,8 @@ successors — Heycock, Tomioka — not yet in the bib) treats *-ga* as
 ambiguous between a neutral-description marker and an exhaustive-
 listing/focus marker, with *-wa* (intentionally excluded from this Fragment
 as a topic/focus particle, not a case marker) covering categorical/topic
-readings. The right home for those distinctions is a future
-`Phenomena/InformationStructure/` study file, not this Fragment.
+readings. The right home for those distinctions is a future `Studies/`
+file on Japanese information structure, not this Fragment.
 
 Other phenomena out of scope at the case-marking layer:
 - Dative subjects in stative-experiencer constructions (*Tarō-ni eigo-ga

--- a/Linglib/Fragments/Japanese/Classifier.lean
+++ b/Linglib/Fragments/Japanese/Classifier.lean
@@ -37,7 +37,7 @@ every projection function and every consumer that pattern-matches on
 
 `Classifier.toEntry : Classifier → ClassifierEntry` is the migration seam
 to the old `Typology.ClassifierEntry` record type that
-sibling fragments (Mandarin, Shan, Chol) and `Phenomena/Classifiers/Typology`
+sibling fragments (Mandarin, Shan, Chol) and `Typology/ClassifierSystem`
 still consume. Once those fragments are migrated to the same enum pattern,
 both this bridge and `ClassifierEntry` itself can be retired.
 
@@ -259,14 +259,14 @@ def lookup (s : String) : Option Classifier :=
   all.find? fun c => c.form = s
 
 /-- The list of all semantic parameters encoded by some classifier in the
-    inventory (with duplicates removed). Used by `Phenomena/Classifiers/Typology`
-    to compute `preferredSemantics`. -/
+    inventory (with duplicates removed). Used by
+    `Fragments/Japanese/ClassifierSystem` to compute `preferredSemantics`. -/
 def allEncodedParams : List SemanticParameter :=
   (all.flatMap encodes).eraseDups
 
 /-! ## §5: Bridge to legacy `ClassifierEntry`
 
-Migration seam: `Phenomena/Classifiers/Typology.lean` and the sibling
+Migration seam: `Typology/ClassifierSystem.lean` and the sibling
 fragments (Mandarin, Shan, Chol) still consume `Typology.
 ClassifierEntry`. `toEntry` projects a typed `Classifier` back to the
 legacy record so cross-language aggregations continue to work during

--- a/Linglib/Fragments/Latin/Indefinites.lean
+++ b/Linglib/Fragments/Latin/Indefinites.lean
@@ -10,7 +10,7 @@ specific-unknown (AAB pattern); *quidam* (interrogative `qui` + `-dam`)
 covers specific-known. Both forms are interrogative-based.
 
 Latin is not in [wals-2013] F46A's 326-language sample, so no WALS
-bridge theorem is stated for Latin in `Phenomena/Indefinites/Typology.lean`.
+bridge theorem is stated for Latin in `Studies/Haspelmath1997.lean`.
 The morphological-basis encoding is recorded for cross-linguistic
 comparison anyway.
 -/

--- a/Linglib/Fragments/Mandarin/ClassifierSystem.lean
+++ b/Linglib/Fragments/Mandarin/ClassifierSystem.lean
@@ -9,7 +9,7 @@ import Linglib.Fragments.Mandarin.Classifiers
 Classifier-system metadata for Mandarin (ISO `cmn`). The lexical
 classifier inventory itself lives in `Fragments/Mandarin/Classifiers.lean`;
 this file aggregates that inventory into the typological-system summary
-(`NounCategorizationSystem`) consumed by `Phenomena/Classifiers/Typology.lean`.
+(`NounCategorizationSystem`) consumed by `Typology/ClassifierSystem.lean`.
 
 The per-language claims (obligatoriness with numerals + demonstratives,
 default 个 gè, semantic-with-lexical-residue assignment) follow

--- a/Linglib/Fragments/Yakut/Indefinites.lean
+++ b/Linglib/Fragments/Yakut/Indefinites.lean
@@ -20,7 +20,7 @@ dayanï 'anybody'"); not formalized as a separate entry.
 Since all four series use the interrogative `kim` 'who' as their host, the
 paradigm derives to [wals-2013] F46A `.interrogativeBased` —
 matching WALS's classification for `iso = "sah"` (verified in
-`Phenomena/Indefinites/Typology.lean`).
+`Studies/Haspelmath1997.lean`).
 
 The Degano & Aloni 7-type classification of `ere` and `eme` (types ii and
 iii respectively, after [bubnov-2026] Table 1) is theory-side
@@ -93,7 +93,7 @@ theorem yakut_paradigm_is_ABB :
 /-- Yakut's paradigm uses a single morphological basis (interrogative
     `kim`) across all four forms, deriving the WALS F46A classification
     `.interrogativeBased`. The cross-check against [wals-2013]
-    F46A.allData lives in `Phenomena/Indefinites/Typology.lean`. -/
+    F46A.allData lives in `Studies/Haspelmath1997.lean`. -/
 theorem yakut_paradigm_is_interrogativeBased :
     paradigm.toWALS46A = some .interrogativeBased := rfl
 

--- a/Linglib/Morphology/Case/WALS.lean
+++ b/Linglib/Morphology/Case/WALS.lean
@@ -17,7 +17,7 @@ in the same `Linglib/Typology/{Domain}.lean` mould as `WordOrder.lean`,
 - **Ch 50** (Iggesen 2013): Asymmetrical Case-Marking — Iggesen's actual
   five-way WALS partition (`symmetrical`, `additiveQuantitativelyAsymmetrical`,
   `subtractiveQuantitativelyAsymmetrical`, `qualitativelyAsymmetrical`,
-  `syncretismInRelevantNpTypes`). Note: an earlier `Phenomena/Case/Typology.lean`
+  `syncretismInRelevantNpTypes`). Note: an earlier case-typology
   file silently re-coded this dimension in Aissen-friendly conditioning-factor
   categories (`animacyOnly` / `definitenessOnly` / `pronounOnly` / etc.); that
   re-coding was deleted in the dissolution because (a) it didn't match the

--- a/Linglib/Morphology/RootTypology.lean
+++ b/Linglib/Morphology/RootTypology.lean
@@ -43,7 +43,8 @@ between functional head and root.
 - `TemplateHead.vBecome` = the templatic operator that result roots lexicalize
 - `CoSType.inception` = BECOME as ¬P→P transition (ChangeOfState/Theory)
 - `Template.achievement`/`.accomplishment` = templates containing BECOME (EventStructure)
-- Crosslinguistic data validates the correlations (Phenomena)
+- Crosslinguistic data validates the correlations (`Studies/`, e.g.
+  `Coon2019`, `BeaversEtAl2021`)
 
 ## Unified Root (§§15–17)
 

--- a/Linglib/Phonology/Autosegmental/GrammaticalTone.lean
+++ b/Linglib/Phonology/Autosegmental/GrammaticalTone.lean
@@ -46,7 +46,7 @@ triggers tonal modification of its complement, e.g., Kalabari associative
 L-H melody on nouns).
 
 This module provides the core types and operations. Language-specific
-instantiations live in `Fragments/`; empirical applications in `Phenomena/`.
+instantiations live in `Fragments/`; empirical applications in `Studies/`.
 
 ## References
 

--- a/Linglib/Pragmatics/Implicature/EpistemicBlocking.lean
+++ b/Linglib/Pragmatics/Implicature/EpistemicBlocking.lean
@@ -8,8 +8,8 @@ import Linglib.Core.Logic.Modal.Defs
 
 Categorical primitives for the primary/secondary implicature distinction
 of [sauerland-2004]. Pure pragmatic theory — no RSA, no specific
-empirical paper. Consumed by `Phenomena/.../Studies/` files (e.g.,
-`Numerals/Studies/Kennedy2015.lean`) that need a categorical implicature
+empirical paper. Consumed by `Studies/` files (e.g.,
+`Studies/Kennedy2015.lean`) that need a categorical implicature
 operator alongside or instead of an RSA derivation.
 
 ## Sauerland's Framework

--- a/Linglib/Pragmatics/RSA/Operators.lean
+++ b/Linglib/Pragmatics/RSA/Operators.lean
@@ -58,7 +58,7 @@ denominator AND the uniform prior in one move.
 
 Phase 1 of the RSA → mathlib-PMF migration: this file is a pure addition.
 `RSAConfig` and `RSAConfig.L1` (in `Basic.lean`) remain in place; consumer
-code is unchanged. A subsequent phase migrates one Phenomena study end-to-end
+code is unchanged. A subsequent phase migrates one RSA study end-to-end
 to demonstrate that `rsa_predict` reflection still applies to operator
 applications.
 -/

--- a/Linglib/Semantics/Aspect/Basic.lean
+++ b/Linglib/Semantics/Aspect/Basic.lean
@@ -97,8 +97,9 @@ inductive ViewpointType where
 /-- Bool-level viewpoint aspect, capturing the perfective/imperfective distinction
     without the full interval-based `Event Time → Prop`/`IntervalPred` machinery.
 
-    Used by `Modal/Ability.lean` (actuality inferences) and
-    `Phenomena/ActualityInferences/Data.lean` where the key insight is simply
+    Used by `Modal/Ability.lean` and the actuality-inference consumers
+    (`Modality/ActualityEntailments.lean`, `Studies/Hacquard2006.lean`)
+    where the key insight is simply
     "perfective requires actualization, imperfective doesn't." -/
 inductive ViewpointAspectB where
   | perfective

--- a/Linglib/Semantics/Degree/Basic.lean
+++ b/Linglib/Semantics/Degree/Basic.lean
@@ -26,7 +26,7 @@ for framework-level theorems. `Gradability.Basic` uses concrete
 `Degree max := Fin (max + 1)` for computation in RSA models and Fragment
 entries. The two serve different clients: this module is imported by
 `Degree/Comparative.lean` and other framework siblings; `Gradability.Basic`
-is imported by `Fragments/English/` and `Phenomena/Gradability/` bridges.
+is imported by `Fragments/English/` and gradability `Studies/` files.
 -/
 
 namespace Semantics.Degree

--- a/Linglib/Semantics/Dynamic/Effects/HasFiberedLookup.lean
+++ b/Linglib/Semantics/Dynamic/Effects/HasFiberedLookup.lean
@@ -139,7 +139,7 @@ Where does pronoun resolution come from?
 | Bayesian | posterior conditioning on observed reference |
 
 The deepest seam — not in the lookup signature, but in how lookups get
-used by `Phenomena/.../Studies/`. Each Studies file commits in its own
+used by `Studies/` files. Each Studies file commits in its own
 resolution semantics. (Karttunen 1976 introduced *the idea* of drefs
 without the assignment-update formalization, so the binding row is
 attributed to Heim/Kamp.)

--- a/Linglib/Semantics/Gradability/Intensification.lean
+++ b/Linglib/Semantics/Gradability/Intensification.lean
@@ -44,7 +44,7 @@ An evaluative measure function assigns a rational-valued "goodness of fit"
 score to each degree on a scale.
 
 - `form`: the adjectival base (e.g., "horrible")
-- `valence`: evaluative valence from the Phenomena layer
+- `valence`: evaluative valence from `Features/Valence`
 - `mu`: the measure function μ : Nat → ℚ (takes degree's Nat value)
 
 The measure function captures how well a degree matches the evaluative
@@ -168,8 +168,8 @@ theorem goldilocks_at_norm_10 :
 Bridge between evaluative valence and evaluative measure behavior:
 negative-evaluative measures peak at extremes, positive at the norm.
 
-This connects the Phenomena-layer `EvaluativeValence` to the
-Theory-layer `EvaluativeMeasure` structural properties.
+This connects the `Features/`-layer `EvaluativeValence` to the
+theory-layer `EvaluativeMeasure` structural properties.
 -/
 theorem negative_valence_extreme_peak :
     (muHorrible 10).valence = .negative ∧

--- a/Linglib/Semantics/Numerals/Roundness.lean
+++ b/Linglib/Semantics/Numerals/Roundness.lean
@@ -16,9 +16,9 @@ The 6 properties (ordered by frequency effect, [woodin-etal-2023]):
 5. Multiple of 10 (β = 0.52)
 6. Multiple of 5 (β = 0.06) — weakest predictor
 
-This module lives in Core because both Phenomena (empirical data) and
-Theories (Semantics.Montague, NeoGricean, RSA) depend on the roundness
-score, avoiding a cross-layer Theories→Phenomena import.
+This module lives in substrate because both empirical consumers
+(`Studies/`) and theory files (Semantics.Montague, NeoGricean, RSA)
+depend on the roundness score.
 
 -/
 
@@ -146,7 +146,7 @@ The contextual score derives from actual divisibility properties relative
 to the base (not a flat bonus), paralleling how standard k-ness derives
 from divisibility by 2/2.5/5/10 × powers of 10.
 
-Composes with `GranularityDatum` in `Phenomena.Gradability.Imprecision.Numerals`.
+Composes with `GranularityDatum` in `Studies/ThomasDeo2020.lean`.
 -/
 def roundnessInContext (n : Nat) (base : Nat) : Nat :=
   max (roundnessScore n) (contextualRoundnessScore n base)

--- a/Linglib/Studies/Adger2003.lean
+++ b/Linglib/Studies/Adger2003.lean
@@ -63,7 +63,7 @@ open Minimalist Minimalist.FromFragments
 /-! ## §0: Lexicon — Fragment-grounded SO building blocks
 
 Migrated from the deleted `Syntax/Minimalism/Derivations.lean`;
-instances belong in Phenomena per the architecture audit. Each SO is a
+instances belong in `Studies/` per the architecture audit. Each SO is a
 leaf with `Cat` and `SelStack` derived from its Fragment lexical entry.
 
 ### LIToken id allocation (one-derivation scope)

--- a/Linglib/Studies/Aissen2003.lean
+++ b/Linglib/Studies/Aissen2003.lean
@@ -51,7 +51,7 @@ open Core.Optimization.Evaluation (Finset.checkAll Finset.checkAny)
 --
 -- The 8 DOM language profiles plus monotonicity / 1D-classification /
 -- scale-dominance / extreme-cell theorems were dissolved here from a
--- former `Phenomena/Case/Typology.lean` mash-up (which mixed WALS Iggesen
+-- former case-typology mash-up file (which mixed WALS Iggesen
 -- substrate with Aissen DOM data). DOM data empirically belongs to Aissen
 -- 2003 — it is the empirical input the OT factorial typology (§§1–8 below)
 -- predicts. The substrate type `DifferentialMarkingProfile` lives in

--- a/Linglib/Studies/Anderson2021.lean
+++ b/Linglib/Studies/Anderson2021.lean
@@ -642,13 +642,14 @@ theorem conversationStep_lr_zero (cg : DistributionalCG MFWorld) (u : MFUtteranc
   exact updateCG_lr_zero cg _ _ w
 
 -- ════════════════════════════════════════════════════
--- § 15. Bridge to Empirical Observations (Basic.lean)
+-- § 15. Qualitative information-sharing properties
 -- ════════════════════════════════════════════════════
 
-/-! The RSA predictions above verify properties from `Phenomena.Dialogue.Basic`:
+/-! The RSA predictions above verify the qualitative properties of
+successful information sharing:
 
 1. **Contributions informative**: S1 prefers specific utterances over null
-   (§9, `s1_null_suboptimal`), matching `contributionsInformative = true`.
+   (§9, `s1_null_suboptimal`).
 
 2. **Uncertainty decreases**: L1 concentrates probability after hearing
    an informative utterance (this section).
@@ -659,15 +660,13 @@ theorem conversationStep_lr_zero (cg : DistributionalCG MFWorld) (u : MFUtteranc
 /-- L1 concentrates probability after an informative utterance:
 L1(nancy|studyHumanity) > L1(nancy|null). The null utterance gives
 uniform L1 (= 1/4), while "studyHumanity" concentrates on the 2
-German-studying worlds (= 1/2). This matches
-`Phenomena.Dialogue.successfulInfoSharing.uncertaintyDecreases`. -/
+German-studying worlds (= 1/2). -/
 theorem l1_concentrates_after_utterance :
     mfRSA.L1 .studyHumanity .nancy > mfRSA.L1 .null .nancy := by
   rsa_predict
 
 /-- Informed speakers are informative: S1 assigns higher probability
-to a true specific utterance than to null. This matches
-`Phenomena.Dialogue.successfulInfoSharing.contributionsInformative`. -/
+to a true specific utterance than to null. -/
 theorem s1_informed_speaker_is_informative :
     mfRSA.S1 () .nancy .studyHumanity > mfRSA.S1 () .nancy .null :=
   s1_null_suboptimal

--- a/Linglib/Studies/Ariel2001.lean
+++ b/Linglib/Studies/Ariel2001.lean
@@ -238,7 +238,7 @@ theorem strength_coarsening_agrees :
 
 -- `GivennessStatus` and `GivennessStatus.rank` were promoted to
 -- `Features/Givenness.lean` (the substrate layer) so Centering and
--- other non-Phenomena consumers can import them. The Ariel-specific
+-- other substrate-level consumers can import them. The Ariel-specific
 -- `toAccessibility` projection below remains here as the
 -- study-specific bridge.
 

--- a/Linglib/Studies/AugurzkyEtAl2023.lean
+++ b/Linglib/Studies/AugurzkyEtAl2023.lean
@@ -28,7 +28,7 @@ The `no` / `not every` asymmetry is the central puzzle.
 
 ## Provenance
 
-This data was previously bundled inside `Phenomena/Imprecision/Projection.lean`
+This data was previously bundled inside an imprecision-projection file
 (then `Studies/Haslinger2025.lean`). Moved here at 0.230.521 — the empirical
 anchor is Augurzky et al. 2023, not Haslinger. The asymmetry's *theoretical
 explanation* in the original file invoked exhaustification logic from

--- a/Linglib/Studies/BillEtAl2025.lean
+++ b/Linglib/Studies/BillEtAl2025.lean
@@ -417,16 +417,17 @@ theorem georgian_contradicts_transparency :
 -- Connection to Form-Meaning Correspondences
 
 /-!
-## Link to Phenomena/Gradability/Imprecision/FormMeaning.lean
+## Link to form-meaning correspondences (`Studies/Haslinger2025.lean`)
 
 The Transparency Principle is the acquisition-side counterpart of
-the No Needless Manner Violations principle formalized in FormMeaning.lean.
+the No Needless Manner Violations principle formalized in
+`Studies/Haslinger2025.lean`.
 
 Both principles relate form complexity to meaning:
 - NNMV: More complex form → more precise meaning
 - Transparency: More overt form-meaning mapping → easier acquisition
 
-The `andBoth` datum in FormMeaning.lean is particularly relevant:
+The `andBoth` datum in `Studies/Haslinger2025.lean` is particularly relevant:
 "Ann and Bert" (J-only) vs "both Ann and Bert" (≈ J+MU).
 "Both" adds precision (removes homogeneity gap) — it's arguably an
 overt realization of MU/distributivity, paralleling the J-MU strategy.

--- a/Linglib/Studies/Bruening2001.lean
+++ b/Linglib/Studies/Bruening2001.lean
@@ -399,7 +399,7 @@ def availableReadings (config : MinimalistScopeConfig) : Availability :=
   else
     .ambiguous
 
--- Predictions for Phenomena
+-- Predictions for the empirical examples
 
 /-- Build config from a freezing example (fallback path — no tree). -/
 def configFromExample (ex : Example) : MinimalistScopeConfig :=

--- a/Linglib/Studies/Cacchioli2025.lean
+++ b/Linglib/Studies/Cacchioli2025.lean
@@ -21,7 +21,7 @@ grammaticality judgments, and co-occurrence restrictions.
 
 -/
 
-namespace Phenomena.Complementation.Cacchioli2025
+namespace Cacchioli2025
 
 -- ============================================================================
 -- Section A: Prefix inventory
@@ -286,4 +286,4 @@ theorem all_prefixes_verbal :
     catFamily kemzi.headCat = .verbal ∧
     catFamily ay_n.headCat = .verbal := by decide
 
-end Phenomena.Complementation.Cacchioli2025
+end Cacchioli2025

--- a/Linglib/Studies/CarianiSantorio2018.lean
+++ b/Linglib/Studies/CarianiSantorio2018.lean
@@ -391,7 +391,7 @@ The Auxiliaries Fragment is a hub: other studies that analyse the
 same entries ([condoravdi-2002], [kratzer-1981], etc.) record
 their own morphological preconditions parallel to these. To enumerate
 every analysis that touches a given entry, grep for
-`English.Auxiliaries.<entry>` across `Phenomena/`.
+`English.Auxiliaries.<entry>` across the library.
 
 This section records *morphological* preconditions only. The C&S
 semantic clauses (`willSem`, `wouldSem`) and their downstream theorems

--- a/Linglib/Studies/Charlow2019.lean
+++ b/Linglib/Studies/Charlow2019.lean
@@ -320,7 +320,7 @@ non-interreducible theorems in their respective files. -/
 -- algebraic interpretation: both reduce to `cylindrify` from
 -- `Core.CylindricAlgebra`. These bridges previously lived in
 -- `Linglib/Core/Logic/CylindricAlgebra/DynamicSemantics.lean`, but a Core
--- file importing from Studies inverted the substrate→Phenomena arrow.
+-- file importing from Studies inverted the substrate→Studies dependency arrow.
 -- They live here now: a Studies file importing the Core substrate it
 -- depends on is layering-legal.
 

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -55,9 +55,9 @@ TCS prediction direction matches the data.
 ## Architecture
 
 This file is anchored on the Cobreros-Egré-Ripley-van Rooij 2012 paper
-itself. Per CLAUDE.md "no bridge files" + "Theory examples to Phenomena"
-discipline, the worked example was extracted here from a previous
-embedding inside `Semantics/Supervaluation/TCS.lean`.
+itself. Per the "no bridge files" + "worked examples live in Studies, not
+theory files" discipline, the worked example was extracted here from a
+previous embedding inside `Semantics/Supervaluation/TCS.lean`.
 -/
 
 namespace CobrerosEtAl2012
@@ -392,7 +392,8 @@ theorem tcs_borderline_contradiction_categorical
       `PMF`-typed instance of this generic bound.
 
     The empirical Alxatib-Pelletier 2011 acceptance rate (44.7% — see
-    `Phenomena/Gradability/Vagueness.lean::alxatibPelletier2011Tall`)
+    the [alxatib-pelletier-2011] contrast section of
+    `Studies/LassiterGoodman2017PMF.lean`)
     exceeds the product-rule's 25% ceiling, refuting the literal-rule
     framework empirically. TCS's categorical prediction is consistent
     with the empirical direction without committing to any specific
@@ -434,13 +435,12 @@ theorem klein_delineation_tension_concrete :
   ⟨b_is_borderline, c_is_borderline, by decide, by simp [soritesModel], by simp [soritesModel]⟩
 
 -- ════════════════════════════════════════════════════
--- § 11. Backwards-compatibility shim for Compare.lean
+-- § 11. Single-premise sorites unsoundness
 -- ════════════════════════════════════════════════════
 
 /-- Single-premise sorites unsoundness (the previous formalization's
     `sorites_chain_invalid`). Subsumed by `st_three_step_invalid` above
-    but exposed here under the historical name so `Phenomena/Gradability/Compare.lean`
-    keeps building without theorem-statement changes. -/
+    but kept under the historical name. -/
 theorem sorites_chain_invalid :
     ¬ tcsConsequence (D := Elt) (Pred := VPred) .strict .tolerant
       [.atom (.pred .tall .a)] (.atom (.pred .tall .d)) := by

--- a/Linglib/Studies/Dayal2016.lean
+++ b/Linglib/Studies/Dayal2016.lean
@@ -50,7 +50,7 @@ holds (`IsExhaustivelyResolvable`).
 
 * **Number sensitivity** (§2.3.1–§2.3.3) requires plural / atomic
   individuals (`Sharvy 1980`/`Link 1983` join semilattice). Deferred
-  to a follow-up that uses `Phenomena.Plurality` substrate.
+  to a follow-up that uses the `Semantics/Plurality/` substrate.
 * **Scope marking** (§2.2.2 ex. 33–37) is a syntax-side phenomenon
   (German *was*-construction, Hindi-Urdu *kyaa*); deferred to the
   Hindi-Urdu fragment + Dayal-2025 study.

--- a/Linglib/Studies/DelPinalBassiSauerland2024.lean
+++ b/Linglib/Studies/DelPinalBassiSauerland2024.lean
@@ -53,7 +53,7 @@ open Semantics.Presupposition.Accommodation
 -- ============================================================================
 
 /-!
-## Bridge to Phenomena
+## Bridge to the Free Choice Data
 
 pex predicts that free choice is a pragmatic inference (derived by the
 covert operator pex), not a semantic entailment — consistent with the observed

--- a/Linglib/Studies/Dendikken1995Causatives.lean
+++ b/Linglib/Studies/Dendikken1995Causatives.lean
@@ -78,7 +78,7 @@ for the Theme.
 - `Studies/Dendikken1995` — the triadic
   formalisation (book ch. 3). Same SC-in-SC template, V-slot filled
   with abstract BE rather than V_emb.
-- `Phenomena/Constructions/ParticleVerbs/Studies/Dendikken1995` — the
+- `Studies/Dendikken1995ParticleVerbs` — the
   simplex PVC formalisation (book ch. 2.4). Particles in PVCs
   ≡ affixal particles in causatives at the syntactic level
   (book p. 235 ex. 25).
@@ -133,7 +133,7 @@ def V_schaffen : SyntacticObject := mkLeafPhon .V [.D] "schaffen" 505
 
 Each "affixal causativiser/applicativiser" morpheme is realised here
 as a category-P leaf with no selectional features — the canonical
-shape for a particle (compare `Phenomena/Constructions/ParticleVerbs/Studies/Dendikken1995`'s
+shape for a particle (compare `Studies/Dendikken1995ParticleVerbs`'s
 particle leaves like `mkLeafPhon .P [] "up"`). -/
 
 /-- French causative X is empty (*faire* construction). -/

--- a/Linglib/Studies/EgreEtAl2023.lean
+++ b/Linglib/Studies/EgreEtAl2023.lean
@@ -858,12 +858,12 @@ theorem bir_matches_closed_form :
 
 -- Bridge: BIR closed-form matches empirical data
 
-/-- Closed form matches Phenomena datum for center: P(x=20 | around 20) = 21/441. -/
+/-- Closed form matches the empirical datum for center: P(x=20 | around 20) = 21/441. -/
 theorem closed_form_matches_phenomena_center :
     birClosedForm 20 20 = closedForm_center.expectedProb := by
   native_decide
 
-/-- Closed form matches Phenomena datum for offset: P(x=15 | around 20) = 16/441. -/
+/-- Closed form matches the empirical datum for offset: P(x=15 | around 20) = 16/441. -/
 theorem closed_form_matches_phenomena_offset5 :
     birClosedForm 20 15 = closedForm_offset5.expectedProb := by
   native_decide

--- a/Linglib/Studies/FoxHackl2006Numerals.lean
+++ b/Linglib/Studies/FoxHackl2006Numerals.lean
@@ -8,7 +8,7 @@ import Linglib.Semantics.Numerals.Basic
 [fox-hackl-2006] [kennedy-2015]
 
 Surfaces the maximal informativity theorems from
-`Semantics/Entailment/Extremum.lean` at the Phenomena level,
+`Semantics/Entailment/Extremum.lean` at the Studies level,
 connecting numeral semantics (the named `*Meaning` functions) to the
 `HasMaxInf` / `IsMaxInf` infrastructure and the [fox-hackl-2006]
 density predictions.

--- a/Linglib/Studies/Hacquard2006.lean
+++ b/Linglib/Studies/Hacquard2006.lean
@@ -278,8 +278,7 @@ end Hacquard2006
 # Actuality Inference Data (Cross-Linguistic)
 [bhatt-1999] [hacquard-2006] [nadathur-2023]
 
-Cross-linguistic empirical data on actuality inferences with ability modals,
-following the pattern of `Phenomena/Causation/Data.lean`.
+Cross-linguistic empirical data on actuality inferences with ability modals.
 
 ## Key Generalization ([nadathur-2023], Chapter 1)
 

--- a/Linglib/Studies/Heim1992Projection.lean
+++ b/Linglib/Studies/Heim1992Projection.lean
@@ -29,7 +29,7 @@ connecting `KnowledgeBeliefFrame` (from `EpistemicLogic.lean`) through
 The *other* half of [heim-1992] — comparative-belief desire
 semantics for `want`/`wish`/`hope` — is at
 `Studies/Heim1992.lean`. Both halves of the paper are
-formalized; the substrate splits along the natural Phenomena boundary
+formalized; the substrate splits along the natural empirical boundary
 (presupposition vs modality).
 
 -/

--- a/Linglib/Studies/Heine1997.lean
+++ b/Linglib/Studies/Heine1997.lean
@@ -447,7 +447,7 @@ theorem wals_agrees_with_predicativeSource :
 -- ============================================================================
 
 /-! Per-language verifications previously co-located in Fragment files.
-    Moved here per CLAUDE.md "Fragments never import Phenomena" rule:
+    Moved here per the layering rule that Fragments never import Studies:
     paper-anchored predictions must live in the paper's study file. -/
 
 /-! ### Russian: Location Schema (primary) + Action Schema (`imet'`, secondary). -/

--- a/Linglib/Studies/Hudson1990.lean
+++ b/Linglib/Studies/Hudson1990.lean
@@ -31,7 +31,7 @@ private def grammaticalForCoreference (ws : List Word) : Bool :=
   decide (Binding.grammaticalForCoreference Binding.bindingClassOf ws)
 
 -- ============================================================================
--- Capturing the Phenomena Data
+-- Capturing the Coreference Data
 -- ============================================================================
 
 /-- Check all pairs in a PhenomenonData -/
@@ -39,7 +39,7 @@ def capturesCoreferenceData (phenom : PhenomenonData) : Bool :=
   capturesPhenomenonData grammaticalForCoreference phenom
 
 -- ============================================================================
--- Theorems - Dependency Grammar Captures Imported Phenomena
+-- Theorems - Dependency Grammar Captures the Imported Binding Data
 -- ============================================================================
 
 /-- Dependency Grammar captures reflexiveCoreferenceData -/

--- a/Linglib/Studies/Hudson2010.lean
+++ b/Linglib/Studies/Hudson2010.lean
@@ -14,7 +14,7 @@ running non-linguistic example (§3.2 with Fig 3.7, cross-referenced from
 syntactic triangle of Figure 7.6 (p. 161, "A triangle in syntax and in
 kinship").
 
-This study file is the Phenomena-level demonstration that the *same*
+This study file is the demonstration that the *same*
 `WordGrammar.Inheritance.Network` infrastructure used by `WordGrammar.englishAuxNet`
 also supports a kinship hierarchy. Two demos:
 

--- a/Linglib/Studies/Jenks2018.lean
+++ b/Linglib/Studies/Jenks2018.lean
@@ -354,8 +354,7 @@ Two empirical points the paper makes (p. 524-526):
   *ne* (continuing topic + alternative-set).
 
 The substrate has `Roberts2012` QUD machinery in
-`Phenomena/Discourse/Strategy/QUDStack.lean` (per memory:
-`project_qud_dissolution.md`). A faithful formalization of paper §5.3
+`Discourse/QUDStack.lean`. A faithful formalization of paper §5.3
 would need a topic predicate over `Description` configurations
 co-occurring with QUD-stack state — substrate the linglib has but
 that this study file does not yet plug into.

--- a/Linglib/Studies/Kennedy2007.lean
+++ b/Linglib/Studies/Kennedy2007.lean
@@ -9,7 +9,7 @@ import Linglib.Semantics.Degree.HasMeasure
 [kennedy-2007] [kennedy-mcnally-2005] [schwarzschild-2005] [solt-2015] [winter-2005]
 
 Bridge connecting [kennedy-2007]'s measure function approach to the
-comparative construction data in `Phenomena/Comparison/`.
+comparative construction data collected below.
 
 ## Key Bridges
 

--- a/Linglib/Studies/Kennedy2007Licensing.lean
+++ b/Linglib/Studies/Kennedy2007Licensing.lean
@@ -13,7 +13,7 @@ import Linglib.Features.Antonymy
 
 Connects the abstract `adjMeasure` and `LicensingPipeline` algebra
 (Core/Scale) to concrete Fragment entries (`tall`, `full`, `wet`, `dry`)
-and Phenomena data (`closurePuzzle`, `completelyModifier`).
+and empirical data (`closurePuzzle`, `completelyModifier`, both below).
 
 ## Bridge Structure
 

--- a/Linglib/Studies/Kramer2020.lean
+++ b/Linglib/Studies/Kramer2020.lean
@@ -30,7 +30,7 @@ assignment. Three main results:
 ## Integration
 
 - **Typology ↔ DM bridge**: `SemanticBasis.toGenderDimension` connects the
-  typological `SemanticBasis` (from `Phenomena/Gender/Typology.lean`) to
+  typological `SemanticBasis` (from `Studies/Corbett1991.lean`) to
   the DM `GenderDimension` (from `Morphology/DM/Categorizer.lean`),
   making explicit that the semantic core properties are the *same things*
   parameterized as feature dimensions in the structural approach.

--- a/Linglib/Studies/Kratzer1998.lean
+++ b/Linglib/Studies/Kratzer1998.lean
@@ -25,8 +25,8 @@ The `kratzerEnglishPast` / `kratzerGermanPreterit` / `kratzerZeroTense`
 lexical entries live at the Theories layer
 (`Tense/SOT/Decomposition.lean`) because
 `Fragments/{English,German,Italian}/Tense.lean` consume them via the
-`Fragments → Theories` import direction. CLAUDE.md's "Fragments
-imports Theories, not Phenomena" discipline forces the substrate
+`Fragments → Theories` import direction. The "Fragments import
+Theories, never Studies" layering discipline forces the substrate
 placement; this Studies file collects the paper-anchored cross-paper
 claims and bridge theorems that don't need to be Fragment-visible.
 

--- a/Linglib/Studies/LassiterGoodman2017PMF.lean
+++ b/Linglib/Studies/LassiterGoodman2017PMF.lean
@@ -193,8 +193,7 @@ Supervaluation (`Fine1975.lean`) maps borderline to `Truth3.indet`;
 epistemicism denies the very framing (borderline cases have determinate
 Boolean truth values we don't know); TCS predicts borderline
 contradictions are tolerantly *true*, with empirical support from
-[alxatib-pelletier-2011]. See `Phenomena/Gradability/Compare.lean`
-for the comparison taxonomy. -/
+[alxatib-pelletier-2011]. -/
 
 /-- **Borderline-case theorem**: when both some threshold below `h` AND
 some threshold ≥ `h` are in the posterior support, the metalinguistic
@@ -450,8 +449,7 @@ maximised at the maximally borderline `P_T = 1/2`.
 
 Empirical contrast: [alxatib-pelletier-2011] report **44.7%
 acceptance** for "X is tall and not tall" applied to the median
-(borderline) man in their visual stimulus. The data is encoded at
-`Phenomena/Gradability/Vagueness.lean::alxatibPelletier2011Tall`.
+(borderline) man in their visual stimulus.
 
 `44.7% > 25%`, so a literal-meaning probabilistic account cannot
 reproduce the data. This is the formal expression of the empirical

--- a/Linglib/Studies/LiuYip2026.lean
+++ b/Linglib/Studies/LiuYip2026.lean
@@ -118,9 +118,9 @@ theorem types_ordered :
     proposition > situation > event in transparency-decreasing order.
 
     Local to this Studies file; promotion to `Syntax/Complementation/`
-    is contingent on a second paper-anchored consumer (see Phenomena/Control
-    studies and Studies/Grano2024.lean as candidate
-    second sites).
+    is contingent on a second paper-anchored consumer (the control
+    studies — e.g. Studies/Landau2015.lean — and Studies/Grano2024.lean
+    are candidate second sites).
 
     `LinearOrder` is *not* derived: the implicational content of the ICH is
     a theorem about a *transparency relation*, not a structural property of

--- a/Linglib/Studies/LoGuercio2025.lean
+++ b/Linglib/Studies/LoGuercio2025.lean
@@ -106,8 +106,9 @@ omission triggers an ACI only when honorification is locally relevant.
   line of analysis (late-merge at PF following [lo-guercio-orlando-2022]);
   not formalized.
 * §4 embeddability data (paper (55)-(60)) — paper devotes 3 pages;
-  promote to a `Phenomena/Expressives/Embeddability.lean` hub once a
-  second study (Kratzer 1999 or Potts 2007) contributes parallel stimuli.
+  promote to a shared embeddability generalisation (`Data/Generalizations/`)
+  once a second study (Kratzer 1999 or Potts 2007) contributes parallel
+  stimuli.
 * §4 Magri-style oddness puzzles (paper (64)-(68)) — paper itself
   declares this unresolved/erratic; defer.
 * The `priorMention_yes_ACI` reachability hypothesis is currently

--- a/Linglib/Studies/Ney2026.lean
+++ b/Linglib/Studies/Ney2026.lean
@@ -92,8 +92,8 @@ Insinuative reference is distinct from:
 [ney-2026] §5 proposes reserving "insinuation" for the Camp-style
 implicature phenomenon and using "insinuative speech" as the broader
 deniability-preserving category encompassing all four. This file's
-namespace is `Ney2026`; a future
-`Phenomena.InsinuativeSpeech.*` superclass with sibling Camp / Saul
+namespace is `Ney2026`; a future shared insinuative-speech
+superclass with sibling Camp / Saul
 formalizations is the obvious organising principle but is not built
 here.
 

--- a/Linglib/Studies/Osborne2019Ellipsis.lean
+++ b/Linglib/Studies/Osborne2019Ellipsis.lean
@@ -30,8 +30,8 @@ def toGappingEllipsisType :
   | .gapping => some .gapping
   | .stripping => some .stripping
   | .sluicing => some .sluicing
-  | .pseudogapping => none  -- No Phenomena equivalent
-  | .fragmentAnswer => none  -- No Phenomena equivalent
+  | .pseudogapping => none  -- No Steedman2000 equivalent
+  | .fragmentAnswer => none  -- No Steedman2000 equivalent
 
 /-- Gapping (from Steedman's taxonomy) is a special case of catena-ellipsis.
     The verb alone is elided — always a singleton catena. -/

--- a/Linglib/Studies/Osborne2019Islands.lean
+++ b/Linglib/Studies/Osborne2019Islands.lean
@@ -2,13 +2,13 @@ import Linglib.Syntax.DependencyGrammar.Formal.Islands
 import Linglib.Studies.Ross1967
 
 /-!
-# Bridge: DG Islands → Phenomena Island Constraints
+# Bridge: DG Islands → Ross 1967 Island Constraints
 [osborne-2019] [ross-1967]
 
 Maps the DG rising-catena island taxonomy from [osborne-2019] to the
-Phenomena island constraint types from `Ross1967`.
+island `ConstraintType` taxonomy from `Studies/Ross1967`.
 
-Three of Osborne's island types have direct Phenomena equivalents:
+Three of Osborne's island types have direct `ConstraintType` equivalents:
 - adjunct → .adjunct
 - subject → .subject
 - wh-island → .embeddedQuestion
@@ -22,7 +22,7 @@ namespace Osborne2019Islands
 open DepGrammar.Islands (OsborneIslandType)
 
 /-- Map `OsborneIslandType` to `ConstraintType` for the shared types. -/
-def toPhenomenaConstraintType :
+def toRossConstraintType :
     OsborneIslandType → Option ConstraintType
   | .adjunct       => some .adjunct
   | .subject       => some .subject

--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -79,7 +79,7 @@ by this file.
   sibling accounts whose distinct predictions can be refuted by explicit
   theorem rather than by docstring claim.
 - A `Fragments/Ndebele/` graduation once a second Ndebele paper lands.
-- Cross-Bantu typology hub `Phenomena/Agreement/Bantu.lean`.
+- A cross-Bantu agreement typology hub under `Typology/`.
 - Typeclass-based phasehood-attestation registry (per the audit's
   "obvious next move"): would let convergence with E&S 2025 be
   true-by-construction via `instance` declarations.

--- a/Linglib/Studies/QingEtAl2025.lean
+++ b/Linglib/Studies/QingEtAl2025.lean
@@ -144,7 +144,7 @@ We can verify that predictions match observations:
 Semantics.Attitudes.BuilderProperties.Attitude.nvpClass hope.attitude = some.class3_cDist_positive
 -- This predicts: canTakeQuestion = false
 
--- From Phenomena/QingEtAl2025/Data.lean:
+-- From the empirical data in this file:
 hopeEn.takesPolQ = false ∧ hopeEn.takesWhQ = false ✓
 ```
 

--- a/Linglib/Studies/SagWasowBender2003Extraction.lean
+++ b/Linglib/Studies/SagWasowBender2003Extraction.lean
@@ -5,8 +5,8 @@ import Linglib.Studies.Ross1967
 # Bridge: HPSG Extraction to Filler-Gap Phenomena
 [sag-wasow-bender-2003] [hofmeister-sag-2010]
 
-Connects HPSG's Head-Filler Schema and SLASH mechanism to empirical
-filler-gap data in `Phenomena.FillerGap`.
+Connects HPSG's Head-Filler Schema and SLASH mechanism to the
+empirical island taxonomy from `Studies/Ross1967`.
 
 ## Main results
 
@@ -103,7 +103,7 @@ example : extractionLicensed weakIslandNP = true := rfl
 example : extractionLicensed weakIslandPP = false := rfl
 
 -- ============================================================================
--- Connecting to Phenomena Data
+-- Connecting to the Ross 1967 Island Taxonomy
 -- ============================================================================
 
 /-- Map island constraint types to HPSG GAP restrictions.

--- a/Linglib/Studies/SagWasowBender2003RelativeClauses.lean
+++ b/Linglib/Studies/SagWasowBender2003RelativeClauses.lean
@@ -5,7 +5,7 @@ import Linglib.Syntax.HPSG.RelativeClauses
 [sag-wasow-bender-2003] [pollard-sag-1994]
 
 Connects the HPSG relative clause mechanism (MOD feature + SLASH/GAP
-+ Head-Modifier Schema) to empirical data in `Phenomena.FillerGap`.
++ Head-Modifier Schema) to empirical relative-clause data (inlined below).
 
 ## Main results
 
@@ -96,7 +96,7 @@ def ppRelWho : RelClauseConfig :=
 #guard relClauseLicensed ppRelWho
 
 -- ============================================================================
--- Connecting to Phenomena Data
+-- Connecting to Empirical Data
 -- ============================================================================
 
 /-- Object relative clause data matches HPSG derivation.

--- a/Linglib/Studies/SarvasyAikhenvald2025.lean
+++ b/Linglib/Studies/SarvasyAikhenvald2025.lean
@@ -47,12 +47,12 @@ the origin (the final verb's context).
    DS = `.agent` differs
 -/
 
-namespace Phenomena.ClauseChaining
+namespace ClauseChaining
 
 open _root_.Typology.ClauseChaining
 
 -- ============================================================================
--- Language data (was `Phenomena/ClauseChaining/Data.lean`; inlined per the
+-- Language data (inlined per the
 -- provenance-tracking policy). [sarvasy-aikhenvald-2025] is the natural
 -- owner — the parameter sample comes from this paper.
 -- ============================================================================
@@ -224,7 +224,7 @@ because the SR morpheme absorbs sequential/simultaneous distinctions. -/
 theorem noSR_richer_relations :
     allLanguages.all (λ p => p.hasSR || p.relationsMarked.length ≥ 7) = true := by decide
 
-end Phenomena.ClauseChaining
+end ClauseChaining
 
 
 -- ============================================================================
@@ -237,7 +237,7 @@ namespace SarvasyAikhenvald2025
 -- Part I: Fragment Verification
 -- ============================================================================
 
-open Phenomena.ClauseChaining
+open ClauseChaining
 open Typology.ClauseChaining
 open Nungon.MedialVerbs (SRCategory dsParadigm ssSuffixes ds2du ds3du ds2pl ds3pl)
 open Manambu.MedialVerbs (allMarkers ssMarkers dsMarkers neutralMarkers

--- a/Linglib/Studies/Scontras2014.lean
+++ b/Linglib/Studies/Scontras2014.lean
@@ -44,13 +44,13 @@ Container nouns can be disambiguated:
 
 ## Architecture
 
-This is a Phenomena file: it encodes empirical observations and proves that
+This file encodes empirical observations and proves that
 the Fragment entries (class assignments) correctly predict the Theory's
 MEASURE-reading licensing.
 
 Dependency chain:
   Theory (`licensesMeasureReading`) → Fragment (`QuantizingNounEntry.nounClass`)
-    → Phenomena (this file)
+    → Studies (this file)
 
 -/
 
@@ -181,7 +181,7 @@ class + reading to a MEASURE-licensing prediction (Scontras Table 3.5 p. 89).
 We prove that this prediction matches the empirical observation for EVERY
 example in our data.
 
-This is the payoff of the Theories → Fragments → Phenomena architecture: if
+This is the payoff of the Theories → Fragments → Studies architecture: if
 someone changes a noun's class assignment in the Fragment, or changes the
 `licensesMeasureReading` function in the Theory, the bridge theorems break. -/
 

--- a/Linglib/Studies/Spector2016.lean
+++ b/Linglib/Studies/Spector2016.lean
@@ -17,7 +17,7 @@ The abstract Spector framework lives in
 `Semantics/Exhaustification/Operators/Basic.lean`. This file holds the
 empirical exemplars — small finite worlds, scale-specific alternative
 sets, and the per-scale `exhMW ≡ exhIE` corollaries — kept out of the
-theory file in line with the project's Theory/Phenomena split.
+theory file in line with the project's theory/Studies split.
 
 It also collects the [chierchia-2013] Maximize Strength worked
 examples (matrix-clause SI computed, DE-context SI suppressed) as a small

--- a/Linglib/Studies/Stassen1985.lean
+++ b/Linglib/Studies/Stassen1985.lean
@@ -443,13 +443,13 @@ theorem turkish_three_layer :
 /-- Korean: absolute deranking predicts non-finite medial verbs. -/
 theorem korean_deranking_consistent :
     koreanCT = .absoluteDeranking ∧
-    Phenomena.ClauseChaining.korean.medialVerbForm =
+    ClauseChaining.korean.medialVerbForm =
       UD.VerbForm.Conv :=
   ⟨rfl, rfl⟩
 
 theorem turkish_deranking_consistent :
     turkishCT = .absoluteDeranking ∧
-    Phenomena.ClauseChaining.turkish.medialVerbForm =
+    ClauseChaining.turkish.medialVerbForm =
       UD.VerbForm.Conv :=
   ⟨rfl, rfl⟩
 

--- a/Linglib/Studies/XuEtAl2024.lean
+++ b/Linglib/Studies/XuEtAl2024.lean
@@ -37,7 +37,7 @@ length and listener confusion. Bridges synchronic copredication judgments
 ([asher-2011], [gotham-2017]) to a diachronic functional account.
 -/
 
-namespace Phenomena.Polysemy
+namespace XuEtAl2024.Polysemy
 
 open Pragmatics.Communication (AsymmetricCommModel)
 open Pragmatics.Efficiency (CostPair weightedCost)
@@ -295,4 +295,4 @@ theorem all_english_reuse_creates_polysemy :
     (reuseIsPolysemyGeneration englishReuse).length = englishReuse.length := by
   decide
 
-end Phenomena.Polysemy
+end XuEtAl2024.Polysemy

--- a/Linglib/Syntax/Case/Dependent.lean
+++ b/Linglib/Syntax/Case/Dependent.lean
@@ -337,7 +337,7 @@ In a tripartite system, both dependent ergative and dependent accusative
 are active simultaneously: the higher NP gets ERG, the lower gets ACC,
 and an NP with no case competitor gets unmarked ABS. These are properties
 of the algorithm, not of any particular language. Language-specific
-derivations (e.g., SJA Mam) belong in `Phenomena/Case/Bridge/`. -/
+derivations live in Studies files (e.g., SJA Mam in `Studies/Scott2023`). -/
 
 /-- Tripartite transitive: higher NP gets dependent ERG. -/
 theorem tripartite_higher_gets_erg :

--- a/Linglib/Syntax/Minimalist/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Basic.lean
@@ -336,7 +336,7 @@ end SyntacticObject
 
 /-- Cascade combinator: lift a `FreeMagma (LIToken ⊕ Nat) → β` aux to
     `SyntacticObject → β`, hiding the `FreeMagma.CommRel` machinery
-    from Phenomena consumers. Same as `FreeCommMagma.lift` modulo the
+    from downstream consumers. Same as `FreeCommMagma.lift` modulo the
     SO type ascription at the SO interface. The `_respects` hypothesis
     still has to be provided, but the type signature is consumer-friendly.
 
@@ -1204,9 +1204,9 @@ def SyntacticObject.shape : SyntacticObject → FreeCommMagma Unit :=
 /-- The unit shape — a single leaf in `FreeCommMagma Unit`. Useful
     abbreviation for stating shape equalities like
     `so.shape = leafShape * (leafShape * leafShape)`. Was previously
-    duplicated as `private def leafShape` in three Phenomena Studies
-    files (DendikkenBasic, HaddicanEtAl, Causatives); hoisted to
-    substrate to eliminate the triplicate. -/
+    duplicated as `private def leafShape` in three Studies files
+    (Dendikken1995, HaddicanEtAl2026, Dendikken1995Causatives);
+    hoisted to substrate to eliminate the triplicate. -/
 abbrev leafShape : FreeCommMagma Unit := FreeCommMagma.of ()
 
 @[simp] theorem SyntacticObject.shape_leaf (tok : LIToken) :

--- a/Linglib/Syntax/Minimalist/FromFragments.lean
+++ b/Linglib/Syntax/Minimalist/FromFragments.lean
@@ -13,7 +13,7 @@ Maps Fragment lexical entries (`VerbEntry`, `PersonalPronoun`, `NounEntry`,
 appropriate `Cat` and `SelStack` features.
 
 Concrete derivation *instances* using these projections live in
-`Phenomena/`, anchored to specific paper analyses (e.g.
+`Studies/`, anchored to specific paper analyses (e.g.
 `Studies/Adger2003.lean` for c-selection).
 
 ## Sections

--- a/Linglib/Syntax/Minimalist/Merge/External.lean
+++ b/Linglib/Syntax/Minimalist/Merge/External.lean
@@ -612,7 +612,7 @@ Linglib's `Derivation` (in `Syntax/Minimalist/Derivation.lean`)
 has constructors `Step.emR`, `Step.emL`, `Step.im`. There is no
 `Step.sideward` because Sideward is suppressed by Prop 1.5.1; there is
 no `Step.wlm` because Wholesale Late Merger derivations were never
-attested in Phenomena consumers and MCB §1.7 predicts wlm-outputs are
+attested in downstream consumers and MCB §1.7 predicts wlm-outputs are
 derivable from EM/IM regardless.
 
 This section provides the **EM-only chain bridge**: a joint linguistic+

--- a/Linglib/Syntax/Minimalist/Scope.lean
+++ b/Linglib/Syntax/Minimalist/Scope.lean
@@ -25,8 +25,8 @@ Inverse scope is unavailable when:
 In earlier versions, `PositionedQuantifier` carried a stipulated
 `inDoubleObject : Bool` flag. This has been replaced: the theory layer
 provides `superiorityFromTree`, which derives superiority from
-asymmetric c-command in a `SyntacticObject` tree. Bridge files in
-`Phenomena/` use this to connect DOC scope freezing to
+asymmetric c-command in a `SyntacticObject` tree.
+`Studies/Bruening2001.lean` uses this to connect DOC scope freezing to
 [larson-1988]'s tree derivation.
 
 -/

--- a/Linglib/Syntax/Tree/Basic.lean
+++ b/Linglib/Syntax/Tree/Basic.lean
@@ -354,8 +354,8 @@ instance {C W : Type} : Core.Order.HasContent (Tree C W) W where
 /-! ### `Branching.yield`-instance simp lemmas
 
 Make the generic `Branching.yield` reduce by `simp`/`decide` at
-concrete `Tree` constructors — the prerequisite for consumers (Studies,
-Phenomena) to replace bespoke yield computations with the generic API. -/
+concrete `Tree` constructors — the prerequisite for consumers (Studies
+files) to replace bespoke yield computations with the generic API. -/
 
 @[simp] theorem branching_content_terminal {C W : Type} (c : C) (w : W) :
     Core.Order.HasContent.content? (Tree.terminal c w) = some w := rfl

--- a/Linglib/Typology/Adposition.lean
+++ b/Linglib/Typology/Adposition.lean
@@ -8,7 +8,7 @@ import Linglib.Typology.WordOrder
 
 Framework-agnostic enum for storing per-language adposition order
 (WALS Ch 85). Lives in `Typology/` so both `Fragments/` (per-language
-profiles) and `Phenomena/` (cross-linguistic generalisations) can
+profiles) and `Studies/` (cross-linguistic generalisations) can
 import without violating the layered dependency hierarchy.
 
 Sister substrate to `Typology.WordOrder` — same shape (enum with

--- a/Linglib/Typology/PolarityMarking.lean
+++ b/Linglib/Typology/PolarityMarking.lean
@@ -10,8 +10,8 @@ Per-language typological substrate for polarity-marking strategies
 (neg → affirm switches): the form-class taxonomy + per-marker
 environments + the cross-linguistic entry record. Fragment files for
 Dutch, German, English, Italian, Spanish, French, Swedish populate
-the schema; Phenomena/Polarity/Studies files consume it for
-cross-linguistic predictions.
+the schema; Studies files (TurcoBraunDimroth2014, GarassinoJacob2018,
+MaticNikolaeva2018) consume it for cross-linguistic predictions.
 
 Moved from `Features/InformationStructure.lean` in the 0.230.493 cleanup
 (commit 3/3 of the InformationStructure dump-bag dissolution; cluster B


### PR DESCRIPTION
Phase 4 finale of the Phenomena→Data migration: ~120 stale docstring references across 63 files re-pointed at each item's current home (Data/Examples, Fragments, Typology, Studies) or deleted where the content has no successor; layer-architecture prose rewritten for the post-Phenomena layering; the last five code-level identifiers renamed (Phenomena.ClauseChaining→ClauseChaining, Phenomena.Polysemy→XuEtAl2024.Polysemy, Phenomena.Complementation.Cacchioli2025→Cacchioli2025, Phenomena.PsychVerbs→Pesetsky1995.PsychVerbs landed earlier, toPhenomenaConstraintType→toRossConstraintType); Linglib.lean section comments cleaned. The Phenomena/ directory itself vanished with its last file in #361. Remaining grep hits are legitimate English, paper titles, and past-tense provenance notes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)