### PR TITLE
feat(Semantics/Questions): prove InqML denotation homomorphism laws

### DIFF
--- a/Linglib/Semantics/Questions/Basic.lean
+++ b/Linglib/Semantics/Questions/Basic.lean
@@ -403,6 +403,32 @@ theorem sInf_eq (S : Set (Question W)) : sInf S = sInfContent S := rfl
 theorem top_eq : (⊤ : Question W) = top := rfl
 theorem bot_eq : (⊥ : Question W) = bot := rfl
 
+@[simp] theorem mem_inf {P Q : Question W} {q : Set W} :
+    q ∈ P ⊓ Q ↔ q ∈ P ∧ q ∈ Q := Iff.rfl
+
+@[simp] theorem mem_sup {P Q : Question W} {q : Set W} :
+    q ∈ P ⊔ Q ↔ q ∈ P ∨ q ∈ Q := Iff.rfl
+
+@[simp] theorem mem_bot {q : Set W} : q ∈ (⊥ : Question W) ↔ q = ∅ := Iff.rfl
+
+@[simp] theorem mem_top {q : Set W} : q ∈ (⊤ : Question W) := trivial
+
+/-- A state lies in `X` iff its principal ideal entails `X`: `declarative s`
+    is the smallest `Question` containing `s`. -/
+theorem mem_iff_declarative_le {X : Question W} {s : Set W} :
+    s ∈ X ↔ declarative s ≤ X := by
+  rw [le_def]
+  refine ⟨fun hs _r hr => X.downward_closed s hs _ (mem_declarative.mp hr), fun h => h ?_⟩
+  exact mem_declarative.mpr subset_rfl
+
+/-- **Heyting implication, pointwise**: `s` resolves `P ⇨ Q` iff every
+    substate of `s` that resolves `P` also resolves `Q`. The defining
+    property of the Heyting arrow on inquisitive contents. -/
+theorem mem_himp {P Q : Question W} {s : Set W} :
+    s ∈ (P ⇨ Q) ↔ ∀ r ⊆ s, r ∈ P → r ∈ Q := by
+  rw [mem_iff_declarative_le, le_himp_iff, inf_eq_conj, le_def]
+  exact ⟨fun h _r hrs hrP => h ⟨hrs, hrP⟩, fun h _r hr => h _r hr.1 hr.2⟩
+
 @[simp] theorem mem_sSup_props {S : Set (Question W)} {q : Set W} :
     q ∈ (sSup S).props ↔ q = ∅ ∨ ∃ P ∈ S, q ∈ P.props := Iff.rfl
 

--- a/Linglib/Studies/Ciardelli2022.lean
+++ b/Linglib/Studies/Ciardelli2022.lean
@@ -15,17 +15,16 @@ and empty-state obligations discharge directly from InqML's persistence
 
 The denotation is a lattice/Heyting homomorphism: it carries InqML's
 `conj`/`inqDisj`/`impl`/`bot` to the `Question` algebra's
-`⊓`/`⊔`/`⇨`/`⊥` (`ofInqML_conj` … `ofInqML_bot`). These are stated here
-but not yet proved (`sorry`); the crux is transporting the Finset/Set
-coercion through the operations. They land once a downstream study needs
-them.
+`⊓`/`⊔`/`⇨`/`⊥` (`ofInqML_conj` … `ofInqML_bot`), through the injective
+`Finset → Set` coercion and the pointwise `mem_himp` characterization of
+the Heyting arrow.
 
 ## Main declarations
 
 * `Question.ofInqML` — the InqML denotation map.
 * `Question.mem_ofInqML` — its membership characterization.
 * `Question.ofInqML_conj` / `_inqDisj` / `_impl` / `_bot` — the
-  homomorphism laws (currently `sorry`).
+  lattice/Heyting homomorphism laws.
 -/
 
 namespace Question
@@ -35,6 +34,7 @@ open Core.Logic.Modal.Inquisitive
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
+omit [DecidableEq W] in
 /-- The image of a lower family of teams under the `Finset W → Set W`
     coercion is again lower (`Fintype W`: every state is the coercion of
     its `toFinset`). The reusable bridge any downward-closed team logic
@@ -59,8 +59,8 @@ def ofInqML (M : KripkeModel W Atom) (φ : Formula Atom) : Question W :=
 /-- Membership in the InqML denotation: a state `s : Set W` lies in the
     `Question` iff some supporting team `t : Finset W` coerces to `s`. -/
 @[simp] theorem mem_ofInqML (M : KripkeModel W Atom) (φ : Formula Atom) (s : Set W) :
-    s ∈ (ofInqML M φ).props ↔ ∃ t : Finset W, ↑t = s ∧ support M φ t := by
-  simp only [ofInqML, props_ofLowerSet, Set.mem_image, Set.mem_setOf_eq, and_comm]
+    s ∈ ofInqML M φ ↔ ∃ t : Finset W, ↑t = s ∧ support M φ t := by
+  simp only [ofInqML, mem_ofLowerSet, Set.mem_image, Set.mem_setOf_eq, and_comm]
 
 /-- `ofInqML` carries InqML conjunction to the lattice meet `⊓`.
     `support (.conj φ ψ)` is the pointwise `And`, so the supporting-team
