### PR TITLE
refactor(orthologic): rename Orthoframe.Reg → Regular; mathlib-style section headers

### DIFF
--- a/Linglib/Core/Logic/Orthologic/FrameSemantics.lean
+++ b/Linglib/Core/Logic/Orthologic/FrameSemantics.lean
@@ -6,10 +6,10 @@ import Linglib.Core.Order.Orthoframe.Representation
 
 [holliday-mandelkern-2024] §4.1 — Goldblatt's compatibility-frame semantics for
 orthologic and its completeness theorem (Theorem 4.19). A compatibility model is an
-`Orthoframe` `F` with a valuation `V : Var → F.Reg` assigning each variable a regular
+`Orthoframe` `F` with a valuation `V : Var → F.Regular` assigning each variable a regular
 proposition. The support relation `s ⊩ φ` is defined recursively; the set of
 supporters `{s | s ⊩ φ}` is exactly the extent of the algebraic value
-`Formula.eval V φ` in the ortholattice `F.Reg` (`support_setOf_eq_extent`).
+`Formula.eval V φ` in the ortholattice `F.Regular` (`support_setOf_eq_extent`).
 
 Soundness and completeness then reduce to the algebraic versions (Theorem 3.13): the
 bridge turns frame consequence into the algebraic inequality in every frame algebra,
@@ -35,15 +35,15 @@ variable {Var : Type u} {S : Type u}
 /-- The support relation `s ⊩ φ` of the compatibility model `(F, V)`
     ([holliday-mandelkern-2024] Def 4.16): `¬φ` is supported at `s` exactly when `s`
     is orthogonal to (incompatible with) every point supporting `φ`. -/
-def Support (F : Orthoframe S) (V : Var → F.Reg) (s : S) : Formula Var → Prop
+def Support (F : Orthoframe S) (V : Var → F.Regular) (s : S) : Formula Var → Prop
   | .top => True
   | .var p => s ∈ (V p).extent
   | .neg φ => ∀ t, Support F V t φ → F.ortho s t
   | .and φ ψ => Support F V s φ ∧ Support F V s ψ
 
 /-- **The bridge**: the supporters of `φ` are exactly the extent of its algebraic
-    value `Formula.eval V φ` in `F.Reg`. -/
-theorem support_setOf_eq_extent (F : Orthoframe S) (V : Var → F.Reg) (φ : Formula Var) :
+    value `Formula.eval V φ` in `F.Regular`. -/
+theorem support_setOf_eq_extent (F : Orthoframe S) (V : Var → F.Regular) (φ : Formula Var) :
     {s | Support F V s φ} = (Formula.eval V φ).extent := by
   induction φ with
   | top =>
