### PR TITLE
fix(Studies): correct Stojkovic2026 present-stem data; mathlib idiom pass

### DIFF
--- a/Linglib/Studies/Stojkovic2026.lean
+++ b/Linglib/Studies/Stojkovic2026.lean
@@ -15,12 +15,15 @@ Three-way surface alternation across Slavic:
 
 | Group        | INF stem VC | Languages                                  |
 |--------------|-------------|--------------------------------------------|
-| [ov] group   | [ov]        | Polish, Czech, Slovak, U/L Sorbian,...    |
-| [ov]/[ev]    | [ov]∼[ev]   | BCMS, Slovenian, Russian,...              |
+| [ov] group   | [ov]        | Polish, Czech, Slovak, U/L Sorbian,...     |
+| [ov]/[ev]    | [ov]∼[ev]   | BCMS, Slovenian, Russian,...               |
 | [uv] group   | [uv]        | Ukrainian, Lemko Rusyn, Bulgarian, Maced.  |
 
-All groups share the present-stem vowel [u] (before /-je-/). The
-variation is confined to the infinitive stem (before /-a-/).
+Where the VBLZ precedes the theme vowel /-je-/ in the present, the
+present stem is the single vowel [u] and the VC alternation is confined
+to the infinitive stem (before /-a-/). Bulgarian and Macedonian are the
+exception: having lost the INF/PRS distinction, they have /-a-/ after the
+VBLZ in both stems, so the VC sequence [uv] surfaces throughout (Table 1).
 
 ## Candidates
 
@@ -34,7 +37,7 @@ slot of the diphthong is resolved:
 | [ev]      | [e] = [−back, −high] | share [−back] from palatal, epenthesise [−high] |
 | [uv]      | [u] = [+back, +high] | epenthesise [+back] and [+high] |
 | [iv]      | [i] = [−back, +high] | share [−back] from palatal, epenthesise [+high] |
-| [u.a]     | hiatus     | monophthongise, delete unspecified slot |
+| [u]       | monophthong | delete the unspecified slot |
 
 ## Constraints
 
@@ -58,9 +61,16 @@ explicit as DEP[+high] yields the correct factorial typology.
 
 ## Factorial Typology
 
-The 4! = 24 permutations of the four variable constraints produce
-exactly 4 distinct optima: {[ov]}, {[ev]}, {[uv]}, {[iv]}. Three
-correspond to attested groups; {[iv]} is unattested.
+[stojkovic-2026]'s own factorial typology (31) ranks *three* constraints
+(*SHARE[−back], DEP[+back], DEP[−high]) and derives the three attested
+patterns — [ov], the context-sensitive [ov]~[ev], and [uv] — plus a
+hypothetical [uv]~[iv] (31f). In pure OT those three constraints leave [uv]
+harmonically bounding [ov] (§4.2, p. 14), which the paper resolves by the
+markedness of [−high] epenthesis rather than a constraint. Making that
+preference explicit as DEP[+high], the 4! = 24 permutations of the four
+variable constraints here yield four singleton optima — {[ov]}, {[ev]},
+{[uv]}, {[iv]} — the first three attested, [iv] unattested ((32): the
+hypothetical Ukrainian [uv]~[iv] pairs).
 
 -/
 
@@ -68,9 +78,33 @@ namespace Stojkovic2026
 
 open Phonology.Constraint.OT Core.Optimization.Evaluation Phonology.Constraints
 
--- ============================================================================
--- § 0: Empirical Data
--- ============================================================================
+/-! ### Candidates -/
+
+/-- Candidate surface realisations of the VBLZ, each a resolution of the
+    defective diphthong. This is the typed surface-form inventory used
+    throughout the file (no stringly-typed forms). -/
+inductive VBLZCandidate where
+  /-- [ov]: diphthong fissions, slot 1 → [o] via epenthetic [+back, −high]. -/
+  | ov
+  /-- [ev]: diphthong fissions, slot 1 → [e] via shared [−back], epenthetic [−high]. -/
+  | ev
+  /-- [uv]: diphthong fissions, slot 1 → [u] via epenthetic [+back, +high]. -/
+  | uv
+  /-- [iv]: diphthong fissions, slot 1 → [i] via shared [−back], epenthetic [+high]. -/
+  | iv
+  /-- [u]: monophthong — the unspecified slot is deleted. Before a vowel this
+      yields a hiatus ([u.a], penalised by NOHIATUS); before a consonant (the
+      /-je-/ present) it is the licit single vowel [u]. -/
+  | uMono
+  deriving DecidableEq, Repr
+
+/-- All candidates. -/
+def allCandidates : List VBLZCandidate := [.ov, .ev, .uv, .iv, .uMono]
+
+/-- The four fission candidates (excluding the monophthong), for factorial typology. -/
+def fissionCandidates : List VBLZCandidate := [.ov, .ev, .uv, .iv]
+
+/-! ### Empirical data -/
 
 /-- Representative Slavic languages exhibiting secondary imperfectivisation. -/
 inductive SlavicLang where
