### PR TITLE
feat(Studies/SagWasowBender2003): ground binding in RSRL Principles A/B

### DIFF
--- a/Linglib/Studies/SagWasowBender2003.lean
+++ b/Linglib/Studies/SagWasowBender2003.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.HPSG.Coreference
+import Linglib.Syntax.HPSG.Binding
 import Linglib.Syntax.HPSG.HeadFiller
 import Linglib.Syntax.HPSG.RelativeClauses
 import Linglib.Syntax.HPSG.GapAmalgamation
@@ -108,6 +109,29 @@ theorem reflexive_pairs_captured :
 theorem reciprocal_plural_antecedent :
     grammaticalForCoreference [they, see, eachOther] = true ∧
     grammaticalForCoreference [john, sees, eachOther] = false := by
+  decide
+
+/-! #### Model-theoretic grounding (RSRL Principles A/B)
+
+The ARG-ST outranking judgments above are the parser-facing shadow of the **model-theoretic** Binding
+Theory (`Syntax/HPSG/Binding`): Principles A and B as RSRL descriptions (`Desc`) over a sort hierarchy
+of anaphors/pronouns/indices with a local-o-command relation. The two formalizations — computational
+ARG-ST outranking here, model-theoretic `Models` there — agree on the diagnostic cases. -/
+
+/-- The reflexive (Principle A) judgments are grounded in the RSRL model theory: the computational
+ARG-ST account (a coindexed reflexive object is bound, a reflexive subject is not) and the RSRL
+Principle-A model (a coindexed anaphor satisfies the grammar; a disjoint anaphor violates it) agree. -/
+theorem reflexive_binding_grounded_in_rsrl :
+    grammaticalForCoreference [john, sees, himself] = true ∧
+    grammaticalForCoreference [himself, sees, john] = false ∧
+    (_root_.HPSG.RSRL.Binding.clause .ana .i1).Models _root_.HPSG.RSRL.Binding.bindingGrammar ∧
+    ¬ (_root_.HPSG.RSRL.Binding.clause .ana .i2).Models [_root_.HPSG.RSRL.Binding.principleA] := by
+  decide
+
+/-- Principle B grounded in RSRL: a coindexed personal pronoun violates the model-theoretic
+Principle B (a pronoun must be locally o-free), the counterpart of the ARG-ST disjoint-reference data. -/
+theorem pronoun_binding_grounded_in_rsrl :
+    ¬ (_root_.HPSG.RSRL.Binding.clause .ppro .i1).Models [_root_.HPSG.RSRL.Binding.principleB] := by
   decide
 
 end Binding


### PR DESCRIPTION
Phase 3 (binding bridge): grounds the study's ARG-ST outranking binding judgments in the **model-theoretic** Binding Theory (`Syntax/HPSG/Binding`, Principles A/B as RSRL `Desc`s).

Adds `reflexive_binding_grounded_in_rsrl` and `pronoun_binding_grounded_in_rsrl` — the computational ARG-ST account (coindexed reflexive bound, reflexive subject not; coindexed pronoun disjoint) and the RSRL `Models` of Principles A/B agree on the diagnostic cases. The computational judgments are the parser-facing shadow of the model theory.

**This gives `Syntax/HPSG/Binding.lean` its first external consumer** — closing the last zero-consumer RSRL file, fully reversing the original audit's complaint that the RSRL substrate had rigor but no consumers. Axiom-clean.