### PR TITLE
feat(Syntax/HPSG): five filler-gap constructions on the construct hierarchy

### DIFF
--- a/Linglib/Studies/Sag2010.lean
+++ b/Linglib/Studies/Sag2010.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Syntax.HPSG.HeadFiller
+import Linglib.Syntax.HPSG.Construction
 import Linglib.Studies.Ross1967
 import Linglib.Studies.SagWasowBender2003Extraction
 import Linglib.Features.ClauseForm
@@ -320,6 +321,39 @@ The `declarative-cl` membership of topicalization follows [sag-2010]'s
 Appendix-B hierarchy; construction (61) states only `↑filler-head-cxt` explicitly. -/
 theorem topicalized_theClause_share_clauseType :
     (fgParams .topicalized).clauseType = (fgParams .theClause).clauseType := rfl
+
+/-! ### Grounding in the RSRL construct hierarchy ([sag-etal-2020] Figs. 6–7)
+
+The five clause types are sorts in the RSRL construct hierarchy (`Syntax/HPSG/Construction`), where
+the filler-head inheritance and the clausal cross-classification above are *theorems about the sort
+order* — the model-theoretic substrate ([richter-2000]) under the `fgParams` record. -/
+
+/-- Each filler-gap clause type as a construct sort in the RSRL hierarchy. -/
+def fgSort : FGClauseType → HPSG.Construction.FHSort
+  | .whInterrogative => .nsWhIntCl
+  | .whExclamative => .whExclCl
+  | .topicalized => .topCl
+  | .whRelative => .whRelCl
+  | .theClause => .theCl
+
+/-- Every clause type is a filler-head construct in the RSRL hierarchy, so it inherits
+`filler-head-cxt`'s constraints (head verbal, filler↔gap token identity) proved in `Construction.lean`
+— the model-theoretic ground of `fg_inherits_nonverbal_filler`. -/
+theorem fgSort_filler_head (c : FGClauseType) :
+    fgSort c ≤ HPSG.Construction.FHSort.headFillerCxt := by cases c <;> decide
+
+/-- The local `ClauseType` as the matching RSRL clausal sort (Fig. 7). -/
+def clauseTypeSort : ClauseType → HPSG.Construction.FHSort
+  | .interrogativeCl => .interrogativeCl
+  | .relativeCl => .relativeCl
+  | .exclamativeCl => .exclamativeCl
+  | .declarativeCl => .declarativeCl
+
+/-- The RSRL clausal cross-classification agrees with the local `clauseType` assignment: each clause
+type's construct sits below the RSRL clausal sort matching `(fgParams c).clauseType`. The
+cross-classification of this section is thus the same fact as the RSRL sort order. -/
+theorem fgSort_matches_clauseType (c : FGClauseType) :
+    fgSort c ≤ clauseTypeSort (fgParams c).clauseType := by cases c <;> decide
 
 /-! ### Inversion ((28)) -/
 

--- a/Linglib/Syntax/HPSG/Construction.lean
+++ b/Linglib/Syntax/HPSG/Construction.lean
@@ -36,11 +36,14 @@ one sort assignment — the keystone theorem below.
 
 ## Scope
 
-This file establishes the hierarchy and the `ns-wh-int-cl` cross-classification keystone. The full five
-filler-gap constructions ([sag-2010]) and the inversion construction (`aux-initial-cxt`, [sag-etal-2020]
-(39)) are paper-anchored consumers built on this substrate; n-ary `DTRS`, GAP amalgamation, islands,
-and compositional `SEM` are deferred. Decidability stays inside `Models` over fixed finite
-interpretations (Kepser 2004: full RSRL model-checking is undecidable).
+This file establishes the hierarchy, the cross-classification keystone, and **all five filler-gap
+constructions** ([sag-2010] §5): topicalization, wh-exclamative, nonsubject wh-interrogative,
+wh-relative, and the-clause — distinguished by their clausal semantics, wh-relative's nominal filler,
+and the topicalization/the-clause head contrast (verb vs CP). The inversion construction
+(`aux-initial-cxt`, [sag-etal-2020] (39)), n-ary `DTRS`, GAP amalgamation, islands, the
+`WH`/`REL`/`IC`/`INV`/`VFORM` finer variation, and compositional `SEM` are deferred. Decidability stays
+inside `Models` over fixed finite interpretations (Kepser 2004: full RSRL model-checking is
+undecidable).
 -/
 
 namespace HPSG.Construction
