### PR TITLE
feat(Pragmatics/RSA): uniform-prior speaker reduction + worked example

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2609,6 +2609,7 @@ import Linglib.Pragmatics.RSA.LatentOperators
 import Linglib.Pragmatics.RSA.Silence
 import Linglib.Pragmatics.RSA.Cancellation
 import Linglib.Pragmatics.RSA.Gibbs
+import Linglib.Pragmatics.RSA.GibbsExample
 import Linglib.Studies.Haspelmath2001
 import Linglib.Morphology.Grammaticalization
 import Linglib.Studies.Traugott2010

--- a/Linglib/Pragmatics/RSA/Gibbs.lean
+++ b/Linglib/Pragmatics/RSA/Gibbs.lean
@@ -3,6 +3,7 @@ import Mathlib.MeasureTheory.Measure.Count
 import Mathlib.MeasureTheory.Integral.Bochner.Basic
 import Mathlib.Probability.Kernel.Posterior
 import Mathlib.InformationTheory.KullbackLeibler.Basic
+import Mathlib.Probability.UniformOn
 import Linglib.Core.Probability.GibbsVariational
 
 /-!
@@ -24,11 +25,17 @@ reimplementation, and is the object on which the variational (free-energy /
 
 ## Main statements
 
-* `speaker_count_singleton` — closed form of the speaker mass at an utterance,
-  for the counting base: `ofReal (exp (score u) / ∑ u', exp (score u'))`.
-* `speaker_count_lt_iff_score_lt` — **monotonicity in informativity**: the
-  speaker prefers `u₂` over `u₁` iff its utility is higher. The partition
-  function cancels; reduces to strict monotonicity of `Real.exp`.
+* `speaker_count_lt_iff_score_lt` / `speaker_uniformOn_lt_iff_score_lt` —
+  **monotonicity in informativity**: the speaker prefers `b` over `a` iff `b` has
+  the higher utility. The partition function cancels; reduces to strict
+  monotonicity of `Real.exp`. The `uniformOn` form discharges every measure-side
+  condition, so an RSA study reduces a speaker preference to a `score` comparison.
+* `listener` / `listener_comp_speaker_marginal` / `listener_region` — the
+  pragmatic listener as the Bayesian posterior `S1 † prior`, stated measure-natively
+  (Bayes consistency, region inference) rather than by pointwise singletons.
+* `speaker_isGreatest` — the RSA speaker is the **rational optimizer**: it attains
+  the greatest expected-utility-minus-KL-cost, a direct instance of the Gibbs /
+  Donsker–Varadhan principle (`MeasureTheory.isGreatest_logIntegralExp`).
 -/
 
 open MeasureTheory Real
@@ -69,6 +76,62 @@ theorem speaker_count_lt_iff_score_lt [Fintype U] [MeasurableSpace U]
     Finset.sum_pos (fun u _ => Real.exp_pos _) ⟨a, Finset.mem_univ a⟩
   rw [ENNReal.ofReal_lt_ofReal_iff (by positivity),
       div_lt_div_iff_of_pos_right hZ, Real.exp_lt_exp]
+
+/-- **Speaker monotonicity, general probability/finite base**: for any finite
+base measure that assigns equal nonzero mass to the two utterances, the speaker
+prefers `b` over `a` iff `b` has the higher utility. Generalizes
+`speaker_count_lt_iff_score_lt` off the counting base — the form the variational
+principle needs, where the base is a *probability* measure (e.g.
+`ProbabilityTheory.uniformOn`). The shared singleton mass and the partition
+function `Z = ∫ y, exp (score y) ∂base` cancel, reducing to `Real.exp`
+monotonicity.
+
+An integrability hypothesis on `exp ∘ score` is required (and is automatic on a
+`Fintype`): without it a non-integrable tilt collapses to the zero measure
+(`MeasureTheory.tilted_of_not_integrable`), making both sides vanish and the
+equivalence false. It mirrors the `h_exp` hypothesis of `speaker_isGreatest`. -/
+theorem speaker_lt_iff_score_lt {U : Type*} [Fintype U] [MeasurableSpace U]
+    [MeasurableSingletonClass U] (base : Measure U) [IsFiniteMeasure base]
+    (score : U → ℝ) (a b : U) (hmass : base {a} = base {b}) (hpos : base {a} ≠ 0)
+    (hexp : Integrable (fun u => Real.exp (score u)) base) :
+    speaker base score {a} < speaker base score {b} ↔ score a < score b := by
+  have : NeZero base := ⟨fun h => hpos (by rw [h]; rfl)⟩
+  have hZ : 0 < ∫ y, Real.exp (score y) ∂base := integral_exp_pos hexp
+  have key : ∀ x : U, speaker base score {x}
+      = ENNReal.ofReal (Real.exp (score x) / ∫ y, Real.exp (score y) ∂base) * base {x} := by
+    intro x
+    rw [speaker, tilted_apply, lintegral_singleton]
+  rw [key a, key b, hmass,
+    ENNReal.mul_lt_mul_iff_left (hmass ▸ hpos) (measure_ne_top base {b}),
+    ENNReal.ofReal_lt_ofReal_iff (by positivity),
+    div_lt_div_iff_of_pos_right hZ, Real.exp_lt_exp]
+
+/-- The uniform prior on a finite type assigns every singleton the same mass
+`(card)⁻¹`. A generic `ProbabilityTheory.uniformOn` fact (upstream candidate),
+tagged `@[simp]` so the equal-mass and nonzero side conditions of
+`speaker_lt_iff_score_lt` discharge automatically over a uniform prior. -/
+@[simp] theorem uniformOn_univ_singleton {Ω : Type*} [Fintype Ω] [MeasurableSpace Ω]
+    [MeasurableSingletonClass Ω] (a : Ω) :
+    ProbabilityTheory.uniformOn (Set.univ : Set Ω) {a} = (Fintype.card Ω : ℝ≥0∞)⁻¹ := by
+  rw [ProbabilityTheory.uniformOn_univ, Measure.count_singleton, ENNReal.div_eq_inv_mul,
+    mul_one]
+
+/-- **Speaker monotonicity over the uniform prior** — the study-facing reduction.
+For the canonical RSA prior (`ProbabilityTheory.uniformOn` over a finite utterance
+type), the speaker prefers `b` over `a` iff `b` has the higher utility. This is
+`speaker_lt_iff_score_lt` with *every* measure-theoretic side condition discharged
+— equal singleton mass and nonzeroness via `uniformOn_univ_singleton`, and
+integrability via `Integrable.of_finite` — so an RSA study reduces a speaker
+preference to a plain `score` comparison with a single `rw`. -/
+theorem speaker_uniformOn_lt_iff_score_lt {U : Type*} [Fintype U] [Nonempty U]
+    [MeasurableSpace U] [MeasurableSingletonClass U] (score : U → ℝ) (a b : U) :
+    speaker (ProbabilityTheory.uniformOn (Set.univ : Set U)) score {a}
+        < speaker (ProbabilityTheory.uniformOn (Set.univ : Set U)) score {b}
+      ↔ score a < score b :=
+  speaker_lt_iff_score_lt _ _ _ _
+    (by rw [uniformOn_univ_singleton, uniformOn_univ_singleton])
+    (by rw [uniformOn_univ_singleton]; exact ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top _))
+    Integrable.of_finite
 
 /-! ### The pragmatic listener as a Bayesian posterior (measure-native)
 

