### PR TITLE
refactor(Phonology/Featural): dissolve ComplexSegments namespace into Segment.* / FeatureGeometry

### DIFF
--- a/Linglib/Phonology/Featural/ComplexSegments.lean
+++ b/Linglib/Phonology/Featural/ComplexSegments.lean
@@ -24,8 +24,6 @@ articulator; labio-velars are possible because labial and dorsal are
 independent.
 -/
 
--- Define `isArticulator` in the FeatureGeometry namespace so dot notation
--- works on GeomNode values across the codebase.
 namespace Phonology.FeatureGeometry
 
 /-- Is this a place articulator node? The three place articulators —
@@ -43,13 +41,6 @@ def GeomNode.IsArticulator : GeomNode → Prop
 instance : DecidablePred GeomNode.IsArticulator := fun n => by
   cases n <;> unfold GeomNode.IsArticulator <;> infer_instance
 
-end Phonology.FeatureGeometry
-
-namespace Phonology.ComplexSegments
-
-open Phonology (Segment Feature FeatureVal)
-open Phonology.FeatureGeometry (GeomNode)
-
 -- ============================================================================
 -- § 1: Articulator Nodes
 -- ============================================================================
@@ -61,47 +52,7 @@ def articulatorNodes : List GeomNode :=
 theorem articulatorNodes_count : articulatorNodes.length = 3 := rfl
 
 -- ============================================================================
--- § 2: Active Articulators
--- ============================================================================
-
-/-- Which articulator nodes have at least one specified feature in segment `s`? -/
-def activeArticulators (s : Segment) : List GeomNode :=
-  articulatorNodes.filter λ n =>
-    n.features.any λ f => s.spec f |>.isSome
-
-/-- Number of active articulator nodes in a segment. -/
-def articulatorCount (s : Segment) : Nat :=
-  (activeArticulators s).length
-
--- ============================================================================
--- § 3: Segment Classification
--- ============================================================================
-
-/-- A complex segment has two or more simultaneously active articulator
-    nodes — e.g., labiovelars [k͡p] (labial + dorsal). -/
-def IsComplex (s : Segment) : Prop :=
-  articulatorCount s ≥ 2
-
-instance : DecidablePred IsComplex := fun _ =>
-  inferInstanceAs (Decidable (_ ≥ _))
-
--- ============================================================================
--- § 4: Well-Formedness
--- ============================================================================
-
-/-- Complex segment well-formedness: active articulators must be distinct
-    nodes. This is trivially satisfied by `activeArticulators` (which returns
-    a duplicate-free sublist of `articulatorNodes`), but we state it
-    explicitly as the standard WFC. -/
-def ComplexWF (s : Segment) : Prop :=
-  let aa := activeArticulators s
-  aa.length = aa.eraseDups.length
-
-instance : DecidablePred ComplexWF := fun _ =>
-  inferInstanceAs (Decidable (_ = _))
-
--- ============================================================================
--- § 5: Verification
+-- § 4: Geometry of articulators (verification)
 -- ============================================================================
 
 /-- Articulators are exactly the leaf-level nodes (no children). -/
@@ -140,4 +91,46 @@ theorem place_articulators_distinct :
 theorem articulators_under_place :
     ∀ n ∈ articulatorNodes, GeomNode.Dominates .place n := by decide
 
-end Phonology.ComplexSegments
+end Phonology.FeatureGeometry
+
+namespace Phonology
+
+open Phonology.FeatureGeometry (GeomNode articulatorNodes)
+
+-- ============================================================================
+-- § 2: Active articulators of a segment
+-- ============================================================================
+
+/-- Which articulator nodes have at least one specified feature in segment `s`? -/
+def Segment.activeArticulators (s : Segment) : List GeomNode :=
+  articulatorNodes.filter λ n =>
+    n.features.any λ f => s.spec f |>.isSome
+
+/-- Number of active articulator nodes in a segment. -/
+def Segment.articulatorCount (s : Segment) : Nat :=
+  s.activeArticulators.length
+
+-- ============================================================================
+-- § 3: Segment classification + well-formedness
+-- ============================================================================
+
+/-- A complex segment has two or more simultaneously active articulator
+    nodes — e.g., labiovelars [k͡p] (labial + dorsal). -/
+def Segment.IsComplex (s : Segment) : Prop :=
+  s.articulatorCount ≥ 2
+
+instance : DecidablePred Segment.IsComplex := fun _ =>
+  inferInstanceAs (Decidable (_ ≥ _))
+
+/-- Complex segment well-formedness: active articulators must be distinct
+    nodes. This is trivially satisfied by `activeArticulators` (which returns
+    a duplicate-free sublist of `articulatorNodes`), but we state it
+    explicitly as the standard WFC. -/
+def Segment.ComplexWF (s : Segment) : Prop :=
+  let aa := s.activeArticulators
+  aa.length = aa.eraseDups.length
+
+instance : DecidablePred Segment.ComplexWF := fun _ =>
+  inferInstanceAs (Decidable (_ = _))
+
+end Phonology

