### PR TITLE
refactor(Core/Order/Mereology): ground QUA in IsAntichain, clean consumers

### DIFF
--- a/Linglib/Core/Order/Mereology.lean
+++ b/Linglib/Core/Order/Mereology.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Algebra.Order.Ring.Unbundled.Rat
 import Mathlib.Order.Closure
 import Mathlib.Order.SupClosed
+import Mathlib.Order.Antichain
 import Mathlib.Order.Interval.Set.OrdConnected
 import Mathlib.Order.UpperLower.Closure
 import Mathlib.Order.Hom.Lattice
@@ -92,11 +93,23 @@ theorem div_iff {α : Type*} [Preorder α] {P : α → Prop} :
     [krifka-1989] D 14: `QUAₛ(P) ⇔ ∀x,y. P(x) ∧ P(y) → ¬ y ⊂ₛ x`.
     [champollion-2017] §2.3.5 reformulates as `∀x,y. P(x) ∧ y < x → ¬P(y)`,
     which is propositionally equivalent (`(A → B → ¬C) ↔ (A → C → ¬B)`).
-    Linglib uses Champollion's form because its introduction pattern fits
-    intro-style proofs more cleanly (assume `P x` and `y < x`, derive `¬ P y`).
-    Telic predicates are canonically quantized. -/
-def QUA {α : Type*} [PartialOrder α] (P : α → Prop) : Prop :=
-  ∀ (x y : α), P x → y < x → ¬ P y
+    Grounded in mathlib's `IsAntichain` — `QUA P` **is**
+    `IsAntichain (· ≤ ·) {x | P x}` (a quantized predicate's extension is an
+    antichain: its members are pairwise incomparable). A `QUA` hypothesis is
+    *applied directly* as an antichain (`hQ hPx hPy hne : ¬ x ≤ y`); to build one
+    from Champollion's paper form, use `qua_of_forall`. -/
+abbrev QUA {α : Type*} [PartialOrder α] (P : α → Prop) : Prop :=
+  IsAntichain (· ≤ ·) {x | P x}
+
+/-- Converge Champollion's paper condition into the mathlib `IsAntichain` normal
+    form: if no P-element sits strictly below another P-element, the extension is
+    an antichain. This is the *construction* direction (paper form ⟹ `QUA`); to
+    *use* a `QUA` hypothesis, apply it directly as an antichain. There is no
+    `QUA ⟹ ∀ x y` unfold by design — that runs against the simp grain. -/
+theorem qua_of_forall {α : Type*} [PartialOrder α] {P : α → Prop}
+    (h : ∀ x y, P x → y < x → ¬ P y) : QUA P := by
+  rintro a ha b hb hab hab_le
+  exact h b a hb (lt_of_le_of_ne hab_le hab) ha
 
 /-- Mereological atom: x has no proper part.
     [link-1983] (D.10, D.22 condition 2);
@@ -152,23 +165,32 @@ theorem qua_cum_incompatible {α : Type*} [SemilatticeSup α]
     {x y : α} (hx : P x) (hy : P y) (hne : x ≠ y) :
     ¬ CUM P := by
   intro hC
-  have hxy := cum_iff.mp hC x y hx hy
-  have hle : x ≤ x ⊔ y := le_sup_left
-  by_cases heq : x = x ⊔ y
-  · have : y ≤ x := heq ▸ le_sup_right
-    by_cases hyx : y = x
-    · exact hne hyx.symm
-    · have hlt : y < x := lt_of_le_of_ne this hyx
-      exact hQ x y hx hlt hy
-  · have hlt : x < x ⊔ y := lt_of_le_of_ne hle heq
-    exact hQ (x ⊔ y) x hxy hlt hx
+  have hxy : P (x ⊔ y) := hC hx hy
+  rcases eq_or_lt_of_le (le_sup_left : x ≤ x ⊔ y) with hx_eq | hx_lt
+  · rcases eq_or_lt_of_le (le_sup_right : y ≤ x ⊔ y) with hy_eq | hy_lt
+    · exact hne (hx_eq.trans hy_eq.symm)
+    · exact hQ hy hxy hy_lt.ne hy_lt.le
+  · exact hQ hx hxy hx_lt.ne hx_lt.le
 
