### PR TITLE
refactor(Core/Computability/Subregular): golf 𝒟/𝒦/ℒℐ equation sections

### DIFF
--- a/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
@@ -67,11 +67,6 @@ def kGeneralizedDefiniteEquation : Prop :=
 
 variable {L} {k}
 
-/-- `(· ∈ L)` factors through `f` when `f` preserves membership pointwise. -/
-private lemma factorsThrough_of_mem_iff {f : List α → List α}
-    (key : ∀ w, w ∈ L ↔ f w ∈ L) : Function.FactorsThrough (· ∈ L) f :=
-  fun a b hab => by simp only [key a, key b, hab]
-
 /-! ### Definite (`𝒟`) -/
 
 /-- Under the `𝒟` equation, prepending any prefix to a length-`k` word fixes its class. -/
@@ -93,22 +88,24 @@ theorem IsDefinite.satisfies_kDefiniteEquation (hL : L.IsDefinite k) :
       show x ++ αs ++ y = x ++ (αs ++ y) by simp [List.append_assoc],
       Edge.takeAt_right_append_of_le_length _ _ h, Edge.takeAt_right_append_of_le_length _ _ h]
 
+/-- Under the `𝒟` equation a word and its length-`k` suffix share a syntactic class
+("the class is memoryless past the `k`-suffix") — the pivot for the reverse direction. -/
+private lemma syntacticClass_eq_takeAt (h : kDefiniteEquation L k) (w : List α) :
+    L.syntacticClass w = L.syntacticClass (Edge.right.takeAt k w) := by
+  by_cases hw : w.length ≤ k
+  · rw [Edge.takeAt_of_length_le _ hw]
+  · have hlen : (Edge.right.takeAt k w).length = k := by rw [Edge.length_takeAt]; omega
+    have base := syntacticClass_of_kDefiniteEquation h
+      (w.take (w.length - k)) (Edge.right.takeAt k w) hlen
+    have decomp : w = w.take (w.length - k) ++ Edge.right.takeAt k w :=
+      (List.rdrop_append_rtake w k).symm
+    rwa [← decomp] at base
+
 /-- Reverse: the `𝒟` equation forces `k`-definiteness. -/
 theorem isDefinite_of_satisfies_kDefiniteEquation (h : kDefiniteEquation L k) :
-    L.IsDefinite k := by
-  -- short words are their own `k`-suffix; long words are syntactically equivalent to it.
-  have key : ∀ w : List α, w ∈ L ↔ Edge.right.takeAt k w ∈ L := by
-    intro w
-    by_cases hw : w.length ≤ k
-    · rw [Edge.takeAt_of_length_le _ hw]
-    · have hlen : (Edge.right.takeAt k w).length = k := by rw [Edge.length_takeAt]; omega
-      refine mem_iff_of_syntacticClass_eq ?_
-      have base := syntacticClass_of_kDefiniteEquation h
-        (w.take (w.length - k)) (Edge.right.takeAt k w) hlen
-      have decomp : w = w.take (w.length - k) ++ Edge.right.takeAt k w :=
-        (List.rdrop_append_rtake w k).symm
-      rwa [← decomp] at base
-  exact factorsThrough_of_mem_iff key
+    L.IsDefinite k :=
+  isDefinite_iff_mem_takeAt.mpr fun w =>
+    mem_iff_of_syntacticClass_eq (syntacticClass_eq_takeAt h w)
 
 /-- `k`-definite ↔ the `𝒟` equation. -/
 theorem isDefinite_iff_satisfies_kDefiniteEquation :

--- a/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
@@ -72,68 +72,48 @@ private lemma factorsThrough_of_mem_iff {f : List α → List α}
     (key : ∀ w, w ∈ L ↔ f w ∈ L) : Function.FactorsThrough (· ∈ L) f :=
   fun a b hab => by simp only [key a, key b, hab]
 
