### PR TITLE
refactor(Core/Computability): intrinsic syntacticCon, syntacticClass API

### DIFF
--- a/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
@@ -9,132 +9,48 @@ import Linglib.Core.Computability.Subregular.Language.Definite
 import Linglib.Core.Data.List.DropRight
 
 /-!
-# Equational characterizations of subregular language classes
+# Equational characterizations of the definite subregular classes
 
-[lambert-2026] §6.2 (paper p. 22-25, with summary in Table 6 p. 28)
-characterizes each base-class of subregular languages by a system of
-equations on the *syntactic semigroup*: `D = ⟦sx^ω = x^ω⟧`,
-`K = ⟦x^ω y = x^ω⟧`, `LI = ⟦x^ω y x^ω = x^ω⟧`, `N = ⟦x^ω y = x^ω;
-yx^ω = x^ω⟧` (definite, reverse-definite, generalized-definite,
-co/finite, respectively).
-
-This file lands the **`k`-definite case** (Lambert Prop 53, p. 23) as a
-feasibility probe — the simplest entry into Lambert's algebraic story
-because it requires no `omegaPow` (idempotent power) machinery.
-Lambert's claim:
-
-> A language is `k`-definite if and only if it is in
-> `⟦sx₁ … xₖ = x₁ … xₖ⟧`.
-
-## Mathlib precedent: monoid + length-`k` letter-sequence variables
-
-Lambert's syntactic *semigroup* excludes the empty word; our
-`Language.syntacticMonoid L` (built via `Con (FreeMonoid α)`, see
-`SyntacticMonoid.lean`) includes the identity (the class of the empty
-word). Mathlib's `Con.Quotient` precedent gives us a `Monoid`, not a
-`Semigroup`; there is no established mathlib `syntacticSemigroup`
-pattern. **We follow mathlib precedent and keep the `Monoid` setting.**
-
-### Letter-sequence quantification (not arbitrary monoid elements)
-
-To recover Lambert's intended characterization in the monoid setting,
-the equation quantifies `x₁, …, xₖ` over **length-`k` letter sequences**
-in the alphabet `α` rather than over arbitrary syntactic-monoid
-elements. This is the "generators" interpretation: the equation says
-"prepending any prefix to a length-`k` letter sequence preserves its
-syntactic class".
-
-The naïve pure-monoid form
-`∀ s ≠ 1, ∀ xs : List M of length k, (∀ x ∈ xs, x ≠ 1) →
-   s * xs.prod = xs.prod`
-is **strictly weaker** and does not characterize `k`-definite. Concrete
-counterexample: take `L = (a|b)*` over the alphabet `{a, b, c}` —
-membership is "no `c` anywhere". Then `[a] = [b] = 1` in the syntactic
-monoid (inserting `a` or `b` anywhere preserves "no `c`"), and the
-syntactic monoid is the rank-2 lattice `M = {1, 0}` with `0 = [c]`
-absorbing. The pure-monoid equation trivially holds: the only
-non-identity element is `0`, and `0 * 0 = 0`. Yet `L` is not
-`k`-definite for any `k` — the words `c·a^k` and `a^k` share the
-length-`k` suffix `a^k` but only the latter is in `L`.
-
-The letter-sequence formulation rules this out: for `αs = [a]` of
-length 1, the syntactic class of `αs` is `1` in `M`, and the equation
-`s * 1 = 1` forces `s = 1`, which fails for `s = [c] = 0`. So the
-equation correctly detects that `L` is not 1-definite.
-
-(Lambert's semigroup version sidesteps the trivial-letter issue
-because his syntactic semigroup is generated only by the *non-trivial*
-letter classes, implicitly ignoring L-trivial letters in the alphabet.
-The letter-sequence monoid form makes this explicit.)
+[lambert-2026] characterizes base classes of subregular languages by equations on
+the syntactic semigroup. This file gives the finite-`k` forms for the **definite**
+(`𝒟`), **reverse-definite** (`𝒦`), and **generalized definite** (`ℒℐ`) classes; the
+classical ω-power forms in `Pin.lean` are derived from them.
 
 ## Main definitions
 
-* `Language.kDefiniteEquation L k` — the equation
-  `∀ s ∈ L.syntacticMonoid, ∀ αs : List α with αs.length = k,
-  s * [αs] = [αs]`. The product on the left is monoid multiplication
-  in `L.syntacticMonoid`; `[αs]` denotes
-  `L.toSyntacticMonoid (FreeMonoid.ofList αs)`.
+* `Language.kDefiniteEquation`, `Language.kReverseDefiniteEquation`,
+  `Language.kGeneralizedDefiniteEquation` — for every syntactic-monoid element `s`
+  and length-`k` word `αs`, prepending, appending, resp. sandwiching `s` around the
+  class of `αs` fixes it (`s * [αs] = [αs]`, `[αs] * s = [αs]`, `[αs] * s * [αs] = [αs]`),
+  where `[αs]` is `L.syntacticClass αs`.
 
 ## Main results
 
-* `Language.IsDefinite.satisfies_kDefiniteEquation` — **forward
-  direction**: a `k`-definite language's syntactic monoid satisfies
-  the equation. Proof: extract a `FreeMonoid α` representative `w` of
-  `s`; the equation reduces to `L.syntacticCon (w ++ αs) αs`, which
-  follows from `takeAt_right_append_left_absorb` (since `|αs| = k`,
-  the length-`k` suffix of `x ++ w ++ αs ++ y` already discards `w`).
+* `Language.isDefinite_iff_satisfies_kDefiniteEquation`,
+  `Language.isReverseDefinite_iff_satisfies_kReverseDefiniteEquation`,
+  `Language.isGeneralizedDefinite_iff_satisfies_kGeneralizedDefiniteEquation`
+  ([lambert-2026], Props 53, 57, 58) — each class equals the languages whose
+  syntactic monoid satisfies the corresponding equation.
 
-* `Language.isDefinite_of_satisfies_kDefiniteEquation` — **reverse
-  direction**: the equation implies `k`-definiteness. Construction:
-  `G.permitted := { Edge.right.takeAt k w | w ∈ L }`. The trivial
-  inclusion `L ⊆ G.lang` holds with witness `w' = w`. The reverse
-  inclusion `G.lang ⊆ L` is by case analysis on word length: short
-  words equal their own suffix (forcing equality); long words decompose
-  as `prefix ++ ks` and the equation gives `L.syntacticCon w ks`,
-  then `L`-saturation closes the case.
+## Implementation notes
 
-* `Language.isDefinite_iff_satisfies_kDefiniteEquation` — Lambert
-  Prop 53 bidirectional bundling.
-
-In the same file, Lambert Prop 57 (reverse-definite, K) and Prop 58
-(generalized definite, ℒℐ) are also landed using the same letter-sequence
-template. The Pin omega-power forms (`Pin.lean`) consume these finite-`k`
-iffs to derive their own iffs.
-
-## Out of scope (queued for follow-up files)
-
-* `multitier ℬ𝒯C` extensions ([lambert-2026] §6.3, Table 6 right
-  column).
-
-## References
-
-* [lambert-2026] §6.2, Prop 53 (paper p. 23).
-* [straubing-1985], [almeida-1995] — the equational-class
-  framework Lambert builds on.
+The `xᵢ` range over length-`k` **letter sequences** (`αs : List α`), not arbitrary
+monoid elements: the latter is strictly weaker, ignoring `L`-trivial letters (e.g.
+`(a|b)*` over `{a, b, c}` would spuriously qualify). [lambert-2026] works in the
+syntactic *semigroup* (no empty word); we keep mathlib's `Con (FreeMonoid α)` monoid
+and recover the characterization through this letter-sequence quantification.
 -/
 
 open Subregular
 
 namespace Language
 
-/-- **Lambert (2026) Prop 53 equation** (length-`k` letter-sequence form):
-for any element `s` of `L.syntacticMonoid` and any length-`k` letter
-sequence `αs : List α`, prepending `s` to the syntactic class of `αs`
-preserves it.
-
-The variables `x₁, …, xₖ` of Lambert's notation
-`⟦sx₁ … xₖ = x₁ … xₖ⟧` are instantiated by the letters of `αs`,
-each `xᵢ` as the syntactic class of a single letter, so the product
-`x₁ ⋯ xₖ` corresponds to the syntactic class of `αs`. See file
-docstring for the rationale: the alternative pure-monoid form
-quantifying over arbitrary `xs : List M` is strictly weaker and
-fails to characterize `k`-definite. -/
-def kDefiniteEquation {α : Type*} (L : Language α) (k : ℕ) : Prop :=
-  ∀ (s : L.syntacticMonoid) (αs : List α), αs.length = k →
-    s * L.toSyntacticMonoid (FreeMonoid.ofList αs) =
-    L.toSyntacticMonoid (FreeMonoid.ofList αs)
-
 variable {α : Type*}
+
+/-- **Lambert Prop 53 equation** (`𝒟`): `s * [αs] = [αs]` for any length-`k` word `αs`. -/
+def kDefiniteEquation (L : Language α) (k : ℕ) : Prop :=
+  ∀ (s : L.syntacticMonoid) (αs : List α), αs.length = k →
+    s * L.syntacticClass αs = L.syntacticClass αs
 
 /-- A membership predicate `(· ∈ L)` factors through `f` as soon as `f`
 preserves membership pointwise. The shared reverse-direction engine for the
@@ -156,21 +72,14 @@ lemma takeAt_right_append_left_absorb {α : Type*}
 
 /-! ### Lifting the equation to a syntactic-class equality -/
 
