### PR TITLE
feat(Syntax/HPSG): add φ-agreement to RSRL binding theory

### DIFF
--- a/Linglib/Studies/SagWasowBender2003.lean
+++ b/Linglib/Studies/SagWasowBender2003.lean
@@ -121,18 +121,33 @@ ARG-ST outranking here, model-theoretic `Models` there — agree on the diagnost
 
 /-- The reflexive (Principle A) judgments are grounded in the RSRL model theory: the computational
 ARG-ST account (a coindexed reflexive object is bound, a reflexive subject is not) and the RSRL
-Principle-A model (a coindexed anaphor satisfies the grammar; a disjoint anaphor violates it) agree. -/
+Principle-A model (a coindexed, φ-agreeing anaphor satisfies the grammar; a disjoint one violates it)
+agree. -/
 theorem reflexive_binding_grounded_in_rsrl :
     grammaticalForCoreference [john, sees, himself] = true ∧
     grammaticalForCoreference [himself, sees, john] = false ∧
-    (_root_.HPSG.RSRL.Binding.clause .ana .i1).Models _root_.HPSG.RSRL.Binding.bindingGrammar ∧
-    ¬ (_root_.HPSG.RSRL.Binding.clause .ana .i2).Models [_root_.HPSG.RSRL.Binding.principleA] := by
+    (_root_.HPSG.RSRL.Binding.clause .ana .iSubj .gMasc .nSing).Models
+      _root_.HPSG.RSRL.Binding.bindingGrammar ∧
+    ¬ (_root_.HPSG.RSRL.Binding.clause .ana .iObj .gMasc .nSing).Models
+      [_root_.HPSG.RSRL.Binding.principleA] := by
   decide
 
 /-- Principle B grounded in RSRL: a coindexed personal pronoun violates the model-theoretic
 Principle B (a pronoun must be locally o-free), the counterpart of the ARG-ST disjoint-reference data. -/
 theorem pronoun_binding_grounded_in_rsrl :
-    ¬ (_root_.HPSG.RSRL.Binding.clause .ppro .i1).Models [_root_.HPSG.RSRL.Binding.principleB] := by
+    ¬ (_root_.HPSG.RSRL.Binding.clause .ppro .iSubj .gMasc .nSing).Models
+      [_root_.HPSG.RSRL.Binding.principleB] := by
+  decide
+
+/-- **φ-agreement grounded in RSRL.** The gender/number agreement of binding (the `Word.Agree` check in
+the computational engine) is the model-theoretic requirement that the bound anaphor's `GEND`/`NUM` are
+token-identical to the binder's: a *coindexed but φ-clashing* anaphor (feminine — *John likes herself*;
+or plural — *they like himself*) is not locally o-bound, violating Principle A. -/
+theorem agreement_binding_grounded_in_rsrl :
+    ¬ (_root_.HPSG.RSRL.Binding.clause .ana .iSubj .gFem .nSing).Models
+      [_root_.HPSG.RSRL.Binding.principleA] ∧
+    ¬ (_root_.HPSG.RSRL.Binding.clause .ana .iSubj .gMasc .nPlur).Models
+      [_root_.HPSG.RSRL.Binding.principleA] := by
   decide
 
 end Binding

--- a/Linglib/Syntax/HPSG/Binding.lean
+++ b/Linglib/Syntax/HPSG/Binding.lean
@@ -1,65 +1,81 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.HPSG.Description
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# HPSG Binding Theory (Principles A & B) in RSRL
+# HPSG Binding Theory (Principles A & B) in RSRL, with φ-agreement
 [pollard-sag-1994], [richter-2000], [muller-2024-binding]
 
-The first *relational, quantified* HPSG principles in the RSRL substrate, exercising the
+The *relational, quantified* HPSG binding principles in the RSRL substrate, exercising the
 `rel`/`ex`/`all` machinery of `Description.lean`. Following HPSG Binding Theory
