### PR TITLE
refactor(Phonology): rename Tier projection → TierProjection, drop dead bundle tier

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -328,7 +328,7 @@ import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 import Linglib.Core.Computability.Subregular.Function.LetterSubsequential
 import Linglib.Core.Computability.Subregular.Function.Bimachine
 import Linglib.Core.Computability.Subregular.Function.Hierarchy
-import Linglib.Phonology.Tier
+import Linglib.Phonology.TierProjection
 import Linglib.Features.VerbCluster
 import Linglib.Features.Case.Basic
 import Linglib.Features.Case.Capabilities

--- a/Linglib/Phonology/Featural/Bundle.lean
+++ b/Linglib/Phonology/Featural/Bundle.lean
@@ -37,7 +37,7 @@ The value type `V` is parametric:
    the feature *space* is data, not built into the type.
 
 2. The autosegmental tier is just a sequence of bundles
-   (`Tier F V := List (FeatureBundle F V)`). Association to bearers and
+   (`List (FeatureBundle F V)`). Association to bearers and
    no-crossing constraints can be added on top without changing the bundle
    algebra.
 
@@ -52,11 +52,12 @@ The value type `V` is parametric:
 ## Connection to existing infrastructure
 
 - `Core/Computability/StringHom.lean` (Kleisli morphisms of `Option`) is exactly the
-  type of tier-projection homomorphisms `Tier F V → Tier F' V'`.
+  type of tier-projection homomorphisms
+  `List (FeatureBundle F V) → List (FeatureBundle F' V')`.
 - `Core/Order/PullbackPreorder.lean` gives the satisfaction preorder on
   bundles when `V` carries an order.
-- `Phonology/Autosegmental/Tier.lean` (already present) collects
-  tier-rule infrastructure that the bundle algebra slots into.
+- `Phonology/TierProjection.lean` provides the erasing tier-projection
+  morphism (`TierProjection`) that the bundle algebra slots into.
 -/
 
 namespace Phonology.Featural
@@ -73,13 +74,6 @@ section Definitions
     (presence vs absence). -/
 abbrev FeatureBundle (F : Type u) (V : Type v) : Type (max u v) :=
   F → Option V
-
-/-- A **tier** is a sequence of bundles over the same feature space. The
-    sequence captures *paradigmatic* feature content; *syntagmatic*
-    relations (adjacency, no-crossing, association to a TBU tier) are
-    layered on top. -/
-abbrev Tier (F : Type u) (V : Type v) : Type (max u v) :=
-  List (FeatureBundle F V)
 
 end Definitions
 
@@ -158,20 +152,5 @@ def set [DecidableEq F]
 end AlgebraicOps
 
 end FeatureBundle
-
-namespace Tier
-
-variable {F : Type u} {V : Type v}
-
-/-- **Local assimilation along a tier** at feature `f`: each bundle takes
-    its value at `f` from its left neighbour (when the left neighbour
-    specifies `f`). Models leftward-trigger spreading. -/
-def assimilateLeftward [DecidableEq F] (f : F) : Tier F V → Tier F V
-  | []               => []
-  | [b]              => [b]
-  | b₁ :: b₂ :: rest =>
-      b₁ :: assimilateLeftward f (FeatureBundle.assimilate f b₁ b₂ :: rest)
-
-end Tier
 
 end Phonology.Featural

--- a/Linglib/Phonology/Featural/ElementTheory.lean
+++ b/Linglib/Phonology/Featural/ElementTheory.lean
@@ -181,7 +181,7 @@ end ETBundle
     headedness); the I/U-tier registers |I|/|U| presence.
 
     This is exactly the parametric tier-projection idea of
-    `Rolle2018.tonalTier` (the tonal tier, via `Tier.total`)
+    `Rolle2018.tonalTier` (the tonal tier, via `TierProjection.total`)
     for tones, instantiated for ET. -/
 def aTier (b : ETBundle) : Option Headedness := b .A
 

--- a/Linglib/Phonology/OptimalityTheory/Constraints.lean
+++ b/Linglib/Phonology/OptimalityTheory/Constraints.lean
@@ -1,7 +1,7 @@
 import Linglib.Phonology.Constraint.Defs
 import Linglib.Phonology.OptimalityTheory.Optimality
 import Linglib.Phonology.Constraint.Weighted
-import Linglib.Phonology.Tier
+import Linglib.Phonology.TierProjection
 import Linglib.Core.Computability.Subregular.Language.ForbiddenPairs
 
 /-!
@@ -170,9 +170,9 @@ export Subregular (countAdjacent)
     zero-violation candidates as members of the corresponding tier-based
     strictly 2-local language for any choice of `R`. -/
 def mkForbidPairsOnTier {C α β : Type} (name : String) (R : β → β → Prop)
-    [DecidableRel R] (T : Tier α β) (extract : C → List α) :
+    [DecidableRel R] (T : TierProjection α β) (extract : C → List α) :
     NamedConstraint C :=
-  mkMarkGrad name (fun c => countAdjacent R (Tier.apply T (extract c)))
+  mkMarkGrad name (fun c => countAdjacent R (TierProjection.apply T (extract c)))
 
 -- ---- SL_1 helper for forbidden singletons ---------------------------------
 
