### PR TITLE
feat(Syntax/HPSG): retire GapRestriction, islands as RSRL Models facts

### DIFF
--- a/Linglib/Studies/LuPanDegen2025.lean
+++ b/Linglib/Studies/LuPanDegen2025.lean
@@ -813,7 +813,7 @@ grammar-based islands (those with `[GAP ⟨⟩]` on the mother).
 effects. [lu-pan-degen-2025]'s MoS islands are a third mechanism.
 Together the three accounts cover disjoint islands. -/
 
-open Sag2010 (FGClauseType fgParams islandConstructions)
+open Sag2010 (FGClauseType islandConstructions)
 
 /-- [sag-2010]'s two island constructions are a proper subset of all
 F-G types. The non-island types (interrogative, relative, the-clause)
@@ -827,9 +827,9 @@ are disjoint from [hofmeister-sag-2010]'s processing-based islands
 discourse-based islands (MoS). The three accounts cover different cases
 under different mechanisms. -/
 theorem complementary_coverage :
-    (fgParams .topicalized).IsIsland ∧
-    (fgParams .whExclamative).IsIsland ∧
-    mosIslandSources = [.discourse] := ⟨rfl, rfl, rfl⟩
+    FGClauseType.topicalized.IsIsland ∧
+    FGClauseType.whExclamative.IsIsland ∧
+    mosIslandSources = [.discourse] := ⟨by decide, by decide, rfl⟩
 
 /-- MoS islands are discourse-sourced and so distinct from the syntactic
 baseline assumed for traditional islands. -/

--- a/Linglib/Studies/Sag2010.lean
+++ b/Linglib/Studies/Sag2010.lean
@@ -47,8 +47,9 @@ would live in the HPSG theory layer.
 
 ## Bridges (true by construction, not by prose)
 
-* islands reground on `HPSG.GapRestriction`: islandhood is derived from
-  `IsAbsoluteIsland` (`[GAP ⟨⟩]`), not a boolean stipulation;
+* islands reground on the canonical RSRL signature (`Syntax/HPSG/Construction`):
+  islandhood is a `Models` fact — a topicalized/exclamative construct rejects a
+  second, undischarged gap (`[GAP ⟨⟩]` plus amalgamation), not a boolean stipulation;
 * agreement with [sag-wasow-bender-2003]'s SLASH model on the topicalization
   island;
 * divergence from [ross-1967]'s configurational Complex-NP Constraint on
@@ -59,7 +60,6 @@ would live in the HPSG theory layer.
 
 namespace Sag2010
 
-open HPSG (GapRestriction)
 open Features (ClauseForm)
 
 /-! ### Syntactic categories -/
@@ -164,9 +164,11 @@ inductive Composition
 /-! ### The construction bundle -/
 
 /-- The constraints a filler-gap construction imposes, indexed by [sag-2010]'s
-seven parameters of variation ((6)). Models the descriptive parameter table of
-§2.1; `clauseType` records the cross-classifying supertype from which the
-semantic type is inherited. -/
+parameters of variation ((6)). Models the descriptive parameter table of §2.1;
+`clauseType` records the cross-classifying supertype from which the semantic type
+is inherited. The (6f) island parameter is *not* a field here — islandhood is a
+`Models` fact about the construction's RSRL sort (`FGClauseType.IsIsland`), derived
+from the `[GAP ⟨⟩]` principle plus amalgamation, not stored as a tag. -/
 structure FGConstruction where
   /-- (6b) Allowed syntactic categories of the filler daughter ((25)). -/
   fillerCategories : List SynCat
@@ -178,9 +180,6 @@ structure FGConstruction where
   headInversion : InversionPolicy
   /-- (6d) Whether the head daughter may be infinitival ((29)). -/
   headFiniteness : Finiteness
-  /-- (6f) Island status as an HPSG GAP restriction: `[GAP ⟨⟩]` (`noGap`) is an
-  absolute extraction island ((67), (73), (74)). -/
-  gapRestriction : GapRestriction
   /-- (6e) The cross-classifying clause-type supertype, which determines the
   semantic type ((30)). -/
   clauseType : ClauseType
@@ -193,14 +192,6 @@ structure FGConstruction where
 /-- The semantic type of a construction, inherited from its clause supertype. -/
 def FGConstruction.semType (k : FGConstruction) : SemType :=
   k.clauseType.semType
