### PR TITLE
feat(Studies/VanRooy2003): §4.1 EUV-monotonicity via Blackwell forward

### DIFF
--- a/Linglib/Core/Probability/Decision/Blackwell.lean
+++ b/Linglib/Core/Probability/Decision/Blackwell.lean
@@ -29,8 +29,8 @@ direction is proved; the converse is the deep direction and is currently a `sorr
   greater than `P'` for every decision problem (the data-processing direction).
 * `isGarblingOf_of_forall_bayesRisk_le`: conversely, if `P` has Bayes risk no greater than `P'`
   for *every* decision problem, then `P'` is a garbling of `P` (the Blackwell–Sherman–Stein
-  direction, finite case; currently `sorry`). False without finiteness/standard-Borel
-  hypotheses.
+  direction, finite case; currently `sorry`). Requires finite spaces and that both `P` and
+  `P'` are Markov kernels — false otherwise (see the theorem docstring for counterexamples).
 * `isGarblingOf_iff_forall_bayesRisk_le`: the two directions combined.
 
 ## Implementation notes
@@ -73,6 +73,15 @@ namespace ProbabilityTheory
 variable {Θ 𝓧 𝓧' : Type*} {mΘ : MeasurableSpace Θ}
   {m𝓧 : MeasurableSpace 𝓧} {m𝓧' : MeasurableSpace 𝓧'}
 
+/-- On finite kernels, `comp` evaluated on a singleton is matrix multiplication:
+`(η ∘ₖ P) θ {x'} = ∑ₓ η x {x'} · P θ {x}`. The first brick of the finite Blackwell
+bridge (kernels ↔ stochastic matrices). -/
+lemma comp_singleton_eq_sum [Fintype 𝓧] [MeasurableSingletonClass 𝓧]
+    [MeasurableSingletonClass 𝓧']
+    (η : Kernel 𝓧 𝓧') (P : Kernel Θ 𝓧) (θ : Θ) (x' : 𝓧') :
+    (η ∘ₖ P) θ {x'} = ∑ x, η x {x'} * P θ {x} := by
+  rw [Kernel.comp_apply' η P θ (measurableSet_singleton x'), lintegral_fintype]
+
 /-- `P'` is a **garbling** of `P` (Blackwell): there is a Markov post-processing
 kernel `η` with `P' = η ∘ₖ P`. Read "`P` is at least as informative as `P'`". -/
 def Kernel.IsGarblingOf (P' : Kernel Θ 𝓧') (P : Kernel Θ 𝓧) : Prop :=
@@ -94,18 +103,28 @@ theorem bayesRisk_le_of_isGarblingOf {𝓨 : Type u} [MeasurableSpace 𝓨]
 larger than `P'` for *every* decision problem (loss `ℓ` over an arbitrary measurable action
 space `𝓨`, and prior `π`), then `P'` is a garbling of `P`.
 
-Stated for finite parameter and sample spaces. The converse is **false** for general
-measurable spaces — this is the finite Blackwell equivalence ([blackwell-1953]); the
-standard-Borel version additionally requires the experiments to be dominated. The
-quantification over *all* decision problems is essential: dominance for a single one does
-not force garbling.
+Stated for finite parameter and sample spaces, with both experiments Markov kernels. All
+three hypotheses are essential:
+
+* The converse is **false** for general measurable spaces — this is the *finite* Blackwell
+  equivalence ([blackwell-1953]); the standard-Borel version additionally requires the
+  experiments to be dominated.
+* `[IsMarkovKernel P]` is necessary: a defective `P` can attain low risk without being
+  informative. E.g. the zero kernel `P = 0` has `bayesRisk ℓ 0 π = 0` for every loss (the
+  least possible value), so it dominates every `P'`, yet `η ∘ₖ 0 = 0` forces `P' = 0`.
+* `[IsMarkovKernel P']` is necessary: an over-massed `P'` inflates every risk. E.g. over a
+  one-point sample space with `P' = 2 • P` one has `bayesRisk ℓ P' π = 2 • bayesRisk ℓ P π
+  ≥ bayesRisk ℓ P π` for every loss, yet `P'` (mass `2`) is not `η ∘ₖ P` for any Markov `η`.
+
+The quantification over *all* decision problems is likewise essential: dominance for a
+single one does not force garbling.
 
 A proof requires convex geometry on the (finite-dimensional) space of garblings of `P`,
 which Mathlib does not yet expose for kernels — see the module `TODO`. -/
 theorem isGarblingOf_of_forall_bayesRisk_le
     [Fintype Θ] [Fintype 𝓧] [Fintype 𝓧']
     [MeasurableSingletonClass Θ] [MeasurableSingletonClass 𝓧] [MeasurableSingletonClass 𝓧']
-    {P : Kernel Θ 𝓧} {P' : Kernel Θ 𝓧'}
+    {P : Kernel Θ 𝓧} {P' : Kernel Θ 𝓧'} [IsMarkovKernel P] [IsMarkovKernel P']
     (h : ∀ {𝓨 : Type u} [MeasurableSpace 𝓨] (ℓ : Θ → 𝓨 → ℝ≥0∞) (π : Measure Θ),
       bayesRisk ℓ P π ≤ bayesRisk ℓ P' π) :
     P'.IsGarblingOf P := by
@@ -114,11 +133,12 @@ theorem isGarblingOf_of_forall_bayesRisk_le
 /-- **[blackwell-1953]** (finite case). `P` is at least as informative as `P'` (`P'` is a
 garbling of `P`) iff `P` attains a Bayes risk no larger than `P'` across every decision
 problem. The forward direction (`bayesRisk_le_of_isGarblingOf`) holds for arbitrary spaces;
-the reverse (`isGarblingOf_of_forall_bayesRisk_le`) needs finiteness. -/
+the reverse (`isGarblingOf_of_forall_bayesRisk_le`) needs finiteness and that both
+experiments are Markov kernels. -/
 theorem isGarblingOf_iff_forall_bayesRisk_le
     [Fintype Θ] [Fintype 𝓧] [Fintype 𝓧']
     [MeasurableSingletonClass Θ] [MeasurableSingletonClass 𝓧] [MeasurableSingletonClass 𝓧']
-    {P : Kernel Θ 𝓧} {P' : Kernel Θ 𝓧'} :
+    {P : Kernel Θ 𝓧} {P' : Kernel Θ 𝓧'} [IsMarkovKernel P] [IsMarkovKernel P'] :
     P'.IsGarblingOf P ↔
       ∀ {𝓨 : Type u} [MeasurableSpace 𝓨] (ℓ : Θ → 𝓨 → ℝ≥0∞) (π : Measure Θ),
         bayesRisk ℓ P π ≤ bayesRisk ℓ P' π := by

--- a/Linglib/Semantics/Questions/DecisionTheory.lean
+++ b/Linglib/Semantics/Questions/DecisionTheory.lean
@@ -3,6 +3,8 @@ import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Finset.Lattice.Fold
 import Mathlib.Data.Finset.Max
 import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Algebra.Order.GroupWithZero.Finset
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Ring
 import Linglib.Semantics.Questions.Relevance
@@ -241,6 +243,233 @@ theorem euv_eq_evsi {W A : Type*} [Fintype W] [DecidableEq W] [DecidableEq A]
     | none => simp
     | some a => exact hLTE a
   rw [hLHS, hRHS]
+
+/-! ### Refinement monotonicity (Blackwell forward direction / [van-rooy-2003] §4.1)
+
+[van-rooy-2003] p. 743 states that `Q ⊑ Q' ↔ ∀ DP, EUV(Q) ≥ EUV(Q')` is "a special
+case of [blackwell-1953]". The `⟹` ("only if") direction is the data-processing /
+Jensen inequality: a *finer* question can only raise question utility. We prove it
+directly at the `questionUtility` level.
+
+The mathematical core is the **unnormalized cell value** `maxₐ ∑_{w∈c} P(w)·U(w,a)`,
+which equals `P(c)·V(D|c)` (`cellProb_mul_valueAfterLearning_eq_uValue`) and is
+**superadditive** under splitting a cell into disjoint pieces
+(`uValue_union_le`): the max of a sum is at most the sum of the maxes. Summed over a
+partition, this gives `questionUtility (finer) ≥ questionUtility (coarser)`. -/
+
+/-- The **unnormalized cell value** of `cell`: the best, over actions, of the
+*unnormalized* expected utility `∑_{w∈cell} P(w)·U(w,a)`. This linearizes the
+probability-weighted conditional value `P(cell)·V(D|cell)` (see
+`cellProb_mul_valueAfterLearning_eq_uValue`), turning Van Rooy's question utility into
+a sum that splitting a cell can only increase. -/
+private def uValue {W A : Type*} [DecidableEq W]
+    (dp : DecisionProblem W A) (acts : Finset A) (cell : Finset W) : ℚ :=
+  if h : acts.Nonempty then
+    acts.sup' h (fun a => ∑ w ∈ cell, dp.prior w * dp.utility w a)
+  else 0
+
+/-- `P(cell)·V(D|cell) = maxₐ ∑_{w∈cell} P(w)·U(w,a)`: the probability-weighted
+conditional value equals the unnormalized cell value. The normalizing `1/P(cell)` in
+`conditionalEU` cancels against the `P(cell)` weight; when `P(cell) = 0`, a nonnegative
+prior forces every `P(w) = 0` on the cell, so both sides vanish. -/
+private lemma cellProb_mul_valueAfterLearning_eq_uValue {W A : Type*} [DecidableEq W]
+    (dp : DecisionProblem W A) (acts : Finset A) (cell : Finset W)
+    (hprior : ∀ w, 0 ≤ dp.prior w) :
+    cellProbability dp cell * valueAfterLearning dp acts cell = uValue dp acts cell := by
+  unfold uValue valueAfterLearning
+  by_cases hne : acts.Nonempty
+  · rw [dif_pos hne, dif_pos hne]
+    have htp_nonneg : 0 ≤ cellProbability dp cell :=
+      Finset.sum_nonneg (fun w _ => hprior w)
+    by_cases htp : cellProbability dp cell = 0
+    · rw [htp, zero_mul]
+      have hpw : ∀ w ∈ cell, dp.prior w = 0 :=
+        (Finset.sum_eq_zero_iff_of_nonneg (fun w _ => hprior w)).mp htp
+      have hz : ∀ a ∈ acts, (∑ w ∈ cell, dp.prior w * dp.utility w a) = 0 := by
+        intro a _; exact Finset.sum_eq_zero (fun w hw => by rw [hpw w hw, zero_mul])
+      rw [Finset.sup'_congr hne rfl hz, Finset.sup'_const]
+    · rw [Finset.mul₀_sup' htp_nonneg (conditionalEU dp cell) acts hne]
+      refine Finset.sup'_congr hne rfl (fun a _ => ?_)
+      have htp' : cell.sum dp.prior ≠ 0 := htp
+      have hcEU : conditionalEU dp cell a
+          = cell.sum (fun w => dp.prior w / cell.sum dp.prior * dp.utility w a) := by
+        show (if cell.sum dp.prior = 0 then (0 : ℚ) else
+              cell.sum (fun w => dp.prior w / cell.sum dp.prior * dp.utility w a)) = _
+        rw [if_neg htp']
+      show cell.sum dp.prior * conditionalEU dp cell a
+          = ∑ w ∈ cell, dp.prior w * dp.utility w a
+      rw [hcEU, Finset.mul_sum]
+      refine Finset.sum_congr rfl (fun w _ => ?_)
+      rw [div_mul_eq_mul_div, ← mul_div_assoc, mul_div_cancel_left₀ _ htp']
+  · rw [dif_neg hne, dif_neg hne, mul_zero]
+
+/-- **Superadditivity of unnormalized cell value under splitting**: when `cell` is the
+disjoint union of `c₁` and `c₂`, splitting it can only raise the best-action value,
+`uValue (c₁ ∪ c₂) ≤ uValue c₁ + uValue c₂` (max of a sum ≤ sum of maxes). This is the
+combinatorial heart of [blackwell-1953]'s forward direction. -/
+private lemma uValue_union_le {W A : Type*} [DecidableEq W]
+    (dp : DecisionProblem W A) (acts : Finset A) {c₁ c₂ : Finset W}
+    (hdisj : Disjoint c₁ c₂) :
+    uValue dp acts (c₁ ∪ c₂) ≤ uValue dp acts c₁ + uValue dp acts c₂ := by
+  unfold uValue
+  by_cases hne : acts.Nonempty
+  · rw [dif_pos hne, dif_pos hne, dif_pos hne]
+    refine Finset.sup'_le hne _ (fun a ha => ?_)
+    rw [Finset.sum_union hdisj]
+    exact add_le_add (Finset.le_sup' (fun a => ∑ w ∈ c₁, dp.prior w * dp.utility w a) ha)
+      (Finset.le_sup' (fun a => ∑ w ∈ c₂, dp.prior w * dp.utility w a) ha)
+  · rw [dif_neg hne, dif_neg hne, dif_neg hne, add_zero]
+
+/-- **Splitting a cell never decreases its decision value**: for disjoint cells `c₁`, `c₂`
+and a nonnegative prior,
+`P(c₁)·V(D|c₁) + P(c₂)·V(D|c₂) ≥ P(c₁ ∪ c₂)·V(D|c₁ ∪ c₂)`.
+This is [blackwell-1953]'s data-processing inequality for a single binary refinement, the
+building block of [van-rooy-2003]'s §4.1 question-utility monotonicity (p. 743). -/
+theorem cellProb_valueAfterLearning_split_ge {W A : Type*} [DecidableEq W]
+    (dp : DecisionProblem W A) (acts : Finset A) {c₁ c₂ : Finset W}
+    (hdisj : Disjoint c₁ c₂) (hprior : ∀ w, 0 ≤ dp.prior w) :
+    cellProbability dp (c₁ ∪ c₂) * valueAfterLearning dp acts (c₁ ∪ c₂) ≤
+    cellProbability dp c₁ * valueAfterLearning dp acts c₁ +
+    cellProbability dp c₂ * valueAfterLearning dp acts c₂ := by
+  rw [cellProb_mul_valueAfterLearning_eq_uValue dp acts _ hprior,
+    cellProb_mul_valueAfterLearning_eq_uValue dp acts _ hprior,
+    cellProb_mul_valueAfterLearning_eq_uValue dp acts _ hprior]
+  exact uValue_union_le dp acts hdisj
+
+/-- **Question utility rises under refinement (binary split)** — the `⟹` ("only if")
+direction of [van-rooy-2003]'s §4.1 Fact (p. 743), in its elementary case. Splitting one
+cell `c₁ ∪ c₂` of a question into the two disjoint cells `c₁`, `c₂` can only increase the
+expected utility value `EUV`. This is the finite-partition instance of [blackwell-1953]'s
+data-processing inequality; any finite refinement of one partition by another is a
+composition of such binary splits, so iterating gives the full §4.1 monotonicity. -/
+theorem questionUtility_split_ge {W A : Type*} [Fintype W] [DecidableEq W] [DecidableEq A]
+    (dp : DecisionProblem W A) (acts : Finset A)
+    {c₁ c₂ : Finset W} (rest : Finset (Finset W))
+    (hdisj : Disjoint c₁ c₂) (hprior : ∀ w, 0 ≤ dp.prior w)
+    (hc₁ : c₁ ∉ rest) (hc₂ : c₂ ∉ rest) (hne12 : c₁ ≠ c₂) (hcrest : c₁ ∪ c₂ ∉ rest) :
+    questionUtility dp acts (insert (c₁ ∪ c₂) rest) ≤
+    questionUtility dp acts (insert c₁ (insert c₂ rest)) := by
+  have hc₁' : c₁ ∉ insert c₂ rest := by
+    simp only [Finset.mem_insert, not_or]; exact ⟨hne12, hc₁⟩
+  have hcp : cellProbability dp (c₁ ∪ c₂)
+      = cellProbability dp c₁ + cellProbability dp c₂ := Finset.sum_union hdisj
+  have hcpd : cellProbability dp (c₁ ∪ c₂) * dpValue dp acts
+      = cellProbability dp c₁ * dpValue dp acts
+        + cellProbability dp c₂ * dpValue dp acts := by rw [hcp]; ring
+  have hsplit := cellProb_valueAfterLearning_split_ge dp acts hdisj hprior
+  unfold questionUtility
+  rw [Finset.sum_insert hcrest, Finset.sum_insert hc₁', Finset.sum_insert hc₂]
+  simp only [utilityValue, mul_sub]
+  linarith [hsplit, hcpd]
+
+/-! #### General partition refinement
+
+The binary `questionUtility_split_ge` lifts to an arbitrary refinement of one partition by
+another, via general superadditivity of `uValue` and a fiberwise regrouping. The refinement
+is presented by a map `assign` sending each finer cell to the coarser cell containing it,
+with each coarser cell the union (`Finset.sup`) of its fiber. -/
+
+private lemma uValue_empty {W A : Type*} [DecidableEq W]
+    (dp : DecisionProblem W A) (acts : Finset A) : uValue dp acts ∅ = 0 := by
+  unfold uValue
+  by_cases h : acts.Nonempty
+  · rw [dif_pos h]; simp only [Finset.sum_empty, Finset.sup'_const]
+  · rw [dif_neg h]
+
+/-- **General superadditivity of `uValue`**: splitting a union of pairwise-disjoint cells
+into its pieces never lowers the best-action value, `uValue (⨆ parts) ≤ ∑ uValue`. The
+`Finset.induction` engine for the refinement monotonicity below. -/
+private lemma uValue_sup_le {W A : Type*} [DecidableEq W]
+    (dp : DecisionProblem W A) (acts : Finset A) :
+    ∀ {parts : Finset (Finset W)},
+      (∀ p₁ ∈ parts, ∀ p₂ ∈ parts, p₁ ≠ p₂ → Disjoint p₁ p₂) →
+      uValue dp acts (parts.sup id) ≤ ∑ p ∈ parts, uValue dp acts p := by
+  intro parts
+  induction parts using Finset.induction with
+  | empty => intro _; simp [uValue_empty]
+  | insert p s hp ih =>
+    intro hdisj
+    have hsub : ∀ p₁ ∈ s, ∀ p₂ ∈ s, p₁ ≠ p₂ → Disjoint p₁ p₂ :=
+      fun a ha b hb hab =>
+        hdisj a (Finset.mem_insert_of_mem ha) b (Finset.mem_insert_of_mem hb) hab
+    have hdp : Disjoint p (s.sup id) :=
+      Finset.disjoint_sup_right.mpr fun q hq =>
+        hdisj p (Finset.mem_insert_self p s) q (Finset.mem_insert_of_mem hq)
+          (fun h => hp (h ▸ hq))
+    rw [Finset.sup_insert, Finset.sum_insert hp, id_eq]
+    calc uValue dp acts (p ⊔ s.sup id)
+        ≤ uValue dp acts p + uValue dp acts (s.sup id) := uValue_union_le dp acts hdp
+      _ ≤ uValue dp acts p + ∑ q ∈ s, uValue dp acts q := by linarith [ih hsub]
+
+/-- Cell probability is additive over a union of pairwise-disjoint cells. -/
+private lemma cellProb_sup {W A : Type*} [DecidableEq W]
+    (dp : DecisionProblem W A) :
+    ∀ {parts : Finset (Finset W)},
+      (∀ p₁ ∈ parts, ∀ p₂ ∈ parts, p₁ ≠ p₂ → Disjoint p₁ p₂) →
+      cellProbability dp (parts.sup id) = ∑ p ∈ parts, cellProbability dp p := by
+  intro parts
+  induction parts using Finset.induction with
+  | empty => intro _; simp [cellProbability, Finset.sup_empty, Finset.bot_eq_empty]
+  | insert p s hp ih =>
+    intro hdisj
+    have hsub : ∀ p₁ ∈ s, ∀ p₂ ∈ s, p₁ ≠ p₂ → Disjoint p₁ p₂ :=
+      fun a ha b hb hab =>
+        hdisj a (Finset.mem_insert_of_mem ha) b (Finset.mem_insert_of_mem hb) hab
+    have hdp : Disjoint p (s.sup id) :=
+      Finset.disjoint_sup_right.mpr fun q hq =>
+        hdisj p (Finset.mem_insert_self p s) q (Finset.mem_insert_of_mem hq)
+          (fun h => hp (h ▸ hq))
+    rw [Finset.sup_insert, Finset.sum_insert hp, id_eq, ← ih hsub]
+    exact Finset.sum_union hdp
+
+/-- `questionUtility` in linearized form: total best-action value minus the baseline value
+weighted by total cell mass. Lets refinement monotonicity reduce to `∑ uValue` superadditivity
+once total mass is shown invariant. -/
+private lemma questionUtility_eq {W A : Type*} [Fintype W] [DecidableEq W] [DecidableEq A]
+    (dp : DecisionProblem W A) (acts : Finset A) (cells : Finset (Finset W))
+    (hprior : ∀ w, 0 ≤ dp.prior w) :
+    questionUtility dp acts cells
+      = (∑ c ∈ cells, uValue dp acts c)
+        - dpValue dp acts * (∑ c ∈ cells, cellProbability dp c) := by
+  unfold questionUtility
+  rw [Finset.mul_sum, ← Finset.sum_sub_distrib]
+  refine Finset.sum_congr rfl (fun c _ => ?_)
+  unfold utilityValue
+  rw [mul_sub, cellProb_mul_valueAfterLearning_eq_uValue dp acts c hprior]
+  ring
+
+/-- **Question utility is monotone under partition refinement** — the `⟹` direction of
+[van-rooy-2003]'s §4.1 Fact (p. 743), in full generality. A finer partition `fine`
+(presented as a refinement of `coarse` via `assign`, with each coarse cell the disjoint
+union of its fiber) has `EUV ≥` the coarser one. By [blackwell-1953]: post-processing the
+finer experiment cannot raise the convex value. Generalizes `questionUtility_split_ge`. -/
+theorem questionUtility_mono_of_refines {W A : Type*} [Fintype W] [DecidableEq W] [DecidableEq A]
+    (dp : DecisionProblem W A) (acts : Finset A)
+    {fine coarse : Finset (Finset W)} (assign : Finset W → Finset W)
+    (hmaps : ∀ f ∈ fine, assign f ∈ coarse)
+    (hcover : ∀ c ∈ coarse, c = (fine.filter (fun f => assign f = c)).sup id)
+    (hdisj : ∀ f₁ ∈ fine, ∀ f₂ ∈ fine, f₁ ≠ f₂ → Disjoint f₁ f₂)
+    (hprior : ∀ w, 0 ≤ dp.prior w) :
+    questionUtility dp acts coarse ≤ questionUtility dp acts fine := by
+  have hfdisj : ∀ c ∈ coarse, ∀ f₁ ∈ fine.filter (fun f => assign f = c),
+      ∀ f₂ ∈ fine.filter (fun f => assign f = c), f₁ ≠ f₂ → Disjoint f₁ f₂ :=
+    fun c _ f₁ hf₁ f₂ hf₂ hne =>
+      hdisj f₁ (Finset.mem_of_mem_filter _ hf₁) f₂ (Finset.mem_of_mem_filter _ hf₂) hne
+  have hcell : ∑ c ∈ coarse, cellProbability dp c = ∑ f ∈ fine, cellProbability dp f := by
+    rw [← Finset.sum_fiberwise_of_maps_to hmaps (fun f => cellProbability dp f)]
+    refine Finset.sum_congr rfl (fun c hc => ?_)
+    rw [← cellProb_sup dp (hfdisj c hc)]
+    exact congrArg (cellProbability dp) (hcover c hc)
+  have huv : ∑ c ∈ coarse, uValue dp acts c ≤ ∑ f ∈ fine, uValue dp acts f := by
+    calc ∑ c ∈ coarse, uValue dp acts c
+        = ∑ c ∈ coarse, uValue dp acts ((fine.filter (fun f => assign f = c)).sup id) :=
+          Finset.sum_congr rfl (fun c hc => congrArg (uValue dp acts) (hcover c hc))
+      _ ≤ ∑ c ∈ coarse, ∑ f ∈ fine.filter (fun f => assign f = c), uValue dp acts f :=
+          Finset.sum_le_sum (fun c hc => uValue_sup_le dp acts (hfdisj c hc))
+      _ = ∑ f ∈ fine, uValue dp acts f :=
+          Finset.sum_fiberwise_of_maps_to hmaps (fun f => uValue dp acts f)
+  rw [questionUtility_eq dp acts coarse hprior, questionUtility_eq dp acts fine hprior, hcell]
+  linarith [huv]
 
 /-! ### Maximin Monotonicity
 

--- a/Linglib/Studies/VanRooy2003.lean
+++ b/Linglib/Studies/VanRooy2003.lean
@@ -43,12 +43,18 @@ notation maps to the substrate as:
   *completely irrelevant* exactly when `EUV(Q) = EVSI(Q) = 0`, i.e. no
   answer changes the optimal action (p. 742). `alts_resolve_distinct`
   recasts a witness in the substrate's `IsResolved` vocabulary.
-* **§4.1 Blackwell-style ordering** (p. 741, 743): "Q is more
-  informative than Q'" is `Question.questionEntails Q Q'` (= van Rooy's
-  `Q ⊑ Q'`). Van Rooy's §4.1 theorem (p. 743, "a special case of
-  [blackwell-1953]") is the quantitative *iff*
-  `Q ⊑ Q' ↔ ∀ DP, EUV(Q) ≥ EUV(Q')`; `decisionRelevance_preserved_under_cover`
-  is a qualitative one-directional surrogate (see its docstring).
+* **§4.1 Blackwell Fact** (p. 741, 743): "Q is more informative than Q'" is van
+  Rooy's `Q ⊑ Q'`. Van Rooy's §4.1 theorem (p. 743, "a special case of
+  [blackwell-1953]") is the quantitative *iff* `Q ⊑ Q' ↔ ∀ DP, EUV(Q) ≥ EUV(Q')`,
+  stated over partition cells as `blackwell_euv_fact`. Its `⟹` ("only if")
+  direction — a finer partition weakly dominates a coarser one for every decision
+  problem — is the data-processing inequality `blackwell_euv_fact_forward`
+  (deriving the substrate refinement map from `⊑` and applying
+  `Core.DecisionTheory.questionUtility_mono_of_refines`). The `⟸` direction is the
+  [blackwell-1953] *converse*, `ProbabilityTheory.isGarblingOf_of_forall_bayesRisk_le`
+  (finite, kernel-level; the deep direction, currently open).
+  `decisionRelevance_preserved_under_cover` is a separate, qualitative
+  one-directional transfer (see its docstring).
 
 ## What this file does NOT replicate
 
@@ -241,8 +247,13 @@ is reflexive (`questionEntails_refl`) and transitive
     witness, but its dual does. On partition questions the two coincide,
     recovering [van-rooy-2003]'s partition-based argument.
 
-    TODO: prove the faithful EUV-monotonicity Blackwell Fact (p. 743)
-    against `Core.DecisionTheory.questionUtility`. -/
+    For the *quantitative* §4.1 Fact (p. 743), the EUV-monotonicity ("only if")
+    direction is now `Core.DecisionTheory.questionUtility_split_ge` (a finer
+    partition has `EUV ≥` the coarser one, for every decision problem). The
+    remaining gap to the full `questionEntails`-level *iff* is (i) a
+    `Question W → Finset (Finset W)` partition-cell bridge via `HasAltList`, and
+    (ii) the [blackwell-1953] converse
+    `ProbabilityTheory.isGarblingOf_of_forall_bayesRisk_le`. -/
 theorem decisionRelevance_preserved_under_cover
     {Q Q' : Question W} (hCover : CoversAltsOf Q Q')
     {dp : DecisionProblem W A} {acts : Set A}
@@ -254,5 +265,91 @@ theorem decisionRelevance_preserved_under_cover
   exact ⟨pP, hpP, hpP_ne, p'P, hp'P, hp'P_ne, a, ha, a', ha',
          fun w hw => hpa w (hpP_sub hw),
          fun w hw => hpa' w (hp'P_sub hw)⟩
+
+/-! ### §4.1 The Blackwell Fact (p. 743): partition-cell form
+
+[van-rooy-2003] p. 743 states that `Q ⊑ Q' ↔ ∀ DP, EUV(Q) ≥ EUV(Q')` is "a special case
+of [blackwell-1953]". We state it over [groenendijk-stokhof-1984] partition cells — the
+`Finset (Finset W)` that `Core.DecisionTheory.questionUtility` consumes. There, van Rooy's
+`Q ⊑ Q'` (p. 741: "∀ q ∈ Q : ∃ q' ∈ Q' : q ⊆ q'") is the cell-level refinement
+`∀ f ∈ fine, ∃ c ∈ coarse, f ⊆ c`, and the value side ranges over every decision problem
+with a proper prior.
+
+(The lift to the type-level `Question.questionEntails`/`Question W` is the remaining
+mechanical step: a `HasAltList Q → Finset (Finset W)` adapter via `Set.Finite.toFinset`,
+discharging `questionEntails` against this cell refinement.) -/
+
+/-- **[van-rooy-2003] §4.1 Fact, the `⟹` ("only if") direction** (p. 743): a finer question
+is weakly better than a coarser one for *every* decision problem (the data-processing
+inequality). Van Rooy's refinement `fine ⊑ coarse` (each fine cell `⊆` some coarse cell,
+p. 741) plus the partition structure furnish the substrate refinement map — each fine cell's
+containing coarse cell — and `Core.DecisionTheory.questionUtility_mono_of_refines` concludes.
+
+`hfine_cover` and the disjointness hypotheses encode that `fine`, `coarse` are genuine
+[groenendijk-stokhof-1984] partitions of the world set. -/
+theorem blackwell_euv_fact_forward [Fintype W] [DecidableEq W] [DecidableEq A]
+    {fine coarse : Finset (Finset W)}
+    (hcoarse_disj : ∀ c₁ ∈ coarse, ∀ c₂ ∈ coarse, c₁ ≠ c₂ → Disjoint c₁ c₂)
+    (hfine_disj : ∀ f₁ ∈ fine, ∀ f₂ ∈ fine, f₁ ≠ f₂ → Disjoint f₁ f₂)
+    (hfine_cover : ∀ w : W, ∃ f ∈ fine, w ∈ f)
+    (href : ∀ f ∈ fine, ∃ c ∈ coarse, f ⊆ c)
+    (dp : DecisionProblem W A) (acts : Finset A) (hprior : ∀ w, 0 ≤ dp.prior w) :
+    questionUtility dp acts coarse ≤ questionUtility dp acts fine := by
+  classical
+  set g : Finset W → Finset W :=
+    fun f => if h : ∃ c ∈ coarse, f ⊆ c then h.choose else ∅ with hg_def
+  have hgspec : ∀ f ∈ fine, g f ∈ coarse ∧ f ⊆ g f := by
+    intro f hf
+    have h : ∃ c ∈ coarse, f ⊆ c := href f hf
+    have hgf : g f = h.choose := by rw [hg_def]; exact dif_pos h
+    rw [hgf]; exact h.choose_spec
+  refine questionUtility_mono_of_refines dp acts g
+    (fun f hf => (hgspec f hf).1) ?_ hfine_disj hprior
+  -- hcover: every coarse cell is the union of the fine cells mapping to it
+  intro c hc
+  refine le_antisymm ?_ ?_
+  · -- c ⊆ ⨆ fiber
+    intro w hw
+    obtain ⟨f, hf, hwf⟩ := hfine_cover w
+    have hwgf : w ∈ g f := (hgspec f hf).2 hwf
+    have hgfc : g f = c := by
+      by_contra hne
+      exact absurd hw (Finset.disjoint_left.mp
+        (hcoarse_disj (g f) (hgspec f hf).1 c hc hne) hwgf)
+    rw [Finset.mem_sup]
+    exact ⟨f, Finset.mem_filter.mpr ⟨hf, hgfc⟩, hwf⟩
+  · -- ⨆ fiber ⊆ c
+    refine Finset.sup_le (fun f hf => ?_)
+    rw [Finset.mem_filter] at hf
+    exact hf.2 ▸ (hgspec f hf.1).2
+
+/-- **[van-rooy-2003] §4.1 Fact** (p. 743), partition-cell form. For two
+[groenendijk-stokhof-1984] partitions `fine`, `coarse` of the worlds, van Rooy's refinement
+order `fine ⊑ coarse` (every fine cell is contained in some coarse cell, p. 741) is
+equivalent to: the finer question has expected utility value `≥` the coarser one for
+*every* decision problem (with a proper, nonnegative prior). Van Rooy calls this "a special
+case of [blackwell-1953]".
+
+The `⟹` direction is `blackwell_euv_fact_forward` (the data-processing inequality). The
+`⟸` direction (EUV-dominance across all decision problems forces refinement) is the
+[blackwell-1953] *converse*, `ProbabilityTheory.isGarblingOf_of_forall_bayesRisk_le` — the
+deep direction, currently open. -/
+theorem blackwell_euv_fact [Fintype W] [DecidableEq W] [DecidableEq A]
+    {fine coarse : Finset (Finset W)}
+    (hfine_disj : ∀ f₁ ∈ fine, ∀ f₂ ∈ fine, f₁ ≠ f₂ → Disjoint f₁ f₂)
+    (hcoarse_disj : ∀ c₁ ∈ coarse, ∀ c₂ ∈ coarse, c₁ ≠ c₂ → Disjoint c₁ c₂)
+    (hfine_cover : ∀ w : W, ∃ f ∈ fine, w ∈ f) :
+    (∀ f ∈ fine, ∃ c ∈ coarse, f ⊆ c) ↔
+      (∀ (dp : DecisionProblem W A) (acts : Finset A), (∀ w, 0 ≤ dp.prior w) →
+        questionUtility dp acts coarse ≤ questionUtility dp acts fine) := by
+  refine ⟨fun href dp acts hprior =>
+    blackwell_euv_fact_forward hcoarse_disj hfine_disj hfine_cover href dp acts hprior, ?_⟩
+  -- ⟸ : EUV-dominance across all decision problems forces refinement.
+  -- The finite [blackwell-1953] converse at the partition-cell level
+  -- (`ProbabilityTheory.isGarblingOf_of_forall_bayesRisk_le`), the deep direction.
+  -- TODO: instantiate the Blackwell converse with the deterministic (partition-cell)
+  -- experiments of `fine`/`coarse`; when refinement fails, the separating decision problem
+  -- reverses the EUV ordering.
+  sorry
 
 end VanRooy2003


### PR DESCRIPTION
van Rooy 2003 §4.1's Blackwell Fact (p. 743), `Q ⊑ Q' ↔ ∀ DP, EUV(Q) ≥ EUV(Q')` — forward direction.

- `Core.DecisionTheory.questionUtility_mono_of_refines`: EUV is monotone under partition refinement (the data-processing inequality); `questionUtility_split_ge` is the binary-split case.
- `VanRooy2003.blackwell_euv_fact` states the iff over partition cells: `⟹` proved (`blackwell_euv_fact_forward`), `⟸` a documented `sorry` — the open finite Blackwell converse `isGarblingOf_of_forall_bayesRisk_le`.
- Corrects the Blackwell converse statement to require `[IsMarkovKernel P] [IsMarkovKernel P']` (false otherwise: `P = 0` and `P' = 2•P` counterexamples).