### PR TITLE
feat(Semantics/Lexical/Roots): add Root outcome axis + changeType

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2366,6 +2366,7 @@ import Linglib.Semantics.Lexical.Roots.Template
 import Linglib.Semantics.Lexical.Roots.Typology
 import Linglib.Semantics.Lexical.Roots.Closure
 import Linglib.Semantics.Lexical.Roots.SalienceClass
+import Linglib.Semantics.Lexical.Roots.OutcomeCardinality
 import Linglib.Semantics.Lexical.Roots.Outcomes
 import Linglib.Morphology.RootTypology
 import Linglib.Morphology.TheorySpace

--- a/Linglib/Fragments/Mayan/Yukatek/Roots.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Roots.lean
@@ -65,22 +65,22 @@ namespace Yukatek.Roots
     feature in Yukatek (cf. `motion_roots_not_separate_class`); jumping
     qualifies as a manner-of-action irrespective of whether it
     incidentally involves displacement. -/
-def siit : Root := ⟨"siit'", {.hasManner "jumping"}⟩
+def siit : Root := ⟨"siit'", {.hasManner "jumping"}, none⟩
 
 /-- ¢'iib "write" — manner-of-action activity ([lucy-1994] p. 628). -/
-def tziib : Root := ⟨"tziib", {.hasManner "writing"}⟩
+def tziib : Root := ⟨"tziib", {.hasManner "writing"}, none⟩
 
 /-- mìis "sweep" — manner-of-action activity
     ([lucy-1994] agent-salient list). -/
-def miis : Root := ⟨"mìis", {.hasManner "sweeping"}⟩
+def miis : Root := ⟨"mìis", {.hasManner "sweeping"}, none⟩
 
 /-- ć'eh "shout" — manner-of-action activity
     ([lucy-1994] agent-salient list). -/
-def cheh : Root := ⟨"ć'eh", {.hasManner "shouting"}⟩
+def cheh : Root := ⟨"ć'eh", {.hasManner "shouting"}, none⟩
 
 /-- paak "weed" — manner-of-action activity
     ([lucy-1994] agent-salient list). -/
-def paak : Root := ⟨"paak", {.hasManner "weeding"}⟩
+def paak : Root := ⟨"paak", {.hasManner "weeding"}, none⟩
 
 /-! ### Agent-patient salient roots (root transitives, take `=∅`)
 
@@ -96,79 +96,79 @@ root transitive a Manner/Result-Complementarity violator. -/
 /-- kuč "carry" — manner-of-action, lexically transitive
     ([lucy-1994] ex. 1b). Underived transitive; no derivation
     needed. -/
-def kuc : Root := ⟨"kuc", {.hasManner "carrying"}⟩
+def kuc : Root := ⟨"kuc", {.hasManner "carrying"}, none⟩
 
 /-- p'is "measure" — manner-of-action, lexically transitive
     ([lucy-1994] p. 629). No entailed change of state. -/
-def pis : Root := ⟨"pis", {.hasManner "measuring"}⟩
+def pis : Root := ⟨"pis", {.hasManner "measuring"}, none⟩
 
 /-- lo'š "punch" — manner-of-action, lexically transitive
     ([lucy-1994] p. 629). Surface-contact manner without entailed
     result, like B&K-G's *hit*-type. No `.contact` atom: contact is
     implicit in the manner of striking rather than a B&K-G feature in
     Lucy's typology. -/
-def los : Root := ⟨"los", {.hasManner "striking"}⟩
+def los : Root := ⟨"los", {.hasManner "striking"}, none⟩
 
 -- ════════════════════════════════════════════════════
 -- § 3. Patient-Salient Roots (result only, take `=s`)
 -- ════════════════════════════════════════════════════
 
 /-- kíim "die" — spontaneous state change ([lucy-1994] ex. 1c, 2). -/
-def kiim : Root := ⟨"kiim", {.becomesState "dead"}⟩
+def kiim : Root := ⟨"kiim", {.becomesState "dead"}, none⟩
 
 /-- háan "stop, cease, heal" ([lucy-1994] patient-salient list,
     p. 630, ex. 2). High-tone vowel: distinct from `Yukatek.haanEat`
     "eat" (low-tone `hàan`), which is `inactive`-class but
     internally caused — see `Fragments/Mayan/Yukatek/VerbClasses.lean`
     and [bohnemeyer-2004] ex. (9). -/
