### PR TITLE
feat(Semantics/Modality/Orthologic): Std typeclass frames + Orthoframe bridge

### DIFF
--- a/Linglib/Semantics/Modality/Orthologic/Frames.lean
+++ b/Linglib/Semantics/Modality/Orthologic/Frames.lean
@@ -57,8 +57,20 @@ variable {S : Type*}
     instance separately for each concrete frame. -/
 structure CompatFrame (S : Type*) where
   compat : S → S → Prop
-  compat_refl : ∀ x, compat x x
-  compat_symm : ∀ x y, compat x y ↔ compat y x
+  compat_refl : Std.Refl compat
+  compat_symm : Std.Symm compat
+
+namespace CompatFrame
+
+/-- Compatibility is reflexive (accessor for the bundled `Std.Refl`). -/
+theorem refl (F : CompatFrame S) (x : S) : F.compat x x := F.compat_refl.refl x
+
+/-- Compatibility is symmetric: `h.symm : F.compat y x` for `h : F.compat x y`
+    (mirrors `SimpleGraph.Adj.symm`). -/
+theorem compat.symm {F : CompatFrame S} {x y : S} (h : F.compat x y) : F.compat y x :=
+  F.compat_symm.symm x y h
+
+end CompatFrame
 
 /-! ### Orthocomplement negation and connectives -/
 
@@ -179,7 +191,7 @@ theorem orthoNeg_classical
   simp only [mem_orthoNeg]
   constructor
   · intro h hAx
-    exact h x (F.compat_refl x) hAx
+    exact h x (F.refl x) hAx
   · intro hNotA y hcompat hAy
     have heq := hClassical x y hcompat
     subst heq; exact hNotA hAy
@@ -187,8 +199,8 @@ theorem orthoNeg_classical
 /-- The identity compatibility frame: compat x y ↔ x = y. -/
 def identityFrame [DecidableEq S] : CompatFrame S where
   compat := λ x y => x = y
-  compat_refl := λ _ => rfl
-  compat_symm := λ _ _ => eq_comm
+  compat_refl := ⟨λ _ => rfl⟩
+  compat_symm := ⟨λ _ _ h => h.symm⟩
 
 instance [DecidableEq S] :
     DecidableRel (identityFrame (S := S)).compat := λ a b => by
@@ -213,17 +225,17 @@ def regularClosure (F : CompatFrame S) : ClosureOperator (Set S) where
   toFun A := { x | ∀ y, F.compat x y → ∃ z, F.compat y z ∧ z ∈ A }
   monotone' _ _ hAB _ hx y hy := by
     obtain ⟨z, hyz, hz⟩ := hx y hy; exact ⟨z, hyz, hAB hz⟩
-  le_closure' _ x hx _ hy := ⟨x, (F.compat_symm _ _).mp hy, hx⟩
+  le_closure' _ x hx _ hy := ⟨x, hy.symm, hx⟩
   idempotent' A := by
     apply Set.eq_of_subset_of_subset
     · intro x hx y hy
       obtain ⟨z, hyz, hz⟩ := hx y hy
-      have hzy : F.compat z y := (F.compat_symm _ _).mp hyz
+      have hzy : F.compat z y := hyz.symm
       obtain ⟨w, hyw, hwA⟩ := hz y hzy
       exact ⟨w, hyw, hwA⟩
     · intro x hx y hy
       obtain ⟨z, hyz, hz⟩ := hx y hy
-      exact ⟨z, hyz, λ y' hy' => ⟨z, (F.compat_symm _ _).mp hy', hz⟩⟩
+      exact ⟨z, hyz, λ y' hy' => ⟨z, hy'.symm, hz⟩⟩
   IsClosed A := IsRegular F A
   isClosed_iff {A} := by
     constructor
@@ -237,7 +249,7 @@ def regularClosure (F : CompatFrame S) : ClosureOperator (Set S) where
           obtain ⟨z, hyz, hzA⟩ := hx y hxy
           exact hy z hyz hzA
       · intro x hx _ hy
-        exact ⟨x, (F.compat_symm _ _).mp hy, hx⟩
+        exact ⟨x, hy.symm, hx⟩
     · -- c_◇(A) = A → IsRegular F A
       intro hEq x
       by_cases h : x ∈ A

