### PR TITLE
refactor(Semantics/Possessive): unify carrier API, slim Carrier

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2834,4 +2834,5 @@ import Linglib.Data.Examples.TesslerGoodman2022
 import Linglib.Data.Examples.CaoWhiteLassiter2025
 import Linglib.Studies.Barker1995
 import Linglib.Studies.ParteeBorschev2001
+import Linglib.Studies.ParteeBorschev2003
 import Linglib.Studies.ViknerJensen2002

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2236,7 +2236,8 @@ import Linglib.Semantics.Quantification.Syllogistic.Trees
 import Linglib.Semantics.Quantification.Syllogistic.Square
 import Linglib.Semantics.Quantification.Lexicon
 import Linglib.Semantics.Quantification.Exceptive
-import Linglib.Semantics.Quantification.Possessive
+import Linglib.Semantics.Possessive.Basic
+import Linglib.Semantics.Possessive.GQ
 import Linglib.Semantics.Quantification.UnifiedUniversal
 import Linglib.Semantics.Quantification.ONEModifiers
 import Linglib.Semantics.Quantification.ChoiceFunction
@@ -2832,3 +2833,4 @@ import Linglib.Core.Logic.TweetyNixon
 import Linglib.Data.Examples.TesslerGoodman2022
 import Linglib.Data.Examples.CaoWhiteLassiter2025
 import Linglib.Studies.Barker1995
+import Linglib.Studies.ParteeBorschev2001

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2834,3 +2834,4 @@ import Linglib.Data.Examples.TesslerGoodman2022
 import Linglib.Data.Examples.CaoWhiteLassiter2025
 import Linglib.Studies.Barker1995
 import Linglib.Studies.ParteeBorschev2001
+import Linglib.Studies.ViknerJensen2002

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2245,7 +2245,9 @@ import Linglib.Semantics.Quantification.Syllogistic.Square
 import Linglib.Semantics.Quantification.Lexicon
 import Linglib.Semantics.Quantification.Exceptive
 import Linglib.Semantics.Possessive.Basic
+import Linglib.Semantics.Possessive.Denotation
 import Linglib.Semantics.Possessive.GQ
+import Linglib.Semantics.Possessive.PronounMixing
 import Linglib.Semantics.Quantification.UnifiedUniversal
 import Linglib.Semantics.Quantification.ONEModifiers
 import Linglib.Semantics.Quantification.ChoiceFunction

--- a/Linglib/Morphology/DM/CategorizerSemantics.lean
+++ b/Linglib/Morphology/DM/CategorizerSemantics.lean
@@ -1,5 +1,6 @@
 import Linglib.Morphology.DM.Categorizer
 import Linglib.Semantics.ArgumentStructure.Relational
+import Linglib.Semantics.Possessive.Basic
 
 /-!
 # Categorizer Semantics [adamson-2024] [barker-2011]
@@ -166,10 +167,10 @@ def teopHouseSortal (isHouse : Pred1 E S) : Pred1 E S :=
   nSortalDenot isHouse
 
 /-- With a specific possessor, the iPossessed body part reduces to a
