### PR TITLE
refactor(Syntax/HPSG): re-found all signatures on structural subsumption order

### DIFF
--- a/Linglib/Syntax/HPSG/Binding.lean
+++ b/Linglib/Syntax/HPSG/Binding.lean
@@ -34,18 +34,30 @@ inductive BAttr | SUBJ | OBJ | IDX deriving DecidableEq, Fintype, Repr
 /-- One relation: local o-command, `locO` (arity 2). -/
 inductive BRel | locO deriving DecidableEq, Fintype, Repr
 
-/-- Subsumption: the nom-obj species are `≤ synsem`; everything `≤ top`. -/
-def bleB : BSort → BSort → Bool
-  | _, .top => true
+/-- Direct subsumption ("covers"): the DAG edges. The nom-obj species (`ana`/`ppro`/`npro`) cover
+`synsem`; `sign`/`synsem`/`idx` cover `top`. The order is `ReflTransGen bCovers`. -/
+def bCovers : BSort → BSort → Bool
+  | .sign, .top => true
+  | .synsem, .top => true
+  | .idx, .top => true
   | .ana, .synsem => true
   | .ppro, .synsem => true
   | .npro, .synsem => true
-  | a, b => decide (a = b)
+  | _, _ => false
+
+/-- Specificity depth; every covers edge strictly increases it (giving antisymmetry). -/
+def bRank : BSort → Nat
+  | .top => 0
+  | .sign => 1 | .synsem => 1 | .idx => 1
+  | .ana => 2 | .ppro => 2 | .npro => 2
 
 instance : PartialOrder BSort :=
-  partialOrderOfBool bleB (by decide) (by decide) (by decide)
+  partialOrderOfCovers (bCovers · · = true) bRank (by decide)
 
-instance : DecidableLE BSort := fun a b => inferInstanceAs (Decidable (bleB a b = true))
+instance : DecidableLE BSort := fun a b =>
+  decidableLEOfCovers (covers := (bCovers · · = true))
+    [.top, .sign, .synsem, .ana, .ppro, .npro, .idx]
+    (by decide) a b
 
 /-- Appropriateness: a sign has `SUBJ`/`OBJ` synsems; every synsem species has an `IDX`. -/
 def bapprop : BSort → BAttr → Option BSort

--- a/Linglib/Syntax/HPSG/Construction.lean
+++ b/Linglib/Syntax/HPSG/Construction.lean
@@ -81,84 +81,64 @@ inductive FHSort
   | topCl | whExclCl | nsWhIntCl | whRelCl | theCl | interrogativeSAI
   deriving DecidableEq, Fintype, Repr
 
-/-- Subsumption (`fhLe a b` = "`a` at least as specific as `b`"). **Must be written transitively
-closed by hand** — every transitive consequence is listed explicitly (e.g. `noun ≤ nominal` *and*
-`noun ≤ nonverbal` *and* `noun ≤ cat`), and the `PartialOrder` instance's `le_trans`/`le_antisymm`
-`decide`s verify the closure is correct and acyclic. When adding a sort or edge, add all its downstream
-transitive arms or `le_trans` fails. The two arms for `nsWhIntCl` — below both `fillerHeadCxt` and
-`interrogativeCl` — are the multiple inheritance. -/
-def fhLe : FHSort → FHSort → Bool
-  | _, .top => true
+/-- Direct subsumption ("covers"): the **DAG edges** (a is *directly* more specific than b), not the
+transitive closure. The order is `ReflTransGen fhCovers`, so transitivity is structural and there is no
+hand-maintained closure or `|FHSort|³` `decide`. Each filler-gap construction covers **two** parents —
+its `headed-cxt` subtype and its clausal type — the multiple inheritance. -/
+def fhCovers : FHSort → FHSort → Bool
   -- categories (nonverbal > {nominal, adj}; nominal > {noun, prep})
