### PR TITLE
refactor(SequenceOfTense): relocate de re foil to study; dedup ogihara-1995

### DIFF
--- a/Linglib/Semantics/Tense/Sequence/Basic.lean
+++ b/Linglib/Semantics/Tense/Sequence/Basic.lean
@@ -123,15 +123,11 @@ def sizeGatedLicense (boundary : Clause.Size) : LocalLicense :=
 def LocalLicense.gate (L : LocalLicense) (g : Node → Node → Bool) : LocalLicense :=
   fun a c => if g a c then L a c else (L a c).erase Ordering.eq
 
-/-- Res-movement de re foil: size- and tense-blind, so it adds the forward atom
-    and overgenerates. -/
-def deReLicense : LocalLicense := fun _ _ => unrestricted
-
 /-! ### Worked example: the schemas diverge on an opaque past clause
 
 A concrete demonstration that the interface carries weight: on an opaque past
-clause (grade `5`, boundary `5`), the relational and de re schemas license the
-simultaneous reading but the size-gated one does not. -/
+clause (grade `5`, boundary `5`), the relational schema licenses the simultaneous
+reading but the size-gated one does not. -/
 
 /-- A matrix past clause (size below any boundary used here). -/
 def exMatrix : Node := ⟨notAfter, 0⟩
@@ -142,7 +138,6 @@ def exTransparentPast : Node := ⟨notAfter, 0⟩
 
 example : Simultaneous (relationalLicense exMatrix exOpaquePast) := by decide
 example : ¬ Simultaneous (sizeGatedLicense 5 exMatrix exOpaquePast) := by decide
-example : Simultaneous (deReLicense exMatrix exOpaquePast) := by decide
 
 /-- The size-gated profile over a chain `[opaque, transparent]`: the opaque
     level is back-shift only (`before`), the transparent level keeps both

--- a/Linglib/Studies/Egressy2026.lean
+++ b/Linglib/Studies/Egressy2026.lean
@@ -49,7 +49,7 @@ namespace Egressy2026
 
 open Tense (EmbeddedTenseReading SOTParameter availableReadings)
 open SequenceOfTense
-open Core.Order (notAfter before after)
+open Core.Order (notAfter before after unrestricted)
 open Minimalist
 open Hungarian.Predicates
 
@@ -348,28 +348,38 @@ def ex15 : List Node :=
   [clauseNode notAfter .speechReporting, clauseNode notAfter .speechReporting]
 theorem ex15_profile : simProfile ex15 = [false, false] := by decide
 
-/-- [ogihara-1995]'s ex. (18) (English): *said* > *will claim* > *was*. The
-    intervening future *will* (`after`) is not an agreeing past, so the deepest
-    `was` has no simultaneous reading — the `agreeingPast` gate blocks it,
-    independently of size (English is size-insensitive here). -/
+/-- Past-under-*will*-under-past (English; [ogihara-1996], discussed by
+    [egressy-2026]): *said* > *will claim* > *was*. The intervening future *will*
+    (`after`) is not an agreeing past, so the deepest `was` has no simultaneous
+    reading — the `agreeingPast` gate blocks it, independently of size (English
+    is size-insensitive here). -/
 def ex18 : List Node :=
   [clauseNode after .speechReporting, clauseNode notAfter .speechReporting]
 theorem ex18_no_simultaneous : simProfile ex18 = [false, false] := by decide
 
 
-/-! ### Williams-Cycle support over a de re alternative ([egressy-2026], §3.3)
+/-! ### Williams-Cycle support over an *unbounded* de re alternative ([egressy-2026], §3.3)
 
-A *res*-movement (de re) derivation of the simultaneous reading ([abusch-1988],
-[abusch-1997]) moves the embedded `PAST` to an A-position inside the matrix VP.
-Such movement would not be stopped by the `Say` layer, so it is *size-blind*:
-it predicts the simultaneous reading for speech-reporting clauses too. The
-observed asymmetry (`speech_backshift_only`) therefore favors the SOT-Agree
-analysis, whose dependency obeys the Williams Cycle. -/
+An *unbounded* res-movement (de re) derivation would move the embedded `PAST` to
+an A-position inside the matrix VP, unstopped by the `Say` layer — hence
+*size-blind*. Egressy argues the Williams Cycle rules this out: a size-blind
+mechanism would license simultaneity for speech-reporting clauses, contrary to
+fact. The foil below ([abusch-1988], [abusch-1997]) is exactly that size-blind
+account; the *restricted* de re of [ogihara-sharvit-2012] (and the Polish
+account of Mucha, Renans & Romoli) is a different, constrained mechanism this
+argument does not, on its own, refute. -/
 
-/-- The de re account overgenerates: size-blind, it licenses simultaneity for a
-    speech-reporting clause, which `egressyLicense` correctly blocks. -/
+/-- The unbounded (size-blind) de re foil: it licenses every reading. Local to
+    this study — it is Egressy's reductio against unbounded res-movement, not a
+    neutral SOT mechanism. -/
+def deReUnrestricted : LocalLicense := fun _ _ => unrestricted
+
+/-- The *unbounded* de re foil overgenerates: size-blind, it licenses
+    simultaneity for a speech-reporting clause, which `egressyLicense` correctly
+    blocks. This refutes unbounded res-movement, not the restricted de re of
+    [ogihara-sharvit-2012]. -/
 theorem de_re_overgenerates :
-    Simultaneous (deReLicense pastMatrix (clauseNode notAfter .speechReporting)) ∧
+    Simultaneous (deReUnrestricted pastMatrix (clauseNode notAfter .speechReporting)) ∧
     ¬ Simultaneous (egressyLicense pastMatrix (clauseNode notAfter .speechReporting)) := by decide
 
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -9538,16 +9538,6 @@
   role      = {formalized},
   sources   = {Studies/Egressy2026.lean}
 }
-@book{ogihara-1995,
-  author    = {Ogihara, Toshiyuki},
-  year      = {1995},
-  title     = {Tense, Attitudes, and Scope},
-  publisher = {Springer},
-  subfield  = {semantics/tense},
-  validated = {true},
-  role      = {cited},
-  sources   = {Studies/Egressy2026.lean}
-}
 @book{williams-2003,
   author    = {Williams, Edwin},
   year      = {2003},


### PR DESCRIPTION
First step of the long-run SOT API plan (panel-vetted; spec in scratch/sot-longrun-api.md).

- **Remove the `deReLicense := unrestricted` strawman from the substrate** (`Semantics/Tense/Sequence/Basic.lean`). A size-blind `unrestricted` license froze Egressy's polemical conclusion into the neutral interface. It moves to `Studies/Egressy2026.deReUnrestricted` as what it actually is — Egressy's reductio against *unbounded* res-movement — with the docstring noting that the *restricted* de re of Ogihara-Sharvit / Mucha et al. is a different mechanism this argument does not refute. `de_re_overgenerates` re-stated over `deReUnrestricted`.
- **Dedup `ogihara-1995`**: it was a duplicate of `ogihara-1996` (both the book "Tense, Attitudes, and Scope"). Repointed the one cite to `ogihara-1996` and deleted the duplicate entry. Also dropped an unverifiable "ex. (18)" example-number citation in favor of a content description.

Substrate `Sequence/Basic.lean` now ships only genuine, neutral license schemas (`relationalLicense`, `sizeGatedLicense`, `LocalLicense.gate`); theory-specific foils live in their study. Warm-verified green.