### PR TITLE
refactor(Syntax/Minimalist): deletion-domain predicates Bool→Prop

### DIFF
--- a/Linglib/Studies/AnandHardtMcCloskey2025.lean
+++ b/Linglib/Studies/AnandHardtMcCloskey2025.lean
@@ -430,11 +430,11 @@ theorem sic_predicts_germanCaseMismatch :
     analysis ([E] on C → Voice inside TP) independently block these mismatches
     in sluicing. -/
 theorem merchant_deletion_domain_matches_corpus :
-    Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
-      Minimalist.Ellipsis.voiceMismatch = false ∧
+    ¬ Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
+        Minimalist.Ellipsis.voiceMismatch ∧
     AnandHardtMcCloskey2021.MismatchDimension.corpusCount .voice = 0 ∧
-    Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
-      Minimalist.Ellipsis.transitivityMismatch = false ∧
+    ¬ Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
+        Minimalist.Ellipsis.transitivityMismatch ∧
     AnandHardtMcCloskey2021.MismatchDimension.corpusCount .argumentStructure = 0 :=
   ⟨by decide, rfl, by decide, rfl⟩
 
@@ -448,12 +448,12 @@ theorem merchant_deletion_domain_matches_corpus :
     data the two theories make different predictions. -/
 theorem sic_merchant_diverge_on_vpe :
     -- Sluicing: both block voice mismatch (convergence)
