### PR TITLE
fix(Studies): correct Iatridou2000 Tables 1-2 gating + citations; idiom pass

### DIFF
--- a/Linglib/Studies/Iatridou2000.lean
+++ b/Linglib/Studies/Iatridou2000.lean
@@ -1,496 +1,286 @@
 import Linglib.Semantics.Modality.Exclusion
-import Linglib.Features.Aktionsart
-import Linglib.Features.Attitudes
-import Linglib.Features.Causation
-import Linglib.Semantics.Lexical.LevinClass
-import Linglib.Semantics.Lexical.MeaningComponents
-import Linglib.Data.Examples.Schema
-import Linglib.Data.Examples.Iatridou2000
+import Mathlib.Data.Finset.Basic
 
 /-!
-# [iatridou-2000] — Morphological Data [iatridou-2000]
+# Iatridou (2000): The Grammatical Ingredients of Counterfactuality [iatridou-2000]
 
-Theory-neutral cross-linguistic data on counterfactual morphology from
-[iatridou-2000] "The Grammatical Ingredients of Counterfactuality",
-*Linguistic Inquiry* 31(2): 231–270.
+Theory-neutral cross-linguistic data and the ExclF analysis from [iatridou-2000]
+"The Grammatical Ingredients of Counterfactuality", *Linguistic Inquiry* 31(2):
+231–270.
 
-## Key Empirical Generalizations
+Iatridou's central claim: the morphology we call "past tense" provides a skeletal
+*exclusion feature* (ExclF), `T(x) excludes C(x)` — the topic `x` excludes the
+speaker's `x`. Over times it yields temporal past; over worlds it yields
+counterfactuality. A counterfactual is built from ExclF, an aspectual component
+(imperfective in some languages), and mood.
+
+## Key empirical generalizations
 
 1. **Past morphology is uniform**: FLV, PresCF, and PastCF all use past
-   morphology, but differ in the *number* of past layers.
-2. **Imperfective is not universal**: languages that lack imperfective
-   (e.g., English) omit it in CFs; languages with imperfective (e.g., Greek)
-   use it in all CF types.
-3. **Subjunctive mirrors past subjunctive availability**: a CF can contain
-   subjunctive only if the language has a distinct past subjunctive form
-   (generalization 42).
-
-## Data Sources
-
-- Tables 1–2 of [iatridou-2000]
-- Example sentences from §2
+   morphology, differing in the *number* of ExclF layers (1, 1, 2).
+2. **Imperfective is not universal**: languages with imperfective (Greek, French)
+   use it in CFs; languages without it (English) omit it.
+3. **Subjunctive mirrors past-subjunctive availability** (§6.1): a CF uses
+   subjunctive only in languages with a past-subjunctive paradigm — German and
+   Italian do; French and Indo-Aryan have only a nonpast subjunctive and don't.
 
 ## See also
 
-- `Studies/CarianiSantorio2018.lean` — selectional
-  account where past morphology shifts the modal parameter rather than
-  introducing a separate counterfactual operator. C&S §5.3.2 identifies
-  *would* with morphological past *will*, dovetailing with Iatridou's
-  past-morphology-as-modal-shift generalization.
+- `Studies/CarianiSantorio2018.lean` — selectional account where past morphology
+  shifts the modal parameter rather than introducing a separate CF operator.
 -/
 
 namespace Iatridou2000
 
 open Semantics.Modality.Exclusion
-open Features (VendlerClass)
-open Features
-open Data.Examples (LinguisticExample)
+open Semantics.Context
+open Semantics.Mood (subjShift)
 
--- ════════════════════════════════════════════════════════════════
--- § [iatridou-2000]'s counterfactual typology
--- ════════════════════════════════════════════════════════════════
+/-! ### Iatridou's counterfactual typology -/
 
-/-- [iatridou-2000]'s predicate classification for counterfactual
-gating.
-
-The distinction between FLV and PresCF (both with 1 modal ExclF)
-depends on the predicate type:
-- ILPs and statives yield PresCF ("If he knew French,...")
-- Telic predicates yield FLV ("If he were to leave tomorrow,...") -/
-inductive IatridouPredType where
-  /-- Individual-Level Predicate: "be tall", "know French" -/
-  | ilp
-  /-- Stage-Level stative: "be sick", "be available" -/
-  | stative
-  /-- Telic predicate: "arrive", "build a house" -/
-  | telic
-  deriving DecidableEq, Repr
-
-/-- Map Vendler classes to [iatridou-2000]'s predicate
-classification.
-
-States and activities map to stative; achievements and accomplishments
-map to telic. -/
-def VendlerClass.toIatridou : VendlerClass → IatridouPredType
-  | .state | .activity | .semelfactive => .stative
-  | .achievement | .accomplishment => .telic
-
-/-- [iatridou-2000]'s three counterfactual conditional types,
-distinguished by the number of ExclFs and predicate type. -/
+/-- [iatridou-2000]'s three counterfactual conditional types, distinguished by the
+    number of ExclFs and (in the one-ExclF cases) the predicate's Aktionsart. -/
 inductive CounterfactualType where
