### PR TITLE
refactor(Semantics): prune dead surface from Relational.lean

### DIFF
--- a/Linglib/Morphology/DM/CategorizerSemantics.lean
+++ b/Linglib/Morphology/DM/CategorizerSemantics.lean
@@ -109,10 +109,6 @@ theorem nBodyPartDenot_eq_pi {E S : Type}
     (rootPred : Pred1 E S) (bodyPartOf : Pred2 E S) :
     nBodyPartDenot rootPred bodyPartOf = π rootPred bodyPartOf := rfl
 
-/-- n_{sortal} IS Barker's bare semantics: identity on the root predicate. -/
-theorem nSortalDenot_eq_bare {E S : Type} (rootPred : Pred1 E S) :
-    nSortalDenot rootPred = bareSemantics rootPred := rfl
-
 /-- n_{alienator} is the argument-flipped version of Barker's Ex.
 
     Barker's Ex closes the second argument of R(x,y):

--- a/Linglib/Semantics/ArgumentStructure/Relational.lean
+++ b/Linglib/Semantics/ArgumentStructure/Relational.lean
@@ -12,11 +12,11 @@ returns the relational predicate `fun x y ↦ P y ∧ R x y`. Its quasi-adjoint
 `Ex` collapses a relation back to a property by existentially closing the
 second argument.
 
-The structural condition *having a relatum slot* controls three surface
-phenomena — possessor licensing, antecedent bridging, and demonstrative
-anaphora. They are tracked as separate predicates (`hasRelatumSlot`,
-`canTakePossessor`, `canBridge`) over `NominalInterpType` because they
-describe distinct linguistic facts, even though they coincide by construction.
+The structural condition *having a relatum slot* controls two surface
+phenomena — possessor licensing and demonstrative anaphora. They are tracked
+as separate predicates (`hasRelatumSlot`, `canTakePossessor`) over
+`NominalInterpType` because they describe distinct linguistic facts, even
+though they coincide by construction.
 
 The possessive-specific carriers, capability mixins, and quantificational layer
 live in the unified `Possessive` namespace (`Semantics/Possessive/`), built on
@@ -55,16 +55,6 @@ abbrev Pred1 (E S : Type*) := E → S → Prop
 /-- Two-place predicate over entities and states. -/
 abbrev Pred2 (E S : Type*) := E → E → S → Prop
 
-/-- Semantic arity of a nominal expression. -/
-inductive SemType where
-  /-- Property `Pred1`. -/
-  | pred1
-  /-- Relation `Pred2`. -/
-  | pred2
-  /-- Bare individual. -/
-  | entity
-  deriving DecidableEq, Repr
-
 /-! ### Type shifters -/
 
 section TypeShifters
@@ -74,8 +64,6 @@ variable {E S : Type*}
 /-- Barker's relationalizer: `π P R x y s ↔ P y s ∧ R x y s`. -/
 def π (P : Pred1 E S) (R : Pred2 E S) : Pred2 E S :=
   λ x y s => P y s ∧ R x y s
-
-@[inherit_doc] scoped notation "relationalizer(" P ", " R ")" => π P R
 
 /-- Existential closure of a relation in its second argument:
 `Ex R x s ↔ ∃ y, R x y s`. -/
@@ -106,9 +94,8 @@ abbrev iotaPresupposition (P : Pred1 E S) (s : S) : Prop := ∃! x, P x s
 
 /-- Demonstrative-headed nominal: `π` applied to a sortal noun with the
 demonstrative supplying the relatum. -/
-def naSemantics (nounPred : Pred1 E S) (R : Pred2 E S) (relatum : E) :
-    Pred1 E S :=
-  λ x s => π nounPred R relatum x s
+def naSemantics (nounPred : Pred1 E S) (R : Pred2 E S) (relatum : E) : Pred1 E S :=
+  π nounPred R relatum
 
 /-- Bare nominal: identity on the predicate (no relatum slot). -/
 def bareSemantics (nounPred : Pred1 E S) : Pred1 E S :=
@@ -164,14 +151,6 @@ def canTakePossessor : NominalInterpType → Prop
 
 instance : DecidablePred canTakePossessor := λ t => by
   cases t <;> unfold canTakePossessor <;> infer_instance
-
-/-- Whether the interpretation type can accommodate bridging. -/
-def canBridge : NominalInterpType → Prop
-  | .pred1 => False
-  | .pred2 => True
-
-instance : DecidablePred canBridge := λ t => by
-  cases t <;> unfold canBridge <;> infer_instance
 
 end NominalInterpType
 

--- a/Linglib/Studies/Heine1997.lean
+++ b/Linglib/Studies/Heine1997.lean
@@ -49,7 +49,7 @@ Cambridge Studies in Linguistics 83. Cambridge University Press, 1997.
 
 open Typology.Possession
 open Grammaticalization
-open Semantics.ArgumentStructure.Relational (Pred1 Pred2 SemType)
+open Semantics.ArgumentStructure.Relational (Pred1 Pred2 NominalInterpType)
 
 namespace Heine1997
 
@@ -325,7 +325,7 @@ theorem location_not_permanent :
     constructions: the possessee is the sole core argument, and the
     possessor is an oblique adjunct. The possessive predicate is Pred1,
     with the possessor introduced by Ex closure or case marking. -/
-def schemaArity : PossessionSource → SemType
+def schemaArity : PossessionSource → NominalInterpType
   | .action    => .pred2  -- X takes Y: two core arguments
   | .companion => .pred2  -- X is with Y: two core arguments
   | _          => .pred1  -- Y exists/is-at/...: one core argument + oblique
@@ -378,7 +378,7 @@ structure SchemaPrediction where
   yieldsHave : Bool
   yieldsBelong : Bool
   possessorIsSubject : Bool
-  arity : SemType
+  arity : NominalInterpType
 
 /-- Derive predictions from a schema. -/
 def predictionsFor (s : PossessionSource) : SchemaPrediction :=


### PR DESCRIPTION
PR2 of the definiteness-API consolidation (dedup; mathlib-reviewer-vetted). Pure cleanup, no logic change.

- Delete dead `NominalInterpType.canBridge` (zero consumers; identical to the two live predicates `hasRelatumSlot`/`canTakePossessor`, which stay).
- Delete `SemType` (its `.entity` case was unused; it duplicated `NominalInterpType` at the only cases used) and repoint its sole consumer `Heine1997` to `NominalInterpType`.
- Delete the dead `scoped notation relationalizer(...)` (zero consumers).
- Eta-reduce `naSemantics` to `π nounPred R relatum` (defeq; no proof changes).
- Drop `CategorizerSemantics.nSortalDenot_eq_bare` (an `id = id` rfl lemma); `bareSemantics` and `nSortalDenot := bareSemantics` are kept.

`bareSemantics`/`naSemantics` (the bare/na denotation pair) and `InterpretationSource`/`CanFillRelatum` (the genuine 3-way source map) are deliberately retained. Verified across the consumer cone. Follow-ups (out of scope): `CategorizerSemantics` `Type`→`Type*`; re-home the ι/na/bare layer into `Semantics/Definiteness/`.