### PR TITLE
refactor(Core/Computability/Subregular/Function): strip linguistics from docstrings; fix coherence

### DIFF
--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -14,11 +14,10 @@ using **both** directions of context: a left automaton scans `→` and assigns a
 to each position, a right automaton scans `←` and assigns a right state, and the output at
 position `i` is `out (leftState before i) (input i) (rightState after i)`.
 
-Following [meinhardt-mai-bakovic-mccollum-2024] (Def. 5), a bimachine over a single
-alphabet is **non-interacting** when its output is a *union of one-sided change-rules over
-the identity*: each side may add its own change, but neither can suppress the other's.
-`IsBimachineWeaklyDeterministic` is computability by such a bimachine — the
-weakly-deterministic functions of [heinz-lai-2013].
+A bimachine over a single alphabet is **non-interacting** when its output is a *union of
+one-sided change-rules over the identity*: each side may add its own change, but neither
+can suppress the other's. `IsBimachineWeaklyDeterministic` is computability by such a
+bimachine — the weakly-deterministic functions.
 
 ## Main results
 
@@ -26,9 +25,9 @@ weakly-deterministic functions of [heinz-lai-2013].
 * `not_isBimachineWeaklyDeterministic_of_requiresBothSides` — a map with an unbounded
   *interaction* (`RequiresBothSides`: the target is changed, yet perturbing either far side
   reverts it) is **not** weakly deterministic. The far perturbations force both one-sided
-  rules inert at the witness cell while the base needs one to fire — the faithful McCollum
-  et al. teeth ([meinhardt-mai-bakovic-mccollum-2024] Def. 2). Conjunctive blocking
-  (Tutrugbu) satisfies it; union-spreading (Maasai) does not.
+  rules inert at the witness cell while the base needs one to fire — no union of one-sided
+  rules can produce the change. A conjunctive change satisfies it; a two-sided union does
+  not.
 -/
 
 namespace Subregular.Function
@@ -134,11 +133,10 @@ def unite (cL cR a : α) : α := if cL = a then (if cR = a then a else cR) else 
 theorem unite_eq_default {cL cR a : α} (h : unite cL cR a = a) : cL = a ∧ cR = a := by
   unfold unite at h; split_ifs at h with h1 h2 <;> simp_all
 
-/-- **Non-interaction** (faithful to [meinhardt-mai-bakovic-mccollum-2024] Def. 5): the cell
-output is a *union of one-sided change-rules over the identity default* — `ωL`/`ωR` each
-propose a change for their side, and the output takes whichever fires, else leaves the
-symbol unchanged. Neither side can *suppress* the other's change; that asymmetry is
-exactly what blocking (interaction) would require. -/
+/-- **Non-interaction**: the cell output is a *union of one-sided change-rules over the
+identity default* — `ωL`/`ωR` each propose a change for their side, and the output takes
+whichever fires, else leaves the symbol unchanged. Neither side can *suppress* the other's
+change; that asymmetry is exactly what interaction would require. -/
 def Bimachine.IsNonInteracting (B : Bimachine L R α α) : Prop :=
   ∃ (ωL : L → α → α) (ωR : R → α → α), ∀ l a r, B.out l a r = unite (ωL l a) (ωR r a) a
 
@@ -147,11 +145,10 @@ def IsBimachineWeaklyDeterministic (f : List α → List α) : Prop :=
   ∃ (L R : Type) (_ : Fintype L) (_ : Fintype R) (B : Bimachine L R α α),
     B.run = f ∧ B.IsNonInteracting
 
