### PR TITLE
refactor(Semantics): migrate NaturalLogic to top-level, bare namespace

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -180,7 +180,7 @@ import Linglib.Semantics.Verb.Basic
 import Linglib.Semantics.Verb.Denotation
 import Linglib.Semantics.Verb.Distributivity
 import Linglib.Semantics.Verb.RootContent
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 import Linglib.Core.Optimization.Profile
 import Linglib.Phonology.Constraint.Weighted
 import Linglib.Phonology.Constraint.Superoptimal

--- a/Linglib/Features/Polarity.lean
+++ b/Linglib/Features/Polarity.lean
@@ -8,7 +8,7 @@ multiplicity inferences, homogeneity gaps, scalar implicatures, etc.
 
 Note: This is distinct from other polarity-like distinctions in the library:
 - `Core.Lexical.UD.Polarity` — morphological feature (`.Pos`/`.Neg`)
-- `Core.NaturalLogic.ContextPolarity` — monotonicity direction (`.upward`/`.downward`)
+- `NaturalLogic.ContextPolarity` — monotonicity direction (`.upward`/`.downward`)
 - `Rett2015Implicature.Polarity` — adjective markedness
 - `Semantics.Presupposition.OntologicalPreconditions.Polarity` — event assertion (`.affirmed`/`.negated`)
 -/

--- a/Linglib/Semantics/Entailment/AntiAdditivity.lean
+++ b/Linglib/Semantics/Entailment/AntiAdditivity.lean
@@ -4,7 +4,7 @@ import Mathlib.Order.Heyting.Hom
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Fintype.Basic
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 import Linglib.Semantics.Entailment.Basic
 import Linglib.Semantics.Entailment.Polarity
 
@@ -37,7 +37,7 @@ domains, his §1.1).
 
 namespace Entailment
 
-open Core.NaturalLogic (DEStrength UEStrength strengthSufficient)
+open NaturalLogic (DEStrength UEStrength strengthSufficient)
 open Entailment
 open List (Sublist)
 

--- a/Linglib/Semantics/Entailment/Polarity.lean
+++ b/Linglib/Semantics/Entailment/Polarity.lean
@@ -1,11 +1,11 @@
 import Mathlib.Order.Monotone.Defs
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 import Linglib.Semantics.Entailment.Basic
 
 /-!
 # Grounded context polarity
 
-Semantic grounding for `ContextPolarity` (defined in `Core.NaturalLogic`) via
+Semantic grounding for `ContextPolarity` (defined in `NaturalLogic`) via
 mathlib's `Monotone`/`Antitone` infrastructure: `IsUpwardEntailing`/
 `IsDownwardEntailing` abbreviate `Monotone`/`Antitone` on `Set α → Set β`,
 so the composition rules (UE ∘ UE = UE, DE ∘ DE = UE, mixed = DE) are
@@ -17,7 +17,7 @@ context function with its monotonicity proof on the toy `World` model.
 
 namespace Entailment
 
-export Core.NaturalLogic (ContextPolarity)
+export NaturalLogic (ContextPolarity)
 
 open Entailment
 

--- a/Linglib/Semantics/Entailment/PositionProfile.lean
+++ b/Linglib/Semantics/Entailment/PositionProfile.lean
@@ -31,7 +31,7 @@ certified profiles as worked instances.
 - `every_sem_soundFor`, `no_sem_soundFor`: certified determiner profiles.
 -/
 
-namespace Core.NaturalLogic
+namespace NaturalLogic
 
 open Entailment
 open Quantification
@@ -164,4 +164,4 @@ example : Sig₂.SoundFor ⟨.antiAddMult * .anti, .antiAddMult * .mono⟩
 
 end GQBridges
 
-end Core.NaturalLogic
+end NaturalLogic

--- a/Linglib/Semantics/Entailment/Soundness.lean
+++ b/Linglib/Semantics/Entailment/Soundness.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 import Linglib.Semantics.Entailment.AntiAdditivity
 
 /-!
@@ -42,7 +42,7 @@ monotonicity `EntailmentSig.project_refines`. `soundFor_all` holds
 unconditionally — every function realizes the no-property row.
 -/
 
-namespace Core.NaturalLogic
+namespace NaturalLogic
 
 open Entailment
 
@@ -203,7 +203,7 @@ theorem soundFor_all (f : α → β) : EntailmentSig.SoundFor .all f :=
 
 /-- Relation-level order soundness: `Refines` is the implication order on
 the lattice content ([icard-2012] §1). -/
-theorem _root_.Core.NaturalLogic.NLRelation.Holds.of_refines
+theorem _root_.NaturalLogic.NLRelation.Holds.of_refines
     {R R' : NLRelation} {u v : β} (h : R.Holds u v) (href : R.Refines R') :
     R'.Holds u v := by
   cases R <;> cases R' <;>
