### PR TITLE
Audit-fix ClemDeal2024: reground §7 on real dependent-case algorithm; PDF-verified citations

### DIFF
--- a/Linglib/Studies/ClemDeal2024.lean
+++ b/Linglib/Studies/ClemDeal2024.lean
@@ -1,5 +1,11 @@
-import Linglib.Studies.Deal2024
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Fragments.Kawapanan.Shawi.Basic
+import Linglib.Studies.Deal2024
+import Linglib.Syntax.Case.Dependent
 
 /-!
 # Dependent Case by Agree: Ergative in Shawi [clem-deal-2024]
@@ -13,19 +19,30 @@ on subject" (OAgr-on-S) morpheme spells out the inner φ-features of the
 same bundle.
 
 The distribution of `-ri` in Shawi is a **strictly descending** /
-ultrastrong PCC pattern (1>2>3): ergative appears iff the subject is at
-least as high as the object on the person hierarchy. This is exactly
-[deal-2024]'s `strictlyDescending` grammar (`SAT:[SPKR]`,
-`DynINT:[PART]↑`), already formalized in `Deal2024.lean`.
+ultrastrong PCC pattern (1>2>3). [clem-deal-2024]'s final generalization
+(their (10), p. 274) is: ergative appears when the subject is at least as
+high as the object on the person hierarchy 1>2>3 *and both arguments are
+in the same syntactic domain*. The hierarchy half is exactly [deal-2024]'s
+`strictlyDescending` grammar (`SAT:[SPKR]`, `DynINT:[PART]↑`), already
+formalized in `Deal2024.lean`; the same-domain half is the object's
+visibility to the v probe (`objectVisible`).
+
+`predictsErgative` realizes both factors. Note it follows the [deal-2024]
+mechanism the paper adopts, not the loose prose of (10): a 1st-person
+object satisfies `SAT:[SPKR]` and halts the probe, so `predictsErgative`
+predicts *no* ergative at the reflexive 1→1 cell, even though "at least as
+high as" (1 ≥ 1) would admit it. Shawi data do not document the reflexive
+1→1/2→2 cells — Table 4 (p. 285) has no such rows — so this is a prediction
+of the mechanism, not a tested fact.
 
 This study file does five things:
 
 1. **Map** the Shawi clause to the Deal-2024 PCC framing: the lower goal
    (DO) is the object, the higher / second goal (IO) is the subject.
-2. **Predict** the distribution of `-ri` over the 7 (subject, object,
-   3rd-person-object-position) cells of [clem-deal-2024] Table 4
-   from the existing `strictlyDescending` grammar plus the high/low
-   ambiguity for 3rd-person objects (the source of "(✓)" optionality).
+2. **Predict** the distribution of `-ri` over the cells of
+   [clem-deal-2024] Table 4 (p. 285) from the existing `strictlyDescending`
+   grammar plus the high/low ambiguity for 3rd-person objects (the source
+   of "(✓)" optionality).
 3. **Ground** the predictions in the privative person geometry shared
    with [deal-2024]'s `dpBears` (and via that, with
    [pancheva-zubizarreta-2018]'s `satisfiesProminence` and
@@ -33,8 +50,11 @@ This study file does five things:
 4. **Bridge** to the existing person-rank order via
    `Deal2024.sd_off_diagonal_iff_outranks` — the Shawi pattern's
    1>2>3 hierarchy is exactly the one that fell out of Deal-2024.
-5. **Counterexample** the simple and augmented configurational case
-   rules (paper §4.1, equations (1) and (37)) on Shawi cells.
+5. **Counterexample** the configurational case rules [clem-deal-2024]
+   discusses (§1 (1), after [baker-2015]; §4.1 (37), a
+   [barany-sheehan-2024]-style rule) by running linglib's *own* formalized
+   dependent-case algorithm (`Syntax.Case.assignCases`) on Shawi cells,
+   rather than a local strawman.
 
 Genuinely new machinery — bidirectional Agree (goal flagging),
 Distributed-Morphology Vocabulary Insertion, Kinyalolo's Constraint —
