### PR TITLE
refactor(Core/Computability/SyntacticMonoid): lift L to the variable block + eliminate SyntacticEquiv

### DIFF
--- a/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
@@ -80,7 +80,7 @@ The letter-sequence monoid form makes this explicit.)
 * `Language.IsDefinite.satisfies_kDefiniteEquation` — **forward
   direction**: a `k`-definite language's syntactic monoid satisfies
   the equation. Proof: extract a `FreeMonoid α` representative `w` of
-  `s`; the equation reduces to `SyntacticEquiv L (w ++ αs) αs`, which
+  `s`; the equation reduces to `L.syntacticCon (w ++ αs) αs`, which
   follows from `takeAt_right_append_left_absorb` (since `|αs| = k`,
   the length-`k` suffix of `x ++ w ++ αs ++ y` already discards `w`).
 
@@ -90,7 +90,7 @@ The letter-sequence monoid form makes this explicit.)
   inclusion `L ⊆ G.lang` holds with witness `w' = w`. The reverse
   inclusion `G.lang ⊆ L` is by case analysis on word length: short
   words equal their own suffix (forcing equality); long words decompose
-  as `prefix ++ ks` and the equation gives `SyntacticEquiv L w ks`,
+  as `prefix ++ ks` and the equation gives `L.syntacticCon w ks`,
   then `L`-saturation closes the case.
 
 * `Language.isDefinite_iff_satisfies_kDefiniteEquation` — Lambert
@@ -149,30 +149,24 @@ lemma takeAt_right_append_left_absorb {α : Type*}
   List.rtake_append_of_le_length x rest h
 
 -- ============================================================================
--- §2. Lifting the equation to `SyntacticEquiv`
+-- §2. Lifting the equation to a syntactic-class equality
 -- ============================================================================
 
 /-- Under the `k`-definite equation, prepending any prefix to a
-length-`k` word gives a syntactically equivalent word.
+length-`k` word preserves its syntactic class.
 
 This is the algebraic heart of the reverse direction: applying the
 equation at `s = [w]` and unfolding
 `L.toSyntacticMonoid (w * αs) = L.toSyntacticMonoid w *
 L.toSyntacticMonoid αs` gives the syntactic-monoid equality
-`[w * αs] = [αs]`, which lifts via `Quotient.exact` to the two-sided
-syntactic equivalence on the underlying lists. -/
-lemma syntacticEquiv_of_kDefiniteEquation {L : Language α} {k : ℕ}
+`[w * αs] = [αs]`. -/
+lemma syntacticCon_of_kDefiniteEquation {L : Language α} {k : ℕ}
     (h : Language.kDefiniteEquation L k)
     (w αs : List α) (hαs_len : αs.length = k) :
-    SyntacticEquiv L (w ++ αs) αs := by
-  have h_eq :=
-    h (L.toSyntacticMonoid (FreeMonoid.ofList w)) αs hαs_len
-  have h_pre :
-      L.toSyntacticMonoid (FreeMonoid.ofList (w ++ αs)) =
-      L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
-    rw [FreeMonoid.ofList_append, MonoidHom.map_mul]
-    exact h_eq
-  exact (syntacticCon_iff L).mp (Quotient.exact h_pre)
+    L.toSyntacticMonoid (FreeMonoid.ofList (w ++ αs)) =
+    L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
+  rw [FreeMonoid.ofList_append, MonoidHom.map_mul]
+  exact h (L.toSyntacticMonoid (FreeMonoid.ofList w)) αs hαs_len
 
 -- ============================================================================
 -- §3. Lambert Prop 53 — both directions
@@ -221,12 +215,13 @@ interesting direction `G.lang ⊆ L`: if `w ∈ G.lang`, there is some
    `u`, `w` themselves; equality forces `w = u ∈ L`.
 2. `u.length ≤ k`, `w.length > k`: the suffix-length match forces
    `u.length = k`, so `u` is the length-`k` right-suffix of `w`. Apply
-   the equation to get `SyntacticEquiv L w u`; saturation closes.
+   the equation to get `[w] = [u]` in the syntactic monoid; saturation
+   closes.
 3. `u.length > k`, `w.length ≤ k`: symmetric to (2).
 4. Both `u.length > k`, `w.length > k`: both decompose as
    `prefix ++ ks` for the shared length-`k` suffix `ks`. Apply
