### PR TITLE
refactor(Phonology/Autosegmental): relocate Sagey interval-NCC to its study

### DIFF
--- a/Linglib/Phonology/Autosegmental/Defs.lean
+++ b/Linglib/Phonology/Autosegmental/Defs.lean
@@ -1,4 +1,3 @@
-import Linglib.Core.Order.Interval
 import Linglib.Phonology.Featural.Features
 import Linglib.Phonology.Featural.Geometry
 import Mathlib.Data.Set.Pairwise.Basic
@@ -25,12 +24,10 @@ including the negative argument against simultaneity.
 * `AutosegRep.spread`, `AutosegRep.delink`, `AutosegRep.spreadFeatures` —
   atomic operations on autosegmental representations.
 * `copyFeaturesUnder` — replace features under a geometric node.
-* `TierPosition`, `Association`, `validAssociation`, `crosses` — temporal
-  tier substrate for the no-crossing derivation.
-* `no_crossing`, `no_crossing_symm` — derivation of the NCC from temporal
-  precedence and overlap.
-* `geminate`, `contourTone` — concrete demonstrations that overlap (not
-  simultaneity) is the correct association relation.
+
+The Sagey-1986 interval-overlap derivation of the No-Crossing Constraint
+(`TierPosition`/`Association`/`no_crossing`/…) lives with its paper in
+`Studies/Sagey1986.lean`, its sole consumer.
 
 ## Implementation notes
 
@@ -193,166 +190,5 @@ theorem spread_delink_not_present (r : AutosegRep) (pos : Nat) (n : GeomNode)
   rw [List.filter_cons, if_neg (by rw [hcond]; decide)]
   exact ⟨trivial, filter_all_pass shs _ h⟩
 
