### PR TITLE
refactor(Syntax/Minimalist): laws + wiring + hygiene for the Probe API

### DIFF
--- a/Linglib/Studies/BejarRezac2003.lean
+++ b/Linglib/Studies/BejarRezac2003.lean
@@ -25,7 +25,7 @@ in a [chomsky-2000] probe-goal system:
   F); a weak 1st/2nd accusative has only the [π]-probe, which the
   dative absorbs — the PCC.
 
-Through `Phi/Probing.lean`, the [π]-probe is the **off-diagonal**
+Through `Probe/Basic.lean`, the [π]-probe is the **off-diagonal**
 licensing shape: visibility is total (`pi.vis = ⊤` — closest goal),
 neediness is bearing [participant] — the same shape as Mam's Voice_TR
 (visible, halting, non-valuing intervener; `Studies/Scott2023.lean`)

--- a/Linglib/Studies/Deal2024.lean
+++ b/Linglib/Studies/Deal2024.lean
@@ -259,6 +259,16 @@ theorem probe_vis_antitone (g : DealGrammar) (st : ProbeState)
     (h : ((step g st t).probe).vis a = true) : st.probe.vis a = true :=
   dpBears_antitone (step_int_mono g st t) a h
 
+/-- Narrowing the probe cannot gain a goal: if the later (narrower)
+    state's probe still finds one, so did the earlier — the outcome-level
+    form of "interaction only narrows", from the substrate's
+    `Probe.outcome_valued_mono` fed by `probe_vis_antitone`. -/
+theorem probe_outcome_antitone (g : DealGrammar) (st : ProbeState)
+    (t : Person × Nat) (goals : List Person)
+    (h : ((step g st t).probe).outcome goals = .valued) :
+    st.probe.outcome goals = .valued :=
+  Minimalist.Probe.outcome_valued_mono (fun a _ ha => probe_vis_antitone g st t a ha) h
+
 /-- A satisfied probe is inert: satisfaction halts all further
     interaction (her (8b)). -/
 theorem step_of_satisfied (g : DealGrammar) (st : ProbeState)

--- a/Linglib/Studies/Halpert2012.lean
+++ b/Linglib/Studies/Halpert2012.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Minimalist.Probe.Basic
+import Linglib.Syntax.Minimalist.ObligatoryOperations
 
 /-!
 # Halpert 2012 — Argument Licensing and Agreement in Zulu [halpert-2012]
@@ -17,7 +18,7 @@ still converge even if a probe fails to find a goal" —
 failure-tolerance, adopted by [preminger-2014] Ch. 6 as the second
 case study in tolerated failed agreement.
 
-Formalized through `Phi/Probing.lean`: L⁰ is the **indiscriminate**
+Formalized through `Probe/Basic.lean`: L⁰ is the **indiscriminate**
 instance of `Probe.search` (`Probe.indiscriminate`, so bare minimality delivers
 `List.head?`; augmented nominals intervene, her Chomsky-2000-style
 intervention), and the licensing condition is the off-diagonal

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -73,7 +73,7 @@ probes, definitionally: `afAgreementTarget` IS the cascade, the ∅
 row is failed Agree realized by the DM Elsewhere entry, and the rank
 comparison is the derived form (`afAgreementTarget_eq_rank`).
 There is no salience scale, and `personRestrictionOk_iff_plc`
-derives the person restriction from the PLC via `Phi/Probing.lean`'s
+derives the person restriction from the PLC via `Probe/Phi.lean`'s
 search-licensing substrate.
 
 ## Why not a hierarchy
@@ -108,9 +108,9 @@ gives five arguments against hierarchy accounts:
 
 - `Syntax/Minimalist/Phi/Geometry.lean` — `decomposePerson`,
   `probeVisible`, `probeResolutionRank`.
