### PR TITLE
refactor(Core/Computability/TransitionMonoid): golf transitionHom + terser docstrings

### DIFF
--- a/Linglib/Core/Computability/TransitionMonoid.lean
+++ b/Linglib/Core/Computability/TransitionMonoid.lean
@@ -15,24 +15,20 @@ import Mathlib.GroupTheory.Congruence.Hom
 /-!
 # The transition monoid of a DFA
 
-The **transition monoid** of an automaton is the monoid of state-transformations induced by input
-words. It is foundational algebraic automata theory (syntactic monoid, Schützenberger's theorem,
-Eilenberg variety theory) and is currently **absent from mathlib**. This file prototypes it.
+The *transition monoid* of an automaton is the monoid of state-transformations induced by input
+words — foundational algebraic automata theory (syntactic monoid, Schützenberger's theorem,
+Eilenberg variety theory), currently absent from mathlib.
 
-A word `w` acts on a state `s` of `M : DFA α σ` by `s ↦ M.evalFrom s w`. Because reading `u` then
-`v` is `evalFrom_of_append`, this is a *right* action: `act (u * v) = act v ∘ act u`, i.e. an
-*anti*-homomorphism into `Function.End σ`. Packaged as a genuine `MonoidHom`, the target is the
-opposite monoid `(Function.End σ)ᵐᵒᵖ`.
+A word `w` acts on a state `s` of `M : DFA α σ` by `s ↦ M.evalFrom s w`. Reading `u` then `v`
+(`evalFrom_of_append`) makes this a *right* action — an anti-homomorphism into `Function.End σ` — so
+as a `MonoidHom` its target is the opposite monoid `(Function.End σ)ᵐᵒᵖ`.
 
 * `DFA.transitionHom M : FreeMonoid α →* (Function.End σ)ᵐᵒᵖ` — the transition action.
 * `DFA.transitionMonoid M : Submonoid (Function.End σ)ᵐᵒᵖ` — its range, the transition monoid.
 * `DFA.transitionMonoidEquiv M` — the first iso theorem: `(Con.ker M.transitionHom).Quotient ≃*`
   the transition monoid.
-* `Finite (Function.End σ)` / `Finite M.transitionMonoid` instances (these do **not**
-  auto-synthesize from `Finite σ`, so we register them here once).
-
-The syntactic monoid of a `Language α` is built as a consumer of this layer in
-`Linglib.Core.Computability.SyntacticMonoid`.
+* `Finite (Function.End σ)` / `Finite M.transitionMonoid` instances (these do not auto-synthesize
+  from `Finite σ`, so we register them here once).
 -/
 
 noncomputable section
@@ -43,50 +39,33 @@ namespace DFA
 
 variable {α : Type u} {σ : Type v} (M : DFA α σ)
 
-/-- The transition action of words on the states of `M`, packaged as a monoid hom into the opposite
-of `Function.End σ`. A word `w` sends the state `s` to `M.evalFrom s w`. The action is on the
-*right* (reading `u` then `v`), hence the `ᵐᵒᵖ`. -/
+/-- The transition action of `M`: word `w` sends state `s` to `M.evalFrom s w`. -/
 def transitionHom : FreeMonoid α →* (Function.End σ)ᵐᵒᵖ where
   toFun w := MulOpposite.op fun s => M.evalFrom s w.toList
-  map_one' := by
-    refine congrArg MulOpposite.op (funext fun s => ?_)
-    rw [FreeMonoid.toList_one, M.evalFrom_nil]
-    rfl
-  map_mul' u v := by
-    apply MulOpposite.unop_injective
-    funext s
-    show M.evalFrom s (u * v).toList = M.evalFrom (M.evalFrom s u.toList) v.toList
-    rw [FreeMonoid.toList_mul, M.evalFrom_of_append]
+  map_one' := rfl
+  map_mul' u v := MulOpposite.unop_injective <| funext fun s => M.evalFrom_of_append s u.toList v.toList
 
 @[simp]
 theorem unop_transitionHom_apply (w : FreeMonoid α) (s : σ) :
     (M.transitionHom w).unop s = M.evalFrom s w.toList := rfl
 
-/-- Two words induce the same transition iff they are indistinguishable by `evalFrom` from every
-state. -/
-theorem transitionHom_eq_iff {u v : FreeMonoid α} :
-    M.transitionHom u = M.transitionHom v ↔
-      ∀ s : σ, M.evalFrom s u.toList = M.evalFrom s v.toList := by
-  rw [← MulOpposite.unop_inj]
-  exact funext_iff
+/-- Two words induce the same transition iff `evalFrom` agrees from every state. -/
+theorem transitionHom_eq_iff {u v : FreeMonoid α} : M.transitionHom u = M.transitionHom v ↔
+    ∀ s : σ, M.evalFrom s u.toList = M.evalFrom s v.toList :=
+  MulOpposite.unop_inj.symm.trans funext_iff
 
-/-- The transition monoid of `M`: the submonoid of `(Function.End σ)ᵐᵒᵖ` of all
-state-transformations induced by words. -/
+/-- The transition monoid of `M`: the range of its transition action. -/
 def transitionMonoid : Submonoid (Function.End σ)ᵐᵒᵖ := MonoidHom.mrange M.transitionHom
 
-/-- The first isomorphism theorem: the transition monoid is the quotient of the free monoid by the
-kernel of the transition action. -/
+/-- First isomorphism theorem: the transition monoid as a quotient of `FreeMonoid α`. -/
 def transitionMonoidEquiv : (Con.ker M.transitionHom).Quotient ≃* M.transitionMonoid :=
   Con.quotientKerEquivRange _
 
-/-- `Function.End σ` is finite when `σ` is. This does **not** synthesize automatically (the
-definitional unfolding of `Function.End` is not reducible enough for the instance search), so we
-register it here. -/
+/-- `Function.End σ` is finite when `σ` is (not found automatically through the `def`). -/
 instance Function.End.instFinite [Finite σ] : Finite (Function.End σ) :=
   Finite.of_equiv (σ → σ) (Equiv.refl _)
 
-/-- `(Function.End σ)ᵐᵒᵖ` is finite when `σ` is. Like `Function.End.instFinite`, this does not
-synthesize automatically, so we register it for the transition-monoid finiteness instance. -/
+/-- `(Function.End σ)ᵐᵒᵖ` is finite when `σ` is (likewise not found automatically). -/
 instance instFiniteEndMop [Finite σ] : Finite (Function.End σ)ᵐᵒᵖ :=
   Finite.of_equiv (Function.End σ) MulOpposite.opEquiv
 


### PR DESCRIPTION
Follow-up polish to #648 (which auto-merged on its first commit, before these refinements landed). Touches only `TransitionMonoid.lean`; no statement or signature changes.

- `transitionHom.map_one'` → `rfl`; `map_mul'` → a one-line term over `evalFrom_of_append`. The `toList_one`/`toList_mul`/`evalFrom_nil` rewrites in the original only bridged definitional equalities.
- `transitionHom_eq_iff` → the term `MulOpposite.unop_inj.symm.trans funext_iff` (was a 2-tactic block).
- Module doc streamlined (dropped the consumer pointer, de-bolded); all declaration docstrings reduced to one-liners.

Net −21 lines. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)