### PR TITLE
L2 case-carrier: down-set decomposition of a rank order is generic

### DIFF
--- a/Linglib/Core/Order/PartialRank.lean
+++ b/Linglib/Core/Order/PartialRank.lean
@@ -1,4 +1,5 @@
 import Mathlib.Order.RelClasses
+import Mathlib.Order.Interval.Finset.Basic
 
 /-!
 # Partial-Rank Orders
@@ -33,6 +34,10 @@ totality whenever any element is unranked.
   an unranked element is `≤`-related only to itself
 * `Core.Order.partialOrderOfRank` — `partialOrderOfSO` at `RankLT r`;
   `<` is definitionally `RankLT` and `≤` is `RankLE`
+* `Core.Order.rankShells` — the canonical down-set decomposition `Iic ∘ r`,
+  and `rankLT_iff_rankShells`: the rank order *is* the shadow of inclusion
+  between the down-sets (the structural fact behind nanosyntactic "feature
+  stack" decompositions, replacing per-instance stipulate-a-table-and-`decide`)
 -/
 
 namespace Core.Order
@@ -122,5 +127,48 @@ abbrev partialOrderOfRank (r : α → Option β) [Preorder β] :
   partialOrderOfSO (RankLT r)
 
 end Preorder
+
+section Shells
+
+variable {ι : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι]
+
+/-- The canonical **down-set decomposition** of a partial rank: an element's
+    content is the initial segment `Finset.Iic` of its rank (its "shell
+    stack"). For a rank into a chain an element *is* this down-set, and the
+    rank order is the shadow of inclusion between the down-sets
+    (`rankLT_iff_rankShells`). This is the order-theoretic content behind
+    nanosyntactic feature-stack decompositions (`Syntax/Case/Order.lean`). -/
+def rankShells (r : α → Option ι) (a : α) : Option (Finset ι) :=
+  (r a).map Finset.Iic
+
+/-- `Finset.Iic` is strictly monotone: `Iic a ⊂ Iic b ↔ a < b`. -/
+theorem Iic_ssubset_Iic {a b : ι} : Finset.Iic a ⊂ Finset.Iic b ↔ a < b := by
+  rw [Finset.ssubset_iff_subset_ne, Finset.Iic_subset_Iic, lt_iff_le_and_ne]
+  refine and_congr_right (fun hab => ?_)
+  constructor
+  · intro hne he; exact hne (by rw [he])
+  · intro hne he
+    refine hne (le_antisymm hab ?_)
+    exact Finset.mem_Iic.mp (he ▸ Finset.mem_Iic.mpr le_rfl)
+
+/-- **The rank order is the shadow of its down-set decomposition.** Strict-rank
+    comparison through `r` coincides with strict inclusion of the shell stacks
+    `rankShells r`. Generic over any rank into a chain — replacing per-instance
+    "stipulate a shells table + `decide` it agrees with the rank" with one
+    structural fact. -/
+theorem rankLT_iff_rankShells (r : α → Option ι) (a b : α) :
+    RankLT r a b ↔ RankLT (rankShells r) a b := by
+  rw [rankLT_iff, rankLT_iff]
+  constructor
+  · rintro ⟨x, y, hx, hy, hxy⟩
+    exact ⟨Finset.Iic x, Finset.Iic y, by rw [rankShells, hx]; rfl,
+      by rw [rankShells, hy]; rfl, Iic_ssubset_Iic.mpr hxy⟩
+  · rintro ⟨X, Y, hX, hY, hXY⟩
+    simp only [rankShells, Option.map_eq_some_iff] at hX hY
+    obtain ⟨x, hx, rfl⟩ := hX
+    obtain ⟨y, hy, rfl⟩ := hY
+    exact ⟨x, y, hx, hy, Iic_ssubset_Iic.mp hXY⟩
+
+end Shells
 
 end Core.Order

--- a/Linglib/Syntax/Case/Order.lean
+++ b/Linglib/Syntax/Case/Order.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.Finset.Basic
+import Mathlib.Order.Interval.Finset.Fin
 import Linglib.Core.Order.PartialRank
 import Linglib.Features.Case.Basic
 /-!
@@ -123,25 +124,22 @@ rank encoding above is the shadow of that decomposition. -/
 
 /-- The shell stack of an on-hierarchy case: the downward-closed set of
     case shells its representation contains ([caha-2009]'s nested
-    functional sequence, with shells indexed abstractly). Stipulated
-    independently of `containmentRank`; `cahaLT_iff_kshells_ssubset`
-    certifies the two agree. -/
-def kshells : Case → Option (Finset (Fin 5))
-  | .nom => some {0}
-  | .acc => some {0, 1}
-  | .gen => some {0, 1, 2}
-  | .dat => some {0, 1, 2, 3}
-  | .loc => some {0, 1, 2, 3, 4}
-  | _ => none
+    functional sequence). **Derived** as the down-set `Iic` of the
+    containment rank (`Core.Order.rankShells`), not stipulated alongside
+    `containmentRank` — so the two cannot drift, and
+    `cahaLT_iff_kshells_ssubset` is the structural shadow fact rather than a
+    coincidence to be `decide`d. -/
+def kshells : Case → Option (Finset (Fin 5)) :=
+  Core.Order.rankShells containmentRank
 
-/-- **The order is the shadow of the decomposition**: the containment
-    order through the numeric rank coincides with the partial-rank order
-    through the shell stacks (`<` on `Finset` is strict inclusion `⊂`).
-    The rank encoding is certified against the structural containment
-    claim, not stipulated alongside it. -/
+/-- **The order is the shadow of the decomposition**: the containment order
+    through the numeric rank coincides with the partial-rank order through the
+    shell stacks (`<` on `Finset` is strict inclusion `⊂`). Now an instance of
+    the generic `Core.Order.rankLT_iff_rankShells`, since `kshells` *is* the
+    rank's down-set decomposition. -/
 theorem cahaLT_iff_kshells_ssubset (c₁ c₂ : Case) :
     cahaLT c₁ c₂ ↔ RankLT kshells c₁ c₂ := by
-  revert c₁ c₂; decide
+  unfold kshells; exact Core.Order.rankLT_iff_rankShells containmentRank c₁ c₂
 
 /-! ### The Caha order as scoped instances
 
@@ -246,20 +244,19 @@ def PathDir.rank : PathDir → Fin 4
 
 /-- The shell stack of a path direction: the downward-closed set of path
     heads its structure contains ([pantcheva-2011]'s nested
-    [Route [Source [Goal [Place]]]]). Stipulated independently of `rank`;
-    `lt_iff_shells_ssubset` certifies they agree. -/
-def PathDir.shells : PathDir → Finset (Fin 4)
-  | .place => {0}
-  | .goal => {0, 1}
-  | .source => {0, 1, 2}
-  | .route => {0, 1, 2, 3}
+    [Route [Source [Goal [Place]]]]). **Derived** as the down-set `Iic` of
+    `PathDir.rank`, not stipulated alongside it; `lt_iff_shells_ssubset` is
+    then the structural shadow fact (`Core.Order.Iic_ssubset_Iic`). -/
+def PathDir.shells (d : PathDir) : Finset (Fin 4) := Finset.Iic d.rank
 
 /-- **The order is the shadow of the decomposition**: directional
     containment (strict rank) coincides with strict inclusion of shell
