### PR TITLE
refactor(Core/Computability/Subregular): polish ForbiddenPairs

### DIFF
--- a/Linglib/Core/Computability/Subregular/ForbiddenPairs.lean
+++ b/Linglib/Core/Computability/Subregular/ForbiddenPairs.lean
@@ -8,54 +8,45 @@ import Linglib.Core.Data.List.Factors
 import Linglib.Core.Data.List.Chain
 
 /-!
-# Forbidden-Pair TSL_2 Grammars
+# Forbidden-pair TSL_2 grammars
 
-A reusable schema [heinz-rawal-tanner-2011] for tier-based strictly
-2-local languages defined by a *forbidden-pair* relation
-`R : α → α → Prop`. The TSL_2 grammar `TSLGrammar.ofForbiddenPairs R p`
-rules out any string whose tier projection contains an adjacent pair
-`(a, b)` with `R a b`.
+A tier-based strictly 2-local schema [heinz-rawal-tanner-2011]: for a
+*forbidden-pair* relation `R : α → α → Prop` and tier predicate `p`,
+`TSLGrammar.ofForbiddenPairs R p` bans any string whose tier projection has an
+adjacent pair `(a, b)` with `R a b`. The canonical instance is the OCP
+[mccarthy-1986] (`R := (· = ·)`); OCP-Feature and single-tier harmony (with `p`
+carrying blocking/transparency [mcmullin-2016]) are other choices of `R`.
 
-The canonical instance is `R := (· = ·)`: no two adjacent identicals on
-the tier projection. This is the OCP [mccarthy-1986]
-(`Phonology.Subregular.OCP`). The schema is general enough to capture
-OCP-Feature variants (`R := share-feature-X`) and any single-tier
-2-factor markedness constraint over a fixed subset projection.
-Long-distance harmony patterns over a single segmental tier instantiate
-other choices of `R` (e.g. `R := disagree-on-feature-X`).
+## Main definitions
 
-Note that stress-rhythm constraints (\*Lapse, \*Clash) and the syllable
-phonotactic \*Coda ban are *not* TSL_2 instances over the segmental
-alphabet: \*Lapse and \*Clash are SL_2 over a *syllable*-level alphabet
-(carrying stress weight), and \*Coda is SL_1 over an alphabet that
-encodes syllable structure (e.g. CV templates with marked coda symbols).
-The OT-side helper for the SL_1 case is `mkForbidSingletonOnTier` in
-`Phonology/OptimalityTheory/Constraints.lean`; the language-side
-SL_1 substrate is in `Subregular/StrictlyLocal.lean` (the `k = 1` case).
+* `Subregular.TSLGrammar.ofForbiddenPairs R p` — the TSL_2 grammar above.
+* `Subregular.countAdjacent R xs` — count of `R`-related adjacent pairs in `xs`.
 
-The single bridge theorem `mem_ofForbiddenPairs_lang_iff_filter_isChain`
-characterizes language membership as an `IsChain` check on the projected
-string. This is the chain-side payoff of the boundary-vacuity machinery
-in `Subregular/Boundary.lean`. Phonological-constraint bridges
-(`mkForbidPairsOnTier_zero_iff_in_lang`) layer on top in
-`Phonology/Subregular/`.
+## Main results
+
+* `Subregular.mem_ofForbiddenPairs_lang_iff_filter_isChain` — membership reduces
+  to an `IsChain (¬ R · ·)` check on the tier-projected string.
+
+## Implementation notes
+
+Out of scope (they need a richer-than-segmental alphabet): \*Lapse/\*Clash (SL_2
+over a syllable alphabet) and \*Coda (SL_1, via `mkForbidSingletonOnTier`).
+Similarity-graded [hansson-2010] and interval-conditioned (ITSL) harmony, and
+cross-tier dependencies (MTSL), also fall outside this single-tier constructor.
 -/
 
 namespace Subregular
 
-variable {α : Type*}
+variable {α : Type*} (R : α → α → Prop)
 
