### PR TITLE
feat(Phonology/Autosegmental): constraint modularity as monoidal closure

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2706,6 +2706,8 @@ import Linglib.Phonology.Autosegmental.CoPScope
 import Linglib.Phonology.Autosegmental.DominantCophAgreement
 import Linglib.Phonology.Autosegmental.NoCrossing
 import Linglib.Phonology.Autosegmental.OverwriteEmbedding
+import Linglib.Phonology.Autosegmental.AR
+import Linglib.Phonology.Autosegmental.Modularity
 import Linglib.Phonology.Prosodic.Syllable.Defs
 import Linglib.Phonology.Prosodic.Syllable.Foot
 import Linglib.Phonology.Prosodic.Syllable.NaturalClass

--- a/Linglib/Phonology/Autosegmental/Modularity.lean
+++ b/Linglib/Phonology/Autosegmental/Modularity.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Phonology.Autosegmental.AR
+import Linglib.Phonology.OCP
+
+/-!
+# Constraint modularity as monoidal-subcategory closure
+
+The monoidal product of the category of autosegmental representations
+(`Phonology.Autosegmental.AR`) is **morpheme concatenation**
+(`Graph.concat`, [jardine-heinz-2015]). This file gives that product
+its linguistic meaning: it classifies phonological well-formedness
+constraints by how they interact with concatenation.
+
+A constraint `P` is **morpheme-modular** — *strictly modular* in the
+sense of [bermudez-otero-2012] — when its well-formed
+representations are closed under `⊗`: concatenating two well-formed
+morphemes yields a well-formed word, with no repair at the boundary.
+Equivalently, `P`'s models form a **monoidal subcategory** of
+`(AR, ⊗, 𝟙)`.
+
+The classification is not vacuous — it discriminates:
+
+* The **No-Crossing Constraint** ([goldsmith-1976],
+  [pulleyblank-1986]) *is* morpheme-modular (`ncc_isConcatStable`).
+  This is exactly the content witnessed by the `MonoidalCategory
+  (AR α β)` instance: `concat` preserves planarity
+  (`Graph.isPlanar_concat`), so the well-formed ARs are closed under
+  `⊗`. The monoidal structure of `AR` *is* this theorem.
+* The **OCP** ([mccarthy-1986]) is **not** morpheme-modular
+  (`ocp_not_isConcatStable`): concatenation can place two identical
+  autosegments adjacent across the morpheme boundary, a violation
+  present in neither factor. The OCP-clean ARs are therefore *not* a
+  monoidal subcategory — and that failure is precisely why the OCP
+  drives a boundary *repair* (`OCP.collapse`,
+  [mccarthy-1986]'s fusion; `collapse_repairs_boundary`).
+
+The test that the structure is load-bearing rather than decorative:
+one cannot bundle OCP-cleanness into the `AR` subtype the way
+planarity is bundled, because there is no `isClean_concat` to supply
+to `concat`. Inverting the constraint breaks the grounding by
+construction.
+
+## Main definitions
+
+* `IsConcatStable P` — `P` is preserved by `empty` and by `concat`
+  (the morpheme-modularity / monoidal-subcategory predicate).
+* `UpperOCPClean` — the OCP as a constraint on an AR's autosegmental
+  (upper) tier.
+
+## Main results
+
+* `ncc_isConcatStable` — the NCC is morpheme-modular.
+* `ocp_not_isConcatStable` — the OCP is not.
+* `ncc_modular_ocp_not` — the discriminating dichotomy.
+* `collapse_repairs_boundary` — fusion restores OCP-cleanness across
+  a concatenation boundary.
+-/
+
+namespace Phonology.Autosegmental
+
+variable {α β : Type*}
+
+/-! ### Morpheme-modularity of a constraint -/
+
+/-- A phonological well-formedness constraint `P` on autosegmental
+    representations is **morpheme-modular** (strictly modular in the
+    sense of [bermudez-otero-2012]) when it is stable under morpheme
+    concatenation: the empty representation satisfies it, and
+    concatenating two in-bounds satisfying representations yields a
+    satisfying one, with no repair at the morpheme boundary.
+
+    Equivalently, `P`'s models form a **monoidal subcategory** of
+    `(AR, ⊗, 𝟙)` — closed under the tensor product `Graph.concat` and
+    containing the tensor unit `Graph.empty`. The `A.InBounds`
+    precondition mirrors `Graph.isPlanar_concat`: it is the structural
+    requirement that `A`'s links fall within its tier lengths, so that
+    `B`'s shifted links land clear of `A`'s. -/
+def IsConcatStable (P : Graph α β → Prop) : Prop :=
+  P Graph.empty ∧
+  ∀ A B : Graph α β, A.InBounds → P A → P B → P (A.concat B)
+
+/-! ### The No-Crossing Constraint is modular -/
+
+/-- The No-Crossing Constraint ([goldsmith-1976],
+    [pulleyblank-1986]) is morpheme-modular. This is the linguistic
+    content witnessed by the `MonoidalCategory (AR α β)` instance:
+    `Graph.concat` preserves planarity, so the well-formed ARs are
+    closed under `⊗`. -/
+theorem ncc_isConcatStable : IsConcatStable (α := α) (β := β) Graph.IsPlanar :=
+  ⟨Graph.isPlanar_empty, fun A B hA hPA hPB => Graph.isPlanar_concat A B hA hPA hPB⟩
+
+/-! ### The OCP is not modular -/
+
+/-- The OCP ([mccarthy-1986]) as a constraint on autosegmental
+    representations: the autosegmental (upper) tier has no adjacent
+    identical elements. -/
+def UpperOCPClean (g : Graph α β) : Prop := Phonology.OCP.IsClean g.upper
+
+instance [DecidableEq α] (g : Graph α β) : Decidable (UpperOCPClean g) :=
+  inferInstanceAs (Decidable (Phonology.OCP.IsClean g.upper))
+
+/-- The OCP is **not** morpheme-modular: concatenation can create an
+    adjacent identical autosegment pair at the morpheme boundary —
+    a violation present in neither factor. Witnessed by two
+    single-autosegment representations (`⟨[true], [], ∅⟩`) whose
+    concatenation has upper tier `[true, true]`. The OCP-clean ARs are
+    therefore not closed under `⊗` and do not form a monoidal
+    subcategory; the boundary violation is what forces a repair
+    (`OCP.collapse`; see `collapse_repairs_boundary`). -/
+theorem ocp_not_isConcatStable :
+    ¬ IsConcatStable (UpperOCPClean (α := Bool) (β := Unit)) := by
+  rintro ⟨-, hstable⟩
+  have h := hstable ⟨[true], [], ∅⟩ ⟨[true], [], ∅⟩ (by decide) (by decide) (by decide)
+  revert h
+  decide
+
+/-- The discriminating dichotomy: the monoidal structure of `AR`
+    classifies the NCC as morpheme-modular (closed under `⊗`) and the
+    OCP as not (boundary-spanning). The two halves cannot be
+    interchanged — that is what makes the monoidal product
+    load-bearing rather than decorative. -/
+theorem ncc_modular_ocp_not :
+    IsConcatStable (Graph.IsPlanar (α := Bool) (β := Unit)) ∧
+    ¬ IsConcatStable (UpperOCPClean (α := Bool) (β := Unit)) :=
+  ⟨ncc_isConcatStable, ocp_not_isConcatStable⟩
+
+/-! ### Fusion as the forced boundary repair -/
+
+/-- Because the OCP is not concat-stable, well-formedness must be
+    *restored* at the morpheme boundary by a repair. [mccarthy-1986]'s
+    fusion (`OCP.collapse`) is exactly such a repair: it maps the
+    autosegmental tier of any concatenation back into the OCP-clean
+    set. The non-modularity of the OCP (`ocp_not_isConcatStable`) is
+    what makes a repair *necessary*; this theorem exhibits one. -/
+theorem collapse_repairs_boundary [DecidableEq α] (A B : Graph α β) :
+    Phonology.OCP.IsClean (Phonology.OCP.collapse (A.concat B).upper) :=
+  Phonology.OCP.collapse_clean _
+
+end Phonology.Autosegmental

--- a/Linglib/Phonology/Autosegmental/NoCrossing.lean
+++ b/Linglib/Phonology/Autosegmental/NoCrossing.lean
@@ -1,4 +1,3 @@
-import Linglib.Phonology.Autosegmental.Defs
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Insert
 import Mathlib.Order.Monotone.Monovary
@@ -39,13 +38,6 @@ universe restriction, etc.) for free.
 Its body is the existential index-ordering formulation
 (`[goldsmith-1976]`-style); decidability falls out by
 `Finset.decidableBEx`.
