### PR TITLE
refactor(Syntax/HPSG): de-stutter Construction names (Srt/sig/grammar)

### DIFF
--- a/Linglib/Studies/Sag2010.lean
+++ b/Linglib/Studies/Sag2010.lean
@@ -315,7 +315,7 @@ the filler-head inheritance and the clausal cross-classification above are *theo
 order* — the model-theoretic substrate ([richter-2000]) under the `fgParams` record. -/
 
 /-- Each filler-gap clause type as a construct sort in the RSRL hierarchy. -/
-def fgSort : FGClauseType → Construction.ConstructSort
+def fgSort : FGClauseType → Construction.Srt
   | .whInterrogative => .nsWhIntCl
   | .whExclamative => .whExclCl
   | .topicalized => .topCl
@@ -326,10 +326,10 @@ def fgSort : FGClauseType → Construction.ConstructSort
 `filler-head-cxt`'s constraints (head verbal, filler↔gap token identity) proved in `Construction.lean`
 — the model-theoretic ground of `fg_inherits_nonverbal_filler`. -/
 theorem fgSort_filler_head (c : FGClauseType) :
-    fgSort c ≤ Construction.ConstructSort.fillerHeadCxt := by cases c <;> decide
+    fgSort c ≤ Construction.Srt.fillerHeadCxt := by cases c <;> decide
 
 /-- The local `ClauseType` as the matching RSRL clausal sort (Fig. 7). -/
-def clauseTypeSort : ClauseType → Construction.ConstructSort
+def clauseTypeSort : ClauseType → Construction.Srt
   | .interrogativeCl => .interrogativeCl
   | .relativeCl => .relativeCl
   | .exclamativeCl => .exclamativeCl
@@ -367,23 +367,23 @@ not stored as a tag. Each case is `¬ Models` of the construction's two-gap RSRL
 worked model (`Syntax/HPSG/Construction`): an island rejects the second gap, a
 non-island admits it. -/
 def FGClauseType.IsIsland : FGClauseType → Prop
-  | .whInterrogative => ¬ Construction.nsWhIntSecondGap.Models Construction.constructGrammar
-  | .whExclamative   => ¬ Construction.whExclSecondGap.Models Construction.constructGrammar
-  | .topicalized     => ¬ Construction.topClSecondGap.Models Construction.constructGrammar
-  | .whRelative      => ¬ Construction.whRelSecondGap.Models Construction.constructGrammar
-  | .theClause       => ¬ Construction.theClSecondGap.Models Construction.constructGrammar
+  | .whInterrogative => ¬ Construction.nsWhIntSecondGap.Models Construction.grammar
+  | .whExclamative   => ¬ Construction.whExclSecondGap.Models Construction.grammar
+  | .topicalized     => ¬ Construction.topClSecondGap.Models Construction.grammar
+  | .whRelative      => ¬ Construction.whRelSecondGap.Models Construction.grammar
+  | .theClause       => ¬ Construction.theClSecondGap.Models Construction.grammar
 
 instance : DecidablePred FGClauseType.IsIsland
   | .whInterrogative =>
-      inferInstanceAs (Decidable (¬ Construction.nsWhIntSecondGap.Models Construction.constructGrammar))
+      inferInstanceAs (Decidable (¬ Construction.nsWhIntSecondGap.Models Construction.grammar))
   | .whExclamative =>
-      inferInstanceAs (Decidable (¬ Construction.whExclSecondGap.Models Construction.constructGrammar))
+      inferInstanceAs (Decidable (¬ Construction.whExclSecondGap.Models Construction.grammar))
   | .topicalized =>
-      inferInstanceAs (Decidable (¬ Construction.topClSecondGap.Models Construction.constructGrammar))
+      inferInstanceAs (Decidable (¬ Construction.topClSecondGap.Models Construction.grammar))
   | .whRelative =>
-      inferInstanceAs (Decidable (¬ Construction.whRelSecondGap.Models Construction.constructGrammar))
+      inferInstanceAs (Decidable (¬ Construction.whRelSecondGap.Models Construction.grammar))
   | .theClause =>
-      inferInstanceAs (Decidable (¬ Construction.theClSecondGap.Models Construction.constructGrammar))
+      inferInstanceAs (Decidable (¬ Construction.theClSecondGap.Models Construction.grammar))
 
 /-- Topicalization is an absolute island ((67)): a topicalized construct with a
 second gap is rejected by the `[GAP ⟨⟩]` principle. -/
@@ -425,7 +425,7 @@ second gap. Derived from [sag-wasow-bender-2003]'s authoritative `islands_rsrl_g
 canonical `Syntax/HPSG/Construction` signature), not re-stated — the construction-tag level and the
 gap-list mechanism agree. -/
 theorem island_grounded_in_rsrl :
-    ¬ Construction.islandTwoGap.Models Construction.constructGrammar :=
+    ¬ Construction.islandTwoGap.Models Construction.grammar :=
   SagWasowBender2003.islands_rsrl_grounded.2.1
 
 /-- Agreement with [sag-wasow-bender-2003]: the topicalization island is the same
@@ -433,7 +433,7 @@ datum in two analyses — Sag's `[GAP ⟨⟩]` topicalization construct and the 
 HPSG SLASH model both block a second gap. -/
 theorem topicalized_island_agrees_swb :
     FGClauseType.topicalized.IsIsland ∧
-      ¬ Construction.islandTwoGap.Models Construction.constructGrammar :=
+      ¬ Construction.islandTwoGap.Models Construction.grammar :=
   ⟨by decide, SagWasowBender2003.islands_rsrl_grounded.2.1⟩
 
 /-- The sharpest divergence from [ross-1967]: the relative clause is Ross's
