### PR TITLE
refactor(Phonology/Autosegmental): FloatingForm substrate golf + lift

### DIFF
--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -121,7 +121,7 @@ instance {S T : Type*} [Repr S] [Repr T] : Repr (FloatingForm S T) where
 
 namespace FloatingForm
 
-variable {S T : Type*} (f : FloatingForm S T)
+variable {S T : Type*} [DecidableEq S] [DecidableEq T] (f : FloatingForm S T)
 
 /-! ### Surface graph (derived view) -/
 
@@ -219,7 +219,7 @@ abbrev Crosses (k : TierIdx) (i : SegIdx) : Prop :=
     insert-and-associate and shift. The no-crossing filter ([goldsmith-1976])
     enforces well-formedness: without it a floating tone could dock across an
     intervening linked tone. -/
-def gen [DecidableEq S] [DecidableEq T] : Finset (FloatingForm S T) :=
+def gen : Finset (FloatingForm S T) :=
   let aliveIdxs := (Finset.range f.upper.length).filter (λ k => f.IsAlive k)
   let floatIdxs := aliveIdxs.filter (λ k => ¬ f.IsLinked k)
   let segIdxs := Finset.range f.lower.length

--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -42,36 +42,17 @@ floating features) chooses other `T` values.
 
 ## Implementation notes
 
-The form carries an immutable **underlying** state (`segs`, `ulTier`,
-`ulLinks`) and a mutable **surface** state (`deletedTier`,
-`surfaceLinks`). GEN operations modify only the surface state. A
-tier element is **floating** iff it is not deleted and no surface
-link references it.
+A `FloatingForm` carries an immutable **underlying** state (the inherited
+`Graph`: `lower`, `upper`, `links`) and a mutable **surface** state
+(`deletedTier`, `surfaceLinks`); GEN modifies only the surface. A tier element
+is **floating** iff it is alive (not deleted) and no surface link references it.
+This multi-element-per-position encoding (vs. the prior `tonalOverwrite`) is what
+[mcpherson-lamont-2026]'s `*CROWD` / `*FALL` constraints require.
 
-The refactor over the prior overwrite-semantics encoding
-(`GrammaticalTone.tonalOverwrite`) is required by
-[mcpherson-lamont-2026]: *CROWD penalises backbone positions
-with too many associated tier elements, and *FALL penalises HM/HL/ML
-contours — both of which presuppose multi-element-per-position
-representation.
-
-A surface link `(k, i)` is **tautomorphic** iff
-`upper[k].morpheme = lower[i].morpheme`. *TAUTDOCK (after
-[wolf-2007]) penalises tautomorphic links inserted by GEN.
-
-`gen` implements a paper-subset of operations: delete tier element,
-insert link, delete link. Insert-and-associate and shift operations
-are omitted (not needed for the fig. 3 derivation in the source
-paper). The no-crossing filter inside GEN enforces autosegmental
-well-formedness ([goldsmith-1976]).
-
-## References
-
-* [goldsmith-1976] — autosegmental phonology, no-crossing constraint
-* [wolf-2007] — *TAUTDOCK
-* [mcpherson-lamont-2026] — grammatical tone with multi-tone TBUs
-* [laoide-kemp-2026] — non-tonal floating segments (Irish ICM)
-* [lieber-1983] — floating features in autosegmental morphology
+`gen` is a paper-subset (delete tier element, insert/delete link; no
+insert-and-associate or shift), filtered for no-crossing ([goldsmith-1976]). A
+link is **tautomorphic** when its tier element and backbone share a morpheme
+(`*TAUTDOCK`, after [wolf-2007]).
 -/
 
 namespace Autosegmental
@@ -83,10 +64,10 @@ export Morphology.WordStructure (Morpheme)
 /-! ### Tier and link primitives -/
 
 /-- Index into the upper tier. -/
-abbrev TierIdx := Nat
+abbrev TierIdx := ℕ
 
 /-- Index into the lower tier. -/
