### PR TITLE
refactor(Core/Order/Mereology): ground DIV in mathlib's IsLowerSet

### DIFF
--- a/Linglib/Core/Order/Mereology.lean
+++ b/Linglib/Core/Order/Mereology.lean
@@ -73,12 +73,19 @@ theorem cum_iff {α : Type*} [SemilatticeSup α] {P : α → Prop} :
     CUM P ↔ ∀ (x y : α), P x → P y → P (x ⊔ y) :=
   ⟨fun h _ _ hx hy => h hx hy, fun h _ hx _ hy => h _ _ hx hy⟩
 
-/-- Divisive reference (DIV): P is closed downward under ≤.
+/-- Divisive reference (DIV): P is closed downward under ≤. Grounded in
+    mathlib's `IsLowerSet` — `DIV P` **is** `IsLowerSet {x | P x}`;
+    `div_iff` recovers the paper-faithful `∀ x y` form.
     [champollion-2017] §2.3.3: DIV(P) ⇔ ∀x,y. P(x) ∧ y ≤ x → P(y).
     This is the mereological analog of the subinterval property.
     Only requires `Preorder` since the definition only uses `≤`. -/
-def DIV {α : Type*} [Preorder α] (P : α → Prop) : Prop :=
-  ∀ (x y : α), P x → y ≤ x → P y
+abbrev DIV {α : Type*} [Preorder α] (P : α → Prop) : Prop :=
+  IsLowerSet {x | P x}
+
+/-- Paper-faithful unfolding of `DIV` to the `∀ x y` form. -/
+theorem div_iff {α : Type*} [Preorder α] {P : α → Prop} :
+    DIV P ↔ ∀ (x y : α), P x → y ≤ x → P y :=
+  ⟨fun h _ _ hx hyx => h hyx hx, fun h a b hba ha => h a b ha hba⟩
 
 /-- Quantized reference (QUA): no proper part of a P-entity is also P.
 
@@ -169,7 +176,7 @@ theorem div_closed_under_le {α : Type*} [PartialOrder α]
     (hDiv : DIV P)
     {z : α} (hz : P z) {w : α} (hle : w ≤ z) :
     P w :=
-  hDiv z w hz hle
+  div_iff.mp hDiv z w hz hle
 
 /-- CUM and QUA partition event predicates (for non-trivial predicates):
     a predicate with ≥ 2 distinct elements cannot be both CUM and QUA.
@@ -616,7 +623,7 @@ def gHomogeneous {α : Type*} [PartialOrder α] (P : α → Prop) : Prop :=
     a fortiori every proper part has a P-part (itself). -/
 theorem div_implies_gHomogeneous {α : Type*} [PartialOrder α]
     {P : α → Prop} (hDiv : DIV P) : gHomogeneous P :=
-  fun x y hPx hlt => ⟨y, le_refl y, hDiv x y hPx (le_of_lt hlt)⟩
+  fun x y hPx hlt => ⟨y, le_refl y, div_iff.mp hDiv x y hPx (le_of_lt hlt)⟩
 
 /-- g-Homogeneity is vacuously satisfied at atoms: since atoms have
     no proper parts, the universal condition `∀ y < a, ∃ z ≤ y, P z`

--- a/Linglib/Semantics/Kinds/NominalMappingParameter.lean
+++ b/Linglib/Semantics/Kinds/NominalMappingParameter.lean
@@ -137,7 +137,7 @@ variable {World Atom : Type*}
     then `y ∈ P w`. Every part of a mass-noun instance is also an instance. -/
 theorem isMass_div (P : Property World Atom) (hMass : IsMass World Atom P) (w : World) :
     Mereology.DIV (P w) :=
-  fun x y hx hyx => (hMass w y).mpr fun a ha => (hMass w x).mp hx a (hyx ha)
+  Mereology.div_iff.mpr fun x y hx hyx => (hMass w y).mpr fun a ha => (hMass w x).mp hx a (hyx ha)
 
 /-- Mass properties have cumulative reference: if `x ∈ P w` and `y ∈ P w`,
     then `x ∪ y ∈ P w`. Combining mass-noun instances yields an instance. -/

