### PR TITLE
feat(Semantics): Coordinator.op + BooleanAlgebra Denot instances

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2221,7 +2221,9 @@ import Linglib.Semantics.Gradability.Basic
 import Linglib.Semantics.Reference.Binding
 import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Syntax.Minimalist.LongDistanceAgree
+import Linglib.Semantics.Coordination.Basic
 import Linglib.Semantics.Composition.Tree
+import Linglib.Semantics.Composition.Coordination
 import Linglib.Semantics.Composition.Model
 import Linglib.Semantics.Composition.Reduction
 import Linglib.Semantics.Composition.WriterMonad

--- a/Linglib/Core/Logic/Intensional/Algebra.lean
+++ b/Linglib/Core/Logic/Intensional/Algebra.lean
@@ -222,4 +222,46 @@ theorem entails_singleton (p q : Denot E W .prop) :
     entails (E := E) (W := W) [p] q = box (fun i => impl (p i) (q i)) := by
   simp [entails, trueAt, box, impl]
 
+-- ════════════════════════════════════════════════════════════════
+-- § Boolean-Algebra Instances on `Denot E W τ`
+-- ════════════════════════════════════════════════════════════════
+
+/-! The pointwise Boolean-algebra structure of conjoinable types, registered
+explicitly by recursion on `τ` (base `Prop`, then the `Pi` lift for `fn`/`intens`).
+Instance resolution cannot synthesize these on its own — it does not unfold the
+`Denot` `def` — so the recursion instances make `BooleanAlgebra (Denot E W τ)`
+available for every conjoinable type. Non-conjoinable types (`.e`) get no instance,
+which is exactly correct: `⊓`/`⊔` are a type error on entities.
+
+With these in scope, [partee-rooth-1983]'s `genConj`/`genDisj` are `⊓`/`⊔` at
+*every* conjoinable type (not just the `t` base case proved above), so the bespoke
+recursion is provably the pointwise lattice operation. -/
+
+instance instBooleanAlgebraDenotT : BooleanAlgebra (Denot E W .t) :=
+  inferInstanceAs (BooleanAlgebra Prop)
+
+instance instBooleanAlgebraDenotFn (a b : Ty) [BooleanAlgebra (Denot E W b)] :
+    BooleanAlgebra (Denot E W (a ⇒ b)) :=
+  inferInstanceAs (BooleanAlgebra (Denot E W a → Denot E W b))
+
+instance instBooleanAlgebraDenotIntens (a : Ty) [BooleanAlgebra (Denot E W a)] :
+    BooleanAlgebra (Denot E W (.intens a)) :=
+  inferInstanceAs (BooleanAlgebra (W → Denot E W a))
+
+open Conjunction in
+/-- Generalized conjunction is `⊓` at `⟨e,t⟩` — the inductive step, where the
+earlier `genConj_eq_inf_t` only covered the `t` base case. -/
+theorem genConj_eq_inf_et (f g : Denot E W (.e ⇒ .t)) :
+    genConj (.e ⇒ .t) E W f g = f ⊓ g := rfl
+
+open Conjunction in
+/-- Generalized conjunction is `⊓` at `⟨e,⟨e,t⟩⟩` (binary relations). -/
+theorem genConj_eq_inf_eet (f g : Denot E W (.e ⇒ .e ⇒ .t)) :
+    genConj (.e ⇒ .e ⇒ .t) E W f g = f ⊓ g := rfl
+
+open Conjunction in
+/-- Generalized disjunction is `⊔` at `⟨e,t⟩`. -/
+theorem genDisj_eq_sup_et (f g : Denot E W (.e ⇒ .t)) :
+    genDisj (.e ⇒ .t) E W f g = f ⊔ g := rfl
+
 end Core.Logic.Intensional.Algebra

--- a/Linglib/Core/Logic/Intensional/Conjunction.lean
+++ b/Linglib/Core/Logic/Intensional/Conjunction.lean
@@ -41,6 +41,15 @@ def genDisj (τ : Ty) (E W : Type) : Denot E W τ → Denot E W τ → Denot E W
   | .fn _ τ' => λ f g => λ x => genDisj τ' E W (f x) (g x)
   | .intens a => λ f g => λ i => genDisj a E W (f i) (g i)
 
+/-- Generalized negation (pointwise complement) — the recursion form of `·ᶜ`,
+    needed for negative coordination (`nor` = `¬(A ∨ B)`). Junk at `.e`. -/
+def genNeg (τ : Ty) (E W : Type) : Denot E W τ → Denot E W τ :=
+  match τ with
+  | .t => λ p => ¬p
+  | .e => λ x => x
+  | .fn _ τ' => λ f => λ x => genNeg τ' E W (f x)
+  | .intens a => λ f => λ i => genNeg a E W (f i)
+
 theorem genConj_at_t (E W : Type) (p q : Prop) :
     genConj .t E W p q = (p ∧ q) := rfl
 

