### PR TITLE
refactor(Semantics/Lexical): demote LevinClass spot-checks to universals

### DIFF
--- a/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Lexical.LevinClassProfiles
 # Argument Structure Derivation Pipeline
 
 [beavers-koontz-garboden-2020] [rappaport-hovav-levin-1998]
-[rappaport-hovav-levin-2024] [dowty-1991]
+[dowty-1991]
 
 The derivational chain from root content to argument structure, made
 explicit as composed functions:

--- a/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
@@ -138,17 +138,17 @@ theorem fullSpec_licenses :
     "The rug is flat" (state) / "The rug flattened" (achievement) /
     "Kim flattened the rug" (accomplishment). -/
 theorem pc_alternation_count :
-    (licensedTemplates propertyConcept).length = 3 := by native_decide
+    (licensedTemplates propertyConcept).length = 3 := by decide
 
 /-- Pure manner roots license 1 template — no alternation into
     state-based frames (*"Kim jogged the ball broken"). -/
 theorem pureManner_alternation_count :
-    (licensedTemplates pureManner).length = 1 := by native_decide
+    (licensedTemplates pureManner).length = 1 := by decide
 
 /-- Full-spec roots license all 4 templates — maximal flexibility
     (conative, causative/inchoative, locative, etc.). -/
 theorem fullSpec_alternation_count :
-    (licensedTemplates fullSpec).length = 4 := by native_decide
+    (licensedTemplates fullSpec).length = 4 := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 2. Template → ArgTemplate
@@ -250,11 +250,11 @@ def deriveAll (re : Root.Kinds) : List ArgTemplate :=
 /-- causativeResult roots derive 3 ArgTemplates (state, achievement,
     accomplishment variants). -/
 theorem causativeResult_derives_three :
-    (deriveAll causativeResult).length = 3 := by native_decide
+    (deriveAll causativeResult).length = 3 := by decide
 
 /-- fullSpec roots derive 4 ArgTemplates (all templates). -/
 theorem fullSpec_derives_four :
-    (deriveAll fullSpec).length = 4 := by native_decide
+    (deriveAll fullSpec).length = 4 := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 5. Root-Enriched Derivation

--- a/Linglib/Semantics/Lexical/LevinClassProfiles.lean
+++ b/Linglib/Semantics/Lexical/LevinClassProfiles.lean
@@ -181,39 +181,14 @@ open Verb
 open Verb.Root.Kinds
 
 -- ════════════════════════════════════════════════════
--- § 5. Verification: templates match existing canonical profiles
+-- § 5. Manner roots lack result entailments
 -- ════════════════════════════════════════════════════
 