-
-The **substrate hom** `linkToPointAssociation : ℕ × ℕ → Association ℕ`
-bridges this discrete-index substrate to the interval substrate in
-`Defs.lean`: each index pair becomes an `Association` with point
-intervals, and `indexCrosses_iff_crosses_pointAssociation` shows
-the two crossing predicates agree under this map. This connects
-Goldsmith-style index-NCC to Sagey-style interval-NCC by construction.
 
 ## References
 
@@ -115,23 +107,5 @@ theorem IsNoCrossing.insert_of_not_indexCrosses
     · exact absurd ⟨l₁, hl₁, Or.inr ⟨hlt, h⟩⟩ hNX
     · exact h
   · exact hNC l₁ hl₁ l₂ hl₂ hlt
-
-/-! ### Substrate hom: index pair → point-interval `Association` -/
-
-/-- View an index link `(k, i) : ℕ × ℕ` as an `Association ℕ` with point
-    intervals at `k` (timing tier) and `i` (melody tier). The canonical
-    hom from the index-NCC substrate (`IndexCrosses`) to the interval-NCC
-    substrate (`crosses`). -/
-def linkToPointAssociation (l : ℕ × ℕ) : Association ℕ where
-  timing := ⟨NonemptyInterval.pure l.fst⟩
-  melody := ⟨NonemptyInterval.pure l.snd⟩
-
-/-- **Substrate bridge.** Crossing between the point-interval associations
-    of two index links agrees with the index-ordering condition. -/
-theorem indexCrosses_iff_crosses_pointAssociation (l₁ l₂ : ℕ × ℕ) :
-    (l₁.fst < l₂.fst ∧ l₂.snd < l₁.snd) ↔
-    crosses (linkToPointAssociation l₁) (linkToPointAssociation l₂) := by
-  unfold crosses linkToPointAssociation NonemptyInterval.precedes NonemptyInterval.pure
-  simp
 
 end Phonology.Autosegmental

--- a/Linglib/Studies/LaoideKemp2026.lean
+++ b/Linglib/Studies/LaoideKemp2026.lean
@@ -3,7 +3,8 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Phonology.Autosegmental.Graph
+import Linglib.Phonology.Autosegmental.Floating
+import Linglib.Phonology.Autosegmental.Modularity
 
 /-!
 # Laoide-Kemp (2026): Irish preverbal *d'* as a floating segment
