### PR TITLE
refactor(Semantics/Quantification): retire covert-GQ clones

### DIFF
--- a/Linglib/Semantics/Genericity/Generics.lean
+++ b/Linglib/Semantics/Genericity/Generics.lean
@@ -1,5 +1,5 @@
 import Mathlib.Data.Rat.Defs
-import Linglib.Semantics.Quantification.CovertQuantifier
+import Linglib.Semantics.Quantification.Counting
 
 /-!
 # Traditional Generic Semantics (GEN Operator)
@@ -9,9 +9,12 @@ import Linglib.Semantics.Quantification.CovertQuantifier
 This module formalizes the traditional covert GEN operator posited for
 generic sentences like "Dogs bark", "Birds fly", etc.
 
-GEN is an instance of the shared covert quantifier infrastructure in
-`CovertQuantifier.lean`: `traditionalGEN = covertQ` with `D = Situation`,
-`restriction = normal ∧ restrictor`, `scope = scope`.
+GEN is grounded on the canonical generalized-quantifier substrate in
+`Quantification/Counting.lean`: `traditionalGEN` is `Quantification.everyOn`
+over the situation domain with restriction `normal ∧ restrictor` and nuclear
+scope `scope` (`gen_is_every_on`). The prevalence-based alternative is the
+ℚ view `Quantification.prevalenceOn` (`prevalence`), with the threshold
+reading `Quantification.thresholdGtOn` (`thresholdGeneric`).
 
 ## The Traditional Account
 
@@ -31,8 +34,9 @@ Example: "Dogs bark"
 
 The `normal` parameter does all the explanatory work but is (1) not observable
 (covert), (2) context-dependent (varies by property), and (3) essentially
-circular (stipulated to give right results). See `CovertQuantifier.lean` for
-the shared structure and the threshold-based alternative that eliminates it.
+circular (stipulated to give right results). The threshold-based alternative
+below (`thresholdGeneric`, grounded on `Quantification.thresholdGtOn`)
+eliminates it.
 
 ## Descriptive vs Definitional ([krifka-2013])
 
@@ -49,14 +53,11 @@ restrict the interpretation index, not the world index. See
 - Threshold is uncertain, inferred pragmatically
 - Prior over prevalence varies by property
 
-See `Studies/TesslerGoodman2019.lean` for the RSA account
-and `Comparisons/GenericSemantics.lean` for the formal comparison.
+See `Studies/TesslerGoodman2019.lean` for the RSA account.
 
 -/
 
 namespace Semantics.Genericity.Generics
-
-open Quantification.CovertQuantifier
 
 -- Core Types
 
@@ -96,8 +97,10 @@ Traditional GEN as a quantifier over situations.
     This is essentially a restricted universal quantifier:
       ∀s. (normal(s) ∧ restrictor(s)) → scope(s)
 
-    Equivalently, `covertQ situations (λ s => normal s && restrictor s) scope`,
-    where the restriction is the conjunction of normalcy and restrictor.
+    Equivalently, `Quantification.everyOn situations.toFinset
+    (λ s => normal s && restrictor s) scope`, where the restriction is the
+    conjunction of normalcy and restrictor — the canonical relativized
+    restricted universal.
 
     The key parameters:
     - `situations`: the domain of quantification (possible cases)
@@ -108,25 +111,26 @@ Traditional GEN as a quantifier over situations.
     The `normal` parameter is where all the
     context-sensitivity and exception-tolerance is hidden.
 -/
-def traditionalGEN
+@[reducible] def traditionalGEN
     (situations : List Situation)
     (normal : NormalcyPredicate)      -- THE HIDDEN PARAMETER
     (restrictor : Restrictor)
     (scope : Scope)
-    : Bool :=
-  situations.all λ s =>
-    -- For all normal situations where restrictor holds, scope holds
-    !(normal s && restrictor s) || scope s
+    : Prop :=
+  Quantification.everyOn situations.toFinset
+    (fun s => (normal s && restrictor s) = true) (fun s => scope s = true)
 
-/-- GEN is an instance of the shared covert quantifier, with restriction =
-    normal ∧ restrictor. -/
-theorem gen_is_covertQ
+/-- GEN is the canonical relativized restricted universal `everyOn`, with
+    restriction = normal ∧ restrictor (a grounding identity, true by
+    construction). -/
+theorem gen_is_every_on
     (situations : List Situation)
     (normal : NormalcyPredicate)
     (restrictor : Restrictor)
     (scope : Scope)
     : traditionalGEN situations normal restrictor scope =
-      covertQ situations (λ s => normal s && restrictor s) scope := rfl
+      Quantification.everyOn situations.toFinset
+        (fun s => (normal s && restrictor s) = true) (fun s => scope s = true) := rfl
 
 /--
 Alternative formulation: existential test for counterexamples.
@@ -138,19 +142,22 @@ def traditionalGEN_existential
     (normal : NormalcyPredicate)
     (restrictor : Restrictor)
     (scope : Scope)
-    : Bool :=
-  !situations.any λ s => normal s && restrictor s && !scope s
+    : Prop :=
+  ¬ Quantification.someOn situations.toFinset
+      (fun s => (normal s && restrictor s) = true) (fun s => scope s ≠ true)
 
-/-- The two formulations are equivalent (derived from shared De Morgan proof). -/
+/-- The two formulations are equivalent: the relativized restricted universal
+    is exactly the absence of a (normal restrictor) counterexample to scope. -/
 theorem gen_formulations_equiv
     (situations : List Situation)
     (normal : NormalcyPredicate)
     (restrictor : Restrictor)
     (scope : Scope)
-    : traditionalGEN situations normal restrictor scope =
+    : traditionalGEN situations normal restrictor scope ↔
       traditionalGEN_existential situations normal restrictor scope := by
-  rw [gen_is_covertQ]
-  exact covertQ_equiv situations (λ s => normal s && restrictor s) scope
+  unfold traditionalGEN traditionalGEN_existential Quantification.everyOn Quantification.someOn
+  push_neg
+  rfl
 
 -- Prevalence-Based Alternative
 
