### PR TITLE
refactor(Phonology/Prosodic): nest layers under Prosody hierarchy namespace

### DIFF
--- a/Linglib/Fragments/Japanese/Prosody.lean
+++ b/Linglib/Fragments/Japanese/Prosody.lean
@@ -34,9 +34,9 @@ affix typology from [kawahara-2015].
 namespace Japanese.Prosody
 
 open Features.Prosody
-open Phonology.Accent (defaultAccentAAR latinStressRule accentToTones
+open Prosody.Accent (defaultAccentAAR latinStressRule accentToTones
   LevelTone shortN2CompoundAccent longN2CompoundAccent)
-open Phonology.Syllable (SyllWeight)
+open Prosody.Syllable (SyllWeight)
 open BeckmanPierrehumbert1986
 
 -- ============================================================================

--- a/Linglib/Fragments/Latin/Phonology.lean
+++ b/Linglib/Fragments/Latin/Phonology.lean
@@ -32,7 +32,7 @@ that consume this Fragment.
 **Vowel length is prosodic, not segmental.** The `[long]` feature is not
 in the `Phonology.Featural.Features` inventory (which follows
 [hayes-2009]'s decision to treat duration as a syllable-level
-property). Long vowels are encoded as two morae in `Phonology.Moraic`
+property). Long vowels are encoded as two morae in `Prosody.Moraic`
 rather than as distinct segments; consumers needing a surface short-vs-long
 contrast construct it at the syllable level.
 

--- a/Linglib/Fragments/Tarifit/Inventory.lean
+++ b/Linglib/Fragments/Tarifit/Inventory.lean
@@ -36,7 +36,7 @@ are from the paper's word list / online appendix.
 
 namespace Tarifit.Inventory
 
-open Phonology.Syllable
+open Prosody.Syllable
 
 -- ============================================================================
 -- § 1: Word Type

--- a/Linglib/Morphology/ConsonantalRoot.lean
+++ b/Linglib/Morphology/ConsonantalRoot.lean
@@ -7,7 +7,7 @@ Single source of truth for the Semitic-style notion of a *consonantal root*:
 an ordered melody of segments stored independently of vocalization or template.
 
 The segment type `α` is parametric. Studies of Tarifit Berber may instantiate
