### PR TITLE
refactor(Semantics/Definiteness): drop existsUnique dup, use mathlib ∃!

### DIFF
--- a/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
@@ -227,13 +227,7 @@ theorem Possessive.denote_isSome_iff_iotaPresupposition (p : Possessive) :
           (fun x (_ : PUnit) => R g gs x ∧ rel g gs (possessor g gs) x) PUnit.unit := by
   rw [Possessive.denote_selector]
   show (russellIota (fun x => R g gs x ∧ rel g gs (possessor g gs) x)).isSome ↔ _
-  rw [russellIota_isSome_iff_existsUnique]
-  unfold existsUnique Existence Uniqueness iotaPresupposition
-  constructor
-  · rintro ⟨⟨x, hx⟩, huniq⟩
-    exact ⟨x, hx, fun y hy => huniq y x hy hx⟩
-  · rintro ⟨x, hx, huniq⟩
-    exact ⟨⟨x, hx⟩, fun a b ha hb => (huniq a ha).trans (huniq b hb).symm⟩
+  rw [russellIota_isSome_iff_exists_unique]
 
 /-- At a context where its presupposition holds, the possessive determiner
 assembles into a `Possessive.Definite` carrier (over the trivial situation) whose

--- a/Linglib/Semantics/Definiteness/Interpret.lean
+++ b/Linglib/Semantics/Definiteness/Interpret.lean
@@ -150,33 +150,30 @@ theorem interpret_unique_witness_satisfies
     is the unique satisfier, `.unique` returns it. Closes the standard
     Russellian-iota extraction in one line — without it, every concrete
     `interpret_*` instance needs the six-step ritual of
-    `interpret_unique` → `russellIota_isSome_iff_existsUnique` → `Option.isSome_iff_exists` →
+    `interpret_unique` → `russellIota_isSome_iff_exists_unique` → `Option.isSome_iff_exists` →
     `russellIota_witness_satisfies` → case analysis. -/
 theorem interpret_unique_eq_some_of_existsUnique
     (R : DenotGS E W .et) (sIdx : Nat)
     (g : Assignment E) (gs : SitAssignment W) (e : E)
     (hSat : R g gs e) (hUniq : ∀ y, R g gs y → y = e) :
     interpret (.unique R sIdx) g gs = some e := by
-  have hExU : existsUnique (fun x => R g gs x) :=
-    ⟨⟨e, hSat⟩, fun x y hx hy => (hUniq x hx).trans (hUniq y hy).symm⟩
+  have hExU : ∃! x, R g gs x := ⟨e, hSat, hUniq⟩
   rw [interpret_unique]
   obtain ⟨e', he'⟩ : ∃ e', russellIota (fun x => R g gs x) = some e' :=
-    Option.isSome_iff_exists.mp ((russellIota_isSome_iff_existsUnique _).mpr hExU)
+    Option.isSome_iff_exists.mp ((russellIota_isSome_iff_exists_unique _).mpr hExU)
   rw [he']
   congr 1
   exact hUniq e' (russellIota_witness_satisfies _ _ he')
 
 /-- Specialization of `interpret_unique_eq_some_of_existsUnique` to a packaged
-    `existsUnique` hypothesis, with the witness extracted. The first projection
-    of `existsUnique` gives the entity; the second proves uniqueness. -/
+    `∃!` hypothesis, with the witness extracted via `Exists.choose`. -/
 theorem interpret_unique_eq_some_choose
     (R : DenotGS E W .et) (sIdx : Nat)
     (g : Assignment E) (gs : SitAssignment W)
-    (hExU : existsUnique (fun x => R g gs x)) :
-    interpret (.unique R sIdx) g gs = some hExU.1.choose :=
-  interpret_unique_eq_some_of_existsUnique R sIdx g gs hExU.1.choose
-    hExU.1.choose_spec
-    (fun y hy => hExU.2 y _ hy hExU.1.choose_spec)
+    (hExU : ∃! x, R g gs x) :
+    interpret (.unique R sIdx) g gs = some hExU.choose :=
+  interpret_unique_eq_some_of_existsUnique R sIdx g gs hExU.choose
+    hExU.choose_spec.1 hExU.choose_spec.2
 
 /-- An anaphoric definite that returns a witness must return the indexed
     entity — it never picks anything else. -/
@@ -202,6 +199,17 @@ theorem interpret_anaphoric_isSome_iff
   by_cases h : R g gs (g d)
   · simp [h]
   · simp [h]
