### PR TITLE
refactor(Minimalist/Merge): derive Minimal Yield from MCB Lemma 1.6.3

### DIFF
--- a/Linglib/Core/Combinatorics/RootedTree/AdmissibleCut.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/AdmissibleCut.lean
@@ -1079,46 +1079,33 @@ theorem nonTraceSize_remainder_pos_of_cutForest_singleton [Inhabited β]
   obtain ⟨l, r, rfl⟩ := isNode_of_cutForest_singleton c β_t h_cf
   exact nonTraceSize_remainder_pos_of_node c
 
-/-- **MCB Lemma 1.6.3 eq. 1.6.8** (book p. 65): for a single-edge cut on
-    `T` extracting accessible term `β_t`, the contraction-quotient's
-    accCountC satisfies `α(T) = α(T_v) + α^c(T/^c T_v) + 1`. The `+1`
-    accounts for the root vertex of `T` (counted in `accCount T = T.size − 1`
-    but not in the per-piece sum since the root is the new merged node
-    when re-merging).
+/-- Convenience wrapper: the tree in a singleton `cutForest = {β_t}` of a
+    trace-free `T` is itself trace-free. Discharges the membership obligation
+    of `nonTraceSize_eq_size_of_mem_cutForest`. -/
+theorem nonTraceSize_eq_size_of_cutForest_singleton
+    {T : TraceTree α β} (c : CutShape T) (β_t : TraceTree α β)
+    (h_tf : T.nonTraceSize = T.size)
+    (h_cf : c.cutForest = ({β_t} : TraceForest α β)) :
+    β_t.nonTraceSize = β_t.size := by
+  apply nonTraceSize_eq_size_of_mem_cutForest c β_t h_tf
+  rw [h_cf]; exact Multiset.mem_singleton.mpr rfl
 
-    Concretely: `T.size − 1 = (β_t.size − 1) + ((T/^c β_t).nonTraceSize − 1) + 1`
-    follows from `cut_size_conservation_contraction` with cutForest = {β_t}
-    and the size-pos witnesses. -/
+/-- **MCB Lemma 1.6.3 eq. 1.6.8** (book p. 65): `α(T) = α(T_v) + αᶜ(T/^c T_v) + 1`.
+    Stated in αᶜ form for a trace-free `T` (where `α(T) = αᶜ(T)`) so it feeds the
+    Δ^c size-delta proofs directly: `αᶜ(T) = αᶜ(β_t) + αᶜ(T/^c β_t) + 1`. The trace
+    cancellation ("deeper copy") is internal to `accCountC` on the quotient. -/
 theorem singleEdgeCut_contraction_alpha [Inhabited β]
     {T : TraceTree α β} (c : CutShape T) (β_t : TraceTree α β)
     (h_tf : T.nonTraceSize = T.size)
     (h_cf : c.cutForest = ({β_t} : TraceForest α β)) :
-    T.accCount = β_t.accCount + c.remainder.accCountC + 1 := by
+    T.accCountC = β_t.accCountC + c.remainder.accCountC + 1 := by
   have h := cut_size_conservation_contraction c h_tf
   rw [h_cf, TraceForest.sizeForest_singleton] at h
+  have h_β_tf := nonTraceSize_eq_size_of_cutForest_singleton c β_t h_tf h_cf
   have hβ := β_t.size_pos
   have hRem_pos : c.remainder.nonTraceSize ≥ 1 :=
     nonTraceSize_remainder_pos_of_cutForest_singleton c β_t h_cf
-  show T.size - 1 = (β_t.size - 1) + (c.remainder.nonTraceSize - 1) + 1
-  omega
-
-/-- **MCB Lemma 1.6.3 eq. 1.6.10** (book p. 65): `σ(T) = σ(T_v) + σ(T/^c T_v)`
-    for a single-edge cut on T extracting β_t. (No `+1` in this case — the
-    root vertex is already counted in σ_v + σ_q via the b₀ contribution.)
-
-    Concretely: `1 + (T.size − 1) = (1 + (β_t.size − 1)) + (1 + ((T/^c β_t).nonTraceSize − 1))`
-    follows from `cut_size_conservation_contraction`. -/
-theorem singleEdgeCut_contraction_sigma [Inhabited β]
-    {T : TraceTree α β} (c : CutShape T) (β_t : TraceTree α β)
-    (h_tf : T.nonTraceSize = T.size)
-    (h_cf : c.cutForest = ({β_t} : TraceForest α β)) :
-    TraceForest.sigma ({T} : TraceForest α β)
-      = TraceForest.sigma ({β_t} : TraceForest α β)
-      + TraceForest.sigmaC ({c.remainder} : TraceForest α β) := by
-  have h_alpha := singleEdgeCut_contraction_alpha c β_t h_tf h_cf
-  rw [TraceForest.sigma_singleton, TraceForest.sigma_singleton,
-      TraceForest.sigmaC_singleton]
-  show 1 + T.accCount = 1 + β_t.accCount + (1 + c.remainder.accCountC)
+  show T.nonTraceSize - 1 = (β_t.nonTraceSize - 1) + (c.remainder.nonTraceSize - 1) + 1
   omega
 
 /-- **Single-edge cut produces non-collapsing remainder**: if a cut has
@@ -1329,8 +1316,8 @@ theorem numContractions_twoEdge
     **Corollary of `cut_size_conservation`** with `numContractions = 1`
     (single-edge case, by `numContractions_singleEdge`).
 
-    Used by `MinimalYield.im_pair_size_deltas_deltaD` and
-    `MinimalYield.sideward_2b_size_deltas_deltaD` to discharge the
+    Used by `MinimalYield.im_pair_size_deltas_deletion` and
+    `MinimalYield.sideward_2b_size_deltas_deletion` to discharge the
     `h_size` hypothesis from cut data. -/
 theorem singleEdgeCut_size_relation
     {T : TraceTree α β} (c : CutShape T) (β_t Q : TraceTree α β)
@@ -1341,6 +1328,65 @@ theorem singleEdgeCut_size_relation
   have h_nc := numContractions_singleEdge c β_t h_cf
   rw [h_cf, h_rd, TraceForest.sizeForest_singleton, h_nc] at h_general
   simpa using h_general
+
+/-- **MCB Lemma 1.6.3 eq. 1.6.7** (book p. 65): for a single-edge cut on `T`
+    extracting `β_t` with deletion-quotient `Q`, the Δ^d counting of accessible
+    terms satisfies `α(T) = α(β_t) + α(Q) + 2`. The additive `accCount` form of
+    `singleEdgeCut_size_relation` — it discharges the `size → accCount` bridge
+    once (internalising the size-positivity) so consumers reason additively. -/
+theorem singleEdgeCut_deletion_alpha
+    {T : TraceTree α β} (c : CutShape T) (β_t Q : TraceTree α β)
+    (h_cf : c.cutForest = ({β_t} : TraceForest α β))
+    (h_rd : c.remainderDeletion = some Q) :
+    T.accCount = β_t.accCount + Q.accCount + 2 := by
+  have h := singleEdgeCut_size_relation c β_t Q h_cf h_rd
+  have hβ := β_t.size_pos
+  have hQ := Q.size_pos
+  show T.size - 1 = (β_t.size - 1) + (Q.size - 1) + 2
+  omega
+
+/-- **MCB Lemma 1.6.3 eq. 1.6.7, two-edge form** (book p. 70): for a two-edge cut
+    `cutForest = {a, b}` with deletion-quotient `Q`, the Δ^d counting satisfies
+    `α(T) = α(a) + α(b) + α(Q) + numContractions c + 2` — the additive `accCount`
+    form of `cut_size_conservation` for the pair case. -/
+theorem pairCut_deletion_alpha
+    {T : TraceTree α β} (c : CutShape T) (a b Q : TraceTree α β)
+    (h_cf : c.cutForest = ({a, b} : TraceForest α β))
+    (h_rd : c.remainderDeletion = some Q) :
+    T.accCount = a.accCount + b.accCount + Q.accCount + numContractions c + 2 := by
+  have h := cut_size_conservation c
+  rw [h_cf, h_rd, TraceForest.sizeForest_pair] at h
+  simp only [Option.elim] at h
+  have ha := a.size_pos
+  have hb := b.size_pos
+  have hQ := Q.size_pos
+  show T.size - 1 = (a.size - 1) + (b.size - 1) + (Q.size - 1) + numContractions c + 2
+  omega
+
+/-- **MCB Lemma 1.6.3 eq. 1.6.8, two-edge form** (book p. 71): for a two-edge cut
+    `cutForest = {a, b}` on a trace-free `T` with contraction-quotient remainder,
+    the Δ^c counting satisfies `αᶜ(T) = αᶜ(a) + αᶜ(b) + αᶜ(T/^c {a,b}) + 2`. The
+    αᶜ analogue of `pairCut_deletion_alpha`. -/
+theorem pairCut_contraction_alpha [Inhabited β]
+    {T : TraceTree α β} (c : CutShape T) (a b : TraceTree α β)
+    (h_tf : T.nonTraceSize = T.size)
+    (h_cf : c.cutForest = ({a, b} : TraceForest α β))
+    (h_rem_pos : c.remainder.nonTraceSize ≥ 1) :
+    T.accCountC = a.accCountC + b.accCountC + c.remainder.accCountC + 2 := by
+  have h := cut_size_conservation_contraction c h_tf
+  rw [h_cf, TraceForest.sizeForest_pair] at h
+  have h_a_tf : a.nonTraceSize = a.size :=
+    nonTraceSize_eq_size_of_mem_cutForest c a h_tf
+      (by rw [h_cf]; exact Multiset.mem_cons_self _ _)
+  have h_b_tf : b.nonTraceSize = b.size :=
+    nonTraceSize_eq_size_of_mem_cutForest c b h_tf
+      (by rw [h_cf, show ({a, b} : TraceForest α β) = a ::ₘ ({b} : TraceForest α β) from rfl,
+          Multiset.mem_cons]; exact Or.inr (Multiset.mem_singleton.mpr rfl))
+  have ha := a.size_pos
+  have hb := b.size_pos
+  show T.nonTraceSize - 1
+      = (a.nonTraceSize - 1) + (b.nonTraceSize - 1) + (c.remainder.nonTraceSize - 1) + 2
+  omega
 
 end CutShape
 

--- a/Linglib/Core/Combinatorics/RootedTree/Decorated.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Decorated.lean
@@ -690,16 +690,6 @@ def TraceForest.sigma {α β : Type*} (F : TraceForest α β) : Nat := F.b₀ + 
     TraceForest.sigma (F + G) = F.sigma + G.sigma := by
   unfold sigma; rw [b₀_add, alpha_add]; omega
 