-   equation to both, getting `SyntacticEquiv L w ks` and
-   `SyntacticEquiv L u ks`; chain transitively, then saturation. -/
+   equation to both, getting `[w] = [ks]` and `[u] = [ks]`; chain by
+   transitivity, then saturation. -/
 theorem isDefinite_of_satisfies_kDefiniteEquation
     {L : Language α} {k : ℕ}
     (h : Language.kDefiniteEquation L k) :
@@ -240,13 +235,14 @@ theorem isDefinite_of_satisfies_kDefiniteEquation
     · push_neg at hw
       have hlen : (Edge.right.takeAt k w).length = k := by
         rw [Edge.takeAt_right, List.length_rtake]; omega
-      have hequiv : SyntacticEquiv L w (Edge.right.takeAt k w) := by
-        have base := syntacticEquiv_of_kDefiniteEquation h
+      have hcon : L.toSyntacticMonoid (FreeMonoid.ofList w) =
+          L.toSyntacticMonoid (FreeMonoid.ofList (Edge.right.takeAt k w)) := by
+        have base := syntacticCon_of_kDefiniteEquation h
           (w.take (w.length - k)) (Edge.right.takeAt k w) hlen
         have decomp : w = w.take (w.length - k) ++ Edge.right.takeAt k w :=
           (List.rdrop_append_rtake w k).symm
         rwa [← decomp] at base
-      exact hequiv.mem_iff
+      exact mem_iff_of_syntacticCon (Quotient.exact hcon)
   exact fun a b hab => by simp only [key a, key b, hab]
 
 /-- **Lambert (2026) Prop 53**: a language is `k`-definite iff its
@@ -305,23 +301,18 @@ private lemma decompose_at_left_takeAt {α : Type*} {k : ℕ} {xs : List α}
   show xs = xs.take k ++ xs.drop k
   exact (List.take_append_drop _ _).symm
 
--- §4.2. Lifting the K equation to `SyntacticEquiv`
+-- §4.2. Lifting the K equation to a syntactic-class equality
 
 /-- Under the reverse-`k`-definite equation, **appending** any suffix to
-a length-`k` word gives a syntactically equivalent word. Mirror of
-`syntacticEquiv_of_kDefiniteEquation`. -/
-lemma syntacticEquiv_of_kReverseDefiniteEquation {L : Language α} {k : ℕ}
+a length-`k` word preserves its syntactic class. Mirror of
+`syntacticCon_of_kDefiniteEquation`. -/
+lemma syntacticCon_of_kReverseDefiniteEquation {L : Language α} {k : ℕ}
     (h : Language.kReverseDefiniteEquation L k)
     (αs w : List α) (hαs_len : αs.length = k) :
-    SyntacticEquiv L (αs ++ w) αs := by
-  have h_eq :=
-    h (L.toSyntacticMonoid (FreeMonoid.ofList w)) αs hαs_len
-  have h_pre :
-      L.toSyntacticMonoid (FreeMonoid.ofList (αs ++ w)) =
-      L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
-    rw [FreeMonoid.ofList_append, MonoidHom.map_mul]
-    exact h_eq
-  exact (syntacticCon_iff L).mp (Quotient.exact h_pre)
+    L.toSyntacticMonoid (FreeMonoid.ofList (αs ++ w)) =
+    L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
+  rw [FreeMonoid.ofList_append, MonoidHom.map_mul]
+  exact h (L.toSyntacticMonoid (FreeMonoid.ofList w)) αs hαs_len
 
 -- §4.3. Lambert Prop 57 — both directions
 
@@ -366,11 +357,12 @@ theorem isReverseDefinite_of_satisfies_kReverseDefiniteEquation
     · push_neg at hw
       have hlen : (Edge.left.takeAt k w).length = k :=
         takeAt_left_length_of_long (le_of_lt hw)
