### PR TITLE
feat(Syntax/Minimalist/Merge): MinimalYield on canonical Nonplanar (retire legacy)

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1870,6 +1870,7 @@ import Linglib.Core.Combinatorics.RootedTree.Nonplanar
 import Linglib.Core.Combinatorics.RootedTree.Nonplanar.Insertion
 import Linglib.Core.Combinatorics.RootedTree.Counting
 import Linglib.Core.Combinatorics.RootedTree.TraceCounting
+import Linglib.Core.Combinatorics.RootedTree.Rebinarize
 import Linglib.Core.Algebra.RootedTree.ConnesKreimer
 import Linglib.Core.Algebra.RootedTree.Coproduct.Defs
 import Linglib.Core.Algebra.RootedTree.Coproduct.Pruning
@@ -1880,6 +1881,7 @@ import Linglib.Core.Algebra.RootedTree.Coproduct.PruningDuality
 import Linglib.Core.Algebra.RootedTree.Coproduct.TraceNonplanar
 import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionNonplanar
 import Linglib.Core.Algebra.RootedTree.Coproduct.Conservation
+import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionConservation
 import Linglib.Core.Algebra.RootedTree.HopfAlgebraNonplanar
 import Linglib.Core.Algebra.RootedTree.InsertionLieDuality
 import Linglib.Core.Algebra.RootedTree.FormSet

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Conservation.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Conservation.lean
@@ -489,4 +489,35 @@ theorem cutSummandsCN_accCountC_single (τ : Nonplanar (α ⊕ β) → β)
   simp only [Nonplanar.accCountC, Nonplanar.accCount]
   omega
 
+/-- **Two-cut accessible-term extraction** (MCB eq. 1.6.8 for a 2-edge admissible
+    cut): contracting two accessible subtrees `Tv`, `Tw` adds two contractions,
+    `αᶜ(T) = αᶜ(Tv) + αᶜ(Tw) + αᶜ(T/^c {Tv,Tw}) + 2`. Used for Sideward Merge 3(a). -/
+theorem cutSummandsCN_accCountC_pair (τ : Nonplanar (α ⊕ β) → β)
+    (T : Nonplanar (α ⊕ β)) (a₀ : α) (F₀ : Forest (Nonplanar (α ⊕ β)))
+    (hT : T = Nonplanar.node (Sum.inl a₀) F₀)
+    (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) (hp : p ∈ cutSummandsCN τ T)
+    (Tv Tw : Nonplanar (α ⊕ β)) (hcard : p.1 = {Tv, Tw}) :
+    T.accCountC = Tv.accCountC + Tw.accCountC + p.2.accCountC + 2 := by
+  have hw := cutSummandsCN_weight τ T p hp
+  have hl := cutSummandsCN_traceLeafCount τ T p hp
+  have hTv_lt : Tv.traceLeafCount < Tv.weight :=
+    cutSummandsCN_crown_traceLeafCount_lt_weight τ T p hp Tv
+      (by rw [hcard]; exact Multiset.mem_cons_self Tv {Tw})
+  have hTw_lt : Tw.traceLeafCount < Tw.weight :=
+    cutSummandsCN_crown_traceLeafCount_lt_weight τ T p hp Tw
+      (by rw [hcard]; exact Multiset.mem_cons_of_mem (Multiset.mem_singleton_self Tw))
+  have hT_root : T.rootLabel = Sum.inl a₀ := by
+    rw [hT, Nonplanar.rootLabel_node]
+  have hT_lt : T.traceLeafCount < T.weight :=
+    Nonplanar.traceLeafCount_lt_weight_of_rootInl T a₀ hT_root
+  have hp2_lt : p.2.traceLeafCount < p.2.weight :=
+    Nonplanar.traceLeafCount_lt_weight_of_rootInl p.2 a₀
+      ((cutSummandsCN_trunk_rootLabel τ T p hp).trans hT_root)
+  rw [hcard] at hw hl
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.sum_cons,
+    Multiset.map_singleton, Multiset.sum_singleton, Multiset.card_cons,
+    Multiset.card_singleton] at hw hl
+  simp only [Nonplanar.accCountC, Nonplanar.accCount]
+  omega
+
 end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionConservation.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionConservation.lean
@@ -1,0 +1,101 @@
+import Linglib.Core.Algebra.RootedTree.Coproduct.Pruning
+
+/-!
+# Weight conservation for the Δ^ρ / Δᵈ (deletion) cut enumeration
+[marcolli-chomsky-berwick-2025]
+
+The deletion coproduct `cutSummandsP` (MCB Δ^ρ, Def. 1.2.6) extracts a crown
+forest and leaves the **remainder** `ρ_C(T)` — the cut subtrees are removed
+entirely (no trace placeholder), so vertices are conserved exactly:
+`Σ #V(crown) + #V(trunk) = #V(T)` (`cutSummandsP_weight`), with **no** `+#cuts`
+correction (contrast the trace variant, which adds one replacement leaf per cut).
+
+MCB's **Δᵈ** (Def. 1.2.5) rebinarizes the remainder via `contractUnary`; each
+contracted unary node drops one vertex, giving the `+2`-per-cut accessible-term
+extraction (eq. 1.6.7) downstream.
+-/
+
+namespace RootedTree
+
+namespace ConnesKreimer
+
+open Planar
+
+variable {α : Type*}
+
+/-- The weight contributed by an `Option`-valued deletion remainder. -/
+private def optWeight (o : Option (Planar α)) : ℕ := o.elim 0 Planar.weight
+
+@[simp] private theorem optWeight_none : optWeight (none : Option (Planar α)) = 0 := rfl
+@[simp] private theorem optWeight_some (t : Planar α) : optWeight (some t) = t.weight := rfl
+
+mutual
+
+/-- **Vertex conservation** for the deletion cut enumeration (tree level):
+    crown vertices plus trunk vertices recover the tree's vertices exactly. -/
+theorem cutSummandsP_weight :
+    ∀ (t : Planar α), ∀ p ∈ cutSummandsP t,
+      (Multiset.map Planar.weight p.1).sum + Planar.weight p.2 = Planar.weight t
+  | .node a cs => by
+    intro p hp
+    rw [cutSummandsP_node] at hp
+    obtain ⟨q, hq, rfl⟩ := Multiset.mem_map.mp hp
+    have h := cutListSummandsP_weight cs q hq
+    show (Multiset.map Planar.weight q.1).sum + (1 + weightList q.2) = 1 + weightList cs
+    omega
+
+/-- Mutual aux: vertex conservation for children-list deletion cut summands. -/
+theorem cutListSummandsP_weight :
+    ∀ (cs : List (Planar α)), ∀ q ∈ cutListSummandsP cs,
+      (Multiset.map Planar.weight q.1).sum + weightList q.2 = weightList cs
+  | [] => by
+    intro q hq
+    rw [cutListSummandsP_nil] at hq
+    obtain rfl := Multiset.mem_singleton.mp hq
+    rfl
+  | t :: ts => by
+    intro q hq
+    rw [cutListSummandsP_cons] at hq
+    obtain ⟨pr, hpr, rfl⟩ := Multiset.mem_map.mp hq
+    obtain ⟨ha, hq'⟩ := Multiset.mem_product.mp hpr
+    have h1 := augActionP_weight t pr.1 ha
+    have h2 := cutListSummandsP_weight ts pr.2 hq'
+    cases hm : pr.1.2 with
+    | none =>
+      simp only [hm, optWeight_none] at h1
+      show (Multiset.map Planar.weight (pr.1.1 + pr.2.1)).sum + weightList pr.2.2
+        = weight t + weightList ts
+      rw [Multiset.map_add, Multiset.sum_add]
+      omega
+    | some r =>
+      simp only [hm, optWeight_some] at h1
+      show (Multiset.map Planar.weight (pr.1.1 + pr.2.1)).sum + weightList (r :: pr.2.2)
+        = weight t + weightList ts
+      rw [Multiset.map_add, Multiset.sum_add]
+      show (Multiset.map Planar.weight pr.1.1).sum + (Multiset.map Planar.weight pr.2.1).sum
+          + (weight r + weightList pr.2.2) = weight t + weightList ts
+      omega
+
+/-- Mutual aux: vertex conservation for per-child deletion actions. -/
+theorem augActionP_weight :
+    ∀ (t : Planar α), ∀ a ∈ augActionP t,
+      (Multiset.map Planar.weight a.1).sum + optWeight a.2 = Planar.weight t
+  | t => by
+    intro a ha
+    rw [augActionP_eq] at ha
+    rcases Multiset.mem_cons.mp ha with h | h
+    · obtain rfl := h
+      show (Multiset.map Planar.weight {t}).sum + optWeight (none : Option (Planar α))
+        = Planar.weight t
+      rw [Multiset.map_singleton, Multiset.sum_singleton, optWeight_none]
+      omega
+    · obtain ⟨p, hp, rfl⟩ := Multiset.mem_map.mp h
+      show (Multiset.map Planar.weight p.1).sum + optWeight (some p.2) = Planar.weight t
+      rw [optWeight_some]
+      exact cutSummandsP_weight t p hp
+
+end
+
+end ConnesKreimer
+
+end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionConservation.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionConservation.lean
@@ -1,4 +1,7 @@
 import Linglib.Core.Algebra.RootedTree.Coproduct.Pruning
+import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
+import Linglib.Core.Combinatorics.RootedTree.Rebinarize
+import Linglib.Core.Combinatorics.RootedTree.Counting
 
 /-!
 # Weight conservation for the Δ^ρ / Δᵈ (deletion) cut enumeration
@@ -19,7 +22,7 @@ namespace RootedTree
 
 namespace ConnesKreimer
 
-open Planar
+open _root_.RootedTree.Planar
 
 variable {α : Type*}
 
@@ -95,6 +98,48 @@ theorem augActionP_weight :
       exact cutSummandsP_weight t p hp
 
 end
