### PR TITLE
refactor(Studies): mathlib idioms + fidelity in CiardelliGuerrini2026

### DIFF
--- a/Linglib/Studies/CiardelliGuerrini2026.lean
+++ b/Linglib/Studies/CiardelliGuerrini2026.lean
@@ -5,62 +5,39 @@ import Linglib.Studies.RotterLiu2025Concord
 import Mathlib.Data.Set.Basic
 
 /-!
-# [ciardelli-guerrini-2026] — Against Wide Scope Free Choice
-[ciardelli-guerrini-2026] [zeijlstra-2007]
+# Against wide scope free choice ([ciardelli-guerrini-2026])
 
-Semantics and Pragmatics 19(4). 2026.
+The free-choice reading of "you may A or you may B" does not arise from the
+wide-scope LF `◇A ∨ ◇B`, but from the narrow-scope LF `◇(A ∨ B)`. For
+disjunction the two LFs are truth-conditionally equivalent
+(`scope_equivalence`), so the scope distinction is invisible to truth
+conditions; it matters only compositionally, because only `◇(A ∨ B)` feeds the
+exhaustification that derives `◇A ∧ ◇B`. The wide-scope LF instead yields an
+*ignorance* reading and does not, on its own, entail free choice
+(`wideScope_underdetermines_fc`). (For conjunction the two LFs are *not*
+equivalent; see §8.)
 
-## The Reductionist Thesis
+The narrow-scope LF is derived by modal concord [zeijlstra-2007]: modal
+auxiliaries carry uninterpretable features `[u∃/∀-MOD]`; a single silent
+interpretable operator c-commanding the coordination checks both, so only it is
+interpreted, yielding `Δ(A ∘ B)` rather than `ΔA ∘ ΔB`.
 
-The free-choice reading of sentences like "You may A or you may B" does
-NOT arise from the wide-scope LF ◇A ∨ ◇B. It arises from the narrow-scope
-LF ◇(A ∨ B). There is no separate problem of "wide-scope free choice."
+`MOD A COORD MOD B` is scope-ambiguous across the board:
 
-The two LFs are **truth-conditionally equivalent** in standard modal logic
-(`diamond_distributes_iff`). The difference is compositional: only ◇(A ∨ B)
-feeds into pragmatic enrichment mechanisms (exhaustification, RSA, BSML)
-that derive the conjunctive free-choice inference ◇A ∧ ◇B.
+| surface form     | wide-scope LF | narrow-scope LF |
+|------------------|---------------|-----------------|
+| may A or may B   | `◇A ∨ ◇B`     | `◇(A ∨ B)`      |
+| must A or must B | `□A ∨ □B`     | `□(A ∨ B)`      |
+| may A and may B  | `◇A ∧ ◇B`     | `◇(A ∧ B)`      |
 
-## Evidence (§2)
+## Main declarations
 
-"MOD A COORD MOD B" sentences are systematically scope-ambiguous:
-
-| Surface form            | Wide-scope LF    | Narrow-scope LF |
-|------------------------|------------------|-----------------|
-| may A or may B          | ◇A ∨ ◇B         | ◇(A ∨ B)       |
-| must A or must B        | □A ∨ □B         | □(A ∨ B)       |
-| may A and may B         | ◇A ∧ ◇B         | ◇(A ∧ B)       |
-
-- **Must-or-must**: "You must write an essay or you must give a presentation"
-  naturally receives the narrow-scope reading □(essay ∨ presentation) —
-  a disjunctive obligation, not uncertainty between two obligations.
-
-- **May-and-may**: "You may go to Bob's party and you may go to Charlie's
-  party" naturally receives the narrow-scope reading ◇(Bob ∧ Charlie) —
-  permission to attend BOTH, not two separate permissions.
-
-## Compositional Mechanism (§3)
-
-The narrow-scope LF arises via **modal concord** ([zeijlstra-2007]).
-Modal auxiliaries carry uninterpretable features [u∃/∀-MOD]. When two
-auxiliaries with the same feature appear in a coordination, a single
-silent operator [i∃/∀-MOD] c-commands the coordination and checks both
-features. The silent operator is semantically interpreted; the auxiliaries
-are vacuous. This yields Δ(A ∘ B), not ΔA ∘ ΔB.
-
-## Key Predictions (§4)
-
-1. **Auxiliary vs non-auxiliary**: Non-auxiliary modal constructions
-   ("it's ok that", "be allowed to") carry interpretable features and
-   cannot participate in concord → no FC reading in coordination.
-
-2. **Either position**: Initial "either" does not block narrow-scope
-   readings, contra [meyer-sauerland-2017], because the silent
-   operator can check features from above "either."
-
-3. **Negation flips force for concord**: derived from `ModalForce.dual`
-   — ALLOW[i∃](¬NEED[u∀]) is well-formed because ¬∀ = ∃ = dual(∀).
-
+* `scope_equivalence` — the two disjunction LFs are truth-conditionally equal.
+* `ConcordDerivation` — two `[u-MOD]` auxiliaries checked by one silent operator.
+* `narrowScope_yields_fc` / `wideScope_underdetermines_fc` — free choice from the
+  narrow LF; non-entailment of free choice from the wide LF.
+* `reductionist_thesis` — the two packaged together.
+* `negation_concord_pattern` — cross-negation concord succeeds iff forces are duals.
 -/
 
 namespace CiardelliGuerrini2026
@@ -69,153 +46,127 @@ open Semantics.Modality
 open Exhaustification.FreeChoice (diamond diamond_distributes_iff FCAltSet free_choice_forward)
 open English.Auxiliaries
 
--- ============================================================================
--- §1. Semantic Equivalence: ◇(A∨B) ↔ ◇A ∨ ◇B
--- ============================================================================
+/-! ### Truth-conditional equivalence
 