-- `Syntax/Minimalist/Phi/Probing.lean` — `Probe`, `Probe.Licensed`,
-  `PLC`: the search-and-licensing layer the derivations below
-  consume.
+- `Syntax/Minimalist/Probe/Basic.lean` — `Probe`, `Probe.Licensed`;
+  `Probe/Phi.lean` — `PLC`: the search-and-licensing layer the
+  derivations below consume.
 - `Syntax/Minimalist/ObligatoryOperations.lean` — the Ch. 5 model
   (`AgreementModel`, `Probe.Outcome`, `PFRealization`), consumed
   below for the failed-Agree theorems.

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -544,7 +544,7 @@ theorem satisfaction_matches_fragment :
   · constructor <;> intro h <;> first | (native_decide) | trivial
   · exact ⟨fun _ => trivial, fun _ => by native_decide⟩
 
-/-! ### Deriving the probe table from relativized search (`Phi/Probing.lean`)
+/-! ### Deriving the probe table from relativized search (`Probe/Basic.lean`)
 
 The `agreeProbe` table stipulates which head agrees with which
 position. Here it is DERIVED: each probe runs `Probe.search` over the

--- a/Linglib/Syntax/Minimalist/Agree.lean
+++ b/Linglib/Syntax/Minimalist/Agree.lean
@@ -342,10 +342,13 @@ def validAgreeWithActivity (a : AgreeRelation) (root : SyntacticObject) : Prop :
   validAgree a root ∧
   isActive a.goalFeatures = true
 
--- Multiple Agree ([hiraiwa-2001]) is `Probe` over a goal list; defective
--- intervention ([chomsky-2000]) is a visible-but-inactive closest goal
--- absorbing the probe (`Probe.agree_eq_none_of_inactive`). The former
--- `MultipleAgree`/`DefectiveElement` reinventions (zero consumers) were retired.
+-- Defective intervention ([chomsky-2000]) is a visible-but-inactive
+-- closest goal absorbing the probe (`Probe.agree_eq_none_of_inactive`).
+-- The former `MultipleAgree`/`DefectiveElement` reinventions (zero
+-- consumers) were retired. Hiraiwa's Multiple Agree (simultaneous
+-- valuation of *all* matching goals) is a transmission operation the
+-- search-only `Probe` API does not model — see `Probe/Basic.lean`'s
+-- scope note.
 
 -- ============================================================================
 -- § 12: Phase-Bounded Agree

--- a/Linglib/Syntax/Minimalist/CyclicAgree.lean
+++ b/Linglib/Syntax/Minimalist/CyclicAgree.lean
@@ -328,7 +328,7 @@ theorem plc_violation_iff_inverse (geom : Geometry) (probe : Probe.Articulation)
     isInverseContext geom probe ea ia = true := by
   simp [eaIsLicensed, isInverseContext]
 
-/-! ### Grounding in relativized search (`Phi/Probing.lean`)
+/-! ### Grounding in relativized search (`Probe/Basic.lean`)
 
 An articulated probe is a *family* of flat relativized searches, one
 per segment, over the cyclically ordered token list: B&R's segments

--- a/Linglib/Syntax/Minimalist/NestedAgree.lean
+++ b/Linglib/Syntax/Minimalist/NestedAgree.lean
@@ -173,6 +173,63 @@ theorem runStack_some_iff (c : NestedAgreeConfig) (i : Nat) :
   · rw [if_neg h]; exact iff_of_false (by simp) h
 
 -- ============================================================================