-  | .verbal, .cat => true
-  | .nonverbal, .cat => true
-  | .verb, .verbal => true | .verb, .cat => true
-  | .comp, .verbal => true | .comp, .cat => true
-  | .nominal, .nonverbal => true | .nominal, .cat => true
-  | .noun, .nominal => true | .noun, .nonverbal => true | .noun, .cat => true
-  | .prep, .nominal => true | .prep, .nonverbal => true | .prep, .cat => true
-  | .adj, .nonverbal => true | .adj, .cat => true
+  | .verbal, .cat => true | .nonverbal, .cat => true
+  | .verb, .verbal => true | .comp, .verbal => true
+  | .nominal, .nonverbal => true | .adj, .nonverbal => true
+  | .noun, .nominal => true | .prep, .nominal => true
   -- semantic types
-  | .austinean, .semType => true
-  | .question, .semType => true
-  | .fact, .semType => true
-  | .proposition, .semType => true
+  | .austinean, .semType => true | .question, .semType => true
+  | .fact, .semType => true | .proposition, .semType => true
   -- inversion values
-  | .invPlus, .invVal => true
-  | .invMinus, .invVal => true
+  | .invPlus, .invVal => true | .invMinus, .invVal => true
+  -- the maximal sorts, directly below top
+  | .cat, .top => true | .semType, .top => true | .invVal, .top => true
+  | .sign, .top => true | .construct, .top => true
   -- construct backbone