-    stacks — the directional analogue of `cahaLT_iff_kshells_ssubset`. -/
+    stacks — the directional analogue of `cahaLT_iff_kshells_ssubset`,
+    here just `Core.Order.Iic_ssubset_Iic` since the shells *are* `Iic` of
+    the rank. -/
 theorem PathDir.lt_iff_shells_ssubset (d₁ d₂ : PathDir) :
     d₁.rank < d₂.rank ↔ d₁.shells ⊂ d₂.shells := by
-  revert d₁ d₂; decide
+  unfold PathDir.shells; exact Core.Order.Iic_ssubset_Iic.symm
 
 /-! ### Directional denotation ([pantcheva-2011] Ch. 5)
 


### PR DESCRIPTION
**L2 of the Case-as-object arc** (`scratch/case-source-spine-spec.md`). First carrier-layer brick: lift the "feature stack = down-set of the rank" decomposition into the shared partial-rank gadget, and **derive** the two `Syntax/Case/Order.lean` instances from it instead of stipulating-and-bridging.

## The anti-pattern removed
Both halves of `Order.lean` did the same thing: a rank function, *plus* an independently stipulated `shells` table, *plus* a `decide` theorem certifying the two agree —
```
def kshells | .nom => {0} | .acc => {0,1} | …   -- re-encodes containmentRank
theorem cahaLT_iff_kshells_ssubset … := by decide   -- bridges the two stipulations
```
That's "stipulate two, bridge them" — the shells table just re-encodes what the rank already says (the shells are always initial segments `{0}, {0,1}, …` = `Iic ∘ rank`).

## The consolidation
- **`Core/Order/PartialRank.lean`** (the generic gadget): add `rankShells r := (r ·).map Finset.Iic` — the canonical down-set decomposition of *any* partial rank — and `rankLT_iff_rankShells`: **the rank order is the shadow of `⊂` between the down-sets**. Plus helper `Iic_ssubset_Iic`. This is the order-theoretic content behind nanosyntactic "feature stack" decompositions, stated once, generically.
- **`Syntax/Case/Order.lean`**: `kshells` and `PathDir.shells` are now `Iic ∘ rank` (two explicit tables deleted); the two order-shadow theorems become instances of the generic structural fact, not `decide` over a redundant stipulation. Values are **byte-identical** (behavior-preserving; verified by `decide` examples and by `Pantcheva2011`/`Caha2009`/fragments still building).

## Verification
- Targeted build green (`PartialRank` + `Order` + `Caha2009` + `Pantcheva2011` + `Dependent` + the Finnish/Hungarian/Telugu fragment consumers, 831 jobs). Full lib left to CI.
- `propext`/`Classical.choice`/`Quot.sound` only; no `sorry`, no `native_decide`.

## Why it's "carrier as object"
`kshells` *is* now the down-set object `Iic(rank)` (the spec's `caseToFeatures`, in the faithful partial form the off-hierarchy silence requires), and the order-is-down-set-inclusion property holds generically. The same `rankShells` gadget can later absorb other "feature → down-closure" stipulations in the lib (e.g. `PersonFeature.below`-style geometries) — a follow-up.

Part of the arc in `scratch/case-source-spine-spec.md`: L1 (typed lift, #620) done; this is L2; L3 = alignment as `Setoid.ker` (Bell(3)=5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)