### PR TITLE
refactor(Phonology/Autosegmental): rename Defs to FeatureSharing

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2716,7 +2716,7 @@ import Linglib.Phonology.Featural.ComplexSegments
 import Linglib.Phonology.Featural.Bundle
 import Linglib.Phonology.Featural.Underspecification
 import Linglib.Phonology.Featural.ElementTheory
-import Linglib.Phonology.Autosegmental.Defs
+import Linglib.Phonology.Autosegmental.FeatureSharing
 import Linglib.Phonology.Tone.Basic
 import Linglib.Phonology.Autosegmental.GrammaticalTone
 import Linglib.Phonology.Autosegmental.Floating

--- a/Linglib/Fragments/Finnish/VowelHarmony.lean
+++ b/Linglib/Fragments/Finnish/VowelHarmony.lean
@@ -1,7 +1,7 @@
 import Linglib.Phonology.Featural.Features
 import Linglib.Phonology.Featural.Geometry
 import Linglib.Phonology.Subregular.LocalRewrite
-import Linglib.Phonology.Autosegmental.Defs
+import Linglib.Phonology.Autosegmental.FeatureSharing
 import Linglib.Phonology.Subregular.Harmony
 
 /-!

--- a/Linglib/Fragments/Turkish/VowelHarmony.lean
+++ b/Linglib/Fragments/Turkish/VowelHarmony.lean
@@ -1,7 +1,7 @@
 import Linglib.Phonology.Featural.Features
 import Linglib.Phonology.Featural.Geometry
 import Linglib.Phonology.Subregular.LocalRewrite
-import Linglib.Phonology.Autosegmental.Defs
+import Linglib.Phonology.Autosegmental.FeatureSharing
 import Linglib.Phonology.Subregular.Harmony
 
 /-!

--- a/Linglib/Phonology/Autosegmental/FeatureSharing.lean
+++ b/Linglib/Phonology/Autosegmental/FeatureSharing.lean
@@ -1,28 +1,35 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Phonology.Featural.Features
 import Linglib.Phonology.Featural.Geometry
 import Mathlib.Data.Set.Pairwise.Basic
 
 /-!
-# Autosegmental Representations
+# Autosegmental feature sharing
 
 Autosegmental phonology adds **feature sharing** to segmental
 representations: when adjacent segments share a geometric node's features, they
-are linked to a single autosegmental element on that node's tier. This module
-builds on the feature geometry (`FeatureGeometry.lean`) and segment type
-(`Features.lean`) to provide feature agreement predicates,
-autosegmental representations with consistency checking, spread/delink
-operations, and a temporal derivation of the no-crossing constraint
-including the negative argument against simultaneity.
+are linked to a single autosegmental element on that node's tier. This is the
+**feature-geometry** representation (segments plus feature-sharing
+specifications over geometric nodes) — distinct from, and unconnected to, the
+bipartite tier-association object `AR` (`Graph.lean` / `AR.lean`). It builds on
+the feature geometry (`Featural/Geometry.lean`) and segment type
+(`Featural/Features.lean`) to provide feature agreement predicates,
+feature-sharing representations with consistency checking, and spread/delink
+operations.
 
 ## Main definitions
 
 * `agreeAt`, `placeAssimilation`, `totalAssimilation` — feature agreement
   predicates over a geometric node.
-* `Sharing`, `AutosegRep` — autosegmental representations as a segmental
+* `Sharing`, `AutosegRep` — feature-sharing representations: a segmental
   backbone plus a list of feature-sharing specifications.
 * `AutosegRep.inBounds`, `AutosegRep.consistent` — well-formedness checks.
 * `AutosegRep.spread`, `AutosegRep.delink`, `AutosegRep.spreadFeatures` —
-  atomic operations on autosegmental representations.
+  atomic operations on feature-sharing representations.
 * `copyFeaturesUnder` — replace features under a geometric node.
 
 The Sagey-1986 interval-overlap derivation of the No-Crossing Constraint

--- a/Linglib/Studies/Clements1985.lean
+++ b/Linglib/Studies/Clements1985.lean
@@ -1,4 +1,4 @@
-import Linglib.Phonology.Autosegmental.Defs
+import Linglib.Phonology.Autosegmental.FeatureSharing
 import Linglib.Fragments.English.Phonology
 
 /-!

--- a/Linglib/Studies/Sagey1986.lean
+++ b/Linglib/Studies/Sagey1986.lean
@@ -1,6 +1,6 @@
 import Linglib.Phonology.Featural.ComplexSegments
 import Linglib.Phonology.Featural.Geometry
-import Linglib.Phonology.Autosegmental.Defs
+import Linglib.Phonology.Autosegmental.FeatureSharing
 import Linglib.Phonology.Autosegmental.NoCrossing
 import Linglib.Phonology.Subregular.LocalRewrite
 import Linglib.Core.Order.Interval


### PR DESCRIPTION
`Autosegmental/Defs.lean` was misnamed: it isn't the directory's foundational defs (those are `Graph.lean`/`AR.lean`) but a separate SPE/Sagey **feature-geometry** formalism — `AutosegRep` + `agreeAt`/`spread`/`delink` over geometric nodes, consumed only by feature-geometry/harmony files (Finnish/Turkish vowel harmony, Clements1985, Sagey1986). Its docstring also collided with `AR` (both called their type 'the autosegmental representation'). Rename the file to `FeatureSharing.lean` and retitle/disambiguate the docstring; add license header. The `AutosegRep` *type*-name overlap with `AR` remains a follow-up.