@@ -68,36 +68,56 @@ def ofInqML (M : KripkeModel W Atom) (φ : Formula Atom) : Question W :=
     preserves it. -/
 theorem ofInqML_conj (M : KripkeModel W Atom) (φ ψ : Formula Atom) :
     ofInqML M (.conj φ ψ) = ofInqML M φ ⊓ ofInqML M ψ := by
-  -- TODO: unfold `support_conj` to `support φ ∧ support ψ`; `Set.image`
-  -- of an intersection under the injective coercion is the intersection
-  -- of images (`Set.InjOn.image_inter`), matching `inf_eq_conj`.
-  sorry
+  ext s
+  simp only [mem_ofInqML, support_conj, mem_inf]
+  constructor
+  · rintro ⟨t, hts, hφ, hψ⟩
+    exact ⟨⟨t, hts, hφ⟩, ⟨t, hts, hψ⟩⟩
+  · rintro ⟨⟨t, hts, hφ⟩, ⟨u, hus, hψ⟩⟩
+    have htu : t = u := Finset.coe_injective (hts.trans hus.symm)
+    subst htu
+    exact ⟨t, hts, hφ, hψ⟩
 
 /-- `ofInqML` carries InqML disjunction to the lattice join `⊔`.
     `support (.inqDisj φ ψ)` is the pointwise `Or`, and `Set.image`
     distributes over union unconditionally. -/
 theorem ofInqML_inqDisj (M : KripkeModel W Atom) (φ ψ : Formula Atom) :
     ofInqML M (.inqDisj φ ψ) = ofInqML M φ ⊔ ofInqML M ψ := by
-  -- TODO: `support_inqDisj` is `support φ ∨ support ψ`; `Set.image_union`
-  -- gives the join, matching `sup_eq_inqDisj`.
-  sorry
+  ext s
+  simp only [mem_ofInqML, support_inqDisj, mem_sup]
+  constructor
+  · rintro ⟨t, hts, hφ | hψ⟩
+    · exact Or.inl ⟨t, hts, hφ⟩
+    · exact Or.inr ⟨t, hts, hψ⟩
+  · rintro (⟨t, hts, hφ⟩ | ⟨t, hts, hψ⟩)
+    · exact ⟨t, hts, Or.inl hφ⟩
+    · exact ⟨t, hts, Or.inr hψ⟩
 
 /-- `ofInqML` carries InqML implication to the Heyting arrow `⇨`.
     `support (.impl φ ψ) t` is `∀ u ⊆ t, support φ u → support ψ u`. -/
 theorem ofInqML_impl (M : KripkeModel W Atom) (φ ψ : Formula Atom) :
     ofInqML M (.impl φ ψ) = ofInqML M φ ⇨ ofInqML M ψ := by
-  -- TODO: the crux. Characterize `Question`'s Heyting `⇨` pointwise as
-  -- `{s | ∀ r ⊆ s, r ∈ P.props → r ∈ Q.props}`, then bridge the Finset
-  -- subteam quantifier to the Set substate quantifier via `Fintype W`
-  -- (every `r ⊆ ↑t` is `↑u` for a unique `u ⊆ t`).
-  sorry
+  ext s
+  rw [mem_himp]
+  simp only [mem_ofInqML, support_impl]
+  constructor
+  · rintro ⟨t, rfl, hsupp⟩ r hrs ⟨a, ha, haφ⟩
+    exact ⟨a, ha, hsupp a (Finset.coe_subset.mp (ha.le.trans hrs)) haφ⟩
+  · intro h
+    refine ⟨(Set.toFinite s).toFinset, by simp, fun u hu hφu => ?_⟩
+    have hus : (↑u : Set W) ⊆ s := by
+      rw [← (Set.toFinite s).coe_toFinset]; exact Finset.coe_subset.mpr hu
+    obtain ⟨b, hb, hψb⟩ := h ↑u hus ⟨u, rfl, hφu⟩
+    rwa [← Finset.coe_injective hb]
 
 /-- `ofInqML` carries InqML `⊥` to the lattice bottom `⊥`.
     `support .bot t` holds iff `t = ∅`, so the denotation is `{∅}`. -/
 theorem ofInqML_bot (M : KripkeModel W Atom) :
     ofInqML M (Atom := Atom) .bot = ⊥ := by
-  -- TODO: `support_bot t ↔ t = ∅`; the image of `{∅}` is `{∅} = bot.props`
-  -- (`bot_eq`).
-  sorry
+  ext s
+  simp only [mem_ofInqML, support_bot, mem_bot]
+  constructor
+  · rintro ⟨t, rfl, rfl⟩; simp
+  · rintro rfl; exact ⟨∅, by simp, rfl⟩
 
 end Question


### PR DESCRIPTION
Discharges the four `sorry` stubs from #464: `Question.ofInqML` is a lattice/Heyting homomorphism (`ofInqML_conj`/`_inqDisj`/`_impl`/`_bot` carry InqML's connectives to `⊓`/`⊔`/`⇨`/`⊥`).

- Adds the missing membership API to `Basic.lean`: `mem_inf`/`mem_sup`/`mem_bot`/`mem_top`, plus `mem_iff_declarative_le` and the pointwise Heyting characterization `mem_himp` (`s ∈ P ⇨ Q ↔ ∀ r ⊆ s, r ∈ P → r ∈ Q`).
- `mem_ofInqML` restated in SetLike `∈` form (more idiomatic; `mem_props` shadowed the `.props` form). The `impl` law uses the `Fintype W` bridge (every state is `↑(toFinset)`).