### PR TITLE
feat(Core/Combinatorics/RootedTree): MCB counting layer on Nonplanar

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1866,6 +1866,8 @@ import Linglib.Core.Combinatorics.RootedTree.Subtypes
 import Linglib.Core.Combinatorics.RootedTree.PlanarCut
 import Linglib.Core.Combinatorics.RootedTree.Nonplanar
 import Linglib.Core.Combinatorics.RootedTree.Nonplanar.Insertion
+import Linglib.Core.Combinatorics.RootedTree.Counting
+import Linglib.Core.Combinatorics.RootedTree.TraceCounting
 import Linglib.Core.Algebra.RootedTree.ConnesKreimer
 import Linglib.Core.Algebra.RootedTree.Coproduct.Defs
 import Linglib.Core.Algebra.RootedTree.Coproduct.Pruning

--- a/Linglib/Core/Combinatorics/RootedTree/Counting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Counting.lean
@@ -1,37 +1,50 @@
+import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 import Linglib.Core.Combinatorics.RootedTree.Nonplanar
 
 /-!
-# Size counting on nonplanar rooted trees
+# Size counting on nonplanar rooted trees and workspaces
 
 The MCB size measures for syntactic-object combinatorics
 ([marcolli-chomsky-berwick-2025]), on the canonical `Nonplanar` carrier.
-These permutation-invariant counts build directly on the lifted
-`Nonplanar.weight`; the legacy planar `Decorated`/`AdmissibleCut` substrate
-provided the same measures over the unfaithful planar-binary `TraceTree`.
+A *workspace* (forest) is a `Multiset (Nonplanar α)`; MCB foregrounds the
+measures `b₀`/`α`/`σ` on workspaces (eq. 1.6.1), with a single tree as the
+one-component case. The tree-level `accCount` is the recursive primitive that
+`α` folds over.
+
+These build directly on the lifted `Nonplanar.weight` (= MCB's `#V`); the
+legacy planar `Decorated`/`AdmissibleCut` substrate provided the same measures
+over the unfaithful planar-binary `TraceTree`.
 
 ## Main definitions
 
-* `Nonplanar.accCount` — accessible-term count `α(T) = #V(T) - 1`.
+* `Nonplanar.accCount` — accessible-term count `α(T) = #V(T) - 1` (tree primitive).
+* `Forest.b₀` — number of component trees (Betti number).
+* `Forest.alpha` — total accessible terms `α(F) = Σ α(Tᵢ)`.
+* `Forest.sigma` — workspace size `σ(F) = b₀(F) + α(F)`.
 
 ## Main results
 
-* `Nonplanar.accCount_merge` — external Merge `M(T_v, T_w)` adds two accessible
-  terms (MCB Lemma 1.6.3, eq. 1.6.5).
+* `Nonplanar.accCount_merge` — external Merge adds two accessible terms (eq. 1.6.5).
+* `Forest.sigma_eq_sum_weight` — `σ(F) = #V(F)` (eq. 1.2.6); unconditional on the
+  generic carrier (no trace leaves). The contraction-quotient exception
+  (`σᶜ ≠ #V`, MCB p.66) lives in `TraceCounting`.
 
 ## TODO
 
-* Forest measures `b₀`/`alpha`/`sigma` on `Multiset (Nonplanar α)`.
-* Trace-aware `nonTraceSize`/`accCountC` on `Nonplanar (α ⊕ β)` (contraction count).
-* The admissible-cut layer (`Fintype`-enumerable cuts + conservation lemmas).
+* `leafCount` (complexity grading `#L`, Def 1.6.2) — needs `Planar.leafCount` + lift.
+* Trace-aware `accCountC`/`alphaC`/`sigmaC` on `Nonplanar (α ⊕ β)` (`TraceCounting.lean`).
+* The admissible-cut layer (`Fintype`-enumerable cuts + extraction identities 1.6.7/1.6.8).
 -/
 
-namespace RootedTree.Nonplanar
+namespace RootedTree
+
+namespace Nonplanar
 
 variable {α : Type*}
 
-/-- The **accessible-term count** `α(T) = #V(T) - 1`: the number of proper
-subterms of a syntactic object. -/
-def accCount (t : Nonplanar α) : Nat := t.weight - 1
+/-- The **accessible-term count** `α(T) = #V(T) - 1`: every vertex of a
+syntactic object except its root (MCB eq. 1.2.5). -/
+def accCount (t : Nonplanar α) : ℕ := t.weight - 1
 
 @[simp] theorem accCount_leaf (a : α) : (leaf a : Nonplanar α).accCount = 0 := by
   simp only [accCount, weight_leaf]
@@ -48,4 +61,68 @@ theorem accCount_merge (a : α) (l r : Nonplanar α) :
     Multiset.sum_cons, Multiset.map_singleton, Multiset.sum_singleton]
   omega
 
