### PR TITLE
refactor(Semantics/Quantification): ergonomics: ops, namespace, notation

### DIFF
--- a/Linglib/Fragments/English/Determiners.lean
+++ b/Linglib/Fragments/English/Determiners.lean
@@ -227,7 +227,7 @@ def QuantityWord.toList : List QuantityWord :=
     `Quantification.Quantifier`. -/
 noncomputable def QuantityWord.gqDenotation (q : QuantityWord)
     {α : Type*} [Fintype α] : Quantification.GQ α :=
-  open Quantification.Quantifier in
+  open Quantification in
   match q with
   | .none_ => no_sem
   | .some_ => some_sem

--- a/Linglib/Semantics/Composition/Scope.lean
+++ b/Linglib/Semantics/Composition/Scope.lean
@@ -26,7 +26,7 @@ namespace Semantics.Scope
 
 open Core.Logic.Intensional
 open ScopeTheory
-open Quantification.Quantifier
+open Quantification
 
 -- Scope Configurations
 

--- a/Linglib/Semantics/Definiteness/Basic.lean
+++ b/Linglib/Semantics/Definiteness/Basic.lean
@@ -42,7 +42,8 @@ This module retains:
 namespace Semantics.Definiteness
 
 open Core.Logic.Intensional (Ty)
-open Quantification.Quantifier (every_sem some_sem Ty.det)
+open Quantification (every_sem some_sem)
+open Quantification.Quantifier (Ty.det)
 open Semantics.Composition.TypeShifting (iota lift)
 open Semantics.Presupposition (PartialProp)
 open Features.Definiteness (DefPresupType Definiteness)

--- a/Linglib/Semantics/Numerals/Basic.lean
+++ b/Linglib/Semantics/Numerals/Basic.lean
@@ -341,22 +341,22 @@ open Classical Core.Logic.Intensional Quantification
 /-- GQT "at least `n`" agrees with `atLeastMeaning` on intersection cardinality. -/
 theorem gqt_atLeast_agrees {α : Type*} [Fintype α]
     (n : Nat) (R S : α → Prop) :
-    Quantifier.at_least_n_sem n R S ↔
-    atLeastMeaning n (Quantifier.count (fun x : α => R x ∧ S x)) :=
+    at_least_n_sem n R S ↔
+    atLeastMeaning n (count (fun x : α => R x ∧ S x)) :=
   Iff.rfl
 
 /-- GQT "at most `n`" agrees with `atMostMeaning` on intersection cardinality. -/
 theorem gqt_atMost_agrees {α : Type*} [Fintype α]
     (n : Nat) (R S : α → Prop) :
-    Quantifier.at_most_n_sem n R S ↔
-    atMostMeaning n (Quantifier.count (fun x : α => R x ∧ S x)) :=
+    at_most_n_sem n R S ↔
+    atMostMeaning n (count (fun x : α => R x ∧ S x)) :=
   Iff.rfl
 
 /-- GQT "exactly `n`" agrees with `bareMeaning` on intersection cardinality. -/
 theorem gqt_exactly_agrees {α : Type*} [Fintype α]
     (n : Nat) (R S : α → Prop) :
-    Quantifier.exactly_n_sem n R S ↔
-    bareMeaning n (Quantifier.count (fun x : α => R x ∧ S x)) :=
+    exactly_n_sem n R S ↔
+    bareMeaning n (count (fun x : α => R x ∧ S x)) :=
   Iff.rfl
 
 end GQTBridge

--- a/Linglib/Semantics/Quantification/Basic.lean
+++ b/Linglib/Semantics/Quantification/Basic.lean
@@ -37,6 +37,13 @@ def SatisfiesUniversals {α : Type*} (q : GQ α) : Prop :=
 
 variable {α : Type*}
 
+/-- Denotation brackets for the logical determiners (Heim & Kratzer `⟦·⟧`), with `α`
+    pinned to the section variable — so a bare statement reads `Conservative ⟦every⟧`
+    instead of the noisy `Conservative (every_sem (α := α))`. -/
+local notation:max "⟦every⟧" => (every_sem : GQ α)
+local notation:max "⟦some⟧" => (some_sem : GQ α)
+local notation:max "⟦no⟧" => (no_sem : GQ α)
+
 /-! ### Bijection invariance -/
 
 /-- `∀ x, P x` is invariant under bijective substitution. -/
@@ -55,48 +62,48 @@ theorem exists_bij_inv (f : α → α) (hBij : Function.Bijective f)
 
 /-! ### Conservativity -/
 
-theorem every_conservative : Conservative (every_sem (α := α)) := by
+theorem every_conservative : Conservative ⟦every⟧ := by
   intro R S; simp only [every_sem]
   exact ⟨fun h x hR => ⟨hR, h x hR⟩, fun h x hR => (h x hR).2⟩
 
-theorem some_conservative : Conservative (some_sem (α := α)) := by
+theorem some_conservative : Conservative ⟦some⟧ := by
   intro R S; simp only [some_sem]
   exact ⟨fun ⟨x, hR, hS⟩ => ⟨x, hR, hR, hS⟩, fun ⟨x, hR, _, hS⟩ => ⟨x, hR, hS⟩⟩
 
-theorem no_conservative : Conservative (no_sem (α := α)) := by
+theorem no_conservative : Conservative ⟦no⟧ := by
   intro R S; simp only [no_sem]
   exact ⟨fun h x hR ⟨_, hS⟩ => h x hR hS, fun h x hR hS => h x hR ⟨hR, hS⟩⟩
 
 /-! ### Scope monotonicity -/
 
-theorem every_scope_up : ScopeUpwardMono (every_sem (α := α)) := by
+theorem every_scope_up : ScopeUpwardMono ⟦every⟧ := by
   intro R S S' hSS' h x hR; exact hSS' x (h x hR)
 
-theorem some_scope_up : ScopeUpwardMono (some_sem (α := α)) := by
+theorem some_scope_up : ScopeUpwardMono ⟦some⟧ := by
   intro R S S' hSS' ⟨x, hR, hS⟩; exact ⟨x, hR, hSS' x hS⟩
 
-theorem no_scope_down : ScopeDownwardMono (no_sem (α := α)) := by
+theorem no_scope_down : ScopeDownwardMono ⟦no⟧ := by
   intro R S S' hSS' h x hR hS; exact h x hR (hSS' x hS)
 
 /-! ### Symmetry (P&W Ch.6) -/
 
-theorem some_symmetric : QSymmetric (some_sem (α := α)) := by
+theorem some_symmetric : QSymmetric ⟦some⟧ := by
   intro R S; simp only [some_sem]
   exact ⟨fun ⟨x, hR, hS⟩ => ⟨x, hS, hR⟩, fun ⟨x, hS, hR⟩ => ⟨x, hR, hS⟩⟩
 
-theorem no_symmetric : QSymmetric (no_sem (α := α)) := by
+theorem no_symmetric : QSymmetric ⟦no⟧ := by
   intro R S; simp only [no_sem]
   exact ⟨fun h x hS hR => h x hR hS, fun h x hR hS => h x hS hR⟩
 
 /-! ### Intersectivity (CONSERV + SYMM bridge) -/
 
-theorem some_intersective : IntersectionCondition (some_sem (α := α)) := by
+theorem some_intersective : IntersectionCondition ⟦some⟧ := by
   intro R S R' S' hInt
   simp only [some_sem]
   exact ⟨fun ⟨x, hR, hS⟩ => let ⟨hR', hS'⟩ := (hInt x).mp ⟨hR, hS⟩; ⟨x, hR', hS'⟩,
          fun ⟨x, hR', hS'⟩ => let ⟨hR, hS⟩ := (hInt x).mpr ⟨hR', hS'⟩; ⟨x, hR, hS⟩⟩
 
-theorem no_intersective : IntersectionCondition (no_sem (α := α)) := by
+theorem no_intersective : IntersectionCondition ⟦no⟧ := by
   intro R S R' S' hInt
   simp only [no_sem]
   refine ⟨fun h x hR' hS' => h x ((hInt x).mpr ⟨hR', hS'⟩).1 ((hInt x).mpr ⟨hR', hS'⟩).2,
@@ -104,17 +111,17 @@ theorem no_intersective : IntersectionCondition (no_sem (α := α)) := by
 
 /-! ### Left/right anti-additivity (P&W §5.8) -/
 
-theorem every_laa : LeftAntiAdditive (every_sem (α := α)) := by
+theorem every_laa : LeftAntiAdditive ⟦every⟧ := by
   intro R R' S; simp only [every_sem]
   refine ⟨fun h => ⟨fun x hR => h x (Or.inl hR), fun x hR' => h x (Or.inr hR')⟩,
           fun ⟨h1, h2⟩ x hRR' => hRR'.elim (h1 x) (h2 x)⟩
 
