### PR TITLE
feat(Semantics/Modality): ground branching tense in Core.Order.holds

### DIFF
--- a/Linglib/Semantics/Modality/BranchingTime.lean
+++ b/Linglib/Semantics/Modality/BranchingTime.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Order.LeftLinear
+import Linglib.Core.Order.Relation
 import Mathlib.Order.Zorn
 import Mathlib.Order.Directed
 
@@ -203,5 +204,40 @@ def kaufmannPast [PartialOrder M] (φ : OProp M) : OProp M := oPast φ
     notions of "settled that φ will happen" coincide. -/
 theorem isInevitable_iff_oSupervaluation_oFut [PartialOrder M] (φ : MProp M) (m : M) :
     IsInevitable φ m ↔ oSupervaluation (oFut (oAtom φ)) m := Iff.rfl
+
+/-! ### Grounding in the `Core.Order` comparison kernel
+
+The Ockhamist past/future operators reuse the shared point-comparison kernel (`Core.Order.holds` over
+`Finset Ordering`) rather than re-stipulating "earlier"/"later": `oPast`'s witness sits `before` the
+evaluation moment, `oFut`'s sits `after` it. Since `Core.Order.before = Tense.past` and
+`Core.Order.after = Tense.future`, branching-time tense and the rest of the library's tense are the
+*same* comparison. These are the **linear-frame** reductions (no branching, so the comparison is total
+on all of `M`); for a genuinely branching frame the comparison lives on each history's chain order
+(`Flag`'s `LinearOrder`), `oFut_oAtom_holds_on_hist`. -/
+
+@[simp] theorem oPast_oAtom_iff_holds {M : Type*} [LinearOrder M]
+    (φ : MProp M) (m : M) (h : Flag M) :
+    oPast (oAtom φ) m h ↔ ∃ m', Core.Order.holds Core.Order.before m' m ∧ φ m' := by
+  simp only [oPast, oAtom, Core.Order.holds_before]
+
+@[simp] theorem oFut_oAtom_iff_holds {M : Type*} [LinearOrder M]
+    (φ : MProp M) (m : M) (h : Flag M) :
+    oFut (oAtom φ) m h ↔ ∃ m' ∈ h, Core.Order.holds Core.Order.after m' m ∧ φ m' := by
+  simp only [oFut, oAtom, Core.Order.holds_after]
+
+/-- **Genuine-branching grounding** (`oFut` on any branching frame): the future witness comparison
+    is `Core.Order.holds after` over the history's own chain order (mathlib's `LinearOrder ↥h` for a
+    maximal chain `h`). So the Ockhamist future *along a history* is literally the comparison-kernel
+    future, with the chain supplying the linear order `Core.Order.holds` requires. -/
+theorem oFut_oAtom_holds_on_hist {M : Type*} [PartialOrder M]
+    [DecidableEq M] [DecidableRel (· ≤ · : M → M → Prop)] [DecidableLT M]
+    (φ : MProp M) {m : M} {h : Flag M} (hm : m ∈ h) :
+    oFut (oAtom φ) m h ↔ ∃ x : ↥h, Core.Order.holds Core.Order.after x ⟨m, hm⟩ ∧ φ (x : M) := by
+  simp only [oFut, oAtom, Core.Order.holds_after]
+  constructor
+  · rintro ⟨m', hm', hlt, hφ⟩
+    exact ⟨⟨m', hm'⟩, hlt, hφ⟩
+  · rintro ⟨x, hlt, hφ⟩
+    exact ⟨x, x.2, hlt, hφ⟩
 
 end BranchingTime

--- a/Linglib/Studies/RumbergLauer2023.lean
+++ b/Linglib/Studies/RumbergLauer2023.lean
@@ -112,4 +112,18 @@ theorem oFut_beat_but_not_inevitable :
   obtain ⟨hw, hnow_w, hwin_w⟩ := Flag.exists_mem_mem (le_of_lt now_lt_win)
   exact ⟨hw, hnow_w, win, hwin_w, now_lt_win, rfl⟩
 
+/-- **The Ockham side, grounded in the comparison kernel** (`BranchingTime.oFut_oAtom_holds_on_hist`):
+    *beat*'s history-relative future truth *is* a `Core.Order.holds Core.Order.after` comparison along
+    its witnessing history — `win` sits in the `after` cell relative to `now` (`after = Tense.future`),
+    with the history's own chain order supplying the linear order `holds` needs. The Peircean contrast
+    is deliberately preserved: *beat* is still `¬ IsInevitable`, so the load-bearing felicity prediction
+    remains settledness, not bare `oFut`. -/
+theorem beat_future_is_holds_after_but_not_inevitable :
+    (∃ (h : Flag Moment) (hm : now ∈ h),
+        ∃ x : ↥h, Core.Order.holds Core.Order.after x ⟨now, hm⟩ ∧ beat (x : Moment))
+      ∧ ¬ IsInevitable beat now := by
+  refine ⟨?_, beat_not_inevitable⟩
+  obtain ⟨h, hh, hfut⟩ := oFut_beat_but_not_inevitable.1
+  exact ⟨h, hh, (oFut_oAtom_holds_on_hist beat hh).mp hfut⟩
+
 end RumbergLauer2023


### PR DESCRIPTION
Ground `BranchingTime`'s Ockhamist tense operators in the shared `Core.Order.holds` comparison kernel (the spine the GramTense dissolution unified), so branching-time past/future stops re-stipulating `∃ m' < m` and *is* the rest of the library's tense, by construction.

- `oPast_oAtom_iff_holds` / `oFut_oAtom_iff_holds` — on a linear frame the operators reduce to `holds before`/`holds after` (`= Tense.past`/`Tense.future`).
- `oFut_oAtom_holds_on_hist` — on a genuine branching frame the future witness comparison is `holds after` over the history's own chain order (mathlib's `LinearOrder` on a maximal `Flag`).
- `RumbergLauer2023.beat_future_is_holds_after_but_not_inevitable` — applies it: *beat*'s history-relative future truth is a `holds after` comparison, while the Peircean `¬ IsInevitable` contrast (the load-bearing felicity prediction) is preserved.

Grounded in `Core.Order` directly (no Modality→Tense edge); structural proofs, no `native_decide`.