### PR TITLE
refactor(Phonology): fold ItemSpecificity/ParadigmUniformity into their frameworks

### DIFF
--- a/Linglib/Fragments/Japanese/Prosody.lean
+++ b/Linglib/Fragments/Japanese/Prosody.lean
@@ -132,7 +132,7 @@ structure JLexicalEntry extends JProsodicEntry where
     standard mathlib coercion. The instance is `noncomputable` because
     `ℝ` is noncomputable; the `ℚ` field itself remains computable for
     `decide`-style proofs. -/
-noncomputable instance : Phonology.ItemSpecificity.HasTokenFreq JLexicalEntry where
+noncomputable instance : Constraint.ItemSpecificity.HasTokenFreq JLexicalEntry where
   tokenLogFreq e := (e.tokenLogFreq : ℝ)
 
 -- ============================================================================

--- a/Linglib/Phonology/ItemSpecificity/Defs.lean
+++ b/Linglib/Phonology/ItemSpecificity/Defs.lean
@@ -42,7 +42,7 @@ empirically standard predictor and (b) frequency-scaled-weight theories
 want raw counts can `Real.exp ∘ tokenLogFreq`.
 -/
 
-namespace Phonology.ItemSpecificity
+namespace Constraint.ItemSpecificity
 
 -- ============================================================================
 -- § 1: Frequency channels
@@ -95,4 +95,4 @@ abbrev isAboveThreshold {α : Type} [HasTokenFreq α] (threshold : ℝ) (a : α)
 noncomputable instance {α : Type} [HasTokenFreq α] (threshold : ℝ) :
     DecidablePred (isAboveThreshold (α := α) threshold) := fun _ => Classical.dec _
 
-end Phonology.ItemSpecificity
+end Constraint.ItemSpecificity

--- a/Linglib/Phonology/ItemSpecificity/IndexedConstraints.lean
+++ b/Linglib/Phonology/ItemSpecificity/IndexedConstraints.lean
@@ -29,9 +29,9 @@ theory under-fits relative to `ScaledWeights` /
 `RepresentationStrength`.
 -/
 
-namespace Phonology.ItemSpecificity.Indexed
+namespace Constraint.ItemSpecificity.Indexed
 
-open Phonology.ItemSpecificity
+open Constraint.ItemSpecificity
 open Constraint OptimalityTheory
 
 -- ============================================================================
@@ -86,4 +86,4 @@ theorem mkCoreOnly_constant_within_stratum
     (mkCoreOnly cutoff base).eval c1 = (mkCoreOnly cutoff base).eval c2 := by
   simp [mkCoreOnly, h1, h2, hbase]
 
-end Phonology.ItemSpecificity.Indexed
+end Constraint.ItemSpecificity.Indexed

--- a/Linglib/Phonology/ItemSpecificity/RepresentationStrength.lean
+++ b/Linglib/Phonology/ItemSpecificity/RepresentationStrength.lean
@@ -75,9 +75,9 @@ from S-G's optimality condition without further machinery; cf.
 discrimination across siblings.
 -/
 
-namespace Phonology.ItemSpecificity.RepStrength
+namespace Constraint.ItemSpecificity.RepStrength
 
-open Phonology.ItemSpecificity
+open Constraint.ItemSpecificity
 
 -- ============================================================================
 -- § 1: Activation
@@ -132,4 +132,4 @@ def addCombine (a b : ℝ) : ℝ := a + b
     by S-G's coalescence mechanism. -/
 def minCombine (a b : ℝ) : ℝ := min a b
 
-end Phonology.ItemSpecificity.RepStrength
+end Constraint.ItemSpecificity.RepStrength

--- a/Linglib/Phonology/ItemSpecificity/ScaledWeights.lean
+++ b/Linglib/Phonology/ItemSpecificity/ScaledWeights.lean
@@ -38,9 +38,9 @@ theory needs separate slopes per constraint — which it has, and so
 remains a viable account.
 -/
 
-namespace Phonology.ItemSpecificity.Scaled
+namespace Constraint.ItemSpecificity.Scaled
 
-open Phonology.ItemSpecificity
+open Constraint.ItemSpecificity
 open Constraint OptimalityTheory
 
 -- ============================================================================
@@ -92,4 +92,4 @@ theorem scaledWeight_monotone_in_freq
   unfold scaledWeight
   exact (add_le_add_iff_left baseWeight).mpr (mul_le_mul_of_nonneg_left hab h)
 
-end Phonology.ItemSpecificity.Scaled
+end Constraint.ItemSpecificity.Scaled

--- a/Linglib/Phonology/ItemSpecificity/Separation.lean
+++ b/Linglib/Phonology/ItemSpecificity/Separation.lean
@@ -60,13 +60,13 @@ have observable consequences.
   nasalisation; this file stays abstract.
 -/
 
-namespace Phonology.ItemSpecificity.Separation
+namespace Constraint.ItemSpecificity.Separation
 
