### PR TITLE
refactor(Semantics/Verb/Root): prune dead proto-role atoms + redundant instances

### DIFF
--- a/Linglib/Semantics/Verb/Root/Basic.lean
+++ b/Linglib/Semantics/Verb/Root/Basic.lean
@@ -1,6 +1,6 @@
-import Linglib.Semantics.Verb.Root.Signature
 import Linglib.Semantics.Verb.Root.OutcomeCardinality
 import Linglib.Semantics.Verb.Root.Profile
+import Linglib.Semantics.Verb.Root.Signature
 
 /-!
 # Atomic Lexical Entailments and Roots
@@ -17,8 +17,8 @@ commitments.
 
 ## Main declarations
 
-* `LexEntailment` — labeled atoms; `LexEntailment.kind` projects the
-  B&K-G kind, if any
+* `LexEntailment` — labeled atoms; `LexEntailment.kind` projects its
+  B&K-G kind
 * `Root` — a named list of atoms
 * `Root.kinds` — the derived signature
 * `Root.HasState`/`HasManner`/`HasResult`/`HasCause` — kind membership
@@ -28,13 +28,15 @@ namespace Verb
 
 /-! ### Atomic entailments -/
 
-/-- An atomic claim a root can make. The four B&K-G kinds
-    (state, manner, result, cause) correspond to the kinds of atoms
-    present in a root's entailment set (`LexEntailment.kind`).
+/-- An atomic structural claim a verbal root makes — one of the four
+    B&K-G entailment kinds (state, manner, result, cause). The three
+    contentful kinds carry a label; `hasCause` is nullary.
+    `LexEntailment.kind` projects the kind each realizes.
 
-    The remaining atoms (volitional, sentient, motion, contact)
-    cover Dowty's proto-role components that are independent of the
-    state/manner/result/cause cut. -/
+    Participant/proto-role entailments (volition, sentience, movement,
+    affectedness, …) are deliberately *not* modeled here: they are an
+    orthogonal, linking-relevant layer carried by
+    `Semantics.ArgumentStructure.EntailmentProfile`. -/
 inductive LexEntailment where
   /-- Attributes a static property (state-kind atom). -/
   | hasState     (label : String)
@@ -48,26 +50,18 @@ inductive LexEntailment where
       [bohnemeyer-2004]) is carried separately by
       `Semantics.Lexical.EventStructure.InternalExternalCause`. -/
   | hasCause
-  /-- The agent acts intentionally. -/
-  | volitional
-  /-- The agent is sentient. -/
-  | sentient
-  /-- An entity changes location. -/
-  | motion
-  /-- Two entities are in physical contact. -/
-  | contact
   deriving DecidableEq, Repr
 
 namespace LexEntailment
 
-/-- The B&K-G kind an atom realizes, if any. The proto-role atoms
-    (volitional, sentient, motion, contact) carry no kind. -/
+/-- The B&K-G kind an atom realizes. Total — every atom has a kind —
+    but kept `Option`-valued for the closure API (`Closure.lean`),
+    which quantifies over `a.kind = some k`. -/
 def kind : LexEntailment → Option LexKind
   | hasState _     => some .state
   | hasManner _    => some .manner
   | becomesState _ => some .result
   | hasCause       => some .cause
-  | _              => none
 
 end LexEntailment
 
@@ -79,7 +73,7 @@ end LexEntailment
     The set is the root's *base* entailment set — the atoms asserted
     directly. A closure operation (B&K-G's networks of entailments
     where one atom may entail another) is layered on top in
-    `Roots/Closure.lean`. -/
+    `Closure.lean`. -/
 structure Root where
   /-- The root form; `""` for an unnamed annotation (e.g. a quality-profile-only
       root carried by a verb whose root form is its citation form). -/
@@ -97,19 +91,18 @@ structure Root where
   profile : Verb.Root.Profile := {}
   deriving DecidableEq
 
-/-- `Finset` carries neither `Repr` nor `BEq`, so `Root` cannot `deriving` either;
-    we supply both by hand so `Verb` can derive `Repr`/`BEq` over its `root` field.
-    The `Repr` shows the `name`, `outcomes`, and `profile` fields in full plus the
-    `entailments` cardinality — the entailment *set* itself has no computable `Repr`
-    (`Finset`/`Multiset` would need a `LinearOrder` on the elements to render), but
-    this already distinguishes roots that differ in outcomes/profile, which the old
-    name-only `Repr` collapsed. The `BEq` is the lawful `DecidableEq`-backed one. -/
+/-- `Finset` carries no `Repr`, so `Root` cannot `deriving Repr`; we supply
+    one by hand so `Verb` can `deriving Repr` over its `root` field. It shows
+    `name`, `outcomes`, and `profile` in full plus the `entailments`
+    cardinality — the entailment *set* itself has no computable `Repr`
+    (`Finset`/`Multiset` would need a `LinearOrder` on the elements to render),
+    but this already distinguishes roots that differ in outcomes/profile, which
+    the old name-only `Repr` collapsed.
+
+    `BEq`/`LawfulBEq` need no hand-rolled instance: both come from the derived
+    `DecidableEq` (line above) via the global `instBEqOfDecidableEq`. -/
 instance : Repr Root :=
   ⟨fun r _ => repr (r.name, r.entailments.card, r.outcomes, r.profile)⟩