-/-! ### Temporal derivation of the No-Crossing Constraint
-
-[sagey-1986] §5.3 derives the ban on crossing association lines from
-temporal precedence rather than stipulating it as a well-formedness condition.
-
-The key move is choosing the right temporal relation for association lines.
-Simultaneity (identity of time points) is too strong — it predicts that
-contour segments and geminates are impossible, since two distinct elements
-cannot both be identical to the same time point (§5.2.2). Overlap is the
-correct relation: it is reflexive and symmetric but crucially NOT transitive
-(`NonemptyInterval.overlaps_not_transitive`), which is what allows the NCC proof to
-go through via a contradiction chain (§5.2.3, fn. 6).
-
-The derivation (§5.3, p.294): if timing₁ ≺ timing₂ on the timing tier but
-melody₂ ≺ melody₁ on the melody tier, the overlap requirements on valid
-associations produce a chain melody₂.finish < melody₁.start ≤ timing₁.finish
-< timing₂.start ≤ melody₂.finish — a contradiction. Crossing is therefore
-logically impossible for valid associations.
-
-This section formalizes the derivation using `NonemptyInterval` for
-temporal intervals and its `precedes`/`overlaps` relations.
--/
-
-section NoCrossing
-
-variable {T : Type*} [LinearOrder T]
-
-
-/-- A position on an autosegmental tier, occupying a temporal interval. -/
-structure TierPosition (T : Type*) [LinearOrder T] where
-  interval : NonemptyInterval T
-
-/-- An association between a timing-tier position and a melody-tier position.
-    An association line represents temporal overlap: the melody element is
-    realized during the timing position's interval. -/
-structure Association (T : Type*) [LinearOrder T] where
-  timing : TierPosition T
-  melody : TierPosition T
-
-/-- Association validity: the timing and melody intervals must overlap.
-    This is the phonetic grounding — an association line means the melodic
-    content is realized during the timing slot. -/
-def validAssociation (a : Association T) : Prop :=
-  a.timing.interval.overlaps a.melody.interval
-
-/-- **Simultaneity contradicts contours** ([sagey-1986] §5.2.2):
-    if association required temporal identity (simultaneity), contour
-    segments — two distinct melody elements F ≠ G associated to the same
-    timing position x — would be impossible, since F = x and G = x
-    imply F = G by transitivity. This is Sagey's negative argument for
-    why association must be overlap, not identity. -/
-theorem simultaneity_no_contours {T : Type*} (t m₁ m₂ : T)
-    (h₁ : t = m₁) (h₂ : t = m₂) : m₁ = m₂ :=
-  h₁.symm.trans h₂
-
-/-- Two associations cross iff their timing positions are ordered one way
-    but their melody positions are ordered the other way.
-    Crossing(a₁, a₂) ≡ timing₁ ≺ timing₂ ∧ melody₂ ≺ melody₁. -/
-def crosses (a₁ a₂ : Association T) : Prop :=
-  a₁.timing.interval.precedes a₂.timing.interval ∧
-  a₂.melody.interval.precedes a₁.melody.interval
-
-/-- **No-Crossing Constraint** ([sagey-1986] §5.3, [goldsmith-1976]):
-    Two valid associations cannot cross.
-
-    If timing₁ ≺ timing₂, then timing₁.finish < timing₂.start.
-    Validity requires timing₁ overlaps melody₁ and timing₂ overlaps melody₂.
-    If melodies also cross (melody₂ ≺ melody₁), then melody₂.finish < melody₁.start.
-
-    From timing₁ overlaps melody₁: melody₁.start ≤ timing₁.finish.
-    From timing₂ overlaps melody₂: timing₂.start ≤ melody₂.finish.
-
-    Chaining: melody₂.finish < melody₁.start ≤ timing₁.finish < timing₂.start ≤ melody₂.finish.
-    This gives melody₂.finish < melody₂.finish — a contradiction. -/
-theorem no_crossing (a₁ a₂ : Association T)
-    (h₁ : validAssociation a₁) (h₂ : validAssociation a₂) :
-    ¬ crosses a₁ a₂ := by
-  intro ⟨htime, hmelody⟩
-  -- Unpack definitions
-  simp only [NonemptyInterval.precedes] at htime hmelody
-  simp only [validAssociation, NonemptyInterval.overlaps] at h₁ h₂
-  obtain ⟨h₁_tm, h₁_mt⟩ := h₁
-  obtain ⟨h₂_tm, h₂_mt⟩ := h₂
-  -- Chain: melody₂.finish < melody₁.start ≤ timing₁.finish < timing₂.start ≤ melody₂.finish
-  have : a₂.melody.interval.snd < a₂.melody.interval.snd :=
-    calc a₂.melody.interval.snd
-        < a₁.melody.interval.fst := hmelody
-      _ ≤ a₁.timing.interval.snd := h₁_mt
-      _ < a₂.timing.interval.fst := htime
-      _ ≤ a₂.melody.interval.snd := h₂_tm
-  exact lt_irrefl _ this
-
-/-- Crossing is also impossible in the symmetric direction: if timing₂ ≺ timing₁
-    and melody₁ ≺ melody₂, the same contradiction arises. -/
-theorem no_crossing_symm (a₁ a₂ : Association T)
-    (h₁ : validAssociation a₁) (h₂ : validAssociation a₂) :
-    ¬ crosses a₂ a₁ :=
-  no_crossing a₂ a₁ h₂ h₁
-
-/-! ### Set-level No-Crossing Constraint -/
-
-namespace Association
-
-/-- A set of associations satisfies the **No-Crossing Constraint** iff no two
-    associations in the set cross. Expressed via mathlib's `Set.Pairwise`. -/
-def IsNoCrossing (associations : Set (Association T)) : Prop :=
-  associations.Pairwise (fun a₁ a₂ => ¬ crosses a₁ a₂)
-
-/-- **Set-level lift of `no_crossing`**: any set of valid associations
-    automatically satisfies the No-Crossing Constraint. -/
-theorem IsNoCrossing.of_all_valid {associations : Set (Association T)}
-    (hValid : ∀ a ∈ associations, validAssociation a) :
-    IsNoCrossing associations :=
-  fun a₁ ha₁ a₂ ha₂ _ => no_crossing a₁ a₂ (hValid a₁ ha₁) (hValid a₂ ha₂)
-
-/-- A subset of a no-crossing association set is no-crossing.
-    Inherited from `Set.Pairwise.mono`. -/
-theorem IsNoCrossing.subset {s t : Set (Association T)} (hst : s ⊆ t)
-    (h : IsNoCrossing t) : IsNoCrossing s :=
-  Set.Pairwise.mono hst h
-
-end Association
-
-/-! ### Concrete demonstrations -/
-
-/-- Helper: build an interval from start and finish with a proof of validity. -/
-private def mkInterval (s f : T) (h : s ≤ f) : NonemptyInterval T := ⟨⟨s, f⟩, h⟩
-
-/-- A geminate consonant: two adjacent timing positions associated to a single
-    melodic element. The melodic element's interval spans both timing slots.
-
-    Example: /t/ linked to two C-slots in [atta].
-
-    ```
-    C-tier:    C₁    C₂
-                \  /
-    melody:     t
-    ``` -/
-def geminate (t1s t1f t2s t2f ms mf : T)
-    (h1 : t1s ≤ t1f) (h2 : t2s ≤ t2f) (hm : ms ≤ mf)
-    : Association T × Association T :=
-  ( ⟨⟨mkInterval t1s t1f h1⟩, ⟨mkInterval ms mf hm⟩⟩,
-    ⟨⟨mkInterval t2s t2f h2⟩, ⟨mkInterval ms mf hm⟩⟩ )
-
-/-- A contour tone: one timing position associated to two tonal elements
-    sequenced within it. The two tonal elements occupy sub-intervals.
-
-    Example: falling tone HL on a single syllable.
-
-    ```
-    timing:     σ
-               / \
-    tone:     H   L
-    ``` -/
-def contourTone (ts tf m1s m1f m2s m2f : T)
-    (ht : ts ≤ tf) (hm1 : m1s ≤ m1f) (hm2 : m2s ≤ m2f)
-    : Association T × Association T :=
-  ( ⟨⟨mkInterval ts tf ht⟩, ⟨mkInterval m1s m1f hm1⟩⟩,
-    ⟨⟨mkInterval ts tf ht⟩, ⟨mkInterval m2s m2f hm2⟩⟩ )
-
-end NoCrossing
 
 end Phonology.Autosegmental