@@ -185,10 +185,10 @@ def mkForbidPairsOnTier {C α β : Type} (name : String) (R : β → β → Prop
     not yet wired; the constructor exists to keep SL_1 phenomena from
     silently masquerading as TSL_2. -/
 def mkForbidSingletonOnTier {C α β : Type} (name : String) (P : β → Prop)
-    [DecidablePred P] (T : Tier α β) (extract : C → List α) :
+    [DecidablePred P] (T : TierProjection α β) (extract : C → List α) :
     NamedConstraint C :=
   mkMarkGrad name
-    (fun c => (Tier.apply T (extract c)).countP (fun x => decide (P x)))
+    (fun c => (TierProjection.apply T (extract c)).countP (fun x => decide (P x)))
 
 -- ---- OCP as the identity-relation instance --------------------------------
 
@@ -210,12 +210,12 @@ def mkOCP {C α : Type} [DecidableEq α] (name : String) (project : C → List �
     NamedConstraint C :=
   mkMarkGrad name (λ c => adjacentIdentical (project c))
 
-/-- Build an OCP constraint from a `Tier` projection. The candidate's
+/-- Build an OCP constraint from a `TierProjection` projection. The candidate's
     raw symbol list is extracted by `extract`, and the tier `T` projects
     that string onto the relevant tier alphabet (an erasing string
     homomorphism — see `Core.StringHom`).
 
-    This is the constraint-algebra adapter for the unified `Tier` interface:
+    This is the constraint-algebra adapter for the unified `TierProjection` interface:
     autosegmental tonal-tier OCP, sibilant-harmony OCP, and learned-tier
     OCP (à la [belth-2026]) all factor through this constructor.
 
@@ -225,13 +225,13 @@ def mkOCP {C α : Type} [DecidableEq α] (name : String) (project : C → List �
 
     [goldsmith-1976] [berent-2026] -/
 def mkOCPOnTier {C α β : Type} [DecidableEq β]
-    (name : String) (T : Tier α β) (extract : C → List α) :
+    (name : String) (T : TierProjection α β) (extract : C → List α) :
     NamedConstraint C :=
   mkForbidPairsOnTier name (· = ·) T extract
 
 -- ---- AGREE as the inequality-relation instance ----------------------------
 
-/-- Build an AGREE constraint from a `Tier` projection: penalizes
+/-- Build an AGREE constraint from a `TierProjection` projection: penalizes
     each tier-adjacent pair `(a, b)` with `a ≠ b`. The non-identity dual of
     `mkOCPOnTier`. AGREE-style markedness in OT phonology is the symmetric
     specialization of `mkForbidPairsOnTier` with `R := (· ≠ ·)`, just as the
@@ -240,7 +240,7 @@ def mkOCPOnTier {C α β : Type} [DecidableEq β]
     harmony, dissimilation, anti-OCP) use the same machinery up to the
     choice of `R`. -/
 def mkAgreeOnTier {C α β : Type} [DecidableEq β]
-    (name : String) (T : Tier α β) (extract : C → List α) :
+    (name : String) (T : TierProjection α β) (extract : C → List α) :
     NamedConstraint C :=
   mkForbidPairsOnTier name (· ≠ ·) T extract
 
@@ -298,18 +298,18 @@ theorem mkMaxCtx_is_faithfulness {C : Type} (name : String)
 
 /-- Forbidden-pair constraints are markedness constraints. -/
 theorem mkForbidPairsOnTier_is_markedness {C α β : Type} (name : String)
-    (R : β → β → Prop) [DecidableRel R] (T : Tier α β)
+    (R : β → β → Prop) [DecidableRel R] (T : TierProjection α β)
     (extract : C → List α) :
     (mkForbidPairsOnTier name R T extract).family = .markedness := rfl
 
 /-- AGREE constraints are markedness constraints. -/
 theorem mkAgreeOnTier_is_markedness {C α β : Type} [DecidableEq β]
-    (name : String) (T : Tier α β) (extract : C → List α) :
+    (name : String) (T : TierProjection α β) (extract : C → List α) :
     (mkAgreeOnTier name T extract).family = .markedness := rfl
 
 /-- Forbidden-singleton constraints are markedness constraints. -/
 theorem mkForbidSingletonOnTier_is_markedness {C α β : Type} (name : String)
-    (P : β → Prop) [DecidablePred P] (T : Tier α β)
+    (P : β → Prop) [DecidablePred P] (T : TierProjection α β)
     (extract : C → List α) :
     (mkForbidSingletonOnTier name P T extract).family = .markedness := rfl
 
@@ -318,9 +318,9 @@ theorem mkOCP_is_markedness {C α : Type} [DecidableEq α] (name : String)
     (project : C → List α) :
     (mkOCP name project).family = .markedness := rfl
 
-/-- Tier-driven OCP constraints are markedness constraints. -/
+/-- TierProjection-driven OCP constraints are markedness constraints. -/
 theorem mkOCPOnTier_is_markedness {C α β : Type} [DecidableEq β] (name : String)
-    (T : Tier α β) (extract : C → List α) :
+    (T : TierProjection α β) (extract : C → List α) :
     (mkOCPOnTier name T extract).family = .markedness := rfl
 
 /-- ALIGN constraints are markedness constraints

--- a/Linglib/Phonology/Subregular/Agree.lean
+++ b/Linglib/Phonology/Subregular/Agree.lean
@@ -77,13 +77,13 @@ lemma AgreeCleanPair.isBoundaryVacuous [DecidableEq α] :
   CleanPair.isBoundaryVacuous
 
 /-- **Bridge** (relational form): a candidate's AGREE score is zero iff its
-raw string projects (under `Tier.byClass p`) to a list with no two
+raw string projects (under `TierProjection.byClass p`) to a list with no two
 adjacent distinct elements — i.e. all on-tier elements are equal.
 Inequality-relation specialization of `mkForbidPairsOnTier_zero_iff_isChain`. -/
 theorem mkAgreeOnTier_zero_iff_isChain [DecidableEq α] {C : Type}
     (name : String) (p : α → Prop) [DecidablePred p]
     (extract : C → List α) (c : C) :
-    (mkAgreeOnTier name (Tier.byClass p) extract).eval c = 0 ↔
+    (mkAgreeOnTier name (TierProjection.byClass p) extract).eval c = 0 ↔
       ((extract c).filter (fun x => decide (p x))).IsChain (fun a b => ¬ a ≠ b) :=
   mkForbidPairsOnTier_zero_iff_isChain name (· ≠ ·) p extract c
 
@@ -95,7 +95,7 @@ Inequality-relation specialization of `mkForbidPairsOnTier_zero_iff_in_lang`. -/
 theorem mkAgreeOnTier_zero_iff_in_agree_lang [DecidableEq α] {C : Type}
     (name : String) (p : α → Prop) [DecidablePred p]
     (extract : C → List α) (c : C) :
-    (mkAgreeOnTier name (Tier.byClass p) extract).eval c = 0 ↔
+    (mkAgreeOnTier name (TierProjection.byClass p) extract).eval c = 0 ↔
       extract c ∈ (TSLGrammar.agree p).lang :=
   mkForbidPairsOnTier_zero_iff_in_lang name (· ≠ ·) p extract c
 
@@ -107,7 +107,7 @@ corresponding AGREE-TSL_2 language. Sibling of
 `mkOCPOnTier_zeroSet_eq` in OCP.lean. -/
 theorem mkAgreeOnTier_zeroSet_eq [DecidableEq α]
     (name : String) (p : α → Prop) [DecidablePred p] :
-    (mkAgreeOnTier name (Tier.byClass p) (id : List α → List α)).zeroSet =
+    (mkAgreeOnTier name (TierProjection.byClass p) (id : List α → List α)).zeroSet =
       (TSLGrammar.agree p).lang := by
   ext w
   exact mkAgreeOnTier_zero_iff_in_agree_lang name p id w

--- a/Linglib/Phonology/Subregular/ForbidPairs.lean
+++ b/Linglib/Phonology/Subregular/ForbidPairs.lean
@@ -34,16 +34,16 @@ variable {α : Type}
 -- itself) since it is alphabet-generic.
 
 /-- **Bridge** (relational form): a candidate's forbidden-pair score is zero
-iff its raw string projects (under `Tier.byClass p`) to a list with no
+iff its raw string projects (under `TierProjection.byClass p`) to a list with no
 two adjacent elements related by `R`. The chain-side payoff of the
 generic forbidden-pair design. -/
 theorem mkForbidPairsOnTier_zero_iff_isChain {C : Type} (name : String)
     (R : α → α → Prop) [DecidableRel R] (p : α → Prop) [DecidablePred p]
     (extract : C → List α) (c : C) :
-    (mkForbidPairsOnTier name R (Tier.byClass p) extract).eval c = 0 ↔
+    (mkForbidPairsOnTier name R (TierProjection.byClass p) extract).eval c = 0 ↔
       ((extract c).filter (fun x => decide (p x))).IsChain (fun a b => ¬ R a b) := by
-  show countAdjacent R (Tier.apply (Tier.byClass p) (extract c)) = 0 ↔ _
-  rw [Tier.apply_byClass]
+  show countAdjacent R (TierProjection.apply (TierProjection.byClass p) (extract c)) = 0 ↔ _
+  rw [TierProjection.apply_byClass]
   exact countAdjacent_eq_zero_iff_isChain _ _
 
 /-- **Bridge** (TSL_2 language form): a candidate's forbidden-pair score is
@@ -55,7 +55,7 @@ language characterization `mem_ofForbiddenPairs_lang_iff_filter_isChain`. -/
 theorem mkForbidPairsOnTier_zero_iff_in_lang {C : Type} (name : String)
     (R : α → α → Prop) [DecidableRel R] (p : α → Prop) [DecidablePred p]
     (extract : C → List α) (c : C) :
-    (mkForbidPairsOnTier name R (Tier.byClass p) extract).eval c = 0 ↔
+    (mkForbidPairsOnTier name R (TierProjection.byClass p) extract).eval c = 0 ↔
       extract c ∈ (TSLGrammar.ofForbiddenPairs R p).lang := by
   rw [mkForbidPairsOnTier_zero_iff_isChain,
       mem_ofForbiddenPairs_lang_iff_filter_isChain]

--- a/Linglib/Phonology/Subregular/Harmony.lean
+++ b/Linglib/Phonology/Subregular/Harmony.lean
@@ -121,7 +121,7 @@ def System.mk' (feature : Feature)
     (direction : HarmonyDir := .rightward)
     (isBlocker : Segment → Bool := fun _ => false) : System where
   toTierRule :=
-    { tier := Tier.byClass (fun s => !isTransparent s = true)
+    { tier := TierProjection.byClass (fun s => !isTransparent s = true)
       side := direction.toSide
       targetIsContext := fun s => isTrigger s = true
       relation := .agree

--- a/Linglib/Phonology/Subregular/OCP.lean
+++ b/Linglib/Phonology/Subregular/OCP.lean
@@ -83,13 +83,13 @@ lemma OCPCleanPair.isBoundaryVacuous [DecidableEq α] :
   CleanPair.isBoundaryVacuous
 
 /-- **Bridge** (relational form): a candidate's OCP score is zero iff its
-raw string projects (under `Tier.byClass p`) to a list with no two
+raw string projects (under `TierProjection.byClass p`) to a list with no two
 adjacent identical elements. Identity-relation specialization of
 `mkForbidPairsOnTier_zero_iff_isChain`. -/
 theorem mkOCPOnTier_zero_iff_isChain [DecidableEq α] {C : Type}
     (name : String) (p : α → Prop) [DecidablePred p]
     (extract : C → List α) (c : C) :
-    (mkOCPOnTier name (Tier.byClass p) extract).eval c = 0 ↔
+    (mkOCPOnTier name (TierProjection.byClass p) extract).eval c = 0 ↔
       ((extract c).filter (fun x => decide (p x))).IsChain (· ≠ ·) :=
   mkForbidPairsOnTier_zero_iff_isChain name (· = ·) p extract c
 
@@ -101,7 +101,7 @@ one principle rather than parallel formalisations — both characterise
 theorem mkOCPOnTier_zero_iff_isClean [DecidableEq α] {C : Type}
     (name : String) (p : α → Prop) [DecidablePred p]
     (extract : C → List α) (c : C) :
-    (mkOCPOnTier name (Tier.byClass p) extract).eval c = 0 ↔
+    (mkOCPOnTier name (TierProjection.byClass p) extract).eval c = 0 ↔
       OCP.IsClean ((extract c).filter (fun x => decide (p x))) :=
   mkOCPOnTier_zero_iff_isChain name p extract c
 
@@ -125,7 +125,7 @@ specialization of `mkForbidPairsOnTier_zero_iff_in_lang`. -/
 theorem mkOCPOnTier_zero_iff_in_ocp_lang [DecidableEq α] {C : Type}
     (name : String) (p : α → Prop) [DecidablePred p]
     (extract : C → List α) (c : C) :
-    (mkOCPOnTier name (Tier.byClass p) extract).eval c = 0 ↔
+    (mkOCPOnTier name (TierProjection.byClass p) extract).eval c = 0 ↔
       extract c ∈ (TSLGrammar.ocp p).lang :=
   mkForbidPairsOnTier_zero_iff_in_lang name (· = ·) p extract c
 
@@ -135,7 +135,7 @@ markedness constraint's zero-set *is* the corresponding OCP-TSL_2
 language. Sibling of `mkForbidPairsOnTier_zeroSet_eq` in OTBound.lean. -/
 theorem mkOCPOnTier_zeroSet_eq [DecidableEq α]
     (name : String) (p : α → Prop) [DecidablePred p] :
-    (mkOCPOnTier name (Tier.byClass p) (id : List α → List α)).zeroSet =
+    (mkOCPOnTier name (TierProjection.byClass p) (id : List α → List α)).zeroSet =
       (TSLGrammar.ocp p).lang := by
   ext w
   exact mkOCPOnTier_zero_iff_in_ocp_lang name p id w

--- a/Linglib/Phonology/Subregular/OTBound.lean
+++ b/Linglib/Phonology/Subregular/OTBound.lean
@@ -72,7 +72,7 @@ zero-set side directly. -/
 theorem mkForbidPairsOnTier_zeroSet_eq
     (name : String) (R : α → α → Prop) [DecidableRel R]
     (p : α → Prop) [DecidablePred p] :
-    (mkForbidPairsOnTier name R (Tier.byClass p) (id : List α → List α)).zeroSet =
+    (mkForbidPairsOnTier name R (TierProjection.byClass p) (id : List α → List α)).zeroSet =
       (TSLGrammar.ofForbiddenPairs R p).lang := by
   ext w
   exact mkForbidPairsOnTier_zero_iff_in_lang name R p id w

--- a/Linglib/Phonology/Subregular/TierProjection.lean
+++ b/Linglib/Phonology/Subregular/TierProjection.lean
@@ -3,14 +3,14 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Phonology.Tier
+import Linglib.Phonology.TierProjection
 import Linglib.Core.Computability.Subregular.Language.TierStrictlyLocal
 
 /-!
-# Bridge: Autosegmental Tier ↔ TSL Tier Projection
+# Bridge: Autosegmental TierProjection ↔ TSL TierProjection Projection
 
-The autosegmental tier formalism (`Tier`, the Kleisli morphism
-`α → Option β` lifted via `List.filterMap`, now in `Phonology/Tier.lean`) and
+The autosegmental tier formalism (`TierProjection`, the Kleisli morphism
+`α → Option β` lifted via `List.filterMap`, now in `Phonology/TierProjection.lean`) and
 the subregular TSL formalism (`Subregular.tierProject`,
 `List.filter`) compute the same projection. Since the two now live in different
 layers (Phonology vs Core) they no longer coincide *by definition*, so this file
@@ -23,7 +23,7 @@ tier) plugs into TSL machinery without restating projection or filtering.
 
 Phonological constraints already in the codebase (`mkOCPOnTier` in
 `Phonology/OptimalityTheory/Constraints.lean`, the tonal tier `tonalTier`
-in `Studies/Rolle2018.lean`) reuse the same `Tier.apply` machinery as TSL
+in `Studies/Rolle2018.lean`) reuse the same `TierProjection.apply` machinery as TSL
 grammars — the bridge `apply_byClass_eq_tierProject` reconnects the two
 projections in one line.
 -/
@@ -32,19 +32,19 @@ namespace Subregular
 
 variable {α : Type*}
 
-/-- **Bridge identity**: the autosegmental projection `Tier.apply (Tier.byClass T)`
+/-- **Bridge identity**: the autosegmental projection `TierProjection.apply (TierProjection.byClass T)`
 and the subregular `tierProject T` are the same map — both reduce to `List.filter`.
-Now that the `Tier` projection morphism lives in `Phonology/` and `tierProject` is
+Now that the `TierProjection` projection morphism lives in `Phonology/` and `tierProject` is
 de-coupled to `List.filter` directly, this is an explicit lemma (via
-`Tier.apply_byClass` and `tierProject_eq_filter`) rather than `rfl`. -/
+`TierProjection.apply_byClass` and `tierProject_eq_filter`) rather than `rfl`. -/
 theorem apply_byClass_eq_tierProject (T : α → Prop) [DecidablePred T]
     (xs : List α) :