-([muller-2024-binding], Ch. 20): **local o-command** ("less oblique, same ARG-ST", the
-relation `locO`), **o-bind** (coindexed ∧ o-commands), **Principle A** (a locally o-commanded
+([muller-2024-binding], Ch. 20): **local o-command** ("less oblique, same ARG-ST", the relation
+`locO`), **o-bind** (coindexed ∧ o-commands ∧ **agrees in φ**), **Principle A** (a locally o-commanded
 anaphor is locally o-bound), **Principle B** (a pronoun is locally o-free).
 
-Coindexation is **token identity** of `INDEX` (`pathEq`), the RSRL-faithful reading. ARG-ST is
-modeled via `SUBJ`/`OBJ` attributes and `locO` interpreted per model (deriving `locO` from a
-`FIRST`/`REST` list is a refinement). A bridge to the computational binding
-(`Coreference.lean`, coindexation as `index : Option Nat` value equality) is deferred — the same
-value-vs-token gap as the HFP bridge.
+Coindexation is **token identity** of `INDEX` (`pathEq`). Binding additionally requires **φ-agreement**
+(`GEND`/`NUM` token-identical between binder and bindee) — so a *coindexed but φ-clashing* anaphor (*John
+likes herself*, gender; *they like himself*, number) is **not** bound and Principle A is violated. This
+is the model-theoretic counterpart of the neutral binding engine's `Word.Agree` check
+(`Syntax/Binding/Basic`), against which `Studies/SagWasowBender2003` cross-checks.
+
+ARG-ST is modeled via `SUBJ`/`OBJ` attributes and `locO` interpreted per model.
 -/
 
 namespace HPSG.RSRL.Binding
 
-/-! ### Signature: nom-obj hierarchy, INDEX, and the o-command relation -/
+/-! ### Signature: nom-obj hierarchy, INDEX, φ-features, and the o-command relation -/
 
-/-- Sorts: a `sign`, `synsem` objects with the nom-obj species (`ana`/`ppro`/`npro`), and an
-atomic `idx` (referential index). -/
-inductive BSort | top | sign | synsem | ana | ppro | npro | idx
+/-- Sorts: a `sign`, `synsem` objects with the nom-obj species (`ana`/`ppro`/`npro`), an atomic `idx`
+(referential index), and the φ-value hierarchies `gender > {masc, fem}` and `number > {sing, plur}`. -/
+inductive BSort
+  | top | sign | synsem | ana | ppro | npro | idx
+  | gender | masc | fem | number | sing | plur
   deriving DecidableEq, Fintype, Repr
 
-/-- Attributes: `SUBJ`/`OBJ` (a sign's arguments — a flattened ARG-ST) and `IDX` (a synsem's
-referential index). -/
-inductive BAttr | SUBJ | OBJ | IDX deriving DecidableEq, Fintype, Repr
+/-- Attributes: `SUBJ`/`OBJ` (a sign's arguments — a flattened ARG-ST), `IDX` (a synsem's referential
+index), and the φ-features `GEND`/`NUM`. -/
+inductive BAttr | SUBJ | OBJ | IDX | GEND | NUM deriving DecidableEq, Fintype, Repr
 
 /-- One relation: local o-command, `locO` (arity 2). -/
 inductive BRel | locO deriving DecidableEq, Fintype, Repr
 
-/-- Direct subsumption ("covers"): the DAG edges. The nom-obj species (`ana`/`ppro`/`npro`) cover
-`synsem`; `sign`/`synsem`/`idx` cover `top`. The order is `ReflTransGen bCovers`. -/
+/-- Direct subsumption ("covers"): the DAG edges. Nom-obj species cover `synsem`; gender/number values
+cover their φ root; `sign`/`synsem`/`idx`/`gender`/`number` cover `top`. -/
 def bCovers : BSort → BSort → Bool
   | .sign, .top => true
   | .synsem, .top => true
   | .idx, .top => true
+  | .gender, .top => true
+  | .number, .top => true
   | .ana, .synsem => true
   | .ppro, .synsem => true
   | .npro, .synsem => true
+  | .masc, .gender => true
+  | .fem, .gender => true
+  | .sing, .number => true
+  | .plur, .number => true
   | _, _ => false
 
 /-- Specificity depth; every covers edge strictly increases it (giving antisymmetry). -/
 def bRank : BSort → Nat
   | .top => 0
-  | .sign => 1 | .synsem => 1 | .idx => 1
-  | .ana => 2 | .ppro => 2 | .npro => 2
+  | .sign => 1 | .synsem => 1 | .idx => 1 | .gender => 1 | .number => 1
+  | .ana => 2 | .ppro => 2 | .npro => 2 | .masc => 2 | .fem => 2 | .sing => 2 | .plur => 2
 
 instance : PartialOrder BSort :=
   partialOrderOfCovers (bCovers · · = true) bRank (by decide)
 
 instance : DecidableLE BSort := fun a b =>
   decidableLEOfCovers (covers := (bCovers · · = true))
-    [.top, .sign, .synsem, .ana, .ppro, .npro, .idx]
+    [.top, .sign, .synsem, .ana, .ppro, .npro, .idx, .gender, .masc, .fem, .number, .sing, .plur]
     (by decide) a b
 
-/-- Appropriateness: a sign has `SUBJ`/`OBJ` synsems; every synsem species has an `IDX`. -/
+/-- Appropriateness: a sign has `SUBJ`/`OBJ` synsems; every synsem species has an `IDX`, a `GEND`, and
+a `NUM`. -/
 def bapprop : BSort → BAttr → Option BSort
   | .sign, .SUBJ => some .synsem
   | .sign, .OBJ => some .synsem
@@ -67,6 +83,14 @@ def bapprop : BSort → BAttr → Option BSort
   | .ana, .IDX => some .idx
   | .ppro, .IDX => some .idx
   | .npro, .IDX => some .idx
+  | .synsem, .GEND => some .gender
+  | .ana, .GEND => some .gender
+  | .ppro, .GEND => some .gender
+  | .npro, .GEND => some .gender
+  | .synsem, .NUM => some .number
+  | .ana, .NUM => some .number
+  | .ppro, .NUM => some .number
+  | .npro, .NUM => some .number
   | _, _ => none
 
 private theorem bapprop_inh : ∀ (σ₁ σ₂ : BSort) (α : BAttr) (τ₁ : BSort),
@@ -87,9 +111,15 @@ Variable `0` is the bound synsem `x`; `1` is the candidate binder `y`. -/
 def coindexed (x y : Nat) : Desc bindingSig :=
   .pathEq (.feat (.var x) .IDX) (.feat (.var y) .IDX)
 
-/-- `y` locally o-binds `x`: `locO(y, x)` and they are coindexed. -/
+/-- **φ-agreement** of `x` and `y`: token identity of their `GEND` and `NUM` (HPSG agreement as
+re-entrancy). -/
+def agrees (x y : Nat) : Desc bindingSig :=
+  .and (.pathEq (.feat (.var x) .GEND) (.feat (.var y) .GEND))
+       (.pathEq (.feat (.var x) .NUM) (.feat (.var y) .NUM))
+
+/-- `y` locally o-binds `x`: `locO(y, x)`, coindexed, **and agreeing in φ**. -/
 def locallyOBinds (y x : Nat) : Desc bindingSig :=
-  .and (.rel .locO [.var y, .var x]) (coindexed x y)
+  .and (.rel .locO [.var y, .var x]) (.and (coindexed x y) (agrees x y))
 
 /-- **Principle A**: a locally o-commanded anaphor must be locally o-bound. -/
 def principleA : Desc bindingSig :=
@@ -97,8 +127,7 @@ def principleA : Desc bindingSig :=
     (.and (.sortAssign (.var 0) .ana) (.ex 1 (.rel .locO [.var 1, .var 0])))
     (.ex 1 (locallyOBinds 1 0)))
 
