### PR TITLE
refactor(Syntax/Minimalist): consolidate Probe API under Probe/

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2112,13 +2112,15 @@ import Linglib.Syntax.HPSG.Binding
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.Checking
 import Linglib.Syntax.Minimalist.Agree
-import Linglib.Syntax.Minimalist.Probe
+import Linglib.Syntax.Minimalist.Probe.Basic
+import Linglib.Syntax.Minimalist.Probe.Phi
+import Linglib.Syntax.Minimalist.Probe.Profile
+import Linglib.Syntax.Minimalist.Probe.Satisfaction
 import Linglib.Syntax.Minimalist.Aspect
 import Linglib.Syntax.Minimalist.CyclicAgree
 import Linglib.Syntax.Minimalist.NestedAgree
 import Linglib.Syntax.Minimalist.Phi.Geometry
 import Linglib.Syntax.Minimalist.Phi.Lattice
-import Linglib.Syntax.Minimalist.Phi.Probing
 import Linglib.Syntax.Minimalist.Phi.Articulation
 import Linglib.Syntax.Minimalist.PConstraint
 import Linglib.Syntax.Minimalist.ObligatoryOperations

--- a/Linglib/Studies/AissenPolian2025.lean
+++ b/Linglib/Studies/AissenPolian2025.lean
@@ -1,6 +1,7 @@
 import Linglib.Fragments.Mayan.Tseltalan
 import Linglib.Morphology.DM.NominalStructure
 import Linglib.Syntax.Minimalist.Agree
+import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Binding.SpecificityCondition
 import Linglib.Features.InformationStructure
 import Linglib.Typology.WordOrder

--- a/Linglib/Studies/BejarRezac2003.lean
+++ b/Linglib/Studies/BejarRezac2003.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Minimalist.Phi.Probing
+import Linglib.Syntax.Minimalist.Probe.Phi
 
 /-!
 # Béjar & Rezac 2003 — Person Licensing and the Derivation of PCC Effects

--- a/Linglib/Studies/CoonKeine2021.lean
+++ b/Linglib/Studies/CoonKeine2021.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Minimalist.Phi.Probing
+import Linglib.Syntax.Minimalist.Probe.Phi
 import Linglib.Syntax.Minimalist.Phi.Articulation
 import Linglib.Syntax.Minimalist.CyclicAgree
 import Linglib.Syntax.Minimalist.PConstraint

--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -1,7 +1,7 @@
 import Linglib.Fragments.NezPerce.ClausalEmbedding
 import Linglib.Typology.Complementation
-import Linglib.Syntax.Minimalist.Agree
-import Linglib.Syntax.Minimalist.Probe
+import Linglib.Syntax.Minimalist.Probe.Satisfaction
+import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Minimalist.ClauseSpine
 import Linglib.Semantics.Presupposition.ProjectiveContent
 

--- a/Linglib/Studies/Egressy2026.lean
+++ b/Linglib/Studies/Egressy2026.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Minimalist.Probe
+import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Semantics.Tense.Basic
 import Linglib.Semantics.Tense.Sequence.Basic
 import Linglib.Fragments.Hungarian.Predicates

--- a/Linglib/Studies/Halpert2012.lean
+++ b/Linglib/Studies/Halpert2012.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Minimalist.Phi.Probing
+import Linglib.Syntax.Minimalist.Probe.Basic
 
 /-!
 # Halpert 2012 — Argument Licensing and Agreement in Zulu [halpert-2012]

--- a/Linglib/Studies/Keine2019.lean
+++ b/Linglib/Studies/Keine2019.lean
@@ -1,5 +1,6 @@
 import Linglib.Syntax.Minimalist.Agree
 import Linglib.Syntax.Minimalist.ClauseSpine
+import Linglib.Syntax.Minimalist.Probe.Profile
 
 /-!
 # Selective Opacity [keine-2019]

--- a/Linglib/Studies/Keine2020.lean
+++ b/Linglib/Studies/Keine2020.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Minimalist.Probe
+import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Minimalist.ClauseSpine
 
 /-!

--- a/Linglib/Studies/LiuYip2026.lean
+++ b/Linglib/Studies/LiuYip2026.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Minimalist.Aspect
-import Linglib.Syntax.Minimalist.Probe
+import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Minimalist.ClauseSpine
 import Linglib.Typology.Complementation
 import Linglib.Features.Aktionsart

--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -2,7 +2,7 @@ import Linglib.Syntax.Minimalist.Voice
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.Agree
 import Linglib.Syntax.Minimalist.Phase
-import Linglib.Syntax.Minimalist.Probe
+import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Studies.ErlewineSommerlot2025
 import Linglib.Studies.Coon2019
 import Linglib.Studies.CoonMateoPedroPreminger2014

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Minimalist.Phi.Geometry
-import Linglib.Syntax.Minimalist.Phi.Probing
+import Linglib.Syntax.Minimalist.Probe.Phi
 import Linglib.Syntax.Minimalist.ObligatoryOperations
 import Linglib.Morphology.DM.VocabSimple
 import Linglib.Fragments.Mayan.Kaqchikel.Agreement

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -2,7 +2,8 @@ import Linglib.Syntax.Case.Dependent
 import Linglib.Syntax.Case.Alignment
 import Linglib.Syntax.Minimalist.Voice
 import Linglib.Syntax.Minimalist.Agree
-import Linglib.Syntax.Minimalist.Phi.Probing
+import Linglib.Syntax.Minimalist.Probe.Basic
+import Linglib.Syntax.Minimalist.Probe.Satisfaction
 import Linglib.Syntax.Minimalist.ObligatoryOperations
 import Linglib.Morphology.DM.VocabSimple
 import Linglib.Morphology.DM.Impoverishment
@@ -568,25 +569,20 @@ structure Encounter where
   feats : FeatureBundle
   cat : Option Cat
 
-/-- Visibility of an encounter to a probe with satisfaction condition
-    `cond`: the encounter halts the search ([deal-2024] interaction). -/
-def halts (cond : SatisfactionCond) (e : Encounter) : Bool :=
-  cond.isSatisfied e.feats e.cat
+/-- The probe a `SatisfactionCond` denotes over `Encounter`s: the
+    substrate's generic `SatisfactionCond.toProbe`
+    (`Probe/Satisfaction.lean`) instantiated at the `Encounter`
+    projections — visibility = halting ([deal-2024] interaction),
+    activity = feature copying (satisfaction). -/
+def satProbe (cond : SatisfactionCond) : Probe Encounter :=
+  cond.toProbe Encounter.feats Encounter.cat
 
