### PR TITLE
feat(Semantics/Verb): carry root via Verb.root + content accessors

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -177,6 +177,7 @@ import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
 import Linglib.Semantics.Verb.Defs
 import Linglib.Semantics.Verb.Basic
 import Linglib.Semantics.Verb.Denotation
+import Linglib.Semantics.Verb.RootContent
 import Linglib.Core.Logic.NaturalLogic
 import Linglib.Core.Optimization.Profile
 import Linglib.Phonology.Constraint.Weighted

--- a/Linglib/Semantics/Lexical/Roots/Basic.lean
+++ b/Linglib/Semantics/Lexical/Roots/Basic.lean
@@ -88,6 +88,12 @@ structure Root where
   outcomes : Option OutcomeCardinality := none
   deriving DecidableEq
 
+/-- `Repr`/`BEq` from the data + `DecidableEq` (the `Finset` field blocks deriving
+    either); needed so `Verb` can carry `root : Option Verb.Root` and still derive
+    `Repr`/`BEq`. -/
+instance : Repr Root := ⟨fun r _ => repr r.name⟩
+instance : BEq Root := ⟨fun a b => decide (a = b)⟩
+
 namespace Root
 
 /-- The derived feature signature of a root: the set of kinds its

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -13,6 +13,7 @@ import Linglib.Semantics.Causation.Psych
 import Linglib.Semantics.Aspect.DegreeAchievement
 import Linglib.Semantics.Aspect.Incremental
 import Linglib.Semantics.Lexical.LevinClassProfiles
+import Linglib.Semantics.Lexical.Roots.Basic
 import Linglib.Semantics.Lexical.Roots.Profile
 
 /-! # Verb entry — core type
@@ -258,6 +259,11 @@ structure Attitude where
 
 end Verb
 
+section
+-- Open the `Verb` namespace so the `root` field below resolves `Root` as
+-- `Verb.Root`: inside the `structure Verb` body the `Verb` *type* shadows the
+-- `Verb` *namespace*, so a bare `Verb.Root` mis-parses as a field projection.
+open _root_.Verb
 /--
 Cross-linguistic verb core: all semantic fields shared across languages.
 
@@ -274,6 +280,12 @@ structure Verb extends
   /-- Root-specific quality dimensions (within-class variation;
       [spalek-mcnally-2026]). -/
   rootProfile : Option Verb.Root.Profile := none
+  /-- The verb's lexical root — its entailment atoms, derived B&KG feature
+      signature, and [bhadra-2024] outcome axis. The content carrier the Verb
+      API integrates around (P-HUB): when present, the verb's signature / outcome
+      / change-type are read off *this* root rather than the `levinClass` table.
+      `none` until a Fragment annotates it. -/
+  root : Option Root := none
   /-- Citation form (cross-linguistic) -/
   form : String
   /-- Does the verb denote the performance of an illocutionary act?
@@ -284,3 +296,5 @@ structure Verb extends
       Most verbs use `.default`; polysemous entries use descriptive tags. -/
   senseTag : SenseTag := .default
   deriving Repr, BEq
+
+end

--- a/Linglib/Semantics/Verb/RootContent.lean
+++ b/Linglib/Semantics/Verb/RootContent.lean
@@ -1,0 +1,64 @@
+import Linglib.Semantics.Verb.Basic
+import Linglib.Morphology.RootTypology
+
+/-!
+# Verb ↔ root content accessors
+
+The integration seam (P-HUB) between a `Verb` and the root it carries
+(`Verb.root : Option Verb.Root`): a verb's B&KG feature signature, [bhadra-2024]
+outcome cardinality, and change-entailment type are read off *its own root* when
+present, falling back to its Levin class only for the signature (the per-class
+outcome assignment is a Study-level claim, so there is no Levin fallback for
+outcomes).
+
+`RootType` and `Verb.Root.changeType` live in `Morphology/RootTypology.lean`, so
+these accessors (which mention them) live here rather than in `Verb/Basic.lean`.
+
+## Main definitions
+
+* `Verb.featureSignature` — the verb's entailment-kind signature (root, else Levin)
+* `Verb.outcomes` — the verb's outcome-set cardinality (root only)
+* `Verb.changeType` — the verb's change-entailment type (derived from its root)
+-/
+
+open Verb
+open Semantics.Lexical
+
+/-- The verb's B&KG feature signature: from its annotated `root` if present, else
+    its Levin class's signature ([levin-1993] fallback, via `rootEntailments`). -/
+def Verb.featureSignature (v : Verb) : Option Verb.Root.FeatureSignature :=
+  v.root.map (·.featureSignature) <|> v.levinClass.map LevinClass.rootEntailments
+
+/-- The verb's outcome-set cardinality ([bhadra-2024]), read off its `root`. No
+    Levin fallback: the per-class outcome assignment is a Study-level claim. -/
+def Verb.outcomes (v : Verb) : Option Verb.OutcomeCardinality :=
+  v.root.bind (·.outcomes)
+
+/-- The verb's change-entailment type ([beavers-etal-2021]), derived from its
+    root's feature signature. -/
+def Verb.changeType (v : Verb) : Option RootType :=
+  v.root.map Verb.Root.changeType
+
+/-- A verb's `changeType` is blind to its root's outcome axis (it factors through
+    `Verb.Root.changeType`): verbs whose roots share entailments share a
+    `changeType` whatever their outcomes — the verb-level lift of the root
+    orthogonality, and why outcome cardinality is an independent dimension. -/
+theorem Verb.changeType_ignores_outcomes {v v' : Verb} {r r' : Verb.Root}
+    (hr : v.root = some r) (hr' : v'.root = some r')
+    (h : r.entailments = r'.entailments) : v.changeType = v'.changeType := by
+  unfold Verb.changeType
+  rw [hr, hr']
+  exact congrArg some (Verb.Root.changeType_ignores_outcomes h)
+
+/-- The verb's outcome cardinality is exactly its root's, when annotated. -/
+@[simp] theorem Verb.outcomes_root {v : Verb} {r : Verb.Root} (hr : v.root = some r) :
+    v.outcomes = r.outcomes := by
+  unfold Verb.outcomes; rw [hr]; rfl
+
+/-- End-to-end (P-HUB): for any verb, reading its `changeType` off a root and off
+    the same-entailment root with a different outcome cardinality agree — only the
+    outcome axis distinguishes them. -/
+example (v : Verb) :
+    ({ v with root := some ⟨"r", ∅, some .multi⟩ }).changeType
+      = ({ v with root := some ⟨"r", ∅, some .singleton⟩ }).changeType :=
+  Verb.changeType_ignores_outcomes rfl rfl rfl


### PR DESCRIPTION
Adds `root : Option Verb.Root` to `Verb`, plus `featureSignature`/`outcomes`/`changeType` accessors reading a verb's content off its own root (Levin-class fallback only for the signature). The keystone the LevinClass demotion and Bhadra de-duplication build on.