-/-- The set of forbidden 2-factors induced by a binary relation `R`: pairs
-`[some a, some b]` with `R a b`. Boundary-adjacent factors are not
-forbidden — the chain relation `CleanPair R` is boundary-vacuous. -/
-def forbiddenPairsSet (R : α → α → Prop) : Set (Augmented α) :=
+/-- The forbidden 2-factors induced by `R`: the pairs `[some a, some b]` with
+`R a b`. -/
+def forbiddenPairs : Set (Augmented α) :=
   { f | ∃ a b, R a b ∧ f = [some a, some b] }
 
-/-- Chain relation associated with a forbidden-pair relation `R`: two
-augmented symbols are *clean as a pair* iff they are not both `some`
-related by `R`. Boundary symbols are vacuously clean on either side
-(`CleanPair.isBoundaryVacuous`). -/
-def CleanPair (R : α → α → Prop) : Option α → Option α → Prop
+/-- The adjacency relation for `R`: a pair is clean unless both symbols are
+`some` and `R`-related (`none` is vacuously clean — `CleanPair.isBoundaryVacuous`). -/
+def CleanPair : Option α → Option α → Prop
   | some a, some b => ¬ R a b
   | _, _ => True
 
@@ -72,144 +63,87 @@ variable {R : α → α → Prop}
 lemma some_some (a b : α) :
     CleanPair R (some a) (some b) ↔ ¬ R a b := Iff.rfl
 
-/-- The clean-pair relation is boundary-vacuous: `none` always satisfies it
-on either side. Used to lift chain-membership of the boundary-padded
-augmented string to the unpadded core. -/
+/-- `CleanPair R` is boundary-vacuous: `none` satisfies it on either side. -/
 lemma isBoundaryVacuous : IsBoundaryVacuous (CleanPair (α := α) R) :=
   ⟨none_left, none_right⟩
 
 end CleanPair
 
-/-- A list of `Option α` has no `[some a, some b]` 2-factor with `R a b`
-iff it is a chain for `CleanPair R`. The factor-membership/chain bridge
-underlying `mem_forbidPairs_lang_iff_filter_isChain`. -/
-lemma forall_kFactors_two_not_forbiddenPairsSet_iff_isChain
-    (R : α → α → Prop) (xs : List (Option α)) :
-    (∀ f ∈ List.kFactors 2 xs, f ∉ forbiddenPairsSet R) ↔
-      xs.IsChain (CleanPair R) := by
+/-- A list has no forbidden 2-factor iff it is a chain for `CleanPair R`. -/
+lemma forbiddenPairFree_iff_isChain (xs : Augmented α) :
+    (∀ f ∈ List.kFactors 2 xs, f ∉ forbiddenPairs R) ↔ xs.IsChain (CleanPair R) := by
   induction xs with
-  | nil =>
-    refine ⟨fun _ => List.isChain_nil, ?_⟩
-    intro _ f hf
-    simp only [List.kFactors_two_nil, List.not_mem_nil] at hf
-  | cons a rest ih =>
-    cases rest with
-    | nil =>
-      refine ⟨fun _ => List.isChain_singleton _, ?_⟩
-      intro _ f hf
-      simp only [List.kFactors_two_singleton, List.not_mem_nil] at hf
+  | nil => simp
+  | cons a rest ih => cases rest with
+    | nil => simp
     | cons b rest' =>
-      rw [List.kFactors_two_cons_cons, List.forall_mem_cons, List.isChain_cons_cons,
-          ih]
-      refine and_congr_left' ?_
-      constructor
-      · intro h1
-        cases a with
-        | none => exact CleanPair.none_left _
-        | some a' =>
-          cases b with
-          | none => exact CleanPair.none_right _
-          | some b' =>
-            rw [CleanPair.some_some]
-            intro hab
-            exact h1 ⟨a', b', hab, rfl⟩
-      · intro h1
-        rintro ⟨a', b', hR, hz⟩
-        simp only [List.cons.injEq, and_true] at hz
-        obtain ⟨rfl, rfl⟩ := hz
-        exact h1 hR
+      rw [List.kFactors_two_cons_cons, List.forall_mem_cons, List.isChain_cons_cons, ih]
+      exact and_congr_left' (by cases a <;> cases b <;> simp [forbiddenPairs, CleanPair])
 
