### PR TITLE
refactor(Semantics/Verb): fold rootProfile into Verb.Root.profile

### DIFF
--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -129,11 +129,11 @@ def run : VerbEntry where
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .mannerOfMotion
-  rootProfile := some {
+  root := some { profile := {
     forceMag := some [.moderate]
     agentVolition := some [.volitional]
     agentControl := some [.compatible]
-  }
+  } }
 
 /-- "arrive" — unaccusative intransitive -/
 def arrive : VerbEntry := .mkRegular {
@@ -159,11 +159,11 @@ def eat : VerbEntry where
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .eat
-  rootProfile := some {
+  root := some { profile := {
     forceMag := some [.low, .moderate]
     agentVolition := some [.volitional]
     agentControl := some [.compatible]
-  }
+  } }
 
 /-- "kick" — transitive -/
 def kick : VerbEntry := .mkRegular {
@@ -173,12 +173,12 @@ def kick : VerbEntry := .mkRegular {
   objectEntailments := some ⟨false, false, false, false, false, true, false, true, true, false⟩
   vendlerClass := some .activity
   levinClass := some .hit
-  rootProfile := some {
+  root := some { profile := {
     forceMag := some [.moderate, .high]
     forceDir := some [.unidirectional]
     agentVolition := some [.neutral, .volitional]
     agentControl := some [.neutral, .compatible]
-  } }
+  } } }
 
 /-- "give" — ditransitive, alternates DOC/PP.
     Implicit goal is definite ([fillmore-1986]: pragmatically recoverable).
@@ -801,11 +801,11 @@ def kill : VerbEntry := .mkRegular {
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .murder
-  rootProfile := some {
+  root := some { profile := {
     resultType := some [.totalDestruction]
     agentVolition := some [.neutral, .volitional]
     agentControl := some [.neutral, .compatible]
-  } }
+  } } }
 
 /-- "break" — thick lexical causative (Levin 45.1 Break Verbs; [embick-2009] break-class).
     Pure change-of-state verb: change in "material integrity"
@@ -821,7 +821,7 @@ def break_ : VerbEntry where
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .break_
-  rootProfile := some {
+  root := some { profile := {
     forceMag := some [.moderate, .high]
     -- forceDir unconstrained: *break* covers snapping (bidirectional),
     -- hammering (omnidirectional), and directed blows (unidirectional)
@@ -830,7 +830,7 @@ def break_ : VerbEntry where
     agentControl := some [.incompatible, .neutral]
     -- break is unspecified for instrument and object dimensionality
     -- ([majid-boster-bowerman-2008]: Dim 1 low predictability)
-  }
+  } }
 
 /-- "tear" — Levin 45.1 Break Verbs. Contrary-direction separation with force.
     Unlike *break*, *tear* implies a specific directionality (bidirectional /
@@ -851,7 +851,7 @@ def tear_ : VerbEntry where
   verbIncClass := some .sinc
   causative := some .make
   levinClass := some .break_
-  rootProfile := some {
+  root := some { profile := {
     forceMag := some [.moderate, .high]
     forceDir := some [.bidirectional, .unidirectional]
     patientRob := some [.flimsy, .moderate, .robust]
@@ -859,7 +859,7 @@ def tear_ : VerbEntry where
     agentControl := some [.neutral, .compatible]
     instrumentType := some [.hands]
     patientDim := some [.twoD]
-  }
+  } }
 
 -- ════════════════════════════════════════════════════
 -- § Physical Disturbance CoS Verbs ([tham-2025])
@@ -931,13 +931,13 @@ def burn : VerbEntry := .mkRegular {
   verbIncClass := some .sinc
   causative := some .make
   levinClass := some .otherCoS
-  rootProfile := some {
+  root := some { profile := {
     forceMag := some [.moderate, .high]
     patientRob := some [.flimsy, .moderate, .robust]
     resultType := some [.totalDestruction, .deformation]
     agentVolition := some [.neutral, .volitional]
     agentControl := some [.neutral, .compatible]
-  } }
+  } } }
 
 /-- "destroy" — thin lexical causative (result-only, no manner). -/
 def destroy : VerbEntry := .mkRegular {
@@ -946,11 +946,11 @@ def destroy : VerbEntry := .mkRegular {
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .destroy
-  rootProfile := some {
+  root := some { profile := {
     resultType := some [.totalDestruction]
     agentVolition := some [.neutral, .volitional]
     agentControl := some [.neutral, .compatible]
-  } }
+  } } }
 
 /-- "melt" — thick lexical causative (manner = by heat).
     Base transitive that productively takes DOC ("melt me some ice cream").