-end RootedTree.Nonplanar
+end Nonplanar
+
+/-! ## Workspace (forest) measures
+
+A workspace is a `Multiset (Nonplanar α)`. MCB's primitive workspace measures
+are `b₀` (component count) and `α` (accessible terms); `σ` is derived. -/
+
+namespace Forest
+
+variable {α : Type*}
+
+/-- The number of component trees in a workspace — MCB's `b₀`, the Betti
+number `b₀(F) = #I` (eq. 1.6.1). -/
+def b₀ (F : Multiset (Nonplanar α)) : ℕ := Multiset.card F
+
+@[simp] theorem b₀_zero : b₀ (0 : Multiset (Nonplanar α)) = 0 := Multiset.card_zero
+@[simp] theorem b₀_cons (T : Nonplanar α) (F : Multiset (Nonplanar α)) :
+    b₀ (T ::ₘ F) = b₀ F + 1 := Multiset.card_cons T F
+@[simp] theorem b₀_singleton (T : Nonplanar α) :
+    b₀ ({T} : Multiset (Nonplanar α)) = 1 := Multiset.card_singleton T
+@[simp] theorem b₀_add (F G : Multiset (Nonplanar α)) :
+    b₀ (F + G) = b₀ F + b₀ G := Multiset.card_add F G
+
+/-- Total accessible terms across the workspace, `α(F) = Σ α(Tᵢ)` (eq. 1.2.4). -/
+def alpha (F : Multiset (Nonplanar α)) : ℕ := (F.map Nonplanar.accCount).sum
+
+@[simp] theorem alpha_zero : alpha (0 : Multiset (Nonplanar α)) = 0 := rfl
+@[simp] theorem alpha_cons (T : Nonplanar α) (F : Multiset (Nonplanar α)) :
+    alpha (T ::ₘ F) = T.accCount + alpha F := by
+  simp only [alpha, Multiset.map_cons, Multiset.sum_cons]
+@[simp] theorem alpha_singleton (T : Nonplanar α) :
+    alpha ({T} : Multiset (Nonplanar α)) = T.accCount := by
+  simp only [alpha, Multiset.map_singleton, Multiset.sum_singleton]
+@[simp] theorem alpha_add (F G : Multiset (Nonplanar α)) :
+    alpha (F + G) = alpha F + alpha G := by
+  simp only [alpha, Multiset.map_add, Multiset.sum_add]
+
+/-- Workspace size `σ(F) = b₀(F) + α(F)` (MCB eq. 1.6.1): components plus
+accessible terms. For trace-free workspaces this is the total vertex count
+(`sigma_eq_sum_weight`); it is *not* the vertex count for contraction quotients
+(a trace leaf is a vertex but not an accessible term, MCB p.66). -/
+def sigma (F : Multiset (Nonplanar α)) : ℕ := b₀ F + alpha F
+
+@[simp] theorem sigma_zero : sigma (0 : Multiset (Nonplanar α)) = 0 := rfl
+@[simp] theorem sigma_cons (T : Nonplanar α) (F : Multiset (Nonplanar α)) :
+    sigma (T ::ₘ F) = T.weight + sigma F := by
+  have hT := T.weight_pos
+  simp only [sigma, b₀_cons, alpha_cons, Nonplanar.accCount_eq_weight_sub_one]
+  omega
+@[simp] theorem sigma_add (F G : Multiset (Nonplanar α)) :
+    sigma (F + G) = sigma F + sigma G := by
+  simp only [sigma, b₀_add, alpha_add]; omega
+
+/-- `σ(F) = #V(F)`, the total vertex count (MCB eq. 1.2.6). Unconditional on the
+generic carrier, where every `accCount` is `weight − 1`; the contraction-quotient
+exception lives in `TraceCounting`. -/
+theorem sigma_eq_sum_weight (F : Multiset (Nonplanar α)) :
+    sigma F = (F.map Nonplanar.weight).sum := by
+  induction F using Multiset.induction with
+  | empty => rfl
+  | cons T F ih => rw [sigma_cons, ih, Multiset.map_cons, Multiset.sum_cons]
+
+end Forest
+
+end RootedTree