-    property (Barker's possessiveRelational). -/
+    property (`Possessive.viaArgument`). -/
 theorem ipossessed_with_possessor (john : E) (x : E) (s : S) :
     teopSpleenIPossessed isSpleen bodyPartOf john x s =
-    possessiveRelational john (π isSpleen bodyPartOf) x s := rfl
+    Possessive.viaArgument john (π isSpleen bodyPartOf) x s := rfl
 
 /-- The sortal noun has no relatum slot — it cannot directly take a
     possessor without π. -/

--- a/Linglib/Semantics/ArgumentStructure/Relational.lean
+++ b/Linglib/Semantics/ArgumentStructure/Relational.lean
@@ -18,18 +18,17 @@ anaphora. They are tracked as separate predicates (`hasRelatumSlot`,
 `canTakePossessor`, `canBridge`) over `NominalInterpType` because they
 describe distinct linguistic facts, even though they coincide by construction.
 
+The possessive-specific carriers, capability mixins, and quantificational layer
+live in the unified `Possessive` namespace (`Semantics/Possessive/`), built on
+this substrate.
+
 ## Main definitions
 
 * `π P R`: Barker's relationalizer.
 * `Ex R`: existential closure of a relation.
-* `possessiveRelational possessor R`: applying a possessor to a relational noun.
-* `possessiveSortal possessor P R`: applying a possessor to a sortal noun via `π`.
 * `iotaPresupposition P`: Russellian uniqueness presupposition for definites.
+* `naSemantics`, `bareSemantics`: demonstrative and bare nominal denotations.
 * `NominalInterpType`: relational arity of a nominal denotation.
-* `PossessionRelationType`: four-way Vikner-Jensen possession taxonomy.
-* `HasPossessor`, `HasPossesseePredicate`, `HasPossessionRelation`,
-  `HasIotaWitness`: composable capability mixins for possessive carriers.
-* `possesseeSet`, `existsUnique_possessee`: capability-polymorphic consumers.
 
 ## Main statements
 
@@ -39,13 +38,11 @@ describe distinct linguistic facts, even though they coincide by construction.
 ## References
 
 * [barker-2011]: Possessives and relational nouns
-  (§6 of Portner/Heusinger/Maienborn handbook; π and Ex on pp. 184–189,
-  Vikner-Jensen taxonomy reproduced in Fig 6.1 p. 185).
-* [vikner-jensen-2002]: Semantic analysis of the English possessive.
+  (§6 of Portner/Heusinger/Maienborn handbook; π and Ex on pp. 184–189).
 
 ## Tags
 
-possessive, relational noun, type shifting, bridging, definite description
+relational noun, type shifting, bridging, definite description, demonstrative
 -/
 
 namespace Semantics.ArgumentStructure.Relational
@@ -95,39 +92,16 @@ theorem ex_pi_retraction [Nonempty E]
 
 end TypeShifters
 
-/-! ### Possessive constructions -/
+/-! ### Definiteness and demonstratives -/
 
-section Possessives
+section Definites
 
 variable {E S : Type*}
-
-/-- Possessor, possessee predicate, possession relation, and a flag
-recording whether the relation is lexical (vs pragmatically supplied). -/
-structure PossessiveSemantics (E S : Type*) where
-  possessor : E
-  possesseePred : Pred1 E S
-  relation : Pred2 E S
-  relationIsLexical : Bool
-
-/-- Applying a possessor to a lexically relational noun. -/
-def possessiveRelational (possessor : E) (nounRel : Pred2 E S) : Pred1 E S :=
-  λ y s => nounRel possessor y s
-
-/-- Applying a possessor to a sortal noun via `π`. -/
-def possessiveSortal (possessor : E) (nounPred : Pred1 E S)
-    (R : Pred2 E S) : Pred1 E S :=
-  λ y s => π nounPred R possessor y s
 
 /-- Russellian uniqueness presupposition: there exists a unique `x` satisfying
 `P`. -/
 def iotaPresupposition (P : Pred1 E S) (s : S) : Prop :=
   ∃ x : E, P x s ∧ ∀ y : E, P y s → y = x
-
-/-- A definite possessive carrying its uniqueness presupposition. -/
-structure DefinitePossessive (E S : Type*) where
-  possessor : E
-  predicate : Pred1 E S
-  presupposition : ∀ s : S, iotaPresupposition predicate s
 
 /-- Demonstrative-headed nominal: `π` applied to a sortal noun with the
 demonstrative supplying the relatum. -/
@@ -139,7 +113,7 @@ def naSemantics (nounPred : Pred1 E S) (R : Pred2 E S) (relatum : E) :
 def bareSemantics (nounPred : Pred1 E S) : Pred1 E S :=
   nounPred
 
-end Possessives
+end Definites
 
 /-! ### Interpretation sources and bridging -/
 
@@ -161,24 +135,6 @@ def CanFillRelatum : InterpretationSource → Prop
 
 instance : DecidablePred CanFillRelatum := λ s => by
   cases s <;> unfold CanFillRelatum <;> infer_instance
-
-/-! ### Vikner-Jensen possession taxonomy -/
-
-/-- Four-way lexical taxonomy of possession relations from
-[vikner-jensen-2002] §3.1.2, reproduced in Fig 6.1 of
-[barker-2011]. The separate "pragmatic" interpretation
-([vikner-jensen-2002] §3.1.1) is not lexical and is not one of the
-four cases below. -/
-inductive PossessionRelationType where
-  /-- Inherent relation: lexically argument-structural (the teacher's class). -/
-  | inherent
-  /-- Part-whole relation (the girl's nose, the car's wheel). -/
-  | partWhole
-  /-- Agentive relation (the girl's poem = the poem the girl wrote). -/
-  | agentive
-  /-- Control relation: ownership or legal control (the girl's car). -/
-  | control
-  deriving DecidableEq, Repr
 
 /-! ### Nominal interpretation type -/
 
@@ -218,128 +174,4 @@ instance : DecidablePred canBridge := λ t => by
 
 end NominalInterpType
 
-/-! ### Bridge to type ⟨1⟩ quantifiers -/
-
-/-- Possessive as a type ⟨1⟩ quantifier (NPQ):
-`⟦John's⟧ = fun R P ↦ ∃ y, R possessor y ∧ P y`.
-
-Possessive GQs are not isomorphism-invariant: they depend on the identity of
-the possessor, not just cardinalities. -/
-def possessiveAsNPQ {E : Type*} (possessor : E) (R : E → E → Bool) :
-    Core.Quantification.NPQ E :=
-  λ P => ∃ y : E, R possessor y = true ∧ P y
-
 end Semantics.ArgumentStructure.Relational
-
-/-! ## Composable carrier capabilities
-
-Cross-cutting capability mixins for the long-run library where 20-30+ possessive
-carriers (lexical determiners; clitics; possessive pronouns; possessor agreement
-affixes; possessive classifiers; construct-state nouns; genitive case markers;
-possessive adjectives; whose-wh; possessor reflexives; external-possessor
-applicatives; predicative-possession heads; Wood's i*; …) each implement a
-subset of the axes. Following the mathlib `Add`/`Mul`/`Inv`/`Neg` idiom: many
-small composable classes, each one operation; carriers opt in to whichever axes
-they bear; consumers depend on exactly those they touch.
-
-| Carrier | `HasPossessor` | `HasPossesseePredicate` | `HasPossessionRelation` | `HasIotaWitness` |
-|---|---|---|---|---|
-| `PossessiveSemantics E S` | ✓ | ✓ | ✓ | — |
-| `DefinitePossessive E S`  | ✓ | ✓ | — | ✓ |
-
-Lexical determiners (`Syntax/Determiner/Basic.lean`'s `Possessive`) hold no
-model-level data — possessor/R/predicate are supplied at denotation time — so
-they bear no bundled-carrier capability. -/
-
-open Semantics.ArgumentStructure.Relational
-
-/-! ### Bundled accessors -/
-
-/-- A carrier whose values bundle a possessor entity. Lexical determiners
-(`Possessive`, where the possessor is supplied externally) do not implement
-this; bundled denotational carriers (`PossessiveSemantics`, `DefinitePossessive`,
-future possessive DPs) do. -/
-class HasPossessor (α : Type*) (E : outParam Type*) where
-  /-- Project the bundled possessor entity. -/
-  possessor : α → E
-
-/-- A carrier whose values bundle a possessee predicate `Pred1 E S` — the set
-of possible possessees as a situation-relative property. -/
-class HasPossesseePredicate (α : Type*) (E S : outParam Type*) where
-  /-- Project the bundled possessee predicate. -/
-  possesseePredicate : α → Pred1 E S
-
-/-- A carrier whose values bundle a possession relation `Pred2 E S`. Distinct
-from `HasPossesseePredicate`: a relational noun's R is the noun denotation
-itself, while a sortal-with-π construction carries R separately from the
-sortal predicate. Carriers without an explicitly stored R (definite possessives
-that absorb R into the unique witness; classifier systems where R is the
-classifier) do not implement this. -/
-class HasPossessionRelation (α : Type*) (E S : outParam Type*) where
-  /-- Project the bundled possession relation. -/
-  possessionRelation : α → Pred2 E S
-
-/-! ### Russellian uniqueness -/
-
-/-- Prop class: a possessive carrier whose possessee predicate has a unique
-witness at every situation. Definite possessives ("the boy's cat", "my
-mother") bear this by construction; existential ("a friend of mine") and
-quantificational ("every student's") do not. Future carriers bearing
-Russellian uniqueness (definite DPs, familiarity-anaphoric possessives,
-ι-shifted possessor reflexives) implement this. -/
-class HasIotaWitness (α : Type*) (E S : outParam Type*)
-    [HasPossesseePredicate α E S] : Prop where
-  /-- The possessee predicate has a unique witness at every situation. -/
-  iotaWitness : ∀ (a : α) (s : S),
-    iotaPresupposition (HasPossesseePredicate.possesseePredicate a) s
-
-/-! ### Seed instances -/
-
-namespace Semantics.ArgumentStructure.Relational
-
-variable {E S : Type*}
-
-instance : HasPossessor (PossessiveSemantics E S) E :=
-  ⟨PossessiveSemantics.possessor⟩
-
-instance : HasPossesseePredicate (PossessiveSemantics E S) E S :=
-  ⟨PossessiveSemantics.possesseePred⟩
-
-instance : HasPossessionRelation (PossessiveSemantics E S) E S :=
-  ⟨PossessiveSemantics.relation⟩
-
-instance : HasPossessor (DefinitePossessive E S) E :=
-  ⟨DefinitePossessive.possessor⟩
-
-instance : HasPossesseePredicate (DefinitePossessive E S) E S :=
-  ⟨DefinitePossessive.predicate⟩
-
-/-- `DefinitePossessive` carries its iota-presupposition as a structure field;
-the typeclass instance just exposes it. -/
-instance : HasIotaWitness (DefinitePossessive E S) E S :=
-  ⟨fun a => a.presupposition⟩
-
-end Semantics.ArgumentStructure.Relational
-
-/-! ### Consuming the capabilities
-
-Capability-polymorphic results: stated once over the mixin classes, inherited by
-every instance. This is the payoff of the `Add`/`Mul`-style design — a consumer
-depends on exactly the axes it touches, and new carriers get the results for
-free, with no carrier-specific reproof. -/
-
-variable {α E S : Type*}
-
-/-- The possessee set determined by any carrier bundling a possessor and a
-possession relation: the entities standing in the relation to the possessor. -/
-def possesseeSet [HasPossessor α E] [HasPossessionRelation α E S] (a : α) :
-    Pred1 E S :=
-  fun y s => HasPossessionRelation.possessionRelation a (HasPossessor.possessor a) y s
-
-/-- Any carrier bearing a Russellian iota-witness denotes a unique possessee at
-every situation. Definite possessives inherit `∃!`-reference with no
-carrier-specific reproof. -/
-theorem existsUnique_possessee [HasPossesseePredicate α E S] [HasIotaWitness α E S]
-    (a : α) (s : S) :
-    ∃! y : E, HasPossesseePredicate.possesseePredicate a y s :=
-  HasIotaWitness.iotaWitness a s

--- a/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
@@ -40,7 +40,7 @@ deictic feature projects: deixis filters the referent but never selects it
   (previously deferred): a definite description selecting the unique satisfier
   of the possessee restrictor that stands in the possession relation to the
   possessor; the GQ-form possessive (`PossW`, narrowing-aware) lives in
-  `Semantics/Quantification/Possessive.lean`.
+  `Semantics/Possessive/GQ.lean`.
 
 ## Implementation notes
 
@@ -161,7 +161,7 @@ vacuous; the definite's only presupposition is definedness, exposed as the
 selector returning `some`.
 
 The narrowing-aware GQ form for quantificational possessors ("every student's
-cat") is `Semantics.Quantification.Possessive.PossW` — `(individual a)` of
+cat") is `Possessive.PossW` — `(individual a)` of
 `PossW` reduces here when the possessor is an entity. -/
 noncomputable def _root_.Possessive.denote (_p : Possessive)
     (R : DenotGS E W .et) (possessor : DenotGS E W .e) (rel : DenotGS E W .eet) :

--- a/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
@@ -1,6 +1,7 @@
 import Linglib.Semantics.Definiteness.Interpret
 import Linglib.Semantics.Definiteness.DeterminerLicensing
 import Linglib.Semantics.Reference.Nominal
+import Linglib.Semantics.Possessive.Basic
 
 /-!
 # The denotation of a determiner
@@ -41,6 +42,10 @@ deictic feature projects: deixis filters the referent but never selects it
   of the possessee restrictor that stands in the possession relation to the
   possessor; the GQ-form possessive (`PossW`, narrowing-aware) lives in
   `Semantics/Possessive/GQ.lean`.
+* `interpret_possessive_eq_viaModifier`, `Possessive.denote_isSome_iff_iotaPresupposition`,
+  `Possessive.toCarrier` — the determiner denotation *is* the `Possessive`
+  carrier API: same restrictor (Barker's `viaModifier`), same definedness
+  presupposition, same referent.
 
 ## Implementation notes
 
@@ -185,5 +190,72 @@ theorem Possessive.denote_licensed (p : Possessive)
     (R : DenotGS E W .et) (possessor : DenotGS E W .e) (rel : DenotGS E W .eet) :
     Determiner.licenses [.possessive p] (Description.possessive R possessor rel) :=
   ⟨.possessive p, List.mem_singleton_self _, trivial⟩
+
+/-! ### Unification with the possessive carrier API
+
+The possessive determiner's denotation (`Description.possessive`/`russellIota`)
+and the `Possessive` carrier API are not two analyses — they are the same
+construction. The determiner's restrictor *is* Barker's `Possessive.viaModifier`
+(π of the noun predicate and the possession relation); its definedness
+presupposition *is* the carrier's Russellian iota-presupposition; and at a
+context where the presupposition holds, the determiner assembles into a
+`Possessive.Definite` carrier whose `existsUnique_possessee` selects the very
+referent the determiner does. -/
+
+section CarrierUnification
+
+open Semantics.ArgumentStructure.Relational
+
+variable (R : DenotGS E W .et) (possessor : DenotGS E W .e) (rel : DenotGS E W .eet)
+  (g : Assignment E) (gs : SitAssignment W)
+
+/-- The possessive determiner's restrictor *is* Barker's `Possessive.viaModifier`
+(π of the noun predicate `R` and the possession relation `rel`): the
+`Definiteness` and `Possessive` encodings select through the same construction,
+by construction. -/
+theorem interpret_possessive_eq_viaModifier :
+    interpret (.possessive R possessor rel) g gs
+      = russellIota (fun x => Possessive.viaModifier (S := PUnit) (possessor g gs)
+          (fun y _ => R g gs y) (fun a b _ => rel g gs a b) x PUnit.unit) :=
+  rfl
+
+/-- The possessive determiner's definedness presupposition *is* the carrier
+API's Russellian iota-presupposition (`HasIotaWitness`'s condition). -/
+theorem Possessive.denote_isSome_iff_iotaPresupposition (p : Possessive) :
+    ((p.denote R possessor rel).selector (g, gs) PUnit.unit).isSome
+      ↔ iotaPresupposition
+          (fun x (_ : PUnit) => R g gs x ∧ rel g gs (possessor g gs) x) PUnit.unit := by
+  rw [Possessive.denote_selector]
+  show (russellIota (fun x => R g gs x ∧ rel g gs (possessor g gs) x)).isSome ↔ _
+  rw [russellIota_isSome_iff_existsUnique]
+  unfold existsUnique Existence Uniqueness iotaPresupposition
+  constructor
+  · rintro ⟨⟨x, hx⟩, huniq⟩
+    exact ⟨x, hx, fun y hy => huniq y x hy hx⟩
+  · rintro ⟨x, hx, huniq⟩
+    exact ⟨⟨x, hx⟩, fun a b ha hb => (huniq a ha).trans (huniq b hb).symm⟩
+
+/-- At a context where its presupposition holds, the possessive determiner
+assembles into a `Possessive.Definite` carrier (over the trivial situation) whose
+possessee predicate is the determiner's restrictor. -/
+def Possessive.toCarrier
+    (h : iotaPresupposition
+      (fun x (_ : PUnit) => R g gs x ∧ rel g gs (possessor g gs) x) PUnit.unit) :
+    Possessive.Definite E PUnit where
+  possessor := possessor g gs
+  predicate := fun x _ => R g gs x ∧ rel g gs (possessor g gs) x
+  presupposition := fun _ => h
+
+/-- The carrier's unique possessee (`existsUnique_possessee`, inherited from
+`HasIotaWitness`) is the referent the determiner selects — the two encodings
+agree by construction. -/
+theorem Possessive.toCarrier_existsUnique
+    (h : iotaPresupposition
+      (fun x (_ : PUnit) => R g gs x ∧ rel g gs (possessor g gs) x) PUnit.unit) :
+    ∃! y : E, HasPossesseePredicate.possesseePredicate
+      (Possessive.toCarrier R possessor rel g gs h) y PUnit.unit :=
+  existsUnique_possessee _ PUnit.unit
+
+end CarrierUnification
 
 end Semantics.Definiteness

--- a/Linglib/Semantics/Possessive/Basic.lean
+++ b/Linglib/Semantics/Possessive/Basic.lean
@@ -1,0 +1,186 @@
+import Linglib.Semantics.ArgumentStructure.Relational
+
+/-!
+# Possessive carriers and capabilities
+
+The unified `Possessive` namespace for the semantics of possessive
+constructions, built on the general relational-noun substrate
+(`ArgumentStructure.Relational`: `π`, `Ex`, `iotaPresupposition`, …). The
+quantificational layer (`Poss`, `PossW`, narrowing, `carrierGQ`) is in
+`Possessive/GQ.lean`; the determiner that denotes through these carriers is
+`Possessive.denote` (`Semantics/Definiteness/DeterminerDenotation.lean`).
+
+## Main declarations
+
+* `Possessive.viaArgument`, `Possessive.viaModifier` — the two ways a possessor
+  combines with a noun: with a relational noun's own relation (the argument
+  genitive) or with a free relation over a sortal restrictor (the modifier
+  genitive, Barker's `π`).
+* `Possessive.Carrier` — a possessor + relation + sortal restrictor; the
+  possessee predicate is *derived* (`viaModifier`), never stored, so a carrier
+  cannot be incoherent.
+* `Possessive.Definite` — a possessive carrying a Russellian uniqueness
+  presupposition.
+* `HasPossessor`, `HasPossesseePredicate`, `HasPossessionRelation`,
+  `HasIotaWitness` — composable capability mixins (root namespace, `Add`/`Mul`
+  idiom); carriers opt into whichever axes they bear.
+* `possesseeSet`, `existsUnique_possessee` — capability-polymorphic consumers.
+* `Possessive.PossessionRelationType` — the four-way Vikner-Jensen possession
+  taxonomy.
+-/
+
+open Semantics.ArgumentStructure.Relational
+
+namespace Possessive
+
+variable {E S : Type*}
+
+/-! ### Combining a possessor with a noun -/
+
+/-- Applying a possessor to a lexically relational noun — the *argument*
+genitive: `⟦John's teacher⟧ = λy. teacher(John)(y)`. -/
+def viaArgument (possessor : E) (nounRel : Pred2 E S) : Pred1 E S :=
+  fun y s => nounRel possessor y s
+
+/-- Applying a possessor to a sortal noun via Barker's `π` — the *modifier*
+genitive with a free relation `R`: `⟦John's team⟧ = λy. team(y) ∧ R(John)(y)`. -/
+def viaModifier (possessor : E) (nounPred : Pred1 E S) (R : Pred2 E S) : Pred1 E S :=
+  fun y s => π nounPred R possessor y s
+
+/-- The argument genitive is the modifier genitive over a trivial restrictor. -/
+theorem viaArgument_eq_viaModifier_top (possessor : E) (R : Pred2 E S) :
+    viaArgument possessor R = viaModifier possessor (fun _ _ => True) R := by
+  funext y s; simp [viaArgument, viaModifier, π]
+
+/-! ### Carriers -/
+
+/-- A possessive carrier: a possessor, a possession relation, and a sortal
+restrictor (the noun predicate; `⊤` for a purely relational noun). The possessee
+predicate is *derived* (`viaModifier`), not stored — so a carrier cannot bundle
+a predicate unrelated to its relation. -/
+structure Carrier (E S : Type*) where
+  /-- The possessor entity. -/
+  possessor : E
+  /-- The possession relation. -/
+  relation : Pred2 E S
+  /-- The sortal restrictor (the noun predicate). -/
+  restrictor : Pred1 E S
+
+namespace Carrier
+
+/-- The derived possessee predicate: the restrictor conjoined with the relation
+applied to the possessor. -/
+def possesseePred (c : Carrier E S) : Pred1 E S :=
+  viaModifier c.possessor c.restrictor c.relation
+
+end Carrier
+
+/-- A definite possessive carrying its Russellian uniqueness presupposition
+("the boy's cat", "my mother"). -/
+structure Definite (E S : Type*) where
+  /-- The possessor entity. -/
+  possessor : E
+  /-- The possessee predicate (a definite description's restrictor). -/
+  predicate : Pred1 E S
+  /-- The possessee predicate has a unique witness at every situation. -/
+  presupposition : ∀ s : S, iotaPresupposition predicate s
+
+/-! ### Vikner-Jensen possession taxonomy -/
+
+/-- Four-way lexical taxonomy of possession relations from
+[vikner-jensen-2002] §3.1.2, reproduced in Fig 6.1 of [barker-2011]. The
+separate "pragmatic" interpretation is not lexical and is not one of these. -/
+inductive PossessionRelationType where
+  /-- Inherent relation: lexically argument-structural (the teacher's class). -/
+  | inherent
+  /-- Part-whole relation (the girl's nose, the car's wheel). -/
+  | partWhole
+  /-- Agentive relation (the girl's poem = the poem the girl wrote). -/
+  | agentive
+  /-- Control relation: ownership or legal control (the girl's car). -/
+  | control
+  deriving DecidableEq, Repr
+
+/-! ### Bridge to type ⟨1⟩ quantifiers -/
+
+/-- Possessive as a type ⟨1⟩ quantifier (NPQ):
+`⟦John's⟧ = fun R P ↦ ∃ y, R possessor y ∧ P y`. Not isomorphism-invariant: it
+depends on the identity of the possessor, not just cardinalities. -/
+def asNPQ {E : Type*} (possessor : E) (R : E → E → Bool) :
+    Core.Quantification.NPQ E :=
+  fun P => ∃ y : E, R possessor y = true ∧ P y
+
+end Possessive
+
+/-! ### Composable carrier capabilities
+
+Cross-cutting capability mixins for the long-run library where 20-30+ possessive
+carriers each implement a subset of the axes. Following the mathlib
+`Add`/`Mul`/`Inv`/`Neg` idiom: many small composable classes, each one
+operation; carriers opt in to whichever axes they bear.
+
+| Carrier | `HasPossessor` | `HasPossesseePredicate` | `HasPossessionRelation` | `HasIotaWitness` |
+|---|---|---|---|---|
+| `Possessive.Carrier E S`  | ✓ | ✓ | ✓ | — |
+| `Possessive.Definite E S` | ✓ | ✓ | — | ✓ | -/
+
+/-- A carrier whose values bundle a possessor entity. -/
+class HasPossessor (α : Type*) (E : outParam Type*) where
+  /-- Project the bundled possessor entity. -/
+  possessor : α → E
+
+/-- A carrier whose values bundle a possessee predicate `Pred1 E S`. -/
+class HasPossesseePredicate (α : Type*) (E S : outParam Type*) where
+  /-- Project the bundled possessee predicate. -/
+  possesseePredicate : α → Pred1 E S
+
+/-- A carrier whose values bundle a possession relation `Pred2 E S`. Distinct
+from `HasPossesseePredicate`: a relational noun's R is the noun denotation
+itself, while a sortal-with-π construction carries R separately. -/
+class HasPossessionRelation (α : Type*) (E S : outParam Type*) where
+  /-- Project the bundled possession relation. -/
+  possessionRelation : α → Pred2 E S
+
+/-- Prop class: a possessive carrier whose possessee predicate has a unique
+witness at every situation. Definite possessives bear this; existential and
+quantificational ones do not. -/
+class HasIotaWitness (α : Type*) (E S : outParam Type*)
+    [HasPossesseePredicate α E S] : Prop where
+  /-- The possessee predicate has a unique witness at every situation. -/
+  iotaWitness : ∀ (a : α) (s : S),
+    iotaPresupposition (HasPossesseePredicate.possesseePredicate a) s
+
+namespace Possessive
+
+variable {E S : Type*}
+
+instance : HasPossessor (Carrier E S) E := ⟨Carrier.possessor⟩
+instance : HasPossesseePredicate (Carrier E S) E S := ⟨Carrier.possesseePred⟩
+instance : HasPossessionRelation (Carrier E S) E S := ⟨Carrier.relation⟩
+
+instance : HasPossessor (Definite E S) E := ⟨Definite.possessor⟩
+instance : HasPossesseePredicate (Definite E S) E S := ⟨Definite.predicate⟩
+
+/-- `Definite` carries its iota-presupposition as a structure field; the
+typeclass instance just exposes it. -/
+instance : HasIotaWitness (Definite E S) E S := ⟨fun a => a.presupposition⟩
+
+end Possessive
+
+/-! ### Consuming the capabilities -/
+
+variable {α E S : Type*}
+
+/-- The possessee set determined by any carrier bundling a possessor and a
+possession relation: the entities standing in the relation to the possessor. -/
+def possesseeSet [HasPossessor α E] [HasPossessionRelation α E S] (a : α) :
+    Pred1 E S :=
+  fun y s => HasPossessionRelation.possessionRelation a (HasPossessor.possessor a) y s
+
+/-- Any carrier bearing a Russellian iota-witness denotes a unique possessee at
+every situation. Definite possessives inherit `∃!`-reference with no
+carrier-specific reproof. -/
+theorem existsUnique_possessee [HasPossesseePredicate α E S] [HasIotaWitness α E S]
+    (a : α) (s : S) :
+    ∃! y : E, HasPossesseePredicate.possesseePredicate a y s :=
+  HasIotaWitness.iotaWitness a s

--- a/Linglib/Semantics/Possessive/Denotation.lean
+++ b/Linglib/Semantics/Possessive/Denotation.lean
@@ -1,0 +1,89 @@
+import Linglib.Semantics.Reference.Nominal
+import Linglib.Semantics.Definiteness.Maximality
+import Linglib.Semantics.Possessive.Basic
+
+/-!
+# Possessive-of as a Kleisli arrow
+
+The possessive denotation in the unified referential currency `NominalDenot`
+(`Semantics/Reference/Nominal.lean`), which is a monad. *NP's N* is **Kleisli
+`bind`** into the definite possessee of the possessor: re-point the possessor
+denotation's selector through the possession relation (`russellIota` of the
+relation), inheriting the possessor's intrinsic presupposition. So:
+
+* possessive **nesting** (*John's mother's friend*) is `bind` associativity;
+* the possessor's φ-features (when it is a pronoun) **ride along** to the whole
+  possessive, by `applyTo_presup`;
+* the existence/uniqueness presupposition is **selector definedness**
+  (`russellIota_isSome_iff_existsUnique`), not a separate intrinsic presup.
+
+## Main declarations
+
+* `Possessive.theOf R` — the Kleisli arrow: the unique `R`-possessee of a
+  possessor, as a `NominalDenot`.
+* `Possessive.applyTo nd R = nd >>= theOf R` — *NP's N*.
+* `Possessive.Definite.toNominalDenot` — a definite carrier as a `NominalDenot`
+  (always-defined selector, from `HasIotaWitness`).
+
+## Main statements
+
+* `applyTo_presup` — the possessive's presupposition *is* the possessor's.
+* `applyTo_selector` — the selector binds through the iota of the relation.
+* `applyTo_applyTo` — nesting, from `bind_assoc`.
+-/
+
+namespace Possessive
+
+open Semantics.Reference (NominalDenot)
+open Semantics.Definiteness (russellIota russellIota_isSome_iff_existsUnique existsUnique)
+
+variable {Ctx : Type*} {W E : Type}
+
+/-! ### The Kleisli arrow -/
+
+/-- The unique entity the `possessor` stands in relation `R` to, as a
+`NominalDenot`: a definite referent (`russellIota`) with vacuous intrinsic
+presupposition — definedness is its only presupposition. -/
+noncomputable def theOf (R : E → E → Prop) (possessor : E) : NominalDenot Ctx W E where
+  presup := fun _ _ => True
+  selector := fun _ _ => russellIota (E := E) (W := W) (fun y => R possessor y)
+
+/-- *NP's N*: re-select the possessor denotation through the possession relation
+`R`. -/
+noncomputable def applyTo (nd : NominalDenot Ctx W E) (R : E → E → Prop) : NominalDenot Ctx W E :=
+  nd >>= theOf R
+
+/-! ### Composition laws -/
+
+/-- The possessive's intrinsic presupposition **is** the possessor's — a
+possessor pronoun's φ-features ride along to the whole possessive. -/
+@[simp] theorem applyTo_presup (nd : NominalDenot Ctx W E) (R : E → E → Prop)
+    (c : Ctx) (w : W) : (applyTo nd R).presup c w = nd.presup c w := by
+  simp only [applyTo, theOf, NominalDenot.bind_presup]
+  cases nd.selector c w <;> simp
+
+/-- The possessive's selector binds the possessor through the iota of the
+relation: defined exactly when the possessor is defined and has a unique
+`R`-possessee. -/
+@[simp] theorem applyTo_selector (nd : NominalDenot Ctx W E) (R : E → E → Prop)
+    (c : Ctx) (w : W) :
+    (applyTo nd R).selector c w =
+      (nd.selector c w).bind (fun p => russellIota (E := E) (W := W) (fun y => R p y)) := by
+  simp only [applyTo, theOf, NominalDenot.bind_selector]
+
+/-- Nesting (*John's mother's friend*) — from `bind` associativity. -/
+theorem applyTo_applyTo (nd : NominalDenot Ctx W E) (R₁ R₂ : E → E → Prop) :
+    applyTo (applyTo nd R₁) R₂ = nd >>= fun p => applyTo (theOf R₁ p) R₂ := by
+  simp only [applyTo, NominalDenot.bind_assoc]
+
+/-! ### Definite carriers as nominal denotations -/
+
+/-- A definite possessive carrier as a `NominalDenot` over its situations: the
+selector is `russellIota` of the possessee predicate, always defined because the
+carrier bears the iota-presupposition (`HasIotaWitness`). -/
+noncomputable def Definite.toNominalDenot {S : Type} (d : Possessive.Definite E S) :
+    NominalDenot Ctx S E where
+  presup := fun _ _ => True
+  selector := fun _ s => russellIota (E := E) (W := S) (fun y => d.predicate y s)
+
+end Possessive

--- a/Linglib/Semantics/Possessive/GQ.lean
+++ b/Linglib/Semantics/Possessive/GQ.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.ArgumentStructure.Relational
+import Linglib.Semantics.Possessive.Basic
 
 /-!
 # Possessive Quantifiers
@@ -24,13 +24,13 @@ which keeps narrowing in the scope.
 - `possW_individual_existential_import`: "John's A B" entails John possesses
   an A-thing ([peters-westerstahl-2013])
 - `possessiveAsNPQ_iff_possW`: [barker-2011]'s type ⟨1⟩ possessive
-  (`Relational.possessiveAsNPQ`) is `PossW` of a Montagovian individual with
+  (`Possessive.asNPQ`) is `PossW` of a Montagovian individual with
   existential `Q₂`
 - `poss_not_quantityInvariant`: possessive GQs with a fixed `R` are not
   isomorphism-invariant (P&W p. 256)
 -/
 
-namespace Semantics.Quantification.Possessive
+namespace Possessive
 
 open Core.Quantification
 
@@ -167,7 +167,7 @@ theorem possW_individual_existential_import {Q₂ : GQ α} {R : α → α → Pr
 /-! ### Denoting a bundled carrier
 
 A possessive carrier bundling a possessor and a possession relation (any
-`HasPossessor` + `HasPossessionRelation` instance, e.g. `PossessiveSemantics`)
+`HasPossessor` + `HasPossessionRelation` instance, e.g. `Possessive.Carrier`)
 denotes, at a situation, as the `PossW` of its possessor taken whole. Routing
 every carrier through one operator is what makes the API unified: a carrier
 inherits narrowing and existential import with no bespoke proof. -/
@@ -193,15 +193,15 @@ theorem carrierGQ_existential_import {γ E S : Type*}
 /-! ### Bridge to Barker's type ⟨1⟩ possessive -/
 
 /-- [barker-2011]'s possessive NPQ (`⟦John's⟧ = fun P => ∃ y, R j y ∧ P y`,
-    `Relational.possessiveAsNPQ`) is `PossW` at a Montagovian individual with
+    `Possessive.asNPQ`) is `PossW` at a Montagovian individual with
     existential `Q₂` and trivial possessee restrictor — the possessee class is
     folded into `R` by Barker's π shift. -/
 theorem possessiveAsNPQ_iff_possW {E : Type*} (a : E) (R : E → E → Bool)
     (P : E → Prop) :
-    Semantics.ArgumentStructure.Relational.possessiveAsNPQ a R P ↔
+    Possessive.asNPQ a R P ↔
       PossW (individual a) some_sem (fun x y => R x y = true)
         (fun _ => True) P := by
-  unfold Semantics.ArgumentStructure.Relational.possessiveAsNPQ PossW dom
+  unfold Possessive.asNPQ PossW dom
     individual some_sem
   constructor
   · rintro ⟨y, hR, hP⟩
@@ -232,4 +232,4 @@ theorem poss_not_quantityInvariant :
   obtain ⟨x, ⟨-, b, hb, -, hb'⟩, -⟩ := hiff.mp hpos
   exact absurd (hb' ▸ hb) (by simp)
 
-end Semantics.Quantification.Possessive
+end Possessive

--- a/Linglib/Semantics/Possessive/PronounMixing.lean
+++ b/Linglib/Semantics/Possessive/PronounMixing.lean
@@ -1,0 +1,58 @@
+import Linglib.Semantics.Possessive.Denotation
+import Linglib.Semantics.Reference.PronounDenotation
+
+/-!
+# Possessive pronouns: where the possessive and pronoun APIs meet
+
+A possessive pronoun (*his book*, *mine*) is the possessive Kleisli arrow
+(`Possessive.applyTo` / `theOf`) applied to a possessor that is a **pronoun**
+denotation. Because both APIs trade in `NominalDenot` and possessive-of is
+`bind`, they compose with no glue:
+
+* the selector picks the **possessee** (the unique `R`-possessee of the pronoun's
+  referent), while
+* the intrinsic presupposition is the pronoun's **φ-features on the possessor**
+  (`g i`) — *not* on the possessee.
+
+That presup-on-possessor / selector-on-possessee split — what distinguishes a
+possessive pronoun from a plain pronoun — is exactly `Possessive.applyTo_presup`,
+i.e. *derived*, not stipulated.
+
+## Main statements
+
+* `possessivePronoun_presup` — *his N*'s presupposition is the possessor
+  pronoun's φ-presupposition (on `g i`).
+* `possessivePronoun_selector` — *his N*'s selector is the unique `R`-possessee
+  of the pronoun's referent.
+-/
+
+namespace Possessive
+
+open Semantics.Reference (NominalDenot)
+open Semantics.Definiteness (russellIota)
+open Core (Assignment)
+open Core.Logic.Intensional.Variables (interpPronoun)
+
+variable {E : Type} [PartialOrder E]
+
+/-- *his N*'s intrinsic presupposition is the possessor pronoun's φ-feature
+presupposition, imposed on the **possessor** `g i` — the φ-features ride along
+the possessive by `applyTo_presup`. -/
+theorem possessivePronoun_presup (p : PersonalPronoun) (i : ℕ)
+    (speaker addressee : E) (isFemale isInanimate : E → Prop) (R : E → E → Prop)
+    (g : Assignment E) (w : PUnit) :
+    (applyTo (p.denote i speaker addressee isFemale isInanimate) R).presup g w
+      = (p.phiPresup speaker addressee isFemale isInanimate).presup (g i) := by
+  simp only [applyTo_presup, PersonalPronoun.denote]
+
+/-- *his N*'s selector picks the unique `R`-possessee of the pronoun's
+referent — the possessee, not the possessor. -/
+theorem possessivePronoun_selector (p : PersonalPronoun) (i : ℕ)
+    (speaker addressee : E) (isFemale isInanimate : E → Prop) (R : E → E → Prop)
+    (g : Assignment E) (w : PUnit) :
+    (applyTo (p.denote i speaker addressee isFemale isInanimate) R).selector g w
+      = russellIota (E := E) (W := PUnit)
+          (fun y => R (interpPronoun (E := E) (W := PUnit) i g) y) := by
+  rw [applyTo_selector]; rfl
+
+end Possessive

--- a/Linglib/Semantics/Reference/Nominal.lean
+++ b/Linglib/Semantics/Reference/Nominal.lean
@@ -106,6 +106,66 @@ def toPartialProp (nd : NominalDenot Ctx W E) (scope : E → W → Prop)
   PartialProp.and { presup := nd.presup c, assertion := fun _ => True }
     (nd.resolve scope c)
 
+/-! ### Monad structure
+
+`NominalDenot Ctx W` is the presupposition-projecting partiality monad: `bind`
+threads the partial referent (`Option.bind`) and accumulates presuppositions,
+projecting the continuation's presupposition through definedness of the head
+(`Option.elim`). This is what lets a re-selection (e.g. possessive-of) compose
+as a Kleisli arrow while a head's intrinsic presupposition (φ-features, deixis)
+rides along. -/
+
+instance : Monad (NominalDenot Ctx W) where
+  pure a := { presup := fun _ _ => True, selector := fun _ _ => some a }
+  bind nd k :=
+    { presup := fun c w =>
+        nd.presup c w ∧ (nd.selector c w).elim True (fun e => (k e).presup c w)
+      selector := fun c w => (nd.selector c w).bind (fun e => (k e).selector c w) }
+
+/-- Extensionality: a `NominalDenot` is its presupposition and selector. -/
+@[ext] theorem ext {nd₁ nd₂ : NominalDenot Ctx W E}
+    (hp : nd₁.presup = nd₂.presup) (hs : nd₁.selector = nd₂.selector) : nd₁ = nd₂ := by
+  cases nd₁; cases nd₂; cases hp; cases hs; rfl
+
+universe u
+variable {α β γ : Type u}
+
+@[simp] theorem pure_selector (a : α) (c : Ctx) (w : W) :
+    (pure a : NominalDenot Ctx W α).selector c w = some a := rfl
+
+@[simp] theorem pure_presup (a : α) (c : Ctx) (w : W) :
+    (pure a : NominalDenot Ctx W α).presup c w = True := rfl
+
+@[simp] theorem bind_selector (nd : NominalDenot Ctx W α)
+    (k : α → NominalDenot Ctx W β) (c : Ctx) (w : W) :
+    (nd >>= k).selector c w = (nd.selector c w).bind (fun e => (k e).selector c w) := rfl
+
+@[simp] theorem bind_presup (nd : NominalDenot Ctx W α)
+    (k : α → NominalDenot Ctx W β) (c : Ctx) (w : W) :
+    (nd >>= k).presup c w =
+      (nd.presup c w ∧ (nd.selector c w).elim True (fun e => (k e).presup c w)) := rfl
+
+/-- Left identity: feeding a pure referent to a continuation is the continuation
+at that referent. -/
+theorem pure_bind (a : α) (k : α → NominalDenot Ctx W β) :
+    (pure a : NominalDenot Ctx W α) >>= k = k a := by
+  ext c w <;> simp
+
+/-- Right identity: re-selecting a denotation by `pure` is the identity. -/
+theorem bind_pure (nd : NominalDenot Ctx W α) : nd >>= pure = nd := by
+  ext c w <;>
+    simp only [bind_presup, bind_selector, pure_presup, pure_selector] <;>
+    cases nd.selector c w <;> simp
+
+/-- Associativity: nested binds compose — the law that makes possessive nesting
+(*John's mother's friend*) free. -/
+theorem bind_assoc (nd : NominalDenot Ctx W α) (k : α → NominalDenot Ctx W β)
+    (h : β → NominalDenot Ctx W γ) :
+    nd >>= k >>= h = nd >>= fun a => k a >>= h := by
+  ext c w <;>
+    simp only [bind_presup, bind_selector] <;>
+    cases nd.selector c w <;> simp [and_assoc]
+
 end NominalDenot
 
 end Semantics.Reference

--- a/Linglib/Studies/Barker1995.lean
+++ b/Linglib/Studies/Barker1995.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Quantification.Possessive
+import Linglib.Semantics.Possessive.GQ
 
 /-!
 # Barker 1995: *Possessive Descriptions*
@@ -10,13 +10,13 @@ the dissertation's signature claims, tested against concrete models:
   quantification to those possessors that stand in the possession relation to
   some possessee. *Most planets' rings are made of ice* is evaluated only over
   planets that have rings. The substrate operator
-  `Semantics.Quantification.Possessive.Poss` builds this in via the domain
+  `Possessive.Poss` builds this in via the domain
   restriction `dom A R`; here we exhibit a model where narrowing flips the truth
   value (demonstrated with `every`, since the `dom` restriction is independent of
   the choice of possessor quantifier; `most` is noncomputable cardinality).
 
 * **Definiteness and uniqueness**: a definite possessive denotes a unique
-  possessee. The `HasIotaWitness` capability of `DefinitePossessive` yields this
+  possessee. The `HasIotaWitness` capability of `Possessive.Definite` yields this
   via `existsUnique_possessee` with no bespoke proof — the payoff of the
   composable-mixin design.
 
@@ -37,7 +37,7 @@ the dissertation's signature claims, tested against concrete models:
 namespace Barker1995
 
 open Core.Quantification
-open Semantics.Quantification.Possessive
+open Possessive
 open Semantics.ArgumentStructure.Relational
 
 /-! ### Narrowing
@@ -89,7 +89,7 @@ sisters"), exercising the possessive-carrier capability mixins
 
 /-- "the boy's cat": possessor `0` (the boy), with a uniquely-identified cat
 `1`. Entities are `Fin 3` (boy, cat, dog); one situation. -/
-def theBoysCat : DefinitePossessive (Fin 3) Unit where
+def theBoysCat : Possessive.Definite (Fin 3) Unit where
   possessor := 0
   predicate := fun y _ => y = 1
   presupposition := fun _ => ⟨1, rfl, fun _ hy => hy⟩
@@ -103,13 +103,12 @@ theorem theBoysCat_unique (s : Unit) :
 /-- The sibling relation: `0`'s siblings are `1` and `2`. -/
 def sibling : Fin 3 → Fin 3 → Prop := fun x y => x = 0 ∧ (y = 1 ∨ y = 2)
 
-/-- "John's sisters": possessor `0` (John), with the (lexical) sibling relation
-as the possession relation. -/
-def johnsSisters : PossessiveSemantics (Fin 3) Unit where
+/-- "John's sisters": possessor `0` (John), with the sibling relation as the
+possession relation (a relational noun, so the restrictor is trivial). -/
+def johnsSisters : Possessive.Carrier (Fin 3) Unit where
   possessor := 0
-  possesseePred := fun y _ => sibling 0 y
   relation := fun x y _ => sibling x y
-  relationIsLexical := true
+  restrictor := fun _ _ => True
 
 /-- The relational possessive's `possesseeSet` is its lexical possession
 relation applied to the possessor — derived through the `HasPossessor` and
@@ -127,11 +126,10 @@ because planet 2 has no ring. Reuses the planets/rings model above. -/
 
 /-- "planet 2's rings": possessor `2`, with `hasRing` as the possession
 relation. -/
-def planet2sRings : PossessiveSemantics (Fin 5) Unit where
+def planet2sRings : Possessive.Carrier (Fin 5) Unit where
   possessor := 2
-  possesseePred := fun y _ => isRing y ∧ hasRing 2 y
   relation := fun x y _ => hasRing x y
-  relationIsLexical := true
+  restrictor := fun y _ => isRing y
 
 /-- *Planet 2's rings are icy* is false: via the unified carrier denotation,
 existential import (`carrierGQ_existential_import`) requires planet 2 to possess

--- a/Linglib/Studies/ParteeBorschev2001.lean
+++ b/Linglib/Studies/ParteeBorschev2001.lean
@@ -1,0 +1,151 @@
+import Linglib.Semantics.Possessive.Basic
+
+/-!
+# Partee & Borschev 2001: Some puzzles of predicate possessives
+
+Paper-anchored consumer of the possessive substrate for [partee-borschev-2001].
+P&B argue against the uniform "argument-only" analysis of possessives
+([jensen-vikner-1994]) using **predicate possessives**: a possessive occurs as a
+bare predicate (type ⟨e,t⟩) only when its possession relation is a free
+contextual variable (a *modifier* genitive), not when it is the inherent
+relation of a relational noun or adjective (an *argument* genitive).
+
+The argument/modifier distinction is **study-local**: it is P&B's analysis of a
+*construction*, contested by [vikner-jensen-2002] (who deny the split is
+grammatical), so it is not a field of the theory-neutral substrate carrier
+(`Possessive.Carrier`). The predicate form itself *is* substrate — the bare
+⟨e,t⟩ possessive predicate is `Possessive.viaArgument` (the relation applied to
+the possessor).
+
+## Main statements
+
+* `canBePredicate_iff_modifier` — predicativity is exactly modifier-provenance.
+* `team_predicate_ok` / `brother_predicate_bad` / `favoriteMovie_predicate_bad`
+  — P&B (1c)–(3c): *that team is John's* ✓, *#that brother/favorite movie is
+  John's* (decide-checked from the relation source).
+* `RussianForm.predicativity` — the morphosyntactically overt confirmation
+  (§2.2): the Russian genitive NP (argument) cannot predicate, the prenominal
+  possessive (modifier) can.
+* `predicateForm_eq_viaArgument` — the bare predicate possessive is the substrate
+  `Possessive.viaArgument` predicate.
+
+## References
+
+* [partee-borschev-2001]: Some puzzles of predicate possessives.
+* [jensen-vikner-1994]: the uniform argument-only analysis P&B argue against.
+-/
+
+namespace ParteeBorschev2001
+
+open Semantics.ArgumentStructure.Relational
+
+/-! ### Relation provenance and predicativity
+
+The argument/modifier distinction is P&B's analytical classification of a
+construction, kept study-local (V&J reject it). -/
+
+/-- The provenance of a genitive's possession relation: supplied lexically by a
+relational noun/adjective (*argument*) or as a free contextual variable
+(*modifier*). -/
+inductive RelationProvenance where
+  /-- Inherent/lexical relation — the argument genitive. -/
+  | argument
+  /-- Free contextual relation — the modifier genitive. -/
+  | modifier
+  deriving DecidableEq, Repr
+
+/-- A possessive occurs as a bare predicate (*that team is John's*) iff its
+relation is modifier-provenance. Argument genitives cannot — P&B's central
+generalization. -/
+def CanBePredicate : RelationProvenance → Prop
+  | .modifier => True
+  | .argument => False
+
+instance : DecidablePred CanBePredicate := fun p => by
+  cases p <;> unfold CanBePredicate <;> infer_instance
+
+/-- Predicativity is exactly modifier-provenance. Inverting the provenance flips
+the prediction, so the distinction is not decorative. -/
+theorem canBePredicate_iff_modifier (p : RelationProvenance) :
+    CanBePredicate p ↔ p = .modifier := by
+  cases p <;> simp [CanBePredicate]
+
+/-! ### English predicate possessives (P&B 2001 (1)–(3))
+
+The genitive relation has three sources: the context (a free `R`, with a plain
+noun), an inherently relational noun (*brother*), or an inherently relational
+adjective (*favorite*). Only the contextual source is a modifier. -/
+
+/-- The three sources of the genitive relation (P&B 2001 §1.1). -/
+inductive RelationSource where
+  /-- Free contextual relation (plain noun, e.g. *team*). -/
+  | context
+  /-- Inherent relation of a relational noun (*brother*). -/
+  | relationalNoun
+  /-- Inherent relation of a relational adjective (*favorite*). -/
+  | relationalAdjective
+  deriving DecidableEq, Repr
+
+/-- Only the contextual source yields a modifier genitive; the two inherent
+sources yield argument genitives. -/
+def RelationSource.provenance : RelationSource → RelationProvenance
+  | .context => .modifier
+  | .relationalNoun => .argument
+  | .relationalAdjective => .argument
+
+/-- P&B (1c) *that team is John's* — acceptable: contextual relation (modifier). -/
+theorem team_predicate_ok :
+    CanBePredicate RelationSource.context.provenance := by decide
+
+/-- P&B (2c) *#that brother is John's* — degraded: relational noun (argument). -/
+theorem brother_predicate_bad :
+    ¬ CanBePredicate RelationSource.relationalNoun.provenance := by decide
+
+/-- P&B (3c) *#that favorite movie is John's* — degraded: relational adjective
+(argument). The whole N-bar *favorite movie* supplies the relation. -/
+theorem favoriteMovie_predicate_bad :
+    ¬ CanBePredicate RelationSource.relationalAdjective.provenance := by decide
+
+/-! ### Russian: overt morphosyntax (P&B 2001 §2.2)
+
+In Russian the distinction is visible in the form: the genitive NP (*Peti*) is
+uniformly argument-like and cannot occur in predicate position, while the
+prenominal quasi-adjectival possessive (*Petin*) and possessive pronouns admit
+the modifier reading and can. -/
+
+/-- Russian possessive forms and their relation provenance (P&B 2001 §2.2). -/
+inductive RussianForm where
+  /-- Postnominal genitive NP, *Peti* — uniformly argument. -/
+  | genitiveNP
+  /-- Prenominal quasi-adjectival possessive, *Petin* — admits modifier. -/
+  | prenominalPossessive
+  /-- Possessive pronoun, *moj* — admits modifier. -/
+  | possessivePronoun
+  deriving DecidableEq, Repr
+
+/-- Provenance of each Russian form. -/
+def RussianForm.provenance : RussianForm → RelationProvenance
+  | .genitiveNP => .argument
+  | .prenominalPossessive => .modifier
+  | .possessivePronoun => .modifier
+
+/-- The overt confirmation: a Russian form occurs as a predicate iff it is not
+the (argument-only) genitive NP. -/
+theorem RussianForm.predicativity (f : RussianForm) :
+    CanBePredicate f.provenance ↔ f ≠ .genitiveNP := by
+  cases f <;> decide
+
+/-! ### The predicate form is substrate
+
+The bare predicate possessive *John's* (`λx. R(John)(x)`) is the substrate
+`Possessive.viaArgument` — the relation applied to the possessor, a genuine
+⟨e,t⟩ predicate that the uniform argument-only approach cannot produce
+standalone. -/
+
+variable {E S : Type*}
+
+theorem predicateForm_eq_viaArgument (possessor : E) (R : Pred2 E S) :
+    (fun x s => R possessor x s) = Possessive.viaArgument possessor R :=
+  rfl
+
+end ParteeBorschev2001

--- a/Linglib/Studies/ParteeBorschev2003.lean
+++ b/Linglib/Studies/ParteeBorschev2003.lean
@@ -1,0 +1,128 @@
+import Linglib.Semantics.Possessive.Basic
+
+/-!
+# Partee & Borschev 2003: Genitives, relational nouns, and argument-modifier ambiguity
+
+Paper-anchored consumer of the relational/possessive substrate for
+[partee-borschev-2003]. P&B defend a **split** analysis of the genitive against
+the **uniform "argument-only"** analysis of [vikner-jensen-2002] (J&V): some
+genitives are *arguments* of a relational noun, others are *modifiers* carrying
+a free contextual relation. The two construction types map exactly onto the
+substrate:
+
+* **argument genitive** (relational head noun supplies R): `of John's = λR[R(John)]`,
+  `teacher of John's = λx[teacher(John)(x)]` — this is `viaArgument`.
+* **modifier genitive** (sortal head noun + free relation `Rᵢ`):
+  `of John's = λPλx[P(x) ∧ Rᵢ(John)(x)]`, `team of John's = λx[team(x) ∧ Rᵢ(John)(x)]`
+  — this is `viaModifier` (Barker's `π`).
+
+## Main statements
+
+* `vj_coerce_eq_pb_modifier` — **convergence** (P&B §4.3): for a pragmatically
+  coerced sortal noun, J&V's "coerce to a relation, then take as argument" and
+  P&B's modifier genitive yield the *same* predicate. The accounts differ only
+  in *where* the free relation enters, not in truth conditions — `rfl`.
+* `FormerMansion.readingA_ne_readingB` — **divergence** (P&B §4.3, *Mary's former
+  mansion*): under the modifier *former*, putting the free relation inside vs.
+  outside its scope gives different predicates. J&V's coercion derives both;
+  P&B's split derives only the R-outside reading — J&V's empirical advantage.
+* `predicateGenitive_eq` — P&B §5.1: the predicate genitive *John's* (*that team
+  is John's*) is a bare ⟨e,t⟩ predicate `λx[Rᵢ(John)(x)]` = `viaArgument`,
+  which the uniform argument-only approach cannot produce standalone.
+
+## References
+
+* [partee-borschev-2003]: Genitives, relational nouns, and argument-modifier
+  ambiguity.
+* [vikner-jensen-2002]: the uniform "argument-only" analysis P&B argue against.
+-/
+
+namespace ParteeBorschev2003
+
+open Semantics.ArgumentStructure.Relational
+open Possessive
+
+variable {E S : Type*}
+
+/-! ### The two approaches converge on coerced sortals (P&B §4.3)
+
+For *team of Mary's* both accounts derive `λx[team(x) ∧ Rᵢ(Mary)(x)]`. J&V coerce
+*team* to the relation `π team Rᵢ` and apply the argument genitive; P&B apply the
+modifier genitive directly. The free relation enters inside the coerced noun for
+J&V, with the construction for P&B — but the result is identical. -/
+
+/-- **Convergence** (P&B §4.3): J&V's coerce-then-argument equals P&B's modifier
+genitive. The "two theories of genitives" are, on the coerced-sortal case, a
+single denotation reached two ways. -/
+theorem vj_coerce_eq_pb_modifier (possessor : E) (P : Pred1 E S) (R : Pred2 E S) :
+    viaArgument possessor (π P R) = viaModifier possessor P R :=
+  rfl
+
+/-! ### The predicate genitive (P&B §5.1)
+
+*That team is John's*: the genitive surfaces as a bare one-place predicate with a
+free relation, `λx[Rᵢ(John)(x)]`. P&B argue this is not always reducible to an
+elliptical argument NP, so English needs the modifier genitive — a problem for
+the uniform argument-only approach. -/
+
+/-- The predicate genitive *John's* is the possessee predicate `λx[R possessor x]`
+= `viaArgument possessor R`, a genuine ⟨e,t⟩ predicate (here `Pred1`). -/
+theorem predicateGenitive_eq (possessor : E) (R : Pred2 E S) :
+    (fun x s => R possessor x s) = viaArgument possessor R :=
+  rfl
+
+/-! ### The readings of *Mary's former mansion* (P&B §4.3)
+
+`former` (CN/CN) modifies the noun predicate; `formerRel` (TCN/TCN) modifies a
+relation. With the free relation `R` *outside* `former` (Reading A) vs. *inside*
+`formerRel`'s scope (Reading B), the genitive denotes differently. P&B's split
+introduces `R` only with the construction, after `former`, deriving Reading A
+alone; J&V's coercion can introduce `R` at the noun-shift, deriving both. -/
+
+/-- Reading A: the free relation is outside `former`'s scope — *a former mansion
+that is now Mary's*. The only reading P&B's split derives. -/
+def readingA (former : Pred1 E S → Pred1 E S) (possessor : E)
+    (noun : Pred1 E S) (R : Pred2 E S) : Pred1 E S :=
+  viaModifier possessor (former noun) R
+
+/-- Reading B: the free relation is inside `formerRel`'s scope — *something that
+was formerly Mary's mansion*. Available on J&V's coercion. -/
+def readingB (formerRel : Pred2 E S → Pred2 E S) (possessor : E)
+    (noun : Pred1 E S) (R : Pred2 E S) : Pred1 E S :=
+  viaArgument possessor (formerRel (π noun R))
+
+namespace FormerMansion
+
+/-- Entities: building `0`, Mary `1`. -/
+abbrev Ent := Fin 2
+/-- Time: `true` now, `false` past. -/
+abbrev Tm := Bool
+
+/-- The building `0` is a mansion at every time. -/
+def mansion : Pred1 Ent Tm := fun x _ => x = 0
+/-- Mary (`1`) owned the building (`0`) only in the past. -/
+def owns : Pred2 Ent Tm := fun o x t => o = 1 ∧ x = 0 ∧ t = false
+/-- *former* P: was P in the past, no longer P now. -/
+def former (P : Pred1 Ent Tm) : Pred1 Ent Tm := fun x t => P x false ∧ ¬ P x t
+/-- *former* on a relation: held in the past, no longer. -/
+def formerRel (Rel : Pred2 Ent Tm) : Pred2 Ent Tm :=
+  fun o x t => Rel o x false ∧ ¬ Rel o x t
+
+/-- **Divergence**: the locus of the free relation is detectable under *former*.
+The building is still a mansion now but Mary no longer owns it, so Reading B
+(*was Mary's mansion*) holds of it while Reading A (*a former mansion now
+Mary's*) does not. P&B's split derives only Reading A; J&V's coercion derives
+both — J&V's empirical advantage (P&B §4.3). -/
+theorem readingA_ne_readingB :
+    readingA former 1 mansion owns ≠ readingB formerRel 1 mansion owns := by
+  intro h
+  have hA : ¬ readingA former 1 mansion owns 0 true := by
+    unfold readingA viaModifier π former mansion owns; decide
+  have hB : readingB formerRel 1 mansion owns 0 true := by
+    unfold readingB viaArgument formerRel π mansion owns; decide
+  rw [h] at hA
+  exact hA hB
+
+end FormerMansion
+
+end ParteeBorschev2003

--- a/Linglib/Studies/ViknerJensen2002.lean
+++ b/Linglib/Studies/ViknerJensen2002.lean
@@ -1,0 +1,161 @@
+import Linglib.Semantics.Possessive.Basic
+
+/-!
+# Vikner & Jensen 2002: A semantic analysis of the English genitive
+
+Paper-anchored consumer of the relational/possessive substrate for
+[vikner-jensen-2002]. V&J give the prenominal genitive a single syntactic type
+(it always combines with a *relational* noun); a non-relational head noun is
+coerced to relational, with the genitive relation *derived* from the noun's
+Pustejovsky qualia rather than stipulated.
+
+* **Four lexical relation types** (§3.1.2): inherent, part-whole, agentive,
+  control. These *are* the project's `PossessionRelationType` — V&J is the
+  source of that taxonomy (cited in `Semantics/Possessive/Basic.lean`), and
+  this study is its first consumer.
+* **Qualia derivation** (§3.2.3): the relation type follows from lexical
+  structure — inherent from relationality, part-whole from the constitutive
+  quale, agentive from the agentive quale; control is always available. So the
+  three-way ambiguity of *the girl's picture* is derived, not listed.
+* **The denotation** (§3.2.3, (20)–(21)): the genitive is the possessor plus a
+  narrow-scope definite — the unique entity standing in the resolved relation to
+  the possessor. The relation combines with the noun via Barker's `π`
+  (`viaArgument` for a relational noun, `viaModifier` for a coerced
+  sortal noun); uniqueness is `iotaPresupposition`, and a worked entry feeds the
+  `Possessive.Definite` carrier's `existsUnique_possessee`.
+
+## Main statements
+
+* `control_always`, `picture_three_ways`, `nose_partWhole`, … — the
+  qualia-derivation predictions (decide-checked).
+* `girlsTeacher_existsUnique` — V&J's inherent genitive as a carrier-API
+  definite (unique referent via `existsUnique_possessee`).
+* `girlsCar_eq_sortal` — V&J's coerced (control) genitive as `viaModifier`.
+
+## References
+
+* [vikner-jensen-2002]: A semantic analysis of the English genitive.
+-/
+
+namespace ViknerJensen2002
+
+open Semantics.ArgumentStructure.Relational
+open Possessive
+
+/-! ### Qualia structure (Pustejovsky, as used by V&J §3.2.1) -/
+
+/-- The relation-bearing qualia V&J read off a head noun. The telic and formal
+qualia do not contribute a genitive relation type in V&J's four-way taxonomy, so
+they are omitted. -/
+structure NounQualia where
+  /-- Inherently relational (e.g. *sister*, *teacher*) — bears its own relatum. -/
+  isRelational : Bool
+  /-- Bears a constitutive quale (*nose*: part-of a body). -/
+  hasConstitutive : Bool
+  /-- Bears an agentive quale (*poem*: composed by someone). -/
+  hasAgentive : Bool
+  deriving DecidableEq, Repr
+
+/-! ### Deriving the relation type from qualia (V&J §3.2.3) -/
+
+/-- V&J's central thesis: the genitive's relation type is *derived* from the head
+noun's lexical structure, not stipulated. A noun licenses the inherent relation
+iff it is relational, the part-whole relation iff it bears a constitutive quale,
+the agentive relation iff it bears an agentive quale; the control relation is
+always available (the default, independent of qualia, §3.1.2). The codomain is
+the project's `PossessionRelationType` — V&J is the source of that taxonomy. -/
+def availableRelations (q : NounQualia) : List PossessionRelationType :=
+  (if q.isRelational then [PossessionRelationType.inherent] else []) ++
+  (if q.hasConstitutive then [PossessionRelationType.partWhole] else []) ++
+  (if q.hasAgentive then [PossessionRelationType.agentive] else []) ++
+  [PossessionRelationType.control]
+
+/-- Control is available whatever the noun's qualia (V&J §3.1.2: it is always
+available, ownership being only one special case of control). -/
+theorem control_always (q : NounQualia) :
+    PossessionRelationType.control ∈ availableRelations q := by
+  simp [availableRelations]
+
+/-! ### Lexical entries (V&J (9), §3.1.2) -/
+
+/-- *sister* — inherently relational. -/
+def sister : NounQualia := ⟨true, false, false⟩
+/-- *nose* — constitutive quale (part-of a body). -/
+def nose : NounQualia := ⟨false, true, false⟩
+/-- *poem* — agentive quale (composed). -/
+def poem : NounQualia := ⟨false, false, true⟩
+/-- *car* — agentive quale (constructed); the salient reading is control. -/
+def car : NounQualia := ⟨false, false, true⟩
+/-- *picture* — relational (*picture of*) and agentive (*picture made by*). -/
+def picture : NounQualia := ⟨true, false, true⟩
+
+/-- *the girl's sister*: inherent relation, plus the ever-present control. -/
+theorem sister_inherent :
+    availableRelations sister = [.inherent, .control] := by decide
+
+/-- *the girl's nose*: part-whole, via the constitutive quale (no inherent or
+agentive reading). -/
+theorem nose_partWhole :
+    availableRelations nose = [.partWhole, .control] := by decide
+
+/-- *the girl's poem*: agentive, via the agentive quale. -/
+theorem poem_agentive :
+    availableRelations poem = [.agentive, .control] := by decide
+
+/-- *the girl's picture* is three ways ambiguous (V&J §3.1.2): inherent
+(*picture of the girl*), agentive (*picture the girl made*), and control
+(*picture at her disposal*) — but **not** part-whole. -/
+theorem picture_three_ways :
+    availableRelations picture = [.inherent, .agentive, .control] := by decide
+
+/-- The qualia derivation distinguishes the readings: *picture* is three-way
+ambiguous, *nose* only two-way. -/
+theorem picture_more_ambiguous_than_nose :
+    (availableRelations picture).length = 3 ∧ (availableRelations nose).length = 2 := by
+  decide
+
+/-! ### The denotation: possessor + narrow-scope definite (V&J §3.2.3)
+
+Model over `Fin 4` (girl `0`, her teacher `1`, her car `2`, an unrelated `3`),
+single situation. The genitive picks the unique entity standing in the resolved
+relation to the possessor. -/
+
+/-- The (inherent) teacher relation: `0`'s teacher is `1`. -/
+def teacherRel : Pred2 (Fin 4) Unit := fun x y _ => x = 0 ∧ y = 1
+
+/-- *the girl's teacher* (inherent, V&J (21)): the possessee predicate is the
+relation applied to the possessor (`viaArgument`), and there is a unique
+satisfier — V&J's narrow-scope definite, here as `iotaPresupposition`. -/
+theorem girlsTeacher_unique (s : Unit) :
+    iotaPresupposition (viaArgument (E := Fin 4) 0 teacherRel) s := by
+  refine ⟨1, ⟨rfl, rfl⟩, ?_⟩
+  rintro y ⟨-, hy⟩
+  exact hy
+
+/-- *the girl's teacher* as a `Possessive.Definite` carrier: its unique referent
+is delivered by the carrier API's `existsUnique_possessee`, no bespoke proof. -/
+def theGirlsTeacher : Possessive.Definite (Fin 4) Unit where
+  possessor := 0
+  predicate := viaArgument 0 teacherRel
+  presupposition := girlsTeacher_unique
+
+theorem girlsTeacher_existsUnique (s : Unit) :
+    ∃! y : Fin 4, HasPossesseePredicate.possesseePredicate theGirlsTeacher y s :=
+  existsUnique_possessee theGirlsTeacher s
+
+/-- The control relation: the girl `0` controls the car `2`. -/
+def controlRel : Pred2 (Fin 4) Unit := fun x y _ => x = 0 ∧ y = 2
+
+/-- *car* as a sortal noun predicate. -/
+def carPred : Pred1 (Fin 4) Unit := fun y _ => y = 2
+
+/-- *the girl's car* (coerced, control): the sortal noun is shifted to a relation
+via Barker's `π` (`viaModifier`), and the result selects the controlled car.
+This is V&J's coercion of a non-relational head noun. -/
+theorem girlsCar_eq_sortal (y : Fin 4) :
+    viaModifier (E := Fin 4) 0 carPred controlRel y () ↔ y = 2 := by
+  constructor
+  · rintro ⟨hcar, -, -⟩; exact hcar
+  · rintro rfl; exact ⟨rfl, rfl, rfl⟩
+
+end ViknerJensen2002

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -2981,6 +2981,34 @@
   role      = {cited},
   sources   = {Phenomena/Presupposition/ProjectiveContent.lean;Pragmatics/Implicature/ConventionalImplicatures.lean;Phenomena/Expressives/Studies/LoGuercio2025.lean}
 }
+@incollection{partee-borschev-2001,
+  author    = {Partee, Barbara H. and Borschev, Vladimir},
+  year      = {2001},
+  title     = {Some Puzzles of Predicate Possessives},
+  booktitle = {Perspectives on Semantics, Pragmatics and Discourse: A Festschrift for Ferenc Kiefer},
+  editor    = {Kenesei, Istv{\'a}n and Harnish, Robert M.},
+  pages     = {91--117},
+  publisher = {John Benjamins},
+  address   = {Amsterdam},
+  subfield  = {semantics/lexical},
+  role      = {formalized},
+  sources   = {Studies/ParteeBorschev2001.lean}
+}
+
+@incollection{jensen-vikner-1994,
+  author    = {Jensen, Per Anker and Vikner, Carl},
+  year      = {1994},
+  title     = {Lexical Knowledge and the Semantic Analysis of Danish Genitive Constructions},
+  booktitle = {Topics in Knowledge-based NLP Systems},
+  editor    = {Hansen, Steffen Leo and Wegener, Heinz},
+  pages     = {37--55},
+  publisher = {Samfundslitteratur},
+  address   = {Copenhagen},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  sources   = {Studies/ParteeBorschev2001.lean}
+}
+
 @book{peters-westerstahl-2006,
   author    = {Peters, Stanley and Westerst\r{a}hl, Dag},
   year      = {2006},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -3009,6 +3009,20 @@
   sources   = {Studies/ParteeBorschev2001.lean}
 }
 
+@article{vikner-jensen-2002,
+  author  = {Vikner, Carl and Jensen, Per Anker},
+  year    = {2002},
+  title   = {A Semantic Analysis of the English Genitive: Interaction of Lexical and Formal Semantics},
+  journal = {Studia Linguistica},
+  volume  = {56},
+  number  = {2},
+  pages   = {191--226},
+  doi     = {10.1111/1467-9582.00092},
+  subfield = {semantics/lexical},
+  role    = {formalized},
+  sources = {Studies/ViknerJensen2002.lean;Semantics/Possessive/Basic.lean}
+}
+
 @book{peters-westerstahl-2006,
   author    = {Peters, Stanley and Westerst\r{a}hl, Dag},
   year      = {2006},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -2981,6 +2981,7 @@
   role      = {cited},
   sources   = {Phenomena/Presupposition/ProjectiveContent.lean;Pragmatics/Implicature/ConventionalImplicatures.lean;Phenomena/Expressives/Studies/LoGuercio2025.lean}
 }
+<<<<<<< HEAD
 @incollection{partee-borschev-2001,
   author    = {Partee, Barbara H. and Borschev, Vladimir},
   year      = {2001},
@@ -3007,6 +3008,20 @@
   subfield  = {semantics/lexical},
   role      = {cited},
   sources   = {Studies/ParteeBorschev2001.lean}
+}
+
+@incollection{partee-borschev-2003,
+  author    = {Partee, Barbara H. and Borschev, Vladimir},
+  year      = {2003},
+  title     = {Genitives, Relational Nouns, and Argument-Modifier Ambiguity},
+  booktitle = {Modifying Adjuncts},
+  editor    = {Lang, Ewald and Maienborn, Claudia and Fabricius-Hansen, Cathrine},
+  series    = {Interface Explorations},
+  publisher = {Mouton de Gruyter},
+  address   = {Berlin},
+  subfield  = {semantics/lexical},
+  role      = {formalized},
+  sources   = {Studies/ParteeBorschev2003.lean}
 }
 
 @article{vikner-jensen-2002,


### PR DESCRIPTION
Unify the possessive denotation surface under one root `Possessive` namespace (new `Semantics/Possessive/`): carriers (`Carrier` slimmed — possessee predicate derived, not stored; provenance `Bool` flag dropped), the renamed combination ops (`viaArgument`/`viaModifier`), the capability mixins (root), and the GQ/narrowing layer (`Poss`/`PossW`/`carrierGQ`, moved from `Quantification/Possessive`). `ArgumentStructure/Relational` keeps the theory-neutral relational-noun substrate (π, Ex, bridging, demonstratives). Adds `Studies/ParteeBorschev2001` with the argument/modifier provenance kept study-local (V&J contest it).

Depends on rebasing #370 and #371 onto the new namespaces.