### PR TITLE
feat(Studies): Cinque 2005, deriving Greenberg's Universal 20

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1231,6 +1231,7 @@ import Linglib.Studies.Pantcheva2011
 import Linglib.Studies.Pesetsky2013
 import Linglib.Studies.BakerVinokurova2010
 import Linglib.Studies.Comrie1989
+import Linglib.Studies.Cinque2005
 import Linglib.Studies.Cinque2020
 import Linglib.Typology.ClauseChaining
 import Linglib.Studies.SarvasyAikhenvald2025

--- a/Linglib/Studies/Cinque2005.lean
+++ b/Linglib/Studies/Cinque2005.lean
@@ -1,0 +1,196 @@
+import Linglib.Syntax.Minimalist.Derivation
+
+/-!
+# Cinque 2005: Deriving Greenberg's Universal 20 [cinque-2005]
+
+[cinque-2005] derives the cross-linguistic typology of the four DP-internal
+elements **demonstrative, numeral, adjective, noun** from a single universal
+Merge order plus constrained phrasal movement:
+
+- **Universal Merge order** `[ Dem [ Num [ A [ NP ]]]]` (Dem > Num > A > N), the
+  same for every language — the prenominal order of [greenberg-1963]'s Universal
+  20.
+- **Movement**: only the NP, or an XP *containing* the NP, raises leftward,
+  Spec-to-Spec, around the modifiers (with/without pied-piping; total/partial).
+  No movement of a phrase not containing the NP (no remnant movement).
+
+Of the 4! = 24 logically possible orders, exactly **14 are attested** and all 14
+are derivable; the 10 unattested are exactly the underivable ones (each would
+require a *wrong Merge order* of the modifiers).
+
+## What this file establishes
+
+This study runs Cinque's derivations on the **real MCB Merge substrate**
+(`Syntax/Minimalist/Derivation.lean`): each order is a `Derivation` (fixed-order
+External Merge to build the base, then `Step.im` leftward movements), and the
+surface order is read off by the computable `Derivation.surfaceCats`
+(derivation-grounded externalization — MCB σ_L, not `Quot.out`). The orders are
+verified by `decide`.
+
+**Eight of the fourteen attested orders are derived explicitly here** (the
+bare-NP-raising series a–d and the pied-piping cases n, o, t, x), demonstrating
+the mechanism end-to-end on the substrate. The full enumeration of the legal
+derivation space (to prove the **remaining** attested orders derivable *and the
+10 unattested ones underivable*), and the markedness-tracks-frequency result, are
+flagged TODOs below — they require generating the complete bounded movement space.
+
+## Encoding note
+
+The substrate `Cat` enum has `.Num`, `.A`, `.N` but no dedicated demonstrative
+constructor, so **`.D` encodes the demonstrative slot** here. A dedicated
+`Cat.Dem` (with its extended-projection F-level and ±V/±N features) is a deferred
+substrate refinement; it does not affect the combinatorial result, which only
+needs four distinct categories.
+-/
+
+namespace Cinque2005
+
+open Minimalist
+
+/-! ### The four elements (head-initial leaves) -/
+
+/-- Noun (the raising NP). -/
+def noun : SyntacticObject := mkLeaf .N [] 1
+/-- Adjective. -/
+def adj : SyntacticObject := mkLeaf .A [] 2
+/-- Numeral. -/
+def numl : SyntacticObject := mkLeaf .Num [] 3
+/-- Demonstrative (encoded as `.D`; see module note). -/
+def dem : SyntacticObject := mkLeaf .D [] 4
+
+/-! ### Frequency buckets and the 24-order attestation table ([cinque-2005] (6))
+
+Transcribed from the paper. `√` rows are attested; `*` rows unattested. Frequency
+is the paper's cross-linguistic bucket (number of languages instantiating the
+order). `.D` stands for the demonstrative. -/
+
+/-- Cross-linguistic frequency of an order ([cinque-2005] (6)). -/
+inductive Freq | veryMany | many | few | veryFew | unattested
+  deriving DecidableEq, Repr
+
+/-- One row of Cinque's typology table: an order of {Dem,Num,A,N}, whether it is
+    attested, and its frequency bucket. -/
+structure OrderRow where
+  order : List Cat
+  attested : Bool
+  freq : Freq
+  deriving DecidableEq, Repr
+
+/-- [cinque-2005] table (6), rows a–x. -/
+def table : List OrderRow :=
+  [ ⟨[.D, .Num, .A, .N], true,  .veryMany⟩   -- a
+  , ⟨[.D, .Num, .N, .A], true,  .many⟩       -- b
+  , ⟨[.D, .N, .Num, .A], true,  .veryFew⟩    -- c
+  , ⟨[.N, .D, .Num, .A], true,  .few⟩        -- d
+  , ⟨[.Num, .D, .A, .N], false, .unattested⟩ -- e
+  , ⟨[.Num, .D, .N, .A], false, .unattested⟩ -- f
+  , ⟨[.Num, .N, .D, .A], false, .unattested⟩ -- g
+  , ⟨[.N, .Num, .D, .A], false, .unattested⟩ -- h
+  , ⟨[.A, .D, .Num, .N], false, .unattested⟩ -- i
+  , ⟨[.A, .D, .N, .Num], false, .unattested⟩ -- j
+  , ⟨[.A, .N, .D, .Num], true,  .veryFew⟩    -- k
+  , ⟨[.N, .A, .D, .Num], true,  .few⟩        -- l
+  , ⟨[.D, .A, .Num, .N], false, .unattested⟩ -- m
+  , ⟨[.D, .A, .N, .Num], true,  .veryFew⟩    -- n
+  , ⟨[.D, .N, .A, .Num], true,  .many⟩       -- o
+  , ⟨[.N, .D, .A, .Num], true,  .veryFew⟩    -- p
+  , ⟨[.Num, .A, .D, .N], false, .unattested⟩ -- q
+  , ⟨[.Num, .A, .N, .D], true,  .veryFew⟩    -- r
+  , ⟨[.Num, .N, .A, .D], true,  .few⟩        -- s
+  , ⟨[.N, .Num, .A, .D], true,  .few⟩        -- t
+  , ⟨[.A, .Num, .D, .N], false, .unattested⟩ -- u
+  , ⟨[.A, .Num, .N, .D], false, .unattested⟩ -- v
+  , ⟨[.A, .N, .Num, .D], true,  .veryFew⟩    -- w
+  , ⟨[.N, .A, .Num, .D], true,  .veryMany⟩ ] -- x
+
+/-- [cinque-2005]: exactly 14 of the 24 orders are attested. -/
+theorem attested_count : (table.filter (·.attested)).length = 14 := by decide
+
+/-- The 10 unattested orders. -/
+theorem unattested_count : (table.filter (¬ ·.attested)).length = 10 := by decide
+
+/-- Every attested order is `.unattested`-free; every unattested order has freq
+    `.unattested` (table internal consistency). -/
+theorem table_freq_consistent :
+    table.all (fun r => r.attested = (r.freq ≠ .unattested)) := by decide
+
+/-! ### Derivations on the MCB substrate
+
+Built bottom-up: `initial := noun`, then head-initial External Merge of A, Num,
+Dem (`emL`), interleaved with `Step.im` leftward raising. `surfaceCats` reads off
+the order via the computable derivation-grounded externalization.
+
+Movers: a bare NP raise passes `noun`; a pied-piping raise passes the
+NP-containing constituent (which contains the earlier traces). -/
+
+/-- (a) Dem Num A N — no movement. -/
+def derA : Derivation := { initial := noun, steps := [.emL adj, .emL numl, .emL dem] }
+
+/-- (b) Dem Num N A — NP raises around A (bare). -/
+def derB : Derivation :=
+  { initial := noun, steps := [.emL adj, .im noun 1, .emL numl, .emL dem] }
+
+/-- (c) Dem N Num A — NP raises around A then Num (partial, bare). -/
+def derC : Derivation :=
+  { initial := noun, steps := [.emL adj, .im noun 1, .emL numl, .im noun 2, .emL dem] }
+
+/-- (d) N Dem Num A — NP raises around A, Num, Dem (total, bare). -/
+def derD : Derivation :=
+  { initial := noun
+    steps := [.emL adj, .im noun 1, .emL numl, .im noun 2, .emL dem, .im noun 3] }
+
+/-- (n) Dem A N Num — pied-pipe `[A N]` around Num (no sub-raise). -/
+def derN : Derivation :=
+  { initial := noun, steps := [.emL adj, .emL numl, .im (adj * noun) 2, .emL dem] }
+
+/-- (o) Dem N A Num — raise N around A, then pied-pipe `[N A]` around Num. -/
+def derO : Derivation :=
+  { initial := noun
+    steps := [.emL adj, .im noun 1, .emL numl, .im (noun * (adj * mkTrace 1)) 2, .emL dem] }
+
+/-- (t) N Num A Dem — bare raise around A and Num, then pied-pipe `[N Num A]`
+    around Dem. -/
+def derT : Derivation :=
+  { initial := noun
+    steps := [.emL adj, .im noun 1, .emL numl, .im noun 2, .emL dem,
+              .im (noun * (numl * (mkTrace 2 * (adj * mkTrace 1)))) 3] }
+
+/-- (x) N A Num Dem — successive pied-piping all the way up (the roll-up). -/
+def derX : Derivation :=
+  { initial := noun
+    steps := [.emL adj, .im noun 1, .emL numl, .im (noun * (adj * mkTrace 1)) 2,
+              .emL dem, .im ((noun * (adj * mkTrace 1)) * (numl * mkTrace 2)) 3] }
+
+/-! ### The eight derivations produce their attested orders (kernel-checked) -/
+
+theorem derA_order : derA.surfaceCats = [.D, .Num, .A, .N] := by decide
+theorem derB_order : derB.surfaceCats = [.D, .Num, .N, .A] := by decide
+theorem derC_order : derC.surfaceCats = [.D, .N, .Num, .A] := by decide
+theorem derD_order : derD.surfaceCats = [.N, .D, .Num, .A] := by decide
+theorem derN_order : derN.surfaceCats = [.D, .A, .N, .Num] := by decide
+theorem derO_order : derO.surfaceCats = [.D, .N, .A, .Num] := by decide
+theorem derT_order : derT.surfaceCats = [.N, .Num, .A, .D] := by decide
+theorem derX_order : derX.surfaceCats = [.N, .A, .Num, .D] := by decide
+
+/-- Each of the eight derived orders is an **attested** order in Cinque's table
+    (the constructive half of Universal 20: these orders arise by NP-movement
+    from the universal base). -/
+theorem derived_orders_attested :
+    [derA, derB, derC, derD, derN, derO, derT, derX].all
+      (fun d => (table.filter (·.attested)).any (·.order = d.surfaceCats)) := by
+  decide
+
+/-! ### TODO (follow-up)
+
+- **Full 14/10 split**: enumerate the bounded legal-derivation space (fixed base +
+  leftward NP-containing movements, ≤3 notches × pied-piping modes × partial/total)
+  as a `List Derivation`, and prove its `surfaceCats` image equals exactly the 14
+  attested orders — i.e. derive the remaining attested orders (k, l, p, r, s, w)
+  *and* the underivability of the 10 unattested ones. This is the restrictive core
+  of [cinque-2005] (the "wrong Merge order" diagnostic).
+- **Markedness ⇒ frequency**: encode the paper's markedness ordering (whose-picture
+  < bare < picture-of-who; total < partial) and show cheapest-derivation cost is
+  monotone in the `Freq` bucket.
+-/
+
+end Cinque2005

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -18642,6 +18642,20 @@
   validated = {true},
   sources   = {Fragments/Italian/Modals.lean;Phenomena/Modality/Bridge/EventRelativityRestructuring.lean}
 }% REF: Mac Congáil (2004). Irish Grammar. Cois Life.
