### PR TITLE
refactor(Core/Computability): hom-closure on List, drop StringHom

### DIFF
--- a/Linglib/Core/Computability/ContextFreeGrammar/Closure.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Closure.lean
@@ -1,6 +1,5 @@
 import Mathlib.Computability.ContextFreeGrammar
 import Mathlib.Computability.DFA
-import Linglib.Core.Computability.StringHom
 import Linglib.Core.Computability.ContextFreeGrammar.Map
 import Linglib.Core.Computability.ContextFreeGrammar.InterRegular
 
@@ -32,22 +31,6 @@ ARE proved here:
   non-CF argument.
 -/
 
-/-- **Bridge to mathlib's `Language.map`.** When `h` is the letter-to-letter
-    `StringHom.letterMap f` (each input symbol → singleton output), the
-    homomorphic image collapses to mathlib's `Language.map f`, the
-    letter-by-letter image. Lifts mathlib's existing ringHom structure to
-    the letter-map case of `stringMap` automatically. -/
-@[simp] theorem Language.stringMap_letterMap {α β : Type*}
-    (f : α → β) (L : Language α) :
-    Language.stringMap (Core.StringHom.letterMap f) L = Language.map f L := by
-  ext w
-  simp only [Language.stringMap, Set.mem_setOf_eq, Core.StringHom.apply_letterMap,
-             Language.map, RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk,
-             Set.mem_image]
-  constructor
-  · rintro ⟨v, hv, rfl⟩; exact ⟨v, hv, rfl⟩
-  · rintro ⟨v, hv, rfl⟩; exact ⟨v, hv, rfl⟩
-
 -- ============================================================================
 -- Contrapositive corollaries (the useful direction for non-CF arguments)
 -- ============================================================================
@@ -57,10 +40,10 @@ ARE proved here:
 /-- Contrapositive of homomorphism closure: if the homomorphic image of `L`
     is not context-free, then `L` is not context-free. -/
 theorem Language.not_isContextFree_of_stringMap_not {α β : Type*}
-    (h : Core.StringHom α β) {L : Language α}
-    (hImg : ¬ (Language.stringMap h L).IsContextFree) :
+    (f : α → List β) {L : Language α}
+    (hImg : ¬ (Language.stringMap f L).IsContextFree) :
     ¬ L.IsContextFree :=
-  fun hL => hImg (Language.IsContextFree.stringMap h hL)
+  fun hL => hImg (Language.IsContextFree.stringMap f hL)
 
 /-- Contrapositive of regular-intersection closure: if `L ∩ R` is not
     context-free for some regular `R`, then `L` is not context-free. -/
@@ -80,9 +63,9 @@ theorem Language.not_isContextFree_of_inter_regular_not {α : Type*}
     homomorphic abstraction (e.g., case-marker-only projection) plus
     regular filtering (e.g., case-sorted clause shape). -/
 theorem Language.not_isContextFree_via_witness {α β : Type*}
-    (h : Core.StringHom α β) (R : Language β) {L : Language α}
+    (f : α → List β) (R : Language β) {L : Language α}
     (hR : R.IsRegular)
-    (hWitness : ¬ (Language.stringMap h L ⊓ R).IsContextFree) :
+    (hWitness : ¬ (Language.stringMap f L ⊓ R).IsContextFree) :
     ¬ L.IsContextFree :=
   fun hL =>
-    hWitness ((Language.IsContextFree.stringMap h hL).inter_isRegular hR)
+    hWitness ((Language.IsContextFree.stringMap f hL).inter_isRegular hR)

--- a/Linglib/Core/Computability/ContextFreeGrammar/Map.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Map.lean
@@ -1,19 +1,28 @@
 import Mathlib.Computability.ContextFreeGrammar
-import Linglib.Core.Computability.StringHom
 
 /-!
 # Closure of `IsContextFree` under string homomorphism
 
-The image of a context-free language under a string homomorphism `h : T → List T'`
-is context-free. Construction: replace each terminal `a` in each grammar rule's
-output with the symbol-list `(h a).map .terminal`. Nonterminals are unchanged.
+The image of a context-free language under a string homomorphism — induced by a
+per-symbol map `f : T → List T'` — is context-free. Construction: replace each
+terminal `a` in each grammar rule's output with the symbol-list `(f a).map .terminal`.
+Nonterminals are unchanged.
 
-Owns the `Language.stringMap` definition and proves
-`Language.IsContextFree.stringMap`. Together with the parallel Bar-Hillel
-proof in `InterRegular.lean`, this dissolves the closure axioms previously
-in `Closure.lean`.
+## Main definitions
 
-[hopcroft-motwani-ullman-2000] Theorem 7.24 part 4 (p. 284-285, homomorphism case).
+* `Language.stringMap f : Language T →+* Language T'` — image under the string
+  homomorphism. Since `List α = FreeMonoid α`, the action `List.flatMap f` is the
+  free-monoid lift `FreeMonoid.lift f`; bundled as a semiring hom mirroring mathlib's
+  `Language.map`, of which the letter-to-letter case is the special case
+  `Language.stringMap_letterMap`.
+
+## Main theorems
+
+* `Language.IsContextFree.stringMap` — context-free languages are closed under
+  string homomorphism.
+* `ContextFreeGrammar.applyHom_language` — the grammar construction realizes `stringMap`.
+
+[hopcroft-motwani-ullman-2000] (homomorphism-closure construction).
 -/
 
 open scoped Classical
