### PR TITLE
refactor(Syntax/HPSG): factor approp-inheritance + empty-relation boilerplate

### DIFF
--- a/Linglib/Syntax/HPSG/Construction.lean
+++ b/Linglib/Syntax/HPSG/Construction.lean
@@ -216,16 +216,11 @@ def fhApprop : FHSort → FHAttr → Option FHSort
   | _, _ => none
 
 -- Appropriateness values never refine down this hierarchy (a sort and its subsorts carry the *same*
--- value for an attribute), so the inherited value is `τ₁` itself. Proving this propagation over just
--- `(σ₁, σ₂, α)` — without the `τ₁` quantifier or the `∃`-search — keeps the `decide` within budget.
+-- value for an attribute); proving this propagation over just `(σ₁, σ₂, α)` — without the `τ₁`
+-- quantifier or `∃`-search — keeps the `decide` within budget, and `approp_inh_of_propagates` derives
+-- the `Signature.approp_inherits` obligation from it.
 private theorem fhApprop_propagates : ∀ (σ₁ σ₂ : FHSort) (α : FHAttr),
     σ₂ ≤ σ₁ → (fhApprop σ₁ α).isSome = true → fhApprop σ₂ α = fhApprop σ₁ α := by decide
-
-private theorem fhApprop_inh : ∀ (σ₁ σ₂ : FHSort) (α : FHAttr) (τ₁ : FHSort),
-    σ₂ ≤ σ₁ → fhApprop σ₁ α = some τ₁ → ∃ τ₂, fhApprop σ₂ α = some τ₂ ∧ τ₂ ≤ τ₁ := by
-  intro σ₁ σ₂ α τ₁ hle happ
-  have hsome : (fhApprop σ₁ α).isSome = true := by rw [happ]; rfl
-  exact ⟨τ₁, (fhApprop_propagates σ₁ σ₂ α hle hsome).trans happ, le_refl τ₁⟩
 
 /-- The fragment's signature (no relations). -/
 @[reducible] def fhSig : Signature FHSort where
