### PR TITLE
refactor(Semantics/Aspect): CSUB as lower set of run-time image

### DIFF
--- a/Linglib/Semantics/Aspect/Stratified.lean
+++ b/Linglib/Semantics/Aspect/Stratified.lean
@@ -67,7 +67,7 @@ property.
 
 * The stativity opposition along τ (Champollion's fourth opposition) is
   realized in linglib by `HasSubintervalProp` in
-  `Tense/Aspect/SubintervalProperty.lean` rather than as a decomposition
+  `Semantics/Aspect/SubintervalProperty.lean` rather than as a decomposition
   form. The `(τ, point-granularity)` form has no current consumer.
 * `Studies/Champollion2017.lean` covers distributivity (Ch 6) + a basic
   subinterval-reference↔Vendler atelicity bridge (§ 5), but does NOT yet

--- a/Linglib/Semantics/Aspect/SubintervalProperty.lean
+++ b/Linglib/Semantics/Aspect/SubintervalProperty.lean
@@ -1,30 +1,41 @@
+/-
+Copyright (c) 2026 Linglib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Order.UpperLower.Basic
 import Linglib.Semantics.Aspect.Basic
 
 /-!
 # The Subinterval Property
 
-The subinterval property (Bennett & Partee 1972, Dowty 1979) is a fundamental
-semantic property of event predicates that determines their aspectual class:
+The subinterval property ([bennett-partee-1972], [dowty-1979]) is a fundamental
+semantic property of event predicates that diagnoses the atelic/telic
+(homogeneous/non-homogeneous) division of aspectual classes:
 
 - **Statives and activities** have it: if John is sleeping for [1pm, 3pm],
   he is sleeping at every subinterval
 - **Accomplishments and achievements** lack it: if John built a house in
   [Jan, Dec], he did not build a house in [Jan, Feb]
 
-This property is central to the semantics of temporal adverbials
-([rouillard-2026]), NPI licensing in boundary adverbials
-([iatridou-zeijlstra-2021]), and the distribution of progressive
+It does *not* by itself fix the full four-way Vendler class (state vs. activity
+and accomplishment vs. achievement need stativity/punctuality diagnostics);
+it draws only the homogeneous/non-homogeneous line.
+
+This property underlies the semantics of temporal adverbials
+([rouillard-2026]) and interacts with the aspectual sensitivity of boundary
+adverbials ([iatridou-zeijlstra-2021]) and the distribution of progressive
 and imperfective aspect crosslinguistically.
 
-Originally extracted from a Rouillard-2026 substrate file (since deleted in
-the 2026-05 rebuild — see `Studies/Rouillard2026.lean`)
-because it is a general property of event predicates, not specific to any
-particular analysis.
+This is general event-predicate substrate, not specific to any particular
+analysis — consumed by `Studies/Rouillard2026.lean`,
+`Studies/IatridouZeijlstra2021.lean`,
+`Studies/OgiharaSteinertThrelkeld2024.lean`, and the run-time projection in
+`Semantics/Tense/TemporalConnectives/Projection.lean`.
 -/
 
 namespace Semantics.Aspect.SubintervalProperty
 
-open Semantics.Aspect
 open Semantics.Aspect
 
 variable {W Time : Type*} [LinearOrder Time]
@@ -35,15 +46,24 @@ variable {W Time : Type*} [LinearOrder Time]
     States and activities have this property; accomplishments/achievements
     lack it.
 
-    This is the universal-witness (Bennett-Partee 1972) form of stativity
-    along the time dimension. The `Stratified.ReferenceUniv` decomposition form at
+    This is the *universal-over-witnesses* form: it constrains only those
+    subintervals that already happen to be some event's runtime. It is
+    therefore **vacuously satisfiable** when the event ontology is sparse
+    (no event has runtime exactly `t` ⇒ the inner `∀ e₂` is empty). The
+    contentful, witness-*producing* form is `HasClosedSubintervalProp`
+    (CSUB) below, which every operator-level theorem in this file consumes;
+    plain SUB is the weaker conditional and does not on its own express
+    Bennett-Partee/Dowty homogeneity.
+
+    The `Stratified.SubintervalReference` decomposition form at
     [champollion-2017]'s analogous parameter-space point (dim = τ,
     point-interval granularity) is genuinely different math — ∃-decomposition
