### PR TITLE
feat(Core/Probability): Gibbs–Donsker–Varadhan variational principle

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2608,6 +2608,7 @@ import Linglib.Pragmatics.RSA.Composition
 import Linglib.Pragmatics.RSA.LatentOperators
 import Linglib.Pragmatics.RSA.Silence
 import Linglib.Pragmatics.RSA.Cancellation
+import Linglib.Pragmatics.RSA.Gibbs
 import Linglib.Studies.Haspelmath2001
 import Linglib.Morphology.Grammaticalization
 import Linglib.Studies.Traugott2010
@@ -2883,6 +2884,7 @@ import Linglib.Studies.ViknerJensen2002
 import Linglib.Core.Probability.RandomUtility
 import Linglib.Core.Probability.LogitChoice
 import Linglib.Core.Probability.SoftmaxTheory
+import Linglib.Core.Probability.GibbsVariational
 import Linglib.Core.Probability.CoupledEvaluation
 import Linglib.Processing.Psychophysics.Thurstone
 import Linglib.Processing.Psychophysics.SignalDetection

--- a/Linglib/Core/Probability/GibbsVariational.lean
+++ b/Linglib/Core/Probability/GibbsVariational.lean
@@ -1,0 +1,135 @@
+import Mathlib.MeasureTheory.Measure.Tilted
+import Mathlib.MeasureTheory.Measure.LogLikelihoodRatio
+import Mathlib.InformationTheory.KullbackLeibler.Basic
+import Mathlib.Probability.Moments.Basic
+
+/-!
+# The Gibbs / Donsker–Varadhan variational principle  [UPSTREAM]
+
+For a probability measure `μ` and a function `f`, the **exponentially tilted
+measure** `μ.tilted f` (`MeasureTheory.Measure.tilted`, the Gibbs measure /
+Esscher transform with density `∝ exp f`) is the maximizer of the free-energy
+functional `q ↦ 𝔼_q[f] − KL(q ‖ μ)`, and the maximal value is the **log-partition
+function** `log ∫ exp f ∂μ`. This is the **Gibbs variational principle**
+(a.k.a. **Donsker–Varadhan**), the variational characterization of the
+Kullback–Leibler divergence anticipated by the module docstring of
+`Mathlib/MeasureTheory/Measure/Tilted.lean`.
+
+## Main definitions
+
+* `MeasureTheory.Measure.logIntegralExp μ f = log (∫ x, exp (f x) ∂μ)` — the
+  log-partition / free-energy functional. It generalizes the cumulant generating
+  function `ProbabilityTheory.cgf` (the affine case `f = t • X`); see
+  `logIntegralExp_const_mul`.
+
+## Main statements
+
+* `toReal_klDiv_tilted_right` — the **Gibbs decomposition identity**:
+  `KL(q ‖ μ.tilted f) = KL(q ‖ μ) − 𝔼_q[f] + logIntegralExp μ f`.
+* `sub_klDiv_le_logIntegralExp` — the **variational inequality**:
+  `𝔼_q[f] − KL(q ‖ μ) ≤ logIntegralExp μ f` for all `q ≪ μ`.
+* `sub_klDiv_tilted_eq_logIntegralExp` — the bound is **attained** at `μ.tilted f`.
+* `isGreatest_logIntegralExp` — the **variational principle** in `IsGreatest` form:
+  `logIntegralExp μ f` is the greatest value of `q ↦ 𝔼_q[f] − KL(q ‖ μ)`.
+
+## Implementation notes
+
+The decomposition reuses the log-likelihood-ratio identity
+`MeasureTheory.integral_llr_tilted_right`; both `klDiv` terms collapse to their
+`llr`-integrals via `toReal_klDiv_of_measure_eq` (the `univ`-mass correction in
+`toReal_klDiv` vanishes because every measure in play is a probability measure —
+`μ.tilted f` is normalized by construction). The statements are over probability
+measures; the finite-measure generalization carries an additive `μ.real univ`
+correction and is left for future work.
+-/
+
+open Real MeasureTheory ProbabilityTheory InformationTheory
+open scoped ENNReal
+
+namespace MeasureTheory
+
+variable {α : Type*} {mα : MeasurableSpace α}
+
+/-- The **log-partition** (free-energy) functional `log ∫ exp f ∂μ`. Generalizes
+the cumulant generating function `ProbabilityTheory.cgf` to an arbitrary
+integrand (the affine case `f = fun x ↦ t * X x` recovers `cgf X μ t`, see
+`logIntegralExp_const_mul`). -/
+noncomputable def Measure.logIntegralExp (μ : Measure α) (f : α → ℝ) : ℝ :=
+  Real.log (∫ x, Real.exp (f x) ∂μ)
+
+/-- `logIntegralExp` generalizes the cumulant generating function: on the affine
+family `f = fun x ↦ t * X x` it is `ProbabilityTheory.cgf X μ t`. -/
+theorem logIntegralExp_const_mul (μ : Measure α) (X : α → ℝ) (t : ℝ) :
+    μ.logIntegralExp (fun x => t * X x) = cgf X μ t := by
+  simp only [Measure.logIntegralExp, cgf, mgf]
+
+/-- **Gibbs decomposition identity**: for `q ≪ μ` (both probability measures),
+the Kullback–Leibler divergence from the Gibbs measure `μ.tilted f` splits as
+`KL(q ‖ μ.tilted f) = KL(q ‖ μ) − 𝔼_q[f] + logIntegralExp μ f`.
+
+A `klDiv`-level repackaging of `integral_llr_tilted_right`: both divergences
+reduce to their `llr`-integrals via `toReal_klDiv_of_measure_eq` (the mass
+correction vanishes — all measures are probability measures), after which the
+log-likelihood-ratio decomposition closes it. -/
+theorem toReal_klDiv_tilted_right (μ q : Measure α) [IsProbabilityMeasure μ]
+    [IsProbabilityMeasure q] {f : α → ℝ} (hqμ : q ≪ μ)
+    (h_int_llr : Integrable (llr q μ) q) (h_int_f : Integrable f q)
+    (h_exp : Integrable (fun x => Real.exp (f x)) μ) :
+    (klDiv q (μ.tilted f)).toReal
+      = (klDiv q μ).toReal - (∫ x, f x ∂q) + μ.logIntegralExp f := by
+  have h_prob_tilt : IsProbabilityMeasure (μ.tilted f) := isProbabilityMeasure_tilted h_exp
+  have hq_tilt : q ≪ μ.tilted f := hqμ.trans (absolutelyContinuous_tilted h_exp)
+  rw [toReal_klDiv_of_measure_eq hq_tilt (by rw [measure_univ, measure_univ]),
+      toReal_klDiv_of_measure_eq hqμ (by rw [measure_univ, measure_univ]),
+      integral_llr_tilted_right hqμ h_int_f h_exp h_int_llr, Measure.logIntegralExp]
+
+/-- **Gibbs / Donsker–Varadhan variational inequality**: for every probability
+measure `q ≪ μ`, expected value minus relative entropy is bounded by the
+log-partition function, `𝔼_q[f] − KL(q ‖ μ) ≤ logIntegralExp μ f`. Immediate from
+the decomposition identity and `0 ≤ KL`. -/
+theorem sub_klDiv_le_logIntegralExp (μ q : Measure α) [IsProbabilityMeasure μ]
+    [IsProbabilityMeasure q] {f : α → ℝ} (hqμ : q ≪ μ)
+    (h_int_llr : Integrable (llr q μ) q) (h_int_f : Integrable f q)
+    (h_exp : Integrable (fun x => Real.exp (f x)) μ) :
+    (∫ x, f x ∂q) - (klDiv q μ).toReal ≤ μ.logIntegralExp f := by
+  have h := toReal_klDiv_tilted_right μ q hqμ h_int_llr h_int_f h_exp
+  have hnn : 0 ≤ (klDiv q (μ.tilted f)).toReal := ENNReal.toReal_nonneg
+  linarith
+
+/-- The variational bound `sub_klDiv_le_logIntegralExp` is **attained** at the
+Gibbs measure `μ.tilted f`: `𝔼_{μ.tilted f}[f] − KL(μ.tilted f ‖ μ) =
+logIntegralExp μ f`. Immediate from the decomposition at `q = μ.tilted f`, where
+the relative-entropy term `KL(μ.tilted f ‖ μ.tilted f)` vanishes. -/
+theorem sub_klDiv_tilted_eq_logIntegralExp (μ : Measure α) [IsProbabilityMeasure μ]
+    {f : α → ℝ} (h_int_f : Integrable f (μ.tilted f))
+    (h_int_llr : Integrable (llr (μ.tilted f) μ) (μ.tilted f))
+    (h_exp : Integrable (fun x => Real.exp (f x)) μ) :
+    (∫ x, f x ∂(μ.tilted f)) - (klDiv (μ.tilted f) μ).toReal = μ.logIntegralExp f := by
+  have h_prob_tilt : IsProbabilityMeasure (μ.tilted f) := isProbabilityMeasure_tilted h_exp
+  have h := toReal_klDiv_tilted_right μ (μ.tilted f) (tilted_absolutelyContinuous μ f)
+    h_int_llr h_int_f h_exp
+  rw [klDiv_self, ENNReal.toReal_zero] at h
+  linarith
+
+/-- **Gibbs / Donsker–Varadhan variational principle**: the log-partition
+function `logIntegralExp μ f` is the *greatest* value of the free-energy
+functional `q ↦ 𝔼_q[f] − KL(q ‖ μ)` over probability measures `q ≪ μ` (with the
+relevant integrability), the maximum being attained at the Gibbs measure
+`μ.tilted f`. Bundles `sub_klDiv_le_logIntegralExp` (upper bound) and
+`sub_klDiv_tilted_eq_logIntegralExp` (attainment). -/
+theorem isGreatest_logIntegralExp (μ : Measure α) [IsProbabilityMeasure μ] {f : α → ℝ}
+    (h_int_f : Integrable f (μ.tilted f))
+    (h_int_llr : Integrable (llr (μ.tilted f) μ) (μ.tilted f))
+    (h_exp : Integrable (fun x => Real.exp (f x)) μ) :
+    IsGreatest
+      {x : ℝ | ∃ q : Measure α, IsProbabilityMeasure q ∧ q ≪ μ ∧
+        Integrable (llr q μ) q ∧ Integrable f q ∧
+        x = (∫ a, f a ∂q) - (klDiv q μ).toReal}
+      (μ.logIntegralExp f) := by
+  refine ⟨⟨μ.tilted f, isProbabilityMeasure_tilted h_exp, tilted_absolutelyContinuous μ f,
+      h_int_llr, h_int_f, (sub_klDiv_tilted_eq_logIntegralExp μ h_int_f h_int_llr h_exp).symm⟩, ?_⟩
+  rintro x ⟨q, hq_prob, hqμ, hq_llr, hq_f, rfl⟩
+  haveI := hq_prob
+  exact sub_klDiv_le_logIntegralExp μ q hqμ hq_llr hq_f h_exp
+
+end MeasureTheory