-/-- Hit-class subject = kickSubjectProfile (both full agent). -/
-theorem hit_subject_eq_kick :
-    mannerContact.subjectProfile = kickSubjectProfile := rfl
-
-/-- Hit-class object lacks CoS (manner verbs don't entail change of state).
-    This correctly differs from `kickObjectProfile` (which has CoS=true) — the
-    class-level profile captures the Beavers & Koontz-Garboden generalization
-    that manner roots lack result entailments. -/
+/-- Hit-class object lacks CoS (manner verbs don't entail change of state) —
+    the Beavers & Koontz-Garboden generalization that manner roots lack result
+    entailments, read off the class-level template. -/
 theorem mannerContact_object_no_cos :
     (mannerContact.objectProfile.map (·.changeOfState)) = some false := rfl
-
-/-- Creation-class object = buildObjectProfile. -/
-theorem creation_object_eq_build :
-    creation.objectProfile = some buildObjectProfile := rfl
-
-/-- Consumption-class object = eatObjectProfile. -/
-theorem consumption_object_eq_eat :
-    consumption.objectProfile = some eatObjectProfile := rfl
-
-/-- Self-motion subject = runSubjectProfile. -/
-theorem selfMotion_subject_eq_run :
-    selfMotion.subjectProfile = runSubjectProfile := rfl
-
-/-- Directed-motion subject = arriveSubjectProfile. -/
-theorem directedMotion_subject_eq_arrive :
-    directedMotion.subjectProfile = arriveSubjectProfile := rfl
-
-/-- Perception subject = seeSubjectProfile. -/
-theorem perception_subject_eq_see :
-    perception.subjectProfile = seeSubjectProfile := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 6. Derived role labels match expectations
@@ -221,29 +196,29 @@ theorem perception_subject_eq_see :
 
 /-- Hit-class subject → agent label. -/
 theorem hit_subject_role :
-    mannerContact.subjectProfile.toRole = some .agent := by native_decide
+    mannerContact.subjectProfile.toRole = some .agent := by decide
 
 /-- Hit-class object → patient label (CA+St maps to patient). -/
 theorem hit_object_role :
-    kickObjectProfile.toRole = some .patient := by native_decide
+    kickObjectProfile.toRole = some .patient := by decide
 
 /-- Self-motion subject → agent label. -/
 theorem selfMotion_subject_role :
-    selfMotion.subjectProfile.toRole = some .agent := by native_decide
+    selfMotion.subjectProfile.toRole = some .agent := by decide
 
 /-- Perception subject → experiencer label. -/
 theorem perception_subject_role :
-    perception.subjectProfile.toRole = some .experiencer := by native_decide
+    perception.subjectProfile.toRole = some .experiencer := by decide
 
 /-- Psych-causal subject → stimulus label. -/
 theorem psychCausal_subject_role :
-    psychCausal.subjectProfile.toRole = some .stimulus := by native_decide
+    psychCausal.subjectProfile.toRole = some .stimulus := by decide
 
 /-- Directed-motion subject → patient: the unaccusative subject of *arrive*
     undergoes a change of location (`changeOfState`) without agentivity. Formerly
     `none` (the moving subject was dropped); `toRole` now restores it. -/
 theorem directedMotion_subject_role :
-    directedMotion.subjectProfile.toRole = some .patient := by native_decide
+    directedMotion.subjectProfile.toRole = some .patient := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 7. Root.Kinds → ArgTemplate (the missing derivation)
@@ -308,42 +283,18 @@ def toArgTemplate (re : Root.Kinds) : Option ArgTemplate :=
 defined, we verify that the derived ArgTemplate either MATCHES the
 hand-specified one or is a documented override. -/
 
--- § 8a. Classes where derivation matches exactly
+-- § 8a. The table is not the naive derivation
 
-/-- Break-class: causativeResult → resultChange ✓ -/
-theorem break_derived_matches :
-    toArgTemplate (LevinClass.rootEntailments .break_) =
-    LevinClass.argTemplate .break_ := by native_decide
-
-/-- Bend-class: causativeResult → resultChange ✓ -/
-theorem bend_derived_matches :
-    toArgTemplate (LevinClass.rootEntailments .bend) =
-    LevinClass.argTemplate .bend := by native_decide
-
-/-- Destroy-class: causativeResult → resultChange ✓ -/
-theorem destroy_derived_matches :
-    toArgTemplate (LevinClass.rootEntailments .destroy) =
-    LevinClass.argTemplate .destroy := by native_decide
-
-/-- Murder-class: causativeResult → resultChange ✓ -/
-theorem murder_derived_matches :
-    toArgTemplate (LevinClass.rootEntailments .murder) =
-    LevinClass.argTemplate .murder := by native_decide
-
-/-- Cooking-class: causativeResult → resultChange ✓ -/
-theorem cooking_derived_matches :
-    toArgTemplate (LevinClass.rootEntailments .cooking) =
-    LevinClass.argTemplate .cooking := by native_decide
-
-/-- Cut-class: fullSpec → resultChange ✓ -/
-theorem cut_derived_matches :
-    toArgTemplate (LevinClass.rootEntailments .cut) =
-    LevinClass.argTemplate .cut := by native_decide
-
-/-- MannerOfMotion-class: pureManner → selfMotion ✓ -/
-theorem mannerOfMotion_derived_matches :
-    toArgTemplate (LevinClass.rootEntailments .mannerOfMotion) =
-    LevinClass.argTemplate .mannerOfMotion := by native_decide
+/-- `argTemplate` is not merely `toArgTemplate ∘ rootEntailments`: it diverges
+    for the documented overrides (creation, psych-causal). *Build* witnesses
+    this — its `causativeResult` root derives `resultChange`, but the class
+    template is `creation` (incremental-theme object). A table that always
+    matched the derivation would be redundant with it; this divergence is why
+    `argTemplate` exists as a separate label, and §8b documents the overrides. -/
+theorem argTemplate_diverges_from_derivation :
+    ∃ c : LevinClass,
+      LevinClass.argTemplate c ≠ toArgTemplate (LevinClass.rootEntailments c) :=
+  ⟨.build, by decide⟩
 
 -- § 8b. Documented overrides (derivation gives a default that the
 --        class specializes)

--- a/Linglib/Semantics/Lexical/LevinClassProfiles.lean
+++ b/Linglib/Semantics/Lexical/LevinClassProfiles.lean
@@ -6,7 +6,7 @@ import Linglib.Semantics.Lexical.LevinTheory
 # Levin Class → Entailment Profile Mapping
 
 [levin-1993] [dowty-1991] [beavers-2010]
-[beavers-koontz-garboden-2020] [rappaport-hovav-levin-2024]
+[beavers-koontz-garboden-2020] [rappaport-hovav-levin-1998]
 
 Maps [levin-1993] verb classes to proto-role entailment profiles
 ([dowty-1991]), encoding the argument-structure generalizations
@@ -224,9 +224,9 @@ theorem directedMotion_subject_role :
 -- § 7. Root.Kinds → ArgTemplate (the missing derivation)
 -- ════════════════════════════════════════════════════
 
-/-! Root kind signatures determine argument templates — this is the
-field consensus ([beavers-koontz-garboden-2020], [rappaport-hovav-levin-2024]).
-The derivational direction runs:
+/-! Root kind signatures determine argument templates — the derivational
+direction in the argument-realization tradition ([beavers-koontz-garboden-2020]
+roots, [rappaport-hovav-levin-1998] event-template linking). The chain runs:
 
     Root.Kinds → Template → ArgTemplate → ThetaRole labels
 

--- a/Linglib/Semantics/Lexical/LevinTheory.lean
+++ b/Linglib/Semantics/Lexical/LevinTheory.lean
@@ -10,24 +10,28 @@ import Linglib.Semantics.Lexical.EventStructure
 # Levin Verb Class Theory
 [levin-1993] [dowty-1991] [beavers-koontz-garboden-2020]
 
-The `LevinClass` enum and its classification data (`MeaningComponents`,
-`meaningComponents`, `predictsUnaccusative`, `isVerbOfCreation`) are
-defined in `Core/Lexical/VerbClass.lean`.
+The `LevinClass` enum and its classification data (`meaningComponents`,
+`predictsUnaccusative`, `isVerbOfCreation`) live in
+`Semantics/Lexical/LevinClass.lean`; `MeaningComponents` in
+`Semantics/Lexical/MeaningComponents.lean`.
 
 This file provides the theoretical content that depends on `Root.Kinds`:
-root signature mapping, root–MC bridge enums, and universal consistency
-theorems.
+the root signature label, the root–MC bridge enums, and the universal
+consistency/divergence theorems that ground them. `LevinClass` is a *lossy
+realization label*, not a source of truth (that is `Verb.Root.kinds`); the
+theorems below are the non-decorative grounding — each holds for every class
+and breaks if a table row changes, so per-class `rfl` spot-checks are not
+restated.
 
-## § 1. Root entailment mapping ([beavers-koontz-garboden-2020])
+## § 1. Root entailment label ([beavers-koontz-garboden-2020])
 
-Root kind signatures, well-formedness verification, and
-manner+result (MRC) tests.
+The `rootEntailments` signature label and its universal soundness theorem.
 
 ## § 2. Root–MC bridge
 
 Classification enums (CausationSource, ResultKind, MannerKind) naming the
 systematic divergences between B&KG root features and Levin meaning
-components, plus universal consistency theorems.
+components, plus the universal consistency theorems and a divergence witness.
 -/
 
 -- ════════════════════════════════════════════════════
@@ -189,37 +193,20 @@ def LevinClass.rootEntailments : LevinClass → Root.Kinds
   -- §57 Weather
   | .weather => minimal            -- (default)
 
-/-! ### Well-formedness verification -/
+/-! ### Table soundness (universal)
 
-theorem break_root_wf : (LevinClass.rootEntailments .break_).WellFormed := by decide
-theorem cut_root_wf : (LevinClass.rootEntailments .cut).WellFormed := by decide
-theorem hit_root_wf : (LevinClass.rootEntailments .hit).WellFormed := by decide
-theorem touch_root_wf : (LevinClass.rootEntailments .touch).WellFormed := by decide
-theorem give_root_wf : (LevinClass.rootEntailments .give).WellFormed := by decide
-theorem destroy_root_wf : (LevinClass.rootEntailments .destroy).WellFormed := by decide
-theorem murder_root_wf : (LevinClass.rootEntailments .murder).WellFormed := by decide
-theorem poison_root_wf : (LevinClass.rootEntailments .poison).WellFormed := by decide
+`rootEntailments` is a lossy realization *label*, not a source of truth. It
+earns its place via a theorem that holds for *every* class and breaks if a
+row is changed: every assigned signature is well-formed (collocationally
+closed). Invert any row to an unclosed signature and this fails — the
+grounding is not decorative. Manner/result complementarity of these
+signatures is covered by the canonical kinds-layer theory
+(`Roots/Closure.lean`, `closed_violatesBifurcation_iff`), which quantifies
+over all `Root.Kinds`, so no per-class MRC spot-check is restated here. -/
 
-/-! ### Manner/Result Complementarity verification -/
-
-theorem cut_hasMannerAndResult :
-    (LevinClass.rootEntailments .cut).HasMannerAndResult := by decide
-theorem cooking_hasMannerAndResult :
-    (LevinClass.rootEntailments .cooking).HasMannerAndResult := by decide
-theorem poison_hasMannerAndResult :
-    (LevinClass.rootEntailments .poison).HasMannerAndResult := by decide
-theorem break_not_hasMannerAndResult :
-    ¬ (LevinClass.rootEntailments .break_).HasMannerAndResult := by decide
-theorem hit_not_hasMannerAndResult :
-    ¬ (LevinClass.rootEntailments .hit).HasMannerAndResult := by decide
-
-/-! ### VOC–root entailment theorems -/
-
-/-- Core creation classes have causativeResult root signatures. -/
-theorem build_class_causative :
-    LevinClass.build.rootEntailments = causativeResult := rfl
-theorem create_class_causative :
-    LevinClass.create.rootEntailments = causativeResult := rfl
+/-- Every Levin class is assigned a well-formed (closed) root signature. -/
+theorem rootEntailments_wellFormed (c : LevinClass) :
+    c.rootEntailments.WellFormed := by cases c <;> decide
 
 -- ════════════════════════════════════════════════════
 -- § 2. Root–MC Bridge ([beavers-koontz-garboden-2020])
@@ -308,62 +295,11 @@ def LevinClass.mannerKind (c : LevinClass) : MannerKind :=
   else if mc.mannerSpec then .mannerSpec
   else .unspecified
 
-/-! #### Causation source verification -/
-
-theorem break_causation_rootExternal :
-    LevinClass.causationSource .break_ = .rootExternal := rfl
-theorem destroy_causation_rootExternal :
-    LevinClass.causationSource .destroy = .rootExternal := rfl
-theorem murder_causation_rootExternal :
-    LevinClass.causationSource .murder = .rootExternal := rfl
-theorem eat_causation_rootNonDetachable :
-    LevinClass.causationSource .eat = .rootNonDetachable := rfl
-theorem devour_causation_rootNonDetachable :
-    LevinClass.causationSource .devour = .rootNonDetachable := rfl
-theorem put_causation_template :
-    LevinClass.causationSource .put = .template := rfl
-theorem send_causation_template :
-    LevinClass.causationSource .send = .template := rfl
-theorem grow_causation_template :
-    LevinClass.causationSource .grow = .template := rfl
-theorem hit_causation_none :
-    LevinClass.causationSource .hit = .none := rfl
-theorem mannerOfMotion_causation_none :
-    LevinClass.causationSource .mannerOfMotion = .none := rfl
-
-/-! #### Result kind verification -/
-
-theorem break_result_stateChange :
-    LevinClass.resultKind .break_ = .stateChange := rfl
-theorem destroy_result_stateChange :
-    LevinClass.resultKind .destroy = .stateChange := rfl
-theorem throw_result_locationChange :
-    LevinClass.resultKind .throw = .locationChange := rfl
-theorem inherentlyDirectedMotion_result_locationChange :
-    LevinClass.resultKind .inherentlyDirectedMotion = .locationChange := rfl
-theorem leave_result_locationChange :
-    LevinClass.resultKind .leave = .locationChange := rfl
-theorem give_result_possessionChange :
-    LevinClass.resultKind .give = .possessionChange := rfl
-theorem hit_result_none :
-    LevinClass.resultKind .hit = .none := rfl
-
-/-! #### Manner kind verification -/
-
-theorem cooking_manner_mannerSpec :
-    LevinClass.mannerKind .cooking = .mannerSpec := rfl
-theorem mannerOfMotion_manner_mannerSpec :
-    LevinClass.mannerKind .mannerOfMotion = .mannerSpec := rfl
-theorem cut_manner_instrumentSpec :
-    LevinClass.mannerKind .cut = .instrumentSpec := rfl
-theorem poke_manner_instrumentSpec :
-    LevinClass.mannerKind .poke = .instrumentSpec := rfl
-theorem hit_manner_unspecified :
-    LevinClass.mannerKind .hit = .unspecified := rfl
-theorem pushPull_manner_unspecified :
-    LevinClass.mannerKind .pushPull = .unspecified := rfl
-theorem break_manner_none :
-    LevinClass.mannerKind .break_ = .none := rfl
+/-! The `causationSource`/`resultKind`/`mannerKind` classifiers are grounded
+not by per-class `rfl` confirmations (which merely restate a row of the
+`def` and break in lockstep when the row changes) but by the universal
+consistency theorems below, which relate them to the root signature and the
+event template and break under a genuine table change. -/
 
 /-! ### Root-structural MC contribution -/
 
@@ -413,5 +349,18 @@ theorem template_resultState_not_iff_resultKind_stateChange :
       c.eventTemplate.HasResultState ∧ c.resultKind ≠ .stateChange := by
   refine ⟨.aspectual, ?_⟩
   decide
+
+/-- The naive structural prediction `structuralMC ∘ rootEntailments` is *not*
+    a refinement of the hand-specified `meaningComponents`: a class can carry
+    `result` in its root signature (so `structuralMC` predicts `changeOfState`)
+    yet have Levin `changeOfState = false` — change of possession/location
+    carries `result` in B&KG but is not a change *of state* for Levin. This
+    divergence witness is why the bridge enums (`ResultKind` et al.) exist and
+    `meaningComponents` is not just `structuralMC ∘ rootEntailments`. -/
+theorem structuralMC_diverges_from_meaningComponents :
+    ∃ c : LevinClass,
+      (Verb.Root.Kinds.structuralMC c.rootEntailments).changeOfState = true ∧
+      c.meaningComponents.changeOfState = false :=
+  ⟨.give, by decide⟩
 
 end Semantics.Lexical

--- a/Linglib/Semantics/Lexical/LevinTheory.lean
+++ b/Linglib/Semantics/Lexical/LevinTheory.lean
@@ -16,7 +16,7 @@ The `LevinClass` enum and its classification data (`meaningComponents`,
 `Semantics/Lexical/MeaningComponents.lean`.
 
 This file provides the theoretical content that depends on `Root.Kinds`:
-the root signature label, the root–MC bridge enums, and the universal
+the root signature label, the root–MC comparison enums, and the universal
 consistency/divergence theorems that ground them. `LevinClass` is a *lossy
 realization label*, not a source of truth (that is `Verb.Root.kinds`); the
 theorems below are the non-decorative grounding — each holds for every class
@@ -27,11 +27,11 @@ restated.
 
 The `rootEntailments` signature label and its universal soundness theorem.
 
-## § 2. Root–MC bridge
+## § 2. Root–MC comparison
 
 Classification enums (CausationSource, ResultKind, MannerKind) naming the
 systematic divergences between B&KG root features and Levin meaning
-components, plus the universal consistency theorems and a divergence witness.
+components, plus the universal consistency theorems and divergence witnesses.
 -/
 
 -- ════════════════════════════════════════════════════
@@ -209,18 +209,14 @@ theorem rootEntailments_wellFormed (c : LevinClass) :
     c.rootEntailments.WellFormed := by cases c <;> decide
 
 -- ════════════════════════════════════════════════════
--- § 2. Root–MC Bridge ([beavers-koontz-garboden-2020])
+-- § 2. Root–MC Comparison ([beavers-koontz-garboden-2020], [levin-1993])
 -- ════════════════════════════════════════════════════
 
-/-! ### Root–MC correspondence (2026 consensus)
+/-! ### Root–MC comparison
 
-The 2026 consensus in lexical semantics ([beavers-koontz-garboden-2020],
-[rappaport-hovav-levin-2024]) treats root entailments as primary:
-verb behavior at the Levin diagnostic level is determined by root content
-plus semantic field membership plus template structure.
-
-But the B&KG root features and the Levin meaning components are NOT
-isomorphic — they conceptualize different levels of granularity:
+[levin-1993]'s meaning components and [beavers-koontz-garboden-2020]'s root
+entailments are two independently-motivated lexical decompositions; they are
+NOT isomorphic — they conceptualize different levels of granularity:
 
 | B&KG concept | Levin concept | Relationship |
 |---|---|---|
@@ -228,8 +224,15 @@ isomorphic — they conceptualize different levels of granularity:
 | `manner` | `mannerSpec` ∨ `instrumentSpec` | B&KG broader: includes contact-manner (hit) |
 | `cause` | `causation` | Distinct: root-level vs event-level causation |
 
-The three `*Kind` enums below name the specific cases where the two
-frameworks diverge, making the divergences grep-able and testable. -/
+Because B&KG `result`/`manner` are *coarser* than the Levin features, neither
+table is a function of the other (`give` carries `result` but
+`changeOfState = false`; `hit` carries `manner` but `mannerSpec = false`), so
+the two are related by the consistency/divergence theorems below, not by a
+derivation — a morphism `meaningComponents = f rootEntailments` is not just
+absent from the literature but mathematically impossible here, and the
+manner/result-complementarity dispute ([beavers-koontz-garboden-2020] vs the
+Rappaport Hovav & Levin tradition) is exactly over this independence. The three
+`*Kind` enums name the specific divergences, making them grep-able and testable. -/
 
 /-- Where a verb class's event-level causation originates.
 

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -38,11 +38,16 @@ def Verb.derivedVendlerClass (v : Verb) : Option VendlerClass :=
 def Verb.rootProfile (v : Verb) : Verb.Root.Profile :=
   v.root.profile
 
-/-- The verb's kind signature ([beavers-koontz-garboden-2020]): the collocational
-    closure of its root's kinds (`cause ⟹ result ⟹ state`), which the
-    event-structure spine (`Verb.Root.template`, `CosModel.denote`) runs on. (The
-    raw, un-closed atom-kinds are `v.root.kinds`; the coarse class-derived view is
-    `Verb.classKinds`.) -/
+/-- The verb's raw kind signature ([beavers-koontz-garboden-2020]): the
+    un-closed atom-kinds of its root, the source of truth for what the verb
+    structurally entails. `Verb.closedKinds` is its collocational closure and
+    `Verb.classKinds` the coarse class-derived view (an independent provenance). -/
+def Verb.kinds (v : Verb) : Verb.Root.Kinds :=
+  v.root.kinds
+
+/-- The verb's closed kind signature ([beavers-koontz-garboden-2020]): the
+    collocational closure of `Verb.kinds` (`cause ⟹ result ⟹ state`), which the
+    event-structure spine (`Verb.Root.template`, `CosModel.denote`) runs on. -/
 def Verb.closedKinds (v : Verb) : Verb.Root.Kinds :=
   v.root.closedKinds
 

--- a/Linglib/Semantics/Verb/RootContent.lean
+++ b/Linglib/Semantics/Verb/RootContent.lean
@@ -4,12 +4,12 @@ import Linglib.Morphology.RootTypology
 /-!
 # Verb ↔ root content accessors
 
-The integration seam (P-HUB) between a `Verb` and the root it carries
-(`Verb.root : Option Verb.Root`): a verb's B&KG kind signature, [bhadra-2024]
-outcome cardinality, and change-entailment type are read off *its own root* when
-present, falling back to its Levin class only for the signature (the per-class
-outcome assignment is a Study-level claim, so there is no Levin fallback for
-outcomes).
+The integration seam (P-HUB) between a `Verb` and the (total) root it carries
+(`Verb.root : Verb.Root`): a verb's [bhadra-2024] outcome cardinality and
+change-entailment type are read off its own root. The coarse Levin-class view
+of the kind signature (`Verb.classKinds`) is kept as a *separate, named*
+provenance — the realization label's prediction, not the source of truth
+(`Verb.kinds`); the two agree only by theorem, never by construction.
 
 `RootType` and `Verb.Root.changeType` live in `Morphology/RootTypology.lean`, so
 these accessors (which mention them) live here rather than in `Verb/Basic.lean`.
@@ -17,10 +17,16 @@ these accessors (which mention them) live here rather than in `Verb/Basic.lean`.
 ## Main definitions
 
 * `Verb.classKinds` — the class-derived kind signature (the coarse Levin view)
-* `Verb.outcomes` — the verb's outcome-set cardinality (root only)
+* `Verb.outcomes` — the verb's outcome-set cardinality
 * `Verb.changeType` — the verb's change-entailment type (derived from its root)
 
-(`Verb.kinds`, the root-sourced signature, lives in `Verb/Basic.lean`.)
+## Main results
+
+* `Verb.classKinds_wellFormed` — the class view, when present, is a well-formed
+  signature (grounded in `rootEntailments_wellFormed`)
+
+(`Verb.kinds`, the root-sourced source-of-truth signature, lives in
+`Verb/Basic.lean`.)
 -/
 
 open Verb
@@ -32,6 +38,19 @@ open Semantics.Lexical
     `classKinds = kinds` agreement is a theorem, not a default. -/
 def Verb.classKinds (v : Verb) : Option Verb.Root.Kinds :=
   v.levinClass.map LevinClass.rootEntailments
+
+/-- The class-derived signature, when present, is well-formed (collocationally
+    closed) — `classKinds`'s grounding, inherited from `rootEntailments_wellFormed`.
+    The stronger `classKinds ⊆ Verb.kinds` is deliberately *not* a theorem:
+    `classKinds` (the Levin label's prediction) and `Verb.kinds` (the verb's own
+    root) are independent provenances, so they coincide only for a faithfully
+    classified verb — a per-verb hypothesis the type does not enforce. -/
+theorem Verb.classKinds_wellFormed (v : Verb) :
+    ∀ s ∈ v.classKinds, s.WellFormed := by
+  intro s hs
+  simp only [Verb.classKinds] at hs
+  obtain ⟨c, -, rfl⟩ := Option.mem_map.1 hs
+  exact Semantics.Lexical.rootEntailments_wellFormed c
 
 /-- The verb's outcome-set cardinality ([bhadra-2024]), read off its `root`
     (`none` where the root is not annotated for outcomes). -/

--- a/Linglib/Studies/Krejci2012.lean
+++ b/Linglib/Studies/Krejci2012.lean
@@ -156,23 +156,23 @@ def allVerbs : List LexReflexiveVerb :=
 -- ════════════════════════════════════════════════════
 
 /-- All four verbs pass the *again* ambiguity diagnostic. -/
-theorem all_again : allVerbs.all (·.againAmbiguity) = true := by native_decide
+theorem all_again : allVerbs.all (·.againAmbiguity) = true := by decide
 
 /-- All four verbs pass the *re-* prefixation diagnostic. -/
-theorem all_re : allVerbs.all (·.rePrefixation) = true := by native_decide
+theorem all_re : allVerbs.all (·.rePrefixation) = true := by decide
 
 /-- All four verbs pass the *almost* ambiguity diagnostic. -/
-theorem all_almost : allVerbs.all (·.almostAmbiguity) = true := by native_decide
+theorem all_almost : allVerbs.all (·.almostAmbiguity) = true := by decide
 
 /-- All four verbs pass the negation-over-CAUSE diagnostic. -/
-theorem all_negation : allVerbs.all (·.negationOverCause) = true := by native_decide
+theorem all_negation : allVerbs.all (·.negationOverCause) = true := by decide
 
 /-- All four diagnostics pass for every verb in the dataset:
     the simple forms of eat, wash, dress, and learn are bieventive. -/
 theorem all_bieventive :
     allVerbs.all (λ v =>
       v.againAmbiguity && v.rePrefixation &&
-      v.almostAmbiguity && v.negationOverCause) = true := by native_decide
+      v.almostAmbiguity && v.negationOverCause) = true := by decide
 
 /-- Middles and ingestives are both represented. -/
 theorem both_subtypes :
@@ -284,7 +284,7 @@ theorem accomplishment_has_variant :
     accomplishment). The template infrastructure predicts alternation;
     the blocking is root-level, not template-level. -/
 theorem eat_root_alternation_possible :
-    (licensedTemplates (LevinClass.rootEntailments .eat)).length = 3 := by native_decide
+    (licensedTemplates (LevinClass.rootEntailments .eat)).length = 3 := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 7. Bridge to Event Structure
@@ -378,6 +378,6 @@ theorem middle_no_theta :
 
 /-- The causativizability hierarchy holds for all 12 languages. -/
 theorem hierarchy_holds :
-    krejciLanguages.all (·.respectsHierarchy) = true := by native_decide
+    krejciLanguages.all (·.respectsHierarchy) = true := by decide
 
 end Krejci2012


### PR DESCRIPTION
Demote the LevinClass realization-label tables from ~70 decorative per-class spot-checks to universal consistency/divergence theorems (blueprint step #11; informed by a mathlib-lens audit of the Verb API).

- `rootEntailments_wellFormed` + the 4 kept cross-table universals + divergence witnesses (incl. `structuralMC`) replace the per-class `rfl`/`decide` row-confirmations.
- Add `Verb.kinds` (was documented but undefined) and `Verb.classKinds_wellFormed`; fix the stale `Option Verb.Root` docstring (root is total since #403).
- Drop all `native_decide` from the Levin-derivation cone (LevinClassProfiles, ArgDerivation, Krejci2012) → `decide`.
- Correct a mis-attributed `[rappaport-hovav-levin-2024]` (an agentivity paper) cited for the "root determines class" thesis; reframe the Root–MC section as a cross-framework *comparison* (the two tables are non-isomorphic — neither is a function of the other — so no morphism, by design).