@@ -54,8 +57,8 @@ open HPSG.RSRL
 worked cross-classified subtype (Fig. 5). -/
 inductive FHSort
   | top
-  -- category hierarchy (head-filler-cxt keys on verbal/nonverbal)
-  | cat | verbal | nonverbal | verb | noun
+  -- category hierarchy (head-filler-cxt keys on verbal/nonverbal; wh-rel on nominal; the-cl on comp)
+  | cat | verbal | nonverbal | verb | comp | nominal | noun | prep | adj
   -- semantic-type hierarchy (clause types key on the MTR's SEM type)
   | semType | austinean | question | fact | proposition
   -- signs
@@ -64,19 +67,23 @@ inductive FHSort
   | construct | phrasalCxt | lexicalCxt | headedCxt | clause | headFillerCxt
   -- clausal hierarchy (Fig. 7)
   | coreCl | relativeCl | declarativeCl | interrogativeCl | exclamativeCl
-  -- the cross-classified construct (Fig. 5): < head-filler-cxt AND < interrogative-cl
-  | nsWhIntCl
+  -- the filler-gap constructions, each cross-classifying a clausal type (Fig. 5; [sag-2010] §5)
+  | topCl | whExclCl | nsWhIntCl | whRelCl | theCl
   deriving DecidableEq, Fintype, Repr
 
 /-- Subsumption (`fhLe a b` = "`a` at least as specific as `b`"), transitively closed. The two arms
 for `nsWhIntCl` — below both `headFillerCxt` and `interrogativeCl` — are the multiple inheritance. -/
 def fhLe : FHSort → FHSort → Bool
   | _, .top => true
-  -- categories
+  -- categories (nonverbal > {nominal, adj}; nominal > {noun, prep})
   | .verbal, .cat => true
   | .nonverbal, .cat => true
   | .verb, .verbal => true | .verb, .cat => true
-  | .noun, .nonverbal => true | .noun, .cat => true
+  | .comp, .verbal => true | .comp, .cat => true
+  | .nominal, .nonverbal => true | .nominal, .cat => true
+  | .noun, .nominal => true | .noun, .nonverbal => true | .noun, .cat => true
+  | .prep, .nominal => true | .prep, .nonverbal => true | .prep, .cat => true
+  | .adj, .nonverbal => true | .adj, .cat => true
   -- semantic types
   | .austinean, .semType => true
   | .question, .semType => true
@@ -98,10 +105,24 @@ def fhLe : FHSort → FHSort → Bool
   | .interrogativeCl, .phrasalCxt => true | .interrogativeCl, .construct => true
   | .exclamativeCl, .coreCl => true | .exclamativeCl, .clause => true
   | .exclamativeCl, .phrasalCxt => true | .exclamativeCl, .construct => true
-  -- cross-classified: ns-wh-int-cl < head-filler-cxt (headed dim.) AND < interrogative-cl (clausal)
+  -- filler-gap constructions: each < head-filler-cxt (+ headed-cxt) AND its clausal type ([sag-2010]
+  -- §5; the cross-classification of Fig. 5). Note relative-cl is directly under clause (Fig. 7), so
+  -- whRelCl does not pass through core-cl.
+  | .topCl, .headFillerCxt => true | .topCl, .headedCxt => true
+  | .topCl, .declarativeCl => true | .topCl, .coreCl => true
+  | .topCl, .clause => true | .topCl, .phrasalCxt => true | .topCl, .construct => true
+  | .whExclCl, .headFillerCxt => true | .whExclCl, .headedCxt => true
+  | .whExclCl, .exclamativeCl => true | .whExclCl, .coreCl => true
+  | .whExclCl, .clause => true | .whExclCl, .phrasalCxt => true | .whExclCl, .construct => true
   | .nsWhIntCl, .headFillerCxt => true | .nsWhIntCl, .headedCxt => true
   | .nsWhIntCl, .interrogativeCl => true | .nsWhIntCl, .coreCl => true
   | .nsWhIntCl, .clause => true | .nsWhIntCl, .phrasalCxt => true | .nsWhIntCl, .construct => true
+  | .whRelCl, .headFillerCxt => true | .whRelCl, .headedCxt => true
+  | .whRelCl, .relativeCl => true
+  | .whRelCl, .clause => true | .whRelCl, .phrasalCxt => true | .whRelCl, .construct => true
+  | .theCl, .headFillerCxt => true | .theCl, .headedCxt => true
+  | .theCl, .declarativeCl => true | .theCl, .coreCl => true
+  | .theCl, .clause => true | .theCl, .phrasalCxt => true | .theCl, .construct => true
   | a, b => decide (a = b)
 
 instance : PartialOrder FHSort :=
@@ -135,19 +156,40 @@ def fhApprop : FHSort → FHAttr → Option FHSort
   | .interrogativeCl, .MTR => some .sign
   | .exclamativeCl, .MTR => some .sign
   | .nsWhIntCl, .MTR => some .sign
+  | .topCl, .MTR => some .sign
+  | .whExclCl, .MTR => some .sign
+  | .whRelCl, .MTR => some .sign
+  | .theCl, .MTR => some .sign
   | .headedCxt, .HDDTR => some .sign
   | .headedCxt, .FILLERDTR => some .sign
   | .headFillerCxt, .HDDTR => some .sign
   | .headFillerCxt, .FILLERDTR => some .sign
   | .nsWhIntCl, .HDDTR => some .sign
   | .nsWhIntCl, .FILLERDTR => some .sign
+  | .topCl, .HDDTR => some .sign
+  | .topCl, .FILLERDTR => some .sign
+  | .whExclCl, .HDDTR => some .sign
+  | .whExclCl, .FILLERDTR => some .sign
+  | .whRelCl, .HDDTR => some .sign
+  | .whRelCl, .FILLERDTR => some .sign
+  | .theCl, .HDDTR => some .sign
+  | .theCl, .FILLERDTR => some .sign
   | .sign, .CAT => some .cat
   | .sign, .GAP => some .cat
   | .sign, .SEM => some .semType
   | _, _ => none
 
+-- Appropriateness values never refine down this hierarchy (a sort and its subsorts carry the *same*
+-- value for an attribute), so the inherited value is `τ₁` itself. Proving this propagation over just
+-- `(σ₁, σ₂, α)` — without the `τ₁` quantifier or the `∃`-search — keeps the `decide` within budget.
+private theorem fhApprop_propagates : ∀ (σ₁ σ₂ : FHSort) (α : FHAttr),
+    σ₂ ≤ σ₁ → (fhApprop σ₁ α).isSome = true → fhApprop σ₂ α = fhApprop σ₁ α := by decide
+
 private theorem fhApprop_inh : ∀ (σ₁ σ₂ : FHSort) (α : FHAttr) (τ₁ : FHSort),
-    σ₂ ≤ σ₁ → fhApprop σ₁ α = some τ₁ → ∃ τ₂, fhApprop σ₂ α = some τ₂ ∧ τ₂ ≤ τ₁ := by decide
+    σ₂ ≤ σ₁ → fhApprop σ₁ α = some τ₁ → ∃ τ₂, fhApprop σ₂ α = some τ₂ ∧ τ₂ ≤ τ₁ := by
+  intro σ₁ σ₂ α τ₁ hle happ
+  have hsome : (fhApprop σ₁ α).isSome = true := by rw [happ]; rfl
+  exact ⟨τ₁, (fhApprop_propagates σ₁ σ₂ α hle hsome).trans happ, le_refl τ₁⟩
 
 /-- The fragment's signature (no relations). -/
 @[reducible] def fhSig : Signature FHSort where
@@ -185,10 +227,23 @@ def exclamativePrinciple : Desc fhSig :=
 def relativePrinciple : Desc fhSig :=
   .imp (.sortAssign .colon .relativeCl) (.sortAssign (.path [.MTR, .SEM]) .proposition)
 
-/-- The grammar: the filler-head construction and the four clausal-type principles. -/
+/-- The **wh-relative construction**'s distinguishing constraint ([sag-2010] (92), (25b)): unlike the
+other filler-gap constructions (nonverbal filler), the relative filler is `[CAT nominal]` — an NP or PP
+(`nominal` resolves to `noun`/`prep`), excluding AP/AdvP. -/
+def whRelPrinciple : Desc fhSig :=
+  .imp (.sortAssign .colon .whRelCl) (.sortAssign (.path [.FILLERDTR, .CAT]) .nominal)
+
+/-- The **topicalization construction**'s distinguishing constraint ([sag-2010] (61), (27a)): its head
+daughter is a `[CAT verb]` projection (an S), excluding the complementizer-headed CP that the
+otherwise-similar (also austinean) the-clause allows ((27b): the-clause head is S or CP). -/
+def topPrinciple : Desc fhSig :=
+  .imp (.sortAssign .colon .topCl) (.sortAssign (.path [.HDDTR, .CAT]) .verb)
+
+/-- The grammar: the filler-head construction, the four clausal-type principles, and the
+construction-specific restrictions (topicalization's verb head, wh-relative's nominal filler). -/
 def fhGrammar : Grammar fhSig :=
   [headFillerPrinciple, declarativePrinciple, interrogativePrinciple, exclamativePrinciple,
-    relativePrinciple]
+    relativePrinciple, whRelPrinciple, topPrinciple]
 
 /-! ### Multiple inheritance: `ns-wh-int-cl` is a lower bound across the two dimensions -/
 
