### PR TITLE
fix(Studies/Sagey1986): reground impossible-segment docstring in §2.2

### DIFF
--- a/Linglib/Studies/Sagey1986.lean
+++ b/Linglib/Studies/Sagey1986.lean
@@ -414,12 +414,13 @@ theorem velar_nasal_wf : ComplexWF velar_nasal := by decide
 -- § 5: Impossible Complex Segments (Ch. 2)
 -- ============================================================================
 
-/-- A coronal-only segment (alveolar /t/) with multiple coronal features
-    is NOT complex: [+cor, +ant, −dist] all fall under the single coronal
-    articulator. This formalizes Sagey's key prediction: palatal–velar
-    stops are impossible because palatals and velars are both dorsal —
-    no combination of features under a single articulator can produce a
-    complex segment. -/
+/-- A coronal-only segment (alveolar /t/, [+cor, +ant]) is NOT complex:
+    multiple coronal features fall under the single coronal articulator. This
+    formalizes Sagey's key prediction (§2.2): complex segments are possible
+    only for combinations of two *different* articulators, so no combination of
+    features under a single articulator yields a complex segment. The
+    same-articulator bar is exactly why alveolars and alveopalatals — both
+    coronal — cannot form a doubly-articulated stop ([sagey-1986] §2.2, p.64). -/
 def alveolar_t : Segment :=
   Segment.ofSpecs
     [(.consonantal, true), (.sonorant, false), (.continuant, false),


### PR DESCRIPTION
Final fidelity pass over `Sagey1986.lean`'s impossible-complex-segment section (§5), against the dissertation's §2.2.

`alveopalatal_not_complex`'s claim + §2.2 citation check out verbatim (p.64: *"Alveolars with alveopalatals are impossible because both are formed with the coronal articulator"*; the (13) representations confirm both are coronal).

But `alveolar_not_complex`'s docstring justified the single-articulator bar with *"palatal–velar stops are impossible because palatals and velars are both dorsal."* §2.2 never establishes palatals as dorsal — it treats alveopalatals as **coronal** — so that claim is unsupported by the cited section and tangential to the alveolar example. Regrounded it in §2.2's actual content (complex segments need two *different* articulators; alveolar+alveopalatal, both coronal, is the impossibility §2.2 demonstrates).