### PR TITLE
feat(Studies/Sag2010): ground construction islands in RSRL gap mechanism

### DIFF
--- a/Linglib/Studies/Sag2010.lean
+++ b/Linglib/Studies/Sag2010.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Syntax.HPSG.HeadFiller
 import Linglib.Syntax.HPSG.Construction
+import Linglib.Syntax.HPSG.GapAmalgamation
 import Linglib.Studies.Ross1967
 import Linglib.Studies.SagWasowBender2003
 import Linglib.Features.ClauseForm
@@ -405,6 +406,15 @@ theorem islandConstructions_eq :
 [sag-2010]'s construction-typed islands classify *whole construction types*,
 orthogonal to [ross-1967]'s configurational island *domains*. The
 chronologically-later account (Sag) draws the comparison. -/
+
+/-- The construction-typed `IsIsland` verdicts are grounded in the same RSRL gap mechanism as the SLASH
+analysis: the model-theoretic content of an absolute island is `[GAP ⟨⟩]` plus amalgamation blocking a
+second gap. Derived from [sag-wasow-bender-2003]'s authoritative `islands_rsrl_grounded`
+(`Syntax/HPSG/GapAmalgamation`), not re-stated — the construction-tag level and the gap-list mechanism
+agree. -/
+theorem island_grounded_in_rsrl :
+    ¬ HPSG.GapAmalgamation.islandTwoGap.Models HPSG.GapAmalgamation.gGrammar :=
+  SagWasowBender2003.islands_rsrl_grounded.2.1
 
 /-- Agreement with [sag-wasow-bender-2003]: the topicalization island is the same
 datum in two analyses — Sag's `[GAP ⟨⟩]` construction and the HPSG SLASH model


### PR DESCRIPTION
Migrates Sag2010 onto the unified RSRL gap API. Its construction-typed `IsIsland` verdicts (topicalization/wh-exclamative carry `[GAP ⟨⟩]`) are now grounded in [sag-wasow-bender-2003]'s authoritative `islands_rsrl_grounded` (the gap-amalgamation mechanism), **deriving** the absolute-island fact rather than re-stating it — `island_grounded_in_rsrl := …islands_rsrl_grounded.2.1`.

Note: fully *retiring* the computational `GapRestriction` tag would require the canonical fhSig+gSig signature (so a construction carries its island status in one model — `topCl` lives in `fhSig`, `islandCxt` in `gSig`); that's the next, larger build, now unblocked by the structural order. Axiom-clean.