-/-!
-## The Two LFs are Truth-Conditionally Equivalent
-
-In standard modal logic, ◇(A ∨ B) ↔ ◇A ∨ ◇B. The forward direction is
-`diamond_distributes` (from `Exhaustification/FreeChoice.lean`). The
-reverse is trivially provable. This equivalence is *the point* of C&G:
-the scope distinction cannot be detected truth-conditionally — it
-matters only for compositional derivation and pragmatic enrichment.
+For disjunction the two LFs collapse: `◇(A ∨ B) ↔ ◇A ∨ ◇B` in standard modal
+logic. This is *the point* of [ciardelli-guerrini-2026] — the scope distinction
+is invisible to truth conditions, and matters only for compositional derivation
+and pragmatic enrichment. (For conjunction the LFs are *not* equivalent; see §8.)
 -/
 
-/-- **The semantic equivalence**: ◇(A ∨ B) ↔ ◇A ∨ ◇B.
+/-- The two disjunction LFs are truth-conditionally equivalent: `◇(A ∨ B) ↔ ◇A ∨ ◇B`.
+A thin alias for `Exhaustification.FreeChoice.diamond_distributes_iff`, recording its
+role as the central observation of [ciardelli-guerrini-2026]. -/
+theorem scope_equivalence {World : Type*} (A B : Set World) :
+    diamond (A ∪ B) ↔ diamond A ∨ diamond B :=
+  diamond_distributes_iff A B
 
-    Promoted to `Exhaustification.FreeChoice.diamond_distributes_iff`.
-    The scope distinction is truth-conditionally vacuous — it matters
-    only for pragmatic enrichment. This is the central observation of
-    [ciardelli-guerrini-2026]. -/
-example {World : Type*} (p q : Set World) :
-    diamond (p ∪ q) ↔ diamond p ∨ diamond q :=
-  diamond_distributes_iff p q
+/-! ### Scope-ambiguity data (§2)
 
--- ============================================================================
--- §2. Scope Ambiguity Data
--- ============================================================================
+`MOD A COORD MOD B` sentences are scope-ambiguous. The illustrative sentences
+record the modal force, which §10 cross-checks against the Fragment; narrow-scope
+*availability* is witnessed structurally by the concord derivations of §3
+(`mayMayConcord`, `mustMustConcord`), whose mere existence as well-typed terms is
+the proof that the two auxiliaries can undergo concord. -/
 
-/-- Scope availability for "MOD A COORD MOD B" sentences. -/
-inductive ModalCoordScope where
-  | wideOnly    -- only ΔA ∘ ΔB
-  | narrowOnly  -- only Δ(A ∘ B)
-  | ambiguous   -- both readings available
-  deriving DecidableEq, Repr, BEq
-
-/-- A scope ambiguity datum for "MOD A COORD MOD B" sentences. -/
+/-- An illustrative "MOD A COORD MOD B" sentence. -/
 structure ScopeAmbiguityDatum where
   sentence : String
-  coord : String           -- "or" / "and"
+  /-- The coordinator: "or" or "and". -/
+  coord : String
   modalForce : ModalForce
-  /-- Which reading is dominant in context? -/
+  /-- The reading dominant in the discussed context. -/
   dominantReading : String
-  /-- Is the sentence scope-ambiguous? -/
-  scopeAvailability : ModalCoordScope
   deriving Repr
 
-/-- (2) "You may do A or you may do B" — FC reading from narrow-scope. -/
+/-- (2) "You may do A or you may do B" — free choice from the narrow-scope LF. -/
 def mayOrMay : ScopeAmbiguityDatum :=
   { sentence := "You may do A or you may do B"
   , coord := "or", modalForce := .possibility
-  , dominantReading := "narrow-scope (free choice)"
-  , scopeAvailability := .ambiguous }
+  , dominantReading := "narrow-scope (free choice)" }
 
 /-- (5) "You must write an essay or you must give a presentation." -/
 def mustOrMust : ScopeAmbiguityDatum :=
   { sentence := "You must write an essay or you must give a presentation"
   , coord := "or", modalForce := .necessity
-  , dominantReading := "narrow-scope (disjunctive obligation)"
-  , scopeAvailability := .ambiguous }
+  , dominantReading := "narrow-scope (disjunctive obligation)" }
 
 /-- (7) "You may go to Bob's party and you may go to Charlie's party." -/
 def mayAndMay : ScopeAmbiguityDatum :=
   { sentence := "You may go to Bob's party and you may go to Charlie's party"
   , coord := "and", modalForce := .possibility
-  , dominantReading := "narrow-scope (conjunctive permission)"
-  , scopeAvailability := .ambiguous }
+  , dominantReading := "narrow-scope (conjunctive permission)" }
 
 def scopeData : List ScopeAmbiguityDatum := [mayOrMay, mustOrMust, mayAndMay]
 
-/-- All MOD-COORD-MOD sentences are scope-ambiguous (central claim). -/
-theorem all_ambiguous :
-    scopeData.all (·.scopeAvailability == .ambiguous) = true := rfl
+/-! ### Modal concord derivation (§3)
 
--- ============================================================================
--- §3. Modal Concord Derivation (connected to Fragment entries)
--- ============================================================================
+[zeijlstra-2007]'s feature system explains how the narrow-scope LF `◇(A ∨ B)`
+arises compositionally for "may A or may B":
 
-/-!
-## Deriving Narrow-Scope LF via Modal Concord
-
-[zeijlstra-2007]'s feature system explains how the narrow-scope LF
-◇(A ∨ B) arises compositionally for "may A or may B":
-
-1. Each "may" carries [u∃-MOD] (uninterpretable existential feature)
-2. A silent ◇ operator [i∃-MOD] is projected above the coordination
-3. The silent operator checks both [u∃-MOD] features in the conjuncts
-4. Only the silent operator is semantically interpreted → ◇(A ∨ B)
+1. each "may" carries `[u∃-MOD]` (uninterpretable existential feature);
+2. a silent `◇` operator `[i∃-MOD]` is projected above the coordination;
+3. the silent operator checks both `[u∃-MOD]` features in the conjuncts;
+4. only the silent operator is semantically interpreted, giving `◇(A ∨ B)`.
 -/
 