-/-- The probe a `SatisfactionCond` specification denotes, over
-    encounters: visibility = halting ([deal-2024] interaction),
-    activity = feature copying. The canonical
-    specification-to-`Probe` map for satisfaction conditions. -/
-def _root_.Minimalist.SatisfactionCond.toProbe (cond : SatisfactionCond) :
-    Probe Encounter :=
-  { vis := halts cond, act := fun e => cond.copiedFeatures e.feats e.cat }
-
-/-- The argument position a probe φ-agrees with: `cond.toProbe.agree`
+/-- The argument position a probe φ-agrees with: `(satProbe cond).agree`
     — the probe agrees with the found element only if satisfaction
     copied features (feature match, not head encounter). -/
 def agreesWith (cond : SatisfactionCond) (goals : List Encounter) :
     Option ArgPosition :=
-  (cond.toProbe.agree goals).bind (·.pos)
+  ((satProbe cond).agree goals).bind (·.pos)
 
 /-- Transitive Voice as an encounter: a head of category `.v`, no
     φ-features visible to the probe. -/
@@ -631,21 +627,18 @@ theorem infl_truncated_at_voiceTR (rest : List Encounter) :
 theorem infl_finds_S (φS : FeatureBundle)
     (hS : hasValuedFeature φS (.phi (.person .third)) = true) :
     agreesWith mamInflSatisfaction [dpGoal .S φS] = some .S := by
-  have h1 : halts mamInflSatisfaction ⟨some .S, φS, none⟩ = true := by
-    simp [halts, mamInflSatisfaction_isSatisfied, hS]
-  simp [agreesWith, SatisfactionCond.toProbe, Probe.agree, Probe.search, Option.filter_some,
-    dpGoal, h1, mamInflSatisfaction_copiedFeatures, hS]
+  simp [agreesWith, satProbe, SatisfactionCond.toProbe, Probe.agree, Probe.search,
+    Option.filter_some, dpGoal, mamInflSatisfaction_isSatisfied,
+    mamInflSatisfaction_copiedFeatures, hS]
 
 /-- Voice's search finds the agent (closest goal), provided A bears
     person. -/
 theorem voice_finds_A (φA φP : FeatureBundle)
     (hA : hasValuedFeature φA (.phi (.person .third)) = true) :
     agreesWith voiceSat [dpGoal .A φA, dpGoal .P φP] = some .A := by
-  have h1 : halts (.featureMatch (.phi (.person .third)))
-      ⟨some .A, φA, none⟩ = true := by
-    simp [halts, SatisfactionCond.isSatisfied, hA]
-  simp [agreesWith, SatisfactionCond.toProbe, Probe.agree, Probe.search, Option.filter_some,
-    dpGoal, voiceSat, h1, SatisfactionCond.copiedFeatures, hA]
+  simp [agreesWith, satProbe, SatisfactionCond.toProbe, Probe.agree, Probe.search,
+    Option.filter_some, dpGoal, voiceSat, SatisfactionCond.isSatisfied,
+    SatisfactionCond.copiedFeatures, hA]
 
 /-- DERIVED probe table: which head φ-agrees with position `p`,
     computed by running each probe's `Probe.search` over the goal
@@ -682,7 +675,7 @@ theorem agreeProbe_eq_derived_3sg :
 
 /-- φ-valuation outcome of a probe with a satisfaction condition:
     valued iff the search found a goal AND satisfaction copied
-    features. NOTE: this is NOT `cond.toProbe.outcome` — a
+    features. NOTE: this is NOT `(satProbe cond).outcome` — a
     head-encounter halt satisfies the search but leaves the probe
     φ-unvalued. -/
 def valuationOutcome (cond : SatisfactionCond) (goals : List Encounter) :
@@ -703,7 +696,7 @@ theorem transitive_unvalued_elsewhere (rest : List Encounter) :
     element. The valuation/satisfaction distinction is exactly
     [deal-2024]'s interaction-vs-satisfaction split. -/
 theorem searchOutcome_valued_but_unvalued (rest : List Encounter) :
-    (mamInflSatisfaction.toProbe).outcome (voiceTR :: rest) = .valued ∧
+    (satProbe mamInflSatisfaction).outcome (voiceTR :: rest) = .valued ∧
     valuationOutcome mamInflSatisfaction (voiceTR :: rest) = .unvalued :=
   ⟨rfl, rfl⟩
 

--- a/Linglib/Syntax/Minimalist/Agree.lean
+++ b/Linglib/Syntax/Minimalist/Agree.lean
@@ -1,6 +1,6 @@
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.Phase
-import Linglib.Syntax.Minimalist.Probe
+import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 
 /-!
 # Agree (Minimalist Feature Checking)
@@ -102,75 +102,17 @@ def validAgree (a : AgreeRelation) (root : SyntacticObject) : Prop :=
 -- § 3: Locality (Closest Goal)
 -- ============================================================================
 
-/-- X intervenes between probe and goal (within tree `root`) iff:
-    - probe c-commands X
-    - X c-commands goal
-    - X has a matching valued feature -/
-def intervenes (root : SyntacticObject) (probe x goal : SyntacticObject)
-    (xFeatures : FeatureBundle) (ftype : FeatureVal) : Prop :=
-  cCommandsIn root probe x ∧
-  cCommandsIn root x goal ∧
-  hasValuedFeature xFeatures ftype = true
+-- "Closest matching goal, no intervener" is the canonical list engine
+-- `Probe.search` (`Probe/Basic.lean`, `search_eq_some_iff_closest`); the
+-- tree-native `closestGoal`/`closestGoalWith`/`intervenes` reinventions
+-- (zero consumers) were retired. `SyntacticObject` is a commutative magma
+-- with no canonical c-command linearization, so the tree↔list bridge is
+-- not definitional; `closestGoalB` below is the decidable tree presentation.
 
