### PR TITLE
fix(Studies): correct AnandHardtMcCloskey2021 stats, move SIC to 2025

### DIFF
--- a/Linglib/Data/Examples/AnandHardtMcCloskey2025.json
+++ b/Linglib/Data/Examples/AnandHardtMcCloskey2025.json
@@ -16,7 +16,7 @@
       ["phenomenon", "sluicing"],
       ["ppType", "nonargument"]
     ],
-    "comment": "UNVERIFIED paperLabel: ex. (13a) carried from Studies/AnandHardtMcCloskey2025.lean strandedPrepEx13a, not checked against the published paper. SCSS corpus ID [138195] per the Lean source field. The stranded 'in' marks a nonargument PP merged above vP, outside the argument domain, so the Structural Identity Condition does not require it to match. Lean fields: antecedent = 'government regulation is necessary'; innerAntecedent = 'a one-size-fits-all approach'; whPhrase = 'what form'; elided = 'government regulation is necessary in'.",
+    "comment": "UNVERIFIED paperLabel: ex. (13a) carried from Studies/AnandHardtMcCloskey2025.lean strandedPrepEx13a, not checked against the published paper. SCEP corpus ID [138195] per the Lean source field. The stranded 'in' marks a nonargument PP merged above vP, outside the argument domain, so the Structural Identity Condition does not require it to match. Lean fields: antecedent = 'government regulation is necessary'; innerAntecedent = 'a one-size-fits-all approach'; whPhrase = 'what form'; elided = 'government regulation is necessary in'.",
     "metaLanguage": "stan1293",
     "lgrConformance": ""
   },
@@ -37,7 +37,7 @@
       ["phenomenon", "sluicing"],
       ["ppType", "nonargument"]
     ],
-    "comment": "UNVERIFIED paperLabel: ex. (13b) carried from Studies/AnandHardtMcCloskey2025.lean strandedPrepEx13b, not checked against the published paper. SCSS corpus ID [F38] per the Lean source field. Lean fields: antecedent = 'I remembered meeting her'; innerAntecedent = 'her'; whPhrase = 'what date'; elided = 'I met her on'.",
+    "comment": "UNVERIFIED paperLabel: ex. (13b) carried from Studies/AnandHardtMcCloskey2025.lean strandedPrepEx13b, not checked against the published paper. SCEP corpus ID [F38] per the Lean source field. Lean fields: antecedent = 'I remembered meeting her'; innerAntecedent = 'her'; whPhrase = 'what date'; elided = 'I met her on'.",
     "metaLanguage": "stan1293",
     "lgrConformance": ""
   },

--- a/Linglib/Data/Examples/AnandHardtMcCloskey2025.lean
+++ b/Linglib/Data/Examples/AnandHardtMcCloskey2025.lean
@@ -27,7 +27,7 @@ def ex_13a : LinguisticExample :=
     alternatives := []
     readings := []
     paperFeatures := [("phenomenon", "sluicing"), ("ppType", "nonargument")]
-    comment := "UNVERIFIED paperLabel: ex. (13a) carried from Studies/AnandHardtMcCloskey2025.lean strandedPrepEx13a, not checked against the published paper. SCSS corpus ID [138195] per the Lean source field. The stranded 'in' marks a nonargument PP merged above vP, outside the argument domain, so the Structural Identity Condition does not require it to match. Lean fields: antecedent = 'government regulation is necessary'; innerAntecedent = 'a one-size-fits-all approach'; whPhrase = 'what form'; elided = 'government regulation is necessary in'."
+    comment := "UNVERIFIED paperLabel: ex. (13a) carried from Studies/AnandHardtMcCloskey2025.lean strandedPrepEx13a, not checked against the published paper. SCEP corpus ID [138195] per the Lean source field. The stranded 'in' marks a nonargument PP merged above vP, outside the argument domain, so the Structural Identity Condition does not require it to match. Lean fields: antecedent = 'government regulation is necessary'; innerAntecedent = 'a one-size-fits-all approach'; whPhrase = 'what form'; elided = 'government regulation is necessary in'."
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
@@ -45,7 +45,7 @@ def ex_13b : LinguisticExample :=
     alternatives := []
     readings := []
     paperFeatures := [("phenomenon", "sluicing"), ("ppType", "nonargument")]
-    comment := "UNVERIFIED paperLabel: ex. (13b) carried from Studies/AnandHardtMcCloskey2025.lean strandedPrepEx13b, not checked against the published paper. SCSS corpus ID [F38] per the Lean source field. Lean fields: antecedent = 'I remembered meeting her'; innerAntecedent = 'her'; whPhrase = 'what date'; elided = 'I met her on'."
+    comment := "UNVERIFIED paperLabel: ex. (13b) carried from Studies/AnandHardtMcCloskey2025.lean strandedPrepEx13b, not checked against the published paper. SCEP corpus ID [F38] per the Lean source field. Lean fields: antecedent = 'I remembered meeting her'; innerAntecedent = 'her'; whPhrase = 'what date'; elided = 'I met her on'."
     metaLanguage := "stan1293"
     lgrConformance := "" }
 

--- a/Linglib/Studies/AnandHardtMcCloskey2021.lean
+++ b/Linglib/Studies/AnandHardtMcCloskey2021.lean
@@ -1,400 +1,221 @@
-import Linglib.Data.UD.Basic
-import Linglib.Data.Examples.Merchant2001
-import Linglib.Syntax.Minimalist.Ellipsis.FormalMatching
-import Linglib.Syntax.Minimalist.Ellipsis.DeletionDomain
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 
 /-!
-# [anand-hardt-mccloskey-2021] — Corpus Data
+# [anand-hardt-mccloskey-2021] — The Santa Cruz sluicing data set
 
 [anand-hardt-mccloskey-2021]
 
-Distributional findings from the Santa Cruz Sluicing Corpus (SCSS),
-a 4,700-example annotated data set of naturally occurring English sluices.
+Distributional findings from the **Santa Cruz sluicing data set**, a 4,700-example
+annotated corpus of naturally occurring English sluices drawn from the New York
+Times subset of the Gigaword corpus, built by the Santa Cruz Ellipsis Project
+(SCEP).
 
 ## Key Findings
 