--- a/Linglib/Core/Combinatorics/RootedTree/Counting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Counting.lean
@@ -31,8 +31,9 @@ over the unfaithful planar-binary `TraceTree`.
 
 ## TODO
 
-* `leafCount` (complexity grading `#L`, Def 1.6.2) — needs `Planar.leafCount` + lift.
-* Trace-aware `accCountC`/`alphaC`/`sigmaC` on `Nonplanar (α ⊕ β)` (`TraceCounting.lean`).
+* Trace-aware `accCountC`/`alphaC`/`sigmaC` and the complexity grading `#L`
+  on lexical leaves (`leafCountSO0`) over `Nonplanar (α ⊕ β)` (`TraceCounting.lean`);
+  builds on the carrier `Nonplanar.leafCount`.
 * The admissible-cut layer (`Fintype`-enumerable cuts + extraction identities 1.6.7/1.6.8).
 -/
 

--- a/Linglib/Core/Combinatorics/RootedTree/Counting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Counting.lean
@@ -1,0 +1,51 @@
+import Linglib.Core.Combinatorics.RootedTree.Nonplanar
+
+/-!
+# Size counting on nonplanar rooted trees
+
+The MCB size measures for syntactic-object combinatorics
+([marcolli-chomsky-berwick-2025]), on the canonical `Nonplanar` carrier.
+These permutation-invariant counts build directly on the lifted
+`Nonplanar.weight`; the legacy planar `Decorated`/`AdmissibleCut` substrate
+provided the same measures over the unfaithful planar-binary `TraceTree`.
+
+## Main definitions
+
+* `Nonplanar.accCount` — accessible-term count `α(T) = #V(T) - 1`.
+
+## Main results
+
+* `Nonplanar.accCount_merge` — external Merge `M(T_v, T_w)` adds two accessible
+  terms (MCB Lemma 1.6.3, eq. 1.6.5).
+
+## TODO
+
+* Forest measures `b₀`/`alpha`/`sigma` on `Multiset (Nonplanar α)`.
+* Trace-aware `nonTraceSize`/`accCountC` on `Nonplanar (α ⊕ β)` (contraction count).
+* The admissible-cut layer (`Fintype`-enumerable cuts + conservation lemmas).
+-/
+
+namespace RootedTree.Nonplanar
+
+variable {α : Type*}
+
+/-- The **accessible-term count** `α(T) = #V(T) - 1`: the number of proper
+subterms of a syntactic object. -/
+def accCount (t : Nonplanar α) : Nat := t.weight - 1
+
+@[simp] theorem accCount_leaf (a : α) : (leaf a : Nonplanar α).accCount = 0 := by
+  simp only [accCount, weight_leaf]
+
+theorem accCount_eq_weight_sub_one (t : Nonplanar α) : t.accCount = t.weight - 1 := rfl
+
+/-- External Merge of two syntactic objects adds exactly two accessible terms
+(MCB Lemma 1.6.3, eq. 1.6.5). -/
+theorem accCount_merge (a : α) (l r : Nonplanar α) :
+    (node a {l, r}).accCount = l.accCount + r.accCount + 2 := by
+  have hl := l.weight_pos
+  have hr := r.weight_pos
+  simp only [accCount, weight_node, Multiset.insert_eq_cons, Multiset.map_cons,
+    Multiset.sum_cons, Multiset.map_singleton, Multiset.sum_singleton]
+  omega
+
+end RootedTree.Nonplanar

--- a/Linglib/Core/Combinatorics/RootedTree/Nonplanar.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Nonplanar.lean
@@ -174,6 +174,58 @@ theorem weight_planarEquiv {t s : Planar α} (h : PlanarEquiv t s) :
   | symm _ _ _ ih => exact ih.symm
   | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
 