@@ -963,13 +963,13 @@ def melt : VerbEntry := .mkRegular {
   verbIncClass := some .sinc
   causative := some .make
   levinClass := some .otherCoS
-  rootProfile := some {
+  root := some { profile := {
     forceMag := some [.low, .moderate]
     patientRob := some [.moderate, .robust]
     resultType := some [.deformation]
     agentVolition := some [.neutral, .volitional]
     agentControl := some [.compatible]
-  } }
+  } } }
 
 -- ════════════════════════════════════════════════════
 -- § [martin-rose-nichols-2025] — Thick/Thin Causatives
@@ -1114,11 +1114,11 @@ def devour : VerbEntry := .mkRegular {
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .devour
-  rootProfile := some {
+  root := some { profile := {
     forceMag := some [.moderate, .high]
     agentVolition := some [.volitional]
     agentControl := some [.neutral]
-  } }
+  } } }
 
 /-- "read" — transitive, no presupposition -/
 def read : VerbEntry where
@@ -1175,12 +1175,12 @@ def sweep : VerbEntry where
   subjectEntailments := some ⟨false, false, false, true, true, false, false, false, false, false⟩
   passivizable := true
   levinClass := some .wipe
-  rootProfile := some {
+  root := some { profile := {
     forceMag := some [.low, .moderate]
     forceDir := some [.unidirectional]
     agentVolition := some [.volitional]
     agentControl := some [.compatible]
-  }
+  } }
 
 /-- "sweep" instrument sense — obligatorily agentive, broom lexicalized. -/
 def sweep_instr : VerbEntry where
@@ -1195,12 +1195,12 @@ def sweep_instr : VerbEntry where
   passivizable := true
   senseTag := .instrumental
   levinClass := some .wipe
-  rootProfile := some {
+  root := some { profile := {
     forceMag := some [.low, .moderate]
     forceDir := some [.unidirectional]
     agentVolition := some [.volitional]
     agentControl := some [.compatible]
-  }
+  } }
 
 -- ════════════════════════════════════════════════════
 -- § Verb Entries — Communication
@@ -2369,10 +2369,10 @@ def cut : VerbEntry where
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .cut
-  rootProfile := some {
+  root := some { profile := {
     resultType := some [.surfaceBreach]
     instrumentType := some [.sharpBlade]
-  }
+  } }
 
 /-- "chop" — Levin 21.2 Carve verbs. -/
 def chop : VerbEntry where

--- a/Linglib/Fragments/Mayan/Yukatek/Roots.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Roots.lean
@@ -67,22 +67,22 @@ open Verb
     feature in Yukatek (cf. `motion_roots_not_separate_class`); jumping
     qualifies as a manner-of-action irrespective of whether it
     incidentally involves displacement. -/
-def siit : Root := ⟨"siit'", {.hasManner "jumping"}, none⟩
+def siit : Root := ⟨"siit'", {.hasManner "jumping"}, none, {}⟩
 
 /-- ¢'iib "write" — manner-of-action activity ([lucy-1994] p. 628). -/
-def tziib : Root := ⟨"tziib", {.hasManner "writing"}, none⟩
+def tziib : Root := ⟨"tziib", {.hasManner "writing"}, none, {}⟩
 
 /-- mìis "sweep" — manner-of-action activity
     ([lucy-1994] agent-salient list). -/
-def miis : Root := ⟨"mìis", {.hasManner "sweeping"}, none⟩
+def miis : Root := ⟨"mìis", {.hasManner "sweeping"}, none, {}⟩
 
 /-- ć'eh "shout" — manner-of-action activity
     ([lucy-1994] agent-salient list). -/
