### PR TITLE
refactor(Features/Coordination): extract Boundness + CoordSymmetry

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -47,6 +47,7 @@ import Linglib.Features.Acceptability
 import Linglib.Semantics.Dynamic.ParameterizedUpdate
 import Linglib.Syntax.Tree.Basic
 import Linglib.Syntax.Tree.Cat
+import Linglib.Features.Boundness
 import Linglib.Features.Coordination
 import Linglib.Core.Logic.Duality
 import Linglib.Semantics.Quantification
@@ -2130,6 +2131,7 @@ import Linglib.Syntax.Minimalist.Polarity
 import Linglib.Syntax.Minimalist.Questions
 import Linglib.Syntax.Minimalist.Labeling
 import Linglib.Syntax.Minimalist.Phase
+import Linglib.Syntax.Minimalist.Coordination
 import Linglib.Syntax.Minimalist.Multidominance
 import Linglib.Syntax.Minimalist.Economy
 import Linglib.Syntax.Minimalist.Modification

--- a/Linglib/Features/Boundness.lean
+++ b/Linglib/Features/Boundness.lean
@@ -1,0 +1,17 @@
+/-!
+# Boundness
+
+Morphological boundness of a lexical item: a free word versus a bound
+clitic or suffix. A general per-entry morphological feature, not specific to
+any one construction — relevant to acquisition ([clark-2017] argues free
+morphemes are acquired more readily than bound ones) and to coordination
+typology ([mitrovic-sauerland-2016]), among others.
+-/
+
+/-- Morphological boundness: free word vs bound clitic/suffix. -/
+inductive Boundness where
+  /-- Independent word (Hungarian "is", English "and"). -/
+  | free
+  /-- Clitic or suffix (Georgian "-c", Latin "-que"). -/
+  | bound
+  deriving DecidableEq, Repr, BEq

--- a/Linglib/Features/Coordination.lean
+++ b/Linglib/Features/Coordination.lean
@@ -1,3 +1,5 @@
+import Linglib.Features.Boundness
+
 /-!
 # Coordination Types
 
@@ -15,12 +17,6 @@ decomposition and beyond:
 - `advers` — adversative ("but")
 - `negDisj` — negative disjunction ("nor")
 - `negCoord` — negative coordination ("neither...nor")
-
-## Boundness
-
-Whether a morpheme is a free word or a bound clitic/suffix.
-Relevant to acquisition: [clark-2017] argues free morphemes
-are acquired more readily than bound ones.
 
 ## CoordEntry
 
@@ -51,14 +47,6 @@ inductive CoordRole where
   | negDisj
   /-- Negative coordination (Latin "neque/nec" = "neither...nor") -/
   | negCoord
-  deriving DecidableEq, Repr, BEq
-
-/-- Morphological boundness: free word vs bound clitic/suffix. -/
-inductive Boundness where
-  /-- Independent word (Hungarian "is", English "and") -/
-  | free
-  /-- Clitic or suffix (Georgian "-c", Latin "-que") -/
-  | bound
   deriving DecidableEq, Repr, BEq
 
 /-- A coordination morpheme entry, used by all Fragment lexicons. -/
@@ -128,30 +116,5 @@ to acquire (closer to 1-to-1 form-meaning mapping).
 -/
 def ConjunctionStrategy.predictedTransparency : ConjunctionStrategy → Nat :=
   ConjunctionStrategy.overtMorphemeCount
-
--- ============================================================================
--- Structural Symmetry ([schwarzer-2026])
--- ============================================================================
-
-/--
-Structural symmetry of a coordinate phrase.
-
-The three groups of analyses for selection-violating coordination
-([schwarzer-2026]) disagree on this parameter:
-- **Bottom-up accounts** assume `asymmetric` structure: the first conjunct
-  is structurally more prominent (c-commands the second), so only it must
-  satisfy the selector's c-selectional requirements.
-- **Linear/temporal closeness accounts** are compatible with either, but
-  their predictions derive from linear/temporal order, not structure.
-- **Symmetric accounts** ([neeleman-etal-2022], [przepiorkowski-2024])
-  posit flat or multidominance structures with no structural prominence.
--/
-inductive CoordSymmetry where
-  /-- Flat or multidominance: no conjunct is structurally more prominent. -/
-  | symmetric
-  /-- Binary &P: first conjunct is structurally more prominent
-      (c-commands the second conjunct). -/
-  | asymmetric
-  deriving DecidableEq, Repr, BEq
 
 end Features.Coordination

