### PR TITLE
refactor(Core/Computability): build the syntactic monoid on a new DFA.transitionMonoid layer

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1903,6 +1903,7 @@ import Linglib.Core.Computability.ContextFreeGrammar.Closure
 import Linglib.Core.Computability.ContextFreeGrammar.Weighted
 import Linglib.Core.Algebra.Free
 import Linglib.Core.Algebra.IdempotentPower
+import Linglib.Core.Computability.TransitionMonoid
 import Linglib.Core.Computability.SyntacticMonoid
 import Linglib.Core.Computability.Subregular.Language.Algebra.Equations
 import Linglib.Core.Computability.Subregular.Language.Algebra.Pin

--- a/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
@@ -172,7 +172,7 @@ lemma syntacticEquiv_of_kDefiniteEquation {L : Language α} {k : ℕ}
       L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
     rw [FreeMonoid.ofList_append, MonoidHom.map_mul]
     exact h_eq
-  exact Quotient.exact h_pre
+  exact (syntacticCon_iff L).mp (Quotient.exact h_pre)
 
 -- ============================================================================
 -- §3. Lambert Prop 53 — both directions
@@ -189,6 +189,7 @@ theorem IsDefinite.satisfies_kDefiniteEquation
   obtain ⟨w, hw⟩ := Quotient.exists_rep s
   rw [show s = L.toSyntacticMonoid w from hw.symm, ← MonoidHom.map_mul]
   apply Quotient.sound
+  refine (syntacticCon_iff L).mpr ?_
   intro x y
   show x ++ FreeMonoid.toList (w * FreeMonoid.ofList αs) ++ y ∈ L ↔
        x ++ FreeMonoid.toList (FreeMonoid.ofList αs) ++ y ∈ L
@@ -245,7 +246,7 @@ theorem isDefinite_of_satisfies_kDefiniteEquation
         have decomp : w = w.take (w.length - k) ++ Edge.right.takeAt k w :=
           (List.rdrop_append_rtake w k).symm
         rwa [← decomp] at base
-      exact mem_iff_of_syntacticEquiv hequiv
+      exact hequiv.mem_iff
   exact fun a b hab => by simp only [key a, key b, hab]
 
 /-- **Lambert (2026) Prop 53**: a language is `k`-definite iff its
@@ -320,7 +321,7 @@ lemma syntacticEquiv_of_kReverseDefiniteEquation {L : Language α} {k : ℕ}
       L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
     rw [FreeMonoid.ofList_append, MonoidHom.map_mul]
     exact h_eq
-  exact Quotient.exact h_pre
+  exact (syntacticCon_iff L).mp (Quotient.exact h_pre)
 
 -- §4.3. Lambert Prop 57 — both directions
 
@@ -333,6 +334,7 @@ theorem IsReverseDefinite.satisfies_kReverseDefiniteEquation
   obtain ⟨w, hw⟩ := Quotient.exists_rep s
   rw [show s = L.toSyntacticMonoid w from hw.symm, ← MonoidHom.map_mul]
   apply Quotient.sound
+  refine (syntacticCon_iff L).mpr ?_
   intro x y
   show x ++ FreeMonoid.toList (FreeMonoid.ofList αs * w) ++ y ∈ L ↔
        x ++ FreeMonoid.toList (FreeMonoid.ofList αs) ++ y ∈ L
@@ -368,7 +370,7 @@ theorem isReverseDefinite_of_satisfies_kReverseDefiniteEquation
         have base := syntacticEquiv_of_kReverseDefiniteEquation h
           (Edge.left.takeAt k w) (w.drop k) hlen
         rwa [← decompose_at_left_takeAt (le_of_lt hw)] at base
-      exact mem_iff_of_syntacticEquiv hequiv
+      exact hequiv.mem_iff
   exact fun a b hab => by simp only [key a, key b, hab]
 
 /-- **Lambert (2026) Prop 57**: a language is reverse-`k`-definite iff
@@ -419,7 +421,7 @@ lemma syntacticEquiv_of_kGeneralizedDefiniteEquation
     rw [FreeMonoid.ofList_append, FreeMonoid.ofList_append, MonoidHom.map_mul,
         MonoidHom.map_mul]
     exact h_eq
-  exact Quotient.exact h_pre
+  exact (syntacticCon_iff L).mp (Quotient.exact h_pre)
 
 -- §5.2. Lambert Prop 58 — forward direction
 