-abbrev SegIdx := Nat
+abbrev SegIdx := ℕ
 
 /-- An autosegmental link: tier element `fst` is associated to
     backbone-position `snd`. -/
@@ -140,15 +121,14 @@ instance {S T : Type*} [Repr S] [Repr T] : Repr (FloatingForm S T) where
 
 namespace FloatingForm
 
-variable {S T : Type*} [DecidableEq S] [DecidableEq T]
+variable {S T : Type*} [DecidableEq S] [DecidableEq T] (f : FloatingForm S T)
 
 /-! ### Surface graph (derived view) -/
 
 /-- The **surface graph**: same tiers as the underlying graph but with
     `surfaceLinks` in place of `links`. Makes the underlying/surface
     duality explicit — both states are `Graph`s sharing tier data. -/
-@[reducible] def surfaceGraph (f : FloatingForm S T) :
-    Graph (TierSpec T) (SegSpec S) :=
+@[reducible] def surfaceGraph : Graph (TierSpec T) (SegSpec S) :=
   { f.toGraph with links := f.surfaceLinks }
 
 /-! ### Construction -/
@@ -167,43 +147,41 @@ def mkInput (lower : List (SegSpec S)) (upper : List (TierSpec T))
 
 /-- The tone at index `k` is alive (not deleted). The structural
     primitive; `IsDeleted` is its negation. -/
-abbrev IsAlive (f : FloatingForm S T) (k : TierIdx) : Prop := k ∉ f.deletedTier
+abbrev IsAlive (k : TierIdx) : Prop := k ∉ f.deletedTier
 
 /-- The tone at index `k` is deleted. Sugar for `¬ IsAlive`. -/
-abbrev IsDeleted (f : FloatingForm S T) (k : TierIdx) : Prop := ¬ f.IsAlive k
+abbrev IsDeleted (k : TierIdx) : Prop := ¬ f.IsAlive k
 
 /-- The tone at index `k` is linked to some TBU on the surface. -/
-abbrev IsLinked (f : FloatingForm S T) (k : TierIdx) : Prop :=
-  ∃ l ∈ f.surfaceLinks, l.fst = k
+abbrev IsLinked (k : TierIdx) : Prop := ∃ l ∈ f.surfaceLinks, l.fst = k
 
 /-- The tone at index `k` is floating (alive but unlinked). -/
-abbrev IsFloating (f : FloatingForm S T) (k : TierIdx) : Prop :=
-  f.IsAlive k ∧ ¬ f.IsLinked k
+abbrev IsFloating (k : TierIdx) : Prop := f.IsAlive k ∧ ¬ f.IsLinked k
 
 /-- A surface link `(k, i)` is **tautomorphic** iff its tone and TBU
     share a morpheme. Out-of-range indices on either side make this
     false. Used by *TAUTDOCK and the tautomorphic vs heteromorphic
     distinction discussed in the module docstring. -/
-abbrev IsTautomorphic (f : FloatingForm S T) (l : Link) : Prop :=
+abbrev IsTautomorphic (l : Link) : Prop :=
   (f.upper[l.fst]?).map TierSpec.morpheme =
     (f.lower[l.snd]?).map SegSpec.morpheme ∧
   (f.upper[l.fst]?).isSome
 
 /-! ### Atomic GEN operations -/
 
-/-- (6c) Delete the underlying tone at index `k`. Cascades to remove
-    any surface link referencing it. -/
-def deleteTierElem (f : FloatingForm S T) (k : TierIdx) : FloatingForm S T :=
+/-- Delete the underlying tone at index `k`. Cascades to remove any
+    surface link referencing it. -/
+def deleteTierElem (k : TierIdx) : FloatingForm S T :=
   { f with
     deletedTier := insert k f.deletedTier
     surfaceLinks := f.surfaceLinks.filter (λ l => l.fst ≠ k) }
 