--- a/Linglib/Studies/Sagey1986.lean
+++ b/Linglib/Studies/Sagey1986.lean
@@ -2,6 +2,8 @@ import Linglib.Phonology.Featural.ComplexSegments
 import Linglib.Phonology.Featural.Geometry
 import Linglib.Phonology.Autosegmental.Defs
 import Linglib.Phonology.Subregular.LocalRewrite
+import Linglib.Core.Order.Interval
+import Mathlib.Data.Set.Pairwise.Basic
 
 /-!
 # Sagey (1986) [sagey-1986]
@@ -41,6 +43,172 @@ open Phonology (Segment Feature FeatureVal)
 open Phonology.FeatureGeometry (GeomNode)
 open Phonology.ComplexSegments
 open Phonology.Autosegmental (agreeAt)
+
+namespace Phonology.Autosegmental
+
+/-! ### Interval-overlap semantics for association lines
+
+[sagey-1986] §5.3 derives the ban on crossing association lines from
+temporal precedence rather than stipulating it as a well-formedness condition.
+
+The key move is choosing the right temporal relation for association lines.
+Simultaneity (identity of time points) is too strong — it predicts that
+contour segments and geminates are impossible, since two distinct elements
+cannot both be identical to the same time point (§5.2.2). Overlap is the
+correct relation: it is reflexive and symmetric but crucially NOT transitive
+(`NonemptyInterval.overlaps_not_transitive`), which is what allows the NCC proof to
+go through via a contradiction chain (§5.2.3, fn. 6).
+
+The derivation (§5.3, p.294): if timing₁ ≺ timing₂ on the timing tier but
+melody₂ ≺ melody₁ on the melody tier, the overlap requirements on valid
+associations produce a chain melody₂.finish < melody₁.start ≤ timing₁.finish
+< timing₂.start ≤ melody₂.finish — a contradiction. Crossing is therefore
+logically impossible for valid associations.
+
+This section formalizes the derivation using `NonemptyInterval` for
+temporal intervals and its `precedes`/`overlaps` relations.
+-/
+
+section NoCrossing
+
+variable {T : Type*} [LinearOrder T]
+
+
+/-- A position on an autosegmental tier, occupying a temporal interval. -/
+structure TierPosition (T : Type*) [LinearOrder T] where
+  interval : NonemptyInterval T
+
+/-- An association between a timing-tier position and a melody-tier position.
+    An association line represents temporal overlap: the melody element is
+    realized during the timing position's interval. -/
+structure Association (T : Type*) [LinearOrder T] where
+  timing : TierPosition T
+  melody : TierPosition T
+
+/-- Association validity: the timing and melody intervals must overlap.
+    This is the phonetic grounding — an association line means the melodic
+    content is realized during the timing slot. -/
+def validAssociation (a : Association T) : Prop :=
+  a.timing.interval.overlaps a.melody.interval
+
+/-- **Simultaneity contradicts contours** ([sagey-1986] §5.2.2):
+    if association required temporal identity (simultaneity), contour
+    segments — two distinct melody elements F ≠ G associated to the same
+    timing position x — would be impossible, since F = x and G = x
+    imply F = G by transitivity. This is Sagey's negative argument for
+    why association must be overlap, not identity. -/
+theorem simultaneity_no_contours {T : Type*} (t m₁ m₂ : T)
+    (h₁ : t = m₁) (h₂ : t = m₂) : m₁ = m₂ :=
+  h₁.symm.trans h₂
+
+/-- Two associations cross iff their timing positions are ordered one way
+    but their melody positions are ordered the other way.
+    Crossing(a₁, a₂) ≡ timing₁ ≺ timing₂ ∧ melody₂ ≺ melody₁. -/
+def crosses (a₁ a₂ : Association T) : Prop :=
+  a₁.timing.interval.precedes a₂.timing.interval ∧
+  a₂.melody.interval.precedes a₁.melody.interval
+
+/-- **No-Crossing Constraint** ([sagey-1986] §5.3, [goldsmith-1976]):
+    Two valid associations cannot cross.
+
+    If timing₁ ≺ timing₂, then timing₁.finish < timing₂.start.
+    Validity requires timing₁ overlaps melody₁ and timing₂ overlaps melody₂.
+    If melodies also cross (melody₂ ≺ melody₁), then melody₂.finish < melody₁.start.
+
+    From timing₁ overlaps melody₁: melody₁.start ≤ timing₁.finish.
+    From timing₂ overlaps melody₂: timing₂.start ≤ melody₂.finish.
+
+    Chaining: melody₂.finish < melody₁.start ≤ timing₁.finish < timing₂.start ≤ melody₂.finish.
+    This gives melody₂.finish < melody₂.finish — a contradiction. -/
+theorem no_crossing (a₁ a₂ : Association T)
+    (h₁ : validAssociation a₁) (h₂ : validAssociation a₂) :
+    ¬ crosses a₁ a₂ := by
+  intro ⟨htime, hmelody⟩
+  -- Unpack definitions
+  simp only [NonemptyInterval.precedes] at htime hmelody
+  simp only [validAssociation, NonemptyInterval.overlaps] at h₁ h₂
+  obtain ⟨h₁_tm, h₁_mt⟩ := h₁
+  obtain ⟨h₂_tm, h₂_mt⟩ := h₂
+  -- Chain: melody₂.finish < melody₁.start ≤ timing₁.finish < timing₂.start ≤ melody₂.finish
+  have : a₂.melody.interval.snd < a₂.melody.interval.snd :=
+    calc a₂.melody.interval.snd
+        < a₁.melody.interval.fst := hmelody
+      _ ≤ a₁.timing.interval.snd := h₁_mt
+      _ < a₂.timing.interval.fst := htime
+      _ ≤ a₂.melody.interval.snd := h₂_tm
+  exact lt_irrefl _ this
+
+/-- Crossing is also impossible in the symmetric direction: if timing₂ ≺ timing₁
+    and melody₁ ≺ melody₂, the same contradiction arises. -/
+theorem no_crossing_symm (a₁ a₂ : Association T)
+    (h₁ : validAssociation a₁) (h₂ : validAssociation a₂) :
+    ¬ crosses a₂ a₁ :=
+  no_crossing a₂ a₁ h₂ h₁
+
+/-! ### Set-level No-Crossing Constraint -/
+
+namespace Association
+
+/-- A set of associations satisfies the **No-Crossing Constraint** iff no two
+    associations in the set cross. Expressed via mathlib's `Set.Pairwise`. -/
+def IsNoCrossing (associations : Set (Association T)) : Prop :=
+  associations.Pairwise (fun a₁ a₂ => ¬ crosses a₁ a₂)
+
+/-- **Set-level lift of `no_crossing`**: any set of valid associations
+    automatically satisfies the No-Crossing Constraint. -/
+theorem IsNoCrossing.of_all_valid {associations : Set (Association T)}
+    (hValid : ∀ a ∈ associations, validAssociation a) :
+    IsNoCrossing associations :=
+  fun a₁ ha₁ a₂ ha₂ _ => no_crossing a₁ a₂ (hValid a₁ ha₁) (hValid a₂ ha₂)
+
+/-- A subset of a no-crossing association set is no-crossing.
+    Inherited from `Set.Pairwise.mono`. -/
+theorem IsNoCrossing.subset {s t : Set (Association T)} (hst : s ⊆ t)
+    (h : IsNoCrossing t) : IsNoCrossing s :=
+  Set.Pairwise.mono hst h
+
+end Association
+
+/-! ### Concrete demonstrations -/
+
+/-- Helper: build an interval from start and finish with a proof of validity. -/
+private def mkInterval (s f : T) (h : s ≤ f) : NonemptyInterval T := ⟨⟨s, f⟩, h⟩
+
+/-- A geminate consonant: two adjacent timing positions associated to a single
+    melodic element. The melodic element's interval spans both timing slots.
+
+    Example: /t/ linked to two C-slots in [atta].
+
+    ```
+    C-tier:    C₁    C₂
+                \  /
+    melody:     t
+    ``` -/
+def geminate (t1s t1f t2s t2f ms mf : T)
+    (h1 : t1s ≤ t1f) (h2 : t2s ≤ t2f) (hm : ms ≤ mf)
+    : Association T × Association T :=
+  ( ⟨⟨mkInterval t1s t1f h1⟩, ⟨mkInterval ms mf hm⟩⟩,
+    ⟨⟨mkInterval t2s t2f h2⟩, ⟨mkInterval ms mf hm⟩⟩ )
+
+/-- A contour tone: one timing position associated to two tonal elements
+    sequenced within it. The two tonal elements occupy sub-intervals.
+
+    Example: falling tone HL on a single syllable.
+
+    ```
+    timing:     σ
+               / \
+    tone:     H   L
+    ``` -/
+def contourTone (ts tf m1s m1f m2s m2f : T)
+    (ht : ts ≤ tf) (hm1 : m1s ≤ m1f) (hm2 : m2s ≤ m2f)
+    : Association T × Association T :=
+  ( ⟨⟨mkInterval ts tf ht⟩, ⟨mkInterval m1s m1f hm1⟩⟩,
+    ⟨⟨mkInterval ts tf ht⟩, ⟨mkInterval m2s m2f hm2⟩⟩ )
+
+end NoCrossing
+
+end Phonology.Autosegmental
 
 namespace Sagey1986
 


### PR DESCRIPTION
Moves the single-paper interval-overlap derivation of the No-Crossing Constraint (`TierPosition`/`Association`/`validAssociation`/`crosses`/`no_crossing`/`geminate`/`contourTone`, the `[sagey-1986]` Ch. 5 substrate) out of the shared `Autosegmental/Defs.lean` into its **sole consumer** `Studies/Sagey1986.lean`, which already houses the concrete examples that use it.

- `Defs.lean` becomes the pure feature-sharing substrate; drops its now-orphaned `Core.Order.Interval` import.
- `Sagey1986.lean` gains the definitions (in `namespace Phonology.Autosegmental`, ahead of its existing § 6 examples) + the interval imports.

Anchoring cleanup: single-paper substrate now lives with its paper, per the dependency discipline. The index-level NCC (`NoCrossing.IsNoCrossing` / `Graph.IsPlanar`) remains the canonical, multi-consumer formalization.