@@ -98,11 +132,11 @@ inductive VBLZGroup where
   | uvGroup
   deriving DecidableEq, Repr
 
-/-- Surface VC forms attested in the infinitive stem for each group. -/
-def VBLZGroup.forms : VBLZGroup → List String
-  | .ovGroup   => ["ov"]
-  | .ovEvGroup => ["ov", "ev"]
-  | .uvGroup   => ["uv"]
+/-- Surface candidates attested in the infinitive stem for each group. -/
+def VBLZGroup.forms : VBLZGroup → List VBLZCandidate
+  | .ovGroup   => [.ov]
+  | .ovEvGroup => [.ov, .ev]
+  | .uvGroup   => [.uv]
 
 /-- Group membership for each language. -/
 def SlavicLang.vblzGroup : SlavicLang → VBLZGroup
@@ -110,25 +144,25 @@ def SlavicLang.vblzGroup : SlavicLang → VBLZGroup
   | .russian | .bcms | .slovenian                              => .ovEvGroup
   | .ukrainian | .lemkoRusyn | .bulgarian | .macedonian        => .uvGroup
 
-/-- A VBLZ datum: language, infinitive-stem VC, present-stem V. -/
+/-- A VBLZ datum: language, infinitive-stem and present-stem surface candidate. -/
 structure VBLZDatum where
   lang : SlavicLang
-  infStem : String
-  presStem : String
+  infStem : VBLZCandidate
+  presStem : VBLZCandidate
   deriving DecidableEq, Repr
 
