### PR TITLE
feat(Quantification): mark quantifiers, dissolve QuantifierEntry

### DIFF
--- a/Linglib/Fragments/English/Determiners.lean
+++ b/Linglib/Fragments/English/Determiners.lean
@@ -24,10 +24,10 @@ strength, conservativity) is a theorem about that denotation, not a stored field
 (see `Studies/BarwiseCooper1981.lean`).
 
 The cross-paper typological labels (B&C Table II strength/monotonicity, K&S
-force) are kept as the textbook-consensus `QuantityWord.entry : QuantifierEntry`
-metadata table (`Semantics/Quantification/Lexicon.lean`), consumed by GQT and
-exceptive studies that need the descriptive classification rather than the
-denotation.
+force) are kept as the textbook-consensus `QuantityWord.entry : QuantityWord.Metadata`
+metadata table (a small local record over the `Quantification.Lexicon` enums),
+consumed by GQT and exceptive studies that need the descriptive classification
+rather than the denotation.
 
 ## Scope
 
@@ -38,7 +38,7 @@ prototype-theory prototypes/spreads) and theory-bridge theorems live elsewhere:
 - Compositional GQ denotations (`every_sem`, `both_sem`, `neither_sem`, …):
   `Semantics/Quantification/Quantifier.lean`.
 - GQT/PT meaning operators consuming numerical parameters:
-  `Semantics/Quantification/Quantifier.lean` (`gqtMeaning`),
+  `Studies/VanTielEtAl2021.lean` (`gqtMeaning`, van Tiel's threshold scale-model),
   `Semantics/Probabilistic/PrototypeTheory.lean` (`ptMeaning`).
 - Per-paper parameter values: `Studies/VanTielEtAl2021.lean`.
 -/
@@ -46,7 +46,7 @@ prototype-theory prototypes/spreads) and theory-bridge theorems live elsewhere:
 namespace English.Determiners
 
 export Quantification.Lexicon
-  (QForce Monotonicity Strength QuantifierEntry)
+  (QForce Monotonicity Strength)
 
 /-! ## Quantificational determiners
 
@@ -188,6 +188,20 @@ instance : Fintype QuantityWord where
   elems := {.none_, .few, .some_, .half, .most, .all}
   complete := fun x => by cases x <;> simp
 