-open Phonology.ItemSpecificity
-open Phonology.ItemSpecificity.Indexed
-open Phonology.ItemSpecificity.Scaled
-open Phonology.ItemSpecificity.UseListed
-open Phonology.ItemSpecificity.RepStrength
+open Constraint.ItemSpecificity
+open Constraint.ItemSpecificity.Indexed
+open Constraint.ItemSpecificity.Scaled
+open Constraint.ItemSpecificity.UseListed
+open Constraint.ItemSpecificity.RepStrength
 open Constraint OptimalityTheory
 
 -- ============================================================================
@@ -337,4 +337,4 @@ theorem sep_repstrength_vs_indexed_within_stratum :
       show (10 : ℝ) ≥ 3; norm_num
     simp [mkCoreOnly, h_lo, h_hi, baseOne]
 
-end Phonology.ItemSpecificity.Separation
+end Constraint.ItemSpecificity.Separation

--- a/Linglib/Phonology/ItemSpecificity/UseListed.lean
+++ b/Linglib/Phonology/ItemSpecificity/UseListed.lean
@@ -32,9 +32,9 @@ compounds show the same compound-frequency-conditioned nasalisation
 gradient as familiar compounds, contra UseListed.
 -/
 
-namespace Phonology.ItemSpecificity.UseListed
+namespace Constraint.ItemSpecificity.UseListed
 
-open Phonology.ItemSpecificity
+open Constraint.ItemSpecificity
 
 -- ============================================================================
 -- § 1: Listed-vs-computed gate
@@ -77,4 +77,4 @@ theorem dispatch_novel_eq_grammar
   unfold dispatch
   simp [not_le.mpr hnovel]
 
-end Phonology.ItemSpecificity.UseListed
+end Constraint.ItemSpecificity.UseListed

--- a/Linglib/Phonology/ParadigmUniformity/Antifaithfulness.lean
+++ b/Linglib/Phonology/ParadigmUniformity/Antifaithfulness.lean
@@ -45,7 +45,7 @@ counts pairs where they *differ*. Together they partition the edge:
   `identViol c r₁ r₂ + antifaithViol c r₁ r₂ = (edge r₁ r₂).card`
 -/
 
-namespace Phonology.ParadigmUniformity.Antifaithfulness
+namespace OptimalityTheory.ParadigmUniformity.Antifaithfulness
 
 open OptimalityTheory.Correspondence (Corr)
 open Constraint OptimalityTheory
@@ -112,4 +112,4 @@ def toAntifaithConstraint {Role α : Type} [DecidableEq α] (r₁ r₂ : Role)
   family := .faithfulness
   eval c := antifaithViol c r₁ r₂
 
-end Phonology.ParadigmUniformity.Antifaithfulness
+end OptimalityTheory.ParadigmUniformity.Antifaithfulness

--- a/Linglib/Phonology/ParadigmUniformity/Defs.lean
+++ b/Linglib/Phonology/ParadigmUniformity/Defs.lean
@@ -45,7 +45,7 @@ Breiss-Katsuda-Kawahara compound study
 which pairing best fits Japanese velar nasalisation.
 -/
 
-namespace Phonology.ParadigmUniformity
+namespace OptimalityTheory.ParadigmUniformity
 
 open Constraint OptimalityTheory
 
@@ -76,4 +76,4 @@ def liftPairwise {Form : Type} (name : String) (family : ConstraintFamily)
     eval := fun paradigm =>
       ((paradigm.product paradigm).map (fun (a, b) => compare a b)).sum }
 
-end Phonology.ParadigmUniformity
+end OptimalityTheory.ParadigmUniformity

--- a/Linglib/Phonology/ParadigmUniformity/LexicalConservatism.lean
+++ b/Linglib/Phonology/ParadigmUniformity/LexicalConservatism.lean
@@ -53,7 +53,7 @@ without auxiliary stipulation; LC handles it by paradigm membership.
   `mismatch f f = 0` (well-formedness on the diagonal).
 -/
 
-namespace Phonology.ParadigmUniformity
+namespace OptimalityTheory.ParadigmUniformity
 
 open Constraint OptimalityTheory
 open OptimalityTheory.Correspondence (Corr)
@@ -134,4 +134,4 @@ theorem lc_unanchored_zero {Form : Type} (name : String)
     (mkLCFaith name mismatch).eval (lcParadigm candidate none) = 0 := by
   simp [mkLCFaith, lcParadigm, liftPairwise, List.product, h_diagonal]
 
-end Phonology.ParadigmUniformity
+end OptimalityTheory.ParadigmUniformity

--- a/Linglib/Phonology/ParadigmUniformity/OptimalParadigms.lean
+++ b/Linglib/Phonology/ParadigmUniformity/OptimalParadigms.lean
@@ -40,7 +40,7 @@ that phonological behavior tracks paradigm structure. See
 `Studies/MarcoRasin2026.lean`.
 -/
 