@@ -69,14 +69,14 @@ theorem support_setOf_eq_extent (F : Orthoframe S) (V : Var → F.Reg) (φ : For
 /-- Semantic consequence over compatibility frames ([holliday-mandelkern-2024]
     Def 4.18): in every model, every point supporting `φ` supports `ψ`. -/
 def FrameConsequence (φ ψ : Formula Var) : Prop :=
-  ∀ {S : Type u} (F : Orthoframe S) (V : Var → F.Reg) (s : S),
+  ∀ {S : Type u} (F : Orthoframe S) (V : Var → F.Regular) (s : S),
     Support F V s φ → Support F V s ψ
 
 @[inherit_doc] scoped infix:50 " ⊨ᶠ " => FrameConsequence
 
 /-- Frame consequence is the algebraic inequality holding in every frame algebra. -/
 theorem frameConsequence_iff_eval {φ ψ : Formula Var} :
-    (φ ⊨ᶠ ψ) ↔ ∀ {S : Type u} (F : Orthoframe S) (V : Var → F.Reg),
+    (φ ⊨ᶠ ψ) ↔ ∀ {S : Type u} (F : Orthoframe S) (V : Var → F.Regular),
       Formula.eval V φ ≤ Formula.eval V ψ := by
   constructor
   · intro h S F V

--- a/Linglib/Core/Order/Orthoframe.lean
+++ b/Linglib/Core/Order/Orthoframe.lean
@@ -26,12 +26,12 @@ that stack lives downstream (Core cannot import the semantics layer).
 * `Concept.instOrthocomplementedLattice` — the concept lattice of a symmetric,
   irreflexive relation is an ortholattice.
 * `Orthoframe` — a bundled symmetric, irreflexive orthogonality relation;
-  `Orthoframe.Reg F` is its ortholattice of regular propositions.
+  `Orthoframe.Regular F` is its ortholattice of regular propositions.
 
 ## TODO
 
 * Goldblatt representation ([holliday-mandelkern-2024] Theorem 4.13): every
-  complete ortholattice is isomorphic to `Orthoframe.Reg` of its canonical
+  complete ortholattice is isomorphic to `Orthoframe.Regular` of its canonical
   orthoframe on a join-dense set, with `a ⊥ b ↔ a ≤ bᶜ`.
 -/
 
@@ -85,7 +85,7 @@ end Concept
 
 /-- An **orthoframe**: a set with a symmetric, irreflexive orthogonality
     relation `ortho` (written `x ⊥ y`). Its regular propositions form an
-    ortholattice (`Orthoframe.Reg`). The `Semantics.Modality.Orthologic`
+    ortholattice (`Orthoframe.Regular`). The `Semantics.Modality.Orthologic`
     compatibility frames are the special case `ortho = ¬compat`. -/
 structure Orthoframe (S : Type*) where
   /-- The orthogonality relation, written `x ⊥ y`. -/
@@ -101,9 +101,9 @@ attribute [instance] ortho_symm ortho_irrefl
 
 /-- The ortholattice of regular propositions of an orthoframe: the concepts of
     its orthogonality relation. -/
-abbrev Reg (F : Orthoframe S) : Type _ := Concept S S F.ortho
+abbrev Regular (F : Orthoframe S) : Type _ := Concept S S F.ortho
 
-instance (F : Orthoframe S) : OrthocomplementedLattice F.Reg :=
+instance (F : Orthoframe S) : OrthocomplementedLattice F.Regular :=
   Concept.instOrthocomplementedLattice F.ortho
 
 end Orthoframe

--- a/Linglib/Core/Order/Orthoframe/Representation.lean
+++ b/Linglib/Core/Order/Orthoframe/Representation.lean
@@ -5,7 +5,7 @@ import Mathlib.Order.Irreducible
 # Representation of ortholattices by orthoframes
 
 [holliday-mandelkern-2024] Theorem 4.13: every complete ortholattice is isomorphic
-to `Orthoframe.Reg` of its canonical orthoframe; every finite ortholattice via its
+to `Orthoframe.Regular` of its canonical orthoframe; every finite ortholattice via its
 join-irreducibles (Corollary 4.14). This is the converse of the `Orthoframe` layer
 (which gives `frame → ortholattice`).
 
@@ -19,7 +19,7 @@ the nonzero elements of a join-dense `V`, and the representation map is
 **Theorem 4.13 is complete and sorry-free.** The construction (`ofOrtholattice`), the
 extent characterization, the full ortholattice **embedding** (`⊓ ⊔ ¬ ⊤ ⊥` preserved,
 order-reflecting), and — for a `CompleteOrthocomplementedLattice` — the
-**isomorphism** `representation : L ≃o (ofOrtholattice V).Reg` over any join-dense
+**isomorphism** `representation : L ≃o (ofOrtholattice V).Regular` over any join-dense
 `V`. The orthocomplement preservation (`represent_compl`, the heart) falls out of the
 `upperPolar` computation `upperPolar_Iic`; no De Morgan over the join is needed.
 Corollary 4.14 (`representationFinite`) specialises the isomorphism to a
@@ -54,7 +54,7 @@ def ofOrtholattice (V : Set L) : Orthoframe (Point V) where
     (ofOrtholattice V).ortho a b ↔ a.1 ≤ b.1ᶜ := Iff.rfl
 
 /-- The representation map `a ↦ {b ∈ V\{0} | b ≤ a}`, as a concept. -/
-def represent (V : Set L) (a : L) : (ofOrtholattice V).Reg :=
+def represent (V : Set L) (a : L) : (ofOrtholattice V).Regular :=
   Concept.ofObjects (ofOrtholattice V).ortho {b | b.1 ≤ a}
 
 variable {V : Set L}
@@ -158,7 +158,7 @@ variable {L : Type*} [CompleteOrthocomplementedLattice L] {V : Set L}
 
 /-- Surjectivity (the `←` of Theorem 4.13): every concept is `represent V a`, taking
     `a` to be the join of the underlying elements of its extent. -/
-theorem represent_surjective (hV : JoinDense V) (c : (ofOrtholattice V).Reg) :
+theorem represent_surjective (hV : JoinDense V) (c : (ofOrtholattice V).Regular) :
     represent V (sSup (Subtype.val '' c.extent)) = c := by
   apply Concept.ext
   rw [represent_extent hV]
@@ -189,9 +189,9 @@ theorem sSup_represent_extent (hV : JoinDense V) (a : L) :
     · exact hu ⟨⟨c, hcV, hc0⟩, hca, rfl⟩
 
 /-- **The representation isomorphism** ([holliday-mandelkern-2024] Theorem 4.13): a
-    complete ortholattice is order-isomorphic to `Orthoframe.Reg` of its canonical
+    complete ortholattice is order-isomorphic to `Orthoframe.Regular` of its canonical
     orthoframe over any join-dense `V`. -/
-def representation (hV : JoinDense V) : L ≃o (ofOrtholattice V).Reg where
+def representation (hV : JoinDense V) : L ≃o (ofOrtholattice V).Regular where
   toFun := represent V
   invFun c := sSup (Subtype.val '' c.extent)
   left_inv := sSup_represent_extent hV
@@ -211,10 +211,10 @@ theorem joinDense_supIrred [WellFoundedLT L] : JoinDense {a : L | SupIrred a} :=
   exact Finset.sup_le fun b hb => hu ⟨hsIrred hb, hs ▸ Finset.le_sup hb⟩
 
 /-- **Corollary 4.14** ([holliday-mandelkern-2024]): a finite (more generally,
-    well-founded) ortholattice is order-isomorphic to `Orthoframe.Reg` of the
+    well-founded) ortholattice is order-isomorphic to `Orthoframe.Regular` of the
     orthoframe on its join-irreducibles. -/
 def representationFinite [WellFoundedLT L] :
