### PR TITLE
feat(Semantics): polymorphic StrengthScale + LinearOrder DEStrength

### DIFF
--- a/Linglib/Semantics/NaturalLogic.lean
+++ b/Linglib/Semantics/NaturalLogic.lean
@@ -1,5 +1,6 @@
 import Mathlib.Order.BoundedOrder.Basic
 import Mathlib.Algebra.BigOperators.Group.List.Defs
+import Mathlib.Data.Nat.Basic
 
 /-!
 # Natural Logic Relations and Entailment Signatures
@@ -539,6 +540,21 @@ inductive DEStrength where
   | antiMorphic    -- Anti-additive + ∧-distributive (= negation)
   deriving DecidableEq, Repr
 
+/-- Rank in the Zwarts chain `weak < antiAdditive < antiMorphic`. -/
+def DEStrength.toNat : DEStrength → Nat
+  | .weak => 0
+  | .antiAdditive => 1
+  | .antiMorphic => 2
+
+theorem DEStrength.toNat_injective : Function.Injective DEStrength.toNat := by
+  intro a b h; cases a <;> cases b <;> simp_all [DEStrength.toNat]
+
+/-- The Zwarts DE hierarchy as the linear order `weak < antiAdditive < antiMorphic`.
+This is the carrier of the canonical `zwartsScale` (`Semantics/Polarity/Licensing.lean`);
+other theories of NPI strength supply other ordered carriers. -/
+instance : LinearOrder DEStrength :=
+  LinearOrder.lift' DEStrength.toNat DEStrength.toNat_injective
+
 /--
 Strength of upward entailingness (dual of DEStrength).
 
@@ -557,15 +573,10 @@ inductive UEStrength where
 Check if a context's DE strength is sufficient for an NPI.
 
 `strengthSufficient contextStrength requiredStrength` returns true
-when `contextStrength ≥ requiredStrength` in the Zwarts hierarchy.
+when `requiredStrength ≤ contextStrength` in the Zwarts hierarchy (`LinearOrder DEStrength`).
 -/
 def strengthSufficient (contextStrength requiredStrength : DEStrength) : Bool :=
-  match requiredStrength, contextStrength with
-  | .weak, _ => true
-  | .antiAdditive, .weak => false
-  | .antiAdditive, _ => true
-  | .antiMorphic, .antiMorphic => true
-  | .antiMorphic, _ => false
+  decide (requiredStrength ≤ contextStrength)
 
 #guard strengthSufficient .antiMorphic .weak          -- negation licenses weak NPIs
 #guard strengthSufficient .antiMorphic .antiAdditive   -- negation licenses strong NPIs

--- a/Linglib/Semantics/Polarity/Licensing.lean
+++ b/Linglib/Semantics/Polarity/Licensing.lean
@@ -268,6 +268,48 @@ abbrev LicensedBySignature (e : Typology.PolarityItem.PolarityItemEntry)
     (c : LicensingContext) : Prop :=
   strengthLicenses e c = true
 
+/-! ### Polymorphic strength scales
+
+`strengthLicenses` is the Zwarts/`DEStrength` instance of a general pattern: a
+theory of NPI strength is an *ordered carrier* `S` plus how items and contexts
+project onto it, with licensing = `≤` on `S`. Different theories of strength
+(Gajewski plain-vs-exhaustified, Giannakidou veridicality, gradient) instantiate
+it with different carriers — see `scratch/npi-api-design.md`. -/
+
+/-- A **strength scale** for NPI licensing: how items and contexts project onto
+an ordered strength carrier `S`. `none` on either side = "no strength here" (the
+item licenses via another mechanism, or the context supplies none). -/
+structure StrengthScale (Item Context S : Type*) [Preorder S] where
+  /-- The strength an item requires (`none` = not strength-licensed). -/
+  required : Item → Option S
+  /-- The strength a context supplies (`none` = supplies no strength). -/
+  supplied : Context → Option S
+
+/-- Licensing on a scale: the context supplies at least the strength the item
+requires (both sides present). -/
+def StrengthScale.licenses {Item Context S : Type*} [Preorder S]
+    (L : StrengthScale Item Context S) (i : Item) (c : Context) : Prop :=
+  ∃ r ∈ L.required i, ∃ s ∈ L.supplied c, r ≤ s
+
+/-- The canonical Zwarts/[ladusaw-1979] scale: carrier `DEStrength`, item
+strength from `PolarityItemEntry.strength`, context strength from the row's
+Strawson signature. The first instance of `StrengthScale`. -/
+def zwartsScale :
+    StrengthScale Typology.PolarityItem.PolarityItemEntry LicensingContext
+      NaturalLogic.DEStrength where
+  required e := e.strength
+  supplied c := (contextProperties c).strawsonSignature.toDEStrength
+
+/-- The polymorphic scale subsumes the bespoke predicate: `zwartsScale.licenses`
+is exactly `LicensedBySignature` (derive-don't-duplicate). -/
+theorem zwartsScale_licenses_iff (e : Typology.PolarityItem.PolarityItemEntry)
+    (c : LicensingContext) :
+    zwartsScale.licenses e c ↔ LicensedBySignature e c := by
+  simp only [StrengthScale.licenses, zwartsScale, LicensedBySignature,
+    strengthLicenses, NaturalLogic.strengthSufficient]
+  cases (contextProperties c).strawsonSignature.toDEStrength <;>
+    cases e.strength <;> simp
+
 /-- A context is **Strawson-only** when no classical signature row holds
 ([von-fintel-1999]): only-focus, adversatives, temporal *since*,
 superlatives. -/

--- a/Linglib/Semantics/Polarity/Witnesses.lean
+++ b/Linglib/Semantics/Polarity/Witnesses.lean
@@ -205,7 +205,22 @@ noncomputable def contextWitness? :
   | .adversative => some adversativeWitness
   | .sinceTemporal => some sinceTemporalWitness
   | .superlative => some superlativeWitness
-  | _ => none
+  -- Not yet grounded (no witness operator built). Explicit `none` arms — no `_`
+  -- catch-all — so a newly-added `LicensingContext` fails to compile here rather
+  -- than silently being treated as unwitnessed.
+  | .beforeClause => none
+  | .withoutClause => none
+  | .question => none
+  | .comparativeNP => none
+  | .comparativeS => none
+  | .tooTo => none
+  | .modalPossibility => none
+  | .modalNecessity => none
+  | .imperative => none
+  | .generic => none
+  | .freeRelative => none
+  | .doubtVerb => none
+  | .denyVerb => none
 
 -- Coverage sentries (drift detection, not aggregate counts).
 example : (contextWitness? .negation).isSome = true := rfl


### PR DESCRIPTION
R0 of the NPI keystone arc (the grounding-independent, audit-flagged correctness fixes), with the strength layer made polymorphic so different theories can instantiate it.

- `LinearOrder DEStrength` (Zwarts chain); `strengthSufficient` grounded in `≤` (was a hand-rolled Bool match)
- `StrengthScale (Item Context S) [Preorder S]` — a theory's ordered strength carrier + item/context projections, licensing = `≤`; `zwartsScale` is instance #1, proven to subsume `LicensedBySignature`
- exhaustive `contextWitness?` arms (no `_ => none`): a new `LicensingContext` now fails to compile rather than silently licensing nothing

Deferred: the De Morgan `.antitone`-from-dual derivation (cleanup, not a fix). Design: scratch/npi-api-design.md.