-    (Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
-        Minimalist.Ellipsis.voiceMismatch = false ∧
+    (¬ Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.sluicing
+        Minimalist.Ellipsis.voiceMismatch ∧
       ¬ structurallyIdentical activeVP passiveVP) ∧
     -- VP-ellipsis: Merchant tolerates, the height-blind SIC still blocks (divergence)
     (Minimalist.Ellipsis.canMismatch Minimalist.Ellipsis.englishVPE
-        Minimalist.Ellipsis.voiceMismatch = true ∧
+        Minimalist.Ellipsis.voiceMismatch ∧
       ¬ structurallyIdentical activeVP passiveVP) :=
   ⟨⟨by decide, by decide⟩, ⟨by decide, by decide⟩⟩
 

--- a/Linglib/Studies/BenzSalzmann2025.lean
+++ b/Linglib/Studies/BenzSalzmann2025.lean
@@ -239,14 +239,14 @@ def ePositionFromContrast (nounContrastive : Bool) : NomSpinePos :=
 /-- When N is contrastive, [E] is on n. The n head (to which N has moved)
     is external → the noun survives via its moved copy at n. -/
 theorem contrastive_nHead_survives :
-    nomSurvives .n ⟨ePositionFromContrast true, ""⟩ = true := rfl
+    nomSurvives .n ⟨ePositionFromContrast true, ""⟩ := by decide
 
 /-- When N is not contrastive, [E] is on Num. Both N (base position)
     and n are in the deletion domain — the noun is deleted along with
     all NP-internal and nP-internal material. -/
 theorem nonContrastive_noun_deleted :
-    nomInDeletionDomain .N ⟨ePositionFromContrast false, ""⟩ = true ∧
-    nomInDeletionDomain .n ⟨ePositionFromContrast false, ""⟩ = true := ⟨rfl, rfl⟩
+    nomInDeletionDomain .N ⟨ePositionFromContrast false, ""⟩ ∧
+    nomInDeletionDomain .n ⟨ePositionFromContrast false, ""⟩ := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 3: Predictions — Prenominal vs. Postnominal Asymmetry
@@ -262,13 +262,13 @@ theorem nonContrastive_noun_deleted :
     under n[E], only material below n (= NP-internal) is deleted. -/
 theorem prenominal_postnominal_asymmetry :
     -- Postnominal material (NP-internal = below n): deleted under n[E]
-    nomInDeletionDomain .N nStrandingNPE = true ∧
+    nomInDeletionDomain .N nStrandingNPE ∧
     -- Prenominal adjectives (nP-internal = above NP): survive n[E]
-    nomSurvives .NP_adj nStrandingNPE = true ∧
+    nomSurvives .NP_adj nStrandingNPE ∧
     -- Numerals (at Num level): survive n[E]
-    nomSurvives .Num nStrandingNPE = true ∧
+    nomSurvives .Num nStrandingNPE ∧
     -- D (determiner): always survives
-    nomSurvives .D nStrandingNPE = true := ⟨rfl, rfl, rfl, rfl⟩
+    nomSurvives .D nStrandingNPE := by decide
 
 /-- Individual prenominal deletion is impossible: any [E] position that
     puts the prenominal adjective in the deletion domain also puts N
@@ -300,11 +300,11 @@ theorem no_individual_numeral_deletion (p : NomSpinePos) :
     which deletes the entire NP. -/
 theorem all_or_nothing_postnominal :
     -- Under N-stranding: ALL NP-internal material is deleted
-    nomInDeletionDomain .N nStrandingNPE = true ∧
+    nomInDeletionDomain .N nStrandingNPE ∧
     -- Under nP-ellipsis: NP-internal material PLUS n-level material deleted
-    nomInDeletionDomain .N nPEllipsis = true ∧
-    nomInDeletionDomain .NP_adj nPEllipsis = true ∧
-    nomInDeletionDomain .n nPEllipsis = true := ⟨rfl, rfl, rfl, rfl⟩
+    nomInDeletionDomain .N nPEllipsis ∧
+    nomInDeletionDomain .NP_adj nPEllipsis ∧
+    nomInDeletionDomain .n nPEllipsis := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 4: N-Stranding as X-Stranding
@@ -319,14 +319,14 @@ theorem all_or_nothing_postnominal :
     (VP/NP) is deleted while the moved head survives. -/
 theorem n_stranding_parallels_v_stranding :
     -- N-stranding: n external under n[E], N's base deleted under n[E]
-    nomSurvives .n nStrandingNPE = true ∧
-    nomInDeletionDomain .N nStrandingNPE = true ∧
+    nomSurvives .n nStrandingNPE ∧
+    nomInDeletionDomain .N nStrandingNPE ∧
     -- V-stranding: v external under v[E], V deleted under v[E]
-    (isInDeletionDomain .v vVPE = false) ∧
-    isInDeletionDomain .V vVPE = true ∧
+    (¬ isInDeletionDomain .v vVPE) ∧
+    isInDeletionDomain .V vVPE ∧
     -- Same structural reason: lexical head below categorizer in both spines
-    NomSpinePos.N.isBelow NomSpinePos.n = true ∧
-    SpinePos.V.isBelow SpinePos.v = true := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+    inDomain NomSpinePos.N NomSpinePos.n ∧
+    inDomain SpinePos.V SpinePos.v := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 5: Connection to Saab (2026)
@@ -351,9 +351,9 @@ theorem german_spanish_e_height :
     Adjectives survive German n[E] but not Spanish Num[E]. -/
 theorem german_more_survivors_than_spanish :
     -- Adjective survives German N-stranding
-    nomSurvives .NP_adj nStrandingNPE = true ∧
+    nomSurvives .NP_adj nStrandingNPE ∧
     -- Adjective does NOT survive Spanish nP-ellipsis
-    nomSurvives .NP_adj nPEllipsis = false := ⟨rfl, rfl⟩
+    ¬ nomSurvives .NP_adj nPEllipsis := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 6: Gender Mismatch Parallel
@@ -377,12 +377,12 @@ theorem german_more_survivors_than_spanish :
     do become possible in our N-stranding NP-ellipsis data." -/
 theorem gender_voice_parallel :
     -- n external under n[E] → gender mismatch tolerated
-    nomSurvives .n nStrandingNPE = true ∧
+    nomSurvives .n nStrandingNPE ∧
     -- Voice external under Voice[E] → voice mismatch tolerated
-    canMismatch englishVPE voiceMismatch = true ∧
+    canMismatch englishVPE voiceMismatch ∧
     -- n internal under Num[E] → gender mismatch blocked
-    nomInDeletionDomain .n nPEllipsis = true ∧
+    nomInDeletionDomain .n nPEllipsis ∧
     -- Voice internal under C[E] → voice mismatch blocked
-    canMismatch sluicing voiceMismatch = false := ⟨rfl, rfl, rfl, rfl⟩
+    ¬ canMismatch sluicing voiceMismatch := by decide
 
 end BenzSalzmann2025

--- a/Linglib/Studies/Kalyakin2026.lean
+++ b/Linglib/Studies/Kalyakin2026.lean
@@ -58,15 +58,15 @@ open Minimalist.Ellipsis
 /-- The core prediction: vVPE tolerates both voice and transitivity
     mismatches while blocking lexical verb mismatches. -/
 theorem vVPE_mismatch_profile :
-    canMismatch vVPE voiceMismatch = true ∧
-    canMismatch vVPE transitivityMismatch = true ∧
-    canMismatch vVPE lexicalMismatch = false := ⟨rfl, rfl, rfl⟩
+    canMismatch vVPE voiceMismatch ∧
+    canMismatch vVPE transitivityMismatch ∧
+    ¬ canMismatch vVPE lexicalMismatch := by decide
 
 /-- English VPE has a strictly more restrictive profile than vVPE:
     it additionally blocks transitivity mismatches. -/
 theorem englishVPE_more_restrictive :
-    canMismatch englishVPE transitivityMismatch = false ∧
-    canMismatch vVPE transitivityMismatch = true := ⟨rfl, rfl⟩
+    ¬ canMismatch englishVPE transitivityMismatch ∧
+    canMismatch vVPE transitivityMismatch := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 2. Causative Alternation Under vVPE
@@ -130,12 +130,12 @@ theorem alternation_same_root :
 /-- The causative alternation is tolerated under vVPE because
     transitivity mismatches are allowed. -/
 theorem causative_alternation_ok_under_vVPE :
-    canMismatch vVPE transitivityMismatch = true := rfl
+    canMismatch vVPE transitivityMismatch := by decide
 
 /-- The causative alternation is blocked under English VPE because
     transitivity mismatches are blocked. -/
 theorem causative_alternation_blocked_english :
-    canMismatch englishVPE transitivityMismatch = false := rfl
+    ¬ canMismatch englishVPE transitivityMismatch := by decide
 
 /-- The same root structure is used in both alternants — the complement
     of v (= VP) is identical. This is why vVPE succeeds: it only
@@ -154,10 +154,10 @@ theorem shared_vp_core :
     to match the empirical judgment; `canMismatch` derives the same value
     from spine positions. -/
 theorem alternation_predicted_by_merchant :
-    inchoativeToCausative.grammatical = canMismatch vVPE transitivityMismatch ∧
-    causativeToInchoative.grammatical = canMismatch vVPE transitivityMismatch ∧
-    englishAlternationBlocked.grammatical = canMismatch englishVPE transitivityMismatch :=
-  ⟨rfl, rfl, rfl⟩
+    (inchoativeToCausative.grammatical = true ↔ canMismatch vVPE transitivityMismatch) ∧
+    (causativeToInchoative.grammatical = true ↔ canMismatch vVPE transitivityMismatch) ∧
+    (englishAlternationBlocked.grammatical = true ↔
+      canMismatch englishVPE transitivityMismatch) := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 4. Antipassive Blocking
@@ -167,12 +167,12 @@ theorem alternation_predicted_by_merchant :
     placing them outside vVPE's deletion domain. They therefore
     cannot be elided under vVPE. -/
 theorem antipassive_blocks_vVPE :
-    rootInVVPEDomain .adjoined = false := rfl
+    ¬ rootInVVPEDomain .adjoined := by decide
 
 /-- Change-of-state roots (object-adjoined) ARE inside vVPE's
     deletion domain — they can be elided. -/
 theorem change_of_state_allows_vVPE :
-    rootInVVPEDomain .complement = true := rfl
+    rootInVVPEDomain .complement := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 5. Cross-Linguistic Predictions
@@ -183,21 +183,21 @@ theorem change_of_state_allows_vVPE :
     Each step down tolerates strictly more mismatches. -/
 theorem mismatch_hierarchy :
     -- Sluicing: blocks both voice and transitivity
-    canMismatch sluicing voiceMismatch = false ∧
-    canMismatch sluicing transitivityMismatch = false ∧
+    ¬ canMismatch sluicing voiceMismatch ∧
+    ¬ canMismatch sluicing transitivityMismatch ∧
     -- English VPE: allows voice, blocks transitivity
-    canMismatch englishVPE voiceMismatch = true ∧
-    canMismatch englishVPE transitivityMismatch = false ∧
+    canMismatch englishVPE voiceMismatch ∧
+    ¬ canMismatch englishVPE transitivityMismatch ∧
     -- vVPE: allows both voice and transitivity
-    canMismatch vVPE voiceMismatch = true ∧
-    canMismatch vVPE transitivityMismatch = true := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
+    canMismatch vVPE voiceMismatch ∧
+    canMismatch vVPE transitivityMismatch := by
+  decide
 
 /-- vVPE's [E] position (v) is strictly below English VPE's (Voice).
     By monotonicity, any mismatch tolerated by English VPE is also
     tolerated by vVPE. -/
 theorem vVPE_below_englishVPE :
-    SpinePos.v.isBelow SpinePos.Voice = true := rfl
+    inDomain SpinePos.v SpinePos.Voice := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 6. End-to-End Argumentation Chain
@@ -224,10 +224,10 @@ theorem end_to_end_causative_chain :
     isCausative (buildDecomposition voiceAgent [.vCAUSE, .vGO, .vBE]) = true ∧
     isInchoative (buildDecomposition voiceAnticausative [.vCAUSE, .vGO, .vBE]) = true ∧
     -- Step 2: vVPE tolerates the transitivity difference (Merchant)
-    canMismatch vVPE transitivityMismatch = true ∧
+    canMismatch vVPE transitivityMismatch ∧
     -- Step 3: Alternation under vVPE is grammatical (Kalyakin)
     inchoativeToCausative.grammatical = true :=
-  ⟨rfl, rfl, rfl, rfl⟩
+  ⟨rfl, rfl, by decide, rfl⟩
 
 /-- Convergent prediction: Merchant's theory correctly predicts that
     sluicing (C[E]) blocks voice mismatches — Voice is inside TP, the
@@ -238,7 +238,7 @@ theorem end_to_end_causative_chain :
     The same theoretical apparatus that Kalyakin extends to vVPE
     already works for sluicing. -/
 theorem sluicing_voice_blocked_convergent :
-    canMismatch sluicing voiceMismatch = false := rfl
+    ¬ canMismatch sluicing voiceMismatch := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 7. Again Diagnostic
@@ -253,20 +253,20 @@ theorem sluicing_voice_blocked_convergent :
     [toosarvandani-2009] (ex. 90) independently shows both readings
     available for Persian vVPE. -/
 theorem vVPE_both_again :
-    againSurvives .vP_adjunction vVPE = true ∧
-    againSurvives .VP_adjunction vVPE = true := by native_decide
+    againSurvives .vP_adjunction vVPE ∧
+    againSurvives .VP_adjunction vVPE := by decide
 
 /-- English VPE deletes restitutive *again*: only repetitive survives.
     ([merchant-2013], building on Johnson 2004, von Stechow 1996). -/
 theorem englishVPE_only_repetitive :
-    againSurvives .vP_adjunction englishVPE = true ∧
-    againSurvives .VP_adjunction englishVPE = false := by native_decide
+    againSurvives .vP_adjunction englishVPE ∧
+    ¬ againSurvives .VP_adjunction englishVPE := by decide
 
 /-- The *again* contrast directly distinguishes vVPE from English VPE:
     same test, different result — proving different deletion domains. -/
 theorem again_distinguishes_vVPE_from_englishVPE :
-    againSurvives .VP_adjunction vVPE = true ∧
-    againSurvives .VP_adjunction englishVPE = false := by native_decide
+    againSurvives .VP_adjunction vVPE ∧
+    ¬ againSurvives .VP_adjunction englishVPE := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 8. Fragment Integration: NV Root Position → vVPE
@@ -278,17 +278,20 @@ open Dargwa.ComplexPredicates in
     The fragment's `AnnotatedCPr` stores `Root.Position` (from
     `Semantics/Lexical/Roots/Template.lean`); this function bridges to the
     Minimalist `rootInVVPEDomain` from `DeletionDomain.lean`. -/