-/-- The modal feature carried by English "may" — fully derived from the
-    Fragment entry's force AND interpretability. -/
+/-- The modal feature carried by English "may" — derived from the Fragment entry's
+force and interpretability. -/
 def mayFeature : ModalFeature := may.toModalFeature.get!
 
-/-- The modal feature carried by English "must" — fully derived from Fragment. -/
+/-- The modal feature carried by English "must" — derived from the Fragment. -/
 def mustFeature : ModalFeature := must.toModalFeature.get!
 
-/-- "May" carries [u∃-MOD]: possibility force, uninterpretable. -/
+/-- "May" carries `[u∃-MOD]`: possibility force, uninterpretable. -/
 theorem may_feature_eq :
     may.toModalFeature = some ⟨.possibility, .uninterpretable⟩ := rfl
 
-/-- "Must" carries [u∀-MOD]: necessity force, uninterpretable. -/
+/-- "Must" carries `[u∀-MOD]`: necessity force, uninterpretable. -/
 theorem must_feature_eq :
     must.toModalFeature = some ⟨.necessity, .uninterpretable⟩ := rfl
 
 /-- The silent operator that checks a given u-feature: same force, but
-    interpretable. This is the operator C&G posit above the coordination. -/
+interpretable. This is the operator [ciardelli-guerrini-2026] posit above the
+coordination. -/
 def silentChecker (f : ModalFeature) : ModalFeature := ⟨f.force, .interpretable⟩
 
-/-- **Core derivation**: for any u-feature, the matching silent operator
-    checks it. This is the general form of C&G's concord mechanism —
-    not just "may" or "must", but ANY auxiliary carrying a u-feature. -/
+/-- **Core derivation**: the matching silent operator checks any u-feature. This is
+the general form of the concord mechanism — not just "may" or "must", but *any*
+auxiliary carrying a u-feature. -/
 theorem silent_checker_works (f : ModalFeature) (h : f.interp = .uninterpretable) :
     (silentChecker f).checks f = true := by
   simp only [silentChecker, ModalFeature.checks, h]
   cases f.force <;> decide
 
-/-- A silent [i-MOD] with force f₁ checks any [u-MOD] with matching concord class. -/
+/-- A silent `[i-MOD]` with force `g₁` checks any `[u-MOD]` of matching concord class. -/
 private theorem silent_checks_matching (g₁ g₂ : ModalFeature)
     (hI : g₂.interp = .uninterpretable)
     (hF : ConcordType.fromModalForce g₁.force = ConcordType.fromModalForce g₂.force) :
     (silentChecker g₁).checks g₂ = true := by
-  unfold silentChecker ModalFeature.checks
-  rw [hI, hF]
-  simp
-  exact ⟨rfl, rfl⟩
+  have hforce : (silentChecker g₁).checks g₂ = (silentChecker g₂).checks g₂ := by
+    simp only [silentChecker, ModalFeature.checks, hF]
+  rw [hforce]
+  exact silent_checker_works g₂ hI
 
-/-! ### ConcordDerivation: packaging the full derivation chain -/
+/-! #### ConcordDerivation: packaging the full derivation chain -/
 
-/-- A concord derivation witnesses that two modal features can be checked
-    by a single silent operator. This is the formal content of
-    [ciardelli-guerrini-2026]'s compositional mechanism.
+/-- A concord derivation witnesses that two modal features can be checked by a
+single silent operator. This is the formal content of [ciardelli-guerrini-2026]'s
+compositional mechanism.
 
-    A `ConcordDerivation` exists iff:
-    1. Both features are uninterpretable (u-MOD)
-    2. They belong to the same concord class (both ∃-type or both ∀-type)
-
-    The silent operator, checking proofs, and resulting narrow-scope
-    interpretation are all derived automatically from these two conditions. -/
+A `ConcordDerivation` exists iff both features are uninterpretable (u-MOD) and
+belong to the same concord class (both ∃-type or both ∀-type). The silent
+operator, the checking proofs, and the resulting narrow-scope interpretation are
+all derived from these two conditions. -/
 structure ConcordDerivation where
-  /-- The feature of the first modal auxiliary -/
+  /-- The feature of the first modal auxiliary. -/
   f₁ : ModalFeature
-  /-- The feature of the second modal auxiliary -/
+  /-- The feature of the second modal auxiliary. -/
   f₂ : ModalFeature
-  /-- Both are uninterpretable -/
+  /-- Both are uninterpretable. -/
   uInterp₁ : f₁.interp = .uninterpretable
   uInterp₂ : f₂.interp = .uninterpretable
-  /-- Same concord class -/
+  /-- Same concord class. -/
   sameClass : ConcordType.fromModalForce f₁.force = ConcordType.fromModalForce f₂.force
 
 namespace ConcordDerivation
@@ -240,8 +191,8 @@ theorem checks_second (cd : ConcordDerivation) :
 
 end ConcordDerivation
 
-/-- Construct a `ConcordDerivation` from two `AuxEntry`s. The derivation
-    is built entirely from Fragment data — no stipulation. -/
+/-- Construct a `ConcordDerivation` from two `AuxEntry`s. The derivation is built
+entirely from Fragment data — no stipulation. -/
 def ConcordDerivation.fromAux (a₁ a₂ : AuxEntry)
     {f₁ f₂ : ModalFeature}
     (_h₁ : a₁.toModalFeature = some f₁) (_h₂ : a₂.toModalFeature = some f₂)
@@ -250,272 +201,210 @@ def ConcordDerivation.fromAux (a₁ a₂ : AuxEntry)
     ConcordDerivation :=
   ⟨f₁, f₂, hI₁, hI₂, hF⟩
 
-/-! ### Universal modal properties -/
+/-! #### Universal modal properties -/
 
-/-- The modal auxiliaries that participate in concord: all entries in the
-    Fragment with uninterpretable features. -/
+/-- The modal auxiliaries that participate in concord: Fragment entries with
+uninterpretable features. -/
 def modalAuxiliaries : List AuxEntry :=
   allAuxiliaries.filter (λ a => a.interpretability == some .uninterpretable)
 
 /-- Exactly 13 English modal auxiliaries carry u-features. -/