-      have hequiv : SyntacticEquiv L w (Edge.left.takeAt k w) := by
-        have base := syntacticEquiv_of_kReverseDefiniteEquation h
+      have hcon : L.toSyntacticMonoid (FreeMonoid.ofList w) =
+          L.toSyntacticMonoid (FreeMonoid.ofList (Edge.left.takeAt k w)) := by
+        have base := syntacticCon_of_kReverseDefiniteEquation h
           (Edge.left.takeAt k w) (w.drop k) hlen
         rwa [← decompose_at_left_takeAt (le_of_lt hw)] at base
-      exact hequiv.mem_iff
+      exact mem_iff_of_syntacticCon (Quotient.exact hcon)
   exact fun a b hab => by simp only [key a, key b, hab]
 
 /-- **Lambert (2026) Prop 57**: a language is reverse-`k`-definite iff
@@ -404,24 +396,19 @@ def kGeneralizedDefiniteEquation (L : Language α) (k : ℕ) : Prop :=
     L.toSyntacticMonoid (FreeMonoid.ofList αs)
 
 
--- §5.1. Lifting LI equation to `SyntacticEquiv`
+-- §5.1. Lifting LI equation to a syntactic-class equality
 
 /-- Under the LI equation, sandwiching any word `w` between two copies
-of a length-`k` word `αs` is syntactically equivalent to `αs` alone. -/
-lemma syntacticEquiv_of_kGeneralizedDefiniteEquation
+of a length-`k` word `αs` preserves the syntactic class of `αs`. -/
+lemma syntacticCon_of_kGeneralizedDefiniteEquation
     {L : Language α} {k : ℕ}
     (h : Language.kGeneralizedDefiniteEquation L k)
     (αs w : List α) (hαs_len : αs.length = k) :
-    SyntacticEquiv L (αs ++ w ++ αs) αs := by
-  have h_eq :=
-    h (L.toSyntacticMonoid (FreeMonoid.ofList w)) αs hαs_len
-  have h_pre :
-      L.toSyntacticMonoid (FreeMonoid.ofList (αs ++ w ++ αs)) =
-      L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
-    rw [FreeMonoid.ofList_append, FreeMonoid.ofList_append, MonoidHom.map_mul,
-        MonoidHom.map_mul]
-    exact h_eq
-  exact (syntacticCon_iff L).mp (Quotient.exact h_pre)
+    L.toSyntacticMonoid (FreeMonoid.ofList (αs ++ w ++ αs)) =
+    L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
+  rw [FreeMonoid.ofList_append, FreeMonoid.ofList_append, MonoidHom.map_mul,
+      MonoidHom.map_mul]
+  exact h (L.toSyntacticMonoid (FreeMonoid.ofList w)) αs hαs_len
 
 -- §5.2. Lambert Prop 58 — forward direction
 
@@ -548,27 +535,28 @@ theorem isGeneralizedDefinite_of_satisfies_kGeneralizedDefiniteEquation
       have h_w₂_drop : w₂.drop (w₂.length - k) = βs := this
       show w₂ = w₂.take (w₂.length - k) ++ βs
       rw [← h_w₂_drop]; exact (List.take_append_drop _ _).symm
