### PR TITLE
feat(Syntax/HPSG): model weak islands in RSRL gap-list; migrate SWB2003 islands

### DIFF
--- a/Linglib/Studies/SagWasowBender2003.lean
+++ b/Linglib/Studies/SagWasowBender2003.lean
@@ -240,29 +240,23 @@ theorem gap_removes_complement :
       (fun p => p.1.synsem.val.comps.isEmpty && p.2.gaps == [.NOUN]) = some true := by
   decide
 
-/-- End-to-end: extraction is licensed iff not blocked by an island. -/
-theorem extraction_and_island_complementary :
-    let free : ExtractionConfig := ⟨.PRON, .NOUN, .unrestricted⟩  -- no island → licensed
-    let abs  : ExtractionConfig := ⟨.PRON, .NOUN, .noGap⟩         -- absolute island → blocked
-    let weakNP : ExtractionConfig := ⟨.PRON, .NOUN, .npOnly⟩      -- weak island + NP → licensed
-    let weakPP : ExtractionConfig := ⟨.ADP, .ADP, .npOnly⟩        -- weak island + PP → blocked
-    extractionLicensed free = true ∧
-    extractionLicensed abs = false ∧
-    extractionLicensed weakNP = true ∧
-    extractionLicensed weakPP = false := by
-  decide
+/-! #### Model-theoretic grounding (RSRL) — the full island taxonomy
 
-/-! #### Model-theoretic grounding (RSRL)
+The computational `extractionLicensed`/`GapRestriction` predicates above are the parser-facing shadow
+of the **model-theoretic** RSRL list-valued `GAP` (`Syntax/HPSG/GapAmalgamation`), where the whole
+island taxonomy is *derived* from gap amalgamation ([sag-2010] (67); after [bouma-malouf-sag-2001]),
+not stipulated as Subjacency: a dependency penetrates a domain iff its `GAP` survives amalgamation. -/
 
-The computational island-blocking above (`extractionLicensed = false` for an island-restricted
-configuration) is the parser-facing shadow of a **model-theoretic** result on the RSRL list-valued
-`GAP` (`Syntax/HPSG/GapAmalgamation`): a second gap cannot penetrate a `[GAP ⟨⟩]` construct, derived
-from amalgamation ([sag-2010] (67)), not stipulated as Subjacency. -/
-
-/-- The absolute-island blocking is grounded in the RSRL model theory: an island construct with a
-second un-bound gap is rejected by the gap-amalgamation grammar (`GapAmalgamation.islandTwoGap`). -/
-theorem absolute_island_rsrl_grounded :
-    ¬ HPSG.GapAmalgamation.islandTwoGap.Models HPSG.GapAmalgamation.gGrammar := by decide
+/-- The island taxonomy, grounded in the RSRL model theory — the authoritative statement of which the
+computational `extractionLicensed` cases above are the coarse shadow. A free filler-head construct
+licenses extraction; an absolute island (`[GAP ⟨⟩]`) blocks a second gap; a weak island lets an NP gap
+pass but blocks a PP gap — the `unrestricted`/`noGap`/`npOnly` cases of `GapRestriction`, each a
+`Models` fact over the gap-amalgamation grammar. -/
+theorem islands_rsrl_grounded :
+    HPSG.GapAmalgamation.goodTwoGap.Models HPSG.GapAmalgamation.gGrammar ∧
+    ¬ HPSG.GapAmalgamation.islandTwoGap.Models HPSG.GapAmalgamation.gGrammar ∧
+    HPSG.GapAmalgamation.weakIslandNPGap.Models HPSG.GapAmalgamation.gGrammar ∧
+    ¬ HPSG.GapAmalgamation.weakIslandPPGap.Models HPSG.GapAmalgamation.gGrammar := by decide
 
 end Extraction
 

--- a/Linglib/Syntax/HPSG/GapAmalgamation.lean
+++ b/Linglib/Syntax/HPSG/GapAmalgamation.lean
@@ -44,14 +44,15 @@ open HPSG.RSRL
 
 /-! ### Sorts: categories, `GAP` lists, signs, and the filler-head / island constructs -/
 