-  | .phrasalCxt, .construct => true
-  | .lexicalCxt, .construct => true
-  | .headedCxt, .phrasalCxt => true | .headedCxt, .construct => true
-  | .clause, .phrasalCxt => true | .clause, .construct => true
-  | .fillerHeadCxt, .headedCxt => true | .fillerHeadCxt, .phrasalCxt => true
-  | .fillerHeadCxt, .construct => true
-  | .auxInitialCxt, .headedCxt => true | .auxInitialCxt, .phrasalCxt => true
-  | .auxInitialCxt, .construct => true
-  -- clausal
-  | .coreCl, .clause => true | .coreCl, .phrasalCxt => true | .coreCl, .construct => true
-  | .relativeCl, .clause => true | .relativeCl, .phrasalCxt => true | .relativeCl, .construct => true
-  | .declarativeCl, .coreCl => true | .declarativeCl, .clause => true
-  | .declarativeCl, .phrasalCxt => true | .declarativeCl, .construct => true
-  | .interrogativeCl, .coreCl => true | .interrogativeCl, .clause => true
-  | .interrogativeCl, .phrasalCxt => true | .interrogativeCl, .construct => true
-  | .exclamativeCl, .coreCl => true | .exclamativeCl, .clause => true
-  | .exclamativeCl, .phrasalCxt => true | .exclamativeCl, .construct => true
-  -- filler-gap constructions: each < filler-head-cxt (+ headed-cxt) AND its clausal type ([sag-2010]
-  -- §5). Note relative-cl is directly under clause (Fig. 7), so whRelCl does not pass through core-cl.
-  | .topCl, .fillerHeadCxt => true | .topCl, .headedCxt => true
-  | .topCl, .declarativeCl => true | .topCl, .coreCl => true
-  | .topCl, .clause => true | .topCl, .phrasalCxt => true | .topCl, .construct => true
-  | .whExclCl, .fillerHeadCxt => true | .whExclCl, .headedCxt => true
-  | .whExclCl, .exclamativeCl => true | .whExclCl, .coreCl => true
-  | .whExclCl, .clause => true | .whExclCl, .phrasalCxt => true | .whExclCl, .construct => true
-  | .nsWhIntCl, .fillerHeadCxt => true | .nsWhIntCl, .headedCxt => true
-  | .nsWhIntCl, .interrogativeCl => true | .nsWhIntCl, .coreCl => true
-  | .nsWhIntCl, .clause => true | .nsWhIntCl, .phrasalCxt => true | .nsWhIntCl, .construct => true
-  | .whRelCl, .fillerHeadCxt => true | .whRelCl, .headedCxt => true
-  | .whRelCl, .relativeCl => true
-  | .whRelCl, .clause => true | .whRelCl, .phrasalCxt => true | .whRelCl, .construct => true
-  | .theCl, .fillerHeadCxt => true | .theCl, .headedCxt => true
-  | .theCl, .declarativeCl => true | .theCl, .coreCl => true
-  | .theCl, .clause => true | .theCl, .phrasalCxt => true | .theCl, .construct => true
-  -- the interrogative SAI: < aux-initial-cxt (headed dim.) AND < interrogative-cl (clausal)
-  | .interrogativeSAI, .auxInitialCxt => true | .interrogativeSAI, .headedCxt => true
-  | .interrogativeSAI, .interrogativeCl => true | .interrogativeSAI, .coreCl => true
-  | .interrogativeSAI, .clause => true | .interrogativeSAI, .phrasalCxt => true
-  | .interrogativeSAI, .construct => true
-  | a, b => decide (a = b)
+  | .phrasalCxt, .construct => true | .lexicalCxt, .construct => true
+  | .headedCxt, .phrasalCxt => true | .clause, .phrasalCxt => true
+  | .fillerHeadCxt, .headedCxt => true | .auxInitialCxt, .headedCxt => true
+  | .coreCl, .clause => true | .relativeCl, .clause => true
+  | .declarativeCl, .coreCl => true | .interrogativeCl, .coreCl => true
+  | .exclamativeCl, .coreCl => true
+  -- filler-gap constructions and the interrogative SAI: each covers its headed parent AND its clausal
+  -- type ([sag-2010] §5; whRelCl's clausal parent is relative-cl, directly under clause, Fig. 7)
+  | .topCl, .fillerHeadCxt => true | .topCl, .declarativeCl => true
+  | .whExclCl, .fillerHeadCxt => true | .whExclCl, .exclamativeCl => true
+  | .nsWhIntCl, .fillerHeadCxt => true | .nsWhIntCl, .interrogativeCl => true
+  | .whRelCl, .fillerHeadCxt => true | .whRelCl, .relativeCl => true
+  | .theCl, .fillerHeadCxt => true | .theCl, .declarativeCl => true
+  | .interrogativeSAI, .auxInitialCxt => true | .interrogativeSAI, .interrogativeCl => true
+  | _, _ => false
 
--- The transitivity check is `decide` over `FHSort³`; the proof term's nesting depth is intrinsic to
--- the hierarchy *size* (the fold over `|FHSort|³` triples), so it exceeds the default elaborator
--- recursion depth of 512 (a stack limit, not a compute budget — distinct from `maxHeartbeats`).
--- Empirically the default fails and ~1000 suffices; this scales with `|FHSort|`, so adding sorts may
--- require a bump. (An edge-list/closure encoding of `fhLe` would not help — the depth is the `decide`
--- fold, not `fhLe`'s match.)
-set_option maxRecDepth 1000 in
+/-- Specificity depth; every covers edge strictly increases it, giving antisymmetry. The filler-gap
+constructions sit at depth 6, above *both* their depth-4 headed parent and their depth-5 clausal type. -/
+def fhRank : FHSort → Nat
+  | .top => 0
+  | .cat => 1 | .semType => 1 | .invVal => 1 | .sign => 1 | .construct => 1
+  | .verbal => 2 | .nonverbal => 2 | .austinean => 2 | .question => 2 | .fact => 2 | .proposition => 2
+  | .invPlus => 2 | .invMinus => 2 | .phrasalCxt => 2 | .lexicalCxt => 2
+  | .verb => 3 | .comp => 3 | .nominal => 3 | .adj => 3 | .headedCxt => 3 | .clause => 3
+  | .noun => 4 | .prep => 4 | .fillerHeadCxt => 4 | .auxInitialCxt => 4 | .coreCl => 4 | .relativeCl => 4
+  | .declarativeCl => 5 | .interrogativeCl => 5 | .exclamativeCl => 5
+  | .topCl => 6 | .whExclCl => 6 | .nsWhIntCl => 6 | .whRelCl => 6 | .theCl => 6 | .interrogativeSAI => 6
+
 instance : PartialOrder FHSort :=
-  partialOrderOfBool fhLe (by decide) (by decide) (by decide)
+  partialOrderOfCovers (fhCovers · · = true) fhRank (by decide)
 
-instance : DecidableLE FHSort := fun a b => inferInstanceAs (Decidable (fhLe a b = true))
+instance : DecidableLE FHSort := fun a b =>
+  decidableLEOfCovers (covers := (fhCovers · · = true))
+    [.top, .cat, .verbal, .nonverbal, .verb, .comp, .nominal, .noun, .prep, .adj,
+     .semType, .austinean, .question, .fact, .proposition, .invVal, .invPlus, .invMinus, .sign,
+     .construct, .phrasalCxt, .lexicalCxt, .headedCxt, .clause, .fillerHeadCxt, .auxInitialCxt,
+     .coreCl, .relativeCl, .declarativeCl, .interrogativeCl, .exclamativeCl,
+     .topCl, .whExclCl, .nsWhIntCl, .whRelCl, .theCl, .interrogativeSAI]
+    (by decide) a b
 
 /-! ### Attributes and the signature -/
 

--- a/Linglib/Syntax/HPSG/GapAmalgamation.lean
+++ b/Linglib/Syntax/HPSG/GapAmalgamation.lean
@@ -54,19 +54,34 @@ inductive GSort
   | construct | fillerHeadCxt | islandCxt
   deriving DecidableEq, Fintype, Repr
 
-/-- Subsumption (`gLe a b` = "`a` at least as specific as `b`"), transitively closed. -/
-def gLe : GSort → GSort → Bool
-  | _, .top => true
+/-- Direct subsumption ("covers"): the `~|GSort|` **DAG edges** (a is *directly* more specific than b),
+not the transitive closure. The order is `ReflTransGen gCovers`. -/
+def gCovers : GSort → GSort → Bool
+  | .cat, .top => true
+  | .list, .top => true
+  | .sign, .top => true
+  | .construct, .top => true
   | .elist, .list => true
   | .nelist, .list => true
   | .fillerHeadCxt, .construct => true
-  | .islandCxt, .fillerHeadCxt => true | .islandCxt, .construct => true
-  | a, b => decide (a = b)
+  | .islandCxt, .fillerHeadCxt => true
+  | _, _ => false
+
+/-- Specificity depth; every covers edge strictly increases it (so `gCovers a b → gRank b < gRank a`),
+giving antisymmetry. -/
+def gRank : GSort → Nat
+  | .top => 0
+  | .cat => 1 | .list => 1 | .sign => 1 | .construct => 1
+  | .elist => 2 | .nelist => 2 | .fillerHeadCxt => 2
+  | .islandCxt => 3
 
 instance : PartialOrder GSort :=
-  partialOrderOfBool gLe (by decide) (by decide) (by decide)
+  partialOrderOfCovers (gCovers · · = true) gRank (by decide)
 
-instance : DecidableLE GSort := fun a b => inferInstanceAs (Decidable (gLe a b = true))
+instance : DecidableLE GSort := fun a b =>
+  decidableLEOfCovers (covers := (gCovers · · = true))
+    [.top, .cat, .list, .elist, .nelist, .sign, .construct, .fillerHeadCxt, .islandCxt]
+    (by decide) a b
 
 /-! ### Attributes and the signature -/
 

--- a/Linglib/Syntax/HPSG/Model.lean
+++ b/Linglib/Syntax/HPSG/Model.lean
@@ -7,14 +7,14 @@ import Linglib.Syntax.HPSG.Basic
 
 A minimal HPSG signature fragment over the RSRL substrate, the **Head Feature Principle** as a
 description, two worked head-complement models (one satisfying, one violating the HFP) showing
-the principle genuinely filters, and a deliberately partial bridge from the project's
-*computational* HPSG core (`HPSG.HeadCompRule.hfp`) to a sort-agreement description.
+the principle genuinely filters, and a faithful **structure-sharing** bridge from the project's
+*computational* HPSG core (`HPSG.HeadCompRule.hfp`) to the token-identity HFP.
 
 The HFP here works at **CAT** granularity (what `HeadCompRule.hfp` exposes), a valence-free
-stand-in for the canonical **HEAD**-value sharing ([pollard-sag-1994]). The bridge is
-partial: `HeadCompRule.hfp` is value equality, the grammar's `pathEq` HFP is token identity —
-genuinely different notions, so the bridge proves only sort-agreement (see that theorem). Only
-`hpsgSig` is `@[reducible]`; the models are plain `def`s with explicit carrier instances.
+stand-in for the canonical **HEAD**-value sharing ([pollard-sag-1994]). The bridge is subtle:
+`HeadCompRule.hfp` is value equality while the grammar's `pathEq` HFP is token identity, so the
+induced model must structure-share the category object for the principle to hold (`toInterpShared`).
+Only `hpsgSig` is `@[reducible]`; the models are plain `def`s with explicit carrier instances.
 -/
 
 namespace HPSG.RSRL
@@ -33,23 +33,34 @@ inductive HAttr where
   | CAT | HD
   deriving DecidableEq, Fintype, Repr
 
-/-- Subsumption as a boolean relation: `hleB a b` is "`a` is at least as specific as `b`". -/
-def hleB : HSort → HSort → Bool
-  | _, .top => true
-  | .word, .sign => true
+/-- Direct subsumption ("covers"): the DAG edges (a *directly* more specific than b). The order is
+`ReflTransGen hCovers`. -/
+def hCovers : HSort → HSort → Bool
+  | .sign, .top => true
+  | .category, .top => true
   | .phrase, .sign => true
+  | .word, .sign => true
   | .headedPhrase, .phrase => true
-  | .headedPhrase, .sign => true
   | .nounCat, .category => true
   | .verbCat, .category => true
   | .otherCat, .category => true
-  | a, b => decide (a = b)
+  | _, _ => false
+
+/-- Specificity depth; every covers edge strictly increases it (giving antisymmetry). -/
+def hRank : HSort → Nat
+  | .top => 0
+  | .sign => 1 | .category => 1
+  | .phrase => 2 | .word => 2 | .nounCat => 2 | .verbCat => 2 | .otherCat => 2
+  | .headedPhrase => 3
 
 /-- The sort hierarchy as a `PartialOrder` (`a ≤ b` = "`a` at least as specific as `b`"). -/
 instance : PartialOrder HSort :=
-  partialOrderOfBool hleB (by decide) (by decide) (by decide)
+  partialOrderOfCovers (hCovers · · = true) hRank (by decide)
 
-instance : DecidableLE HSort := fun a b => inferInstanceAs (Decidable (hleB a b = true))
+instance : DecidableLE HSort := fun a b =>
+  decidableLEOfCovers (covers := (hCovers · · = true))
+    [.top, .sign, .phrase, .headedPhrase, .word, .category, .nounCat, .verbCat, .otherCat]
+    (by decide) a b
 
 /-- Appropriateness: `CAT` is appropriate to every sign (value `category`); `HD` to headed
 phrases (value `sign`). Categories are attributeless. -/
@@ -146,54 +157,19 @@ example : ¬ negModel.Models hpsgGrammar := by decide
 /-- It is nonetheless well-typed: it only violates the *principle*, not the signature. -/
 example : negModel.WellTyped := by decide
 
-/-! ### A partial bridge to the computational HPSG core -/
+/-! ### A faithful structure-sharing bridge to the computational HPSG core
+
+`HPSG.HeadCompRule.hfp` is value equality (the mother and head daughter agree in category *value*),
+while the grammar's `pathEq` HFP is *token identity*. Value equality does not entail token identity, so
+a naive induced model with *distinct* category entities would satisfy only sort agreement, not the HFP.
+The faithful bridge therefore **structure-shares** the category object — the mother and head daughter
+point at one entity — which the rule's value-equality HFP (`r.hfp`) justifies. -/
 
 /-- A category species for each UD category. -/
 def catSpecies : UD.UPOS → HSort
   | .NOUN => .nounCat
   | .VERB => .verbCat
   | _ => .otherCat
-
-/-- The interpretation induced by a head-complement rule: a mother and a head daughter, each
-with its own category entity whose species is `catSpecies` of the rule's category value. -/
-def toInterp (r : HPSG.HeadCompRule) : Interpretation hpsgSig where
-  U := Ent
-  S := fun
-    | .mother => .headedPhrase
-    | .headDtr => .word
-    | .catM => catSpecies r.result.synsem.cat
-    | .catH => catSpecies r.head.synsem.cat
-  A := fun a u => match a, u with
-    | .CAT, .mother => some .catM
-    | .CAT, .headDtr => some .catH
-    | .HD, .mother => some .headDtr
-    | _, _ => none
-  R := fun e => e.elim
-
-/-- From the project's computational HFP (`HPSG.HeadCompRule.hfp`: a head-complement rule's
-mother and head daughter share their category *value*), the induced interpretation satisfies a
-category **sort-agreement** description — the head daughter's category sort is the mother's.
-The proof discharges on `r.hfp`.
-
-**This is strictly weaker than, and distinct from, the grammar's Head Feature Principle**
-(`hfp`), which is **token identity** (`pathEq`). Value equality does not entail token identity,
-so this does NOT establish `(toInterp r).Models hpsgGrammar`: `toInterp` gives the mother and
-head daughter *distinct* category entities (`catM`/`catH`), which the grammar's `pathEq` HFP
-rejects even when their sorts agree. The faithful computational↔token-identity bridge — where the
-induced model structure-shares the category object — is `toInterpShared` below. -/
-theorem toInterp_categoryAgreement_of_hfp (r : HPSG.HeadCompRule)
-    (ass : Nat → (toInterp r).U) :
-    (toInterp r).satisfies ass .mother
-      (.sortAssign (.path [.HD, .CAT]) (catSpecies r.result.synsem.cat)) := by
-  show catSpecies r.head.synsem.cat ≤ catSpecies r.result.synsem.cat
-  rw [r.hfp]
-
-/-! ### A faithful structure-sharing bridge
-
-`toInterp` mapped a head-complement rule to a model with *distinct* category entities, so the
-token-identity HFP could not hold (only sort agreement). `toInterpShared` instead **structure-shares**
-the category object — the mother and head daughter point at one entity — so the grammar's `pathEq` HFP
-is realized, and that sharing is justified by the rule's value-equality HFP (`r.hfp`). -/
 
 /-- A category species is never a phrase sort, so it can never trigger the headed-phrase HFP. -/
 private theorem catSpecies_not_headedPhrase (c : UD.UPOS) :
@@ -202,7 +178,7 @@ private theorem catSpecies_not_headedPhrase (c : UD.UPOS) :
 
 /-- The interpretation induced by a head-complement rule that **structure-shares** the category
 object: the mother and head daughter both point at one category entity (`catM`, species from the head
-daughter). Unlike `toInterp`'s distinct `catM`/`catH`, this realizes the token-identity HFP. -/
+daughter), realizing the token-identity HFP. -/
 def toInterpShared (r : HPSG.HeadCompRule) : Interpretation hpsgSig where
   U := Ent
   S := fun