-/-- Under the `k`-definite equation, prepending any prefix to a
-length-`k` word preserves its syntactic class.
-
-This is the algebraic heart of the reverse direction: applying the
-equation at `s = [w]` and unfolding
-`L.toSyntacticMonoid (w * αs) = L.toSyntacticMonoid w *
-L.toSyntacticMonoid αs` gives the syntactic-monoid equality
-`[w * αs] = [αs]`. -/
-lemma syntacticCon_of_kDefiniteEquation {L : Language α} {k : ℕ}
+/-- Under the `k`-definite equation, prepending any prefix to a length-`k` word
+preserves its syntactic class — the algebraic heart of the reverse direction. -/
+lemma syntacticClass_of_kDefiniteEquation {L : Language α} {k : ℕ}
     (h : Language.kDefiniteEquation L k)
     (w αs : List α) (hαs_len : αs.length = k) :
-    L.toSyntacticMonoid (FreeMonoid.ofList (w ++ αs)) =
-    L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
-  rw [FreeMonoid.ofList_append, MonoidHom.map_mul]
-  exact h (L.toSyntacticMonoid (FreeMonoid.ofList w)) αs hαs_len
+    L.syntacticClass (w ++ αs) = L.syntacticClass αs := by
+  rw [syntacticClass_append]
+  exact h (L.syntacticClass w) αs hαs_len
 
 /-! ### Lambert Prop 53 — both directions -/
 
@@ -182,25 +91,14 @@ theorem IsDefinite.satisfies_kDefiniteEquation
     {L : Language α} {k : ℕ} (hL : L.IsDefinite k) :
     Language.kDefiniteEquation L k := by
   intro s αs hαs_len
-  obtain ⟨w, hw⟩ := Quotient.exists_rep s
-  rw [show s = L.toSyntacticMonoid w from hw.symm, ← MonoidHom.map_mul]
-  apply Quotient.sound
-  refine (syntacticCon_iff L).mpr ?_
+  obtain ⟨w, rfl⟩ := L.syntacticClass_surjective s
+  rw [← syntacticClass_append, syntacticClass_eq_iff]
   intro x y
-  show x ++ FreeMonoid.toList (w * FreeMonoid.ofList αs) ++ y ∈ L ↔
-       x ++ FreeMonoid.toList (FreeMonoid.ofList αs) ++ y ∈ L
-  have hwmul : FreeMonoid.toList (w * FreeMonoid.ofList αs) =
-               FreeMonoid.toList w ++ αs := rfl
-  have hαsId : FreeMonoid.toList (FreeMonoid.ofList αs) = αs := rfl
-  rw [hwmul, hαsId]
   refine iff_of_eq (hL ?_)
