### PR TITLE
feat(Core/Logic/FirstOrder): finite-rank Ehrenfeucht-Fraisse foundation

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2758,6 +2758,7 @@ import Linglib.Core.Logic.FirstOrder.Binders
 import Linglib.Studies.ChatzikyriakidisLuo2017
 import Linglib.Core.Logic.FirstOrder.Kripke
 import Linglib.Core.Logic.FirstOrder.QuantifierRank
+import Linglib.Core.Logic.FirstOrder.EhrenfeuchtFraisse
 import Linglib.Core.Logic.Modal.QBSML.StandardTranslation
 import Linglib.Core.Logic.Modal.QBSML.FreeChoice
 import Linglib.Studies.Yan2023

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2759,6 +2759,7 @@ import Linglib.Studies.ChatzikyriakidisLuo2017
 import Linglib.Core.Logic.FirstOrder.Kripke
 import Linglib.Core.Logic.FirstOrder.QuantifierRank
 import Linglib.Core.Logic.FirstOrder.EhrenfeuchtFraisse
+import Linglib.Core.Logic.FirstOrder.EhrenfeuchtFraisseGame
 import Linglib.Core.Logic.Modal.QBSML.StandardTranslation
 import Linglib.Core.Logic.Modal.QBSML.FreeChoice
 import Linglib.Studies.Yan2023

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2757,6 +2757,7 @@ import Linglib.Studies.KeenanStavi1986
 import Linglib.Core.Logic.FirstOrder.Binders
 import Linglib.Studies.ChatzikyriakidisLuo2017
 import Linglib.Core.Logic.FirstOrder.Kripke
+import Linglib.Core.Logic.FirstOrder.QuantifierRank
 import Linglib.Core.Logic.Modal.QBSML.StandardTranslation
 import Linglib.Core.Logic.Modal.QBSML.FreeChoice
 import Linglib.Studies.Yan2023

