### PR TITLE
fix(Attitudes): drop vacuous conjunction-fallacy thm; consistent witness

### DIFF
--- a/Linglib/Semantics/Attitudes/Confidence.lean
+++ b/Linglib/Semantics/Attitudes/Confidence.lean
@@ -23,8 +23,9 @@ Key features:
   (CSW §4.1)
 - **Not per-theme**: the ordering ranks states across themes, not within
   one theme
-- **Not probabilistic**: the ordering need not respect conjunction
-  (`conjunction_fallacy_compatible`, CSW (52))
+- **Not probabilistic**: the ordering need not respect conjunction — there is
+  no conjunction-monotonicity axiom; the divergence witness is
+  `EpistemicThreshold.confidence_not_probabilistic` (CSW (52))
 - **Bounded above (for ordinary holders)**: `certain` picks out the
   maximal elements (CSW §5.2). The maximality assumption is supplied
   per-theorem via `h_top`, not baked into the structure — CSW p.19 hedges
@@ -249,24 +250,21 @@ theorem confident_excludes_doubts {E W : Type*}
   letI := co.toPreorder
   exact disjoint_regions (confidentEntry co confPt) (doubtsEntry co doubtPt) h_strict s
 
-/-- Confidence orderings need not respect logical conjunction:
-    it is consistent to be confident that (p ∧ q) without being
-    confident that p (CSW (52), [tversky-kahneman-1983]).
+/-! ### Conjunction-fallacy compatibility (CSW (52))
 
-    Witness: ℕ as a toy ordering with contrast point 1 — the state ranked
-    2 is in the positive region (1 ≤ 2) while the state ranked 0 is not
-    (¬ 1 ≤ 0). Applied to confidence: assign rank 2 to the (p ∧ q)-state
-    and rank 0 to the p-state. The ordering is subjective and not
-    constrained by logical entailment.
+Confidence orderings need not respect logical conjunction: it is consistent to be
+confident that (p ∧ q) without being confident that p (CSW (52),
+[tversky-kahneman-1983]). In this substrate that is not a *theorem* but the
+*absence of a constraint* — the background `Preorder` carries no
+conjunction-monotonicity axiom, unlike a probability measure.
 
-    CSW §4.6 use this to argue against any probability-functional account:
-    probability functions force `Pr(p ∧ q) ≤ Pr(p)`. The cross-framework
-    refutation is `EpistemicThreshold.confidence_not_probabilistic`,
-    which witnesses that no probabilistic credence agrees with this. -/
-theorem conjunction_fallacy_compatible :
-    ∃ (contrastPt high low : ℕ),
-      contrastPt ≤ high ∧ ¬(contrastPt ≤ low) :=
-  ⟨1, 2, 0, by omega, by omega⟩
+The genuine witness that this diverges from a probabilistic account — a
+non-monotone credence ranking a *consistent* conjunction above a conjunct, which
+no probability measure can do — is
+`EpistemicThreshold.confidence_not_probabilistic`; the packaged cross-framework
+refutation is `CarianiSantorioWellwood2024.states_vs_threshold_on_conjunction_fallacy`.
+(Earlier a vacuous `conjunction_fallacy_compatible : ∃ a b c : ℕ, a ≤ b ∧ ¬ a ≤ c`
+stood here; it encoded nothing about confidence or conjunction and was removed.) -/
 
 /-! ## §5. Bridge to Neo-Davidsonian Event Semantics
 

--- a/Linglib/Semantics/Attitudes/EpistemicThreshold.lean
+++ b/Linglib/Semantics/Attitudes/EpistemicThreshold.lean
@@ -354,13 +354,13 @@ theorem credence_upward_monotone (cr : AgentCredence E W)
 /-!
 ### Key Divergence from Confidence.lean
 
-CSW's confidence ordering is NOT constrained to respect logical conjunction:
-`conjunction_fallacy_compatible` (Confidence.lean) shows it is consistent
-to be confident of (p ∧ q) without being confident of p.
+CSW's confidence ordering is NOT constrained to respect logical conjunction
+(it imposes no conjunction-monotonicity axiom on the background preorder), so it
+is consistent to be confident of (p ∧ q) without being confident of p.
 
 When `AgentCredence` is a genuine probability measure (as in LaBToM), this