@@ -51,6 +71,7 @@ open Deal2024 (DealGrammar isLicit strictlyDescending dpBears
   sd_off_diagonal_iff_outranks)
 open Kawapanan.Shawi (ObjectPosition ObjectSyntax Phi mustBeHigh
   ergativeMarker oagrOnSMarker objectSyntaxLicit)
+open Syntax.Case (NPInDomain assignCases getCaseOf)
 
 -- ============================================================================
 -- § 1: Mapping Shawi to Deal-2024
@@ -59,13 +80,13 @@ open Kawapanan.Shawi (ObjectPosition ObjectSyntax Phi mustBeHigh
 /-- The v probe in Shawi sits between the object (lower) and the subject
     (higher). Cyclic Agree (Béjar & Rezac 2009) makes the object the
     first goal (G1 ≡ DO in Deal-2024 terms) and the subject the second
-    goal (G2 ≡ IO). [clem-deal-2024] (3), (15)–(19). -/
+    goal (G2 ≡ IO). [clem-deal-2024] (13) (cyclic expansion), (15)–(19). -/
 def shawiGrammar : DealGrammar := strictlyDescending
 
 /-- Shawi's surface 1>2>3 pattern is what Deal-2024 calls strictly
-    descending. This is a definitional alignment, not a discovery. -/
-theorem shawi_is_strictly_descending :
-    shawiGrammar = strictlyDescending := rfl
+    descending. This is a definitional alignment (a drift guard), not a
+    discovery — hence an anonymous `example`. -/
+example : shawiGrammar = strictlyDescending := rfl
 
 -- ============================================================================
 -- § 2: The two factors of the ergative prediction
@@ -73,13 +94,18 @@ theorem shawi_is_strictly_descending :
 
 /-- Whether v can interact with the object as G1. 3rd-person *low*
     objects sit inside the inner v_cat phase and are invisible to the
-    v probe ([clem-deal-2024] §3.2, (24)). Local-person and
-    high-positioned 3rd-person objects are visible.
+    v probe ([clem-deal-2024] §3.2, (24), (30)). Every other object —
+    local-person (1/2, including the clusivity cells) and high-positioned
+    3rd-person — is visible.
 
-    Note: `objectVisible .first .low` and `objectVisible .second .low`
-    return `true` vacuously — local-person objects never occupy the
-    low position (`mustBeHigh` is `true` for them), so this case is
-    structurally inaccessible. -/
+    Two notes on the wildcard. (i) `objectVisible .first .low` and
+    `objectVisible .second .low` return `true` vacuously: local-person
+    objects never occupy the low position (`mustBeHigh` is `true` for
+    them), so the case is structurally inaccessible. (ii) The impersonal
+    `.zero` and the clusivity cells `.firstInclusive`/`.firstExclusive`
+    fall through to `true`; only the bare `.third` low cell is invisible,
+    matching the paper's treatment of 3rd-person objects as the persons
+    that show no overt object agreement and may stay low. -/
 def objectVisible : Person → ObjectPosition → Bool
   | .third, .low => false
   | _, _         => true
@@ -117,7 +143,7 @@ theorem erg_with_2p_obj_iff_subj_part (subj : Person) :
 
 /-- 3P high object: lacks [SPKR] *and* lacks [PART], so the probe
     neither halts nor narrows. The subject is visible as G2 regardless
-    of its features. [clem-deal-2024] (8), (19). -/
+    of its features. [clem-deal-2024] (8), (22). -/
 theorem erg_with_3p_obj_high_always (subj : Person) :
     predictsErgative subj .third .high = true := by
   cases subj <;> rfl
@@ -153,29 +179,24 @@ theorem erg_off_diagonal_iff_subj_outranks_obj
 -- § 5: Cell-by-cell verification of Table 4
 -- ============================================================================
 
-/-- [clem-deal-2024] Table 4 (p. 19) — full ergative distribution
-    over the 7 (subject, object) combinations × object position.
-    All 10 cells reduce by `rfl` from `predictsErgative`. -/
-example : -- row a (1→2): obligatory
-    predictsErgative .first .second .high = true := rfl
-example : -- row b high (1→3 high): present
-    predictsErgative .first .third .high = true := rfl
-example : -- row b low (1→3 low): absent
-    predictsErgative .first .third .low = false := rfl
-example : -- row c (2→1): impossible
-    predictsErgative .second .first .high = false := rfl
-example : -- row d high (2→3 high): present
-    predictsErgative .second .third .high = true := rfl
-example : -- row d low (2→3 low): absent
-    predictsErgative .second .third .low = false := rfl
-example : -- row e (3→1): impossible
-    predictsErgative .third .first .high = false := rfl
-example : -- row f (3→2): impossible
-    predictsErgative .third .second .high = false := rfl
-example : -- row g high (3→3 high): present
-    predictsErgative .third .third .high = true := rfl
-example : -- row g low (3→3 low): absent
-    predictsErgative .third .third .low = false := rfl
+/-- [clem-deal-2024] Table 4 (p. 285) — the full ergative distribution by
+    person of subject and object, here with the high/low split of the
+    3rd-person-object rows giving 10 cells. Each reduces by `rfl` from
+    `predictsErgative`. Table 4 lists 7 (subject, object) person pairs; it
+    has no reflexive 1→1 or 2→2 rows (see the header note on the 1→1
+    mechanism prediction). -/
+theorem table4 :
+    predictsErgative .first  .second .high = true  ∧  -- a   1→2      obligatory
+    predictsErgative .first  .third  .high = true  ∧  -- b   1→3 high present
+    predictsErgative .first  .third  .low  = false ∧  -- b   1→3 low  absent
+    predictsErgative .second .first  .high = false ∧  -- c   2→1      impossible
+    predictsErgative .second .third  .high = true  ∧  -- d   2→3 high present
+    predictsErgative .second .third  .low  = false ∧  -- d   2→3 low  absent
+    predictsErgative .third  .first  .high = false ∧  -- e   3→1      impossible
+    predictsErgative .third  .second .high = false ∧  -- f   3→2      impossible
+    predictsErgative .third  .third  .high = true  ∧  -- g   3→3 high present
+    predictsErgative .third  .third  .low  = false :=  -- g   3→3 low  absent
+  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 /-- Optionality is exactly the `(✓)` cells: 1→3, 2→3, 3→3. -/
 theorem optionality_only_with_3p_object (subj obj : Person) :
@@ -204,43 +225,85 @@ theorem local_object_must_be_high (p : Person) (h : p.IsSAP) :
   cases p <;> first | rfl | exact h.elim
 
 -- ============================================================================
--- § 7: Counterexamples to configurational case (paper §4.1)
+-- § 7: Configurational case as a foil (paper §1, §4.1)
 -- ============================================================================
 
-/-- The simple configurational rule for ergative assignment from
-    [baker-2015], paper (1): "if there are two distinct NPs in
-    the same spell-out domain such that NP1 c-commands NP2, then
-    value the case feature of NP1 as ergative unless NP2 has already
-    been marked for case." Predicts ergative for *every* transitive
-    subject. -/
-def configurationalRulePredictsErg (_subj _obj : Person) : Bool := true
+/-- A Shawi monotransitive mapped to a dependent-case Spell-Out domain:
+    the subject c-commands the object (earlier = structurally higher), and
+    neither bears lexical case. Person-blind, exactly as a configurational
+    case rule is. -/
+def shawiDomain (_subj _obj : Person) : List NPInDomain :=
+  [⟨"subj", none⟩, ⟨"obj", none⟩]
 
-/-- The simple rule overgenerates 2→1: it predicts `-ri` on a 2P
-    subject with a 1P object, but Shawi disallows it
-    ([clem-deal-2024] (4a), (7a)). -/
+/-- Baker's configurational rule for ergative ([baker-2015]; [clem-deal-2024]
+    (1)): "if there are two distinct NPs in the same spell-out domain such
+    that NP1 c-commands NP2, then value the case feature of NP1 as ergative
+    unless NP2 has already been marked for case." Rather than restate this
+    as a local strawman, we *run* linglib's own dependent-case algorithm —
+    `Syntax.Case.assignCases .ergative`, which values the higher of two
+    caseless NPs ergative — over the Shawi domain. -/
+def configErg (subj obj : Person) : Bool :=
+  getCaseOf "subj" (assignCases .ergative (shawiDomain subj obj)) == some .erg
+
+/-- The configurational rule is person-blind: `assignCases .ergative` values
+    *every* transitive subject ergative, regardless of person. -/
+theorem configErg_person_blind (subj obj : Person) :
+    configErg subj obj = true := by cases subj <;> cases obj <;> decide
+
+/-- It therefore overgenerates exactly where Shawi bans `-ri` because the
+    object outranks the subject. 2→1: [clem-deal-2024] (7a). This is the
+    paper's own argument against rule (1). -/
 theorem configurational_rule_overgenerates_2_to_1 :