-def cprInVVPEDomain (cpr : Dargwa.ComplexPredicates.AnnotatedCPr) : Bool :=
+def cprInVVPEDomain (cpr : Dargwa.ComplexPredicates.AnnotatedCPr) : Prop :=
   rootInVVPEDomain cpr.rootPosition
+
+instance (cpr : Dargwa.ComplexPredicates.AnnotatedCPr) : Decidable (cprInVVPEDomain cpr) := by
+  unfold cprInVVPEDomain; infer_instance
 
 open Dargwa.ComplexPredicates in
 
 /-- Change-of-state NVs (complement position) are inside vVPE's
     deletion domain: they can be elided. -/
 theorem cos_in_domain :
-    cprInVVPEDomain warmUp = true ∧ cprInVVPEDomain openCPr = true ∧
-    cprInVVPEDomain calmCPr = true ∧ cprInVVPEDomain praiseCPr = true ∧
-    cprInVVPEDomain repairCPr = true := ⟨rfl, rfl, rfl, rfl, rfl⟩
+    cprInVVPEDomain warmUp ∧ cprInVVPEDomain openCPr ∧
+    cprInVVPEDomain calmCPr ∧ cprInVVPEDomain praiseCPr ∧
+    cprInVVPEDomain repairCPr := by decide
 
 open Dargwa.ComplexPredicates in
 
@@ -296,7 +299,7 @@ open Dargwa.ComplexPredicates in
     deletion domain: they survive ellipsis. This is why antipassive
     roots (coerced to adjunction) block vVPE. -/
 theorem manner_outside_domain :
-    cprInVVPEDomain runCPr = false ∧ cprInVVPEDomain jumpCPr = false := ⟨rfl, rfl⟩
+    ¬ cprInVVPEDomain runCPr ∧ ¬ cprInVVPEDomain jumpCPr := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 9. NV-Drop Test (vVPE vs Argument Ellipsis)

--- a/Linglib/Studies/Merchant2013.lean
+++ b/Linglib/Studies/Merchant2013.lean
@@ -134,20 +134,20 @@ def ex11a : VoiceMismatchDatum :=
 
 /-- VP-ellipsis data matches canMismatch. -/
 theorem vpe_voice_predicted :
-    ex1a.grammatical = canMismatch englishVPE voiceMismatch ∧
-    ex2a.grammatical = canMismatch englishVPE voiceMismatch := ⟨rfl, rfl⟩
+    (ex1a.grammatical = true ↔ canMismatch englishVPE voiceMismatch) ∧
+    (ex2a.grammatical = true ↔ canMismatch englishVPE voiceMismatch) := by decide
 
 /-- Sluicing data matches canMismatch across three languages. -/
 theorem sluicing_voice_predicted :
-    ex5.grammatical  = canMismatch sluicing voiceMismatch ∧
-    ex6a.grammatical = canMismatch sluicing voiceMismatch ∧
-    ex25a.grammatical = canMismatch sluicing voiceMismatch := ⟨rfl, rfl, rfl⟩
+    (ex5.grammatical = true ↔ canMismatch sluicing voiceMismatch) ∧
+    (ex6a.grammatical = true ↔ canMismatch sluicing voiceMismatch) ∧
+    (ex25a.grammatical = true ↔ canMismatch sluicing voiceMismatch) := by decide
 
 /-- All high ellipsis types block voice mismatches. -/
 theorem high_ellipsis_voice_predicted :
-    ex9a.grammatical  = canMismatch fragmentAnswers voiceMismatch ∧
-    ex10a.grammatical = canMismatch gapping voiceMismatch ∧
-    ex11a.grammatical = canMismatch stripping voiceMismatch := ⟨rfl, rfl, rfl⟩
+    (ex9a.grammatical = true ↔ canMismatch fragmentAnswers voiceMismatch) ∧
+    (ex10a.grammatical = true ↔ canMismatch gapping voiceMismatch) ∧
+    (ex11a.grammatical = true ↔ canMismatch stripping voiceMismatch) := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 4. Argument Structure Alternation Data (§3.3)
@@ -220,14 +220,14 @@ def ex44 : ArgStructureDatum :=
 /-- Per-datum verification: each datum's grammaticality equals the
     canMismatch prediction for its alternation type and ellipsis type. -/
 theorem argStructure_data_predicted :
