### PR TITLE
feat(Core/Logic/Temporal): T × W tense-modal object logic + algebra

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -41,6 +41,8 @@ import Linglib.Core.Logic.Modal.Inclusion
 import Linglib.Core.Logic.Modal.Inquisitive
 import Linglib.Core.Logic.Modal.Kripke
 import Linglib.Core.Logic.Modal.Bisimulation
+import Linglib.Core.Logic.Temporal.Defs
+import Linglib.Core.Logic.Temporal.Basic
 import Linglib.Core.Logic.Team.Algebra
 import Linglib.Core.Logic.Team.Closure
 import Linglib.Core.Logic.Team.Definability

--- a/Linglib/Core/Logic/Temporal/Basic.lean
+++ b/Linglib/Core/Logic/Temporal/Basic.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Logic.Temporal.Defs
+
+/-!
+# T × W tense-modal logic: the modal algebra of satisfaction
+[von-kutschera-1997] [thomason-1984]
+
+Basic semantic lemmas for `Core.Logic.Temporal` satisfaction: the satisfaction-clause `@[simp]`
+lemmas, the dual operators (`M`/`dia`/`Fut`/`Pst`), the modality hierarchy `box ⊃ N ⊃ A`, and the
+fact that historical necessity `N` and the all-worlds `box` are **S5** modalities (`N` because `∼ₜ`
+is an equivalence; `box` because it quantifies over all worlds) ([von-kutschera-1997] A4, A5).
+
+## Main results
+* `sat_neg`/`sat_and`/`sat_G`/`sat_H`/`sat_N`/`sat_box` — satisfaction clauses (`@[simp]`).
+* `sat_M` — historical possibility `M` is `∃` over `∼ₜ`-alternatives.
+* `sat_box_imp_N`, `sat_N_imp_self`, `sat_box_imp_self` — the `box ⊃ N ⊃ A` hierarchy.
+* `sat_N_imp_N_N`, `sat_M_imp_N_M` — `N` is S5 (axioms 4 and 5).
+* `sat_box_imp_box_box`, `sat_dia_imp_box_dia` — `box` is S5.
+-/
+
+namespace Core.Logic.Temporal.TWFrame
+
+variable {Time : Type*} {World : Type*} {Atom : Type*} [LinearOrder Time]
+  (F : TWFrame Time World) (V : Atom → Time → World → Prop)
+
+/-! ### Satisfaction clauses -/
+
+@[simp] theorem sat_atom (p : Atom) (t : Time) (w : World) :
+    F.sat V (.atom p) t w ↔ V p t w := Iff.rfl
+
+@[simp] theorem sat_neg (a : OForm Atom) (t : Time) (w : World) :
+    F.sat V (.neg a) t w ↔ ¬ F.sat V a t w := Iff.rfl
+
+@[simp] theorem sat_and (a b : OForm Atom) (t : Time) (w : World) :
+    F.sat V (.and a b) t w ↔ F.sat V a t w ∧ F.sat V b t w := Iff.rfl
+
+@[simp] theorem sat_G (a : OForm Atom) (t : Time) (w : World) :
+    F.sat V (.G a) t w ↔ ∀ t', t < t' → F.sat V a t' w := Iff.rfl
+
+@[simp] theorem sat_H (a : OForm Atom) (t : Time) (w : World) :
+    F.sat V (.H a) t w ↔ ∀ t', t' < t → F.sat V a t' w := Iff.rfl
+
+@[simp] theorem sat_N (a : OForm Atom) (t : Time) (w : World) :
+    F.sat V (.N a) t w ↔ ∀ w', F.sim t w w' → F.sat V a t w' := Iff.rfl
+
+@[simp] theorem sat_box (a : OForm Atom) (t : Time) (w : World) :
+    F.sat V (.box a) t w ↔ ∀ w', F.sat V a t w' := Iff.rfl
+
+/-! ### Dual operators -/
+
+@[simp] theorem sat_M (a : OForm Atom) (t : Time) (w : World) :
+    F.sat V a.M t w ↔ ∃ w', F.sim t w w' ∧ F.sat V a t w' := by
+  simp only [OForm.M, sat_neg, sat_N, not_forall, not_not, exists_prop]
+
+@[simp] theorem sat_dia (a : OForm Atom) (t : Time) (w : World) :
+    F.sat V a.dia t w ↔ ∃ w', F.sat V a t w' := by
+  simp only [OForm.dia, sat_neg, sat_box, not_forall, not_not]
+
+@[simp] theorem sat_Fut (a : OForm Atom) (t : Time) (w : World) :
+    F.sat V a.Fut t w ↔ ∃ t', t < t' ∧ F.sat V a t' w := by
+  simp only [OForm.Fut, sat_neg, sat_G, not_forall, not_not, exists_prop]
+
+@[simp] theorem sat_Pst (a : OForm Atom) (t : Time) (w : World) :
+    F.sat V a.Pst t w ↔ ∃ t', t' < t ∧ F.sat V a t' w := by
+  simp only [OForm.Pst, sat_neg, sat_H, not_forall, not_not, exists_prop]
+
+/-! ### The modality hierarchy `box ⊃ N ⊃ A`
+
+Truth in all worlds implies truth at every historical alternative (a fortiori), which — since `∼ₜ` is
+reflexive — implies truth here ([von-kutschera-1997] A7, A4a). -/
+
+theorem sat_box_imp_N {a : OForm Atom} {t : Time} {w : World} :
+    F.sat V (.box a) t w → F.sat V (.N a) t w :=
+  fun h w' _ => h w'
+
+theorem sat_N_imp_self {a : OForm Atom} {t : Time} {w : World} :
+    F.sat V (.N a) t w → F.sat V a t w :=
+  fun h => h w ((F.sim_equiv t).refl w)
+
+theorem sat_box_imp_self {a : OForm Atom} {t : Time} {w : World} :
+    F.sat V (.box a) t w → F.sat V a t w :=
+  fun h => h w
+
+/-! ### `N` is an S5 modality
+
+Reflexivity gives the `T` axiom (`sat_N_imp_self`); transitivity gives `4`; symmetry gives `5`. -/
+
+theorem sat_N_imp_N_N {a : OForm Atom} {t : Time} {w : World} :
+    F.sat V (.N a) t w → F.sat V (.N (.N a)) t w :=
+  fun h w' hww' w'' hw'w'' => h w'' ((F.sim_equiv t).trans hww' hw'w'')
+
+theorem sat_M_imp_N_M {a : OForm Atom} {t : Time} {w : World} :
+    F.sat V a.M t w → F.sat V a.M.N t w := by
+  intro h w' hww'
+  rw [sat_M] at h ⊢
+  obtain ⟨w₀, hww₀, ha⟩ := h
+  exact ⟨w₀, (F.sim_equiv t).trans ((F.sim_equiv t).symm hww') hww₀, ha⟩
+
+/-! ### `box` is an S5 modality (universal accessibility) -/
+
+theorem sat_box_imp_box_box {a : OForm Atom} {t : Time} {w : World} :
+    F.sat V (.box a) t w → F.sat V (.box (.box a)) t w :=
+  fun h _ => h
+
+theorem sat_dia_imp_box_dia {a : OForm Atom} {t : Time} {w : World} :
+    F.sat V a.dia t w → F.sat V a.dia.box t w := by
+  intro h w'
+  rw [sat_dia] at h ⊢
+  obtain ⟨w₀, ha⟩ := h
+  exact ⟨w₀, ha⟩
+
+/-! ### The temporal adjunctions `Fut ⊣ H`, `Pst ⊣ G`
+
+The tense operators are Galois-adjoint on each model's entailment preorder ([burgess-1984]): `Fut`
+(future `∃`) is left adjoint to `H` (past `∀`), and `Pst` (past `∃`) to `G` (future `∀`). -/
+
+theorem Fut_adjoint_H (a b : OForm Atom) :
+    F.entails V a.Fut b ↔ F.entails V a (.H b) := by
+  simp only [entails, sat_Fut, sat_H]
+  constructor
+  · intro h t w hat t' ht
+    exact h t' w ⟨t, ht, hat⟩
+  · rintro h t w ⟨u, htu, hau⟩
+    exact h u w hau t htu
+
+theorem Pst_adjoint_G (a b : OForm Atom) :
+    F.entails V a.Pst b ↔ F.entails V a (.G b) := by
+  simp only [entails, sat_Pst, sat_G]
+  constructor
+  · intro h t w hat t' ht
+    exact h t' w ⟨t, ht, hat⟩
+  · rintro h t w ⟨u, hut, hau⟩
+    exact h u w hau t hut
+
+end Core.Logic.Temporal.TWFrame

--- a/Linglib/Core/Logic/Temporal/Defs.lean
+++ b/Linglib/Core/Logic/Temporal/Defs.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Order.Basic
+
+/-!
+# T × W tense-modal logic: frames, language, and satisfaction
+
+The object language and Kripke semantics of **T × W logic** ([thomason-1984], [von-kutschera-1997]):
+linear tense (`G`/`H`) with historical modality (`N` over historical alternatives `∼ₜ`, `box` over all
+worlds) on worlds sharing one time order. A `Core` restatement of the
+`Semantics.Modality.HistoricalAlternatives` substrate, kept Semantics-free for the metatheory
+(soundness; [dimaio-zanardo-1994] definability).
+
+## Main definitions
+* `TWFrame` — a T × W frame (linear time + per-time, backward-closed historical equivalence).
+* `OForm` — the object language `L`.
+* `TWFrame.sat` — the satisfaction relation.
+* `OForm.M` — historical possibility `¬N¬` (the Ockhamist `◇`).
+-/
+
+namespace Core.Logic.Temporal
+
+universe u v
+
+/-- A **T × W frame** ([thomason-1984], [von-kutschera-1997]): linear time, worlds, and a per-time
+    historical-equivalence `sim` that is an equivalence and backward-closed. -/
+structure TWFrame (Time : Type u) (World : Type v) [LinearOrder Time] where
+  /-- Historical equivalence `∼ₜ`: `sim t w w'` holds iff `w`, `w'` share their history up to `t`. -/
+  sim : Time → World → World → Prop
+  /-- Each `∼ₜ` is an equivalence relation. -/
+  sim_equiv : ∀ t, Equivalence (sim t)
+  /-- **Backward closure**: agreement up to `t` implies agreement up to any earlier `t'`. -/
+  sim_backward : ∀ {t t' : Time} (w w' : World), t' ≤ t → sim t w w' → sim t' w w'
+
+/-- The object language `L` of T × W logic ([von-kutschera-1997] §1). -/
+inductive OForm (Atom : Type*) where
+  /-- A sentential constant. -/
+  | atom : Atom → OForm Atom
+  /-- Negation. -/
+  | neg : OForm Atom → OForm Atom
+  /-- Conjunction. -/
+  | and : OForm Atom → OForm Atom → OForm Atom
+  /-- `G` — "it will always be that" (∀ later times, same world). -/
+  | G : OForm Atom → OForm Atom
+  /-- `H` — "it has always been that" (∀ earlier times, same world). -/
+  | H : OForm Atom → OForm Atom
+  /-- `N` — historical necessity (∀ `∼ₜ`-alternatives, same time). -/
+  | N : OForm Atom → OForm Atom
+  /-- `box` — truth in all worlds (von Kutschera's `N₄`). -/
+  | box : OForm Atom → OForm Atom
+  deriving DecidableEq
+
+namespace TWFrame
+
+variable {Time : Type u} {World : Type v} {Atom : Type*} [LinearOrder Time]
+
+/-- Satisfaction `V_{t,w}(A)` ([von-kutschera-1997]) relative to an atomic valuation `V`. -/
+def sat (F : TWFrame Time World) (V : Atom → Time → World → Prop) :
+    OForm Atom → Time → World → Prop
+  | .atom p,  t, w => V p t w
+  | .neg a,   t, w => ¬ F.sat V a t w
+  | .and a b, t, w => F.sat V a t w ∧ F.sat V b t w
+  | .G a,     t, w => ∀ t', t < t' → F.sat V a t' w
+  | .H a,     t, w => ∀ t', t' < t → F.sat V a t' w
+  | .N a,     t, w => ∀ w', F.sim t w w' → F.sat V a t w'
+  | .box a,   t, w => ∀ w', F.sat V a t w'
+
+/-- Local entailment in a model: `a` entails `b` iff `b` holds wherever `a` does. -/
+def entails (F : TWFrame Time World) (V : Atom → Time → World → Prop) (a b : OForm Atom) : Prop :=
+  ∀ t w, F.sat V a t w → F.sat V b t w
+
+end TWFrame
+
+/-! ### Derived (dual) operators -/
+
+variable {Atom : Type*}
+
+/-- Historical possibility `M = ¬N¬` (the Ockhamist `◇`). -/
+def OForm.M (a : OForm Atom) : OForm Atom := .neg (.N (.neg a))
+
+/-- Tense `F` — "it will at some point be that" (`¬G¬`). -/
+def OForm.Fut (a : OForm Atom) : OForm Atom := .neg (.G (.neg a))
+
+/-- Tense `P` — "it was at some point that" (`¬H¬`). -/
+def OForm.Pst (a : OForm Atom) : OForm Atom := .neg (.H (.neg a))
+
+/-- Possibility in all worlds `◇ = ¬□¬`. -/
+def OForm.dia (a : OForm Atom) : OForm Atom := .neg (.box (.neg a))
+
+end Core.Logic.Temporal

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -33556,3 +33556,49 @@
   role      = {cited},
   sources   = {Semantics/Modality/BranchingTime.lean, Studies/RumbergLauer2023.lean}
 }
+
+@article{von-kutschera-1997,
+  author    = {von Kutschera, Franz},
+  year      = {1997},
+  title     = {T × W completeness},
+  journal   = {Journal of Philosophical Logic},
+  volume    = {26},
+  pages     = {241--250},
+  doi       = {10.1023/A:1017942520078},
+  subfield  = {semantics/tense},
+  role      = {cited},
+  validated = {true},
+  sources   = {Core/Logic/Temporal/Defs.lean;Core/Logic/Temporal/Basic.lean}
+}
+
+@incollection{dimaio-zanardo-1994,
+  author    = {Di Maio, Maria Concetta and Zanardo, Alberto},
+  year      = {1994},
+  title     = {Synchronized histories in {Prior}--{Thomason} representation of branching time},
+  booktitle = {Temporal Logic ({ICTL} '94)},
+  editor    = {Gabbay, Dov M. and Ohlbach, Hans J{\"u}rgen},
+  series    = {Lecture Notes in Computer Science},
+  volume    = {827},
+  pages     = {265--282},
+  publisher = {Springer},
+  doi       = {10.1007/BFb0013993},
+  subfield  = {semantics/tense},
+  role      = {cited},
+  validated = {true},
+  sources   = {Core/Logic/Temporal/Defs.lean}
+}
+
+@incollection{burgess-1984,
+  author    = {Burgess, John P.},
+  year      = {1984},
+  title     = {Basic tense logic},
+  booktitle = {Handbook of Philosophical Logic},
+  editor    = {Gabbay, Dov and Guenthner, Franz},
+  volume    = {2},
+  pages     = {89--133},
+  publisher = {Reidel},
+  subfield  = {semantics/tense},
+  role      = {cited},
+  validated = {false},
+  sources   = {Core/Logic/Temporal/Basic.lean}
+}


### PR DESCRIPTION
Core, Semantics-free foundation for T × W tense-modal logic ([thomason-1984], [von-kutschera-1997]): the `TWFrame` (linear time + per-time backward-closed historical equivalence), the object language `OForm` (`G`/`H`/`N`/`box`), the `sat` relation, and its modal algebra — the `box ⊃ N ⊃ A` hierarchy, `N`/`box` as S5 modalities, and the tense Galois adjunctions `Fut ⊣ H`, `Pst ⊣ G` ([burgess-1984]). Sorry-free.

Abstract `Core` restatement of the `Semantics.Modality.HistoricalAlternatives` substrate, kept dependency-free so the metatheory (soundness; [dimaio-zanardo-1994] definability) can follow. First piece of the spec; the `sat ↔ oFut/oSettled` Semantics bridge and the `TW` calculus land later.