### PR TITLE
refactor(Core/Order): rip out NormalityOrder; add Preorder lattice

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -102,6 +102,7 @@ import Linglib.Core.Order.Branching
 import Linglib.Core.Order.LeftLinear
 import Linglib.Core.Order.Positions
 import Linglib.Core.Order.Command
+import Linglib.Core.Order.PreorderLattice
 import Linglib.Core.Order.Normality
 import Linglib.Core.Order.SimilarityOrdering
 import Linglib.Core.Order.Plausibility

--- a/Linglib/Core/Logic/BeliefRevision.lean
+++ b/Linglib/Core/Logic/BeliefRevision.lean
@@ -38,7 +38,7 @@ AGM revision operator (this file: K*1–K*5)
 
 namespace Core.Logic.BeliefRevision
 
-open Core.Order (PlausibilityOrder PreferentialConsequence NormalityOrder)
+open Core.Order (PlausibilityOrder PreferentialConsequence)
 
 -- ══════════════════════════════════════════════════════════════════════
 -- § 1. AGM Belief Revision (Alchourrón, [alchouron-gardenfors-makinson-1985])
@@ -131,7 +131,7 @@ private lemma sublist_length_lt_of_mem {α : Type*} {l₁ l₂ : List α}
 open Classical in
 noncomputable def kratzerPlausibility {W : Type*} [Fintype W] [DecidableEq W]
     (orderingSource : List (W → Prop)) : PlausibilityOrder W where
-  toNormalityOrder := Core.Order.NormalityOrder.fromProps orderingSource
+  toPreorder := Core.Order.Normality.fromProps orderingSource
   smooth := fun φ w hφw => by
     classical
     let sat := fun (v : W) => (orderingSource.filter (fun p => decide (p v))).length

--- a/Linglib/Core/Logic/RankingFunction.lean
+++ b/Linglib/Core/Logic/RankingFunction.lean
@@ -189,15 +189,12 @@ theorem rankProp_union [Fintype W] (κ : RankingFunction W)
     every non-empty subset of ℕ has a minimum, so among the
     φ-worlds with rank ≤ κ(w), we can find a minimal one. -/
 def toPlausibilityOrder (κ : RankingFunction W) : PlausibilityOrder W where
-  le := fun w v => κ.rank w ≤ κ.rank v
-  le_refl := fun _ => Nat.le_refl _
-  le_trans := fun _ _ _ h1 h2 => Nat.le_trans h1 h2
+  toPreorder := Preorder.lift κ.rank
   smooth := fun φ w hφw => by
     classical
-    -- Among φ-worlds with rank ≤ κ(w), find one with minimal rank.
-    -- Such worlds exist (w itself qualifies).
-    -- The ranks of candidates form a nonempty subset of ℕ.
-    -- Use Nat.find to get the minimal rank value.
+    show ∃ v, φ v ∧ κ.rank v ≤ κ.rank w ∧
+      ∀ u, φ u → κ.rank u ≤ κ.rank v → κ.rank v ≤ κ.rank u
+    -- Among φ-worlds with rank ≤ κ(w), find one with minimal rank (via `Nat.find`).
     let minRank := Nat.find (⟨κ.rank w, w, hφw, Nat.le_refl _, rfl⟩ :
       ∃ n, ∃ v, φ v ∧ κ.rank v ≤ κ.rank w ∧ κ.rank v = n)
     obtain ⟨v, hφv, hvw, hvrank⟩ := Nat.find_spec (⟨κ.rank w, w, hφw, Nat.le_refl _, rfl⟩ :
@@ -226,7 +223,7 @@ def toPreferential (κ : RankingFunction W) : PreferentialConsequence W :=
     distinguishes ranked models from merely preferential models and
     is what makes Rational Monotonicity hold. -/
 theorem ranking_connected (κ : RankingFunction W) :
-    κ.toPlausibilityOrder.toNormalityOrder.connected := by
+    Core.Order.Normality.connected κ.toPlausibilityOrder.toPreorder := by
   intro w v
   show κ.rank w ≤ κ.rank v ∨ κ.rank v ≤ κ.rank w
   omega

--- a/Linglib/Core/Order/Normality.lean
+++ b/Linglib/Core/Order/Normality.lean
@@ -1,360 +1,227 @@
-import Mathlib.Data.Set.Basic
+import Mathlib.Order.Minimal
 import Linglib.Core.Order.OfCriteria
+import Linglib.Core.Order.PreorderLattice
 
 /-!
-# Normality Orderings
-[kraus-magidor-1990] [veltman-1996] [rudin-2025a]
+# Normality orderings (default reasoning over preorders)
 
-A normality ordering is a preorder on worlds encoding relative normalcy.
-This structure appears in four places across formal semantics:
+[kraus-magidor-1990] [veltman-1996] [rudin-2025a] [kratzer-1981]
 
-1. **[kratzer-1981]**: ordering sources induce normality orderings
-   for modal semantics (`Semantics/Modality/Kratzer.lean`)
-2. **[kraus-magidor-1990]**: plausibility orderings interpret
-   default consequence, System P (`Core/Logic/BeliefRevision.lean`)
-3. **[veltman-1996]**: expectation patterns are normality orderings that
-   get dynamically refined (`Semantics/Dynamic/UpdateSemantics/`)
-4. **[rudin-2025a]**: ordering-source updates for epistemic modals
-   (`Semantics/Dynamic/Epistemic/`)
+A *normality ordering* is just a `Preorder` on worlds: `p.le w v` means
+`w` is at least as normal as `v`. There is **no bespoke structure** here —
+the order is mathlib's `Preorder`, so the entire order API (`<`, `Minimal`,
+order-duals, monotone maps) is available, and the default-reasoning
+operations are thin definitions over it:
 
-This module extracts the common mathematical core. The `PlausibilityOrder`
-in `BeliefRevision.lean` adds a smoothness condition (every satisfiable
-proposition has minimal elements); for finite types smoothness is automatic,
-and `NormalityOrder` captures the shared preorder structure without it.
+* `optimal p d` — the most-normal worlds in `d` — is mathlib's `Minimal`.
+* `connected p` — totality — is `∀ w v, p.le w v ∨ p.le v w`.
+* `total = ⊤` — the all-equal order — is the top of `CompleteLattice (Preorder W)`.
+* `refine p φ = p ⊓ crit φ` — [veltman-1996]'s promote-φ update — is **meet**
+  with the criterion preorder `crit φ` (`w ≤ v ↔ (φ v → φ w)`). The whole
+  refinement calculus (commutativity, idempotence, the total order as unit)
+  is therefore the meet-semilattice laws (`inf_right_comm`, `inf_right_idem`,
+  `inf_top_eq`).
+* `fromProps` — [kratzer-1981]'s ordering-source order — is `Preorder.ofCriteria`.
 
-## Key definitions
-
-- `NormalityOrder W`: preorder on worlds (reflexive, transitive)
-- `optimal`: most normal worlds in a domain
-- `refine`: promote φ-worlds — [veltman-1996]'s key operation
-- `connected`: every two worlds are comparable (totality)
-- `fromProps`: construct from ordering source — [kratzer-1981]'s pattern
-- `respects` / persistence: defaults survive further updates
+This replaces the former hand-rolled `NormalityOrder` structure (a
+field-for-field reimplementation of `Preorder`).
 -/
 
 namespace Core.Order
-
-/-- A normality ordering: a preorder on worlds.
-    `le w v` means w is at least as normal as v. -/
-structure NormalityOrder (W : Type*) where
-  le : W → W → Prop
-  le_refl : ∀ w, le w w
-  le_trans : ∀ u v w, le u v → le v w → le u w
-
-namespace NormalityOrder
+namespace Normality
 
 variable {W : Type*}
 
-/-- Extensionality: two normality orderings are equal iff they agree on
-    all pairs. Uses `propext` and `funext`. -/
-@[ext]
-theorem ext {a b : NormalityOrder W}
-    (h : ∀ w v, a.le w v ↔ b.le w v) : a = b := by
-  have hle : a.le = b.le := funext fun w => funext fun v => propext (h w v)
-  cases a; cases b; simp only [mk.injEq]; exact hle
+/-! ### Optimality, totality, the total order -/
 
-/-- An ordering is **connected** (total) if every two worlds are
-    comparable: for all w, v, either w ≤ v or v ≤ w. -/
-def connected (no : NormalityOrder W) : Prop :=
-  ∀ w v, no.le w v ∨ no.le v w
+/-- The **optimal** (most normal) worlds in a domain `d`: mathlib's
+    `Minimal` for the membership predicate, under the preorder `p`. -/
+def optimal (p : Preorder W) (d : Set W) : Set W := {w | @Minimal W p.toLE (· ∈ d) w}
 
-/-- The total ordering: all worlds equally normal. This is the initial
-    state before any defaults have been processed. -/
-def total : NormalityOrder W where
-  le := fun _ _ => True
-  le_refl _ := True.intro
-  le_trans _ _ _ _ _ := True.intro
+theorem mem_optimal {p : Preorder W} {d : Set W} {w : W} :
+    w ∈ optimal p d ↔ w ∈ d ∧ ∀ ⦃v⦄, v ∈ d → p.le v w → p.le w v := Iff.rfl
 
-/-- Strict normality: w is strictly more normal than v. -/
-@[reducible] def slt (no : NormalityOrder W) (w v : W) : Prop :=
-  no.le w v ∧ ¬no.le v w
+theorem optimal_subset (p : Preorder W) (d : Set W) : optimal p d ⊆ d := fun _ h => h.1
 
-/-- Optimal (most normal) worlds in a domain: those with no strictly
-    more normal world in the domain.
+/-- A preorder is **connected** (total) if every two worlds are comparable. -/
+def connected (p : Preorder W) : Prop := ∀ w v, p.le w v ∨ p.le v w
 
-    Equivalent to `PlausibilityOrder.minimal` in `BeliefRevision.lean`
-    and to [veltman-1996]'s opt_ε(σ). -/
-def optimal (no : NormalityOrder W) (d : Set W) : Set W :=
-  { w ∈ d | ∀ v ∈ d, no.le v w → no.le w v }
+/-- The **total** normality order: all worlds equally normal — the top of
+    the lattice of preorders. -/
+abbrev total : Preorder W := ⊤
 
-/-- Optimal worlds are in the domain. -/
-theorem optimal_subset (no : NormalityOrder W) (d : Set W) :
-    no.optimal d ⊆ d := fun _ hw => hw.1
+theorem total_connected : connected (total : Preorder W) := fun _ _ => Or.inl trivial
 
-/-- The total ordering is connected. -/
-theorem total_connected : (total : NormalityOrder W).connected :=
-  fun _ _ => Or.inl True.intro
-
-/-- Under the total ordering, every world in the domain is optimal. -/
-theorem total_all_optimal (d : Set W) :
-    NormalityOrder.total.optimal d = d := by
+theorem total_all_optimal (d : Set W) : optimal (total : Preorder W) d = d := by
   ext w
-  simp only [optimal, total, Set.mem_setOf_eq]
-  exact ⟨fun ⟨h, _⟩ => h, fun h => ⟨h, fun _ _ _ => True.intro⟩⟩
+  rw [mem_optimal]
+  exact ⟨fun h => h.1, fun h => ⟨h, fun _ _ _ => trivial⟩⟩
 
+/-! ### Refinement as meet with a criterion preorder -/
 
--- ═══ Refinement ═══
+/-- The **criterion preorder** for a property `φ`: `w ≤ v ↔ (φ v → φ w)`.
+    Defined directly (not via `Preorder.ofCriteria {φ}`) so that
+    `(refine p φ).le` reduces definitionally to `p.le … ∧ (φ … → φ …)`. -/
+@[reducible] def crit (φ : W → Prop) : Preorder W :=
+  Preorder.ofLE (fun w v => φ v → φ w) (fun _ => id)
+    (fun _ _ _ hab hbc h => hab (hbc h))
 
-/-- **Refinement**: promote φ-worlds in the normality ordering.
+theorem crit_le {φ : W → Prop} {w v : W} : (crit φ).le w v ↔ (φ v → φ w) := Iff.rfl
 
-    After `refine no φ`, a non-φ-world can no longer be as normal as a
-    φ-world: w ≤' v iff (w ≤ v) ∧ (φ v → φ w).
+/-- **Refinement** ([veltman-1996]): promote φ-worlds. `refine p φ` is the
+    meet of `p` with the criterion preorder for `φ`, so
+    `(refine p φ).le w v ↔ p.le w v ∧ (φ v → φ w)`. -/
+@[reducible] def refine (p : Preorder W) (φ : W → Prop) : Preorder W := p ⊓ crit φ
 
-    This is [veltman-1996]'s key operation. "Normally φ" updates the
-    expectation pattern by intersecting with {⟨w,v⟩ : φ v → φ w}. -/
-def refine (no : NormalityOrder W) (φ : W → Prop) : NormalityOrder W where
-  le w v := no.le w v ∧ (φ v → φ w)
-  le_refl w := ⟨no.le_refl w, id⟩
-  le_trans u v w := fun ⟨huv, hφuv⟩ ⟨hvw, hφvw⟩ =>
-    ⟨no.le_trans u v w huv hvw, fun hw => hφuv (hφvw hw)⟩
+theorem refine_le {p : Preorder W} {φ : W → Prop} {w v : W} :
+    (refine p φ).le w v ↔ p.le w v ∧ (φ v → φ w) := and_congr Iff.rfl crit_le
 
-/-- Refinement strengthens: the refined ordering implies the original. -/
-theorem refine_le_imp (no : NormalityOrder W) (φ : W → Prop)
-    {w v : W} (h : (no.refine φ).le w v) : no.le w v := h.1
+theorem refine_le_imp {p : Preorder W} {φ : W → Prop} {w v : W}
+    (h : (refine p φ).le w v) : p.le w v := (refine_le.mp h).1
 
 /-- After refinement by φ, a non-φ-world cannot be as normal as a φ-world. -/
-theorem refine_separates (no : NormalityOrder W) (φ : W → Prop)
-    {w v : W} (hv : φ v) (hw : ¬φ w) :
-    ¬(no.refine φ).le w v :=
-  fun ⟨_, h⟩ => hw (h hv)
+theorem refine_separates (p : Preorder W) (φ : W → Prop)
+    {w v : W} (hv : φ v) (hw : ¬φ w) : ¬(refine p φ).le w v :=
+  fun h => hw ((refine_le.mp h).2 hv)
 
-/-- After refinement, if v was ≤ w and v is a φ-world while w is not,
-    then v strictly dominates w. -/
-theorem refine_promotes (no : NormalityOrder W) (φ : W → Prop)
-    {w v : W} (hv : φ v) (hw : ¬φ w) (hle : no.le v w) :
-    (no.refine φ).slt v w :=
-  ⟨⟨hle, fun _ => hv⟩, refine_separates no φ hv hw⟩
+/-! ### Respect and persistence -/
 
+/-- An ordering **respects** φ if it already promotes φ-worlds. -/
+def respects (p : Preorder W) (φ : W → Prop) : Prop :=
+  ∀ w v, p.le w v → φ v → φ w
 
--- ═══ Respect and Persistence ═══
+theorem refine_respects (p : Preorder W) (φ : W → Prop) : respects (refine p φ) φ :=
+  fun _ _ h hv => (refine_le.mp h).2 hv
 
-/-- An ordering **respects** φ if it already promotes φ-worlds:
-    whenever w ≤ v and v satisfies φ, then w satisfies φ too.
+/-- **Persistence**: respecting φ survives further refinement. -/
+theorem refine_preserves_respects (p : Preorder W) (φ ψ : W → Prop)
+    (h : respects p φ) : respects (refine p ψ) φ :=
+  fun w v hle => h w v (refine_le_imp hle)
 
