### PR TITLE
refactor(Semantics/Verb): make Verb.root total (drop the Option)

### DIFF
--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -129,7 +129,7 @@ def run : VerbEntry where
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .mannerOfMotion
-  root := some { profile := {
+  root := { profile := {
     forceMag := some [.moderate]
     agentVolition := some [.volitional]
     agentControl := some [.compatible]
@@ -159,7 +159,7 @@ def eat : VerbEntry where
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .eat
-  root := some { profile := {
+  root := { profile := {
     forceMag := some [.low, .moderate]
     agentVolition := some [.volitional]
     agentControl := some [.compatible]
@@ -173,7 +173,7 @@ def kick : VerbEntry := .mkRegular {
   objectEntailments := some ⟨false, false, false, false, false, true, false, true, true, false⟩
   vendlerClass := some .activity
   levinClass := some .hit
-  root := some { profile := {
+  root := { profile := {
     forceMag := some [.moderate, .high]
     forceDir := some [.unidirectional]
     agentVolition := some [.neutral, .volitional]
@@ -801,7 +801,7 @@ def kill : VerbEntry := .mkRegular {
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .murder
-  root := some { profile := {
+  root := { profile := {
     resultType := some [.totalDestruction]
     agentVolition := some [.neutral, .volitional]
     agentControl := some [.neutral, .compatible]
@@ -821,7 +821,7 @@ def break_ : VerbEntry where
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .break_
-  root := some { profile := {
+  root := { profile := {
     forceMag := some [.moderate, .high]
     -- forceDir unconstrained: *break* covers snapping (bidirectional),
     -- hammering (omnidirectional), and directed blows (unidirectional)
@@ -851,7 +851,7 @@ def tear_ : VerbEntry where
   verbIncClass := some .sinc
   causative := some .make
   levinClass := some .break_
-  root := some { profile := {
+  root := { profile := {
     forceMag := some [.moderate, .high]
     forceDir := some [.bidirectional, .unidirectional]
     patientRob := some [.flimsy, .moderate, .robust]
@@ -931,7 +931,7 @@ def burn : VerbEntry := .mkRegular {
   verbIncClass := some .sinc
   causative := some .make
   levinClass := some .otherCoS
-  root := some { profile := {
+  root := { profile := {
     forceMag := some [.moderate, .high]
     patientRob := some [.flimsy, .moderate, .robust]
     resultType := some [.totalDestruction, .deformation]
@@ -946,7 +946,7 @@ def destroy : VerbEntry := .mkRegular {
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .destroy
-  root := some { profile := {
+  root := { profile := {
     resultType := some [.totalDestruction]
     agentVolition := some [.neutral, .volitional]
     agentControl := some [.neutral, .compatible]
@@ -963,7 +963,7 @@ def melt : VerbEntry := .mkRegular {
   verbIncClass := some .sinc
   causative := some .make
   levinClass := some .otherCoS
-  root := some { profile := {
+  root := { profile := {
     forceMag := some [.low, .moderate]
     patientRob := some [.moderate, .robust]
     resultType := some [.deformation]
@@ -1114,7 +1114,7 @@ def devour : VerbEntry := .mkRegular {
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .devour
-  root := some { profile := {
+  root := { profile := {
     forceMag := some [.moderate, .high]
     agentVolition := some [.volitional]
     agentControl := some [.neutral]
@@ -1175,7 +1175,7 @@ def sweep : VerbEntry where
   subjectEntailments := some ⟨false, false, false, true, true, false, false, false, false, false⟩
   passivizable := true
   levinClass := some .wipe
-  root := some { profile := {
+  root := { profile := {
     forceMag := some [.low, .moderate]
     forceDir := some [.unidirectional]
     agentVolition := some [.volitional]
@@ -1195,7 +1195,7 @@ def sweep_instr : VerbEntry where
   passivizable := true
   senseTag := .instrumental
   levinClass := some .wipe
-  root := some { profile := {
+  root := { profile := {
     forceMag := some [.low, .moderate]
     forceDir := some [.unidirectional]
     agentVolition := some [.volitional]
@@ -2369,7 +2369,7 @@ def cut : VerbEntry where
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .cut
-  root := some { profile := {
+  root := { profile := {
     resultType := some [.surfaceBreach]
     instrumentType := some [.sharpBlade]
   } }

--- a/Linglib/Fragments/Spanish/Predicates.lean
+++ b/Linglib/Fragments/Spanish/Predicates.lean
@@ -199,7 +199,7 @@ def rasgar : SpanishVerbEntry :=
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := true,
     levinClass := some .break_,
-    root := some { profile := {
+    root := { profile := {
       forceMag := some [.low, .moderate]
       forceDir := some [.unidirectional]
       patientRob := some [.insubstantial, .flimsy]

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -34,18 +34,17 @@ def Verb.derivedVendlerClass (v : Verb) : Option VendlerClass :=
   v.vendlerClass <|> v.degreeAchievementScale.map (·.defaultVendlerClass)
 
 /-- The verb's within-class quality profile ([spalek-mcnally-2026]), read off its
-    `root` (where the profile is now carried — formerly a separate `Verb` field).
-    `none` when the verb has no root. -/
-def Verb.rootProfile (v : Verb) : Option Verb.Root.Profile :=
-  v.root.map (·.profile)
+    `root` (where the profile is carried). -/
+def Verb.rootProfile (v : Verb) : Verb.Root.Profile :=
+  v.root.profile
 
 /-- The verb's kind signature ([beavers-koontz-garboden-2020]): the collocational
     closure of its root's kinds (`cause ⟹ result ⟹ state`), which the
-    event-structure spine (`Verb.Root.template`, `CosModel.denote`) runs on.
-    `none` when the verb has no root. (The raw, un-closed atom-kinds are
-    `v.root.kinds`; the coarse class-derived view is `Verb.classKinds`.) -/
-def Verb.closedKinds (v : Verb) : Option Verb.Root.Kinds :=
-  v.root.map (·.closedKinds)
+    event-structure spine (`Verb.Root.template`, `CosModel.denote`) runs on. (The
+    raw, un-closed atom-kinds are `v.root.kinds`; the coarse class-derived view is
+    `Verb.classKinds`.) -/
+def Verb.closedKinds (v : Verb) : Verb.Root.Kinds :=
+  v.root.closedKinds
 
 /-- Effective subject entailment profile: verb-level override if present,
     otherwise falls back to the Levin class–level profile

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -277,12 +277,12 @@ structure Verb extends
     Verb.Causation, Verb.Attitude where
   /-- [levin-1993] verb class (§§ 9–57). -/
   levinClass : Option LevinClass := none
-  /-- The verb's lexical root — its entailment atoms, derived B&KG feature
+  /-- The verb's lexical root — its entailment atoms, derived B&KG kind
       signature, and [bhadra-2024] outcome axis. The content carrier the Verb
-      API integrates around (P-HUB): when present, the verb's signature / outcome
-      / change-type are read off *this* root rather than the `levinClass` table.
-      `none` until a Fragment annotates it. -/
-  root : Option Root := none
+      API integrates around (P-HUB): the verb's signature / outcome / change-type
+      are read off *this* root rather than the `levinClass` table. Total, with
+      the trivial root `{}` (no annotation) as the `⊥`. -/
+  root : Root := {}
   /-- Citation form (cross-linguistic) -/
   form : String
   /-- Does the verb denote the performance of an illocutionary act?

--- a/Linglib/Semantics/Verb/Denotation.lean
+++ b/Linglib/Semantics/Verb/Denotation.lean
@@ -129,8 +129,8 @@ theorem causative_entails_resultState (M : CosModel Entity State Time)
     kinds *select the event template* — the denotational payoff of the signature. -/
 def denote (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
     Event Time → Prop :=
-  if LexKind.cause ∈ (v.closedKinds).getD ∅ then M.causative v y x
-  else if LexKind.result ∈ (v.closedKinds).getD ∅ then M.inchoative v x
+  if LexKind.cause ∈ v.closedKinds then M.causative v y x
+  else if LexKind.result ∈ v.closedKinds then M.inchoative v x
   else M.manner v
 
 /-- The denotational payoff of a `.result` root: any verb whose root signature
@@ -141,10 +141,10 @@ def denote (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
     `denote` is the manner core). -/
 theorem denote_result_entails_resultState (M : CosModel Entity State Time)
     (v : Verb) (y x : Entity) (e : Event Time)
-    (hres : LexKind.result ∈ (v.closedKinds).getD ∅)
+    (hres : LexKind.result ∈ v.closedKinds)
     (h : M.denote v y x e) : ∃ e' s, M.become s e' ∧ M.rootState v x s := by
   unfold denote at h
-  by_cases hc : LexKind.cause ∈ (v.closedKinds).getD ∅
+  by_cases hc : LexKind.cause ∈ v.closedKinds
   · rw [if_pos hc] at h
     exact M.causative_entails_resultState v y x e h
   · rw [if_neg hc, if_pos hres] at h
@@ -156,13 +156,10 @@ theorem denote_result_entails_resultState (M : CosModel Entity State Time)
     `Template.HasResultState` are one fact, through the closed kind signature
     ([beavers-koontz-garboden-2020]; [rappaport-hovav-levin-1998]). -/
 theorem denote_result_from_template (M : CosModel Entity State Time)
-    (v : Verb) (r : Verb.Root) (hroot : v.root = some r)
-    (ht : r.template.HasResultState) (y x : Entity) (e : Event Time)
+    (v : Verb) (ht : v.root.template.HasResultState) (y x : Entity) (e : Event Time)
     (h : M.denote v y x e) : ∃ e' s, M.become s e' ∧ M.rootState v x s := by
   refine M.denote_result_entails_resultState v y x e ?_ h
-  have heq : (v.closedKinds).getD ∅ = r.closedKinds := by
-    simp [Verb.closedKinds, hroot]
-  rw [heq]
-  exact (Verb.Root.template_hasResultState_iff r).mp ht
+  show LexKind.result ∈ v.root.closedKinds
+  exact (Verb.Root.template_hasResultState_iff v.root).mp ht
 
 end Verb.CosModel

--- a/Linglib/Semantics/Verb/RootContent.lean
+++ b/Linglib/Semantics/Verb/RootContent.lean
@@ -33,36 +33,28 @@ open Semantics.Lexical
 def Verb.classKinds (v : Verb) : Option Verb.Root.Kinds :=
   v.levinClass.map LevinClass.rootEntailments
 
-/-- The verb's outcome-set cardinality ([bhadra-2024]), read off its `root`. No
-    Levin fallback: the per-class outcome assignment is a Study-level claim. -/
+/-- The verb's outcome-set cardinality ([bhadra-2024]), read off its `root`
+    (`none` where the root is not annotated for outcomes). -/
 def Verb.outcomes (v : Verb) : Option Verb.OutcomeCardinality :=
-  v.root.bind (·.outcomes)
+  v.root.outcomes
 
 /-- The verb's change-entailment type ([beavers-etal-2021]), derived from its
     root's kind signature. -/
-def Verb.changeType (v : Verb) : Option RootType :=
-  v.root.map Verb.Root.changeType
+def Verb.changeType (v : Verb) : RootType :=
+  v.root.changeType
 
 /-- A verb's `changeType` is blind to its root's outcome axis (it factors through
     `Verb.Root.changeType`): verbs whose roots share entailments share a
-    `changeType` whatever their outcomes — the verb-level lift of the root
-    orthogonality, and why outcome cardinality is an independent dimension. -/
-theorem Verb.changeType_ignores_outcomes {v v' : Verb} {r r' : Verb.Root}
-    (hr : v.root = some r) (hr' : v'.root = some r')
-    (h : r.entailments = r'.entailments) : v.changeType = v'.changeType := by
-  unfold Verb.changeType
-  rw [hr, hr']
-  exact congrArg some (Verb.Root.changeType_ignores_outcomes h)
+    `changeType` whatever their outcomes — why outcome cardinality is an
+    independent dimension. -/
+theorem Verb.changeType_ignores_outcomes {v v' : Verb}
+    (h : v.root.entailments = v'.root.entailments) : v.changeType = v'.changeType :=
+  Verb.Root.changeType_ignores_outcomes h
 
-/-- The verb's outcome cardinality is exactly its root's, when annotated. -/
-@[simp] theorem Verb.outcomes_root {v : Verb} {r : Verb.Root} (hr : v.root = some r) :
-    v.outcomes = r.outcomes := by
-  unfold Verb.outcomes; rw [hr]; rfl
-
-/-- End-to-end (P-HUB): for any verb, reading its `changeType` off a root and off
-    the same-entailment root with a different outcome cardinality agree — only the
-    outcome axis distinguishes them. -/
+/-- End-to-end (P-HUB): for any verb, its `changeType` off two same-entailment
+    roots that differ only in outcome cardinality agree — only the outcome axis
+    distinguishes them. -/
 example (v : Verb) :
-    ({ v with root := some { entailments := ∅, outcomes := some .multi } }).changeType
-      = ({ v with root := some { entailments := ∅, outcomes := some .singleton } }).changeType :=
-  Verb.changeType_ignores_outcomes rfl rfl rfl
+    ({ v with root := { entailments := ∅, outcomes := some .multi } }).changeType
+      = ({ v with root := { entailments := ∅, outcomes := some .singleton } }).changeType :=
+  Verb.changeType_ignores_outcomes rfl

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -185,10 +185,10 @@ follows from the signature. √crack (`+cause+result`) entails a result state in
 any model; √jog (pure manner) does not — the *break*/*hit* contrast. -/
 
 /-- `crack` the change-of-state verb (`Mary cracked the vase`). -/
-def crackV : Verb := { form := "crack", complementType := .np, root := some crack }
+def crackV : Verb := { form := "crack", complementType := .np, root := crack }
 
 /-- `jog` the pure-manner activity verb (`Mary jogged`). -/
-def jogV : Verb := { form := "jog", complementType := .none, root := some jog }
+def jogV : Verb := { form := "jog", complementType := .none, root := jog }
 
 /-- √crack carries `.result`, so in **any** model its denotation entails the
     result state — the non-cancelable result of [beavers-koontz-garboden-2020]
@@ -234,6 +234,6 @@ theorem crack_template_forces_denote_result {Entity State Time : Type*}
     [LinearOrder Time] (M : Verb.CosModel Entity State Time) (y x : Entity)
     (e : Event Time) (h : M.denote crackV y x e) :
     ∃ e' s, M.become s e' ∧ M.rootState crackV x s :=
-  M.denote_result_from_template crackV crack rfl crack_template_hasResultState y x e h
+  M.denote_result_from_template crackV crack_template_hasResultState y x e h
 
 end BeaversKoontzGarboden2020

--- a/Linglib/Studies/MajidBosterBowerman2008.lean
+++ b/Linglib/Studies/MajidBosterBowerman2008.lean
@@ -508,7 +508,7 @@ theorem cut_break_same_template :
 open English.Predicates.Verbal in
 /-- Extract the root profile from a Fragment verb entry. -/
 private def fragmentProfile (v : VerbEntry) : Root.Profile :=
-  v.rootProfile.getD {}
+  v.rootProfile
 
 open English.Predicates.Verbal
 

--- a/Linglib/Studies/SpalekMcNally2026.lean
+++ b/Linglib/Studies/SpalekMcNally2026.lean
@@ -73,16 +73,16 @@ theorem patient_restriction_differs :
 /-- *tear* implies bidirectional (contrary-direction) force;
     *rasgar* implies unidirectional (linear/gash-like) force. -/
 theorem force_direction_differs :
-    tear_.rootProfile.bind (·.forceDir) ≠
-    rasgar.rootProfile.bind (·.forceDir) := by
+    tear_.rootProfile.forceDir ≠
+    rasgar.rootProfile.forceDir := by
   decide
 
 /-- *tear* is compatible with controlled action; *rasgar* is not.
     [spalek-mcnally-2026] ex. (17): "carefully tore the tin foil" ✓
     vs. "??rasgaron con cuidado el papel de aluminio" (§3.2). -/
 theorem agent_control_differs :
-    tear_.rootProfile.bind (·.agentControl) ≠
-    rasgar.rootProfile.bind (·.agentControl) := by
+    tear_.rootProfile.agentControl ≠
+    rasgar.rootProfile.agentControl := by
   decide
 
 -- ════════════════════════════════════════════════════
@@ -94,7 +94,7 @@ theorem agent_control_differs :
     where both verbs are applicable. This overlap zone is where they
     function as translation equivalents (§4.2, Table 1). -/
 theorem roots_overlap :
-    (tear_.rootProfile.get!).overlaps (rasgar.rootProfile.get!) := by
+    tear_.rootProfile.overlaps rasgar.rootProfile := by
   decide
 
 -- ════════════════════════════════════════════════════


### PR DESCRIPTION
Makes `Verb.root : Verb.Root` total (default `{}`, the trivial root), dropping the `Option` — `none` and `some {}` were two encodings of "no annotation." The content accessors lose their `Option` (`rootProfile : Profile`, `closedKinds : Root.Kinds`, `changeType : RootType`; `outcomes` stays `Option` as the root's own field is), `denote`'s dispatch + `denote_result_from_template` simplify (no `some r`/`hroot`), and the ~18 `root := some {…}` setters become `root := {…}`. Blueprint #8 (the root-total foundation).