### PR TITLE
refactor(Phonology): relocate Tier projection from Core, de-Tier subregular

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -325,7 +325,7 @@ import Linglib.Core.Computability.Subregular.Function.LetterSubsequential
 import Linglib.Core.Computability.Subregular.Function.Bimachine
 import Linglib.Core.Computability.Subregular.Function.Hierarchy
 import Linglib.Core.Computability.Subregular.Function.WeaklyDeterministic
-import Linglib.Core.Computability.Tier
+import Linglib.Phonology.Tier
 import Linglib.Features.VerbCluster
 import Linglib.Features.Case.Basic
 import Linglib.Features.Case.Capabilities

--- a/Linglib/Core/Computability/Subregular/Function/ISL.lean
+++ b/Linglib/Core/Computability/Subregular/Function/ISL.lean
@@ -7,7 +7,6 @@ import Mathlib.Data.List.Basic
 import Mathlib.Data.Fintype.Sigma
 import Mathlib.Data.Fintype.Vector
 import Linglib.Core.Computability.Subregular.Function.Direction
-import Linglib.Core.Computability.Tier
 import Linglib.Core.Computability.Subregular.Function.Subsequential
 
 /-!
@@ -36,8 +35,8 @@ function-level subregular hierarchy.
 * `isLeftInputStrictlyLocal_left_subsequential` — every Left-ISL
   function is Left-Subsequential, witnessed by `ISLRule.toSFST`.
 * `flatMap_isLeftInputStrictlyLocal_one`,
-  `Core.Tier.apply_isLeftInputStrictlyLocal_one` — letterwise
-  homomorphisms and tier projections are the `k = 1` specialisation.
+  `filterMap_isLeftInputStrictlyLocal_one` — letterwise homomorphisms and
+  erasing (tier) projections are the `k = 1` specialisation.
 
 ## Implementation notes
 
@@ -230,8 +229,9 @@ lemma isLeftInputStrictlyLocal_const_nil (k : ℕ) :
 
 A letterwise string homomorphism `h : α → List β` (string action `List.flatMap h`,
 the free-monoid lift) is the `k = 1` specialisation: the window argument is always
-empty and only the current input symbol matters. `Tier α β := α → Option β` is the
-further erasing specialisation. -/
+empty and only the current input symbol matters. An erasing letterwise map
+`g : α → Option β` (string action `List.filterMap g`) is the further erasing
+specialisation. -/
 
 /-- Embed a letterwise string homomorphism `h : α → List β` as a 1-ISL rule (no left
 context). The windowOutput ignores its window argument and behaves letterwise. -/
@@ -263,20 +263,21 @@ theorem flatMap_isLeftInputStrictlyLocal_one (h : α → List β) :
     IsLeftInputStrictlyLocal 1 (List.flatMap h) :=
   ⟨ISLRule.ofStringHom h, ISLRule.ofStringHom_apply h⟩
 
-/-- **Every tier projection is 1-Left-ISL.** Tier projections are
-letterwise erasing (`Tier α β := α → Option β`), hence a special case
-of `ISLRule.ofStringHom` via `fun x => (T x).toList`. -/
-theorem Core.Tier.apply_isLeftInputStrictlyLocal_one (T : Core.Tier α β) :
-    IsLeftInputStrictlyLocal 1 (Core.Tier.apply T) := by
-  -- Tier.apply T = filterMap T = List.flatMap (fun x => (T x).toList)
-  refine ⟨ISLRule.ofStringHom (fun x => (T x).toList), ?_⟩
+/-- **Every erasing letterwise projection is 1-Left-ISL.** `List.filterMap g`
+(for `g : α → Option β`) is letterwise erasing, hence a special case of
+`ISLRule.ofStringHom` via `fun x => (g x).toList`. Phonological tier projections
+are the instance where `g` is a tier-membership map. -/
+theorem filterMap_isLeftInputStrictlyLocal_one (g : α → Option β) :
+    IsLeftInputStrictlyLocal 1 (List.filterMap g) := by
+  -- filterMap g = List.flatMap (fun x => (g x).toList)
+  refine ⟨ISLRule.ofStringHom (fun x => (g x).toList), ?_⟩
   rw [ISLRule.ofStringHom_apply]
   funext xs