+
+/-! ### Nonplanar descent + Δᵈ extraction -/
+
+/-- Vertex conservation for the nonplanar deletion cuts, descended from
+    `cutSummandsP_weight`. -/
+theorem cutSummandsN_weight (T : Nonplanar α) :
+    ∀ p ∈ cutSummandsN T,
+      (p.1.map Nonplanar.weight).sum + p.2.weight = T.weight := by
+  obtain ⟨T₀, rfl⟩ : ∃ T₀ : Planar α, T = Nonplanar.mk T₀ :=
+    ⟨T.out, (Quotient.out_eq T).symm⟩
+  intro p hp
+  rw [cutSummandsN_mk] at hp
+  obtain ⟨q, hq, rfl⟩ := Multiset.mem_map.mp hp
+  have hcons := cutSummandsP_weight T₀ q hq
+  show ((q.1.map Nonplanar.mk).map Nonplanar.weight).sum + (Nonplanar.mk q.2).weight
+    = (Nonplanar.mk T₀).weight
+  rw [Nonplanar.weight_mk, Nonplanar.weight_mk, Multiset.map_map,
+      show q.1.map (Nonplanar.weight ∘ Nonplanar.mk) = q.1.map Planar.weight from
+        Multiset.map_congr rfl (fun x _ => Nonplanar.weight_mk x)]
+  exact hcons
+
+/-- **Single-cut Δᵈ accessible-term extraction** (MCB eq. 1.6.7): deleting one
+    accessible subtree `mover` from `T` and rebinarizing the remainder
+    (`contractUnary p.2`) removes two accessible terms — the subtree's edge and
+    the contracted parent. The hypothesis `unaryCount p.2 = 1` characterizes a
+    single edge cut at a binary node (exactly one unary node is created). -/
+theorem cutSummandsN_accCount_single_deletion (T : Nonplanar α)
+    (p : Forest (Nonplanar α) × Nonplanar α) (hp : p ∈ cutSummandsN T)
+    (mover : Nonplanar α) (hcard : p.1 = {mover}) (huc : p.2.unaryCount = 1) :
+    T.accCount = mover.accCount + (Nonplanar.contractUnary p.2).accCount + 2 := by
+  have hw := cutSummandsN_weight T p hp
+  have hcu := Nonplanar.weight_contractUnary_add p.2
+  have hmT := T.weight_pos
+  have hmm := mover.weight_pos
+  have hmp := p.2.weight_pos
+  have hmc := (Nonplanar.contractUnary p.2).weight_pos
+  rw [hcard] at hw
+  simp only [Multiset.map_singleton, Multiset.sum_singleton] at hw
+  rw [huc] at hcu
+  rw [Nonplanar.accCount_eq_weight_sub_one T, Nonplanar.accCount_eq_weight_sub_one mover,
+      Nonplanar.accCount_eq_weight_sub_one (Nonplanar.contractUnary p.2)]
+  omega
 
 end ConnesKreimer
 

--- a/Linglib/Core/Combinatorics/RootedTree/Rebinarize.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Rebinarize.lean
@@ -79,6 +79,146 @@ theorem weightList_contractUnaryList_add :
     omega
 end
 
+/-! ### Bridges to `List.map` / `List.sum` and the ≥2-child reductions -/
+
+theorem contractUnaryList_eq_map (cs : List (Planar α)) :
+    contractUnaryList cs = cs.map contractUnary := by
+  induction cs with
+  | nil => rfl
+  | cons c cs ih => rw [contractUnaryList_cons, List.map_cons, ih]
+
+theorem unaryCountList_eq_sum_map (cs : List (Planar α)) :
+    unaryCountList cs = (cs.map unaryCount).sum := by
+  induction cs with
+  | nil => rfl
+  | cons c cs ih => rw [unaryCountList_cons, List.map_cons, List.sum_cons, ih]
+
+theorem contractUnary_node_of_two_le (a : α) (L : List (Planar α)) (h : 2 ≤ L.length) :
+    contractUnary (.node a L) = .node a (contractUnaryList L) := by
+  rcases L with _ | ⟨c, _ | ⟨d, cs⟩⟩
+  · simp at h
+  · simp at h
+  · rfl
+
+theorem unaryCount_node_of_two_le (a : α) (L : List (Planar α)) (h : 2 ≤ L.length) :
+    unaryCount (.node a L) = unaryCountList L := by
+  rcases L with _ | ⟨c, _ | ⟨d, cs⟩⟩
+  · simp at h
+  · simp at h
+  · rfl
+
+private theorem two_le_length_append_of {pre post : List (Planar α)} {x : Planar α}
+    (h : ¬ (pre = [] ∧ post = [])) : 2 ≤ (pre ++ x :: post).length := by
+  rcases pre with _ | ⟨p, ps⟩ <;> rcases post with _ | ⟨q, qs⟩
+  · exact absurd ⟨rfl, rfl⟩ h
+  · simp only [List.length_append, List.length_nil, List.length_cons]; omega
+  · simp only [List.length_append, List.length_nil, List.length_cons]; omega
+  · simp only [List.length_append, List.length_cons]; omega
+
+/-! ### `unaryCount` is `PlanarEquiv`-invariant -/
+
+private theorem unaryCountList_perm {cs ds : List (Planar α)} (h : cs.Perm ds) :
+    unaryCountList cs = unaryCountList ds := by
+  induction h with
+  | nil => rfl
+  | cons _ _ ih => simp only [unaryCountList_cons]; omega
+  | swap _ _ _ => simp only [unaryCountList_cons]; omega
+  | trans _ _ ih1 ih2 => exact ih1.trans ih2
+
+theorem unaryCount_planarStep {t s : Planar α} (hstep : PlanarStep t s) :
+    unaryCount t = unaryCount s := by
+  induction hstep with
+  | @swapAtRoot a l r pre post =>
+    rw [unaryCount_node_of_two_le a (pre ++ l :: r :: post)
+          (two_le_length_append_of (by simp)),
+        unaryCount_node_of_two_le a (pre ++ r :: l :: post)
+          (two_le_length_append_of (by simp))]
+    exact unaryCountList_perm ((List.Perm.swap r l post).append_left pre)
+  | @recurse a pre old new post _ ih =>
+    by_cases h1 : pre = [] ∧ post = []
+    · obtain ⟨rfl, rfl⟩ := h1
+      show 1 + unaryCount old = 1 + unaryCount new
+      omega
+    · rw [unaryCount_node_of_two_le a (pre ++ old :: post) (two_le_length_append_of h1),
+          unaryCount_node_of_two_le a (pre ++ new :: post) (two_le_length_append_of h1),
+          unaryCountList_eq_sum_map, unaryCountList_eq_sum_map,
+          List.map_append, List.map_append, List.map_cons, List.map_cons,
+          List.sum_append, List.sum_append, List.sum_cons, List.sum_cons, ih]
+
+theorem unaryCount_planarEquiv {t s : Planar α} (h : PlanarEquiv t s) :
+    unaryCount t = unaryCount s := by
+  induction h with
+  | rel _ _ hstep => exact unaryCount_planarStep hstep
+  | refl _ => rfl
+  | symm _ _ _ ih => exact ih.symm
+  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+
+/-! ### `contractUnary` is `PlanarEquiv`-invariant -/
+
+theorem contractUnary_planarStep {t s : Planar α} (hstep : PlanarStep t s) :
+    PlanarEquiv (contractUnary t) (contractUnary s) := by
+  induction hstep with
+  | @swapAtRoot a l r pre post =>
+    rw [contractUnary_node_of_two_le a (pre ++ l :: r :: post)
+          (two_le_length_append_of (by simp)),
+        contractUnary_node_of_two_le a (pre ++ r :: l :: post)
+          (two_le_length_append_of (by simp)),
+        contractUnaryList_eq_map, contractUnaryList_eq_map]
+    exact planarEquiv_root_perm
+      ((List.Perm.append_left pre (List.Perm.swap r l post)).map contractUnary)
+  | @recurse a pre old new post _ ih =>
+    by_cases h1 : pre = [] ∧ post = []
+    · obtain ⟨rfl, rfl⟩ := h1
+      exact ih
+    · rw [contractUnary_node_of_two_le a (pre ++ old :: post) (two_le_length_append_of h1),
+          contractUnary_node_of_two_le a (pre ++ new :: post) (two_le_length_append_of h1),
+          contractUnaryList_eq_map, contractUnaryList_eq_map,
+          List.map_append, List.map_append, List.map_cons, List.map_cons]
+      apply planarEquiv_node_componentwise
+      generalize pre.map contractUnary = P
+      induction P with
+      | nil =>
+        exact List.Forall₂.cons ih
+          (List.forall₂_same.mpr (fun _ _ => PlanarEquiv.refl _))
+      | cons p ps ihp => exact List.Forall₂.cons (PlanarEquiv.refl p) ihp
+
+theorem contractUnary_planarEquiv {t s : Planar α} (h : PlanarEquiv t s) :
+    PlanarEquiv (contractUnary t) (contractUnary s) := by
+  induction h with
+  | rel _ _ hstep => exact contractUnary_planarStep hstep
+  | refl _ => exact PlanarEquiv.refl _
+  | symm _ _ _ ih => exact ih.symm
+  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+
 end Planar