-/-- Sorts: a category, the `GAP`-list sorts (`list > {elist, nelist}`), `sign`, and the construct
-types (`island-cxt < filler-head-cxt < construct`). -/
+/-- Sorts: categories (`cat > {nominal-cat, prep-cat}`, the NP/PP distinction weak islands are
+sensitive to), the `GAP`-list sorts (`list > {elist, nelist}`), `sign`, and the construct types
+(`{island-cxt, weak-island-cxt} < filler-head-cxt < construct`). -/
 inductive GSort
   | top
-  | cat
+  | cat | nominalCat | prepCat
   | list | elist | nelist
   | sign
-  | construct | fillerHeadCxt | islandCxt
+  | construct | fillerHeadCxt | islandCxt | weakIslandCxt
   deriving DecidableEq, Fintype, Repr
 
 /-- Direct subsumption ("covers"): the `~|GSort|` **DAG edges** (a is *directly* more specific than b),
@@ -61,10 +62,13 @@ def gCovers : GSort → GSort → Bool
   | .list, .top => true
   | .sign, .top => true
   | .construct, .top => true
+  | .nominalCat, .cat => true
+  | .prepCat, .cat => true
   | .elist, .list => true
   | .nelist, .list => true
   | .fillerHeadCxt, .construct => true
   | .islandCxt, .fillerHeadCxt => true
+  | .weakIslandCxt, .fillerHeadCxt => true
   | _, _ => false
 
 /-- Specificity depth; every covers edge strictly increases it (so `gCovers a b → gRank b < gRank a`),
@@ -73,14 +77,16 @@ def gRank : GSort → Nat
   | .top => 0
   | .cat => 1 | .list => 1 | .sign => 1 | .construct => 1
   | .elist => 2 | .nelist => 2 | .fillerHeadCxt => 2
-  | .islandCxt => 3
+  | .nominalCat => 2 | .prepCat => 2
+  | .islandCxt => 3 | .weakIslandCxt => 3
 
 instance : PartialOrder GSort :=
   partialOrderOfCovers (gCovers · · = true) gRank (by decide)
 
 instance : DecidableLE GSort := fun a b =>
   decidableLEOfCovers (covers := (gCovers · · = true))
-    [.top, .cat, .list, .elist, .nelist, .sign, .construct, .fillerHeadCxt, .islandCxt]
+    [.top, .cat, .nominalCat, .prepCat, .list, .elist, .nelist, .sign,
+     .construct, .fillerHeadCxt, .islandCxt, .weakIslandCxt]
     (by decide) a b
 
 /-! ### Attributes and the signature -/
@@ -104,6 +110,9 @@ def gApprop : GSort → GAttr → Option GSort
   | .islandCxt, .MTR => some .sign
   | .islandCxt, .HDDTR => some .sign
   | .islandCxt, .FILLERDTR => some .sign
+  | .weakIslandCxt, .MTR => some .sign
+  | .weakIslandCxt, .HDDTR => some .sign
+  | .weakIslandCxt, .FILLERDTR => some .sign
   | .sign, .CAT => some .cat
   | .sign, .GAP => some .list
   | .nelist, .FIRST => some .cat
@@ -137,8 +146,18 @@ dependency penetrates beyond the one its filler binds. -/
 def islandPrinciple : Desc gSig :=
   .imp (.sortAssign .colon .islandCxt) (.sortAssign (.path [.MTR, .GAP]) .elist)
 
-/-- The grammar: amalgamation and the island constraint. -/
-def gGrammar : Grammar gSig := [amalgamationPrinciple, islandPrinciple]
+/-- **Weak-island constraint**: a weak island is *selectively* permeable — an NP dependency passes
+through, a PP (more generally, non-nominal) dependency does not ([sag-wasow-bender-2003] Ch. 15 on weak
+islands; the `npOnly` case of the computational `GapRestriction`). Stated on the *passing* gap: if a
+weak-island construct's mother `GAP|FIRST` is a `prep-cat`, the mother must be `[GAP ⟨⟩]` — so a PP
+cannot penetrate, while a `nominal-cat` mother gap is unconstrained and passes. -/
+def weakIslandPrinciple : Desc gSig :=
+  .imp (.and (.sortAssign .colon .weakIslandCxt)
+             (.sortAssign (.path [.MTR, .GAP, .FIRST]) .prepCat))
+    (.sortAssign (.path [.MTR, .GAP]) .elist)
+
+/-- The grammar: amalgamation, the absolute-island and the weak-island constraints. -/
+def gGrammar : Grammar gSig := [amalgamationPrinciple, islandPrinciple, weakIslandPrinciple]
 
 /-! ### Worked constructs
 
