### PR TITLE
docs(Studies): fix verified citation locators in McPherson/Akinbo

### DIFF
--- a/Linglib/Studies/AkinboFwangwar2026.lean
+++ b/Linglib/Studies/AkinboFwangwar2026.lean
@@ -35,7 +35,7 @@ grammatical tones targeting ideophones in Mwaghavul. *Natural Language
 4. **Expressiveness survives integration.** Derived ideophonic verbs
    retain expressive properties (affective meaning,
    nondisplaceability, ineffability) despite full morphosyntactic
-   integration ([potts-2005]-style secondary meanings),
+   integration ([potts-2007]-style secondary meanings),
    challenging the inverse correlation predicted by
    [dingemanse-akita-2017].
 
@@ -684,11 +684,11 @@ theorem deadjectival_ideophone_verb :
     Recategorization.deadjectival.target = .v := ⟨rfl, rfl⟩
 
 -- ============================================================================
--- §9: Expressiveness Preservation (after [potts-2005])
+-- §9: Expressiveness Preservation (after [potts-2007])
 -- ============================================================================
 
 /-! [akinbo-fwangwar-2026] §4.2 argues that derived ideophonic
-    verbs retain [potts-2005]-style expressive properties despite
+    verbs retain [potts-2007]-style expressive properties despite
     morphosyntactic integration: affective meaning, nondisplaceability,
     descriptive ineffability, context-dependence. This challenges
     [dingemanse-akita-2017]'s prediction of inverse correlation

--- a/Linglib/Studies/McPhersonLamont2026.lean
+++ b/Linglib/Studies/McPhersonLamont2026.lean
@@ -33,9 +33,9 @@ Harmonic Grammar, but **does** yield to directional Harmonic Serialism
 2. **Positive**: directional HS, with `*FLOAT` evaluated left-to-right,
    selects the leftmost-floating-H deletion at each derivational step
    and converges on the attested form. Right-to-left evaluation yields
-   the wrong `*[kāk rī dó]` (paper, fig. 3); standard HS produces a
+   the wrong `*[kāk rī dó]` (paper, eq. (61); fig. 3); standard HS produces a
    divergent tie ([pruitt-2009] sense — the term is from Pruitt's
-   2009 manuscript, cited at fig. 3 caption).
+   2009 manuscript, cited in the §4 text accompanying fig. 3).
 
 The eq. 59 support uses only four of the ~20 constraints in the paper's
 Hasse diagram (fig. 2) because the paradox comparison is restricted to
@@ -969,7 +969,7 @@ central trifecta argument. Coverage extensions not in this file:
   immutable-`ulTier` invariant.
 - **Boundary tone L%**: currently omitted (sits at right edge after
   existing L tones, doesn't affect the M-then-L adjacency analyses
-  here). Needed for paper §3.3 LH-rising-tone tableaux (eq. 33–50).
+  here). Needed for paper §3.3 LH-rising-tone tableaux (eq. (33) onward).
 - **Other Hasse constraints**: `*LongTone`, `*L̃T̃<L`, `DEP(H)`,
   `DEP(M)`, `DEP(link)/L`, `DEP(link)/L%`. Marginal value for the
   central argument; needed for some §3.3 / §3.4 tableaux.


### PR DESCRIPTION
Audit-verified against the source PDFs:
- McPherson-Lamont: the RL wrong-output cites eq. (61); fig. 3 (not fig. 3 alone), the divergent-tie term is cited from §4 text, and the `*M<L` range is softened to eq. (33) onward.
- Akinbo-Fwangwar: `[potts-2005]`→`[potts-2007]` — the paper cites Potts 2007 "The expressive dimension" (the source of the six expressive properties the file encodes), not the 2005 book.