+/-! #### Leaf-count invariance -/
+
+/-- Leaf count is invariant under children-list permutation: `leafCountList`
+    is a sum, hence permutation-invariant. -/
+private theorem leafCountList_perm (cs ds : List (Planar α))
+    (h : List.Perm cs ds) :
+    leafCountList cs = leafCountList ds := by
+  induction h with
+  | nil => rfl
+  | cons _ _ ih =>
+    show leafCount _ + leafCountList _ = leafCount _ + leafCountList _
+    rw [ih]
+  | swap _ _ _ =>
+    show leafCount _ + (leafCount _ + leafCountList _)
+       = leafCount _ + (leafCount _ + leafCountList _)
+    omega
+  | trans _ _ ih1 ih2 => exact ih1.trans ih2
+
+/-- Leaf count is invariant under `PlanarStep`. -/
+private theorem leafCount_planarStep {t s : Planar α} (h : PlanarStep t s) :
+    t.leafCount = s.leafCount := by
+  induction h with
+  | swapAtRoot =>
+    rename_i a l r pre post
+    rw [leafCount_node_of_ne_nil a (pre ++ l :: r :: post) (by simp),
+        leafCount_node_of_ne_nil a (pre ++ r :: l :: post) (by simp)]
+    apply leafCountList_perm
+    apply List.Perm.append_left
+    exact .swap r l post
+  | recurse _ ih =>
+    rename_i a pre old new post _hstep
+    rw [leafCount_node_of_ne_nil a (pre ++ old :: post) (by simp),
+        leafCount_node_of_ne_nil a (pre ++ new :: post) (by simp)]
+    induction pre with
+    | nil =>
+      show leafCount old + leafCountList post = leafCount new + leafCountList post
+      rw [ih]
+    | cons head tail ih_pre =>
+      simp only [List.cons_append]
+      show leafCount head + leafCountList (tail ++ old :: post)
+         = leafCount head + leafCountList (tail ++ new :: post)
+      rw [ih_pre]
+
+/-- Leaf count is invariant under `PlanarEquiv`. -/
+theorem leafCount_planarEquiv {t s : Planar α} (h : PlanarEquiv t s) :
+    t.leafCount = s.leafCount := by
+  induction h with
+  | rel _ _ hstep => exact leafCount_planarStep hstep
+  | refl _ => rfl
+  | symm _ _ _ ih => exact ih.symm
+  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+
 /-! #### Label invariance -/
 
 /-- The root label is preserved by every `PlanarStep`. -/
@@ -459,6 +511,16 @@ def weight : Nonplanar α → Nat :=
 @[simp] theorem weight_leaf (a : α) : (leaf a : Nonplanar α).weight = 1 := by
   show (Planar.leaf a).weight = 1
   unfold Planar.leaf Planar.weight Planar.weightList; rfl
+
+/-- The **leaf count** (number of childless vertices) of a nonplanar tree,
+    lifted from `Planar.leafCount` via `PlanarEquiv`-invariance. MCB's
+    complexity grading `#L` (Def. 1.6.2) is built on this. -/
+def leafCount : Nonplanar α → Nat :=
+  Nonplanar.lift Planar.leafCount (fun _ _ h => Planar.leafCount_planarEquiv h)
+
+@[simp] theorem leafCount_mk (t : Planar α) : (mk t).leafCount = t.leafCount := rfl
+
+@[simp] theorem leafCount_leaf (a : α) : (leaf a : Nonplanar α).leafCount = 1 := rfl
 
 /-- The **arity** (root child count) of a nonplanar tree. -/
 def arity : Nonplanar α → Nat :=
@@ -755,6 +817,13 @@ theorem map_map (f : α → β) (g : β → γ) (t : Nonplanar α) :
   intro p
   show (map f (mk p)).isLeaf = (mk p).isLeaf
   rw [map_mk, isLeaf_mk, isLeaf_mk, Planar.isLeaf_map]
+
+@[simp] theorem leafCount_map (f : α → β) (t : Nonplanar α) :
+    (map f t).leafCount = t.leafCount := by
+  refine Quotient.inductionOn t ?_
+  intro p
+  show (map f (mk p)).leafCount = (mk p).leafCount
+  rw [map_mk, leafCount_mk, leafCount_mk, Planar.leafCount_map]
 
 end Nonplanar
 

--- a/Linglib/Core/Combinatorics/RootedTree/Planar.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Planar.lean
@@ -136,6 +136,36 @@ def isLeaf : Planar α → Bool
 @[simp] theorem isLeaf_node_cons (a : α) (c : Planar α) (cs : List (Planar α)) :
     Planar.isLeaf (Planar.node a (c :: cs)) = false := rfl
 
