### PR TITLE
refactor(Semantics/Lexical): rename Root.FeatureSignature to Root.Kinds

### DIFF
--- a/Linglib/Fragments/Mayan/Yukatek/Operators.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Operators.lean
@@ -23,7 +23,7 @@ or `=s` is required to form a transitive stem from an underived root:
 | `=∅` (root)     | agent-patient salient  | lexically transitive ("require two arguments")            |
 | `=s` (CAUS)     | patient-salient        | spontaneous state change; one (patient) argument salient   |
 
-The structural conditions are over (B&K-G feature signature × Coon
+The structural conditions are over (B&K-G kind signature × Coon
 arity): zero derivation tracks root transitivity
 (`Root.Arity.selectsTheme`); the two intransitive transitivisers split
 by signature (manner vs result). Each condition is the corresponding
@@ -47,7 +47,7 @@ open Yukatek.Roots
     without inherent result. -/
 def affectiveT : DerivOp :=
   { name := "=t"
-  , applies := fun r => IsAgentSalient r.featureSignature (arity r)
+  , applies := fun r => IsAgentSalient r.kinds (arity r)
   , decApplies := inferInstance }
 
 /-- Zero derivation `=∅`: signals that the root is already lexically
@@ -68,7 +68,7 @@ def zeroDeriv : DerivOp :=
     result without specified manner. -/
 def causativeS : DerivOp :=
   { name := "=s"
-  , applies := fun r => IsPatientSalient r.featureSignature (arity r)
+  , applies := fun r => IsPatientSalient r.kinds (arity r)
   , decApplies := inferInstance }
 
 /-- Positional inchoative `-tal` (allomorph `-lah`): forms a positional stem from a
@@ -79,7 +79,7 @@ def causativeS : DerivOp :=
     result, or cause atoms. -/
 def positionalTal : DerivOp :=
   { name := "-tal"
-  , applies := fun r => IsPositional r.featureSignature (arity r)
+  , applies := fun r => IsPositional r.kinds (arity r)
   , decApplies := inferInstance }
 
 /-! ### The inventory -/

--- a/Linglib/Fragments/Mayan/Yukatek/Roots.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Roots.lean
@@ -218,84 +218,84 @@ def rootTransitives : List Root := [kuc, pis, los]
 def arity (r : Root) : Root.Arity :=
   if r ∈ rootTransitives then .selectsTheme else .noTheme
 
-/-! ### Per-root feature signatures -/
+/-! ### Per-root kind signatures -/
 
 /-! Agent-salient roots → `{.manner}`. -/
 
 theorem siit_signature :
-    siit.featureSignature = {.manner} := by decide
+    siit.kinds = {.manner} := by decide
 theorem tziib_signature :
-    tziib.featureSignature = {.manner} := by decide
+    tziib.kinds = {.manner} := by decide
 theorem miis_signature :
-    miis.featureSignature = {.manner} := by decide
+    miis.kinds = {.manner} := by decide
 theorem cheh_signature :
-    cheh.featureSignature = {.manner} := by decide
+    cheh.kinds = {.manner} := by decide
 theorem paak_signature :
-    paak.featureSignature = {.manner} := by decide
+    paak.kinds = {.manner} := by decide
 
 /-! Agent-patient salient (root-transitive) roots → `{.manner}`. -/
 
 theorem kuc_signature :
-    kuc.featureSignature = {.manner} := by decide
+    kuc.kinds = {.manner} := by decide
 theorem pis_signature :
-    pis.featureSignature = {.manner} := by decide
+    pis.kinds = {.manner} := by decide
 theorem los_signature :
-    los.featureSignature = {.manner} := by decide
+    los.kinds = {.manner} := by decide
 
 /-! Patient-salient roots → `{.result}`. -/
 
 theorem kiim_signature :
-    kiim.featureSignature = {.result} := by decide
+    kiim.kinds = {.result} := by decide
 theorem haanCease_signature :
-    haanCease.featureSignature = {.result} := by decide
+    haanCease.kinds = {.result} := by decide
 theorem luub_signature :
-    luub.featureSignature = {.result} := by decide
+    luub.kinds = {.result} := by decide
 theorem ok_signature :
-    ok.featureSignature = {.result} := by decide
+    ok.kinds = {.result} := by decide
 theorem ah_signature :
-    ah.featureSignature = {.result} := by decide
+    ah.kinds = {.result} := by decide
 theorem wen_signature :
-    wen.featureSignature = {.result} := by decide
+    wen.kinds = {.result} := by decide
 theorem siih_signature :
-    siih.featureSignature = {.result} := by decide
+    siih.kinds = {.result} := by decide
 theorem tuub_signature :
-    tuub.featureSignature = {.result} := by decide
+    tuub.kinds = {.result} := by decide
 theorem kaah_signature :
-    kaah.featureSignature = {.result} := by decide
+    kaah.kinds = {.result} := by decide
 theorem chuun_signature :
-    chuun.featureSignature = {.result} := by decide
+    chuun.kinds = {.result} := by decide
 theorem chenCease_signature :
-    chenCease.featureSignature = {.result} := by decide
+    chenCease.kinds = {.result} := by decide
 theorem hoop_signature :
-    hoop.featureSignature = {.result} := by decide
+    hoop.kinds = {.result} := by decide
 theorem heel_signature :
-    heel.featureSignature = {.result} := by decide
+    heel.kinds = {.result} := by decide
 theorem paat_signature :
-    paat.featureSignature = {.result} := by decide
+    paat.kinds = {.result} := by decide
 
 /-! Motion roots (also patient-salient) → `{.result}`. -/
 
 theorem maan_signature :
-    maan.featureSignature = {.result} := by decide
+    maan.kinds = {.result} := by decide
 theorem taal_signature :
-    taal.featureSignature = {.result} := by decide
+    taal.kinds = {.result} := by decide
 theorem bin_signature :
-    bin.featureSignature = {.result} := by decide
+    bin.kinds = {.result} := by decide
 theorem naak_signature :
-    naak.featureSignature = {.result} := by decide
+    naak.kinds = {.result} := by decide
 theorem liik_signature :
-    liik.featureSignature = {.result} := by decide
+    liik.kinds = {.result} := by decide
 
 /-! Positional roots → `{.state}`. -/
 
 theorem cin_signature :
-    cin.featureSignature = {.state} := by decide
+    cin.kinds = {.state} := by decide
 theorem kul_signature :
-    kul.featureSignature = {.state} := by decide
+    kul.kinds = {.state} := by decide
 
-/-! ### Per-root closed feature signatures -/
+/-! ### Per-root closed kind signatures -/
 
-/-! The collocational closure (`Root.FeatureSignature.close`) adds `.state`
+/-! The collocational closure (`Root.Kinds.close`) adds `.state`
     to any signature containing `.result`, and `.result` + `.state` to
     any containing `.cause`. No Yukatek root here carries a `.cause`
     atom, so only the result→state edge fires. Closure does *not*
@@ -307,37 +307,37 @@ theorem kul_signature :
     (cf. `Lucy1994.predictedClass_closure_invariant`). -/
 
 theorem siit_closed_signature :
-    siit.closedFeatureSignature = {.manner} := by decide
+    siit.closedKinds = {.manner} := by decide
 
 theorem tziib_closed_signature :
-    tziib.closedFeatureSignature = {.manner} := by decide
+    tziib.closedKinds = {.manner} := by decide
 
 theorem kuc_closed_signature :
-    kuc.closedFeatureSignature = {.manner} := by decide
+    kuc.closedKinds = {.manner} := by decide
 
 theorem pis_closed_signature :
-    pis.closedFeatureSignature = {.manner} := by decide
+    pis.closedKinds = {.manner} := by decide
 
 theorem los_closed_signature :
-    los.closedFeatureSignature = {.manner} := by decide
+    los.closedKinds = {.manner} := by decide
 
 theorem kiim_closed_signature :
-    kiim.closedFeatureSignature = {.state, .result} := by decide
+    kiim.closedKinds = {.state, .result} := by decide
 
 theorem haanCease_closed_signature :
-    haanCease.closedFeatureSignature = {.state, .result} := by decide
+    haanCease.closedKinds = {.state, .result} := by decide
 
 theorem luub_closed_signature :
-    luub.closedFeatureSignature = {.state, .result} := by decide
+    luub.closedKinds = {.state, .result} := by decide
 
 theorem ok_closed_signature :
-    ok.closedFeatureSignature = {.state, .result} := by decide
+    ok.closedKinds = {.state, .result} := by decide
 
 theorem cin_closed_signature :
-    cin.closedFeatureSignature = {.state} := by decide
+    cin.closedKinds = {.state} := by decide
 
 theorem kul_closed_signature :
-    kul.closedFeatureSignature = {.state} := by decide
+    kul.closedKinds = {.state} := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 7. Class Lists

--- a/Linglib/Morphology/RootTypology.lean
+++ b/Linglib/Morphology/RootTypology.lean
@@ -172,24 +172,24 @@ which is precisely why outcome cardinality is a genuinely independent dimension
 of root content, the one that drives reversative *un-* where the manner/result
 typology cannot. -/
 
-/-- The change-entailment type of a root, derived from its feature signature:
+/-- The change-entailment type of a root, derived from its kind signature:
     a root entails change iff its signature carries `result` ([beavers-etal-2021]).
     The derived analog of `RootClassification.changeType`. -/
 def Verb.Root.changeType (r : Verb.Root) : RootType :=
-  if LexKind.result ∈ r.featureSignature then .result else .propertyConcept
+  if LexKind.result ∈ r.kinds then .result else .propertyConcept
 
 theorem Verb.Root.changeType_eq_result_iff (r : Verb.Root) :
     r.changeType = .result ↔ r.HasResult := by
   unfold Verb.Root.changeType Verb.Root.HasResult
-  by_cases h : LexKind.result ∈ r.featureSignature <;> simp [h]
+  by_cases h : LexKind.result ∈ r.kinds <;> simp [h]
 
 /-- `changeType` is blind to outcomes: same entailments ⇒ same `changeType`,
     whatever the `outcomes`. The formal statement of why [bhadra-2024]'s outcome
     cardinality is an independent axis the manner/result signature cannot see. -/
 theorem Verb.Root.changeType_ignores_outcomes {r r' : Verb.Root}
     (h : r.entailments = r'.entailments) : r.changeType = r'.changeType := by
-  have hsig : r.featureSignature = r'.featureSignature := by
-    unfold Verb.Root.featureSignature; rw [h]
+  have hsig : r.kinds = r'.kinds := by
+    unfold Verb.Root.kinds; rw [h]
   unfold Verb.Root.changeType; rw [hsig]
 
 /-- A *bend*-like and a *break*-like root with the same entailments but different
@@ -390,7 +390,7 @@ theorem result_roots_witness_against_bifurcation :
 theorem pc_roots_consistent_with_bifurcation :
     RootType.entailsChange .propertyConcept = false := rfl
 
-/-- **B&[beavers-koontz-garboden-2020] strengthened bifurcation failure via `Root.FeatureSignature`.**
+/-- **B&[beavers-koontz-garboden-2020] strengthened bifurcation failure via `Root.Kinds`.**
 
     [beavers-etal-2021] show roots can entail CHANGE (one templatic notion).
     B&[beavers-koontz-garboden-2020] show roots can entail CHANGE, CAUSATION, and MANNER —
@@ -399,16 +399,16 @@ theorem pc_roots_consistent_with_bifurcation :
     roots encoding manner+cause (√GUILLOTINE, √HAND) violate bifurcation
     on three separate dimensions simultaneously.
 
-    Witness: `Root.FeatureSignature.fullSpec` carries all four kinds. -/
+    Witness: `Root.Kinds.fullSpec` carries all four kinds. -/
 theorem bkg_bifurcation_fails_all_dimensions :
     -- Roots can entail change (result kind)
-    LexKind.result ∈ Root.FeatureSignature.fullSpec ∧
+    LexKind.result ∈ Root.Kinds.fullSpec ∧
     -- Roots can entail causation (cause kind)
-    LexKind.cause ∈ Root.FeatureSignature.fullSpec ∧
+    LexKind.cause ∈ Root.Kinds.fullSpec ∧
     -- Roots can entail manner (manner kind)
-    LexKind.manner ∈ Root.FeatureSignature.fullSpec ∧
+    LexKind.manner ∈ Root.Kinds.fullSpec ∧
     -- All at once — not just one dimension
-    LexKind.state ∈ Root.FeatureSignature.fullSpec := by decide
+    LexKind.state ∈ Root.Kinds.fullSpec := by decide
 
 /-- Multiple Levin classes witness the stronger bifurcation failure. -/
 theorem bkg_bifurcation_multiple_witnesses :
@@ -625,7 +625,7 @@ theorem RootDen.pc_respects {Entity State Event : Type}
     (RootDen.pc sp : RootDen Entity State Event).denotationViolatesMRC = false := rfl
 
 /-- **Bridge: denotation-level MRC → signature-level MRC
-    (`Root.FeatureSignature.HasMannerAndResult`).**
+    (`Root.Kinds.HasMannerAndResult`).**
     MRC violation requires BOTH conditions — having manner alone
     (if such a constructor existed) would not be a violation. -/
 theorem RootDen.mrc_requires_both {Entity State Event : Type}
@@ -881,17 +881,17 @@ theorem break_no_MRC_violation : breakDiagnostics.showsMRCViolation = false := r
 theorem hit_no_MRC_violation : hitDiagnostics.showsMRCViolation = false := rfl
 theorem drown_MRC_violation : drownDiagnostics.showsMRCViolation = true := rfl
 
-/-- Cut is MRC-violating by BOTH diagnostics AND feature signature. -/
+/-- Cut is MRC-violating by BOTH diagnostics AND kind signature. -/
 theorem cut_diagnostics_match_entailments :
     cutDiagnostics.showsMRCViolation = true ↔
     (LevinClass.rootEntailments .cut).HasMannerAndResult := by decide
 
-/-- Break is MRC-respecting by BOTH diagnostics AND feature signature. -/
+/-- Break is MRC-respecting by BOTH diagnostics AND kind signature. -/
 theorem break_diagnostics_match_entailments :
     breakDiagnostics.showsMRCViolation = true ↔
     (LevinClass.rootEntailments .break_).HasMannerAndResult := by decide
 
-/-- Hit is MRC-respecting by BOTH diagnostics AND feature signature. -/
+/-- Hit is MRC-respecting by BOTH diagnostics AND kind signature. -/
 theorem hit_diagnostics_match_entailments :
     hitDiagnostics.showsMRCViolation = true ↔
     (LevinClass.rootEntailments .hit).HasMannerAndResult := by decide
@@ -1459,7 +1459,7 @@ theorem same_change_same_morphosyntax (r₁ r₂ : RootClassification)
     positions give 32 theoretical cells, of which 7 are attested and
     the rest are principled gaps. -/
 structure FullRootSpec where
-  entailments : Root.FeatureSignature
+  entailments : Root.Kinds
   position : Root.Position
   deriving DecidableEq
 
@@ -1495,29 +1495,29 @@ instance (s : FullRootSpec) : Decidable s.WellFormed :=
 
 /-- √FLAT: +S −M −R −C, complement. Property concept root. -/
 def FullRootSpec.flat : FullRootSpec :=
-  ⟨Root.FeatureSignature.propertyConcept, .complement⟩
+  ⟨Root.Kinds.propertyConcept, .complement⟩
 
 /-- √BLOSSOM: +S −M +R −C, complement. Pure result root. -/
 def FullRootSpec.blossom : FullRootSpec :=
-  ⟨Root.FeatureSignature.pureResult, .complement⟩
+  ⟨Root.Kinds.pureResult, .complement⟩
 
 /-- √CRACK: +S −M +R +C, complement. Causative result root. -/
 def FullRootSpec.crack : FullRootSpec :=
-  ⟨Root.FeatureSignature.causativeResult, .complement⟩
+  ⟨Root.Kinds.causativeResult, .complement⟩
 
 /-- √JOG: −S +M −R −C, adjoined. Pure manner root. -/
 def FullRootSpec.jog : FullRootSpec :=
-  ⟨Root.FeatureSignature.pureManner, .adjoined⟩
+  ⟨Root.Kinds.pureManner, .adjoined⟩
 
 /-- √DROWN: +S +M +R +C, complement. Manner+result in complement position —
     the manner restricts HOW the state is caused. -/
 def FullRootSpec.drown : FullRootSpec :=
-  ⟨Root.FeatureSignature.fullSpec, .complement⟩
+  ⟨Root.Kinds.fullSpec, .complement⟩
 
 /-- √TOSS: +S +M +R +C, adjoined. Manner+result in adjunct position —
     the manner is the primary event that happens to cause a state change. -/
 def FullRootSpec.toss : FullRootSpec :=
-  ⟨Root.FeatureSignature.fullSpec, .adjoined⟩
+  ⟨Root.Kinds.fullSpec, .adjoined⟩
 
 /-- √HAND: same entailments + position as √TOSS. The difference is in
     the ditransitive layer (DitransitiveRootClass.causedPossession vs
@@ -1526,7 +1526,7 @@ abbrev FullRootSpec.hand : FullRootSpec := FullRootSpec.toss
 
 /-- √EXIST: −S −M −R −C, complement. Minimal stative root. -/
 def FullRootSpec.exist : FullRootSpec :=
-  ⟨Root.FeatureSignature.minimal, .complement⟩
+  ⟨Root.Kinds.minimal, .complement⟩
 
 -- All attested types are well-formed
 theorem flat_wf : FullRootSpec.flat.WellFormed := by decide
@@ -1576,7 +1576,7 @@ inductive TemplateHead where
     - +manner alone → no v_act (manner without causation doesn't entail
       activity — √JOG specifies jogging manner but v_act still provides
       the activity frame) -/
-def Verb.Root.FeatureSignature.entailedHeads (s : Verb.Root.FeatureSignature) : List TemplateHead :=
+def Verb.Root.Kinds.entailedHeads (s : Verb.Root.Kinds) : List TemplateHead :=
   (if LexKind.result ∈ s then [.vBecome] else []) ++
   (if LexKind.cause ∈ s then [.vCause] else []) ++
   (if LexKind.manner ∈ s ∧ LexKind.cause ∈ s then [.vAct] else [])
@@ -1597,51 +1597,51 @@ def DitransitiveRootClass.additionalHeads : DitransitiveRootClass → List Templ
     The root specifies jogging manner, but v_act still provides
     the activity frame — the root doesn't make it redundant. -/
 theorem jog_no_heads :
-    Root.FeatureSignature.pureManner.entailedHeads = [] := by decide
+    Root.Kinds.pureManner.entailedHeads = [] := by decide
 
 /-- √FLAT (propertyConcept): no template heads entailed.
     The root names a state, but doesn't entail change or cause. -/
 theorem flat_no_heads :
-    Root.FeatureSignature.propertyConcept.entailedHeads = [] := by decide
+    Root.Kinds.propertyConcept.entailedHeads = [] := by decide
 
 /-- √BLOSSOM (pureResult): v_become entailed.
     The root entails change — v_become's contribution is redundant. -/
 theorem blossom_heads :
-    Root.FeatureSignature.pureResult.entailedHeads = [.vBecome] := by decide
+    Root.Kinds.pureResult.entailedHeads = [.vBecome] := by decide
 
 /-- √CRACK (causativeResult): v_become + v_cause entailed.
     The root entails change AND causation. -/
 theorem crack_heads :
-    Root.FeatureSignature.causativeResult.entailedHeads = [.vBecome, .vCause] := by
+    Root.Kinds.causativeResult.entailedHeads = [.vBecome, .vCause] := by
   decide
 
 /-- √DROWN (fullSpec): v_become + v_cause + v_act entailed.
     The root entails change, causation, AND activity (manner that causes). -/
 theorem drown_heads :
-    Root.FeatureSignature.fullSpec.entailedHeads = [.vBecome, .vCause, .vAct] := by
+    Root.Kinds.fullSpec.entailedHeads = [.vBecome, .vCause, .vAct] := by
   decide
 
 /-- √TOSS (fullSpec + ballistic): v_become + v_cause + v_act + P_loc.
     Verbal heads from entailments + P_loc from ditransitive class. -/
 theorem toss_heads :
-    Root.FeatureSignature.fullSpec.entailedHeads ++
+    Root.Kinds.fullSpec.entailedHeads ++
     DitransitiveRootClass.additionalHeads .ballisticMotion =
     [.vBecome, .vCause, .vAct, .pLoc] := by decide
 
 /-- √HAND (fullSpec + causedPossession): all 5 heads.
     Verbal heads from entailments + P_loc + P_have from ditransitive class. -/
 theorem hand_heads :
-    Root.FeatureSignature.fullSpec.entailedHeads ++
+    Root.Kinds.fullSpec.entailedHeads ++
     DitransitiveRootClass.additionalHeads .causedPossession =
     [.vBecome, .vCause, .vAct, .pLoc, .pHave] := by decide
 
 /-- Monotonicity: more root entailments → weakly more heads entailed.
     Pure result ⊂ causative result ⊂ full spec (by inclusion). -/
 theorem heads_monotone :
-    Root.FeatureSignature.pureResult.entailedHeads.length ≤
-    Root.FeatureSignature.causativeResult.entailedHeads.length ∧
-    Root.FeatureSignature.causativeResult.entailedHeads.length ≤
-    Root.FeatureSignature.fullSpec.entailedHeads.length := ⟨by decide, by decide⟩
+    Root.Kinds.pureResult.entailedHeads.length ≤
+    Root.Kinds.causativeResult.entailedHeads.length ∧
+    Root.Kinds.causativeResult.entailedHeads.length ≤
+    Root.Kinds.fullSpec.entailedHeads.length := ⟨by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
 -- § 19. Gap Predictions (B&[beavers-koontz-garboden-2020] §5.4.1, Table 12)
@@ -1677,19 +1677,19 @@ B&KG (§5.4.1) identify three principled gap types:
 
 /-- Gap type 1: adjoined position requires manner. -/
 theorem gap_adjoined_no_manner :
-    ¬ (FullRootSpec.mk Root.FeatureSignature.propertyConcept .adjoined).PositionLicensed := by
+    ¬ (FullRootSpec.mk Root.Kinds.propertyConcept .adjoined).PositionLicensed := by
   decide
 
 theorem gap_adjoined_result :
-    ¬ (FullRootSpec.mk Root.FeatureSignature.pureResult .adjoined).PositionLicensed := by
+    ¬ (FullRootSpec.mk Root.Kinds.pureResult .adjoined).PositionLicensed := by
   decide
 
 theorem gap_adjoined_causativeResult :
-    ¬ (FullRootSpec.mk Root.FeatureSignature.causativeResult .adjoined).PositionLicensed := by
+    ¬ (FullRootSpec.mk Root.Kinds.causativeResult .adjoined).PositionLicensed := by
   decide
 
 theorem gap_adjoined_minimal :
-    ¬ (FullRootSpec.mk Root.FeatureSignature.minimal .adjoined).PositionLicensed := by
+    ¬ (FullRootSpec.mk Root.Kinds.minimal .adjoined).PositionLicensed := by
   decide
 
 /-- Gap type 2: +manner +state −result −cause is incoherent. -/
@@ -1703,10 +1703,10 @@ theorem gap_manner_state_no_result_adj :
 
 /-- Gap type 3: well-formedness violations. -/
 theorem gap_result_no_state :
-    ¬ ({.result} : Root.FeatureSignature).WellFormed := by decide
+    ¬ ({.result} : Root.Kinds).WellFormed := by decide
 
 theorem gap_cause_no_result :
-    ¬ ({.state, .cause} : Root.FeatureSignature).WellFormed := by decide
+    ¬ ({.state, .cause} : Root.Kinds).WellFormed := by decide
 
 /-! ### Attested cells are well-formed and recognized -/
 
@@ -1724,7 +1724,7 @@ theorem exist_attested : FullRootSpec.exist.IsAttestedCell := by decide
     without external causation. Left as NOT attested per Table 12,
     pending further research. -/
 theorem mannerResult_complement_unattested :
-    ¬ (FullRootSpec.mk Root.FeatureSignature.mannerResult .complement).IsAttestedCell := by
+    ¬ (FullRootSpec.mk Root.Kinds.mannerResult .complement).IsAttestedCell := by
   decide
 
 /-- The complement/adjoined split for fullSpec roots is the only

--- a/Linglib/Semantics/ArgumentStructure/Affectedness/Profile.lean
+++ b/Linglib/Semantics/ArgumentStructure/Affectedness/Profile.lean
@@ -61,7 +61,7 @@ representation in the codebase:
 
 - `EntailmentProfile.changeOfState` — the proto-patient entailment (this file's input)
 - `MeaningComponents.changeOfState` — the surface diagnostic (`Semantics/Lexical/MeaningComponents.lean`)
-- `LexKind.result` membership in a root's `Root.FeatureSignature` — whether the root itself entails change (`Semantics/Lexical/Roots/Signature.lean`)
+- `LexKind.result` membership in a root's `Root.Kinds` — whether the root itself entails change (`Semantics/Lexical/Roots/Signature.lean`)
 
 These are NOT the same concept. [beavers-koontz-garboden-2020] show
 that surface CoS can come from either the root or the template. The

--- a/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
@@ -10,7 +10,7 @@ import Linglib.Semantics.Lexical.LevinClassProfiles
 The derivational chain from root content to argument structure, made
 explicit as composed functions:
 
-    Root.FeatureSignature → Template → ArgTemplate → ThetaRole
+    Root.Kinds → Template → ArgTemplate → ThetaRole
 
 Each step exists in the literature: [beavers-koontz-garboden-2020]
 define root entailments; [rappaport-hovav-levin-1998] define event
@@ -52,7 +52,7 @@ open Semantics.Lexical
 open Semantics.Lexical.EventStructure (Template)
 open Features.LevinClassProfiles
 open Semantics.ArgumentStructure.EntailmentProfile
-open Root.FeatureSignature
+open Root.Kinds
 
 -- ════════════════════════════════════════════════════
 -- § 1. Root-Template Compatibility
@@ -76,18 +76,18 @@ open Root.FeatureSignature
       BECOME to apply to (template adds the change)
     - **accomplishment** `[[x ACT] CAUSE [BECOME [y STATE]]]`: root
       provides state for the caused result -/
-def RootLicensesTemplate (re : Root.FeatureSignature) : Template → Prop
+def RootLicensesTemplate (re : Root.Kinds) : Template → Prop
   | .state         => .state ∈ re
   | .activity      => .manner ∈ re
   | .achievement   => .state ∈ re
   | .accomplishment => .state ∈ re
 
-instance (re : Root.FeatureSignature) (t : Template) :
+instance (re : Root.Kinds) (t : Template) :
     Decidable (RootLicensesTemplate re t) := by
   cases t <;> unfold RootLicensesTemplate <;> infer_instance
 
 /-- All templates licensed by a root (captures alternation). -/
-def licensedTemplates (re : Root.FeatureSignature) : List Template :=
+def licensedTemplates (re : Root.Kinds) : List Template :=
   [.state, .activity, .achievement, .accomplishment].filter
     (λ t => decide (RootLicensesTemplate re t))
 
@@ -195,7 +195,7 @@ def templateArgTemplate (t : Template) : ArgTemplate where
     | causativeResult (BREAK) | accomplishment |
     | pureManner (JOG) | activity |
     | fullSpec (CUT) | accomplishment | -/
-def primaryTemplate (re : Root.FeatureSignature) : Option Template :=
+def primaryTemplate (re : Root.Kinds) : Option Template :=
   if .cause ∈ re then some .accomplishment
   else if .result ∈ re then some .achievement
   else if .manner ∈ re then some .activity
@@ -235,14 +235,14 @@ theorem primary_licensed_canonical :
 
 /-- The full derivational pipeline: root entailments → primary
     template → template-level ArgTemplate. -/
-def derivePrimary (re : Root.FeatureSignature) : Option ArgTemplate :=
+def derivePrimary (re : Root.Kinds) : Option ArgTemplate :=
   (primaryTemplate re).map templateArgTemplate
 
 /-- All ArgTemplates derivable from a root (one per licensed template).
     Multiple entries represent alternation possibilities:
     e.g., a causativeResult root derives both an accomplishment
     ArgTemplate (transitive) and a state ArgTemplate (bare stative). -/
-def deriveAll (re : Root.FeatureSignature) : List ArgTemplate :=
+def deriveAll (re : Root.Kinds) : List ArgTemplate :=
   (licensedTemplates re).map templateArgTemplate
 
 -- § 4a. Pipeline produces non-trivial results
@@ -291,7 +291,7 @@ def activityObjectProfile (mc : MeaningComponents) : Option EntailmentProfile :=
     For other templates, the template's own profiles are used directly.
 
     Returns `none` for roots with no structural entailments (minimal). -/
-def deriveEnriched (re : Root.FeatureSignature) (mc : MeaningComponents) : Option ArgTemplate :=
+def deriveEnriched (re : Root.Kinds) (mc : MeaningComponents) : Option ArgTemplate :=
   match primaryTemplate re with
   | none => none
   | some t =>
@@ -527,7 +527,7 @@ theorem caused_result_full :
     consequence of downward closure under the collocational order —
     not a per-signature stipulation. -/
 theorem root_typology_hierarchy :
-    ∀ s : Root.FeatureSignature, s.WellFormed →
+    ∀ s : Root.Kinds, s.WellFormed →
       (.cause ∈ s → .result ∈ s) ∧ (.result ∈ s → .state ∈ s) := by decide
 
 /-- PC and result roots differ in licensing predictions:
@@ -569,7 +569,7 @@ directedMotion, and minimal-rootEntailments classes need overrides.
 The full derivational chain:
 
     Root entailments → Template → Template profiles → Root enrichment → Class override
-    (Root.FeatureSignature)  (primary)  (templateArg)     (deriveEnriched)   (LevinClass.argTemplate)
+    (Root.Kinds)  (primary)  (templateArg)     (deriveEnriched)   (LevinClass.argTemplate)
 -/
 
 end Semantics.ArgumentStructure.ArgDerivation

--- a/Linglib/Semantics/Lexical/EventStructure.lean
+++ b/Linglib/Semantics/Lexical/EventStructure.lean
@@ -124,7 +124,7 @@ theorem cause_implies_resultState (t : Template) :
 `Template` is a **function** of the root's collocational kind signature, not a
 parallel theory: `.cause` → accomplishment, `.result` → achievement, `.manner` →
 activity, else state. The `HasCause`/`HasResultState` diagnostics then reduce to
-signature membership (`ofSignature_hasCause_iff`/`hasResultState_iff`), so the
+signature membership (`ofKinds_hasCause_iff`/`hasResultState_iff`), so the
 denotational result entailment and `cause_implies_resultState` are one fact seen
 through the signature. -/
 
@@ -132,46 +132,46 @@ section Signature
 open Verb (LexKind Root)
 
 /-- The event-structure template determined by a root's (closed) kind signature. -/
-def Template.ofSignature (σ : Root.FeatureSignature) : Template :=
+def Template.ofKinds (σ : Root.Kinds) : Template :=
   if LexKind.cause ∈ σ then .accomplishment
   else if LexKind.result ∈ σ then .achievement
   else if LexKind.manner ∈ σ then .activity
   else .state
 
 /-- `HasCause` reduces to carrying the `cause` kind. -/
-theorem ofSignature_hasCause_iff (σ : Root.FeatureSignature) :
-    (Template.ofSignature σ).HasCause ↔ LexKind.cause ∈ σ := by
-  unfold Template.ofSignature
+theorem ofKinds_hasCause_iff (σ : Root.Kinds) :
+    (Template.ofKinds σ).HasCause ↔ LexKind.cause ∈ σ := by
+  unfold Template.ofKinds
   split_ifs <;> simp_all [Template.HasCause]
 
 /-- For a well-formed (collocationally closed) signature, `HasResultState`
     reduces to carrying the `result` kind — via `cause` ⟹ `result`. -/
-theorem ofSignature_hasResultState_iff {σ : Root.FeatureSignature}
+theorem ofKinds_hasResultState_iff {σ : Root.Kinds}
     (h : σ.WellFormed) :
-    (Template.ofSignature σ).HasResultState ↔ LexKind.result ∈ σ := by
+    (Template.ofKinds σ).HasResultState ↔ LexKind.result ∈ σ := by
   have hcr : LexKind.cause ∈ σ → LexKind.result ∈ σ := by
     intro hc
-    have hr : LexKind.result ∈ Root.FeatureSignature.close σ :=
-      (Root.FeatureSignature.mem_close_iff σ LexKind.result).mpr
+    have hr : LexKind.result ∈ Root.Kinds.close σ :=
+      (Root.Kinds.mem_close_iff σ LexKind.result).mpr
         ⟨LexKind.cause, hc, by decide⟩
-    have he : Root.FeatureSignature.close σ = σ := h
+    have he : Root.Kinds.close σ = σ := h
     rwa [he] at hr
-  unfold Template.ofSignature
+  unfold Template.ofKinds
   split_ifs with hc hr hm <;> simp_all [Template.HasResultState]
 
 /-- A root's event-structure template, read off its collocational closure. -/
 def _root_.Verb.Root.template (r : Root) : Template :=
-  Template.ofSignature r.closedFeatureSignature
+  Template.ofKinds r.closedKinds
 
 /-- A root entails a result state (template-level) iff it carries `result` —
     the [beavers-koontz-garboden-2020] result entailment, bridged to the
     `EventStructure` template diagnostic. -/
 theorem _root_.Verb.Root.template_hasResultState_iff (r : Root) :
-    r.template.HasResultState ↔ LexKind.result ∈ r.closedFeatureSignature := by
-  apply ofSignature_hasResultState_iff
-  show Root.FeatureSignature.close r.closedFeatureSignature = r.closedFeatureSignature
-  unfold Verb.Root.closedFeatureSignature
-  exact Root.FeatureSignature.close_idem _
+    r.template.HasResultState ↔ LexKind.result ∈ r.closedKinds := by
+  apply ofKinds_hasResultState_iff
+  show Root.Kinds.close r.closedKinds = r.closedKinds
+  unfold Verb.Root.closedKinds
+  exact Root.Kinds.close_idem _
 
 end Signature
 

--- a/Linglib/Semantics/Lexical/LevinClassProfiles.lean
+++ b/Linglib/Semantics/Lexical/LevinClassProfiles.lean
@@ -178,7 +178,7 @@ namespace Features.LevinClassProfiles
 open Semantics.Lexical
 open Semantics.ArgumentStructure.EntailmentProfile
 open Verb
-open Verb.Root.FeatureSignature
+open Verb.Root.Kinds
 
 -- ════════════════════════════════════════════════════
 -- § 5. Verification: templates match existing canonical profiles
@@ -244,14 +244,14 @@ theorem directedMotion_subject_role :
     directedMotion.subjectProfile.toRole = none := by native_decide
 
 -- ════════════════════════════════════════════════════
--- § 7. Root.FeatureSignature → ArgTemplate (the missing derivation)
+-- § 7. Root.Kinds → ArgTemplate (the missing derivation)
 -- ════════════════════════════════════════════════════
 
-/-! Root feature signatures determine argument templates — this is the
+/-! Root kind signatures determine argument templates — this is the
 field consensus ([beavers-koontz-garboden-2020], [rappaport-hovav-levin-2024]).
 The derivational direction runs:
 
-    Root.FeatureSignature → Template → ArgTemplate → ThetaRole labels
+    Root.Kinds → Template → ArgTemplate → ThetaRole labels
 
 `toArgTemplate` formalizes the default derivation. It
 captures the majority pattern: causative roots produce agent subjects
@@ -269,7 +269,7 @@ Two classes of systematic overrides exist:
 
 These overrides are documented and verified below. -/
 
-/-- Derive a default ArgTemplate from a root feature signature.
+/-- Derive a default ArgTemplate from a root kind signature.
 
     The derivation follows B&KG's event structure decomposition:
 
@@ -286,7 +286,7 @@ These overrides are documented and verified below. -/
     (causativeResult): both produce the same default ArgTemplate.
     The manner flag restricts HOW the cause proceeds (cutting vs.
     breaking), not WHETHER there's an agent. -/
-def toArgTemplate (re : Root.FeatureSignature) : Option ArgTemplate :=
+def toArgTemplate (re : Root.Kinds) : Option ArgTemplate :=
   if .cause ∈ re then
     some resultChange
   else if .result ∈ re then

--- a/Linglib/Semantics/Lexical/LevinTheory.lean
+++ b/Linglib/Semantics/Lexical/LevinTheory.lean
@@ -14,13 +14,13 @@ The `LevinClass` enum and its classification data (`MeaningComponents`,
 `meaningComponents`, `predictsUnaccusative`, `isVerbOfCreation`) are
 defined in `Core/Lexical/VerbClass.lean`.
 
-This file provides the theoretical content that depends on `Root.FeatureSignature`:
+This file provides the theoretical content that depends on `Root.Kinds`:
 root signature mapping, root–MC bridge enums, and universal consistency
 theorems.
 
 ## § 1. Root entailment mapping ([beavers-koontz-garboden-2020])
 
-Root feature signatures, well-formedness verification, and
+Root kind signatures, well-formedness verification, and
 manner+result (MRC) tests.
 
 ## § 2. Root–MC bridge
@@ -37,10 +37,10 @@ components, plus universal consistency theorems.
 section LevinClassMethods
 open Semantics.Lexical
 open Verb
-open Root.FeatureSignature
+open Root.Kinds
 namespace Semantics.Lexical
 
-/-- Root feature signature for each Levin class.
+/-- Root kind signature for each Levin class.
 
     Assignments marked (B&KG) are directly from [beavers-koontz-garboden-2020] Table 12 and Chapters 2–5. Others are inferred from class
     semantics following B&KG's framework:
@@ -52,7 +52,7 @@ namespace Semantics.Lexical
 
     Classes marked (default) use `minimal` as a conservative placeholder
     pending detailed study under B&KG's framework. -/
-def LevinClass.rootEntailments : LevinClass → Root.FeatureSignature
+def LevinClass.rootEntailments : LevinClass → Root.Kinds
   -- §9 Putting: template provides CAUSE+BECOME; root content varies
   | .put => minimal                -- (default)
   | .funnel => pureManner          -- manner of channeling
@@ -369,7 +369,7 @@ theorem break_manner_none :
 
 /-- Root structural contribution to meaning components.
     Maps result → changeOfState and manner → mannerSpec. -/
-def _root_.Verb.Root.FeatureSignature.structuralMC (re : Root.FeatureSignature) : MeaningComponents :=
+def _root_.Verb.Root.Kinds.structuralMC (re : Root.Kinds) : MeaningComponents :=
   { changeOfState := decide (.result ∈ re)
   , contact := false
   , motion := false

--- a/Linglib/Semantics/Lexical/MeaningComponents.lean
+++ b/Linglib/Semantics/Lexical/MeaningComponents.lean
@@ -21,7 +21,7 @@ substrate.
 The 4-feature decomposition is [levin-1993]'s diagnostic apparatus.
 [beavers-koontz-garboden-2020] argue these are SURFACE behaviors,
 not root-level entailments — root-level structural features live in
-`Semantics/Lexical/Roots/Signature.lean::Root.FeatureSignature`
+`Semantics/Lexical/Roots/Signature.lean::Root.Kinds`
 (state/manner/result/cause). The two carve-ups are NOT equivalent:
 e.g., `causation` here is what diathesis alternations diagnose, while
 B&KG's `cause` is a root entailment.
@@ -62,7 +62,7 @@ namespace Semantics.Lexical
 
     These describe **surface** verb behavior, not root-level entailments.
     [beavers-koontz-garboden-2020] argue that surface CoS and causation
-    can come from either the template or the root; see `Root.FeatureSignature`
+    can come from either the template or the root; see `Root.Kinds`
     in `Semantics/Lexical/Roots/Signature.lean` for the
     root-level decomposition.
 

--- a/Linglib/Semantics/Lexical/Roots/Basic.lean
+++ b/Linglib/Semantics/Lexical/Roots/Basic.lean
@@ -9,8 +9,8 @@ Lexical entailments are the atomic claims a verbal root makes about
 the events it describes and the participants in those events.
 Following [beavers-koontz-garboden-2020], we treat these as
 *structured atoms* rather than as a fixed feature vector: a **root**
-is a finite collection of such atoms, and its feature signature
-(`Root.FeatureSignature`) is the *derived* set of kinds its atoms realize —
+is a finite collection of such atoms, and its kind signature
+(`Root.Kinds`) is the *derived* set of kinds its atoms realize —
 exposing the Bifurcation Thesis of Roots and Manner/Result
 Complementarity as testable conjectures rather than architectural
 commitments.
@@ -20,7 +20,7 @@ commitments.
 * `LexEntailment` — labeled atoms; `LexEntailment.kind` projects the
   B&K-G kind, if any
 * `Root` — a named list of atoms
-* `Root.featureSignature` — the derived signature
+* `Root.kinds` — the derived signature
 * `Root.HasState`/`HasManner`/`HasResult`/`HasCause` — kind membership
 -/
 
@@ -85,11 +85,11 @@ structure Root where
       root carried by a verb whose root form is its citation form). -/
   name : String := ""
   /-- The B&KG structural-entailment atoms; `∅` where the root's structural
-      content has not been annotated (its `featureSignature` is then uninformative,
-      and a verb falls back to its class via `Verb.classSignature`). -/
+      content has not been annotated (its `kinds` is then uninformative,
+      and a verb falls back to its class via `Verb.classKinds`). -/
   entailments : Finset LexEntailment := ∅
   /-- The outcome-set cardinality the root encodes ([bhadra-2024]): the axis
-      orthogonal to the `featureSignature` (derived from `entailments`). `none`
+      orthogonal to the `kinds` (derived from `entailments`). `none`
       where the root has not been annotated for outcomes. -/
   outcomes : Option OutcomeCardinality := none
   /-- Within-class graded quality dimensions ([spalek-mcnally-2026],
@@ -105,26 +105,26 @@ instance : BEq Root := ⟨fun a b => decide (a = b)⟩
 
 namespace Root
 
-/-- The derived feature signature of a root: the set of kinds its
+/-- The derived kind signature of a root: the set of kinds its
     atoms realize. -/
-def featureSignature (r : Root) : Root.FeatureSignature :=
+def kinds (r : Root) : Root.Kinds :=
   Finset.univ.filter (fun k => ∃ a ∈ r.entailments, a.kind = some k)
 
-theorem mem_featureSignature {r : Root} {k : LexKind} :
-    k ∈ r.featureSignature ↔ ∃ a ∈ r.entailments, a.kind = some k := by
-  simp [featureSignature]
+theorem mem_kinds {r : Root} {k : LexKind} :
+    k ∈ r.kinds ↔ ∃ a ∈ r.entailments, a.kind = some k := by
+  simp [kinds]
 
 /-- The root entails attribution of some state. -/
-def HasState (r : Root) : Prop := .state ∈ r.featureSignature
+def HasState (r : Root) : Prop := .state ∈ r.kinds
 
 /-- The root specifies some manner. -/
-def HasManner (r : Root) : Prop := .manner ∈ r.featureSignature
+def HasManner (r : Root) : Prop := .manner ∈ r.kinds
 
 /-- The root entails some change of state (B&K-G "result"). -/
-def HasResult (r : Root) : Prop := .result ∈ r.featureSignature
+def HasResult (r : Root) : Prop := .result ∈ r.kinds
 
 /-- The root entails causation. -/
-def HasCause (r : Root) : Prop := .cause ∈ r.featureSignature
+def HasCause (r : Root) : Prop := .cause ∈ r.kinds
 
 instance (r : Root) : Decidable r.HasState :=
   inferInstanceAs (Decidable (_ ∈ _))

--- a/Linglib/Semantics/Lexical/Roots/Closure.lean
+++ b/Linglib/Semantics/Lexical/Roots/Closure.lean
@@ -10,10 +10,10 @@ and +cause entails +result.
 
 Two levels of closure, each a mathlib `ClosureOperator`:
 
-* **Kind level** (canonical): `Root.closedFeatureSignature` is the
-  collocational closure `Root.FeatureSignature.close` of the root's
+* **Kind level** (canonical): `Root.closedKinds` is the
+  collocational closure `Root.Kinds.close` of the root's
   derived signature. Both book restrictions hold of closed signatures
-  by construction (`closedFeatureSignature_wellFormed`).
+  by construction (`closedKinds_wellFormed`).
 * **Atom level** (label-tracking): `Root.closedEntailments` closes the
   labeled atom set under `bkgRules` (`becomesState s ⇒ hasState s`),
   packaged as `bkgCloseOp`. Only the result→state edge is expressible
@@ -23,7 +23,7 @@ Two levels of closure, each a mathlib `ClosureOperator`:
 ## Main declarations
 
 * `bkgRules`, `bkgClose`, `bkgCloseOp`, `Root.closedEntailments`
-* `Root.closedFeatureSignature`
+* `Root.closedKinds`
 * `mem_kind_closedEntailments` — the atom/kind bridge
 -/
 
@@ -36,7 +36,7 @@ namespace Verb
     the resulting state attribution `s`, label preserved). The
     cause→result restriction is not expressible at atom level
     (`hasCause` carries no label) and is handled by
-    `Root.FeatureSignature.close`. -/
+    `Root.Kinds.close`. -/
 def bkgRules : LexEntailment → Finset LexEntailment
   | .becomesState s => {.hasState s}
   | _ => ∅
@@ -96,28 +96,28 @@ def closedEntailments (r : Root) : Finset LexEntailment :=
 
 /-! ### Kind-level closure -/
 
-/-- The closed feature signature: the collocational closure of the
+/-- The closed kind signature: the collocational closure of the
     derived signature. Captures both book restrictions (result→state
     and cause→result). -/
-def closedFeatureSignature (r : Root) : Root.FeatureSignature :=
-  r.featureSignature.close
+def closedKinds (r : Root) : Root.Kinds :=
+  r.kinds.close
 
 /-- The closed signature satisfies the collocational constraints by
     construction — what `RootEntailments.WellFormed` used to stipulate
     is a theorem of closure. -/
-theorem closedFeatureSignature_wellFormed (r : Root) :
-    r.closedFeatureSignature.WellFormed :=
-  Root.FeatureSignature.close_wellFormed _
+theorem closedKinds_wellFormed (r : Root) :
+    r.closedKinds.WellFormed :=
+  Root.Kinds.close_wellFormed _
 
-theorem featureSignature_le_closed (r : Root) :
-    r.featureSignature ≤ r.closedFeatureSignature :=
-  Root.FeatureSignature.le_close _
+theorem kinds_le_closed (r : Root) :
+    r.kinds ≤ r.closedKinds :=
+  Root.Kinds.le_close _
 
 /-- Both theses are insensitive to the closure edges: a root violates
     Bifurcation iff its closed signature does. -/
 theorem closed_violatesBifurcation_iff (r : Root) :
-    r.closedFeatureSignature.ViolatesBifurcation ↔ r.ViolatesBifurcation :=
-  Root.FeatureSignature.violatesBifurcation_close_iff _
+    r.closedKinds.ViolatesBifurcation ↔ r.ViolatesBifurcation :=
+  Root.Kinds.violatesBifurcation_close_iff _
 
 /-! ### The atom/kind bridge -/
 
@@ -125,18 +125,18 @@ theorem closed_violatesBifurcation_iff (r : Root) :
     `state` kind whenever a result atom is present. -/
 theorem mem_kind_closedEntailments {r : Root} {k : LexKind} :
     (∃ a ∈ r.closedEntailments, a.kind = some k) ↔
-      k ∈ r.featureSignature ∨ (k = .state ∧ r.HasResult) := by
+      k ∈ r.kinds ∨ (k = .state ∧ r.HasResult) := by
   simp only [closedEntailments, bkgClose, Finset.mem_union, Finset.mem_biUnion]
   constructor
   · rintro ⟨a, ha | ⟨b, hb, hab⟩, hk⟩
-    · exact .inl (Root.mem_featureSignature.mpr ⟨a, ha, hk⟩)
+    · exact .inl (Root.mem_kinds.mpr ⟨a, ha, hk⟩)
     · obtain ⟨hak, hbk⟩ := bkgRules_kind hab
       refine .inr ⟨by rw [hk] at hak; exact Option.some_inj.mp hak, ?_⟩
-      exact Root.mem_featureSignature.mpr ⟨b, hb, hbk⟩
+      exact Root.mem_kinds.mpr ⟨b, hb, hbk⟩
   · rintro (hk | ⟨rfl, hres⟩)
-    · obtain ⟨a, ha, hak⟩ := Root.mem_featureSignature.mp hk
+    · obtain ⟨a, ha, hak⟩ := Root.mem_kinds.mp hk
       exact ⟨a, .inl ha, hak⟩
-    · obtain ⟨b, hb, hbk⟩ := Root.mem_featureSignature.mp hres
+    · obtain ⟨b, hb, hbk⟩ := Root.mem_kinds.mp hres
       cases b <;> simp [LexEntailment.kind] at hbk
       rename_i lab
       exact ⟨.hasState lab, .inr ⟨_, hb, by simp [bkgRules]⟩, rfl⟩
@@ -147,10 +147,10 @@ theorem mem_kind_closedEntailments {r : Root} {k : LexKind} :
     only). -/
 theorem kind_closedEntailments_le (r : Root) {k : LexKind}
     (h : ∃ a ∈ r.closedEntailments, a.kind = some k) :
-    k ∈ r.closedFeatureSignature := by
+    k ∈ r.closedKinds := by
   rcases mem_kind_closedEntailments.mp h with hk | ⟨rfl, hres⟩
-  · exact featureSignature_le_closed r hk
-  · exact (Root.FeatureSignature.mem_close_iff _ _).mpr
+  · exact kinds_le_closed r hk
+  · exact (Root.Kinds.mem_close_iff _ _).mpr
       ⟨.result, hres, by decide⟩
 
 end Root

--- a/Linglib/Semantics/Lexical/Roots/Outcomes.lean
+++ b/Linglib/Semantics/Lexical/Roots/Outcomes.lean
@@ -13,7 +13,7 @@ invariant (`OutcomeCardinality`) lives in `Roots/OutcomeCardinality.lean` so tha
 A verb root lexically encodes the **set of outcomes** its object can be in after
 the action — the dimension [bhadra-2024] adds to root semantics, orthogonal to
 the manner/result/cause kinds of [beavers-koontz-garboden-2020]'s
-`Root.FeatureSignature` (*bend* and *break* share a signature, differ in
+`Root.Kinds` (*bend* and *break* share a signature, differ in
 outcomes).
 
 ## Main definitions

--- a/Linglib/Semantics/Lexical/Roots/Profile.lean
+++ b/Linglib/Semantics/Lexical/Roots/Profile.lean
@@ -8,7 +8,7 @@ force, robustness, instrument, dimensionality, agent properties. A
 multi-paper synthesis ([talmy-1988], [talmy-2000], [dowty-1991],
 [majid-boster-bowerman-2008], [spalek-mcnally-2026]); no single paper
 carries this profile. Structural entailments (state, manner, result,
-cause) are the separate `Root.FeatureSignature` (`Roots/Signature.lean`).
+cause) are the separate `Root.Kinds` (`Roots/Signature.lean`).
 
 ## Main declarations
 
@@ -177,7 +177,7 @@ open Profile (Range)
 /-- Within-class root content profile.
 
     Captures **quality** dimensions of root content — force, robustness,
-    agent properties — as opposed to `Root.FeatureSignature`, which captures
+    agent properties — as opposed to `Root.Kinds`, which captures
     **structural** entailments (state, manner, result, cause).
 
     Each dimension is a `Range` of acceptable values; `none` means the

--- a/Linglib/Semantics/Lexical/Roots/SalienceClass.lean
+++ b/Linglib/Semantics/Lexical/Roots/SalienceClass.lean
@@ -56,7 +56,7 @@ inductive SalienceClass where
 /-! ### Named class conditions
 
 Structural conditions characterising membership in each [lucy-1994]
-salience class, over the pair (B&K-G feature signature × Coon arity).
+salience class, over the pair (B&K-G kind signature × Coon arity).
 These conditions are language-independent: the same conditions
 characterise the class in any inventory whose transitivisers respect
 the diagnostic. They appear directly as the `applies` field of each
@@ -67,10 +67,10 @@ construction* rather than only provable per-case. -/
 /-- Agent-salient: intransitive manner-of-action root (requires `=t`
     to transitivise; [lucy-1994]: "actions or activities that some
     entity undertakes"). -/
-def IsAgentSalient (s : Root.FeatureSignature) (ar : Root.Arity) : Prop :=
+def IsAgentSalient (s : Root.Kinds) (ar : Root.Arity) : Prop :=
   ar = .noTheme ∧ .manner ∈ s ∧ .result ∉ s
 
-instance (s : Root.FeatureSignature) (ar : Root.Arity) :
+instance (s : Root.Kinds) (ar : Root.Arity) :
     Decidable (IsAgentSalient s ar) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
@@ -87,29 +87,29 @@ instance (ar : Root.Arity) : Decidable (IsAgentPatientSalient ar) :=
 /-- Patient-salient: intransitive change-of-state root (requires `=s`
     to transitivise; [lucy-1994]: "state changes that some entity
     undergoes more or less spontaneously"). -/
-def IsPatientSalient (s : Root.FeatureSignature) (ar : Root.Arity) : Prop :=
+def IsPatientSalient (s : Root.Kinds) (ar : Root.Arity) : Prop :=
   ar = .noTheme ∧ .manner ∉ s ∧ .result ∈ s
 
-instance (s : Root.FeatureSignature) (ar : Root.Arity) :
+instance (s : Root.Kinds) (ar : Root.Arity) :
     Decidable (IsPatientSalient s ar) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-- Positional: pure stative configurational root (requires `-tal`
     for the inchoative; [lucy-1994]). -/
-def IsPositional (s : Root.FeatureSignature) (ar : Root.Arity) : Prop :=
+def IsPositional (s : Root.Kinds) (ar : Root.Arity) : Prop :=
   ar = .noTheme ∧ s = {.state}
 
-instance (s : Root.FeatureSignature) (ar : Root.Arity) :
+instance (s : Root.Kinds) (ar : Root.Arity) :
     Decidable (IsPositional s ar) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-! ### Salience classifier -/
 
-/-- Map a (B&K-G feature signature × Coon arity) pair to its salience
+/-- Map a (B&K-G kind signature × Coon arity) pair to its salience
     class ([lucy-1994]) by dispatching on the four named conditions,
     which align with operator applicability conditions in
     `Fragments/Mayan/Yukatek/Operators.lean`. -/
-def classOf (s : Root.FeatureSignature) (ar : Root.Arity) :
+def classOf (s : Root.Kinds) (ar : Root.Arity) :
     Option SalienceClass :=
   if IsAgentPatientSalient ar then some .agentPatient
   else if IsAgentSalient s ar then some .agent
@@ -125,7 +125,7 @@ def classOf (s : Root.FeatureSignature) (ar : Root.Arity) :
     not pure `{state}` fall outside all four; see
     `classOf_eq_none_iff`.) -/
 theorem classes_pairwise_disjoint :
-    ∀ (s : Root.FeatureSignature) (ar : Root.Arity),
+    ∀ (s : Root.Kinds) (ar : Root.Arity),
       ¬ (IsAgentSalient s ar ∧ IsAgentPatientSalient ar) ∧
       ¬ (IsAgentSalient s ar ∧ IsPatientSalient s ar) ∧
       ¬ (IsAgentSalient s ar ∧ IsPositional s ar) ∧
@@ -139,7 +139,7 @@ theorem classes_pairwise_disjoint :
     roots with neither a manner nor a result kind, other than pure
     `{state}`, are unclassified by Lucy's Yukatek diagnostic. -/
 theorem classOf_eq_none_iff :
-    ∀ (s : Root.FeatureSignature) (ar : Root.Arity),
+    ∀ (s : Root.Kinds) (ar : Root.Arity),
       classOf s ar = none ↔
         ¬ IsAgentSalient s ar ∧ ¬ IsAgentPatientSalient ar ∧
         ¬ IsPatientSalient s ar ∧ ¬ IsPositional s ar := by

--- a/Linglib/Semantics/Lexical/Roots/Signature.lean
+++ b/Linglib/Semantics/Lexical/Roots/Signature.lean
@@ -6,10 +6,10 @@ import Mathlib.Order.UpperLower.Basic
 import Mathlib.Order.Closure
 
 /-!
-# Root Feature Signatures
+# Root Kind Signatures
 
 The four-feature vocabulary of [beavers-koontz-garboden-2020]'s root
-typology (ch. 5): a root's **feature signature** records which *kinds*
+typology (ch. 5): a root's **kind signature** records which *kinds*
 of lexical entailment it carries — state, manner, result, cause — as a
 `Finset LexKind`, so signatures inherit the Boolean lattice of finite
 sets (`≤` is "carries at most these kinds").
@@ -30,14 +30,14 @@ substrate.
 ## Main declarations
 
 * `LexKind`, with its collocational `PartialOrder`
-* `Root.FeatureSignature := Finset LexKind`
-* `Root.FeatureSignature.close`, `Root.FeatureSignature.closeOp`,
-  `Root.FeatureSignature.WellFormed`
+* `Root.Kinds := Finset LexKind`
+* `Root.Kinds.close`, `Root.Kinds.closeOp`,
+  `Root.Kinds.WellFormed`
 * canonical signatures (`propertyConcept`, `pureResult`,
   `causativeResult`, `pureManner`, `mannerResult`, `fullSpec`,
   `minimal`)
-* `Root.FeatureSignature.ViolatesBifurcation`,
-  `Root.FeatureSignature.HasMannerAndResult`
+* `Root.Kinds.ViolatesBifurcation`,
+  `Root.Kinds.HasMannerAndResult`
 -/
 
 namespace Verb
@@ -79,37 +79,37 @@ instance : DecidableLE LexKind := fun _ _ => inferInstanceAs (Decidable (_ = tru
 
 end LexKind
 
-/-! ### Feature signatures -/
+/-! ### Kind signatures -/
 
-/-- A root feature signature: the set of entailment kinds carried.
+/-- A root kind signature: the set of entailment kinds carried.
     `≤` (= `⊆`) and the lattice operations come from `Finset`. -/
-abbrev Root.FeatureSignature := Finset LexKind
+abbrev Root.Kinds := Finset LexKind
 
-namespace Root.FeatureSignature
+namespace Root.Kinds
 
 /-- The collocational closure: a signature carrying `cause` is
     completed with `result` and `state`; one carrying `result` is
     completed with `state`. This is the lower closure under the
     `LexKind` order (`mem_close_iff`). -/
-def close (s : Root.FeatureSignature) : Root.FeatureSignature :=
+def close (s : Root.Kinds) : Root.Kinds :=
   s ∪ (if .cause ∈ s then {.result, .state} else ∅)
     ∪ (if .result ∈ s then {.state} else ∅)
 
-theorem le_close : ∀ s : Root.FeatureSignature, s ≤ close s := by decide
+theorem le_close : ∀ s : Root.Kinds, s ≤ close s := by decide
 
-theorem close_idem : ∀ s : Root.FeatureSignature, close (close s) = close s := by
+theorem close_idem : ∀ s : Root.Kinds, close (close s) = close s := by
   decide
 
-theorem close_mono : ∀ {s t : Root.FeatureSignature}, s ≤ t → close s ≤ close t := by
+theorem close_mono : ∀ {s t : Root.Kinds}, s ≤ t → close s ≤ close t := by
   decide
 
 /-- `close` is the lower closure under the collocational order:
     `k` is in the closure iff some kind in `s` dominates it. -/
-theorem mem_close_iff : ∀ (s : Root.FeatureSignature) (k : LexKind),
+theorem mem_close_iff : ∀ (s : Root.Kinds) (k : LexKind),
     k ∈ close s ↔ ∃ j ∈ s, k ≤ j := by decide
 
 /-- The collocational closure as a mathlib `ClosureOperator`. -/
-def closeOp : ClosureOperator Root.FeatureSignature where
+def closeOp : ClosureOperator Root.Kinds where
   toFun := close
   monotone' _ _ := close_mono
   le_closure' := le_close
@@ -117,13 +117,13 @@ def closeOp : ClosureOperator Root.FeatureSignature where
 
 /-- A signature is well-formed iff it already satisfies the
     collocational constraints (it is a fixed point of `close`). -/
-def WellFormed (s : Root.FeatureSignature) : Prop := close s = s
+def WellFormed (s : Root.Kinds) : Prop := close s = s
 
-instance (s : Root.FeatureSignature) : Decidable s.WellFormed :=
+instance (s : Root.Kinds) : Decidable s.WellFormed :=
   inferInstanceAs (Decidable (_ = _))
 
 /-- Well-formedness is downward-closedness in the `LexKind` order. -/
-theorem wellFormed_iff_isLowerSet (s : Root.FeatureSignature) :
+theorem wellFormed_iff_isLowerSet (s : Root.Kinds) :
     s.WellFormed ↔ IsLowerSet (↑s : Set LexKind) := by
   constructor
   · intro hwf a b hba ha
@@ -137,7 +137,7 @@ theorem wellFormed_iff_isLowerSet (s : Root.FeatureSignature) :
 
 /-- Closure output is always well-formed — the collocational
     constraints hold of closed signatures *by construction*. -/
-theorem close_wellFormed : ∀ s : Root.FeatureSignature, (close s).WellFormed :=
+theorem close_wellFormed : ∀ s : Root.Kinds, (close s).WellFormed :=
   close_idem
 
 /-! ### Canonical signatures
@@ -148,12 +148,12 @@ ch. 5 (their example display (12), §5.4). -/
 /-- +S −M −R −C: property concept roots (√FLAT, √DRY).
     Deadjectival COS verbs — the root names the result state.
     Complement position. -/
-def propertyConcept : Root.FeatureSignature := {.state}
+def propertyConcept : Root.Kinds := {.state}
 
 /-- +S −M +R −C: internally caused result roots (√BLOSSOM, √RUST).
     Root entails both a state and a change to that state, but not
     external causation. Complement position. -/
-def pureResult : Root.FeatureSignature := {.state, .result}
+def pureResult : Root.Kinds := {.state, .result}
 
 /-- +S −M +R +C: externally caused result roots (√CRACK, √BREAK).
     Root entails a state, change, AND causation. If roots subdivide by
@@ -161,32 +161,32 @@ def pureResult : Root.FeatureSignature := {.state, .result}
     (1995) externally vs internally caused change-of-state distinction
     ([beavers-koontz-garboden-2020], hedged as a possibility).
     Complement position. -/
-def causativeResult : Root.FeatureSignature := {.state, .result, .cause}
+def causativeResult : Root.Kinds := {.state, .result, .cause}
 
 /-- −S +M −R −C: pure manner roots (√JOG, √RUN, √SWIM).
     Root specifies action manner without entailing any state.
     Adjoined position. -/
-def pureManner : Root.FeatureSignature := {.manner}
+def pureManner : Root.Kinds := {.manner}
 
 /-- +S +M +R −C: manner + result without cause. Well-formed per the
     constraints; [beavers-koontz-garboden-2020] leave its attestation
     an open question ("whether a change and a manner can exist together
     in a single meaning without causation"), with candidate witnesses
     *slide* and motion-in-sound-emission *buzz*. -/
-def mannerResult : Root.FeatureSignature := {.state, .manner, .result}
+def mannerResult : Root.Kinds := {.state, .manner, .result}
 
 /-- +S +M +R +C: fully specified roots (√HAND adjoined, √DROWN and the
     other manner-of-killing roots in complement position;
     [beavers-koontz-garboden-2020] chs. 3–4). These are the attested
     MRC violators. The adjoined/complement contrast is carried by
     `Root.Position`, not by the signature. -/
-def fullSpec : Root.FeatureSignature := {.state, .manner, .result, .cause}
+def fullSpec : Root.Kinds := {.state, .manner, .result, .cause}
 
 /-- −S −M −R −C: minimal roots — no structural entailments.
     Conservative default for classes not yet studied under B&KG's
     framework. Not a row in B&KG's typology (which only lists roots
     with at least one positive feature). -/
-def minimal : Root.FeatureSignature := ∅
+def minimal : Root.Kinds := ∅
 
 /-- Every canonical signature is well-formed. -/
 theorem canonical_wellFormed :
@@ -199,54 +199,54 @@ theorem canonical_wellFormed :
 
 /-- The ontological kinds — all the Bifurcation Thesis allows a root
     to carry. -/
-def ontological : Root.FeatureSignature := {.state, .manner}
+def ontological : Root.Kinds := {.state, .manner}
 
 /-- A signature violates the Bifurcation Thesis ([embick-2009]; the
     assumption of [arad-2005]) iff it carries templatic (eventive)
     content — it is not bounded by `ontological`. -/
-def ViolatesBifurcation (s : Root.FeatureSignature) : Prop := ¬ s ≤ ontological
+def ViolatesBifurcation (s : Root.Kinds) : Prop := ¬ s ≤ ontological
 
-instance (s : Root.FeatureSignature) : Decidable s.ViolatesBifurcation :=
+instance (s : Root.Kinds) : Decidable s.ViolatesBifurcation :=
   inferInstanceAs (Decidable (¬ _ ≤ _))
 
 /-- Violation is carrying a `result` or `cause` kind. -/
 theorem violatesBifurcation_iff :
-    ∀ s : Root.FeatureSignature,
+    ∀ s : Root.Kinds,
       s.ViolatesBifurcation ↔ .result ∈ s ∨ .cause ∈ s := by decide
 
 /-- Bifurcation violation is monotone: adding entailments cannot
     repair a violation. (Equivalently, the thesis carves out a lower
     set of the signature lattice.) -/
 theorem violatesBifurcation_mono :
-    ∀ {s t : Root.FeatureSignature}, s ≤ t →
+    ∀ {s t : Root.Kinds}, s ≤ t →
       s.ViolatesBifurcation → t.ViolatesBifurcation := by decide
 
 /-- A signature has both manner and result — the configuration
     Manner/Result Complementarity ([rappaport-hovav-levin-2010])
     claims no root realizes. -/
-def HasMannerAndResult (s : Root.FeatureSignature) : Prop :=
+def HasMannerAndResult (s : Root.Kinds) : Prop :=
   {LexKind.manner, LexKind.result} ≤ s
 
-instance (s : Root.FeatureSignature) : Decidable s.HasMannerAndResult :=
+instance (s : Root.Kinds) : Decidable s.HasMannerAndResult :=
   inferInstanceAs (Decidable (_ ≤ _))
 
 /-- MRC violation is monotone in the signature order. -/
 theorem hasMannerAndResult_mono :
-    ∀ {s t : Root.FeatureSignature}, s ≤ t →
+    ∀ {s t : Root.Kinds}, s ≤ t →
       s.HasMannerAndResult → t.HasMannerAndResult := by decide
 
 /-- Both theses are invariant under collocational closure: `close`
     only adds `state`/`result` kinds forced by `cause`, never `manner`,
     and a closed signature violates Bifurcation iff its base does. -/
 theorem violatesBifurcation_close_iff :
-    ∀ s : Root.FeatureSignature,
+    ∀ s : Root.Kinds,
       (close s).ViolatesBifurcation ↔ s.ViolatesBifurcation := by decide
 
 theorem hasMannerAndResult_close_iff :
-    ∀ s : Root.FeatureSignature,
+    ∀ s : Root.Kinds,
       (close s).HasMannerAndResult ↔
         s.HasMannerAndResult ∨ (.manner ∈ s ∧ .cause ∈ s) := by decide
 
-end Root.FeatureSignature
+end Root.Kinds
 
 end Verb

--- a/Linglib/Semantics/Lexical/Roots/Typology.lean
+++ b/Linglib/Semantics/Lexical/Roots/Typology.lean
@@ -11,7 +11,7 @@ stated for roots by delegation to the signature level
   [arad-2005]): meaning introduced by a functional head — change,
   cause — can never be part of a root's meaning. As an order
   statement: every root's signature lies below
-  `Root.FeatureSignature.ontological`.
+  `Root.Kinds.ontological`.
 - **Manner/Result Complementarity** ([rappaport-hovav-levin-2010]): a
   single root entails a manner *or* a result, never both. As an order
   statement: no root's signature lies above `{manner, result}`.
@@ -31,16 +31,16 @@ namespace Root
 
 /-- A root *violates* Bifurcation iff it itself carries templatic
     (eventive) meaning — change of state or cause
-    (`Root.FeatureSignature.violatesBifurcation_iff`). The Bifurcation
+    (`Root.Kinds.violatesBifurcation_iff`). The Bifurcation
     Thesis ([embick-2009]; [arad-2005]) is the universal claim that no
     root does. (The ditransitive prepositional heads P_loc and P_have,
     which [beavers-koontz-garboden-2020] also treat as templatic, are
     not modeled here.) -/
 def ViolatesBifurcation (r : Root) : Prop :=
-  r.featureSignature.ViolatesBifurcation
+  r.kinds.ViolatesBifurcation
 
 instance (r : Root) : Decidable r.ViolatesBifurcation :=
-  inferInstanceAs (Decidable (Root.FeatureSignature.ViolatesBifurcation _))
+  inferInstanceAs (Decidable (Root.Kinds.ViolatesBifurcation _))
 
 /-- Negation of `ViolatesBifurcation`: the root carries only
     ontological entailments (state, manner). -/
@@ -54,17 +54,17 @@ instance (r : Root) : Decidable r.RespectsBifurcation :=
     its signature is bounded by the ontological kinds. -/
 theorem respectsBifurcation_iff_le {r : Root} :
     r.RespectsBifurcation ↔
-      r.featureSignature ≤ Root.FeatureSignature.ontological :=
+      r.kinds ≤ Root.Kinds.ontological :=
   not_not
 
 /-- A root has both manner and result entailments — Manner/Result
     Complementarity ([rappaport-hovav-levin-2010]) is the universal
     claim that no root does. -/
 def HasMannerAndResult (r : Root) : Prop :=
-  r.featureSignature.HasMannerAndResult
+  r.kinds.HasMannerAndResult
 
 instance (r : Root) : Decidable r.HasMannerAndResult :=
-  inferInstanceAs (Decidable (Root.FeatureSignature.HasMannerAndResult _))
+  inferInstanceAs (Decidable (Root.Kinds.HasMannerAndResult _))
 
 /-- Negation of `HasMannerAndResult`. -/
 def RespectsMannerResultComplementarity (r : Root) : Prop :=

--- a/Linglib/Semantics/Verb/Denotation.lean
+++ b/Linglib/Semantics/Verb/Denotation.lean
@@ -143,7 +143,7 @@ For a change-of-state verb the opaque lexical core unpacks into the
 event-structural decomposition of [beavers-koontz-garboden-2020] (22)–(24): a
 root denotes a *state* predicate `⟦√V⟧(x,s)`, and the verb's event predicate is
 built by the templatic operators `become'` and `cause'`. The root's
-`featureSignature` selects which operators apply — `.result` → `become`,
+`kinds` selects which operators apply — `.result` → `become`,
 `.cause` → `cause`/`effector` — so the decomposition is the denotational payoff
 of the root's kinds. -/
 
@@ -210,13 +210,13 @@ theorem causative_entails_resultState (M : CosModel Entity State Time)
   exact ⟨e, hinch⟩
 
 /-- The verb's change-of-state denotation, dispatched on its root's
-    `featureSignature` (cf. [beavers-koontz-garboden-2020] (18)–(19)): `.cause` →
+    `kinds` (cf. [beavers-koontz-garboden-2020] (18)–(19)): `.cause` →
     causative, else `.result` → inchoative, else the bare manner core. The root's
     kinds *select the event template* — the denotational payoff of the signature. -/
 def denote (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
     Event Time → Prop :=
-  if LexKind.cause ∈ (v.root.map (·.featureSignature)).getD ∅ then M.causative v y x
-  else if LexKind.result ∈ (v.root.map (·.featureSignature)).getD ∅ then M.inchoative v x
+  if LexKind.cause ∈ (v.root.map (·.kinds)).getD ∅ then M.causative v y x
+  else if LexKind.result ∈ (v.root.map (·.kinds)).getD ∅ then M.inchoative v x
   else M.manner v
 
 /-- The denotational payoff of a `.result` root: any verb whose root signature
@@ -227,10 +227,10 @@ def denote (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
     `denote` is the manner core). -/
 theorem denote_result_entails_resultState (M : CosModel Entity State Time)
     (v : Verb) (y x : Entity) (e : Event Time)
-    (hres : LexKind.result ∈ (v.root.map (·.featureSignature)).getD ∅)
+    (hres : LexKind.result ∈ (v.root.map (·.kinds)).getD ∅)
     (h : M.denote v y x e) : ∃ e' s, M.become s e' ∧ M.rootState v x s := by
   unfold denote at h
-  by_cases hc : LexKind.cause ∈ (v.root.map (·.featureSignature)).getD ∅
+  by_cases hc : LexKind.cause ∈ (v.root.map (·.kinds)).getD ∅
   · rw [if_pos hc] at h
     exact M.causative_entails_resultState v y x e h
   · rw [if_neg hc, if_pos hres] at h

--- a/Linglib/Semantics/Verb/RootContent.lean
+++ b/Linglib/Semantics/Verb/RootContent.lean
@@ -5,7 +5,7 @@ import Linglib.Morphology.RootTypology
 # Verb ↔ root content accessors
 
 The integration seam (P-HUB) between a `Verb` and the root it carries
-(`Verb.root : Option Verb.Root`): a verb's B&KG feature signature, [bhadra-2024]
+(`Verb.root : Option Verb.Root`): a verb's B&KG kind signature, [bhadra-2024]
 outcome cardinality, and change-entailment type are read off *its own root* when
 present, falling back to its Levin class only for the signature (the per-class
 outcome assignment is a Study-level claim, so there is no Levin fallback for
@@ -16,7 +16,7 @@ these accessors (which mention them) live here rather than in `Verb/Basic.lean`.
 
 ## Main definitions
 
-* `Verb.featureSignature` — the verb's entailment-kind signature (root, else Levin)
+* `Verb.kinds` — the verb's entailment-kind signature (root, else Levin)
 * `Verb.outcomes` — the verb's outcome-set cardinality (root only)
 * `Verb.changeType` — the verb's change-entailment type (derived from its root)
 -/
@@ -24,18 +24,18 @@ these accessors (which mention them) live here rather than in `Verb/Basic.lean`.
 open Verb
 open Semantics.Lexical
 
-/-- The verb's B&KG feature signature, read off its annotated `root` (the fine
+/-- The verb's B&KG kind signature, read off its annotated `root` (the fine
     source of truth). `none` when the verb carries no root. Sibling of `outcomes`
     and `changeType` — root-only, no class fallback; the coarser class-derived
-    signature is `classSignature`. -/
-def Verb.featureSignature (v : Verb) : Option Verb.Root.FeatureSignature :=
-  v.root.map (·.featureSignature)
+    signature is `classKinds`. -/
+def Verb.kinds (v : Verb) : Option Verb.Root.Kinds :=
+  v.root.map (·.kinds)
 
 /-- The signature [levin-1993] attributes to the verb *via its class*
     (`LevinClass.rootEntailments`) — the coarse REALIZATION-layer view, distinct
-    from the root's own `featureSignature`. They are independent provenances; a
-    `classSignature = featureSignature` agreement is a theorem, not a default. -/
-def Verb.classSignature (v : Verb) : Option Verb.Root.FeatureSignature :=
+    from the root's own `kinds`. They are independent provenances; a
+    `classKinds = kinds` agreement is a theorem, not a default. -/
+def Verb.classKinds (v : Verb) : Option Verb.Root.Kinds :=
   v.levinClass.map LevinClass.rootEntailments
 
 /-- The verb's outcome-set cardinality ([bhadra-2024]), read off its `root`. No
@@ -44,7 +44,7 @@ def Verb.outcomes (v : Verb) : Option Verb.OutcomeCardinality :=
   v.root.bind (·.outcomes)
 
 /-- The verb's change-entailment type ([beavers-etal-2021]), derived from its
-    root's feature signature. -/
+    root's kind signature. -/
 def Verb.changeType (v : Verb) : Option RootType :=
   v.root.map Verb.Root.changeType
 

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -23,9 +23,9 @@ the falsification of the Bifurcation Thesis of Roots ([embick-2009];
 
 The +state cells of √blossom, √crack, √hand, √drown are *derived*:
 the book's typology values are the collocational closures
-(`Root.closedFeatureSignature`) of the base atom kinds, and each
+(`Root.closedKinds`) of the base atom kinds, and each
 closed signature is one of the canonical typology rows
-(`Root.FeatureSignature.pureResult`, `causativeResult`, `fullSpec`).
+(`Root.Kinds.pureResult`, `causativeResult`, `fullSpec`).
 √blossom falsifies Bifurcation on its own, since change of state is
 templatic (`v_become`) content. √hand and √drown additionally falsify
 Manner/Result Complementarity; they differ only in root position
@@ -73,50 +73,50 @@ def hand : Root := ⟨"hand",
 def drown : Root := ⟨"drown",
   {.hasManner "submersion-in-liquid", .becomesState "dead", .hasCause}, none, {}⟩
 
-/-! ### Feature signatures
+/-! ### Kind signatures
 
 Base signatures record the atom kinds; closed signatures are their
 collocational closures, and coincide with the canonical rows of the
 book's typology. -/
 
-theorem flat_featureSignature : flat.featureSignature = {.state} := by
+theorem flat_kinds : flat.kinds = {.state} := by
   decide
 
-theorem jog_featureSignature : jog.featureSignature = {.manner} := by
+theorem jog_kinds : jog.kinds = {.manner} := by
   decide
 
-theorem blossom_featureSignature :
-    blossom.featureSignature = {.result} := by decide
+theorem blossom_kinds :
+    blossom.kinds = {.result} := by decide
 
-theorem crack_featureSignature :
-    crack.featureSignature = {.result, .cause} := by decide
+theorem crack_kinds :
+    crack.kinds = {.result, .cause} := by decide
 
-theorem hand_featureSignature :
-    hand.featureSignature = {.manner, .result, .cause} := by decide
+theorem hand_kinds :
+    hand.kinds = {.manner, .result, .cause} := by decide
 
-theorem drown_featureSignature :
-    drown.featureSignature = {.manner, .result, .cause} := by decide
+theorem drown_kinds :
+    drown.kinds = {.manner, .result, .cause} := by decide
 
-theorem flat_closedFeatureSignature :
-    flat.closedFeatureSignature = Root.FeatureSignature.propertyConcept := by
+theorem flat_closedKinds :
+    flat.closedKinds = Root.Kinds.propertyConcept := by
   decide
 
-theorem jog_closedFeatureSignature :
-    jog.closedFeatureSignature = Root.FeatureSignature.pureManner := by decide
+theorem jog_closedKinds :
+    jog.closedKinds = Root.Kinds.pureManner := by decide
 
-theorem blossom_closedFeatureSignature :
-    blossom.closedFeatureSignature = Root.FeatureSignature.pureResult := by
+theorem blossom_closedKinds :
+    blossom.closedKinds = Root.Kinds.pureResult := by
   decide
 
-theorem crack_closedFeatureSignature :
-    crack.closedFeatureSignature = Root.FeatureSignature.causativeResult := by
+theorem crack_closedKinds :
+    crack.closedKinds = Root.Kinds.causativeResult := by
   decide
 
-theorem hand_closedFeatureSignature :
-    hand.closedFeatureSignature = Root.FeatureSignature.fullSpec := by decide
+theorem hand_closedKinds :
+    hand.closedKinds = Root.Kinds.fullSpec := by decide
 
-theorem drown_closedFeatureSignature :
-    drown.closedFeatureSignature = Root.FeatureSignature.fullSpec := by decide
+theorem drown_closedKinds :
+    drown.closedKinds = Root.Kinds.fullSpec := by decide
 
 /-! ### Falsifying the Bifurcation Thesis -/
 
@@ -179,7 +179,7 @@ theorem crack_respectsMannerResultComplementarity :
 /-! ### The roots cash out denotationally ([beavers-koontz-garboden-2020] §1.3.2)
 
 Threading the roots through the change-of-state denotation (`Verb.CosModel`): a
-verb's denotation is dispatched on its root's `featureSignature`, so the kinds
+verb's denotation is dispatched on its root's `kinds`, so the kinds
 proven above *select the event template* and the result entailment of (6)
 follows from the signature. √crack (`+cause+result`) entails a result state in
 any model; √jog (pure manner) does not — the *break*/*hit* contrast. -/
@@ -213,7 +213,7 @@ theorem jog_denote_eq_manner {Entity State Time : Type*} [LinearOrder Time]
 collocational closure; the kinds proven above fix it, and `HasResultState`
 reduces to carrying `result` (`Verb.Root.template_hasResultState_iff`). So the
 denotational result entailment (√crack) and the template result diagnostic are
-*one fact* seen through `featureSignature`. -/
+*one fact* seen through `kinds`. -/
 
 theorem flat_template : flat.template = .state := by decide
 theorem jog_template : jog.template = .activity := by decide

--- a/Linglib/Studies/HaninkKoontzGarboden2025.lean
+++ b/Linglib/Studies/HaninkKoontzGarboden2025.lean
@@ -56,7 +56,7 @@ Property concept (PC) roots in Wá·šiw come in two semantic types:
   inside the verbal categorizer's denotation.
 - Against [menon-pancheva-2014]'s universalist claim: not all PC
   roots have the same meaning.
-- All Wá·šiw PC roots are `Root.FeatureSignature.propertyConcept` (+S −M −R −C)
+- All Wá·šiw PC roots are `Root.Kinds.propertyConcept` (+S −M −R −C)
   per [beavers-koontz-garboden-2020] — the variation is in *semantic
   type*, not in structural entailments.
 -/

--- a/Linglib/Studies/Krejci2012.lean
+++ b/Linglib/Studies/Krejci2012.lean
@@ -49,7 +49,7 @@ namespace Krejci2012
 
 open Verb
 open Semantics.Lexical
-open Root.FeatureSignature
+open Root.Kinds
 open Causation.Morphological
 open Semantics.Lexical.EventStructure
 open Semantics.ArgumentStructure.ArgDerivation
@@ -228,7 +228,7 @@ theorem dress_same_form : dress.lexicalCausative = none := rfl
 -- ════════════════════════════════════════════════════
 
 /-! [krejci-2012]'s claim that eat and dress have causative event
-    structure aligns with their `Root.FeatureSignature` classification:
+    structure aligns with their `Root.Kinds` classification:
     both are `causativeResult` ({state, result, cause}), meaning the
     root itself entails external causation. -/
 

--- a/Linglib/Studies/Levin2026.lean
+++ b/Linglib/Studies/Levin2026.lean
@@ -119,7 +119,7 @@ theorem agrees_with_diathesis_data :
     no causation. The result and causation come from the construction. -/
 theorem all_classes_pure_manner :
     intrPushOpenClasses.all
-      (·.rootEntailments == Root.FeatureSignature.pureManner) = true := by
+      (·.rootEntailments == Root.Kinds.pureManner) = true := by
   decide
 
 /-- All core classes encode contact and motion but NOT change of state
@@ -767,7 +767,7 @@ theorem blocked_wrong_adjective :
 theorem end_to_end_push_open :
     -- Step 1-2: verb class blocks alternation alone
     LevinClass.pushPull.participatesIn .causativeInchoative = false ∧
-    LevinClass.rootEntailments .pushPull == Root.FeatureSignature.pureManner ∧
+    LevinClass.rootEntailments .pushPull == Root.Kinds.pureManner ∧
     -- Step 3: fusion — construction adds CoS + causation → alternation predicted
     predictedAlternationInConstruction
       LevinClass.pushPull.meaningComponents

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -60,10 +60,10 @@ open Yukatek.Operators
 /-- A root's predicted salience class: the substrate classifier
     applied to its signature and the fragment's arity assignment. -/
 abbrev predictedClass (r : Root) : Option SalienceClass :=
-  classOf r.featureSignature (arity r)
+  classOf r.kinds (arity r)
 
 theorem class_depends_only_on_signature_and_arity
-    (r₁ r₂ : Root) (h : r₁.featureSignature = r₂.featureSignature)
+    (r₁ r₂ : Root) (h : r₁.kinds = r₂.kinds)
     (h' : arity r₁ = arity r₂) :
     predictedClass r₁ = predictedClass r₂ := by
   unfold predictedClass
@@ -72,7 +72,7 @@ theorem class_depends_only_on_signature_and_arity
 /-! ### Predicted class agrees with operator applicability -/
 
 /-! Both `predictedClass` and the inventory's applicability profile
-    factor through the pair (feature signature × arity), drawn from a
+    factor through the pair (kind signature × arity), drawn from a
     32-element fintype. Each characterisation therefore reduces —
     after rewriting the profile to pair level
     (`applicableNames_eq_profile`) and generalising the pair — to a
@@ -85,14 +85,14 @@ theorem class_depends_only_on_signature_and_arity
     name appears. -/
 private theorem applicableNames_eq_profile (r : Root) :
     inventory.applicableNames r =
-      (if IsAgentSalient r.featureSignature (arity r) then ["=t"] else []) ++
+      (if IsAgentSalient r.kinds (arity r) then ["=t"] else []) ++
       (if IsAgentPatientSalient (arity r) then ["=∅"] else []) ++
-      (if IsPatientSalient r.featureSignature (arity r) then ["=s"] else []) ++
-      (if IsPositional r.featureSignature (arity r) then ["-tal"] else []) := by
+      (if IsPatientSalient r.kinds (arity r) then ["=s"] else []) ++
+      (if IsPositional r.kinds (arity r) then ["-tal"] else []) := by
   simp only [inventory, Inventory.applicableNames, affectiveT, zeroDeriv,
     causativeS, positionalTal, List.filter_cons, List.filter_nil,
     decide_eq_true_eq]
-  generalize r.featureSignature = s
+  generalize r.kinds = s
   generalize arity r = a
   revert s a
   decide
@@ -101,7 +101,7 @@ local macro "lucy_applicable " r:term : tactic =>
   `(tactic|
     (rw [applicableNames_eq_profile]
      unfold predictedClass
-     generalize ($r).featureSignature = s
+     generalize ($r).kinds = s
      generalize arity $r = a
      revert s a
      decide))
@@ -142,9 +142,9 @@ theorem applicableNames_eq_iff_predictedClass_eq (r₁ r₂ : Root) :
       predictedClass r₁ = predictedClass r₂ := by
   rw [applicableNames_eq_profile, applicableNames_eq_profile]
   unfold predictedClass
-  generalize r₁.featureSignature = s₁
+  generalize r₁.kinds = s₁
   generalize arity r₁ = a₁
-  generalize r₂.featureSignature = s₂
+  generalize r₂.kinds = s₂
   generalize arity r₂ = a₂
   revert s₁ a₁ s₂ a₂
   decide
@@ -223,11 +223,11 @@ theorem rootTransitives_respect_mrc :
 
 /-! ### Closure robustness -/
 
-/-- The class predicted from a root's *closed* feature signature
-    (the collocational closure `Root.FeatureSignature.close` of the derived
+/-- The class predicted from a root's *closed* kind signature
+    (the collocational closure `Root.Kinds.close` of the derived
     signature). Arity is closure-invariant. -/
 def closedPredictedClass (r : Root) : Option SalienceClass :=
-  classOf r.closedFeatureSignature (arity r)
+  classOf r.closedKinds (arity r)
 
 /-- For cause-free roots, collocational closure does not change the
     Lucy 1994 salience classification: arity is untouched, the only
@@ -241,9 +241,9 @@ def closedPredictedClass (r : Root) : Option SalienceClass :=
 theorem predictedClass_closure_invariant (r : Root) (h : ¬ r.HasCause) :
     closedPredictedClass r = predictedClass r := by
   unfold Root.HasCause at h
-  unfold closedPredictedClass predictedClass Root.closedFeatureSignature
+  unfold closedPredictedClass predictedClass Root.closedKinds
   revert h
-  generalize r.featureSignature = s
+  generalize r.kinds = s
   generalize arity r = a
   revert s a
   decide


### PR DESCRIPTION
Pure rename: `Root.FeatureSignature`→`Root.Kinds` (and `.featureSignature`→`.kinds`, `closedFeatureSignature`→`closedKinds`, `classSignature`→`classKinds`, `Template.ofSignature`→`ofKinds`). 'feature' wrongly suggested morphosyntactic features — these are the four B&KG lexical-entailment *kinds* (state/manner/result/cause). Behavior-preserving (+268/−268).