-
-/-- A construction is an absolute extraction island iff its mother carries
-`[GAP ⟨⟩]`. Derived from the HPSG `GapRestriction`, not stipulated. -/
-def FGConstruction.IsIsland (k : FGConstruction) : Prop :=
-  k.gapRestriction.IsAbsoluteIsland
-
-instance : DecidablePred FGConstruction.IsIsland :=
-  fun k => inferInstanceAs (Decidable k.gapRestriction.IsAbsoluteIsland)
 
 /-! ### The five constructions -/
 
@@ -226,7 +217,6 @@ def fgParams : FGClauseType → FGConstruction
         headCategory := .s                            -- (27a)
         headInversion := .iffIndependent              -- (28a), (84): matrix inverts, embedded does not
         headFiniteness := .infinitivalPossible        -- (29b)
-        gapRestriction := .unrestricted               -- §5.3: not an extraction island
         clauseType := .interrogativeCl                -- (30a) → question
         ic := .unconstrained                          -- (78): matrix or embedded
         composition := .clausal }
@@ -236,7 +226,6 @@ def fgParams : FGClauseType → FGConstruction
         headCategory := .s
         headInversion := .prohibited                  -- (28b)
         headFiniteness := .finiteOnly                 -- (29a)
-        gapRestriction := .noGap                      -- (74): absolute island
         clauseType := .exclamativeCl                  -- (30c) → fact
         ic := .unconstrained                          -- (71): independent or embedded
         composition := .clausal }
@@ -246,7 +235,6 @@ def fgParams : FGClauseType → FGConstruction
         headCategory := .s
         headInversion := .prohibited                  -- (28b)
         headFiniteness := .finiteOnly                 -- (29a)
-        gapRestriction := .noGap                      -- (67): absolute island
         clauseType := .declarativeCl                  -- (30e) → austinean
         ic := .mainClause                             -- (61): [IC +], embeddable in MCP contexts
         composition := .clausal }
@@ -256,8 +244,6 @@ def fgParams : FGClauseType → FGConstruction
         headCategory := .s
         headInversion := .prohibited                  -- (28b)
         headFiniteness := .infinitivalPossible        -- (29b), (97)
-        gapRestriction := .unrestricted               -- no constructional [GAP ⟨⟩]; CNPC effect is
-                                                       -- processing, not grammar ([hofmeister-sag-2010])
         clauseType := .relativeCl                     -- (30b) → proposition
         ic := .embeddedOnly                           -- (91): [IC −]
         composition := .cnpModifier }                 -- (90): λPλx[…] modifies a CNP
@@ -267,7 +253,6 @@ def fgParams : FGClauseType → FGConstruction
         headCategory := .sOrCP                         -- (27b): S or CP
         headInversion := .optional                    -- (28c)
         headFiniteness := .finiteOnly                 -- (29a)
-        gapRestriction := .unrestricted               -- not an island
         clauseType := .declarativeCl                  -- (30d) → austinean
         ic := .unconstrained
         composition := .clausal }
@@ -366,34 +351,61 @@ theorem inversionPolicies :
       = [.iffIndependent, .prohibited, .prohibited, .prohibited, .optional] := by
   decide
 
-/-! ### Islands as GAP restrictions (bridge to `HPSG.GapRestriction`)
+/-! ### Islands as a property of the construction type ([sag-2010] §5.1)
 
 [sag-2010] argues islandhood is a construction-specific `[GAP ⟨⟩]` restriction,
-not universal Subjacency. The island parameter regrounds on the HPSG
-`GapRestriction`, so islandhood is *derived* from `IsAbsoluteIsland`. -/
+not universal Subjacency. Here islandhood is a **`Models` fact** about the
+construction's sort in the canonical RSRL signature (`Syntax/HPSG/Construction`):
+a construction is an absolute island iff its construct cannot host a second,
+undischarged gap — the `[GAP ⟨⟩]` principle plus amalgamation reject it. -/
 
