### PR TITLE
feat(SequenceOfTense): pragmatic Narrowing layer (constraint refinement)

### DIFF
--- a/Linglib/Semantics/Tense/Sequence/Basic.lean
+++ b/Linglib/Semantics/Tense/Sequence/Basic.lean
@@ -123,6 +123,30 @@ def sizeGatedLicense (boundary : Clause.Size) : LocalLicense :=
 def LocalLicense.gate (L : LocalLicense) (g : Node → Node → Bool) : LocalLicense :=
   fun a c => if g a c then L a c else (L a c).erase Ordering.eq
 
+/-! ### Pragmatic narrowing (layer 2: a constraint on the grammatical reading set)
+
+Grammar (a `LocalLicense`) emits the *grammatically available* reading set; a
+pragmatic inference then *narrows* it — direct perception (one cannot perceive a
+past event), a cessation implicature (a past stative implicates non-overlap with
+now), etc. A narrowing is **intersection with a context-conditioned constraint**
+(a further point-algebra relation), so it can only *remove* readings, never
+license a new one — the grammar/pragmatics boundary, free from
+`Finset.inter_subset_left` rather than a stipulated law. The context `C` is
+whatever the inference consults (polarity, perception-directness, …). -/
+
+/-- A pragmatic narrowing: the point-algebra constraint it imposes, as a function
+    of the context the inference consults. -/
+abbrev Narrowing (C : Type*) := C → Finset Ordering
+
+/-- Narrow a grammatically-licensed reading set: intersect with the constraint. -/
+def Narrowing.apply {C : Type*} (n : Narrowing C) (ctx : C) (s : Finset Ordering) :
+    Finset Ordering := s ∩ n ctx
+
+/-- Pragmatics filters, never licenses: narrowing only removes readings. -/
+theorem Narrowing.apply_subset {C : Type*} (n : Narrowing C) (ctx : C)
+    (s : Finset Ordering) : n.apply ctx s ⊆ s :=
+  Finset.inter_subset_left
+
 /-! ### Worked example: the schemas diverge on an opaque past clause
 
 A concrete demonstration that the interface carries weight: on an opaque past

--- a/Linglib/Studies/Egressy2026.lean
+++ b/Linglib/Studies/Egressy2026.lean
@@ -49,7 +49,7 @@ namespace Egressy2026
 
 open Tense (EmbeddedTenseReading SOTParameter availableReadings)
 open SequenceOfTense
-open Core.Order (notAfter before after unrestricted)
+open Core.Order (notAfter before after unrestricted overlapping)
 open Minimalist
 open Hungarian.Predicates
 
@@ -296,9 +296,10 @@ theorem ex11_verb_from_fragment : ex11_mond.matrixVerb = mond.formPastDef := rfl
 
 For the direct-perception examples (4)–(6) the back-shifted reading is excluded
 for *pragmatic* reasons — one cannot directly perceive a past event — even
-though it is grammatically available (`nonSpeech_both`). This is prose in the
-paper, recorded here as the data fact that direct-perception clauses are
-observed simultaneous. -/
+though it is grammatically available (`nonSpeech_both`). This is the layer-2
+`Narrowing` from the foundation: direct perception intersects the grammatical
+reading set with the `overlapping` (=) constraint, leaving simultaneous-only
+(`direct_perception_narrows`). -/
 
 /-- The direct-perception data (perception and dreaming). -/
 def directPerceptionData : List SOTDatum := [ex4_lat, ex5_hall, ex6_almodik]
@@ -311,6 +312,17 @@ theorem direct_perception_simultaneous :
       d.simultaneousObserved &&
         (toReadings (egressyLicense pastMatrix (clauseNode notAfter d.clauseType))
           == [EmbeddedTenseReading.shifted, EmbeddedTenseReading.simultaneous])) = true := by
+  decide
+
+/-- Direct perception as a layer-2 `Narrowing`: it imposes the `overlapping` (=)
+    constraint — only a simultaneous reading is perceivable. -/
+def directPerception : Narrowing Unit := fun _ => overlapping
+
+/-- The prose fact as a theorem: direct perception narrows the grammatically
+    both-readings non-speech license down to simultaneous-only. -/
+theorem direct_perception_narrows :
+    directPerception.apply ()
+        (egressyLicense pastMatrix (clauseNode notAfter .nonSpeechReporting)) = overlapping := by
   decide
 
 


### PR DESCRIPTION
Step 3 of the long-run SOT plan (scratch/sot-longrun-api.md): the second layer of the three-layer architecture.

- `Narrowing C := C → Finset Ordering` + `Narrowing.apply` (intersect the grammatically-licensed reading set with a context-conditioned point-algebra constraint). Because narrowing **is intersection**, the grammar/pragmatics boundary — "pragmatics filters, never licenses" — is *free*: `Narrowing.apply_subset` is just `Finset.inter_subset_left`, not a stipulated law.
- First consumer: `Egressy2026.directPerception` (imposes the `overlapping` = constraint). This turns the paper's prose fact — direct perception is simultaneous-only because one cannot perceive a past event — into the theorem `direct_perception_narrows`, replacing the data-fact workaround.

The layer is deliberately minimal (a type + one def + one lemma); the cessation-implicature narrowing (Mucha / Altshuler-Schwarzschild, polarity-conditioned) is the planned 2nd consumer. Warm-verified green.