-/-- (6a) Insert a surface link `(k, i)`. -/
-def insertLink (f : FloatingForm S T) (k : TierIdx) (i : SegIdx) : FloatingForm S T :=
+/-- Insert a surface link `(k, i)`. -/
+def insertLink (k : TierIdx) (i : SegIdx) : FloatingForm S T :=
   { f with surfaceLinks := insert (k, i) f.surfaceLinks }
 
-/-- (6b) Delete the surface link `(k, i)`. -/
-def deleteLink (f : FloatingForm S T) (k : TierIdx) (i : SegIdx) : FloatingForm S T :=
+/-- Delete the surface link `(k, i)`. -/
+def deleteLink (k : TierIdx) (i : SegIdx) : FloatingForm S T :=
   { f with surfaceLinks := f.surfaceLinks.erase (k, i) }
 
 /-! ### Well-formedness: no crossing lines -/
@@ -212,20 +190,18 @@ def deleteLink (f : FloatingForm S T) (k : TierIdx) (i : SegIdx) : FloatingForm 
     Wraps the substrate `IndexCrosses` defined over `Finset (ℕ × ℕ)`;
     `IsNonCrossing` (via mathlib's `MonovaryOn`) provides the set-level
     NCC and inherits mathlib's lemma library. -/
-abbrev Crosses (f : FloatingForm S T) (k : TierIdx) (i : SegIdx) : Prop :=
+abbrev Crosses (k : TierIdx) (i : SegIdx) : Prop :=
   IndexCrosses f.surfaceLinks k i
 
 /-! ### GEN: one-step candidate generation -/
 
-/-- One-step GEN. Enumerates: (a) the faithful candidate, (b) deleting
-    each alive tone, (c) for each FLOATING tone, inserting a link to
-    each TBU that doesn't cross an existing link. Subset of paper
-    eq. 6: omits (d) insert-and-associate and (e) shift, which fig. 3
-    doesn't use. The no-crossing filter ([goldsmith-1976])
-    enforces autosegmental well-formedness — without it, a floating H
-    could dock across an intervening linked tone, which the paper's
-    GEN implicitly forbids. -/
-def gen (f : FloatingForm S T) : Finset (FloatingForm S T) :=
+/-- One-step GEN: the faithful candidate, deleting each alive tone, and (for
+    each FLOATING tone) inserting a link to each TBU that doesn't cross an
+    existing link. A subset of [mcpherson-lamont-2026]'s GEN — omits
+    insert-and-associate and shift. The no-crossing filter ([goldsmith-1976])
+    enforces well-formedness: without it a floating tone could dock across an
+    intervening linked tone. -/
+def gen : Finset (FloatingForm S T) :=
   let aliveIdxs := (Finset.range f.upper.length).filter (λ k => f.IsAlive k)
   let floatIdxs := aliveIdxs.filter (λ k => ¬ f.IsLinked k)
   let segIdxs := Finset.range f.lower.length
@@ -236,11 +212,10 @@ def gen (f : FloatingForm S T) : Finset (FloatingForm S T) :=
 
 /-! ### Indicator vectors for constraint evaluation -/
 
-/-- Indicator vector for floating-tone presence at each underlying-tone
-    position, in tier order. Entry `k` is `1` iff `ulTones[k]` is
-    currently floating, else `0`. Used by directional `*FLOAT`
-    (paper, eq. 16). -/
-def floatIndicator (f : FloatingForm S T) : List Nat :=
+/-- Indicator vector for floating-tone presence at each tier position, in
+    tier order. Entry `k` is `1` iff `upper[k]` is currently floating, else
+    `0`. Used by directional `*FLOAT`. -/
+def floatIndicator : List ℕ :=
   (List.range f.upper.length).map λ k => if f.IsFloating k then 1 else 0
 
 /-- Surface tones linked to TBU `i`, returned in tier order (smallest
@@ -248,12 +223,12 @@ def floatIndicator (f : FloatingForm S T) : List Nat :=
     `List.range f.upper.length` so the result is naturally sorted
     and reduces well via kernel `decide` (avoiding `Finset.sort`,
     which doesn't unfold structurally). -/
-def linksTo (f : FloatingForm S T) (i : SegIdx) : List TierIdx :=
+def linksTo (i : SegIdx) : List TierIdx :=
   (List.range f.upper.length).filter λ k => (k, i) ∈ f.surfaceLinks
 
 /-- Sequence of tier values linked to backbone position `i`, in tier
     order. -/
-def tierValues (f : FloatingForm S T) (i : SegIdx) : List T :=
+def tierValues (i : SegIdx) : List T :=
   (f.linksTo i).filterMap λ k => f.upper[k]?.map TierSpec.value
 
 /-! ### Tier and morpheme subsequences -/
@@ -261,12 +236,12 @@ def tierValues (f : FloatingForm S T) (i : SegIdx) : List T :=
 /-- Indices of alive (non-deleted) underlying tones, in tier order.
     Iterates `List.range f.upper.length` so the result is naturally
     sorted and reduces well via kernel `decide`. -/
-def aliveTierIdxs (f : FloatingForm S T) : List TierIdx :=
+def aliveTierIdxs : List TierIdx :=
   (List.range f.upper.length).filter (λ k => f.IsAlive k)
 
 /-- Segment indices belonging to morpheme `m`, in segmental order.
     Out-of-range indices are excluded by construction. -/
-def segsOfMorpheme (f : FloatingForm S T) (m : Morpheme) : List SegIdx :=
+def segsOfMorpheme (m : Morpheme) : List SegIdx :=
   (List.range f.lower.length).filter (λ i =>
     (f.lower[i]?).map SegSpec.morpheme = some m)
 
@@ -274,12 +249,12 @@ def segsOfMorpheme (f : FloatingForm S T) (m : Morpheme) : List SegIdx :=
 
 /-- Count tier (tone) positions satisfying decidable `p`. `List.range`-based so it
     reduces under kernel `decide` (avoiding `Finset` pipelines). -/
-def countTones (f : FloatingForm S T) (p : TierIdx → Prop) [DecidablePred p] : Nat :=
-  (List.range f.upper.length).countP (fun k => decide (p k))
+def countTones (p : TierIdx → Prop) [DecidablePred p] : ℕ :=
+  (List.range f.upper.length).countP (λ k => decide (p k))
 
 /-- Count backbone (TBU) positions satisfying decidable `p`. -/
-def countTBUs (f : FloatingForm S T) (p : SegIdx → Prop) [DecidablePred p] : Nat :=
-  (List.range f.lower.length).countP (fun i => decide (p i))
+def countTBUs (p : SegIdx → Prop) [DecidablePred p] : ℕ :=
+  (List.range f.lower.length).countP (λ i => decide (p i))
 
 end FloatingForm
 

--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -121,7 +121,7 @@ instance {S T : Type*} [Repr S] [Repr T] : Repr (FloatingForm S T) where
 
 namespace FloatingForm
 
-variable {S T : Type*} [DecidableEq S] [DecidableEq T] (f : FloatingForm S T)
+variable {S T : Type*} (f : FloatingForm S T)
 
 /-! ### Surface graph (derived view) -/
 
@@ -155,25 +155,25 @@ def lowerMorpheme? (i : SegIdx) : Option Morpheme := (f.lower[i]?).map SegSpec.m
 def morphemes : Finset Morpheme :=
   (f.lower.map SegSpec.morpheme).toFinset ∪ (f.upper.map TierSpec.morpheme).toFinset
 
-/-! ### Predicates on tones and links -/
+/-! ### Predicates on tier elements and links -/
 
-/-- The tone at index `k` is alive (not deleted). The structural
+/-- The upper-tier element at index `k` is alive (not deleted). The structural
     primitive; `IsDeleted` is its negation. -/
 abbrev IsAlive (k : TierIdx) : Prop := k ∉ f.deletedTier
 
-/-- The tone at index `k` is deleted. Sugar for `¬ IsAlive`. -/
+/-- The upper-tier element at index `k` is deleted. Sugar for `¬ IsAlive`. -/
 abbrev IsDeleted (k : TierIdx) : Prop := ¬ f.IsAlive k
 
-/-- The tone at index `k` is linked to some TBU on the surface. -/
+/-- The upper-tier element at index `k` is linked to a backbone position
+    on the surface. -/
 abbrev IsLinked (k : TierIdx) : Prop := ∃ l ∈ f.surfaceLinks, l.fst = k
 
-/-- The tone at index `k` is floating (alive but unlinked). -/
+/-- The upper-tier element at index `k` is floating (alive but unlinked). -/
 abbrev IsFloating (k : TierIdx) : Prop := f.IsAlive k ∧ ¬ f.IsLinked k
 
-/-- A surface link `(k, i)` is **tautomorphic** iff its tone and TBU
-    share a morpheme. Out-of-range indices on either side make this
-    false. Used by *TAUTDOCK and the tautomorphic vs heteromorphic
-    distinction discussed in the module docstring. -/
+/-- A surface link `(k, i)` is **tautomorphic** iff its upper- and lower-tier
+    endpoints share a morpheme. Out-of-range indices on either side make this
+    false. -/
 abbrev IsTautomorphic (l : Link) : Prop :=
   f.upperMorpheme? l.fst = f.lowerMorpheme? l.snd ∧ (f.upper[l.fst]?).isSome
 
@@ -187,8 +187,8 @@ abbrev IsDeletedLink (l : Link) : Prop := l ∈ f.links ∧ l ∉ f.surfaceLinks
 
 /-! ### Atomic GEN operations -/
 
-/-- Delete the underlying tone at index `k`. Cascades to remove any
-    surface link referencing it. -/
+/-- Delete the underlying upper-tier element at index `k`. Cascades to remove
+    any surface link referencing it. -/
 def deleteTierElem (k : TierIdx) : FloatingForm S T :=
   { f with
     deletedTier := insert k f.deletedTier
@@ -219,7 +219,7 @@ abbrev Crosses (k : TierIdx) (i : SegIdx) : Prop :=
     insert-and-associate and shift. The no-crossing filter ([goldsmith-1976])
     enforces well-formedness: without it a floating tone could dock across an
     intervening linked tone. -/
-def gen : Finset (FloatingForm S T) :=
+def gen [DecidableEq S] [DecidableEq T] : Finset (FloatingForm S T) :=
   let aliveIdxs := (Finset.range f.upper.length).filter (λ k => f.IsAlive k)
   let floatIdxs := aliveIdxs.filter (λ k => ¬ f.IsLinked k)
   let segIdxs := Finset.range f.lower.length
@@ -230,17 +230,16 @@ def gen : Finset (FloatingForm S T) :=
 
 /-! ### Indicator vectors for constraint evaluation -/
 
-/-- Indicator vector for floating-tone presence at each tier position, in
-    tier order. Entry `k` is `1` iff `upper[k]` is currently floating, else
-    `0`. Used by directional `*FLOAT`. -/
+/-- Indicator vector of floating upper-tier elements, in tier order: entry `k`
+    is `1` iff `upper[k]` is currently floating, else `0`. Drives directional
+    floating constraints (e.g. `*FLOAT`). -/
 def floatIndicator : List ℕ :=
   (List.range f.upper.length).map λ k => if f.IsFloating k then 1 else 0
 
-/-- Surface tones linked to TBU `i`, returned in tier order (smallest
-    tone index first). Used by *FALL and *CROWD. We iterate over
-    `List.range f.upper.length` so the result is naturally sorted
-    and reduces well via kernel `decide` (avoiding `Finset.sort`,
-    which doesn't unfold structurally). -/
+/-- Upper-tier elements surface-linked to backbone position `i`, in tier order
+    (smallest index first). `List.range`-based so the result is naturally sorted
+    and reduces under kernel `decide` (avoiding `Finset.sort`, which doesn't
+    unfold structurally). -/
 def linksTo (i : SegIdx) : List TierIdx :=
   (List.range f.upper.length).filter λ k => (k, i) ∈ f.surfaceLinks
 
@@ -251,25 +250,24 @@ def tierValues (i : SegIdx) : List T :=
 
 /-! ### Tier and morpheme subsequences -/
 
-/-- Indices of alive (non-deleted) underlying tones, in tier order.
-    Iterates `List.range f.upper.length` so the result is naturally
-    sorted and reduces well via kernel `decide`. -/
+/-- Indices of alive (non-deleted) underlying upper-tier elements, in tier
+    order; `List.range`-based so it reduces under kernel `decide`. -/
 def aliveTierIdxs : List TierIdx :=
   (List.range f.upper.length).filter (λ k => f.IsAlive k)
 
-/-- Segment indices belonging to morpheme `m`, in segmental order.
+/-- Lower-tier (backbone) indices belonging to morpheme `m`, in order.
     Out-of-range indices are excluded by construction. -/
 def segsOfMorpheme (m : Morpheme) : List SegIdx :=
   (List.range f.lower.length).filter (λ i => f.lowerMorpheme? i = some m)
 
 /-! ### Position counts -/
 
-/-- Count tier (tone) positions satisfying decidable `p`. `List.range`-based so it
+/-- Count upper-tier positions satisfying decidable `p`. `List.range`-based so it
     reduces under kernel `decide` (avoiding `Finset` pipelines). -/
 def countTones (p : TierIdx → Prop) [DecidablePred p] : ℕ :=
   (List.range f.upper.length).countP (λ k => decide (p k))
 
-/-- Count backbone (TBU) positions satisfying decidable `p`. -/
+/-- Count lower-tier (backbone) positions satisfying decidable `p`. -/
 def countTBUs (p : SegIdx → Prop) [DecidablePred p] : ℕ :=
   (List.range f.lower.length).countP (λ i => decide (p i))
 

--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -143,6 +143,18 @@ def mkInput (lower : List (SegSpec S)) (upper : List (TierSpec T))
     deletedTier := ∅
     surfaceLinks := links }
 
+/-! ### Morphemic structure -/
+
+/-- The morpheme of the `k`-th upper-tier element, or `none` if out of range. -/
+def upperMorpheme? (k : TierIdx) : Option Morpheme := (f.upper[k]?).map TierSpec.morpheme
+
+/-- The morpheme of the `i`-th lower-tier element, or `none` if out of range. -/
+def lowerMorpheme? (i : SegIdx) : Option Morpheme := (f.lower[i]?).map SegSpec.morpheme
+
+/-- Every morpheme occurring on either tier. -/
+def morphemes : Finset Morpheme :=
+  (f.lower.map SegSpec.morpheme).toFinset ∪ (f.upper.map TierSpec.morpheme).toFinset
+
 /-! ### Predicates on tones and links -/
 
 /-- The tone at index `k` is alive (not deleted). The structural
@@ -163,9 +175,15 @@ abbrev IsFloating (k : TierIdx) : Prop := f.IsAlive k ∧ ¬ f.IsLinked k
     false. Used by *TAUTDOCK and the tautomorphic vs heteromorphic
     distinction discussed in the module docstring. -/
 abbrev IsTautomorphic (l : Link) : Prop :=
-  (f.upper[l.fst]?).map TierSpec.morpheme =
-    (f.lower[l.snd]?).map SegSpec.morpheme ∧
-  (f.upper[l.fst]?).isSome
+  f.upperMorpheme? l.fst = f.lowerMorpheme? l.snd ∧ (f.upper[l.fst]?).isSome
+
+/-! ### Faithfulness: surface vs underlying -/
+
+/-- A surface link absent underlyingly — inserted by GEN (`DEP` / `*TAUTDOCK` source). -/
+abbrev IsInsertedLink (l : Link) : Prop := l ∈ f.surfaceLinks ∧ l ∉ f.links
+
+/-- An underlying link absent on the surface — deleted by GEN (`MAX` source). -/
+abbrev IsDeletedLink (l : Link) : Prop := l ∈ f.links ∧ l ∉ f.surfaceLinks
 
 /-! ### Atomic GEN operations -/
 
@@ -242,8 +260,7 @@ def aliveTierIdxs : List TierIdx :=
 /-- Segment indices belonging to morpheme `m`, in segmental order.
     Out-of-range indices are excluded by construction. -/
 def segsOfMorpheme (m : Morpheme) : List SegIdx :=
-  (List.range f.lower.length).filter (λ i =>
-    (f.lower[i]?).map SegSpec.morpheme = some m)
+  (List.range f.lower.length).filter (λ i => f.lowerMorpheme? i = some m)
 
 /-! ### Position counts -/
 

--- a/Linglib/Phonology/Tone/Constraints.lean
+++ b/Linglib/Phonology/Tone/Constraints.lean
@@ -52,15 +52,11 @@ open Constraint OptimalityTheory
 
 variable {S : Type*} [DecidableEq S] (f : FloatingForm S TRN)
 
-/-! ### Predicate Helpers -/
+/-! ### Tone-value predicate
 
-/-- The link `(k, i)` was inserted by GEN (in surface but not in underlying). -/
-abbrev IsInsertedLink (l : Link) : Prop :=
-  l ∈ f.surfaceLinks ∧ l ∉ f.links
-
-/-- The link `(k, i)` was deleted by GEN (in underlying but not in surface). -/
-abbrev IsDeletedLink (l : Link) : Prop :=
-  l ∈ f.links ∧ l ∉ f.surfaceLinks
+Link faithfulness (`FloatingForm.IsInsertedLink` / `IsDeletedLink`) and the morpheme
+accessors (`upperMorpheme?` / `lowerMorpheme?` / `morphemes`) are tone-agnostic and live
+on `FloatingForm`; only the `TRN`-reading predicate is here. -/
 
 /-- The tone at index `k` has value `t`. -/
 abbrev ToneHasValue (k : TierIdx) (t : TRN) : Prop :=
@@ -88,37 +84,24 @@ def starFloatCount : DirectionalConstraint (FloatingForm S TRN) :=
     per GEN-inserted tautomorphic surface link. -/
 def starTautDock : DirectionalConstraint (FloatingForm S TRN) :=
   .ofCount "*TAUTDOCK" .markedness
-    (fun f => (f.surfaceLinks.filter (fun l => IsInsertedLink f l ∧ f.IsTautomorphic l)).card)
+    (fun f => (f.surfaceLinks.filter (fun l => f.IsInsertedLink l ∧ f.IsTautomorphic l)).card)
 
 /-! ### *CROWD (per-morpheme tone count) -/
 
-/-- The tone at index `k` belongs to morpheme `m`. -/
-abbrev ToneInMorpheme (k : TierIdx) (m : Morpheme) : Prop :=
-  (f.upper[k]?).map TierSpec.morpheme = some m
-
-/-- The TBU at index `i` belongs to morpheme `m`. -/
-abbrev SegInMorpheme (i : SegIdx) (m : Morpheme) : Prop :=
-  (f.lower[i]?).map SegSpec.morpheme = some m
-
-/-- The set of tone indices counting toward morpheme `m`'s tonal mass:
-    surviving underlying tones of `m`, plus tones surface-linked to
-    TBUs of `m`. -/
+/-- The tone indices counting toward morpheme `m`'s tonal mass: surviving
+    underlying tones of `m`, plus tones surface-linked to TBUs of `m`. -/
 def tonesForMorpheme (m : Morpheme) : Finset TierIdx :=
   let ownAlive := (Finset.range f.upper.length).filter fun k =>
-    f.IsAlive k ∧ ToneInMorpheme f k m
-  let docked := (f.surfaceLinks.filter fun l => SegInMorpheme f l.snd m).image Prod.fst
+    f.IsAlive k ∧ f.upperMorpheme? k = some m
+  let docked := (f.surfaceLinks.filter fun l => f.lowerMorpheme? l.snd = some m).image Prod.fst
   ownAlive ∪ docked
-
-/-- All morphemes occurring in `f`, on either tier. -/
-def morphemes : Finset Morpheme :=
-  (f.lower.map SegSpec.morpheme).toFinset ∪ (f.upper.map TierSpec.morpheme).toFinset
 
 /-- `*CROWD` (paper eq. 5): one violation per morpheme with more than `threshold`
     tones (default 2), counting its surviving underlying tones plus tones docked onto
     its TBUs from other morphemes. -/
 def starCrowd (threshold : Nat := 2) : DirectionalConstraint (FloatingForm S TRN) :=
   .ofCount s!"*CROWD({threshold})" .markedness
-    (fun f => ((morphemes f).filter (fun m => threshold < (tonesForMorpheme f m).card)).card)
+    (fun f => (f.morphemes.filter (fun m => threshold < (tonesForMorpheme f m).card)).card)
 
 /-! ### *FALL (falling contours on multi-linked TBUs) -/
 
@@ -177,13 +160,13 @@ def maxTone (t : TRN) : DirectionalConstraint (FloatingForm S TRN) :=
     inserted by GEN whose linked tone has value `t`. -/
 def depLinkTone (t : TRN) : DirectionalConstraint (FloatingForm S TRN) :=
   .ofCount s!"DEP(link)/{reprStr t}" .faithfulness
-    (fun f => (f.surfaceLinks.filter (fun l => IsInsertedLink f l ∧ ToneHasValue f l.fst t)).card)
+    (fun f => (f.surfaceLinks.filter (fun l => f.IsInsertedLink l ∧ ToneHasValue f l.fst t)).card)
 
 /-- `MAX(link)/T` (paper, eq. 7b): one violation per underlying link of
     value `t` deleted by GEN. -/
 def maxLinkTone (t : TRN) : DirectionalConstraint (FloatingForm S TRN) :=
   .ofCount s!"MAX(link)/{reprStr t}" .faithfulness
-    (fun f => (f.links.filter (fun l => IsDeletedLink f l ∧ ToneHasValue f l.fst t)).card)
+    (fun f => (f.links.filter (fun l => f.IsDeletedLink l ∧ ToneHasValue f l.fst t)).card)
 
 /-- `INTEGRITY` ([mccarthy-prince-1995]; [akinbo-fwangwar-2026]): no input tone has
     multiple output correspondents — here, alive `ulTier` entries sharing tone value `t`
@@ -192,6 +175,6 @@ def maxLinkTone (t : TRN) : DirectionalConstraint (FloatingForm S TRN) :=
 def integrityTone (m : Morpheme) (t : TRN) :
     DirectionalConstraint (FloatingForm S TRN) :=
   .ofCount s!"INTEGRITY-{reprStr t}({m.form})" .faithfulness
-    (fun f => f.countTones (fun k => f.IsAlive k ∧ ToneInMorpheme f k m ∧ ToneHasValue f k t) - 1)
+    (fun f => f.countTones (fun k => f.IsAlive k ∧ f.upperMorpheme? k = some m ∧ ToneHasValue f k t) - 1)
 
 end Tone


### PR DESCRIPTION
Makes `FloatingForm` the elegant common substrate for the autosegmental tone/floating papers (McPherson-Lamont, Laoide-Kemp, Akinbo-Fwangwar).

- **Golf:** `f`→`variable`, `Nat`→`ℕ`, tier-neutral docstrings, citation fixes, `DecidableEq` scoped to `gen` (not the whole namespace).
- **Lift:** the tone-agnostic primitives move onto `FloatingForm` — link faithfulness (`IsInsertedLink`/`IsDeletedLink` = `DEP`/`MAX` source) and morphemic structure (`upperMorpheme?`/`lowerMorpheme?`/`morphemes`; `IsTautomorphic`/`segsOfMorpheme` now derive from the accessors). `Tone/Constraints` becomes a thin `TRN`-reading client (the boundary is now exactly "reads the tier-value `T`?").