--- a/Linglib/Studies/BillEtAl2025.lean
+++ b/Linglib/Studies/BillEtAl2025.lean
@@ -1,6 +1,7 @@
 import Linglib.Core.Logic.Intensional.Defs
 import Linglib.Core.Logic.Intensional.Conjunction
 import Linglib.Semantics.Plurality.Distributivity
+import Linglib.Features.Boundness
 import Linglib.Features.Coordination
 import Linglib.Studies.Haspelmath2007
 import Linglib.Studies.MitrovicSauerland2016

--- a/Linglib/Studies/BrueningAlKhalaf2020.lean
+++ b/Linglib/Studies/BrueningAlKhalaf2020.lean
@@ -1,5 +1,6 @@
 import Linglib.Typology.WordOrder
 import Linglib.Features.Coordination
+import Linglib.Syntax.Minimalist.Coordination
 import Linglib.Syntax.Tree.Cat
 import Linglib.Fragments.English.WordOrder
 import Mathlib.Data.Finset.Basic
@@ -51,6 +52,7 @@ rather than stipulating it. Apparent mismatches in predication and modification
 namespace BrueningAlKhalaf2020
 
 open Features.Coordination
+open Minimalist (CoordSymmetry)
 open Syntax (Cat)
 open Syntax.Cat (NP VP AdjP AdvP PP)
 open Typology.WordOrder

--- a/Linglib/Studies/Schwarzer2026.lean
+++ b/Linglib/Studies/Schwarzer2026.lean
@@ -4,6 +4,7 @@ import Linglib.Fragments.German.V2
 import Linglib.Fragments.German.WordOrder
 import Linglib.Typology.WordOrder
 import Linglib.Features.Coordination
+import Linglib.Syntax.Minimalist.Coordination
 import Linglib.Studies.BrueningAlKhalaf2020
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 
@@ -77,7 +78,7 @@ The competing analyses make different predictions for the preverbal
 (= OV) condition. All agree on the postverbal (= VO) condition.
 -/
 
-open Minimalist (ForceHead)
+open Minimalist (ForceHead CoordSymmetry)
 open German (german)
 
 /-- German has V2 in root declaratives: the finite verb moves to C°,

--- a/Linglib/Syntax/Minimalist/Coordination.lean
+++ b/Linglib/Syntax/Minimalist/Coordination.lean
@@ -1,0 +1,32 @@
+/-!
+# Coordinate-structure symmetry
+
+The structural-symmetry parameter of a coordinate phrase (`&P`): whether one
+conjunct is structurally more prominent (c-commands the other) or the structure
+is flat / multidominant. This is a syntactic structural primitive — the three
+groups of analyses for selection-violating coordination ([schwarzer-2026])
+disagree precisely on this parameter.
+-/
+
+namespace Minimalist
+
+/-- Structural symmetry of a coordinate phrase.
+
+    The three groups of analyses for selection-violating coordination
+    ([schwarzer-2026]) disagree on this parameter:
+    - **Bottom-up accounts** assume `asymmetric` structure: the first conjunct
+      is structurally more prominent (c-commands the second), so only it must
+      satisfy the selector's c-selectional requirements.
+    - **Linear/temporal closeness accounts** are compatible with either, but
+      their predictions derive from linear/temporal order, not structure.
+    - **Symmetric accounts** ([neeleman-etal-2022], [przepiorkowski-2024])
+      posit flat or multidominance structures with no structural prominence. -/
+inductive CoordSymmetry where
+  /-- Flat or multidominance: no conjunct is structurally more prominent. -/
+  | symmetric
+  /-- Binary `&P`: first conjunct is structurally more prominent
+      (c-commands the second conjunct). -/
+  | asymmetric
+  deriving DecidableEq, Repr, BEq
+
+end Minimalist

--- a/Linglib/Typology/Coordination.lean
+++ b/Linglib/Typology/Coordination.lean
@@ -1,3 +1,4 @@
+import Linglib.Features.Boundness
 import Linglib.Features.Coordination
 import Linglib.Data.WALS.Features.F56A
 import Linglib.Data.WALS.Features.F63A


### PR DESCRIPTION
First step of the coordination substrate reorg (`scratch/coordination-reorg-plan.md`): dissolve the `Features/Coordination` grab-bag by owner.

- `Boundness` → `Features/Boundness.lean` (root-level; a general morphological feature, not coordination-specific).
- `CoordSymmetry` → `Syntax/Minimalist/Coordination.lean` (`namespace Minimalist`; a structural-syntax parameter).

Additive: `CoordRole`/`CoordEntry`/`ConjunctionStrategy` stay put for now. Consumers repointed (BillEtAl2025, Typology/Coordination, Schwarzer2026, BrueningAlKhalaf2020).