### PR TITLE
feat(Syntax/CCG): make coordinator role load-bearing in .coord interp

### DIFF
--- a/Linglib/Studies/Mueller2013.lean
+++ b/Linglib/Studies/Mueller2013.lean
@@ -144,7 +144,7 @@ def classifyCCGDerivStep : CCG.DerivStep → Option CombinationKind
   | .lex _ => none
   | .ftr _ _ => none
   | .btr _ _ => none
-  | .coord _ _ => none
+  | .coord _ _ _ => none
 
 /-! ### HPSG classification -/
 

--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -1,5 +1,6 @@
 import Linglib.Data.Examples.Steedman2000
 import Linglib.Fragments.English.Toy
+import Linglib.Fragments.English.Coordination
 import Linglib.Studies.BresnanEtAl1982
 import Linglib.Syntax.CCG.Basic
 import Linglib.Syntax.CCG.CrossSerial
@@ -68,7 +69,7 @@ theorem john_likes_and_mary_hates_beans_cat :
     john_likes_and_mary_hates_beans.cat = some S := rfl
 
 def john_sleeps_and_mary_sleeps : DerivStep :=
-  .coord
+  .coord .j
     (.bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩))
     (.bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"sleeps", IV⟩))
 
@@ -153,7 +154,7 @@ theorem getMeaning_john_likes_and_mary_hates_beans :
 
 /-- The spelled-out paraphrase "John likes beans and Mary hates beans". -/
 def john_likes_beans_and_mary_hates_beans : DerivStep :=
-  .coord
+  .coord .j
     (.bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"likes", TV⟩) (.lex ⟨"beans", NP⟩)))
     (.bapp (.lex ⟨"Mary", NP⟩) (.fapp (.lex ⟨"hates", TV⟩) (.lex ⟨"beans", NP⟩)))
 
@@ -163,6 +164,39 @@ yields the same predicate-argument structure as the canonical one. -/
 theorem nonConstituentCoord_eq_spelledOut :
     getMeaning (john_likes_and_mary_hates_beans.interp toySemLexicon) =
       getMeaning (john_likes_beans_and_mary_hates_beans.interp toySemLexicon) := rfl
+
+/-! ### The coordinator's `role` is truth-conditionally load-bearing
+
+`interp` reads the coordinator's `role` off the `.coord` node — it no longer hardcodes
+conjunction — so *which* coordinator a derivation uses is part of its truth conditions.
+Using the actual English fragment coordinators, conjoining a true sentence `p` and a false
+sentence `q` with `and_` (`role = .j`) gives `p ∧ q` (false), while `or_` (`role = .disj`)
+gives `p ∨ q` (true). They differ, so the marking's `role` field is load-bearing — flipping
+`English.Coordination.and_.role` to `.disj` would break the theorem below, rather than no
+theorem depending on it. -/
+
+/-- Minimal lexicon: sentence `p` is true, `q` is false. -/
+private def pqLex : SemLexicon Unit Unit := fun w _ =>
+  match w with
+  | "p" => some ⟨.atom .S, True⟩
+  | "q" => some ⟨.atom .S, False⟩
+  | _ => none
+
+private def dp : DerivStep := .lex ⟨"p", .atom .S⟩
+private def dq : DerivStep := .lex ⟨"q", .atom .S⟩
+
+/-- The coordinator's `role` flips the truth conditions: English `and_` yields `p ∧ q`,
+    `or_` yields `p ∨ q`, and these differ at `p = ⊤`, `q = ⊥`. Flipping a fragment
+    coordinator's `role` collapses the inequality, so the `role` marking is not decorative. -/
+theorem coord_role_load_bearing :
+    getMeaning ((DerivStep.coord English.Coordination.and_.role dp dq).interp pqLex) ≠
+    getMeaning ((DerivStep.coord English.Coordination.or_.role dp dq).interp pqLex) := by
+  have hand : getMeaning ((DerivStep.coord English.Coordination.and_.role dp dq).interp pqLex)
+      = some (True ∧ False) := rfl
+  have hor : getMeaning ((DerivStep.coord English.Coordination.or_.role dp dq).interp pqLex)
+      = some (True ∨ False) := rfl
+  rw [hand, hor, ne_eq, Option.some.injEq, eq_iff_iff]
+  exact fun h => (h.mpr (Or.inl trivial)).2
 
 end Coordination
 

--- a/Linglib/Syntax/CCG/Basic.lean
+++ b/Linglib/Syntax/CCG/Basic.lean
@@ -1,3 +1,5 @@
+import Linglib.Features.Coordination
+
 /-!
 # Combinatory Categorial Grammar (CCG)
 
@@ -153,7 +155,8 @@ inductive DerivStep where
   | fcompx : DerivStep → DerivStep → DerivStep -- forward crossed comp
   | ftr : DerivStep → Cat → DerivStep          -- forward type-raise to target
   | btr : DerivStep → Cat → DerivStep          -- backward type-raise to target
-  | coord : DerivStep → DerivStep → DerivStep  -- coordination (X and X ⇒ X)
+  | coord : Features.Coordination.CoordRole → DerivStep → DerivStep → DerivStep
+      -- coordination (X c X ⇒ X); `c` is the coordinator's role (and/or/but/nor)
   deriving Repr
 
 /-- Get the category of a derivation. -/
@@ -185,7 +188,7 @@ def DerivStep.cat : DerivStep → Option Cat
   | .btr d t => do
     let x ← d.cat
     some (backwardTypeRaise x t)
-  | .coord d1 d2 => do
+  | .coord _ d1 d2 => do
     let c1 ← d1.cat
     let c2 ← d2.cat
     coordinate c1 c2