-    configurationalRulePredictsErg .second .first = true ∧
-    predictsErgative .second .first .high = false := ⟨rfl, rfl⟩
+    configErg .second .first = true ∧
+    predictsErgative .second .first .high = false := by decide
 
-/-- And 3→1: same pattern ([clem-deal-2024] (7b)). -/
+/-- And 3→1: [clem-deal-2024] (7b). -/
 theorem configurational_rule_overgenerates_3_to_1 :
-    configurationalRulePredictsErg .third .first = true ∧
-    predictsErgative .third .first .high = false := ⟨rfl, rfl⟩
+    configErg .third .first = true ∧
+    predictsErgative .third .first .high = false := by decide
 
-/-- The augmented configurational rule from Bárány & Sheehan 2024,
-    paper (37): "NP1 outranks NP2 on the person hierarchy 1>2>3"
-    written into the configurational rule itself. Still overgenerates
-    on 3→3 with low object: the rule fires (3 ≥ 3) but Shawi shows
-    no `-ri` ([clem-deal-2024] (23c), (24)). The Agree-based
-    analysis predicts the absence because a low 3P object is invisible
-    to the probe, so the subject is G1 rather than G2 — no goal
-    flagging, no ergative. -/
-def augmentedConfigRulePredictsErg (subj obj : Person) : Bool :=
+/-- The augmented configurational rule [clem-deal-2024] (37) writes the
+    person hierarchy into rule (1) itself: NP1 gets ergative when it
+    c-commands a caseless NP2 *and* "NP1 is at least as high as NP2 on the
+    person hierarchy 1>2>3" — note `≥` (the paper's "at least as high as"),
+    so it fires on the person diagonal too. This is [clem-deal-2024]'s
+    rendering of an option explored by [barany-sheehan-2024]; linglib has no
+    formalized person-augmented configurational rule, consistent with the
+    paper's third concern (§4.1) that such rules face no principled limit on
+    the hierarchies they may stipulate. -/
+def augmentedConfigErg (subj obj : Person) : Bool :=
   decide (subj.prominence ≥ obj.prominence)
 
