### PR TITLE
feat(Studies/RumbergLauer2023): settledness contrast + Flag future lemma

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -628,6 +628,7 @@ import Linglib.Processing.VisualWorld
 import Linglib.Processing.SelfPacedReading
 import Linglib.Morphology.WugTest
 import Linglib.Features.MinimalPairs
+import Linglib.Studies.RumbergLauer2023
 import Linglib.Studies.SprouseEtAl2012
 -- Fragments
 import Linglib.Fragments.Arabic.ModernStandard.Negation

--- a/Linglib/Semantics/Modality/BranchingTime.lean
+++ b/Linglib/Semantics/Modality/BranchingTime.lean
@@ -31,7 +31,7 @@ the felicity facts (eventive futurate present, apprehensionals) turn on it.
 * `Hist` — the histories through a moment.
 * `pPast`; `oAtom`/`oPast`/`oFut`/`oSettled`/`oSupervaluation` — the Peircean/Ockhamist operators.
 * `IsInevitable`, `PresumedSettled`, `IsSettledWhether` — settledness (context-relative).
-* `kaufmannPresent`, `kaufmannPast` — [kaufmann-2005]'s non-deictic tenses, reconstructed in
+* `kaufmannPresent`, `kaufmannPast` — [kaufmann-2005-truth]'s non-deictic tenses, reconstructed in
   Ockhamist branching time by [rumberg-lauer-2023] §4.1.3 (NOT framework-neutral primitives).
 
 ## Main results
@@ -92,6 +92,32 @@ theorem Iic_subset_of_mem [PartialOrder M] [IsLeftLinear M] {m : M} {h : Flag M}
   have hmem : x ∈ (h : Set M) ∪ Set.Iic m := Or.inr hx
   rwa [← heq] at hmem
 
