### PR TITLE
feat(Studies): Vikner-Jensen & Partee-Borschev genitive analyses

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2832,4 +2832,5 @@ import Linglib.Core.Logic.TweetyNixon
 import Linglib.Data.Examples.TesslerGoodman2022
 import Linglib.Data.Examples.CaoWhiteLassiter2025
 import Linglib.Studies.Barker1995
+import Linglib.Studies.ParteeBorschev2003
 import Linglib.Studies.ViknerJensen2002

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2832,3 +2832,4 @@ import Linglib.Core.Logic.TweetyNixon
 import Linglib.Data.Examples.TesslerGoodman2022
 import Linglib.Data.Examples.CaoWhiteLassiter2025
 import Linglib.Studies.Barker1995
+import Linglib.Studies.ViknerJensen2002

--- a/Linglib/Studies/ParteeBorschev2003.lean
+++ b/Linglib/Studies/ParteeBorschev2003.lean
@@ -1,0 +1,127 @@
+import Linglib.Semantics.ArgumentStructure.Relational
+
+/-!
+# Partee & Borschev 2003: Genitives, relational nouns, and argument-modifier ambiguity
+
+Paper-anchored consumer of the relational/possessive substrate for
+[partee-borschev-2003]. P&B defend a **split** analysis of the genitive against
+the **uniform "argument-only"** analysis of [vikner-jensen-2002] (J&V): some
+genitives are *arguments* of a relational noun, others are *modifiers* carrying
+a free contextual relation. The two construction types map exactly onto the
+substrate:
+
+* **argument genitive** (relational head noun supplies R): `of John's = λR[R(John)]`,
+  `teacher of John's = λx[teacher(John)(x)]` — this is `possessiveRelational`.
+* **modifier genitive** (sortal head noun + free relation `Rᵢ`):
+  `of John's = λPλx[P(x) ∧ Rᵢ(John)(x)]`, `team of John's = λx[team(x) ∧ Rᵢ(John)(x)]`
+  — this is `possessiveSortal` (Barker's `π`).
+
+## Main statements
+
+* `vj_coerce_eq_pb_modifier` — **convergence** (P&B §4.3): for a pragmatically
+  coerced sortal noun, J&V's "coerce to a relation, then take as argument" and
+  P&B's modifier genitive yield the *same* predicate. The accounts differ only
+  in *where* the free relation enters, not in truth conditions — `rfl`.
+* `FormerMansion.readingA_ne_readingB` — **divergence** (P&B §4.3, *Mary's former
+  mansion*): under the modifier *former*, putting the free relation inside vs.
+  outside its scope gives different predicates. J&V's coercion derives both;
+  P&B's split derives only the R-outside reading — J&V's empirical advantage.
+* `predicateGenitive_eq` — P&B §5.1: the predicate genitive *John's* (*that team
+  is John's*) is a bare ⟨e,t⟩ predicate `λx[Rᵢ(John)(x)]` = `possessiveRelational`,
+  which the uniform argument-only approach cannot produce standalone.
+
+## References
+
+* [partee-borschev-2003]: Genitives, relational nouns, and argument-modifier
+  ambiguity.
+* [vikner-jensen-2002]: the uniform "argument-only" analysis P&B argue against.
+-/
+
+namespace ParteeBorschev2003
+
+open Semantics.ArgumentStructure.Relational
+
+variable {E S : Type*}
+
+/-! ### The two approaches converge on coerced sortals (P&B §4.3)
+
+For *team of Mary's* both accounts derive `λx[team(x) ∧ Rᵢ(Mary)(x)]`. J&V coerce
+*team* to the relation `π team Rᵢ` and apply the argument genitive; P&B apply the
+modifier genitive directly. The free relation enters inside the coerced noun for
+J&V, with the construction for P&B — but the result is identical. -/
+
+/-- **Convergence** (P&B §4.3): J&V's coerce-then-argument equals P&B's modifier
+genitive. The "two theories of genitives" are, on the coerced-sortal case, a
+single denotation reached two ways. -/
+theorem vj_coerce_eq_pb_modifier (possessor : E) (P : Pred1 E S) (R : Pred2 E S) :
+    possessiveRelational possessor (π P R) = possessiveSortal possessor P R :=
+  rfl
+
+/-! ### The predicate genitive (P&B §5.1)
+
+*That team is John's*: the genitive surfaces as a bare one-place predicate with a
+free relation, `λx[Rᵢ(John)(x)]`. P&B argue this is not always reducible to an
+elliptical argument NP, so English needs the modifier genitive — a problem for
+the uniform argument-only approach. -/
+
+/-- The predicate genitive *John's* is the possessee predicate `λx[R possessor x]`
+= `possessiveRelational possessor R`, a genuine ⟨e,t⟩ predicate (here `Pred1`). -/
+theorem predicateGenitive_eq (possessor : E) (R : Pred2 E S) :
+    (fun x s => R possessor x s) = possessiveRelational possessor R :=
+  rfl
+
+/-! ### The readings of *Mary's former mansion* (P&B §4.3)
+
+`former` (CN/CN) modifies the noun predicate; `formerRel` (TCN/TCN) modifies a
+relation. With the free relation `R` *outside* `former` (Reading A) vs. *inside*
+`formerRel`'s scope (Reading B), the genitive denotes differently. P&B's split
+introduces `R` only with the construction, after `former`, deriving Reading A
+alone; J&V's coercion can introduce `R` at the noun-shift, deriving both. -/
+
+/-- Reading A: the free relation is outside `former`'s scope — *a former mansion
+that is now Mary's*. The only reading P&B's split derives. -/
+def readingA (former : Pred1 E S → Pred1 E S) (possessor : E)
+    (noun : Pred1 E S) (R : Pred2 E S) : Pred1 E S :=
+  possessiveSortal possessor (former noun) R
+
+/-- Reading B: the free relation is inside `formerRel`'s scope — *something that
+was formerly Mary's mansion*. Available on J&V's coercion. -/
+def readingB (formerRel : Pred2 E S → Pred2 E S) (possessor : E)
+    (noun : Pred1 E S) (R : Pred2 E S) : Pred1 E S :=
+  possessiveRelational possessor (formerRel (π noun R))
+
+namespace FormerMansion
+
+/-- Entities: building `0`, Mary `1`. -/
+abbrev Ent := Fin 2
+/-- Time: `true` now, `false` past. -/
+abbrev Tm := Bool
+
+/-- The building `0` is a mansion at every time. -/
+def mansion : Pred1 Ent Tm := fun x _ => x = 0
+/-- Mary (`1`) owned the building (`0`) only in the past. -/
+def owns : Pred2 Ent Tm := fun o x t => o = 1 ∧ x = 0 ∧ t = false
+/-- *former* P: was P in the past, no longer P now. -/
+def former (P : Pred1 Ent Tm) : Pred1 Ent Tm := fun x t => P x false ∧ ¬ P x t
+/-- *former* on a relation: held in the past, no longer. -/
+def formerRel (Rel : Pred2 Ent Tm) : Pred2 Ent Tm :=
+  fun o x t => Rel o x false ∧ ¬ Rel o x t
+
+/-- **Divergence**: the locus of the free relation is detectable under *former*.
+The building is still a mansion now but Mary no longer owns it, so Reading B
+(*was Mary's mansion*) holds of it while Reading A (*a former mansion now
+Mary's*) does not. P&B's split derives only Reading A; J&V's coercion derives
+both — J&V's empirical advantage (P&B §4.3). -/
+theorem readingA_ne_readingB :
+    readingA former 1 mansion owns ≠ readingB formerRel 1 mansion owns := by
+  intro h
+  have hA : ¬ readingA former 1 mansion owns 0 true := by
+    unfold readingA possessiveSortal π former mansion owns; decide
+  have hB : readingB formerRel 1 mansion owns 0 true := by
+    unfold readingB possessiveRelational formerRel π mansion owns; decide
+  rw [h] at hA
+  exact hA hB
+
+end FormerMansion
+
+end ParteeBorschev2003

--- a/Linglib/Studies/ViknerJensen2002.lean
+++ b/Linglib/Studies/ViknerJensen2002.lean
@@ -1,0 +1,160 @@
+import Linglib.Semantics.ArgumentStructure.Relational
+
+/-!
+# Vikner & Jensen 2002: A semantic analysis of the English genitive
+
+Paper-anchored consumer of the relational/possessive substrate for
+[vikner-jensen-2002]. V&J give the prenominal genitive a single syntactic type
+(it always combines with a *relational* noun); a non-relational head noun is
+coerced to relational, with the genitive relation *derived* from the noun's
+Pustejovsky qualia rather than stipulated.
+
+* **Four lexical relation types** (§3.1.2): inherent, part-whole, agentive,
+  control. These *are* the project's `PossessionRelationType` — V&J is the
+  source of that taxonomy (cited in `ArgumentStructure/Relational.lean`), and
+  this study is its first consumer.
+* **Qualia derivation** (§3.2.3): the relation type follows from lexical
+  structure — inherent from relationality, part-whole from the constitutive
+  quale, agentive from the agentive quale; control is always available. So the
+  three-way ambiguity of *the girl's picture* is derived, not listed.
+* **The denotation** (§3.2.3, (20)–(21)): the genitive is the possessor plus a
+  narrow-scope definite — the unique entity standing in the resolved relation to
+  the possessor. The relation combines with the noun via Barker's `π`
+  (`possessiveRelational` for a relational noun, `possessiveSortal` for a coerced
+  sortal noun); uniqueness is `iotaPresupposition`, and a worked entry feeds the
+  `DefinitePossessive` carrier's `existsUnique_possessee`.
+
+## Main statements
+
+* `control_always`, `picture_three_ways`, `nose_partWhole`, … — the
+  qualia-derivation predictions (decide-checked).
+* `girlsTeacher_existsUnique` — V&J's inherent genitive as a carrier-API
+  definite (unique referent via `existsUnique_possessee`).
+* `girlsCar_eq_sortal` — V&J's coerced (control) genitive as `possessiveSortal`.
+
+## References
+
+* [vikner-jensen-2002]: A semantic analysis of the English genitive.
+-/
+
+namespace ViknerJensen2002
+
+open Semantics.ArgumentStructure.Relational
+
+/-! ### Qualia structure (Pustejovsky, as used by V&J §3.2.1) -/
+
+/-- The relation-bearing qualia V&J read off a head noun. The telic and formal
+qualia do not contribute a genitive relation type in V&J's four-way taxonomy, so
+they are omitted. -/
+structure NounQualia where
+  /-- Inherently relational (e.g. *sister*, *teacher*) — bears its own relatum. -/
+  isRelational : Bool
+  /-- Bears a constitutive quale (*nose*: part-of a body). -/
+  hasConstitutive : Bool
+  /-- Bears an agentive quale (*poem*: composed by someone). -/
+  hasAgentive : Bool
+  deriving DecidableEq, Repr
+
+/-! ### Deriving the relation type from qualia (V&J §3.2.3) -/
+
+/-- V&J's central thesis: the genitive's relation type is *derived* from the head
+noun's lexical structure, not stipulated. A noun licenses the inherent relation
+iff it is relational, the part-whole relation iff it bears a constitutive quale,
+the agentive relation iff it bears an agentive quale; the control relation is
+always available (the default, independent of qualia, §3.1.2). The codomain is
+the project's `PossessionRelationType` — V&J is the source of that taxonomy. -/
+def availableRelations (q : NounQualia) : List PossessionRelationType :=
+  (if q.isRelational then [PossessionRelationType.inherent] else []) ++
+  (if q.hasConstitutive then [PossessionRelationType.partWhole] else []) ++
+  (if q.hasAgentive then [PossessionRelationType.agentive] else []) ++
+  [PossessionRelationType.control]
+
+/-- Control is available whatever the noun's qualia (V&J §3.1.2: it is always
+available, ownership being only one special case of control). -/
+theorem control_always (q : NounQualia) :
+    PossessionRelationType.control ∈ availableRelations q := by
+  simp [availableRelations]
+
+/-! ### Lexical entries (V&J (9), §3.1.2) -/
+
+/-- *sister* — inherently relational. -/
+def sister : NounQualia := ⟨true, false, false⟩
+/-- *nose* — constitutive quale (part-of a body). -/
+def nose : NounQualia := ⟨false, true, false⟩
+/-- *poem* — agentive quale (composed). -/
+def poem : NounQualia := ⟨false, false, true⟩
+/-- *car* — agentive quale (constructed); the salient reading is control. -/
+def car : NounQualia := ⟨false, false, true⟩
+/-- *picture* — relational (*picture of*) and agentive (*picture made by*). -/
+def picture : NounQualia := ⟨true, false, true⟩
+
+/-- *the girl's sister*: inherent relation, plus the ever-present control. -/
+theorem sister_inherent :
+    availableRelations sister = [.inherent, .control] := by decide
+
+/-- *the girl's nose*: part-whole, via the constitutive quale (no inherent or
+agentive reading). -/
+theorem nose_partWhole :
+    availableRelations nose = [.partWhole, .control] := by decide
+
+/-- *the girl's poem*: agentive, via the agentive quale. -/
+theorem poem_agentive :
+    availableRelations poem = [.agentive, .control] := by decide
+
+/-- *the girl's picture* is three ways ambiguous (V&J §3.1.2): inherent
+(*picture of the girl*), agentive (*picture the girl made*), and control
+(*picture at her disposal*) — but **not** part-whole. -/
+theorem picture_three_ways :
+    availableRelations picture = [.inherent, .agentive, .control] := by decide
+
+/-- The qualia derivation distinguishes the readings: *picture* is three-way
+ambiguous, *nose* only two-way. -/
+theorem picture_more_ambiguous_than_nose :
+    (availableRelations picture).length = 3 ∧ (availableRelations nose).length = 2 := by
+  decide
+
+/-! ### The denotation: possessor + narrow-scope definite (V&J §3.2.3)
+
+Model over `Fin 4` (girl `0`, her teacher `1`, her car `2`, an unrelated `3`),
+single situation. The genitive picks the unique entity standing in the resolved
+relation to the possessor. -/
+
+/-- The (inherent) teacher relation: `0`'s teacher is `1`. -/
+def teacherRel : Pred2 (Fin 4) Unit := fun x y _ => x = 0 ∧ y = 1
+
+/-- *the girl's teacher* (inherent, V&J (21)): the possessee predicate is the
+relation applied to the possessor (`possessiveRelational`), and there is a unique
+satisfier — V&J's narrow-scope definite, here as `iotaPresupposition`. -/
+theorem girlsTeacher_unique (s : Unit) :
+    iotaPresupposition (possessiveRelational (E := Fin 4) 0 teacherRel) s := by
+  refine ⟨1, ⟨rfl, rfl⟩, ?_⟩
+  rintro y ⟨-, hy⟩
+  exact hy
+
+/-- *the girl's teacher* as a `DefinitePossessive` carrier: its unique referent
+is delivered by the carrier API's `existsUnique_possessee`, no bespoke proof. -/
+def theGirlsTeacher : DefinitePossessive (Fin 4) Unit where
+  possessor := 0
+  predicate := possessiveRelational 0 teacherRel
+  presupposition := girlsTeacher_unique
+
+theorem girlsTeacher_existsUnique (s : Unit) :
+    ∃! y : Fin 4, HasPossesseePredicate.possesseePredicate theGirlsTeacher y s :=
+  existsUnique_possessee theGirlsTeacher s
+
+/-- The control relation: the girl `0` controls the car `2`. -/
+def controlRel : Pred2 (Fin 4) Unit := fun x y _ => x = 0 ∧ y = 2
+
+/-- *car* as a sortal noun predicate. -/
+def carPred : Pred1 (Fin 4) Unit := fun y _ => y = 2
+
+/-- *the girl's car* (coerced, control): the sortal noun is shifted to a relation
+via Barker's `π` (`possessiveSortal`), and the result selects the controlled car.
+This is V&J's coercion of a non-relational head noun. -/
+theorem girlsCar_eq_sortal (y : Fin 4) :
+    possessiveSortal (E := Fin 4) 0 carPred controlRel y () ↔ y = 2 := by
+  constructor
+  · rintro ⟨hcar, -, -⟩; exact hcar
+  · rintro rfl; exact ⟨rfl, rfl, rfl⟩
+
+end ViknerJensen2002

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -2981,6 +2981,20 @@
   role      = {cited},
   sources   = {Phenomena/Presupposition/ProjectiveContent.lean;Pragmatics/Implicature/ConventionalImplicatures.lean;Phenomena/Expressives/Studies/LoGuercio2025.lean}
 }