-theorem augmented_config_rule_overgenerates_3_3_low :
-    augmentedConfigRulePredictsErg .third .third = true ∧
-    predictsErgative .third .third .low = false := ⟨rfl, rfl⟩
+/-- [clem-deal-2024] do *not* refute (37) empirically — they grant it "is
+    simple to state" (§4.1), and it is descriptively adequate: on every
+    documented (high-object) cell of Table 4 it predicts exactly the
+    Agree analysis. -/
+theorem augmented_config_matches_on_documented_cells :
+    (augmentedConfigErg .first  .second = predictsErgative .first  .second .high) ∧
+    (augmentedConfigErg .first  .third  = predictsErgative .first  .third  .high) ∧
+    (augmentedConfigErg .second .first  = predictsErgative .second .first  .high) ∧
+    (augmentedConfigErg .second .third  = predictsErgative .second .third  .high) ∧
+    (augmentedConfigErg .third  .first  = predictsErgative .third  .first  .high) ∧
+    (augmentedConfigErg .third  .second = predictsErgative .third  .second .high) ∧
+    (augmentedConfigErg .third  .third  = predictsErgative .third  .third  .high) := by
+  decide
+
+/-- The paper's objections to (37) are architectural, not empirical (§4.1):
+    a person-augmented configurational rule (i) severs the case↔agreement
+    (OAgr-on-S) connection, (ii) cannot unify the case-split person hierarchy
+    with the identical hierarchy seen in agreement (e.g. Spanish
+    ditransitives), and (iii) places no principled limit on which hierarchies
+    a case rule may stipulate. linglib's internal counterpart is *expressive*:
+    being a rule over person alone, (37) is blind to object position, so it
+    cannot produce the position-conditioned optionality of 3rd-person objects
+    (Table 4 rows b, d, g; (8), (23)). It predicts ergative for 3→3 (3 ≥ 3) —
+    the high-object reading, (22) — but has no way to derive the low-object,
+    no-ergative reading, (24), that the Agree analysis gets from object
+    visibility. -/
+theorem augmented_config_blind_to_object_position :
+    augmentedConfigErg .third .third = true ∧
+    predictsErgative .third .third .high = true ∧
+    predictsErgative .third .third .low = false := by decide
 
 -- ============================================================================
 -- § 8: Object syntax — overt-postverbal blocked under ergative