-  show List.flatMap (fun x => (T x).toList) xs = List.filterMap T xs
+  show List.flatMap (fun x => (g x).toList) xs = List.filterMap g xs
   induction xs with
   | nil => rfl
   | cons x ys ih =>
-    cases h : T x with
+    cases h : g x with
     | none =>
       simp only [List.flatMap_cons, List.filterMap_cons, h, Option.toList_none,
         List.nil_append, ih]

--- a/Linglib/Core/Computability/Subregular/Tier.lean
+++ b/Linglib/Core/Computability/Subregular/Tier.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Computability.Subregular.StrictlyLocal
-import Linglib.Core.Computability.Tier
+import Mathlib.Data.List.Basic
 
 /-!
 # Tier-Based Strictly Local Languages (TSL_k)
@@ -29,50 +29,28 @@ an SL grammar — projection is the identity. This gives the inclusion
 
 The `tier` here is the *segmental* tier in the sense of [lambert-2022]
 Ch 3 (language-theoretic side, §3.2) — a subset of the alphabet, not an
-autosegmental melody floating above it. The TSL definition specializes to
-the case where projection is `List.filter` over a tier predicate
-(equivalently, an erasing string homomorphism that keeps tier symbols and
-deletes off-tier symbols, with no relabeling). For autosegmental tiers
-(high/low tone, nasal melody, register), see `Phonology/Autosegmental/`.
-
-## Single source of truth: `Core.Tier`
-
-`tierProject` is the alias `Core.Tier.apply (Core.Tier.byClass T)` — the
-class-membership specialization of the autosegmental Kleisli morphism
-`α → Option β`. After the `Tier.byClass` migration to `Prop`+`Decidable`
-predicates, the alias contains *no* `decide` wrapper and the bridge to
-the autosegmental formalism is the identity, available either as
-`rfl` or via `tierProject_eq_apply_byClass` below.
+autosegmental melody floating above it. Accordingly `tierProject` is just
+`List.filter` over a tier predicate (keep tier symbols, delete off-tier
+ones, no relabeling). The autosegmental tier-projection *morphism* (the
+Kleisli `α → Option β` with `byClass`/`lastWith`/`firstWith`) is a phonology
+concept and lives in `Phonology/`; the bridge `tierProject = Tier.apply
+(Tier.byClass T)` is re-established there as an explicit lemma.
 -/
 
 namespace Core.Computability.Subregular
 
 variable {α : Type*}
 
-/-- **Tier projection**: the class-membership specialization of
-`Core.Tier.apply` to a `Prop`-valued predicate `T`. Keeps symbols
-satisfying `T`, erases the rest.
-
-Defined as `Core.Tier.apply (Core.Tier.byClass T)` so the bridge to the
-autosegmental tier formalism is `rfl`. By `Tier.apply_byClass` this
-equals `xs.filter (decide ∘ T)`. -/
+/-- **Tier projection**: keep the symbols satisfying the tier predicate `T`,
+erase the rest. This is `List.filter` over `T` — the language-theoretic tier
+of [lambert-2022], independent of the autosegmental projection morphism. -/
 def tierProject (T : α → Prop) [DecidablePred T] (xs : List α) : List α :=
-  Core.Tier.apply (Core.Tier.byClass T) xs
+  xs.filter (fun x => decide (T x))
 
-/-- **Bridge identity** to the autosegmental tier formalism: `tierProject`
-is by definition `Tier.apply (Tier.byClass T)`. Since the migration of
-`Tier.byClass` to `Prop`+`Decidable` predicates, this is `rfl` with no
-`decide` plumbing. -/
-lemma tierProject_eq_apply_byClass (T : α → Prop) [DecidablePred T]
-    (xs : List α) :
-    tierProject T xs = Core.Tier.apply (Core.Tier.byClass T) xs := rfl
-
-/-- `tierProject` reduces to `List.filter` via `Tier.apply_byClass`. This
-is the canonical bridge to Lambert's filter-based formulation
-[lambert-2022]. -/
+/-- `tierProject` is `List.filter`, by definition. The canonical bridge to
+Lambert's filter-based formulation [lambert-2022]. -/
 lemma tierProject_eq_filter (T : α → Prop) [DecidablePred T] (xs : List α) :
