### PR TITLE
refactor(Core/Computability/Subregular): reground PiecewiseTestable on InvariantUnder

### DIFF
--- a/Linglib/Core/Computability/Subregular/PiecewiseTestable.lean
+++ b/Linglib/Core/Computability/Subregular/PiecewiseTestable.lean
@@ -3,39 +3,27 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Core.Computability.Language
 import Linglib.Core.Computability.Subregular.StrictlyPiecewise
 import Mathlib.Computability.Language
 
 /-!
-# Piecewise Testable Languages (PT_k)
+# Piecewise testable languages (PT_k)
 
-A language `L` is **piecewise `k`-testable** when membership depends only
-on which length-`k` *subsequences* the input contains [simon-1975]
-[rogers-pullum-2011] [lambert-2022]. PT is to SP what LT is to
-SL: the Boolean closure of the strictly variant.
-
-Both are *property-based* (extensional) classifications — there is no
-canonical grammar, only an indistinguishability relation on strings:
-`w₁ ~_PT w₂` iff their `k`-subsequence sets coincide. `L` is PT_k iff it
-is closed under `~_PT`.
-
-## Lambert (2026) and the multitier extension
-
-The multitier closure of PT (which Lambert classifies as 𝒥) covers a
-large fraction of attested phonotactic constraints — including the
-piecewise-testable analyses of unbounded stress patterns surveyed in
-[lambert-2026] §3 and the Karanga Shona tone analysis (which is
-piecewise testable but not multitier generalised definite). The
-substrate sits adjacent to `Multitier.lean` and is composed via
-`IsBTC IsPiecewiseTestable`.
+A language is **piecewise `k`-testable** when its membership depends only on the set of
+length-`≤ k` subsequences (scattered subwords) of the input [simon-1975] — i.e. it is
+invariant under the map `subseqSet k`. PT_k is the Boolean closure of SP_k, the
+piecewise analogue of locally testable over strictly local.
 
 ## Main definitions
 
-* `subseqSet k w` — the set of length-`k` subsequences of `w`.
-* `IsPiecewiseTestable k L` — closure of `L` under equality of `subseqSet`.
+* `subseqSet k w` — the subsequences of `w` of length `≤ k`.
+* `Language.IsPiecewiseTestable L k` — `L.InvariantUnder (subseqSet k)`.
 
-The cast `Language.IsStrictlyPiecewise L k → IsPiecewiseTestable k L` lives at
-the end of the file (mathlib convention: cast lives with the larger class).
+## Main results
+
+* `Language.IsStrictlyPiecewise.toIsPiecewiseTestable` — `SP_k ⊆ PT_k`.
+* Closure under complement is inherited from `Language.InvariantUnder.compl`.
 -/
 
 namespace Subregular
@@ -44,17 +32,8 @@ open List
 
 variable {α : Type*}
 
-/-- The set of subsequences of `w` of length **at most** `k`. The PT
-indistinguishability relation `w₁ ~_PT w₂` is equality of
-`subseqSet k w₁` and `subseqSet k w₂`.
-
-The "up to `k`" semantics matches [simon-1975] and the Heinz/Lambert
-literature ([lambert-2026] Def 11; [heinz-2018]). The "exactly
-`k`" alternative would mis-classify languages that distinguish strings
-of length less than `k` (e.g. Luganda high-tone plateauing
-[lambert-2026] (37) distinguishes `[h]` from `[ℓ]` while their
-length-3 subsequence sets are both empty). Unlike `factorSet`, no
-boundary augmentation: SP/PT are insensitive to position. -/
+/-- The subsequences of `w` of length **at most** `k`. The "≤ k" (rather than
+"exactly k") bound is what keeps strings shorter than `k` distinguishable. -/
 def subseqSet (k : ℕ) (w : List α) : Set (List α) :=
   { s | s <+ w ∧ s.length ≤ k }
 
@@ -62,35 +41,40 @@ def subseqSet (k : ℕ) (w : List α) : Set (List α) :=
     s ∈ subseqSet k w ↔ s <+ w ∧ s.length ≤ k :=
   Iff.rfl
 
-/-- A language is **piecewise `k`-testable** iff strings with the same set
-of length-≤-`k` subsequences are either both in `L` or both out. -/
-def IsPiecewiseTestable (k : ℕ) (L : Language α) : Prop :=
-  ∀ w₁ w₂ : List α, subseqSet k w₁ = subseqSet k w₂ → (w₁ ∈ L ↔ w₂ ∈ L)
-
-/-- Subsequences of length at most `k` are interchangeable across strings
-sharing their `subseqSet k`. The standard ratchet for proving
-`IsPiecewiseTestable k L` from a predicate that depends only on
-length-≤-`k` subsequence presence. -/
+/-- Subsequences of length at most `k` are interchangeable across strings sharing
+their `subseqSet k`. The ratchet for proving piecewise testability from a predicate
+depending only on length-`≤ k` subsequence presence. -/
 lemma subseqSet_eq_iff {k : ℕ} {w₁ w₂ : List α}
     (heq : subseqSet k w₁ = subseqSet k w₂) {s : List α} (hlen : s.length ≤ k) :
     s <+ w₁ ↔ s <+ w₂ := by
