### PR TITLE
feat(Semantics/Mereology): IsAtomicDomain — unify atomic-domain encodings

### DIFF
--- a/Linglib/Semantics/Mereology.lean
+++ b/Linglib/Semantics/Mereology.lean
@@ -276,6 +276,44 @@ theorem Overlap.symm {γ : Type*} [PartialOrder γ] {x y : γ}
     (h : Overlap x y) : Overlap y x :=
   let ⟨z, hzx, hzy⟩ := h; ⟨z, hzy, hzx⟩
 
+/-! ### Atomic domains (discrete orders)
+
+The sort-level, instance-resolvable companion of `QUA`. An `IsAtomicDomain` is a
+`PartialOrder` every element of which is an `Atom` (`IsMin`) — equivalently a
+discrete order (`a ≤ b ↔ a = b`), equivalently a sort on which
+`QUA (fun _ => True)` holds. It is the single consolidation point for the
+"flat/atomic domain" that recurs across studies (the `Student`-style fixtures)
+and that distributive determiners (English *each*, the `ONE_AT` presupposition)
+require of their restrictor sort: a sort with a non-atomic element (time
+intervals) simply has no instance. Everything below reduces to the existing
+`Atom`/`QUA`/`IsAntichain` machinery — this class adds resolution ergonomics, not
+a new notion. -/
+
+/-- A `PartialOrder` all of whose elements are atoms (`IsMin`) — a discrete order
+/ a `≤`-antichain on the whole type. -/
+class IsAtomicDomain (α : Type*) [PartialOrder α] : Prop where
+  /-- Every element is an atom. -/
+  all_atoms : ∀ x : α, Atom x
+
+/-- A discrete order (`a ≤ b ↔ a = b`) is an atomic domain — the canonical way to
+discharge the instance for `Student`-style flat fixtures. -/
+theorem isAtomicDomain_of_le_iff_eq {α : Type*} [PartialOrder α]
+    (h : ∀ a b : α, a ≤ b ↔ a = b) : IsAtomicDomain α where
+  all_atoms x := fun {b} hbx => le_of_eq ((h b x).1 hbx).symm
+
+/-- The whole type of an atomic domain is quantized — the sort-level face of
+`QUA`, routed through `qua_of_atom`. -/
+theorem IsAtomicDomain.qua_true {α : Type*} [PartialOrder α] [IsAtomicDomain α] :
+    QUA (fun _ : α => True) :=
+  qua_of_atom fun x _ => IsAtomicDomain.all_atoms x
+
+/-- In an atomic domain, overlapping elements are equal (atoms are disjoint). -/
+theorem IsAtomicDomain.eq_of_overlap {α : Type*} [PartialOrder α] [IsAtomicDomain α]
+    {x y : α} (h : Overlap x y) : x = y :=
+  let ⟨_, hzx, hzy⟩ := h
+  (Atom.eq (IsAtomicDomain.all_atoms x) hzx).symm.trans
+    (Atom.eq (IsAtomicDomain.all_atoms y) hzy)
+
 /-- Extensive measure function: additive over non-overlapping entities.
     [krifka-1998] §2.2, eq. (7): μ(x ⊕ y) = μ(x) + μ(y) when ¬O(x,y).
     Examples: weight, volume, number (cardinality). Order-interval sibling:

--- a/Linglib/Semantics/Quantification/ONEModifiers.lean
+++ b/Linglib/Semantics/Quantification/ONEModifiers.lean
@@ -110,4 +110,14 @@ theorem every_distributes {α : Type*} [PartialOrder α]
   · intro hAll x ⟨hPx, _⟩
     exact hAll x hPx
 
