### PR TITLE
refactor(Phonology/Subregular): join Core's Subregular namespace

### DIFF
--- a/Linglib/Fragments/English/Phonology.lean
+++ b/Linglib/Fragments/English/Phonology.lean
@@ -6,7 +6,7 @@ import Linglib.Data.PHOIBLE.Inventories.English
 # English Phonological Inventory
 
 Concrete English segments and language-specific phonological rules,
-defined using the SPE formalism from `Phonology.LocalRewrite`.
+defined using the SPE formalism from `Subregular.LocalRewrite`.
 
 ## Segments
 
@@ -21,7 +21,7 @@ Core inventory for demo alternations: /p t k b d m n ŋ s w r æ ɪ ə/.
 -/
 
 open Phonology
-open Phonology.LocalRewrite
+open Subregular.LocalRewrite
 
 namespace English.Phonology
 

--- a/Linglib/Fragments/Finnish/ConsonantGradation.lean
+++ b/Linglib/Fragments/Finnish/ConsonantGradation.lean
@@ -32,7 +32,7 @@ right context: a following consonant signals a closed syllable.
 namespace Finnish.ConsonantGradation
 
 open Phonology (Segment Feature Segment.ofSpecs)
-open Phonology.LocalRewrite
+open Subregular.LocalRewrite
 
 -- ============================================================================
 -- § 1: Natural Classes

--- a/Linglib/Fragments/Finnish/VowelHarmony.lean
+++ b/Linglib/Fragments/Finnish/VowelHarmony.lean
@@ -40,7 +40,7 @@ namespace Finnish.VowelHarmony
 open Phonology (Segment Feature FeatureVal)
 open Phonology.FeatureGeometry (GeomNode)
 open Phonology.Autosegmental (AutosegRep agreeAt)