-theorem modal_aux_count : modalAuxiliaries.length = 13 := by native_decide
+theorem modal_aux_count : modalAuxiliaries.length = 13 := by decide
 
-/-- Modal auxiliaries with modal meaning (i.e., those that can form
-    `ConcordDerivation`s). Excludes `dare` which has u-features but
-    no modal meaning specification. -/
+/-- Modal auxiliaries with modal meaning (those that can form `ConcordDerivation`s).
+Excludes `dare`, which has u-features but no modal-meaning specification. -/
 def concordCapableModals : List AuxEntry :=
   modalAuxiliaries.filter (λ a => a.toModalFeature.isSome)
 
 /-- 12 of 13 modal auxiliaries have derivable modal features. -/
-theorem concord_capable_count : concordCapableModals.length = 12 := by native_decide
+theorem concord_capable_count : concordCapableModals.length = 12 := by decide
 
 /-- Every concord-capable modal's feature is uninterpretable. -/
 theorem concord_capable_all_uninterpretable :
     concordCapableModals.all (λ a =>
       decide (a.interpretability == some .uninterpretable)) = true := by
-  native_decide
+  decide
 
-/-- Non-modal auxiliaries have no modal feature — they cannot participate
-    in concord at all. -/
+/-- Non-modal auxiliaries have no modal feature — they cannot participate in
+concord at all. -/
 theorem do_no_feature : do_.toModalFeature = none := rfl
 theorem be_no_feature : am.toModalFeature = none := rfl
 theorem have_no_feature : have_.toModalFeature = none := rfl
 
-/-! ### Instantiations -/
+/-! #### Instantiations -/
 
-/-- "May A or may B" concord derivation — fully derived from Fragment. -/
+/-- "May A or may B" concord derivation — fully derived from the Fragment. -/
 def mayMayConcord : ConcordDerivation :=
   .fromAux may may may_feature_eq may_feature_eq rfl rfl rfl
 
-/-- "Must A or must B" concord derivation — fully derived from Fragment. -/
+/-- "Must A or must B" concord derivation — fully derived from the Fragment. -/
 def mustMustConcord : ConcordDerivation :=
   .fromAux must must must_feature_eq must_feature_eq rfl rfl rfl
 
-/-- Cross-force checking fails: silent □ cannot check "may"[u∃]. -/
+/-- Cross-force checking fails: a silent `□` cannot check "may" `[u∃]`. -/
 theorem cross_force_blocked :
-    (silentChecker mustFeature).checks mayFeature = false := by native_decide
+    (silentChecker mustFeature).checks mayFeature = false := by decide
 
--- ============================================================================
--- §3b. The FC Pipeline: Concord → Narrow Scope → Free Choice
--- ============================================================================
+/-! ### The FC pipeline: concord → narrow scope → free choice (§3)
 
-/-!
-## The Full Pipeline: From Lexical Features to Free Choice
+The pipeline has three stages:
 
-This is the deepest formalization of [ciardelli-guerrini-2026]'s
-reductionist thesis. The pipeline has three stages:
+1. **feature matching** → `ConcordDerivation` (above);
+2. **narrow scope** → a single modal operator over the coordination;
+3. **exhaustification** → the free-choice inference.
 
-1. **Feature matching** → `ConcordDerivation` (§3 above)
-2. **Narrow scope** → single modal operator over coordination
-3. **Exhaustification** → free choice inference
+The key point: the narrow/wide scope distinction is truth-conditionally vacuous
+*for disjunction* (`scope_equivalence`) but pragmatically active. Only the
+narrow-scope LF, exhaustified, yields free choice; the wide-scope LF
+underdetermines it (and yields an ignorance reading instead). -/
 
-The key insight: the narrow-scope / wide-scope distinction is
-**truth-conditionally vacuous** (`scope_equivalence`) but **pragmatically
-active** — exhaustification produces opposite results:
-
-- Narrow scope: Exh²(◇(A∨B)) → ◇A ∧ ◇B  (free choice: both permitted)
-- Wide scope: Exh(◇A ∨ ◇B) → ¬(◇A ∧ ◇B)  (exclusive: at most one)
--/
-
-/-- The **free choice pipeline**: narrow-scope ◇(A∨B), when doubly
-    exhaustified, yields free choice ◇A ∧ ◇B.
-
-    This IS the reductionist thesis in action: FC arises from the
-    narrow-scope LF (derived via concord) fed to the standard
-    exhaustification mechanism. Uses `free_choice_forward` from
-    `Exhaustification/FreeChoice.lean`. -/
+/-- The **free-choice pipeline**: the narrow-scope `◇(A ∨ B)`, doubly exhaustified,
+yields free choice `◇A ∧ ◇B`. This is the reductionist thesis in action — FC
+arises from the narrow-scope LF (derived via concord) fed to the standard
+exhaustification mechanism (`free_choice_forward`). -/
 theorem narrowScope_yields_fc {World : Type*} (A B : Set World)
     (hExh : (FCAltSet.mk A B).exh2) : diamond A ∧ diamond B :=
   free_choice_forward ⟨A, B⟩ hExh
 
-/-- Wide-scope exhaustification: Exh(◇A ∨ ◇B) asserts the disjunction
-    while negating the conjunction — yielding exclusive disjunction.
+/-- The wide-scope LF `◇A ∨ ◇B` does **not** entail free choice `◇A ∧ ◇B`: a
+disjunction of possibilities holds even when only one disjunct is possible. This
+is why [ciardelli-guerrini-2026] locate the free-choice reading exclusively in the
+narrow-scope LF — the wide-scope LF yields the *ignorance* reading (the speaker is
+unsure which disjunct holds), not free choice. -/
+theorem wideScope_underdetermines_fc :
+    ∃ (A B : Set Unit), (diamond A ∨ diamond B) ∧ ¬ (diamond A ∧ diamond B) := by
+  refine ⟨Set.univ, ∅, Or.inl ⟨(), trivial⟩, ?_⟩
+  rintro ⟨-, w, hw⟩
+  exact Set.notMem_empty w hw
 