-def haanCease : Root := ⟨"háan", {.becomesState "stopped"}⟩
+def haanCease : Root := ⟨"háan", {.becomesState "stopped"}, none⟩
 
 /-- lúub' "fall" ([lucy-1994] ex. 4, Table 4). A "motion verb" by
     any reasonable cross-linguistic notional taxonomy, but patterns
     morphologically with other patient-salient change-of-state roots
     in Yukatek. No `.motion` atom: motion is the *issue*, not a
     feature — see `motion_roots_not_separate_class`. -/
-def luub : Root := ⟨"luub'", {.becomesState "fallen"}⟩
+def luub : Root := ⟨"luub'", {.becomesState "fallen"}, none⟩
 
 /-- 'ok "enter, intrude" ([lucy-1994] ex. 4, Table 4). Another
     notional motion root that takes `=s` like patient-salient state
     changes. -/
-def ok : Root := ⟨"'ok", {.becomesState "inside"}⟩
+def ok : Root := ⟨"'ok", {.becomesState "inside"}, none⟩
 
 /-! Additional patient-salient roots from the page-630 list. -/
 
 /-- 'ah "wake" ([lucy-1994] patient-salient list). -/
-def ah : Root := ⟨"'ah", {.becomesState "awake"}⟩
+def ah : Root := ⟨"'ah", {.becomesState "awake"}, none⟩
 
 /-- wen "sleep" ([lucy-1994] patient-salient list). State change
     *into* sleep, not the activity of sleeping. -/
-def wen : Root := ⟨"wen", {.becomesState "asleep"}⟩
+def wen : Root := ⟨"wen", {.becomesState "asleep"}, none⟩
 
 /-- siih "be born" ([lucy-1994] patient-salient list). -/
-def siih : Root := ⟨"siih", {.becomesState "born"}⟩
+def siih : Root := ⟨"siih", {.becomesState "born"}, none⟩
 
 /-- tú'ub' "be forgotten" ([lucy-1994] patient-salient list). -/
-def tuub : Root := ⟨"tú'ub'", {.becomesState "forgotten"}⟩
+def tuub : Root := ⟨"tú'ub'", {.becomesState "forgotten"}, none⟩
 
 /-- k'a'ah "remember" ([lucy-1994] patient-salient list). -/
-def kaah : Root := ⟨"k'a'ah", {.becomesState "remembered"}⟩
+def kaah : Root := ⟨"k'a'ah", {.becomesState "remembered"}, none⟩
 
 /-- čú'un "begin" ([lucy-1994] patient-salient list). -/
-def chuun : Root := ⟨"čú'un", {.becomesState "begun"}⟩
+def chuun : Root := ⟨"čú'un", {.becomesState "begun"}, none⟩
 
 /-- č'en "stop, cease" ([lucy-1994] patient-salient list).
     Distinct from `haanCease` (Lucy lists them as separate entries). -/
-def chenCease : Root := ⟨"č'en", {.becomesState "ceased"}⟩
+def chenCease : Root := ⟨"č'en", {.becomesState "ceased"}, none⟩
 
 /-- hó'op' "begin" ([lucy-1994] patient-salient list). Doublet of
     `chuun`; both gloss as "begin" in the patient-salient list. -/
-def hoop : Root := ⟨"hó'op'", {.becomesState "started"}⟩
+def hoop : Root := ⟨"hó'op'", {.becomesState "started"}, none⟩
 
 /-- hé'el "rest" ([lucy-1994] patient-salient list). -/
-def heel : Root := ⟨"hé'el", {.becomesState "rested"}⟩
+def heel : Root := ⟨"hé'el", {.becomesState "rested"}, none⟩
 
 /-- p'át "remain" ([lucy-1994] patient-salient list). -/
-def paat : Root := ⟨"p'át", {.becomesState "remaining"}⟩
+def paat : Root := ⟨"p'át", {.becomesState "remaining"}, none⟩
 
 /-! Motion roots from [lucy-1994] Table 4. These pattern as
     patient-salient (`becomesState` only) — the central typological
@@ -176,21 +176,21 @@ def paat : Root := ⟨"p'át", {.becomesState "remaining"}⟩
     `motion_roots_predicted_patient`. -/
 
 /-- máan "pass" ([lucy-1994] Table 4). -/