-def polishVBLZ : VBLZDatum := ⟨.polish, "ov", "u"⟩
-def czechVBLZ : VBLZDatum := ⟨.czech, "ov", "u"⟩
-def slovakVBLZ : VBLZDatum := ⟨.slovak, "ov", "u"⟩
-def upperSorbianVBLZ : VBLZDatum := ⟨.upperSorbian, "ov", "u"⟩
-def lowerSorbianVBLZ : VBLZDatum := ⟨.lowerSorbian, "ov", "u"⟩
-def russianVBLZ : VBLZDatum := ⟨.russian, "ov", "u"⟩
-def bcmsVBLZ : VBLZDatum := ⟨.bcms, "ov", "u"⟩
-def slovenianVBLZ : VBLZDatum := ⟨.slovenian, "ov", "u"⟩
-def ukrainianVBLZ : VBLZDatum := ⟨.ukrainian, "uv", "u"⟩
-def lemkoRusynVBLZ : VBLZDatum := ⟨.lemkoRusyn, "uv", "u"⟩
-def bulgarianVBLZ : VBLZDatum := ⟨.bulgarian, "uv", "u"⟩
-def macedonianVBLZ : VBLZDatum := ⟨.macedonian, "uv", "u"⟩
+def polishVBLZ : VBLZDatum := ⟨.polish, .ov, .uMono⟩
+def czechVBLZ : VBLZDatum := ⟨.czech, .ov, .uMono⟩
+def slovakVBLZ : VBLZDatum := ⟨.slovak, .ov, .uMono⟩
+def upperSorbianVBLZ : VBLZDatum := ⟨.upperSorbian, .ov, .uMono⟩
+def lowerSorbianVBLZ : VBLZDatum := ⟨.lowerSorbian, .ov, .uMono⟩
+def russianVBLZ : VBLZDatum := ⟨.russian, .ov, .uMono⟩
+def bcmsVBLZ : VBLZDatum := ⟨.bcms, .ov, .uMono⟩
+def slovenianVBLZ : VBLZDatum := ⟨.slovenian, .ov, .uMono⟩
+def ukrainianVBLZ : VBLZDatum := ⟨.ukrainian, .uv, .uMono⟩
+def lemkoRusynVBLZ : VBLZDatum := ⟨.lemkoRusyn, .uv, .uMono⟩
+def bulgarianVBLZ : VBLZDatum := ⟨.bulgarian, .uv, .uv⟩
+def macedonianVBLZ : VBLZDatum := ⟨.macedonian, .uv, .uv⟩
 
 def allData : List VBLZDatum :=
   [polishVBLZ, czechVBLZ, slovakVBLZ, upperSorbianVBLZ, lowerSorbianVBLZ,
@@ -137,215 +171,162 @@ def allData : List VBLZDatum :=
 
 theorem allData_length : allData.length = 12 := rfl
 
-/-- The present-stem vowel is universally [u] across all three groups. -/
-theorem presentStemUniversal :
-    allData.all (fun d => d.presStem == "u") = true := rfl
+/-- Bulgarian and Macedonian lack the INF/PRS distinction: the VBLZ precedes the
+    theme vowel /-a-/ in *both* stems, so the VC sequence [uv] surfaces in the
+    present too. All other languages have /-je-/ in the present, where the VBLZ
+    is the single vowel [u] ([stojkovic-2026], Table 1, §4.4). -/
+def SlavicLang.HasVCPresent : SlavicLang → Prop
+  | .bulgarian | .macedonian => True
+  | _ => False
 
-/-- Each datum's infinitive stem is consistent with its language's group. -/
-theorem infStem_matches_group :
-    allData.all (fun d => d.lang.vblzGroup.forms.contains d.infStem) = true := rfl
+instance : DecidablePred SlavicLang.HasVCPresent := fun l => by
+  cases l <;> unfold SlavicLang.HasVCPresent <;> infer_instance
 
--- ============================================================================
--- § 1: Candidates
--- ============================================================================
+/-- The present stem is the single vowel [u] exactly in the languages with a
+    /-je-/ present; Bulgarian and Macedonian surface the VC sequence [uv]
+    throughout — the paper's central cross-Slavic exception ([stojkovic-2026],
+    Table 1, §4.4). -/
+theorem presentStem_iff_VCPresent :
+    ∀ d ∈ allData, d.lang.HasVCPresent ↔ d.presStem = .uv := by decide
 
-/-- Candidate surface realisations of the VBLZ before the thematic /-a-/.
-    Each represents a different resolution of the defective diphthong. -/
-inductive VBLZCandidate where
-  /-- [ov]: diphthong fissions, slot 1 → [o] via epenthetic [+back, −high]. -/
-  | ov
-  /-- [ev]: diphthong fissions, slot 1 → [e] via shared [−back], epenthetic [−high]. -/
-  | ev
-  /-- [uv]: diphthong fissions, slot 1 → [u] via epenthetic [+back, +high]. -/
-  | uv
-  /-- [iv]: diphthong fissions, slot 1 → [i] via shared [−back], epenthetic [+high]. -/
-  | iv
-  /-- [u.a]: monophthongisation, unspecified slot deleted, hiatus with /-a-/. -/
-  | uHiatus
-  deriving DecidableEq, Repr
+/-- Each datum's infinitive stem is one of its language's group forms. -/
+theorem infStem_mem_group_forms :
+    ∀ d ∈ allData, d.infStem ∈ d.lang.vblzGroup.forms := by decide
 
-/-- All candidates. -/
-def allCandidates : List VBLZCandidate := [.ov, .ev, .uv, .iv, .uHiatus]
+/-! ### Constraints -/
 
-/-- The four fission candidates (excluding hiatus), for factorial typology. -/
-def fissionCandidates : List VBLZCandidate := [.ov, .ev, .uv, .iv]
-
--- ============================================================================
--- § 2: Constraints
--- ============================================================================
-
-/-- NOHIATUS: assign * for adjacent vowels. -/
+/-- NOHIATUS: assign * for adjacent vowels. In the pre-vocalic evaluation the
+    monophthong `.uMono` realises [u] next to /-a-/, creating the hiatus this
+    constraint penalises. -/
 def noHiatus : NamedConstraint VBLZCandidate :=
-  mkMark "NOHIATUS" fun c => c = .uHiatus
+  mkMark "NOHIATUS" fun c => c = .uMono
 
