### PR TITLE
refactor(Semantics/Verb): denote dispatches via Verb.kinds accessor

### DIFF
--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -38,6 +38,12 @@ def Verb.derivedVendlerClass (v : Verb) : Option VendlerClass :=
 def Verb.rootProfile (v : Verb) : Option Verb.Root.Profile :=
   v.root.map (·.profile)
 
+/-- The verb's B&KG kind signature ([beavers-koontz-garboden-2020]), read off its
+    `root` (the source of truth). `none` when the verb has no root. Root-only — the
+    coarser class-derived view is `Verb.classKinds` (`Verb/RootContent.lean`). -/
+def Verb.kinds (v : Verb) : Option Verb.Root.Kinds :=
+  v.root.map (·.kinds)
+
 /-- Effective subject entailment profile: verb-level override if present,
     otherwise falls back to the Levin class–level profile
     ([levin-1993], [dowty-1991]). -/

--- a/Linglib/Semantics/Verb/Denotation.lean
+++ b/Linglib/Semantics/Verb/Denotation.lean
@@ -215,8 +215,8 @@ theorem causative_entails_resultState (M : CosModel Entity State Time)
     kinds *select the event template* — the denotational payoff of the signature. -/
 def denote (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
     Event Time → Prop :=
-  if LexKind.cause ∈ (v.root.map (·.kinds)).getD ∅ then M.causative v y x
-  else if LexKind.result ∈ (v.root.map (·.kinds)).getD ∅ then M.inchoative v x
+  if LexKind.cause ∈ (v.kinds).getD ∅ then M.causative v y x
+  else if LexKind.result ∈ (v.kinds).getD ∅ then M.inchoative v x
   else M.manner v
 
 /-- The denotational payoff of a `.result` root: any verb whose root signature
@@ -227,10 +227,10 @@ def denote (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
     `denote` is the manner core). -/
 theorem denote_result_entails_resultState (M : CosModel Entity State Time)
     (v : Verb) (y x : Entity) (e : Event Time)
-    (hres : LexKind.result ∈ (v.root.map (·.kinds)).getD ∅)
+    (hres : LexKind.result ∈ (v.kinds).getD ∅)
     (h : M.denote v y x e) : ∃ e' s, M.become s e' ∧ M.rootState v x s := by
   unfold denote at h
-  by_cases hc : LexKind.cause ∈ (v.root.map (·.kinds)).getD ∅
+  by_cases hc : LexKind.cause ∈ (v.kinds).getD ∅
   · rw [if_pos hc] at h
     exact M.causative_entails_resultState v y x e h
   · rw [if_neg hc, if_pos hres] at h

--- a/Linglib/Semantics/Verb/RootContent.lean
+++ b/Linglib/Semantics/Verb/RootContent.lean
@@ -16,22 +16,17 @@ these accessors (which mention them) live here rather than in `Verb/Basic.lean`.
 
 ## Main definitions
 
-* `Verb.kinds` — the verb's entailment-kind signature (root, else Levin)
+* `Verb.classKinds` — the class-derived kind signature (the coarse Levin view)
 * `Verb.outcomes` — the verb's outcome-set cardinality (root only)
 * `Verb.changeType` — the verb's change-entailment type (derived from its root)
+
+(`Verb.kinds`, the root-sourced signature, lives in `Verb/Basic.lean`.)
 -/
 
 open Verb
 open Semantics.Lexical
 
-/-- The verb's B&KG kind signature, read off its annotated `root` (the fine
-    source of truth). `none` when the verb carries no root. Sibling of `outcomes`
-    and `changeType` — root-only, no class fallback; the coarser class-derived
-    signature is `classKinds`. -/
-def Verb.kinds (v : Verb) : Option Verb.Root.Kinds :=
-  v.root.map (·.kinds)
-
-/-- The signature [levin-1993] attributes to the verb *via its class*
+/-- The kind signature [levin-1993] attributes to the verb *via its class*
     (`LevinClass.rootEntailments`) — the coarse REALIZATION-layer view, distinct
     from the root's own `kinds`. They are independent provenances; a
     `classKinds = kinds` agreement is a theorem, not a default. -/


### PR DESCRIPTION
Moves `Verb.kinds` from `RootContent` to `Verb.Basic` (a low-dep root projection) and has `CosModel.denote` dispatch via `v.kinds` instead of the inline `(v.root.map (·.kinds)).getD ∅` re-stipulation — wiring the accessor (its first consumer) and removing the duplication. Blueprint (`scratch/verb-api-blueprint.md`) step 4b, cleanup half.