-    ex30a.grammatical = canMismatch ex30a.ellipsisType ex30a.alternationType ∧
-    ex31a.grammatical = canMismatch ex31a.ellipsisType ex31a.alternationType ∧
-    ex35a.grammatical = canMismatch ex35a.ellipsisType ex35a.alternationType ∧
-    ex36a.grammatical = canMismatch ex36a.ellipsisType ex36a.alternationType ∧
-    ex39a.grammatical = canMismatch ex39a.ellipsisType ex39a.alternationType ∧
-    ex43a.grammatical = canMismatch ex43a.ellipsisType ex43a.alternationType ∧
-    ex44.grammatical  = canMismatch ex44.ellipsisType ex44.alternationType := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
+    (ex30a.grammatical = true ↔ canMismatch ex30a.ellipsisType ex30a.alternationType) ∧
+    (ex31a.grammatical = true ↔ canMismatch ex31a.ellipsisType ex31a.alternationType) ∧
+    (ex35a.grammatical = true ↔ canMismatch ex35a.ellipsisType ex35a.alternationType) ∧
+    (ex36a.grammatical = true ↔ canMismatch ex36a.ellipsisType ex36a.alternationType) ∧
+    (ex39a.grammatical = true ↔ canMismatch ex39a.ellipsisType ex39a.alternationType) ∧
+    (ex43a.grammatical = true ↔ canMismatch ex43a.ellipsisType ex43a.alternationType) ∧
+    (ex44.grammatical = true ↔ canMismatch ex44.ellipsisType ex44.alternationType) := by
+  decide
 
 /-- All v-level alternations are blocked under high-[E] ellipsis types
     (sluicing, VPE, fragment answers, gapping, pseudogapping) — because
@@ -235,16 +235,16 @@ theorem argStructure_data_predicted :
     Under vVPE ([E] on v), these alternations ARE tolerated
     ([kalyakin-2026]). -/
 theorem v_alternations_blocked_high_ellipsis :
-    canMismatch sluicing dativeAlternation = false ∧
-    canMismatch sluicing prepAlternation = false ∧
-    canMismatch sluicing middleAlternation = false ∧
-    canMismatch englishVPE dativeAlternation = false ∧
-    canMismatch englishVPE prepAlternation = false ∧
-    canMismatch englishVPE middleAlternation = false ∧
-    canMismatch fragmentAnswers dativeAlternation = false ∧
-    canMismatch gapping middleAlternation = false ∧
-    canMismatch pseudogapping prepAlternation = false := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
+    ¬ canMismatch sluicing dativeAlternation ∧
+    ¬ canMismatch sluicing prepAlternation ∧
+    ¬ canMismatch sluicing middleAlternation ∧
+    ¬ canMismatch englishVPE dativeAlternation ∧
+    ¬ canMismatch englishVPE prepAlternation ∧
+    ¬ canMismatch englishVPE middleAlternation ∧
+    ¬ canMismatch fragmentAnswers dativeAlternation ∧
+    ¬ canMismatch gapping middleAlternation ∧
+    ¬ canMismatch pseudogapping prepAlternation := by
+  decide
 
 -- ════════════════════════════════════════════════════
 -- § 6. Key Theoretical Claims
@@ -253,38 +253,36 @@ theorem v_alternations_blocked_high_ellipsis :
 /-- The uneven distribution: voice mismatches are tolerated in VP-ellipsis
     (low [E]) but blocked in all clausal ellipses (high [E]). -/
 theorem uneven_distribution :
-    canMismatch englishVPE voiceMismatch = true ∧
-    canMismatch sluicing voiceMismatch = false ∧
-    canMismatch fragmentAnswers voiceMismatch = false ∧
-    canMismatch gapping voiceMismatch = false ∧
-    canMismatch stripping voiceMismatch = false ∧
-    canMismatch pseudogapping voiceMismatch = false := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
+    canMismatch englishVPE voiceMismatch ∧
+    ¬ canMismatch sluicing voiceMismatch ∧
+    ¬ canMismatch fragmentAnswers voiceMismatch ∧
+    ¬ canMismatch gapping voiceMismatch ∧
+    ¬ canMismatch stripping voiceMismatch ∧
+    ¬ canMismatch pseudogapping voiceMismatch := by
+  decide
 
 /-- Voice is the discriminating dimension: the only mismatch that
     distinguishes VP-ellipsis from sluicing. All v-level and V-level
     dimensions are blocked under both. -/
 theorem voice_uniquely_discriminates :
-    canMismatch englishVPE voiceMismatch ≠ canMismatch sluicing voiceMismatch ∧
-    canMismatch englishVPE transitivityMismatch =
-      canMismatch sluicing transitivityMismatch ∧
-    canMismatch englishVPE dativeAlternation =
-      canMismatch sluicing dativeAlternation ∧
-    canMismatch englishVPE lexicalMismatch =
-      canMismatch sluicing lexicalMismatch := by
-  refine ⟨?_, ?_, ?_, ?_⟩
-  · intro h; cases h
-  · native_decide
-  · native_decide
-  · native_decide
+    -- voice DISCRIMINATES: VPE tolerates it, sluicing does not
+    (canMismatch englishVPE voiceMismatch ∧ ¬ canMismatch sluicing voiceMismatch) ∧
+    -- all other dimensions AGREE between VPE and sluicing
+    (canMismatch englishVPE transitivityMismatch ↔
+      canMismatch sluicing transitivityMismatch) ∧
+    (canMismatch englishVPE dativeAlternation ↔
+      canMismatch sluicing dativeAlternation) ∧
+    (canMismatch englishVPE lexicalMismatch ↔
+      canMismatch sluicing lexicalMismatch) := by
+  decide
 
 /-- Merchant's negative prediction: if voice mismatches were tolerated
     in sluicing (high [E]), monotonicity would force them to be tolerated
     in VP-ellipsis (low [E]) too. No language can have the reverse of
     the attested pattern. -/
 theorem no_inverse_language :
-    canMismatch sluicing voiceMismatch = true →
-    canMismatch englishVPE voiceMismatch = true :=
+    canMismatch sluicing voiceMismatch →
+    canMismatch englishVPE voiceMismatch :=
   fun h => mismatch_monotone voiceMismatch sluicing englishVPE h rfl
 
 /-- Voice's discriminating power follows from its spine position:
@@ -318,11 +316,11 @@ theorem end_to_end_voice_chain :
     -- Step 1: Active and passive are distinct Voice flavors
     VoiceFlavor.agentive ≠ VoiceFlavor.passive ∧
     -- Step 2: Voice is external to VPE's deletion domain
-    canMismatch englishVPE voiceMismatch = true ∧
+    canMismatch englishVPE voiceMismatch ∧
     -- Step 3: Empirical data matches
     ex1a.grammatical = true ∧
     ex2a.grammatical = true := by
-  refine ⟨?_, rfl, rfl, rfl⟩
+  refine ⟨?_, by decide, rfl, rfl⟩
   intro h; cases h
 
 /-- The *again* diagnostic (§4): under VPE, only repetitive *again*
@@ -330,7 +328,7 @@ theorem end_to_end_voice_chain :
     VP-adjunction) is inside the deletion domain. This confirms
     that VPE targets vP, not VP. -/
 theorem again_confirms_vp_boundary :