-  refine ⟨fun hs => ?_, fun hs => ?_⟩
-  · have h₁ : s ∈ subseqSet k w₁ := ⟨hs, hlen⟩
-    rw [heq] at h₁
-    exact h₁.1
-  · have h₂ : s ∈ subseqSet k w₂ := ⟨hs, hlen⟩
-    rw [← heq] at h₂
-    exact h₂.1
-
-/-- **SP_k ⊆ PT_k**: every strictly-`k`-piecewise language is piecewise
-`k`-testable. The SP test ("every length-`k` subsequence is permitted")
-trivially depends only on the *set* of subsequences of that length. -/
-theorem _root_.Language.IsStrictlyPiecewise.toIsPiecewiseTestable {k : ℕ} {L : Language α}
-    (h : L.IsStrictlyPiecewise k) : IsPiecewiseTestable k L := by
-  obtain ⟨G, rfl⟩ := h
-  intro w₁ w₂ heq
-  refine ⟨fun hw s hlen hs => hw s hlen ?_, fun hw s hlen hs => hw s hlen ?_⟩
-  · exact (subseqSet_eq_iff heq hlen.le).mpr hs
-  · exact (subseqSet_eq_iff heq hlen.le).mp hs
+  simpa [hlen] using Set.ext_iff.mp heq s
 
 end Subregular
