### PR TITLE
style(Phonology): dedup redundant opens in Constraints and MaxEnt

### DIFF
--- a/Linglib/Phonology/HarmonicGrammar/MaxEnt.lean
+++ b/Linglib/Phonology/HarmonicGrammar/MaxEnt.lean
@@ -43,7 +43,7 @@ namespace HarmonicGrammar
 open Core.Optimization
 
 
-open Constraint OptimalityTheory Core Constraint
+open Constraint OptimalityTheory Core
 
 -- ============================================================================
 -- § 1: MaxEnt Grammar (Classical — Individual Mappings)

--- a/Linglib/Phonology/OptimalityTheory/Constraints.lean
+++ b/Linglib/Phonology/OptimalityTheory/Constraints.lean
@@ -47,7 +47,6 @@ Binary constraints use a `Bool` predicate; gradient constraints use a
 namespace OptimalityTheory
 
 open Constraint
-open Constraint OptimalityTheory
 
 -- ============================================================================
 -- § 1: Faithfulness Constraint Constructors


### PR DESCRIPTION
Audit hygiene: `Constraints.lean` opened `Constraint` twice plus a self-`open OptimalityTheory` (it's already in `namespace OptimalityTheory`); `MaxEnt.lean` listed `Constraint` twice in one `open`. Deduped both.