### PR TITLE
refactor(Pragmatics/RSA): complete α API, golf, autoParam membership conditions

### DIFF
--- a/Linglib/Core/Probability/GibbsVariational.lean
+++ b/Linglib/Core/Probability/GibbsVariational.lean
@@ -18,9 +18,10 @@ Kullback–Leibler divergence anticipated by the module docstring of
 ## Main definitions
 
 * `MeasureTheory.Measure.logIntegralExp μ f = log (∫ x, exp (f x) ∂μ)` — the
-  log-partition / free-energy functional. It generalizes the cumulant generating
-  function `ProbabilityTheory.cgf` (the affine case `f = t • X`); see
-  `logIntegralExp_const_mul`.
+  log-partition / free-energy functional. It is the cumulant generating function
+  at unit argument (`logIntegralExp_eq_cgf : logIntegralExp μ f = cgf f μ 1`), and
+  conversely `cgf X μ t = logIntegralExp μ (t • X)` (`logIntegralExp_const_mul`);
+  the two are interchangeable, with `logIntegralExp` carrying the free-energy reading.
 
 ## Main statements
 
@@ -39,8 +40,11 @@ The decomposition reuses the log-likelihood-ratio identity
 `llr`-integrals via `toReal_klDiv_of_measure_eq` (the `univ`-mass correction in
 `toReal_klDiv` vanishes because every measure in play is a probability measure —
 `μ.tilted f` is normalized by construction). The statements are over probability
-measures; the finite-measure generalization carries an additive `μ.real univ`
-correction and is left for future work.
+measures. Two separate relaxations are possible upstream: the *prior* `μ` could be
+`[IsFiniteMeasure]` at the cost of an additive `μ.real univ` correction term; the
+*candidate* `q`, however, is pinned to `[IsProbabilityMeasure]` by
+`integral_llr_tilted_right` itself (which requires it on its left measure), so
+relaxing `q` is a separate upstream concern in `LogLikelihoodRatio`, not here.
 -/
 
 open Real MeasureTheory ProbabilityTheory InformationTheory
@@ -50,15 +54,21 @@ namespace MeasureTheory
 
 variable {α : Type*} {mα : MeasurableSpace α}
 
-/-- The **log-partition** (free-energy) functional `log ∫ exp f ∂μ`. Generalizes
-the cumulant generating function `ProbabilityTheory.cgf` to an arbitrary
-integrand (the affine case `f = fun x ↦ t * X x` recovers `cgf X μ t`, see
-`logIntegralExp_const_mul`). -/
+/-- The **log-partition** (free-energy) functional `log ∫ exp f ∂μ`. It coincides
+with the cumulant generating function `ProbabilityTheory.cgf` at unit argument
+(`logIntegralExp_eq_cgf`), the free-energy reading being the one that makes the
+variational principle below natural. -/
 noncomputable def Measure.logIntegralExp (μ : Measure α) (f : α → ℝ) : ℝ :=
   Real.log (∫ x, Real.exp (f x) ∂μ)
 
-/-- `logIntegralExp` generalizes the cumulant generating function: on the affine
-family `f = fun x ↦ t * X x` it is `ProbabilityTheory.cgf X μ t`. -/
+/-- The log-partition functional is the cumulant generating function at unit
+argument: `logIntegralExp μ f = cgf f μ 1`. -/
+theorem logIntegralExp_eq_cgf (μ : Measure α) (f : α → ℝ) :
+    μ.logIntegralExp f = cgf f μ 1 := by
+  simp only [Measure.logIntegralExp, cgf, mgf, one_mul]
+
+/-- The cumulant generating function is the log-partition functional of the scaled
+integrand: `cgf X μ t = logIntegralExp μ (t • X)`. -/
 theorem logIntegralExp_const_mul (μ : Measure α) (X : α → ℝ) (t : ℝ) :
     μ.logIntegralExp (fun x => t * X x) = cgf X μ t := by
   simp only [Measure.logIntegralExp, cgf, mgf]
@@ -79,8 +89,8 @@ theorem toReal_klDiv_tilted_right (μ q : Measure α) [IsProbabilityMeasure μ]
       = (klDiv q μ).toReal - (∫ x, f x ∂q) + μ.logIntegralExp f := by
   have h_prob_tilt : IsProbabilityMeasure (μ.tilted f) := isProbabilityMeasure_tilted h_exp
   have hq_tilt : q ≪ μ.tilted f := hqμ.trans (absolutelyContinuous_tilted h_exp)
