### PR TITLE
feat(Semantics/Quantification): square diagonals onto Aristotelian hub

### DIFF
--- a/Linglib/Semantics/Quantification/Basic.lean
+++ b/Linglib/Semantics/Quantification/Basic.lean
@@ -137,14 +137,14 @@ theorem innerNeg_every_eq_no :
 /-- The dual of `every` is `some`: Q̌(every) = some. -/
 theorem dualQ_every_eq_some :
     (dualQ (every_sem (α := α)) : GQ α) = (some_sem (α := α) : GQ α) := by
-  funext R S; simp only [dualQ, outerNeg, innerNeg, every_sem, some_sem]
+  funext R S; simp only [dualQ, outerNeg_apply, innerNeg, every_sem, some_sem]
   exact propext ⟨fun h => by push_neg at h; exact h,
                  fun ⟨x, hR, hS⟩ h => h x hR hS⟩
 
 /-- `outerNeg ⟦some⟧ = ⟦no⟧`: negating existence gives universal negation. -/
 theorem outerNeg_some_eq_no :
     (outerNeg (some_sem (α := α)) : GQ α) = (no_sem (α := α) : GQ α) := by
-  funext R S; simp only [outerNeg, some_sem, no_sem]
+  funext R S; simp only [outerNeg_apply, some_sem, no_sem]
   exact propext ⟨fun h x hR hS => h ⟨x, hR, hS⟩,
                  fun h ⟨x, hR, hS⟩ => h x hR hS⟩
 
@@ -227,12 +227,21 @@ theorem every_filtrating : Filtrating (every_sem (α := α)) := by
 
 /-! ### Aristotelian square of opposition
 
-The six theorems below establish the four Aristotelian relations among GQ
-denotations `(every_sem, some_sem, no_sem, outerNeg every_sem)` at fixed
-restrictor `R`. They work over `Prop`-valued predicates, while
-`Core.Logic.Aristotelian.Basic` formulates the same relations over
-`Bool`-valued predicates. The two frameworks are mathematically equivalent
-but type-different. -/
+The four Aristotelian relations among GQ denotations `(every_sem, some_sem, no_sem,
+outerNeg every_sem)` at a fixed restrictor `R`, where the corners are elements of the
+Pi-instance Boolean algebra `(α → Prop) → Prop`.
+
+The **contradictory** diagonals are placed on the `Aristotelian` hub by construction:
+since `outerNeg = ᶜ` (`Defs.outerNeg`), every quantifier is `Aristotelian.IsContradictory`
+to its outer negation — `isContradictory_outerNeg`, which is just `isCompl_compl` — and the
+A–O and E–I diagonals are instances. The pointwise `↔`-form theorems
+(`every_contradicts_notEvery`, `no_contradicts_some`) are the unfolded readings.
+
+**Contrariety** and **subalternation** are *not* hub relations: they hold only under
+existential import (non-empty restrictor) and are `|R|`-sensitive — at a singleton `R`,
+`every`/`no` are contradictory, not contrary — so the unconditional `IsContrary`/`IsSubaltern`
+do not apply. They stay as the conditional theorems (`a_e_contrary`, `subalternation_a_i`, …),
+the faithful Aristotelian-vs-Boolean existential-import treatment. -/
 
 /-- Contradiction (A vs O): the A-form and O-form are contradictories. -/
 theorem every_contradicts_notEvery (R S : α → Prop) :
@@ -275,21 +284,29 @@ theorem subcontrariety_i_o (R S : α → Prop)
   · right; intro hA; apply h
     obtain ⟨x, hRx⟩ := hR; exact ⟨x, hRx, hA x hRx⟩
 