-def cheh : Root := ⟨"ć'eh", {.hasManner "shouting"}, none⟩
+def cheh : Root := ⟨"ć'eh", {.hasManner "shouting"}, none, {}⟩
 
 /-- paak "weed" — manner-of-action activity
     ([lucy-1994] agent-salient list). -/
-def paak : Root := ⟨"paak", {.hasManner "weeding"}, none⟩
+def paak : Root := ⟨"paak", {.hasManner "weeding"}, none, {}⟩
 
 /-! ### Agent-patient salient roots (root transitives, take `=∅`)
 
@@ -98,79 +98,79 @@ root transitive a Manner/Result-Complementarity violator. -/
 /-- kuč "carry" — manner-of-action, lexically transitive
     ([lucy-1994] ex. 1b). Underived transitive; no derivation
     needed. -/
-def kuc : Root := ⟨"kuc", {.hasManner "carrying"}, none⟩
+def kuc : Root := ⟨"kuc", {.hasManner "carrying"}, none, {}⟩
 
 /-- p'is "measure" — manner-of-action, lexically transitive
     ([lucy-1994] p. 629). No entailed change of state. -/
-def pis : Root := ⟨"pis", {.hasManner "measuring"}, none⟩
+def pis : Root := ⟨"pis", {.hasManner "measuring"}, none, {}⟩
 
 /-- lo'š "punch" — manner-of-action, lexically transitive
     ([lucy-1994] p. 629). Surface-contact manner without entailed
     result, like B&K-G's *hit*-type. No `.contact` atom: contact is
     implicit in the manner of striking rather than a B&K-G feature in
     Lucy's typology. -/
-def los : Root := ⟨"los", {.hasManner "striking"}, none⟩
+def los : Root := ⟨"los", {.hasManner "striking"}, none, {}⟩
 
 -- ════════════════════════════════════════════════════
 -- § 3. Patient-Salient Roots (result only, take `=s`)
 -- ════════════════════════════════════════════════════
 
 /-- kíim "die" — spontaneous state change ([lucy-1994] ex. 1c, 2). -/
-def kiim : Root := ⟨"kiim", {.becomesState "dead"}, none⟩
+def kiim : Root := ⟨"kiim", {.becomesState "dead"}, none, {}⟩
 
 /-- háan "stop, cease, heal" ([lucy-1994] patient-salient list,
     p. 630, ex. 2). High-tone vowel: distinct from `Yukatek.haanEat`
     "eat" (low-tone `hàan`), which is `inactive`-class but
     internally caused — see `Fragments/Mayan/Yukatek/VerbClasses.lean`
     and [bohnemeyer-2004] ex. (9). -/
-def haanCease : Root := ⟨"háan", {.becomesState "stopped"}, none⟩
+def haanCease : Root := ⟨"háan", {.becomesState "stopped"}, none, {}⟩
 
 /-- lúub' "fall" ([lucy-1994] ex. 4, Table 4). A "motion verb" by
     any reasonable cross-linguistic notional taxonomy, but patterns
     morphologically with other patient-salient change-of-state roots
     in Yukatek. No `.motion` atom: motion is the *issue*, not a
     feature — see `motion_roots_not_separate_class`. -/
-def luub : Root := ⟨"luub'", {.becomesState "fallen"}, none⟩
+def luub : Root := ⟨"luub'", {.becomesState "fallen"}, none, {}⟩
 
 /-- 'ok "enter, intrude" ([lucy-1994] ex. 4, Table 4). Another
     notional motion root that takes `=s` like patient-salient state
     changes. -/
-def ok : Root := ⟨"'ok", {.becomesState "inside"}, none⟩
+def ok : Root := ⟨"'ok", {.becomesState "inside"}, none, {}⟩
 
 /-! Additional patient-salient roots from the page-630 list. -/
 
 /-- 'ah "wake" ([lucy-1994] patient-salient list). -/
-def ah : Root := ⟨"'ah", {.becomesState "awake"}, none⟩
+def ah : Root := ⟨"'ah", {.becomesState "awake"}, none, {}⟩
 
 /-- wen "sleep" ([lucy-1994] patient-salient list). State change
     *into* sleep, not the activity of sleeping. -/