-    Tier.apply (Tier.byClass T) xs = tierProject T xs :=
-  (Tier.apply_byClass T xs).trans (tierProject_eq_filter T xs).symm
+    TierProjection.apply (TierProjection.byClass T) xs = tierProject T xs :=
+  (TierProjection.apply_byClass T xs).trans (tierProject_eq_filter T xs).symm
 
 /-- **Adapter**: build a TSL_k grammar from a class-membership autosegmental
 tier given as a `Bool` predicate. The TSL tier predicate is `(p · = true)`,
-giving the TSL projection that matches `Tier.apply (Tier.byClass p)` on
+giving the TSL projection that matches `TierProjection.apply (TierProjection.byClass p)` on
 every input. Provided as a convenience for callers whose class predicates
 arise from `FeatureSpec`-style Bool lookups; native `Prop`-valued
 predicates can construct `TSLGrammar` records directly. -/
@@ -55,7 +55,7 @@ def TSLGrammar.ofByClass (k : ℕ) (p : α → Bool)
   permitted := permitted
 
 /-- The TSL grammar built from `byClass` projects via the same filter as
-`Tier.apply (Tier.byClass p)`. -/
+`TierProjection.apply (TierProjection.byClass p)`. -/
 @[simp] theorem tierProject_ofByClass (k : ℕ) (p : α → Bool) (xs : List α) :
     tierProject (TSLGrammar.ofByClass (α := α) k p ∅).tier xs =
       xs.filter p := by

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -1,10 +1,10 @@
 import Mathlib.Data.Fintype.Option
