### PR TITLE
refactor(Discourse): re-carrier DistributionalCG on PMF W

### DIFF
--- a/Linglib/Discourse/Commitment/Basic.lean
+++ b/Linglib/Discourse/Commitment/Basic.lean
@@ -191,8 +191,9 @@ instance : CommitmentGrade Prop where
   complement := Not
 
 -- No `Bool` instance by default — consumers needing decidable grades
--- declare locally. Anderson 2021's distributional CommonGround provides
--- `HasSupport ℝ` at its own site.
+-- declare locally. Anderson 2021's distributional CommonGround is a genuine
+-- distribution (`PMF W`, in `Discourse/DistributionalCG.lean`), not a graded
+-- commitment, so it does not instantiate this hierarchy.
 
 /-! ### Speaker-Indexed Commitments -/
 

--- a/Linglib/Discourse/CommitmentSpace.lean
+++ b/Linglib/Discourse/CommitmentSpace.lean
@@ -53,10 +53,12 @@ Out of scope (would need substrate extensions):
 - **Time-indexed commitments** (Lauer 2013 PB/PEP carry a `t` index): the
   substrate has no time index; `rejectFirst` is the closest proxy for
   rescission. True time-indexed commitment dynamics need a separate layer.
-- **Anderson 2021 distributional CommonGround**: requires `weight_nonneg` on the
-  per-world weight. Hosting Anderson via `CommitmentSpace W ℝ` would need
-  an `[OrderedAddCommMonoid G]` constraint or an Anderson wrapper —
-  current substrate does not enforce non-negativity.
+- **Anderson 2021 distributional CommonGround**: a probability distribution
+  over worlds, hosted as `PMF W` in `Discourse/DistributionalCG.lean`. It is
+  *not* routed through the commitment-space substrate: a `CommitmentSpace W ℝ`
+  would carry unconstrained per-world reals (no sum-to-one, no normalisation),
+  losing exactly the structure Anderson's entropy/KL criteria depend on. The
+  two models of the conversational scoreboard are kept distinct.
 
 ## Citation discipline
 
@@ -759,8 +761,7 @@ open CommonGround in
 /-- A polymorphic commitment space projects to a context set via its root,
     using the `[HasSupport G]` typeclass's `support` projection. Recovers
     the binary case at `G = Prop` definitionally (via `support := id` in
-    the `Prop` instance). Anderson 2021's distributional CommonGround (`G = ℝ`)
-    becomes a consumer via `HasSupport ℝ` provided in `Anderson2021.lean`. -/
+    the `Prop` instance). -/
 instance {W G : Type*} [HasSupport G] :
     HasContextSet (CommitmentSpace W G) W where
   toContextSet := CommitmentSpace.toContextSet

--- a/Linglib/Discourse/DistributionalCG.lean
+++ b/Linglib/Discourse/DistributionalCG.lean
@@ -1,150 +1,220 @@
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Linarith
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Discourse.CommonGround
-import Linglib.Discourse.Commitment.Basic
-import Linglib.Discourse.CommitmentSpace
+import Linglib.Core.Probability.Constructions
+import Linglib.Core.Probability.Entropy
 
 /-!
 # Distributional Common Ground
 
 [anderson-2021]
 
