### PR TITLE
refactor(Core/Computability/Subregular): tidy StrictlyLocal/StrictlyPiecewise

### DIFF
--- a/Linglib/Core/Computability/Subregular/StrictlyLocal.lean
+++ b/Linglib/Core/Computability/Subregular/StrictlyLocal.lean
@@ -8,13 +8,12 @@ import Linglib.Core.Computability.Subregular.Boundary
 import Linglib.Core.Data.List.Factors
 
 /-!
-# Strictly Local Languages (SL_k)
+# Strictly local languages (SL_k)
 
 A language `L` is **strictly `k`-local** when membership is determined by the
-length-`k` substrings of the boundary-augmented input [rogers-pullum-2011]
-[lambert-2022]: a grammar is a set `G` of permitted `k`-factors, and `w ∈ L` iff
-every `k`-factor of `boundary k w` lies in `G`. Phonology usually states the
-*forbidden* dual (`G = Fᶜ`), finite even over an infinite alphabet.
+length-`k` substrings of the boundary-augmented input: a grammar is a set `G` of
+permitted `k`-factors, and `w ∈ L` iff every `k`-factor of `boundary k w` lies in
+`G`. The forbidden-factor dual (`G = Fᶜ`) is finite even over an infinite alphabet.
 
 ## Main definitions
 
@@ -58,15 +57,18 @@ def ofForbidden (forbidden : Set (Augmented α)) : SLGrammar α := forbiddenᶜ
 
 end SLGrammar
 
+end Subregular
+
+namespace Language
+
+variable {α : Type*}
+
+open Subregular
+
 /-- A language `L` is **strictly `k`-local** iff some `SLGrammar α` generates it at
 width `k`. Witness-style, mirroring `Language.IsRegular`/`Language.IsContextFree`
 ("L is regular iff some DFA accepts L"). -/
-def _root_.Language.IsStrictlyLocal (L : Language α) (k : ℕ) : Prop :=
+def IsStrictlyLocal (L : Language α) (k : ℕ) : Prop :=
   ∃ G : SLGrammar α, G.language k = L
 
-/-- Every SL grammar witnesses `Language.IsStrictlyLocal` for its language. -/
-lemma SLGrammar.isStrictlyLocal_language (k : ℕ) (G : SLGrammar α) :
-    (G.language k).IsStrictlyLocal k :=
-  ⟨G, rfl⟩
-
-end Subregular
+end Language

--- a/Linglib/Core/Computability/Subregular/StrictlyPiecewise.lean
+++ b/Linglib/Core/Computability/Subregular/StrictlyPiecewise.lean
@@ -7,33 +7,26 @@ import Mathlib.Computability.Language
 import Mathlib.Data.List.Sublists
 
 /-!
-# Strictly Piecewise Languages (SP_k)
+# Strictly piecewise languages (SP_k)
 
 A language `L` is **strictly `k`-piecewise** when membership is determined by which
-length-`k` *subsequences* (scattered, non-contiguous selections) the input contains
-[rogers-pullum-2011] [lambert-2022]. Whereas SL_k constrains adjacent material via
-*factors* (contiguous infixes), SP_k constrains long-distance co-occurrence via
-*subsequences*.
-
-## Why subsequences (not factors)
-
-The two locality dimensions in the subregular hierarchy are *adjacency-based*
-(SL/LT/LTT, contiguous `k`-factors) and *precedence-based* (SP, `k`-element
-subsequences). A long-distance pattern such as sibilant harmony — *sasi* but not
-*saʃi* — is naturally SP_2: the forbidden length-2 subsequence is `[s, ʃ]`,
-regardless of intervening material. No boundary augmentation is needed: subsequences
-are blind to position, so edge markers add no information [heinz-rogers-2010].
+length-`k` *subsequences* (scattered, non-contiguous selections) the input contains.
+Where SL_k constrains adjacent material via contiguous factors, SP_k constrains
+long-distance co-occurrence via subsequences — so no boundary augmentation is needed
+(subsequences are blind to position).
 
 ## Main definitions
 
-* `Subregular.SPGrammar α` — a grammar is a set of permitted length-`k`
-  subsequences; the width `k` is supplied to `language`.
+* `Subregular.SPGrammar α` — a set of permitted subsequences; the width `k` is
+  supplied to `language`, not baked into the carrier.
 * `Subregular.SPGrammar.language k` — the `Language α` it generates: every length-`k`
   subsequence of `w` must be permitted.
 * `Language.IsStrictlyPiecewise L k` — `L` is strictly `k`-piecewise.
 
-The relation `List.Sublist` (`<+`) is mathlib's "is a (non-contiguous) subsequence
-of" — exactly what SP needs.
+## Implementation notes
+
+`List.Sublist` (`<+`) is mathlib's non-contiguous "is a subsequence of", exactly the
+SP primitive.
 -/
 
 namespace Subregular
@@ -71,14 +64,17 @@ instance decidableMemLanguage (k : ℕ) (G : SPGrammar α)
 
 end SPGrammar
 
+end Subregular
+
+namespace Language
+
+variable {α : Type*}
+
+open Subregular
+
 /-- A language `L` is **strictly `k`-piecewise** iff some `SPGrammar α` generates it
 at width `k`. -/
-def _root_.Language.IsStrictlyPiecewise (L : Language α) (k : ℕ) : Prop :=
+def IsStrictlyPiecewise (L : Language α) (k : ℕ) : Prop :=
   ∃ G : SPGrammar α, G.language k = L
 
-/-- Every SP grammar witnesses `Language.IsStrictlyPiecewise` for its language. -/
-lemma SPGrammar.isStrictlyPiecewise_language (k : ℕ) (G : SPGrammar α) :
-    (G.language k).IsStrictlyPiecewise k :=
-  ⟨G, rfl⟩
-
-end Subregular
+end Language


### PR DESCRIPTION
Small mathlib-quality pass on the two foundational grammar classes (already structurally clean from #606/#607; this is the namespace + docstring follow-up).

- Move `IsStrictlyLocal`/`IsStrictlyPiecewise` out of the awkward `def _root_.Language.X` (written *inside* `namespace Subregular`) into a proper `namespace Language` block with `open Subregular`, mirroring `Definite.lean`.
- Drop the unused trivial witness lemmas `SLGrammar.isStrictlyLocal_language` / `SPGrammar.isStrictlyPiecewise_language` (zero consumers; each just `⟨G, rfl⟩`).
- Docstrings: no phonology/linguistics (upstreamable) — cut the `rogers-pullum`/`lambert`/`heinz` citations, the "Phonology usually states" aside, and the sibilant-harmony example; keep the formal adjacency-vs-precedence content. Titles to sentence case; SP docstring de-duplicated (the "Why subsequences" section restated the intro) and given a `## Implementation notes` for the `List.Sublist` primitive.

Def names (`Language.IsStrictlyLocal`/`IsStrictlyPiecewise`) are unchanged, so consumers (Tier/Multitier/PiecewiseTestable/ForbiddenPairs/Studies) are unaffected; cone builds green.