-/-- **Principle B**: a personal pronoun must be locally o-free — no component locally o-binds
-it. -/
+/-- **Principle B**: a personal pronoun must be locally o-free — no component locally o-binds it. -/
 def principleB : Desc bindingSig :=
   .all 0 (.imp (.sortAssign (.var 0) .ppro)
     (.neg (.ex 1 (locallyOBinds 1 0))))
@@ -108,45 +137,66 @@ def bindingGrammar : Grammar bindingSig := [principleA, principleB]
 
 /-! ### Worked models
 
-One transitive-clause carrier and one builder `clause`; the three binding configurations are
-instantiations differing only in the object's sort and index. -/
+One transitive-clause carrier and one builder `clause`; the binding configurations are instantiations
+differing in the object's sort, index, and φ-features. The subject is a masculine-singular `npro`
+indexed `iSubj`. -/
 
-/-- Entities of a transitive clause: the verb sign, subject, object, and two indices. -/
-inductive BindEnt | s | subj | obj | i1 | i2 deriving DecidableEq, Fintype, Repr
+/-- Entities of a transitive clause: verb sign, subject, object, two indices, and the gender/number
+value objects (`gMasc`/`gFem`, `nSing`/`nPlur`). -/
+inductive BindEnt
+  | s | subj | obj | iSubj | iObj | gMasc | gFem | nSing | nPlur
+  deriving DecidableEq, Fintype, Repr
 
-/-- A transitive clause "`subj` V `obj`": the subject is an `npro` indexed `i1` and locally
-o-commands the object; the object has sort `objSort` and index `objIdx`. Coindexation is
-`objIdx = i1`. -/
-@[reducible] def clause (objSort : BSort) (objIdx : BindEnt) : Interpretation bindingSig where
+/-- A transitive clause "`subj` V `obj`": the subject is a masc-sing `npro` indexed `iSubj` and locally
+o-commands the object; the object has sort `objSort`, index `objIdx`, gender `objGend`, number `objNum`.
+Coindexation is `objIdx = iSubj`; agreement is `objGend = gMasc ∧ objNum = nSing`. -/
+@[reducible] def clause (objSort : BSort) (objIdx objGend objNum : BindEnt) :
+    Interpretation bindingSig where
   U := BindEnt
   S := fun
     | .s => .sign
     | .subj => .npro
     | .obj => objSort