@@ -219,7 +195,7 @@ def toInterpShared (r : HPSG.HeadCompRule) : Interpretation hpsgSig where
 
 /-- **The faithful bridge.** The structure-sharing induced model satisfies the grammar's
 token-identity Head Feature Principle — the mother and head daughter genuinely share one category
-object, not merely agree in sort — which `toInterp` could not establish. -/
+object, not merely agree in sort. -/
 theorem toInterpShared_models_hfp (r : HPSG.HeadCompRule) :
     (toInterpShared r).Models hpsgGrammar := by
   intro u d hd
@@ -234,8 +210,7 @@ theorem toInterpShared_models_hfp (r : HPSG.HeadCompRule) :
 
 /-- The structure-sharing is *justified* by the computational value-equality HFP (`r.hfp`): the
 mother's and head daughter's category species coincide, so collapsing them to one object loses no
-information. Where `toInterp` recovers only sort agreement (`toInterp_categoryAgreement_of_hfp`), this
-recovers genuine token identity. -/
+information — recovering genuine token identity from value equality. -/
 theorem toInterpShared_faithful_of_hfp (r : HPSG.HeadCompRule) :
     catSpecies r.result.synsem.cat = catSpecies r.head.synsem.cat := by
   rw [r.hfp]

--- a/Linglib/Syntax/HPSG/Signature.lean
+++ b/Linglib/Syntax/HPSG/Signature.lean
@@ -1,5 +1,6 @@
 import Mathlib.Order.Basic
 import Mathlib.Order.Max