-/-- Goal is the closest matching goal for probe.
-
-    **Caveat**: this definition existentially quantifies over feature
-    bundles (`∃ xFeats`), meaning ANY structurally intervening node
-    blocks regardless of its actual features. This is strictly stronger
-    than necessary — a V° with no phi-features would block a phi-probe.
-    For derivations that need to distinguish nodes by their actual
-    features, use `closestGoalWith` (propositional, with feature
-    assignment) or `closestGoalB` (boolean, with matching predicate). -/
-def closestGoal (a : AgreeRelation) (root : SyntacticObject) : Prop :=
-  validAgree a root ∧
-  ¬∃ (x : SyntacticObject) (xFeats : FeatureBundle),
-    isTermOf x root ∧
-    x ≠ a.goal ∧
-    intervenes root a.probe x a.goal xFeats a.feature
-
--- ============================================================================
--- § 3b: Feature-Aware Locality
--- ============================================================================
-
-/-- A feature assignment maps each syntactic object in a tree to its
-    actual feature bundle. -/
-abbrev FeatureAssignment := SyntacticObject → FeatureBundle
-
-/-- Goal is the closest matching goal for probe, given a feature
-    assignment that determines each node's actual features.
-
-    Compared to `closestGoal`: the existential `∃ xFeats` is replaced
-    by `fa x`, so only nodes whose ACTUAL features match can intervene.
-    This correctly models Agree: a V° (no phi-features) should not
-    block T°'s phi-probe even if V° is structurally between T° and the
-    subject DP. `closestGoal` is strictly stronger (see
-    `closestGoal_implies_closestGoalWith`). -/
-def closestGoalWith (a : AgreeRelation) (root : SyntacticObject)
-    (fa : FeatureAssignment) : Prop :=
-  validAgree a root ∧
-  ¬∃ x, isTermOf x root ∧ x ≠ a.goal ∧
-    intervenes root a.probe x a.goal (fa x) a.feature
-
-/-- `closestGoal` (existential over features) implies `closestGoalWith`
-    (fixed feature assignment): if no node with ANY features intervenes,
-    then no node with its ACTUAL features intervenes. -/
-theorem closestGoal_implies_closestGoalWith
-    (a : AgreeRelation) (root : SyntacticObject) (fa : FeatureAssignment)
-    (h : closestGoal a root) : closestGoalWith a root fa :=
-  ⟨h.1, fun ⟨x, hTerm, hNeq, hInt⟩ => h.2 ⟨x, fa x, hTerm, hNeq, hInt⟩⟩
-
-/-- Boolean closest-goal check: is `goal` the closest node matching
-    `pred` in `probe`'s c-command domain within `root`?
-
-    This is the computational counterpart of `closestGoalWith`, using
-    decidable `cCommandsIn` and a matching predicate. `pred` determines
-    which nodes are potential goals/interveners — typically a category
-    check (e.g., "is this node D-bearing?").
-
-    1. `probe` c-commands `goal`
-    2. `goal` matches the predicate
-    3. No other matching node is both c-commanded by `probe` AND
-       c-commands `goal` (= no intervener) -/
+/-- Decidable tree presentation of `Probe.search`-locality
+    (`Probe.search_eq_some_iff_closest`, `pred` playing `Probe.vis`):
+    `goal` is `pred`-matching and c-commanded by `probe`, with no
+    `pred`-matching node c-commanded by `probe` c-commanding `goal`. -/
 def closestGoalB (root probe goal : SyntacticObject)
     (pred : SyntacticObject → Bool) : Bool :=
   decide (cCommandsIn root probe goal) &&
@@ -400,70 +342,10 @@ def validAgreeWithActivity (a : AgreeRelation) (root : SyntacticObject) : Prop :
   validAgree a root ∧
   isActive a.goalFeatures = true
 