@@ -229,5 +248,40 @@ instance : Fintype islandTwoGap.U := inferInstanceAs (Fintype GEnt)
 instance : DecidableEq islandTwoGap.U := inferInstanceAs (DecidableEq GEnt)
 
 example : ¬ islandTwoGap.Models gGrammar := by decide
+
+/-! ### Weak islands: the NP/PP asymmetry
+
+A *weak* island (`weak-island-cxt`) is selectively permeable. The constructs below reuse the two-gap
+amalgamation geometry of `goodTwoGap` — the filler binds the first gap, the second passes up — but the
+passing gap's category decides whether it survives the weak-island constraint. -/
+
+/-- **NP extraction through a weak island is licensed.** A weak-island construct whose passing
+(second) gap is a `nominal-cat` amalgamates a non-empty mother `GAP ⟨NP⟩`; the weak-island antecedent
+(`prep-cat` mother gap) is false, so the constraint is vacuous and the structure is well-formed. -/
+def weakIslandNPGap : Interpretation gSig where
+  U := GEnt
+  S := fun u => match u with | .cxt => .weakIslandCxt | .c2 => .nominalCat | u => baseS u
+  A := goodTwoGap.A
+  R := fun e => e.elim
+
+instance : Fintype weakIslandNPGap.U := inferInstanceAs (Fintype GEnt)
+instance : DecidableEq weakIslandNPGap.U := inferInstanceAs (DecidableEq GEnt)
+
+example : weakIslandNPGap.Models gGrammar := by decide
+
+/-- **PP extraction through a weak island is blocked.** The same geometry with a `prep-cat` passing
+gap makes the mother `GAP ⟨PP⟩`; the weak-island constraint then forces `[GAP ⟨⟩]`, contradicting the
+non-empty mother gap — so the construct is rejected. The NP/PP asymmetry, derived from the constraint,
+not stipulated. -/
+def weakIslandPPGap : Interpretation gSig where
+  U := GEnt
+  S := fun u => match u with | .cxt => .weakIslandCxt | .c2 => .prepCat | u => baseS u
+  A := goodTwoGap.A
+  R := fun e => e.elim
+
+instance : Fintype weakIslandPPGap.U := inferInstanceAs (Fintype GEnt)
+instance : DecidableEq weakIslandPPGap.U := inferInstanceAs (DecidableEq GEnt)
+
+example : ¬ weakIslandPPGap.Models gGrammar := by decide
 
 end HPSG.GapAmalgamation


### PR DESCRIPTION
Completes the RSRL gap-list's island taxonomy and migrates the study's island claim onto it — the consolidated model-theoretic API now covers the full `GapRestriction` range.

- **`GapAmalgamation`**: adds the **weak island** (`weak-island-cxt`) with the NP/PP asymmetry. New category sorts `nominal-cat`/`prep-cat`; `weakIslandPrinciple` blocks a *passing* PP gap (`MTR|GAP|FIRST` a `prep-cat` ⇒ `[GAP ⟨⟩]`) while an NP gap passes. Worked models `weakIslandNPGap.Models gGrammar` (passes) and `¬ weakIslandPPGap.Models gGrammar` (blocked) — the asymmetry *derived* from the constraint. With `fillerHeadCxt` (unrestricted) and `islandCxt` (absolute), RSRL now models all three `GapRestriction` cases.
- **`SagWasowBender2003`**: migrates the island claim onto it. The computational summary `extraction_and_island_complementary` and the partial `absolute_island_rsrl_grounded` are replaced by one comprehensive `islands_rsrl_grounded` (unrestricted/absolute/weak-NP/weak-PP as `Models` facts) — the RSRL is now the authoritative statement, the computational `extractionLicensed` its coarse shadow.

All `decide`, axiom-clean.