@@ -197,12 +252,23 @@ def fhGrammar : Grammar fhSig :=
 theorem nsWhIntCl_inherits :
     (FHSort.nsWhIntCl ≤ .headFillerCxt) ∧ (FHSort.nsWhIntCl ≤ .interrogativeCl) := by decide
 
+/-- All four filler-gap constructions cross-classify: each is below `head-filler-cxt` (so inherits the
+filler-head constraints) **and** below the clausal type fixing its semantics ([sag-2010] §5,
+[sag-etal-2020] Fig. 5) — topicalization/declarative, wh-exclamative/exclamative,
+nonsubject-wh-interrogative/interrogative, wh-relative/relative. -/
+theorem fg_cross_classify :
+    ((FHSort.topCl ≤ .headFillerCxt) ∧ (FHSort.topCl ≤ .declarativeCl)) ∧
+      ((FHSort.whExclCl ≤ .headFillerCxt) ∧ (FHSort.whExclCl ≤ .exclamativeCl)) ∧
+      ((FHSort.nsWhIntCl ≤ .headFillerCxt) ∧ (FHSort.nsWhIntCl ≤ .interrogativeCl)) ∧
+      ((FHSort.whRelCl ≤ .headFillerCxt) ∧ (FHSort.whRelCl ≤ .relativeCl)) ∧
+      ((FHSort.theCl ≤ .headFillerCxt) ∧ (FHSort.theCl ≤ .declarativeCl)) := by decide
+
 /-! ### Worked constructs -/
 
 /-- Entities shared by the worked constructs: the construct, its mother and two daughters, two
 category objects, and one semantic object. -/
 inductive Ent