--- a/Linglib/Pragmatics/RSA/Gibbs.lean
+++ b/Linglib/Pragmatics/RSA/Gibbs.lean
@@ -1,0 +1,165 @@
+import Mathlib.MeasureTheory.Measure.Tilted
+import Mathlib.MeasureTheory.Measure.Count
+import Mathlib.MeasureTheory.Integral.Bochner.Basic
+import Mathlib.Probability.Kernel.Posterior
+import Mathlib.InformationTheory.KullbackLeibler.Basic
+import Linglib.Core.Probability.GibbsVariational
+
+/-!
+# The RSA speaker as a Gibbs (exponentially-tilted) measure
+[frank-goodman-2012] [goodman-stuhlmuller-2013]
+
+Layer 1 of the analytic theory of RSA (Measure/Kernel-native foundation). The
+pragmatic speaker `S1(· | w)` is the **exponential tilting** of a base
+utterance measure by the rationality-scaled utility
+`score w u = α · (log L0(w | u) − cost u)`:
+
+  `S1(· | w) = base.tilted (score w)`
+
+i.e. the speaker is a **Gibbs measure** in mathlib's sense
+(`MeasureTheory.Measure.tilted`). This grounds the RSA speaker in mathlib's
+exponential-family machinery rather than a bespoke `PMF.normalize ∘ exp`
+reimplementation, and is the object on which the variational (free-energy /
+`klDiv`) characterization will be built (Layer 0 keystone, to follow).
+
+## Main statements
+
+* `speaker_count_singleton` — closed form of the speaker mass at an utterance,
+  for the counting base: `ofReal (exp (score u) / ∑ u', exp (score u'))`.
+* `speaker_count_lt_iff_score_lt` — **monotonicity in informativity**: the
+  speaker prefers `u₂` over `u₁` iff its utility is higher. The partition
+  function cancels; reduces to strict monotonicity of `Real.exp`.
+-/
+
+open MeasureTheory Real
+open scoped ENNReal
+
+namespace RSA.Gibbs
+
+variable {U : Type*}
+
+/-- The RSA pragmatic speaker as an exponentially-tilted (Gibbs) measure: the
+base utterance measure tilted by the utility `score`. With `score u =
+α · (log L0(w|u) − cost u)` this is `S1(· | w) ∝ L0(w|u)^α · exp(−α·cost)`. -/
+noncomputable def speaker [MeasurableSpace U] (base : Measure U) (score : U → ℝ) :
+    Measure U :=
+  base.tilted score
+
+/-- Closed form of the speaker mass at a single utterance, for the counting
+base: `ofReal (exp (score u) / Z)` with partition `Z = ∑ u', exp (score u')`. -/
+theorem speaker_count_singleton [Fintype U] [MeasurableSpace U]
+    [MeasurableSingletonClass U] (score : U → ℝ) (a : U) :
+    speaker (Measure.count : Measure U) score {a}
+      = ENNReal.ofReal (Real.exp (score a) / ∑ u, Real.exp (score u)) := by
+  rw [speaker, tilted_apply, lintegral_singleton, Measure.count_singleton, mul_one,
+      integral_count]
+
+/-- **Speaker monotonicity in informativity**: at a fixed world, the speaker
+assigns more mass to `b` than to `a` iff `b` has the higher utility. The
+partition function cancels exactly; the comparison reduces to the strict
+monotonicity of `Real.exp`. The RSA "speaker prefers the more informative
+utterance" fact, as a theorem about the Gibbs measure. -/
+theorem speaker_count_lt_iff_score_lt [Fintype U] [MeasurableSpace U]
+    [MeasurableSingletonClass U] (score : U → ℝ) (a b : U) :
+    speaker (Measure.count : Measure U) score {a}
+        < speaker (Measure.count : Measure U) score {b}
+      ↔ score a < score b := by
+  rw [speaker_count_singleton, speaker_count_singleton]
+  have hZ : 0 < ∑ u, Real.exp (score u) :=
+    Finset.sum_pos (fun u _ => Real.exp_pos _) ⟨a, Finset.mem_univ a⟩
+  rw [ENNReal.ofReal_lt_ofReal_iff (by positivity),
+      div_lt_div_iff_of_pos_right hZ, Real.exp_lt_exp]
+
+/-! ### The pragmatic listener as a Bayesian posterior (measure-native)
+
+The pragmatic listener `L1` is the **Bayesian posterior** of the speaker kernel
+`S1 : Kernel World Utterance` against the world prior — mathlib's
+`ProbabilityTheory.posterior`, `S1 † prior : Kernel Utterance World`. This is
+the listener stated *measure-natively*: it is a kernel/measure, characterized by
+Bayes-consistency rather than by pointwise singleton values, so it is uniform
+across discrete and continuous distribution classes (where singletons are null
+and a pointwise reading is unavailable). -/
+
+open ProbabilityTheory
+
+/-- The RSA pragmatic listener: the Bayesian posterior `S1 † prior` of the
+speaker kernel against the world prior. -/
+noncomputable def listener {W U : Type*} [MeasurableSpace W] [MeasurableSpace U]
+    [StandardBorelSpace W] [Nonempty W]
+    (S1 : Kernel W U) (prior : Measure W) [IsFiniteMeasure prior] [IsFiniteKernel S1] :
+    Kernel U W :=
+  S1 † prior
+
+/-- **Listener–speaker consistency** (measure-native): averaging the listener
+over the speaker's marginal of the prior recovers the prior,
+`L1 ∘ₘ (S1 ∘ₘ prior) = prior`. The Bayesian-coherence identity for RSA, as an
+equality of measures — no singletons, any distribution class. -/
+theorem listener_comp_speaker_marginal {W U : Type*} [MeasurableSpace W]
+    [MeasurableSpace U] [StandardBorelSpace W] [Nonempty W]
+    (S1 : Kernel W U) (prior : Measure W) [IsFiniteMeasure prior] [IsMarkovKernel S1] :
+    listener S1 prior ∘ₘ (S1 ∘ₘ prior) = prior := by
+  unfold listener; exact posterior_comp_self
+
+/-! ### Bayes' theorem and region inference (measure-native) -/
+
+/-- **Bayes' theorem for the RSA listener**: for almost every utterance `u`, the
+listener is the prior **reweighted by the per-world speaker likelihood-ratio**,
+`L1 u = prior.withDensity (fun w ↦ (S1 w).rnDeriv (S1 ∘ₘ prior) u)`. The posterior
+is the prior tilted by how diagnostic each world is for `u`. For countable worlds
+the absolute-continuity side condition is automatic. -/
+theorem listener_eq_withDensity {W U : Type*} [MeasurableSpace W] [MeasurableSpace U]
+    [Countable W] [StandardBorelSpace W] [Nonempty W]
+    (S1 : Kernel W U) (prior : Measure W) [IsFiniteMeasure prior] [IsFiniteKernel S1] :
+    ∀ᵐ u ∂(S1 ∘ₘ prior),
+      listener S1 prior u
+        = prior.withDensity (fun w => (S1 w).rnDeriv (S1 ∘ₘ prior) u) := by
+  unfold listener
+  exact posterior_eq_withDensity_of_countable S1 prior
+
+/-- **Region inference**: the listener's posterior mass on a set of worlds `A`
+given utterance `u` is the integral of the speaker likelihood-ratio over `A`.
+This is the measure-native quantity behind RSA "the listener infers `φ`" claims
+(projection, exhaustivity = posterior mass on the relevant region of worlds) —
+stated at the level of sets, where it is meaningful for any distribution class,
+rather than at points. -/
+theorem listener_region {W U : Type*} [MeasurableSpace W] [MeasurableSpace U]
+    [Countable W] [StandardBorelSpace W] [Nonempty W]
+    (S1 : Kernel W U) (prior : Measure W) [IsFiniteMeasure prior] [IsFiniteKernel S1]
+    {A : Set W} (hA : MeasurableSet A) :
+    ∀ᵐ u ∂(S1 ∘ₘ prior),
+      listener S1 prior u A = ∫⁻ w in A, (S1 w).rnDeriv (S1 ∘ₘ prior) u ∂prior := by
+  filter_upwards [listener_eq_withDensity S1 prior] with u hu
+  rw [hu, withDensity_apply _ hA]
+
+/-! ### The RSA speaker is the rational optimizer
+
+`speaker base score = base.tilted score` is a Gibbs measure, so the
+Gibbs / Donsker–Varadhan variational principle
+(`MeasureTheory.isGreatest_logIntegralExp`, proved generically in
+`Core/Probability/GibbsVariational.lean`) applies directly: among all candidate
+distributions over utterances, the speaker is the one **maximizing expected
+utility `𝔼_q[score]` minus the KL cost `KL(q ‖ base)` of departing from the
+prior**, with optimal value the free energy `base.logIntegralExp score`. This
+turns RSA's "rational speaker" from a stipulated softmax into a theorem. -/
+
+open InformationTheory
+
+/-- The RSA speaker is the **rational optimizer**: `speaker base score` attains
+the greatest value of expected-utility-minus-KL-cost
+`q ↦ 𝔼_q[score] − KL(q ‖ base)` over candidate utterance distributions, the
+optimum being the free energy `base.logIntegralExp score`. A direct instance of
+the Gibbs / Donsker–Varadhan variational principle
+`MeasureTheory.isGreatest_logIntegralExp` at the tilt defining the speaker. -/
+theorem speaker_isGreatest {U : Type*} [MeasurableSpace U] (base : Measure U)
+    [IsProbabilityMeasure base] (score : U → ℝ)
+    (h_int_f : Integrable score (speaker base score))
+    (h_int_llr : Integrable (llr (speaker base score) base) (speaker base score))
+    (h_exp : Integrable (fun u => Real.exp (score u)) base) :
+    IsGreatest
+      {x : ℝ | ∃ q : Measure U, IsProbabilityMeasure q ∧ q ≪ base ∧
+        Integrable (llr q base) q ∧ Integrable score q ∧
+        x = (∫ u, score u ∂q) - (klDiv q base).toReal}
+      (base.logIntegralExp score) :=
+  isGreatest_logIntegralExp base h_int_f h_int_llr h_exp
+
+end RSA.Gibbs