+-- § 4b: Grounding in `Probe.search`
+-- ============================================================================
+
+/-- The goal-seeking probe: visible exactly at the shared goal. Nested
+    Agree's locality lives in `searchDomain`; the probe itself just seeks
+    the goal. -/
+def NestedAgreeConfig.goalProbe (c : NestedAgreeConfig) : Probe SyntacticObject :=
+  Probe.ofVis (fun y => decide (y = c.goalHead))
+
+private theorem find?_decideEq (L : List SyntacticObject) (g : SyntacticObject) :
+    L.find? (fun y => decide (y = g)) = if g ∈ L then some g else none := by
+  induction L with
+  | nil => simp
+  | cons x xs ih =>
+    by_cases hx : x = g
+    · subst hx; rw [List.find?_cons_of_pos (by simp)]; simp
+    · rw [List.find?_cons_of_neg (by simp [hx]), ih]
+      have hgx : ¬ g = x := fun h => hx h.symm
+      simp [List.mem_cons, hgx]
+
+/-- `runStack` factors through the canonical `Probe.search`: running
+    probe `i` is the goal-seeking probe searching probe `i`'s derived
+    domain (when probe `i` exists). The bespoke membership test *is*
+    `Probe.search` over `searchDomain i`, bringing Nested Agree onto the
+    one probe engine (cf. `CyclicAgree.eaIsLicensed_iff_segment_licensed`).
+    The whole-stack composition is `findSome?`/`Probe.cascade` over the
+    indices; the per-probe truncated domains are why each step is a
+    `search` over its own `searchDomain`, not a `cascade` over one list. -/
+theorem runStack_eq_search (c : NestedAgreeConfig) (i : Nat) :
+    runStack c i =
+      if i < c.length then c.goalProbe.search (c.searchDomain i).toList
+      else none := by
+  have hsearch : c.goalProbe.search (c.searchDomain i).toList
+      = if c.goalHead ∈ c.searchDomain i then some c.goalHead else none := by
+    simp only [NestedAgreeConfig.goalProbe, Probe.search, Probe.ofVis]
+    rw [find?_decideEq]
+    simp only [Multiset.mem_toList]
+  rw [runStack]
+  by_cases hi : i < c.length
+  · rw [if_pos hi, hsearch]
+    by_cases hg : c.goalHead ∈ c.searchDomain i
+    · rw [if_pos ⟨hi, hg⟩, if_pos hg]
+    · rw [if_neg (fun h => hg h.2), if_neg hg]
+  · rw [if_neg hi, if_neg (fun h => hi h.1)]
+
+/-- The Nested-Agree licensing fact in the licensing API: probe `i`
+    licenses the shared goal iff the goal is in probe `i`'s domain. -/
+theorem goalProbe_licensed_iff (c : NestedAgreeConfig) (i : Nat) :
+    c.goalProbe.Licensed (c.searchDomain i).toList c.goalHead ↔
+      c.goalHead ∈ c.searchDomain i := by
+  unfold Probe.Licensed
+  simp only [NestedAgreeConfig.goalProbe, Probe.search, Probe.ofVis]
+  rw [find?_decideEq]
+  simp only [Multiset.mem_toList]
+  by_cases hg : c.goalHead ∈ c.searchDomain i <;> simp [hg]
+
+-- ============================================================================
 -- § 5: Truncation
 -- ============================================================================
 

--- a/Linglib/Syntax/Minimalist/ObligatoryOperations.lean
+++ b/Linglib/Syntax/Minimalist/ObligatoryOperations.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Minimalist.Agree
+import Linglib.Syntax.Minimalist.Probe.Basic
 
 /-!
 # Obligatory Operations [preminger-2014]
@@ -83,18 +84,10 @@ inductive AgreementModel where
 -- § 2: Probe Outcomes
 -- ============================================================================
 
-/-- The outcome of an obligatory probing operation.
-
-    - **valued**: the probe found a goal and was valued by its φ-features.
-    - **unvalued**: the probe attempted but found no suitable goal.
-      In the crash model, this crashes. In the obligatory-no-crash
-      model, the derivation continues with default morphology. -/
-inductive Probe.Outcome where
-  /-- Probe successfully agreed with a goal. -/
-  | valued
-  /-- Probe attempted but found no suitable goal. -/
-  | unvalued
-  deriving DecidableEq, Repr
+-- `Probe.Outcome` (valued/unvalued) is defined in `Probe/Basic.lean`;
+-- this file adds its PF/convergence interpretation. In the crash model
+-- `unvalued` crashes; in the obligatory-no-crash model the derivation
+-- continues with default morphology.
 
 -- ============================================================================
 -- § 3: Convergence