-    -- Way 1: αs-sandwich gives `(w₁ ++ w₂) ≡_L w₂`.
-    have h_αs_eq : SyntacticEquiv L (w₁ ++ w₂) w₂ := by
-      rw [hw₁_αs, hw₂_αs]
-      intro x y
-      -- Apply (αs ++ b₁ ++ αs) ≡_L αs at context (x, b₂ ++ y).
-      have h_inner := syntacticEquiv_of_kGeneralizedDefiniteEquation
-        h αs b₁ hαs_len x (b₂ ++ y)
-      simp only [List.append_assoc] at h_inner ⊢
-      exact h_inner
-    -- Way 2: βs-sandwich gives `(w₁ ++ w₂) ≡_L w₁`.
-    have h_βs_eq : SyntacticEquiv L (w₁ ++ w₂) w₁ := by
-      rw [hw₁_βs, hw₂_βs]
-      intro x y
-      -- Apply (βs ++ c₂ ++ βs) ≡_L βs at context (x ++ c₁, y).
-      have h_inner := syntacticEquiv_of_kGeneralizedDefiniteEquation
-        h βs c₂ hβs_len (x ++ c₁) y
-      simp only [List.append_assoc] at h_inner ⊢
-      exact h_inner
-    -- Combine: w₁ ≡_L w₂.
-    have hequiv : SyntacticEquiv L w₁ w₂ := h_βs_eq.symm.trans h_αs_eq
-    exact hequiv.mem_iff
+    -- Way 1: αs-sandwich gives `[w₁ ++ w₂] = [w₂]`, by absorbing
+    -- the `αs ++ b₁ ++ αs` block into `αs`.
+    have h_αs_eq : L.toSyntacticMonoid (FreeMonoid.ofList (w₁ ++ w₂)) =
+        L.toSyntacticMonoid (FreeMonoid.ofList w₂) := by
+      conv_lhs => rw [hw₁_αs, hw₂_αs,
+        show (αs ++ b₁) ++ (αs ++ b₂) = (αs ++ b₁ ++ αs) ++ b₂ by
+          simp [List.append_assoc]]
+      rw [FreeMonoid.ofList_append, MonoidHom.map_mul,
+        syntacticCon_of_kGeneralizedDefiniteEquation h αs b₁ hαs_len,
+        ← MonoidHom.map_mul, ← FreeMonoid.ofList_append, ← hw₂_αs]
+    -- Way 2: βs-sandwich gives `[w₁ ++ w₂] = [w₁]`, by absorbing
+    -- the `βs ++ c₂ ++ βs` block into `βs`.
+    have h_βs_eq : L.toSyntacticMonoid (FreeMonoid.ofList (w₁ ++ w₂)) =
+        L.toSyntacticMonoid (FreeMonoid.ofList w₁) := by
+      conv_lhs => rw [hw₁_βs, hw₂_βs,
+        show (c₁ ++ βs) ++ (c₂ ++ βs) = c₁ ++ (βs ++ c₂ ++ βs) by
+          simp [List.append_assoc]]
+      rw [FreeMonoid.ofList_append, MonoidHom.map_mul,
+        syntacticCon_of_kGeneralizedDefiniteEquation h βs c₂ hβs_len,
+        ← MonoidHom.map_mul, ← FreeMonoid.ofList_append, ← hw₁_βs]
+    -- Combine: `[w₁] = [w₂]`, hence `w₁ ≡_L w₂`.
+    exact mem_iff_of_syntacticCon (Quotient.exact (h_βs_eq.symm.trans h_αs_eq))
   · -- Short case: `|w₁| < k`. Then `Edge.left.takeAt k w₁ = w₁`, so
     -- the prefix equality yields `w₁ = Edge.left.takeAt k w₂`, which
     -- forces `|w₂| ≤ k` (otherwise the takeAt has length `k > |w₁|`).

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -46,33 +46,23 @@ universe u
 
 namespace Language
 