+
+/-! ### Nonplanar `contractUnary` / `unaryCount` -/
+
+namespace Nonplanar
+
+variable {α : Type*}
+
+/-- The number of unary nodes of a nonplanar tree. -/
+def unaryCount : Nonplanar α → Nat :=
+  Nonplanar.lift Planar.unaryCount (fun _ _ h => Planar.unaryCount_planarEquiv h)
+
+@[simp] theorem unaryCount_mk (t : Planar α) : (mk t).unaryCount = t.unaryCount := rfl
+
+/-- Rebinarize: contract every unary node (MCB Δᵈ, Def. 1.2.5). -/
+def contractUnary : Nonplanar α → Nonplanar α :=
+  Quotient.map Planar.contractUnary (fun _ _ h => Planar.contractUnary_planarEquiv h)
+
+@[simp] theorem contractUnary_mk (t : Planar α) :
+    contractUnary (mk t) = mk (Planar.contractUnary t) := rfl
+
+/-- Each contracted unary node drops one vertex. -/
+theorem weight_contractUnary_add (t : Nonplanar α) :
+    (contractUnary t).weight + t.unaryCount = t.weight := by
+  refine Quotient.inductionOn t fun p => ?_
+  show (mk (Planar.contractUnary p)).weight + (mk p).unaryCount = (mk p).weight
+  rw [weight_mk, unaryCount_mk, weight_mk]
+  exact Planar.weight_contractUnary_add p
+
+end Nonplanar
 
 end RootedTree

--- a/Linglib/Core/Combinatorics/RootedTree/Rebinarize.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Rebinarize.lean
@@ -1,0 +1,84 @@
+import Linglib.Core.Combinatorics.RootedTree.Nonplanar
+
+/-!
+# Rebinarization: contracting unary (non-branching) nodes
+[marcolli-chomsky-berwick-2025]
+
+`contractUnary` collapses every unary node (a vertex with exactly one child)
+into that child, the edge-contraction that takes a syntactic object to its
+**unique maximal binary rooted tree** (MCB Def. 1.2.5). It is the second step
+of MCB's deletion quotient `T/ᵈF_v`: delete the cut subtrees (leaving the
+not-necessarily-binary `T/ᵖF_v`), then `contractUnary` to rebinarize.
+
+Each contracted unary node removes exactly one vertex, so
+`weight (contractUnary t) + unaryCount t = weight t`.
+-/
+
+namespace RootedTree
+
+namespace Planar
+
+variable {α : Type*}
+
+/-! ### Definitions -/
+
+mutual
+/-- Contract every unary node into its child (rebinarize to maximal binary). -/
+def contractUnary : Planar α → Planar α
+  | .node a []              => .node a []
+  | .node _ [c]             => contractUnary c
+  | .node a (c₁ :: c₂ :: cs) => .node a (contractUnaryList (c₁ :: c₂ :: cs))
+/-- Auxiliary: `contractUnary` across a list of children. -/
+def contractUnaryList : List (Planar α) → List (Planar α)
+  | []      => []
+  | c :: cs => contractUnary c :: contractUnaryList cs
+end
+
+mutual
+/-- The number of unary (single-child) nodes in a tree. -/
+def unaryCount : Planar α → Nat
+  | .node _ []              => 0
+  | .node _ [c]             => 1 + unaryCount c
+  | .node _ (c₁ :: c₂ :: cs) => unaryCountList (c₁ :: c₂ :: cs)
+/-- Auxiliary: total unary-node count across a list of trees. -/
+def unaryCountList : List (Planar α) → Nat
+  | []      => 0
+  | c :: cs => unaryCount c + unaryCountList cs
+end
+
+@[simp] theorem contractUnaryList_cons (c : Planar α) (cs : List (Planar α)) :
+    contractUnaryList (c :: cs) = contractUnary c :: contractUnaryList cs := rfl
+
+@[simp] theorem unaryCountList_cons (c : Planar α) (cs : List (Planar α)) :
+    unaryCountList (c :: cs) = unaryCount c + unaryCountList cs := rfl
+
+/-! ### Weight conservation: each contracted unary node drops one vertex -/
+
+mutual
+theorem weight_contractUnary_add :
+    ∀ (t : Planar α), weight (contractUnary t) + unaryCount t = weight t
+  | .node a []              => rfl
+  | .node a [c]             => by
+    have ih := weight_contractUnary_add c
+    show weight (contractUnary c) + (1 + unaryCount c) = 1 + weight c
+    omega
+  | .node a (c₁ :: c₂ :: cs) => by
+    have ihl := weightList_contractUnaryList_add (c₁ :: c₂ :: cs)
+    show (1 + weightList (contractUnaryList (c₁ :: c₂ :: cs)))
+        + unaryCountList (c₁ :: c₂ :: cs) = 1 + weightList (c₁ :: c₂ :: cs)
+    omega
+theorem weightList_contractUnaryList_add :
+    ∀ (cs : List (Planar α)),
+      weightList (contractUnaryList cs) + unaryCountList cs = weightList cs
+  | []      => rfl
+  | c :: cs => by
+    have ih := weight_contractUnary_add c
+    have ihl := weightList_contractUnaryList_add cs
+    show (weight (contractUnary c) + weightList (contractUnaryList cs))
+        + (unaryCount c + unaryCountList cs) = weight c + weightList cs
+    omega
+end
+
+end Planar
+
+end RootedTree

--- a/Linglib/Core/Combinatorics/RootedTree/TraceCounting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/TraceCounting.lean
@@ -127,6 +127,13 @@ theorem traceLeafCount_planarEquiv {t s : Planar (α ⊕ β)}
   | symm _ _ _ ih => exact ih.symm
   | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
 
+theorem traceLeafCountList_eq_sum_map (cs : List (Planar (α ⊕ β))) :
+    Planar.traceLeafCountList cs = (cs.map Planar.traceLeafCount).sum := by
+  induction cs with
+  | nil => rfl
+  | cons c cs ih =>
+    rw [Planar.traceLeafCountList_cons, List.map_cons, List.sum_cons, ih]
+
 end Planar
 
 namespace Nonplanar
@@ -153,6 +160,40 @@ def traceLeafCount : Nonplanar (α ⊕ β) → Nat :=
     subtraction handles the all-trace edge case (e.g. `T = traceLeaf b`, where
     `α = 0` and `#traceLeaves = 1`). -/
 def accCountC (t : Nonplanar (α ⊕ β)) : ℕ := t.accCount - t.traceLeafCount
+
+/-- Trace leaves of a lexical-rooted node: the root contributes none, so the
+    count is the children's total. -/
+@[simp] theorem traceLeafCount_node_inl (a : α) (F : Multiset (Nonplanar (α ⊕ β))) :
+    (Nonplanar.node (Sum.inl a) F).traceLeafCount = (F.map Nonplanar.traceLeafCount).sum := by
+  refine Quotient.inductionOn F fun lst => ?_
+  show (mk (.node (Sum.inl a) (lst.map Quotient.out))).traceLeafCount = _
+  rw [traceLeafCount_mk]
+  show Planar.traceLeafCount (.node (Sum.inl a) (lst.map Quotient.out)) = _
+  rw [Planar.traceLeafCount_inl, Planar.traceLeafCountList_eq_sum_map, List.map_map]
+  simp only [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.sum_coe]
+  refine congrArg List.sum (List.map_congr_left fun t _ => ?_)
+  show (mk (Quotient.out t)).traceLeafCount = Nonplanar.traceLeafCount t
+  exact congrArg Nonplanar.traceLeafCount (Quotient.out_eq t)
+
+/-- External Merge adds two accessible terms in the trace-aware count: the two
+    children's roots become accessible (MCB Lemma 1.6.3, eq. 1.6.5). Needs each
+    child to have a lexical vertex (`traceLeafCount < weight`), automatic for a
+    real syntactic object. -/
+theorem accCountC_merge (a : α) (l r : Nonplanar (α ⊕ β))
+    (hl : l.traceLeafCount < l.weight) (hr : r.traceLeafCount < r.weight) :
+    (Nonplanar.node (Sum.inl a) {l, r}).accCountC = l.accCountC + r.accCountC + 2 := by
+  have hw := Nonplanar.accCount_merge (Sum.inl a) l r
+  have htl : (Nonplanar.node (Sum.inl a) {l, r}).traceLeafCount
+      = l.traceLeafCount + r.traceLeafCount := by
+    rw [traceLeafCount_node_inl]
+    simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.sum_cons,
+      Multiset.map_singleton, Multiset.sum_singleton]
+  have hbl : l.traceLeafCount ≤ l.accCount := by
+    rw [Nonplanar.accCount_eq_weight_sub_one]; omega
+  have hbr : r.traceLeafCount ≤ r.accCount := by
+    rw [Nonplanar.accCount_eq_weight_sub_one]; omega
+  simp only [accCountC, htl, hw]
+  omega
 
 /-- The **complexity grading** `#L` restricted to lexical leaves:
     `#L_{SO₀}(T) = #L(T) − #traceLeaves(T)`. The trace-exclusion follows the

--- a/Linglib/Studies/Adger2025.lean
+++ b/Linglib/Studies/Adger2025.lean
@@ -1,6 +1,7 @@
 import Linglib.Studies.Ross1967
 import Linglib.Syntax.SynGraph
 import Linglib.Syntax.Minimalist.Merge.MinimalYield
+import Linglib.Syntax.Minimalist.Basic
 
 set_option autoImplicit false
 
@@ -195,7 +196,7 @@ between theories … become visible across the codebase").
 The bundled theorem below is *honestly* a verdict-comparison: a
 conjunction of two unrelated propositions about different structural
 objects, both true. A genuine reduction would require a translation
-`SynGraph → TraceForest` lifting `satisfiesAL ↔ MinimalYieldWeak`;
+`SynGraph → Forest (Nonplanar …)` lifting `satisfiesAL ↔ MinimalYieldWeak`;
 no such bridge is in scope here. -/
 
 /-- Verdict comparison: the canonical Sideward configuration is rejected
@@ -205,11 +206,11 @@ no such bridge is in scope here. -/
     parameters `T_i Tnode T_iq`; the MCB conjunct does not reference the
     AL graph. The bundling is documentation, not a reduction. -/
 theorem adger_and_mcb_both_reject_sideward