-/-! ### Helper lemmas on `Edge.right.takeAt` -/
-
-/-- The right-`k`-suffix of `x ++ rest` is that of `rest`, when `k ≤ rest.length`. -/
-lemma takeAt_right_append_left_absorb {α : Type*}
-    (x rest : List α) {k : ℕ} (h : k ≤ rest.length) :
-    Edge.right.takeAt k (x ++ rest) = Edge.right.takeAt k rest :=
-  List.rtake_append_of_le_length x rest h
-
-/-! ### Lifting the equation to a syntactic-class equality -/
-
-/-- Under the `𝒟` equation, prepending any prefix to a length-`k` word fixes its class. -/
-lemma syntacticClass_of_kDefiniteEquation
-    (h : Language.kDefiniteEquation L k)
-    (w αs : List α) (hαs_len : αs.length = k) :
-    L.syntacticClass (w ++ αs) = L.syntacticClass αs := by
-  rw [syntacticClass_append]
-  exact h αs hαs_len (L.syntacticClass w)
-
 /-! ### Definite (`𝒟`) -/
 
+/-- Under the `𝒟` equation, prepending any prefix to a length-`k` word fixes its class. -/
+private lemma syntacticClass_of_kDefiniteEquation
+    (h : kDefiniteEquation L k) (w αs : List α) (hαs_len : αs.length = k) :
+    L.syntacticClass (w ++ αs) = L.syntacticClass αs := by
+  rw [syntacticClass_append]; exact h αs hαs_len (L.syntacticClass w)
+
 /-- Forward: a `k`-definite language satisfies the `𝒟` equation. -/
-theorem IsDefinite.satisfies_kDefiniteEquation
-    (hL : L.IsDefinite k) :
-    Language.kDefiniteEquation L k := by
+theorem IsDefinite.satisfies_kDefiniteEquation (hL : L.IsDefinite k) :
+    kDefiniteEquation L k := by
   intro αs hαs_len s
   obtain ⟨w, rfl⟩ := L.syntacticClass_surjective s
   rw [← syntacticClass_append, syntacticClass_eq_iff]
   intro x y
   refine iff_of_eq (hL ?_)
+  have h : k ≤ (αs ++ y).length := by rw [List.length_append]; omega
   rw [show x ++ (w ++ αs) ++ y = (x ++ w) ++ (αs ++ y) by simp [List.append_assoc],
-      show x ++ αs ++ y = x ++ (αs ++ y) by simp [List.append_assoc]]
-  have h_combined_len : k ≤ (αs ++ y).length := by rw [List.length_append]; omega
-  rw [takeAt_right_append_left_absorb (x ++ w) (αs ++ y) h_combined_len,
-      takeAt_right_append_left_absorb x (αs ++ y) h_combined_len]
+      show x ++ αs ++ y = x ++ (αs ++ y) by simp [List.append_assoc],
+      Edge.takeAt_right_append_of_le_length _ _ h, Edge.takeAt_right_append_of_le_length _ _ h]
 
 /-- Reverse: the `𝒟` equation forces `k`-definiteness. -/
-theorem isDefinite_of_satisfies_kDefiniteEquation
-    (h : Language.kDefiniteEquation L k) :
+theorem isDefinite_of_satisfies_kDefiniteEquation (h : kDefiniteEquation L k) :
     L.IsDefinite k := by
-  -- Membership equals membership of the length-`k` suffix: short words are their
-  -- own suffix; long words are syntactically equivalent to it via the equation.
+  -- short words are their own `k`-suffix; long words are syntactically equivalent to it.
   have key : ∀ w : List α, w ∈ L ↔ Edge.right.takeAt k w ∈ L := by
     intro w
     by_cases hw : w.length ≤ k
     · rw [Edge.takeAt_of_length_le _ hw]
-    · push Not at hw
-      have hlen : (Edge.right.takeAt k w).length = k := by
-        rw [Edge.length_takeAt]; omega
-      have hcon : L.syntacticClass w = L.syntacticClass (Edge.right.takeAt k w) := by
-        have base := syntacticClass_of_kDefiniteEquation h
-          (w.take (w.length - k)) (Edge.right.takeAt k w) hlen
-        have decomp : w = w.take (w.length - k) ++ Edge.right.takeAt k w :=
-          (List.rdrop_append_rtake w k).symm
-        rwa [← decomp] at base
-      exact mem_iff_of_syntacticClass_eq hcon
+    · have hlen : (Edge.right.takeAt k w).length = k := by rw [Edge.length_takeAt]; omega
+      refine mem_iff_of_syntacticClass_eq ?_
+      have base := syntacticClass_of_kDefiniteEquation h
+        (w.take (w.length - k)) (Edge.right.takeAt k w) hlen
+      have decomp : w = w.take (w.length - k) ++ Edge.right.takeAt k w :=
+        (List.rdrop_append_rtake w k).symm
+      rwa [← decomp] at base
   exact factorsThrough_of_mem_iff key
 
 /-- `k`-definite ↔ the `𝒟` equation. -/
 theorem isDefinite_iff_satisfies_kDefiniteEquation :
