### PR TITLE
feat(Core/Logic): graduate bilattice substrate + Schoter1996 consumer

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -32,6 +32,7 @@ import Linglib.Typology.Pronoun.WALS
 import Linglib.Typology.Evidentiality
 import Linglib.Core.Logic.FactorsThroughOn
 import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Bilattice
 import Linglib.Core.Logic.Consequence
 import Linglib.Core.Logic.ThreeValuedLogic
 import Linglib.Core.Logic.Bilateral.Defs
@@ -1342,6 +1343,7 @@ import Linglib.Studies.BillEtAl2025
 import Linglib.Studies.BrueningAlKhalaf2020
 import Linglib.Studies.Bruening2025
 import Linglib.Studies.Schwarzer2026
+import Linglib.Studies.Schoter1996
 import Linglib.Studies.Stassen2000
 import Linglib.Studies.Haspelmath2007
 import Linglib.Studies.MitrovicSauerland2016

--- a/Linglib/Core/Logic/Bilattice.lean
+++ b/Linglib/Core/Logic/Bilattice.lean
@@ -1,0 +1,82 @@
+import Mathlib.Order.Basic
+import Mathlib.Data.Bool.Basic
+
+/-!
+# Evidential bilattices over a chain
+[fitting-1994] [schoter-1996]
+
+A *bilattice* carries two orders on one carrier — a *truth* order `≤_t` and an
+*information/knowledge* order `≤_k` ([fitting-1994]). The *evidential* bilattices
+([schoter-1996]) are the ones of the form `S ⊙ S` for a chain `S`: a value is a
+pair `(for, against)` of degrees of evidence, with
+
+* `≤_t` truer  = more evidence-for, less evidence-against;
+* `≤_k` more informative = more evidence both ways;
+* `neg` (truth inversion) swaps the two coordinates;
+* `conf` (knowledge inversion, the *conflation*) complements each coordinate.
+
+With `S = Bool` this is Belnap's `FOUR`; with `S = Fin 3` (the chain `0 < ½ < 1`)
+it is [schoter-1996]'s 9-valued `PRESUP` (see `Studies.Schoter1996`). This file
+is the shared substrate; concrete bilattices and their linguistic uses live in
+the consuming `Studies` files.
+
+## Main definitions
+
+* `Bilattice.Evidential S := S × S` — the evidential bilattice over a chain `S`
+* `Evidential.tLE`/`kLE`/`neg`/`conf`/`Consistent` — the two orders, negation,
+  conflation, and the consistent (`x ≤_k −x`, non-glut) fragment
+* `Bilattice.FOUR := Evidential Bool` — Belnap's four-valued bilattice
+-/
+
+namespace Bilattice
+
+/-- The evidential bilattice over a chain `S`: values are `(for, against)`
+pairs ([schoter-1996]'s `S ⊙ S`). -/
+abbrev Evidential (S : Type*) := S × S
+
+namespace Evidential
+
+variable {S : Type*} [Preorder S]
+
+/-- Truth order: more evidence-for and less evidence-against. -/
+@[reducible] def tLE (x y : Evidential S) : Prop := x.1 ≤ y.1 ∧ y.2 ≤ x.2
+/-- Knowledge order: more evidence both ways. -/
+@[reducible] def kLE (x y : Evidential S) : Prop := x.1 ≤ y.1 ∧ x.2 ≤ y.2
+/-- Negation: truth inversion, swaps the coordinates. -/
+def neg : Evidential S → Evidential S := Prod.swap
+/-- Conflation `−`: knowledge inversion, complements each coordinate by `compl`,
+which is intended to be the order-reversing involution on the chain `S`
+(`(! ·)` for `Bool`, `Fin.rev` for `Fin n`). -/
+def conf (compl : S → S) (x : Evidential S) : Evidential S := (compl x.2, compl x.1)
+/-- The consistent (non-glut) fragment: `x ≤_k −x` ([fitting-1994]). -/
+@[reducible] def Consistent (compl : S → S) (x : Evidential S) : Prop :=
+  kLE x (conf compl x)
+
+end Evidential
+
+/-- Belnap's four-valued bilattice `FOUR = Bool ⊙ Bool`, `(for, against)` over
+`Bool`. -/
+abbrev FOUR := Evidential Bool
+
+namespace FOUR
+
+/-- `⊥`: neither — no information (a truth-value gap). -/
+def U : FOUR := (false, false)
+/-- `true`. -/
+def T : FOUR := (true, false)
+/-- `false`. -/
+def F : FOUR := (false, true)
+/-- `⊤`: both — inconsistent (a truth-value glut). -/
+def I : FOUR := (true, true)
+
+/-- Conflation on `FOUR` (Boolean complement). -/
+@[reducible] def conf (x : FOUR) : FOUR := Evidential.conf (! ·) x
+/-- The consistent (non-glut) fragment of `FOUR` — equivalently `x ≠ I`. -/
+@[reducible] def Consistent (x : FOUR) : Prop := Evidential.Consistent (! ·) x
+
+@[simp] theorem consistent_iff (x : FOUR) : Consistent x ↔ x ≠ I := by
+  obtain ⟨a, b⟩ := x; cases a <;> cases b <;> decide
+
+end FOUR
+
+end Bilattice

--- a/Linglib/Studies/Fitting1994.lean
+++ b/Linglib/Studies/Fitting1994.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Bilattice
 
 /-!
 # Kleene's three-valued logic as the consistent fragment of Belnap's FOUR
@@ -6,72 +7,33 @@ import Linglib.Core.Logic.Truth3
 
 [fitting-1994] ("Kleene's Three Valued Logics and Their Children") organizes
 Kleene's logics as fragments of Belnap's four-valued bilattice `FOUR`, sliced by
-the *conflation* `−` (the knowledge-order involution). His key observation: the
-strong Kleene values are exactly those `x` with `x ≤_k −x`, i.e. information that
-does not exceed its own conflation — the *consistent* (non-glut) values.
+the *conflation* `−` (the knowledge-order involution): the strong Kleene values
+are exactly those `x` with `x ≤_k −x` — the *consistent* (non-glut) values.
 
-`FOUR` carries two orders — truth `≤_t` and knowledge `≤_k` — with negation `¬`
-(truth inversion, swaps `true`/`false`) and conflation `−` (knowledge inversion,
-swaps `⊥`/`⊤`). Here `FOUR = Bool × Bool` with coordinates `(for, against)`
-(membership in the true- and false-extensions; [schoter-1996]'s evidence pairs,
-transposed).
-
-This file proves that linglib's `Truth3` (Kleene's three-valued logic,
-[kleene-1952]) is exactly the consistent fragment of `FOUR`, in **both** orders:
-`ofTruth3` embeds `Truth3` onto `{x // Consistent x}`, matching the truth order
-(`Truth3`'s `≤`), the knowledge order (`Truth3.toFlat`, i.e. `Flat Bool`, from
-the Kleene-bilattice grounding), and negation. So the gap logic linglib already
-uses for presupposition is the `I`-free slice of the four-valued bilattice; the
-glut `I` is what trivalence excludes. The bilattice route to natural-language
-entailment, implicature, and presupposition is [schoter-1996].
+`FOUR` and its two orders / negation / conflation are the shared substrate in
+`Core.Logic.Bilattice`. Here we prove the slicing for linglib's `Truth3`
+(Kleene's three-valued logic, [kleene-1952]): `ofTruth3` embeds `Truth3` onto the
+consistent fragment of `FOUR`, matching the truth order (`Truth3`'s `≤`), the
+knowledge order (`Truth3.toFlat`, i.e. `Flat Bool`), and negation. So the gap
+logic linglib uses for presupposition is the `I`-free slice; the glut `I` is what
+trivalence excludes. The bilattice route to natural-language entailment,
+implicature, and presupposition is [schoter-1996] (see `Studies.Schoter1996`).
 
 ## Main results
 
-* `FOUR` — Belnap's four-valued bilattice, `(for, against)` pairs over `Bool`
-* `FOUR.tLE`/`kLE`/`neg`/`conf` — truth & knowledge orders, negation, conflation
-* `FOUR.Consistent` — the non-glut fragment `x ≤_k −x` (`= x ≠ I`)
-* `Fitting1994.tLE_ofTruth3`, `kLE_ofTruth3`, `neg_ofTruth3` — `Truth3` is the
-  consistent fragment of `FOUR` as a bilattice (both orders + negation)
+* `Fitting1994.ofTruth3` — the embedding `Truth3 → FOUR`
+* `Fitting1994.ofTruth3_consistent`, `consistent_range` — its image is exactly
+  the consistent fragment
+* `tLE_ofTruth3`, `kLE_ofTruth3`, `neg_ofTruth3` — `Truth3` is the consistent
+  fragment of `FOUR` as a bilattice (both orders + negation)
 -/
 
-open Core.Duality
+open Core.Duality (Truth3)
+open Bilattice (FOUR)
+open Bilattice.Evidential (tLE kLE neg)
+open Bilattice.FOUR (U T F Consistent)
 
 namespace Fitting1994
-
-/-- Belnap's four-valued bilattice `FOUR`, as `(for, against)` pairs over `Bool`
-(membership in the true- / false-extension). -/
-abbrev FOUR := Bool × Bool
-
-namespace FOUR
-
-/-- `⊥`: neither true nor false — no information (a truth-value gap). -/
-def U : FOUR := (false, false)
-/-- `true`. -/
-def T : FOUR := (true, false)
-/-- `false`. -/
-def F : FOUR := (false, true)
-/-- `⊤`: both true and false — inconsistent (a truth-value glut). -/
-def I : FOUR := (true, true)
-
-/-- Truth order: `x ≤_t y` iff more evidence-for and less evidence-against. -/
-@[reducible] def tLE (x y : FOUR) : Prop := x.1 ≤ y.1 ∧ y.2 ≤ x.2
-/-- Knowledge order: `x ≤_k y` iff more evidence both ways (subset of info). -/
-@[reducible] def kLE (x y : FOUR) : Prop := x.1 ≤ y.1 ∧ x.2 ≤ y.2
-/-- Negation: truth inversion, swaps the two coordinates (`true ↔ false`). -/
-def neg (x : FOUR) : FOUR := (x.2, x.1)
-/-- Conflation `−`: knowledge inversion, `(a,b) ↦ (¬b, ¬a)` (swaps `⊥ ↔ ⊤`). -/
-def conf (x : FOUR) : FOUR := (!x.2, !x.1)
-
-/-- The *consistent* (non-glut) fragment: information does not exceed its own
-conflation, `x ≤_k −x` — equivalently `x ≠ I` ([fitting-1994]). -/
-@[reducible] def Consistent (x : FOUR) : Prop := kLE x (conf x)
-
-@[simp] theorem consistent_iff (x : FOUR) : Consistent x ↔ x ≠ I := by
-  obtain ⟨a, b⟩ := x; cases a <;> cases b <;> decide
-
-end FOUR
-
-open FOUR
 
 /-- The embedding of `Truth3` (Kleene-3) into `FOUR`: `indet ↦ ⊥`, `true ↦ T`,
 `false ↦ F`. Its image is exactly the consistent fragment. -/
@@ -81,7 +43,7 @@ def ofTruth3 : Truth3 → FOUR
   | .false => F
 
 theorem ofTruth3_injective : Function.Injective ofTruth3 := by
-  intro a b h; cases a <;> cases b <;> simp_all [ofTruth3, U, T, F]
+  intro a b; cases a <;> cases b <;> decide
 
 theorem ofTruth3_consistent (a : Truth3) : Consistent (ofTruth3 a) := by
   cases a <;> decide

--- a/Linglib/Studies/Schoter1996.lean
+++ b/Linglib/Studies/Schoter1996.lean
@@ -1,0 +1,88 @@
+import Linglib.Core.Logic.Bilattice
+import Mathlib.Order.Fin.Basic
+
+/-!
+# Schöter's evidential bilattices: `PRESUP` and the defeasible progression
+[schoter-1996]
+
+[schoter-1996]'s Evidential Bilattice Logic analyzes natural-language entailment,
+implicature, and presupposition by climbing a progression of evidential
+bilattices `S ⊙ S` (`Bilattice.Evidential`): `classical ⊂` Kleene-3 `⊂ FOUR ⊂
+PRESUP`. A value is a pair `(for, against)` of degrees of evidence drawn from a
+chain `S`.
+
+This file is the second consumer of the `Bilattice` substrate (the first is
+`Studies.Fitting1994`, which shows Kleene-3 = the consistent fragment of `FOUR`).
+It adds the top of Schöter's progression:
+
+* **`PRESUP := Evidential (Fin 3)`** — evidence from the 3-chain `0 < ½ < 1`,
+  adding *defeasible* (presumed) values `P⁺`/`P⁻` above `FOUR`.
+* **`embed : FOUR → PRESUP`** — `FOUR` is a sub-bilattice of `PRESUP`
+  (order-preserving in both `≤_t` and `≤_k`): Schöter's "`FOUR` is a sublattice
+  of all bilattices."
+* the presupposition gap `U` and a defeasible presumption `P⁺` are both
+  *consistent* (non-glut); only the overdefined `I` is excluded — so the
+  gap-based presupposition logic survives and gains a defeasible layer.
+
+Scope: the value space and the progression. Schöter's inference apparatus
+(assertion/evaluation/inference, evidential links, the implemented engine,
+`FOEBL`/`FOMEBL`) is out of scope.
+-/
+
+open Bilattice
+
+namespace Schoter1996
+
+/-- Schöter's `PRESUP`: the evidential bilattice over the 3-chain `Fin 3 ~
+{0, ½, 1}` — `FOUR` with defeasible/presumed values added. -/
+abbrev PRESUP := Evidential (Fin 3)
+
+namespace PRESUP
+
+/-- `⊥`: no information (a presupposition gap). -/
+def U : PRESUP := (0, 0)
+/-- Definite truth (full evidence for, none against). -/
+def T : PRESUP := (2, 0)
+/-- Definite falsity. -/
+def F : PRESUP := (0, 2)
+/-- Inconsistent / overdefined (a glut). -/
+def I : PRESUP := (2, 2)
+/-- Presumably true: defeasible (`½`) evidence for, none against. -/
+def Pplus : PRESUP := (1, 0)
+/-- Presumably false. -/
+def Pminus : PRESUP := (0, 1)
+
+/-- Conflation on `PRESUP`, complementing on the chain by `Fin.rev`. -/
+@[reducible] def conf (x : PRESUP) : PRESUP := Evidential.conf Fin.rev x
+/-- The consistent (non-glut) fragment of `PRESUP`. -/
+@[reducible] def Consistent (x : PRESUP) : Prop := Evidential.Consistent Fin.rev x
+
+end PRESUP
+
+/-- `Bool ↪ Fin 3`: `false ↦ 0` (no evidence), `true ↦ 2` (full evidence). -/
+def boolToFin3 : Bool → Fin 3 := fun b => if b then 2 else 0
+
+/-- The embedding of `FOUR` into `PRESUP` (definite values only). -/
+def embed : FOUR → PRESUP := Prod.map boolToFin3 boolToFin3
+
+/-- **`FOUR ⊂ PRESUP`, truth order**: the embedding preserves and reflects `≤_t`. -/
+theorem embed_tLE (x y : FOUR) :
+    Evidential.tLE x y ↔ Evidential.tLE (embed x) (embed y) := by
+  obtain ⟨xa, xb⟩ := x; obtain ⟨ya, yb⟩ := y
+  cases xa <;> cases xb <;> cases ya <;> cases yb <;> decide
+
+/-- **`FOUR ⊂ PRESUP`, knowledge order**: the embedding preserves and reflects `≤_k`. -/
+theorem embed_kLE (x y : FOUR) :
+    Evidential.kLE x y ↔ Evidential.kLE (embed x) (embed y) := by
+  obtain ⟨xa, xb⟩ := x; obtain ⟨ya, yb⟩ := y
+  cases xa <;> cases xb <;> cases ya <;> cases yb <;> decide
+
+/-- A presupposition gap (`U`) and a defeasible presumption (`P⁺`) are both
+*consistent*; only the overdefined glut `I` is excluded. So `PRESUP` keeps the
+gap-based presupposition logic and layers defeasible values on top. -/
+theorem gap_and_presumption_consistent :
+    PRESUP.Consistent PRESUP.U ∧ PRESUP.Consistent PRESUP.Pplus
+      ∧ ¬ PRESUP.Consistent PRESUP.I := by
+  decide
+
+end Schoter1996

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -33581,8 +33581,8 @@
   pages     = {65--105},
   doi       = {10.1007/BF00215627},
   subfield  = {semantics/presupposition},
-  role      = {cited},
-  sources   = {Studies/Fitting1994.lean}
+  role      = {formalized},
+  sources   = {Studies/Fitting1994.lean;Studies/Schoter1996.lean}
 }
 
 @article{von-kutschera-1997,


### PR DESCRIPTION
Graduate the evidential-bilattice substrate to the theory layer, now that a second consumer exists (linglib's "≥2 Studies → theory layer").

- `Core/Logic/Bilattice.lean`: `Evidential S := S × S` over a chain — truth/knowledge orders, negation (`= Prod.swap`), conflation, and the consistent (non-glut) fragment; `FOUR := Evidential Bool`.
- `Studies/Schoter1996.lean` ([schoter-1996], NEW): `PRESUP := Evidential (Fin 3)`; the `FOUR ⊂ PRESUP` progression (`embed`); gap/presumption consistency.
- `Studies/Fitting1994.lean`: re-pointed onto the shared substrate (drops its inline `FOUR`).

No general `Bilattice` class yet — the concrete construction suffices for two consumers; the class waits for the representation theorem (`interlaced ⟹ L₁ ⊙ L₂`), per the spec.