@@ -159,38 +166,41 @@ Prevalence: the proportion of restrictor-satisfying cases where scope holds.
 
 Polymorphic over the domain type — works for situation-based models
 ([cohen-1999a], [tessler-goodman-2019]) and entity-based models
-([nickel-2009]) alike. An alias for `measure` with a domain-specific name.
+([nickel-2009]) alike. The genericity-named view of the canonical
+`Quantification.prevalenceOn` (the ℚ analogue of `Rel.edgeDensity`).
 -/
-def prevalence {D : Type}
+def prevalence {D : Type} [DecidableEq D]
     (domain : List D)
     (restrictor : D → Bool)
     (scope : D → Bool)
     : ℚ :=
-  measure domain restrictor scope
+  Quantification.prevalenceOn domain.toFinset
+    (fun d => restrictor d = true) (fun d => scope d = true)
 
 /--
 Threshold-based generic (a la [tessler-goodman-2019]).
 
-The generic is true iff prevalence exceeds threshold.
-This replaces the hidden "normalcy" with observable prevalence.
+The generic is true iff prevalence exceeds the threshold `num/denom`.
+This replaces the hidden "normalcy" with observable prevalence. The canonical
+cross-multiplied `Quantification.thresholdGtOn` (division-free `Nat`
+comparison) so the truth value is kernel-`decide`-able.
 -/
-def thresholdGeneric {D : Type}
+@[reducible] def thresholdGeneric {D : Type} [DecidableEq D]
     (domain : List D)
     (restrictor : D → Bool)
     (scope : D → Bool)
-    (threshold : ℚ)
-    : Bool :=
-  prevalence domain restrictor scope > threshold
+    (num denom : Nat)
+    : Prop :=
+  Quantification.thresholdGtOn domain.toFinset
+    (fun d => restrictor d = true) (fun d => scope d = true) num denom
 
 /-!
 GEN is eliminable via threshold semantics — but only for **descriptive** generics
 ([krifka-2013]). Definitional generics ("A madrigal is polyphonic") restrict
 the interpretation index, not the world index, and cannot be reduced to a
-prevalence threshold.
-
-The theorem `gen_eliminable` proving eliminability for the descriptive case is in
-`Comparisons/GenericSemantics.lean`, which connects traditional GEN to
-[tessler-goodman-2019] RSA approach.
+prevalence threshold. See `Studies/TesslerGoodman2019.lean` for the RSA
+account that makes the threshold uncertain and pragmatically inferred, and
+`Studies/Krifka2013.lean` for the descriptive/definitional split.
 -/
 
 -- Example: Dogs Bark
@@ -217,9 +227,25 @@ def dogBarks : Scope := λ s =>
 def normalDogSituation : NormalcyPredicate := λ s =>
   s.id != 2  -- Sleeping is not "normal" for purposes of barking
 
-#guard traditionalGEN dogSituations normalDogSituation isDogSituation dogBarks
-#guard prevalence dogSituations isDogSituation dogBarks == 4/5
-#guard thresholdGeneric dogSituations isDogSituation dogBarks (1/2)
+/-- "Dogs bark" is true on the traditional (normalcy-restricted universal)
+    reading: every normal dog-situation has the dog barking. -/
+example : traditionalGEN dogSituations normalDogSituation isDogSituation dogBarks := by decide
+
+/-- Prevalence of barking among the (all-dog) situations is 4/5: four of the
+    five dogs bark. Routed through the count form (ℚ division is not
+    kernel-`decide`-able). -/
+theorem dogBarks_prevalence :
+    prevalence dogSituations isDogSituation dogBarks = 4/5 := by
+  have hR : Quantification.countOn dogSituations.toFinset
+      (fun d => isDogSituation d = true) = 5 := by decide
+  have hRS : Quantification.countOn dogSituations.toFinset
+      (fun d => (isDogSituation d = true) ∧ (dogBarks d = true)) = 4 := by decide
+  unfold prevalence Quantification.prevalenceOn
+  rw [hR, hRS]; norm_num
+
+/-- On the threshold reading the generic holds at θ = 1/2: prevalence 4/5
+    exceeds one half. Kernel-`decide`-able via the cross-multiplied count form. -/
+example : thresholdGeneric dogSituations isDogSituation dogBarks 1 2 := by decide
 
 /-!
 ## Related Theory
@@ -253,28 +279,32 @@ def genHomogeneityPresup
     (situations : List Situation)
     (restrictor : Restrictor)
     (scope : Scope)
-    : Bool :=
-  let restricted := situations.filter restrictor
-  restricted.all scope || restricted.all (fun s => !scope s)
+    : Prop :=
+  Quantification.everyOn situations.toFinset
+      (fun s => restrictor s = true) (fun s => scope s = true) ∨
+  Quantification.noOn situations.toFinset
+      (fun s => restrictor s = true) (fun s => scope s = true)
 
-/-- Homogeneity holds trivially when ALL situations satisfy scope
+/-- Homogeneity holds when ALL restrictor-situations satisfy scope
     (the YES branch). -/
 theorem homogeneity_yes
     (situations : List Situation)
     (restrictor : Restrictor)
     (scope : Scope)
-    (h : (situations.filter restrictor).all scope = true) :
-    genHomogeneityPresup situations restrictor scope = true := by
-  simp only [genHomogeneityPresup, h, Bool.true_or]
+    (h : Quantification.everyOn situations.toFinset
+      (fun s => restrictor s = true) (fun s => scope s = true)) :
+    genHomogeneityPresup situations restrictor scope :=
+  Or.inl h
 
-/-- Homogeneity holds trivially when NO situations satisfy scope
+/-- Homogeneity holds when NO restrictor-situation satisfies scope
     (the NO branch). -/
 theorem homogeneity_no
     (situations : List Situation)
     (restrictor : Restrictor)
     (scope : Scope)