-/-- A target whose spread **requires both sides**: `f` changes `base[i]` from its input,
-but perturbing either far side reverts it to identity. The suppression/conjunction
-structure of unbounded interaction ([meinhardt-mai-bakovic-mccollum-2024] Def. 2). Unlike
-`IsUnboundedCircumambient`, union-spreading (Maasai) does *not* satisfy it: removing one
-trigger leaves the other, so the output stays changed. -/
+/-- A target that **requires both sides**: `f` changes `base[i]` from its input, but
+perturbing either far side reverts it to identity. The suppression/conjunction structure of
+unbounded interaction. Unlike `IsUnboundedCircumambient`, a two-sided union does *not*
+satisfy it: removing one trigger leaves the other, so the output stays changed. -/
 def RequiresBothSides (f : List α → List α) : Prop :=
   ∀ d, ∃ (base : List α) (i : ℕ), i < base.length ∧ (f base)[i]? ≠ base[i]? ∧
     (∃ uL : List α, uL.length = base.length ∧ AgreeFrom base uL (i - d) ∧
@@ -159,11 +156,10 @@ def RequiresBothSides (f : List α → List α) : Prop :=
     (∃ uR : List α, uR.length = base.length ∧ AgreeUpto base uR (i + d) ∧
       uR[i]? = base[i]? ∧ (f uR)[i]? = uR[i]?)
 
-/-- **Unbounded interaction ⟹ not weakly deterministic** — the faithful McCollum et al.
-teeth. At the witness, the base spreads but each far perturbation reverts: the right
-perturbation keeps the left state, forcing `ωL` inert at this cell; the left perturbation
-keeps the right state, forcing `ωR` inert; yet the base needs one of them to fire — no
-union of one-sided rules can produce the spread. -/
+/-- **Unbounded interaction ⟹ not weakly deterministic.** At the witness, the base changes
+but each far perturbation reverts: the right perturbation keeps the left state, forcing `ωL`
+inert at this cell; the left perturbation keeps the right state, forcing `ωR` inert; yet the
+base needs one of them to fire — no union of one-sided rules can produce the change. -/
 theorem not_isBimachineWeaklyDeterministic_of_requiresBothSides {f : List α → List α}
     (hf : RequiresBothSides f) : ¬ IsBimachineWeaklyDeterministic f := by
   rintro ⟨L, R, _, _, B, rfl, ωL, ωR, hω⟩
@@ -194,8 +190,8 @@ theorem not_isBimachineWeaklyDeterministic_of_requiresBothSides {f : List α →
   rw [B.run_getElem?, hbi, Option.map_some, hω, hωL, hωR, unite_self]
 
 /-- Non-vacuity: any bimachine whose cell output is literally a `unite` of independent
-one-sided rules is non-interacting — the class genuinely admits two-sided union-spreading
-(the Maasai shape), which the per-cell notion wrongly excluded. -/
+one-sided rules is non-interacting — the class genuinely admits two-sided union changes,
+which a naive per-cell notion would wrongly exclude. -/
 example (ωL : L → α → α) (ωR : R → α → α) (lInit : L) (lStep : L → α → L)
     (rInit : R) (rStep : R → α → R) :
     (Bimachine.mk lInit lStep rInit rStep

--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -33,13 +33,11 @@ trivial, so its cell output is a *one-sided* rule — non-interacting.
 
 Both inclusions are proper:
 
-* **WD ⊊ regular** — `weaklyDeterministic_strict_subset_regular`: the conjunctive spread
+* **WD ⊊ regular** — `weaklyDeterministic_strict_subset_regular`: the conjunctive change
   `conjBM` (a target raised iff a trigger occurs on *both* sides) is bimachine-computable
-  but `RequiresBothSides`. Tutrugbu ATR is the attested instance
-  (`McCollumEtAl2020.tutrugbu_not_weaklyDeterministic`).
-* **subsequential ⊊ WD** — Maasai ATR (`MeinhardtEtAl2024.maasai_not_letterLeftSubsequential`)
-  is a genuinely two-sided union, `IsUnboundedCircumambient` hence not right-myopic hence
-  not left-subsequential, yet WD.
+  but `RequiresBothSides`.
+* **subsequential ⊊ WD** — a genuinely two-sided union is `IsUnboundedCircumambient`,
+  hence not right-myopic, hence not left-subsequential, yet WD.
 -/
 
 namespace Subregular.Function
@@ -85,11 +83,11 @@ theorem IsBimachineComputable.of_weaklyDeterministic {f : List α → List α}
 
 /-! ### Strictness: WD ⊊ regular
 
-A *conjunctive* spread — a target raised iff a trigger occurs on **both** sides — is
+A *conjunctive* change — a target raised iff a trigger occurs on **both** sides — is
 bimachine-computable but `RequiresBothSides`, so no non-interacting bimachine computes
-it. (Tutrugbu ATR is the attested instance; `McCollumEtAl2020.tutrugbu_not_weaklyDeterministic`.) -/
+it. -/
 
-/-- Toy alphabet for the conjunctive-spread witness: a trigger, a recessive target, and
+/-- Toy alphabet for the conjunctive-change witness: a trigger, a recessive target, and
 its raised form. -/
 inductive ConjSym | trig | tgt | raised
   deriving DecidableEq, Repr
@@ -195,10 +193,9 @@ theorem weaklyDeterministic_strict_subset_regular :
 /-! ### The strictly-local lower end: single-symbol ISL/OSL ⊆ subsequential
 
 The ISL/OSL classes are block-output (length-changing) in general, so they sit outside the
-length-preserving lattice. Their **single-symbol** (length-preserving) fragment — the
-harmony-relevant case (e.g. `MeinhardtEtAl2024.rightwardATR_osl`) — embeds: the same
-bounded window that makes `toFinSFST` finite-state serves as a `LetterSFST` state, with the
-lone output symbol as the letter. This extends the chain to
+length-preserving lattice. Their **single-symbol** (length-preserving) fragment embeds: the
+same bounded window that makes `toFinSFST` finite-state serves as a `LetterSFST` state, with
+the lone output symbol as the letter. This extends the chain to
 `single-symbol ISL/OSL ⊆ subsequential ⊆ WD ⊆ regular`. -/
 
 /-- A length-preserving (single-symbol) left-ISL rule as a synchronous transducer: the

--- a/Linglib/Core/Computability/Subregular/Function/ISL.lean
+++ b/Linglib/Core/Computability/Subregular/Function/ISL.lean
@@ -45,14 +45,6 @@ The witness style `IsX k f := ∃ r : XRule k α β, r.apply = f` mirrors
 `StrictlyLocal.lean`. The `k` parameter is a type-level annotation only:
 `windowOutput` is unconstrained at the type level; `applyAux` truncates the
 threaded window to length `k - 1`.
-
-## References
-
-* [chandlee-2014]
-* [chandlee-heinz-2018]
-* [chandlee-eyraud-heinz-2015]
-* [heinz-lai-2013]
-* [jardine-2016]
 -/
 
 namespace Subregular.Function
@@ -246,8 +238,7 @@ theorem flatMap_isLeftInputStrictlyLocal_one (h : α → List β) :
 
 /-- **Every erasing letterwise projection is 1-Left-ISL.** `List.filterMap g`
 (for `g : α → Option β`) is letterwise erasing, hence a special case of
-`ISLRule.ofStringHom` via `fun x => (g x).toList`. Phonological tier projections
-are the instance where `g` is a tier-membership map. -/
+`ISLRule.ofStringHom` via `fun x => (g x).toList`. -/
 theorem filterMap_isLeftInputStrictlyLocal_one (g : α → Option β) :
     IsLeftInputStrictlyLocal 1 (List.filterMap g) := by
   -- filterMap g = List.flatMap (fun x => (g x).toList)
@@ -270,9 +261,9 @@ theorem filterMap_isLeftInputStrictlyLocal_one (g : α → Option β) :
 
 `ISLRule.toFinSFST` projects an ISL rule into a finite-state SFST whose
 state space is the bounded input window `{l : List α // l.length ≤ k - 1}`.
-The `[Fintype α]` constraint matches the source literature
-([mohri-1997]; [chandlee-2014]): every subsequential model has
-a finite alphabet and finite state by definition. The inclusion theorem
+The `[Fintype α]` constraint matches the source literature [mohri-1997]:
+every subsequential model has a finite alphabet and finite state by
+definition. The inclusion theorem
 rides on the run-equality. Co-located on the source side because the
 dependency direction (SFST in `Subsequential.lean`; ISL projects into
 it) forces both construction and cast into this file. -/

--- a/Linglib/Core/Computability/Subregular/Function/OSL.lean
+++ b/Linglib/Core/Computability/Subregular/Function/OSL.lean
@@ -11,13 +11,10 @@ import Linglib.Core.Computability.Subregular.Function.Subsequential
 
 A function `f : List α → List β` is **k-Output Strictly Local** when each
 output block depends only on the last `k - 1` *output* symbols plus the
-current input symbol. OSL captures iterative spreading processes —
-progressive nasal harmony, vowel harmony, tone spreading — where the
-decision at position *i* feeds forward to the decision at position
+current input symbol. OSL captures iterative processes where the output
+already emitted at position *i* feeds forward to the decision at position
 *i + 1*. The function-level subregular hierarchy at this layer is
-ISL ⊊ OSL ⊊ Subsequential; bidirectional iterative harmony (Maasai,
-Turkana ATR) is Weakly Deterministic (composition of two
-opposite-direction subsequentials) rather than OSL in either direction.
+ISL ⊊ OSL ⊊ Subsequential.
 
 ## Main definitions
 
@@ -50,13 +47,6 @@ window-length truncation in `applyAux` is what enforces it semantically.
 `OSLRule.toSFST` deliberately repeats `r.windowOutput outputWindow x`
 in the two tuple components of `step` rather than `let`-binding it, so
 that `(step ow x).2` reduces definitionally for `toSFST_run_eq_apply`.
-
-## References
-
-* [chandlee-eyraud-heinz-2015]
-* [aksenova-rawski-graf-heinz-2020]
-* [heinz-lai-2013]
-* [meinhardt-mai-bakovic-mccollum-2024]
 -/
 
 namespace Subregular.Function
@@ -71,7 +61,7 @@ emits an output block.
 In contrast to `ISLRule` (whose window is over input symbols), the
 window here is over **already-emitted output symbols**. This lets the
 rule see what it has just produced and react accordingly — the
-mechanism behind iterative spreading.
+mechanism behind iterative output dependence.
 
 The `k` parameter is a type-level annotation; semantic enforcement
 happens in `apply`'s window threading. -/

--- a/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
@@ -10,16 +10,14 @@ import Linglib.Core.Computability.Subregular.Function.Subsequential
 /-!
 # Side-determinacy: myopia and unbounded circumambience
 
-Locality predicates on string functions, used to classify phonological maps in the
-function-level subregular hierarchy. The kernel `OutputDependsOn f i K` says output
-coordinate `i` of `f` is fixed by the input positions in `K`.
+Locality predicates on string functions for the function-level subregular hierarchy.
+The kernel `OutputDependsOn f i K` says output coordinate `i` of `f` is fixed by the
+input positions in `K`. Two notions are instances:
 
-The two phonological notions both papers in this line center are instances:
-
-* **Myopia** ([wilson-2006]; the "no look-ahead" generalisation): a side's influence
-  on the output is *bounded*.
-* **Unbounded circumambience** ([mccollum-bakovic-mai-meinhardt-2020] def. 13): some
-  target depends on input *arbitrarily far on both sides at once*.
+* **Myopia** (the "no look-ahead" condition): a side's influence on the output is
+  *bounded*.
+* **Unbounded circumambience**: some target depends on input *arbitrarily far on both
+  sides at once*.
 
 ## Main definitions
 
@@ -27,8 +25,8 @@ The two phonological notions both papers in this line center are instances:
 * `UnboundedDependence f s` — for every distance `d`, some output flips under a
   perturbation strictly beyond `d` on side `s`.
 * `IsMyopicTowards f s` — the negation: dependence on side `s` is bounded.
-* `IsUnboundedCircumambient` — co-located form of def. 13: for every `d`, ONE base
-  word with a target that flips under both a far-left and a far-right perturbation.
+* `IsUnboundedCircumambient` — co-located form: for every `d`, ONE base word with a
+  target that flips under both a far-left and a far-right perturbation.
 
 ## Implementation notes
 
@@ -36,15 +34,15 @@ The predicates are **distance-based** (`∀ d, ∃ word + target`), not fixed-in
 fixed target index has only finitely many positions to its left, so a fixed-index
 "unbounded left dependence" is unsatisfiable; the unbounded distance must be witnessed
 by ever-longer words. The co-located `IsUnboundedCircumambient` keeps both
-perturbations on a single shared base (so any computing automaton hits one context
-where neither side alone fixes the output) — the hook for the deferred
-"circumambient ⟹ non-deterministic" classification.
+perturbations on a single shared base, so any computing automaton hits one context
+where neither side alone fixes the output.
 
-## Todo
-
-* The machine-level "`IsUnboundedCircumambient` ⟹ not weakly-deterministic" theorem,
-  bridging to `Function/Bimachine.lean`'s `IsBimachineWeaklyDeterministic`, with the
-  co-located base as its automaton-context witness.
+Circumambience is *not* the weak-determinism boundary: a map can be
+`IsUnboundedCircumambient` yet weakly deterministic (a two-sided *union* spread is
+perturbed at one output by either side, but neither side alone reverts it). The
+not-weakly-deterministic classification is driven by the strictly stronger
+`RequiresBothSides` (in `Bimachine.lean`), where perturbing either far side reverts
+the target to the identity.
 -/
 
 namespace Subregular.Function
@@ -76,14 +74,14 @@ def UnboundedDependence (f : List α → List β) : Direction → Prop
   | .right => ∀ d, ∃ (u v : List α) (i : ℕ), u.length = v.length ∧ i < u.length ∧
                 AgreeUpto u v (i + d) ∧ (f u)[i]? ≠ (f v)[i]?
 
-/-- **Myopia towards `s`** ([wilson-2006]): dependence on side `s` is bounded. -/
+/-- **Myopia towards `s`**: dependence on side `s` is bounded. -/
 def IsMyopicTowards (f : List α → List β) (s : Direction) : Prop :=
   ¬ UnboundedDependence f s
 
-/-- **Unbounded circumambience** ([mccollum-bakovic-mai-meinhardt-2020] def. 13),
-co-located: for every `d`, one base word with a target `i` whose output flips under
-BOTH a far-left perturbation (agreeing from `i - d`) and a far-right one (agreeing up
-to `i + d`). Co-location keeps both flips on a single base (one automaton context). -/
+/-- **Unbounded circumambience**, co-located: for every `d`, one base word with a
+target `i` whose output flips under BOTH a far-left perturbation (agreeing from
+`i - d`) and a far-right one (agreeing up to `i + d`). Co-location keeps both flips on
+a single base (one automaton context). -/
 def IsUnboundedCircumambient (f : List α → List β) : Prop :=
   ∀ d, ∃ (base : List α) (i : ℕ), i < base.length ∧
     (∃ uL : List α, uL.length = base.length ∧ AgreeFrom base uL (i - d) ∧
@@ -130,8 +128,6 @@ theorem IsMyopicTowards.right_of_prefixDetermined {f : List α → List β}
 /-- Output coordinate `i` is fixed by the prefix `{k | k ≤ i}` (the right side is
 irrelevant) — the footprint shape of a left-to-right transducer. -/
 def LeftDetermined (f : List α → List β) (i : ℕ) : Prop := OutputDependsOn f i {k | k ≤ i}
-/-- Dually, fixed by the suffix `{k | i ≤ k}`. -/
-def RightDetermined (f : List α → List β) (i : ℕ) : Prop := OutputDependsOn f i {k | i ≤ k}
 
 /-- **Left-determined everywhere ⟹ right-myopic.** If every output coordinate is fixed
 by its prefix `{k | k ≤ i}`, the map has no rightward look-ahead. -/

--- a/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
@@ -12,12 +12,10 @@ import Mathlib.Data.Fintype.Prod
 A function `f : List α → List β` is **subsequential** when it is computed
 by a deterministic finite-state transducer with state-based final output
 [mohri-1997]. Subsequential functions form a proper subclass of the
-regular relations (= rational functions) and a proper superclass of the
-Output Strictly Local class [aksenova-rawski-graf-heinz-2020].
+regular relations (= rational functions).
 
 The class comes in **left** and **right** variants depending on whether
-the FST consumes input left-to-right or right-to-left
-[meinhardt-mai-bakovic-mccollum-2024]. The right-subsequential
+the FST consumes input left-to-right or right-to-left. The right-subsequential
 class equals the image of the left-subsequential class under input/output
 reversal: `f ∈ R-Subseq ↔ (List.reverse ∘ f ∘ List.reverse) ∈ L-Subseq`.
 
@@ -36,11 +34,9 @@ reversal: `f ∈ R-Subseq ↔ (List.reverse ∘ f ∘ List.reverse) ∈ L-Subseq
 ## What this file does NOT cover
 
 * **Finite-state minimisation**, canonical forms, equivalence of SFSTs
-  (Choffrut 1979, Mohri 1997 §5).
-* **Two-way subsequential** functions (extended class for some
-  reduplication patterns, Dolatian-Heinz 2020).
-* **p-subsequential** functions (Mohri 1997 footnote 7) — handle
-  variation/optionality with multiple outputs per input.
+  (Choffrut, [mohri-1997]).
+* **Two-way subsequential** functions (two-way deterministic transducers).
+* **p-subsequential** functions [mohri-1997] — multiple outputs per input.
 -/
 
 namespace Subregular.Function
@@ -219,10 +215,10 @@ end SFST
 
 /-! ### Composition
 
-Subsequential functions are closed under composition (Mohri 1997 §3,
+Subsequential functions are closed under composition ([mohri-1997],
 back to Schützenberger and Choffrut). This is the load-bearing fact
-that makes the Heinz-Lai 2013 Weakly Deterministic class definition
-work (compositions of two subsequentials).
+that makes the weakly-deterministic class (compositions of two
+subsequentials) well-defined.
 
 Construction: the **product SFST** with state `σ_f × σ_g` threads both
 machines, where the consumer FST `T_g` walks over each output block
@@ -281,10 +277,9 @@ The witness-style predicates below follow mathlib's `Language.IsRegular`
 shape: the state space `σ` is existentially quantified at `Type` with a
 `Fintype σ` instance, while the alphabets `α β` are universe-polymorphic
 at `Type*`. The `Fintype` constraint matches the source literature
-([mohri-1997] §3; [heinz-lai-2013]; [chandlee-2014]),
-where every SFST has finitely many states by definition, and also lets
-the universe parameter for state collapse cleanly without `universe`
-declarations or `ULift` coercions.
+([mohri-1997]), where every SFST has finitely many states by definition,
+and also lets the universe parameter for state collapse cleanly without
+`universe` declarations or `ULift` coercions.
 
 Constructor lemmas (`SFST.isLeftSubsequential`, `SFST.isRightSubsequential`
 below) hide the existential-over-types shape so future redesigns
@@ -295,8 +290,7 @@ witness the predicate (`Function/{ISL,OSL}.lean`). -/
 
 /-- A function `f : List α → List β` is **left-subsequential** iff some
 SFST with a finite state space computes it via left-to-right scan. The
-`Fintype σ` constraint matches the source literature
-([mohri-1997]; [chandlee-2014]). -/
+`Fintype σ` constraint matches the source literature [mohri-1997]. -/
 def IsLeftSubsequential {α β : Type*} (f : List α → List β) : Prop :=
   ∃ σ : Type, ∃ _ : Fintype σ, ∃ T : SFST σ α β, T.run = f
 
@@ -379,12 +373,12 @@ theorem isRightSubsequential_iff_left_reverse {α β : Type*}
     rw [List.reverse_reverse] at h
     rw [h, List.reverse_reverse]
 
-/-- **Subsequential functions are closed under composition** (Mohri 1997
-§3, originally Schützenberger and Choffrut). The load-bearing fact that
-makes the Heinz-Lai 2013 Weakly Deterministic class definition work as
-the composition of two subsequential functions reading from opposite
-directions. The product state `σf × σg` inherits `Fintype` automatically
-from `Mathlib.Data.Fintype.Prod`. -/
+/-- **Subsequential functions are closed under composition** ([mohri-1997],
+originally Schützenberger and Choffrut). The load-bearing fact that makes
+the weakly-deterministic class — the composition of two subsequential
+functions reading from opposite directions — well-defined. The product
+state `σf × σg` inherits `Fintype` automatically from
+`Mathlib.Data.Fintype.Prod`. -/
 theorem IsLeftSubsequential.comp {α β γ : Type*}
     {g : List β → List γ} (hg : IsLeftSubsequential g)
     {f : List α → List β} (hf : IsLeftSubsequential f) :


### PR DESCRIPTION
## What

De-linguistics the `Function/` cone docstrings (Core must be mathlib-upstreamable — pure formal-language theory) and fix three coherence issues.

## Docstring scrub
- **Cut** the linguistics-application citations: Chandlee, Heinz–Lai, Jardine, Aksenova et al., Wilson, McCollum et al., Meinhardt et al. (9 keys, ~24 occurrences).
- **Keep** `[mohri-1997]` — the automata-theory origin of subsequential transducers/bimachines (parallel to the kept `[simon-1975]`) — with its memory-cited `§`/footnote locators stripped.
- **Delete** the two `## References` sections (`ISL`, `OSL`).
- **Cut** phenomenon names (Maasai/Turkana/Tutrugbu ATR, nasal/vowel/tone harmony) and references to `Studies/` decls. The in-file math witnesses (`conjBM`, `RequiresBothSides`, `IsUnboundedCircumambient`) already carry the content.

## Coherence fixes
- **Delete** dead `RightDetermined` (0 consumers; unused dual of `LeftDetermined`).
- **Retract** SideDeterminacy's `## Todo` claiming "`IsUnboundedCircumambient` ⟹ not weakly-deterministic" — **this theorem is false**: a two-sided union spread is `IsUnboundedCircumambient` yet weakly deterministic. The not-WD classification is driven by the strictly stronger `RequiresBothSides` (Bimachine.lean); now stated as an implementation note.
- **Fix** the OSL header's factual error (it claimed bidirectional ATR harmony is weakly deterministic — the opposite of the cited paper's result); removed with the rest of the phonology framing.

Only code change is the `RightDetermined` deletion; everything else is docstrings/comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)