### PR TITLE
refactor(Studies/HaslingerEtAl2025): derive German inventory from fragment

### DIFF
--- a/Linglib/Studies/HaslingerEtAl2025.lean
+++ b/Linglib/Studies/HaslingerEtAl2025.lean
@@ -33,6 +33,7 @@ preserves it at the operator level. See `Studies/Haslinger2025.lean`.
 
 import Linglib.Semantics.Plurality.Distributivity
 import Linglib.Semantics.Plurality.Trivalent
+import Linglib.Fragments.German.Distributives
 
 namespace HaslingerEtAl2025
 
@@ -56,26 +57,25 @@ structure LexicalItem where
   semanticClass : DistMaxClass
   deriving Repr
 
-/-- jeder (DP-internal and distance): +distributive, +maximal -/
-def jeder : LexicalItem :=
-  { form := "jeder"
-  , gloss := "every/each"
-  , uses := [.dpInternal, .distance]
-  , semanticClass := .distMax }
+/-- Derive a `LexicalItem` from the German distributive Fragment entry, so the
+form/gloss/classification are read off `Fragments/German/Distributives.lean`
+rather than restated here (the fragment is anchored to this same paper). -/
+def LexicalItem.ofEntry (e : German.Distributives.DistributiveEntry) : LexicalItem :=
+  { form := e.form
+  , gloss := e.gloss
+  , uses := (if e.hasDPUse then [.dpInternal] else []) ++
+            (if e.hasDistanceUse then [.distance] else [])
+  , semanticClass := e.distMaxClass }
 
-/-- jeweils (distance only): +distributive, -maximal -/
-def jeweils : LexicalItem :=
-  { form := "jeweils"
-  , gloss := "each/respectively"
-  , uses := [.distance]  -- No DP-internal use!
-  , semanticClass := .distNonMax }
+/-- jeder (DP-internal and distance): +distributive, +maximal. Derived from the
+German fragment's `jederEntry`. -/
+def jeder : LexicalItem := .ofEntry German.Distributives.jederEntry
 
-/-- alle (DP-internal): -distributive, +maximal -/
-def alle : LexicalItem :=
-  { form := "alle"
-  , gloss := "all"
-  , uses := [.dpInternal]
-  , semanticClass := .nonDistMax }
+/-- jeweils (distance only): +distributive, -maximal. Derived from `jeweilsEntry`. -/
+def jeweils : LexicalItem := .ofEntry German.Distributives.jeweilsEntry
+
+/-- alle (DP-internal): -distributive, +maximal. Derived from `alleEntry`. -/
+def alle : LexicalItem := .ofEntry German.Distributives.alleEntry
 
 /-- Definite plurals: -distributive, -maximal -/
 def definitePlural : LexicalItem :=


### PR DESCRIPTION
Removes the third copy of the German distributive inventory. The S&P study re-defined `jeder`/`jeweils`/`alle` as its own `LexicalItem` with stipulated `semanticClass : DistMaxClass` — duplicating `Fragments/German/Distributives.lean`'s `*Entry` records (same paper anchor). They now derive via a `LexicalItem.ofEntry` adapter (form/gloss/uses/class read off the fragment; `uses` from `hasDPUse`/`hasDistanceUse`).

Transparent: every derived value is `rfl`-identical to the old stipulated one, so all existing theorems (`typologyTable`, `jeder.semanticClass = .distMax`, the independence results) still hold unchanged.

(Note: the originally-specced PR 2 — delete `DistributiveEntry` + move `DistMaxClass` to this study — was dropped: `DistMaxClass` is used by Fragments, which can't import Studies, and the `*Entry` records are what the NLLT study's §6/§7 correctly *derive* from. This is the actual non-regressive consolidation.)