-def wen : Root := ⟨"wen", {.becomesState "asleep"}, none⟩
+def wen : Root := ⟨"wen", {.becomesState "asleep"}, none, {}⟩
 
 /-- siih "be born" ([lucy-1994] patient-salient list). -/
-def siih : Root := ⟨"siih", {.becomesState "born"}, none⟩
+def siih : Root := ⟨"siih", {.becomesState "born"}, none, {}⟩
 
 /-- tú'ub' "be forgotten" ([lucy-1994] patient-salient list). -/
-def tuub : Root := ⟨"tú'ub'", {.becomesState "forgotten"}, none⟩
+def tuub : Root := ⟨"tú'ub'", {.becomesState "forgotten"}, none, {}⟩
 
 /-- k'a'ah "remember" ([lucy-1994] patient-salient list). -/
-def kaah : Root := ⟨"k'a'ah", {.becomesState "remembered"}, none⟩
+def kaah : Root := ⟨"k'a'ah", {.becomesState "remembered"}, none, {}⟩
 
 /-- čú'un "begin" ([lucy-1994] patient-salient list). -/
-def chuun : Root := ⟨"čú'un", {.becomesState "begun"}, none⟩
+def chuun : Root := ⟨"čú'un", {.becomesState "begun"}, none, {}⟩
 
 /-- č'en "stop, cease" ([lucy-1994] patient-salient list).
     Distinct from `haanCease` (Lucy lists them as separate entries). -/
-def chenCease : Root := ⟨"č'en", {.becomesState "ceased"}, none⟩
+def chenCease : Root := ⟨"č'en", {.becomesState "ceased"}, none, {}⟩
 
 /-- hó'op' "begin" ([lucy-1994] patient-salient list). Doublet of
     `chuun`; both gloss as "begin" in the patient-salient list. -/
-def hoop : Root := ⟨"hó'op'", {.becomesState "started"}, none⟩
+def hoop : Root := ⟨"hó'op'", {.becomesState "started"}, none, {}⟩
 
 /-- hé'el "rest" ([lucy-1994] patient-salient list). -/
-def heel : Root := ⟨"hé'el", {.becomesState "rested"}, none⟩
+def heel : Root := ⟨"hé'el", {.becomesState "rested"}, none, {}⟩
 
 /-- p'át "remain" ([lucy-1994] patient-salient list). -/
-def paat : Root := ⟨"p'át", {.becomesState "remaining"}, none⟩
+def paat : Root := ⟨"p'át", {.becomesState "remaining"}, none, {}⟩
 
 /-! Motion roots from [lucy-1994] Table 4. These pattern as
     patient-salient (`becomesState` only) — the central typological
@@ -178,21 +178,21 @@ def paat : Root := ⟨"p'át", {.becomesState "remaining"}, none⟩
     `motion_roots_predicted_patient`. -/
 
 /-- máan "pass" ([lucy-1994] Table 4). -/
-def maan : Root := ⟨"máan", {.becomesState "passed"}, none⟩
+def maan : Root := ⟨"máan", {.becomesState "passed"}, none, {}⟩
 
 /-- tàal "come" ([lucy-1994] Table 4). -/
-def taal : Root := ⟨"tàal", {.becomesState "arrived"}, none⟩
+def taal : Root := ⟨"tàal", {.becomesState "arrived"}, none, {}⟩
 
 /-- b'in "go" ([lucy-1994] Table 4). -/
-def bin : Root := ⟨"b'in", {.becomesState "departed"}, none⟩
+def bin : Root := ⟨"b'in", {.becomesState "departed"}, none, {}⟩
 
 /-- nàak "ascend" ([lucy-1994] Table 4). Distinct from
     `Yukatek.naak` "ascend" in `VerbClasses.lean`, which encodes
     Bohnemeyer's stem-class data; both refer to the same Yukatek root. -/
-def naak : Root := ⟨"nàak", {.becomesState "ascended"}, none⟩
+def naak : Root := ⟨"nàak", {.becomesState "ascended"}, none, {}⟩
 
 /-- lìik' "rise" ([lucy-1994] Table 4). -/