-import Linglib.Phonology.Tier
+import Linglib.Phonology.TierProjection
 import Linglib.Core.Computability.Subregular.Function.Subsequential
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 
 /-!
-# Tier-based rules (`TierRule`)
+# TierProjection-based rules (`TierRule`)
 [belth-2026] [goldsmith-1976]
 
 The canonical operational schema for SPE-style phonological alternations
@@ -15,7 +15,7 @@ that factor through a tier projection. A rule has the shape
 
 where:
 
-- `T ⊆ α` is a tier (an erasing string-homomorphism — see `Tier`);
+- `T ⊆ α` is a tier (an erasing string-homomorphism — see `TierProjection`);
 - `C ⊆ T` is the natural class of the *triggering* tier-adjacent segment;
 - `A ⊆ α` is the natural class of *targets* (here: a single underspecified
   position identified by index, à la [belth-2026]);
@@ -106,7 +106,7 @@ abbrev Side := Subregular.Direction
       fallback). `none` means *no* default — when no context is found,
       `applyAt` returns `none`. `some v` is the concrete fallback. -/
 structure TierRule (α : Type) where
-  tier : Tier α α
+  tier : TierProjection α α
   side : Side := .left
   targetIsContext : α → Prop
   [decTarget : DecidablePred targetIsContext]
