### PR TITLE
feat(Phonology/Autosegmental): Monoid (Graph/AR); toGraph as MonoidHom

### DIFF
--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Autosegmental.Graph
+import Mathlib.Algebra.Group.Hom.Defs
 import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.CategoryTheory.Monoidal.Category
 
@@ -198,6 +199,28 @@ theorem empty_concat (A : AR α β) : empty.concat A = A :=
     `Graph.concat_empty`). -/
 theorem concat_empty (A : AR α β) : A.concat empty = A :=
   ext_toGraph (Graph.concat_empty A.toGraph)
+
+/-- ARs form a monoid under concatenation, with the empty AR as unit — the
+    well-formed (in-bounds, planar) submonoid of `Graph`'s concatenation monoid
+    (see `toGraphHom`). The monoid laws are the lifts above. -/
+instance instMonoid : Monoid (AR α β) where
+  mul := concat
+  one := empty
+  mul_assoc := concat_assoc
+  one_mul := empty_concat
+  mul_one := concat_empty
+
+@[simp] theorem mul_eq_concat (A B : AR α β) : A * B = A.concat B := rfl
+
+@[simp] theorem one_eq_empty : (1 : AR α β) = empty := rfl
+
+/-- The underlying-graph projection is a monoid homomorphism: `AR α β` is the
+    in-bounds, planar submonoid of `Graph α β`. Injective by `ext_toGraph`, so
+    it exhibits the autosegmental monoid as a submonoid of all graphs. -/
+def toGraphHom : AR α β →* Graph α β where
+  toFun A := A.toGraph
+  map_one' := rfl
+  map_mul' _ _ := rfl
 
 /-! ### Category instance
 

--- a/Linglib/Phonology/Autosegmental/Graph.lean
+++ b/Linglib/Phonology/Autosegmental/Graph.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Data.Finset.Image
+import Mathlib.Algebra.Group.Defs
 import Linglib.Phonology.Autosegmental.NoCrossing
 
 /-!
@@ -456,6 +457,21 @@ theorem concat_assoc (A B C : Graph α β) :
   · simp only [links_concat, upper_concat, lower_concat, List.length_append,
                Finset.image_union, Finset.image_image, shiftLink_comp]
     rw [Finset.union_assoc]
+
+/-- **The monoid of autosegmental representations** ([jardine-heinz-2015]
+    Theorems 1, 3): graphs form a `Monoid` under concatenation, with `empty`
+    as the unit. `A * B = A.concat B`, `1 = empty`; the monoid laws are
+    `empty_concat`/`concat_empty`/`concat_assoc`. -/
+instance instMonoid : Monoid (Graph α β) where
+  mul := concat
+  one := empty
+  mul_assoc := concat_assoc
+  one_mul := empty_concat
+  mul_one := concat_empty
+
+@[simp] theorem mul_eq_concat (A B : Graph α β) : A * B = A.concat B := rfl
+
+@[simp] theorem one_eq_empty : (1 : Graph α β) = empty := rfl
 
 /-! #### Planarity preservation ([jardine-heinz-2015] Theorem 4) -/
 


### PR DESCRIPTION
Propagates the Orthoframe code-quality pattern (provide the mathlib algebraic-hierarchy *instance*, structural reuse follows) to autosegmental representations.

- `Monoid (Graph α β)` and `Monoid (AR α β)`: `Mul = concat`, `One = empty`, laws = the existing `concat_assoc`/`empty_concat`/`concat_empty` (no new proof obligation). The file's "Monoid laws" section now actually yields a `Monoid` — [jardine-heinz-2015]'s "monoid of autosegmental representations".
- `toGraphHom : AR α β →* Graph α β` exhibits AR as the in-bounds/planar submonoid of Graph (injective via `ext_toGraph`), so the hand `ext_toGraph` law-lifts become hom structure.
- Bridge `@[simp]` lemmas `mul_eq_concat`/`one_eq_empty`. Full `lake build Linglib` green.