-/-- SPECIFY(•→[F]): assign * for unspecified base node.
-    Only violated by the fully faithful candidate (not in our candidate set),
-    so this constraint is vacuously satisfied. Included for completeness. -/
+/-- SPECIFY(•→[F]): assign * for an unspecified base node. Only the fully
+    faithful candidate (not in our candidate set) violates it, so it is
+    vacuously satisfied here; included for faithfulness to the paper's set. -/
 def specify : NamedConstraint VBLZCandidate :=
   mkMark "SPECIFY" fun _ => False
 
 /-- *SHARE[−back]: don't copy [−back] from an adjacent palatal.
-    Violated by [ev] (shares [−back] for [e]) and [iv] (shares [−back] for [i]). -/
+    Violated by [ev] and [iv] (both share [−back]). -/
 def noShareBack : NamedConstraint VBLZCandidate :=
   mkMark "*SHARE[−back]" fun c => c = .ev ∨ c = .iv
 
-/-- DEP[+back]: don't epenthesise [+back] on the unspecified slot.
-    Violated by [ov] and [uv] (both epenthesise [+back] to get a back vowel). -/
+/-- DEP[+back]: don't epenthesise [+back]. Violated by [ov] and [uv]. -/
 def depBack : NamedConstraint VBLZCandidate :=
   mkDep "DEP[+back]" fun c => c = .ov ∨ c = .uv
 
-/-- DEP[−high]: don't epenthesise [−high] on the unspecified slot.
-    Violated by [ov] and [ev] (both epenthesise [−high] to get a mid vowel). -/
-def depLowHigh : NamedConstraint VBLZCandidate :=
+/-- DEP[−high]: don't epenthesise [−high]. Violated by [ov] and [ev] (mid vowels). -/
+def depMinusHigh : NamedConstraint VBLZCandidate :=
   mkDep "DEP[−high]" fun c => c = .ov ∨ c = .ev
 
-/-- DEP[+high]: don't epenthesise [+high] on the unspecified slot.
-    Violated by [uv] and [iv] (both epenthesise [+high] to get a high vowel).
+/-- DEP[+high]: don't epenthesise [+high]. Violated by [uv] and [iv] (high vowels).
 