--- ============================================================================
--- § 10: Multiple Agree ([hiraiwa-2001], 2005)
--- ============================================================================
-
-/-- Multiple Agree: a probe agreeing with a list of goals -/
-structure MultipleAgree where
-  probe : SyntacticObject
-  probeFeatures : FeatureBundle
-  goals : List (SyntacticObject × FeatureBundle)
-  feature : FeatureVal
-  -- All goals must have the relevant valued feature
-  goalsHaveFeature : goals.all (λ ⟨_, gf⟩ => hasValuedFeature gf feature)
-  deriving Repr
-
-/-- Is Multiple Agree valid? Each goal must be c-commanded by probe (within tree) -/
-def MultipleAgree.isValid (ma : MultipleAgree) (root : SyntacticObject) : Prop :=
-  hasUnvaluedFeature ma.probeFeatures ma.feature = true ∧
-  ∀ (g : SyntacticObject × FeatureBundle), g ∈ ma.goals →
-    cCommandsIn root ma.probe g.1
-
-/-- Apply Multiple Agree: value probe's feature, mark all goals -/
-def applyMultipleAgree (ma : MultipleAgree) : Option FeatureBundle :=
-  match ma.goals.head? with
-  | none => none
-  | some (_, gf) =>
-    match getValuedFeature gf ma.feature with
-    | none => none
-    | some goalFeat =>
-      some (ma.probeFeatures.map λ f =>
-        if f.isUnvalued && (f.featureType == ma.feature) then
-          match valueFeature f goalFeat with
-          | some v => v
-          | none => f
-        else f)
-
--- ============================================================================
--- § 11: Defective Intervention ([chomsky-2000])
--- ============================================================================
-
-/-- A defective element: has some matching features but incomplete set -/
-structure DefectiveElement where
-  so : SyntacticObject
-  features : FeatureBundle
-  -- Has at least one phi feature
-  hasPartialPhi : (features.any λ f => match f.featureType with
-    | .phi _ => true
-    | _ => false) = true
-  -- But not a complete phi set (deficient)
-  isDeficient : Bool  -- Simplified: mark as deficient
-  deriving Repr
-
-/-- Does X defectively intervene between probe and goal (within tree `root`)?
-
-    X defectively intervenes if:
-    - X is between probe and goal (c-command wise)
-    - X has matching features
-    - X is defective (can't be a full goal) -/
-def defectivelyIntervenes (root : SyntacticObject) (probe x goal : SyntacticObject)
-    (xDef : DefectiveElement) (ftype : FeatureVal) : Prop :=
-  cCommandsIn root probe x ∧
-  cCommandsIn root x goal ∧
-  xDef.so = x ∧
-  xDef.isDeficient = true ∧
-  (xDef.features.any λ f => featuresMatch f (.unvalued ftype)) = true
+-- Multiple Agree ([hiraiwa-2001]) is `Probe` over a goal list; defective
+-- intervention ([chomsky-2000]) is a visible-but-inactive closest goal
+-- absorbing the probe (`Probe.agree_eq_none_of_inactive`). The former
+-- `MultipleAgree`/`DefectiveElement` reinventions (zero consumers) were retired.
 
 -- ============================================================================
 -- § 12: Phase-Bounded Agree
@@ -526,118 +408,5 @@ theorem neg_features_match :
 
 theorem rel_features_match :
     featuresMatch (.unvalued (.rel true)) (.valued (.rel false)) = true := rfl
-
--- ============================================================================
--- § 14: Satisfaction Conditions ([deal-2024]; [keine-2019])
--- ============================================================================
-
-/-- How a probe's search can be terminated.
-
-    Standard Agree assumes a probe is satisfied only by finding a matching
-    valued feature (simple feature match). [deal-2024] argues for richer
-    conditions to capture e.g. Mam's Infl probe, which is satisfied by
-    EITHER matching φ-features OR encountering transitive Voice:
-
-    **Mam example** ([scott-2023], via [deal-2024]):
-    - Infl carries [uφ] with satisfaction [SAT: φ or Voice_TR]
-    - Intransitive: probe passes through (no Voice_TR) → finds S → real φ-agreement
-    - Transitive: probe encounters Voice_TR → satisfied without copying φ → default "∅"
-
-    This turns the Mam bridge's prose account into a computable derivation:
-    ```
-    def mamInflSatisfaction : SatisfactionCond :=
-.disjunctive [.featureMatch (.phi (.person.third)),.headEncounter.v]
-    ```
--/
-inductive SatisfactionCond where
-  /-- Standard: probe is satisfied by finding a matching valued feature. -/
-  | featureMatch : FeatureVal → SatisfactionCond
-  /-- Disjunctive: probe is satisfied by ANY of these conditions.
-      Models [deal-2024]'s interaction-based probes. -/
-  | disjunctive : List SatisfactionCond → SatisfactionCond
-  /-- Head encounter: probe is satisfied by encountering a head of this
-      category, even without feature matching. The probe stops but copies
-      no features — yielding the Elsewhere (default) exponent at PF. -/
-  | headEncounter : Cat → SatisfactionCond
-  deriving Repr
-
-/-- Is an atomic (non-disjunctive) condition met? -/
-private def atomicSatisfied (cond : SatisfactionCond) (fb : FeatureBundle)
-    (ctx : Option Cat) : Bool :=
-  match cond with
-  | .featureMatch ft => hasValuedFeature fb ft
-  | .headEncounter cat => ctx == some cat
-  | .disjunctive _ => false  -- nested disjunctions handled at top level
-
-/-- Check whether a satisfaction condition is met.
-
-    `fb` is the feature bundle of the element the probe encounters.
-    `ctx` is the syntactic category of that element (if it's a head).
-    Returns `true` if the probe should stop searching. -/
-def SatisfactionCond.isSatisfied (cond : SatisfactionCond) (fb : FeatureBundle)
-    (ctx : Option Cat) : Bool :=
-  match cond with
-  | .featureMatch ft => hasValuedFeature fb ft
-  | .disjunctive conds => conds.any (atomicSatisfied · fb ctx)
-  | .headEncounter cat => ctx == some cat
-
-/-- Did the probe copy features, or just stop?
-
-    When satisfied by feature match, the probe copies features (→ real agreement).
-    When satisfied by head encounter, no features are copied (→ default/Elsewhere).
-    For disjunctive conditions, feature copying occurs iff the first satisfied
-    condition is a feature match. -/
-def SatisfactionCond.copiedFeatures (cond : SatisfactionCond) (fb : FeatureBundle)
-    (ctx : Option Cat) : Bool :=
-  match cond with
-  | .featureMatch ft => hasValuedFeature fb ft
-  | .disjunctive conds =>
-    match conds.find? (atomicSatisfied · fb ctx) with
-    | some (.featureMatch ft) => hasValuedFeature fb ft
-    | _ => false  -- head encounter or nested → no features copied
-  | .headEncounter _ => false
-
-/-- Mam's Infl probe satisfaction condition:
-    satisfied by EITHER matching φ-features OR encountering transitive Voice. -/
-def mamInflSatisfaction : SatisfactionCond :=
-  .disjunctive [.featureMatch (.phi (.person .third)), .headEncounter .v]
-
-/-- Intransitive environment: the probe encounters a DP with φ-features
-    (no Voice_TR in the way). Feature match is satisfied → real agreement. -/
-theorem mam_intransitive_satisfied :
-    mamInflSatisfaction.isSatisfied
-      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
-      none = true := by rfl
-
-/-- Transitive environment: the probe encounters Voice_TR (category.v).
-    Head encounter is satisfied → probe stops without copying features. -/
-theorem mam_transitive_satisfied :
-    mamInflSatisfaction.isSatisfied [] (some .v) = true := by rfl
-
-/-- In the transitive case, no features are copied — yielding default. -/
-theorem mam_transitive_no_copy :
-    mamInflSatisfaction.copiedFeatures [] (some .v) = false := by rfl
-
-/-- In the intransitive case, features ARE copied — yielding real agreement. -/
-theorem mam_intransitive_copies :
-    mamInflSatisfaction.copiedFeatures
-      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
-      none = true := by rfl
-
-/-- Infl's satisfaction condition, unfolded: φ-match or Voice_TR encounter. -/
-theorem mamInflSatisfaction_isSatisfied (fb : FeatureBundle) (ctx : Option Cat) :
-    mamInflSatisfaction.isSatisfied fb ctx
-      = (hasValuedFeature fb (.phi (.person .third)) || ctx == some Cat.v) := by
-  simp [mamInflSatisfaction, SatisfactionCond.isSatisfied, atomicSatisfied]
-
-/-- Head-encounter satisfaction never copies: Infl copies features iff
-    they are there to copy, whatever the context. -/
-theorem mamInflSatisfaction_copiedFeatures (fb : FeatureBundle) (ctx : Option Cat) :
-    mamInflSatisfaction.copiedFeatures fb ctx
-      = hasValuedFeature fb (.phi (.person .third)) := by
-  cases hv : hasValuedFeature fb (.phi (.person .third)) <;>
-    cases hc : ctx == some Cat.v <;>
-      simp [mamInflSatisfaction, SatisfactionCond.copiedFeatures, atomicSatisfied,
-        List.find?, hv, hc]
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Aspect.lean
+++ b/Linglib/Syntax/Minimalist/Aspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Minimalist.Probe
+import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Features.Aktionsart
 

--- a/Linglib/Syntax/Minimalist/CyclicAgree.lean
+++ b/Linglib/Syntax/Minimalist/CyclicAgree.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Minimalist.Phi.Geometry
-import Linglib.Syntax.Minimalist.Phi.Probing
+import Linglib.Syntax.Minimalist.Probe.Phi
 
 /-!
 # Cyclic Agree [bejar-rezac-2009]

--- a/Linglib/Syntax/Minimalist/NestedAgree.lean
+++ b/Linglib/Syntax/Minimalist/NestedAgree.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Minimalist.Probe
+import Linglib.Syntax.Minimalist.Probe.Profile
 
 /-!
 # Nested Agree [amato-2025]

--- a/Linglib/Syntax/Minimalist/Probe/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Basic.lean
@@ -1,38 +1,43 @@
 import Mathlib.Order.UpperLower.Basic
-import Linglib.Syntax.Agreement.Paradigm
-import Linglib.Syntax.Minimalist.Phi.Geometry
 import Linglib.Syntax.Minimalist.ObligatoryOperations
 
 /-!
-# Probes: relativized search over a goal sequence
+# Probe: relativized search over a goal sequence
 [bejar-rezac-2003] [preminger-2014]
 
-The derivational middle layer between DP-level probe visibility
-(`probeVisible`, `Phi/Geometry.lean`) and PF-level outcomes
-(`Probe.Outcome`, `ObligatoryOperations.lean`). A `Probe` bundles what
-it *sees* (`vis` — interaction/halting: the search stops at the first
-visible goal) and what it can *value* there (`act` — activity: a
-visible but inactive goal absorbs the probe without valuing it,
-[bejar-rezac-2003]'s inactive dative, [deal-2024]-style interaction
-vs. satisfaction). Licensing is being the goal the search reaches —
-from which the Person Licensing Condition's effects derive: one
-search licenses at most one goal (`Probe.allLicensed_iff`).
+The canonical, theory-agnostic probe primitive. A `Probe α` searches a
+goal sequence of arbitrary type `α`; everything probe-shaped in the
+library denotes one of these by a `toProbe`-map rather than
+re-implementing search (see **Probe specifications** below). The probe
+bundles what it *sees* (`vis` — interaction/halting: the search stops at
+the first visible goal) and what it can *value* there (`act` —
+activity: a visible but inactive goal absorbs the probe without valuing
+it, [bejar-rezac-2003]'s inactive dative, [deal-2024]-style interaction
+vs. satisfaction). Licensing is being the goal the search reaches — from
+which the Person Licensing Condition's effects derive: one search
+licenses at most one goal (`Probe.allLicensed_iff`).
+
+This file is the maximally-general core (`α` arbitrary); the φ-feature
+*specialization* (`Agreement.Cell.visibleTo`, `Probe.Target.toProbe`,
+`PLC`) lives in `Probe/Phi.lean`, the Deal satisfaction-condition spec
+in `Probe/Satisfaction.lean`, and Keine's locality/horizon spec in
+`Probe/Profile.lean`. `Minimalist/Probe.lean` re-exports the lot.
 
 Relativization is [preminger-2014]'s addition (§4.2, recalling
-[rizzi-1990]): the φ-instantiation (`Agreement.Cell.visibleTo`,
-`PLC`) specializes `vis` to his participant-relativized person probe.
-[bejar-rezac-2003]'s own π-probe is *unrelativized* — the closest
-goal matches and can absorb it (`Studies/BejarRezac2003.lean`) — and
-the unrelativized, bare-minimality probe (`Probe.indiscriminate`,
-goal = `List.head?`) is [halpert-2012]'s Zulu L⁰
-(`Studies/Halpert2012.lean`, the cross-linguistic point of
-[preminger-2014] Ch. 7). [bejar-rezac-2009]'s articulated probe is a
-*family* of these searches, one per probe segment over the cyclically
-ordered token list — see `CyclicAgree.eaIsLicensed_iff_segment_licensed`,
-and `Phi/Articulation.lean` for the laws of articulation. For probe
+[rizzi-1990]): the φ-instantiation (`Agreement.Cell.visibleTo`, `PLC`)
+specializes `vis` to his participant-relativized person probe.
+[bejar-rezac-2003]'s own π-probe is *unrelativized* — the closest goal
+matches and can absorb it (`Studies/BejarRezac2003.lean`) — and the
+unrelativized, bare-minimality probe (`Probe.indiscriminate`, goal =
+`List.head?`) is [halpert-2012]'s Zulu L⁰ (`Studies/Halpert2012.lean`,
+the cross-linguistic point of [preminger-2014] Ch. 7).
+[bejar-rezac-2009]'s articulated probe is a *family* of these searches,
+one per probe segment over the cyclically ordered token list — see
+`CyclicAgree.eaIsLicensed_iff_segment_licensed`, and
+`Phi/Articulation.lean` for the laws of articulation. For probe
 *horizons* (what terminates search across domains, Keine) see