+
+/-- A possessive definite returns a referent iff its `π`-modified restrictor has
+    a unique satisfier — the typed-world form of the relational definite's
+    uniqueness presupposition (`Relational.iotaPresupposition`, = `∃!`). -/
+theorem interpret_possessive_isSome_iff_exists_unique
+    (R : DenotGS E W .et) (possessor : DenotGS E W .e) (rel : DenotGS E W .eet)
+    (g : Assignment E) (gs : SitAssignment W) :
+    (interpret (.possessive R possessor rel) g gs).isSome
+      ↔ ∃! x, R g gs x ∧ rel g gs (possessor g gs) x := by
+  rw [interpret_possessive]
+  exact russellIota_isSome_iff_exists_unique _
 
 /-- [patel-grosz-grosz-2017]'s "DEM = PER + index": the **strong** article
     (`anaphoric` at index `i`) and the **weak** article (`unique`) over a shared

--- a/Linglib/Semantics/Definiteness/Maximality.lean
+++ b/Linglib/Semantics/Definiteness/Maximality.lean
@@ -66,16 +66,19 @@ def Existence {E : Type*} (P : E → Prop) : Prop :=
 def Uniqueness {E : Type*} (P : E → Prop) : Prop :=
   ∀ x y : E, P x → P y → x = y
 
-/-- The classical Russellian condition: `∃!x. P x`. By construction the
-    conjunction of [coppock-beaver-2015]'s two components. -/
-def existsUnique {E : Type*} (P : E → Prop) : Prop :=
-  Existence P ∧ Uniqueness P
-
-/-- Russellian existence-and-uniqueness is exactly the conjunction of
-    Coppock–Beaver Existence and Uniqueness. By definition. -/
-theorem existsUnique_iff_existence_and_uniqueness
-    {E : Type*} (P : E → Prop) :
-    existsUnique P ↔ (Existence P ∧ Uniqueness P) := Iff.rfl
+/-- The Russellian condition `∃! x, P x` factors into Coppock–Beaver's two
+    components: `Existence` (asserted) and `Uniqueness` (presupposed). A genuine
+    iff, not `rfl` — mathlib's `∃!` bundles the components under one existential,
+    CB splits them. Uniqueness is mathlib `∃!` *everywhere* in this subsystem
+    (there is no separate `existsUnique` def); this theorem is the bridge to the
+    CB components, and `Relational.iotaPresupposition` is `∃!` by `abbrev`. -/
+theorem existsUnique_iff_existence_and_uniqueness {E : Type*} (P : E → Prop) :
+    (∃! x, P x) ↔ (Existence P ∧ Uniqueness P) := by
+  constructor
+  · rintro ⟨x, hx, huniq⟩
+    exact ⟨⟨x, hx⟩, fun a b ha hb => (huniq a ha).trans (huniq b hb).symm⟩
+  · rintro ⟨⟨x, hx⟩, huniq⟩
+    exact ⟨x, hx, fun y hy => huniq y x hy hx⟩
 
 /-- Existence and Uniqueness are logically independent. The empty predicate
     `λ _ => False` satisfies Uniqueness (vacuously) but not Existence —
@@ -92,17 +95,15 @@ theorem uniqueness_does_not_imply_existence {E : Type*} :
     is exactly one P-satisfier. Order-free version usable when no preorder is
     declared on `E`. -/
 noncomputable def russellIota {E : Type*} (P : E → Prop) : Option E :=
-  letI := Classical.dec (existsUnique P)
-  if h : existsUnique P then some h.1.choose else none
+  letI := Classical.dec (∃! x, P x)
+  if h : ∃! x, P x then some h.choose else none
 
-/-- `russellIota` returns `some` exactly when Russellian existence-and-
-    uniqueness holds. -/
-theorem russellIota_isSome_iff_existsUnique
-    {E : Type*} (P : E → Prop) :
-    (russellIota P).isSome ↔ existsUnique P := by
+/-- `russellIota` returns `some` exactly when mathlib's `∃!` holds. -/
+theorem russellIota_isSome_iff_exists_unique {E : Type*} (P : E → Prop) :
+    (russellIota P).isSome ↔ ∃! x, P x := by
   classical
   unfold russellIota
-  by_cases h : existsUnique P
+  by_cases h : ∃! x, P x
   · simp [h]
   · simp [h]
 