+mutual
+/-- The **leaf count** of a tree: number of childless vertices. A leaf
+    (`node _ []`) counts as `1`; an internal node delegates to its
+    children (whose empty-list sum is `0`, so it is not double-counted). -/
+def leafCount : Planar α → Nat
+  | .node _ []        => 1
+  | .node _ (c :: cs) => leafCountList (c :: cs)
+/-- Auxiliary: total leaf count across a list of trees. -/
+def leafCountList : List (Planar α) → Nat
+  | []      => 0
+  | t :: ts => leafCount t + leafCountList ts
+end
+
+@[simp] theorem leafCount_node_nil (a : α) :
+    Planar.leafCount (Planar.node a [] : Planar α) = 1 := rfl
+
+@[simp] theorem leafCountList_nil :
+    Planar.leafCountList ([] : List (Planar α)) = 0 := rfl
+
+@[simp] theorem leafCountList_cons (t : Planar α) (ts : List (Planar α)) :
+    Planar.leafCountList (t :: ts) = leafCount t + leafCountList ts := rfl
+
+/-- On a non-leaf node, `leafCount` is the `leafCountList` of its children.
+    Clears the empty/nonempty split in the `leafCount` definition. -/
+theorem leafCount_node_of_ne_nil (a : α) (L : List (Planar α)) (h : L ≠ []) :
+    Planar.leafCount (Planar.node a L) = leafCountList L := by
+  cases L with
+  | nil => contradiction
+  | cons c cs => rfl
+
 /-! ## §4: Smart constructors -/
 
 /-- A **leaf** with the given α-label. -/
@@ -271,6 +301,25 @@ end
     | nil => rfl
     | cons _ _ => rfl
 
+mutual
+@[simp] theorem leafCount_map {β : Type*} (f : α → β) :
+    ∀ (t : Planar α), (map f t).leafCount = t.leafCount
+  | .node _ [] => by rw [map_node]; rfl
+  | .node a (c :: cs) => by
+    rw [map_node, mapList_cons]
+    show leafCountList (map f c :: mapList f cs) = leafCountList (c :: cs)
+    rw [leafCountList_cons, leafCountList_cons, leafCount_map f c,
+      leafCountList_mapList f cs]
+theorem leafCountList_mapList {β : Type*} (f : α → β) :
+    ∀ (cs : List (Planar α)), leafCountList (mapList f cs) = leafCountList cs
+  | [] => by rfl
+  | c :: cs => by
+    rw [mapList_cons]
+    show leafCount (map f c) + leafCountList (mapList f cs)
+       = leafCount c + leafCountList cs
+    rw [leafCount_map f c, leafCountList_mapList f cs]
+end
+
 /-! ## §5b: Sanity tests at compile time -/
 
 example : Planar.weight (leaf 1 : Planar Nat) = 1 := by
@@ -280,11 +329,14 @@ example : Planar.depth (leaf 1 : Planar Nat) = 1 := by
   unfold leaf depth depthMaxList; rfl
 example : Planar.isLeaf (leaf 1 : Planar Nat) = true := rfl
 
+example : Planar.leafCount (leaf 1 : Planar Nat) = 1 := rfl
+
 example : Planar.weight (binary 1 (leaf 2) (leaf 3) : Planar Nat) = 3 := by
   unfold binary leaf weight weightList; rfl
 example : Planar.arity (binary 1 (leaf 2) (leaf 3) : Planar Nat) = 2 := rfl
 example : Planar.depth (binary 1 (leaf 2) (leaf 3) : Planar Nat) = 2 := by
   unfold binary leaf depth depthMaxList; rfl
+example : Planar.leafCount (binary 1 (leaf 2) (leaf 3) : Planar Nat) = 2 := rfl
 
 /-! ## §6: Inhabited -/
 