-    L ≃o (ofOrtholattice {a : L | SupIrred a}).Reg :=
+    L ≃o (ofOrtholattice {a : L | SupIrred a}).Regular :=
   representation joinDense_supIrred
 
 end Iso

--- a/Linglib/Core/Order/Ortholattice.lean
+++ b/Linglib/Core/Order/Ortholattice.lean
@@ -79,9 +79,7 @@ namespace OrthocomplementedLattice
 
 variable {α : Type*} [OrthocomplementedLattice α] {a b : α}
 
--- ════════════════════════════════════════════════════
--- § 1. Basic Identities
--- ════════════════════════════════════════════════════
+/-! ### Basic Identities -/
 
 @[simp]
 theorem inf_compl_eq_bot (a : α) : a ⊓ aᶜ = ⊥ :=
@@ -99,9 +97,7 @@ theorem compl_bot : (⊥ : α)ᶜ = ⊤ := by
 theorem compl_top : (⊤ : α)ᶜ = ⊥ := by
   have h := inf_compl_eq_bot (⊤ : α); rwa [top_inf_eq] at h
 
--- ════════════════════════════════════════════════════
--- § 2. Order Properties
--- ════════════════════════════════════════════════════
+/-! ### Order Properties -/
 
 theorem compl_le_compl_iff_le : aᶜ ≤ bᶜ ↔ b ≤ a :=
   ⟨fun h => OrthocomplementedLattice.compl_compl b ▸