-  | cxt | mtr | hd | fl | npCat | vpCat | sem
+  | cxt | mtr | hd | fl | npCat | vpCat | adjCat | compCat | sem
   deriving DecidableEq, Fintype, Repr
 
 /-- A well-formed filler-head construct (sort `head-filler-cxt`): nonverbal filler, verbal head, and
@@ -215,6 +281,8 @@ def goodFillerHead : Interpretation fhSig where
     | .fl => .sign
     | .npCat => .noun
     | .vpCat => .verb
+    | .adjCat => .adj
+    | .compCat => .comp
     | .mtr => .sign
     | .sem => .semType
   A := fun a u => match a, u with
@@ -269,6 +337,8 @@ def goodNsWhInt : Interpretation fhSig where
     | .fl => .sign
     | .npCat => .noun
     | .vpCat => .verb
+    | .adjCat => .adj
+    | .compCat => .comp
     | .sem => .question
   A := fun a u => match a, u with
     | .MTR, .cxt => some .mtr
@@ -302,6 +372,8 @@ def nsWhIntWrongSem : Interpretation fhSig where
     | .fl => .sign
     | .npCat => .noun
     | .vpCat => .verb
+    | .adjCat => .adj
+    | .compCat => .comp
     | .sem => .austinean    -- not a question
   A := goodNsWhInt.A
   R := fun e => e.elim
