### PR TITLE
refactor(Core/Order/Mereology): direct-apply CUM/DIV, drop *_iff shims

### DIFF
--- a/Linglib/Core/Order/Mereology.lean
+++ b/Linglib/Core/Order/Mereology.lean
@@ -63,31 +63,25 @@ inductive AlgClosure {α : Type*} [SemilatticeSup α] (P : α → Prop) : α →
 
 /-- Cumulative reference (CUM): P is closed under join. Grounded in mathlib's
     `SupClosed` — `CUM P` **is** `SupClosed {x | P x}` (the sup-closed-set
-    predicate); `cum_iff` recovers the paper-faithful `∀ x y` form.
+    predicate). Apply a `CUM` hypothesis directly (`hC hx hy : P (x ⊔ y)`);
+    construct one with a direct lambda (`fun _ hx _ hy => …`), as for any
+    `SupClosed` (cf. mathlib `IsUpperSet.supClosed`).
     [link-1983] (T.11); [krifka-1989] D 12; [champollion-2017] §2.3.2:
     `CUMₛ(P) ⇔ ∀x,y. P(x) ∧ P(y) → P(x ∪ₛ y)`.
     Activities and states are canonically cumulative. -/
 abbrev CUM {α : Type*} [SemilatticeSup α] (P : α → Prop) : Prop :=
   SupClosed {x | P x}
 
-/-- Paper-faithful unfolding of `CUM` to Krifka's `∀ x y` form. -/
-theorem cum_iff {α : Type*} [SemilatticeSup α] {P : α → Prop} :
-    CUM P ↔ ∀ (x y : α), P x → P y → P (x ⊔ y) :=
-  ⟨fun h _ _ hx hy => h hx hy, fun h _ hx _ hy => h _ _ hx hy⟩
-
 /-- Divisive reference (DIV): P is closed downward under ≤. Grounded in
-    mathlib's `IsLowerSet` — `DIV P` **is** `IsLowerSet {x | P x}`;
-    `div_iff` recovers the paper-faithful `∀ x y` form.
+    mathlib's `IsLowerSet` — `DIV P` **is** `IsLowerSet {x | P x}`. Apply a
+    `DIV` hypothesis directly (`hDiv hle hz : P w` from `hle : w ≤ z`,
+    `hz : P z`); construct one with a direct lambda (`fun _ _ hba ha => …`).
+    Equivalently `DIV P ↔ Antitone P` via mathlib's `isLowerSet_setOf`.
     [champollion-2017] §2.3.3: DIV(P) ⇔ ∀x,y. P(x) ∧ y ≤ x → P(y).
     This is the mereological analog of the subinterval property.
     Only requires `Preorder` since the definition only uses `≤`. -/
 abbrev DIV {α : Type*} [Preorder α] (P : α → Prop) : Prop :=
   IsLowerSet {x | P x}
-
-/-- Paper-faithful unfolding of `DIV` to the `∀ x y` form. -/
-theorem div_iff {α : Type*} [Preorder α] {P : α → Prop} :
-    DIV P ↔ ∀ (x y : α), P x → y ≤ x → P y :=
-  ⟨fun h _ _ hx hyx => h hyx hx, fun h a b hba ha => h a b ha hba⟩
 
 /-- Quantized reference (QUA): no proper part of a P-entity is also P.
 