--- a/Linglib/Core/Logic/FirstOrder/EhrenfeuchtFraisse.lean
+++ b/Linglib/Core/Logic/FirstOrder/EhrenfeuchtFraisse.lean
@@ -1,0 +1,81 @@
+import Linglib.Core.Logic.FirstOrder.QuantifierRank
+import Mathlib.ModelTheory.Bundled
+
+/-!
+# Ehrenfeucht–Fraïssé: n-equivalence and first-order inexpressibility
+
+`[UPSTREAM]` candidate. `M ≡ₙ N` (`NEquiv n M N`) holds when `M` and `N` agree on
+every sentence of quantifier rank ≤ `n` — the finite-rank refinement of mathlib's
+`ElementarilyEquivalent` (`= ∀ n, NEquiv n`). On it rests the
+**Ehrenfeucht–Fraïssé inexpressibility** corollary: a property of structures that
+can be `≡ₙ`-fooled for every `n` is not first-order definable. This is the abstract
+engine behind `most ∉ FO` (`Studies.BarwiseCooper1981`), parity, connectivity, etc.
+
+mathlib has the ∞-rank apparatus (`ElementarilyEquivalent`, the unbounded
+back-and-forth `IsExtensionPair`) but not this finite-rank layer; quantifier rank
+itself is `BoundedFormula.qr` (this directory).
+
+## Main definitions / results
+
+* `FirstOrder.Language.NEquiv` — n-equivalence of structures.
+* `FirstOrder.Language.FODefinable` — a structure property captured by a sentence.
+* `FirstOrder.Language.not_foDefinable_of_nEquiv` — the EF inexpressibility corollary.
+-/
+
+universe u v w
+
+namespace FirstOrder.Language
+
+open BoundedFormula CategoryTheory
+open scoped FirstOrder
+
+variable {L : Language.{u, v}} {n m : ℕ}
+
+/-- `n`-equivalence: `M` and `N` satisfy the same sentences of quantifier rank ≤ `n`.
+The finite-rank refinement of `ElementarilyEquivalent` (`≅[L]`), which is the `n = ∞`
+case (`elementarilyEquivalent_iff_forall_nEquiv`). -/
+def NEquiv (n : ℕ) (M N : Bundled.{w} L.Structure) : Prop :=
+  ∀ φ : L.Sentence, φ.qr ≤ n → (M ⊨ φ ↔ N ⊨ φ)
+
+namespace NEquiv
+
+variable {M N P : Bundled.{w} L.Structure}
+
+@[refl] theorem refl (n : ℕ) (M : Bundled.{w} L.Structure) : NEquiv n M M :=
+  fun _ _ => Iff.rfl
+
+theorem symm (h : NEquiv n M N) : NEquiv n N M := fun φ hφ => (h φ hφ).symm
+
+theorem trans (h₁ : NEquiv n M N) (h₂ : NEquiv n N P) : NEquiv n M P :=
+  fun φ hφ => (h₁ φ hφ).trans (h₂ φ hφ)
+
+/-- `n`-equivalence is antitone in the rank: agreeing up to rank `m` implies agreeing
+up to any smaller rank `n`. -/
+theorem mono (hnm : n ≤ m) (h : NEquiv m M N) : NEquiv n M N :=
+  fun φ hφ => h φ (hφ.trans hnm)
+
+end NEquiv
+
+/-- `ElementarilyEquivalent` is exactly `n`-equivalence at every rank. -/
+theorem elementarilyEquivalent_iff_forall_nEquiv (M N : Bundled.{w} L.Structure) :
+    (M ≅[L] N) ↔ ∀ n, NEquiv n M N := by
+  rw [elementarilyEquivalent_iff]
+  exact ⟨fun h _ φ _ => h φ, fun h φ => h φ.qr φ le_rfl⟩
+
+/-- A property of structures is *first-order definable* when some sentence captures
+exactly the structures with the property. -/
+def FODefinable (P : Bundled.{w} L.Structure → Prop) : Prop :=
+  ∃ φ : L.Sentence, ∀ M : Bundled.{w} L.Structure, (M ⊨ φ ↔ P M)
+
+/-- **Ehrenfeucht–Fraïssé inexpressibility.** If for every rank `n` there are
+structures that are `n`-equivalent yet separated by `P` (one has it, the other does
+not), then `P` is not first-order definable. The standard route to FO-inexpressibility:
+the sentence's own quantifier rank is the `n` at which the witnesses fool it. -/
+theorem not_foDefinable_of_nEquiv {P : Bundled.{w} L.Structure → Prop}
+    (h : ∀ n, ∃ M N : Bundled.{w} L.Structure, NEquiv n M N ∧ ¬ (P M ↔ P N)) :
+    ¬ FODefinable P := by
+  rintro ⟨φ, hφ⟩
+  obtain ⟨M, N, hMN, hne⟩ := h φ.qr
+  exact hne ((hφ M).symm.trans ((hMN φ le_rfl).trans (hφ N)))
+
+end FirstOrder.Language