-/-- The TSL_2 grammar capturing "no tier-adjacent pair satisfies `R`": tier
-projection (via `Tier.byClass p`) followed by an SL_2 ban on
-`forbiddenPairsSet R`. OCP and any single-tier adjacency-based markedness
-constraint factor through this constructor. -/
-def TSLGrammar.ofForbiddenPairs (R : α → α → Prop) [DecidableRel R]
-    (p : α → Prop) [DecidablePred p] : TSLGrammar 2 α where
+/-- The TSL_2 grammar banning tier-adjacent pairs satisfying `R`: tier `p`,
+permitting everything but `forbiddenPairs R`. -/
+def TSLGrammar.ofForbiddenPairs (p : α → Prop) [DecidablePred p] : TSLGrammar 2 α where
   tier := p
-  permitted := (forbiddenPairsSet R)ᶜ
+  permitted := (forbiddenPairs R)ᶜ
 
-/-- **Bridge** (TSL_2 language form): membership in
-`TSLGrammar.ofForbiddenPairs R p` reduces to an `IsChain (¬ R · ·)` check on
-the tier-projected string. The single generic membership characterization
-that all forbidden-pair markedness constraints inherit. Composes (i) the
-factor/chain bridge `forall_kFactors_two_not_forbiddenPairsSet_iff_isChain`,
-(ii) the boundary-vacuity of `CleanPair R`, and (iii) `List.isChain_map` to
-drop the `some`. -/
-lemma mem_ofForbiddenPairs_lang_iff_filter_isChain (R : α → α → Prop)
-    [DecidableRel R] (p : α → Prop) [DecidablePred p] (w : List α) :
+/-- Membership in `ofForbiddenPairs R p` reduces to an `IsChain (¬ R · ·)` check
+on the tier-projected string — the characterization all forbidden-pair
+constraints inherit. -/
+lemma mem_ofForbiddenPairs_lang_iff_filter_isChain (p : α → Prop) [DecidablePred p] (w : List α) :
     w ∈ (TSLGrammar.ofForbiddenPairs R p).lang ↔
       (w.filter (fun x => decide (p x))).IsChain (fun a b => ¬ R a b) := by
   rw [TSLGrammar.mem_lang]
   simp only [TSLGrammar.ofForbiddenPairs, Set.mem_compl_iff]