-def liik : Root := ⟨"lìik'", {.becomesState "risen"}, none⟩
+def liik : Root := ⟨"lìik'", {.becomesState "risen"}, none, {}⟩
 
 -- ════════════════════════════════════════════════════
 -- § 4. Positional Roots (state only, take `-tal`)
@@ -200,11 +200,11 @@ def liik : Root := ⟨"lìik'", {.becomesState "risen"}, none⟩
 
 /-- čin "bow, bend down, bend over" ([lucy-1994] ex. 5, 7).
     Positional root; takes `-tal` (or `-lah`) for the inchoative stem. -/
-def cin : Root := ⟨"cin", {.hasState "bent"}, none⟩
+def cin : Root := ⟨"cin", {.hasState "bent"}, none, {}⟩
 
 /-- kul "sit" — positional root (cf. [lucy-1994] ex. 8c on
     relational positional semantics: "x is-seated [on y]"). -/
-def kul : Root := ⟨"kul", {.hasState "seated"}, none⟩
+def kul : Root := ⟨"kul", {.hasState "seated"}, none, {}⟩
 
 /-! ### Root arity -/
 

--- a/Linglib/Fragments/Spanish/Predicates.lean
+++ b/Linglib/Fragments/Spanish/Predicates.lean
@@ -199,13 +199,13 @@ def rasgar : SpanishVerbEntry :=
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := true,
     levinClass := some .break_,
