### PR TITLE
refactor(Phonology/Autosegmental): rename AutosegRep→SharingRep + file hygiene

### DIFF
--- a/Linglib/Fragments/Finnish/VowelHarmony.lean
+++ b/Linglib/Fragments/Finnish/VowelHarmony.lean
@@ -39,7 +39,7 @@ namespace Finnish.VowelHarmony
 
 open Phonology (Segment Feature FeatureVal)
 open Phonology.FeatureGeometry (GeomNode)
-open Autosegmental (AutosegRep agreeAt)
+open Autosegmental (SharingRep agreeAt)
 open Subregular.Harmony (System HarmonyDir triggerValue
   harmonizeOne spreadSuffix)
 

--- a/Linglib/Phonology/Autosegmental/FeatureSharing.lean
+++ b/Linglib/Phonology/Autosegmental/FeatureSharing.lean
@@ -25,10 +25,10 @@ operations.
 
 * `agreeAt`, `placeAssimilation`, `totalAssimilation` — feature agreement
   predicates over a geometric node.
-* `Sharing`, `AutosegRep` — feature-sharing representations: a segmental
+* `Sharing`, `SharingRep` — feature-sharing representations: a segmental
   backbone plus a list of feature-sharing specifications.
-* `AutosegRep.inBounds`, `AutosegRep.consistent` — well-formedness checks.
-* `AutosegRep.spread`, `AutosegRep.delink`, `AutosegRep.spreadFeatures` —
+* `SharingRep.inBounds`, `SharingRep.consistent` — well-formedness checks.
+* `SharingRep.spread`, `SharingRep.delink`, `SharingRep.spreadFeatures` —
   atomic operations on feature-sharing representations.
 * `copyFeaturesUnder` — replace features under a geometric node.
 
@@ -80,16 +80,16 @@ structure Sharing where
 
 /-- An autosegmental representation: a sequence of segments with an explicit
     record of which adjacent pairs share features under which geometric nodes. -/
-structure AutosegRep where
+structure SharingRep where
   segments : List Segment
   sharing  : List Sharing
 
 /-- Are all sharing specifications within bounds? -/
-def AutosegRep.inBounds (r : AutosegRep) : Bool :=
+def SharingRep.inBounds (r : SharingRep) : Bool :=
   r.sharing.all fun s => decide (s.left + 1 < r.segments.length)
 
 /-- Is each sharing specification consistent with the segments' feature values? -/
-def AutosegRep.consistent (r : AutosegRep) : Bool :=
+def SharingRep.consistent (r : SharingRep) : Bool :=
   r.sharing.all fun sh =>
     match r.segments[sh.left]?, r.segments[sh.left + 1]? with
     | some seg1, some seg2 => agreeAt seg1 seg2 sh.node
@@ -98,13 +98,13 @@ def AutosegRep.consistent (r : AutosegRep) : Bool :=
 /-! ### Operations -/
 
 /-- Spread node `n` rightward from position `pos`. -/
-def AutosegRep.spread (r : AutosegRep) (pos : Nat) (n : GeomNode) :
-    AutosegRep :=
+def SharingRep.spread (r : SharingRep) (pos : Nat) (n : GeomNode) :
+    SharingRep :=
   { r with sharing := ⟨pos, n⟩ :: r.sharing }
 
 /-- Remove sharing at position `pos` for node `n`. -/
-def AutosegRep.delink (r : AutosegRep) (pos : Nat) (n : GeomNode) :
-    AutosegRep :=
+def SharingRep.delink (r : SharingRep) (pos : Nat) (n : GeomNode) :
+    SharingRep :=
   { r with sharing := r.sharing.filter fun s =>
       !(s.left == pos && s.node == n) }
 
@@ -120,8 +120,8 @@ def copyFeaturesUnder (tgt src : Segment) (n : GeomNode) : Segment where
 /-- Spread node `n` from position `pos + 1` onto position `pos`, replacing
     the target's features under `n` with the trigger's values and recording
     the sharing link. -/
-def AutosegRep.spreadFeatures (r : AutosegRep) (pos : Nat) (n : GeomNode) :
-    AutosegRep :=
+def SharingRep.spreadFeatures (r : SharingRep) (pos : Nat) (n : GeomNode) :
+    SharingRep :=
   match r.segments[pos]?, r.segments[pos + 1]? with
   | some tgt, some src =>
     let newTgt := copyFeaturesUnder tgt src n