@@ -441,6 +443,7 @@ theorem IsGeneralizedDefinite.satisfies_kGeneralizedDefiniteEquation
       L.toSyntacticMonoid (FreeMonoid.ofList αs * w * FreeMonoid.ofList αs) by
     rw [MonoidHom.map_mul, MonoidHom.map_mul]]
   apply Quotient.sound
+  refine (syntacticCon_iff L).mpr ?_
   intro x y
   show x ++ FreeMonoid.toList (FreeMonoid.ofList αs * w * FreeMonoid.ofList αs) ++ y ∈ L ↔
        x ++ FreeMonoid.toList (FreeMonoid.ofList αs) ++ y ∈ L
@@ -565,7 +568,7 @@ theorem isGeneralizedDefinite_of_satisfies_kGeneralizedDefiniteEquation
       exact h_inner
     -- Combine: w₁ ≡_L w₂.
     have hequiv : SyntacticEquiv L w₁ w₂ := h_βs_eq.symm.trans h_αs_eq
-    exact mem_iff_of_syntacticEquiv hequiv
+    exact hequiv.mem_iff
   · -- Short case: `|w₁| < k`. Then `Edge.left.takeAt k w₁ = w₁`, so
     -- the prefix equality yields `w₁ = Edge.left.takeAt k w₂`, which
     -- forces `|w₂| ≤ k` (otherwise the takeAt has length `k > |w₁|`).

--- a/Linglib/Core/Computability/Subregular/Language/Algebra/Pin.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Algebra/Pin.lean
@@ -617,6 +617,7 @@ theorem IsGeneralizedDefinite.satisfies_pinGeneralizedDefiniteEquation
           show (1 : L.syntacticMonoid) = L.toSyntacticMonoid 1 from
             (L.toSyntacticMonoid.map_one).symm]
       apply Quotient.sound
+      refine (syntacticCon_iff L).mpr ?_
       intro p q
       show p ++ FreeMonoid.toList u ++ q ∈ L ↔ p ++ FreeMonoid.toList 1 ++ q ∈ L
       apply isGeneralizedDefinite_iff_edges.mp hk
@@ -654,6 +655,7 @@ theorem IsGeneralizedDefinite.satisfies_pinGeneralizedDefiniteEquation
         L.toSyntacticMonoid (FreeMonoid.ofList v * s' * FreeMonoid.ofList v) by
       rw [MonoidHom.map_mul, MonoidHom.map_mul]]
     apply Quotient.sound