-    L.IsDefinite k ↔ Language.kDefiniteEquation L k :=
-  ⟨IsDefinite.satisfies_kDefiniteEquation,
-   isDefinite_of_satisfies_kDefiniteEquation⟩
+    L.IsDefinite k ↔ kDefiniteEquation L k :=
+  ⟨IsDefinite.satisfies_kDefiniteEquation, isDefinite_of_satisfies_kDefiniteEquation⟩
 
 /-! ### Reverse-definite (`𝒦`) — by reverse duality -/
 
@@ -217,8 +197,8 @@ theorem IsGeneralizedDefinite.satisfies_kGeneralizedDefiniteEquation
           simp [List.append_assoc],
         show x ++ αs ++ y = x ++ (αs ++ y) by simp [List.append_assoc]]
     have h_αsy_len : k ≤ (αs ++ y).length := by rw [List.length_append]; omega
-    rw [takeAt_right_append_left_absorb (x ++ αs ++ w) (αs ++ y) h_αsy_len,
-        takeAt_right_append_left_absorb x (αs ++ y) h_αsy_len]
+    rw [Edge.takeAt_right_append_of_le_length (x ++ αs ++ w) (αs ++ y) h_αsy_len,
+        Edge.takeAt_right_append_of_le_length x (αs ++ y) h_αsy_len]
 
 /-! #### Reverse direction -/
 

--- a/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
@@ -160,132 +160,78 @@ theorem isReverseDefinite_of_satisfies_kReverseDefiniteEquation
 
 /-! ### Generalized definite (`ℒℐ`) -/
 
-/-! #### Lifting the LI equation to a syntactic-class equality -/
-
 /-- Under the `ℒℐ` equation, sandwiching a word inside a length-`k` word fixes its class. -/
-lemma syntacticClass_of_kGeneralizedDefiniteEquation
-    (h : Language.kGeneralizedDefiniteEquation L k)
+private lemma syntacticClass_of_kGeneralizedDefiniteEquation
+    (h : kGeneralizedDefiniteEquation L k)
     (αs w : List α) (hαs_len : αs.length = k) :
     L.syntacticClass (αs ++ w ++ αs) = L.syntacticClass αs := by
   rw [syntacticClass_append, syntacticClass_append]
   exact h (L.syntacticClass w) αs hαs_len
 
-/-! #### Forward direction -/
-
 /-- Forward: a generalized-`k`-definite language satisfies the `ℒℐ` equation. -/
 theorem IsGeneralizedDefinite.satisfies_kGeneralizedDefiniteEquation
     (hL : L.IsGeneralizedDefinite k) :
-    Language.kGeneralizedDefiniteEquation L k := by
+    kGeneralizedDefiniteEquation L k := by
   intro s αs hαs_len
   obtain ⟨w, rfl⟩ := L.syntacticClass_surjective s
   rw [← syntacticClass_append, ← syntacticClass_append, syntacticClass_eq_iff]
   intro x y
   apply isGeneralizedDefinite_iff_edges.mp hL