-    againSurvives .vP_adjunction englishVPE = true ∧
-    againSurvives .VP_adjunction englishVPE = false := by native_decide
+    againSurvives .vP_adjunction englishVPE ∧
+    ¬ againSurvives .VP_adjunction englishVPE := by decide
 
 end Merchant2013

--- a/Linglib/Syntax/Minimalist/Ellipsis/DeletionDomain.lean
+++ b/Linglib/Syntax/Minimalist/Ellipsis/DeletionDomain.lean
@@ -67,14 +67,17 @@ open Verb
     - [E] on head H → complement of H (everything `isBelow` H) is deleted
     - Monotonicity: lower [E] → smaller deletion domain
     - Irreflexivity: H itself is never in its own deletion domain -/
-class DeletionSpine (α : Type) where
+class DeletionSpine (α : Type*) where
   /-- `isBelow p₁ p₂` = true iff p₁ is in the deletion domain when [E]
       is at p₂. Encodes the complement-of relation, NOT simple structural
       ordering — adjunction sites may be structurally between two heads
-      without being in the lower head's complement. -/
+      without being in the lower head's complement. A `Bool` decision
+      procedure; the `Prop` predicate layer (`inDomain`/`canMismatch`)
+      is built on top. -/
   isBelow : α → α → Bool
   /-- `isAtOrBelow p₁ p₂` = true iff p₁ is structurally at or below p₂.
-      A simple linear ordering used for monotonicity reasoning. -/
+      A simple linear ordering used for monotonicity reasoning.
+      (A mathlib `LinearOrder` upgrade of this is a planned follow-up.) -/
   isAtOrBelow : α → α → Bool
   /-- No position is in its own deletion domain. -/
   isBelow_irrefl : ∀ (p : α), isBelow p p = false
@@ -83,30 +86,14 @@ class DeletionSpine (α : Type) where
   isBelow_mono : ∀ (d p₁ p₂ : α),
     isBelow d p₁ = false → isAtOrBelow p₂ p₁ = true → isBelow d p₂ = false
 
-/-- Generic: is position c in the deletion domain of [E] at ePos? -/
-def inDomain {α : Type} [DeletionSpine α] (c ePos : α) : Bool :=
-  DeletionSpine.isBelow c ePos
+/-- Generic: is position c in the deletion domain of [E] at ePos?
+    A `Prop` predicate; the underlying `isBelow` stays a `Bool` decision
+    procedure (the `Nat.ble`-style computational core). -/
+def inDomain {α : Type*} [DeletionSpine α] (c ePos : α) : Prop :=
+  DeletionSpine.isBelow c ePos = true
 