-theorem no_laa : LeftAntiAdditive (no_sem (α := α)) := by
+theorem no_laa : LeftAntiAdditive ⟦no⟧ := by
   intro R R' S; simp only [no_sem]
   refine ⟨fun h => ⟨fun x hR => h x (Or.inl hR), fun x hR' => h x (Or.inr hR')⟩,
           fun ⟨h1, h2⟩ x hRR' => hRR'.elim (h1 x) (h2 x)⟩
 
-theorem no_raa : RightAntiAdditive (no_sem (α := α)) := by
+theorem no_raa : RightAntiAdditive ⟦no⟧ := by
   intro R S S'; simp only [no_sem]
   refine ⟨fun h => ⟨fun x hR hS => h x hR (Or.inl hS),
                     fun x hR hS' => h x hR (Or.inr hS')⟩,
@@ -123,106 +130,106 @@ theorem no_raa : RightAntiAdditive (no_sem (α := α)) := by
 /-- [peters-westerstahl-2006] Prop 13: the only non-trivial CONSERV, EXT,
     and ISOM quantifiers satisfying LAA are `every` and `no` (and `A = ∅`). -/
 theorem laa_characterization :
-    LeftAntiAdditive (every_sem (α := α)) ∧
-    LeftAntiAdditive (no_sem (α := α)) := ⟨every_laa, no_laa⟩
+    LeftAntiAdditive ⟦every⟧ ∧
+    LeftAntiAdditive ⟦no⟧ := ⟨every_laa, no_laa⟩
 
 /-! ### Duality square (B&C §4.11) -/
 
 /-- Inner negation maps `every` to `no`: every...not = no.
     `∀x. R(x) → ¬S(x)` = `¬∃x. R(x) ∧ S(x)`. -/
 theorem innerNeg_every_eq_no :
-    (innerNeg (every_sem (α := α)) : GQ α) = (no_sem (α := α) : GQ α) := by
+    (innerNeg ⟦every⟧ : GQ α) = ⟦no⟧ := by
   funext R S; simp only [innerNeg, every_sem, no_sem]
 
 /-- The dual of `every` is `some`: Q̌(every) = some. -/
 theorem dualQ_every_eq_some :
-    (dualQ (every_sem (α := α)) : GQ α) = (some_sem (α := α) : GQ α) := by
+    (dualQ ⟦every⟧ : GQ α) = ⟦some⟧ := by
   funext R S; simp only [dualQ, outerNeg_apply, innerNeg, every_sem, some_sem]
   exact propext ⟨fun h => by push_neg at h; exact h,
                  fun ⟨x, hR, hS⟩ h => h x hR hS⟩
 
 /-- `outerNeg ⟦some⟧ = ⟦no⟧`: negating existence gives universal negation. -/
 theorem outerNeg_some_eq_no :
-    (outerNeg (some_sem (α := α)) : GQ α) = (no_sem (α := α) : GQ α) := by
+    (outerNeg ⟦some⟧ : GQ α) = ⟦no⟧ := by
   funext R S; simp only [outerNeg_apply, some_sem, no_sem]
   exact propext ⟨fun h x hR hS => h ⟨x, hR, hS⟩,
                  fun h ⟨x, hR, hS⟩ => h x hR hS⟩
 
 /-! ### Positive/negative strong (P&W Ch.6) -/
 
-theorem every_positive_strong : PositiveStrong (every_sem (α := α)) := by
+theorem every_positive_strong : PositiveStrong ⟦every⟧ := by
   intro R x hR; exact hR
 
 /-- `⟦no⟧` is negative strong on non-empty restrictors:
     no(A,A) = false for all non-empty A. -/
 theorem no_negative_strong_nonempty (R : α → Prop)
     (hR : ∃ x : α, R x) :
-    ¬ no_sem (α := α) R R := by
+    ¬ ⟦no⟧ R R := by
   intro h; obtain ⟨x, hRx⟩ := hR; exact h x hRx hRx
 
 /-! ### K&S existential det classification (§3.3, G3) -/
 
-theorem some_existential : Existential (some_sem (α := α)) := by
+theorem some_existential : Existential ⟦some⟧ := by
   intro R S; simp only [some_sem]
   exact ⟨fun ⟨x, hR, hS⟩ => ⟨x, ⟨hR, hS⟩, trivial⟩,
          fun ⟨x, ⟨hR, hS⟩, _⟩ => ⟨x, hR, hS⟩⟩
 
-theorem no_existential : Existential (no_sem (α := α)) := by
+theorem no_existential : Existential ⟦no⟧ := by
   intro R S; simp only [no_sem]
   exact ⟨fun h x ⟨hR, hS⟩ _ => h x hR hS,
          fun h x hR hS => h x ⟨hR, hS⟩ trivial⟩
 
 /-! ### Relational properties ([van-benthem-1984]) -/
 
-theorem every_transitive : QTransitive (every_sem (α := α)) := by
+theorem every_transitive : QTransitive ⟦every⟧ := by
   intro A B C hAB hBC x hA; exact hBC x (hAB x hA)
 
-theorem every_antisymmetric : QAntisymmetric (every_sem (α := α)) := by
+theorem every_antisymmetric : QAntisymmetric ⟦every⟧ := by
   intro A B hAB hBA
   funext x; exact propext ⟨fun hA => hAB x hA, fun hB => hBA x hB⟩
 
-theorem some_quasi_reflexive : QuasiReflexive (some_sem (α := α)) := by
+theorem some_quasi_reflexive : QuasiReflexive ⟦some⟧ := by
   intro A B ⟨x, hA, _⟩; exact ⟨x, hA, hA⟩
 
-theorem no_quasi_universal : QuasiUniversal (no_sem (α := α)) := by
+theorem no_quasi_universal : QuasiUniversal ⟦no⟧ := by
   intro A B hAA x hA; exact absurd hA (hAA x hA)
 
 /-! ### Double monotonicity classification ([van-benthem-1984] §4.2) -/
 
 /-- `⟦every⟧` is restrictor-↓ (anti-persistent). Follows from Zwarts bridge:
     reflexive + transitive + CONSERV → ↓MON. -/
-theorem every_restrictor_down : RestrictorDownwardMono (every_sem (α := α)) :=
+theorem every_restrictor_down : RestrictorDownwardMono ⟦every⟧ :=
   zwarts_refl_trans_restrictorDown _ every_conservative every_positive_strong
     every_transitive
 
-theorem some_restrictor_up : RestrictorUpwardMono (some_sem (α := α)) := by
+theorem some_restrictor_up : RestrictorUpwardMono ⟦some⟧ := by
   intro R R' S hRR' ⟨x, hR, hS⟩; exact ⟨x, hRR' x hR, hS⟩
 