-namespace Phonology.ParadigmUniformity
+namespace OptimalityTheory.ParadigmUniformity
 
 open Constraint OptimalityTheory
 open OptimalityTheory.Correspondence (Corr)
@@ -107,4 +107,4 @@ theorem majority_minimizes_violations (a b : Nat) (h : a > b) :
     (a + 1) * b < a * (b + 1) := by
   rw [Nat.add_mul, Nat.mul_add]; omega
 
-end Phonology.ParadigmUniformity
+end OptimalityTheory.ParadigmUniformity

--- a/Linglib/Phonology/ParadigmUniformity/Transderivational.lean
+++ b/Linglib/Phonology/ParadigmUniformity/Transderivational.lean
@@ -32,7 +32,7 @@ constraint or the lift — it is in the **evaluation discipline** (recursive
 base-priority), which is captured in `TCT.TCTGrammar`'s type signatures.
 -/
 
-namespace Phonology.ParadigmUniformity.Transderivational
+namespace OptimalityTheory.ParadigmUniformity.Transderivational
 
 open OptimalityTheory.Correspondence (Corr)
 open OptimalityTheory.TCT (Role)
@@ -141,4 +141,4 @@ theorem identOO_when_equal {α : Type} [DecidableEq α]
   simp only [not_not]
   exact congrArg (fun i : Fin shared.length => shared[i]) (Fin.ext hpq)
 
-end Phonology.ParadigmUniformity.Transderivational
+end OptimalityTheory.ParadigmUniformity.Transderivational

--- a/Linglib/Studies/Benua1997.lean
+++ b/Linglib/Studies/Benua1997.lean
@@ -51,7 +51,7 @@ markedness constraint M₂ is satisfied or violated by the base output.
 
 Consumes:
 - `Phonology.OptimalityTheory.TCT.Role` and `TetruSchema`
-- `Phonology.ParadigmUniformity.Transderivational.diagramWithEdge`
+- `OptimalityTheory.ParadigmUniformity.Transderivational.diagramWithEdge`
   (general 3-role correspondence with explicit OO alignment)
 - `Phonology.OptimalityTheory.Correspondence.Corr.identViol` (segmental)
   and `Corr.identViolFeature` (featural)
@@ -66,7 +66,7 @@ namespace Benua1997
 
 open OptimalityTheory.Correspondence (Corr)
 open OptimalityTheory.TCT (Role TetruSchema)
-open Phonology.ParadigmUniformity.Transderivational
+open OptimalityTheory.ParadigmUniformity.Transderivational
   (diagramWithEdge identOOViol)
 open Constraint OptimalityTheory
 

--- a/Linglib/Studies/BreissKatsudaKawahara2026.lean
+++ b/Linglib/Studies/BreissKatsudaKawahara2026.lean
@@ -119,9 +119,9 @@ favouring a paradigm-anchored account.
 namespace BreissKatsudaKawahara2026
 
 open Japanese.Prosody
-open Phonology.ItemSpecificity
-open Phonology.ItemSpecificity.Scaled (scaledWeight)
-open Phonology.ParadigmUniformity (liftPairwise lcParadigm mkLCFaith lc_unanchored_zero)
+open Constraint.ItemSpecificity
+open Constraint.ItemSpecificity.Scaled (scaledWeight)
+open OptimalityTheory.ParadigmUniformity (liftPairwise lcParadigm mkLCFaith lc_unanchored_zero)
 open Morphology.WugTest (Attestation HasFactor HasAttestation HasFrequency Rate
   NovelShowsFreqGradient NovelInvariantInFrequency
   novelGradient_inconsistent_with_invariance)

--- a/Linglib/Studies/MarcoRasin2026.lean
+++ b/Linglib/Studies/MarcoRasin2026.lean
@@ -45,7 +45,7 @@ namespace MarcoRasin2026
 
 open Core.Optimization Constraint OptimalityTheory
 open OptimalityTheory
-open Phonology.ParadigmUniformity
+open OptimalityTheory.ParadigmUniformity
 open Prosody.Syllable (SonorityRank)
 
 -- ============================================================================


### PR DESCRIPTION
Per the audit: neither owns a carrier type — they're *phenomena* over the constraint/OT frameworks, so they shouldn't hold top-level namespaces.
- `Phonology.ItemSpecificity.*` → `Constraint.ItemSpecificity.*` (frequency-conditioned constraint variants + the `HasTokenFreq` channel).
- `Phonology.ParadigmUniformity.*` → `OptimalityTheory.ParadigmUniformity.*` (output-output correspondence machinery).

Namespace-only change; the `Phonology/ItemSpecificity/` and `Phonology/ParadigmUniformity/` directories (module paths) stay. Consumers (Benua1997, BreissKatsudaKawahara2026, MarcoRasin2026, Japanese/Prosody) updated.