-    This captures [veltman-1996]'s notion of "accepting" a default:
-    σ accepts "normally φ" iff σ's pattern already respects φ. -/
-def respects (no : NormalityOrder W) (φ : W → Prop) : Prop :=
-  ∀ w v, no.le w v → φ v → φ w
+theorem respects_refine_iff (p : Preorder W) (φ : W → Prop)
+    (h : respects p φ) {w v : W} : (refine p φ).le w v ↔ p.le w v :=
+  ⟨fun hle => (refine_le.mp hle).1, fun hle => refine_le.mpr ⟨hle, fun hv => h w v hle hv⟩⟩
 
-/-- Refinement by φ always produces an ordering that respects φ. -/
-theorem refine_respects (no : NormalityOrder W) (φ : W → Prop) :
-    (no.refine φ).respects φ := fun _ _ ⟨_, h⟩ => h
+/-- **Idempotency**: refining by φ twice is refining once (`inf_right_idem`). -/
+theorem refine_idempotent (p : Preorder W) (φ : W → Prop) :
+    refine (refine p φ) φ = refine p φ := inf_right_idem _ _
 
-/-- **Persistence**: if an ordering respects φ, further refinement by
-    any ψ still respects φ. Defaults are not undone by later defaults.
+/-- **Commutativity**: refinement order is immaterial (`inf_right_comm`). -/
+theorem refine_comm (p : Preorder W) (φ ψ : W → Prop) :
+    refine (refine p φ) ψ = refine (refine p ψ) φ := inf_right_comm _ _ _
 
-    [veltman-1996], Proposition 3.6(iv). -/
-theorem refine_preserves_respects (no : NormalityOrder W) (φ ψ : W → Prop)
-    (h : no.respects φ) : (no.refine ψ).respects φ :=
-  fun w v ⟨hle, _⟩ => h w v hle
+theorem crit_const_top (b : Prop) : crit (W := W) (fun _ => b) = ⊤ :=
+  le_antisymm le_top (fun _ _ _ => crit_le.mpr id)
 
-/-- When an ordering respects φ, its restriction to φ-worlds is the same
-    as the full ordering: refinement is idempotent on respected defaults. -/
-theorem respects_refine_iff (no : NormalityOrder W) (φ : W → Prop)
-    (h : no.respects φ) {w v : W} :
-    (no.refine φ).le w v ↔ no.le w v :=
-  ⟨fun ⟨hle, _⟩ => hle, fun hle => ⟨hle, h w v hle⟩⟩
+/-- Refining by the universal property is the identity (`inf_top_eq`). -/
+theorem refine_univ (p : Preorder W) : refine p (fun _ => True) = p := by
+  show p ⊓ crit (fun _ => True) = p
+  rw [crit_const_top True, inf_top_eq]
 
+theorem refine_empty (p : Preorder W) : refine p (fun _ => False) = p := by
+  show p ⊓ crit (fun _ => False) = p
+  rw [crit_const_top False, inf_top_eq]
 
-/-- **Idempotency**: refining by φ twice is the same as refining once.
+/-- If an ordering respects φ, refining by φ changes nothing. -/
+theorem refine_of_respects (p : Preorder W) (φ : W → Prop)
+    (h : respects p φ) : refine p φ = p :=
+  le_antisymm inf_le_left (fun w v hle => refine_le.mpr ⟨hle, fun hv => h w v hle hv⟩)
 
-    [veltman-1996], Proposition 3.6(ii): (ε ∘ e) ∘ e = ε ∘ e. -/
-theorem refine_idempotent (no : NormalityOrder W) (φ : W → Prop) :
-    (no.refine φ).refine φ = no.refine φ :=
-  ext fun _ _ => (respects_refine_iff (no.refine φ) φ (refine_respects no φ))
+theorem respects_no_domination (p : Preorder W) (φ : W → Prop)
+    (hresp : respects p φ) {w v : W} (hv : φ v) (hw : ¬φ w) : ¬p.le w v :=
+  fun hle => hw (hresp w v hle hv)
 
-/-- **Commutativity**: the order of refinements doesn't matter.
+/-! ### Connectedness and optimality -/
 
-    Follows from refinement being intersection with a set of pairs:
-    (ε ∘ e₁) ∘ e₂ = ε ∩ R(e₁) ∩ R(e₂) = (ε ∘ e₂) ∘ e₁. -/
-theorem refine_comm (no : NormalityOrder W) (φ ψ : W → Prop) :
-    (no.refine φ).refine ψ = (no.refine ψ).refine φ :=
-  ext fun _ _ => ⟨fun ⟨⟨h, hφ⟩, hψ⟩ => ⟨⟨h, hψ⟩, hφ⟩,
-                  fun ⟨⟨h, hψ⟩, hφ⟩ => ⟨⟨h, hφ⟩, hψ⟩⟩
-
-/-- Refining by the universal property is the identity. -/
-theorem refine_univ (no : NormalityOrder W) :
-    no.refine (fun _ => True) = no :=
-  ext fun _ _ => ⟨fun ⟨h, _⟩ => h, fun h => ⟨h, fun _ => True.intro⟩⟩
-
-/-- Refining by the empty property is the identity (vacuously). -/
-theorem refine_empty (no : NormalityOrder W) :
-    no.refine (fun _ => False) = no :=
-  ext fun _ _ => ⟨fun ⟨h, _⟩ => h, fun h => ⟨h, fun hf => hf.elim⟩⟩
-
-/-- **Respecting ordering equality**: if an ordering respects φ, then
-    refining by φ gives back the same ordering.
-
-    [veltman-1996]: ε ∘ e = ε when e is already a default in ε. -/
-theorem refine_of_respects (no : NormalityOrder W) (φ : W → Prop)
-    (h : no.respects φ) : no.refine φ = no :=
-  ext fun _ _ => respects_refine_iff no φ h
-
-
--- ═══ Connectedness and Optimality ═══
-
-/-- Under a **connected** ordering that respects φ, all optimal worlds
-    in a domain satisfy φ — provided the domain has at least one φ-world.
-
-    This generalizes `refine_total_optimal` beyond the total ordering.
-    Connectedness is essential: without it, a non-φ-world can be optimal
-    by being incomparable with all φ-worlds.
-
-    Note: [veltman-1996] Proposition 3.4(i) states this without the
-    connectedness assumption, but his proof implicitly relies on states
-    being reachable from the total ordering, which ensures connectedness
-    after a single refinement. After multiple refinements by "crossing"
-    properties, connectedness can fail and the result no longer holds
-    for arbitrary respecting orderings. -/
-theorem optimal_of_respects_connected (no : NormalityOrder W)
-    (φ : W → Prop) (d : Set W) (hresp : no.respects φ)
-    (hconn : no.connected) (hex : ∃ w ∈ d, φ w) :
-    no.optimal d ⊆ { w ∈ d | φ w } := by
-  intro w ⟨hwd, hopt⟩
+theorem optimal_of_respects_connected (p : Preorder W)
+    (φ : W → Prop) (d : Set W) (hresp : respects p φ)
+    (hconn : connected p) (hex : ∃ w ∈ d, φ w) :
+    optimal p d ⊆ { w ∈ d | φ w } := by
+  intro w hw
+  rw [mem_optimal] at hw
+  obtain ⟨hwd, hopt⟩ := hw
   obtain ⟨v, hvd, hφv⟩ := hex
   refine ⟨hwd, ?_⟩
   rcases hconn w v with hwv | hvw
   · exact hresp w v hwv hφv
-  · exact hresp w v (hopt v hvd hvw) hφv
+  · exact hresp w v (hopt hvd hvw) hφv
 
-
--- ═══ Key Theorem ═══
-
-/-- **Refinement makes φ-worlds optimal.** Starting from the total
-    ordering, refining by φ makes the optimal worlds in any domain d
-    exactly the φ-worlds in d — provided at least one φ-world exists.
-
-    This is the mathematical core of Veltman's system: "normally φ"
-    followed by "presumably φ" succeeds, because refinement guarantees
-    φ-worlds become the most normal. -/
-theorem refine_total_optimal (φ : W → Prop) (d : Set W)
-    (hex : ∃ w ∈ d, φ w) :
-    (total.refine φ).optimal d = { w ∈ d | φ w } := by
+/-- **Refinement makes φ-worlds optimal**: from the total order, refining by
+    φ makes the optimal worlds in `d` exactly the φ-worlds in `d`. -/
+theorem refine_total_optimal (φ : W → Prop) (d : Set W) (hex : ∃ w ∈ d, φ w) :
+    optimal (refine total φ) d = { w ∈ d | φ w } := by
   ext w
+  rw [mem_optimal, Set.mem_setOf_eq]
   constructor
-  · -- → : optimal implies φ
-    intro ⟨hwd, hopt⟩
+  · rintro ⟨hwd, hopt⟩
     obtain ⟨v, hvd, hφv⟩ := hex
     refine ⟨hwd, ?_⟩
     by_contra hnφw
-    -- v ≤' w: total gives True, φ w → φ v is vacuous since ¬φ w
-    have hle : (total.refine φ).le v w :=
-      ⟨True.intro, fun h => absurd h hnφw⟩
-    -- By optimality: w ≤' v, giving φ v → φ w. With φ v → φ w. Contradiction.
-    exact hnφw ((hopt v hvd hle).2 hφv)
-  · -- ← : φ-world is optimal
-    intro ⟨hwd, hφw⟩
-    exact ⟨hwd, fun _ _ _ => ⟨True.intro, fun _ => hφw⟩⟩
+    have hle : (refine total φ).le v w := refine_le.mpr ⟨trivial, fun h => absurd h hnφw⟩
+    exact hnφw ((refine_le.mp (hopt hvd hle)).2 hφv)
+  · rintro ⟨hwd, hφw⟩
+    exact ⟨hwd, fun _ _ _ => refine_le.mpr ⟨trivial, fun _ => hφw⟩⟩
 
-/-- An optimal φ-world under `no` remains optimal under `no.refine φ`.
+theorem optimal_refine_of_mem (p : Preorder W) (φ : W → Prop)
+    (d : Set W) {w : W} (hopt : w ∈ optimal p d) (hφ : φ w) :
+    w ∈ optimal (refine p φ) d := by
+  rw [mem_optimal] at hopt ⊢
+  exact ⟨hopt.1, fun v hv hle =>
+    refine_le.mpr ⟨hopt.2 hv (refine_le.mp hle).1, fun _ => hφ⟩⟩
 
-    If w is optimal in d (no world in d strictly dominates it) and w
-    satisfies φ, then w is still optimal in d after refinement by φ.
-    This is the core lemma for coherence preservation (Proposition 4.7):
-    refinement can't destroy the optimality of worlds that satisfy the
-    refinement property. -/
-theorem optimal_refine_of_mem (no : NormalityOrder W) (φ : W → Prop)
-    (d : Set W) {w : W} (hopt : w ∈ no.optimal d) (hφ : φ w) :
-    w ∈ (no.refine φ).optimal d :=
-  ⟨hopt.1, fun v hv ⟨hle, _⟩ => ⟨hopt.2 v hv hle, fun _ => hφ⟩⟩
-
-/-- Refinement preserves nonemptiness of optimal sets when the original
-    optimal set contains φ-worlds. -/
-theorem optimal_refine_nonempty (no : NormalityOrder W) (φ : W → Prop)
-    (d : Set W) (hex : ∃ w ∈ no.optimal d, φ w) :
-    (no.refine φ).optimal d |>.Nonempty := by
+theorem optimal_refine_nonempty (p : Preorder W) (φ : W → Prop)
+    (d : Set W) (hex : ∃ w ∈ optimal p d, φ w) :
+    (optimal (refine p φ) d).Nonempty := by
   obtain ⟨w, hopt, hφ⟩ := hex
-  exact ⟨w, optimal_refine_of_mem no φ d hopt hφ⟩
+  exact ⟨w, optimal_refine_of_mem p φ d hopt hφ⟩
 
-/-- When the ordering respects φ, no non-φ-world can dominate a φ-world.
-    Combined with optimality, this constrains which worlds can be optimal. -/
-theorem respects_no_domination (no : NormalityOrder W) (φ : W → Prop)
-    (hresp : no.respects φ) {w v : W} (hv : φ v) (hw : ¬φ w) :
-    ¬no.le w v :=
-  fun hle => hw (hresp w v hle hv)
+/-! ### Construction from propositions ([kratzer-1981]) -/
 
+/-- Construct a normality ordering from a list of propositions:
+    `w ≤ v` iff every proposition satisfied by `v` is satisfied by `w`.
+    This is `Preorder.ofCriteria` with the ordering source as criteria. -/
+@[reducible] def fromProps (props : List (W → Prop)) : Preorder W :=
+  Preorder.ofCriteria (fun w p => p w) {p | p ∈ props}
 
--- ═══ Construction from Propositions ═══
-
-/-- Repackage a `Preorder` as a `NormalityOrder`. -/
-def ofPreorder (p : Preorder W) : NormalityOrder W where
-  le := p.le
-  le_refl := p.le_refl
-  le_trans u v w := p.le_trans u v w
-
-/-- Construct a normality ordering from a list of propositions.
-    w ≤ v iff every proposition satisfied by v is also satisfied by w —
-    the criteria-derived preorder `Preorder.ofCriteria` with the ordering
-    source as criteria, repackaged.
-
-    This is [kratzer-1981]'s ordering source construction:
-    {p ∈ A : v ∈ p} ⊆ {p ∈ A : w ∈ p}.
-    `Semantics.Modality.Kratzer.kratzerNormality` is definitionally this;
-    `kratzerPlausibility` in `BeliefRevision.lean` adds smoothness. -/
-def fromProps (props : List (W → Prop)) : NormalityOrder W :=
-  ofPreorder (Preorder.ofCriteria (fun w p => p w) {p | p ∈ props})
-
-/-- The empty ordering source gives the total ordering. -/
 theorem fromProps_nil {w v : W} : (fromProps ([] : List (W → Prop))).le w v :=
   fun _ h => nomatch h
 
-/-- Adding a proposition to the ordering source refines it. -/
 theorem fromProps_cons_le (p : W → Prop) (ps : List (W → Prop))
-    {w v : W} (h : (fromProps (p :: ps)).le w v) :
-    (fromProps ps).le w v :=
+    {w v : W} (h : (fromProps (p :: ps)).le w v) : (fromProps ps).le w v :=
   fun q hq => h q (List.mem_cons_of_mem p hq)
 
-/-- Refining from the total ordering always gives a connected ordering.
-
-    In the total ordering, every pair is related in both directions.
-    After one refinement by φ, the ordering `(φ v → φ w)` is still
-    connected because material implication between truth values always
-    holds in at least one direction.
-
-    This does NOT generalize to arbitrary connected orderings: if only
-    `w ≤ v` holds (not `v ≤ w`) and φ(v), ¬φ(w), neither refined
-    direction holds. And after two refinements by "crossing" properties,
-    connectedness can fail entirely. -/
 theorem refine_total_connected (φ : W → Prop) :
-    (total.refine φ : NormalityOrder W).connected := by
+    connected (refine total φ : Preorder W) := by
   intro w v
   by_cases hφw : φ w
-  · left; exact ⟨True.intro, fun _ => hφw⟩
+  · exact Or.inl (refine_le.mpr ⟨trivial, fun _ => hφw⟩)
   · by_cases hφv : φ v
-    · right; exact ⟨True.intro, fun h => absurd h hφw⟩
-    · left; exact ⟨True.intro, fun h => absurd h hφv⟩
+    · exact Or.inr (refine_le.mpr ⟨trivial, fun h => absurd h hφw⟩)
+    · exact Or.inl (refine_le.mpr ⟨trivial, fun h => absurd h hφv⟩)
 
--- ═══ Darwiche-Pearl Representation Conditions ═══
+/-! ### Darwiche-Pearl representation conditions
 
-/-! [darwiche-pearl-1997], Definition 8. Conditions on how a total
-    pre-order (faithful assignment) may change under revision by μ.
-    These are the representation-theorem equivalents of the iterated
-    revision postulates C1–C4. They constrain how *any* ordering-based
-    semantics — Kratzer modals, Lewis conditionals, Veltman defaults —
-    should evolve under discourse update.
+[darwiche-pearl-1997]: conditions on how a total preorder may change under
+revision by `μ`. `prior`/`post` are the orderings before/after revision. -/
 