-`Syntax/Minimalist/Probe.lean`; for conditional feature-acquiring
-re-probing see `Syntax/Minimalist/Probing/DefectiveCircumvention.lean`.
+`Probe/Profile.lean`; for conditional feature-acquiring re-probing see
+`Syntax/Minimalist/Probing/DefectiveCircumvention.lean`.
 
 ## Main declarations
 
@@ -49,19 +54,19 @@ re-probing see `Syntax/Minimalist/Probing/DefectiveCircumvention.lean`.
   goal is the closest).
 - `Probe.cascade` — ordered probe sequence: first probe with output
   wins (the single-slot morphological competition).
-- `PLC` — the Person Licensing Condition over φ-bearing goal tokens.
 
 ## Probe specifications
 
 Theory-side probe descriptions relate to `Probe` by *denotation*
 (canonical `toProbe`-maps), not extension — the relationship is
 one-to-many for articulated probes and state-indexed for dynamic
-ones: `Probe.Target.toProbe` (here), `SatisfactionCond.toProbe`
-(`Studies/Scott2023.lean`), `Probe.Articulated.toProbes`
-(`Phi/Articulation.lean`, the per-segment family),
-`CyclicAgree.segProbe` (per segment and geometry), and
-`Deal2024.ProbeState.probe` (the state-indexed family whose
-narrowing law is `probe_vis_antitone`).
+ones: `Probe.Target.toProbe` (`Probe/Phi.lean`),
+`SatisfactionCond.toProbe` (`Probe/Satisfaction.lean`),
+`Probe.Profile.toProbe` (`Probe/Profile.lean`),
+`Probe.Articulated.toProbes` (`Phi/Articulation.lean`, the per-segment
+family), `CyclicAgree.segProbe` (per segment and geometry), and
+`Deal2024.ProbeState.probe` (the state-indexed family whose narrowing
+law is `probe_vis_antitone`).
 -/
 
 namespace Minimalist
