### PR TITLE
refactor(Phonology/Autosegmental): drop Phonology prefix, bare-root framework namespace

### DIFF
--- a/Linglib/Fragments/Finnish/VowelHarmony.lean
+++ b/Linglib/Fragments/Finnish/VowelHarmony.lean
@@ -39,7 +39,7 @@ namespace Finnish.VowelHarmony
 
 open Phonology (Segment Feature FeatureVal)
 open Phonology.FeatureGeometry (GeomNode)
-open Phonology.Autosegmental (AutosegRep agreeAt)
+open Autosegmental (AutosegRep agreeAt)
 open Subregular.Harmony (System HarmonyDir triggerValue
   harmonizeOne spreadSuffix)
 

--- a/Linglib/Fragments/Poko/Tone.lean
+++ b/Linglib/Fragments/Poko/Tone.lean
@@ -46,7 +46,7 @@ fields.
 
 namespace Poko
 
-open Phonology.Autosegmental
+open Autosegmental
 open Tone (TRN)
 
 -- ============================================================================

--- a/Linglib/Fragments/Turkish/VowelHarmony.lean
+++ b/Linglib/Fragments/Turkish/VowelHarmony.lean
@@ -51,7 +51,7 @@ Turkish VH decomposes into two `System` instances:
 namespace Turkish.VowelHarmony
 
 open Phonology (Segment Feature)
-open Phonology.Autosegmental (agreeAt)
+open Autosegmental (agreeAt)
 open Subregular.Harmony (System HarmonyDir triggerValue)
 
 -- ============================================================================

--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -44,7 +44,7 @@ broader Heinz-Jardine-Chandlee tradition.
   object-monoid.
 -/
 
-namespace Phonology.Autosegmental
+namespace Autosegmental
 
 /-! ### The bundled type `AR`
 
@@ -297,4 +297,4 @@ instance : MonoidalCategory (AR α β) :=
 
 end AR
 
-end Phonology.Autosegmental
+end Autosegmental

--- a/Linglib/Phonology/Autosegmental/FeatureSharing.lean
+++ b/Linglib/Phonology/Autosegmental/FeatureSharing.lean
@@ -50,7 +50,7 @@ two distinct elements cannot be identical to the same time point.
   argument against simultaneity.
 -/
 
-namespace Phonology.Autosegmental
+namespace Autosegmental
 
 open Phonology (Segment Feature FeatureVal)
 open Phonology.FeatureGeometry (GeomNode)
@@ -198,4 +198,4 @@ theorem spread_delink_not_present (r : AutosegRep) (pos : Nat) (n : GeomNode)
   exact ⟨trivial, filter_all_pass shs _ h⟩
 
 
-end Phonology.Autosegmental
+end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -69,10 +69,10 @@ well-formedness ([goldsmith-1976]).
 * [lieber-1983] — floating features in autosegmental morphology
 -/
 
-namespace Phonology.Autosegmental
+namespace Autosegmental
 
 -- Re-export `Morpheme` so autosegmental consumers see it unqualified
--- after `open Phonology.Autosegmental`.
+-- after `open Autosegmental`.
 export Morphology.WordStructure (Morpheme)
 
 /-! ### Tier and link primitives -/
@@ -278,4 +278,4 @@ def countTBUs (f : FloatingForm S T) (p : SegIdx → Prop) [DecidablePred p] : N
 
 end FloatingForm
 
-end Phonology.Autosegmental
+end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Graph.lean
+++ b/Linglib/Phonology/Autosegmental/Graph.lean
@@ -12,7 +12,7 @@ import Linglib.Phonology.Autosegmental.NoCrossing
 [goldsmith-1976] [pulleyblank-1986] [jardine-heinz-2015]
 [jardine-2017] [leben-2018-autoseg] [coleman-local-1991]
 