-    Implicit in Stojković's analysis. Without this constraint, [uv]
-    harmonically bounds [ov], making it impossible for any ranking to
-    select [ov] as optimal. Stojković derives the equivalent effect
-    from the markedness of [+high] vs [−high] (p. 14): "The feature
-    [−high] is cross-linguistically more likely to be unmarked compared
-    to [+high]." -/
+    Implicit in [stojkovic-2026]: without it [uv] harmonically bounds [ov], so no
+    ranking selects [ov]. The paper derives the same effect from the markedness
+    of [+high] vs [−high] (p. 14: "The feature [−high] is cross-linguistically
+    more likely to be unmarked compared to [+high]."). -/
 def depHigh : NamedConstraint VBLZCandidate :=
   mkDep "DEP[+high]" fun c => c = .uv ∨ c = .iv
 
-/-- The four variable constraints (excluding the undominated NOHIATUS
-    and vacuous SPECIFY). These are permuted in the factorial typology. -/
+/-- The four variable constraints (excluding the undominated NOHIATUS and vacuous
+    SPECIFY), permuted in the factorial typology. -/
 def variableConstraints : List (NamedConstraint VBLZCandidate) :=
-  [noShareBack, depBack, depLowHigh, depHigh]
+  [noShareBack, depBack, depMinusHigh, depHigh]
 
-/-- All six constraints in one list. -/
+/-- All six constraints. -/
 def allConstraints : List (NamedConstraint VBLZCandidate) :=
-  [noHiatus, specify, noShareBack, depBack, depLowHigh, depHigh]
+  [noHiatus, specify, noShareBack, depBack, depMinusHigh, depHigh]
 
--- ============================================================================
--- § 3: Group-Specific Rankings
--- ============================================================================
+/-! ### Group-specific rankings -/
 
-/-- [ov] group ranking (Stojković 2026, (17)):
-    NOHIATUS, SPECIFY ≫ *SHARE[−back] ≫ DEP[+high] ≫ DEP[+back] ≫ DEP[−high]
+/-- [ov]-group ranking, adapted from [stojkovic-2026] (17). The paper's (17) is
+    `NOHIATUS; SPECIFY ≫ *SHARE[−back] ≫ DEP[−high] ≫ DEP[+back] ≫ MAX•`, with
+    [ov]≻[uv] following from the markedness of [−high] epenthesis (p. 14) rather
+    than a constraint; we make that preference explicit via DEP[+high], giving
+    `*SHARE[−back] ≫ DEP[+high] ≫ DEP[+back] ≫ DEP[−high]`.
 
-    *SHARE[−back] high: sharing [−back] from palatals is banned.
-    DEP[+high] above DEP[−high]: [+high] epenthesis is costlier than [−high],
-    making [−high] the default → mid vowel [o] surfaces. -/
+    *SHARE[−back] high: sharing [−back] from palatals is banned. DEP[+high] high:
+    [+high] epenthesis is costly, so the unmarked [−high] surfaces → mid [o]. -/
 def ovRanking : List (NamedConstraint VBLZCandidate) :=
-  [noHiatus, specify, noShareBack, depHigh, depBack, depLowHigh]
+  [noHiatus, specify, noShareBack, depHigh, depBack, depMinusHigh]
 
-/-- [ov]/[ev] group ranking (Stojković 2026, (21)):
-    NOHIATUS, SPECIFY ≫ DEP[+back] ≫ DEP[+high] ≫ *SHARE[−back] ≫ DEP[−high]
+/-- [ov]/[ev]-group ranking, adapted from [stojkovic-2026] (21). The paper's (21)
+    is `NOHIATUS; SPECIFY ≫ DEP[+back] ≫ DEP[−high] ≫ *SHARE[−back] ≫ MAX•`; with
+    DEP[+high] made explicit: `DEP[+back] ≫ DEP[+high] ≫ *SHARE[−back] ≫ DEP[−high]`.
 
-    DEP[+back] high: epenthesising [+back] is banned. After palatals,
-    sharing [−back] is the only option → [ev]. After non-palatals,
-    [−high] epenthesis yields [ov] (in a separate non-palatal evaluation). -/
+    DEP[+back] high: epenthesising [+back] is banned. After a palatal, sharing
+    [−back] is the only option → [ev]; after a non-palatal, [−high] epenthesis
+    yields [ov] (a separate, non-palatal evaluation — not modelled here). -/
 def ovEvRanking : List (NamedConstraint VBLZCandidate) :=
-  [noHiatus, specify, depBack, depHigh, noShareBack, depLowHigh]
+  [noHiatus, specify, depBack, depHigh, noShareBack, depMinusHigh]
 
-/-- [uv] group ranking (Stojković 2026, (29)):
-    NOHIATUS, SPECIFY ≫ DEP[−high] ≫ *SHARE[−back] ≫ DEP[+back] ≫ DEP[+high]
+/-- [uv]-group ranking, adapted from [stojkovic-2026] (29). The paper's (29) is
+    `NOHIATUS; SPECIFY ≫ DEP[−high] ≫ *SHARE[−back] ≫ DEP[+back] ≫ MAX•`; we keep
+    that order and replace the bottom MAX• with the explicit DEP[+high]:
+    `DEP[−high] ≫ *SHARE[−back] ≫ DEP[+back] ≫ DEP[+high]`.
 
     DEP[−high] high: epenthesising [−high] is banned → [+high] surfaces.
-    *SHARE[−back] above DEP[+back]: epenthesising [+back] is cheaper
-    than sharing [−back] → back vowel [u] surfaces. -/
+    *SHARE[−back] above DEP[+back]: epenthesising [+back] is cheaper than sharing
+    [−back] → back vowel [u] surfaces. -/
 def uvRanking : List (NamedConstraint VBLZCandidate) :=
-  [noHiatus, specify, depLowHigh, noShareBack, depBack, depHigh]
+  [noHiatus, specify, depMinusHigh, noShareBack, depBack, depHigh]
 
--- ============================================================================
--- § 4: Optimality Theorems
--- ============================================================================
+/-! ### Optimality theorems -/
 
-/-- The [ov] group ranking selects [ov] as the unique optimal candidate. -/
+/-- The [ov]-group ranking selects [ov] as the unique optimum. -/
 theorem ov_optimal :
-    (mkTableau allCandidates ovRanking).optimal
-      = {.ov} := by native_decide
+    (mkTableau allCandidates ovRanking).optimal = {.ov} := by decide
 
-/-- The [ov]/[ev] ranking selects [ev] as optimal in the palatal context.
-    (In the non-palatal context, [ev] and [iv] are unavailable because
-    there is no palatal to share [−back]; [ov] wins trivially.) -/
+/-- The [ov]/[ev] ranking selects [ev] in the palatal context. (Non-palatally,
+    [ev] and [iv] are unavailable — no palatal to share [−back] — and [ov] wins;
+    that contextual split is not modelled in this single tableau.) -/
 theorem ev_optimal :
-    (mkTableau allCandidates ovEvRanking).optimal
-      = {.ev} := by native_decide
+    (mkTableau allCandidates ovEvRanking).optimal = {.ev} := by decide
 
-/-- The [uv] group ranking selects [uv] as the unique optimal candidate. -/
+/-- The [uv]-group ranking selects [uv] as the unique optimum. -/
 theorem uv_optimal :
-    (mkTableau allCandidates uvRanking).optimal
-      = {.uv} := by native_decide
+    (mkTableau allCandidates uvRanking).optimal = {.uv} := by decide
 
--- ============================================================================
--- § 5: Factorial Typology
--- ============================================================================
+/-! ### Factorial typology -/
 
 set_option maxRecDepth 1024 in
-/-- The factorial typology over the four variable constraints and four
-    fission candidates produces exactly 4 distinct optimal sets.
-
-    Three correspond to attested Slavic groups:
-    - {[ov]}: *SHARE, DEP[+high] ranked high
-    - {[ev]}: DEP[+back], DEP[+high] ranked high
-    - {[uv]}: DEP[−high], *SHARE ranked high
-
-    The fourth ({[iv]}) is unattested in Slavic. -/
+/-- This file's four-constraint factorial typology (the three sharing/epenthesis
+    constraints plus the explicit DEP[+high]) over the four fission candidates
+    produces exactly four distinct optimal sets: {[ov]}, {[ev]}, {[uv]}, {[iv]}.
+    [stojkovic-2026]'s own typology (31) is over *three* constraints and yields
+    the three attested groups (with [ov]~[ev] one context-sensitive grammar) plus
+    a hypothetical [uv]~[iv]; see the module docstring. -/
 theorem factorial_typology_size :