-  · -- takeAt_left k matches: both have x ++ αs as prefix.
-    show (x ++ (αs ++ w ++ αs) ++ y).take k = (x ++ αs ++ y).take k
-    rw [show x ++ (αs ++ w ++ αs) ++ y = (x ++ αs) ++ (w ++ αs ++ y) by
-          simp [List.append_assoc],
-        show x ++ αs ++ y = (x ++ αs) ++ y by simp [List.append_assoc]]
-    have h_xαs_len : k ≤ (x ++ αs).length := by rw [List.length_append]; omega
-    rw [List.take_append_of_le_length h_xαs_len, List.take_append_of_le_length h_xαs_len]
-  · -- takeAt_right k matches: both end with αs ++ y.
-    show Edge.right.takeAt k (x ++ (αs ++ w ++ αs) ++ y) =
-         Edge.right.takeAt k (x ++ αs ++ y)
-    rw [show x ++ (αs ++ w ++ αs) ++ y = (x ++ αs ++ w) ++ (αs ++ y) by
-          simp [List.append_assoc],
-        show x ++ αs ++ y = x ++ (αs ++ y) by simp [List.append_assoc]]
-    have h_αsy_len : k ≤ (αs ++ y).length := by rw [List.length_append]; omega
-    rw [Edge.takeAt_right_append_of_le_length (x ++ αs ++ w) (αs ++ y) h_αsy_len,
-        Edge.takeAt_right_append_of_le_length x (αs ++ y) h_αsy_len]
-
-/-! #### Reverse direction -/
+  · -- left edge: both have `x ++ αs` as length-`k` prefix.
+    have hp : k ≤ (x ++ αs).length := by rw [List.length_append]; omega
+    rw [show x ++ (αs ++ w ++ αs) ++ y = (x ++ αs) ++ (w ++ αs ++ y) by simp [List.append_assoc],
+        show x ++ αs ++ y = (x ++ αs) ++ y by simp [List.append_assoc],
+        Edge.takeAt_left_append_of_le_length _ _ hp, Edge.takeAt_left_append_of_le_length _ _ hp]
+  · -- right edge: both end with `αs ++ y` as length-`k` suffix.
+    have hs : k ≤ (αs ++ y).length := by rw [List.length_append]; omega
+    rw [show x ++ (αs ++ w ++ αs) ++ y = (x ++ αs ++ w) ++ (αs ++ y) by simp [List.append_assoc],
+        show x ++ αs ++ y = x ++ (αs ++ y) by simp [List.append_assoc],
+        Edge.takeAt_right_append_of_le_length _ _ hs, Edge.takeAt_right_append_of_le_length _ _ hs]
 
 /-- Reverse: the `ℒℐ` equation forces generalized-`k`-definiteness. -/
 theorem isGeneralizedDefinite_of_satisfies_kGeneralizedDefiniteEquation
-    (h : Language.kGeneralizedDefiniteEquation L k) :
+    (h : kGeneralizedDefiniteEquation L k) :
     L.IsGeneralizedDefinite k := by
   refine isGeneralizedDefinite_iff_edges.mpr ?_
   intro w₁ w₂ hpre hsuf
   by_cases hw₁_long : k ≤ w₁.length
-  · -- Both `|wᵢ| ≥ k`: the matching length-`k` prefix forces `|w₂| ≥ k` too,
-    -- since otherwise `Edge.left.takeAt k w₂` would be shorter than `k`.
-    have h_pre_len_w₁ : (Edge.left.takeAt k w₁).length = k := by
-      rw [Edge.length_takeAt]; omega
+  · -- Both `|wᵢ| ≥ k`: the matching length-`k` prefix forces `|w₂| ≥ k` too.
+    have hαs_len : (Edge.left.takeAt k w₁).length = k := by rw [Edge.length_takeAt]; omega
     have hw₂_long : k ≤ w₂.length := by
-      have h_pre_len_w₂ : (Edge.left.takeAt k w₂).length = k := by
-        rw [← hpre]; exact h_pre_len_w₁
-      rw [Edge.length_takeAt] at h_pre_len_w₂; omega
-    -- Set up αs, βs, b_i, c_i and the two decompositions of each wᵢ.
+      have := hαs_len; rw [hpre, Edge.length_takeAt] at this; omega
     set αs := Edge.left.takeAt k w₁
     set βs := Edge.right.takeAt k w₁
-    have hαs_len : αs.length = k := h_pre_len_w₁
     have hβs_len : βs.length = k := by
