### PR TITLE
refactor(Studies): JSON-ify OgiharaSteinertThrelkeld2024 stimuli

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2893,3 +2893,4 @@ import Linglib.Pragmatics.BToM
 import Linglib.Pragmatics.BToMCredence
 import Linglib.Pragmatics.Emotion
 import Linglib.Data.Examples.Mizuno2024
+import Linglib.Data.Examples.OgiharaSteinertThrelkeld2024

--- a/Linglib/Data/Examples/OgiharaSteinertThrelkeld2024.json
+++ b/Linglib/Data/Examples/OgiharaSteinertThrelkeld2024.json
@@ -1,0 +1,230 @@
+[
+  {
+    "id": "ost2024_after_veridical",
+    "source": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "veridicality"},
+    "language": "stan1293",
+    "primaryText": "He left after she arrived.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "He left after she arrived.",
+    "context": "*After* is veridical: the sentence entails that she arrived.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "veridicality"],
+      ["connective", "after"],
+      ["complement_entailed", "true"]
+    ],
+    "comment": "after(leave, arrive) |= arrive",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ost2024_before_nonveridical",
+    "source": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "veridicality"},
+    "language": "stan1293",
+    "primaryText": "He left before she arrived.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "He left before she arrived.",
+    "context": "*Before* is non-veridical: compatible with her arriving (veridical), not arriving (counterfactual), or indeterminate (non-committal).",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "veridicality"],
+      ["connective", "before"],
+      ["complement_entailed", "false"]
+    ],
+    "comment": "before(leave, arrive) |/= arrive",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ost2024_before_counterfactual",
+    "source": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "veridicality"},
+    "language": "stan1293",
+    "primaryText": "The bomb exploded before anyone defused it.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "The bomb exploded before anyone defused it.",
+    "context": "Counterfactual reading of *before*: the defusing did not occur ([beaver-condoravdi-2003], the \"barely prevented\" reading).",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "veridicality"],
+      ["connective", "before"],
+      ["complement_entailed", "false"]
+    ],
+    "comment": "before(explode, defuse) and not defuse",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ost2024_after_veridical_2",
+    "source": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "veridicality"},
+    "language": "stan1293",
+    "primaryText": "She finished her coffee after he left.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "She finished her coffee after he left.",
+    "context": "*After* is veridical: the sentence entails that he left.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "veridicality"],
+      ["connective", "after"],
+      ["complement_entailed", "true"]
+    ],
+    "comment": "after(finish, leave) |= leave",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ost2024_before_noncommittal",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(43)"},
+    "reportedIn": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "veridicality"},
+    "language": "stan1293",
+    "primaryText": "I left the party before there was any trouble.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "I left the party before there was any trouble.",
+    "context": "Non-committal reading of *before*: implies trouble seemed likely but does not commit to whether it occurred. (B&C (22), the Supreme Court \"uncounted votes\" case, is counterfactual, not non-committal — B&C §6.)",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "veridicality"],
+      ["connective", "before"],
+      ["complement_entailed", "false"]
+    ],
+    "comment": "before(leave, trouble) |/= trouble (non-committal)",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ost2024_before_counterfactual_mozart",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(24)"},
+    "reportedIn": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "veridicality"},
+    "language": "stan1293",
+    "primaryText": "Mozart died before he finished the Requiem.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Mozart died before he finished the Requiem.",
+    "context": "Counterfactual reading of *before*: Mozart never finished the Requiem.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "veridicality"],
+      ["connective", "before"],
+      ["complement_entailed", "false"]
+    ],
+    "comment": "before(die, finish) and not finish (counterfactual)",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ost2024_ohtani",
+    "source": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "(20a)"},
+    "language": "stan1293",
+    "primaryText": "Unfortunately, the 2021 MLB season will be over before Shohei Ohtani earns his 10th win of the season.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Unfortunately, the 2021 MLB season will be over before Shohei Ohtani earns his 10th win of the season.",
+    "context": "Uttered in the middle of September 2021. The A-time is the end of the 2021 MLB season; the complement (Ohtani's 10th win) can only occur during the season, before the A-time — a counterexample to B&C's forward-branching alt(w,t).",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "bc_counterexample"],
+      ["reading", "counterfactual"]
+    ],
+    "comment": "O&ST (20a). Complement temporally bounded before the A-time.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ost2024_snow",
+    "source": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "(20b)"},
+    "language": "stan1293",
+    "primaryText": "2020 might come to an end before it snows for the first time this year.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "2020 might come to an end before it snows for the first time this year.",
+    "context": "Uttered on Christmas Day 2020. *This year* refers to 2020; the first snow of 2020 can only occur in 2020, so a modal alternative placing it after 2020 does not work.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "bc_counterexample"],
+      ["reading", "nonCommittal"]
+    ],
+    "comment": "O&ST (20b). Complement bounded to the end of 2020.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ost2024_nostradamus",
+    "source": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "(20c)"},
+    "language": "stan1293",
+    "primaryText": "July 1999 will come to an end before Nostradamus' prophecy about the end of the world comes true.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "July 1999 will come to an end before Nostradamus' prophecy about the end of the world comes true.",
+    "context": "Uttered a few minutes before the end of July 1999. The prophecy (a King of terror in July 1999) can only come true in July 1999 — not after.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "bc_counterexample"],
+      ["reading", "counterfactual"]
+    ],
+    "comment": "O&ST (20c). Complement bounded to July 1999.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ost2024_noncommittal_available",
+    "source": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "(22a)"},
+    "language": "stan1293",
+    "primaryText": "Mary will leave the party before Bill gets drunk.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Mary will leave the party before Bill gets drunk.",
+    "context": "Non-committal reading available: Bill's getting drunk is a normal continuation of being at a party.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "noncommittal"],
+      ["noncommittal_available", "true"]
+    ],
+    "comment": "getting drunk is a normal continuation of being at a party",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ost2024_noncommittal_unavailable",
+    "source": {"bibkey": "ogihara-steinert-threlkeld-2024", "paperLabel": "(22b)"},
+    "language": "stan1293",
+    "primaryText": "Mary will leave the party before Quebec becomes an independent country.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Mary will leave the party before Quebec becomes an independent country.",
+    "context": "Non-committal reading unavailable (odd): Quebec's independence is not a contextually normal continuation of the party.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "noncommittal"],
+      ["noncommittal_available", "false"]
+    ],
+    "comment": "Quebec independence is not a contextually normal continuation",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Data/Examples/OgiharaSteinertThrelkeld2024.lean
@@ -1,0 +1,216 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `OgiharaSteinertThrelkeld2024` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/OgiharaSteinertThrelkeld2024.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace OgiharaSteinertThrelkeld2024.Examples`.
+-/
+
+namespace OgiharaSteinertThrelkeld2024.Examples
+
+open Data.Examples
+
+def ost2024_after_veridical : LinguisticExample :=
+  { id := "ost2024_after_veridical"
+    source := ⟨"ogihara-steinert-threlkeld-2024", "veridicality"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "He left after she arrived."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "He left after she arrived."
+    context := "*After* is veridical: the sentence entails that she arrived."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "veridicality"), ("connective", "after"), ("complement_entailed", "true")]
+    comment := "after(leave, arrive) |= arrive"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ost2024_before_nonveridical : LinguisticExample :=
+  { id := "ost2024_before_nonveridical"
+    source := ⟨"ogihara-steinert-threlkeld-2024", "veridicality"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "He left before she arrived."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "He left before she arrived."
+    context := "*Before* is non-veridical: compatible with her arriving (veridical), not arriving (counterfactual), or indeterminate (non-committal)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "veridicality"), ("connective", "before"), ("complement_entailed", "false")]
+    comment := "before(leave, arrive) |/= arrive"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ost2024_before_counterfactual : LinguisticExample :=
+  { id := "ost2024_before_counterfactual"
+    source := ⟨"ogihara-steinert-threlkeld-2024", "veridicality"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The bomb exploded before anyone defused it."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The bomb exploded before anyone defused it."
+    context := "Counterfactual reading of *before*: the defusing did not occur ([beaver-condoravdi-2003], the \"barely prevented\" reading)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "veridicality"), ("connective", "before"), ("complement_entailed", "false")]
+    comment := "before(explode, defuse) and not defuse"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ost2024_after_veridical_2 : LinguisticExample :=
+  { id := "ost2024_after_veridical_2"
+    source := ⟨"ogihara-steinert-threlkeld-2024", "veridicality"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "She finished her coffee after he left."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "She finished her coffee after he left."
+    context := "*After* is veridical: the sentence entails that he left."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "veridicality"), ("connective", "after"), ("complement_entailed", "true")]
+    comment := "after(finish, leave) |= leave"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ost2024_before_noncommittal : LinguisticExample :=
+  { id := "ost2024_before_noncommittal"
+    source := ⟨"beaver-condoravdi-2003", "(43)"⟩
+    reportedIn := some ⟨"ogihara-steinert-threlkeld-2024", "veridicality"⟩
+    language := "stan1293"
+    primaryText := "I left the party before there was any trouble."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I left the party before there was any trouble."
+    context := "Non-committal reading of *before*: implies trouble seemed likely but does not commit to whether it occurred. (B&C (22), the Supreme Court \"uncounted votes\" case, is counterfactual, not non-committal — B&C §6.)"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "veridicality"), ("connective", "before"), ("complement_entailed", "false")]
+    comment := "before(leave, trouble) |/= trouble (non-committal)"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ost2024_before_counterfactual_mozart : LinguisticExample :=
+  { id := "ost2024_before_counterfactual_mozart"
+    source := ⟨"beaver-condoravdi-2003", "(24)"⟩
+    reportedIn := some ⟨"ogihara-steinert-threlkeld-2024", "veridicality"⟩
+    language := "stan1293"
+    primaryText := "Mozart died before he finished the Requiem."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mozart died before he finished the Requiem."
+    context := "Counterfactual reading of *before*: Mozart never finished the Requiem."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "veridicality"), ("connective", "before"), ("complement_entailed", "false")]
+    comment := "before(die, finish) and not finish (counterfactual)"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ost2024_ohtani : LinguisticExample :=
+  { id := "ost2024_ohtani"
+    source := ⟨"ogihara-steinert-threlkeld-2024", "(20a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Unfortunately, the 2021 MLB season will be over before Shohei Ohtani earns his 10th win of the season."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Unfortunately, the 2021 MLB season will be over before Shohei Ohtani earns his 10th win of the season."
+    context := "Uttered in the middle of September 2021. The A-time is the end of the 2021 MLB season; the complement (Ohtani's 10th win) can only occur during the season, before the A-time — a counterexample to B&C's forward-branching alt(w,t)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "bc_counterexample"), ("reading", "counterfactual")]
+    comment := "O&ST (20a). Complement temporally bounded before the A-time."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ost2024_snow : LinguisticExample :=
+  { id := "ost2024_snow"
+    source := ⟨"ogihara-steinert-threlkeld-2024", "(20b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "2020 might come to an end before it snows for the first time this year."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "2020 might come to an end before it snows for the first time this year."
+    context := "Uttered on Christmas Day 2020. *This year* refers to 2020; the first snow of 2020 can only occur in 2020, so a modal alternative placing it after 2020 does not work."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "bc_counterexample"), ("reading", "nonCommittal")]
+    comment := "O&ST (20b). Complement bounded to the end of 2020."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ost2024_nostradamus : LinguisticExample :=
+  { id := "ost2024_nostradamus"
+    source := ⟨"ogihara-steinert-threlkeld-2024", "(20c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "July 1999 will come to an end before Nostradamus' prophecy about the end of the world comes true."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "July 1999 will come to an end before Nostradamus' prophecy about the end of the world comes true."
+    context := "Uttered a few minutes before the end of July 1999. The prophecy (a King of terror in July 1999) can only come true in July 1999 — not after."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "bc_counterexample"), ("reading", "counterfactual")]
+    comment := "O&ST (20c). Complement bounded to July 1999."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ost2024_noncommittal_available : LinguisticExample :=
+  { id := "ost2024_noncommittal_available"
+    source := ⟨"ogihara-steinert-threlkeld-2024", "(22a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary will leave the party before Bill gets drunk."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mary will leave the party before Bill gets drunk."
+    context := "Non-committal reading available: Bill's getting drunk is a normal continuation of being at a party."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "noncommittal"), ("noncommittal_available", "true")]
+    comment := "getting drunk is a normal continuation of being at a party"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ost2024_noncommittal_unavailable : LinguisticExample :=
+  { id := "ost2024_noncommittal_unavailable"
+    source := ⟨"ogihara-steinert-threlkeld-2024", "(22b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary will leave the party before Quebec becomes an independent country."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mary will leave the party before Quebec becomes an independent country."
+    context := "Non-committal reading unavailable (odd): Quebec's independence is not a contextually normal continuation of the party."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "noncommittal"), ("noncommittal_available", "false")]
+    comment := "Quebec independence is not a contextually normal continuation"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ost2024_after_veridical, ost2024_before_nonveridical, ost2024_before_counterfactual, ost2024_after_veridical_2, ost2024_before_noncommittal, ost2024_before_counterfactual_mozart, ost2024_ohtani, ost2024_snow, ost2024_nostradamus, ost2024_noncommittal_available, ost2024_noncommittal_unavailable]
+
+end OgiharaSteinertThrelkeld2024.Examples

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -6,6 +6,7 @@ import Linglib.Semantics.Aspect.SubintervalProperty
 import Linglib.Fragments.English.TemporalExpressions
 import Linglib.Fragments.Japanese.TemporalConnectives
 import Linglib.Semantics.Presupposition.Basic
+import Linglib.Data.Examples.OgiharaSteinertThrelkeld2024
 
 /-!
 # [ogihara-steinert-threlkeld-2024] — Data
@@ -31,12 +32,24 @@ temporal connectives *before* and *after*.
 
 namespace OgiharaSteinertThrelkeld2024
 
+open Data.Examples (LinguisticExample)
+open OgiharaSteinertThrelkeld2024.Examples
+
+/-- Value of a `paperFeatures` key, if present. -/
+def featureOf (e : LinguisticExample) (k : String) : Option String :=
+  (e.paperFeatures.find? (·.1 == k)).map (·.2)
+
+/-- A `paperFeatures` flag read as a Bool (`true` iff the value is `"true"`). -/
+def flagOf (e : LinguisticExample) (k : String) : Bool := featureOf e k == some "true"
+
 -- ════════════════════════════════════════════════════════════════
 -- § 1: Veridicality Judgments
 -- ════════════════════════════════════════════════════════════════
 
-/-- An empirical judgment about whether a temporal connective entails
-    the truth of its complement clause. -/
+/-- An empirical judgment about whether a temporal connective entails the truth of its
+    complement clause. Stimuli live in `Data/Examples/OgiharaSteinertThrelkeld2024.json`
+    (generated `OgiharaSteinertThrelkeld2024.Examples`); this record is derived from a
+    `LinguisticExample` by `ofVeridicality`. -/
 structure VeridicalityDatum where
   /-- The example sentence -/
   sentence : String
@@ -48,64 +61,43 @@ structure VeridicalityDatum where
   gloss : String
   deriving Repr
 
+/-- Derive a `VeridicalityDatum` from a generated `LinguisticExample`: the sentence is the
+    `primaryText`; the connective and complement-entailment are `paperFeatures` tags. -/
+def ofVeridicality (e : LinguisticExample) : VeridicalityDatum where
+  sentence := e.primaryText
+  connective := (featureOf e "connective").getD ""
+  complementEntailed := flagOf e "complement_entailed"
+  gloss := e.comment
+
 -- ════════════════════════════════════════════════════════════════
 -- § 2: Core Veridicality Data
 -- ════════════════════════════════════════════════════════════════
 
 /-- "He left after she arrived" entails "she arrived". -/
-def after_veridical : VeridicalityDatum where
-  sentence := "He left after she arrived"
-  connective := "after"
-  complementEntailed := true
-  gloss := "after(leave, arrive) |= arrive"
+def after_veridical : VeridicalityDatum := ofVeridicality ost2024_after_veridical
 
-/-- "He left before she arrived" does NOT entail "she arrived".
-    Compatible with: she did arrive (veridical reading), she didn't
-    arrive (counterfactual reading, e.g. "before she could arrive"),
-    or indeterminate (non-committal reading). -/
-def before_nonveridical : VeridicalityDatum where
-  sentence := "He left before she arrived"
-  connective := "before"
-  complementEntailed := false
-  gloss := "before(leave, arrive) |/= arrive"
+/-- "He left before she arrived" does NOT entail "she arrived" (compatible with the
+    veridical, counterfactual, or non-committal reading). -/
+def before_nonveridical : VeridicalityDatum := ofVeridicality ost2024_before_nonveridical
 
-/-- "The bomb exploded before anyone defused it" — the complement
-    event (defusing) did NOT occur. This is the counterfactual reading
-    of *before* ([beaver-condoravdi-2003], "barely prevented"). -/
-def before_counterfactual : VeridicalityDatum where
-  sentence := "The bomb exploded before anyone defused it"
-  connective := "before"
-  complementEntailed := false
-  gloss := "before(explode, defuse) ∧ ¬defuse"
+/-- "The bomb exploded before anyone defused it" — counterfactual *before*: the defusing
+    did not occur ([beaver-condoravdi-2003], "barely prevented"). -/
+def before_counterfactual : VeridicalityDatum := ofVeridicality ost2024_before_counterfactual
 
 /-- "She finished her coffee after he left" entails "he left". -/
-def after_veridical_2 : VeridicalityDatum where
-  sentence := "She finished her coffee after he left"
-  connective := "after"
-  complementEntailed := true
-  gloss := "after(finish, leave) |= leave"
+def after_veridical_2 : VeridicalityDatum := ofVeridicality ost2024_after_veridical_2
 
 -- ════════════════════════════════════════════════════════════════
 -- § 3: Additional Veridicality Data ([beaver-condoravdi-2003], §2)
 -- ════════════════════════════════════════════════════════════════
 
-/-- "I left the party before there was any trouble" — non-committal: implies trouble
-    seemed likely but does not commit to whether trouble occurred
-    ([beaver-condoravdi-2003], ex. 43). (B&C's (22), the Supreme Court "uncounted
-    votes" case, is *counterfactual*, not non-committal — see [beaver-condoravdi-2003] §6.) -/
-def before_noncommittal : VeridicalityDatum where
-  sentence := "I left the party before there was any trouble"
-  connective := "before"
-  complementEntailed := false
-  gloss := "before(leave, trouble) |/= trouble (non-committal)"
+/-- "I left the party before there was any trouble" — non-committal
+    ([beaver-condoravdi-2003], ex. 43; B&C's (22) Supreme Court case is counterfactual). -/
+def before_noncommittal : VeridicalityDatum := ofVeridicality ost2024_before_noncommittal
 
-/-- "Mozart died before he finished the Requiem" — counterfactual:
-    Mozart never finished the Requiem ([beaver-condoravdi-2003], ex. 24). -/
-def before_counterfactual_mozart : VeridicalityDatum where
-  sentence := "Mozart died before he finished the Requiem"
-  connective := "before"
-  complementEntailed := false
-  gloss := "before(die, finish) ∧ ¬finish (counterfactual)"
+/-- "Mozart died before he finished the Requiem" — counterfactual
+    ([beaver-condoravdi-2003], ex. 24). -/
+def before_counterfactual_mozart : VeridicalityDatum := ofVeridicality ost2024_before_counterfactual_mozart
 
 -- B&C's before/after logical-property asymmetries (antisymmetry, transitivity, NPI
 -- licensing) are Anscombe's ([anscombe-1964] §I-II), formalized canonically in
@@ -168,7 +160,7 @@ theorem bc_cannot_place_bounded_complement
     The complement (Ohtani's 10th win) can only occur during the season
     (before day 276). (O&[ogihara-steinert-threlkeld-2024], §5.1, ex. 20a) -/
 def ost_counterexample_ohtani : BCCounterexampleDatum where
-  sentence := "Unfortunately, the 2021 MLB season will be over before Shohei Ohtani earns his 10th win of the season"
+  sentence := ost2024_ohtani.primaryText
   aTime := 276
   complementUpperBound := 275
   boundedBefore := by omega
@@ -180,7 +172,7 @@ def ost_counterexample_ohtani : BCCounterexampleDatum where
     proposal that posits a fictitious snow event after the end of 2020 does not
     work. (O&[ogihara-steinert-threlkeld-2024], §5.1, ex. 20b) -/
 def ost_counterexample_snow : BCCounterexampleDatum where
-  sentence := "2020 might come to an end before it snows for the first time this year"
+  sentence := ost2024_snow.primaryText
   aTime := 366
   complementUpperBound := 366
   boundedBefore := le_refl _
@@ -193,7 +185,7 @@ def ost_counterexample_snow : BCCounterexampleDatum where
     only come true if the world is destroyed in July 1999 — it cannot come true
     after the end of July 1999. (O&[ogihara-steinert-threlkeld-2024], §5.1, ex. 20c) -/
 def ost_counterexample_nostradamus : BCCounterexampleDatum where
-  sentence := "July 1999 will come to an end before Nostradamus' prophecy about the end of the world comes true"
+  sentence := ost2024_nostradamus.primaryText
   aTime := 31
   complementUpperBound := 31
   boundedBefore := le_refl _
@@ -215,25 +207,20 @@ structure NonCommittalDatum where
   explanation : String
   deriving Repr
 
-/-- "Mary will leave the party before Bill gets drunk."
-    Non-committal reading is available: maybe Bill gets drunk, maybe not.
-    B&C's Event Continuation Condition is satisfied (Bill getting drunk is
-    a normal continuation). (O&[ogihara-steinert-threlkeld-2024], §5.2) -/
-def noncommittal_available : NonCommittalDatum where
-  sentence := "Mary will leave the party before Bill gets drunk"
-  nonCommittalAvailable := true
-  explanation := "getting drunk is a normal continuation of being at a party"
+/-- Derive a `NonCommittalDatum` from a generated `LinguisticExample`. -/
+def ofNonCommittal (e : LinguisticExample) : NonCommittalDatum where
+  sentence := e.primaryText
+  nonCommittalAvailable := flagOf e "noncommittal_available"
+  explanation := e.comment
 
-/-- "Mary will leave the party before Quebec becomes an independent country."
-    Non-committal reading is NOT available (sentence is odd): Quebec's
-    independence is not a normal continuation of the party. B&C's Event
-    Continuation Condition should block this, but the mechanism is unclear
-    for *before*-clauses with pragmatically impossible complements.
-    (O&[ogihara-steinert-threlkeld-2024], §5.2) -/
-def noncommittal_unavailable : NonCommittalDatum where
-  sentence := "Mary will leave the party before Quebec becomes an independent country"
-  nonCommittalAvailable := false
-  explanation := "Quebec independence is not a contextually normal continuation"
+/-- "Mary will leave the party before Bill gets drunk" — non-committal reading available
+    (getting drunk is a normal continuation). (O&[ogihara-steinert-threlkeld-2024], §5.2) -/
+def noncommittal_available : NonCommittalDatum := ofNonCommittal ost2024_noncommittal_available
+
+/-- "Mary will leave the party before Quebec becomes an independent country" — non-committal
+    reading unavailable (Quebec independence is not a normal continuation); B&C's Event
+    Continuation Condition should block this. (O&[ogihara-steinert-threlkeld-2024], §5.2) -/
+def noncommittal_unavailable : NonCommittalDatum := ofNonCommittal ost2024_noncommittal_unavailable
 
 /-- The non-committal reading is sensitive to contextual plausibility:
     available when the complement is a normal continuation, unavailable


### PR DESCRIPTION
Migrate the Ogihara & Steinert-Threlkeld glossed stimuli to `Data/Examples/OgiharaSteinertThrelkeld2024.json` (11 examples), per the "no hand-typed empirical tables in .lean" discipline — mirroring the Mizuno/Iatridou migrations.

- New JSON: the 6 veridicality minimal pairs (§1-3), the 3 (20a-c) B&C counterexamples, the 2 (22) non-committal sentences — with connective / complement-entailment / reading tags in `paperFeatures`.
- The typed `VeridicalityDatum` / `NonCommittalDatum` are now **derived** from the examples via `ofVeridicality` / `ofNonCommittal` (consumer theorems unchanged — they reduce through the derived defs); `BCCounterexampleDatum` sources its sentence from JSON, keeping its analytical fields (`aTime`/`complementUpperBound`/`boundedBefore` proof/`reading`) inline.

Left as-is (noted): `CrossLinguisticDatum` (mae/ato) — it carries no glossed sentence and duplicates the imported `Japanese.TemporalConnectives` Fragment, so it's a Fragment-dissolution task, not stimulus JSON-ification.