@@ -129,8 +129,8 @@ attribute [instance] TierRule.decTarget
 def apply (r : TierRule α) (pre post : List α) : Option Bool :=
   let ctx? :=
     match r.side with
-    | .left  => Tier.lastWith  r.tier r.targetIsContext pre
-    | .right => Tier.firstWith r.tier r.targetIsContext post
+    | .left  => TierProjection.lastWith  r.tier r.targetIsContext pre
+    | .right => TierProjection.firstWith r.tier r.targetIsContext post
   match ctx? with
   | none     => r.default
   | some ctx =>
@@ -165,7 +165,7 @@ def flipRelation (r : TierRule α) : TierRule α :=
     `Agree([?voice], {voice}) / [*] __` over the trivial projection —
     [belth-2026]). -/
 theorem id_tier_left_is_strict_local (r : TierRule α)
-    (h_id : r.tier = Tier.id) (h_side : r.side = .left) (pre : List α) :
+    (h_id : r.tier = TierProjection.id) (h_side : r.side = .left) (pre : List α) :
     apply r pre [] =
       (match (pre.filter (fun x => decide (r.targetIsContext x))).getLast? with
         | none => r.default
@@ -173,9 +173,9 @@ theorem id_tier_left_is_strict_local (r : TierRule α)
                       | none => r.default
                       | some v => some (match r.relation with
                                         | .agree => v | .disagree => !v)) := by
