### PR TITLE
feat(Gradability): max-quantified states comparative + admissibility spine

### DIFF
--- a/Linglib/Semantics/Attitudes/Confidence.lean
+++ b/Linglib/Semantics/Attitudes/Confidence.lean
@@ -301,8 +301,8 @@ def confidenceLogicalForm {E W : Type*}
     smaller measure than the `p`-themed state. CSW fn. 25 explicitly
     reject the unique-state assumption ("This is not the picture we
     adopt"), but the simplification is useful for theorem statements that
-    don't need the full `max`-quantification. The maximality version lives
-    at the study-file level via `Wellwood2015.adjectival_max_reduces`. -/
+    don't need the full `max`-quantification. The faithful maximality version is
+    `confidenceComparative` below; this is its unique-state reduction. -/
 def comparativeConfidenceLogicalForm {E W : Type*}
     (co : ConfidenceOrdering E W)
     {D : Type*} [LinearOrder D]
@@ -313,5 +313,34 @@ def comparativeConfidenceLogicalForm {E W : Type*}
     s_q.holder = holder ∧ s_q.theme = q ∧
     letI := co.toPreorder
     statesComparativeSem μ s_p s_q
+
+/-! ### Faithful comparative (CSW (47)) and the admissibility spine -/
+
+/-- Comparative confidence (CSW (47)): "A is more confident that `p` than that
+    `q`" — `StatesBased.statesComparative` with the holder/theme predicates as
+    the matrix (`p`) and than-clause (`q`) restrictions. The `max`-quantified
+    than-clause does **not** assume a unique state per theme (CSW fn 25), unlike
+    `comparativeConfidenceLogicalForm`, which is its unique-state reduction. It
+    is measure-based and contrast-blind, so the `confident`/`certain` scale-mate
+    equivalence (CSW (72)) holds by construction. -/
+def confidenceComparative {E W D : Type*} [Preorder D]
+    (μ : ConfidenceState E W → D) (holder : E) (p q : W → Prop) : Prop :=
+  statesComparative (fun s => s.holder = holder ∧ s.theme = p)
+                    (fun s => s.holder = holder ∧ s.theme = q) μ
+
+/-- The admissibility spine (CSW (21)/(31)): when the measure `μ` is admissible
+    (`StrictMono` w.r.t. the holder's confidence ordering), the ordering entails
+    the comparative — if `s_q ≺ s_p` then A is more confident of `s_p` than
+    `s_q`. This ties the measure-comparative to the `ConfidenceOrdering`, the
+    constraint the free-`μ` `comparative_transitive`/`comparative_antisymmetric`
+    lack. (Over a `Preorder`, only this forward direction holds — CSW's ordering
+    need not be connected.) -/
+theorem confidence_more_of_ordering {E W D : Type*} [Preorder D]
+    (co : ConfidenceOrdering E W) (μ : ConfidenceState E W → D)
+    {s_p s_q : ConfidenceState E W} :
+    letI := co.toPreorder
+    admissibleMeasure μ → s_q < s_p → statesComparativeSem μ s_p s_q := by
+  letI := co.toPreorder
+  exact fun h hlt => statesComparativeSem_of_lt μ h hlt
 
 end Semantics.Attitudes.Confidence

--- a/Linglib/Semantics/Gradability/StatesBased.lean
+++ b/Linglib/Semantics/Gradability/StatesBased.lean
@@ -1,6 +1,7 @@
 import Linglib.Core.Order.Boundedness
 import Linglib.Core.Order.ComparativeScale
 import Linglib.Semantics.Gradability.Basic
+import Mathlib.Order.Bounds.Basic
 
 /-!
 # States-Based Gradable Adjective Semantics
@@ -181,6 +182,54 @@ abbrev admissibleMeasure {D : Type*} [Preorder D] (μ : S → D) : Prop :=
 def statesComparativeSem {D : Type*} [Preorder D]
     (μ : S → D) (s_a s_b : S) : Prop :=
   μ s_b < μ s_a
+
+/-- An admissible measure makes the background ordering entail the comparative:
+    if `s_b ≺ s_a` in the background ordering and `μ` is admissible (`StrictMono`,
+    CSW (21)/(31)), then `A is more G of s_a than s_b`. This is the spine that
+    ties the measure-comparative to the background ordering — over a `Preorder`
+    only the forward direction holds (the reverse needs a linear order, which
+    CSW's connectedness-agnostic ordering need not be). -/
+theorem statesComparativeSem_of_lt {D : Type*} [Preorder D]
+    (μ : S → D) (h : admissibleMeasure μ) {s_a s_b : S} (hlt : s_b < s_a) :
+    statesComparativeSem μ s_a s_b :=
+  h hlt
+
+/-! ### The max-quantified comparative (CSW (46)/(47), Wellwood §2–3)
+
+`statesComparativeSem` above is the unique-state *collapse* of the comparative
+(direct two-state measure comparison). CSW fn 25 explicitly reject this as the
+general picture: the faithful comparative compares a matrix state's measure
+against the **maximum** of the than-clause degree set. The full form is
+contrast-blind (no `StatesBasedEntry` argument), so scale-mate equivalence
+(CSW (72)) holds by construction. -/
+
+/-- The than-clause degree set (CSW (46)): the degrees met by some
+    `Pthan`-state. -/
+def thanDegrees {D : Type*} [Preorder D] (Pthan : S → Prop) (μ : S → D) : Set D :=
+  {d | ∃ s, Pthan s ∧ d ≤ μ s}
+
+/-- The max-quantified comparative (CSW (47)): some `Pmatrix`-state's measure
+    strictly exceeds the maximum of the `Pthan` degree set. -/
+def statesComparative {D : Type*} [Preorder D]
+    (Pmatrix Pthan : S → Prop) (μ : S → D) : Prop :=
+  ∃ δ, IsGreatest (thanDegrees Pthan μ) δ ∧ ∃ s, Pmatrix s ∧ δ < μ s
+
+omit [Preorder S] in
+/-- Under unique matrix and than states, the max-quantified comparative reduces
+    to the direct comparison `statesComparativeSem` (= `μ s_b < μ s_a`) — the
+    simplification CSW fn 25 set aside. So the collapse is a *corollary* of the
+    faithful form, not the definition. -/
+theorem statesComparative_unique_reduces {D : Type*} [Preorder D]
+    (μ : S → D) (s_a s_b : S) :
+    statesComparative (· = s_a) (· = s_b) μ ↔ statesComparativeSem μ s_a s_b := by
+  constructor
+  · rintro ⟨δ, ⟨_, hub⟩, s, rfl, hlt⟩
+    exact lt_of_le_of_lt (hub (show μ s_b ∈ thanDegrees (· = s_b) μ from
+      ⟨s_b, rfl, le_refl _⟩)) hlt
+  · intro h
+    refine ⟨μ s_b, ⟨⟨s_b, rfl, le_refl _⟩, ?_⟩, s_a, rfl, h⟩
+    rintro d ⟨s, rfl, hle⟩
+    exact hle
 
 -- ════════════════════════════════════════════════════
 -- § 4. Bridge: States-Based ↔ Kennedy


### PR DESCRIPTION
The deeper-implementation fix for CSW (2024) flagged in the substrate audit: the confidence comparative was the unique-state *collapse* (`μ s_b < μ s_a`) that CSW fn 25 explicitly reject, and its transitivity/antisymmetry theorems floated free of the background confidence ordering. This adds the faithful machinery under `Semantics.Gradability.StatesBased` (the existing states-based-gradability framework namespace).

**`StatesBased`** (the owner):
- `thanDegrees` + `statesComparative` — the `max`-quantified comparative (CSW (46)/(47), via mathlib `IsGreatest`), contrast-blind so scale-mate equivalence (CSW (72)) is structural.
- `statesComparative_unique_reduces` — the old direct-comparison form (`statesComparativeSem`) is now a *corollary* under unique states, the simplification CSW fn 25 set aside, not the definition.
- `statesComparativeSem_of_lt` — the admissibility spine (CSW (21)/(31)): an admissible (`StrictMono`) measure makes the background ordering entail the comparative. Over a `Preorder` only the forward direction holds (CSW's ordering need not be connected).

**`Confidence`** (consumer):
- `confidenceComparative` — CSW (47) for confidence states (holder/theme predicates), the faithful max-form; `comparativeConfidenceLogicalForm` re-doc'd as its unique-state reduction.
- `confidence_more_of_ordering` — wires the comparative to the `ConfidenceOrdering` via admissibility, the constraint the free-`μ` comparatives lacked.

Purely additive (+80/−2); no consumer broke (CSW study builds). **Deferred** (orthogonal, noted): graduating Wellwood2015's general event-comparative to substrate so confidence/Wellwood/Pasternak share one `more`; the `StatesBasedEntry → Entry` stutter rename.