### PR TITLE
feat(Tense/Sequence): SOT licensing API on neutral Clause.Size

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -256,6 +256,7 @@ import Linglib.Semantics.Tense.Domain
 import Linglib.Semantics.Tense.System
 import Linglib.Semantics.Tense.Defs
 import Linglib.Semantics.Tense.Reichenbach
+import Linglib.Semantics.Tense.Sequence.Basic
 import Linglib.Semantics.Tense.Pronoun
 import Linglib.Typology.WordOrder
 import Linglib.Typology.Adposition
@@ -2153,6 +2154,7 @@ import Linglib.Syntax.Minimalist.Economy
 import Linglib.Syntax.Minimalist.Modification
 import Linglib.Syntax.Minimalist.Scope
 import Linglib.Syntax.Minimalist.TraceInterpretation
+import Linglib.Syntax.Clause.Basic
 import Linglib.Syntax.Minimalist.Basic
 import Linglib.Syntax.Minimalist.Derivation
 import Linglib.Syntax.Minimalist.HeadFunction

--- a/Linglib/Semantics/Tense/Sequence/Basic.lean
+++ b/Linglib/Semantics/Tense/Sequence/Basic.lean
@@ -1,0 +1,144 @@
+import Linglib.Core.Order.Relation
+import Linglib.Syntax.Clause.Basic
+import Linglib.Semantics.Tense.Reichenbach
+
+/-!
+# Sequence of tense: the cross-cutting licensing interface
+[kauf-zeijlstra-2018] [ogihara-2019] [egressy-2026]
+
+Past-under-past embeddings have a simultaneous and a backward-shifted reading
+(and, with an intervening future, a forward-shifted one). Rival accounts —
+relational/feature ([kauf-zeijlstra-2018]), deletion ([ogihara-2019]), res-movement
+de re, clause-size ([egressy-2026]) — disagree only about *when each reading is
+licensed*, not about what a reading is. This file is the seam.
+
+## What a reading is (no enum)
+
+A reading is which comparison atom the embedded reference time bears to its
+anchor. `Tense.embeddedFrame` puts the anchor at the matrix event time, so the
+three readings are exactly the overhaul's frame predicates: `.lt`/`isPast` =
+back-shifted, `.eq`/`isPresent` = simultaneous, `.gt`/`isFuture` = forward.
+
+## What a theory provides
+
+A theory is one `LocalLicense` — a relation reading, off an immediately
+containing clause and the clause it contains, which atoms are licensed. Both
+syntactic and semantic theories emit the same `Finset Ordering`, so they are
+peers; `profile` folds the relation **pairwise** along the c-command chain
+(adjacency-local, so an intervening tense re-anchors). Clause size enters only
+through the **framework-neutral** `Clause.Size` (`Syntax/Clause`), never
+`Minimalist` machinery.
+
+Double-access (a two-anchor present) and modal-base orientation (Klecha) do not
+fit one cell against one anchor; they are deliberately *out* of this interface
+and handled by separate substrate.
+-/
+
+namespace Tense.Sequence
+
+open Core.Order
+
+/-- A node in an embedding chain: a clause's morphological tense as a relative
+    comparison cell (past = `notAfter`, the ≤ of [kauf-zeijlstra-2018]) and its
+    framework-neutral `Clause.Size`. Not a `Minimalist.ComplementSize` — a
+    Minimalist clause *provides* its size via `ComplementSize.toClauseSize`. -/
+structure Node where
+  /-- The clause's tense as a relative comparison cell to its anchor. -/
+  tense : Finset Ordering
+  /-- The clause's framework-neutral size (`Clause.Size`). -/
+  size  : Clause.Size
+
+/-- The cross-cutting interface: given a containing clause and the clause it
+    immediately contains, which comparison atoms hold between the contained
+    reference time and its anchor. A theory **is** a value of this type. -/
+abbrev LocalLicense := Node → Node → Finset Ordering
+
+/-- Compose a license pairwise along the c-command chain (matrix first): the
+    licensed reading-set at each embedding level. Adjacency-local — not a fold
+    or product — so an intervening tense re-anchors and blocking propagates
+    ([ogihara-1996]'s past-under-*will*-under-past). -/
+def profile (L : LocalLicense) : Node → List Node → List (Finset Ordering)
+  | _, []        => []
+  | a, c :: rest => L a c :: profile L c rest
+
+/-! ### Reading availability (the atoms — no `Reading` enum) -/
+
+/-- The simultaneous reading is licensed iff the `eq` atom is. -/
+def Simultaneous   (s : Finset Ordering) : Prop := Ordering.eq ∈ s
+/-- The backward-shifted reading is licensed iff the `lt` atom is. -/
+def Backshifted    (s : Finset Ordering) : Prop := Ordering.lt ∈ s
+/-- The forward-shifted reading is licensed iff the `gt` atom is. -/
+def ForwardShifted (s : Finset Ordering) : Prop := Ordering.gt ∈ s
+
+instance (s : Finset Ordering) : Decidable (Simultaneous s) :=
+  inferInstanceAs (Decidable (Ordering.eq ∈ s))
+instance (s : Finset Ordering) : Decidable (Backshifted s) :=
+  inferInstanceAs (Decidable (Ordering.lt ∈ s))
+instance (s : Finset Ordering) : Decidable (ForwardShifted s) :=
+  inferInstanceAs (Decidable (Ordering.gt ∈ s))
+
+/-! ### Realization: the atoms are the overhaul's frame predicates
+
+For an embedded frame whose perspective time is the matrix event time
+(`Tense.embeddedFrame`), the licensed atom is its `R`-vs-`P` comparison, and the
+three named readings are exactly `ReichenbachFrame.isPast/isPresent/isFuture`. -/
+
+variable {T : Type*} [LinearOrder T]
+
+theorem isPast_iff_atom (f : Time.ReichenbachFrame T) :
+    f.isPast ↔ compare f.referenceTime f.perspectiveTime = Ordering.lt := by
+  simp [Time.ReichenbachFrame.isPast, holds, Tense.past, before]
+
+theorem isPresent_iff_atom (f : Time.ReichenbachFrame T) :
+    f.isPresent ↔ compare f.referenceTime f.perspectiveTime = Ordering.eq := by
+  simp [Time.ReichenbachFrame.isPresent]
+
+theorem isFuture_iff_atom (f : Time.ReichenbachFrame T) :
+    f.isFuture ↔ compare f.referenceTime f.perspectiveTime = Ordering.gt := by
+  simp [Time.ReichenbachFrame.isFuture, holds, Tense.future, after]
+
+/-! ### License schemas
+
+Reusable `LocalLicense` constructors that the rival accounts instantiate. The
+*specific* boundary (e.g. Egressy's `Say`) is a study's commitment; the schemas
+are shared. -/
+
+/-- Relational schema ([kauf-zeijlstra-2018]): the clause's own relative tense,
+    size-blind. Past = `notAfter` (≤) yields `{lt, eq}` = back-shift ∨ sim. -/
+def relationalLicense : LocalLicense := fun _ c => c.tense
+
+/-- Size-gated schema ([egressy-2026]): an opaque clause (size not below
+    `boundary`) loses the simultaneous (`eq`) atom; a transparent one keeps the
+    full relative tense. -/
+def sizeGatedLicense (boundary : Clause.Size) : LocalLicense :=
+  fun _ c => if Clause.transparentTo c.size boundary then c.tense else c.tense.erase .eq
+
+/-- Res-movement de re foil: size- and tense-blind, so it adds the forward atom
+    and overgenerates. -/
+def deReLicense : LocalLicense := fun _ _ => unrestricted
+
+/-! ### Worked example: the schemas diverge on an opaque past clause
+
+A concrete demonstration that the interface carries weight: on an opaque past
+clause (grade `5`, boundary `5`), the relational and de re schemas license the
+simultaneous reading but the size-gated one does not. -/
+
+/-- A matrix past clause (size below any boundary used here). -/
+def exMatrix : Node := ⟨notAfter, 0⟩
+/-- An opaque past complement: grade `5`, not below boundary `5`. -/
+def exOpaquePast : Node := ⟨notAfter, 5⟩
+/-- A transparent past complement: grade `0`, below boundary `5`. -/
+def exTransparentPast : Node := ⟨notAfter, 0⟩
+
+example : Simultaneous (relationalLicense exMatrix exOpaquePast) := by decide
+example : ¬ Simultaneous (sizeGatedLicense 5 exMatrix exOpaquePast) := by decide
+example : Simultaneous (deReLicense exMatrix exOpaquePast) := by decide
+
+/-- The size-gated profile over a chain `[opaque, transparent]`: the opaque
+    level is back-shift only (`before`), the transparent level keeps both
+    (`notAfter`). -/
+example :
+    profile (sizeGatedLicense 5) exMatrix [exOpaquePast, exTransparentPast]
+      = [before, notAfter] := by decide
+
+end Tense.Sequence

--- a/Linglib/Syntax/Clause/Basic.lean
+++ b/Linglib/Syntax/Clause/Basic.lean
@@ -1,0 +1,53 @@
+import Linglib.Core.Order.Relation
+
+/-!
+# Clause: theory-neutral clause size and transparency
+
+A clause's *size* and its *transparency to a dependency* are framework-neutral
+notions: every theory of clause structure (Minimalist cartography, HPSG, CCG, …)
+ranks its clauses and tells you when a dependency can reach inside one. This
+file owns those notions so that downstream consumers — sequence of tense
+(`Semantics/Tense/Sequence`), relative-clause opacity, long-distance Agree — do
+**not** import any one framework's machinery (`Cat`, `fValue`, …).
+
+A framework *provides* the interface: e.g. `Minimalist.ComplementSize.toClauseSize`
+ranks a complement by its functional grade. Reasoning about opacity then runs
+through `Clause.Size` / `Clause.transparentTo`, not through `Cat`.
+
+The whole notion reduces to `Core.Order`: a size is a grade in a scale, and a
+clause is transparent to a dependency stopped at `boundary` iff its grade is
+*before* (below) the boundary.
+-/
+
+namespace Clause
+
+open Core.Order
+
+/-- A theory-neutral clause size: a grade in a scale, decoupled from any
+    framework's representation. The scale is `ℕ` — every framework can rank its
+    clauses into it (Minimalist via `fValue`, …) — but consumers should reason
+    through `transparentTo`, not the numeral. -/
+abbrev Size : Type := ℕ
+
+/-- A clause of size `s` is transparent to a dependency whose opacity boundary
+    is `boundary` iff its grade is strictly below the boundary in the scale —
+    `Core.Order.before`. (Selective opacity, the Williams Cycle in the abstract:
+    a dependency stopped at `boundary` reaches into everything smaller.) -/
+def transparentTo (s boundary : Size) : Prop := holds before s boundary
+
+instance (s boundary : Size) : Decidable (transparentTo s boundary) :=
+  inferInstanceAs (Decidable (holds _ _ _))
+
+@[simp] theorem transparentTo_iff (s boundary : Size) :
+    transparentTo s boundary ↔ s < boundary := holds_before s boundary
+
+/-- **Upward entailment** (the abstract Williams Cycle): if a clause is opaque
+    to a dependency, every larger clause is opaque too. Framework instances
+    (e.g. `Minimalist`'s `upward_entailment`) are special cases. -/
+theorem opaque_upward {s₁ s₂ boundary : Size}
+    (h : ¬ transparentTo s₁ boundary) (hle : s₁ ≤ s₂) :
+    ¬ transparentTo s₂ boundary := by
+  rw [transparentTo_iff, not_lt] at h ⊢
+  exact le_trans h hle
+
+end Clause

--- a/Linglib/Syntax/Minimalist/ExtendedProjection/Basic.lean
+++ b/Linglib/Syntax/Minimalist/ExtendedProjection/Basic.lean
@@ -24,6 +24,7 @@ Standard EPs:
 
 import Linglib.Syntax.Minimalist.Labeling
 import Linglib.Typology.Profile
+import Linglib.Syntax.Clause.Basic
 
 namespace Minimalist
 
@@ -573,6 +574,12 @@ structure ComplementSize where
 /-- The F-level of a complement (derived from `fValue`). -/
 def ComplementSize.fLevel (cs : ComplementSize) : Nat :=
   fValue cs.highestHead
+
+/-- The theory-neutral `Clause.Size` of this complement: its functional grade.
+    This is how the Minimalist framework *provides* the framework-neutral
+    clause-size interface — downstream opacity/tense reasoning consumes
+    `Clause.Size` (via `Clause.transparentTo`), not `Cat`/`fValue`. -/
+def ComplementSize.toClauseSize (cs : ComplementSize) : Clause.Size := cs.fLevel
 
 /-- A complement is phase-sized (≥ CP) if its highest head is at or
     above the C level in the functional sequence. -/

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -9538,6 +9538,31 @@
   role      = {formalized},
   sources   = {Studies/Egressy2026.lean}
 }
+@inproceedings{kauf-zeijlstra-2018,
+  author    = {Kauf, Carina and Zeijlstra, Hedde},
+  year      = {2018},
+  title     = {Towards a New Explanation of Sequence of Tense},
+  booktitle = {Proceedings of SALT 28},
+  pages     = {59--77},
+  subfield  = {semantics/tense},
+  validated = {true},
+  role      = {cited},
+  sources   = {Semantics/Tense/Sequence/Basic.lean}
+}
+@incollection{ogihara-2019,
+  author    = {Ogihara, Toshiyuki},
+  year      = {2019},
+  title     = {Tense},
+  booktitle = {Semantics: Noun Phrases and Verb Phrases},
+  editor    = {Portner, Paul and von Heusinger, Klaus and Maienborn, Claudia},
+  publisher = {De Gruyter Mouton},
+  pages     = {436--462},
+  doi       = {10.1515/9783110589443-013},
+  subfield  = {semantics/tense},
+  validated = {true},
+  role      = {cited},
+  sources   = {Semantics/Tense/Sequence/Basic.lean}
+}
 @book{reichenbach-1947,
   author    = {Reichenbach, Hans},
   year      = {1947},


### PR DESCRIPTION
The minimal composable foundation for sequence of tense: a cross-cutting licensing interface that both syntactic and semantic theories instantiate as peers.

- `Syntax/Clause/Basic.lean` — framework-neutral `Clause.Size` + `Clause.transparentTo` (selective opacity, reusing `Core.Order`); no `Cat`/`fValue`. `upward_entailment` generalized as `Clause.opaque_upward`.
- `Minimalist.ComplementSize.toClauseSize` — Minimalist *provides* the neutral interface via `fLevel`; it is not required by consumers.
- `Semantics/Tense/Sequence/Basic.lean` — `Node`, `LocalLicense := Node → Node → Finset Ordering`, `profile` (pairwise/adjacency-local fold), reading-views (`Simultaneous`/`Backshifted`/`ForwardShifted` as atoms, no enum), realization bridge to `ReichenbachFrame.isPast/isPresent/isFuture`, and license schemas (relational [kauf-zeijlstra-2018] / size-gated [egressy-2026] / de re) shown to diverge on an opaque past.

Independent of #501 (uses only `Core.Order`, `ComplementSize.fLevel`, `ReichenbachFrame`). Migrating the faithful `Egressy2026` onto this API is a follow-up once #501 lands (it needs the `Say` boundary). Co-edits `ExtendedProjection/Basic` (adds `toClauseSize`) — disjoint region from #501's edits.