### PR TITLE
refactor(Semantics/Definiteness): predicate operators over E → Prop

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1213,6 +1213,7 @@ import Linglib.Studies.Charlow2014
 import Linglib.Studies.Chomsky1981
 import Linglib.Studies.Cooper2023.Basic
 import Linglib.Studies.Cooper2023.Ch8
+import Linglib.Studies.CoppockBeaver2015
 import Linglib.Studies.Heim1982.Basic
 import Linglib.Studies.KampReyle1993
 import Linglib.Studies.KeshetAbney2024

--- a/Linglib/Semantics/Definiteness/Maximality.lean
+++ b/Linglib/Semantics/Definiteness/Maximality.lean
@@ -5,8 +5,12 @@ import Linglib.Core.Logic.Intensional.Variables
 [sharvy-1980] [kriz-2015] [coppock-beaver-2015] [russell-1905]
 
 Predicate operators consumed by the `Description` interpretation function in
-`Semantics/Definiteness/Interpret.lean`. All operators live over
-`Core.Logic.Intensional.Denot` so they slot directly into the IL stack.
+`Semantics/Definiteness/Interpret.lean`. They operate over entity predicates
+`E → Prop` — the extensional fragment of `Core.Logic.Intensional.Denot E W .et`.
+At type `.et` a denotation reduces to `E → Prop` with no occurrence of the
+situation type `W`, so these world-blind operators do not bind it: they apply
+to any IL denotation of type `.et` by defeq, with `E` inferred from the
+predicate's domain.
 
 ## What this module provides
 
@@ -48,59 +52,53 @@ Predicate operators consumed by the `Description` interpretation function in
 
 namespace Semantics.Definiteness
 
-open Core.Logic.Intensional
-
--- ════════════════════════════════════════════════════════════════
--- § Coppock–Beaver Factorization
--- ════════════════════════════════════════════════════════════════
+/-! ### Coppock–Beaver factorization -/
 
 /-- [coppock-beaver-2015]'s Existence component. Asserted, not
     presupposed, in their factorization of the Russellian iota. -/
-def Existence {E W : Type} (P : Denot E W .et) : Prop :=
+def Existence {E : Type} (P : E → Prop) : Prop :=
   ∃ x : E, P x
 
 /-- [coppock-beaver-2015]'s Uniqueness component. Presupposed (rather
     than asserted) on their account; this is the projection contrast that
     distinguishes "the King of France isn't bald" (uniqueness presupposed)
     from a plain Russellian negation (uniqueness in scope of negation). -/
-def Uniqueness {E W : Type} (P : Denot E W .et) : Prop :=
+def Uniqueness {E : Type} (P : E → Prop) : Prop :=
   ∀ x y : E, P x → P y → x = y
 
 /-- The classical Russellian condition: `∃!x. P x`. By construction the
     conjunction of [coppock-beaver-2015]'s two components. -/
-def existsUnique {E W : Type} (P : Denot E W .et) : Prop :=
+def existsUnique {E : Type} (P : E → Prop) : Prop :=
   Existence P ∧ Uniqueness P
 
 /-- Russellian existence-and-uniqueness is exactly the conjunction of
     Coppock–Beaver Existence and Uniqueness. By definition. -/
 theorem existsUnique_iff_existence_and_uniqueness
-    {E W : Type} (P : Denot E W .et) :
+    {E : Type} (P : E → Prop) :
     existsUnique P ↔ (Existence P ∧ Uniqueness P) := Iff.rfl
 
 /-- Existence and Uniqueness are logically independent. The empty predicate
     `λ _ => False` satisfies Uniqueness (vacuously) but not Existence —
     [coppock-beaver-2015]'s key motivating data. -/
-theorem uniqueness_does_not_imply_existence {E W : Type} :
-    Uniqueness (E := E) (W := W) (fun _ => False) ∧ ¬ Existence (E := E) (W := W) (fun _ => False) := by
+theorem uniqueness_does_not_imply_existence {E : Type} :
+    Uniqueness (E := E) (fun _ => False) ∧ ¬ Existence (E := E) (fun _ => False) := by
   refine ⟨?_, ?_⟩
   · intro x y hx _; exact False.elim hx
   · rintro ⟨_, h⟩; exact h
 
