### PR TITLE
feat(Core/Order/Antichain): preimage_strictMono, reground qua_pullback

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -84,6 +84,7 @@ import Linglib.Semantics.Modality.Kratzer.ConversationalBackground
 import Linglib.Core.Logic.Intensional.Situations
 import Linglib.Semantics.Conditionals.Counterfactual.Lumping
 import Linglib.Core.Logic.BeliefRevision
+import Linglib.Core.Order.Antichain
 import Linglib.Core.Order.Tree
 import Linglib.Core.Order.TreePath
 import Linglib.Core.Order.Branching

--- a/Linglib/Core/Order/Antichain.lean
+++ b/Linglib/Core/Order/Antichain.lean
@@ -1,0 +1,35 @@
+import Mathlib.Order.Antichain
+
+/-!
+# Strict-monotone preimage of an antichain
+
+`[UPSTREAM]` candidate for `Mathlib/Order/Antichain.lean`: a `StrictMono`
+pullback lemma for `≤`-antichains, complementing mathlib's existing
+`IsAntichain.preimage` (injective + relation-preserving) and
+`IsAntichain.preimage_embedding` (order embeddings). On a partial order
+`StrictMono` is strictly weaker than `Injective ∧ Monotone`, so this
+*generalizes* the `≤`-instance of `preimage`.
+
+This file mirrors mathlib's `Order/Antichain.lean` path: on upstreaming, the
+lemma moves verbatim into `namespace IsAntichain` there and this file is
+deleted.
+
+## Main statements
+
+* `IsAntichain.preimage_strictMono`
+-/
+
+namespace IsAntichain
+
+/-- The preimage of a `≤`-antichain under a strictly monotone map is a
+`≤`-antichain. Unlike `IsAntichain.preimage` (which needs `f` injective and
+relation-preserving) and `IsAntichain.preimage_embedding` (order embeddings),
+this needs only `StrictMono f` — strictly weaker on a partial order. -/
+theorem preimage_strictMono {α β : Type*} [PartialOrder α] [Preorder β] {s : Set β}
+    (hs : IsAntichain (· ≤ ·) s) {f : α → β} (hf : StrictMono f) :
+    IsAntichain (· ≤ ·) (f ⁻¹' s) := by
+  intro a ha b hb hab hab_le
+  have hlt : f a < f b := hf (lt_of_le_of_ne hab_le hab)
+  exact hs ha hb hlt.ne hlt.le
+
+end IsAntichain

--- a/Linglib/Semantics/Mereology.lean
+++ b/Linglib/Semantics/Mereology.lean
@@ -14,6 +14,7 @@ import Mathlib.Order.Lattice
 import Mathlib.Order.Minimal
 import Mathlib.Order.SupClosed
 import Mathlib.Order.UpperLower.Closure
+import Linglib.Core.Order.Antichain
 
 /-!
 # Algebraic Mereology
@@ -411,27 +412,16 @@ theorem atomCount_sup_disjoint (α : Type*) [SemilatticeSup α]
 
 /-! ### QUA/CUM Pullback (contravariant functoriality) -/
 
-/-- QUA pullback along strictly monotone maps.
-
-    If `d : α → β` is strictly monotone and `P` is quantized over `β`,
-    then `P ∘ d` is quantized over `α`. This is the general theorem
-    subsuming both `extMeasure_qua` (where d = μ) and the functional
-    version of `qua_propagation` (where d = θ as a function).
-
-    Categorically: QUA is a contravariant functor from the category of
-    partially ordered types with StrictMono morphisms to Prop.
-
-    The relational `qua_propagation` in Krifka1998.lean (using MSO + UP
-    on a binary relation θ) is genuinely different — it operates on
-    relations, not functions. Both coexist: the functional case is a
-    special case of this theorem. -/
+/-- QUA pullback along a strictly monotone map: if `d` is `StrictMono` and `P`
+    is quantized over `β`, then `P ∘ d` is quantized over `α`. The linguistic
+    (setOf-predicate) form of `IsAntichain.preimage_strictMono`
+    (`Core/Order/Antichain.lean`); subsumes `extMeasure_qua` (`d = μ`) and the
+    functional case of the relational `qua_propagation` in Krifka1998.lean. -/
 theorem qua_pullback {α β : Type*} [PartialOrder α] [PartialOrder β]
     {d : α → β} (hd : StrictMono d)
     {P : β → Prop} (hP : QUA P) :
-    QUA (P ∘ d) := by
-  rintro a ha b hb hab hab_le
-  have hlt := hd (lt_of_le_of_ne hab_le hab)
-  exact hP ha hb hlt.ne hlt.le
+    QUA (P ∘ d) :=
+  hP.preimage_strictMono hd
 
 /-- CUM pullback along sum homomorphisms.
 


### PR DESCRIPTION
Establishes the **mathlib-mirror staging** pattern for `Core/Order/`: a genuine mathlib gap lives at the path mirroring its mathlib destination, stated exactly as it'll appear upstream, so contributing it is a copy-paste and linglib drops the file.

First instance: `IsAntichain.preimage_strictMono` (the general content of Mereology's `qua_pullback`) → `Core/Order/Antichain.lean`, `[UPSTREAM]`-marked for `Mathlib/Order/Antichain.lean`. It *generalizes* mathlib's existing `IsAntichain.preimage` (needs `Injective ∧ Monotone`) — `StrictMono` is strictly weaker on a partial order — so it slots next to the `preimage`/`preimage_embedding` family.

`Mereology.qua_pullback` now derives from it by defeq (`hP.preimage_strictMono hd`); no consumer changes.