-    (h : (situations.filter restrictor).all (fun s => !scope s) = true) :
-    genHomogeneityPresup situations restrictor scope = true := by
-  simp only [genHomogeneityPresup, h, Bool.or_true]
+    (h : Quantification.noOn situations.toFinset
+      (fun s => restrictor s = true) (fun s => scope s = true)) :
+    genHomogeneityPresup situations restrictor scope :=
+  Or.inr h
 
 end Semantics.Genericity.Generics

--- a/Linglib/Semantics/Genericity/GenericsDynamic.lean
+++ b/Linglib/Semantics/Genericity/GenericsDynamic.lean
@@ -599,8 +599,8 @@ This is a single Boolean judgment — it doesn't decompose into "select
 normal instances, then universally quantify." The `GenericSentence` shape
 (restrict → select normals → ∀) captures the normality-based family of
 theories; threshold semantics is a genuinely different algebraic shape.
-See `CovertQuantifier.reduces_to_threshold` for the threshold ↔ GEN
-eliminability result. -/
+See `Generics.thresholdGeneric` (on `Quantification.thresholdGtOn`) for the
+threshold reading of GEN. -/
 
 /-- Construct a `GenericSentence` from a binary normalcy predicate.
 

--- a/Linglib/Semantics/Quantification/Counting.lean
+++ b/Linglib/Semantics/Quantification/Counting.lean
@@ -921,4 +921,28 @@ theorem not_qsymmetric_most_sem : ¬ QSymmetric (most_sem : GQ (Fin 3)) := by
     simp only [count, countOn]; decide
   rw [v0, v1, v2, v3] at key; revert key; decide
 
+/-! ### Whole-carrier recovery for `mostOn` and inherited proportionality
+
+`mostOn Finset.univ` is the `s = Finset.univ` fibre of the relativized
+`most`, matching the whole-carrier `most_sem` (modulo the
+`DecidablePred`-instance bridge `Finset.filter_congr_decidable`). The
+`Proportional` theorem proved for `most_sem` therefore transfers to it by
+inheritance, not re-proof — exhibiting "GEN-as-thresholded-most" as a
+specialization of the canonical proportional quantifier rather than a clone. -/
+
+omit [DecidableEq α] in
+@[simp] theorem mostOn_univ (R S : α → Prop) [DecidablePred R] [DecidablePred S] :
+    mostOn Finset.univ R S ↔ most_sem R S := by
+  unfold mostOn most_sem
+  congr! 2
+
+omit [DecidableEq α] in
+/-- "GEN-as-most is proportional" — inherited from `most_proportional`, not
+    re-proved: at `s = Finset.univ` the relativized `mostOn` IS `most_sem`. -/
+theorem mostOn_univ_proportional :
+    Proportional (fun R S => mostOn (Finset.univ : Finset α) R S) := by
+  have h : (fun (R S : α → Prop) => mostOn (Finset.univ : Finset α) R S) = most_sem := by
+    funext R S; exact propext (mostOn_univ R S)
+  rw [h]; exact most_proportional
+
 end Quantification

--- a/Linglib/Semantics/Quantification/CovertQuantifier.lean
+++ b/Linglib/Semantics/Quantification/CovertQuantifier.lean
@@ -1,139 +1,39 @@
-import Mathlib.Data.Rat.Defs
-import Mathlib.Tactic.Linarith
+import Linglib.Semantics.Quantification.Counting
 import Linglib.Semantics.Intensional.Defs
 import Linglib.Semantics.Composition.LexEntry
 
 /-!
-# Covert Operators: Theory and Compositional Interface
+# Covert Operators: Montague-Typed Constructors
 
 [krifka-etal-1995] [carlson-1977] [guerrini-2026]
 
 Covert operators (Gen, DIST, Hab, DPP) are semantically contentful LF nodes
-with no overt realization. This module provides:
+with no overt realization. This module packages them as `LexEntry` values
+that compose via FA in `evalTree`.
 
-1. **Abstract quantifier theory** (`covertQ`, `measure`, `thresholdQ`) —
-   domain-polymorphic semantics with eliminability proofs. GEN and HAB
-   are both instances.
-
-2. **Montague-typed constructors** (`gen`, `genThreshold`, `dist`, `dpp`,
-   `hab`) — `LexEntry` values that compose via FA in `evalTree`.
-   These package the theory-layer semantics for tree-based interpretation.
+The *semantics* these wrap is the canonical generalized-quantifier substrate
+in `Quantification/Counting.lean` (`everyOn`, `mostOn`, `thresholdOn`,
+`prevalenceOn`, …). GEN's threshold reading is `genThreshold`, whose
+denotation is `Quantification.thresholdOn` over the atom domain; the
+universal reading is `Generics.traditionalGEN`, grounded on
+`Quantification.everyOn`. Earlier versions of this file re-implemented those
+quantifiers in an inferior `Bool`/`List`/ℚ representation
+(`covertQ`/`measure`/`thresholdQ`); those clones are retired in favour of the
+`Counting.lean` API.
 
 ## Usage
 
 ```
-open Quantification.CovertQuantifier (genThreshold dist dpp extendLexicon)
+open Quantification.CovertQuantifier (genThreshold dist dpp)
 
-def myLex : Lexicon E W :=
-  extendLexicon baseLex
-    [("Gen",  genThreshold E W atoms 2 3),
-     ("DIST", dist E W atomsOf)]
+def myLex : Lexicon E W := fun s => match s with
+  | "Gen"  => some (genThreshold E W atoms 2 3)
+  | "DIST" => some (dist E W atomsOf)
+  | _      => none
 ```
 -/
 
 namespace Quantification.CovertQuantifier
