### PR TITLE
fix(Studies/Belth2026): drop vestigial open Phonology broken by OCP rename

### DIFF
--- a/Linglib/Studies/Belth2026.lean
+++ b/Linglib/Studies/Belth2026.lean
@@ -81,7 +81,6 @@ licenses convergence.
 namespace Belth2026
 
 open Core
-open Phonology
 open Subregular
 
 -- ============================================================================


### PR DESCRIPTION
**Fixes red main.** #671 (OCP → bare-root) removed the `Phonology.OCP` namespace, which was the last `namespace Phonology` that Belth2026's vestigial `open Phonology` (line 84) could see transitively (via `Subregular/OCP.lean` → root OCP). Belth uses `LatSeg`/`Subregular`, never bare `Segment`/`Feature`, so the `open` was dead — removed. All other bare-`open Phonology` files build (they import the Featural core or are genuine Segment/Feature users).