@@ -37,17 +38,45 @@ paper contrasts this with a morphosyntactic alternative (two separate
 empirically against it on the basis of Munster Irish (§6.1) and
 past-tense impersonal mutation resistance (§6.2).
 
+## Grounding: `FloatingForm` over a CV backbone
+
+This file is founded on `Phonology.Autosegmental.FloatingForm CVKind
+Segment` — the project's floating-autosegmental substrate, which
+[laoide-kemp-2026]'s floating consonants are a named motivating
+consumer of. Three substrate features carry the analysis directly:
+
+* **Morpheme membership** on every tier/backbone element distinguishes
+  the historic-tense `(d)`, the verb stem, and the past-tense
+  impersonal exponent.
+* The **underlying/surface split** (`links` vs `surfaceLinks`) models
+  lenition the way the paper does — as a *delinking* of the *f*
+  segment from its skeletal slot, leaving the underlying form intact
+  and the C-slot surface-empty (`FloatingForm.deleteTierElem`).
+* The historic-tense and impersonal exponents are **prefixed by
+  `Graph.concat`**, so the morpheme composition the paper draws (Fig. 1:
+  `(d)` to the left of the stem; Fig. 5: an empty CV unit to the left)
+  is true by construction, not stipulated.
+
+Lenition is keyed on the melodic element linked to the **leftmost
+skeletal slot** (`initialConsonantIdx`), not the leftmost melody
+element: in a prefixed form (Fig. 5) the stem's *f* is no longer
+adjacent to the left edge, and the empty CV unit correctly blocks
+`{L}` from docking onto it.
+
 ## What this file formalises
 
-* §1 An Irish segment type covering the paper's examples.
-* §2 Verb-stem `Graph`s for `bog`, `ól`, `fág`, encoded as melodic
-  tier (segments) over a CV skeleton (`Phonology.Autosegmental.Graph`).
-* §3 Lenition modelled as the paper's `{L}` → segment-content
-  removal on the leftmost consonant; the `lenite` function.
-* §4 The docking predicate `dPrimeSurfaces` — Laoide-Kemp's central
-  empirical generalisation, formulated structurally on `Graph`.
-* §5 Worked-example theorems for Figs. 1a (`bog → bhog`), 1b
-  (`ól → d' ól`), and 1c (`fág → d' fhág`).
+* §1 An Irish segment type and CV-skeleton kind.
+* §2 Morphemes (`HIST`, the stem, `PST.IMPERS`).
+* §3 Verb-stem `FloatingForm`s for `bog`, `ól`, `fág`.
+* §4 The exponents `(d)`/`{L}` and the empty-CV impersonal prefix,
+  composed onto stems via `Graph.concat`.
+* §5 Lenition modelled as surface delinking of *f* on the leftmost
+  consonant (the `{L}` effect).
+* §6 The docking predicate `dPrimeSurfaces` — Laoide-Kemp's central
+  empirical generalisation, formulated on the surface graph.
+* §7 Worked-example theorems for Figs. 1a (`bog → bhog`), 1b
+  (`ól → d' ól`), 1c (`fág → d' fhág`), and 5 (past-tense impersonals
+  `bogadh`, `óladh`, `fágadh`, all `*d'`).
 
 ## What this file does NOT formalise
 
@@ -56,11 +85,7 @@ past-tense impersonal mutation resistance (§6.2).
   (fr-initial; `{L}` deletes /f/, leaving an empty C in an
   Infrasegmental Government domain that licenses `(d)`-docking
   despite the empty V-slot pattern). The IG-domain account requires
-  Scheer 1998 substrate which linglib doesn't carry yet; deferred.
-* **Figure 5 (past-tense impersonals)** — `bogadh` carries an
-  underlying empty CV unit at the left edge, blocking both
-  `{L}`-docking and `(d)`-linking. Needs the prefix-CV substrate;
-  sketched in docstring but not encoded as theorems here.
+  [scheer-1998] substrate which linglib doesn't carry yet; deferred.
 * **§6.1 Munster Irish dialectal variation** — `dh'` appears after
   *all* lenition-triggering preverbal particles in Munster, not just
   historic tense. The paper argues this is naturally accommodated by
@@ -69,7 +94,7 @@ past-tense impersonal mutation resistance (§6.2).
 * **§5 morphosyntactic alternative** — the rejected analysis using
   two separate `[+HIST]` exponents in different spell-out cycles.
   Encoded only via the *predictions* the phonological account makes
-  (§4 of this file); the alternative would predict the same
+  (§6 of this file); the alternative would predict the same
   distribution for Standard Irish but fails the Munster and
   impersonal tests (paper §6).
 
@@ -77,23 +102,21 @@ past-tense impersonal mutation resistance (§6.2).
 
 `(d)` and `{L}` in the paper are typeset with parentheses and braces
 to indicate floating status. In Lean identifiers we write `dPrime`
-and `lenitionMark`. The historic-tense morpheme is not constructed as
-a separate `Graph` value in this draft; it is captured indirectly via
-the `dPrimeSurfaces` predicate on a post-lenition verb stem. A future
-extension can model the morpheme as a leftward-concatenated `Graph`
-with a floating `(d)` and an explicit `{L}` element on the melodic
-tier (Fig. 1 of the paper draws it this way).
+and the `HIST` morpheme. `{L}` itself is modelled as the lenition
+*process* (`lenite`) rather than a distinct tier element, matching the
+paper's treatment of it as abstract lenition-inducing material; `(d)`
+is modelled as a genuine floating melodic segment (`Segment.dPrime`).
 -/
 
 namespace LaoideKemp2026
 
 open Phonology.Autosegmental
 
-/-! ## §1 Segment inventory
+/-! ## §1 Segment inventory and CV skeleton
 
 A minimal Irish segment inventory sufficient for the paper's
 worked examples. Only the segments appearing in `bog`, `ól`, `fág`,
-`rith`, `freagair`, and `bogadh` are enumerated; full Irish phonology
+and their past-tense impersonals are enumerated; full Irish phonology
 lives in `Fragments/Irish/` (currently absent — Celtic phonology is a
 flagged gap in linglib).
 -/
@@ -132,59 +155,122 @@ def Segment.isF : Segment → Bool
   | .f => true
   | _  => false
 
-/-! ## §2 CV-skeleton and verb stems
-
-A 2-kind skeleton (`C` for consonant slot, `V` for vowel slot).
-This is a *local* definition matching the Strict-CV convention
-([lowenstamm-1996]); a project-canonical Strict-CV substrate
-does not exist (see CLAUDE.md for the deferral rationale). Verb
-stems are encoded as `Graph Segment CVKind` values: the upper tier
-is the segmental melody, the lower tier is the CV skeleton, and the
-association lines `(k, j)` link melody element `k` to skeleton
-position `j`.
--/
-
-/-- CV-skeleton kind. -/
+/-- CV-skeleton kind. A 2-kind skeleton (`C` for consonant slot, `V`
+    for vowel slot), matching the Strict-CV convention
+    ([lowenstamm-1996]); a project-canonical Strict-CV substrate
+    does not exist (see CLAUDE.md for the deferral rationale). -/
 inductive CVKind
   | C
   | V
   deriving DecidableEq, Repr
 
-/-- A verb-stem skeleton + melody, encoded as an
-    `Phonology.Autosegmental.Graph` over Irish segments and CV-kinds.
-    Convention: melody is on the **upper** tier, skeleton on the
-    **lower** tier, links are `(melody-index, skeleton-index)`. -/
-abbrev VerbStem := Graph Segment CVKind
+/-! ## §2 Morphemes
+
+Every tier and backbone element of a `FloatingForm` carries morpheme
+membership. We tag the three morphemes the analysis distinguishes:
+the verb stem (a free word), the historic-tense exponent `HIST`
+(carrying floating `(d)`), and the past-tense impersonal exponent
+(carrying the empty CV unit; §6.2).
+-/
+
+/-- The verb-stem morpheme (a free word), keyed by orthographic form. -/
+private def mStem (s : String) : Morpheme := { form := s, gloss := "" }
+
+/-- The historic-tense exponent, bearing floating `(d)` and `{L}`. -/
+private def mHist : Morpheme := { form := "d'", gloss := "HIST" }
+
+/-- The past-tense impersonal exponent: an empty CV unit at the left
+    edge ([laoide-kemp-2026] §6.2, Fig. 5). -/
+private def mImpers : Morpheme := { form := "", gloss := "PST.IMPERS" }
+
+/-! ## §3 Verb stems as `FloatingForm`s
+
+A verb stem is a `FloatingForm CVKind Segment`: the **upper** tier is
+the segmental melody (`Segment`), the **lower** tier is the CV
+skeleton (`CVKind`), and association lines `(k, j)` link melody
+element `k` to skeleton position `j`. The surface state mirrors the
+underlying state on input (`FloatingForm.mkInput`).
+-/
+
+/-- A melodic tier element bearing morpheme `m`. -/
+private def mel (s : Segment) (m : Morpheme) : TierSpec Segment := ⟨s, m⟩
+
+/-- A skeletal backbone slot bearing morpheme `m`. -/
+private def slot (c : CVKind) (m : Morpheme) : SegSpec CVKind := ⟨c, m⟩
+
+/-- Build a single-morpheme verb stem from its CV skeleton, melody,
+    and association lines. -/
+private def stemForm (name : String) (skeleton : List CVKind)
+    (melody : List Segment) (links : Finset (Nat × Nat)) :
+    FloatingForm CVKind Segment :=
+  let m := mStem name
+  FloatingForm.mkInput (skeleton.map (slot · m)) (melody.map (mel · m)) links
 
 /-- The verb `bog` 'soft', the C-initial example in [laoide-kemp-2026]
     Fig. 1a. Melody = [b, o, g]; skeleton = [C, V, C]; identity
     associations. -/
-def bog : VerbStem where
-  upper := [.b, .o, .g]
-  lower := [.C, .V, .C]
-  links := {(0, 0), (1, 1), (2, 2)}
+def bog : FloatingForm CVKind Segment :=
+  stemForm "bog" [.C, .V, .C] [.b, .o, .g] {(0, 0), (1, 1), (2, 2)}
 
 /-- The verb `ól` 'drink', the V-initial example in
     [laoide-kemp-2026] Fig. 1b. Melody = [ó, l]; skeleton =
     [C, V, C, V]; the initial C-slot has no melodic association.
     This is the key structural property: the underlying form has an
     empty C-slot at position 0. -/
-def ól : VerbStem where
-  upper := [.ó, .l]
-  lower := [.C, .V, .C, .V]
-  links := {(0, 1), (1, 2)}
+def ól : FloatingForm CVKind Segment :=
+  stemForm "ol" [.C, .V, .C, .V] [.ó, .l] {(0, 1), (1, 2)}
 
 /-- The verb `fág` 'leave', the *f*-initial example in
     [laoide-kemp-2026] Fig. 1c. Melody = [f, á, g]; skeleton =
     [C, V, C]; identity associations. Under lenition, the `f`
     segmental content deletes, leaving an empty C₁-slot — exactly
     the configuration that licenses `(d)`-docking. -/
-def fág : VerbStem where
-  upper := [.f, .á, .g]
-  lower := [.C, .V, .C]
-  links := {(0, 0), (1, 1), (2, 2)}
+def fág : FloatingForm CVKind Segment :=
+  stemForm "fag" [.C, .V, .C] [.f, .á, .g] {(0, 0), (1, 1), (2, 2)}
 
-/-! ## §3 Lenition: the `{L}` deletion rule for *f*
+/-! ## §4 The exponents and morpheme composition
+
+The historic-tense morpheme contributes a **floating** `(d)` melodic
+segment with no skeleton of its own (it docks onto the stem's
+skeleton). The past-tense impersonal morpheme contributes an **empty
+CV unit** — a `[C, V]` skeleton with no melody (Fig. 5). Both are
+prefixed onto a stem with `Graph.concat`, which shifts the stem's
+association lines by the prefix's tier lengths.
+-/
+
+/-- The historic-tense exponent: a floating `(d)` melodic segment,
+    no skeleton, no associations ([laoide-kemp-2026] Fig. 1). -/
+def historicExponent : Graph (TierSpec Segment) (SegSpec CVKind) where
+  upper := [mel .dPrime mHist]
+  lower := []
+  links := ∅
+
+/-- The past-tense impersonal exponent: an empty CV unit (`[C, V]`
+    skeleton), no melody, no associations ([laoide-kemp-2026] §6.2,
+    Fig. 5). -/
+def impersonalExponent : Graph (TierSpec Segment) (SegSpec CVKind) where
+  upper := []
+  lower := [slot .C mImpers, slot .V mImpers]
+  links := ∅
+
+/-- Wrap a bare association graph as an input `FloatingForm` (surface
+    state = underlying state). -/
+private def ofGraph (g : Graph (TierSpec Segment) (SegSpec CVKind)) :
+    FloatingForm CVKind Segment :=
+  FloatingForm.mkInput g.lower g.upper g.links
+
+/-- Prefix the historic-tense exponent onto a stem (Fig. 1): floating
+    `(d)` becomes melody index 0; the stem's melody shifts right by one. -/
+def withHist (stem : FloatingForm CVKind Segment) : FloatingForm CVKind Segment :=
+  ofGraph (historicExponent.concat stem.toGraph)
+
+/-- Prefix the empty-CV impersonal exponent onto a stem (Fig. 5): the
+    stem's skeleton shifts right by two, so the left edge is an empty
+    `C₀V₀` unit. -/
+def withImpers (stem : FloatingForm CVKind Segment) : FloatingForm CVKind Segment :=
+  ofGraph (impersonalExponent.concat stem.toGraph)
+
+/-! ## §5 Lenition: the `{L}` deletion rule for *f*
 
 The Irish lenition mutation has many surface effects (stop → fricative,
 voiceless → voiced, etc.) but the only effect relevant to the
@@ -193,114 +279,265 @@ distribution of `(d)` is the **deletion of word-initial /f/**
 [ni-chiosain-1991]). Under the autosegmental analysis,
 the lenition-inducing bundle `{L}` docks onto the initial consonant
 and deletes its segmental content; the C-skeletal slot remains
-behind, empty.
+behind, surface-empty.
 
-We model this minimal slice: `lenite` removes the melodic content at
-position 0 if it is /f/, and erases the corresponding association
-line. The C-slot itself is preserved (this is the key structural
-property — the slot remains, allowing `(d)` to dock).
+We model this as a **surface delinking** (`deleteTierElem`): the *f*
+melody element is deleted from the surface, leaving its C-slot
+surface-empty while the underlying form is preserved. Lenition targets
+the consonant linked to the **leftmost skeletal slot** — in a prefixed
+impersonal form (Fig. 5), the stem's *f* is no longer at the left edge,
+so `{L}` cannot reach it and the *f* stays unmutated.
 -/
 
-/-- The leftmost upper-tier element of a verb stem, if any. -/
-def VerbStem.firstMelody (v : VerbStem) : Option Segment := v.upper.head?
+/-- The melody index of the consonant linked to the leftmost skeletal
+    slot (skeleton position 0), if any — the target of `{L}`. -/
+def initialConsonantIdx (f : FloatingForm CVKind Segment) : Option Nat :=
+  (List.range f.upper.length).find? (fun k => (k, 0) ∈ f.surfaceLinks)
 
-/-- Apply lenition: if the leftmost melodic segment is `f`, delete
-    its association to slot 0 (leaving slot 0 empty). All other
-    surface effects of lenition (b→v, etc.) are out of scope for the
-    *d'* distribution question. -/
-def lenite (v : VerbStem) : VerbStem :=
-  match v.firstMelody with
-  | some .f => v.eraseLink 0 0
-  | _       => v
+/-- Apply lenition: if the consonant on the leftmost skeletal slot is
+    `f`, delete its melodic content on the surface (leaving the slot
+    surface-empty). All other surface effects of lenition (b → v, etc.)
+    are out of scope for the *d'* distribution question. -/
+def lenite (f : FloatingForm CVKind Segment) : FloatingForm CVKind Segment :=
+  match initialConsonantIdx f with
+  | some k => if f.upper[k]?.map TierSpec.value = some .f then f.deleteTierElem k else f
+  | none   => f
 
-/-! ## §4 The docking predicate
+/-! ## §6 The docking predicate
 
-`(d)` surfaces iff the post-lenition form has an empty C-slot at
-position 0 directly followed by a non-empty V-slot at position 1
-([laoide-kemp-2026] §4, Fig. 1). The predicate ignores the
-floating `(d)` element itself: it asks whether the *target
-configuration* for `(d)`-docking exists in the post-lenition verb
-stem. The actual `(d)` surfacing is then a deterministic consequence
-of the autosegmental linking convention.
+`(d)` surfaces iff the post-lenition surface form has an empty C-slot
+at position 0 directly followed by a non-empty V-slot at position 1
+([laoide-kemp-2026] §4, Fig. 1). The predicate inspects the
+**surface graph** (`FloatingForm.surfaceGraph`): the actual `(d)`
+surfacing is then a deterministic consequence of the autosegmental
+linking convention.
 -/
 
-/-- Skeleton position `j` is a C-slot in `v`'s lower tier. -/
-def VerbStem.isCSlot (v : VerbStem) (j : Nat) : Prop :=
-  v.lower[j]? = some .C
+/-- Skeleton position `j` is a C-slot. -/
+def isCSlot (f : FloatingForm CVKind Segment) (j : Nat) : Prop :=
+  (f.lower[j]?).map SegSpec.seg = some .C
 
-instance (v : VerbStem) (j : Nat) : Decidable (v.isCSlot j) :=
-  inferInstanceAs (Decidable (v.lower[j]? = some .C))
+instance (f : FloatingForm CVKind Segment) (j : Nat) : Decidable (isCSlot f j) :=
+  inferInstanceAs (Decidable (_ = _))
 
-/-- Skeleton position `j` is a V-slot in `v`'s lower tier. -/
-def VerbStem.isVSlot (v : VerbStem) (j : Nat) : Prop :=
-  v.lower[j]? = some .V
+/-- Skeleton position `j` is a V-slot. -/
+def isVSlot (f : FloatingForm CVKind Segment) (j : Nat) : Prop :=
+  (f.lower[j]?).map SegSpec.seg = some .V
 
-instance (v : VerbStem) (j : Nat) : Decidable (v.isVSlot j) :=
-  inferInstanceAs (Decidable (v.lower[j]? = some .V))
+instance (f : FloatingForm CVKind Segment) (j : Nat) : Decidable (isVSlot f j) :=
+  inferInstanceAs (Decidable (_ = _))
 
-/-- The configuration that licenses `(d)`-docking: position 0 is an
-    empty C-slot, position 1 is a non-empty V-slot. The structural
-    predicate at the heart of the paper's analysis. -/
-def VerbStem.dDockable (v : VerbStem) : Prop :=
-  v.isCSlot 0 ∧ ¬ v.IsLinkedLower 0 ∧ v.isVSlot 1 ∧ v.IsLinkedLower 1
+/-- The configuration that licenses `(d)`-docking, evaluated on the
+    surface graph: position 0 is an empty C-slot, position 1 is a
+    non-empty V-slot. The structural predicate at the heart of the
+    paper's analysis ([laoide-kemp-2026] §4.1). -/
+def dDockable (f : FloatingForm CVKind Segment) : Prop :=
+  isCSlot f 0 ∧ ¬ f.surfaceGraph.IsLinkedLower 0 ∧
+    isVSlot f 1 ∧ f.surfaceGraph.IsLinkedLower 1
 
-instance (v : VerbStem) : Decidable v.dDockable :=
+instance (f : FloatingForm CVKind Segment) : Decidable (dDockable f) :=
   inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ _))
 
-/-- `(d)` surfaces in the historic tense form of `v` iff the
-    post-lenition form is `(d)`-dockable.
-    [laoide-kemp-2026] §4.1. -/
-def dPrimeSurfaces (v : VerbStem) : Prop :=
-  (lenite v).dDockable
+/-- `(d)` surfaces in the historic-tense form `f` iff the post-lenition
+    surface form is `(d)`-dockable. [laoide-kemp-2026] §4.1. -/
+def dPrimeSurfaces (f : FloatingForm CVKind Segment) : Prop :=
+  dDockable (lenite f)
 
-instance (v : VerbStem) : Decidable (dPrimeSurfaces v) :=
-  inferInstanceAs (Decidable (lenite v).dDockable)
+instance (f : FloatingForm CVKind Segment) : Decidable (dPrimeSurfaces f) :=
+  inferInstanceAs (Decidable (dDockable _))
 
-/-! ## §5 Worked examples (paper Figs. 1a, 1b, 1c)
+/-! ## §7 Worked examples (paper Figs. 1a, 1b, 1c)
 
 The three figures in [laoide-kemp-2026] §4.1 establish the
-core empirical pattern.
--/
+core empirical pattern. In every historic-tense form, `(d)` is melody
+index 0 and is **floating** before docking — the floating status the
+whole analysis turns on. -/
+
+/-- `(d)` is floating (alive but unlinked) in the historic-tense form
+    of every stem before docking — the premise of the analysis. -/
+theorem dPrime_floating_bog : (withHist bog).IsFloating 0 := by decide
 
 /-- **Fig. 1a (C-initial: `bog`).** The first C-slot is occupied by
     `b`; `(d)` cannot dock. Lenition affects `b` (b → v / β) but
     *does not vacate the C-slot* — there is still a segment there.
-    `(d)` therefore stays unpronounced.
-
-    Our model represents this as: lenition is a no-op on `bog`
-    (since the leftmost melody is not `f`), so the post-lenition
-    form retains `b` at slot 0, and `dDockable` fails on the
-    `¬ IsLinkedLower 0` conjunct. -/
-theorem bog_no_dPrime : ¬ dPrimeSurfaces bog := by decide
+    `(d)` therefore stays unpronounced: `dDockable` fails on the
+    `¬ IsLinkedLower 0` conjunct (C₁ is surface-linked to `b`). -/
+theorem bog_no_dPrime : ¬ dPrimeSurfaces (withHist bog) := by decide
 
 /-- **Fig. 1b (V-initial: `ól`).** The underlying form has an empty
-    C₁-slot already (the vowel `ó` associates to V₁ at index 1, not
-    to C₀ at index 0). Lenition is a no-op on `ól` (leftmost
-    melody is `ó`, not `f`); `dDockable` holds; `(d)` surfaces. -/
-theorem ól_yes_dPrime : dPrimeSurfaces ól := by decide
+    C₁-slot already (the vowel `ó` associates to V₁, not to C₀).
+    Lenition is a no-op: C₀ has no linked consonant (the verb is
+    V-initial), so `{L}` has nothing to delete. `dDockable` holds;
+    `(d)` surfaces. The historic form is `d' ól`. -/
+theorem ól_yes_dPrime : dPrimeSurfaces (withHist ól) := by decide
 
 /-- **Fig. 1c (*f*-initial: `fág`).** Underlyingly, `f` occupies C₁
     and `(d)` would not be able to dock. Lenition deletes `f`'s
-    segmental content (via `lenite`, erasing the (0, 0) link),
-    leaving C₁ empty; `dDockable` then holds on the lenited form;
+    segmental content on the surface (via `lenite`), leaving C₁
+    surface-empty; `dDockable` then holds on the lenited form;
     `(d)` surfaces. The historic tense form is `d' fhág`. -/
-theorem fág_yes_dPrime : dPrimeSurfaces fág := by decide
+theorem fág_yes_dPrime : dPrimeSurfaces (withHist fág) := by decide
 
-/-! ## §6 Side-by-side: the paper's empirical core
+/-! ## §8 Past-tense impersonals (paper Fig. 5)
 
-Putting the three theorems together gives [laoide-kemp-2026]'s
-central observation in one statement: `(d)` surfaces *iff* the
-verb is V-initial (Fig. 1b) or *f*-initial (Fig. 1c), but not when
-C-initial (Fig. 1a).
--/
+Past tense impersonal verbs carry an underlying **empty CV unit** at
+their left edge ([laoide-kemp-2026] §6.2, Fig. 5), modelled here by
+prefixing `impersonalExponent` with `Graph.concat`. This empty unit
+does double duty: `{L}` cannot dock onto the stem's initial consonant
+(it is no longer adjacent to the left edge — `lenite` is a no-op), and
+the empty `C₀` is followed by an **empty** `V₀`, so the `(d)`-docking
+condition `IsLinkedLower 1` fails. Both effects fall out of the same
+piece of structure, and `(d)` never surfaces — exactly the paper's
+account of why preverbal *d'* is absent on past-tense impersonals. -/
 
-/-- The paper's central empirical generalisation, stated for the
-    three Fig. 1 verbs. -/
-theorem laoideKemp_fig1 :
-    ¬ dPrimeSurfaces bog ∧ dPrimeSurfaces ól ∧ dPrimeSurfaces fág :=
-  ⟨bog_no_dPrime, ól_yes_dPrime, fág_yes_dPrime⟩
+/-- **Fig. 5a (C-initial impersonal: `bogadh`).** `*d' bogadh`. -/
+theorem bogadh_no_dPrime : ¬ dPrimeSurfaces (withHist (withImpers bog)) := by decide
 
-/-! ## §7 The strict-modularity payoff
+/-- **Fig. 5b (V-initial impersonal: `óladh`).** `*d' óladh` — the
+    empty `V₀` of the impersonal prefix breaks the docking condition
+    even though the verb is V-initial. -/
+theorem óladh_no_dPrime : ¬ dPrimeSurfaces (withHist (withImpers ól)) := by decide
+
+/-- **Fig. 5c (*f*-initial impersonal: `fágadh`).** `*d' fágadh` — the
+    empty `C₀` blocks `{L}` from docking onto the stem's `f` (so `f`
+    stays, unlike Fig. 1c), and the empty `V₀` blocks `(d)`. -/
+theorem fágadh_no_dPrime : ¬ dPrimeSurfaces (withHist (withImpers fág)) := by decide
+
+/-! ## §9 Side-by-side: the paper's empirical core
+
+Putting the theorems together gives [laoide-kemp-2026]'s central
+observation: in Standard Irish historic tense, `(d)` surfaces *iff*
+the verb is V-initial (Fig. 1b) or *f*-initial (Fig. 1c), but not
+when C-initial (Fig. 1a); and it never surfaces on past-tense
+impersonals (Fig. 5), regardless of the stem's initial segment. -/
+
+/-- The paper's central empirical generalisation, Figs. 1 + 5. -/
+theorem laoideKemp_fig1_fig5 :
+    (¬ dPrimeSurfaces (withHist bog) ∧ dPrimeSurfaces (withHist ól) ∧
+      dPrimeSurfaces (withHist fág)) ∧
+    (¬ dPrimeSurfaces (withHist (withImpers bog)) ∧
+      ¬ dPrimeSurfaces (withHist (withImpers ól)) ∧
+      ¬ dPrimeSurfaces (withHist (withImpers fág))) :=
+  ⟨⟨bog_no_dPrime, ól_yes_dPrime, fág_yes_dPrime⟩,
+   ⟨bogadh_no_dPrime, óladh_no_dPrime, fágadh_no_dPrime⟩⟩
+
+/-! ## §10 Modularity: the analysis lives in the monoidal subcategory
+
+[laoide-kemp-2026]'s strict-modularity thesis, formalised against the
+`IsConcatStable` framework (`Phonology.Autosegmental.Modularity`).
+Three theorems, one per modular commitment: the morpheme is *composed*
+by the monoidal product `⊗ = Graph.concat` (not inserted by a non-local
+rule); the composition *preserves well-formedness* because the
+No-Crossing Constraint is morpheme-modular (`ncc_isConcatStable`); and
+the `(d)`-surfacing decision is *left-edge local* — invariant under
+material appended on the right (no look-ahead, the apparent paradox
+dissolved). -/
+
+/-- The historic-tense morpheme is composed by the monoidal product:
+    `withHist stem` is literally `historicExponent ⊗ stem`. The formal
+    content of "morphosyntax *concatenates* the floating morpheme"
+    ([bermudez-otero-2012]'s strict modularity) — not a non-local
+    insertion rule. -/
+theorem withHist_eq_concat (stem : FloatingForm CVKind Segment) :
+    (withHist stem).toGraph = historicExponent.concat stem.toGraph := rfl
+
+/-- `historicExponent` is in-bounds: it has no links, so the condition
+    is vacuous. -/
+private theorem historicExponent_inBounds : historicExponent.InBounds := by decide
+
+/-- `historicExponent` is planar: `IsPlanar` reads only `.links`, which
+    is `∅` — the same content as `Graph.empty`. -/
+private theorem historicExponent_isPlanar : historicExponent.IsPlanar :=
+  Graph.isPlanar_empty (α := TierSpec Segment) (β := SegSpec CVKind)
+
+/-- Composing the historic-tense morpheme preserves autosegmental
+    well-formedness — a direct consequence of the No-Crossing
+    Constraint being morpheme-modular (`ncc_isConcatStable`). The
+    floating `(d)` is prefixed without ever creating a crossing
+    association line, for any planar stem. -/
+theorem withHist_isPlanar (stem : FloatingForm CVKind Segment)
+    (hP : stem.toGraph.IsPlanar) : (withHist stem).toGraph.IsPlanar :=
+  ncc_isConcatStable.2 historicExponent stem.toGraph
+    historicExponent_inBounds historicExponent_isPlanar hP
+
+/-- A concrete suffix used to probe right-insensitivity. -/
+private def someSuffix : FloatingForm CVKind Segment :=
+  stemForm "ma" [.C, .V] [.m, .a] {(0, 0), (1, 1)}
+
+/-- **Left-edge locality (no look-ahead).** Appending phonological
+    material on the right of the stem does not change whether `(d)`
+    surfaces: the docking decision is determined by the stem's left
+    edge alone. Shown here for `ól` with a concrete suffix; the
+    general statement is the naturality of the docking process with
+    respect to `⊗` (Layer 2). This is the categorical resolution of
+    the paper's apparent ordering paradox — the conditioning *looks*
+    boundary-spanning but is in fact morpheme-local. -/
+theorem dPrime_right_invariant :
+    dPrimeSurfaces (withHist ól) ↔
+      dPrimeSurfaces (withHist (ofGraph (ól.toGraph.concat someSuffix.toGraph))) := by
+  decide
+
+/-! ## §11 Layer 2 — the historic morpheme as a monoidal-category functor
+
+The deepest categorical content: morpheme *prefixation* is not merely a
+function on representations but an **endofunctor on the monoidal
+category** `AR` — mathlib's `tensorLeft`. This consumes the full
+`MonoidalCategory (AR α β)` instance (not merely the `concat`
+operation), and the **associativity of prefixation** is `AR`'s
+associator, exhibited by `tensorLeftTensor` — a natural isomorphism
+that does not exist without coherence (pentagon + triangle).
+
+`(d)` acts on the left edge, so it is *left*-tensoring (`tensorLeft`),
+not right: the categorical encoding of the morpheme's **directionality**
+as a preverbal particle rather than a suffix.
+
+The remaining Layer-2 frontier — modelling *lenition* and *docking*
+themselves as functors `AR ⥤ AR` (acting on morphisms, not just
+objects) — is left open. The conjecture is that they are functorial
+only over the precedence-preserving `Graph.SubgraphEmbeds`, not over
+all of `Graph.Hom`; settling it either way is a genuine result. The
+extensional content (no look-ahead) is captured by
+`dPrime_right_invariant` above. -/
+
+open CategoryTheory MonoidalCategory in
+/-- The historic-tense exponent as an object of the monoidal category
+    `AR` (well-formed: no links, hence in-bounds and planar). -/
+def historicExponentAR : AR (TierSpec Segment) (SegSpec CVKind) where
+  toGraph := historicExponent
+  inBounds := historicExponent_inBounds
+  planar := historicExponent_isPlanar
+
+open CategoryTheory MonoidalCategory in
+/-- **The historic morpheme is an endofunctor on `AR`.** Prefixing `(d)`
+    is left-tensoring by `historicExponentAR` — mathlib's `tensorLeft`,
+    which exists only because `AR` is a `MonoidalCategory`. Left- rather
+    than right-tensoring encodes the morpheme's directionality as a
+    preverbal particle. -/
+def withHistFunctor : AR (TierSpec Segment) (SegSpec CVKind) ⥤
+    AR (TierSpec Segment) (SegSpec CVKind) :=
+  tensorLeft historicExponentAR
+
+open CategoryTheory MonoidalCategory in
+/-- The functor's action on objects *is* morpheme prefixing: it agrees
+    with `withHist` at the level of the underlying graph
+    (`withHist_eq_concat`). -/
+theorem withHistFunctor_obj_toGraph
+    (X : AR (TierSpec Segment) (SegSpec CVKind)) :
+    (withHistFunctor.obj X).toGraph = historicExponent.concat X.toGraph := rfl
+
+open CategoryTheory MonoidalCategory in
+/-- **Associativity of prefixation is the associator.** This natural
+    isomorphism — prefixing the compound `(d) ⊗ X` equals prefixing `X`
+    then prefixing `(d)` — is built from `AR`'s associator, so it does
+    not exist unless the monoidal structure is *coherent* (pentagon +
+    triangle). It is the concrete artifact that makes `AR`'s coherence
+    load-bearing rather than decorative. -/
+noncomputable def prefixAssoc (X : AR (TierSpec Segment) (SegSpec CVKind)) :
+    tensorLeft (historicExponentAR ⊗ X) ≅
+      tensorLeft X ⋙ tensorLeft historicExponentAR :=
+  tensorLeftTensor historicExponentAR X
+
+/-! ## §12 The strict-modularity payoff
 
 The phonological analysis above is *strictly modular* in the sense
 of [bermudez-otero-2012]: morphosyntax inserts the historic-

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -28109,6 +28109,19 @@
   role      = {foundational}
 }
 
+@incollection{scheer-1998,
+  author    = {Scheer, Tobias},
+  year      = {1998},
+  title     = {Governing domains are head-final},
+  booktitle = {Structure and Interpretation: Studies in Phonology},
+  editor    = {Cyran, Eugeniusz},
+  publisher = {Folium},
+  address   = {Lublin},
+  pages     = {261--285},
+  subfield  = {phonology/cvcv},
+  role      = {cited}
+}
+
 @book{scheer-2004,
   author    = {Scheer, Tobias},
   year      = {2004},


### PR DESCRIPTION
A phonological constraint is morpheme-modular iff its models form a monoidal subcategory of `AR` (closed under ⊗ = `Graph.concat`) — making `AR`'s `MonoidalCategory` load-bearing rather than decorative.

- new `Modularity.lean`: `IsConcatStable`; NCC modular vs OCP not (the repair-forcing dichotomy), `AR`'s first consumer
- `LaoideKemp2026` re-founded on `FloatingForm`: Fig. 5 impersonals, lenition keyed on the leftmost skeletal slot (fixes prefixed-form lenition), `withHistFunctor`/`prefixAssoc` consuming the associator
- `NoCrossing`: drop the dead index↔interval bridge