@@ -195,7 +198,8 @@ def DerivStep.cat : DerivStep → Option Cat
 Combinatory rules concatenate their daughters and type-raising leaves the string
 untouched, so the yield is independent of the derivation's combinatory structure —
 the property that lets a CCG derivation witness a string language. (Coordination
-elides the conjunction word, which `DerivStep.coord` does not carry.) -/
+elides the conjunction's surface form in the yield; `DerivStep.coord` carries the
+coordinator's `role`, not its spelled-out word.) -/
 def DerivStep.yield : DerivStep → List String
   | .lex e => [e.form]
   | .fapp d1 d2 => d1.yield ++ d2.yield
@@ -205,7 +209,7 @@ def DerivStep.yield : DerivStep → List String
   | .fcompx d1 d2 => d1.yield ++ d2.yield
   | .ftr d _ => d.yield
   | .btr d _ => d.yield
-  | .coord d1 d2 => d1.yield ++ d2.yield
+  | .coord _ d1 d2 => d1.yield ++ d2.yield
 
 end Derivations
 
@@ -249,7 +253,7 @@ def DerivStep.opCount : DerivStep → Nat
   | .fcompx d1 d2 => 2 + d1.opCount + d2.opCount
   | .ftr d _ => 1 + d.opCount                     -- type-raising has cost
   | .btr d _ => 1 + d.opCount
-  | .coord d1 d2 => 1 + d1.opCount + d2.opCount
+  | .coord _ d1 d2 => 1 + d1.opCount + d2.opCount
 
 /-- Depth of derivation tree. -/
 def DerivStep.depth : DerivStep → Nat
@@ -261,7 +265,7 @@ def DerivStep.depth : DerivStep → Nat
   | .fcompx d1 d2 => 1 + max d1.depth d2.depth
   | .ftr d _ => 1 + d.depth
   | .btr d _ => 1 + d.depth
-  | .coord d1 d2 => 1 + max d1.depth d2.depth
+  | .coord _ d1 d2 => 1 + max d1.depth d2.depth
 
 example : derivesS john_sleeps = true := rfl
 example : derivesS john_sees_mary = true := rfl
@@ -283,7 +287,7 @@ def john_likes : DerivStep := .fcomp john_tr (.lex ⟨"likes", TV⟩)
 def mary_tr : DerivStep := .ftr (.lex ⟨"Mary", NP⟩) S
 def mary_hates : DerivStep := .fcomp mary_tr (.lex ⟨"hates", TV⟩)
 
-def john_likes_and_mary_hates : DerivStep := .coord john_likes mary_hates
+def john_likes_and_mary_hates : DerivStep := .coord .j john_likes mary_hates
 
 def john_likes_and_mary_hates_beans : DerivStep :=
   .fapp john_likes_and_mary_hates (.lex ⟨"beans", NP⟩)

--- a/Linglib/Syntax/CCG/Interface.lean
+++ b/Linglib/Syntax/CCG/Interface.lean
@@ -167,17 +167,18 @@ def DerivStep.interp {E W : Type} (d : DerivStep) (lex : SemLexicon E W)
       let ⟨x, m⟩ ← d.interp lex
       some ⟨backwardTypeRaise x t, T m⟩
 
-  | .coord d1 d2 => do
-      -- Coordination: X and X → X, via the Coordinator API (`Coordinator.op .j`,
-      -- here its runtime form `engineOp`; = generalized conjunction [partee-rooth-1983]),
-      -- restricted to conjoinable types.
+  | .coord role d1 d2 => do
+      -- Coordination: X c X → X, via the Coordinator API — the meaning is `Coordinator.op`
+      -- of the coordinator's own `role` (runtime form `engineOp`; = generalized conjunction
+      -- [partee-rooth-1983] at `.j`), restricted to conjoinable types. The `role` is read off
+      -- the derivation, so *which* coordinator is used is truth-conditionally load-bearing.
       let ⟨c1, m1⟩ ← d1.interp lex
       let ⟨c2, m2⟩ ← d2.interp lex
       if h : c1 = c2 then
         let ty := catToTy c1
         if ty.isConjoinable then
           let m2' : Denot E W (catToTy c1) := h ▸ m2
-          some ⟨c1, Coordinator.engineOp .j ty E W m1 m2'⟩
+          some ⟨c1, Coordinator.engineOp role ty E W m1 m2'⟩
         else none
       else none
 

--- a/Linglib/Syntax/CCG/Scope.lean
+++ b/Linglib/Syntax/CCG/Scope.lean
@@ -50,7 +50,7 @@ def analyzeDerivation : DerivStep → DerivationType
   | .fcompx _ _ => .composed
   | .ftr _ _ => .typeRaised
   | .btr _ _ => .typeRaised
-  | .coord d1 d2 =>
+  | .coord _ d1 d2 =>
     match analyzeDerivation d1, analyzeDerivation d2 with
     | .typeRaised, _ | _, .typeRaised => .typeRaised
     | .composed, _ | _, .composed => .composed


### PR DESCRIPTION
Discharges the coordinator marking's `role` (it was decorative — no theorem depended on it; CCG `.coord` hardcoded `.j`).

- `DerivStep.coord` now carries the coordinator's `role`; `interp` computes `engineOp role` instead of hardcoded conjunction.
- `Steedman2000.coord_role_load_bearing`: conjoining a true and a false sentence with English `and_` (`.j`) vs `or_` (`.disj`) gives different truth conditions — so flipping a fragment coordinator's `role` breaks the proof.

Prep for the coordination substrate reorg; independent of #417.