--- a/Linglib/Syntax/Minimalist/Phi/Geometry.lean
+++ b/Linglib/Syntax/Minimalist/Phi/Geometry.lean
@@ -75,7 +75,7 @@ The `probeResolutionRank` function below assigns rank 2 to
 rank 0 elsewhere — the *surface effect* of the two-probe (π⁰
 before #⁰) system on a single DP. Its derived status is a theorem:
 target resolution is `Probe.cascade` over the two probes
-(`Phi/Probing.lean`), and the rank comparison agrees with the
+(`Probe/Basic.lean`), and the rank comparison agrees with the
 cascade on the φ-cell inventory
 (`Preminger2014.afAgreementTarget_eq_rank`). It is not a salience
 scale ([preminger-2014] Ch. 7).
@@ -189,7 +189,7 @@ def probeVisible (target : Probe.Target) (person : Person) (isPlural : Bool) : B
     targets any DP bearing the sought feature. The rank captures
     the combined effect on a single DP; its derived status is
     `Preminger2014.afAgreementTarget_eq_rank` (cascade resolution,
-    `Phi/Probing.lean`). It is not a salience scale
+    `Probe/Basic.lean`). It is not a salience scale
     ([preminger-2014] Ch. 7). -/
 def probeResolutionRank (person : Person) (isPlural : Bool) : Nat :=
   if (decomposePerson person).hasParticipant then 2

--- a/Linglib/Syntax/Minimalist/Probe/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Basic.lean
@@ -1,27 +1,34 @@
-import Mathlib.Order.UpperLower.Basic
-import Linglib.Syntax.Minimalist.ObligatoryOperations
+import Mathlib.Data.Set.Subsingleton
+import Mathlib.Data.List.Basic
 
 /-!
 # Probe: relativized search over a goal sequence
 [bejar-rezac-2003] [preminger-2014]
 
-The canonical, theory-agnostic probe primitive. A `Probe α` searches a
-goal sequence of arbitrary type `α`; everything probe-shaped in the
-library denotes one of these by a `toProbe`-map rather than
-re-implementing search (see **Probe specifications** below). The probe
-bundles what it *sees* (`vis` — interaction/halting: the search stops at
-the first visible goal) and what it can *value* there (`act` —
+The canonical, theory-agnostic relativized-*search* kernel. A `Probe α`
+searches a goal sequence of arbitrary type `α`; probe *specifications*
+(relativized targets, satisfaction conditions, horizon profiles,
+articulated/dynamic probes) denote one of these by a `toProbe`-map
+rather than re-implementing search (see **Probe specifications**). The
+probe bundles what it *sees* (`vis` — interaction/halting: the search
+stops at the first visible goal) and what it can *value* there (`act` —
 activity: a visible but inactive goal absorbs the probe without valuing
 it, [bejar-rezac-2003]'s inactive dative, [deal-2024]-style interaction
 vs. satisfaction). Licensing is being the goal the search reaches — from
 which the Person Licensing Condition's effects derive: one search
 licenses at most one goal (`Probe.allLicensed_iff`).
 
+Scope: this models a probe's *search* (locality, intervention,
+satisfaction). Feature *transmission* — what a successful Agree copies,
+shares, or values, and Multiple-Agree-style simultaneous valuation of
+several goals — is a separate concern (`applyAgree`, `Agree.lean`) not
+folded into `Probe`.
+
 This file is the maximally-general core (`α` arbitrary); the φ-feature
 *specialization* (`Agreement.Cell.visibleTo`, `Probe.Target.toProbe`,
 `PLC`) lives in `Probe/Phi.lean`, the Deal satisfaction-condition spec
 in `Probe/Satisfaction.lean`, and Keine's locality/horizon spec in
-`Probe/Profile.lean`. `Minimalist/Probe.lean` re-exports the lot.
+`Probe/Profile.lean`. There is no umbrella; import the leaf you need.
 
 Relativization is [preminger-2014]'s addition (§4.2, recalling
 [rizzi-1990]): the φ-instantiation (`Agreement.Cell.visibleTo`, `PLC`)
@@ -67,6 +74,23 @@ ones: `Probe.Target.toProbe` (`Probe/Phi.lean`),
 family), `CyclicAgree.segProbe` (per segment and geometry), and
 `Deal2024.ProbeState.probe` (the state-indexed family whose narrowing
 law is `probe_vis_antitone`).