-/-- Topicalization is an absolute island because its mother carries `[GAP ⟨⟩]`
-((67)) — a theorem about the HPSG `GapRestriction`, not a stipulation. -/
-theorem topicalized_isIsland : (fgParams .topicalized).IsIsland := rfl
+/-- A filler-gap construction is an **absolute extraction island** iff its
+construct cannot host a second, undischarged gap — a `Models` fact about the RSRL
+sort ((67), (73), (74)), derived from the `[GAP ⟨⟩]` principle plus amalgamation,
+not stored as a tag. Each case is `¬ Models` of the construction's two-gap RSRL
+worked model (`Syntax/HPSG/Construction`): an island rejects the second gap, a
+non-island admits it. -/
+def FGClauseType.IsIsland : FGClauseType → Prop
+  | .whInterrogative => ¬ HPSG.Construction.nsWhIntSecondGap.Models HPSG.Construction.fhGrammar
+  | .whExclamative   => ¬ HPSG.Construction.whExclSecondGap.Models HPSG.Construction.fhGrammar
+  | .topicalized     => ¬ HPSG.Construction.topClSecondGap.Models HPSG.Construction.fhGrammar
+  | .whRelative      => ¬ HPSG.Construction.whRelSecondGap.Models HPSG.Construction.fhGrammar
+  | .theClause       => ¬ HPSG.Construction.theClSecondGap.Models HPSG.Construction.fhGrammar
+
+instance : DecidablePred FGClauseType.IsIsland
+  | .whInterrogative =>
+      inferInstanceAs (Decidable (¬ HPSG.Construction.nsWhIntSecondGap.Models HPSG.Construction.fhGrammar))
+  | .whExclamative =>
+      inferInstanceAs (Decidable (¬ HPSG.Construction.whExclSecondGap.Models HPSG.Construction.fhGrammar))
+  | .topicalized =>
+      inferInstanceAs (Decidable (¬ HPSG.Construction.topClSecondGap.Models HPSG.Construction.fhGrammar))
+  | .whRelative =>
+      inferInstanceAs (Decidable (¬ HPSG.Construction.whRelSecondGap.Models HPSG.Construction.fhGrammar))
+  | .theClause =>
+      inferInstanceAs (Decidable (¬ HPSG.Construction.theClSecondGap.Models HPSG.Construction.fhGrammar))
+
+/-- Topicalization is an absolute island ((67)): a topicalized construct with a
+second gap is rejected by the `[GAP ⟨⟩]` principle. -/
+theorem topicalized_isIsland : FGClauseType.topicalized.IsIsland := by decide
 
 /-- Wh-exclamatives are absolute islands ((74)). -/
-theorem exclamative_isIsland : (fgParams .whExclamative).IsIsland := rfl
+theorem exclamative_isIsland : FGClauseType.whExclamative.IsIsland := by decide
 
 /-- Wh-interrogatives, wh-relatives, and the-clauses are not constructional
-islands: their constructions impose no `[GAP ⟨⟩]`. For wh-relatives this diverges
-from the classic Complex-NP Constraint — [sag-2010] re-attributes the residual
-degradation to processing ([hofmeister-sag-2010]), not grammar. -/
+islands: a second gap amalgamates freely (no `[GAP ⟨⟩]`). For wh-relatives this
+diverges from the classic Complex-NP Constraint — [sag-2010] re-attributes the
+residual degradation to processing ([hofmeister-sag-2010]), not grammar. -/
 theorem interrogative_relative_theClause_not_islands :
-    ¬ (fgParams .whInterrogative).IsIsland ∧
-      ¬ (fgParams .whRelative).IsIsland ∧
-      ¬ (fgParams .theClause).IsIsland := by
+    ¬ FGClauseType.whInterrogative.IsIsland ∧
+      ¬ FGClauseType.whRelative.IsIsland ∧
+      ¬ FGClauseType.theClause.IsIsland := by
   decide
 
 /-- The filler-gap constructions that are absolute extraction islands — exactly
-those whose mother carries `[GAP ⟨⟩]` ((67), (73), (74)). Computed from the GAP
-restriction, not stipulated. -/
+those whose construct rejects a second gap ((67), (73), (74)). Computed from the
+RSRL `Models` verdict, not stipulated. -/
 def islandConstructions : List FGClauseType :=
-  allTypes.filter (fun c => decide (fgParams c).IsIsland)
+  allTypes.filter (fun c => decide c.IsIsland)
 
 /-- Exactly wh-exclamatives and topicalization are filler-gap islands. -/
 theorem islandConstructions_eq :
@@ -416,21 +428,22 @@ theorem island_grounded_in_rsrl :
   SagWasowBender2003.islands_rsrl_grounded.2.1
 
 /-- Agreement with [sag-wasow-bender-2003]: the topicalization island is the same