-cannot happen: Pr(A, p ∧ q) ≤ Pr(A, p) always. The two theories make
-different empirical predictions about conjunction fallacy data.
+cannot happen: Pr(A, p ∧ q) ≤ Pr(A, p) always (`isProbabilistic_conj_elim`).
+The witness that the two diverge is `confidence_not_probabilistic` below.
 -/
 
 /-- A probabilistic credence function is `Monotone` (from Mathlib) in
@@ -368,9 +368,10 @@ different empirical predictions about conjunction fallacy data.
     Pr(A, φ) ≤ Pr(A, ψ).
 
     This is the axiom that separates LaBToM's probabilistic credence
-    from CSW's ordinal confidence ordering. CSW's ordering permits
-    conjunction fallacies (`conjunction_fallacy_compatible` in
-    `Confidence.lean`); `isProbabilistic` rules them out.
+    from CSW's ordinal confidence ordering, which imposes no
+    conjunction-monotonicity constraint and so permits conjunction
+    fallacies; `isProbabilistic` rules them out (witness:
+    `confidence_not_probabilistic`).
 
     Conjunction elimination (`isProbabilistic_conj_elim`) is a
     consequence: since `φ ∧ ψ ≤ φ` pointwise, monotonicity gives
@@ -405,40 +406,36 @@ theorem prob_conjunction_elim (cr : AgentCredence E W)
 
 /-- **CSW vs threshold-credence divergence theorem.**
 
-    There exists an `AgentCredence` admitting a conjunction-fallacy
-    witness — formally, an instance where `cr (φ ∧ ψ) > cr φ` — and
-    consequently failing `isProbabilistic`.
+    There exists an `AgentCredence` admitting a conjunction-fallacy witness —
+    `cr (φ ∧ ψ) > cr φ` with `φ`, `ψ`, and `φ ∧ ψ` all *consistent* — that
+    consequently fails `isProbabilistic`.
 
-    This formalizes the empirical disagreement CSW §4.6 (around (52))
-    use to argue against probabilistic-credence accounts of confidence:
-    `Confidence.conjunction_fallacy_compatible` shows the CSW ordering
-    *admits* such witnesses (the John/Linda case from
-    [tversky-kahneman-1983]); this theorem shows that any credence
-    function reproducing such a witness *cannot* satisfy
-    `isProbabilistic`. The two theories therefore make incompatible
-    predictions about the same data point.
+    This formalizes the empirical disagreement CSW §4.6 (around (52)) use against
+    probabilistic-credence accounts of confidence: a confidence ordering can rank
+    a conjunction strictly above one of its conjuncts (the Tversky–Kahneman
+    pattern, [tversky-kahneman-1983]), whereas any probabilistic credence forbids
+    it (`prob_conjunction_elim`). The two theories make incompatible predictions
+    on the same datum.
 
-    Witness construction: `cr` assigns 1 to the always-false proposition
-    and 0 to everything else, on Unit-agent / Bool-world. Then
-    `id ∧ (fun w => !w) = (fun _ => false)`, so `cr (id ∧ neg) = 1 > 0
-    = cr id` realizes the John/Linda pattern. The `cr` is non-monotone
-    because `(fun _ => false) ≤ id` pointwise but `1 > 0`. -/
+    Witness (Unit-agent / Bool-world): `cr a p = if p false then 0 else 1`,
+    `φ = ⊤` (always true), `ψ = {true}` (`fun w => w`). Then `φ ∧ ψ = {true} ⊊ φ`,
+    all three *consistent*, and `cr φ = 0 < 1 = cr (φ ∧ ψ)`. The `cr` is
+    non-monotone because `{true} ≤ ⊤` pointwise yet `cr {true} = 1 > 0 = cr ⊤`.
+    (Earlier this used a `φ ∧ ψ = ⊥` witness — confidence in a contradiction —
+    which proved the existential but modelled the fallacy degenerately.) -/
 theorem confidence_not_probabilistic :
     ∃ (cr : AgentCredence Unit Bool),
       ¬ isProbabilistic cr ∧
       ∃ (φ ψ : Bool → Bool),
         cr () φ < cr () (fun w => φ w && ψ w) := by