+/-- B&C Table II typological metadata: the textbook-consensus descriptive
+    labels (force, monotonicity, weak/strong strength) a quantity word carries.
+    A small local record over the `Quantification.Lexicon` enums — *not* the
+    lexical marking (that is `Quantifier`, above) and *not* the denotation
+    (that is `QuantityWord.gqDenotation`). -/
+structure QuantityWord.Metadata where
+  /-- Quantificational force. -/
+  qforce : QForce
+  /-- Monotonicity (typological label). -/
+  monotonicity : Monotonicity := .increasing
+  /-- Weak/strong (B&C Table II). -/
+  strength : Strength := .weak
+  deriving Repr, BEq, DecidableEq
+
 /-- B&C Table II typological metadata for each quantity word: force,
     monotonicity, and weak/strong strength. This is the textbook-consensus
     descriptive classification ([barwise-cooper-1981] Table II,
@@ -196,22 +210,13 @@ instance : Fintype QuantityWord where
     theorems about it (`Studies/BarwiseCooper1981.lean`). Consumed by the GQT
     model ([van-tiel-franke-sauerland-2021]) and the exceptive-licensing bridge
     ([von-fintel-1993]) that want the descriptive label. -/
-def QuantityWord.entry : QuantityWord → QuantifierEntry
-  | .none_ => { form := "none", qforce := .negative, allowsMass := true
-              , monotonicity := .decreasing, strength := .weak }
-  | .few   => { form := "few", qforce := .proportional
-              , numberRestriction := some .Plur
-              , monotonicity := .decreasing, strength := .weak }
-  | .some_ => { form := "some", qforce := .existential, allowsMass := true
-              , monotonicity := .increasing, strength := .weak }
-  | .half  => { form := "half", qforce := .proportional, allowsMass := true
-              , monotonicity := .nonMonotone, strength := .weak }
-  | .most  => { form := "most", qforce := .proportional
-              , numberRestriction := some .Plur, allowsMass := true
-              , monotonicity := .increasing, strength := .strong }
-  | .all   => { form := "all", qforce := .universal
-              , numberRestriction := some .Plur, allowsMass := true
-              , monotonicity := .increasing, strength := .strong }
+def QuantityWord.entry : QuantityWord → QuantityWord.Metadata
+  | .none_ => { qforce := .negative, monotonicity := .decreasing, strength := .weak }
+  | .few   => { qforce := .proportional, monotonicity := .decreasing, strength := .weak }
+  | .some_ => { qforce := .existential, monotonicity := .increasing, strength := .weak }
+  | .half  => { qforce := .proportional, monotonicity := .nonMonotone, strength := .weak }
+  | .most  => { qforce := .proportional, monotonicity := .increasing, strength := .strong }
+  | .all   => { qforce := .universal, monotonicity := .increasing, strength := .strong }
 
 /-- Convenience accessor. -/
 def QuantityWord.monotonicity (q : QuantityWord) : Monotonicity :=

--- a/Linglib/Fragments/English/Determiners.lean
+++ b/Linglib/Fragments/English/Determiners.lean
@@ -1,31 +1,46 @@
 import Linglib.Data.UD.Basic
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Semantics.Quantification.Quantifier
+import Linglib.Semantics.Quantification.Lexicon
 
 /-!
 # English Determiners
 [horn-1972] [barwise-cooper-1981]
 
-English-specific determiner lexicon. The shared `QuantifierEntry`
-structure (and the `QForce`/`Monotonicity`/`Strength` enums) lives in
-`Semantics/Quantification/Lexicon.lean`; this file is the
-English instantiation, a small numerical-determiner sublexicon, and the
-canonical 6-element ⟨none, few, some, half, most, all⟩ quantity scale
-(`QuantityWord`) with its B&C-style GQ denotation table.
+English-specific determiner lexicon. Each entry is *marked* like a `Pronoun`
+(a decidable record carrying only the morphosyntax synonyms diverge on) and
+typed by the standard determiner taxonomy in `Syntax/Determiner/Basic.lean`:
+
+- the genuinely quantificational words (every, some, no, most, few, half, all,
+  each, many, both, neither) are `Syntax.Determiner.Quantifier`;
+- the definites/indefinites (the, a, an) are `Article`s and the demonstratives
+  (this, that, these, those) are `DemonstrativeDeterminer`s.
+
+A determiner's **denotation** is a generalized quantifier supplied externally —
+the marked record carries no `GQ`, exactly as `Pronoun` carries no referent.
+For the six-word quantity scale the form↦`GQ` map is `QuantityWord.gqDenotation`
+(`Semantics/Quantification`); everything a meaning *fixes* (force, monotonicity,
+strength, conservativity) is a theorem about that denotation, not a stored field
+(see `Studies/BarwiseCooper1981.lean`).
+
+The cross-paper typological labels (B&C Table II strength/monotonicity, K&S
+force) are kept as the textbook-consensus `QuantityWord.entry : QuantifierEntry`
+metadata table (`Semantics/Quantification/Lexicon.lean`), consumed by GQT and
+exceptive studies that need the descriptive classification rather than the
+denotation.
 
 ## Scope
 
-This file carries descriptive lexical data and its projection to the
-GQ denotations. Per-paper model parameters (GQT thresholds,
-prototype-theory prototypes/spreads) and theory-bridge theorems live
-elsewhere:
+This file carries descriptive lexical data, its projection to GQ denotations,
+and the typological metadata table. Per-paper model parameters (GQT thresholds,
+prototype-theory prototypes/spreads) and theory-bridge theorems live elsewhere:
 
-- Compositional GQ denotations (`every_sem`, `both_sem`, `neither_sem`,
-  …): `Semantics/Quantification/Quantifier.lean`.
+- Compositional GQ denotations (`every_sem`, `both_sem`, `neither_sem`, …):
+  `Semantics/Quantification/Quantifier.lean`.
 - GQT/PT meaning operators consuming numerical parameters:
   `Semantics/Quantification/Quantifier.lean` (`gqtMeaning`),
   `Semantics/Probabilistic/PrototypeTheory.lean` (`ptMeaning`).
-- Per-paper parameter values:
-  `Studies/VanTielEtAl2021.lean`.
+- Per-paper parameter values: `Studies/VanTielEtAl2021.lean`.
 -/
 
 namespace English.Determiners
@@ -33,64 +48,85 @@ namespace English.Determiners
 export Quantification.Lexicon
   (QForce Monotonicity Strength QuantifierEntry)
 
-def none_ : QuantifierEntry :=
-  { form := "none", qforce := .negative, allowsMass := true, monotonicity := .decreasing }
+/-! ## Quantificational determiners
 
-def few : QuantifierEntry :=
-  { form := "few", qforce := .proportional, numberRestriction := some .Plur
-  , monotonicity := .decreasing }
+Marked `Quantifier` records: `form`, the selectional `numberRestriction`
+(root `Number`), and `selectsMass`. The meaning leaves these open — *every* and
+*all* can share a denotation yet differ in `numberRestriction`. -/
 
-def some_ : QuantifierEntry :=
-  { form := "some", qforce := .existential, allowsMass := true, monotonicity := .increasing }
+/-- "none" — negative, accepts mass NPs. -/
+def none_ : Quantifier := { form := "none", selectsMass := true }
 
-def half : QuantifierEntry :=
-  { form := "half", qforce := .proportional, allowsMass := true, monotonicity := .nonMonotone }
+/-- "few" — proportional, plural. -/
+def few : Quantifier := { form := "few", numberRestriction := some .plural }
 
-/-- "most" - more than half -/
-def most : QuantifierEntry :=
-  { form := "most"
-  , qforce := .proportional
-  , numberRestriction := some .Plur
-  , allowsMass := true
-  , monotonicity := .increasing
-  , strength := .strong  -- B&C Table II: *"There are most cats"
-  }
+/-- "some" — existential, accepts mass NPs. -/
+def some_ : Quantifier := { form := "some", selectsMass := true }
 
-/-- "all" - everything satisfies -/
-def all : QuantifierEntry :=
-  { form := "all"
-  , qforce := .universal
-  , numberRestriction := some .Plur
-  , allowsMass := true
-  , monotonicity := .increasing
-  , strength := .strong  -- B&C Table II: *"There is all cats"
-  }
+/-- "half" — proportional, accepts mass NPs. -/
+def half : Quantifier := { form := "half", selectsMass := true }
 
-/-- "every" - universal, singular -/
-def every : QuantifierEntry :=
-  { form := "every"
-  , qforce := .universal
-  , numberRestriction := some .Sing
-  , monotonicity := .increasing
-  , strength := .strong  -- B&C Table II: *"There is every cat"
-  }
+/-- "most" — proportional, plural, accepts mass NPs. -/
+def most : Quantifier :=
+  { form := "most", numberRestriction := some .plural, selectsMass := true }
 
-/-- "each" - universal, distributive -/
-def each : QuantifierEntry :=
-  { form := "each"
-  , qforce := .universal
-  , numberRestriction := some .Sing
-  , monotonicity := .increasing
-  , strength := .strong  -- B&C Table II: *"There is each cat"
-  }
+/-- "all" — universal, plural, accepts mass NPs. -/
+def all : Quantifier :=
+  { form := "all", numberRestriction := some .plural, selectsMass := true }
 
-/-- "many" - a large number -/
-def many : QuantifierEntry :=
-  { form := "many"
-  , qforce := .proportional
-  , numberRestriction := some .Plur
-  , monotonicity := .increasing
-  }
+/-- "every" — universal, singular. -/
+def every : Quantifier := { form := "every", numberRestriction := some .singular }
+
+/-- "each" — universal, distributive, singular. -/
+def each : Quantifier := { form := "each", numberRestriction := some .singular }
+
+/-- "many" — proportional, plural. -/
+def many : Quantifier := { form := "many", numberRestriction := some .plural }
+
+/-- "both" — universal dual, presupposes exactly 2.
+    K&S (83a): [_Det each of the two] ⇒ both. Compositional denotation
+    `both_sem` lives in `Quantification.Quantifier`.
+
+    `numberRestriction := some .dual` carries the dual core concept
+    ([harbour-2014] `[−atomic, +minimal]`); the cardinality clause `|R| ≥ 2`
+    on the denotation side reflects the Harbour `dualPredOnLattice` reading
+    ([jeretic-bassi-gonzalez-yatsushiro-meyer-sauerland-2025]). -/
+def both : Quantifier := { form := "both", numberRestriction := some .dual }
+
+/-- "neither" — negative dual, presupposes exactly 2.
+    K&S (83b): [_Det (not one) of the two] ⇒ neither. Compositional denotation
+    `neither_sem` lives in `Quantification.Quantifier`. -/
+def neither : Quantifier := { form := "neither", numberRestriction := some .dual }
+
+/-! ## Articles and demonstratives
+
+The definites/indefinites and demonstratives are *not* quantifiers: their
+denotation is definiteness, not a generalized quantifier. -/
+
+/-- "the" — definite article, syncretic over both [schwarz-2009] strengths. -/
+def the : Article :=
+  { form := "the", definiteness := .definite, exponent := .dedicatedMorpheme
+  , uses := [.immediateSituation, .largerSituation, .anaphoric, .donkey] }
+
+/-- "a" — indefinite article, singular. -/
+def a : Article :=
+  { form := "a", definiteness := .indefinite, exponent := .dedicatedMorpheme }
+
+/-- "an" — indefinite article, singular (phonological allomorph of *a*). -/
+def an : Article :=
+  { form := "an", definiteness := .indefinite, exponent := .dedicatedMorpheme }
+
+/-- "this" — proximal demonstrative determiner, singular. -/
+def this : DemonstrativeDeterminer := { form := "this", deictic := .proximal }
+
+/-- "that" — distal demonstrative determiner, singular. -/
+def that : DemonstrativeDeterminer := { form := "that", deictic := .distal }
+
+/-- "these" — proximal demonstrative determiner, plural. -/
+def these : DemonstrativeDeterminer := { form := "these", deictic := .proximal }
+
+/-- "those" — distal demonstrative determiner, plural. -/
+def those : DemonstrativeDeterminer := { form := "those", deictic := .distal }
 
 /-! ## Numerical Determiners
 [barwise-cooper-1981] [van-de-pol-etal-2023]
@@ -134,59 +170,6 @@ def fewerThan (n : Nat) : NumericalDetEntry :=
   { form := s!"fewer than {n}", qforce := .proportional
   , monotonicity := .decreasing, threshold := n }
 
-/-! ## Definite Determiners (less relevant for quantity scales) -/
-
-def the : QuantifierEntry :=
-  { form := "the", qforce := .definite, allowsMass := true, strength := .strong }
-
-def this : QuantifierEntry :=
-  { form := "this", qforce := .definite, numberRestriction := some .Sing, strength := .strong }
-
-def that : QuantifierEntry :=
-  { form := "that", qforce := .definite, numberRestriction := some .Sing, strength := .strong }
-
-def these : QuantifierEntry :=
-  { form := "these", qforce := .definite, numberRestriction := some .Plur, strength := .strong }
-
-def those : QuantifierEntry :=
-  { form := "those", qforce := .definite, numberRestriction := some .Plur, strength := .strong }
-
-def a : QuantifierEntry :=
-  { form := "a", qforce := .existential, numberRestriction := some .Sing }
-
-def an : QuantifierEntry :=
-  { form := "an", qforce := .existential, numberRestriction := some .Sing }
-
-/-- "both" - universal dual, presupposes exactly 2.
-    K&S (83a): [_Det each of the two] ⇒ both.
-    Compositional denotation `both_sem` lives in
-    `Quantification.Quantifier`.
-
-    `numberRestriction := some .Dual` carries the dual core concept
-    ([harbour-2014] `[−atomic, +minimal]`); the cardinality clause
-    `|R| ≥ 2` on the denotation side reflects the Harbour
-    `dualPredOnLattice` reading
-    ([jeretic-bassi-gonzalez-yatsushiro-meyer-sauerland-2025]). -/
-def both : QuantifierEntry :=
-  { form := "both"
-  , qforce := .universal
-  , numberRestriction := some .Dual
-  , monotonicity := .increasing
-  , strength := .strong  -- K&S §3.2: definite dets are strong
-  }
-
-/-- "neither" - negative dual, presupposes exactly 2.
-    K&S (83b): [_Det (not one) of the two] ⇒ neither.
-    Compositional denotation `neither_sem` lives in
-    `Quantification.Quantifier`. -/
-def neither : QuantifierEntry :=
-  { form := "neither"
-  , qforce := .negative
-  , numberRestriction := some .Dual
-  , monotonicity := .decreasing
-  , strength := .strong  -- K&S §3.3: negative strong
-  }
-
 /-! ## The Canonical Quantity Scale
 [barwise-cooper-1981] [van-tiel-franke-sauerland-2021]
 
@@ -205,14 +188,30 @@ instance : Fintype QuantityWord where
   elems := {.none_, .few, .some_, .half, .most, .all}
   complete := fun x => by cases x <;> simp
 
-/-- Lexical entry for each quantity word. -/
+/-- B&C Table II typological metadata for each quantity word: force,
+    monotonicity, and weak/strong strength. This is the textbook-consensus
+    descriptive classification ([barwise-cooper-1981] Table II,
+    [van-de-pol-etal-2023] for *half*), *not* the denotation — the denotation
+    is `QuantityWord.gqDenotation`, and the properties this table labels are
+    theorems about it (`Studies/BarwiseCooper1981.lean`). Consumed by the GQT
+    model ([van-tiel-franke-sauerland-2021]) and the exceptive-licensing bridge
+    ([von-fintel-1993]) that want the descriptive label. -/
 def QuantityWord.entry : QuantityWord → QuantifierEntry
-  | .none_ => _root_.English.Determiners.none_
-  | .few   => _root_.English.Determiners.few
-  | .some_ => _root_.English.Determiners.some_
-  | .half  => _root_.English.Determiners.half
-  | .most  => _root_.English.Determiners.most
-  | .all   => _root_.English.Determiners.all
+  | .none_ => { form := "none", qforce := .negative, allowsMass := true
+              , monotonicity := .decreasing, strength := .weak }
+  | .few   => { form := "few", qforce := .proportional
+              , numberRestriction := some .Plur
+              , monotonicity := .decreasing, strength := .weak }
+  | .some_ => { form := "some", qforce := .existential, allowsMass := true
+              , monotonicity := .increasing, strength := .weak }
+  | .half  => { form := "half", qforce := .proportional, allowsMass := true
+              , monotonicity := .nonMonotone, strength := .weak }
+  | .most  => { form := "most", qforce := .proportional
+              , numberRestriction := some .Plur, allowsMass := true
+              , monotonicity := .increasing, strength := .strong }
+  | .all   => { form := "all", qforce := .universal
+              , numberRestriction := some .Plur, allowsMass := true
+              , monotonicity := .increasing, strength := .strong }
 
 /-- Convenience accessor. -/
 def QuantityWord.monotonicity (q : QuantityWord) : Monotonicity :=
@@ -238,18 +237,21 @@ noncomputable def QuantityWord.gqDenotation (q : QuantityWord)
 
 /-! ## Lexicon Access -/
 
-/-- All quantifier entries (excluding definites). -/
-def allQuantifiers : List QuantifierEntry := [
+/-- All quantificational determiner entries (excluding definites). -/
+def allQuantifiers : List Quantifier := [
   none_, few, some_, half, most, all, every, each, many, both, neither
 ]
 
-/-- All determiner entries (including definites). -/
-def allDeterminers : List QuantifierEntry := [
-  the, this, that, these, those, a, an
-] ++ allQuantifiers
+/-- All article entries. -/
+def allArticles : List Article := [the, a, an]
 
-/-- Lookup by form. -/
-def lookup (form : String) : Option QuantifierEntry :=
-  allDeterminers.find? λ d => d.form == form
+/-- All demonstrative-determiner entries. -/
+def allDemonstratives : List DemonstrativeDeterminer := [this, that, these, those]
+
+/-- The full inventory as a heterogeneous `List Determiner.Entry`
+    (the per-language form a Fragment declares). -/
+def inventory : List Determiner.Entry :=
+  allArticles.map .article ++ allDemonstratives.map .demonstrative ++
+    allQuantifiers.map .quantifier
 
 end English.Determiners

--- a/Linglib/Fragments/English/TemporalExpressions.lean
+++ b/Linglib/Fragments/English/TemporalExpressions.lean
@@ -8,7 +8,7 @@ import Linglib.Fragments.English.FunctionWords
 [alstott-aravind-2026] [heinamaki-1974] [rett-2020] [karttunen-1974] [ogihara-steinert-threlkeld-2024] [iatridou-anagnostopoulou-izvorski-2001] [vendler-1957]
 
 Lexical entries for English temporal expressions, organised into two sibling
-structures (mathlib pattern, mirroring `QuantifierEntry` + `NumericalDetEntry`
+structures (mathlib pattern, mirroring `Quantifier` + `NumericalDetEntry`
 in `Determiners.lean`):
 
 - `TemporalExprEntry` — **ordering expressions**: subordinating connectives
@@ -495,7 +495,7 @@ inductive DurationKind where
     Iatridou-Zeijlstra 2021's domain-widening profile) lives as
     partial projections from this structure in the relevant Theory
     or Studies file (mathlib-style pattern: same discipline as
-    `QuantifierEntry → gqDenotation/ptMeaning/gqtMeaning` in
+    `QuantityWord → gqDenotation/ptMeaning/gqtMeaning` in
     `Determiners.lean`).
 
     Cross-references for *in years* (the NPI-gap entry):

--- a/Linglib/Fragments/French/Determiners.lean
+++ b/Linglib/Fragments/French/Determiners.lean
@@ -1,98 +1,81 @@
-import Linglib.Data.UD.Basic
-import Linglib.Semantics.Quantification.Lexicon
+import Linglib.Syntax.Determiner.Basic
 
 /-!
 # French Determiners and Quantifiers
 [jeretic-bassi-gonzalez-yatsushiro-meyer-sauerland-2025]
 
 A small lexicon of French determiners and quantifiers, structured to
-parallel `English.Determiners` so that the two can be
-compared directly in cross-linguistic studies. The shape `QuantifierEntry`
-is reused; only `form` and language-specific feature combinations
-differ.
+parallel `English.Determiners` so that the two can be compared directly
+in cross-linguistic studies. The genuinely quantificational words are
+`Syntax.Determiner.Quantifier` records (marked like a `Pronoun`, carrying
+only the morphosyntax synonyms diverge on); the definite/indefinite
+articles (*les*, *un*) are `Article`s. Only `form` and language-specific
+feature combinations differ from English.
 
-This fragment is the minimum needed by
-`Studies/JereticEtAl2025.lean`. The notable
-gap relative to English: French has no lexical dual universal
-quantifier (no counterpart of `both`). The expression `les deux` is the
-nearest equivalent and is encoded here, with `numberRestriction := some
-.du`, marking that — unlike `tous`, which is plural-restricted — it
-realizes the dual core concept (`JereticEtAl2025.CoreConcept.Id.dual`).
+This fragment is the minimum needed by `Studies/JereticEtAl2025.lean`. The
+notable gap relative to English: French has no lexical dual universal
+quantifier (no counterpart of `both`). The expression *les deux* is the
+nearest equivalent and is encoded here as a `Quantifier` with
+`numberRestriction := some .dual`, marking that — unlike *tous*, which is
+plural-restricted — it realizes the dual core concept
+(`JereticEtAl2025.CoreConcept.Id.dual`).
 -/
 
 namespace French.Determiners
 
-open Quantification.Lexicon
-  (QuantifierEntry QForce Monotonicity Strength)
+/-! ## Quantificational determiners
+
+Marked `Quantifier` records: `form`, the selectional `numberRestriction`
+(root `Number`), and `selectsMass`. -/
 
 /-- *tous* — universal, plural. The French universal of [chemla-2007]'s
 puzzle: anti-dual despite the lack of any French *both*. The paper's
 analysis: anti-duality is implicated via competition with the indirect
 alternative *les deux* (`les_deux`). -/
-def tous : QuantifierEntry :=
+def tous : Quantifier :=
   { form := "tous"
-  , qforce := .universal
-  , numberRestriction := some .Plur
-  , allowsMass := true
-  , monotonicity := .increasing
-  , strength := .strong
-  }
+  , numberRestriction := some .plural
+  , selectsMass := true }
 
 /-- *chaque* — universal, singular distributive (≈ English *each*). -/
-def chaque : QuantifierEntry :=
+def chaque : Quantifier :=
   { form := "chaque"
-  , qforce := .universal
-  , numberRestriction := some .Sing
-  , monotonicity := .increasing
-  , strength := .strong
-  }
+  , numberRestriction := some .singular }
 
 /-- *aucun* — negative, singular. NOT anti-dual: French has no
 expression simple enough to act as an indirect alternative
 (*aucun des deux* and *ni l'un ni l'autre* are both more complex).
 See JereticEtAl2025 §5.2. -/
-def aucun : QuantifierEntry :=
+def aucun : Quantifier :=
   { form := "aucun"
-  , qforce := .negative
-  , numberRestriction := some .Sing
-  , monotonicity := .decreasing
-  , strength := .strong
-  }
+  , numberRestriction := some .singular }
 
 /-- *les deux* — definite dual ('the two'). The pronounceable
 expression that serves as an indirect alternative for the unpronounceable