+
+namespace Language
+
+open Subregular
+
+variable {α : Type*}
+
+/-- A language is **piecewise `k`-testable**: membership factors through the
+length-`≤ k` subsequence set `subseqSet k`. -/
+def IsPiecewiseTestable (L : Language α) (k : ℕ) : Prop :=
+  L.InvariantUnder (subseqSet k)
+
+/-- Pointwise form: strings with equal `subseqSet k` are `L`-equivalent. -/
+lemma isPiecewiseTestable_iff {L : Language α} {k : ℕ} :
+    L.IsPiecewiseTestable k ↔
+      ∀ w₁ w₂, subseqSet k w₁ = subseqSet k w₂ → (w₁ ∈ L ↔ w₂ ∈ L) :=
+  ⟨fun h _ _ h' => h.iff h', fun h => InvariantUnder.mk fun _ _ h' => h _ _ h'⟩
+
+/-- **SP_k ⊆ PT_k**: the strictly-piecewise test ("every length-`k` subsequence is
+permitted") depends only on the set of subsequences of that length. -/
+theorem IsStrictlyPiecewise.toIsPiecewiseTestable {k : ℕ} {L : Language α}
+    (h : L.IsStrictlyPiecewise k) : L.IsPiecewiseTestable k := by
+  obtain ⟨G, rfl⟩ := h
+  refine InvariantUnder.mk fun w₁ w₂ heq => ⟨fun hw s hlen hs => ?_, fun hw s hlen hs => ?_⟩
+  · exact hw s hlen ((subseqSet_eq_iff heq hlen.le).mpr hs)
+  · exact hw s hlen ((subseqSet_eq_iff heq hlen.le).mp hs)
+
+end Language

--- a/Linglib/Studies/Lambert2026.lean
+++ b/Linglib/Studies/Lambert2026.lean
@@ -861,8 +861,8 @@ length-3 `[h, ℓ, h]`, the length-2 `[h, ℓ]`, and the length-1 `[h]`.
 The proof reduces each conjunct of `lugandaPred` to the corresponding
 `subseqSet 3` membership question, then transfers via
 `subseqSet_eq_iff`. -/
-theorem luganda_isPT : IsPiecewiseTestable 3 lugandaLang := by
-  intro w₁ w₂ heq
+theorem luganda_isPT : lugandaLang.IsPiecewiseTestable 3 := by
+  refine Language.isPiecewiseTestable_iff.mpr fun w₁ w₂ heq => ?_
   simp only [mem_lugandaLang, lugandaPred]
   -- Bridge: `LugandaTone.high ∈ w` ↔ `[high] <+ w`
   have mem_iff_sublist : ∀ (w : List LugandaTone),
@@ -1035,8 +1035,8 @@ def prinmiLang : Language LugandaTone := { w | prinmiPred w }
 /-- **Prinmi pitch-accent ∈ PT_3** (Lambert 2026 (39)). All three
 conjuncts depend only on length-≤-3 subsequence presence: the length-1
 `[h]` and the two length-3 patterns. -/
-theorem prinmi_isPT : IsPiecewiseTestable 3 prinmiLang := by
-  intro w₁ w₂ heq
+theorem prinmi_isPT : prinmiLang.IsPiecewiseTestable 3 := by
+  refine Language.isPiecewiseTestable_iff.mpr fun w₁ w₂ heq => ?_
   simp only [mem_prinmiLang, prinmiPred]
   have h1 : ([LugandaTone.high] <+ w₁) ↔ ([LugandaTone.high] <+ w₂) :=
     subseqSet_eq_iff heq (by decide : (1 : ℕ) ≤ 3)
@@ -1107,8 +1107,8 @@ def arigibiLang : Language LugandaTone :=
 
 /-- **Arigibi pitch-accent ∈ PT_2** (Lambert 2026 §5.3, formula `¬h..h`).
 The constraint depends only on length-2 subseq `[h, h]`. -/
-theorem arigibi_isPT : IsPiecewiseTestable 2 arigibiLang := by
-  intro w₁ w₂ heq
+theorem arigibi_isPT : arigibiLang.IsPiecewiseTestable 2 := by
+  refine Language.isPiecewiseTestable_iff.mpr fun w₁ w₂ heq => ?_
   show ¬ ([LugandaTone.high, .high] <+ w₁) ↔ ¬ ([LugandaTone.high, .high] <+ w₂)
   exact not_congr (subseqSet_eq_iff heq (le_refl 2))
 
@@ -1205,8 +1205,8 @@ def chuaveLang : Language LugandaTone := { w | LugandaTone.high ∈ w }
 
 /-- **Chuave obligatoriness ∈ PT_1** (Lambert 2026 §5.5). The constraint
 `high ∈ w` is the singleton subseq presence `[high] <+ w`. -/
-theorem chuave_isPT : IsPiecewiseTestable 1 chuaveLang := by
-  intro w₁ w₂ heq
+theorem chuave_isPT : chuaveLang.IsPiecewiseTestable 1 := by
+  refine Language.isPiecewiseTestable_iff.mpr fun w₁ w₂ heq => ?_
   show LugandaTone.high ∈ w₁ ↔ LugandaTone.high ∈ w₂
   rw [← List.singleton_sublist, ← List.singleton_sublist]
   exact subseqSet_eq_iff heq (le_refl 1)
@@ -1294,8 +1294,8 @@ def kagoshimaLang : Language LugandaTone := { w | kagoshimaPred w }
 /-- **Kagoshima Japanese pitch-accent ∈ PT_3** (Lambert 2026 (42)).
 All three conjuncts depend only on length-≤-3 subseq presence:
 length-1 `[h]`, length-2 `[h, h]`, length-3 `[h, ℓ, ℓ]`. -/
-theorem kagoshima_isPT : IsPiecewiseTestable 3 kagoshimaLang := by
-  intro w₁ w₂ heq
+theorem kagoshima_isPT : kagoshimaLang.IsPiecewiseTestable 3 := by
+  refine Language.isPiecewiseTestable_iff.mpr fun w₁ w₂ heq => ?_
   simp only [mem_kagoshimaLang, kagoshimaPred]
   have h1 : ([LugandaTone.high] <+ w₁) ↔ ([LugandaTone.high] <+ w₂) :=
     subseqSet_eq_iff heq (by decide : (1 : ℕ) ≤ 3)


### PR DESCRIPTION
Mathlib-quality pass on `Subregular/PiecewiseTestable.lean`, folding it into the `InvariantUnder` family that `Definite.lean` already inhabits.

## Substantive
- **`Language.IsPiecewiseTestable L k := L.InvariantUnder (subseqSet k)`** — was a hand-rolled `∀ w₁ w₂, subseqSet k w₁ = subseqSet k w₂ → (w₁ ∈ L ↔ w₂ ∈ L)`, which is exactly `invariantUnder_iff`'s RHS. Now L-first + `Language`-namespaced (matching `Language.IsDefinite`), inheriting `.compl`/`.iff`/`.mk` for free. `isPiecewiseTestable_iff` is the pointwise accessor.
- `subseqSet_eq_iff` golfed to one line; `IsStrictlyPiecewise.toIsPiecewiseTestable` routed through `InvariantUnder.mk`.

## Hygiene
- Docstring to mathlib idiom; **no phonology/linguistics** (upstreamable) — kept only `[simon-1975]`, the genuine *mathematical* origin (automata theory) that mathlib would cite, and dropped the linguistics-application cites (`rogers-pullum`/`heinz`/`lambert`) + the Luganda/Karanga examples + section/def locators.
- Cut the **fabricated** `IsBTC IsPiecewiseTestable` cross-ref (no such composition exists) and the **factually-wrong** "Karanga is PT-but-not-BTLI" claim (the study proves Karanga *is* BTLI).
- Variable discipline left per-lemma, matching mathlib's `Data/List/Sublists.lean` (the direct length-`n`-sublists analogue uses `variable {α β γ}` only).

`Lambert2026` PT theorems migrated to L-first + `isPiecewiseTestable_iff.mpr`. Cone green (977 jobs).