@@ -112,10 +113,10 @@ theorem russellIota_witness_satisfies
     (h : russellIota P = some e) : P e := by
   classical
   unfold russellIota at h
-  by_cases hexu : existsUnique P
+  by_cases hexu : ∃! x, P x
   · rw [dif_pos hexu] at h
-    have heq : hexu.1.choose = e := Option.some_inj.mp h
-    rw [← heq]; exact hexu.1.choose_spec
+    have heq : hexu.choose = e := Option.some_inj.mp h
+    rw [← heq]; exact hexu.choose_spec.1
   · rw [dif_neg hexu] at h; cases h
 
 /-- Two witnesses returned by `russellIota` (over the same predicate) must

--- a/Linglib/Semantics/Possessive/Denotation.lean
+++ b/Linglib/Semantics/Possessive/Denotation.lean
@@ -15,7 +15,7 @@ relation), inheriting the possessor's intrinsic presupposition. So:
 * the possessor's φ-features (when it is a pronoun) **ride along** to the whole
   possessive, by `applyTo_presup`;
 * the existence/uniqueness presupposition is **selector definedness**
-  (`russellIota_isSome_iff_existsUnique`), not a separate intrinsic presup.
+  (`russellIota_isSome_iff_exists_unique`), not a separate intrinsic presup.
 
 ## Main declarations
 
@@ -35,7 +35,7 @@ relation), inheriting the possessor's intrinsic presupposition. So:
 namespace Possessive
 
 open Semantics.Reference (NominalDenot)
-open Semantics.Definiteness (russellIota russellIota_isSome_iff_existsUnique existsUnique)
+open Semantics.Definiteness (russellIota)
 
 variable {Ctx : Type*} {W E : Type}
 

--- a/Linglib/Studies/CoppockBeaver2015.lean
+++ b/Linglib/Studies/CoppockBeaver2015.lean
@@ -102,17 +102,19 @@ theorem theSun_existence_and_uniqueness :
 
 /-- For `theSun`, the Russellian condition holds: `existsUnique` is by
     construction the conjunction of Existence and Uniqueness. -/
-theorem theSun_existsUnique : existsUnique theSun :=
-  theSun_existence_and_uniqueness
+theorem theSun_existsUnique : ∃! x, theSun x :=
+  (existsUnique_iff_existence_and_uniqueness _).mpr theSun_existence_and_uniqueness
 
 /-- For `kingOfFrance`, `existsUnique` fails — Existence is the missing
     conjunct. The factorization explains *which* component fails. -/
-theorem kingOfFrance_not_existsUnique : ¬ existsUnique kingOfFrance := by
+theorem kingOfFrance_not_existsUnique : ¬ ∃! x, kingOfFrance x := by
+  rw [existsUnique_iff_existence_and_uniqueness]
   rintro ⟨hExist, _⟩
   exact kingOfFrance_uniqueness_without_existence.2 hExist
 
 /-- For `planet`, `existsUnique` fails — Uniqueness is the missing conjunct. -/
-theorem planet_not_existsUnique : ¬ existsUnique planet := by
+theorem planet_not_existsUnique : ¬ ∃! x, planet x := by
+  rw [existsUnique_iff_existence_and_uniqueness]
   rintro ⟨_, hUniq⟩
   exact planet_existence_without_uniqueness.2 hUniq
 
@@ -127,11 +129,11 @@ def gs₀ : SitAssignment Unit := fun _ => ()
     interprets to `none` — the shared engine behind the Existence-failure
     and Uniqueness-failure diagnostics below. -/
 private theorem interpret_unique_const_none_of_not_existsUnique
-    (R : Denot Body Unit .et) (h : ¬ existsUnique R) :
+    (R : Denot Body Unit .et) (h : ¬ ∃! x, R x) :
     interpret (.unique (DenotGS.const R) 0) g₀ gs₀ = none := by
   rw [interpret_unique]
   have hns : ¬ (russellIota (fun x => (DenotGS.const R) g₀ gs₀ x)).isSome := by
-    rw [russellIota_isSome_iff_existsUnique]; exact h
+    rw [russellIota_isSome_iff_exists_unique]; exact h
   rcases hr : russellIota (fun x => (DenotGS.const R) g₀ gs₀ x) with _ | e
   · rfl
   · exact absurd (hr ▸ rfl) hns