-    | .i1 => .idx
-    | .i2 => .idx
+    | .iSubj => .idx
+    | .iObj => .idx
+    | .gMasc => .masc
+    | .gFem => .fem
+    | .nSing => .sing
+    | .nPlur => .plur
   A := fun a u => match a, u with
     | .SUBJ, .s => some .subj
     | .OBJ, .s => some .obj
-    | .IDX, .subj => some .i1
+    | .IDX, .subj => some .iSubj
     | .IDX, .obj => some objIdx
+    | .GEND, .subj => some .gMasc
+    | .GEND, .obj => some objGend
+    | .NUM, .subj => some .nSing
+    | .NUM, .obj => some objNum
     | _, _ => none
   R := fun _ args => args = [BindEnt.subj, BindEnt.obj]
 
-instance (objSort : BSort) (objIdx : BindEnt) (ρ : bindingSig.Rel) :
-    DecidablePred ((clause objSort objIdx).R ρ) :=
+instance (objSort : BSort) (objIdx objGend objNum : BindEnt) (ρ : bindingSig.Rel) :
+    DecidablePred ((clause objSort objIdx objGend objNum).R ρ) :=
   fun args => inferInstanceAs (Decidable (args = [BindEnt.subj, BindEnt.obj]))
 
-/-- *Mary likes herself*: a coindexed anaphor object (`objIdx = i1`) is locally o-bound by the
-subject — Principle A satisfied, and the whole grammar (Principle B vacuous: no pronoun). -/
-example : (clause .ana .i1).Models bindingGrammar := by decide
+/-- *John likes himself*: a coindexed, φ-agreeing anaphor (masc-sing, like the subject) is locally
+o-bound — Principle A satisfied (Principle B vacuous: no pronoun). -/
+example : (clause .ana .iSubj .gMasc .nSing).Models bindingGrammar := by decide
 
-/-- *Mary likes himself* (gender clash): the anaphor object has a *distinct* index (`i2`), so it
-is locally o-commanded but not locally o-bound — Principle A violated (a genuine filter). -/
-example : ¬ (clause .ana .i2).Models [principleA] := by decide
+/-- *John likes herself* (**gender clash**): a coindexed anaphor whose `GEND` is feminine disagrees with
+the masculine subject, so it is locally o-commanded but not locally o-*bound* — Principle A violated. -/
+example : ¬ (clause .ana .iSubj .gFem .nSing).Models [principleA] := by decide
 
-/-- *Mary likes her_i* coindexed: a coindexed pronoun object is locally o-bound, so not locally
+/-- *They like himself* (**number clash**): a coindexed anaphor whose `NUM` is singular disagrees with
+the (here plural-construed) subject's number — Principle A violated on agreement. -/
+example : ¬ (clause .ana .iSubj .gMasc .nPlur).Models [principleA] := by decide
+
+/-- *Himself likes John* (**structural**): a disjoint-indexed anaphor (`objIdx = iObj`) is locally
+o-commanded but not coindexed, so not locally o-bound — Principle A violated. -/
+example : ¬ (clause .ana .iObj .gMasc .nSing).Models [principleA] := by decide
+
+/-- *John likes him_i* coindexed: a coindexed, agreeing pronoun is locally o-bound, so not locally
 o-free — Principle B violated. -/
-example : ¬ (clause .ppro .i1).Models [principleB] := by decide
+example : ¬ (clause .ppro .iSubj .gMasc .nSing).Models [principleB] := by decide
 
 end HPSG.RSRL.Binding


### PR DESCRIPTION
Phase 6a of the core-retirement roadmap: build **φ-agreement** in RSRL Binding (`Syntax/HPSG/Binding`), the model-theoretic counterpart of the neutral engine's `Word.Agree` — the theory needed before `Coreference` can be retired.

- Adds gender/number value hierarchies (`gender > {masc, fem}`, `number > {sing, plur}`) + `GEND`/`NUM` features on synsems. **Binding now requires agreement**: `locallyOBinds` is coindexed ∧ `Word.Agree`-style φ-match (token-identical `GEND`/`NUM`), so a *coindexed but φ-clashing* anaphor fails Principle A.
- Worked models distinguish all four cases: agreeing reflexive (✓), gender clash (✗), number clash (✗), structural/disjoint (✗), plus the coindexed pronoun (Principle B ✗).
- `SagWasowBender2003`: clause-based RSRL groundings updated to the φ-aware signature; new `agreement_binding_grounded_in_rsrl` grounds the gender/number-clash data as `Models` facts.

Axiom-clean. Follow-up (6b) re-encodes SWB2003's parsing-based binding *coverage* (`captures_*`) on this agreement-aware RSRL Binding, then retires `Coreference.lean`.