-    `prior` and `post` are the orderings before and after revision by μ.
-    Lower in the ordering = more normal/plausible. -/
+/-- CR1: the ordering among μ-worlds is preserved. -/
+@[reducible] def satisfies_CR1 (prior post : Preorder W) (μ : W → Bool) : Prop :=
+  ∀ w v, μ w = true → μ v = true → (prior.le w v ↔ post.le w v)
 
-/-- CR1: The ordering among μ-worlds is preserved. -/
-@[reducible] def satisfies_CR1 (prior post : NormalityOrder W) (μ : W → Bool) : Prop :=
-  ∀ w v, μ w = true → μ v = true →
-    (prior.le w v ↔ post.le w v)
+/-- CR2: the ordering among ¬μ-worlds is preserved. -/
+@[reducible] def satisfies_CR2 (prior post : Preorder W) (μ : W → Bool) : Prop :=
+  ∀ w v, μ w = false → μ v = false → (prior.le w v ↔ post.le w v)
 
-/-- CR2: The ordering among ¬μ-worlds is preserved. -/
-@[reducible] def satisfies_CR2 (prior post : NormalityOrder W) (μ : W → Bool) : Prop :=
-  ∀ w v, μ w = false → μ v = false →
-    (prior.le w v ↔ post.le w v)
-
-/-- CR3: If a μ-world was strictly below a ¬μ-world, it stays strictly below. -/
-@[reducible] def satisfies_CR3 (prior post : NormalityOrder W) (μ : W → Bool) : Prop :=
+/-- CR3: a μ-world strictly below a ¬μ-world stays strictly below. The strict
+    order is spelled `le … ∧ ¬ le …` (definitionally `<`) so the relation is
+    decidable on finite world sets. -/
+@[reducible] def satisfies_CR3 (prior post : Preorder W) (μ : W → Bool) : Prop :=
   ∀ w v, μ w = true → μ v = false →
-    prior.slt w v → post.slt w v
+    (prior.le w v ∧ ¬ prior.le v w) → (post.le w v ∧ ¬ post.le v w)
 
-/-- CR4: If a μ-world was ≤ a ¬μ-world, it stays ≤. -/
-@[reducible] def satisfies_CR4 (prior post : NormalityOrder W) (μ : W → Bool) : Prop :=
-  ∀ w v, μ w = true → μ v = false →
-    prior.le w v → post.le w v
+/-- CR4: a μ-world ≤ a ¬μ-world stays ≤. -/
+@[reducible] def satisfies_CR4 (prior post : Preorder W) (μ : W → Bool) : Prop :=
+  ∀ w v, μ w = true → μ v = false → prior.le w v → post.le w v
 
-end NormalityOrder
+end Normality
 end Core.Order

--- a/Linglib/Core/Order/Plausibility.lean
+++ b/Linglib/Core/Order/Plausibility.lean
@@ -2,144 +2,106 @@ import Linglib.Core.Order.Normality
 import Mathlib.Data.Set.Basic
 
 /-!
-# Plausibility Orderings and Preferential Consequence
+# Plausibility orderings and preferential consequence
 
 [kraus-magidor-1990] [halpern-2003]
 
-Plausibility orderings and preferential consequence relations are the
-general mathematical structures underlying default reasoning. This file
-extracts them from the AGM-specific machinery in `BeliefRevision.lean`,
-placing them in `Core/Order/` alongside `NormalityOrder`.
+A *plausibility ordering* is a `Preorder` on worlds together with a
+**smoothness** (stopperedness) property: every satisfiable proposition has a
+minimal element below any witness. The most-plausible φ-worlds are mathlib's
+`Minimal` (= `Normality.optimal`). This replaces the former
+`PlausibilityOrder extends NormalityOrder` hand-rolled structure.
 
-## Key definitions
+## Main definitions
 
-- `PlausibilityOrder W`: `NormalityOrder` + smoothness (every satisfiable
-  proposition has minimal elements)
-- `PreferentialConsequence W`: System P axioms for `φ |~ ψ`
-- `rationalMonotonicity`: the stronger property satisfied by ranked models
-- `PlausibilityOrder.toPreferential`: the sound construction
-
-## Architecture
-
-```
-Core/Order/Normality.lean      — NormalityOrder (preorder on worlds)
-    ↓ extends
-Core/Order/Plausibility.lean   — PlausibilityOrder + System P
-    ↑ uses                         ↑ uses
-Core/Logic/RankingFunction.lean    Core/Logic/BeliefRevision.lean (AGM)
-Core/Logic/SystemZ.lean
-```
+- `Smooth p` — [kraus-magidor-1990]'s stopperedness for a `Preorder`.
+- `PlausibilityOrder W` — a `Preorder W` bundled with `Smooth`.
+- `PreferentialConsequence W` — System P for `φ |~ ψ`.
+- `PlausibilityOrder.toPreferential` — soundness for System P.
 -/
 
 namespace Core.Order
 
--- ══════════════════════════════════════════════════════════════════════
--- § 1. Preferential Consequence (System P)
--- ══════════════════════════════════════════════════════════════════════
+/-! ### Preferential consequence (System P) -/
 
 /-- A preferential consequence relation: `φ |~ ψ` reads "normally, if φ then ψ".
-
-    System P axiomatizes the minimal
-    properties of default reasoning. [halpern-2003] shows that
-    System P is sound and complete for preferential models — structures
-    where worlds are ordered by plausibility, and `φ |~ ψ` iff ψ holds
-    at all most-plausible φ-worlds. -/
+    System P axiomatizes the minimal properties of default reasoning;
+    [halpern-2003] shows soundness and completeness for preferential models. -/
 structure PreferentialConsequence (W : Type*) where
   /-- The default consequence relation: `default φ ψ` means φ |~ ψ -/
   default : Set W → Set W → Prop
-
   /-- Reflexivity: φ |~ φ -/
   refl : ∀ φ, default φ φ
-
   /-- Left Logical Equivalence: if φ ↔ ψ then (φ |~ χ ↔ ψ |~ χ) -/
-  leftEquiv : ∀ φ ψ χ,
-    (∀ w, φ w ↔ ψ w) → (default φ χ ↔ default ψ χ)
-
+  leftEquiv : ∀ φ ψ χ, (∀ w, φ w ↔ ψ w) → (default φ χ ↔ default ψ χ)
   /-- Right Weakening: if φ |~ ψ and ψ → χ, then φ |~ χ -/
-  rightWeaken : ∀ φ ψ χ,
-    default φ ψ → (∀ w, ψ w → χ w) → default φ χ
-
+  rightWeaken : ∀ φ ψ χ, default φ ψ → (∀ w, ψ w → χ w) → default φ χ
   /-- And: if φ |~ ψ and φ |~ χ, then φ |~ (ψ ∧ χ) -/
-  and_ : ∀ φ ψ χ,
-    default φ ψ → default φ χ → default φ (fun w => ψ w ∧ χ w)
-
+  and_ : ∀ φ ψ χ, default φ ψ → default φ χ → default φ (fun w => ψ w ∧ χ w)
   /-- Or: if φ |~ χ and ψ |~ χ, then (φ ∨ ψ) |~ χ -/
-  or_ : ∀ φ ψ χ,
-    default φ χ → default ψ χ →
-    default (fun w => φ w ∨ ψ w) χ
-
+  or_ : ∀ φ ψ χ, default φ χ → default ψ χ → default (fun w => φ w ∨ ψ w) χ
   /-- Cautious Monotonicity: if φ |~ ψ and φ |~ χ, then (φ ∧ ψ) |~ χ -/
-  cautiousMono : ∀ φ ψ χ,
-    default φ ψ → default φ χ →
-    default (fun w => φ w ∧ ψ w) χ
+  cautiousMono : ∀ φ ψ χ, default φ ψ → default φ χ → default (fun w => φ w ∧ ψ w) χ
 
 /-- Rational Monotonicity: if φ |~ χ and ¬(φ |~ ¬ψ), then (φ ∧ ψ) |~ χ.
-
-    This is strictly stronger than System P. [halpern-2003] shows
-    it corresponds to ranked (well-ordered) plausibility models, not
-    merely preferential ones. -/
+    Strictly stronger than System P; [halpern-2003] ties it to ranked models. -/
 def rationalMonotonicity {W : Type*} (pc : PreferentialConsequence W) : Prop :=
   ∀ φ ψ χ : Set W,
     pc.default φ χ → ¬pc.default φ (fun w => ¬ψ w) →
     pc.default (fun w => φ w ∧ ψ w) χ
 
--- ══════════════════════════════════════════════════════════════════════
--- § 2. Plausibility Orderings
--- ══════════════════════════════════════════════════════════════════════
+/-! ### Plausibility orderings -/
 
-/-- A plausibility ordering on worlds: w₁ ≤ w₂ means w₁ is at least
-    as plausible as w₂. The minimal elements of a proposition A are
-    the most plausible A-worlds.
+/-- **Smoothness** ([kraus-magidor-1990] stopperedness): every satisfiable φ
+    has a minimal element below any witness. Automatic for finite `W`; for
+    infinite `W` it is the well-foundedness condition ruling out infinite
+    descending chains. -/
+def Smooth {W : Type*} (p : Preorder W) : Prop :=
+  ∀ (φ : Set W) (w : W), φ w →
+    ∃ v, φ v ∧ p.le v w ∧ ∀ u, φ u → p.le u v → p.le v u
 
-    Extends `NormalityOrder` with the **smoothness condition** (also
-    called "limit assumption"): every satisfiable proposition has
-    minimal elements. This is automatic for finite W; for infinite W
-    it rules out infinite descending chains. [kraus-magidor-1990] call this
-    "stopperedness". -/
-structure PlausibilityOrder (W : Type*) extends NormalityOrder W where
-  /-- Smoothness: every satisfiable φ has a minimal element -/
-  smooth : ∀ (φ : Set W) (w : W), φ w →
-    ∃ v, φ v ∧ le v w ∧ ∀ u, φ u → le u v → le v u
+/-- A plausibility ordering: a `Preorder` with the smoothness property.
+    `toPreorder.le w v` means `w` is at least as plausible as `v`. -/
+structure PlausibilityOrder (W : Type*) where
+  /-- The underlying plausibility preorder. -/
+  toPreorder : Preorder W
+  /-- Smoothness / stopperedness. -/
+  smooth : Smooth toPreorder
 
-/-- The most plausible worlds satisfying φ: those with no strictly
-    more plausible φ-world.
-
-    This is the same as `NormalityOrder.optimal` applied to the set
-    `{w | φ w}`, but stated with `Prop'` for the System P interface. -/
+/-- The most plausible φ-worlds: those with no strictly more plausible
+    φ-world. The same as `Normality.optimal toPreorder φ`. -/
 def PlausibilityOrder.minimal {W : Type*} (po : PlausibilityOrder W)
     (φ : Set W) : Set W :=
-  fun w => φ w ∧ ∀ v, φ v → po.le v w → po.le w v
+  fun w => φ w ∧ ∀ v, φ v → po.toPreorder.le v w → po.toPreorder.le w v
 
 /-- A plausibility ordering induces a preferential consequence relation:
-    φ |~ ψ iff all minimal φ-worlds satisfy ψ.
-
-    [halpern-2003], Theorem 8.1.1: System P is sound and complete for
-    this semantics. -/
+    φ |~ ψ iff all minimal φ-worlds satisfy ψ. [halpern-2003]: System P is
+    sound and complete for this semantics. -/
 def PlausibilityOrder.toPreferential {W : Type*}
     (po : PlausibilityOrder W) : PreferentialConsequence W where
   default := fun φ ψ => ∀ w, po.minimal φ w → ψ w
-  refl := fun φ w ⟨hφ, _⟩ => hφ
+  refl := fun _ _ ⟨hφ, _⟩ => hφ
   leftEquiv := fun φ ψ χ hEquiv => by
     constructor
     · intro h w ⟨hψ, hmin⟩
       exact h w ⟨(hEquiv w).mpr hψ, fun v hv hle => hmin v ((hEquiv v).mp hv) hle⟩
     · intro h w ⟨hφ, hmin⟩
       exact h w ⟨(hEquiv w).mp hφ, fun v hv hle => hmin v ((hEquiv v).mpr hv) hle⟩
-  rightWeaken := fun φ ψ χ hdef hent w hmin => hent w (hdef w hmin)
-  and_ := fun φ ψ χ hψ hχ w hmin => ⟨hψ w hmin, hχ w hmin⟩
-  or_ := fun φ ψ χ hφχ hψχ w ⟨hφψ, hmin⟩ =>
+  rightWeaken := fun _ _ _ hdef hent w hmin => hent w (hdef w hmin)
+  and_ := fun _ _ _ hψ hχ w hmin => ⟨hψ w hmin, hχ w hmin⟩
+  or_ := fun _ _ _ hφχ hψχ w ⟨hφψ, hmin⟩ =>
     hφψ.elim
       (fun hφ => hφχ w ⟨hφ, fun v hv hle => hmin v (Or.inl hv) hle⟩)
       (fun hψ => hψχ w ⟨hψ, fun v hv hle => hmin v (Or.inr hv) hle⟩)
-  cautiousMono := fun φ ψ χ hψ hχ w ⟨⟨hφ, hψw⟩, hmin⟩ => by
+  cautiousMono := fun φ ψ χ hψ hχ w ⟨⟨hφ, _⟩, hmin⟩ => by
     obtain ⟨v, hφv, hvw, hmin_v⟩ := po.smooth φ w hφ
     have hψv : ψ v := hψ v ⟨hφv, hmin_v⟩
     have hwv := hmin v ⟨hφv, hψv⟩ hvw
-    have hmin_w : ∀ u, φ u → po.le u w → po.le w u := by
+    have hmin_w : ∀ u, φ u → po.toPreorder.le u w → po.toPreorder.le w u := by
       intro u hφu huw
-      have huv := po.le_trans u w v huw hwv
+      have huv := po.toPreorder.le_trans u w v huw hwv
       have hvu := hmin_v u hφu huv
-      exact po.le_trans w v u hwv hvu
+      exact po.toPreorder.le_trans w v u hwv hvu
     exact hχ w ⟨hφ, hmin_w⟩
 
 end Core.Order

