### PR TITLE
refactor(Semantics/Mereology): use mathlib Maximal, drop isMaximal alias

### DIFF
--- a/Linglib/Semantics/Mereology.lean
+++ b/Linglib/Semantics/Mereology.lean
@@ -320,9 +320,6 @@ theorem atomize_qua {α : Type*} [PartialOrder α]
     {P : α → Prop} : QUA (atomize P) :=
   setOf_minimal_antichain P
 
-def isMaximal {α : Type*} [PartialOrder α] (P : α → Prop) (x : α) : Prop :=
-  P x ∧ ∀ (y : α), P y → x ≤ y → x = y
-
 /-- Count atoms below `x`, as the cardinality of the (classically finite)
     set of atomic parts. Used by [charlow-2021] for cardinality tests on
     plural individuals. -/
@@ -334,9 +331,10 @@ noncomputable def atomCount (α : Type*) [PartialOrder α] [Fintype α]
     Cumulative predicates have at most one maximal element: the join of all P-elements. -/
 theorem cum_maximal_unique {α : Type*} [SemilatticeSup α]
     {P : α → Prop} (hCum : CUM P)
-    {x y : α} (hx : isMaximal P x) (hy : isMaximal P y) : x = y := by
+    {x y : α} (hx : Maximal P x) (hy : Maximal P y) : x = y := by
   have hxy := hCum hx.1 hy.1
-  exact (hx.2 _ hxy le_sup_left).trans (hy.2 _ hxy le_sup_right).symm
+  exact (le_antisymm le_sup_left (hx.2 hxy le_sup_left)).trans
+    (le_antisymm le_sup_right (hy.2 hxy le_sup_right)).symm
 
 theorem qua_pullback {α β : Type*} [PartialOrder α] [PartialOrder β]
     {d : α → β} (hd : StrictMono d)

--- a/Linglib/Semantics/Quantification/UnifiedUniversal.lean
+++ b/Linglib/Semantics/Quantification/UnifiedUniversal.lean
@@ -25,7 +25,7 @@ This is the **Distributivity-Number Generalization (DNG)**.
 ## Architecture
 
 Q_∀ is defined abstractly over `PartialOrder` using `Mereology.Overlap`,
-`Mereology.Atom`, and `Mereology.isMaximal`. A decidable `Finset`-based
+`Mereology.Atom`, and `Mereology.Maximal`. A decidable `Finset`-based
 variant is provided for computational verification.
 
 The connection to the standard GQ `every_sem` (in `Quantifier.lean`) and
@@ -75,12 +75,12 @@ def QForall {α : Type*} [PartialOrder α]
 
 /-! ### Properties of maxNonOverlap -/
 
-/-- maxNonOverlap implies isMaximal: if x absorbs all overlapping
+/-- maxNonOverlap implies Maximal: if x absorbs all overlapping
     P-elements, it is certainly maximal (no proper P-extension). -/
-theorem maxNonOverlap_imp_isMaximal {α : Type*} [PartialOrder α]
+theorem maxNonOverlap_imp_maximal {α : Type*} [PartialOrder α]
     {P : α → Prop} {x : α} (h : maxNonOverlap P x) :
-    isMaximal P x :=
-  ⟨h.1, λ y hy hle => le_antisymm hle (h.2 y hy ⟨x, le_refl x, hle⟩)⟩
+    Maximal P x :=
+  ⟨h.1, λ y hy hle => h.2 y hy ⟨x, le_refl x, hle⟩⟩
 
 /-- For atoms with a disjointness property, maxNonOverlap reduces to
     membership in P.
@@ -95,7 +95,7 @@ theorem maxNonOverlap_of_atom {α : Type*} [PartialOrder α]
     maxNonOverlap P x :=
   ⟨hPx, λ y hy hov => le_of_eq (hDisj y hy hov)⟩
 