@@ -270,33 +333,24 @@ theorem fronted_and_prodropped_always_licit
   ⟨rfl, rfl⟩
 
 -- ============================================================================
--- § 9: OAgr-on-S correlation ([clem-deal-2024] §4.3, fn. 7)
+-- § 9: OAgr-on-S correlation ([clem-deal-2024] §2, §3.3, fn. 7)
 -- ============================================================================
 
-/-- "Object agreement on subject" can spell out the inner φ-features of
-    the goal-flag bundle that `-ri` exposes; if no such bundle is
-    present (i.e., no ergative), there is nothing for the OAgr-on-S
-    morpheme to attach to.
+/-! "Object agreement on subject" (OAgr-on-S) can spell out the inner
+φ-features of the goal-flag bundle that `-ri` exposes; if no such bundle is
+present (i.e. no ergative), there is nothing for the OAgr-on-S morpheme to
+attach to. [clem-deal-2024]'s empirical generalization (§2, p. 274, with
+footnote 7, elaborated in §3.3) is that OAgr-on-S obtains *only if* the
+subject is ergative — an *only if*, not an *iff*: an ergative subject may
+appear with or without OAgr-on-S.
 
-    We define availability by reusing `predictsErgative` directly,
-    matching [clem-deal-2024] §4.3's empirical generalization that
-    OAgr-on-S obtains *only if* the subject is ergative. The non-trivial
-    asymmetry (ergative *without* OAgr-on-S is grammatical; OAgr-on-S
-    *without* ergative is not) is structurally true here only by
-    construction; deriving it requires the goal-flagging machinery
-    flagged in "Follow-ups". -/
-def oagrOnSAvailable : Person → Person → ObjectPosition → Bool :=
-  predictsErgative
-
-/-- Inheriting the hierarchy bridge: OAgr-on-S is available off the
-    diagonal iff the subject outranks the object — same pattern as
-    `-ri` itself. -/
-theorem oagrOnS_off_diagonal_iff_subj_outranks_obj
-    (subj obj : Person)
-    (h_neq : decomposePerson subj ≠ decomposePerson obj) :
-    oagrOnSAvailable subj obj .high = true ↔
-      subj.prominence > obj.prominence :=
-  erg_off_diagonal_iff_subj_outranks_obj subj obj h_neq
+We deliberately do **not** ship a separate `oagrOnSAvailable` predicate.
+Its availability coincides with `predictsErgative` only *by construction*
+here, so a definition `oagrOnSAvailable := predictsErgative` plus a "bridge"
+theorem would merely rename `predictsErgative` and re-export its theorems.
+The substantive content — the only-if/not-iff asymmetry — is not derivable
+without the goal-flagging machinery flagged in §11; until then it is an
+empirical generalization *about* `predictsErgative`, not a separate object. -/
 
 -- ============================================================================
 -- § 10: Bridges — Shawi inherits Deal-2024 cell counts
