### PR TITLE
refactor(Semantics/Verb): drop dead opaque Verb.Model/denote

### DIFF
--- a/Linglib/Semantics/Verb/Denotation.lean
+++ b/Linglib/Semantics/Verb/Denotation.lean
@@ -7,78 +7,37 @@ import Linglib.Semantics.ArgumentStructure.Linking
 
 A verb is, first of all, an **operation**: applied to its arguments it builds an
 event predicate. This file is that operation — the DO layer of the Verb API —
-parallel to how the φ substrate models person features as *operations*
-(`oplus`/`act` building a partition) rather than predicates.
+parallel to how the φ substrate models person features as *operations* rather
+than predicates.
 
-The verb's classificatory facets (`Verb.ArgStructure`, `Verb.Aspect`, …) are the
-**parameters** of this operation: the per-argument `EntailmentProfile`s determine
-the theta-grid (`subjectRole`/`objectRole`), and a `Model` supplies the thematic
-frame and the lexical core. The denotation is then the neo-Davidsonian
-composition `λe. ⟦√V⟧(e) ∧ θ(arg, e) …` — derived, not stipulated.
+For a change-of-state verb the operation is the [beavers-koontz-garboden-2020]
+§1.3.2 decomposition (`Verb.CosModel`): a root denotes a state predicate and the
+event predicate is built by `become'`/`cause'`, dispatched on the root's `kinds`.
+The proto-role theta-grid (`Verb.subjectRole`/`objectRole`, derived from the
+effective `EntailmentProfile`s via `EntailmentProfile.toRole`) supplies the
+participant roles.
 
 ## Main definitions
 
-* `ThetaRole.toRel` — the theta-role → frame-relation seam (the composer)
-* `Verb.Model` — a theory hub: thematic frame + lexical core, over an entity/time
-  domain
-* `Verb.subjectRole` / `Verb.objectRole` — the theta-grid, derived from the
-  effective `EntailmentProfile`s via `EntailmentProfile.toRole`
-* `Verb.denote` — the operation: an `ArgFrame` ↦ event predicate
+* `Verb.subjectRole` / `Verb.objectRole` — the theta-grid from the proto-role
+  profiles
+* `Verb.CosModel` + `inchoative`/`causative`/`denote` — the change-of-state
+  denotation, dispatched on the root's `kinds`
 
 ## Main results
 
-* `Verb.denote_transitive` / `Verb.denote_intransitive` — the operation's truth
-  conditions: lexical core conjoined with the thematic-role relations its
-  theta-grid selects
+* `CosModel.causative_entails_inchoative`, `denote_result_entails_resultState` —
+  the [beavers-koontz-garboden-2020] entailments, *derived* from the root signature
 
 ## References
 
 * [davidson-1967], [parsons-1990] (neo-Davidsonian composition)
-* [kratzer-1996] (severed external argument)
+* [beavers-koontz-garboden-2020] (the change-of-state decomposition)
 * [dowty-1991] (the proto-role profiles that drive the theta-grid)
 -/
 
-namespace Semantics.ArgumentStructure
-
-/-- Map a theta-role to the corresponding relation of a thematic frame: the seam
-    that lets the verb's theta-grid compose with a model's role relations.
-    (Removed in PR #378 as dead; restored here — `Verb.denote` is exactly the
-    Verb→ThematicFrame composer it was the seam for.) -/
-def ThetaRole.toRel {Entity Time : Type*} [LinearOrder Time]
-    (θ : ThetaRole) (frame : ThematicFrame Entity Time) : ThematicRel Entity Time :=
-  match θ with
-  | .agent       => frame.agent
-  | .patient     => frame.patient
-  | .theme       => frame.theme
-  | .experiencer => frame.experiencer
-  | .goal        => frame.goal
-  | .source      => frame.source
-  | .instrument  => frame.instrument
-  | .stimulus    => frame.stimulus
-
-end Semantics.ArgumentStructure
-
 open Semantics.ArgumentStructure
 open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
-
-/-! ### The theory hub and the argument frame -/
-
-/-- A model for verb denotation: the thematic frame (the role relations) and the
-    lexical core (`⟦√V⟧ : Event → Prop` per verb). Parameterized by the semantic
-    domain; instantiated by Studies. This is CLAUDE.md's "theory-hub denotation". -/
-structure Verb.Model (Entity Time : Type*) [LinearOrder Time] where
-  /-- The thematic frame: how each role relates entities to events. -/
-  frame : ThematicFrame Entity Time
-  /-- The lexical core of each verb: its bare event predicate `⟦√V⟧`. -/
-  lex : Verb → Event Time → Prop
-
-/-- An assignment of entities to a verb's argument slots. Phase-1 frame: an
-    external argument and an optional internal argument. -/
-structure ArgFrame (Entity : Type*) where
-  /-- The entity in subject position. -/
-  subject : Entity
-  /-- The entity in object position, if any. -/
-  object : Option Entity := none
 
 /-! ### The theta-grid (derived from the proto-role profiles) -/
 
@@ -90,52 +49,6 @@ def Verb.subjectRole (v : Verb) : Option ThetaRole :=
 /-- The object's theta-role, derived from its effective `EntailmentProfile`. -/
 def Verb.objectRole (v : Verb) : Option ThetaRole :=
   v.effectiveObjectEntailments.bind (·.toRole)
