### PR TITLE
refactor(Core/Computability/Subregular/Function): post-review refinements (Direction leaf, Mealy, dedup)

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -323,6 +323,7 @@ import Linglib.Core.Computability.Subregular.Language.Multitier
 import Linglib.Core.Computability.Subregular.Language.ForbiddenPairs
 import Linglib.Core.Computability.Subregular.Function.ISL
 import Linglib.Core.Computability.Subregular.Function.OSL
+import Linglib.Core.Computability.Subregular.Function.Direction
 import Linglib.Core.Computability.Subregular.Function.Subsequential
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 import Linglib.Core.Computability.Subregular.Function.LetterSubsequential

--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -95,24 +95,6 @@ theorem run_getElem? (B : Bimachine L R α β) (x : List α) (i : ℕ) :
 
 end Bimachine
 
-/-! ### Locality of the context states -/
-
-/-- Prefixes agreeing below `i` have equal `i`-truncations. -/
-theorem take_eq_of_agree {u v : List α} {i : ℕ} (h : ∀ k, k < i → u[k]? = v[k]?) :
-    u.take i = v.take i := by
-  apply List.ext_getElem?
-  intro k
-  rcases lt_or_ge k i with hk | hk
-  · simpa only [List.getElem?_take_of_lt hk] using h k hk
-  · simp [List.getElem?_take_eq_none hk]
-
-/-- Lists agreeing from `i` upward have equal `i`-suffixes. -/
-theorem drop_eq_of_agree {u v : List α} {i : ℕ} (h : ∀ k, i ≤ k → u[k]? = v[k]?) :
-    u.drop i = v.drop i := by
-  apply List.ext_getElem?
-  intro k
-  simpa only [List.getElem?_drop] using h (i + k) (Nat.le_add_right i k)
-
 /-! ### Weak determinism -/
 
 /-- Computability by a finite bimachine (the length-preserving regular functions). -/

--- a/Linglib/Core/Computability/Subregular/Function/Direction.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Direction.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Logic.Basic
+
+/-!
+# Scan direction
+
+The orientation of a left-to-right vs right-to-left scan, shared by the transducer
+machines and the side-determinacy predicates of `Core/Computability/Subregular/Function/`.
+Extracted to its own leaf so the footprint-predicate file (`SideDeterminacy.lean`) does
+not have to depend on the transducer machine file just to name a `left`/`right` tag.
+-/
+
+namespace Subregular.Function
+
+/-- The orientation of an FST scan: `left` consumes input head-first, `right`
+tail-first (via `List.reverse` conjugation). The two scan modes give rise to
+distinct function classes — isomorphic under reversal but not equal as
+subclasses of the regular functions over un-reversed strings. -/
+inductive Direction
+  | left
+  | right
+  deriving DecidableEq, Repr
+
+end Subregular.Function

--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -26,7 +26,7 @@ trivial, so its cell output is a *one-sided* rule — non-interacting.
 * `IsBimachineComputable.of_weaklyDeterministic` — WD ⊆ regular.
 * `weaklyDeterministic_strict_subset_regular` — the second inclusion is *proper*.
 * `isLetterLeftSubsequential_of_ISLRule` / `_of_OSLRule` — single-symbol ISL/OSL ⊆
-  subsequential (the bounded window as a `LetterSFST` state); `.of_ISLRule` / `.of_OSLRule`
+  subsequential (the bounded window as a `Mealy` state); `.of_ISLRule` / `.of_OSLRule`
   extend the chain to WD.
 
 ## Strictness
@@ -48,12 +48,12 @@ private theorem unite_default_right (cL a : α) : unite cL a a = cL := by
   unfold unite; split_ifs <;> simp_all
 
 omit [DecidableEq α] in
-private theorem letterSFST_stateAfter_eq_foldl {σ : Type*} (T : LetterSFST σ α α)
+private theorem mealy_stateAfter_eq_foldl {σ : Type*} (T : Mealy σ α α)
     (s : σ) (pre : List α) :
     T.stateAfter s pre = pre.foldl (fun l a => (T.step l a).1) s := by
   induction pre generalizing s with
   | nil => rfl