@@ -341,8 +395,9 @@ machinery that linglib does not yet have:
    from features deposited there by Agree ([clem-deal-2024] fn. 23).
    Required to state the ergative VI without overgenerating.
 
-Once (1)–(3) are in place, the OAgr-on-S correlation here can be
-strengthened from a definitional implication to a derived theorem.
+Once (1)–(3) are in place, the OAgr-on-S generalization noted in §9 —
+currently an empirical *only if* *about* `predictsErgative` — can be
+derived as a theorem, including the only-if/not-iff asymmetry.
 -/
 
 end ClemDeal2024

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -17496,15 +17496,29 @@
 }
 @article{clem-deal-2024,
   author    = {Clem, Emily and Deal, Amy Rose},
-  year      = {2024},
+  year      = {2026},
   title     = {Dependent Case by {Agree}: {Ergative} in {Shawi}},
   journal   = {Linguistic Inquiry},
-  note      = {Early Access},
+  volume    = {57},
+  number    = {2},
+  pages     = {267--313},
   doi       = {10.1162/ling_a_00529},
   subfield  = {syntax},
   role      = {formalized},
   validated = {true},
-  sources   = {Phenomena/Agreement/Studies/ClemDeal2024.lean;Fragments/Kawapanan/Shawi/Basic.lean;Phenomena/Agreement/Studies/BakerVinokurova2010.lean}
+  sources   = {Studies/ClemDeal2024.lean;Fragments/Kawapanan/Shawi/Basic.lean;Studies/BakerVinokurova2010.lean}
+}
+
+@incollection{barany-sheehan-2024,
+  author    = {B\'{a}r\'{a}ny, Andr\'{a}s and Sheehan, Michelle},
+  year      = {2024},
+  title     = {Challenges for dependent case theory},
+  booktitle = {The Place of Case in the Grammar},
+  editor    = {Sevdali, Christina and Mertyris, Dionysios and Anagnostopoulou, Elena},
+  pages     = {93--126},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  subfield  = {syntax}
 }
 @article{deal-2026,
   author    = {Deal, Amy Rose},


### PR DESCRIPTION
Deep multi-agent mathlib-quality audit of `Studies/ClemDeal2024.lean` (a randomly-picked non-fragment file — Clem & Deal 2024, *Dependent Case by Agree: Ergative in Shawi*), with fixes verified against the **published** *Linguistic Inquiry* version (57(2):267–313).

The file was already honest (good §11 disclosure) and its PCC half cleanly inherits `Deal2024.strictlyDescending`. The defects were concentrated in its "counterexample" deliverable (§7) and its citations.

## What changed

**§7 — stop strawmanning a rival linglib already formalizes.** The simple configurational rule was `def configurationalRulePredictsErg (_subj _obj) := true`, making `configurational_rule_overgenerates_2_to_1` prove `true = true ∧ …`. It now *runs* linglib's own dependent-case algorithm, `Syntax.Case.assignCases .ergative`, over a Shawi Spell-Out domain (`configErg`), so the overgeneration theorems genuinely refute Baker's rule (1) as linglib formalizes it (consumed elsewhere by `Studies/Baker2015.lean`).

**§7 — the augmented rule (37) was misframed.** The published paper (p. 292) grants (37) "is simple to state" and refutes it on **architectural**, not empirical, grounds. The old `augmented_config_rule_overgenerates_3_3_low` manufactured a fake empirical overgeneration and mis-cited (23c) (which actually shows ergative *optionally present*). Replaced with: `augmented_config_matches_on_documented_cells` (37 is descriptively adequate on every documented cell) + `augmented_config_blind_to_object_position` (its real limitation is position-blindness), and a docstring stating the paper's three actual objections. The `≥` rendering was confirmed *faithful* — (37) literally reads "at least as high as."

**Header (C1).** Now states the paper's final generalization (10) including the *same-syntactic-domain* condition, and notes that `predictsErgative` follows the Deal-2024 mechanism — predicting no ergative at the reflexive 1→1 cell (which the paper's data do not document; Table 4 has no 1→1/2→2 rows) — rather than the loose prose of (10).

**§9 — deduplicate, don't bridge.** Dropped `def oagrOnSAvailable := predictsErgative` and its re-exported "bridge" theorem (a renamed `predictsErgative`); §9 now states the OAgr-on-S *only-if* generalization in prose, with the asymmetry deferred to the §11 follow-ups.

**Citations (all checked against the published PDF the maintainer provided):**
- Table 4 `p. 19` → `p. 285` (preprint vs published page)
- 2→1 ban: drop `(4a)` (an *intransitive*) → `(7a)`
- 3P-high object: `(19)` (a 1→2 tree) → `(22)`
- §9: `§4.3` → `§3.3`; **fn. 7 kept** (correct in the published version — the preprint-based finding of "fn. 9" did not apply)
- probe-between-arguments: `(3)` → `(13)` (cyclic expansion)

**`references.bib`:** fixed the stale `Phenomena/Agreement/Studies/…` source paths on `clem-deal-2024`; updated to published metadata (2026; 57(2):267–313); added the missing `barany-sheehan-2024` entry (source of (37)).

**Tidy:** ten Table-4 `example`s → one citable `table4` theorem; vacuous `shawi_is_strictly_descending` demoted to `example`; `objectVisible` wildcard documented (`.zero`/clusivity cells); license header added; imports sorted.

## Verification
- `lake build Linglib.Studies.ClemDeal2024` green.
- All theorems `propext`-only; `configErg_person_blind` is axiom-free. No `sorry`, no `native_decide`.

## Out of scope (flagged for a follow-up)
The sibling bib entries `deal-2024` and `baker-vinokurova-2010` carry the same stale `Phenomena/` paths *and* other dead paths (`Syntax/Minimalist/Core/{Agree,DependentCase}.lean`); they deserve a dedicated bib-hygiene sweep rather than a half-fix here. The bib **key** `clem-deal-2024` was kept (its year field is now 2026) to avoid cascading a rename across ~30 `[clem-deal-2024]` citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-on in this PR: Layer 1 of the `CaseSource` spine

The audit's deepest finding was structural: linglib has **two formalized theories of ergative case that can't be stated in one type** — `Syntax/Case/Dependent.lean` (`assignCases`, producing `CasedNP { case, source }`) vs `Deal2024`/`ClemDeal2024` (bare `Bool`). That Bool altitude is *why* the strawman was possible. Full vision in `scratch/case-source-spine-spec.md` (3 layers; keystone = "case = goal-flag" / bidirectional Agree, deferred to its own spec).

**Layer 1 (here)** lifts the Shawi Agree analysis into the shared `CasedNP`/`CaseSource` vocabulary the dependent-case studies already speak:

- `shawiSubjectCase : … → CasedNP` — ergative is `Case.erg`/`source .agree` (Clem & Deal's thesis), else nominative `.unmarked`.
- `predictsErgative_iff_shawiSubjectCase_erg` — the Bool predicate is the `.erg`-projection of the typed assignment (deduplicate, not bridge).
- `shawi_erg_is_agree_not_dependent` — **the modality disagreement over one type**: both theories value the 1→2 subject `Case.erg`, but Clem & Deal source it from Agree and `assignCases` from configuration (`.dependent`) — a `getSourceOf` disagreement, à la `Baker2015.dependent_source_distinct_from_inherent`.
- `shawi_nom_where_configurational_overgenerates` — the typed 2→1 overgeneration (`.nom` vs `.erg`).

All `propext`-only. ClemDeal2024 stops being a Bool island and becomes the person-sensitive counterpoint in linglib's case story.
