### PR TITLE
refactor(Core/Order): home CompleteOrthocomplementedLattice + le_compl_comm in Ortholattice

### DIFF
--- a/Linglib/Core/Order/Orthoframe/Representation.lean
+++ b/Linglib/Core/Order/Orthoframe/Representation.lean
@@ -33,27 +33,6 @@ open Order Set
 def JoinDense {L : Type*} [Preorder L] (V : Set L) : Prop :=
   ∀ a : L, IsLUB {b | b ∈ V ∧ b ≤ a} a
 
-/-- A **complete orthocomplemented lattice**: a complete lattice with an
-    orthocomplement satisfying the ortholattice axioms. Bundling avoids the
-    `Lattice` diamond that `[CompleteLattice] [OrthocomplementedLattice]` would
-    create — the single `Lattice` comes from `CompleteLattice`. -/
-class CompleteOrthocomplementedLattice (α : Type*) extends CompleteLattice α, Compl α where
-  /-- Complement is involutive. -/
-  compl_compl (a : α) : aᶜᶜ = a
-  /-- Complement is order-reversing. -/
-  compl_antitone {a b : α} : a ≤ b → bᶜ ≤ aᶜ
-  /-- Non-contradiction. -/
-  inf_compl_le_bot (a : α) : a ⊓ aᶜ ≤ ⊥
-  /-- Excluded middle. -/
-  top_le_sup_compl (a : α) : ⊤ ≤ a ⊔ aᶜ
-
-instance (priority := 100) {α : Type*} [CompleteOrthocomplementedLattice α] :
-    OrthocomplementedLattice α where
-  compl_compl := CompleteOrthocomplementedLattice.compl_compl
-  compl_antitone := CompleteOrthocomplementedLattice.compl_antitone
-  inf_compl_le_bot := CompleteOrthocomplementedLattice.inf_compl_le_bot
-  top_le_sup_compl := CompleteOrthocomplementedLattice.top_le_sup_compl
-
 namespace Orthoframe
 
 variable {L : Type*} [OrthocomplementedLattice L]
@@ -79,11 +58,6 @@ def represent (V : Set L) (a : L) : (ofOrtholattice V).Reg :=
   Concept.ofObjects (ofOrtholattice V).ortho {b | b.1 ≤ a}
 
 variable {V : Set L}
-
-/-- In an ortholattice, `a ≤ bᶜ ↔ b ≤ aᶜ` (orthogonality is symmetric). -/
-theorem _root_.OrthocomplementedLattice.le_compl_comm {a b : L} : a ≤ bᶜ ↔ b ≤ aᶜ :=
-  ⟨fun h => OrthocomplementedLattice.compl_compl b ▸ OrthocomplementedLattice.compl_antitone h,
-   fun h => OrthocomplementedLattice.compl_compl a ▸ OrthocomplementedLattice.compl_antitone h⟩
 
 /-- The upper polar of `{c | c ≤ x}` is `{d | x ≤ dᶜ}` (uses join-density at `x`). -/
 theorem upperPolar_Iic (hV : JoinDense V) (x : L) :

--- a/Linglib/Core/Order/Ortholattice.lean
+++ b/Linglib/Core/Order/Ortholattice.lean
@@ -1,4 +1,5 @@
 import Mathlib.Order.BooleanAlgebra.Basic
+import Mathlib.Order.CompleteLattice.Basic
 import Mathlib.Order.Disjoint
 
 /-!
@@ -121,6 +122,10 @@ theorem compl_eq_iff_eq_compl : aᶜ = b ↔ a = bᶜ := by
   · intro h; rw [← h, OrthocomplementedLattice.compl_compl]
   · intro h; rw [h, OrthocomplementedLattice.compl_compl]
 
+/-- Orthogonality is symmetric: `a ≤ bᶜ ↔ b ≤ aᶜ`. -/
+theorem le_compl_comm : a ≤ bᶜ ↔ b ≤ aᶜ :=
+  ⟨fun h => compl_compl b ▸ compl_antitone h, fun h => compl_compl a ▸ compl_antitone h⟩
+
 -- ════════════════════════════════════════════════════
 -- § 3. De Morgan Laws
 -- ════════════════════════════════════════════════════
@@ -171,3 +176,16 @@ instance (priority := 100) instBooleanOrtho {α : Type*} [BooleanAlgebra α] :
   compl_antitone := fun h => _root_.compl_le_compl h
   inf_compl_le_bot := BooleanAlgebra.inf_compl_le_bot
   top_le_sup_compl := BooleanAlgebra.top_le_sup_compl
+
+-- ════════════════════════════════════════════════════
+-- § 6. Complete Orthocomplemented Lattices
+-- ════════════════════════════════════════════════════
+
+/-- A *complete orthocomplemented lattice*: a complete lattice that is also
+    orthocomplemented. Bundling (rather than separate `[CompleteLattice α]` and
+    `[OrthocomplementedLattice α]` instances) shares the single `Lattice`, avoiding a
+    diamond — the same pattern as `CompleteBooleanAlgebra extends CompleteLattice,
+    BooleanAlgebra`. The forgetful instance to `OrthocomplementedLattice` is the free
+    parent projection. -/
+class CompleteOrthocomplementedLattice (α : Type*) extends
+  CompleteLattice α, OrthocomplementedLattice α


### PR DESCRIPTION
Audit follow-up (placement). Moves two general algebraic notions out of the representation-theorem file into `Ortholattice.lean` where they belong:

- `CompleteOrthocomplementedLattice` — redesigned as `extends CompleteLattice α, OrthocomplementedLattice α` (empty body), matching `CompleteBooleanAlgebra`. The forgetful `OrthocomplementedLattice` instance is now a free parent projection (the hand-written one + the four re-listed axioms are deleted).
- `le_compl_comm` (`a ≤ bᶜ ↔ b ≤ aᶜ`) — a basic ortho identity; the `_root_.` escape hatch in `Representation.lean` was the tell it didn't belong there.

No behaviour change; `Representation.lean` consumes both transitively. Downstream cone (FrameSemantics, Lifting, the study) green.