@@ -161,6 +166,13 @@ theorem agree_eq_none_of_inactive {a : α}
     p.agree goals = none := by
   simp [agree, h, Option.filter_some, ha]
 
+/-- Locality as list search: the probe finds `a` iff `a` is visible and
+    every earlier goal is invisible (no intervener). -/
+theorem search_eq_some_iff_closest {a : α} :
+    p.search goals = some a ↔
+      p.vis a ∧ ∃ l₁ l₂, goals = l₁ ++ a :: l₂ ∧ ∀ b ∈ l₁, !p.vis b :=
+  List.find?_eq_some_iff_append
+
 /-! ### Outcomes ([preminger-2014] Ch. 5) -/
 
 /-- The outcome of an obligatory probing operation over a goal
@@ -211,6 +223,13 @@ instance [DecidableEq α] (p : Probe α) (goals : List α) (a : α) :
 theorem Licensed.unique {a b : α}
     (ha : p.Licensed goals a) (hb : p.Licensed goals b) : a = b :=
   Option.some.inj (ha.symm.trans hb)
+
+/-- Licensing is being the closest visible goal: no matching goal
+    intervenes (`search_eq_some_iff_closest` in the licensing API). -/
+theorem licensed_iff_closest {a : α} :
+    p.Licensed goals a ↔
+      p.vis a ∧ ∃ l₁ l₂, goals = l₁ ++ a :: l₂ ∧ ∀ b ∈ l₁, !p.vis b :=
+  search_eq_some_iff_closest
 
 /-- Licensing by the indiscriminate probe is being the structurally
     closest goal — bare minimality, [halpert-2012]'s L⁰. -/
@@ -312,39 +331,5 @@ theorem mem_of_cascade_eq_some {a : α}
   mem_of_search_eq_some hq
 
 end Probe
-
-/-! ### φ-probes -/
-
-/-- Visibility of a φ-cell to a relativized probe: the cell bears the
-    feature the probe seeks (`probeVisible`, `Phi/Geometry.lean`). -/
-def _root_.Agreement.Cell.visibleTo (c : Agreement.Cell) (t : Probe.Target) : Bool :=
-  probeVisible t c.toPerson c.isPlural
-
-/-- The probe a `Probe.Target` specification denotes: relativized to
-    the sought feature, over φ-cells. The canonical
-    specification-to-`Probe` map for the substrate's probe enum —
-    [preminger-2014]'s π⁰ is `Probe.Target.participant.toProbe`, his
-    #⁰ is `Probe.Target.plural.toProbe`. -/
-def Probe.Target.toProbe (t : Probe.Target) : Probe Agreement.Cell :=
-  .ofVis (·.visibleTo t)
-
-/-- The Person Licensing Condition ([bejar-rezac-2003];
-    [preminger-2014] (40)/(75)): every [participant]-bearing goal
-    token must be licensed by the person probe's search. Goal tokens
-    have type `α` with a φ-cell projection, so two arguments with
-    identical φ remain distinct licensees.
-
-    This is [preminger-2014]'s single-cycle, search-only, diagonal
-    rendering of the condition: it omits [bejar-rezac-2003]'s
-    F-licensing route (a nominal's own φ-bearing P/dative/focus head
-    counts as a licensing Agree relation) and multi-cycle repairs —
-    for the paper's own condition see `BejarRezac2003.PLCOk`. -/
-def PLC (cellOf : α → Agreement.Cell) (goals : List α) : Prop :=
-  (Probe.ofVis fun a => (cellOf a).visibleTo .participant).AllLicensed
-    (fun a => (cellOf a).visibleTo .participant) goals
-
-instance [DecidableEq α] (cellOf : α → Agreement.Cell) (goals : List α) :
-    Decidable (PLC cellOf goals) :=
-  inferInstanceAs (Decidable (Probe.AllLicensed _ _ goals))
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Probe/Phi.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Phi.lean
@@ -1,0 +1,57 @@
+import Linglib.Syntax.Minimalist.Probe.Basic
+import Linglib.Syntax.Agreement.Paradigm
+import Linglib.Syntax.Minimalist.Phi.Geometry
+
+/-!
+# φ-probes: the φ-feature specialization of `Probe`
+[preminger-2014] [bejar-rezac-2003]
+
+The φ-instantiation of the general `Probe` core (`Probe/Basic.lean`):
+probes over `Agreement.Cell`s, relativized by the sought feature
+(`Probe.Target`, `Phi/Geometry.lean`). This is [preminger-2014]'s
+participant-relativized person probe and the Person Licensing
+Condition built on it.
+
+## Main declarations
+
+- `Agreement.Cell.visibleTo` — a cell bears the feature a target seeks.
+- `Probe.Target.toProbe` — the canonical specification-to-`Probe` map:
+  π⁰ is `Probe.Target.participant.toProbe`, #⁰ is `.plural.toProbe`.
+- `PLC` — the Person Licensing Condition over φ-bearing goal tokens.
+-/
+
+namespace Minimalist
+
+/-- Visibility of a φ-cell to a relativized probe: the cell bears the
+    feature the probe seeks (`probeVisible`, `Phi/Geometry.lean`). -/
+def _root_.Agreement.Cell.visibleTo (c : Agreement.Cell) (t : Probe.Target) : Bool :=
+  probeVisible t c.toPerson c.isPlural
+
+/-- The probe a `Probe.Target` specification denotes: relativized to
+    the sought feature, over φ-cells. The canonical
+    specification-to-`Probe` map for the substrate's probe enum —
+    [preminger-2014]'s π⁰ is `Probe.Target.participant.toProbe`, his
+    #⁰ is `Probe.Target.plural.toProbe`. -/
+def Probe.Target.toProbe (t : Probe.Target) : Probe Agreement.Cell :=
+  .ofVis (·.visibleTo t)
+
+/-- The Person Licensing Condition ([bejar-rezac-2003];
+    [preminger-2014] (40)/(75)): every [participant]-bearing goal
+    token must be licensed by the person probe's search. Goal tokens
+    have type `α` with a φ-cell projection, so two arguments with
+    identical φ remain distinct licensees.
+
+    This is [preminger-2014]'s single-cycle, search-only, diagonal
+    rendering of the condition: it omits [bejar-rezac-2003]'s
+    F-licensing route (a nominal's own φ-bearing P/dative/focus head
+    counts as a licensing Agree relation) and multi-cycle repairs —
+    for the paper's own condition see `BejarRezac2003.PLCOk`. -/
+def PLC {α : Type*} (cellOf : α → Agreement.Cell) (goals : List α) : Prop :=
+  (Probe.ofVis fun a => (cellOf a).visibleTo .participant).AllLicensed
+    (fun a => (cellOf a).visibleTo .participant) goals
+
+instance {α : Type*} [DecidableEq α] (cellOf : α → Agreement.Cell) (goals : List α) :
+    Decidable (PLC cellOf goals) :=
+  inferInstanceAs (Decidable (Probe.AllLicensed _ _ goals))
+
+end Minimalist