-  refine ⟨fun _ φ => match φ true, φ false with
-            | false, false => (1 : ℚ)
-            | _, _         => 0,
-          ?_, id, (fun w => !w), ?_⟩
+  refine ⟨fun _ p => if p false then (0 : ℚ) else 1,
+          ?_, (fun _ => true), (fun w => w), ?_⟩
   · intro h
-    have hle : (fun (_ : Bool) => false) ≤ id := by
-      intro w; cases w <;> decide
+    have hle : (fun w => w) ≤ (fun _ : Bool => true) := by intro w; cases w <;> decide
     have : (1 : ℚ) ≤ 0 := h () hle
     linarith
   · show (0 : ℚ) < 1
-    decide
+    norm_num
 
 
 -- ============================================================================
@@ -785,10 +782,10 @@ introduce an identity-function alias. -/
 ### Conjunction-Closure Side of the CSW Divergence
 
 The headline empirical disagreement between this file and `Confidence.lean`
-is conjunction elimination. CSW's confidence ordering admits the
-conjunction fallacy (`Confidence.conjunction_fallacy_compatible`).
-Probabilistic credence rules it out, as the lemmas in this section make
-precise. The packaged refutation lives in §6
+is conjunction elimination. CSW's confidence ordering admits the conjunction
+fallacy (its background preorder imposes no conjunction-monotonicity
+constraint). Probabilistic credence rules it out, as the lemmas in this
+section make precise. The packaged refutation lives in §6
 (`confidence_not_probabilistic`) above.
 -/
 

--- a/Linglib/Studies/CarianiSantorioWellwood2024.lean
+++ b/Linglib/Studies/CarianiSantorioWellwood2024.lean
@@ -30,7 +30,7 @@ witnesses the central cross-framework disagreement against
 | CSW section | What this file covers                                                |
 |-------------|----------------------------------------------------------------------|
 | §3.3        | POS-free positive form: `inPositiveRegion` over `confidentEntry`     |
-| §4.6 (52)   | Conjunction fallacy compatibility (`Confidence.conjunction_fallacy_compatible`) |
+| §4.6 (52)   | Conjunction fallacy: `conjunction_fallacy_predicted` (→ `confidence_not_probabilistic`) |
 | §4.6 (53)   | Upward monotonicity (`Confidence.confidence_upward_monotone`)        |
 | §4.6 (54)   | Transitivity of comparative confidence                               |
 | §4.6 (55)   | Antisymmetry of equative confidence                                  |
@@ -59,6 +59,8 @@ namespace CarianiSantorioWellwood2024
 
 open Semantics.Gradability.StatesBased
 open Semantics.Attitudes.Confidence
+open Semantics.Attitudes.EpistemicThreshold (AgentCredence isProbabilistic
+  meetsThreshold prob_conjunction_elim confidence_not_probabilistic)
 
 /-! ## §1. Felicity Gradient
 
@@ -174,17 +176,21 @@ def connectednessStance : ConnectednessStance := {}
 
 /-! ### §3.4 Conjunction Fallacy (CSW (52)) -/
 
-/-- CSW (52): it is consistent for "John is not confident that Linda is
-    a banker" and "John is confident that Linda is a feminist banker"
-    to be true together. Confidence orderings are not constrained to
-    respect logical conjunction (CSW's central argument against
-    probability-functional accounts; [tversky-kahneman-1983]).
+/-- CSW (52): it is consistent for "John is not confident that Linda is a
+    banker" and "John is confident that Linda is a feminist banker" to hold
+    together — confidence orderings are not constrained to respect logical
+    conjunction (CSW's central argument against probability-functional accounts;
+    [tversky-kahneman-1983]).
 
-    Witness imported from `Confidence.conjunction_fallacy_compatible`. -/
+    Genuine witness: a non-monotone credence ranking a *consistent* conjunction
+    strictly above a conjunct (`EpistemicThreshold.confidence_not_probabilistic`),
+    which no probability measure can do. The cross-framework consequence is §6's
+    `states_vs_threshold_on_conjunction_fallacy`. -/
 theorem conjunction_fallacy_predicted :
