### PR TITLE
refactor(Semantics/Conditionals): tidy and dedup selection conditionals

### DIFF
--- a/Linglib/Semantics/Conditionals/Counterfactual.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual.lean
@@ -623,6 +623,7 @@ theorem stalnakerCounterfactual_eq_willConditional_universe
       s A B Set.univ w := by
   unfold stalnakerCounterfactual
     Semantics.Conditionals.WillConditional.willConditional
+    Semantics.Conditionals.WillConditional.restrict
     Semantics.Modality.Selectional.willSem
   rw [Set.univ_inter]
 

--- a/Linglib/Semantics/Conditionals/Counterfactual.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual.lean
@@ -544,12 +544,14 @@ selection function, the supervaluation analysis (`Truth3`) reduces to the
 single-function analysis (`Bool`) under `Truth3.ofBool`. -/
 
 /-- **Stalnaker's single-selection-function counterfactual** [stalnaker-1968].
-    `A □→ B` is true at `w` iff `B` holds at `s(w, ‖A‖)`. This reuses the
-    same `Semantics.Conditionals.SelectionFunction` infrastructure that [cariani-santorio-2018]
-    apply to *will* — the mechanism is identical across the two papers. -/
+    `A □→ B` is true at `w` iff `B` holds at `s(w, ‖A‖)`. The counterfactual
+    reading is the `Semantics.Conditionals.selectionConditional` clause
+    (shared substrate) supplied with a similarity-induced selection function;
+    it is the *same* truth-condition as the indicative
+    `Stalnaker.moodedConditional`, differing only in admissible `s`. -/
 def stalnakerCounterfactual {W : Type*} (s : Semantics.Conditionals.SelectionFunction W)
     (A B : W → Prop) (w : W) : Prop :=
-  B (s.sel w {w' | A w'})
+  Semantics.Conditionals.selectionConditional s A B w
 
 instance stalnakerCounterfactual_decidable {W : Type*} (s : Semantics.Conditionals.SelectionFunction W)
     (A B : W → Prop) [DecidablePred B] (w : W) :