-/-- In a CUM predicate, an element that is isMaximal is also
+/-- In a CUM predicate, an element that is Maximal is also
     maxNonOverlap. CUM ensures all P-elements join into the max,
     so any P-element overlapping max is necessarily ≤ max.
 
@@ -103,13 +103,9 @@ theorem maxNonOverlap_of_atom {α : Type*} [PartialOrder α]
     x ≤ x ⊔ y, so x = x ⊔ y (by maximality), hence y ≤ x. -/
 theorem maxNonOverlap_of_cum_maximal {α : Type*} [SemilatticeSup α]
     {P : α → Prop} (hCum : CUM P)
-    {x : α} (hMax : isMaximal P x) :
+    {x : α} (hMax : Maximal P x) :
     maxNonOverlap P x :=
-  ⟨hMax.1, λ y hy _hov => by
-    have hxy := hCum hMax.1 hy
-    have hle : x ≤ x ⊔ y := le_sup_left
-    have heq : x = x ⊔ y := hMax.2 (x ⊔ y) hxy hle
-    exact heq ▸ le_sup_right⟩
+  ⟨hMax.1, λ y hy _hov => le_trans le_sup_right (hMax.2 (hCum hMax.1 hy) le_sup_left)⟩
 
 /-! ### The Distributivity-Number Generalization (DNG) -/
 
@@ -145,7 +141,7 @@ P-elements — the "maximal plurality."
 -/
 theorem dng_cum {α : Type*} [SemilatticeSup α]
     {P Q : α → Prop} (hCum : CUM P)
