### PR TITLE
refactor(Phonology): promote OCP to bare-root namespace

### DIFF
--- a/Linglib/Morphology/ConsonantalRoot.lean
+++ b/Linglib/Morphology/ConsonantalRoot.lean
@@ -69,14 +69,14 @@ def segmentAt (r : Root α) (i : Nat) : Option α := r.segments[i]?
 /-- **Root-level OCP** ([mccarthy-1981], [faust-2026]): a consonantal root has no two
     adjacent identical segments. Segment-level and theory-neutral — it commits to no
     tier projection or feature decomposition (stronger tier-relative variants go
-    through `Phonology.OCP.IsCleanOn`). Definitionally the segment tier being
-    `Phonology.OCP.IsClean`. -/
+    through `OCP.IsCleanOn`). Definitionally the segment tier being
+    `OCP.IsClean`. -/
 def IsOCPClean [DecidableEq α] (r : Root α) : Prop :=
-  Phonology.OCP.IsClean r.segments
+  OCP.IsClean r.segments
 
 instance instDecidablePredIsOCPClean [DecidableEq α] :
     DecidablePred (IsOCPClean (α := α)) :=
-  fun r => inferInstanceAs (Decidable (Phonology.OCP.IsClean r.segments))
+  fun r => inferInstanceAs (Decidable (OCP.IsClean r.segments))
 
 end Root
 end Morphology

--- a/Linglib/Phonology/Autosegmental/Modularity.lean
+++ b/Linglib/Phonology/Autosegmental/Modularity.lean
@@ -98,10 +98,10 @@ theorem ncc_isConcatStable : IsConcatStable (α := α) (β := β) Graph.IsPlanar
 /-- The OCP ([mccarthy-1986]) as a constraint on autosegmental
     representations: the autosegmental (upper) tier has no adjacent
     identical elements. -/
-def UpperOCPClean (g : Graph α β) : Prop := Phonology.OCP.IsClean g.upper
+def UpperOCPClean (g : Graph α β) : Prop := OCP.IsClean g.upper
 
 instance [DecidableEq α] (g : Graph α β) : Decidable (UpperOCPClean g) :=
-  inferInstanceAs (Decidable (Phonology.OCP.IsClean g.upper))
+  inferInstanceAs (Decidable (OCP.IsClean g.upper))
 
 /-- The OCP is **not** morpheme-modular: concatenation can create an
     adjacent identical autosegment pair at the morpheme boundary —
@@ -137,7 +137,7 @@ theorem ncc_modular_ocp_not :
     set. The non-modularity of the OCP (`ocp_not_isConcatStable`) is
     what makes a repair *necessary*; this theorem exhibits one. -/
 theorem collapse_repairs_boundary [DecidableEq α] (A B : Graph α β) :
-    Phonology.OCP.IsClean (Phonology.OCP.collapse (A.concat B).upper) :=
-  Phonology.OCP.collapse_clean _
+    OCP.IsClean (OCP.collapse (A.concat B).upper) :=
+  OCP.collapse_clean _
 
 end Autosegmental

--- a/Linglib/Phonology/Featural/ElementTheory.lean
+++ b/Linglib/Phonology/Featural/ElementTheory.lean
@@ -51,7 +51,7 @@ the instantiation `F := Feature`, `V := Bool` (after a thin
 `Segment` wrapper).
 
 The shared OCP-merger operation lives at the tier level
-(`Phonology.OCP.collapse`) and works
+(`OCP.collapse`) and works
 uniformly for all three instantiations. The framework-divergence
 between Hayes binary, Lionnet subtonal, and ET privative-with-head
 lives at the *segment representation* level — different `(F, V)`
@@ -214,9 +214,9 @@ def projectIU (b : ETBundle) : ETBundle :=
 /-- The element-tier OCP merger lands in the OCP-clean set: collapsing runs of
     identical `Headedness` markers (the |A|+|A| guttural fusion of
     [faust-lampitelli-2026]) leaves no two adjacent identicals. ET's instantiation of
