### PR TITLE
feat(Minimalist/Merge): ε-weighted Minimal Search, MCB Prop 1.5.1

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1880,6 +1880,7 @@ import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningDuality
 import Linglib.Core.Algebra.RootedTree.Coproduct.TraceNonplanar
 import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionNonplanar
+import Linglib.Core.Algebra.RootedTree.Coproduct.GenericNonplanar
 import Linglib.Core.Algebra.RootedTree.Coproduct.Conservation
 import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionConservation
 import Linglib.Core.Algebra.RootedTree.HopfAlgebraNonplanar
@@ -2182,6 +2183,7 @@ import Linglib.Syntax.Minimalist.Merge.NoComplexityLoss
 import Linglib.Syntax.Minimalist.Merge.MinimalYield
 import Linglib.Syntax.Minimalist.Merge.Phase
 import Linglib.Syntax.Minimalist.Merge.PhaseCoproduct
+import Linglib.Syntax.Minimalist.Merge.MinimalSearch
 import Linglib.Syntax.Minimalist.SpellOut
 import Linglib.Syntax.Minimalist.Linearization.LCA
 import Linglib.Morphology.DM.VocabSimple

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Conservation.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Conservation.lean
@@ -200,6 +200,69 @@ theorem augActionG_traceLeafCount
 
 end
 
+mutual
+
+/-- **Crown trace leaves are bounded by the source's** (tree level): the extracted
+    crown forest of any cut has no more trace leaves than the whole tree, since
+    each crown component is a subtree. Independent of the replacement policy
+    (no `hext` hypothesis) — only the crown side is counted. Together with
+    `cutSummandsG_traceLeafCount` this forces ≥ 1 fresh trace per cut into the
+    trunk (`cutSummandsCN_trunk_traceLeafCount_ge_card`). -/
+theorem cutSummandsG_crown_traceLeafCount_le
+    (extract : Planar (α ⊕ β) → Option (List (Planar (α ⊕ β)))) :
+    ∀ (t : Planar (α ⊕ β)), ∀ p ∈ cutSummandsG extract t,
+      (Multiset.map Planar.traceLeafCount p.1).sum ≤ Planar.traceLeafCount t
+  | .node a cs => by
+    intro p hp
+    rw [cutSummandsG_node] at hp
+    obtain ⟨q, hq, rfl⟩ := Multiset.mem_map.mp hp
+    show (Multiset.map Planar.traceLeafCount q.1).sum ≤ Planar.traceLeafCount (.node a cs)
+    exact (cutListSummandsG_crown_traceLeafCount_le extract cs q hq).trans
+      (Planar.traceLeafCountList_le_node a cs)
+
+/-- Mutual aux: crown trace-leaf bound for children-list cut summands. -/
+theorem cutListSummandsG_crown_traceLeafCount_le
+    (extract : Planar (α ⊕ β) → Option (List (Planar (α ⊕ β)))) :
+    ∀ (cs : List (Planar (α ⊕ β))), ∀ q ∈ cutListSummandsG extract cs,
+      (Multiset.map Planar.traceLeafCount q.1).sum ≤ Planar.traceLeafCountList cs
+  | [] => by
+    intro q hq
+    rw [cutListSummandsG_nil] at hq
+    obtain rfl := Multiset.mem_singleton.mp hq
+    exact Nat.zero_le _
+  | t :: ts => by
+    intro q hq
+    rw [cutListSummandsG_cons] at hq
+    obtain ⟨pr, hpr, rfl⟩ := Multiset.mem_map.mp hq
+    obtain ⟨ha, hq'⟩ := Multiset.mem_product.mp hpr
+    have h1 := augActionG_crown_traceLeafCount_le extract t pr.1 ha
+    have h2 := cutListSummandsG_crown_traceLeafCount_le extract ts pr.2 hq'
+    show (Multiset.map Planar.traceLeafCount (pr.1.1 + pr.2.1)).sum ≤
+      Planar.traceLeafCount t + Planar.traceLeafCountList ts
+    rw [Multiset.map_add, Multiset.sum_add]
+    omega
+
+/-- Mutual aux: crown trace-leaf bound for per-child actions. -/
+theorem augActionG_crown_traceLeafCount_le
+    (extract : Planar (α ⊕ β) → Option (List (Planar (α ⊕ β)))) :
+    ∀ (t : Planar (α ⊕ β)), ∀ a ∈ augActionG extract t,
+      (Multiset.map Planar.traceLeafCount a.1).sum ≤ Planar.traceLeafCount t
+  | t => by
+    intro a ha
+    rw [augActionG_eq] at ha
+    rcases Multiset.mem_add.mp ha with h | h
+    · cases hex : extract t with
+      | none => rw [hex] at h; exact absurd h (Multiset.notMem_zero a)
+      | some r =>
+        rw [hex] at h
+        obtain rfl := Multiset.mem_singleton.mp h
+        show (Multiset.map Planar.traceLeafCount {t}).sum ≤ Planar.traceLeafCount t
+        simp only [Multiset.map_singleton, Multiset.sum_singleton, le_refl]
+    · obtain ⟨p, hp, rfl⟩ := Multiset.mem_map.mp h
+      exact cutSummandsG_crown_traceLeafCount_le extract t p hp
+
+end
+
 /-- The Δ^c extraction policy leaves unit-trace-count replacements. -/
 private theorem extractC_traceLeafCountList_one (τ : Planar (α ⊕ β) → β) :
     ∀ t r, extractC τ t = some r → Planar.traceLeafCountList r = 1 := by
@@ -279,6 +342,17 @@ theorem cutSummandsCN_weight (τ : Nonplanar (α ⊕ β) → β)
 def Cut.numContractions (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) : ℕ :=
   Multiset.card p.1
 
