### PR TITLE
refactor(Core/Order/Mereology): ground Atom as IsMin, atomize as Minimal

### DIFF
--- a/Linglib/Core/Order/Mereology.lean
+++ b/Linglib/Core/Order/Mereology.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Order.Ring.Unbundled.Rat
 import Mathlib.Order.Closure
 import Mathlib.Order.SupClosed
 import Mathlib.Order.Antichain
+import Mathlib.Order.Minimal
 import Mathlib.Order.Interval.Set.OrdConnected
 import Mathlib.Order.UpperLower.Closure
 import Mathlib.Order.Hom.Lattice
@@ -111,13 +112,18 @@ theorem qua_of_forall {α : Type*} [PartialOrder α] {P : α → Prop}
   rintro a ha b hb hab hab_le
   exact h b a hb (lt_of_le_of_ne hab_le hab) ha
 
-/-- Mereological atom: x has no proper part.
-    [link-1983] (D.10, D.22 condition 2);
-    [champollion-2017] §2.2: Atom(x) ⇔ ¬∃y. y < x.
-    Defined without OrderBot since many domains lack a natural
-    bottom element. -/
-def Atom {α : Type*} [PartialOrder α] (x : α) : Prop :=
-  ∀ (y : α), y ≤ x → y = x
+/-- Mereological atom: x has no proper part — grounded as mathlib's `IsMin`
+    (minimal element). [link-1983] (D.10); [champollion-2017] §2.2:
+    `Atom(x) ⇔ ¬∃y. y < x`. This is the **absolute** (P-independent) notion;
+    the P-relative one (Krifka D17, "no proper *P*-part") is `atomize` /
+    mathlib `Minimal P`. No `OrderBot` needed — many mereological domains lack
+    a bottom. -/
+abbrev Atom {α : Type*} [PartialOrder α] (x : α) : Prop := IsMin x
+
+/-- An atom's only part is itself — the `y = x` elimination form of `IsMin`. -/
+theorem Atom.eq {α : Type*} [PartialOrder α] {x y : α} (h : Atom x) (hy : y ≤ x) :
+    y = x :=
+  le_antisymm hy (h hy)
 
 -- ════════════════════════════════════════════════════
 -- § 3. Key Theorems
@@ -172,12 +178,12 @@ theorem qua_cum_incompatible {α : Type*} [SemilatticeSup α]
     · exact hQ hy hxy hy_lt.ne hy_lt.le
   · exact hQ hx hxy hx_lt.ne hx_lt.le
 
-/-- Atoms form an antichain: distinct atoms are incomparable (`a ≤ b` with `b`
-    an atom forces `a = b`). The engine behind `qua_of_atom`. -/
+/-- Atoms form an antichain — the absolute case of mathlib's
+    `setOf_minimal_antichain` (atoms are the `Minimal (fun _ => True)` elements,
+    via `minimal_true`). The engine behind `qua_of_atom`. -/
 theorem isAntichain_setOf_atom {α : Type*} [PartialOrder α] :
     IsAntichain (· ≤ ·) {x : α | Atom x} := by
-  rintro a _ha b hb hab hab_le
-  exact hab (hb a hab_le)
+  simp only [Atom, ← minimal_true]; exact setOf_minimal_antichain _
 
 /-- **Combinator**: a predicate holding only of atoms is quantized — its
     extension is a subset of the atoms, which form an antichain
