### PR TITLE
feat(Core/Logic/Bilattice): distributive representation theorem

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -32,8 +32,9 @@ import Linglib.Typology.Pronoun.WALS
 import Linglib.Typology.Evidentiality
 import Linglib.Core.Logic.FactorsThroughOn
 import Linglib.Core.Logic.Truth3
-import Linglib.Core.Logic.Bilattice
-import Linglib.Core.Logic.TwistProduct
+import Linglib.Core.Logic.Bilattice.Basic
+import Linglib.Core.Logic.Bilattice.TwistProduct
+import Linglib.Core.Logic.Bilattice.Representation
 import Linglib.Core.Logic.Consequence
 import Linglib.Core.Logic.ThreeValuedLogic
 import Linglib.Core.Logic.Bilateral.Defs

--- a/Linglib/Core/Logic/Bilattice/Basic.lean
+++ b/Linglib/Core/Logic/Bilattice/Basic.lean
@@ -1,0 +1,82 @@
+import Mathlib.Order.Basic
+import Mathlib.Data.Bool.Basic
+
+/-!
+# Evidential bilattices over a chain
+[fitting-1994] [schoter-1996]
+
+A *bilattice* carries two orders on one carrier — a *truth* order `≤_t` and an
+*information/knowledge* order `≤_k` ([fitting-1994]). The *evidential* bilattices
+([schoter-1996]) are the ones of the form `S ⊙ S` for a chain `S`: a value is a
+pair `(for, against)` of degrees of evidence, with
+
+* `≤_t` truer  = more evidence-for, less evidence-against;
+* `≤_k` more informative = more evidence both ways;
+* `neg` (truth inversion) swaps the two coordinates;
+* `conf` (knowledge inversion, the *conflation*) complements each coordinate.
+
+With `S = Bool` this is Belnap's `FOUR`; with `S = Fin 3` (the chain `0 < ½ < 1`)
+it is [schoter-1996]'s 9-valued `PRESUP` (see `Studies.Schoter1996`). This file
+is the shared substrate; concrete bilattices and their linguistic uses live in
+the consuming `Studies` files.
+
+## Main definitions
+
+* `Bilattice.Evidential S := S × S` — the evidential bilattice over a chain `S`
+* `Evidential.tLE`/`kLE`/`neg`/`conf`/`Consistent` — the two orders, negation,
+  conflation, and the consistent (`x ≤_k −x`, non-glut) fragment
+* `Bilattice.FOUR := Evidential Bool` — Belnap's four-valued bilattice
+-/
+
+namespace Bilattice
+
+/-- The evidential bilattice over a chain `S`: values are `(for, against)`
+pairs ([schoter-1996]'s `S ⊙ S`). -/
+abbrev Evidential (S : Type*) := S × S
+
+namespace Evidential
+
+variable {S : Type*} [Preorder S]
+
+/-- Truth order: more evidence-for and less evidence-against. -/
+@[reducible] def tLE (x y : Evidential S) : Prop := x.1 ≤ y.1 ∧ y.2 ≤ x.2
+/-- Knowledge order: more evidence both ways. -/
+@[reducible] def kLE (x y : Evidential S) : Prop := x.1 ≤ y.1 ∧ x.2 ≤ y.2
+/-- Negation: truth inversion, swaps the coordinates. -/
+def neg : Evidential S → Evidential S := Prod.swap
+/-- Conflation `−`: knowledge inversion, complements each coordinate by `compl`,
+which is intended to be the order-reversing involution on the chain `S`
+(`(! ·)` for `Bool`, `Fin.rev` for `Fin n`). -/
+def conf (compl : S → S) (x : Evidential S) : Evidential S := (compl x.2, compl x.1)
+/-- The consistent (non-glut) fragment: `x ≤_k −x` ([fitting-1994]). -/
+@[reducible] def Consistent (compl : S → S) (x : Evidential S) : Prop :=
+  kLE x (conf compl x)
+
+end Evidential
+
+/-- Belnap's four-valued bilattice `FOUR = Bool ⊙ Bool`, `(for, against)` over
+`Bool`. -/
+abbrev FOUR := Evidential Bool
+
+namespace FOUR
+
+/-- `⊥`: neither — no information (a truth-value gap). -/
+def U : FOUR := (false, false)
+/-- `true`. -/
+def T : FOUR := (true, false)
+/-- `false`. -/
+def F : FOUR := (false, true)
+/-- `⊤`: both — inconsistent (a truth-value glut). -/
+def I : FOUR := (true, true)
+
+/-- Conflation on `FOUR` (Boolean complement). -/
+@[reducible] def conf (x : FOUR) : FOUR := Evidential.conf (! ·) x
+/-- The consistent (non-glut) fragment of `FOUR` — equivalently `x ≠ I`. -/
+@[reducible] def Consistent (x : FOUR) : Prop := Evidential.Consistent (! ·) x
+
+@[simp] theorem consistent_iff (x : FOUR) : Consistent x ↔ x ≠ I := by
+  obtain ⟨a, b⟩ := x; cases a <;> cases b <;> decide
+
+end FOUR
+
+end Bilattice

--- a/Linglib/Core/Logic/Bilattice/Representation.lean
+++ b/Linglib/Core/Logic/Bilattice/Representation.lean
@@ -1,0 +1,98 @@
+import Mathlib.Order.Hom.Basic
+import Mathlib.Order.Interval.Set.Basic
+import Mathlib.Order.Disjoint
+
+/-!
+# Representation of distributive bilattices
+[avron-1996] [arieli-avron-1996]
+
+Constructive direction (`Core.Logic.TwistProduct`): the twist product `L ⊙ R` is
+an interlaced bilattice. This file proves the **converse / representation theorem**
+for the *distributive* case (Ginsberg–Fitting; [avron-1996] Thm 4.3 generalizes it
+to all interlaced bilattices).
+
+Presented *knowledge-first*: a distributive bilattice is a bounded distributive
+lattice `B` — the **knowledge** lattice `(≤_k, ⊗ = ⊓, ⊕ = ⊔, ⊥, ⊤)` — together
+with the two **truth bounds** `t, f`, which are *complementary* (`IsCompl t f`:
+`t ⊗ f = ⊥`, `t ⊕ f = ⊤`). The truth order is recovered from the decomposition.
+
+The representation: `B` decomposes as the twist product `(Iic t) ⊙ (Iic f)` of
+the two principal ideals, via `x ↦ (x ⊗ t, x ⊗ f)` with inverse `(a, b) ↦ a ⊕ b`
+([avron-1996] Cor 3.8(1), Thm 4.3). The factors `Iic t = {x | ⊥ ≤_t x}` and
+`Iic f = {x | x ≤_t ⊥}` are [avron-1996]'s `L_B`, `R_B`.
+
+## Main results
+
+* `Bilattice.decompose` — the knowledge-order isomorphism `B ≃o Iic t × Iic f`
+* `Bilattice.tLE` / `tLE_iff_decompose` — the recovered truth order is the twist
+  order on the factors (first factor up, second factor down): the bilattice
+  representation (cf. `Core.Logic.TwistProduct.tLE`)
+-/
+
+variable {B : Type*}
+
+namespace Bilattice
+
+section Decompose
+
+variable [DistribLattice B] [BoundedOrder B] {t f : B}
+
+/-- The knowledge-order decomposition of a distributive bilattice: `x ↦ (x ⊓ t,
+x ⊓ f)` is an order isomorphism `B ≃o Iic t × Iic f` ([avron-1996] Thm 4.3,
+distributive case), with inverse `(a, b) ↦ a ⊔ b`. -/
+def decompose (h : IsCompl t f) : B ≃o (Set.Iic t × Set.Iic f) where
+  toFun x := (⟨x ⊓ t, inf_le_right⟩, ⟨x ⊓ f, inf_le_right⟩)
+  invFun p := p.1.1 ⊔ p.2.1
+  left_inv x := by
+    show x ⊓ t ⊔ x ⊓ f = x
+    rw [← inf_sup_left, h.sup_eq_top, inf_top_eq]
+  right_inv p := by
+    obtain ⟨⟨a, ha⟩, ⟨b, hb⟩⟩ := p
+    have hat : a ⊓ t = a := inf_eq_left.mpr ha
+    have hbf : b ⊓ f = b := inf_eq_left.mpr hb
+    have hbt : b ⊓ t = ⊥ := le_bot_iff.mp <|
+      le_trans (inf_le_inf_right t hb) (by rw [inf_comm]; exact h.inf_eq_bot.le)
+    have haf : a ⊓ f = ⊥ := le_bot_iff.mp <|
+      le_trans (inf_le_inf_right f ha) h.inf_eq_bot.le
+    refine Prod.ext (Subtype.ext ?_) (Subtype.ext ?_)
+    · show (a ⊔ b) ⊓ t = a
+      rw [inf_sup_right, hat, hbt, sup_bot_eq]
+    · show (a ⊔ b) ⊓ f = b
+      rw [inf_sup_right, haf, hbf, bot_sup_eq]
+  map_rel_iff' {x y} := by
+    constructor
+    · rintro ⟨h1, h2⟩
+      calc x = x ⊓ t ⊔ x ⊓ f := by rw [← inf_sup_left, h.sup_eq_top, inf_top_eq]
+        _ ≤ y ⊓ t ⊔ y ⊓ f := sup_le_sup h1 h2
+        _ = y := by rw [← inf_sup_left, h.sup_eq_top, inf_top_eq]
+    · intro hxy
+      exact ⟨inf_le_inf_right t hxy, inf_le_inf_right f hxy⟩
+
+theorem decompose_apply (h : IsCompl t f) (x : B) :
+    decompose h x = (⟨x ⊓ t, inf_le_right⟩, ⟨x ⊓ f, inf_le_right⟩) := rfl
+
+theorem decompose_symm_apply (h : IsCompl t f) (p : Set.Iic t × Set.Iic f) :
+    (decompose h).symm p = p.1.1 ⊔ p.2.1 := rfl
+
+end Decompose
+
+section Truth
+
+variable [DistribLattice B] [BoundedOrder B] (t f : B)
+
+/-- The recovered **truth order** on a distributive bilattice: `x ≤_t y` iff `x`
+has less evidence-for-truth (`⊓ t`) and more evidence-for-falsity (`⊓ f`)
+([avron-1996] Def 2.4(ii)). -/
+def tLE (x y : B) : Prop := x ⊓ t ≤ y ⊓ t ∧ y ⊓ f ≤ x ⊓ f
+
+/-- The recovered truth order *is* the twist order on the decomposition factors
+(`Iic t` up, `Iic f` down): this exhibits `B` as the twist product
+`(Iic t) ⊙ (Iic f)`, i.e. the bilattice representation. -/
+theorem tLE_iff_decompose {t f : B} (h : IsCompl t f) (x y : B) :
+    tLE t f x y ↔
+      (decompose h x).1 ≤ (decompose h y).1 ∧ (decompose h y).2 ≤ (decompose h x).2 :=
+  Iff.rfl
+
+end Truth
+
+end Bilattice

--- a/Linglib/Core/Logic/Bilattice/TwistProduct.lean
+++ b/Linglib/Core/Logic/Bilattice/TwistProduct.lean
@@ -1,0 +1,165 @@
+import Mathlib.Order.Lattice
+import Mathlib.Order.BoundedOrder.Basic
+
+/-!
+# The Ginsberg–Fitting bilattice product (twist structure)
+[avron-1996] [arieli-avron-1996]
+
+A *bilattice* carries two lattice orders on one carrier — a *truth* order `≤_t`
+and a *knowledge/information* order `≤_k` — with the four operations monotone
+w.r.t. *both* (an *interlaced* bilattice, [avron-1996] Def 2.1). The fundamental
+construction is the **twist product** (Ginsberg–Fitting product) `L ⊙ R` of two
+bounded lattices ([avron-1996] Def 2.4): the carrier is `L × R`, where a value
+`(a, b)` records evidence *for* (`a ∈ L`) and *against* (`b ∈ R`).
+
+* the **knowledge** order `≤_k` is the product order on `L × R` (more evidence
+  both ways) — i.e. mathlib's `Prod` lattice, with `⊗ = ⊓`, `⊕ = ⊔`;
+* the **truth** order `≤_t` dualizes the second factor (more for, less against);
+  its operations `∧`/`∨` are `tInf`/`tSup`.
+
+Following the project's plain-`Prop` convention (and avoiding the `Prod`-instance
+clash of putting two `Lattice`s on one type), the knowledge structure *is*
+mathlib's `Prod` lattice (`≤`, `⊓`, `⊔`), while the truth structure is the named
+relations/operations `tLE`, `tInf`, `tSup`.
+
+This file proves the **constructive half** of the structure theory ([avron-1996]
+Thm 2.5): the twist product is an interlaced bilattice — the truth relations form
+a lattice, and all four operations are interlaced.
+
+`Evidential S` (`Core.Logic.Bilattice`) is the diagonal case `S ⊙ S`; `FOUR =
+Bool ⊙ Bool`, `PRESUP = Fin 3 ⊙ Fin 3`.
+
+## Main results
+
+* `Bilattice.TwistProduct.tLE`/`tInf`/`tSup` — the truth order, meet `∧`, join `∨`
+* `tInf_isGLB`-style lemmas (`tInf_tLE_left`, `le_tInf`, …) — the truth lattice
+* `tInf_kmono`/`tSup_kmono`/`kInf_tmono`/`kSup_tmono` — the four interlacing laws
+  (truth ops are `≤_k`-monotone; knowledge ops `⊓`/`⊔` are `≤_t`-monotone)
+* `neg`, `neg_neg`, `neg_tLE`, `neg_kLE` — Ginsberg negation on the diagonal `L ⊙ L`
+
+## TODO
+
+The **representation theorem** ([avron-1996] Thm 4.3), the converse of Thm 2.5:
+every interlaced bilattice `B` is isomorphic to `L_B ⊙ R_B` for bounded lattices
+`L_B = {x | ⊥ ≤_t x}`, `R_B = {x | x ≤_t ⊥}`, via `g x = (x ∨ ⊥, x ∧ ⊥)` with
+inverse `(a, b) ↦ a ⊕ b`; `L_B`, `R_B` are unique up to isomorphism, and with a
+negation `L_B ≅ R_B`. This needs an abstract `InterlacedBilattice` class and the
+interlacing-algebra chain (Avron Prop 3.2 → Cor 3.8 → Thm 4.3); it is the theorem
+that earns the abstract class.
+-/
+
+universe u v
+
+variable {L : Type u} {R : Type v}
+
+namespace Bilattice.TwistProduct
+
+section Lattice
+
+variable [Lattice L] [Lattice R]
+
+/-- Truth order `≤_t` on `L × R`: more evidence-for, less evidence-against
+([avron-1996] Def 2.4(ii)). The knowledge order `≤_k` is the `Prod` order `≤`. -/
+def tLE (x y : L × R) : Prop := x.1 ≤ y.1 ∧ y.2 ≤ x.2
+
+/-- Truth meet `∧`: meet the evidence-for, join the evidence-against
+([avron-1996] Def 2.4(iv)). The knowledge meet `⊗` is the `Prod` meet `⊓`. -/
+def tInf (x y : L × R) : L × R := (x.1 ⊓ y.1, x.2 ⊔ y.2)
+
+/-- Truth join `∨`: join the evidence-for, meet the evidence-against
+([avron-1996] Def 2.4(iii)). The knowledge join `⊕` is the `Prod` join `⊔`. -/
+def tSup (x y : L × R) : L × R := (x.1 ⊔ y.1, x.2 ⊓ y.2)
+
+@[refl] theorem tLE_refl (x : L × R) : tLE x x := ⟨le_rfl, le_rfl⟩
+
+theorem tLE_trans {x y z : L × R} (h₁ : tLE x y) (h₂ : tLE y z) : tLE x z :=
+  ⟨le_trans h₁.1 h₂.1, le_trans h₂.2 h₁.2⟩
+
+theorem tLE_antisymm {x y : L × R} (h₁ : tLE x y) (h₂ : tLE y x) : x = y :=
+  Prod.ext (le_antisymm h₁.1 h₂.1) (le_antisymm h₂.2 h₁.2)
+
+/-! ### The truth order is a lattice -/
+
+theorem tInf_tLE_left (x y : L × R) : tLE (tInf x y) x := ⟨inf_le_left, le_sup_left⟩
+theorem tInf_tLE_right (x y : L × R) : tLE (tInf x y) y := ⟨inf_le_right, le_sup_right⟩
+theorem tLE_tInf {x y z : L × R} (h₁ : tLE z x) (h₂ : tLE z y) : tLE z (tInf x y) :=
+  ⟨le_inf h₁.1 h₂.1, sup_le h₁.2 h₂.2⟩
+
+theorem tLE_tSup_left (x y : L × R) : tLE x (tSup x y) := ⟨le_sup_left, inf_le_left⟩
+theorem tLE_tSup_right (x y : L × R) : tLE y (tSup x y) := ⟨le_sup_right, inf_le_right⟩
+theorem tSup_tLE {x y z : L × R} (h₁ : tLE x z) (h₂ : tLE y z) : tLE (tSup x y) z :=
+  ⟨sup_le h₁.1 h₂.1, le_inf h₁.2 h₂.2⟩
+
+end Lattice
+
+/-! ### Interlacing
+
+The four operations are monotone w.r.t. *both* orders ([avron-1996] Def 2.1(3)).
+The knowledge structure is mathlib's `Prod` lattice (`≤`, `⊓`, `⊔`); the truth
+operations are `tInf`/`tSup`. -/
+
+section Interlaced
+
+variable [Lattice L] [Lattice R]
+
+/-- **Interlacing 1**: the truth meet `∧` is `≤_k`-monotone. -/
+theorem tInf_kmono {x y : L × R} (z : L × R) (h : x ≤ y) : tInf x z ≤ tInf y z :=
+  ⟨inf_le_inf h.1 le_rfl, sup_le_sup h.2 le_rfl⟩
+
+/-- **Interlacing 2**: the truth join `∨` is `≤_k`-monotone. -/
+theorem tSup_kmono {x y : L × R} (z : L × R) (h : x ≤ y) : tSup x z ≤ tSup y z :=
+  ⟨sup_le_sup h.1 le_rfl, inf_le_inf h.2 le_rfl⟩
+
+/-- **Interlacing 3**: the knowledge meet `⊗ = ⊓` is `≤_t`-monotone. -/
+theorem kInf_tmono {x y : L × R} (z : L × R) (h : tLE x y) : tLE (x ⊓ z) (y ⊓ z) :=
+  ⟨inf_le_inf h.1 le_rfl, inf_le_inf h.2 le_rfl⟩
+
+/-- **Interlacing 4**: the knowledge join `⊕ = ⊔` is `≤_t`-monotone. -/
+theorem kSup_tmono {x y : L × R} (z : L × R) (h : tLE x y) : tLE (x ⊔ z) (y ⊔ z) :=
+  ⟨sup_le_sup h.1 le_rfl, sup_le_sup h.2 le_rfl⟩
+
+end Interlaced
+
+/-! ### Bounds
+
+With bounded factors the twist product has four extremes ([avron-1996]
+Def 2.4(vii)): truth bounds `t = (⊤, ⊥)`, `f = (⊥, ⊤)`, and knowledge bounds
+`⊤ = (⊤, ⊤)`, `⊥ = (⊥, ⊥)` (the latter are the `Prod` `BoundedOrder`). -/
+
+section Bounds
+
+variable [Lattice L] [Lattice R] [BoundedOrder L] [BoundedOrder R]
+
+/-- Truth top `t = (⊤, ⊥)` (maximal for, minimal against). -/
+def tTop : L × R := (⊤, ⊥)
+/-- Truth bottom `f = (⊥, ⊤)`. -/
+def tBot : L × R := (⊥, ⊤)
+
+theorem tLE_tTop (x : L × R) : tLE x tTop := ⟨le_top, bot_le⟩
+theorem tBot_tLE (x : L × R) : tLE tBot x := ⟨bot_le, le_top⟩
+
+end Bounds
+
+/-! ### Negation
+
+On the diagonal `L ⊙ L`, Ginsberg's negation swaps the coordinates: it reverses
+`≤_t`, preserves `≤_k`, and is an involution ([avron-1996] Thm 2.5(2)). -/
+
+section Negation
+
+/-- Ginsberg negation on `L ⊙ L`: swap evidence for/against. -/
+def neg (x : L × L) : L × L := (x.2, x.1)
+
+@[simp] theorem neg_neg (x : L × L) : neg (neg x) = x := rfl
+
+variable [Lattice L]
+
+/-- Negation reverses the truth order ([avron-1996] Def 2.3(ii)). -/
+theorem neg_tLE {x y : L × L} (h : tLE x y) : tLE (neg y) (neg x) := ⟨h.2, h.1⟩
+
+/-- Negation preserves the knowledge order ([avron-1996] Def 2.3(iii)). -/
+theorem neg_kLE {x y : L × L} (h : x ≤ y) : neg x ≤ neg y := ⟨h.2, h.1⟩
+
+end Negation
+
+end Bilattice.TwistProduct

