### PR TITLE
refactor(Semantics/Lexical/Roots): improve Root Repr; add LawfulBEq

### DIFF
--- a/Linglib/Semantics/Lexical/Roots/Basic.lean
+++ b/Linglib/Semantics/Lexical/Roots/Basic.lean
@@ -97,11 +97,19 @@ structure Root where
   profile : Verb.Root.Profile := {}
   deriving DecidableEq
 
-/-- `Repr`/`BEq` from the data + `DecidableEq` (the `Finset` field blocks deriving
-    either); needed so `Verb` can carry `root : Option Verb.Root` and still derive
-    `Repr`/`BEq`. -/
-instance : Repr Root := ⟨fun r _ => repr r.name⟩
+/-- `Finset` carries neither `Repr` nor `BEq`, so `Root` cannot `deriving` either;
+    we supply both by hand so `Verb` can derive `Repr`/`BEq` over its `root` field.
+    The `Repr` shows the `name`, `outcomes`, and `profile` fields in full plus the
+    `entailments` cardinality — the entailment *set* itself has no computable `Repr`
+    (`Finset`/`Multiset` would need a `LinearOrder` on the elements to render), but
+    this already distinguishes roots that differ in outcomes/profile, which the old
+    name-only `Repr` collapsed. The `BEq` is the lawful `DecidableEq`-backed one. -/
+instance : Repr Root :=
+  ⟨fun r _ => repr (r.name, r.entailments.card, r.outcomes, r.profile)⟩
 instance : BEq Root := ⟨fun a b => decide (a = b)⟩
+instance : LawfulBEq Root where
+  eq_of_beq h := of_decide_eq_true h
+  rfl := decide_eq_true_eq.mpr rfl
 
 namespace Root
 


### PR DESCRIPTION
Audit follow-up on `Verb.Root`'s hand-rolled instances. `Repr` now shows `name`/`outcomes`/`profile` in full plus the `entailments` cardinality (was name-only, which collapsed roots differing only in outcomes/profile); add the missing `LawfulBEq Root` for the `DecidableEq`-backed `BEq`. `Finset`/`Multiset` have no computable `Repr` (would need a `LinearOrder` on the atoms), so the entailment set is shown by count rather than rendered.