-      show (w₁.drop (w₁.length - k)).length = k
-      rw [List.length_drop]; omega
-    set b₁ := w₁.drop k
-    set b₂ := w₂.drop k
-    set c₁ := w₁.take (w₁.length - k)
-    set c₂ := w₂.take (w₂.length - k)
-    -- αs-decompositions: wᵢ = αs ++ bᵢ.
-    have hw₁_αs : w₁ = αs ++ b₁ := by
-      show w₁ = w₁.take k ++ w₁.drop k
-      exact (List.take_append_drop _ _).symm
-    have hw₂_αs : w₂ = αs ++ b₂ := by
-      have : Edge.left.takeAt k w₂ = αs := hpre.symm
-      have h_w₂_take : w₂.take k = αs := this
-      show w₂ = αs ++ w₂.drop k
-      rw [← h_w₂_take]; exact (List.take_append_drop _ _).symm
-    -- βs-decompositions: wᵢ = cᵢ ++ βs.
-    have hw₁_βs : w₁ = c₁ ++ βs := by
-      show w₁ = w₁.take (w₁.length - k) ++ w₁.drop (w₁.length - k)
-      exact (List.take_append_drop _ _).symm
-    have hw₂_βs : w₂ = c₂ ++ βs := by
-      have : Edge.right.takeAt k w₂ = βs := hsuf.symm
-      have h_w₂_drop : w₂.drop (w₂.length - k) = βs := this
-      show w₂ = w₂.take (w₂.length - k) ++ βs
-      rw [← h_w₂_drop]; exact (List.take_append_drop _ _).symm
-    -- Way 1: αs-sandwich gives `[w₁ ++ w₂] = [w₂]`, by absorbing
-    -- the `αs ++ b₁ ++ αs` block into `αs`.
+      show (w₁.drop (w₁.length - k)).length = k; rw [List.length_drop]; omega
+    set b₁ := w₁.drop k; set b₂ := w₂.drop k
+    set c₁ := w₁.take (w₁.length - k); set c₂ := w₂.take (w₂.length - k)
+    -- `wᵢ = αs ++ bᵢ` (shared prefix) and `wᵢ = cᵢ ++ βs` (shared suffix).
+    have hw₁_αs : w₁ = αs ++ b₁ := (List.take_append_drop k w₁).symm
+    have hw₂_αs : w₂ = αs ++ b₂ := by rw [hpre]; exact (List.take_append_drop k w₂).symm
+    have hw₁_βs : w₁ = c₁ ++ βs := (List.take_append_drop (w₁.length - k) w₁).symm
+    have hw₂_βs : w₂ = c₂ ++ βs := by rw [hsuf]; exact (List.take_append_drop (w₂.length - k) w₂).symm
+    -- Way 1: the αs-sandwich absorbs into `w₂`; Way 2: the βs-sandwich absorbs into `w₁`.
     have h_αs_eq : L.syntacticClass (w₁ ++ w₂) = L.syntacticClass w₂ := by
       conv_lhs => rw [hw₁_αs, hw₂_αs,
-        show (αs ++ b₁) ++ (αs ++ b₂) = (αs ++ b₁ ++ αs) ++ b₂ by
-          simp [List.append_assoc]]
+        show (αs ++ b₁) ++ (αs ++ b₂) = (αs ++ b₁ ++ αs) ++ b₂ by simp [List.append_assoc]]
       rw [syntacticClass_append, syntacticClass_of_kGeneralizedDefiniteEquation h αs b₁ hαs_len,
         ← syntacticClass_append, ← hw₂_αs]
-    -- Way 2: βs-sandwich gives `[w₁ ++ w₂] = [w₁]`, by absorbing
-    -- the `βs ++ c₂ ++ βs` block into `βs`.
     have h_βs_eq : L.syntacticClass (w₁ ++ w₂) = L.syntacticClass w₁ := by
       conv_lhs => rw [hw₁_βs, hw₂_βs,
-        show (c₁ ++ βs) ++ (c₂ ++ βs) = c₁ ++ (βs ++ c₂ ++ βs) by
-          simp [List.append_assoc]]
+        show (c₁ ++ βs) ++ (c₂ ++ βs) = c₁ ++ (βs ++ c₂ ++ βs) by simp [List.append_assoc]]
       rw [syntacticClass_append, syntacticClass_of_kGeneralizedDefiniteEquation h βs c₂ hβs_len,
         ← syntacticClass_append, ← hw₁_βs]