+
+## TODO
+
+- **Transmission axis.** `Probe` models *search*, not what a successful
+  Agree copies/shares/values. A `Probe.agreeWith : Probe α → (α → V) →
+  List α → Σ` (Σ = `Option V` / `List V` for [hiraiwa-2001] Multiple
+  Agree / a shared-occurrence type for Frampton-Gutmann feature-sharing)
+  would fold `applyAgree`, Multiple Agree, Agree-Link/Copy
+  ([arregi-nevins-2012]), and case-by-Agree into one extension.
+- **Upward Agree.** Search is downward (c-command, `search_eq_some_iff_closest`);
+  add a direction parameter for Bjorkman & Zeijlstra (2019)-style upward Agree.
+- **`Preorder (Probe α)`** by pointwise `vis`-refinement, so
+  `outcome_valued_mono` / `Deal2024.probe_vis_antitone` become order facts.
+- **`Articulated.toProbes` ↔ `cascade` bridge**: prove an articulated
+  probe's behaviour is the cascade of its segment probes.
+- **`HalpertHammerly2026.agreementClass`**: re-stipulated relativized
+  search; should be two `Probe` searches with a `_eq_derived` theorem.
 -/
 
 namespace Minimalist
@@ -80,6 +104,15 @@ variable {α : Type*}
 structure Probe (α : Type*) where
   vis : α → Bool
   act : α → Bool := fun _ => true
+
+/-- The outcome of an obligatory probing operation: `valued` if the
+    search found a goal, else `unvalued`. The PF/convergence
+    interpretation (crash vs. default morphology) lives in
+    `ObligatoryOperations.lean`. -/
+inductive Probe.Outcome where
+  | valued
+  | unvalued
+  deriving DecidableEq, Repr
 
 namespace Probe
 
@@ -166,6 +199,26 @@ theorem agree_eq_none_of_inactive {a : α}
     p.agree goals = none := by
   simp [agree, h, Option.filter_some, ha]
 
+@[simp] theorem search_nil : p.search [] = none := rfl
+
+/-- Satisfaction refines interaction: what the probe Agrees with, it found. -/
+theorem agree_le_search {a : α} (h : p.agree goals = some a) :
+    p.search goals = some a :=
+  (agree_eq_some_iff.mp h).1
+
+/-- When every goal is active, Agree coincides with search — the `act`
+    gate is degenerate for `ofVis`-built probes. -/
+theorem agree_eq_search_of_act (h : ∀ a, p.act a = true) :
+    p.agree goals = p.search goals := by
+  rw [agree]
+  cases p.search goals with
+  | none => rfl
+  | some a => rw [Option.filter_some, if_pos (h a)]
+
+theorem agree_eq_none_iff :
+    p.agree goals = none ↔ ¬ ∃ a, p.search goals = some a ∧ p.act a = true := by
+  simp only [← Option.not_isSome_iff_eq_none, Option.isSome_iff_exists, agree_eq_some_iff]
+
 /-- Locality as list search: the probe finds `a` iff `a` is visible and
     every earlier goal is invisible (no intervener). -/
 theorem search_eq_some_iff_closest {a : α} :
@@ -207,6 +260,17 @@ theorem outcome_eq_unvalued_iff :
   rw [outcome_eq_unvalued_iff_eq_none]
   exact search_eq_none_iff
 
+/-- Widening visibility can only keep a probe valued: if `p` is valued
+    and `q` sees everything `p` sees (among `goals`), so is `q`. The
+    substrate home of [deal-2024]-style narrowing (`Deal2024`'s
+    `probe_vis_antitone` is the contrapositive on a probe family). -/
+theorem outcome_valued_mono {q : Probe α}
+    (h : ∀ a ∈ goals, p.vis a = true → q.vis a = true) :
+    p.outcome goals = .valued → q.outcome goals = .valued := by
+  simp only [outcome_eq_valued_iff]
+  rintro ⟨a, ha, hva⟩
+  exact ⟨a, ha, h a ha hva⟩
+
 /-! ### Licensing -/
 
 /-- A goal is licensed by a probe iff the probe's single search
@@ -230,6 +294,14 @@ theorem licensed_iff_closest {a : α} :
     p.Licensed goals a ↔
       p.vis a ∧ ∃ l₁ l₂, goals = l₁ ++ a :: l₂ ∧ ∀ b ∈ l₁, !p.vis b :=
   search_eq_some_iff_closest