### PR DESCRIPTION
Adds the Gibbs / Donsker–Varadhan variational principle for exponentially-tilted measures — the variational characterization of `klDiv` that `Mathlib/MeasureTheory/Measure/Tilted.lean`'s docstring anticipates but mathlib lacks — and uses it to ground the RSA speaker.

`Core/Probability/GibbsVariational.lean` (`[UPSTREAM]`, namespace `MeasureTheory`):
- `Measure.logIntegralExp μ f = log ∫ exp f ∂μ` + `logIntegralExp_const_mul` (= `cgf` on the affine family — bridges KullbackLeibler ↔ Moments)
- `toReal_klDiv_tilted_right` — decomposition `KL(q‖μ.tilted f) = KL(q‖μ) − 𝔼_q[f] + logIntegralExp μ f` (repackages `integral_llr_tilted_right`)
- `sub_klDiv_le_logIntegralExp` (variational inequality), `sub_klDiv_tilted_eq_logIntegralExp` (attained at the tilt), `isGreatest_logIntegralExp` (headline)

`Pragmatics/RSA/Gibbs.lean`: RSA speaker as the Gibbs measure (`tilted`) + listener as Bayesian `posterior`, with `speaker_isGreatest` — the RSA speaker is the rational optimizer. Kernel-clean throughout.