### PR TITLE
refactor(Core/Computability/Subregular): rename Defs to Boundary

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -309,7 +309,7 @@ import Linglib.Features.OntologicalCategory
 import Linglib.Features.Genericity
 import Linglib.Core.Data.List.Chain
 import Linglib.Core.Data.List.Factors
-import Linglib.Core.Computability.Subregular.Defs
+import Linglib.Core.Computability.Subregular.Boundary
 import Linglib.Core.Computability.Subregular.StrictlyLocal
 import Linglib.Core.Computability.Language
 import Linglib.Core.Computability.Subregular.Tier

--- a/Linglib/Core/Computability/Subregular/Boundary.lean
+++ b/Linglib/Core/Computability/Subregular/Boundary.lean
@@ -87,17 +87,4 @@ lemma isChain_boundary_two_iff (hR : IsBoundaryVacuous R) (ys : List α) :
 
 end IsBoundaryVacuous
 
-/-! ### Scan direction -/
-
-namespace Function
-
-/-- The orientation of a subregular transducer's scan: left-to-right or
-right-to-left. -/
-inductive Direction
-  | left
-  | right
-  deriving DecidableEq, Repr
-
-end Function
-
 end Subregular

--- a/Linglib/Core/Computability/Subregular/ForbiddenPairs.lean
+++ b/Linglib/Core/Computability/Subregular/ForbiddenPairs.lean
@@ -36,7 +36,7 @@ SL_1 substrate is in `Subregular/StrictlyLocal.lean` (the `k = 1` case).
 The single bridge theorem `mem_ofForbiddenPairs_lang_iff_filter_isChain`
 characterizes language membership as an `IsChain` check on the projected
 string. This is the chain-side payoff of the boundary-vacuity machinery
-in `Subregular/Defs.lean`. Phonological-constraint bridges
+in `Subregular/Boundary.lean`. Phonological-constraint bridges
 (`mkForbidPairsOnTier_zero_iff_in_lang`) layer on top in
 `Phonology/Subregular/`.
 -/

--- a/Linglib/Core/Computability/Subregular/Function/ISL.lean
+++ b/Linglib/Core/Computability/Subregular/Function/ISL.lean
@@ -6,7 +6,6 @@ Authors: Robert Hawkins
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Fintype.Sigma
 import Mathlib.Data.Fintype.Vector
-import Linglib.Core.Computability.Subregular.Defs
 import Linglib.Core.Computability.Subregular.Function.Subsequential
 
 /-!

--- a/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
@@ -5,7 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Set.Basic
-import Linglib.Core.Computability.Subregular.Defs
+import Linglib.Core.Computability.Subregular.Function.Subsequential
 
 /-!
 # Side-determinacy: myopia and unbounded circumambience

--- a/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
@@ -5,7 +5,6 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Fintype.Prod
-import Linglib.Core.Computability.Subregular.Defs
 
 /-!
 # Subsequential Functions and Finite-State Transducers
@@ -46,17 +45,16 @@ reversal: `f ∈ R-Subseq ↔ (List.reverse ∘ f ∘ List.reverse) ∈ L-Subseq
 
 namespace Subregular.Function
 
-/-! ## Direction of FST scan
+/-! ## Direction of FST scan -/
 
-`Direction` (left or right) controls whether an FST consumes its input
-head-first (left scan) or tail-first via `List.reverse` conjugation
-(right scan). The two scan modes give rise to distinct function classes
-isomorphic under reversal but not equal as subclasses of the regular
-functions over un-reversed strings.
-
-Re-exported from `Core/Direction.lean` so the classification predicates
-below can use `.left`/`.right` unqualified. -/
-
+/-- The orientation of an FST scan: `left` consumes input head-first, `right`
+tail-first (via `List.reverse` conjugation). The two scan modes give rise to
+distinct function classes — isomorphic under reversal but not equal as
+subclasses of the regular functions over un-reversed strings. -/
+inductive Direction
+  | left
+  | right
+  deriving DecidableEq, Repr
 
 /-- A **subsequential finite-state transducer** with state space `σ`,
 input alphabet `α`, output alphabet `β`. The scan is total deterministic

--- a/Linglib/Core/Computability/Subregular/StrictlyLocal.lean
+++ b/Linglib/Core/Computability/Subregular/StrictlyLocal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Computability.Language
-import Linglib.Core.Computability.Subregular.Defs
+import Linglib.Core.Computability.Subregular.Boundary
 import Linglib.Core.Data.List.Factors
 
 /-!

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -1,6 +1,5 @@
 import Mathlib.Data.Fintype.Option
 import Linglib.Phonology.Tier
-import Linglib.Core.Computability.Subregular.Defs
 import Linglib.Core.Computability.Subregular.Function.Subsequential
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 


### PR DESCRIPTION
Renames `Core/Computability/Subregular/Defs.lean` → `Boundary.lean` — the file holds boundary-augmentation substrate (`Augmented`, `boundary`, `IsBoundaryVacuous`), not a `Defs`/`Basic` pair, so `Defs` was a misnomer.

- Relocates the misfit `Direction` enum (FST scan orientation) to its conceptual home in `Function/Subsequential.lean`, fixing a stale `Core/Direction.lean` docstring reference. Same `Subregular.Function.Direction` name, so all consumers keep resolving.
- The `Function/` side now detaches from the boundary substrate entirely (it only ever used `Direction`).