+
+/-- A licensed goal is a member of the sequence. -/
+theorem Licensed.mem {a : α} (h : p.Licensed goals a) : a ∈ goals :=
+  mem_of_search_eq_some h
+
+/-- A licensed goal is visible to the probe. -/
+theorem Licensed.vis {a : α} (h : p.Licensed goals a) : p.vis a = true :=
+  visible_of_search_eq_some h
 
 /-- Licensing by the indiscriminate probe is being the structurally
     closest goal — bare minimality, [halpert-2012]'s L⁰. -/
@@ -317,6 +389,21 @@ theorem cascade_cons {q : Probe α} :
     cascade (q :: ps) goals = (q.search goals <|> cascade ps goals) := by
   rw [cascade, List.findSome?_cons]
   cases q.search goals <;> rfl
+
+@[simp] theorem cascade_nil : cascade ([] : List (Probe α)) goals = none := rfl
+
+@[simp] theorem cascade_singleton {q : Probe α} :
+    cascade [q] goals = q.search goals := by
+  rw [cascade_cons, cascade_nil]
+  cases q.search goals <;> rfl
+
+/-- `cascade` is a monoid map `(List (Probe α), ++) → (Option α, <|>)`:
+    the single-slot competition runs the left probes, then the right. -/
+theorem cascade_append {qs : List (Probe α)} :
+    cascade (ps ++ qs) goals = (cascade ps goals <|> cascade qs goals) := by
+  unfold cascade
+  rw [List.findSome?_append]
+  cases ps.findSome? (·.search goals) <;> rfl
 
 /-- The cascade's goal is licensed by one of its probes. -/
 theorem exists_licensed_of_cascade_eq_some {a : α}

--- a/Linglib/Syntax/Minimalist/Probe/Profile.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Profile.lean
@@ -188,8 +188,10 @@ remain unchanged, and `AbarDep` is a thin wrapper providing only the predicate
     *cuukwe* 'know') select bare CPs with no internal `AbarDep`. -/
 def AbarDep := { p : Probe.Profile // p.isĀProbe = true }
 
-/-- An `AbarDep` projects back to its underlying probe. -/
-def AbarDep.toProbe (a : AbarDep) : Probe.Profile := a.val
+/-- An `AbarDep` projects back to its underlying profile. (Named
+    `toProfile`, not `toProbe`, since the file-wide `toProbe` convention
+    denotes a `Probe α` — this returns a `Probe.Profile`.) -/
+def AbarDep.toProfile (a : AbarDep) : Probe.Profile := a.val
 
 /-- The keine Ā-probe is an `AbarDep` (lifted from `ābar_is_Ā`). -/
 def keineĀDep : AbarDep := ⟨keineĀProbe, ābar_is_Ā⟩


### PR DESCRIPTION
Follow-up to #548 from the multi-agent audit of the Probe API.

- **Laws** (`Probe/Basic.lean`): `outcome_valued_mono` (narrowing); cascade monoid laws `cascade_nil`/`cascade_singleton`/`cascade_append`; `agree_le_search`, `agree_eq_search_of_act`, `agree_eq_none_iff`; `Licensed.mem`/`.vis`; `search_nil`. Adds a `## TODO` header for deferred work (transmission axis, upward Agree, `Preorder (Probe α)`, `Articulated.toProbes ↔ cascade`, `HalpertHammerly2026.agreementClass`).
- **Dependency-minimal core**: `Probe.Outcome` moved into `Basic` (now Mathlib-only); `ObligatoryOperations` keeps the PF interpretation.
- **Wiring**: `Deal2024.probe_outcome_antitone` and `NestedAgree`'s `runStack_eq_search`/`goalProbe`/`goalProbe_licensed_iff` factor those bespoke engines through `Probe.search`.
- **Hygiene**: `AbarDep.toProbe` → `toProfile` (returns a `Probe.Profile`, not `Probe α`); repoint stale `Phi/Probing.lean` docstring refs; soften the Multiple-Agree comment.