### PR TITLE
refactor(Syntax/Minimalist): isInArgumentDomain Bool→Prop

### DIFF
--- a/Linglib/Studies/AnandHardtMcCloskey2025.lean
+++ b/Linglib/Studies/AnandHardtMcCloskey2025.lean
@@ -164,11 +164,11 @@ theorem sc_strictly_smaller_than_clause :
     differ freely between antecedent and ellipsis site. The SIC is
     agnostic to these categories. -/
 theorem outside_argdomain_free :
-    isInArgumentDomain .T .C = false ∧
-    isInArgumentDomain .Mod .C = false ∧
-    isInArgumentDomain .Neg .C = false ∧
-    isInArgumentDomain .C .C = false ∧
-    isInArgumentDomain .Fin .C = false := by decide
+    ¬ isInArgumentDomain .T .C ∧
+    ¬ isInArgumentDomain .Mod .C ∧
+    ¬ isInArgumentDomain .Neg .C ∧
+    ¬ isInArgumentDomain .C .C ∧
+    ¬ isInArgumentDomain .Fin .C := by decide
 
 -- ============================================================================
 -- § 3: Active–Passive Voice Mismatch Blocking (paper §3, ex. 10–11)
@@ -355,11 +355,11 @@ theorem sic_checks_heads_not_nodes :
     This imports and extends the bridge theorems from
     [anand-hardt-mccloskey-2021]. -/
 theorem consistent_with_2021_corpus :
-    isInArgumentDomain .v .C = true ∧
+    isInArgumentDomain .v .C ∧
     AnandHardtMcCloskey2021.MismatchDimension.corpusCount .argumentStructure = 0 ∧
-    isInArgumentDomain .T .C = false ∧
+    ¬ isInArgumentDomain .T .C ∧
     AnandHardtMcCloskey2021.MismatchDimension.corpusCount .tense > 0 ∧
-    isInArgumentDomain .Mod .C = false ∧
+    ¬ isInArgumentDomain .Mod .C ∧
     AnandHardtMcCloskey2021.MismatchDimension.corpusCount .modality > 0 :=
   ⟨by decide, rfl, by decide, by decide, by decide, by decide⟩
 

--- a/Linglib/Studies/Saab2026.lean
+++ b/Linglib/Studies/Saab2026.lean
@@ -68,13 +68,13 @@ theorem argdomain_boundary_parallel :
     Both exclude inflectional heads (T/Num at F2). -/
 theorem verbal_nominal_argdomain_symmetric :
     -- Verbal: V and v are in, T is out
-    isInArgumentDomain .V .C = true ∧
-    isInArgumentDomain .v .C = true ∧
-    isInArgumentDomain .T .C = false ∧
+    isInArgumentDomain .V .C ∧
+    isInArgumentDomain .v .C ∧
+    ¬ isInArgumentDomain .T .C ∧
     -- Nominal: N and n are in, Q (first head above n) is out
-    isInArgumentDomain .N .D = true ∧
-    isInArgumentDomain .n .D = true ∧
-    isInArgumentDomain .Q .D = false := by decide
+    isInArgumentDomain .N .D ∧
+    isInArgumentDomain .n .D ∧
+    ¬ isInArgumentDomain .Q .D := by decide
 
 -- ═══════════════════════════════════════════════════════════════
 -- § 3: NP-Ellipsis Licensing via Num[E]

--- a/Linglib/Syntax/Minimalist/Ellipsis/FormalMatching.lean
+++ b/Linglib/Syntax/Minimalist/Ellipsis/FormalMatching.lean
@@ -189,15 +189,15 @@ instance (sl : SluicingLicense) : Decidable sl.isLicensed := by
     [anand-hardt-mccloskey-2021]: voice mismatches ARE blocked by the SIC because
     v[agentive] ≠ v[nonThematic] within the argument domain. -/
 theorem voice_flavor_in_argdomain :
-    isInArgumentDomain .Voice .C = true := by decide
+    isInArgumentDomain .Voice .C := by decide
 
 /-- T is not within the argument domain of a CP. -/
 theorem t_outside_argdomain :
-    isInArgumentDomain .T .C = false := by decide
+    ¬ isInArgumentDomain .T .C := by decide
 
 /-- C is not within the argument domain. -/
 theorem c_outside_argdomain :
-    isInArgumentDomain .C .C = false := by decide
+    ¬ isInArgumentDomain .C .C := by decide
 
 /-- Head pairs for an active (agentive) transitive vP.
     v[agentive] selects VP, V selects DP. -/
@@ -224,11 +224,11 @@ theorem voice_match_licenses_sluicing :
 
 /-- V is within the argument domain of a CP (F0 ≤ F1). -/
 theorem v_lexical_in_argdomain :
-    isInArgumentDomain .V .C = true := by decide
+    isInArgumentDomain .V .C := by decide
 
 /-- v is within the argument domain of a CP (F1 ≤ F1). -/
 theorem v_functional_in_argdomain :
-    isInArgumentDomain .v .C = true := by decide
+    isInArgumentDomain .v .C := by decide
 
 -- Small clause predictions
 
@@ -240,7 +240,7 @@ theorem small_clause_argdomain_is_self :
 /-- In a small clause, v is NOT in the argument domain
     (since the top is V at F0, and v is F1). -/
 theorem small_clause_excludes_v :