-    This is the standard scalar implicature for disjunction: "A or B"
-    implicates "not both." -/
-def wideScopeExh {World : Type*} (A B : Set World) : Prop :=
-  (diamond A ∨ diamond B) ∧ ¬(diamond A ∧ diamond B)
+/-- **The reductionist thesis** ([ciardelli-guerrini-2026], formalized).
 
-/-- Wide-scope exhaustification is **incompatible** with free choice.
-    FC = ◇A ∧ ◇B, but wide-scope Exh asserts ¬(◇A ∧ ◇B). -/
-theorem wideScope_blocks_fc {World : Type*} (A B : Set World)
-    (h : wideScopeExh A B) : ¬(diamond A ∧ diamond B) :=
-  h.2
-
-/-- Truth-conditional equivalence: the scope distinction is semantically
-    vacuous. ◇(A∨B) ↔ ◇A∨◇B in standard modal logic. -/
-theorem scope_equivalence {World : Type*} (A B : Set World) :
-    diamond (A ∪ B) ↔ diamond A ∨ diamond B :=
-  diamond_distributes_iff A B
-
-/-- **The Reductionist Thesis** ([ciardelli-guerrini-2026], formalized).
-
-    Despite truth-conditional equivalence (`scope_equivalence`),
-    the two LFs diverge under pragmatic enrichment:
-
-    1. Narrow scope + Exh² → FC (both permitted)
-    2. Wide scope + Exh → ¬FC (at most one)
-
-    There is no separate problem of "wide-scope free choice" — the FC
-    reading arises exclusively from the narrow-scope LF, which is
-    derived via modal concord (`ConcordDerivation`). -/
+Despite truth-conditional equivalence (`scope_equivalence`), the FC reading arises
+only from the narrow-scope LF: (1) the two disjunction LFs are equivalent, and
+(2) the narrow-scope LF, exhaustified, yields free choice. The wide-scope LF does
+not (`wideScope_underdetermines_fc`), so there is no separate problem of
+"wide-scope free choice". -/
 theorem reductionist_thesis {World : Type*} (A B : Set World) :
-    -- (1) Narrow scope + exhaustification → free choice
-    ((FCAltSet.mk A B).exh2 → diamond A ∧ diamond B) ∧
-    -- (2) Wide scope + exhaustification → NOT free choice
-    (wideScopeExh A B → ¬(diamond A ∧ diamond B)) :=
-  ⟨narrowScope_yields_fc A B, wideScope_blocks_fc A B⟩
+    (diamond (A ∪ B) ↔ diamond A ∨ diamond B) ∧
+    ((FCAltSet.mk A B).exh2 → diamond A ∧ diamond B) :=
+  ⟨scope_equivalence A B, narrowScope_yields_fc A B⟩
 
--- ============================================================================
--- §4. Auxiliary vs Non-Auxiliary Prediction
--- ============================================================================
-
-/-!
-## Prediction: Non-Auxiliary Modals Block FC in Coordination
+/-! ### Auxiliary vs non-auxiliary modals (§4.1)
 
 [meyer-sauerland-2017] observed that (19a-b) lack FC readings:
 
   (19a) It's ok for John to sing or it's ok for John to dance.  (*FC)
   (19b) John is allowed to sing or he is allowed to dance.      (*FC)
 
-[ciardelli-guerrini-2026] explain this: "it's ok" and "be allowed"
-carry **interpretable** features. They cannot participate in concord
-with a higher silent operator, so no narrow-scope LF is available.
-
-Modal auxiliaries ("may", "must", "can") carry **uninterpretable**
-features and CAN participate in concord → FC available.
-
-The auxiliary status of "may", "must", "can", "need" is derived from
+[ciardelli-guerrini-2026] explain this: "it's ok" and "be allowed" carry
+**interpretable** features, so they are already interpreted and cannot be checked
+by a higher silent operator — no narrow-scope LF, no FC. Modal auxiliaries ("may",
+"must", "can") carry **uninterpretable** features and *can* be checked → FC
+available. The auxiliary status of "may", "must", "can", "need" is derived from
 `English.FunctionWords` — they are all `.modal` entries.
--/
 
-/-- Fragment-derived: all English modals used by C&G are modal auxiliaries
-    with uninterpretable features. -/
+Caveat: in §4.3 the authors flag (31) "it is possible that A or it is possible
+that B", a *non-auxiliary* modal that nevertheless seems to allow FC, as an
+outstanding problem. The prediction below is therefore about the concord
+*mechanism* (interpreted features cannot be checked), not an exceptionless surface
+generalization. -/
+
+/-- Fragment-derived: the English modals used by [ciardelli-guerrini-2026] are
+modal auxiliaries. -/
 theorem may_is_modal : may.auxType = .modal := rfl
 theorem must_is_modal : must.auxType = .modal := rfl
 theorem can_is_modal : can.auxType = .modal := rfl
 theorem need_is_modal : need.auxType = .modal := rfl
 
-/-- All C&G modals carry uninterpretable features in the Fragment. -/
+/-- All these modals carry uninterpretable features in the Fragment. -/
 theorem may_uninterpretable : may.interpretability = some .uninterpretable := rfl
 theorem must_uninterpretable : must.interpretability = some .uninterpretable := rfl
 theorem can_uninterpretable : can.interpretability = some .uninterpretable := rfl
 theorem need_uninterpretable : need.interpretability = some .uninterpretable := rfl
 