--- ════════════════════════════════════════════════════════════════
--- § Russellian Iota (order-free)
--- ════════════════════════════════════════════════════════════════
+/-! ### Russellian iota (order-free) -/
 
 /-- The order-free unique-element selector: returns the witness when there
     is exactly one P-satisfier. Order-free version usable when no preorder is
     declared on `E`. -/
-noncomputable def russellIota {E W : Type} (P : Denot E W .et) : Option E :=
+noncomputable def russellIota {E : Type} (P : E → Prop) : Option E :=
   letI := Classical.dec (existsUnique P)
   if h : existsUnique P then some h.1.choose else none
 
 /-- `russellIota` returns `some` exactly when Russellian existence-and-
     uniqueness holds. -/
 theorem russellIota_isSome_iff_existsUnique
-    {E W : Type} (P : Denot E W .et) :
+    {E : Type} (P : E → Prop) :
     (russellIota P).isSome ↔ existsUnique P := by
   classical
   unfold russellIota
@@ -110,7 +108,7 @@ theorem russellIota_isSome_iff_existsUnique
 
 /-- The witness returned by `russellIota` satisfies the predicate. -/
 theorem russellIota_witness_satisfies
-    {E W : Type} (P : Denot E W .et) (e : E)
+    {E : Type} (P : E → Prop) (e : E)
     (h : russellIota P = some e) : P e := by
   classical
   unfold russellIota at h
@@ -123,7 +121,7 @@ theorem russellIota_witness_satisfies
 /-- Two witnesses returned by `russellIota` (over the same predicate) must
     coincide. By Uniqueness. -/
 theorem russellIota_witness_unique
-    {E W : Type} (P : Denot E W .et) (e₁ e₂ : E)
+    {E : Type} (P : E → Prop) (e₁ e₂ : E)
     (h₁ : russellIota P = some e₁) (h₂ : russellIota P = some e₂) :
     e₁ = e₂ := by
   rw [h₁] at h₂