--- a/Linglib/Semantics/Composition/Coordination.lean
+++ b/Linglib/Semantics/Composition/Coordination.lean
@@ -1,0 +1,42 @@
+import Linglib.Semantics.Coordination.Basic
+import Linglib.Semantics.Composition.Tree
+
+/-!
+# Coordination in the composition engine
+
+`tryCoord` wires `Coordinator.op` into [heim-kratzer-1998] type-driven interpretation —
+the composition-engine mode that is the sibling of `tryFA`/`tryIFA`/`tryPM`. `tryPM`
+(intersective predicate modification) is its `⟨e,t⟩` conjunction case
+(`tryPM_eq_tryCoord_j`), so the engine's existing modification mode already routes
+through the Coordinator API.
+
+`tryCoord` is an *engine* mode (the `tryX` convention), not part of the `Coordinator`
+API surface; it invokes `Coordinator.engineOp`.
+-/
+
+namespace Semantics.Composition.Tree
+
+open Core.Logic.Intensional
+open Core.Logic.Intensional.Conjunction
+
+/-- **Coordination composition mode** — the sibling of `tryFA`/`tryIFA`/`tryPM`.
+    Two same-conjoinable-type sisters combine via `Coordinator.op` (through its runtime
+    form `Coordinator.engineOp`), threaded through the effect functor `M`. Non-conjoinable
+    or type-mismatched sisters yield `none`. -/
+def tryCoord {E W : Type} {M : Type → Type} [Applicative M] (role : Coordinator.Role)
+    (d1 d2 : TypedDenot E W M) : Option (TypedDenot E W M) :=
+  if h : d1.ty = d2.ty ∧ d1.ty.isConjoinable then
+    some ⟨d1.ty, (Coordinator.engineOp role d1.ty E W) <$> d1.val <*> (h.1 ▸ d2.val)⟩
+  else none
+
+/-- `tryPM` is the `⟨e,t⟩` conjunction case of `tryCoord`: intersective predicate
+    modification *is* generalized conjunction at `⟨e,t⟩`. -/
+theorem tryPM_eq_tryCoord_j {E W : Type} {M : Type → Type} [Applicative M]
+    (d1 d2 : TypedDenot E W M) (h1 : d1.ty = (.e ⇒ .t)) (h2 : d2.ty = (.e ⇒ .t)) :
+    tryPM d1 d2 = tryCoord .j d1 d2 := by
+  obtain ⟨t1, v1⟩ := d1
+  obtain ⟨t2, v2⟩ := d2
+  subst h1; subst h2
+  rfl
+
+end Semantics.Composition.Tree