-open Phonology.Harmony (System HarmonyDir triggerValue
+open Subregular.Harmony (System HarmonyDir triggerValue
   harmonizeOne spreadSuffix)
 
 -- ============================================================================

--- a/Linglib/Fragments/Hungarian/VowelHarmony.lean
+++ b/Linglib/Fragments/Hungarian/VowelHarmony.lean
@@ -84,7 +84,7 @@ set_option autoImplicit false
 namespace Hungarian.VowelHarmony
 
 open Phonology (Segment Feature FeatureVal)
-open Phonology.Harmony (System HarmonyDir triggerValue
+open Subregular.Harmony (System HarmonyDir triggerValue
   harmonizeOne harmonyDomain spreadSuffix)
 
 -- ============================================================================

--- a/Linglib/Fragments/Korean/Phonology.lean
+++ b/Linglib/Fragments/Korean/Phonology.lean
@@ -5,7 +5,7 @@ import Linglib.Phonology.Subregular.LocalRewrite
 # Korean Phonological Inventory
 
 Korean segments and the stop nasalization rule, using the SPE formalism
-from `Phonology.LocalRewrite`.
+from `Subregular.LocalRewrite`.
 
 ## Segments
 
@@ -21,7 +21,7 @@ target feature for the nasalization rule.
 -/
 
 open Phonology
-open Phonology.LocalRewrite
+open Subregular.LocalRewrite
 
 namespace Korean.Phonology
 

--- a/Linglib/Fragments/Tagalog/Phonology.lean
+++ b/Linglib/Fragments/Tagalog/Phonology.lean
@@ -6,7 +6,7 @@ import Linglib.Phonology.Subregular.LocalRewrite
 [hayes-2009] [zuraw-2010]
 
 Segment inventory and the nasal substitution process for Tagalog,
-defined using the SPE formalism from `Phonology.LocalRewrite`.
+defined using the SPE formalism from `Subregular.LocalRewrite`.
 
 ## Nasal substitution
 
@@ -46,7 +46,7 @@ the independent rule of homorganic-nasal-place assimilation, which
 -/
 
 open Phonology
-open Phonology.LocalRewrite
+open Subregular.LocalRewrite
 
 namespace Tagalog.Phonology
 

--- a/Linglib/Fragments/Turkish/VowelHarmony.lean
+++ b/Linglib/Fragments/Turkish/VowelHarmony.lean
@@ -52,7 +52,7 @@ namespace Turkish.VowelHarmony
 
 open Phonology (Segment Feature)
 open Phonology.Autosegmental (agreeAt)
-open Phonology.Harmony (System HarmonyDir triggerValue)
+open Subregular.Harmony (System HarmonyDir triggerValue)
 
 -- ============================================================================
 -- § 1: Turkish Vowel Inventory (8 vowels)

--- a/Linglib/Phonology/OptimalityTheory/Constraints.lean
+++ b/Linglib/Phonology/OptimalityTheory/Constraints.lean
@@ -166,7 +166,7 @@ export Subregular (countAdjacent)
     Generic markedness constructor for adjacency-based phonological
     constraints over a single tier. OCP is the case `R := (· = ·)`
     (`mkOCPOnTier` below). The TSL_2 bridge
-    `Phonology.mkForbidPairsOnTier_zero_iff_in_lang` characterizes
+    `Subregular.mkForbidPairsOnTier_zero_iff_in_lang` characterizes
     zero-violation candidates as members of the corresponding tier-based
     strictly 2-local language for any choice of `R`. -/
 def mkForbidPairsOnTier {C α β : Type} (name : String) (R : β → β → Prop)

--- a/Linglib/Phonology/Subregular/Agree.lean
+++ b/Linglib/Phonology/Subregular/Agree.lean
@@ -35,7 +35,7 @@ forbidden-pair infrastructure to `R := (· ≠ ·)`. The AGREE-specific names
 downstream consumers reference.
 -/
 
-namespace Phonology
+namespace Subregular
 
 open OptimalityTheory
 open Subregular
@@ -112,4 +112,4 @@ theorem mkAgreeOnTier_zeroSet_eq [DecidableEq α]
   ext w
   exact mkAgreeOnTier_zero_iff_in_agree_lang name p id w
 
-end Phonology
+end Subregular

--- a/Linglib/Phonology/Subregular/ForbidPairs.lean
+++ b/Linglib/Phonology/Subregular/ForbidPairs.lean
@@ -22,7 +22,7 @@ forbidden-pair relation `R`. The OCP-specific specialization (with
 corollary.
 -/
 
-namespace Phonology
+namespace Subregular
 
 open OptimalityTheory
 open Subregular
@@ -60,4 +60,4 @@ theorem mkForbidPairsOnTier_zero_iff_in_lang {C : Type} (name : String)
   rw [mkForbidPairsOnTier_zero_iff_isChain,
       mem_ofForbiddenPairs_lang_iff_filter_isChain]
 
-end Phonology
+end Subregular

--- a/Linglib/Phonology/Subregular/Harmony.lean
+++ b/Linglib/Phonology/Subregular/Harmony.lean
@@ -62,7 +62,7 @@ theory-neutral harmony profile consumed by rival accounts is future work.
   non-neutral suffix vowels; neutral vowels (/i, í, e, é/) are transparent
 -/
 
-namespace Phonology.Harmony
+namespace Subregular.Harmony
 
 open Phonology (Segment Feature FeatureVal)
 open Phonology
@@ -293,4 +293,4 @@ theorem spreadSuffix_blocker (sys : System) (val : Bool)
     spreadSuffix sys val (s :: rest) = s :: rest := by
   simp [spreadSuffix, hb]
 
-end Phonology.Harmony
+end Subregular.Harmony

--- a/Linglib/Phonology/Subregular/LocalRewrite.lean
+++ b/Linglib/Phonology/Subregular/LocalRewrite.lean
@@ -46,7 +46,7 @@ Iterative spreading lies in the strictly larger Output Strictly Local class
   (cf. `Core/Computability/Subregular/Function/ISL.lean`).
 -/
 
-namespace Phonology.LocalRewrite
+namespace Subregular.LocalRewrite
 
 open Phonology
 
@@ -145,4 +145,4 @@ previous rule (extrinsic ordering, the SPE convention). -/
 def derive (rules : List Rule) (input : List Segment) : List Segment :=
   rules.foldl (fun s r => r.apply s) input
 
-end Phonology.LocalRewrite
+end Subregular.LocalRewrite

--- a/Linglib/Phonology/Subregular/OCP.lean
+++ b/Linglib/Phonology/Subregular/OCP.lean
@@ -44,7 +44,7 @@ formalisations but the constraint and a retraction onto it, both characterising
 `Phonology.OCP.IsClean`, both subregular.
 -/
 
-namespace Phonology
+namespace Subregular
 
 open OptimalityTheory
 open Subregular
@@ -186,4 +186,4 @@ theorem collapse_isISL [DecidableEq α] :
     rw [Phonology.OCP.collapse_eq_destutter, List.destutter_cons']
     exact key x rest
 
-end Phonology
+end Subregular

--- a/Linglib/Phonology/Subregular/OTBound.lean
+++ b/Linglib/Phonology/Subregular/OTBound.lean
@@ -51,7 +51,7 @@ subregular hierarchy.
 --       in PR-7d to make it visible to non-phonology consumers.)
 -- ============================================================================
 
-namespace Phonology.OTBound
+namespace Subregular.OTBound
 
 open OptimalityTheory
 open Subregular
@@ -120,4 +120,4 @@ theorem exists_namedConstraint_zeroSet_not_isRegular :
   rw [supraregularConstraint_zeroSet]
   exact balancedAB_not_isRegular
 
-end Phonology.OTBound
+end Subregular.OTBound

--- a/Linglib/Phonology/Subregular/Sibilant.lean
+++ b/Linglib/Phonology/Subregular/Sibilant.lean
@@ -17,7 +17,7 @@ over this alphabet — symmetric (`TSLGrammar.agree`) or asymmetric
 (`TSLGrammar.ofForbiddenPairs`) — and keeps its language-specific data and citations.
 -/
 
-namespace Phonology
+namespace Subregular
 
 /-- The three sibilant-harmony classes: `anterior` (`s`-class), `posterior` (`ʃ`-class),
 and `neutral` (off the harmony tier). -/
@@ -34,4 +34,4 @@ instance : DecidablePred Sibilant.onTier
   | .anterior | .posterior => isTrue trivial
   | .neutral => isFalse not_false
 
-end Phonology
+end Subregular

--- a/Linglib/Phonology/Subregular/TierProjection.lean
+++ b/Linglib/Phonology/Subregular/TierProjection.lean
@@ -28,9 +28,7 @@ grammars — the bridge `apply_byClass_eq_tierProject` reconnects the two
 projections in one line.
 -/
 
-namespace Phonology
-
-open Subregular
+namespace Subregular
 
 variable {α : Type*}
 
@@ -67,4 +65,4 @@ def TSLGrammar.ofByClass (k : ℕ) (p : α → Bool)
   show decide (p x = true) = p x
   cases p x <;> rfl
 
-end Phonology
+end Subregular

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -26,7 +26,7 @@ This schema covers Belth-style D2L rules (Latin `-alis` / `-aris` liquid
 dissimilation, Turkish vowel harmony, Finnish backness harmony with
 neutral-vowel transparency — see [belth-2026]), Rose-Walker harmony
 systems (which structurally **contain** a `TierRule` as their value-prediction
-core — see `Phonology.Harmony.System` in `Subregular/Harmony.lean`), and
+core — see `Subregular.Harmony.System` in `Subregular/Harmony.lean`), and
 any SPE rule whose context is a single tier-adjacent segment.
 
 The schema does **not** cover:
@@ -53,7 +53,7 @@ is straightforward but requires careful threading of the trivial tier;
 land it once a Studies file needs to invoke the bridge concretely.
 -/
 
-namespace Phonology
+namespace Subregular
 
 open Subregular
 
@@ -197,7 +197,7 @@ where
 
 end TierRule
 
-end Phonology
+end Subregular
 
 /-! ## Function-level subregular classification
 
@@ -218,7 +218,7 @@ The non-trivial-tier classification is **deferred** (the SFST witness
 needs to thread the tier projection's state alongside the
 predicate-evaluation state); the identity-tier case is discharged below.
 Land the general witness here once a Studies file consumes it. -/
-namespace Phonology.TierRule
+namespace Subregular.TierRule
 
 open Subregular
 
@@ -358,4 +358,4 @@ theorem applyToString_isRightMyopic (r : TierRule α) :
     IsMyopicTowards r.applyToString .right :=
   IsMyopicTowards.right_of_prefixDetermined (applyToString_prefixDetermined r)
 
-end Phonology.TierRule
+end Subregular.TierRule

--- a/Linglib/Studies/Belth2026.lean
+++ b/Linglib/Studies/Belth2026.lean
@@ -19,9 +19,9 @@ tier and tries again, until either a tolerated rule is found or no further
 deletion helps.
 
 The output of D2L is a tier-based alternation rule, modelled here by the
-canonical `Phonology.TierRule` schema (in
+canonical `Subregular.TierRule` schema (in
 `Phonology/Alternation.lean`); the closely-related SPE
-non-tier `Phonology.LocalRewrite.Rule` schema in
+non-tier `Subregular.LocalRewrite.Rule` schema in
 `Phonology/Subregular/LocalRewrite.lean` is the right substrate
 when the alternation does not factor through a tier projection.
 The function-level subregular classification of D2L outputs lives in
@@ -82,6 +82,7 @@ namespace Belth2026
 
 open Core
 open Phonology
+open Subregular
 
 -- ============================================================================
 -- § 1: A Minimal Latin Alphabet
@@ -314,7 +315,7 @@ theorem consTier_apply_eq_tierProject (xs : List LatSeg) :
     TSL_k schema, instantiated with `IsCons` as the tier predicate and
     the OCP forbidden 2-factor `[some x, some x]`. -/
 def latinTSLGrammar : Subregular.TSLGrammar 2 LatSeg :=
-  Phonology.TSLGrammar.ocp LatSeg.IsCons
+  Subregular.TSLGrammar.ocp LatSeg.IsCons
 
 -- ============================================================================
 -- § 9: OCP-on-Tier Bridge and OT Tableau ([goldsmith-1976])
@@ -336,12 +337,12 @@ theorem latinOCP_is_markedness :
 
 /-- The OCP-on-tier evaluation of `latinOCP` on a candidate is zero iff
     that candidate is in `latinTSLGrammar.lang`. Specialization of
-    `Phonology.mkOCPOnTier_zero_iff_in_ocp_lang` to the Latin
+    `Subregular.mkOCPOnTier_zero_iff_in_ocp_lang` to the Latin
     grammar. The two perspectives — markedness constraint with zero
     violations and TSL_2 grammar membership — coincide. -/
 theorem latinOCP_zero_iff_in_TSL (c : List LatSeg) :
     latinOCP.eval c = 0 ↔ c ∈ latinTSLGrammar.lang :=
-  Phonology.mkOCPOnTier_zero_iff_in_ocp_lang
+  Subregular.mkOCPOnTier_zero_iff_in_ocp_lang
     "OCP/[+cons]" LatSeg.IsCons id c
 
 /-! The OT analysis uses a minimal two-constraint inventory:
@@ -534,7 +535,7 @@ D2L converges to two rules on Turkish CHILDES + MorphoChallenge data:
   — voicing assimilation: the projection component is the *trivial*
   identity tier (every segment projects). This is the strict-locality
   case captured generically by
-  `Phonology.TierRule.id_tier_left_is_strict_local`.
+  `Subregular.TierRule.id_tier_left_is_strict_local`.
 
 D2L's reported test accuracy on the two corpora exceeds 0.98, beating
 [hayes-wilson-2008] generative phonotactic learners and LSTM

--- a/Linglib/Studies/Hansson2010.lean
+++ b/Linglib/Studies/Hansson2010.lean
@@ -145,7 +145,7 @@ inductive NSeg where
   deriving DecidableEq, Repr
 
 /-- `NSeg`'s sibilant class, grounding the tier predicate in the shared
-`Phonology.Sibilant` substrate: the two sibilant series map to `anterior` and
+`Subregular.Sibilant` substrate: the two sibilant series map to `anterior` and
 `posterior`, the transparent material (non-sibilant consonants, vowels) to `neutral`. -/
 @[reducible] def NSeg.toSibilant : NSeg → Sibilant
   | .antSib => .anterior

--- a/Linglib/Studies/Lambert2026.lean
+++ b/Linglib/Studies/Lambert2026.lean
@@ -108,8 +108,7 @@ namespace Lambert2026
 open Subregular
 open Language
 open List  -- for `<+` (List.Sublist) infix in subseqSet equivalence proofs
-open Phonology (Sibilant)
-open Phonology  -- for `TSLGrammar.agree`
+-- `Sibilant` and `TSLGrammar.agree` now live in the shared `Subregular` namespace (opened above)
 
 /-! ### Sandwich-word helpers
 
@@ -651,7 +650,7 @@ theorem karanga_shona_verb_stem_isBTLI :
 /-! ### Sibilant-harmony grammars over the shared `Sibilant` alphabet
 
 Both asymmetric directions plus the symmetric foil, over the shared
-`Phonology.Sibilant` substrate. Lambert's classification draws the
+`Subregular.Sibilant` substrate. Lambert's classification draws the
 symmetric-vs-asymmetric comparison: the symmetric grammar is the [hansson-2010]
 Navajo profile (`TSLGrammar.agree`, disagreement forbidden in both directions),
 the anterior-first asymmetric grammar the [cook-1978] Tsuut'ina profile. -/
@@ -713,7 +712,7 @@ theorem symmetricHarmony_lang_subset_asymPostFirst :
     Sibilant.onTier
 
 /-- The Tsuut'ina sibilant alphabet ([cook-1978]) is the shared three-class
-`Phonology.Sibilant` (anterior `s`, posterior `ʃ`, neutral non-sibilant). -/
+`Subregular.Sibilant` (anterior `s`, posterior `ʃ`, neutral non-sibilant). -/
 abbrev TsuutinaSeg := Sibilant
 
 /-- The TSL_2 grammar for Tsuut'ina asymmetric sibilant harmony ([cook-1978];

--- a/Linglib/Studies/SiptarTorkenczy2000.lean
+++ b/Linglib/Studies/SiptarTorkenczy2000.lean
@@ -43,7 +43,7 @@ goals. One type system, no enum wrappers.
 namespace SiptarTorkenczy2000
 
 open Phonology (Segment Feature)
-open Phonology.Harmony
+open Subregular.Harmony
 open OptimalityTheory.Correspondence (Corr)
 open Constraint OptimalityTheory Core.Optimization Core.Optimization.Evaluation
 open Hungarian.VowelHarmony


### PR DESCRIPTION
Phonology's subregular files now declare `namespace Subregular` (the shared formal-language-theory namespace from `Core/Computability/Subregular`) instead of a parallel `namespace Phonology.*` — the way `Polynomial` spans `Algebra/`+`RingTheory/`. This fixes dot-notation that was silently broken: `TSLGrammar.agree`/`.ocp`/`.ofByClass` now sit at `Subregular.TSLGrammar.*` beside Core's `TSLGrammar.ofForbiddenPairs`, so `g.agree` resolves.

First step of the literature-grounded Phonology namespace re-carve (by object, not directory).