-  /-- Future Less Vivid: 1 ExclF modal + telic predicate -/
+  /-- Future Less Vivid: one ExclF (over worlds) + telic/activity predicate. -/
   | flv
-  /-- Present Counterfactual: 1 ExclF modal + ILP/stative -/
+  /-- Present Counterfactual: one ExclF (over worlds) + individual-level stative. -/
   | presCF
-  /-- Past Counterfactual: 2 ExclFs (modal + temporal) -/
+  /-- Past Counterfactual: two ExclFs — one over worlds, one over times. -/
   | pastCF
   deriving DecidableEq, Repr
 
-/-- The number of ExclFs required for each counterfactual type. -/
+/-- ExclF count per type. PresCF/FLV have one (over worlds); PastCF has two — the
+    pluperfect's two past layers, one fake (modal) and one real (temporal)
+    ([iatridou-2000] §4, p. 252). -/
 def CounterfactualType.exclFCount : CounterfactualType → Nat
   | .flv | .presCF => 1
   | .pastCF => 2
 
-/-- Classify a counterfactual from its ExclF configuration and
-predicate type. Returns `none` if there is no modal ExclF
-(a non-counterfactual sentence). -/
-def classifyCounterfactual (modalExcl temporalExcl : Bool)
-    (predType : IatridouPredType) : Option CounterfactualType :=
-  match modalExcl, temporalExcl with
-  | true, true => some .pastCF
-  | true, false => match predType with
-    | .telic => some .flv
-    | .ilp | .stative => some .presCF
-  | false, _ => none
+/-- Predicate Aktionsart relevant to the FLV/PresCF split ([iatridou-2000],
+    Tables 1–2). The individual-level vs stage-level distinction among statives
+    is *not* recoverable from Vendler class (both are "states"), so it is encoded
+    directly rather than derived from a `VendlerClass`. -/
+inductive IatridouPredType where
+  /-- Telic: arrive, build a house (evaluated in the future → FLV). -/
+  | telic
+  /-- Activity: run, push the cart — patterns with telics ([iatridou-2000], fn 24). -/
+  | activity
+  /-- Individual-level stative: be tall, know French (holds also now → PresCF). -/
+  | ilp
+  /-- Stage-level stative: be sick, be drunk (future *or* now → FLV *or* PresCF). -/
+  | slp
+  deriving DecidableEq, Repr
 
-/-- Telic predicate + 1 modal ExclF = FLV. -/
-theorem telic_one_exclF_is_flv :
-    classifyCounterfactual true false .telic = some .flv := rfl
+/-- Classify a counterfactual from its ExclF configuration and predicate type,
+    returning the *set* of licensed CF readings (`∅` if there is no modal ExclF).
 
-/-- ILP + 1 modal ExclF = PresCF. -/
-theorem ilp_one_exclF_is_presCF :
-    classifyCounterfactual true false .ilp = some .presCF := rfl
+    Faithful to [iatridou-2000] Table 1: with one (modal) ExclF, a telic or
+    activity predicate yields FLV, an individual-level stative yields PresCF, and
+    a stage-level stative yields *both* (FLV with a future adverbial, PresCF
+    otherwise — ex (64)). Two ExclFs yield PastCF regardless of predicate. -/
+def classifyCounterfactual : Bool → Bool → IatridouPredType → Finset CounterfactualType
+  | false, _,     _         => ∅
+  | true,  true,  _         => {.pastCF}
+  | true,  false, .telic    => {.flv}
+  | true,  false, .activity => {.flv}
+  | true,  false, .ilp      => {.presCF}
+  | true,  false, .slp      => {.flv, .presCF}
 
-/-- Stative + 1 modal ExclF = PresCF. -/
-theorem stative_one_exclF_is_presCF :
-    classifyCounterfactual true false .stative = some .presCF := rfl
+/-- Telic + one modal ExclF → FLV. -/
+theorem telic_one_exclF : classifyCounterfactual true false .telic = {.flv} := rfl
 
-/-- Two ExclFs = PastCF regardless of predicate type. -/
-theorem two_exclFs_is_pastCF (pred : IatridouPredType) :
-    classifyCounterfactual true true pred = some .pastCF := by
-  cases pred <;> rfl
+/-- Activity + one modal ExclF → FLV ([iatridou-2000], fn 24). -/
+theorem activity_one_exclF : classifyCounterfactual true false .activity = {.flv} := rfl
 
-/-- No modal ExclF = not a counterfactual. -/
+/-- Individual-level stative + one modal ExclF → PresCF only. -/
+theorem ilp_one_exclF : classifyCounterfactual true false .ilp = {.presCF} := rfl
+
+/-- Stage-level stative + one modal ExclF → *both* FLV and PresCF
+    ([iatridou-2000], Table 1, ex (64)): "If he were drunk at next week's
+    meeting" (FLV) vs "If he were drunk, he would be louder" (PresCF). -/
+theorem slp_one_exclF : classifyCounterfactual true false .slp = {.flv, .presCF} := rfl
+
+/-- Two ExclFs → PastCF, regardless of predicate type. -/
+theorem two_exclFs_pastCF (pred : IatridouPredType) :
+    classifyCounterfactual true true pred = {.pastCF} := by cases pred <;> rfl
+
+/-- No modal ExclF → not a counterfactual. -/
 theorem no_modal_not_cf (temporalExcl : Bool) (pred : IatridouPredType) :
