### PR TITLE
refactor(Semantics/Homogeneity): unify decided-domain core

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2313,6 +2313,7 @@ import Linglib.Semantics.Genericity.GenericsDynamic
 import Linglib.Studies.Krifka2004
 import Linglib.Semantics.Kinds.Subkinds
 import Linglib.Semantics.Homogeneity.Basic
+import Linglib.Semantics.Homogeneity.Decided
 import Linglib.Semantics.ArgumentStructure.Relational
 import Linglib.Semantics.ArgumentStructure.ArgumentIntroduction
 import Linglib.Semantics.Plurality.Algebra

--- a/Linglib/Semantics/Attitudes/NegRaising.lean
+++ b/Linglib/Semantics/Attitudes/NegRaising.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Attitudes.Doxastic
 import Linglib.Core.Logic.Aristotelian.Square
+import Linglib.Semantics.Homogeneity.Decided
 
 /-!
 # Neg-Raising as O→E Pragmatic Strengthening
@@ -39,6 +40,11 @@ a gap between ¬Bel(p) and Bel(¬p)) but NOT for `know` (veridical: ¬know(p)
 includes cases where p is false, so strengthening to know(¬p) would require
 ¬p to be true, which is a factual claim the speaker may not intend).
 
+## See also
+
+The domain-general structural core — neg-raising / force collapse ⟺ the modal's
+domain being a subsingleton — lives in `Semantics/Homogeneity/Decided.lean`. This
+file is the doxastic (believe / think / know) application layer.
 -/
 
 namespace Semantics.Attitudes.NegRaising
@@ -47,9 +53,7 @@ open Aristotelian (Square SquareRelations)
 open Semantics.Attitudes.Doxastic
   (DoxasticPredicate Veridicality boxAt diaAt AccessRel)
 
--- ============================================================================
--- §1 The Doxastic Square
--- ============================================================================
+/-! ### The doxastic square -/
 
 /-- The doxastic square for a belief predicate.
 
@@ -71,7 +75,7 @@ theorem doxasticSquare_contradAO {W E : Type*} (R : AccessRel W E)
     (agent : E) (worlds : List W) (p : W → Prop) (w : W) :
     (doxasticSquare R agent worlds p).A w ↔
     ¬ (doxasticSquare R agent worlds p).O w := by
-  simp [doxasticSquare]
+  simp only [doxasticSquare, not_not]
 
 /-- The doxastic square satisfies the E–I contradiction diagonal.
 
@@ -88,29 +92,56 @@ theorem doxasticSquare_contradEI {W E : Type*} (R : AccessRel W E)
   · intro h w' hw' hR hp
     exact h ⟨w', hw', hR, hp⟩
 
--- ============================================================================
--- §2 Neg-Raising Predicates
--- ============================================================================
+/-! ### Neg-raising and the excluded-middle premise
 
-/-- A neg-raising predicate is a doxastic predicate whose negation is
-pragmatically strengthened from O (¬Bel(p)) to E (Bel(¬p)).
+Neg-raising is the O→E inference `¬Bel(p) → Bel(¬p)`. It is *not* generally valid:
+for a non-veridical attitude the doxastic state is mixed, so `¬Bel(p)` leaves a
+gap. What licenses the strengthening is the **excluded-middle premise** that the
+agent is *opinionated* about `p` (`Bel(p) ∨ Bel(¬p)`), supplied pragmatically
+([gajewski-2007]); given it the inference is a disjunctive syllogism. Being
+opinionated about *every* prejacent is exactly the decided/subsingleton limit
+(`Homogeneity.excludedMiddle_iff_subsingleton`), where neg-raising holds as a
+validity rather than a defeasible move. -/
 
-The `negRaises` field indicates whether the predicate supports this
-inference. Structurally, neg-raising is available when the predicate
-is non-veridical (belief, not knowledge). -/
-structure NegRaisingPredicate (W E : Type*) extends DoxasticPredicate W E where
-  /-- Whether negation of this predicate raises into the complement. -/
-  negRaises : Bool
-
-/-- Neg-raising is the pragmatic inference from O to E:
-¬V(p) is strengthened to V(¬p).
-
-This is the "excluded middle of belief": when a speaker says "I don't
-think p", they implicate they have a settled opinion, namely Bel(¬p). -/
+/-- Neg-raising: the O→E inference `¬Bel(p) → Bel(¬p)` at a world. -/
 def negRaisesAt {W E : Type*} (R : AccessRel W E) (agent : E)
     (worlds : List W) (p : W → Prop) (w : W) : Prop :=
   ¬ boxAt R agent w worlds p →
   boxAt R agent w worlds (λ w' => ¬ p w')