--- a/Linglib/Studies/Hanink2021.lean
+++ b/Linglib/Studies/Hanink2021.lean
@@ -109,20 +109,18 @@ def gsLiving : SitAssignment Room := fun _ => Room.living
 /-- Restrictor uniqueness in the kitchen situation: only `tableKitchen`
     satisfies `tableAtSit0`. -/
 theorem tableAtSit0_existsUnique_kitchen :
-    existsUnique (E := Item) (fun x => tableAtSit0 g₀ gsKitchen x) := by
-  refine ⟨⟨Item.tableKitchen, trivial⟩, ?_⟩
-  intro x y hx hy
-  cases x <;> cases y <;>
-    simp_all [tableAtSit0, tableIn, interpSitPronoun, gsKitchen]
+    ∃! x : Item, tableAtSit0 g₀ gsKitchen x := by
+  refine ⟨Item.tableKitchen, trivial, ?_⟩
+  intro y hy
+  cases y <;> simp_all [tableAtSit0, tableIn, interpSitPronoun, gsKitchen]
 
 /-- Restrictor uniqueness in the living-room situation: only
     `tableLiving` satisfies `tableAtSit0`. -/
 theorem tableAtSit0_existsUnique_living :
-    existsUnique (E := Item) (fun x => tableAtSit0 g₀ gsLiving x) := by
-  refine ⟨⟨Item.tableLiving, trivial⟩, ?_⟩
-  intro x y hx hy
-  cases x <;> cases y <;>
-    simp_all [tableAtSit0, tableIn, interpSitPronoun, gsLiving]
+    ∃! x : Item, tableAtSit0 g₀ gsLiving x := by
+  refine ⟨Item.tableLiving, trivial, ?_⟩
+  intro y hy
+  cases y <;> simp_all [tableAtSit0, tableIn, interpSitPronoun, gsLiving]
 
 /-- Witness extraction for the kitchen case: the unique satisfier is
     `tableKitchen`. -/

--- a/Linglib/Studies/Schwarz2009.lean
+++ b/Linglib/Studies/Schwarz2009.lean
@@ -357,12 +357,13 @@ theorem weak_article_fails_on_multi :
     interpret (E := Student) (W := Unit) (.unique studentRestr 0) gAlice gs0 = none := by
   classical
   rw [interpret_unique]
-  have hExU : ¬ existsUnique (fun x : Student => studentRestr gAlice gs0 x) := by
+  have hExU : ¬ ∃! x : Student, studentRestr gAlice gs0 x := by
+    rw [existsUnique_iff_existence_and_uniqueness]
     rintro ⟨_, h⟩
     have : Student.alice = Student.bob := h .alice .bob trivial trivial
     cases this
   by_contra h
-  exact hExU ((russellIota_isSome_iff_existsUnique _).mp
+  exact hExU ((russellIota_isSome_iff_exists_unique _).mp
     (Option.ne_none_iff_isSome.mp h))
 
 /-- The strong article succeeds — it returns the discourse-indexed


### PR DESCRIPTION
PR3 of the definiteness-API consolidation — the uniqueness-predicate dedup (revised from a bridge to a true deduplication, per review).

`Maximality.existsUnique` was a second spelling of `∃!` (`Existence P ∧ Uniqueness P`) — keeping it plus a bridge lemma is the very anti-pattern this consolidation targets. So instead:

- **Delete** `Maximality.existsUnique`. Mathlib `∃!` is now the *sole* uniqueness predicate across the subsystem (matching `Relational.iotaPresupposition`, which is `∃!` by `abbrev`, and the possessive carrier side, which already used `∃!` via `existsUnique_possessee`).
- Keep the Coppock-Beaver **components** `Existence`/`Uniqueness` (genuine cited content: asserted vs presupposed); restate the factorization as a theorem *about* `∃!`: `existsUnique_iff_existence_and_uniqueness : (∃! x, P x) ↔ Existence P ∧ Uniqueness P`.
- Regate `russellIota` on `∃!` (via `Exists.choose`/`.choose_spec`); `russellIota_isSome_iff_exists_unique` is the one isSome lemma.
- Add `interpret_possessive_isSome_iff_exists_unique`; simplify the buried `denote_isSome_iff_iotaPresupposition` proof to 3 lines.
- Migrate consumers (CoppockBeaver2015, Hanink2021, Schwarz2009, Possessive/Denotation) to `∃!`.

Net: one uniqueness predicate (`∃!`) everywhere, no duplicate def, no bridge. Verified across the definiteness/possessive cone.