+import Linglib.Core.Relation.ReflTransGen
 
 /-!
 # RSRL signatures
@@ -25,6 +26,54 @@ on a finite type). Reducible so `≤` unfolds to `leB · · = true` in instance 
   le_refl := le_refl
   le_trans := le_trans
   le_antisymm := le_antisymm
+
+/-! ### Structural subsumption order from a covers relation
+
+`partialOrderOfBool` discharges transitivity by `decide`, which is `|α|³` and exceeds the elaborator
+recursion depth on a large sort hierarchy. The mathlib-idiomatic alternative is to define `≤` as the
+**reflexive-transitive closure** of a *direct-subsumption* (`covers`) relation, so transitivity is
+structural (`ReflTransGen.trans`) and never a proof obligation — and antisymmetry follows from a `rank`
+function every edge strictly decreases. The author then declares the `~|α|`-edge DAG and a depth
+function, not the transitively-closed relation. -/
+
+private theorem rankLe_of_reflTransGen {α : Type u} {covers : α → α → Prop} {rank : α → ℕ}
+    (hrank : ∀ a b, covers a b → rank b < rank a)
+    {a b : α} (hab : Relation.ReflTransGen covers a b) : rank b ≤ rank a := by
+  induction hab with
+  | refl => exact le_refl _
+  | tail _ hr ih => exact le_of_lt (lt_of_lt_of_le (hrank _ _ hr) ih)
+
+private theorem eq_of_reflTransGen_rank_eq {α : Type u} {covers : α → α → Prop} {rank : α → ℕ}
+    (hrank : ∀ a b, covers a b → rank b < rank a)
+    {a b : α} (hab : Relation.ReflTransGen covers a b) (h : rank a = rank b) : a = b := by
+  cases hab with
+  | refl => rfl
+  | tail hac hcb =>
+    exfalso
+    have h1 := rankLe_of_reflTransGen hrank hac
+    have h2 := hrank _ _ hcb
+    omega
+
+/-- Build a `PartialOrder` from a **direct-subsumption ("covers") relation** and a `rank` that every
+edge strictly decreases. `≤` is `ReflTransGen covers`; transitivity is structural and antisymmetry
+follows from `rank` — no `decide` over the order, so it scales where `partialOrderOfBool` does not. -/
+@[reducible] def partialOrderOfCovers {α : Type u} (covers : α → α → Prop) (rank : α → ℕ)
+    (hrank : ∀ a b, covers a b → rank b < rank a) : PartialOrder α where
+  le a b := Relation.ReflTransGen covers a b
+  le_refl _ := Relation.ReflTransGen.refl
+  le_trans _ _ _ := Relation.ReflTransGen.trans
+  le_antisymm _ _ hab hba :=
+    eq_of_reflTransGen_rank_eq hrank hab
+      (Nat.le_antisymm (rankLe_of_reflTransGen hrank hba) (rankLe_of_reflTransGen hrank hab))
+
+/-- `Decidable (a ≤ b)` for `partialOrderOfCovers`, via finite reachability over an explicit list of
+all sorts (`Core.Relation.ReflTransGen.decidable_of_finite` — mathlib has no `Decidable (ReflTransGen
+…)`; the **`List`**-based variant kernel-reduces under `decide` where the `Finset`/`Quotient` one does
+not). `allSorts` need only contain every `covers`-target; pass the sort enumeration. -/
+@[reducible] def decidableLEOfCovers {α : Type u} [DecidableEq α] {covers : α → α → Prop}
+    [DecidableRel covers] (allSorts : List α) (complete : ∀ a b, covers a b → b ∈ allSorts)
+    (a b : α) : Decidable (Relation.ReflTransGen covers a b) :=
+  Relation.ReflTransGen.decidable_of_finite allSorts complete a b
 
 /-- An RSRL signature ([richter-2000], Def. 47) over a sort hierarchy `Srt`. -/
 structure Signature (Srt : Type u) [PartialOrder Srt] where