-    tierProject T xs = xs.filter (fun x => decide (T x)) :=
-  Core.Tier.apply_byClass _ _
+    tierProject T xs = xs.filter (fun x => decide (T x)) := rfl
 
 @[simp] lemma tierProject_nil (T : α → Prop) [DecidablePred T] :
     tierProject T ([] : List α) = [] := rfl

--- a/Linglib/Phonology/Featural/ElementTheory.lean
+++ b/Linglib/Phonology/Featural/ElementTheory.lean
@@ -181,7 +181,7 @@ end ETBundle
     headedness); the I/U-tier registers |I|/|U| presence.
 
     This is exactly the parametric tier-projection idea of
-    `Rolle2018.tonalTier` (the tonal tier, via `Core.Tier.total`)
+    `Rolle2018.tonalTier` (the tonal tier, via `Tier.total`)
     for tones, instantiated for ET. -/
 def aTier (b : ETBundle) : Option Headedness := b .A
 

--- a/Linglib/Phonology/OptimalityTheory/Constraints.lean
+++ b/Linglib/Phonology/OptimalityTheory/Constraints.lean
@@ -1,7 +1,7 @@
 import Linglib.Phonology.Constraint.Defs
 import Linglib.Phonology.OptimalityTheory.Optimality
 import Linglib.Phonology.Constraint.Weighted
-import Linglib.Core.Computability.Tier
+import Linglib.Phonology.Tier
 import Linglib.Core.Computability.Subregular.ForbiddenPairs
 
 /-!
@@ -170,9 +170,9 @@ export Core.Computability.Subregular (countAdjacent)
     zero-violation candidates as members of the corresponding tier-based
     strictly 2-local language for any choice of `R`. -/
 def mkForbidPairsOnTier {C α β : Type} (name : String) (R : β → β → Prop)
-    [DecidableRel R] (T : Core.Tier α β) (extract : C → List α) :
+    [DecidableRel R] (T : Tier α β) (extract : C → List α) :
     NamedConstraint C :=
-  mkMarkGrad name (fun c => countAdjacent R (Core.Tier.apply T (extract c)))
+  mkMarkGrad name (fun c => countAdjacent R (Tier.apply T (extract c)))
 
 -- ---- SL_1 helper for forbidden singletons ---------------------------------
 