+/-- A history through a non-maximal moment contains a **future** moment: if `m ∈ h` and `m < x`
+    for some `x`, then `h` contains some `y > m`. (Otherwise `insert x h` would be a strictly
+    larger chain, contradicting `h`'s maximality.) The engine of inevitability reasoning: a
+    history cannot stop at a moment that still has a future. -/
+theorem exists_mem_gt_of_lt [PartialOrder M] {m x : M} {h : Flag M}
+    (hm : m ∈ h) (hx : m < x) : ∃ y ∈ h, m < y := by
+  by_contra hcon
+  push_neg at hcon
+  have hbx : ∀ b ∈ (h : Set M), b ≤ x := by
+    intro b hb
+    rcases h.le_or_le hb hm with hbm | hmb
+    · exact le_of_lt (lt_of_le_of_lt hbm hx)
+    · have hbeq : m = b := (hmb.lt_or_eq).resolve_left (hcon b hb)
+      exact le_of_lt (hbeq ▸ hx)
+  have hchain : IsChain (· ≤ ·) (insert x (h : Set M)) := by
+    rintro a ha b hb _
+    simp only [Set.mem_insert_iff] at ha hb
+    rcases ha with rfl | ha <;> rcases hb with rfl | hb
+    · exact Or.inl le_rfl
+    · exact Or.inr (hbx b hb)
+    · exact Or.inl (hbx a ha)
+    · exact h.le_or_le ha hb
+  have heq : (h : Set M) = insert x (h : Set M) := h.max_chain' hchain (Set.subset_insert x _)
+  have hxh : x ∈ (h : Set M) := by rw [heq]; exact Set.mem_insert x _
+  exact hcon x hxh hx
+
 /-! ### Postsemantics
 
 `MProp` = truth at a moment (Peircean); `OProp` = truth at a moment/history pair (Ockhamist;
@@ -149,16 +175,16 @@ def PresumedSettled [PartialOrder M] (C : Set (Flag M)) (φ : MProp M) (m : M) :
 abbrev IsSettledWhether [PartialOrder M] (φ : MProp M) (m : M) : Prop :=
   PresumedSettled (Hist m) φ m
 
-/-! ### Tense translations ([kaufmann-2005] via [rumberg-lauer-2023] §4.1.3)
+/-! ### Tense translations ([kaufmann-2005-truth] via [rumberg-lauer-2023] §4.1.3)
 
-`PRESENT Q := Q ∨ F_O Q`, `PAST Q := P_O Q`. These encode [kaufmann-2005]'s non-deictic-present
+`PRESENT Q := Q ∨ F_O Q`, `PAST Q := P_O Q`. These encode [kaufmann-2005-truth]'s non-deictic-present
 analysis (morphological present = non-pastness) reconstructed in Ockhamism — *not* neutral
 branching primitives ([schulz-2008]'s Peircean reconstruction gives the same surface forms). -/
 
-/-- [kaufmann-2005]'s present (non-deictic), Ockhamist reconstruction. -/
+/-- [kaufmann-2005-truth]'s present (non-deictic), Ockhamist reconstruction. -/
 def kaufmannPresent [PartialOrder M] (φ : OProp M) : OProp M := fun m h => φ m h ∨ oFut φ m h
 
-/-- [kaufmann-2005]'s past, Ockhamist reconstruction. -/
+/-- [kaufmann-2005-truth]'s past, Ockhamist reconstruction. -/
 def kaufmannPast [PartialOrder M] (φ : OProp M) : OProp M := oPast φ
 
 /-! ### Theorems -/

--- a/Linglib/Studies/RumbergLauer2023.lean
+++ b/Linglib/Studies/RumbergLauer2023.lean
@@ -1,0 +1,115 @@
+import Linglib.Semantics.Modality.BranchingTime
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# [rumberg-lauer-2023]: Conditionals, tense, and branching time — the settledness contrast
+[rumberg-lauer-2023] [kaufmann-2005-truth] [schulz-2008]
+
+[rumberg-lauer-2023] (§2.1) observe that the eventive **futurate present** is felicitous only when
+the eventuality is *settled* — historically necessary, i.e. **true on every possible future**.
+Their minimal pair:
+
+- (6a)  *The Red Sox play the Yankees tomorrow.* — felicitous: the game is scheduled, so on every
+  way the future might go, they play.
+- (6b) #*The Red Sox beat the Yankees tomorrow.* — infelicitous out of the blue: the outcome is
+  open, so that they win is **not settled-true** (felicitous only if the game is fixed *for them*).
+
+We formalize the contrast against the `BranchingTime` substrate (the 𝔗 model). In a model where the
+game's *outcome* branches, *play* is `IsInevitable` (settled-true on every history through the
+utterance moment), while *beat* is **not** `IsInevitable`. Both members of the minimal pair are
+measured by the *same* unilateral notion (settled = historically necessary), which is R&L's actual
+constraint — a settled *loss* would not rescue (6b). (The bilateral `IsSettledWhether`/`PresumedSettled`
+in the substrate serves the [phillips-2021] apprehensional consumer, not R&L here.)
+
+R&L (§4) reconstruct Kaufmann (2005) as an **Ockhamist** account and Schulz (2008) as a **Peircean**
+one. Both *agree* that the bare futurate present requires settledness; they differ in mechanism. The
+Ockhamism-vs-Peirceanism axis itself is the gap between history-relative future truth (`oFut`) and
+settledness (`IsInevitable`), which the same branching model exhibits.
+-/
+
+namespace RumbergLauer2023
+
+open BranchingTime
+
+/-! ### A minimal branching model: the game's outcome branches
+
+Three moments: `now` (game scheduled) below the two incomparable outcomes `win` / `lose`. -/
+
+/-- The moments of the Red Sox scenario. -/
+inductive Moment | now | win | lose
+  deriving DecidableEq, Fintype, Repr
+
+open Moment
+
+/-- `now` is below everything; otherwise the order is discrete, so `win` and `lose` are maximal
+    and incomparable. -/
+instance : LE Moment where
+  le a b := a = now ∨ a = b
+
+instance : DecidableRel (· ≤ · : Moment → Moment → Prop) :=
+  fun a b => inferInstanceAs (Decidable (a = now ∨ a = b))
+
+instance : PartialOrder Moment where
+  le_refl := by decide
+  le_trans := by decide
+  le_antisymm := by decide
+
+instance : DecidableLT Moment := decidableLTOfDecidableLE
+
+/-- Left-linear: `now` is the only predecessor of anything, so any two predecessors of a moment
+    are comparable. -/
+instance : IsLeftLinear Moment := ⟨by decide⟩
+
+/-- Historically connected: `now` is a global minimum, hence a common lower bound of any two
+    moments. -/
+instance : IsCodirectedOrder Moment := ⟨by decide⟩
+
+/-- The outcome model is a genuine branching frame ([rumberg-lauer-2023] Def 1). -/
+instance : IsBranchingTime Moment := ⟨⟩
+
+theorem now_lt_win : (now : Moment) < win := by decide
+theorem now_lt_lose : (now : Moment) < lose := by decide
+
+/-! ### The two eventualities (minimal pair) -/
+
+/-- *The Red Sox play* — true at **both** outcomes (the game is played either way). -/
+def played : MProp Moment := fun m => m = win ∨ m = lose
+
+/-- *The Red Sox beat the Yankees* — true **only** at the `win` outcome. -/
+def beat : MProp Moment := fun m => m = win
+
+/-! ### The contrast -/
+
+/-- **(6a) is felicitous**: *play* is inevitable. On every history through `now`, the game is
+    played — because every history contains a future moment (`exists_mem_gt_of_lt`), and every
+    successor of `now` is a playing moment. -/
+theorem played_inevitable : IsInevitable played now := by
+  intro h hh
+  obtain ⟨y, hy, hlt⟩ := exists_mem_gt_of_lt hh now_lt_win
+  refine ⟨y, hy, hlt, ?_⟩
+  cases y with
+  | now => exact absurd hlt (lt_irrefl now)
+  | win => exact Or.inl rfl
+  | lose => exact Or.inr rfl
+
+/-- **(6b) is infelicitous**: *beat* is not inevitable. The lose-history passes through `now` but
+    has no winning future, so winning is not settled-true (not historically necessary) — the same
+    unilateral notion that makes (6a) felicitous. -/
+theorem beat_not_inevitable : ¬ IsInevitable beat now := by
+  obtain ⟨hl, hnow_l, hlose_l⟩ := Flag.exists_mem_mem (le_of_lt now_lt_lose)
+  intro hinev
+  obtain ⟨m', hm'l, _, hbeat⟩ := hinev hl hnow_l
+  rw [beat] at hbeat; subst hbeat
+  exact absurd (hl.le_or_le hm'l hlose_l) (by decide)
+
+/-- The Ockhamism-vs-Peirceanism axis underlying R&L's two reconstructions
+    ([rumberg-lauer-2023] §3.2, §4): on the win-history, *beat* is Ockhamist-future-true (`oFut`,
+    history-relative), yet it is not settled (not `IsInevitable`/Peircean) — future truth and
+    settledness come apart. Kaufmann's account is Ockhamist, Schulz's Peircean. -/
+theorem oFut_beat_but_not_inevitable :
+    (∃ h ∈ Hist now, oFut (oAtom beat) now h) ∧ ¬ IsInevitable beat now := by
+  refine ⟨?_, beat_not_inevitable⟩
+  obtain ⟨hw, hnow_w, hwin_w⟩ := Flag.exists_mem_mem (le_of_lt now_lt_win)
+  exact ⟨hw, hnow_w, win, hwin_w, now_lt_win, rfl⟩
+
+end RumbergLauer2023

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -33541,3 +33541,18 @@
   role      = {cited},
   sources   = {Semantics/Modality/BranchingTime.lean}
 }
+
+@article{kaufmann-2005-truth,
+  author    = {Kaufmann, Stefan},
+  year      = {2005},
+  title     = {Conditional Truth and Future Reference},
+  journal   = {Journal of Semantics},
+  volume    = {22},
+  number    = {3},
+  pages     = {231--280},
+  doi       = {10.1093/jos/ffh025},
+  subfield  = {semantics/conditionals},
+  validated = {true},
+  role      = {cited},
+  sources   = {Semantics/Modality/BranchingTime.lean, Studies/RumbergLauer2023.lean}
+}


### PR DESCRIPTION
First consumer of the branching-time substrate: [rumberg-lauer-2023]'s eventive-futurate-present settledness diagnostic (the Red Sox *play*/#*beat* minimal pair).

- Concrete 3-moment branching model (outcome branches); proved to be an `IsBranchingTime` frame.
- `played_inevitable` / `beat_not_inevitable` — the felicitous/infelicitous pair, both measured by R&L's *unilateral* settled-true notion (`IsInevitable`); `oFut_beat_but_not_inevitable` exhibits the Ockhamism-vs-Peirceanism gap.
- New substrate lemma `BranchingTime.exists_mem_gt_of_lt` (a history through a non-maximal moment contains a future) — the engine of inevitability reasoning; mathlib-upstreamable `Flag` fact.
- Fixes a citation error caught in review: R&L reconstruct Kaufmann (2005) *Conditional truth and future reference* (J. Semantics, settledness/T×W) — added `kaufmann-2005-truth` and repointed the branching-time cites (the existing `kaufmann-2005` is the unrelated *Conditional predictions*). Sorry-free.