--- a/Linglib/Syntax/HPSG/Signature.lean
+++ b/Linglib/Syntax/HPSG/Signature.lean
@@ -16,25 +16,13 @@ namespace HPSG.RSRL
 
 universe u
 
-/-- Build a `PartialOrder` from a decidable boolean order whose laws hold (typically `by decide`
-on a finite type). Reducible so `≤` unfolds to `leB · · = true` in instance search. -/
-@[reducible] def partialOrderOfBool {α : Type u} (leB : α → α → Bool)
-    (le_refl : ∀ a, leB a a = true)
-    (le_trans : ∀ a b c, leB a b = true → leB b c = true → leB a c = true)
-    (le_antisymm : ∀ a b, leB a b = true → leB b a = true → a = b) : PartialOrder α where
-  le a b := leB a b = true
-  le_refl := le_refl
-  le_trans := le_trans
-  le_antisymm := le_antisymm
-
 /-! ### Structural subsumption order from a covers relation
 
-`partialOrderOfBool` discharges transitivity by `decide`, which is `|α|³` and exceeds the elaborator
-recursion depth on a large sort hierarchy. The mathlib-idiomatic alternative is to define `≤` as the
-**reflexive-transitive closure** of a *direct-subsumption* (`covers`) relation, so transitivity is
-structural (`ReflTransGen.trans`) and never a proof obligation — and antisymmetry follows from a `rank`
-function every edge strictly decreases. The author then declares the `~|α|`-edge DAG and a depth
-function, not the transitively-closed relation. -/
+The sort hierarchy's `≤` is the **reflexive-transitive closure** of a *direct-subsumption* (`covers`)
+relation, so transitivity is structural (`ReflTransGen.trans`) and never a proof obligation — and, since
+the order is not decided by a Bool predicate, there is no `|α|³` transitivity `decide` to exceed the
+elaborator recursion depth on a large hierarchy. Antisymmetry follows from a `rank` function every edge
+strictly decreases; the author declares the `~|α|`-edge DAG and a depth function, not the closure. -/
 
 private theorem rankLe_of_reflTransGen {α : Type u} {covers : α → α → Prop} {rank : α → ℕ}
     (hrank : ∀ a b, covers a b → rank b < rank a)