-  rw [toReal_klDiv_of_measure_eq hq_tilt (by rw [measure_univ, measure_univ]),
-      toReal_klDiv_of_measure_eq hqμ (by rw [measure_univ, measure_univ]),
+  rw [toReal_klDiv_of_measure_eq hq_tilt (by simp only [measure_univ]),
+      toReal_klDiv_of_measure_eq hqμ (by simp only [measure_univ]),
       integral_llr_tilted_right hqμ h_int_f h_exp h_int_llr, Measure.logIntegralExp]
 
 /-- **Gibbs / Donsker–Varadhan variational inequality**: for every probability

--- a/Linglib/Pragmatics/RSA/Gibbs.lean
+++ b/Linglib/Pragmatics/RSA/Gibbs.lean
@@ -38,10 +38,12 @@ reimplementation, and is the object on which the variational (free-energy /
 * `speakerAlpha` — the **rationality parameter α** (`S₁ ∝ L0^α`, Boltzmann/softmax
   at inverse temperature α): `speakerAlpha_count_lt_iff_score_lt` (α > 0 keeps the
   order), `speakerAlpha_count_zero_singleton` (α = 0 is uniform), and the
-  zero-temperature limits `speakerAlpha_count_tendsto_one_of_isMax` /
-  `_tendsto_zero_of_exists_gt` (α → ∞ is the argmax / fully-rational speaker).
-* `listener` / `listener_comp_speaker_marginal` / `listener_region` — the pragmatic
-  listener as the Bayesian posterior `S1 † prior`, stated measure-natively.
+  zero-temperature limits `speakerAlpha_countRestrict_tendsto_one_of_isMax` /
+  `_tendsto_zero_of_exists_gt` (α → ∞ is the argmax / fully-rational speaker, over
+  the applicable set).
+* `listener` / `listener_comp_speaker_marginal` / `listener_eq_withDensity` /
+  `listener_region` — the pragmatic listener as the Bayesian posterior `S1 † prior`,
+  stated measure-natively (Bayes consistency, density reweighting, region inference).
 * `speaker_isGreatest` — the RSA speaker is the **rational optimizer** (Gibbs /
   Donsker–Varadhan variational principle).
 -/
@@ -98,7 +100,7 @@ An integrability hypothesis on `exp ∘ score` is required (and is automatic on 
 `Fintype`): without it a non-integrable tilt collapses to the zero measure
 (`MeasureTheory.tilted_of_not_integrable`), making both sides vanish and the
 equivalence false. It mirrors the `h_exp` hypothesis of `speaker_isGreatest`. -/
-theorem speaker_lt_iff_score_lt {U : Type*} [Fintype U] [MeasurableSpace U]
+theorem speaker_lt_iff_score_lt [Fintype U] [MeasurableSpace U]
     [MeasurableSingletonClass U] (base : Measure U) [IsFiniteMeasure base]
     (score : U → ℝ) (a b : U) (hmass : base {a} = base {b}) (hpos : base {a} ≠ 0)
     (hexp : Integrable (fun u => Real.exp (score u)) base) :
@@ -212,7 +214,7 @@ theorem speakerAlpha_count_lt_iff_score_lt [Fintype U] [MeasurableSpace U]
         < speakerAlpha (Measure.count : Measure U) α score {b}
       ↔ score a < score b := by
   rw [speakerAlpha, speaker_count_lt_iff_score_lt]
-  exact ⟨fun h => lt_of_mul_lt_mul_left h hα.le, fun h => mul_lt_mul_of_pos_left h hα⟩
+  exact mul_lt_mul_iff_of_pos_left hα
 
 /-- **α = 0 is the uniform (indifferent) speaker**: with zero rationality the
 speaker ignores utility and spreads its mass uniformly, `(card U)⁻¹` at every
@@ -225,71 +227,114 @@ theorem speakerAlpha_count_zero_singleton [Fintype U] [MeasurableSpace U]
   simp only [zero_mul, Real.exp_zero, Finset.sum_const, Finset.card_univ, nsmul_eq_mul,
     mul_one, one_div]
 
-/-- **α → ∞ concentrates on the unique best utterance**: if `a` strictly maximizes
-the utility, the fully-rational speaker assigns it mass `→ 1`. The softmax becomes
-the argmax; this is the zero-temperature / fully-rational limit. -/
-theorem speakerAlpha_count_tendsto_one_of_isMax [Fintype U] [DecidableEq U] [MeasurableSpace U]
-    [MeasurableSingletonClass U] (score : U → ℝ) (a : U) (hmax : ∀ b, b ≠ a → score b < score a) :
-    Tendsto (fun α => speakerAlpha (Measure.count : Measure U) α score {a}) atTop (𝓝 1) := by
-  have hreal : Tendsto (fun α : ℝ => Real.exp (α * score a) / ∑ u, Real.exp (α * score u))
-      atTop (𝓝 1) := by
-    have hrw : ∀ α : ℝ, Real.exp (α * score a) / ∑ u, Real.exp (α * score u)
-        = (∑ u, Real.exp (α * (score u - score a)))⁻¹ := by
-      intro α
-      have hsum : ∑ u, Real.exp (α * score u)
-          = Real.exp (α * score a) * ∑ u, Real.exp (α * (score u - score a)) := by
-        rw [Finset.mul_sum]
-        refine Finset.sum_congr rfl fun u _ => ?_
-        rw [← Real.exp_add]; congr 1; ring
-      rw [hsum, div_mul_eq_div_div, div_self (Real.exp_ne_zero _), one_div]
-    rw [tendsto_congr hrw]
-    have hg : Tendsto (fun α : ℝ => ∑ u, Real.exp (α * (score u - score a))) atTop (𝓝 1) := by
-      rw [show (1 : ℝ) = ∑ _u : U, (if _u = a then (1 : ℝ) else 0) by simp]
-      refine tendsto_finsetSum _ fun u _ => ?_
-      by_cases hu : u = a
-      · subst hu; simp only [sub_self, mul_zero, Real.exp_zero]; exact tendsto_const_nhds
-      · simp only [if_neg hu]
-        have hc : score u - score a < 0 := by have := hmax u hu; linarith
-        exact Real.tendsto_exp_atBot.comp
-          ((tendsto_mul_const_atBot_of_neg hc).mpr tendsto_id)
-    simpa using hg.inv₀ one_ne_zero
-  have heq : (fun α => speakerAlpha (Measure.count : Measure U) α score {a})
-      = fun α => ENNReal.ofReal (Real.exp (α * score a) / ∑ u, Real.exp (α * score u)) :=
-    funext fun α => speakerAlpha_count_singleton α score a
-  rw [heq, show (1 : ℝ≥0∞) = ENNReal.ofReal 1 from ENNReal.ofReal_one.symm]
-  exact (ENNReal.continuous_ofReal.tendsto 1).comp hreal
+/-- Closed form of the α-speaker over the **applicable set** `A`: the softmax at
+inverse temperature `α` restricted to `A`. Generalizes `speakerAlpha_count_singleton`
+(the `A = univ` case) to the finite-support speaker the studies consume. -/
+theorem speakerAlpha_countRestrict_singleton [Fintype U] [DecidableEq U] [MeasurableSpace U]
+    [MeasurableSingletonClass U] (A : Finset U) (α : ℝ) (score : U → ℝ) (a : U) (ha : a ∈ A) :
+    speakerAlpha (Measure.count.restrict (↑A : Set U)) α score {a}
+      = ENNReal.ofReal (Real.exp (α * score a) / ∑ x ∈ A, Real.exp (α * score x)) :=
+  speaker_countRestrict_singleton A (fun u => α * score u) a ha
 
-/-- **α → ∞ abandons a dominated utterance**: if some utterance strictly beats `a`,
-the fully-rational speaker assigns `a` mass `→ 0`. Dual to
-`speakerAlpha_count_tendsto_one_of_isMax`. -/
-theorem speakerAlpha_count_tendsto_zero_of_exists_gt [Fintype U] [MeasurableSpace U]
-    [MeasurableSingletonClass U] (score : U → ℝ) (a : U) (hbeat : ∃ b, score a < score b) :
-    Tendsto (fun α => speakerAlpha (Measure.count : Measure U) α score {a}) atTop (𝓝 0) := by
-  obtain ⟨b, hb⟩ := hbeat
-  have hreal : Tendsto (fun α : ℝ => Real.exp (α * score a) / ∑ u, Real.exp (α * score u))
+/-- A non-applicable utterance gets zero α-speaker mass. -/
+theorem speakerAlpha_countRestrict_singleton_of_not_mem [Fintype U] [MeasurableSpace U]
+    [MeasurableSingletonClass U] (A : Finset U) (α : ℝ) (score : U → ℝ) (a : U) (ha : a ∉ A) :
+    speakerAlpha (Measure.count.restrict (↑A : Set U)) α score {a} = 0 :=
+  speaker_countRestrict_singleton_of_not_mem A (fun u => α * score u) a ha
+
+/-- **α-monotonicity, finite support** (`α > 0`): over the applicable set `A`, the
+positively-rational speaker prefers the higher-utility utterance. -/
+theorem speakerAlpha_countRestrict_lt_iff_score_lt [Fintype U] [MeasurableSpace U]
+    [MeasurableSingletonClass U] (A : Finset U) {α : ℝ} (hα : 0 < α) (score : U → ℝ) (a b : U)
+    (ha : a ∈ A) (hb : b ∈ A) :
+    speakerAlpha (Measure.count.restrict (↑A : Set U)) α score {a}
+        < speakerAlpha (Measure.count.restrict (↑A : Set U)) α score {b}
+      ↔ score a < score b := by
+  rw [speakerAlpha, speaker_countRestrict_lt_iff_score_lt A (fun u => α * score u) a b ha hb]
+  exact mul_lt_mul_iff_of_pos_left hα
+
+/-- **α = 0 is the uniform speaker over the applicable set**: zero rationality
+spreads mass uniformly across `A`, `(A.card)⁻¹` at each applicable utterance. -/
+theorem speakerAlpha_countRestrict_zero_singleton [Fintype U] [DecidableEq U] [MeasurableSpace U]
+    [MeasurableSingletonClass U] (A : Finset U) (score : U → ℝ) (a : U) (ha : a ∈ A) :
+    speakerAlpha (Measure.count.restrict (↑A : Set U)) 0 score {a}
+      = ENNReal.ofReal ((A.card : ℝ)⁻¹) := by
+  rw [speakerAlpha_countRestrict_singleton A 0 score a ha]
+  simp only [zero_mul, Real.exp_zero, Finset.sum_const, nsmul_eq_mul, mul_one, one_div]
+
+/-- The softmax "shift" identity that removes the `∞/∞` indeterminacy in the
+zero-temperature limits: dividing through by `exp (α · score a)`,
+`exp (α · score a) / ∑ = (∑ exp (α · (score · − score a)))⁻¹`. -/
+private theorem softmax_shift (A : Finset U) (score : U → ℝ) (a : U) (α : ℝ) :
+    Real.exp (α * score a) / ∑ x ∈ A, Real.exp (α * score x)
+      = (∑ x ∈ A, Real.exp (α * (score x - score a)))⁻¹ := by
+  have hsum : ∑ x ∈ A, Real.exp (α * score x)
+      = Real.exp (α * score a) * ∑ x ∈ A, Real.exp (α * (score x - score a)) := by
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun x _ => ?_
+    rw [← Real.exp_add]; congr 1; ring
+  rw [hsum, div_mul_eq_div_div, div_self (Real.exp_ne_zero _), one_div]
+
+/-- Transfer a real-valued limit of the softmax ratio to the `ℝ≥0∞`-valued speaker
+mass, via continuity of `ENNReal.ofReal`. The shared wrapper of the two
+zero-temperature limits. -/
+private theorem speakerAlpha_countRestrict_tendsto_ofReal [Fintype U] [DecidableEq U]
+    [MeasurableSpace U] [MeasurableSingletonClass U] (A : Finset U) (score : U → ℝ) (a : U)
+    (ha : a ∈ A) {l : ℝ}
+    (h : Tendsto (fun α : ℝ => Real.exp (α * score a) / ∑ x ∈ A, Real.exp (α * score x))
+      atTop (𝓝 l)) :
+    Tendsto (fun α => speakerAlpha (Measure.count.restrict (↑A : Set U)) α score {a}) atTop
+      (𝓝 (ENNReal.ofReal l)) := by
+  have heq : (fun α => speakerAlpha (Measure.count.restrict (↑A : Set U)) α score {a})
+      = fun α => ENNReal.ofReal (Real.exp (α * score a) / ∑ x ∈ A, Real.exp (α * score x)) :=
+    funext fun α => speakerAlpha_countRestrict_singleton A α score a ha
+  rw [heq]
+  exact (ENNReal.continuous_ofReal.tendsto l).comp h
+
+/-- **α → ∞ concentrates on the unique best applicable utterance**: if `a` strictly
+maximizes the utility over the applicable set `A`, the fully-rational speaker
+assigns it mass `→ 1`. The softmax becomes the argmax (zero-temperature limit). -/
+theorem speakerAlpha_countRestrict_tendsto_one_of_isMax [Fintype U] [DecidableEq U]
+    [MeasurableSpace U] [MeasurableSingletonClass U] (A : Finset U) (score : U → ℝ) (a : U)
+    (ha : a ∈ A) (hmax : ∀ b ∈ A, b ≠ a → score b < score a) :
+    Tendsto (fun α => speakerAlpha (Measure.count.restrict (↑A : Set U)) α score {a})
+      atTop (𝓝 1) := by
+  have hreal : Tendsto (fun α : ℝ => Real.exp (α * score a) / ∑ x ∈ A, Real.exp (α * score x))
+      atTop (𝓝 1) := by
+    rw [tendsto_congr (softmax_shift A score a)]
+    have hg : Tendsto (fun α : ℝ => ∑ x ∈ A, Real.exp (α * (score x - score a))) atTop (𝓝 1) := by
+      rw [show (1 : ℝ) = ∑ x ∈ A, (if x = a then (1 : ℝ) else 0) by simp [ha]]
+      refine tendsto_finsetSum _ fun x hx => ?_
+      by_cases hxa : x = a
+      · subst hxa; simp only [sub_self, mul_zero, Real.exp_zero]; exact tendsto_const_nhds
+      · simp only [if_neg hxa]
+        have hc : score x - score a < 0 := by have := hmax x hx hxa; linarith
+        exact Real.tendsto_exp_atBot.comp ((tendsto_mul_const_atBot_of_neg hc).mpr tendsto_id)
+    simpa using hg.inv₀ one_ne_zero
+  have h := speakerAlpha_countRestrict_tendsto_ofReal A score a ha hreal
+  rwa [ENNReal.ofReal_one] at h
+
+/-- **α → ∞ abandons a dominated utterance**: if some applicable utterance strictly
+beats `a`, the fully-rational speaker assigns `a` mass `→ 0`. Dual to
+`speakerAlpha_countRestrict_tendsto_one_of_isMax`. -/
+theorem speakerAlpha_countRestrict_tendsto_zero_of_exists_gt [Fintype U] [DecidableEq U]
+    [MeasurableSpace U] [MeasurableSingletonClass U] (A : Finset U) (score : U → ℝ) (a : U)
+    (ha : a ∈ A) (hbeat : ∃ b ∈ A, score a < score b) :
+    Tendsto (fun α => speakerAlpha (Measure.count.restrict (↑A : Set U)) α score {a})
       atTop (𝓝 0) := by
-    have hrw : ∀ α : ℝ, Real.exp (α * score a) / ∑ u, Real.exp (α * score u)
-        = (∑ u, Real.exp (α * (score u - score a)))⁻¹ := by
-      intro α
-      have hsum : ∑ u, Real.exp (α * score u)
-          = Real.exp (α * score a) * ∑ u, Real.exp (α * (score u - score a)) := by
-        rw [Finset.mul_sum]
-        refine Finset.sum_congr rfl fun u _ => ?_
-        rw [← Real.exp_add]; congr 1; ring
-      rw [hsum, div_mul_eq_div_div, div_self (Real.exp_ne_zero _), one_div]
-    rw [tendsto_congr hrw]
+  obtain ⟨b, hbA, hb⟩ := hbeat
+  have hreal : Tendsto (fun α : ℝ => Real.exp (α * score a) / ∑ x ∈ A, Real.exp (α * score x))
+      atTop (𝓝 0) := by
+    rw [tendsto_congr (softmax_shift A score a)]
     refine Tendsto.inv_tendsto_atTop
       (tendsto_atTop_mono (f := fun α => Real.exp (α * (score b - score a))) ?_ ?_)
     · intro α
-      exact Finset.single_le_sum (f := fun u => Real.exp (α * (score u - score a)))
-        (fun i _ => (Real.exp_pos _).le) (Finset.mem_univ b)
+      exact Finset.single_le_sum (f := fun x => Real.exp (α * (score x - score a)))
+        (fun i _ => (Real.exp_pos _).le) hbA
     · have hc : 0 < score b - score a := by linarith
       exact Real.tendsto_exp_atTop.comp ((tendsto_mul_const_atTop_of_pos hc).mpr tendsto_id)
-  have heq : (fun α => speakerAlpha (Measure.count : Measure U) α score {a})
-      = fun α => ENNReal.ofReal (Real.exp (α * score a) / ∑ u, Real.exp (α * score u)) :=
-    funext fun α => speakerAlpha_count_singleton α score a
-  rw [heq, show (0 : ℝ≥0∞) = ENNReal.ofReal 0 from ENNReal.ofReal_zero.symm]
-  exact (ENNReal.continuous_ofReal.tendsto 0).comp hreal
+  have h := speakerAlpha_countRestrict_tendsto_ofReal A score a ha hreal
+  rwa [ENNReal.ofReal_zero] at h
 
 /-! ### The pragmatic listener as a Bayesian posterior (measure-native)
 
@@ -371,7 +416,7 @@ the greatest value of expected-utility-minus-KL-cost
 optimum being the free energy `base.logIntegralExp score`. A direct instance of
 the Gibbs / Donsker–Varadhan variational principle
 `MeasureTheory.isGreatest_logIntegralExp` at the tilt defining the speaker. -/
-theorem speaker_isGreatest {U : Type*} [MeasurableSpace U] (base : Measure U)
+theorem speaker_isGreatest [MeasurableSpace U] (base : Measure U)
     [IsProbabilityMeasure base] (score : U → ℝ)
     (h_int_f : Integrable score (speaker base score))
     (h_int_llr : Integrable (llr (speaker base score) base) (speaker base score))

--- a/Linglib/Studies/FrankGoodman2012.lean
+++ b/Linglib/Studies/FrankGoodman2012.lean
@@ -29,7 +29,9 @@ theorem here.
 
 * `prefers_informative` — the speaker prefers the uniquely-identifying `circle`
   over the ambiguous `blue` for the target (Fig. 1A); `prefers_informative_alpha`
-  shows this holds at every rationality `α > 0` (consuming `RSA.Gibbs.speakerAlpha`).
+  shows this holds at every rationality `α > 0`, and `fully_rational_picks_circle`
+  that the `α → ∞` speaker concentrates all its mass on `circle` (consuming
+  `RSA.Gibbs.speakerAlpha` and its zero-temperature limit).
 * `size_principle` — generally, the speaker prefers the smaller-extension applicable
   utterance.
 * `narrowing_blue` / `narrowing_square` — **pragmatic narrowing**: the speaker is
@@ -40,7 +42,7 @@ theorem here.
 -/
 
 open MeasureTheory
-open scoped ENNReal
+open scoped ENNReal Topology
 
 namespace FrankGoodman2012
 
@@ -91,67 +93,89 @@ restricted to the applicable utterances `W(r)` by the surprisal `score`. -/
 noncomputable def speakerAt (r : Object) : Measure Feature :=
   RSA.Gibbs.speaker (Measure.count.restrict (↑(applicable r) : Set Feature)) score
 
-/-! ### Speaker mass closed forms (eq. 2) -/
+/-! ### Speaker API at this stimulus
+
+These wrappers carry `by decide` defaults for the applicability side-conditions, so
+the concrete predictions below never spell out `w ∈ applicable r` proofs. -/
 
 /-- At an applicable utterance, the speaker mass is the softmax over `W(r)`. -/
-theorem speakerAt_apply (r : Object) (w : Feature) (h : w ∈ applicable r) :
+theorem speakerAt_apply (r : Object) (w : Feature) (h : w ∈ applicable r := by decide) :
     speakerAt r {w}
       = ENNReal.ofReal (Real.exp (score w) / ∑ x ∈ applicable r, Real.exp (score x)) :=
   RSA.Gibbs.speaker_countRestrict_singleton (applicable r) score w h
 
 /-- A non-applicable utterance gets zero speaker mass. -/
-theorem speakerAt_apply_zero (r : Object) (w : Feature) (h : w ∉ applicable r) :
+theorem speakerAt_apply_zero (r : Object) (w : Feature) (h : w ∉ applicable r := by decide) :
     speakerAt r {w} = 0 :=
   RSA.Gibbs.speaker_countRestrict_singleton_of_not_mem (applicable r) score w h
 
+/-- Speaker preference at a referent reduces to the surprisal comparison. -/
+theorem speakerAt_lt_iff (r : Object) (w₁ w₂ : Feature)
+    (h₁ : w₁ ∈ applicable r := by decide) (h₂ : w₂ ∈ applicable r := by decide) :
+    speakerAt r {w₁} < speakerAt r {w₂} ↔ score w₁ < score w₂ :=
+  RSA.Gibbs.speaker_countRestrict_lt_iff_score_lt (applicable r) score w₁ w₂ h₁ h₂
+
+/-- α-speaker preference at a referent (`α > 0`) reduces to the surprisal comparison. -/
+theorem speakerAtAlpha_lt_iff (r : Object) {α : ℝ} (hα : 0 < α) (w₁ w₂ : Feature)
+    (h₁ : w₁ ∈ applicable r := by decide) (h₂ : w₂ ∈ applicable r := by decide) :
+    RSA.Gibbs.speakerAlpha (Measure.count.restrict (↑(applicable r) : Set Feature)) α score {w₁}
+        < RSA.Gibbs.speakerAlpha (Measure.count.restrict (↑(applicable r) : Set Feature)) α score {w₂}
+      ↔ score w₁ < score w₂ :=
+  RSA.Gibbs.speakerAlpha_countRestrict_lt_iff_score_lt (applicable r) hα score w₁ w₂ h₁ h₂
+
 /-! ### Numerical bookkeeping -/
 
-private theorem expScore_blue   : Real.exp (score .blue)   = 1 / 2 := by
-  rw [score, show numApplies Feature.blue = 2 from by decide, Nat.cast_ofNat,
-    Real.exp_neg, Real.exp_log (by norm_num)]; norm_num
-private theorem expScore_green  : Real.exp (score .green)  = 1 := by
-  rw [score, show numApplies Feature.green = 1 from by decide, Nat.cast_one,
-    Real.exp_neg, Real.exp_log (by norm_num)]; norm_num
-private theorem expScore_square : Real.exp (score .square) = 1 / 2 := by
-  rw [score, show numApplies Feature.square = 2 from by decide, Nat.cast_ofNat,
-    Real.exp_neg, Real.exp_log (by norm_num)]; norm_num
-private theorem expScore_circle : Real.exp (score .circle) = 1 := by
-  rw [score, show numApplies Feature.circle = 1 from by decide, Nat.cast_one,
-    Real.exp_neg, Real.exp_log (by norm_num)]; norm_num
+/-- Every feature applies to at least one object, so its extension is nonempty. -/
+private theorem numApplies_pos (w : Feature) : 0 < numApplies w := by cases w <;> decide
 
-/-- Partition (total alternative weight) at each referent: `1` at `blueSquare`
-(two ambiguous words), `3/2` at `blueCircle` and `greenSquare` (one ambiguous +
-one uniquely-identifying word). -/
+/-- `exp (score w) = |w|⁻¹` — the literal-listener target probability the speaker
+tilts by (the content of eq. 2). -/
+private theorem expScore (w : Feature) : Real.exp (score w) = (numApplies w : ℝ)⁻¹ := by
+  rw [score, Real.exp_neg, Real.exp_log (by exact_mod_cast numApplies_pos w)]
+
+/-- Partition over a two-word applicable set, in closed form. -/
+private theorem partition_pair (r : Object) (w₁ w₂ : Feature)
+    (h : applicable r = {w₁, w₂}) (hne : w₁ ∉ ({w₂} : Finset Feature)) :
+    ∑ x ∈ applicable r, Real.exp (score x) = (numApplies w₁ : ℝ)⁻¹ + (numApplies w₂ : ℝ)⁻¹ := by
+  rw [h, Finset.sum_insert hne, Finset.sum_singleton, expScore, expScore]
+
+/-- Partition (total alternative weight) at each referent: `1` at `blueSquare` (two
+ambiguous words), `3/2` at `blueCircle` and `greenSquare` (one ambiguous + one
+uniquely-identifying word). -/
 private theorem partition_blueSquare :
     ∑ x ∈ applicable .blueSquare, Real.exp (score x) = 1 := by
-  rw [show applicable Object.blueSquare = {Feature.blue, Feature.square} from by decide,
-    Finset.sum_insert (by decide), Finset.sum_singleton, expScore_blue, expScore_square]
-  norm_num
+  rw [partition_pair .blueSquare .blue .square (by decide) (by decide),
+    show numApplies Feature.blue = 2 from by decide,
+    show numApplies Feature.square = 2 from by decide]; norm_num
 
 private theorem partition_blueCircle :
     ∑ x ∈ applicable .blueCircle, Real.exp (score x) = 3 / 2 := by
-  rw [show applicable Object.blueCircle = {Feature.blue, Feature.circle} from by decide,
-    Finset.sum_insert (by decide), Finset.sum_singleton, expScore_blue, expScore_circle]
-  norm_num
+  rw [partition_pair .blueCircle .blue .circle (by decide) (by decide),
+    show numApplies Feature.blue = 2 from by decide,
+    show numApplies Feature.circle = 1 from by decide]; norm_num
 
 private theorem partition_greenSquare :
     ∑ x ∈ applicable .greenSquare, Real.exp (score x) = 3 / 2 := by
-  rw [show applicable Object.greenSquare = {Feature.green, Feature.square} from by decide,
-    Finset.sum_insert (by decide), Finset.sum_singleton, expScore_green, expScore_square]
-  norm_num
+  rw [partition_pair .greenSquare .green .square (by decide) (by decide),
+    show numApplies Feature.green = 1 from by decide,
+    show numApplies Feature.square = 2 from by decide]; norm_num
 
 /-! ### Predictions -/
+
+/-- `circle` is more informative than `blue`: `score blue < score circle`
+(`= log(1/2) < log 1`). Shared by `prefers_informative` and its α-robust form. -/
+private theorem score_blue_lt_circle : score .blue < score .circle := by
+  rw [score, score, show numApplies Feature.blue = 2 from by decide,
+    show numApplies Feature.circle = 1 from by decide, Nat.cast_ofNat, Nat.cast_one, Real.log_one]
+  simp only [neg_zero, neg_lt_zero]
+  exact Real.log_pos (by norm_num)
 
 /-- **The speaker prefers the uniquely-identifying description** (Fig. 1A): for the
 target (`blueCircle`), `circle` (which uniquely identifies it) gets strictly more
 mass than the ambiguous `blue`. Reduces via `speaker_countRestrict_lt_iff_score_lt`
 to the surprisal comparison `score blue < score circle`. -/
-theorem prefers_informative : speakerAt .blueCircle {.blue} < speakerAt .blueCircle {.circle} := by
-  rw [speakerAt, RSA.Gibbs.speaker_countRestrict_lt_iff_score_lt _ score _ _ (by decide) (by decide),
-    score, score, show numApplies Feature.blue = 2 from by decide,
-    show numApplies Feature.circle = 1 from by decide, Nat.cast_ofNat, Nat.cast_one, Real.log_one]
-  simp only [neg_zero, neg_lt_zero]
-  exact Real.log_pos (by norm_num)
+theorem prefers_informative : speakerAt .blueCircle {.blue} < speakerAt .blueCircle {.circle} :=
+  (speakerAt_lt_iff .blueCircle .blue .circle).mpr score_blue_lt_circle
 
 /-- **Robustness to rationality**: the informativeness preference holds at *every*
 rationality level `α > 0`, not just the canonical `α = 1` (`prefers_informative`).
@@ -160,58 +184,65 @@ theorem prefers_informative_alpha {α : ℝ} (hα : 0 < α) :
     RSA.Gibbs.speakerAlpha (Measure.count.restrict (↑(applicable .blueCircle) : Set Feature))
         α score {.blue}
       < RSA.Gibbs.speakerAlpha (Measure.count.restrict (↑(applicable .blueCircle) : Set Feature))
-        α score {.circle} := by
-  have hsc : score .blue < score .circle := by
-    rw [score, score, show numApplies Feature.blue = 2 from by decide,
-      show numApplies Feature.circle = 1 from by decide, Nat.cast_ofNat, Nat.cast_one, Real.log_one]
-    simp only [neg_zero, neg_lt_zero]
-    exact Real.log_pos (by norm_num)
-  simp only [RSA.Gibbs.speakerAlpha]
-  rw [RSA.Gibbs.speaker_countRestrict_lt_iff_score_lt _ _ _ _ (by decide) (by decide)]
-  exact mul_lt_mul_of_pos_left hsc hα
+        α score {.circle} :=
+  (speakerAtAlpha_lt_iff .blueCircle hα .blue .circle).mpr score_blue_lt_circle
+
+/-- **The fully-rational speaker is deterministic** (`α → ∞`): at the target, the
+speaker concentrates all its mass on the uniquely-identifying `circle`. The
+zero-temperature limit of `prefers_informative`, via
+`RSA.Gibbs.speakerAlpha_countRestrict_tendsto_one_of_isMax`. -/
+theorem fully_rational_picks_circle :
+    Filter.Tendsto (fun α => RSA.Gibbs.speakerAlpha
+        (Measure.count.restrict (↑(applicable .blueCircle) : Set Feature)) α score {.circle})
+      Filter.atTop (𝓝 1) := by
+  refine RSA.Gibbs.speakerAlpha_countRestrict_tendsto_one_of_isMax _ score _ (by decide) ?_
+  intro b hb hbne
+  have hb' : b ∈ ({Feature.blue, Feature.circle} : Finset Feature) := by
+    rwa [show applicable Object.blueCircle = {Feature.blue, Feature.circle} from by decide] at hb
+  fin_cases hb'
+  · exact score_blue_lt_circle
+  · exact absurd rfl hbne
 
 /-- **Size principle**: among applicable utterances, the speaker prefers the one
 with the smaller extension (lower `numApplies`). -/
 theorem size_principle (r : Object) (w₁ w₂ : Feature) (h₁ : w₁ ∈ applicable r)
     (h₂ : w₂ ∈ applicable r) (h : numApplies w₂ < numApplies w₁) :
     speakerAt r {w₁} < speakerAt r {w₂} := by
-  have hpos : 0 < numApplies w₂ :=
-    Finset.card_pos.mpr ⟨r, Finset.mem_filter.mpr ⟨Finset.mem_univ r, (Finset.mem_filter.mp h₂).2⟩⟩
-  rw [speakerAt, RSA.Gibbs.speaker_countRestrict_lt_iff_score_lt _ score _ _ h₁ h₂, score, score,
-    neg_lt_neg_iff]
-  exact Real.log_lt_log (by exact_mod_cast hpos) (by exact_mod_cast h)
+  refine (speakerAt_lt_iff r w₁ w₂ h₁ h₂).mpr ?_
+  rw [score, score, neg_lt_neg_iff]
+  exact Real.log_lt_log (by exact_mod_cast numApplies_pos w₂) (by exact_mod_cast h)
 
 /-- **Pragmatic narrowing for "blue"**: the speaker assigns less mass to "blue" at
 `blueCircle` (where "circle" uniquely identifies, raising the partition) than at
-`blueSquare` (where the only alternative "square" is equally ambiguous). This
-asymmetry — `S₁(blue | blueCircle) = 1/3 < 1/2 = S₁(blue | blueSquare)` — is what
-lets a listener hearing "blue" narrow toward `blueSquare`. -/
+`blueSquare` (where the only alternative "square" is equally ambiguous). The
+numerators are equal; the comparison is the partition comparison `3/2 > 1` — which
+is what lets a listener hearing "blue" narrow toward `blueSquare`. -/
 theorem narrowing_blue : speakerAt .blueCircle {.blue} < speakerAt .blueSquare {.blue} := by
-  rw [speakerAt_apply _ _ (by decide), speakerAt_apply _ _ (by decide),
-    partition_blueCircle, partition_blueSquare, expScore_blue,
-    ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
+  rw [speakerAt_apply .blueCircle .blue, speakerAt_apply .blueSquare .blue,
+    partition_blueCircle, partition_blueSquare, ENNReal.ofReal_lt_ofReal_iff (by positivity),
+    div_one]
+  exact div_lt_self (Real.exp_pos _) (by norm_num)
 
 /-- **Pragmatic narrowing for "square"**: symmetrically, "square" is less likely at
 `greenSquare` (where "green" uniquely identifies) than at `blueSquare`. -/
 theorem narrowing_square : speakerAt .greenSquare {.square} < speakerAt .blueSquare {.square} := by
-  rw [speakerAt_apply _ _ (by decide), speakerAt_apply _ _ (by decide),
-    partition_greenSquare, partition_blueSquare, expScore_square,
-    ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
+  rw [speakerAt_apply .greenSquare .square, speakerAt_apply .blueSquare .square,
+    partition_greenSquare, partition_blueSquare, ENNReal.ofReal_lt_ofReal_iff (by positivity),
+    div_one]
+  exact div_lt_self (Real.exp_pos _) (by norm_num)
 
 /-- **Unique reference for "green"**: "green" applies only to `greenSquare`, so it
 gets zero mass at `blueSquare` and positive mass at `greenSquare` — the listener
 hearing "green" identifies `greenSquare`. -/
 theorem unique_green : speakerAt .blueSquare {.green} < speakerAt .greenSquare {.green} := by
-  rw [speakerAt_apply_zero _ _ (by decide), speakerAt_apply _ _ (by decide),
-    partition_greenSquare, expScore_green]
-  exact ENNReal.ofReal_pos.mpr (by norm_num)
+  rw [speakerAt_apply_zero .blueSquare .green, speakerAt_apply .greenSquare .green,
+    partition_greenSquare]
+  exact ENNReal.ofReal_pos.mpr (by positivity)
 
 /-- **Unique reference for "circle"**: "circle" applies only to `blueCircle`. -/
 theorem unique_circle : speakerAt .blueSquare {.circle} < speakerAt .blueCircle {.circle} := by
-  rw [speakerAt_apply_zero _ _ (by decide), speakerAt_apply _ _ (by decide),
-    partition_blueCircle, expScore_circle]
-  exact ENNReal.ofReal_pos.mpr (by norm_num)
+  rw [speakerAt_apply_zero .blueSquare .circle, speakerAt_apply .blueCircle .circle,
+    partition_blueCircle]
+  exact ENNReal.ofReal_pos.mpr (by positivity)
 
 end FrankGoodman2012


### PR DESCRIPTION
Audit pass over the analytic-RSA cone (GibbsVariational, Gibbs, FrankGoodman2012).

- **API completion**: the α-`countRestrict` layer now matches the count layer — added `speakerAlpha_countRestrict_{lt_iff_score_lt, zero_singleton, singleton_of_not_mem}`.
- **Ergonomics**: FG2012 carries `by decide` autoParam defaults on its membership side-conditions (`speakerAt_apply`, `speakerAt_lt_iff`, …), so the predictions no longer spell out `(by decide) (by decide)`.
- **Golf**: FG2012 DRY'd (unified `expScore`/`numApplies_pos`/`partition_pair`/`score_blue_lt_circle`; narrowing/unique are now structural — equal numerators + partition comparison); Gibbs α-limits share `softmax_shift` + an `ofReal` wrapper; `mul_lt_mul_iff_of_pos_left` replaces a hand-built iff; dropped redundant `{U}` re-decls.
- **GibbsVariational**: honest `logIntegralExp = cgf · μ 1` framing (+`logIntegralExp_eq_cgf`); sharpened the upstream note (`q` is pinned to `IsProbabilityMeasure` by `integral_llr_tilted_right`).

All kernel-clean.