-datum in two analyses — Sag's `[GAP ⟨⟩]` construction and the HPSG SLASH model
-both block extraction from a topicalized clause. -/
+datum in two analyses — Sag's `[GAP ⟨⟩]` topicalization construct and the generic
+HPSG SLASH model both block a second gap. -/
 theorem topicalized_island_agrees_swb :
-    (fgParams .topicalized).gapRestriction
-      = SagWasowBender2003.topicIslandExtraction.restriction := rfl
+    FGClauseType.topicalized.IsIsland ∧
+      ¬ HPSG.Construction.islandTwoGap.Models HPSG.Construction.fhGrammar :=
+  ⟨by decide, SagWasowBender2003.islands_rsrl_grounded.2.1⟩
 
 /-- The sharpest divergence from [ross-1967]: the relative clause is Ross's
 paradigm Complex-NP-Constraint island, yet [sag-2010]'s wh-relative construction
-imposes no `[GAP ⟨⟩]`. Where [sag-wasow-bender-2003] maps the CNPC to an absolute
-`noGap` restriction, Sag's wh-relative construction is `unrestricted` — the
-residual effect is processing, not grammar ([hofmeister-sag-2010]). -/
+is no grammatical island — its construct *admits* a second gap, whereas a
+configurational island (Ross's CNPC domain, modeled as a generic absolute island)
+blocks it. The residual effect is processing, not grammar ([hofmeister-sag-2010]). -/
 theorem relative_diverges_from_cnpc :
-    (fgParams .whRelative).gapRestriction = .unrestricted ∧
-      SagWasowBender2003.islandToGapRestriction .complexNP = .noGap := by
-  decide
+    HPSG.Construction.whRelSecondGap.Models HPSG.Construction.fhGrammar ∧
+      ¬ HPSG.Construction.islandTwoGap.Models HPSG.Construction.fhGrammar :=
+  ⟨by decide, SagWasowBender2003.islands_rsrl_grounded.2.1⟩
 
 /-! ### Surface clause form (bridge to `Features.ClauseForm`) -/
 

--- a/Linglib/Studies/SagWasowBender2003.lean
+++ b/Linglib/Studies/SagWasowBender2003.lean
@@ -139,41 +139,14 @@ end Binding
 
 /-! ### Long-Distance Dependencies: extraction and islands (Ch. 15)
 
-The Head-Filler Schema and SLASH mechanism, with the empirical island taxonomy of `Studies/Ross1967`
-mapped to GAP feature values. -/
+The Head-Filler Schema and SLASH mechanism. The empirical island taxonomy is stated **model-
+theoretically** over the canonical RSRL signature (`islands_rsrl_grounded` below), which subsumes the
+former coarse `GapRestriction` enum — a dependency penetrates a domain iff its `GAP` survives
+amalgamation. -/
 
 section Extraction
 
 open HPSG
-
-/-- Model of a filler-gap dependency: a wh-filler, a gapped clause,
-and an optional island restriction on the embedded domain. -/
-structure ExtractionConfig where
-  /-- Category of the filler (wh-phrase) -/
-  fillerCat : UD.UPOS
-  /-- Category of the gap (missing complement) -/
-  gapCat : UD.UPOS
-  /-- GAP restriction on intervening domain (if any) -/
-  restriction : GapRestriction := .unrestricted
-
-/-- Extraction from a topicalized clause is blocked ("*What did this book, John read ___?"). Retained
-as the `[GAP ⟨⟩]` datum `Studies/Sag2010` cross-references; the licensing itself is the model-theoretic
-`islands_rsrl_grounded` below, which subsumes the former coarse `extractionLicensed` predicate (filler-gap
-category matching is RSRL amalgamation; island survival is the island/weak-island principles). -/
-def topicIslandExtraction : ExtractionConfig :=
-  { fillerCat := .PRON, gapCat := .NOUN, restriction := .noGap }
-
-/-- Map island constraint types to HPSG GAP restrictions ([ross-1967]'s taxonomy → `[GAP ⟨⟩]`/weak),
-cross-referenced by `Studies/Sag2010`'s divergence theorem. -/
-def islandToGapRestriction : ConstraintType → GapRestriction
-  | .embeddedQuestion  => .noGap     -- absolute barrier (but see weak island analysis)
-  | .complexNP         => .noGap     -- absolute barrier
-  | .adjunct           => .noGap     -- absolute barrier
-  | .coordinate        => .noGap     -- absolute barrier
-  | .subject           => .npOnly    -- weak: some NP extraction ok
-  | .sententialSubject => .noGap     -- absolute barrier
-  | .mannerOfSpeaking  => .npOnly    -- weak: ameliorable with focus
-  | .definiteNominal   => .npOnly    -- weak: ameliorated by VOCs ([shen-huang-2026])
 
 /-- The gap introduction mechanism correctly removes complements. -/
 theorem gap_removes_complement :
@@ -188,15 +161,13 @@ theorem gap_removes_complement :
 Extraction licensing is stated directly over the **model-theoretic** RSRL list-valued `GAP`
 (the canonical `Syntax/HPSG/Construction` signature): filler-gap category matching is gap amalgamation,
 and island permeability is the island/weak-island principles. The whole taxonomy is *derived* from
-amalgamation
-([sag-2010] (67); after [bouma-malouf-sag-2001]), not stipulated as Subjacency — a dependency penetrates
-a domain iff its `GAP` survives amalgamation. The `GapRestriction` tags above are retained only as the
-`Studies/Ross1967` taxonomy map that `Studies/Sag2010` cross-references. -/
+amalgamation ([sag-2010] (67); after [bouma-malouf-sag-2001]), not stipulated as Subjacency — a
+dependency penetrates a domain iff its `GAP` survives amalgamation. -/
 
-/-- The island taxonomy as RSRL `Models` facts (superseding the former coarse `extractionLicensed`
-predicate). A free filler-head construct licenses extraction; an absolute island (`[GAP ⟨⟩]`) blocks a
-second gap; a weak island lets an NP gap pass but blocks a PP gap — the `unrestricted`/`noGap`/`npOnly`
-cases of `GapRestriction`, each over the canonical construction grammar. -/
+/-- The island taxonomy as RSRL `Models` facts (the three cases of the now-retired coarse
+`GapRestriction` enum: unrestricted / absolute / weak). A free filler-head construct licenses
+extraction; an absolute island (`[GAP ⟨⟩]`) blocks a second gap; a weak island lets an NP gap pass but
+blocks a PP gap — each over the canonical construction grammar. -/
 theorem islands_rsrl_grounded :
     HPSG.Construction.goodTwoGap.Models HPSG.Construction.fhGrammar ∧
     ¬ HPSG.Construction.islandTwoGap.Models HPSG.Construction.fhGrammar ∧

--- a/Linglib/Syntax/HPSG/HeadFiller.lean
+++ b/Linglib/Syntax/HPSG/HeadFiller.lean
@@ -18,7 +18,10 @@ HPSG's three immediate dominance schemata.
 - `HeadFillerRule` — filler combines with `S[SLASH {XP}]`, discharging the gap
 - `HPSGSchema` — unifies all three schemata
 - `TrackedSign` — sign paired with its SLASH value
-- `GapRestriction` — island constraints via GAP restrictions
+
+Islands are **not** modeled here: the model-theoretic `[GAP ⟨⟩]` island taxonomy lives over the
+canonical RSRL signature (`Syntax/HPSG/Construction`, consumed by `Studies/SagWasowBender2003` and
+`Studies/Sag2010`), which subsumes the former coarse `GapRestriction` enum.
 
 ## Connection to [mueller-2013]
 
@@ -248,44 +251,6 @@ the need for a separate island module in the grammar.
   (e.g., wh-islands allow NP extraction but not PP)
 - **Unrestricted**: any GAP value permeates (no island constraint) -/
 
-/-- GAP restriction on a construction.
-
-This classifies constructions by what kinds of gaps they permit,
-deriving island effects from the same feature system used for
-non-island dependencies. -/
-inductive GapRestriction where
-  | unrestricted  -- Any GAP value (not an island)
-  | npOnly        -- [GAP list(NP)] — weak island (only NP extraction)
-  | noGap         -- [GAP ⟨⟩] — absolute barrier to extraction
-  deriving Repr, DecidableEq
-
-/-- Does this GAP restriction block all extraction? -/
-def GapRestriction.IsAbsoluteIsland (g : GapRestriction) : Prop :=
-  g = .noGap
-
-instance : DecidablePred GapRestriction.IsAbsoluteIsland :=
-  fun _ => inferInstanceAs (Decidable (_ = _))
-
-/-- Does this GAP restriction allow NP extraction? -/
-def GapRestriction.AllowsNPExtraction (g : GapRestriction) : Prop :=
-  g = .unrestricted ∨ g = .npOnly
-
-instance : DecidablePred GapRestriction.AllowsNPExtraction :=
-  fun _ => inferInstanceAs (Decidable (_ ∨ _))
-
-/-- A SLASH value satisfies a GAP restriction if all its gaps are
-permitted by the restriction. -/
-def SlashValue.satisfiesRestriction (sv : SlashValue) (r : GapRestriction) : Bool :=
-  match r with
-  | .unrestricted => true
-  | .npOnly => sv.gaps.all (· == .NOUN)
-  | .noGap => sv.gaps.isEmpty
-
-/-- Empty SLASH always satisfies any restriction. -/
-theorem empty_satisfies_any_restriction (r : GapRestriction) :
-    SlashValue.empty.satisfiesRestriction r = true := by
-  cases r <;> rfl
-
 -- ============================================================================
 -- Derivation Examples
 -- ============================================================================
@@ -361,55 +326,5 @@ theorem extraction_complete :
   decide
 
 end DerivationExamples
-
--- ============================================================================
--- Island Blocking
--- ============================================================================
-
-/-! ### Islands block SLASH propagation
-
-When a construction has a GAP restriction of `.noGap`, no SLASH values
-can percolate through it. This blocks extraction from islands.
-
-Example: "*What did John wonder who saw ___?"
-- The embedded question "who saw ___" has SLASH {NP}
-- But the embedded question construction has [GAP ⟨⟩] (`.noGap`)
-- SLASH cannot pass through → extraction blocked
--/
-
-section IslandBlocking
-
-/-- Check that a SLASH value can propagate through a construction.
-Returns the SLASH that survives the restriction. -/
-def propagateSlash (sv : SlashValue) (restriction : GapRestriction) : SlashValue :=
-  if sv.satisfiesRestriction restriction then sv
-  else .empty
-
--- Extraction from a non-island succeeds: SLASH passes through
-#guard (propagateSlash ⟨[.NOUN]⟩ .unrestricted).gaps == [.NOUN]
-
--- Extraction from an absolute island fails: SLASH is blocked
-#guard (propagateSlash ⟨[.NOUN]⟩ .noGap).isEmpty
-
--- Extraction of NP from a weak island succeeds
-#guard (propagateSlash ⟨[.NOUN]⟩ .npOnly).gaps == [.NOUN]
-
--- But extraction of PP from a weak island fails
-#guard (propagateSlash ⟨[.ADP]⟩ .npOnly).isEmpty
-
-/-- Extraction from a non-island construction always succeeds. -/
-theorem extraction_from_nonisland (c : UD.UPOS) :
-    (propagateSlash ⟨[c]⟩ .unrestricted).gaps = [c] := by
-  simp [propagateSlash, SlashValue.satisfiesRestriction]
-
-/-- Extraction from an absolute island is always blocked. -/
-theorem extraction_blocked_by_island (gaps : List UD.UPOS) (h : gaps ≠ []) :
-    (propagateSlash ⟨gaps⟩ .noGap).isEmpty = true := by
-  simp [propagateSlash, SlashValue.satisfiesRestriction, SlashValue.isEmpty]
-  cases gaps with
-  | nil => exact absurd rfl h
-  | cons _ _ => rfl
-
-end IslandBlocking
 
 end HPSG


### PR DESCRIPTION
Completes the canonical-signature unification (#706): the coarse computational `GapRestriction` enum is now subsumed by the list-valued RSRL `GAP`, so it and the residual extraction machinery are deleted.

- `HeadFiller.lean`: drop `GapRestriction` + `IsAbsoluteIsland`/`AllowsNPExtraction`, `SlashValue.satisfiesRestriction`, `propagateSlash` and the island-blocking section.
- `SagWasowBender2003.lean`: drop `ExtractionConfig`/`topicIslandExtraction`/`islandToGapRestriction` (the island taxonomy is the model-theoretic `islands_rsrl_grounded`).
- `Sag2010.lean`: `FGConstruction` drops its `gapRestriction` field; `FGClauseType.IsIsland` and the cross-paper island theorems are now `Models` facts over `Syntax/HPSG/Construction`. `LuPanDegen2025` updated to match.

Axiom-clean. Depends on #706 (merged).