-instance : BEq Root := ⟨fun a b => decide (a = b)⟩
-instance : LawfulBEq Root where
-  eq_of_beq h := of_decide_eq_true h
-  rfl := decide_eq_true_eq.mpr rfl
 
 namespace Root
 
@@ -120,28 +113,21 @@ def kinds (r : Root) : Root.Kinds :=
 
 theorem mem_kinds {r : Root} {k : LexKind} :
     k ∈ r.kinds ↔ ∃ a ∈ r.entailments, a.kind = some k := by
-  simp [kinds]
+  simp only [kinds, Finset.mem_filter, Finset.mem_univ, true_and]
 
-/-- The root entails attribution of some state. -/
-def HasState (r : Root) : Prop := .state ∈ r.kinds
+/-- The root entails attribution of some state.
+    `abbrev` (not `def`) so `Decidable`/`simp`/`decide` see through to the
+    underlying `Finset` membership without per-predicate boilerplate. -/
+abbrev HasState (r : Root) : Prop := .state ∈ r.kinds
 
 /-- The root specifies some manner. -/
-def HasManner (r : Root) : Prop := .manner ∈ r.kinds
+abbrev HasManner (r : Root) : Prop := .manner ∈ r.kinds
 
 /-- The root entails some change of state (B&K-G "result"). -/
-def HasResult (r : Root) : Prop := .result ∈ r.kinds
+abbrev HasResult (r : Root) : Prop := .result ∈ r.kinds
 
 /-- The root entails causation. -/
-def HasCause (r : Root) : Prop := .cause ∈ r.kinds
-
-instance (r : Root) : Decidable r.HasState :=
-  inferInstanceAs (Decidable (_ ∈ _))
-instance (r : Root) : Decidable r.HasManner :=
-  inferInstanceAs (Decidable (_ ∈ _))
-instance (r : Root) : Decidable r.HasResult :=
-  inferInstanceAs (Decidable (_ ∈ _))
-instance (r : Root) : Decidable r.HasCause :=
-  inferInstanceAs (Decidable (_ ∈ _))
+abbrev HasCause (r : Root) : Prop := .cause ∈ r.kinds
 
 end Root
 

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -49,7 +49,7 @@ open Verb
 def flat : Root := ⟨"flat", {.hasState "flat"}, none, {}⟩
 
 /-- √jog — pure manner of motion. -/
-def jog : Root := ⟨"jog", {.hasManner "jogging-gait", .motion}, none, {}⟩
+def jog : Root := ⟨"jog", {.hasManner "jogging-gait"}, none, {}⟩
 
 /-- √blossom — result with no specified manner or cause (an
     internally caused change of state). -/


### PR DESCRIPTION
Follow-up to #618 (the `Lexical/Roots` → `Verb/Root` relocation). Addresses a four-lens audit (mathlib code-quality, lexical-semantics faithfulness, integration, cross-framework) of `Verb/Root/Basic.lean`.

## Changes

**1. Remove the four inert proto-role atoms** (`volitional`/`sentient`/`motion`/`contact`) from `LexEntailment`. The audit found them:
- **inert** — `LexEntailment.kind` mapped all four to `none`, `Root.kinds` filtered them out, and the *only* construction site in the library was √jog's `.motion`, which `jog_kinds = {.manner}` already ignored;
- **misattributed** — the docstring called all four "Dowty proto-role components", but `contact` is a Levin (1993) manner component (and B&K-G treat surface-contact as a *manner* entailment, not something orthogonal to the state/manner/result/cause cut);
- **duplicative** — they partially re-stipulated the live, consumed proto-role model `Semantics.ArgumentStructure.EntailmentProfile`.

The docstring now delegates participant/linking entailments to `EntailmentProfile`. Removing them makes `LexEntailment.kind` **total**, retiring its catch-all `| _ => none` (a silent-misclassification hazard if a constructor is later added).

**2. Drop the redundant hand-rolled `BEq Root` / `LawfulBEq Root`.** Both derive for free from the `DecidableEq` via the global `instBEqOfDecidableEq` (verified: downstream `Verb`'s `deriving BEq` still works). This had re-introduced exactly the shadowing instance `Syntax/Tree/Basic.lean` documents removing. Kept only the genuinely-needed hand-rolled `Repr` (`Finset` carries none).

**3. `HasState`/`HasManner`/`HasResult`/`HasCause`: `def` → `abbrev`**, deleting the four boilerplate `Decidable` instances (reducible abbrevs resolve through to `Finset` membership). Consumers that `unfold` these (`Morphology/RootTypology`, `Studies/Lucy1994`) are unaffected — confirmed by build.

**4. Tidy:** alphabetized imports; `mem_kinds` proof `simp [kinds]` → `simp only [...]` for robustness.

Net −14 lines.

## Verification

Full `lake build Linglib` green — **6311 jobs**, no errors.

A separate cross-framework follow-up (give Manner/Result Complementarity a named defender so its refutation reads as a cross-framework theorem; bridge the two Bifurcation refutations) is tracked but not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)