--- a/Linglib/Core/Logic/FirstOrder/EhrenfeuchtFraisseGame.lean
+++ b/Linglib/Core/Logic/FirstOrder/EhrenfeuchtFraisseGame.lean
@@ -1,0 +1,230 @@
+import Linglib.Core.Logic.FirstOrder.EhrenfeuchtFraisse
+
+/-!
+# The finite-rank Ehrenfeucht–Fraïssé back-and-forth relation
+
+`[UPSTREAM]` candidate. The rank-`k` **back-and-forth relation** `BackForth k v w`
+on structures-with-tuples `(M, v)`, `(N, w)` is the syntax-free combinatorial
+characterization of `k`-equivalence: `BackForth 0` is agreement on quantifier-free
+formulas, and `BackForth (k+1)` is the *forth* (every `a : M` is matched by some
+`b : N`) and *back* (dually) conditions, recursing at rank `k`. This is the
+rank-bounded refinement of mathlib's *unbounded* `IsExtensionPair` /
+`FGEquiv`-based back-and-forth.
+
+The **soundness** direction — `BackForth k v w` implies the two tuples satisfy the
+same formulas of quantifier rank `≤ k` (`BackForth.agree`), hence the structures
+are `≡ₖ` (`nEquiv_of_backForth`, feeding `not_foDefinable_of_nEquiv`) — is the
+tractable half and is proved here in full (under the finite-model-theory convention
+that the domains are `[Nonempty]`, used to extract quantifier-free agreement of a tuple
+from the higher-rank forth/back data). The converse (Libkin "1 ⟹ 3", via rank-`k`
+Hintikka formulas / `k`-types) is left as future work.
+
+Construction: Libkin, *Elements of Finite Model Theory*, Thm 3.18; Hodges,
+*Model Theory*, §3.2 (general back-and-forth systems).
+
+## Main definitions / results
+
+* `FirstOrder.Language.BackForth` — the rank-`k` back-and-forth relation.
+* `FirstOrder.Language.BackForth.agree` — soundness: back-and-forth ⟹ agreement on
+  rank-`≤ k` formulas.
+* `FirstOrder.Language.nEquiv_of_backForth` — back-and-forth on the empty tuples ⟹ `≡ₖ`.
+-/
+
+universe u v w
+
+namespace FirstOrder.Language
+
+open BoundedFormula CategoryTheory
+open scoped FirstOrder
+
+variable {L : Language.{u, v}}
+
+section BackForth
+
+variable (M : Type w) (N : Type w) [L.Structure M] [L.Structure N]
+
+/-- The rank-`k` **Ehrenfeucht–Fraïssé back-and-forth relation** between a structure
+`M` with an `m`-tuple `v` and a structure `N` with an `m`-tuple `w`.
+
+* At rank `0`: `v` and `w` satisfy the same quantifier-free formulas (here phrased as
+  all formulas of quantifier rank `0`).
+* At rank `k + 1`: the **forth** condition (every `a : M` extends `v` to a pair still
+  related at rank `k` by some `b : N`) and the dual **back** condition. -/
+def BackForth : (k : ℕ) → {m : ℕ} → (Fin m → M) → (Fin m → N) → Prop
+  | 0, m, v, w =>
+    ∀ φ : L.BoundedFormula (Fin m) 0, φ.qr = 0 → (φ.Realize v default ↔ φ.Realize w default)
+  | k + 1, _, v, w =>
+    (∀ a : M, ∃ b : N, BackForth k (Fin.snoc v a) (Fin.snoc w b)) ∧
+      (∀ b : N, ∃ a : M, BackForth k (Fin.snoc v a) (Fin.snoc w b))
+
+end BackForth
+
+namespace BackForth
+
+variable {M : Type w} {N : Type w} [L.Structure M] [L.Structure N] {m : ℕ}
+
+/-- Lift a free-variable formula `φ` over `Fin m` to one over `Fin (m + 1)` by
+ignoring the new last variable; rank-preserving, and realizing the lift at
+`Fin.snoc v a` agrees with realizing `φ` at `v`. -/
+private def liftLast (φ : L.BoundedFormula (Fin m) 0) : L.BoundedFormula (Fin (m + 1)) 0 :=
+  φ.relabel (fun i => Sum.inl i.castSucc)
+
+private theorem realize_liftLast (φ : L.BoundedFormula (Fin m) 0) (v : Fin m → M) (a : M) :
+    (liftLast φ).Realize (Fin.snoc v a) default ↔ φ.Realize v default := by
+  rw [liftLast, realize_relabel]
+  refine Iff.of_eq (congrArg₂ _ ?_ (Subsingleton.elim _ _))
+  funext i
+  simp [Fin.snoc_castSucc]
+
+private theorem qr_relabel {α β : Type*} {n' : ℕ} (g : α → β ⊕ (Fin n')) :
+    ∀ {k} (φ : L.BoundedFormula α k), (φ.relabel g).qr = φ.qr
+  | _, .falsum => rfl
+  | _, .equal _ _ => rfl
+  | _, .rel _ _ => rfl
+  | _, .imp f₁ f₂ => by
+      rw [relabel_imp, qr_imp, qr_imp, qr_relabel g f₁, qr_relabel g f₂]
+  | _, .all f => by
+      rw [relabel_all, qr_all, qr_all, qr_relabel g f]
+
+private theorem qr_liftLast (φ : L.BoundedFormula (Fin m) 0) : (liftLast φ).qr = φ.qr :=
+  qr_relabel _ φ
+
+/-- **Monotonicity:** a rank-`k+1` back-and-forth pair is also a rank-`k` one. The base
+step (rank `1 → 0`) recovers quantifier-free agreement of the tuple `(v, w)` itself by
+extending along the *forth* clause at an arbitrary element (whence `[Nonempty M]`) and
+discarding the new last variable via `liftLast`. -/
+theorem mono [Nonempty M] {k : ℕ} :
+    ∀ {m} {v : Fin m → M} {w : Fin m → N},
+      BackForth (L := L) M N (k + 1) v w → BackForth (L := L) M N k v w := by
+  induction k with
+  | zero =>
+      intro m v w h φ hφ
+      obtain ⟨b, hab⟩ := h.1 (Classical.arbitrary M)
+      have := hab (liftLast φ) (by rw [qr_liftLast]; exact hφ)
+      rwa [realize_liftLast, realize_liftLast] at this
+  | succ k ih =>
+      intro m v w h
+      exact ⟨fun a => (h.1 a).imp fun _ hb => ih hb,
+        fun b => (h.2 b).imp fun _ ha => ih ha⟩
+
+/-- A rank-`k` back-and-forth pair is also a rank-`0` one (quantifier-free agreement). -/
+theorem mono_zero [Nonempty M] [Nonempty N] :
+    ∀ {k} {m} {v : Fin m → M} {w : Fin m → N},
+      BackForth (L := L) M N k v w → BackForth (L := L) M N 0 v w
+  | 0, _, _, _, h => h
+  | _ + 1, _, _, _, h => mono_zero (mono h)
+
+/-- The "combined" valuation on `Fin (m + n)` formed by appending the bound tuple to the
+free tuple is the appropriate reindexing of the `Sum.elim` valuation that `Realize` uses. -/
+private theorem append_eq_elim {m n : ℕ} (v : Fin m → M) (xs : Fin n → M) :
+    Fin.append v xs = Sum.elim v xs ∘ finSumFinEquiv.symm := by
+  funext j
+  refine Fin.addCases (fun i => ?_) (fun i => ?_) j
+  · simp [Fin.append_left, finSumFinEquiv_symm_apply_castAdd]
+  · simp [Fin.append_right, finSumFinEquiv_symm_apply_natAdd]
+
+/-- The variable reindexing `Fin m ⊕ Fin n → Fin (m + n) ⊕ Fin 0` that frees the bound
+slots into the free index. -/
+private def combineVar {m n : ℕ} : Fin m ⊕ (Fin n) → Fin (m + n) ⊕ (Fin 0) :=
+  Sum.inl ∘ finSumFinEquiv
+
+private theorem elim_comp_combineVar {m n : ℕ} (v : Fin m → M) (xs : Fin n → M) :
+    Sum.elim (Fin.append v xs) (default : Fin 0 → M) ∘ combineVar = Sum.elim v xs := by
+  funext x
+  rcases x with i | i
+  · simp [combineVar, Function.comp_apply, Fin.append_left]
+  · simp [combineVar, Function.comp_apply, Fin.append_right]
+
+/-- An atomic formula over `Fin m` with `n` bound slots, relabelled to free its bound slots,
+yielding a formula over `Fin (m + n)` with none — used to feed atomic agreement of the
+combined tuple into the back-and-forth base case. -/
+private def combineAtomic {m n : ℕ} : (φ : L.BoundedFormula (Fin m) n) → φ.IsAtomic →
+    L.BoundedFormula (Fin (m + n)) 0
+  | .equal t₁ t₂, _ => .equal (t₁.relabel combineVar) (t₂.relabel combineVar)
+  | .rel R ts, _ => .rel R (fun i => (ts i).relabel combineVar)
+
+private theorem realize_combineAtomic {m n : ℕ} {v : Fin m → M} {xs : Fin n → M} :
+    ∀ {φ : L.BoundedFormula (Fin m) n} (hφ : φ.IsAtomic),
+      (combineAtomic φ hφ).Realize (Fin.append v xs) default ↔ φ.Realize v xs
+  | .equal t₁ t₂, _ => by
+      simp only [combineAtomic, Realize, Term.realize_relabel]
+      rw [elim_comp_combineVar]
+  | .rel R ts, _ => by
+      simp only [combineAtomic, Realize]
+      refine Iff.of_eq (congrArg _ (funext fun i => ?_))
+      rw [Term.realize_relabel, elim_comp_combineVar]
+
+/-- **Generalized soundness** (induction on rank, then formula). If the combined free+bound
+tuples are rank-`k` back-and-forth related, then any formula of quantifier rank `≤ k` is
+agreed on. The bound tuples `xs`, `ys` are absorbed into the back-and-forth via
+`Fin.append`; the `all` case uses the *forth*/*back* clauses to extend them. -/
+private theorem agree_aux [Nonempty M] [Nonempty N] {m : ℕ}
+    {v : Fin m → M} {w : Fin m → N} :
+    ∀ {n} (φ : L.BoundedFormula (Fin m) n) {k} {xs : Fin n → M} {ys : Fin n → N},
+      BackForth (L := L) M N k (Fin.append v xs) (Fin.append w ys) →
+      φ.qr ≤ k → (φ.Realize v xs ↔ φ.Realize w ys) := by
+  intro n φ
+  induction φ with
+  | falsum => intro k xs ys _ _; exact Iff.rfl
+  | equal t₁ t₂ =>
+      intro k xs ys h _
+      have := (mono_zero h) (combineAtomic _ (.equal t₁ t₂)) rfl
+      rwa [realize_combineAtomic, realize_combineAtomic] at this
+  | rel R ts =>
+      intro k xs ys h _
+      have := (mono_zero h) (combineAtomic _ (.rel R ts)) rfl
+      rwa [realize_combineAtomic, realize_combineAtomic] at this
+  | imp f₁ f₂ ih₁ ih₂ =>
+      intro k xs ys h hφ
+      simp only [realize_imp]
+      rw [ih₁ h (le_trans (le_max_left _ _) hφ), ih₂ h (le_trans (le_max_right _ _) hφ)]
+  | all f ih =>
+      intro k xs ys h hφ
+      rw [qr_all] at hφ
+      obtain ⟨k, rfl⟩ : ∃ k', k = k' + 1 := ⟨k - 1, by omega⟩
+      have hf : f.qr ≤ k := by omega
+      simp only [realize_all]
+      constructor
+      · intro hM b
+        obtain ⟨a, hab⟩ := h.2 b
+        rw [← Fin.append_snoc, ← Fin.append_snoc] at hab
+        exact (ih hab hf).mp (hM a)
+      · intro hN a
+        obtain ⟨b, hab⟩ := h.1 a
+        rw [← Fin.append_snoc, ← Fin.append_snoc] at hab
+        exact (ih hab hf).mpr (hN b)
+
+/-- **Soundness of back-and-forth (Libkin Thm 3.18, "3 ⟹ 1").** If `(M, v)` and
+`(N, w)` are related by the rank-`k` back-and-forth relation, then they satisfy the
+same formulas of quantifier rank `≤ k`. Proof: the `all` case uses the *forth* clause and
+the rank-`k` recursion, the dual `ex` case the *back* clause; atomic agreement descends to
+the quantifier-free base case via `mono_zero`. -/
+theorem agree [Nonempty M] [Nonempty N] {k : ℕ} {v : Fin m → M} {w : Fin m → N}
+    (h : BackForth (L := L) M N k v w) :
+    ∀ φ : L.BoundedFormula (Fin m) 0, φ.qr ≤ k →
+      (φ.Realize v default ↔ φ.Realize w default) := by
+  have hv : Fin.append v (default : Fin 0 → M) = v := by
+    rw [Subsingleton.elim (default : Fin 0 → M) Fin.elim0, Fin.append_elim0]; rfl
+  have hw : Fin.append w (default : Fin 0 → N) = w := by
+    rw [Subsingleton.elim (default : Fin 0 → N) Fin.elim0, Fin.append_elim0]; rfl
+  intro φ hφ
+  exact agree_aux (v := v) (w := w) φ (xs := default) (ys := default) (by rw [hv, hw]; exact h) hφ
+
+end BackForth
+
+/-- A rank-`k` back-and-forth relation between the structures themselves (on the empty
+tuples) witnesses `k`-equivalence — and so feeds `not_foDefinable_of_nEquiv`. -/
+theorem nEquiv_of_backForth {k : ℕ} (M N : Bundled.{w} L.Structure)
+    [Nonempty M] [Nonempty N]
+    (h : BackForth (L := L) M N k (default : Fin 0 → M) (default : Fin 0 → N)) :
+    NEquiv k M N := fun φ hφ => by
+  -- relabel the sentence's free variables `Empty` to `Fin 0` to match `agree`
+  let e : Empty ≃ Fin 0 := Equiv.equivOfIsEmpty Empty (Fin 0)
+  have hqr : (BoundedFormula.relabelEquiv e φ).qr ≤ k := by
+    rwa [BoundedFormula.qr_relabelEquiv]
+  have key := BackForth.agree h (BoundedFormula.relabelEquiv e φ) hqr
+  rw [BoundedFormula.realize_relabelEquiv, BoundedFormula.realize_relabelEquiv] at key
+  simpa only [Sentence.Realize, Formula.Realize,
+    Subsingleton.elim (default ∘ e.symm) default] using key
+
+end FirstOrder.Language

--- a/Linglib/Core/Logic/FirstOrder/QuantifierRank.lean
+++ b/Linglib/Core/Logic/FirstOrder/QuantifierRank.lean
@@ -1,0 +1,78 @@
+import Mathlib.ModelTheory.Complexity
+
+/-!
+# Quantifier rank of first-order formulas
+
+`[UPSTREAM]` candidate. mathlib's `ModelTheory` has formula *complexity classes*
+(`IsQF`, `IsPrenex`, `IsUniversal`) but no quantifier-*rank* function. `qr φ` is the
+maximal nesting depth of quantifiers in `φ` — the standard measure indexing
+Ehrenfeucht–Fraïssé games and `≡ₙ` n-equivalence, the foundation of every
+first-order inexpressibility result (e.g. `Studies.BarwiseCooper1981`'s
+`most ∉ FO`, whose ad-hoc `numQuant` this generalizes).
+
+mathlib has the `∞`-rank apparatus (`ElementarilyEquivalent`, the unbounded
+back-and-forth `IsExtensionPair`); `qr` is the bottom of the missing finite-rank
+layer.
+
+## Main definitions
+
+* `FirstOrder.Language.BoundedFormula.qr` — quantifier rank (max quantifier nesting).
+-/
+
+namespace FirstOrder.Language.BoundedFormula
+
+variable {L : Language} {α : Type*} {n : ℕ}
+
+/-- Quantifier rank: the maximal nesting depth of quantifiers in a formula.
+Atomic formulas have rank `0`, `imp` takes the max, and `all` adds one. -/
+def qr : ∀ {n : ℕ}, L.BoundedFormula α n → ℕ
+  | _, .falsum => 0
+  | _, .equal _ _ => 0
+  | _, .rel _ _ => 0
+  | _, .imp f₁ f₂ => max (qr f₁) (qr f₂)
+  | _, .all f => qr f + 1
+
+@[simp] theorem qr_falsum : (falsum : L.BoundedFormula α n).qr = 0 := rfl
+
+@[simp] theorem qr_bot : (⊥ : L.BoundedFormula α n).qr = 0 := rfl
+
+@[simp] theorem qr_equal (t₁ t₂ : L.Term (α ⊕ (Fin n))) :
+    (equal t₁ t₂ : L.BoundedFormula α n).qr = 0 := rfl
+
+@[simp] theorem qr_rel {l : ℕ} (R : L.Relations l) (ts : Fin l → L.Term (α ⊕ (Fin n))) :
+    (rel R ts).qr = 0 := rfl
+
+@[simp] theorem qr_imp (φ ψ : L.BoundedFormula α n) : (φ.imp ψ).qr = max φ.qr ψ.qr := rfl
+
+@[simp] theorem qr_all (φ : L.BoundedFormula α (n + 1)) : φ.all.qr = φ.qr + 1 := rfl
+
+@[simp] theorem qr_not (φ : L.BoundedFormula α n) : φ.not.qr = φ.qr := by
+  simp [BoundedFormula.not]
+
+@[simp] theorem qr_top : (⊤ : L.BoundedFormula α n).qr = 0 := by
+  simp [Top.top]
+
+@[simp] theorem qr_inf (φ ψ : L.BoundedFormula α n) : (φ ⊓ ψ).qr = max φ.qr ψ.qr := by
+  change ((φ.imp ψ.not).not).qr = _; simp
+
+@[simp] theorem qr_sup (φ ψ : L.BoundedFormula α n) : (φ ⊔ ψ).qr = max φ.qr ψ.qr := by
+  change (φ.not.imp ψ).qr = _; simp
+
+@[simp] theorem qr_iff (φ ψ : L.BoundedFormula α n) : (φ.iff ψ).qr = max φ.qr ψ.qr := by
+  simp only [BoundedFormula.iff, qr_inf, qr_imp, max_comm ψ.qr φ.qr, max_self]
+
+@[simp] theorem qr_ex (φ : L.BoundedFormula α (n + 1)) : φ.ex.qr = φ.qr + 1 := by
+  simp [BoundedFormula.ex]
+
+/-- An atomic formula has quantifier rank `0`. -/
+theorem IsAtomic.qr_eq_zero {φ : L.BoundedFormula α n} (h : φ.IsAtomic) : φ.qr = 0 := by
+  cases h <;> rfl
+
+/-- A quantifier-free formula has quantifier rank `0`. -/
+theorem IsQF.qr_eq_zero {φ : L.BoundedFormula α n} (h : φ.IsQF) : φ.qr = 0 := by
+  induction h with
+  | falsum => rfl
+  | of_isAtomic h => exact h.qr_eq_zero
+  | imp _ _ ih₁ ih₂ => simp [ih₁, ih₂]
+
+end FirstOrder.Language.BoundedFormula

--- a/Linglib/Core/Logic/FirstOrder/QuantifierRank.lean
+++ b/Linglib/Core/Logic/FirstOrder/QuantifierRank.lean
@@ -64,6 +64,20 @@ def qr : ∀ {n : ℕ}, L.BoundedFormula α n → ℕ
 @[simp] theorem qr_ex (φ : L.BoundedFormula α (n + 1)) : φ.ex.qr = φ.qr + 1 := by
   simp [BoundedFormula.ex]
 
+/-- Quantifier rank is invariant under relabelling free variables along a bijection
+(`relabelEquiv` acts structurally, only on the terms inside atomic formulas). -/
+@[simp] theorem qr_relabelEquiv {β : Type*} (g : α ≃ β) :
+    ∀ {n : ℕ} (φ : L.BoundedFormula α n), (relabelEquiv g φ).qr = φ.qr
+  | _, .falsum => rfl
+  | _, .equal _ _ => rfl
+  | _, .rel _ _ => rfl
+  | _, .imp f₁ f₂ => by
+      have : relabelEquiv g (f₁.imp f₂) = (relabelEquiv g f₁).imp (relabelEquiv g f₂) := rfl
+      rw [this, qr_imp, qr_imp, qr_relabelEquiv g f₁, qr_relabelEquiv g f₂]
+  | _, .all f => by
+      have : relabelEquiv g f.all = (relabelEquiv g f).all := rfl
+      rw [this, qr_all, qr_all, qr_relabelEquiv g f]
+
 /-- An atomic formula has quantifier rank `0`. -/
 theorem IsAtomic.qr_eq_zero {φ : L.BoundedFormula α n} (h : φ.IsAtomic) : φ.qr = 0 := by
   cases h <;> rfl


### PR DESCRIPTION
The finite-rank layer of model theory that mathlib lacks — it has the ∞-rank `ElementarilyEquivalent` + unbounded back-and-forth `IsExtensionPair`, but no rank-bounded apparatus. Faithful to Libkin *Elements of Finite Model Theory* §3 and Hodges *Model Theory* §3.2–3.3. `[UPSTREAM]` candidates; all axiom-clean.

- **`QuantifierRank.lean`** — `BoundedFormula.qr` (Libkin Def 3.8), full computational simp-set + `IsAtomic`/`IsQF → qr = 0` + `qr_relabelEquiv`. Generalizes the ad-hoc `numQuant` in `Studies/BarwiseCooper1981`.
- **`EhrenfeuchtFraisse.lean`** — `NEquiv n M N` (n-equivalence; Libkin `≡ₖ`) with refl/symm/trans/antitone + `ElementarilyEquivalent = ∀ n, NEquiv n`; `FODefinable`; and **`not_foDefinable_of_nEquiv`** — the EF inexpressibility corollary (Libkin Cor 3.10).
- **`EhrenfeuchtFraisseGame.lean`** — the **back-and-forth relation** `BackForth k` (Libkin Thm 3.18 / Hodges §3.2: `≃₀` = atomic agreement, `≃ₖ₊₁` = forth ∧ back via `Fin.snoc`) and its **soundness** `BackForth.agree` (back-and-forth ⟹ agreement on `FO[k]`), feeding `nEquiv_of_backForth : BackForth k → NEquiv k`. The de Bruijn `∃`-case is handled by absorbing the bound tuple into the back-and-forth via `Fin.append`. Standard `[Nonempty]` side condition. The converse (via rank-k Hintikka types, Libkin §3.4) is the documented next piece.

Together: the complete **soundness** route to first-order inexpressibility (`BackForth k` witnesses ⟹ `not_foDefinable`), reusable for parity/connectivity/most∉FO. Stages C+D of `scratch/quantification/model-theoretic-vision.md`.