-/-- Generic: a mismatch at head position dPos is tolerated under [E] at
-    ePos iff dPos is external (not in the deletion domain). -/
-def toleratesMismatch {α : Type} [DeletionSpine α] (ePos dPos : α) : Bool :=
-  !inDomain dPos ePos
-
-/-- The [E]-bearing head is always external to its own deletion domain. -/
-theorem eHead_external {α : Type} [DeletionSpine α] (ePos : α) :
-    inDomain ePos ePos = false :=
-  DeletionSpine.isBelow_irrefl ePos
-
-/-- Generic monotonicity: if a mismatch is tolerated at ePos₁, it is
-    tolerated at any structurally lower ePos₂.
-    [sailor-2014]'s generalization, proved once for all spines. -/
-theorem toleratesMismatch_mono {α : Type} [DeletionSpine α]
-    (dPos ePos₁ ePos₂ : α)
-    (h₁ : toleratesMismatch ePos₁ dPos = true)
-    (h₂ : DeletionSpine.isAtOrBelow ePos₂ ePos₁ = true) :
-    toleratesMismatch ePos₂ dPos = true := by
-  simp only [toleratesMismatch, inDomain, Bool.not_eq_true'] at *
-  exact DeletionSpine.isBelow_mono dPos ePos₁ ePos₂ h₁ h₂
+instance {α : Type*} [DeletionSpine α] (c ePos : α) : Decidable (inDomain c ePos) := by
+  unfold inDomain; infer_instance
 
 /-- X-stranding ([liptak-saab-2014]): if X has moved from `base` to
     the [E]-bearing head at `ePos`, X is external (survives ellipsis)
@@ -119,10 +106,10 @@ theorem toleratesMismatch_mono {α : Type} [DeletionSpine α]
     Instances:
     - V-stranding VPE: V moves to v, [E] on v → V survives, VP deleted
     - N-stranding NP-ellipsis: N moves to n, [E] on n → N survives, NP deleted -/
-theorem xStranding {α : Type} [DeletionSpine α] (ePos base : α)
-    (h_base_in_domain : DeletionSpine.isBelow base ePos = true) :
-    inDomain ePos ePos = false ∧ inDomain base ePos = true :=
-  ⟨DeletionSpine.isBelow_irrefl ePos, h_base_in_domain⟩
+theorem xStranding {α : Type*} [DeletionSpine α] (ePos base : α)
+    (h_base_in_domain : inDomain base ePos) :
+    ¬ inDomain ePos ePos ∧ inDomain base ePos :=
+  ⟨by simp [inDomain, DeletionSpine.isBelow_irrefl ePos], h_base_in_domain⟩
 
 -- ════════════════════════════════════════════════════
 -- § 1. Clausal Spine
@@ -223,8 +210,11 @@ theorem isSurface (e : EllipsisType) : Anaphor.HasDepth.IsSurface e := rfl
 /-- Is a spine position inside the deletion domain of an ellipsis type?
     A position is in the deletion domain iff it is strictly below the
     [E]-bearing head. -/
-def isInDeletionDomain (c : SpinePos) (e : EllipsisType) : Bool :=
-  c.isBelow e.ePosition
+def isInDeletionDomain (c : SpinePos) (e : EllipsisType) : Prop :=
+  inDomain c e.ePosition
+
+instance (c : SpinePos) (e : EllipsisType) : Decidable (isInDeletionDomain c e) := by
+  unfold isInDeletionDomain; infer_instance
 
 /-- Sluicing: [E] on C, deletes TP. Contains Voice → voice mismatch blocked. -/
 def sluicing : EllipsisType := ⟨.C, "sluicing"⟩
@@ -280,8 +270,11 @@ def middleAlternation : MismatchDimension := ⟨"middle alternation", .v⟩
 /-- A mismatch in dimension d is tolerated by ellipsis type e iff the
     head bearing the feature is NOT in the deletion domain — i.e., it
     is at or above the [E]-bearing head. -/
-def canMismatch (e : EllipsisType) (d : MismatchDimension) : Bool :=
-  !isInDeletionDomain d.headPosition e
+def canMismatch (e : EllipsisType) (d : MismatchDimension) : Prop :=
+  ¬ isInDeletionDomain d.headPosition e
+
+instance (e : EllipsisType) (d : MismatchDimension) : Decidable (canMismatch e d) := by
+  unfold canMismatch; infer_instance
 
 -- ════════════════════════════════════════════════════
 -- § 4. Core Predictions
@@ -291,84 +284,85 @@ def canMismatch (e : EllipsisType) (d : MismatchDimension) : Bool :=
 
 /-- English VPE tolerates voice mismatches: Voice is external to vP. -/
 theorem englishVPE_voice_ok :
-    canMismatch englishVPE voiceMismatch = true := by decide
+    canMismatch englishVPE voiceMismatch := by decide
 
 /-- English VPE blocks transitivity mismatches: v is inside vP. -/
 theorem englishVPE_transitivity_blocked :
-    canMismatch englishVPE transitivityMismatch = false := by decide
+    ¬ canMismatch englishVPE transitivityMismatch := by decide
 
 /-- English VPE blocks lexical verb mismatches: V is inside vP. -/
 theorem englishVPE_lexical_blocked :
-    canMismatch englishVPE lexicalMismatch = false := by decide
+    ¬ canMismatch englishVPE lexicalMismatch := by decide
 
 -- Sluicing: [E] on C
 
 /-- Sluicing blocks voice mismatches: Voice is inside TP. -/
 theorem sluicing_voice_blocked :
-    canMismatch sluicing voiceMismatch = false := by decide
+    ¬ canMismatch sluicing voiceMismatch := by decide
 
 /-- Sluicing blocks transitivity mismatches: v is inside TP. -/
 theorem sluicing_transitivity_blocked :
-    canMismatch sluicing transitivityMismatch = false := by decide
+    ¬ canMismatch sluicing transitivityMismatch := by decide
 
 -- v-stranding VPE: [E] on v
 
 /-- vVPE tolerates voice mismatches: Voice is external to VP. -/
 theorem vVPE_voice_ok :
-    canMismatch vVPE voiceMismatch = true := by decide
+    canMismatch vVPE voiceMismatch := by decide
 
 /-- vVPE tolerates transitivity mismatches: v is external to VP. -/
 theorem vVPE_transitivity_ok :
-    canMismatch vVPE transitivityMismatch = true := by decide
+    canMismatch vVPE transitivityMismatch := by decide
 
 /-- vVPE blocks lexical verb mismatches: V is inside VP. -/
 theorem vVPE_lexical_blocked :
-    canMismatch vVPE lexicalMismatch = false := by decide
+    ¬ canMismatch vVPE lexicalMismatch := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 5. Monotonicity
 -- ════════════════════════════════════════════════════
 
-/-- If a head is outside the deletion domain at position p₁, then it
-    is also outside the deletion domain at any lower position p₂.
-    This is [sailor-2014]'s monotonicity: lower [E] → smaller
-    domain → more mismatches tolerated. -/
-private theorem isBelow_monotone (d p₁ p₂ : SpinePos)
-    (h₁ : d.isBelow p₁ = false) (h₂ : p₂.isAtOrBelow p₁ = true) :
-    d.isBelow p₂ = false := by
-  cases d <;> cases p₁ <;> cases p₂ <;>
-    simp_all [SpinePos.isBelow, SpinePos.isAtOrBelow]
-
 /-- Monotonicity of mismatch tolerance: if ellipsis type e₁ tolerates
     a mismatch dimension d, then any ellipsis type e₂ whose [E] position
-    is at or below e₁'s also tolerates d. -/
+    is at or below e₁'s also tolerates d. [sailor-2014]'s monotonicity:
+    lower [E] → smaller domain → more mismatches tolerated. Routed through
+    the generic class law `DeletionSpine.isBelow_mono`. -/
 theorem mismatch_monotone (d : MismatchDimension) (e₁ e₂ : EllipsisType)
-    (h₁ : canMismatch e₁ d = true)
+    (h₁ : canMismatch e₁ d)
     (h₂ : e₂.ePosition.isAtOrBelow e₁.ePosition = true) :
-    canMismatch e₂ d = true := by
-  simp only [canMismatch, isInDeletionDomain, Bool.not_eq_true'] at *
-  exact isBelow_monotone d.headPosition e₁.ePosition e₂.ePosition h₁ h₂
+    canMismatch e₂ d := by
+  simp only [canMismatch, isInDeletionDomain, inDomain, Bool.not_eq_true] at h₁ ⊢
+  exact DeletionSpine.isBelow_mono d.headPosition e₁.ePosition e₂.ePosition h₁ h₂
 
 -- ════════════════════════════════════════════════════
 -- § 6. Root Attachment Position
 -- ════════════════════════════════════════════════════
 
-/-- Is a root inside the vVPE deletion domain (= VP)?
-    Uses `Root.Position` (`Semantics/Lexical/Roots/Template.lean`; Marantz,
-    [beavers-koontz-garboden-2020]):
-    - `.complement` roots (change-of-state) are inside VP → deleted
-    - `.adjoined` roots (manner/activity) are outside VP → survive -/
-def rootInVVPEDomain : Root.Position → Bool
-  | .complement => true
-  | .adjoined => false
+/-- Spine position of a root by its attachment (`Root.Position`,
+    `Semantics/Lexical/Roots/Template.lean`; Marantz, [beavers-koontz-garboden-2020]):
+    change-of-state `.complement` roots sit at `V` (in v's complement),
+    manner/activity `.adjoined` roots at `VP_adj` (outside it). -/
+def rootSpinePos : Root.Position → SpinePos
+  | .complement => .V
+  | .adjoined => .VP_adj
 
-/-- Complement roots (change-of-state) are deleted under vVPE. -/
-theorem complementRoot_in_vVPE : rootInVVPEDomain .complement = true := rfl
+/-- Is a root inside the vVPE deletion domain (= complement of v)?
+    Derived from the spine, not stipulated: a root is deleted under vVPE
+    iff its attachment position is below `v`. -/
+def rootInVVPEDomain (p : Root.Position) : Prop :=
+  isInDeletionDomain (rootSpinePos p) vVPE
 
-/-- Adjoined roots (manner/activity) survive vVPE — they are outside
-    the deletion domain. This is why antipassive roots block vVPE in
-    Muira Dargwa: antipassive coerces adjunction ([kalyakin-2026]). -/
-theorem adjoinedRoot_outside_vVPE : rootInVVPEDomain .adjoined = false := rfl
+instance (p : Root.Position) : Decidable (rootInVVPEDomain p) := by
+  unfold rootInVVPEDomain; infer_instance
+
+/-- Complement roots (change-of-state) are deleted under vVPE: `V` is in
+    v's complement (follows from the spine, not stipulated). -/
+theorem complementRoot_in_vVPE : rootInVVPEDomain .complement := by decide
+
+/-- Adjoined roots (manner/activity) survive vVPE — `VP_adj` is outside
+    v's complement. This is why antipassive roots block vVPE in Muira
+    Dargwa: antipassive coerces adjunction ([kalyakin-2026]). -/
+theorem adjoinedRoot_outside_vVPE : ¬ rootInVVPEDomain .adjoined := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 7. Again Ambiguity
@@ -391,18 +385,21 @@ inductive AgainPosition where
     v's complement (survives vVPE, [E] on v). The distinction between
     `VP_adj` and `V` is crucial: V (the head) is in v's complement,
     but VP-adjunction is at the complement boundary, outside it. -/
-def againSurvives (pos : AgainPosition) (e : EllipsisType) : Bool :=
+def againSurvives (pos : AgainPosition) (e : EllipsisType) : Prop :=
   match pos with
-  | .vP_adjunction => !isInDeletionDomain .Voice e   -- VoiceP-level adjunction
-  | .VP_adjunction => !isInDeletionDomain .VP_adj e   -- VP-adjunction level
+  | .vP_adjunction => ¬ isInDeletionDomain .Voice e   -- VoiceP-level adjunction
+  | .VP_adjunction => ¬ isInDeletionDomain .VP_adj e   -- VP-adjunction level
+
+instance (pos : AgainPosition) (e : EllipsisType) : Decidable (againSurvives pos e) := by
+  unfold againSurvives; split <;> infer_instance
 
 /-- Under English VPE, restitutive *again* is inside the deletion domain
     (deleted), while repetitive *again* survives.
     [merchant-2013]: only repetitive reading available (Johnson 2004
     exx. 49a–b). -/
 theorem englishVPE_again :
-    againSurvives .vP_adjunction englishVPE = true ∧
-    againSurvives .VP_adjunction englishVPE = false := by decide
+    againSurvives .vP_adjunction englishVPE ∧
+    ¬ againSurvives .VP_adjunction englishVPE := by decide
 
 /-- Under vVPE, BOTH readings survive: restitutive *again* (VP-adjoined)
     is outside v's complement, so it is not deleted.
@@ -411,8 +408,8 @@ theorem englishVPE_again :
     This is the key diagnostic proving the deletion domain is VP (smaller
     than English VPE's vP). -/
 theorem vVPE_again :
-    againSurvives .vP_adjunction vVPE = true ∧
-    againSurvives .VP_adjunction vVPE = true := by decide
+    againSurvives .vP_adjunction vVPE ∧
+    againSurvives .VP_adjunction vVPE := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 8. Cross-Linguistic Comparison
@@ -420,21 +417,21 @@ theorem vVPE_again :
 
 /-- English VPE and vVPE agree on voice: both tolerate voice mismatches. -/
 theorem voice_agreement :
-    canMismatch englishVPE voiceMismatch = true ∧
-    canMismatch vVPE voiceMismatch = true := ⟨rfl, rfl⟩
+    canMismatch englishVPE voiceMismatch ∧
+    canMismatch vVPE voiceMismatch := by decide
 
 /-- English VPE and vVPE diverge on transitivity: English blocks it,
     vVPE allows it. This is the key prediction that distinguishes the
     two ellipsis types. -/
 theorem transitivity_divergence :
-    canMismatch englishVPE transitivityMismatch = false ∧
-    canMismatch vVPE transitivityMismatch = true := ⟨rfl, rfl⟩
+    ¬ canMismatch englishVPE transitivityMismatch ∧
+    canMismatch vVPE transitivityMismatch := by decide
 
 /-- Both block lexical verb mismatches: V is inside the deletion domain
     of both English VPE and vVPE. -/
 theorem lexical_blocked_both :
-    canMismatch englishVPE lexicalMismatch = false ∧
-    canMismatch vVPE lexicalMismatch = false := ⟨rfl, rfl⟩
+    ¬ canMismatch englishVPE lexicalMismatch ∧
+    ¬ canMismatch vVPE lexicalMismatch := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 9. Cross-Linguistic vVPE Typology
@@ -494,14 +491,14 @@ theorem dargwa_persian_same_domain :
 theorem bangla_larger_domain :
     banglaVVPE.ellipsisType.ePosition = SpinePos.Voice ∧
     muiraDargwaVVPE.ellipsisType.ePosition = SpinePos.v ∧
-    SpinePos.v.isBelow SpinePos.Voice = true := ⟨rfl, rfl, rfl⟩
+    inDomain SpinePos.v SpinePos.Voice := by decide
 
 /-- The *again* test correctly differentiates Bangla (vP domain) from
     Muira Dargwa (VP domain): restitutive *again* is deleted under
     Bangla's ellipsis but survives Muira Dargwa's. -/
 theorem again_differentiates_bangla_dargwa :
-    againSurvives .VP_adjunction banglaVVPE.ellipsisType = false ∧
-    againSurvives .VP_adjunction muiraDargwaVVPE.ellipsisType = true := by
+    ¬ againSurvives .VP_adjunction banglaVVPE.ellipsisType ∧
+    againSurvives .VP_adjunction muiraDargwaVVPE.ellipsisType := by
   decide
 
 -- ════════════════════════════════════════════════════
@@ -573,12 +570,18 @@ structure NomEllipsisType where
   deriving Repr
 
 /-- Is a nominal position in the deletion domain? -/
-def nomInDeletionDomain (c : NomSpinePos) (e : NomEllipsisType) : Bool :=
-  c.isBelow e.ePosition
+def nomInDeletionDomain (c : NomSpinePos) (e : NomEllipsisType) : Prop :=
+  inDomain c e.ePosition
+
+instance (c : NomSpinePos) (e : NomEllipsisType) : Decidable (nomInDeletionDomain c e) := by
+  unfold nomInDeletionDomain; infer_instance
 
 /-- Does a nominal position survive ellipsis? -/
-def nomSurvives (c : NomSpinePos) (e : NomEllipsisType) : Bool :=
-  !nomInDeletionDomain c e
+def nomSurvives (c : NomSpinePos) (e : NomEllipsisType) : Prop :=
+  ¬ nomInDeletionDomain c e
+
+instance (c : NomSpinePos) (e : NomEllipsisType) : Decidable (nomSurvives c e) := by
+  unfold nomSurvives; infer_instance
 
 /-- NumP-ellipsis: [E] on D, deletes everything below D.
     Determiner/demonstrative survives; N, adjectives, numerals deleted. -/
@@ -602,54 +605,54 @@ def nStrandingNPE : NomEllipsisType := ⟨.n, "N-stranding NP-ellipsis"⟩
 /-- Under N-stranding, NP-internal material (postnominal PPs, relatives,
     genitive arguments) is in the deletion domain. -/
 theorem nStranding_deletes_NP :
-    nomInDeletionDomain .N nStrandingNPE = true := rfl
+    nomInDeletionDomain .N nStrandingNPE := by decide
 
 /-- Under N-stranding, prenominal adjectives survive: they are inside nP
     but NOT in n's complement (NP).
     [benz-salzmann-2025] ex. (25): *Ich habe das schönste Auto und du
     das schönste Motorrad — adjective cannot be deleted. -/
 theorem nStranding_adj_survives :
-    nomSurvives .NP_adj nStrandingNPE = true := rfl
+    nomSurvives .NP_adj nStrandingNPE := by decide
 
 /-- Under N-stranding, the n head is external (it bears [E]). N moves
     here via N-to-n head movement and survives. -/
 theorem nStranding_n_external :
-    nomSurvives .n nStrandingNPE = true := rfl
+    nomSurvives .n nStrandingNPE := by decide
 
 /-- Under N-stranding, Num is external (numerals survive).
     [benz-salzmann-2025] ex. (25b): numeral *zwei* cannot be deleted
     under N-stranding. -/
 theorem nStranding_num_survives :
-    nomSurvives .Num nStrandingNPE = true := rfl
+    nomSurvives .Num nStrandingNPE := by decide
 
 -- nP-ellipsis: [E] on Num
 
 /-- Under nP-ellipsis, N is in the deletion domain (N does not survive). -/
 theorem nPE_deletes_N :
-    nomInDeletionDomain .N nPEllipsis = true := rfl
+    nomInDeletionDomain .N nPEllipsis := by decide
 
 /-- Under nP-ellipsis, prenominal adjectives are deleted (inside nP). -/
 theorem nPE_deletes_adj :
-    nomInDeletionDomain .NP_adj nPEllipsis = true := rfl
+    nomInDeletionDomain .NP_adj nPEllipsis := by decide
 
 /-- Under nP-ellipsis, n is deleted. -/
 theorem nPE_deletes_n :
-    nomInDeletionDomain .n nPEllipsis = true := rfl
+    nomInDeletionDomain .n nPEllipsis := by decide
 
 /-- Under nP-ellipsis, Num is external (numerals survive).
     [saab-2026]: the numeral/determiner remnant in Spanish
     pseudo-partitive ellipsis. -/
 theorem nPE_num_survives :
-    nomSurvives .Num nPEllipsis = true := rfl
+    nomSurvives .Num nPEllipsis := by decide
 
 -- NumP-ellipsis: [E] on D
 
 /-- Under NumP-ellipsis, everything below D is deleted. -/
 theorem numPE_deletes_all :
-    nomInDeletionDomain .N numPEllipsis = true ∧
-    nomInDeletionDomain .NP_adj numPEllipsis = true ∧
-    nomInDeletionDomain .n numPEllipsis = true ∧
-    nomInDeletionDomain .Num numPEllipsis = true := ⟨rfl, rfl, rfl, rfl⟩
+    nomInDeletionDomain .N numPEllipsis ∧
+    nomInDeletionDomain .NP_adj numPEllipsis ∧
+    nomInDeletionDomain .n numPEllipsis ∧
+    nomInDeletionDomain .Num numPEllipsis := by decide
 
 -- Monotonicity across nominal ellipsis types
 
@@ -658,15 +661,15 @@ theorem numPE_deletes_all :
     Anything deleted under n[E] is also deleted under Num[E] and D[E]. -/
 theorem nom_deletion_monotone :
     -- N is deleted under all three
-    nomInDeletionDomain .N nStrandingNPE = true ∧
-    nomInDeletionDomain .N nPEllipsis = true ∧
-    nomInDeletionDomain .N numPEllipsis = true ∧
+    nomInDeletionDomain .N nStrandingNPE ∧
+    nomInDeletionDomain .N nPEllipsis ∧
+    nomInDeletionDomain .N numPEllipsis ∧
     -- NP_adj: NOT deleted under N-stranding, IS deleted under nP-ellipsis
-    nomSurvives .NP_adj nStrandingNPE = true ∧
-    nomInDeletionDomain .NP_adj nPEllipsis = true ∧
+    nomSurvives .NP_adj nStrandingNPE ∧
+    nomInDeletionDomain .NP_adj nPEllipsis ∧
     -- n: NOT deleted under N-stranding, IS deleted under nP-ellipsis
-    nomSurvives .n nStrandingNPE = true ∧
-    nomInDeletionDomain .n nPEllipsis = true := ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+    nomSurvives .n nStrandingNPE ∧
+    nomInDeletionDomain .n nPEllipsis := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 12. X-Stranding Instantiations
@@ -677,17 +680,17 @@ theorem nom_deletion_monotone :
     domain but the n head (where N has moved) is external.
     [benz-salzmann-2025]: German N-stranding NP-ellipsis. -/
 theorem n_stranding_is_xStranding :
-    inDomain NomSpinePos.n NomSpinePos.n = false ∧
-    inDomain NomSpinePos.N NomSpinePos.n = true :=
-  xStranding NomSpinePos.n NomSpinePos.N rfl
+    ¬ inDomain NomSpinePos.n NomSpinePos.n ∧
+    inDomain NomSpinePos.N NomSpinePos.n :=
+  xStranding NomSpinePos.n NomSpinePos.N (by decide)
 
 /-- V-to-v movement is the clausal analogue: V (base) is below v (landing),
     so when [E] is on v, V's base position is deleted but v survives.
     This is exactly v-stranding VPE ([kalyakin-2026]). -/
 theorem v_stranding_is_xStranding :
-    inDomain SpinePos.v SpinePos.v = false ∧
-    inDomain SpinePos.V SpinePos.v = true :=
-  xStranding SpinePos.v SpinePos.V rfl
+    ¬ inDomain SpinePos.v SpinePos.v ∧
+    inDomain SpinePos.V SpinePos.v :=
+  xStranding SpinePos.v SpinePos.V (by decide)
 
 /-- The clausal and nominal X-stranding patterns are structurally
     identical: both are instances of the generic `xStranding` theorem
@@ -695,8 +698,8 @@ theorem v_stranding_is_xStranding :
     V:v :: N:n — the same abstract relationship. -/
 theorem clausal_nominal_xStranding_parallel :
     -- Clausal: V below v
-    SpinePos.V.isBelow SpinePos.v = true ∧
+    inDomain SpinePos.V SpinePos.v ∧
     -- Nominal: N below n
-    NomSpinePos.N.isBelow NomSpinePos.n = true := ⟨rfl, rfl⟩
+    inDomain NomSpinePos.N NomSpinePos.n := by decide
 
 end Minimalist.Ellipsis


### PR DESCRIPTION
Re-lands the deletion-domain `Bool`→`Prop` conversion against `main`. (It was previously merged as #659 but into the intermediate `audit-ahm-sluicing` branch *after* that branch had already been squashed to main as #656, so the conversion never reached `main` — this PR brings it the rest of the way. Identical content; cherry-picked cleanly onto current main.)

Convert the deletion-domain predicate layer from `Bool` to `Prop` + `Decidable`: `canMismatch`, `isInDeletionDomain`, `inDomain`, `nomInDeletionDomain`, `nomSurvives`, `againSurvives`, `rootInVVPEDomain`. Consumers lose all `= true`/`= false` noise; proofs stay `by decide`. Larger sibling of #657 (`isInArgumentDomain`).

- `rootInVVPEDomain` now derives from the spine (`Root.Position → SpinePos` + `isInDeletionDomain`) instead of a stipulated table.
- Pruned the dead generic API; deleted the `private isBelow_monotone` duplicate (routed `mismatch_monotone` through the class law).
- Datum-conformance theorems restated as `↔`; the `≠`/`=` discrimination theorem restated semantically; `native_decide` → `decide` swept in Merchant2013/Kalyakin2026.

The `isBelow`/`isAtOrBelow` spine relations stay `Bool` decision procedures; a mathlib `LinearOrder` upgrade is a deliberate follow-up (`scratch/deletion-domain-prop-refactor-spec.md`).