-    classifyCounterfactual false temporalExcl pred = none := by
-  cases temporalExcl <;> rfl
+    classifyCounterfactual false temporalExcl pred = ∅ := by cases temporalExcl <;> rfl
 
-/-- [iatridou-2000]'s subjunctive generalization (42): "A CF can
-contain a subjunctive morpheme only if that subjunctive morpheme has a
-past tense form".
+/-- [iatridou-2000]'s subjunctive prediction (§6.1, p. 264): a CF uses subjunctive
+    only in languages that have a past-subjunctive paradigm.
 
-Strictly, the paper states this as a one-directional conditional
-(requires → has). We encode the biconditional because all languages in
-our data satisfy both directions: English and Greek lack past
-subjunctive and don't require subjunctive in CFs; Italian has past
-subjunctive and requires it. -/
+    The paper states it one-directionally (uses → has); we encode the
+    biconditional, which all languages in the data satisfy: English, Greek, and
+    French lack a productive past subjunctive and use none in CFs; Italian has
+    one and requires it. -/
 def iatridouSubjGeneralization (hasPastSubj requiresSubj : Bool) : Prop :=
   requiresSubj = hasPastSubj
 
-/-- All three counterfactual types collapse to the framework-agnostic
-`Semantics.Mood.SubjunctiveType.counterfactual` tag. -/
+/-- All three CF types collapse to the framework-agnostic
+    `Semantics.Mood.SubjunctiveType.counterfactual` tag. -/
 def CounterfactualType.toSubjunctiveType (_ : CounterfactualType) :
-    Semantics.Mood.SubjunctiveType :=
-  .counterfactual
+    Semantics.Mood.SubjunctiveType := .counterfactual
 
-/-- Every [iatridou-2000] counterfactual type maps to
-`.counterfactual`. -/
 theorem all_counterfactuals_are_counterfactual (t : CounterfactualType) :
     t.toSubjunctiveType = .counterfactual := by cases t <;> rfl
 
-/-- PastCF tower has depth 2 — corresponding to the two past morpheme
-layers observed cross-linguistically.
-
-(Tower-level corollary; uses the `subjShift`/`temporalShift`
-infrastructure from `Semantics.Modality.Exclusion`.) -/
-theorem pastCF_tower_depth {W E P T : Type*} (c : Semantics.Context.KContext W E P T)
+/-- A PastCF tower has depth 2 — the two past morpheme layers (one fake/modal,
+    one real/temporal). -/
+theorem pastCF_tower_depth {W E P T : Type*} (c : KContext W E P T)
     (w' : W) (t' t'' : T) :
-    (((Semantics.Context.ContextTower.root c).push
-        (Semantics.Mood.subjShift w' t')).push
-      (Semantics.Context.temporalShift t'')).depth = 2 := by
-  simp [Semantics.Context.ContextTower.push, Semantics.Context.ContextTower.depth,
-    Semantics.Context.ContextTower.root]
+    (((ContextTower.root c).push (subjShift w' t')).push
+      (temporalShift t'')).depth = 2 := by
+  simp [ContextTower.push, ContextTower.depth, ContextTower.root]
 
--- ════════════════════════════════════════════════════════════════
--- § Datum Structures
--- ════════════════════════════════════════════════════════════════
+/-! ### Datum structures -/
 
-/-- A morphological datum for counterfactual conditionals.
-
-Each datum records the verb morphology in the antecedent and consequent
-of a specific counterfactual type in a specific language. -/
+/-- A morphological datum for a counterfactual conditional: the verb morphology
+    in the antecedent and consequent of one CF type in one language. -/
 structure CFMorphologyDatum where
-  /-- Language name -/
   language : String
-  /-- Counterfactual type: "FLV", "PresCF", or "PastCF" -/
-  cfType : String
-  /-- Verb morphology in the antecedent -/
+  cfType : CounterfactualType
+  /-- Verb morphology in the antecedent (descriptive). -/
   antecedentForm : String
-  /-- Verb morphology in the consequent -/
+  /-- Verb morphology in the consequent (descriptive). -/
   consequentForm : String
-  /-- Whether past morphology is present -/
   hasPastMorph : Bool
-  /-- Whether imperfective morphology is present -/
   hasImpfMorph : Bool
-  /-- Whether subjunctive morphology is present -/
   hasSubjMorph : Bool
-  /-- Number of past morpheme layers -/
   pastLayers : Nat
-  /-- Gloss of the example -/
   gloss : String
   deriving Repr
 
-/-- A datum for whether a language requires subjunctive in counterfactuals.
-
-Iatridou's generalization: a language requires subjunctive in CFs iff it
-has a morphologically distinct past subjunctive. -/
+/-- Whether a language requires subjunctive in CFs, and whether it has a distinct
+    past subjunctive. -/
 structure SubjRequirementDatum where
