### PR TITLE
refactor(Studies): derive B&C before/after asymmetries + fix OST defects

### DIFF
--- a/Linglib/Studies/BeaverCondoravdi2003.lean
+++ b/Linglib/Studies/BeaverCondoravdi2003.lean
@@ -413,4 +413,97 @@ theorem histAlt_subset_altIE_trivial
   rw [altIE, Set.mem_setOf_eq, equivIE_trivial_iff_agree]
   exact hIBP w t w' hw'
 
+-- ============================================================================
+-- § 10: Asymmetries of *before* and *after* ([anscombe-1964] time-set semantics)
+-- ============================================================================
+
+/-! [beaver-condoravdi-2003] §2 present three asymmetries that appear to motivate a
+    *non-uniform* lexicon for *before*/*after*, all stated over [anscombe-1964]'s
+    time-set semantics (their (27)): a clause denotes the set of times at which it
+    holds, and
+
+      `A before B` ≔ ∃ t ∈ A, ∀ t' ∈ B, t < t'      (universal over B)
+      `A after  B` ≔ ∃ t ∈ A, ∃ t' ∈ B, t' < t      (existential over B)
+
+    The asymmetries are theorems of these definitions: *before* is antisymmetric
+    ((3)-(4)), transitive ((12)-(14)), and downward-monotone in its complement
+    ((15)-(18), licensing NPIs via [ladusaw-1979]); *after* is none of these
+    ((5)-(11)). B&C's contribution is that the *same* facts follow from their
+    uniform `earliest` semantics (§3 above), so the asymmetries do not force a
+    non-uniform lexicon. The universal-over-B form also overgenerates ((32)-(33),
+    the "ketchup" examples) — `anscombeBefore_vacuous` — which their modal
+    `BC.before` repairs. -/
+
+section Anscombe
+variable {α : Type*} [Preorder α] {A B B' C : Set α}
+
+/-- [anscombe-1964] / [beaver-condoravdi-2003] (27): some A-time precedes *every*
+    B-time. The universal over B drives the asymmetries below. -/
+def anscombeBefore (A B : Set α) : Prop := ∃ t ∈ A, ∀ t' ∈ B, t < t'
+
+/-- [anscombe-1964] / [beaver-condoravdi-2003] (27): some A-time follows *some*
+    B-time (existential over B). -/
+def anscombeAfter (A B : Set α) : Prop := ∃ t ∈ A, ∃ t' ∈ B, t' < t
+
+/-- Antisymmetry of *before* ([beaver-condoravdi-2003] (3)-(4)): `A before B` and
+    `B before A` cannot both hold — some A-time precedes all B-times, so no B-time
+    precedes all A-times. -/
+theorem anscombeBefore_asymm (h₁ : anscombeBefore A B) (h₂ : anscombeBefore B A) :
+    False := by
+  obtain ⟨ta, haA, ha⟩ := h₁
+  obtain ⟨tb, hbB, hb⟩ := h₂
+  exact lt_asymm (ha tb hbB) (hb ta haA)
+
+/-- Transitivity of *before* ([beaver-condoravdi-2003] (12)-(14)). -/
+theorem anscombeBefore_trans (h₁ : anscombeBefore A B) (h₂ : anscombeBefore B C) :
+    anscombeBefore A C := by
+  obtain ⟨ta, haA, ha⟩ := h₁
+  obtain ⟨tb, hbB, hb⟩ := h₂
+  exact ⟨ta, haA, fun tc hcC => lt_trans (ha tb hbB) (hb tc hcC)⟩
+
+/-- *Before* is downward-monotone (antitone) in its complement
+    ([beaver-condoravdi-2003] (15)-(18)): shrinking B preserves `A before B`. This
+    downward-monotonicity is why *before* licenses NPIs ([ladusaw-1979]). -/
+theorem anscombeBefore_antitone (hsub : B ⊆ B') (h : anscombeBefore A B') :
+    anscombeBefore A B := by
+  obtain ⟨t, htA, ht⟩ := h
+  exact ⟨t, htA, fun t' ht'B => ht t' (hsub ht'B)⟩
+
+/-- *After* is upward-monotone in its complement: growing B preserves `A after B`.
+    Upward-monotonicity is why *after* does not license NPIs. -/
+theorem anscombeAfter_monotone (hsub : B ⊆ B') (h : anscombeAfter A B) :
+    anscombeAfter A B' := by
+  obtain ⟨t, htA, t', ht'B, hlt⟩ := h
+  exact ⟨t, htA, t', hsub ht'B, hlt⟩
+
+/-- The Anscombe overgeneration ([beaver-condoravdi-2003] (32)-(33), the "ketchup"/
+    "squares had four sides" examples): because *before* universally quantifies over
+    B, `A before ∅` holds whenever A is instantiated — predicting "David ate ketchup
+    before he won all the gold medals" true even if he never won. B&C's modal
+    `BC.before` (§3) avoids this. -/
+theorem anscombeBefore_vacuous (hA : A.Nonempty) : anscombeBefore A (∅ : Set α) := by
+  obtain ⟨t, ht⟩ := hA
+  exact ⟨t, ht, fun t' ht' => ((Set.mem_empty_iff_false t').mp ht').elim⟩
+
+/-- *After* is NOT antisymmetric ([beaver-condoravdi-2003] (5)-(7)): with overlapping
+    time sets, `A after B` and `B after A` both hold. Witness over ℕ. -/
+theorem anscombeAfter_not_antisymm :
+    ∃ A B : Set ℕ, anscombeAfter A B ∧ anscombeAfter B A := by
+  refine ⟨{0, 2}, {1}, ⟨2, by simp, 1, by simp, by decide⟩,
+    ⟨1, by simp, 0, by simp, by decide⟩⟩
+
+/-- *After* is NOT transitive ([beaver-condoravdi-2003] (8)-(11), the Ginger/Fred/
+    Delores dancing model): `A after B` and `B after C` without `A after C`. Witness
+    `A = {2}`, `B = {1,4}`, `C = {3}`. -/
+theorem anscombeAfter_not_trans :
+    ∃ A B C : Set ℕ, anscombeAfter A B ∧ anscombeAfter B C ∧ ¬ anscombeAfter A C := by
+  refine ⟨{2}, {1, 4}, {3}, ⟨2, by simp, 1, by simp, by decide⟩,
+    ⟨4, by simp, 3, by simp, by decide⟩, ?_⟩
+  rintro ⟨t, htA, t', ht'C, hlt⟩
+  simp only [Set.mem_singleton_iff] at htA ht'C
+  subst htA; subst ht'C
+  exact absurd hlt (by decide)
+
+end Anscombe
+
 end Tense.TemporalConnectives.BeaverCondoravdi

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -89,14 +89,15 @@ def after_veridical_2 : VeridicalityDatum where
 -- § 3: Additional Veridicality Data ([beaver-condoravdi-2003], §2)
 -- ════════════════════════════════════════════════════════════════
 
-/-- "The Supreme Court decided the election before the votes were
-    counted" — non-committal: compatible with votes eventually being
-    counted or never counted ([beaver-condoravdi-2003], ex. 22). -/
+/-- "I left the party before there was any trouble" — non-committal: implies trouble
+    seemed likely but does not commit to whether trouble occurred
+    ([beaver-condoravdi-2003], ex. 43). (B&C's (22), the Supreme Court "uncounted
+    votes" case, is *counterfactual*, not non-committal — see [beaver-condoravdi-2003] §6.) -/
 def before_noncommittal : VeridicalityDatum where
-  sentence := "The Supreme Court decided the election before the votes were counted"
+  sentence := "I left the party before there was any trouble"
   connective := "before"
   complementEntailed := false
-  gloss := "before(decide, count) |/= count (non-committal)"
+  gloss := "before(leave, trouble) |/= trouble (non-committal)"
 
 /-- "Mozart died before he finished the Requiem" — counterfactual:
     Mozart never finished the Requiem ([beaver-condoravdi-2003], ex. 24). -/
@@ -170,27 +171,9 @@ def before_licenses_npis : LogicalPropertyDatum where
   example_ := "Cleo left before anyone noticed / *Cleo left after anyone noticed"
   gloss := "before licenses NPIs; after does not"
 
--- ════════════════════════════════════════════════════════════════
--- § 5: Pragmatic Oddity Data ([beaver-condoravdi-2003], exx. 32-33)
--- ════════════════════════════════════════════════════════════════
-
-/-- "David won the race before he entered it" — pragmatically odd because
-    winning temporally presupposes entering: there is no historical
-    alternative where one wins before entering. ([beaver-condoravdi-2003], ex. 32) -/
-def before_oddity_win : VeridicalityDatum where
-  sentence := "David won the race before he entered it"
-  connective := "before"
-  complementEntailed := false
-  gloss := "before(win, enter) — pragmatically odd: winning presupposes entering"
-
-/-- "David entered the race after he won it" — same temporal impossibility
-    viewed through *after*: entering after winning reverses the natural
-    temporal order. ([beaver-condoravdi-2003], ex. 33) -/
-def after_oddity_enter : VeridicalityDatum where
-  sentence := "David entered the race after he won it"
-  connective := "after"
-  complementEntailed := true
-  gloss := "after(enter, win) — pragmatically odd: entering presupposes not yet having won"
+-- B&C's (32)/(33) — the "ketchup"/"squares had four sides" Anscombe overgeneration —
+-- are formalized as `BeaverCondoravdi.anscombeBefore_vacuous` (in that paper's anchor),
+-- not as the fabricated "win before entering" examples this file previously carried.
 
 open Tense.TemporalConnectives.BeaverCondoravdi
 


### PR DESCRIPTION
Relocate Beaver & Condoravdi's before/after logical-property asymmetries to their own paper-anchor as **derived theorems**, and fix two defects in the Ogihara & Steinert-Threlkeld study (both verified against the now-read B&C 2003 SALT and O&ST 2024 S&P PDFs).

**BeaverCondoravdi2003.lean** — new Anscombe time-set section (`anscombeBefore`/`anscombeAfter`, B&C (27)) with the §2 asymmetries proven, not stipulated:
- `anscombeBefore_asymm` / `anscombeBefore_trans` — antisymmetry/transitivity of *before* ((3)-(4), (12)-(14)).
- `anscombeAfter_not_antisymm` / `anscombeAfter_not_trans` — their failure for *after* ((5)-(11), the Ginger/Fred/Delores model) via explicit ℕ witnesses.
- `anscombeBefore_antitone` / `anscombeAfter_monotone` — the down/up monotonicity grounding NPI licensing ((15)-(18), [ladusaw-1979]).
- `anscombeBefore_vacuous` — B&C's (32)/(33) "ketchup"/"squares had four sides" overgeneration as `A before ∅` holding whenever A is instantiated.

**OgiharaSteinertThrelkeld2024.lean** — fix two audit findings:
- Remove the fabricated §5 oddity ("David won the race before he entered it" cited B&C (32)/(33), which are actually the ketchup/squares examples — now correctly formalized above).
- Fix §3: `before_noncommittal` cited B&C (22), which is *counterfactual* ("uncounted votes", B&C §6); replaced with B&C's actual non-committal example (43) "I left the party before there was any trouble."

Follow-up (noted): dedup OST's §4/§14/§15 logical-property data now superseded here, and JSON-ify the OST stimuli.