-/-- Non-auxiliary modal constructions — these have no Fragment entry
-    because they are multi-word periphrastic constructions, not
-    single-word auxiliaries in Zwicky & Pullum's sense. Their absence
-    from the auxiliary lexicon IS the prediction: no `AuxEntry` →
-    no uninterpretable feature → no concord → no narrow-scope LF. -/
-structure NonAuxModalDatum where
-  form : String
-  fcInCoordination : Bool  -- can FC arise in "X A or X B"?
-  deriving Repr
+/-- **The mechanism behind the auxiliary/non-auxiliary contrast**: an *interpreted*
+feature can never be checked. Non-auxiliary modal constructions ("it's ok that",
+"be allowed/required to") carry interpretable features, so no silent operator can
+check them — hence no narrow-scope LF and no FC in coordination. This is derived
+from `ModalFeature.checks` (which requires the checked feature to be
+uninterpretable), not stipulated. -/
+theorem interpreted_unchecked (checker f : ModalFeature)
+    (h : f.interp = .interpretable) : checker.checks f = false := by
+  have hb : (f.interp == .uninterpretable) = false := by rw [h]; decide
+  simp only [ModalFeature.checks, hb, Bool.and_false, Bool.false_and]
 
-def nonAuxData : List NonAuxModalDatum :=
-  [ ⟨"it's ok that", false⟩
-  , ⟨"be allowed to", false⟩
-  , ⟨"be required to", false⟩ ]
+/-- Corollary: an interpreted feature cannot be the checked conjunct of a
+`ConcordDerivation` — that would contradict `uInterp₂`. -/
+theorem interpreted_not_concord_checked (cd : ConcordDerivation) :
+    cd.f₂.interp ≠ .interpretable := by
+  rw [cd.uInterp₂]; decide
 
-/-- No non-auxiliary modal construction permits FC in coordination. -/
-theorem nonAux_no_fc : nonAuxData.all (·.fcInCoordination == false) = true := rfl
+/-! ### Against ATB movement (§1, ex. 3)
 
--- ============================================================================
--- §5. ATB Movement Counterexample
--- ============================================================================
-
-/-!
-## Against ATB Movement (§1, ex. 3)
-
-[simons-2005] proposed that the narrow-scope LF ◇(A ∨ B) arises
-from across-the-board (ATB) movement of the modal at LF. C&G note there
-is evidence AGAINST this: ATB movement is independently blocked for
-nominal quantifiers:
+[simons-2005] proposed that the narrow-scope LF `◇(A ∨ B)` arises from
+across-the-board (ATB) movement of the modal at LF. [ciardelli-guerrini-2026] note
+evidence *against* this: ATB movement is independently blocked for nominal
+quantifiers.
 
   (3a) Everyone sang or everyone danced.
   (3b) Everyone sang or danced.
 
-(3a) CANNOT be interpreted as (3b). If ATB movement of "everyone" were
-possible at LF, (3a) should receive the (3b) reading — but it doesn't.
-This undermines ATB as the mechanism for deriving narrow-scope modal LFs.
+(3a) cannot be interpreted as (3b). If ATB movement of "everyone" were possible at
+LF, (3a) should receive the (3b) reading — but it does not. This undermines ATB as
+the mechanism for deriving narrow-scope modal LFs. The modal concord account avoids
+the problem: the narrow-scope LF is derived by feature checking (specific to
+modals), not movement (which would overgeneralize to quantifiers).
 
-C&G's modal concord account avoids this problem: the narrow-scope LF is
-derived via feature checking (specific to modals), not movement (which
-would overgeneralize to quantifiers).
--/
+Formalizing the contrast faithfully needs a movement/quantifier substrate this
+study does not import, so the argument is recorded here as prose. -/
 
-/-- ATB counterexample data. -/
-structure ATBCounterexample where
-  surface : String
-  atbReading : String
-  atbReadingAvailable : Bool
-  deriving Repr
+/-! ### Concord across negation (§4.2)
 
-/-- (3) "Everyone sang or everyone danced" ≠ "Everyone sang or danced." -/
-def everyoneATB : ATBCounterexample :=
-  { surface := "Everyone sang or everyone danced"
-  , atbReading := "Everyone sang or danced"
-  , atbReadingAvailable := false }
+Modal concord across negation requires **opposite** forces. The checking uses
+`ModalForce.dual` — negation over a modal operator yields its dual:
 
--- ============================================================================
--- §6. Negation Flips Force for Concord
--- ============================================================================
+  (24) ALLOW[i∃](¬NEED[u∀]) ✓  — dual(∀) = ∃, matches the checker
+  (26) *DEMAND[i∀](¬NEED[u∀]) ✗  — dual(∀) = ∃ ≠ ∀
+  (25) DEMAND[i∀](¬MAY[u∃]) ✓  — dual(∃) = ∀, matches the checker
+  (27) *ALLOW[i∃](¬MAY[u∃]) ✗  — dual(∃) = ∀ ≠ ∃
 
-/-!
-## Concord Across Negation (§4.2)
-
-Modal concord across negation requires **opposite** forces. The checking
-uses `ModalForce.dual` — negation over a modal operator yields its dual:
-
-  (24) The countess allowed that I needn't do it again.
-       ALLOW[i∃](¬NEED[u∀]) ✓  — dual(∀) = ∃, matches checker
-
-  (26) *The countess firmly demanded that I needn't do it again.
-       *DEMAND[i∀](¬NEED[u∀]) ✗  — dual(∀) = ∃ ≠ ∀
-
-  (25) A restraining order demands that Roiland may not harass the plaintiff.
-       DEMAND[i∀](¬MAY[u∃]) ✓  — dual(∃) = ∀, matches checker
-
-  (27) *A special permit allows that Roiland may not recycle.
-       *ALLOW[i∃](¬MAY[u∃]) ✗  — dual(∃) = ∀ ≠ ∃
-
-The pattern: checking across negation succeeds iff the checker's force
-equals the dual of the checked item's force. This follows from
-`ModalFeature.checksAcrossNegation`, which uses `ModalForce.dual`.
--/
+The pattern: checking across negation succeeds iff the checker's force equals the
+dual of the checked item's force. This follows from
+`ModalFeature.checksAcrossNegation`, which uses `ModalForce.dual`. The
+generalization is from [grosz-2010] and [anand-brasoveanu-2010]. -/
 
 /-- (24) ALLOW[i∃] checks ¬NEED[u∀]: well-formed (dual(∀) = ∃). -/
 theorem allow_neg_need_ok :
     (ModalFeature.checksAcrossNegation
       ⟨.possibility, .interpretable⟩
       ⟨.necessity, .uninterpretable⟩)