-  /-- Language name -/
   language : String
-  /-- Whether the language has a distinct past subjunctive form -/
   hasPastSubjunctive : Bool
-  /-- Whether counterfactuals require subjunctive morphology -/
   cfRequiresSubjunctive : Bool
   deriving Repr
 
--- ════════════════════════════════════════════════════════════════
--- § English Data
--- ════════════════════════════════════════════════════════════════
+/-! ### English data -/
 
-/-- English FLV: "If he were to take the exam tomorrow,..." -/
+/-- English FLV: "If he were to take the exam tomorrow, …" -/
 def english_flv : CFMorphologyDatum where
-  language := "English"
-  cfType := "FLV"
-  antecedentForm := "were to V"
-  consequentForm := "would V"
-  hasPastMorph := true
-  hasImpfMorph := false
-  hasSubjMorph := false
-  pastLayers := 1
+  language := "English"; cfType := .flv
+  antecedentForm := "were to V"; consequentForm := "would V"
+  hasPastMorph := true; hasImpfMorph := false; hasSubjMorph := false; pastLayers := 1
   gloss := "If he were to take the exam tomorrow, he would pass."
 
-/-- English PresCF: "If he knew the answer,..." -/
+/-- English PresCF: "If he knew the answer, …" -/
 def english_presCF : CFMorphologyDatum where
-  language := "English"
-  cfType := "PresCF"
-  antecedentForm := "V-ed"
-  consequentForm := "would V"
-  hasPastMorph := true
-  hasImpfMorph := false
-  hasSubjMorph := false
-  pastLayers := 1
+  language := "English"; cfType := .presCF
+  antecedentForm := "V-ed"; consequentForm := "would V"
+  hasPastMorph := true; hasImpfMorph := false; hasSubjMorph := false; pastLayers := 1
   gloss := "If he knew the answer, he would tell us."
 
-/-- English PastCF: "If he had taken the exam,..." -/
+/-- English PastCF: "If he had taken the exam, …" -/
 def english_pastCF : CFMorphologyDatum where
-  language := "English"
-  cfType := "PastCF"
-  antecedentForm := "had V-ed"
-  consequentForm := "would have V-ed"
-  hasPastMorph := true
-  hasImpfMorph := false
-  hasSubjMorph := false
-  pastLayers := 2
+  language := "English"; cfType := .pastCF
+  antecedentForm := "had V-ed"; consequentForm := "would have V-ed"
+  hasPastMorph := true; hasImpfMorph := false; hasSubjMorph := false; pastLayers := 2
   gloss := "If he had taken the exam yesterday, he would have passed."
 
--- ════════════════════════════════════════════════════════════════
--- § Greek Data
--- ════════════════════════════════════════════════════════════════
+/-! ### Greek data -/
 
-/-- Greek FLV: "An + past + impf, tha + past + impf"
-
-Based on [iatridou-2000], example (6). Greek FLV and PresCF have
-identical morphological form; the FLV/PresCF distinction is made by
-predicate type and temporal adverbials, not by morphology. -/
+/-- Greek FLV ([iatridou-2000], ex (8)): "an + past + impf, tha + past + impf".
+    Greek FLV and PresCF have identical morphology; the distinction is by
+    predicate type and temporal adverbials, not by morphology (§4, p. 250). -/
 def greek_flv : CFMorphologyDatum where
-  language := "Greek"
-  cfType := "FLV"
-  antecedentForm := "an + past + impf"
-  consequentForm := "tha + past + impf"
-  hasPastMorph := true
-  hasImpfMorph := true
-  hasSubjMorph := false
-  pastLayers := 1
-  gloss := "An eperne to siropi tu avrio, tha yinotan kala."
+  language := "Greek"; cfType := .flv
+  antecedentForm := "an + past + impf"; consequentForm := "tha + past + impf"
+  hasPastMorph := true; hasImpfMorph := true; hasSubjMorph := false; pastLayers := 1
+  gloss := "An eperne afto to siropi, tha yinotan kala."
 
-/-- Greek PresCF: "An + past + impf, tha + past + impf"
-
-Based on [iatridou-2000], example (6). Morphologically identical
-to FLV in Greek; the counterfactual reading arises from the stative
-predicate. -/
+/-- Greek PresCF: morphologically identical to the Greek FLV (ex (8)); the CF
+    reading arises from the individual-level/stative predicate (Tables 1–2). -/
 def greek_presCF : CFMorphologyDatum where
-  language := "Greek"
-  cfType := "PresCF"
-  antecedentForm := "an + past + impf"
-  consequentForm := "tha + past + impf"
-  hasPastMorph := true
-  hasImpfMorph := true
-  hasSubjMorph := false
-  pastLayers := 1
-  gloss := "An eperne to siropi tu, tha yinotan kala."
+  language := "Greek"; cfType := .presCF
+  antecedentForm := "an + past + impf"; consequentForm := "tha + past + impf"
+  hasPastMorph := true; hasImpfMorph := true; hasSubjMorph := false; pastLayers := 1
+  gloss := "An iksere ti apandisi, tha mas tin elege."
 
