### PR TITLE
feat(Semantics): NominalDenot monad and possessive-of Kleisli arrow

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2245,7 +2245,9 @@ import Linglib.Semantics.Quantification.Syllogistic.Square
 import Linglib.Semantics.Quantification.Lexicon
 import Linglib.Semantics.Quantification.Exceptive
 import Linglib.Semantics.Possessive.Basic
+import Linglib.Semantics.Possessive.Denotation
 import Linglib.Semantics.Possessive.GQ
+import Linglib.Semantics.Possessive.PronounMixing
 import Linglib.Semantics.Quantification.UnifiedUniversal
 import Linglib.Semantics.Quantification.ONEModifiers
 import Linglib.Semantics.Quantification.ChoiceFunction

--- a/Linglib/Semantics/Possessive/Denotation.lean
+++ b/Linglib/Semantics/Possessive/Denotation.lean
@@ -1,0 +1,89 @@
+import Linglib.Semantics.Reference.Nominal
+import Linglib.Semantics.Definiteness.Maximality
+import Linglib.Semantics.Possessive.Basic
+
+/-!
+# Possessive-of as a Kleisli arrow
+
+The possessive denotation in the unified referential currency `NominalDenot`
+(`Semantics/Reference/Nominal.lean`), which is a monad. *NP's N* is **Kleisli
+`bind`** into the definite possessee of the possessor: re-point the possessor
+denotation's selector through the possession relation (`russellIota` of the
+relation), inheriting the possessor's intrinsic presupposition. So:
+
+* possessive **nesting** (*John's mother's friend*) is `bind` associativity;
+* the possessor's φ-features (when it is a pronoun) **ride along** to the whole
+  possessive, by `applyTo_presup`;
+* the existence/uniqueness presupposition is **selector definedness**
+  (`russellIota_isSome_iff_existsUnique`), not a separate intrinsic presup.
+
+## Main declarations
+
+* `Possessive.theOf R` — the Kleisli arrow: the unique `R`-possessee of a
+  possessor, as a `NominalDenot`.
+* `Possessive.applyTo nd R = nd >>= theOf R` — *NP's N*.
+* `Possessive.Definite.toNominalDenot` — a definite carrier as a `NominalDenot`
+  (always-defined selector, from `HasIotaWitness`).
+
+## Main statements
+
+* `applyTo_presup` — the possessive's presupposition *is* the possessor's.
+* `applyTo_selector` — the selector binds through the iota of the relation.
+* `applyTo_applyTo` — nesting, from `bind_assoc`.
+-/
+
+namespace Possessive
+
+open Semantics.Reference (NominalDenot)
+open Semantics.Definiteness (russellIota russellIota_isSome_iff_existsUnique existsUnique)
+
+variable {Ctx : Type*} {W E : Type}
+
+/-! ### The Kleisli arrow -/
+
+/-- The unique entity the `possessor` stands in relation `R` to, as a
+`NominalDenot`: a definite referent (`russellIota`) with vacuous intrinsic
+presupposition — definedness is its only presupposition. -/
+noncomputable def theOf (R : E → E → Prop) (possessor : E) : NominalDenot Ctx W E where
+  presup := fun _ _ => True
+  selector := fun _ _ => russellIota (E := E) (W := W) (fun y => R possessor y)
+
+/-- *NP's N*: re-select the possessor denotation through the possession relation
+`R`. -/
+noncomputable def applyTo (nd : NominalDenot Ctx W E) (R : E → E → Prop) : NominalDenot Ctx W E :=
+  nd >>= theOf R
+
+/-! ### Composition laws -/
+
+/-- The possessive's intrinsic presupposition **is** the possessor's — a
+possessor pronoun's φ-features ride along to the whole possessive. -/
+@[simp] theorem applyTo_presup (nd : NominalDenot Ctx W E) (R : E → E → Prop)
+    (c : Ctx) (w : W) : (applyTo nd R).presup c w = nd.presup c w := by
+  simp only [applyTo, theOf, NominalDenot.bind_presup]
+  cases nd.selector c w <;> simp
+
+/-- The possessive's selector binds the possessor through the iota of the
+relation: defined exactly when the possessor is defined and has a unique
+`R`-possessee. -/
+@[simp] theorem applyTo_selector (nd : NominalDenot Ctx W E) (R : E → E → Prop)
+    (c : Ctx) (w : W) :
+    (applyTo nd R).selector c w =
+      (nd.selector c w).bind (fun p => russellIota (E := E) (W := W) (fun y => R p y)) := by
+  simp only [applyTo, theOf, NominalDenot.bind_selector]
+
+/-- Nesting (*John's mother's friend*) — from `bind` associativity. -/
+theorem applyTo_applyTo (nd : NominalDenot Ctx W E) (R₁ R₂ : E → E → Prop) :
+    applyTo (applyTo nd R₁) R₂ = nd >>= fun p => applyTo (theOf R₁ p) R₂ := by
+  simp only [applyTo, NominalDenot.bind_assoc]
+
+/-! ### Definite carriers as nominal denotations -/
+
+/-- A definite possessive carrier as a `NominalDenot` over its situations: the
+selector is `russellIota` of the possessee predicate, always defined because the
+carrier bears the iota-presupposition (`HasIotaWitness`). -/
+noncomputable def Definite.toNominalDenot {S : Type} (d : Possessive.Definite E S) :
+    NominalDenot Ctx S E where
+  presup := fun _ _ => True
+  selector := fun _ s => russellIota (E := E) (W := S) (fun y => d.predicate y s)
+
+end Possessive