--- a/Linglib/Semantics/Coordination/Basic.lean
+++ b/Linglib/Semantics/Coordination/Basic.lean
@@ -1,0 +1,85 @@
+import Linglib.Features.Coordination
+import Linglib.Core.Logic.Intensional.Algebra
+
+/-!
+# The Coordinator API — the operation
+
+`and`/`or`/`but`/`nor` denote the meet/join/complement of the Boolean algebra on
+whatever conjoinable carrier the conjuncts inhabit. `Coordinator.op` is the single
+operation, polymorphic over `[BooleanAlgebra α]` — one def, every Boolean carrier
+(`Denot E W τ`, `Prop`, `Set E`, propositions, GQs). The [partee-rooth-1983]
+`genConj`/`genDisj` recursion is proven to *be* it.
+
+This file sits *below* the composition engine: the engine mode `tryCoord`
+(`Semantics/Composition/Coordination.lean`), the CCG `.coord` rule, and the lexical
+fragments all consume `Coordinator.op` from here. The naming target is
+`Coordinator.Role` (the `Coord` prefix on `CoordRole` is absorbed at the marking
+migration); for now `Role` aliases `Features.Coordination.CoordRole`.
+
+## Main definitions
+
+* `Coordinator.op` — the DO layer (role → Boolean operation), polymorphic.
+* `Coordinator.engineOp` — the runtime-`Ty`-dispatch form (via `genConj`/`genDisj`/`genNeg`).
+* `Features.Coordination.CoordEntry.op` — a lexical coordinator's operation = `op` of its role.
+
+## Main results
+
+* `genConj_eq_op_et`, `genDisj_eq_op_et`, `op_*_t` — the recursion / wrappers ARE `op`
+  (flow-through bucket (a)).
+-/
+
+namespace Coordinator
+
+open Core.Logic.Intensional
+open Core.Logic.Intensional.Conjunction
+
+/-- The role of a coordinator — which Boolean operation it denotes.
+    Aliases `Features.Coordination.CoordRole` pending the marking migration. -/
+abbrev Role := Features.Coordination.CoordRole
+
+/-- **DO layer.** The operation a coordinator denotes, polymorphic over any
+    Boolean-algebra carrier: the role selects the *method* (`⊓`/`⊔`/`·ᶜ∘⊔`), the
+    instance supplies the *algebra*. -/
+def op {α : Type*} [BooleanAlgebra α] : Role → α → α → α
+  | .j | .mu | .advers => (· ⊓ ·)
+  | .disj => (· ⊔ ·)
+  | .negDisj | .negCoord => fun p q => (p ⊔ q)ᶜ
+
+/-! ### Bridges: the [partee-rooth-1983] recursion / IL wrappers ARE `op` (bucket (a)) -/
+
+theorem genConj_eq_op_et {E W : Type} (f g : Denot E W (.e ⇒ .t)) :
+    genConj (.e ⇒ .t) E W f g = op .j f g := rfl
+
+theorem genDisj_eq_op_et {E W : Type} (f g : Denot E W (.e ⇒ .t)) :
+    genDisj (.e ⇒ .t) E W f g = op .disj f g := rfl
+
+theorem op_j_t {E W : Type} (p q : Denot E W .t) : op .j p q = (p ⊓ q) := rfl
+theorem op_disj_t {E W : Type} (p q : Denot E W .t) : op .disj p q = (p ⊔ q) := rfl
+theorem op_nor_t {E W : Type} (p q : Denot E W .t) : op .negDisj p q = (p ⊔ q)ᶜ := rfl
+
+/-- Engine-side operation: runtime dispatch on the type `τ` via the recursion forms,
+    which the bridges above prove equal to `op` at every conjoinable type. The engine
+    needs runtime `Ty` dispatch where `op` would need a statically-resolved instance. -/
+def engineOp : Role → (τ : Ty) → (E W : Type) → Denot E W τ → Denot E W τ → Denot E W τ
+  | .j, τ, E, W => genConj τ E W
+  | .mu, τ, E, W => genConj τ E W
+  | .advers, τ, E, W => genConj τ E W
+  | .disj, τ, E, W => genDisj τ E W
+  | .negDisj, τ, E, W => fun p q => genNeg τ E W (genDisj τ E W p q)
+  | .negCoord, τ, E, W => fun p q => genNeg τ E W (genDisj τ E W p q)
+
+theorem engineOp_j (τ : Ty) (E W : Type) : engineOp .j τ E W = genConj τ E W := rfl
+theorem engineOp_disj (τ : Ty) (E W : Type) : engineOp .disj τ E W = genDisj τ E W := rfl
+
+end Coordinator
+
+namespace Features.Coordination
+
+/-- **A lexical coordinator's operation** = `Coordinator.op` of its role. The 19 Fragment
+    coordinators (English *and*/*or*, German *und*/*oder*, Japanese *to*/*mo*/*ka*, …)
+    route their denotation through the single `Coordinator.op` here (flow-through
+    bucket (b): the marking derives its operation from `op`). -/
+def CoordEntry.op {α : Type*} [BooleanAlgebra α] (e : CoordEntry) : α → α → α :=
+  Coordinator.op e.role
+
+end Features.Coordination

--- a/Linglib/Syntax/CCG/Interface.lean
+++ b/Linglib/Syntax/CCG/Interface.lean
@@ -1,6 +1,7 @@
 import Linglib.Syntax.CCG.Basic
 import Linglib.Core.Logic.Intensional.Defs
 import Linglib.Core.Logic.Intensional.Conjunction
+import Linglib.Semantics.Coordination.Basic
 import Linglib.Semantics.Composition.Combinator
 
 /-!
@@ -167,15 +168,16 @@ def DerivStep.interp {E W : Type} (d : DerivStep) (lex : SemLexicon E W)
       some ⟨backwardTypeRaise x t, T m⟩
 
   | .coord d1 d2 => do
-      -- Coordination: X and X → X, semantically generalized conjunction
-      -- ([partee-rooth-1983]), restricted to conjoinable types
+      -- Coordination: X and X → X, via the Coordinator API (`Coordinator.op .j`,
+      -- here its runtime form `engineOp`; = generalized conjunction [partee-rooth-1983]),
+      -- restricted to conjoinable types.
       let ⟨c1, m1⟩ ← d1.interp lex
       let ⟨c2, m2⟩ ← d2.interp lex
       if h : c1 = c2 then
         let ty := catToTy c1
         if ty.isConjoinable then
           let m2' : Denot E W (catToTy c1) := h ▸ m2
-          some ⟨c1, genConj ty E W m1 m2'⟩
+          some ⟨c1, Coordinator.engineOp .j ty E W m1 m2'⟩
         else none
       else none
 


### PR DESCRIPTION
A single `Coordinator.op {α} [BooleanAlgebra α]` for `and`/`or`/`nor` (Boolean meet/join/complement), with `BooleanAlgebra (Denot E W τ)` recursion instances so the existing coordination machinery routes through it.

- `genConj`/`genDisj` and the IL wrappers `= op` (bridges by `rfl`); the `Denot` Boolean-algebra instances also make the quantifier/modal operators in `Algebra.lean` real instances rather than `rfl`-only bridges.
- `tryCoord` composition mode with `tryPM_eq_tryCoord_j` (intersective predicate modification *is* generalized conjunction at `⟨e,t⟩`).
- CCG `.coord` retargeted to `Coordinator.engineOp .j` (defeq); `CoordEntry.op` routes the 19 lexical coordinators through `op`.