### PR TITLE
refactor(Semantics): prune orphan head-list + dead Verb defs

### DIFF
--- a/Linglib/Semantics/Lexical/Roots/Profile.lean
+++ b/Linglib/Semantics/Lexical/Roots/Profile.lean
@@ -30,11 +30,11 @@ namespace Root.Profile
 
     Roots are **regions**, not points: a verb like *tear* is compatible with
     a range of force levels, not a single one. -/
-abbrev Range (α : Type) := Option (List α)
+abbrev Range (α : Type*) := Option (List α)
 
 namespace Range
 
-variable {α : Type}
+variable {α : Type*}
 
 def unconstrained : Range α := none
 

--- a/Linglib/Semantics/Lexical/Roots/Template.lean
+++ b/Linglib/Semantics/Lexical/Roots/Template.lean
@@ -1,41 +1,20 @@
 import Linglib.Semantics.Lexical.Roots.Basic
 
 /-!
-# Templatic Heads and Event Structure Composition
+# Root attachment position
 
-The event-structural architecture of [beavers-koontz-garboden-2020]
-(ch. 1): **templatic heads** combine with **roots**, and a root
-attaches in one of two structural positions (adjoined to a head, or as
-its complement). The familiar [rappaport-hovav-levin-1998] templates
-(state, activity, achievement, accomplishment) are *compositions* of
-these primitives.
-
-Scope: the three verbal heads `v_act`/`v_become`/`v_cause` of the
-change-of-state and manner fragment (chs. 1–2, 4–5). The ditransitive
-prepositional heads P_loc and P_have and the modalized causative of
-ch. 3 are not modeled.
+A verb root attaches in one of two structural positions
+([beavers-koontz-garboden-2020] ch. 1; the Distributed-Morphology tradition,
+Marantz): adjoined to a head, or as a head's complement. The distinction
+conditions vVPE eligibility ([kalyakin-2026]), result-state modifier scope, and
+the restitutive/repetitive *again* ambiguity ([merchant-2013]).
 
 ## Main declarations
 
-* `TemplaticHead` — the three primitive heads
 * `Root.Position` — complement vs adjoined attachment
-* `Root.EventStructure` — heads composed with a positioned root
 -/
 
 namespace Verb
-
-/-! ### Templatic heads -/
-
-/-- The three primitive event-structural heads of
-    [beavers-koontz-garboden-2020] ch. 1. The book glosses
-    `v_become` as `λPλxλe. ∃s. become′(s, e) ∧ P(x, s)` and `v_cause`
-    as `λQλyλv. ∃e. effector′(y, v) ∧ cause′(v, e) ∧ Q(e)` — one
-    event-predicate argument, introducing the effector. -/
-inductive TemplaticHead where
-  | v_act     -- activity (Davidsonian event predicate)
-  | v_become  -- change of state into the root's state
-  | v_cause   -- causation by an effector
-  deriving DecidableEq, Repr
 
 /-! ### Root position -/
 
@@ -56,59 +35,5 @@ inductive Root.Position where
   | complement
   | adjoined
   deriving DecidableEq, Repr
-
-/-! ### Composed event structures -/
-
-namespace Root
-
-/-- An event structure: a list of templatic heads (outermost first)
-    composed with a root in a specific structural position.
-
-    Examples:
-    - `⟨[v_act], jog, adjoined⟩`           — pure activity (jog)
-    - `⟨[v_become], blossom, complement⟩`  — achievement
-    - `⟨[v_cause, v_become], crack, complement⟩` — accomplishment
-    - `⟨[v_cause, v_become], hand, adjoined⟩`    — caused result with
-      manner root in adjoined position -/
-structure EventStructure where
-  heads : List TemplaticHead
-  root : Root
-  position : Root.Position
-
-namespace EventStructure
-
-/-- Does the event structure include a particular head? -/
-def hasHead (es : EventStructure) (h : TemplaticHead) : Bool :=
-  es.heads.contains h
-
-/-- Has activity head. -/
-def hasAct (es : EventStructure) : Bool := es.hasHead .v_act
-
-/-- Has BECOME head. -/
-def hasBecome (es : EventStructure) : Bool := es.hasHead .v_become
-
-/-- Has CAUSE head. -/
-def hasCause (es : EventStructure) : Bool := es.hasHead .v_cause
-
-end EventStructure
-
-/-! ### Canonical compositions -/
-
-/-- A pure activity: `[v_act]` with manner root adjoined.
-    [x ACT⟨manner⟩] -/
-def activityOf (r : Root) : EventStructure :=
-  ⟨[.v_act], r, .adjoined⟩
-
-/-- An achievement: `[v_become]` with state root as complement.
-    [BECOME [x ⟨STATE⟩]] -/
-def achievementOf (r : Root) : EventStructure :=
-  ⟨[.v_become], r, .complement⟩
-
-/-- An accomplishment: `[v_cause, v_become]` with state root as
-    complement to BECOME. [[x ACT] CAUSE [BECOME [y ⟨STATE⟩]]] -/
-def accomplishmentOf (r : Root) : EventStructure :=
-  ⟨[.v_cause, .v_become], r, .complement⟩
-
-end Root
 
 end Verb

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -67,33 +67,12 @@ def Verb.isDoxastic (v : Verb) : Bool :=
 def Verb.isPreferential (v : Verb) : Bool :=
   v.attitude.map (·.isPreferential) |>.getD false
 
-/-- Does this attitude distribute over conjunction?
-    DERIVED from complementSig: any signature that refines `.mono`
-    (mono, additive, mult, addMult, all) distributes. -/
-def Verb.distribOverConj (v : Verb) : Bool :=
-  v.complementSig.map (fun s => decide (s ≤ .mono)) |>.getD false
-
-/-- Is the complement position upward-entailing?
-    DERIVED from complementSig. -/
-def Verb.isComplementUE (v : Verb) : Bool :=
-  v.complementSig.map (fun s => decide (s ≤ .mono)) |>.getD false
-
 /-- Valence is DERIVED from the attitude builder (for preferential attitudes) -/
 def Verb.preferentialValence (v : Verb) : Option AttitudeValence :=
   v.attitude.bind (·.valence)
 
 -- Note: Verb.cDistributive, Verb.nvpClass, and Verb.takesQuestion
 -- are derived properties defined in Semantics.Intensional/Attitude/BuilderProperties.lean
-
-/--
-Get the CoS semantics for a verb (if it's a CoS verb).
-
-Returns `some (cosSemantics t P)` if the verb has a CoS type,
-where `P` is the activity predicate (complement denotation).
--/
-def Verb.getCoSSemantics {W : Type*} (v : Verb) (P : W → Prop) :
-    Option (PartialProp W) :=
-  v.cosType.map λ t => cosSemantics t P
 
 /-- Does this verb presuppose its complement via factivity?
     DERIVED from attitude: true iff the verb is doxastic veridical. -/


### PR DESCRIPTION
Prunes audit-flagged orphans: the `Roots/Template.lean` templatic head-list (`TemplaticHead`/`Root.EventStructure`/`activityOf`/…, 0 consumers, redundant with `EventStructure.Template` — keeps `Root.Position`); dead `Verb.Basic` defs (`distribOverConj`/`isComplementUE`/`getCoSSemantics`); `Profile.Range` `Type`→`Type*`. `RootTypology.RootDen` deferred — it carries the restitutive-*again* predictions, to be superseded by blueprint #9 rather than dropped. Blueprint #6.