-  unfold apply Tier.lastWith
+  unfold apply TierProjection.lastWith
   rw [h_side, h_id]
-  simp [Tier.apply_id]
+  simp [TierProjection.apply_id]
 
 /-- Reify a `TierRule` as a string-to-string function: at each input
 position, predict the feature value for the implicit "hole" using the
@@ -209,7 +209,7 @@ per [aksenova-rawski-graf-heinz-2020]:
 * Identity-tier `TierRule`s → **Left-Subsequential** (the trivial-tier
   case lemma `id_tier_left_is_strict_local` above shows the structural
   equivalence to scanning the raw input for the context class).
-* Non-trivial-tier `TierRule`s → **Tier-Subsequential** (a strictly
+* Non-trivial-tier `TierRule`s → **TierProjection-Subsequential** (a strictly
   larger class than Left-Subsequential, captured by the standard
   Heinz-Rawski-Tanner 2011 tier-strictly-local family applied to
   function classes).
@@ -275,7 +275,7 @@ lemma lastContextOf_append_singleton (r : TierRule α) (past : List α) (x : α)
 `predictFromCtx ∘ lastContextOf` — the structural rephrasing of
 `id_tier_left_is_strict_local`. -/
 lemma applyAt_eq_predictFromCtx (r : TierRule α)
-    (h_id : r.tier = Tier.id) (h_side : r.side = .left) (past : List α) :
+    (h_id : r.tier = TierProjection.id) (h_side : r.side = .left) (past : List α) :
     r.applyAt past = predictFromCtx r (r.lastContextOf past) := by
   unfold applyAt predictFromCtx lastContextOf
   exact id_tier_left_is_strict_local r h_id h_side past
@@ -284,7 +284,7 @@ lemma applyAt_eq_predictFromCtx (r : TierRule α)
 starting state (which represents the lastContextOf of some virtual
 past) and the corresponding past. -/
 lemma toIdTierSFST_runFrom_eq_applyToStringAux (r : TierRule α)
-    (h_id : r.tier = Tier.id) (h_side : r.side = .left)
+    (h_id : r.tier = TierProjection.id) (h_side : r.side = .left)
     (past : List α) (input : List α) :
     r.toIdTierSFST.runFrom (r.lastContextOf past) input
       = applyToString.applyToStringAux r input past := by
@@ -307,7 +307,7 @@ functions.** Closes audit D6 with a real witness construction (not a
 sorry): the SFST has state `Option α` (last-context-matching segment
 seen) and emits the rule's prediction at each step. -/
 theorem applyToString_isLeftSubsequential_of_id_tier [Fintype α]
-    (r : TierRule α) (h_id : r.tier = Tier.id) (h_side : r.side = .left) :
+    (r : TierRule α) (h_id : r.tier = TierProjection.id) (h_side : r.side = .left) :
     IsLeftSubsequential r.applyToString := by
   have h_run : r.toIdTierSFST.run = r.applyToString := by
     funext input

--- a/Linglib/Phonology/TierProjection.lean
+++ b/Linglib/Phonology/TierProjection.lean
@@ -17,17 +17,17 @@ under string homomorphism lives in
 
 This module provides:
 
-- `Tier α β := α → Option β` — the erasing case.
-- `Tier.apply` — lift to `List α → List β` (the projection itself).
-- `Tier.id`, `Tier.empty`, `Tier.byClass`, `Tier.total` — constructors.
+- `TierProjection α β := α → Option β` — the erasing case.
+- `TierProjection.apply` — lift to `List α → List β` (the projection itself).
+- `TierProjection.id`, `TierProjection.empty`, `TierProjection.byClass`, `TierProjection.total` — constructors.
 
-The monoid-homomorphism law (`Tier.apply_append`) holds **definitionally**
+The monoid-homomorphism law (`TierProjection.apply_append`) holds **definitionally**
 via `List.filterMap_append`; this is what licenses tier projections in OT
 and HG constraint evaluation (`mkOCP` in `Phonology/Constraints.lean`
-already takes a generic `project : C → List α`, so `Tier.apply T` plugs in
+already takes a generic `project : C → List α`, so `TierProjection.apply T` plugs in
 directly).
 
-Home: `Phonology/` (not `Core/`) because the `Tier` abstraction — the
+Home: `Phonology/` (not `Core/`) because the `TierProjection` abstraction — the
 autosegmental Kleisli morphism with `byClass`/`lastWith`/`firstWith` — is a
 linguistics concept, not upstreamable to `mathlib/Computability`. The
 formal-language tier (a subalphabet, projection = `List.filter`) lives
@@ -45,55 +45,55 @@ universe u v
     This is the morphism `α → β` in the Kleisli category of `Option`, and
     equivalently a letterwise erasing string homomorphism. The lift to
     `List α → List β` is `List.filterMap`. -/
-abbrev Tier (α : Type u) (β : Type v) : Type _ := α → Option β
+abbrev TierProjection (α : Type u) (β : Type v) : Type _ := α → Option β
 
-namespace Tier
+namespace TierProjection
 
 variable {α : Type u} {β : Type v}
 
 /-- The identity tier: every symbol projects to itself. -/
-protected def id : Tier α α := some
+protected def id : TierProjection α α := some
 
 /-- The empty tier: no symbol projects. -/
-def empty : Tier α β := fun _ => none
+def empty : TierProjection α β := fun _ => none
 
-/-- Tier defined by a class predicate: keep symbols satisfying `p`, erase
+/-- A tier projection defined by a class predicate: keep symbols satisfying `p`, erase
     the rest. The standard form for autosegmental tonal/featural tiers.
 
     Following mathlib's `Finset.filter` / `Multiset.filter` convention,
     `p` is `Prop`-valued with `[DecidablePred]`, so call sites can pass
     structural predicates (`fun x => x = .l`, `fun x => IsCons x`)
     without inserting `decide` wrappers. -/
-def byClass (p : α → Prop) [DecidablePred p] : Tier α α :=
+def byClass (p : α → Prop) [DecidablePred p] : TierProjection α α :=
   fun x => if p x then some x else none
 
-/-- Tier defined by a total function: every symbol projects to its image. -/
-def total (f : α → β) : Tier α β := some ∘ f
+/-- A tier projection defined by a total function: every symbol projects to its image. -/
+def total (f : α → β) : TierProjection α β := some ∘ f
 
 /-- Lift a tier to `List α → List β`. This is the canonical projection. -/
-def apply (T : Tier α β) : List α → List β := List.filterMap T
+def apply (T : TierProjection α β) : List α → List β := List.filterMap T
 
 -- ---- Monoid-homomorphism laws ----------------------------------------------
 
 /-- Tier projection distributes over concatenation. This is the
     monoid-homomorphism property — load-bearing for compositional
     tier-based constraint evaluation. -/
-@[simp] theorem apply_append (T : Tier α β) (xs ys : List α) :
+@[simp] theorem apply_append (T : TierProjection α β) (xs ys : List α) :
     apply T (xs ++ ys) = apply T xs ++ apply T ys :=
   List.filterMap_append
 
 /-- Tier projection sends the empty word to the empty word. -/
-@[simp] theorem apply_nil (T : Tier α β) : apply T [] = [] := rfl
+@[simp] theorem apply_nil (T : TierProjection α β) : apply T [] = [] := rfl
 
 -- ---- Constructor lemmas ----------------------------------------------------
 
 /-- The identity tier is the identity on lists. -/
-@[simp] theorem apply_id (xs : List α) : apply (Tier.id : Tier α α) xs = xs :=
+@[simp] theorem apply_id (xs : List α) : apply (TierProjection.id : TierProjection α α) xs = xs :=
   List.filterMap_some
 
 /-- The empty tier projects every list to the empty list. -/
 @[simp] theorem apply_empty (xs : List α) :
-    apply (Tier.empty : Tier α β) xs = [] := by
+    apply (TierProjection.empty : TierProjection α β) xs = [] := by
   induction xs with
   | nil => rfl
   | cons _ _ ih =>
@@ -104,26 +104,26 @@ def apply (T : Tier α β) : List α → List β := List.filterMap T
     inserts `decide` because `List.filter` is `Bool`-valued; consumers
     that already work in `Bool` should use this lemma directly. -/
 theorem apply_byClass (p : α → Prop) [DecidablePred p] (xs : List α) :
-    apply (Tier.byClass p) xs = xs.filter (fun x => decide (p x)) := by
-  show List.filterMap (Tier.byClass p) xs = _
+    apply (TierProjection.byClass p) xs = xs.filter (fun x => decide (p x)) := by
+  show List.filterMap (TierProjection.byClass p) xs = _
   induction xs with
   | nil => rfl
   | cons x rest ih =>
     rw [List.filterMap_cons, List.filter_cons]
     by_cases hpx : p x
-    · have hbc : Tier.byClass p x = some x := by simp [Tier.byClass, hpx]
+    · have hbc : TierProjection.byClass p x = some x := by simp [TierProjection.byClass, hpx]
       rw [hbc, ih, decide_eq_true hpx]; rfl
-    · have hbc : Tier.byClass p x = none := by simp [Tier.byClass, hpx]
+    · have hbc : TierProjection.byClass p x = none := by simp [TierProjection.byClass, hpx]
       rw [hbc, ih, decide_eq_false hpx]; rfl
 
 /-- A total-function tier acts as `List.map`. -/
 @[simp] theorem apply_total (f : α → β) (xs : List α) :
-    apply (Tier.total f) xs = xs.map f :=
+    apply (TierProjection.total f) xs = xs.map f :=
   congrFun List.filterMap_eq_map xs
 
 /-- `total` is length-preserving — all symbols survive. -/
 @[simp] theorem length_apply_total (f : α → β) (xs : List α) :
-    (apply (Tier.total f) xs).length = xs.length := by
+    (apply (TierProjection.total f) xs).length = xs.length := by
   simp
 
 -- ---- Derived scans (used by tier-based alternation rules) -----------------
@@ -131,14 +131,14 @@ theorem apply_byClass (p : α → Prop) [DecidablePred p] (xs : List α) :
 /-- The last (rightmost) projected symbol of `xs` satisfying `q`. The
     standard "preceding tier-adjacent context" lookup for rules like
     [belth-2026]'s `Disagree(A, F) / C __ ∘ proj(·, T)`. -/
-def lastWith (T : Tier α β) (q : β → Prop) [DecidablePred q]
+def lastWith (T : TierProjection α β) (q : β → Prop) [DecidablePred q]
     (xs : List α) : Option β :=
   ((apply T xs).filter (fun y => decide (q y))).getLast?
 
 /-- The first (leftmost) projected symbol of `xs` satisfying `q`. The
     symmetric right-context lookup for `C / __ C ∘ proj(·, T)` rules. -/
-def firstWith (T : Tier α β) (q : β → Prop) [DecidablePred q]
+def firstWith (T : TierProjection α β) (q : β → Prop) [DecidablePred q]
     (xs : List α) : Option β :=
   ((apply T xs).filter (fun y => decide (q y))).head?
 
-end Tier
+end TierProjection

--- a/Linglib/Studies/Belth2026.lean
+++ b/Linglib/Studies/Belth2026.lean
@@ -124,7 +124,7 @@ def isLat : LatSeg → Option Bool
 
 /-- The consonantal tier (Belth's learned tier for Latin, rule 54).
     Every `[+cons]` segment projects. -/
-def consTier : Tier LatSeg LatSeg := Tier.byClass IsCons
+def consTier : TierProjection LatSeg LatSeg := TierProjection.byClass IsCons
 
 end LatSeg
 
@@ -305,8 +305,8 @@ theorem latinDissimRule_tolerated_on_examples :
 theorem consTier_apply_eq_tierProject (xs : List LatSeg) :
     LatSeg.consTier.apply xs =
       Subregular.tierProject LatSeg.IsCons xs := by
-  show Tier.apply (Tier.byClass LatSeg.IsCons) xs = _
-  rw [Tier.apply_byClass, Subregular.tierProject_eq_filter]
+  show TierProjection.apply (TierProjection.byClass LatSeg.IsCons) xs = _
+  rw [TierProjection.apply_byClass, Subregular.tierProject_eq_filter]
 
 /-- The TSL_2 grammar witnessing the Latin allomorphy pattern as a
     tier-based subregular language: project to the `[+cons]` tier, then

--- a/Linglib/Studies/Hansson2010.lean
+++ b/Linglib/Studies/Hansson2010.lean
@@ -255,7 +255,7 @@ a `NamedConstraint` via the `mkAgreeOnTier` specialization. The TSL
 grammar characterizes the *language*; this constraint *evaluates* it. -/
 def navajoAgree : Constraint.NamedConstraint (List NSeg) :=
   OptimalityTheory.mkAgreeOnTier
-    "AGREE-[ant]/CC" (Tier.byClass NSeg.onTier) id
+    "AGREE-[ant]/CC" (TierProjection.byClass NSeg.onTier) id
 
 /-- `navajoAgree` is a markedness constraint by construction. -/
 theorem navajoAgree_is_markedness :

--- a/Linglib/Studies/Rolle2018.lean
+++ b/Linglib/Studies/Rolle2018.lean
@@ -288,17 +288,17 @@ def basemapOutput {S : Type} [DecidableEq S] [BEq S] [Repr S]
 /-- Extract the tonal tier from a list of TBUs.
 
     Grounded in the `Tier` abstraction
-    (`Tier.apply (Tier.total TBU.tone)`): an erasing string
+    (`TierProjection.apply (TierProjection.total TBU.tone)`): an erasing string
     homomorphism `(TBU S)* → TRN*` in the Kleisli category of `Option`.
     The tonal tier is the `total` (no-erasure) case [goldsmith-1976]. -/
 def tonalTier {S : Type} (tbus : List (TBU S)) : List TRN :=
-  Tier.apply (Tier.total TBU.tone) tbus
+  TierProjection.apply (TierProjection.total TBU.tone) tbus
 
 /-- The tonal tier reduces to `List.map TBU.tone` (the historical
-    formulation), via `Tier.total`'s length-preservation property. -/
+    formulation), via `TierProjection.total`'s length-preservation property. -/
 @[simp] theorem tonalTier_eq_map {S : Type} (tbus : List (TBU S)) :
     tonalTier tbus = tbus.map TBU.tone :=
-  Tier.apply_total _ _
+  TierProjection.apply_total _ _
 
 /-! ### Matrix-Basemap Correspondence — derived from `Corr` -/
 

--- a/Linglib/Studies/RoseWalker2004.lean
+++ b/Linglib/Studies/RoseWalker2004.lean
@@ -212,7 +212,7 @@ specialization) because Kikongo's forbidden pair is asymmetric — see the
 "What this file formalizes" docstring above. -/
 def kikongoAgree : Constraint.NamedConstraint (List KSeg) :=
   OptimalityTheory.mkForbidPairsOnTier
-    "AGREE-[nas]/CC" KSeg.forbidNasalStop (Tier.byClass KSeg.onTier) id
+    "AGREE-[nas]/CC" KSeg.forbidNasalStop (TierProjection.byClass KSeg.onTier) id
 
 /-- `kikongoAgree` is a markedness constraint by construction. -/
 theorem kikongoAgree_is_markedness :


### PR DESCRIPTION
Resolves the overloaded `Tier` name. Two unrelated types shared it:
- `Phonology/Tier.lean`'s `Tier α β := α → Option β` is the *erasing projection map* (not a tier) → renamed **`TierProjection`**, file `Tier.lean`→`TierProjection.lean`. This makes it parallel to `Phonology/Subregular/TierProjection.lean`, which *specializes* it (the bridge `apply_byClass_eq_tierProject` connects it to Core's `tierProject`) — the standard mathlib general→specialized split.
- `Featural/Bundle.lean`'s `Tier F V := List (FeatureBundle F V)` was dead (0 uses, only `assimilateLeftward`) → deleted, with the module docstring's design note kept but de-referenced.