-
-variable {D : Type}
-
-/-- A covert quantifier: `∀d ∈ domain. restriction(d) → scope(d)`.
-GEN instantiates with `D = Situation`, `restriction = normal ∧ restrictor`
-(see `traditionalGEN` in `Genericity/Generics.lean`). The "habituality is
-genericity" view ([chierchia-1995], [krifka-etal-1995]) treats
-HAB the same way; the Boneh–Doron view ([boneh-doron-2013]) treats
-HAB as a structurally distinct existential, not a `covertQ` instance —
-see `Studies/BonehDoron2013.lean`. -/
-def covertQ (domain : List D) (restriction : D → Bool) (scope : D → Bool) : Bool :=
-  domain.all λ d => !restriction d || scope d
-
-/-- Dual formulation: no counterexample exists. -/
-def covertQ_dual (domain : List D) (restriction : D → Bool) (scope : D → Bool) : Bool :=
-  !domain.any λ d => restriction d && !scope d
-
-/-- The two formulations are equivalent (De Morgan). -/
-theorem covertQ_equiv (domain : List D) (restriction : D → Bool) (scope : D → Bool) :
-    covertQ domain restriction scope = covertQ_dual domain restriction scope := by
-  simp only [covertQ, covertQ_dual, List.all_eq_not_any_not]
-  congr 1
-  induction domain with
-  | nil => rfl
-  | cons d ds ih =>
-    simp only [List.any_cons]
-    rw [ih]
-    cases restriction d <;> cases scope d <;> rfl
-
-/-- Measure: proportion of restriction-satisfying cases where scope holds. -/
-def measure (domain : List D) (restriction : D → Bool) (scope : D → Bool) : ℚ :=
-  let restricted := domain.filter restriction
-  let satisfied := restricted.filter scope
-  if restricted.length = 0 then 0
-  else (satisfied.length : ℚ) / (restricted.length : ℚ)
-
-/-- Threshold-based alternative: measure > θ. -/
-def thresholdQ (domain : List D) (restriction : D → Bool)
-    (scope : D → Bool) (θ : ℚ) : Bool :=
-  measure domain restriction scope > θ
-
-/-- Measure is non-negative. -/
-theorem measure_nonneg (domain : List D) (restriction : D → Bool) (scope : D → Bool) :
-    measure domain restriction scope ≥ 0 := by
-  simp only [measure]
-  by_cases h : (domain.filter restriction).length = 0
-  · simp [h]
-  · simp only [h, ↓reduceIte]
-    apply div_nonneg
-    · exact Nat.cast_nonneg _
-    · exact Nat.cast_nonneg _
-
-/-- Measure is at most 1 (when restriction domain is non-empty). -/
-theorem measure_le_one (domain : List D) (restriction : D → Bool) (scope : D → Bool)
-    (hNonEmpty : (domain.filter restriction).length > 0) :
-    measure domain restriction scope ≤ 1 := by
-  simp only [measure]
-  have hPos : (domain.filter restriction).length ≠ 0 := Nat.pos_iff_ne_zero.mp hNonEmpty
-  simp only [hPos, ↓reduceIte]
-  have hLenLe : (List.filter scope (List.filter restriction domain)).length ≤
-                (List.filter restriction domain).length :=
-    List.length_filter_le _ _
-  have hDenom : (0 : ℚ) < ↑(List.filter restriction domain).length := by
-    rw [Nat.cast_pos]; exact hNonEmpty
-  calc (↑(List.filter scope (List.filter restriction domain)).length : ℚ) /
-         ↑(List.filter restriction domain).length
-       ≤ ↑(List.filter restriction domain).length /
-         ↑(List.filter restriction domain).length := by
-           apply div_le_div_of_nonneg_right
-           · exact Nat.cast_le.mpr hLenLe
-           · exact le_of_lt hDenom
-     _ = 1 := div_self (ne_of_gt hDenom)
-
-/-- Any covert quantifier configuration can be matched by threshold semantics.
-
-    Note: this is a *degeneracy* result — the existential threshold is either -1
-    (if Q holds) or 1 (if Q fails). It shows eliminability in principle, not that
-    the threshold is informative. The RSA treatment adds substance by making the
-    threshold uncertain and pragmatically inferred. -/
-theorem reduces_to_threshold (domain : List D)
-    (restriction : D → Bool) (scope : D → Bool)
-    (hNonEmpty : (domain.filter restriction).length > 0) :
-    ∃ θ : ℚ, covertQ domain restriction scope =
-             thresholdQ domain restriction scope θ := by
-  let m := measure domain restriction scope
-  by_cases hQ : covertQ domain restriction scope
-  · -- Q = true: pick θ = -1
-    use -1
-    simp only [thresholdQ, hQ]
-    have hNonneg := measure_nonneg domain restriction scope
-    symm; rw [decide_eq_true_iff]
-    have h : (-1 : ℚ) < 0 := by decide
-    linarith
-  · -- Q = false: pick θ = 1
-    use 1
-    simp only [thresholdQ]
-    have hLe := measure_le_one domain restriction scope hNonEmpty
-    have hNotQ : covertQ domain restriction scope = false := by
-      simp only [Bool.eq_false_iff]; exact hQ
-    simp only [hNotQ]
-    symm; rw [decide_eq_false_iff_not]
-    intro hContra; linarith
 
 /-! ### Montague-Typed Constructors -/
 
@@ -146,8 +46,9 @@ open Semantics.Montague (LexEntry Lexicon)
 
     `generally` encodes the truth conditions — different theories
     instantiate it differently (threshold, normalcy, probabilistic).
-    `traditionalGEN` (in `Generics.lean`) and `thresholdQ` (above)
-    are specific instantiations. -/
+    `traditionalGEN` (in `Generics.lean`, grounded on
+    `Quantification.everyOn`) and `Quantification.thresholdOn` are specific
+    instantiations. -/
 def gen (E W : Type)
     (generally : (E → Prop) → (E → Prop) → Prop)
     : LexEntry E W :=
@@ -155,13 +56,14 @@ def gen (E W : Type)
 
 open Classical in
 /-- Gen with threshold: true iff ≥ `num/denom` of restrictor-satisfying