-A non-negative real-valued weight function over worlds, refining
-[stalnaker-2002]'s sharp set-membership context set with graded
-plausibility. The probabilistic counterpart of `CommonGround W`.
+A probability distribution over worlds representing the state of the
+conversation. The probabilistic counterpart of [stalnaker-2002]'s sharp
+set-membership context set: instead of a membership predicate (`W → Prop`),
+the common ground assigns graded plausibility that **sums to one**
+(Anderson 2021, §3.2: *"I model the Common Ground as a distribution over
+worlds reflecting the state of the conversation"*).
+
+## Carrier
+
+`DistributionalCG W` wraps mathlib's `PMF W` — a genuine probability mass
+function, not an unnormalised weight. This makes Anderson's success
+criterion expressible: §3.2 measures conversational progress by the
+**entropy** of the common ground (*"In a successful conversation, the
+entropy of the Common Ground should decrease"*), and footnote 15 names KL
+divergence as the perspective-alignment objective. Both `PMF.entropy` and
+`PMF.klDiv` are available on the carrier.
 
 ## Substrate role
 
 This file hosts:
-- The `DistributionalCG W` structure with the `weight_nonneg`
-  invariant.
-- The `HasContextSet (DistributionalCG W) W` instance projecting to
-  the positive-weight subset.
-- The `HasSupport ℝ` instance enabling the polymorphic
-  `CommitmentSpace W G` substrate to be hosted at `G = ℝ`.
-- The `toCommitmentSpace` bridge from `DistributionalCG W` to
-  `Discourse.Krifka.CommitmentSpace W ℝ`, plus the support-equivalence
-  theorem.
+- The `DistributionalCG W` structure over `PMF W`.
+- `weight`/`weight_nonneg`/`sum_weight` — the ℝ-valued view of the masses
+  (via `PMF.toRealFn`), the interface every RSA consumer reads.
+- `toContextSet` projecting to the positive-mass worlds, with
+  `toContextSet_eq_support` identifying it with mathlib's `PMF.support`.
+- `uniform` — the genuine `1/|W|` distribution (`PMF.uniformOfFintype`),
+  Anderson's empty/maximally-uncertain common ground.
+- `ofWeights` — the renormalising constructor from non-negative weights
+  (Anderson 2021, footnote 3: *"At each step, the probabilities are
+  renormalized"*), built on `PMF.ofRealWeightFn`.
+- The `HasContextSet (DistributionalCG W) W` instance.
 
-The Anderson 2021 study (`Studies/Anderson2021.lean`)
-imports this substrate and adds the conversation-update + RSA-bridge
-content on top.
+The Anderson 2021 study (`Studies/Anderson2021.lean`) imports this
+substrate and adds the conversation-update + RSA-bridge content on top.
 
-## Why no `[CommitmentGrade ℝ]`
+## Non-monotonicity
 
-`HasSupport ℝ` is provided (`support g := 0 < g`); `CommitmentGrade ℝ`
-is NOT, because the involution law
-`support (complement g) ↔ ¬ support g` fails on unrestricted reals
-(e.g., `0 < 1 - 1/2 = 1/2` AND `0 < 1/2`). A future `CommitmentGrade
-NNReal` or `CommitmentGrade Probability` instance with proper laws
-over `[0,1]` would unlock graded bipolar questions for probabilistic
-frameworks.
+Unlike Stalnaker's context set — where worlds, once excluded, stay
+excluded — the distributional common ground is non-monotonic by design
+(Anderson 2021, footnote 7: *"worlds can regain probability"*). The
+classical set-intersection update is recovered only in the degenerate
+limit; see `Anderson2021.lr_one_excludes_false_worlds` for the one
+direction that survives, and `Anderson2021.graded_update_keeps_false_world`
+for the divergence the graded model insists on.
 -/
 
 namespace Discourse
 
 open CommonGround (ContextSet HasContextSet)
-open Discourse (DiscourseRole)
-open Discourse.Commitment (HasSupport IndexedWeightedCommitment CommitmentForce)
 
 -- ════════════════════════════════════════════════════
 -- § 1. DistributionalCG
 -- ════════════════════════════════════════════════════
 
-/-- A distributional common ground: a non-negative weight function
-    over worlds ([anderson-2021]). The probabilistic
-    counterpart of [stalnaker-2002]'s context set — instead of
-    a sharp membership predicate (`W → Prop`), the CommonGround assigns graded
-    plausibility (`W → ℝ`). -/
+/-- A distributional common ground: a probability distribution over worlds
+    ([anderson-2021], §3.2). The probabilistic counterpart of
+    [stalnaker-2002]'s context set — instead of a sharp membership
+    predicate (`W → Prop`), the common ground is a genuine `PMF W`,
+    assigning graded plausibility that sums to one. -/
 structure DistributionalCG (W : Type*) where
-  weight : W → ℝ
-  weight_nonneg : ∀ w, 0 ≤ weight w
+  /-- The probability distribution over worlds. -/
+  dist : PMF W
 
 namespace DistributionalCG
 
 variable {W : Type*}
 
-/-- Uniform distributional CommonGround: all worlds equally plausible (empty CommonGround). -/
-noncomputable def uniform : DistributionalCG W where
-  weight _ := 1
-  weight_nonneg _ := le_of_lt one_pos
+@[ext]
+theorem ext {cg₁ cg₂ : DistributionalCG W} (h : cg₁.dist = cg₂.dist) :
+    cg₁ = cg₂ := by
+  cases cg₁; cases cg₂; simp_all
 
-/-- Bridge to classical context set: a world is "in the context" iff
-    its weight is positive. Recovers [stalnaker-2002]'s
-    set-membership view from the distributional representation. -/
+/-- The ℝ-valued masses of the common ground (via `PMF.toRealFn`). This is
+    the interface every RSA consumer reads: it plugs directly into
+    `RSAConfig.worldPrior`/`meaning`, which expect `W → ℝ`. -/
+noncomputable def weight (cg : DistributionalCG W) : W → ℝ := cg.dist.toRealFn
+
+@[simp] theorem weight_def (cg : DistributionalCG W) (w : W) :
+    cg.weight w = (cg.dist w).toReal := rfl
+
+/-- The masses are non-negative — *derived* from `PMF`, not stipulated as a
+    structural invariant. -/
+theorem weight_nonneg (cg : DistributionalCG W) (w : W) : 0 ≤ cg.weight w :=
+  cg.dist.toRealFn_nonneg w
+
+/-- Each mass is at most one. -/
+theorem weight_le_one (cg : DistributionalCG W) (w : W) : cg.weight w ≤ 1 :=
+  cg.dist.toRealFn_le_one w
+
+/-- The masses sum to one — the normalisation Anderson's entropy/KL criteria
+    depend on. -/
+theorem sum_weight [Fintype W] (cg : DistributionalCG W) :
+    ∑ w, cg.weight w = 1 :=
+  cg.dist.sum_toRealFn_eq_one
+
+/-- Shannon entropy of the common ground (Anderson 2021, §3.2: the success
+    criterion is that this *decreases* over a conversation). -/
+noncomputable def entropy [Fintype W] (cg : DistributionalCG W) : ℝ :=
+  cg.dist.entropy
+
+theorem entropy_nonneg [Fintype W] (cg : DistributionalCG W) : 0 ≤ cg.entropy :=
+  cg.dist.entropy_nonneg
+
+/-- Bridge to classical context set: a world is "in the context" iff its
+    mass is positive. Recovers [stalnaker-2002]'s set-membership view from
+    the distributional representation. -/
 def toContextSet (cg : DistributionalCG W) : ContextSet W :=
-  λ w => 0 < cg.weight w
+  fun w => 0 < cg.weight w
 
-/-- Uniform distributional CommonGround maps to the trivial context set. -/
-theorem uniform_toContextSet :
-    (uniform : DistributionalCG W).toContextSet = ContextSet.trivial := by
-  funext w
-  simp only [toContextSet, uniform, ContextSet.trivial]
-  exact propext ⟨λ _ => True.intro, λ _ => one_pos⟩
+@[simp] theorem toContextSet_apply (cg : DistributionalCG W) (w : W) :
+    cg.toContextSet w ↔ 0 < cg.weight w := Iff.rfl
 
-/-- A world with zero weight is excluded from the classical context set. -/
+/-- The positive-mass projection coincides with mathlib's `PMF.support`. -/
+theorem toContextSet_eq_support (cg : DistributionalCG W) :
+    cg.toContextSet = cg.dist.support := by
+  ext w
+  show 0 < cg.weight w ↔ w ∈ cg.dist.support
+  rw [weight_def, PMF.mem_support_iff, ENNReal.toReal_pos_iff, pos_iff_ne_zero]
+  exact and_iff_left (lt_top_iff_ne_top.mpr (cg.dist.apply_ne_top w))
+
+/-- A world with zero mass is excluded from the classical context set. -/
 theorem zero_weight_excluded (cg : DistributionalCG W) (w : W)
     (h : cg.weight w = 0) : ¬cg.toContextSet w := by
-  intro hpos
-  simp only [toContextSet] at hpos
-  linarith
+  rw [toContextSet_apply, h]; exact lt_irrefl 0
+
+-- ════════════════════════════════════════════════════
+-- § 2. Uniform common ground
+-- ════════════════════════════════════════════════════
+
+/-- The uniform common ground: every world equally plausible at `1/|W|`
+    (Anderson 2021: `CG = Uniform(worlds)`, the empty/maximally-uncertain
+    starting point). A genuine distribution, via `PMF.uniformOfFintype`. -/
+noncomputable def uniform [Fintype W] [Nonempty W] : DistributionalCG W :=
+  ⟨PMF.uniformOfFintype W⟩
+
+@[simp] theorem uniform_weight [Fintype W] [Nonempty W] (w : W) :
+    (uniform : DistributionalCG W).weight w = (Fintype.card W : ℝ)⁻¹ := by
+  show ((PMF.uniformOfFintype W) w).toReal = _
+  rw [PMF.uniformOfFintype_apply, ENNReal.toReal_inv, ENNReal.toReal_natCast]
+
+/-- The uniform common ground maps to the trivial (universal) context set:
+    every world has positive mass. -/
+theorem uniform_toContextSet [Fintype W] [Nonempty W] :
+    (uniform : DistributionalCG W).toContextSet = ContextSet.trivial := by
+  ext w
+  show 0 < (uniform : DistributionalCG W).weight w ↔ w ∈ ContextSet.trivial
+  rw [uniform_weight]
+  simp only [ContextSet.trivial, Set.mem_univ, iff_true]
+  positivity
+
+-- ════════════════════════════════════════════════════
+-- § 3. Renormalising constructor
+-- ════════════════════════════════════════════════════
+
+/-- Build a common ground from non-negative `ℝ` weights by renormalising
+    (Anderson 2021, footnote 3: *"the probabilities are renormalized"*).
+    Routes through `PMF.ofRealWeightFn`; the positivity witness is derived
+    from the positive total. -/
+noncomputable def ofWeights [Fintype W] (f : W → ℝ) (hn : ∀ w, 0 ≤ f w)
+    (hpos : 0 < ∑ w, f w) : DistributionalCG W :=
+  have hex : ∃ w, 0 < f w := by
+    by_contra h
+    push_neg at h
+    exact absurd hpos (not_lt.mpr (Finset.sum_nonpos fun w _ => h w))
+  ⟨PMF.ofRealWeightFn f hn hex.choose hex.choose_spec⟩
+
+/-- The support of a renormalised common ground is the set of
+    strictly-positive weights — normalisation preserves the support. -/
+theorem ofWeights_toContextSet [Fintype W] (f : W → ℝ) (hn : ∀ w, 0 ≤ f w)
+    (hpos : 0 < ∑ w, f w) :
+    (ofWeights f hn hpos).toContextSet = {w | 0 < f w} := by
+  rw [toContextSet_eq_support, ofWeights, PMF.support_ofRealWeightFn]
+
+/-- Closed form of a renormalised mass: each weight divided by the total.
+    Anderson's renormalisation made explicit (`CG(w) = f(w) / Σ f`). -/
+theorem ofWeights_weight_eq [Fintype W] (f : W → ℝ) (hn : ∀ w, 0 ≤ f w)
+    (hpos : 0 < ∑ w, f w) (w : W) :
+    (ofWeights f hn hpos).weight w = f w / (∑ x, f x) := by
+  simp only [weight_def, ofWeights, PMF.ofRealWeightFn_apply]
+  rw [ENNReal.toReal_mul, ENNReal.toReal_ofReal (hn w),
+    ← ENNReal.ofReal_sum_of_nonneg (fun x _ => hn x), ENNReal.toReal_inv,
+    ENNReal.toReal_ofReal hpos.le, div_eq_mul_inv]
+
+/-- Renormalisation preserves the strict ordering of weights — the same
+    positive total divides both sides. Drives the "beliefs favour world
+    `w`" comparisons. -/
+theorem ofWeights_weight_lt_iff [Fintype W] (f : W → ℝ) (hn : ∀ w, 0 ≤ f w)
+    (hpos : 0 < ∑ w, f w) (w₁ w₂ : W) :
+    (ofWeights f hn hpos).weight w₁ < (ofWeights f hn hpos).weight w₂ ↔
+      f w₁ < f w₂ := by
+  rw [ofWeights_weight_eq, ofWeights_weight_eq, div_lt_div_iff_of_pos_right hpos]
+
+/-- Renormalising an already-normalised weight vector recovers it exactly. -/
+theorem ofWeights_weight [Fintype W] (f : W → ℝ) (hn : ∀ w, 0 ≤ f w)
+    (hpos : 0 < ∑ w, f w) (hsum : ∑ w, f w = 1) (w : W) :
+    (ofWeights f hn hpos).weight w = f w := by
+  rw [ofWeights_weight_eq, hsum, div_one]
 
 end DistributionalCG
 
-/-- A distributional CommonGround projects to a context set: worlds with
-    positive weight. -/
+/-- A distributional common ground projects to a context set: the worlds
+    with positive mass. -/
 instance {W : Type*} : HasContextSet (DistributionalCG W) W where
   toContextSet := DistributionalCG.toContextSet
-
--- ════════════════════════════════════════════════════
--- § 2. HasSupport ℝ
--- ════════════════════════════════════════════════════
-
-/-- `[HasSupport ℝ]` instance for distributional CGs.
-    `support g := 0 < g` matches Anderson's "world has positive weight
-    iff in CommonGround" projection (cf. `DistributionalCG.toContextSet`).
-
-    Provides ONLY `HasSupport ℝ`, NOT `CommitmentGrade ℝ`: the latter
-    would require the involution law on `complement`, which fails on
-    unrestricted reals. See module docstring. -/
-instance : HasSupport ℝ where
-  support g := 0 < g
-
--- ════════════════════════════════════════════════════
--- § 3. Bridge to polymorphic CommitmentSpace W ℝ
--- ════════════════════════════════════════════════════
-
-/-- Bridge: a distributional CommonGround embeds into a commitment space at
-    `G = ℝ`. The speaker's distributional weights become a single
-    `commit speaker .doxastic weight` entry in the root.
-
-    Note: the `weight_nonneg` constraint on `DistributionalCG` is NOT
-    propagated into `CommitmentSpace W ℝ` — the substrate doesn't
-    enforce non-negativity. The bridge is sound in the
-    `support`-projection direction but loses Anderson's structural
-    invariant. -/
-noncomputable def DistributionalCG.toCommitmentSpace {W : Type*}
-    (cg : DistributionalCG W) :
-    Discourse.Krifka.CommitmentSpace W ℝ where
-  root := [IndexedWeightedCommitment.commit .speaker .doxastic cg.weight]
-  continuations := []
-
-/-- Bridge theorem: the support of a distributional CommonGround equals the
-    `toContextSet` projection of the bridged commitment space.
-    Demonstrates that the polymorphic substrate at `G = ℝ`
-    faithfully captures Anderson's distributional CommonGround when projected
-    to its support. -/
-theorem DistributionalCG.toCommitmentSpace_support {W : Type*}
-    (cg : DistributionalCG W) (w : W) :
-    (cg.toCommitmentSpace).toContextSet w ↔ cg.toContextSet w := by
-  unfold toCommitmentSpace
-  simp only [Discourse.Krifka.CommitmentSpace.toContextSet, List.mem_singleton]
-  constructor
-  · intro h
-    have := h _ rfl
-    exact this
-  · intro h _ heq
-    rw [heq]
-    exact h
 
 end Discourse

--- a/Linglib/Studies/Anderson2021.lean
+++ b/Linglib/Studies/Anderson2021.lean
@@ -2,7 +2,6 @@ import Linglib.Tactics.RSAPredict
 import Linglib.Pragmatics.RSA.Basic
 import Linglib.Core.DecisionTheory.Learning
 import Linglib.Discourse.CommonGround
-import Linglib.Discourse.CommitmentSpace
 import Linglib.Discourse.DistributionalCG
 
 /-!
@@ -70,6 +69,8 @@ instance : Fintype MFWorld where
   elems := {.ina, .katie, .nancy, .sally}
   complete x := by cases x <;> simp
 
+theorem card_mfworld : Fintype.card MFWorld = 4 := by decide
+
 inductive Major where | astronomy | german
   deriving DecidableEq, Repr
 
@@ -122,12 +123,11 @@ theorem studyHumanity_partition :
 -- § 2. Distributional Common Ground (re-exported from substrate)
 -- ════════════════════════════════════════════════════
 
-/-! `DistributionalCG`, its `HasContextSet` instance, the `HasSupport ℝ`
-    instance, the `toCommitmentSpace` bridge, and the support-equivalence
-    theorem are all hosted in the substrate file
-    `Discourse/DistributionalCG.lean` (extracted from this file
-    in CHANGELOG 0.230.670). The Anderson study below builds on those
-    primitives. The substrate file is opened via the `Discourse` namespace. -/
+/-! `DistributionalCG` (a `PMF W` over worlds), its `weight`/`toContextSet`
+    projections, the `uniform` distribution, the `ofWeights` renormaliser,
+    and the `HasContextSet` instance are all hosted in the substrate file
+    `Discourse/DistributionalCG.lean`. The Anderson study below builds the
+    conversation-update + RSA-bridge content on those primitives. -/
 
 open Discourse (DistributionalCG)
 
@@ -135,28 +135,43 @@ open Discourse (DistributionalCG)
 -- § 3. CommonGround Update
 -- ════════════════════════════════════════════════════
 
-/-- Convex combination update for distributional common ground:
+/-- Convex-combination update for distributional common ground:
 
     CommonGround'(w) = (1 - lr) · CommonGround(w) + lr · posterior(w)
 
-The learning rate `lr ∈ [0,1]` controls how much weight is given to new
+Both inputs are genuine distributions, so the `lr`-weighted mixture is
+automatically a distribution (no renormalisation needed) — built as a
+`PMF.ofFintype` mixture, exactly mirroring `PMF.midPMF`'s `1/2` case. The
+learning rate `lr ∈ [0,1]` controls how much weight is given to new
 information vs. the existing CommonGround. -/
-noncomputable def updateCG {W : Type*} (cg : DistributionalCG W)
-    (posterior : W → ℝ) (post_nonneg : ∀ w, 0 ≤ posterior w)
-    (lr : ℝ) (hlr : 0 ≤ lr) (hlr1 : lr ≤ 1) :
-    DistributionalCG W where
-  weight w := (1 - lr) * cg.weight w + lr * posterior w
-  weight_nonneg w := add_nonneg
-    (mul_nonneg (by linarith) (cg.weight_nonneg w))
-    (mul_nonneg hlr (post_nonneg w))
+noncomputable def updateCG {W : Type*} [Fintype W] (cg post : DistributionalCG W)
+    (lr : ℝ) (hlr : 0 ≤ lr) (hlr1 : lr ≤ 1) : DistributionalCG W :=
+  ⟨PMF.ofFintype
+    (fun w => ENNReal.ofReal (1 - lr) * cg.dist w + ENNReal.ofReal lr * post.dist w)
+    (by
+      have hcg : (∑ w, cg.dist w) = 1 :=
+        (tsum_eq_sum (fun w (h : w ∉ Finset.univ) =>
+          absurd (Finset.mem_univ w) h)).symm.trans (PMF.tsum_coe cg.dist)
+      have hpost : (∑ w, post.dist w) = 1 :=
+        (tsum_eq_sum (fun w (h : w ∉ Finset.univ) =>
+          absurd (Finset.mem_univ w) h)).symm.trans (PMF.tsum_coe post.dist)
+      rw [Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.mul_sum, hcg, hpost,
+        mul_one, mul_one, ← ENNReal.ofReal_add (by linarith) hlr, sub_add_cancel,
+        ENNReal.ofReal_one])⟩
 
-/-- The CommonGround update formula is a convex combination — definitionally equal
-to `(1 - lr) · CommonGround(w) + lr · posterior(w)`. -/
-theorem updateCG_eq {W : Type*} (cg : DistributionalCG W)
-    (posterior : W → ℝ) (hn : ∀ w, 0 ≤ posterior w)
+/-- The CommonGround update is the convex combination
+`(1 - lr) · CommonGround(w) + lr · posterior(w)`, exactly — both inputs sum
+to one, so the mixture preserves total mass with no rescaling. -/
+theorem updateCG_eq {W : Type*} [Fintype W] (cg post : DistributionalCG W)
     (lr : ℝ) (h0 : 0 ≤ lr) (h1 : lr ≤ 1) (w : W) :
-    (updateCG cg posterior hn lr h0 h1).weight w =
-    (1 - lr) * cg.weight w + lr * posterior w := rfl
+    (updateCG cg post lr h0 h1).weight w =
+    (1 - lr) * cg.weight w + lr * post.weight w := by
+  simp only [DistributionalCG.weight_def, updateCG, PMF.ofFintype_apply]
+  rw [ENNReal.toReal_add
+        (ENNReal.mul_ne_top ENNReal.ofReal_ne_top (cg.dist.apply_ne_top w))
+        (ENNReal.mul_ne_top ENNReal.ofReal_ne_top (post.dist.apply_ne_top w)),
+    ENNReal.toReal_mul, ENNReal.toReal_mul,
+    ENNReal.toReal_ofReal (by linarith : (0:ℝ) ≤ 1 - lr), ENNReal.toReal_ofReal h0]
 
 /-- **Bridge to [luce-1959] linear learning**: the CommonGround update has the same
 algebraic form as `LinearLearner.update` with retention rate `1 - lr` and
@@ -167,29 +182,24 @@ reinforcement target `posterior`:
 
 Setting `α = 1 - lr` and `r = posterior` makes the formulas identical.
 Multi-turn conversation IS iterated learning over distributions. -/
-theorem updateCG_matches_linear_learning {W : Type*}
-    (cg : DistributionalCG W)
-    (posterior : W → ℝ) (hn : ∀ w, 0 ≤ posterior w)
+theorem updateCG_matches_linear_learning {W : Type*} [Fintype W]
+    (cg post : DistributionalCG W)
     (lr : ℝ) (h0 : 0 ≤ lr) (h1 : lr ≤ 1) (w : W) :
-    (updateCG cg posterior hn lr h0 h1).weight w =
-    ((1 - lr) * cg.weight w + (1 - (1 - lr)) * posterior w : ℝ) := by
-  simp only [updateCG_eq]; ring
+    (updateCG cg post lr h0 h1).weight w =
+    ((1 - lr) * cg.weight w + (1 - (1 - lr)) * post.weight w : ℝ) := by
+  rw [updateCG_eq]; ring
 
 /-- With learning rate 0, the CommonGround is unchanged (full retention). -/
-theorem updateCG_lr_zero {W : Type*} (cg : DistributionalCG W)
-    (posterior : W → ℝ) (hn : ∀ w, 0 ≤ posterior w) (w : W) :
-    (updateCG cg posterior hn 0 (le_refl 0) zero_le_one).weight w =
-    cg.weight w := by
-  show ((1 - (0 : ℝ)) * cg.weight w + (0 : ℝ) * posterior w : ℝ) = cg.weight w
-  ring
+theorem updateCG_lr_zero {W : Type*} [Fintype W] (cg post : DistributionalCG W)
+    (w : W) :
+    (updateCG cg post 0 (le_refl 0) zero_le_one).weight w = cg.weight w := by
+  rw [updateCG_eq]; ring
 
 /-- With learning rate 1, the CommonGround is replaced by the posterior. -/
-theorem updateCG_lr_one {W : Type*} (cg : DistributionalCG W)
-    (posterior : W → ℝ) (hn : ∀ w, 0 ≤ posterior w) (w : W) :
-    (updateCG cg posterior hn 1 zero_le_one (le_refl 1)).weight w =
-    posterior w := by
-  show ((1 - (1 : ℝ)) * cg.weight w + (1 : ℝ) * posterior w : ℝ) = posterior w
-  ring
+theorem updateCG_lr_one {W : Type*} [Fintype W] (cg post : DistributionalCG W)
+    (w : W) :
+    (updateCG cg post 1 zero_le_one (le_refl 1)).weight w = post.weight w := by
+  rw [updateCG_eq]; ring
 
 -- ════════════════════════════════════════════════════
 -- § 4. Conversation State
@@ -215,7 +225,7 @@ structure ConversationState (W : Type*) where
   speakerIsA : Bool
 
 /-- Initial conversation state: uniform CommonGround, specified beliefs, A speaks first. -/
-noncomputable def ConversationState.initial {W : Type*}
+noncomputable def ConversationState.initial {W : Type*} [Fintype W] [Nonempty W]
     (belA belB : DistributionalCG W) (lr : ℝ) : ConversationState W where
   cg := DistributionalCG.uniform
   belA := belA
@@ -230,7 +240,7 @@ noncomputable def ConversationState.initial {W : Type*}
 /-- **Weighted sampling**: sample a world proportional to the speaker's belief.
 Biased toward truth (zero-probability worlds are never sampled) but can
 lead to flip-flopping when the speaker has no strong beliefs. -/
-def weightedSample {W : Type*} (bel : DistributionalCG W) : W → ℝ :=
+noncomputable def weightedSample {W : Type*} (bel : DistributionalCG W) : W → ℝ :=
   bel.weight
 
 /-- **Thresholded sampling**: filter out worlds below a confidence threshold.
@@ -273,40 +283,59 @@ with `Shared := DistributionalCG W` and `Action := U`.
 The `World` parameter is unused: the listener doesn't know the true world,
 so the CommonGround update depends on the *posterior* (derived from the utterance),
 not the true world directly. -/
-noncomputable def toBToMSharedUpdate {W U : Type*}
-    (posteriorFn : U → W → ℝ)
-    (post_nonneg : ∀ u w, 0 ≤ posteriorFn u w)
+noncomputable def toBToMSharedUpdate {W U : Type*} [Fintype W]
+    (posteriorFn : U → DistributionalCG W)
     (lr : ℝ) (hlr : 0 ≤ lr) (hlr1 : lr ≤ 1) :
     DistributionalCG W → U → W → DistributionalCG W :=
-  fun cg u _w => updateCG cg (posteriorFn u) (post_nonneg u) lr hlr hlr1
+  fun cg u _w => updateCG cg (posteriorFn u) lr hlr hlr1
 
 -- ════════════════════════════════════════════════════
 -- § 7. Example Beliefs
 -- ════════════════════════════════════════════════════
 
-/-- A believes the person is Nancy: weight 3 on Nancy, 1 on others. -/
-noncomputable def beliefsA : DistributionalCG MFWorld where
-  weight
-    | .nancy => 3
-    | _ => 1
-  weight_nonneg w := by cases w <;> norm_num
+/-- The unnormalised belief weights: `peak` on one world, `1` elsewhere.
+Their total over the four MutualFriends worlds is `6`. -/
+private theorem mfWorld_sum_peak (peak : ℝ) (p : MFWorld) :
+    (∑ x : MFWorld, if x = p then peak else 1) = peak + 3 := by
+  rw [show (Finset.univ : Finset MFWorld) = {.ina, .katie, .nancy, .sally} from rfl]
+  cases p <;>
+    simp [Finset.sum_insert, Finset.mem_insert] <;> ring
 
-/-- B believes the person is Katie: weight 3 on Katie, 1 on others. -/
-noncomputable def beliefsB : DistributionalCG MFWorld where
-  weight
-    | .katie => 3
-    | _ => 1
-  weight_nonneg w := by cases w <;> norm_num
+/-- A believes the person is Nancy: (unnormalised) weight 3 on Nancy, 1 on
+others — renormalised to the distribution `[1/6, 1/6, 1/2, 1/6]`. -/
+noncomputable def beliefsA : DistributionalCG MFWorld :=
+  DistributionalCG.ofWeights (fun w => if w = .nancy then 3 else 1)
+    (fun w => by split <;> norm_num)
+    (Finset.sum_pos' (fun w _ => by split <;> norm_num)
+      ⟨.nancy, Finset.mem_univ _, by rw [if_pos rfl]; norm_num⟩)
+
+/-- B believes the person is Katie: (unnormalised) weight 3 on Katie, 1 on
+others — renormalised to the distribution `[1/6, 1/2, 1/6, 1/6]`. -/
+noncomputable def beliefsB : DistributionalCG MFWorld :=
+  DistributionalCG.ofWeights (fun w => if w = .katie then 3 else 1)
+    (fun w => by split <;> norm_num)
+    (Finset.sum_pos' (fun w _ => by split <;> norm_num)
+      ⟨.katie, Finset.mem_univ _, by rw [if_pos rfl]; norm_num⟩)
+
+/-- Closed form of A's renormalised beliefs: `3/6` on Nancy, `1/6` elsewhere. -/
+theorem beliefsA_weight (w : MFWorld) :
+    beliefsA.weight w = (if w = .nancy then 3 else 1) / 6 := by
+  rw [beliefsA, DistributionalCG.ofWeights_weight_eq, mfWorld_sum_peak]; norm_num
+
+/-- Closed form of B's renormalised beliefs: `3/6` on Katie, `1/6` elsewhere. -/
+theorem beliefsB_weight (w : MFWorld) :
+    beliefsB.weight w = (if w = .katie then 3 else 1) / 6 := by
+  rw [beliefsB, DistributionalCG.ofWeights_weight_eq, mfWorld_sum_peak]; norm_num
 
 /-- A's beliefs favor Nancy over all other worlds. -/
 theorem beliefsA_favors_nancy (w : MFWorld) (hw : w ≠ .nancy) :
     beliefsA.weight w < beliefsA.weight .nancy := by
-  cases w <;> simp_all [beliefsA]
+  rw [beliefsA_weight w, beliefsA_weight .nancy, if_neg hw, if_pos rfl]; norm_num
 
 /-- B's beliefs favor Katie over all other worlds. -/
 theorem beliefsB_favors_katie (w : MFWorld) (hw : w ≠ .katie) :
     beliefsB.weight w < beliefsB.weight .katie := by
-  cases w <;> simp_all [beliefsB]
+  rw [beliefsB_weight w, beliefsB_weight .katie, if_neg hw, if_pos rfl]; norm_num
 
 /-- Under difference-based sampling, A initially prioritizes Nancy
 (highest positive difference from uniform CommonGround). -/
@@ -315,7 +344,9 @@ noncomputable def aDiffFromUniform : MFWorld → ℝ :=
 
 theorem a_diff_nancy_positive :
     0 < aDiffFromUniform .nancy := by
-  simp only [aDiffFromUniform, differenceSample, beliefsA, DistributionalCG.uniform]
+  rw [aDiffFromUniform, differenceSample, lt_max_iff]
+  right
+  rw [beliefsA_weight, DistributionalCG.uniform_weight, card_mfworld]
   norm_num
 
 -- ════════════════════════════════════════════════════
@@ -612,24 +643,29 @@ Given the current CommonGround and an utterance:
 This closes the loop: RSA inference → CommonGround update → new RSA model.
 The returned CommonGround serves as the world prior for the next turn's model.
 
-**Normalization note**: The L1 posterior is normalized (sums to 1), so
-the CommonGround weights should also be normalized for the convex combination
-to preserve total weight. With normalized CommonGround, `updateCG` is a true
-convex combination and preserves sum-to-1. Starting from
-`DistributionalCG.uniform` (weight=1 per world) gives correct RSA
-predictions but produces CommonGround updates with a different scale than the
-paper's normalized distributions. -/
+**Renormalisation**: the L1 posterior is repackaged as a `DistributionalCG`
+via `ofWeights` (Anderson 2021, footnote 3: *"the probabilities are
+renormalized"*), so `updateCG` is a genuine convex combination of two
+distributions and the result is again a distribution. The guard handles the
+degenerate case of an utterance contradicting the entire common ground
+(`∑ L1 = 0`, e.g. `studyHumanity` against a CG concentrated on Ina): then
+the posterior carries no information and the CommonGround is left unchanged —
+matching Anderson's null-utterance "skip the update" behaviour (§7.1). -/
 noncomputable def conversationStep
     (cg : DistributionalCG MFWorld) (u : MFUtterance)
     (lr : ℝ) (hlr : 0 ≤ lr) (hlr1 : lr ≤ 1) :
     DistributionalCG MFWorld :=
   let rsaModel := mfRSAAt cg.weight cg.weight_nonneg
   let posterior := rsaModel.L1 u
-  let posterior_nonneg : ∀ w, 0 ≤ posterior w :=
-    fun w => rsaModel.L1agent.policy_nonneg u w
-  updateCG cg posterior posterior_nonneg lr hlr hlr1
+  let postCG : DistributionalCG MFWorld :=
+    if h : 0 < ∑ w, posterior w then
+      DistributionalCG.ofWeights posterior
+        (fun w => rsaModel.L1agent.policy_nonneg u w) h
+    else cg
+  updateCG cg postCG lr hlr hlr1
 
-/-- The conversation step preserves CommonGround non-negativity. -/
+/-- The conversation step preserves CommonGround non-negativity (now free:
+the result is a genuine distribution). -/
 theorem conversationStep_nonneg (cg : DistributionalCG MFWorld)
     (u : MFUtterance) (lr : ℝ) (hlr : 0 ≤ lr) (hlr1 : lr ≤ 1) (w : MFWorld) :
     0 ≤ (conversationStep cg u lr hlr hlr1).weight w :=
@@ -639,7 +675,7 @@ theorem conversationStep_nonneg (cg : DistributionalCG MFWorld)
 theorem conversationStep_lr_zero (cg : DistributionalCG MFWorld) (u : MFUtterance) (w : MFWorld) :
     (conversationStep cg u 0 (le_refl 0) zero_le_one).weight w = cg.weight w := by
   simp only [conversationStep]
-  exact updateCG_lr_zero cg _ _ w
+  exact updateCG_lr_zero cg _ w
 
 -- ════════════════════════════════════════════════════
 -- § 15. Qualitative information-sharing properties
@@ -676,19 +712,36 @@ theorem s1_informed_speaker_is_informative :
 -- ════════════════════════════════════════════════════
 
 /-- Anderson's distributional CommonGround update subsumes [stalnaker-2002]'s
-set-intersection update as a special case: with learning rate 1 and a
-posterior that assigns zero weight to worlds where the utterance is false,
-the updated CommonGround excludes exactly those worlds — recovering `ContextSet.update`.
+set-intersection update **only in the degenerate `lr = 1` limit**: when the
+whole prior CommonGround is discarded (`lr = 1`) and the posterior assigns
+zero mass to a world, that world drops out of the context set — recovering
+classical elimination.
 
-This bridge connects the probabilistic conversation model to the classical
-assertion framework in `CommonGround`. -/
-theorem lr_one_excludes_false_worlds (cg : DistributionalCG MFWorld)
-    (posterior : MFWorld → ℝ) (hn : ∀ w, 0 ≤ posterior w) (w : MFWorld)
-    (h : posterior w = 0) :
-    ¬(updateCG cg posterior hn 1 zero_le_one (le_refl 1)).toContextSet w := by
+This is the *one* direction of the Stalnaker bridge that survives. The
+graded model diverges for every `lr < 1`; see
+`graded_update_keeps_false_world`. -/
+theorem lr_one_excludes_false_worlds (cg post : DistributionalCG MFWorld)
+    (w : MFWorld) (h : post.weight w = 0) :
+    ¬(updateCG cg post 1 zero_le_one (le_refl 1)).toContextSet w := by
   apply DistributionalCG.zero_weight_excluded
-  show ((1 - (1 : ℝ)) * cg.weight w + (1 : ℝ) * posterior w : ℝ) = 0
-  rw [h]; ring
+  rw [updateCG_lr_one]; exact h
+
+/-- **The divergence the graded model insists on** (Anderson 2021, footnote
+7: *"worlds can regain probability"*). For any `lr < 1`, a world the
+utterance rules out (`post.weight w = 0`) is **not** excluded from the
+context set — the prior CommonGround keeps it alive with mass
+`(1 - lr) · cg.weight w`. This is exactly where Anderson's distributional
+update parts ways with Stalnaker's monotone set-intersection: graded
+interpolation never deletes a world unless it is *already* dead in the prior.
+Linglib surfaces the incompatibility rather than papering over it. -/
+theorem graded_update_keeps_false_world (cg post : DistributionalCG MFWorld)
+    (w : MFWorld) (hcg : 0 < cg.weight w) (lr : ℝ) (h0 : 0 ≤ lr) (h1 : lr < 1) :
+    (updateCG cg post lr h0 h1.le).toContextSet w := by
+  rw [DistributionalCG.toContextSet_apply, updateCG_eq]
+  have : 0 < (1 - lr) * cg.weight w := mul_pos (by linarith) hcg
+  have : 0 ≤ lr * post.weight w :=
+    mul_nonneg h0 (DistributionalCG.weight_nonneg _ _)
+  linarith
 
 -- ════════════════════════════════════════════════════
 -- § 17. Exact Numerical Predictions (Figure 5)
@@ -763,7 +816,7 @@ structure ApproxCGState (W : Type*) where
   lr : ℝ
   speakerIsA : Bool
 
-noncomputable def ApproxCGState.initial {W : Type*}
+noncomputable def ApproxCGState.initial {W : Type*} [Fintype W] [Nonempty W]
     (belA belB : DistributionalCG W) (lr : ℝ) : ApproxCGState W where
   cgA := DistributionalCG.uniform
   cgB := DistributionalCG.uniform
@@ -821,7 +874,7 @@ structure BeliefUpdateState (W : Type*) where
   belLR : ℝ
   speakerIsA : Bool
 
-noncomputable def BeliefUpdateState.initial {W : Type*}
+noncomputable def BeliefUpdateState.initial {W : Type*} [Fintype W] [Nonempty W]
     (belA belB : DistributionalCG W) (cgLR belLR : ℝ) :
     BeliefUpdateState W where
   cgA := DistributionalCG.uniform
@@ -835,12 +888,12 @@ noncomputable def BeliefUpdateState.initial {W : Type*}
 /-- Belief update is algebraically identical to CommonGround update — both are
 instances of [luce-1959]'s linear learning rule. The only difference
 is the learning rate parameter and the interpretation (private vs shared). -/
-theorem belief_update_is_linear_learning {W : Type*}
-    (bel : DistributionalCG W)
-    (posterior : W → ℝ) (hn : ∀ w, 0 ≤ posterior w)
+theorem belief_update_is_linear_learning {W : Type*} [Fintype W]
+    (bel post : DistributionalCG W)
     (lr : ℝ) (h0 : 0 ≤ lr) (h1 : lr ≤ 1) (w : W) :
-    (updateCG bel posterior hn lr h0 h1).weight w =
-    (1 - lr) * bel.weight w + lr * posterior w := rfl
+    (updateCG bel post lr h0 h1).weight w =
+    (1 - lr) * bel.weight w + lr * post.weight w :=
+  updateCG_eq bel post lr h0 h1 w
 
 -- ════════════════════════════════════════════════════
 -- § 20. Noncommittal Speaker Problem (§7.1)
@@ -862,16 +915,17 @@ sampling — a noncommittal speaker has no basis for choosing. -/
 theorem uniform_weighted_constant (w₁ w₂ : MFWorld) :
     weightedSample (DistributionalCG.uniform : DistributionalCG MFWorld) w₁ =
     weightedSample (DistributionalCG.uniform : DistributionalCG MFWorld) w₂ := by
-  simp [weightedSample, DistributionalCG.uniform]
+  simp only [weightedSample, DistributionalCG.uniform_weight]
 
 /-- Threshold sampling filters out all worlds when beliefs don't exceed
-the threshold. For uniform beliefs (weight 1), any θ > 1 produces zero
-weight everywhere — the speaker passes (Figure 13). -/
+the threshold. Every mass of a distribution is `≤ 1`, so any `θ > 1`
+produces zero weight everywhere — the speaker passes (Figure 13). -/
 theorem threshold_filters_uniform (θ : ℝ) (hθ : 1 < θ) (w : MFWorld) :
     thresholdedSample (DistributionalCG.uniform : DistributionalCG MFWorld) θ w = 0 := by
-  simp only [thresholdedSample, DistributionalCG.uniform]
-  have : ¬((1 : ℝ) ≥ θ) := by linarith
-  simp [this]
+  have hle : (DistributionalCG.uniform : DistributionalCG MFWorld).weight w ≤ 1 :=
+    DistributionalCG.weight_le_one _ _
+  simp only [thresholdedSample]
+  rw [if_neg (by linarith)]
 
 /-- Threshold preserves confident worlds: weights above θ pass through. -/
 theorem threshold_preserves_confident {W : Type*}
@@ -913,8 +967,18 @@ theorem a_initial_diff_nancy_highest :
     aDiffFromUniform .nancy > aDiffFromUniform .ina ∧
     aDiffFromUniform .nancy > aDiffFromUniform .katie ∧
     aDiffFromUniform .nancy > aDiffFromUniform .sally := by
-  refine ⟨?_, ?_, ?_⟩ <;>
-    simp only [aDiffFromUniform, differenceSample, beliefsA, DistributionalCG.uniform] <;>
-    norm_num
+  have hn : aDiffFromUniform .nancy = 1 / 4 := by
+    simp only [aDiffFromUniform, differenceSample, beliefsA_weight,
+      DistributionalCG.uniform_weight, card_mfworld, if_pos]
+    rw [max_eq_right (by norm_num)]; norm_num
+  have ho : ∀ w : MFWorld, w ≠ .nancy → aDiffFromUniform w = 0 := by
+    intro w hw
+    simp only [aDiffFromUniform, differenceSample, beliefsA_weight,
+      DistributionalCG.uniform_weight, card_mfworld, if_neg hw]
+    rw [max_eq_left (by norm_num)]
+  refine ⟨?_, ?_, ?_⟩ <;> rw [hn]
+  · rw [ho .ina (by decide)]; norm_num
+  · rw [ho .katie (by decide)]; norm_num
+  · rw [ho .sally (by decide)]; norm_num
 
 end Anderson2021


### PR DESCRIPTION
## Origin

Random-file mathlib-quality audit of `Discourse/DistributionalCG.lean` (4-lens panel: mathlib code-quality, linglib integration, pragmatics domain, cross-framework). The four lenses converged on one root cause — and reading **Anderson (2021)** against the formalization confirmed it.

## The problem

Anderson models the common ground as a **probability distribution over worlds**: §3.2 makes *entropy decrease* the success criterion, fn. 3 renormalises at every step, fn. 15 names KL divergence as the alternative objective. The old encoding was a bare non-negative `W → ℝ` weight with **no normalisation** — a measure, not a distribution. Consequences:

- Entropy / KL (Anderson's own success criteria) were **not statable**.
- `uniform` assigned weight `1` to every world, not `1/|W|`.
- It forced an **orphan `HasSupport ℝ`** instance and a **dead, lossy `toCommitmentSpace`** bridge (zero consumers) that even dropped the structural invariant — Anderson never cites Krifka.

## The change

Re-carrier `DistributionalCG W` onto mathlib's **`PMF W`**, building on the repo's existing `Core/Probability` stack:

| | before | after |
|---|---|---|
| carrier | `{ weight : W → ℝ // 0 ≤ · }` | `PMF W` |
| `weight_nonneg` | stipulated field | **free** (derived from PMF) |
| `toContextSet` | `0 < weight` | same, **proved `= PMF.support`** |
| `uniform` | weight `1` | `PMF.uniformOfFintype` (true `1/|W|`) |
| `ofWeights` | — | renormaliser via `PMF.ofRealWeightFn` (fn. 3) |
| entropy / KL | inexpressible | `PMF.entropy` / `PMF.klDiv` on the carrier |
| `updateCG` | tuple arithmetic | lr-weighted `PMF.ofFintype` mixture (mirrors `midPMF`), **exact Luce identity preserved** |

**Deleted** the orphan `HasSupport ℝ` and the dead `toCommitmentSpace` bridge (+ their `CommitmentSpace`/`Commitment` imports); cleaned the now-stale cross-references.

## Surfacing the divergence (linglib's thesis)

Added `graded_update_keeps_false_world`: for **any `lr < 1`**, a world the utterance rules out is **not** excluded from the context set — the prior keeps it alive with mass `(1−lr)·cg.weight w`. This makes the graded-vs-Stalnaker incompatibility *visible* (fn. 7, "worlds can regain probability") instead of papering over it. `lr_one_excludes_false_worlds` is restated honestly as the lone degenerate-corner survivor.

## Verification

- The RSA numeric predictions are **untouched** — they run on raw `MFWorld → ℝ` and are invariant under prior rescaling (exactly the property Anderson relies on).
- Full `lake build Linglib` green (exit 0); no new errors or `sorry`.
- `#print axioms` on the seven key declarations: only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no custom axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)