@@ -310,5 +382,129 @@ instance : Fintype nsWhIntWrongSem.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq nsWhIntWrongSem.U := inferInstanceAs (DecidableEq Ent)
 
 example : ¬ nsWhIntWrongSem.Models fhGrammar := by decide
+
+/-! ### The five filler-gap constructions ([sag-2010] §5)
+
+A worked construct of each sort. By `fg_cross_classify`, each satisfies the inherited filler-head
+constraints and its clausal semantics; wh-relative additionally satisfies its nominal-filler
+restriction and topicalization its verb-head restriction. The constructions are distinguished here by
+their clausal `SEM` (austinean / fact / question / proposition), wh-relative's nominal filler, and the
+topicalization-vs-the-clause head contrast (verb vs CP); the finer parametric variation (`WH`/`REL`,
+head `IC`/`INV`/`VFORM`) is deferred. -/
+
+/-- Topicalization ([sag-2010] (61)): a declarative (austinean) filler-head construct. -/
+def goodTopCl : Interpretation fhSig where
+  U := Ent
+  S := fun
+    | .cxt => .topCl
+    | .mtr => .sign | .hd => .sign | .fl => .sign
+    | .npCat => .noun | .vpCat => .verb | .adjCat => .adj | .compCat => .comp
+    | .sem => .austinean
+  A := goodNsWhInt.A
+  R := fun e => e.elim
+
+instance : Fintype goodTopCl.U := inferInstanceAs (Fintype Ent)
+instance : DecidableEq goodTopCl.U := inferInstanceAs (DecidableEq Ent)
+
+example : goodTopCl.Models fhGrammar := by decide
+
+/-- Wh-exclamative ([sag-2010] (70)): an exclamative (fact) filler-head construct. -/
+def goodWhExcl : Interpretation fhSig where
+  U := Ent
+  S := fun
+    | .cxt => .whExclCl
+    | .mtr => .sign | .hd => .sign | .fl => .sign
+    | .npCat => .noun | .vpCat => .verb | .adjCat => .adj | .compCat => .comp
+    | .sem => .fact
+  A := goodNsWhInt.A
+  R := fun e => e.elim
+
+instance : Fintype goodWhExcl.U := inferInstanceAs (Fintype Ent)
+instance : DecidableEq goodWhExcl.U := inferInstanceAs (DecidableEq Ent)
+
+example : goodWhExcl.Models fhGrammar := by decide
+
+/-- Wh-relative ([sag-2010] (92)): a relative (proposition) filler-head construct whose filler is
+nominal (NP/PP). -/
+def goodWhRel : Interpretation fhSig where
+  U := Ent
+  S := fun
+    | .cxt => .whRelCl
+    | .mtr => .sign | .hd => .sign | .fl => .sign
+    | .npCat => .noun | .vpCat => .verb | .adjCat => .adj | .compCat => .comp
+    | .sem => .proposition
+  A := goodNsWhInt.A
+  R := fun e => e.elim
+
+instance : Fintype goodWhRel.U := inferInstanceAs (Fintype Ent)
+instance : DecidableEq goodWhRel.U := inferInstanceAs (DecidableEq Ent)
+
+example : goodWhRel.Models fhGrammar := by decide
+
+/-- The wh-relative filler restriction genuinely binds: an AP filler (`adj` — nonverbal but not
+nominal) satisfies the inherited filler-head constraint (and its token identity) yet violates the
+relative-specific `[CAT nominal]` restriction, so the construct is rejected. -/
+def whRelAdjFiller : Interpretation fhSig where
+  U := Ent
+  S := goodWhRel.S
+  A := fun a u => match a, u with
+    | .MTR, .cxt => some .mtr
+    | .HDDTR, .cxt => some .hd
+    | .FILLERDTR, .cxt => some .fl
+    | .SEM, .mtr => some .sem
+    | .CAT, .fl => some .adjCat    -- AP filler: nonverbal but not nominal
+    | .CAT, .hd => some .vpCat
+    | .GAP, .hd => some .adjCat     -- token-identical to the filler, so only the nominal restriction fails
+    | _, _ => none
+  R := fun e => e.elim
+
+instance : Fintype whRelAdjFiller.U := inferInstanceAs (Fintype Ent)
+instance : DecidableEq whRelAdjFiller.U := inferInstanceAs (DecidableEq Ent)
+
+example : ¬ whRelAdjFiller.Models fhGrammar := by decide
+
+/-- The-clause ([sag-2010] (108)): an austinean filler-head construct whose head may be a
+complementizer-headed CP (`comp`) — distinguishing it from topicalization, whose head must be a verb
+projection ((27a) vs (27b)). -/
+def goodTheCl : Interpretation fhSig where
+  U := Ent
+  S := fun
+    | .cxt => .theCl
+    | .mtr => .sign | .hd => .sign | .fl => .sign
+    | .npCat => .noun | .vpCat => .verb | .adjCat => .adj | .compCat => .comp
+    | .sem => .austinean
+  A := fun a u => match a, u with
+    | .MTR, .cxt => some .mtr
+    | .HDDTR, .cxt => some .hd
+    | .FILLERDTR, .cxt => some .fl
+    | .SEM, .mtr => some .sem
+    | .CAT, .fl => some .npCat
+    | .CAT, .hd => some .compCat    -- a CP head, licensed for the-clauses
+    | .GAP, .hd => some .npCat
+    | _, _ => none
+  R := fun e => e.elim
+
+instance : Fintype goodTheCl.U := inferInstanceAs (Fintype Ent)
+instance : DecidableEq goodTheCl.U := inferInstanceAs (DecidableEq Ent)
+
+example : goodTheCl.Models fhGrammar := by decide
+
+/-- The topicalization head restriction binds: a CP (`comp`) head is verbal (so the inherited
+filler-head constraint holds) but violates topicalization's `[CAT verb]` restriction — the very
+constraint separating topicalization from the otherwise-identical (austinean) the-clause. -/
+def topClCompHead : Interpretation fhSig where
+  U := Ent
+  S := fun
+    | .cxt => .topCl
+    | .mtr => .sign | .hd => .sign | .fl => .sign
+    | .npCat => .noun | .vpCat => .verb | .adjCat => .adj | .compCat => .comp
+    | .sem => .austinean
+  A := goodTheCl.A
+  R := fun e => e.elim
+
+instance : Fintype topClCompHead.U := inferInstanceAs (Fintype Ent)
+instance : DecidableEq topClCompHead.U := inferInstanceAs (DecidableEq Ent)
+
+example : ¬ topClCompHead.Models fhGrammar := by decide
 
 end HPSG.Construction