-1. **Sprouting dominates**: 65.5% of sluices have no overt correlate,
-   overturning the theoretical literature's focus on merger.
+1. **Sprouting dominates**: 65.5% of sluices have no overt correlate, overturning
+   the theoretical literature's focus on merger (34.5%).
 
-2. **Why dominates**: *why* accounts for 53.8% of all sluices (2,529/4,700).
+2. ***why* / Reason is the largest remnant type**, not a majority. *why* sluices
+   are 53.8% of *sprouting* and 37.2% of *all* sluices; the Reason semantic type
+   (Table 1) totals 1,752/4,700 (≈37.3%) — the single most frequent remnant type,
+   but well short of a majority of all sluices. (The "53.8% of the total" figure
+   holds only in the paper's footnote variant that folds in *why not* questions,
+   which the authors caution "should probably not be analyzed in the same terms as
+   sluicing.")
 
-3. **Mismatches are systematic**: Tense (129), modality (394), and polarity
-   (28) mismatches between antecedent and ellipsis site are attested.
-   Argument structure mismatches (voice, transitivity) are entirely absent.
+3. **Mismatches are systematic but bounded**: tense (129), modality (394), polarity
+   (28), and new-words (71 clear cases) mismatches between antecedent and ellipsis
+   site are attested. Voice and argument-structure (transitivity) mismatches have
+   **zero attestations** — which the paper is careful to note is consistent with
+   great rarity, not demonstrated impossibility.
 
-4. **Embedding is the norm**: 72.4% of sluices are embedded.
+4. **Embedding is the norm**: 72.4% of sluices are embedded (3,404), vs. 27.6% root
+   (1,296).
 
+The paper is a descriptive data-set report; it explicitly defers theoretical
+interpretation to a companion paper. The Syntactic-Isomorphism-Condition bridge
+theorems that relate this corpus to a formal-matching account therefore live in
+`Studies/AnandHardtMcCloskey2025.lean`, not here (chronological grounding).
 -/
 
 namespace AnandHardtMcCloskey2021
 
--- ============================================================================
--- § 1: Sluice Classification
--- ============================================================================
+/-! ### Antecedent–ellipsis mismatch dimensions (§5)
 
-/-- Whether a sluice has an overt correlate in the antecedent.
+The data set documents which form/interpretation mismatches between antecedent and
+ellipsis site are attested and which are absent. Attested mismatches challenge
+strict syntactic-identity requirements; the absent ones (especially argument
+structure) constrain theories of ellipsis licensing. These six dimensions are the
+§5 mismatch taxonomy — distinct from the paper's broader annotation ontology
+(antecedent/wh-remnant/paraphrase/correlate obligatory tags; the E-TYPE, IGNORE,
+ISLAND, MISSINGANTE, QEMBEDDER global tags), which is not modelled here. -/
 
-    Merger: "Someone₁ left, but I don't know who₁" — *someone* is the correlate.
-    Sprouting: "John left, but I don't know why" — no overt correlate. -/
-inductive SluiceKind where
-  | merger    -- Overt correlate (inner antecedent) present
-  | sprouting -- No overt correlate; wh-phrase corresponds to an implicit argument
-  deriving DecidableEq, Repr
-
-/-- Embedding context of a sluice. -/
-inductive EmbeddingContext where
-  | root     -- Matrix clause: "Who did she see?"
-  | embedded -- Subordinate: "I don't know who she saw"
-  deriving DecidableEq, Repr
-
--- ============================================================================
--- § 2: Antecedent–Ellipsis Mismatches (§5)
--- ============================================================================
-
-/-- Dimension along which antecedent and ellipsis site can differ.
-
-    The SCSS documents which mismatches are attested and which are absent.
-    Attested mismatches challenge strict syntactic identity requirements;
-    absent mismatches (especially argument structure) constrain theories
-    of ellipsis licensing. -/
+/-- Dimension along which antecedent and ellipsis site can differ (§5). -/
 inductive MismatchDimension where
-  | tense              -- §5.1: Past/present mismatch (129 cases)
-  | modality           -- §5.2: Modal in ellipsis absent from antecedent (394 cases)
-  | polarity           -- §5.3: Negation added or removed (28 cases)
-  | newWords           -- §5.4: Novel lexical material in paraphrase (71 clear cases)
-  | voice              -- §5.5: Active/passive — NOT ATTESTED
-  | argumentStructure  -- §5.5: Transitivity change — NOT ATTESTED
+  | tense              -- §5.1: past/present mismatch (129 cases)
+  | modality           -- §5.2: modal in ellipsis absent from antecedent (394 cases)
+  | polarity           -- §5.3: negation added or removed (28 cases)
+  | newWords           -- §5.4: novel lexical material in paraphrase (71 clear cases)
+  | voice              -- §5.5: active/passive — 0 attestations
+  | argumentStructure  -- §5.5: transitivity change — 0 attestations
   deriving DecidableEq, Repr
 
-/-- Whether a mismatch dimension is attested in the corpus. -/
-def MismatchDimension.attested : MismatchDimension → Bool
-  | .tense             => true
-  | .modality          => true
-  | .polarity          => true
-  | .newWords          => true
-  | .voice             => false
-  | .argumentStructure => false
+/-- Corpus count for each mismatch dimension (§5).
 
-/-- Corpus count for each mismatch dimension (SCSS §5). -/
+    The two zero counts (voice, argument structure) record *non-attestation in this
+    4,700-example corpus*. The paper (§5.5) stresses this is consistent with the
+    mismatches being very rare rather than impossible. -/
 def MismatchDimension.corpusCount : MismatchDimension → Nat
   | .tense             => 129
   | .modality          => 394
   | .polarity          => 28
-  | .newWords          => 71   -- clear cases after filtering (§5.4)
+  | .newWords          => 71   -- clear cases after filtering (of ~160 NEW WORDS tags)
   | .voice             => 0
   | .argumentStructure => 0
 
--- ============================================================================
--- § 3: Polarity Mismatch Subtypes (§5.3)
--- ============================================================================
+/-! ### Remnant semantic-type distribution (Table 1)
 
-/-- Discourse contexts licensing polarity reversal under sluicing (§5.3).
+The wh-remnant semantic-type distribution is a central descriptive contribution:
+prior work (Ross 1969, Chung et al. 1995, Merchant 2001) focused on Entity remnants,
+which are only 13.8% here, while Reason (typically *why*) and Degree dominate. -/
 
-    Polarity reversal is pragmatically conditioned — it requires the
-    discourse context to make the reversed polarity salient. -/
-inductive PolarityReversalContext where
-  | negRaising       -- "I don't think she'll pass, but I don't know why" (ex. 33)
-  | withoutAdjunct   -- "without" phrases adjoin to VP (ex. 32)
-  | disjunction      -- Disjunction/doubt/remember (ex. 34)
-  | qudPartialAnswer -- Negative partial answer to a superordinate QUD (ex. 35)
-  | howEmbedded      -- "how" under know/learn/see — negation absent from antecedent
+/-- Semantic type of the wh-remnant (Table 1). -/
+inductive RemnantSemanticType where
+  | reason          -- typically *why*
+  | degree          -- *how much*, *how tall*, *how often*
+  | entity          -- *who*, *what*
+  | manner          -- *how*
+  | temporal        -- *when*
+  | locative        -- *where*
+  | classificatory  -- *which* N
+  | other
   deriving DecidableEq, Repr
 
--- ============================================================================
--- § 4: New Words Subtypes (§5.4)
--- ============================================================================
+/-- Count of embedded sluices of each remnant type (Table 1, EMBEDDED column). -/
+def RemnantSemanticType.embeddedCount : RemnantSemanticType → Nat
+  | .reason         => 1642
+  | .degree         => 685
+  | .entity         => 335
+  | .manner         => 290
+  | .temporal       => 253
+  | .locative       => 137
+  | .classificatory => 15
+  | .other          => 47
 
-/-- Subtypes of novel lexical material in sluice paraphrases (§5.4).
+/-- Count of root sluices of each remnant type (Table 1, ROOT column). -/
+def RemnantSemanticType.rootCount : RemnantSemanticType → Nat
+  | .reason         => 110
+  | .degree         => 353
+  | .entity         => 315
+  | .manner         => 45
+  | .temporal       => 9
+  | .locative       => 20
+  | .classificatory => 45
+  | .other          => 399
 
-    These are cases where the paraphrase of the elided material contains
-    words not present in the antecedent clause. -/
-inductive NewWordsSubtype where
-  | copularClause        -- Nominal antecedent → copular clause (46 cases)
-  | existentialInterp    -- Existential interpretation in ellipsis site (17 cases)
-  | strandedPreposition  -- Preposition in ellipsis with no antecedent source (17 cases)
-  deriving DecidableEq, Repr
+/-- Total count of each remnant type (Table 1, TOTAL column), derived. -/
+def RemnantSemanticType.totalCount (t : RemnantSemanticType) : Nat :=
+  t.embeddedCount + t.rootCount
 
--- ============================================================================
--- § 5: Corpus Summary Statistics
--- ============================================================================
+/-! ### Corpus summary statistics
 
-/-- Summary statistics from the SCSS.
+Percentages are stored as integer tenths (655 = 65.5%) since every downstream fact
+about them is an integer (in)equality; this preserves the paper's reported
+precision without rational arithmetic. -/
 
-    Percentages are stored as tenths (655 = 65.5%) to avoid rationals
-    while preserving the paper's reported precision. -/
+/-- Summary statistics from the Santa Cruz sluicing data set. -/
 structure CorpusSummary where
   totalSluices : Nat
   sproutingPctTenths : Nat    -- 655 = 65.5%
   mergerPctTenths : Nat       -- 345 = 34.5%
   rootPctTenths : Nat         -- 276 = 27.6%
   embeddedPctTenths : Nat     -- 724 = 72.4%
-  whyCount : Nat
-  whyPctTenths : Nat          -- 538 = 53.8%
-  antecedentlessCount : Nat
+  antecedentlessCount : Nat   -- 167 well-formed antecedentless examples (3.6%)
   deriving Repr
 
-/-- The SCSS corpus summary. -/
-def scss : CorpusSummary where
+/-- The data-set summary. -/
+def dataSet : CorpusSummary where
   totalSluices := 4700
   sproutingPctTenths := 655
   mergerPctTenths := 345
   rootPctTenths := 276
   embeddedPctTenths := 724
-  whyCount := 2529
-  whyPctTenths := 538
   antecedentlessCount := 167
 
--- ============================================================================
--- § 6: Per-Datum Verification
--- ============================================================================
+/-! ### Corpus distribution -/
 
-/-- Sprouting + merger = 100%. -/
-theorem sprouting_merger_exhaustive :
-    scss.sproutingPctTenths + scss.mergerPctTenths = 1000 := by decide
-
-/-- Root + embedded = 100%. -/
-theorem root_embedded_exhaustive :
-    scss.rootPctTenths + scss.embeddedPctTenths = 1000 := by decide
-
-/-- Sprouting is the majority kind. -/
-theorem sprouting_majority :
-    scss.sproutingPctTenths > scss.mergerPctTenths := by decide
-
-/-- *Why* is the majority wh-remnant type. -/
-theorem why_majority :
-    scss.whyPctTenths > 500 := by decide
+/-- Sprouting is the majority sluice kind (overturning the literature's focus on
+    merger). -/
+theorem sprouting_is_majority_kind :
+    dataSet.sproutingPctTenths > 500 := by decide
 
 /-- Embedding is the majority context. -/
-theorem embedded_majority :
-    scss.embeddedPctTenths > scss.rootPctTenths := by decide
+theorem embedded_is_majority_context :
+    dataSet.embeddedPctTenths > 500 := by decide
+
+/-- The reported sprouting/merger percentages are mutually consistent (sum to
+    100%). -/
+theorem sprouting_merger_exhaustive :
+    dataSet.sproutingPctTenths + dataSet.mergerPctTenths = 1000 := by decide
+
+/-- The reported root/embedded percentages are mutually consistent (sum to 100%). -/
+theorem root_embedded_exhaustive :
+    dataSet.rootPctTenths + dataSet.embeddedPctTenths = 1000 := by decide
+
+/-- The Table 1 semantic-type totals partition the full corpus. -/
+theorem semantic_type_totals_exhaustive :
+    RemnantSemanticType.reason.totalCount
+      + RemnantSemanticType.degree.totalCount
+      + RemnantSemanticType.entity.totalCount
+      + RemnantSemanticType.manner.totalCount
+      + RemnantSemanticType.temporal.totalCount
+      + RemnantSemanticType.locative.totalCount
+      + RemnantSemanticType.classificatory.totalCount
+      + RemnantSemanticType.other.totalCount
+      = dataSet.totalSluices := by decide
+
+/-- Reason (typically *why*) is the largest remnant semantic type. -/
+theorem reason_largest_remnant_type :
+    RemnantSemanticType.degree.totalCount < RemnantSemanticType.reason.totalCount ∧
+    RemnantSemanticType.entity.totalCount < RemnantSemanticType.reason.totalCount ∧
+    RemnantSemanticType.manner.totalCount < RemnantSemanticType.reason.totalCount ∧
+    RemnantSemanticType.temporal.totalCount < RemnantSemanticType.reason.totalCount ∧
+    RemnantSemanticType.locative.totalCount < RemnantSemanticType.reason.totalCount ∧
+    RemnantSemanticType.classificatory.totalCount < RemnantSemanticType.reason.totalCount ∧
+    RemnantSemanticType.other.totalCount < RemnantSemanticType.reason.totalCount := by
+  decide
+
+/-- Reason is the largest remnant type but NOT a majority of all sluices: at
+    1,752/4,700 (≈37.3%), twice the Reason count still falls short of the total.
+    This is the corrected form of the paper's "*why* dominates" finding — *why* is
+    the single most frequent remnant type, not a majority. -/
+theorem reason_not_majority :
+    2 * RemnantSemanticType.reason.totalCount < dataSet.totalSluices := by decide
+
+/-! ### Attested vs. absent mismatches -/
 
 /-- Modality mismatches are the most frequent mismatch type. -/
 theorem modality_most_frequent_mismatch :
     MismatchDimension.corpusCount .modality >
-    MismatchDimension.corpusCount .tense ∧
+      MismatchDimension.corpusCount .tense ∧
     MismatchDimension.corpusCount .modality >
-    MismatchDimension.corpusCount .polarity ∧
+      MismatchDimension.corpusCount .polarity ∧
     MismatchDimension.corpusCount .modality >
-    MismatchDimension.corpusCount .newWords :=
+      MismatchDimension.corpusCount .newWords :=
   ⟨by decide, by decide, by decide⟩
 
-/-- Voice mismatches are absent. -/
+/-- Voice mismatches have zero attestations in the corpus (the paper notes this is
+    consistent with rarity, not proven impossibility — §5.5). -/
 theorem no_voice_mismatches :
     MismatchDimension.corpusCount .voice = 0 := rfl
 
-/-- Argument structure mismatches are absent. -/
+/-- Argument-structure (transitivity) mismatches have zero attestations in the
+    corpus (likewise consistent with rarity rather than impossibility — §5.5). -/
 theorem no_argstructure_mismatches :
     MismatchDimension.corpusCount .argumentStructure = 0 := rfl
-
-/-- Every attested dimension has a nonzero count;
-    every unattested dimension has a zero count. -/
-theorem attested_iff_nonzero (d : MismatchDimension) :
-    d.attested = true ↔ d.corpusCount > 0 := by
-  cases d <;> simp only [MismatchDimension.attested, MismatchDimension.corpusCount] <;> decide
-
--- ============================================================================
--- § 7: Sluicing — Minimalist Bridge Theorems
--- ============================================================================
--- [anand-hardt-mccloskey-2021] [anand-hardt-mccloskey-2025]
--- Connects empirical sluicing data — the [merchant-2001] case-matching
--- examples (`Merchant2001.Examples`) and the corpus findings from
--- [anand-hardt-mccloskey-2021] — to the Syntactic Isomorphism Condition
--- (SIC) formalized in `Minimalist.Ellipsis.FormalMatching`.
-
-open Minimalist
-open Minimalist.Ellipsis.FormalMatching
-
--- ============================================================================
--- § 7.1: Concrete SIC Licensing
--- ============================================================================
-
--- The argument domain of a full clause (CP) is vP, containing head pairs
--- ⟨v, V⟩ and ⟨V, D⟩ (v selects VP, V selects DP). When antecedent and
--- ellipsis site share the same verb, these head pairs are identical.
-
-/-- Head pairs for a simple transitive vP: v selects V, V selects D.
-    This is the argument domain structure of "someone left" / "John ate
-    something" — any clause with a single verb and a DP argument. -/
-def transitiveVP : List HeadPair := [⟨.v, .V, none, none, none⟩, ⟨.V, .D, none, none, none⟩]
-
-/-- Head pairs for an intransitive vP: v selects V only.
-    Used for the antecedent of sprouting examples like "John left." -/
-def intransitiveVP : List HeadPair := [⟨.v, .V, none, none, none⟩]
-
-/-- SIC licenses basic sluicing: "Someone left, but I don't know who."
-
-    Antecedent "someone left" and ellipsis "[who] left" share the same
-    verb, so their argument domains have identical head pairs. -/
-theorem basic_sluice_licensed :
-    structurallyIdentical transitiveVP transitiveVP := by
-  decide
-
-/-- SIC licenses object sluicing: "John ate something, but I don't know what."
-
-    Same verb "ate" → same head pairs. -/
-theorem object_sluice_licensed :
-    structurallyIdentical transitiveVP transitiveVP := by
-  decide
-
-/-- A `SluicingLicense` for same-verb sluices is licensed. -/
-theorem same_verb_license_is_licensed :
-    (SluicingLicense.mk transitiveVP transitiveVP).isLicensed := by
-  decide
-
--- Case matching: case is assigned within the argument domain, so the SIC
--- requires case to match between antecedent and ellipsis site.
-
-/-- Head pairs for a dative-assigning transitive vP.
-    V assigns dative case to its DP complement (e.g., German *helfen*). -/
-def dativeVP : List HeadPair :=
-  [⟨.v, .V, none, none, none⟩, ⟨.V, .D, some .Dat, none, none⟩]
-
-/-- Head pairs for an accusative-assigning transitive vP.
-    V assigns accusative case to its DP complement (e.g., German *sehen*). -/
-def accusativeVP : List HeadPair :=
-  [⟨.v, .V, none, none, none⟩, ⟨.V, .D, some .Acc, none, none⟩]
-
-/-- Same-case head pairs are structurally identical (case match OK). -/
-theorem case_match_licensed :
-    structurallyIdentical dativeVP dativeVP := by
-  decide
-
-/-- Case mismatch blocks structural identity. -/
-theorem case_mismatch_blocked :
-    ¬ structurallyIdentical dativeVP accusativeVP := by
-  decide
-
-/-- SIC correctly predicts `Merchant2001.Examples.german_case_match`
-    ("Er will jemandem schmeicheln, aber sie wissen nicht, wem") is
-    acceptable: the dative wh-phrase *wem* matches the dative correlate
-    *jemandem*, and the argument domains have structurally identical
-    head pairs (both assign dative). -/
-theorem sic_predicts_germanCaseMatch :
-    Merchant2001.Examples.german_case_match.judgment = .acceptable ∧
-    structurallyIdentical dativeVP dativeVP :=
-  ⟨rfl, by decide⟩
-
-/-- SIC correctly predicts the *wen*-variant — the sole `alternatives`
-    entry of `Merchant2001.Examples.german_case_match` — is
-    ungrammatical: accusative *wen* does not match the dative correlate,
-    and the SIC blocks sluicing because dative ≠ accusative within the
-    argument domain ([merchant-2001]: German *wem*/*wen* data). -/
-theorem sic_predicts_germanCaseMismatch :
-    Merchant2001.Examples.german_case_match.alternatives.map Prod.snd
-      = [.ungrammatical] ∧
-    ¬ structurallyIdentical dativeVP accusativeVP :=
-  ⟨rfl, by decide⟩
-
--- ============================================================================
--- § 7.2: SIC Mismatch Predictions Confirmed by Corpus
--- ============================================================================
-
--- The SIC partitions categories into those inside and outside the
--- argument domain. Categories inside (V, v) must match; categories
--- outside (T, Mod, C) may differ freely.
-
-/-- V and v are inside the argument domain: argument structure must match.
-    The corpus confirms: zero argument structure mismatches. -/
-theorem argstructure_inside_and_absent :
-    isInArgumentDomain .V .C = true ∧
-    isInArgumentDomain .v .C = true ∧
-    MismatchDimension.corpusCount .argumentStructure = 0 :=
-  ⟨by decide, by decide, rfl⟩
-
-/-- T is outside the argument domain: tense mismatches are licit.
-    The corpus confirms: 129 tense mismatches attested. -/
-theorem tense_outside_and_attested :
-    isInArgumentDomain .T .C = false ∧
-    MismatchDimension.corpusCount .tense > 0 :=
-  ⟨by decide, by decide⟩
-
-/-- Mod is outside the argument domain: modal mismatches are licit.
-    The corpus confirms: 394 modal mismatches — the most frequent type. -/
-theorem modality_outside_and_attested :
-    isInArgumentDomain .Mod .C = false ∧
-    MismatchDimension.corpusCount .modality > 0 :=
-  ⟨by decide, by decide⟩
-
-/-- The SIC cleanly separates tolerated from untolerated mismatches:
-    every mismatch dimension inside the argument domain has 0 corpus
-    attestations; every dimension outside has nonzero attestations. -/
-theorem sic_partition_confirmed :
-    -- Inside arg domain → 0 mismatches
-    MismatchDimension.corpusCount .argumentStructure = 0 ∧
-    MismatchDimension.corpusCount .voice = 0 ∧
-    -- Outside arg domain → mismatches attested
-    MismatchDimension.corpusCount .tense > 0 ∧
-    MismatchDimension.corpusCount .modality > 0 :=
-  ⟨rfl, rfl, by decide, by decide⟩
-
--- ============================================================================
--- § 7.3: Voice Mismatch Resolution ([anand-hardt-mccloskey-2021])
--- ============================================================================
-
--- [anand-hardt-mccloskey-2021] resolves the voice puzzle: voice mismatches are correctly
--- blocked by the SIC because active v[agentive] ≠ passive v[nonThematic]
--- within the argument domain (v is F1, inside vP). The 0 corpus count
--- is predicted, not puzzling.
-
-/-- The SIC correctly blocks voice mismatches in sluicing: active
-    v[agentive] ≠ passive v[nonThematic], and both are within the
-    argument domain (F1 ≤ F1). The corpus confirms: 0 voice mismatches.
-
-    This resolves the voice puzzle from the earlier analysis. The puzzle
-    arose from treating voice as outside the argument domain (like T/Mod),
-    but [anand-hardt-mccloskey-2021] shows that voice flavor is encoded on v, which IS inside
-    the argument domain. Uses `activeVP`/`passiveVP` from FormalMatching. -/
-theorem voice_correctly_blocked :
-    ¬ structurallyIdentical activeVP passiveVP ∧
-    MismatchDimension.corpusCount .voice = 0 :=
-  ⟨by decide, rfl⟩
-
--- ============================================================================
--- § 7.4: Corpus Distributions
--- ============================================================================
-
-/-- Sprouting is the dominant sluice kind (65.5%), overturning the
-    literature's focus on merger. -/
-theorem sprouting_is_default :
-    scss.sproutingPctTenths > 500 := by decide
-
-/-- *Why* accounts for the majority of sluicing. Since virtually all
-    *why*-sluices are sprouting (reason adjuncts lack overt correlates),
-    the prototypical sluice is "John left, but I don't know why"
-    (sprouting, reason), not "Someone left, but I don't know who"
-    (merger, entity). -/
-theorem why_dominates :
-    scss.whyCount > scss.totalSluices / 2 := by decide
-
--- ============================================================================
--- § 8: Merchant's Deletion Domain Predictions ([merchant-2013])
--- ============================================================================
-
--- Merchant's [E]-feature theory provides a complementary explanation for
--- the corpus findings. The SIC (§ 7) explains voice mismatch blocking
--- via structural identity within the argument domain; Merchant's deletion
--- domain analysis explains it via the position of [E]: sluicing has C[E],
--- so everything below C (including Voice and v) is inside the deletion domain.
-
-/-- Merchant's deletion domain theory converges with the corpus: sluicing
-    (C[E]) predicts both voice and transitivity mismatches are blocked,
-    and the SCSS finds exactly 0 attestations of each.
-
-    This is a convergent prediction with the SIC (§ 7.2): both the SIC
-    (structural identity within the argument domain) and the deletion
-    domain analysis ([E] on C → Voice inside TP) independently predict
-    that voice and argument structure mismatches are blocked in sluicing. -/
-theorem merchant_deletion_domain_matches_corpus :
-    -- Merchant predicts: voice mismatches blocked under sluicing
-    Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
-      Minimalist.Ellipsis.voiceMismatch = false ∧
-    -- Corpus confirms: 0 voice mismatches
-    MismatchDimension.corpusCount .voice = 0 ∧
-    -- Merchant predicts: transitivity mismatches blocked under sluicing
-    Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
-      Minimalist.Ellipsis.transitivityMismatch = false ∧
-    -- Corpus confirms: 0 argument structure mismatches
-    MismatchDimension.corpusCount .argumentStructure = 0 :=
-  ⟨rfl, rfl, rfl, rfl⟩
 
 end AnandHardtMcCloskey2021

--- a/Linglib/Studies/AnandHardtMcCloskey2025.lean
+++ b/Linglib/Studies/AnandHardtMcCloskey2025.lean
@@ -164,11 +164,11 @@ theorem sc_strictly_smaller_than_clause :
     differ freely between antecedent and ellipsis site. The SIC is
     agnostic to these categories. -/
 theorem outside_argdomain_free :
-    isInArgumentDomain .T .C = false ∧
-    isInArgumentDomain .Mod .C = false ∧
-    isInArgumentDomain .Neg .C = false ∧
-    isInArgumentDomain .C .C = false ∧
-    isInArgumentDomain .Fin .C = false := by decide
+    ¬ isInArgumentDomain .T .C ∧
+    ¬ isInArgumentDomain .Mod .C ∧
+    ¬ isInArgumentDomain .Neg .C ∧
+    ¬ isInArgumentDomain .C .C ∧
+    ¬ isInArgumentDomain .Fin .C := by decide
 
 -- ============================================================================
 -- § 3: Active–Passive Voice Mismatch Blocking (paper §3, ex. 10–11)
@@ -355,11 +355,11 @@ theorem sic_checks_heads_not_nodes :
     This imports and extends the bridge theorems from
     [anand-hardt-mccloskey-2021]. -/
 theorem consistent_with_2021_corpus :
-    isInArgumentDomain .v .C = true ∧
+    isInArgumentDomain .v .C ∧
     AnandHardtMcCloskey2021.MismatchDimension.corpusCount .argumentStructure = 0 ∧
-    isInArgumentDomain .T .C = false ∧
+    ¬ isInArgumentDomain .T .C ∧
     AnandHardtMcCloskey2021.MismatchDimension.corpusCount .tense > 0 ∧
-    isInArgumentDomain .Mod .C = false ∧
+    ¬ isInArgumentDomain .Mod .C ∧
     AnandHardtMcCloskey2021.MismatchDimension.corpusCount .modality > 0 :=
   ⟨by decide, rfl, by decide, by decide, by decide, by decide⟩
 

--- a/Linglib/Studies/AnandHardtMcCloskey2025.lean
+++ b/Linglib/Studies/AnandHardtMcCloskey2025.lean
@@ -1,6 +1,8 @@
 import Linglib.Syntax.Minimalist.Ellipsis.FormalMatching
+import Linglib.Syntax.Minimalist.Ellipsis.DeletionDomain
 import Linglib.Syntax.Minimalist.Copula
 import Linglib.Studies.AnandHardtMcCloskey2021
+import Linglib.Data.Examples.Merchant2001
 import Linglib.Data.Examples.AnandHardtMcCloskey2025
 
 /-!
@@ -381,7 +383,82 @@ theorem stranded_prep_prediction :
   refine ⟨?_, ?_⟩ <;> decide
 
 -- ============================================================================
--- § 8: Collected Data
+-- § 8: Merchant 2001 Case-Matching Bridge
+-- ============================================================================
+
+-- The SIC's case-matching prediction grounds out against a real annotated
+-- example: [merchant-2001]'s German *wem*/*wen* contrast, stored as
+-- `Merchant2001.Examples.german_case_match`. Case is assigned within the
+-- argument domain, so the SIC requires it to match between antecedent and
+-- ellipsis site. These theorems state the prediction over the canonical
+-- substrate frames (`dativeFrame`/`accusativeFrame`), not local re-stipulations.
+
+/-- The SIC correctly predicts `Merchant2001.Examples.german_case_match`
+    ("Er will jemandem schmeicheln, aber sie wissen nicht, wem") is acceptable:
+    the dative wh-phrase *wem* matches the dative correlate *jemandem*, and the
+    argument domains are structurally identical (both assign dative). -/
+theorem sic_predicts_germanCaseMatch :
+    Merchant2001.Examples.german_case_match.judgment = .acceptable ∧
+    frameSluicingLicensed dativeFrame dativeFrame :=
+  ⟨rfl, same_case_from_frames⟩
+
+/-- The SIC correctly predicts the *wen*-variant — the sole `alternatives`
+    entry of `Merchant2001.Examples.german_case_match` — is ungrammatical:
+    accusative *wen* does not match the dative correlate, so structural identity
+    fails within the argument domain ([merchant-2001]: German *wem*/*wen* data). -/
+theorem sic_predicts_germanCaseMismatch :
+    Merchant2001.Examples.german_case_match.alternatives.map Prod.snd
+      = [.ungrammatical] ∧
+    ¬ frameSluicingLicensed dativeFrame accusativeFrame :=
+  ⟨rfl, case_mismatch_from_frames⟩
+
+-- ============================================================================
+-- § 9: Relation to Merchant's [E]-Feature Deletion Domain ([merchant-2013])
+-- ============================================================================
+
+-- Two formal-matching theories of the sluicing voice gap coexist in the
+-- library: the argument-domain SIC above, and [merchant-2013]'s [E]-feature
+-- deletion-domain account (`Ellipsis.DeletionDomain`). They CONVERGE on
+-- sluicing but DIVERGE on VP-ellipsis — making the comparison legible rather
+-- than letting two notations pass for one theory.
+
+/-- Merchant's deletion-domain theory converges with the 2021 corpus: sluicing
+    ([E] on C) predicts both voice and transitivity mismatches are blocked, and
+    the data set finds exactly 0 attestations of each. This is a convergent
+    prediction with the SIC (`consistent_with_2021_corpus`): both the SIC
+    (structural identity within the argument domain) and the deletion-domain
+    analysis ([E] on C → Voice inside TP) independently block these mismatches
+    in sluicing. -/
+theorem merchant_deletion_domain_matches_corpus :
+    Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
+      Minimalist.Ellipsis.voiceMismatch = false ∧
+    AnandHardtMcCloskey2021.MismatchDimension.corpusCount .voice = 0 ∧
+    Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
+      Minimalist.Ellipsis.transitivityMismatch = false ∧
+    AnandHardtMcCloskey2021.MismatchDimension.corpusCount .argumentStructure = 0 :=
+  ⟨by decide, rfl, by decide, rfl⟩
+
+/-- The SIC and Merchant's deletion-domain account AGREE on sluicing but DIVERGE
+    on VP-ellipsis. Merchant's [E]-on-Voice tolerates voice mismatch under VPE —
+    the active/passive asymmetry that motivates [merchant-2013] "Voice and
+    ellipsis." The SIC's `structurallyIdentical` is **height-blind** (it takes no
+    [E]-position argument), so it blocks the very same active/passive head pairs
+    regardless of ellipsis type, and cannot express the VPE-vs-sluicing contrast.
+    The convergence on sluicing is therefore real but local; off the sluicing
+    data the two theories make different predictions. -/
+theorem sic_merchant_diverge_on_vpe :
+    -- Sluicing: both block voice mismatch (convergence)
+    (Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
+        Minimalist.Ellipsis.voiceMismatch = false ∧
+      ¬ structurallyIdentical activeVP passiveVP) ∧
+    -- VP-ellipsis: Merchant tolerates, the height-blind SIC still blocks (divergence)
+    (Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.englishVPE
+        Minimalist.Ellipsis.voiceMismatch = true ∧
+      ¬ structurallyIdentical activeVP passiveVP) :=
+  ⟨⟨by decide, by decide⟩, ⟨by decide, by decide⟩⟩
+
+-- ============================================================================
+-- § 10: Collected Data
 -- ============================================================================
 
 def scSluicingData : List SCSluicingDatum :=

--- a/Linglib/Studies/Kalyakin2026.lean
+++ b/Linglib/Studies/Kalyakin2026.lean
@@ -231,8 +231,9 @@ theorem end_to_end_causative_chain :
 
 /-- Convergent prediction: Merchant's theory correctly predicts that
     sluicing (C[E]) blocks voice mismatches — Voice is inside TP, the
-    deletion domain of sluicing. The SCSS corpus ([anand-hardt-mccloskey-2021],
-    §5.5) independently confirms this: across 4,700 annotated sluices, zero
+    deletion domain of sluicing. The Santa Cruz sluicing data set
+    ([anand-hardt-mccloskey-2021], §5.5) independently confirms this: across
+    4,700 annotated sluices, zero
     antecedent–ellipsis site pairings exhibit active/passive voice mismatches.
     The same theoretical apparatus that Kalyakin extends to vVPE
     already works for sluicing. -/

--- a/Linglib/Studies/Saab2026.lean
+++ b/Linglib/Studies/Saab2026.lean
@@ -68,13 +68,13 @@ theorem argdomain_boundary_parallel :
     Both exclude inflectional heads (T/Num at F2). -/
 theorem verbal_nominal_argdomain_symmetric :
     -- Verbal: V and v are in, T is out
-    isInArgumentDomain .V .C = true ∧
-    isInArgumentDomain .v .C = true ∧
-    isInArgumentDomain .T .C = false ∧
+    isInArgumentDomain .V .C ∧
+    isInArgumentDomain .v .C ∧
+    ¬ isInArgumentDomain .T .C ∧
     -- Nominal: N and n are in, Q (first head above n) is out
-    isInArgumentDomain .N .D = true ∧
-    isInArgumentDomain .n .D = true ∧
-    isInArgumentDomain .Q .D = false := by decide
+    isInArgumentDomain .N .D ∧
+    isInArgumentDomain .n .D ∧
+    ¬ isInArgumentDomain .Q .D := by decide
 
 -- ═══════════════════════════════════════════════════════════════
 -- § 3: NP-Ellipsis Licensing via Num[E]

--- a/Linglib/Syntax/Minimalist/Ellipsis/FormalMatching.lean
+++ b/Linglib/Syntax/Minimalist/Ellipsis/FormalMatching.lean
@@ -189,15 +189,15 @@ instance (sl : SluicingLicense) : Decidable sl.isLicensed := by
     [anand-hardt-mccloskey-2021]: voice mismatches ARE blocked by the SIC because
     v[agentive] ≠ v[nonThematic] within the argument domain. -/
 theorem voice_flavor_in_argdomain :
-    isInArgumentDomain .Voice .C = true := by decide
+    isInArgumentDomain .Voice .C := by decide
 
 /-- T is not within the argument domain of a CP. -/
 theorem t_outside_argdomain :
-    isInArgumentDomain .T .C = false := by decide
+    ¬ isInArgumentDomain .T .C := by decide
 
 /-- C is not within the argument domain. -/
 theorem c_outside_argdomain :
-    isInArgumentDomain .C .C = false := by decide
+    ¬ isInArgumentDomain .C .C := by decide
 
 /-- Head pairs for an active (agentive) transitive vP.
     v[agentive] selects VP, V selects DP. -/
@@ -224,11 +224,11 @@ theorem voice_match_licenses_sluicing :
 
 /-- V is within the argument domain of a CP (F0 ≤ F1). -/
 theorem v_lexical_in_argdomain :
-    isInArgumentDomain .V .C = true := by decide
+    isInArgumentDomain .V .C := by decide
 
 /-- v is within the argument domain of a CP (F1 ≤ F1). -/
 theorem v_functional_in_argdomain :
-    isInArgumentDomain .v .C = true := by decide
+    isInArgumentDomain .v .C := by decide
 
 -- Small clause predictions
 
@@ -240,7 +240,7 @@ theorem small_clause_argdomain_is_self :
 /-- In a small clause, v is NOT in the argument domain
     (since the top is V at F0, and v is F1). -/
 theorem small_clause_excludes_v :
-    isInArgumentDomain .v .V = false := by decide
+    ¬ isInArgumentDomain .v .V := by decide
 
 -- Cross-categorial SC argument domains ([anand-hardt-mccloskey-2025] Def 4)
 
@@ -513,10 +513,10 @@ theorem verbframe_argdomain_wellformed :
 /-- The verbal argument domain contains exactly F0 (.V) and F1 (.v).
     Everything above (T, C, Mod, ...) is outside. -/
 theorem verbframe_argdomain_complete :
-    isInArgumentDomain .V .C = true ∧
-    isInArgumentDomain .v .C = true ∧
-    isInArgumentDomain .T .C = false ∧
-    isInArgumentDomain .C .C = false := by decide
+    isInArgumentDomain .V .C ∧
+    isInArgumentDomain .v .C ∧
+    ¬ isInArgumentDomain .T .C ∧
+    ¬ isInArgumentDomain .C .C := by decide
 
 -- ── Concrete tree verification ─────────────────────────────────
 -- The following examples verify at compile time that the

--- a/Linglib/Syntax/Minimalist/Ellipsis/Nominal.lean
+++ b/Linglib/Syntax/Minimalist/Ellipsis/Nominal.lean
@@ -43,23 +43,23 @@ def NominalEllipsisLicense.isLicensed (nel : NominalEllipsisLicense) : Bool :=
 
 /-- N is within the nominal argument domain (F0 ≤ F1 = n). -/
 theorem n_lexical_in_nominal_argdomain :
-    isInArgumentDomain .N .D = true := by decide
+    isInArgumentDomain .N .D := by decide
 
 /-- n is within the nominal argument domain (F1 ≤ F1). -/
 theorem n_functional_in_nominal_argdomain :
-    isInArgumentDomain .n .D = true := by decide
+    isInArgumentDomain .n .D := by decide
 
 /-- Num is NOT in the nominal argument domain (F2 > F1 = n). -/
 theorem num_not_in_nominal_argdomain :
-    isInArgumentDomain .Num .D = false := by decide
+    ¬ isInArgumentDomain .Num .D := by decide
 
 /-- Q is NOT in the nominal argument domain (F3 > F1 = n). -/
 theorem q_not_in_nominal_argdomain :
-    isInArgumentDomain .Q .D = false := by decide
+    ¬ isInArgumentDomain .Q .D := by decide
 
 /-- D is NOT in the nominal argument domain (F4 > F1 = n). -/
 theorem d_not_in_nominal_argdomain :
-    isInArgumentDomain .D .D = false := by decide
+    ¬ isInArgumentDomain .D .D := by decide
 
 /-- NP-ellipsis with Num[E]: pseudo-partitive/quantificational
     binominals license deletion of the nominal argument domain. -/

--- a/Linglib/Syntax/Minimalist/ExtendedProjection/Properties.lean
+++ b/Linglib/Syntax/Minimalist/ExtendedProjection/Properties.lean
@@ -179,8 +179,11 @@ def argumentDomainCat (topCat : Cat) : Cat :=
 
 /-- Is a category within the argument domain of a given top category?
     The argument domain includes all F-levels ≤ the boundary. -/
-def isInArgumentDomain (c topCat : Cat) : Bool :=
+def isInArgumentDomain (c topCat : Cat) : Prop :=
   fValue c ≤ fValue (argumentDomainCat topCat)
+
+instance (c topCat : Cat) : Decidable (isInArgumentDomain c topCat) := by
+  unfold isInArgumentDomain; infer_instance
 
 -- ═══════════════════════════════════════════════════════════════
 -- Part 6: Bridge Theorems
@@ -266,19 +269,19 @@ theorem nump_argdomain :
 
 /-- V is within the argument domain of a full clause. -/
 theorem v_in_argdomain :
-    isInArgumentDomain .V .C = true := by decide
+    isInArgumentDomain .V .C := by decide
 
 /-- v is within the argument domain of a full clause. -/
 theorem v_head_in_argdomain :
-    isInArgumentDomain .v .C = true := by decide
+    isInArgumentDomain .v .C := by decide
 
 /-- T is NOT within the argument domain of a full clause. -/
 theorem t_not_in_argdomain :
-    isInArgumentDomain .T .C = false := by decide
+    ¬ isInArgumentDomain .T .C := by decide
 
 /-- C is NOT within the argument domain (it's the top). -/
 theorem c_not_in_argdomain :
-    isInArgumentDomain .C .C = false := by decide
+    ¬ isInArgumentDomain .C .C := by decide
 
 /-- The argument domain boundary is always in the property-or-intermediate zone.
 


### PR DESCRIPTION
The Anand–Hardt–McCloskey sluicing files conflated the 2021 descriptive data set with the 2025 companion paper's Syntactic Isomorphism Condition (SIC). Verified against the published paper (Language 97.1, e04) and split the two.

- **Corpus statistics corrected against the paper.** Drop `whyCount := 2529` (a figure that appears nowhere in the paper); the headline is *why* = 37.2% of sluices / 53.8% of *sprouting* — the largest remnant type, **not** a majority. Add the Table 1 `RemnantSemanticType` distribution. Rename the invented "Santa Cruz Sluicing Corpus (SCSS)" to "Santa Cruz sluicing data set"; soften the voice/argument-structure absence to "zero attestations, consistent with rarity not impossibility" (§5.5).
- **Chronology fix.** Move the SIC + Merchant deletion-domain bridge theorems out of the 2021 file (a descriptive report) into `AnandHardtMcCloskey2025.lean`, where the SIC is correctly anchored; re-grounded on substrate `dativeFrame`/`accusativeFrame` instead of local toy VPs. The 2021 file is now import-free, theory-free descriptive corpus.
- **Cross-framework theorem.** Add `sic_merchant_diverge_on_vpe`: SIC and Merchant converge on sluicing but diverge on VP-ellipsis (the height-blind SIC cannot express the voice-mismatch asymmetry that motivates merchant-2013).
- Delete five dead taxonomy enums + the `attested` table; fix `SCSS` leaks in `Kalyakin2026.lean` and the 2025 examples JSON.