-/-- Atoms are trivially quantized: the singleton {x} is QUA when x is an atom. -/
+/-- Atoms form an antichain: distinct atoms are incomparable (`a ≤ b` with `b`
+    an atom forces `a = b`). The engine behind `qua_of_atom`. -/
+theorem isAntichain_setOf_atom {α : Type*} [PartialOrder α] :
+    IsAntichain (· ≤ ·) {x : α | Atom x} := by
+  rintro a _ha b hb hab hab_le
+  exact hab (hb a hab_le)
+
+/-- **Combinator**: a predicate holding only of atoms is quantized — its
+    extension is a subset of the atoms, which form an antichain
+    (`IsAntichain.subset`). Factors the recurring "atomic ⟹ QUA" pattern
+    (mass-noun part predicates, classifier atoms). -/
+theorem qua_of_atom {α : Type*} [PartialOrder α] {P : α → Prop}
+    (h : ∀ ⦃x⦄, P x → Atom x) : QUA P :=
+  isAntichain_setOf_atom.subset h
+
+/-- Atoms are trivially quantized: the singleton `{x}` is QUA when x is an atom. -/
 theorem atom_qua {α : Type*} [PartialOrder α]
-    {x : α} (hAtom : Atom x) : QUA (· = x) := by
-  intro a b ha hlt hn
-  subst ha; subst hn
-  exact absurd (hAtom b (le_of_lt hlt)) (ne_of_lt hlt).symm
+    {x : α} (hAtom : Atom x) : QUA (· = x) :=
+  qua_of_atom fun _ hz => hz ▸ hAtom
 
 /-- DIV allows extracting parts: if P is DIV and P(z), then P(w) for any w ≤ z. -/
 theorem div_closed_under_le {α : Type*} [PartialOrder α]
@@ -364,9 +386,8 @@ theorem atomize_sub {α : Type*} [PartialOrder α]
 
 /-- Atomized predicates are quantized: no proper part of an atom is an atom. -/
 theorem atomize_qua {α : Type*} [PartialOrder α]
-    {P : α → Prop} : QUA (atomize P) := by
-  intro x y ⟨_, hAtom⟩ hlt _
-  exact absurd (hAtom y (le_of_lt hlt)) (ne_of_lt hlt)
+    {P : α → Prop} : QUA (atomize P) :=
+  qua_of_atom fun _ h => h.2
 
 /-- Atomize turns cumulative predicates into quantized ones.
     This is the core of CLF-for-N semantics: the classifier takes a
@@ -458,8 +479,10 @@ theorem atomCount_sup_disjoint (α : Type*) [SemilatticeSup α]
 theorem qua_pullback {α β : Type*} [PartialOrder α] [PartialOrder β]
     {d : α → β} (hd : StrictMono d)
     {P : β → Prop} (hP : QUA P) :
-    QUA (P ∘ d) :=
-  fun _x _y hx hlt hy => hP _ _ hx (hd hlt) hy
+    QUA (P ∘ d) := by
+  rintro a ha b hb hab hab_le
+  have hlt := hd (lt_of_le_of_ne hab_le hab)
+  exact hP ha hb hlt.ne hlt.le
 
 /-- CUM pullback along sum homomorphisms.
 
@@ -493,10 +516,8 @@ theorem extMeasure_strictMono {α : Type*} [SemilatticeSup α]
     This generalizes `atom_qua`, which required `Atom x`. The Atom
     hypothesis is unnecessary for singletons. -/
 theorem singleton_qua {α : Type*} [PartialOrder α]
-    (n : α) : QUA (· = n) := by
-  intro x y hx hlt hy
-  subst hx; subst hy
-  exact absurd hlt (lt_irrefl _)
+    (n : α) : QUA (· = n) :=
+  Set.Subsingleton.isAntichain (fun _ ha _ hb => ha.trans hb.symm) _
 
 /-- Measure phrases create QUA predicates: `{x : μ(x) = n}` is QUA
     whenever μ is an extensive measure ([krifka-1998] §2.2).
@@ -510,6 +531,13 @@ theorem extMeasure_qua {α : Type*} [SemilatticeSup α]
     {μ : α → ℚ} [hμ : ExtMeasure α μ] (n : ℚ) :
     QUA (fun x => μ x = n) :=
   qua_pullback (extMeasure_strictMono hμ) (singleton_qua n)
+
+/-- **Combinator**: a measure-quantizing modification is quantized.
+    `QMOD R μ n ⊆ {μ = n}`, an antichain by `extMeasure_qua`, so any subset is
+    too (`IsAntichain.subset`). -/
+theorem qmod_qua {α : Type*} [SemilatticeSup α] {μ : α → ℚ} [ExtMeasure α μ]
+    (R : α → Prop) (n : ℚ) : QUA (QMOD R μ n) :=
+  (extMeasure_qua n).subset fun _ h => h.2
 
 /-- QUA pullback composes: if `d₁ : α → β` and `d₂ : β → γ` are both
     StrictMono, then `QUA P → QUA (P ∘ d₂ ∘ d₁)`.