+
+/-- The **excluded-middle premise**: the agent is *opinionated* about `p`,
+believing `p` or believing `¬p`. Gajewski's neg-raising presupposition. -/
+def opinionated {W E : Type*} (R : AccessRel W E) (agent : E)
+    (worlds : List W) (p : W → Prop) (w : W) : Prop :=
+  boxAt R agent w worlds p ∨ boxAt R agent w worlds (λ w' => ¬ p w')
+
+/-- **The pragmatic mechanism.** Opinionatedness about `p` licenses the O→E
+strengthening — a disjunctive syllogism. Neg-raising is this inference run on the
+(pragmatically presupposed) excluded-middle premise, not a semantic entailment. -/
+theorem negRaisesAt_of_opinionated {W E : Type*} (R : AccessRel W E) (agent : E)
+    (worlds : List W) (p : W → Prop) (w : W) :
+    opinionated R agent worlds p w → negRaisesAt R agent worlds p w :=
+  fun hem hnot => hem.resolve_left hnot
+
+/-- The accessible-worlds set at `w`; `boxAt … p` is `∀ w' ∈ accessibleSet, p w'`. -/
+def accessibleSet {W E : Type*} (R : AccessRel W E) (agent : E) (worlds : List W)
+    (w : W) : Set W :=
+  {w' | w' ∈ worlds ∧ R agent w w'}
+
+theorem boxAt_iff_forall_accessibleSet {W E : Type*} (R : AccessRel W E) (agent : E)
+    (worlds : List W) (p : W → Prop) (w : W) :
+    boxAt R agent w worlds p ↔ ∀ w' ∈ accessibleSet R agent worlds w, p w' := by
+  simp only [boxAt, accessibleSet, Set.mem_setOf_eq, and_imp]
+
+/-- **Validity ⟺ decided state.** The agent is opinionated about *every* prejacent
+(neg-raising then holds as a validity) iff the accessible state is decided — a
+subsingleton — connecting the doxastic layer to the shared `Homogeneity` core. -/
+theorem forall_opinionated_iff_subsingleton {W E : Type*} (R : AccessRel W E)
+    (agent : E) (worlds : List W) (w : W) :
+    (∀ p : W → Prop, opinionated R agent worlds p w) ↔
+      (accessibleSet R agent worlds w).Subsingleton := by
+  rw [← Homogeneity.excludedMiddle_iff_subsingleton (accessibleSet R agent worlds w)]
+  simp only [opinionated, boxAt_iff_forall_accessibleSet]
 
 /-- Neg-raising is available exactly when the predicate admits a gap
 between ¬Bel(p) and Bel(¬p) — i.e., when the O→E strengthening is
@@ -130,56 +161,21 @@ def negRaisingAvailable (v : Veridicality) : Bool :=
   | .nonVeridical => true   -- believe, think: gap exists
   | .veridical => false     -- know: no neg-raising
 
--- ============================================================================
--- §3 Standard Predicate Classifications
--- ============================================================================
-
-/-- "believe" supports neg-raising.
-"I don't believe it's raining" ≈ "I believe it's not raining". -/
-def believeNR {W E : Type*} (R : AccessRel W E) : NegRaisingPredicate W E :=
-  { toDoxasticPredicate := Doxastic.believeTemplate R
-    negRaises := true }
-
-/-- "think" supports neg-raising.
-"I don't think it's raining" ≈ "I think it's not raining". -/
-def thinkNR {W E : Type*} (R : AccessRel W E) : NegRaisingPredicate W E :=
-  { toDoxasticPredicate := Doxastic.thinkTemplate R
-    negRaises := true }
-
-/-- "know" does NOT support neg-raising.
-"I don't know it's raining" ≠ "I know it's not raining". -/
-def knowNR {W E : Type*} (R : AccessRel W E) : NegRaisingPredicate W E :=
-  { toDoxasticPredicate := Doxastic.knowTemplate R
-    negRaises := false }
-
--- ============================================================================
--- §4 Theorems
--- ============================================================================
+/-! ### Veridicality and square lemmas -/
 
 /-- Neg-raising availability aligns with non-veridicality. -/
 theorem negRaising_iff_nonVeridical (v : Veridicality) :
     negRaisingAvailable v = true ↔ v = .nonVeridical := by
-  cases v <;> simp [negRaisingAvailable]
+  cases v <;> decide
 
-/-- "believe" is classified as neg-raising. -/
-theorem believe_negRaises {W E : Type*} (R : AccessRel W E) :
-    (believeNR R : NegRaisingPredicate W E).negRaises = true := rfl
-
-/-- "think" is classified as neg-raising. -/
-theorem think_negRaises {W E : Type*} (R : AccessRel W E) :
-    (thinkNR R : NegRaisingPredicate W E).negRaises = true := rfl
-
-/-- "know" is NOT classified as neg-raising. -/
-theorem know_not_negRaises {W E : Type*} (R : AccessRel W E) :
-    (knowNR R : NegRaisingPredicate W E).negRaises = false := rfl
-
-/-- Neg-raising predicates are non-veridical. -/
-theorem negRaising_implies_nonVeridical {W E : Type*}
-    (V : NegRaisingPredicate W E) (hNR : V.negRaises = true)
-    (hAlign : V.negRaises = negRaisingAvailable V.veridicality) :
-    V.veridicality = .nonVeridical := by
-  rw [hNR] at hAlign
-  exact (negRaising_iff_nonVeridical V.veridicality).mp hAlign.symm
+/-- The standard predicates' neg-raising status is *derived* from their
+veridicality, not stipulated as a flag: believe and think are non-veridical
+(neg-raising available), know is veridical (not). -/
+theorem believe_think_negRaise_know_not {W E : Type*} (R : AccessRel W E) :
+    negRaisingAvailable (Doxastic.believeTemplate R).veridicality = true ∧
+    negRaisingAvailable (Doxastic.thinkTemplate R).veridicality = true ∧
+    negRaisingAvailable (Doxastic.knowTemplate R).veridicality = false :=
+  ⟨rfl, rfl, rfl⟩
 
 /-- The doxastic square for "believe" satisfies the contradiction diagonals. -/
 theorem believe_square_contradictions {W E : Type*} (R : AccessRel W E)
@@ -191,25 +187,9 @@ theorem believe_square_contradictions {W E : Type*} (R : AccessRel W E)
   ⟨doxasticSquare_contradAO R agent worlds p w,
    doxasticSquare_contradEI R agent worlds p w⟩
 
--- ============================================================================
--- §3 The excluded-middle core: neg-raising ⟺ subsingleton domain
--- ============================================================================
-
-/-- **The structural core of neg-raising.** A universal modal `∀ w ∈ A, p w`
-validates the neg-raising inference `¬□p → □¬p` for *every* prejacent `p` iff its
-domain `A` is a subsingleton — all worlds in `A` agree on every proposition.
-Equivalently, `A` admits no truth-value gap (cf. `Semantics.Homogeneity`), so this
-single lemma is the formal heart shared by Rubinstein's neg-raising and
-Agha & Jeretič's homogeneity. The doxastic `negRaisesAt` (§2) is the instance
-with `A` the agent's accessible worlds. General over any world type. -/
-theorem negRaising_iff_subsingleton {W : Type*} (A : Set W) :
-    (∀ p : W → Prop, ¬ (∀ w ∈ A, p w) → ∀ w ∈ A, ¬ p w) ↔ A.Subsingleton := by
-  constructor
-  · intro hEM a ha b hb
-    by_contra hab
-    have hnotall : ¬ ∀ w ∈ A, w = a := fun hall => hab (hall b hb).symm
-    exact (hEM (· = a) hnotall a ha) rfl
-  · intro hsub p hnot w hw hpw
-    exact hnot fun v hv => by rw [hsub hv hw]; exact hpw
+-- The domain-general core — neg-raising / force-collapse / excluded middle ⟺ the
+-- domain being a subsingleton — lives in `Semantics/Homogeneity/Decided.lean`,
+-- consumed here (via `forall_opinionated_iff_subsingleton`) and by the modal-force
+-- studies and nominal plural homogeneity.
 
 end Semantics.Attitudes.NegRaising

--- a/Linglib/Semantics/Homogeneity/Decided.lean
+++ b/Linglib/Semantics/Homogeneity/Decided.lean
@@ -1,0 +1,105 @@
+import Mathlib.Data.Set.Subsingleton
+
+/-!
+# Decided domains: the no-gap / force-collapse boundary
+
+A set `A` is *decided* when all its elements agree on every proposition — that is,
+`A.Subsingleton`. This is the boundary at which plural predication over `A` stops
+exhibiting a homogeneity gap and at which universal and existential force collapse.
+It is the bivalent companion to the trivalent treatment in `Homogeneity.Basic`
+(`isBivalent` / `gapExt`).
+
+The point of this file is that one condition on the domain — being a subsingleton —
+is the shared structural core of several superficially different phenomena:
+
+* attitude **neg-raising** ([gajewski-2007], [horn-2001]):
+  `Semantics/Attitudes/NegRaising.lean`;
+* modal **weak necessity** — the comparative ([rubinstein-2014]), homogeneity
+  ([agha-jeretic-2022]), and domain-restriction analyses surveyed in
+  [agha-jeretic-2026] all reduce their neg-raising prediction to it;
+* nominal **plural homogeneity** — the same lemmas instantiated over individuals
+  rather than worlds ("Ann didn't eat the cookies" = ate none).
+
+The lemmas are stated over an arbitrary `Set W`, so all three are instances.
+
+## Main results
+
+* `negRaising_iff_subsingleton` — the excluded-middle / neg-raising inference
+  `¬□p → □¬p` holds for every `p` iff the domain is decided.
+* `forceCollapse_iff_subsingleton` — over a nonempty domain, `□p ↔ ◇p` for every
+  `p` iff the domain is decided.
+* `negRaising_iff_forceCollapse` — the two faces coincide.
+-/
+
+namespace Semantics.Homogeneity
+
+variable {W : Type*}
+
+/-- **Neg-raising face.** A universal modal `∀ w ∈ A, p w` validates the
+neg-raising inference `¬□p → □¬p` for *every* prejacent `p` iff its domain `A` is
+a subsingleton — all elements of `A` agree on every proposition. -/
+theorem negRaising_iff_subsingleton (A : Set W) :
+    (∀ p : W → Prop, ¬ (∀ w ∈ A, p w) → ∀ w ∈ A, ¬ p w) ↔ A.Subsingleton := by
+  constructor
+  · intro hEM a ha b hb
+    by_contra hab
+    have hnotall : ¬ ∀ w ∈ A, w = a := fun hall => hab (hall b hb).symm
+    exact (hEM (· = a) hnotall a ha) rfl
+  · intro hsub p hnot w hw hpw
+    exact hnot fun v hv => by rw [hsub hv hw]; exact hpw
+
+/-- **Force-collapse face.** Over a nonempty domain, the universal and existential
+modal forces coincide (`□p ↔ ◇p` for every prejacent) iff the domain is a
+subsingleton — the limit at which a strong/weak (universal/existential) force
+distinction ceases to be a difference in force. Fully constructive. -/
+theorem forceCollapse_iff_subsingleton {A : Set W} (hne : A.Nonempty) :
+    (∀ p : W → Prop, (∀ w ∈ A, p w) ↔ (∃ w ∈ A, p w)) ↔ A.Subsingleton := by
+  constructor
+  · intro hfc a ha b hb
+    exact ((hfc (· = a)).mpr ⟨a, ha, rfl⟩ b hb).symm
+  · intro hsub p
+    obtain ⟨a, ha⟩ := hne
+    refine ⟨fun hall => ⟨a, ha, hall a ha⟩, ?_⟩
+    rintro ⟨b, hb, hpb⟩ c hc
+    rw [hsub hc hb]
+    exact hpb
+
+/-- **The two faces are one.** Over a nonempty domain the neg-raising inference
+holds (for every prejacent) iff modal force collapses (`□p ↔ ◇p` for every
+prejacent) — both iff the domain is decided. Neg-raising is the symptom of the
+universal/existential force distinction collapsing. -/
+theorem negRaising_iff_forceCollapse {A : Set W} (hne : A.Nonempty) :
+    (∀ p : W → Prop, ¬ (∀ w ∈ A, p w) → ∀ w ∈ A, ¬ p w) ↔
+    (∀ p : W → Prop, (∀ w ∈ A, p w) ↔ (∃ w ∈ A, p w)) := by
+  rw [negRaising_iff_subsingleton, forceCollapse_iff_subsingleton hne]
+
+/-- **Excluded-middle face.** A universal modal is *opinionated* about every
+prejacent (`□p ∨ □¬p` for all `p`) iff its domain is a subsingleton. This is the
+form the condition takes as Gajewski's excluded-middle presupposition for
+neg-raising ([gajewski-2007]). -/
+theorem excludedMiddle_iff_subsingleton (A : Set W) :
+    (∀ p : W → Prop, (∀ w ∈ A, p w) ∨ (∀ w ∈ A, ¬ p w)) ↔ A.Subsingleton := by
+  constructor
+  · intro hem a ha b hb
+    rcases hem (· = a) with h | h
+    · exact (h b hb).symm
+    · exact absurd rfl (h a ha)
+  · intro hsub p
+    by_cases hp : ∀ w ∈ A, p w
+    · exact Or.inl hp
+    · exact Or.inr ((negRaising_iff_subsingleton A).mpr hsub p hp)
+
+/-! ### The same core is nominal plural homogeneity
+
+Instantiating the domain at a set of individuals rather than worlds gives the
+homogeneity of *nominal* plural predication: "the `cookies` are `p`" is decided —
+no gap, force collapsed — iff the set of cookies is a subsingleton. This is
+[agha-jeretic-2022]'s point that modal *should* patterns like a plural definite
+("Ann didn't eat the cookies" = ate none): the shared fact is one lemma at two
+domains (worlds vs individuals). -/
+example {α : Type*} (cookies : Set α) (hne : cookies.Nonempty) :
+    (∀ p : α → Prop, (∀ c ∈ cookies, p c) ↔ (∃ c ∈ cookies, p c)) ↔
+      cookies.Subsingleton :=
+  forceCollapse_iff_subsingleton hne
+
+end Semantics.Homogeneity

--- a/Linglib/Studies/AghaJeretic2022.lean
+++ b/Linglib/Studies/AghaJeretic2022.lean
@@ -3,7 +3,7 @@ import Linglib.Core.Logic.Truth3
 import Linglib.Data.Examples.AghaJeretic2022
 import Linglib.Data.Generalizations.HomogeneityGap
 import Linglib.Semantics.Modality.Directive
-import Linglib.Semantics.Attitudes.NegRaising
+import Linglib.Semantics.Homogeneity.Decided
 import Linglib.Semantics.Plurality.Distributivity
 import Linglib.Fragments.English.Auxiliaries
 import Linglib.Fragments.Javanese.Modals
@@ -71,7 +71,7 @@ namespace AghaJeretic2022
 
 open Core.Duality (Truth3)
 open Generalizations.HomogeneityGap (GapDatum GapScenario GapPredict fromExample)
-open Semantics.Attitudes.NegRaising (negRaising_iff_subsingleton)
+open Semantics.Homogeneity (negRaising_iff_subsingleton)
 
 -- ============================================================================
 -- §1. Trivalent Semantics for Modals (§4.2)
@@ -1053,13 +1053,13 @@ A&J analyse *should*'s wide-scope-under-negation as **homogeneity** (a truth-val
 gap in mixed domains), not genuine neg-raising; [rubinstein-2014] analyses the same
 data as genuine neg-raising. Both reduce to one structural condition on the modal's
 domain — being a subsingleton — via the shared