-    over P-parts vs ∀-projection over hypothetical witness events. The
-    quantifier-level cousin (Zhao 2025 Def. 5.36, ATOM-DIST_t) lives in
-    `Core/Time/AtomDist.lean`. The three formulations are NOT directly
-    interderivable; bridging requires explicit witness-existence
-    assumptions. -/
+    over P-parts vs ∀-projection over hypothetical witness events; the
+    distinctness is backed by the counterexamples in
+    `Semantics/Aspect/Stratified.lean`. The quantifier-level cousin
+    ([zhao-2025] ATOM-DIST_t) lives in `Semantics/Aspect/AtomDist.lean`. The
+    three formulations are NOT directly interderivable; bridging requires
+    explicit witness-existence assumptions. -/
 def HasSubintervalProp (P : W → Event Time → Prop) : Prop :=
   ∀ (e₁ : Event Time) (w : W),
     P w e₁ →
@@ -51,65 +71,114 @@ def HasSubintervalProp (P : W → Event Time → Prop) : Prop :=
     ∀ (e₂ : Event Time), e₂.τ = t →
     P w e₂
 
-/-- **Closed subinterval property** (CSUB).
-    For any subinterval t of a P-event's runtime, there exists a P-event
-    whose runtime is t. Stronger than SUB: guarantees witnesses exist,
-    not just that predication is preserved. -/
+/-- **Closed subinterval property** (CSUB): `P`'s run-times form a *lower set*.
+
+    This is the contentful homogeneity property — `eventDenotation (P w ·)`
+    (the run-time image, `Semantics/Events/Basic.lean`) is downward-closed in
+    `NonemptyInterval Time` at every world. Equivalently, for any subinterval
+    `t` of a P-event's runtime there *exists* a P-event whose runtime is `t`
+    (the witness form — see `hasClosedSubintervalProp_iff_witnesses`).
+
+    CSUB is exactly **Krifka divisivity** of the run-time image: `DIV`
+    ([champollion-2017]; `Semantics/Mereology.lean`) is by definition
+    `IsLowerSet`, so `HasClosedSubintervalProp P ↔ ∀ w, DIV (eventDenotation (P w ·))`
+    holds definitionally. Stating CSUB directly on mathlib's `IsLowerSet`
+    collapses three former encodings of the same concept — the bespoke
+    ∀∀∃ witness predicate, `Mereology.DIV`, and the lower-set fact proved
+    ad hoc in `Tense/TemporalConnectives/Projection.lean` — onto one carrier.
+
+    Stronger than `HasSubintervalProp` (SUB): SUB only constrains witnesses
+    that already exist and is vacuous under a sparse event ontology; CSUB
+    *produces* a witness at every subinterval, which is what every
+    operator-level theorem below consumes. -/
 def HasClosedSubintervalProp (P : W → Event Time → Prop) : Prop :=
-  ∀ (e₁ : Event Time) (w : W),
-    P w e₁ →
-    ∀ (t : NonemptyInterval Time), t ≤ e₁.τ →
-    ∃ (e₂ : Event Time), e₂.τ = t ∧ P w e₂
+  ∀ w, IsLowerSet (eventDenotation (fun e => P w e))
+
+/-- **CSUB ⟺ the witness form.** Unfolds the lower-set definition to the
+    classic Bennett-Partee/Dowty statement: every subinterval of a P-event's
+    runtime is itself the runtime of some P-event. Operator-level theorems
+    consume CSUB through this characterization. -/
+theorem hasClosedSubintervalProp_iff_witnesses {P : W → Event Time → Prop} :
+    HasClosedSubintervalProp P ↔
+      ∀ (e₁ : Event Time) (w : W), P w e₁ →
+        ∀ (t : NonemptyInterval Time), t ≤ e₁.τ →
+        ∃ (e₂ : Event Time), e₂.τ = t ∧ P w e₂ := by
+  constructor
+  · intro h e₁ w hP t ht
+    obtain ⟨e₂, hPe₂, he₂⟩ := h w ht (mem_eventDenotation_of hP)
+    exact ⟨e₂, he₂, hPe₂⟩
+  · intro h w a b hba ha
+    obtain ⟨e₁, hPe₁, rfl⟩ := ha
+    obtain ⟨e₂, he₂, hPe₂⟩ := h e₁ w hPe₁ b hba
+    exact ⟨e₂, hPe₂, he₂⟩
 
 -- ════════════════════════════════════════════════════
 -- § Operator-Level Consequences
 -- ════════════════════════════════════════════════════
 
 /-! The subinterval property's consequences at the level of aspect operators.