--- a/Linglib/Semantics/Possessive/PronounMixing.lean
+++ b/Linglib/Semantics/Possessive/PronounMixing.lean
@@ -1,0 +1,58 @@
+import Linglib.Semantics.Possessive.Denotation
+import Linglib.Semantics.Reference.PronounDenotation
+
+/-!
+# Possessive pronouns: where the possessive and pronoun APIs meet
+
+A possessive pronoun (*his book*, *mine*) is the possessive Kleisli arrow
+(`Possessive.applyTo` / `theOf`) applied to a possessor that is a **pronoun**
+denotation. Because both APIs trade in `NominalDenot` and possessive-of is
+`bind`, they compose with no glue:
+
+* the selector picks the **possessee** (the unique `R`-possessee of the pronoun's
+  referent), while
+* the intrinsic presupposition is the pronoun's **φ-features on the possessor**
+  (`g i`) — *not* on the possessee.
+
+That presup-on-possessor / selector-on-possessee split — what distinguishes a
+possessive pronoun from a plain pronoun — is exactly `Possessive.applyTo_presup`,
+i.e. *derived*, not stipulated.
+
+## Main statements
+
+* `possessivePronoun_presup` — *his N*'s presupposition is the possessor
+  pronoun's φ-presupposition (on `g i`).
+* `possessivePronoun_selector` — *his N*'s selector is the unique `R`-possessee
+  of the pronoun's referent.
+-/
+
+namespace Possessive
+
+open Semantics.Reference (NominalDenot)
+open Semantics.Definiteness (russellIota)
+open Core (Assignment)
+open Core.Logic.Intensional.Variables (interpPronoun)
+
+variable {E : Type} [PartialOrder E]
+
+/-- *his N*'s intrinsic presupposition is the possessor pronoun's φ-feature
+presupposition, imposed on the **possessor** `g i` — the φ-features ride along
+the possessive by `applyTo_presup`. -/
+theorem possessivePronoun_presup (p : PersonalPronoun) (i : ℕ)
+    (speaker addressee : E) (isFemale isInanimate : E → Prop) (R : E → E → Prop)
+    (g : Assignment E) (w : PUnit) :
+    (applyTo (p.denote i speaker addressee isFemale isInanimate) R).presup g w
+      = (p.phiPresup speaker addressee isFemale isInanimate).presup (g i) := by
+  simp only [applyTo_presup, PersonalPronoun.denote]
+
+/-- *his N*'s selector picks the unique `R`-possessee of the pronoun's
+referent — the possessee, not the possessor. -/
+theorem possessivePronoun_selector (p : PersonalPronoun) (i : ℕ)
+    (speaker addressee : E) (isFemale isInanimate : E → Prop) (R : E → E → Prop)
+    (g : Assignment E) (w : PUnit) :
+    (applyTo (p.denote i speaker addressee isFemale isInanimate) R).selector g w
+      = russellIota (E := E) (W := PUnit)
+          (fun y => R (interpPronoun (E := E) (W := PUnit) i g) y) := by
+  rw [applyTo_selector]; rfl
+
+end Possessive

