### PR TITLE
refactor(Semantics): unify monster + Kaplan thesis via Stable relation

### DIFF
--- a/Linglib/Semantics/Context/Tower.lean
+++ b/Linglib/Semantics/Context/Tower.lean
@@ -226,6 +226,33 @@ theorem local_updates (ap : AccessPattern C R) (hd : ap.depth = .local)
   rw [← ContextTower.push_depth, ContextTower.contextAt_depth,
       ContextTower.push_innermost]
 
+/-- An access pattern is *stable* under a shift when pushing that shift onto any
+    tower leaves its resolution unchanged. This relation underlies both
+    Kaplan-compliance (`Reference/Kaplan.lean`: an expression stable under
+    *every* shift) and monsterhood (`Reference/Monsters.lean`: a shift that
+    destabilizes *some* expression) — the two are its ∀-over-shifts and
+    ∃-over-expressions projections. -/
+def Stable (ap : AccessPattern C R) (σ : ContextShift C) : Prop :=
+  ∀ t, ap.resolve (t.push σ) = ap.resolve t
+
+/-- Origin-depth access is stable under every shift — the access-pattern form
+    of `origin_stable`, and the sufficient condition for Kaplan-compliance. -/
+theorem Stable_of_depth_origin (ap : AccessPattern C R) (hd : ap.depth = .origin)
+    (σ : ContextShift C) : ap.Stable σ :=
+  fun t => origin_stable ap hd t σ
+
+/-- The canonical *innermost reader*: returns the innermost context verbatim
+    (`.local` depth, identity projection). It is the universal witness for
+    instability — a shift destabilizes some access pattern iff it destabilizes
+    this one, because a push only ever changes the innermost context — so
+    monsterhood is defined as its instability (`Reference/Monsters.lean`). -/
+def innermostReader (C : Type*) : AccessPattern C C := ⟨.local, id⟩
+
+@[simp] theorem innermostReader_resolve (t : ContextTower C) :
+    (innermostReader C).resolve t = t.innermost := by
+  simp only [innermostReader, resolve, DepthSpec.local_resolve,
+    ContextTower.contextAt_depth, id_eq]
+
 /-- Bridge to the substrate's `Intension` framework: an `AccessPattern`
     IS an `Intension (ContextTower C) R` via its `resolve` method. The
     substrate's `Intension`-based machinery (`Intensional.Intension.IsRigid`,

--- a/Linglib/Semantics/Reference/Kaplan.lean
+++ b/Linglib/Semantics/Reference/Kaplan.lean
@@ -253,26 +253,39 @@ theorem opActually_shift_invariant
 -- § Kaplan's Thesis (Tower Formulation)
 -- ════════════════════════════════════════════════════════════════
 
-/-- Kaplan's thesis as a tower property: an access pattern is Kaplan-compliant
-    iff its depth is `.origin`. This means it reads from the speech-act context
-    and is unaffected by any embedding operators. -/
+/-- Kaplan's thesis as a tower property: an access pattern is *Kaplan-compliant*
+    when it is stable under every embedding shift — pushing any operator leaves
+    its resolution unchanged. This is the ∀-over-operators projection of
+    `AccessPattern.Stable`, dual to monsterhood's ∃-over-operators projection
+    (`Reference/Monsters.lean`).
+
+    Reading from the origin (`depth =.origin`) is the canonical sufficient
+    condition (`isKaplanCompliant_of_depth_origin`): an origin-reading
+    expression sees the speech-act context regardless of embedding. -/
 def IsKaplanCompliant {C R : Type*} (ap : AccessPattern C R) : Prop :=
-  ap.depth = .origin
+  ∀ σ, ap.Stable σ
+
+/-- An origin-reading access pattern is Kaplan-compliant. -/
+theorem isKaplanCompliant_of_depth_origin {C R : Type*} (ap : AccessPattern C R)
+    (hd : ap.depth = .origin) : IsKaplanCompliant ap :=
+  fun σ => ap.Stable_of_depth_origin hd σ
 
 /-- All English pure indexicals are Kaplan-compliant: they all read from
     the origin (speech-act context).
 
-    This is the tower formulation of [kaplan-1989] §VIII: natural language
-    (English) operators cannot shift the context of utterance. In tower
-    terms, English indexicals have `depth =.origin`, so embedding (pushing
-    shifts) has no effect on their resolution. -/
+    This is the tower formulation of [kaplan-1989]'s anti-monster thesis:
+    natural language (English) operators cannot shift the context of utterance.
+    In tower terms, English indexicals have `depth =.origin`, so embedding
+    (pushing shifts) has no effect on their resolution. -/
 theorem kaplansThesisTower :
     IsKaplanCompliant (pronI_access (W' := W') (E' := E') (P' := P') (T' := T')) ∧
     IsKaplanCompliant (pronYou_access (W' := W') (E' := E') (P' := P') (T' := T')) ∧
     IsKaplanCompliant (opNow_access (W' := W') (E' := E') (P' := P') (T' := T')) ∧
     IsKaplanCompliant (opHere_access (W' := W') (E' := E') (P' := P') (T' := T')) ∧
     IsKaplanCompliant (opActually_access (W' := W') (E' := E') (P' := P') (T' := T')) :=