@@ -56,7 +44,7 @@ private theorem eq_of_reflTransGen_rank_eq {α : Type u} {covers : α → α →
 
 /-- Build a `PartialOrder` from a **direct-subsumption ("covers") relation** and a `rank` that every
 edge strictly decreases. `≤` is `ReflTransGen covers`; transitivity is structural and antisymmetry
-follows from `rank` — no `decide` over the order, so it scales where `partialOrderOfBool` does not. -/
+follows from `rank` — no `decide` over the order, so it scales to large hierarchies. -/
 @[reducible] def partialOrderOfCovers {α : Type u} (covers : α → α → Prop) (rank : α → ℕ)
     (hrank : ∀ a b, covers a b → rank b < rank a) : PartialOrder α where
   le a b := Relation.ReflTransGen covers a b


### PR DESCRIPTION
Replaces the `decide`-based subsumption order with the mathlib-idiomatic **structural** one across the whole RSRL substrate, dissolving the `|Sort|³` recursion-depth wall.

- **`Signature.lean`**: adds `partialOrderOfCovers` (`≤ := ReflTransGen covers`; `le_trans = ReflTransGen.trans`, antisymmetry from a `rank`) + `decidableLEOfCovers` (List-based reachability, which kernel-reduces under `decide`). **Retires `partialOrderOfBool`** (the old `|α|³`-transitivity API) — now unused.
- **All four signatures migrated** to the covers DAG + rank: `fhSig` (Construction, 35 sorts — **`maxRecDepth 1000` deleted**, builds faster), `gSig` (GapAmalgamation), `hpsgSig` (Model), `bindingSig` (Binding). Each filler-gap construction covers its two parents (headed + clausal).
- Also cuts the subsumed `toInterp` bridge from Model.lean (folds #702), keeping the faithful `toInterpShared`.

`Models`/`approp`/cross-classification still `decide`, axiom-clean. (mathlib/Batteries/core have no `Decidable (ReflTransGen …)` for a directed relation, so the local `Core/Relation/ReflTransGen` is a genuine gap-filler.) This unblocks the canonical comprehensive signature — no longer `decide`-scaling-bound.