### PR TITLE
refactor(Phonology/Autosegmental): golf NonCrossing to terminal closers

### DIFF
--- a/Linglib/Phonology/Autosegmental/NonCrossing.lean
+++ b/Linglib/Phonology/Autosegmental/NonCrossing.lean
@@ -24,10 +24,6 @@ filter on autosegmental GEN.
 
 ## Main results
 
-* `monovaryOn_union` / `monovaryOn_insert` / `monovaryOn_singleton`: the
-  `Monovary` analogues of mathlib's `Set.pairwise_union` / `_insert` /
-  `_singleton`, absent from the `MonovaryOn` API (`[UPSTREAM]` candidates). The
-  structural keystones the rest derive from (`union` is the fundamental lemma).
 * `isNonCrossing_iff`: the elementary `∀∀→` form of `IsNonCrossing`.
 * `IsNonCrossing.subset`: subset closure.
 * `isNonCrossing_insert_iff'`: the insert-algebra — `insert p` stays
@@ -52,8 +48,7 @@ variable {ι α β : Type*} [Preorder α] [Preorder β] {f : ι → α} {g : ι 
 
 /-- `MonovaryOn` holds vacuously on a singleton: there is only one index. -/
 @[simp] theorem monovaryOn_singleton (a : ι) : MonovaryOn f g {a} := by
-  rintro i rfl j rfl h
-  exact absurd h (lt_irrefl _)
+  simp [MonovaryOn]
 
 /-- `MonovaryOn` on a union: monovary on each part, plus neither part inverts the
     order against the other. The `Monovary` analogue of `Set.pairwise_union` (the
@@ -107,8 +102,7 @@ theorem IsNonCrossing.subset {s t : Finset (ι × κ)} (hst : s ⊆ t)
 theorem isNonCrossing_insert_iff' [DecidableEq ι] [DecidableEq κ] (p : ι × κ) :
     IsNonCrossing (insert p links) ↔
       IsNonCrossing links ∧ ∀ q ∈ links, IsNonCrossing {p, q} := by
-  simp only [IsNonCrossing, Finset.coe_insert, Finset.coe_singleton, monovaryOn_insert,
-    monovaryOn_singleton, Finset.mem_coe, Set.mem_singleton_iff, forall_eq, true_and]
+  simp [IsNonCrossing, monovaryOn_insert]
 
 instance [DecidableLT ι] [DecidableLE κ] :
     Decidable (IsNonCrossing links) :=

--- a/Linglib/Phonology/Autosegmental/NonCrossing.lean
+++ b/Linglib/Phonology/Autosegmental/NonCrossing.lean
@@ -37,11 +37,10 @@ namespace Autosegmental
 
 /-! ### `MonovaryOn` on `union`, `insert`, and singletons
 
-`monovaryOn_union` / `monovaryOn_insert` are the `Monovary` analogues of
-mathlib's `Set.pairwise_union` / `Set.pairwise_insert`, which the `MonovaryOn`
-API lacks; together with `monovaryOn_singleton` they are `[UPSTREAM]` candidates
-for `Mathlib/Order/Monotone/Monovary.lean`. As in mathlib, `union` is the
-fundamental lemma and `insert` derives from it via `Set.insert_eq`. -/
+`monovaryOn_union` / `monovaryOn_insert` / `monovaryOn_singleton` are the
+`Monovary` analogues of mathlib's `Set.pairwise_union` / `_insert` /
+`_singleton`, which the `MonovaryOn` API lacks — `[UPSTREAM]` candidates for
+`Mathlib/Order/Monotone/Monovary.lean`. -/
 
 section Monovary
 variable {ι α β : Type*} [Preorder α] [Preorder β] {f : ι → α} {g : ι → β} {s t : Set ι}
@@ -57,13 +56,11 @@ theorem monovaryOn_union : MonovaryOn f g (s ∪ t) ↔ MonovaryOn f g s ∧ Mon
     ∀ a ∈ s, ∀ b ∈ t, (g a < g b → f a ≤ f b) ∧ (g b < g a → f b ≤ f a) := by
   grind [MonovaryOn]
 
-/-- `MonovaryOn` on `insert a s`, derived from `monovaryOn_union` (as mathlib
-    derives `Set.pairwise_insert` from `Set.pairwise_union` via `Set.insert_eq`). -/
+/-- `MonovaryOn` on `insert a s`. The `Monovary` analogue of `Set.pairwise_insert`. -/
 theorem monovaryOn_insert {a : ι} :
     MonovaryOn f g (insert a s) ↔
       MonovaryOn f g s ∧ ∀ b ∈ s, (g a < g b → f a ≤ f b) ∧ (g b < g a → f b ≤ f a) := by
-  simp only [Set.insert_eq, monovaryOn_union, monovaryOn_singleton, Set.mem_singleton_iff,
-    forall_eq, true_and]
+  grind [MonovaryOn]
 
 end Monovary
 
@@ -73,8 +70,7 @@ section
 variable {ι κ : Type*} [Preorder ι] [Preorder κ] (links : Finset (ι × κ))
 
 /-- The link set has no crossings: its two index coordinates monovary. -/
-def IsNonCrossing : Prop :=
-  MonovaryOn Prod.snd Prod.fst (↑links : Set (ι × κ))
+def IsNonCrossing : Prop := MonovaryOn Prod.snd Prod.fst (↑links : Set (ι × κ))
 
 /-- `IsNonCrossing` in elementary form. -/
 theorem isNonCrossing_iff : IsNonCrossing links ↔


### PR DESCRIPTION
Follow-up to #698. Tightens `NonCrossing.lean`: `monovaryOn_insert` now closes with `grind [MonovaryOn]` (uniform with `monovaryOn_union`), `monovaryOn_singleton`/`isNonCrossing_singleton`/`isNonCrossing_insert_iff'` reduced to terminal `simp`, `IsNonCrossing` def + several signatures/docstrings on one line. Behaviour-preserving; single file.