--- a/Linglib/Core/Combinatorics/RootedTree/TraceCounting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/TraceCounting.lean
@@ -1,0 +1,236 @@
+import Linglib.Core.Combinatorics.RootedTree.Counting
+
+/-!
+# Trace-aware size counting on `Nonplanar (α ⊕ β)`
+[marcolli-chomsky-berwick-2025]
+
+The MCB size measures specialized to the **contraction-quotient carrier**
+`Nonplanar (α ⊕ β)`, where `Sum.inl` vertices carry original lexical
+decorations and `Sum.inr` vertices are trace-marker placeholders left by
+the Δ^c coproduct (a trace leaf is `node (Sum.inr b) []`, the encoding of
+`Coproduct.Trace.traceLeaf`). A trace leaf is a vertex but **not** an
+accessible term: it is excluded from `Acc`, so the trace-aware counts
+subtract it off the generic carrier measures.
+
+The key consequence is the failure of the clean trace-free identity
+`σ = #V`: for a contraction quotient `σᶜ ≠ #V` (MCB p. 66 caveat), because
+a trace leaf inflates `#V` without contributing an accessible term.
+
+## Main definitions
+
+* `Nonplanar.traceLeafCount` — number of `Sum.inr`-labeled leaves.
+* `Nonplanar.accCountC` — trace-excluding accessible-term count `α − #traceLeaves`.
+* `Nonplanar.leafCountSO0` — complexity grading `#L` on lexical leaves only.
+* `Forest.alphaC` / `Forest.sigmaC` — the trace-aware workspace measures.
+-/
+
+namespace RootedTree
+
+namespace Planar
+
+variable {α β : Type*}
+
+/-! ### `traceLeafCount` — counting trace-marker leaves
+
+A trace marker is a `Sum.inr`-labeled vertex (always a leaf in practice).
+Defined by structural recursion mirroring `leafCount`, with the leaf base
+case split on the label's `Sum`-side. -/
+
+mutual
+/-- The number of `Sum.inr`-labeled leaves (trace markers) in a tree. -/
+def traceLeafCount : Planar (α ⊕ β) → Nat
+  | .node (Sum.inr _) []        => 1
+  | .node (Sum.inr _) (c :: cs) => traceLeafCountList (c :: cs)
+  | .node (Sum.inl _) cs        => traceLeafCountList cs
+/-- Auxiliary: total trace-leaf count across a list of trees. -/
+def traceLeafCountList : List (Planar (α ⊕ β)) → Nat
+  | []      => 0
+  | t :: ts => traceLeafCount t + traceLeafCountList ts
+end
+
+@[simp] theorem traceLeafCount_inr_nil (b : β) :
+    traceLeafCount (Planar.node (Sum.inr b) [] : Planar (α ⊕ β)) = 1 := rfl
+
+@[simp] theorem traceLeafCount_inr_cons (b : β) (c : Planar (α ⊕ β))
+    (cs : List (Planar (α ⊕ β))) :
+    traceLeafCount (Planar.node (Sum.inr b) (c :: cs)) =
+      traceLeafCountList (c :: cs) := rfl
+
+@[simp] theorem traceLeafCount_inl (a : α) (cs : List (Planar (α ⊕ β))) :
+    traceLeafCount (Planar.node (Sum.inl a) cs) = traceLeafCountList cs := rfl
+
+@[simp] theorem traceLeafCountList_nil :
+    traceLeafCountList ([] : List (Planar (α ⊕ β))) = 0 := rfl
+
+@[simp] theorem traceLeafCountList_cons (t : Planar (α ⊕ β))
+    (ts : List (Planar (α ⊕ β))) :
+    traceLeafCountList (t :: ts) = traceLeafCount t + traceLeafCountList ts := rfl
+
+/-- On a non-leaf node, `traceLeafCount` is the `traceLeafCountList` of its
+    children, regardless of the root label's `Sum`-side. Clears the
+    empty/nonempty split. -/
+theorem traceLeafCount_node_of_ne_nil (a : α ⊕ β) (L : List (Planar (α ⊕ β)))
+    (h : L ≠ []) : traceLeafCount (Planar.node a L) = traceLeafCountList L := by
+  cases a with
+  | inl x => rfl
+  | inr y =>
+    cases L with
+    | nil => contradiction
+    | cons c cs => rfl
+
+/-! #### Trace-leaf-count invariance under `PlanarEquiv` -/
+
+private theorem traceLeafCountList_perm (cs ds : List (Planar (α ⊕ β)))
+    (h : List.Perm cs ds) : traceLeafCountList cs = traceLeafCountList ds := by
+  induction h with
+  | nil => rfl
+  | cons _ _ ih =>
+    show traceLeafCount _ + traceLeafCountList _
+       = traceLeafCount _ + traceLeafCountList _
+    rw [ih]
+  | swap _ _ _ =>
+    show traceLeafCount _ + (traceLeafCount _ + traceLeafCountList _)
+       = traceLeafCount _ + (traceLeafCount _ + traceLeafCountList _)
+    omega
+  | trans _ _ ih1 ih2 => exact ih1.trans ih2
+
+private theorem traceLeafCount_planarStep {t s : Planar (α ⊕ β)}
+    (h : PlanarStep t s) : t.traceLeafCount = s.traceLeafCount := by
+  induction h with
+  | swapAtRoot =>
+    rename_i a l r pre post
+    rw [traceLeafCount_node_of_ne_nil a (pre ++ l :: r :: post) (by simp),
+        traceLeafCount_node_of_ne_nil a (pre ++ r :: l :: post) (by simp)]
+    apply traceLeafCountList_perm
+    apply List.Perm.append_left
+    exact .swap r l post
+  | recurse _ ih =>
+    rename_i a pre old new post _hstep
+    rw [traceLeafCount_node_of_ne_nil a (pre ++ old :: post) (by simp),
+        traceLeafCount_node_of_ne_nil a (pre ++ new :: post) (by simp)]
+    induction pre with
+    | nil =>
+      show traceLeafCount old + traceLeafCountList post
+         = traceLeafCount new + traceLeafCountList post
+      rw [ih]
+    | cons head tail ih_pre =>
+      simp only [List.cons_append]
+      show traceLeafCount head + traceLeafCountList (tail ++ old :: post)
+         = traceLeafCount head + traceLeafCountList (tail ++ new :: post)
+      rw [ih_pre]
+
+theorem traceLeafCount_planarEquiv {t s : Planar (α ⊕ β)}
+    (h : PlanarEquiv t s) : t.traceLeafCount = s.traceLeafCount := by
+  induction h with
+  | rel _ _ hstep => exact traceLeafCount_planarStep hstep
+  | refl _ => rfl
+  | symm _ _ _ ih => exact ih.symm
+  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+
+end Planar
+
+namespace Nonplanar
+
+variable {α β : Type*}
+
+/-- The number of `Sum.inr`-labeled (trace-marker) leaves of a nonplanar
+    tree, lifted from `Planar.traceLeafCount`. -/
+def traceLeafCount : Nonplanar (α ⊕ β) → Nat :=
+  Nonplanar.lift Planar.traceLeafCount
+    (fun _ _ h => Planar.traceLeafCount_planarEquiv h)
+
+@[simp] theorem traceLeafCount_mk (t : Planar (α ⊕ β)) :
+    (mk t).traceLeafCount = t.traceLeafCount := rfl
+
+@[simp] theorem traceLeafCount_leaf_inl (a : α) :
+    (leaf (Sum.inl a) : Nonplanar (α ⊕ β)).traceLeafCount = 0 := rfl
+
+@[simp] theorem traceLeafCount_leaf_inr (b : β) :
+    (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).traceLeafCount = 1 := rfl
+
+/-- The **trace-excluding accessible-term count** `αᶜ(T) = α(T) − #traceLeaves(T)`:
+    a trace leaf is a vertex but not an accessible term (MCB p. 66). Truncated
+    subtraction handles the all-trace edge case (e.g. `T = traceLeaf b`, where
+    `α = 0` and `#traceLeaves = 1`). -/
+def accCountC (t : Nonplanar (α ⊕ β)) : ℕ := t.accCount - t.traceLeafCount
+
+/-- The **complexity grading** `#L` restricted to lexical leaves:
+    `#L_{SO₀}(T) = #L(T) − #traceLeaves(T)`. The trace-exclusion follows the
+    UNVERIFIED-default reading of MCB Remark 1.2.2 (leaves labeled by `SO₀`);
+    whether a trace leaf counts in `#L` is not settled in the book. -/
+def leafCountSO0 (t : Nonplanar (α ⊕ β)) : ℕ := t.leafCount - t.traceLeafCount
+
+end Nonplanar
+
+/-! ## Trace-aware workspace (forest) measures -/
+
+namespace Forest
+
+variable {α β : Type*}
+
+/-- Trace-excluding accessible terms across a workspace, `αᶜ(F) = Σ αᶜ(Tᵢ)`. -/
+def alphaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ :=
+  (F.map Nonplanar.accCountC).sum
+
+@[simp] theorem alphaC_zero : alphaC (0 : Multiset (Nonplanar (α ⊕ β))) = 0 := rfl
+@[simp] theorem alphaC_cons (T : Nonplanar (α ⊕ β))
+    (F : Multiset (Nonplanar (α ⊕ β))) :
+    alphaC (T ::ₘ F) = T.accCountC + alphaC F := by
+  simp only [alphaC, Multiset.map_cons, Multiset.sum_cons]
+@[simp] theorem alphaC_singleton (T : Nonplanar (α ⊕ β)) :
+    alphaC ({T} : Multiset (Nonplanar (α ⊕ β))) = T.accCountC := by
+  simp only [alphaC, Multiset.map_singleton, Multiset.sum_singleton]
+@[simp] theorem alphaC_add (F G : Multiset (Nonplanar (α ⊕ β))) :
+    alphaC (F + G) = alphaC F + alphaC G := by
+  simp only [alphaC, Multiset.map_add, Multiset.sum_add]
+
+/-- Trace-aware workspace size `σᶜ(F) = b₀(F) + αᶜ(F)`. Unlike the generic
+    `σ`, this is **not** the vertex count for contraction quotients
+    (`σᶜ ≠ #V`, MCB p. 66): a trace leaf is a vertex but not an accessible
+    term, so it raises `#V` without raising `σᶜ`. -/
+def sigmaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ := b₀ F + alphaC F
+
+@[simp] theorem sigmaC_zero : sigmaC (0 : Multiset (Nonplanar (α ⊕ β))) = 0 := rfl
+@[simp] theorem sigmaC_cons (T : Nonplanar (α ⊕ β))
+    (F : Multiset (Nonplanar (α ⊕ β))) :
+    sigmaC (T ::ₘ F) = T.accCountC + 1 + sigmaC F := by
+  simp only [sigmaC, b₀_cons, alphaC_cons]; omega
+@[simp] theorem sigmaC_add (F G : Multiset (Nonplanar (α ⊕ β))) :
+    sigmaC (F + G) = sigmaC F + sigmaC G := by
+  simp only [sigmaC, b₀_add, alphaC_add]; omega
+
+end Forest
+
+/-! ### The `σᶜ ≠ #V` caveat, concretely
+
+A lexical root over a single trace leaf: `#V = 2` (root + trace leaf) but the
+trace leaf contributes no accessible term, so `αᶜ = 0` and `σᶜ = 1`. -/
+
+namespace Nonplanar
+
+variable {α β : Type*}
+
+/-- Minimal contraction-quotient witness for the `σᶜ ≠ #V` caveat. -/
+private def traceWitness (a : α) (b : β) : Nonplanar (α ⊕ β) :=
+  Nonplanar.mk (.node (Sum.inl a) [.node (Sum.inr b) []])
+
+example (a : α) (b : β) : (traceWitness a b).weight = 2 := rfl
+example (a : α) (b : β) : (traceWitness a b).traceLeafCount = 1 := rfl
+example (a : α) (b : β) : (traceWitness a b).accCountC = 0 := rfl
+example (a : α) (b : β) : (traceWitness a b).leafCountSO0 = 0 := rfl
+
+/-- `σᶜ` undercounts `#V` on the contraction quotient: the trace leaf is a
+    vertex but not an accessible term. -/
+example (a : α) (b : β) :
+    Forest.sigmaC ({traceWitness a b} : Multiset (Nonplanar (α ⊕ β))) ≠
+      (({traceWitness a b} : Multiset (Nonplanar (α ⊕ β))).map
+        Nonplanar.weight).sum := by
+  simp only [Forest.sigmaC, Forest.b₀_singleton, Forest.alphaC_singleton,
+    Multiset.map_singleton, Multiset.sum_singleton,
+    show (traceWitness a b).accCountC = 0 from rfl,
+    show (traceWitness a b).weight = 2 from rfl]
+  decide
+
+end Nonplanar
+
+end RootedTree


### PR DESCRIPTION
MCB syntactic-object size measures on the canonical `Nonplanar` carrier (`accCount`, `leafCount`, forest `b₀`/`α`/`σ`, the external-Merge `+2` identity, and trace-aware `accCountC`/`σᶜ` on `Nonplanar (α ⊕ β)` with the `σᶜ ≠ #V` contraction-quotient caveat), replacing the legacy planar-binary `Decorated`/`AdmissibleCut` measures. Additive; first step of the Phase D counting-layer port.