### PR TITLE
fix(Phonology): repair orphan FeatureSharing imports after #686 rename

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2722,7 +2722,7 @@ import Linglib.Phonology.Featural.ComplexSegments
 import Linglib.Phonology.Featural.Bundle
 import Linglib.Phonology.Featural.Underspecification
 import Linglib.Phonology.Featural.ElementTheory
-import Linglib.Phonology.Autosegmental.FeatureSharing
+import Linglib.Phonology.Featural.Sharing
 import Linglib.Phonology.Tone.Basic
 import Linglib.Phonology.Tone.Grammatical
 import Linglib.Phonology.Autosegmental.Floating

--- a/Linglib/Fragments/Finnish/VowelHarmony.lean
+++ b/Linglib/Fragments/Finnish/VowelHarmony.lean
@@ -1,7 +1,7 @@
 import Linglib.Phonology.Featural.Features
 import Linglib.Phonology.Featural.Geometry
 import Linglib.Phonology.Subregular.LocalRewrite
-import Linglib.Phonology.Autosegmental.FeatureSharing
+import Linglib.Phonology.Featural.Sharing
 import Linglib.Phonology.Subregular.Harmony
 
 /-!

--- a/Linglib/Fragments/Turkish/VowelHarmony.lean
+++ b/Linglib/Fragments/Turkish/VowelHarmony.lean
@@ -1,7 +1,7 @@
 import Linglib.Phonology.Featural.Features
 import Linglib.Phonology.Featural.Geometry
 import Linglib.Phonology.Subregular.LocalRewrite
-import Linglib.Phonology.Autosegmental.FeatureSharing
+import Linglib.Phonology.Featural.Sharing
 import Linglib.Phonology.Subregular.Harmony
 
 /-!

--- a/Linglib/Studies/Clements1985.lean
+++ b/Linglib/Studies/Clements1985.lean
@@ -1,4 +1,4 @@
-import Linglib.Phonology.Autosegmental.FeatureSharing
+import Linglib.Phonology.Featural.Sharing
 import Linglib.Fragments.English.Phonology
 
 /-!

--- a/Linglib/Studies/Sagey1986.lean
+++ b/Linglib/Studies/Sagey1986.lean
@@ -1,6 +1,6 @@
 import Linglib.Phonology.Featural.ComplexSegments
 import Linglib.Phonology.Featural.Geometry
-import Linglib.Phonology.Autosegmental.FeatureSharing
+import Linglib.Phonology.Featural.Sharing
 import Linglib.Phonology.Autosegmental.NoCrossing
 import Linglib.Phonology.Subregular.LocalRewrite
 import Linglib.Core.Order.Interval


### PR DESCRIPTION
#686 moved `Autosegmental/FeatureSharing.lean` → `Featural/Sharing.lean` (pure rename) but left five files importing the old path, breaking `main` CI (orphan imports → clean-build failure). Updates the import path in `Linglib.lean`, Finnish/Turkish `VowelHarmony`, `Clements1985`, and `Sagey1986`; the `Autosegmental` namespace is unchanged, so only the import line moves.