-variable {α : Type u} {L : Language α}
-
-/-- Evaluating the minimal DFA `L.toDFA` from a quotient state `s` along a word `w` lands on the
-left quotient of `s` by `w`. -/
-@[simp]
-theorem evalFrom_toDFA (L : Language α) (s : Set.range L.leftQuotient) (w : List α) :
-    (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
-  induction w using List.reverseRecOn with
-  | nil => simp
-  | append_singleton x a ih =>
-    rw [DFA.evalFrom_append_singleton, step_toDFA, ih, ← leftQuotient_append]
+variable {α : Type u} (L : Language α)
 
 /-! ### The syntactic congruence and monoid -/
 
 /-- The *syntactic congruence* of `L`, obtained as the kernel of the transition action of `L.toDFA`
 (the transition monoid of the minimal DFA). -/
-def syntacticCon (L : Language α) : Con (FreeMonoid α) := Con.ker L.toDFA.transitionHom
+def syntacticCon : Con (FreeMonoid α) := Con.ker L.toDFA.transitionHom
 
 /-! ### Syntactic equivalence on words -/
 
 /-- `u` and `v` are *syntactically equivalent* in `L`: no two-sided context distinguishes them. -/
-def SyntacticEquiv (L : Language α) (u v : List α) : Prop :=
+def SyntacticEquiv (u v : List α) : Prop :=
   ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
 
 namespace SyntacticEquiv
 
-variable {u v w : List α}
+variable {L} {u v w : List α}
 
 @[refl] protected theorem refl (u : List α) : SyntacticEquiv L u u := fun _ _ => Iff.rfl
 
@@ -103,9 +93,19 @@ theorem mem_iff (h : SyntacticEquiv L u v) : u ∈ L ↔ v ∈ L := by simpa usi
 
 end SyntacticEquiv
 
+/-- Evaluating the minimal DFA `L.toDFA` from a quotient state `s` along a word `w` lands on the
+left quotient of `s` by `w`. -/
+@[simp]
+theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
+    (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
+  induction w using List.reverseRecOn with
+  | nil => simp
+  | append_singleton x a ih =>
+    rw [DFA.evalFrom_append_singleton, step_toDFA, ih, ← leftQuotient_append]
+
 /-- The kernel of the transition monoid of the minimal DFA is exactly the two-sided syntactic
 congruence: `u` and `v` are congruent iff they are interchangeable in every two-sided context. -/
-theorem syntacticCon_iff (L : Language α) {u v : FreeMonoid α} :
+theorem syntacticCon_iff {u v : FreeMonoid α} :
     L.syntacticCon u v ↔ SyntacticEquiv L u v := by
   rw [syntacticCon, Con.ker_apply, DFA.transitionHom_eq_iff]
   -- `SyntacticEquiv L u v` is defeq to `∀ x y, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L`
@@ -125,14 +125,16 @@ theorem syntacticCon_iff (L : Language α) {u v : FreeMonoid α} :
     exact h x y
 
 /-- The *syntactic monoid* of `L`: the quotient of `FreeMonoid α` by the syntactic congruence. -/
-def syntacticMonoid (L : Language α) : Type u := (syntacticCon L).Quotient
+def syntacticMonoid : Type u := (syntacticCon L).Quotient
 
 instance : Monoid (syntacticMonoid L) := inferInstanceAs (Monoid (syntacticCon L).Quotient)
 
 /-- The canonical projection sending each word to its syntactic class; the underlying `Con.mk'`. -/
-def toSyntacticMonoid (L : Language α) : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L).mk'
+def toSyntacticMonoid : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L).mk'
 
 /-! ### Universal property -/
+
+variable {L}
 
 /-- `φ` *recognises* `L` when `L` is a union of `φ`-fibres, i.e. `L = φ ⁻¹' S` for some `S ⊆ M`. -/
 def Recognises {M : Type*} [Monoid M] (φ : FreeMonoid α →* M) (L : Language α) : Prop :=

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -25,7 +25,6 @@ equivalence via `Language.syntacticCon_iff`. This is the two-sided refinement of
 
 * `Language.syntacticCon L : Con (FreeMonoid α)`: the syntactic congruence, the kernel of the
   transition action of `L.toDFA`.
-* `Language.SyntacticEquiv L u v`: the two-sided context equivalence on words.
 * `Language.syntacticMonoid L`: the quotient monoid `(syntacticCon L).Quotient`.
 * `Language.toSyntacticMonoid L`: the projection `FreeMonoid α →* L.syntacticMonoid`.
 * `Language.Recognises φ L`: `φ` recognises `L`, i.e. `L` is a union of `φ`-fibres.
@@ -33,8 +32,8 @@ equivalence via `Language.syntacticCon_iff`. This is the two-sided refinement of
 ## Main results
 
 * `Language.syntacticCon_iff`: the syntactic congruence is exactly the two-sided context
-  equivalence.
-* `Language.SyntacticEquiv.mem_iff`: `L` is saturated by syntactic equivalence.
+  equivalence `∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L`.
+* `Language.mem_iff_of_syntacticCon`: `L` is saturated by the syntactic congruence.
 * `Language.ker_le_syntacticCon_of_recognises`: the syntactic congruence is the coarsest congruence
   recognising `L`, so every recognising hom factors through `toSyntacticMonoid` via `Con.lift`.
 * `Language.isRegular_iff_finite_syntacticMonoid`: the Myhill–Nerode theorem in monoid form.
@@ -54,63 +53,19 @@ variable {α : Type u} (L : Language α)
 (the transition monoid of the minimal DFA). -/
 def syntacticCon : Con (FreeMonoid α) := Con.ker L.toDFA.transitionHom
 