-/-- The canonical A↔O contradiction diagonal, packaged as
-    `Aristotelian.IsContradictory` over the Pi-instance Boolean algebra
-    on `(α → Prop) → Prop`. -/
+/-- Every quantifier is `Aristotelian.IsContradictory` to its outer negation: the Boolean
+    complement law `isCompl_compl` on the Pi-instance Boolean algebra `(α → Prop) → Prop`
+    (where `outerNeg = ᶜ`). The square's contradictory diagonals are instances — this is the
+    "single home" for the diagonals, by construction rather than re-derivation. -/
+theorem isContradictory_outerNeg (q : GQ α) (R : α → Prop) :
+    Aristotelian.IsContradictory ((q R) : (α → Prop) → Prop) (outerNeg q R) :=
+  isCompl_compl
+
+/-- A–O diagonal: `every` and `not-every` are contradictory. -/
 theorem every_satisfies_isContradictory_pointwise (R : α → Prop) :
     Aristotelian.IsContradictory
       ((every_sem (α := α) R) : (α → Prop) → Prop)
-      (outerNeg (every_sem (α := α)) R) := by
-  unfold Aristotelian.IsContradictory
-  rw [isCompl_iff, disjoint_iff, codisjoint_iff]
-  refine ⟨?_, ?_⟩
-  · funext S
-    exact propext ⟨fun ⟨h1, h2⟩ => h2 h1, fun h => h.elim⟩
-  · funext S
-    exact propext ⟨fun _ => trivial, fun _ =>
-      (Classical.em (every_sem (α := α) R S)).elim Or.inl Or.inr⟩
+      (outerNeg (every_sem (α := α)) R) :=
+  isContradictory_outerNeg _ R
+
+/-- E–I diagonal: `no` and `some` are contradictory, since `some = ~no`. -/
+theorem no_satisfies_isContradictory_pointwise (R : α → Prop) :
+    Aristotelian.IsContradictory
+      ((no_sem (α := α) R) : (α → Prop) → Prop)
+      (some_sem (α := α) R) := by
+  have hno : outerNeg (no_sem (α := α)) = some_sem := by
+    rw [← innerNeg_every_eq_no]; exact dualQ_every_eq_some
+  rw [← hno]; exact isContradictory_outerNeg _ R
 
 /-! ### Basic left monotonicities ([peters-westerstahl-2006] §5.5) -/
 

--- a/Linglib/Semantics/Quantification/Counting.lean
+++ b/Linglib/Semantics/Quantification/Counting.lean
@@ -243,7 +243,7 @@ theorem some_eq_at_least_1 :
 theorem at_most_eq_outerNeg_at_least_succ (n : Nat) :
     (at_most_n_sem (α := α) n : GQ α) =
     (outerNeg (at_least_n_sem (α := α) (n + 1)) : GQ α) := by
-  funext R S; simp only [at_most_n_sem, at_least_n_sem, outerNeg]
+  funext R S; simp only [at_most_n_sem, at_least_n_sem, outerNeg_apply]
   exact propext ⟨fun h hGe => by omega, fun h => by omega⟩
 
 /-- `⟦no⟧ = ⟦at most 0⟧`. -/
@@ -501,7 +501,7 @@ theorem quantity_of_quantityInvariant (q : GQ α)
 theorem quantity_outerNeg (q : GQ α) (h : Quantity q) :
     Quantity (outerNeg q) := by
   intro R₁ S₁ R₂ S₂ hTT hTF hFT hFF
-  simp only [outerNeg]; exact Iff.not (h R₁ S₁ R₂ S₂ hTT hTF hFT hFF)
+  simp only [outerNeg_apply]; exact Iff.not (h R₁ S₁ R₂ S₂ hTT hTF hFT hFF)
 
 theorem quantity_gqMeet (q₁ q₂ : GQ α)
     (h₁ : Quantity q₁) (h₂ : Quantity q₂) :

--- a/Linglib/Semantics/Quantification/Defs.lean
+++ b/Linglib/Semantics/Quantification/Defs.lean
@@ -1,6 +1,7 @@
 import Mathlib.Order.Lattice
 import Mathlib.Order.Monotone.Defs
 import Mathlib.Order.Sublattice
+import Mathlib.Order.BooleanAlgebra.Basic
 import Linglib.Core.Logic.NaturalLogic
 import Linglib.Core.Logic.Truth3
 