-    -- Combine: `[w₁] = [w₂]`, hence `w₁ ≡_L w₂`.
     exact mem_iff_of_syntacticClass_eq (h_βs_eq.symm.trans h_αs_eq)
-  · -- Short case: `|w₁| < k`. Then `Edge.left.takeAt k w₁ = w₁`, so
-    -- the prefix equality yields `w₁ = Edge.left.takeAt k w₂`, which
-    -- forces `|w₂| ≤ k` (otherwise the takeAt has length `k > |w₁|`).
-    push Not at hw₁_long
-    have h_w₁_pre : Edge.left.takeAt k w₁ = w₁ :=
-      Edge.takeAt_of_length_le _ (le_of_lt hw₁_long)
-    rw [h_w₁_pre] at hpre
-    -- Now hpre : w₁ = Edge.left.takeAt k w₂.
+  · -- Short case `|w₁| < k`: the prefix match collapses to `w₁ = w₂`.
+    rw [Edge.takeAt_of_length_le _ (not_le.mp hw₁_long).le] at hpre
     by_cases hw₂_long : k ≤ w₂.length
-    · -- Length-`k` takeAt of `w₂` has length `k > |w₁|`. Contradicts hpre.
-      have h_pre_len : (Edge.left.takeAt k w₂).length = k := by
-        rw [Edge.length_takeAt]; omega
-      rw [← hpre] at h_pre_len
-      omega
-    · push Not at hw₂_long
-      have h_w₂_pre : Edge.left.takeAt k w₂ = w₂ :=
-        Edge.takeAt_of_length_le _ (le_of_lt hw₂_long)
-      rw [h_w₂_pre] at hpre
-      rw [hpre]
+    · have hlen : (Edge.left.takeAt k w₂).length = k := by rw [Edge.length_takeAt]; omega
+      rw [← hpre] at hlen; omega
+    · rw [Edge.takeAt_of_length_le _ (not_le.mp hw₂_long).le] at hpre; rw [hpre]
 
 /-- generalized-`k`-definite ↔ the `ℒℐ` equation. -/
 theorem isGeneralizedDefinite_iff_satisfies_kGeneralizedDefiniteEquation :
-    L.IsGeneralizedDefinite k ↔
-    Language.kGeneralizedDefiniteEquation L k :=
+    L.IsGeneralizedDefinite k ↔ kGeneralizedDefiniteEquation L k :=
   ⟨IsGeneralizedDefinite.satisfies_kGeneralizedDefiniteEquation,
    isGeneralizedDefinite_of_satisfies_kGeneralizedDefiniteEquation⟩
 

--- a/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Algebra/Equations.lean
@@ -114,24 +114,25 @@ theorem isDefinite_iff_satisfies_kDefiniteEquation :
 
 /-! ### Reverse-definite (`𝒦`) — by reverse duality -/
 
+/-- A class is a **right zero** iff prepending any word fixes it. -/
+private lemma isRightZero_syntacticClass_iff {αs : List α} :
+    IsRightZero (L.syntacticClass αs) ↔ ∀ v, L.syntacticClass (v ++ αs) = L.syntacticClass αs := by
+  refine ⟨fun h v => by rw [syntacticClass_append]; exact h _, fun h a => ?_⟩
+  obtain ⟨v, rfl⟩ := L.syntacticClass_surjective a; rw [← syntacticClass_append]; exact h v
+
+/-- A class is a **left zero** iff appending any word fixes it. -/
+private lemma isLeftZero_syntacticClass_iff {αs : List α} :
+    IsLeftZero (L.syntacticClass αs) ↔ ∀ v, L.syntacticClass (αs ++ v) = L.syntacticClass αs := by
+  refine ⟨fun h v => by rw [syntacticClass_append]; exact h _, fun h a => ?_⟩
+  obtain ⟨v, rfl⟩ := L.syntacticClass_surjective a; rw [← syntacticClass_append]; exact h v
+
 /-- Reverse duality, element form: a class is a right zero in `L.reverse` iff the
-reversed-word class is a left zero in `L`. -/
+reversed-word class is a left zero in `L` (reindex the absorbed word by `reverse`). -/
 private lemma isRightZero_reverse_syntacticClass {αs : List α} :
     IsRightZero (L.reverse.syntacticClass αs) ↔ IsLeftZero (L.syntacticClass αs.reverse) := by