-    `Phonology.OCP.collapse_clean`. -/
+    `OCP.collapse_clean`. -/
 theorem element_tier_collapse_clean (xs : List Headedness) :
-    Phonology.OCP.IsClean (Phonology.OCP.collapse xs) :=
-  Phonology.OCP.collapse_clean xs
+    OCP.IsClean (OCP.collapse xs) :=
+  OCP.collapse_clean xs
 
 end Phonology.ElementTheory

--- a/Linglib/Phonology/OCP.lean
+++ b/Linglib/Phonology/OCP.lean
@@ -11,7 +11,7 @@ import Mathlib.Data.List.Destutter
 The categorical, strict-identity, single-tier OCP: the ban on two *identical* adjacent
 autosegments on one tier ([mccarthy-1986]), on a projected tier for `IsCleanOn`
 ([chandlee-jardine-2019]). As a stringset the constraint is tier-based strictly local
-(TSL₂, [heinz-rawal-tanner-2011]), characterised in `Phonology.OCP`. The
+(TSL₂, [heinz-rawal-tanner-2011]), characterised in `OCP`. The
 fusion repair `collapse` is mathlib's
 `List.destutter (· ≠ ·)` ([goldsmith-1976], [mccarthy-prince-1995]) — a retraction onto
 cleanness, input-strictly-local ([chandlee-heinz-2018]); the blocking repair `block` is
@@ -34,7 +34,7 @@ and lives in the thresholded-TSL substrate, not here.
 * `block_eq_self` — antigemination: a rule is blocked when it would violate the OCP.
 -/
 
-namespace Phonology.OCP
+namespace OCP
 
 variable {α β : Type*}
 
@@ -135,4 +135,4 @@ theorem block_isClean {xs : List α} (hx : IsClean xs) : IsClean (block rule xs)
 
 end
 
-end Phonology.OCP
+end OCP

--- a/Linglib/Phonology/Subregular/OCP.lean
+++ b/Linglib/Phonology/Subregular/OCP.lean
@@ -34,14 +34,14 @@ points downstream consumers reference.
 ## The subregular face of the OCP
 
 This file is the **subregular characterization** of the OCP — one face of the