-    [smith-1997] Ch. 2: states and activities have the subinterval
-    property; accomplishments, achievements, and semelfactives lack it.
+    The atelic/telic homogeneity generalization is canonically
+    [dowty-1979] / [bennett-partee-1972]; [smith-1997] supplies the
+    viewpoint-classification framing (states and activities have the
+    subinterval property; accomplishments, achievements, and semelfactives
+    lack it).
+
+    **Caveat — these are *extensional* results.** `IMPF`/`PRFV` here
+    existentially quantify over a *completed* event in the evaluation world
+    (`Basic.lean`). The genuine imperfective paradox — "John was building a
+    house" can be true with no house ever completed — is *intensional* and
+    requires a modal PROG over inertia/continuation worlds ([dowty-1979];
+    Landman 1992; Portner 1998), which this file does NOT model. What is
+    proved below is the homogeneity half: for subinterval-closed predicates
+    the extensional imperfective entails the perfective, and for telic ones
+    it need not.
 
     `Features/Aktionsart.lean` carries the VendlerClass enum used to
     state the consumer-side facts (`c = .state ∨ c = .activity` for
     SUB-having classes). Here we prove the operator-level consequences:
 
-    1. **Activity entailment** (p. 25): IMPF(activity) at I entails
-       PRFV(activity) at some I' ⊆ I — activities have part-whole homogeneity.
-    2. **Imperfective paradox** (p. 29): IMPF(accomplishment) does NOT
-       entail PRFV(accomplishment) — the missing endpoint problem.
-    3. **IMPF ⊢ PRFV ⟺ CSIP**: the imperfective entails the perfective
-       if and only if the predicate has the closed subinterval property. -/
+    1. **Activity entailment**: for CSUB predicates, holding at `e₁` yields a
+       P-event at every subinterval of `e₁`'s runtime — part-whole homogeneity.
+    2. **Telic non-homogeneity**: not every predicate is subinterval-closed
+       (the missing-endpoint predicate is a witness).
+    3. **IMPF ⊢ PRFV ⟺ CSUB**: the extensional imperfective entails the
+       perfective iff the predicate has the closed subinterval property. -/
 
 open Features
 