+/-- On an atomic restrictor sort (`Mereology.IsAtomicDomain`), every restrictor
+satisfies `ONE_AT`'s atomicity for free, so the presupposition reduces to the
+`|P| > 1` cardinality condition. This connects the sort-level
+`Mereology.IsAtomicDomain` typeclass to the predicate-level `ONE_AT` structure —
+they are the same atomicity at two granularities, not parallel notions. -/
+theorem ONE_AT_of_isAtomicDomain {α : Type*} [PartialOrder α] [IsAtomicDomain α]
+    {P : α → Prop} (h2 : ∃ (x y : α), P x ∧ P y ∧ x ≠ y) : ONE_AT P where
+  has_two := h2
+  all_atomic := fun x _ => IsAtomicDomain.all_atoms x
+
 end Quantification.ONEModifiers

--- a/Linglib/Studies/HaslingerHienEtAl2025.lean
+++ b/Linglib/Studies/HaslingerHienEtAl2025.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Quantification.UnifiedUniversal
 import Linglib.Semantics.Quantification.ONEModifiers
+import Linglib.Semantics.Quantification.Basic
 import Linglib.Semantics.Plurality.Distributivity
 import Linglib.Semantics.Plurality.Trivalent
 import Linglib.Typology.UniversalQuantifier
@@ -142,26 +143,27 @@ instance : PartialOrder Student where
   le_trans := fun _ _ _ h1 h2 => h1.trans h2
   le_antisymm := fun _ _ h _ => h
 
+/-- The flat `Student` order is the canonical `IsAtomicDomain`: its atomicity and
+disjointness now come from the shared `Mereology` machinery, not bespoke proofs. -/
+instance : IsAtomicDomain Student := isAtomicDomain_of_le_iff_eq (fun _ _ => Iff.rfl)
+
 /-- "passed the exam" -/
 def passed : Student → Prop
   | .alice => True
   | .bob => True
   | .carol => False
 
-/-- In a flat order, all elements are atoms. -/
+/-- All `Student`s are atoms — derived from the `IsAtomicDomain` instance. -/
 theorem student_atoms : ∀ (x : Student), (fun _ => True : Student → Prop) x →
-    Mereology.Atom x := by
-  intro x _ z hz
-  exact hz.symm
+    Mereology.Atom x :=
+  fun x _ => IsAtomicDomain.all_atoms x
 
-/-- In a flat order, distinct elements don't overlap. -/
+/-- Distinct `Student`s don't overlap — derived from the `IsAtomicDomain` instance. -/
 theorem student_disjoint : ∀ (x y : Student),
     (fun _ => True : Student → Prop) x →
     (fun _ => True : Student → Prop) y →
-    Mereology.Overlap x y → x = y := by
-  intro x y _ _ ⟨z, hzx, hzy⟩
-  -- In Student's flat order, ≤ is =, so hzx : z = x and hzy : z = y
-  exact hzx.symm.trans hzy
+    Mereology.Overlap x y → x = y :=
+  fun _ _ _ _ h => IsAtomicDomain.eq_of_overlap h
 
 /-- DNG-SG: `Q_∀` on a flat domain distributes to each element. -/
 theorem dng_sg_concrete :
@@ -313,5 +315,27 @@ theorem each_ten_minutes_blocked {α : Type*} [PartialOrder α]
     (hONE_AT : ONE_AT P) : False := by
   obtain ⟨x, hPx, hNA⟩ := hNonAtomic
   exact hNA (hONE_AT.all_atomic x hPx)
+
+/-! ### Bridge to the canonical generalized quantifier
+
+On an **atomic restrictor sort** (`Mereology.IsAtomicDomain α`), `Q_∀` *is* the
+canonical universal generalized quantifier `every_sem` (`λR S. ∀x. R x → S x`).
+The instance discharges both the atomicity and the disjointness conditions of
+`QForall_eq_standardGQ`, so the bridge is automatic — and `*each ten minutes`
+is exactly the case where the interval sort has no `IsAtomicDomain` instance.
+This snaps the mereological `Q_∀` tower onto the shared `∀`-denotation that the
+Barwise–Cooper `every_sem`, the Lindström `everyDet.toGQ`, and Sauerland's
+`JE∘DER` already meet at, with the atomicity presupposition realized as a
+typeclass on the sort rather than a side condition. -/
+
+/-- On an atomic restrictor sort, `Q_∀` is the canonical universal generalized
+quantifier `every_sem`. The `[IsAtomicDomain α]` instance is *used* — it
+discharges both hypotheses of `QForall_eq_standardGQ`.
+[haslinger-etal-2025-nllt] eq. (30b). -/
+theorem QForall_eq_every_sem {α : Type*} [PartialOrder α] [IsAtomicDomain α]
+    {P Q : α → Prop} :
+    QForall P Q ↔ Quantification.every_sem P Q :=
+  QForall_eq_standardGQ (fun x _ => IsAtomicDomain.all_atoms x)
+    (fun _ _ _ _ h => IsAtomicDomain.eq_of_overlap h)
 
 end HaslingerHienEtAl2025