--- a/Linglib/Core/Order/PreorderLattice.lean
+++ b/Linglib/Core/Order/PreorderLattice.lean
@@ -1,0 +1,91 @@
+import Mathlib.Order.Basic
+import Mathlib.Order.CompleteLattice.Basic
+
+/-!
+# The complete lattice of preorders on a type
+
+[UPSTREAM] candidate. This mirrors `CompleteLattice (Setoid α)`
+(`Mathlib.Data.Setoid.Basic`) for preorders: the preorders on a fixed type
+`α`, ordered by relation inclusion (`p ≤ q` iff every `p`-related pair is
+`q`-related), form a complete lattice.
+
+* `⊤` is the **total** preorder (everything related) — the coarsest order.
+* `⊥` is equality `(· = ·)` — the finest preorder.
+* `p ⊓ q` is the **intersection** of the two relations.
+* `⨅ i, p i` (`sInf`) is the intersection of a family.
+
+This is the order-theoretic substrate of *refinement* in default-reasoning
+and conditional semantics: refining a normality/plausibility ordering by a
+criterion is meet with that criterion's induced preorder, so the refinement
+calculus (commutativity, idempotence, the total order as unit) is just the
+meet-semilattice laws. `Preorder.lift` (mathlib) supplies the criterion
+orders; this file supplies the algebra that combines them.
+
+`Mathlib` has `CompleteLattice (Setoid α)` but no order structure on
+`Preorder α`; this fills that gap.
+-/
+
+namespace Preorder
+
+variable {α : Type*}
+
+/-- Smart constructor: a `Preorder` from a reflexive-transitive relation,
+    with the strict order taken canonically (`a < b ↔ a ≤ b ∧ ¬ b ≤ a`).
+    Avoids the default-`lt` synthesis failing on relations built pointwise. -/
+@[reducible] def ofLE (r : α → α → Prop) (hrefl : ∀ a, r a a)
+    (htrans : ∀ a b c, r a b → r b c → r a c) : Preorder α where
+  le := r
+  le_refl := hrefl
+  le_trans := htrans
+  lt a b := r a b ∧ ¬ r b a
+  lt_iff_le_not_ge _ _ := Iff.rfl
+
+/-- Preorders are ordered by relation inclusion: `p ≤ q` iff every pair
+    related by `p` is related by `q` (i.e. `p` is finer). -/
+instance : LE (Preorder α) where
+  le p q := ∀ ⦃a b⦄, p.le a b → q.le a b
+
+theorem le_def {p q : Preorder α} : p ≤ q ↔ ∀ ⦃a b⦄, p.le a b → q.le a b :=
+  Iff.rfl
+
+instance : PartialOrder (Preorder α) where
+  le := (· ≤ ·)
+  lt p q := p ≤ q ∧ ¬ q ≤ p
+  le_refl _ _ _ h := h
+  le_trans _ _ _ hpq hqr _ _ h := hqr (hpq h)
+  lt_iff_le_not_ge _ _ := Iff.rfl
+  le_antisymm _ _ hpq hqp :=
+    Preorder.toLE_injective (LE.ext (funext fun _ => funext fun _ =>
+      propext ⟨fun h => hpq h, fun h => hqp h⟩))
+
+instance : InfSet (Preorder α) where
+  sInf S := ofLE (fun a b => ∀ p ∈ S, p.le a b)
+    (fun a p _ => p.le_refl a)
+    (fun a b c hab hbc p hp => p.le_trans a b c (hab p hp) (hbc p hp))
+
+instance : CompleteLattice (Preorder α) :=
+  { (completeLatticeOfInf (Preorder α) fun _ =>
+      ⟨fun _ hp _ _ h => h _ hp, fun _ hr _ _ h _ hr' => hr hr' h⟩) with
+    inf p q := ofLE (fun a b => p.le a b ∧ q.le a b)
+      (fun a => ⟨p.le_refl a, q.le_refl a⟩)
+      (fun a b c hab hbc =>
+        ⟨p.le_trans a b c hab.1 hbc.1, q.le_trans a b c hab.2 hbc.2⟩)
+    inf_le_left := fun _ _ _ _ h => h.1
+    inf_le_right := fun _ _ _ _ h => h.2
+    le_inf := fun _ _ _ h1 h2 _ _ h => ⟨h1 h, h2 h⟩
+    top := ofLE (fun _ _ => True) (fun _ => trivial) (fun _ _ _ _ _ => trivial)
+    le_top := fun _ _ _ _ => trivial
+    bot := ofLE (· = ·) (fun _ => rfl) (fun _ _ _ h1 h2 => h1.trans h2)
+    bot_le := fun p _ _ h => h ▸ p.le_refl _ }
+
+@[simp] theorem top_le (a b : α) : (⊤ : Preorder α).le a b := trivial
+
+@[simp] theorem bot_le_iff {a b : α} : (⊥ : Preorder α).le a b ↔ a = b := Iff.rfl
+
+theorem inf_le_iff {p q : Preorder α} {a b : α} :
+    (p ⊓ q).le a b ↔ p.le a b ∧ q.le a b := Iff.rfl
+
+theorem sInf_le_iff {S : Set (Preorder α)} {a b : α} :
+    (sInf S).le a b ↔ ∀ p ∈ S, p.le a b := Iff.rfl
+
+end Preorder

--- a/Linglib/Core/Order/Satisfaction.lean
+++ b/Linglib/Core/Order/Satisfaction.lean
@@ -129,13 +129,14 @@ theorem equivalent_trans (o : SatisfactionOrdering α Criterion) {a b c : α}
     (hab : o.equivalent a b) (hbc : o.equivalent b c) : o.equivalent a c :=
   ⟨o.le_trans a b c hab.1 hbc.1, o.le_trans c b a hbc.2 hab.2⟩
 
-/-! ## NormalityOrder projection -/
+/-! ## Normality-ordering projection -/
 
-/-- The induced `NormalityOrder`: connects satisfaction-based orderings
-    (Kratzer modal semantics, Phillips-Brown desire) to the default reasoning
-    infrastructure (`optimal`, `refine`, `respects`, CR1–CR4). -/
-def toNormalityOrder (o : SatisfactionOrdering α Criterion) : NormalityOrder α :=
-  .ofPreorder o.toPreorder
+/-- The induced normality ordering — just the underlying `Preorder`, which
+    connects satisfaction-based orderings (Kratzer modal semantics,
+    Phillips-Brown desire) to the default-reasoning infrastructure
+    (`Normality.optimal`, `Normality.refine`, `Normality.respects`, CR1–CR4). -/
+def toNormalityOrder (o : SatisfactionOrdering α Criterion) : Preorder α :=
+  o.toPreorder
 
 /-! ## Maxima and undominated elements -/
 

--- a/Linglib/Core/Order/SimilarityOrdering.lean
+++ b/Linglib/Core/Order/SimilarityOrdering.lean
@@ -1,123 +1,102 @@
-import Mathlib.Data.Set.Basic
-import Mathlib.Data.Finset.Filter
+import Mathlib.Order.Minimal
 import Mathlib.Order.Preorder.Finite
-import Linglib.Core.Order.Normality
+import Mathlib.Data.Finset.Filter
+import Linglib.Core.Order.PreorderLattice
 
 /-!
 # Similarity orderings
 
 [lewis-1973] [stalnaker-1968]
 
-A `SimilarityOrdering W` equips a type of worlds with a *centered* ternary
-relation `closer w₀ w₁ w₂` ("`w₁` is at least as close to `w₀` as `w₂` is")
-that is reflexive and transitive in the second/third arguments at every
-center. This is the order-theoretic substrate of variably-strict
-counterfactuals ([lewis-1973] / [stalnaker-1968]) and of any
-"closest-world" semantics — selectional, supervaluation, homogeneity, etc.
+A `SimilarityOrdering W` is a **centered family of preorders**: for each
+center `w₀`, `atCenter w₀` is the closeness `Preorder` (`(atCenter w₀).le w₁ w₂`
+means `w₁` is at least as close to `w₀` as `w₂`). This replaces the former
+hand-rolled ternary relation `closer` with per-center reflexivity/transitivity
+fields — those are now just the `Preorder` axioms of `atCenter w₀`.
 
-The structure lives in `Core.Order` (not `Conditionals`) because it is a
-general-purpose primitive: it is used directly by counterfactual operators
-in `Semantics/Conditionals/`, by alternative-sensitive operators
-([santorio-2018]), by causal psycholinguistic models in
-`Semantics/Causation/`, and by any future "closest match" theory.
+The closest worlds are mathlib's `Minimal`, and the Limit Assumption is
+`Set.Finite.exists_minimal`.
 
 ## Key operations
 
-- `closer w₀ w₁ w₂` — the relation itself (reflexive, transitive)
-- `closestWorlds w₀ A` — minimal elements of a `Finset` under `closer`
-- `atCenter w₀` — coerce to a `Core.Order.NormalityOrder` centered at `w₀`
-- `isCentered` — strong centering: `w` is the unique closest world to itself
-- `candidateSelections` — the set of selection-function candidates induced
-  by the ordering (bridge to Stalnaker selection)
+- `atCenter w₀` — the closeness preorder centered at `w₀`.
+- `closer w₀ w₁ w₂` — `(atCenter w₀).le w₁ w₂`, the ternary closeness relation.
+- `closestWorlds w₀ A` — minimal elements of a `Finset` under `closer w₀`.
+- `isCentered` — strong centering ([lewis-1973]).
 - `≤[sim, w₀]` notation: `w₁ ≤[sim, w₀] w₂` reads "`w₁` is at least as
-  similar to `w₀` as `w₂` is" ([lewis-1973]-style notation)
-
-## Connection to selection functions
-
-`Semantics.Conditionals.SelectionFunction` and `SimilarityOrdering` are dual presentations of
-the same intuition. A coherent selection function induces a similarity
-ordering via the `coherentSelectionToSimilarity` constructor (which lives
-in `Semantics/Conditionals/Basic.lean` because it depends on
-selection-function machinery from `Semantics.Conditionals.SelectionFunction`).
+  similar to `w₀` as `w₂` is".
 -/
 
 namespace Core.Order
 
 /-! ## Structure -/
 
-/-- A **similarity ordering** on worlds: a centered ternary relation
-    `closer w₀ w₁ w₂` saying that `w₁` is at least as close to `w₀` as
-    `w₂` is, reflexive and transitive in `w₁`/`w₂`/`w₃` at each center
-    `w₀`. -/
+/-- A **similarity ordering**: a centered family of preorders. `atCenter w₀`
+    is the closeness preorder centered at `w₀`. -/
 structure SimilarityOrdering (W : Type*) where
-  /-- `closer w₀ w₁ w₂` means `w₁` is at least as close to `w₀` as `w₂` is. -/
-  closer : W → W → W → Prop
-  /-- Every world is at least as close to any center as itself. -/
-  closer_refl (w₀ w : W) : closer w₀ w w
-  /-- Transitivity in the candidate arguments at a fixed center. -/
-  closer_trans (w₀ w₁ w₂ w₃ : W) :
-    closer w₀ w₁ w₂ → closer w₀ w₂ w₃ → closer w₀ w₁ w₃
-  /-- The relation is decidable. -/
-  closerDec (w₀ w₁ w₂ : W) : Decidable (closer w₀ w₁ w₂)
-
-instance {W : Type*} (sim : SimilarityOrdering W) (w₀ w₁ w₂ : W) :
-    Decidable (sim.closer w₀ w₁ w₂) :=
-  sim.closerDec w₀ w₁ w₂
+  /-- The closeness preorder centered at each world. -/
+  atCenter : W → Preorder W
+  /-- Closeness is decidable at each center. -/
+  decClose : ∀ w₀ w₁ w₂, Decidable ((atCenter w₀).le w₁ w₂)
 
 namespace SimilarityOrdering
 
 variable {W : Type*}
 
+/-- `closer w₀ w₁ w₂` means `w₁` is at least as close to `w₀` as `w₂` is —
+    the `≤` of the preorder centered at `w₀`. -/
+@[reducible] def closer (sim : SimilarityOrdering W) (w₀ w₁ w₂ : W) : Prop :=
+  (sim.atCenter w₀).le w₁ w₂
+
+instance (sim : SimilarityOrdering W) (w₀ w₁ w₂ : W) :
+    Decidable (sim.closer w₀ w₁ w₂) :=
+  sim.decClose w₀ w₁ w₂
+
+/-- Every world is at least as close to any center as itself. -/
+theorem closer_refl (sim : SimilarityOrdering W) (w₀ w : W) : sim.closer w₀ w w :=
+  (sim.atCenter w₀).le_refl w
+
+/-- Transitivity of closeness at a fixed center. -/
+theorem closer_trans (sim : SimilarityOrdering W) (w₀ w₁ w₂ w₃ : W) :
+    sim.closer w₀ w₁ w₂ → sim.closer w₀ w₂ w₃ → sim.closer w₀ w₁ w₃ :=
+  (sim.atCenter w₀).le_trans w₁ w₂ w₃
+
 /-! ## Constructors -/
 
 /-- Construct a `SimilarityOrdering` from a `Bool`-valued function.
-    Reflexivity and transitivity proofs can typically be discharged by
-    `decide` on finite types. -/
+    Reflexivity and transitivity can typically be discharged by `decide`. -/
 def ofBool (f : W → W → W → Bool)
     (hrefl : ∀ w₀ w, f w₀ w w = true)
     (htrans : ∀ w₀ w₁ w₂ w₃, f w₀ w₁ w₂ = true → f w₀ w₂ w₃ = true →
       f w₀ w₁ w₃ = true) :
     SimilarityOrdering W where
-  closer w₀ w₁ w₂ := f w₀ w₁ w₂ = true
-  closer_refl := hrefl
-  closer_trans w₀ w₁ w₂ w₃ := htrans w₀ w₁ w₂ w₃
-  closerDec _ _ _ := inferInstance
-
-/-- The `NormalityOrder` centered at world `w₀`: `le w₁ w₂` iff `w₁` is
-    at least as close to `w₀` as `w₂` is. Bridges variably-strict
-    semantics to the default-reasoning infrastructure (`optimal`,
-    `refine`, `respects`, CR1–CR4) in `Core.Order.Normality`. -/
-def atCenter (sim : SimilarityOrdering W) (w₀ : W) : NormalityOrder W where
-  le := sim.closer w₀
-  le_refl w := sim.closer_refl w₀ w
-  le_trans w₁ w₂ w₃ := sim.closer_trans w₀ w₁ w₂ w₃
+  atCenter w₀ :=
+    Preorder.ofLE (fun w₁ w₂ => f w₀ w₁ w₂ = true) (hrefl w₀)
+      (fun w₁ w₂ w₃ => htrans w₀ w₁ w₂ w₃)
+  decClose w₀ w₁ w₂ := inferInstanceAs (Decidable (f w₀ w₁ w₂ = true))
 
 /-! ## Centering -/
 
