### PR TITLE
chore(Studies/LittleMoroneyRoyer2022): drop unused Mereology import

### DIFF
--- a/Linglib/Studies/LittleMoroneyRoyer2022.lean
+++ b/Linglib/Studies/LittleMoroneyRoyer2022.lean
@@ -1,5 +1,4 @@
 import Linglib.Typology.ClassifierSystem
-import Linglib.Core.Order.Mereology
 import Linglib.Syntax.Tree.Cat
 import Linglib.Core.Logic.Assignment
 import Linglib.Core.Logic.Intensional.Defs


### PR DESCRIPTION
Audit of Mereology's 26 importers found this one references nothing from the module (the `atomize` mentions are prose). Builds clean without it.