+@incollection{partee-borschev-2003,
+  author    = {Partee, Barbara H. and Borschev, Vladimir},
+  year      = {2003},
+  title     = {Genitives, Relational Nouns, and Argument-Modifier Ambiguity},
+  booktitle = {Modifying Adjuncts},
+  editor    = {Lang, Ewald and Maienborn, Claudia and Fabricius-Hansen, Cathrine},
+  series    = {Interface Explorations},
+  publisher = {Mouton de Gruyter},
+  address   = {Berlin},
+  subfield  = {semantics/lexical},
+  role      = {formalized},
+  sources   = {Studies/ParteeBorschev2003.lean}
+}
+
 @article{vikner-jensen-2002,
   author  = {Vikner, Carl and Jensen, Per Anker},
   year    = {2002},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -2981,6 +2981,20 @@
   role      = {cited},
   sources   = {Phenomena/Presupposition/ProjectiveContent.lean;Pragmatics/Implicature/ConventionalImplicatures.lean;Phenomena/Expressives/Studies/LoGuercio2025.lean}
 }
+@article{vikner-jensen-2002,
+  author  = {Vikner, Carl and Jensen, Per Anker},
+  year    = {2002},
+  title   = {A Semantic Analysis of the English Genitive: Interaction of Lexical and Formal Semantics},
+  journal = {Studia Linguistica},
+  volume  = {56},
+  number  = {2},
+  pages   = {191--226},
+  doi     = {10.1111/1467-9582.00092},
+  subfield = {semantics/lexical},
+  role    = {formalized},
+  sources = {Studies/ViknerJensen2002.lean;Semantics/ArgumentStructure/Relational.lean}
+}
+
 @book{peters-westerstahl-2006,
   author    = {Peters, Stanley and Westerst\r{a}hl, Dag},
   year      = {2006},


### PR DESCRIPTION
Two paper-anchored consumers of the relational/possessive substrate, formalizing the genitive argument-vs-modifier debate:

- ViknerJensen2002 — first consumer of `PossessionRelationType` (V&J is its source; `[vikner-jensen-2002]` was dangling, now in the bib). Qualia-derived relation types (the *girl's picture* three-way ambiguity); denotation via π + narrow-scope iota.
- ParteeBorschev2003 — the split analysis vs V&J's uniform one. `vj_coerce_eq_pb_modifier` (`rfl`: the accounts converge truth-conditionally on coerced sortals), `FormerMansion.readingA_ne_readingB` (they diverge under *former*), predicate genitive = `possessiveRelational`.