### PR TITLE
chore(Studies/Sag2010): drop unused HeadFiller import (core-free)

### DIFF
--- a/Linglib/Studies/Sag2010.lean
+++ b/Linglib/Studies/Sag2010.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Syntax.HPSG.HeadFiller
 import Linglib.Syntax.HPSG.Construction
 import Linglib.Studies.Ross1967
 import Linglib.Studies.SagWasowBender2003


### PR DESCRIPTION
Phase 2 of the core-retirement roadmap: `Sag2010` now imports none of the computational core. It turned out trivial — the `import HeadFiller` was already dead (prior PRs #704/#706/#708 migrated every island/construction claim to RSRL `Models` facts over `Construction`), so this just removes the unused import. Proves a consumer can shed the core; builds green.