--- a/Linglib/Semantics/Reference/Nominal.lean
+++ b/Linglib/Semantics/Reference/Nominal.lean
@@ -106,6 +106,66 @@ def toPartialProp (nd : NominalDenot Ctx W E) (scope : E → W → Prop)
   PartialProp.and { presup := nd.presup c, assertion := fun _ => True }
     (nd.resolve scope c)
 
+/-! ### Monad structure
+
+`NominalDenot Ctx W` is the presupposition-projecting partiality monad: `bind`
+threads the partial referent (`Option.bind`) and accumulates presuppositions,
+projecting the continuation's presupposition through definedness of the head
+(`Option.elim`). This is what lets a re-selection (e.g. possessive-of) compose
+as a Kleisli arrow while a head's intrinsic presupposition (φ-features, deixis)
+rides along. -/
+
+instance : Monad (NominalDenot Ctx W) where
+  pure a := { presup := fun _ _ => True, selector := fun _ _ => some a }
+  bind nd k :=
+    { presup := fun c w =>
+        nd.presup c w ∧ (nd.selector c w).elim True (fun e => (k e).presup c w)
+      selector := fun c w => (nd.selector c w).bind (fun e => (k e).selector c w) }
+
+/-- Extensionality: a `NominalDenot` is its presupposition and selector. -/
+@[ext] theorem ext {nd₁ nd₂ : NominalDenot Ctx W E}
+    (hp : nd₁.presup = nd₂.presup) (hs : nd₁.selector = nd₂.selector) : nd₁ = nd₂ := by
+  cases nd₁; cases nd₂; cases hp; cases hs; rfl
+
+universe u
+variable {α β γ : Type u}
+
+@[simp] theorem pure_selector (a : α) (c : Ctx) (w : W) :
+    (pure a : NominalDenot Ctx W α).selector c w = some a := rfl
+
+@[simp] theorem pure_presup (a : α) (c : Ctx) (w : W) :
+    (pure a : NominalDenot Ctx W α).presup c w = True := rfl
+
+@[simp] theorem bind_selector (nd : NominalDenot Ctx W α)
+    (k : α → NominalDenot Ctx W β) (c : Ctx) (w : W) :
+    (nd >>= k).selector c w = (nd.selector c w).bind (fun e => (k e).selector c w) := rfl
+
+@[simp] theorem bind_presup (nd : NominalDenot Ctx W α)
+    (k : α → NominalDenot Ctx W β) (c : Ctx) (w : W) :
+    (nd >>= k).presup c w =
+      (nd.presup c w ∧ (nd.selector c w).elim True (fun e => (k e).presup c w)) := rfl
+
+/-- Left identity: feeding a pure referent to a continuation is the continuation
+at that referent. -/
+theorem pure_bind (a : α) (k : α → NominalDenot Ctx W β) :
+    (pure a : NominalDenot Ctx W α) >>= k = k a := by
+  ext c w <;> simp
+
+/-- Right identity: re-selecting a denotation by `pure` is the identity. -/
+theorem bind_pure (nd : NominalDenot Ctx W α) : nd >>= pure = nd := by
+  ext c w <;>
+    simp only [bind_presup, bind_selector, pure_presup, pure_selector] <;>
+    cases nd.selector c w <;> simp
+
+/-- Associativity: nested binds compose — the law that makes possessive nesting
+(*John's mother's friend*) free. -/
+theorem bind_assoc (nd : NominalDenot Ctx W α) (k : α → NominalDenot Ctx W β)
+    (h : β → NominalDenot Ctx W γ) :
+    nd >>= k >>= h = nd >>= fun a => k a >>= h := by
+  ext c w <;>
+    simp only [bind_presup, bind_selector] <;>
+    cases nd.selector c w <;> simp [and_assoc]
+
 end NominalDenot
 
 end Semantics.Reference


### PR DESCRIPTION
Make `NominalDenot Ctx W` a monad (presupposition-projecting partiality) with `pure_bind`/`bind_pure`/`bind_assoc`, and define possessive-of as the Kleisli arrow `Possessive.theOf R` / `applyTo nd R = nd >>= theOf R`. Composition falls out: `applyTo_presup` (possessor's presupposition rides along — φ-features of a pronoun possessor), `applyTo_selector` (iota of the relation), `applyTo_applyTo` (nesting from `bind_assoc`). `PronounMixing` derives *his book*: presup = the pronoun's φ on the possessor, selector = the possessee.

Depends on #372 (the unified Possessive namespace).