-    atoms also satisfy scope. Montague-typed counterpart of `thresholdQ`. -/
-noncomputable def genThreshold (E W : Type) (atoms : List E)
+    atoms also satisfy scope. Montague-typed wrapper whose denotation is the
+    canonical `Quantification.thresholdOn` (cross-multiplied `Nat`, `≥`-form)
+    over the atom domain. Noncomputable only because the Montague denotations
+    `restr`/`scope` are arbitrary `Prop`-predicates (decided classically). -/
+noncomputable def genThreshold (E W : Type) [DecidableEq E] (atoms : List E)
     (num denom : Nat) : LexEntry E W :=
   ⟨(.e ⇒ .t) ⇒ (.e ⇒ .t) ⇒ .t, fun restr scope =>
-    let restricted := atoms.filter (fun x => decide (restr x))
-    let both := restricted.filter (fun x => decide (scope x))
-    denom * both.length ≥ num * restricted.length⟩
+    Quantification.thresholdOn atoms.toFinset restr scope num denom⟩
 
 /-- DIST: `(e→t) → (e→t)`. Distributive operator.
 
@@ -181,17 +83,6 @@ def dpp (E W : Type) (atoms : List E) : LexEntry E W :=
   ⟨(.e ⇒ .t) ⇒ (.e ⇒ .t) ⇒ .t, fun prop pred =>
     ∃ x ∈ atoms, prop x ∧ pred x⟩
 
-/-- Hab: `(e→t) → (e→t)`. Habitual aspectual operator.
-
-    `h` maps a predicate to its habitual counterpart.
-    On the Chierchia/Krifka "Hab-is-Gen" view, `h` collapses into the
-    universal `covertQ` skeleton above; on the Boneh–Doron view it is a
-    distinct existential operator (see
-    `Studies/BonehDoron2013.lean`). -/
-def hab (E W : Type) (h : (E → Prop) → (E → Prop))
-    : LexEntry E W :=
-  ⟨(.e ⇒ .t) ⇒ (.e ⇒ .t), h⟩
-
 /-- EXH: `(s→t) → (s→t)`. Exhaustivity operator (proposition modifier).
 
     `exhOp` maps a proposition to its exhaustified version — typically
@@ -210,13 +101,6 @@ def hab (E W : Type) (h : (E → Prop) → (E → Prop))
 def exh (E W : Type) (exhOp : (W → Prop) → (W → Prop))
     : LexEntry E W :=
   ⟨(.intens .t) ⇒ (.intens .t), exhOp⟩
-
-/-- Extend a lexicon with named covert operators. -/
-def extendLexicon {E W : Type} (base : Lexicon E W)
-    (ops : List (String × LexEntry E W)) : Lexicon E W :=
-  fun s => match ops.find? (fun p => p.1 == s) with
-    | some (_, entry) => some entry
-    | none => base s
 
 end Compositional
 

--- a/Linglib/Studies/BonehDoron2013.lean
+++ b/Linglib/Studies/BonehDoron2013.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Quantification.CovertQuantifier
+import Linglib.Semantics.Quantification.Counting
 import Linglib.Semantics.Genericity.Generics
 import Linglib.Semantics.Aspect.Basic
 import Linglib.Features.Genericity
@@ -13,7 +13,7 @@ Theoretical Linguistics 43.
 
 HAB and GEN are **distinct** covert operators, not a single operator with
 different parameters. They share the same quantificational skeleton
-(`covertQ` in `CovertQuantifier.lean`) but differ in:
+(the relativized restricted universal `Quantification.everyOn`) but differ in:
 
 1. **Quantificational force**: HAB is a modalized *existential* quantifier
    over sums of events; GEN is a modalized *universal* quantifier.
@@ -36,11 +36,11 @@ the simple past tense form, the periphrastic *used to*, and *would*.
 
 ## Connection to Existing Infrastructure
 
-- `CovertQuantifier.lean`: shared skeleton `covertQ`. GEN derives from it
-  (see `gen_skeleton` below). HAB does *not* — B&D's central claim is that
-  HAB is a modalized *existential* over event sums, structurally distinct
-  from `covertQ`'s universal form; its force is recorded by
-  `habConfig.force = .existential`.
+- `Quantification.everyOn` (`Counting.lean`): the shared restricted-universal
+  skeleton. GEN derives from it (see `gen_skeleton` below). HAB does *not* —
+  B&D's central claim is that HAB is a modalized *existential* over event sums,
+  structurally distinct from `everyOn`'s universal form; its force is recorded
+  by `habConfig.force = .existential`.
 - `Aspect/Basic.lean`: `ViewpointAspectB` — the `aspectCompatibility`
   bridge connects B&D's Table (41) to the aspectual infrastructure.
 - `DelPrete2013.lean`: Del Prete's Same-Object Effect (SOE) is the Italian
@@ -52,7 +52,7 @@ namespace BonehDoron2013
 
 open Intensional (WorldTimeIndex)
 
-open Quantification.CovertQuantifier
+open Quantification
 open Semantics.Genericity.Generics (Situation traditionalGEN)
 open Semantics.Aspect (ViewpointAspectB)
 
@@ -72,7 +72,7 @@ inductive QForce where
   deriving DecidableEq, Repr
 
 /-- Configuration for a covert quantifier, recording the structural
-    differences between GEN and HAB beyond the shared `covertQ` skeleton. -/
+    differences between GEN and HAB beyond the shared `everyOn` skeleton. -/
 structure CovertQConfig where
   /-- Quantificational force (existential vs universal) -/
   force : QForce
@@ -98,7 +98,7 @@ def habConfig : CovertQConfig :=
   , isModal := true
   }
 
-/-- GEN and HAB have distinct configurations despite sharing `covertQ`. -/
+/-- GEN and HAB have distinct configurations despite sharing `everyOn`. -/
 theorem gen_hab_distinct : genConfig ≠ habConfig := by decide
 
 /-- GEN and HAB agree on modality (both are modalized) but differ on
@@ -470,18 +470,20 @@ theorem would_no_retrospective :
 
 -- ═══ GEN-side skeleton ═══
 
