### PR TITLE
feat(Semantics/Quantification): close GQ foundation sorries

### DIFF
--- a/Linglib/Semantics/Quantification/Basic.lean
+++ b/Linglib/Semantics/Quantification/Basic.lean
@@ -336,7 +336,8 @@ theorem no_coSmooth_partial :
   ⟨restrictorDownMono_to_downNW _ no_restrictor_down,
    restrictorDownMono_to_downNE _ no_restrictor_down⟩
 
-/-! ### Satisfies universals ([van-de-pol-etal-2023]) -/
+/-! ### Satisfies universals: B&C's CONS + MON ([barwise-cooper-1981]; used as a
+learnability/complexity target by [van-de-pol-etal-2023]) -/
 
 theorem some_satisfiesUniversals : SatisfiesUniversals (some_sem (α := α)) :=
   ⟨some_conservative, Or.inl some_scope_up⟩

--- a/Linglib/Semantics/Quantification/Binominal.lean
+++ b/Linglib/Semantics/Quantification/Binominal.lean
@@ -125,21 +125,21 @@ def isDoctorB (p : GradableNouns.Person) : Bool := decide (isDoctor p)
 /-- George is "that idiot of a doctor": he is a doctor (true) and
     his idiocy degree (8) exceeds the standard (3). -/
 theorem george_is_idiot_doctor :
-    ebnpSemantics exampleIdiot isDoctorB .george = true := by native_decide
+    ebnpSemantics exampleIdiot isDoctorB .george = true := by decide
 
 /-- Sarah is also "an idiot of a doctor": doctor (true), idiocy 4 ≥ 3. -/
 theorem sarah_is_idiot_doctor :
-    ebnpSemantics exampleIdiot isDoctorB .sarah = true := by native_decide
+    ebnpSemantics exampleIdiot isDoctorB .sarah = true := by decide
 
 /-- Floyd is not "an idiot of a doctor": he is not a doctor. -/
 theorem floyd_not_idiot_doctor :
-    ebnpSemantics exampleIdiot isDoctorB .floyd = false := by native_decide
+    ebnpSemantics exampleIdiot isDoctorB .floyd = false := by decide
 
 /-- George would be an idiot even if he weren't a doctor — the
     gradable noun threshold is independent of the N₂ restriction.
     This confirms that ebnpSemantics is genuinely conjunctive. -/
 theorem george_idiot_independent :
-    exampleIdiot.pos .george = true := by native_decide
+    exampleIdiot.pos .george = true := by decide
 
 /-! ### : Evaluative Modifier (EM) Semantics -/
 
@@ -262,32 +262,50 @@ def hellEval : EvaluativeMeasure 10 := muHorrible 10
 μ_hell(9) = |9−5| = 4 > 3 = θ_eval ✓. -/
 theorem george_hell_of_doctor :
     emSemantics hellEval doctorQuality (thr 3) isDoctorB .george = true := by
-  native_decide
+  simp only [emSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
+             Semantics.Degree.Degree.toNat, Semantics.Degree.Threshold.toNat]
+  norm_num
 
 /-- Sarah is not "a hell of a doctor": quality (6) yields
 μ_hell(6) = |6−5| = 1, not > 3. -/
 theorem sarah_not_hell_of_doctor :
     emSemantics hellEval doctorQuality (thr 3) isDoctorB .sarah = false := by
-  native_decide
+  simp only [emSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
+             Semantics.Degree.Degree.toNat, Semantics.Degree.Threshold.toNat]
+  norm_num
 
 /-- George is "a hell of a good doctor": good(9 > 5) ✓ AND
 μ_hell(9) = 4 > 3 ✓. BI compounds both thresholds. -/
 theorem george_hell_of_good_doctor :
     biSemantics hellEval doctorQuality (thr 5) (thr 3) isDoctorB .george = true := by
-  native_decide
+  simp only [biSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
+             Semantics.Gradability.Intensification.intensifiedMeaning,
+             Semantics.Degree.positiveMeaning,
+             Semantics.Degree.Degree.toNat, Semantics.Degree.Threshold.toNat,
+             Bool.and_eq_true, decide_eq_true_eq]
+  refine ⟨trivial, ?_, ?_⟩
+  · decide
+  · norm_num
 
 /-- Sarah is not "a hell of a good doctor": good(6 > 5) ✓ but
 μ_hell(6) = 1, not > 3. She's good, but not hell-level good. -/
 theorem sarah_not_hell_of_good_doctor :
     biSemantics hellEval doctorQuality (thr 5) (thr 3) isDoctorB .sarah = false := by