--- a/Linglib/Studies/Sagey1986.lean
+++ b/Linglib/Studies/Sagey1986.lean
@@ -42,7 +42,6 @@ the consensus geometry:
 
 open Phonology (Segment Feature FeatureVal)
 open Phonology.FeatureGeometry (GeomNode)
-open Phonology.ComplexSegments
 open Autosegmental (agreeAt)
 
 namespace Autosegmental
@@ -382,10 +381,10 @@ def nupe_kp_segment : Segment :=
      (.voice, false), (.labial, true), (.dorsal, true)]
 
 /-- The Nupe /k͡p/ is a complex segment (two active place articulators). -/
-theorem nupe_kp_is_complex : IsComplex nupe_kp_segment := by decide
+theorem nupe_kp_is_complex : Segment.IsComplex nupe_kp_segment := by decide
 
 /-- The Nupe /k͡p/ is well-formed: labial ≠ dorsal. -/
-theorem nupe_kp_wf : ComplexWF nupe_kp_segment := by decide
+theorem nupe_kp_wf : Segment.ComplexWF nupe_kp_segment := by decide
 
 /-- A simple /p/ (labial only) is not complex. -/
 def simple_p : Segment :=
@@ -393,7 +392,7 @@ def simple_p : Segment :=
     [(.consonantal, true), (.sonorant, false), (.continuant, false),
      (.voice, false), (.labial, true)]
 
-theorem simple_p_not_complex : ¬ IsComplex simple_p := by decide
+theorem simple_p_not_complex : ¬ Segment.IsComplex simple_p := by decide
 
 /-- A velar nasal /ŋ/ is NOT complex despite activating both the dorsal
     articulator and the soft palate (velum lowering). The soft palate
@@ -405,10 +404,10 @@ def velar_nasal : Segment :=
     [(.consonantal, true), (.sonorant, true), (.continuant, false),
      (.nasal, true), (.voice, true), (.dorsal, true)]
 
-theorem velar_nasal_not_complex : ¬ IsComplex velar_nasal := by decide
+theorem velar_nasal_not_complex : ¬ Segment.IsComplex velar_nasal := by decide
 
 /-- The velar nasal is well-formed (only one place articulator: dorsal). -/
-theorem velar_nasal_wf : ComplexWF velar_nasal := by decide
+theorem velar_nasal_wf : Segment.ComplexWF velar_nasal := by decide
 
 -- ============================================================================
 -- § 5: Impossible Complex Segments (Ch. 2)
@@ -426,7 +425,7 @@ def alveolar_t : Segment :=
     [(.consonantal, true), (.sonorant, false), (.continuant, false),
      (.voice, false), (.coronal, true), (.anterior, true)]
 
-theorem alveolar_not_complex : ¬ IsComplex alveolar_t := by decide
+theorem alveolar_not_complex : ¬ Segment.IsComplex alveolar_t := by decide
 
 /-- An alveopalatal (postalveolar) is [+cor, −ant, +dist] — still just
     one articulator (coronal), so not complex. An alveolar-alveopalatal
@@ -438,7 +437,7 @@ def alveopalatal : Segment :=
      (.voice, false), (.coronal, true), (.anterior, false),
      (.distributed, true)]
 
-theorem alveopalatal_not_complex : ¬ IsComplex alveopalatal := by decide
+theorem alveopalatal_not_complex : ¬ Segment.IsComplex alveopalatal := by decide
 
 -- ============================================================================
 -- § 6: No-Crossing Constraint (Ch. 5)


### PR DESCRIPTION
Per the audit: `Phonology.ComplexSegments` was an area-named namespace. Its segment-classification predicates (`IsComplex`, `ComplexWF`, `activeArticulators`, `articulatorCount`) become `Segment.*` dot-notation methods (owner-relative), and the articulator-geometry facts (`articulatorNodes` + the verification theorems) move to `FeatureGeometry` (their real owner). Sole consumer (Sagey1986) updated. `FeatureGeometry` stays owned under `Phonology` (extends `Feature`/`GeomNode`).