--- a/Linglib/Syntax/Minimalist/Probe/Profile.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Profile.lean
@@ -1,5 +1,6 @@
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Syntax.Minimalist.ClauseSpine
+import Linglib.Syntax.Minimalist.Probe.Basic
 
 /-!
 # Probe Profiles ([keine-2019], [keine-2020])
@@ -35,8 +36,11 @@ Hindi, English, and German each have different probe–horizon pairings.
 
 This file imports `ExtendedProjection/Basic.lean` (for `fValue`, `Cat`,
 `ComplementSize`) and `ClauseSpine.lean` (for bilateral label checks in
-vacuity and BIM theorems). The full Agree operation, tree-based horizons,
-and satisfaction conditions remain in `Agree.lean`, which imports this file.
+vacuity and BIM theorems). It is the *horizon* probe specification of
+the canonical `Probe` core (`Probe/Basic.lean`): `Probe.Profile.toProbe`
+denotes a profile as a `Probe α` (visibility = clause transparency).
+The tree-based Agree operation lives in `Agree.lean`; the Deal/Keine
+satisfaction-condition spec in `Probe/Satisfaction.lean`.
 -/
 
 namespace Minimalist
@@ -893,5 +897,13 @@ theorem ābar_does_not_force_agreement_hindi :
       ClauseSpine.cP.projectedHeads = true ∧
     LanguageProbeConfig.hindi.phi.transparentToLabel
       ClauseSpine.cP.projectedHeads = false := by decide