--- a/Linglib/Studies/Zimmermann2008.lean
+++ b/Linglib/Studies/Zimmermann2008.lean
@@ -99,6 +99,11 @@ instance : PartialOrder Faasinjee where
   le_trans _ _ _ h1 h2 := h1.trans h2
   le_antisymm _ _ h _ := h
 
+/-- The flat `Faasinjee` order is an `IsAtomicDomain`; its atom/disjoint facts now
+derive from the shared `Mereology` machinery rather than bespoke proofs. -/
+instance : Mereology.IsAtomicDomain Faasinjee :=
+  Mereology.isAtomicDomain_of_le_iff_eq (fun _ _ => Iff.rfl)
+
 /-- *yā daurà wàndà* 'buckled their seatbelt'. -/
 def Daura : Faasinjee → Prop
   | .audu => True
@@ -112,11 +117,11 @@ instance : DecidablePred Daura := fun x => match x with
 
 /-! ### Mereological structure -/
 
-theorem atom_of_faasinjee (x : Faasinjee) : Mereology.Atom x := by
-  intro z hz; exact hz.symm
+theorem atom_of_faasinjee (x : Faasinjee) : Mereology.Atom x :=
+  Mereology.IsAtomicDomain.all_atoms x
 
 theorem faasinjee_disjoint (x y : Faasinjee) (h : Mereology.Overlap x y) :
-    x = y := by obtain ⟨z, hzx, hzy⟩ := h; exact hzx.symm.trans hzy
+    x = y := Mereology.IsAtomicDomain.eq_of_overlap h
 
 /-- `ONE_empty` holds of the universal *faasinjèe* predicate. This is
 the presupposition Z2008's *kō-wh* analysis (via Q_∀ + ONE_∅) places


### PR DESCRIPTION
Consolidates the scattered atomicity/discrete-domain encodings under one spine. (Reworked from the original denote-spine PR after a mathlib-idiom audit found that version was redundant/anti-pattern; spec: `scratch/quantifier-api-spec.md`.)

The codebase already unified atomicity around mathlib's `IsAntichain` (`Mereology.QUA`, `qua_of_atom`), but `ONE_AT`/`ONE_∅`, a deleted `AtomicSort`, and inline `Student`/`Faasinjee` flat domains each re-encoded it. This adds the single consolidation point:

- **`Mereology.IsAtomicDomain`** — the instance-resolvable typeclass face of `QUA univ` (`∀x, Atom x`); lemmas route through the existing `Atom`/`QUA` machinery.
- **`ONE_AT_of_isAtomicDomain`** ties the sort-level class to Haslinger's predicate-level `ONE_AT`.
- **NLLT study**: `QForall_eq_every_sem [IsAtomicDomain α]` (instance *used* — discharges both `QForall_eq_standardGQ` hypotheses; targets `every_sem`); `Student` fixture is now an `IsAtomicDomain` instance.
- **Zimmermann2008**: `Faasinjee` consolidated too — `atom_of_faasinjee`/`faasinjee_disjoint` now derive from the instance.

(Other suspected flat-domain re-rolls — Schwarz2009/Sudo2016/DalrympleKaplan2000/AissenPolian2025/Angelopoulos2026 — turned out not to duplicate the machinery; left untouched.)