-    ∃ (contrastPt high low : ℕ),
-      contrastPt ≤ high ∧ ¬(contrastPt ≤ low) :=
-  conjunction_fallacy_compatible
+    ∃ (cr : AgentCredence Unit Bool),
+      ¬ isProbabilistic cr ∧
+      ∃ (φ ψ : Bool → Bool), cr () φ < cr () (fun w => φ w && ψ w) :=
+  confidence_not_probabilistic
 
 /-! ### §3.5 Upward Monotonicity (CSW (53)) -/
 
@@ -294,8 +300,8 @@ credence function validates `Pr(p ∧ q) ≤ Pr(p)`.
 
 The two halves of the disagreement are now formal:
 
-- States-based admits the fallacy: `Confidence.conjunction_fallacy_compatible`
-  (and the §3.4 invocation above).
+- States-based admits the fallacy: `confidence_not_probabilistic` (a non-monotone
+  credence ranking a consistent conjunction above a conjunct; §3.4 above).
 - Probabilistic credence forbids it: `EpistemicThreshold.prob_conjunction_elim`.
 - A credence function realizing the fallacy cannot be probabilistic:
   `EpistemicThreshold.confidence_not_probabilistic`.
@@ -303,16 +309,12 @@ The two halves of the disagreement are now formal:
 This study file packages the disagreement as the joint statement
 below. -/
 
-open Semantics.Attitudes.EpistemicThreshold (AgentCredence isProbabilistic
-  meetsThreshold prob_conjunction_elim confidence_not_probabilistic)
-
 /-- The empirical disagreement on CSW (52) / Tversky–Kahneman 1983,
     formalized as the conjunction of two opposing predictions:
 
     1. **States-based prediction** (CSW): there is a confidence ordering
-       admitting the fallacy (`conjunction_fallacy_compatible` provides
-       a Nat witness; `confidence_not_probabilistic` lifts it to an
-       `AgentCredence` witness).
+       admitting the fallacy (`confidence_not_probabilistic` provides an
+       `AgentCredence` witness with consistent propositions).
     2. **Threshold-probabilistic prediction**: any probabilistic credence
        blocks the fallacy at every threshold
        (`prob_conjunction_elim`).


### PR DESCRIPTION
A substrate audit traced from `Studies/CarianiSantorioWellwood2024.lean` (which delegates almost everything to substrate) found that CSW's *central* anti-probabilistic argument — the conjunction fallacy (CSW (52), Tversky–Kahneman) — was formalized vacuously, and the genuine witness modelled it degenerately.

- **Deleted** `Confidence.conjunction_fallacy_compatible`, which proved `∃ a b c : ℕ, a ≤ b ∧ ¬ a ≤ c` (`⟨1,2,0,…⟩`) — a triviality about ℕ mentioning no confidence ordering, no themes, no conjunction. Replaced with an honest section note: in this substrate, fallacy-compatibility is the *absence* of a conjunction-monotonicity constraint on the background `Preorder`, not a theorem; the genuine witness lives in `EpistemicThreshold`.
- **Strengthened** `EpistemicThreshold.confidence_not_probabilistic`'s witness to *consistent* propositions. It previously witnessed `cr(φ∧ψ) > cr(φ)` with `φ∧ψ = ⊥` (confidence in a contradiction); now `φ = ⊤`, `ψ = {true}`, `φ∧ψ = {true} ⊊ φ`, all consistent — a faithful Tversky–Kahneman pattern, with `cr` non-monotone. Statement unchanged, so no consumer is affected.
- **Study**: `conjunction_fallacy_predicted` (§3.4) was a trivial re-export of the deleted ℕ theorem; it now re-exports the genuine `confidence_not_probabilistic` (a non-probabilistic `AgentCredence` with the fallacy). Coverage docstrings updated.

The rest of the substrate (`StatesBased.lean`, the `EpistemicThreshold` threshold lattice / Klein reduction) was found sound — the rot was localized to this one theorem. Touches substrate (`Confidence`/`EpistemicThreshold`); CI's cold build is the gate. Warm cone built clean.