-A `Phonology.Autosegmental.Graph α β` is a finite ordered bipartite
+A `Autosegmental.Graph α β` is a finite ordered bipartite
 labeled relation between two tiers: an `upper` sequence of `α`-elements,
 a `lower` sequence of `β`-elements, and a `Finset` of association lines
 between them. It is the standard *autosegmental representation* (AR;
@@ -24,11 +24,11 @@ phonology tradition ([jardine-2017], [chandlee-jardine-2019],
 
 Mathlib pattern: directory-qualified object name + short category symbol.
 
-* **Object**: `Phonology.Autosegmental.Graph α β` — the path supplies
+* **Object**: `Autosegmental.Graph α β` — the path supplies
   the "autosegmental" qualifier; the type itself is just `Graph`.
   Matches mathlib's `Mathlib.Combinatorics.SimpleGraph` / `SimpleGraph V`
   and `Mathlib.Topology.MetricSpace` / `MetricSpace X` pattern.
-* **Category** (reserved): `Phonology.Autosegmental.AR α β` — the
+* **Category** (reserved): `Autosegmental.AR α β` — the
   literature-canonical symbol used uniformly in [coleman-local-1991],
   [jardine-2017], [chandlee-jardine-2019], and the entire
   Heinz-Jardine-Chandlee tradition. Mirrors mathlib's `Group`/`Grp`,
@@ -38,7 +38,7 @@ Mathlib pattern: directory-qualified object name + short category symbol.
 Two well-formedness conditions are formalised as separable `Prop`s:
 
 * `IsPlanar` — Goldsmith's **no-crossing constraint**
-  ([goldsmith-1976]; lifted from `Phonology.Autosegmental.IsNoCrossing`
+  ([goldsmith-1976]; lifted from `Autosegmental.IsNoCrossing`
   so the existing mathlib `MonovaryOn` lemma library applies directly).
   This is **Pulleyblank**'s reformulated Well-Formedness Condition
   ([pulleyblank-1986]): the *sole* structural WF requirement,
@@ -160,7 +160,7 @@ intuitive role of `upper`/`lower`; the type is just a list.
   upper tier is `Quantum`-typed.
 -/
 
-namespace Phonology.Autosegmental
+namespace Autosegmental
 
 /-- A bipartite autosegmental representation: two ordered tiers and a
     finite set of association lines between them. Generic over both
@@ -874,4 +874,4 @@ theorem SubgraphEmbeds.refl (G : Graph α β) : SubgraphEmbeds G G := by
 
 end Graph
 
-end Phonology.Autosegmental
+end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Modularity.lean
+++ b/Linglib/Phonology/Autosegmental/Modularity.lean
@@ -10,7 +10,7 @@ import Linglib.Phonology.OCP
 # Constraint modularity as monoidal-subcategory closure
 
 The monoidal product of the category of autosegmental representations
-(`Phonology.Autosegmental.AR`) is **morpheme concatenation**
+(`Autosegmental.AR`) is **morpheme concatenation**
 (`Graph.concat`, [jardine-heinz-2015]). This file gives that product
 its linguistic meaning: it classifies phonological well-formedness
 constraints by how they interact with concatenation.
@@ -60,7 +60,7 @@ construction.
   a concatenation boundary.
 -/
 
-namespace Phonology.Autosegmental
+namespace Autosegmental
 
 variable {α β : Type*}
 
@@ -140,4 +140,4 @@ theorem collapse_repairs_boundary [DecidableEq α] (A B : Graph α β) :
     Phonology.OCP.IsClean (Phonology.OCP.collapse (A.concat B).upper) :=
   Phonology.OCP.collapse_clean _
 
-end Phonology.Autosegmental
+end Autosegmental

--- a/Linglib/Phonology/Autosegmental/NoCrossing.lean
+++ b/Linglib/Phonology/Autosegmental/NoCrossing.lean
@@ -45,7 +45,7 @@ Its body is the existential index-ordering formulation
 * [sagey-1986] — temporal derivation of NCC from interval overlap
 -/
 
-namespace Phonology.Autosegmental
+namespace Autosegmental
 
 
 /-! ### Candidate-level crossing predicate -/
@@ -108,4 +108,4 @@ theorem IsNoCrossing.insert_of_not_indexCrosses
     · exact h
   · exact hNC l₁ hl₁ l₂ hl₂ hlt
 
-end Phonology.Autosegmental
+end Autosegmental

--- a/Linglib/Phonology/Prosodic/CompensatoryLengthening.lean
+++ b/Linglib/Phonology/Prosodic/CompensatoryLengthening.lean
@@ -171,7 +171,7 @@ theorem wbp_strands_mora (v c₁ c₂ : Segment) :
     CL through vowel loss always lengthens the vowel to the **left** of the
     deleted vowel, never to the right. In moraic theory this follows from
     Parasitic Delinking + the No-Crossing Constraint (derived from temporal
-    precedence in `Phonology.Autosegmental.no_crossing`,
+    precedence in `Autosegmental.no_crossing`,
     [sagey-1986] §5.3): a stranded mora can only be picked up by
     spreading leftward without crossing. -/
 theorem vowel_loss_leftward (v₁ v₂ : Segment) :

--- a/Linglib/Phonology/Tone/Constraints.lean
+++ b/Linglib/Phonology/Tone/Constraints.lean
@@ -46,7 +46,7 @@ intent and selects vector reversal for the right-to-left case.
 
 namespace Tone
 
-open Phonology.Autosegmental
+open Autosegmental
 open Tone (TRN)
 open Constraint OptimalityTheory
 

--- a/Linglib/Studies/AkinboFwangwar2026.lean
+++ b/Linglib/Studies/AkinboFwangwar2026.lean
@@ -41,7 +41,7 @@ grammatical tones targeting ideophones in Mwaghavul. *Natural Language
 
 ## Substrate
 
-The OT analysis is built on `Phonology.Autosegmental.FloatingForm Syl TRN`
+The OT analysis is built on `Autosegmental.FloatingForm Syl TRN`
 (Goldsmith-style autosegmental representation; built originally for
 [mcpherson-lamont-2026]). Each `ulTier` entry is one
 autosegment; `surfaceLinks` records associations between tier and
@@ -71,7 +71,7 @@ anchor combinators defined in §2 below.
 namespace AkinboFwangwar2026
 
 open Constraint OptimalityTheory
-open Phonology.Autosegmental
+open Autosegmental
 open Tone (TRN)
 open Tone (integrityTone)
 open Mwaghavul

--- a/Linglib/Studies/ChuangEtAl2026.lean
+++ b/Linglib/Studies/ChuangEtAl2026.lean
@@ -99,7 +99,7 @@ tonal categories are statistical generalisations across token-level
 pitch contours, not stored cognitive objects.
 
 This file's claims live on continuous f0 vectors (`PitchContour` below),
-deliberately *not* on `Phonology.Autosegmental.FloatingForm`. The two
+deliberately *not* on `Autosegmental.FloatingForm`. The two
 substrates coexist as competing analyses of overlapping data; this file
 does not bridge them. The decision is methodological: bridging would
 require committing to a translation between continuous contours and

--- a/Linglib/Studies/Clements1985.lean
+++ b/Linglib/Studies/Clements1985.lean
@@ -19,7 +19,7 @@ namespace Clements1985
 
 open Phonology
 open Phonology.FeatureGeometry (GeomNode)
-open Phonology.Autosegmental
+open Autosegmental
 open English.Phonology
 
 -- ============================================================================

--- a/Linglib/Studies/Jardine2017.lean
+++ b/Linglib/Studies/Jardine2017.lean
@@ -32,7 +32,7 @@ left-edge pattern. Hirosaki Japanese (§5.3), Northern Karanga Shona
 docstring as future extensions — each follows the same `Graph`-
 based forbidden-subgraph schema.
 
-Second consumer of `Phonology.Autosegmental.Graph` after
+Second consumer of `Autosegmental.Graph` after
 `Studies/LaoideKemp2026.lean`. Exercises the `SubgraphEmbeds`
 predicate (precedence-preserving translation embedding), which
 Laoide-Kemp doesn't touch.
@@ -68,7 +68,7 @@ to consecutive positions in G).
 
 namespace Jardine2017
 
-open Phonology.Autosegmental Phonology.Autosegmental.Graph
+open Autosegmental Autosegmental.Graph
 
 /-! ## §1 Label types
 

--- a/Linglib/Studies/LaoideKemp2026.lean
+++ b/Linglib/Studies/LaoideKemp2026.lean
@@ -40,7 +40,7 @@ past-tense impersonal mutation resistance (§6.2).
 
 ## Grounding: `FloatingForm` over a CV backbone
 
-This file is founded on `Phonology.Autosegmental.FloatingForm CVKind
+This file is founded on `Autosegmental.FloatingForm CVKind
 Segment` — the project's floating-autosegmental substrate, which
 [laoide-kemp-2026]'s floating consonants are a named motivating
 consumer of. Three substrate features carry the analysis directly:
@@ -110,7 +110,7 @@ is modelled as a genuine floating melodic segment (`Segment.dPrime`).
 
 namespace LaoideKemp2026
 
-open Phonology.Autosegmental
+open Autosegmental
 
 /-! ## §1 Segment inventory and CV skeleton
 
@@ -424,7 +424,7 @@ theorem laoideKemp_fig1_fig5 :
 /-! ## §10 Modularity: the analysis lives in the monoidal subcategory
 
 [laoide-kemp-2026]'s strict-modularity thesis, formalised against the
-`IsConcatStable` framework (`Phonology.Autosegmental.Modularity`).
+`IsConcatStable` framework (`Autosegmental.Modularity`).
 Three theorems, one per modular commitment: the morpheme is *composed*
 by the monoidal product `⊗ = Graph.concat` (not inserted by a non-local
 rule); the composition *preserves well-formedness* because the

--- a/Linglib/Studies/McPhersonLamont2026.lean
+++ b/Linglib/Studies/McPhersonLamont2026.lean
@@ -257,7 +257,7 @@ theorem weighted_HG_inadequate :
 
 /-! Paper, fig. 3 with the full constraint inventory and faithful
     autosegmental candidate type. Builds on three substrate pieces:
-    - `Phonology.Autosegmental.Floating` for `FloatingForm` + GEN
+    - `Autosegmental.Floating` for `FloatingForm` + GEN
       (autosegmental rep with multi-tone TBUs, no-crossing GEN)
     - `Phonology.Tone.Constraints` for the generic constraint constructors
     - `Poko.Tone` for Poko-specific syllables and morpheme IDs
@@ -283,7 +283,7 @@ theorem weighted_HG_inadequate :
 namespace Fig3
 
 open Constraint OptimalityTheory
-open Phonology.Autosegmental
+open Autosegmental
 open Tone (TRN)
 open Tone (starFloat starTautDock starCrowd maxTone depLinkTone
                      maxLinkTone starFall haveTone)
@@ -583,7 +583,7 @@ end Fig3
 namespace Eq24
 
 open Constraint OptimalityTheory
-open Phonology.Autosegmental
+open Autosegmental
 open Tone (TRN)
 open Tone (starFloat starTautDock starCrowd maxTone depLinkTone
                      maxLinkTone starFall haveTone)
@@ -665,7 +665,7 @@ end Eq24
 namespace Eq21
 
 open Constraint OptimalityTheory
-open Phonology.Autosegmental
+open Autosegmental
 open Tone (TRN)
 open Tone (starFloat starTautDock starCrowd maxTone depLinkTone
                      maxLinkTone starFall haveTone)
@@ -733,7 +733,7 @@ end Eq21
 namespace Eq27
 
 open Constraint OptimalityTheory
-open Phonology.Autosegmental
+open Autosegmental
 open Tone (TRN)
 open Tone (starFloat starTautDock starCrowd maxTone depLinkTone
                      maxLinkTone starFall haveTone)
@@ -803,7 +803,7 @@ end Eq27
 namespace Eq30
 
 open Constraint OptimalityTheory
-open Phonology.Autosegmental
+open Autosegmental
 open Tone (TRN)
 open Tone (starFloat starTautDock starCrowd maxTone depLinkTone
                      maxLinkTone starFall haveTone starMlessL)
@@ -886,7 +886,7 @@ end Eq30
 namespace Eq22
 
 open Constraint OptimalityTheory
-open Phonology.Autosegmental
+open Autosegmental
 open Tone (TRN)
 open Tone (starFloat starTautDock starCrowd maxTone depLinkTone
                      maxLinkTone starFall haveTone)
@@ -995,7 +995,7 @@ substrate, theorem-level not editorial.
 References: [rolle-2018] (replacive-dominant GT via `tonalOverwrite`),
 [mcpherson-lamont-2026] (multi-tone TBUs in Poko), [wolf-2007] (*TAUTDOCK). -/
 
-namespace Phonology.Autosegmental
+namespace Autosegmental
 
 open Tone (TBU)
 open Tone (TRN)
@@ -1060,4 +1060,4 @@ theorem FloatingForm.exists_multi_tone_TBU :
       surfaceLinks := {(0, 0), (1, 0)} }
   · decide
 
-end Phonology.Autosegmental
+end Autosegmental

--- a/Linglib/Studies/Sagey1986.lean
+++ b/Linglib/Studies/Sagey1986.lean
@@ -43,9 +43,9 @@ the consensus geometry:
 open Phonology (Segment Feature FeatureVal)
 open Phonology.FeatureGeometry (GeomNode)
 open Phonology.ComplexSegments
-open Phonology.Autosegmental (agreeAt)
+open Autosegmental (agreeAt)
 
-namespace Phonology.Autosegmental
+namespace Autosegmental
 
 /-! ### Interval-overlap semantics for association lines
 
@@ -272,7 +272,7 @@ def contourTone (ts tf m1s m1f m2s m2f : T)
 
 end NoCrossing
 
-end Phonology.Autosegmental
+end Autosegmental
 
 namespace Sagey1986
 
@@ -452,7 +452,7 @@ concrete integer-valued time instances. -/
 
 section NoCrossing
 
-open Phonology.Autosegmental (Association TierPosition
+open Autosegmental (Association TierPosition
   validAssociation crosses no_crossing)
 
 /-- Helper: build a ℤ interval. -/


### PR DESCRIPTION
`Phonology.Autosegmental` → bare-root `Autosegmental`, a framework namespace (the `CategoryTheory`/`MeasureTheory` pattern, like the already-bare `OptimalityTheory`/`HarmonicGrammar`): it owns several cooperating carriers — `Autosegmental.{Graph, AR, AutosegRep, FloatingForm, …}` — so it's framework-shaped, not a single object. Namespacing `Graph` as `Autosegmental.Graph` also removes the bare-root `Graph` shadow worry; all consumers use selective opens, so it never enters scope unqualified.

Second step of the literature-grounded Phonology namespace re-carve (by object, not directory).