### PR TITLE
feat(Syntax/HPSG): ground categories in UD, retire isNom hack

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2136,6 +2136,7 @@ import Linglib.Syntax.HPSG.LexicalRules
 import Linglib.Syntax.HPSG.RelativeClauses
 import Linglib.Syntax.HPSG.Coreference
 import Linglib.Syntax.HPSG.Binding
+import Linglib.Syntax.HPSG.Categories
 import Linglib.Syntax.HPSG.Construction
 -- Theories: Minimalism
 import Linglib.Syntax.Minimalist.Features

--- a/Linglib/Syntax/HPSG/Categories.lean
+++ b/Linglib/Syntax/HPSG/Categories.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.HPSG.Construction
+import Linglib.Data.UD.Basic
+
+/-!
+# HPSG categories: grounding in Universal Dependencies and compatibility
+[sag-2010]
+
+The HPSG syntactic categories are the **cat sub-hierarchy** of the RSRL construct signature
+(`Syntax/HPSG/Construction`): `cat > {verbal, nonverbal}`, `verbal > {verb, comp}`,
+`nonverbal > {nominal, adj}`, `nominal > {noun, prep}`, with a genuine subsumption order. Empirical
+data is tagged with **Universal Dependencies** POS tags (`UD.UPOS`); `udToCat` is the grounding bridge,
+mapping each UD tag to its HPSG cat sort so UD-tagged data enters the category hierarchy by conversion
+(the project's Layered-Grounding discipline) rather than `UD.UPOS` being used *as* the category type.
+
+`udToCat` is **where the nominal conflation becomes principled**: `NOUN`/`PRON`/`PROPN` all map to
+`noun`, so `categoriesMatch` treats them alike via the cat hierarchy's `≤` (`noun ≤ nominal`, etc.)
+without any hand-coded `isNom` test. Tags with no HPSG cat correspondent (`ADV`, `DET`, `NUM`, …) map to
+`none`, and `categoriesMatch` falls back to UD-tag equality for them.
+-/
+
+namespace HPSG
+
+open HPSG.Construction (Srt)
+
+/-- The HPSG cat sort a Universal Dependencies POS tag grounds to ([sag-2010]'s category hierarchy).
+`NOUN`/`PRON`/`PROPN` → `noun` (NP), `ADP` → `prep` (PP), `VERB`/`AUX` → `verb`, `ADJ` → `adj`,
+`SCONJ` → `comp` (complementizer); tags with no cat correspondent are `none`. -/
+def udToCat : UD.UPOS → Option Srt
+  | .NOUN => some .noun
+  | .PRON => some .noun
+  | .PROPN => some .noun
+  | .ADP => some .prep
+  | .VERB => some .verb
+  | .AUX => some .verb
+  | .ADJ => some .adj
+  | .SCONJ => some .comp
+  | _ => none
+
+/-- Are two categories compatible? Grounded in the HPSG cat hierarchy: each UD tag maps to its cat sort
+(`udToCat`) and the two must be comparable in the subsumption order — so all nominal categories
+(`NOUN`/`PRON`/`PROPN` → `noun`) match each other without a hand-coded test, and a sort compares with its
+supersorts. For tags with no cat correspondent it falls back to UD-tag equality. -/
+def categoriesMatch (c1 c2 : UD.UPOS) : Bool :=
+  match udToCat c1, udToCat c2 with
+  | some a, some b => decide (a ≤ b) || decide (b ≤ a)
+  | _, _ => c1 == c2
+
+end HPSG

--- a/Linglib/Syntax/HPSG/HeadFiller.lean
+++ b/Linglib/Syntax/HPSG/HeadFiller.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.HPSG.Basic
+import Linglib.Syntax.HPSG.Categories
 
 /-!
 # Head-Filler Schema and SLASH Feature
@@ -69,15 +70,8 @@ instance : BEq SlashValue where
 
 /-! ## Nominal Category Compatibility
 
-In HPSG, all nominals share a single head type (noun). Our UD-based system
-distinguishes NOUN, PRON, and PROPN. For SLASH matching, these are compatible. -/
-
-/-- Are two categories compatible for SLASH matching?
-All nominal categories (NOUN, PRON, PROPN) match each other. -/
-def categoriesMatch (c1 c2 : UD.UPOS) : Bool :=
-  let isNom (c : UD.UPOS) : Bool := c == .NOUN || c == .PRON || c == .PROPN
-  if isNom c1 && isNom c2 then true
-  else c1 == c2
+Category compatibility for SLASH matching is `categoriesMatch` (`Syntax/HPSG/Categories`), grounded in
+the HPSG cat hierarchy via `udToCat`: all nominals (`NOUN`/`PRON`/`PROPN` → `noun`) match each other. -/
 
 /-- Check if SLASH contains a compatible category (using nominal matching). -/
 def SlashValue.containsCompatible (sv : SlashValue) (c : UD.UPOS) : Bool :=


### PR DESCRIPTION
Phase 1 of the core-retirement roadmap (`scratch/hpsg-core-retirement-spec.md`): kill the `categoriesMatch` nominal-conflation hack and ground HPSG categories in the cat hierarchy, while **keeping UD as the empirical anchor**.

New `Syntax/HPSG/Categories.lean` holds `udToCat : UD.UPOS → Option Srt` (the grounding map: `NOUN`/`PRON`/`PROPN` → `noun`, `ADP` → `prep`, `VERB`/`AUX` → `verb`, `ADJ` → `adj`, `SCONJ` → `comp`) and `categoriesMatch`, now defined by cat-sort subsumption: `udToCat c1 ≤ udToCat c2 ∨ udToCat c2 ≤ udToCat c1`, falling back to UD-tag equality for unmapped tags.

This retires `UD.UPOS` as the category *type* (it's used *as* the category in the old `isNom` test) while keeping it as the *grounding* — the nominal conflation is now principled (the map sends the three nominal tags to `noun`), no hand-coded `isNom`. `categoriesMatch` moves out of `HeadFiller` into `Categories` (it's a category op, used by SLASH/MOD/relatives, and survives the core's retirement). All `#guard`s, `categoriesMatch_refl`, and consumers (SWB2003, RelativeClauses, Mueller2013, Sag2010, KOS) green; axiom-clean.