@@ -186,11 +186,11 @@ private theorem filter_all_pass (l : List Sharing) (p : Sharing → Bool)
 
 /-- Spreading and then delinking returns the original representation when the
     position/node pair was not already present in the sharing list. -/
-theorem spread_delink_not_present (r : AutosegRep) (pos : Nat) (n : GeomNode)
+theorem spread_delink_not_present (r : SharingRep) (pos : Nat) (n : GeomNode)
     (h : (r.sharing.all fun s => !(s.left == pos && s.node == n)) = true) :
     (r.spread pos n).delink pos n = r := by
   cases r with | mk segs shs =>
-  simp only [AutosegRep.spread, AutosegRep.delink, AutosegRep.mk.injEq]
+  simp only [SharingRep.spread, SharingRep.delink, SharingRep.mk.injEq]
   -- Head ⟨pos, n⟩ fails the filter: !(pos == pos && n == n) = false
   have hnn : (n == n) = true := by cases n <;> rfl
   have hcond : (!(pos == pos && n == n)) = false := by rw [beq_self_eq_true, hnn]; rfl

--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Morphology.MorphWord
 import Linglib.Phonology.Autosegmental.Graph
 import Linglib.Phonology.Autosegmental.NoCrossing

--- a/Linglib/Phonology/Autosegmental/Graph.lean
+++ b/Linglib/Phonology/Autosegmental/Graph.lean
@@ -85,8 +85,8 @@ building block.
 
 ## Specializations
 
-* `Graph (SegSpec S) ToneSpec` — tonal-segmental autosegmental form
-  (the structure `FloatingForm` recovers once tier-generalised).
+* `Graph (TierSpec T) (SegSpec S)` — tonal/featural autosegmental form
+  (the structure `FloatingForm`).
 * `Graph Segment SkeletonSlot` — melodic tier docking onto a
   CV-skeleton, as in [laoide-kemp-2026] Figs. 1–2.
 * `Graph (Root α) CVSlot` — McCarthy-style root-template

--- a/Linglib/Phonology/Autosegmental/NoCrossing.lean
+++ b/Linglib/Phonology/Autosegmental/NoCrossing.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Insert
 import Mathlib.Order.Monotone.Monovary

--- a/Linglib/Studies/Clements1985.lean
+++ b/Linglib/Studies/Clements1985.lean
@@ -29,12 +29,12 @@ open English.Phonology
 section VelarAssimilation
 
 /-- Underlying representation: /nk/ with no sharing. -/
-def ur_nk : AutosegRep where
+def ur_nk : SharingRep where
   segments := [n, k]
   sharing := []
 
 /-- Surface representation: result of spreading place from /k/ onto /n/. -/
-def sr_nk : AutosegRep := ur_nk.spreadFeatures 0 .place
+def sr_nk : SharingRep := ur_nk.spreadFeatures 0 .place
 
 /-- /n/ and /k/ disagree at the place node in the UR. -/
 theorem n_k_disagree_at_place : agreeAt n k .place = false := by decide
@@ -63,12 +63,12 @@ end VelarAssimilation
 section LabialAssimilation
 
 /-- Underlying representation: /np/ with no sharing. -/
-def ur_np : AutosegRep where
+def ur_np : SharingRep where
   segments := [n, p]
   sharing := []
 
 /-- Surface representation: result of spreading place from /p/ onto /n/. -/
-def sr_np : AutosegRep := ur_np.spreadFeatures 0 .place
+def sr_np : SharingRep := ur_np.spreadFeatures 0 .place
 
 /-- /n/ and /p/ disagree at the place node in the UR. -/
 theorem n_p_disagree_at_place : agreeAt n p .place = false := by decide


### PR DESCRIPTION
From the 3-reviewer file-organization audit:
- `AutosegRep` → `SharingRep` — it was a name collision with `AR` (both = 'autosegmental representation'); `AR` (the graph-based object) keeps the name, the feature-geometry segment+sharing model becomes `SharingRep` (the representation built from `Sharing` records). Consumers (Finnish/VowelHarmony, Clements1985) updated.
- Added the Apache license header to `Floating.lean` and `NoCrossing.lean` (the only two in the dir missing it).
- Fixed a reversed type-orientation in `Graph.lean`'s specialization docstring (`FloatingForm` is `Graph (TierSpec T) (SegSpec S)`).

(Deferred, noted in the audit: re-ground `SharingRep` on `Graph Segment GeomNode` so it stops re-implementing the association/spreading spine — it's mis-factored, not mis-placed; feature spreading is autosegmental.)