### PR TITLE
refactor(orthologic): eliminate RegularProp structure; regular props are Orthoframe.Regular

### DIFF
--- a/Linglib/Core/Order/Orthoframe.lean
+++ b/Linglib/Core/Order/Orthoframe.lean
@@ -66,6 +66,21 @@ instance instCompl [Std.Symm r] : Compl (Concept S S r) where
 @[simp] theorem intent_compl [Std.Symm r] (c : Concept S S r) :
     cᶜ.intent = upperPolar r c.intent := rfl
 
+/-- A concept of a single-sorted relation is determined by its extent, so concepts
+    form a `SetLike` family with `↑c = c.extent`. (No `PartialOrder` diamond: `SetLike`
+    supplies only `Membership`/coercions, and `Concept`'s order is already `extent`-lifted.) -/
+instance instSetLike {r : S → S → Prop} : SetLike (Concept S S r) S where
+  coe c := c.extent
+  coe_injective _ _ h := extent_injective h
+
+/-- For an irreflexive relation the bottom concept has empty extent (no point is
+    orthogonal to everything, including itself). -/
+theorem extent_bot_eq_empty [Std.Irrefl r] : (⊥ : Concept S S r).extent = ∅ := by
+  rw [Concept.extent_bot]
+  ext x
+  simp only [Set.mem_empty_iff_false, iff_false]
+  exact fun hx => Std.Irrefl.irrefl x (hx (Set.mem_univ x))
+
 /-- The concepts of a symmetric, irreflexive relation form an orthocomplemented
     lattice ([holliday-mandelkern-2024] Proposition 4.8). The lattice structure
     is mathlib's concept lattice; only the orthocomplement and its four axioms

--- a/Linglib/Semantics/Modality/Orthologic/Frames.lean
+++ b/Linglib/Semantics/Modality/Orthologic/Frames.lean
@@ -215,10 +215,8 @@ theorem identityFrame_classical [DecidableEq S]
 /-! ### The c_◇ closure operator -/
 
 /-- The c_◇ closure operator on `Set S` for a compatibility frame `F`,
-    mapping `A ↦ {x | ∀ y ◇ x, ∃ z ◇ y, z ∈ A}`. The fixed points of
-    `regularClosure F` are precisely the ◇-regular sets — making
-    `RegularProp F = (regularClosure F).fixedPoints` a mathlib-typed
-    closure-operator-based construction.
+    mapping `A ↦ {x | ∀ y ◇ x, ∃ z ◇ y, z ∈ A}`. Its fixed points are precisely the
+    `◇`-regular sets (`IsRegular F`), i.e. the underlying sets of `CompatFrame.Regular`.
     [holliday-mandelkern-2024] footnote 19 (page 858 of the
     published JPL version). -/
 def regularClosure (F : CompatFrame S) : ClosureOperator (Set S) where

--- a/Linglib/Semantics/Modality/Orthologic/Lifting.lean
+++ b/Linglib/Semantics/Modality/Orthologic/Lifting.lean
@@ -84,7 +84,7 @@ theorem eBset_regular (a : B) : IsRegular (epistemicFrame B) (eBset a) := by
 
 /-- The embedding `e_B : B → O(Bᵉ)` ([holliday-mandelkern-2024] Theorem 5.7.2) as a
     regular proposition. -/
-def eB (a : B) : RegularProp (epistemicFrame B) := ⟨eBset a, eBset_regular a⟩
+def eB (a : B) : (epistemicFrame B).Regular := (epistemicFrame B).regOf (eBset a) (eBset_regular a)
 
 @[simp] theorem mem_eB (a : B) (q : Possibility B) : q ∈ (eB a : Set _) ↔ q.truth ≤ a :=
   Iff.rfl
@@ -104,29 +104,29 @@ theorem eB_le_iff {a a' : B} : eB a ≤ eB a' ↔ a ≤ a' := by
   · exact bot_le
   · exact @h ⟨a, ⊤, ha, le_top⟩ (le_refl a)
 
-theorem eB_injective : Function.Injective (eB : B → RegularProp (epistemicFrame B)) :=
+theorem eB_injective : Function.Injective (eB : B → (epistemicFrame B).Regular) :=
   fun _ _ h => le_antisymm (eB_le_iff.mp h.le) (eB_le_iff.mp h.ge)
 
 theorem eB_top : eB (⊤ : B) = ⊤ := by
   apply SetLike.coe_injective
-  rw [coe_eB, RegularProp.coe_top]
+  rw [coe_eB, CompatFrame.Regular.coe_top]
   ext q; simp [eBset]
 
 theorem eB_bot : eB (⊥ : B) = ⊥ := by
   apply SetLike.coe_injective
-  rw [coe_eB, RegularProp.coe_bot]
+  rw [coe_eB, CompatFrame.Regular.coe_bot]
   ext q; simp [eBset, le_bot_iff, q.truth_ne_bot]
 
 theorem eB_inf (a a' : B) : eB (a ⊓ a') = eB a ⊓ eB a' := by
   apply SetLike.coe_injective
-  rw [coe_eB, RegularProp.coe_inf, coe_eB, coe_eB]
+  rw [coe_eB, CompatFrame.Regular.coe_inf, coe_eB, coe_eB]
   ext q; simp [eBset, le_inf_iff]
 
 /-- `e_B` preserves complement ([holliday-mandelkern-2024] Thm 5.7.2): the orthonegation
     of `e_B(a)` is `e_B(aᶜ)`. The `←` direction reuses the witness `(q ⊓ a, q.info)`. -/
 theorem eB_compl (a : B) : eB aᶜ = (eB a)ᶜ := by
   apply SetLike.coe_injective
-  rw [coe_eB, RegularProp.coe_compl, coe_eB]
+  rw [coe_eB, CompatFrame.Regular.coe_compl, coe_eB]
   ext q
   simp only [eBset, Set.mem_setOf_eq, mem_orthoNeg]
   constructor

--- a/Linglib/Semantics/Modality/Orthologic/RegularProp.lean
+++ b/Linglib/Semantics/Modality/Orthologic/RegularProp.lean
@@ -7,42 +7,21 @@ import Mathlib.Data.SetLike.Basic
 # Regular Propositions of a Compatibility Frame
 [holliday-mandelkern-2024]
 
-The bundled type `RegularProp F` of `◇`-regular subsets of a compatibility
-frame `F`, equipped with its `OrthocomplementedLattice` structure.
+The `◇`-regular subsets of a compatibility frame `F` form an orthocomplemented
+lattice. Rather than re-derive it, this file identifies that lattice with the
+abstract concept lattice of the orthogonality relation `¬ compat`:
+`CompatFrame.Regular F := Orthoframe.Regular F.toOrthoframe` (mathlib `Order.Concept`,
+via `Core.Order.Orthoframe`), so the `OrthocomplementedLattice` structure and
+Holliday–Mandelkern's Proposition 4.8 (`compl_compl`) come for free.
 
-## Construction
+What this file contributes is the **decidable construction interface**: the
+`IsRegular` predicate (a bounded-quantifier `Prop`, hence `decide`-able on finite
+frames), its closure lemmas, the bridge `isRegular_iff_isExtent`, and the smart
+constructor `CompatFrame.regOf` building a `Regular` element from a regularity proof.
 
-`RegularProp F` is a bundled structure (mathlib `Submodule`/`SetLike`
-pattern) wrapping a `Set S` together with its regularity proof. The
-underlying mathematical object is `(regularClosure F).fixedPoints` —
-the fixed points of the `c_◇` closure operator (Holliday–Mandelkern
-footnote 19); this file proves the lattice operations on these fixed
-points form an orthocomplemented lattice.
-
-The four `OrthocomplementedLattice` axioms:
-
-| axiom | difficulty | uses regularity? |
-|-------|------------|------------------|
-| `compl_antitone`  | trivial from `orthoNeg` def      | no  |
-| `inf_compl_le_bot`| one-liner via reflexivity         | no  |
-| `top_le_sup_compl`| from `orthoNeg²` containment       | no  |
-| `compl_compl`     | the substantive theorem (Prop 4.8) | YES |
-
-The load-bearing fact is `orthoNeg_orthoNeg_of_isRegular` — the
-involutivity of `orthoNeg` on regular sets, which is precisely
-Holliday–Mandelkern's Proposition 4.8.
-
-## Architecture
-
-This file depends on:
-- `Linglib.Semantics.Modality.Orthologic.Frames` — substrate
-  (compatibility frames, `orthoNeg`, `disj`, `IsRegular`, `regularClosure`).
-- `Linglib.Core.Order.Ortholattice` — abstract `OrthocomplementedLattice`
-  typeclass.
-
-The `RegularProp F` carrier is the natural mathlib subobject for any
-future ortholattice consumer (BSML, inquisitive semantics, truthmaker
-semantics — all of which traffic in non-Boolean propositional algebras).
+## Main definitions
+* `CompatFrame.toOrthoframe`, `CompatFrame.Regular`, `CompatFrame.regOf`.
+* `isRegular_iff_isExtent` — `IsRegular F` is `IsExtent` of the orthogonality relation.
 -/
 
 namespace Orthologic
@@ -118,128 +97,6 @@ theorem orthoNeg_orthoNeg_of_isRegular (F : CompatFrame S) {A : Set S}
     push Not
     exact ⟨x, hxy.symm, hxA⟩
 
-/-! ### The Bundled Type RegularProp F -/
-
-/-- A regular proposition of a compatibility frame `F`: a `Set S` satisfying
-    the `◇`-regularity condition. Bundled as a structure with `SetLike`
-    instance, mirroring mathlib's subobject pattern (`Submodule`, `Subgroup`,
-    `Subalgebra`). -/
-@[ext]
-structure RegularProp (F : CompatFrame S) where
-  /-- The underlying set of the regular proposition. -/
-  carrier : Set S
-  /-- The regularity proof. -/
-  regular' : IsRegular F carrier
-
-namespace RegularProp
-
-instance : SetLike (RegularProp F) S where
-  coe := RegularProp.carrier
-  coe_injective := by
-    rintro ⟨A, _⟩ ⟨B, _⟩ (rfl : A = B)
-    rfl
-
-@[simp] theorem mem_mk (A : Set S) (hA : IsRegular F A) (x : S) :
-    x ∈ (⟨A, hA⟩ : RegularProp F) ↔ x ∈ A := Iff.rfl
-
-@[simp] theorem coe_mk (A : Set S) (hA : IsRegular F A) :
-    ((⟨A, hA⟩ : RegularProp F) : Set S) = A := rfl
-
-theorem regular (A : RegularProp F) : IsRegular F (A : Set S) := A.regular'
-
-/-! ### Lattice Operations -/
-
-instance : Min (RegularProp F) where
-  min A B := ⟨(A : Set S) ∩ (B : Set S), inter_isRegular A.regular B.regular⟩
-
-instance : Max (RegularProp F) where
-  max A B := ⟨disj F (A : Set S) (B : Set S), disj_isRegular F _ _⟩
-
-instance : Bot (RegularProp F) where
-  bot := ⟨∅, empty_isRegular F⟩
-
-instance : Top (RegularProp F) where
-  top := ⟨Set.univ, univ_isRegular F⟩
-
-instance : Compl (RegularProp F) where
-  compl A := ⟨orthoNeg F (A : Set S), orthoNeg_isRegular F _⟩
-
-@[simp] theorem coe_inf (A B : RegularProp F) :
-    ((A ⊓ B : RegularProp F) : Set S) = (A : Set S) ∩ (B : Set S) := rfl
-
-@[simp] theorem coe_sup (A B : RegularProp F) :
-    ((A ⊔ B : RegularProp F) : Set S) = disj F (A : Set S) (B : Set S) := rfl
-
-@[simp] theorem coe_bot : ((⊥ : RegularProp F) : Set S) = ∅ := rfl
-
-@[simp] theorem coe_top : ((⊤ : RegularProp F) : Set S) = Set.univ := rfl
-
-@[simp] theorem coe_compl (A : RegularProp F) :
-    ((Aᶜ : RegularProp F) : Set S) = orthoNeg F (A : Set S) := rfl
-
-/-! ### Lattice + BoundedOrder Instance -/
-
-instance : PartialOrder (RegularProp F) := PartialOrder.ofSetLike (RegularProp F) S
-
-instance : Lattice (RegularProp F) where
-  inf := (· ⊓ ·)
-  sup := (· ⊔ ·)
-  inf_le_left A B := fun _ hx => hx.1
-  inf_le_right A B := fun _ hx => hx.2
-  le_inf A B C hAB hAC := fun x hx => ⟨hAB hx, hAC hx⟩
-  le_sup_left A B := by
-    intro x hxA
-    show x ∈ disj F (A : Set S) (B : Set S)
-    intro y hxy hy
-    exact hy.1 x (hxy.symm) hxA
-  le_sup_right A B := by
-    intro x hxB
-    show x ∈ disj F (A : Set S) (B : Set S)
-    intro y hxy hy
-    exact hy.2 x (hxy.symm) hxB
-  sup_le A B C hAC hBC := by
-    intro x hx
-    -- hx : x ∈ disj F A.carrier B.carrier
-    by_contra hxC
-    rcases C.regular x with hxC' | ⟨y, hxy, hy⟩
-    · exact hxC hxC'
-    · have habs : ¬ (y ∈ orthoNeg F (A : Set S) ∩ orthoNeg F (B : Set S)) :=
-        hx y hxy
-      rw [Set.mem_inter_iff, not_and_or] at habs
-      rcases habs with hyN | hyN
-      all_goals
-        rw [mem_orthoNeg] at hyN
-        push Not at hyN
-      · obtain ⟨z, hyz, hzA⟩ := hyN
-        exact hy z hyz (hAC hzA)
-      · obtain ⟨z, hyz, hzB⟩ := hyN
-        exact hy z hyz (hBC hzB)
-
-instance : BoundedOrder (RegularProp F) where
-  bot_le := fun _ _ hx => hx.elim
-  le_top := fun _ _ _ => trivial
-
-/-! ### OrthocomplementedLattice Instance -/
-
-instance instOrthocomplementedLattice : OrthocomplementedLattice (RegularProp F) where
-  compl_compl A := SetLike.coe_injective <|
-    orthoNeg_orthoNeg_of_isRegular F A.regular
-  compl_antitone {A B} hAB := by
-    intro x hxBN y hxy hyA
-    exact hxBN y hxy (hAB hyA)
-  inf_compl_le_bot A := by
-    intro x hx
-    exact hx.2 x (F.refl x) hx.1
-  top_le_sup_compl A := by
-    intro x _
-    show x ∈ disj F (A : Set S) (orthoNeg F (A : Set S))
-    intro y hxy hy
-    -- hy : y ∈ orthoNeg F A ∩ orthoNeg F (orthoNeg F A)
-    -- Apply hy.2 (= y ∈ orthoNeg² A) at z = y via reflexivity:
-    -- y ∉ orthoNeg F A. Contradicts hy.1.
-    exact hy.2 y (F.refl y) hy.1
-
-end RegularProp
 
 /-! ### Bridge to the abstract orthoframe construction -/
 
@@ -277,18 +134,37 @@ theorem isRegular_iff_isExtent (F : CompatFrame S) (A : Set S) :
       orthoNeg_eq_upperPolar, orthoNeg_eq_upperPolar,
       upperPolar_eq_lowerPolar F.toOrthoframe.ortho]
 