+/-- The **Minimal-Search depth** of a Δ^c cut summand (MCB §1.5.2): the total
+    extraction depth `Σ d_{v_i}`, read off the trunk's trace markers. The Δ^c
+    quotient places a trace leaf at each cut site at *exactly* the cut depth, so
+    the trunk's `traceDepthSum` is the signed `+d` extraction cost of MCB rule 1.
+    Under Internal Merge the matching `−d` quotient term (rule 2) references this
+    same value and cancels it (cost 0); Sideward Merge incurs it uncancelled
+    (cost > 0, `Cut.depthC_pos`). Depends only on the trunk `p.2`, like
+    `Cut.numContractions` depends only on the crown. -/
+def Cut.depthC (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) : ℕ :=
+  p.2.traceDepthSum
+
 /-- **Lexical (non-trace) vertex conservation**: combining weight and
     trace-leaf conservation, the trace leaf added at each cut is excluded
     from the lexical count exactly when the vertex it replaced is removed,
@@ -292,6 +366,40 @@ theorem cutSummandsCN_lexical_conservation (τ : Nonplanar (α ⊕ β) → β)
   intro p hp
   have hw := cutSummandsCN_weight τ T p hp
   have ht := cutSummandsCN_traceLeafCount τ T p hp
+  omega
+
+/-- **Crown trace leaves bounded by the source's**, descended to `Nonplanar`:
+    the extracted crown forest of a Δ^c cut has no more trace markers than `T`.
+    (Each crown component is a subtree of `T`.) -/
+theorem cutSummandsCN_crown_traceLeafCount_le (τ : Nonplanar (α ⊕ β) → β)
+    (T : Nonplanar (α ⊕ β)) :
+    ∀ p ∈ cutSummandsCN τ T,
+      (p.1.map Nonplanar.traceLeafCount).sum ≤ T.traceLeafCount := by
+  obtain ⟨T₀, rfl⟩ : ∃ T₀ : Planar (α ⊕ β), T = Nonplanar.mk T₀ :=
+    ⟨T.out, (Quotient.out_eq T).symm⟩
+  intro p hp
+  rw [cutSummandsCN_mk, ConnesKreimer.cutSummandsCP_def] at hp
+  obtain ⟨q, hq, rfl⟩ := Multiset.mem_map.mp hp
+  have hle := ConnesKreimer.cutSummandsG_crown_traceLeafCount_le
+    (ConnesKreimer.extractC (τ ∘ Nonplanar.mk)) T₀ q hq
+  show ((q.1.map Nonplanar.mk).map Nonplanar.traceLeafCount).sum ≤
+    (Nonplanar.mk T₀).traceLeafCount
+  rw [Nonplanar.traceLeafCount_mk, Multiset.map_map,
+      show q.1.map (Nonplanar.traceLeafCount ∘ Nonplanar.mk) =
+          q.1.map Planar.traceLeafCount from
+        Multiset.map_congr rfl (fun x _ => Nonplanar.traceLeafCount_mk x)]
+  exact hle
+
+/-- **Each Δ^c contraction leaves ≥ 1 trace marker in the trunk** (MCB Lemma
+    1.6.3 corollary): the trunk's trace count is at least the number of cuts.
+    From trace-leaf conservation (`Σtrace(crown) + trace(trunk) = trace(T) + #cuts`)
+    and the crown bound (`Σtrace(crown) ≤ trace(T)`). -/
+theorem cutSummandsCN_trunk_traceLeafCount_ge_card (τ : Nonplanar (α ⊕ β) → β)
+    (T : Nonplanar (α ⊕ β)) :
+    ∀ p ∈ cutSummandsCN τ T, Multiset.card p.1 ≤ p.2.traceLeafCount := by
+  intro p hp
+  have hcons := cutSummandsCN_traceLeafCount τ T p hp
+  have hle := cutSummandsCN_crown_traceLeafCount_le τ T p hp
   omega
 
 /-! ### Non-degeneracy: lexical-rooted pieces have a non-trace vertex
@@ -420,6 +528,20 @@ theorem traceLeafCount_lt_weight_of_rootInl (t : Nonplanar (α ⊕ β)) (a : α)
     rw [Nonplanar.traceLeafCount_mk, Nonplanar.weight_mk]
     exact Planar.traceLeafCount_lt_weight_of_inl a cs
 
+/-- A lexical-rooted nonplanar tree puts every trace marker at depth ≥ 1, so its
+    depth-weighted trace count dominates its plain trace count. -/
+theorem traceLeafCount_le_traceDepthSum_of_rootInl (t : Nonplanar (α ⊕ β)) (a : α)
+    (h : t.rootLabel = Sum.inl a) : t.traceLeafCount ≤ t.traceDepthSum := by
+  obtain ⟨t₀, rfl⟩ : ∃ t₀ : Planar (α ⊕ β), t = Nonplanar.mk t₀ :=
+    ⟨t.out, (Quotient.out_eq t).symm⟩
+  rw [Nonplanar.rootLabel_mk] at h
+  cases t₀ with
+  | node x cs =>
+    rw [Planar.label_node] at h
+    subst h
+    rw [Nonplanar.traceLeafCount_mk, Nonplanar.traceDepthSum_mk]
+    exact Planar.traceLeafCount_le_traceDepthSum_of_inl a cs
+
 end Nonplanar
 
 /-! ### α extraction identity (MCB eq. 1.6.8) -/
@@ -519,5 +641,71 @@ theorem cutSummandsCN_accCountC_pair (τ : Nonplanar (α ⊕ β) → β)
     Multiset.card_singleton] at hw hl
   simp only [Nonplanar.accCountC, Nonplanar.accCount]
   omega