-
-/-! ### The operation -/
-
-/-- What a verb DOES: build an event predicate from an argument assignment, in a
-    model. Neo-Davidsonian — the lexical core conjoined with one thematic-role
-    relation per filled argument slot (vacuous where the theta-grid or the frame
-    has no entry). The classificatory facets enter only through `subjectRole` /
-    `objectRole`; nothing here is stipulated. -/
-def Verb.denote {Entity Time : Type*} [LinearOrder Time]
-    (M : Verb.Model Entity Time) (v : Verb) (args : ArgFrame Entity) :
-    Event Time → Prop :=
-  fun e =>
-    M.lex v e
-    ∧ (match v.subjectRole with
-        | some θ => θ.toRel M.frame args.subject e
-        | none => True)
-    ∧ (match args.object, v.objectRole with
-        | some x, some θ => θ.toRel M.frame x e
-        | _, _ => True)
-
-/-! ### The operation's truth conditions -/
-
-/-- A transitive verb whose theta-grid is agent/patient denotes the lexical core
-    conjoined with `Agent(subj)` and `Patient(obj)` — the standard
-    neo-Davidsonian truth conditions, *derived* from the operation. -/
-theorem Verb.denote_transitive {Entity Time : Type*} [LinearOrder Time]
-    (M : Verb.Model Entity Time) (v : Verb) (s o : Entity) (e : Event Time)
-    (hs : v.subjectRole = some .agent) (ho : v.objectRole = some .patient) :
-    v.denote M ⟨s, some o⟩ e ↔
-      M.lex v e ∧ M.frame.agent s e ∧ M.frame.patient o e := by
-  simp only [Verb.denote, hs, ho, ThetaRole.toRel]
-
-/-- An intransitive use (no object) drops the object conjunct entirely. -/
-theorem Verb.denote_intransitive {Entity Time : Type*} [LinearOrder Time]
-    (M : Verb.Model Entity Time) (v : Verb) (s : Entity) (e : Event Time)
-    (hs : v.subjectRole = some .agent) :
-    v.denote M ⟨s, none⟩ e ↔ M.lex v e ∧ M.frame.agent s e := by
-  simp only [Verb.denote, hs, ThetaRole.toRel, and_true]
-
-/-- When the theta-grid is empty (no profile data), the denotation is just the
-    lexical core — graceful degradation, no spurious conjuncts. -/
-theorem Verb.denote_bare {Entity Time : Type*} [LinearOrder Time]
-    (M : Verb.Model Entity Time) (v : Verb) (s : Entity) (e : Event Time)
-    (hs : v.subjectRole = none) :
-    v.denote M ⟨s, none⟩ e ↔ M.lex v e := by
-  simp only [Verb.denote, hs, and_true]
 
 /-! ### Change-of-state decomposition ([beavers-koontz-garboden-2020] §1.3.2)
 

--- a/Linglib/Studies/AndersonJM2006.lean
+++ b/Linglib/Studies/AndersonJM2006.lean
@@ -7,6 +7,7 @@ import Linglib.Features.Case.Basic
 import Linglib.Semantics.ArgumentStructure.EntailmentProfile
 import Linglib.Semantics.ArgumentStructure.Linking
 import Linglib.Fragments.English.Predicates.Verbal
+import Linglib.Semantics.Verb.Denotation
 
 /-!
 # Anderson (2006): Modern Grammars of Case [anderson-jm-2006]
@@ -312,16 +313,11 @@ theorem experiencer_agent_distinct_same_rank :
 -- § 3: Verb → Scenario (End-to-End Bridge)
 -- ============================================================================
 
-private def subjectRole (v : Verb) : Option ThetaRole :=
-  v.effectiveSubjectEntailments.bind (·.toRole)
-
-private def objectRole (v : Verb) : Option ThetaRole :=
-  v.effectiveObjectEntailments.bind (·.toRole)
-
-/-- Derive Anderson's `Scenario` from a Fragment verb entry's derived roles. -/
+/-- Derive Anderson's `Scenario` from a Fragment verb entry's derived roles
+    (`Verb.subjectRole`/`objectRole`, the canonical theta-grid). -/
 def toScenario (v : Verb) : Scenario :=
-  ⟨(subjectRole v |>.map thetaToCaseRelation).toList ++
-   (objectRole v |>.map thetaToCaseRelation).toList⟩
+  ⟨(v.subjectRole |>.map thetaToCaseRelation).toList ++
+   (v.objectRole |>.map thetaToCaseRelation).toList⟩
 
 -- ============================================================================
 -- § 4: Anderson as LinkingTheory
@@ -373,7 +369,7 @@ theorem experiencer_correctly_predicted :
 theorem anderson_linking_accuracy :
     (allVerbs.filter λ v =>
       (andersonPredictedSubjectTheta v.toVerb).isSome ==
-      (subjectRole v.toVerb).isSome).length = allVerbs.length := by
+      (v.toVerb.subjectRole).isSome).length = allVerbs.length := by
   native_decide
 
 -- ============================================================================
@@ -415,10 +411,10 @@ theorem experiencer_distinguished :
     not collapsed into agent (for verbs with entailment profiles). -/
 theorem experiencer_verbs_correct :
     (allVerbs.filter λ v =>
-      (subjectRole v.toVerb) == some .experiencer ∧
+      (v.toVerb.subjectRole) == some .experiencer ∧
       andersonPredictedSubjectTheta v.toVerb == some .experiencer).length =
     (allVerbs.filter λ v =>
-      (subjectRole v.toVerb) == some .experiencer).length := by
+      (v.toVerb.subjectRole) == some .experiencer).length := by
   native_decide
 
 -- ============================================================================


### PR DESCRIPTION
Deletes the dead opaque theta-grid layer — `Verb.Model` (opaque `lex`), `ArgFrame`, `ThetaRole.toRel`, `Verb.denote`, and the three `denote_*` theorems (audit-confirmed 0 consumers; the structured `Verb.CosModel` is the denotation). Keeps `Verb.subjectRole`/`objectRole` and refactors `AndersonJM2006` off its byte-identical private copies onto them — their first real consumer. Blueprint (`scratch/verb-api-blueprint.md`) step #5.