### PR TITLE
refactor(Semantics/Quantification): ground gqMeet/gqJoin as ⊓/⊔

### DIFF
--- a/Linglib/Semantics/Quantification/Counting.lean
+++ b/Linglib/Semantics/Quantification/Counting.lean
@@ -187,7 +187,7 @@ theorem both_conservative : Conservative (both_sem (α := α)) := by
   intro R S; simp only [both_sem]; rw [every_conservative R S]
 
 theorem neither_conservative : Conservative (neither_sem (α := α)) := by
-  intro R S; simp only [neither_sem, gqMeet]; rw [no_conservative R S]
+  intro R S; simp only [neither_sem, gqMeet_apply]; rw [no_conservative R S]
 
 theorem at_least_n_conservative (n : Nat) :
     Conservative (at_least_n_sem (α := α) n) := by
@@ -255,7 +255,7 @@ theorem no_eq_at_most_0 :
 theorem exactly_eq_meet_at_least_at_most (n : Nat) :
     (exactly_n_sem (α := α) n : GQ α) =
     (gqMeet (at_least_n_sem (α := α) n) (at_most_n_sem (α := α) n) : GQ α) := by
-  funext R S; simp only [exactly_n_sem, at_least_n_sem, at_most_n_sem, gqMeet]
+  funext R S; simp only [exactly_n_sem, at_least_n_sem, at_most_n_sem, gqMeet_apply]
   exact propext ⟨fun h => ⟨by omega, by omega⟩, fun ⟨h1, h2⟩ => by omega⟩
 
 /-- `⟦all but 0⟧ = ⟦every⟧`. -/

--- a/Linglib/Semantics/Quantification/Defs.lean
+++ b/Linglib/Semantics/Quantification/Defs.lean
@@ -333,16 +333,22 @@ def dualQ (q : GQ α) : GQ α :=
 
 /-! #### Boolean algebra (K&S §2.3) -/
 
-/-- Meet of two GQ denotations: (f ∧ g)(A,B) = f(A,B) ∧ g(A,B).
+/-- Meet of two GQ denotations: determiner conjunction. This is the meet `⊓` on the
+    pointwise Boolean algebra `GQ α`, named for the linguistic operation.
     K&S (20): conjunction of dets, e.g., "both John's and Mary's".
     Also: "between n and m" = (at least n) ∧ (at most m). -/
-def gqMeet (f g : GQ α) : GQ α :=
-  fun R S => f R S ∧ g R S
+def gqMeet (f g : GQ α) : GQ α := f ⊓ g
 
-/-- Join of two GQ denotations: (f ∨ g)(A,B) = f(A,B) ∨ g(A,B).
+@[simp] theorem gqMeet_apply (f g : GQ α) (R S : α → Prop) :
+    gqMeet f g R S = (f R S ∧ g R S) := rfl
+
+/-- Join of two GQ denotations: determiner disjunction. This is the join `⊔` on the
+    pointwise Boolean algebra `GQ α`.
     K&S (24): disjunction of dets, e.g., "either John's or Mary's". -/
-def gqJoin (f g : GQ α) : GQ α :=
-  fun R S => f R S ∨ g R S
+def gqJoin (f g : GQ α) : GQ α := f ⊔ g
+
+@[simp] theorem gqJoin_apply (f g : GQ α) (R S : α → Prop) :
+    gqJoin f g R S = (f R S ∨ g R S) := rfl
 
 /-- Restriction of a GQ by a restricting function (adjective/relative clause).
     K&S (66): h_f(s) = h(f(s)). In our representation, the adjective


### PR DESCRIPTION
Defines `gqMeet`/`gqJoin` (K&S determiner conjunction/disjunction) as the pointwise Boolean-algebra `⊓`/`⊔` on `GQ α`, keeping the linguistic names with `@[simp] gqMeet_apply`/`gqJoin_apply` for the `∧`/`∨` form. Completes the GQ Boolean-algebra convergence begun with `outerNeg = ᶜ` (#390); the ~40 existing `gqMeet`/`gqJoin` references stay valid since the names are kept, so only 2 simp-unfold sites changed.