-  rw [show x ++ (FreeMonoid.toList w ++ αs) ++ y =
-          (x ++ FreeMonoid.toList w) ++ (αs ++ y) by simp [List.append_assoc],
+  rw [show x ++ (w ++ αs) ++ y = (x ++ w) ++ (αs ++ y) by simp [List.append_assoc],
       show x ++ αs ++ y = x ++ (αs ++ y) by simp [List.append_assoc]]
-  have h_combined_len : k ≤ (αs ++ y).length := by
-    rw [List.length_append]; omega
-  rw [takeAt_right_append_left_absorb (x ++ FreeMonoid.toList w)
-        (αs ++ y) h_combined_len,
+  have h_combined_len : k ≤ (αs ++ y).length := by rw [List.length_append]; omega
+  rw [takeAt_right_append_left_absorb (x ++ w) (αs ++ y) h_combined_len,
       takeAt_right_append_left_absorb x (αs ++ y) h_combined_len]
 
 /-- **Lambert Prop 53 (reverse direction)**: if a language's syntactic
@@ -237,14 +135,13 @@ theorem isDefinite_of_satisfies_kDefiniteEquation
     · push Not at hw
       have hlen : (Edge.right.takeAt k w).length = k := by
         rw [Edge.length_takeAt]; omega
-      have hcon : L.toSyntacticMonoid (FreeMonoid.ofList w) =
-          L.toSyntacticMonoid (FreeMonoid.ofList (Edge.right.takeAt k w)) := by
-        have base := syntacticCon_of_kDefiniteEquation h
+      have hcon : L.syntacticClass w = L.syntacticClass (Edge.right.takeAt k w) := by
+        have base := syntacticClass_of_kDefiniteEquation h
           (w.take (w.length - k)) (Edge.right.takeAt k w) hlen
         have decomp : w = w.take (w.length - k) ++ Edge.right.takeAt k w :=
           (List.rdrop_append_rtake w k).symm
         rwa [← decomp] at base
-      exact mem_iff_of_syntacticCon (Quotient.exact hcon)
+      exact mem_iff_of_syntacticClass_eq hcon
   exact factorsThrough_of_mem_iff key
 
 /-- **Lambert (2026) Prop 53**: a language is `k`-definite iff its
@@ -268,8 +165,7 @@ languages (length-`k` letter-sequence, monoid form): for any element
 Lambert's notation: `𝒦_k = ⟦x₁ ⋯ xₖ s = x₁ ⋯ xₖ⟧` (paper Prop 57). -/
 def kReverseDefiniteEquation (L : Language α) (k : ℕ) : Prop :=
   ∀ (s : L.syntacticMonoid) (αs : List α), αs.length = k →
-    L.toSyntacticMonoid (FreeMonoid.ofList αs) * s =
-    L.toSyntacticMonoid (FreeMonoid.ofList αs)
+    L.syntacticClass αs * s = L.syntacticClass αs
 
 /-! #### Helper lemmas on `Edge.left.takeAt` (mirror of `Edge.right`) -/
 
@@ -283,16 +179,14 @@ private lemma takeAt_left_append_right_absorb {α : Type*}
 
 /-! #### Lifting the K equation to a syntactic-class equality -/
 
-/-- Under the reverse-`k`-definite equation, **appending** any suffix to
-a length-`k` word preserves its syntactic class. Mirror of
-`syntacticCon_of_kDefiniteEquation`. -/
-lemma syntacticCon_of_kReverseDefiniteEquation {L : Language α} {k : ℕ}
+/-- Under the reverse-`k`-definite equation, **appending** any suffix to a length-`k`
+word preserves its syntactic class. Mirror of `syntacticClass_of_kDefiniteEquation`. -/
+lemma syntacticClass_of_kReverseDefiniteEquation {L : Language α} {k : ℕ}
     (h : Language.kReverseDefiniteEquation L k)
     (αs w : List α) (hαs_len : αs.length = k) :
-    L.toSyntacticMonoid (FreeMonoid.ofList (αs ++ w)) =
-    L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
-  rw [FreeMonoid.ofList_append, MonoidHom.map_mul]
-  exact h (L.toSyntacticMonoid (FreeMonoid.ofList w)) αs hαs_len
+    L.syntacticClass (αs ++ w) = L.syntacticClass αs := by
+  rw [syntacticClass_append]
+  exact h (L.syntacticClass w) αs hαs_len
 
 /-! #### Lambert Prop 57 — both directions -/
 
@@ -302,25 +196,14 @@ theorem IsReverseDefinite.satisfies_kReverseDefiniteEquation
     {L : Language α} {k : ℕ} (hL : L.IsReverseDefinite k) :
     Language.kReverseDefiniteEquation L k := by
   intro s αs hαs_len
-  obtain ⟨w, hw⟩ := Quotient.exists_rep s
-  rw [show s = L.toSyntacticMonoid w from hw.symm, ← MonoidHom.map_mul]
-  apply Quotient.sound
-  refine (syntacticCon_iff L).mpr ?_
+  obtain ⟨w, rfl⟩ := L.syntacticClass_surjective s
+  rw [← syntacticClass_append, syntacticClass_eq_iff]
   intro x y
-  show x ++ FreeMonoid.toList (FreeMonoid.ofList αs * w) ++ y ∈ L ↔
-       x ++ FreeMonoid.toList (FreeMonoid.ofList αs) ++ y ∈ L
-  have hwmul : FreeMonoid.toList (FreeMonoid.ofList αs * w) =
-               αs ++ FreeMonoid.toList w := rfl
-  have hαsId : FreeMonoid.toList (FreeMonoid.ofList αs) = αs := rfl
-  rw [hwmul, hαsId]
   refine iff_of_eq (hL ?_)
-  rw [show x ++ (αs ++ FreeMonoid.toList w) ++ y =
-          (x ++ αs) ++ (FreeMonoid.toList w ++ y) by simp [List.append_assoc],
+  rw [show x ++ (αs ++ w) ++ y = (x ++ αs) ++ (w ++ y) by simp [List.append_assoc],
       show x ++ αs ++ y = (x ++ αs) ++ y by simp [List.append_assoc]]
-  have h_combined_len : k ≤ (x ++ αs).length := by
-    rw [List.length_append]; omega
-  rw [takeAt_left_append_right_absorb (x ++ αs)
-        (FreeMonoid.toList w ++ y) h_combined_len,
+  have h_combined_len : k ≤ (x ++ αs).length := by rw [List.length_append]; omega
+  rw [takeAt_left_append_right_absorb (x ++ αs) (w ++ y) h_combined_len,
       takeAt_left_append_right_absorb (x ++ αs) y h_combined_len]
 
 /-- **Lambert Prop 57 (reverse direction)**: if a language's syntactic
@@ -337,14 +220,13 @@ theorem isReverseDefinite_of_satisfies_kReverseDefiniteEquation
     · push Not at hw
       have hlen : (Edge.left.takeAt k w).length = k := by
         rw [Edge.length_takeAt]; omega
-      have hcon : L.toSyntacticMonoid (FreeMonoid.ofList w) =
-          L.toSyntacticMonoid (FreeMonoid.ofList (Edge.left.takeAt k w)) := by
-        have base := syntacticCon_of_kReverseDefiniteEquation h
+      have hcon : L.syntacticClass w = L.syntacticClass (Edge.left.takeAt k w) := by
+        have base := syntacticClass_of_kReverseDefiniteEquation h
           (Edge.left.takeAt k w) (w.drop k) hlen
         have decomp : w = Edge.left.takeAt k w ++ w.drop k :=
           (List.take_append_drop k w).symm
         rwa [← decomp] at base
-      exact mem_iff_of_syntacticCon (Quotient.exact hcon)
+      exact mem_iff_of_syntacticClass_eq hcon
   exact factorsThrough_of_mem_iff key
 
 /-- **Lambert (2026) Prop 57**: a language is reverse-`k`-definite iff
@@ -371,24 +253,20 @@ instances are bound to the **same** letter sequence; this is the
 the same class. -/
 def kGeneralizedDefiniteEquation (L : Language α) (k : ℕ) : Prop :=
   ∀ (s : L.syntacticMonoid) (αs : List α), αs.length = k →
-    L.toSyntacticMonoid (FreeMonoid.ofList αs) * s *
-    L.toSyntacticMonoid (FreeMonoid.ofList αs) =
-    L.toSyntacticMonoid (FreeMonoid.ofList αs)
+    L.syntacticClass αs * s * L.syntacticClass αs = L.syntacticClass αs
 
 
 /-! #### Lifting the LI equation to a syntactic-class equality -/
 
-/-- Under the LI equation, sandwiching any word `w` between two copies
-of a length-`k` word `αs` preserves the syntactic class of `αs`. -/
-lemma syntacticCon_of_kGeneralizedDefiniteEquation
+/-- Under the LI equation, sandwiching any word `w` between two copies of a length-`k`
+word `αs` preserves the syntactic class of `αs`. -/
+lemma syntacticClass_of_kGeneralizedDefiniteEquation
     {L : Language α} {k : ℕ}
     (h : Language.kGeneralizedDefiniteEquation L k)
     (αs w : List α) (hαs_len : αs.length = k) :
-    L.toSyntacticMonoid (FreeMonoid.ofList (αs ++ w ++ αs)) =
-    L.toSyntacticMonoid (FreeMonoid.ofList αs) := by
-  rw [FreeMonoid.ofList_append, FreeMonoid.ofList_append, MonoidHom.map_mul,
-      MonoidHom.map_mul]
-  exact h (L.toSyntacticMonoid (FreeMonoid.ofList w)) αs hαs_len
+    L.syntacticClass (αs ++ w ++ αs) = L.syntacticClass αs := by
+  rw [syntacticClass_append, syntacticClass_append]
+  exact h (L.syntacticClass w) αs hαs_len
 
 /-! #### Lambert Prop 58 — forward direction -/
 
@@ -403,46 +281,25 @@ theorem IsGeneralizedDefinite.satisfies_kGeneralizedDefiniteEquation
     {L : Language α} {k : ℕ} (hL : L.IsGeneralizedDefinite k) :
     Language.kGeneralizedDefiniteEquation L k := by
   intro s αs hαs_len
-  obtain ⟨w, hw⟩ := Quotient.exists_rep s
-  rw [show s = L.toSyntacticMonoid w from hw.symm]
-  rw [show L.toSyntacticMonoid (FreeMonoid.ofList αs) * L.toSyntacticMonoid w *
-        L.toSyntacticMonoid (FreeMonoid.ofList αs) =
-      L.toSyntacticMonoid (FreeMonoid.ofList αs * w * FreeMonoid.ofList αs) by
-    rw [MonoidHom.map_mul, MonoidHom.map_mul]]
-  apply Quotient.sound
-  refine (syntacticCon_iff L).mpr ?_
+  obtain ⟨w, rfl⟩ := L.syntacticClass_surjective s
+  rw [← syntacticClass_append, ← syntacticClass_append, syntacticClass_eq_iff]
   intro x y
-  show x ++ FreeMonoid.toList (FreeMonoid.ofList αs * w * FreeMonoid.ofList αs) ++ y ∈ L ↔
-       x ++ FreeMonoid.toList (FreeMonoid.ofList αs) ++ y ∈ L
-  -- Both sides reduce to checking IsGeneralizedDefinite on appropriate words.
-  have hwmul : FreeMonoid.toList (FreeMonoid.ofList αs * w * FreeMonoid.ofList αs) =
-               αs ++ FreeMonoid.toList w ++ αs := rfl
-  have hαsId : FreeMonoid.toList (FreeMonoid.ofList αs) = αs := rfl
-  rw [hwmul, hαsId]
-  -- Apply IsGenDef to (x ++ αs ++ toList w ++ αs ++ y, x ++ αs ++ y).
   apply isGeneralizedDefinite_iff_edges.mp hL
   · -- takeAt_left k matches: both have x ++ αs as prefix.
-    show (x ++ (αs ++ FreeMonoid.toList w ++ αs) ++ y).take k =
-         (x ++ αs ++ y).take k
-    rw [show x ++ (αs ++ FreeMonoid.toList w ++ αs) ++ y =
-            (x ++ αs) ++ (FreeMonoid.toList w ++ αs ++ y) by
+    show (x ++ (αs ++ w ++ αs) ++ y).take k = (x ++ αs ++ y).take k
+    rw [show x ++ (αs ++ w ++ αs) ++ y = (x ++ αs) ++ (w ++ αs ++ y) by
           simp [List.append_assoc],
         show x ++ αs ++ y = (x ++ αs) ++ y by simp [List.append_assoc]]
-    have h_xαs_len : k ≤ (x ++ αs).length := by
-      rw [List.length_append]; omega
-    rw [List.take_append_of_le_length h_xαs_len,
-        List.take_append_of_le_length h_xαs_len]
+    have h_xαs_len : k ≤ (x ++ αs).length := by rw [List.length_append]; omega
+    rw [List.take_append_of_le_length h_xαs_len, List.take_append_of_le_length h_xαs_len]
   · -- takeAt_right k matches: both end with αs ++ y.
-    show Edge.right.takeAt k (x ++ (αs ++ FreeMonoid.toList w ++ αs) ++ y) =
+    show Edge.right.takeAt k (x ++ (αs ++ w ++ αs) ++ y) =
          Edge.right.takeAt k (x ++ αs ++ y)
-    rw [show x ++ (αs ++ FreeMonoid.toList w ++ αs) ++ y =
-            (x ++ αs ++ FreeMonoid.toList w) ++ (αs ++ y) by
+    rw [show x ++ (αs ++ w ++ αs) ++ y = (x ++ αs ++ w) ++ (αs ++ y) by
           simp [List.append_assoc],
         show x ++ αs ++ y = x ++ (αs ++ y) by simp [List.append_assoc]]
-    have h_αsy_len : k ≤ (αs ++ y).length := by
-      rw [List.length_append]; omega
-    rw [takeAt_right_append_left_absorb (x ++ αs ++ FreeMonoid.toList w)
-          (αs ++ y) h_αsy_len,
+    have h_αsy_len : k ≤ (αs ++ y).length := by rw [List.length_append]; omega
+    rw [takeAt_right_append_left_absorb (x ++ αs ++ w) (αs ++ y) h_αsy_len,
         takeAt_right_append_left_absorb x (αs ++ y) h_αsy_len]
 
 /-! #### Lambert Prop 58 — reverse direction -/
@@ -515,26 +372,22 @@ theorem isGeneralizedDefinite_of_satisfies_kGeneralizedDefiniteEquation
       rw [← h_w₂_drop]; exact (List.take_append_drop _ _).symm
     -- Way 1: αs-sandwich gives `[w₁ ++ w₂] = [w₂]`, by absorbing
     -- the `αs ++ b₁ ++ αs` block into `αs`.
-    have h_αs_eq : L.toSyntacticMonoid (FreeMonoid.ofList (w₁ ++ w₂)) =
-        L.toSyntacticMonoid (FreeMonoid.ofList w₂) := by
+    have h_αs_eq : L.syntacticClass (w₁ ++ w₂) = L.syntacticClass w₂ := by
       conv_lhs => rw [hw₁_αs, hw₂_αs,
         show (αs ++ b₁) ++ (αs ++ b₂) = (αs ++ b₁ ++ αs) ++ b₂ by
           simp [List.append_assoc]]
-      rw [FreeMonoid.ofList_append, MonoidHom.map_mul,
-        syntacticCon_of_kGeneralizedDefiniteEquation h αs b₁ hαs_len,
-        ← MonoidHom.map_mul, ← FreeMonoid.ofList_append, ← hw₂_αs]
+      rw [syntacticClass_append, syntacticClass_of_kGeneralizedDefiniteEquation h αs b₁ hαs_len,
+        ← syntacticClass_append, ← hw₂_αs]
     -- Way 2: βs-sandwich gives `[w₁ ++ w₂] = [w₁]`, by absorbing
     -- the `βs ++ c₂ ++ βs` block into `βs`.
-    have h_βs_eq : L.toSyntacticMonoid (FreeMonoid.ofList (w₁ ++ w₂)) =
-        L.toSyntacticMonoid (FreeMonoid.ofList w₁) := by
+    have h_βs_eq : L.syntacticClass (w₁ ++ w₂) = L.syntacticClass w₁ := by
       conv_lhs => rw [hw₁_βs, hw₂_βs,
         show (c₁ ++ βs) ++ (c₂ ++ βs) = c₁ ++ (βs ++ c₂ ++ βs) by
           simp [List.append_assoc]]
-      rw [FreeMonoid.ofList_append, MonoidHom.map_mul,
-        syntacticCon_of_kGeneralizedDefiniteEquation h βs c₂ hβs_len,
-        ← MonoidHom.map_mul, ← FreeMonoid.ofList_append, ← hw₁_βs]
+      rw [syntacticClass_append, syntacticClass_of_kGeneralizedDefiniteEquation h βs c₂ hβs_len,
+        ← syntacticClass_append, ← hw₁_βs]
     -- Combine: `[w₁] = [w₂]`, hence `w₁ ≡_L w₂`.
-    exact mem_iff_of_syntacticCon (Quotient.exact (h_βs_eq.symm.trans h_αs_eq))
+    exact mem_iff_of_syntacticClass_eq (h_βs_eq.symm.trans h_αs_eq)
   · -- Short case: `|w₁| < k`. Then `Edge.left.takeAt k w₁ = w₁`, so
     -- the prefix equality yields `w₁ = Edge.left.takeAt k w₂`, which
     -- forces `|w₂| ≤ k` (otherwise the takeAt has length `k > |w₁|`).

--- a/Linglib/Core/Computability/Subregular/Language/Algebra/Pin.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Algebra/Pin.lean
@@ -24,7 +24,7 @@ syntactic monoid:
 | `𝒩` (co/finite) | both `𝒟`'s and `𝒦`'s | both-sided absorbing |
 | `ℒℐ` (generalized definite) | `[w]^ω · s · [w]^ω = [w]^ω` | sandwich-absorbing |
 
-Where `[w]^ω = Monoid.omegaPow (L.toSyntacticMonoid (FreeMonoid.ofList w))`
+Where `[w]^ω = Monoid.omegaPow (L.syntacticClass w)`
 is the unique idempotent in the cyclic submonoid of `[w]` (see
 `Linglib/Core/Algebra/IdempotentPower.lean`). The variables `s` range
 over `L.syntacticMonoid` and `w` over non-empty `List α`
@@ -97,8 +97,8 @@ omega-power equation, not Lambert-specific — hence the namespace is
 `Language` (no author-named namespace). -/
 def pinDefiniteEquation (L : Language α) [Finite L.syntacticMonoid] : Prop :=
   ∀ (s : L.syntacticMonoid) (w : List α), w ≠ [] →
-    s * Monoid.omegaPow (L.toSyntacticMonoid (FreeMonoid.ofList w)) =
-    Monoid.omegaPow (L.toSyntacticMonoid (FreeMonoid.ofList w))
+    s * Monoid.omegaPow (L.syntacticClass w) =
+    Monoid.omegaPow (L.syntacticClass w)
 
 -- ============================================================================
 -- §1. FreeMonoid power length
@@ -123,11 +123,11 @@ of length `≥ k` is **left-absorbing**. -/
 private lemma left_absorbing_of_kDefiniteEquation {L : Language α} {k : ℕ}
     (hkEq : Language.kDefiniteEquation L k)
     {v : List α} (hv : k ≤ v.length) (s : L.syntacticMonoid) :
-    s * L.toSyntacticMonoid (FreeMonoid.ofList v) =
-    L.toSyntacticMonoid (FreeMonoid.ofList v) := by
-  set vM := L.toSyntacticMonoid (FreeMonoid.ofList v) with hvM_def
+    s * L.syntacticClass v =
+    L.syntacticClass v := by
+  set vM := L.syntacticClass v with hvM_def
   set suf := Edge.right.takeAt k v with hsuf_def
-  set sufM := L.toSyntacticMonoid (FreeMonoid.ofList suf) with hsufM_def
+  set sufM := L.syntacticClass suf with hsufM_def
   have hsuf_len : suf.length = k := by
     show (v.drop (v.length - k)).length = k
     rw [List.length_drop]; omega
@@ -135,8 +135,8 @@ private lemma left_absorbing_of_kDefiniteEquation {L : Language α} {k : ℕ}
     show v = v.take (v.length - k) ++ v.drop (v.length - k)
     exact (List.take_append_drop _ _).symm
   have hvM_eq_sufM : vM = sufM := by
-    rw [hvM_def, hv_decomp, FreeMonoid.ofList_append, MonoidHom.map_mul]
-    exact hkEq (L.toSyntacticMonoid (FreeMonoid.ofList (v.take (v.length - k))))
+    rw [hvM_def, hv_decomp, syntacticClass_append]
+    exact hkEq (L.syntacticClass (v.take (v.length - k)))
                 suf hsuf_len
   rw [hvM_eq_sufM]
   exact hkEq s suf hsuf_len
@@ -159,7 +159,7 @@ theorem IsDefinite.satisfies_pinDefiniteEquation
     {L : Language α} {k : ℕ} [Finite L.syntacticMonoid]
     (hk : L.IsDefinite k) : pinDefiniteEquation L := by
   intro s w hw
-  set wM := L.toSyntacticMonoid (FreeMonoid.ofList w) with hwM_def
+  set wM := L.syntacticClass w with hwM_def
   have hkEq := IsDefinite.satisfies_kDefiniteEquation hk
   by_cases hk0 : k = 0
   · subst hk0
@@ -181,10 +181,10 @@ theorem IsDefinite.satisfies_pinDefiniteEquation
       have h1 : k ≤ N * k := Nat.le_mul_of_pos_left k hN_pos
       have h2 : N * k ≤ N * k * w.length := Nat.le_mul_of_pos_right (N * k) hw_len
       omega
-    have hv_eq : L.toSyntacticMonoid (FreeMonoid.ofList v) = wM ^ (N * k) := by
-      have h_id : (FreeMonoid.ofList v : FreeMonoid α) =
-                  (FreeMonoid.ofList w) ^ (N * k) := rfl
-      rw [h_id, MonoidHom.map_pow]
+    have hv_eq : L.syntacticClass v = wM ^ (N * k) := by
+      rw [hwM_def]
+      simp only [syntacticClass]
+      rw [show FreeMonoid.ofList v = (FreeMonoid.ofList w) ^ (N * k) from rfl, map_pow]
     rw [← hv_eq]
     exact left_absorbing_of_kDefiniteEquation hkEq hv_len s
 
@@ -200,11 +200,11 @@ private lemma left_absorbing_of_pin_pigeonhole
     (h : pinDefiniteEquation L)
     {v : List α}
     {i_lo i_hi : ℕ} (hij : i_lo < i_hi) (hi_hi_le : i_hi ≤ v.length)
-    (h_eq : L.toSyntacticMonoid (FreeMonoid.ofList (v.take i_lo)) =
-            L.toSyntacticMonoid (FreeMonoid.ofList (v.take i_hi)))
+    (h_eq : L.syntacticClass (v.take i_lo) =
+            L.syntacticClass (v.take i_hi))
     (s : L.syntacticMonoid) :
-    s * L.toSyntacticMonoid (FreeMonoid.ofList v) =
-    L.toSyntacticMonoid (FreeMonoid.ofList v) := by
+    s * L.syntacticClass v =
+    L.syntacticClass v := by
   -- Decompose v = pre ++ middle ++ suf, where pre has length i_lo,
   -- middle has length (i_hi - i_lo), suf is the rest.
   set pre := v.take i_lo with hpre_def
@@ -226,13 +226,13 @@ private lemma left_absorbing_of_pin_pigeonhole
   have h_v_decomp : v = pre ++ middle ++ suf := by
     rw [show pre ++ middle = v.take i_hi from h_take_j_decomp.symm, hsuf_def,
         List.take_append_drop]
-  set preM := L.toSyntacticMonoid (FreeMonoid.ofList pre) with hpreM_def
-  set middleM := L.toSyntacticMonoid (FreeMonoid.ofList middle) with hmiddleM_def
-  set sufM := L.toSyntacticMonoid (FreeMonoid.ofList suf) with hsufM_def
+  set preM := L.syntacticClass pre with hpreM_def
+  set middleM := L.syntacticClass middle with hmiddleM_def
+  set sufM := L.syntacticClass suf with hsufM_def
   -- [v.take i_hi] = preM * middleM
-  have h_take_j_M : L.toSyntacticMonoid (FreeMonoid.ofList (v.take i_hi)) =
+  have h_take_j_M : L.syntacticClass (v.take i_hi) =
                     preM * middleM := by
-    rw [h_take_j_decomp, FreeMonoid.ofList_append, MonoidHom.map_mul]
+    rw [h_take_j_decomp, syntacticClass_append]
   -- preM = preM * middleM (from pigeonhole)
   have h_pre_idemp : preM = preM * middleM := h_eq.trans h_take_j_M
   -- preM = preM * middleM^n for all n ≥ 0
@@ -250,12 +250,12 @@ private lemma left_absorbing_of_pin_pigeonhole
   -- preM = omegaPow middleM
   have h_pre_eq : preM = Monoid.omegaPow middleM := h_pre_omega.trans h_pin
   -- [v] = preM * middleM * sufM
-  have h_v_M : L.toSyntacticMonoid (FreeMonoid.ofList v) = preM * middleM * sufM := by
-    rw [h_v_decomp, FreeMonoid.ofList_append, MonoidHom.map_mul,
-        FreeMonoid.ofList_append, MonoidHom.map_mul]
+  have h_v_M : L.syntacticClass v = preM * middleM * sufM := by
+    rw [h_v_decomp, syntacticClass_append,
+        syntacticClass_append]
   -- preM * middleM = preM (h_pre_idemp reversed)
   -- So [v] = preM * sufM = omegaPow middleM * sufM
-  have h_v_omega : L.toSyntacticMonoid (FreeMonoid.ofList v) =
+  have h_v_omega : L.syntacticClass v =
                    Monoid.omegaPow middleM * sufM := by
     rw [h_v_M, ← h_pre_idemp, h_pre_eq]
   -- s * [v] = s * (omegaPow middleM * sufM) = (s * omegaPow middleM) * sufM
@@ -269,8 +269,8 @@ private lemma left_absorbing_of_pinDefiniteEquation
     (h : pinDefiniteEquation L)
     {v : List α} (hv : Nat.card L.syntacticMonoid ≤ v.length)
     (s : L.syntacticMonoid) :
-    s * L.toSyntacticMonoid (FreeMonoid.ofList v) =
-    L.toSyntacticMonoid (FreeMonoid.ofList v) := by
+    s * L.syntacticClass v =
+    L.syntacticClass v := by
   classical
   haveI : Fintype L.syntacticMonoid := Fintype.ofFinite _
   have hNat : Nat.card L.syntacticMonoid = Fintype.card L.syntacticMonoid :=
@@ -283,7 +283,7 @@ private lemma left_absorbing_of_pinDefiniteEquation
   obtain ⟨i, j, h_ne, h_eq⟩ :=
     Fintype.exists_ne_map_eq_of_card_lt
       (fun n : Fin (Fintype.card L.syntacticMonoid + 1) =>
-        L.toSyntacticMonoid (FreeMonoid.ofList (v.take n.val)))
+        L.syntacticClass (v.take n.val))
       hcard
   have h_val_ne : i.val ≠ j.val := fun h => h_ne (Fin.ext h)
   -- Bound on j.val (and i.val): ≤ |M| ≤ v.length.
@@ -326,8 +326,8 @@ Mirror of `pinDefiniteEquation` with right-multiplication instead of
 left. Same alphabet-relativized non-empty `w` quantifier. -/
 def pinReverseDefiniteEquation (L : Language α) [Finite L.syntacticMonoid] : Prop :=
   ∀ (s : L.syntacticMonoid) (w : List α), w ≠ [] →
-    Monoid.omegaPow (L.toSyntacticMonoid (FreeMonoid.ofList w)) * s =
-    Monoid.omegaPow (L.toSyntacticMonoid (FreeMonoid.ofList w))
+    Monoid.omegaPow (L.syntacticClass w) * s =
+    Monoid.omegaPow (L.syntacticClass w)
 
 /-- **Right-absorbing from `kReverseDefiniteEquation`**: mirror of
 `left_absorbing_of_kDefiniteEquation`. The syntactic class of any word
@@ -336,11 +336,11 @@ of length `≥ k` is right-absorbing, decomposing `v = pre ++ suf` with
 private lemma right_absorbing_of_kReverseDefiniteEquation {L : Language α} {k : ℕ}
     (hkEq : Language.kReverseDefiniteEquation L k)
     {v : List α} (hv : k ≤ v.length) (s : L.syntacticMonoid) :
-    L.toSyntacticMonoid (FreeMonoid.ofList v) * s =
-    L.toSyntacticMonoid (FreeMonoid.ofList v) := by
-  set vM := L.toSyntacticMonoid (FreeMonoid.ofList v) with hvM_def
+    L.syntacticClass v * s =
+    L.syntacticClass v := by
+  set vM := L.syntacticClass v with hvM_def
   set pre := Edge.left.takeAt k v with hpre_def
-  set preM := L.toSyntacticMonoid (FreeMonoid.ofList pre) with hpreM_def
+  set preM := L.syntacticClass pre with hpreM_def
   have hpre_len : pre.length = k := by
     show (v.take k).length = k
     rw [List.length_take]; omega
@@ -348,8 +348,8 @@ private lemma right_absorbing_of_kReverseDefiniteEquation {L : Language α} {k :
     show v = v.take k ++ v.drop k
     exact (List.take_append_drop _ _).symm
   have hvM_eq_preM : vM = preM := by
-    rw [hvM_def, hv_decomp, FreeMonoid.ofList_append, MonoidHom.map_mul]
-    exact hkEq (L.toSyntacticMonoid (FreeMonoid.ofList (v.drop k))) pre hpre_len
+    rw [hvM_def, hv_decomp, syntacticClass_append]
+    exact hkEq (L.syntacticClass (v.drop k)) pre hpre_len
   rw [hvM_eq_preM]
   exact hkEq s pre hpre_len
 
@@ -360,7 +360,7 @@ theorem IsReverseDefinite.satisfies_pinReverseDefiniteEquation
     {L : Language α} {k : ℕ} [Finite L.syntacticMonoid]
     (hk : L.IsReverseDefinite k) : pinReverseDefiniteEquation L := by
   intro s w hw
-  set wM := L.toSyntacticMonoid (FreeMonoid.ofList w) with hwM_def
+  set wM := L.syntacticClass w with hwM_def
   have hkEq := IsReverseDefinite.satisfies_kReverseDefiniteEquation hk
   by_cases hk0 : k = 0
   · subst hk0
@@ -382,10 +382,10 @@ theorem IsReverseDefinite.satisfies_pinReverseDefiniteEquation
       have h1 : k ≤ N * k := Nat.le_mul_of_pos_left k hN_pos
       have h2 : N * k ≤ N * k * w.length := Nat.le_mul_of_pos_right (N * k) hw_len
       omega
-    have hv_eq : L.toSyntacticMonoid (FreeMonoid.ofList v) = wM ^ (N * k) := by
-      have h_id : (FreeMonoid.ofList v : FreeMonoid α) =
-                  (FreeMonoid.ofList w) ^ (N * k) := rfl
-      rw [h_id, MonoidHom.map_pow]
+    have hv_eq : L.syntacticClass v = wM ^ (N * k) := by
+      rw [hwM_def]
+      simp only [syntacticClass]
+      rw [show FreeMonoid.ofList v = (FreeMonoid.ofList w) ^ (N * k) from rfl, map_pow]
     rw [← hv_eq]
     exact right_absorbing_of_kReverseDefiniteEquation hkEq hv_len s
 
@@ -402,12 +402,13 @@ private lemma right_absorbing_of_pin_pigeonhole
     (h : pinReverseDefiniteEquation L)
     {v : List α}
     {i_lo i_hi : ℕ} (hij : i_lo < i_hi) (hi_hi_le : i_hi ≤ v.length)
-    (h_eq : L.toSyntacticMonoid (FreeMonoid.ofList (v.drop i_lo)) =
-            L.toSyntacticMonoid (FreeMonoid.ofList (v.drop i_hi)))
+    (h_eq : L.syntacticClass (v.drop i_lo) =
+            L.syntacticClass (v.drop i_hi))
     (s : L.syntacticMonoid) :
-    L.toSyntacticMonoid (FreeMonoid.ofList v) * s =
-    L.toSyntacticMonoid (FreeMonoid.ofList v) := by
-  -- v = pre ++ middle ++ suf, where pre = v.take i_lo, middle = v.drop i_lo .take (i_hi - i_lo), suf = v.drop i_hi.
+    L.syntacticClass v * s =
+    L.syntacticClass v := by
+  -- v = pre ++ middle ++ suf, where pre = v.take i_lo,
+  -- middle = (v.drop i_lo).take (i_hi - i_lo), suf = v.drop i_hi.
   set pre := v.take i_lo with hpre_def
   set middle := (v.drop i_lo).take (i_hi - i_lo) with hmiddle_def
   set suf := v.drop i_hi with hsuf_def
@@ -433,13 +434,13 @@ private lemma right_absorbing_of_pin_pigeonhole
     rw [show pre ++ middle ++ suf = pre ++ (middle ++ suf) by simp [List.append_assoc],
         ← h_drop_lo_decomp]
     exact (List.take_append_drop _ _).symm
-  set preM := L.toSyntacticMonoid (FreeMonoid.ofList pre) with hpreM_def
-  set middleM := L.toSyntacticMonoid (FreeMonoid.ofList middle) with hmiddleM_def
-  set sufM := L.toSyntacticMonoid (FreeMonoid.ofList suf) with hsufM_def
+  set preM := L.syntacticClass pre with hpreM_def
+  set middleM := L.syntacticClass middle with hmiddleM_def
+  set sufM := L.syntacticClass suf with hsufM_def
   -- [v.drop i_lo] = middleM * sufM
-  have h_drop_lo_M : L.toSyntacticMonoid (FreeMonoid.ofList (v.drop i_lo)) =
+  have h_drop_lo_M : L.syntacticClass (v.drop i_lo) =
                      middleM * sufM := by
-    rw [h_drop_lo_decomp, FreeMonoid.ofList_append, MonoidHom.map_mul]
+    rw [h_drop_lo_decomp, syntacticClass_append]
   -- Pigeonhole gives [v.drop i_lo] = [v.drop i_hi] = sufM. With h_drop_lo_M
   -- expressing [v.drop i_lo] as middleM * sufM, transitivity closes.
   have h_mid_idemp : middleM * sufM = sufM := h_drop_lo_M.symm.trans h_eq
@@ -458,14 +459,14 @@ private lemma right_absorbing_of_pin_pigeonhole
   -- So sufM = omegaPow middleM.
   have h_suf_eq : sufM = Monoid.omegaPow middleM := h_omega_idemp.symm.trans h_pin
   -- [v] = preM * middleM * sufM
-  have h_v_M : L.toSyntacticMonoid (FreeMonoid.ofList v) = preM * middleM * sufM := by
-    rw [h_v_decomp, FreeMonoid.ofList_append, MonoidHom.map_mul,
-        FreeMonoid.ofList_append, MonoidHom.map_mul]
+  have h_v_M : L.syntacticClass v = preM * middleM * sufM := by
+    rw [h_v_decomp, syntacticClass_append,
+        syntacticClass_append]
   -- Substitute h_suf_eq → preM * middleM * omegaPow middleM
   -- Simplify middleM * omegaPow middleM = ? Hmm.
   -- Actually: [v] = preM * (middleM * sufM) = preM * sufM (by h_mid_idemp).
   -- And sufM = omegaPow middleM, so [v] = preM * omegaPow middleM.
-  have h_v_omega : L.toSyntacticMonoid (FreeMonoid.ofList v) =
+  have h_v_omega : L.syntacticClass v =
                    preM * Monoid.omegaPow middleM := by
     rw [h_v_M, mul_assoc, h_mid_idemp, h_suf_eq]
   -- For any s: [v] * s = preM * omegaPow middleM * s = preM * omegaPow middleM = [v]
@@ -478,8 +479,8 @@ private lemma right_absorbing_of_pinReverseDefiniteEquation
     (h : pinReverseDefiniteEquation L)
     {v : List α} (hv : Nat.card L.syntacticMonoid ≤ v.length)
     (s : L.syntacticMonoid) :
-    L.toSyntacticMonoid (FreeMonoid.ofList v) * s =
-    L.toSyntacticMonoid (FreeMonoid.ofList v) := by
+    L.syntacticClass v * s =
+    L.syntacticClass v := by
   classical
   haveI : Fintype L.syntacticMonoid := Fintype.ofFinite _
   have hNat : Nat.card L.syntacticMonoid = Fintype.card L.syntacticMonoid :=
@@ -492,7 +493,7 @@ private lemma right_absorbing_of_pinReverseDefiniteEquation
   obtain ⟨i, j, h_ne, h_eq⟩ :=
     Fintype.exists_ne_map_eq_of_card_lt
       (fun n : Fin (Fintype.card L.syntacticMonoid + 1) =>
-        L.toSyntacticMonoid (FreeMonoid.ofList (v.drop n.val)))
+        L.syntacticClass (v.drop n.val))
       hcard
   have h_val_ne : i.val ≠ j.val := fun h => h_ne (Fin.ext h)
   have hi_le : i.val ≤ v.length := le_trans (Nat.lt_succ_iff.mp i.isLt) hv
@@ -585,9 +586,9 @@ equivalent to the more general two-variable form
 omega-power idempotence. -/
 def pinGeneralizedDefiniteEquation (L : Language α) [Finite L.syntacticMonoid] : Prop :=
   ∀ (s : L.syntacticMonoid) (w : List α), w ≠ [] →
-    Monoid.omegaPow (L.toSyntacticMonoid (FreeMonoid.ofList w)) * s *
-    Monoid.omegaPow (L.toSyntacticMonoid (FreeMonoid.ofList w)) =
-    Monoid.omegaPow (L.toSyntacticMonoid (FreeMonoid.ofList w))
+    Monoid.omegaPow (L.syntacticClass w) * s *
+    Monoid.omegaPow (L.syntacticClass w) =
+    Monoid.omegaPow (L.syntacticClass w)
 
 /-- **Pin's ℒℐ-theorem (forward direction)**: a generalized-`k`-definite
 language's syntactic monoid satisfies the LI omega-power equation.
@@ -603,7 +604,7 @@ theorem IsGeneralizedDefinite.satisfies_pinGeneralizedDefiniteEquation
     (hk : L.IsGeneralizedDefinite k) :
     pinGeneralizedDefiniteEquation L := by
   intro s w hw
-  set wM := L.toSyntacticMonoid (FreeMonoid.ofList w) with hwM_def
+  set wM := L.syntacticClass w with hwM_def
   by_cases hk0 : k = 0
   · -- k = 0: IsGenDef 0 L means ∀ w₁ w₂, w₁ ∈ L ↔ w₂ ∈ L (vacuous prefix/suffix).
     -- So L is constant: L = ∅ or L = univ. Either way M is trivial.
@@ -641,52 +642,29 @@ theorem IsGeneralizedDefinite.satisfies_pinGeneralizedDefiniteEquation
       have h1 : k ≤ N * k := Nat.le_mul_of_pos_left k hN_pos
       have h2 : N * k ≤ N * k * w.length := Nat.le_mul_of_pos_right (N * k) hw_len
       omega
-    have hv_eq : L.toSyntacticMonoid (FreeMonoid.ofList v) = wM ^ (N * k) := by
-      have h_id : (FreeMonoid.ofList v : FreeMonoid α) =
-                  (FreeMonoid.ofList w) ^ (N * k) := rfl
-      rw [h_id, MonoidHom.map_pow]
+    have hv_eq : L.syntacticClass v = wM ^ (N * k) := by
+      rw [hwM_def]
+      simp only [syntacticClass]
+      rw [show FreeMonoid.ofList v = (FreeMonoid.ofList w) ^ (N * k) from rfl, map_pow]
     rw [← hv_eq]
     -- Goal: [v] · s · [v] = [v]. Apply IsGenDef k L directly via context-extension.
-    obtain ⟨s', hs'⟩ := Quotient.exists_rep s
-    rw [show s = L.toSyntacticMonoid s' from hs'.symm]
-    rw [show L.toSyntacticMonoid (FreeMonoid.ofList v) *
-            L.toSyntacticMonoid s' *
-            L.toSyntacticMonoid (FreeMonoid.ofList v) =
-        L.toSyntacticMonoid (FreeMonoid.ofList v * s' * FreeMonoid.ofList v) by
-      rw [MonoidHom.map_mul, MonoidHom.map_mul]]
-    apply Quotient.sound
-    refine (syntacticCon_iff L).mpr ?_
+    obtain ⟨s', rfl⟩ := L.syntacticClass_surjective s
+    rw [← syntacticClass_append, ← syntacticClass_append, syntacticClass_eq_iff]
     intro x y
-    show x ++ FreeMonoid.toList (FreeMonoid.ofList v * s' * FreeMonoid.ofList v) ++ y ∈ L ↔
-         x ++ FreeMonoid.toList (FreeMonoid.ofList v) ++ y ∈ L
-    have hwmul : FreeMonoid.toList (FreeMonoid.ofList v * s' * FreeMonoid.ofList v) =
-                 v ++ FreeMonoid.toList s' ++ v := rfl
-    have hvId : FreeMonoid.toList (FreeMonoid.ofList v) = v := rfl
-    rw [hwmul, hvId]
-    -- Apply IsGenDef k L to (x ++ v ++ toList s' ++ v ++ y, x ++ v ++ y).
+    -- Apply IsGenDef k L to (x ++ v ++ s' ++ v ++ y, x ++ v ++ y).
     apply isGeneralizedDefinite_iff_edges.mp hk
     · -- takeAt_left k matches: both have x ++ v as prefix; |x ++ v| ≥ k.
-      show (x ++ (v ++ FreeMonoid.toList s' ++ v) ++ y).take k =
-           (x ++ v ++ y).take k
-      rw [show x ++ (v ++ FreeMonoid.toList s' ++ v) ++ y =
-              (x ++ v) ++ (FreeMonoid.toList s' ++ v ++ y) by
-            simp [List.append_assoc],
-          show x ++ v ++ y = (x ++ v) ++ y from by simp [List.append_assoc]]
-      have h_xv_len : k ≤ (x ++ v).length := by
-        rw [List.length_append]; omega
-      rw [List.take_append_of_le_length h_xv_len,
-          List.take_append_of_le_length h_xv_len]
+      show (x ++ (v ++ s' ++ v) ++ y).take k = (x ++ v ++ y).take k
+      rw [show x ++ (v ++ s' ++ v) ++ y = (x ++ v) ++ (s' ++ v ++ y) by simp [List.append_assoc],
+          show x ++ v ++ y = (x ++ v) ++ y by simp [List.append_assoc]]
+      have h_xv_len : k ≤ (x ++ v).length := by rw [List.length_append]; omega
+      rw [List.take_append_of_le_length h_xv_len, List.take_append_of_le_length h_xv_len]
     · -- takeAt_right k matches: both end with v ++ y; |v ++ y| ≥ k.
-      show Edge.right.takeAt k (x ++ (v ++ FreeMonoid.toList s' ++ v) ++ y) =
-           Edge.right.takeAt k (x ++ v ++ y)
-      rw [show x ++ (v ++ FreeMonoid.toList s' ++ v) ++ y =
-              (x ++ v ++ FreeMonoid.toList s') ++ (v ++ y) by
-            simp [List.append_assoc],
+      show Edge.right.takeAt k (x ++ (v ++ s' ++ v) ++ y) = Edge.right.takeAt k (x ++ v ++ y)
+      rw [show x ++ (v ++ s' ++ v) ++ y = (x ++ v ++ s') ++ (v ++ y) by simp [List.append_assoc],
           show x ++ v ++ y = x ++ (v ++ y) by simp [List.append_assoc]]
-      have h_vy_len : k ≤ (v ++ y).length := by
-        rw [List.length_append]; omega
-      rw [takeAt_right_append_left_absorb (x ++ v ++ FreeMonoid.toList s')
-            (v ++ y) h_vy_len,
+      have h_vy_len : k ≤ (v ++ y).length := by rw [List.length_append]; omega
+      rw [takeAt_right_append_left_absorb (x ++ v ++ s') (v ++ y) h_vy_len,
           takeAt_right_append_left_absorb x (v ++ y) h_vy_len]
 
 /-- Helper for the LI reverse direction: given a pigeonhole pair
@@ -710,12 +688,12 @@ private lemma sandwich_absorbing_of_pin_pigeonhole
     (h : pinGeneralizedDefiniteEquation L)
     {v : List α}
     {i_lo i_hi : ℕ} (hij : i_lo < i_hi) (hi_hi_le : i_hi ≤ v.length)
-    (h_eq : L.toSyntacticMonoid (FreeMonoid.ofList (v.take i_lo)) =
-            L.toSyntacticMonoid (FreeMonoid.ofList (v.take i_hi)))
+    (h_eq : L.syntacticClass (v.take i_lo) =
+            L.syntacticClass (v.take i_hi))
     (s : L.syntacticMonoid) :
-    L.toSyntacticMonoid (FreeMonoid.ofList v) * s *
-    L.toSyntacticMonoid (FreeMonoid.ofList v) =
-    L.toSyntacticMonoid (FreeMonoid.ofList v) := by
+    L.syntacticClass v * s *
+    L.syntacticClass v =
+    L.syntacticClass v := by
   set pre := v.take i_lo with hpre_def
   set middle := (v.drop i_lo).take (i_hi - i_lo) with hmiddle_def
   set suf := v.drop i_hi with hsuf_def
@@ -735,12 +713,12 @@ private lemma sandwich_absorbing_of_pin_pigeonhole
   have h_v_decomp : v = pre ++ middle ++ suf := by
     rw [show pre ++ middle = v.take i_hi from h_take_j_decomp.symm, hsuf_def,
         List.take_append_drop]
-  set preM := L.toSyntacticMonoid (FreeMonoid.ofList pre) with hpreM_def
-  set middleM := L.toSyntacticMonoid (FreeMonoid.ofList middle) with hmiddleM_def
-  set sufM := L.toSyntacticMonoid (FreeMonoid.ofList suf) with hsufM_def
-  have h_take_j_M : L.toSyntacticMonoid (FreeMonoid.ofList (v.take i_hi)) =
+  set preM := L.syntacticClass pre with hpreM_def
+  set middleM := L.syntacticClass middle with hmiddleM_def
+  set sufM := L.syntacticClass suf with hsufM_def
+  have h_take_j_M : L.syntacticClass (v.take i_hi) =
                     preM * middleM := by
-    rw [h_take_j_decomp, FreeMonoid.ofList_append, MonoidHom.map_mul]
+    rw [h_take_j_decomp, syntacticClass_append]
   have h_pre_idemp : preM = preM * middleM := h_eq.trans h_take_j_M
   have h_iter : ∀ n : ℕ, preM = preM * middleM ^ n := by
     intro n
@@ -750,10 +728,10 @@ private lemma sandwich_absorbing_of_pin_pigeonhole
   have h_pre_omega : preM = preM * Monoid.omegaPow middleM := by
     rw [Monoid.omegaPow_eq_pow]; exact h_iter _
   -- [v] = preM * middleM * sufM = preM * sufM = preM * ω(middleM) * sufM.
-  have h_v_omega : L.toSyntacticMonoid (FreeMonoid.ofList v) =
+  have h_v_omega : L.syntacticClass v =
                    preM * Monoid.omegaPow middleM * sufM := by
-    rw [h_v_decomp, FreeMonoid.ofList_append, MonoidHom.map_mul,
-        FreeMonoid.ofList_append, MonoidHom.map_mul,
+    rw [h_v_decomp, syntacticClass_append,
+        syntacticClass_append,
         ← h_pre_idemp, ← h_pre_omega]
   -- Apply Pin LI: ω · (sufM * s * preM) · ω = ω.
   have h_pin := h (sufM * s * preM) middle h_middle_ne
@@ -776,9 +754,9 @@ private lemma sandwich_absorbing_of_pinGeneralizedDefiniteEquation
     (h : pinGeneralizedDefiniteEquation L)
     {v : List α} (hv : Nat.card L.syntacticMonoid ≤ v.length)
     (s : L.syntacticMonoid) :
-    L.toSyntacticMonoid (FreeMonoid.ofList v) * s *
-    L.toSyntacticMonoid (FreeMonoid.ofList v) =
-    L.toSyntacticMonoid (FreeMonoid.ofList v) := by
+    L.syntacticClass v * s *
+    L.syntacticClass v =
+    L.syntacticClass v := by
   classical
   haveI : Fintype L.syntacticMonoid := Fintype.ofFinite _
   have hNat : Nat.card L.syntacticMonoid = Fintype.card L.syntacticMonoid :=
@@ -791,7 +769,7 @@ private lemma sandwich_absorbing_of_pinGeneralizedDefiniteEquation
   obtain ⟨i, j, h_ne, h_eq⟩ :=
     Fintype.exists_ne_map_eq_of_card_lt
       (fun n : Fin (Fintype.card L.syntacticMonoid + 1) =>
-        L.toSyntacticMonoid (FreeMonoid.ofList (v.take n.val)))
+        L.syntacticClass (v.take n.val))
       hcard
   have h_val_ne : i.val ≠ j.val := fun h => h_ne (Fin.ext h)
   have hi_le : i.val ≤ v.length := le_trans (Nat.lt_succ_iff.mp i.isLt) hv

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -12,100 +12,120 @@ The *syntactic monoid* of a language `L : Language α` is the quotient of the fr
 `FreeMonoid α` by the *syntactic congruence*: two words are identified when no two-sided context
 distinguishes them as `L`-members, `∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L`.
 
-We obtain the syntactic congruence as the kernel of the transition action of the minimal DFA
-`L.toDFA` (the *transition monoid* of `L.toDFA`, see
-`Linglib.Core.Computability.TransitionMonoid`), and identify it with the two-sided context
-equivalence via `Language.syntacticCon_iff`. This is the two-sided refinement of
-`Mathlib.Computability.MyhillNerode`, which builds the one-sided right-Nerode quotient
-(`Language.leftQuotient`) and proves regularity ↔ finitely many left quotients. It carries a
-*monoid* structure rather than just a set of states, and its Myhill–Nerode theorem reads
-`L.IsRegular ↔ Finite L.syntacticMonoid`.
+The syntactic congruence is defined directly as this two-sided context equivalence, and identified
+with the kernel of the minimal DFA's transition action (the *transition monoid* of `L.toDFA`, see
+`Linglib.Core.Computability.TransitionMonoid`) via `Language.syntacticCon_eq_ker_transitionHom`.
+This is the two-sided refinement of `Mathlib.Computability.MyhillNerode`, which builds the one-sided
+right-Nerode quotient (`Language.leftQuotient`) and proves regularity ↔ finitely many left
+quotients. It carries a *monoid* structure rather than just a set of states, and its Myhill–Nerode
+theorem reads `L.IsRegular ↔ Finite L.syntacticMonoid`.
 
 ## Main definitions
 
-* `Language.syntacticCon L : Con (FreeMonoid α)`: the syntactic congruence, the kernel of the
-  transition action of `L.toDFA`.
+* `Language.syntacticCon L : Con (FreeMonoid α)`: the syntactic congruence (two-sided context
+  equivalence).
 * `Language.syntacticMonoid L`: the quotient monoid `(syntacticCon L).Quotient`.
 * `Language.toSyntacticMonoid L`: the projection `FreeMonoid α →* L.syntacticMonoid`.
-* `Language.Recognises φ L`: `φ` recognises `L`, i.e. `L` is a union of `φ`-fibres.
+* `Language.syntacticClass L w`: the syntactic class of a word `w : List α`.
+* `Language.Recognizes φ L`: `φ` recognizes `L`, i.e. `L` is a union of `φ`-fibres.
 
 ## Main results
 
-* `Language.syntacticCon_iff`: the syntactic congruence is exactly the two-sided context
-  equivalence `∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L`.
-* `Language.mem_iff_of_syntacticCon`: `L` is saturated by the syntactic congruence.
-* `Language.ker_le_syntacticCon_of_recognises`: the syntactic congruence is the coarsest congruence
-  recognising `L`, so every recognising hom factors through `toSyntacticMonoid` via `Con.lift`.
+* `Language.syntacticClass_eq_iff`: two words share a syntactic class iff no two-sided context
+  distinguishes them, `∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L`.
+* `Language.syntacticCon_eq_ker_transitionHom`: the intrinsic congruence is the kernel of the
+  transition action of `L.toDFA`.
+* `Language.ker_le_syntacticCon_of_recognizes`: the syntactic congruence is the coarsest congruence
+  recognizing `L`, so every recognizing hom factors through `toSyntacticMonoid` via `Con.lift`.
 * `Language.isRegular_iff_finite_syntacticMonoid`: the Myhill–Nerode theorem in monoid form.
 -/
 
-noncomputable section
-
-universe u
-
 namespace Language
 
-variable {α : Type u} (L : Language α)
+variable {α : Type*} (L : Language α)
 
 /-! ### The syntactic congruence and monoid -/
 
-/-- The *syntactic congruence* of `L`, obtained as the kernel of the transition action of `L.toDFA`
-(the transition monoid of the minimal DFA). -/
-def syntacticCon : Con (FreeMonoid α) := Con.ker L.toDFA.transitionHom
+/-- The *syntactic congruence* of `L`: two words are congruent when no two-sided context
+distinguishes them as `L`-members. -/
+def syntacticCon : Con (FreeMonoid α) where
+  r u v := ∀ x y : List α, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L
+  iseqv :=
+    ⟨fun _ _ _ => Iff.rfl, fun h x y => (h x y).symm, fun h h' x y => (h x y).trans (h' x y)⟩
+  mul' {a b c d} hab hcd x y := by
+    have h1 := hab x (c.toList ++ y)
+    have h2 := hcd (x ++ b.toList) y
+    simp only [FreeMonoid.toList_mul, ← List.append_assoc] at h1 h2 ⊢
+    exact h1.trans h2
 
-/-- Evaluating the minimal DFA `L.toDFA` from a quotient state `s` along a word `w` lands on the
-left quotient of `s` by `w`. -/
-@[simp]
-theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
-    (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
-  induction w using List.reverseRecOn <;>
-    simp_all [DFA.evalFrom_append_singleton, step_toDFA, leftQuotient_append]
-
-/-- The kernel of the transition monoid of the minimal DFA is exactly the two-sided context
-equivalence: `u` and `v` are congruent iff they are interchangeable in every two-sided context. -/
+/-- The syntactic congruence is two-sided context equivalence — by definition. -/
 theorem syntacticCon_iff {u v : FreeMonoid α} :
-    L.syntacticCon u v ↔ ∀ x y : List α, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L := by
-  rw [syntacticCon, Con.ker_apply, DFA.transitionHom_eq_iff]
-  constructor
-  · intro h x y
-    have h' := congrArg Subtype.val (h ⟨L.leftQuotient x, ⟨x, rfl⟩⟩)
-    rw [evalFrom_toDFA, evalFrom_toDFA, ← leftQuotient_append, ← leftQuotient_append] at h'
-    rw [← mem_leftQuotient, ← mem_leftQuotient, h']
-  · intro h s
-    apply Subtype.ext
-    obtain ⟨x, hx⟩ := s.2
-    rw [evalFrom_toDFA, evalFrom_toDFA, ← hx, ← leftQuotient_append, ← leftQuotient_append]
-    ext y
-    rw [mem_leftQuotient, mem_leftQuotient]
-    exact h x y
+    L.syntacticCon u v ↔ ∀ x y, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L :=
+  Iff.rfl
 
 variable {L} in
 /-- Words congruent under the syntactic congruence agree on membership of `L`: `L` is saturated by
 `syntacticCon L` (take the empty two-sided context). -/
-theorem mem_iff_of_syntacticCon {u v : FreeMonoid α} (h : L.syntacticCon u v) : u ∈ L ↔ v ∈ L := by
-  have := (syntacticCon_iff L).mp h [] []
+theorem mem_iff_of_syntacticCon {u v : FreeMonoid α} (h : L.syntacticCon u v) :
+    u ∈ L ↔ v ∈ L := by
+  have := h [] []
   simp only [List.nil_append, List.append_nil] at this
   exact this
 
 /-- The *syntactic monoid* of `L`: the quotient of `FreeMonoid α` by the syntactic congruence. -/
-def syntacticMonoid : Type u := (syntacticCon L).Quotient
+def syntacticMonoid : Type _ := (syntacticCon L).Quotient
 
 instance : Monoid (syntacticMonoid L) := inferInstanceAs (Monoid (syntacticCon L).Quotient)
 
 /-- The canonical projection sending each word to its syntactic class; the underlying `Con.mk'`. -/
 def toSyntacticMonoid : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L).mk'
 
+/-- The syntactic projection identifies two words iff they are syntactically congruent. -/
+theorem toSyntacticMonoid_eq_iff {u v : FreeMonoid α} :
+    L.toSyntacticMonoid u = L.toSyntacticMonoid v ↔ L.syntacticCon u v :=
+  Con.eq _
+
+/-! ### The syntactic class of a word -/
+
+/-- The *syntactic class* of a word `w`: its image in the syntactic monoid (the literature's
+`η(w)`, applied to a `List α` rather than a bundled `FreeMonoid α`). -/
+def syntacticClass (w : List α) : L.syntacticMonoid := L.toSyntacticMonoid (FreeMonoid.ofList w)
+
+@[simp] theorem syntacticClass_nil : L.syntacticClass [] = 1 := by simp [syntacticClass]
+
+@[simp] theorem syntacticClass_append (u v : List α) :
+    L.syntacticClass (u ++ v) = L.syntacticClass u * L.syntacticClass v := by
+  simp [syntacticClass, FreeMonoid.ofList_append]
+
+theorem syntacticClass_surjective : Function.Surjective L.syntacticClass := fun s => by
+  obtain ⟨u, rfl⟩ := Quotient.exists_rep s
+  exact ⟨u.toList, congrArg L.toSyntacticMonoid (FreeMonoid.ofList_toList u)⟩
+
+variable {L} in
+/-- Word-level form of `syntacticCon_iff`: two words share a syntactic class iff no two-sided
+context distinguishes them as `L`-members. -/
+theorem syntacticClass_eq_iff {u v : List α} : L.syntacticClass u = L.syntacticClass v ↔
+    ∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L := by
+  simp only [syntacticClass, toSyntacticMonoid_eq_iff, syntacticCon_iff, FreeMonoid.toList_ofList]
+
+variable {L} in
+/-- `L` is saturated by syntactic class: equal class implies equal membership. -/
+theorem mem_iff_of_syntacticClass_eq {u v : List α}
+    (h : L.syntacticClass u = L.syntacticClass v) : u ∈ L ↔ v ∈ L := by
+  simpa using syntacticClass_eq_iff.mp h [] []
+
 /-! ### Universal property -/
 
 variable {L}
 
-/-- `φ` *recognises* `L` when `L` is a union of `φ`-fibres, i.e. `L = φ ⁻¹' S` for some `S ⊆ M`. -/
-def Recognises {M : Type*} [Monoid M] (φ : FreeMonoid α →* M) (L : Language α) : Prop :=
+/-- `φ` *recognizes* `L` when `L` is a union of `φ`-fibres, i.e. `L = φ ⁻¹' S` for some
+`S ⊆ M`. -/
+def Recognizes {M : Type*} [Monoid M] (φ : FreeMonoid α →* M) (L : Language α) : Prop :=
   ∃ S : Set M, L = φ ⁻¹' S
 
-/-- An `L`-recognising hom's kernel lies below `syntacticCon L`, the coarsest such congruence. -/
-theorem ker_le_syntacticCon_of_recognises {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
-    (hrec : Recognises φ L) : Con.ker φ ≤ syntacticCon L := by
+/-- An `L`-recognizing hom's kernel lies below `syntacticCon L`, the coarsest such congruence. -/
+theorem ker_le_syntacticCon_of_recognizes {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
+    (hrec : Recognizes φ L) : Con.ker φ ≤ syntacticCon L := by
   intro u v huv
   rw [syntacticCon_iff]
   obtain ⟨S, rfl⟩ := hrec
@@ -113,11 +133,40 @@ theorem ker_le_syntacticCon_of_recognises {M : Type*} [Monoid M] {φ : FreeMonoi
   intro x y
   simp only [Set.mem_preimage, map_mul, Con.ker_apply.mp huv]
 
+/-! ### Connection to the minimal DFA -/
+
+/-- Evaluating the minimal DFA `L.toDFA` from a quotient state `s` along `w` lands on the left
+quotient of `s` by `w`. -/
+theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
+    (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
+  induction w using List.reverseRecOn <;>
+    simp_all [DFA.evalFrom_append_singleton, step_toDFA, leftQuotient_append]
+
+/-- The intrinsic syntactic congruence is the kernel of the minimal DFA's transition action — the
+two-sided context definition agrees with the transition-monoid quotient. -/
+theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.transitionHom := by
+  ext u v
+  rw [syntacticCon_iff, Con.ker_apply, DFA.transitionHom_eq_iff]
+  constructor
+  · intro h s
+    apply Subtype.ext
+    obtain ⟨x, hx⟩ := s.2
+    rw [evalFrom_toDFA, evalFrom_toDFA, ← hx, ← leftQuotient_append, ← leftQuotient_append]
+    ext y
+    rw [mem_leftQuotient, mem_leftQuotient]
+    exact h x y
+  · intro h x y
+    have h' := congrArg Subtype.val (h ⟨L.leftQuotient x, ⟨x, rfl⟩⟩)
+    rw [evalFrom_toDFA, evalFrom_toDFA, ← leftQuotient_append, ← leftQuotient_append] at h'
+    rw [← mem_leftQuotient, ← mem_leftQuotient, h']
+
 /-! ### Regularity implies a finite syntactic monoid -/
 
 /-- A regular language has a finite syntactic monoid (forward Myhill–Nerode). -/
 theorem finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticMonoid := by
   have : Finite (Set.range L.leftQuotient) := h.finite_range_leftQuotient.to_subtype
+  show Finite (syntacticCon L).Quotient
+  rw [syntacticCon_eq_ker_transitionHom]
   exact Finite.of_equiv _ (DFA.transitionMonoidEquiv L.toDFA).symm.toEquiv
 
 /-! ### A finite syntactic monoid implies regularity -/
@@ -130,7 +179,6 @@ theorem isRegular_of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.I
   have factor : ∀ u v : FreeMonoid α, L.syntacticCon u v →
       L.leftQuotient u.toList = L.leftQuotient v.toList := by
     intro u v huv
-    rw [syntacticCon_iff] at huv
     ext y; rw [mem_leftQuotient, mem_leftQuotient]; exact huv [] y
   let g : L.syntacticMonoid → Language α := Quot.lift (fun w => L.leftQuotient w.toList) factor
   refine (Set.finite_range g).subset ?_
@@ -142,5 +190,3 @@ theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.syntacti
   ⟨finite_syntacticMonoid, isRegular_of_finite_syntacticMonoid⟩
 
 end Language
-
-end


### PR DESCRIPTION
Follow-up to #653 (which merged only the first cleanup commit; the substantive refactor below was pushed to that branch post-merge and stranded). Reshapes the syntactic-monoid layer toward mathlib-upstream form and threads it through consumers.

- `SyntacticMonoid`: define `syntacticCon` **intrinsically** as the two-sided context congruence (was `Con.ker L.toDFA.transitionHom`); the DFA route is now `syntacticCon_eq_ker_transitionHom`. Drops `noncomputable`, removes the backwards dependency on the transition-monoid layer from the *definition*, makes `syntacticCon_iff` definitional.
- Add the word-level `syntacticClass : List α → syntacticMonoid` API (`_append`/`_nil`/`_eq_iff`/`_surjective`, `mem_iff_of_syntacticClass_eq`) — the literature's η(w), List-phrased to match `MyhillNerode`.
- Rethread `Equations.lean` and `Pin.lean` onto `syntacticClass`, removing the `FreeMonoid.ofList`/`.toList` plumbing and the `Quotient.sound`/`syntacticCon_iff` ritual in forward/reverse proofs.
- Cleanups: `Type*`, `Recognises`→`Recognizes`, golfed docstrings/proofs.

Net −123 lines across the three files; no `sorry`, builds green.