@@ -22,10 +31,30 @@ universe u v
 
 variable {T : Type u} {T' : Type v}
 
-/-- The homomorphic image of a language under a string homomorphism.
-    `Language.stringMap h L = {h(v) | v ∈ L}`. -/
-def Language.stringMap (h : Core.StringHom T T') (L : Language T) : Language T' :=
-  {w | ∃ v ∈ L, Core.StringHom.apply h v = w}
+/-- The image of a language under the string homomorphism induced by a per-symbol
+    map `f : T → List T'`. On a word the action is `List.flatMap f` — i.e. the
+    free-monoid lift `FreeMonoid.lift f`, since `List α = FreeMonoid α`. Bundled as a
+    semiring hom mirroring mathlib's `Language.map`; the letter-to-letter map is the
+    special case `Language.stringMap_letterMap`. -/
+def Language.stringMap (f : T → List T') : Language T →+* Language T' where
+  toFun := Set.image (List.flatMap f)
+  map_zero' := Set.image_empty _
+  map_one' := Set.image_singleton
+  map_add' := Set.image_union _
+  map_mul' _ _ := Set.image_image2_distrib fun _ _ => List.flatMap_append ..
+
+@[simp] theorem Language.mem_stringMap {f : T → List T'} {L : Language T} {w : List T'} :
+    w ∈ Language.stringMap f L ↔ ∃ v ∈ L, List.flatMap f v = w := Iff.rfl
+
+/-- **Bridge to mathlib's `Language.map`.** The letter-to-letter map `f : T → T'`
+    (singleton outputs) is the special case of `stringMap` that collapses to mathlib's
+    `Language.map f`, so `stringMap` genuinely generalizes the existing letter image. -/
+@[simp] theorem Language.stringMap_letterMap (f : T → T') (L : Language T) :
+    Language.stringMap (fun a => [f a]) L = Language.map f L := by
+  have hfun : (List.flatMap (fun a => [f a]) : List T → List T') = List.map f :=
+    funext fun _ => List.map_eq_flatMap.symm
+  show Set.image (List.flatMap fun a => [f a]) L = Set.image (List.map f) L
+  rw [hfun]
 
 namespace ContextFreeRule
 
@@ -146,13 +175,14 @@ namespace ContextFreeGrammar
     `Language.stringMap h G.language`. -/
 theorem applyHom_language_subset (h : T → List T') (G : ContextFreeGrammar T) :
     Language.stringMap h G.language ≤ (G.applyHom h).language := by
-  rintro w' ⟨w, hw, rfl⟩
+  intro w' hw'
+  obtain ⟨w, hw, rfl⟩ := Language.mem_stringMap.mp hw'
   show (G.applyHom h).Derives [.nonterminal G.initial]
-        ((Core.StringHom.apply h w).map .terminal)
+        ((List.flatMap h w).map .terminal)
   have hd := Derives.applyHom h hw
   convert hd using 1
   · simp [ContextFreeRule.Symbol.applyHom]
-  · simp [Core.StringHom.apply, ContextFreeRule.applyHomList_map_terminal]
+  · simp [ContextFreeRule.applyHomList_map_terminal]
 
 -- ============================================================================
 -- Backward direction helpers (private to this file)
@@ -311,7 +341,7 @@ private lemma derivesLift {h : T → List T'} {G : ContextFreeGrammar T}
 private lemma liftMapTerminal {h : T → List T'} {N : Type*} :
     ∀ {t : List (Symbol T N)} {w' : List T'},
     ContextFreeRule.applyHomList h t = w'.map (Symbol.terminal (N := N)) →
-    ∃ w : List T, t = w.map .terminal ∧ Core.StringHom.apply h w = w' := by
+    ∃ w : List T, t = w.map .terminal ∧ List.flatMap h w = w' := by
   intro t
   induction t with
   | nil =>
@@ -357,7 +387,7 @@ theorem applyHom_language_subset_inv (h : T → List T') (G : ContextFreeGrammar
     simp [ContextFreeRule.applyHomList, ContextFreeRule.Symbol.applyHom]
   obtain ⟨t, hGt, ht_eq⟩ := derivesLift hw' hlift
   obtain ⟨w, hw_term, hw_apply⟩ := liftMapTerminal ht_eq
-  refine ⟨w, ?_, hw_apply⟩
+  refine Language.mem_stringMap.mpr ⟨w, ?_, hw_apply⟩
   show G.Derives [.nonterminal G.initial] (w.map .terminal)
   rw [← hw_term]; exact hGt
 
@@ -369,9 +399,9 @@ end ContextFreeGrammar
 
 namespace Language.IsContextFree
 
-theorem stringMap (h : Core.StringHom T T') {L : Language T}
-    (hL : L.IsContextFree) : (Language.stringMap h L).IsContextFree := by
+theorem stringMap (f : T → List T') {L : Language T}
+    (hL : L.IsContextFree) : (Language.stringMap f L).IsContextFree := by
   obtain ⟨G, rfl⟩ := hL
-  exact ⟨G.applyHom h, ContextFreeGrammar.applyHom_language h G⟩
+  exact ⟨G.applyHom f, ContextFreeGrammar.applyHom_language f G⟩
 
 end Language.IsContextFree

--- a/Linglib/Core/Computability/NonContextFree/AnBnCn.lean
+++ b/Linglib/Core/Computability/NonContextFree/AnBnCn.lean
@@ -108,6 +108,35 @@ private theorem makeString_anbnc_in_language (n : Nat) :
     change (makeString_anbnc (k + 1) == makeString_anbnc (k + 1)) = true
     exact beq_self_eq_true _
 
+/-- Membership characterization: every string in `anbnc` is `makeString_anbnc n`
+    for some `n`. Mirror of `mem_anbncndn_iff`; consumed by the homomorphic
+    reduction aⁿbⁿcⁿdⁿ → aⁿbⁿcⁿ in `AnBnCnDn`. -/
+theorem mem_anbnc_iff (w : List ThreeSymbol) :
+    w ∈ anbnc ↔ ∃ n, w = makeString_anbnc n := by
+  constructor
+  · intro hw
+    by_cases hempty : w = []
+    · exact ⟨0, by rw [hempty]; rfl⟩
+    · have heq := isInLang3_nonempty w hempty
+      have hw' : isInLanguage_anbnc w = true := hw
+      rw [heq] at hw'
+      simp only [Bool.and_eq_true, beq_iff_eq] at hw'
+      obtain ⟨⟨h_ab, h_bc⟩, h_eq⟩ := hw'
+      refine ⟨(w.filter (· == .a)).length, ?_⟩
+      have hb_eq : (w.filter (· == .b)).length = (w.filter (· == .a)).length := h_ab.symm
+      have hc_eq : (w.filter (· == .c)).length = (w.filter (· == .a)).length :=
+        h_bc.symm.trans h_ab.symm
+      calc w
+          = List.replicate (w.filter (· == .a)).length .a ++
+              List.replicate (w.filter (· == .b)).length .b ++
+              List.replicate (w.filter (· == .c)).length .c := h_eq
+        _ = List.replicate (w.filter (· == .a)).length .a ++
+              List.replicate (w.filter (· == .a)).length .b ++
+              List.replicate (w.filter (· == .a)).length .c := by rw [hb_eq, hc_eq]
+        _ = makeString_anbnc (w.filter (· == .a)).length := rfl
+  · rintro ⟨n, rfl⟩
+    exact makeString_anbnc_in_language n
+
 set_option maxHeartbeats 800000 in
 /-- {aⁿbⁿcⁿ} does NOT have the CFL pumping property. -/
 theorem anbnc_not_pumpable :

--- a/Linglib/Core/Computability/NonContextFree/AnBnCnDn.lean
+++ b/Linglib/Core/Computability/NonContextFree/AnBnCnDn.lean
@@ -1,31 +1,35 @@
-import Linglib.Core.Computability.ContextFreeGrammar.Pumping
 import Linglib.Core.Computability.NonContextFree.BlockWitness
+import Linglib.Core.Computability.NonContextFree.AnBnCn
+import Linglib.Core.Computability.ContextFreeGrammar.Closure
 
 /-!
 # {aⁿbⁿcⁿdⁿ}: a four-symbol non-context-free witness language
 
-The single-parameter four-symbol witness `anbncndn = {aⁿbⁿcⁿdⁿ | n ≥ 0}`,
-proven non-context-free via the CFL pumping lemma + the unified adjacency
-lemma in `BlockWitness`.
-
+The single-parameter four-symbol witness `anbncndn = {aⁿbⁿcⁿdⁿ | n ≥ 0}`.
 Membership requires `na = nb = nc = nd` (all four counts equal) **and** the
-sorted shape `aⁿbⁿcⁿdⁿ`. Pumping breaks at least one count equality.
+sorted shape `aⁿbⁿcⁿdⁿ`.
+
+Non-context-freeness is **derived by closure, not re-proved by pumping**: the
+erasing homomorphism `dropD : d ↦ ε` maps `anbncndn` exactly onto the irreducible
+counting core `anbnc = {aⁿbⁿcⁿ}` (`AnBnCn`), so `anbncndn_not_contextFree`
+follows from `anbnc_not_contextFree` through `Language.IsContextFree.stringMap`
+(the hom-closure root in `Map`, run contrapositively via `Closure`). aⁿbⁿcⁿdⁿ is
+the *nested-counting* case; the genuinely *crossing* witness that [shieber-1985]'s
+Swiss-German argument requires is the two-parameter `ambncmdn` sibling, which does
+not reduce by single-symbol erasure.
 
 This file also hosts the **shared `FourSymbol` substrate** consumed by the
 two-parameter relaxation in `NonContextFree.AmBnCmDn`:
 
 * The alphabet (`FourSymbol`, `FourString`, `LawfulBEq`).
 * Witness-form bridges (`makeString_anbncndn_eq_blockwitness`).
-* Three adjacency consequences via `BlockWitness.not_both_in_vxy`
-  (`not_a_and_d_in_vxy`, `not_a_and_c_in_vxy`, `not_b_and_d_in_vxy`).
+* Adjacency consequences via `BlockWitness.not_both_in_vxy`
+  (`not_a_and_c_in_vxy`, `not_b_and_d_in_vxy`).
 * Filter-count machinery (`filter_count`, `filter_eq_nil_of_not_mem`,
   `fourSymbol_filter_total`).
-
-Closure properties for `IsContextFree` (homomorphism, regular intersection)
-live in `Linglib.Core.Computability.ContextFreeGrammar.Closure`.
 -/
 
-/-- Alphabet for cross-serial dependency patterns. -/
+/-- Alphabet for the four-symbol counting witness languages. -/
 inductive FourSymbol where
   | a | b | c | d
   deriving DecidableEq, Repr
@@ -36,7 +40,11 @@ instance : LawfulBEq FourSymbol where
 
 abbrev FourString := List FourSymbol
 
-/-- The language {aⁿbⁿcⁿdⁿ | n ≥ 0}, modeling Dutch cross-serial dependencies. -/
+/-- The language {aⁿbⁿcⁿdⁿ | n ≥ 0}: the pedagogical four-symbol counting language. The
+    genuinely *crossing* witness that [shieber-1985]'s Swiss-German non-context-freeness
+    argument requires is the two-parameter `ambncmdn` sibling; this single-parameter
+    language is the nested-counting case (cf. [bresnan-etal-1982] on Dutch cross-serial
+    word order, which is itself only weakly context-free). -/
 def isInLanguage_anbncndn (w : FourString) : Bool :=
   match w with
   | [] => true
@@ -109,11 +117,6 @@ private theorem not_both_in_vxy_FourSymbol {s t : FourSymbol} {i j : Nat}
     (by decide : ([FourSymbol.a, .b, .c, .d] : List FourSymbol).Nodup)
     hi hj hij (makeString_anbncndn_eq_blockwitness p ▸ hw) hvxy
 
-theorem not_a_and_d_in_vxy (p : Nat) (u vxy z : FourString)
-    (hw : makeString_anbncndn p = u ++ vxy ++ z) (hvxy : vxy.length ≤ p) :
-    ¬(FourSymbol.a ∈ vxy ∧ FourSymbol.d ∈ vxy) :=
-  not_both_in_vxy_FourSymbol (i := 0) (j := 3) rfl rfl (by decide) p u vxy z hw hvxy
-
 theorem not_a_and_c_in_vxy (p : Nat) (u vxy z : FourString)
     (hw : makeString_anbncndn p = u ++ vxy ++ z) (hvxy : vxy.length ≤ p) :
     ¬(FourSymbol.a ∈ vxy ∧ FourSymbol.c ∈ vxy) :=
@@ -137,17 +140,6 @@ theorem fourSymbol_filter_total (l : FourString) :
   | cons h t ih =>
     simp only [List.filter_cons, List.length_cons]
     cases h <;> simp <;> omega
-
-private theorem counts_eq_of_inLanguage (w : FourString) (hne : w ≠ [])
-    (hin : isInLanguage_anbncndn w = true) :
-    (w.filter (· == .a)).length = (w.filter (· == .b)).length ∧
-    (w.filter (· == .b)).length = (w.filter (· == .c)).length ∧
-    (w.filter (· == .c)).length = (w.filter (· == .d)).length := by
-  unfold isInLanguage_anbncndn at hin
-  match w, hne with
-  | _ :: _, _ =>
-    simp only [Bool.and_eq_true, beq_iff_eq] at hin
-    exact ⟨hin.1.1.1, hin.1.1.2, hin.1.2⟩
 
 -- ============================================================================
 -- Membership characterizations
@@ -201,81 +193,61 @@ theorem mem_anbncndn_iff (w : FourString) :
     exact makeString_in_language n
 
 -- ============================================================================
--- Pumping fails for {aⁿbⁿcⁿdⁿ}
+-- Non-context-freeness by homomorphic reduction to {aⁿbⁿcⁿ}
 -- ============================================================================
 
-set_option maxHeartbeats 800000 in
-/-- Pumping breaks membership in {aⁿbⁿcⁿdⁿ}. -/
-theorem pump_breaks_anbncndn (p : Nat) (_hp : p > 0) :
-    let w := makeString_anbncndn p
-    ∀ u v x y z : FourString,
-      w = u ++ v ++ x ++ y ++ z →
-      (v ++ x ++ y).length ≤ p →
-      (v.length + y.length) ≥ 1 →
-      ∃ i : Nat, (u ++ List.flatten (List.replicate i v) ++ x ++
-                   List.flatten (List.replicate i y) ++ z) ∉ anbncndn := by
-  intro w u v x y z hw hvxy_len hvy_len
-  use 0
-  simp only [List.replicate_zero, List.flatten_nil, List.append_nil]
-  have hw' : makeString_anbncndn p = u ++ (v ++ x ++ y) ++ z := by
-    have : w = u ++ v ++ x ++ y ++ z := hw
-    simp only [List.append_assoc] at this ⊢; exact this
-  have hcontig := not_a_and_d_in_vxy p u (v ++ x ++ y) z hw' hvxy_len
-  have hvxy_len' : v.length + x.length + y.length ≤ p := by
-    simp only [List.length_append] at hvxy_len; omega
-  show ¬ (isInLanguage_anbncndn (u ++ x ++ z) = true)
-  intro hin
-  have huxz_ne : u ++ x ++ z ≠ [] := by
-    intro h
-    have huxz0 : u.length + x.length + z.length = 0 := by
-      have := congr_arg List.length h; simp only [List.length_append, List.length_nil] at this; omega
-    have hlen : u.length + v.length + x.length + y.length + z.length = 4 * p := by
-      have := congr_arg List.length hw'.symm
-      simp only [makeString_anbncndn, List.length_append, List.length_replicate] at this; omega
-    omega
-  obtain ⟨hab, hbc, hcd⟩ := counts_eq_of_inLanguage _ huxz_ne hin
-  have hrel : ∀ s : FourSymbol,
-      ((u ++ x ++ z).filter (· == s)).length +
-      (v.filter (· == s)).length + (y.filter (· == s)).length = p := by
-    intro s
-    have h1 := filter_count p s; rw [hw'] at h1
-    simp only [List.filter_append, List.length_append] at h1 ⊢; omega
-  have h4k : 4 * ((u ++ x ++ z).filter (· == .a)).length = (u ++ x ++ z).length := by
-    have := fourSymbol_filter_total (u ++ x ++ z); omega
-  have hlen_uxz : (u ++ x ++ z).length + (v.length + y.length) = 4 * p := by
-    have hlen : (makeString_anbncndn p).length = 4 * p := by
-      simp [makeString_anbncndn, List.length_append, List.length_replicate]; omega
-    rw [hw'] at hlen; simp only [List.length_append] at hlen ⊢; omega
-  have hk_eq_p : ((u ++ x ++ z).filter (· == .a)).length = p := by
-    by_cases ha : FourSymbol.a ∈ (v ++ x ++ y)
-    · have hd : FourSymbol.d ∉ (v ++ x ++ y) := fun hd => hcontig ⟨ha, hd⟩
-      have hdv : FourSymbol.d ∉ v :=
-        fun h => hd (List.mem_append_left _ (List.mem_append_left _ h))
-      have hdy : FourSymbol.d ∉ y :=
-        fun h => hd (List.mem_append_right _ h)
-      have hrd := hrel .d
-      rw [filter_eq_nil_of_not_mem v .d hdv, filter_eq_nil_of_not_mem y .d hdy] at hrd
-      simp only [List.length_nil, Nat.add_zero] at hrd; omega
-    · have hav : FourSymbol.a ∉ v :=
-        fun h => ha (List.mem_append_left _ (List.mem_append_left _ h))
-      have hay : FourSymbol.a ∉ y :=
-        fun h => ha (List.mem_append_right _ h)
-      have hra := hrel .a
-      rw [filter_eq_nil_of_not_mem v .a hav, filter_eq_nil_of_not_mem y .a hay] at hra
-      simp only [List.length_nil, Nat.add_zero] at hra; exact hra
-  omega
+/-- The erasing homomorphism `d ↦ ε` (per-symbol map; the string action is
+    `List.flatMap dropD`, the free-monoid lift), relabelling the surviving a/b/c into
+    the `ThreeSymbol` alphabet. The witness for the reduction aⁿbⁿcⁿdⁿ → aⁿbⁿcⁿ. -/
+def dropD : FourSymbol → List ThreeSymbol
+  | FourSymbol.a => [ThreeSymbol.a]
+  | FourSymbol.b => [ThreeSymbol.b]
+  | FourSymbol.c => [ThreeSymbol.c]
+  | FourSymbol.d => []
 
-/-- {aⁿbⁿcⁿdⁿ} does NOT have the CFL pumping property. -/
-theorem anbncndn_not_pumpable :
-    ¬ HasCFLPumpingProperty anbncndn := by
-  intro ⟨p, hp, hpump⟩
-  have hw_in := makeString_in_language p
-  have hw_len : (makeString_anbncndn p).length ≥ p := by
-    simp only [makeString_anbncndn, List.length_append, List.length_replicate]; omega
-  obtain ⟨u, v, x, y, z, hw, hvxy, hvy, hall⟩ := hpump _ hw_in hw_len
-  obtain ⟨i, hbreak⟩ := pump_breaks_anbncndn p hp u v x y z hw hvxy hvy
-  exact hbreak (hall i)
+private theorem flatten_replicate_singleton {α : Type*} (n : Nat) (x : α) :
+    (List.replicate n [x]).flatten = List.replicate n x := by
+  induction n with
+  | zero => rfl
+  | succ k ih => simp [List.replicate_succ, ih]
 
-/-- {aⁿbⁿcⁿdⁿ} is not context-free. -/
+private theorem flatten_replicate_nil {α : Type*} (n : Nat) :
+    (List.replicate n ([] : List α)).flatten = [] := by
+  induction n with
+  | zero => rfl
+  | succ k ih => simp [List.replicate_succ, ih]
+
+private theorem dropD_replicate (n : Nat) (s : FourSymbol) :
+    List.flatMap dropD (List.replicate n s) =
+      List.flatten (List.replicate n (dropD s)) := by
+  induction n with
+  | zero => rfl
+  | succ k ih =>
+    rw [List.replicate_succ, List.flatMap_cons, ih, List.replicate_succ, List.flatten_cons]
+
+/-- `dropD` erases the `dⁿ` block and relabels, sending the witness to `makeString_anbnc n`. -/
+@[simp] theorem dropD_makeString (n : Nat) :
+    List.flatMap dropD (makeString_anbncndn n) = makeString_anbnc n := by
+  simp only [makeString_anbncndn, List.flatMap_append, dropD_replicate, dropD,
+             flatten_replicate_singleton, flatten_replicate_nil, List.append_nil, makeString_anbnc]
+
+/-- `dropD` maps `anbncndn` exactly onto the counting core `anbnc`. This image
+    equality is what powers the closure reduction. -/
+theorem stringMap_dropD_anbncndn : Language.stringMap dropD anbncndn = anbnc := by
+  ext w
+  rw [Language.mem_stringMap]
+  constructor
+  · rintro ⟨v, hv, rfl⟩
+    obtain ⟨n, rfl⟩ := (mem_anbncndn_iff v).mp hv
+    rw [dropD_makeString]
+    exact (mem_anbnc_iff _).mpr ⟨n, rfl⟩
+  · intro hw
+    obtain ⟨n, rfl⟩ := (mem_anbnc_iff w).mp hw
+    exact ⟨makeString_anbncndn n, makeString_in_language n, dropD_makeString n⟩
+
+/-- **{aⁿbⁿcⁿdⁿ} is not context-free** — derived by closure from the counting
+    core `anbnc_not_contextFree` via the erasing homomorphism `dropD`, rather than
+    re-proved by pumping. -/
 theorem anbncndn_not_contextFree : ¬ Language.IsContextFree anbncndn :=
-  not_isContextFree_of_not_pumpable anbncndn anbncndn_not_pumpable
+  Language.not_isContextFree_of_stringMap_not dropD
+    (by rw [stringMap_dropD_anbncndn]; exact anbnc_not_contextFree)

--- a/Linglib/Core/Computability/StringHom.lean
+++ b/Linglib/Core/Computability/StringHom.lean
@@ -1,22 +1,22 @@
 import Mathlib.Data.List.Basic
 
 /-!
-# Erasing String Homomorphisms and Tier Projections
+# Tier Projections (erasing letterwise homomorphisms)
 
-A **string homomorphism** `h : α* → β*` is a monoid homomorphism on free
-monoids: it satisfies `h(uv) = h(u) ++ h(v)` and `h(ε) = ε`. Such a map is
-**letterwise** when it is determined by its action on single symbols, and
-**erasing** when each symbol maps to *at most one* output symbol.
-
-A **tier projection** in autosegmental phonology ([goldsmith-1976]) and
-in tier-based learning ([belth-2026]) is exactly the letterwise erasing
-case: a per-symbol partial map `α → Option β`, lifted to `α* → β*` via
-`List.filterMap`. This is the morphism `α → β` in the Kleisli category of
+A **tier projection** in autosegmental phonology ([goldsmith-1976]) and in
+tier-based learning ([belth-2026]) is a letterwise *erasing* string
+homomorphism: a per-symbol partial map `α → Option β`, lifted to `α* → β*`
+via `List.filterMap`. This is the morphism `α → β` in the Kleisli category of
 `Option` over the free-monoid functor.
+
+General (non-erasing) string homomorphisms need no bespoke wrapper: a per-symbol
+map is just `α → List β`, and the string action is `List.flatMap` — which, since
+`List α = FreeMonoid α`, *is* the free-monoid lift `FreeMonoid.lift`. CFL closure
+under string homomorphism lives in
+`Linglib.Core.Computability.ContextFreeGrammar.Map`.
 
 This module provides:
 
-- `StringHom α β := α → List β` — the general letterwise homomorphism.
 - `Tier α β := α → Option β` — the erasing case.
 - `Tier.apply` — lift to `List α → List β` (the projection itself).
 - `Tier.id`, `Tier.empty`, `Tier.byClass`, `Tier.total` — constructors.
@@ -33,48 +33,6 @@ directly).
 namespace Core
 
 universe u v
-
--- ============================================================================
--- § 1: Letterwise String Homomorphism
--- ============================================================================
-
-/-- A **letterwise string homomorphism** `α* → β*`: a per-symbol map sending
-    each input symbol to a (possibly empty, possibly multi-symbol) output
-    string. Lifted to lists via `List.flatMap`. -/
-abbrev StringHom (α : Type u) (β : Type v) : Type _ := α → List β
-
-namespace StringHom
-
-variable {α : Type u} {β : Type v}
-
-/-- Lift a letterwise homomorphism to `List α → List β`. -/
-def apply (h : StringHom α β) : List α → List β :=
-  List.flatMap h
-
-/-- Monoid-hom law: `h` distributes over concatenation. -/
-@[simp] theorem apply_append (h : StringHom α β) (xs ys : List α) :
-    apply h (xs ++ ys) = apply h xs ++ apply h ys :=
-  List.flatMap_append
-
-/-- Monoid-hom law: `h` sends the empty word to the empty word. -/
-@[simp] theorem apply_nil (h : StringHom α β) : apply h [] = [] := rfl
-
-/-- The letter-to-letter homomorphism induced by `f : α → β`: each input
-    symbol maps to a singleton output. The image of `apply (letterMap f)`
-    coincides with `List.map f`; see `apply_letterMap`. -/
-def letterMap (f : α → β) : StringHom α β := fun a => [f a]
-
-/-- Letter-to-letter homomorphism applied to a list is `List.map`. -/
-@[simp] theorem apply_letterMap (f : α → β) (xs : List α) :
-    apply (letterMap f) xs = xs.map f := by
-  show List.flatMap (fun a => [f a]) xs = xs.map f
-  exact List.map_eq_flatMap.symm
-
-end StringHom
-
--- ============================================================================
--- § 2: Tier — The Erasing Special Case
--- ============================================================================
 
 /-- A **tier projection** `α* → β*`: a per-symbol partial map.
     Each input symbol either projects to one tier symbol or is erased.

--- a/Linglib/Core/Computability/Subregular/Function/ISL.lean
+++ b/Linglib/Core/Computability/Subregular/Function/ISL.lean
@@ -35,7 +35,7 @@ function-level subregular hierarchy.
   reverse-conjugate of the left class.
 * `isLeftInputStrictlyLocal_left_subsequential` — every Left-ISL
   function is Left-Subsequential, witnessed by `ISLRule.toSFST`.
-* `Core.StringHom.apply_isLeftInputStrictlyLocal_one`,
+* `flatMap_isLeftInputStrictlyLocal_one`,
   `Core.Tier.apply_isLeftInputStrictlyLocal_one` — letterwise
   homomorphisms and tier projections are the `k = 1` specialisation.
 
@@ -226,20 +226,21 @@ lemma isLeftInputStrictlyLocal_const_nil (k : ℕ) :
     show ([] : List β) ++ _ = []
     rw [List.nil_append, ih]
 
-/-! ### StringHom / Tier as the `k = 1` specialisation
+/-! ### Letterwise homomorphisms / Tier as the `k = 1` specialisation
 
-`StringHom α β := α → List β` is the `k = 1` specialisation: the window
-argument is always empty and only the current input symbol matters.
-`Tier α β := α → Option β` is the further erasing specialisation. -/
+A letterwise string homomorphism `h : α → List β` (string action `List.flatMap h`,
+the free-monoid lift) is the `k = 1` specialisation: the window argument is always
+empty and only the current input symbol matters. `Tier α β := α → Option β` is the
+further erasing specialisation. -/
 
-/-- Embed a string homomorphism as a 1-ISL rule (no left context). The
-windowOutput ignores its window argument and behaves letterwise. -/
-def ISLRule.ofStringHom (h : Core.StringHom α β) : ISLRule 1 α β where
+/-- Embed a letterwise string homomorphism `h : α → List β` as a 1-ISL rule (no left
+context). The windowOutput ignores its window argument and behaves letterwise. -/
+def ISLRule.ofStringHom (h : α → List β) : ISLRule 1 α β where
   windowOutput := fun _ x => h x
 
-private lemma ISLRule.applyAux_ofStringHom (h : Core.StringHom α β)
+private lemma ISLRule.applyAux_ofStringHom (h : α → List β)
     (window : List α) (xs : List α) :
-    (ISLRule.ofStringHom h).applyAux window xs = Core.StringHom.apply h xs := by
+    (ISLRule.ofStringHom h).applyAux window xs = List.flatMap h xs := by
   induction xs generalizing window with
   | nil => rfl
   | cons x ys ih =>
@@ -247,18 +248,19 @@ private lemma ISLRule.applyAux_ofStringHom (h : Core.StringHom α β)
     congr 1
     exact ih _
 
-/-- The 1-ISL rule constructed from `h` computes `h` on lists. Definitional
-up to `applyAux` unfolding; the inductive proof handles the window-threading. -/
-@[simp] theorem ISLRule.ofStringHom_apply (h : Core.StringHom α β) :
-    (ISLRule.ofStringHom h).apply = Core.StringHom.apply h := by
+/-- The 1-ISL rule constructed from `h` computes `List.flatMap h` on lists.
+Definitional up to `applyAux` unfolding; the inductive proof handles the window-threading. -/
+@[simp] theorem ISLRule.ofStringHom_apply (h : α → List β) :
+    (ISLRule.ofStringHom h).apply = List.flatMap h := by
   funext xs
   show (ISLRule.ofStringHom h).applyAux [] xs = _
   exact ISLRule.applyAux_ofStringHom h [] xs
 
-/-- **Every string homomorphism is 1-Left-ISL.** The substrate-level claim
-that `StringHom α β` and `ISLRule 1 α β` denote the same function class. -/
-theorem Core.StringHom.apply_isLeftInputStrictlyLocal_one (h : Core.StringHom α β) :
-    IsLeftInputStrictlyLocal 1 (Core.StringHom.apply h) :=
+/-- **Every letterwise string homomorphism is 1-Left-ISL.** The substrate-level
+claim that the letterwise-homomorphism function class (`List.flatMap h` for
+`h : α → List β`) and `ISLRule 1 α β` denote the same function class. -/
+theorem flatMap_isLeftInputStrictlyLocal_one (h : α → List β) :
+    IsLeftInputStrictlyLocal 1 (List.flatMap h) :=
   ⟨ISLRule.ofStringHom h, ISLRule.ofStringHom_apply h⟩
 
 /-- **Every tier projection is 1-Left-ISL.** Tier projections are
@@ -266,7 +268,7 @@ letterwise erasing (`Tier α β := α → Option β`), hence a special case
 of `ISLRule.ofStringHom` via `fun x => (T x).toList`. -/
 theorem Core.Tier.apply_isLeftInputStrictlyLocal_one (T : Core.Tier α β) :
     IsLeftInputStrictlyLocal 1 (Core.Tier.apply T) := by
-  -- Tier.apply T = filterMap T = flatMap (Option.toList ∘ T) = StringHom.apply (Option.toList ∘ T)
+  -- Tier.apply T = filterMap T = List.flatMap (fun x => (T x).toList)
   refine ⟨ISLRule.ofStringHom (fun x => (T x).toList), ?_⟩
   rw [ISLRule.ofStringHom_apply]
   funext xs

--- a/Linglib/Studies/PullumGazdar1982.lean
+++ b/Linglib/Studies/PullumGazdar1982.lean
@@ -323,8 +323,8 @@ theorem crossSerial_order_cf_but_caseMatching_not :
     -- Cross-serial word order is context-free (grammar 29 generates it)
     (∃ _g : ContextFreeGrammar DutchT, True) ∧
     -- Cross-serial order + case-matching is not context-free (Shieber 1985)
-    ¬ HasCFLPumpingProperty anbncndn :=
-  ⟨⟨dutchGrammar, trivial⟩, anbncndn_not_pumpable⟩
+    ¬ Language.IsContextFree anbncndn :=
+  ⟨⟨dutchGrammar, trivial⟩, anbncndn_not_contextFree⟩
 
 /-- The question of whether natural languages are context-free remained open
     as of 1982. [gazdar-pullum-1982] conclude: "Notice that this paper
@@ -338,8 +338,8 @@ theorem crossSerial_order_cf_but_caseMatching_not :
 theorem question_settled_by_shieber :
     (∀ n, Shieber1985.clauseImage
         (Shieber1985.arbitraryDepth n n) ∈ anbncndn) ∧
-    ¬ HasCFLPumpingProperty anbncndn :=
-  ⟨Shieber1985.diagonal_in_language, anbncndn_not_pumpable⟩
+    ¬ Language.IsContextFree anbncndn :=
+  ⟨Shieber1985.diagonal_in_language, anbncndn_not_contextFree⟩
 
 -- ============================================================================
 -- §8: IsContextFree Results (Mathlib Integration)

--- a/Linglib/Studies/Shieber1985.lean
+++ b/Linglib/Studies/Shieber1985.lean
@@ -104,7 +104,6 @@ not duplicated here.
 
 namespace Shieber1985
 
-open Core (StringHom)
 open SwissGerman.Case (CrossSerialVerb verbObjectCase)
 
 -- ============================================================================
@@ -229,8 +228,9 @@ def tokenToSymbol : Token → FourSymbol
     singleton {a,b,c,d} letters; matrix tokens are erased. This `[]`-valued
     case is essential for full-SG fidelity: it lets the schema apply to
     sentences with arbitrary boundary material wrapping the cross-serial
-    core. The function is no longer a `StringHom.letterMap` for that reason. -/
-def tokenStringHom : StringHom Token FourSymbol := fun
+    core. The function is no longer a letterwise (singleton-valued) map for that reason.
+    The string action is `List.flatMap tokenStringHom`, the free-monoid lift. -/
+def tokenStringHom : Token → List FourSymbol := fun
   | .matrix => []
   | t       => [tokenToSymbol t]
 
@@ -246,12 +246,12 @@ def clauseImage (c : CaseMatchedClause) : FourString :=
   List.replicate c.datNPs .a ++ List.replicate c.accNPs .b ++
   List.replicate c.datVs .c ++ List.replicate c.accVs .d
 
-/-- The image of a case-matched clause is the `StringHom.apply` of
-    `tokenStringHom` on its case-sorted token sequence. -/
+/-- The image of a case-matched clause is `List.flatMap tokenStringHom` (the
+    free-monoid lift) on its case-sorted token sequence. -/
 theorem clauseImage_eq_apply (c : CaseMatchedClause) :
-    clauseImage c = StringHom.apply tokenStringHom (caseSortedTokens c) := by
+    clauseImage c = List.flatMap tokenStringHom (caseSortedTokens c) := by
   simp [clauseImage, caseSortedTokens, tokenStringHom, tokenToSymbol,
-        StringHom.apply, List.flatMap_append, List.flatMap_replicate]
+        List.flatMap_append, List.flatMap_replicate]
 
 /-- A case-matched clause with m DAT-pairs and n ACC-pairs maps to
     `aᵐ bⁿ cᵐ dⁿ`. -/
@@ -708,7 +708,7 @@ theorem stringMap_swissGerman_inter_caseSorted_eq_ambncmdn :
     -- ts has cross-serial core (nps ++ vs after stripping matrix) with case-
     -- matched counts on cross-serial tokens.
     obtain ⟨nps, vs, hts_filter, h_nps, h_vs, h_dat, h_acc⟩ := hts_in
-    -- w = StringHom.apply tokenStringHom ts = ts.flatMap tokenStringHom.
+    -- w = List.flatMap tokenStringHom ts = ts.flatMap tokenStringHom.
     have hw_flatMap : w = ts.flatMap tokenStringHom := hApply.symm
     -- Counts in w: p = #a, q = #b, r = #c, s = #d (from the decomposition).
     have h_p : w.countP (· == .a) = p := by
@@ -769,7 +769,7 @@ theorem stringMap_swissGerman_inter_caseSorted_eq_ambncmdn :
     refine ⟨caseSortedTokens (arbitraryDepth m n),
             caseSortedTokens_in_swissGermanLang m n, ?_⟩
     -- The canonical preimage has no matrix tokens, so flatMap = map.
-    show StringHom.apply tokenStringHom _ = _
+    show List.flatMap tokenStringHom _ = _
     rw [← clauseImage_eq_apply, clauseImage_shape]
     rfl
 

--- a/Linglib/Syntax/CCG/GenerativeCapacity.lean
+++ b/Linglib/Syntax/CCG/GenerativeCapacity.lean
@@ -50,11 +50,11 @@ target language lies beyond the context-free tier. -/
 theorem ccg_exceeds_cfg : ¬ Language.IsContextFree anbncndn :=
   anbncndn_not_contextFree
 
-/-- The witness language contains every `aⁿbⁿcⁿdⁿ` string and lacks the CFL pumping
-property, hence is genuinely non-context-free. -/
+/-- The witness language contains every `aⁿbⁿcⁿdⁿ` string and is not context-free
+(the closure corollary `anbncndn_not_contextFree`). -/
 theorem witness_language_non_contextFree :
     (∀ n : Nat, makeString_anbncndn n ∈ anbncndn) ∧
-    ¬ HasCFLPumpingProperty anbncndn :=
-  ⟨makeString_in_language, anbncndn_not_pumpable⟩
+    ¬ Language.IsContextFree anbncndn :=
+  ⟨makeString_in_language, anbncndn_not_contextFree⟩
 
 end CCG.GenerativeCapacity


### PR DESCRIPTION
Dissolve `Core.StringHom`: the CFL homomorphism-closure substrate now uses a per-symbol map `f : T → List T'` with `List.flatMap` (the free-monoid lift on `List = FreeMonoid`) directly, no bespoke wrapper.

- `Language.stringMap` is bundled as `Language T →+* Language T'`, mirroring mathlib's `Language.map`, which becomes its letter-map special case (`stringMap_letterMap`).
- aⁿbⁿcⁿdⁿ ∉ CFL becomes a closure corollary of aⁿbⁿcⁿ via the erasing hom `dropD`; its bespoke pumping is deleted and the `¬HasCFLPumpingProperty` consumers move to `¬IsContextFree`.
- `StringHom.lean` keeps only `Tier`; `Shieber1985`/`ISL` use `List.flatMap`.