### PR TITLE
refactor(Phonology/Tone): move GrammaticalTone to Tone/Grammatical

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2718,7 +2718,7 @@ import Linglib.Phonology.Featural.Underspecification
 import Linglib.Phonology.Featural.ElementTheory
 import Linglib.Phonology.Autosegmental.Defs
 import Linglib.Phonology.Tone.Basic
-import Linglib.Phonology.Autosegmental.GrammaticalTone
+import Linglib.Phonology.Tone.Grammatical
 import Linglib.Phonology.Autosegmental.Floating
 import Linglib.Phonology.OCP
 import Linglib.Phonology.Tone.Constraints

--- a/Linglib/Fragments/Hausa/Tone.lean
+++ b/Linglib/Fragments/Hausa/Tone.lean
@@ -1,4 +1,4 @@
-import Linglib.Phonology.Autosegmental.GrammaticalTone
+import Linglib.Phonology.Tone.Grammatical
 import Linglib.Phonology.Tone.Basic
 
 /-!
@@ -19,7 +19,7 @@ Hausa, not a parallel hierarchy:
 - `Tone.TRN` is the
   underlying autosegmental primitive; `HausaTone` is a surface
   inventory whose decomposition is given by `toAutoseg`.
-- `Phonology.Autosegmental.GrammaticalTone.GTSpec` is the GT-trigger
+- `Tone.GTSpec` is the GT-trigger
   type. Hausa uses two of [rolle-2018]'s six dominance cells —
   replacive-dominant and neutral. We expose smart constructors
   `mkReplacive`/`mkNeutral` that fix the other GTSpec fields to the
@@ -33,7 +33,7 @@ Per-cell facts (e.g. *the plural template is dominant*) appear as
 namespace Hausa.Tone
 
 open _root_.Tone (TRN)
-open Phonology.Autosegmental.GrammaticalTone
+open _root_.Tone
   (Spec GTSpec TonalMelody ValuationWindow GTDominance
    GTLevel ExponenceType tonalOverwrite TBU)
 

--- a/Linglib/Fragments/Mwaghavul/Basic.lean
+++ b/Linglib/Fragments/Mwaghavul/Basic.lean
@@ -1,5 +1,5 @@
 import Linglib.Phonology.Tone.Basic
-import Linglib.Phonology.Autosegmental.GrammaticalTone
+import Linglib.Phonology.Tone.Grammatical
 
 /-!
 # Mwaghavul Phonological Fragment
@@ -41,7 +41,7 @@ namespace Mwaghavul
 
 open Tone (TRN TBUKind
   WordProsodicType)
-open Phonology.Autosegmental.GrammaticalTone (TBU Spec ValuationWindow)
+open Tone (TBU Spec ValuationWindow)
 
 -- ============================================================================
 -- S 1: Phonological Inventory
@@ -148,7 +148,7 @@ def deriveVerb (base : Ideophone) : List TRN :=
     | .m  => verbM
     | .mh => verbMH
   let host := base.tones.map λ t => mkTSyl base.form t
-  (Phonology.Autosegmental.GrammaticalTone.tonalOverwrite host spec).map TBU.tone
+  (Tone.tonalOverwrite host spec).map TBU.tone
 
 -- M-tone verbaliser: wùlàʃ [L L] → wūlāʃ [M M]
 theorem wuulash_verb : deriveVerb wuulash = [.M, .M] := by decide
@@ -176,7 +176,7 @@ theorem jalpat_verb : deriveVerb jalpat = [.M, .H] := by decide
 theorem m_verb_uniform (i : Ideophone) (h : i.verbType = .m) :
     deriveVerb i = i.tones.map (λ _ => TRN.M) := by
   simp [deriveVerb, h, verbM,
-    Phonology.Autosegmental.GrammaticalTone.tonalOverwrite,
+    Tone.tonalOverwrite,
     List.map_map, Function.comp_def]
 
 /-- M-H derived verbs have M on nonfinal TBUs and H on the final TBU.
@@ -187,6 +187,6 @@ theorem mh_verb_bisyllabic_pattern (i : Ideophone)
   simp [deriveVerb, h, verbMH]
   match i, h2 with
   | ⟨_, _, [_, _], _⟩, _ =>
-    simp [Phonology.Autosegmental.GrammaticalTone.tonalOverwrite]
+    simp [Tone.tonalOverwrite]
 
 end Mwaghavul

--- a/Linglib/Fragments/Poko/Tone.lean
+++ b/Linglib/Fragments/Poko/Tone.lean
@@ -1,5 +1,5 @@
 import Linglib.Phonology.Tone.Basic
-import Linglib.Phonology.Autosegmental.GrammaticalTone
+import Linglib.Phonology.Tone.Grammatical
 import Linglib.Phonology.Autosegmental.Floating
 
 /-!