@@ -442,8 +442,8 @@ is no grammatical island — its construct *admits* a second gap, whereas a
 configurational island (Ross's CNPC domain, modeled as a generic absolute island)
 blocks it. The residual effect is processing, not grammar ([hofmeister-sag-2010]). -/
 theorem relative_diverges_from_cnpc :
-    Construction.whRelSecondGap.Models Construction.constructGrammar ∧
-      ¬ Construction.islandTwoGap.Models Construction.constructGrammar :=
+    Construction.whRelSecondGap.Models Construction.grammar ∧
+      ¬ Construction.islandTwoGap.Models Construction.grammar :=
   ⟨by decide, SagWasowBender2003.islands_rsrl_grounded.2.1⟩
 
 /-! ### Surface clause form (bridge to `Features.ClauseForm`) -/

--- a/Linglib/Studies/SagEtAl2020.lean
+++ b/Linglib/Studies/SagEtAl2020.lean
@@ -42,18 +42,18 @@ open HPSG.RSRL HPSG.Construction
 (`[INV +]`) word — an invertible finite auxiliary. Unlike the filler-gap constructions it carries no
 shared semantics (Fillmore 1999, [sag-etal-2020] fn. 34); its clausal meaning comes only from
 cross-classification. -/
-def auxInitialPrinciple : Desc constructSig :=
+def auxInitialPrinciple : Desc sig :=
   .imp (.sortAssign .colon .auxInitialCxt) (.sortAssign (.path [.HDDTR, .INV]) .invPlus)
 
 /-- The filler-gap grammar of `Construction.lean` extended with the inversion construction. -/
-def saiGrammar : Grammar constructSig := constructGrammar ++ [auxInitialPrinciple]
+def saiGrammar : Grammar sig := grammar ++ [auxInitialPrinciple]
 
 /-- `aux-initial-cxt` is a sibling of `filler-head-cxt` under `headed-cxt`, and the interrogative SAI
 cross-classifies it with `interrogative-cl` — the same machinery as [sag-2010]'s filler-gap
 constructions, now for the second paper's construction. -/
 theorem sai_cross_classify :
-    ((ConstructSort.auxInitialCxt ≤ .headedCxt) ∧ (ConstructSort.fillerHeadCxt ≤ .headedCxt)) ∧
-      ((ConstructSort.interrogativeSAI ≤ .auxInitialCxt) ∧ (ConstructSort.interrogativeSAI ≤ .interrogativeCl)) := by
+    ((Srt.auxInitialCxt ≤ .headedCxt) ∧ (Srt.fillerHeadCxt ≤ .headedCxt)) ∧
+      ((Srt.interrogativeSAI ≤ .auxInitialCxt) ∧ (Srt.interrogativeSAI ≤ .interrogativeCl)) := by
   decide
 
 /-! ### A worked interrogative SAI -/
@@ -65,7 +65,7 @@ inductive SAIEnt
   deriving DecidableEq, Fintype, Repr
 
 /-- A well-formed interrogative SAI (sort `interrogative-SAI`): inverted head, interrogative mother. -/
-def goodInterrogativeSAI : Interpretation constructSig where
+def goodInterrogativeSAI : Interpretation sig where
   U := SAIEnt
   S := fun
     | .cxt => .interrogativeSAI
@@ -90,7 +90,7 @@ example : goodInterrogativeSAI.Models saiGrammar := by decide
 
 /-- The inverted-head restriction binds: an aux-initial construct with an `[INV −]` head violates the
 aux-initial principle. -/
-def saiUninverted : Interpretation constructSig where
+def saiUninverted : Interpretation sig where
   U := SAIEnt
   S := fun
     | .cxt => .interrogativeSAI

--- a/Linglib/Studies/SagWasowBender2003.lean
+++ b/Linglib/Studies/SagWasowBender2003.lean
@@ -169,10 +169,10 @@ dependency penetrates a domain iff its `GAP` survives amalgamation. -/
 extraction; an absolute island (`[GAP ⟨⟩]`) blocks a second gap; a weak island lets an NP gap pass but
 blocks a PP gap — each over the canonical construction grammar. -/
 theorem islands_rsrl_grounded :
-    Construction.goodTwoGap.Models Construction.constructGrammar ∧
-    ¬ Construction.islandTwoGap.Models Construction.constructGrammar ∧
-    Construction.weakIslandNPGap.Models Construction.constructGrammar ∧
-    ¬ Construction.weakIslandPPGap.Models Construction.constructGrammar := by decide
+    Construction.goodTwoGap.Models Construction.grammar ∧
+    ¬ Construction.islandTwoGap.Models Construction.grammar ∧
+    Construction.weakIslandNPGap.Models Construction.grammar ∧
+    ¬ Construction.weakIslandPPGap.Models Construction.grammar := by decide
 
 end Extraction
 

--- a/Linglib/Syntax/HPSG/Construction.lean
+++ b/Linglib/Syntax/HPSG/Construction.lean
@@ -14,7 +14,7 @@ set_option autoImplicit false
 
 The **single canonical RSRL signature** for the Sign-Based Construction Grammar fragment, formalized on
 the RSRL feature-structure substrate (`Syntax/HPSG/{Signature,Interpretation,Description}`). One
-`Signature` (`constructSig`) carries, in one feature-structure language:
+`Signature` (`sig`) carries, in one feature-structure language:
 
 * the **construct type hierarchy with monotonic multiple inheritance** ([sag-etal-2020] Figs. 6–7);
 * a **list-valued `GAP` (SLASH) feature** with gap **amalgamation** ([sag-2010] §4, after
@@ -87,7 +87,7 @@ open HPSG.RSRL
 (`list > {elist, nelist}`), `sign`, and the [sag-etal-2020] construct (Fig. 6) and clausal (Fig. 7)
 type hierarchies, with `ns-wh-int-cl` as the worked cross-classified subtype ([sag-2010] (80), Fig. 8)
 and the generic `island-cxt`/`weak-island-cxt` demonstration subtypes of `filler-head-cxt`. -/
-inductive ConstructSort
+inductive Srt
   | top
   -- category hierarchy (filler-head-cxt keys on verbal/nonverbal; wh-rel on nominal; the-cl on comp;
   -- the noun/prep split is the NP/PP distinction weak islands are sensitive to)
@@ -113,10 +113,10 @@ inductive ConstructSort
   deriving DecidableEq, Fintype, Repr
 
 /-- Direct subsumption ("covers"): the **DAG edges** (a is *directly* more specific than b), not the
-transitive closure. The order is `ReflTransGen constructCovers`, so transitivity is structural and there is no
-hand-maintained closure or `|ConstructSort|³` `decide`. Each filler-gap construction covers **two** parents —
+transitive closure. The order is `ReflTransGen covers`, so transitivity is structural and there is no
+hand-maintained closure or `|Srt|³` `decide`. Each filler-gap construction covers **two** parents —
 its `headed-cxt` subtype and its clausal type — the multiple inheritance. -/
-def constructCovers : ConstructSort → ConstructSort → Bool
+def covers : Srt → Srt → Bool
   -- categories (nonverbal > {nominal, adj}; nominal > {noun, prep})
   | .verbal, .cat => true | .nonverbal, .cat => true
   | .verb, .verbal => true | .comp, .verbal => true
@@ -152,7 +152,7 @@ def constructCovers : ConstructSort → ConstructSort → Bool
 
 /-- Specificity depth; every covers edge strictly increases it, giving antisymmetry. The filler-gap
 constructions sit at depth 6, above *both* their depth-4 headed parent and their depth-5 clausal type. -/
-def constructRank : ConstructSort → Nat
+def rank : Srt → Nat
   | .top => 0
   | .cat => 1 | .semType => 1 | .invVal => 1 | .list => 1 | .sign => 1 | .construct => 1
   | .verbal => 2 | .nonverbal => 2 | .austinean => 2 | .question => 2 | .fact => 2 | .proposition => 2
@@ -163,11 +163,11 @@ def constructRank : ConstructSort → Nat
   | .declarativeCl => 5 | .interrogativeCl => 5 | .exclamativeCl => 5
   | .topCl => 6 | .whExclCl => 6 | .nsWhIntCl => 6 | .whRelCl => 6 | .theCl => 6 | .interrogativeSAI => 6
 
-instance : PartialOrder ConstructSort :=
-  partialOrderOfCovers (constructCovers · · = true) constructRank (by decide)
+instance : PartialOrder Srt :=
+  partialOrderOfCovers (covers · · = true) rank (by decide)
 
-instance : DecidableLE ConstructSort := fun a b =>
-  decidableLEOfCovers (covers := (constructCovers · · = true))
+instance : DecidableLE Srt := fun a b =>
+  decidableLEOfCovers (covers := (covers · · = true))
     [.top, .cat, .verbal, .nonverbal, .verb, .comp, .nominal, .noun, .prep, .adj,
      .semType, .austinean, .question, .fact, .proposition, .invVal, .invPlus, .invMinus,
      .list, .elist, .nelist, .sign,
@@ -182,7 +182,7 @@ instance : DecidableLE ConstructSort := fun a b =>
 /-- Attributes: a construct's mother (`MTR`) and head/filler daughters (`HDDTR`/`FILLERDTR`); a sign's
 `CAT`, (list-valued) `GAP`, `SEM` type, and `INV` value; a nonempty list's `FIRST` (a category) and
 `REST` (a list). -/
-inductive ConstructAttr
+inductive Feat
   | MTR | HDDTR | FILLERDTR | CAT | GAP | SEM | INV | FIRST | REST
   deriving DecidableEq, Fintype, Repr
 
@@ -190,7 +190,7 @@ inductive ConstructAttr
 have `HDDTR` (and `filler-head-cxt` a `FILLERDTR`); a `sign` has `CAT`/`SEM`/`INV` and a list-valued
 `GAP`; a `nelist` has `FIRST` (a category) and `REST` (a list). Respects feature inheritance
 ([richter-2024]): an attribute appropriate to a sort is appropriate to its subsorts. -/
-def constructApprop : ConstructSort → ConstructAttr → Option ConstructSort
+def approp : Srt → Feat → Option Srt
   | .construct, .MTR => some .sign
   | .phrasalCxt, .MTR => some .sign
   | .lexicalCxt, .MTR => some .sign
@@ -244,16 +244,16 @@ def constructApprop : ConstructSort → ConstructAttr → Option ConstructSort
 -- value for an attribute); proving this propagation over just `(σ₁, σ₂, α)` — without the `τ₁`
 -- quantifier or `∃`-search — keeps the `decide` within budget, and `approp_inh_of_propagates` derives
 -- the `Signature.approp_inherits` obligation from it.
-private theorem constructApprop_propagates : ∀ (σ₁ σ₂ : ConstructSort) (α : ConstructAttr),
-    σ₂ ≤ σ₁ → (constructApprop σ₁ α).isSome = true → constructApprop σ₂ α = constructApprop σ₁ α := by decide
+private theorem approp_propagates : ∀ (σ₁ σ₂ : Srt) (α : Feat),
+    σ₂ ≤ σ₁ → (approp σ₁ α).isSome = true → approp σ₂ α = approp σ₁ α := by decide
 
 /-- The fragment's signature (no relations). -/
-@[reducible] def constructSig : Signature ConstructSort where
-  Attr := ConstructAttr
+@[reducible] def sig : Signature Srt where
+  Attr := Feat
   Rel := Empty
   arity := fun e => e.elim
-  approp := constructApprop
-  approp_inherits := fun hle happ => approp_inh_of_propagates constructApprop_propagates hle happ
+  approp := approp
+  approp_inherits := fun hle happ => approp_inh_of_propagates approp_propagates hle happ
 
 /-! ### Principles (constructions as `τ ⇒ D`)
 
@@ -268,7 +268,7 @@ amalgamation after [bouma-malouf-sag-2001]): the head daughter is `[CAT verbal]`
 per-subtype generalization (each F-G construction's (25)-style parameter, refined to `nominal` for
 wh-relative, (25b)) rather than a constraint of (58) itself; it is stated here once on the supertype
 because every subtype satisfies it. -/
-def fillerHeadPrinciple : Desc constructSig :=
+def fillerHeadPrinciple : Desc sig :=
   .imp (.sortAssign .colon .fillerHeadCxt)
     (.and (.sortAssign (.path [.FILLERDTR, .CAT]) .nonverbal)
       (.and (.sortAssign (.path [.HDDTR, .CAT]) .verbal)
@@ -278,39 +278,39 @@ def fillerHeadPrinciple : Desc constructSig :=
 /-- Clausal semantics ([sag-etal-2020] Fig. 7, following G&S 2000): the mother's `SEM` type is fixed
 by the clausal type — `declarative-cl` ⇒ austinean, `interrogative-cl` ⇒ question,
 `exclamative-cl` ⇒ fact, `relative-cl` ⇒ proposition. -/
-def declarativePrinciple : Desc constructSig :=
+def declarativePrinciple : Desc sig :=
   .imp (.sortAssign .colon .declarativeCl) (.sortAssign (.path [.MTR, .SEM]) .austinean)
-def interrogativePrinciple : Desc constructSig :=
+def interrogativePrinciple : Desc sig :=
   .imp (.sortAssign .colon .interrogativeCl) (.sortAssign (.path [.MTR, .SEM]) .question)
-def exclamativePrinciple : Desc constructSig :=
+def exclamativePrinciple : Desc sig :=
   .imp (.sortAssign .colon .exclamativeCl) (.sortAssign (.path [.MTR, .SEM]) .fact)
-def relativePrinciple : Desc constructSig :=
+def relativePrinciple : Desc sig :=
   .imp (.sortAssign .colon .relativeCl) (.sortAssign (.path [.MTR, .SEM]) .proposition)
 
 /-- The **wh-relative construction**'s distinguishing constraint ([sag-2010] (92), (25b)): unlike the
 other filler-gap constructions (nonverbal filler), the relative filler is `[CAT nominal]` — an NP or PP
 (`nominal` resolves to `noun`/`prep`), excluding AP/AdvP. -/
-def whRelPrinciple : Desc constructSig :=
+def whRelPrinciple : Desc sig :=
   .imp (.sortAssign .colon .whRelCl) (.sortAssign (.path [.FILLERDTR, .CAT]) .nominal)
 
 /-- The **topicalization construction**'s distinguishing constraint ([sag-2010] (61), (27a)): its head
 daughter is a `[CAT verb]` projection (an S), excluding the complementizer-headed CP that the
 otherwise-similar (also austinean) the-clause allows ((27b): the-clause head is S or CP). -/
-def topPrinciple : Desc constructSig :=
+def topPrinciple : Desc sig :=
   .imp (.sortAssign .colon .topCl) (.sortAssign (.path [.HDDTR, .CAT]) .verb)
 
 /-- **Absolute island** ([sag-2010] (67)): a generic island construct's mother is `[GAP ⟨⟩]` — no
 dependency penetrates beyond the one its filler binds. This generic `island-cxt` demonstrates the
 mechanism for Ross's island *domains* (`Studies/SagWasowBender2003`); the F-G constructions that are
 absolute islands carry their own `[GAP ⟨⟩]` principle below. -/
-def islandPrinciple : Desc constructSig :=
+def islandPrinciple : Desc sig :=
   .imp (.sortAssign .colon .islandCxt) (.sortAssign (.path [.MTR, .GAP]) .elist)
 
 /-- **Weak-island constraint**: a weak island is *selectively* permeable — an NP dependency passes
 through, a PP (more generally, non-nominal) dependency does not ([sag-wasow-bender-2003] Ch. 15). Stated
 on the *passing* gap: if a weak-island construct's mother `GAP|FIRST` is a `prep` (PP), the mother must
 be `[GAP ⟨⟩]` — so a PP cannot penetrate, while a `noun` (NP) mother gap is unconstrained and passes. -/
-def weakIslandPrinciple : Desc constructSig :=
+def weakIslandPrinciple : Desc sig :=
   .imp (.and (.sortAssign .colon .weakIslandCxt)
              (.sortAssign (.path [.MTR, .GAP, .FIRST]) .prep))
     (.sortAssign (.path [.MTR, .GAP]) .elist)
@@ -318,12 +318,12 @@ def weakIslandPrinciple : Desc constructSig :=
 /-- **Topicalization is an absolute island** ([sag-2010] (67)): a topicalization construct's mother is
 `[GAP ⟨⟩]`. Stated directly on `top-cl` (as [sag-2010] does, not via a generic island supertype the
 paper lacks), so a topicalized clause with a second, undischarged gap is rejected. -/
-def topIslandPrinciple : Desc constructSig :=
+def topIslandPrinciple : Desc sig :=
   .imp (.sortAssign .colon .topCl) (.sortAssign (.path [.MTR, .GAP]) .elist)
 
 /-- **Wh-exclamatives are absolute islands** ([sag-2010] (74)): a wh-exclamative construct's mother is
 `[GAP ⟨⟩]`. -/
-def whExclIslandPrinciple : Desc constructSig :=
+def whExclIslandPrinciple : Desc sig :=
   .imp (.sortAssign .colon .whExclCl) (.sortAssign (.path [.MTR, .GAP]) .elist)
 
 /-- The grammar: the filler-head construction (with gap amalgamation), the four clausal-type
@@ -331,7 +331,7 @@ principles, the filler-gap construction-specific restrictions (topicalization's 
 nominal filler), the generic absolute/weak island constraints, and the absolute-island status of
 topicalization and wh-exclamatives. The aux-initial / inversion construction is paper-anchored in
 `Studies/SagEtAl2020.lean`, which extends this grammar. -/
-def constructGrammar : Grammar constructSig :=
+def grammar : Grammar sig :=
   [fillerHeadPrinciple, declarativePrinciple, interrogativePrinciple, exclamativePrinciple,
     relativePrinciple, whRelPrinciple, topPrinciple,
     islandPrinciple, weakIslandPrinciple, topIslandPrinciple, whExclIslandPrinciple]
@@ -342,18 +342,18 @@ def constructGrammar : Grammar constructSig :=
 (the clausal dimension) — the cross-classification of [sag-2010] (80), Fig. 8 (the cross-classification
 mechanism being the one [sag-etal-2020] Fig. 5 illustrates for `subj-pred-cl`). -/
 theorem nsWhIntCl_inherits :
-    (ConstructSort.nsWhIntCl ≤ .fillerHeadCxt) ∧ (ConstructSort.nsWhIntCl ≤ .interrogativeCl) := by decide
+    (Srt.nsWhIntCl ≤ .fillerHeadCxt) ∧ (Srt.nsWhIntCl ≤ .interrogativeCl) := by decide
 
 /-- All four filler-gap constructions cross-classify: each is below `filler-head-cxt` (so inherits the
 filler-head constraints) **and** below the clausal type fixing its semantics ([sag-2010] §5) —
 topicalization/declarative, wh-exclamative/exclamative, nonsubject-wh-interrogative/interrogative,
 wh-relative/relative. -/
 theorem fg_cross_classify :
-    ((ConstructSort.topCl ≤ .fillerHeadCxt) ∧ (ConstructSort.topCl ≤ .declarativeCl)) ∧
-      ((ConstructSort.whExclCl ≤ .fillerHeadCxt) ∧ (ConstructSort.whExclCl ≤ .exclamativeCl)) ∧
-      ((ConstructSort.nsWhIntCl ≤ .fillerHeadCxt) ∧ (ConstructSort.nsWhIntCl ≤ .interrogativeCl)) ∧
-      ((ConstructSort.whRelCl ≤ .fillerHeadCxt) ∧ (ConstructSort.whRelCl ≤ .relativeCl)) ∧
-      ((ConstructSort.theCl ≤ .fillerHeadCxt) ∧ (ConstructSort.theCl ≤ .declarativeCl)) := by decide
+    ((Srt.topCl ≤ .fillerHeadCxt) ∧ (Srt.topCl ≤ .declarativeCl)) ∧
+      ((Srt.whExclCl ≤ .fillerHeadCxt) ∧ (Srt.whExclCl ≤ .exclamativeCl)) ∧
+      ((Srt.nsWhIntCl ≤ .fillerHeadCxt) ∧ (Srt.nsWhIntCl ≤ .interrogativeCl)) ∧
+      ((Srt.whRelCl ≤ .fillerHeadCxt) ∧ (Srt.whRelCl ≤ .relativeCl)) ∧
+      ((Srt.theCl ≤ .fillerHeadCxt) ∧ (Srt.theCl ≤ .declarativeCl)) := by decide
 
 /-! ### Worked constructs
 
@@ -371,7 +371,7 @@ inductive Ent
 /-- Common species assignment: the cells are `nelist`, `nil` is `elist`, `c2` defaults to `noun` (NP),
 `sem` defaults to `austinean`, `cxt` defaults to `filler-head-cxt`; each model overrides `cxt` (its
 construction type) and, where the clausal type demands, `sem`/`c2`. -/
-def baseS : Ent → ConstructSort
+def baseS : Ent → Srt
   | .cxt => .fillerHeadCxt
   | .mtr => .sign | .hd => .sign | .fl => .sign
   | .npCat => .noun | .vpCat => .verb | .adjCat => .adj | .compCat => .comp
@@ -381,7 +381,7 @@ def baseS : Ent → ConstructSort
 
 /-- Single-gap filler-head geometry: head `GAP ⟨c⟩` (`g1`), filler binds `c` (token-identical to the
 head's first gap `npCat`), mother `GAP ⟨⟩`; verbal head, nonverbal (NP) filler, mother `SEM` `sem`. -/
-def singleGapA : ConstructAttr → Ent → Option Ent := fun a u => match a, u with
+def singleGapA : Feat → Ent → Option Ent := fun a u => match a, u with
   | .MTR, .cxt => some .mtr
   | .HDDTR, .cxt => some .hd
   | .FILLERDTR, .cxt => some .fl
@@ -396,7 +396,7 @@ def singleGapA : ConstructAttr → Ent → Option Ent := fun a u => match a, u w
 
 /-- Two-gap amalgamation geometry: head `GAP ⟨npCat, c2⟩`, the filler binds the first gap, and the
 second gap `c2` passes up — mother `GAP ⟨c2⟩` (`g2`). -/
-def twoGapA : ConstructAttr → Ent → Option Ent := fun a u => match a, u with
+def twoGapA : Feat → Ent → Option Ent := fun a u => match a, u with
   | .MTR, .cxt => some .mtr
   | .HDDTR, .cxt => some .hd
   | .FILLERDTR, .cxt => some .fl
@@ -413,7 +413,7 @@ def twoGapA : ConstructAttr → Ent → Option Ent := fun a u => match a, u with
 
 /-- A well-formed filler-head construct (sort `filler-head-cxt`): nonverbal filler, verbal head, the
 head's first `GAP` token-identical to the filler's `CAT`, the (empty) rest amalgamated to the mother. -/
-def goodFillerHead : Interpretation constructSig where
+def goodFillerHead : Interpretation sig where
   U := Ent
   S := baseS
   A := singleGapA
@@ -424,12 +424,12 @@ instance : DecidableEq goodFillerHead.U := inferInstanceAs (DecidableEq Ent)
 
 /-- The well-formed filler-head construct satisfies the grammar (the clausal/island principles are
 vacuous — `filler-head-cxt` is below no clausal type or island type). -/
-example : goodFillerHead.Models constructGrammar := by decide
+example : goodFillerHead.Models grammar := by decide
 
 /-- Breaking the filler↔gap token identity (filler `CAT` ≠ head `GAP|FIRST`) violates the filler-head
 principle. The filler is an AP (nonverbal, so the nonverbal constraint still holds) while the head's
 bound gap is an NP — isolating the token-identity failure. -/
-def gapMismatch : Interpretation constructSig where
+def gapMismatch : Interpretation sig where
   U := Ent
   S := baseS
   A := fun a u => match a, u with
@@ -440,7 +440,7 @@ def gapMismatch : Interpretation constructSig where
 instance : Fintype gapMismatch.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq gapMismatch.U := inferInstanceAs (DecidableEq Ent)
 
-example : ¬ gapMismatch.Models constructGrammar := by decide
+example : ¬ gapMismatch.Models grammar := by decide
 
 /-! ### The keystone: cross-classification by inheritance
 
@@ -450,7 +450,7 @@ principle — both inherited via `nsWhIntCl_inherits`, neither stipulated on `ns
 /-- A well-formed nonsubject wh-interrogative construct (sort `ns-wh-int-cl`): nonverbal filler, verbal
 head, filler↔gap token identity (from `filler-head-cxt`), and the mother's `SEM` a question (from
 `interrogative-cl`). -/
-def goodNsWhInt : Interpretation constructSig where
+def goodNsWhInt : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .nsWhIntCl | .sem => .question | u => baseS u
   A := singleGapA
@@ -463,12 +463,12 @@ instance : DecidableEq goodNsWhInt.U := inferInstanceAs (DecidableEq Ent)
 inherited filler-head constraints and the inherited interrogative semantics, from its single sort
 assignment (`nsWhIntCl_inherits`). No filler-head or interrogative constraint is restated on
 `ns-wh-int-cl`; both fire because its sort lies below both supersorts. -/
-example : goodNsWhInt.Models constructGrammar := by decide
+example : goodNsWhInt.Models grammar := by decide
 
 /-- The inherited interrogative constraint genuinely binds: an `ns-wh-int-cl` construct whose mother's
 `SEM` is austinean (not a question) violates the **inherited** interrogative principle — even though
 nothing about interrogativity is stated on `ns-wh-int-cl` directly. -/
-def nsWhIntWrongSem : Interpretation constructSig where
+def nsWhIntWrongSem : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .nsWhIntCl | u => baseS u    -- sem = austinean (baseS default)
   A := singleGapA
@@ -477,7 +477,7 @@ def nsWhIntWrongSem : Interpretation constructSig where
 instance : Fintype nsWhIntWrongSem.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq nsWhIntWrongSem.U := inferInstanceAs (DecidableEq Ent)
 
-example : ¬ nsWhIntWrongSem.Models constructGrammar := by decide
+example : ¬ nsWhIntWrongSem.Models grammar := by decide
 
 /-! ### The five filler-gap constructions ([sag-2010] §5)
 
@@ -488,7 +488,7 @@ also satisfy their absolute-island principle (the one bound gap leaves the mothe
 two-gap island theorems below show the constraint genuinely binds. -/
 
 /-- Topicalization ([sag-2010] (61)): a declarative (austinean) filler-head construct, verb head. -/
-def goodTopCl : Interpretation constructSig where
+def goodTopCl : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .topCl | u => baseS u
   A := singleGapA
@@ -497,10 +497,10 @@ def goodTopCl : Interpretation constructSig where
 instance : Fintype goodTopCl.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq goodTopCl.U := inferInstanceAs (DecidableEq Ent)
 
-example : goodTopCl.Models constructGrammar := by decide
+example : goodTopCl.Models grammar := by decide
 
 /-- Wh-exclamative ([sag-2010] (70)): an exclamative (fact) filler-head construct. -/
-def goodWhExcl : Interpretation constructSig where
+def goodWhExcl : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .whExclCl | .sem => .fact | u => baseS u
   A := singleGapA
@@ -509,11 +509,11 @@ def goodWhExcl : Interpretation constructSig where
 instance : Fintype goodWhExcl.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq goodWhExcl.U := inferInstanceAs (DecidableEq Ent)
 
-example : goodWhExcl.Models constructGrammar := by decide
+example : goodWhExcl.Models grammar := by decide
 
 /-- Wh-relative ([sag-2010] (92)): a relative (proposition) filler-head construct whose filler is
 nominal (NP/PP). -/
-def goodWhRel : Interpretation constructSig where
+def goodWhRel : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .whRelCl | .sem => .proposition | u => baseS u
   A := singleGapA
@@ -522,12 +522,12 @@ def goodWhRel : Interpretation constructSig where
 instance : Fintype goodWhRel.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq goodWhRel.U := inferInstanceAs (DecidableEq Ent)
 
-example : goodWhRel.Models constructGrammar := by decide
+example : goodWhRel.Models grammar := by decide
 
 /-- The wh-relative filler restriction genuinely binds: an AP filler (`adj` — nonverbal but not
 nominal), token-identical to the head's gap so the filler-head constraint holds, violates the
 relative-specific `[CAT nominal]` restriction, so the construct is rejected. -/
-def whRelAdjFiller : Interpretation constructSig where
+def whRelAdjFiller : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .whRelCl | .sem => .proposition | u => baseS u
   A := fun a u => match a, u with
@@ -539,12 +539,12 @@ def whRelAdjFiller : Interpretation constructSig where
 instance : Fintype whRelAdjFiller.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq whRelAdjFiller.U := inferInstanceAs (DecidableEq Ent)
 
-example : ¬ whRelAdjFiller.Models constructGrammar := by decide
+example : ¬ whRelAdjFiller.Models grammar := by decide
 
 /-- The-clause ([sag-2010] (108)): an austinean filler-head construct whose head may be a
 complementizer-headed CP (`comp`) — distinguishing it from topicalization, whose head must be a verb
 projection ((27a) vs (27b)). -/
-def goodTheCl : Interpretation constructSig where
+def goodTheCl : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .theCl | u => baseS u
   A := fun a u => match a, u with
@@ -555,12 +555,12 @@ def goodTheCl : Interpretation constructSig where
 instance : Fintype goodTheCl.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq goodTheCl.U := inferInstanceAs (DecidableEq Ent)
 
-example : goodTheCl.Models constructGrammar := by decide
+example : goodTheCl.Models grammar := by decide
 
 /-- The topicalization head restriction binds: a CP (`comp`) head is verbal (so the inherited
 filler-head constraint holds) but violates topicalization's `[CAT verb]` restriction — the very
 constraint separating topicalization from the otherwise-identical (austinean) the-clause. -/
-def topClCompHead : Interpretation constructSig where
+def topClCompHead : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .topCl | u => baseS u
   A := fun a u => match a, u with
@@ -571,7 +571,7 @@ def topClCompHead : Interpretation constructSig where
 instance : Fintype topClCompHead.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq topClCompHead.U := inferInstanceAs (DecidableEq Ent)
 
-example : ¬ topClCompHead.Models constructGrammar := by decide
+example : ¬ topClCompHead.Models grammar := by decide
 
 /-! ### Gap amalgamation and islands ([sag-2010] §4–§5.1, after [bouma-malouf-sag-2001])
 
@@ -583,7 +583,7 @@ theorems of `Studies/SagWasowBender2003` and `Studies/Sag2010`. -/
 /-- **Amalgamation of overlapping dependencies** ([sag-2010] (53), (59)): a generic filler-head head
 with two gaps `⟨c₁, c₂⟩`; the filler binds `c₁` and the second gap `c₂` passes up — the mother's `GAP`
 is `⟨c₂⟩`. -/
-def goodTwoGap : Interpretation constructSig where
+def goodTwoGap : Interpretation sig where
   U := Ent
   S := baseS
   A := twoGapA
@@ -592,13 +592,13 @@ def goodTwoGap : Interpretation constructSig where
 instance : Fintype goodTwoGap.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq goodTwoGap.U := inferInstanceAs (DecidableEq Ent)
 
-example : goodTwoGap.Models constructGrammar := by decide
+example : goodTwoGap.Models grammar := by decide
 
 /-- **The absolute-island theorem** ([sag-2010] (67)–(68)). A *second* gap cannot penetrate a generic
 absolute island (`island-cxt`): a two-gap head amalgamates a non-empty mother `GAP ⟨c₂⟩`, contradicting
 the island's `[GAP ⟨⟩]` — so the construct is rejected. Topicalization is an absolute extraction island
 (`topClSecondGap` below), derived from the `[GAP ⟨⟩]` constraint plus amalgamation, not from Subjacency. -/
-def islandTwoGap : Interpretation constructSig where
+def islandTwoGap : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .islandCxt | u => baseS u
   A := twoGapA
@@ -607,12 +607,12 @@ def islandTwoGap : Interpretation constructSig where
 instance : Fintype islandTwoGap.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq islandTwoGap.U := inferInstanceAs (DecidableEq Ent)
 
-example : ¬ islandTwoGap.Models constructGrammar := by decide
+example : ¬ islandTwoGap.Models grammar := by decide
 
 /-- **NP extraction through a weak island is licensed.** A weak-island construct whose passing (second)
 gap is an NP (`noun`) amalgamates a non-empty mother `GAP ⟨NP⟩`; the weak-island antecedent (a `prep`
 mother gap) is false, so the constraint is vacuous and the structure is well-formed. -/
-def weakIslandNPGap : Interpretation constructSig where
+def weakIslandNPGap : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .weakIslandCxt | u => baseS u    -- c2 = noun (baseS default)
   A := twoGapA
@@ -621,13 +621,13 @@ def weakIslandNPGap : Interpretation constructSig where
 instance : Fintype weakIslandNPGap.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq weakIslandNPGap.U := inferInstanceAs (DecidableEq Ent)
 
-example : weakIslandNPGap.Models constructGrammar := by decide
+example : weakIslandNPGap.Models grammar := by decide
 
 /-- **PP extraction through a weak island is blocked.** The same geometry with a `prep` (PP) passing gap
 makes the mother `GAP ⟨PP⟩`; the weak-island constraint then forces `[GAP ⟨⟩]`, contradicting the
 non-empty mother gap — so the construct is rejected. The NP/PP asymmetry, derived from the constraint,
 not stipulated. -/
-def weakIslandPPGap : Interpretation constructSig where
+def weakIslandPPGap : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .weakIslandCxt | .c2 => .prep | u => baseS u
   A := twoGapA
@@ -636,7 +636,7 @@ def weakIslandPPGap : Interpretation constructSig where
 instance : Fintype weakIslandPPGap.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq weakIslandPPGap.U := inferInstanceAs (DecidableEq Ent)
 
-example : ¬ weakIslandPPGap.Models constructGrammar := by decide
+example : ¬ weakIslandPPGap.Models grammar := by decide
 
 /-! ### Islands as a property of the construction type ([sag-2010] §5.1)
 
@@ -647,7 +647,7 @@ wh-interrogative, wh-relative, and the-clause are not (their two-gap variants pa
 
 /-- **Topicalization blocks a second gap** ([sag-2010] (67)): a `top-cl` construct with two gaps
 amalgamates a non-empty mother `GAP`, contradicting `topIslandPrinciple`'s `[GAP ⟨⟩]` — rejected. -/
-def topClSecondGap : Interpretation constructSig where
+def topClSecondGap : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .topCl | u => baseS u
   A := twoGapA
@@ -656,11 +656,11 @@ def topClSecondGap : Interpretation constructSig where
 instance : Fintype topClSecondGap.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq topClSecondGap.U := inferInstanceAs (DecidableEq Ent)
 
-example : ¬ topClSecondGap.Models constructGrammar := by decide
+example : ¬ topClSecondGap.Models grammar := by decide
 
 /-- **Wh-exclamatives block a second gap** ([sag-2010] (74)): same as topicalization, via
 `whExclIslandPrinciple`. -/
-def whExclSecondGap : Interpretation constructSig where
+def whExclSecondGap : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .whExclCl | .sem => .fact | u => baseS u
   A := twoGapA
@@ -669,11 +669,11 @@ def whExclSecondGap : Interpretation constructSig where
 instance : Fintype whExclSecondGap.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq whExclSecondGap.U := inferInstanceAs (DecidableEq Ent)
 
-example : ¬ whExclSecondGap.Models constructGrammar := by decide
+example : ¬ whExclSecondGap.Models grammar := by decide
 
 /-- **Nonsubject wh-interrogatives are not islands** ([sag-2010] §5.3): a `ns-wh-int-cl` construct with
 a second gap passes — no `[GAP ⟨⟩]` constraint applies, so the second dependency amalgamates freely. -/
-def nsWhIntSecondGap : Interpretation constructSig where
+def nsWhIntSecondGap : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .nsWhIntCl | .sem => .question | u => baseS u
   A := twoGapA
@@ -682,12 +682,12 @@ def nsWhIntSecondGap : Interpretation constructSig where
 instance : Fintype nsWhIntSecondGap.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq nsWhIntSecondGap.U := inferInstanceAs (DecidableEq Ent)
 
-example : nsWhIntSecondGap.Models constructGrammar := by decide
+example : nsWhIntSecondGap.Models grammar := by decide
 
 /-- **Wh-relatives are not constructional islands** ([sag-2010], pace the Complex-NP Constraint): a
 `wh-rel-cl` construct with a second gap passes; the residual degradation is processing, not grammar
 ([hofmeister-sag-2010]). -/
-def whRelSecondGap : Interpretation constructSig where
+def whRelSecondGap : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .whRelCl | .sem => .proposition | u => baseS u
   A := twoGapA
@@ -696,10 +696,10 @@ def whRelSecondGap : Interpretation constructSig where
 instance : Fintype whRelSecondGap.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq whRelSecondGap.U := inferInstanceAs (DecidableEq Ent)
 
-example : whRelSecondGap.Models constructGrammar := by decide
+example : whRelSecondGap.Models grammar := by decide
 
 /-- **The-clauses are not islands**: a `the-cl` construct with a second gap passes. -/
-def theClSecondGap : Interpretation constructSig where
+def theClSecondGap : Interpretation sig where
   U := Ent
   S := fun u => match u with | .cxt => .theCl | u => baseS u
   A := twoGapA
@@ -708,6 +708,6 @@ def theClSecondGap : Interpretation constructSig where
 instance : Fintype theClSecondGap.U := inferInstanceAs (Fintype Ent)
 instance : DecidableEq theClSecondGap.U := inferInstanceAs (DecidableEq Ent)
 
-example : theClSecondGap.Models constructGrammar := by decide
+example : theClSecondGap.Models grammar := by decide
 
 end HPSG.Construction


### PR DESCRIPTION
Re-applies the namespace-relative rename that was stranded: my de-stutter force-push lost the merge race on #710, so main landed the intermediate `Construction.ConstructSort`/`Construction.constructGrammar` (which stutter the namespace) instead of the short forms.

`ConstructSort`→`Srt`, `ConstructAttr`→`Feat`, `constructSig`→`sig`, `constructGrammar`→`grammar`, `constructCovers`/`constructRank`/`constructApprop`→`covers`/`rank`/`approp`. The `Construction` namespace supplies the context (mathlib's `Finset.card`). Axiom-clean.