@@ -312,10 +313,13 @@ def QuantityInvariant (q : GQ α) : Prop :=
 
 /-! #### Duality (B&C §4.11) -/
 
-/-- Outer negation: `(~Q)(A,B) = ¬Q(A,B)` (B&C §4.11).
+/-- Outer negation: `(~Q)(A,B) = ¬Q(A,B)` (B&C §4.11). This is exactly the Boolean
+    complement on the pointwise Boolean algebra `GQ α`, named for the linguistic
+    duality square (it pairs with the non-Boolean `innerNeg`/`dualQ`).
     Example: ~every = not-every ("Not every student passed"). -/
-def outerNeg (q : GQ α) : GQ α :=
-  fun R S => ¬ q R S
+def outerNeg (q : GQ α) : GQ α := qᶜ
+
+@[simp] theorem outerNeg_apply (q : GQ α) (R S : α → Prop) : outerNeg q R S = ¬ q R S := rfl
 
 /-- Inner negation: `(Q~)(A,B) = Q(A, ¬B)` (B&C §4.11).
     Example: every~ = every...not ("Every student didn't pass"). -/

--- a/Linglib/Semantics/Quantification/Lindstrom.lean
+++ b/Linglib/Semantics/Quantification/Lindstrom.lean
@@ -262,7 +262,7 @@ iso-invariant class to GQ outer negation: `(¬Q).toGQ = outerNeg Q.toGQ`
 diagonal as `Quantification.every_contradicts_notEvery`. -/
 theorem toGQ_compl (Q : Det.{u}) (α : Type u) : Det.toGQ Q.compl α = outerNeg (Q.toGQ α) := by
   funext A B
-  simp only [Det.toGQ, LindstromQuantifier.compl_holds, Set.mem_compl_iff, outerNeg]
+  simp only [Det.toGQ, LindstromQuantifier.compl_holds, Set.mem_compl_iff, outerNeg_apply]
 
 /-- The `E` corner: `no` realizes the inner negation of `every` (`every…not = no`). -/
 theorem noDet_toGQ_eq_innerNeg (α : Type u) :

--- a/Linglib/Semantics/Quantification/Properties.lean
+++ b/Linglib/Semantics/Quantification/Properties.lean
@@ -70,7 +70,7 @@ theorem dualQ_involution (q : GQ α) : dualQ (dualQ q) = q := by
 theorem quantityInvariant_outerNeg (q : GQ α)
     (h : QuantityInvariant q) : QuantityInvariant (outerNeg q) := by
   intro A B A' B' f hBij hA hB
-  simp only [outerNeg, not_iff_not]
+  simp only [outerNeg_apply, not_iff_not]
   exact h A B A' B' f hBij hA hB
 
 /-- Inner negation preserves QuantityInvariant: if Q is bijection-invariant,
@@ -421,7 +421,7 @@ theorem symmetric_iff_upSW_downNE (q : GQ α) (hCons : Conservative q) :
 /-- Conservativity is closed under complement. -/
 theorem conservative_outerNeg (q : GQ α) (h : Conservative q) :
     Conservative (outerNeg q) := by
-  intro R S; simp only [outerNeg, not_iff_not]; exact h R S
+  intro R S; simp only [outerNeg_apply, not_iff_not]; exact h R S
 
 /-- Conservativity is closed under meet. -/
 theorem conservative_gqMeet (f g : GQ α)


### PR DESCRIPTION
Grounds `outerNeg` as the Boolean complement `ᶜ` on `GQ α` (pointwise `@[simp] outerNeg_apply`), and places the square of opposition's contradictory diagonals on the `Aristotelian` hub by construction: `isContradictory_outerNeg` (= `isCompl_compl`) replaces the hand-rolled `isCompl_iff`/`disjoint_iff`/`codisjoint_iff` re-derivation, yielding the A–O (`every`/`not-every`) and E–I (`no`/`some`) diagonals. Contrariety/subalternation correctly stay as conditional theorems — they need existential import and are |R|-sensitive, so they are not unconditional hub relations. `gqMeet`/`gqJoin` → `⊓`/`⊔` retirement follows as a separate cleanup.