### PR TITLE
feat(Studies): Cohen GEN is proportional most; real generics are not

### DIFF
--- a/Linglib/Semantics/Quantification/Counting.lean
+++ b/Linglib/Semantics/Quantification/Counting.lean
@@ -99,6 +99,18 @@ theorem thresholdGtOn_iff_prevalenceOn {α : Type*} (s : Finset α) (R S : α �
       mul_comm (countOn s (fun x => R x ∧ S x) : ℚ) (denom : ℚ),
       ← Nat.cast_mul, ← Nat.cast_mul, Nat.cast_lt]
 
+/-- "More than half" is exactly "most": `thresholdGtOn s R S 1 2` (more than `1/2`
+    of the `R`'s in `s` are `S`) coincides with `mostOn s R S` (strictly more
+    `R∧S` than `R∧¬S`). Both are division-free `Nat` comparisons; the bridge is
+    `countOn_decompose`. The threshold `1/2` is special because it is the cutpoint
+    *at* the `1 : 1` cell ratio. -/
+theorem thresholdGtOn_one_two_iff_mostOn {α : Type*} (s : Finset α) (R S : α → Prop)
+    [DecidablePred R] [DecidablePred S] :
+    thresholdGtOn s R S 1 2 ↔ mostOn s R S := by
+  unfold thresholdGtOn mostOn
+  rw [countOn_decompose s R S]
+  omega
+
 /-! The relativized `∀`/`∃` companions of `Basic`'s whole-carrier `every_sem`/
 `some_sem`/`no_sem`: bounded over an explicit `Finset`, hence decidable with no
 `Fintype` (`Finset.decidableDforallFinset`). They are *not* duplicates of the
@@ -927,8 +939,7 @@ theorem not_qsymmetric_most_sem : ¬ QSymmetric (most_sem : GQ (Fin 3)) := by
 `most`, matching the whole-carrier `most_sem` (modulo the
 `DecidablePred`-instance bridge `Finset.filter_congr_decidable`). The
 `Proportional` theorem proved for `most_sem` therefore transfers to it by
-inheritance, not re-proof — exhibiting "GEN-as-thresholded-most" as a
-specialization of the canonical proportional quantifier rather than a clone. -/
+inheritance, not re-proof. -/
 
 omit [DecidableEq α] in
 @[simp] theorem mostOn_univ (R S : α → Prop) [DecidablePred R] [DecidablePred S] :
@@ -937,8 +948,9 @@ omit [DecidableEq α] in
   congr! 2
 
 omit [DecidableEq α] in
-/-- "GEN-as-most is proportional" — inherited from `most_proportional`, not
-    re-proved: at `s = Finset.univ` the relativized `mostOn` IS `most_sem`. -/
+/-- `mostOn` at the whole carrier is proportional — inherited from
+    `most_proportional`, not re-proved: at `s = Finset.univ` the relativized
+    `mostOn` IS `most_sem`. -/
 theorem mostOn_univ_proportional :
     Proportional (fun R S => mostOn (Finset.univ : Finset α) R S) := by
   have h : (fun (R S : α → Prop) => mostOn (Finset.univ : Finset α) R S) = most_sem := by

--- a/Linglib/Studies/Cohen1999.lean
+++ b/Linglib/Studies/Cohen1999.lean
@@ -57,7 +57,9 @@ divergence as a theorem against `cohenGEN`.
 namespace Cohen1999
 
 open Semantics.Genericity.Generics (Situation)
-open Quantification (prevalenceOn countOn everyOn thresholdGtOn thresholdGtOn_iff_prevalenceOn)
+open Quantification (prevalenceOn countOn everyOn thresholdGtOn thresholdGtOn_iff_prevalenceOn
+  mostOn thresholdGtOn_one_two_iff_mostOn Proportional mostOn_univ_proportional
+  count count_decompose)
 
 /-! ### Cohen's Probability-Based GEN
 