-theorem no_restrictor_down : RestrictorDownwardMono (no_sem (α := α)) := by
+theorem no_restrictor_down : RestrictorDownwardMono ⟦no⟧ := by
   intro R R' S hRR' hQ x hR; exact hQ x (hRR' x hR)
 
 theorem every_doubleMono :
-    RestrictorDownwardMono (every_sem (α := α)) ∧
-    ScopeUpwardMono (every_sem (α := α)) :=
+    RestrictorDownwardMono ⟦every⟧ ∧
+    ScopeUpwardMono ⟦every⟧ :=
   ⟨every_restrictor_down, every_scope_up⟩
 
 theorem some_doubleMono :
-    RestrictorUpwardMono (some_sem (α := α)) ∧
-    ScopeUpwardMono (some_sem (α := α)) :=
+    RestrictorUpwardMono ⟦some⟧ ∧
+    ScopeUpwardMono ⟦some⟧ :=
   ⟨some_restrictor_up, some_scope_up⟩
 
 theorem no_doubleMono :
-    RestrictorDownwardMono (no_sem (α := α)) ∧
-    ScopeDownwardMono (no_sem (α := α)) :=
+    RestrictorDownwardMono ⟦no⟧ ∧
+    ScopeDownwardMono ⟦no⟧ :=
   ⟨no_restrictor_down, no_scope_down⟩
 
 theorem notAll_doubleMono :
-    RestrictorUpwardMono (outerNeg (every_sem (α := α))) ∧
-    ScopeDownwardMono (outerNeg (every_sem (α := α))) :=
+    RestrictorUpwardMono (outerNeg ⟦every⟧) ∧
+    ScopeDownwardMono (outerNeg ⟦every⟧) :=
   ⟨outerNeg_restrictorDown_to_up _ every_restrictor_down,
    outerNeg_up_to_down _ every_scope_up⟩
 
-theorem every_filtrating : Filtrating (every_sem (α := α)) := by
+theorem every_filtrating : Filtrating ⟦every⟧ := by
   intro A B C hAB hAC x hA; exact ⟨hAB x hA, hAC x hA⟩
 
 /-! ### Aristotelian square of opposition
@@ -245,18 +252,18 @@ the faithful Aristotelian-vs-Boolean existential-import treatment. -/
 
 /-- Contradiction (A vs O): the A-form and O-form are contradictories. -/
 theorem every_contradicts_notEvery (R S : α → Prop) :
-    every_sem (α := α) R S ↔ ¬ (outerNeg (every_sem (α := α)) R S) := by
+    ⟦every⟧ R S ↔ ¬ (outerNeg ⟦every⟧ R S) := by
   simp [outerNeg, Classical.not_not]
 
 /-- Contradiction (E vs I): the E-form and I-form are contradictories. -/
 theorem no_contradicts_some (R S : α → Prop) :
-    no_sem (α := α) R S ↔ ¬ (some_sem (α := α) R S) := by
+    ⟦no⟧ R S ↔ ¬ (⟦some⟧ R S) := by
   simp only [no_sem, some_sem]; push_neg; rfl
 
 /-- Contrariety (A ∧ E): the A-form and E-form can't both hold unless the
     restrictor is empty. -/
 theorem a_e_contrary (R S : α → Prop) :
-    every_sem (α := α) R S → no_sem (α := α) R S →
+    ⟦every⟧ R S → ⟦no⟧ R S →
     ∀ x : α, ¬ R x := by
   intro hA hE x hR; exact hE x hR (hA x hR)
 
@@ -264,22 +271,22 @@ theorem a_e_contrary (R S : α → Prop) :
     restrictor is non-empty. -/
 theorem subalternation_a_i (R S : α → Prop)
     (hR : ∃ x : α, R x) :
-    every_sem (α := α) R S → some_sem (α := α) R S := by
+    ⟦every⟧ R S → ⟦some⟧ R S := by
   intro hA; obtain ⟨x, hRx⟩ := hR; exact ⟨x, hRx, hA x hRx⟩
 
 /-- Subalternation (E → O): the E-form entails the O-form when the
     restrictor is non-empty. -/
 theorem subalternation_e_o (R S : α → Prop)
     (hR : ∃ x : α, R x) :
-    no_sem (α := α) R S → outerNeg (every_sem (α := α)) R S := by
+    ⟦no⟧ R S → outerNeg ⟦every⟧ R S := by
   intro hE hA; obtain ⟨x, hRx⟩ := hR; exact hE x hRx (hA x hRx)
 
 /-- Subcontrariety (I ∨ O): the I-form and O-form can't both fail when the
     restrictor is non-empty. -/
 theorem subcontrariety_i_o (R S : α → Prop)
     (hR : ∃ x : α, R x) :
-    some_sem (α := α) R S ∨ outerNeg (every_sem (α := α)) R S := by
-  by_cases h : some_sem (α := α) R S
+    ⟦some⟧ R S ∨ outerNeg ⟦every⟧ R S := by
+  by_cases h : ⟦some⟧ R S
   · exact Or.inl h
   · right; intro hA; apply h
     obtain ⟨x, hRx⟩ := hR; exact ⟨x, hRx, hA x hRx⟩
@@ -295,74 +302,74 @@ theorem isContradictory_outerNeg (q : GQ α) (R : α → Prop) :
 /-- A–O diagonal: `every` and `not-every` are contradictory. -/
 theorem every_satisfies_isContradictory_pointwise (R : α → Prop) :
     Aristotelian.IsContradictory
-      ((every_sem (α := α) R) : (α → Prop) → Prop)
-      (outerNeg (every_sem (α := α)) R) :=
+      ((⟦every⟧ R) : (α → Prop) → Prop)
+      (outerNeg ⟦every⟧ R) :=
   isContradictory_outerNeg _ R
 
 /-- E–I diagonal: `no` and `some` are contradictory, since `some = ~no`. -/
 theorem no_satisfies_isContradictory_pointwise (R : α → Prop) :
     Aristotelian.IsContradictory
-      ((no_sem (α := α) R) : (α → Prop) → Prop)
-      (some_sem (α := α) R) := by
-  have hno : outerNeg (no_sem (α := α)) = some_sem := by
+      ((⟦no⟧ R) : (α → Prop) → Prop)
+      (⟦some⟧ R) := by
+  have hno : outerNeg ⟦no⟧ = some_sem := by
     rw [← innerNeg_every_eq_no]; exact dualQ_every_eq_some
   rw [← hno]; exact isContradictory_outerNeg _ R
 
 /-! ### Basic left monotonicities ([peters-westerstahl-2006] §5.5) -/
 
-theorem some_upSE : UpSEMon (some_sem (α := α)) :=
+theorem some_upSE : UpSEMon ⟦some⟧ :=
   restrictorUpMono_to_upSE _ some_restrictor_up
 
-theorem some_upSW : UpSWMon (some_sem (α := α)) :=
+theorem some_upSW : UpSWMon ⟦some⟧ :=
   restrictorUpMono_to_upSW _ some_restrictor_up
 
-theorem every_downNW : DownNWMon (every_sem (α := α)) :=
+theorem every_downNW : DownNWMon ⟦every⟧ :=
   restrictorDownMono_to_downNW _ every_restrictor_down
 
-theorem every_downNE : DownNEMon (every_sem (α := α)) :=
+theorem every_downNE : DownNEMon ⟦every⟧ :=
   restrictorDownMono_to_downNE _ every_restrictor_down
 
-theorem no_downNW : DownNWMon (no_sem (α := α)) :=
+theorem no_downNW : DownNWMon ⟦no⟧ :=
   restrictorDownMono_to_downNW _ no_restrictor_down
 
-theorem no_downNE : DownNEMon (no_sem (α := α)) :=
+theorem no_downNE : DownNEMon ⟦no⟧ :=
   restrictorDownMono_to_downNE _ no_restrictor_down
 
 /-! ### Smooth quantifiers ([peters-westerstahl-2006] §5.6) -/
 
 /-- `⟦some⟧` is ↓_NE Mon (direct proof). -/
-theorem some_downNE : DownNEMon (some_sem (α := α)) := by
+theorem some_downNE : DownNEMon ⟦some⟧ := by
   intro R S R' _ hKeep ⟨x, hR, hS⟩
   exact ⟨x, hKeep x hR hS, hS⟩
 
-theorem some_smooth : Smooth (some_sem (α := α)) :=
+theorem some_smooth : Smooth ⟦some⟧ :=
   ⟨some_downNE, restrictorUpMono_to_upSE _ some_restrictor_up⟩
 
 /-- `⟦every⟧` is ↑_SE Mon (direct proof). -/
-theorem every_upSE_direct : UpSEMon (every_sem (α := α)) := by
+theorem every_upSE_direct : UpSEMon ⟦every⟧ := by
   intro R S R' _ hDiff hQ x hR'
   by_cases hS : S x
   · exact hS
   · exact hQ x (hDiff x hR' hS)
 
-theorem every_smooth : Smooth (every_sem (α := α)) :=
+theorem every_smooth : Smooth ⟦every⟧ :=
   ⟨every_downNE, every_upSE_direct⟩
 
 theorem no_coSmooth_partial :
-    DownNWMon (no_sem (α := α)) ∧ DownNEMon (no_sem (α := α)) :=
+    DownNWMon ⟦no⟧ ∧ DownNEMon ⟦no⟧ :=
   ⟨restrictorDownMono_to_downNW _ no_restrictor_down,
    restrictorDownMono_to_downNE _ no_restrictor_down⟩
 
 /-! ### Satisfies universals: B&C's CONS + MON ([barwise-cooper-1981]; used as a
 learnability/complexity target by [van-de-pol-etal-2023]) -/
 
-theorem some_satisfiesUniversals : SatisfiesUniversals (some_sem (α := α)) :=
+theorem some_satisfiesUniversals : SatisfiesUniversals ⟦some⟧ :=
   ⟨some_conservative, Or.inl some_scope_up⟩
 
-theorem every_satisfiesUniversals : SatisfiesUniversals (every_sem (α := α)) :=
+theorem every_satisfiesUniversals : SatisfiesUniversals ⟦every⟧ :=
   ⟨every_conservative, Or.inl every_scope_up⟩
 
-theorem no_satisfiesUniversals : SatisfiesUniversals (no_sem (α := α)) :=
+theorem no_satisfiesUniversals : SatisfiesUniversals ⟦no⟧ :=
   ⟨no_conservative, Or.inr no_scope_down⟩
 
 end Quantification

--- a/Linglib/Semantics/Quantification/Counting.lean
+++ b/Linglib/Semantics/Quantification/Counting.lean
@@ -112,7 +112,7 @@ theorem count_bij_inv (f : α → α) (hBij : Function.Bijective f)
     exact ⟨x, by simp [Finset.mem_filter, hy], rfl⟩
 
 /-- Equivalent predicates produce equal counts. -/
-private theorem count_congr_iff {P Q : α → Prop}
+theorem count_congr_iff {P Q : α → Prop}
     [DecidablePred P] [DecidablePred Q]
     (h : ∀ x, P x ↔ Q x) : count P = count Q := by
   unfold count; congr 1; ext x
@@ -122,7 +122,7 @@ private theorem count_congr_iff {P Q : α → Prop}
 
 /-- Instance-polymorphic: `count(R∧S) = count(R∧(R∧S))` for any
     `DecidablePred` instances. -/
-private theorem count_and_idem_any (R S : α → Prop)
+theorem count_and_idem_any (R S : α → Prop)
     (inst1 : DecidablePred (fun x : α => R x ∧ S x))
     (inst2 : DecidablePred (fun x : α => R x ∧ (R x ∧ S x))) :
     @count _ _ _ inst1 = @count _ _ _ inst2 := by
@@ -132,7 +132,7 @@ private theorem count_and_idem_any (R S : α → Prop)
 
 /-- Instance-polymorphic: `count(R∧¬S) = count(R∧¬(R∧S))` for any
     `DecidablePred` instances. -/
-private theorem count_neg_idem_any (R S : α → Prop)
+theorem count_neg_idem_any (R S : α → Prop)
     (inst1 : DecidablePred (fun x : α => R x ∧ ¬ S x))
     (inst2 : DecidablePred (fun x : α => R x ∧ ¬ (R x ∧ S x))) :
     @count _ _ _ inst1 = @count _ _ _ inst2 := by
@@ -142,14 +142,14 @@ private theorem count_neg_idem_any (R S : α → Prop)
          fun ⟨hR, hN⟩ => ⟨hR, fun hS => hN ⟨hR, hS⟩⟩⟩
 
 /-- If `P` implies `Q` pointwise, then `|filter P| ≤ |filter Q|`. -/
-private theorem count_le_of_imp {P Q : α → Prop}
+theorem count_le_of_imp {P Q : α → Prop}
     [DecidablePred P] [DecidablePred Q]
     (h : ∀ x, P x → Q x) : count P ≤ count Q := by
   apply Finset.card_le_card
   intro x; simp only [Finset.mem_filter, Finset.mem_univ, true_and]; exact h x
 
 /-- |R| = |R∩S| + |R\S|. -/
-private theorem count_decompose (R S : α → Prop)
+theorem count_decompose (R S : α → Prop)
     [DecidablePred R] [DecidablePred S] :
     count (fun x : α => R x) =
       count (fun x : α => R x ∧ S x) +
@@ -187,7 +187,7 @@ theorem both_conservative : Conservative (both_sem (α := α)) := by
   intro R S; simp only [both_sem]; rw [every_conservative R S]
 
 theorem neither_conservative : Conservative (neither_sem (α := α)) := by
-  intro R S; simp only [neither_sem, gqMeet]; rw [no_conservative R S]
+  intro R S; simp only [neither_sem, gqMeet_apply]; rw [no_conservative R S]
 
 theorem at_least_n_conservative (n : Nat) :
     Conservative (at_least_n_sem (α := α) n) := by
@@ -255,7 +255,7 @@ theorem no_eq_at_most_0 :
 theorem exactly_eq_meet_at_least_at_most (n : Nat) :
     (exactly_n_sem (α := α) n : GQ α) =
     (gqMeet (at_least_n_sem (α := α) n) (at_most_n_sem (α := α) n) : GQ α) := by
-  funext R S; simp only [exactly_n_sem, at_least_n_sem, at_most_n_sem, gqMeet]
+  funext R S; simp only [exactly_n_sem, at_least_n_sem, at_most_n_sem, gqMeet_apply]
   exact propext ⟨fun h => ⟨by omega, by omega⟩, fun ⟨h1, h2⟩ => by omega⟩
 
 /-- `⟦all but 0⟧ = ⟦every⟧`. -/

--- a/Linglib/Semantics/Quantification/Counting.lean
+++ b/Linglib/Semantics/Quantification/Counting.lean
@@ -163,30 +163,42 @@ theorem count_decompose (R S : α → Prop)
   · simp only [Finset.disjoint_filter]
     intro x _ ⟨_, h1⟩ ⟨_, h2⟩; exact h2 h1
 
+/-- Denotation brackets for the named determiners (`α` pinned to the section variable),
+    so statements read `Conservative ⟦most⟧`. The `n`-parameterized cardinals
+    (`at_least_n_sem n`, …) stay explicit. -/
+local notation:max "⟦every⟧" => (every_sem : GQ α)
+local notation:max "⟦some⟧" => (some_sem : GQ α)
+local notation:max "⟦no⟧" => (no_sem : GQ α)
+local notation:max "⟦most⟧" => (most_sem : GQ α)
+local notation:max "⟦few⟧" => (few_sem : GQ α)
+local notation:max "⟦half⟧" => (half_sem : GQ α)
+local notation:max "⟦both⟧" => (both_sem : GQ α)
+local notation:max "⟦neither⟧" => (neither_sem : GQ α)
+
 /-! ### Conservativity of counting GQs -/
 
-theorem most_conservative : Conservative (most_sem (α := α)) := by
+theorem most_conservative : Conservative ⟦most⟧ := by
   intro R S; simp only [most_sem]
   constructor <;> intro h
   · rw [← count_and_idem_any R S _ _, ← count_neg_idem_any R S _ _]; exact h
   · rw [count_and_idem_any R S _ _, count_neg_idem_any R S _ _]; exact h
 
-theorem few_conservative : Conservative (few_sem (α := α)) := by
+theorem few_conservative : Conservative ⟦few⟧ := by
   intro R S; simp only [few_sem]
   constructor <;> intro h
   · rw [← count_and_idem_any R S _ _, ← count_neg_idem_any R S _ _]; exact h
   · rw [count_and_idem_any R S _ _, count_neg_idem_any R S _ _]; exact h
 
-theorem half_conservative : Conservative (half_sem (α := α)) := by
+theorem half_conservative : Conservative ⟦half⟧ := by
   intro R S; simp only [half_sem]
   constructor <;> intro h
   · rw [← count_and_idem_any R S _ _]; exact h
   · rw [count_and_idem_any R S _ _]; exact h
 
-theorem both_conservative : Conservative (both_sem (α := α)) := by
+theorem both_conservative : Conservative ⟦both⟧ := by
   intro R S; simp only [both_sem]; rw [every_conservative R S]
 
-theorem neither_conservative : Conservative (neither_sem (α := α)) := by
+theorem neither_conservative : Conservative ⟦neither⟧ := by
   intro R S; simp only [neither_sem, gqMeet_apply]; rw [no_conservative R S]
 
 theorem at_least_n_conservative (n : Nat) :
@@ -226,7 +238,7 @@ theorem between_n_m_conservative (n k : Nat) :
 
 /-- `⟦some⟧ = ⟦at least 1⟧`. -/
 theorem some_eq_at_least_1 :
-    (some_sem (α := α) : GQ α) = (at_least_n_sem (α := α) 1 : GQ α) := by
+    ⟦some⟧ = (at_least_n_sem (α := α) 1 : GQ α) := by
   funext R S
   simp only [some_sem, at_least_n_sem]
   refine propext ⟨fun ⟨x, hR, hS⟩ => ?_, fun h => ?_⟩
@@ -248,7 +260,7 @@ theorem at_most_eq_outerNeg_at_least_succ (n : Nat) :
 
 /-- `⟦no⟧ = ⟦at most 0⟧`. -/
 theorem no_eq_at_most_0 :
-    (no_sem (α := α) : GQ α) = (at_most_n_sem (α := α) 0 : GQ α) := by
+    ⟦no⟧ = (at_most_n_sem (α := α) 0 : GQ α) := by
   rw [← outerNeg_some_eq_no, some_eq_at_least_1, at_most_eq_outerNeg_at_least_succ]
 
 /-- `⟦exactly n⟧ = ⟦at least n⟧ ⊓ ⟦at most n⟧`. -/
@@ -260,7 +272,7 @@ theorem exactly_eq_meet_at_least_at_most (n : Nat) :
 
 /-- `⟦all but 0⟧ = ⟦every⟧`. -/
 theorem all_but_0_eq_every :
-    (all_but_n_sem (α := α) 0 : GQ α) = (every_sem (α := α) : GQ α) := by
+    (all_but_n_sem (α := α) 0 : GQ α) = ⟦every⟧ := by
   funext R S; simp only [all_but_n_sem, every_sem]
   refine propext ⟨fun h x hR => ?_, fun h => ?_⟩
   · by_contra hS
@@ -273,7 +285,7 @@ theorem all_but_0_eq_every :
 
 /-! ### Scope monotonicity of counting GQs -/
 
-theorem few_scope_down : ScopeDownwardMono (few_sem (α := α)) := by
+theorem few_scope_down : ScopeDownwardMono ⟦few⟧ := by
   intro R S S' hSS' h
   simp only [few_sem] at *
   have h1 : count (fun x : α => R x ∧ S x) ≤
@@ -284,7 +296,7 @@ theorem few_scope_down : ScopeDownwardMono (few_sem (α := α)) := by
     count_le_of_imp fun x ⟨hR, hNS'⟩ => ⟨hR, fun hS => hNS' (hSS' x hS)⟩
   omega
 
-theorem most_scope_up : ScopeUpwardMono (most_sem (α := α)) := by
+theorem most_scope_up : ScopeUpwardMono ⟦most⟧ := by
   intro R S S' hSS' h
   simp only [most_sem] at *
   have h1 : count (fun x : α => R x ∧ S x) ≤
@@ -308,7 +320,7 @@ theorem at_most_n_scope_down (n : Nat) :
 
 /-! ### Smoothness -/
 
-theorem most_downNE : DownNEMon (most_sem (α := α)) := by
+theorem most_downNE : DownNEMon ⟦most⟧ := by
   intro R S R' hSub hKeep hQ
   simp only [most_sem] at *
   have hEq : count (fun x : α => R' x ∧ S x) =
@@ -322,7 +334,7 @@ theorem most_downNE : DownNEMon (most_sem (α := α)) := by
     count_le_of_imp fun x ⟨hR', hS⟩ => ⟨hSub x hR', hS⟩
   omega
 
-theorem most_upSE : UpSEMon (most_sem (α := α)) := by
+theorem most_upSE : UpSEMon ⟦most⟧ := by
   intro R S R' hSub hDiff hQ
   simp only [most_sem] at *
   have hEq : count (fun x : α => R' x ∧ ¬ S x) =
@@ -336,7 +348,7 @@ theorem most_upSE : UpSEMon (most_sem (α := α)) := by
     count_le_of_imp fun x ⟨hR, hS⟩ => ⟨hSub x hR, hS⟩
   omega
 
-theorem most_smooth : Smooth (most_sem (α := α)) :=
+theorem most_smooth : Smooth ⟦most⟧ :=
   ⟨most_downNE, most_upSE⟩
 
 theorem at_least_n_restrictor_up (n : Nat) :
@@ -528,34 +540,34 @@ theorem exactly_n_quantity (n : Nat) :
   rw [exactly_eq_meet_at_least_at_most]
   exact quantity_gqMeet _ _ (at_least_n_quantity n) (at_most_n_quantity n)
 
-theorem some_quantity : Quantity (some_sem (α := α)) := by
+theorem some_quantity : Quantity ⟦some⟧ := by
   rw [some_eq_at_least_1]; exact at_least_n_quantity 1
 
-theorem no_quantity : Quantity (no_sem (α := α)) := by
+theorem no_quantity : Quantity ⟦no⟧ := by
   rw [no_eq_at_most_0]; exact at_most_n_quantity 0
 
 /-- `⟦every⟧` satisfies `QuantityInvariant` (proved directly via bijection
     invariance of `∀`). -/
 private theorem every_quantityInvariant :
-    QuantityInvariant (every_sem (α := α)) := by
+    QuantityInvariant ⟦every⟧ := by
   intro A B A' B' f hBij hA hB
   simp only [every_sem]
   rw [forall_bij_inv f hBij]
   exact forall_congr' fun x => by
     rw [show A (f x) ↔ A' x from hA x, show B (f x) ↔ B' x from hB x]
 
-theorem every_quantity : Quantity (every_sem (α := α)) :=
+theorem every_quantity : Quantity ⟦every⟧ :=
   quantity_of_quantityInvariant _ every_quantityInvariant
 
-theorem most_quantity : Quantity (most_sem (α := α)) := by
+theorem most_quantity : Quantity ⟦most⟧ := by
   intro R₁ S₁ R₂ S₂ hTT hTF _ _
   simp only [most_sem]; omega
 
-theorem few_quantity : Quantity (few_sem (α := α)) := by
+theorem few_quantity : Quantity ⟦few⟧ := by
   intro R₁ S₁ R₂ S₂ hTT hTF _ _
   simp only [few_sem]; omega
 
-theorem half_quantity : Quantity (half_sem (α := α)) := by
+theorem half_quantity : Quantity ⟦half⟧ := by
   intro R₁ S₁ R₂ S₂ hTT _ _ _
   simp only [half_sem]
   constructor <;> intro h
@@ -577,10 +589,10 @@ theorem between_n_m_quantity (n k : Nat) :
 
 /-! ### Satisfies universals (counting) -/
 
-theorem most_satisfiesUniversals : SatisfiesUniversals (most_sem (α := α)) :=
+theorem most_satisfiesUniversals : SatisfiesUniversals ⟦most⟧ :=
   ⟨most_conservative, Or.inl most_scope_up⟩
 
-theorem few_satisfiesUniversals : SatisfiesUniversals (few_sem (α := α)) :=
+theorem few_satisfiesUniversals : SatisfiesUniversals ⟦few⟧ :=
   ⟨few_conservative, Or.inr few_scope_down⟩
 
 theorem at_least_n_satisfiesUniversals (n : Nat) :
@@ -644,12 +656,12 @@ private theorem cross_ratio_eq_iff (a₁ b₁ a₂ b₂ : Nat)
     rw [Nat.mul_comm a₁ b₂] at hcross
     exact Nat.mul_left_cancel (by omega) hcross
 
-theorem most_proportional : Proportional (most_sem (α := α)) := by
+theorem most_proportional : Proportional ⟦most⟧ := by
   intro R₁ S₁ R₂ S₂ a₁ b₁ a₂ b₂ hNE₁ hNE₂ hCross
   simp only [most_sem]
   exact cross_ratio_gt_iff a₁ b₁ a₂ b₂ hNE₁ hNE₂ hCross
 
-theorem few_proportional : Proportional (few_sem (α := α)) := by
+theorem few_proportional : Proportional ⟦few⟧ := by
   intro R₁ S₁ R₂ S₂ a₁ b₁ a₂ b₂ hNE₁ hNE₂ hCross
   simp only [few_sem]
   exact cross_ratio_lt_iff a₁ b₁ a₂ b₂ hNE₁ hNE₂ hCross
@@ -664,7 +676,7 @@ private theorem half_prop_core (a₁ b₁ a₂ b₂ : Nat)
   · have := (cross_ratio_eq_iff a₁ b₁ a₂ b₂ hNE₁ hNE₂ hCross).mpr (by omega)
     omega
 
-theorem half_proportional : Proportional (half_sem (α := α)) := by
+theorem half_proportional : Proportional ⟦half⟧ := by
   intro R₁ S₁ R₂ S₂
   dsimp only []
   intro hNE₁ hNE₂ hCross

--- a/Linglib/Semantics/Quantification/Defs.lean
+++ b/Linglib/Semantics/Quantification/Defs.lean
@@ -317,7 +317,7 @@ def QuantityInvariant (q : GQ α) : Prop :=
     complement on the pointwise Boolean algebra `GQ α`, named for the linguistic
     duality square (it pairs with the non-Boolean `innerNeg`/`dualQ`).
     Example: ~every = not-every ("Not every student passed"). -/
-def outerNeg (q : GQ α) : GQ α := qᶜ
+abbrev outerNeg (q : GQ α) : GQ α := qᶜ
 
 @[simp] theorem outerNeg_apply (q : GQ α) (R S : α → Prop) : outerNeg q R S = ¬ q R S := rfl
 
@@ -333,16 +333,23 @@ def dualQ (q : GQ α) : GQ α :=
 
 /-! #### Boolean algebra (K&S §2.3) -/
 
-/-- Meet of two GQ denotations: (f ∧ g)(A,B) = f(A,B) ∧ g(A,B).
+/-- Meet of two GQ denotations: determiner conjunction. This is the meet `⊓` on the
+    pointwise Boolean algebra `GQ α`, named for the linguistic operation; as an `abbrev`
+    it shares `⊓`'s `simp` normal form.
     K&S (20): conjunction of dets, e.g., "both John's and Mary's".
     Also: "between n and m" = (at least n) ∧ (at most m). -/
-def gqMeet (f g : GQ α) : GQ α :=
-  fun R S => f R S ∧ g R S
+abbrev gqMeet (f g : GQ α) : GQ α := f ⊓ g
 
-/-- Join of two GQ denotations: (f ∨ g)(A,B) = f(A,B) ∨ g(A,B).
+@[simp] theorem gqMeet_apply (f g : GQ α) (R S : α → Prop) :
+    gqMeet f g R S = (f R S ∧ g R S) := rfl
+
+/-- Join of two GQ denotations: determiner disjunction. This is the join `⊔` on the
+    pointwise Boolean algebra `GQ α`.
     K&S (24): disjunction of dets, e.g., "either John's or Mary's". -/
-def gqJoin (f g : GQ α) : GQ α :=
-  fun R S => f R S ∨ g R S
+abbrev gqJoin (f g : GQ α) : GQ α := f ⊔ g
+
+@[simp] theorem gqJoin_apply (f g : GQ α) (R S : α → Prop) :
+    gqJoin f g R S = (f R S ∨ g R S) := rfl
 
 /-- Restriction of a GQ by a restricting function (adjective/relative clause).
     K&S (66): h_f(s) = h(f(s)). In our representation, the adjective

--- a/Linglib/Semantics/Quantification/DomainRestriction.lean
+++ b/Linglib/Semantics/Quantification/DomainRestriction.lean
@@ -47,8 +47,6 @@ set_option autoImplicit false
 
 namespace Quantification.DomainRestriction
 
-open Quantification.Quantifier
-
 /-! ### Domain-restricted quantifiers -/
 
 /-- A domain restrictor is a predicate selecting contextually relevant entities. -/

--- a/Linglib/Semantics/Quantification/Quantifier.lean
+++ b/Linglib/Semantics/Quantification/Quantifier.lean
@@ -24,50 +24,6 @@ namespace Quantification.Quantifier
 open Core.Logic.Intensional
 open Quantification
 
-export Quantification
-  (every_sem some_sem no_sem
-   most_sem few_sem half_sem both_sem neither_sem
-   at_least_n_sem at_most_n_sem exactly_n_sem all_but_n_sem between_n_m_sem m_sem
-   count Quantity Proportional SatisfiesUniversals
-   every_conservative some_conservative no_conservative
-   most_conservative few_conservative half_conservative both_conservative
-   neither_conservative
-   at_least_n_conservative at_most_n_conservative exactly_n_conservative
-   all_but_n_conservative between_n_m_conservative
-   every_scope_up some_scope_up no_scope_down few_scope_down most_scope_up
-   at_least_n_scope_up at_most_n_scope_down
-   every_restrictor_down some_restrictor_up no_restrictor_down
-   at_least_n_restrictor_up at_most_n_restrictor_down
-   some_symmetric no_symmetric
-   some_intersective no_intersective
-   every_laa no_laa no_raa laa_characterization
-   innerNeg_every_eq_no dualQ_every_eq_some outerNeg_some_eq_no
-   every_positive_strong no_negative_strong_nonempty
-   some_existential no_existential
-   every_transitive every_antisymmetric some_quasi_reflexive no_quasi_universal
-   every_doubleMono some_doubleMono no_doubleMono notAll_doubleMono
-   every_filtrating
-   every_contradicts_notEvery no_contradicts_some
-   a_e_contrary subalternation_a_i subalternation_e_o subcontrariety_i_o
-   every_satisfies_isContradictory_pointwise
-   some_upSE some_upSW every_downNW every_downNE no_downNW no_downNE
-   some_downNE some_smooth every_upSE_direct every_smooth no_coSmooth_partial
-   most_downNE most_upSE most_smooth at_least_n_downNE at_least_n_smooth
-   at_most_n_coSmooth
-   forall_bij_inv exists_bij_inv count_bij_inv
-   quantity_outerNeg quantity_gqMeet
-   at_least_n_quantity at_most_n_quantity exactly_n_quantity
-   some_quantity no_quantity every_quantity
-   most_quantity few_quantity half_quantity
-   all_but_n_quantity between_n_m_quantity
-   some_eq_at_least_1 at_most_eq_outerNeg_at_least_succ no_eq_at_most_0
-   exactly_eq_meet_at_least_at_most all_but_0_eq_every
-   some_satisfiesUniversals every_satisfiesUniversals no_satisfiesUniversals
-   most_satisfiesUniversals few_satisfiesUniversals
-   at_least_n_satisfiesUniversals at_most_n_satisfiesUniversals
-   most_proportional few_proportional half_proportional
-   quantityInvariant_of_quantity quantity_of_quantityInvariant)
-
 /-! ### Semantic-type alias -/
 
 /-- The determiner type ⟨⟨e,t⟩,⟨⟨e,t⟩,t⟩⟩. -/

--- a/Linglib/Semantics/Quantification/Syllogistic/Forms.lean
+++ b/Linglib/Semantics/Quantification/Syllogistic/Forms.lean
@@ -37,7 +37,7 @@ for the full opposition diagram in the Demey–Smessaert sense.
 
 namespace Quantification.Syllogistic
 
-open Quantification.Quantifier
+open Quantification
   (every_sem some_sem no_sem subalternation_a_i)
 
 /-! ### Syllogistic forms (modern reading, no existential import) -/

--- a/Linglib/Studies/Asudeh2022.lean
+++ b/Linglib/Studies/Asudeh2022.lean
@@ -55,6 +55,7 @@ namespace Asudeh2022
 open Core.Logic.Intensional
 open Semantics.Montague
 open Quantification.Quantifier
+open Quantification
 
 -- ════════════════════════════════════════════════════════════════════
 -- § Glue Logic: Implicational Fragment of Linear Logic

--- a/Linglib/Studies/BarwiseCooper1981.lean
+++ b/Linglib/Studies/BarwiseCooper1981.lean
@@ -43,31 +43,11 @@ to the GQ property predicates in `Quantification` and
 - `MonotonicitySimplicity`, `ConservativitySimplicity`, `QuantitySimplicity`:
   [van-de-pol-etal-2023] LZ complexity effect sizes.
 
-## Thread map
-
-- **Formal definitions**: `Quantification` — `Conservative`, `ScopeUpwardMono`,
-  `ScopeDownwardMono`, `QuantityInvariant`, `PositiveStrong`, `QSymmetric`,
-  `outerNeg`, `innerNeg`, `dualQ`
-- **Concrete denotations**: `Quantification.Quantifier` —
-  `every_sem`, `some_sem`, `no_sem`, `most_sem`, `few_sem`, `half_sem`
-- **Fragment entries**: `English.Determiners.QuantityWord.gqDenotation`
-- **Domain restriction**: `Quantification.DomainRestriction` —
-  `DomainRestrictor`, `DDRP`, `conservative_domain_restricted`
-- **Impossibility theorems**: `Quantification.NumberTreeGQ` —
-  `no_asymmetric`, `no_strict_partial_order`, `no_euclidean`
-- **Counting formula**: `Quantification.conservativeQuantifierCount`
-- **Appendix C** (this file, below): C12 — *more than half* is not
-  first-order definable over finite models (`more_than_half_not_definable`,
-  restated through the codebase's ⟦most⟧ as `most_sem_not_definable`);
-  C13 — not definable even from the unrelativized majority quantifier
-  (`more_than_half_not_Q_definable`): *most* is a determiner.
-
 -/
 
 namespace BarwiseCooper1981
 
 open English.Determiners (Monotonicity Strength QuantityWord)
-open Quantification.Quantifier
 open Quantification
 open Quantification.DomainRestriction (DomainRestrictor
   conservative_domain_restricted)
@@ -85,12 +65,12 @@ theorem conservativity_universal :
     Conservative (q.gqDenotation (α := α)) := by
   intro q α inst inst2
   cases q <;> simp only [QuantityWord.gqDenotation]
-  · exact Quantification.Quantifier.no_conservative
-  · exact Quantification.Quantifier.few_conservative
-  · exact Quantification.Quantifier.some_conservative
-  · exact Quantification.Quantifier.half_conservative
-  · exact Quantification.Quantifier.most_conservative
-  · exact Quantification.Quantifier.every_conservative
+  · exact Quantification.no_conservative
+  · exact Quantification.few_conservative
+  · exact Quantification.some_conservative
+  · exact Quantification.half_conservative
+  · exact Quantification.most_conservative
+  · exact Quantification.every_conservative
 
 -- ============================================================================
 -- §2. [mostowski-1957] / [keenan-stavi-1986]: Quantity
@@ -273,7 +253,7 @@ end ToyWitnesses
 theorem dual_all_eq_some {α : Type*} [Fintype α] [DecidableEq α] :
     dualQ (QuantityWord.all.gqDenotation (α := α)) = QuantityWord.some_.gqDenotation (α := α) := by
   simp only [QuantityWord.gqDenotation]
-  exact Quantification.Quantifier.dualQ_every_eq_some
+  exact Quantification.dualQ_every_eq_some
 
 /-- Inner negation maps ⟦every⟧ to ⟦no⟧: every~ = no ([barwise-cooper-1981] §4.11).
     ∀x. R(x) → ¬S(x) = ¬∃x. R(x) ∧ S(x).
@@ -281,7 +261,7 @@ theorem dual_all_eq_some {α : Type*} [Fintype α] [DecidableEq α] :
 theorem innerNeg_all_eq_none {α : Type*} [Fintype α] [DecidableEq α] :
     innerNeg (QuantityWord.all.gqDenotation (α := α)) = QuantityWord.none_.gqDenotation (α := α) := by
   simp only [QuantityWord.gqDenotation]
-  exact Quantification.Quantifier.innerNeg_every_eq_no
+  exact Quantification.innerNeg_every_eq_no
 
 /-- Outer negation maps ⟦some⟧ to ⟦no⟧: ~some = no ([barwise-cooper-1981] §4.11).
     ¬(∃x. R(x) ∧ S(x)) = ∀x. R(x) → ¬S(x).
@@ -289,7 +269,7 @@ theorem innerNeg_all_eq_none {α : Type*} [Fintype α] [DecidableEq α] :
 theorem outerNeg_some_eq_none {α : Type*} [Fintype α] [DecidableEq α] :
     outerNeg (QuantityWord.some_.gqDenotation (α := α)) = QuantityWord.none_.gqDenotation (α := α) := by
   simp only [QuantityWord.gqDenotation]
-  exact Quantification.Quantifier.outerNeg_some_eq_no
+  exact Quantification.outerNeg_some_eq_no
 
 -- ============================================================================
 -- §9. Left anti-additivity → NPI licensing
@@ -315,8 +295,8 @@ theorem positive_strong_determiners_upward_monotone :
     ScopeUpwardMono (q.gqDenotation (α := α)) := by
   intro q α inst inst2 hPS
   cases q
-  case all => exact Quantification.Quantifier.every_scope_up
-  case some_ => exact Quantification.Quantifier.some_scope_up
+  case all => exact Quantification.every_scope_up
+  case some_ => exact Quantification.some_scope_up
   -- TODO: Adapt remaining cases for Prop-valued GQs.
   -- The vacuity argument (PositiveStrong contradicted by R = fun _ => False)
   -- needs count lemmas adapted for Prop predicates.

--- a/Linglib/Studies/Belnap1970.lean
+++ b/Linglib/Studies/Belnap1970.lean
@@ -74,7 +74,7 @@ namespace Belnap1970
 open Semantics.Presupposition (PartialProp)
 open Core.Duality (Truth3)
 open Aristotelian (Square SquareRelations)
-open Quantification.Quantifier
+open Quantification
 open Semantics.Montague (ToyEntity)
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -74,7 +74,7 @@ open Semantics.Composition
 open Semantics.Composition.Continuation
 open Semantics.Composition.Tree
 open Pragmatics.Expressives
-open Quantification.Quantifier
+open Quantification
 open Semantics.Reference.Binding
 open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables

--- a/Linglib/Studies/DavidsonGagne2022.lean
+++ b/Linglib/Studies/DavidsonGagne2022.lean
@@ -73,7 +73,7 @@ set_option autoImplicit false
 
 namespace DavidsonGagne2022
 
-open Quantification.Quantifier (every_sem some_sem)
+open Quantification (every_sem some_sem)
 open Quantification.DomainRestriction
 open ASL.Height
 

--- a/Linglib/Studies/HeimKratzer1998.lean
+++ b/Linglib/Studies/HeimKratzer1998.lean
@@ -58,6 +58,7 @@ open Semantics.Montague
 open Syntax
 open Semantics.Composition.Tree
 open Quantification.Quantifier
+open Quantification
 open Semantics.Montague.ToyLexicon (student_sem person_sem)
 
 /-! ### Model and lexicon -/

--- a/Linglib/Studies/Katzir2007.lean
+++ b/Linglib/Studies/Katzir2007.lean
@@ -39,7 +39,7 @@ open Syntax
 open Semantics.Composition.Tree
 open Semantics.Montague (ToyEntity)
 open Semantics.Montague.ToyLexicon (sleeps_sem student_sem)
-open Quantification.Quantifier (some_sem every_sem)
+open Quantification (some_sem every_sem)
 
 -- ════════════════════════════════════════════════════════════════════
 -- § Source Tree

--- a/Linglib/Studies/Ladusaw1979.lean
+++ b/Linglib/Studies/Ladusaw1979.lean
@@ -35,7 +35,6 @@ open Quantification
 open Typology.PolarityItem (LicensingContext)
 open Core.Logic.Intensional
 open Semantics.Montague (ToyEntity)
-open Quantification.Quantifier
 
 -- ============================================================================
 -- §1. Monotonicity classification of licensing contexts

--- a/Linglib/Studies/RitchieSchiller2024.lean
+++ b/Linglib/Studies/RitchieSchiller2024.lean
@@ -61,7 +61,7 @@ set_option autoImplicit false
 
 namespace RitchieSchiller2024
 
-open Quantification.Quantifier (every_sem some_sem)
+open Quantification (every_sem some_sem)
 open Quantification.DomainRestriction
 
 -- ============================================================================

--- a/Linglib/Studies/ScontrasPearl2021Quantification.lean
+++ b/Linglib/Studies/ScontrasPearl2021Quantification.lean
@@ -325,7 +325,7 @@ namespace EveryNot
 open BigOperators
 open Real (rpow rpow_nonneg)
 open Core.Logic.Intensional (Denot)
-open Quantification.Quantifier (every_sem)
+open Quantification (every_sem)
 open Semantics.Scope (ScopeConfig ScopeDerivation)
 
 /-- Utterances: null (silence) or "Every horse didn't jump". -/
@@ -844,7 +844,7 @@ theorem atLeast_truth_table :
 -- Compositional Grounding
 
 open Core.Logic.Intensional (Denot)
-open Quantification.Quantifier (exactly_n_sem at_least_n_sem)
+open Quantification (exactly_n_sem at_least_n_sem)
 open Semantics.Scope (ScopeConfig ScopeDerivation)
 
 /-- 4-horse domain for grounding two-not truth conditions in numeral quantifier semantics. -/
@@ -891,14 +891,14 @@ noncomputable def twoNotExact_inverse (w : JumpOutcome4) : Prop :=
 theorem exact_surface_from_exactly_n_sem :
     ∀ w, (twoNotTruth .exact .surface w = true) ↔ twoNotExact_surface w := by
   intro w; cases w <;> simp [twoNotTruth, twoNotExact_surface, exactly_n_sem,
-    horse4_sem, jumpIn4_sem, jumpIn4, Quantification.Quantifier.count] <;> sorry
+    horse4_sem, jumpIn4_sem, jumpIn4, Quantification.count] <;> sorry
 
 /-- Exact inverse grounding: `twoNotTruth .exact .inverse` derives from
     negating the compositional ⟦exactly 2⟧(horse)(jump). -/
 theorem exact_inverse_from_exactly_n_sem :
     ∀ w, (twoNotTruth .exact .inverse w = true) ↔ twoNotExact_inverse w := by
   intro w; cases w <;> simp [twoNotTruth, twoNotExact_inverse, exactly_n_sem,
-    horse4_sem, jumpIn4_sem, jumpIn4, Quantification.Quantifier.count] <;> sorry
+    horse4_sem, jumpIn4_sem, jumpIn4, Quantification.count] <;> sorry
 
 -- At-least semantics grounding
 
@@ -917,14 +917,14 @@ noncomputable def twoNotAtLeast_inverse (w : JumpOutcome4) : Prop :=
 theorem atLeast_surface_from_at_least_n_sem :
     ∀ w, (twoNotTruth .atLeast .surface w = true) ↔ twoNotAtLeast_surface w := by
   intro w; cases w <;> simp [twoNotTruth, twoNotAtLeast_surface, at_least_n_sem,
-    horse4_sem, jumpIn4_sem, jumpIn4, Quantification.Quantifier.count] <;> sorry
+    horse4_sem, jumpIn4_sem, jumpIn4, Quantification.count] <;> sorry
 
 /-- At-least inverse grounding: `twoNotTruth .atLeast .inverse` derives from
     negating the compositional ⟦at least 2⟧(horse)(jump). -/
 theorem atLeast_inverse_from_at_least_n_sem :
     ∀ w, (twoNotTruth .atLeast .inverse w = true) ↔ twoNotAtLeast_inverse w := by
   intro w; cases w <;> simp [twoNotTruth, twoNotAtLeast_inverse, at_least_n_sem,
-    horse4_sem, jumpIn4_sem, jumpIn4, Quantification.Quantifier.count] <;> sorry
+    horse4_sem, jumpIn4_sem, jumpIn4, Quantification.count] <;> sorry
 
 /-- RSA meaning is grounded in compositional semantics: the meaning function
     used by the two-not RSA config matches the GQT numeral quantifiers. -/


### PR DESCRIPTION
Audit-driven GQ API ergonomics pass:
- **Transparent ops**: `outerNeg`/`gqMeet`/`gqJoin` become `abbrev`s for `ᶜ`/`⊓`/`⊔`, fixing a `simp only` non-confluence between the named and mathlib-BA surfaces.
- **No re-export drift**: deleted the hand-maintained `export Quantification (~90 names)` block in `Quantifier.lean`; ~15 consumers switched to `open Quantification`.
- **Denotation brackets**: `⟦every⟧`/`⟦some⟧`/`⟦no⟧` (and `⟦most⟧`/`⟦few⟧`/`⟦half⟧`/…) as local α-pinning notation, eliminating ~100 `(α := α)` annotations in `Basic`/`Counting` (Heim & Kratzer `⟦·⟧`).
- Exposed the `count_*` helpers a new counting determiner needs.
No umbrella import (blanket imports forbidden per CLAUDE.md).