@@ -126,9 +122,7 @@ theorem compl_eq_iff_eq_compl : aᶜ = b ↔ a = bᶜ := by
 theorem le_compl_comm : a ≤ bᶜ ↔ b ≤ aᶜ :=
   ⟨fun h => compl_compl b ▸ compl_antitone h, fun h => compl_compl a ▸ compl_antitone h⟩
 
--- ════════════════════════════════════════════════════
--- § 3. De Morgan Laws
--- ════════════════════════════════════════════════════
+/-! ### De Morgan Laws -/
 
 theorem compl_sup (a b : α) : (a ⊔ b)ᶜ = aᶜ ⊓ bᶜ := by
   apply le_antisymm
@@ -150,9 +144,7 @@ theorem compl_inf (a b : α) : (a ⊓ b)ᶜ = aᶜ ⊔ bᶜ := by
   rw [OrthocomplementedLattice.compl_compl, OrthocomplementedLattice.compl_compl] at h
   rw [← h, OrthocomplementedLattice.compl_compl]
 
--- ════════════════════════════════════════════════════
--- § 4. IsCompl and ComplementedLattice
--- ════════════════════════════════════════════════════
+/-! ### IsCompl and ComplementedLattice -/
 
 theorem isCompl_compl (a : α) : IsCompl a aᶜ where
   disjoint := disjoint_iff.mpr (inf_compl_eq_bot a)
@@ -163,9 +155,7 @@ instance instComplementedLattice : ComplementedLattice α :=
 
 end OrthocomplementedLattice
 
--- ════════════════════════════════════════════════════
--- § 5. BooleanAlgebra → OrthocomplementedLattice
--- ════════════════════════════════════════════════════
+/-! ### BooleanAlgebra → OrthocomplementedLattice -/
 
 /-- Every Boolean algebra is an orthocomplemented lattice. The converse fails:
     ortholattices need not be distributive. Low priority so existing
@@ -177,15 +167,9 @@ instance (priority := 100) instBooleanOrtho {α : Type*} [BooleanAlgebra α] :
   inf_compl_le_bot := BooleanAlgebra.inf_compl_le_bot
   top_le_sup_compl := BooleanAlgebra.top_le_sup_compl
 
--- ════════════════════════════════════════════════════
--- § 6. Complete Orthocomplemented Lattices
--- ════════════════════════════════════════════════════
+/-! ### Complete Orthocomplemented Lattices -/
 
-/-- A *complete orthocomplemented lattice*: a complete lattice that is also
-    orthocomplemented. Bundling (rather than separate `[CompleteLattice α]` and
-    `[OrthocomplementedLattice α]` instances) shares the single `Lattice`, avoiding a
-    diamond — the same pattern as `CompleteBooleanAlgebra extends CompleteLattice,
-    BooleanAlgebra`. The forgetful instance to `OrthocomplementedLattice` is the free
-    parent projection. -/
+/-- A complete lattice that is also orthocomplemented; bundled like
+    `CompleteBooleanAlgebra` so the single `Lattice` is shared (no diamond). -/
 class CompleteOrthocomplementedLattice (α : Type*) extends
   CompleteLattice α, OrthocomplementedLattice α

--- a/Linglib/Semantics/Modality/Orthologic/RegularProp.lean
+++ b/Linglib/Semantics/Modality/Orthologic/RegularProp.lean
@@ -49,9 +49,7 @@ namespace Orthologic
 
 variable {S : Type*} {F : CompatFrame S}
 
--- ════════════════════════════════════════════════════
--- § 1. Closure-under-regularity helpers
--- ════════════════════════════════════════════════════
+/-! ### Closure-under-regularity helpers -/
 
 /-- The orthocomplement of any set is regular (whether or not the original set is). -/
 theorem orthoNeg_isRegular (F : CompatFrame S) (A : Set S) :