-/-- **Activity entailment** ([smith-1997] p. 25):
-    If an activity predicate P holds at interval I (IMPF reading: I is
-    inside the event's runtime), then P holds at every subinterval of I
-    (PRFV reading: subinterval is contained in the event).
+/-- **Activity entailment** ([dowty-1979]; [bennett-partee-1972]):
+    if an activity predicate `P` has the closed subinterval property and
+    holds of event `e₁`, then every subinterval `t` of `e₁`'s runtime is
+    itself the runtime of a P-event.
 
-    Formally: HasSubintervalProp(P) → IMPF(P)(w)(I) → ∀ I' ⊆ I, ∃e. τ(e) = I' ∧ P(w)(e).
+    Formally: `HasClosedSubintervalProp P → P w e₁ → t ≤ e₁.τ →
+    ∃ e₂, e₂.τ = t ∧ P w e₂`.
 
-    This is the semantic content of "activities entail their own
-    imperfective": "John was running" at I entails "John ran" at
-    every subinterval of I. -/
+    This is the part-whole homogeneity behind "activities entail their own
+    imperfective" — "John was running" entails "John ran" at every
+    subinterval. It is the witness form of CSUB
+    (`hasClosedSubintervalProp_iff_witnesses`). -/
 theorem activity_entailment
     (P : W → Event Time → Prop) (hSub : HasClosedSubintervalProp P)
     (w : W) (e₁ : Event Time) (hP : P w e₁)
     (t : NonemptyInterval Time) (hSub' : t ≤ e₁.τ) :
     ∃ (e₂ : Event Time), e₂.τ = t ∧ P w e₂ :=
-  hSub e₁ w hP t hSub'
+  hasClosedSubintervalProp_iff_witnesses.mp hSub e₁ w hP t hSub'
 
-/-- **Imperfective paradox** ([smith-1997] p. 29):
-    The subinterval property fails for accomplishments. This is why
-    "John was building a house" does not entail "John built a house":
-    proper subintervals of a house-building event are not themselves
-    house-building events (the result state is missing).
+/-- **Telic non-homogeneity** (the extensional core of the imperfective
+    paradox, [dowty-1979]): the subinterval property is not universal — some
+    predicates fail it. This is why "John was building a house" does not
+    entail "John built a house": proper subintervals of a house-building
+    event are not themselves house-building events (the result state is
+    missing). (The *full* paradox — truth without any completed event — is
+    intensional and modeled elsewhere; see the section caveat above. This
+    theorem only exhibits a non-subinterval-closed predicate.)
 
     The hypothesis `t₁ < t₂` ensures Time is nontrivial — in a singleton
-    Time there is only one interval and the SIP holds vacuously for all P.
-    With two distinct time points, we can construct a "telic" predicate
-    P that holds only for events spanning the full interval [t₁, t₂]
-    and fails for proper subintervals like [t₁, t₁]. -/
+    Time there is only one interval and SUB holds vacuously for all P.
+    With two distinct time points, we construct a "telic" predicate
+    P that holds only for events finishing at t₂ and fails for proper
+    subintervals like [t₁, t₁]. -/
 theorem imperfective_paradox_possible
     (w : W) (t₁ t₂ : Time) (hlt : t₁ < t₂) :
     ¬ (∀ (P : W → Event Time → Prop), HasSubintervalProp P) := by
@@ -118,14 +187,14 @@ theorem imperfective_paradox_possible
   let P : W → Event Time → Prop := λ _ e => e.τ.snd = t₂
   have hSub := hall P
   -- Construct an event e₁ with runtime [t₁, t₂]; P holds (finish = t₂)
-  -- sort defaults to .action; the proof doesn't reference .sort
+  -- sort is irrelevant here (defaults to .dynamic); the proof never reads .sort
   let e₁ : Event Time := ⟨⟨⟨t₁, t₂⟩, le_of_lt hlt⟩, .dynamic⟩
   have hPe₁ : P w e₁ := rfl
   -- [t₁, t₁] is a subinterval of [t₁, t₂]
   let sub : NonemptyInterval Time := ⟨⟨t₁, t₁⟩, le_refl t₁⟩
   have hSI : sub ≤ e₁.τ := NonemptyInterval.le_def.mpr ⟨le_refl t₁, le_of_lt hlt⟩
   -- SIP says P must hold for any event with runtime [t₁, t₁]
-  -- sort defaults to .action; the proof doesn't reference .sort
+  -- sort is irrelevant here (defaults to .dynamic); the proof never reads .sort
   let e₂ : Event Time := ⟨sub, .dynamic⟩
   have hPe₂ := hSub e₁ w hPe₁ sub hSI e₂ rfl
   -- But P w e₂ means t₁ = t₂, contradicting t₁ < t₂
@@ -136,71 +205,75 @@ theorem imperfective_paradox_possible
 -- ════════════════════════════════════════════════════
 
 /-! The central result connecting aspect operators to the subinterval
-    property. For predicates with the closed SIP (states, activities),
-    the imperfective entails the perfective at the same interval:
+    property. For predicates with the closed subinterval property (CSUB —
+    states, activities), the extensional imperfective entails the perfective
+    at the same interval:
 
-      CSIP(P) → IMPF(P)(w)(t) → PRFV(P)(w)(t)
+      CSUB(P) → IMPF(P)(w)(t) → PRFV(P)(w)(t)
 
-    This is the formal reason the imperfective paradox does NOT arise
-    for homogeneous predicates. "Mary was running" (IMPF) entails
+    This is the formal reason the (extensional) imperfective paradox does NOT
+    arise for homogeneous predicates. "Mary was running" (IMPF) entails
     "Mary ran" (PRFV) because any subinterval of a running event is
     itself a running event — so the reference time t, which is inside
     the event's runtime, is itself the runtime of a running event.
 
-    Combined with `imperfective_paradox_possible` (which shows that
-    predicates without the SIP can fail this entailment), this gives
+    Combined with `csub_necessary_for_impf_prfv` (the converse), this gives
     a complete characterization:
 
-      IMPF entails PRFV ⟺ the predicate has the subinterval property
+      (∀ P, IMPF(P) ⊆ PRFV(P)) ⟺ (∀ P, CSUB(P))
 
     The proof:
     1. IMPF gives us event e with t ⊂ τ(e) and P(w, e)
-    2. properSubinterval implies subinterval: t ⊆ τ(e)
-    3. CSIP with e, w, t yields witness e₂ with τ(e₂) = t and P(w, e₂)
-    4. Since τ(e₂) = t ⊆ t (reflexive), PRFV holds with witness e₂ -/
+    2. proper containment implies containment: t ≤ τ(e)
+    3. CSUB with e, w, t yields witness e₂ with τ(e₂) = t and P(w, e₂)
+    4. Since τ(e₂) = t ≤ t (reflexive), PRFV holds with witness e₂ -/
 
-/-- **IMPF entails PRFV for CSIP predicates** ([smith-1997] Ch. 2).
+/-- **IMPF entails PRFV for CSUB predicates** ([dowty-1979]; [smith-1997]).
     If P has the closed subinterval property, then IMPF(P)(w)(t) entails
-    PRFV(P)(w)(t) — the imperfective entails the perfective at the same
-    reference interval.
+    PRFV(P)(w)(t) — the (extensional) imperfective entails the perfective at
+    the same reference interval.
 
     This is why "Mary was running" entails "Mary ran": the reference
     time t is properly inside the running event's runtime, and since
-    running has the CSIP, there exists a running event whose runtime
+    running has CSUB, there exists a running event whose runtime
     IS exactly t, which satisfies the PRFV containment requirement. -/
-theorem impf_entails_prfv_of_csip
-    (P : W → Event Time → Prop) (hCSIP : HasClosedSubintervalProp P)
+theorem impf_entails_prfv_of_csub
+    (P : W → Event Time → Prop) (hCSUB : HasClosedSubintervalProp P)
     (w : W) (t : NonemptyInterval Time) :
     IMPF P w t → PRFV P w t := by
   intro ⟨e, hPSub, hP⟩
   -- hPSub : t < e.τ — reference time properly inside event
   -- hPSub.1 : t ≤ e.τ — non-strict containment (first component)
   -- hP : P w e — the predicate holds for e
-  obtain ⟨e₂, he₂, hPe₂⟩ := hCSIP e w hP t hPSub.1
+  obtain ⟨e₂, he₂, hPe₂⟩ := hasClosedSubintervalProp_iff_witnesses.mp hCSUB e w hP t hPSub.1
   -- e₂ : event with τ(e₂) = t and P(w, e₂)
   -- For PRFV we need τ(e₂) ⊆ t, i.e. t ⊆ t (since τ(e₂) = t)
   exact ⟨e₂, he₂ ▸ le_refl t, hPe₂⟩
 
-/-- **CSIP is necessary for IMPF→PRFV** (converse of `impf_entails_prfv_of_csip`):
-    if IMPF entails PRFV for ALL predicates, then every predicate has CSIP.
+/-- **CSUB is necessary for IMPF→PRFV** (converse of `impf_entails_prfv_of_csub`):
+    if IMPF entails PRFV for ALL predicates, then every predicate has CSUB.
 
     Combined with the forward direction, this gives a complete characterization:
-      (∀ P, IMPF(P) ⊆ PRFV(P)) ⟺ (∀ P, CSIP(P))
+      (∀ P, IMPF(P) ⊆ PRFV(P)) ⟺ (∀ P, CSUB(P))
 
     The proof uses the **refined predicate trick**: given P, e, w, t with
     P(w,e) and t ⊆ τ(e), we apply the hypothesis not to P directly but
-    to Q(w', e') := P(w', e') ∧ t ⊆ τ(e'). Then:
+    to Q(w', e') := P(w', e') ∧ t ⊆ τ(e'). The case split on `e.τ = t` is
+    load-bearing: IMPF requires *strict* containment `t < e.τ`, so the
+    equality case must be discharged by `e` itself. Then:
     - PRFV gives τ(e₂) ⊆ t (event contained in reference time)
     - Q gives t ⊆ τ(e₂) (from the predicate's second conjunct)
     - Mutual containment gives τ(e₂) = t (closing the ⊆ → = gap) -/
-theorem csip_necessary_for_impf_prfv :
+theorem csub_necessary_for_impf_prfv :
     (∀ (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time),
       IMPF P w t → PRFV P w t) →
     ∀ (P : W → Event Time → Prop), HasClosedSubintervalProp P := by
-  intro hall P e w hP t hSub
+  intro hall P
+  rw [hasClosedSubintervalProp_iff_witnesses]
+  intro e w hP t hSub
   -- Case split: τ(e) = t or τ(e) ≠ t
   by_cases heq : e.τ = t
-  · -- τ(e) = t: e itself witnesses CSIP
+  · -- τ(e) = t: e itself witnesses CSUB
     exact ⟨e, heq, hP⟩
   · -- τ(e) ≠ t: t is strictly contained in τ(e)
     have hProper : t < e.τ := lt_of_le_of_ne hSub (fun h => heq (h ▸ rfl))

--- a/Linglib/Semantics/Events/Basic.lean
+++ b/Linglib/Semantics/Events/Basic.lean
@@ -1,4 +1,5 @@
 import Mathlib.Order.Basic
+import Mathlib.Data.Set.Image
 import Linglib.Core.Order.Interval
 import Linglib.Features.Aktionsart
 
@@ -167,6 +168,46 @@ def Manner.sharedBy (m : Manner Time) (e₁ e₂ : Event Time) : Prop :=
   m.exhibits e₁ ∧ m.exhibits e₂
 
 end Event
+
+/-! ### Run-time projection (event predicate → interval set)
+
+The event→interval projection: the set of run-time intervals of the events
+satisfying `P`, i.e. the image of `P` under the temporal trace τ
+([krifka-1989], [krifka-1998]). This is neutral event substrate — the upper
+rung of the projection ladder whose tense-specific lower rungs (`timeTrace`,
+the canonical denotation patterns) live in
+`Semantics/Tense/TemporalConnectives/`. It is homed here, upstream of all
+aspect/tense theories, so that subinterval/homogeneity properties can be
+stated as order-theoretic facts about it (see
+`Semantics/Aspect/SubintervalProperty.lean`). -/
+
+section Denotation
+
+variable {Time : Type*} [LinearOrder Time]
+
+/-- The event→interval projection: the set of run-time intervals of events
+    satisfying `P`, i.e. the image of `P` under the temporal trace τ. Every
+    event-level temporal theory projects to the interval level through this map. -/
+def eventDenotation (P : Event Time → Prop) : Set (NonemptyInterval Time) :=
+  Event.τ '' { e | P e }
+
+/-- Membership in `eventDenotation`: an interval is a run-time of some `P`-event. -/
+@[simp]
+theorem mem_eventDenotation {P : Event Time → Prop} {i : NonemptyInterval Time} :
+    i ∈ eventDenotation P ↔ ∃ e, P e ∧ e.τ = i := Iff.rfl
+
+/-- No events satisfy `P` ↔ the denotation is empty. -/
+theorem eventDenotation_eq_empty {P : Event Time → Prop} :
+    eventDenotation P = ∅ ↔ ∀ e, ¬ P e := by
+  rw [eventDenotation, Set.image_eq_empty]
+  exact Set.eq_empty_iff_forall_notMem
+
+/-- The run-time of any `P`-event is in the denotation. -/
+theorem mem_eventDenotation_of {P : Event Time → Prop} {e : Event Time} (he : P e) :
+    e.τ ∈ eventDenotation P :=
+  Set.mem_image_of_mem _ he
+
+end Denotation
 
 /-! ### Concrete examples (ℤ-time events) -/
 

--- a/Linglib/Semantics/Tense/TemporalConnectives/Projection.lean
+++ b/Linglib/Semantics/Tense/TemporalConnectives/Projection.lean
@@ -11,15 +11,16 @@ import Linglib.Semantics.Aspect.SubintervalProperty
 # The event→interval projection
 [krifka-1989] [krifka-1998] [parsons-1990] [champollion-2017]
 
-`eventDenotation` projects a (neo-Davidsonian, [parsons-1990]) event predicate to the
-set of run-time intervals of its events: the image of the predicate under the temporal
-trace τ ([krifka-1989], [krifka-1998]). It is the upper rung of the three-level
-projection ladder whose lower rungs (`timeTrace`, the denotation patterns) live in
-`Basic.lean`:
+`eventDenotation` (defined upstream in `Semantics/Events/Basic.lean`) projects a
+(neo-Davidsonian, [parsons-1990]) event predicate to the set of run-time intervals of
+its events: the image of the predicate under the temporal trace τ ([krifka-1989],
+[krifka-1998]). It is the upper rung of the three-level projection ladder; this file
+supplies the rung that connects it to the tense-layer denotation patterns and the
+`timeTrace` lower rung in `Basic.lean`:
 
 ```
 Level 3: Event Time → Prop   (event predicates — O&ST, future theories)
-    ↓ eventDenotation (this file)
+    ↓ eventDenotation (Events/Basic.lean)
 Level 2: SentDenotation Time (interval sets — Anscombe, Rett)
     ↓ timeTrace (Basic.lean)
 Level 1: Set Time            (point sets)
@@ -64,34 +65,14 @@ namespace Tense.TemporalConnectives
 
 variable {Time : Type*} [LinearOrder Time]
 
-/-! ### The projection -/
+/-! ### Time trace factoring
 
-/-- The event→interval projection: the set of run-time intervals of events satisfying
-    `P`, i.e. the image of `P` under the temporal trace τ. Every event-level temporal
-    connective theory projects down to the interval level through this map, where it can
-    be compared with the Anscombe and Rett accounts. -/
-def eventDenotation (P : Event Time → Prop) : SentDenotation Time :=
-  Event.τ '' { e | P e }
-
-/-- Membership in `eventDenotation`: an interval is a run-time of some `P`-event. -/
-@[simp]
-theorem mem_eventDenotation {P : Event Time → Prop} {i : NonemptyInterval Time} :
-    i ∈ eventDenotation P ↔ ∃ e, P e ∧ e.τ = i := Iff.rfl
-
-/-! ### Basic properties -/
-
-/-- No events satisfy `P` ↔ the denotation is empty. -/
-theorem eventDenotation_eq_empty {P : Event Time → Prop} :
-    eventDenotation P = ∅ ↔ ∀ e, ¬ P e := by
-  rw [eventDenotation, Set.image_eq_empty]
-  exact Set.eq_empty_iff_forall_notMem
-
-/-- The run-time of any `P`-event is in the denotation. -/
-theorem mem_eventDenotation_of {P : Event Time → Prop} {e : Event Time} (he : P e) :
-    e.τ ∈ eventDenotation P :=
-  Set.mem_image_of_mem _ he
-
-/-! ### Time trace factoring -/
+    The `eventDenotation` projection itself (`Event.τ '' {e | P e}`) and its
+    basic membership/emptiness API now live upstream in
+    `Semantics/Events/Basic.lean` — it is neutral event substrate, not
+    tense-specific. The lemmas below connect it to the *tense-layer*
+    denotation patterns (`timeTrace`, `stativeDenotation`,
+    `accomplishmentDenotation`) defined in `Basic.lean`. -/
 
 /-- The time trace of an event denotation factors through τ: a time is in the trace iff
     some event satisfying `P` has a run-time containing it. This is the composition
@@ -137,17 +118,16 @@ open Semantics.Aspect.SubintervalProperty in
     `Aspect/SubintervalProperty.lean`) at world `w`, its run-time denotation is a lower
     set — homogeneous / subinterval-closed in the sense of `IsLowerSet`.
 
-    This is the complement to `eventDenotation_sub_stative`: that gives only `⊆`
-    (subintervals that are nobody's run-time are absent), and CSUB is exactly what
-    closes the gap — it guarantees a witness event for every subinterval, populating the
-    denotation. The *closed* variant is necessary: plain `HasSubintervalProp` only
-    constrains hypothetical witnesses and cannot place an event at each subinterval. -/
+    Since CSUB is now *defined* as "`eventDenotation` is a lower set at every world"
+    (`Aspect/SubintervalProperty.lean`), this Tense-layer accessor is the bare
+    per-world projection `hP w`. It is the complement to `eventDenotation_sub_stative`:
+    that gives only `⊆` (subintervals that are nobody's run-time are absent), and CSUB
+    is exactly what closes the gap — a witness event at every subinterval. The *closed*
+    variant is necessary: plain `HasSubintervalProp` only constrains hypothetical
+    witnesses and cannot place an event at each subinterval. -/
 theorem isLowerSet_eventDenotation_of_csub {W : Type*}
     (P : W → Event Time → Prop) (w : W) (hP : HasClosedSubintervalProp P) :
-    IsLowerSet (eventDenotation (fun e => P w e)) := by
-  intro a b hba ha
-  obtain ⟨e₁, hPe₁, rfl⟩ := ha
-  obtain ⟨e₂, he₂τ, hPe₂⟩ := hP e₁ w hPe₁ b hba
-  exact ⟨e₂, hPe₂, he₂τ⟩
+    IsLowerSet (eventDenotation (fun e => P w e)) :=
+  hP w
 
 end Tense.TemporalConnectives

--- a/Linglib/Studies/Giannakidou2002.lean
+++ b/Linglib/Studies/Giannakidou2002.lean
@@ -206,11 +206,10 @@ theorem prfvDen_singleton_eq_accomplishmentDenotation
     prfvDen (fun () (e : Event Time) => e.τ = i) =
     accomplishmentDenotation i := by
   ext j
-  simp only [prfvDen, mem_eventDenotation, accomplishmentDenotation,
-    Set.mem_setOf_eq, Event.τ]
+  simp only [prfvDen, mem_eventDenotation, accomplishmentDenotation, Event.τ]
   constructor
   · rintro ⟨e, rfl, rfl⟩; rfl
-    -- sort defaults to .action; the proof doesn't reference .sort
+    -- sort is irrelevant here (defaults to .dynamic); the proof never reads .sort
   · intro h; exact ⟨⟨i, .dynamic⟩, rfl, h.symm⟩
 
 -- ============================================================================

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -478,13 +478,13 @@ The following theorems make this structural parallel precise. -/
     from existential (not universal) quantificational structure.
 
     Formally: CSIP(P) → IMPF(P)(w)(t) → PRFV(P)(w)(t). This is
-    `impf_entails_prfv_of_csip` from SubintervalProperty.lean. -/
+    `impf_entails_prfv_of_csub` from SubintervalProperty.lean. -/
 theorem csip_entails_completion
     {W Time : Type*} [LinearOrder Time]
     (P : W → Event Time → Prop) (hCSIP : HasClosedSubintervalProp P)
     (w : W) (t : NonemptyInterval Time) :
     IMPF P w t → PRFV P w t :=
-  fun h => impf_entails_prfv_of_csip P hCSIP w t h
+  fun h => impf_entails_prfv_of_csub P hCSIP w t h
 
 /-- **Non-CSIP predicates may lack completion**: the imperfective paradox shows
     that not all predicates support the IMPF→PRFV entailment.
@@ -542,7 +542,7 @@ theorem csip_determines_modal_need
       -- Modal resolution needed: must appeal to alternative worlds
       ∃ e, t < e.τ ∧ P w e) := by
   constructor
-  · intro hCSIP; exact impf_entails_prfv_of_csip P hCSIP w t
+  · intro hCSIP; exact impf_entails_prfv_of_csub P hCSIP w t
   · intro ⟨e, hSub, hP⟩ _ _
     exact ⟨e, hSub, hP⟩
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -1379,6 +1379,18 @@
   validated = {true},
   sources   = {Fragments/Arabic/ModernStandard/Negation.lean}
 }
+@techreport{bennett-partee-1972,
+  author    = {Bennett, Michael and Partee, Barbara Hall},
+  year      = {1972},
+  title     = {Toward the Logic of Tense and Aspect in {English}},
+  institution = {System Development Corporation},
+  address   = {Santa Monica, CA},
+  note      = {Reprinted by Indiana University Linguistics Club, 1978; reprinted in Partee, B.H. (2004), Compositionality in Formal Semantics, Blackwell, pp. 59--109},
+  subfield  = {semantics/lexical},
+  role      = {foundational},
+  validated = {true},
+  sources   = {Semantics/Aspect/SubintervalProperty.lean}
+}
 @phdthesis{benz-2025,
   author    = {Benz, Johanna},
   year      = {2025},


### PR DESCRIPTION
Collapse three encodings of run-time-image homogeneity onto mathlib `IsLowerSet`.

- `HasClosedSubintervalProp` is now `∀ w, IsLowerSet (eventDenotation (P w ·))`; the ∀∀∃ witness form is preserved as the characterization lemma `hasClosedSubintervalProp_iff_witnesses`. This is definitionally Krifka divisibility (`DIV`) of the run-time image.
- The neutral `eventDenotation` projection moves up from `Tense/TemporalConnectives/Projection.lean` to `Events/Basic.lean` (it is event substrate, not tense-specific); the Tense-layer `isLowerSet_eventDenotation_of_csub` collapses to the per-world projection `hP w`.
- Bundles a `SubintervalProperty` audit pass: adds the `[bennett-partee-1972]` bib entry + `[key]` cites, renames `*_of_csip`→`*_of_csub`, flags the extensional-vs-intensional gap in the imperfective-paradox framing, and fixes stale module paths.