-/-- **MCB Lemma 1.6.3 eq. 1.6.6** (book p. 65): `σ(M(T_v, T_w)) = σ(T_v) +
-    σ(T_w) + 1` at the singleton-forest level. -/
-theorem TraceForest.sigma_merge_singleton {α β : Type*} (T_v T_w : TraceTree α β) :
-    TraceForest.sigma ({TraceTree.node T_v T_w} : TraceForest α β)
-      = TraceForest.sigma ({T_v} : TraceForest α β)
-        + TraceForest.sigma ({T_w} : TraceForest α β) + 1 := by
-  rw [sigma_singleton, sigma_singleton, sigma_singleton,
-      TraceTree.accCount_merge]
-  omega
-
 /-! ## §7: Δ^c-aware forest measures (αᶜ, σᶜ)
 [marcolli-chomsky-berwick-2025] §1.6.2
 
@@ -732,6 +722,16 @@ def TraceTree.accCountC {α β : Type*} : TraceTree α β → Nat := fun T => T.
 @[simp] theorem TraceTree.accCountC_node {α β : Type*} (l r : TraceTree α β) :
     (TraceTree.node l r).accCountC = l.nonTraceSize + r.nonTraceSize := by
   show (1 + l.nonTraceSize + r.nonTraceSize) - 1 = l.nonTraceSize + r.nonTraceSize
+  omega
+
+/-- The Δ^c analogue of `accCount_merge` (MCB Lemma 1.6.3 eq. 1.6.5 for αᶜ): for
+    a node whose children each carry at least one non-trace vertex, the
+    contraction-aware count satisfies `αᶜ(node X Y) = αᶜ(X) + αᶜ(Y) + 2`. -/
+theorem TraceTree.accCountC_merge {α β : Type*} (X Y : TraceTree α β)
+    (hX : X.nonTraceSize ≥ 1) (hY : Y.nonTraceSize ≥ 1) :
+    (TraceTree.node X Y).accCountC = X.accCountC + Y.accCountC + 2 := by
+  rw [TraceTree.accCountC_node]
+  show X.nonTraceSize + Y.nonTraceSize = (X.nonTraceSize - 1) + (Y.nonTraceSize - 1) + 2
   omega
 
 /-- αᶜ on a forest. Non-trace non-root vertex count summed across components. -/

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -1,33 +1,23 @@
 import Linglib.Syntax.Minimalist.Merge.External
-import Linglib.Syntax.Minimalist.Merge.Internal
 import Linglib.Core.Order.PullbackPreorder
 import Mathlib.Order.OrderDual
 
 /-!
 # Minimal Yield (MCB Definition 1.6.1)
-[marcolli-chomsky-berwick-2025] §1.6.1, book p. 63
+[marcolli-chomsky-berwick-2025] §1.6.1, Def 1.6.1 on book p. 63
 
-Realises M-C-B's **Minimal Yield principle** (Def 1.6.1) as a predicate on
-forest transformations, plus the per-merge counting characterization of
-**Proposition 1.6.4** (book p. 66) and **Proposition 1.6.8** (book p. 69)
-for the EM/IM/Sideward cases.
+Realises M-C-B's **Minimal Yield principle** as a predicate on forest
+transformations and proves the per-merge counting characterizations of
+**Prop 1.6.4** (EM/IM, book p. 66) and **Prop 1.6.8** (Sideward, book p. 69).
 
-## Definition (verbatim, MCB Def 1.6.1, book p. 63 + eq. 1.6.2)
+The principle (Def 1.6.1, eq. 1.6.2) asks three things of a transformation
+`Φ`: `b₀(Φ F) ≤ b₀ F` (no divergence), `α(Φ F) ≥ α F` (no information loss),
+and `σ(Φ F) = σ F + 1` (minimality of yield). MCB's parenthetical **weak
+form** drops the last condition; we provide `MinimalYield` (strong) and
+`MinimalYieldWeak` (the first two bounds only). The strong form rules out
+Sideward 3(a)/3(b) under Δ^c, the weak form under Δ^d (p. 69).
 
