### PR TITLE
chore(Studies): rename OgiharaST2024 to OgiharaSteinertThrelkeld2024

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1756,7 +1756,7 @@ import Linglib.Studies.Kiparsky2002
 import Linglib.Studies.Pancheva2003
 import Linglib.Studies.BeaverCondoravdi2003
 import Linglib.Studies.Cruse1973
-import Linglib.Studies.OgiharaST2024
+import Linglib.Studies.OgiharaSteinertThrelkeld2024
 import Linglib.Studies.Koev2017
 import Linglib.Studies.Egressy2026
 import Linglib.Studies.GokselKerslake2005

--- a/Linglib/Semantics/Tense/TemporalConnectives.lean
+++ b/Linglib/Semantics/Tense/TemporalConnectives.lean
@@ -12,7 +12,7 @@ analyses live in `Studies/`:
 - `Karttunen1974.lean`: *When*, *while*, *until*, *till*, *since*, *by*
 - `Rett2020.lean`: Antonymy + aspectual coercion + ambidirectionality
 - `BeaverCondoravdi2003.lean`: Intensional uniform analysis with `earliest`
-- `OgiharaST2024.lean` (in `Studies/`): Critique of B&C, eventuality-relative equivalence
+- `OgiharaSteinertThrelkeld2024.lean` (in `Studies/`): Critique of B&C, eventuality-relative equivalence
 
 ## Submodules
 

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -29,7 +29,7 @@ temporal connectives *before* and *after*.
 - Beaver, D. & Condoravdi, C. (2003), §2 (three readings of *before*).
 -/
 
-namespace OgiharaST2024
+namespace OgiharaSteinertThrelkeld2024
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1: Veridicality Judgments
@@ -944,7 +944,7 @@ theorem mozart_is_case_iii
 
 end Def19
 
-end OgiharaST2024
+end OgiharaSteinertThrelkeld2024
 
 -- ════════════════════════════════════════════════════════════════
 -- Veridicality ↔ Presupposition Bridge
@@ -964,13 +964,13 @@ For each temporal connective, the Fragment's `complementVeridical` field is
 **grounded** in a theory-level proof, and matches the empirical data.
 -/
 
-namespace OgiharaST2024.VeridicalityBridge
+namespace OgiharaSteinertThrelkeld2024.VeridicalityBridge
 
 open Core.Order
 open NonemptyInterval
 open Tense.TemporalConnectives
 open English.TemporalExpressions
-open OgiharaST2024
+open OgiharaSteinertThrelkeld2024
 
 -- ============================================================================
 -- § 19: Fragment ↔ Theory Agreement (Per-Entry Verification)
@@ -1111,4 +1111,4 @@ theorem bc_readings_in_data :
     before_noncommittal.complementEntailed = false :=
   ⟨rfl, rfl, rfl⟩
 
-end OgiharaST2024.VeridicalityBridge
+end OgiharaSteinertThrelkeld2024.VeridicalityBridge

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -10198,7 +10198,7 @@
   subfield  = {semantics/tense},
   validated = {true},
   role      = {formalized},
-  sources   = {Phenomena/TenseAspect/Studies/OgiharaST2024.lean;Phenomena/TemporalConnectives/Studies/BeaverCondoravdi2003.lean}
+  sources   = {Phenomena/TenseAspect/Studies/OgiharaSteinertThrelkeld2024.lean;Phenomena/TemporalConnectives/Studies/BeaverCondoravdi2003.lean}
 }
 @article{beaver-condoravdi-2003,
   author    = {Beaver, David and Condoravdi, Cleo},
@@ -10211,7 +10211,7 @@
   subfield  = {semantics/tense},
   validated = {true},
   role      = {formalized},
-  sources   = {Phenomena/TemporalConnectives/Studies/BeaverCondoravdi2003.lean;Phenomena/TenseAspect/Studies/OgiharaST2024.lean}
+  sources   = {Phenomena/TemporalConnectives/Studies/BeaverCondoravdi2003.lean;Phenomena/TenseAspect/Studies/OgiharaSteinertThrelkeld2024.lean}
 }
 @article{moens-steedman-1988,
   author    = {Moens, Marc and Steedman, Mark},


### PR DESCRIPTION
The file name's "ST" reads as "Sequence of Tense" but the paper is **Ogihara & Steinert-Threlkeld (2024)**, "Limitations of a modal analysis of *before* and *after*" (S&P 17(1)). Rename to the repo's two-author convention (cf. `KennedyLevin2008`, `CarianiSantorioWellwood2024`).

Mechanical: file + namespace `OgiharaST2024` → `OgiharaSteinertThrelkeld2024`, plus the `Linglib.lean` import, a `TemporalConnectives` docstring mention, and the bib `sources` path. The bib key (`ogihara-steinert-threlkeld-2024`) was already correct. A content audit of the file (against the now-verified Ogihara and Beaver & Condoravdi PDFs) follows separately.