@@ -571,6 +573,7 @@ theorem stalnaker_eq_selectional_singleton {W : Type*} [DecidableEq W] [Fintype 
     selectionalCounterfactual sim A B w =
     Truth3.ofBool (decide (stalnakerCounterfactual s A B w)) := by
   unfold selectionalCounterfactual stalnakerCounterfactual
+    Semantics.Conditionals.selectionConditional
   rw [h_singleton]
   by_cases hB : B (s.sel w {w' | A w'})
   · -- Both sides equal .true
@@ -608,8 +611,8 @@ set, recovering Stalnaker's `s(w, ‖A‖)`. -/
 [cariani-santorio-2018] §5.3.2 + §5.3.1: when the modal parameter
 of the will-conditional is taken to be `Set.univ`, the Kratzer
 restriction `Set.univ ∩ ‖A‖ = ‖A‖` recovers Stalnaker's selection
-target. The Bool-valued `stalnakerCounterfactual` and the Prop-valued
-`willConditional` thus coincide modulo the `· = true` reflection.
+target. The `stalnakerCounterfactual` and `willConditional`
+truth-conditions thus coincide (`↔`).
 
 This is the formal payoff of the unification: bare *will* (`willSem`),
 will-conditionals (`willConditional`), Stalnaker counterfactuals, and
@@ -622,6 +625,7 @@ theorem stalnakerCounterfactual_eq_willConditional_universe
     Semantics.Conditionals.WillConditional.willConditional
       s A B Set.univ w := by
   unfold stalnakerCounterfactual
+    Semantics.Conditionals.selectionConditional
     Semantics.Conditionals.WillConditional.willConditional
     Semantics.Conditionals.WillConditional.restrict
     Semantics.Modality.Selectional.willSem

--- a/Linglib/Semantics/Conditionals/SelectionFunction.lean
+++ b/Linglib/Semantics/Conditionals/SelectionFunction.lean
@@ -74,6 +74,26 @@ theorem sel_neg_swap (s : SelectionFunction W) (A : W → Prop) (f : Set W)
 
 end SelectionFunction
 
+/-- **Selection conditional** [stalnaker-1968]: "if `p`, `q`" is true at
+`w` iff `q` holds at the world `s` selects from the `p`-worlds. This is the
+bare selection-conditional clause of the selection-function framework. The
+indicative refinement ([stalnaker-1975], via a pragmatic constraint on `s`)
+and the counterfactual reading ([stalnaker-1981]/[lewis-1973], via a
+similarity-induced `s`) share this single clause and differ only in which
+selection functions are admissible — so both `Stalnaker.moodedConditional`
+and `Counterfactual.stalnakerCounterfactual` specialize it here rather than
+re-stating the truth-condition. -/
+def selectionConditional {W : Type*} (s : SelectionFunction W)
+    (p q : W → Prop) : W → Prop :=
+  fun w => q (s.sel w {w' | p w'})
+
+/-- `selectionConditional` is decidable when its consequent is. The single
+decidability instance the indicative and counterfactual readings inherit. -/
+instance selectionConditional_decidable {W : Type*} (s : SelectionFunction W)
+    (p q : W → Prop) [DecidablePred q] (w : W) :
+    Decidable (selectionConditional s p q w) :=
+  inferInstanceAs (Decidable (q _))
+
 /-- **Pairwise preference induced by a selection function.**
 
 `w₁` is preferred to `w₂` from center `w₀` iff when choosing between

--- a/Linglib/Semantics/Conditionals/Stalnaker.lean
+++ b/Linglib/Semantics/Conditionals/Stalnaker.lean
@@ -85,20 +85,13 @@ def coherentSelectionToSimilarity {W : Type*} [DecidableEq W]
       (fun w₁ w₂ w₃ => h_coherent w₀ w₁ w₂ w₃)
   decClose w₀ w₁ w₂ := by exact inferInstanceAs (Decidable (s.sel w₀ {w₁, w₂} = w₁))
 
-/-! ## Selection conditional + Stalnakerian mood machinery -/
+/-! ## Stalnakerian mood machinery
 
-/-- **Selection-based conditional**: "if p, then q" is true at `w` iff
-    `q` holds at the world selected by `s` from the p-worlds. The common
-    semantic core of [stalnaker-1975] indicatives and subjunctives. -/
-def selectionConditional {W : Type*} (s : SelectionFunction W)
-    (p q : W → Prop) : W → Prop :=
-  λ w => q (s.sel w {w' | p w'})
-
-/-- `selectionConditional` is decidable when its consequent is. -/
-instance selectionConditional_decidable {W : Type*} (s : SelectionFunction W)
-    (p q : W → Prop) [DecidablePred q] (w : W) :
-    Decidable (selectionConditional s p q w) :=
-  inferInstanceAs (Decidable (q _))
+The bare selection-conditional clause `selectionConditional` and its
+decidability instance now live in `SelectionFunction.lean` — the
+[stalnaker-1968] substrate shared with the counterfactual reading
+(`Counterfactual.stalnakerCounterfactual`). This section adds the
+[stalnaker-1975] indicative refinements on top of that shared clause. -/
 
 /-- **Pragmatic constraint on selection** ([stalnaker-1975] §III).
 

--- a/Linglib/Semantics/Conditionals/Stalnaker.lean
+++ b/Linglib/Semantics/Conditionals/Stalnaker.lean
@@ -27,9 +27,10 @@ Key distinction from [lewis-1973]: Lewis universally quantifies
 over closest A-worlds; Stalnaker selects a single A-world (with
 supervaluation for ties — see `Conditionals/Counterfactual.lean`).
 
-`SelectionFunction` itself lives in `Core/SelectionFunction.lean` and
-is shared with [cariani-santorio-2018]'s selectional *will* in
-`WillConditional.lean`.
+`SelectionFunction` itself lives in
+`Semantics/Conditionals/SelectionFunction.lean` and is shared with
+[cariani-santorio-2018]'s selectional *will* (`Semantics/Modality/Selectional.lean`)
+and will-conditionals (`Semantics/Conditionals/WillConditional.lean`).
 
 ## Selection ↔ Similarity Bridge ([stalnaker-1981])
 

--- a/Linglib/Semantics/Conditionals/WillConditional.lean
+++ b/Linglib/Semantics/Conditionals/WillConditional.lean
@@ -1,13 +1,19 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Modality.Selectional
 
 /-!
 # Selectional `will`-Conditionals
 [cariani-santorio-2018]
 
-[cariani-santorio-2018] §5.3.1 (eq. 20) lifts the selectional
-analysis of *will* to conditionals via Kratzerian restriction: an
-*if*-clause restricts the modal parameter `f` to its intersection with
-the antecedent's truth set.
+[cariani-santorio-2018] §5.3.1 lifts the selectional analysis of *will*
+to conditionals via Kratzerian restriction: an *if*-clause restricts the
+modal parameter `f` to its intersection with the antecedent's truth set.
+The restriction rule is paper eq. (21); eq. (20) is the LF of the example
+sentence and eq. (23) its informal English gloss.
 
 `⟦if A, will B⟧^{w,s,g} = ⟦will B⟧^{w,s,g[f ↦ g(f) ∩ ‖A‖]}`
                        `= B (s(w, g(f) ∩ ‖A‖))`
@@ -19,6 +25,8 @@ single-valuedness.
 
 ## What's here
 
+- `restrict`: the Kratzer restriction operation `f ∩ ‖A‖` shared by
+  every will-conditional construction in this file.
 - `willConditional`: the restrictor analysis applied to the selectional
   `will`. The if-clause intersects the modal parameter.
 - `compositional_CEM`: `if A, will B ∨ if A, will ¬B` is valid₂ —
@@ -40,14 +48,21 @@ open Semantics.Modality.Selectional
 
 variable {W : Type*}
 
+/-- **Kratzer restriction** [cariani-santorio-2018] §5.3.1: the if-clause
+    `A` restricts the modal parameter `f` to the alternatives that also
+    satisfy `A`, i.e. `f ∩ ‖A‖`. Every will-conditional construction in
+    this file feeds the selection function this restricted parameter. -/
+def restrict (A : W → Prop) (f : Set W) : Set W :=
+  f ∩ {w' | A w'}
+
 /-- **Selectional `will`-conditional** [cariani-santorio-2018]
-    §5.3.1 (eq. 20): the if-clause `A` Kratzer-restricts the modal
-    parameter `f` to `f ∩ ‖A‖` before evaluating the *will*-prejacent
-    `B`. (Eq. 22 in the paper is the informal English gloss of this
-    rule; eq. 20 is the actual semantic clause.) -/
+    §5.3.1: the if-clause `A` Kratzer-`restrict`s the modal parameter
+    `f` to `f ∩ ‖A‖` before evaluating the *will*-prejacent `B`. The
+    restriction rule is paper eq. (21); eq. (23) is its informal English
+    gloss. -/
 def willConditional (s : SelectionFunction W) (A B : W → Prop)
     (f : Set W) (w : W) : Prop :=
-  willSem s B (f ∩ {w' | A w'}) w
+  willSem s B (restrict A f) w
 
 @[simp] theorem willConditional_def (s : SelectionFunction W) (A B : W → Prop)
     (f : Set W) (w : W) :
@@ -66,7 +81,7 @@ theorem compositional_CEM (s : SelectionFunction W) (A B : W → Prop)
     (f : Set W) (w : W) :
     willConditional s A B f w ∨
     willConditional s A (fun w' => ¬ B w') f w :=
-  s.sel_em B (f ∩ {w' | A w'}) w
+  s.sel_em B (restrict A f) w
 
 /-- **Compositional CEM** is valid₂ (paper §7): holds at every
     ⟨s, f, w⟩ index. -/
@@ -86,7 +101,7 @@ theorem narrow_negation_swap (s : SelectionFunction W) (A B : W → Prop)
     (f : Set W) (w : W) :
     willConditional s A (fun w' => ¬ B w') f w ↔
     ¬ willConditional s A B f w :=
-  s.sel_neg_swap B (f ∩ {w' | A w'}) w
+  s.sel_neg_swap B (restrict A f) w
 
 /-- **Narrow Negation Swap** is valid₂. -/
 theorem valid2_narrow_negation_swap (A B : W → Prop) :
@@ -97,13 +112,12 @@ theorem valid2_narrow_negation_swap (A B : W → Prop) :
 
 /-- **Wide Negation Swap in Conditionals** [cariani-santorio-2018]
     §7: under the *wide* reading where negation scopes over the entire
-    conditional, `¬ (if A, will B) ↔ (if A, will ¬B)`. Definitionally
-    equal to the narrow biconditional in the selectional setting, since
-    selection-function single-valuedness collapses the LF-position
-    distinction: regardless of where negation attaches, the truth
-    condition reduces to `¬ B (s.sel w (f ∩ ‖A‖))`. The paper highlights
-    that this collapse is a positive prediction of the selectional
-    analysis — universal-base treatments scope-distinguish the two. -/
+    conditional, `¬ (if A, will B) ↔ (if A, will ¬B)`. In the selectional
+    setting this is definitionally the converse of `narrow_negation_swap`:
+    selection-function single-valuedness reduces both LF positions to the
+    same truth condition `¬ B (s.sel w (f ∩ ‖A‖))`, so C&S derive Wide
+    Negation Swap from Narrow plus the matrix Negation Swap (paper §7).
+    The wide/narrow collapse is internal to the selectional analysis. -/
 theorem wide_negation_swap (s : SelectionFunction W) (A B : W → Prop)
     (f : Set W) (w : W) :
     ¬ willConditional s A B f w ↔
@@ -126,12 +140,12 @@ theorem valid2_wide_negation_swap (A B : W → Prop) :
     separates Validity₁ from Validity₂. -/
 theorem postsemantic_CEM (A B : W → Prop) (sCtx : SelectionFunction W)
     (fCtx : Set W) (wCtx : W) :
-    Semantics.Modality.Selectional.Valid1 (W := W)
+    Valid1 (W := W)
       (fun s f w =>
         willConditional s A B f w ∨
         willConditional s A (fun w' => ¬ B w') f w)
       sCtx fCtx wCtx :=
-  Semantics.Modality.Selectional.valid2_implies_valid1
+  valid2_implies_valid1
     (fun s f w => compositional_CEM s A B f w) sCtx fCtx wCtx
 
 /-- **Conditional collapse**: when the evaluation world `w` is in the
@@ -140,9 +154,8 @@ theorem postsemantic_CEM (A B : W → Prop) (sCtx : SelectionFunction W)
     consequent `B w` by Centering. -/
 theorem willConditional_collapse (s : SelectionFunction W) (A B : W → Prop)
     (f : Set W) (w : W) (hw_f : w ∈ f) (hw_A : A w) :
-    willConditional s A B f w ↔ B w := by
-  unfold willConditional
-  exact unembedded_collapse s B (f ∩ {w' | A w'}) w ⟨hw_f, hw_A⟩
+    willConditional s A B f w ↔ B w :=
+  unembedded_collapse s B (restrict A f) w ⟨hw_f, hw_A⟩
 
 /-- **Restriction is idempotent under satisfaction**: if `f ⊆ ‖A‖`,
     restricting by `A` is a no-op, so `will A → will A` and
@@ -150,11 +163,34 @@ theorem willConditional_collapse (s : SelectionFunction W) (A B : W → Prop)
 theorem willConditional_redundant (s : SelectionFunction W) (A B : W → Prop)
     (f : Set W) (w : W) (h_subset : ∀ w' ∈ f, A w') :
     willConditional s A B f w ↔ willSem s B f w := by
-  have h_eq : f ∩ {w' | A w'} = f := by
+  have h_eq : restrict A f = f := by
     ext w'
     exact ⟨fun ⟨hf, _⟩ => hf, fun hf => ⟨hf, h_subset w' hf⟩⟩
-  unfold willConditional willSem
+  unfold willConditional
   rw [h_eq]
+
+/-! ## The universal-base foil for will-conditionals
+
+The Lewis-style universal-quantifier reading lifts to conditionals the
+same way the selectional one does — by Kratzer-restricting the modal
+parameter — but evaluates the prejacent *universally* over the restricted
+parameter instead of at the single selected world. This is the
+conditional image of [cariani-santorio-2018]'s matrix foil
+`Selectional.universalWill`. It is the natural-language analogue of
+[lewis-1973]'s counterfactual semantics, and it falsifies Compositional
+CEM: when the restricted parameter contains both a `B`-world and a
+`¬B`-world, neither `(if A, will B)` nor `(if A, will ¬B)` is universally
+true. The concrete refutation is `CarianiSantorio2018`'s
+`universal_will_conditional_cem_fails`, the will-conditional analogue of
+`Stalnaker1981.bizet_cem_fails_universal`. -/
+
+/-- **Universal-base will-conditional** (the foil): the if-clause
+    Kratzer-restricts the parameter to `f ∩ ‖A‖`, then *will B* is read
+    as universal quantification over that restricted parameter. Unlike
+    `willConditional`, this validates neither Compositional CEM nor
+    Negation Swap. -/
+def universalWillConditional (A B : W → Prop) (f : Set W) (w : W) : Prop :=
+  universalWill B (restrict A f) w
 
 /-! ## *Would*-conditionals — the past-tense morphological derivative
 
@@ -173,40 +209,38 @@ def wouldConditional (s : SelectionFunction W) (A B : W → Prop)
     (f : Set W) (w : W) : Prop :=
   willConditional s A B f w
 
-@[simp] theorem wouldConditional_def (s : SelectionFunction W) (A B : W → Prop)
-    (f : Set W) (w : W) :
-    wouldConditional s A B f w ↔ B (s.sel w (f ∩ {w' | A w'})) := Iff.rfl
-
 /-- **Past-tense morphology = parameter shift** for conditionals:
     *would*-conditionals and *will*-conditionals share their semantic
-    clause. -/
-theorem wouldConditional_eq_willConditional (s : SelectionFunction W)
+    clause (the conditional analogue of `wouldSem_eq_willSem`). Tagged
+    `@[simp]` so `wouldConditional` reduces to the canonical
+    `willConditional` normal form. -/
+@[simp] theorem wouldConditional_eq_willConditional (s : SelectionFunction W)
     (A B : W → Prop) (f : Set W) (w : W) :
     wouldConditional s A B f w = willConditional s A B f w := rfl
 
 /-! ## Modal subordination
 
-[cariani-santorio-2018] §5.3.1: "If A, will B. Will C." reads with
-modal subordination — the second sentence's *will* inherits the first
-sentence's restricted parameter `f ∩ ‖A‖` rather than starting fresh
-from `f`. The selectional analysis predicts this for free: a discourse
-of two will-utterances under a shared restricted parameter is just the
-conjunction of two `willSem` calls at that parameter.
-
-The selection function picks the *same* world for both prejacents
-because `s.sel w (f ∩ ‖A‖)` is single-valued. This is the discourse
-analogue of `compositional_CEM` and `narrow_negation_swap`: structural
-single-valuedness, not propositional content, drives the prediction. -/
+[cariani-santorio-2018] §5.3.1 models modal subordination in a
+discourse "If A, will B. Will C." by *coindexing* the second sentence's
+*will* to the same restricted modal-base variable the if-clause
+introduces, so both *will*s are interpreted under the antecedent's
+supposition `f ∩ ‖A‖` rather than the second starting fresh from `f`.
+C&S treat the coindexing as a discourse assumption (following Klecha),
+not as something the semantics forces. Under that coindexing the
+selection function picks the *same* world for both prejacents, because
+`s.sel w (f ∩ ‖A‖)` is single-valued — the discourse analogue of the
+single-valuedness behind `compositional_CEM` and `narrow_negation_swap`. -/
 
 /-- **Modally-subordinated will-discourse** [cariani-santorio-2018]
-    §5.3.1: a two-sentence discourse "If A, will B. Will C." where the
-    second *will* inherits the if-clause's restricted parameter
-    `f ∩ ‖A‖`. The discourse holds iff both prejacents hold at the
-    Stalnaker-selected world from the restricted parameter. -/
+    §5.3.1: the minimal two-*will* instance of C&S's coindexing
+    analysis — "If A, will B. Will C." with the second *will*'s modal
+    base coindexed to the if-clause's restricted parameter `f ∩ ‖A‖`.
+    Holds iff both prejacents hold at the Stalnaker-selected world from
+    the restricted parameter. -/
 def subordinatedWillDiscourse (s : SelectionFunction W) (A B C : W → Prop)
     (f : Set W) (w : W) : Prop :=
   willConditional s A B f w ∧
-  willSem s C (f ∩ {w' | A w'}) w
+  willSem s C (restrict A f) w
 
 /-- **Modal subordination = shared selected world**: the subordinated
     discourse picks the *same* world for both prejacents, because
@@ -219,17 +253,19 @@ theorem subordinatedWillDiscourse_eq_conj (s : SelectionFunction W)
     (B (s.sel w (f ∩ {w' | A w'})) ∧ C (s.sel w (f ∩ {w' | A w'}))) :=
   Iff.rfl
 
-/-- **Subordination ≠ unrestricted continuation**: the modally-
-    subordinated reading `f ∩ ‖A‖` differs in general from a fresh
-    *will* at the original parameter `f`. The two coincide only when
-    `s.sel w f = s.sel w (f ∩ ‖A‖)` — i.e. when restricting by `A`
-    does not shift the selected world. -/
-theorem subordinated_eq_unrestricted_iff (s : SelectionFunction W)
+/-- **Subordination coincides with an unrestricted continuation exactly
+    when the if-clause does not shift the selected world.** The
+    modally-subordinated reading evaluates the continuation *will C* at
+    the restricted parameter `f ∩ ‖A‖`, whereas a fresh, non-subordinated
+    *will C* would evaluate it at `f`. The two readings agree precisely
+    when restricting by `A` leaves the selected world fixed
+    (`s.sel w f = s.sel w (f ∩ ‖A‖)`); in general they diverge. -/
+theorem subordinated_eq_unrestricted_of_no_shift (s : SelectionFunction W)
     (A B C : W → Prop) (f : Set W) (w : W)
-    (hB : willConditional s A B f w) :
+    (h_no_shift : s.sel w f = s.sel w (restrict A f)) :
     subordinatedWillDiscourse s A B C f w ↔
-    (willConditional s A B f w ∧ C (s.sel w (f ∩ {w' | A w'}))) := by
-  unfold subordinatedWillDiscourse willSem
-  exact ⟨fun ⟨_, h⟩ => ⟨hB, h⟩, fun ⟨_, h⟩ => ⟨hB, h⟩⟩
+    (willConditional s A B f w ∧ willSem s C f w) := by
+  unfold subordinatedWillDiscourse willConditional willSem
+  rw [h_no_shift]
 
 end Semantics.Conditionals.WillConditional

--- a/Linglib/Semantics/Modality/Selectional.lean
+++ b/Linglib/Semantics/Modality/Selectional.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Conditionals.SelectionFunction
 import Linglib.Semantics.Modality.HistoricalAlternatives
 import Linglib.Core.Probability.Finite
@@ -118,7 +123,7 @@ theorem will_excluded_middle (s : SelectionFunction W) (A : W → Prop)
     willSem s A f w ∨ willSem s (fun w' => ¬ A w') f w :=
   s.sel_em A f w
 
-/-- **Unembedded collapse** [cariani-santorio-2018] eq. (17):
+/-- **Unembedded collapse** [cariani-santorio-2018] eq. (18):
     when the evaluation world is itself in the modal parameter,
     Centering forces the selected world to be `w`, so `will A`
     reduces to `A w`.
@@ -290,9 +295,10 @@ def willHistorical {Time : Type*} (s : SelectionFunction W)
     (w : W) (t : Time) : Prop :=
   willSem s A (metaphysicalBase history w t) w
 
-/-- When the world-history relation is reflexive (the standard case
-    [condoravdi-2002] §4.1 condition (i)), `willHistorical`
-    collapses to its prejacent: `will_t A` at `w` reduces to `A w`. -/
+/-- When the world-history relation is reflexive (the standard
+    assumption that a world is among its own historical alternatives,
+    [condoravdi-2002]), `willHistorical` collapses to its prejacent:
+    `will_t A` at `w` reduces to `A w`. -/
 theorem willHistorical_reflexive_collapse {Time : Type*}
     (s : SelectionFunction W) {history : HistoricalAlternatives W Time}
     (hRefl : history.reflexive) (A : W → Prop) (w : W) (t : Time) :

--- a/Linglib/Studies/CarianiSantorio2018.lean
+++ b/Linglib/Studies/CarianiSantorio2018.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Modality.Selectional
 import Linglib.Semantics.Conditionals.WillConditional
 import Linglib.Semantics.Modality.HistoricalAlternatives
@@ -55,9 +60,11 @@ applying (paper §8.2 footnote 32).
 | 5 | Speaker with w in modal base ⇒ collapse | `member_collapses` |
 | 6 | Selectional `will`: μ(‖will Warriors-cap‖) = 1/3 | `cynthia_credence_one_third` |
 | 7 | Universal `will`: μ(‖∀Warriors-cap‖) = 0 (collapse) | `universal_will_credence_zero` |
-| 8 | "If Robin wears a cap, Robin'll wear a Warriors cap" — credence 1/2 (paper eq. 30, §8.1)| `cap_warriors_credence_one_half` |
+| 8 | "If Robin wears a cap, Robin'll wear a Warriors cap" — *conditional* credence 1/2 (paper ex. (31)/eq. (32), §8)| `cap_warriors_credence_one_half` |
 | 9 | Hájek triviality fails: no proposition has probability 1/2 unconditionally (§8.2 fn 32) | `no_unconditional_one_half` |
 | 10| `cynthiaSel` is coherent (§5.1: selection induces a well-ordering) | `cynthiaSel_coherent` |
+| 11| Selectional will-conditional validates Compositional CEM (§7) | `cap_will_conditional_cem` |
+| 12| Universal-base will-conditional refutes CEM (the Lewis side) | `universal_will_conditional_cem_fails` |
 -/
 
 set_option autoImplicit false
@@ -66,7 +73,8 @@ namespace CarianiSantorio2018
 
 open _root_.Semantics.Conditionals (SelectionFunction)
 open Semantics.Modality.Selectional
-open Semantics.Conditionals.WillConditional (wouldConditional willConditional)
+open Semantics.Conditionals.WillConditional
+  (wouldConditional willConditional universalWillConditional compositional_CEM)
 open scoped ENNReal
 
 -- ============================================================================
@@ -199,7 +207,7 @@ theorem nonmember_no_collapse :
   unfold selFn counterfactualAlt
   simp [warriorsCap]
 
-/-- **Prediction 5** (= [cariani-santorio-2018] eq. (17) collapse):
+/-- **Prediction 5** (= [cariani-santorio-2018] eq. (18) collapse):
     when `w` is in the modal parameter, `will A` collapses to `A w`. -/
 theorem member_collapses (A : W → Prop) (w : W) (hw : w ∈ histAlt) :
     willSem cynthiaSel A histAlt w ↔ A w :=
@@ -280,27 +288,29 @@ theorem universal_will_credence_zero :
   rw [hempty, PMF.probOfSet_empty]
 
 -- ============================================================================
--- §5. The cap-conditional (paper eq. (30), §8.1)
+-- §5. The cap-conditional (paper ex. (31)/eq. (32), §8)
 -- ============================================================================
 
-/-- **Prediction 8** (will-conditional, paper eq. (30) §8.1):
+/-- **Prediction 8** (will-conditional, paper ex. (31)/eq. (32) §8):
     *If Robin wears a cap, Robin'll wear a Warriors cap*. The Kratzer
-    restriction sends the modal parameter from `histAlt = {cw, cg, cn}`
-    to `histAlt ∩ ‖cap‖ = {cw, cg}` — the cap-wearing alternatives.
-    Inside this restricted parameter, both `cw` and `cg` are equally
-    open, but the antecedent's truth-set assigns positive mass to `cw`
-    only.
+    restriction (`willConditional`) sends the modal parameter from
+    `histAlt = {cw, cg, cn}` to `histAlt ∩ ‖cap‖ = {cw, cg}` — the
+    cap-wearing alternatives.
 
-    Cynthia's credence in this conditional is 1/2 (paper §8.1):
-    of the cap-wearing worlds (total mass 2/3), the Warriors-cap world
-    has mass 1/3, so the conditional credence is 1/3 ÷ 2/3 = 1/2. The
-    next theorem proves the *unconditional* credence in the world
-    where the cap-conditional is true: the world `cw`, which has
-    mass 1/3 ÷ (1/3 + 1/3) = 1/2 of the cap-wearing mass.
+    The theorem records the **conditional** (Bayesian) credence
+    `P(Warriors-cap | cap) = 1/2`: of the cap-wearing worlds (mass 2/3),
+    the Warriors-cap world has mass 1/3, so `1/3 ÷ 2/3 = 1/2`. This is
+    the intuitive Adams-thesis value.
 
-    This exercises [cariani-santorio-2018] §5.3.1 + §5.3.2: the
-    conditional uses `willConditional`, which Kratzer-restricts the
-    modal parameter. -/
+    Note [cariani-santorio-2018] §8 are explicit that the selectional
+    will-conditional *proposition* itself does **not** reach 1/2 in this
+    3-world model — it gets 1/3 or 2/3, since "no proposition can have
+    probability 1/2" when every world has probability 1/3. Standard
+    conditional semantics "fails to vindicate the intuitive assignments
+    of probabilities to conditional sentences"; recovering 1/2 for the
+    proposition needs the §8 refinement to a finer world-algebra. The
+    theorem here captures the Bayesian conditional ratio (the value that
+    refinement targets), not the selectional proposition's probability. -/
 theorem cap_warriors_credence_one_half :
     cynthiaPMF.probOfSet wearsCap ≠ 0 ∧
     cynthiaPMF.condProbSet wearsCap warriorsCap = 1/2 := by
@@ -337,6 +347,65 @@ theorem cap_would_eq_will (w : W) :
     wouldConditional cynthiaSel wearsCap warriorsCap histAlt w =
     willConditional cynthiaSel wearsCap warriorsCap histAlt w :=
   rfl
+
+-- ============================================================================
+-- §5b. Conditional Excluded Middle: selectional validates, universal refutes
+-- ============================================================================
+
+/-! ## The Stalnaker/Lewis CEM fault line, lifted to will-conditionals
+
+[cariani-santorio-2018] §7 derive Compositional CEM —
+`(if A, will B) ∨ (if A, will ¬B)` — from selection single-valuedness.
+The Lewis-style universal-base reading (`universalWillConditional`)
+refutes it, exactly as Lewis's universal counterfactual refutes
+Conditional Excluded Middle for counterfactuals (cf.
+`Stalnaker1981.bizet_cem_fails_universal`). The contrast below exhibits
+that fault line at the future-modal layer, on the Sports Fan model: the
+restricted parameter `histAlt ∩ ‖cap‖ = {cw, cg}` contains both a
+Warriors-cap world (`cw`) and a non-Warriors-cap world (`cg`). -/
+
+/-- **Selectional will-conditionals validate Compositional CEM**
+    (paper §7): for the cap-conditional on the Sports Fan model,
+    `(if cap, will Warriors) ∨ (if cap, will ¬Warriors)` holds. Inherited
+    from the generic `WillConditional.compositional_CEM`. -/
+theorem cap_will_conditional_cem :
+    willConditional cynthiaSel wearsCap warriorsCap histAlt .cw ∨
+    willConditional cynthiaSel wearsCap (fun w => ¬ warriorsCap w) histAlt .cw :=
+  compositional_CEM cynthiaSel wearsCap warriorsCap histAlt .cw
+
+/-- **The universal-base reading refutes Compositional CEM** — the
+    will-conditional analogue of `Stalnaker1981.bizet_cem_fails_universal`.
+    On the restricted parameter `histAlt ∩ ‖cap‖ = {cw, cg}`, neither
+    `(if cap, will Warriors)` nor `(if cap, will ¬Warriors)` is
+    universally true: `cg` is a cap-world that is not a Warriors-world
+    (killing the first disjunct) and `cw` is a Warriors-world (killing the
+    second). So the Lewis-style universal future-conditional falsifies the
+    CEM that the selectional analysis validates. -/
+theorem universal_will_conditional_cem_fails :
+    ¬ universalWillConditional wearsCap warriorsCap histAlt .cw ∧
+    ¬ universalWillConditional wearsCap (fun w => ¬ warriorsCap w) histAlt .cw := by
+  unfold universalWillConditional _root_.Semantics.Modality.Selectional.universalWill
+    _root_.Semantics.Conditionals.WillConditional.restrict
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · have hcg : (W.cg) ∈ warriorsCap :=
+      h .cg ⟨by simp [histAlt], show (W.cg) ∈ wearsCap by decide⟩
+    exact absurd hcg (by decide)
+  · have hcw : ¬ (W.cw) ∈ warriorsCap :=
+      h .cw ⟨by simp [histAlt], show (W.cw) ∈ wearsCap by decide⟩
+    exact absurd (show (W.cw) ∈ warriorsCap by decide) hcw
+
+/-- **The CEM split at the future-modal layer**: the selectional
+    will-conditional validates Compositional CEM while the universal-base
+    reading refutes it. This is the future-tense image of the Stalnaker /
+    Lewis dispute that `Stalnaker1981` records for counterfactuals — one
+    structural divergence, surfaced at both the counterfactual and the
+    will-conditional layer. -/
+theorem will_conditional_cem_split :
+    (willConditional cynthiaSel wearsCap warriorsCap histAlt .cw ∨
+     willConditional cynthiaSel wearsCap (fun w => ¬ warriorsCap w) histAlt .cw) ∧
+    (¬ universalWillConditional wearsCap warriorsCap histAlt .cw ∧
+     ¬ universalWillConditional wearsCap (fun w => ¬ warriorsCap w) histAlt .cw) :=
+  ⟨cap_will_conditional_cem, universal_will_conditional_cem_fails⟩
 
 -- ============================================================================
 -- §6. Hájek triviality fails (paper §8.2 footnote 32)

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -11245,7 +11245,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {formalized},
-  sources   = {Semantics/Modality/Selectional.lean;Phenomena/Modality/Studies/CarianiSantorio2018.lean}
+  sources   = {Semantics/Modality/Selectional.lean;Semantics/Conditionals/WillConditional.lean;Studies/CarianiSantorio2018.lean}
 }
 @article{cariani-santorio-wellwood-2024,
   author    = {Cariani, Fabrizio and Santorio, Paolo and Wellwood, Alexis},


### PR DESCRIPTION
Audit-driven cleanup of the Cariani & Santorio (2018) selectional-*will* cone, plus a dedup of the shared selection-conditional clause.

- Correct 3 PDF-verified citation errors (restriction rule eq. (21) not (20); collapse eq. (18) not (17); cap-conditional ex. (31)/eq. (32) not (30)), reframe the cap-conditional credence, soften two overclaims, add license headers, fix stale source paths.
- Repair a vacuous lemma, name the Kratzer `restrict`, drop a redundant simp lemma; add the universal-base CEM foil lifting the Stalnaker/Lewis dispute to will-conditionals.
- Single-source `selectionConditional` in `SelectionFunction.lean`; `stalnakerCounterfactual`/`moodedConditional` specialize it — no cross-anchor import, no bridge.