-    (T_i Tnode T_iq : ConnesKreimer.TraceTree Minimalist.LIToken Unit) :
+    (T_i Tnode T_iq : RootedTree.Nonplanar (Minimalist.LIToken ⊕ Unit)) :
     -- MCB: Sideward 3(a)-shape transformation violates MinimalYieldWeak
     (¬ Minimalist.Merge.MinimalYieldWeak
-        ({T_i} : ConnesKreimer.TraceForest Minimalist.LIToken Unit)
-        ({Tnode, T_iq} : ConnesKreimer.TraceForest Minimalist.LIToken Unit))
+        ({T_i} : RootedTree.Forest (RootedTree.Nonplanar (Minimalist.LIToken ⊕ Unit)))
+        ({Tnode, T_iq} : RootedTree.Forest (RootedTree.Nonplanar (Minimalist.LIToken ⊕ Unit))))
     ∧
     -- Adger: the canonical Sideward subjunction configuration fails AL
     (g_sideward.satisfiesAL ⟨2, by decide⟩ ⟨1, by decide⟩ = false) :=

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -1,6 +1,7 @@
 import Linglib.Core.Combinatorics.RootedTree.Counting
 import Linglib.Core.Combinatorics.RootedTree.TraceCounting
 import Linglib.Core.Algebra.RootedTree.Coproduct.Conservation
+import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionConservation
 import Linglib.Core.Order.PullbackPreorder
 import Mathlib.Order.OrderDual
 