@@ -133,7 +127,7 @@ theorem Atom.eq {α : Type*} [PartialOrder α] {x y : α} (h : Atom x) (hy : y �
     This is the fundamental property of algebraic closure. -/
 theorem algClosure_cum {α : Type*} [SemilatticeSup α]
     {P : α → Prop} : CUM (AlgClosure P) :=
-  cum_iff.mpr (λ _ _ hx hy => AlgClosure.sum hx hy)
+  fun _ hx _ hy => AlgClosure.sum hx hy
 
 /-- P ⊆ *P: algebraic closure extends the original predicate. -/
 theorem subset_algClosure {α : Type*} [SemilatticeSup α]
@@ -161,7 +155,7 @@ theorem algClosure_of_cum {α : Type*} [SemilatticeSup α]
     AlgClosure P x ↔ P x :=
   ⟨fun h => by induction h with
     | base h => exact h
-    | sum _ _ ihx ihy => exact cum_iff.mp hCUM _ _ ihx ihy,
+    | sum _ _ ihx ihy => exact hCUM ihx ihy,
    fun h => AlgClosure.base h⟩
 
 /-- QUA predicates cannot be cumulative (for predicates with ≥ 2 elements).
@@ -204,7 +198,7 @@ theorem div_closed_under_le {α : Type*} [PartialOrder α]
     (hDiv : DIV P)
     {z : α} (hz : P z) {w : α} (hle : w ≤ z) :
     P w :=
-  div_iff.mp hDiv z w hz hle
+  hDiv hle hz
 
 /-- CUM and QUA partition event predicates (for non-trivial predicates):
     a predicate with ≥ 2 distinct elements cannot be both CUM and QUA.
@@ -307,12 +301,8 @@ theorem IsSumHom.cum_preimage {α β : Type*}
     [SemilatticeSup α] [SemilatticeSup β]
     {f : α → β} (hf : IsSumHom f)
     {P : β → Prop} (hCum : CUM P) :
-    CUM (P ∘ f) := by
-  rw [cum_iff]
-  intro x y hx hy
-  simp only [Function.comp] at *
-  rw [hf.map_sup]
-  exact cum_iff.mp hCum _ _ hx hy
+    CUM (P ∘ f) :=
+  hCum.preimage hf.toSupHom
 
 -- ════════════════════════════════════════════════════
 -- § 5. Overlap and Extensive Measures ([krifka-1998] §2.2)
@@ -425,7 +415,7 @@ noncomputable def atomCount (α : Type*) [PartialOrder α] [Fintype α]
 theorem cum_maximal_unique {α : Type*} [SemilatticeSup α]
     {P : α → Prop} (hCum : CUM P)
     {x y : α} (hx : isMaximal P x) (hy : isMaximal P y) : x = y := by
-  have hxy := cum_iff.mp hCum x y hx.1 hy.1
+  have hxy := hCum hx.1 hy.1
   have hle_x : x ≤ x ⊔ y := le_sup_left
   have hle_y : y ≤ x ⊔ y := le_sup_right
   have heq_x : x = x ⊔ y := hx.2 (x ⊔ y) hxy hle_x
@@ -659,7 +649,7 @@ def gHomogeneous {α : Type*} [PartialOrder α] (P : α → Prop) : Prop :=
     a fortiori every proper part has a P-part (itself). -/
 theorem div_implies_gHomogeneous {α : Type*} [PartialOrder α]
     {P : α → Prop} (hDiv : DIV P) : gHomogeneous P :=
-  fun x y hPx hlt => ⟨y, le_refl y, div_iff.mp hDiv x y hPx (le_of_lt hlt)⟩
+  fun x y hPx hlt => ⟨y, le_refl y, hDiv (le_of_lt hlt) hPx⟩
 
 /-- g-Homogeneity is vacuously satisfied at atoms: since atoms have
     no proper parts, the universal condition `∀ y < a, ∃ z ≤ y, P z`
@@ -937,7 +927,7 @@ theorem cum_sum_exceeds {α : Type*} [SemilatticeSup α]
     {x y : α} (hx : P x) (hy : P y) (h_not_le : ¬ x ≤ y) :
     P (x ⊔ y) ∧ μ (x ⊔ y) > μ y := by
   constructor
-  · exact cum_iff.mp hCum x y hx hy
+  · exact hCum hx hy
   · have hle : y ≤ x ⊔ y := le_sup_right
     have hne : y ≠ x ⊔ y := by
       intro heq; exact h_not_le (heq ▸ le_sup_left)
@@ -954,7 +944,7 @@ theorem cum_sum_exceeds_both {α : Type*} [SemilatticeSup α]
     {x y : α} (hx : P x) (hy : P y)
     (hxy : ¬ x ≤ y) (hyx : ¬ y ≤ x) :
     P (x ⊔ y) ∧ μ (x ⊔ y) > μ x ∧ μ (x ⊔ y) > μ y := by
-  refine ⟨cum_iff.mp hCum x y hx hy, ?_, (cum_sum_exceeds hCum hx hy hxy).2⟩
+  refine ⟨hCum hx hy, ?_, (cum_sum_exceeds hCum hx hy hxy).2⟩
   have hle : x ≤ x ⊔ y := le_sup_left
   have hne : x ≠ x ⊔ y := by
     intro heq; exact hyx (heq ▸ le_sup_right)
@@ -1096,7 +1086,7 @@ theorem cum_exceeds_source {α : Type*} [SemilatticeSup α]
     {x y : α} (hx : P x) (hy : P y) (hyx : ¬ y ≤ x) :
     P (x ⊔ y) ∧ μ (x ⊔ y) > μ x := by
   constructor
-  · exact cum_iff.mp hCum x y hx hy
+  · exact hCum hx hy
   · have hle : x ≤ x ⊔ y := le_sup_left
     have hne : x ≠ x ⊔ y := fun heq => hyx (heq ▸ le_sup_right)
     exact hμ.strict_mono _ _ (lt_of_le_of_ne hle hne)
@@ -1133,7 +1123,7 @@ theorem cum_measure_unbounded {α : Type*} [SemilatticeSup α]
       intro x hx
       obtain ⟨z, hPz, hμz⟩ := ih x hx
       obtain ⟨y, hPy, hDisj, hμy⟩ := hSupply z hPz
-      refine ⟨z ⊔ y, cum_iff.mp hCum z y hPz hPy, ?_⟩
+      refine ⟨z ⊔ y, hCum hPz hPy, ?_⟩
       rw [hμ.additive z y hDisj, Nat.cast_succ, add_mul, one_mul]
       linarith
   -- By Archimedean ℚ, find n with n * δ > M - μ(x₀)

--- a/Linglib/Features/Number/Interp.lean
+++ b/Linglib/Features/Number/Interp.lean
@@ -90,7 +90,7 @@ theorem not_nonminimal_of_atoms {P : D → Prop}
     (quantized), with one feature governing both. -/
 theorem additive_subregion_is_cum (Q : D → Prop) :
     Mereology.CUM (fun x => additiveIn Q x) :=
-  Mereology.cum_iff.mpr fun x y hx hy => additiveIn_sup hx hy
+  fun _ hx _ hy => additiveIn_sup hx hy
 
 /-! ### The value denotations -/
 

--- a/Linglib/Semantics/Aspect/Cumulativity.lean
+++ b/Linglib/Semantics/Aspect/Cumulativity.lean
@@ -64,9 +64,10 @@ def VP (θ : α → β → Prop) (OBJ : α → Prop) : β → Prop :=
 private theorem cum_propagation_of_cumTheta {θ : α → β → Prop} {OBJ : α → Prop}
     (hCum : CumTheta θ) (hObj : CUM OBJ) :
     CUM (VP θ OBJ) := by
-  rw [Mereology.cum_iff]
-  intro e₁ e₂ ⟨y₁, hobj₁, hθ₁⟩ ⟨y₂, hobj₂, hθ₂⟩
-  exact ⟨y₁ ⊔ y₂, Mereology.cum_iff.mp hObj y₁ y₂ hobj₁ hobj₂, hCum y₁ y₂ e₁ e₂ hθ₁ hθ₂⟩
+  intro e₁ he₁ e₂ he₂
+  obtain ⟨y₁, hobj₁, hθ₁⟩ := he₁
+  obtain ⟨y₂, hobj₂, hθ₂⟩ := he₂
+  exact ⟨y₁ ⊔ y₂, hObj hobj₁ hobj₂, hCum y₁ y₂ e₁ e₂ hθ₁ hθ₂⟩
 
 /-! ### QUA Propagation (K98 §3.3) -/
 

--- a/Linglib/Semantics/Events/CEM.lean
+++ b/Linglib/Semantics/Events/CEM.lean
@@ -67,10 +67,9 @@ def LexCum (Time : Type*) [LinearOrder Time] [cem : EventCEM Time]
 theorem cum_iff_lexCum (Time : Type*) [LinearOrder Time] [cem : EventCEM Time]
     (P : Event Time → Prop) :
     @CUM _ cem.evSemilatticeSup P ↔ LexCum Time P := by
-  rw [Mereology.cum_iff]
   constructor
-  · intro h e₁ e₂ h₁ h₂; exact h e₁ e₂ h₁ h₂
-  · intro h x y hx hy; exact h x y hx hy
+  · intro h e₁ e₂ h₁ h₂; exact h h₁ h₂
+  · intro h x hx y hy; exact h x y hx hy
 
 /-! ### Role Homomorphism (θ preserves ⊕) -/
 

--- a/Linglib/Semantics/Kinds/NominalMappingParameter.lean
+++ b/Linglib/Semantics/Kinds/NominalMappingParameter.lean
@@ -137,13 +137,13 @@ variable {World Atom : Type*}
     then `y ∈ P w`. Every part of a mass-noun instance is also an instance. -/
 theorem isMass_div (P : Property World Atom) (hMass : IsMass World Atom P) (w : World) :
     Mereology.DIV (P w) :=
-  Mereology.div_iff.mpr fun x y hx hyx => (hMass w y).mpr fun a ha => (hMass w x).mp hx a (hyx ha)
+  fun x y hyx hx => (hMass w y).mpr fun a ha => (hMass w x).mp hx a (hyx ha)
 
 /-- Mass properties have cumulative reference: if `x ∈ P w` and `y ∈ P w`,
     then `x ∪ y ∈ P w`. Combining mass-noun instances yields an instance. -/
 theorem isMass_cum (P : Property World Atom) (hMass : IsMass World Atom P) (w : World) :
     Mereology.CUM (P w) :=
-  Mereology.cum_iff.mpr fun x y hx hy => (hMass w (x ⊔ y)).mpr fun a ha =>
+  fun x hx y hy => (hMass w (x ⊔ y)).mpr fun a ha =>
     Or.elim ha (fun h => (hMass w x).mp hx a h) (fun h => (hMass w y).mp hy a h)
 
 end MereologyBridge

--- a/Linglib/Semantics/Quantification/UnifiedUniversal.lean
+++ b/Linglib/Semantics/Quantification/UnifiedUniversal.lean
@@ -106,7 +106,7 @@ theorem maxNonOverlap_of_cum_maximal {α : Type*} [SemilatticeSup α]
     {x : α} (hMax : isMaximal P x) :
     maxNonOverlap P x :=
   ⟨hMax.1, λ y hy _hov => by
-    have hxy := Mereology.cum_iff.mp hCum x y hMax.1 hy
+    have hxy := hCum hMax.1 hy
     have hle : x ≤ x ⊔ y := le_sup_left
     have heq : x = x ⊔ y := hMax.2 (x ⊔ y) hxy hle
     exact heq ▸ le_sup_right⟩

--- a/Linglib/Studies/BondarenkoElliott2026.lean
+++ b/Linglib/Studies/BondarenkoElliott2026.lean
@@ -227,7 +227,7 @@ theorem believes_closure_under_entailment
     Believes believe HOLDER CONT M p' := by
   obtain ⟨e, hbel, hhol, hcont⟩ := h_bel
   obtain ⟨e', hlt, hcont'⟩ := h_msi hcont h_lt
-  refine ⟨e', Mereology.div_iff.mp h_div.1 e e' hbel (le_of_lt hlt),
+  refine ⟨e', h_div.1 (le_of_lt hlt) hbel,
           h_div.2 hhol (le_of_lt hlt), hcont'⟩
 
 /-- **Lemma — paper eq. 46**: MSI implies negated belief is *downward*
@@ -372,7 +372,7 @@ theorem positive_sharvit_closure
   -- Step 2 (MSI): get e' < e with CONT_v e' = some p'.
   obtain ⟨e', h_e'_lt, h_cont_e'⟩ := h_msi h_cont_e h_lt
   -- Step 3 (BelievingDIV): e' is a believing of M.
-  have h_bel' : believe e' := Mereology.div_iff.mp h_div.1 e e' h_bel (le_of_lt h_e'_lt)
+  have h_bel' : believe e' := h_div.1 (le_of_lt h_e'_lt) h_bel
   have h_hol' : HOLDER e' = some M := h_div.2 h_hol (le_of_lt h_e'_lt)
   -- Step 4 (WorldLocatedDIV): e' is located at w too.
   have h_loc' : located e' w := h_world_div (le_of_lt h_e'_lt) h_loc

--- a/Linglib/Studies/Borer2005.lean
+++ b/Linglib/Studies/Borer2005.lean
@@ -127,7 +127,7 @@ theorem algClosure_div_sub_cum (P : α → Prop) (hCum : CUM P) :
   intro x hx
   induction hx with
   | base h => exact h.1
-  | sum _ _ ih₁ ih₂ => exact Mereology.cum_iff.mp hCum _ _ ih₁ ih₂
+  | sum _ _ ih₁ ih₂ => exact hCum ih₁ ih₂
 
 /-- Counting requires prior individuation.
 

--- a/Linglib/Studies/Champollion2017.lean
+++ b/Linglib/Studies/Champollion2017.lean
@@ -68,8 +68,7 @@ def LexicallyCumulative {α : Type*} [SemilatticeSup α] (P : α → Prop) : Pro
 /-- Lexical cumulativity entails Krifka's `CUM` (closure under binary join). -/
 theorem lexicallyCumulative_imp_cum {α : Type*} [SemilatticeSup α]
     {P : α → Prop} (h : LexicallyCumulative P) : CUM P := by
-  rw [Mereology.cum_iff]
-  intro x y hPx hPy
+  intro x hPx y hPy
   exact (h _).mp (AlgClosure.sum (AlgClosure.base hPx) (AlgClosure.base hPy))
 
 end ThematicRolesAndCumulativity

--- a/Linglib/Studies/Filip2012.lean
+++ b/Linglib/Studies/Filip2012.lean
@@ -95,7 +95,7 @@ private theorem not_cum_vp_of_cumTheta_up {θ : α → β → Prop} {OBJ : α �
   intro hCum
   have hVP₁ : VP θ OBJ e₁ := ⟨x, hx, hθ₁⟩
   have hVP₂ : VP θ OBJ e₂ := ⟨y, hy, hθ₂⟩
-  obtain ⟨z, hz_obj, hz_θ⟩ := Mereology.cum_iff.mp hCum e₁ e₂ hVP₁ hVP₂
+  obtain ⟨z, hz_obj, hz_θ⟩ := hCum hVP₁ hVP₂
   have hθ_sum := hCumTheta x y e₁ e₂ hθ₁ hθ₂
   have hz_eq := hUP z (x ⊔ y) (e₁ ⊔ e₂) hz_θ hθ_sum
   exact hSum (hz_eq ▸ hz_obj)

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -693,8 +693,7 @@ theorem twoApples_qua : QUA twoApples :=
 /-- `someApples` is CUM: nonempty ⊔ nonempty = nonempty. Bare plurals
     propagate cumulativity (K89 §3 / K98 §3.3). -/
 theorem someApples_cum : CUM someApples := by
-  rw [Mereology.cum_iff]
-  intro x y hx _hy
+  intro x hx y _hy
   -- hx : x.Nonempty ⇒ x ⊔ y = x ∪ y is nonempty
   exact hx.mono (by intro a ha; exact Finset.mem_union.mpr (Or.inl ha))
 

--- a/Linglib/Studies/Moon2026.lean
+++ b/Linglib/Studies/Moon2026.lean
@@ -140,7 +140,7 @@ theorem connectivity_breaks_cum {α : Type*} [SemilatticeSup α]
     {x y : α} (hx : P x) (hy : P y)
     (hDisc : ¬ SelfConnected (x ⊔ y)) :
     ¬ CUM P :=
-  fun hCum => hDisc (hConn _ (Mereology.cum_iff.mp hCum x y hx hy))
+  fun hCum => hDisc (hConn _ (hCum hx hy))
 
 /-- ¬CUM ∧ ¬QUA from connectivity: the middle ground between mass and
     standard count that pure mereology cannot express. -/

--- a/Linglib/Studies/Pasternak2019.lean
+++ b/Linglib/Studies/Pasternak2019.lean
@@ -306,7 +306,7 @@ theorem mentalStateHomogeneity_iff {Event : Type*} [Preorder Event]
     (P : Event → Prop) (h : MentalStateHomogeneity P) (e : Event) :
     P e ↔ ∀ e' : Event, e' ≤ e → P e' := by
   constructor
-  · intro hPe e' hle; exact Mereology.div_iff.mp h e e' hPe hle
+  · intro hPe e' hle; exact h hle hPe
   · intro hAll; exact hAll e (le_refl e)
 
 /-! ## §5.1 Intensity Comparative Max-Reduction
@@ -368,7 +368,7 @@ theorem sortDetermined_isHomogeneous
     (s : Features.Dynamicity) :
     letI := Event.preorder Time
     MentalStateHomogeneity (fun e : Event Time => e.sort = s) := by
-  exact Mereology.div_iff.mpr fun e e' hPe hle =>
+  exact fun e e' hle hPe =>
     (Event.Mereology.sort_preserved e' e hle).trans hPe
 
 /-- On a `PartialOrder` carrier, Pasternak's `MentalStateHomogeneity`


### PR DESCRIPTION
Complete the QUA-style direct-application convergence for the last two core predicates. `CUM`/`DIV` hypotheses now apply directly (`hC hx hy`, `hDiv hle hz`) and construct via direct lambdas — matching mathlib's `SupClosed`/`IsLowerSet` idiom (no `_of_forall` wrappers; the def *is* the construction principle, cf. `IsUpperSet.supClosed`). `IsSumHom.cum_preimage` now reduces to mathlib's `SupClosed.preimage` via the `toSupHom` bridge.