-  native_decide
+  simp only [biSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
+             Semantics.Gradability.Intensification.intensifiedMeaning,
+             Semantics.Degree.positiveMeaning,
+             Semantics.Degree.Degree.toNat, Semantics.Degree.Threshold.toNat,
+             Bool.and_eq_false_iff, decide_eq_false_iff_not]
+  right
+  push Not
+  norm_num
 
 /-- BI → EM entailment holds in the worked example:
 George's BI truth entails his EM truth (by `bi_entails_em`). -/
 theorem george_bi_entails_em :
     emSemantics hellEval doctorQuality (thr 3) isDoctorB .george = true :=
   bi_entails_em hellEval doctorQuality (thr 5) (thr 3) isDoctorB .george
-    (by native_decide)
+    george_hell_of_good_doctor
 
 end EMBIExample
 
@@ -310,7 +328,7 @@ The worked example witnesses both directions of independence:
     idiot-doctor) but fails `emSemantics` (she is not a hell-of-a-doctor). -/
 theorem ebnp_not_entails_em :
     ebnpSemantics exampleIdiot isDoctorB .sarah = true ∧
-    emSemantics hellEval doctorQuality (Semantics.Degree.thr 3) isDoctorB .sarah = false := by
-  constructor <;> native_decide
+    emSemantics hellEval doctorQuality (Semantics.Degree.thr 3) isDoctorB .sarah = false :=
+  ⟨by decide, sarah_not_hell_of_doctor⟩
 
 end Quantification.Binominal

--- a/Linglib/Semantics/Quantification/Counting.lean
+++ b/Linglib/Semantics/Quantification/Counting.lean
@@ -1,6 +1,8 @@
 import Linglib.Semantics.Quantification.Basic
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.EquivFin
 import Mathlib.Data.Finset.Card
+import Mathlib.Logic.Equiv.Basic
 import Mathlib.Tactic.NormNum
 
 /-!
@@ -372,9 +374,11 @@ theorem at_most_n_coSmooth (n : Nat) :
 
 /-! ### Quantity / isomorphism closure ([mostowski-1957])
 
-Cardinality-based, `Fintype`-gated. Bridges to the model-agnostic
-`QuantityInvariant` (in `Defs.lean`) are sorry'd pending a Prop-predicate
-adaptation of the cell-bijection machinery. -/
+Cardinality-based, `Fintype`-gated. `quantityInvariant_of_quantity` and
+`quantity_of_quantityInvariant` bridge to the model-agnostic
+`QuantityInvariant` (in `Defs.lean`): the four Venn cells are the fibers of
+the `Bool × Bool` code `x ↦ (decide (R x), decide (S x))`, and equal cell
+cardinalities glue (`Equiv.ofFiberEquiv`) into a domain bijection. -/
 
 /-- Quantity / isomorphism closure: `Q(A, B)` depends only on the four
     cardinalities `|A ∩ B|`, `|A \ B|`, `|B \ A|`, `|M \ (A ∪ B)|`.
@@ -393,21 +397,104 @@ def Quantity (q : GQ α) : Prop :=
     (q R₁ S₁ ↔ q R₂ S₂)
 
 /-- `Quantity → QuantityInvariant`: cardinality-dependence implies
-    bijection-invariance.
-    TODO: proof requires adapting cell-bijection machinery to Prop predicates. -/
+    bijection-invariance. Each cell count of `(A', B')` equals the
+    corresponding cell count of `(A, B)`: the bijection `f` maps the
+    `(A', B')`-cell into the `(A, B)`-cell (membership transported by the
+    `A ∘ f ↔ A'`, `B ∘ f ↔ B'` hypotheses), so the filters have equal card. -/
 theorem quantityInvariant_of_quantity (q : GQ α) (hQ : Quantity q) :
     QuantityInvariant q := by
-  sorry
+  classical
+  intro A B A' B' f hBij hA hB
+  -- For each cell predicate `P`, `count (P A B) = count (P A' B')`. The
+  -- bijection `f` maps the `(A', B')`-cell into the `(A, B)`-cell (membership
+  -- transported by `hA`/`hB`), so the two filters have equal cardinality.
+  have key : ∀ (P Q : α → Prop) [DecidablePred P] [DecidablePred Q],
+      (∀ x, Q x ↔ P (f x)) → count P = count Q := by
+    intro P Q _ _ hPQ
+    refine (Finset.card_bij (fun x _ => f x) ?_ ?_ ?_).symm
+    · intro x hx
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx ⊢
+      exact (hPQ x).mp hx
+    · intro x₁ _ x₂ _ h; exact hBij.injective h
+    · intro y hy
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy
+      obtain ⟨x, rfl⟩ := hBij.surjective y
+      refine ⟨x, ?_, rfl⟩
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      exact (hPQ x).mpr hy
+  refine hQ A B A' B' ?_ ?_ ?_ ?_
+  · exact key _ _ (fun x => by rw [hA x, hB x])
+  · exact key _ _ (fun x => by rw [hA x, hB x])
+  · exact key _ _ (fun x => by rw [hA x, hB x])
+  · exact key _ _ (fun x => by rw [hA x, hB x])
 
 variable [DecidableEq α]
 