@@ -120,9 +118,7 @@ theorem orthoNeg_orthoNeg_of_isRegular (F : CompatFrame S) {A : Set S}
     push Not
     exact ⟨x, hxy.symm, hxA⟩
 
--- ════════════════════════════════════════════════════
--- § 2. The Bundled Type RegularProp F
--- ════════════════════════════════════════════════════
+/-! ### The Bundled Type RegularProp F -/
 
 /-- A regular proposition of a compatibility frame `F`: a `Set S` satisfying
     the `◇`-regularity condition. Bundled as a structure with `SetLike`
@@ -151,9 +147,7 @@ instance : SetLike (RegularProp F) S where
 
 theorem regular (A : RegularProp F) : IsRegular F (A : Set S) := A.regular'
 
--- ════════════════════════════════════════════════════
--- § 3. Lattice Operations
--- ════════════════════════════════════════════════════
+/-! ### Lattice Operations -/
 
 instance : Min (RegularProp F) where
   min A B := ⟨(A : Set S) ∩ (B : Set S), inter_isRegular A.regular B.regular⟩
@@ -183,9 +177,7 @@ instance : Compl (RegularProp F) where
 @[simp] theorem coe_compl (A : RegularProp F) :
     ((Aᶜ : RegularProp F) : Set S) = orthoNeg F (A : Set S) := rfl
 
--- ════════════════════════════════════════════════════
--- § 4. Lattice + BoundedOrder Instance
--- ════════════════════════════════════════════════════
+/-! ### Lattice + BoundedOrder Instance -/
 
 instance : PartialOrder (RegularProp F) := PartialOrder.ofSetLike (RegularProp F) S
 
@@ -227,9 +219,7 @@ instance : BoundedOrder (RegularProp F) where
   bot_le := fun _ _ hx => hx.elim
   le_top := fun _ _ _ => trivial
 
--- ════════════════════════════════════════════════════
--- § 5. OrthocomplementedLattice Instance
--- ════════════════════════════════════════════════════
+/-! ### OrthocomplementedLattice Instance -/
 
 instance instOrthocomplementedLattice : OrthocomplementedLattice (RegularProp F) where
   compl_compl A := SetLike.coe_injective <|
@@ -288,12 +278,12 @@ theorem isRegular_iff_isExtent (F : CompatFrame S) (A : Set S) :
       upperPolar_eq_lowerPolar F.toOrthoframe.ortho]
 
 /-- **The bridge.** `RegularProp F` is order-isomorphic to the ortholattice of
-    regular propositions of its orthogonality orthoframe (`Orthoframe.Reg`) —
+    regular propositions of its orthogonality orthoframe (`Orthoframe.Regular`) —
     i.e. the concept extents of `¬ compat`. The hand-built
     `OrthocomplementedLattice (RegularProp F)` and the abstract `Concept`-based
     one coincide. -/
 def RegularProp.equivReg (F : CompatFrame S) :
-    RegularProp F ≃o Orthoframe.Reg F.toOrthoframe where
+    RegularProp F ≃o Orthoframe.Regular F.toOrthoframe where
   toFun A := Concept.ofIsExtent F.toOrthoframe.ortho A.carrier
     ((isRegular_iff_isExtent F A.carrier).mp A.regular')
   invFun c := ⟨c.extent, (isRegular_iff_isExtent F c.extent).mpr c.isExtent_extent⟩


### PR DESCRIPTION
Audit follow-up (naming + style), no behaviour change:

- `Orthoframe.Reg` → `Orthoframe.Regular` (mathlib spells out the descriptor; cf. `Submodule`, not `Submod`) — rippled to `Representation`, `FrameSemantics`, `RegularProp`.
- Replace the `-- ═══ § N. Title ═══` ASCII banners with `/-! ### Title -/` per CLAUDE.md, in `Ortholattice` + the renamed files.
- Compress the `CompleteOrthocomplementedLattice` docstring.

Whole cone (incl. the study) green.