+
+/-! ### Minimal-Search positivity (MCB Prop 1.5.1, Sideward direction) -/
+
+/-- **A proper Δ^c cut of a lexical-rooted object costs ≥ 1** (MCB Prop 1.5.1).
+    The trunk keeps the tree's lexical root (`cutSummandsCN_trunk_rootLabel`), so
+    each of its `#cuts ≥ 1` fresh trace markers sits at depth ≥ 1; hence the
+    Minimal-Search depth `Cut.depthC p = Σ d_{v_i} ≥ #cuts ≥ 1`. This is the
+    uncancelled Sideward cost that vanishes at ε → 0, leaving only the cost-0
+    External and Internal Merges. -/
+theorem Cut.depthC_pos (τ : Nonplanar (α ⊕ β) → β) (T : Nonplanar (α ⊕ β)) (a₀ : α)
+    (hT : T.rootLabel = Sum.inl a₀)
+    (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) (hp : p ∈ cutSummandsCN τ T)
+    (hproper : p.1 ≠ 0) :
+    1 ≤ Cut.depthC p := by
+  have htrunk_root : p.2.rootLabel = Sum.inl a₀ :=
+    (cutSummandsCN_trunk_rootLabel τ T p hp).trans hT
+  have h1 : Multiset.card p.1 ≤ p.2.traceLeafCount :=
+    cutSummandsCN_trunk_traceLeafCount_ge_card τ T p hp
+  have h2 : p.2.traceLeafCount ≤ p.2.traceDepthSum :=
+    Nonplanar.traceLeafCount_le_traceDepthSum_of_rootInl p.2 a₀ htrunk_root
+  have h3 : 1 ≤ Multiset.card p.1 := by
+    rw [Nat.one_le_iff_ne_zero, Ne, Multiset.card_eq_zero]; exact hproper
+  show 1 ≤ p.2.traceDepthSum
+  omega
+
+/-! ### Signed Minimal-Search cost (MCB §1.5.2 rules 1–2)
+
+The cost of a Merge `𝔐(α,β)` sums the *signed* depth-costs of its two operands.
+An extracted accessible term costs `+d` (rule 1); a contraction quotient costs
+`−d` (rule 2). Internal Merge re-grafts an extracted crown with its own quotient,
+so the two costs of the *same* cut cancel; Sideward Merge grafts a crown with a
+non-matching partner, leaving `+d` uncancelled. -/
+
+/-- **Extraction cost** of a Δ^c cut (MCB rule 1): pulling out the crown costs
+    `+d`, the cut depth `Cut.depthC`. Signed (ℤ) so it can cancel the quotient
+    cost under Internal Merge. -/
+def Cut.extractionCost (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) : ℤ :=
+  (Cut.depthC p : ℤ)
+
+/-- **Quotient cost** of a Δ^c cut (MCB rule 2): the contraction quotient (trunk)
+    costs `−d` — a deep quotient is close to the whole tree, hence cheap. The
+    negative companion to `Cut.extractionCost`. -/
+def Cut.quotientCost (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) : ℤ :=
+  -(Cut.depthC p : ℤ)
+
+/-- **Internal Merge cancellation** (MCB Prop 1.5.1, IM bullet): re-merging an
+    extracted crown `T_v` with its OWN quotient `T_i/T_v` sums the two signed
+    costs of the *same* cut, `(+d) + (−d) = 0` — the cost-0 that survives ε → 0.
+    Derives from the two signed rules, not stipulated. -/
+theorem Cut.extractionCost_add_quotientCost
+    (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) :
+    Cut.extractionCost p + Cut.quotientCost p = 0 := by
+  simp only [Cut.extractionCost, Cut.quotientCost, add_neg_cancel]
+
+/-- **Sideward Merge cost is positive** (MCB Prop 1.5.1, Sideward bullets):
+    grafting an extracted crown of a lexical-rooted object with a non-matching
+    partner leaves the `+d` extraction cost uncancelled (no quotient operand to
+    supply the `−d`). Vanishes at ε → 0. -/
+theorem Cut.extractionCost_pos (τ : Nonplanar (α ⊕ β) → β) (T : Nonplanar (α ⊕ β))
+    (a₀ : α) (hT : T.rootLabel = Sum.inl a₀)
+    (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) (hp : p ∈ cutSummandsCN τ T)
+    (hproper : p.1 ≠ 0) :
+    0 < Cut.extractionCost p := by
+  have h := Cut.depthC_pos τ T a₀ hT p hp hproper
+  simp only [Cut.extractionCost]
+  exact_mod_cast h
 
 end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/GenericNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/GenericNonplanar.lean