@@ -300,4 +300,4 @@ example : EntailmentSig.SoundFor .addMult (pnot ∘ pnot) :=
 
 end PnotInstance
 
-end Core.NaturalLogic
+end NaturalLogic

--- a/Linglib/Semantics/Entailment/StrawsonSoundness.lean
+++ b/Linglib/Semantics/Entailment/StrawsonSoundness.lean
@@ -34,7 +34,7 @@ deliberately not attempted here — its home is a bridge to
 `Semantics/Presupposition/`, not an ad-hoc operator.
 -/
 
-namespace Core.NaturalLogic
+namespace NaturalLogic
 
 open Entailment
 
@@ -168,4 +168,4 @@ theorem sinceFull_strawsonSoundFor_anti (pastEvent sinceWindow : W → Set W) :
 
 end SetInstances
 
-end Core.NaturalLogic
+end NaturalLogic

--- a/Linglib/Semantics/Focus/Particles.lean
+++ b/Linglib/Semantics/Focus/Particles.lean
@@ -1,5 +1,5 @@
 import Mathlib.Data.Set.Basic
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 
 /-!
 # Focus-sensitive particles: even and only
@@ -72,10 +72,10 @@ def TraditionalEven.defined (even : TraditionalEven (World := World)) : Prop :=
 def TraditionalEven.trueAt (even : TraditionalEven (World := World)) (w : World) : Prop :=
   even.defined ∧ even.prejacent w
 
-open Core.NaturalLogic (ContextPolarity)
+open NaturalLogic (ContextPolarity)
 
 /-- NPI licensing condition: EVEN presupposition must be satisfiable.
-    Uses `ContextPolarity` from `Core.NaturalLogic`. -/
+    Uses `ContextPolarity` from `NaturalLogic`. -/
 def npiLicensed (pol : ContextPolarity) (npiDomain : Set Entity) (regularDomain : Set Entity)
     (_hWider : regularDomain ⊆ npiDomain) : Prop :=
   match pol with

--- a/Linglib/Semantics/Gradability/ClauseEmbedding.lean
+++ b/Linglib/Semantics/Gradability/ClauseEmbedding.lean
@@ -19,7 +19,7 @@ copula and its syntax belong in the Theory/Syntax layer, not here.
 namespace Semantics.Gradability
 
 open Features (Attitude)
-open Core.NaturalLogic (EntailmentSig)
+open NaturalLogic (EntailmentSig)
 
 /-- A clause-embedding adjective: an adjective that takes a propositional
     complement. Carries the semantic spine shared with clause-embedding verbs

--- a/Linglib/Semantics/NaturalLogic.lean
+++ b/Linglib/Semantics/NaturalLogic.lean
@@ -29,7 +29,7 @@ Natural Language."
 
 -/
 
-namespace Core.NaturalLogic
+namespace NaturalLogic
 
 -- ============================================================================
 -- §1 — NLRelation: Seven Natural Logic Relations
@@ -867,4 +867,4 @@ def negationSig : EntailmentSig := .antiAddMult
 #guard EntailmentSig.project .cover .antiAdd == .alternation        -- ◇ : anti-additive flips ∼ to |
 #guard EntailmentSig.project .cover .antiAddMult == .alternation    -- ◇⊟ : anti-morph swaps | ↔ ∼
 
-end Core.NaturalLogic
+end NaturalLogic

--- a/Linglib/Semantics/Negation/Defs.lean
+++ b/Linglib/Semantics/Negation/Defs.lean
@@ -25,7 +25,7 @@ coherent architecture with three layers:
   PolarityClass, PolarityLicensing) with Mathlib lattice instances
 - `Mathlib.Data.Set.Basic` — set complement (`pᶜ`) is the canonical
   propositional negation (no custom `pnot` wrapper)
-- `Core.Logic.NaturalLogic` — `DEStrength` (weak/antiAdditive/antiMorphic),
+- `NaturalLogic` — `DEStrength` (weak/antiAdditive/antiMorphic),
   `strengthSufficient`
 - `Entailment` — `IsDE = Antitone`,
   `IsUE = Monotone`, `pnot_isDownwardEntailing`
@@ -37,7 +37,7 @@ namespace Semantics.Negation
 
 open Typology.Negation (ENType ENStrength PolarityLicensing PolarityClass
            weakENProfile strongENProfile standardNegProfile)
-open Core.NaturalLogic (DEStrength strengthSufficient)
+open NaturalLogic (DEStrength strengthSufficient)
 open Entailment (World)
 open Entailment (IsDE IsUE pnot_isDownwardEntailing)
 open Entailment (IsAntiAdditive IsAntiMorphic

--- a/Linglib/Semantics/Polarity/Licensing.lean
+++ b/Linglib/Semantics/Polarity/Licensing.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 import Linglib.Features.LicensingContext
 import Linglib.Typology.PolarityItem
 
@@ -120,7 +120,7 @@ structure ContextProperties where
       Strawson reading): the row a Strawson-relativized soundness
       statement (`EntailmentSig.StrawsonSoundFor`) realizes. Coincides
       with the classical row for presupposition-free contexts. -/