--- a/Linglib/Semantics/Modality/Orthologic/Modal.lean
+++ b/Linglib/Semantics/Modality/Orthologic/Modal.lean
@@ -51,7 +51,11 @@ namespace Orthologic
     Per-instance frames may witness all three conditions. -/
 structure ModalCompatFrame (S : Type*) extends CompatFrame S where
   access : S → S → Prop
-  access_refl : ∀ x, access x x
+  access_refl : Std.Refl access
+
+/-- Accessibility is reflexive (accessor for the bundled `Std.Refl`). -/
+theorem ModalCompatFrame.accessRefl {S : Type*} (F : ModalCompatFrame S) (x : S) :
+    F.access x x := F.access_refl.refl x
 
 /-- Box operator: `□A = {x | R(x) ⊆ A}`.
     [holliday-mandelkern-2024] eq. (3). -/
@@ -101,7 +105,7 @@ instance diamond_apply_decidable {S : Type*} [Fintype S] (F : ModalCompatFrame S
 theorem T_axiom_general {S : Type*}
     (F : ModalCompatFrame S) (A : Set S) (x : S)
     (h : x ∈ box F A) : x ∈ A :=
-  h x (F.access_refl x)
+  h x (F.accessRefl x)
 
 -- ════════════════════════════════════════════════════
 -- § 3. R-Regularity, Knowability, Epistemic Frames
@@ -179,7 +183,7 @@ theorem wittgensteinLaw {S : Type*} (F : ModalCompatFrame S) (hK : IsKnowable F)
   -- `compat x y`. But `◇A = orthoNeg (box (orthoNeg A))`, so `x ∈ ◇A`
   -- forbids any compat-witness in `box (orthoNeg A)`. Contradiction.
   have hxCompatY : F.toCompatFrame.compat x y :=
-    hy y (F.access_refl y) y (F.toCompatFrame.compat_refl y)
+    hy y (F.accessRefl y) y (F.toCompatFrame.refl y)
   exact hxDiam y hxCompatY hyBox
 
 namespace EpistemicCompatFrame

--- a/Linglib/Semantics/Modality/Orthologic/RegularProp.lean
+++ b/Linglib/Semantics/Modality/Orthologic/RegularProp.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Modality.Orthologic.Frames
 import Linglib.Core.Order.Ortholattice
+import Linglib.Core.Order.Orthoframe
 import Mathlib.Data.SetLike.Basic
 
 /-!
@@ -60,11 +61,11 @@ theorem orthoNeg_isRegular (F : CompatFrame S) (A : Set S) :
   · exact Or.inl h
   · right
     rw [mem_orthoNeg] at h
-    push_neg at h
+    push Not at h
     obtain ⟨y, hxy, hyA⟩ := h
     refine ⟨y, hxy, fun z hyz hzN => ?_⟩
     rw [mem_orthoNeg] at hzN
-    exact hzN y ((F.compat_symm _ _).mp hyz) hyA
+    exact hzN y (hyz.symm) hyA
 
 /-- Regular sets are closed under intersection. -/
 theorem inter_isRegular {F : CompatFrame S} {A B : Set S}
@@ -91,7 +92,7 @@ theorem disj_isRegular (F : CompatFrame S) (A B : Set S) :
 /-- The empty set is regular (vacuously: take `y = x` by reflexivity). -/
 theorem empty_isRegular (F : CompatFrame S) : IsRegular F (∅ : Set S) := by
   intro x
-  exact Or.inr ⟨x, F.compat_refl x, fun _ _ h => h.elim⟩
+  exact Or.inr ⟨x, F.refl x, fun _ _ h => h.elim⟩
 
 /-- The full set is regular (trivially). -/
 theorem univ_isRegular (F : CompatFrame S) : IsRegular F (Set.univ : Set S) :=
@@ -109,15 +110,15 @@ theorem orthoNeg_orthoNeg_of_isRegular (F : CompatFrame S) {A : Set S}
       rw [mem_orthoNeg] at hx
       have hyN : ¬ y ∈ orthoNeg F A := hx y hxy
       rw [mem_orthoNeg] at hyN
-      push_neg at hyN
+      push Not at hyN
       obtain ⟨z, hyz, hzA⟩ := hyN
       exact hy z hyz hzA
   · intro x hxA
     rw [mem_orthoNeg]
     intro y hxy
     rw [mem_orthoNeg]
-    push_neg
-    exact ⟨x, (F.compat_symm _ _).mp hxy, hxA⟩
+    push Not
+    exact ⟨x, hxy.symm, hxA⟩
 
 -- ════════════════════════════════════════════════════
 -- § 2. The Bundled Type RegularProp F
@@ -198,12 +199,12 @@ instance : Lattice (RegularProp F) where
     intro x hxA
     show x ∈ disj F (A : Set S) (B : Set S)
     intro y hxy hy
-    exact hy.1 x ((F.compat_symm _ _).mp hxy) hxA
+    exact hy.1 x (hxy.symm) hxA
   le_sup_right A B := by
     intro x hxB
     show x ∈ disj F (A : Set S) (B : Set S)
     intro y hxy hy
-    exact hy.2 x ((F.compat_symm _ _).mp hxy) hxB
+    exact hy.2 x (hxy.symm) hxB
   sup_le A B C hAC hBC := by
     intro x hx
     -- hx : x ∈ disj F A.carrier B.carrier
@@ -216,7 +217,7 @@ instance : Lattice (RegularProp F) where
       rcases habs with hyN | hyN
       all_goals
         rw [mem_orthoNeg] at hyN
-        push_neg at hyN
+        push Not at hyN
       · obtain ⟨z, hyz, hzA⟩ := hyN
         exact hy z hyz (hAC hzA)
       · obtain ⟨z, hyz, hzB⟩ := hyN
@@ -238,7 +239,7 @@ instance instOrthocomplementedLattice : OrthocomplementedLattice (RegularProp F)
     exact hxBN y hxy (hAB hyA)
   inf_compl_le_bot A := by
     intro x hx
-    exact hx.2 x (F.compat_refl x) hx.1
+    exact hx.2 x (F.refl x) hx.1
   top_le_sup_compl A := by
     intro x _
     show x ∈ disj F (A : Set S) (orthoNeg F (A : Set S))
@@ -246,8 +247,58 @@ instance instOrthocomplementedLattice : OrthocomplementedLattice (RegularProp F)
     -- hy : y ∈ orthoNeg F A ∩ orthoNeg F (orthoNeg F A)
     -- Apply hy.2 (= y ∈ orthoNeg² A) at z = y via reflexivity:
     -- y ∉ orthoNeg F A. Contradicts hy.1.
-    exact hy.2 y (F.compat_refl y) hy.1
+    exact hy.2 y (F.refl y) hy.1
 
 end RegularProp
+
+/-! ### Bridge to the abstract orthoframe construction -/
+
+open Order
+
+/-- The orthogonality (incompatibility) orthoframe of a compatibility frame:
+    `x ⊥ y ↔ ¬ compat x y`. Symmetry and irreflexivity come from symmetry and
+    reflexivity of `compat`. -/
+def CompatFrame.toOrthoframe (F : CompatFrame S) : Orthoframe S where
+  ortho x y := ¬ F.compat x y
+  ortho_symm := ⟨fun _ _ h hc => h hc.symm⟩
+  ortho_irrefl := ⟨fun a h => h (F.refl a)⟩
+
+/-- `orthoNeg` is the `upperPolar` of the orthogonality relation. -/
+theorem orthoNeg_eq_upperPolar (F : CompatFrame S) (A : Set S) :
+    orthoNeg F A = upperPolar F.toOrthoframe.ortho A := by
+  ext x
+  constructor
+  · intro hx a ha hc
+    exact hx a hc.symm ha
+  · intro hx y hxy hyA
+    exact hx hyA hxy.symm
+
+/-- `IsRegular` is the double-orthonegation fixed-point condition. -/
+theorem isRegular_iff_orthoNeg_orthoNeg (F : CompatFrame S) (A : Set S) :
+    IsRegular F A ↔ orthoNeg F (orthoNeg F A) = A :=
+  ⟨orthoNeg_orthoNeg_of_isRegular F, fun h => h ▸ orthoNeg_isRegular F _⟩
+
+/-- The `◇`-regular sets of `F` are exactly the concept extents of its
+    orthogonality relation; Holliday–Mandelkern's Proposition 4.8 is mathlib's
+    `upperPolar_lowerPolar_upperPolar` (see `Core.Order.Orthoframe`). -/
+theorem isRegular_iff_isExtent (F : CompatFrame S) (A : Set S) :
+    IsRegular F A ↔ IsExtent F.toOrthoframe.ortho A := by
+  rw [isRegular_iff_orthoNeg_orthoNeg, isExtent_iff,
+      orthoNeg_eq_upperPolar, orthoNeg_eq_upperPolar,
+      upperPolar_eq_lowerPolar F.toOrthoframe.ortho]
+
+/-- **The bridge.** `RegularProp F` is order-isomorphic to the ortholattice of
+    regular propositions of its orthogonality orthoframe (`Orthoframe.Reg`) —
+    i.e. the concept extents of `¬ compat`. The hand-built
+    `OrthocomplementedLattice (RegularProp F)` and the abstract `Concept`-based
+    one coincide. -/
+def RegularProp.equivReg (F : CompatFrame S) :
+    RegularProp F ≃o Orthoframe.Reg F.toOrthoframe where
+  toFun A := Concept.ofIsExtent F.toOrthoframe.ortho A.carrier
+    ((isRegular_iff_isExtent F A.carrier).mp A.regular')
+  invFun c := ⟨c.extent, (isRegular_iff_isExtent F c.extent).mpr c.isExtent_extent⟩
+  left_inv := fun _ => rfl
+  right_inv := fun _ => Concept.ext rfl
+  map_rel_iff' := Iff.rfl
 
 end Orthologic

--- a/Linglib/Studies/HollidayMandelkern2024.lean
+++ b/Linglib/Studies/HollidayMandelkern2024.lean
@@ -102,8 +102,8 @@ instance : DecidableRel Poss5.compat := fun a b => by
 /-- The path compatibility frame: adjacent possibilities are compatible. -/
 def pathFrame : CompatFrame Poss5 where
   compat := Poss5.compat
-  compat_refl := fun x => by cases x <;> simp [Poss5.compat]
-  compat_symm := fun x y => by cases x <;> cases y <;> simp [Poss5.compat]
+  compat_refl := ⟨fun x => by cases x <;> simp [Poss5.compat]⟩
+  compat_symm := ⟨fun x y => by cases x <;> cases y <;> simp [Poss5.compat]⟩
 
 instance : DecidableRel pathFrame.compat :=
   inferInstanceAs (DecidableRel Poss5.compat)
@@ -293,7 +293,7 @@ instance : DecidableRel Poss5.epistAccess := fun a b => by
 def epistemicScale : ModalCompatFrame Poss5 where
   toCompatFrame := pathFrame
   access := Poss5.epistAccess
-  access_refl := fun x => by cases x <;> simp [Poss5.epistAccess]
+  access_refl := ⟨fun x => by cases x <;> simp [Poss5.epistAccess]⟩
 
 instance : DecidableRel epistemicScale.access :=
   inferInstanceAs (DecidableRel Poss5.epistAccess)


### PR DESCRIPTION
Modernize `CompatFrame`/`ModalCompatFrame` to bundle `Std.Refl`/`Std.Symm` fields (mirroring mathlib's `SimpleGraph`), with `CompatFrame.refl`/`compat.symm` accessors so call sites read `h.symm`/`F.refl x` (no field-projection stutter).

Adds the bridge to the abstract Core construction (#487): `CompatFrame.toOrthoframe` (`x ⊥ y ↔ ¬ compat x y`), `orthoNeg_eq_upperPolar`, `isRegular_iff_isExtent`, and `RegularProp F ≃o Orthoframe.Reg F.toOrthoframe` — proving the hand-built ortholattice *is* the `Concept`-extent one. Also fixes the deprecated `push_neg` in `RegularProp`.