@@ -368,26 +374,28 @@ theorem qmod_sub {α μTy : Type*} {R : α → Prop} {μ : α → μTy} {n : μT
 -- § 6b. Atomization ([little-moroney-royer-2022])
 -- ════════════════════════════════════════════════════
 
-/-- Atomize a predicate: restrict P to its atomic members.
-    [little-moroney-royer-2022] eq. (13):
-    ⟦CLF⟧ = λPλx.[P(x) ∧ ¬∃y[P(y) ∧ y < x]]
+/-- Atomize a predicate to its **P-relative** minimal members — mathlib's
+    `Minimal P`. [little-moroney-royer-2022] eq. (13):
+    `⟦CLF⟧ = λPλx.[P(x) ∧ ¬∃y[P(y) ∧ y < x]]`, which is exactly `Minimal P x`
+    (`minimal_iff_forall_lt`). NB this is *P-relative* (no *P*-element strictly
+    below x), distinct from the absolute `Atom`/`IsMin`; for a divisive P the
+    two coincide (`minimal_iff_isMin`).
 
     In classifier-for-noun theories ([chierchia-1998]; [jenks-2011];
     [dayal-2012]; [nomoto-2013]), the classifier atomizes the noun
-    denotation so the numeral can count individual entities. This is the
-    semantic contribution that distinguishes CLF-for-N from CLF-for-NUM. -/
-def atomize {α : Type*} [PartialOrder α] (P : α → Prop) : α → Prop :=
-  fun x => P x ∧ Atom x
+    denotation so the numeral can count individual entities. -/
+abbrev atomize {α : Type*} [PartialOrder α] (P : α → Prop) : α → Prop := Minimal P
 
 /-- Atomize restricts: atomize P ⊆ P. -/
 theorem atomize_sub {α : Type*} [PartialOrder α]
     {P : α → Prop} {x : α} (h : atomize P x) : P x :=
   h.1
 
-/-- Atomized predicates are quantized: no proper part of an atom is an atom. -/
+/-- Atomized predicates are quantized: the P-minimal elements form an antichain
+    (mathlib's `setOf_minimal_antichain`). -/
 theorem atomize_qua {α : Type*} [PartialOrder α]
     {P : α → Prop} : QUA (atomize P) :=
-  qua_of_atom fun _ h => h.2
+  setOf_minimal_antichain P
 
 /-- Atomize turns cumulative predicates into quantized ones.
     This is the core of CLF-for-N semantics: the classifier takes a
@@ -665,7 +673,7 @@ theorem atom_gHomogeneous_trivial {α : Type*} [PartialOrder α]
     {P : α → Prop} {a : α} (_hP : P a) (hAtom : Atom a) :
     ∀ y, y < a → ∃ z, z ≤ y ∧ P z := by
   intro y hlt
-  exact absurd (hAtom y (le_of_lt hlt)) (ne_of_lt hlt)
+  exact absurd (Atom.eq hAtom (le_of_lt hlt)) (ne_of_lt hlt)
 
 /-- A predicate that is cumulative but NOT g-homogeneous has "fake mass"
     behavior ([deal-2017]; [moroney-2021] §2.4): sums of

--- a/Linglib/Features/Number/Interp.lean
+++ b/Linglib/Features/Number/Interp.lean
@@ -75,7 +75,7 @@ theorem additiveIn_sup {Q : D → Prop}
 theorem minimalIn_of_atom {P : D → Prop}
     (hAllAtoms : ∀ x, P x → Mereology.Atom x)
     {x : D} (hPx : P x) : minimalIn P x :=
-  ⟨hPx, fun y _ hle => hAllAtoms x hPx y hle⟩
+  ⟨hPx, fun y _ hle => Mereology.Atom.eq (hAllAtoms x hPx) hle⟩
 
 /-- The `[−minimal]` complement of an all-atom region is empty
     ([harbour-2014] §4.2). -/
@@ -138,7 +138,7 @@ theorem interp_isSome_iff (P : D → Prop) (n : Number) :
     (`Features/Number/Decomposition.lean`). -/
 theorem singular_subset_minimal (P : D → Prop) {x : D}
     (h : P x ∧ Mereology.Atom x) : minimalIn P x :=
-  ⟨h.1, fun y _ hle => h.2 y hle⟩
+  ⟨h.1, fun y _ hle => Mereology.Atom.eq h.2 hle⟩
 
 /-- Dual and plural partition the non-atoms: every non-atom of `P` is
     dual or plural, never both — the `[±minimal]` split of the

--- a/Linglib/Semantics/Classifier/Basic.lean
+++ b/Linglib/Semantics/Classifier/Basic.lean
@@ -172,7 +172,7 @@ theorem classifier_quantizes_forNoun {α : Type*} [SemilatticeSup α]
 theorem clfForNoun_mem {α : Type*} [PartialOrder α]
     {P : α → Prop} {x : α} (hAtom : Atom x) (hP : P x) :
     clfForNoun P x :=
-  ⟨hP, hAtom⟩
+  ⟨hP, fun _ _ hyx => hAtom hyx⟩
 
 /-- If P has atoms, then CLF-for-N is non-empty. This is the
     content of the "sortal classifier" requirement: the classifier
@@ -182,6 +182,6 @@ theorem clfForNoun_mem {α : Type*} [PartialOrder α]
 theorem clfForNoun_nonempty {α : Type*} [PartialOrder α]
     {P : α → Prop} {a : α} (hP : P a) (hAtom : Atom a) :
     ∃ x, clfForNoun P x :=
-  ⟨a, hP, hAtom⟩
+  ⟨a, hP, fun _ _ hyx => hAtom hyx⟩
 
 end Semantics.Classifier

--- a/Linglib/Semantics/Plurality/Algebra.lean
+++ b/Linglib/Semantics/Plurality/Algebra.lean
@@ -105,7 +105,7 @@ def D (P : E → Prop) (x : E) : Prop :=
 theorem D_self_of_atom {P : E → Prop} {x : E} (hAtom : Atom x) (hP : P x) :
     D P x := by
   intro y hle _
-  rw [hAtom y hle]
+  rw [Atom.eq hAtom hle]
   exact hP
 
 /-- `D` is monotone in `P`: weakening `P` weakens `D P`. -/
@@ -218,9 +218,8 @@ theorem pred_of_atom_star {P : E → Prop} :
   induction hStar with
   | base hp => exact hp
   | @sum a b _ _ iha _ =>
-    have heq : a = a ⊔ b := hAtom a le_sup_left
-    have hAtom_a : Atom a :=
-      fun y hy => (hAtom y (le_trans hy le_sup_left)).trans heq.symm
+    have heq : a = a ⊔ b := Atom.eq hAtom le_sup_left
+    have hAtom_a : Atom a := heq.symm ▸ hAtom
     have h := iha hAtom_a
     rw [show a ⊔ b = a from heq.symm]
     exact h
@@ -283,7 +282,7 @@ theorem distr_atom_part {P : E → Prop} (hDistr : IsDistr P)
   induction hStar with
   | base hp =>
     intro z hz hle
-    have heq : z = _ := (hDistr _ hp) z hle
+    have heq : z = _ := Atom.eq (hDistr _ hp) hle
     rwa [heq]
   | @sum a b _ _ iha ihb =>
     intro z hz hle
@@ -305,7 +304,7 @@ theorem distr_properPlural_extends {P : E → Prop}
     properPlural P (x ⊔ y) :=
   ⟨AlgClosure.sum (AlgClosure.base hx) (AlgClosure.base hy),
    fun hAtom => hne
-     ((hAtom x le_sup_left).trans (hAtom y le_sup_right).symm)⟩
+     ((Atom.eq hAtom le_sup_left).trans (Atom.eq hAtom le_sup_right).symm)⟩
 
 /-- CUM for the proper plural ⊕P: sums of proper plurals are
     proper plurals. -/
@@ -313,8 +312,8 @@ theorem properPlural_cum {P : E → Prop} {x y : E}
     (hx : properPlural P x) (hy : properPlural P y) :
     properPlural P (x ⊔ y) := by
   refine ⟨AlgClosure.sum hx.1 hy.1, fun hAtom => ?_⟩
-  have : x = x ⊔ y := hAtom x le_sup_left
-  exact hx.2 (fun z hz => by rw [show x ⊔ y = x from this.symm] at hAtom; exact hAtom z hz)
+  have : x = x ⊔ y := Atom.eq hAtom le_sup_left
+  exact hx.2 (fun z hz => by rw [show x ⊔ y = x from this.symm] at hAtom; exact hAtom hz)
 
 end Classification
 

--- a/Linglib/Semantics/Quantification/ONEModifiers.lean
+++ b/Linglib/Semantics/Quantification/ONEModifiers.lean
@@ -62,8 +62,8 @@ theorem ONE_AT_implies_ONE_empty {α : Type*} [PartialOrder α]
     {P : α → Prop} (h : ONE_AT P) : ONE_empty P where
   has_two := h.has_two
   pairwise_disjoint := λ x y hPx hPy ⟨z, hzx, hzy⟩ =>
-    let hzx_eq := h.all_atomic x hPx z hzx  -- z = x
-    let hzy_eq := h.all_atomic y hPy z hzy  -- z = y
+    let hzx_eq := Atom.eq (h.all_atomic x hPx) hzx  -- z = x
+    let hzy_eq := Atom.eq (h.all_atomic y hPy) hzy  -- z = y
     hzx_eq.symm.trans hzy_eq
 
 /-! ### English UQ Decomposition -/

--- a/Linglib/Studies/HaslingerHienEtAl2025.lean
+++ b/Linglib/Studies/HaslingerHienEtAl2025.lean
@@ -141,7 +141,7 @@ def passed : Student → Prop
 theorem student_atoms : ∀ (x : Student), (fun _ => True : Student → Prop) x →
     Mereology.Atom x := by
   intro x _ z hz
-  exact hz
+  exact hz.symm
 
 /-- In a flat order, distinct elements don't overlap. -/
 theorem student_disjoint : ∀ (x y : Student),

--- a/Linglib/Studies/Moon2026.lean
+++ b/Linglib/Studies/Moon2026.lean
@@ -229,7 +229,18 @@ structure MixedDrinkWitness {n : ℕ} (recipe : Recipe α n)
 
     The MEASURED PART is the ingredient at `recipe.measuredPart` — it
     provides the unit for individuation and is what *double* targets
-    ([wagiel-2021]). -/
+    ([wagiel-2021]).
+
+    TODO: formula (28)'s `MEASURED PART(y₀)` conjunct is not imposed as a
+    truth condition — `recipe.measuredPart` only records *which* index is
+    the measured part (consumed by `doubleRecipe`); no `MixedDrinkWitness`
+    field asserts it is individuable. So this denotation is Moon's earlier
+    formula (19) plus CONNECTED LIQUID, and [moon-2026] notes (19)
+    over-generates to ratio-structured mass mixtures like *lemonade*. The
+    ¬CUM and ¬QUA results below are unaffected (they use only connectivity
+    and the witness), but the denotation does not yet separate a margarita
+    from ratioed lemonade. Encoding it needs truth conditions for MEASURED
+    PART, which [moon-2026] leaves informal. -/
 def mixedDrinkDen {n : ℕ} (recipe : Recipe α n)
     (μ : α → ℚ) (phase : α → Phase) (x : α) : Prop :=
   Nonempty (MixedDrinkWitness recipe μ phase x)

--- a/Linglib/Studies/Moon2026.lean
+++ b/Linglib/Studies/Moon2026.lean
@@ -558,8 +558,8 @@ theorem mixedDrink_not_atom {n : ℕ}
     ¬ Atom x := by
   intro hAtom
   obtain ⟨w⟩ := hx
-  have h0 : w.assign 0 = x := hAtom (w.assign 0) (w.part_le 0)
-  have h1 : w.assign 1 = x := hAtom (w.assign 1) (w.part_le 1)
+  have h0 : w.assign 0 = x := Atom.eq hAtom (w.part_le 0)
+  have h1 : w.assign 1 = x := Atom.eq hAtom (w.part_le 1)
   have hne : (0 : Fin (n + 2)) ≠ 1 := by simp
   have hDisj := w.disjoint 0 1 hne
   rw [h0, h1] at hDisj

--- a/Linglib/Studies/Sauerland2003.lean
+++ b/Linglib/Studies/Sauerland2003.lean
@@ -102,7 +102,7 @@ theorem sg_domain_subset_pl {E : Type*} [PartialOrder E] (x : E) :
 theorem sg_domain_strict_subset_pl {E : Type*} [SemilatticeSup E]
     (a b : E) (_ : Atom a) (_ : Atom b) (hne : a ≠ b) :
     (plSem E).defined (a ⊔ b) ∧ ¬(sgSem E).defined (a ⊔ b) :=
-  ⟨trivial, fun hAtom => hne ((hAtom a le_sup_left).trans (hAtom b le_sup_right).symm)⟩
+  ⟨trivial, fun hAtom => hne ((Atom.eq hAtom le_sup_left).trans (Atom.eq hAtom le_sup_right).symm)⟩
 
 /-- The `specLevel` ordering on `ContainmentPair` is the Feature-Subset
     Principle: more specified cells have strictly smaller presuppositional
@@ -207,7 +207,7 @@ variable {E : Type*} [SemilatticeSup E]
 /-- A coordination of two distinct atoms produces a non-atom. -/
 theorem coordination_nonatom (a b : E) (_ : Atom a) (_ : Atom b)
     (hne : a ≠ b) : ¬Atom (a ⊔ b) :=
-  fun hAtom => hne ((hAtom a le_sup_left).trans (hAtom b le_sup_right).symm)
+  fun hAtom => hne ((Atom.eq hAtom le_sup_left).trans (Atom.eq hAtom le_sup_right).symm)
 
 /-- Each conjunct individually satisfies [Sg]. -/
 theorem conjuncts_singular (a b : E) (ha : Atom a) (hb : Atom b) :

--- a/Linglib/Studies/Zimmermann2008.lean
+++ b/Linglib/Studies/Zimmermann2008.lean
@@ -113,7 +113,7 @@ instance : DecidablePred Daura := fun x => match x with
 /-! ### Mereological structure -/
 
 theorem atom_of_faasinjee (x : Faasinjee) : Mereology.Atom x := by
-  intro z hz; exact hz
+  intro z hz; exact hz.symm
 
 theorem faasinjee_disjoint (x y : Faasinjee) (h : Mereology.Overlap x y) :
     x = y := by obtain ⟨z, hzx, hzy⟩ := h; exact hzx.symm.trans hzy


### PR DESCRIPTION
Grounds the last two core mereological primitives in mathlib's order hierarchy, and fixes a latent fidelity bug.

- **`Atom` → `IsMin`** (absolute minimal element). Bucket-A consumers (the `[±atomic]` feature, `atomCount`, join-primality, flat-order atoms) adapt via the new `Atom.eq` accessor (the `y = x` elimination form) or construct `IsMin` directly.
- **`atomize` → `Minimal P`** (P-relative minimal — Krifka D17 / LMR eq. 13, `= minimal_iff_forall_lt`). The old `P ∧ Atom` was the latent bug (too strict: excludes P-minimal non-atoms; coincides only for divisive P via `minimal_iff_isMin`). `atomize_qua` is now literally mathlib's **`setOf_minimal_antichain P`** (hand proof deleted), and `isAntichain_setOf_atom` routes through `minimal_true`.

The absolute/P-relative split is clean — absolute = "is this individual atomic" (`IsMin`); P-relative = "atomize a predicate to its smallest members" (`Minimal`).

Follow-up groundings (correct as-is, optional): `Studies/Krifka1989.AtomicForP` and `Borer2005.Div` are the same `Minimal P` pattern.