-/-- Greek PastCF: "An + past + past + impf, tha + past + past + impf"
-
-Based on [iatridou-2000], example (6c). The additional past
-layer (the pluperfect ixe + participle) distinguishes PastCF from
-PresCF/FLV. -/
+/-- Greek PastCF ([iatridou-2000], ex (5)): the pluperfect (ixe + participle) adds
+    a second past layer, distinguishing PastCF from PresCF/FLV. -/
 def greek_pastCF : CFMorphologyDatum where
-  language := "Greek"
-  cfType := "PastCF"
-  antecedentForm := "an + past + past + impf"
-  consequentForm := "tha + past + past + impf"
-  hasPastMorph := true
-  hasImpfMorph := true
-  hasSubjMorph := false
-  pastLayers := 2
-  gloss := "An ixe pari to siropi tu xthes, tha ixe yini kala."
+  language := "Greek"; cfType := .pastCF
+  antecedentForm := "an + past + past + impf"; consequentForm := "tha + past + past + impf"
+  hasPastMorph := true; hasImpfMorph := true; hasSubjMorph := false; pastLayers := 2
+  gloss := "An ixe pari to siropi, tha ixe yini kala."
 
--- ════════════════════════════════════════════════════════════════
--- § French Data
--- ════════════════════════════════════════════════════════════════
+/-! ### French data -/
 
-/-- French FLV: "imparfait, conditionnel" -/
+/-- French FLV: imparfait, conditionnel. -/
 def french_flv : CFMorphologyDatum where
-  language := "French"
-  cfType := "FLV"
-  antecedentForm := "imparfait"
-  consequentForm := "conditionnel"
-  hasPastMorph := true
-  hasImpfMorph := true
-  hasSubjMorph := false
-  pastLayers := 1
+  language := "French"; cfType := .flv
+  antecedentForm := "imparfait"; consequentForm := "conditionnel"
+  hasPastMorph := true; hasImpfMorph := true; hasSubjMorph := false; pastLayers := 1
   gloss := "S'il passait l'examen demain, il réussirait."
 
-/-- French PresCF: "imparfait, conditionnel" -/
+/-- French PresCF: imparfait, conditionnel. -/
 def french_presCF : CFMorphologyDatum where
-  language := "French"
-  cfType := "PresCF"
-  antecedentForm := "imparfait"
-  consequentForm := "conditionnel"
-  hasPastMorph := true
-  hasImpfMorph := true
-  hasSubjMorph := false
-  pastLayers := 1
+  language := "French"; cfType := .presCF
+  antecedentForm := "imparfait"; consequentForm := "conditionnel"
+  hasPastMorph := true; hasImpfMorph := true; hasSubjMorph := false; pastLayers := 1
   gloss := "S'il savait la réponse, il nous le dirait."
 
-/-- French PastCF: "plus-que-parfait, conditionnel passé" -/
+/-- French PastCF ([iatridou-2000], ex (99)): plus-que-parfait, conditionnel passé.
+    French uses past *indicative*, not the (lost productive) past subjunctive. -/
 def french_pastCF : CFMorphologyDatum where
-  language := "French"
-  cfType := "PastCF"
-  antecedentForm := "plus-que-parfait"
-  consequentForm := "conditionnel passé"
-  hasPastMorph := true
-  hasImpfMorph := true
-  hasSubjMorph := false
-  pastLayers := 2
+  language := "French"; cfType := .pastCF
+  antecedentForm := "plus-que-parfait"; consequentForm := "conditionnel passé"
+  hasPastMorph := true; hasImpfMorph := true; hasSubjMorph := false; pastLayers := 2
   gloss := "S'il avait passé l'examen hier, il aurait réussi."
 
--- ════════════════════════════════════════════════════════════════
--- § Subjunctive Requirement Data
--- ════════════════════════════════════════════════════════════════
+/-- All morphological data. -/
+def allData : List CFMorphologyDatum :=
+  [english_flv, english_presCF, english_pastCF,
+   greek_flv, greek_presCF, greek_pastCF,
+   french_flv, french_presCF, french_pastCF]
 
-/-- English: no distinct past subjunctive, no subjunctive required. -/
+/-! ### Subjunctive-requirement data ([iatridou-2000], §6.1) -/
+
+/-- English: no productive past subjunctive (vestigial *were* aside), none required. -/
 def english_subj : SubjRequirementDatum where
-  language := "English"
-  hasPastSubjunctive := false
-  cfRequiresSubjunctive := false
+  language := "English"; hasPastSubjunctive := false; cfRequiresSubjunctive := false
 
-/-- Greek: no past subjunctive, no subjunctive required in CFs.
-
-Greek CFs use past + imperfective morphology (indicative), not subjunctive.
-Greek has a subjunctive-like particle (na), but this is not used in
-counterfactual conditionals. -/
+/-- Greek: na-clauses are not CF subjunctive ([iatridou-2000], fn 37); none required. -/
 def greek_subj : SubjRequirementDatum where