@@ -151,23 +149,21 @@ theorem russellIotaList_eq_some_iff {E : Type*} (domain : List E) (P : E → Boo
     | nil => simp
     | cons hd' tl' => simp
 
--- ════════════════════════════════════════════════════════════════
--- § Sharvy Maximality (preorder-relative)
--- ════════════════════════════════════════════════════════════════
+/-! ### Sharvy maximality (preorder-relative) -/
 
 /-- [sharvy-1980]: an entity `e` is *maximal* among the P-satisfiers
     when `e` satisfies `P` and dominates every other P-satisfier under `≤`.
     For singular count nouns the order is flat (only `e ≤ e`) so maximality
     coincides with Russellian uniqueness; for plurals (with [link-1983]'s
     join semilattice) maximality returns the sum of all atoms. -/
-def IsMaximal {E W : Type} [LE E] (P : Denot E W .et) (e : E) : Prop :=
+def IsMaximal {E : Type} [LE E] (P : E → Prop) (e : E) : Prop :=
   P e ∧ ∀ x : E, P x → x ≤ e
 
 /-- Sharvy maximality is unique: at most one entity is `IsMaximal P` under a
     partial order. Antisymmetry collapses two maxima into one. -/
 theorem isMaximal_unique
-    {E W : Type} [PartialOrder E]
-    (P : Denot E W .et) (e₁ e₂ : E)
+    {E : Type} [PartialOrder E]
+    (P : E → Prop) (e₁ e₂ : E)
     (h₁ : IsMaximal P e₁) (h₂ : IsMaximal P e₂) : e₁ = e₂ := by
   exact le_antisymm (h₂.2 _ h₁.1) (h₁.2 _ h₂.1)
 
@@ -175,13 +171,13 @@ theorem isMaximal_unique
     P-satisfier when one exists; `none` otherwise (no satisfier, or no
     upper bound among the satisfiers). -/
 noncomputable def sharvyMax
-    {E W : Type} [PartialOrder E] (P : Denot E W .et) : Option E :=
+    {E : Type} [PartialOrder E] (P : E → Prop) : Option E :=
   letI := Classical.dec (∃ e, IsMaximal P e)
   if h : ∃ e, IsMaximal P e then some h.choose else none
 
 /-- `sharvyMax` returns `some` exactly when a maximal P-satisfier exists. -/
 theorem sharvyMax_isSome_iff_isMaximal
-    {E W : Type} [PartialOrder E] (P : Denot E W .et) :
+    {E : Type} [PartialOrder E] (P : E → Prop) :
     (sharvyMax P).isSome ↔ ∃ e, IsMaximal P e := by
   classical
   unfold sharvyMax
@@ -191,7 +187,7 @@ theorem sharvyMax_isSome_iff_isMaximal
 
 /-- The witness returned by `sharvyMax` is maximal. -/
 theorem sharvyMax_witness_isMaximal
-    {E W : Type} [PartialOrder E] (P : Denot E W .et) (e : E)
+    {E : Type} [PartialOrder E] (P : E → Prop) (e : E)
     (h : sharvyMax P = some e) : IsMaximal P e := by
   classical
   unfold sharvyMax at h
@@ -203,34 +199,32 @@ theorem sharvyMax_witness_isMaximal
 
 /-- The witness returned by `sharvyMax` satisfies `P`. -/
 theorem sharvyMax_witness_satisfies
-    {E W : Type} [PartialOrder E] (P : Denot E W .et) (e : E)
+    {E : Type} [PartialOrder E] (P : E → Prop) (e : E)
     (h : sharvyMax P = some e) : P e :=
   (sharvyMax_witness_isMaximal P e h).1
 
--- ════════════════════════════════════════════════════════════════
--- § Križ Homogeneity
--- ════════════════════════════════════════════════════════════════
+/-! ### Križ homogeneity -/
 
 /-- [kriz-2015]: a scope predicate `S` is *homogeneous* on the
     P-satisfiers when it holds either of all of them or of none of them.
     This is what licenses "the boys are tall" — Križ argues uniformity is
     presupposed, so partial-truth cases (some boys tall, others not) yield
     presupposition failure rather than `False`. -/
-def Homogeneous {E W : Type} (P S : Denot E W .et) : Prop :=
+def Homogeneous {E : Type} (P S : E → Prop) : Prop :=
   (∀ x, P x → S x) ∨ (∀ x, P x → ¬ S x)
 
 /-- Homogeneity is symmetric in its two failure modes (uniformly-S vs
     uniformly-¬S). Both yield well-defined truth values; only the *split*
     case is presupposition failure. By definition. -/
 theorem homogeneous_symmetric_in_truth_value
-    {E W : Type} (P S : Denot E W .et) :
+    {E : Type} (P S : E → Prop) :
     Homogeneous P S ↔ ((∀ x, P x → S x) ∨ (∀ x, P x → ¬ S x)) := Iff.rfl
 
 /-- Russellian uniqueness implies Križ homogeneity (vacuously beyond the
     unique witness): if there is exactly one P-satisfier, then any S is
     trivially uniform on the (singleton) extension of P. -/
 theorem uniqueness_implies_homogeneous_classical
-    {E W : Type} (P S : Denot E W .et)
+    {E : Type} (P S : E → Prop)
     (hU : Uniqueness P) :
     Homogeneous P S := by
   classical

--- a/Linglib/Semantics/Possessive/Denotation.lean
+++ b/Linglib/Semantics/Possessive/Denotation.lean
@@ -46,7 +46,7 @@ variable {Ctx : Type*} {W E : Type}
 presupposition — definedness is its only presupposition. -/
 noncomputable def theOf (R : E → E → Prop) (possessor : E) : NominalDenot Ctx W E where
   presup := fun _ _ => True
-  selector := fun _ _ => russellIota (E := E) (W := W) (fun y => R possessor y)
+  selector := fun _ _ => russellIota (E := E) (fun y => R possessor y)
 
 /-- *NP's N*: re-select the possessor denotation through the possession relation
 `R`. -/
@@ -68,7 +68,7 @@ relation: defined exactly when the possessor is defined and has a unique
 @[simp] theorem applyTo_selector (nd : NominalDenot Ctx W E) (R : E → E → Prop)
     (c : Ctx) (w : W) :
     (applyTo nd R).selector c w =
-      (nd.selector c w).bind (fun p => russellIota (E := E) (W := W) (fun y => R p y)) := by
+      (nd.selector c w).bind (fun p => russellIota (E := E) (fun y => R p y)) := by
   simp only [applyTo, theOf, NominalDenot.bind_selector]
 
 /-- Nesting (*John's mother's friend*) — from `bind` associativity. -/
@@ -84,6 +84,6 @@ carrier bears the iota-presupposition (`HasIotaWitness`). -/
 noncomputable def Definite.toNominalDenot {S : Type} (d : Possessive.Definite E S) :
     NominalDenot Ctx S E where
   presup := fun _ _ => True
-  selector := fun _ s => russellIota (E := E) (W := S) (fun y => d.predicate y s)
+  selector := fun _ s => russellIota (E := E) (fun y => d.predicate y s)
 
 end Possessive

--- a/Linglib/Semantics/Possessive/PronounMixing.lean
+++ b/Linglib/Semantics/Possessive/PronounMixing.lean
@@ -51,7 +51,7 @@ theorem possessivePronoun_selector (p : PersonalPronoun) (i : ℕ)
     (speaker addressee : E) (isFemale isInanimate : E → Prop) (R : E → E → Prop)
     (g : Assignment E) (w : PUnit) :
     (applyTo (p.denote i speaker addressee isFemale isInanimate) R).selector g w
-      = russellIota (E := E) (W := PUnit)
+      = russellIota (E := E)
           (fun y => R (interpPronoun (E := E) (W := PUnit) i g) y) := by
   rw [applyTo_selector]; rfl
 

--- a/Linglib/Studies/CoppockBeaver2015.lean
+++ b/Linglib/Studies/CoppockBeaver2015.lean
@@ -19,24 +19,24 @@ one king (Uniqueness), while leaving Existence in the scope of negation.
 The classical Russellian analysis collapses both into the assertion and
 loses this distinction.
 
-## What this file tests
+The factorization is operationalized in `Semantics.Definiteness` as
+`Existence`, `Uniqueness`, and `existsUnique`; this file tests it over a
+tiny frame (`Body`: sun / moon / mars, one situation index).
 
-The factorization is operationalized in `Semantics.Definiteness.Maximality` as
-`Existence`, `Uniqueness`, and `existsUnique` over `Denot Body Unit .et`. This
-study file builds three concrete restrictors over a tiny frame (sun /
-moon / mars; one index) and verifies:
+## Main results
 
-1. **Logical independence** — Uniqueness can hold without Existence
-   (the empty `kingOfFrance` extension), and Existence can hold without
-   Uniqueness (the multi-witness `planet` extension).
-2. **Russellian collapse** — `existsUnique` is true exactly for
-   restrictors with a singleton extension (`theSun`).
-3. **Interpretation alignment** — `Semantics.Definiteness.interpret` on a
-   `.unique` description returns `none` precisely in the Russellian
-   failure cases (no extension, or non-unique extension).
-4. **Negation-projection contrast** — the Uniqueness component projects
-   through the assertion's polarity: ¬(the King of France is bald)
-   still requires uniqueness of the King of France.
+- `kingOfFrance_uniqueness_without_existence`,
+  `planet_existence_without_uniqueness`: Existence and Uniqueness are
+  logically independent.
+- `theSun_existsUnique`, `kingOfFrance_not_existsUnique`,
+  `planet_not_existsUnique`: Russellian `existsUnique` holds exactly for a
+  singleton extension.
+- `interpret_theSun`, `interpret_kingOfFrance`, `interpret_planet`:
+  `Semantics.Definiteness.interpret` on a `.unique` description returns
+  `none` precisely in the Russellian failure cases.
+- `uniqueness_projects_through_negation`,
+  `existence_does_not_project_through_negation`: the projection contrast —
+  Uniqueness survives a scope operator, Existence does not.
 -/
 
 namespace CoppockBeaver2015
@@ -45,9 +45,7 @@ open Core.Logic.Intensional
 open Core.Logic.Intensional.Variables
 open Semantics.Definiteness
 
--- ════════════════════════════════════════════════════════════════
--- §1: A tiny frame for the projection diagnostics
--- ════════════════════════════════════════════════════════════════
+/-! ### A tiny frame for the projection diagnostics -/
 
 /-- Three celestial bodies. `sun` is the unique satisfier of `theSun`;
     `moon` and `mars` jointly witness the multi-extension `planet`. -/
@@ -57,9 +55,9 @@ inductive Body where
   | mars
   deriving DecidableEq, Repr
 
-/-- Singleton restrictor: `theSun` holds of exactly one entity.
-    One index suffices: the diagnostics are about predicate extensions,
-    not about world-variability. -/
+/-- Singleton restrictor: `theSun` holds of exactly one entity. One index
+    suffices — the diagnostics are about predicate extensions, not about
+    world-variability. -/
 def theSun : Denot Body Unit .et
   | .sun => True
   | _    => False
@@ -70,30 +68,24 @@ def planet : Denot Body Unit .et
   | .mars => True
   | _    => False
 
-/-- Empty restrictor: `kingOfFrance` has no satisfier. The
+/-- Empty restrictor: `kingOfFrance` has no satisfier — the
     [coppock-beaver-2015] motivating case. -/
 def kingOfFrance : Denot Body Unit .et := fun _ => False
 
--- ════════════════════════════════════════════════════════════════
--- §2: Existence and Uniqueness are logically independent
--- ════════════════════════════════════════════════════════════════
+/-! ### Existence and Uniqueness are logically independent -/
 
-/-- The empty restrictor satisfies Uniqueness vacuously, but not
-    Existence. The exact configuration [coppock-beaver-2015] use
-    to argue that Uniqueness is a separate component, projecting
-    through assertion polarity. -/
+/-- The empty restrictor satisfies Uniqueness vacuously but not Existence —
+    the configuration [coppock-beaver-2015] use to argue that Uniqueness is a
+    separate component, projecting through assertion polarity. A concrete
+    instance of the substrate's `uniqueness_does_not_imply_existence`. -/
 theorem kingOfFrance_uniqueness_without_existence :
-    Uniqueness (E := Body) (W := Unit) kingOfFrance ∧
-    ¬ Existence (E := Body) (W := Unit) kingOfFrance := by
-  refine ⟨?_, ?_⟩
-  · intro x y hx _; exact hx.elim
-  · rintro ⟨_, h⟩; exact h
+    Uniqueness kingOfFrance ∧ ¬ Existence kingOfFrance :=
+  uniqueness_does_not_imply_existence
 
-/-- The multi-witness restrictor satisfies Existence but not Uniqueness.
-    Witnesses: moon and mars are both planets and are distinct. -/
+/-- The multi-witness restrictor satisfies Existence but not Uniqueness:
+    moon and mars are both planets and are distinct. -/
 theorem planet_existence_without_uniqueness :
-    Existence (E := Body) (W := Unit) planet ∧
-    ¬ Uniqueness (E := Body) (W := Unit) planet := by
+    Existence planet ∧ ¬ Uniqueness planet := by
   refine ⟨⟨.moon, trivial⟩, ?_⟩
   intro h
   have : Body.moon = Body.mars := h .moon .mars trivial trivial
@@ -101,103 +93,89 @@ theorem planet_existence_without_uniqueness :
 
 /-- The singleton restrictor satisfies both components. -/
 theorem theSun_existence_and_uniqueness :
-    Existence (E := Body) (W := Unit) theSun ∧ Uniqueness (E := Body) (W := Unit) theSun := by
+    Existence theSun ∧ Uniqueness theSun := by
   refine ⟨⟨.sun, trivial⟩, ?_⟩
   intro x y hx hy
-  cases x <;> cases y <;> simp_all [theSun]
+  cases x <;> cases y <;> simp only [theSun] at hx hy ⊢
 
--- ════════════════════════════════════════════════════════════════
--- §3: Russellian collapse — `existsUnique` is the conjunction
--- ════════════════════════════════════════════════════════════════
+/-! ### Russellian collapse: `existsUnique` is the conjunction -/
 
 /-- For `theSun`, the Russellian condition holds: `existsUnique` is by
     construction the conjunction of Existence and Uniqueness. -/
-theorem theSun_existsUnique :
-    existsUnique (E := Body) (W := Unit) theSun :=
+theorem theSun_existsUnique : existsUnique theSun :=
   theSun_existence_and_uniqueness
 
 /-- For `kingOfFrance`, `existsUnique` fails — Existence is the missing
     conjunct. The factorization explains *which* component fails. -/
-theorem kingOfFrance_not_existsUnique :
-    ¬ existsUnique (E := Body) (W := Unit) kingOfFrance := by
+theorem kingOfFrance_not_existsUnique : ¬ existsUnique kingOfFrance := by
   rintro ⟨hExist, _⟩
   exact kingOfFrance_uniqueness_without_existence.2 hExist
 
-/-- For `planet`, `existsUnique` fails — Uniqueness is the missing
-    conjunct. -/
-theorem planet_not_existsUnique :
-    ¬ existsUnique (E := Body) (W := Unit) planet := by
+/-- For `planet`, `existsUnique` fails — Uniqueness is the missing conjunct. -/
+theorem planet_not_existsUnique : ¬ existsUnique planet := by
   rintro ⟨_, hUniq⟩
   exact planet_existence_without_uniqueness.2 hUniq
 
--- ════════════════════════════════════════════════════════════════
--- §4: Alignment with `Semantics.Definiteness.interpret`
--- ════════════════════════════════════════════════════════════════
+/-! ### Alignment with `Semantics.Definiteness.interpret` -/
 
 /-- A trivial bi-assignment: every entity slot is `sun`, every situation
     slot is `()`. The diagnostics in this file do not bind anything. -/
 def g₀ : Core.Assignment Body := fun _ => Body.sun
 def gs₀ : SitAssignment Unit := fun _ => ()
 
+/-- A `.unique` description whose restrictor lacks a unique satisfier
+    interprets to `none` — the shared engine behind the Existence-failure
+    and Uniqueness-failure diagnostics below. -/
+private theorem interpret_unique_const_none_of_not_existsUnique
+    (R : Denot Body Unit .et) (h : ¬ existsUnique R) :
+    interpret (.unique (DenotGS.const R) 0) g₀ gs₀ = none := by
+  rw [interpret_unique]
+  have hns : ¬ (russellIota (fun x => (DenotGS.const R) g₀ gs₀ x)).isSome := by
+    rw [russellIota_isSome_iff_existsUnique]; exact h
+  rcases hr : russellIota (fun x => (DenotGS.const R) g₀ gs₀ x) with _ | e
+  · rfl
+  · exact absurd (hr ▸ rfl) hns
+
 /-- `the sun` (as a `.unique` description with restrictor `theSun`)
     interprets to `some sun` — the unique-witness case. -/
 theorem interpret_theSun :
-    interpret (E := Body) (W := Unit) (.unique (DenotGS.const theSun) 0) g₀ gs₀ = some Body.sun :=
+    interpret (.unique (DenotGS.const theSun) 0) g₀ gs₀ = some Body.sun :=
   interpret_unique_eq_some_of_existsUnique _ 0 g₀ gs₀ Body.sun trivial
-    (fun y hy => by cases y <;> simp_all [theSun, DenotGS.const])
+    (fun y hy => by cases y <;> simp only [theSun, DenotGS.const] at hy ⊢)
 
 /-- `the King of France` interprets to `none` — Existence failure. The
-    Russellian iota collapses the projection structure here, but the
-    diagnostic in §2 already isolated *which* component failed. -/
+    Russellian iota collapses the projection structure here, but §2 already
+    isolated *which* component failed. -/
 theorem interpret_kingOfFrance :
-    interpret (E := Body) (W := Unit)
-      (.unique (DenotGS.const kingOfFrance) 0) g₀ gs₀ = none := by
-  rw [interpret_unique]
-  have : ¬ (russellIota (fun x => (DenotGS.const kingOfFrance) g₀ gs₀ x)).isSome := by
-    rw [russellIota_isSome_iff_existsUnique]; exact kingOfFrance_not_existsUnique
-  rcases h : russellIota (fun x => (DenotGS.const kingOfFrance) g₀ gs₀ x) with _ | e
-  · rfl
-  · exact absurd (h ▸ rfl) this
+    interpret (.unique (DenotGS.const kingOfFrance) 0) g₀ gs₀ = none :=
+  interpret_unique_const_none_of_not_existsUnique kingOfFrance kingOfFrance_not_existsUnique
 
 /-- `the planet` interprets to `none` — Uniqueness failure. Same surface
     output as the Existence-failure case, even though the underlying
     presupposition violation is structurally different. -/
 theorem interpret_planet :
-    interpret (E := Body) (W := Unit)
-      (.unique (DenotGS.const planet) 0) g₀ gs₀ = none := by
-  rw [interpret_unique]
-  have : ¬ (russellIota (fun x => (DenotGS.const planet) g₀ gs₀ x)).isSome := by
-    rw [russellIota_isSome_iff_existsUnique]; exact planet_not_existsUnique
-  rcases h : russellIota (fun x => (DenotGS.const planet) g₀ gs₀ x) with _ | e
-  · rfl
-  · exact absurd (h ▸ rfl) this
+    interpret (.unique (DenotGS.const planet) 0) g₀ gs₀ = none :=
+  interpret_unique_const_none_of_not_existsUnique planet planet_not_existsUnique
 
--- ════════════════════════════════════════════════════════════════
--- §5: Negation-projection contrast (the empirical payoff)
--- ════════════════════════════════════════════════════════════════
+/-! ### Negation-projection contrast -/
 
 /-- Predicate-level negation does not affect Uniqueness. This is the
-    [coppock-beaver-2015] projection diagnostic, expressed at the
-    restrictor layer: whether the King of France is bald or non-bald,
-    the Uniqueness presupposition on `kingOfFrance` survives.
-    Operationalized here as: Uniqueness is a property of the *restrictor*,
-    not the *scope*, so any sentential operator wrapping the description
-    leaves it unchanged. -/
-theorem uniqueness_projects_through_negation
-    (scope : Denot Body Unit .et) :
-    Uniqueness (E := Body) (W := Unit) kingOfFrance ∧
-    Uniqueness (E := Body) (W := Unit) (fun x => ¬ scope x ∧ kingOfFrance x) := by
+    [coppock-beaver-2015] projection diagnostic, expressed at the restrictor
+    layer: whether the King of France is bald or non-bald, the Uniqueness
+    presupposition on `kingOfFrance` survives. Uniqueness is a property of the
+    *restrictor*, not the *scope*, so any sentential operator wrapping the
+    description leaves it unchanged. -/
+theorem uniqueness_projects_through_negation (scope : Denot Body Unit .et) :
+    Uniqueness kingOfFrance ∧ Uniqueness (fun x => ¬ scope x ∧ kingOfFrance x) := by
   refine ⟨kingOfFrance_uniqueness_without_existence.1, ?_⟩
   intro x y hx _; exact hx.2.elim
 
-/-- The Existence component, by contrast, can be negated independently:
-    a non-existing King of France can satisfy or fail to satisfy any
-    scope predicate vacuously. This is the contrast that motivates the
-    factorization — Existence enters the scope of negation, Uniqueness
-    does not. -/
-theorem existence_does_not_project_through_negation
-    (scope : Denot Body Unit .et) :
-    ¬ Existence (E := Body) (W := Unit) (fun x => scope x ∧ kingOfFrance x) := by
+/-- The Existence component, by contrast, can be negated independently: a
+    non-existing King of France satisfies or fails any scope predicate
+    vacuously. This is the contrast that motivates the factorization —
+    Existence enters the scope of negation, Uniqueness does not. -/
+theorem existence_does_not_project_through_negation (scope : Denot Body Unit .et) :
+    ¬ Existence (fun x => scope x ∧ kingOfFrance x) := by
   rintro ⟨_, _, h⟩; exact h
 
 end CoppockBeaver2015

--- a/Linglib/Studies/Hanink2021.lean
+++ b/Linglib/Studies/Hanink2021.lean
@@ -109,7 +109,7 @@ def gsLiving : SitAssignment Room := fun _ => Room.living
 /-- Restrictor uniqueness in the kitchen situation: only `tableKitchen`
     satisfies `tableAtSit0`. -/
 theorem tableAtSit0_existsUnique_kitchen :
-    existsUnique (E := Item) (W := Room) (fun x => tableAtSit0 g₀ gsKitchen x) := by
+    existsUnique (E := Item) (fun x => tableAtSit0 g₀ gsKitchen x) := by
   refine ⟨⟨Item.tableKitchen, trivial⟩, ?_⟩
   intro x y hx hy
   cases x <;> cases y <;>
@@ -118,7 +118,7 @@ theorem tableAtSit0_existsUnique_kitchen :
 /-- Restrictor uniqueness in the living-room situation: only
     `tableLiving` satisfies `tableAtSit0`. -/
 theorem tableAtSit0_existsUnique_living :
-    existsUnique (E := Item) (W := Room) (fun x => tableAtSit0 g₀ gsLiving x) := by
+    existsUnique (E := Item) (fun x => tableAtSit0 g₀ gsLiving x) := by
   refine ⟨⟨Item.tableLiving, trivial⟩, ?_⟩
   intro x y hx hy
   cases x <;> cases y <;>

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -193,7 +193,7 @@ theorem feminine_per_picks_unique_female {E W : Type}
         (Semantics.Definiteness.Description.ofPresupType .uniqueness
           ((fun _ _ x => (femSem isFemale).presup x) :
             Core.Logic.Intensional.Variables.DenotGS E W .et) sIdx) g gs
-      = Semantics.Definiteness.russellIota (E := E) (W := W) (fun x => isFemale x) :=
+      = Semantics.Definiteness.russellIota (E := E) (fun x => isFemale x) :=
   Semantics.Definiteness.interpret_unique
     ((fun _ _ x => isFemale x) : Core.Logic.Intensional.Variables.DenotGS E W .et) sIdx g gs
 


### PR DESCRIPTION
State the Definiteness predicate operators (`Existence`/`Uniqueness`/`existsUnique`/`russellIota`/`IsMaximal`/`sharvyMax`/`Homogeneous`) over `E → Prop`. `W` is a phantom at type `.et` (it appears only in `Denot`'s `.intens` case), so these world-blind operators need not bind it; callers passing `Denot E W .et` values still work by defeq, and `interpret` keeps `W`.

- Ripple `(W := …)` drops to Hanink2021, PatelGroszGrosz2017, Possessive/{Denotation,PronounMixing}.
- Audit `CoppockBeaver2015` to mathlib conventions (`/-! ### -/` headers, terse docstring, shared `none`-interpretation helper, derive from substrate) and wire the orphaned module into `Linglib.lean`.