--- a/Linglib/Pragmatics/RSA/GibbsExample.lean
+++ b/Linglib/Pragmatics/RSA/GibbsExample.lean
@@ -1,0 +1,104 @@
+import Mathlib.Probability.UniformOn
+import Linglib.Pragmatics.RSA.Gibbs
+
+/-!
+# Worked example: the Frank–Goodman reference-game speaker  [frank-goodman-2012]
+
+The canonical RSA result — *the pragmatic speaker prefers the more informative
+description* — worked end-to-end on the Measure/Kernel-native foundation of
+`Linglib.Pragmatics.RSA.Gibbs`. It is the template for Measure-native RSA
+studies: the speaker is `RSA.Gibbs.speaker`, a `MeasureTheory.Measure.tilted`
+Gibbs measure over a probability prior (here `ProbabilityTheory.uniformOn`), and
+the predictions are theorems about that measure rather than about a bespoke
+`PMF.softmax` reimplementation.
+
+## Scenario
+
+A speaker refers to a target object with one of two *true* descriptions. Because
+every alternative applies to the target, the literal listener never assigns the
+target probability `0`, so the informativity utility `log L0` is finite (the
+example is log-`0`-free):
+
+* `blue` — applies to two objects, so the literal listener splits its mass and
+  lands on the target with probability `1/2`;
+* `circle` — uniquely identifies the target, so the literal listener is certain
+  (`1`).
+
+The informativity utility is `score u = log (L0target u)` (rationality `α = 1`,
+no cost term), and `rgSpeaker = speaker (uniformOn univ) score`.
+
+## Main statements
+
+* `prefers_circle` — the speaker assigns strictly more mass to `circle` than to
+  `blue`: it prefers the uniquely-identifying description. A direct instance of
+  `RSA.Gibbs.speaker_lt_iff_score_lt`, reducing to `log (1/2) < log 1`.
+* `rgSpeaker_isGreatest` — the reference-game speaker is the **rational
+  optimizer**: it attains the greatest expected-utility-minus-KL-cost over all
+  candidate utterance distributions. A direct instance of
+  `RSA.Gibbs.speaker_isGreatest` (the Gibbs / Donsker–Varadhan principle).
+-/
+
+open MeasureTheory ProbabilityTheory InformationTheory
+open scoped ENNReal
+
+namespace RSA.Gibbs.FrankGoodman
+
+/-- The two true descriptions of the target in the reference game. -/
+inductive Utterance
+  | blue
+  | circle
+  deriving DecidableEq, Fintype, Repr
+
+instance : MeasurableSpace Utterance := ⊤
+
+instance : MeasurableSingletonClass Utterance := ⟨fun _ => trivial⟩
+
+instance : Inhabited Utterance := ⟨.circle⟩
+
+/-- Literal-listener probability of the target given each (true) utterance:
+`blue` applies to two objects (`1/2`), `circle` uniquely identifies (`1`). -/
+noncomputable def L0target : Utterance → ℝ
+  | .blue => 1 / 2
+  | .circle => 1
+
+/-- Informativity utility (rationality `α = 1`, no cost): the log of the
+literal-listener target probability, `score u = log (L0(target | u))`. -/
+noncomputable def score : Utterance → ℝ := fun u => Real.log (L0target u)
+
+/-- The reference-game speaker as a Gibbs measure over the uniform utterance
+prior: `RSA.Gibbs.speaker (uniformOn univ) score`. -/
+noncomputable def rgSpeaker : Measure Utterance :=
+  RSA.Gibbs.speaker (uniformOn (Set.univ : Set Utterance)) score
+
+/-- **The speaker prefers the uniquely-identifying description**: it assigns
+strictly more mass to `circle` than to `blue`. The measure theory is hidden in
+`RSA.Gibbs.speaker_uniformOn_lt_iff_score_lt` — the prediction reduces in one `rw`
+to the informativity comparison `log (1/2) < log 1`. -/
+theorem prefers_circle : rgSpeaker {Utterance.blue} < rgSpeaker {Utterance.circle} := by
+  rw [rgSpeaker, RSA.Gibbs.speaker_uniformOn_lt_iff_score_lt]
+  show Real.log (L0target .blue) < Real.log (L0target .circle)
+  rw [L0target, L0target, Real.log_one]
+  exact Real.log_neg (by norm_num) (by norm_num)
+
+/-- **The reference-game speaker is the rational optimizer**: among all candidate
+utterance distributions absolutely continuous w.r.t. the uniform prior, the
+speaker attains the greatest expected-utility-minus-KL-cost
+`q ↦ 𝔼_q[score] − KL(q ‖ uniformOn univ)`, the optimum being the free energy
+`(uniformOn univ).logIntegralExp score`. A direct instance of the Gibbs /
+Donsker–Varadhan variational principle `RSA.Gibbs.speaker_isGreatest`; all
+integrability hypotheses are automatic over the finite utterance type. -/
+theorem rgSpeaker_isGreatest :
+    IsGreatest
+      {x : ℝ | ∃ q : Measure Utterance, IsProbabilityMeasure q ∧
+        q ≪ uniformOn (Set.univ : Set Utterance) ∧
+        Integrable (llr q (uniformOn (Set.univ : Set Utterance))) q ∧
+        Integrable score q ∧
+        x = (∫ u, score u ∂q) - (klDiv q (uniformOn (Set.univ : Set Utterance))).toReal}
+      ((uniformOn (Set.univ : Set Utterance)).logIntegralExp score) := by
+  haveI : IsFiniteMeasure
+      (RSA.Gibbs.speaker (uniformOn (Set.univ : Set Utterance)) score) :=
+    inferInstanceAs (IsFiniteMeasure ((uniformOn (Set.univ : Set Utterance)).tilted score))
+  exact RSA.Gibbs.speaker_isGreatest (uniformOn (Set.univ : Set Utterance)) score
+    Integrable.of_finite Integrable.of_finite Integrable.of_finite
+
+end RSA.Gibbs.FrankGoodman


### PR DESCRIPTION
Builds on the merged Gibbs–Donsker–Varadhan keystone (#520): adds the uniform-prior speaker monotonicity reduction (`speaker_uniformOn_lt_iff_score_lt`, with `uniformOn_univ_singleton`) and a Frank–Goodman worked example proving the canonical RSA result (`prefers_circle`, `rgSpeaker_isGreatest`) end-to-end on the Measure/Kernel-native foundation.