-  rw [forall_kFactors_two_not_forbiddenPairsSet_iff_isChain,
+  rw [forbiddenPairFree_iff_isChain,
       CleanPair.isBoundaryVacuous.isChain_boundary_two_iff,
       tierProject_eq_filter, List.isChain_map]
   rfl
 
 /-! ### Adjacent-pair counting
 
-Promoted from `Phonology/OptimalityTheory/Constraints.lean`:
-`countAdjacent R xs` counts the adjacent `(a, b)` pairs in `xs` with
-`R a b`. Alphabet-generic; nothing OT-specific. The OT-side
-`mkForbidPairsOnTier` constructor consumes this directly, and the
-chain-bridge `countAdjacent_eq_zero_iff_isChain` connects it to the
-language-level `IsChain` characterization above. -/
+`countAdjacent` is the violation-count companion of the membership view; the
+OT-side `mkForbidPairsOnTier` consumes it via `countAdjacent_eq_zero_iff_isChain`. -/
 
-/-- Count adjacent pairs `(a, b)` in a list satisfying a binary relation
-`R`. The shared engine behind any "forbidden adjacent pair" markedness
-or violation count: OCP (`R := (· = ·)`), agreement (`R := (· ≠ ·)`),
-and asymmetric harmony all pass through. -/
-def countAdjacent (R : α → α → Prop) [DecidableRel R] : List α → Nat
+/-- Count of adjacent pairs `(a, b)` in `xs` with `R a b`. -/
+def countAdjacent [DecidableRel R] : List α → Nat
   | [] | [_] => 0
-  | a :: b :: rest => (if R a b then 1 else 0) + countAdjacent R (b :: rest)
+  | a :: b :: rest => (if R a b then 1 else 0) + countAdjacent (b :: rest)
 
-/-- `countAdjacent R xs = 0` iff no two consecutive elements of `xs` are
-related by `R`. The chain-form characterisation of zero-violation
-forbidden-pair candidates. -/
-lemma countAdjacent_eq_zero_iff_isChain (R : α → α → Prop) [DecidableRel R]
-    (xs : List α) :
+/-- `countAdjacent R xs = 0` iff `xs` is a chain for `¬ R · ·`. -/
+lemma countAdjacent_eq_zero_iff_isChain [DecidableRel R] (xs : List α) :
     countAdjacent R xs = 0 ↔ xs.IsChain (fun a b => ¬ R a b) := by
   induction xs with
-  | nil => exact ⟨fun _ => List.isChain_nil, fun _ => rfl⟩
-  | cons a rest ih =>
-    cases rest with
-    | nil => exact ⟨fun _ => List.isChain_singleton _, fun _ => rfl⟩
+  | nil => simp [countAdjacent]
+  | cons a rest ih => cases rest with
+    | nil => simp [countAdjacent]
     | cons b rest' =>
-      show (if R a b then 1 else 0) + countAdjacent R (b :: rest') = 0 ↔ _
-      rw [List.isChain_cons_cons]
-      by_cases hRab : R a b
-      · simp [hRab]
-      · simp [hRab, ih]
+      rw [List.isChain_cons_cons, ← ih]
+      by_cases hRab : R a b <;> simp [countAdjacent, hRab]
 
 /-! ### API around `ofForbiddenPairs` -/
 
-/-- Membership in `(ofForbiddenPairs R p).lang` is decidable, derived from
-the `IsChain` characterization. -/
-instance decidableMemOfForbiddenPairsLang (R : α → α → Prop) [DecidableRel R]
-    (p : α → Prop) [DecidablePred p] (w : List α) :
+/-- Membership in `(ofForbiddenPairs R p).lang` is decidable, via the `IsChain`
+characterization. -/
+instance decidableMemOfForbiddenPairsLang [DecidableRel R] (p : α → Prop) [DecidablePred p] (w : List α) :
     Decidable (w ∈ (TSLGrammar.ofForbiddenPairs R p).lang) :=
   decidable_of_iff _ (mem_ofForbiddenPairs_lang_iff_filter_isChain R p w).symm
 
-/-- The empty string is in every forbidden-pair language: there are no
-tier-adjacent pairs to check. -/
-@[simp] lemma nil_mem_ofForbiddenPairs_lang (R : α → α → Prop) [DecidableRel R]
-    (p : α → Prop) [DecidablePred p] :
+/-- The empty string is in every forbidden-pair language. -/
+@[simp] lemma nil_mem_ofForbiddenPairs_lang (p : α → Prop) [DecidablePred p] :
     ([] : List α) ∈ (TSLGrammar.ofForbiddenPairs R p).lang :=
   (mem_ofForbiddenPairs_lang_iff_filter_isChain R p []).mpr List.isChain_nil
 
-/-- **Antitonicity in `R`**: forbidding more pairs (`R ≤ R'`) shrinks the
-language. The chain witness for the larger `R'` immediately yields one for
-the smaller `R` since `¬ R' a b → ¬ R a b`. -/
-lemma lang_antitone_R {R R' : α → α → Prop} [DecidableRel R] [DecidableRel R']
-    (h : ∀ a b, R a b → R' a b) (p : α → Prop) [DecidablePred p] :
+/-- Forbidding more pairs shrinks the language: `R ≤ R'` gives
+`lang R' ≤ lang R`. -/
+lemma lang_antitone_R {R R' : α → α → Prop} (h : ∀ a b, R a b → R' a b)
+    (p : α → Prop) [DecidablePred p] :
     (TSLGrammar.ofForbiddenPairs R' p).lang ≤
       (TSLGrammar.ofForbiddenPairs R p).lang := fun w hw =>
   (mem_ofForbiddenPairs_lang_iff_filter_isChain R p w).mpr <|
     ((mem_ofForbiddenPairs_lang_iff_filter_isChain R' p w).mp hw).imp
       fun _ _ hR' hR => hR' (h _ _ hR)
 
-/-- **Boundary case** (`R = ⊥`): if no pair is forbidden, the language is
-universal. -/
+/-- If no pair is forbidden (`R = ⊥`), the language is universal. -/
 @[simp] lemma lang_R_bot (p : α → Prop) [DecidablePred p] :
     (TSLGrammar.ofForbiddenPairs (fun _ _ : α => False) p).lang = Set.univ := by
   ext w
@@ -217,9 +151,8 @@ universal. -/
   exact ⟨fun _ => Set.mem_univ _, fun _ =>
     (List.isChain_top _).imp (fun _ _ _ h => h.elim)⟩
 
-/-- **Boundary case** (`p = ⊥`): if no symbol is on the tier, the projection is
-empty and the language is universal. -/
-@[simp] lemma lang_p_bot (R : α → α → Prop) [DecidableRel R] :
+/-- If no symbol is on the tier (`p = ⊥`), the language is universal. -/
+@[simp] lemma lang_p_bot :
     (TSLGrammar.ofForbiddenPairs R (fun _ : α => False)).lang = Set.univ := by
   ext w
   rw [mem_ofForbiddenPairs_lang_iff_filter_isChain]
@@ -229,12 +162,10 @@ empty and the language is universal. -/
           simp only [decide_false, Bool.false_eq_true] at h)]
   exact List.isChain_nil
 
-/-- **Boundary case** (`p = ⊤`): with no tier filtering the language reduces
-to the SL_2 case — no two adjacent symbols of the raw string may be
-`R`-related. Not marked `@[simp]`: the RHS is not a simpler normal form
-than the LHS (compare `lang_R_bot`/`lang_p_bot` which simplify to
-`Set.univ`). -/
-lemma lang_p_top (R : α → α → Prop) [DecidableRel R] :
+/-- With no tier filtering (`p = ⊤`) the language is the SL_2 case: no two
+adjacent symbols of the raw string are `R`-related. (Not `@[simp]`: the RHS is
+no simpler than the LHS.) -/
+lemma lang_p_top :
     (TSLGrammar.ofForbiddenPairs R (fun _ : α => True)).lang =
       { w | w.IsChain (fun a b => ¬ R a b) } := by
   ext w
@@ -243,44 +174,26 @@ lemma lang_p_top (R : α → α → Prop) [DecidableRel R] :
     rw [List.filter_eq_self]; intros; simp only [decide_true]
   rw [hfilter]; rfl
 
-/-- **Same-tier composition** (membership form): forbidding the disjunction of
-two relations on a single tier coincides with conjunctive membership in the
-two corresponding languages. The cross-tier case (two relations on *different*
-tiers `p₁ ≠ p₂`) does NOT factor through this constructor — that is precisely
-the empirical and formal motivation for multi-tier strictly local languages
-(MTSL). -/
-lemma mem_lang_R_sup_iff (R₁ R₂ : α → α → Prop) [DecidableRel R₁]
-    [DecidableRel R₂] (p : α → Prop) [DecidablePred p] (w : List α) :
+/-- Forbidding `R₁ ∨ R₂` on one tier is conjunctive membership in the two
+languages. (Cross-tier composition needs MTSL, not this constructor.) -/
+lemma mem_lang_R_sup_iff (R₁ R₂ : α → α → Prop) (p : α → Prop) [DecidablePred p] (w : List α) :
     w ∈ (TSLGrammar.ofForbiddenPairs (fun a b => R₁ a b ∨ R₂ a b) p).lang ↔
       w ∈ (TSLGrammar.ofForbiddenPairs R₁ p).lang ∧
         w ∈ (TSLGrammar.ofForbiddenPairs R₂ p).lang := by
-  simp only [mem_ofForbiddenPairs_lang_iff_filter_isChain]
-  refine ⟨fun h => ⟨h.imp (fun _ _ hne h1 => hne (Or.inl h1)),
-                    h.imp (fun _ _ hne h2 => hne (Or.inr h2))⟩, ?_⟩
-  rintro ⟨h1, h2⟩
-  exact (h1.and h2).imp (fun _ _ ⟨hne1, hne2⟩ => fun
-    | Or.inl hR1 => hne1 hR1
-    | Or.inr hR2 => hne2 hR2)
+  simp only [mem_ofForbiddenPairs_lang_iff_filter_isChain, not_or, List.isChain_and_iff]
 
-/-- **Same-tier composition** (lattice form): forbidding the disjunction of two
-relations on a single tier equals the meet of the two corresponding
-languages. The cross-tier case is *not* expressible — see MTSL. -/
-lemma lang_R_sup_eq_inf (R₁ R₂ : α → α → Prop) [DecidableRel R₁]
-    [DecidableRel R₂] (p : α → Prop) [DecidablePred p] :
+/-- Lattice form of `mem_lang_R_sup_iff`: `lang (R₁ ∨ R₂) = lang R₁ ⊓ lang R₂`. -/
+lemma lang_R_sup_eq_inf (R₁ R₂ : α → α → Prop) (p : α → Prop) [DecidablePred p] :
     (TSLGrammar.ofForbiddenPairs (fun a b => R₁ a b ∨ R₂ a b) p).lang =
       (TSLGrammar.ofForbiddenPairs R₁ p).lang ⊓
         (TSLGrammar.ofForbiddenPairs R₂ p).lang :=
   Set.ext fun w => mem_lang_R_sup_iff R₁ R₂ p w
 
-/-! ### Design boundary (mathematical)
+/-! ### Design boundary: non-monotonicity in the tier predicate
 
-The language `(ofForbiddenPairs R p).lang` is **neither monotone nor
-antitone** in the tier predicate `p`. Both failure directions are
-witnessed by the theorems `lang_p_not_monotone` and `lang_p_not_antitone`
-below. This is the formal counterpart of the linguistic intuition that
-*which segments project to the tier* is not just a monotone refinement
-but a substantive theoretical commitment, and it is why TSL_2 over
-different tiers gives genuinely incomparable theories. -/
+`(ofForbiddenPairs R p).lang` is **neither monotone nor antitone** in the tier
+predicate `p` (`lang_p_not_monotone`/`lang_p_not_antitone` below): which segments
+project is a substantive commitment, not just a monotone refinement. -/
 
 /-- Two-element alphabet used as a witness for the design-boundary
 non-monotonicity theorems. Local to this section. -/
@@ -294,58 +207,22 @@ private instance : DecidablePred Pₛ
   | .t => isFalse not_false
 private instance : DecidablePred Pₛₜ := fun _ => isTrue trivial
 
-/-- **Non-monotonicity** of `(ofForbiddenPairs R p).lang` in the tier
-predicate `p` (forward direction): there exist `p ≤ p'` and a string `xs`
-such that `xs ∈ lang p` but `xs ∉ lang p'`. Witness: `R := (· = ·)`,
-`p := {s}`, `p' := {s, t}`, `xs := [s, t, t]`; `filter` under `p` gives
-`[s]` (chain), but under `p'` gives `[s, t, t]` (the adjacent `t, t`
-violates the OCP). -/
-theorem lang_p_not_monotone :
-    ∃ (R : TwoSym → TwoSym → Prop) (_ : DecidableRel R)
-      (p p' : TwoSym → Prop) (_ : DecidablePred p) (_ : DecidablePred p')
-      (xs : List TwoSym),
-      (∀ a, p a → p' a) ∧
-        xs ∈ (TSLGrammar.ofForbiddenPairs R p).lang ∧
-        xs ∉ (TSLGrammar.ofForbiddenPairs R p').lang :=
-  ⟨(· = ·), inferInstance, Pₛ, Pₛₜ, inferInstance, inferInstance,
-    [.s, .t, .t], by intro a _; cases a <;> trivial,
-    by decide, by decide⟩
+/-- `(ofForbiddenPairs R p).lang` is not monotone in `p`: for `Pₛ ≤ Pₛₜ`,
+`[s, t, t] ∈ lang Pₛ` (tier filter `[s]` is a chain) but `∉ lang Pₛₜ` (filter
+`[s, t, t]` has the OCP-violating `t, t`). -/
+private theorem lang_p_not_monotone :
+    (∀ a, Pₛ a → Pₛₜ a) ∧
+      [TwoSym.s, .t, .t] ∈ (TSLGrammar.ofForbiddenPairs (· = ·) Pₛ).lang ∧
+      [TwoSym.s, .t, .t] ∉ (TSLGrammar.ofForbiddenPairs (· = ·) Pₛₜ).lang :=
+  ⟨fun _ _ => trivial, by decide, by decide⟩
 
-/-- **Non-antitonicity** of `(ofForbiddenPairs R p).lang` in the tier
-predicate `p` (reverse direction): there exist `p ≤ p'` and a string `xs`
-such that `xs ∉ lang p` but `xs ∈ lang p'`. Witness: `R := (· = ·)`,
-`p := {s}`, `p' := {s, t}`, `xs := [s, t, s]`; `filter` under `p` gives
-`[s, s]` (the adjacent `s, s` violates the OCP), but under `p'` gives
-`[s, t, s]` (chain — interleaving `t` separates the `s`s). -/
-theorem lang_p_not_antitone :
-    ∃ (R : TwoSym → TwoSym → Prop) (_ : DecidableRel R)
-      (p p' : TwoSym → Prop) (_ : DecidablePred p) (_ : DecidablePred p')
-      (xs : List TwoSym),
-      (∀ a, p a → p' a) ∧
-        xs ∉ (TSLGrammar.ofForbiddenPairs R p).lang ∧
-        xs ∈ (TSLGrammar.ofForbiddenPairs R p').lang :=
-  ⟨(· = ·), inferInstance, Pₛ, Pₛₜ, inferInstance, inferInstance,
-    [.s, .t, .s], by intro a _; cases a <;> trivial,
-    by decide, by decide⟩
-
-/-! ### Design boundary (empirical)
-
-The substantive empirical force of the non-monotonicity result is the
-gradient similarity-based OCP of [frisch-pierrehumbert-broe-2004]:
-Arabic co-occurrence restrictions decay with featural distance rather
-than following a clean tier cut, so the same `R` paired with different
-`p` yields incomparable predictions about which root pairs are licit.
-See `Studies/FrischPierrehumbertBroe2004.lean` for
-the load-bearing instance: the natural-classes similarity metric
-(FPB eq. 7), the worked examples /f, m/ → 2/9 and /b, f/ → 3/8, and
-the `categorical_fails_three_test_points` divergence theorem witnessing
-that no TSL_2 grammar with `R := λ a b => similarity la b ≥ t` can
-reproduce three specific Table IV bins.
-
-Dependencies on multiple tiers — e.g. simultaneous consonantal and
-vocalic harmony — likewise fall outside this single-tier constructor.
-The natural way to combine constraints across tiers is the multi-tier
-strictly local (MTSL) family, which is *not* a special case of this
-constructor. -/
+/-- `(ofForbiddenPairs R p).lang` is not antitone in `p`: for `Pₛ ≤ Pₛₜ`,
+`[s, t, s] ∉ lang Pₛ` (tier filter `[s, s]` violates OCP) but `∈ lang Pₛₜ`
+(filter `[s, t, s]` is a chain — the `t` separates the `s`s). -/
+private theorem lang_p_not_antitone :
+    (∀ a, Pₛ a → Pₛₜ a) ∧
+      [TwoSym.s, .t, .s] ∉ (TSLGrammar.ofForbiddenPairs (· = ·) Pₛ).lang ∧
+      [TwoSym.s, .t, .s] ∈ (TSLGrammar.ofForbiddenPairs (· = ·) Pₛₜ).lang :=
+  ⟨fun _ _ => trivial, by decide, by decide⟩
 
 end Subregular

--- a/Linglib/Core/Data/List/Chain.lean
+++ b/Linglib/Core/Data/List/Chain.lean
@@ -16,8 +16,8 @@ Alphabet-generic `List.IsChain` facts not currently in mathlib, mirroring
 * `List.isChain_top` — every list is a chain for the always-true relation.
 * `List.isChain_cons_iff_of_forall_rel` / `List.isChain_append_singleton_iff_of_forall_rel`
   — prepending/appending an element related to (or from) everything preserves `IsChain`.
-* `List.IsChain.and` — two chains on the same list combine into a chain for the
-  conjunction relation (the companion of mathlib's `List.IsChain.imp`).
+* `List.IsChain.and` / `List.isChain_and_iff` — a chain for a conjunction relation
+  is exactly a chain for each conjunct (the meet law; companion of `List.IsChain.imp`).
 -/
 
 namespace List
@@ -66,5 +66,13 @@ lemma and {S T : α → α → Prop} : ∀ {l : List α},
     exact ⟨⟨hS.1, hT.1⟩, hS.2.and hT.2⟩
 
 end IsChain
+
+/-- A list is a chain for a conjunction relation iff it is a chain for each
+conjunct — the `Iff` strengthening of `IsChain.and` (the meet law for `IsChain`
+over its relation argument). -/
+lemma isChain_and_iff {S T : α → α → Prop} {l : List α} :
+    l.IsChain (fun a b => S a b ∧ T a b) ↔ l.IsChain S ∧ l.IsChain T :=
+  ⟨fun h => ⟨h.imp fun _ _ => And.left, h.imp fun _ _ => And.right⟩,
+   fun ⟨hS, hT⟩ => hS.and hT⟩
 
 end List

--- a/Linglib/Phonology/Subregular/Agree.lean
+++ b/Linglib/Phonology/Subregular/Agree.lean
@@ -47,9 +47,9 @@ variable {α : Type}
 
 /-- Forbidden 2-factors for AGREE: pairs `[some x, some y]` of two distinct
 non-boundary symbols. The inequality-relation specialization of
-`forbiddenPairsSet`. -/
+`forbiddenPairs`. -/
 def agreeForbidden (α : Type) [DecidableEq α] : Set (Augmented α) :=
-  forbiddenPairsSet (α := α) (· ≠ ·)
+  forbiddenPairs (α := α) (· ≠ ·)
 
 /-- The TSL_2 grammar capturing "no two adjacent distinct symbols on the
 tier defined by `p`" — equivalently, every tier-adjacent pair agrees.

--- a/Linglib/Phonology/Subregular/OCP.lean
+++ b/Linglib/Phonology/Subregular/OCP.lean
@@ -55,9 +55,9 @@ variable {α : Type}
 
 /-- Forbidden 2-factors for the OCP: pairs `[some x, some x]` of two identical
 non-boundary symbols. The identity-relation specialization of
-`forbiddenPairsSet`. -/
+`forbiddenPairs`. -/
 def ocpForbidden (α : Type) [DecidableEq α] : Set (Augmented α) :=
-  forbiddenPairsSet (α := α) (· = ·)
+  forbiddenPairs (α := α) (· = ·)
 
 /-- The TSL_2 grammar capturing "no two adjacent identical symbols on the
 tier defined by `p`". The identity-relation specialization of


### PR DESCRIPTION
Mathlib-quality pass on `Subregular/ForbiddenPairs.lean` (the TSL_2 forbidden-pair schema), plus the `IsChain` meet-law it rests on.

- New `List.isChain_and_iff` in `Core/Data/List/Chain.lean` (sibling to `isChain_top`/`IsChain.and`): a chain for a conjunction relation is exactly a chain for each conjunct. Upstream candidate.
- The lattice/order laws of `R ↦ (ofForbiddenPairs R p).lang` now *fall out* of `lang R = {w | (filter w).IsChain (¬R)}`: `⊔ ↦ ⊓` (`mem_lang_R_sup_iff`) from De Morgan + `isChain_and_iff`; `⊥ ↦ ⊤` from `isChain_top`; antitone from `IsChain.imp`.
- Both inductions (`forbiddenPairFree_iff_isChain`, `countAdjacent_eq_zero_iff_isChain`) golfed to the same structural pattern.
- `forbiddenPairsSet` → `forbiddenPairs` (drop redundant `Set` suffix); `[DecidableRel R]` kept only on the 3 decls that use it (vestigial instances dropped from the rest); module + declaration docstrings tightened to mathlib form; the empirical FrischPierrehumbertBroe section moved out of the substrate docstring (it lives in the Studies file).