-  constructor
-  · intro h a
-    obtain ⟨v, rfl⟩ := L.syntacticClass_surjective a
-    rw [← syntacticClass_append]
-    have hb := h (L.reverse.syntacticClass v.reverse)
-    rw [← syntacticClass_append, syntacticClass_reverse_eq_iff, List.reverse_append,
-      List.reverse_reverse] at hb
-    exact hb
-  · intro h a
-    obtain ⟨v, rfl⟩ := L.reverse.syntacticClass_surjective a
-    rw [← syntacticClass_append, syntacticClass_reverse_eq_iff, List.reverse_append]
-    have hb := h (L.syntacticClass v.reverse)
-    rw [← syntacticClass_append] at hb
-    exact hb
+  rw [isRightZero_syntacticClass_iff, isLeftZero_syntacticClass_iff]
+  simp only [syntacticClass_reverse_eq_iff, List.reverse_append]
+  exact ⟨fun h v => by simpa using h v.reverse, fun h v => by simpa using h v.reverse⟩
 
 /-- The `𝒦` equation for `L` is the `𝒟` equation for `L.reverse`. -/
 theorem kReverseDefiniteEquation_iff_reverse :

--- a/Linglib/Core/Computability/Subregular/Language/Algebra/Pin.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Algebra/Pin.lean
@@ -663,8 +663,8 @@ theorem IsGeneralizedDefinite.satisfies_pinGeneralizedDefiniteEquation
       rw [show x ++ (v ++ s' ++ v) ++ y = (x ++ v ++ s') ++ (v ++ y) by simp [List.append_assoc],
           show x ++ v ++ y = x ++ (v ++ y) by simp [List.append_assoc]]
       have h_vy_len : k ≤ (v ++ y).length := by rw [List.length_append]; omega