-    = true := by native_decide
+    = true := by decide
 
 /-- (26) *DEMAND[i∀] checks ¬NEED[u∀]: ill-formed (dual(∀) = ∃ ≠ ∀). -/
 theorem demand_neg_need_bad :
     (ModalFeature.checksAcrossNegation
       ⟨.necessity, .interpretable⟩
       ⟨.necessity, .uninterpretable⟩)
-    = false := by native_decide
+    = false := by decide
 
 /-- (25) DEMAND[i∀] checks ¬MAY[u∃]: well-formed (dual(∃) = ∀). -/
 theorem demand_neg_may_ok :
     (ModalFeature.checksAcrossNegation
       ⟨.necessity, .interpretable⟩
       ⟨.possibility, .uninterpretable⟩)
-    = true := by native_decide
+    = true := by decide
 
 /-- (27) *ALLOW[i∃] checks ¬MAY[u∃]: ill-formed (dual(∃) = ∀ ≠ ∃). -/
 theorem allow_neg_may_bad :
     (ModalFeature.checksAcrossNegation
       ⟨.possibility, .interpretable⟩
       ⟨.possibility, .uninterpretable⟩)
-    = false := by native_decide
+    = false := by decide
 
-/-- General pattern: cross-negation concord succeeds ↔ forces are duals.
-    This is the content of the negation-concord generalization from
-    [grosz-2010] and [anand-brasoveanu-2010], formalized
-    as a consequence of `checksAcrossNegation` using `ModalForce.dual`. -/
+/-- General pattern: cross-negation concord succeeds iff the forces are duals.
+This is the content of the negation-concord generalization from [grosz-2010] and
+[anand-brasoveanu-2010], formalized as a consequence of `checksAcrossNegation`
+using `ModalForce.dual`. -/
 theorem negation_concord_pattern (checkerForce checkedForce : ModalForce)
     (hNec : checkerForce = .necessity ∨ checkerForce = .possibility)
     (hChk : checkedForce = .necessity ∨ checkedForce = .possibility) :
@@ -525,125 +414,101 @@ theorem negation_concord_pattern (checkerForce checkedForce : ModalForce)
     ↔ checkerForce = checkedForce.dual := by
   rcases hNec with rfl | rfl <;> rcases hChk with rfl | rfl <;> decide
 
--- ============================================================================
--- §7. "I need not cook and I need not clean" (§4.2, ex. 28-29)
--- ============================================================================
+/-! ### "I need not cook and I need not clean" (§4.2, ex. 28-29)
 
-/-!
-## Concord + Negation + Coordination (§4.2, ex. 28-29)
+"I need not cook and I need not clean" can convey `◇(¬Cook ∧ ¬Clean)` —
+permission to do neither — but not `□(¬Cook ∧ ¬Clean)` — obligation to do neither.
+This follows from the concord-across-negation generalization; the "need" u-feature
+force (necessity) comes from the Fragment. -/
 
-"I need not cook and I need not clean" can convey ◇(¬Cook ∧ ¬Clean) —
-permission to do neither — but NOT □(¬Cook ∧ ¬Clean) — obligation to do
-neither. This follows from the concord-across-negation generalization.
-
-The "need" u-feature force comes from the Fragment: necessity.
--/
-
-/-- "Need" carries [u∀-MOD] in the Fragment. -/
+/-- "Need" carries `[u∀-MOD]` in the Fragment. -/
 theorem need_feature_eq :
     need.toModalFeature = some ⟨.necessity, .uninterpretable⟩ := rfl
 
-/-- The existential reading is available: ◇[i∃] checks ¬NEED[u∀]. -/
+/-- The existential reading is available: `◇[i∃]` checks `¬NEED[u∀]`. -/
 theorem need_not_existential_ok :
     ModalFeature.checksAcrossNegation
       ⟨.possibility, .interpretable⟩
       need.toModalFeature.get!
-    = true := by native_decide
+    = true := by decide
 
-/-- The universal reading is blocked: □[i∀] cannot check ¬NEED[u∀]. -/
+/-- The universal reading is blocked: `□[i∀]` cannot check `¬NEED[u∀]`. -/
 theorem need_not_universal_blocked :
     ModalFeature.checksAcrossNegation
       ⟨.necessity, .interpretable⟩
       need.toModalFeature.get!
-    = false := by native_decide
+    = false := by decide
 
--- ============================================================================
--- §8. Conjunctive Permission (may-and-may)
--- ============================================================================
+/-! ### Conjunctive permission, may-and-may (§2, ex. 7-8)
 
-/-!
-## Conjunctive Permission (§2, ex. 7-8)
-
-"You may go to Bob's party and you may go to Charlie's party" has a
-reading where Alice is allowed to go to BOTH parties: ◇(Bob ∧ Charlie).
-
-This is distinct from ◇Bob ∧ ◇Charlie. Unlike disjunction, ◇(A ∧ B)
-is strictly STRONGER than ◇A ∧ ◇B — so the scope distinction has
-truth-conditional consequences for conjunction.
--/
+"You may go to Bob's party and you may go to Charlie's party" has a reading where
+Alice is allowed to go to both parties: `◇(Bob ∧ Charlie)`. Unlike disjunction,
+`◇(A ∧ B)` is strictly *stronger* than `◇A ∧ ◇B`, so for conjunction the scope
+distinction has truth-conditional consequences. -/
 
 /-- For conjunction, narrow scope is strictly stronger than wide scope:
-    ◇(A ∧ B) → ◇A ∧ ◇B but not conversely. -/
+`◇(A ∧ B) → ◇A ∧ ◇B` (but not conversely). -/
 theorem conjunctive_narrow_stronger {World : Type*}
     (p q : Set World)
     (h : diamond (p ∩ q)) : diamond p ∧ diamond q := by
   obtain ⟨w, hp, hq⟩ := h
   exact ⟨⟨w, hp⟩, ⟨w, hq⟩⟩
 