-    isInArgumentDomain .v .V = false := by decide
+    ¬ isInArgumentDomain .v .V := by decide
 
 -- Cross-categorial SC argument domains ([anand-hardt-mccloskey-2025] Def 4)
 
@@ -513,10 +513,10 @@ theorem verbframe_argdomain_wellformed :
 /-- The verbal argument domain contains exactly F0 (.V) and F1 (.v).
     Everything above (T, C, Mod, ...) is outside. -/
 theorem verbframe_argdomain_complete :
-    isInArgumentDomain .V .C = true ∧
-    isInArgumentDomain .v .C = true ∧
-    isInArgumentDomain .T .C = false ∧
-    isInArgumentDomain .C .C = false := by decide
+    isInArgumentDomain .V .C ∧
+    isInArgumentDomain .v .C ∧
+    ¬ isInArgumentDomain .T .C ∧
+    ¬ isInArgumentDomain .C .C := by decide
 
 -- ── Concrete tree verification ─────────────────────────────────
 -- The following examples verify at compile time that the

--- a/Linglib/Syntax/Minimalist/Ellipsis/Nominal.lean
+++ b/Linglib/Syntax/Minimalist/Ellipsis/Nominal.lean
@@ -43,23 +43,23 @@ def NominalEllipsisLicense.isLicensed (nel : NominalEllipsisLicense) : Bool :=
 
 /-- N is within the nominal argument domain (F0 ≤ F1 = n). -/
 theorem n_lexical_in_nominal_argdomain :
-    isInArgumentDomain .N .D = true := by decide
+    isInArgumentDomain .N .D := by decide
 
 /-- n is within the nominal argument domain (F1 ≤ F1). -/
 theorem n_functional_in_nominal_argdomain :
-    isInArgumentDomain .n .D = true := by decide
+    isInArgumentDomain .n .D := by decide
 
 /-- Num is NOT in the nominal argument domain (F2 > F1 = n). -/
 theorem num_not_in_nominal_argdomain :
-    isInArgumentDomain .Num .D = false := by decide
+    ¬ isInArgumentDomain .Num .D := by decide
 
 /-- Q is NOT in the nominal argument domain (F3 > F1 = n). -/
 theorem q_not_in_nominal_argdomain :
-    isInArgumentDomain .Q .D = false := by decide
+    ¬ isInArgumentDomain .Q .D := by decide
 
 /-- D is NOT in the nominal argument domain (F4 > F1 = n). -/
 theorem d_not_in_nominal_argdomain :
-    isInArgumentDomain .D .D = false := by decide
+    ¬ isInArgumentDomain .D .D := by decide
 
 /-- NP-ellipsis with Num[E]: pseudo-partitive/quantificational
     binominals license deletion of the nominal argument domain. -/

--- a/Linglib/Syntax/Minimalist/ExtendedProjection/Properties.lean
+++ b/Linglib/Syntax/Minimalist/ExtendedProjection/Properties.lean
@@ -179,8 +179,11 @@ def argumentDomainCat (topCat : Cat) : Cat :=
 
 /-- Is a category within the argument domain of a given top category?
     The argument domain includes all F-levels ≤ the boundary. -/
-def isInArgumentDomain (c topCat : Cat) : Bool :=
+def isInArgumentDomain (c topCat : Cat) : Prop :=
   fValue c ≤ fValue (argumentDomainCat topCat)
+
+instance (c topCat : Cat) : Decidable (isInArgumentDomain c topCat) := by
+  unfold isInArgumentDomain; infer_instance
 
 -- ═══════════════════════════════════════════════════════════════
 -- Part 6: Bridge Theorems
@@ -266,19 +269,19 @@ theorem nump_argdomain :
 
 /-- V is within the argument domain of a full clause. -/
 theorem v_in_argdomain :
-    isInArgumentDomain .V .C = true := by decide
+    isInArgumentDomain .V .C := by decide
 
 /-- v is within the argument domain of a full clause. -/
 theorem v_head_in_argdomain :
-    isInArgumentDomain .v .C = true := by decide
+    isInArgumentDomain .v .C := by decide
 
 /-- T is NOT within the argument domain of a full clause. -/
 theorem t_not_in_argdomain :
-    isInArgumentDomain .T .C = false := by decide
+    ¬ isInArgumentDomain .T .C := by decide
 
 /-- C is NOT within the argument domain (it's the top). -/
 theorem c_not_in_argdomain :
-    isInArgumentDomain .C .C = false := by decide
+    ¬ isInArgumentDomain .C .C := by decide
 
 /-- The argument domain boundary is always in the property-or-intermediate zone.
 


### PR DESCRIPTION
Convert `isInArgumentDomain` from `Bool` to `Prop` + a `Decidable` instance, per the no-`Bool`-for-predicate-shape-data convention. This removes the `= true` / `= false` noise from the argument-domain bridge theorems across `FormalMatching`, `Nominal`, `Saab2026`, and `AnandHardtMcCloskey2025`. Proofs stay `by decide`.

Depends on #656 (shares the AnandHardtMcCloskey files; based on its branch).

Scope note: this is the argument-domain half. The `canMismatch` / `DeletionSpine` deletion-domain predicates are a larger separate cleanup — `isBelow` there likely wants a proper `Order` rather than a mechanical `Bool`→`Prop` flip.