-*tous les NP.dual* (paper Fig. 1 + §4.1). Restricted to dual domains. -/
-def les_deux : QuantifierEntry :=
+*tous les NP.dual* (paper Fig. 1 + §4.1). Restricted to dual domains;
+marked here as a `Quantifier` so its dual `numberRestriction` is
+readable (the dual core-concept witness), paralleling English *both*. -/
+def les_deux : Quantifier :=
   { form := "les deux"
-  , qforce := .definite
-  , numberRestriction := some .Dual
-  , monotonicity := .nonMonotone
-  , strength := .strong
-  }
+  , numberRestriction := some .dual }
 
 /-- *quelques* — existential, plural. -/
-def quelques : QuantifierEntry :=
+def quelques : Quantifier :=
   { form := "quelques"
-  , qforce := .existential
-  , numberRestriction := some .Plur
-  , monotonicity := .increasing
-  }
+  , numberRestriction := some .plural }
 
-/-- *un* — existential, singular. -/
-def un : QuantifierEntry :=
+/-- *un* — indefinite article, singular. -/
+def un : Article :=
   { form := "un"
-  , qforce := .existential
-  , numberRestriction := some .Sing
-  }
+  , definiteness := .indefinite
+  , exponent := .dedicatedMorpheme }
 
 /-- *les* — definite plural article. -/
-def les : QuantifierEntry :=
+def les : Article :=
   { form := "les"
-  , qforce := .definite
-  , numberRestriction := some .Plur
-  , allowsMass := true
-  , strength := .strong
-  }
+  , definiteness := .definite
+  , exponent := .dedicatedMorpheme
+  , uses := [.immediateSituation, .largerSituation, .anaphoric, .donkey] }
 
 /-- *toujours* — universal temporal ('always'). Parallel to English
 `always` (which decomposes as *all*+*ways*); JereticEtAl2025 §5.4
@@ -100,16 +83,15 @@ contrasts: English *always* is anti-dual via competition with
 *both times*; French *toujours*, despite morphological decomposition
 *tous*+*jours*, is NOT anti-dual because *les deux fois* ('the two
 times') is more complex than *toujours*. -/
-def toujours : QuantifierEntry :=
+def toujours : Quantifier :=
   { form := "toujours"
-  , qforce := .universal
-  , numberRestriction := some .Plur
-  , monotonicity := .increasing
-  , strength := .strong
-  }
+  , numberRestriction := some .plural }
 