--- a/Linglib/Phonology/Autosegmental/BasemapCorrespondence.lean
+++ b/Linglib/Phonology/Autosegmental/BasemapCorrespondence.lean
@@ -1,4 +1,4 @@
-import Linglib.Phonology.Autosegmental.GrammaticalTone
+import Linglib.Phonology.Tone.Grammatical
 import Linglib.Phonology.OptimalityTheory.Correspondence
 import Linglib.Phonology.Constraint.Defs
 import Linglib.Phonology.OptimalityTheory.Optimality
@@ -65,7 +65,7 @@ via a separate Hamming-distance implementation.
 
 namespace Phonology.Autosegmental.BasemapCorrespondence
 
-open Phonology.Autosegmental.GrammaticalTone
+open Tone
 open Tone (TRN)
 open OptimalityTheory.Correspondence (Corr)
 open Constraint OptimalityTheory

--- a/Linglib/Phonology/Autosegmental/CoPScope.lean
+++ b/Linglib/Phonology/Autosegmental/CoPScope.lean
@@ -1,4 +1,4 @@
-import Linglib.Phonology.Autosegmental.GrammaticalTone
+import Linglib.Phonology.Tone.Grammatical
 
 /-!
 # CoP-scope: cophonological domain scope hierarchy
@@ -52,7 +52,7 @@ This rules out outward dominance from complements.
 
 namespace Phonology.Autosegmental.CoPScope
 
-open Phonology.Autosegmental.GrammaticalTone
+open Tone
 
 /-! ### CoP-scope positions -/
 

--- a/Linglib/Phonology/Tone/Grammatical.lean
+++ b/Linglib/Phonology/Tone/Grammatical.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Features.Prosody
 import Linglib.Phonology.Tone.Basic
 
@@ -53,9 +58,7 @@ instantiations live in `Fragments/`; empirical applications in `Studies/`.
 [rolle-2018] [hyman-etal-2021]
 -/
 
-namespace Phonology.Autosegmental.GrammaticalTone
-
-open Tone (TRN)
+namespace Tone
 
 /-! ### Tone-bearing units -/
 
@@ -425,4 +428,4 @@ theorem dominant_asymmetry_typical :
 theorem outward_dominance_violates :
     DominantGTAsymmetry.holds ⟨false, true⟩ = false := rfl
 
-end Phonology.Autosegmental.GrammaticalTone
+end Tone

--- a/Linglib/Studies/AkinboFwangwar2026.lean
+++ b/Linglib/Studies/AkinboFwangwar2026.lean
@@ -573,7 +573,7 @@ end Tableau26
     window of the target-host. Verbalisers are word-level + independent
     prosodic exponence (segmentally null — tone is the sole exponent). -/
 
-open Phonology.Autosegmental.GrammaticalTone
+open Tone
   (GTSpec GTDominance GTLevel ExponenceType DominantGTAsymmetry)
 open Phonology.Autosegmental.CoPScope
   (CoPPosition dominant_gt_asymmetry_from_scope)
@@ -733,7 +733,7 @@ with 0 violations on the top constraint forces every optimal candidate to 0. -/
 
 section DominantCophAgreement
 
-open Phonology.Autosegmental.GrammaticalTone (TBU Spec tonalOverwrite)
+open Tone (TBU Spec tonalOverwrite)
 open Phonology.Autosegmental.BasemapCorrespondence
 open OptimalityTheory.CophonologyTheory (mergeRanking cophonologicalEval)
 

--- a/Linglib/Studies/McPhersonLamont2026.lean
+++ b/Linglib/Studies/McPhersonLamont2026.lean
@@ -997,7 +997,7 @@ References: [rolle-2018] (replacive-dominant GT via `tonalOverwrite`),
 
 namespace Phonology.Autosegmental
 
-open Phonology.Autosegmental.GrammaticalTone (TBU)
+open Tone (TBU)
 open Tone (TRN)
 
 /-- Embed a `List (TBU S)` (the output type of `tonalOverwrite`) into


### PR DESCRIPTION
Relocates the grammatical-tone typology out of the autosegmental *mechanism* into the tone *subject*: `Autosegmental/GrammaticalTone.lean` → `Tone/Grammatical.lean` (de-stuttered — the `Tone/` dir supplies 'tone'), namespace `Phonology.Autosegmental.GrammaticalTone` → bare `Tone` (joins `TRN`/constraints). It's reusable GT-typology substrate (3 Fragments type entries with it). Bare-`Tone` collision with `Hausa.Tone` handled via `open _root_.Tone`; added license header. Follow-up: `CoPScope`/`BasemapCorrespondence` (single-consumer Rolle-2018 apparatus) → `Studies/Rolle2018.lean`.