-  ⟨rfl, rfl, rfl, rfl, rfl⟩
+  ⟨isKaplanCompliant_of_depth_origin _ rfl, isKaplanCompliant_of_depth_origin _ rfl,
+   isKaplanCompliant_of_depth_origin _ rfl, isKaplanCompliant_of_depth_origin _ rfl,
+   isKaplanCompliant_of_depth_origin _ rfl⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § Resolution in Root Tower

--- a/Linglib/Semantics/Reference/Monsters.lean
+++ b/Linglib/Semantics/Reference/Monsters.lean
@@ -1,18 +1,20 @@
-import Linglib.Semantics.Intensional.Rigidity
 import Linglib.Semantics.Reference.Kaplan
 
 /-!
 # Kaplan's Anti-Monster Thesis (Tower Formulation)
 [anand-nevins-2004] [kaplan-1989] [schlenker-2003]
 
-[kaplan-1989] "Demonstratives" VIII: the claim that natural language
+[kaplan-1989]'s anti-monster thesis: the claim that natural language
 operators are *content operators* (shifting circumstances of evaluation)
 rather than *context operators* (shifting contexts of utterance).
 
-Under the tower analysis, a monster is a non-identity context shift:
-an embedding operator that pushes a shift where.apply c != c for some c.
-Kaplan's thesis for English says attitude verbs push identity shifts —
-they embed without changing the context of utterance.
+Under the tower analysis, a monster is a shift that destabilizes some
+expression — it changes what an access pattern resolves to (`IsTowerMonster`,
+the ∃-projection of `AccessPattern.Stable`; equivalently a non-identity
+shift). Kaplan's thesis for English says attitude verbs push identity shifts —
+they embed without changing the context of utterance — so English indexicals,
+which read from the origin, are stable under embedding (`IsKaplanCompliant`,
+the dual ∀-projection of `Stable` in `Reference/Kaplan.lean`).
 
 Cross-linguistic counterexamples
 are languages where attitude verbs push non-identity shifts (e.g.,
@@ -32,26 +34,47 @@ monster *predicate* and Kaplan's thesis, not the operator.
 namespace Semantics.Reference.Monsters
 
 open Semantics.Context
-open Intensional (Intension)
-open Intensional.Intension (IsRigid)
 
 -- ════════════════════════════════════════════════════════════════
 -- § Tower Monster
 -- ════════════════════════════════════════════════════════════════
 
-/-- A context shift is a tower monster iff it is non-identity: there exists
-    some context c where applying the shift produces a different context.
+/-- A context shift is a *tower monster* when it destabilizes the innermost
+    reader: pushing it changes what the canonical local access pattern
+    (`AccessPattern.innermostReader`) resolves to. This is the
+    ∃-over-expressions projection of `AccessPattern.Stable` — the innermost
+    reader is its universal witness, since a push only ever changes the
+    innermost context — dual to Kaplan-compliance's ∀-over-operators projection
+    (`IsKaplanCompliant`). Equivalently (`isTowerMonster_iff_exists`) the shift
+    moves some context: `∃ c, σ.apply c ≠ c`.
 
     Under the tower analysis, monsters are exactly the non-identity shifts.
     English attitude verbs push identity shifts (not monsters); Amharic
     attitude verbs push attitude shifts (monsters). -/
 def IsTowerMonster {C : Type*} (σ : ContextShift C) : Prop :=
-  ∃ (c : C), σ.apply c ≠ c
+  ¬ (AccessPattern.innermostReader C).Stable σ
+
+/-- A shift is a monster iff it moves some context: the pointwise
+    characterization recovering the direct form `∃ c, σ.apply c ≠ c`. -/
+theorem isTowerMonster_iff_exists {C : Type*} (σ : ContextShift C) :
+    IsTowerMonster σ ↔ ∃ c, σ.apply c ≠ c := by
+  simp only [IsTowerMonster, AccessPattern.Stable, not_forall,
+    AccessPattern.innermostReader_resolve, ContextTower.push_innermost]
+  constructor
+  · rintro ⟨t, ht⟩; exact ⟨t.innermost, ht⟩
+  · rintro ⟨c, hc⟩; exact ⟨ContextTower.root c, by simpa using hc⟩
+
+/-- Monsterhood depends only on the shift's action `apply`, not its label:
+    shifts with equal `apply` are monsters together. -/
+theorem isTowerMonster_congr {C : Type*} {σ τ : ContextShift C}
+    (h : σ.apply = τ.apply) : IsTowerMonster σ ↔ IsTowerMonster τ := by
+  simp only [isTowerMonster_iff_exists, h]
 
 /-- The identity shift is not a monster. -/
 theorem identityShift_not_monster {W : Type*} {E : Type*} {P : Type*} {T : Type*} :
     ¬ IsTowerMonster (identityShift (W := W) (E := E) (P := P) (T := T)) := by
-  intro ⟨c, h⟩
+  rw [isTowerMonster_iff_exists]
+  rintro ⟨c, h⟩
   exact h (identityShift_apply c)
 
 /-- An attitude shift is a monster when the holder differs from some
@@ -60,12 +83,9 @@ theorem attitudeShift_is_monster {W : Type*} {E : Type*} {P : Type*} {T : Type*}
     (holder : E) (attWorld : W) (c : KContext W E P T)
     (hAgent : c.agent ≠ holder) :
     IsTowerMonster (attitudeShift (P := P) (T := T) holder attWorld) := by
-  refine ⟨c, λ h => ?_⟩
-  have : (attitudeShift (P := P) (T := T) holder attWorld).apply c = c := h
-  have hagent : ((attitudeShift (P := P) (T := T) holder attWorld).apply c).agent = c.agent :=
-    congrArg KContext.agent this
-  simp only [attitudeShift] at hagent
-  exact hAgent hagent.symm
+  rw [isTowerMonster_iff_exists]
+  refine ⟨c, fun h => hAgent ?_⟩
+  simpa using (congrArg KContext.agent h).symm
 
 -- ════════════════════════════════════════════════════════════════
 -- § Kaplan's Thesis (Tower Formulation)

--- a/Linglib/Studies/SchlenkerEtAl2026.lean
+++ b/Linglib/Studies/SchlenkerEtAl2026.lean
@@ -44,7 +44,7 @@ is on a 7-point scale (7 = best, 1 = worst). Classifier direction
 namespace SchlenkerEtAl2026
 
 open Semantics.Iconic
-open Semantics.Reference.Monsters (IsTowerMonster)
+open Semantics.Reference.Monsters (IsTowerMonster attitudeShift_is_monster isTowerMonster_congr)
 open Semantics.Context
 open ASL (SigningSpace)
 
@@ -177,17 +177,18 @@ def roleShiftCtx (character : E) (rsWorld : W) :
   label := .roleShift
 
 /-- Role Shift is a monster (non-identity context shift), connecting
-    to the Kaplan/Schlenker monster debate in `Monsters.lean`. -/
+    to the Kaplan/Schlenker monster debate in `Monsters.lean`.
+
+    Derived directly from `attitudeShift_is_monster`: `roleShiftCtx` shares
+    `attitudeShift`'s `apply`, and monsterhood depends only on `apply`. -/
 theorem roleShift_is_monster
     (character : E) (rsWorld : W)
     (c : KContext W E P T)
     (hAgent : c.agent ≠ character) :
-    IsTowerMonster (roleShiftCtx (P := P) (T := T) character rsWorld) := by
-  refine ⟨c, fun h => ?_⟩
-  have : ((roleShiftCtx character rsWorld).apply c).agent = c.agent :=
-    congrArg KContext.agent h
-  simp only [roleShiftCtx, attitudeShift] at this
-  exact hAgent this.symm
+    IsTowerMonster (roleShiftCtx (P := P) (T := T) character rsWorld) :=
+  (isTowerMonster_congr (σ := roleShiftCtx (P := P) (T := T) character rsWorld)
+      (τ := attitudeShift (P := P) (T := T) character rsWorld) rfl).mpr
+    (attitudeShift_is_monster character rsWorld c hAgent)
 
 /-- Under Role Shift, π* resolves to the character's viewpoint. -/
 theorem contextBound_under_roleShift


### PR DESCRIPTION
Depends on #614 (stacked; retarget to main once #614 merges).

The two tower formulations of Kaplan's thesis — `IsKaplanCompliant` (`Reference/Kaplan.lean`, was `depth = .origin`) and monsterhood (`Reference/Monsters.lean`, was `∃ c, σ.apply c ≠ c`) — were unconnected, each stated as a syntactic proxy. Ground both in one relation instead of bridging them.

- New `AccessPattern.Stable ap σ := ∀ t, ap.resolve (t.push σ) = ap.resolve t` (`Context/Tower.lean`), with `innermostReader` as its universal instability witness.
- `IsKaplanCompliant ap := ∀ σ, ap.Stable σ` (∀-over-operators projection); `isKaplanCompliant_of_depth_origin` is the sufficient condition (= `origin_stable`).
- `IsTowerMonster σ := ¬ (innermostReader _).Stable σ` (∃-over-expressions projection), with `isTowerMonster_iff_exists` recovering `∃ c, σ.apply c ≠ c`.
- `isTowerMonster_congr` (monsterhood is label-independent) collapses `SchlenkerEtAl2026.roleShift_is_monster` to a one-liner deriving from `attitudeShift_is_monster`.
- Drops a dead `Rigidity` import + unverified `§VIII` location cites.