@@ -83,6 +85,47 @@ theorem cohen_iff_thresholdGt {α : Type*} (domain : Finset α) (restrictor scop
     cohenGEN domain restrictor scope ↔ thresholdGtOn domain restrictor scope 1 2 := by
   rw [cohenGEN, thresholdGtOn_iff_prevalenceOn domain restrictor scope 1 2 (by norm_num) hR]
   norm_num
+
+/-! ### Cohen's GEN is proportional majority quantification
+
+Cohen's θ = 1/2 GEN is, over a non-empty restrictor domain, **exactly** the
+canonical majority quantifier `mostOn` — the θ = 1/2 threshold is the cutpoint
+*at* the `1 : 1` cell ratio. It therefore inherits `Proportional` from the GQ
+substrate. This is the precise content of "generics as majority quantification"
+— and exactly the claim the genericity literature rejects: real generics are
+**not** majority statements (`cohen_wrong_on_mosquitoes`; [nickel-2009];
+[leslie-2008]; [tessler-goodman-2019]). The theorems below state what is *true
+of Cohen's operator*, not of generics in general. -/
+
+/-- Cohen's GEN over a non-empty restrictor domain is exactly the canonical
+    majority quantifier `mostOn` (strictly more `R∧S` than `R∧¬S`): θ = 1/2 is
+    the `1 : 1` cell-ratio cutpoint (`thresholdGtOn_one_two_iff_mostOn`). -/
+theorem cohen_iff_mostOn {α : Type*} (domain : Finset α) (restrictor scope : α → Prop)
+    [DecidablePred restrictor] [DecidablePred scope] (hR : 0 < countOn domain restrictor) :
+    cohenGEN domain restrictor scope ↔ mostOn domain restrictor scope :=
+  (cohen_iff_thresholdGt domain restrictor scope hR).trans
+    (thresholdGtOn_one_two_iff_mostOn domain restrictor scope)
+
+open Classical in
+/-- Cohen's majority GEN over the whole (finite) carrier is a **proportional**
+    quantifier ([peters-westerstahl-2006]): its truth depends only on the ratio
+    |R∩S| : |R∖S|. Inherited from `mostOn_univ_proportional` via `cohen_iff_mostOn`,
+    not re-proved.
+
+    This proportionality is a property of Cohen's *majority* operator, **not** of
+    generics in general — the prevalence asymmetry ([leslie-2008];
+    `TesslerGoodman2019.same_prevalence_opposite_endorsement`) shows real generic
+    endorsement is *not* ratio-determined. -/
+theorem cohen_proportional {α : Type*} [Fintype α] :
+    Proportional (fun (R S : α → Prop) => cohenGEN Finset.univ R S) := by
+  intro R₁ S₁ R₂ S₂ tt₁ tf₁ tt₂ tf₂ h1 h2 hcross
+  show cohenGEN Finset.univ R₁ S₁ ↔ cohenGEN Finset.univ R₂ S₂
+  have hR1 : 0 < countOn Finset.univ R₁ := by
+    show 0 < count (fun x => R₁ x); rw [count_decompose R₁ S₁]; exact h1
+  have hR2 : 0 < countOn Finset.univ R₂ := by
+    show 0 < count (fun x => R₂ x); rw [count_decompose R₂ S₂]; exact h2
+  rw [cohen_iff_mostOn Finset.univ R₁ S₁ hR1, cohen_iff_mostOn Finset.univ R₂ S₂ hR2]
+  exact mostOn_univ_proportional R₁ S₁ R₂ S₂ h1 h2 hcross
 
 /-- Cohen's "always": no exceptions — every restrictor-element satisfies the scope.
     For a non-empty restrictor domain this is exactly P(Q | P) = 1; stated as the

--- a/Linglib/Studies/TesslerGoodman2019.lean
+++ b/Linglib/Studies/TesslerGoodman2019.lean
@@ -538,6 +538,21 @@ prevalence). [leslie-2008] documents the empirical observation;
 
 `laysEggs_endorsed` and `isFemale_borderline` (above) derive the predictions. -/
 
+/-- **Generic endorsement is not prevalence-functional** — at the *same* referent
+    prevalence (50%), "robins lay eggs" is endorsed but "robins are female" is not.
+    The verdict is fixed by the property-specific prior, not by the prevalence
+    ratio. This is the prevalence asymmetry ([leslie-2008]) as a structural fact:
+    no generalized quantifier whose truth depends only on the cell ratio
+    |R∩S| : |R∖S| — i.e. no `Proportional` quantifier, every counting quantifier
+    in `Quantification.Counting` including `mostOn` — can capture generic
+    endorsement. This is exactly where the majority view fails: contrast
+    `Cohen1999.cohen_proportional`, which shows Cohen's θ = 1/2 GEN *is* proportional
+    (and hence cannot exhibit this asymmetry). -/
+theorem same_prevalence_opposite_endorsement :
+    (laysEggsCfg.S1 () (prevPct 50) .generic > laysEggsCfg.S1 () (prevPct 50) .silent) ∧
+    ¬(isFemaleCfg.S1 () (prevPct 50) .generic > isFemaleCfg.S1 () (prevPct 50) .silent) :=
+  ⟨laysEggs_endorsed, isFemale_borderline⟩
+
 -- ============================================================================
 -- § 9. Infinite-Rationality Limit: Generics as Categorical Defaults
 -- ============================================================================

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -10877,6 +10877,19 @@
   validated = {true},
   sources   = {Phenomena/Generics/Studies/Cohen1999.lean}
 }
+@article{leslie-2008,
+  author    = {Leslie, Sarah-Jane},
+  year      = {2008},
+  title     = {Generics: Cognition and Acquisition},
+  journal   = {The Philosophical Review},
+  volume    = {117},
+  number    = {1},
+  pages     = {1--47},
+  doi       = {10.1215/00318108-2007-023},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  sources   = {Studies/Cohen1999.lean;Studies/TesslerGoodman2019.lean}
+}
 @article{nunberg-1995,
   author    = {Nunberg, Geoffrey},
   year      = {1995},


### PR DESCRIPTION
Cashes in the inherited-property payoff of the GQ consolidation, honestly scoped after expert review (the naive 'generics inherit Proportional' is an overclaim — it contradicts the codebase's own `cohen_wrong_on_mosquitoes` / prevalence-asymmetry theorems).

- `Counting`: `thresholdGtOn_one_two_iff_mostOn` — 'more than half' = 'most' (the θ=1/2 cutpoint is the 1:1 cell ratio), via `countOn_decompose`. Neutral substrate; drops the genericity gloss from `mostOn_univ_proportional`.
- `Cohen1999`: `cohen_iff_mostOn` + `cohen_proportional` — Cohen's θ=1/2 GEN *is* the canonical majority quantifier and inherits `Proportional` (not re-proved), hedged as Cohen's account (empirically wrong for rare/striking generics).
- `TesslerGoodman2019`: `same_prevalence_opposite_endorsement` — same 50% prevalence, opposite verdict (laysEggs vs isFemale): generic endorsement is *not* ratio-determined, so no `Proportional` quantifier captures it.
- Adds the verified `leslie-2008` entry to `references.bib` (was cited but missing).