-  language := "Greek"
-  hasPastSubjunctive := false
-  cfRequiresSubjunctive := false
+  language := "Greek"; hasPastSubjunctive := false; cfRequiresSubjunctive := false
 
-/-- French: no productive past subjunctive, no subjunctive required in CFs.
-
-French CFs use the indicative imparfait ("si j'avais..."), not the
-subjonctif. French has a literary past subjunctive (subjonctif imparfait),
-but it is not used productively in counterfactuals. -/
+/-- French: no productive past subjunctive (only the dubitative); CFs use the past
+    indicative ([iatridou-2000], §6.1, ex (99)). -/
 def french_subj : SubjRequirementDatum where
-  language := "French"
-  hasPastSubjunctive := false
-  cfRequiresSubjunctive := false
+  language := "French"; hasPastSubjunctive := false; cfRequiresSubjunctive := false
 
-/-- Italian: has distinct past subjunctive, subjunctive required in CFs.
-
-Italian CFs require the congiuntivo (subjunctive), which has a robust
-past form (congiuntivo trapassato). This is one of the positive cases
-for Iatridou's generalization (42): "A CF can contain a subjunctive
-morpheme only if that subjunctive morpheme has a past tense form." -/
+/-- Italian: has a past subjunctive (congiuntivo trapassato) and requires it in
+    CFs — a positive case for [iatridou-2000]'s §6.1 prediction. -/
 def italian_subj : SubjRequirementDatum where
-  language := "Italian"
-  hasPastSubjunctive := true
-  cfRequiresSubjunctive := true
+  language := "Italian"; hasPastSubjunctive := true; cfRequiresSubjunctive := true
 
--- ════════════════════════════════════════════════════════════════
--- § Basic Data Theorems
--- ════════════════════════════════════════════════════════════════
+/-- All subjunctive-requirement data. -/
+def allSubjData : List SubjRequirementDatum :=
+  [english_subj, greek_subj, french_subj, italian_subj]
 
-/-- All CF types use past morphology. -/
-theorem all_cfs_have_past :
-    english_flv.hasPastMorph = true ∧
-    english_presCF.hasPastMorph = true ∧
-    english_pastCF.hasPastMorph = true ∧
-    greek_flv.hasPastMorph = true ∧
-    greek_presCF.hasPastMorph = true ∧
-    greek_pastCF.hasPastMorph = true ∧
-    french_flv.hasPastMorph = true ∧
-    french_presCF.hasPastMorph = true ∧
-    french_pastCF.hasPastMorph = true :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+/-! ### Data theorems -/
 
-/-- PastCF has more past layers than PresCF/FLV. -/
-theorem pastCF_has_more_layers :
-    english_pastCF.pastLayers > english_presCF.pastLayers ∧
-    greek_pastCF.pastLayers > greek_presCF.pastLayers ∧
-    french_pastCF.pastLayers > french_presCF.pastLayers := by
-  decide
+/-- Every CF type uses past morphology (generalization 1). -/
+theorem all_cfs_have_past : ∀ d ∈ allData, d.hasPastMorph = true := by decide
 
--- ════════════════════════════════════════════════════════════════
--- § Bridge: ExclF, Classification, Deal
--- ════════════════════════════════════════════════════════════════
+/-- Each datum's past-layer count matches the ExclF count of its CF type — so
+    PastCFs (2 layers) carry strictly more than FLVs/PresCFs (1 layer). -/
+theorem pastLayers_eq_exclFCount :
+    ∀ d ∈ allData, d.pastLayers = d.cfType.exclFCount := by decide
 
-/-- English FLV: 1 past layer = 1 ExclF (FLV). -/
-theorem english_flv_layers :
-    english_flv.pastLayers = CounterfactualType.flv.exclFCount := rfl
+/-- Each language satisfies [iatridou-2000]'s subjunctive generalization (§6.1). -/
+theorem subj_generalization :
+    ∀ d ∈ allSubjData,
+      iatridouSubjGeneralization d.hasPastSubjunctive d.cfRequiresSubjunctive := by
+  unfold iatridouSubjGeneralization; decide
 