-  strawsonSignature : Core.NaturalLogic.EntailmentSig
+  strawsonSignature : NaturalLogic.EntailmentSig
   /-- K&L mechanism: how this context licenses NPIs. -/
   mechanism : LicensingMechanism
   /-- A canonical English example. -/
@@ -133,7 +133,7 @@ structure ContextProperties where
       superlatives: no `EntailmentSig` row is classically sound for
       them. Defaults to the Strawson row (the presupposition-free
       case). -/
-  classicalSignature : Option Core.NaturalLogic.EntailmentSig :=
+  classicalSignature : Option NaturalLogic.EntailmentSig :=
     some strawsonSignature
   deriving Repr
 
@@ -260,7 +260,7 @@ def strengthLicenses (e : Typology.PolarityItem.PolarityItemEntry)
     (c : LicensingContext) : Bool :=
   match (contextProperties c).strawsonSignature.toDEStrength, e.strength with
   | some supplied, some required =>
-      Core.NaturalLogic.strengthSufficient supplied required
+      NaturalLogic.strengthSufficient supplied required
   | _, _ => false
 
 /-- `strengthLicenses` as a proposition. -/

--- a/Linglib/Semantics/Polarity/Witnesses.lean
+++ b/Linglib/Semantics/Polarity/Witnesses.lean
@@ -34,7 +34,7 @@ retirement is deferred.
 namespace Semantics.Polarity.Licensing
 
 open Features (LicensingContext)
-open Core.NaturalLogic
+open NaturalLogic
 open Quantification
 open Entailment (World pnot)
 open Entailment (atMost2_student atMost_isDE_scope)

--- a/Linglib/Semantics/Quantification/Defs.lean
+++ b/Linglib/Semantics/Quantification/Defs.lean
@@ -2,7 +2,7 @@ import Mathlib.Order.Lattice
 import Mathlib.Order.Monotone.Defs
 import Mathlib.Order.Sublattice
 import Mathlib.Order.BooleanAlgebra.Basic
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 import Linglib.Core.Logic.Truth3
 
 /-!

--- a/Linglib/Semantics/Quantification/Properties.lean
+++ b/Linglib/Semantics/Quantification/Properties.lean
@@ -889,7 +889,7 @@ theorem vanBenthem_symm_quasiUniv_is_disjointness [Fintype α] [DecidableEq α] 
 
 /-! ### Entailment Signature Bridge ([icard-2012]) -/
 
-open Core.NaturalLogic (EntailmentSig ContextPolarity)
+open NaturalLogic (EntailmentSig ContextPolarity)
 
 /--
 Map a pair of entailment signatures (restrictor, scope) to `DoubleMono`,

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -13,7 +13,7 @@ open Semantics.Presupposition
 open Features
 open Semantics.Lexical
 open Features.ChangeOfState
-open Core.NaturalLogic (EntailmentSig)
+open NaturalLogic (EntailmentSig)
 open Causation.Psych (CausalSource)
 open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -5,7 +5,7 @@ import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
 import Linglib.Features.Causation
 import Linglib.Semantics.Lexical.LevinClass
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 import Linglib.Semantics.Aspect.ChangeOfState
 import Linglib.Semantics.Causation.Implicative
 import Linglib.Semantics.ArgumentStructure.Linking
@@ -46,7 +46,7 @@ open Semantics.Presupposition
 open Features
 open Semantics.Lexical
 open Features.ChangeOfState
-open Core.NaturalLogic (EntailmentSig)
+open NaturalLogic (EntailmentSig)
 open Causation.Psych (CausalSource)
 open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)

--- a/Linglib/Studies/Chierchia2013.lean
+++ b/Linglib/Studies/Chierchia2013.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 
 /-!
 # Disjunction Ignorance [chierchia-2013]
@@ -15,7 +15,7 @@ This is different from scalar implicature:
 - Ignorance: "A or B" → speaker doesn't know which
 
 The file provides a `predictReading` function over `ContextPolarity`
-(from `Core.NaturalLogic`) that derives the preferred inclusive/exclusive
+(from `NaturalLogic`) that derives the preferred inclusive/exclusive
 reading from structural position.
 -/
 
@@ -331,7 +331,7 @@ inductive DisjunctionPosition where
   | negation_scope    -- Under negation (DE)
   deriving DecidableEq, Repr
 
-open Core.NaturalLogic (ContextPolarity)
+open NaturalLogic (ContextPolarity)
 
 /--
 Determine context polarity from position.