-/-! ### Syntactic equivalence on words -/
-
-/-- `u` and `v` are *syntactically equivalent* in `L`: no two-sided context distinguishes them. -/
-def SyntacticEquiv (u v : List α) : Prop :=
-  ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
-
-namespace SyntacticEquiv
-
-variable {L} {u v w : List α}
-
-@[refl] protected theorem refl (u : List α) : SyntacticEquiv L u u := fun _ _ => Iff.rfl
-
-@[symm] protected theorem symm (h : SyntacticEquiv L u v) : SyntacticEquiv L v u :=
-  fun x y => (h x y).symm
-
-@[trans] protected theorem trans (h₁ : SyntacticEquiv L u v) (h₂ : SyntacticEquiv L v w) :
-    SyntacticEquiv L u w := fun x y => (h₁ x y).trans (h₂ x y)
-
-/-- Syntactic equivalence is a two-sided congruence for concatenation. -/
-protected theorem append {u₁ u₂ v₁ v₂ : List α} (h₁ : SyntacticEquiv L u₁ v₁)
-    (h₂ : SyntacticEquiv L u₂ v₂) : SyntacticEquiv L (u₁ ++ u₂) (v₁ ++ v₂) := fun x y => by
-  have e₁ := h₁ x (u₂ ++ y)
-  have e₂ := h₂ (x ++ v₁) y
-  simp only [List.append_assoc] at e₁ e₂ ⊢
-  exact e₁.trans e₂
-
-/-- Left concatenation by a fixed word preserves syntactic equivalence. -/
-protected theorem append_left (w : List α) (h : SyntacticEquiv L u v) :
-    SyntacticEquiv L (w ++ u) (w ++ v) := (SyntacticEquiv.refl w).append h
-
-/-- Equivalent words have the same `leftQuotient`: the two-sided test specialised to `x = []`. -/
-theorem leftQuotient_eq (h : SyntacticEquiv L u v) : L.leftQuotient u = L.leftQuotient v := by
-  ext y; simpa using h [] y
-
-/-- Syntactically equivalent words agree on membership of `L`. -/
-theorem mem_iff (h : SyntacticEquiv L u v) : u ∈ L ↔ v ∈ L := by simpa using h [] []
-
-end SyntacticEquiv
-
 /-- Evaluating the minimal DFA `L.toDFA` from a quotient state `s` along a word `w` lands on the
 left quotient of `s` by `w`. -/
 @[simp]
 theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
     (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
-  induction w using List.reverseRecOn with
-  | nil => simp
-  | append_singleton x a ih =>
-    rw [DFA.evalFrom_append_singleton, step_toDFA, ih, ← leftQuotient_append]
+  induction w using List.reverseRecOn <;>
+    simp_all [DFA.evalFrom_append_singleton, step_toDFA, leftQuotient_append]
 
-/-- The kernel of the transition monoid of the minimal DFA is exactly the two-sided syntactic
-congruence: `u` and `v` are congruent iff they are interchangeable in every two-sided context. -/
+/-- The kernel of the transition monoid of the minimal DFA is exactly the two-sided context
+equivalence: `u` and `v` are congruent iff they are interchangeable in every two-sided context. -/
 theorem syntacticCon_iff {u v : FreeMonoid α} :
-    L.syntacticCon u v ↔ SyntacticEquiv L u v := by
+    L.syntacticCon u v ↔ ∀ x y : List α, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L := by
   rw [syntacticCon, Con.ker_apply, DFA.transitionHom_eq_iff]
-  -- `SyntacticEquiv L u v` is defeq to `∀ x y, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L`
-  -- (since `u.toList = u` for `FreeMonoid`); make the `.toList` form explicit for `mem_leftQuotient`.
-  show _ ↔ ∀ x y : List α, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L
   constructor
   · intro h x y
     have h' := congrArg Subtype.val (h ⟨L.leftQuotient x, ⟨x, rfl⟩⟩)
@@ -123,6 +78,14 @@ theorem syntacticCon_iff {u v : FreeMonoid α} :
     ext y
     rw [mem_leftQuotient, mem_leftQuotient]
     exact h x y
+
+variable {L} in
+/-- Words congruent under the syntactic congruence agree on membership of `L`: `L` is saturated by
+`syntacticCon L` (take the empty two-sided context). -/
+theorem mem_iff_of_syntacticCon {u v : FreeMonoid α} (h : L.syntacticCon u v) : u ∈ L ↔ v ∈ L := by
+  have := (syntacticCon_iff L).mp h [] []
+  simp only [List.nil_append, List.append_nil] at this
+  exact this
 
 /-- The *syntactic monoid* of `L`: the quotient of `FreeMonoid α` by the syntactic congruence. -/
 def syntacticMonoid : Type u := (syntacticCon L).Quotient
@@ -144,7 +107,7 @@ def Recognises {M : Type*} [Monoid M] (φ : FreeMonoid α →* M) (L : Language 
 theorem ker_le_syntacticCon_of_recognises {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
     (hrec : Recognises φ L) : Con.ker φ ≤ syntacticCon L := by
   intro u v huv
-  rw [show syntacticCon L u v ↔ SyntacticEquiv L u v from syntacticCon_iff L]
+  rw [syntacticCon_iff]
   obtain ⟨S, rfl⟩ := hrec
   change ∀ x y : FreeMonoid α, x * u * y ∈ φ ⁻¹' S ↔ x * v * y ∈ φ ⁻¹' S
   intro x y
@@ -169,12 +132,10 @@ theorem isRegular_of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.I
     intro u v huv
     rw [syntacticCon_iff] at huv
     ext y; rw [mem_leftQuotient, mem_leftQuotient]; exact huv [] y
-  set g : L.syntacticMonoid → Language α :=
-    Quot.lift (fun w => L.leftQuotient w.toList) (fun u v huv => factor u v huv) with hg
-  have hrange : Set.range L.leftQuotient ⊆ Set.range g := by
-    rintro _ ⟨x, rfl⟩
-    exact ⟨Quot.mk _ (FreeMonoid.ofList x), rfl⟩
-  exact (Set.finite_range g).subset hrange
+  let g : L.syntacticMonoid → Language α := Quot.lift (fun w => L.leftQuotient w.toList) factor
+  refine (Set.finite_range g).subset ?_
+  rintro _ ⟨x, rfl⟩
+  exact ⟨Quot.mk _ (FreeMonoid.ofList x), rfl⟩
 
 /-- Myhill–Nerode (syntactic-monoid form): `L` is regular iff `L.syntacticMonoid` is finite. -/
 theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.syntacticMonoid :=


### PR DESCRIPTION
Post-#648 cleanup of the syntactic-monoid layer (two commits; touches `SyntacticMonoid.lean` and its consumer `Algebra/Equations.lean`). Net −47 lines; affected set builds green; key theorems axiom-clean.

## 1. Lift `L` to the variable block; move `evalFrom_toDFA`
- `(L : Language α)` is now an explicit section variable, with scoped `variable {L}` flips for the lemmas that take it implicitly (`Recognises` keeps its own `(L)` binder, which shadows cleanly). All public signatures are unchanged.
- `evalFrom_toDFA` moves from the top of the file to immediately before its only consumer `syntacticCon_iff` (and is golfed to `induction … <;> simp_all`).

## 2. Eliminate `SyntacticEquiv`
`SyntacticEquiv` was a redundant word-level predicate now that `syntacticCon := Con.ker L.toDFA.transitionHom` carries the equivalence and class-equality structure. Removed (def + `symm`/`trans`/`mem_iff`):

- `syntacticCon_iff` inlines the two-sided context condition directly (no `SyntacticEquiv` name).
- New `mem_iff_of_syntacticCon : syntacticCon L u v → (u ∈ L ↔ v ∈ L)` is the saturation bridge, replacing `SyntacticEquiv.mem_iff`.
- `Algebra/Equations.lean` (Lambert Props 53/57/58) now reasons in syntactic-monoid class equalities (`L.toSyntacticMonoid a = L.toSyntacticMonoid b`, with built-in `Eq.symm`/`.trans`) and crosses to membership only via `mem_iff_of_syntacticCon`; the three lifting lemmas become `syntacticCon_of_kXEquation`. The §5 sandwich chain drops its `SyntacticEquiv.symm.trans` for ordinary `Eq` reasoning.
- `isRegular_of_finite_syntacticMonoid` golfed.

`git grep SyntacticEquiv` is now empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)