@@ -185,10 +185,10 @@ def mkForbidPairsOnTier {C α β : Type} (name : String) (R : β → β → Prop
     not yet wired; the constructor exists to keep SL_1 phenomena from
     silently masquerading as TSL_2. -/
 def mkForbidSingletonOnTier {C α β : Type} (name : String) (P : β → Prop)
-    [DecidablePred P] (T : Core.Tier α β) (extract : C → List α) :
+    [DecidablePred P] (T : Tier α β) (extract : C → List α) :
     NamedConstraint C :=
   mkMarkGrad name
-    (fun c => (Core.Tier.apply T (extract c)).countP (fun x => decide (P x)))
+    (fun c => (Tier.apply T (extract c)).countP (fun x => decide (P x)))
 
 -- ---- OCP as the identity-relation instance --------------------------------
 
@@ -210,7 +210,7 @@ def mkOCP {C α : Type} [DecidableEq α] (name : String) (project : C → List �
     NamedConstraint C :=
   mkMarkGrad name (λ c => adjacentIdentical (project c))
 
-/-- Build an OCP constraint from a `Core.Tier` projection. The candidate's
+/-- Build an OCP constraint from a `Tier` projection. The candidate's
     raw symbol list is extracted by `extract`, and the tier `T` projects
     that string onto the relevant tier alphabet (an erasing string
     homomorphism — see `Core.StringHom`).
@@ -225,13 +225,13 @@ def mkOCP {C α : Type} [DecidableEq α] (name : String) (project : C → List �
 
     [goldsmith-1976] [berent-2026] -/
 def mkOCPOnTier {C α β : Type} [DecidableEq β]
-    (name : String) (T : Core.Tier α β) (extract : C → List α) :
+    (name : String) (T : Tier α β) (extract : C → List α) :
     NamedConstraint C :=
   mkForbidPairsOnTier name (· = ·) T extract
 
 -- ---- AGREE as the inequality-relation instance ----------------------------
 
-/-- Build an AGREE constraint from a `Core.Tier` projection: penalizes
+/-- Build an AGREE constraint from a `Tier` projection: penalizes
     each tier-adjacent pair `(a, b)` with `a ≠ b`. The non-identity dual of
     `mkOCPOnTier`. AGREE-style markedness in OT phonology is the symmetric
     specialization of `mkForbidPairsOnTier` with `R := (· ≠ ·)`, just as the
@@ -240,7 +240,7 @@ def mkOCPOnTier {C α β : Type} [DecidableEq β]
     harmony, dissimilation, anti-OCP) use the same machinery up to the
     choice of `R`. -/
 def mkAgreeOnTier {C α β : Type} [DecidableEq β]
-    (name : String) (T : Core.Tier α β) (extract : C → List α) :
+    (name : String) (T : Tier α β) (extract : C → List α) :
     NamedConstraint C :=
   mkForbidPairsOnTier name (· ≠ ·) T extract
 
@@ -298,18 +298,18 @@ theorem mkMaxCtx_is_faithfulness {C : Type} (name : String)
 
 /-- Forbidden-pair constraints are markedness constraints. -/
 theorem mkForbidPairsOnTier_is_markedness {C α β : Type} (name : String)
-    (R : β → β → Prop) [DecidableRel R] (T : Core.Tier α β)
+    (R : β → β → Prop) [DecidableRel R] (T : Tier α β)
     (extract : C → List α) :
     (mkForbidPairsOnTier name R T extract).family = .markedness := rfl
 
 /-- AGREE constraints are markedness constraints. -/
 theorem mkAgreeOnTier_is_markedness {C α β : Type} [DecidableEq β]
-    (name : String) (T : Core.Tier α β) (extract : C → List α) :
+    (name : String) (T : Tier α β) (extract : C → List α) :
     (mkAgreeOnTier name T extract).family = .markedness := rfl
 
 /-- Forbidden-singleton constraints are markedness constraints. -/
 theorem mkForbidSingletonOnTier_is_markedness {C α β : Type} (name : String)
-    (P : β → Prop) [DecidablePred P] (T : Core.Tier α β)
+    (P : β → Prop) [DecidablePred P] (T : Tier α β)
     (extract : C → List α) :
     (mkForbidSingletonOnTier name P T extract).family = .markedness := rfl
 
@@ -320,7 +320,7 @@ theorem mkOCP_is_markedness {C α : Type} [DecidableEq α] (name : String)
 
 /-- Tier-driven OCP constraints are markedness constraints. -/
 theorem mkOCPOnTier_is_markedness {C α β : Type} [DecidableEq β] (name : String)
-    (T : Core.Tier α β) (extract : C → List α) :
+    (T : Tier α β) (extract : C → List α) :
     (mkOCPOnTier name T extract).family = .markedness := rfl
 
 /-- ALIGN constraints are markedness constraints

--- a/Linglib/Phonology/Subregular/Harmony.lean
+++ b/Linglib/Phonology/Subregular/Harmony.lean
@@ -121,7 +121,7 @@ def System.mk' (feature : Feature)
     (direction : HarmonyDir := .rightward)
     (isBlocker : Segment → Bool := fun _ => false) : System where
   toTierRule :=
-    { tier := Core.Tier.byClass (fun s => !isTransparent s = true)
+    { tier := Tier.byClass (fun s => !isTransparent s = true)
       side := direction.toSide
       targetIsContext := fun s => isTrigger s = true
       relation := .agree

--- a/Linglib/Phonology/Subregular/TierProjection.lean
+++ b/Linglib/Phonology/Subregular/TierProjection.lean
@@ -3,32 +3,29 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Core.Computability.Tier
+import Linglib.Phonology.Tier
 import Linglib.Core.Computability.Subregular.Tier
 
 /-!
 # Bridge: Autosegmental Tier ↔ TSL Tier Projection
 
-The autosegmental tier formalism (`Core.Tier`, the Kleisli morphism
-`α → Option β` lifted via `List.filterMap`) and the subregular TSL
-formalism (`Core.Computability.Subregular.tierProject`) share a single
-underlying primitive: `tierProject T` is literally
-`Core.Tier.apply (Core.Tier.byClass T)`, so the two reduce to one
-another by definition.
-
-This file records the resulting `rfl` identity and provides a thin
-adapter for building a TSL_k grammar directly from a `Bool`-valued
-class predicate (the autosegmental constructor shape), so a
-phonological tier (tonal tier, sibilant tier, nasal tier) plugs into
-TSL machinery without restating projection or filtering.
+The autosegmental tier formalism (`Tier`, the Kleisli morphism
+`α → Option β` lifted via `List.filterMap`, now in `Phonology/Tier.lean`) and
+the subregular TSL formalism (`Core.Computability.Subregular.tierProject`,
+`List.filter`) compute the same projection. Since the two now live in different
+layers (Phonology vs Core) they no longer coincide *by definition*, so this file
+records the bridge as an explicit lemma and provides a thin adapter for building
+a TSL_k grammar directly from a `Bool`-valued class predicate (the autosegmental
+constructor shape), so a phonological tier (tonal tier, sibilant tier, nasal
+tier) plugs into TSL machinery without restating projection or filtering.
 
 ## What this enables
 
 Phonological constraints already in the codebase (`mkOCPOnTier` in
 `Phonology/OptimalityTheory/Constraints.lean`, the tonal tier `tonalTier`
-in `Studies/Rolle2018.lean`) reuse the same
-`Tier.apply` machinery as TSL grammars — the bridge is no longer a theorem
-to discharge but a definitional consequence.
+in `Studies/Rolle2018.lean`) reuse the same `Tier.apply` machinery as TSL
+grammars — the bridge `apply_byClass_eq_tierProject` reconnects the two
+projections in one line.
 -/
 
 namespace Phonology.Subregular
@@ -37,13 +34,15 @@ open Core Core.Computability.Subregular
 
 variable {α : Type*}
 
-/-- **Bridge identity** (definitional): `tierProject T` is by definition
-`Tier.apply (Tier.byClass T)`. After the 0.230.x consolidation onto
-`Core.Tier` and the subsequent `Tier.byClass` migration to
-`Prop`+`Decidable`, this is `rfl`. -/
+/-- **Bridge identity**: the autosegmental projection `Tier.apply (Tier.byClass T)`
+and the subregular `tierProject T` are the same map — both reduce to `List.filter`.
+Now that the `Tier` projection morphism lives in `Phonology/` and `tierProject` is
+de-coupled to `List.filter` directly, this is an explicit lemma (via
+`Tier.apply_byClass` and `tierProject_eq_filter`) rather than `rfl`. -/
 theorem apply_byClass_eq_tierProject (T : α → Prop) [DecidablePred T]
     (xs : List α) :
-    Tier.apply (Tier.byClass T) xs = tierProject T xs := rfl
+    Tier.apply (Tier.byClass T) xs = tierProject T xs :=
+  (Tier.apply_byClass T xs).trans (tierProject_eq_filter T xs).symm
 
 /-- **Adapter**: build a TSL_k grammar from a class-membership autosegmental
 tier given as a `Bool` predicate. The TSL tier predicate is `(p · = true)`,

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -1,5 +1,5 @@
 import Mathlib.Data.Fintype.Option
-import Linglib.Core.Computability.Tier
+import Linglib.Phonology.Tier
 import Linglib.Core.Computability.Subregular.Function.Direction
 import Linglib.Core.Computability.Subregular.Function.Subsequential
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
@@ -16,7 +16,7 @@ that factor through a tier projection. A rule has the shape
 
 where:
 
-- `T ⊆ α` is a tier (an erasing string-homomorphism — see `Core.Tier`);
+- `T ⊆ α` is a tier (an erasing string-homomorphism — see `Tier`);
 - `C ⊆ T` is the natural class of the *triggering* tier-adjacent segment;
 - `A ⊆ α` is the natural class of *targets* (here: a single underspecified
   position identified by index, à la [belth-2026]);

--- a/Linglib/Phonology/Tier.lean
+++ b/Linglib/Phonology/Tier.lean
@@ -27,10 +27,15 @@ and HG constraint evaluation (`mkOCP` in `Phonology/Constraints.lean`
 already takes a generic `project : C → List α`, so `Tier.apply T` plugs in
 directly).
 
+Home: `Phonology/` (not `Core/`) because the `Tier` abstraction — the
+autosegmental Kleisli morphism with `byClass`/`lastWith`/`firstWith` — is a
+linguistics concept, not upstreamable to `mathlib/Computability`. The
+formal-language tier (a subalphabet, projection = `List.filter`) lives
+separately in `Core/Computability/Subregular/Tier.lean` (the TSL class), which
+no longer depends on this morphism.
+
 [goldsmith-1976] [belth-2026]
 -/
-
-namespace Core
 
 universe u v
 
@@ -137,5 +142,3 @@ def firstWith (T : Tier α β) (q : β → Prop) [DecidablePred q]
   ((apply T xs).filter (fun y => decide (q y))).head?
 
 end Tier
-
-end Core

--- a/Linglib/Studies/Belth2026.lean
+++ b/Linglib/Studies/Belth2026.lean
@@ -304,8 +304,9 @@ theorem latinDissimRule_tolerated_on_examples :
     grounds Belth's tier in the TSL_k subregular hierarchy. -/
 theorem consTier_apply_eq_tierProject (xs : List LatSeg) :
     LatSeg.consTier.apply xs =
-      Core.Computability.Subregular.tierProject LatSeg.IsCons xs :=
-  rfl
+      Core.Computability.Subregular.tierProject LatSeg.IsCons xs := by
+  show Tier.apply (Tier.byClass LatSeg.IsCons) xs = _
+  rw [Tier.apply_byClass, Core.Computability.Subregular.tierProject_eq_filter]
 
 /-- The TSL_2 grammar witnessing the Latin allomorphy pattern as a
     tier-based subregular language: project to the `[+cons]` tier, then
@@ -323,7 +324,7 @@ def latinTSLGrammar : Core.Computability.Subregular.TSLGrammar 2 LatSeg :=
     forms produced by the rule should not contain adjacent `[+lat]`
     segments on the consonant tier. We expose this connection via
     `OptimalityTheory.mkOCPOnTier`, which already accepts a generic
-    `Core.Tier`. A tier-adjacent pair of identical liquids contributes
+    `Tier`. A tier-adjacent pair of identical liquids contributes
     one violation. -/
 def latinOCP : Constraint.NamedConstraint (List LatSeg) :=
   OptimalityTheory.mkOCPOnTier "OCP/[+cons]" LatSeg.consTier id

--- a/Linglib/Studies/Rolle2018.lean
+++ b/Linglib/Studies/Rolle2018.lean
@@ -287,18 +287,18 @@ def basemapOutput {S : Type} [DecidableEq S] [BEq S] [Repr S]
 
 /-- Extract the tonal tier from a list of TBUs.
 
-    Grounded in the `Core.Tier` abstraction
-    (`Core.Tier.apply (Core.Tier.total TBU.tone)`): an erasing string
+    Grounded in the `Tier` abstraction
+    (`Tier.apply (Tier.total TBU.tone)`): an erasing string
     homomorphism `(TBU S)* → TRN*` in the Kleisli category of `Option`.
     The tonal tier is the `total` (no-erasure) case [goldsmith-1976]. -/
 def tonalTier {S : Type} (tbus : List (TBU S)) : List TRN :=
-  Core.Tier.apply (Core.Tier.total TBU.tone) tbus
+  Tier.apply (Tier.total TBU.tone) tbus
 
 /-- The tonal tier reduces to `List.map TBU.tone` (the historical
     formulation), via `Tier.total`'s length-preservation property. -/
 @[simp] theorem tonalTier_eq_map {S : Type} (tbus : List (TBU S)) :
     tonalTier tbus = tbus.map TBU.tone :=
-  Core.Tier.apply_total _ _
+  Tier.apply_total _ _
 
 /-! ### Matrix-Basemap Correspondence — derived from `Corr` -/
 


### PR DESCRIPTION
`Tier` (the autosegmental projection `α → Option β` + `byClass`/`lastWith`/`firstWith`) isn't upstreamable to `mathlib/Computability`, so it leaves `Core` for `Phonology/Tier.lean` (bare-root namespace `Tier`).

- De-`Tier` the Core consumers so `Core/Computability` no longer depends on it: `Subregular/Tier.lean` (TSL) projects via `List.filter`; ISL's 1-ISL theorem is restated over `List.filterMap` (`filterMap_isLeftInputStrictlyLocal_one`).
- Separates the two senses of 'tier': the formal-language TSL tier (subalphabet) stays in Core; the autosegmental morphism moves to Phonology.
- Repoint 7 consumers + `Linglib.lean`.