### PR TITLE
docs(Phonology/Autosegmental): fix feature-geometry↔AR relationship + literature audit

### DIFF
--- a/Linglib/Phonology/Autosegmental/FeatureSharing.lean
+++ b/Linglib/Phonology/Autosegmental/FeatureSharing.lean
@@ -14,8 +14,14 @@ Autosegmental phonology adds **feature sharing** to segmental
 representations: when adjacent segments share a geometric node's features, they
 are linked to a single autosegmental element on that node's tier. This is the
 **feature-geometry** representation (segments plus feature-sharing
-specifications over geometric nodes) — distinct from, and unconnected to, the
-bipartite tier-association object `AR` (`Graph.lean` / `AR.lean`). It builds on
+specifications over geometric nodes). Feature geometry is an *extension of*
+autosegmental phonology ([clements-1985], [clements-hume-1995]): spreading is
+the association of one node to multiple anchors ([clements-1985]). So this
+`SharingRep` is a flattened, adjacency-indexed special case of the bipartite
+tier-association object `AR` (`Graph.lean` / `AR.lean`) — a single segment
+backbone with a feature-agreement-consistency law, not two materialized tiers.
+A faithful re-grounding of feature spreading as `AR` association is future work;
+for now the two are kept as separate carriers. It builds on
 the feature geometry (`Featural/Geometry.lean`) and segment type
 (`Featural/Features.lean`) to provide feature agreement predicates,
 feature-sharing representations with consistency checking, and spread/delink
@@ -46,6 +52,10 @@ two distinct elements cannot be identical to the same time point.
 ## References
 
 * [goldsmith-1976] — autosegmental phonology, original NCC.
+* [clements-1985] — feature geometry as an extension of autosegmental
+  phonology; spreading = association of one node to multiple anchors.
+* [clements-hume-1995] — handbook synthesis of autosegmental phonology
+  and feature geometry.
 * [sagey-1986] — temporal derivation of NCC and the negative
   argument against simultaneity.
 -/
@@ -111,9 +121,10 @@ def SharingRep.delink (r : SharingRep) (pos : Nat) (n : GeomNode) :
 /-! ### Feature spreading -/
 
 /-- Replace all features under geometric node `n` in `tgt` with `src`'s values.
-    This models autosegmental node replacement: when a place node spreads,
-    the entire node (including unspecified features) is copied, not just
-    the specified ones. -/
+    This models **node spreading** specifically ([clements-1985]'s class-node
+    assimilation): the entire node — including features `src` leaves
+    unspecified — is copied. (The node-spreading analysis; single-feature
+    spreading and underspecification-sensitive variants behave differently.) -/
 def copyFeaturesUnder (tgt src : Segment) (n : GeomNode) : Segment where
   spec f := if decide (f.DominatedBy n) then src.spec f else tgt.spec f
 

--- a/Linglib/Phonology/Autosegmental/Graph.lean
+++ b/Linglib/Phonology/Autosegmental/Graph.lean
@@ -44,7 +44,7 @@ Two well-formedness conditions are formalised as separable `Prop`s:
   ([pulleyblank-1986]): the *sole* structural WF requirement,
   applying universally to autosegmental representations.
 * `IsSaturatedUpper` / `IsSaturatedLower` — every in-bounds tier
-  position is linked. **Goldsmith** ([goldsmith-1979] p. 27)
+  position is linked. **Goldsmith** ([goldsmith-1979])
   bundled these into WFC; [pulleyblank-1986] reanalysed them as
   the role of *language-particular* association conventions, not
   structural well-formedness. Floating elements ([bird-1966]
@@ -76,11 +76,13 @@ relational composition `{(0,0), (0,1), (1,0), (1,1)}` has the crossing
 
 Goldsmith's 1976 dissertation treated autosegmental tiers as
 "conceptually equal" (cf. [leben-2018-autoseg] §1). The modern picture
-([leben-2018-autoseg] §3, after [clements-1985]) privileges *one
-basic tier* connected to multiple branch tiers (feature geometry,
-templatic CV-skeleton with root + vowel branches). A full multi-tier
-representation is then a paper-specific record of multiple `Graph`s
-sharing the basic tier on one side. The bilateral case below is the
+([leben-2018-autoseg] §3, after [clements-1985], [clements-hume-1995])
+privileges *one basic tier* connected to multiple branch tiers (feature
+geometry, templatic CV-skeleton with root + vowel branches). A full
+multi-tier representation is then a paper-specific record of multiple
+`Graph`s sharing the basic tier on one side — feature geometry is one
+such bundle, with spreading as association of a node to multiple anchors
+([clements-hume-1995]). The bilateral case below is the
 building block.
 
 ## Specializations
@@ -237,7 +239,7 @@ instance (r : Graph α β) (j : Nat) : Decidable (r.IsFloatingLower j) :=
 
 /-! ### Saturation and Goldsmith's WFC
 
-[goldsmith-1979] (p. 27) bundled saturation with non-crossing
+[goldsmith-1979] bundled saturation with non-crossing
 into a single Well-Formedness Condition; [pulleyblank-1986]
 weakened WFC to non-crossing alone, with saturation devolved to
 language-particular association conventions. The post-1986 view is

--- a/Linglib/Phonology/Featural/Geometry.lean
+++ b/Linglib/Phonology/Featural/Geometry.lean
@@ -4,7 +4,8 @@ import Linglib.Phonology.Featural.Features
 # Feature Geometry [clements-1985] [sagey-1986]
 
 Hierarchical organization of phonological features following the standard
-feature geometry model. The tree synthesizes three sources:
+feature geometry model — the hierarchical organization of autosegmental
+tiers ([clements-hume-1995]). The tree synthesizes three sources:
 
 - **[clements-1985]**: root, laryngeal, supralaryngeal, and place nodes
 - **[sagey-1986]**: articulator sub-nodes under Place (labial, coronal, dorsal);


### PR DESCRIPTION
From the foundations review (3 reviewers + Clements 1985 read directly):
- **Correct a factually-wrong docstring.** `FeatureSharing.lean` claimed feature geometry is "distinct from, and unconnected to" the `AR` object. Per [clements-1985] (feature geometry is *an extension of* autosegmental phonology; spreading = association of one node to multiple anchors), it's a flattened, adjacency-indexed special case of `AR` — now stated as such, with a note that a faithful re-grounding is future work.
- **Add [clements-hume-1995]** — the canonical handbook synthesis of autosegmental phonology + feature geometry, previously in `references.bib` but cited in zero files. Added to FeatureSharing/Graph/Geometry where the general↔special relationship is discussed.
- **Narrow an over-claim:** `copyFeaturesUnder`'s "whole node copied" is the *node-spreading* analysis specifically, not general autosegmental theory.
- **De-page** the unverifiable `[goldsmith-1979] p. 27` citations (CLAUDE.md rule).

Foundations verdict (recorded): autosegmental association (`Graph`/`AR`) is the more general foundation; feature geometry derives. The structural re-site (`SharingRep`→`Featural/`) + bundle-of-Graphs reground are separate follow-ups.