### PR TITLE
refactor(Phonology/Featural): collapse Featural→FeatureBundle, ElementTheory bare-root

### DIFF
--- a/Linglib/Phonology/Featural/Bundle.lean
+++ b/Linglib/Phonology/Featural/Bundle.lean
@@ -60,7 +60,7 @@ The value type `V` is parametric:
   morphism (`TierProjection`) that the bundle algebra slots into.
 -/
 
-namespace Phonology.Featural
+namespace Phonology
 
 universe u v
 
@@ -153,4 +153,4 @@ end AlgebraicOps
 
 end FeatureBundle
 
-end Phonology.Featural
+end Phonology

--- a/Linglib/Phonology/Featural/ElementTheory.lean
+++ b/Linglib/Phonology/Featural/ElementTheory.lean
@@ -74,9 +74,9 @@ abandoned charm in favour of headedness as the prominence-encoding
 device.
 -/
 
-namespace Phonology.ElementTheory
+namespace ElementTheory
 
-open Phonology.Featural
+open Phonology
 
 -- ============================================================================
 -- § 1: Elements and Headedness
@@ -219,4 +219,4 @@ theorem element_tier_collapse_clean (xs : List Headedness) :
     OCP.IsClean (OCP.collapse xs) :=
   OCP.collapse_clean xs
 
-end Phonology.ElementTheory
+end ElementTheory

--- a/Linglib/Phonology/Featural/Underspecification.lean
+++ b/Linglib/Phonology/Featural/Underspecification.lean
@@ -63,7 +63,7 @@ SPE-style structural-change rules.
 
 namespace Phonology
 
-open Phonology.Featural
+open Phonology
 
 namespace Segment
 

--- a/Linglib/Phonology/Subregular/Agree.lean
+++ b/Linglib/Phonology/Subregular/Agree.lean
@@ -38,7 +38,6 @@ downstream consumers reference.
 namespace Subregular
 
 open OptimalityTheory
-open Subregular
 
 -- `α : Type` (rather than `Type*`) is forced by `OptimalityTheory`
 -- and `Core.Optimization.eval`, which are monomorphic in universe 0. See

--- a/Linglib/Phonology/Subregular/ForbidPairs.lean
+++ b/Linglib/Phonology/Subregular/ForbidPairs.lean
@@ -25,7 +25,6 @@ corollary.
 namespace Subregular
 
 open OptimalityTheory
-open Subregular
 
 variable {α : Type}
 

--- a/Linglib/Phonology/Subregular/OCP.lean
+++ b/Linglib/Phonology/Subregular/OCP.lean
@@ -47,7 +47,6 @@ formalisations but the constraint and a retraction onto it, both characterising
 namespace Subregular
 
 open OptimalityTheory
-open Subregular
 
 -- `α : Type` (rather than `Type*`) is forced by `OptimalityTheory`
 -- and `Core.Optimization.eval`, which are monomorphic in universe 0.

--- a/Linglib/Phonology/Subregular/OTBound.lean
+++ b/Linglib/Phonology/Subregular/OTBound.lean
@@ -54,7 +54,6 @@ subregular hierarchy.
 namespace Subregular.OTBound
 
 open OptimalityTheory
-open Subregular
 open Constraint OptimalityTheory
 
 -- ============================================================================

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -55,7 +55,6 @@ land it once a Studies file needs to invoke the bridge concretely.
 
 namespace Subregular
 
-open Subregular
 
 -- ============================================================================
 -- § 1: Schema
@@ -220,7 +219,6 @@ predicate-evaluation state); the identity-tier case is discharged below.
 Land the general witness here once a Studies file consumes it. -/
 namespace Subregular.TierRule
 
-open Subregular
 
 variable {α : Type}
 

--- a/Linglib/Phonology/Tone/Basic.lean
+++ b/Linglib/Phonology/Tone/Basic.lean
@@ -71,7 +71,7 @@ be **underspecified** (`none`), with surface values filled in by default.
 
 namespace Tone
 
-open Phonology.Featural
+open Phonology
 
 /-! ### Subtonal features -/
 

--- a/Linglib/Studies/FaustLampitelli2026.lean
+++ b/Linglib/Studies/FaustLampitelli2026.lean
@@ -85,7 +85,7 @@ appropriate.
 
 namespace FaustLampitelli2026
 
-open Phonology.ElementTheory
+open ElementTheory
 
 /-! ## §0 Strict-CV Government Phonology substrate
 [kaye-lowenstamm-vergnaud-1985] [kaye-lowenstamm-vergnaud-1990]


### PR DESCRIPTION
Finishes the Featural-cluster namespace re-carve per the 3-reviewer audit:
- `Phonology.Featural` → `Phonology.FeatureBundle` — `Featural` was a directory-name namespace holding one type (the inner `namespace FeatureBundle` already does the grouping). 3 `open` sites updated; module/import paths (`Linglib.Phonology.Featural.*`, the directory) untouched.
- `Phonology.ElementTheory` → bare-root `ElementTheory` — a rival segment-representation framework (peer of `OptimalityTheory`/`HarmonicGrammar`), not an extension of `Feature`/`Segment`. One consumer updated.
- Dropped 6 redundant self-`open Subregular` (files already inside `namespace Subregular`).

`Feature`/`Segment`/`FeatureVal`/`FeatureGeometry` stay owned under `Phonology` (verified overloaded library-wide). Deferred follow-ups: `ComplexSegments`→`Segment.*`, fold `ItemSpecificity`/`ParadigmUniformity` into Constraint/OT, `Prosodic/`→`Prosody/` dir rename.