-    {m : α} (hMax : isMaximal P m)
+    {m : α} (hMax : Maximal P m)
     (hOnly : ∀ (x' : α), maxNonOverlap P x' → x' = m) :
     QForall P Q ↔ Q m := by
   constructor
@@ -158,21 +154,21 @@ theorem dng_cum {α : Type*} [SemilatticeSup α]
 /-- In a CUM predicate, maxNonOverlap elements are unique (= the max).
 
     This derives `hOnly` for `dng_cum`: if P is CUM, any two
-    maxNonOverlap elements must be equal (both are isMaximal,
+    maxNonOverlap elements must be equal (both are Maximal,
     and CUM predicates have at most one maximal element). -/
 theorem maxNonOverlap_unique_of_cum {α : Type*} [SemilatticeSup α]
     {P : α → Prop} (hCum : CUM P)
     {x y : α} (hx : maxNonOverlap P x) (hy : maxNonOverlap P y) :
     x = y :=
   cum_maximal_unique hCum
-    (maxNonOverlap_imp_isMaximal hx)
-    (maxNonOverlap_imp_isMaximal hy)
+    (maxNonOverlap_imp_maximal hx)
+    (maxNonOverlap_imp_maximal hy)
 
 /-- Combined DNG-PL: for CUM predicates with a maximal element,
     Q_∀(P)(Q) ↔ Q(m), without needing to supply `hOnly` separately. -/
 theorem dng_cum' {α : Type*} [SemilatticeSup α]
     {P Q : α → Prop} (hCum : CUM P)
-    {m : α} (hMax : isMaximal P m) :
+    {m : α} (hMax : Maximal P m) :
     QForall P Q ↔ Q m :=
   dng_cum hCum hMax (λ _x hx =>
     maxNonOverlap_unique_of_cum hCum hx (maxNonOverlap_of_cum_maximal hCum hMax))

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -168,7 +168,7 @@ def Evar (v : Dref S E) (P : E → Prop) : Update S :=
 /-- Mereological maximization (eq. 18): retain outputs of `D` whose `v`-value
 is maximal among the `v`-values of all outputs of `D`. -/
 def Mvar (v : Dref S E) (D : Update S) : Update S :=
-  λ i j => D i j ∧ Mereology.isMaximal (λ x => ∃ k, D i k ∧ v k = x) (v j)
+  λ i j => D i j ∧ Maximal (λ x => ∃ k, D i k ∧ v k = x) (v j)
 
 /-- Cardinality test (eq. 19): test (identity on assignments) that the atom
 count of `v` equals `n`. -/
@@ -414,7 +414,7 @@ output state**. This is the non-distributive operator. -/
 def Mvar_u (v : ℕ) (K : StateCCP W E) [PartialOrder E] : StateCCP W E :=
   λ s =>
     let out := K s
-    {p ∈ out | Mereology.isMaximal (λ x => ∃ q ∈ out, q.2 v = x) (p.2 v)}
+    {p ∈ out | Maximal (λ x => ∃ q ∈ out, q.2 v = x) (p.2 v)}
 
 /-- Cardinality test at the state level (eq. 75): filter the context for
 pairs where the atom count of `v` equals `n`. -/
@@ -466,14 +466,14 @@ theorem Mvar_u_nondistributive [PartialOrder E] [Nonempty W]
   have hnotmem : (w, g₁) ∉ Mvar_u 0 id s := by
     simp only [Mvar_u, id, Set.mem_sep_iff]
     intro ⟨_, _, hmax⟩
-    have : a = b := hmax b ⟨(w, g₂), Or.inr rfl, rfl⟩ (le_of_lt hab)
+    have : a = b := le_antisymm (le_of_lt hab) (hmax ⟨(w, g₂), Or.inr rfl, rfl⟩ (le_of_lt hab))
     exact absurd this (ne_of_lt hab)
   -- But (w, g₁) IS in the per-element union: a is maximal in {(w, g₁)}
   have hmem : (w, g₁) ∈ ({p | ∃ i ∈ s, p ∈ Mvar_u 0 id {i}} : Set _) := by
     refine ⟨(w, g₁), Set.mem_insert _ _, Set.mem_sep (Set.mem_singleton _) ⟨⟨(w, g₁), rfl, rfl⟩, ?_⟩⟩
     intro y ⟨q, hq, hqv⟩ hle
     cases Set.mem_singleton_iff.mp hq
-    exact le_antisymm hle (hqv ▸ le_refl _)
+    exact hqv ▸ le_refl _
   exact hnotmem (h s ▸ hmem)
 
 /-- Cardinality tests are distributive: they inspect one pair at a time. -/
@@ -505,13 +505,13 @@ private theorem evar_u_idempotent (v : ℕ) (P : E → Prop) (s : State W E) :
     exact ⟨⟨q.1, Function.update q.2 v x⟩, ⟨q, hqs, rfl, x, hPx, rfl⟩, hw, x, hPx,
            by rw [hg, Function.update_idem]⟩
 
-/-- Congruence for `isMaximal`: pointwise-equivalent predicates give
+/-- Congruence for `Maximal`: pointwise-equivalent predicates give
 equivalent maximality. -/
-private theorem isMaximal_congr {α : Type*} [PartialOrder α] {P Q : α → Prop}
+private theorem maximal_congr {α : Type*} [PartialOrder α] {P Q : α → Prop}
     (h : ∀ x, P x ↔ Q x) (y : α) :
-    Mereology.isMaximal P y ↔ Mereology.isMaximal Q y :=
-  ⟨fun ⟨hp, hm⟩ => ⟨(h y).mp hp, fun z hz hle => hm z ((h z).mpr hz) hle⟩,
-   fun ⟨hq, hm⟩ => ⟨(h y).mpr hq, fun z hz hle => hm z ((h z).mp hz) hle⟩⟩
+    Maximal P y ↔ Maximal Q y :=
+  ⟨fun ⟨hp, hm⟩ => ⟨(h y).mp hp, fun z hz hle => hm ((h z).mpr hz) hle⟩,
+   fun ⟨hq, hm⟩ => ⟨(h y).mpr hq, fun z hz hle => hm ((h z).mp hz) hle⟩⟩
 
 /-- The `v`-values after `Evar_u v P s` are exactly `{x | P x}` (for
 nonempty input). -/
@@ -556,14 +556,14 @@ theorem exactlyN_u_distributive [PartialOrder E] [Fintype E]
     intro ⟨⟨hmem, hmax⟩, hcount⟩
     obtain ⟨q, hqs, hwq, x, hPx, hgq⟩ := hmem
     refine ⟨q, hqs, ⟨⟨⟨q, rfl, hwq, x, hPx, hgq⟩,
-      (isMaximal_congr (fun y => (evar_u_vvals v P s y ⟨q, hqs⟩).trans
+      (maximal_congr (fun y => (evar_u_vvals v P s y ⟨q, hqs⟩).trans
         (evar_u_vvals_single v P q y).symm) _).mp hmax⟩, hcount⟩⟩
   · -- (⊇) Per-element → full pipeline
     intro ⟨i, his, ⟨⟨hmem_i, hmax_i⟩, hcount_i⟩⟩
     obtain ⟨r, hr_eq, hwr, x, hPx, hgr⟩ := hmem_i
     have hri : r = i := hr_eq; rw [hri] at hwr hgr
     exact ⟨⟨⟨i, his, hwr, x, hPx, hgr⟩,
-      (isMaximal_congr (fun y => (evar_u_vvals_single v P i y).trans
+      (maximal_congr (fun y => (evar_u_vvals_single v P i y).trans
         (evar_u_vvals v P s y ⟨i, his⟩).symm) _).mp hmax_i⟩, hcount_i⟩
 
 end UpdateTheoretic

--- a/Linglib/Studies/Sauerland2003.lean
+++ b/Linglib/Studies/Sauerland2003.lean
@@ -49,7 +49,7 @@ set_option autoImplicit false
 
 namespace Sauerland2003
 
-open Mereology (Atom AlgClosure isMaximal CUM cum_maximal_unique algClosure_cum)
+open Mereology (Atom AlgClosure CUM cum_maximal_unique algClosure_cum)
 open Semantics.Plurality.Algebra (star D)
 open Semantics.Plurality.Cover (IsFinCover algClosure_of_finCover)
 open Features (ContainmentPair ContainmentPairLike)
@@ -341,7 +341,7 @@ theorem je_total_trivial {E : Type*} [PartialOrder E]
 
 /-- **every = JE ∘ DER** (30): Sauerland decomposes *every* into two
     morphemes. DER (the definite article) selects the maximal element
-    of `*R` via `Mereology.isMaximal`. JE distributes over atoms of
+    of `*R` via `Maximal`. JE distributes over atoms of
     the result.
 
     `⟦every⟧(R)(P)` = `⟦JE⟧(max(*R))(P)` -/
@@ -357,7 +357,7 @@ def everySem {E : Type*} [PartialOrder E]
     automatically satisfied for star-closed predicates. -/
 theorem der_unique {E : Type*} [SemilatticeSup E]
     (R : E → Prop) (m₁ m₂ : E)
-    (h₁ : isMaximal (AlgClosure R) m₁) (h₂ : isMaximal (AlgClosure R) m₂) :
+    (h₁ : Maximal (AlgClosure R) m₁) (h₂ : Maximal (AlgClosure R) m₂) :
     m₁ = m₂ :=
   cum_maximal_unique (algClosure_cum (P := R)) h₁ h₂
 


### PR DESCRIPTION
`isMaximal` was a trivial rename of mathlib `Maximal` (`… → x = y` vs `… → y ≤ x`, same notion via antisymmetry) carrying no linguistic content — unlike `atomize`, a real classifier concept that *happens* to be `Minimal`. So it's the `convexClosure`-shim situation: drop it, use `Maximal` directly (consistent with how we already use `Minimal`), inline the `le_antisymm` recovery where the `=` form is needed.

`cum_maximal_unique` + 3 consumers (Sauerland2003/Charlow2021/UnifiedUniversal) on `Maximal`; several constructions *simplified* (the `le_antisymm` recoveries dropped out since `Maximal.2` gives `y ≤ x` directly).