-/-- **The bridge.** `RegularProp F` is order-isomorphic to the ortholattice of
-    regular propositions of its orthogonality orthoframe (`Orthoframe.Regular`) —
-    i.e. the concept extents of `¬ compat`. The hand-built
-    `OrthocomplementedLattice (RegularProp F)` and the abstract `Concept`-based
-    one coincide. -/
-def RegularProp.equivReg (F : CompatFrame S) :
-    RegularProp F ≃o Orthoframe.Regular F.toOrthoframe where
-  toFun A := Concept.ofIsExtent F.toOrthoframe.ortho A.carrier
-    ((isRegular_iff_isExtent F A.carrier).mp A.regular')
-  invFun c := ⟨c.extent, (isRegular_iff_isExtent F c.extent).mpr c.isExtent_extent⟩
-  left_inv := fun _ => rfl
-  right_inv := fun _ => Concept.ext rfl
-  map_rel_iff' := Iff.rfl
+/-! ### The ortholattice of regular propositions -/
+
+/-- The regular propositions of `F`: the ortholattice `Orthoframe.Regular` of its
+    orthogonality orthoframe (the concept extents of `¬ compat`); Holliday–Mandelkern's
+    Proposition 4.8 is mathlib's `upperPolar_lowerPolar_upperPolar`. The decidable
+    `IsRegular` predicate is the construction interface — use `regOf` to build an
+    element from a regularity proof (e.g. `by decide` on a finite frame). -/
+abbrev CompatFrame.Regular (F : CompatFrame S) : Type _ := Orthoframe.Regular F.toOrthoframe
+
+/-- Build a regular proposition from a set and an `IsRegular` proof. -/
+def CompatFrame.regOf (F : CompatFrame S) (A : Set S) (h : IsRegular F A) : F.Regular :=
+  Concept.ofIsExtent F.toOrthoframe.ortho A ((isRegular_iff_isExtent F A).mp h)
+
+@[simp] theorem CompatFrame.coe_regOf (A : Set S) (h : IsRegular F A) :
+    (F.regOf A h : Set S) = A := rfl
+
+@[simp] theorem CompatFrame.mem_regOf (A : Set S) (h : IsRegular F A) (x : S) :
+    x ∈ F.regOf A h ↔ x ∈ A := Iff.rfl
+
+@[simp] theorem CompatFrame.Regular.coe_inf (A B : F.Regular) :
+    ((A ⊓ B : F.Regular) : Set S) = (A : Set S) ∩ (B : Set S) := rfl
+
+@[simp] theorem CompatFrame.Regular.coe_top :
+    ((⊤ : F.Regular) : Set S) = Set.univ := rfl
+
+@[simp] theorem CompatFrame.Regular.coe_bot :
+    ((⊥ : F.Regular) : Set S) = ∅ := Concept.extent_bot_eq_empty F.toOrthoframe.ortho
+
+@[simp] theorem CompatFrame.Regular.coe_compl (A : F.Regular) :
+    ((Aᶜ : F.Regular) : Set S) = orthoNeg F (A : Set S) := by
+  show (Aᶜ).extent = orthoNeg F A.extent
+  rw [orthoNeg_eq_upperPolar, Concept.extent_compl, ← Concept.upperPolar_extent]
 
 end Orthologic

--- a/Linglib/Studies/HollidayMandelkern2024.lean
+++ b/Linglib/Studies/HollidayMandelkern2024.lean
@@ -204,11 +204,9 @@ theorem regular_mid : IsRegular pathFrame pMid := by decide
 theorem regular_empty : IsRegular pathFrame (∅ : Set Poss5) := empty_isRegular pathFrame
 theorem regular_full : IsRegular pathFrame (Set.univ : Set Poss5) := univ_isRegular pathFrame
 
--- ════════════════════════════════════════════════════
--- § 3a. Lifting to RegularProp (typeclass-level reasoning)
--- ════════════════════════════════════════════════════
+/-! ### Lifting to regular propositions (typeclass-level reasoning) -/
 
-/-! Pack the path-frame regular sets as `RegularProp pathFrame` elements
+/-! Pack the path-frame regular sets as `pathFrame.Regular` elements
     and demonstrate that the abstract `OrthocomplementedLattice` instance
     immediately delivers the De Morgan / excluded-middle / non-contradiction
     laws that are otherwise proved pointwise via `decide`. The set-membership
@@ -216,13 +214,13 @@ theorem regular_full : IsRegular pathFrame (Set.univ : Set Poss5) := univ_isRegu
     versions below are the same propositions phrased in lattice notation. -/
 
 /-- `{x₁, x₂}` packaged as a regular proposition. -/
-def pLeftReg : RegularProp pathFrame := ⟨pLeft, regular_left⟩
+def pLeftReg : pathFrame.Regular := pathFrame.regOf pLeft regular_left
 
 /-- `{x₄, x₅}` packaged as a regular proposition. -/
-def pRightReg : RegularProp pathFrame := ⟨pRight, regular_right⟩
+def pRightReg : pathFrame.Regular := pathFrame.regOf pRight regular_right
 
 /-- `{x₃}` packaged as a regular proposition. -/
-def pMidReg : RegularProp pathFrame := ⟨pMid, regular_mid⟩
+def pMidReg : pathFrame.Regular := pathFrame.regOf pMid regular_mid
 
 section TypeclassLevel
 open OrthocomplementedLattice
@@ -249,6 +247,7 @@ end TypeclassLevel
     Lattice-level statement of the pointwise `neg_left` theorem. -/
 theorem pLeftReg_compl_eq : pLeftRegᶜ = pRightReg := by
   apply SetLike.coe_injective
+  simp only [CompatFrame.Regular.coe_compl, CompatFrame.coe_regOf]
   ext x
   exact neg_left x
 
@@ -735,7 +734,7 @@ theorem hm_predicts_wittgenstein_infelicitous :
 /-- HM 2024 predicts that classical contradictions are infelicitous —
     matching Yalcin (2007). Witness: `p ∧ ¬p = ∅` on the Epistemic Scale,
     structurally guaranteed by the `inf_compl_eq_bot` ortholattice axiom
-    on `RegularProp pathFrame`. -/
+    on `pathFrame.Regular`. -/
 theorem hm_predicts_classical_infelicitous :
     (∀ x : Poss5, ¬ conj propP (orthoNeg pathFrame propP) x) ∧
     Yalcin2007.felicitousUnderEmbedding


### PR DESCRIPTION
Audit follow-up — the deepest finding: `RegularProp F` re-derived the orthocomplemented-lattice of regular sets by hand (~150 lines of `Lattice`/`BoundedOrder`/`OrthocomplementedLattice` instances) when `Orthoframe.Regular F.toOrthoframe` already gets it free from mathlib `Order.Concept`. The `≃o` between them had `rfl` in every field — two presentations of one lattice.

- Delete the `RegularProp` structure, its hand-written instances, and `RegularProp.equivReg`.
- `CompatFrame.Regular F := Orthoframe.Regular F.toOrthoframe` (abbrev, zero instances of its own).
- Keep the decidable `IsRegular` predicate + closure lemmas + `isRegular_iff_isExtent` as the **construction interface**; add `CompatFrame.regOf` (so `by decide` on `Poss5` still builds) and a `SetLike (Concept S S r) S` instance (no `PartialOrder` diamond — `Concept`'s order is already `extent`-lifted) so `x ∈ A` / `(A : Set)` ergonomics survive.
- Migrate `Lifting.eB` (name swaps only — the `SetLike` coe ports the proofs) and the study §3a.

Net: RegularProp.lean 304 → ~170 lines; the orthocomplemented-lattice theory is no longer duplicated. Whole cone + study green; `eB_compl` axiom-clean.