### PR TITLE
feat(Semantics/Verb): root-dispatched change-of-state denotation

### DIFF
--- a/Linglib/Semantics/Verb/Denotation.lean
+++ b/Linglib/Semantics/Verb/Denotation.lean
@@ -136,3 +136,104 @@ theorem Verb.denote_bare {Entity Time : Type*} [LinearOrder Time]
     (hs : v.subjectRole = none) :
     v.denote M ⟨s, none⟩ e ↔ M.lex v e := by
   simp only [Verb.denote, hs, and_true]
+
+/-! ### Change-of-state decomposition ([beavers-koontz-garboden-2020] §1.3.2)
+
+For a change-of-state verb the opaque lexical core unpacks into the
+event-structural decomposition of [beavers-koontz-garboden-2020] (22)–(24): a
+root denotes a *state* predicate `⟦√V⟧(x,s)`, and the verb's event predicate is
+built by the templatic operators `become'` and `cause'`. The root's
+`featureSignature` selects which operators apply — `.result` → `become`,
+`.cause` → `cause`/`effector` — so the decomposition is the denotational payoff
+of the root's kinds. -/
+
+/-- The change-of-state model ([beavers-koontz-garboden-2020] (22)): the
+    templatic primitives a COS verb's denotation is built from. `become`/`cause`/
+    `effector` are model primitives here (BKG refine their truth conditions in
+    their §1.6); a Study instantiates them. -/
+structure Verb.CosModel (Entity State Time : Type*) [LinearOrder Time] where
+  /-- `⟦√V⟧(x,s)` (BKG (22a)): a state `s` of the root's lexical property holds of
+      `x` (e.g. `flat'(x,s)`). The root denotes a state predicate. -/
+  rootState : Verb → Entity → State → Prop
+  /-- `become'(s,e)` (BKG (22b)): event `e` gives rise to state `s`. -/
+  become : State → Event Time → Prop
+  /-- `cause'(v,e)` (BKG (22c)): event `v` causes event `e`. -/
+  cause : Event Time → Event Time → Prop
+  /-- `effector'(y,v)` (BKG (22c)): `y` is the effector of event `v`. -/
+  effector : Entity → Event Time → Prop
+  /-- The bare manner/activity core `⟦√V⟧(e)` of a pure-manner root (no change),
+      e.g. `jog`/`run`'s action specification. -/
+  manner : Verb → Event Time → Prop
+
+namespace Verb.CosModel
+
+variable {Entity State Time : Type*} [LinearOrder Time]
+
+/-- The inchoative denotation ([beavers-koontz-garboden-2020] (23c)):
+    `λxλe. ∃s. become'(s,e) ∧ ⟦√V⟧(x,s)` — an event of change giving rise to a
+    state of the root's property holding of the patient `x`. -/
+def inchoative (M : CosModel Entity State Time) (v : Verb) (x : Entity) :
+    Event Time → Prop :=
+  fun e => ∃ s, M.become s e ∧ M.rootState v x s
+
+/-- The causative denotation ([beavers-koontz-garboden-2020] (24c)): the
+    inchoative embedded under an effector and a causing event —
+    `λyλxλw. ∃e. effector'(y,w) ∧ cause'(w,e) ∧ inchoative(x)(e)`. -/
+def causative (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
+    Event Time → Prop :=
+  fun w => ∃ e, M.effector y w ∧ M.cause w e ∧ M.inchoative v x e
+
+/-- BKG's first prediction ([beavers-koontz-garboden-2020] p. 16): the causative
+    **entails** the inchoative — there is an event satisfying the inchoative,
+    "by simple virtue of" the embedding (∃-projection over the caused event).
+    Holds by construction, not stipulation. -/
+theorem causative_entails_inchoative (M : CosModel Entity State Time)
+    (v : Verb) (y x : Entity) (w : Event Time) (h : M.causative v y x w) :
+    ∃ e, M.inchoative v x e := by
+  obtain ⟨e, _, _, hinch⟩ := h
+  exact ⟨e, hinch⟩
+
+/-- The result-state entailment: the inchoative entails the patient reaches a
+    state of the root's property — `∃s. become'(s,e) ∧ ⟦√V⟧(x,s)`. The
+    non-cancelable result of a change-of-state root (the *break* vs *hit*
+    contrast, [beavers-koontz-garboden-2020] (6)); definitional, hence immediate. -/
+theorem inchoative_entails_resultState (M : CosModel Entity State Time)
+    (v : Verb) (x : Entity) (e : Event Time) (h : M.inchoative v x e) :
+    ∃ s, M.become s e ∧ M.rootState v x s := h
+
+/-- Composing the two predictions: a caused change reaches the root state —
+    the causative entails the full result-state condition. -/
+theorem causative_entails_resultState (M : CosModel Entity State Time)
+    (v : Verb) (y x : Entity) (w : Event Time) (h : M.causative v y x w) :
+    ∃ e s, M.become s e ∧ M.rootState v x s := by
+  obtain ⟨e, hinch⟩ := M.causative_entails_inchoative v y x w h
+  exact ⟨e, hinch⟩
+
+/-- The verb's change-of-state denotation, dispatched on its root's
+    `featureSignature` (cf. [beavers-koontz-garboden-2020] (18)–(19)): `.cause` →
+    causative, else `.result` → inchoative, else the bare manner core. The root's
+    kinds *select the event template* — the denotational payoff of the signature. -/
+def denote (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
+    Event Time → Prop :=
+  if LexKind.cause ∈ (v.root.map (·.featureSignature)).getD ∅ then M.causative v y x
+  else if LexKind.result ∈ (v.root.map (·.featureSignature)).getD ∅ then M.inchoative v x
+  else M.manner v
+
+/-- The denotational payoff of a `.result` root: any verb whose root signature
+    carries `result` has a denotation entailing the result state — whether the
+    root is causative (`.cause`) or inchoative. The
+    [beavers-koontz-garboden-2020] non-cancelable result, *derived from the
+    signature* rather than stipulated (and absent for a pure-manner root, whose
+    `denote` is the manner core). -/
+theorem denote_result_entails_resultState (M : CosModel Entity State Time)
+    (v : Verb) (y x : Entity) (e : Event Time)
+    (hres : LexKind.result ∈ (v.root.map (·.featureSignature)).getD ∅)
+    (h : M.denote v y x e) : ∃ e' s, M.become s e' ∧ M.rootState v x s := by
+  unfold denote at h
+  by_cases hc : LexKind.cause ∈ (v.root.map (·.featureSignature)).getD ∅
+  · rw [if_pos hc] at h
+    exact M.causative_entails_resultState v y x e h
+  · rw [if_neg hc, if_pos hres] at h
+    exact ⟨e, M.inchoative_entails_resultState v x e h⟩
+
+end Verb.CosModel

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Lexical.Roots.Closure
+import Linglib.Semantics.Verb.Denotation
 
 /-!
 # Beavers & Koontz-Garboden (2020): The Roots of Verbal Meaning
@@ -173,5 +174,36 @@ theorem jog_respectsBifurcation : jog.RespectsBifurcation := by decide
     Complementarity. -/
 theorem crack_respectsMannerResultComplementarity :
     crack.RespectsMannerResultComplementarity := by decide
+
+/-! ### The roots cash out denotationally ([beavers-koontz-garboden-2020] §1.3.2)
+
+Threading the roots through the change-of-state denotation (`Verb.CosModel`): a
+verb's denotation is dispatched on its root's `featureSignature`, so the kinds
+proven above *select the event template* and the result entailment of (6)
+follows from the signature. √crack (`+cause+result`) entails a result state in
+any model; √jog (pure manner) does not — the *break*/*hit* contrast. -/
+
+/-- `crack` the change-of-state verb (`Mary cracked the vase`). -/
+def crackV : Verb := { form := "crack", complementType := .np, root := some crack }
+
+/-- `jog` the pure-manner activity verb (`Mary jogged`). -/
+def jogV : Verb := { form := "jog", complementType := .none, root := some jog }
+
+/-- √crack carries `.result`, so in **any** model its denotation entails the
+    result state — the non-cancelable result of [beavers-koontz-garboden-2020]
+    (6), derived from crack's signature rather than stipulated. -/
+theorem crack_denote_entails_result {Entity State Time : Type*} [LinearOrder Time]
+    (M : Verb.CosModel Entity State Time) (y x : Entity) (e : Event Time)
+    (h : M.denote crackV y x e) : ∃ e' s, M.become s e' ∧ M.rootState crackV x s :=
+  M.denote_result_entails_resultState crackV y x e (by decide) h
+
+/-- √jog has no `.result` (nor `.cause`), so its denotation is the bare manner
+    core — no `become`, no result state. Only the change-of-state root entails a
+    result. -/
+theorem jog_denote_eq_manner {Entity State Time : Type*} [LinearOrder Time]
+    (M : Verb.CosModel Entity State Time) (y x : Entity) :
+    M.denote jogV y x = M.manner jogV := by
+  unfold Verb.CosModel.denote
+  rw [if_neg (by decide), if_neg (by decide)]
 
 end BeaversKoontzGarboden2020


### PR DESCRIPTION
Wires `Verb.denote` to the root via [beavers-koontz-garboden-2020] §1.3.2: a `Verb.CosModel` supplies `become'`/`cause'`/`effector'` + the root-as-state-predicate, and `denote` dispatches on the root's `featureSignature` to the inchoative/causative templates. The causative⊨inchoative and (non-cancelable) result-state entailments are *derived from the signature*; `Studies/BeaversKoontzGarboden2020` threads √crack (entails a result state) vs √jog (manner-only). Restitutive-*again* and the `toRole` fix are follow-ups.