-  | cons x xs ih => simp only [LetterSFST.stateAfter, List.foldl_cons, ih]
+  | cons x xs ih => simp only [Mealy.stateAfter, List.foldl_cons, ih]
 
 /-- **Subsequential ⊆ weakly deterministic.** A synchronous left-subsequential function is
 computed by a non-interacting bimachine: the left automaton *is* the transducer, the right
@@ -72,7 +72,7 @@ theorem IsBimachineWeaklyDeterministic.of_letterLeftSubsequential {f : List α �
         (fun a => (T.step ((xs.take i).foldl (fun l a => (T.step l a).1) T.initial) a).2)
       = (T.run xs)[i]?
     rw [show T.run xs = T.runFrom T.initial xs from rfl, T.runFrom_getElem?,
-        letterSFST_stateAfter_eq_foldl]
+        mealy_stateAfter_eq_foldl]
   · exact ⟨fun l a => (T.step l a).2, fun _ a => a, fun l a r => (unite_default_right _ _).symm⟩
 
 /-- **Weakly deterministic ⊆ regular.** A non-interacting bimachine is a bimachine. -/
@@ -194,30 +194,30 @@ theorem weaklyDeterministic_strict_subset_regular :
 
 The ISL/OSL classes are block-output (length-changing) in general, so they sit outside the
 length-preserving lattice. Their **single-symbol** (length-preserving) fragment embeds: the
-same bounded window that makes `toFinSFST` finite-state serves as a `LetterSFST` state, with
+same bounded window that makes `toFinSFST` finite-state serves as a `Mealy` state, with
 the lone output symbol as the letter. This extends the chain to
 `single-symbol ISL/OSL ⊆ subsequential ⊆ WD ⊆ regular`. -/
 
 /-- A length-preserving (single-symbol) left-ISL rule as a synchronous transducer: the
 bounded input window is the state, the lone output symbol the letter. -/
-def ISLRule.toLetterSFST {α β : Type*} {k : ℕ} [Fintype α] (r : ISLRule k α β)
+def ISLRule.toMealy {α β : Type*} {k : ℕ} [Fintype α] (r : ISLRule k α β)
     (hs : ∀ w x, (r.windowOutput w x).length = 1) :