-def maan : Root := ⟨"máan", {.becomesState "passed"}⟩
+def maan : Root := ⟨"máan", {.becomesState "passed"}, none⟩
 
 /-- tàal "come" ([lucy-1994] Table 4). -/
-def taal : Root := ⟨"tàal", {.becomesState "arrived"}⟩
+def taal : Root := ⟨"tàal", {.becomesState "arrived"}, none⟩
 
 /-- b'in "go" ([lucy-1994] Table 4). -/
-def bin : Root := ⟨"b'in", {.becomesState "departed"}⟩
+def bin : Root := ⟨"b'in", {.becomesState "departed"}, none⟩
 
 /-- nàak "ascend" ([lucy-1994] Table 4). Distinct from
     `Yukatek.naak` "ascend" in `VerbClasses.lean`, which encodes
     Bohnemeyer's stem-class data; both refer to the same Yukatek root. -/
-def naak : Root := ⟨"nàak", {.becomesState "ascended"}⟩
+def naak : Root := ⟨"nàak", {.becomesState "ascended"}, none⟩
 
 /-- lìik' "rise" ([lucy-1994] Table 4). -/
-def liik : Root := ⟨"lìik'", {.becomesState "risen"}⟩
+def liik : Root := ⟨"lìik'", {.becomesState "risen"}, none⟩
 
 -- ════════════════════════════════════════════════════
 -- § 4. Positional Roots (state only, take `-tal`)
@@ -198,11 +198,11 @@ def liik : Root := ⟨"lìik'", {.becomesState "risen"}⟩
 
 /-- čin "bow, bend down, bend over" ([lucy-1994] ex. 5, 7).
     Positional root; takes `-tal` (or `-lah`) for the inchoative stem. -/
-def cin : Root := ⟨"cin", {.hasState "bent"}⟩
+def cin : Root := ⟨"cin", {.hasState "bent"}, none⟩
 
 /-- kul "sit" — positional root (cf. [lucy-1994] ex. 8c on
     relational positional semantics: "x is-seated [on y]"). -/
-def kul : Root := ⟨"kul", {.hasState "seated"}⟩
+def kul : Root := ⟨"kul", {.hasState "seated"}, none⟩
 
 /-! ### Root arity -/
 

--- a/Linglib/Morphology/RootTypology.lean
+++ b/Linglib/Morphology/RootTypology.lean
@@ -160,6 +160,45 @@ structure RootClassification where
 /-- Does this root lexically entail prior change? -/
 def RootClassification.entailsChange (r : RootClassification) : Bool := r.changeType.entailsChange
 