+
+/-! ### Denotation into the canonical `Probe` -/
+
+/-- The `Probe` a horizon profile denotes: sees a goal iff its enclosing
+    clause (highest head `headOf a`) is transparent (`transparentTo`). -/
+def Probe.Profile.toProbe {α : Type*} (p : Probe.Profile) (headOf : α → Cat) :
+    Probe α :=
+  .ofVis fun a => p.transparentTo (headOf a)
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Probe/Satisfaction.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Satisfaction.lean
@@ -1,0 +1,154 @@
+import Linglib.Syntax.Minimalist.Probe.Basic
+import Linglib.Syntax.Minimalist.Features
+import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
+
+/-!
+# Satisfaction conditions: the Deal/Keine probe specification
+[deal-2024] [keine-2019]
+
+Standard Agree assumes a probe is satisfied only by finding a matching
+valued feature. [deal-2024] argues for richer conditions — a probe can
+*interact* (halt) with more than satisfies it:
+
+- **Feature match**: the standard case.
+- **Head encounter**: probe halts on encountering a head of a category
+  (e.g. Mam's Infl probe stopped by transitive Voice), copying no
+  features → Elsewhere/default exponent.
+- **Disjunctive**: halt on ANY of several conditions.
+
+A `SatisfactionCond` is a *probe specification* in the sense of
+`Probe/Basic.lean`: it denotes a `Probe α` via `SatisfactionCond.toProbe`,
+with visibility = halting ([deal-2024] interaction) and activity =
+feature copying ([deal-2024] satisfaction). The interaction/satisfaction
+split is exactly the `Probe.vis`/`Probe.act` split — this file is where
+the substrate makes that identification (the previously study-local
+bridge in `Studies/Scott2023.lean`).
+
+## Main declarations
+
+- `SatisfactionCond` — featureMatch / headEncounter / disjunctive.
+- `SatisfactionCond.isSatisfied`, `.copiedFeatures` — halting and copying.
+- `SatisfactionCond.toProbe` — the canonical specification-to-`Probe`
+  map, generic over how a goal exposes its features and host category.
+-/
+
+namespace Minimalist
+
+/-- How a probe's search can be terminated.
+
+    Standard Agree assumes a probe is satisfied only by finding a matching
+    valued feature (simple feature match). [deal-2024] argues for richer
+    conditions to capture e.g. Mam's Infl probe, which is satisfied by
+    EITHER matching φ-features OR encountering transitive Voice:
+
+    **Mam example** ([scott-2023], via [deal-2024]):
+    - Infl carries [uφ] with satisfaction [SAT: φ or Voice_TR]
+    - Intransitive: probe passes through (no Voice_TR) → finds S → real φ-agreement
+    - Transitive: probe encounters Voice_TR → satisfied without copying φ → default "∅"
+
+    This turns the Mam bridge's prose account into a computable derivation:
+    ```
+    def mamInflSatisfaction : SatisfactionCond :=
+.disjunctive [.featureMatch (.phi (.person.third)),.headEncounter.v]
+    ```
+-/
+inductive SatisfactionCond where
+  /-- Standard: probe is satisfied by finding a matching valued feature. -/
+  | featureMatch : FeatureVal → SatisfactionCond
+  /-- Disjunctive: probe is satisfied by ANY of these conditions.
+      Models [deal-2024]'s interaction-based probes. -/
+  | disjunctive : List SatisfactionCond → SatisfactionCond
+  /-- Head encounter: probe is satisfied by encountering a head of this
+      category, even without feature matching. The probe stops but copies
+      no features — yielding the Elsewhere (default) exponent at PF. -/
+  | headEncounter : Cat → SatisfactionCond
+  deriving Repr
+
+/-- Is an atomic (non-disjunctive) condition met? -/
+private def atomicSatisfied (cond : SatisfactionCond) (fb : FeatureBundle)
+    (ctx : Option Cat) : Bool :=
+  match cond with
+  | .featureMatch ft => hasValuedFeature fb ft
+  | .headEncounter cat => ctx == some cat
+  | .disjunctive _ => false  -- nested disjunctions handled at top level
+
+/-- Check whether a satisfaction condition is met.
+
+    `fb` is the feature bundle of the element the probe encounters.
+    `ctx` is the syntactic category of that element (if it's a head).
+    Returns `true` if the probe should stop searching. -/
+def SatisfactionCond.isSatisfied (cond : SatisfactionCond) (fb : FeatureBundle)
+    (ctx : Option Cat) : Bool :=
+  match cond with
+  | .featureMatch ft => hasValuedFeature fb ft
+  | .disjunctive conds => conds.any (atomicSatisfied · fb ctx)
+  | .headEncounter cat => ctx == some cat
+
+/-- Did the probe copy features, or just stop?
+
+    When satisfied by feature match, the probe copies features (→ real agreement).
+    When satisfied by head encounter, no features are copied (→ default/Elsewhere).
+    For disjunctive conditions, feature copying occurs iff the first satisfied
+    condition is a feature match. -/
+def SatisfactionCond.copiedFeatures (cond : SatisfactionCond) (fb : FeatureBundle)
+    (ctx : Option Cat) : Bool :=
+  match cond with
+  | .featureMatch ft => hasValuedFeature fb ft
+  | .disjunctive conds =>
+    match conds.find? (atomicSatisfied · fb ctx) with
+    | some (.featureMatch ft) => hasValuedFeature fb ft
+    | _ => false  -- head encounter or nested → no features copied
+  | .headEncounter _ => false
+
+/-- The `Probe` a `SatisfactionCond` denotes, given how a goal exposes
+    its features (`feats`) and host category (`cat`): visibility =
+    halting (interaction), activity = feature copying (satisfaction). -/
+def SatisfactionCond.toProbe {α : Type*} (cond : SatisfactionCond)
+    (feats : α → FeatureBundle) (cat : α → Option Cat) : Probe α :=
+  { vis := fun a => cond.isSatisfied (feats a) (cat a)
+    act := fun a => cond.copiedFeatures (feats a) (cat a) }
+
+/-- Mam's Infl probe satisfaction condition:
+    satisfied by EITHER matching φ-features OR encountering transitive Voice. -/
+def mamInflSatisfaction : SatisfactionCond :=
+  .disjunctive [.featureMatch (.phi (.person .third)), .headEncounter .v]
+
+/-- Intransitive environment: the probe encounters a DP with φ-features
+    (no Voice_TR in the way). Feature match is satisfied → real agreement. -/
+theorem mam_intransitive_satisfied :
+    mamInflSatisfaction.isSatisfied
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
+      none = true := by rfl
+
+/-- Transitive environment: the probe encounters Voice_TR (category.v).
+    Head encounter is satisfied → probe stops without copying features. -/
+theorem mam_transitive_satisfied :
+    mamInflSatisfaction.isSatisfied [] (some .v) = true := by rfl
+
+/-- In the transitive case, no features are copied — yielding default. -/
+theorem mam_transitive_no_copy :
+    mamInflSatisfaction.copiedFeatures [] (some .v) = false := by rfl
+
+/-- In the intransitive case, features ARE copied — yielding real agreement. -/
+theorem mam_intransitive_copies :
+    mamInflSatisfaction.copiedFeatures
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
+      none = true := by rfl
+
+/-- Infl's satisfaction condition, unfolded: φ-match or Voice_TR encounter. -/
+theorem mamInflSatisfaction_isSatisfied (fb : FeatureBundle) (ctx : Option Cat) :
+    mamInflSatisfaction.isSatisfied fb ctx
+      = (hasValuedFeature fb (.phi (.person .third)) || ctx == some Cat.v) := by
+  simp [mamInflSatisfaction, SatisfactionCond.isSatisfied, atomicSatisfied]
+
+/-- Head-encounter satisfaction never copies: Infl copies features iff
+    they are there to copy, whatever the context. -/
+theorem mamInflSatisfaction_copiedFeatures (fb : FeatureBundle) (ctx : Option Cat) :
+    mamInflSatisfaction.copiedFeatures fb ctx
+      = hasValuedFeature fb (.phi (.person .third)) := by
+  cases hv : hasValuedFeature fb (.phi (.person .third)) <;>
+    cases hc : ctx == some Cat.v <;>
+      simp [mamInflSatisfaction, SatisfactionCond.copiedFeatures, atomicSatisfied,
+        List.find?, hv, hc]
+
+end Minimalist


### PR DESCRIPTION
Consolidate the probe substrate around one canonical `Minimalist.Probe`.

- New `Syntax/Minimalist/Probe/`: `Basic` (general `Probe α` core, was buried under `Phi/`), `Phi` (φ specialization), `Satisfaction` (Deal `SatisfactionCond` + a generic `toProbe`, lifted out of `Agree`/`Scott2023`), `Profile` (Keine horizons + a `toProbe`). No umbrella re-export; consumers import the leaf they need.
- Every probe spec now denotes the one `Probe α` via a `toProbe`-map.
- Retire `Agree`'s zero-consumer tree-locality reinventions (`closestGoal`/`intervenes`, `MultipleAgree`, `DefectiveElement`); `Probe.search_eq_some_iff_closest` is the list-engine bridge and `agree_eq_none_of_inactive` covers defective intervention.