@@ -1,0 +1,127 @@
+import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
+
+set_option autoImplicit false
+
+/-!
+# Generic admissible-cut coproduct on `ConnesKreimer R (Nonplanar α)`
+[marcolli-chomsky-berwick-2025]
+
+The three MCB coproducts — Δ^ρ (pruning), Δ^c (contraction/trace), Δ^d
+(deletion) — share one shape: a primitive `ofTree T ⊗ 1` plus a sum over *cut
+summands* `(crown, trunk)` of `of' crown ⊗ ofTree trunk`. They differ **only**
+in the cut enumeration `cuts T`. This file factors that shape into a single
+`cuts`-parameterized algebra hom `comulAlgHomNG`, recovering the existing
+`comulTreeN`/`comulAlgHomN` (Δ^ρ, `cuts := cutSummandsN`) and
+`comulCTreeN`/`comulCAlgHomN τ` (Δ^c, `cuts := cutSummandsCN τ`) as instances —
+the bridges are definitional (`rfl`).
+
+The cut-*enumeration* layer was already generic (`ConnesKreimer.cutSummandsG`,
+over an extraction policy); this lifts that genericity to the coproduct
+*operator*, so one Merge operator (`Minimalist.Merge.mergeOpG`, downstream)
+serves every coproduct instead of one bespoke copy per Δ.
+
+## Main definitions
+
+* `comulTreeNG cuts` / `comulForestNG cuts` — the generic coproduct.
+* `comulAlgHomNG cuts` — packaged as an `AlgHom`.
+* `comulTreeN_eq_G`, `comulCTreeN_eq_G`, `comulAlgHomN_eq_G`,
+  `comulCAlgHomN_eq_G` — the Δ^ρ / Δ^c instance bridges.
+-/
+
+namespace RootedTree.ConnesKreimer
+
+open scoped TensorProduct
+
+variable {R : Type*} [CommSemiring R] {α : Type*}
+
+/-- The **generic admissible-cut coproduct** (tree level), parameterized by a cut
+    enumeration `cuts`. Specializing `cuts` to `cutSummandsN` gives Δ^ρ, to
+    `cutSummandsCN τ` gives Δ^c, to the deletion enumeration gives Δ^d. -/
+noncomputable def comulTreeNG
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
+    (T : Nonplanar α) :
+    ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α) :=
+  ofTree T ⊗ₜ[R] (1 : ConnesKreimer R (Nonplanar α))
+  + ((cuts T).map (fun p => of' (R := R) p.1 ⊗ₜ[R] ofTree p.2)).sum
+
+/-- Forest-level generic coproduct (multiplicative extension). -/
+noncomputable def comulForestNG
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
+    (F : Forest (Nonplanar α)) :
+    ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α) :=
+  (F.map (comulTreeNG (R := R) cuts)).prod
+
+@[simp] theorem comulForestNG_zero
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α)) :
+    comulForestNG (R := R) cuts (0 : Forest (Nonplanar α)) = 1 := by
+  simp only [comulForestNG, Multiset.map_zero, Multiset.prod_zero]
+
+@[simp] theorem comulForestNG_add
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
+    (F G : Forest (Nonplanar α)) :
+    comulForestNG (R := R) cuts (F + G) =
+      comulForestNG (R := R) cuts F * comulForestNG (R := R) cuts G := by
+  unfold comulForestNG
+  rw [Multiset.map_add, Multiset.prod_add]
+
+@[simp] theorem comulForestNG_cons
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
+    (T : Nonplanar α) (F : Forest (Nonplanar α)) :
+    comulForestNG (R := R) cuts (T ::ₘ F) =
+      comulTreeNG (R := R) cuts T * comulForestNG (R := R) cuts F := by
+  unfold comulForestNG
+  rw [Multiset.map_cons, Multiset.prod_cons]
+
+/-- Forest-level generic coproduct as a `MonoidHom` on the additive forest monoid. -/
+noncomputable def comulMonoidHomNG
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α)) :
+    Multiplicative (Forest (Nonplanar α)) →*
+      (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) where
+  toFun F := comulForestNG (R := R) cuts F.toAdd
+  map_one' := comulForestNG_zero cuts
+  map_mul' F G := comulForestNG_add cuts F.toAdd G.toAdd
+
+/-- The **generic admissible-cut coproduct as an algebra hom**, parameterized by
+    the cut enumeration `cuts`. -/
+noncomputable def comulAlgHomNG
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α)) :
+    ConnesKreimer R (Nonplanar α) →ₐ[R]
+      ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α) :=
+  AddMonoidAlgebra.lift R
+    ((ConnesKreimer R (Nonplanar α)) ⊗[R] (ConnesKreimer R (Nonplanar α)))
+    (Forest (Nonplanar α)) (comulMonoidHomNG cuts)
+
+@[simp] theorem comulAlgHomNG_apply_of'
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
+    (F : Forest (Nonplanar α)) :
+    comulAlgHomNG (R := R) cuts (of' F) = comulForestNG cuts F := by
+  show AddMonoidAlgebra.lift R _ _ (comulMonoidHomNG cuts) (Finsupp.single F 1) = _
+  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rfl
+
+@[simp] theorem comulAlgHomNG_apply_ofTree
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
+    (T : Nonplanar α) :
+    comulAlgHomNG (R := R) cuts (ofTree T) = comulTreeNG cuts T := by
+  rw [show (ofTree T : ConnesKreimer R (Nonplanar α)) = of' ({T} : Forest (Nonplanar α))
+        from rfl, comulAlgHomNG_apply_of',
+      show ({T} : Forest (Nonplanar α)) = T ::ₘ (0 : Forest (Nonplanar α)) from rfl,
+      comulForestNG_cons, comulForestNG_zero, mul_one]
+
+/-! ### Instance bridges (Δ^ρ, Δ^c) — definitional -/
+
+/-- Δ^ρ is the generic coproduct at `cuts := cutSummandsN`. -/
+theorem comulTreeN_eq_G (T : Nonplanar α) :
+    comulTreeN (R := R) T = comulTreeNG (R := R) cutSummandsN T := rfl
+
+/-- Δ^c is the generic coproduct at `cuts := cutSummandsCN τ`. -/
+theorem comulCTreeN_eq_G {β : Type*} (τ : Nonplanar (α ⊕ β) → β) (T : Nonplanar (α ⊕ β)) :
+    comulCTreeN (R := R) τ T = comulTreeNG (R := R) (cutSummandsCN τ) T := rfl
+
+theorem comulAlgHomN_eq_G :
+    comulAlgHomN (R := R) (α := α) = comulAlgHomNG (R := R) cutSummandsN := rfl
+
+theorem comulCAlgHomN_eq_G {β : Type*} (τ : Nonplanar (α ⊕ β) → β) :
+    comulCAlgHomN (R := R) τ = comulAlgHomNG (R := R) (cutSummandsCN τ) := rfl
+
+end RootedTree.ConnesKreimer

--- a/Linglib/Core/Combinatorics/RootedTree/TraceCounting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/TraceCounting.lean
@@ -134,6 +134,116 @@ theorem traceLeafCountList_eq_sum_map (cs : List (Planar (α ⊕ β))) :
   | cons c cs ih =>
     rw [Planar.traceLeafCountList_cons, List.map_cons, List.sum_cons, ih]
 
+/-! ### `traceDepthSum` — depth-weighted trace-marker count (Minimal Search depth)
+
+The **Minimal Search depth** `d_v` of MCB §1.5.2 (book p. 59): the sum over
+trace-marker leaves of their distance from the root. A single recursion
+suffices — descending into the children adds `1` per trace leaf below them
+(`+ traceLeafCountList cs`), so a trace leaf at depth `d` is counted `d`
+times, contributing `d`. A bare trace leaf at the root contributes `0`.
+
+For a Δ^c cut, the quotient (trunk) places a trace leaf at each cut site at
+exactly the cut depth (`Coproduct.Trace.traceLeaf`), so
+`traceDepthSum(quotient)` reads off the total extraction depth `Σ d_{v_i}`
+of MCB rule 1 directly — no enumeration tagging required. -/
+
+mutual
+/-- Sum of root-distances of the `Sum.inr`-labeled (trace-marker) leaves. -/
+def traceDepthSum : Planar (α ⊕ β) → Nat
+  | .node _ cs => traceDepthSumList cs + traceLeafCountList cs
+/-- Auxiliary: trace-depth across a list of children, measured in the
+    children's own frame (the parent adds the `+1`-per-level offset). -/
+def traceDepthSumList : List (Planar (α ⊕ β)) → Nat
+  | []      => 0
+  | t :: ts => traceDepthSum t + traceDepthSumList ts
+end
+
+theorem traceDepthSum_node (a : α ⊕ β) (cs : List (Planar (α ⊕ β))) :
+    traceDepthSum (Planar.node a cs) = traceDepthSumList cs + traceLeafCountList cs := rfl
+
+@[simp] theorem traceDepthSumList_nil :
+    traceDepthSumList ([] : List (Planar (α ⊕ β))) = 0 := rfl
+
+@[simp] theorem traceDepthSumList_cons (t : Planar (α ⊕ β))
+    (ts : List (Planar (α ⊕ β))) :
+    traceDepthSumList (t :: ts) = traceDepthSum t + traceDepthSumList ts := rfl
+
+@[simp] theorem traceDepthSum_leaf_inl (a : α) :
+    traceDepthSum (Planar.node (Sum.inl a) [] : Planar (α ⊕ β)) = 0 := rfl
+
+@[simp] theorem traceDepthSum_leaf_inr (b : β) :
+    traceDepthSum (Planar.node (Sum.inr b) [] : Planar (α ⊕ β)) = 0 := rfl
+
+theorem traceDepthSumList_eq_sum_map (cs : List (Planar (α ⊕ β))) :
+    traceDepthSumList cs = (cs.map traceDepthSum).sum := by
+  induction cs with
+  | nil => rfl
+  | cons c cs ih => rw [traceDepthSumList_cons, List.map_cons, List.sum_cons, ih]
+
+/-- The node-level per-child contribution `traceDepthSum c + traceLeafCount c`,
+    summed: combines the two list statistics into one map. -/
+theorem traceDepthSumList_add_traceLeafCountList (cs : List (Planar (α ⊕ β))) :
+    traceDepthSumList cs + traceLeafCountList cs
+      = (cs.map (fun c => traceDepthSum c + traceLeafCount c)).sum := by
+  rw [traceDepthSumList_eq_sum_map, traceLeafCountList_eq_sum_map]
+  induction cs with
+  | nil => rfl
+  | cons c cs ih => simp only [List.map_cons, List.sum_cons]; omega
+
+/-! #### Trace-depth invariance under `PlanarEquiv` -/
+
+private theorem traceDepthSumList_perm (cs ds : List (Planar (α ⊕ β)))
+    (h : List.Perm cs ds) : traceDepthSumList cs = traceDepthSumList ds := by
+  induction h with
+  | nil => rfl
+  | cons _ _ ih => rw [traceDepthSumList_cons, traceDepthSumList_cons, ih]
+  | swap _ _ _ => simp only [traceDepthSumList_cons]; omega
+  | trans _ _ ih1 ih2 => exact ih1.trans ih2
+
+private theorem traceDepthSum_planarStep {t s : Planar (α ⊕ β)}
+    (h : PlanarStep t s) : t.traceDepthSum = s.traceDepthSum := by
+  induction h with
+  | swapAtRoot =>
+    rename_i a l r pre post
+    have hperm : (pre ++ l :: r :: post).Perm (pre ++ r :: l :: post) :=
+      List.Perm.append_left pre (.swap r l post)
+    rw [traceDepthSum_node, traceDepthSum_node,
+        traceDepthSumList_perm _ _ hperm, traceLeafCountList_perm _ _ hperm]
+  | recurse hstep ih =>
+    rename_i a pre old new post
+    have hc : old.traceLeafCount = new.traceLeafCount := traceLeafCount_planarStep hstep
+    rw [traceDepthSum_node, traceDepthSum_node,
+        traceDepthSumList_eq_sum_map, traceDepthSumList_eq_sum_map,
+        traceLeafCountList_eq_sum_map, traceLeafCountList_eq_sum_map]
+    simp only [List.map_append, List.map_cons, List.sum_append, List.sum_cons, ih, hc]
+
+theorem traceDepthSum_planarEquiv {t s : Planar (α ⊕ β)}
+    (h : PlanarEquiv t s) : t.traceDepthSum = s.traceDepthSum := by
+  induction h with
+  | rel _ _ hstep => exact traceDepthSum_planarStep hstep
+  | refl _ => rfl
+  | symm _ _ _ ih => exact ih.symm
+  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+
+/-- The children's trace leaves are bounded by the node's: a `Sum.inr` root
+    can only *add* a trace leaf (the empty-trace-leaf case), never remove one. -/
+theorem traceLeafCountList_le_node (a : α ⊕ β) (cs : List (Planar (α ⊕ β))) :
+    traceLeafCountList cs ≤ traceLeafCount (Planar.node a cs) := by
+  rcases eq_or_ne cs [] with h | h
+  · subst h; exact Nat.zero_le _
+  · exact (traceLeafCount_node_of_ne_nil a cs h).ge
+
+/-- **A lexical root puts every trace marker at depth ≥ 1**: for a
+    `Sum.inl`-rooted tree, the depth-weighted trace count dominates the plain
+    trace count (`traceDepthSum = traceDepthSumList + traceLeafCountList`, and the
+    `+ traceLeafCountList` term is exactly the descent of each child trace by one
+    level). Underlies the Minimal-Search positivity `Cut.depthC_pos`. -/
+theorem traceLeafCount_le_traceDepthSum_of_inl (a : α) (cs : List (Planar (α ⊕ β))) :
+    traceLeafCount (Planar.node (Sum.inl a) cs) ≤
+      traceDepthSum (Planar.node (Sum.inl a) cs) := by
+  rw [traceLeafCount_inl, traceDepthSum_node]
+  exact Nat.le_add_left _ _
+
 end Planar
 
 namespace Nonplanar
@@ -154,6 +264,42 @@ def traceLeafCount : Nonplanar (α ⊕ β) → Nat :=
 
 @[simp] theorem traceLeafCount_leaf_inr (b : β) :
     (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).traceLeafCount = 1 := rfl
+
+/-- The **Minimal Search depth** `d_v` of MCB §1.5: the sum of root-distances
+    of the trace-marker leaves, lifted from `Planar.traceDepthSum`. For a Δ^c
+    cut, `traceDepthSum` of the quotient is the total extraction depth. -/
+def traceDepthSum : Nonplanar (α ⊕ β) → Nat :=
+  Nonplanar.lift Planar.traceDepthSum
+    (fun _ _ h => Planar.traceDepthSum_planarEquiv h)
+
+@[simp] theorem traceDepthSum_mk (t : Planar (α ⊕ β)) :
+    (mk t).traceDepthSum = t.traceDepthSum := rfl
+
+@[simp] theorem traceDepthSum_leaf_inl (a : α) :
+    (leaf (Sum.inl a) : Nonplanar (α ⊕ β)).traceDepthSum = 0 := rfl
+
+@[simp] theorem traceDepthSum_leaf_inr (b : β) :
+    (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).traceDepthSum = 0 := rfl
+
+/-- Trace-depth of a node decomposes over children: each child `c`
+    contributes its own trace-depth plus one per trace leaf it carries
+    (the `+1` for the extra level between the node and `c`). -/
+@[simp] theorem traceDepthSum_node_inl (a : α) (F : Multiset (Nonplanar (α ⊕ β))) :
+    (Nonplanar.node (Sum.inl a) F).traceDepthSum
+      = (F.map (fun c => c.traceDepthSum + c.traceLeafCount)).sum := by
+  refine Quotient.inductionOn F fun lst => ?_
+  show (mk (.node (Sum.inl a) (lst.map Quotient.out))).traceDepthSum = _
+  rw [traceDepthSum_mk]
+  show Planar.traceDepthSum (.node (Sum.inl a) (lst.map Quotient.out)) = _
+  rw [Planar.traceDepthSum_node, Planar.traceDepthSumList_add_traceLeafCountList,
+      List.map_map]
+  simp only [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.sum_coe]
+  refine congrArg List.sum (List.map_congr_left fun t _ => ?_)
+  show Planar.traceDepthSum (Quotient.out t) + Planar.traceLeafCount (Quotient.out t)
+      = Nonplanar.traceDepthSum t + Nonplanar.traceLeafCount t
+  congr 1
+  · exact congrArg Nonplanar.traceDepthSum (Quotient.out_eq t)
+  · exact congrArg Nonplanar.traceLeafCount (Quotient.out_eq t)
 
 /-- The **trace-excluding accessible-term count** `αᶜ(T) = α(T) − #traceLeaves(T)`:
     a trace leaf is a vertex but not an accessible term (MCB p. 66). Truncated
@@ -259,6 +405,21 @@ example (a : α) (b : β) : (traceWitness a b).weight = 2 := rfl
 example (a : α) (b : β) : (traceWitness a b).traceLeafCount = 1 := rfl
 example (a : α) (b : β) : (traceWitness a b).accCountC = 0 := rfl
 example (a : α) (b : β) : (traceWitness a b).leafCountSO0 = 0 := rfl
+
+/-- The trace leaf of `traceWitness` sits at depth 1, so `traceDepthSum = 1`. -/
+example (a : α) (b : β) : (traceWitness a b).traceDepthSum = 1 := rfl
+
+/-- A trace leaf two levels down contributes depth 2 to `traceDepthSum`. -/
+example (a a' : α) (b : β) :
+    Nonplanar.traceDepthSum
+      (Nonplanar.mk (.node (Sum.inl a) [.node (Sum.inl a') [.node (Sum.inr b) []]])) = 2 := rfl
+
+/-- Two trace leaves at depths 1 and 2 sum to 3 — the multi-extraction
+    additivity `d_v = Σ d_{v_i}` of MCB rule 3. -/
+example (a a' : α) (b b' : β) :
+    Nonplanar.traceDepthSum
+      (Nonplanar.mk (.node (Sum.inl a)
+        [.node (Sum.inr b) [], .node (Sum.inl a') [.node (Sum.inr b') []]])) = 3 := rfl
 
 /-- `σᶜ` undercounts `#V` on the contraction quotient: the trace leaf is a
     vertex but not an accessible term. -/

--- a/Linglib/Syntax/Minimalist/Merge/MinimalSearch.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalSearch.lean
@@ -1,0 +1,190 @@
+import Linglib.Syntax.Minimalist.Merge.Basic
+import Linglib.Core.Algebra.RootedTree.Coproduct.GenericNonplanar
+import Linglib.Core.Algebra.RootedTree.Coproduct.Conservation
+
+set_option autoImplicit false
+
+/-!
+# Minimal Search: the generic (cut-policy-parameterized) Merge operator
+[marcolli-chomsky-berwick-2025]
+
+MCB's Merge variants and the three coproducts (Δ^ρ/Δ^c/Δ^d) share one operator
+shape `M = ⊔ ∘ (B ⊗ id) ∘ δ_{S,S'} ∘ Δ`, differing only in the coproduct `Δ`.
+`mergeOpG cuts` parameterizes the operator over the cut enumeration (via
+`comulAlgHomNG`), recovering the Δ^ρ `mergeOp` as the instance
+`cuts := cutSummandsN` (definitional) and defining the Δ^c Merge `mergeOpC τ` as
+`cuts := cutSummandsCN τ`. This is the operator-level companion to the
+already-generic cut layer (`cutSummandsG`).
+
+The Δ^c instance is the home of the **Minimal-Search ε arc** (MCB §1.5,
+Prop 1.5.1): the trace coproduct is where extraction depth is recoverable
+(`RootedTree.Cut.depthC`), so the ε-weighted graft and the ε → 0
+Sideward-elimination belong on `mergeOpC`, not the Δ^ρ `mergeOp`.
+
+## Main definitions
+
+* `mergeOpG cuts lbl S S'` — the generic Merge operator.
+* `mergeOp_eq_G` — the Δ^ρ `mergeOp` is `mergeOpG cutSummandsN` (definitional).
+* `mergeOpC τ lbl S S'` — the Δ^c Merge operator.
+* `epsWeight`, `emNetCost`/`imNetCost`/`swNetCost` — the Minimal-Search ε-weight
+  and the per-merge net costs (EM/IM = 0, Sideward > 0).
+* `mergeOpCEps τ ε c` — the ε-weighted Δ^c Merge (`ε^c • mergeOpC`).
+* `mergeOpCEps_zero_em`, `mergeOpCEps_zero_im`, `mergeOpCEps_zero_sideward` —
+  **MCB Proposition 1.5.1**: at ε → 0, External and Internal Merge survive
+  (`1 • M = M`), Sideward Merge vanishes (`0 • M = 0`).
+-/
+
+namespace Minimalist.Merge
+
+open scoped TensorProduct
+open RootedTree RootedTree.ConnesKreimer
+
+variable {R : Type*} [CommSemiring R] {α : Type*}
+
+/-- The **generic Merge operator** `M_{S,S'}^{cuts}`, parameterized by the cut
+    enumeration `cuts`: `mergePost lbl S S' ∘ comulAlgHomNG cuts`. The
+    coproduct-agnostic post-chain `mergePost` (graft `B`, δ-projection, and
+    multiplication `⊔`) is shared; only the coproduct `comulAlgHomNG cuts`
+    varies. -/
+noncomputable def mergeOpG [DecidableEq (Nonplanar α)]
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
+    (lbl : α) (S S' : Nonplanar α) :
+    ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
+  mergePost (R := R) (α := α) lbl S S' ∘ₗ (comulAlgHomNG cuts).toLinearMap
+
+/-- The Δ^ρ Merge operator `mergeOp` is the generic operator at
+    `cuts := cutSummandsN` — definitional, since `comulAlgHomN = comulAlgHomNG
+    cutSummandsN`. -/
+theorem mergeOp_eq_G [DecidableEq (Nonplanar α)] (lbl : α) (S S' : Nonplanar α) :
+    mergeOp (R := R) lbl S S' = mergeOpG (R := R) cutSummandsN lbl S S' := rfl
+
+/-- The **Δ^c (trace) Merge operator** `mergeOpC τ`, the generic operator at
+    `cuts := cutSummandsCN τ`. Unlike the Δ^ρ `mergeOp`, this coproduct's
+    quotients carry a trace leaf at each cut site at exactly the cut depth, so
+    the Minimal-Search cost `Cut.depthC` is recoverable — making `mergeOpC` the
+    faithful home of MCB's ε-weighted Merge (§1.5). -/
+noncomputable def mergeOpC {β : Type*} [DecidableEq (Nonplanar (α ⊕ β))]
+    (τ : Nonplanar (α ⊕ β) → β) (lbl : α ⊕ β) (S S' : Nonplanar (α ⊕ β)) :
+    ConnesKreimer R (Nonplanar (α ⊕ β)) →ₗ[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
+  mergeOpG (R := R) (cutSummandsCN τ) lbl S S'
+
+/-! ## The Minimal-Search ε arc (MCB §1.5, Prop 1.5.1)
+
+The ε-weighted Merge `M^ε = ⊔ ∘ (Bᵉ ⊗ id) ∘ δ ∘ Δ` (eq 1.5.1) scales the graft
+`Bᵉ(α⊔β) = ε^{c(𝔐(α,β))} B(α⊔β)` (eq 1.5.2) by the Minimal-Search cost `ε^c`.
+Since `mergePost` is linear and the graft is its only creation, scaling the
+graft by `ε^c` equals scaling the whole operator: `mergeOpCEps = ε^c • mergeOpC`.
+The net cost `c` is the sum of the two operands' signed depth-costs (MCB rules
+1–2, `RootedTree.Cut.extractionCost`/`quotientCost`):
+
+* **EM** `𝔐(T_i, T_j)`: both whole, `c = 0`.
+* **IM** `𝔐(T_v, T_i/T_v)`: extracted crown `+d` and its own quotient `−d`
+  cancel, `c = 0`.
+* **Sideward** `𝔐(T_v, T')`: the crown's `+d` is uncancelled (no quotient
+  operand), `c = d > 0`.
+
+At ε → 0, `ε^0 = 1` keeps EM/IM, `ε^{d>0} = 0` drops Sideward. -/
+
+/-- The **Minimal-Search ε-weight** of a merge with net cost `c`: `ε^c`
+    (MCB eq 1.5.2). -/
+def epsWeight (ε : R) (c : ℕ) : R := ε ^ c
+
+@[simp] theorem epsWeight_zero_zero : epsWeight (0 : R) 0 = 1 := pow_zero 0
+
+theorem epsWeight_zero_of_pos {c : ℕ} (hc : 0 < c) : epsWeight (0 : R) c = 0 :=
+  zero_pow (Nat.pos_iff_ne_zero.mp hc)
+
+@[simp] theorem epsWeight_one (c : ℕ) : epsWeight (1 : R) c = 1 := one_pow c
+
+end Minimalist.Merge
+
+namespace Minimalist.Merge
+
+open scoped TensorProduct
+open RootedTree RootedTree.ConnesKreimer
+
+variable {R : Type*} [CommSemiring R] {α β : Type*}
+
+/-- **External Merge net cost** (MCB rule 4, whole operands): `0`. -/
+def emNetCost : ℕ := 0
+
+/-- **Internal Merge net cost** (MCB Prop 1.5.1, IM): the extracted crown's `+d`
+    and its own quotient's `−d` cancel — the signed sum over the *same* cut `p`,
+    truncated to `ℕ` (it is `0`, see `imNetCost_eq_zero`). -/
+def imNetCost (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) : ℕ :=
+  (Cut.extractionCost p + Cut.quotientCost p).toNat
+
+/-- **Sideward Merge net cost** (MCB Prop 1.5.1, Sideward 2b): the extracted
+    crown's `+d`, with no quotient operand to cancel it. Equals `Cut.depthC p`. -/
+def swNetCost (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) : ℕ :=
+  (Cut.extractionCost p).toNat
+
+@[simp] theorem imNetCost_eq_zero (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) :
+    imNetCost p = 0 := by
+  rw [imNetCost, Cut.extractionCost_add_quotientCost]; rfl
+
+@[simp] theorem swNetCost_eq_depthC (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) :
+    swNetCost p = Cut.depthC p := by
+  rw [swNetCost, Cut.extractionCost, Int.toNat_natCast]
+
+/-- A Sideward Merge of a lexical-rooted object has strictly positive net cost
+    (MCB Prop 1.5.1) — the uncancelled extraction depth. -/
+theorem swNetCost_pos (τ : Nonplanar (α ⊕ β) → β) (T : Nonplanar (α ⊕ β)) (a₀ : α)
+    (hT : T.rootLabel = Sum.inl a₀)
+    (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) (hp : p ∈ cutSummandsCN τ T)
+    (hproper : p.1 ≠ 0) :
+    0 < swNetCost p := by
+  rw [swNetCost_eq_depthC]
+  exact Cut.depthC_pos τ T a₀ hT p hp hproper
+
+variable [DecidableEq (Nonplanar (α ⊕ β))]
+
+/-- The **ε-weighted Δ^c Merge operator** (MCB §1.5, eq 1.5.2): the Δ^c merge
+    scaled by the Minimal-Search weight `ε^c`. -/
+noncomputable def mergeOpCEps (τ : Nonplanar (α ⊕ β) → β) (ε : R) (c : ℕ)
+    (lbl : α ⊕ β) (S S' : Nonplanar (α ⊕ β)) :
+    ConnesKreimer R (Nonplanar (α ⊕ β)) →ₗ[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
+  epsWeight ε c • mergeOpC τ lbl S S'
+
+/-- At ε = 1 the weight is trivial and `mergeOpCEps` recovers the unweighted Δ^c
+    Merge. -/
+@[simp] theorem mergeOpCEps_one (τ : Nonplanar (α ⊕ β) → β) (c : ℕ)
+    (lbl : α ⊕ β) (S S' : Nonplanar (α ⊕ β)) :
+    mergeOpCEps τ (1 : R) c lbl S S' = mergeOpC τ lbl S S' := by
+  rw [mergeOpCEps, epsWeight_one, one_smul]
+
+/-- **MCB Prop 1.5.1, External Merge survives ε → 0.** EM has net cost 0, so its
+    weight `ε^0 = 1` is unaffected: `mergeOpCEps τ 0 emNetCost = mergeOpC τ`. -/
+@[simp] theorem mergeOpCEps_zero_em (τ : Nonplanar (α ⊕ β) → β)
+    (lbl : α ⊕ β) (S S' : Nonplanar (α ⊕ β)) :
+    mergeOpCEps τ (0 : R) emNetCost lbl S S' = mergeOpC τ lbl S S' := by
+  rw [mergeOpCEps, emNetCost, epsWeight_zero_zero, one_smul]
+
+/-- **MCB Prop 1.5.1, Internal Merge survives ε → 0.** IM has net cost 0 — the
+    extraction `+d` and its own quotient's `−d` cancel — so its weight is `1` and
+    the operator is preserved at ε = 0. -/
+@[simp] theorem mergeOpCEps_zero_im (τ : Nonplanar (α ⊕ β) → β)
+    (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β))
+    (lbl : α ⊕ β) (S S' : Nonplanar (α ⊕ β)) :
+    mergeOpCEps τ (0 : R) (imNetCost p) lbl S S' = mergeOpC τ lbl S S' := by
+  rw [mergeOpCEps, imNetCost_eq_zero, epsWeight_zero_zero, one_smul]
+
+/-- **MCB Prop 1.5.1, Sideward Merge vanishes ε → 0.** A Sideward Merge has net
+    cost `> 0` (the uncancelled extraction depth), so its weight `ε^{>0} = 0` at
+    ε = 0: the operator is annihilated. -/
+theorem mergeOpCEps_zero_sideward (τ : Nonplanar (α ⊕ β) → β) {c : ℕ} (hc : 0 < c)
+    (lbl : α ⊕ β) (S S' : Nonplanar (α ⊕ β)) :
+    mergeOpCEps τ (0 : R) c lbl S S' = 0 := by
+  rw [mergeOpCEps, epsWeight_zero_of_pos hc, zero_smul]
+
+/-- **MCB Prop 1.5.1, Sideward Merge vanishes** — instantiated at an actual Δ^c
+    extraction `p` of a lexical-rooted object: the uncancelled depth makes
+    `swNetCost p > 0`, so the operator is annihilated at ε = 0. -/
+theorem mergeOpCEps_zero_sideward_of_cut (τ : Nonplanar (α ⊕ β) → β)
+    (T : Nonplanar (α ⊕ β)) (a₀ : α) (hT : T.rootLabel = Sum.inl a₀)
+    (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) (hp : p ∈ cutSummandsCN τ T)
+    (hproper : p.1 ≠ 0) (lbl : α ⊕ β) (S S' : Nonplanar (α ⊕ β)) :
+    mergeOpCEps τ (0 : R) (swNetCost p) lbl S S' = 0 :=
+  mergeOpCEps_zero_sideward τ (swNetCost_pos τ T a₀ hT p hp hproper) lbl S S'
+
+end Minimalist.Merge


### PR DESCRIPTION
Formalizes MCB §1.5 Minimal Search on the Δ^c carrier: the ε-weighted Merge `mergeOpCEps` and Prop 1.5.1 — External/Internal Merge survive ε → 0 (net cost 0), Sideward vanishes (net cost > 0).

- Generic cut-policy coproduct `comulAlgHomNG` and merge `mergeOpG` (Δ^ρ, Δ^c as `rfl` instances).
- Signed depth cost `Cut.depthC`, with the IM extraction/quotient cancellation derived, not stipulated.