-    LetterSFST {l : List α // l.length ≤ k - 1} α β where
+    Mealy {l : List α // l.length ≤ k - 1} α β where
   initial := ⟨[], Nat.zero_le _⟩
   step w x := (⟨(w.val ++ [x]).rtake (k - 1), List.length_rtake_le _ _⟩,
     (r.windowOutput w.val x).head (by have := hs w.val x; exact List.ne_nil_of_length_pos (by omega)))
 
-theorem ISLRule.toLetterSFST_run_eq_apply {α β : Type*} {k : ℕ} [Fintype α] (r : ISLRule k α β)
-    (hs : ∀ w x, (r.windowOutput w x).length = 1) : (r.toLetterSFST hs).run = r.apply := by
+theorem ISLRule.toMealy_run_eq_apply {α β : Type*} {k : ℕ} [Fintype α] (r : ISLRule k α β)
+    (hs : ∀ w x, (r.windowOutput w x).length = 1) : (r.toMealy hs).run = r.apply := by
   rw [← r.toFinSFST_run_eq_apply]
   funext input
   suffices h : ∀ w : {l : List α // l.length ≤ k - 1},
-      LetterSFST.runFrom (r.toLetterSFST hs) w input = SFST.runFrom r.toFinSFST w input from h _
+      Mealy.runFrom (r.toMealy hs) w input = SFST.runFrom r.toFinSFST w input from h _
   intro w
   induction input generalizing w with
   | nil => rfl
   | cons x xs ih =>
-    simp only [LetterSFST.runFrom_cons, SFST.runFrom_cons, ISLRule.toLetterSFST,
+    simp only [Mealy.runFrom_cons, SFST.runFrom_cons, ISLRule.toMealy,
       ISLRule.toFinSFST]
     obtain ⟨a, ha⟩ := List.length_eq_one_iff.mp (hs w.val x)
     simp only [ha, List.head_cons, List.singleton_append]
@@ -226,28 +226,28 @@ theorem ISLRule.toLetterSFST_run_eq_apply {α β : Type*} {k : ℕ} [Fintype α]
 /-- **Single-symbol left-ISL ⊆ left-subsequential.** -/
 theorem isLetterLeftSubsequential_of_ISLRule {α β : Type*} {k : ℕ} [Fintype α] (r : ISLRule k α β)
     (hs : ∀ w x, (r.windowOutput w x).length = 1) : IsLetterLeftSubsequential r.apply :=
-  by rw [← r.toLetterSFST_run_eq_apply hs]; exact (r.toLetterSFST hs).isLetterLeftSubsequential
+  by rw [← r.toMealy_run_eq_apply hs]; exact (r.toMealy hs).isLetterLeftSubsequential
 
 /-- A length-preserving (single-symbol) left-OSL rule as a synchronous transducer: the
 bounded output window is the state. -/
-def OSLRule.toLetterSFST {α β : Type*} {k : ℕ} (r : OSLRule k α β)
+def OSLRule.toMealy {α β : Type*} {k : ℕ} (r : OSLRule k α β)
     (hs : ∀ w x, (r.windowOutput w x).length = 1) :
-    LetterSFST {l : List β // l.length ≤ k - 1} α β where
+    Mealy {l : List β // l.length ≤ k - 1} α β where
   initial := ⟨[], Nat.zero_le _⟩
   step w x := (⟨(w.val ++ r.windowOutput w.val x).rtake (k - 1), List.length_rtake_le _ _⟩,
     (r.windowOutput w.val x).head (by have := hs w.val x; exact List.ne_nil_of_length_pos (by omega)))
 
-theorem OSLRule.toLetterSFST_run_eq_apply {α β : Type*} {k : ℕ} [Fintype β] (r : OSLRule k α β)
-    (hs : ∀ w x, (r.windowOutput w x).length = 1) : (r.toLetterSFST hs).run = r.apply := by
+theorem OSLRule.toMealy_run_eq_apply {α β : Type*} {k : ℕ} [Fintype β] (r : OSLRule k α β)
+    (hs : ∀ w x, (r.windowOutput w x).length = 1) : (r.toMealy hs).run = r.apply := by
   rw [← r.toFinSFST_run_eq_apply]
   funext input
   suffices h : ∀ w : {l : List β // l.length ≤ k - 1},
-      LetterSFST.runFrom (r.toLetterSFST hs) w input = SFST.runFrom r.toFinSFST w input from h _
+      Mealy.runFrom (r.toMealy hs) w input = SFST.runFrom r.toFinSFST w input from h _
   intro w
   induction input generalizing w with
   | nil => rfl
   | cons x xs ih =>
-    simp only [LetterSFST.runFrom_cons, SFST.runFrom_cons, OSLRule.toLetterSFST,
+    simp only [Mealy.runFrom_cons, SFST.runFrom_cons, OSLRule.toMealy,
       OSLRule.toFinSFST]
     obtain ⟨a, ha⟩ := List.length_eq_one_iff.mp (hs w.val x)
     simp only [ha, List.head_cons, List.singleton_append]
@@ -256,7 +256,7 @@ theorem OSLRule.toLetterSFST_run_eq_apply {α β : Type*} {k : ℕ} [Fintype β]
 /-- **Single-symbol left-OSL ⊆ left-subsequential.** -/
 theorem isLetterLeftSubsequential_of_OSLRule {α β : Type*} {k : ℕ} [Fintype β] (r : OSLRule k α β)
     (hs : ∀ w x, (r.windowOutput w x).length = 1) : IsLetterLeftSubsequential r.apply :=
-  by rw [← r.toLetterSFST_run_eq_apply hs]; exact (r.toLetterSFST hs).isLetterLeftSubsequential
+  by rw [← r.toMealy_run_eq_apply hs]; exact (r.toMealy hs).isLetterLeftSubsequential
 
 /-- **Single-symbol left-ISL ⊆ WD** — extends the lattice down through subsequential. -/
 theorem IsBimachineWeaklyDeterministic.of_ISLRule {α : Type*} {k : ℕ} [Fintype α] [DecidableEq α]

--- a/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
@@ -3,14 +3,14 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.EquivFin
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 
 /-!
 # Synchronous (letter) left-subsequential functions
 
-A `LetterSFST` is a deterministic left-to-right transducer emitting exactly one output
-symbol per input symbol — the Mealy / synchronous case, length-preserving by
+A `Mealy` machine is a deterministic left-to-right transducer emitting exactly one
+output symbol per input symbol — the synchronous case, length-preserving by
 construction. Its output coordinate `i` is a function of the input prefix `[0..i]`, so
 the class is cleanly characterised by the `OutputDependsOn` footprint
 (`SideDeterminacy.lean`): `IsLetterLeftSubsequential f → ∀ i, LeftDetermined f i`, hence
@@ -24,12 +24,12 @@ machine view.
 
 ## Main definitions
 
-* `LetterSFST` — synchronous one-symbol-per-step transducer; `run` is length-preserving.
-* `IsLetterLeftSubsequential` — computed by a finite-state `LetterSFST`.
+* `Mealy` — synchronous one-symbol-per-step transducer; `run` is length-preserving.
+* `IsLetterLeftSubsequential` — computed by a finite-state `Mealy`.
 
 ## Main results
 
-* `LetterSFST.runFrom_getElem?` — output `i` is `(step (state-after-prefix) (input i)).2`.
+* `Mealy.runFrom_getElem?` — output `i` is `(step (state-after-prefix) (input i)).2`.
 * `IsLetterLeftSubsequential.leftDetermined` / `.isRightMyopic` — synchronous
   left-subsequential maps are prefix-determined, hence right-myopic.
 
@@ -45,45 +45,45 @@ variable {σ α β : Type*}
 
 /-- A synchronous letter-to-letter left-to-right transducer: exactly one output symbol
 per input symbol (length-preserving by construction). -/
-structure LetterSFST (σ α β : Type*) where
+structure Mealy (σ α β : Type*) where
   initial : σ
   step : σ → α → σ × β
 
-namespace LetterSFST
+namespace Mealy
 
 /-- State reached after consuming a prefix. -/
-def stateAfter (T : LetterSFST σ α β) : σ → List α → σ
+def stateAfter (T : Mealy σ α β) : σ → List α → σ
   | s, [] => s
   | s, x :: xs => T.stateAfter (T.step s x).1 xs
 
 /-- Run from a state: one output symbol per input symbol. -/
-def runFrom (T : LetterSFST σ α β) : σ → List α → List β
+def runFrom (T : Mealy σ α β) : σ → List α → List β
   | _, [] => []
   | s, x :: xs => (T.step s x).2 :: T.runFrom (T.step s x).1 xs
 
 /-- Run from the initial state. -/
-def run (T : LetterSFST σ α β) : List α → List β := T.runFrom T.initial
+def run (T : Mealy σ α β) : List α → List β := T.runFrom T.initial
 
-@[simp] theorem runFrom_nil (T : LetterSFST σ α β) (s : σ) : T.runFrom s [] = [] := rfl
-@[simp] theorem runFrom_cons (T : LetterSFST σ α β) (s : σ) (x : α) (xs : List α) :
+@[simp] theorem runFrom_nil (T : Mealy σ α β) (s : σ) : T.runFrom s [] = [] := rfl
+@[simp] theorem runFrom_cons (T : Mealy σ α β) (s : σ) (x : α) (xs : List α) :
     T.runFrom s (x :: xs) = (T.step s x).2 :: T.runFrom (T.step s x).1 xs := rfl
-@[simp] theorem stateAfter_nil (T : LetterSFST σ α β) (s : σ) : T.stateAfter s [] = s := rfl
-@[simp] theorem stateAfter_cons (T : LetterSFST σ α β) (s : σ) (x : α) (xs : List α) :
+@[simp] theorem stateAfter_nil (T : Mealy σ α β) (s : σ) : T.stateAfter s [] = s := rfl
+@[simp] theorem stateAfter_cons (T : Mealy σ α β) (s : σ) (x : α) (xs : List α) :
     T.stateAfter s (x :: xs) = T.stateAfter (T.step s x).1 xs := rfl
 
 /-- The run is length-preserving (one output symbol per input symbol). -/
-theorem runFrom_length (T : LetterSFST σ α β) (s : σ) (xs : List α) :
+theorem runFrom_length (T : Mealy σ α β) (s : σ) (xs : List α) :
     (T.runFrom s xs).length = xs.length := by
   induction xs generalizing s with
   | nil => rfl
   | cons x xs ih => simp [ih]
 
-theorem run_length (T : LetterSFST σ α β) (xs : List α) :
+theorem run_length (T : Mealy σ α β) (xs : List α) :
     (T.run xs).length = xs.length := T.runFrom_length T.initial xs
 
 /-- **The coordinate characterization**: output `i` is the step output at
 `(state after the prefix [0..i-1], input i)`. -/
-theorem runFrom_getElem? (T : LetterSFST σ α β) (s : σ) (xs : List α) (i : ℕ) :
+theorem runFrom_getElem? (T : Mealy σ α β) (s : σ) (xs : List α) (i : ℕ) :
     (T.runFrom s xs)[i]?
       = (xs[i]?).map (fun x => (T.step (T.stateAfter s (xs.take i)) x).2) := by
   induction xs generalizing s i with
@@ -93,15 +93,15 @@ theorem runFrom_getElem? (T : LetterSFST σ α β) (s : σ) (xs : List α) (i : 
     | zero => simp
     | succ j => simp [ih, List.take_succ_cons]
 
-/-- Transfer a `LetterSFST` along a state-space equivalence `σ ≃ τ`, preserving `run`.
+/-- Transfer a `Mealy` along a state-space equivalence `σ ≃ τ`, preserving `run`.
 Mirrors `SFST.transferEquiv`; the use case is bringing a `Type*` finite state down to
 `Fin (Fintype.card σ) : Type 0` so a universe-polymorphic machine can witness the
 `Type 0`-state existential of `IsLetterLeftSubsequential`. -/
-def transferEquiv {τ : Type*} (T : LetterSFST σ α β) (e : σ ≃ τ) : LetterSFST τ α β where
+def transferEquiv {τ : Type*} (T : Mealy σ α β) (e : σ ≃ τ) : Mealy τ α β where
   initial := e T.initial
   step t x := (e (T.step (e.symm t) x).1, (T.step (e.symm t) x).2)
 
-theorem transferEquiv_runFrom {τ : Type*} (T : LetterSFST σ α β) (e : σ ≃ τ)
+theorem transferEquiv_runFrom {τ : Type*} (T : Mealy σ α β) (e : σ ≃ τ)
     (s : σ) (xs : List α) :
     (T.transferEquiv e).runFrom (e s) xs = T.runFrom s xs := by
   induction xs generalizing s with
@@ -113,23 +113,23 @@ theorem transferEquiv_runFrom {τ : Type*} (T : LetterSFST σ α β) (e : σ ≃
     rw [e.symm_apply_apply, ih]
 
 /-- The transferred machine computes the same string function. -/
-@[simp] theorem transferEquiv_run {τ : Type*} (T : LetterSFST σ α β) (e : σ ≃ τ) :
+@[simp] theorem transferEquiv_run {τ : Type*} (T : Mealy σ α β) (e : σ ≃ τ) :
     (T.transferEquiv e).run = T.run := by
   funext xs; exact T.transferEquiv_runFrom e T.initial xs
 
-end LetterSFST
+end Mealy
 
-/-- The synchronous left-subsequential class: computed by a finite-state `LetterSFST`. -/
+/-- The synchronous left-subsequential class: computed by a finite-state `Mealy`. -/
 def IsLetterLeftSubsequential (f : List α → List β) : Prop :=
-  ∃ (σ : Type) (_ : Fintype σ) (T : LetterSFST σ α β), T.run = f
+  ∃ (σ : Type) (_ : Fintype σ) (T : Mealy σ α β), T.run = f
 
-/-- **Constructor lemma**: every finite-state `LetterSFST` witnesses
+/-- **Constructor lemma**: every finite-state `Mealy` witnesses
 `IsLetterLeftSubsequential` for its `run`. The state `σ` is accepted at arbitrary
 `Type*` and brought down to `Fin (Fintype.card σ) : Type 0` via `transferEquiv` and
 `Fintype.equivFin`, so bounded-window ISL/OSL states at the alphabet's universe can
 witness the predicate (mirrors `SFST.isLeftSubsequential`). -/
-theorem LetterSFST.isLetterLeftSubsequential {σ : Type*} [Fintype σ] {α β : Type*}
-    (T : LetterSFST σ α β) : IsLetterLeftSubsequential T.run :=
+theorem Mealy.isLetterLeftSubsequential {σ : Type*} [Fintype σ] {α β : Type*}
+    (T : Mealy σ α β) : IsLetterLeftSubsequential T.run :=
   ⟨Fin (Fintype.card σ), inferInstance, T.transferEquiv (Fintype.equivFin σ),
    T.transferEquiv_run _⟩
 
@@ -141,15 +141,11 @@ theorem IsLetterLeftSubsequential.leftDetermined {f : List α → List β}
   obtain ⟨σ, _, T, rfl⟩ := hf
   intro u v hlen hag
   have hi : u[i]? = v[i]? := hag i (by simp)
-  have htake : u.take i = v.take i := by
-    apply List.ext_getElem?
-    intro k
-    rcases lt_or_ge k i with hk | hk
-    · simpa only [List.getElem?_take_of_lt hk] using hag k (by simp only [Set.mem_setOf_eq]; omega)
-    · simp [List.getElem?_take_eq_none hk]
+  have htake : u.take i = v.take i :=
+    take_eq_of_agree fun k hk => hag k (by simp only [Set.mem_setOf_eq]; omega)
   show (T.runFrom T.initial u)[i]? = (T.runFrom T.initial v)[i]?
-  rw [LetterSFST.runFrom_getElem? T T.initial u i,
-      LetterSFST.runFrom_getElem? T T.initial v i, hi, htake]
+  rw [Mealy.runFrom_getElem? T T.initial u i,
+      Mealy.runFrom_getElem? T T.initial v i, hi, htake]
 
 /-- A synchronous left-subsequential map is **right-myopic** — it has no look-ahead. -/
 theorem IsLetterLeftSubsequential.isRightMyopic {f : List α → List β}
@@ -175,13 +171,13 @@ theorem isLetterLeftSubsequential_of_stateSummary
     (hlen : ∀ xs, (f xs).length = xs.length) :
     IsLetterLeftSubsequential f := by
   refine ⟨σ, inferInstance, { initial := state [], step := fun s x => (δ s x, out s x) }, ?_⟩
-  set T : LetterSFST σ α β := { initial := state [], step := fun s x => (δ s x, out s x) }
+  set T : Mealy σ α β := { initial := state [], step := fun s x => (δ s x, out s x) }
   have hstate : ∀ (p₀ ps : List α), T.stateAfter (state p₀) ps = state (p₀ ++ ps) := by
     intro p₀ ps
     induction ps generalizing p₀ with
     | nil => simp
     | cons x xs ih =>
-      rw [LetterSFST.stateAfter_cons]
+      rw [Mealy.stateAfter_cons]
       show T.stateAfter (δ (state p₀) x) xs = state (p₀ ++ x :: xs)
       rw [← hδ p₀ x, ih (p₀ ++ [x])]
       simp
@@ -189,7 +185,7 @@ theorem isLetterLeftSubsequential_of_stateSummary
   apply List.ext_getElem?
   intro i
   show (T.runFrom T.initial xs)[i]? = (f xs)[i]?
-  rw [LetterSFST.runFrom_getElem? T T.initial xs i]
+  rw [Mealy.runFrom_getElem? T T.initial xs i]
   show (xs[i]?).map (fun x => out (T.stateAfter (state []) (xs.take i)) x) = (f xs)[i]?
   rw [hstate [] (xs.take i), List.nil_append]
   rcases lt_or_ge i xs.length with hi | hi

--- a/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
@@ -5,7 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Set.Basic
-import Linglib.Core.Computability.Subregular.Function.Subsequential
+import Linglib.Core.Computability.Subregular.Function.Direction
 
 /-!
 # Side-determinacy: myopia and unbounded circumambience
@@ -64,6 +64,22 @@ theorem OutputDependsOn.mono {f : List α → List β} {i : ℕ} {K K' : Set ℕ
 def AgreeFrom (u v : List α) (j : ℕ) : Prop := ∀ k, j ≤ k → u[k]? = v[k]?
 /-- `u` and `v` agree at every index `≤ j`. -/
 def AgreeUpto (u v : List α) (j : ℕ) : Prop := ∀ k, k ≤ j → u[k]? = v[k]?
+
+/-- Prefixes agreeing below `i` have equal `i`-truncations. -/
+theorem take_eq_of_agree {u v : List α} {i : ℕ} (h : ∀ k, k < i → u[k]? = v[k]?) :
+    u.take i = v.take i := by
+  apply List.ext_getElem?
+  intro k
+  rcases lt_or_ge k i with hk | hk
+  · simpa only [List.getElem?_take_of_lt hk] using h k hk
+  · simp [List.getElem?_take_eq_none hk]
+
+/-- Lists agreeing from `i` upward have equal `i`-suffixes. -/
+theorem drop_eq_of_agree {u v : List α} {i : ℕ} (h : ∀ k, i ≤ k → u[k]? = v[k]?) :
+    u.drop i = v.drop i := by
+  apply List.ext_getElem?
+  intro k
+  simpa only [List.getElem?_drop] using h (i + k) (Nat.le_add_right i k)
 
 /-- **Unbounded dependence on side `s`**: for every distance `d`, some target output
 position flips under a perturbation strictly beyond `d` on side `s` (the perturbed

--- a/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Fintype.Prod
+import Linglib.Core.Computability.Subregular.Function.Direction
 
 /-!
 # Subsequential Functions and Finite-State Transducers
@@ -21,7 +22,6 @@ reversal: `f ∈ R-Subseq ↔ (List.reverse ∘ f ∘ List.reverse) ∈ L-Subseq
 
 ## Main definitions
 
-* `Direction` — `.left` or `.right`; orientation of the FST scan.
 * `SFST σ α β` — a deterministic finite-state transducer with state
   space `σ`, input alphabet `α`, output alphabet `β`, total transition
   emitting an output block, plus a state-indexed `finalOutput` emitted
@@ -40,17 +40,6 @@ reversal: `f ∈ R-Subseq ↔ (List.reverse ∘ f ∘ List.reverse) ∈ L-Subseq
 -/
 
 namespace Subregular.Function
-
-/-! ## Direction of FST scan -/
-
-/-- The orientation of an FST scan: `left` consumes input head-first, `right`
-tail-first (via `List.reverse` conjugation). The two scan modes give rise to
-distinct function classes — isomorphic under reversal but not equal as
-subclasses of the regular functions over un-reversed strings. -/
-inductive Direction
-  | left
-  | right
-  deriving DecidableEq, Repr
 
 /-- A **subsequential finite-state transducer** with state space `σ`,
 input alphabet `α`, output alphabet `β`. The scan is total deterministic


### PR DESCRIPTION
Three refinements from the three-reviewer architecture pass:

1. **Extract the `Direction` enum** to its own leaf `Function/Direction.lean`. `SideDeterminacy.lean` is a pure footprint-predicate file (no machine) that was importing the entire `Subsequential` **machine** file solely for the 2-constructor `Direction` tag — the one layering edge a mathlib reviewer flagged. It now imports only `Direction`. (This surfaced a previously-transitive `Fintype` dependency in `LetterSubsequential`, now made explicit via `Mathlib.Data.Fintype.EquivFin` — the decoupling working as intended.)

2. **Rename `LetterSFST` → `Mealy`** (+ `toLetterSFST` → `toMealy`). The synchronous one-symbol-per-step transducer *is* the Mealy machine; `Mealy` is the standard, discoverable name.

3. **Move `take_eq_of_agree`/`drop_eq_of_agree`** out of `Bimachine` to sit beside `AgreeFrom`/`AgreeUpto` in `SideDeterminacy` (they're generic `List` facts, not bimachine content), and dedup the verbatim inline copy in `IsLetterLeftSubsequential.leftDetermined`.

The reviewers came down against hoisting the transducer machines to `Computability/` root (2–1; the dissent rested on `Phonology`/`Studies` consumers that don't upstream), so the machines stay in `Subregular/Function/`. No semantic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)