### PR TITLE
feat(Semantics/Lexical): derive event template from root signature

### DIFF
--- a/Linglib/Semantics/Lexical/EventStructure.lean
+++ b/Linglib/Semantics/Lexical/EventStructure.lean
@@ -1,6 +1,7 @@
 import Linglib.Semantics.ArgumentStructure.EntailmentProfile
 import Linglib.Features.Aktionsart
 import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
+import Linglib.Semantics.Lexical.Roots.Closure
 
 /-!
 # Event Structure Templates
@@ -117,6 +118,62 @@ instance (t : Template) : Decidable t.HasResultState := by
 theorem cause_implies_resultState (t : Template) :
     t.HasCause → t.HasResultState := by
   cases t <;> decide
+
+/-! ### From root signature to template ([beavers-koontz-garboden-2020] §1.3)
+
+`Template` is a **function** of the root's collocational kind signature, not a
+parallel theory: `.cause` → accomplishment, `.result` → achievement, `.manner` →
+activity, else state. The `HasCause`/`HasResultState` diagnostics then reduce to
+signature membership (`ofSignature_hasCause_iff`/`hasResultState_iff`), so the
+denotational result entailment and `cause_implies_resultState` are one fact seen
+through the signature. -/
+
+section Signature
+open Verb (LexKind Root)
+
+/-- The event-structure template determined by a root's (closed) kind signature. -/
+def Template.ofSignature (σ : Root.FeatureSignature) : Template :=
+  if LexKind.cause ∈ σ then .accomplishment
+  else if LexKind.result ∈ σ then .achievement
+  else if LexKind.manner ∈ σ then .activity
+  else .state
+
+/-- `HasCause` reduces to carrying the `cause` kind. -/
+theorem ofSignature_hasCause_iff (σ : Root.FeatureSignature) :
+    (Template.ofSignature σ).HasCause ↔ LexKind.cause ∈ σ := by
+  unfold Template.ofSignature
+  split_ifs <;> simp_all [Template.HasCause]
+
+/-- For a well-formed (collocationally closed) signature, `HasResultState`
+    reduces to carrying the `result` kind — via `cause` ⟹ `result`. -/
+theorem ofSignature_hasResultState_iff {σ : Root.FeatureSignature}
+    (h : σ.WellFormed) :
+    (Template.ofSignature σ).HasResultState ↔ LexKind.result ∈ σ := by
+  have hcr : LexKind.cause ∈ σ → LexKind.result ∈ σ := by
+    intro hc
+    have hr : LexKind.result ∈ Root.FeatureSignature.close σ :=
+      (Root.FeatureSignature.mem_close_iff σ LexKind.result).mpr
+        ⟨LexKind.cause, hc, by decide⟩
+    have he : Root.FeatureSignature.close σ = σ := h
+    rwa [he] at hr
+  unfold Template.ofSignature
+  split_ifs with hc hr hm <;> simp_all [Template.HasResultState]
+
+/-- A root's event-structure template, read off its collocational closure. -/
+def _root_.Verb.Root.template (r : Root) : Template :=
+  Template.ofSignature r.closedFeatureSignature
+
+/-- A root entails a result state (template-level) iff it carries `result` —
+    the [beavers-koontz-garboden-2020] result entailment, bridged to the
+    `EventStructure` template diagnostic. -/
+theorem _root_.Verb.Root.template_hasResultState_iff (r : Root) :
+    r.template.HasResultState ↔ LexKind.result ∈ r.closedFeatureSignature := by
+  apply ofSignature_hasResultState_iff
+  show Root.FeatureSignature.close r.closedFeatureSignature = r.closedFeatureSignature
+  unfold Verb.Root.closedFeatureSignature
+  exact Root.FeatureSignature.close_idem _
+
+end Signature
 
 /-! ### Causative/Inchoative Alternation
 

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Lexical.Roots.Closure
 import Linglib.Semantics.Verb.Denotation
+import Linglib.Semantics.Lexical.EventStructure
 
 /-!
 # Beavers & Koontz-Garboden (2020): The Roots of Verbal Meaning
@@ -205,5 +206,25 @@ theorem jog_denote_eq_manner {Entity State Time : Type*} [LinearOrder Time]
     M.denote jogV y x = M.manner jogV := by
   unfold Verb.CosModel.denote
   rw [if_neg (by decide), if_neg (by decide)]
+
+/-! ### The same contrast at the template level ([rappaport-hovav-levin-1998])
+
+`Verb.Root.template` reads the event-structure template off a root's
+collocational closure; the kinds proven above fix it, and `HasResultState`
+reduces to carrying `result` (`Verb.Root.template_hasResultState_iff`). So the
+denotational result entailment (√crack) and the template result diagnostic are
+*one fact* seen through `featureSignature`. -/
+
+theorem flat_template : flat.template = .state := by decide
+theorem jog_template : jog.template = .activity := by decide
+theorem blossom_template : blossom.template = .achievement := by decide
+theorem crack_template : crack.template = .accomplishment := by decide
+
+/-- √crack's template embeds a result state (it carries `result`); √jog's does
+    not — the *break*/*hit* contrast, now at the template layer and provably the
+    same signature fact as `crack_denote_entails_result`. -/
+theorem crack_template_hasResultState : crack.template.HasResultState := by decide
+
+theorem jog_template_no_resultState : ¬ jog.template.HasResultState := by decide
 
 end BeaversKoontzGarboden2020


### PR DESCRIPTION
Adds `Template.ofSignature : Root.FeatureSignature → Template` with `ofSignature_hasCause_iff`/`hasResultState_iff` — `EventStructure.Template` is now a *function* of the root's kind signature, not a parallel theory. `Verb.Root.template` reads it off the collocational closure; `Studies/BeaversKoontzGarboden2020` shows each root's template + the result-state contrast (√crack accomplishment / √jog activity) — the same `featureSignature` fact as the denotational result entailment. Blueprint (`scratch/verb-api-blueprint.md`) step #4, signature→template half; `denote` dispatch-via-accessor + the denote↔Template connecting theorem follow.