+    refine (syntacticCon_iff L).mpr ?_
     intro x y
     show x ++ FreeMonoid.toList (FreeMonoid.ofList v * s' * FreeMonoid.ofList v) ++ y ∈ L ↔
          x ++ FreeMonoid.toList (FreeMonoid.ofList v) ++ y ∈ L

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -3,11 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Mathlib.Algebra.FreeMonoid.Basic
-import Mathlib.Computability.MyhillNerode
-import Mathlib.Data.Finite.Prod
-import Mathlib.Data.Set.Finite.Range
-import Mathlib.GroupTheory.Congruence.Hom
+import Linglib.Core.Computability.TransitionMonoid
 
 /-!
 # The syntactic monoid of a language
@@ -16,50 +12,62 @@ The *syntactic monoid* of a language `L : Language α` is the quotient of the fr
 `FreeMonoid α` by the *syntactic congruence*: two words are identified when no two-sided context
 distinguishes them as `L`-members, `∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L`.
 
-This is the two-sided, monoid-valued refinement of `Mathlib.Computability.MyhillNerode`, which
-builds the one-sided right-Nerode quotient (`Language.leftQuotient`) and proves regularity ↔
-finitely many left quotients. The syntactic monoid carries a *monoid* structure rather than just a
-set of states, and its Myhill–Nerode theorem reads `L.IsRegular ↔ Finite L.syntacticMonoid`.
+We obtain the syntactic congruence as the kernel of the transition action of the minimal DFA
+`L.toDFA` (the *transition monoid* of `L.toDFA`, see
+`Linglib.Core.Computability.TransitionMonoid`), and identify it with the two-sided context
+equivalence via `Language.syntacticCon_iff`. This is the two-sided refinement of
+`Mathlib.Computability.MyhillNerode`, which builds the one-sided right-Nerode quotient
+(`Language.leftQuotient`) and proves regularity ↔ finitely many left quotients. It carries a
+*monoid* structure rather than just a set of states, and its Myhill–Nerode theorem reads
+`L.IsRegular ↔ Finite L.syntacticMonoid`.
 
 ## Main definitions
 
+* `Language.syntacticCon L : Con (FreeMonoid α)`: the syntactic congruence, the kernel of the
+  transition action of `L.toDFA`.
 * `Language.SyntacticEquiv L u v`: the two-sided context equivalence on words.
-* `Language.syntacticCon L : Con (FreeMonoid α)`: the syntactic congruence.
 * `Language.syntacticMonoid L`: the quotient monoid `(syntacticCon L).Quotient`.
 * `Language.toSyntacticMonoid L`: the projection `FreeMonoid α →* L.syntacticMonoid`.
 * `Language.Recognises φ L`: `φ` recognises `L`, i.e. `L` is a union of `φ`-fibres.
 
 ## Main results
 
-* `Language.mem_iff_of_syntacticEquiv`: `L` is saturated by the syntactic congruence.
+* `Language.syntacticCon_iff`: the syntactic congruence is exactly the two-sided context
+  equivalence.
+* `Language.SyntacticEquiv.mem_iff`: `L` is saturated by syntactic equivalence.
 * `Language.ker_le_syntacticCon_of_recognises`: the syntactic congruence is the coarsest congruence
   recognising `L`, so every recognising hom factors through `toSyntacticMonoid` via `Con.lift`.
 * `Language.isRegular_iff_finite_syntacticMonoid`: the Myhill–Nerode theorem in monoid form.
-
-## Implementation notes
-
-`FreeMonoid α` is definitionally `List α`, but the elaborator does not unfold the `def`.
-`SyntacticEquiv` is stated on `List α` so that `++` and `Language.leftQuotient` apply directly; the
-`Con` packaging reuses it through the definitional equality, bridging `*` on `FreeMonoid` to `++` on
-`List` via `FreeMonoid.toList` (an `Equiv.refl`).
-
-## References
-
-* Myhill (1957), Nerode (1958)
-* Pin, *Mathematical Foundations of Automata Theory*, Chapter I
-* <https://en.wikipedia.org/wiki/Syntactic_monoid>
 -/
+
+noncomputable section
+
+universe u
 
 namespace Language
 
-variable {α : Type*} {L : Language α}
+variable {α : Type u} {L : Language α}
+
+/-- Evaluating the minimal DFA `L.toDFA` from a quotient state `s` along a word `w` lands on the
+left quotient of `s` by `w`. -/
+@[simp]
+theorem evalFrom_toDFA (L : Language α) (s : Set.range L.leftQuotient) (w : List α) :
+    (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
+  induction w using List.reverseRecOn with
+  | nil => simp
+  | append_singleton x a ih =>
+    rw [DFA.evalFrom_append_singleton, step_toDFA, ih, ← leftQuotient_append]
+
+/-! ### The syntactic congruence and monoid -/
+
+/-- The *syntactic congruence* of `L`, obtained as the kernel of the transition action of `L.toDFA`
+(the transition monoid of the minimal DFA). -/
+def syntacticCon (L : Language α) : Con (FreeMonoid α) := Con.ker L.toDFA.transitionHom
 
 /-! ### Syntactic equivalence on words -/
 
-variable (L) in
-/-- Two words are *syntactically equivalent* w.r.t. `L` when no two-sided context distinguishes
-them: the largest left- and right-concatenation-stable equivalence contained in `(· ∈ L)`. -/
-def SyntacticEquiv (u v : List α) : Prop :=
+/-- `u` and `v` are *syntactically equivalent* in `L`: no two-sided context distinguishes them. -/
+def SyntacticEquiv (L : Language α) (u v : List α) : Prop :=
   ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
 
 namespace SyntacticEquiv
@@ -74,126 +82,102 @@ variable {u v w : List α}
 @[trans] protected theorem trans (h₁ : SyntacticEquiv L u v) (h₂ : SyntacticEquiv L v w) :
     SyntacticEquiv L u w := fun x y => (h₁ x y).trans (h₂ x y)
 
-/-- Specialising the two-sided test to `x = []` shows that syntactic equivalence refines the
-right-Nerode equivalence: equivalent words have the same `Language.leftQuotient`. -/
+/-- Syntactic equivalence is a two-sided congruence for concatenation. -/
+protected theorem append {u₁ u₂ v₁ v₂ : List α} (h₁ : SyntacticEquiv L u₁ v₁)
+    (h₂ : SyntacticEquiv L u₂ v₂) : SyntacticEquiv L (u₁ ++ u₂) (v₁ ++ v₂) := fun x y => by
+  have e₁ := h₁ x (u₂ ++ y)
+  have e₂ := h₂ (x ++ v₁) y
+  simp only [List.append_assoc] at e₁ e₂ ⊢
+  exact e₁.trans e₂
+
+/-- Left concatenation by a fixed word preserves syntactic equivalence. -/
+protected theorem append_left (w : List α) (h : SyntacticEquiv L u v) :
+    SyntacticEquiv L (w ++ u) (w ++ v) := (SyntacticEquiv.refl w).append h
+
+/-- Equivalent words have the same `leftQuotient`: the two-sided test specialised to `x = []`. -/
 theorem leftQuotient_eq (h : SyntacticEquiv L u v) : L.leftQuotient u = L.leftQuotient v := by
   ext y; simpa using h [] y
 
+/-- Syntactically equivalent words agree on membership of `L`. -/
+theorem mem_iff (h : SyntacticEquiv L u v) : u ∈ L ↔ v ∈ L := by simpa using h [] []
+
 end SyntacticEquiv
 
-/-! ### The syntactic congruence and monoid -/
+/-- The kernel of the transition monoid of the minimal DFA is exactly the two-sided syntactic
+congruence: `u` and `v` are congruent iff they are interchangeable in every two-sided context. -/
+theorem syntacticCon_iff (L : Language α) {u v : FreeMonoid α} :
+    L.syntacticCon u v ↔ SyntacticEquiv L u v := by
+  rw [syntacticCon, Con.ker_apply, DFA.transitionHom_eq_iff]
+  -- `SyntacticEquiv L u v` is defeq to `∀ x y, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L`
+  -- (since `u.toList = u` for `FreeMonoid`); make the `.toList` form explicit for `mem_leftQuotient`.
+  show _ ↔ ∀ x y : List α, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L
+  constructor
+  · intro h x y
+    have h' := congrArg Subtype.val (h ⟨L.leftQuotient x, ⟨x, rfl⟩⟩)
+    rw [evalFrom_toDFA, evalFrom_toDFA, ← leftQuotient_append, ← leftQuotient_append] at h'
+    rw [← mem_leftQuotient, ← mem_leftQuotient, h']
+  · intro h s
+    apply Subtype.ext
+    obtain ⟨x, hx⟩ := s.2
+    rw [evalFrom_toDFA, evalFrom_toDFA, ← hx, ← leftQuotient_append, ← leftQuotient_append]
+    ext y
+    rw [mem_leftQuotient, mem_leftQuotient]
+    exact h x y
 
-variable (L) in
-/-- The *syntactic congruence* of `L`: syntactic equivalence upgraded with closure under two-sided
-concatenation. The `mul'` proof reassociates the context with `List.append_assoc`; `FreeMonoid.toList`
-(an `Equiv.refl`) bridges `*` on `FreeMonoid` to `++` on `List`. -/
-def syntacticCon : Con (FreeMonoid α) where
-  toSetoid := ⟨SyntacticEquiv L, SyntacticEquiv.refl, SyntacticEquiv.symm, SyntacticEquiv.trans⟩
-  mul' := by
-    intro w x y z hwx hyz a b
-    show a ++ (FreeMonoid.toList w ++ FreeMonoid.toList y) ++ b ∈ L ↔
-         a ++ (FreeMonoid.toList x ++ FreeMonoid.toList z) ++ b ∈ L
-    have h₁ := hwx a (FreeMonoid.toList y ++ b)
-    have h₂ := hyz (a ++ FreeMonoid.toList x) b
-    simp only [List.append_assoc] at h₁ h₂ ⊢
-    exact h₁.trans h₂
+/-- The *syntactic monoid* of `L`: the quotient of `FreeMonoid α` by the syntactic congruence. -/
+def syntacticMonoid (L : Language α) : Type u := (syntacticCon L).Quotient
 
-variable (L) in
-/-- The *syntactic monoid* of `L`: the quotient of `FreeMonoid α` by the syntactic congruence. An
-`abbrev` so that `Monoid` instance search resolves through `Con.Quotient`. -/
-abbrev syntacticMonoid : Type _ := (syntacticCon L).Quotient
+instance : Monoid (syntacticMonoid L) := inferInstanceAs (Monoid (syntacticCon L).Quotient)
 
-variable (L) in
 /-- The canonical projection sending each word to its syntactic class; the underlying `Con.mk'`. -/
-def toSyntacticMonoid : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L).mk'
-
-/-- **`L` is saturated by the syntactic congruence**: equivalent words are equi-members. This is the
-defining property — `syntacticCon L` is the coarsest congruence on `FreeMonoid α` for which `L` is a
-union of classes. -/
-theorem mem_iff_of_syntacticEquiv {u v : List α} (h : SyntacticEquiv L u v) : u ∈ L ↔ v ∈ L := by
-  simpa using h [] []
+def toSyntacticMonoid (L : Language α) : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L).mk'
 
 /-! ### Universal property -/
 
-/-- A monoid hom `φ : FreeMonoid α →* M` *recognises* `L` when `L` is a union of `φ`-fibres, i.e.
-`L = φ ⁻¹' S` for some `S ⊆ M` (Pin, Chapter I). -/
+/-- `φ` *recognises* `L` when `L` is a union of `φ`-fibres, i.e. `L = φ ⁻¹' S` for some `S ⊆ M`. -/
 def Recognises {M : Type*} [Monoid M] (φ : FreeMonoid α →* M) (L : Language α) : Prop :=
   ∃ S : Set M, L = φ ⁻¹' S
 
-/-- **Universal property** (kernel form): the kernel of any `L`-recognising hom is contained in the
-syntactic congruence, so `syntacticCon L` is the coarsest congruence recognising `L`. Composing with
-`Con.lift` gives the factorisation `(syntacticCon L).lift φ (ker_le_syntacticCon_of_recognises h)`. -/
+/-- An `L`-recognising hom's kernel lies below `syntacticCon L`, the coarsest such congruence. -/
 theorem ker_le_syntacticCon_of_recognises {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
     (hrec : Recognises φ L) : Con.ker φ ≤ syntacticCon L := by
-  obtain ⟨S, hS⟩ := hrec
   intro u v huv
-  change ∀ x y : FreeMonoid α, x * u * y ∈ L ↔ x * v * y ∈ L
+  rw [show syntacticCon L u v ↔ SyntacticEquiv L u v from syntacticCon_iff L]
+  obtain ⟨S, rfl⟩ := hrec
+  change ∀ x y : FreeMonoid α, x * u * y ∈ φ ⁻¹' S ↔ x * v * y ∈ φ ⁻¹' S
   intro x y
-  have step : ∀ w : FreeMonoid α, w ∈ L ↔ φ w ∈ S := fun w => by rw [hS]; rfl
-  simp only [step, map_mul, show φ u = φ v from huv]
+  simp only [Set.mem_preimage, map_mul, Con.ker_apply.mp huv]
 
 /-! ### Regularity implies a finite syntactic monoid -/
 
-/-- **Myhill, forward direction**: a regular language has a finite syntactic monoid. The right action
-`[u] ↦ (Q ↦ Q.leftQuotient u)` injects `syntacticMonoid L` into the finite function space `LQ → LQ`,
-where `LQ = Set.range L.leftQuotient` is finite by `IsRegular.finite_range_leftQuotient`. -/
-theorem IsRegular.finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticMonoid := by
-  classical
-  set LQ : Set (Language α) := Set.range L.leftQuotient
-  haveI : Finite LQ := h.finite_range_leftQuotient.to_subtype
-  let action : FreeMonoid α → (LQ → LQ) := fun u Q =>
-    ⟨Q.val.leftQuotient (FreeMonoid.toList u), by
-      obtain ⟨x, hx⟩ := Q.prop
-      exact ⟨x ++ FreeMonoid.toList u, by rw [← hx, ← Language.leftQuotient_append]⟩⟩
-  have action_well_defined :
-      ∀ u v : FreeMonoid α, SyntacticEquiv L u v → action u = action v := by
-    intro u v huv
-    funext Q
-    obtain ⟨x, hx⟩ := Q.prop
-    refine Subtype.ext ?_
-    show Q.val.leftQuotient (FreeMonoid.toList u) = Q.val.leftQuotient (FreeMonoid.toList v)
-    rw [← hx, ← Language.leftQuotient_append, ← Language.leftQuotient_append]
-    refine SyntacticEquiv.leftQuotient_eq fun a b => ?_
-    have := huv (a ++ x) b
-    simp only [List.append_assoc] at this ⊢
-    exact this
-  let phi : L.syntacticMonoid → (LQ → LQ) := fun cls => Con.liftOn cls action action_well_defined
-  have phi_inj : Function.Injective phi := by
-    rintro ⟨u⟩ ⟨v⟩ huv
-    apply Quotient.sound
-    intro a b
-    -- Reading off the action at `Q := L.leftQuotient a` equates the two left quotients.
-    have key : L.leftQuotient (a ++ FreeMonoid.toList u) =
-        L.leftQuotient (a ++ FreeMonoid.toList v) := by
-      rw [Language.leftQuotient_append, Language.leftQuotient_append]
-      exact congr_arg Subtype.val (congr_fun huv ⟨L.leftQuotient a, a, rfl⟩)
-    show b ∈ L.leftQuotient (a ++ FreeMonoid.toList u) ↔
-         b ∈ L.leftQuotient (a ++ FreeMonoid.toList v)
-    rw [key]
-  exact Finite.of_injective phi phi_inj
+/-- A regular language has a finite syntactic monoid (forward Myhill–Nerode). -/
+theorem finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticMonoid := by
+  have : Finite (Set.range L.leftQuotient) := h.finite_range_leftQuotient.to_subtype
+  exact Finite.of_equiv _ (DFA.transitionMonoidEquiv L.toDFA).symm.toEquiv
 
 /-! ### A finite syntactic monoid implies regularity -/
 
-/-- **Myhill, reverse direction**: a language with finite syntactic monoid is regular. The map
-`[u] ↦ L.leftQuotient u` is well-defined on classes (by `SyntacticEquiv.leftQuotient_eq`) and
-surjects onto `Set.range L.leftQuotient`, so the latter is finite; close via
-`IsRegular.of_finite_range_leftQuotient`. -/
-theorem IsRegular.of_finite_syntacticMonoid [Finite L.syntacticMonoid] : L.IsRegular := by
+/-- A language with finite syntactic monoid is regular (reverse Myhill–Nerode). The left-quotient
+map factors through the syntactic monoid, so a finite quotient forces finitely many left
+quotients. -/
+theorem isRegular_of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.IsRegular := by
   apply Language.IsRegular.of_finite_range_leftQuotient
-  let f : L.syntacticMonoid → Language α := fun cls =>
-    Con.liftOn cls L.leftQuotient fun _ _ huv => SyntacticEquiv.leftQuotient_eq huv
-  have hrange : Set.range L.leftQuotient = Set.range f := by
-    ext L'
-    refine ⟨fun ⟨u, hu⟩ => ⟨(syntacticCon L).toQuotient u, hu⟩, ?_⟩
-    rintro ⟨cls, hcls⟩
-    induction cls using Con.induction_on with
-    | _ u => exact ⟨u, hcls⟩
-  rw [hrange]
-  exact Set.finite_range f
+  have factor : ∀ u v : FreeMonoid α, L.syntacticCon u v →
+      L.leftQuotient u.toList = L.leftQuotient v.toList := by
+    intro u v huv
+    rw [syntacticCon_iff] at huv
+    ext y; rw [mem_leftQuotient, mem_leftQuotient]; exact huv [] y
+  set g : L.syntacticMonoid → Language α :=
+    Quot.lift (fun w => L.leftQuotient w.toList) (fun u v huv => factor u v huv) with hg
+  have hrange : Set.range L.leftQuotient ⊆ Set.range g := by
+    rintro _ ⟨x, rfl⟩
+    exact ⟨Quot.mk _ (FreeMonoid.ofList x), rfl⟩
+  exact (Set.finite_range g).subset hrange
 
-/-- **Myhill–Nerode theorem (syntactic-monoid form)**: a language is regular iff its syntactic
-monoid is finite. -/
+/-- Myhill–Nerode (syntactic-monoid form): `L` is regular iff `L.syntacticMonoid` is finite. -/
 theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.syntacticMonoid :=
-  ⟨IsRegular.finite_syntacticMonoid, fun _ => IsRegular.of_finite_syntacticMonoid⟩
+  ⟨finite_syntacticMonoid, isRegular_of_finite_syntacticMonoid⟩
 
 end Language
+
+end

--- a/Linglib/Core/Computability/TransitionMonoid.lean
+++ b/Linglib/Core/Computability/TransitionMonoid.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Algebra.FreeMonoid.Basic
+import Mathlib.Algebra.Group.End
+import Mathlib.Computability.DFA
+import Mathlib.Computability.MyhillNerode
+import Mathlib.Data.Finite.Prod
+import Mathlib.Data.Set.Finite.Range
+import Mathlib.GroupTheory.Congruence.Basic
+import Mathlib.GroupTheory.Congruence.Hom
+
+/-!
+# The transition monoid of a DFA
+
+The **transition monoid** of an automaton is the monoid of state-transformations induced by input
+words. It is foundational algebraic automata theory (syntactic monoid, Schützenberger's theorem,
+Eilenberg variety theory) and is currently **absent from mathlib**. This file prototypes it.
+
+A word `w` acts on a state `s` of `M : DFA α σ` by `s ↦ M.evalFrom s w`. Because reading `u` then
+`v` is `evalFrom_of_append`, this is a *right* action: `act (u * v) = act v ∘ act u`, i.e. an
+*anti*-homomorphism into `Function.End σ`. Packaged as a genuine `MonoidHom`, the target is the
+opposite monoid `(Function.End σ)ᵐᵒᵖ`.
+
+* `DFA.transitionHom M : FreeMonoid α →* (Function.End σ)ᵐᵒᵖ` — the transition action.
+* `DFA.transitionMonoid M : Submonoid (Function.End σ)ᵐᵒᵖ` — its range, the transition monoid.
+* `DFA.transitionMonoidEquiv M` — the first iso theorem: `(Con.ker M.transitionHom).Quotient ≃*`
+  the transition monoid.
+* `Finite (Function.End σ)` / `Finite M.transitionMonoid` instances (these do **not**
+  auto-synthesize from `Finite σ`, so we register them here once).
+
+The syntactic monoid of a `Language α` is built as a consumer of this layer in
+`Linglib.Core.Computability.SyntacticMonoid`.
+-/
+
+noncomputable section
+
+universe u v
+
+namespace DFA
+
+variable {α : Type u} {σ : Type v} (M : DFA α σ)
+
+/-- The transition action of words on the states of `M`, packaged as a monoid hom into the opposite
+of `Function.End σ`. A word `w` sends the state `s` to `M.evalFrom s w`. The action is on the
+*right* (reading `u` then `v`), hence the `ᵐᵒᵖ`. -/
+def transitionHom : FreeMonoid α →* (Function.End σ)ᵐᵒᵖ where
+  toFun w := MulOpposite.op fun s => M.evalFrom s w.toList
+  map_one' := by
+    refine congrArg MulOpposite.op (funext fun s => ?_)
+    rw [FreeMonoid.toList_one, M.evalFrom_nil]
+    rfl
+  map_mul' u v := by
+    apply MulOpposite.unop_injective
+    funext s
+    show M.evalFrom s (u * v).toList = M.evalFrom (M.evalFrom s u.toList) v.toList
+    rw [FreeMonoid.toList_mul, M.evalFrom_of_append]
+
+@[simp]
+theorem unop_transitionHom_apply (w : FreeMonoid α) (s : σ) :
+    (M.transitionHom w).unop s = M.evalFrom s w.toList := rfl
+
+/-- Two words induce the same transition iff they are indistinguishable by `evalFrom` from every
+state. -/
+theorem transitionHom_eq_iff {u v : FreeMonoid α} :
+    M.transitionHom u = M.transitionHom v ↔
+      ∀ s : σ, M.evalFrom s u.toList = M.evalFrom s v.toList := by
+  rw [← MulOpposite.unop_inj]
+  exact funext_iff
+
+/-- The transition monoid of `M`: the submonoid of `(Function.End σ)ᵐᵒᵖ` of all
+state-transformations induced by words. -/
+def transitionMonoid : Submonoid (Function.End σ)ᵐᵒᵖ := MonoidHom.mrange M.transitionHom
+
+/-- The first isomorphism theorem: the transition monoid is the quotient of the free monoid by the
+kernel of the transition action. -/
+def transitionMonoidEquiv : (Con.ker M.transitionHom).Quotient ≃* M.transitionMonoid :=
+  Con.quotientKerEquivRange _
+
+/-- `Function.End σ` is finite when `σ` is. This does **not** synthesize automatically (the
+definitional unfolding of `Function.End` is not reducible enough for the instance search), so we
+register it here. -/
+instance Function.End.instFinite [Finite σ] : Finite (Function.End σ) :=
+  Finite.of_equiv (σ → σ) (Equiv.refl _)
+
+/-- `(Function.End σ)ᵐᵒᵖ` is finite when `σ` is. Like `Function.End.instFinite`, this does not
+synthesize automatically, so we register it for the transition-monoid finiteness instance. -/
+instance instFiniteEndMop [Finite σ] : Finite (Function.End σ)ᵐᵒᵖ :=
+  Finite.of_equiv (Function.End σ) MulOpposite.opEquiv
+
+instance transitionMonoid.instFinite [Finite σ] : Finite (transitionMonoid M) :=
+  inferInstanceAs (Finite (MonoidHom.mrange M.transitionHom))
+
+end DFA
+
+end


### PR DESCRIPTION
Rebuilds the syntactic monoid on a new, general, reusable **transition-monoid** layer, replacing the hand-built Myhill injection. The transition monoid of an automaton is foundational algebraic automata theory (it's the object behind the syntactic monoid, Schützenberger's theorem, Eilenberg variety theory) and is currently absent from mathlib — `Language.toDFA` (the minimal DFA) already exists, so the only gap was the transition monoid itself.

## New `Core/Computability/TransitionMonoid.lean` (general `DFA`, upstream-shaped)

- `DFA.transitionHom : FreeMonoid α →* (Function.End σ)ᵐᵒᵖ` — words acting on states via `evalFrom`. The action is on the *right* (`evalFrom_of_append` composes left-to-right), hence an anti-homomorphism, hence the `ᵐᵒᵖ` target.
- `DFA.transitionMonoid := transitionHom.mrange` (a `Submonoid (Function.End σ)ᵐᵒᵖ`), and `transitionMonoidEquiv` — the first isomorphism theorem `(Con.ker transitionHom).Quotient ≃* transitionMonoid`.
- `Finite (Function.End σ)`, `(…)ᵐᵒᵖ`, and `transitionMonoid` instances — these do **not** auto-synthesize from `Finite σ` (semireducible `def`s), so they're registered once here.

## `SyntacticMonoid.lean` — now a consumer

- `syntacticCon L := Con.ker L.toDFA.transitionHom`, identified with the two-sided context equivalence via the keystone `syntacticCon_iff` (through a new `evalFrom_toDFA`).
- The `SyntacticEquiv` relation API is preserved (`refl`/`symm`/`trans`/`append`/`append_left`/`leftQuotient_eq`/`mem_iff`).
- **Myhill–Nerode** (`isRegular_iff_finite_syntacticMonoid`) now falls out of `transitionMonoidEquiv` + finiteness of the minimal-DFA state set, instead of an inlined function-space injection.

## Consumers

`Algebra/Equations.lean` (6 sites) and `Algebra/Pin.lean` (2 sites) bridge through `syntacticCon_iff` exactly where they previously relied on `syntacticCon` and `SyntacticEquiv` being definitionally equal (after `Quotient.exact`/`Quotient.sound`). No other consumer changes.

## Also folded in

A syntactic-monoid quality pass: one-line docstrings (no bold), `SyntacticEquiv.mem_iff` as dot-notation, `syntacticMonoid` as `def` + explicit `Monoid` instance, inline `(L : Language α)` binders.

## Notes

- Affected set builds green; new lemmas + the Myhill theorem are axiom-clean (`propext`/`Classical.choice`/`Quot.sound`).
- The `Function.End`/`ᵐᵒᵖ` `Finite` instances are currently nested under `namespace DFA`; if `DFA.transitionMonoid` is upstreamed to mathlib they'd move to root-namespace homes. `evalFrom_toDFA` is likewise a natural addition to mathlib's `MyhillNerode.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)