--- ============================================================================
--- §9. Bridge to Rotter & Liu 2025 Modal Concord Data
--- ============================================================================
+/-! ### Bridge to Rotter & Liu 2025 modal concord data
 
-/-!
-## Connection to Empirical Modal Concord ([rotter-liu-2025])
+[rotter-liu-2025] study "must have to VP" stacking, where two necessity modals
+yield a single-necessity reading (concord). This is the same phenomenon
+[ciardelli-guerrini-2026] exploit: one modal is semantically vacuous. The
+`ModalFeature.checks` infrastructure models it directly — one auxiliary carries
+`[i∀-MOD]`, the other `[u∀-MOD]`, and the i-feature checks the u-feature, leaving
+one semantic operator. -/
 
-[rotter-liu-2025] study "must have to VP" stacking, where two necessity
-modals yield a single-necessity reading (concord). This is the same phenomenon
-C&G exploit: modal concord — one modal is semantically vacuous.
-
-The `ModalFeature.checks` infrastructure from §3 models this directly: in
-"must have to", one auxiliary carries [i∀-MOD] and the other [u∀-MOD].
-The i-feature checks the u-feature, leaving only one semantic operator.
-
-The empirical finding that "must have to" preserves single-necessity meaning
-(`meaning_must_close_to_mustHaveTo`) is predicted by the concord mechanism.
--/
-
-/-- "Must" and "have to" have the same modal feature (both [u∀-MOD]).
-    Concord between them is predicted: same-force u-features. -/
+/-- "Must" and "have to" have the same modal feature (both `[u∀-MOD]`). Concord
+between them is predicted: same-force u-features. -/
 theorem must_haveTo_same_feature :
     must.toModalFeature = haveTo.toModalFeature := rfl
 
-/-- "Have to" carries [u∀-MOD]: necessity force, uninterpretable. -/
+/-- "Have to" carries `[u∀-MOD]`: necessity force, uninterpretable. -/
 theorem haveTo_feature_eq :
     haveTo.toModalFeature = some ⟨.necessity, .uninterpretable⟩ := rfl
 
-/-- "Must have to" concord as a `ConcordDerivation` — derived from Fragment.
-    The [rotter-liu-2025] finding that "must have to" yields single
-    necessity (not double necessity) follows: the checker checks both
-    u-features, leaving one semantic operator. -/
+/-- "Must have to" concord as a `ConcordDerivation` — derived from the Fragment. -/
 def mustHaveToConcord : ConcordDerivation :=
   .fromAux must haveTo must_feature_eq haveTo_feature_eq rfl rfl rfl
 
-/-- Cross-force concord fails: "must"[u∀] cannot be checked by a silent
-    [i∃-MOD] operator. This predicts no concord between necessity and
-    possibility modals. -/
+/-- **The concord prediction meets the [rotter-liu-2025] measurement.** The
+`ConcordDerivation` for "must have to" predicts a single-necessity reading; the
+experiment finds the meaning ratings of "must" and "must have to" essentially
+indistinguishable (`meaning_must_close_to_mustHaveTo`) — concord observed, not
+double necessity. -/
+theorem concord_predicts_mustHaveTo_single_necessity :
+    must.toModalFeature = haveTo.toModalFeature ∧
+    (RotterLiu2025Concord.meaningRating .must).mean
+      - (RotterLiu2025Concord.meaningRating .mustHaveTo).mean < 1/2 :=
+  ⟨must_haveTo_same_feature, RotterLiu2025Concord.meaning_must_close_to_mustHaveTo⟩
+
+/-- Cross-force concord fails: "must" `[u∀]` cannot be checked by a silent `[i∃-MOD]`
+operator. This predicts no concord between necessity and possibility modals. -/
 theorem must_may_no_concord :
     (ModalFeature.checks
       ⟨may.toModalFeature.get!.force, .interpretable⟩
       must.toModalFeature.get!)
-    = false := by native_decide
+    = false := by decide
 
--- ============================================================================
--- §10. Scope Data Verification (derived from Fragment)
--- ============================================================================
+/-! ### Scope-data verification against the Fragment
 
-/-!
-## Verifying Scope Data Against Fragment Entries
+The `modalForce` field in each `ScopeAmbiguityDatum` is independently verifiable
+against the Fragment's modal-meaning entries. -/
 
-The `modalForce` field in each `ScopeAmbiguityDatum` is independently
-verifiable against the Fragment's modal meaning entries.
--/
-
-/-- The force in mayOrMay matches the Fragment entry for "may". -/
+/-- The force in `mayOrMay` matches the Fragment entry for "may". -/
 theorem mayOrMay_force_verified :
     mayOrMay.modalForce = may.toModalFeature.get!.force := rfl
 
-/-- The force in mustOrMust matches the Fragment entry for "must". -/
+/-- The force in `mustOrMust` matches the Fragment entry for "must". -/
 theorem mustOrMust_force_verified :
     mustOrMust.modalForce = must.toModalFeature.get!.force := rfl
 
-/-- The force in mayAndMay matches the Fragment entry for "may". -/
+/-- The force in `mayAndMay` matches the Fragment entry for "may". -/
 theorem mayAndMay_force_verified :
     mayAndMay.modalForce = may.toModalFeature.get!.force := rfl
 


### PR DESCRIPTION
Bring `Studies/CiardelliGuerrini2026.lean` into mathlib-idiomatic form and fix two fidelity gaps found against the paper PDF.

- Conventions: 11 `native_decide` → `decide` (kernel-clean), ASCII banner headers → `/-! ### -/`, drop duplicate `example`, `simp` → `simp only`, remove inert Bool-table structs; 650 → 515 lines.
- Fidelity: replace the fabricated wide-scope exclusivity claim with `wideScope_underdetermines_fc` (the paper's non-entailment / ignorance reading); reground the auxiliary/non-auxiliary contrast on `ModalFeature.checks` and add the §4.3 (31) caveat instead of over-asserting `nonAux_no_fc`.
- Make the §9 Rotter & Liu bridge real — `concord_predicts_mustHaveTo_single_necessity` now consumes `meaning_must_close_to_mustHaveTo`.