-    mkFactorialTypologySize fissionCandidates variableConstraints
-      = 4 := by native_decide
+    mkFactorialTypologySize fissionCandidates variableConstraints = 4 := by decide
 
 set_option maxRecDepth 1024 in
 /-- The four distinct optima are exactly the four singleton candidate sets. -/
 theorem factorial_optima_are_singletons :
     mkFactorialOptima fissionCandidates variableConstraints
-     
-    = [{.uv}, {.iv}, {.ov}, {.ev}] := by native_decide
+      = [{.uv}, {.iv}, {.ov}, {.ev}] := by decide
 
-/-- The [iv] pattern (shared [−back] + [+high], giving a front high vowel)
-    is the only unattested pattern among the four predicted by the
-    factorial typology (Stojković 2026, (31f)). -/
-def ivIsUnattested : Prop :=
-  ∀ (l : SlavicLang), l.vblzGroup ≠ .ovGroup →
-    l.vblzGroup ≠ .uvGroup → l.vblzGroup = .ovEvGroup
+/-- [iv] is the unattested optimum: the factorial typology predicts an [iv]
+    grammar (`{.iv}` is among the optima), yet no attested Slavic language
+    surfaces the [iv] form — every group's inventory is one of [ov]/[ev]/[uv]
+    ([stojkovic-2026], (31f)–(32): the Ukrainian [uv]~[iv] pairs are
+    hypothetical and unattested). -/
+theorem iv_unattested :
+    ({VBLZCandidate.iv} : Finset VBLZCandidate) ∈
+        mkFactorialOptima fissionCandidates variableConstraints ∧
+    ∀ d ∈ allData, VBLZCandidate.iv ∉ d.lang.vblzGroup.forms := by
+  refine ⟨?_, by decide⟩
+  rw [factorial_optima_are_singletons]; decide
 
-theorem iv_pattern_unattested : ivIsUnattested := by
-  intro l h1 h2
-  cases l <;> simp [SlavicLang.vblzGroup] at h1 h2 ⊢
+/-! ### Bridge to empirical data -/
 