-`α := Phonology.Syllable.NatClass` (sonority-class roots, used by
+`α := Prosody.Syllable.NatClass` (sonority-class roots, used by
 [afkir-zellou-2025]); studies of Hebrew or Amharic typically instantiate
 `α := String` for IPA symbols.
 

--- a/Linglib/Morphology/DM/Categorizer.lean
+++ b/Linglib/Morphology/DM/Categorizer.lean
@@ -382,7 +382,7 @@ def CatHead.satisfiesLicense (ch : CatHead) (req : Option GenderFeature) : Bool 
     ([kramer-2020]; [faust-2026] (11)).
 
     The predicate is `cat = .n ∧ phi.gender ≠ none`. Used by
-    `Phonology.Templates.RootTemplateMatch.intrusionLicensed` to filter
+    `Prosody.Templates.RootTemplateMatch.intrusionLicensed` to filter
     `RootTemplateMatch` candidates with `intruder`-source associations. -/
 def CatHead.licensesIntrusion (ch : CatHead) : Bool :=
   decide (ch.cat = .n) && ch.phi.gender.isSome

--- a/Linglib/Phonology/Prosodic/Accent.lean
+++ b/Linglib/Phonology/Prosodic/Accent.lean
@@ -42,9 +42,9 @@ Two NonFinality constraints from [prince-smolensky-1993]:
 - **NonFinality(Ft)**: penalizes the head foot in word-final position.
 -/
 
-namespace Phonology.Accent
+namespace Prosody.Accent
 
-open Phonology.Syllable (SyllWeight MetricalParse ParseElement footMorae)
+open Prosody.Syllable (SyllWeight MetricalParse ParseElement footMorae)
 
 -- ============================================================================
 -- § 1: Syllable-from-Mora Lookup
@@ -277,4 +277,4 @@ theorem nonfin_sigma_nonfinal :
 theorem nonfin_sigma_unaccented :
     nonFinalitySigma none 3 = 0 := rfl
 
-end Phonology.Accent
+end Prosody.Accent

--- a/Linglib/Phonology/Prosodic/CompensatoryLengthening.lean
+++ b/Linglib/Phonology/Prosodic/CompensatoryLengthening.lean
@@ -24,10 +24,10 @@ line rearrangements.
 [hayes-1989]
 -/
 
-namespace Phonology.Moraic.CL
+namespace Prosody.Moraic.CL
 
 open Phonology (Segment)
-open Phonology.Moraic
+open Prosody.Moraic
 
 -- ============================================================================
 -- § 1: CL Typology
@@ -196,4 +196,4 @@ theorem no_wbp_params_disable_cl (o n c : Segment) :
     let σ := syllableToMoraic { wbp := false } ⟨[o], [n], [c]⟩
     (deleteMoraic σ 1).2 = 0 := rfl
 
-end Phonology.Moraic.CL
+end Prosody.Moraic.CL

--- a/Linglib/Phonology/Prosodic/Foot.lean
+++ b/Linglib/Phonology/Prosodic/Foot.lean
@@ -27,7 +27,7 @@ trochees, final in iambs.
 - OT constraints: `ftBinViolations`, `parseSylViolations`, `allFtLeftViolations`
 -/
 
-namespace Phonology.Syllable
+namespace Prosody.Syllable
 
 -- `SyllWeight.morae` is now a field accessor — no separate function needed.
 
@@ -218,4 +218,4 @@ private abbrev parse_lllH : MetricalParse :=
 
 theorem lllH_ftbin : ftBinViolations parse_lllH = 2 := rfl
 
-end Phonology.Syllable
+end Prosody.Syllable

--- a/Linglib/Phonology/Prosodic/Moraic.lean
+++ b/Linglib/Phonology/Prosodic/Moraic.lean
@@ -22,10 +22,10 @@ in `Syllable`, which is essentially a segmental (X-theory) view.
 [hayes-1989]
 -/
 
-namespace Phonology.Moraic
+namespace Prosody.Moraic
 
 open Phonology (Segment Feature)
-open Phonology.Syllable (Syllable SyllWeight SyllabifiedForm)
+open Prosody.Syllable (Syllable SyllWeight SyllabifiedForm)
 
 -- ============================================================================
 -- § 1: Moraic Segment — a segment with its mora count
@@ -152,7 +152,7 @@ def MoraicSyllable.toSyllWeight (σ : MoraicSyllable) : SyllWeight :=
     This connects moraic representations to the prosodic word layer,
     enabling minimal word constraints, metrical parsing, and stress
     assignment to operate on moraically-derived weight profiles. -/
-def MoraicForm.toPrWd (f : MoraicForm) : Phonology.ProsodicWord.PrWd :=
+def MoraicForm.toPrWd (f : MoraicForm) : Prosody.ProsodicWord.PrWd :=
   ⟨f.syllables.map MoraicSyllable.toSyllWeight⟩
 
 -- ============================================================================
@@ -245,4 +245,4 @@ theorem moraic_minword (f : MoraicForm) :
 theorem toSyllWeight_morae_faithful (σ : MoraicSyllable) :
     σ.toSyllWeight.morae = σ.moraCount := rfl
 
-end Phonology.Moraic
+end Prosody.Moraic

--- a/Linglib/Phonology/Prosodic/NaturalClass.lean
+++ b/Linglib/Phonology/Prosodic/NaturalClass.lean
@@ -29,7 +29,7 @@ phenomena such as intrusive vowel insertion in Tarifit Berber
 ([afkir-zellou-2025]).
 -/
 
-namespace Phonology.Syllable
+namespace Prosody.Syllable
 
 open Phonology (Segment Feature)
 
@@ -101,4 +101,4 @@ theorem parker_strictly_monotone (a b : NatClass) (h : a ≠ b) :
     NatClass.parkerSonority a > NatClass.parkerSonority b := by
   cases a <;> cases b <;> simp_all [NatClass.parkerSonority]
 
-end Phonology.Syllable
+end Prosody.Syllable

--- a/Linglib/Phonology/Prosodic/Syllable.lean
+++ b/Linglib/Phonology/Prosodic/Syllable.lean
@@ -24,7 +24,7 @@ Theory* (Ch 6, pp. 164–196). Cross-referenced with Hayes §4.6 and §15.
 [goldsmith-2011] [berent-2026]
 -/
 
-namespace Phonology.Syllable
+namespace Prosody.Syllable
 
 open Phonology (Segment Feature)
 
@@ -256,4 +256,4 @@ theorem cvc_is_heavy (σ : Syllable) (h1 : σ.nucleus.length = 1)
     σ.weight = .heavy := by
   simp only [Syllable.weight, Syllable.moraCount, h1, h2, ite_true]
 
-end Phonology.Syllable
+end Prosody.Syllable

--- a/Linglib/Phonology/Prosodic/Templates.lean
+++ b/Linglib/Phonology/Prosodic/Templates.lean
@@ -29,7 +29,7 @@ are exempt from *Misalignment because the intruder is not a root segment in
 the first place — the central analytical move of [faust-2026] §4.
 -/
 
-namespace Phonology.Templates
+namespace Prosody.Templates
 
 open Morphology
 open Constraint OptimalityTheory
@@ -365,4 +365,4 @@ def noCross {α : Type} : NamedConstraint (RootTemplateMatch α) :=
 theorem noCross_is_markedness {α : Type} :
     (noCross (α := α)).family = .markedness := rfl
 
-end Phonology.Templates
+end Prosody.Templates

--- a/Linglib/Phonology/Prosodic/Word.lean
+++ b/Linglib/Phonology/Prosodic/Word.lean
@@ -43,9 +43,9 @@ profiles, minimal word constraints, and the morphosyntax-prosody
 mapping that determines PrWd boundaries.
 -/
 
-namespace Phonology.ProsodicWord
+namespace Prosody.ProsodicWord
 
-open Phonology.Syllable
+open Prosody.Syllable
 
 -- ============================================================================
 -- § 1: Morphological Status and PrWd Membership
@@ -263,4 +263,4 @@ theorem postp_lo_no_long :
 theorem postp_gurinci_no_long :
     (MorphElement.mk "-gurinci" .postposition .light).triggersLongForm = false := rfl
 
-end Phonology.ProsodicWord
+end Prosody.ProsodicWord

--- a/Linglib/Studies/AfkirZellou2025.lean
+++ b/Linglib/Studies/AfkirZellou2025.lean
@@ -58,7 +58,7 @@ paper notes these as partly idiosyncratic (Table 7).
 namespace AfkirZellou2025
 
 open Core.Optimization Constraint OptimalityTheory
-open Phonology.Syllable
+open Prosody.Syllable
 open Tarifit.Inventory
 open Core.Optimization Constraint OptimalityTheory
 

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -55,7 +55,7 @@ namespace Aitha2026
 
 open Core Constraint OptimalityTheory Core.Optimization Core.Optimization.Evaluation
 open Morphology.DM.VI
-open Phonology.Syllable
+open Prosody.Syllable
 
 -- ============================================================================
 -- § 1: Telugu Case System and Paradigm Data
@@ -498,7 +498,7 @@ theorem stem_optimal :
 section WordLevel
 
 open OptimalityTheory.Stratal
-open Phonology.ProsodicWord
+open Prosody.ProsodicWord
 
 -- ────────────────────────────────────────────────────────────────────
 -- Rich phonological exponent substrate ([alderete-1999])
@@ -848,7 +848,7 @@ end CrossStratumReranking
 
 section PrWdIntegration
 
-open Phonology.ProsodicWord
+open Prosody.ProsodicWord
 
 /-- Predict the weak stem form from the following morphological element.
     Uses `MorphElement.triggersLongForm` from `ProsodicWord`: the long
@@ -983,8 +983,8 @@ theorem central_argument :
 section MoraicCLConnection
 
 open Phonology (Segment)
-open Phonology.Moraic (MoraicParams syllableToMoraic MoraicSyllable)
-open Phonology.Moraic.CL (deleteMoraic spreadToFill)
+open Prosody.Moraic (MoraicParams syllableToMoraic MoraicSyllable)
+open Prosody.Moraic.CL (deleteMoraic spreadToFill)
 
 /-- Telugu has Weight by Position: coda consonants bear morae, making
     CVC syllables heavy. This is assumed by the Stem-level parse, where

--- a/Linglib/Studies/Berent2026.lean
+++ b/Linglib/Studies/Berent2026.lean
@@ -51,7 +51,7 @@ data supporting the doubling reversal is in
 [berent-2026]
 -/
 
-open Phonology.Syllable (SonorityRank)
+open Prosody.Syllable (SonorityRank)
 open OptimalityTheory
 open OptimalityTheory.Doubling
 

--- a/Linglib/Studies/Faust2026.lean
+++ b/Linglib/Studies/Faust2026.lean
@@ -55,10 +55,10 @@ jointly resolves three Semitic puzzles:
 This file consumes and exercises the shared infrastructure:
 
 - `Morphology.Root` — polymorphic consonantal-root carrier.
-- `Phonology.Templates` — `CVSlot`, `Template`, `Association`,
+- `Prosody.Templates` — `CVSlot`, `Template`, `Association`,
   `RootTemplateMatch`, with derived `isMisaligned`, `allCSlotsFilled`,
   `satisfies`.
-- `Phonology.Templates.starMisalign` — the \*Misalignment alignment
+- `Prosody.Templates.starMisalign` — the \*Misalignment alignment
   constraint, built via the generic `mkAlign` constructor.
 - `OptimalityTheory.adjacentIdentical` — drives the root-level
   OCP, used to verify [faust-2026]'s OCP-related reanalysis.
@@ -73,7 +73,7 @@ type level rather than restated in prose.
 namespace Faust2026
 
 open Morphology
-open Phonology.Templates
+open Prosody.Templates
 
 -- ============================================================================
 -- § 1: Hebrew templates ([faust-2026] (1), (3), (9)–(10))

--- a/Linglib/Studies/Hayes1989.lean
+++ b/Linglib/Studies/Hayes1989.lean
@@ -40,8 +40,8 @@ over segmental prosodic theories (X theory, CV theory).
 namespace Hayes1989
 
 open Phonology (Segment Feature Segment.ofSpecs)
-open Phonology.Moraic
-open Phonology.Moraic.CL
+open Prosody.Moraic
+open Prosody.Moraic.CL
 
 -- ============================================================================
 -- § 1: Segment Inventory (minimal, for derivations)

--- a/Linglib/Studies/KalinBjorkmanEtAl2026.lean
+++ b/Linglib/Studies/KalinBjorkmanEtAl2026.lean
@@ -263,29 +263,29 @@ theorem clitic_implies_ms_free (s : MorphStatus) (h : s.IsClitic) :
 def prWdMembershipToPBound (isPrWdInternal : Bool) : PBoundedness :=
   if isPrWdInternal then .bound else .free
 
-open Phonology.ProsodicWord in
+open Prosody.ProsodicWord in
 theorem inflectional_is_p_bound :
     prWdMembershipToPBound MorphStatus.inflectional.isPrWdInternal = .bound := rfl
 
-open Phonology.ProsodicWord in
+open Prosody.ProsodicWord in
 theorem agreement_is_p_bound :
     prWdMembershipToPBound MorphStatus.agreement.isPrWdInternal = .bound := rfl
 
-open Phonology.ProsodicWord in
+open Prosody.ProsodicWord in
 theorem derivational_is_p_bound :
     prWdMembershipToPBound MorphStatus.derivational.isPrWdInternal = .bound := rfl
 
-open Phonology.ProsodicWord in
+open Prosody.ProsodicWord in
 theorem postposition_is_p_free :
     prWdMembershipToPBound MorphStatus.postposition.isPrWdInternal = .free := rfl
 
-open Phonology.ProsodicWord in
+open Prosody.ProsodicWord in
 theorem inflAffix_prWdInternal_is_canonicalAffix :
     (wordhoodProfile .inflAffix
       (prWdMembershipToPBound MorphStatus.inflectional.isPrWdInternal)
     ).classify = .canonicalAffix := rfl
 
-open Phonology.ProsodicWord in
+open Prosody.ProsodicWord in
 theorem postposition_prWdExternal_is_canonicalWord :
     (wordhoodProfile .freeWord
       (prWdMembershipToPBound MorphStatus.postposition.isPrWdInternal)

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -27,8 +27,8 @@ epenthesis, rendaku, and vowel devoicing.
    retention; long N2 (≥3μ) triggers N2-initial accent or retention.
 -/
 
-open Phonology.Accent
-open Phonology.Syllable (SyllWeight)
+open Prosody.Accent
+open Prosody.Syllable (SyllWeight)
 
 namespace Kawahara2015
 
@@ -163,7 +163,7 @@ theorem long_n2_initial_avoids_final :
     syllables with short vowels are monomoraic (light). -/
 theorem japanese_wbp_active (o n c : Phonology.Segment) :
     -- CVC with WBP is heavy (e.g., /tan/ = 2μ)
-    (Phonology.Moraic.syllableToMoraic { wbp := true }
+    (Prosody.Moraic.syllableToMoraic { wbp := true }
       ⟨[o], [n], [c]⟩).toSyllWeight = .heavy := rfl
 
 end Kawahara2015

--- a/Linglib/Studies/MarcoRasin2026.lean
+++ b/Linglib/Studies/MarcoRasin2026.lean
@@ -46,7 +46,7 @@ namespace MarcoRasin2026
 open Core.Optimization Constraint OptimalityTheory
 open OptimalityTheory
 open Phonology.ParadigmUniformity
-open Phonology.Syllable (SonorityRank)
+open Prosody.Syllable (SonorityRank)
 
 -- ============================================================================
 -- § 1: Data Types
@@ -94,7 +94,7 @@ def starSchwaOpen : NamedConstraint (List JTAForm) :=
 /-- SONCON: assign * for a CCəC (medial) form when C₂ > C₃ in sonority.
     Parametrized over the sonority ranks of C₂ and C₃, using the
     `LinearOrder SonorityRank` instance from `Syllable`. -/
-def sonCon (c2 c3 : Phonology.Syllable.SonorityRank) :
+def sonCon (c2 c3 : Prosody.Syllable.SonorityRank) :
     NamedConstraint (List JTAForm) :=
   liftPerMember "SONCON" .markedness fun f =>
     if c2 > c3 && f.schwa == .medial then 1 else 0


### PR DESCRIPTION
`Phonology.{Syllable,Moraic,Accent,ProsodicWord,Templates}` → `Prosody.{…}`. Per the prosodic-hierarchy literature (Strict Layer Hypothesis, Selkirk/Nespor-Vogel) the constituents are *layers of one object*, so they nest under the `Prosody` framework namespace rather than scattering bare-root. Continues dismantling the bare `Phonology` junk-drawer; the Segment/Feature-using files already carry explicit `open Phonology (...)`, so a clean un-nesting.