-      rw [takeAt_right_append_left_absorb (x ++ v ++ s') (v ++ y) h_vy_len,
-          takeAt_right_append_left_absorb x (v ++ y) h_vy_len]
+      rw [Edge.takeAt_right_append_of_le_length (x ++ v ++ s') (v ++ y) h_vy_len,
+          Edge.takeAt_right_append_of_le_length x (v ++ y) h_vy_len]
 
 /-- Helper for the LI reverse direction: given a pigeonhole pair
 `i_lo < i_hi` of indices into `v` whose prefixes have the same

--- a/Linglib/Core/Computability/Subregular/Language/Definite.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Definite.lean
@@ -74,6 +74,11 @@ lemma takeAt_of_length_le {k : ℕ} {xs : List α} (h : xs.length ≤ k) :
   | left => exact List.take_of_length_le h
   | right => exact List.rtake_of_length_le h
 
+/-- The right-`k`-suffix of `x ++ rest` is that of `rest`, when `k ≤ rest.length`. -/
+lemma takeAt_right_append_of_le_length {k : ℕ} (x rest : List α) (h : k ≤ rest.length) :
+    Edge.right.takeAt k (x ++ rest) = Edge.right.takeAt k rest :=
+  List.rtake_append_of_le_length x rest h
+
 end Edge
 
 /-! ### Edge-bridge identities

--- a/Linglib/Core/Computability/Subregular/Language/Definite.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Definite.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Computability.Language
 import Mathlib.Logic.Function.Basic
+import Linglib.Core.Logic.FactorsThroughOn
 import Linglib.Core.Data.List.DropRight
 import Mathlib.Data.Fintype.Order
 import Mathlib.Data.Set.Finite.Lemmas
@@ -79,6 +80,10 @@ lemma takeAt_right_append_of_le_length {k : ℕ} (x rest : List α) (h : k ≤ r
     Edge.right.takeAt k (x ++ rest) = Edge.right.takeAt k rest :=
   List.rtake_append_of_le_length x rest h
 
+/-- `takeAt k` is idempotent: its output already has length `≤ k`. -/
+lemma takeAt_idem : e.takeAt k (e.takeAt k xs) = e.takeAt k xs :=
+  takeAt_of_length_le e (by rw [length_takeAt]; exact min_le_left _ _)
+
 end Edge
 
 /-! ### Edge-bridge identities
@@ -135,6 +140,14 @@ lemma isGeneralizedDefinite_iff_edges {k : ℕ} {L : Language α} :
         Edge.right.takeAt k a = Edge.right.takeAt k b → (a ∈ L ↔ b ∈ L) :=
   ⟨fun h _ _ hpre hsuf => iff_of_eq (h (by simp only [hpre, hsuf])),
    fun h _ _ hpair => propext (h (congrArg Prod.fst hpair) (congrArg Prod.snd hpair))⟩
+
+/-- Definiteness in membership form: a word and its length-`k` suffix are
+`L`-equivalent (single-edge analogue of `isGeneralizedDefinite_iff_edges`). -/
+lemma isDefinite_iff_mem_takeAt {k : ℕ} {L : Language α} :
+    L.IsDefinite k ↔ ∀ w, w ∈ L ↔ Edge.right.takeAt k w ∈ L := by
+  unfold IsDefinite
+  rw [Function.factorsThrough_iff_of_idempotent (fun a => Edge.right.takeAt_idem k a)]
+  simp only [eq_iff_iff]
 
 /-- A language is **finite-or-cofinite** (Lambert's 𝒩): `L` or its complement is
 finite (equivalently `L.Finite ∨ L ∈ Filter.cofinite`). -/

--- a/Linglib/Core/Computability/Subregular/Language/Definite.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Definite.lean
@@ -75,6 +75,11 @@ lemma takeAt_of_length_le {k : ℕ} {xs : List α} (h : xs.length ≤ k) :
   | left => exact List.take_of_length_le h
   | right => exact List.rtake_of_length_le h
 
+/-- The left-`k`-prefix of `p ++ rest` is that of `p`, when `k ≤ p.length`. -/
+lemma takeAt_left_append_of_le_length {k : ℕ} (p rest : List α) (h : k ≤ p.length) :
+    Edge.left.takeAt k (p ++ rest) = Edge.left.takeAt k p :=
+  List.take_append_of_le_length h
+
 /-- The right-`k`-suffix of `x ++ rest` is that of `rest`, when `k ≤ rest.length`. -/
 lemma takeAt_right_append_of_le_length {k : ℕ} (x rest : List α) (h : k ≤ rest.length) :
     Edge.right.takeAt k (x ++ rest) = Edge.right.takeAt k rest :=

--- a/Linglib/Core/Logic/FactorsThroughOn.lean
+++ b/Linglib/Core/Logic/FactorsThroughOn.lean
@@ -46,6 +46,13 @@ theorem not_factorsThroughOn_iff_exists_witness {g : α → γ} {f : α → β} 
     ∃ a b, a ∈ s ∧ b ∈ s ∧ f a = f b ∧ g a ≠ g b := by
   simp only [FactorsThroughOn, not_forall, exists_prop]
 
+/-- For an **idempotent** `f`, `g` factors through `f` iff `g` is `f`-invariant
+(pointwise `g = g ∘ f`). -/
+theorem factorsThrough_iff_of_idempotent {g : α → γ} {f : α → α} (hf : ∀ a, f (f a) = f a) :
+    FactorsThrough g f ↔ ∀ a, g a = g (f a) :=
+  ⟨fun h a => h (hf a).symm,
+   fun h a b hab => (h a).trans ((congrArg g hab).trans (h b).symm)⟩
+
 instance {g : α → γ} {f : α → β} {s : Set α}
     [Fintype α] [DecidablePred (· ∈ s)] [DecidableEq β] [DecidableEq γ] :
     Decidable (FactorsThroughOn g f s) := by


### PR DESCRIPTION
Stranded follow-up to #658 (which squash-merged at its first commit). Tidies the 𝒟/𝒦/ℒℐ sections: rehomes the `Edge.takeAt` append helpers (with the missing left-edge mirror), adds `Function.factorsThrough_iff_of_idempotent` + `Language.isDefinite_iff_mem_takeAt` and routes 𝒟's reverse through that pivot, golfs 𝒦 via zero-class characterizations, and symmetrizes the ℒℐ edge proofs. Drops `Language.` self-qualifiers and `push Not`.