+/-- The four Venn cells of `(R, S)` as the fibers of the `Bool × Bool` code
+    `x ↦ (decide (R x), decide (S x))`. The fiber over `(true, true)` is
+    `R ∩ S`, over `(true, false)` is `R ∖ S`, etc. -/
+private def cellCode (R S : α → Prop) [DecidablePred R] [DecidablePred S] :
+    α → Bool × Bool :=
+  fun x => (decide (R x), decide (S x))
+
+/-- Each cell count is the `Fintype.card` of the corresponding `cellCode`
+    fiber. The `b₁`/`b₂` flags select which of the four cells. -/
+private theorem card_cellCode_fiber (R S : α → Prop)
+    [DecidablePred R] [DecidablePred S] (b₁ b₂ : Bool) :
+    Fintype.card { x // cellCode R S x = (b₁, b₂) } =
+      count (fun x => (if b₁ then R x else ¬ R x) ∧
+                      (if b₂ then S x else ¬ S x)) := by
+  rw [Fintype.card_subtype]
+  simp only [count, cellCode, Prod.mk.injEq]
+  congr 1
+  ext x
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  cases b₁ <;> cases b₂ <;> simp [decide_eq_true_eq]
+
 /-- `QuantityInvariant → Quantity`: bijection-invariance implies
-    cardinality-dependence.
-    TODO: proof requires adapting cell-bijection machinery to Prop predicates. -/
+    cardinality-dependence. Equal cell cardinalities give, cell by cell, an
+    equivalence of `cellCode` fibers (`Fintype.equivOfCardEq`); gluing the four
+    over the partition of `α` (`Equiv.ofFiberEquiv`) yields a bijection `f`
+    with `R₁ ∘ f ↔ R₂` and `S₁ ∘ f ↔ S₂`, to which `hQ` applies. -/
 theorem quantity_of_quantityInvariant (q : GQ α)
     (hQ : QuantityInvariant q) :
     Quantity q := by
-  sorry
+  classical
+  intro R₁ S₁ R₂ S₂ hTT hTF hFT hFF
+  -- Cell-by-cell equality of `cellCode` fiber cardinalities.
+  have hCard : ∀ c : Bool × Bool,
+      Fintype.card { x // cellCode R₂ S₂ x = c } =
+        Fintype.card { x // cellCode R₁ S₁ x = c } := by
+    rintro ⟨b₁, b₂⟩
+    rw [card_cellCode_fiber R₂ S₂ b₁ b₂, card_cellCode_fiber R₁ S₁ b₁ b₂]
+    cases b₁ <;> cases b₂
+    · -- (false, false): ¬R ∧ ¬S
+      exact hFF.symm
+    · -- (false, true): ¬R ∧ S
+      exact hFT.symm
+    · -- (true, false): R ∧ ¬S
+      exact hTF.symm
+    · -- (true, true): R ∧ S
+      exact hTT.symm
+  -- Per-fiber equivalence, glued into a global bijection of `α`.
+  let e : ∀ c, { x // cellCode R₂ S₂ x = c } ≃ { x // cellCode R₁ S₁ x = c } :=
+    fun c => Fintype.equivOfCardEq (hCard c)
+  let f : α ≃ α := Equiv.ofFiberEquiv e
+  -- `f` preserves the code: `cellCode R₁ S₁ (f x) = cellCode R₂ S₂ x`.
+  have hf : ∀ x, cellCode R₁ S₁ (f x) = cellCode R₂ S₂ x :=
+    fun x => Equiv.ofFiberEquiv_map e x
+  -- Reading off the two components of the code gives the iff hypotheses.
+  have hR : ∀ x, R₁ (f x) ↔ R₂ x := by
+    intro x
+    have := congrArg Prod.fst (hf x)
+    simp only [cellCode, decide_eq_decide] at this
+    exact this
+  have hS : ∀ x, S₁ (f x) ↔ S₂ x := by
+    intro x
+    have := congrArg Prod.snd (hf x)
+    simp only [cellCode, decide_eq_decide] at this
+    exact this
+  exact hQ R₁ S₁ R₂ S₂ f f.bijective hR hS
 
 /-! ### Quantity closure -/
 
@@ -457,8 +544,8 @@ private theorem every_quantityInvariant :
   exact forall_congr' fun x => by
     rw [show A (f x) ↔ A' x from hA x, show B (f x) ↔ B' x from hB x]
 
-theorem every_quantity : Quantity (every_sem (α := α)) := by
-  sorry -- Requires quantity_of_quantityInvariant which itself is sorry'd
+theorem every_quantity : Quantity (every_sem (α := α)) :=
+  quantity_of_quantityInvariant _ every_quantityInvariant
 
 theorem most_quantity : Quantity (most_sem (α := α)) := by
   intro R₁ S₁ R₂ S₂ hTT hTF _ _

--- a/Linglib/Semantics/Quantification/PolarizedIndividuals.lean
+++ b/Linglib/Semantics/Quantification/PolarizedIndividuals.lean
@@ -325,15 +325,33 @@ theorem pos_inf_neg (e : α) :
     individuals are incomparable in the ConsGQ lattice (they form an
     antichain).
 
-    TODO: revive proof after Bool→Prop GQ migration.  The original proof
-    instantiates the implication at a witness pair `(· = x.1, λ _ => x.2)`;
-    after the migration, the subtype `≤` no longer applies as cleanly and
-    the case-split on `x.2 / y.2` interacts awkwardly with Prop equality.
-    The downstream code uses `pos_sup_neg`/`pos_inf_neg` rather than this
-    antichain lemma, so the gap is non-blocking. -/
+    The order on `ConsGQ α` is pointwise implication, so `≤` unfolds to
+    `∀ R S, toGQ x R S → toGQ y R S`. Instantiating at the restrictor
+    `(· = x.1)` and a scope that selects `x`'s polarity forces `y.1 = x.1`
+    (first conjunct) and `y.2 = x.2` (the polarity branch). -/
 theorem toConsGQ_le_iff [DecidableEq α] (x y : PolInd α) :
     toConsGQ x ≤ toConsGQ y ↔ x = y := by
-  sorry
+  obtain ⟨a, p⟩ := x
+  obtain ⟨b, q⟩ := y
+  refine ⟨fun h => ?_, fun h => h ▸ le_refl _⟩
+  -- `h R S : toGQ (a, p) R S → toGQ (b, q) R S`, pointwise.
+  cases p
+  · -- negative individual `(a, false)`: witness scope `(· ≠ a)`.
+    have hy := h (· = a) (· ≠ a) (by simp [toGQ])
+    simp only [toGQ] at hy
+    obtain ⟨hba, hpol⟩ := hy
+    subst hba
+    cases q
+    · rfl
+    · simp at hpol
+  · -- positive individual `(a, true)`: witness scope `(· = a)`.
+    have hy := h (· = a) (· = a) (by simp [toGQ])
+    simp only [toGQ] at hy
+    obtain ⟨hba, hpol⟩ := hy
+    subst hba
+    cases q
+    · simp at hpol
+    · rfl
 
 /-- The embedding is order-reflecting: an injection into `ConsGQ α`. -/
 theorem toConsGQ_injective [DecidableEq α] :


### PR DESCRIPTION
Phase 0 of the Quantification maturity plan (`scratch/quantification/vision.md`).

- **Closes the 3 exported foundation `sorry`s**, all axiom-clean (`propext`/`Classical.choice`/`Quot.sound` only): `quantityInvariant_of_quantity` + `quantity_of_quantityInvariant` (the Quantity ↔ QuantityInvariant cell-bijection bridges — `Finset.card_bij` one way, `Equiv.ofFiberEquiv` over the four `Bool×Bool` cell-fibers the other) and `toConsGQ_le_iff` (the Birkhoff order-embedding). This unblocks `every_quantity` and `toConsGQ_injective` for free — so the Logicality HOM→INJ→ISOM hierarchy and the Elliott-2025 conservative-GQ injection are now unconditional.
- **Drops `native_decide`**: the 6 ℚ-arithmetic data-checks in `Binominal.lean` (`emSemantics`/`biSemantics` over the evaluative measure) become structural `simp`/`norm_num` proofs.
- **Fixes the `SatisfiesUniversals` attribution** (B&C origin; van de Pol et al. = the learnability/complexity consumer).

Full `lake build Linglib` not re-run here (cone + consumers green, 1206 jobs); CI verifies.