-/-- GEN's denotation reduces to `covertQ` with restrictor conjoined from
-    a normalcy predicate and a kind/restrictor predicate.
+/-- GEN's denotation reduces to the canonical relativized restricted universal
+    `Quantification.everyOn`, with restrictor conjoined from a normalcy
+    predicate and a kind/restrictor predicate.
 
     HAB does *not* admit a parallel reduction: B&D §6.2.1 argue HAB is
     a modalized *existential* over event sums (`∃x [cigarette(x) & Hab e
-    smoke(e, Mary, x)]`), not a universal over a list. The genuinely
+    smoke(e, Mary, x)]`), not a universal over a domain. The genuinely
     distinctive existential force is recorded by
-    `habConfig.force = .existential`; there is no `covertQ`-style
+    `habConfig.force = .existential`; there is no `everyOn`-style
     derivation theorem for HAB. -/
 theorem gen_skeleton
     (sits : List Situation) (normal restrictor scope : Situation → Bool) :
     traditionalGEN sits normal restrictor scope =
-    covertQ sits (λ s => normal s && restrictor s) scope := rfl
+    everyOn sits.toFinset (fun s => (normal s && restrictor s) = true)
+      (fun s => scope s = true) := rfl
 
 end BonehDoron2013

--- a/Linglib/Studies/Cohen2013.lean
+++ b/Linglib/Studies/Cohen2013.lean
@@ -1,6 +1,5 @@
-import Linglib.Semantics.Genericity.Generics
+import Linglib.Semantics.Quantification.Counting
 import Linglib.Semantics.Composition.Scope
-import Linglib.Semantics.Quantification.CovertQuantifier
 
 /-!
 # [cohen-2013]: No Quantification without Reinterpretation
@@ -64,14 +63,15 @@ built directly on `transferGen` and `gamma` from (below):
 3. **Scope hierarchy**: overt > predicateTransfer > typeShift
 
 These connect to (below) (T_g, γ, SHIFT, `QuantifierSource`),
-`Generics.lean` (traditionalGEN), `CovertQuantifier.lean` (shared `covertQ`),
-and `Scope.lean` (ScopeConfig). A local 3-cell `Occasion` enum (below) supplies
-the habitual-side domain.
+the canonical relativized restricted universal `Quantification.everyOn`
+(`Counting.lean`) that both T_g and γ bottom out in, and `Scope.lean`
+(ScopeConfig). A local 3-cell `Occasion` enum (below) supplies the
+habitual-side domain.
 -/
 
 namespace Cohen2013
 
-open Quantification.CovertQuantifier
+open Quantification
 open Semantics.Scope (ScopeConfig)
 
 /-! ### Reinterpretation mechanisms ([cohen-2013], [nunberg-1995])
@@ -94,10 +94,10 @@ kind-level predicate into a quantified predicate over instances of the kind.
 kind x. When `P(∩pandas)` is pragmatically anomalous (kinds don't eat —
 individuals do), Predicate Transfer applies, yielding
 `gen_y[C(y, ∩pandas)][P(y)]`. -/
-def transferGen {Kind Ind : Type}
-    (gen : (Ind → Bool) → (Ind → Bool) → Bool)
+@[reducible] def transferGen {Kind Ind : Type}
+    (gen : (Ind → Bool) → (Ind → Bool) → Prop)
     (instanceOf : Ind → Kind → Bool)
-    (P : Ind → Bool) : Kind → Bool :=
+    (P : Ind → Bool) : Kind → Prop :=
   fun x => gen (fun y => instanceOf y x) P
 
 /-- Partee-Rooth SHIFT: lift an extensional transitive verb to take a
@@ -125,10 +125,10 @@ Triggered by the present-tense / eventive-verb type mismatch, which forces
 γ to fire at the verb level (locally). Locality is why habituals take
 narrow scope. Like SHIFT, γ does not commute with other operators — see
 `gamma_noncommutative` for the concrete instance. -/
-def gamma {Interval Moment : Type}
-    (gen : (Interval → Bool) → (Interval → Bool) → Bool)
+@[reducible] def gamma {Interval Moment : Type}
+    (gen : (Interval → Bool) → (Interval → Bool) → Prop)
     (containedIn : Interval → Moment → Bool)
-    (P : Interval → Bool) : Moment → Bool :=
+    (P : Interval → Bool) : Moment → Prop :=
   fun t => gen (fun e => containedIn e t) P
 
 /-- The mechanism introducing a covert quantifier; determines its scope
@@ -283,9 +283,10 @@ def nestsIn : Stork → NestArea → Bool
   | .s2, .a2 => true
   | _, _ => false
 
-/-- GEN as universal over storks (simplified: all storks are "normal"). -/
-def genStork (restrictor scope : Stork → Bool) : Bool :=
-  covertQ storks restrictor scope
+/-- GEN as the canonical relativized universal over storks (simplified: all
+    storks are "normal"). -/
+@[reducible] def genStork (restrictor scope : Stork → Bool) : Prop :=
+  everyOn storks.toFinset (fun y => restrictor y = true) (fun y => scope y = true)
 
 /-- Chierchia's ∪ applied to ∩storks: every Stork is an instance of the kind. -/
 def instanceOfStork (_ : Stork) (_ : Unit) : Bool := true
@@ -296,22 +297,21 @@ def storkKind : Unit := ()
 /-- **Local T_g**: ∃area(T_g(λy.nestsIn(y, area))(∩storks))
     = ∃area(gen_y[stork(y)][nestsIn(y, area)])
     "There is one area that, in general, storks nest in." -/
-def localTransfer : Bool :=
-  areas.any fun a =>
-    transferGen genStork instanceOfStork (fun y => nestsIn y a) storkKind
+@[reducible] def localTransfer : Prop :=
+  ∃ a ∈ areas, transferGen genStork instanceOfStork (fun y => nestsIn y a) storkKind
 
 /-- **Global T_g**: T_g(λy.∃area(nestsIn(y, area)))(∩storks)
     = gen_y[stork(y)][∃area(nestsIn(y, area))]
     "In general, storks nest in some area (possibly different)." -/
-def globalTransfer : Bool :=
+@[reducible] def globalTransfer : Prop :=
   transferGen genStork instanceOfStork
     (fun y => areas.any fun a => nestsIn y a) storkKind
 
 -- Local T_g is false: no single area works for all storks.
-#guard !localTransfer
+example : ¬ localTransfer := by decide
 
 -- Global T_g is true: each stork has some area.
-#guard globalTransfer
+example : globalTransfer := by decide
 
 /-- **Generic scope ambiguity**: local and global T_g yield different
     truth conditions. This is why generics in transparent contexts
@@ -320,7 +320,7 @@ def globalTransfer : Bool :=
     The two readings correspond to `ScopeConfig.surface` (∃ > gen)
     and `ScopeConfig.inverse` (gen > ∃). -/
 theorem generic_scope_ambiguity :
-    localTransfer = false ∧ globalTransfer = true := ⟨rfl, rfl⟩
+    ¬ localTransfer ∧ globalTransfer := ⟨by decide, by decide⟩
 
 /-- The scope ambiguity matches the empirical datum: both readings available. -/
 theorem generic_both_scopes :
@@ -393,9 +393,10 @@ def smokes : Cigarette → Occasion → Bool
   | .c3, .e3 => true
   | _, _ => false
 
-/-- GEN over occasions (simplified: all occasions are relevant). -/
-def genHab (restrictor scope : Occasion → Bool) : Bool :=
-  covertQ occasions restrictor scope
+/-- GEN over occasions as the canonical relativized universal (simplified:
+    all occasions are relevant). -/
+@[reducible] def genHab (restrictor scope : Occasion → Bool) : Prop :=
+  everyOn occasions.toFinset (fun e => restrictor e = true) (fun e => scope e = true)
 
 /-- All occasions are contained in the relevant interval of speech time t₀. -/
 def containedInSpeech : Occasion → Unit → Bool := fun _ _ => true
@@ -406,22 +407,21 @@ def speechTime : Unit := ()
 /-- **Local γ** (γ at verb, then object composes):
     ∃c(cigarette(c) ∧ γ(λe.smoke(m,c,e))(t₀))
     "There is one cigarette that Mary habitually smokes." -/
-def localGamma : Bool :=
-  cigarettes.any fun c =>
-    gamma genHab containedInSpeech (fun e => smokes c e) speechTime
+@[reducible] def localGamma : Prop :=
+  ∃ c ∈ cigarettes, gamma genHab containedInSpeech (fun e => smokes c e) speechTime
 
 /-- **Global γ** (hypothetical — if γ could apply to the whole VP):
     γ(λe.∃c(cigarette(c) ∧ smoke(m,c,e)))(t₀)
     "Mary is habitually in a situation where she smokes some cigarette." -/
-def globalGamma : Bool :=
+@[reducible] def globalGamma : Prop :=
   gamma genHab containedInSpeech
     (fun e => cigarettes.any fun c => smokes c e) speechTime
 
 -- Local γ is false: no single cigarette is smoked at all occasions.
-#guard !localGamma
+example : ¬ localGamma := by decide
 
 -- Global γ is true: at each occasion, some cigarette is smoked.
-#guard globalGamma
+example : globalGamma := by decide
 
 /-- **Habitual narrow scope**: local and global γ differ, but only
     local is available. The plausible wide-scope reading is blocked
@@ -430,7 +430,7 @@ def globalGamma : Bool :=
     This explains why "#John smokes a cigarette" is odd: the only
     available reading (∃ > hab) is implausible. -/
 theorem habitual_narrow_scope :
-    localGamma = false ∧ globalGamma = true := ⟨rfl, rfl⟩
+    ¬ localGamma ∧ globalGamma := ⟨by decide, by decide⟩
 
 /-- The narrow-scope-only prediction matches the empirical datum. -/
 theorem habitual_matches_datum :
@@ -442,7 +442,7 @@ theorem habitual_matches_datum :
     from §13.3.1 (proved abstractly for SHIFT in `shift_neg_noncommutative`).
     The non-commutativity is what forces γ to apply locally. -/
 theorem gamma_noncommutative :
-    localGamma ≠ globalGamma := by native_decide
+    ¬ (localGamma ↔ globalGamma) := by decide
 
 end HabitualScope
 
@@ -484,25 +484,24 @@ theorem predictions_match_data :
 -- Connection to Existing Infrastructure
 -- ============================================================================
 
-/-- Both T_g and γ produce instances of `covertQ`, confirming that
-    `CovertQuantifier.lean`'s shared infrastructure correctly captures
-    the common logical form. The difference is upstream (how the quantifier
-    is introduced), not downstream (what it evaluates to).
+/-- Both T_g and γ bottom out in the canonical relativized universal
+    `Quantification.everyOn`, confirming that they share the common logical
+    form. The difference is upstream (how the quantifier is introduced), not
+    downstream (what it evaluates to).
 
-    T_g with our stork model reduces to `covertQ storks` because
-    `instanceOfStork y () = true` for all y, making the restrictor
-    equivalent to `fun y => true` — i.e., all storks are in the domain.
-
-    γ with our model reduces to `covertQ occasions` because
-    `containedInSpeech e () = true` for all e, making the restrictor
-    equivalent to `fun e => true` — i.e., all occasions are relevant. -/
-theorem both_reduce_to_covertQ :
-    -- T_g(nestsIn(·, a1))(∩storks) = covertQ storks (λ_ => true) (nestsIn · .a1)
+    T_g with our stork model reduces to `everyOn storks.toFinset` with the
+    restrictor `instanceOfStork · ∩storks` and the scope; γ likewise reduces
+    to `everyOn occasions.toFinset`. Both are `rfl` because `transferGen`/`gamma`
+    are definitionally the relativized universal applied to the kind/moment. -/
+theorem both_reduce_to_everyOn :
+    -- T_g(nestsIn(·, a1))(∩storks) = everyOn storks.toFinset (instanceOf · ∩storks) (nestsIn · .a1)
     transferGen genStork instanceOfStork (fun y => nestsIn y .a1) storkKind =
-    covertQ storks (fun _ => true) (fun y => nestsIn y .a1) ∧
-    -- γ(smoke(c1, ·))(t₀) = covertQ occasions (λ_ => true) (smokes .c1 ·)
+    everyOn storks.toFinset (fun y => instanceOfStork y storkKind = true)
+      (fun y => nestsIn y .a1 = true) ∧
+    -- γ(smoke(c1, ·))(t₀) = everyOn occasions.toFinset (containedIn · t₀) (smokes .c1 ·)
     gamma genHab containedInSpeech (fun e => smokes .c1 e) speechTime =
-    covertQ occasions (fun _ => true) (fun e => smokes .c1 e) :=
+    everyOn occasions.toFinset (fun e => containedInSpeech e speechTime = true)
+      (fun e => smokes .c1 e = true) :=
   ⟨rfl, rfl⟩
 
 /-- The available scope configurations for generics: both surface

--- a/Linglib/Studies/Guerrini2026.lean
+++ b/Linglib/Studies/Guerrini2026.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Kinds.NominalMappingParameter
 import Linglib.Semantics.Genericity.Generics
+import Linglib.Semantics.Quantification.CovertQuantifier
 import Linglib.Semantics.Plurality.Distributivity
 import Linglib.Semantics.Plurality.Cumulativity
 import Linglib.Semantics.Plurality.Trivalent
@@ -1013,7 +1014,7 @@ open Semantics.Genericity.Generics (traditionalGEN Situation
 
     This function makes the compositional content of BFG explicit. -/
 def evalBFG (situations : List Situation) (normal : NormalcyPredicate)
-    (kindRestrictor : Restrictor) (predScope : Scope) : Bool :=
+    (kindRestrictor : Restrictor) (predScope : Scope) : Prop :=
   traditionalGEN situations normal kindRestrictor predScope
 
 /-- Table 1 is derivable from LF availability + LF → flavor mapping.
@@ -1477,7 +1478,7 @@ theorem diagram_145_four_paths :
 aspect operator **Hab**. On the "habituality is genericity" view
 ([chierchia-1995], [chierchia-1998]), Hab IS Gen applied to situations
 involving a single individual — in linglib this view collapses Hab into the
-shared `covertQ` skeleton in `CovertQuantifier.lean`. On the Dobrovie-Sorin (2001)
+shared restricted-universal skeleton `Quantification.everyOn`. On the Dobrovie-Sorin (2001)
 view (also [boneh-doron-2013]), Hab is a distinct existential operator
 below Gen; the existential force is recorded by
 `BonehDoron2013.habConfig.force = .existential`.

--- a/Linglib/Studies/Krifka2013.lean
+++ b/Linglib/Studies/Krifka2013.lean
@@ -138,9 +138,9 @@ theorem def_restricts_interps (cg : CommonGround) (φ : Denotation) :
     changes interpretations. Since threshold semantics measures world-prevalence,
     it cannot capture definitional generics that change truth value through DEF.
 
-    Since traditional GEN (a descriptive operator) reduces to threshold
-    semantics (`CovertQuantifier.reduces_to_threshold`), this theorem shows
-    definitional generics escape that reduction entirely. -/
+    Since traditional GEN (a descriptive operator) has a threshold reading
+    (`Generics.thresholdGeneric`, grounded on `Quantification.thresholdGtOn`),
+    this theorem shows definitional generics escape that reduction entirely. -/
 theorem def_invariant_world_measure {α : Type} (cg : CommonGround) (φ : Denotation)
     (f : List World → α) :
     f (def_ cg φ).worlds = f cg.worlds := by

--- a/Linglib/Studies/TesslerGoodman2019.lean
+++ b/Linglib/Studies/TesslerGoodman2019.lean
@@ -624,9 +624,10 @@ Beta mixtures that capture the qualitative predictions:
 
 The paper reports a model fit of r²(93) = 0.894 on habitual endorsement data.
 
-See also: `CovertQuantifier.reduces_to_threshold` for the general bridge
-from `covertQ` to threshold semantics, completing the pipeline:
-covertQ → threshold → uncertain threshold → RSA endorsement.
+See also: `Generics.thresholdGeneric` (grounded on the canonical
+`Quantification.thresholdGtOn`) for the threshold reading of GEN, completing
+the pipeline:
+GEN → threshold → uncertain threshold → RSA endorsement.
 -/
 
 /-- Frequency prior for "runs": moderate expectation.
@@ -883,7 +884,7 @@ This unification is structural (by construction), not proven post hoc.
 The integration pipeline is:
 
 1. **Traditional operator** (GEN/HAB) reduces to threshold semantics
-   (`CovertQuantifier.reduces_to_threshold`)
+   (`Generics.thresholdGeneric`, on `Quantification.thresholdGtOn`)
 2. **Threshold semantics** with uncertain threshold → marginalized L0
 3. **RSA endorsement** (`mkGenericCfg`) decides between generic and silence
 4. **Endorsement ≈ cue validity** (`endorsed_iff_cue_validity_gt_one`)


### PR DESCRIPTION
Deletes the `CovertQuantifier` Bool/List/ℚ clones (`covertQ`, `covertQ_dual`, `covertQ_equiv`, `measure`, `thresholdQ`, `measure_nonneg`, `measure_le_one`, `reduces_to_threshold`, `hab`, `extendLexicon`) and grounds the whole generics stack on the canonical GQ substrate in `Quantification/Counting.lean`.

- `genThreshold` re-bodied onto `Quantification.thresholdOn`; `gen`/`dist`/`dpp`/`exh` kept.
- `Generics`: `traditionalGEN`→`everyOn`, `prevalence`→`prevalenceOn`, `thresholdGeneric`→`thresholdGtOn`, `genHomogeneityPresup`→`everyOn ∨ noOn`; `gen_is_covertQ`→`gen_is_every_on`.
- Consumers migrated (Cohen2013, BonehDoron2013, Guerrini2026); `native_decide`/`#guard` retired in the touched cone.
- Adds `mostOn_univ` + inherited `mostOn_univ_proportional` to Counting.