--- a/Linglib/Studies/Fitting1994.lean
+++ b/Linglib/Studies/Fitting1994.lean
@@ -1,5 +1,5 @@
 import Linglib.Core.Logic.Truth3
-import Linglib.Core.Logic.Bilattice
+import Linglib.Core.Logic.Bilattice.Basic
 
 /-!
 # Kleene's three-valued logic as the consistent fragment of Belnap's FOUR

--- a/Linglib/Studies/Schoter1996.lean
+++ b/Linglib/Studies/Schoter1996.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.Bilattice
+import Linglib.Core.Logic.Bilattice.Basic
 import Mathlib.Order.Fin.Basic
 
 /-!


### PR DESCRIPTION
Every distributive bilattice is a twist product — the converse of #479 (Ginsberg–Fitting; [avron-1996] Thm 4.3, distributive case).

- `Bilattice/Representation.lean` (new): `decompose : B ≃o Iic t × Iic f` for a bounded distributive lattice `B` (the knowledge lattice) with complementary truth bounds `IsCompl t f`, via `x ↦ (x ⊓ t, x ⊓ f)`, inverse `(a,b) ↦ a ⊔ b`. The recovered truth order `tLE` is the twist order on the factors (`tLE_iff_decompose`).
- Promotes the bilattice files to `Core/Logic/Bilattice/`: `Bilattice.lean → Bilattice/Basic.lean`, `TwistProduct.lean → Bilattice/TwistProduct.lean`.