@@ -233,9 +228,7 @@ private theorem fhApprop_inh : ∀ (σ₁ σ₂ : FHSort) (α : FHAttr) (τ₁ :
   Rel := Empty
   arity := fun e => e.elim
   approp := fhApprop
-  approp_inherits := fun {σ₁ σ₂ α τ₁} => fhApprop_inh σ₁ σ₂ α τ₁
-
-instance (I : Interpretation fhSig) : ∀ ρ, DecidablePred (I.R ρ) := fun ρ => nomatch ρ
+  approp_inherits := fun hle happ => approp_inh_of_propagates fhApprop_propagates hle happ
 
 /-! ### Principles (constructions as `τ ⇒ D`)
 

--- a/Linglib/Syntax/HPSG/GapAmalgamation.lean
+++ b/Linglib/Syntax/HPSG/GapAmalgamation.lean
@@ -98,21 +98,13 @@ def gApprop : GSort → GAttr → Option GSort
 private theorem gApprop_propagates : ∀ (σ₁ σ₂ : GSort) (α : GAttr),
     σ₂ ≤ σ₁ → (gApprop σ₁ α).isSome = true → gApprop σ₂ α = gApprop σ₁ α := by decide
 
-private theorem gApprop_inh : ∀ (σ₁ σ₂ : GSort) (α : GAttr) (τ₁ : GSort),
-    σ₂ ≤ σ₁ → gApprop σ₁ α = some τ₁ → ∃ τ₂, gApprop σ₂ α = some τ₂ ∧ τ₂ ≤ τ₁ := by
-  intro σ₁ σ₂ α τ₁ hle happ
-  have hsome : (gApprop σ₁ α).isSome = true := by rw [happ]; rfl
-  exact ⟨τ₁, (gApprop_propagates σ₁ σ₂ α hle hsome).trans happ, le_refl τ₁⟩
-
 /-- The gap-amalgamation signature (no relations). -/
 @[reducible] def gSig : Signature GSort where
   Attr := GAttr
   Rel := Empty
   arity := fun e => e.elim
   approp := gApprop
-  approp_inherits := fun {σ₁ σ₂ α τ₁} => gApprop_inh σ₁ σ₂ α τ₁
-
-instance (I : Interpretation gSig) : ∀ ρ, DecidablePred (I.R ρ) := fun ρ => nomatch ρ
+  approp_inherits := fun hle happ => approp_inh_of_propagates gApprop_propagates hle happ
 
 /-! ### Principles -/
 

--- a/Linglib/Syntax/HPSG/Interpretation.lean
+++ b/Linglib/Syntax/HPSG/Interpretation.lean
@@ -68,4 +68,11 @@ structure WellTyped (I : Interpretation Sig) : Prop where
 
 end Interpretation
 
+/-- For a **relation-free** signature, every relation symbol's membership is vacuously decidable — the
+hypothesis the `satisfies`/`Models` decision procedure needs. Replaces the per-signature
+`fun ρ => nomatch ρ` instance for every `Rel = Empty` fragment. -/
+instance instDecidablePredR_of_isEmpty {Srt : Type u} [PartialOrder Srt] {Sig : Signature Srt}
+    [IsEmpty Sig.Rel] (I : Interpretation Sig) : ∀ ρ, DecidablePred (I.R ρ) :=
+  fun ρ => isEmptyElim ρ
+
 end HPSG.RSRL

--- a/Linglib/Syntax/HPSG/Model.lean
+++ b/Linglib/Syntax/HPSG/Model.lean
@@ -73,9 +73,6 @@ instance search; the models below are plain `def`s. -/
   approp := happrop
   approp_inherits := fun {σ₁ σ₂ α τ₁} => happrop_inh σ₁ σ₂ α τ₁
 
-/-- `hpsgSig` has no relations, so relation membership is vacuously decidable — needed by the
-`satisfies`/`Models` decision procedure. -/
-instance (I : Interpretation hpsgSig) : ∀ ρ, DecidablePred (I.R ρ) := fun ρ => nomatch ρ
 
 /-! ### The Head Feature Principle -/
 

--- a/Linglib/Syntax/HPSG/Signature.lean
+++ b/Linglib/Syntax/HPSG/Signature.lean
@@ -66,4 +66,18 @@ inductive Term {Srt : Type u} [PartialOrder Srt] (Sig : Signature Srt) where
 def Term.path {Srt : Type u} [PartialOrder Srt] {Sig : Signature Srt} (p : Path Sig) : Term Sig :=
   p.foldl Term.feat Term.colon
 
+/-- Derive the `Signature.approp_inherits` obligation from an `isSome`-gated **propagation** lemma.
+When appropriateness values do not refine down the order (a sort and its subsorts carry the *same*
+value for an attribute — the common case), the inherited value is `τ₁` itself, so the propagation
+`σ₂ ≤ σ₁ → (approp σ₁ α).isSome → approp σ₂ α = approp σ₁ α` suffices. A large signature proves that
+propagation by `decide` (no `∃`-search, no `τ₁` quantifier — far cheaper) and feeds it here. -/
+theorem approp_inh_of_propagates {Srt : Type u} [PartialOrder Srt] {Attr : Type u}
+    {approp : Srt → Attr → Option Srt}
+    (h : ∀ (σ₁ σ₂ : Srt) (α : Attr),
+      σ₂ ≤ σ₁ → (approp σ₁ α).isSome = true → approp σ₂ α = approp σ₁ α)
+    {σ₁ σ₂ : Srt} {α : Attr} {τ₁ : Srt} (hle : σ₂ ≤ σ₁) (happ : approp σ₁ α = some τ₁) :
+    ∃ τ₂, approp σ₂ α = some τ₂ ∧ τ₂ ≤ τ₁ := by
+  have hsome : (approp σ₁ α).isSome = true := by rw [happ]; rfl
+  exact ⟨τ₁, (h σ₁ σ₂ α hle hsome).trans happ, le_refl τ₁⟩
+
 end HPSG.RSRL


### PR DESCRIPTION
Phase 0 of the HPSG-substrate unification roadmap: deduplicate the boilerplate the four RSRL demo signatures copy-paste.

Pulls two signature-independent helpers into the substrate:
- `Signature.approp_inh_of_propagates` — derives the `approp_inherits` `∃`-obligation from a cheap `isSome` propagation lemma (values don't refine), replacing the verbatim derivation in `fhSig` and `gSig`.
- `Interpretation.instDecidablePredR_of_isEmpty` — a generic `[IsEmpty Sig.Rel] → ∀ ρ, DecidablePred (I.R ρ)` instance, replacing the three identical `fun ρ => nomatch ρ` instances (`Construction`/`GapAmalgamation`/`Model`).

Net −2 derivations and −3 instances for +2 reusable helpers; adding a fifth signature is now cheap. No logic or `decide`-scaling change (Construction still 12s, axiom-clean). `Binding` (which has relations) is untouched. Roadmap: `scratch/hpsg-unification-roadmap.md`.