+@article{cinque-2005,
+  author    = {Cinque, Guglielmo},
+  year      = {2005},
+  title     = {Deriving Greenberg's Universal 20 and its exceptions},
+  journal   = {Linguistic Inquiry},
+  volume    = {36},
+  number    = {3},
+  pages     = {315--332},
+  doi       = {10.1162/0024389054396917},
+  subfield  = {syntax},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Studies/Cinque2005.lean}
+}
 @book{cinque-2020,
   author    = {Cinque, Guglielmo},
   year      = {2020},


### PR DESCRIPTION
Runs [cinque-2005]'s derivational account of Greenberg's Universal 20 on the **real MCB Merge substrate**: each DP order is a `Derivation` (fixed-order External Merge for the base `[Dem [Num [A [N]]]]`, then leftward `Step.im` movements), with surface order read off by the computable derivation-grounded `Derivation.surfaceCats` (from #721). Orders verified by `decide`.

- The 24-order attestation table ([cinque-2005] (6)) with frequency buckets — `decide`-checked: 14 attested / 10 unattested, freq-consistent.
- Eight attested orders (a–d bare-NP-raising series; n/o/t/x pied-piping) derived explicitly on the substrate and shown to be attested. The constructive half of U20: attested orders arise by NP-movement from the universal base.
- Deferred (TODO in file): full legal-derivation enumeration for the remaining attested orders + underivability of the 10 unattested; markedness⇒frequency.

`.D` encodes the demonstrative slot (no `Cat.Dem` constructor yet — deferred substrate refinement; doesn't affect the combinatorics). Adds `cinque-2005` to references.bib.