--- a/Linglib/Semantics/Aspect/Cumulativity.lean
+++ b/Linglib/Semantics/Aspect/Cumulativity.lean
@@ -95,11 +95,11 @@ private theorem cum_propagation_of_cumTheta {θ : α → β → Prop} {OBJ : α 
     `private`. -/
 private theorem qua_propagation_of_mso {θ : α → β → Prop} {OBJ : α → Prop}
     (hUP : UP θ) (hMSO : MSO θ) (hQua : QUA OBJ) :
-    QUA (VP θ OBJ) := by
-  intro e e' ⟨y, hobj, hθ⟩ hlt ⟨z, hobj_z, hθ_z⟩
-  obtain ⟨y', hy'_lt, hθ_y'⟩ := hMSO y e e' hθ hlt
-  have hz_eq : z = y' := hUP z y' e' hθ_z hθ_y'
-  exact hQua y y' hobj hy'_lt (hz_eq ▸ hobj_z)
+    QUA (VP θ OBJ) :=
+  Mereology.qua_of_forall fun e e' ⟨y, hobj, hθ⟩ hlt ⟨z, hobj_z, hθ_z⟩ => by
+    obtain ⟨y', hy'_lt, hθ_y'⟩ := hMSO y e e' hθ hlt
+    have hz_eq : z = y' := hUP z y' e' hθ_z hθ_y'
+    exact hQua (hz_eq ▸ hobj_z) hobj hy'_lt.ne hy'_lt.le
 
 /-- QUA propagation from SINC + UP (explicit-witness smart constructor,
     private). In practice, incremental-theme verbs satisfy both SINC

--- a/Linglib/Semantics/Aspect/Stratified.lean
+++ b/Linglib/Semantics/Aspect/Stratified.lean
@@ -407,7 +407,7 @@ theorem qua_incompatible_with_subintervalReference
   have hne : a ≠ e := by
     intro heq; rw [heq] at hGran
     exact lt_irrefl _ hGran
-  exact hQua e a he (lt_of_le_of_ne hle hne) hPa
+  exact hQua hPa he hne hle
 
 /-! ### for-Adverbial Compatibility -/
 

--- a/Linglib/Semantics/Classifier/Basic.lean
+++ b/Linglib/Semantics/Classifier/Basic.lean
@@ -97,10 +97,7 @@ abbrev clfForNum {α : Type*} (P : α → Prop) (μ : α → ℚ) (n : ℚ) : α
 theorem clfForNum_qua {α : Type*} [SemilatticeSup α]
     {P : α → Prop} {μ : α → ℚ} [hμ : ExtMeasure α μ] (n : ℚ) :
     QUA (fun x => QMOD P μ n x) :=
-  fun x y ⟨_, hx⟩ hlt ⟨_, hy⟩ => by
-    have := hμ.strict_mono x y hlt
-    rw [hy, hx] at this
-    exact absurd this (lt_irrefl _)
+  Mereology.qmod_qua P n
 
 -- ============================================================================
 -- §3: Group Classifier — Materialization ([moroney-2021] Ch. 3)
@@ -129,9 +126,8 @@ def groupClf {E D : Type*} [SemilatticeSup E] [SemilatticeSup D]
     is itself a group (since groups are atoms). -/
 theorem groupClf_qua {E D : Type*} [SemilatticeSup E] [SemilatticeSup D]
     (mat : Semantics.Plurality.Algebra.Materialization E D)
-    {P : E → Prop} : QUA (groupClf mat P) := by
-  intro x y ⟨hAtom, _⟩ hlt _
-  exact absurd (hAtom y (le_of_lt hlt)) (ne_of_lt hlt)
+    {P : E → Prop} : QUA (groupClf mat P) :=
+  Mereology.qua_of_atom fun _ h => h.1
 
 -- ============================================================================
 -- §4: Strategy-Indexed Dispatch

--- a/Linglib/Semantics/Measurement/Basic.lean
+++ b/Linglib/Semantics/Measurement/Basic.lean
@@ -379,10 +379,8 @@ theorem extensive_measureFn_qmod_qua
     (hExt : MeasureFn.IsExtensive μ)
     {R : E → Prop} {n : ℚ} (_hn : 0 < n) :
     Mereology.QUA (Mereology.QMOD R μ.apply n) := by
-  intro x y ⟨_, hx_eq⟩ hlt ⟨_, hy_eq⟩
-  have hExt' : @Mereology.ExtMeasure E inst μ.apply := hExt
-  have hμ_qua := @Mereology.extMeasure_qua E inst μ.apply hExt' n
-  exact hμ_qua x y hx_eq hlt hy_eq
+  haveI : @Mereology.ExtMeasure E inst μ.apply := hExt
+  exact Mereology.qmod_qua R n
 
 /-- **Bridge to QMOD.** Scontras's `applyNumeral` and Krifka's `QMOD` check the
 same condition `μ(x) = n` when QMOD's restrictor is taken to be trivial. -/

--- a/Linglib/Studies/Borer2005.lean
+++ b/Linglib/Studies/Borer2005.lean
@@ -98,9 +98,8 @@ theorem div_atom {P : α → Prop} {x : α} (h : Div P x) : Atom x :=
 
     The proof is structural: it holds for ANY root predicate P,
     regardless of whether P is lexically "mass" or "count." -/
-theorem div_qua (P : α → Prop) : QUA (Div P) := by
-  intro x y ⟨_, hAtom⟩ hlt _
-  exact absurd (hAtom y (le_of_lt hlt)) (ne_of_lt hlt)
+theorem div_qua (P : α → Prop) : QUA (Div P) :=
+  Mereology.qua_of_atom fun _ h => h.2
 
 /-- **The anti-lexicalist theorem**: the same root yields both
     mass (CUM) and count (QUA) readings via functional structure.
@@ -262,9 +261,8 @@ theorem divCL_sub_div {P : α → Prop} {cl : ClassifierPred α}
     it doesn't change the fundamental property that atoms have
     no proper parts. -/
 theorem divCL_qua (P : α → Prop) (cl : ClassifierPred α) :
-    QUA (DivCL P cl) := by
-  intro x y ⟨_, hAtom, _⟩ hlt _
-  exact absurd (hAtom y (le_of_lt hlt)) (ne_of_lt hlt)
+    QUA (DivCL P cl) :=
+  Mereology.qua_of_atom fun _ h => h.2.1
 
 /-- Div is DivCL with the trivial classifier.
     Non-classifier languages (English) have covert Div, which is

--- a/Linglib/Studies/Filip2012.lean
+++ b/Linglib/Studies/Filip2012.lean
@@ -117,7 +117,7 @@ private theorem middle_ground_stable_of_postulates {θ : α → β → Prop} {OB
   · exact not_cum_vp_of_cumTheta_up hCumTheta hUP ha hb hθ_a hθ_b hSum
   · intro hQua
     obtain ⟨e_y, he_y_lt, hθ_y⟩ := hSinc.mse x e_x y hθ_x hlt
-    exact hQua e_x e_y ⟨x, hx, hθ_x⟩ he_y_lt ⟨y, hy, hθ_y⟩
+    exact hQua ⟨y, hy, hθ_y⟩ ⟨x, hx, hθ_x⟩ he_y_lt.ne he_y_lt.le
 
 /-- **¬CUM lifts to VP** (canonical typeclass form). `[IsSincVerb θ]`
     bundles `CumTheta` (via `IsCumThetaVerb` parent class) and `UP`. -/

--- a/Linglib/Studies/Krifka1989.lean
+++ b/Linglib/Studies/Krifka1989.lean
@@ -90,10 +90,8 @@ open Features
 theorem qmod_qua {α : Type*} [SemilatticeSup α]
     {R : α → Prop} {μ : α → ℚ} [hμ : ExtMeasure α μ]
     {n : ℚ} (_hn : 0 < n) :
-    QUA (QMOD R μ n) := by
-  intro x y ⟨_, hx_eq⟩ hlt ⟨_, hy_eq⟩
-  have hμ_qua := extMeasure_qua (μ := μ) n
-  exact hμ_qua x y hx_eq hlt hy_eq
+    QUA (QMOD R μ n) :=
+  Mereology.qmod_qua R n
 
 /-- A CUM mass noun combined with QMOD (via an extensive measure)
     yields a QUA measure phrase. [krifka-1989] §3 D28. -/
@@ -517,7 +515,7 @@ def ATM (P : α → Prop) : Prop :=
     proper P-parts), so it is its own atomic-part witness. -/
 theorem qua_implies_atm {P : α → Prop} (hQua : QUA P) : ATM P := by
   intro x hPx
-  exact ⟨x, le_refl x, hPx, fun z hzlt hPz => hQua x z hPx hzlt hPz⟩
+  exact ⟨x, le_refl x, hPx, fun z hzlt hPz => hQua hPz hPx hzlt.ne hzlt.le⟩
 
 /-! The ATM-but-not-QUA case is genuinely possible — that's this
     section's point. K89's *Ann drank wine in 0.43 seconds* shows that
@@ -666,8 +664,7 @@ def k89Section7Data : List K89QuantDatum :=
 /-- **Forward gap**: a predicate can be K89-QUA on a carrier that has no
     `OrderTop` instance. The singleton predicate `(· = 5)` on `ℕ` is QUA
     (no proper part of 5 in ℕ also equals 5), but ℕ has no maximum. -/
-example : Mereology.QUA (α := ℕ) (· = 5) := by
-  intro x y hPx hlt hPy; omega
+example : Mereology.QUA (α := ℕ) (· = 5) := Mereology.singleton_qua 5
 
 example : NoMaxOrder ℕ := inferInstance
 
@@ -680,7 +677,7 @@ example : ¬ Mereology.QUA (α := Fin 3) (fun k => k.val ≤ 1) := by
   have h1 : (1 : Fin 3).val ≤ 1 := by decide
   have h0 : (0 : Fin 3).val ≤ 1 := by decide
   have hlt : (0 : Fin 3) < 1 := by decide
-  exact h 1 0 h1 hlt h0
+  exact h h0 h1 hlt.ne hlt.le
 
 example : OrderTop (Fin 3) := inferInstance
 example : OrderBot (Fin 3) := inferInstance

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -686,10 +686,9 @@ def someApples : Apple → Prop := fun a => a.Nonempty
 /-- `twoApples` is QUA: a proper part of `{0, 1}` cannot also equal
     `{0, 1}`. This is the standard "exact-cardinality NPs are
     quantized" property at the K89/K98 level. -/
-theorem twoApples_qua : QUA twoApples := by
-  intro x y hx hlt hy
-  -- hx : x = {0,1}, hy : y = {0,1}, hlt : y < x. Substitute to get y < y.
-  rw [hx, hy] at hlt; exact hlt.ne rfl
+theorem twoApples_qua : QUA twoApples :=
+  -- `twoApples` is the singleton predicate `(· = {0,1})`, trivially an antichain.
+  Mereology.qua_of_forall fun x y hx hlt hy => by rw [hx, hy] at hlt; exact hlt.ne rfl
 
 /-- `someApples` is CUM: nonempty ⊔ nonempty = nonempty. Bare plurals
     propagate cumulativity (K89 §3 / K98 §3.3). -/

--- a/Linglib/Studies/Moon2026.lean
+++ b/Linglib/Studies/Moon2026.lean
@@ -151,7 +151,7 @@ theorem connectivity_middle_ground {α : Type*} [SemilatticeSup α]
     (hDisc : ¬ SelfConnected (a ⊔ b))
     {x y : α} (hx : P x) (hy : P y) (hlt : y < x) :
     ¬ CUM P ∧ ¬ QUA P :=
-  ⟨connectivity_breaks_cum hConn ha hb hDisc, fun hQ => hQ x y hx hlt hy⟩
+  ⟨connectivity_breaks_cum hConn ha hb hDisc, fun hQ => hQ hy hx hlt.ne hlt.le⟩
 
 -- ════════════════════════════════════════════════════
 -- § 1. Mixed Drink Recipe
@@ -637,7 +637,7 @@ theorem mixedDrink_not_qua {n : ℕ}
     -- part of a mixed drink is also a mixed drink (e.g., half a
     -- margarita with preserved ratios and connectivity)
     ¬ QUA (mixedDrinkDen recipe μ phase) :=
-  fun hQ => hQ x y hx hlt hy
+  fun hQ => hQ hy hx hlt.ne hlt.le
 
 -- ════════════════════════════════════════════════════
 -- § 11. Instantiating the General Principle


### PR DESCRIPTION
Grounds `QUA` as `IsAntichain (· ≤ ·) {x | P x}` (after CUM/DIV in #445/#446), and makes the consumers mathlib-quality.

Key design: a `QUA` hypothesis is applied **directly** as an antichain (`hQ hPx hPy hne : ¬ x ≤ y`), and constructions use combinators — `qua_of_atom` (atoms are an antichain + `.subset`), `qmod_qua` (`extMeasure_qua` + `.subset`), `singleton_qua` (`Set.Subsingleton.isAntichain`), or `qua_of_forall` (one-way convergence of Champollion's `∀ x y` paper form into the antichain normal form — **no** unfold-back direction, by design). 9 consumers' hand-rolled element-pushing rewritten to these (e.g. `clfForNum_qua := qmod_qua`, `groupClf_qua := qua_of_atom …`).

Follow-up: `cum_iff`/`div_iff` get the same convergence orientation + direct-application cleanup.