-    rootProfile := some {
+    root := some { profile := {
       forceMag := some [.low, .moderate]
       forceDir := some [.unidirectional]
       patientRob := some [.insubstantial, .flimsy]
       resultType := some [.separation, .surfaceBreach]
       agentControl := some [.incompatible, .neutral]
-    } }
+    } } }
 
 /-- *asesinar* "assassinate" — AGENT causer required. No anticausative.
     Reflexivization yields reflexive reading only (*El senador se asesinó*

--- a/Linglib/Morphology/RootTypology.lean
+++ b/Linglib/Morphology/RootTypology.lean
@@ -196,8 +196,8 @@ theorem Verb.Root.changeType_ignores_outcomes {r r' : Verb.Root}
     outcome cardinality share a `changeType` — only the outcome axis tells them
     apart ([bhadra-2024]). -/
 example :
-    (Root.mk "x" {.becomesState "s", .hasCause} (some .multi)).changeType
-      = (Root.mk "x" {.becomesState "s", .hasCause} (some .singleton)).changeType :=
+    ({ entailments := {.becomesState "s", .hasCause}, outcomes := some .multi } : Root).changeType
+      = ({ entailments := {.becomesState "s", .hasCause}, outcomes := some .singleton } : Root).changeType :=
   Root.changeType_ignores_outcomes rfl
 
 /-- Property concept root subclasses ([dixon-1982]; [beavers-etal-2021] ex. 5).

--- a/Linglib/Semantics/Lexical/Roots/Basic.lean
+++ b/Linglib/Semantics/Lexical/Roots/Basic.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Lexical.Roots.Signature
 import Linglib.Semantics.Lexical.Roots.OutcomeCardinality
+import Linglib.Semantics.Lexical.Roots.Profile
 
 /-!
 # Atomic Lexical Entailments and Roots
@@ -80,12 +81,20 @@ end LexEntailment
     where one atom may entail another) is layered on top in
     `Roots/Closure.lean`. -/
 structure Root where
-  name : String
-  entailments : Finset LexEntailment
+  /-- The root form; `""` for an unnamed annotation (e.g. a quality-profile-only
+      root carried by a verb whose root form is its citation form). -/
+  name : String := ""
+  /-- The B&KG structural-entailment atoms; `∅` where the root's structural
+      content has not been annotated (its `featureSignature` is then uninformative,
+      and a verb falls back to its class via `Verb.classSignature`). -/
+  entailments : Finset LexEntailment := ∅
   /-- The outcome-set cardinality the root encodes ([bhadra-2024]): the axis
       orthogonal to the `featureSignature` (derived from `entailments`). `none`
       where the root has not been annotated for outcomes. -/
   outcomes : Option OutcomeCardinality := none
+  /-- Within-class graded quality dimensions ([spalek-mcnally-2026],
+      [majid-boster-bowerman-2008]); `{}` (all unconstrained) by default. -/
+  profile : Verb.Root.Profile := {}
   deriving DecidableEq
 
 /-- `Repr`/`BEq` from the data + `DecidableEq` (the `Finset` field blocks deriving

--- a/Linglib/Semantics/Lexical/Roots/Profile.lean
+++ b/Linglib/Semantics/Lexical/Roots/Profile.lean
@@ -201,7 +201,7 @@ structure Profile where
   /-- Patient dimensionality: [majid-boster-bowerman-2008].
       *tear* selects for 2D objects (cloth, paper); *snap* for 1D (stick, twig). -/
   patientDim : Range ObjectDimensionality := none
-  deriving BEq, Repr, Inhabited
+  deriving DecidableEq, BEq, Repr, Inhabited
 
 namespace Profile
 

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -32,6 +32,12 @@ def Verb.derivedUnaccusative (v : Verb) : Bool :=
 def Verb.derivedVendlerClass (v : Verb) : Option VendlerClass :=
   v.vendlerClass <|> v.degreeAchievementScale.map (·.defaultVendlerClass)
 
+/-- The verb's within-class quality profile ([spalek-mcnally-2026]), read off its
+    `root` (where the profile is now carried — formerly a separate `Verb` field).
+    `none` when the verb has no root. -/
+def Verb.rootProfile (v : Verb) : Option Verb.Root.Profile :=
+  v.root.map (·.profile)
+
 /-- Effective subject entailment profile: verb-level override if present,
     otherwise falls back to the Levin class–level profile
     ([levin-1993], [dowty-1991]). -/

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -277,9 +277,6 @@ structure Verb extends
     Verb.Causation, Verb.Attitude where
   /-- [levin-1993] verb class (§§ 9–57). -/
   levinClass : Option LevinClass := none
-  /-- Root-specific quality dimensions (within-class variation;
-      [spalek-mcnally-2026]). -/
-  rootProfile : Option Verb.Root.Profile := none
   /-- The verb's lexical root — its entailment atoms, derived B&KG feature
       signature, and [bhadra-2024] outcome axis. The content carrier the Verb
       API integrates around (P-HUB): when present, the verb's signature / outcome

--- a/Linglib/Semantics/Verb/RootContent.lean
+++ b/Linglib/Semantics/Verb/RootContent.lean
@@ -24,10 +24,19 @@ these accessors (which mention them) live here rather than in `Verb/Basic.lean`.
 open Verb
 open Semantics.Lexical
 
-/-- The verb's B&KG feature signature: from its annotated `root` if present, else
-    its Levin class's signature ([levin-1993] fallback, via `rootEntailments`). -/
+/-- The verb's B&KG feature signature, read off its annotated `root` (the fine
+    source of truth). `none` when the verb carries no root. Sibling of `outcomes`
+    and `changeType` — root-only, no class fallback; the coarser class-derived
+    signature is `classSignature`. -/
 def Verb.featureSignature (v : Verb) : Option Verb.Root.FeatureSignature :=
-  v.root.map (·.featureSignature) <|> v.levinClass.map LevinClass.rootEntailments
+  v.root.map (·.featureSignature)
+
+/-- The signature [levin-1993] attributes to the verb *via its class*
+    (`LevinClass.rootEntailments`) — the coarse REALIZATION-layer view, distinct
+    from the root's own `featureSignature`. They are independent provenances; a
+    `classSignature = featureSignature` agreement is a theorem, not a default. -/
+def Verb.classSignature (v : Verb) : Option Verb.Root.FeatureSignature :=
+  v.levinClass.map LevinClass.rootEntailments
 
 /-- The verb's outcome-set cardinality ([bhadra-2024]), read off its `root`. No
     Levin fallback: the per-class outcome assignment is a Study-level claim. -/
@@ -59,6 +68,6 @@ theorem Verb.changeType_ignores_outcomes {v v' : Verb} {r r' : Verb.Root}
     the same-entailment root with a different outcome cardinality agree — only the
     outcome axis distinguishes them. -/
 example (v : Verb) :
-    ({ v with root := some ⟨"r", ∅, some .multi⟩ }).changeType
-      = ({ v with root := some ⟨"r", ∅, some .singleton⟩ }).changeType :=
+    ({ v with root := some { entailments := ∅, outcomes := some .multi } }).changeType
+      = ({ v with root := some { entailments := ∅, outcomes := some .singleton } }).changeType :=
   Verb.changeType_ignores_outcomes rfl rfl rfl

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -44,17 +44,17 @@ open Verb
 /-! ### The six representative roots -/
 
 /-- √flat — pure state. -/
-def flat : Root := ⟨"flat", {.hasState "flat"}, none⟩
+def flat : Root := ⟨"flat", {.hasState "flat"}, none, {}⟩
 
 /-- √jog — pure manner of motion. -/
-def jog : Root := ⟨"jog", {.hasManner "jogging-gait", .motion}, none⟩
+def jog : Root := ⟨"jog", {.hasManner "jogging-gait", .motion}, none, {}⟩
 
 /-- √blossom — result with no specified manner or cause (an
     internally caused change of state). -/
-def blossom : Root := ⟨"blossom", {.becomesState "flowering"}, none⟩
+def blossom : Root := ⟨"blossom", {.becomesState "flowering"}, none, {}⟩
 
 /-- √crack — caused result without specified manner. -/
-def crack : Root := ⟨"crack", {.becomesState "fissured", .hasCause}, none⟩
+def crack : Root := ⟨"crack", {.becomesState "fissured", .hasCause}, none, {}⟩
 
 /-- √hand — manner + cause + result, adjoined position. The
     possession result is non-cancelable ("#Mary handed John the book,
@@ -63,13 +63,13 @@ def crack : Root := ⟨"crack", {.becomesState "fissured", .hasCause}, none⟩
 def hand : Root := ⟨"hand",
   {.hasManner "by-hand-transfer",
    .becomesState "in-recipient-possession",
-   .hasCause}, none⟩
+   .hasCause}, none, {}⟩
 
 /-- √drown — manner of killing (Levin 1993's *crucify, drown, hang,
     electrocute* class; [beavers-koontz-garboden-2020] ch. 4):
     manner + cause + result, complement position. -/
 def drown : Root := ⟨"drown",
-  {.hasManner "submersion-in-liquid", .becomesState "dead", .hasCause}, none⟩
+  {.hasManner "submersion-in-liquid", .becomesState "dead", .hasCause}, none, {}⟩
 
 /-! ### Feature signatures
 

--- a/Linglib/Studies/SpalekMcNally2026.lean
+++ b/Linglib/Studies/SpalekMcNally2026.lean
@@ -68,14 +68,14 @@ theorem both_causative :
     vs. "??rasgó un trozo de pan" (§3.2). -/
 theorem patient_restriction_differs :
     tear_.rootProfile ≠ rasgar.rootProfile := by
-  simp [tear_, rasgar]
+  decide
 
 /-- *tear* implies bidirectional (contrary-direction) force;
     *rasgar* implies unidirectional (linear/gash-like) force. -/
 theorem force_direction_differs :
     tear_.rootProfile.bind (·.forceDir) ≠
     rasgar.rootProfile.bind (·.forceDir) := by
-  simp [tear_, rasgar]
+  decide
 
 /-- *tear* is compatible with controlled action; *rasgar* is not.
     [spalek-mcnally-2026] ex. (17): "carefully tore the tin foil" ✓
@@ -83,7 +83,7 @@ theorem force_direction_differs :
 theorem agent_control_differs :
     tear_.rootProfile.bind (·.agentControl) ≠
     rasgar.rootProfile.bind (·.agentControl) := by
-  simp [tear_, rasgar]
+  decide
 
 -- ════════════════════════════════════════════════════
 -- § 3. Root Overlap (Translation Equivalence Zone)


### PR DESCRIPTION
Folds the quality `profile` onto `Verb.Root` (its content belongs on the root); `Verb.rootProfile` becomes a derived accessor. Splits `Verb.featureSignature` (root-only) from a new `Verb.classSignature` (the Levin-class view) instead of a priority fallback. `Profile` gains `DecidableEq`; root/profile literals migrated across English/Spanish/Yukatek/BKG2020.