-/-- All French quantifier entries. -/
-def allQuantifiers : List QuantifierEntry :=
-  [tous, chaque, aucun, les_deux, quelques, un, les, toujours]
+/-- All French quantifier entries (definite articles *les*/*un* excluded). -/
+def allQuantifiers : List Quantifier :=
+  [tous, chaque, aucun, les_deux, quelques, toujours]
+
+/-- All French article entries. -/
+def allArticles : List Article := [un, les]
 
 end French.Determiners

--- a/Linglib/Fragments/Italian/Determiners.lean
+++ b/Linglib/Fragments/Italian/Determiners.lean
@@ -1,12 +1,14 @@
 import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Semantics.Quantification.Lexicon
 
 /-! # Italian Determiners (Quantifiers)
 
-Quantifier lexicon with syntactic and semantic properties. Reuses the
-shared `QuantifierEntry` from
-`Semantics/Quantification/Lexicon.lean` and extends it with
-gender agreement.
+Quantifier lexicon with syntactic and semantic properties. Each entry
+`extends Syntax.Determiner.Quantifier` (the marked-determiner base: `form`,
+`numberRestriction`, `selectsMass`) and adds gender agreement plus the
+typological metadata labels (`qforce`/`monotonicity`/`strength`) from
+`Semantics/Quantification/Lexicon.lean`.
 
 Italian quantifiers agree in gender and/or number with their NP:
 - *ogni* (every): invariant, singular
@@ -20,11 +22,17 @@ Italian quantifiers agree in gender and/or number with their NP:
 
 namespace Italian.Determiners
 
-open Quantification.Lexicon
-  (QuantifierEntry QForce Monotonicity Strength)
+open Quantification.Lexicon (QForce Monotonicity Strength)
 
-/-- Italian quantifier entry: shared `QuantifierEntry` + gender. -/
-structure ItalianQuantifierEntry extends QuantifierEntry where
+/-- Italian quantifier entry: the marked `Quantifier` base + gender + the
+    B&C typological metadata labels. -/
+structure ItalianQuantifierEntry extends Quantifier where
+  /-- Quantificational force (typological label). -/
+  qforce : QForce
+  /-- Monotonicity (typological label). -/
+  monotonicity : Monotonicity := .increasing
+  /-- Weak/strong (B&C Table II). -/
+  strength : Strength := .weak
   /-- Gender agreement (none = invariant) -/
   gender : Option Gender := none
   deriving Repr
@@ -35,21 +43,21 @@ def ogni : ItalianQuantifierEntry :=
   , qforce := .universal
   , monotonicity := .increasing
   , strength := .strong
-  , numberRestriction := some .Sing }
+  , numberRestriction := some .singular }
 
 /-- *qualche* — some (invariant, singular, existential). -/
 def qualche : ItalianQuantifierEntry :=
   { form := "qualche"
   , qforce := .existential
   , monotonicity := .increasing
-  , numberRestriction := some .Sing }
+  , numberRestriction := some .singular }
 
 /-- *nessuno* — no one (masculine, singular, negative concord). -/
 def nessuno : ItalianQuantifierEntry :=
   { form := "nessuno"
   , qforce := .negative
   , monotonicity := .decreasing
-  , numberRestriction := some .Sing
+  , numberRestriction := some .singular
   , gender := some .masculine }
 
 /-- *nessuna* — no one (feminine, singular, negative concord). -/
@@ -57,7 +65,7 @@ def nessuna : ItalianQuantifierEntry :=
   { form := "nessuna"
   , qforce := .negative
   , monotonicity := .decreasing
-  , numberRestriction := some .Sing
+  , numberRestriction := some .singular
   , gender := some .feminine }
 
 /-- *tutti* — all (masculine, plural, universal). -/
@@ -66,7 +74,7 @@ def tutti : ItalianQuantifierEntry :=
   , qforce := .universal
   , monotonicity := .increasing
   , strength := .strong
-  , numberRestriction := some .Plur
+  , numberRestriction := some .plural
   , gender := some .masculine }
 
 /-- *tutte* — all (feminine, plural, universal). -/
@@ -75,7 +83,7 @@ def tutte : ItalianQuantifierEntry :=
   , qforce := .universal
   , monotonicity := .increasing
   , strength := .strong
-  , numberRestriction := some .Plur
+  , numberRestriction := some .plural
   , gender := some .feminine }
 
 /-- *alcuni* — some (masculine, plural, existential). -/
@@ -83,7 +91,7 @@ def alcuni : ItalianQuantifierEntry :=
   { form := "alcuni"
   , qforce := .existential
   , monotonicity := .increasing
-  , numberRestriction := some .Plur
+  , numberRestriction := some .plural
   , gender := some .masculine }
 
 /-- *alcune* — some (feminine, plural, existential). -/
@@ -91,7 +99,7 @@ def alcune : ItalianQuantifierEntry :=
   { form := "alcune"
   , qforce := .existential
   , monotonicity := .increasing
-  , numberRestriction := some .Plur
+  , numberRestriction := some .plural
   , gender := some .feminine }
 
 /-- *molti* — many (masculine, plural, proportional). -/
@@ -99,7 +107,7 @@ def molti : ItalianQuantifierEntry :=
   { form := "molti"
   , qforce := .proportional
   , monotonicity := .increasing
-  , numberRestriction := some .Plur
+  , numberRestriction := some .plural
   , gender := some .masculine }
 
 /-- *molte* — many (feminine, plural, proportional). -/
@@ -107,7 +115,7 @@ def molte : ItalianQuantifierEntry :=
   { form := "molte"
   , qforce := .proportional
   , monotonicity := .increasing
-  , numberRestriction := some .Plur
+  , numberRestriction := some .plural
   , gender := some .feminine }
 
 /-- *pochi* — few (masculine, plural, proportional, decreasing). -/
@@ -115,7 +123,7 @@ def pochi : ItalianQuantifierEntry :=
   { form := "pochi"
   , qforce := .proportional
   , monotonicity := .decreasing
-  , numberRestriction := some .Plur
+  , numberRestriction := some .plural
   , gender := some .masculine }
 
 /-- *poche* — few (feminine, plural, proportional, decreasing). -/
@@ -123,7 +131,7 @@ def poche : ItalianQuantifierEntry :=
   { form := "poche"
   , qforce := .proportional
   , monotonicity := .decreasing
-  , numberRestriction := some .Plur
+  , numberRestriction := some .plural
   , gender := some .feminine }
 
 /-- All Italian quantifier entries. -/

--- a/Linglib/Fragments/Japanese/Determiners.lean
+++ b/Linglib/Fragments/Japanese/Determiners.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Fragments.English.Determiners
 
 /-! # Japanese Quantifier Fragment
@@ -20,11 +21,12 @@ namespace Japanese.Determiners
 
 open English.Determiners (QForce Monotonicity Strength)
 
-/-- Japanese quantifier entry. Extends the English pattern with
-    indeterminate/particle morphology and floating quantifier properties. -/
-structure JapaneseQuantEntry where
-  /-- Kana/kanji form -/
-  form : String
+/-- Japanese quantifier entry. `extends Syntax.Determiner.Quantifier` (the
+    marked-determiner base — the inherited `form` holds the kana/kanji surface
+    form) and adds indeterminate/particle morphology, floating-quantifier
+    properties, and the typological metadata labels (`qforce`/`monotonicity`/
+    `strength`). -/
+structure JapaneseQuantEntry extends Quantifier where
   /-- Rōmaji romanization -/
   romaji : String
   /-- English gloss -/

--- a/Linglib/Fragments/Mandarin/Determiners.lean
+++ b/Linglib/Fragments/Mandarin/Determiners.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Syntax.Determiner.Basic
 import Linglib.Typology.ClassifierSystem
 import Linglib.Fragments.English.Determiners
 import Linglib.Fragments.Mandarin.Classifiers
@@ -31,11 +32,11 @@ open English.Determiners (QForce Monotonicity Strength)
 open Typology (ClassifierEntry)
 open Mandarin.Classifiers (ge)
 
-/-- Mandarin quantifier entry. Extends the English pattern with
-    classifier requirements (Mandarin-specific morphosyntax). -/
-structure MandarinQuantEntry where
-  /-- Hànzì form -/
-  hanzi : String
+/-- Mandarin quantifier entry. `extends Syntax.Determiner.Quantifier` (the
+    marked-determiner base — the inherited `form` holds the hànzì surface form)
+    and adds classifier requirements (Mandarin-specific morphosyntax) and the
+    typological metadata labels (`qforce`/`monotonicity`/`strength`). -/
+structure MandarinQuantEntry extends Quantifier where
   /-- Pīnyīn romanization -/
   pinyin : String
   /-- English gloss -/
@@ -59,7 +60,7 @@ structure MandarinQuantEntry where
 /-- 每 měi "every" — universal, singular-like, requires classifier.
     měi-gè xuéshēng 每个学生 "every-CL student" -/
 def mei : MandarinQuantEntry :=
-  { hanzi := "每"
+  { form := "每"
   , pinyin := "měi"
   , gloss := "every"
   , qforce := .universal
@@ -71,7 +72,7 @@ def mei : MandarinQuantEntry :=
 /-- 所有 suǒyǒu "all" — universal, plural-like, no classifier required.
     suǒyǒu xuéshēng 所有学生 "all students" -/
 def suoyou : MandarinQuantEntry :=
-  { hanzi := "所有"
+  { form := "所有"
   , pinyin := "suǒyǒu"
   , gloss := "all"
   , qforce := .universal
@@ -82,7 +83,7 @@ def suoyou : MandarinQuantEntry :=
     quánbù xuéshēng 全部学生 "all students".
     Synonym of suǒyǒu; does not require a classifier. -/
 def quanbu : MandarinQuantEntry :=
-  { hanzi := "全部"
+  { form := "全部"
   , pinyin := "quánbù"
   , gloss := "all"
   , qforce := .universal
@@ -93,7 +94,7 @@ def quanbu : MandarinQuantEntry :=
     hěnduō xuéshēng 很多学生 "many students".
     Can optionally co-occur with dōu but does not require it. -/
 def henduo : MandarinQuantEntry :=
-  { hanzi := "很多"
+  { form := "很多"
   , pinyin := "hěnduō"
   , gloss := "many"
   , qforce := .existential
@@ -103,7 +104,7 @@ def henduo : MandarinQuantEntry :=
 /-- 大部分 dà-bùfèn "most/the greater part" — proportional, increasing, strong.
     dà-bùfèn xuéshēng 大部分学生 "most students" -/
 def dabufen : MandarinQuantEntry :=
-  { hanzi := "大部分"
+  { form := "大部分"
   , pinyin := "dà-bùfèn"
   , gloss := "most"
   , qforce := .proportional

--- a/Linglib/Semantics/Definiteness/Basic.lean
+++ b/Linglib/Semantics/Definiteness/Basic.lean
@@ -108,7 +108,7 @@ theorem the_is_every_on_singletons {α : Type*}
 -- §4: Bridge to Fragments/English/Determiners.lean
 -- ============================================================================
 
-open English.Determiners (QForce QuantifierEntry)
+open English.Determiners (QForce)
 
 /-- English "the" is `QForce.definite` — its denotation is given by
 composing `presupOfReferent` with `russellIotaList domain restrictor`

--- a/Linglib/Semantics/Quantification/Counting.lean
+++ b/Linglib/Semantics/Quantification/Counting.lean
@@ -684,4 +684,127 @@ theorem half_proportional : Proportional ⟦half⟧ := by
   rw [count_decompose R₁ S₁, count_decompose R₂ S₂]
   exact half_prop_core _ _ _ _ hNE₁ hNE₂ hCross
 
+/-! ### Proportional ⇒ not intersective / not monotone (witnessed counterexamples)
+
+The proportional determiners `most`, `few`, `half` are *not* intersective:
+they fail the `Existential` property (felicity in there-sentences), even though
+B&C's Table II labels `few`/`half` "weak". `Existential q` (`q R S ↔ q (R∩S) ⊤`)
+is false for them because the truth value depends on `|R∖S|`, not just on `|R∩S|`.
+Refuting it needs a domain with `|α| ≥ 3` (over `Fin 1`/`Fin 2` `most` is vacuously
+`Existential`), so the witnessed statements pin `α := Fin 3`. `half` is moreover
+non-monotone in scope (goes true→false as the scope grows), and `most` is not
+symmetric. -/
+
+/-- `count` is independent of the chosen `DecidablePred` instance: any instance
+    equals the canonical synthesized one. Lets the classical-`DecidablePred`
+    `count` frozen into the counting denotations be evaluated by `decide`. -/
+theorem count_eq_decidable (P : α → Prop) (inst' : DecidablePred P)
+    [DecidablePred P] :
+    @count α _ P inst' = count P := by
+  unfold count; congr 1; apply Finset.filter_congr_decidable
+
+/-- `most` is proportional, not intersective: it fails `Existential`. Witness over
+    `Fin 3`: `R = ⊤`, `S = {0}` gives `|R∩S| = 1`, `|R∖S| = 2`, so `most R S` is
+    false (`1 > 2` fails) while `most (R∩S) ⊤` is true (`|R∩S| = 1 > 0`). -/
+theorem not_existential_most_sem : ¬ Existential (most_sem : GQ (Fin 3)) := by
+  intro h
+  have key := h (fun _ => True) (fun x => x = 0)
+  simp only [most_sem, true_and, not_true, and_false, and_true] at key
+  rw [count_eq_decidable (fun x : Fin 3 => x = 0),
+      count_eq_decidable (fun x : Fin 3 => ¬ x = 0),
+      count_eq_decidable (fun _ : Fin 3 => False)] at key
+  simp only [count] at key
+  revert key; decide
+
+/-- `few` is proportional, not intersective: it fails `Existential`, despite B&C's
+    "weak" label. Witness over `Fin 3`: `R = ⊤`, `S = {0}` gives `|R∩S| = 1 <
+    |R∖S| = 2`, so `few R S` is true while `few (R∩S) ⊤` is false
+    (`|R∩S| < |∅| = 0` is impossible). -/
+theorem not_existential_few_sem : ¬ Existential (few_sem : GQ (Fin 3)) := by
+  intro h
+  have key := h (fun _ => True) (fun x => x = 0)
+  simp only [few_sem, true_and, not_true, and_false, and_true] at key
+  rw [count_eq_decidable (fun x : Fin 3 => x = 0),
+      count_eq_decidable (fun x : Fin 3 => ¬ x = 0),
+      count_eq_decidable (fun _ : Fin 3 => False)] at key
+  simp only [count] at key
+  revert key; decide
+
+/-- `half` is proportional, not intersective: it fails `Existential`, despite B&C's
+    "weak" label. Witness over `Fin 3`: `R = {0,1}`, `S = {0}` gives `half R S`
+    true (`2·|R∩S| = 2 = |R|`) while `half (R∩S) ⊤` requires `|R∩S| = 0`, false. -/
+theorem not_existential_half_sem : ¬ Existential (half_sem : GQ (Fin 3)) := by
+  intro h
+  have key := h (fun x => x = 0 ∨ x = 1) (fun x => x = 0)
+  simp only [half_sem, and_true,
+    count_eq_decidable (fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ x = 0) _,
+    count_eq_decidable (fun x : Fin 3 => x = 0 ∨ x = 1) _] at key
+  have v1 : (count fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ x = 0) = 1 := by
+    simp only [count]; decide
+  have v2 : (count fun x : Fin 3 => x = 0 ∨ x = 1) = 2 := by
+    simp only [count]; decide
+  rw [v1, v2] at key; revert key; decide
+
+/-- `half` is not scope-upward-monotone. Witness over `Fin 3`: `R = {0,1}`,
+    `S = {0} ⊆ S' = {0,1}`; `half R S` is true (`2·1 = 2 = |R|`) but `half R S'`
+    is false (`2·2 = 4 ≠ 2`) — growing the scope flips it true→false. -/
+theorem half_not_scopeUp : ¬ ScopeUpwardMono (half_sem : GQ (Fin 3)) := by
+  intro h
+  have key := h (fun x => x = 0 ∨ x = 1) (fun x => x = 0) (fun x => x = 0 ∨ x = 1)
+    (fun _ hx => Or.inl hx)
+  simp only [half_sem,
+    count_eq_decidable (fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ x = 0) _,
+    count_eq_decidable (fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ (x = 0 ∨ x = 1)) _,
+    count_eq_decidable (fun x : Fin 3 => x = 0 ∨ x = 1) _] at key
+  have v0 : (count fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ x = 0) = 1 := by
+    simp only [count]; decide
+  have v1 : (count fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ (x = 0 ∨ x = 1)) = 2 := by
+    simp only [count]; decide
+  have v2 : (count fun x : Fin 3 => x = 0 ∨ x = 1) = 2 := by simp only [count]; decide
+  rw [v0, v1, v2] at key; revert key; decide
+
+/-- `half` is not scope-downward-monotone. Witness over `Fin 3`: `R = {0,1}`,
+    `S = ∅ ⊆ S' = {0}`; `half R S'` is true (`2·1 = 2 = |R|`) but `half R S` is
+    false (`2·0 = 0 ≠ 2`) — shrinking the scope flips it true→false. -/
+theorem half_not_scopeDown : ¬ ScopeDownwardMono (half_sem : GQ (Fin 3)) := by
+  intro h
+  have key := h (fun x => x = 0 ∨ x = 1) (fun _ => False) (fun x => x = 0)
+    (fun _ hx => absurd hx id)
+  simp only [half_sem, and_false,
+    count_eq_decidable (fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ x = 0) _,
+    count_eq_decidable (fun x : Fin 3 => x = 0 ∨ x = 1) _] at key
+  have v0 : (count fun _ : Fin 3 => False) = 0 := by simp only [count]; decide
+  have v1 : (count fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ x = 0) = 1 := by
+    simp only [count]; decide
+  have v2 : (count fun x : Fin 3 => x = 0 ∨ x = 1) = 2 := by simp only [count]; decide
+  rw [v0, v1, v2] at key; revert key; decide
+
+/-- `half` is non-monotone in scope: neither scope-upward nor scope-downward
+    monotone ([van-de-pol-etal-2023]). -/
+theorem half_not_monotone :
+    ¬ ScopeUpwardMono (half_sem : GQ (Fin 3)) ∧
+    ¬ ScopeDownwardMono (half_sem : GQ (Fin 3)) :=
+  ⟨half_not_scopeUp, half_not_scopeDown⟩
+
+/-- `most` is not symmetric: `most R S ↔ most S R` fails. Witness over `Fin 3`:
+    `R = {0}`, `S = {0,1}`; `most R S` is true (`|R∩S| = 1 > |R∖S| = 0`) but
+    `most S R` is false (`|S∩R| = 1 > |S∖R| = 1` fails). -/
+theorem not_qsymmetric_most_sem : ¬ QSymmetric (most_sem : GQ (Fin 3)) := by
+  intro h
+  have key := h (fun x => x = 0) (fun x => x = 0 ∨ x = 1)
+  simp only [most_sem,
+    count_eq_decidable (fun x : Fin 3 => x = 0 ∧ (x = 0 ∨ x = 1)) _,
+    count_eq_decidable (fun x : Fin 3 => x = 0 ∧ ¬ (x = 0 ∨ x = 1)) _,
+    count_eq_decidable (fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ x = 0) _,
+    count_eq_decidable (fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ ¬ x = 0) _] at key
+  have v0 : (count fun x : Fin 3 => x = 0 ∧ (x = 0 ∨ x = 1)) = 1 := by
+    simp only [count]; decide
+  have v1 : (count fun x : Fin 3 => x = 0 ∧ ¬ (x = 0 ∨ x = 1)) = 0 := by
+    simp only [count]; decide
+  have v2 : (count fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ x = 0) = 1 := by
+    simp only [count]; decide
+  have v3 : (count fun x : Fin 3 => (x = 0 ∨ x = 1) ∧ ¬ x = 0) = 1 := by
+    simp only [count]; decide
+  rw [v0, v1, v2, v3] at key; revert key; decide
+
 end Quantification

--- a/Linglib/Semantics/Quantification/Lexicon.lean
+++ b/Linglib/Semantics/Quantification/Lexicon.lean
@@ -2,26 +2,24 @@ import Linglib.Data.UD.Basic
 import Linglib.Morphology.Word
 
 /-!
-# Quantifier lexicon — shared structure
+# Quantifier typology — shared enums
 [horn-1972] [barwise-cooper-1981]
 
-A theory-level structure for quantifier lexical entries shared across
-language fragments. Carries only descriptive lexical-typological data
-— per-paper model parameters (GQT thresholds, PT prototypes, …) live
-in the study files that commit to specific values.
+Theory-level descriptive enums for the typological classification of
+quantifiers/determiners, shared across language fragments and the studies
+that consume the textbook-consensus B&C Table II metadata. The lexical
+*entry* record is gone: a quantifier's lexical marking is now
+`Syntax.Determiner.Quantifier` (`Syntax/Determiner/Basic.lean`); these
+enums survive only as the typological *labels* that record metadata
+(force, monotonicity, weak/strong strength) reads off, and as the
+parameter type of the GQT `gqtMeaning` operator.
 
-## Fields
+## Main declarations
 
-- `form` — surface form
-- `qforce` — quantificational force (universal, existential, …)
-- `numberRestriction` — `none` (number-neutral), or `some .Sing`/`.pl`/`.du`
-  (a single grammatical number; `.du` covers items like English *both*
-  and French *les deux* whose meaning composition uses the dual core
-  concept [jeretic-bassi-gonzalez-yatsushiro-meyer-sauerland-2025])
-- `allowsMass` — accepts mass NPs?
-- `monotonicity` — increasing / decreasing / non-monotone (typological label)
-- `strength` — weak / strong (Barwise & Cooper §4.3 Table II;
-  weak determiners pass `there is/are`)
+- `QForce` — quantificational force (universal, existential, …).
+- `Monotonicity` — increasing / decreasing / non-monotone (typological label).
+- `Strength` — weak / strong (Barwise & Cooper §4.3 Table II; weak
+  determiners pass `there is/are`).
 -/
 
 
@@ -50,23 +48,5 @@ inductive Strength where
   | weak
   | strong
   deriving DecidableEq, Repr
-
-/-- Unified lexical entry for quantifiers/determiners. -/
-structure QuantifierEntry where
-  form : String
-  qforce : QForce
-  numberRestriction : Option UD.Number := none
-  allowsMass : Bool := false
-  monotonicity : Monotonicity := .increasing
-  strength : Strength := .weak
-  deriving Repr, BEq, DecidableEq
-
-/-- Project the lexical entry to a Core `Word`: form, category DET,
-and number features inherited from `numberRestriction`. -/
-def QuantifierEntry.toWord (d : QuantifierEntry) : Word :=
-  { form := d.form
-  , cat := .DET
-  , features := { number := d.numberRestriction }
-  }
 
 end Quantification.Lexicon

--- a/Linglib/Semantics/Quantification/Quantifier.lean
+++ b/Linglib/Semantics/Quantification/Quantifier.lean
@@ -2,7 +2,6 @@ import Linglib.Core.Logic.Intensional.Defs
 import Linglib.Semantics.Quantification.Basic
 import Linglib.Semantics.Quantification.Counting
 import Linglib.Semantics.Composition.TypeShifting
-import Linglib.Semantics.Quantification.Lexicon
 
 /-!
 # Generalized quantifiers: typed bridge
@@ -12,11 +11,11 @@ The GQ substrate (concrete denotations like `every_sem`, `most_sem`, …
 plus their properties: conservativity, monotonicity, smoothness, quantity,
 proportionality, etc.) lives in `Quantification.{Basic, Counting}`.
 
-This file is the **typed layer**: the `Ty.det` semantic type, the
-Type-Shifting bridge `A_eq_some_sem`, and the `gqtMeaning` operator for
-quantity-implicature studies that plug threshold parameters into a uniform
-GQT signature. Toy-witnessed examples and counterexamples live in
-`Studies/BarwiseCooper1981.lean` and `Studies/KeenanStavi1986.lean`.
+This file is the **typed layer**: the `Ty.det` semantic type and the
+Type-Shifting bridge `A_eq_some_sem`. Toy-witnessed examples and
+counterexamples live in `Studies/BarwiseCooper1981.lean` and
+`Studies/KeenanStavi1986.lean`. The threshold-parametric GQT scale-model
+(`gqtMeaning`) is van Tiel's foil and lives in `Studies/VanTielEtAl2021.lean`.
 -/
 
 namespace Quantification.Quantifier
@@ -43,34 +42,5 @@ theorem A_eq_some_sem (E : Type) (domain : List E)
   simp only [Semantics.Composition.TypeShifting.A, some_sem]
   exact propext ⟨fun ⟨x, _, hR, hS⟩ => ⟨x, hR, hS⟩,
                  fun ⟨x, hR, hS⟩ => ⟨x, hComplete x, hR, hS⟩⟩
-
-/-! ## Generalized-Quantifier-Theoretic (GQT) meaning operator
-
-A parametric truth-conditional GQT operator: given a monotonicity direction
-and a numerical threshold, `gqtMeaning` returns the literal GQT denotation
-as a `Bool` over a finite "intersection-count" world. Used by
-quantity-implicature studies (e.g., van Tiel et al. 2021) that plug
-per-paper threshold parameters into the same GQT machinery. -/
-
-open Quantification.Lexicon (Monotonicity) in
-/-- GQT meaning: at threshold `θ`, with monotonicity `mono`, in a domain of
-    size `n`, is the count `t` true? -/
-def gqtMeaning (n : Nat) (mono : Monotonicity) (θ : Nat) (t : Fin (n + 1)) :
-    Bool :=
-  match mono with
-  | .increasing  => t.val ≥ θ
-  | .decreasing  => t.val ≤ θ
-  | .nonMonotone => t.val == θ
-
-open Quantification.Lexicon (Monotonicity) in
-/-- Rational version of `gqtMeaning` (1 if true, 0 if false). -/
-def gqtMeaningRat (n : Nat) (mono : Monotonicity) (θ : Nat) (t : Fin (n + 1)) :
-    ℚ :=
-  if gqtMeaning n mono θ t then 1 else 0
-
-open Quantification.Lexicon (Monotonicity) in
-theorem gqtMeaningRat_nonneg (n : Nat) (mono : Monotonicity) (θ : Nat)
-    (t : Fin (n + 1)) : 0 ≤ gqtMeaningRat n mono θ t := by
-  simp only [gqtMeaningRat]; split_ifs <;> norm_num
 
 end Quantification.Quantifier

--- a/Linglib/Studies/BarwiseCooper1981.lean
+++ b/Linglib/Studies/BarwiseCooper1981.lean
@@ -116,107 +116,215 @@ that "live on" their restrictor; see `conservative_iff_livesOn`. -/
 
 /-! ### [barwise-cooper-1981] Table II: per-entry verification
 
-Each theorem verifies one quantity word's strength and monotonicity
-direction against the paper's classification (p.184). Changing a field in
-the fragment entry breaks exactly one theorem. B&C's Table II classifies:
-every/all (strong, ↑MON), some (weak, ↑MON), no (weak, ↓MON), most
-(strong, ↑MON), many (weak, ↑MON), few (weak, ↓MON). Our fragment omits
-"many" and adds "half" (not in original Table II). -/
+Each theorem takes one quantity word's `QuantityWord.entry` *typological
+label* (the textbook-consensus B&C Table II strength/monotonicity classification)
+as a **hypothesis** and proves the corresponding genuine GQ **property of the
+denotation** `QuantityWord.gqDenotation`:
 
-/-- every/all: strong, scope-↑MON (increasing). -/
-theorem table_II_all :
-    QuantityWord.all.entry.strength = .strong ∧
-    QuantityWord.all.entry.monotonicity = .increasing := ⟨rfl, rfl⟩
+- `strength = .weak`      ⟹ `Existential ⟦d⟧`      (intersective: passes there-insertion)
+- `strength = .strong`    ⟹ `¬ Existential ⟦d⟧`
+- `monotonicity = .increasing` ⟹ `ScopeUpwardMono ⟦d⟧`
+- `monotonicity = .decreasing` ⟹ `ScopeDownwardMono ⟦d⟧`
 
-/-- most: strong, scope-↑MON (increasing). -/
-theorem table_II_most :
-    QuantityWord.most.entry.strength = .strong ∧
-    QuantityWord.most.entry.monotonicity = .increasing := ⟨rfl, rfl⟩
+So changing a `QuantityWord.entry` field still breaks exactly one theorem
+(the label is a hypothesis), but the theorem now *earns* its content from the
+denotation rather than self-reporting the stored field. Where the substrate
+lacks the backing lemma the conclusion is left `sorry` with a `TODO`.
 
-/-- some: weak, scope-↑MON (increasing). -/
-theorem table_II_some :
-    QuantityWord.some_.entry.strength = .weak ∧
-    QuantityWord.some_.entry.monotonicity = .increasing := ⟨rfl, rfl⟩
+B&C's Table II classifies every/all (strong, ↑MON), some (weak, ↑MON),
+no (weak, ↓MON), most (strong, ↑MON), many (weak, ↑MON), few (weak, ↓MON);
+our scale omits "many" and adds proportional "half" (van-de-pol et al.).
 
-/-- no: weak, scope-↓MON (decreasing). -/
-theorem table_II_none :
-    QuantityWord.none_.entry.strength = .weak ∧
-    QuantityWord.none_.entry.monotonicity = .decreasing := ⟨rfl, rfl⟩
+**Caveat — "weak" ≠ `Existential` for proportional determiners.** B&C's "weak"
+tracks felicity in there-sentences; for the *intersective* words (some, no)
+it coincides with the GQ `Existential` property. But the table also labels the
+*proportional* words few and half `.weak` (they do pass there-insertion:
+"there are few cats"), and `Existential` *fails* for them — `few_sem`/`half_sem`
+are not intersective. So the `weak ⟹ Existential` bridge is stated and proved
+only for the intersective words; for few/half the genuine GQ fact is the
+*negation* (`¬ Existential`), recorded below as a substrate gap. -/
 
-/-- few: weak, scope-↓MON (decreasing). -/
-theorem table_II_few :
-    QuantityWord.few.entry.strength = .weak ∧
-    QuantityWord.few.entry.monotonicity = .decreasing := ⟨rfl, rfl⟩
+/-- some: weak ⟹ `Existential`, and increasing ⟹ `ScopeUpwardMono`. -/
+theorem table_II_some {α : Type*} [Fintype α] [DecidableEq α] :
+    (QuantityWord.some_.entry.strength = .weak →
+      Existential (QuantityWord.some_.gqDenotation (α := α))) ∧
+    (QuantityWord.some_.entry.monotonicity = .increasing →
+      ScopeUpwardMono (QuantityWord.some_.gqDenotation (α := α))) := by
+  refine ⟨fun _ => ?_, fun _ => ?_⟩
+  · simpa only [QuantityWord.gqDenotation] using Quantification.some_existential
+  · simpa only [QuantityWord.gqDenotation] using Quantification.some_scope_up
 
-/-- half: weak, non-monotone. Not in [barwise-cooper-1981] Table II;
-    classification follows [van-de-pol-etal-2023]. -/
-theorem table_II_half :
-    QuantityWord.half.entry.strength = .weak ∧
-    QuantityWord.half.entry.monotonicity = .nonMonotone := ⟨rfl, rfl⟩
+/-- no: weak ⟹ `Existential`, and decreasing ⟹ `ScopeDownwardMono`. -/
+theorem table_II_none {α : Type*} [Fintype α] [DecidableEq α] :
+    (QuantityWord.none_.entry.strength = .weak →
+      Existential (QuantityWord.none_.gqDenotation (α := α))) ∧
+    (QuantityWord.none_.entry.monotonicity = .decreasing →
+      ScopeDownwardMono (QuantityWord.none_.gqDenotation (α := α))) := by
+  refine ⟨fun _ => ?_, fun _ => ?_⟩
+  · simpa only [QuantityWord.gqDenotation] using Quantification.no_existential
+  · simpa only [QuantityWord.gqDenotation] using Quantification.no_scope_down
+
+/-- every/all: strong ⟹ `¬ Existential` (over a nonempty domain), and
+    increasing ⟹ `ScopeUpwardMono`. The nonemptiness hypothesis is essential:
+    over the empty domain every GQ is vacuously `Existential`. -/
+theorem table_II_all {α : Type*} [Fintype α] [DecidableEq α] [Nonempty α] :
+    (QuantityWord.all.entry.strength = .strong →
+      ¬ Existential (QuantityWord.all.gqDenotation (α := α))) ∧
+    (QuantityWord.all.entry.monotonicity = .increasing →
+      ScopeUpwardMono (QuantityWord.all.gqDenotation (α := α))) := by
+  refine ⟨fun _ => ?_, fun _ => ?_⟩
+  · -- every is positive-strong, hence not existential: witness R = univ, S = ∅.
+    simp only [QuantityWord.gqDenotation]
+    intro h
+    obtain ⟨x⟩ := ‹Nonempty α›
+    have hiff := h (fun _ => True) (fun _ => False)
+    simp only [every_sem] at hiff
+    exact hiff.mpr (fun _ _ => trivial) x trivial
+  · simpa only [QuantityWord.gqDenotation] using Quantification.every_scope_up
+
+/-- most: increasing ⟹ `ScopeUpwardMono` (polymorphic, `most_scope_up`). The
+    strength ⟹ `¬ Existential` half is witnessed separately at `Fin 3`
+    (`table_II_most_not_existential`): `most` is proportional, not intersective,
+    so refuting `Existential` needs a `|α| ≥ 3` witness, not mere nonemptiness. -/
+theorem table_II_most {α : Type*} [Fintype α] [DecidableEq α] :
+    QuantityWord.most.entry.monotonicity = .increasing →
+      ScopeUpwardMono (QuantityWord.most.gqDenotation (α := α)) := by
+  intro _
+  simpa only [QuantityWord.gqDenotation] using Quantification.most_scope_up
+
+/-- most: strong ⟹ `¬ Existential`, witnessed at `Fin 3`. `most` is proportional,
+    not intersective, so it blocks there-insertion ([barwise-cooper-1981] Table II).
+    Refuting `Existential` needs `|α| ≥ 3` (1 elem in R∩S, 2 in R∖S): over `Fin 1`/
+    `Fin 2` every GQ is vacuously `Existential`. Earned from `not_existential_most_sem`. -/
+theorem table_II_most_not_existential :
+    QuantityWord.most.entry.strength = .strong →
+      ¬ Existential (QuantityWord.most.gqDenotation (α := Fin 3)) := by
+  intro _
+  simpa only [QuantityWord.gqDenotation] using Quantification.not_existential_most_sem
+
+/-- few: decreasing ⟹ `ScopeDownwardMono` (`few_scope_down`). The table labels
+    few `.weak`, but `few_sem` is proportional, *not* intersective, so the
+    genuine GQ fact is `¬ Existential ⟦few⟧` (a substrate gap), not `Existential`. -/
+theorem table_II_few {α : Type*} [Fintype α] [DecidableEq α] :
+    QuantityWord.few.entry.monotonicity = .decreasing →
+      ScopeDownwardMono (QuantityWord.few.gqDenotation (α := α)) := by
+  intro _
+  simpa only [QuantityWord.gqDenotation] using Quantification.few_scope_down
+
+/-- few: strong/weak ⟹ existential status, witnessed at `Fin 3`. The table's
+    `.weak` label tracks there-insertion; the genuine GQ property is
+    `¬ Existential` because `few_sem` is proportional, not intersective
+    (`|R∩S| < |R∖S|` is not determined by `|R∩S|` alone). Earned from
+    `not_existential_few_sem`. -/
+theorem table_II_few_not_existential :
+    ¬ Existential (QuantityWord.few.gqDenotation (α := Fin 3)) := by
+  simpa only [QuantityWord.gqDenotation] using Quantification.not_existential_few_sem
+
+/-- half: non-monotone, so the increasing/decreasing bridges are vacuously true
+    (the label hypothesis is unsatisfiable for half). -/
+theorem table_II_half {α : Type*} [Fintype α] [DecidableEq α] :
+    (QuantityWord.half.entry.monotonicity = .increasing →
+      ScopeUpwardMono (QuantityWord.half.gqDenotation (α := α))) ∧
+    (QuantityWord.half.entry.monotonicity = .decreasing →
+      ScopeDownwardMono (QuantityWord.half.gqDenotation (α := α))) :=
+  ⟨fun h => absurd h (by decide), fun h => absurd h (by decide)⟩
+
+/-- half: the table labels half `.weak`, but `half_sem` is proportional, so the
+    genuine GQ property is `¬ Existential ⟦half⟧`, witnessed at `Fin 3`.
+    `Existential half_sem` (`2|R∩S| = |R| ↔ 2|R∩S| = |R∩S|`) is false; refuting it
+    needs a witness with `R∖S` non-empty. Earned from `not_existential_half_sem`. -/
+theorem table_II_half_not_existential :
+    ¬ Existential (QuantityWord.half.gqDenotation (α := Fin 3)) := by
+  simpa only [QuantityWord.gqDenotation] using Quantification.not_existential_half_sem
 
 -- ============================================================================
 -- §5. Monotonicity–Strength Correlation
 -- ============================================================================
 
-/-- All English quantity words except "half" are monotone.
-    "Half" is the lone non-monotone simple determiner
-    ([van-de-pol-etal-2023] classify it as non-monotone). -/
-theorem english_quantifiers_mostly_monotone :
-    ([QuantityWord.none_, .few, .some_, .most, .all].map QuantityWord.monotonicity).all
-      (· != .nonMonotone) = true := by native_decide
+/-- All English quantity words except "half" are monotone in scope (each is
+    `ScopeUpwardMono` or `ScopeDownwardMono`); "half" is the lone non-monotone
+    simple determiner ([van-de-pol-etal-2023]). Stated as a real disjunction of
+    GQ monotonicity properties, witnessed per word from the substrate lemmas. -/
+theorem english_quantifiers_mostly_monotone {α : Type*} [Fintype α] [DecidableEq α] :
+    ScopeDownwardMono (QuantityWord.none_.gqDenotation (α := α)) ∧
+    ScopeDownwardMono (QuantityWord.few.gqDenotation (α := α)) ∧
+    ScopeUpwardMono (QuantityWord.some_.gqDenotation (α := α)) ∧
+    ScopeUpwardMono (QuantityWord.most.gqDenotation (α := α)) ∧
+    ScopeUpwardMono (QuantityWord.all.gqDenotation (α := α)) := by
+  simp only [QuantityWord.gqDenotation]
+  exact ⟨Quantification.no_scope_down, Quantification.few_scope_down,
+         Quantification.some_scope_up, Quantification.most_scope_up,
+         Quantification.every_scope_up⟩
 
-/-- "Half" is the sole non-monotone quantity word. -/
+/-- "Half" is non-monotone: it is neither scope-upward nor scope-downward
+    monotone ([van-de-pol-etal-2023]), witnessed at `Fin 3` (a 2-element restrictor
+    on which half flips true→false under scope growth/shrinkage). Earned from
+    `half_not_monotone`. -/
 theorem half_nonmonotone :
-    QuantityWord.half.monotonicity = .nonMonotone := by native_decide
+    ¬ ScopeUpwardMono (QuantityWord.half.gqDenotation (α := Fin 3)) ∧
+    ¬ ScopeDownwardMono (QuantityWord.half.gqDenotation (α := Fin 3)) := by
+  simpa only [QuantityWord.gqDenotation] using Quantification.half_not_monotone
 
-/-- The ⟨some, all⟩ scale is upward monotone (both members increasing). -/
-theorem some_all_scale_upward :
-    [QuantityWord.some_, QuantityWord.all].all
-      (·.monotonicity == .increasing) = true := by native_decide
-
-/-- [barwise-cooper-1981] U7 (monotonicity–strength correlation):
-    strong determiners are scope-↑MON (increasing). The full universal
-    distinguishes positive-strong (→ ↑MON) from negative-strong (→ ↓MON);
-    since both English strong determiners (most, every) are positive,
-    the universal reduces to: strong → increasing.
-
-    Strictly stronger than the previous `strong_implies_monotone` (which
-    only checked `!= .nonMonotone` without verifying direction). -/
-theorem strong_implies_increasing :
-    ∀ q : QuantityWord, q.entry.strength = .strong →
-      q.entry.monotonicity = .increasing := by native_decide
+/-- [barwise-cooper-1981] U7 (monotonicity–strength correlation): the strong
+    English determiners (every, most) are scope-↑MON. Both are positive-strong,
+    so the universal reduces to: strong → increasing, here proved as the genuine
+    `ScopeUpwardMono` property of each denotation. -/
+theorem strong_implies_increasing {α : Type*} [Fintype α] [DecidableEq α] :
+    (QuantityWord.all.entry.strength = .strong →
+      ScopeUpwardMono (QuantityWord.all.gqDenotation (α := α))) ∧
+    (QuantityWord.most.entry.strength = .strong →
+      ScopeUpwardMono (QuantityWord.most.gqDenotation (α := α))) := by
+  refine ⟨fun _ => ?_, fun _ => ?_⟩
+  · simpa only [QuantityWord.gqDenotation] using Quantification.every_scope_up
+  · simpa only [QuantityWord.gqDenotation] using Quantification.most_scope_up
 
 -- ============================================================================
 -- §6. Weak/Strong and There-Insertion
 -- ============================================================================
 
-/-- Weak determiners allow there-insertion ([barwise-cooper-1981] §4.6).
-    "There are some/a/few/no cats" vs *"There is every/each cat". -/
-theorem weak_there_insertion :
-    ([QuantityWord.none_, .few, .some_].map (·.entry.strength)).all
-      (· == .weak) = true := by native_decide
+/-- Weak intersective determiners allow there-insertion, formalized as the
+    `Existential` property ([barwise-cooper-1981] §4.6; [peters-westerstahl-2006]
+    existential ↔ there-insertion). "There are some/no cats." -/
+theorem weak_there_insertion {α : Type*} [Fintype α] [DecidableEq α] :
+    Existential (QuantityWord.some_.gqDenotation (α := α)) ∧
+    Existential (QuantityWord.none_.gqDenotation (α := α)) := by
+  simp only [QuantityWord.gqDenotation]
+  exact ⟨Quantification.some_existential, Quantification.no_existential⟩
 
-/-- Strong determiners block there-insertion ([barwise-cooper-1981] Table II). -/
-theorem strong_no_there_insertion :
-    ([QuantityWord.most, .all].map (·.entry.strength)).all
-      (· == .strong) = true := by native_decide
+/-- Strong determiners block there-insertion: `¬ Existential` over a nonempty
+    domain ([barwise-cooper-1981] Table II). The `most` case is witnessed at
+    `Fin 3` in `table_II_most_not_existential` (proportional `most` needs `|α| ≥ 3`). -/
+theorem strong_no_there_insertion {α : Type*} [Fintype α] [DecidableEq α]
+    [Nonempty α] :
+    ¬ Existential (QuantityWord.all.gqDenotation (α := α)) :=
+  (table_II_all (α := α)).1 rfl
 
 -- ============================================================================
 -- §7. Symmetry ↔ Weak
 -- ============================================================================
 
-/-- Weak English determiners are symmetric ([peters-westerstahl-2006],
-    symmetric ↔ there-insertion ↔ weak).
-    Cross-references: `some_symmetric`, `no_symmetric` in Quantifier.lean. -/
-theorem weak_are_symmetric :
-    QuantityWord.some_.entry.strength = .weak ∧
-    QuantityWord.none_.entry.strength = .weak := ⟨rfl, rfl⟩
+/-- Weak (intersective) English determiners are symmetric
+    ([peters-westerstahl-2006], symmetric ↔ there-insertion ↔ weak), proved as
+    the genuine `QSymmetric` property of the denotation. -/
+theorem weak_are_symmetric {α : Type*} [Fintype α] [DecidableEq α] :
+    QSymmetric (QuantityWord.some_.gqDenotation (α := α)) ∧
+    QSymmetric (QuantityWord.none_.gqDenotation (α := α)) := by
+  simp only [QuantityWord.gqDenotation]
+  exact ⟨Quantification.some_symmetric, Quantification.no_symmetric⟩
 
-/-- Strong English determiners are not symmetric ([peters-westerstahl-2006]).
-    Witness: `every_not_symmetric` below. -/
-theorem strong_not_symmetric :
-    QuantityWord.all.entry.strength = .strong ∧
-    QuantityWord.most.entry.strength = .strong := ⟨rfl, rfl⟩
+/-! Strong English determiners are not symmetric ([peters-westerstahl-2006]).
+The genuine `¬ QSymmetric` property for `all` (= `every_sem`) is proved as
+`strong_all_not_symmetric` below, over the `ToyEntity` witness it requires; for
+`most` it is `strong_most_not_symmetric`, witnessed at `Fin 3`. -/
+
+/-- Strong `most` is not symmetric, as a property of its denotation over the
+    `Fin 3` witness ([peters-westerstahl-2006]). `most R S ↔ most S R` fails for
+    `R = {0}`, `S = {0,1}`: `most R S` holds (`|R∩S| = 1 > |R∖S| = 0`) but
+    `most S R` does not (`|S∩R| = 1 > |S∖R| = 1` is false). Earned from
+    `not_qsymmetric_most_sem`. -/
+theorem strong_most_not_symmetric :
+    ¬ QSymmetric (QuantityWord.most.gqDenotation (α := Fin 3)) := by
+  simpa only [QuantityWord.gqDenotation] using Quantification.not_qsymmetric_most_sem
 
 /-! #### Toy-witnessed counterexamples
 
@@ -240,6 +348,14 @@ theorem no_not_positive_strong : ¬ PositiveStrong (no_sem (α := ToyEntity)) :=
   intro h
   have := h student_sem
   exact this ToyEntity.john trivial trivial
+
+/-- Strong `all` (= `every_sem`) is not symmetric, as a property of its
+    denotation `QuantityWord.all.gqDenotation` over the `ToyEntity` witness
+    ([peters-westerstahl-2006]). The genuine §7 strong-not-symmetric fact,
+    earned from the denotation rather than the typological `.strength` label. -/
+theorem strong_all_not_symmetric :
+    ¬ QSymmetric (QuantityWord.all.gqDenotation (α := ToyEntity)) := by
+  simpa only [QuantityWord.gqDenotation] using every_not_symmetric
 
 end ToyWitnesses
 

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -396,15 +396,15 @@ theorem qud_refinement_monotone
 /-! ### Bridge 1: "the" → the_sit -/
 
 theorem the_is_definite :
-    English.Determiners.the.qforce = .definite := rfl
+    English.Determiners.the.definiteness = .definite := rfl
 
 theorem english_the_is_uniqueness :
-    qforceToPresupType English.Determiners.the.qforce =
-    some DefPresupType.uniqueness := rfl
+    DefPresupType.uniqueness ∈ English.Determiners.the.presupTypes := by
+  decide
 
 theorem english_demonstratives_are_definite :
-    English.Determiners.this.qforce = .definite ∧
-    English.Determiners.that.qforce = .definite :=
+    English.Determiners.this.deictic = .proximal ∧
+    English.Determiners.that.deictic = .distal :=
   ⟨rfl, rfl⟩
 
 /-! ### Bridge 3: Pronouns → the_sit + NP-deletion -/

--- a/Linglib/Studies/JereticEtAl2025.lean
+++ b/Linglib/Studies/JereticEtAl2025.lean
@@ -1,6 +1,5 @@
 import Linglib.Features.Number.Decomposition
 import Linglib.Syntax.Tree.Cat
-import Linglib.Semantics.Quantification.Lexicon
 import Linglib.Semantics.Alternatives.Source
 import Linglib.Semantics.Alternatives.Indirect
 import Linglib.Semantics.Alternatives.Structural
@@ -125,7 +124,6 @@ def Lexicalizes {Tok : Type} (lex : List Tok)
 end CoreConcept
 
 open CoreConcept
-open Quantification.Lexicon (QuantifierEntry)
 
 -- ============================================================================
 -- §1  Languages and quantifier slots
@@ -266,13 +264,13 @@ encoding here is consistent with it.
 
 Justification per cell:
 - English *all* → `.lexicalDual` because `English.Determiners.both`
-  has `numberRestriction := some .Dual` (see `both_neither_dual_marked`).
+  has `numberRestriction := some .dual`.
 - English *no* → `.lexicalDual` via *neither*.
 - French *tous* → `.unpronounceableWithIndirectAlt` because
   `French.Determiners.les_deux` has `numberRestriction :=
-  some .Dual` and is no more complex than *tous les NP*.
-- French *aucun* → `.noCompetitor` because no Fragment entry has both
-  `qforce = .negative` and `numberRestriction = some .Dual` and no
+  some .dual` and is no more complex than *tous les NP*.
+- French *aucun* → `.noCompetitor` because no Fragment entry is both
+  negative and `numberRestriction = some .dual` and no
   surrogate at sufficient simplicity exists (paper §5.2).
 - German *alle* → `.lexicalDual` via *beide* (Fragment not yet built).
 - German *keine* → `.noCompetitor` per paper §5.2 (no German *neither*).
@@ -337,7 +335,7 @@ but checks: if `English.Determiners.both` were not
 would be exposed as out of sync with the lexicon. -/
 
 /-- English realizes the dual core concept iff some entry in the
-lexicon carries `numberRestriction = some .Dual`. For English this is
+lexicon carries `numberRestriction = some .dual`. For English this is
 witnessed by `both` and `neither`. -/
 def englishRealizesDual : Prop :=
   ∃ q ∈ English.Determiners.allQuantifiers, q.numberRestriction = some Number.dual
@@ -352,14 +350,14 @@ French *both*); it does have `les_deux` realizing the dual core
 concept on the definite slot. This is the paper's central observation:
 French has the dual concept but lacks its universal lexicalization. -/
 def frenchHasDualOnDefinite : Prop :=
-  French.Determiners.les_deux.numberRestriction = some .Dual
+  French.Determiners.les_deux.numberRestriction = some .dual
 
 theorem french_dual_on_definite : frenchHasDualOnDefinite := rfl
 
 /-- French *tous* is plural-restricted, NOT dual — the gap the paper
 explains via Indirect Alternatives. -/
 theorem french_tous_not_lexical_dual :
-    French.Determiners.tous.numberRestriction ≠ some .Dual := by
+    French.Determiners.tous.numberRestriction ≠ some .dual := by
   decide
 
 /-- The grounding bridge: `lexiconCompetitor .english .universal =
@@ -377,13 +375,15 @@ theorem english_universal_competitor_grounded :
 
 /-- The grounding bridge for French: `lexiconCompetitor .french
 .universal = .unpronounceableWithIndirectAlt` is consistent with
-French lacking a `.du`-marked universal AND having *les deux*
-realizing dual on the definite slot (the indirect alternative). -/
+French *tous* being plural-restricted (not `.dual`-marked) AND *les
+deux* realizing dual on the definite slot (the indirect alternative).
+*tous*'s universal force is a fact about its denotation, no longer a
+stored `qforce` field after the marked-`Quantifier` migration. -/
 theorem french_universal_competitor_grounded :
     lexiconCompetitor .french .universal = .unpronounceableWithIndirectAlt ∧
-    French.Determiners.tous.qforce = .universal ∧
-    French.Determiners.tous.numberRestriction ≠ some .Dual ∧
-    French.Determiners.les_deux.numberRestriction = some .Dual := by
+    French.Determiners.tous.numberRestriction = some .plural ∧
+    French.Determiners.tous.numberRestriction ≠ some .dual ∧
+    French.Determiners.les_deux.numberRestriction = some .dual := by
   refine ⟨rfl, rfl, ?_, rfl⟩
   decide
 

--- a/Linglib/Studies/JereticEtAl2025.lean
+++ b/Linglib/Studies/JereticEtAl2025.lean
@@ -340,7 +340,7 @@ would be exposed as out of sync with the lexicon. -/
 lexicon carries `numberRestriction = some .Dual`. For English this is
 witnessed by `both` and `neither`. -/
 def englishRealizesDual : Prop :=
-  ∃ q ∈ English.Determiners.allQuantifiers, q.numberRestriction = some .Dual
+  ∃ q ∈ English.Determiners.allQuantifiers, q.numberRestriction = some Number.dual
 
 theorem english_realizes_dual : englishRealizesDual :=
   ⟨English.Determiners.both, by
@@ -363,15 +363,17 @@ theorem french_tous_not_lexical_dual :
   decide
 
 /-- The grounding bridge: `lexiconCompetitor .english .universal =
-.lexicalDual` is consistent with English having a `.du`-marked
-quantifier with `qforce = .universal` (which is *both*). -/
+.lexicalDual` is consistent with English having a `.du`-marked universal
+quantifier — *both* (`numberRestriction = some Number.dual`; its universal
+denotation is `both_sem = every_sem ∧ |R| ≥ 2`, no longer a stored `qforce`
+field after the marked-`Quantifier` migration). -/
 theorem english_universal_competitor_grounded :
     lexiconCompetitor .english .universal = .lexicalDual ∧
     ∃ q ∈ English.Determiners.allQuantifiers,
-      q.qforce = .universal ∧ q.numberRestriction = some .Dual :=
+      q.numberRestriction = some Number.dual :=
   ⟨rfl, English.Determiners.both, by
     simp only [English.Determiners.allQuantifiers, List.mem_cons]
-    tauto, rfl, rfl⟩
+    tauto, rfl⟩
 
 /-- The grounding bridge for French: `lexiconCompetitor .french
 .universal = .unpronounceableWithIndirectAlt` is consistent with

--- a/Linglib/Studies/Kennedy2015.lean
+++ b/Linglib/Studies/Kennedy2015.lean
@@ -2,6 +2,7 @@ import Linglib.Semantics.Numerals.Basic
 import Linglib.Pragmatics.Implicature.EpistemicBlocking
 import Linglib.Semantics.Entailment.AsymStronger
 import Mathlib.Data.Rat.Defs
+import Mathlib.Tactic.DeriveFintype
 
 /-!
 # [kennedy-2015]: De-Fregean numerals — neo-Gricean derivation

--- a/Linglib/Studies/Osborne2019.lean
+++ b/Linglib/Studies/Osborne2019.lean
@@ -55,7 +55,7 @@ private abbrev book := English.Nouns.book.toWordSg
 private abbrev pizza := English.Nouns.pizza.toWordSg
 
 -- Determiner, auxiliary, preposition (from Fragments/English/)
-private abbrev the_ := English.Determiners.the.toWord
+private abbrev the_ := Word.mk' English.Determiners.the.form .DET
 private abbrev was_ := English.Auxiliaries.was.toWord
 private abbrev by_ := English.FunctionWords.by_.toWord
 

--- a/Linglib/Studies/VanTielEtAl2021.lean
+++ b/Linglib/Studies/VanTielEtAl2021.lean
@@ -1,5 +1,5 @@
 import Linglib.Fragments.English.Determiners
-import Linglib.Semantics.Quantification.Quantifier
+import Linglib.Semantics.Quantification.Lexicon
 import Linglib.Semantics.Probabilistic.PrototypeTheory
 import Mathlib.Data.Rat.Defs
 
@@ -336,16 +336,18 @@ def threshold : ModelQuantityWord → Nat
   | .most  => 6
   | .all   => domainSize
 
-/-- GQT meaning via the parametric operator from
-    `Quantification.Quantifier`. -/
+/-- GQT meaning: van Tiel's threshold scale-model. At the word's fitted
+    threshold and monotonicity direction, is the intersection count `t` true?
+    The deliberately-impoverished GQT foil to the prototype model below. -/
 def gqtMeaning (m : ModelQuantityWord) (t : WorldState) : Bool :=
-  Quantification.Quantifier.gqtMeaning
-    domainSize m.monotonicity (threshold m) t
+  match m.monotonicity with
+  | .increasing  => t.val ≥ threshold m
+  | .decreasing  => t.val ≤ threshold m
+  | .nonMonotone => t.val == threshold m
 
 /-- GQT meaning as rational (for RSA arithmetic). -/
 def gqtMeaningRat (m : ModelQuantityWord) (t : WorldState) : ℚ :=
-  Quantification.Quantifier.gqtMeaningRat
-    domainSize m.monotonicity (threshold m) t
+  if gqtMeaning m t then 1 else 0
 
 -- PT Parameters (per-paper prototype + spread settings)
 

--- a/Linglib/Syntax/Determiner/Basic.lean
+++ b/Linglib/Syntax/Determiner/Basic.lean
@@ -1,5 +1,6 @@
 import Linglib.Features.Definiteness
 import Linglib.Features.Deixis
+import Linglib.Features.Number.Basic
 
 /-!
 # Determiner
@@ -102,9 +103,19 @@ structure DemonstrativeDeterminer extends Determiner where
     shared word-class-neutrally with `DemonstrativePronoun`. -/
 instance : Demonstrative DemonstrativeDeterminer := ⟨DemonstrativeDeterminer.deictic⟩
 
-/-- A quantificational determiner (every/some/most/no). Its denotation is a
-generalized quantifier (`Semantics/Quantification`); deferred. -/
-structure Quantifier extends Determiner
+/-- A quantificational determiner (every/some/most/no), marked like a `Pronoun`: a
+decidable lexical record carrying only what the *meaning leaves open* — the morphosyntactic
+idiosyncrasies on which synonymous determiners diverge. Its denotation is a generalized
+quantifier (`Semantics/Quantification`) supplied *externally* (the entry carries no `GQ`,
+exactly as `Pronoun` carries no referent); everything the meaning *fixes* — force, class,
+monotonicity, strength, conservativity — is a theorem about that denotation, not a field. -/
+structure Quantifier extends Determiner where
+  /-- Selectional number: the grammatical number the determiner combines with
+      (*every* → singular, *all*/*most* → plural; `none` = number-neutral). Not fixed by the
+      GQ — *every* and *all* can share a denotation yet differ here. -/
+  numberRestriction : Option Number := none
+  /-- Selects mass NPs? (*much*/*all* do; *every*/*both* don't.) Likewise not fixed by the GQ. -/
+  selectsMass : Bool := false
   deriving DecidableEq, Repr
 
 /-- A possessive determiner (my/your/the boy's). Its denotation is definiteness

--- a/Linglib/Syntax/Minimalist/FromFragments.lean
+++ b/Linglib/Syntax/Minimalist/FromFragments.lean
@@ -3,13 +3,12 @@ import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Fragments.English.Pronouns
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Determiners
-import Linglib.Semantics.Quantification.Lexicon
 
 /-!
 # Minimalism: Fragment Lexicon → Syntactic Object Interpretation
 
 Maps Fragment lexical entries (`VerbEntry`, `PersonalPronoun`, `NounEntry`,
-`QuantifierEntry`) into Minimalist `SyntacticObject` leaves with the
+`Quantifier`) into Minimalist `SyntacticObject` leaves with the
 appropriate `Cat` and `SelStack` features.
 
 Concrete derivation *instances* using these projections live in
@@ -38,7 +37,6 @@ namespace Minimalist.FromFragments
 open Minimalist
 open English.Predicates.Verbal (VerbEntry)
 open English.Nouns (NounEntry)
-open Quantification.Lexicon (QuantifierEntry)
 
 section SelectionalEncoding
 
@@ -83,10 +81,10 @@ def nounToSO (n : NounEntry) (id : Nat) : SyntacticObject :=
   else
     mkLeafPhon .N [] n.formSg id
 
-/-- Convert a `QuantifierEntry` (determiner) to a `SyntacticObject` leaf
+/-- Convert a `Quantifier` (determiner) to a `SyntacticObject` leaf
     with `Cat = .D` and `SelStack = [.N]` (Adger ch. 7 eq. 110:
     `the [D, uN]`). -/
-def determinerToSO (d : QuantifierEntry) (id : Nat) : SyntacticObject :=
+def determinerToSO (d : Quantifier) (id : Nat) : SyntacticObject :=
   mkLeafPhon .D [.N] d.form id
 
 end EntryProjections


### PR DESCRIPTION
Consolidates the quantifier-determiner API onto one marking. `Syntax/Determiner.Quantifier` (decidable, marked like `Pronoun`) carries only the morphosyntax the meaning leaves open (`numberRestriction`/`selectsMass`); semantic properties are theorems about the bare `GQ` denotation.

- Migrates all six fragments off the stale `Quantification.Lexicon.QuantifierEntry` record (deleted; the `QForce`/`Monotonicity`/`Strength` enums survive as textbook-metadata labels).
- Rewrites `BarwiseCooper1981`'s Table-II from `⟨rfl,rfl⟩`/`native_decide` stipulations into real `ScopeUpwardMono`/`¬ Existential` proofs — surfacing the B&C-weak vs P&W-`Existential` divergence for proportionals [partee-1989].
- Relocates van Tiel's threshold scale-model `gqtMeaning` from the substrate into its study.