--- a/Linglib/Studies/BondarenkoElliott2026.lean
+++ b/Linglib/Studies/BondarenkoElliott2026.lean
@@ -227,7 +227,7 @@ theorem believes_closure_under_entailment
     Believes believe HOLDER CONT M p' := by
   obtain ⟨e, hbel, hhol, hcont⟩ := h_bel
   obtain ⟨e', hlt, hcont'⟩ := h_msi hcont h_lt
-  refine ⟨e', h_div.1 e e' hbel (le_of_lt hlt),
+  refine ⟨e', Mereology.div_iff.mp h_div.1 e e' hbel (le_of_lt hlt),
           h_div.2 hhol (le_of_lt hlt), hcont'⟩
 
 /-- **Lemma — paper eq. 46**: MSI implies negated belief is *downward*
@@ -372,7 +372,7 @@ theorem positive_sharvit_closure
   -- Step 2 (MSI): get e' < e with CONT_v e' = some p'.
   obtain ⟨e', h_e'_lt, h_cont_e'⟩ := h_msi h_cont_e h_lt
   -- Step 3 (BelievingDIV): e' is a believing of M.
-  have h_bel' : believe e' := h_div.1 e e' h_bel (le_of_lt h_e'_lt)
+  have h_bel' : believe e' := Mereology.div_iff.mp h_div.1 e e' h_bel (le_of_lt h_e'_lt)
   have h_hol' : HOLDER e' = some M := h_div.2 h_hol (le_of_lt h_e'_lt)
   -- Step 4 (WorldLocatedDIV): e' is located at w too.
   have h_loc' : located e' w := h_world_div (le_of_lt h_e'_lt) h_loc

--- a/Linglib/Studies/Pasternak2019.lean
+++ b/Linglib/Studies/Pasternak2019.lean
@@ -306,7 +306,7 @@ theorem mentalStateHomogeneity_iff {Event : Type*} [Preorder Event]
     (P : Event → Prop) (h : MentalStateHomogeneity P) (e : Event) :
     P e ↔ ∀ e' : Event, e' ≤ e → P e' := by
   constructor
-  · intro hPe e' hle; exact h e e' hPe hle
+  · intro hPe e' hle; exact Mereology.div_iff.mp h e e' hPe hle
   · intro hAll; exact hAll e (le_refl e)
 
 /-! ## §5.1 Intensity Comparative Max-Reduction
@@ -368,8 +368,8 @@ theorem sortDetermined_isHomogeneous
     (s : Features.Dynamicity) :
     letI := Event.preorder Time
     MentalStateHomogeneity (fun e : Event Time => e.sort = s) := by
-  intro e e' hPe hle
-  exact (Event.Mereology.sort_preserved e' e hle).trans hPe
+  exact Mereology.div_iff.mpr fun e e' hPe hle =>
+    (Event.Mereology.sort_preserved e' e hle).trans hPe
 
 /-- On a `PartialOrder` carrier, Pasternak's `MentalStateHomogeneity`
     implies `Mereology.gHomogeneous` (every proper part has a P-part —


### PR DESCRIPTION
Second step of dissolving `Mereology`'s order-theory shadows into mathlib (after CUM, #445). `DIV` was a verbatim re-implementation of `Order.IsLowerSet`; now `abbrev DIV (P) := IsLowerSet {x | P x}`, with `div_iff` recovering the paper-faithful `∀ x y, P x → y ≤ x → P y` form. 3 consumers migrated via `div_iff` (no semantic change); much smaller blast radius than CUM (DIV has 6 referrers, 3 broke).

Next (same pattern): `QUA → IsAntichain`, then `AlgClosure → supClosure` (harder — constructor migration), then the `Core/Order/ → Semantics/Mereology.lean` relocation.