-`NegRaising.negRaising_iff_subsingleton`. The rival diagnoses of *should* are the
+`Homogeneity.negRaising_iff_subsingleton`. The rival diagnoses of *should* are the
 same fact described differently. -/
 
 /-- A&J's homogeneity (gap-free, i.e. bivalent for every prejacent) and
     Rubinstein's neg-raising coincide: a universal modal over `A` is gap-free for
     every prejacent iff it neg-raises for every prejacent — both hold iff `A` is a
-    subsingleton (`NegRaising.negRaising_iff_subsingleton`). -/
+    subsingleton (`Homogeneity.negRaising_iff_subsingleton`). -/
 theorem bivalent_iff_negRaising {W : Type*} (A : Set W) :
     (∀ p : W → Prop, (∀ w ∈ A, p w) ∨ (∀ w ∈ A, ¬ p w)) ↔
     (∀ p : W → Prop, ¬ (∀ w ∈ A, p w) → ∀ w ∈ A, ¬ p w) := by

--- a/Linglib/Studies/AghaJeretic2026.lean
+++ b/Linglib/Studies/AghaJeretic2026.lean
@@ -1,6 +1,7 @@
 import Linglib.Semantics.Modality.Directive
 import Linglib.Fragments.English.Auxiliaries
 import Linglib.Studies.Rubinstein2014