@@ -108,6 +109,22 @@ theorem im_pair_size_deltas_deletion (lbl : α) {T mover Q : Nonplanar (α ⊕ �
   · simp only [Forest.sigma, Forest.b₀_singleton, Forest.alpha_singleton]
     rw [hnode]
     omega
+
+/-- `im_pair_size_deltas_deletion` with the α relation discharged from a Δᵈ
+    admissible cut: deleting `mover` from `T` and rebinarizing the remainder
+    (`contractUnary p.2`) leaves `b₀`, `α`, `σ` unchanged. `unaryCount p.2 = 1`
+    characterizes a single edge cut at a binary node. -/
+theorem im_pair_size_deltas_deletion_of_cut (lbl : α) (T : Nonplanar (α ⊕ β))
+    (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) (hp : p ∈ ConnesKreimer.cutSummandsN T)
+    (mover : Nonplanar (α ⊕ β)) (hcard : p.1 = {mover}) (huc : p.2.unaryCount = 1) :
+    Forest.b₀ ({Nonplanar.node (Sum.inl lbl) {mover, Nonplanar.contractUnary p.2}}
+        : Forest (Nonplanar (α ⊕ β))) = Forest.b₀ ({T} : Forest (Nonplanar (α ⊕ β)))
+      ∧ Forest.alpha ({Nonplanar.node (Sum.inl lbl) {mover, Nonplanar.contractUnary p.2}}
+        : Forest (Nonplanar (α ⊕ β))) = Forest.alpha ({T} : Forest (Nonplanar (α ⊕ β)))
+      ∧ Forest.sigma ({Nonplanar.node (Sum.inl lbl) {mover, Nonplanar.contractUnary p.2}}
+        : Forest (Nonplanar (α ⊕ β))) = Forest.sigma ({T} : Forest (Nonplanar (α ⊕ β))) :=
+  im_pair_size_deltas_deletion lbl
+    (ConnesKreimer.cutSummandsN_accCount_single_deletion T p hp mover hcard huc)
 
 /-- Internal Merge via composition leaves `b₀` fixed and raises `αᶜ`, `σᶜ` by one
     (Δᶜ counting): the relation `αᶜ(T) = αᶜ(β_t) + αᶜ(trunk) + 1` is MCB eq. 1.6.8. -/

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -128,6 +128,27 @@ theorem im_pair_size_deltas_contraction (lbl : α) {T β_t Q : Nonplanar (α ⊕
     rw [Nonplanar.accCountC_merge lbl β_t Q hβ hQ]
     omega
 
+/-- `im_pair_size_deltas_contraction` with the αᶜ relation discharged from a Δᶜ
+    admissible cut: re-merging an accessible subtree `β_t` of `T = node (inl a₀) F₀`
+    with the contraction quotient `p.2` raises `αᶜ`, `σᶜ` by one. -/
+theorem im_pair_size_deltas_contraction_of_cut (lbl a₀ : α)
+    (τ : Nonplanar (α ⊕ β) → β) (F₀ : Forest (Nonplanar (α ⊕ β)))
+    (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β))
+    (hp : p ∈ cutSummandsCN τ (Nonplanar.node (Sum.inl a₀) F₀))
+    (β_t : Nonplanar (α ⊕ β)) (hcard : p.1 = {β_t}) :
+    Forest.b₀ ({Nonplanar.node (Sum.inl lbl) {β_t, p.2}} : Forest (Nonplanar (α ⊕ β)))
+        = Forest.b₀ ({Nonplanar.node (Sum.inl a₀) F₀} : Forest (Nonplanar (α ⊕ β)))
+      ∧ Forest.alphaC ({Nonplanar.node (Sum.inl lbl) {β_t, p.2}} : Forest (Nonplanar (α ⊕ β)))
+        = Forest.alphaC ({Nonplanar.node (Sum.inl a₀) F₀} : Forest (Nonplanar (α ⊕ β))) + 1
+      ∧ Forest.sigmaC ({Nonplanar.node (Sum.inl lbl) {β_t, p.2}} : Forest (Nonplanar (α ⊕ β)))
+        = Forest.sigmaC ({Nonplanar.node (Sum.inl a₀) F₀} : Forest (Nonplanar (α ⊕ β))) + 1 :=
+  im_pair_size_deltas_contraction lbl
+    (cutSummandsCN_crown_traceLeafCount_lt_weight τ _ p hp β_t
+      (by rw [hcard]; exact Multiset.mem_singleton_self β_t))
+    (Nonplanar.traceLeafCount_lt_weight_of_rootInl p.2 a₀
+      ((cutSummandsCN_trunk_rootLabel τ _ p hp).trans (by rw [Nonplanar.rootLabel_node])))
+    (cutSummandsCN_accCountC_single τ _ a₀ F₀ rfl p hp β_t hcard)
+
 /-! ### Sideward Merge -/
 
 /-- Sideward Merge of type 2(b) leaves the component count `b₀` unchanged. -/

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -1,4 +1,6 @@
-import Linglib.Syntax.Minimalist.Merge.External
+import Linglib.Core.Combinatorics.RootedTree.Counting
+import Linglib.Core.Combinatorics.RootedTree.TraceCounting
+import Linglib.Core.Algebra.RootedTree.Coproduct.Conservation
 import Linglib.Core.Order.PullbackPreorder
 import Mathlib.Order.OrderDual
 
@@ -6,452 +8,190 @@ import Mathlib.Order.OrderDual
 # Minimal Yield (MCB Definition 1.6.1)
 [marcolli-chomsky-berwick-2025] §1.6.1, Def 1.6.1 on book p. 63
 
-Realises M-C-B's **Minimal Yield principle** as a predicate on forest
-transformations and proves the per-merge counting characterizations of
-**Prop 1.6.4** (EM/IM, book p. 66) and **Prop 1.6.8** (Sideward, book p. 69).
+M-C-B's **Minimal Yield principle** as a predicate on workspace transformations,
+with the per-merge counting characterizations of **Prop 1.6.4** (EM/IM, p. 66)
+and **Prop 1.6.8** (Sideward, p. 69), on the canonical nonplanar carrier
+`Nonplanar (α ⊕ β)` (`Sum.inl` lexical, `Sum.inr` trace). A *workspace* is a
+`Forest (Nonplanar (α ⊕ β)) = Multiset (Nonplanar (α ⊕ β))`; External Merge of
+`S`, `S'` builds `Nonplanar.node (Sum.inl lbl) {S, S'}`.
 
-The principle (Def 1.6.1, eq. 1.6.2) asks three things of a transformation
-`Φ`: `b₀(Φ F) ≤ b₀ F` (no divergence), `α(Φ F) ≥ α F` (no information loss),
-and `σ(Φ F) = σ F + 1` (minimality of yield). MCB's parenthetical **weak
-form** drops the last condition; we provide `MinimalYield` (strong) and
-`MinimalYieldWeak` (the first two bounds only). The strong form rules out
-Sideward 3(a)/3(b) under Δ^c, the weak form under Δ^d (p. 69).
+The principle (Def 1.6.1, eq. 1.6.2) asks of a transformation `Φ`:
+`b₀(Φ F) ≤ b₀ F` (no divergence), `α(Φ F) ≥ α F` (no information loss),
+`σ(Φ F) = σ F + 1` (minimal yield). `MinimalYield` (strong) and
+`MinimalYieldWeak` (first two bounds) are stated relationally.
 
 ## Per-merge signatures (Prop 1.6.4 + Prop 1.6.8)
 
 | Merge | Δb₀ | Δα | Δσ | Strong | Weak |
 |---|---|---|---|---|---|
-| External (Δ^c, Δ^d) | −1 | +2 | +1 | ✓ | ✓ |
-| Internal w/ Δ^c | 0 | +1 | +1 | ✓ | ✓ |
-| Internal w/ Δ^d | 0 | 0 | 0 | ✗ (Δσ=0) | ✓ |
-| Sideward 2(b) Δ^c | 0 | +1 | +1 | ✓ | ✓ |
-| Sideward 2(b) Δ^d | 0 | 0 | 0 | ✗ (Δσ=0) | ✓ |
-| Sideward 3(a) Δ^c | +1 | 0 | +1 | ✗ (Δb₀>0) | ✗ (Δb₀>0) |
-| Sideward 3(a) Δ^d | +1 | −2 | −1 | ✗ (Δb₀>0) | ✗ (Δb₀>0) |
-| Sideward 3(b) Δ^c | +1 | 0 | +1 | ✗ (Δb₀>0) | ✗ (Δb₀>0) |
-| Sideward 3(b) Δ^d | +1 | −2 | −1 | ✗ (Δb₀>0) | ✗ (Δb₀>0) |
+| External | −1 | +2 | +1 | ✓ | ✓ |
+| Internal Δᶜ | 0 | +1 | +1 | ✓ | ✓ |
+| Internal Δᵈ | 0 | 0 | 0 | ✗ | ✓ |
+| Sideward 2(b) Δᶜ | 0 | +1 | +1 | ✓ | ✓ |
+| Sideward 3(a)/3(b) | +1 | ⋯ | ⋯ | ✗ | ✗ |
 
-`sideward_3a_size_deltas_deletion` proves the 3(a)/Δ^d row generalized over
-`numContractions c_i`, with `..._specific` recovering MCB's stated
-(+1, −2, −1) for the 2-edge cut via `numContractions_twoEdge`.
-
-IM/Δ^d and Sideward 2(b)/Δ^d share the (0, 0, 0) signature (**Remark 1.6.9**,
-book p. 71): indistinguishable by sizes, separated only by No Complexity Loss
-(`InducedMapNCL` / `sideward_2b_violatesInducedMapNCL` in `NoComplexityLoss.lean`).
+The size-delta theorems take the accessible-term relation as a hypothesis
+(`accCount`/`accCountC` extraction, MCB Lemma 1.6.3, eqs. 1.6.7/1.6.8);
 Sideward 3(a)/3(b) are ruled out by both forms via Δb₀ > 0.
-
-## TODO
-
-Define the per-transformation lift `MinimalYieldTransformation Φ := ∀ F, MinimalYield F (Φ F)`
-(and its weak analogue); the violation theorems here are currently stated on the
-case-specific workspace shapes rather than on a `Φ`.
 -/
 
 namespace Minimalist.Merge
 
-open ConnesKreimer TraceTree TraceForest
+open RootedTree
 
 variable {α β : Type*}
 
-/-- The weak Minimal Yield principle: a forest transformation does not
-    increase `b₀` and does not decrease `α`. -/
-structure MinimalYieldWeak (F F' : TraceForest α β) : Prop where
-  noDivergence  : F'.b₀ ≤ F.b₀
-  noInfoLoss    : F.alpha ≤ F'.alpha
+/-! ### The Minimal Yield principle -/
 
-/-- The Minimal Yield principle: the weak form together with `σ` increasing
-    by exactly one. -/
-structure MinimalYield (F F' : TraceForest α β) : Prop extends MinimalYieldWeak F F' where
-  minimalYield  : F'.sigma = F.sigma + 1
+/-- The weak Minimal Yield principle: no increase in `b₀`, no decrease in `α`. -/
+structure MinimalYieldWeak (F F' : Forest (Nonplanar (α ⊕ β))) : Prop where
+  noDivergence : Forest.b₀ F' ≤ Forest.b₀ F
+  noInfoLoss   : Forest.alpha F ≤ Forest.alpha F'
 
-/-! ### `MinimalYieldWeak` as a Pareto pullback preorder
+/-- The Minimal Yield principle: the weak form plus `σ` up by exactly one. -/
+structure MinimalYield (F F' : Forest (Nonplanar (α ⊕ β))) : Prop
+    extends MinimalYieldWeak F F' where
+  minimalYield : Forest.sigma F' = Forest.sigma F + 1
 
-The two `MinimalYieldWeak` bounds are a Pareto comparison on the `(b₀ᵒᵈ, α)`
-signature (`b₀` dualised so fewer components ranks higher), sharing the
-`PullbackPreorder` shape of `DerivationCost.pullbackPreorder` and
-`Core.Optimization.paretoPullbackPreorder`. The strong form is outside this
-picture: its `σ = +1` is an equality, not a ≤. -/
+/-! ### `MinimalYieldWeak` as a Pareto pullback preorder -/
 
-/-- The Pareto signature `(b₀ᵒᵈ, α)` of a forest, with `b₀` dualised so that
-    fewer components ranks higher. -/
-def MinimalYieldSignature (F : TraceForest α β) : ℕᵒᵈ × ℕ :=
-  (OrderDual.toDual F.b₀, F.alpha)
+/-- The Pareto signature `(b₀ᵒᵈ, α)`, `b₀` dualised so fewer components ranks higher. -/
+def MinimalYieldSignature (F : Forest (Nonplanar (α ⊕ β))) : ℕᵒᵈ × ℕ :=
+  (OrderDual.toDual (Forest.b₀ F), Forest.alpha F)
 
-/-- `MinimalYieldWeak F F'` is exactly the Pareto order on the `(b₀ᵒᵈ, α)`
-    signature. -/
-theorem minimalYieldWeak_iff_signature_le {F F' : TraceForest α β} :
+theorem minimalYieldWeak_iff_signature_le {F F' : Forest (Nonplanar (α ⊕ β))} :
     MinimalYieldWeak F F' ↔ MinimalYieldSignature F ≤ MinimalYieldSignature F' :=
-  ⟨fun ⟨h_b, h_a⟩ => ⟨h_b, h_a⟩,
-   fun ⟨h_b, h_a⟩ => ⟨h_b, h_a⟩⟩
+  ⟨fun ⟨h_b, h_a⟩ => ⟨h_b, h_a⟩, fun ⟨h_b, h_a⟩ => ⟨h_b, h_a⟩⟩
 
-/-- `MinimalYieldWeak` packaged as a `Core.Order.PullbackPreorder` via
-    `MinimalYieldSignature`. Not a `Preorder TraceForest` instance:
-    `TraceForest` already carries the multiset order. -/
+/-- `MinimalYieldWeak` packaged as a `PullbackPreorder`. -/
 def minimalYieldWeakPullbackPreorder :
-    Core.Order.PullbackPreorder (TraceForest α β) (ℕᵒᵈ × ℕ) :=
-  Core.Order.PullbackPreorder.ofProj MinimalYieldSignature
-    (fun _ _ => inferInstance)
+    Core.Order.PullbackPreorder (Forest (Nonplanar (α ⊕ β))) (ℕᵒᵈ × ℕ) :=
+  Core.Order.PullbackPreorder.ofProj MinimalYieldSignature (fun _ _ => inferInstance)
 
 /-! ### External Merge -/
 
 /-- External Merge of a pair satisfies Minimal Yield: Δb₀ = −1, Δα = +2, Δσ = +1. -/
-theorem em_pair_satisfiesMinimalYield (S S' : TraceTree α β) :
-    MinimalYield ({S, S'} : TraceForest α β)
-                 ({.node S S'} : TraceForest α β) := by
-  refine ⟨⟨?_, ?_⟩, ?_⟩ <;>
-    simp only [Multiset.insert_eq_cons, b₀_singleton, b₀_cons, alpha_singleton, alpha_cons,
-      accCount_merge, sigma_singleton, sigma_cons] <;>
+theorem em_pair_satisfiesMinimalYield (lbl : α) (S S' : Nonplanar (α ⊕ β)) :
+    MinimalYield ({S, S'} : Forest (Nonplanar (α ⊕ β)))
+                 ({Nonplanar.node (Sum.inl lbl) {S, S'}}) := by
+  have hnode : (Nonplanar.node (Sum.inl lbl) {S, S'}).accCount
+      = S.accCount + S'.accCount + 2 := Nonplanar.accCount_merge (Sum.inl lbl) S S'
+  refine ⟨⟨?_, ?_⟩, ?_⟩
+  · simp only [Forest.b₀_singleton, Multiset.insert_eq_cons, Forest.b₀_cons, Forest.b₀_zero]
+    omega
+  · rw [Forest.alpha_singleton, hnode]
+    simp only [Multiset.insert_eq_cons, Forest.alpha_cons, Forest.alpha_singleton]
+    omega
+  · simp only [Forest.sigma, Forest.b₀_singleton, Forest.alpha_singleton]
+    rw [hnode]
+    simp only [Multiset.insert_eq_cons, Forest.b₀_cons, Forest.b₀_singleton, Forest.b₀_zero,
+      Forest.alpha_cons, Forest.alpha_singleton]
     omega
 
-/-! ### Internal Merge, Δ^d -/
+/-! ### Internal Merge -/
 
-/-- Internal Merge via composition leaves `b₀`, `α`, and `σ` unchanged (Δ^d counting). -/
-theorem im_pair_size_deltas_deletion {T mover Q : TraceTree α β}
+/-- Internal Merge via composition leaves `b₀`, `α`, `σ` unchanged (Δᵈ counting):
+    the accessible-term relation `α(T) = α(mover) + α(Q) + 2` is MCB eq. 1.6.7. -/
+theorem im_pair_size_deltas_deletion (lbl : α) {T mover Q : Nonplanar (α ⊕ β)}
     (h : T.accCount = mover.accCount + Q.accCount + 2) :
-    b₀ ({.node mover Q} : TraceForest α β)
-        = b₀ ({T} : TraceForest α β)
-      ∧
-    alpha ({.node mover Q} : TraceForest α β)
-        = alpha ({T} : TraceForest α β)
-      ∧
-    sigma ({.node mover Q} : TraceForest α β)
-        = sigma ({T} : TraceForest α β) := by
-  refine ⟨rfl, ?_, ?_⟩ <;>
-    simp only [alpha_singleton, sigma_singleton, accCount_merge, h]
+    Forest.b₀ ({Nonplanar.node (Sum.inl lbl) {mover, Q}} : Forest (Nonplanar (α ⊕ β)))
+        = Forest.b₀ ({T} : Forest (Nonplanar (α ⊕ β)))
+      ∧ Forest.alpha ({Nonplanar.node (Sum.inl lbl) {mover, Q}} : Forest (Nonplanar (α ⊕ β)))
+        = Forest.alpha ({T} : Forest (Nonplanar (α ⊕ β)))
+      ∧ Forest.sigma ({Nonplanar.node (Sum.inl lbl) {mover, Q}} : Forest (Nonplanar (α ⊕ β)))
+        = Forest.sigma ({T} : Forest (Nonplanar (α ⊕ β))) := by
+  have hnode : (Nonplanar.node (Sum.inl lbl) {mover, Q}).accCount
+      = mover.accCount + Q.accCount + 2 := Nonplanar.accCount_merge (Sum.inl lbl) mover Q
+  refine ⟨rfl, ?_, ?_⟩
+  · rw [Forest.alpha_singleton, Forest.alpha_singleton, hnode]
+    omega
+  · simp only [Forest.sigma, Forest.b₀_singleton, Forest.alpha_singleton]
+    rw [hnode]
+    omega
 
-/-- `im_pair_size_deltas_deletion` with the size hypothesis discharged from a
-    single-edge cut. -/
-theorem im_pair_size_deltas_deletion_of_cut {T mover Q : TraceTree α β}
-    (c : CutShape T) (h_cf : c.cutForest = ({mover} : TraceForest α β))
-    (h_rd : c.remainderDeletion = some Q) :
-    b₀ ({.node mover Q} : TraceForest α β)
-        = b₀ ({T} : TraceForest α β)
-      ∧
-    alpha ({.node mover Q} : TraceForest α β)
-        = alpha ({T} : TraceForest α β)
-      ∧
-    sigma ({.node mover Q} : TraceForest α β)
-        = sigma ({T} : TraceForest α β) :=
-  im_pair_size_deltas_deletion (CutShape.singleEdgeCut_deletion_alpha c mover Q h_cf h_rd)
-
-/-! ### Internal Merge, Δ^c -/
-
-/-- Internal Merge via composition leaves `b₀` fixed and raises `αᶜ` and `σᶜ`
-    by one (Δ^c counting). -/
-theorem im_pair_size_deltas_contraction [Inhabited β]
-    {T β_t : TraceTree α β} (c : CutShape T)
-    (h_tf : T.nonTraceSize = T.size)
-    (h_cf : c.cutForest = ({β_t} : TraceForest α β)) :
-    b₀ ({(.node β_t c.remainder : TraceTree α β)} : TraceForest α β)
-        = b₀ ({T} : TraceForest α β)
-      ∧
-    alphaC ({(.node β_t c.remainder : TraceTree α β)} : TraceForest α β)
-        = alphaC ({T} : TraceForest α β) + 1
-      ∧
-    sigmaC ({(.node β_t c.remainder : TraceTree α β)} : TraceForest α β)
-        = sigmaC ({T} : TraceForest α β) + 1 := by
-  have h_β_tf := CutShape.nonTraceSize_eq_size_of_cutForest_singleton c β_t h_tf h_cf
-  have h_rem_pos : c.remainder.nonTraceSize ≥ 1 :=
-    CutShape.nonTraceSize_remainder_pos_of_cutForest_singleton c β_t h_cf
-  have h_β_pos : β_t.nonTraceSize ≥ 1 := by rw [h_β_tf]; exact β_t.size_pos
-  refine ⟨rfl, ?_, ?_⟩ <;>
-    simp only [alphaC_singleton, sigmaC_singleton,
-      accCountC_merge β_t c.remainder h_β_pos h_rem_pos,
-      CutShape.singleEdgeCut_contraction_alpha c β_t h_tf h_cf]
-  omega
+/-- Internal Merge via composition leaves `b₀` fixed and raises `αᶜ`, `σᶜ` by one
+    (Δᶜ counting): the relation `αᶜ(T) = αᶜ(β_t) + αᶜ(trunk) + 1` is MCB eq. 1.6.8. -/
+theorem im_pair_size_deltas_contraction (lbl : α) {T β_t Q : Nonplanar (α ⊕ β)}
+    (hβ : β_t.traceLeafCount < β_t.weight) (hQ : Q.traceLeafCount < Q.weight)
+    (h : T.accCountC = β_t.accCountC + Q.accCountC + 1) :
+    Forest.b₀ ({Nonplanar.node (Sum.inl lbl) {β_t, Q}} : Forest (Nonplanar (α ⊕ β)))
+        = Forest.b₀ ({T} : Forest (Nonplanar (α ⊕ β)))
+      ∧ Forest.alphaC ({Nonplanar.node (Sum.inl lbl) {β_t, Q}} : Forest (Nonplanar (α ⊕ β)))
+        = Forest.alphaC ({T} : Forest (Nonplanar (α ⊕ β))) + 1
+      ∧ Forest.sigmaC ({Nonplanar.node (Sum.inl lbl) {β_t, Q}} : Forest (Nonplanar (α ⊕ β)))
+        = Forest.sigmaC ({T} : Forest (Nonplanar (α ⊕ β))) + 1 := by
+  refine ⟨rfl, ?_, ?_⟩
+  · rw [Forest.alphaC_singleton, Forest.alphaC_singleton,
+        Nonplanar.accCountC_merge lbl β_t Q hβ hQ]
+    omega
+  · simp only [Forest.sigmaC, Forest.b₀_singleton, Forest.alphaC_singleton]
+    rw [Nonplanar.accCountC_merge lbl β_t Q hβ hQ]
+    omega
 
 /-! ### Sideward Merge -/
 
 /-- Sideward Merge of type 2(b) leaves the component count `b₀` unchanged. -/
-theorem sideward_2b_b₀_preserved (T_i T_j Tnode T_j_q : TraceTree α β) :
-    b₀ ({Tnode, T_j_q} : TraceForest α β)
-      = b₀ ({T_i, T_j} : TraceForest α β) := by
-  simp only [Multiset.insert_eq_cons, b₀_cons, b₀_singleton]
-
-/-- Sideward Merge of type 2(b) leaves `b₀`, `α`, and `σ` unchanged (Δ^d counting). -/
-theorem sideward_2b_size_deltas_deletion
-    {T_i T_j β_t Tnode T_j_q : TraceTree α β}
-    (h_T_j : T_j.accCount = β_t.accCount + T_j_q.accCount + 2)
-    (h_node : Tnode.accCount = T_i.accCount + β_t.accCount + 2) :
-    b₀ ({Tnode, T_j_q} : TraceForest α β)
-        = b₀ ({T_i, T_j} : TraceForest α β)
-      ∧
-    alpha ({Tnode, T_j_q} : TraceForest α β)
-        = alpha ({T_i, T_j} : TraceForest α β)
-      ∧
-    sigma ({Tnode, T_j_q} : TraceForest α β)
-        = sigma ({T_i, T_j} : TraceForest α β) := by
-  refine ⟨sideward_2b_b₀_preserved T_i T_j Tnode T_j_q, ?_, ?_⟩ <;>
-    simp only [Multiset.insert_eq_cons, alpha_cons, alpha_singleton, sigma_cons,
-      sigma_singleton, h_T_j, h_node] <;>
-    omega
-
-/-- `sideward_2b_size_deltas_deletion` with both hypotheses discharged from a
-    single-edge cut. -/
-theorem sideward_2b_size_deltas_deletion_of_cut
-    {T_i T_j β_t T_j_q : TraceTree α β}
-    (c : CutShape T_j) (h_cf : c.cutForest = ({β_t} : TraceForest α β))
-    (h_rd : c.remainderDeletion = some T_j_q) :
-    b₀ ({(.node T_i β_t : TraceTree α β), T_j_q} : TraceForest α β)
-        = b₀ ({T_i, T_j} : TraceForest α β)
-      ∧
-    alpha ({(.node T_i β_t : TraceTree α β), T_j_q}
-                          : TraceForest α β)
-        = alpha ({T_i, T_j} : TraceForest α β)
-      ∧
-    sigma ({(.node T_i β_t : TraceTree α β), T_j_q}
-                          : TraceForest α β)
-        = sigma ({T_i, T_j} : TraceForest α β) :=
-  sideward_2b_size_deltas_deletion
-    (CutShape.singleEdgeCut_deletion_alpha c β_t T_j_q h_cf h_rd)
-    (accCount_merge T_i β_t)
-
-/-- Sideward Merge of type 2(b) leaves `b₀` fixed and raises `αᶜ` and `σᶜ`
-    by one (Δ^c counting). -/
-theorem sideward_2b_size_deltas_contraction [Inhabited β]
-    {T_i T_j β_t : TraceTree α β}
-    (c : CutShape T_j) (h_T_j_tf : T_j.nonTraceSize = T_j.size)
-    (h_T_i_tf : T_i.nonTraceSize = T_i.size)
-    (h_cf : c.cutForest = ({β_t} : TraceForest α β)) :
-    b₀ ({(.node T_i β_t : TraceTree α β), c.remainder} : TraceForest α β)
-        = b₀ ({T_i, T_j} : TraceForest α β)
-      ∧
-    alphaC ({(.node T_i β_t : TraceTree α β), c.remainder} : TraceForest α β)
-        = alphaC ({T_i, T_j} : TraceForest α β) + 1
-      ∧
-    sigmaC ({(.node T_i β_t : TraceTree α β), c.remainder} : TraceForest α β)
-        = sigmaC ({T_i, T_j} : TraceForest α β) + 1 := by
-  have h_β_tf := CutShape.nonTraceSize_eq_size_of_cutForest_singleton c β_t h_T_j_tf h_cf
-  have h_rem_pos : c.remainder.nonTraceSize ≥ 1 :=
-    CutShape.nonTraceSize_remainder_pos_of_cutForest_singleton c β_t h_cf
-  have h_β_pos : β_t.nonTraceSize ≥ 1 := by rw [h_β_tf]; exact β_t.size_pos
-  have h_T_i_pos : T_i.nonTraceSize ≥ 1 := by rw [h_T_i_tf]; exact T_i.size_pos
-  refine ⟨sideward_2b_b₀_preserved T_i T_j _ c.remainder, ?_, ?_⟩ <;>
-    simp only [Multiset.insert_eq_cons, alphaC_cons, alphaC_singleton, sigmaC_cons,
-      sigmaC_singleton, accCountC_merge T_i β_t h_T_i_pos h_β_pos,
-      CutShape.singleEdgeCut_contraction_alpha c β_t h_T_j_tf h_cf] <;>
-    omega
+theorem sideward_2b_b₀_preserved (T_i T_j Tnode T_j_q : Nonplanar (α ⊕ β)) :
+    Forest.b₀ ({Tnode, T_j_q} : Forest (Nonplanar (α ⊕ β)))
+      = Forest.b₀ ({T_i, T_j} : Forest (Nonplanar (α ⊕ β))) := by
+  simp only [Multiset.insert_eq_cons, Forest.b₀_cons, Forest.b₀_singleton]
 
 /-- Sideward Merge of type 3(a) increases the component count `b₀` by one. -/
-theorem sideward_3a_b₀_increases (T_i Tnode T_iq : TraceTree α β) :
-    b₀ ({Tnode, T_iq} : TraceForest α β)
-      = b₀ ({T_i} : TraceForest α β) + 1 := by
-  simp only [Multiset.insert_eq_cons, b₀_cons, b₀_singleton]
+theorem sideward_3a_b₀_increases (T_i Tnode T_iq : Nonplanar (α ⊕ β)) :
+    Forest.b₀ ({Tnode, T_iq} : Forest (Nonplanar (α ⊕ β)))
+      = Forest.b₀ ({T_i} : Forest (Nonplanar (α ⊕ β))) + 1 := by
+  simp only [Multiset.insert_eq_cons, Forest.b₀_cons, Forest.b₀_singleton]
 
 /-- Sideward Merge of type 3(b) increases the component count `b₀` by one. -/
-theorem sideward_3b_b₀_increases
-    (T_i T_j Tnode T_iq T_jq : TraceTree α β) :
-    b₀ ({Tnode, T_iq, T_jq} : TraceForest α β)
-      = b₀ ({T_i, T_j} : TraceForest α β) + 1 := by
-  simp only [Multiset.insert_eq_cons, b₀_cons, b₀_singleton]
+theorem sideward_3b_b₀_increases (T_i T_j Tnode T_iq T_jq : Nonplanar (α ⊕ β)) :
+    Forest.b₀ ({Tnode, T_iq, T_jq} : Forest (Nonplanar (α ⊕ β)))
+      = Forest.b₀ ({T_i, T_j} : Forest (Nonplanar (α ⊕ β))) + 1 := by
+  simp only [Multiset.insert_eq_cons, Forest.b₀_cons, Forest.b₀_singleton]
 
-/-- Sideward Merge of type 3(b): Δb₀ = +1, Δα = −2, Δσ = −1 (Δ^d counting). -/
-theorem sideward_3b_size_deltas_deletion
-    {T_i T_j a b T_iq T_jq : TraceTree α β}
-    (h_i : T_i.accCount = a.accCount + T_iq.accCount + 2)
-    (h_j : T_j.accCount = b.accCount + T_jq.accCount + 2) :
-    b₀ ({(.node a b : TraceTree α β), T_iq, T_jq} : TraceForest α β)
-        = b₀ ({T_i, T_j} : TraceForest α β) + 1
-      ∧
-    alpha ({(.node a b : TraceTree α β), T_iq, T_jq}
-                          : TraceForest α β) + 2
-        = alpha ({T_i, T_j} : TraceForest α β)
-      ∧
-    sigma ({(.node a b : TraceTree α β), T_iq, T_jq}
-                          : TraceForest α β) + 1
-        = sigma ({T_i, T_j} : TraceForest α β) := by
-  refine ⟨sideward_3b_b₀_increases T_i T_j _ T_iq T_jq, ?_, ?_⟩ <;>
-    simp only [Multiset.insert_eq_cons, alpha_cons, alpha_singleton, sigma_cons,
-      sigma_singleton, accCount_merge, h_i, h_j] <;>
-    omega
-
-/-- `sideward_3b_size_deltas_deletion` with both size hypotheses discharged from
-    single-edge cuts. -/
-theorem sideward_3b_size_deltas_deletion_of_cut
-    {T_i T_j a b T_iq T_jq : TraceTree α β}
-    (c_i : CutShape T_i) (h_cf_i : c_i.cutForest = ({a} : TraceForest α β))
-    (h_rd_i : c_i.remainderDeletion = some T_iq)
-    (c_j : CutShape T_j) (h_cf_j : c_j.cutForest = ({b} : TraceForest α β))
-    (h_rd_j : c_j.remainderDeletion = some T_jq) :
-    b₀ ({(.node a b : TraceTree α β), T_iq, T_jq} : TraceForest α β)
-        = b₀ ({T_i, T_j} : TraceForest α β) + 1
-      ∧
-    alpha ({(.node a b : TraceTree α β), T_iq, T_jq}
-                          : TraceForest α β) + 2
-        = alpha ({T_i, T_j} : TraceForest α β)
-      ∧
-    sigma ({(.node a b : TraceTree α β), T_iq, T_jq}
-                          : TraceForest α β) + 1
-        = sigma ({T_i, T_j} : TraceForest α β) :=
-  sideward_3b_size_deltas_deletion
-    (CutShape.singleEdgeCut_deletion_alpha c_i a T_iq h_cf_i h_rd_i)
-    (CutShape.singleEdgeCut_deletion_alpha c_j b T_jq h_cf_j h_rd_j)
-
-/-! ### Sideward 3(a): two-edge cut full deltas -/
-
-/-- Sideward Merge of type 3(a): Δb₀ = +1, with Δα and Δσ governed by the
-    cut's contraction count `numContractions c_i` (Δ^d counting). -/
-theorem sideward_3a_size_deltas_deletion
-    {T_i a b T_iq : TraceTree α β} (c_i : CutShape T_i)
-    (h_cf : c_i.cutForest = ({a, b} : TraceForest α β))
-    (h_rd : c_i.remainderDeletion = some T_iq) :
-    b₀ ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
-        = b₀ ({T_i} : TraceForest α β) + 1
-      ∧
-    alpha ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
-        + CutShape.numContractions c_i
-        = alpha ({T_i} : TraceForest α β)
-      ∧
-    sigma ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
-        + CutShape.numContractions c_i
-        = sigma ({T_i} : TraceForest α β) + 1 := by
-  have h := CutShape.pairCut_deletion_alpha c_i a b T_iq h_cf h_rd
-  refine ⟨sideward_3a_b₀_increases T_i _ T_iq, ?_, ?_⟩ <;>
-    simp only [Multiset.insert_eq_cons, alpha_cons, alpha_singleton, sigma_cons,
-      sigma_singleton, accCount_merge, h] <;>
-    omega
-
-/-- `sideward_3a_size_deltas_deletion` for a genuine 2-edge cut: Δb₀ = +1,
-    Δα = −2, Δσ = −1 (the contraction count is `2`). -/
-theorem sideward_3a_size_deltas_deletion_specific
-    {T_i a b T_iq : TraceTree α β} (c_i : CutShape T_i)
-    (h_cf : c_i.cutForest = ({a, b} : TraceForest α β))
-    (h_rd : c_i.remainderDeletion = some T_iq) :
-    b₀ ({(.node a b : TraceTree α β), T_iq} : TraceForest α β)
-        = b₀ ({T_i} : TraceForest α β) + 1
-      ∧
-    alpha ({(.node a b : TraceTree α β), T_iq} : TraceForest α β) + 2
-        = alpha ({T_i} : TraceForest α β)
-      ∧
-    sigma ({(.node a b : TraceTree α β), T_iq} : TraceForest α β) + 1
-        = sigma ({T_i} : TraceForest α β) := by
-  have h_card : c_i.cutForest.card = 2 := by
-    rw [h_cf, show ({a, b} : TraceForest α β) = a ::ₘ ({b} : TraceForest α β) from rfl,
-        Multiset.card_cons, Multiset.card_singleton]
-  have h_nc := CutShape.numContractions_twoEdge c_i T_iq h_card h_rd
-  have ⟨h_b₀, h_α, h_σ⟩ := sideward_3a_size_deltas_deletion c_i h_cf h_rd
-  rw [h_nc] at h_α h_σ
-  refine ⟨h_b₀, h_α, ?_⟩
-  omega
-
-/-- Sideward Merge of type 3(a): Δb₀ = +1, Δαᶜ = 0, Δσᶜ = +1 (Δ^c counting). -/
-theorem sideward_3a_size_deltas_contraction [Inhabited β]
-    {T_i a b : TraceTree α β} (c_i : CutShape T_i)
-    (h_T_i_tf : T_i.nonTraceSize = T_i.size)
-    (h_cf : c_i.cutForest = ({a, b} : TraceForest α β)) :
-    b₀ ({(.node a b : TraceTree α β), c_i.remainder} : TraceForest α β)
-        = b₀ ({T_i} : TraceForest α β) + 1
-      ∧
-    alphaC ({(.node a b : TraceTree α β), c_i.remainder} : TraceForest α β)
-        = alphaC ({T_i} : TraceForest α β)
-      ∧
-    sigmaC ({(.node a b : TraceTree α β), c_i.remainder} : TraceForest α β)
-        = sigmaC ({T_i} : TraceForest α β) + 1 := by
-  have h_a_tf : a.nonTraceSize = a.size := by
-    apply CutShape.nonTraceSize_eq_size_of_mem_cutForest c_i a h_T_i_tf
-    rw [h_cf]; exact Multiset.mem_cons_self _ _
-  have h_b_tf : b.nonTraceSize = b.size := by
-    apply CutShape.nonTraceSize_eq_size_of_mem_cutForest c_i b h_T_i_tf
-    rw [h_cf]
-    rw [show ({a, b} : TraceForest α β) = a ::ₘ ({b} : TraceForest α β) from rfl,
-        Multiset.mem_cons]
-    right; exact Multiset.mem_singleton.mpr rfl
-  have h_rem_pos : c_i.remainder.nonTraceSize ≥ 1 := by
-    cases T_i with
-    | leaf _ =>
-        cases c_i; simp only [CutShape.cutForest] at h_cf
-        have : a ∈ ({a, b} : TraceForest α β) := Multiset.mem_cons_self _ _
-        rw [← h_cf] at this; exact absurd this (Multiset.notMem_zero _)
-    | trace _ =>
-        cases c_i; simp only [CutShape.cutForest] at h_cf
-        have : a ∈ ({a, b} : TraceForest α β) := Multiset.mem_cons_self _ _
-        rw [← h_cf] at this; exact absurd this (Multiset.notMem_zero _)
-    | node _ _ => exact CutShape.nonTraceSize_remainder_pos_of_node c_i
-  have h_a_pos : a.nonTraceSize ≥ 1 := by rw [h_a_tf]; exact a.size_pos
-  have h_b_pos : b.nonTraceSize ≥ 1 := by rw [h_b_tf]; exact b.size_pos
-  refine ⟨sideward_3a_b₀_increases T_i _ c_i.remainder, ?_, ?_⟩ <;>
-    simp only [Multiset.insert_eq_cons, alphaC_cons, alphaC_singleton, sigmaC_cons,
-      sigmaC_singleton, accCountC_merge a b h_a_pos h_b_pos,
-      CutShape.pairCut_contraction_alpha c_i a b h_T_i_tf h_cf h_rem_pos] <;>
-    omega
-
-/-- Sideward Merge of type 3(b): Δb₀ = +1, Δαᶜ = 0, Δσᶜ = +1 (Δ^c counting). -/
-theorem sideward_3b_size_deltas_contraction [Inhabited β]
-    {T_i T_j a b : TraceTree α β}
-    (c_i : CutShape T_i) (h_T_i_tf : T_i.nonTraceSize = T_i.size)
-    (h_cf_i : c_i.cutForest = ({a} : TraceForest α β))
-    (c_j : CutShape T_j) (h_T_j_tf : T_j.nonTraceSize = T_j.size)
-    (h_cf_j : c_j.cutForest = ({b} : TraceForest α β)) :
-    b₀ ({(.node a b : TraceTree α β), c_i.remainder, c_j.remainder}
-                       : TraceForest α β)
-        = b₀ ({T_i, T_j} : TraceForest α β) + 1
-      ∧
-    alphaC ({(.node a b : TraceTree α β), c_i.remainder, c_j.remainder}
-                          : TraceForest α β)
-        = alphaC ({T_i, T_j} : TraceForest α β)
-      ∧
-    sigmaC ({(.node a b : TraceTree α β), c_i.remainder, c_j.remainder}
-                          : TraceForest α β)
-        = sigmaC ({T_i, T_j} : TraceForest α β) + 1 := by
-  have h_a_tf := CutShape.nonTraceSize_eq_size_of_cutForest_singleton c_i a h_T_i_tf h_cf_i
-  have h_b_tf := CutShape.nonTraceSize_eq_size_of_cutForest_singleton c_j b h_T_j_tf h_cf_j
-  have h_a_pos : a.nonTraceSize ≥ 1 := by rw [h_a_tf]; exact a.size_pos
-  have h_b_pos : b.nonTraceSize ≥ 1 := by rw [h_b_tf]; exact b.size_pos
-  refine ⟨sideward_3b_b₀_increases _ _ _ c_i.remainder c_j.remainder, ?_, ?_⟩ <;>
-    simp only [Multiset.insert_eq_cons, alphaC_cons, alphaC_singleton, sigmaC_cons,
-      sigmaC_singleton, accCountC_merge a b h_a_pos h_b_pos,
-      CutShape.singleEdgeCut_contraction_alpha c_i a h_T_i_tf h_cf_i,
-      CutShape.singleEdgeCut_contraction_alpha c_j b h_T_j_tf h_cf_j] <;>
-    omega
-
-/-- Sideward Merge of type 3(a) violates the weak Minimal Yield principle, since
-    `b₀` increases. -/
-theorem sideward_3a_violates_noDivergenceWeak
-    (T_i Tnode T_iq : TraceTree α β) :
-    ¬ MinimalYieldWeak ({T_i} : TraceForest α β)
-                       ({Tnode, T_iq} : TraceForest α β) := by
+/-- Sideward Merge of type 3(a) violates the weak Minimal Yield principle (Δb₀ > 0). -/
+theorem sideward_3a_violates_noDivergenceWeak (T_i Tnode T_iq : Nonplanar (α ⊕ β)) :
+    ¬ MinimalYieldWeak ({T_i} : Forest (Nonplanar (α ⊕ β)))
+                       ({Tnode, T_iq} : Forest (Nonplanar (α ⊕ β))) := by
   intro h
   have hd := h.noDivergence
   rw [sideward_3a_b₀_increases T_i Tnode T_iq] at hd
   omega
 
-/-- Sideward Merge of type 3(b) violates the weak Minimal Yield principle, since
-    `b₀` increases. -/
+/-- Sideward Merge of type 3(b) violates the weak Minimal Yield principle (Δb₀ > 0). -/
 theorem sideward_3b_violates_noDivergenceWeak
-    (T_i T_j Tnode T_iq T_jq : TraceTree α β) :
-    ¬ MinimalYieldWeak ({T_i, T_j} : TraceForest α β)
-                       ({Tnode, T_iq, T_jq} : TraceForest α β) := by
+    (T_i T_j Tnode T_iq T_jq : Nonplanar (α ⊕ β)) :
+    ¬ MinimalYieldWeak ({T_i, T_j} : Forest (Nonplanar (α ⊕ β)))
+                       ({Tnode, T_iq, T_jq} : Forest (Nonplanar (α ⊕ β))) := by
   intro h
   have hd := h.noDivergence
   rw [sideward_3b_b₀_increases T_i T_j Tnode T_iq T_jq] at hd
   omega
 
 /-- Strong-form corollary of `sideward_3a_violates_noDivergenceWeak`. -/
-theorem sideward_3a_violates_noDivergence (T_i Tnode T_iq : TraceTree α β) :
-    ¬ MinimalYield ({T_i} : TraceForest α β)
-                   ({Tnode, T_iq} : TraceForest α β) :=
+theorem sideward_3a_violates_noDivergence (T_i Tnode T_iq : Nonplanar (α ⊕ β)) :
+    ¬ MinimalYield ({T_i} : Forest (Nonplanar (α ⊕ β)))
+                   ({Tnode, T_iq} : Forest (Nonplanar (α ⊕ β))) :=
   fun h => sideward_3a_violates_noDivergenceWeak T_i Tnode T_iq h.toMinimalYieldWeak
 
 /-- Strong-form corollary of `sideward_3b_violates_noDivergenceWeak`. -/
 theorem sideward_3b_violates_noDivergence
-    (T_i T_j Tnode T_iq T_jq : TraceTree α β) :
-    ¬ MinimalYield ({T_i, T_j} : TraceForest α β)
-                   ({Tnode, T_iq, T_jq} : TraceForest α β) :=
+    (T_i T_j Tnode T_iq T_jq : Nonplanar (α ⊕ β)) :
+    ¬ MinimalYield ({T_i, T_j} : Forest (Nonplanar (α ⊕ β)))
+                   ({Tnode, T_iq, T_jq} : Forest (Nonplanar (α ⊕ β))) :=
   fun h => sideward_3b_violates_noDivergenceWeak T_i T_j Tnode T_iq T_jq h.toMinimalYieldWeak
 
 /-! ### Unit merge -/
 
-/-- The unit-merge stage `{T} → {β, T/β}` violates the weak Minimal Yield
-    principle, since `b₀` increases. -/
-theorem unitMerge_violates_noDivergenceWeak (T β_t Q : TraceTree α β) :
-    ¬ MinimalYieldWeak ({T} : TraceForest α β)
-                       ({β_t, Q} : TraceForest α β) :=
+/-- The unit-merge stage `{T} → {β, T/β}` violates weak Minimal Yield (Δb₀ > 0). -/
+theorem unitMerge_violates_noDivergenceWeak (T β_t Q : Nonplanar (α ⊕ β)) :
+    ¬ MinimalYieldWeak ({T} : Forest (Nonplanar (α ⊕ β)))
+                       ({β_t, Q} : Forest (Nonplanar (α ⊕ β))) :=
   sideward_3a_violates_noDivergenceWeak T β_t Q
 
 /-- Strong-form corollary of `unitMerge_violates_noDivergenceWeak`. -/
-theorem unitMerge_violates_noDivergence (T β_t Q : TraceTree α β) :
-    ¬ MinimalYield ({T} : TraceForest α β)
-                   ({β_t, Q} : TraceForest α β) :=
+theorem unitMerge_violates_noDivergence (T β_t Q : Nonplanar (α ⊕ β)) :
+    ¬ MinimalYield ({T} : Forest (Nonplanar (α ⊕ β)))
+                   ({β_t, Q} : Forest (Nonplanar (α ⊕ β))) :=
   sideward_3a_violates_noDivergence T β_t Q
 
 end Minimalist.Merge


### PR DESCRIPTION
Retypes MCB's Minimal Yield (Def 1.6.1) + the Prop 1.6.4/1.6.8 per-merge counting signatures onto the canonical `Nonplanar (α ⊕ β)` carrier, retiring the legacy planar-binary `TraceTree` version; migrates `Adger2025` (the sole consumer). Adds the cut-layer substrate it needs: `accCountC_merge` (eq 1.6.5), single + pair Δᶜ accessible-term extraction (eq 1.6.8), and the Δᵈ path — `contractUnary` (rebinarize, MCB Def 1.2.5) with its weight law, Δ^ρ deletion-cut vertex conservation, and the single-cut Δᵈ extraction (eq 1.6.7) — feeding both Δᶜ and Δᵈ `_of_cut` discharge variants. Phase D.