### PR DESCRIPTION
Adds [sag-2010]'s five filler-gap constructions to the RSRL construct hierarchy (#684), each cross-classifying its clausal type, and grounds `Studies/Sag2010` in them.

**Construction.lean** — `topCl`/`whExclCl`/`nsWhIntCl`/`whRelCl`/`theCl`, each a lower bound of `head-filler-cxt` (headed dim.) and a clausal type ([sag-etal-2020] Fig. 5). They inherit the filler-head constraints; they are distinguished by clausal `SEM` (austinean/fact/question/proposition), wh-relative's `[CAT nominal]` filler ((25b)), and the topicalization/the-clause head contrast (verb vs CP, (27a)/(27b)). `fg_cross_classify` proves all five cross-classify; worked models show each construction-specific restriction genuinely binds (an AP wh-rel filler and a CP topicalization head are rejected). Axiom-clean.

**Sag2010.lean** — `fgSort` maps the five `FGClauseType`s to construct sorts; `fgSort_filler_head` and `fgSort_matches_clauseType` show the filler-head inheritance and clausal cross-classification of the study are theorems about the RSRL sort order, grounding the `fgParams` record in the model theory.

`approp_inherits` is reproved via an `isSome` propagation lemma (values don't refine here) to keep the `decide` within budget at this hierarchy size. Depends on #687 (now merged).