+/-! ### Root change type, and its blindness to the outcome axis
+
+`RootType` is a *projection* of a root's entailment signature, derived not
+stored — `Root.changeType` is the derived analog of the stored
+`RootClassification.changeType`. Crucially it is blind to the [bhadra-2024]
+outcome axis (`Root.outcomes`, the orthogonal dimension `Root` now carries): two
+roots with the same entailments share a `changeType` whatever their outcomes —
+which is precisely why outcome cardinality is a genuinely independent dimension
+of root content, the one that drives reversative *un-* where the manner/result
+typology cannot. -/
+
+/-- The change-entailment type of a root, derived from its feature signature:
+    a root entails change iff its signature carries `result` ([beavers-etal-2021]).
+    The derived analog of `RootClassification.changeType`. -/
+def Root.changeType (r : _root_.Root) : RootType :=
+  if LexKind.result ∈ r.featureSignature then .result else .propertyConcept
+
+theorem Root.changeType_eq_result_iff (r : _root_.Root) :
+    r.changeType = .result ↔ r.HasResult := by
+  unfold Root.changeType _root_.Root.HasResult
+  by_cases h : LexKind.result ∈ r.featureSignature <;> simp [h]
+
+/-- `changeType` is blind to outcomes: same entailments ⇒ same `changeType`,
+    whatever the `outcomes`. The formal statement of why [bhadra-2024]'s outcome
+    cardinality is an independent axis the manner/result signature cannot see. -/
+theorem Root.changeType_ignores_outcomes {r r' : _root_.Root}
+    (h : r.entailments = r'.entailments) : r.changeType = r'.changeType := by
+  have hsig : r.featureSignature = r'.featureSignature := by
+    unfold _root_.Root.featureSignature; rw [h]
+  unfold Root.changeType; rw [hsig]
+
+/-- A *bend*-like and a *break*-like root with the same entailments but different
+    outcome cardinality share a `changeType` — only the outcome axis tells them
+    apart ([bhadra-2024]). -/
+example :
+    (Root.mk "x" {.becomesState "s", .hasCause} (some .multi)).changeType
+      = (Root.mk "x" {.becomesState "s", .hasCause} (some .singleton)).changeType :=
+  Root.changeType_ignores_outcomes rfl
+
 /-- Property concept root subclasses ([dixon-1982]; [beavers-etal-2021] ex. 5).
 
     [dixon-1982] identifies seven semantic categories. [beavers-etal-2021]

--- a/Linglib/Semantics/Lexical/Roots/Basic.lean
+++ b/Linglib/Semantics/Lexical/Roots/Basic.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Lexical.Roots.Signature
+import Linglib.Semantics.Lexical.Roots.OutcomeCardinality
 
 /-!
 # Atomic Lexical Entailments and Roots
@@ -79,6 +80,10 @@ end LexEntailment
 structure Root where
   name : String
   entailments : Finset LexEntailment
+  /-- The outcome-set cardinality the root encodes ([bhadra-2024]): the axis
+      orthogonal to the `featureSignature` (derived from `entailments`). `none`
+      where the root has not been annotated for outcomes. -/
+  outcomes : Option Semantics.Lexical.OutcomeCardinality := none
   deriving DecidableEq
 
 namespace Root

--- a/Linglib/Semantics/Lexical/Roots/OutcomeCardinality.lean
+++ b/Linglib/Semantics/Lexical/Roots/OutcomeCardinality.lean
@@ -1,0 +1,79 @@
+import Mathlib.Order.Basic
+import Mathlib.Data.Set.Subsingleton
+
+/-!
+# Outcome cardinality
+
+The cardinality *tier* of a verb root's outcome set ([bhadra-2024], eq. 62): the
+light invariant of what a root encodes along the outcome axis — `empty` (no
+change specified), `singleton` (a single lexically-specified result — change-of-
+state and impingement roots), or `multi` (potential-for-change roots). Only the
+tier, not an exact count, is grammatically load-bearing, so this is a
+three-element linear order rather than `ℕ∞`.
+
+Factored out from `Roots/Outcomes.lean` (which carries the heavy event-relative
+machinery — `res`/`pre`, `VerbOutcomes`) so that `Root` itself can carry the
+outcome axis without depending on `Event`/`EventRel`.
+
+## Main definitions
+
+* `OutcomeCardinality` — the `empty < singleton < multi` tier
+* `OutcomeCardinality.ofSet` — the tier of a concrete outcome set
+
+## References
+
+* [bhadra-2024] (roots encode outcome sets; the eq. 62 hierarchy)
+-/
+
+namespace Semantics.Lexical
+
+/-- The cardinality tier of an outcome set ([bhadra-2024], eq. 62). -/
+inductive OutcomeCardinality where
+  | empty
+  | singleton
+  | multi
+  deriving Repr, BEq
+
+namespace OutcomeCardinality
+
+/-- Rank embedding into `ℕ`, giving the `empty < singleton < multi` order. -/
+def toNat : OutcomeCardinality → ℕ
+  | .empty => 0
+  | .singleton => 1
+  | .multi => 2
+
+theorem toNat_injective : Function.Injective toNat := by
+  intro a b h; cases a <;> cases b <;> simp_all [toNat]
+
+instance : LinearOrder OutcomeCardinality := LinearOrder.lift' toNat toNat_injective
+
+theorem empty_lt_singleton : empty < singleton := by decide
+theorem singleton_lt_multi : singleton < multi := by decide
+
+/-- The tier of a concrete outcome set: multi-membered iff `Nontrivial`,
+    empty iff there is no outcome, singleton otherwise. -/
+noncomputable def ofSet {State : Type*} (O : Set State) : OutcomeCardinality :=
+  open Classical in
+  if O.Nontrivial then .multi else if O.Nonempty then .singleton else .empty
+
+variable {State : Type*} {O : Set State}
+
+theorem ofSet_eq_multi (h : O.Nontrivial) : ofSet O = .multi := by
+  rw [ofSet, if_pos h]
+
+theorem ofSet_eq_singleton (hne : O.Nonempty) (hnt : ¬ O.Nontrivial) :
+    ofSet O = .singleton := by
+  rw [ofSet, if_neg hnt, if_pos hne]
+
+theorem ofSet_eq_empty (h : ¬ O.Nonempty) : ofSet O = .empty := by
+  rw [ofSet, if_neg (fun hnt => h hnt.nonempty), if_neg h]
+
+@[simp] theorem ofSet_singleton (s : State) : ofSet ({s} : Set State) = .singleton :=
+  ofSet_eq_singleton ⟨s, rfl⟩ (by rw [Set.not_nontrivial_iff]; exact Set.subsingleton_singleton)
+
+@[simp] theorem ofSet_empty : ofSet (∅ : Set State) = .empty :=
+  ofSet_eq_empty (by simp)
+
+end OutcomeCardinality
+
+end Semantics.Lexical

--- a/Linglib/Semantics/Lexical/Roots/Outcomes.lean
+++ b/Linglib/Semantics/Lexical/Roots/Outcomes.lean
@@ -1,96 +1,36 @@
+import Linglib.Semantics.Lexical.Roots.OutcomeCardinality
 import Linglib.Semantics.Events.Basic
 import Linglib.Semantics.ArgumentStructure.Defs
 
 /-!
-# Root outcomes
+# Root outcomes — event-relative machinery
+
+The heavy, event-relative half of the outcome substrate: the boundary operators
+`res`/`pre` and the outcome-bearing carrier `VerbOutcomes`. The light cardinality
+invariant (`OutcomeCardinality`) lives in `Roots/OutcomeCardinality.lean` so that
+`Root` can carry the outcome axis without depending on `Event`/`EventRel`.
 
 A verb root lexically encodes the **set of outcomes** its object can be in after
-the action — the dimension [bhadra-2024] adds to root semantics, distinct from
+the action — the dimension [bhadra-2024] adds to root semantics, orthogonal to
 the manner/result/cause kinds of [beavers-koontz-garboden-2020]'s
-`Root.FeatureSignature`. Two roots with identical feature signatures can carry
-different outcome sets (*bend* vs *break*), so this is a genuinely orthogonal
-axis of what a root encodes.
-
-This file is the substrate: the cardinality invariant, the boundary operators,
-and the outcome-bearing carrier. Affix semantics built on top (reversative
-*un-*, restitutive *re-*/*again*) live in the consuming study files.
+`Root.FeatureSignature` (*bend* and *break* share a signature, differ in
+outcomes).
 
 ## Main definitions
 
-* `OutcomeCardinality` — the `empty < singleton < multi` tier of an outcome set
-  (the light invariant; [bhadra-2024]'s eq. 62 hierarchy)
-* `OutcomeCardinality.ofSet` — the tier of a concrete outcome set
 * `resState` / `preState` — an object's state at the right / left boundary of an
   event ([bhadra-2024], eqs. 64–65)
 * `VerbOutcomes` — an outcome-bearing predicate: base predicate, outcome set,
-  threshold set
+  threshold set; `VerbOutcomes.cardinality` reads off its `OutcomeCardinality`
 
 ## References
 
 * [bhadra-2024] (roots encode outcome sets)
-* [beavers-koontz-garboden-2020] (the orthogonal manner/result/cause axis)
 -/
 
 namespace Semantics.Lexical
 
 open Semantics.ArgumentStructure (EventRel)
-
-/-! ### Outcome cardinality (the light invariant)
-
-The cardinality *tier* of a root's outcome set: empty (no-change-specified
-roots), singleton (a single lexically-specified result — change-of-state and
-impingement roots), or multi-membered (potential-for-change roots). Only the
-tier — not an exact count — is grammatically load-bearing, so this is a
-three-element linear order rather than `ℕ∞`. -/
-
-/-- The cardinality tier of an outcome set ([bhadra-2024], eq. 62). -/
-inductive OutcomeCardinality where
-  | empty
-  | singleton
-  | multi
-  deriving Repr, BEq
-
-namespace OutcomeCardinality
-
-/-- Rank embedding into `ℕ`, giving the `empty < singleton < multi` order. -/
-def toNat : OutcomeCardinality → ℕ
-  | .empty => 0
-  | .singleton => 1
-  | .multi => 2
-
-theorem toNat_injective : Function.Injective toNat := by
-  intro a b h; cases a <;> cases b <;> simp_all [toNat]
-
-instance : LinearOrder OutcomeCardinality := LinearOrder.lift' toNat toNat_injective
-
-theorem empty_lt_singleton : empty < singleton := by decide
-theorem singleton_lt_multi : singleton < multi := by decide
-
-/-- The tier of a concrete outcome set: multi-membered iff `Nontrivial`,
-    empty iff there is no outcome, singleton otherwise. -/
-noncomputable def ofSet {State : Type*} (O : Set State) : OutcomeCardinality :=
-  open Classical in
-  if O.Nontrivial then .multi else if O.Nonempty then .singleton else .empty
-
-variable {State : Type*} {O : Set State}
-
-theorem ofSet_eq_multi (h : O.Nontrivial) : ofSet O = .multi := by
-  rw [ofSet, if_pos h]
-
-theorem ofSet_eq_singleton (hne : O.Nonempty) (hnt : ¬ O.Nontrivial) :
-    ofSet O = .singleton := by
-  rw [ofSet, if_neg hnt, if_pos hne]
-
-theorem ofSet_eq_empty (h : ¬ O.Nonempty) : ofSet O = .empty := by
-  rw [ofSet, if_neg (fun hnt => h hnt.nonempty), if_neg h]
-
-@[simp] theorem ofSet_singleton (s : State) : ofSet ({s} : Set State) = .singleton :=
-  ofSet_eq_singleton ⟨s, rfl⟩ (by rw [Set.not_nontrivial_iff]; exact Set.subsingleton_singleton)
-
-@[simp] theorem ofSet_empty : ofSet (∅ : Set State) = .empty :=
-  ofSet_eq_empty (by simp)
-
-end OutcomeCardinality
 
 /-! ### Event boundaries (eqs. 64–65)
 

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -42,17 +42,17 @@ namespace BeaversKoontzGarboden2020
 /-! ### The six representative roots -/
 
 /-- √flat — pure state. -/
-def flat : Root := ⟨"flat", {.hasState "flat"}⟩
+def flat : Root := ⟨"flat", {.hasState "flat"}, none⟩
 
 /-- √jog — pure manner of motion. -/
-def jog : Root := ⟨"jog", {.hasManner "jogging-gait", .motion}⟩
+def jog : Root := ⟨"jog", {.hasManner "jogging-gait", .motion}, none⟩
 
 /-- √blossom — result with no specified manner or cause (an
     internally caused change of state). -/
-def blossom : Root := ⟨"blossom", {.becomesState "flowering"}⟩
+def blossom : Root := ⟨"blossom", {.becomesState "flowering"}, none⟩
 
 /-- √crack — caused result without specified manner. -/
-def crack : Root := ⟨"crack", {.becomesState "fissured", .hasCause}⟩
+def crack : Root := ⟨"crack", {.becomesState "fissured", .hasCause}, none⟩
 
 /-- √hand — manner + cause + result, adjoined position. The
     possession result is non-cancelable ("#Mary handed John the book,
@@ -61,13 +61,13 @@ def crack : Root := ⟨"crack", {.becomesState "fissured", .hasCause}⟩
 def hand : Root := ⟨"hand",
   {.hasManner "by-hand-transfer",
    .becomesState "in-recipient-possession",
-   .hasCause}⟩
+   .hasCause}, none⟩
 
 /-- √drown — manner of killing (Levin 1993's *crucify, drown, hang,
     electrocute* class; [beavers-koontz-garboden-2020] ch. 4):
     manner + cause + result, complement position. -/
 def drown : Root := ⟨"drown",
-  {.hasManner "submersion-in-liquid", .becomesState "dead", .hasCause}⟩
+  {.hasManner "submersion-in-liquid", .becomesState "dead", .hasCause}, none⟩
 
 /-! ### Feature signatures
 


### PR DESCRIPTION
Phase 2a of the Verb API redesign: the lexical-content axis lands on `Root` (the existing entailment-based content carrier), not a parallel struct.

- Split `OutcomeCardinality` (enum + order + `ofSet`) into its own light file so `Root` can carry it without `Event`/`EventRel` deps; `Outcomes.lean` keeps `res`/`pre`/`VerbOutcomes`.
- `Root` gains `outcomes : Option OutcomeCardinality := none` (the [bhadra-2024] axis orthogonal to the derived `featureSignature`).
- `Root.changeType` derived from the signature + `changeType_ignores_outcomes` — the manner/result projection is blind to the outcome axis (why it's an independent dimension).
- Migrate the 35 positional `Root` literals for the new field.