-/-- A **strongly centered** similarity ordering: every world is *strictly*
-    closest to itself. This is the centering axiom of [lewis-1973]
-    that licenses the inference from variably-strict to material truth. -/
+/-- A **strongly centered** similarity ordering: every world is strictly
+    closest to itself ([lewis-1973]'s centering axiom). -/
 def isCentered (sim : SimilarityOrdering W) : Prop :=
   ∀ w w' : W, w ≠ w' → sim.closer w w w' ∧ ¬sim.closer w w' w
 
 /-! ## Closest worlds -/
 
 /-- The closest `A`-worlds to `w₀`: the minimal elements of `A` under the
-    similarity preorder centered at `w₀`. In [lewis-1973]'s notation,
-    `min_{≤_w}(A) = {w' ∈ A : ¬∃ w'' ∈ A. w'' <_w w'}`. -/
+    similarity preorder centered at `w₀`. -/
 def closestWorlds [DecidableEq W] (sim : SimilarityOrdering W) (w₀ : W)
     (A : Finset W) : Finset W :=
   A.filter fun w' => ∀ w'' ∈ A, sim.closer w₀ w' w'' ∨ ¬sim.closer w₀ w'' w'
 
 @[simp]
-theorem closestWorlds_empty [DecidableEq W] (sim : SimilarityOrdering W)
-    (w₀ : W) :
+theorem closestWorlds_empty [DecidableEq W] (sim : SimilarityOrdering W) (w₀ : W) :
     sim.closestWorlds w₀ ∅ = ∅ := by
   simp only [closestWorlds, Finset.filter_empty]
 
 theorem closestWorlds_subset [DecidableEq W] (sim : SimilarityOrdering W)
-    (w₀ : W) (A : Finset W) :
-    sim.closestWorlds w₀ A ⊆ A :=
+    (w₀ : W) (A : Finset W) : sim.closestWorlds w₀ A ⊆ A :=
   Finset.filter_subset _ A
 
 theorem mem_closestWorlds [DecidableEq W] (sim : SimilarityOrdering W)
@@ -126,43 +105,21 @@ theorem mem_closestWorlds [DecidableEq W] (sim : SimilarityOrdering W)
       w' ∈ A ∧ ∀ w'' ∈ A, sim.closer w₀ w' w'' ∨ ¬sim.closer w₀ w'' w' := by
   simp only [closestWorlds, Finset.mem_filter]
 
-/-- **Closest-world membership is preserved when restricting to a
-    subset.** If `B ⊆ A` and `w` is a closest `A`-world that lies in
-    `B`, then `w` is also a closest `B`-world. (Restricting to fewer
-    competitors can only preserve, never lose, "closest" status.)
-
-    This is the structural lemma underlying the
-    [ciardelli-zhang-champollion-2018] §1.2 argument that any
-    minimal-change semantics inherits the switches falsification: at the
-    actual world, the closest worlds in `A̅ ∪ B̅` decompose into closest
-    worlds in `A̅` or `B̅` individually. -/
-theorem mem_closestWorlds_of_subset [DecidableEq W]
-    (sim : SimilarityOrdering W)
+/-- **Closest-world membership is preserved when restricting to a subset.** -/
+theorem mem_closestWorlds_of_subset [DecidableEq W] (sim : SimilarityOrdering W)
     {w₀ w : W} {A B : Finset W} (hBA : B ⊆ A)
     (hw : w ∈ sim.closestWorlds w₀ A) (hwB : w ∈ B) :
     w ∈ sim.closestWorlds w₀ B := by
   rw [mem_closestWorlds] at hw ⊢
   exact ⟨hwB, fun w'' hw'' => hw.2 w'' (hBA hw'')⟩
 
-/-- **Limit Assumption** (closest-world existence): every non-empty
-    `Finset` has a closest world under the centered preorder.
-    Discharges the [lewis-1973] "Limit Assumption" automatically
-    on finite types — corresponds to mathlib's
-    `Finite.exists_minimal` once the centered relation is exposed
-    as a `Preorder`.
-
-    The proof routes through `Set.Finite.exists_minimal`, which gives
-    a `Minimal (· ∈ A) m`. Membership in `closestWorlds w₀ A` is
-    equivalent (the filter condition `closer w₀ m w'' ∨ ¬ closer w₀ w'' m`
-    matches `Minimal`'s `∀ y, y ≤ m → m ≤ y` by case-splitting on
-    `closer w₀ w'' m`). -/
-theorem closestWorlds_nonempty [DecidableEq W]
-    (sim : SimilarityOrdering W) (w₀ : W) {A : Finset W} (hne : A.Nonempty) :
+/-- **Limit Assumption** ([lewis-1973]): every non-empty `Finset` has a
+    closest world. Routes through `Set.Finite.exists_minimal` on the
+    preorder centered at `w₀`. -/
+theorem closestWorlds_nonempty [DecidableEq W] (sim : SimilarityOrdering W)
+    (w₀ : W) {A : Finset W} (hne : A.Nonempty) :
     (sim.closestWorlds w₀ A).Nonempty := by
-  letI : Preorder W :=
-    { le := sim.closer w₀
-      le_refl := sim.closer_refl w₀
-      le_trans := sim.closer_trans w₀ }
+  letI : Preorder W := sim.atCenter w₀
   obtain ⟨m, hmA, hmin⟩ :=
     A.finite_toSet.exists_minimal (Finset.coe_nonempty.mpr hne)
   refine ⟨m, ?_⟩
@@ -174,27 +131,17 @@ theorem closestWorlds_nonempty [DecidableEq W]
 
 end SimilarityOrdering
 
-/-! ## Selection-function bridge primitives
+/-! ## Selection-function bridge primitives -/
 
-These derive selection-function-flavoured notions from a similarity
-ordering without depending on `Semantics.Conditionals.SelectionFunction` itself, so they
-can sit in `Core.Order`. The full selection-function ↔ similarity
-duality (`coherentSelectionToSimilarity`) lives in
-`Semantics/Conditionals/Basic.lean` where both sides of the
-bridge are imported. -/
-
-/-- **Candidate selection set**: the worlds in `A ∩ domain` that are
-    minimal at `w` under the similarity ordering. Any selection function
-    `s` with `s(w, A) ∈ candidateSelections sim domain w A` is
-    "legitimate" with respect to `sim`. -/
+/-- **Candidate selection set**: the worlds in `A ∩ domain` that are minimal
+    at `w` under the similarity ordering. -/
 def candidateSelections {W : Type*} (sim : SimilarityOrdering W)
     (domain : Set W) (w : W) (A : Set W) : Set W :=
   let pWorlds := A ∩ domain
   { w' ∈ pWorlds | ∀ w'' ∈ pWorlds, sim.closer w w' w'' }
 
 /-- **Comparative-closeness notation** ([lewis-1973]): `w₁ ≤[sim, w₀] w₂`
-    reads "`w₁` is at least as similar to `w₀` as `w₂` is". A direct
-    [lewis-1973]-style alias for `sim.closer w₀ w₁ w₂`. -/
+    reads "`w₁` is at least as similar to `w₀` as `w₂` is". -/
 notation:50 w₁ " ≤[" sim "," w₀ "] " w₂ =>
   SimilarityOrdering.closer sim w₀ w₁ w₂
 

--- a/Linglib/Semantics/Conditionals/Basic.lean
+++ b/Linglib/Semantics/Conditionals/Basic.lean
@@ -168,8 +168,8 @@ theorem perfection_not_entailed_variablyStrict :
       (p q : Set W) (w : W),
       variablyStrictImp sim domain p q w ∧ ¬(conditionalPerfection p q w) := by
   use Bool
-  exact ⟨⟨fun _ _ _ => True, fun _ _ => trivial, fun _ _ _ _ _ _ => trivial,
-    fun _ _ _ => .isTrue trivial⟩,
+  exact ⟨⟨fun _ => Preorder.ofLE (fun _ _ => True) (fun _ => trivial)
+      (fun _ _ _ _ _ => trivial), fun _ _ _ => .isTrue trivial⟩,
     Set.univ, (· = true), (fun _ => True), false,
     Or.inr ⟨true, ⟨Set.mem_univ _, rfl⟩, fun _ _ _ => trivial⟩,
     fun h => h Bool.false_ne_true trivial⟩

--- a/Linglib/Semantics/Conditionals/Stalnaker.lean
+++ b/Linglib/Semantics/Conditionals/Stalnaker.lean
@@ -72,16 +72,17 @@ transitive (from coherence). -/
 def coherentSelectionToSimilarity {W : Type*} [DecidableEq W]
     (s : SelectionFunction W)
     (h_coherent : s.isCoherent) : SimilarityOrdering W where
-  closer := selectionPrefers s
-  closer_refl w₀ w := by
-    show s.sel w₀ {w, w} = w
-    have h_eq : ({w, w} : Set W) = {w} := Set.insert_eq_of_mem (Set.mem_singleton w)
-    rw [h_eq]
-    have h_ne : ({w} : Set W).Nonempty := ⟨w, Set.mem_singleton w⟩
-    have h_in := s.inclusion w₀ {w} h_ne
-    exact Set.mem_singleton_iff.mp h_in
-  closer_trans w₀ w₁ w₂ w₃ := h_coherent w₀ w₁ w₂ w₃
-  closerDec w₀ w₁ w₂ := inferInstanceAs (Decidable (s.sel w₀ {w₁, w₂} = w₁))
+  atCenter w₀ :=
+    Preorder.ofLE (fun w₁ w₂ => selectionPrefers s w₀ w₁ w₂)
+      (fun w => by
+        show s.sel w₀ {w, w} = w
+        have h_eq : ({w, w} : Set W) = {w} := Set.insert_eq_of_mem (Set.mem_singleton w)
+        rw [h_eq]
+        have h_ne : ({w} : Set W).Nonempty := ⟨w, Set.mem_singleton w⟩
+        have h_in := s.inclusion w₀ {w} h_ne
+        exact Set.mem_singleton_iff.mp h_in)
+      (fun w₁ w₂ w₃ => h_coherent w₀ w₁ w₂ w₃)
+  decClose w₀ w₁ w₂ := by exact inferInstanceAs (Decidable (s.sel w₀ {w₁, w₂} = w₁))
 
 /-! ## Selection conditional + Stalnakerian mood machinery -/
 

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Default.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Default.lean
@@ -49,15 +49,16 @@ formalized in `Frames.lean` alongside this module.
   reasoning. Veltman's system is the *dynamic* realization: the default
   consequence relation it induces validates System P.
 
-- **Core/Order/Normality.lean**: The `NormalityOrder` type and `refine`
-  operation are defined there as shared infrastructure. This module
-  builds `ExpState` (expectation states) on top of that.
+- **Core/Order/Normality.lean**: The normality ordering (mathlib
+  `Preorder W`) and the `refine` operation are defined there as shared
+  infrastructure. This module builds `ExpState` (expectation states) on
+  top of that.
 
 -/
 
 namespace Semantics.Dynamic.Default
 
-open Core.Order (NormalityOrder)
+open Core.Order
 
 variable {W : Type*}
 
@@ -78,18 +79,18 @@ structure ExpState (W : Type*) where
   /-- The information state: set of worlds compatible with the discourse -/
   info : Set W
   /-- The normality ordering (expectation pattern) -/
-  order : NormalityOrder W
+  order : Preorder W
 
 /-- The initial expectation state: all worlds are possible and equally
     normal. No information, no expectations. -/
 def ExpState.init : ExpState W where
   info := Set.univ
-  order := NormalityOrder.total
+  order := Normality.total
 
 /-- Optimal worlds in the current state: the most normal worlds
     among those compatible with the discourse. -/
 def ExpState.optimal (σ : ExpState W) : Set W :=
-  σ.order.optimal σ.info
+  Normality.optimal σ.order σ.info
 
 
 -- ═══ Update Operations ═══
@@ -108,7 +109,7 @@ def assertUpdate (φ : W → Prop) (σ : ExpState W) : ExpState W :=
     This is the core innovation of [veltman-1996]: defaults operate on
     the expectation pattern, not on the information state. -/
 def normallyUpdate (φ : W → Prop) (σ : ExpState W) : ExpState W :=
-  ⟨σ.info, σ.order.refine φ⟩
+  ⟨σ.info, Normality.refine σ.order φ⟩
 
 section Classical
 open Classical
@@ -172,15 +173,15 @@ theorem presumablyTest_preserves_order (φ : W → Prop) (σ : ExpState W) :
     This is the general form of Veltman's claim that defaults create
     valid presumptions. The connectedness condition is essential: without
     it, a non-φ-world can be optimal by being incomparable with all
-    φ-worlds (see `NormalityOrder.optimal_of_respects_connected`). -/
+    φ-worlds (see `Normality.optimal_of_respects_connected`). -/
 theorem presumably_passes (σ : ExpState W) (φ : W → Prop)
-    (hresp : σ.order.respects φ) (hconn : σ.order.connected)
+    (hresp : Normality.respects σ.order φ) (hconn : Normality.connected σ.order)
     (hex : ∃ w ∈ σ.info, φ w) :
     presumablyTest φ σ = σ := by
   simp only [presumablyTest]
   rw [if_pos]
   intro w hw
-  exact (NormalityOrder.optimal_of_respects_connected σ.order φ σ.info
+  exact (Normality.optimal_of_respects_connected σ.order φ σ.info
     hresp hconn hex hw).2
 
 /-- **The central result**: after processing "normally p", the test
@@ -190,12 +191,12 @@ theorem presumably_passes (σ : ExpState W) (φ : W → Prop)
     and a single refinement from total preserves connectedness. -/
 theorem normally_presumably_succeeds (φ : W → Prop) (d : Set W)
     (hex : ∃ w ∈ d, φ w) :
-    let σ : ExpState W := ⟨d, NormalityOrder.total⟩
+    let σ : ExpState W := ⟨d, Normality.total⟩
     presumablyTest φ (normallyUpdate φ σ) = normallyUpdate φ σ := by
   simp only [presumablyTest, normallyUpdate, ExpState.optimal]
   rw [if_pos]
   intro w hw
-  rw [NormalityOrder.refine_total_optimal φ d hex] at hw
+  rw [Normality.refine_total_optimal φ d hex] at hw
   exact hw.2
 
 
@@ -207,8 +208,8 @@ theorem normally_presumably_succeeds (φ : W → Prop) (d : Set W)
 
     [veltman-1996], Proposition 3.6(iv). -/
 theorem persistence_assert (σ : ExpState W) (φ ψ : W → Prop)
-    (h : σ.order.respects φ) :
-    (assertUpdate ψ σ).order.respects φ := h
+    (h : Normality.respects σ.order φ) :
+    Normality.respects (assertUpdate ψ σ).order φ := h
 
 /-- **Persistence under further defaults**: if the ordering respects p,
     then processing "normally q" (for any q) preserves this. Later
@@ -216,15 +217,15 @@ theorem persistence_assert (σ : ExpState W) (φ ψ : W → Prop)
 
     [veltman-1996], Proposition 3.6(iv). -/
 theorem persistence_normally (σ : ExpState W) (φ ψ : W → Prop)
-    (h : σ.order.respects φ) :
-    (normallyUpdate ψ σ).order.respects φ :=
-  NormalityOrder.refine_preserves_respects σ.order φ ψ h
+    (h : Normality.respects σ.order φ) :
+    Normality.respects (normallyUpdate ψ σ).order φ :=
+  Normality.refine_preserves_respects σ.order φ ψ h
 
 /-- After "normally p", the ordering respects p. Combined with
     persistence, this means "normally p" creates a permanent expectation. -/
 theorem normally_creates_respect (σ : ExpState W) (φ : W → Prop) :
-    (normallyUpdate φ σ).order.respects φ :=
-  NormalityOrder.refine_respects σ.order φ
+    Normality.respects (normallyUpdate φ σ).order φ :=
+  Normality.refine_respects σ.order φ
 
 
 -- ═══ Idempotency and Commutativity ═══
@@ -234,11 +235,11 @@ theorem normally_creates_respect (σ : ExpState W) (φ : W → Prop) :
 
     [veltman-1996], Proposition 3.6(ii) at the state level. -/
 theorem normallyUpdate_idempotent (σ : ExpState W) (φ : W → Prop)
-    (h : σ.order.respects φ) :
+    (h : Normality.respects σ.order φ) :
     normallyUpdate φ σ = σ := by
-  show ExpState.mk σ.info (σ.order.refine φ) = σ
+  show ExpState.mk σ.info (Normality.refine σ.order φ) = σ
   congr 1
-  exact NormalityOrder.refine_of_respects σ.order φ h
+  exact Normality.refine_of_respects σ.order φ h
 
 /-- Corollary: "normally φ; normally φ" = "normally φ" from any state. -/
 theorem normallyUpdate_normally_idempotent (σ : ExpState W) (φ : W → Prop) :
@@ -249,10 +250,10 @@ theorem normallyUpdate_normally_idempotent (σ : ExpState W) (φ : W → Prop) :
     "Normally φ; normally ψ" = "normally ψ; normally φ". -/
 theorem normallyUpdate_comm (σ : ExpState W) (φ ψ : W → Prop) :
     normallyUpdate ψ (normallyUpdate φ σ) = normallyUpdate φ (normallyUpdate ψ σ) := by
-  show ExpState.mk σ.info ((σ.order.refine φ).refine ψ) =
-       ExpState.mk σ.info ((σ.order.refine ψ).refine φ)
+  show ExpState.mk σ.info (Normality.refine (Normality.refine σ.order φ) ψ) =
+       ExpState.mk σ.info (Normality.refine (Normality.refine σ.order ψ) φ)
   congr 1
-  exact NormalityOrder.refine_comm σ.order φ ψ
+  exact Normality.refine_comm σ.order φ ψ
 
 
 -- ═══ Conflicting Defaults ═══
@@ -267,16 +268,16 @@ theorem normallyUpdate_comm (σ : ExpState W) (φ ψ : W → Prop) :
     defaults "if Quaker then normally pacifist" and "if Republican then
     normally not pacifist" — requires Veltman's §4 expectation frames. -/
 theorem conflicting_defaults_le (φ : W → Prop) (w v : W) :
-    (NormalityOrder.total.refine φ |>.refine (fun x => ¬φ x)).le w v ↔
+    (Normality.refine (Normality.refine Normality.total φ) (fun x => ¬φ x)).le w v ↔
     (φ v → φ w) ∧ (¬φ v → ¬φ w) := by
-  show (True ∧ (φ v → φ w)) ∧ (¬φ v → ¬φ w) ↔ (φ v → φ w) ∧ (¬φ v → ¬φ w)
-  exact ⟨fun ⟨⟨_, h1⟩, h2⟩ => ⟨h1, h2⟩, fun ⟨h1, h2⟩ => ⟨⟨True.intro, h1⟩, h2⟩⟩
+  rw [Normality.refine_le, Normality.refine_le]
+  exact ⟨fun ⟨⟨_, h1⟩, h2⟩ => ⟨h1, h2⟩, fun ⟨h1, h2⟩ => ⟨⟨trivial, h1⟩, h2⟩⟩
 
 /-- The conflicting-default ordering is equivalent to p-agreement:
     w is at most as normal as v iff they agree on p. -/
 theorem conflicting_defaults_iff_agree (φ : W → Prop) [DecidablePred φ]
     (w v : W) :
-    (NormalityOrder.total.refine φ |>.refine (fun x => ¬φ x)).le w v ↔
+    (Normality.refine (Normality.refine Normality.total φ) (fun x => ¬φ x)).le w v ↔
     (φ w ↔ φ v) := by
   rw [conflicting_defaults_le]
   constructor
@@ -293,15 +294,19 @@ theorem conflicting_defaults_iff_agree (φ : W → Prop) [DecidablePred φ]
     than conflict. -/
 theorem compatible_defaults_optimal (φ ψ : W → Prop) (d : Set W)
     (hφψ : ∀ w, φ w → ψ w) (hex : ∃ w ∈ d, φ w) :
-    (NormalityOrder.total.refine ψ |>.refine φ).optimal d ⊆ { w ∈ d | φ w } := by
-  intro w ⟨hwd, hopt⟩
+    Normality.optimal (Normality.refine (Normality.refine Normality.total ψ) φ) d ⊆
+      { w ∈ d | φ w } := by
+  intro w hw
+  rw [Normality.mem_optimal] at hw
+  obtain ⟨hwd, hopt⟩ := hw
   obtain ⟨v, hvd, hφv⟩ := hex
   refine ⟨hwd, ?_⟩
   by_contra hnφw
   have hψv : ψ v := hφψ v hφv
-  have hle : (NormalityOrder.total.refine ψ |>.refine φ).le v w :=
-    ⟨⟨True.intro, fun _ => hψv⟩, fun h => absurd h hnφw⟩
-  exact hnφw ((hopt v hvd hle).2 hφv)
+  have hle : (Normality.refine (Normality.refine Normality.total ψ) φ).le v w :=
+    Normality.refine_le.mpr ⟨Normality.refine_le.mpr ⟨trivial, fun _ => hψv⟩,
+      fun h => absurd h hnφw⟩
+  exact hnφw ((Normality.refine_le.mp (hopt hvd hle)).2 hφv)
 
 
 end Semantics.Dynamic.Default

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Frames.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Frames.lean
@@ -22,7 +22,7 @@ exception.
 
 ## Key definitions
 
-- `ExpFrame W`: function `Set W → NormalityOrder W`
+- `ExpFrame W`: function `Set W → Preorder W`
 - `ExpFrame.normal`: Def 4.3 — check all subdomains, not just d
 - `ExpFrame.coherent`: Def 4.3(iii) — every non-empty d has normals
 - `ExpFrame.refineAt`: Def 4.5 — refine pattern at domain d only
@@ -47,7 +47,7 @@ when every ordering is connected).
 
 namespace Semantics.Dynamic.Default
 
-open Core.Order (NormalityOrder)
+open Core.Order
 
 variable {W : Type*}
 
@@ -62,7 +62,7 @@ variable {W : Type*}
     orderings — this is what enables conditional defaults. -/
 structure ExpFrame (W : Type*) where
   /-- The per-domain normality ordering -/
-  pattern : Set W → NormalityOrder W
+  pattern : Set W → Preorder W
 
 /-- Extensionality for frames: two frames are equal iff they assign
     the same ordering to every domain. -/
@@ -99,17 +99,17 @@ def ExpFrame.coherent (π : ExpFrame W) : Prop :=
     the latter iff `respects`, we use `respects` directly. -/
 def ExpFrame.isDefault (π : ExpFrame W) (d : Set W) (e : W → Prop) :
     Prop :=
-  (∃ w ∈ d, e w) ∧ (π.pattern d).respects e
+  (∃ w ∈ d, e w) ∧ Normality.respects (π.pattern d) e
 
 /-- The **constant frame**: assigns the same ordering to every domain.
     This embeds §3's single-ordering setup into the §4 framework. -/
-def ExpFrame.const (no : NormalityOrder W) : ExpFrame W :=
+def ExpFrame.const (no : Preorder W) : ExpFrame W :=
   ⟨fun _ => no⟩
 
 /-- The **total frame**: assigns the total ordering to every domain.
     The initial state before any defaults have been processed. -/
 def ExpFrame.total : ExpFrame W :=
-  ExpFrame.const NormalityOrder.total
+  ExpFrame.const Normality.total
 
 
 -- ═══ Frame Refinement ═══
@@ -128,7 +128,7 @@ open Classical in
     normal in any d' ⊇ d. -/
 noncomputable def ExpFrame.refineAt (π : ExpFrame W) (d : Set W)
     (e : W → Prop) : ExpFrame W :=
-  ⟨fun d' => if d' = d then (π.pattern d).refine e else π.pattern d'⟩
+  ⟨fun d' => if d' = d then Normality.refine (π.pattern d) e else π.pattern d'⟩
 
 /-- Domains other than d are unchanged by refinement. -/
 theorem ExpFrame.refineAt_unchanged (π : ExpFrame W) (d : Set W)
@@ -139,7 +139,7 @@ theorem ExpFrame.refineAt_unchanged (π : ExpFrame W) (d : Set W)
 /-- The target domain gets its ordering refined. -/
 theorem ExpFrame.refineAt_target (π : ExpFrame W) (d : Set W)
     (e : W → Prop) :
-    (π.refineAt d e).pattern d = (π.pattern d).refine e := by
+    (π.refineAt d e).pattern d = Normality.refine (π.pattern d) e := by
   unfold refineAt; exact if_pos rfl
 
 
@@ -242,7 +242,7 @@ theorem ExpFrame.refineAt_comm_same (π : ExpFrame W) (d : Set W)
   by_cases hd : d' = d
   · subst hd
     simp only [refineAt_target]
-    exact NormalityOrder.refine_comm _ _ _
+    exact Normality.refine_comm _ _ _
   · simp only [refineAt_unchanged _ d _ d' hd]
 
 /-- **Commutativity at different domains**: refinements at da ≠ db
@@ -268,26 +268,26 @@ theorem ExpFrame.refineAt_idempotent (π : ExpFrame W) (d : Set W)
   by_cases hd : d' = d
   · subst hd
     simp only [refineAt_target]
-    exact NormalityOrder.refine_idempotent _ _
+    exact Normality.refine_idempotent _ _
   · simp only [refineAt_unchanged _ d _ d' hd]
 
 /-- If πd already respects e, refinement at d is a no-op. -/
 theorem ExpFrame.refineAt_of_respects (π : ExpFrame W) (d : Set W)
-    (e : W → Prop) (h : (π.pattern d).respects e) :
+    (e : W → Prop) (h : Normality.respects (π.pattern d) e) :
     π.refineAt d e = π := by
   apply ExpFrame.ext; intro d'
   by_cases hd : d' = d
   · subst hd
     rw [refineAt_target]
-    exact NormalityOrder.refine_of_respects _ _ h
+    exact Normality.refine_of_respects _ _ h
   · exact refineAt_unchanged _ d _ d' hd
 
 /-- After refinement at d, the pattern at d respects e. -/
 theorem ExpFrame.refineAt_creates_respect (π : ExpFrame W) (d : Set W)
     (e : W → Prop) :
-    ((π.refineAt d e).pattern d).respects e := by
+    Normality.respects ((π.refineAt d e).pattern d) e := by
   rw [refineAt_target]
-  exact NormalityOrder.refine_respects _ _
+  exact Normality.refine_respects _ _
 
 
 -- ═══ Coherence Preservation ═══
@@ -331,7 +331,7 @@ theorem ExpFrame.refineAt_coherent_iff (π : ExpFrame W) (d : Set W)
     obtain ⟨hwd, hne_w⟩ := hnorm_sub (refineAt_normal_mono π d e d₀ hw_ref)
     -- But the refined pattern at d forces e w (using the e-witness v₀)
     have h := hw_ref.2 d hd_sub hwd v₀ hv₀d
-    rw [refineAt_target] at h
+    rw [refineAt_target, Normality.refine_le] at h
     exact hne_w (h.2 hev₀)
   · -- ←: no bad superdomain → refined coherent
     intro hno_bad d₀ hd₀_ne
@@ -346,7 +346,7 @@ theorem ExpFrame.refineAt_coherent_iff (π : ExpFrame W) (d : Set W)
       refine ⟨w, hw_norm.1, fun d' hd' hwd' v hv => ?_⟩
       by_cases hd'_eq : d' = d
       · -- d' = d: refined pattern demands (πd).le ∧ (e v → e w)
-        rw [hd'_eq, refineAt_target]
+        rw [hd'_eq, refineAt_target, Normality.refine_le]
         constructor
         · have := hw_norm.2 d' hd' hwd' v hv; rwa [hd'_eq] at this
         · intro _; by_contra hne_w; rw [hd'_eq] at hwd'; exact hw_ok ⟨hwd', hne_w⟩
@@ -367,11 +367,11 @@ theorem ExpFrame.refineAt_coherent_iff (π : ExpFrame W) (d : Set W)
     for connected orderings, "top in every subdomain" reduces to
     "optimal in d" — since optimal = top when the ordering is total
     or connected. -/
-theorem ExpFrame.const_normal_of_connected (no : NormalityOrder W)
-    (d : Set W) (hconn : no.connected) :
-    (ExpFrame.const no).normal d = no.optimal d := by
+theorem ExpFrame.const_normal_of_connected (no : Preorder W)
+    (d : Set W) (hconn : Normality.connected no) :
+    (ExpFrame.const no).normal d = Normality.optimal no d := by
   ext w
-  simp only [normal, const, Set.mem_setOf_eq, NormalityOrder.optimal]
+  simp only [normal, const, Set.mem_setOf_eq, Normality.optimal]
   constructor
   · -- normal → optimal: weaker condition
     intro ⟨hwd, hsub⟩
@@ -385,7 +385,7 @@ theorem ExpFrame.const_normal_of_connected (no : NormalityOrder W)
     · exact hwv
     · -- le v w, and v ∈ d' ⊆ d, so v ∈ d
       -- By optimality of w in d: le w v
-      exact hopt v (hd'd hv) hvw
+      exact hopt (hd'd hv) hvw
 
 
 -- ═══ Applicability ═══

--- a/Linglib/Semantics/Genericity/GenericsDynamic.lean
+++ b/Linglib/Semantics/Genericity/GenericsDynamic.lean
@@ -52,7 +52,7 @@ namespace Semantics.Genericity.GenericsDynamic
 
 The `normalInstances` field packages the output of applying a normality
 restriction to the restrictor class. In a full implementation these would
-be computed from a `NormalityOrder` via `optimal`; here they are provided
+be computed from a normality `Preorder` via `Normality.optimal`; here they are provided
 directly to keep the model concrete and the propositional theorems
 decidable on finite witnesses.
 
@@ -589,7 +589,7 @@ constructors below derive it from different theoretical primitives:
   style).  Normal instances = domain elements satisfying both restrictor
   and normalcy.
 
-- **`fromOrder`** — normality ordering (`NormalityOrder` style).
+- **`fromOrder`** — normality ordering (`Preorder` style).
   Normal instances = optimal restrictor-satisfying entities under the ordering.
   Bridges to [kirkpatrick-2024] Definition 21's N_n functors.
 
@@ -637,7 +637,7 @@ theorem fromPredicate_static
 /-- Compute a `GenericSentence` from a decidable normality ordering.
 
     `le e₁ e₂` means `e₁` is at least as normal as `e₂`,
-    matching `NormalityOrder.le`. The normal instances are the
+    matching `Preorder.le`. The normal instances are the
     **optimal** restrictor-satisfying entities: those not strictly
     dominated by any other restrictor-satisfying entity in the domain.
 

--- a/Linglib/Semantics/Modality/Kratzer/Ordering.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Ordering.lean
@@ -97,12 +97,12 @@ theorem ordering_transitive (A : List (W → Prop)) (u v w : W)
     atLeastAsGoodAs A u w :=
   (kratzerPreorder A).le_trans u v w huv hvw
 
-/-- Kratzer's ordering as a `NormalityOrder` — definitionally
-    `NormalityOrder.fromProps` (the same `Preorder.ofCriteria` order
-    repackaged); connects to default reasoning infrastructure
-    (`optimal`, `refine`, `respects`, CR1–CR4). -/
-def kratzerNormality (A : List (W → Prop)) : Core.Order.NormalityOrder W :=
-  Core.Order.NormalityOrder.fromProps A
+/-- Kratzer's ordering as a normality `Preorder` — definitionally
+    `Normality.fromProps` (the same `Preorder.ofCriteria` order); connects to
+    default-reasoning infrastructure (`Normality.optimal`, `refine`,
+    `respects`, CR1–CR4). -/
+def kratzerNormality (A : List (W → Prop)) : Preorder W :=
+  Core.Order.Normality.fromProps A
 
 /-- Equivalence under the ordering. -/
 def orderingEquiv (A : List (W → Prop)) (w z : W) : Prop :=

--- a/Linglib/Studies/AsherPelletier2013.lean
+++ b/Linglib/Studies/AsherPelletier2013.lean
@@ -29,9 +29,11 @@ fly" correctly overrides "Birds fly" for penguins (exx. 7–8).
 
 ## Connection to Existing Infrastructure
 
-1. **`NormalityOrder`** (`Core/Order/Normality.lean`): preorder structure
-   on worlds. A&P's per-individual normality is a normality ordering
-   *per entity and restrictor class*.
+1. **Normality orderings** (`Core/Order/Normality.lean`): a normality
+   ordering is just a `Preorder` on worlds, with the default-reasoning
+   operations as functions in namespace `Core.Order.Normality`. A&P's
+   per-individual normality is a normality ordering *per entity and
+   restrictor class*.
 
 2. **`traditionalGEN`** (`Lexical/Noun/Kind/Generics.lean`): GEN's `normal`
    parameter is the Bool-level projection of a normality ordering.
@@ -41,7 +43,7 @@ fly" correctly overrides "Birds fly" for penguins (exx. 7–8).
 
 ## Refinement vs Specificity
 
-`processDefault` below uses `NormalityOrder.refine` ([veltman-1996]'s
+`processDefault` below uses `Normality.refine` ([veltman-1996]'s
 operation), which intersects ordering constraints. For the Tweety Triangle,
 Veltman's refinement produces **incomparability** between penguinFlies and
 penguinNoFly (neither is ≤ the other, since each satisfies one default
@@ -53,7 +55,7 @@ specificity-resolved result directly.
 
 namespace AsherPelletier2013
 
-open Core.Order (NormalityOrder)
+open Core.Order
 open Core.Logic.TweetyNixon
 
 -- ═══ Generic Truth via Normality Orderings ═══
@@ -69,15 +71,15 @@ structure DefaultRule (W : Type*) where
 /-- Process a default rule as a refinement of a normality ordering.
 
     "Normally, if P then Q" refines the ordering to promote P∧Q worlds
-    over P∧¬Q worlds via `NormalityOrder.refine`. This is
+    over P∧¬Q worlds via `Normality.refine`. This is
     [veltman-1996]'s monotonic (intersection-based) operation.
 
     Note: A&P's actual system uses per-individual evaluation with
     specificity, which goes beyond simple refinement. See the module
     docstring caveat about refinement vs specificity. -/
-def processDefault {W : Type*} (no : NormalityOrder W)
-    (d : DefaultRule W) : NormalityOrder W :=
-  no.refine (λ w => d.restrictor w → d.scope w)
+def processDefault {W : Type*} (no : Preorder W)
+    (d : DefaultRule W) : Preorder W :=
+  Normality.refine no (λ w => d.restrictor w → d.scope w)
 
 
 -- ═══ Per-Individual Evaluation (§12.3, exx. 7–9) ═══
@@ -179,7 +181,7 @@ def penguinsNormallyDontFly : DefaultRule TweetyWorld :=
 
 /-- Veltman-style refinement of both defaults.
 
-    This uses `NormalityOrder.refine` to process both defaults. The
+    This uses `Normality.refine` to process both defaults. The
     result makes penguinNoFly and penguinFlies **incomparable** — neither
     is ≤ the other — because the two defaults create crossing constraints.
     (penguinFlies satisfies "birds fly" but violates "penguins don't fly";
@@ -190,9 +192,9 @@ def penguinsNormallyDontFly : DefaultRule TweetyWorld :=
     A&P's per-individual evaluation resolves this via specificity,
     encoded in `tweetyLe` below.
 
-    The order of processing doesn't matter (`NormalityOrder.refine_comm`). -/
-def tweetyOrdering : NormalityOrder TweetyWorld :=
-  (processDefault NormalityOrder.total birdsNormallyFly)
+    The order of processing doesn't matter (`Normality.refine_comm`). -/
+def tweetyOrdering : Preorder TweetyWorld :=
+  (processDefault Normality.total birdsNormallyFly)
     |> (processDefault · penguinsNormallyDontFly)
 
 /-- The **specificity-resolved** normality ordering for the Tweety Triangle.

--- a/Linglib/Studies/CiardelliZhangChampollion2018.lean
+++ b/Linglib/Studies/CiardelliZhangChampollion2018.lean
@@ -178,10 +178,11 @@ def hamming : World → World → Nat
     is one natural ordering on this scenario; the abstract theorem
     below shows the falsification doesn't depend on this choice. -/
 def hammingSim : SimilarityOrdering World where
-  closer w₀ w₁ w₂ := hamming w₀ w₁ ≤ hamming w₀ w₂
-  closer_refl _ _ := Nat.le_refl _
-  closer_trans _ _ _ _ h₁ h₂ := h₁.trans h₂
-  closerDec _ _ _ := Nat.decLe _ _
+  atCenter w₀ :=
+    Preorder.ofLE (fun w₁ w₂ => hamming w₀ w₁ ≤ hamming w₀ w₂)
+      (fun _ => Nat.le_refl _)
+      (fun _ _ _ h₁ h₂ => h₁.trans h₂)
+  decClose _ _ _ := Nat.decLe _ _
 
 /-! ## Predictions of the universal/Lewis-Stalnaker counterfactual -/
 

--- a/Linglib/Studies/DarwichePearl1997.lean
+++ b/Linglib/Studies/DarwichePearl1997.lean
@@ -37,7 +37,8 @@ transformations that respect AGM success but violate the D&P constraints.
 
 ## Linguistic Connection
 
-Ranking functions → `PlausibilityOrder` → `NormalityOrder` → Kratzer's
+Ranking functions → `PlausibilityOrder` → normality ordering (`Preorder`)
+→ Kratzer's
 ordering sources for modals/conditionals. The D&P postulates constrain
 how modal bases evolve under discourse update — without them, an
 agent's conditional beliefs can shift arbitrarily between utterances.
@@ -49,7 +50,7 @@ the ordering of live possibilities evolves rationally.
 namespace DarwichePearl1997
 
 open Core.Logic.Ranking
-open Core.Order (NormalityOrder)
+open Core.Order.Normality
 
 -- ══════════════════════════════════════════════════════════════════════
 -- § 1. World Type
@@ -66,21 +67,21 @@ instance : Fintype W4 :=
 open W4
 
 -- ══════════════════════════════════════════════════════════════════════
--- § 2. Ranking → NormalityOrder Bridge
+-- § 2. Ranking → Normality Ordering (Preorder) Bridge
 -- ══════════════════════════════════════════════════════════════════════
 
 /-- Convert a ranking function to its induced normality ordering.
     `le w v ↔ κ(w) ≤ κ(v)`. Defined directly (not via `toPlausibilityOrder`)
     so that `le` reduces for `native_decide`. -/
-@[reducible] def rankToOrder (κ : RankingFunction W4) : NormalityOrder W4 where
-  le w v := κ.rank w ≤ κ.rank v
-  le_refl _ := Nat.le_refl _
-  le_trans _ _ _ h1 h2 := Nat.le_trans h1 h2
+@[reducible] def rankToOrder (κ : RankingFunction W4) : Preorder W4 :=
+  Preorder.ofLE (fun w v => κ.rank w ≤ κ.rank v)
+    (fun _ => Nat.le_refl _)
+    (fun _ _ _ h1 h2 => Nat.le_trans h1 h2)
 
 /-- `rankToOrder` agrees with the canonical path through `PlausibilityOrder`. -/
 theorem rankToOrder_eq_canonical (κ : RankingFunction W4) :
-    rankToOrder κ = κ.toPlausibilityOrder.toNormalityOrder :=
-  NormalityOrder.ext fun _ _ => Iff.rfl
+    rankToOrder κ = κ.toPlausibilityOrder.toPreorder :=
+  le_antisymm (fun _ _ h => h) (fun _ _ h => h)
 
 /-- AGM success: all rank-0 worlds in the posterior satisfy μ. -/
 @[reducible] def agmSuccess (post : RankingFunction W4)
@@ -107,16 +108,16 @@ def mu_A1 : W4 → Bool | .w1 => false | _ => true
 
 theorem A1_agm : agmSuccess post_A1 mu_A1 := by native_decide
 theorem A1_violates_CR1 :
-    ¬NormalityOrder.satisfies_CR1 (rankToOrder prior_A1) (rankToOrder post_A1) mu_A1 := by
+    ¬satisfies_CR1 (rankToOrder prior_A1) (rankToOrder post_A1) mu_A1 := by
   native_decide
 theorem A1_satisfies_CR2 :
-    NormalityOrder.satisfies_CR2 (rankToOrder prior_A1) (rankToOrder post_A1) mu_A1 := by
+    satisfies_CR2 (rankToOrder prior_A1) (rankToOrder post_A1) mu_A1 := by
   native_decide
 theorem A1_satisfies_CR3 :
-    NormalityOrder.satisfies_CR3 (rankToOrder prior_A1) (rankToOrder post_A1) mu_A1 := by
+    satisfies_CR3 (rankToOrder prior_A1) (rankToOrder post_A1) mu_A1 := by
   native_decide
 theorem A1_satisfies_CR4 :
-    NormalityOrder.satisfies_CR4 (rankToOrder prior_A1) (rankToOrder post_A1) mu_A1 := by
+    satisfies_CR4 (rankToOrder prior_A1) (rankToOrder post_A1) mu_A1 := by
   native_decide
 
 -- ══════════════════════════════════════════════════════════════════════
@@ -139,16 +140,16 @@ def mu_A2 : W4 → Bool | .w3 => true | .w4 => true | _ => false
 
 theorem A2_agm : agmSuccess post_A2 mu_A2 := by native_decide
 theorem A2_satisfies_CR1 :
-    NormalityOrder.satisfies_CR1 (rankToOrder prior_A2) (rankToOrder post_A2) mu_A2 := by
+    satisfies_CR1 (rankToOrder prior_A2) (rankToOrder post_A2) mu_A2 := by
   native_decide
 theorem A2_violates_CR2 :
-    ¬NormalityOrder.satisfies_CR2 (rankToOrder prior_A2) (rankToOrder post_A2) mu_A2 := by
+    ¬satisfies_CR2 (rankToOrder prior_A2) (rankToOrder post_A2) mu_A2 := by
   native_decide
 theorem A2_satisfies_CR3 :
-    NormalityOrder.satisfies_CR3 (rankToOrder prior_A2) (rankToOrder post_A2) mu_A2 := by
+    satisfies_CR3 (rankToOrder prior_A2) (rankToOrder post_A2) mu_A2 := by
   native_decide
 theorem A2_satisfies_CR4 :
-    NormalityOrder.satisfies_CR4 (rankToOrder prior_A2) (rankToOrder post_A2) mu_A2 := by
+    satisfies_CR4 (rankToOrder prior_A2) (rankToOrder post_A2) mu_A2 := by
   native_decide
 
 -- ══════════════════════════════════════════════════════════════════════
@@ -171,16 +172,16 @@ def mu_A3 : W4 → Bool | .w1 => true | .w2 => true | _ => false
 
 theorem A3_agm : agmSuccess post_A3 mu_A3 := by native_decide
 theorem A3_satisfies_CR1 :
-    NormalityOrder.satisfies_CR1 (rankToOrder prior_A3) (rankToOrder post_A3) mu_A3 := by
+    satisfies_CR1 (rankToOrder prior_A3) (rankToOrder post_A3) mu_A3 := by
   native_decide
 theorem A3_satisfies_CR2 :
-    NormalityOrder.satisfies_CR2 (rankToOrder prior_A3) (rankToOrder post_A3) mu_A3 := by
+    satisfies_CR2 (rankToOrder prior_A3) (rankToOrder post_A3) mu_A3 := by
   native_decide
 theorem A3_violates_CR3 :
-    ¬NormalityOrder.satisfies_CR3 (rankToOrder prior_A3) (rankToOrder post_A3) mu_A3 := by
+    ¬satisfies_CR3 (rankToOrder prior_A3) (rankToOrder post_A3) mu_A3 := by
   native_decide
 theorem A3_satisfies_CR4 :
-    NormalityOrder.satisfies_CR4 (rankToOrder prior_A3) (rankToOrder post_A3) mu_A3 := by
+    satisfies_CR4 (rankToOrder prior_A3) (rankToOrder post_A3) mu_A3 := by
   native_decide
 
 -- ══════════════════════════════════════════════════════════════════════
@@ -203,16 +204,16 @@ def mu_A4 : W4 → Bool | .w1 => true | .w2 => true | _ => false
 
 theorem A4_agm : agmSuccess post_A4 mu_A4 := by native_decide
 theorem A4_satisfies_CR1 :
-    NormalityOrder.satisfies_CR1 (rankToOrder prior_A4) (rankToOrder post_A4) mu_A4 := by
+    satisfies_CR1 (rankToOrder prior_A4) (rankToOrder post_A4) mu_A4 := by
   native_decide
 theorem A4_satisfies_CR2 :
-    NormalityOrder.satisfies_CR2 (rankToOrder prior_A4) (rankToOrder post_A4) mu_A4 := by
+    satisfies_CR2 (rankToOrder prior_A4) (rankToOrder post_A4) mu_A4 := by
   native_decide
 theorem A4_satisfies_CR3 :
-    NormalityOrder.satisfies_CR3 (rankToOrder prior_A4) (rankToOrder post_A4) mu_A4 := by
+    satisfies_CR3 (rankToOrder prior_A4) (rankToOrder post_A4) mu_A4 := by
   native_decide
 theorem A4_violates_CR4 :
-    ¬NormalityOrder.satisfies_CR4 (rankToOrder prior_A4) (rankToOrder post_A4) mu_A4 := by
+    ¬satisfies_CR4 (rankToOrder prior_A4) (rankToOrder post_A4) mu_A4 := by
   native_decide
 
 -- ══════════════════════════════════════════════════════════════════════
@@ -225,29 +226,29 @@ theorem A4_violates_CR4 :
     This is the content of [darwiche-pearl-1997], Appendix A. -/
 theorem CR_independence :
     -- CR1 independent: violated alone
-    (∃ p q : NormalityOrder W4, ∃ μ,
-      ¬NormalityOrder.satisfies_CR1 p q μ ∧
-      NormalityOrder.satisfies_CR2 p q μ ∧
-      NormalityOrder.satisfies_CR3 p q μ ∧
-      NormalityOrder.satisfies_CR4 p q μ) ∧
+    (∃ p q : Preorder W4, ∃ μ,
+      ¬satisfies_CR1 p q μ ∧
+      satisfies_CR2 p q μ ∧
+      satisfies_CR3 p q μ ∧
+      satisfies_CR4 p q μ) ∧
     -- CR2 independent: violated alone
-    (∃ p q : NormalityOrder W4, ∃ μ,
-      NormalityOrder.satisfies_CR1 p q μ ∧
-      ¬NormalityOrder.satisfies_CR2 p q μ ∧
-      NormalityOrder.satisfies_CR3 p q μ ∧
-      NormalityOrder.satisfies_CR4 p q μ) ∧
+    (∃ p q : Preorder W4, ∃ μ,
+      satisfies_CR1 p q μ ∧
+      ¬satisfies_CR2 p q μ ∧
+      satisfies_CR3 p q μ ∧
+      satisfies_CR4 p q μ) ∧
     -- CR3 independent: violated alone
-    (∃ p q : NormalityOrder W4, ∃ μ,
-      NormalityOrder.satisfies_CR1 p q μ ∧
-      NormalityOrder.satisfies_CR2 p q μ ∧
-      ¬NormalityOrder.satisfies_CR3 p q μ ∧
-      NormalityOrder.satisfies_CR4 p q μ) ∧
+    (∃ p q : Preorder W4, ∃ μ,
+      satisfies_CR1 p q μ ∧
+      satisfies_CR2 p q μ ∧
+      ¬satisfies_CR3 p q μ ∧
+      satisfies_CR4 p q μ) ∧
     -- CR4 independent: violated alone
-    (∃ p q : NormalityOrder W4, ∃ μ,
-      NormalityOrder.satisfies_CR1 p q μ ∧
-      NormalityOrder.satisfies_CR2 p q μ ∧
-      NormalityOrder.satisfies_CR3 p q μ ∧
-      ¬NormalityOrder.satisfies_CR4 p q μ) :=
+    (∃ p q : Preorder W4, ∃ μ,
+      satisfies_CR1 p q μ ∧
+      satisfies_CR2 p q μ ∧
+      satisfies_CR3 p q μ ∧
+      ¬satisfies_CR4 p q μ) :=
   ⟨⟨rankToOrder prior_A1, rankToOrder post_A1, mu_A1,
     A1_violates_CR1, A1_satisfies_CR2, A1_satisfies_CR3, A1_satisfies_CR4⟩,
    ⟨rankToOrder prior_A2, rankToOrder post_A2, mu_A2,
@@ -280,7 +281,7 @@ theorem CR_independence :
     RankingFunction.revise
       → satisfies C1–C4 (this file's counterexamples show AGM alone doesn't)
       → PlausibilityOrder (via toPlausibilityOrder)
-      → NormalityOrder (via toNormalityOrder)
+      → normality ordering / Preorder (via toPreorder)
       → Kratzer ordering sources (via fromProps)
       → modal/conditional semantics
     ```

--- a/Linglib/Studies/GoldszmidtPearl1996.lean
+++ b/Linglib/Studies/GoldszmidtPearl1996.lean
@@ -220,7 +220,7 @@ theorem general_default_preserved :
 /-- The induced plausibility ordering is connected (total), so
     Rational Monotonicity holds. -/
 theorem κz_connected :
-    κ_z.toPlausibilityOrder.toNormalityOrder.connected :=
+    Core.Order.Normality.connected κ_z.toPlausibilityOrder.toPreorder :=
   κ_z.ranking_connected
 
 -- ══════════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Kirkpatrick2024.lean
+++ b/Linglib/Studies/Kirkpatrick2024.lean
@@ -74,7 +74,7 @@ instance : DecidablePred isBlack :=
   fun e => by cases e <;> unfold isBlack <;> infer_instance
 
 /-- Normal ravens for the "raven" restrictor class: the non-albino ones.
-    These are the output of `NormalityOrder.optimal` applied to ravens. -/
+    These are the output of `Normality.optimal` applied to ravens. -/
 def normalRavens : List Raven := [.normal1, .normal2]
 
 /-- Normal albino ravens: all albino ravens are "normal" for their subkind.

--- a/Linglib/Studies/Spohn1988.lean
+++ b/Linglib/Studies/Spohn1988.lean
@@ -21,7 +21,7 @@ observation).
    satisfy the conditions of Theorem 4, the order of processing
    doesn't matter — verified for a concrete 4-world instance.
 
-3. **Connection to NormalityOrder**: Ranking functions induce
+3. **Connection to the normality preorder**: Ranking functions induce
    connected (total) plausibility orderings, refining any
    Kratzer-style ordering source with explicit disbelief grades.
 
@@ -197,15 +197,15 @@ theorem commutativity_verified :
      afterSunny2_thenWarm1.rank .rainy_cold) = (0, 1, 2, 4) := rfl
 
 -- ══════════════════════════════════════════════════════════════════════
--- § 4. Connection to NormalityOrder
+-- § 4. Connection to the Normality Preorder
 -- ══════════════════════════════════════════════════════════════════════
 
 /-- The prior ranking induces a connected (total) plausibility ordering,
     refining any Kratzer-style ordering source with explicit disbelief
     grades. This is the structural connection between ranking functions
-    and the 95+ files downstream of NormalityOrder. -/
+    and the files downstream of the normality preorder. -/
 theorem prior_connected :
-    prior.toPlausibilityOrder.toNormalityOrder.connected :=
+    Core.Order.Normality.connected prior.toPlausibilityOrder.toPreorder :=
   prior.ranking_connected
 
 /-- The prior's belief set: sunny_warm is believed (rank 0).

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -33,7 +33,7 @@ namespace Veltman1996
 
 open Core.Logic.TweetyNixon
 open Semantics.Dynamic.Default
-open Core.Order (NormalityOrder)
+open Core.Order
 open Classical
 
 
@@ -95,12 +95,12 @@ theorem ex310_i_exception :
     satisfies ¬p. This is [veltman-1996]'s coherence check
     (Definition 3.9). -/
 theorem ex310_i_conflict :
-    ¬∃ w ∈ (normallyUpdate atomP σ₀).order.optimal Set.univ, ¬atomP w := by
+    ¬∃ w ∈ Normality.optimal (normallyUpdate atomP σ₀).order Set.univ, ¬atomP w := by
   intro ⟨w, hw_opt, hnp⟩
   have hex : ∃ v ∈ (Set.univ : Set PQWorld), atomP v :=
     ⟨w₁, Set.mem_univ _, atomP_w₁⟩
   simp only [normallyUpdate, σ₀, ExpState.init] at hw_opt
-  rw [NormalityOrder.refine_total_optimal atomP Set.univ hex] at hw_opt
+  rw [Normality.refine_total_optimal atomP Set.univ hex] at hw_opt
   exact hnp hw_opt.2
 
 -- ─── Example 3.10(ii): Exceptions defeat presumptions ───
@@ -116,7 +116,7 @@ theorem ex310_ii_defeat :
   intro h
   apply h w₀
   simp only [ExpState.optimal, assertUpdate, normallyUpdate, σ₀, ExpState.init,
-    NormalityOrder.optimal]
+    Normality.optimal]
   refine ⟨⟨Set.mem_univ _, atomP_w₀⟩, fun v ⟨_, hnpv⟩ _ => ?_⟩
   exact ⟨True.intro, fun hpv => absurd hpv hnpv⟩
 
@@ -124,7 +124,7 @@ theorem ex310_ii_defeat :
 
     [veltman-1996], Examples 3.10(ii): normally p, ¬p ⊩ normally p. -/
 theorem ex310_ii_rule_persists :
-    (assertUpdate (fun w => ¬atomP w) (normallyUpdate atomP σ₀)).order.respects atomP :=
+    Normality.respects (assertUpdate (fun w => ¬atomP w) (normallyUpdate atomP σ₀)).order atomP :=
   persistence_assert (normallyUpdate atomP σ₀) atomP _ (normally_creates_respect σ₀ atomP)
 
 -- ─── Example 3.10(iii): Irrelevant information ───
@@ -138,11 +138,11 @@ theorem ex310_iii_irrelevant :
   intro w ⟨⟨_, hqw⟩, hopt⟩
   simp only [normallyUpdate, σ₀, ExpState.init] at hopt
   by_contra hnpw
-  have hle : (NormalityOrder.total.refine atomP).le w₃ w :=
+  have hle : (Normality.refine Normality.total atomP).le w₃ w :=
     ⟨True.intro, fun _ => atomP_w₃⟩
   have hw₃_mem : w₃ ∈ ({w ∈ Set.univ | atomQ w} : Set PQWorld) :=
     ⟨Set.mem_univ _, atomQ_w₃⟩
-  exact hnpw ((hopt w₃ hw₃_mem hle).2 atomP_w₃)
+  exact hnpw ((hopt hw₃_mem hle).2 atomP_w₃)
 
 -- ─── Example 3.10(iv): Independent defaults ───
 
@@ -158,11 +158,11 @@ theorem ex310_iv_independence :
   simp only [normallyUpdate, σ₀, ExpState.init] at hopt
   by_contra hnqw
   -- w₂ (¬p, q) dominates any ¬p ∧ ¬q world
-  have hle : ((NormalityOrder.total.refine atomP).refine atomQ).le w₂ w :=
+  have hle : (Normality.refine (Normality.refine Normality.total atomP) atomQ).le w₂ w :=
     ⟨⟨True.intro, fun hpw => absurd hpw hnpw⟩, fun hqw => absurd hqw hnqw⟩
   have hw₂_mem : w₂ ∈ ({w ∈ Set.univ | ¬atomP w} : Set PQWorld) :=
     ⟨Set.mem_univ _, atomP_w₂⟩
-  exact hnqw ((hopt w₂ hw₂_mem hle).2 atomQ_w₂)
+  exact hnqw ((hopt hw₂_mem hle).2 atomQ_w₂)
 
 -- ─── Example 3.10(v): Ambiguity ───
 
@@ -178,12 +178,12 @@ theorem ex310_v_ambiguity_p :
   intro h
   apply h w₂
   simp only [ExpState.optimal, assertUpdate, normallyUpdate, σ₀, ExpState.init,
-    NormalityOrder.optimal]
+    Normality.optimal]
   refine ⟨⟨Set.mem_univ _, fun ⟨hp, _⟩ => atomP_w₂ hp⟩, fun v ⟨_, hnpq⟩ hle => ?_⟩
   -- hle gives atomQ v (via the atomQ-refinement component evaluated at w₂)
   obtain ⟨⟨_, _⟩, hqv_imp⟩ := hle
   have hqv : atomQ v := hqv_imp atomQ_w₂
-  show ((NormalityOrder.total.refine atomP).refine atomQ).le w₂ v
+  show (Normality.refine (Normality.refine Normality.total atomP) atomQ).le w₂ v
   exact ⟨⟨True.intro, fun hpv => absurd ⟨hpv, hqv⟩ hnpq⟩, fun _ => atomQ_w₂⟩
 
 /-- Symmetric: w₁ (p, ¬q) is optimal but ¬q, so "presumably q" fails.
@@ -197,12 +197,12 @@ theorem ex310_v_ambiguity_q :
   intro h
   apply h w₁
   simp only [ExpState.optimal, assertUpdate, normallyUpdate, σ₀, ExpState.init,
-    NormalityOrder.optimal]
+    Normality.optimal]
   refine ⟨⟨Set.mem_univ _, fun ⟨_, hq⟩ => atomQ_w₁ hq⟩, fun v ⟨_, hnpq⟩ hle => ?_⟩
   -- hle gives atomP v (via the atomP-refinement component evaluated at w₁)
   obtain ⟨⟨_, hpv_imp⟩, _⟩ := hle
   have hpv : atomP v := hpv_imp atomP_w₁
-  show ((NormalityOrder.total.refine atomP).refine atomQ).le w₁ v
+  show (Normality.refine (Normality.refine Normality.total atomP) atomQ).le w₁ v
   exact ⟨⟨True.intro, fun _ => atomP_w₁⟩, fun hqv => absurd ⟨hpv, hqv⟩ hnpq⟩
 
 end Examples310
@@ -220,22 +220,20 @@ def birdDomain : Set TweetyWorld := { w | isBird w }
 def penguinDomain : Set TweetyWorld := { w | isPenguin w }
 
 /-- Ordering for the bird domain: promotes flying. -/
-private def birdOrd : NormalityOrder TweetyWorld where
-  le w v := (flies v → flies w)
-  le_refl _ := id
-  le_trans _ _ _ huv hvw h := huv (hvw h)
+private def birdOrd : Preorder TweetyWorld :=
+  Preorder.ofLE (fun w v => flies v → flies w) (fun _ => id)
+    (fun _ _ _ huv hvw h => huv (hvw h))
 
 /-- Ordering for the penguin domain: promotes ¬flying. -/
-private def penguinOrd : NormalityOrder TweetyWorld where
-  le w v := (¬flies v → ¬flies w)
-  le_refl _ := id
-  le_trans _ _ _ huv hvw h := huv (hvw h)
+private def penguinOrd : Preorder TweetyWorld :=
+  Preorder.ofLE (fun w v => ¬flies v → ¬flies w) (fun _ => id)
+    (fun _ _ _ huv hvw h => huv (hvw h))
 
 private noncomputable def tweetyPattern (d : Set TweetyWorld) :
-    NormalityOrder TweetyWorld :=
+    Preorder TweetyWorld :=
   if d = penguinDomain then penguinOrd
   else if d = birdDomain then birdOrd
-  else NormalityOrder.total
+  else Normality.total
 
 noncomputable def tweetyFrame : ExpFrame TweetyWorld :=
   ⟨tweetyPattern⟩
@@ -258,7 +256,7 @@ private theorem pat_bird : tweetyPattern birdDomain = birdOrd := by
 
 private theorem pat_other (d : Set TweetyWorld)
     (hp : d ≠ penguinDomain) (hb : d ≠ birdDomain) :
-    tweetyPattern d = NormalityOrder.total := by
+    tweetyPattern d = Normality.total := by
   unfold tweetyPattern; rw [if_neg hp, if_neg hb]
 
 private theorem sub_penguin_ne_bird (d : Set TweetyWorld)
@@ -312,21 +310,19 @@ open NixonWorld
 def quakerDomain : Set NixonWorld := { w | isQuaker w }
 def repDomain : Set NixonWorld := { w | isRepublican w }
 
-private def quakerOrd : NormalityOrder NixonWorld where
-  le w v := (isPacifist v → isPacifist w)
-  le_refl _ := id
-  le_trans _ _ _ huv hvw h := huv (hvw h)
+private def quakerOrd : Preorder NixonWorld :=
+  Preorder.ofLE (fun w v => isPacifist v → isPacifist w) (fun _ => id)
+    (fun _ _ _ huv hvw h => huv (hvw h))
 
-private def repOrd : NormalityOrder NixonWorld where
-  le w v := (¬isPacifist v → ¬isPacifist w)
-  le_refl _ := id
-  le_trans _ _ _ huv hvw h := huv (hvw h)
+private def repOrd : Preorder NixonWorld :=
+  Preorder.ofLE (fun w v => ¬isPacifist v → ¬isPacifist w) (fun _ => id)
+    (fun _ _ _ huv hvw h => huv (hvw h))
 
 private noncomputable def nixonPattern (d : Set NixonWorld) :
-    NormalityOrder NixonWorld :=
+    Preorder NixonWorld :=
   if d = quakerDomain then quakerOrd
   else if d = repDomain then repOrd
-  else NormalityOrder.total
+  else Normality.total
 
 noncomputable def nixonFrame : ExpFrame NixonWorld :=
   ⟨nixonPattern⟩
@@ -391,9 +387,10 @@ variable {W : Type*}
     and χ produces an ordering that promotes (ψ ∧ χ)-worlds.
 
     [veltman-1996], §5 (p.256): CC is valid. -/
-theorem conjConsequents_respects (no : NormalityOrder W)
+theorem conjConsequents_respects (no : Preorder W)
     (ψ χ : W → Prop) :
-    ((no.refine ψ).refine χ).respects (fun w => ψ w ∧ χ w) := by
+    Normality.respects (Normality.refine (Normality.refine no ψ) χ)
+      (fun w => ψ w ∧ χ w) := by
   intro w v ⟨⟨_, hψ⟩, hχ⟩ ⟨hψv, hχv⟩
   exact ⟨hψ hψv, hχ hχv⟩
 
@@ -407,7 +404,7 @@ theorem conjConsequents_frame (π : ExpFrame W) (d : Set W)
   by_cases hd : d' = d
   · subst hd
     simp only [ExpFrame.refineAt_target]
-    exact NormalityOrder.refine_of_respects _ _ (conjConsequents_respects _ ψ χ)
+    exact Normality.refine_of_respects _ _ (conjConsequents_respects _ ψ χ)
   · simp only [ExpFrame.refineAt_unchanged _ _ _ _ hd]
 
 -- ─── Invalid: Contraposition (counterexample) ───
@@ -431,8 +428,9 @@ theorem contraposition_fails :
     intro heq
     have h3 : w₃ ∈ d' := by rw [heq]; exact atomP_w₃
     exact absurd atomQ_w₃ (hd' h3)
-  simp only [ExpFrame.refineAt_unchanged _ _ _ _ hd'_ne, ExpFrame.total, ExpFrame.const]
-  exact True.intro
+  have heq := ExpFrame.refineAt_unchanged (ExpFrame.total (W := PQWorld))
+    { w : PQWorld | atomP w } atomQ d' hd'_ne
+  rw [heq]; exact True.intro
 
 -- ─── Invalid: Strengthening the Antecedent (counterexample) ───
 
@@ -469,8 +467,9 @@ theorem defeasible_modus_tollens_fails :
     intro heq
     have h3 : w₃ ∈ d' := by rw [heq]; exact atomP_w₃
     exact absurd atomQ_w₃ (hd' h3)
-  simp only [ExpFrame.refineAt_unchanged _ _ _ _ hd'_ne, ExpFrame.total, ExpFrame.const]
-  exact True.intro
+  have heq := ExpFrame.refineAt_unchanged (ExpFrame.total (W := PQWorld))
+    { w : PQWorld | atomP w } atomQ d' hd'_ne
+  rw [heq]; exact True.intro
 
 end InferencePatterns
 
@@ -492,12 +491,12 @@ variable {W : Type*}
 
     This theorem witnesses the structural identity: "all optimal worlds
     in a domain satisfy the scope" is just the definition of optimality
-    restated. The substantive bridge is that `NormalityOrder.optimal`
-    provides the normalcy predicate for GEN, and `NormalityOrder.refine`
+    restated. The substantive bridge is that `Normality.optimal`
+    provides the normalcy predicate for GEN, and `Normality.refine`
     provides the dynamic mechanism for learning new generic rules. -/
-theorem optimal_as_normalcy (no : NormalityOrder W) (d : Set W)
+theorem optimal_as_normalcy (no : Preorder W) (d : Set W)
     (scope : W → Prop) :
-    (∀ w ∈ no.optimal d, scope w) ↔
+    (∀ w ∈ Normality.optimal no d, scope w) ↔
     ∀ w, w ∈ d → (∀ v ∈ d, no.le v w → no.le w v) → scope w := by
   constructor
   · intro h w hwd hopt; exact h w ⟨hwd, hopt⟩


### PR DESCRIPTION
Replace the hand-rolled `NormalityOrder`/`PlausibilityOrder`/`SimilarityOrdering` order structures with mathlib `Preorder`, and add `CompleteLattice (Preorder α)` — the `Setoid`-analogue lattice of preorders-on-a-type that mathlib lacks (upstreamable).

- Veltman refinement = `⊓` with a criterion preorder; `optimal`/closest-worlds = `Minimal`; `connected` = totality; ranking order = `Preorder.lift`; smoothness via `Smooth`.
- 14 consumer files (Veltman/Darwiche-Pearl/Spohn/Kratzer chain, update-semantics, conditionals) migrated; full `lake build Linglib` green. Net −216 lines.