### PR TITLE
chore(Syntax/Minimalist/Phi): drop unused Mereology import

### DIFF
--- a/Linglib/Syntax/Minimalist/Phi/Recursion.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Recursion.lean
@@ -1,6 +1,5 @@
 import Linglib.Features.Number.Decomposition
 import Linglib.Features.Number.Interp
-import Linglib.Core.Order.Mereology
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.UpperLower.Basic
 


### PR DESCRIPTION
Second vestigial Mereology import surfaced by the importer audit: `Recursion.lean` references `CUM`/`convexClosure` only in docstring prose (conceptual cross-links), with no code dependency — builds clean without the import. Evidence that Mereology's `CUM`/`QUA` vocabulary has no genuine non-semantic consumer.