-unified `Phonology.OCP` principle. It proves that the prohibition reading (a
+unified `OCP` principle. It proves that the prohibition reading (a
 stringset rejecting adjacent identical tier-projected autosegments) is a TSL₂
-language, and that its satisfaction predicate is exactly `Phonology.OCP.IsClean`
-(`mkOCPOnTier_zero_iff_isClean`). The dual fusion repair `Phonology.OCP.collapse`
+language, and that its satisfaction predicate is exactly `OCP.IsClean`
+(`mkOCPOnTier_zero_iff_isClean`). The dual fusion repair `OCP.collapse`
 lands in the same `IsClean` set, and is itself a 2-Input-Strictly-Local map
 (`collapse_isISL`) — so prohibition and merger are not two coexisting
 formalisations but the constraint and a retraction onto it, both characterising
-`Phonology.OCP.IsClean`, both subregular.
+`OCP.IsClean`, both subregular.
 -/
 
 namespace Subregular
@@ -94,25 +94,25 @@ theorem mkOCPOnTier_zero_iff_isChain [DecidableEq α] {C : Type}
   mkForbidPairsOnTier_zero_iff_isChain name (· = ·) p extract c
 
 /-- **Shared satisfaction predicate**: a candidate's OCP score is zero iff its
-tier-projection is `Phonology.OCP.IsClean`. This is what makes the prohibition
-reading (here) and the fusion repair (`Phonology.OCP.collapse`) two faces of
+tier-projection is `OCP.IsClean`. This is what makes the prohibition
+reading (here) and the fusion repair (`OCP.collapse`) two faces of
 one principle rather than parallel formalisations — both characterise
-`Phonology.OCP.IsClean`. -/
+`OCP.IsClean`. -/
 theorem mkOCPOnTier_zero_iff_isClean [DecidableEq α] {C : Type}
     (name : String) (p : α → Prop) [DecidablePred p]
     (extract : C → List α) (c : C) :
     (mkOCPOnTier name (Tier.byClass p) extract).eval c = 0 ↔
-      Phonology.OCP.IsClean ((extract c).filter (fun x => decide (p x))) :=
+      OCP.IsClean ((extract c).filter (fun x => decide (p x))) :=
   mkOCPOnTier_zero_iff_isChain name p extract c
 
 /-- **Shared satisfaction predicate** (off-tier): the optimality-theoretic OCP
 markedness constraint `mkOCP` scores zero iff its projection is
-`Phonology.OCP.IsClean` — routing `OptimalityTheory.adjacentIdentical` (the
+`OCP.IsClean` — routing `OptimalityTheory.adjacentIdentical` (the
 `countAdjacent` form behind `mkOCP`, consumed by Berent2026/Belth2026) through the
 unified predicate. The flat-string companion of `mkOCPOnTier_zero_iff_isClean`. -/
 theorem mkOCP_zero_iff_isClean {C : Type} [DecidableEq α]
     (name : String) (project : C → List α) (c : C) :
-    (mkOCP name project).eval c = 0 ↔ Phonology.OCP.IsClean (project c) := by
+    (mkOCP name project).eval c = 0 ↔ OCP.IsClean (project c) := by
   show countAdjacent (· = ·) (project c) = 0 ↔ _
   rw [countAdjacent_eq_zero_iff_isChain (· = ·)]
   rfl
@@ -142,13 +142,13 @@ theorem mkOCPOnTier_zeroSet_eq [DecidableEq α]
 
 /-! ### The repair is subregular -/
 
-/-- The OCP fusion repair `Phonology.OCP.collapse` is a **2-Input-Strictly-Local**
+/-- The OCP fusion repair `OCP.collapse` is a **2-Input-Strictly-Local**
 string function ([chandlee-heinz-2018]): scanning left-to-right with a one-symbol
 window, delete a symbol iff it equals its predecessor. This completes the subregular
 *repair* face (the constraint side is the TSL₂ result above); cf. the autosegmental
 A-ISL classification of tonal OCP processes in [chandlee-jardine-2019]. -/
 theorem collapse_isISL [DecidableEq α] :
-    IsLeftInputStrictlyLocal 2 (Phonology.OCP.collapse (α := α)) := by
+    IsLeftInputStrictlyLocal 2 (OCP.collapse (α := α)) := by
   refine ⟨{ windowOutput := fun window x => if window = [x] then [] else [x] }, ?_⟩
   set r : ISLRule 2 α α :=
     { windowOutput := fun window x => if window = [x] then [] else [x] } with hr
@@ -174,16 +174,16 @@ theorem collapse_isISL [DecidableEq α] :
         rw [List.cons_append, List.nil_append]
         exact congrArg (a :: ·) (ih b)
   cases xs with
-  | nil => simp [Phonology.OCP.collapse]
+  | nil => simp [OCP.collapse]
   | cons x rest =>
-    show r.applyAux [] (x :: rest) = Phonology.OCP.collapse (x :: rest)
+    show r.applyAux [] (x :: rest) = OCP.collapse (x :: rest)
     rw [ISLRule.applyAux_cons]
     have hwin : ([] ++ [x]).rtake (2 - 1) = [x] := by
       simp [List.rtake]
     rw [hwin]
     show ((if ([] : List α) = [x] then [] else [x]) ++ r.applyAux [x] rest) = _
     rw [if_neg (by simp), List.cons_append, List.nil_append]
-    rw [Phonology.OCP.collapse_eq_destutter, List.destutter_cons']
+    rw [OCP.collapse_eq_destutter, List.destutter_cons']
     exact key x rest
 
 end Subregular

--- a/Linglib/Phonology/Tone/Basic.lean
+++ b/Linglib/Phonology/Tone/Basic.lean
@@ -411,7 +411,7 @@ def subtonalAssimilate (f : Subtonal) (src tgt : TRN) : TRN :=
     features into one, taking each feature from the left TRN where it is specified and
     falling back to the right (`FeatureBundle.merge`). Models the autosegmental fusion
     of two associated tones ([goldsmith-1976]); the tier-level OCP merger that
-    collapses a run of identical tones is `Phonology.OCP.collapse`. -/
+    collapses a run of identical tones is `OCP.collapse`. -/
 def mergeTRN (t₁ t₂ : TRN) : TRN :=
   TRN.ofBundle (FeatureBundle.merge t₁.toBundle t₂.toBundle)
 

--- a/Linglib/Studies/FaustLampitelli2026.lean
+++ b/Linglib/Studies/FaustLampitelli2026.lean
@@ -52,7 +52,7 @@ Two co-equal headline contributions (paper §1, eq. 2):
   * `T4_walker_rose_2015_overshoots` — divergence with witness
     `/mismaʕa/`.
 * §4 The OCP-merger reading: |A|+|A| → |A| as instance of the
-  shared `Phonology.OCP.collapse` substrate.
+  shared `OCP.collapse` substrate.
 * §5 Paper self-flagged limits as LIMITATION-tagged comments.
 
 ## What this file does NOT formalize
@@ -68,7 +68,7 @@ Two co-equal headline contributions (paper §1, eq. 2):
 ## Cross-framework engagement
 
 * §3 T4 makes explicit the divergence with [walker-rose-2015-amp].
-* The OCP merger operation (`Phonology.OCP.collapse`) unifies
+* The OCP merger operation (`OCP.collapse`) unifies
   this paper's |A|+|A| fusion with [lionnet-2022]'s TRN merger
   (Laal subtonal phonology). They are instances of one operation
   on different feature spaces; the framework choice (binary-feature
@@ -78,7 +78,7 @@ Two co-equal headline contributions (paper §1, eq. 2):
 ## Convention
 
 Predicates in this file are `Prop`-valued with `Decidable` instances,
-matching mathlib + the existing `Phonology.OCP` style.
+matching mathlib + the existing `OCP` style.
 Worked examples are checked via `decide` rather than `rfl` where
 appropriate.
 -/
@@ -474,7 +474,7 @@ theorem identicalVowel_synersis_overshoots_walker_rose :
 -/
 
 /-- The |A|+|A| → fused |A| operation of paper eq. (26) is an
-    instance of `Phonology.OCP.collapse` over a tier of
+    instance of `OCP.collapse` over a tier of
     `Headedness` values (the |A| element's headedness signature).
     Two adjacent bare-|A| markers collapse to one.
 
@@ -483,15 +483,15 @@ theorem identicalVowel_synersis_overshoots_walker_rose :
     Laal tones, just instantiated over a different value space
     (`Headedness` vs binary-feature `TRN`). -/
 theorem fusion_is_collapse_instance :
-    Phonology.OCP.collapse [Headedness.bare, Headedness.bare] = [Headedness.bare] := by
+    OCP.collapse [Headedness.bare, Headedness.bare] = [Headedness.bare] := by
   decide
 
 /-- The OCP-merger output is OCP-clean: no two adjacent identical
     elements remain. Direct application of the substrate theorem
-    `Phonology.OCP.collapse_clean`. -/
+    `OCP.collapse_clean`. -/
 theorem fusion_output_is_ocp_clean (xs : List Headedness) :
-    Phonology.OCP.IsClean (Phonology.OCP.collapse xs) :=
-  Phonology.OCP.collapse_clean xs
+    OCP.IsClean (OCP.collapse xs) :=
+  OCP.collapse_clean xs
 
 /-! ## §8 Paper-acknowledged scope limits
 

--- a/Linglib/Studies/Lionnet2022Laal.lean
+++ b/Linglib/Studies/Lionnet2022Laal.lean
@@ -30,7 +30,7 @@ exclusivity (`*MX/XM`) and its instability (M-lowering).
   (`dockFloating`).
 * §5.6 the `[+upper, +raised]` gap (Table-4 type-A system).
 * §5.2 (ex. 53–55, 58) the **optional** OCP-`[raised]` merger — consuming the
-  `Phonology.OCP` fusion repair.
+  `OCP` fusion repair.
 
 ## What this does NOT formalize
 
@@ -43,10 +43,10 @@ exclusivity (`*MX/XM`) and its instability (M-lowering).
 
 M-lowering proper is `[−raised]` *assimilation*, not OCP-merger; and `*MX/XM` is an
 *agreement* constraint (`*[α raised][β raised]`), the opposite of the identity-OCP.
-The `Phonology.OCP` API is consumed only for the merger of (53–55)/(58), which
+The `OCP` API is consumed only for the merger of (53–55)/(58), which
 Lionnet presents explicitly as optional ("not necessary in the present analysis" /
 "or fusion"). It is included because it is the merger face of the same OCP
-principle whose prohibition face lives in `Phonology.OCP`.
+principle whose prohibition face lives in `OCP`.
 -/
 
 namespace Lionnet2022Laal
@@ -125,26 +125,26 @@ theorem superHigh_is_the_gap : TRN.superHigh ∉ laalToneInventory := by decide
 /-- Lionnet (ex. 54–55, 58) notes — but explicitly does *not* adopt — an optional
 OCP-`[raised]` economy under which two adjacent identical `[−raised]` autosegments
 fuse into one multiply-linked autosegment. When two adjacent tones are *fully*
-identical, that fusion is `Phonology.OCP.collapse`: two adjacent L tones collapse to
+identical, that fusion is `OCP.collapse`: two adjacent L tones collapse to
 one. -/
 theorem ocp_raised_merge_LL :
-    Phonology.OCP.collapse [TRN.L, TRN.L] = [TRN.L] := by decide
+    OCP.collapse [TRN.L, TRN.L] = [TRN.L] := by decide
 
 /-- OCP-`[raised]` is **tier-relative** ([chandlee-jardine-2019]): it constrains the
 `[raised]`-projected tier (`IsCleanOn` reading `.raised`), not whole TRNs. H and L
 are distinct *tones* but both `[−raised]`, so adjacent they violate OCP-`[raised]`
 even though `[TRN.H, TRN.L]` is clean as a whole-TRN tier. -/
 theorem ocp_raised_is_tier_relative :
-    ¬ Phonology.OCP.IsCleanOn (fun _ : TRN => True) (·.raised) [TRN.H, TRN.L] ∧
-      Phonology.OCP.IsClean [TRN.H, TRN.L] := by decide
+    ¬ OCP.IsCleanOn (fun _ : TRN => True) (·.raised) [TRN.H, TRN.L] ∧
+      OCP.IsClean [TRN.H, TRN.L] := by decide
 
 /-- Under the optional economy, fusing adjacent identical `[raised]` autosegments
 leaves the `[raised]`-projected tier OCP-clean — the faithful tier-relative reading
 of Lionnet (ex. 54–55, 58), via the substrate retraction `collapse_clean`. The
 merger face of the same OCP principle whose prohibition (TSL₂) face lives in
-`Phonology.OCP`. -/
+`OCP`. -/
 theorem ocp_raised_merge_clean (tier : List TRN) :
-    Phonology.OCP.IsClean (Phonology.OCP.collapse (tier.map (·.raised))) :=
-  Phonology.OCP.collapse_clean _
+    OCP.IsClean (OCP.collapse (tier.map (·.raised))) :=
+  OCP.collapse_clean _
 
 end Lionnet2022Laal


### PR DESCRIPTION
`Phonology.OCP` → bare-root `OCP` — a genuine named principle (Obligatory Contour Principle, [mccarthy-1986]/[goldsmith-1976]), not directory-nested. The acronym is mathlib-consistent (the `DFA`/`NFA`/`PMF` precedent — field-standard acronyms used directly as names, with the docstring spelling it out). Continues dismantling the bare `Phonology` junk-drawer; OCP uses no `Segment`/`Feature`, so a clean un-nesting.