+import Linglib.Semantics.Homogeneity.Decided
 import Mathlib.Data.Fin.Basic
 
 /-!
@@ -42,7 +43,9 @@ neg-raising asymmetries between *should* and *must*.
 namespace AghaJeretic2026
 
 open Semantics.Modality (ModalForce ModalFlavor ForceFlavor ModalItem)
+open Semantics.Modality.Kratzer
 open Semantics.Modality.Directive
+open Semantics.Homogeneity (negRaising_iff_subsingleton)
 open English.Auxiliaries
 
 abbrev World := Fin 4
@@ -353,5 +356,27 @@ theorem must_negRaising_diverges_from_rubinstein :
     Rubinstein2014.Examples.nr_must.readings.lookup "lowerNeg"
       = some Features.Judgment.unacceptable :=
   ⟨rfl, by decide⟩
+
+/-! ### The three competing analyses share one neg-raising logic
+
+VFI's domain-restriction *ought* (`Directive.weakNecessity`) is `∀` over the
+refined best-world set `bestWorlds f (g ∪ g') w`, so the shared lemma applies to
+it exactly as to Rubinstein's `BEST(favored, negotiable)` and A&J's gap domain.
+All three rival analyses of weak necessity predict neg-raising via the *same*
+condition — the domain is a subsingleton — and differ only in how each constructs
+that domain. -/
+
+/-- **Domain-restriction (von Fintel & Iatridou) wired to the shared lemma.** VFI
+    weak necessity neg-raises at `(f, g, g', w)` iff its refined best-world domain
+    `bestWorlds f (g ∪ g') w` is a subsingleton — the same
+    `Homogeneity.negRaising_iff_subsingleton` characterization as Rubinstein's
+    `BEST(favored, negotiable)` and A&J's gap domain. -/
+theorem vfiWeak_negRaises_iff {W : Type*} (f : ModalBase W) (g g' : OrderingSource W)
+    (w : W) :
+    (∀ p : W → Prop, ¬ weakNecessity f g g' p w →
+        weakNecessity f g g' (fun w' => ¬ p w') w) ↔
+      (bestWorlds f (combineOrdering g g') w).Subsingleton := by
+  simp only [weakNecessity, necessity_iff_all]
+  exact negRaising_iff_subsingleton _
 
 end AghaJeretic2026

--- a/Linglib/Studies/Rubinstein2014.lean
+++ b/Linglib/Studies/Rubinstein2014.lean
@@ -1,7 +1,7 @@
 import Linglib.Studies.Narrog2010
 import Linglib.Semantics.Modality.Kratzer.Flavor
 import Linglib.Semantics.Modality.Directive
-import Linglib.Semantics.Attitudes.NegRaising
+import Linglib.Semantics.Homogeneity.Decided
 import Linglib.Fragments.English.Auxiliaries
 import Linglib.Data.Examples.Rubinstein2014
 import Mathlib.Data.Fin.Basic
@@ -58,7 +58,7 @@ abbrev World := Fin 4
 open Semantics.Modality.Kratzer
 open Semantics.Modality.Directive
 open Semantics.Modality (ModalForce)
-open Semantics.Attitudes.NegRaising (negRaising_iff_subsingleton)
+open Semantics.Homogeneity (negRaising_iff_subsingleton)
 open Data.Examples
 
 /-- Named worlds for the concrete `Fin 4` evaluation frame used in the
@@ -418,7 +418,7 @@ theorem strong_verbs_no_neg_raising :
 
 Rubinstein ties neg-raising to negotiability via an "opinionated alternative".
 The structural content is sharper and fully general, and lives as substrate:
-`NegRaising.negRaising_iff_subsingleton` shows a universal modal neg-raises iff
+`Homogeneity.negRaising_iff_subsingleton` shows a universal modal neg-raises iff
 its domain is a subsingleton. The weak/strong split below is then exactly whether
 the ordering source collapses that domain — a negotiable ideal can, the bare
 favored set cannot. (That subsingleton/decidedness property is also what


### PR DESCRIPTION
Extract the decided-domain core — a universal modal neg-raises / force-collapses / is excluded-middle-complete (for every prejacent) iff its domain is a subsingleton — into `Semantics/Homogeneity/Decided.lean`, a neutral home consumed by attitude neg-raising, the three modal-force studies, and nominal plural homogeneity (one lemma at two domains).

- `Attitudes/NegRaising.lean`: regrounded onto the shared core; adds the excluded-middle premise (`opinionated`) and the pragmatic mechanism `negRaisesAt_of_opinionated`, with `forall_opinionated_iff_subsingleton` bridging the doxastic layer to the core; removes the dead `Bool` classification layer (derives the believe/think/know split from veridicality instead).
- `Studies/{Rubinstein2014,AghaJeretic2022,AghaJeretic2026}`: reground to `Homogeneity`; AghaJeretic2026 adds the von Fintel–Iatridou corollary, so all three rival analyses of weak necessity share the one subsingleton characterization.