-A transformation `Φ : 𝓕_SO₀ → 𝓕_SO₀` satisfies the Minimal Yield principle
-if the following conditions hold:
-
-  b₀(Φ(F)) ≤ b₀(F)        (no divergence)
-  α(Φ(F)) ≥ α(F)          (no information loss)
-  σ(Φ(F)) = σ(F) + 1      (minimality of yield)
-
-MCB also implicitly invokes a **weak form** that drops the third condition
-(book p. 69 says Sideward 3(a)/3(b) are "ruled out by the Minimal Yield
-principle, in the strong form (for Δ^c) or in the weak form (for Δ^d)").
-We provide both `MinimalYield` (strong) and `MinimalYieldWeak` (drops
-`minimalYield`).
-
-## Per-merge characterization (MCB Prop 1.6.4 + Prop 1.6.8)
+## Per-merge signatures (Prop 1.6.4 + Prop 1.6.8)
 
 | Merge | Δb₀ | Δα | Δσ | Strong | Weak |
 |---|---|---|---|---|---|
@@ -41,609 +31,322 @@ We provide both `MinimalYield` (strong) and `MinimalYieldWeak` (drops
 | Sideward 3(b) Δ^c | +1 | 0 | +1 | ✗ (Δb₀>0) | ✗ (Δb₀>0) |
 | Sideward 3(b) Δ^d | +1 | −2 | −1 | ✗ (Δb₀>0) | ✗ (Δb₀>0) |
 
-The 3(a)/Δ^d row matches MCB Prop 1.6.8 (book p. 69) for the elementary
-admissible 2-edge cut on T_a (where `numContractions = 2`). Our
-`sideward_3a_size_deltas_deltaD` proves a strict generalization
-parameterized by `numContractions c_i ∈ {1, 2}`, with
-`sideward_3a_size_deltas_deltaD_specific` (corollary via
-`numContractions_twoEdge`) recovering MCB's stated (+1, −2, −1).
+`sideward_3a_size_deltas_deletion` proves the 3(a)/Δ^d row generalized over
+`numContractions c_i`, with `..._specific` recovering MCB's stated
+(+1, −2, −1) for the 2-edge cut via `numContractions_twoEdge`.
 
-The Sideward 2(b)/Δ^c row is **the same as IM/Δ^c** for sizes — Remark
-1.6.9 (book p. 71) explicitly notes that 2(b) is indistinguishable from
-IM by sizes alone in either Δ^c or Δ^d. NCL (`InducedMapNCL`) is what
-discriminates them.
+IM/Δ^d and Sideward 2(b)/Δ^d share the (0, 0, 0) signature (**Remark 1.6.9**,
+book p. 71): indistinguishable by sizes, separated only by No Complexity Loss
+(`InducedMapNCL` / `sideward_2b_violatesInducedMapNCL` in `NoComplexityLoss.lean`).
+Sideward 3(a)/3(b) are ruled out by both forms via Δb₀ > 0.
 
-EM survives both forms unconditionally. IM/Δ^d and Sideward 2(b) produce
-identical (Δb₀, Δα, Δσ) signatures (Remark 1.6.9, book p. 71) — they are
-distinguished only by NCL (`NoComplexityLoss`). Sideward 3(a)/3(b) are
-ruled out by the strong AND weak forms via Δb₀ > 0 (`noDivergence` violation).
+## TODO
 
-## Out of scope (queued)
-
-- Full (Δα, Δσ) tables for Sideward 2(b)/3(a)/3(b) under Δ^c (need Δ^c
-  substrate; only Δ^d is implemented).
-- Sideward NCL negative direction (MCB Prop 1.6.10 negative): linglib's
-  `NCLBetween` is existential; MCB Def 1.6.2 specifies the unique induced
-  map `Φ₀ : π₀(F) → π₀(Φ(F))`. Bridging requires either strengthening
-  `NCLBetween` or adding an `InducedMapNCL` predicate.
-- Per-transformation lifting `MinimalYieldTransformation Φ := ∀ F, MinimalYield F (Φ F)`.
+Define the per-transformation lift `MinimalYieldTransformation Φ := ∀ F, MinimalYield F (Φ F)`
+(and its weak analogue); the violation theorems here are currently stated on the
+case-specific workspace shapes rather than on a `Φ`.
 -/
 
 namespace Minimalist.Merge
 
-open ConnesKreimer
+open ConnesKreimer TraceTree TraceForest
 
 variable {α β : Type*}
 
-/-- **Minimal Yield principle, weak form** (M-C-B Def 1.6.1, book p. 63
-    parenthetical: "One can consider a weaker form by only requiring the
-    two bounds on b₀ and α."). Used at p. 69 to rule out Sideward
-    3(a)/3(b) under Δ^d. Keeps `noDivergence` and `noInfoLoss`; drops the
-    `minimalYield` (σ = +1) condition that the strong form has. -/
+/-- The weak Minimal Yield principle: a forest transformation does not
+    increase `b₀` and does not decrease `α`. -/
 structure MinimalYieldWeak (F F' : TraceForest α β) : Prop where
   noDivergence  : F'.b₀ ≤ F.b₀
   noInfoLoss    : F.alpha ≤ F'.alpha
 
-/-- **Minimal Yield principle, strong form** (M-C-B Def 1.6.1, book p. 63 +
-    eq. 1.6.2). The strong form `extends` the weak form by adding the
-    third condition `σ(F') = σ(F) + 1` ("minimality of yield"). The
-    `toWeak` projection is now automatic via `MinimalYield.toMinimalYieldWeak`. -/
+/-- The Minimal Yield principle: the weak form together with `σ` increasing
+    by exactly one. -/
 structure MinimalYield (F F' : TraceForest α β) : Prop extends MinimalYieldWeak F F' where
   minimalYield  : F'.sigma = F.sigma + 1
 
-/-- Strong implies weak (auto-projection alias). -/
-abbrev MinimalYield.toWeak {F F' : TraceForest α β} (h : MinimalYield F F') :
-    MinimalYieldWeak F F' :=
-  h.toMinimalYieldWeak
+/-! ### `MinimalYieldWeak` as a Pareto pullback preorder
 
-/-! ## §0.5: `MinimalYieldWeak` as a Pareto pullback preorder
+The two `MinimalYieldWeak` bounds are a Pareto comparison on the `(b₀ᵒᵈ, α)`
+signature (`b₀` dualised so fewer components ranks higher), sharing the
+`PullbackPreorder` shape of `DerivationCost.pullbackPreorder` and
+`Core.Optimization.paretoPullbackPreorder`. The strong form is outside this
+picture: its `σ = +1` is an equality, not a ≤. -/
 
-The two `MinimalYieldWeak` conditions are exactly a Pareto comparison
-on the `(b₀ᵒᵈ, α)` signature: `noDivergence` reverses the order on `b₀`
-(smaller is "better"), `noInfoLoss` keeps `α` in the natural direction
-(larger is "better"). Wrapping the relation as a
-`Core.Order.PullbackPreorder` exposes this Pareto structure: same shape
-as `Minimalist.DerivationCost.pullbackPreorder` (4-d cost) and
-`Core.Optimization.paretoPullbackPreorder` (OT/HG
-violation profile).
-
-Reflexivity (`MYWeak F F`) and transitivity (`MYWeak F F' → MYWeak F' F'' →
-MYWeak F F''`) come for free as the underlying `Preorder.lift` instance.
-The strong form (`MinimalYield`) drops out of this picture because its
-`σ = +1` constraint is an *equality*, not a ≤; treat it as MY-Weak plus
-a separate σ-step witness. -/
-
-/-- The Pareto signature for MinimalYieldWeak: pull a forest back to
-    the `(b₀ᵒᵈ, α)` feature space. The `OrderDual` on `b₀` flips its
-    ≤ so that "smaller `b₀`" becomes "larger feature" — matching the
-    MCB sign convention where merges that reduce workspace component
-    count are preferred. -/
+/-- The Pareto signature `(b₀ᵒᵈ, α)` of a forest, with `b₀` dualised so that
+    fewer components ranks higher. -/
 def MinimalYieldSignature (F : TraceForest α β) : ℕᵒᵈ × ℕ :=
   (OrderDual.toDual F.b₀, F.alpha)
 
-/-- `MinimalYieldWeak F F'` is exactly the pullback Pareto-≤ on the
-    `(b₀ᵒᵈ, α)` signature. By `OrderDual.toDual_le_toDual := Iff.rfl`
-    and `Prod`'s componentwise preorder, this collapses to MYWeak's
-    two ≤ conditions definitionally. -/
-@[simp] theorem minimalYieldWeak_iff_signature_le {F F' : TraceForest α β} :
+/-- `MinimalYieldWeak F F'` is exactly the Pareto order on the `(b₀ᵒᵈ, α)`
+    signature. -/
+theorem minimalYieldWeak_iff_signature_le {F F' : TraceForest α β} :
     MinimalYieldWeak F F' ↔ MinimalYieldSignature F ≤ MinimalYieldSignature F' :=
   ⟨fun ⟨h_b, h_a⟩ => ⟨h_b, h_a⟩,
    fun ⟨h_b, h_a⟩ => ⟨h_b, h_a⟩⟩
 
-/-- `MinimalYieldWeak` packaged as a `Core.Order.PullbackPreorder` over
-    `TraceForest α β`, with feature space `ℕᵒᵈ × ℕ` (Pareto pullback
-    via `MinimalYieldSignature`). Same shape as
-    `Minimalist.DerivationCost.pullbackPreorder`.
-
-    Note: not registered as a `Preorder TraceForest` instance because
-    `TraceForest = Multiset` already carries other order structures
-    (multiset ⊆); use `.toPreorder` explicitly when chain reasoning is
-    needed. -/
+/-- `MinimalYieldWeak` packaged as a `Core.Order.PullbackPreorder` via
+    `MinimalYieldSignature`. Not a `Preorder TraceForest` instance:
+    `TraceForest` already carries the multiset order. -/
 def minimalYieldWeakPullbackPreorder :
     Core.Order.PullbackPreorder (TraceForest α β) (ℕᵒᵈ × ℕ) :=
   Core.Order.PullbackPreorder.ofProj MinimalYieldSignature
     (fun _ _ => inferInstance)
 
-/-! ## §1: EM Case 1 satisfies MinimalYield (MCB Prop 1.6.4 EM row)
--/
+/-! ### External Merge -/
 
-/-- **EM Case 1, F̂ = ∅** (MCB Prop 1.6.4 EM row, book p. 66). External
-    Merge of two member components `S, S'` produces the singleton
-    `{.node S S'}`. Δb₀ = −1, Δα = +2, Δσ = +1. -/
+/-- External Merge of a pair satisfies Minimal Yield: Δb₀ = −1, Δα = +2, Δσ = +1. -/
 theorem em_pair_satisfiesMinimalYield (S S' : TraceTree α β) :
     MinimalYield ({S, S'} : TraceForest α β)
                  ({.node S S'} : TraceForest α β) := by
-  have hS := S.size_pos
-  have hS' := S'.size_pos
-  refine ⟨⟨?_, ?_⟩, ?_⟩
-  · rw [TraceForest.b₀_singleton, Multiset.insert_eq_cons, TraceForest.b₀_cons,
-        TraceForest.b₀_singleton]
-    omega
-  · rw [TraceForest.alpha_singleton, TraceTree.accCount_node, Multiset.insert_eq_cons,
-        TraceForest.alpha_cons, TraceForest.alpha_singleton]
-    show TraceTree.accCount S + TraceTree.accCount S' ≤ S.size + S'.size
-    show S.size - 1 + (S'.size - 1) ≤ S.size + S'.size
-    omega
-  · rw [TraceForest.sigma_singleton, TraceTree.accCount_node, Multiset.insert_eq_cons,
-        TraceForest.sigma_cons, TraceForest.sigma_singleton]
-    show 1 + (S.size + S'.size) = 1 + TraceTree.accCount S + (1 + TraceTree.accCount S') + 1
-    show 1 + (S.size + S'.size) = 1 + (S.size - 1) + (1 + (S'.size - 1)) + 1
+  refine ⟨⟨?_, ?_⟩, ?_⟩ <;>
+    simp only [Multiset.insert_eq_cons, b₀_singleton, b₀_cons, alpha_singleton, alpha_cons,
+      accCount_merge, sigma_singleton, sigma_cons] <;>
     omega
 
-/-! ## §2: IM size deltas under Δ^d (MCB Prop 1.6.4 IM/Δ^d row)
--/
+/-! ### Internal Merge, Δ^d -/
 
-/-- **IM via composition (Δ^d)** (MCB Prop 1.6.4 IM/Δ^d row, book p. 66).
-    Under the size-conservation hypothesis `T.size = mover.size + Q.size + 1`
-    (the size analog of `cut_leafCount_conservation`), IM `{T} → {.node mover Q}`
-    preserves all three measures: Δb₀ = 0, Δα = 0, Δσ = 0.
-
-    IM under Δ^d satisfies `MinimalYieldWeak` but NOT `MinimalYield` (the
-    strong form requires Δσ = +1; under Δ^c IM gives Δσ = +1 instead).
-    See MCB Remark 1.6.6 (book p. 67) on the Δ^c vs Δ^d counting difference.
-
-    The hypothesis `h_size : T.size = mover.size + Q.size + 1` is the size
-    analog of `cut_leafCount_conservation`; `im_pair_size_deltas_deltaD_of_cut`
-    below discharges it from a single-edge cut on `T`. -/
-theorem im_pair_size_deltas_deltaD {T mover Q : TraceTree α β}
-    (h_size : T.size = mover.size + Q.size + 1) :
-    TraceForest.b₀ ({.node mover Q} : TraceForest α β)
-        = TraceForest.b₀ ({T} : TraceForest α β)
+/-- Internal Merge via composition leaves `b₀`, `α`, and `σ` unchanged (Δ^d counting). -/
+theorem im_pair_size_deltas_deletion {T mover Q : TraceTree α β}
+    (h : T.accCount = mover.accCount + Q.accCount + 2) :
+    b₀ ({.node mover Q} : TraceForest α β)
+        = b₀ ({T} : TraceForest α β)
       ∧
-    TraceForest.alpha ({.node mover Q} : TraceForest α β)
-        = TraceForest.alpha ({T} : TraceForest α β)
+    alpha ({.node mover Q} : TraceForest α β)
+        = alpha ({T} : TraceForest α β)
       ∧
-    TraceForest.sigma ({.node mover Q} : TraceForest α β)
-        = TraceForest.sigma ({T} : TraceForest α β) := by
-  refine ⟨rfl, ?_, ?_⟩
-  · rw [TraceForest.alpha_singleton, TraceForest.alpha_singleton,
-        TraceTree.accCount_node]
-    show mover.size + Q.size = T.size - 1
-    omega
-  · rw [TraceForest.sigma_singleton, TraceForest.sigma_singleton,
-        TraceTree.accCount_node]
-    show 1 + (mover.size + Q.size) = 1 + (T.size - 1)
-    omega
+    sigma ({.node mover Q} : TraceForest α β)
+        = sigma ({T} : TraceForest α β) := by
+  refine ⟨rfl, ?_, ?_⟩ <;>
+    simp only [alpha_singleton, sigma_singleton, accCount_merge, h]
 
-/-- **IM via composition (Δ^d), discharged from cut data**: drop the
-    `h_size` hypothesis from `im_pair_size_deltas_deltaD` by deriving it
-    from a single-edge cut on `T` (`c.cutForest = {mover}`,
-    `c.remainderDeletion = some Q`). Uses
-    `CutShape.singleEdgeCut_size_relation`. -/
-theorem im_pair_size_deltas_deltaD_of_cut {T mover Q : TraceTree α β}
+/-- `im_pair_size_deltas_deletion` with the size hypothesis discharged from a
+    single-edge cut. -/
+theorem im_pair_size_deltas_deletion_of_cut {T mover Q : TraceTree α β}
     (c : CutShape T) (h_cf : c.cutForest = ({mover} : TraceForest α β))
     (h_rd : c.remainderDeletion = some Q) :
-    TraceForest.b₀ ({.node mover Q} : TraceForest α β)
-        = TraceForest.b₀ ({T} : TraceForest α β)
+    b₀ ({.node mover Q} : TraceForest α β)
+        = b₀ ({T} : TraceForest α β)
       ∧
-    TraceForest.alpha ({.node mover Q} : TraceForest α β)
-        = TraceForest.alpha ({T} : TraceForest α β)
+    alpha ({.node mover Q} : TraceForest α β)
+        = alpha ({T} : TraceForest α β)
       ∧
-    TraceForest.sigma ({.node mover Q} : TraceForest α β)
-        = TraceForest.sigma ({T} : TraceForest α β) :=
-  im_pair_size_deltas_deltaD (CutShape.singleEdgeCut_size_relation c mover Q h_cf h_rd)
+    sigma ({.node mover Q} : TraceForest α β)
+        = sigma ({T} : TraceForest α β) :=
+  im_pair_size_deltas_deletion (CutShape.singleEdgeCut_deletion_alpha c mover Q h_cf h_rd)
 
-/-! ## §2.5: IM size deltas under Δ^c (MCB Prop 1.6.4 IM/Δ^c row)
--/
+/-! ### Internal Merge, Δ^c -/
 
-/-- **IM via composition (Δ^c)** (MCB Prop 1.6.4 IM/Δ^c row, book p. 66).
-    For a single-edge cut `c` on a trace-free `T` extracting `β_t`, the
-    Δ^c-IM workspace transformation `{T} → {.node β_t (T/^c β_t)}`
-    increases αᶜ and σᶜ by exactly 1: Δb₀ = 0, Δαᶜ = +1, Δσᶜ = +1.
-
-    Contrast with IM/Δ^d (`im_pair_size_deltas_deltaD`): Δ^d keeps both
-    measures at 0, while Δ^c shows the +1 increase that distinguishes IM
-    from EM in MCB's preferred (Δ^c) counting. The trace marker in T/^c β_t
-    is correctly EXCLUDED from αᶜ via `accCountC` (MCB's "cancellation of
-    the deeper copy"). -/
+/-- Internal Merge via composition leaves `b₀` fixed and raises `αᶜ` and `σᶜ`
+    by one (Δ^c counting). -/
 theorem im_pair_size_deltas_contraction [Inhabited β]
     {T β_t : TraceTree α β} (c : CutShape T)
     (h_tf : T.nonTraceSize = T.size)
     (h_cf : c.cutForest = ({β_t} : TraceForest α β)) :
-    TraceForest.b₀ ({(.node β_t c.remainder : TraceTree α β)} : TraceForest α β)
-        = TraceForest.b₀ ({T} : TraceForest α β)
+    b₀ ({(.node β_t c.remainder : TraceTree α β)} : TraceForest α β)
+        = b₀ ({T} : TraceForest α β)
       ∧
-    TraceForest.alphaC ({(.node β_t c.remainder : TraceTree α β)} : TraceForest α β)
-        = TraceForest.alphaC ({T} : TraceForest α β) + 1
+    alphaC ({(.node β_t c.remainder : TraceTree α β)} : TraceForest α β)
+        = alphaC ({T} : TraceForest α β) + 1
       ∧
-    TraceForest.sigmaC ({(.node β_t c.remainder : TraceTree α β)} : TraceForest α β)
-        = TraceForest.sigmaC ({T} : TraceForest α β) + 1 := by
-  have hβ := β_t.size_pos
-  have hT := T.size_pos
-  -- β_t is trace-free (subtree of trace-free T).
-  have h_β_tf : β_t.nonTraceSize = β_t.size := by
-    apply CutShape.nonTraceSize_eq_size_of_mem_cutForest c β_t h_tf
-    rw [h_cf]; exact Multiset.mem_singleton.mpr rfl
-  -- αᶜ on trace-free trees equals α.
-  have h_T_alphaC : T.accCountC = T.accCount := by
-    unfold TraceTree.accCountC TraceTree.accCount; rw [h_tf]
-  have h_β_alphaC : β_t.accCountC = β_t.accCount := by
-    unfold TraceTree.accCountC TraceTree.accCount; rw [h_β_tf]
-  have h_size := CutShape.cut_size_conservation_contraction c h_tf
-  rw [h_cf, TraceForest.sizeForest_singleton] at h_size
-  obtain ⟨l, r, rfl⟩ := CutShape.isNode_of_cutForest_singleton c β_t h_cf
+    sigmaC ({(.node β_t c.remainder : TraceTree α β)} : TraceForest α β)
+        = sigmaC ({T} : TraceForest α β) + 1 := by
+  have h_β_tf := CutShape.nonTraceSize_eq_size_of_cutForest_singleton c β_t h_tf h_cf
   have h_rem_pos : c.remainder.nonTraceSize ≥ 1 :=
-    CutShape.nonTraceSize_remainder_pos_of_node c
-  refine ⟨rfl, ?_, ?_⟩
-  · rw [TraceForest.alphaC_singleton, TraceForest.alphaC_singleton,
-        TraceTree.accCountC_node, h_T_alphaC, h_β_tf]
-    show β_t.size + c.remainder.nonTraceSize = (l.node r).accCount + 1
-    show β_t.size + c.remainder.nonTraceSize = (l.node r).size - 1 + 1
-    omega
-  · rw [TraceForest.sigmaC_singleton, TraceForest.sigmaC_singleton,
-        TraceTree.accCountC_node, h_T_alphaC, h_β_tf]
-    show 1 + (β_t.size + c.remainder.nonTraceSize) = 1 + (l.node r).accCount + 1
-    show 1 + (β_t.size + c.remainder.nonTraceSize) = 1 + ((l.node r).size - 1) + 1
-    omega
+    CutShape.nonTraceSize_remainder_pos_of_cutForest_singleton c β_t h_cf
+  have h_β_pos : β_t.nonTraceSize ≥ 1 := by rw [h_β_tf]; exact β_t.size_pos
+  refine ⟨rfl, ?_, ?_⟩ <;>
+    simp only [alphaC_singleton, sigmaC_singleton,
+      accCountC_merge β_t c.remainder h_β_pos h_rem_pos,
+      CutShape.singleEdgeCut_contraction_alpha c β_t h_tf h_cf]
+  omega
 
-/-! ## §3: Sideward Minimal Yield analysis (MCB Prop 1.6.8 + Remark 1.6.9)
--/
+/-! ### Sideward Merge -/
 
-/-- **Sideward 2(b)** preserves b₀ (MCB Prop 1.6.8 2(b) row, book p. 69).
-    Workspace `{T_i, T_j} → {.node T_i β, T_j/β}` retains 2 components. -/
+/-- Sideward Merge of type 2(b) leaves the component count `b₀` unchanged. -/
 theorem sideward_2b_b₀_preserved (T_i T_j Tnode T_j_q : TraceTree α β) :
-    TraceForest.b₀ ({Tnode, T_j_q} : TraceForest α β)
-      = TraceForest.b₀ ({T_i, T_j} : TraceForest α β) := by
-  rw [Multiset.insert_eq_cons, Multiset.insert_eq_cons]
-  show Multiset.card _ = Multiset.card _
-  simp only [Multiset.card_cons, Multiset.card_singleton]
+    b₀ ({Tnode, T_j_q} : TraceForest α β)
+      = b₀ ({T_i, T_j} : TraceForest α β) := by
+  simp only [Multiset.insert_eq_cons, b₀_cons, b₀_singleton]
 
-/-- **Sideward 2(b) (Δα, Δσ) deltas under size conservation** (MCB Prop 1.6.8
-    2(b)/Δ^d row, book p. 69). Under `h_size : T_j.size = β_t.size + T_j_q.size + 1`
-    (the size-conservation hypothesis on the cut producing β_t from T_j)
-    AND `h_node : Tnode.size = T_i.size + β_t.size + 1` (the merged-node size
-    relation, automatic when Tnode = .node T_i β_t), Sideward 2(b) preserves α
-    and σ:
-
-    | Measure | Before `{T_i, T_j}` | After `{Tnode, T_j_q}` | Δ |
-    |---|---|---|---|
-    | b₀ | 2 | 2 | 0 |
-    | α | (T_i.size − 1) + (T_j.size − 1) | Tnode.size − 1 + T_j_q.size − 1 | 0 |
-    | σ | 2 + α(F) | 2 + α(F) | 0 |
-
-    **Realises Remark 1.6.9 (book p. 71)**: "the Sideward Merge of type 2(b)
-    cannot be distinguished solely in terms of its effect on the sizes b₀,
-    α, and σ from Internal Merge." Both produce (0, 0, 0). NCL (`NCLBetween`)
-    is what discriminates them.
-
-    The tree variable is named `β_t` (per `Sideward.lean` convention) to
-    avoid clashing with the type-level `β : Type*` from the file's `variable`
-    declaration. MCB's notation `β` (as in eq. 1.6.7-1.6.10) corresponds. -/
-theorem sideward_2b_size_deltas_deltaD
+/-- Sideward Merge of type 2(b) leaves `b₀`, `α`, and `σ` unchanged (Δ^d counting). -/
+theorem sideward_2b_size_deltas_deletion
     {T_i T_j β_t Tnode T_j_q : TraceTree α β}
-    (h_size : T_j.size = β_t.size + T_j_q.size + 1)
-    (h_node : Tnode.size = T_i.size + β_t.size + 1) :
-    TraceForest.b₀ ({Tnode, T_j_q} : TraceForest α β)
-        = TraceForest.b₀ ({T_i, T_j} : TraceForest α β)
+    (h_T_j : T_j.accCount = β_t.accCount + T_j_q.accCount + 2)
+    (h_node : Tnode.accCount = T_i.accCount + β_t.accCount + 2) :
+    b₀ ({Tnode, T_j_q} : TraceForest α β)
+        = b₀ ({T_i, T_j} : TraceForest α β)
       ∧
-    TraceForest.alpha ({Tnode, T_j_q} : TraceForest α β)
-        = TraceForest.alpha ({T_i, T_j} : TraceForest α β)
+    alpha ({Tnode, T_j_q} : TraceForest α β)
+        = alpha ({T_i, T_j} : TraceForest α β)
       ∧
-    TraceForest.sigma ({Tnode, T_j_q} : TraceForest α β)
-        = TraceForest.sigma ({T_i, T_j} : TraceForest α β) := by
-  have hβ := β_t.size_pos
-  have hT_i := T_i.size_pos
-  have hT_j_q := T_j_q.size_pos
-  refine ⟨sideward_2b_b₀_preserved T_i T_j Tnode T_j_q, ?_, ?_⟩
-  · rw [Multiset.insert_eq_cons, Multiset.insert_eq_cons,
-        TraceForest.alpha_cons, TraceForest.alpha_cons,
-        TraceForest.alpha_singleton, TraceForest.alpha_singleton]
-    show Tnode.accCount + T_j_q.accCount = T_i.accCount + T_j.accCount
-    show Tnode.size - 1 + (T_j_q.size - 1) = T_i.size - 1 + (T_j.size - 1)
-    omega
-  · rw [Multiset.insert_eq_cons, Multiset.insert_eq_cons,
-        TraceForest.sigma_cons, TraceForest.sigma_cons,
-        TraceForest.sigma_singleton, TraceForest.sigma_singleton]
-    show 1 + Tnode.accCount + (1 + T_j_q.accCount)
-       = 1 + T_i.accCount + (1 + T_j.accCount)
-    show 1 + (Tnode.size - 1) + (1 + (T_j_q.size - 1))
-       = 1 + (T_i.size - 1) + (1 + (T_j.size - 1))
+    sigma ({Tnode, T_j_q} : TraceForest α β)
+        = sigma ({T_i, T_j} : TraceForest α β) := by
+  refine ⟨sideward_2b_b₀_preserved T_i T_j Tnode T_j_q, ?_, ?_⟩ <;>
+    simp only [Multiset.insert_eq_cons, alpha_cons, alpha_singleton, sigma_cons,
+      sigma_singleton, h_T_j, h_node] <;>
     omega
 
-/-- **Sideward 2(b) (Δα, Δσ) deltas, discharged from cut data**: drop both
-    `h_size` and `h_node` hypotheses from `sideward_2b_size_deltas_deltaD`.
-    `h_size` comes from a single-edge cut `c` on `T_j` extracting `β_t`
-    and leaving `T_j_q`; `h_node` from `Tnode = .node T_i β_t` (so
-    `size_node` gives the size relation). -/
-theorem sideward_2b_size_deltas_deltaD_of_cut
+/-- `sideward_2b_size_deltas_deletion` with both hypotheses discharged from a
+    single-edge cut. -/
+theorem sideward_2b_size_deltas_deletion_of_cut
     {T_i T_j β_t T_j_q : TraceTree α β}
     (c : CutShape T_j) (h_cf : c.cutForest = ({β_t} : TraceForest α β))
     (h_rd : c.remainderDeletion = some T_j_q) :
-    TraceForest.b₀ ({(.node T_i β_t : TraceTree α β), T_j_q} : TraceForest α β)
-        = TraceForest.b₀ ({T_i, T_j} : TraceForest α β)
+    b₀ ({(.node T_i β_t : TraceTree α β), T_j_q} : TraceForest α β)
+        = b₀ ({T_i, T_j} : TraceForest α β)
       ∧
-    TraceForest.alpha ({(.node T_i β_t : TraceTree α β), T_j_q}
+    alpha ({(.node T_i β_t : TraceTree α β), T_j_q}
                           : TraceForest α β)
-        = TraceForest.alpha ({T_i, T_j} : TraceForest α β)
+        = alpha ({T_i, T_j} : TraceForest α β)
       ∧
-    TraceForest.sigma ({(.node T_i β_t : TraceTree α β), T_j_q}
+    sigma ({(.node T_i β_t : TraceTree α β), T_j_q}
                           : TraceForest α β)
-        = TraceForest.sigma ({T_i, T_j} : TraceForest α β) := by
-  have h_size := CutShape.singleEdgeCut_size_relation c β_t T_j_q h_cf h_rd
-  have h_node : (TraceTree.node T_i β_t).size = T_i.size + β_t.size + 1 := by
-    rw [TraceTree.size_node]; omega
-  exact sideward_2b_size_deltas_deltaD h_size h_node
+        = sigma ({T_i, T_j} : TraceForest α β) :=
+  sideward_2b_size_deltas_deletion
+    (CutShape.singleEdgeCut_deletion_alpha c β_t T_j_q h_cf h_rd)
+    (accCount_merge T_i β_t)
 
-/-- **Sideward 2(b) under Δ^c** (MCB Prop 1.6.8 2(b)/Δ^c row, book p. 69).
-    `{T_i, T_j} → {.node T_i β_t, T_j/^c β_t}` for a single-edge cut on
-    trace-free `T_j` extracting `β_t`. Δb₀ = 0, Δαᶜ = +1, Δσᶜ = +1.
-
-    Like IM/Δ^c, the trace marker in the contraction-quotient is
-    excluded from `αᶜ` per MCB's Lemma 1.6.3 eq. 1.6.8. -/
+/-- Sideward Merge of type 2(b) leaves `b₀` fixed and raises `αᶜ` and `σᶜ`
+    by one (Δ^c counting). -/
 theorem sideward_2b_size_deltas_contraction [Inhabited β]
     {T_i T_j β_t : TraceTree α β}
     (c : CutShape T_j) (h_T_j_tf : T_j.nonTraceSize = T_j.size)
     (h_T_i_tf : T_i.nonTraceSize = T_i.size)
     (h_cf : c.cutForest = ({β_t} : TraceForest α β)) :
-    TraceForest.b₀ ({(.node T_i β_t : TraceTree α β), c.remainder} : TraceForest α β)
-        = TraceForest.b₀ ({T_i, T_j} : TraceForest α β)
+    b₀ ({(.node T_i β_t : TraceTree α β), c.remainder} : TraceForest α β)
+        = b₀ ({T_i, T_j} : TraceForest α β)
       ∧
-    TraceForest.alphaC ({(.node T_i β_t : TraceTree α β), c.remainder} : TraceForest α β)
-        = TraceForest.alphaC ({T_i, T_j} : TraceForest α β) + 1
+    alphaC ({(.node T_i β_t : TraceTree α β), c.remainder} : TraceForest α β)
+        = alphaC ({T_i, T_j} : TraceForest α β) + 1
       ∧
-    TraceForest.sigmaC ({(.node T_i β_t : TraceTree α β), c.remainder} : TraceForest α β)
-        = TraceForest.sigmaC ({T_i, T_j} : TraceForest α β) + 1 := by
-  have h_β_tf : β_t.nonTraceSize = β_t.size := by
-    apply CutShape.nonTraceSize_eq_size_of_mem_cutForest c β_t h_T_j_tf
-    rw [h_cf]; exact Multiset.mem_singleton.mpr rfl
-  have h_size := CutShape.cut_size_conservation_contraction c h_T_j_tf
-  rw [h_cf, TraceForest.sizeForest_singleton] at h_size
-  obtain ⟨l, r, rfl⟩ := CutShape.isNode_of_cutForest_singleton c β_t h_cf
+    sigmaC ({(.node T_i β_t : TraceTree α β), c.remainder} : TraceForest α β)
+        = sigmaC ({T_i, T_j} : TraceForest α β) + 1 := by
+  have h_β_tf := CutShape.nonTraceSize_eq_size_of_cutForest_singleton c β_t h_T_j_tf h_cf
   have h_rem_pos : c.remainder.nonTraceSize ≥ 1 :=
-    CutShape.nonTraceSize_remainder_pos_of_node c
-  have hβ := β_t.size_pos
-  have hT_i := T_i.size_pos
-  have hT_j := (l.node r).size_pos
-  refine ⟨?_, ?_, ?_⟩
-  · rw [Multiset.insert_eq_cons, Multiset.insert_eq_cons]
-    show Multiset.card _ = Multiset.card _
-    simp only [Multiset.card_cons, Multiset.card_singleton]
-  · rw [Multiset.insert_eq_cons, Multiset.insert_eq_cons,
-        TraceForest.alphaC_cons, TraceForest.alphaC_cons,
-        TraceForest.alphaC_singleton, TraceForest.alphaC_singleton,
-        TraceTree.accCountC_node]
-    have h_T_i_C : T_i.accCountC = T_i.accCount := by
-      unfold TraceTree.accCountC TraceTree.accCount; rw [h_T_i_tf]
-    have h_T_j_C : (l.node r).accCountC = (l.node r).accCount := by
-      unfold TraceTree.accCountC TraceTree.accCount; rw [h_T_j_tf]
-    have h_T_i_acc : T_i.accCount = T_i.size - 1 := rfl
-    have h_T_j_acc : (l.node r).accCount = (l.node r).size - 1 := rfl
-    have h_rem_acc : c.remainder.accCountC = c.remainder.nonTraceSize - 1 := rfl
-    rw [h_β_tf, h_T_i_C, h_T_j_C]
-    show T_i.nonTraceSize + β_t.size + c.remainder.accCountC
-       = T_i.accCount + (l.node r).accCount + 1
-    rw [h_T_i_tf, h_T_i_acc, h_T_j_acc, h_rem_acc]
-    omega
-  · rw [Multiset.insert_eq_cons, Multiset.insert_eq_cons,
-        TraceForest.sigmaC_cons, TraceForest.sigmaC_cons,
-        TraceForest.sigmaC_singleton, TraceForest.sigmaC_singleton,
-        TraceTree.accCountC_node]
-    have h_T_i_C : T_i.accCountC = T_i.accCount := by
-      unfold TraceTree.accCountC TraceTree.accCount; rw [h_T_i_tf]
-    have h_T_j_C : (l.node r).accCountC = (l.node r).accCount := by
-      unfold TraceTree.accCountC TraceTree.accCount; rw [h_T_j_tf]
-    have h_T_i_acc : T_i.accCount = T_i.size - 1 := rfl
-    have h_T_j_acc : (l.node r).accCount = (l.node r).size - 1 := rfl
-    have h_rem_acc : c.remainder.accCountC = c.remainder.nonTraceSize - 1 := rfl
-    rw [h_β_tf, h_T_i_C, h_T_j_C]
-    show 1 + (T_i.nonTraceSize + β_t.size) + (1 + c.remainder.accCountC)
-       = 1 + T_i.accCount + (1 + (l.node r).accCount) + 1
-    rw [h_T_i_tf, h_T_i_acc, h_T_j_acc, h_rem_acc]
+    CutShape.nonTraceSize_remainder_pos_of_cutForest_singleton c β_t h_cf
+  have h_β_pos : β_t.nonTraceSize ≥ 1 := by rw [h_β_tf]; exact β_t.size_pos
+  have h_T_i_pos : T_i.nonTraceSize ≥ 1 := by rw [h_T_i_tf]; exact T_i.size_pos
+  refine ⟨sideward_2b_b₀_preserved T_i T_j _ c.remainder, ?_, ?_⟩ <;>
+    simp only [Multiset.insert_eq_cons, alphaC_cons, alphaC_singleton, sigmaC_cons,
+      sigmaC_singleton, accCountC_merge T_i β_t h_T_i_pos h_β_pos,
+      CutShape.singleEdgeCut_contraction_alpha c β_t h_T_j_tf h_cf] <;>
     omega
 
-/-- **Sideward 3(a) increases b₀ by 1** (MCB Prop 1.6.8 3(a) row, book p. 69).
-    Workspace `{T_i} → {.node α β, T_i/(α⊔β)}`: 1 component becomes 2. -/
+/-- Sideward Merge of type 3(a) increases the component count `b₀` by one. -/
 theorem sideward_3a_b₀_increases (T_i Tnode T_iq : TraceTree α β) :
-    TraceForest.b₀ ({Tnode, T_iq} : TraceForest α β)
-      = TraceForest.b₀ ({T_i} : TraceForest α β) + 1 := by
-  rw [Multiset.insert_eq_cons, TraceForest.b₀_cons, TraceForest.b₀_singleton,
-      TraceForest.b₀_singleton]
+    b₀ ({Tnode, T_iq} : TraceForest α β)
+      = b₀ ({T_i} : TraceForest α β) + 1 := by
+  simp only [Multiset.insert_eq_cons, b₀_cons, b₀_singleton]
 
-/-- **Sideward 3(b) increases b₀ by 1** (MCB Prop 1.6.8 3(b) row, book p. 69).
-    Workspace `{T_i, T_j} → {.node α β, T_i/α, T_j/β}`: 2 components become 3. -/
+/-- Sideward Merge of type 3(b) increases the component count `b₀` by one. -/
 theorem sideward_3b_b₀_increases
     (T_i T_j Tnode T_iq T_jq : TraceTree α β) :
-    TraceForest.b₀ ({Tnode, T_iq, T_jq} : TraceForest α β)
-      = TraceForest.b₀ ({T_i, T_j} : TraceForest α β) + 1 := by
-  show Multiset.card _ = Multiset.card _ + 1
-  rw [show ({Tnode, T_iq, T_jq} : TraceForest α β)
-        = Tnode ::ₘ T_iq ::ₘ ({T_jq} : TraceForest α β) from rfl,
-      Multiset.insert_eq_cons]
-  simp only [Multiset.card_cons, Multiset.card_singleton]
+    b₀ ({Tnode, T_iq, T_jq} : TraceForest α β)
+      = b₀ ({T_i, T_j} : TraceForest α β) + 1 := by
+  simp only [Multiset.insert_eq_cons, b₀_cons, b₀_singleton]
 
-/-- **Sideward 3(b) full (Δb₀, Δα, Δσ) under Δ^d** (MCB Prop 1.6.8 3(b) row,
-    book p. 69 — full table). Workspace `{T_i, T_j} → {.node a b, T_iq, T_jq}`
-    where `T_iq` is the deletion-quotient of a single-edge cut on `T_i`
-    extracting `a`, and similarly for `T_jq` from `T_j` extracting `b`.
-
-    | Measure | Before | After | Δ |
-    |---|---|---|---|
-    | b₀ | 2 | 3 | +1 |
-    | α  | (T_i.size − 1) + (T_j.size − 1) | (.node a b).size − 1 + (T_iq − 1) + (T_jq − 1) | −2 |
-    | σ  | 2 + α(F) | 3 + α(F) − 2 | −1 |
-
-    Δb₀ = +1 alone rules out Sideward 3(b) (`sideward_3b_violates_noDivergenceWeak`);
-    here we record the full numerical signature for Remark 1.6.9-style
-    discrimination. -/
-theorem sideward_3b_size_deltas_deltaD
+/-- Sideward Merge of type 3(b): Δb₀ = +1, Δα = −2, Δσ = −1 (Δ^d counting). -/
+theorem sideward_3b_size_deltas_deletion
     {T_i T_j a b T_iq T_jq : TraceTree α β}
-    (h_i : T_i.size = a.size + T_iq.size + 1)
-    (h_j : T_j.size = b.size + T_jq.size + 1) :
-    TraceForest.b₀ ({(.node a b : TraceTree α β), T_iq, T_jq} : TraceForest α β)
-        = TraceForest.b₀ ({T_i, T_j} : TraceForest α β) + 1
+    (h_i : T_i.accCount = a.accCount + T_iq.accCount + 2)
+    (h_j : T_j.accCount = b.accCount + T_jq.accCount + 2) :
+    b₀ ({(.node a b : TraceTree α β), T_iq, T_jq} : TraceForest α β)
+        = b₀ ({T_i, T_j} : TraceForest α β) + 1
       ∧
-    TraceForest.alpha ({(.node a b : TraceTree α β), T_iq, T_jq}
+    alpha ({(.node a b : TraceTree α β), T_iq, T_jq}
                           : TraceForest α β) + 2
-        = TraceForest.alpha ({T_i, T_j} : TraceForest α β)
+        = alpha ({T_i, T_j} : TraceForest α β)
       ∧
-    TraceForest.sigma ({(.node a b : TraceTree α β), T_iq, T_jq}
+    sigma ({(.node a b : TraceTree α β), T_iq, T_jq}
                           : TraceForest α β) + 1
-        = TraceForest.sigma ({T_i, T_j} : TraceForest α β) := by
-  have hT_i := T_i.size_pos
-  have hT_j := T_j.size_pos
-  have hT_iq := T_iq.size_pos
-  have hT_jq := T_jq.size_pos
-  have ha := a.size_pos
-  have hb := b.size_pos
-  -- Triple {x, y, z} for Multiset: definitionally x ::ₘ y ::ₘ {z}.
-  have h_triple : ({(.node a b : TraceTree α β), T_iq, T_jq} : TraceForest α β)
-                  = (.node a b) ::ₘ T_iq ::ₘ ({T_jq} : TraceForest α β) := rfl
-  refine ⟨sideward_3b_b₀_increases T_i T_j _ T_iq T_jq, ?_, ?_⟩
-  · -- α delta: α(F') + 2 = α(F)
-    rw [h_triple, Multiset.insert_eq_cons,
-        TraceForest.alpha_cons, TraceForest.alpha_cons,
-        TraceForest.alpha_cons, TraceForest.alpha_singleton,
-        TraceForest.alpha_singleton, TraceTree.accCount_node]
-    show a.size + b.size + (T_iq.accCount + (T_jq.accCount + 0)) + 2
-         = T_i.accCount + (T_j.accCount + 0)
-    show a.size + b.size + ((T_iq.size - 1) + ((T_jq.size - 1) + 0)) + 2
-         = (T_i.size - 1) + ((T_j.size - 1) + 0)
-    omega
-  · -- σ delta: σ(F') + 1 = σ(F)
-    rw [h_triple, Multiset.insert_eq_cons,
-        TraceForest.sigma_cons, TraceForest.sigma_cons,
-        TraceForest.sigma_cons, TraceForest.sigma_singleton,
-        TraceForest.sigma_singleton, TraceTree.accCount_node]
-    show 1 + (a.size + b.size) + (1 + T_iq.accCount + (1 + T_jq.accCount)) + 1
-         = 1 + T_i.accCount + (1 + T_j.accCount)
-    show 1 + (a.size + b.size) + (1 + (T_iq.size - 1) + (1 + (T_jq.size - 1))) + 1
-         = 1 + (T_i.size - 1) + (1 + (T_j.size - 1))
+        = sigma ({T_i, T_j} : TraceForest α β) := by
+  refine ⟨sideward_3b_b₀_increases T_i T_j _ T_iq T_jq, ?_, ?_⟩ <;>
+    simp only [Multiset.insert_eq_cons, alpha_cons, alpha_singleton, sigma_cons,
+      sigma_singleton, accCount_merge, h_i, h_j] <;>
     omega
 
-/-- **Sideward 3(b) full deltas, discharged from cut data**: drop both
-    `h_i` and `h_j` size hypotheses by deriving them from single-edge cuts
-    `c_i` on `T_i` and `c_j` on `T_j`. -/
-theorem sideward_3b_size_deltas_deltaD_of_cut
+/-- `sideward_3b_size_deltas_deletion` with both size hypotheses discharged from
+    single-edge cuts. -/
+theorem sideward_3b_size_deltas_deletion_of_cut
     {T_i T_j a b T_iq T_jq : TraceTree α β}
     (c_i : CutShape T_i) (h_cf_i : c_i.cutForest = ({a} : TraceForest α β))
     (h_rd_i : c_i.remainderDeletion = some T_iq)
     (c_j : CutShape T_j) (h_cf_j : c_j.cutForest = ({b} : TraceForest α β))
     (h_rd_j : c_j.remainderDeletion = some T_jq) :
-    TraceForest.b₀ ({(.node a b : TraceTree α β), T_iq, T_jq} : TraceForest α β)
-        = TraceForest.b₀ ({T_i, T_j} : TraceForest α β) + 1
+    b₀ ({(.node a b : TraceTree α β), T_iq, T_jq} : TraceForest α β)
+        = b₀ ({T_i, T_j} : TraceForest α β) + 1
       ∧
-    TraceForest.alpha ({(.node a b : TraceTree α β), T_iq, T_jq}
+    alpha ({(.node a b : TraceTree α β), T_iq, T_jq}
                           : TraceForest α β) + 2
-        = TraceForest.alpha ({T_i, T_j} : TraceForest α β)
+        = alpha ({T_i, T_j} : TraceForest α β)
       ∧
-    TraceForest.sigma ({(.node a b : TraceTree α β), T_iq, T_jq}
+    sigma ({(.node a b : TraceTree α β), T_iq, T_jq}
                           : TraceForest α β) + 1
-        = TraceForest.sigma ({T_i, T_j} : TraceForest α β) :=
-  sideward_3b_size_deltas_deltaD
-    (CutShape.singleEdgeCut_size_relation c_i a T_iq h_cf_i h_rd_i)
-    (CutShape.singleEdgeCut_size_relation c_j b T_jq h_cf_j h_rd_j)
+        = sigma ({T_i, T_j} : TraceForest α β) :=
+  sideward_3b_size_deltas_deletion
+    (CutShape.singleEdgeCut_deletion_alpha c_i a T_iq h_cf_i h_rd_i)
+    (CutShape.singleEdgeCut_deletion_alpha c_j b T_jq h_cf_j h_rd_j)
 
 /-! ### Sideward 3(a): two-edge cut full deltas -/
 
-/-- **Sideward 3(a) full (Δb₀, Δα, Δσ) under Δ^d** (MCB Prop 1.6.8 3(a) row,
-    book p. 69 — full table, parameterized by contraction count).
-
-    Workspace `{T_i} → {.node a b, T_iq}` where `T_iq` is the deletion-
-    quotient of a TWO-edge cut `c_i` on `T_i` extracting both `a` and `b`.
-
-    The cut's `numContractions c_i` depends on the relative position of
-    the two extracted subtrees in `T_i`:
-    - 1 contraction if a, b are siblings (single `.bothCut`)
-    - 2+ contractions otherwise (the two cut paths each contract a parent)
-
-    Hence Δα and Δσ "vary" per MCB's prose, but the variation is captured
-    by `numContractions c_i`:
-
-    | Measure | Before | After | Δ |
-    |---|---|---|---|
-    | b₀ | 1 | 2 | +1 |
-    | α  | T_i.size − 1 | (a + b) + (T_iq − 1) | −numContractions c_i |
-    | σ  | T_i.size | 1 + a + b + T_iq | 1 − numContractions c_i |
-
-    Δb₀ = +1 alone rules out 3(a) (`sideward_3a_violates_noDivergenceWeak`);
-    here we record the full numerical signature parameterized by the
-    cut's contraction count, derivable from `cut_size_conservation`. -/
-theorem sideward_3a_size_deltas_deltaD
+/-- Sideward Merge of type 3(a): Δb₀ = +1, with Δα and Δσ governed by the
+    cut's contraction count `numContractions c_i` (Δ^d counting). -/
+theorem sideward_3a_size_deltas_deletion
     {T_i a b T_iq : TraceTree α β} (c_i : CutShape T_i)
     (h_cf : c_i.cutForest = ({a, b} : TraceForest α β))
     (h_rd : c_i.remainderDeletion = some T_iq) :
-    TraceForest.b₀ ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
-        = TraceForest.b₀ ({T_i} : TraceForest α β) + 1
+    b₀ ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
+        = b₀ ({T_i} : TraceForest α β) + 1
       ∧
-    TraceForest.alpha ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
+    alpha ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
         + CutShape.numContractions c_i
-        = TraceForest.alpha ({T_i} : TraceForest α β)
+        = alpha ({T_i} : TraceForest α β)
       ∧
-    TraceForest.sigma ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
+    sigma ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
         + CutShape.numContractions c_i
-        = TraceForest.sigma ({T_i} : TraceForest α β) + 1 := by
-  -- T_i.size = a.size + b.size + T_iq.size + numContractions c_i
-  have h_size := CutShape.cut_size_conservation c_i
-  rw [h_cf, h_rd, TraceForest.sizeForest_pair] at h_size
-  simp only [Option.elim] at h_size
-  have ha := a.size_pos
-  have hb := b.size_pos
-  have hT_iq := T_iq.size_pos
-  refine ⟨sideward_3a_b₀_increases T_i _ T_iq, ?_, ?_⟩
-  · -- α delta
-    rw [Multiset.insert_eq_cons,
-        TraceForest.alpha_cons, TraceForest.alpha_singleton,
-        TraceForest.alpha_singleton, TraceTree.accCount_node]
-    show a.size + b.size + T_iq.accCount + CutShape.numContractions c_i
-         = T_i.accCount
-    show a.size + b.size + (T_iq.size - 1) + CutShape.numContractions c_i
-         = T_i.size - 1
-    omega
-  · -- σ delta
-    rw [Multiset.insert_eq_cons,
-        TraceForest.sigma_cons, TraceForest.sigma_singleton,
-        TraceForest.sigma_singleton, TraceTree.accCount_node]
-    show 1 + (a.size + b.size) + (1 + T_iq.accCount) + CutShape.numContractions c_i
-         = 1 + T_i.accCount + 1
-    show 1 + (a.size + b.size) + (1 + (T_iq.size - 1)) + CutShape.numContractions c_i
-         = 1 + (T_i.size - 1) + 1
+        = sigma ({T_i} : TraceForest α β) + 1 := by
+  have h := CutShape.pairCut_deletion_alpha c_i a b T_iq h_cf h_rd
+  refine ⟨sideward_3a_b₀_increases T_i _ T_iq, ?_, ?_⟩ <;>
+    simp only [Multiset.insert_eq_cons, alpha_cons, alpha_singleton, sigma_cons,
+      sigma_singleton, accCount_merge, h] <;>
     omega
 
-/-- **Sideward 3(a), MCB-specific (+1, −2, −1) form** (Prop 1.6.8 3(a)/Δ^d
-    row, book p. 69 — table form). MCB's proof (book p. 70) restricts to
-    a genuine 2-edge cut leaving a non-trivial deletion-quotient `T_iq`;
-    in that setting `numContractions c_i = 2` always (sibling extractions
-    pass through `.bothCut` collapsing the parent → 1 contraction;
-    separated paths give 2 contractions; either way for the hypothesis
-    `cutForest.card = 2 ∧ remainderDeletion = some _` we get exactly 2,
-    by `numContractions_twoEdge`). -/
-theorem sideward_3a_size_deltas_deltaD_specific
+/-- `sideward_3a_size_deltas_deletion` for a genuine 2-edge cut: Δb₀ = +1,
+    Δα = −2, Δσ = −1 (the contraction count is `2`). -/
+theorem sideward_3a_size_deltas_deletion_specific
     {T_i a b T_iq : TraceTree α β} (c_i : CutShape T_i)
     (h_cf : c_i.cutForest = ({a, b} : TraceForest α β))
     (h_rd : c_i.remainderDeletion = some T_iq) :
-    TraceForest.b₀ ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
-        = TraceForest.b₀ ({T_i} : TraceForest α β) + 1
+    b₀ ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
+        = b₀ ({T_i} : TraceForest α β) + 1
       ∧
-    TraceForest.alpha ({(.node a b : TraceTree α β), T_iq} : TraceForest α β) + 2
-        = TraceForest.alpha ({T_i} : TraceForest α β)
+    alpha ({(.node a b : TraceTree α β), T_iq} : TraceForest α β) + 2
+        = alpha ({T_i} : TraceForest α β)
       ∧
-    TraceForest.sigma ({(.node a b : TraceTree α β), T_iq} : TraceForest α β) + 1
-        = TraceForest.sigma ({T_i} : TraceForest α β) := by
+    sigma ({(.node a b : TraceTree α β), T_iq} : TraceForest α β) + 1
+        = sigma ({T_i} : TraceForest α β) := by
   have h_card : c_i.cutForest.card = 2 := by
     rw [h_cf, show ({a, b} : TraceForest α β) = a ::ₘ ({b} : TraceForest α β) from rfl,
         Multiset.card_cons, Multiset.card_singleton]
   have h_nc := CutShape.numContractions_twoEdge c_i T_iq h_card h_rd
-  have ⟨h_b₀, h_α, h_σ⟩ := sideward_3a_size_deltas_deltaD c_i h_cf h_rd
+  have ⟨h_b₀, h_α, h_σ⟩ := sideward_3a_size_deltas_deletion c_i h_cf h_rd
   rw [h_nc] at h_α h_σ
   refine ⟨h_b₀, h_α, ?_⟩
   omega
 
-/-- **Sideward 3(a) under Δ^c** (MCB Prop 1.6.8 3(a)/Δ^c row, book p. 69).
-    For a 2-edge cut on trace-free `T_i` extracting `a` and `b`:
-    Δb₀ = +1, Δαᶜ = 0, Δσᶜ = +1. (Δb₀ = +1 still rules out 3(a) under
-    Minimal Yield even with Δ^c counting.) -/
+/-- Sideward Merge of type 3(a): Δb₀ = +1, Δαᶜ = 0, Δσᶜ = +1 (Δ^c counting). -/
 theorem sideward_3a_size_deltas_contraction [Inhabited β]
     {T_i a b : TraceTree α β} (c_i : CutShape T_i)
     (h_T_i_tf : T_i.nonTraceSize = T_i.size)
     (h_cf : c_i.cutForest = ({a, b} : TraceForest α β)) :
-    TraceForest.b₀ ({(.node a b : TraceTree α β), c_i.remainder} : TraceForest α β)
-        = TraceForest.b₀ ({T_i} : TraceForest α β) + 1
+    b₀ ({(.node a b : TraceTree α β), c_i.remainder} : TraceForest α β)
+        = b₀ ({T_i} : TraceForest α β) + 1
       ∧
-    TraceForest.alphaC ({(.node a b : TraceTree α β), c_i.remainder} : TraceForest α β)
-        = TraceForest.alphaC ({T_i} : TraceForest α β)
+    alphaC ({(.node a b : TraceTree α β), c_i.remainder} : TraceForest α β)
+        = alphaC ({T_i} : TraceForest α β)
       ∧
-    TraceForest.sigmaC ({(.node a b : TraceTree α β), c_i.remainder} : TraceForest α β)
-        = TraceForest.sigmaC ({T_i} : TraceForest α β) + 1 := by
+    sigmaC ({(.node a b : TraceTree α β), c_i.remainder} : TraceForest α β)
+        = sigmaC ({T_i} : TraceForest α β) + 1 := by
   have h_a_tf : a.nonTraceSize = a.size := by
     apply CutShape.nonTraceSize_eq_size_of_mem_cutForest c_i a h_T_i_tf
     rw [h_cf]; exact Multiset.mem_cons_self _ _
@@ -653,17 +356,6 @@ theorem sideward_3a_size_deltas_contraction [Inhabited β]
     rw [show ({a, b} : TraceForest α β) = a ::ₘ ({b} : TraceForest α β) from rfl,
         Multiset.mem_cons]
     right; exact Multiset.mem_singleton.mpr rfl
-  have h_size := CutShape.cut_size_conservation_contraction c_i h_T_i_tf
-  rw [h_cf, TraceForest.sizeForest_pair] at h_size
-  have ha := a.size_pos
-  have hb := b.size_pos
-  have hT_i := T_i.size_pos
-  have h_a_acc : a.accCount = a.size - 1 := rfl
-  have h_b_acc : b.accCount = b.size - 1 := rfl
-  have h_T_i_acc : T_i.accCount = T_i.size - 1 := rfl
-  have h_T_i_C : T_i.accCountC = T_i.accCount := by
-    unfold TraceTree.accCountC TraceTree.accCount; rw [h_T_i_tf]
-  have h_rem_acc : c_i.remainder.accCountC = c_i.remainder.nonTraceSize - 1 := rfl
   have h_rem_pos : c_i.remainder.nonTraceSize ≥ 1 := by
     cases T_i with
     | leaf _ =>
@@ -675,152 +367,82 @@ theorem sideward_3a_size_deltas_contraction [Inhabited β]
         have : a ∈ ({a, b} : TraceForest α β) := Multiset.mem_cons_self _ _
         rw [← h_cf] at this; exact absurd this (Multiset.notMem_zero _)
     | node _ _ => exact CutShape.nonTraceSize_remainder_pos_of_node c_i
-  refine ⟨sideward_3a_b₀_increases T_i _ c_i.remainder, ?_, ?_⟩
-  · rw [Multiset.insert_eq_cons,
-        TraceForest.alphaC_cons, TraceForest.alphaC_singleton,
-        TraceForest.alphaC_singleton, TraceTree.accCountC_node, h_T_i_C, h_a_tf, h_b_tf,
-        h_T_i_acc, h_rem_acc]
-    omega
-  · rw [Multiset.insert_eq_cons,
-        TraceForest.sigmaC_cons, TraceForest.sigmaC_singleton,
-        TraceForest.sigmaC_singleton, TraceTree.accCountC_node, h_T_i_C, h_a_tf, h_b_tf,
-        h_T_i_acc, h_rem_acc]
+  have h_a_pos : a.nonTraceSize ≥ 1 := by rw [h_a_tf]; exact a.size_pos
+  have h_b_pos : b.nonTraceSize ≥ 1 := by rw [h_b_tf]; exact b.size_pos
+  refine ⟨sideward_3a_b₀_increases T_i _ c_i.remainder, ?_, ?_⟩ <;>
+    simp only [Multiset.insert_eq_cons, alphaC_cons, alphaC_singleton, sigmaC_cons,
+      sigmaC_singleton, accCountC_merge a b h_a_pos h_b_pos,
+      CutShape.pairCut_contraction_alpha c_i a b h_T_i_tf h_cf h_rem_pos] <;>
     omega
 
-/-- **Sideward 3(b) under Δ^c** (MCB Prop 1.6.8 3(b)/Δ^c row, book p. 69).
-    For single-edge cuts `c_i` on trace-free `T_i` extracting `a` and
-    `c_j` on trace-free `T_j` extracting `b`:
-    Δb₀ = +1, Δαᶜ = 0, Δσᶜ = +1. -/
+/-- Sideward Merge of type 3(b): Δb₀ = +1, Δαᶜ = 0, Δσᶜ = +1 (Δ^c counting). -/
 theorem sideward_3b_size_deltas_contraction [Inhabited β]
     {T_i T_j a b : TraceTree α β}
     (c_i : CutShape T_i) (h_T_i_tf : T_i.nonTraceSize = T_i.size)
     (h_cf_i : c_i.cutForest = ({a} : TraceForest α β))
     (c_j : CutShape T_j) (h_T_j_tf : T_j.nonTraceSize = T_j.size)
     (h_cf_j : c_j.cutForest = ({b} : TraceForest α β)) :
-    TraceForest.b₀ ({(.node a b : TraceTree α β), c_i.remainder, c_j.remainder}
+    b₀ ({(.node a b : TraceTree α β), c_i.remainder, c_j.remainder}
                        : TraceForest α β)
-        = TraceForest.b₀ ({T_i, T_j} : TraceForest α β) + 1
+        = b₀ ({T_i, T_j} : TraceForest α β) + 1
       ∧
-    TraceForest.alphaC ({(.node a b : TraceTree α β), c_i.remainder, c_j.remainder}
+    alphaC ({(.node a b : TraceTree α β), c_i.remainder, c_j.remainder}
                           : TraceForest α β)
-        = TraceForest.alphaC ({T_i, T_j} : TraceForest α β)
+        = alphaC ({T_i, T_j} : TraceForest α β)
       ∧
-    TraceForest.sigmaC ({(.node a b : TraceTree α β), c_i.remainder, c_j.remainder}
+    sigmaC ({(.node a b : TraceTree α β), c_i.remainder, c_j.remainder}
                           : TraceForest α β)
-        = TraceForest.sigmaC ({T_i, T_j} : TraceForest α β) + 1 := by
-  have h_a_tf : a.nonTraceSize = a.size := by
-    apply CutShape.nonTraceSize_eq_size_of_mem_cutForest c_i a h_T_i_tf
-    rw [h_cf_i]; exact Multiset.mem_singleton.mpr rfl
-  have h_b_tf : b.nonTraceSize = b.size := by
-    apply CutShape.nonTraceSize_eq_size_of_mem_cutForest c_j b h_T_j_tf
-    rw [h_cf_j]; exact Multiset.mem_singleton.mpr rfl
-  have h_size_i := CutShape.cut_size_conservation_contraction c_i h_T_i_tf
-  rw [h_cf_i, TraceForest.sizeForest_singleton] at h_size_i
-  have h_size_j := CutShape.cut_size_conservation_contraction c_j h_T_j_tf
-  rw [h_cf_j, TraceForest.sizeForest_singleton] at h_size_j
-  have ha := a.size_pos
-  have hb := b.size_pos
-  have hT_i := T_i.size_pos
-  have hT_j := T_j.size_pos
-  have h_T_i_C : T_i.accCountC = T_i.accCount := by
-    unfold TraceTree.accCountC TraceTree.accCount; rw [h_T_i_tf]
-  have h_T_j_C : T_j.accCountC = T_j.accCount := by
-    unfold TraceTree.accCountC TraceTree.accCount; rw [h_T_j_tf]
-  have h_T_i_acc : T_i.accCount = T_i.size - 1 := rfl
-  have h_T_j_acc : T_j.accCount = T_j.size - 1 := rfl
-  have h_rem_i_acc : c_i.remainder.accCountC = c_i.remainder.nonTraceSize - 1 := rfl
-  have h_rem_j_acc : c_j.remainder.accCountC = c_j.remainder.nonTraceSize - 1 := rfl
-  have h_triple : ({(.node a b : TraceTree α β), c_i.remainder, c_j.remainder}
-                       : TraceForest α β)
-                = (.node a b) ::ₘ c_i.remainder
-                              ::ₘ ({c_j.remainder} : TraceForest α β) := rfl
-  have h_rem_i_pos : c_i.remainder.nonTraceSize ≥ 1 :=
-    CutShape.nonTraceSize_remainder_pos_of_cutForest_singleton c_i a h_cf_i
-  have h_rem_j_pos : c_j.remainder.nonTraceSize ≥ 1 :=
-    CutShape.nonTraceSize_remainder_pos_of_cutForest_singleton c_j b h_cf_j
-  refine ⟨sideward_3b_b₀_increases _ _ _ c_i.remainder c_j.remainder, ?_, ?_⟩
-  · rw [h_triple, Multiset.insert_eq_cons,
-        TraceForest.alphaC_cons, TraceForest.alphaC_cons,
-        TraceForest.alphaC_cons, TraceForest.alphaC_singleton,
-        TraceForest.alphaC_singleton,
-        TraceTree.accCountC_node, h_T_i_C, h_T_j_C, h_a_tf, h_b_tf]
-    show a.size + b.size + (c_i.remainder.accCountC + (c_j.remainder.accCountC + 0))
-       = T_i.accCount + (T_j.accCount + 0)
-    rw [h_rem_i_acc, h_rem_j_acc, h_T_i_acc, h_T_j_acc]
-    omega
-  · rw [h_triple, Multiset.insert_eq_cons,
-        TraceForest.sigmaC_cons, TraceForest.sigmaC_cons,
-        TraceForest.sigmaC_cons, TraceForest.sigmaC_singleton,
-        TraceForest.sigmaC_singleton,
-        TraceTree.accCountC_node, h_T_i_C, h_T_j_C, h_a_tf, h_b_tf]
-    show 1 + (a.size + b.size) + (1 + c_i.remainder.accCountC
-                                     + (1 + c_j.remainder.accCountC + 0))
-       = 1 + T_i.accCount + (1 + T_j.accCount + 0) + 1
-    rw [h_rem_i_acc, h_rem_j_acc, h_T_i_acc, h_T_j_acc]
+        = sigmaC ({T_i, T_j} : TraceForest α β) + 1 := by
+  have h_a_tf := CutShape.nonTraceSize_eq_size_of_cutForest_singleton c_i a h_T_i_tf h_cf_i
+  have h_b_tf := CutShape.nonTraceSize_eq_size_of_cutForest_singleton c_j b h_T_j_tf h_cf_j
+  have h_a_pos : a.nonTraceSize ≥ 1 := by rw [h_a_tf]; exact a.size_pos
+  have h_b_pos : b.nonTraceSize ≥ 1 := by rw [h_b_tf]; exact b.size_pos
+  refine ⟨sideward_3b_b₀_increases _ _ _ c_i.remainder c_j.remainder, ?_, ?_⟩ <;>
+    simp only [Multiset.insert_eq_cons, alphaC_cons, alphaC_singleton, sigmaC_cons,
+      sigmaC_singleton, accCountC_merge a b h_a_pos h_b_pos,
+      CutShape.singleEdgeCut_contraction_alpha c_i a h_T_i_tf h_cf_i,
+      CutShape.singleEdgeCut_contraction_alpha c_j b h_T_j_tf h_cf_j] <;>
     omega
 
-/-- **Sideward 3(a) violates `MinimalYieldWeak.noDivergence`** (a fortiori
-    violates the strong form). Δb₀ = +1 rules out Sideward 3(a) under
-    either form. -/
+/-- Sideward Merge of type 3(a) violates the weak Minimal Yield principle, since
+    `b₀` increases. -/
 theorem sideward_3a_violates_noDivergenceWeak
     (T_i Tnode T_iq : TraceTree α β) :
     ¬ MinimalYieldWeak ({T_i} : TraceForest α β)
                        ({Tnode, T_iq} : TraceForest α β) := by
   intro h
-  have h_b₀ := h.noDivergence
-  have h_F  : TraceForest.b₀ ({T_i} : TraceForest α β) = 1 :=
-    TraceForest.b₀_singleton _
-  have h_F' : TraceForest.b₀ ({Tnode, T_iq} : TraceForest α β) = 2 :=
-    (sideward_3a_b₀_increases T_i Tnode T_iq).trans (by rw [h_F])
-  rw [h_F, h_F'] at h_b₀
+  have hd := h.noDivergence
+  rw [sideward_3a_b₀_increases T_i Tnode T_iq] at hd
   omega
 
-/-- **Sideward 3(b) violates `MinimalYieldWeak.noDivergence`** (a fortiori
-    violates the strong form). Δb₀ = +1 rules out Sideward 3(b). -/
+/-- Sideward Merge of type 3(b) violates the weak Minimal Yield principle, since
+    `b₀` increases. -/
 theorem sideward_3b_violates_noDivergenceWeak
     (T_i T_j Tnode T_iq T_jq : TraceTree α β) :
     ¬ MinimalYieldWeak ({T_i, T_j} : TraceForest α β)
                        ({Tnode, T_iq, T_jq} : TraceForest α β) := by
   intro h
-  have h_b₀ := h.noDivergence
-  have h_F : TraceForest.b₀ ({T_i, T_j} : TraceForest α β) = 2 := by
-    rw [Multiset.insert_eq_cons]
-    show Multiset.card _ = 2
-    simp only [Multiset.card_cons, Multiset.card_singleton]
-  have h_F' : TraceForest.b₀ ({Tnode, T_iq, T_jq} : TraceForest α β) = 3 :=
-    (sideward_3b_b₀_increases T_i T_j Tnode T_iq T_jq).trans (by rw [h_F])
-  rw [h_F, h_F'] at h_b₀
+  have hd := h.noDivergence
+  rw [sideward_3b_b₀_increases T_i T_j Tnode T_iq T_jq] at hd
   omega
 
 /-- Strong-form corollary of `sideward_3a_violates_noDivergenceWeak`. -/
 theorem sideward_3a_violates_noDivergence (T_i Tnode T_iq : TraceTree α β) :
     ¬ MinimalYield ({T_i} : TraceForest α β)
                    ({Tnode, T_iq} : TraceForest α β) :=
-  fun h => sideward_3a_violates_noDivergenceWeak T_i Tnode T_iq h.toWeak
+  fun h => sideward_3a_violates_noDivergenceWeak T_i Tnode T_iq h.toMinimalYieldWeak
 
 /-- Strong-form corollary of `sideward_3b_violates_noDivergenceWeak`. -/
 theorem sideward_3b_violates_noDivergence
     (T_i T_j Tnode T_iq T_jq : TraceTree α β) :
     ¬ MinimalYield ({T_i, T_j} : TraceForest α β)
                    ({Tnode, T_iq, T_jq} : TraceForest α β) :=
-  fun h => sideward_3b_violates_noDivergenceWeak T_i T_j Tnode T_iq T_jq h.toWeak
+  fun h => sideward_3b_violates_noDivergenceWeak T_i T_j Tnode T_iq T_jq h.toMinimalYieldWeak
 
-/-! ## §4: Unit-merge violation (MCB Remark 1.6.7, book p. 67)
--/
+/-! ### Unit merge -/
 
-/-- **M_{S,1} alone violates MinimalYield** (MCB Remark 1.6.7, book p. 67).
-    The unit-merge stage of IM via composition transforms `{T} → {β, T/β}`
-    (extracting an accessible term β from T, leaving the deletion-quotient
-    Q = T/β as the other component). Δb₀ = +1 violates `noDivergence`.
-
-    MCB's argument: this shows M_{S,1} cannot occur **standalone** as a
-    Merge operation — it can occur only in the composition
-    `M_{β, T/β} ∘ M_{β, 1}` that gives Internal Merge (Prop 1.4.2). The
-    "virtual particles" caveat in `Internal.lean §4` corresponds to this
-    same observation.
-
-    Proof: structurally identical to `sideward_3a_b₀_increases` —
-    `{T} → {β, T/β}` is one-component-in, two-components-out. -/
+/-- The unit-merge stage `{T} → {β, T/β}` violates the weak Minimal Yield
+    principle, since `b₀` increases. -/
 theorem unitMerge_violates_noDivergenceWeak (T β_t Q : TraceTree α β) :
     ¬ MinimalYieldWeak ({T} : TraceForest α β)
                        ({β_t, Q} : TraceForest α β) :=


### PR DESCRIPTION
Re-grounds the Minimal Yield size-delta theorems on MCB's additive α/αᶜ counting identities (Lemma 1.6.3) instead of a `size`/`nonTraceSize` bridge, mirroring how the book's Prop 1.6.4/1.6.8 proofs compute. Adds the missing 1.6.7/1.6.8 identities (single- and pair-edge forms) to the rooted-tree substrate and drops the redundant σ-forms (σ = b₀ + α). Net −332 lines.