-/-- English PresCF: 1 past layer = 1 ExclF (PresCF). -/
-theorem english_presCF_layers :
-    english_presCF.pastLayers = CounterfactualType.presCF.exclFCount := rfl
-
-/-- English PastCF: 2 past layers = 2 ExclFs (PastCF). -/
-theorem english_pastCF_layers :
-    english_pastCF.pastLayers = CounterfactualType.pastCF.exclFCount := rfl
-
-/-- Greek FLV: 1 past layer = 1 ExclF (FLV). -/
-theorem greek_flv_layers :
-    greek_flv.pastLayers = CounterfactualType.flv.exclFCount := rfl
-
-/-- Greek PresCF: 1 past layer = 1 ExclF (PresCF). -/
-theorem greek_presCF_layers :
-    greek_presCF.pastLayers = CounterfactualType.presCF.exclFCount := rfl
-
-/-- Greek PastCF: 2 past layers = 2 ExclFs (PastCF). -/
-theorem greek_pastCF_layers :
-    greek_pastCF.pastLayers = CounterfactualType.pastCF.exclFCount := rfl
-
-/-- French FLV: 1 past layer = 1 ExclF (FLV). -/
-theorem french_flv_layers :
-    french_flv.pastLayers = CounterfactualType.flv.exclFCount := rfl
-
-/-- French PresCF: 1 past layer = 1 ExclF (PresCF). -/
-theorem french_presCF_layers :
-    french_presCF.pastLayers = CounterfactualType.presCF.exclFCount := rfl
-
-/-- French PastCF: 2 past layers = 2 ExclFs (PastCF). -/
-theorem french_pastCF_layers :
-    french_pastCF.pastLayers = CounterfactualType.pastCF.exclFCount := rfl
-
-/-- English: no past subjunctive, no CF subjunctive required. -/
-theorem english_subj_gen :
-    iatridouSubjGeneralization english_subj.hasPastSubjunctive
-      english_subj.cfRequiresSubjunctive := rfl
-
-/-- Greek: no past subjunctive, no CF subjunctive required. -/
-theorem greek_subj_gen :
-    iatridouSubjGeneralization greek_subj.hasPastSubjunctive
-      greek_subj.cfRequiresSubjunctive := rfl
-
-/-- French: no productive past subjunctive, no CF subjunctive required. -/
-theorem french_subj_gen :
-    iatridouSubjGeneralization french_subj.hasPastSubjunctive
-      french_subj.cfRequiresSubjunctive := rfl
-
-/-- Italian: has past subjunctive, CF requires subjunctive. -/
-theorem italian_subj_gen :
-    iatridouSubjGeneralization italian_subj.hasPastSubjunctive
-      italian_subj.cfRequiresSubjunctive := rfl
-
-/-- "If he knew French" (ILP + 1 modal ExclF) → PresCF. -/
-theorem knew_french_is_presCF :
-    classifyCounterfactual true false .ilp = some .presCF := rfl
-
-/-- "If he were to leave" (telic + 1 modal ExclF) → FLV. -/
-theorem leave_tomorrow_is_flv :
-    classifyCounterfactual true false .telic = some .flv := rfl
-
-/-- "If he had left" (telic + 2 ExclFs) → PastCF. -/
-theorem had_left_is_pastCF :
-    classifyCounterfactual true true .telic = some .pastCF := rfl
-
-/-- "If he were sick" (stative + 1 modal ExclF) → PresCF. -/
-theorem were_sick_is_presCF :
-    classifyCounterfactual true false .stative = some .presCF := rfl
-
-/-- "If he had known" (ILP + 2 ExclFs) → PastCF. -/
-theorem had_known_is_pastCF :
-    classifyCounterfactual true true .ilp = some .pastCF := rfl
-
-/-- PastCF is exempt from ULC via Deal's refined ULC. -/
-theorem pastCF_exempt_from_ulc {T : Type*} [LE T] (R E : T) :
-    refinedULC .counterfactual R E :=
-  trivial
-
--- ════════════════════════════════════════════════════════════════
--- § ContextTower Bridge
--- ════════════════════════════════════════════════════════════════
-
-open Semantics.Context
-open Semantics.Mood (subjShift)
+/-! ### ContextTower bridge -/
 
 abbrev CFCtx := KContext Bool Unit Unit ℤ
 
@@ -501,60 +291,44 @@ def actualCtx : CFCtx :=
 /-- Root tower: the actual speech-act context, depth 0. -/
 def actualTower : ContextTower CFCtx := ContextTower.root actualCtx
 
-/-- FLV/PresCF: one subjunctive shift to a counterfactual world.
-    The counterfactual world (false) differs from the actual world (true). -/
+/-- FLV/PresCF: one subjunctive shift to a counterfactual world (false ≠ true). -/
 def presCFTower : ContextTower CFCtx :=
   actualTower.push (subjShift false 0)
 
-/-- The tower has depth 1 — matching 1 past morpheme layer. -/
+/-- The tower has depth 1 — matching one past morpheme layer. -/
 theorem presCF_depth : presCFTower.depth = 1 := rfl
 
-/-- Modal ExclF holds: counterfactual world ≠ actual world. -/
-theorem presCF_modal_exclF :
-    ExclF .modal presCFTower := by
+/-- Modal ExclF holds: the counterfactual world ≠ the actual world. -/
+theorem presCF_modal_exclF : ExclF .modal presCFTower := by
   unfold ExclF presCFTower actualTower actualCtx subjShift; decide
 
-/-- Temporal ExclF does NOT hold: time is unchanged (0 = 0). -/
-theorem presCF_no_temporal_exclF :
-    ¬ ExclF .temporal presCFTower := by
+/-- Temporal ExclF does *not* hold: the time is unchanged (0 = 0). -/
+theorem presCF_no_temporal_exclF : ¬ ExclF .temporal presCFTower := by
   unfold ExclF presCFTower actualTower actualCtx subjShift; decide
 
-/-- Tower depth (1) matches English FLV past layers (1). -/
-theorem flv_tower_depth_matches_data :
-    presCFTower.depth = english_flv.pastLayers := rfl
+/-- Tower depth (1) matches the English PresCF past-layer count (1). -/
+theorem presCF_depth_matches_data : presCFTower.depth = english_presCF.pastLayers := rfl
 
