### PR TITLE
refactor(Core/Computability/Subregular): rtake API + Definite polish

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -308,6 +308,7 @@ import Linglib.Features.Prominence
 import Linglib.Features.OntologicalCategory
 import Linglib.Features.Genericity
 import Linglib.Core.Data.List.Chain
+import Linglib.Core.Data.List.DropRight
 import Linglib.Core.Data.List.Factors
 import Linglib.Core.Computability.Subregular.Boundary
 import Linglib.Core.Computability.Subregular.StrictlyLocal

--- a/Linglib/Core/Computability/Subregular/Definite.lean
+++ b/Linglib/Core/Computability/Subregular/Definite.lean
@@ -4,40 +4,40 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Computability.Language
+import Linglib.Core.Data.List.DropRight
+import Mathlib.Data.Fintype.Order
 import Mathlib.Data.Set.Finite.Lemmas
 import Mathlib.Data.Set.Finite.List
-import Mathlib.Data.Fintype.Order
 
 /-!
-# Definite Languages (D_k, RD_k, ℒℐ_k, 𝒩)
+# Definite languages
 
-A language `L` is **`k`-definite** when membership is determined by the last `k`
-symbols of the input [rogers-pullum-2011] [lambert-2022]: any two strings agreeing
-on their length-`k` suffix are L-equivalent. Dually, **reverse `k`-definite** (RD_k)
-looks at the length-`k` *prefix*.
+A language `L` is **`k`-definite** when membership is decided by the last `k`
+symbols of a word [rogers-pullum-2011] [lambert-2022]: any two words sharing their
+length-`k` suffix are L-equivalent. **Reverse `k`-definite** (`RD_k`) is the dual
+through the length-`k` prefix, and **generalized `k`-definite** (Lambert's `ℒℐ_k`)
+tests prefix and suffix jointly [lambert-2026].
 
-## The foundation: membership factors through an edge projection
+Each class is `Language.InvariantUnder` for the matching edge projection
+`Edge.takeAt`, hence `Function.FactorsThrough (· ∈ L)` for that projection: the
+family inherits the shared closure API (e.g. `InvariantUnder.compl`) for free, with
+no grammar needed.
 
-The deepest characterisation is **invariance**: `L` is `k`-definite iff membership
-factors through the length-`k` suffix map — `Language.InvariantUnder (Edge.right.takeAt k)`.
-The whole family is read off from `InvariantUnder`:
+## Main definitions
 
-* `IsDefinite k` = invariant under the right (suffix) projection,
-* `IsReverseDefinite k` = invariant under the left (prefix) projection,
-* `IsGeneralizedDefinite k` (Lambert's ℒℐ_k) = invariant under the joint
-  (prefix, suffix) projection.
+* `Subregular.Edge` and `Subregular.Edge.takeAt` — a string edge and its length-`k`
+  substring (`right` = suffix, `left` = prefix).
+* `Language.IsDefinite`, `Language.IsReverseDefinite`, `Language.IsGeneralizedDefinite`
+  — invariance under the suffix, prefix, and joint edge projections.
+* `Language.IsFiniteOrCofinite` — Lambert's `𝒩`: `L` or its complement is finite.
 
-No grammar is needed: `Function.factorsThrough_iff` already supplies the witness
-`∃ e, (· ∈ L) = e ∘ f` — the `e` is precisely the permitted-suffix predicate.
+## Main theorems
 
-## The headline: `𝒩 = 𝒟 ∩ 𝒦`
-
-`IsFiniteOrCofinite` (Lambert's 𝒩) is the classical co/finite class. Over a finite
-alphabet it equals "`k`-definite for some `k` **and** reverse-`k'`-definite for some
-`k'`" — the language-level half of Pin's `𝒩 = 𝒟 ∩ 𝒦` theorem
-(`isFiniteOrCofinite_iff_exists_isDefinite_and_isReverseDefinite`). The algebraic
-counterpart, via Eilenberg's variety theorem, is developed separately; this file is
-pure list combinatorics.
+* `Language.IsDefinite.toIsGeneralizedDefinite` and
+  `Language.IsReverseDefinite.toIsGeneralizedDefinite` — `D_k, RD_k ⊆ ℒℐ_k`.
+* `Language.isFiniteOrCofinite_iff_exists_isDefinite_and_isReverseDefinite` — over a
+  finite alphabet, `𝒩 = 𝒟 ∩ 𝒦` [pin-mfa]: a language is finite-or-cofinite iff it
+  is definite and reverse-definite.
 -/
 
 namespace Subregular
@@ -53,31 +53,30 @@ inductive Edge | left | right
 
 namespace Edge
 
-/-- Take the length-`k` substring at this edge of `xs`. `right` returns the last
-`k` symbols; `left` the first `k`. Strings shorter than `k` are returned in full. -/
-def takeAt (e : Edge) (k : ℕ) (xs : List α) : List α :=
+variable (e : Edge) (k : ℕ) (xs : List α)
+
+/-- Take the length-`k` substring at this edge of `xs`: `left` is the length-`k`
+prefix `List.take`, `right` the length-`k` suffix `List.rtake`. Strings shorter
+than `k` are returned in full. -/
+def takeAt : List α :=
   match e with
   | .left  => xs.take k
-  | .right => xs.drop (xs.length - k)
+  | .right => xs.rtake k
 
-@[simp] lemma left_takeAt (k : ℕ) (xs : List α) : Edge.left.takeAt k xs = xs.take k := rfl
+@[simp] lemma takeAt_left : Edge.left.takeAt k xs = xs.take k := rfl
 
-@[simp] lemma right_takeAt (k : ℕ) (xs : List α) :
-    Edge.right.takeAt k xs = xs.drop (xs.length - k) := rfl
+@[simp] lemma takeAt_right : Edge.right.takeAt k xs = xs.rtake k := rfl
 
 /-- An edge substring has length `min k xs.length`. -/
-lemma length_takeAt (e : Edge) (k : ℕ) (xs : List α) :
-    (e.takeAt k xs).length = min k xs.length := by
-  cases e with
-  | left => simpa [takeAt] using (List.length_take k xs)
-  | right => simp only [takeAt, List.length_drop]; omega
+lemma length_takeAt : (e.takeAt k xs).length = min k xs.length := by
+  cases e <;> simp
 
 /-- For a short string the edge substring is the whole string. -/
-lemma takeAt_of_length_le (e : Edge) {k : ℕ} {xs : List α} (h : xs.length ≤ k) :
+lemma takeAt_of_length_le {k : ℕ} {xs : List α} (h : xs.length ≤ k) :
     e.takeAt k xs = xs := by
   cases e with
   | left => exact List.take_of_length_le h
-  | right => simp only [takeAt]; rw [show xs.length - k = 0 by omega, List.drop_zero]
+  | right => exact List.rtake_of_length_le h
 
 end Edge
 
@@ -86,33 +85,21 @@ end Edge
 A long word can be bridged to one sharing its right `k`-suffix and a prescribed
 left `k'`-prefix; these are the combinatorial core of `𝒩 = 𝒟 ∩ 𝒦`. -/
 
-/-- Bridge two long words via `w' = w₂.take k' ++ w₁.drop (w₁.length - k)`: it shares
-`w₁`'s length-`k` suffix. -/
+/-- Bridge two long words via `w' = w₂.take k' ++ w₁.rtake k`: it shares `w₁`'s
+length-`k` suffix (the tail-take absorbs the prepended prefix). -/
 private lemma takeAt_right_eq_of_bridge {k k' : ℕ} {w₁ w₂ : List α}
-    (hw₁ : k ≤ w₁.length) (hw₂ : k' ≤ w₂.length) :
-    Edge.right.takeAt k (w₂.take k' ++ w₁.drop (w₁.length - k)) =
-    Edge.right.takeAt k w₁ := by
-  show (w₂.take k' ++ w₁.drop (w₁.length - k)).drop
-        ((w₂.take k' ++ w₁.drop (w₁.length - k)).length - k) =
-       w₁.drop (w₁.length - k)
-  have h_take_len : (w₂.take k').length = k' := by rw [List.length_take]; omega
-  have h_drop_len : (w₁.drop (w₁.length - k)).length = k := by rw [List.length_drop]; omega
-  have h_total : (w₂.take k' ++ w₁.drop (w₁.length - k)).length = k' + k := by
-    rw [List.length_append, h_take_len, h_drop_len]
-  have hlen_diff :
-      (w₂.take k' ++ w₁.drop (w₁.length - k)).length - k = k' := by rw [h_total]; omega
-  rw [hlen_diff]
-  exact List.drop_left' h_take_len
+    (hw₁ : k ≤ w₁.length) (_hw₂ : k' ≤ w₂.length) :
+    Edge.right.takeAt k (w₂.take k' ++ w₁.rtake k) = Edge.right.takeAt k w₁ := by
+  have hk : k ≤ (w₁.rtake k).length := by rw [List.length_rtake]; omega
+  rw [Edge.takeAt_right, Edge.takeAt_right, List.rtake_append_of_le_length _ _ hk,
+    List.rtake_of_length_le (by rw [List.length_rtake]; omega)]
 
 /-- The same bridge shares `w₂`'s length-`k'` prefix. -/
 private lemma takeAt_left_eq_of_bridge {k k' : ℕ} {w₁ w₂ : List α}
     (_hw₁ : k ≤ w₁.length) (hw₂ : k' ≤ w₂.length) :
-    Edge.left.takeAt k' (w₂.take k' ++ w₁.drop (w₁.length - k)) =
-    Edge.left.takeAt k' w₂ := by
-  show (w₂.take k' ++ w₁.drop (w₁.length - k)).take k' = w₂.take k'
-  have h_take_len : (w₂.take k').length = k' := by rw [List.length_take]; omega
-  rw [List.take_append_of_le_length (by rw [h_take_len]), List.take_take]
-  congr 1; omega
+    Edge.left.takeAt k' (w₂.take k' ++ w₁.rtake k) = Edge.left.takeAt k' w₂ := by
+  rw [Edge.takeAt_left, Edge.takeAt_left,
+    List.take_append_of_le_length (by rw [List.length_take]; omega), List.take_take, min_self]
 
 end Subregular
 
@@ -180,10 +167,27 @@ theorem IsReverseDefinite.toIsGeneralizedDefinite {k : ℕ} {L : Language α}
 
 /-! ### `𝒩 = 𝒟 ∩ 𝒦` -/
 
-/-- A bounded language is `(N+1)`-definite at either edge: words longer than `N` are
-out, and shorter words are their own length-`(N+1)` edge substring, so that substring
-determines membership. -/
-private theorem isDefinite_of_bounded_aux {L : Language α} {N : ℕ} (e : Edge)
+/-- A language whose membership is constant off a finite set `s` is finite-or-cofinite:
+either some word outside `s` lies in `L` (forcing `Lᶜ ⊆ s`) or none does (forcing
+`L ⊆ s`). The reusable engine behind the reverse direction of `𝒩 = 𝒟 ∩ 𝒦`. -/
+theorem isFiniteOrCofinite_of_eventually_constant {L : Language α} {s : Set (List α)}
+    (hs : s.Finite) (h : ∀ a ∈ sᶜ, ∀ b ∈ sᶜ, (a ∈ L ↔ b ∈ L)) : L.IsFiniteOrCofinite := by
+  by_cases h_witness : ∃ w₀ ∈ sᶜ, w₀ ∈ L
+  · obtain ⟨w₀, hw₀_s, hw₀_L⟩ := h_witness
+    refine Or.inr (hs.subset ?_)
+    intro w hwLc
+    by_contra hws
+    exact hwLc ((h w hws w₀ hw₀_s).mpr hw₀_L)
+  · simp only [not_exists, not_and] at h_witness
+    refine Or.inl (hs.subset ?_)
+    intro w hwL
+    by_contra hws
+    exact h_witness w hws hwL
+
+/-- A bounded language is invariant under the length-`(N+1)` edge projection: words
+longer than `N` are out, and shorter words are their own length-`(N+1)` edge substring,
+so that substring determines membership. -/
+private lemma invariantUnder_takeAt_of_bounded {L : Language α} {N : ℕ} (e : Edge)
     (h_bound : ∀ w ∈ L, w.length ≤ N) : L.InvariantUnder (e.takeAt (N + 1)) := by
   refine InvariantUnder.mk fun a b hab => ?_
   have hlen : min (N + 1) a.length = min (N + 1) b.length := by
@@ -196,18 +200,18 @@ private theorem isDefinite_of_bounded_aux {L : Language α} {N : ℕ} (e : Edge)
   · have hb : ¬ b.length ≤ N := by omega
     exact ⟨fun h => absurd (h_bound a h) ha, fun h => absurd (h_bound b h) hb⟩
 
-/-- A co-bounded language (complement bounded) is `(N+1)`-definite: invariance is
-closed under complement, so this is `isDefinite_of_bounded_aux` applied to `Lᶜ`. -/
-private theorem isDefinite_of_cobounded_aux {L : Language α} {N : ℕ} (e : Edge)
+/-- A co-bounded language (complement bounded) is invariant under the length-`(N+1)`
+edge projection: invariance is closed under complement, so this is
+`invariantUnder_takeAt_of_bounded` applied to `Lᶜ`. -/
+private lemma invariantUnder_takeAt_of_cobounded {L : Language α} {N : ℕ} (e : Edge)
     (h_bound : ∀ w ∈ Lᶜ, w.length ≤ N) : L.InvariantUnder (e.takeAt (N + 1)) := by
-  simpa using (isDefinite_of_bounded_aux e h_bound).compl
+  simpa using (invariantUnder_takeAt_of_bounded e h_bound).compl
 
 /-- A finite set of words has a length bound. -/
-private theorem exists_length_bound_of_finite {S : Set (List α)}
-    (h : S.Finite) : ∃ N, ∀ w ∈ S, w.length ≤ N := by
-  classical
-  obtain ⟨N, hN⟩ := (Set.Finite.image (·.length) h).exists_le
-  exact ⟨N, fun w hw => hN _ ⟨w, hw, rfl⟩⟩
+private lemma exists_length_bound_of_finite {S : Set (List α)} (h : S.Finite) :
+    ∃ N, ∀ w ∈ S, w.length ≤ N :=
+  let ⟨N, hN⟩ := (h.image (·.length)).exists_le
+  ⟨N, fun w hw => hN _ ⟨w, hw, rfl⟩⟩
 
 /-- **Forward direction of `𝒩 = 𝒟 ∩ 𝒦`**: a finite-or-cofinite language is both
 `k`-definite and reverse-`k'`-definite for some `k`, `k'`. -/
@@ -216,11 +220,11 @@ theorem IsFiniteOrCofinite.exists_isDefinite_and_isReverseDefinite
     (∃ k, L.IsDefinite k) ∧ (∃ k', L.IsReverseDefinite k') := by
   rcases h with h | h
   · obtain ⟨N, hN⟩ := exists_length_bound_of_finite h
-    exact ⟨⟨N + 1, isDefinite_of_bounded_aux .right hN⟩,
-           ⟨N + 1, isDefinite_of_bounded_aux .left hN⟩⟩
+    exact ⟨⟨N + 1, invariantUnder_takeAt_of_bounded .right hN⟩,
+           ⟨N + 1, invariantUnder_takeAt_of_bounded .left hN⟩⟩
   · obtain ⟨N, hN⟩ := exists_length_bound_of_finite h
-    exact ⟨⟨N + 1, isDefinite_of_cobounded_aux .right hN⟩,
-           ⟨N + 1, isDefinite_of_cobounded_aux .left hN⟩⟩
+    exact ⟨⟨N + 1, invariantUnder_takeAt_of_cobounded .right hN⟩,
+           ⟨N + 1, invariantUnder_takeAt_of_cobounded .left hN⟩⟩
 
 /-- **Reverse direction of `𝒩 = 𝒟 ∩ 𝒦` (finite alphabet)**: if `L` is both
 `k`-definite and reverse-`k'`-definite, it is finite-or-cofinite. For words of
@@ -230,38 +234,13 @@ theorem isFiniteOrCofinite_of_isDefinite_and_isReverseDefinite [Finite α]
     {L : Language α}
     (h : (∃ k, L.IsDefinite k) ∧ (∃ k', L.IsReverseDefinite k')) :
     L.IsFiniteOrCofinite := by
-  classical
   obtain ⟨⟨k, hD⟩, ⟨k', hR⟩⟩ := h
-  have constancy : ∀ w₁ w₂ : List α,
-      k + k' ≤ w₁.length → k + k' ≤ w₂.length → (w₁ ∈ L ↔ w₂ ∈ L) := by
-    intro w₁ w₂ hw₁ hw₂
-    set w' := w₂.take k' ++ w₁.drop (w₁.length - k) with hw'_def
-    have hk_le_w₁ : k ≤ w₁.length := by omega
-    have hk'_le_w₂ : k' ≤ w₂.length := by omega
-    have hw₁_iff_w' : w₁ ∈ L ↔ w' ∈ L :=
-      hD.iff (takeAt_right_eq_of_bridge hk_le_w₁ hk'_le_w₂).symm
-    have hw'_iff_w₂ : w' ∈ L ↔ w₂ ∈ L :=
-      hR.iff (takeAt_left_eq_of_bridge hk_le_w₁ hk'_le_w₂)
-    exact hw₁_iff_w'.trans hw'_iff_w₂
-  have h_short_finite : Set.Finite {w : List α | w.length < k + k'} :=
-    List.finite_length_lt α (k + k')
-  by_cases h_witness : ∃ w₀, k + k' ≤ w₀.length ∧ w₀ ∈ L
-  · right
-    obtain ⟨w₀, hw₀_len, hw₀_L⟩ := h_witness
-    apply Set.Finite.subset h_short_finite
-    intro w hwLc
-    show w.length < k + k'
-    by_contra hge
-    push_neg at hge
-    exact hwLc ((constancy w w₀ hge hw₀_len).mpr hw₀_L)
-  · left
-    push_neg at h_witness
-    apply Set.Finite.subset h_short_finite
-    intro w hwL
-    show w.length < k + k'
-    by_contra hge
-    push_neg at hge
-    exact h_witness w hge hwL
+  refine isFiniteOrCofinite_of_eventually_constant (List.finite_length_lt α (k + k')) ?_
+  intro w₁ hw₁ w₂ hw₂
+  have hk : k ≤ w₁.length := by rw [Set.mem_compl_iff, Set.mem_setOf_eq, not_lt] at hw₁; omega
+  have hk' : k' ≤ w₂.length := by rw [Set.mem_compl_iff, Set.mem_setOf_eq, not_lt] at hw₂; omega
+  exact (hD.iff (takeAt_right_eq_of_bridge hk hk').symm).trans
+    (hR.iff (takeAt_left_eq_of_bridge hk hk'))
 
 /-- **Pin's `𝒩 = 𝒟 ∩ 𝒦` (finite alphabet)**: a language over a finite alphabet is
 finite-or-cofinite iff it is `k`-definite for some `k` and reverse-`k'`-definite for

--- a/Linglib/Core/Computability/SyntacticMonoid/Equations.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid/Equations.lean
@@ -6,6 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Core.Computability.Language
 import Linglib.Core.Computability.SyntacticMonoid
 import Linglib.Core.Computability.Subregular.Definite
+import Linglib.Core.Data.List.DropRight
 
 /-!
 # Equational characterizations of subregular language classes
@@ -139,37 +140,13 @@ variable {α : Type*}
 -- §1. Helper lemmas on `Edge.right.takeAt`
 -- ============================================================================
 
-/-- The right-`k`-suffix of `x ++ rest` equals the right-`k`-suffix
-of `rest` whenever `rest.length ≥ k`. -/
+/-- The right-`k`-suffix of `x ++ rest` equals the right-`k`-suffix of `rest`
+whenever `rest.length ≥ k` — the `Edge.takeAt` view of
+`List.rtake_append_of_le_length`. -/
 lemma takeAt_right_append_left_absorb {α : Type*}
     (x rest : List α) {k : ℕ} (h : k ≤ rest.length) :
-    Edge.right.takeAt k (x ++ rest) = Edge.right.takeAt k rest := by
-  show (x ++ rest).drop ((x ++ rest).length - k) =
-       rest.drop (rest.length - k)
-  rw [List.length_append,
-      show x.length + rest.length - k = x.length + (rest.length - k) by omega,
-      List.drop_length_add_append]
-
-/-- When `xs.length ≤ k`, the right-`k`-suffix of `xs` is `xs` itself. -/
-private lemma takeAt_right_of_short {α : Type*} {k : ℕ} {xs : List α}
-    (h : xs.length ≤ k) : Edge.right.takeAt k xs = xs := by
-  show xs.drop (xs.length - k) = xs
-  have : xs.length - k = 0 := by omega
-  rw [this, List.drop_zero]
-
-/-- When `xs.length ≥ k`, the right-`k`-suffix of `xs` has length exactly `k`. -/
-private lemma takeAt_right_length_of_long {α : Type*} {k : ℕ} {xs : List α}
-    (h : k ≤ xs.length) : (Edge.right.takeAt k xs).length = k := by
-  show (xs.drop (xs.length - k)).length = k
-  rw [List.length_drop]; omega
-
-/-- A list `xs` of length `≥ k` decomposes as
-`xs.take (xs.length - k) ++ Edge.right.takeAt k xs`. -/
-private lemma decompose_at_right_takeAt {α : Type*} {k : ℕ} {xs : List α}
-    (_h : k ≤ xs.length) :
-    xs = xs.take (xs.length - k) ++ Edge.right.takeAt k xs := by
-  show xs = xs.take (xs.length - k) ++ xs.drop (xs.length - k)
-  exact (List.take_append_drop _ _).symm
+    Edge.right.takeAt k (x ++ rest) = Edge.right.takeAt k rest :=
+  List.rtake_append_of_le_length x rest h
 
 -- ============================================================================
 -- §2. Lifting the equation to `SyntacticEquiv`
@@ -258,14 +235,16 @@ theorem isDefinite_of_satisfies_kDefiniteEquation
   have key : ∀ w : List α, w ∈ L ↔ Edge.right.takeAt k w ∈ L := by
     intro w
     by_cases hw : w.length ≤ k
-    · rw [takeAt_right_of_short hw]
+    · rw [Edge.takeAt_right, List.rtake_of_length_le hw]
     · push_neg at hw
-      have hlen : (Edge.right.takeAt k w).length = k :=
-        takeAt_right_length_of_long (le_of_lt hw)
+      have hlen : (Edge.right.takeAt k w).length = k := by
+        rw [Edge.takeAt_right, List.length_rtake]; omega
       have hequiv : SyntacticEquiv L w (Edge.right.takeAt k w) := by
         have base := syntacticEquiv_of_kDefiniteEquation h
           (w.take (w.length - k)) (Edge.right.takeAt k w) hlen
-        rwa [← decompose_at_right_takeAt (le_of_lt hw)] at base
+        have decomp : w = w.take (w.length - k) ++ Edge.right.takeAt k w :=
+          (List.rdrop_append_rtake w k).symm
+        rwa [← decomp] at base
       exact mem_iff_of_syntacticEquiv hequiv
   exact Language.invariantUnder_iff.mpr fun a b hab => by rw [key a, key b, hab]
 

--- a/Linglib/Core/Data/List/DropRight.lean
+++ b/Linglib/Core/Data/List/DropRight.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.List.DropRight
+
+/-!
+# Length, saturation, and decomposition for `List.rtake`
+
+A handful of facts about `List.rtake` (take from the tail) and `List.rdrop`
+(drop from the tail) that mathlib's `Mathlib/Data/List/DropRight.lean` defines but
+leaves without an API: the length of a tail-take, when it saturates to the whole
+list, how it absorbs a left append, and the `rdrop`/`rtake` decomposition. Each is
+the tail mirror of a front-end `take` lemma and is proved by reducing to it through
+`List.rtake_eq_reverse_take_reverse` — reverse, then `take`. These flesh out an
+under-developed corner of mathlib and are candidates for
+`Mathlib/Data/List/DropRight.lean`.
+
+## Main results
+
+* `List.length_rtake` — `(l.rtake n).length = min n l.length`.
+* `List.rtake_of_length_le` — a short list is its own tail-take.
+* `List.rtake_append_of_le_length` — a tail-take long enough to fit in the right
+  summand ignores the left one.
+* `List.rdrop_append_rtake` — `l.rdrop n ++ l.rtake n = l`, the tail analog of
+  `List.take_append_drop`.
+-/
+
+namespace List
+
+variable {α : Type*}
+
+/-- A tail-take has length `min n l.length` — the tail analog of `List.length_take`. -/
+@[simp] theorem length_rtake (l : List α) (n : ℕ) :
+    (l.rtake n).length = min n l.length := by
+  simp [rtake_eq_reverse_take_reverse]
+
+/-- A list no longer than `n` is its own tail-take — the tail analog of
+`List.take_of_length_le`. -/
+theorem rtake_of_length_le {l : List α} {n : ℕ} (h : l.length ≤ n) : l.rtake n = l := by
+  rw [rtake_eq_reverse_take_reverse, take_of_length_le (by rwa [length_reverse]),
+    reverse_reverse]
+
+/-- A tail-take that fits inside the right summand ignores the left one — the tail
+analog of `List.take_append_of_le_length`. -/
+theorem rtake_append_of_le_length {n : ℕ} (l₁ l₂ : List α) (h : n ≤ l₂.length) :
+    (l₁ ++ l₂).rtake n = l₂.rtake n := by
+  rw [rtake_eq_reverse_take_reverse, reverse_append,
+    take_append_of_le_length (by rwa [length_reverse]), ← rtake_eq_reverse_take_reverse]
+
+/-- Splitting a list at its last `n` symbols — the tail analog of
+`List.take_append_drop`. -/
+@[simp] theorem rdrop_append_rtake (l : List α) (n : ℕ) : l.rdrop n ++ l.rtake n = l := by
+  rw [rdrop_eq_reverse_drop_reverse, rtake_eq_reverse_take_reverse, ← reverse_append,
+    take_append_drop, reverse_reverse]
+
+end List

--- a/Linglib/Studies/Lambert2026.lean
+++ b/Linglib/Studies/Lambert2026.lean
@@ -226,17 +226,11 @@ def tierEndsWithLang (T : UyghurSeg → Bool) (x : UyghurSeg) :
 Helper for `tierEmptyLang_isTierBased`. -/
 private lemma takeAt_right_one_eq_nil_iff (xs : List UyghurSeg) :
     Edge.right.takeAt 1 xs = [] ↔ xs = [] := by
-  cases xs with
-  | nil => simp [Edge.takeAt]
-  | cons a as =>
-    simp only [Edge.takeAt, List.length_cons, Nat.add_sub_cancel]
-    constructor
-    · intro h
-      have : ((a :: as).drop as.length).length = 1 := by
-        rw [List.length_drop]; simp
-      rw [h] at this
-      simp at this
-    · intro h; exact absurd h (List.cons_ne_nil _ _)
+  rw [Edge.takeAt_right]
+  refine ⟨fun h => ?_, fun h => by rw [h]; simp⟩
+  have hlen := List.length_rtake xs 1
+  rw [h, List.length_nil] at hlen
+  exact List.eq_nil_of_length_eq_zero (by omega)
 
 /-- `tierEmptyLang T` is in `IsTierBased (IsDefinite 1)`. The base
 1-definite language is the singleton `{[]}` (only `[]` has right-1-


### PR DESCRIPTION
Mathlib-quality pass on `Subregular/Definite.lean`, grounding its length-`k` suffix on `List.rtake` instead of a hand-rolled `drop (length - k)`.

- New `Core/Data/List/DropRight.lean`: `length_rtake`, `rtake_of_length_le`, `rtake_append_of_le_length`, `rdrop_append_rtake` — the `rtake`/`rdrop` facts mathlib's `DropRight.lean` lacks, each proved by flipping through `rtake_eq_reverse_take_reverse` to reuse the front-end `take` lemmas. Upstream candidates.
- `Definite`: `Edge.takeAt .right` is now `rtake`; bridge lemmas, `length_takeAt`, and `takeAt_of_length_le` reduce to the reused lemmas; `takeAt_left`/`takeAt_right` follow mathlib's function-then-constructor naming; `push_neg` deprecation removed; docstring restructured to mathlib's section layout.
- Extracts the reusable `isFiniteOrCofinite_of_eventually_constant` (a language constant off a finite set is co/finite) — the engine behind the reverse direction of `𝒩 = 𝒟 ∩ 𝒦`, collapsing that proof to its content.
- Dedups the `rtake` facts that were hand-rolled across `SyntacticMonoid/Equations.lean` and `Studies/Lambert2026.lean` onto the shared lemmas.