--- ============================================================================
--- § 6: Bridge to Empirical Data
--- ============================================================================
-
-/-- The [ov] group's OT-predicted form matches the empirical data. -/
-theorem ov_matches_group :
-    VBLZGroup.ovGroup.forms.contains "ov" = true := rfl
-
-/-- The [uv] group's OT-predicted form matches the empirical data. -/
-theorem uv_matches_group :
-    VBLZGroup.uvGroup.forms.contains "uv" = true := rfl
-
-/-- The [ov]/[ev] group's OT-predicted forms match the empirical data:
-    [ev] in the palatal context (proved by `ev_optimal`), [ov] in the
-    non-palatal context (where [ev] is unavailable). -/
-theorem ovEv_matches_group :
-    VBLZGroup.ovEvGroup.forms.contains "ev" = true ∧
-    VBLZGroup.ovEvGroup.forms.contains "ov" = true := ⟨rfl, rfl⟩
-
-/-- The surface form of each candidate. -/
-def VBLZCandidate.surfaceForm : VBLZCandidate → String
-  | .ov => "ov"
-  | .ev => "ev"
-  | .uv => "uv"
-  | .iv => "iv"
-  | .uHiatus => "u"
-
-/-- The OT-optimal candidate for the [ov] group produces the attested form. -/
-theorem ov_surface_correct :
-    VBLZCandidate.ov.surfaceForm = "ov" := rfl
-
-/-- The OT-optimal candidate for the [uv] group produces the attested form. -/
-theorem uv_surface_correct :
-    VBLZCandidate.uv.surfaceForm = "uv" := rfl
-
-/-- The OT-optimal candidate for the [ov]/[ev] palatal context produces
-    the attested palatal-conditioned form. -/
-theorem ev_surface_correct :
-    VBLZCandidate.ev.surfaceForm = "ev" := rfl
+/-- The OT-optimal candidate for each group (`ov_optimal`/`ev_optimal`/`uv_optimal`)
+    is among that group's attested forms; [ov] also figures in the [ov]/[ev]
+    group's inventory. -/
+theorem optimal_forms_attested :
+    VBLZCandidate.ov ∈ VBLZGroup.ovGroup.forms ∧
+    VBLZCandidate.ev ∈ VBLZGroup.ovEvGroup.forms ∧
+    VBLZCandidate.ov ∈ VBLZGroup.ovEvGroup.forms ∧
+    VBLZCandidate.uv ∈ VBLZGroup.uvGroup.forms := by decide
 
 end Stojkovic2026


### PR DESCRIPTION
Audit of `Studies/Stojkovic2026.lean` against the actual paper (Stojković 2026, *Same Form, Different Grammars*) found one empirical error plus citation/idiom issues. The paper itself is faithfully represented (analysis, language groupings, candidates, features all correct) — this corrects the error and brings the file to mathlib quality.

**Empirical fix**
- Bulgarian and Macedonian present stems were recorded as `[u]`; the paper (Table 1, §4.4) states they surface the VC sequence `[uv]` throughout (they lack the INF/PRS distinction). Corrected the data; `presentStemUniversal` (a false universal) is replaced by `presentStem_iff_VCPresent`, which states the paper's actual claim with Bulgarian/Macedonian as the explicit exception.

**Citation fidelity**
- The group rankings and factorial typology are the file's `DEP[+high]` adaptation, not the paper's literal `(17)/(21)/(29)/(31)` (which use `Max•` and derive `[ov]≻[uv]` from markedness). Docstrings now quote the paper's actual hierarchies and flag the adaptation. The vacuous `ivIsUnattested` (true of any 3-group enum) is replaced by a contentful `iv_unattested`.

**mathlib idiom**
- `String` surface forms → the existing typed `VBLZCandidate` inventory (`VBLZGroup.forms`, `VBLZDatum.{infStem,presStem}`); deleted the stringly-typed `surfaceForm`.
- `Bool`-predicate `.all (… ) = true` theorems → `∀ d ∈ allData, P d` (`Prop` + `decide`); `hasVCPresent : Bool` → `HasVCPresent : Prop` + `DecidablePred`.
- `native_decide` → `decide` throughout (kernel-verified).
- Dropped six content-free `rfl`-over-the-data bridge lemmas for one real `optimal_forms_attested`; `/-! ### -/` section headers; `uHiatus`→`uMono`, `depLowHigh`→`depMinusHigh`.