-/-- Tower depth (1) matches English PresCF past layers (1). -/
-theorem presCF_tower_depth_matches_data :
-    presCFTower.depth = english_presCF.pastLayers := rfl
-
-/-- PastCF: two shifts — one modal (subjunctive, world shift) and one
-    temporal (additional past layer, time shift to -5). -/
+/-- PastCF: a modal shift (subjunctive, world) plus a temporal shift (an extra
+    past layer, time → -5). -/
 def pastCFTower : ContextTower CFCtx :=
   presCFTower.push (temporalShift (-5))
 
-/-- Tower depth is 2 — matching 2 past morpheme layers. -/
+/-- The tower has depth 2 — matching two past morpheme layers. -/
 theorem pastCF_depth : pastCFTower.depth = 2 := rfl
 
-/-- Modal ExclF holds: counterfactual world ≠ actual world. -/
-theorem pastCF_modal_exclF :
-    ExclF .modal pastCFTower := by
+/-- Modal ExclF holds: the counterfactual world ≠ the actual world. -/
+theorem pastCF_modal_exclF : ExclF .modal pastCFTower := by
   unfold ExclF pastCFTower presCFTower actualTower actualCtx subjShift; decide
 
-/-- Temporal ExclF holds: shifted time (-5) ≠ speech time (0). -/
-theorem pastCF_temporal_exclF :
-    ExclF .temporal pastCFTower := by
+/-- Temporal ExclF holds: the shifted time (-5) ≠ the speech time (0). -/
+theorem pastCF_temporal_exclF : ExclF .temporal pastCFTower := by
   unfold ExclF pastCFTower presCFTower actualTower actualCtx subjShift temporalShift; decide
 
-/-- Tower depth (2) matches English PastCF past layers (2). -/
-theorem pastCF_tower_depth_matches_data :
-    pastCFTower.depth = english_pastCF.pastLayers := rfl
-
-/-- Tower depth (2) matches Greek PastCF past layers (2). -/
-theorem pastCF_tower_depth_matches_greek :
-    pastCFTower.depth = greek_pastCF.pastLayers := rfl
+/-- Tower depth (2) matches the English PastCF past-layer count (2). -/
+theorem pastCF_depth_matches_data : pastCFTower.depth = english_pastCF.pastLayers := rfl
 
 /-- Even in a PastCF tower (depth 2), the origin context is preserved. -/
-theorem pastCF_origin_preserved :
-    pastCFTower.origin = actualCtx := rfl
+theorem pastCF_origin_preserved : pastCFTower.origin = actualCtx := rfl
 
 end Iatridou2000


### PR DESCRIPTION
Audit of `Studies/Iatridou2000.lean` against the paper (Iatridou 2000, *The Grammatical Ingredients of Counterfactuality*, LI 31(2)). The ExclF analysis, the FLV/PresCF/PastCF typology, the 1/1/2 ExclF counts, and the ContextTower modeling were faithful — but the predicate-gating contradicted the paper's own Tables 1–2, and two example/generalization numbers were fabricated.

**Fidelity fix — predicate gating (Tables 1–2)**
- `classifyCounterfactual` now returns the *set* of licensed CF readings, faithful to Table 1: telic/activity → {FLV}, individual-level stative → {PresCF}, **stage-level stative → {FLV, PresCF}** (ex (64)). Previously it forced stage-level statives → PresCF only, contradicting the paper.
- `IatridouPredType` split into telic / activity / ilp / slp. Activities now pattern with telics (fn 24), not statives.
- Dropped `VendlerClass.toIatridou`: the individual-level vs stage-level distinction is not recoverable from Vendler class (both are "states"), so the lossy map (which also misrouted activities and never produced the `ilp` case) is replaced by gating directly on `IatridouPredType`.

**Citation fixes**
- Greek examples were cited as "(6)/(6c)" — but (6) is the English *will/would* example. Corrected to (8) (FLV) and (5) (PastCF).
- The subjunctive generalization was cited as "(42)" — but (42) is the van-Gogh subject-orientation example. Corrected to §6.1 (p. 264) prose. (Content was already faithful; Italian is correctly a positive case per §6.1.)

**Idiom pass**
- `cfType : String` → the typed `CounterfactualType`.
- Collapsed ~20 `rfl`-over-data bridge lemmas into `all_cfs_have_past`, `pastLayers_eq_exclFCount`, `subj_generalization` (∀-over-`allData`/`allSubjData`, `Prop` + `decide`).
- Dropped `pastCF_exempt_from_ulc` (a `trivial` bridge to Deal's ULC, which Iatridou does not discuss).
- `/-! ### -/` headers; pruned 7 unused imports (Aktionsart, Attitudes, Causation, LevinClass, MeaningComponents, the two Examples modules) down to `Semantics.Modality.Exclusion` + `Finset.Basic`.

Net −439/+213. Kernel-verified (`decide`/`rfl`; no `native_decide`/`sorry`).