--- a/Linglib/Studies/DenicEtAl2021.lean
+++ b/Linglib/Studies/DenicEtAl2021.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 import Linglib.Typology.PolarityItem
 import Linglib.Fragments.English.PolarityItems
 
@@ -50,7 +50,7 @@ namespace DenicEtAl2021
 
 /-- The four monotonicity environments tested.
 
-A refinement of `Core.NaturalLogic.ContextPolarity` that keeps DN distinct
+A refinement of `NaturalLogic.ContextPolarity` that keeps DN distinct
 from UE. `ContextPolarity` maps both to `.upward`; the paper shows PIs
 distinguish them empirically. -/
 inductive MonotonicityEnv where
@@ -232,7 +232,7 @@ def ppiItemTested : String := "some"
 -- § Entailment Signature Bridge
 -- ============================================================================
 
-open Core.NaturalLogic
+open NaturalLogic
 open Typology.PolarityItem
 open English.PolarityItems
 

--- a/Linglib/Studies/KadmonLandman1993.lean
+++ b/Linglib/Studies/KadmonLandman1993.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 import Linglib.Semantics.Polarity.Licensing
 import Linglib.Typology.PolarityItem
 import Linglib.Semantics.Entailment.Polarity
@@ -45,7 +45,7 @@ not sufficient: *each* and comparative *more often than* are DE yet resist
 
 namespace KadmonLandman1993
 
-open Core.NaturalLogic
+open NaturalLogic
 open Typology.PolarityItem (LicensingContext)
 open Semantics.Polarity.Licensing (LicensingMechanism)
 open Entailment

--- a/Linglib/Studies/KrizChemla2015.lean
+++ b/Linglib/Studies/KrizChemla2015.lean
@@ -34,7 +34,7 @@ This file remains the paper-anchored entry point and narrative hub.
 Three projector-synthesized fields are gone from the prior incarnation,
 verified against the paper PDF:
 - `Monotonicity` enum + `monotonicity` function — re-stipulated
-  `Core.Logic.NaturalLogic.ContextPolarity` and contained a return-value /
+  `NaturalLogic.ContextPolarity` and contained a return-value /
   comment contradiction for `notEvery`.
 - `ProjectionDatum`/`EmbeddedTruthConditions` structures with `Bool`
   predicate-shape fields and `String` informal-prose fields — violated

--- a/Linglib/Studies/Ladusaw1979.lean
+++ b/Linglib/Studies/Ladusaw1979.lean
@@ -44,7 +44,7 @@ open Semantics.Montague (ToyEntity)
     [ladusaw-1979]: DE licenses weak NPIs.
     [zwarts-1998]: anti-additive licenses strong NPIs.
 
-    A coarsening of `Core.NaturalLogic.DEStrength` that collapses the
+    A coarsening of `NaturalLogic.DEStrength` that collapses the
     `.antiMorphic` and `.antiAdditive` cases (Ladusaw treats them
     identically: both license strong NPIs). -/
 inductive LicensingStrength where
@@ -54,7 +54,7 @@ inductive LicensingStrength where
   deriving DecidableEq, Repr
 
 /-- Coarsen a `DEStrength` to Ladusaw's three-way classification. -/
-def LicensingStrength.ofDEStrength : Option Core.NaturalLogic.DEStrength → LicensingStrength
+def LicensingStrength.ofDEStrength : Option NaturalLogic.DEStrength → LicensingStrength
   | some .antiMorphic | some .antiAdditive => .antiAdditive
   | some .weak                              => .downwardEntailing
   | none                                    => .nonDE

--- a/Linglib/Typology/PolarityItem.lean
+++ b/Linglib/Typology/PolarityItem.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.LicensingContext
 import Linglib.Typology.NegativeConcord
-import Linglib.Core.Logic.NaturalLogic
+import Linglib.Semantics.NaturalLogic
 
 /-!
 # Typology.PolarityItem
@@ -300,7 +300,7 @@ structure PolarityItemEntry where
     anti-morphic) has no registry items yet — extend `PolarityType`
     when one lands. -/
 def PolarityItemEntry.strength (e : PolarityItemEntry) :
-    Option Core.NaturalLogic.DEStrength :=
+    Option NaturalLogic.DEStrength :=
   match e.polarityType with
   | .npiWeak => some .weak
   | .npiFci => some .weak


### PR DESCRIPTION
Finish the documented Core/Logic→Semantics migration (GQ half was #379). Move `Core/Logic/NaturalLogic.lean` (clean leaf) → top-level `Semantics/NaturalLogic.lean` and rename `Core.NaturalLogic` → bare `NaturalLogic`. The 3 soundness files stay in `Entailment/` but switch to `namespace NaturalLogic`. Pure move + rename; 23 files, git tracks it as a rename.

Depends on #436 (merged).