### PR TITLE
feat(Syntax/Minimalist): Derivation.surfacePhon, real surface-order theorems

### DIFF
--- a/Linglib/Studies/Chomsky1995.lean
+++ b/Linglib/Studies/Chomsky1995.lean
@@ -26,15 +26,9 @@ def john_sees_mary : Derivation :=
 
 /-- The phonological yield of `john_sees_mary` is the SVO string
     "John sees Mary": the Minimalist derivation (built by `emR` then
-    `emL` over `verbToSO`/`nounToSO`) linearizes subject-verb-object.
-
-    Phase 1.0 sorry: blocked on `phonYield` being `noncomputable`
-    (Phase 1.0 placeholder via `Quot.out`). TODO Phase 2: restore once
-    LCA-based linearization lands. -/
+    `emL` over `verbToSO`/`nounToSO`) linearizes subject-verb-object via the
+    derivation-grounded computable externalization (`Derivation.surfacePhon`). -/
 theorem models_svo_word_order :
-    String.intercalate " "
-      (HeadFunction.leftSpine.phonYield john_sees_mary.final)
-    = "John sees Mary" := by
-  sorry
+    String.intercalate " " john_sees_mary.surfacePhon = "John sees Mary" := by decide
 
 end Chomsky1995

--- a/Linglib/Studies/ColeHermon2008.lean
+++ b/Linglib/Studies/ColeHermon2008.lean
@@ -158,15 +158,11 @@ def englishSVO : Derivation :=
 
 /-- VP-raising yields Verb-Object-Subject surface order. -/
 theorem toba_batak_is_vos :
-    HeadFunction.leftSpine.phonYield tobaBatakVOS.final = ["mangatuk", "biangi", "dakdanakan"] := by
-  -- TODO Phase 2: blocked on noncomputable phonYield + LCA linearize
-  sorry
+    tobaBatakVOS.surfacePhon = ["mangatuk", "biangi", "dakdanakan"] := by decide
 
 /-- Subject-raising yields Subject-Verb-Object surface order. -/
 theorem english_is_svo :
-    HeadFunction.leftSpine.phonYield englishSVO.final = ["John", "saw", "Mary"] := by
-  -- TODO Phase 2: blocked on noncomputable phonYield + LCA linearize
-  sorry
+    englishSVO.surfacePhon = ["John", "saw", "Mary"] := by decide
 
 /-- Both derivations have the same tree shape before the movement step
     (stage 4). The only parametric difference is *what* moves in step 5.
@@ -493,16 +489,13 @@ def tobaBatakSVO : Derivation :=
 
 /-- The VOS Hypothesis derives SVO surface order. -/
 theorem toba_batak_svo_order :
-    HeadFunction.leftSpine.phonYield tobaBatakSVO.final = ["dakdanakan", "mangatuk", "biangi"] := by
-  -- TODO Phase 2: blocked on noncomputable phonYield + LCA linearize
-  sorry
+    tobaBatakSVO.surfacePhon = ["dakdanakan", "mangatuk", "biangi"] := by decide
 
 /-- SVO goes through VOS: at stage 5 (before subject-raising), the
     intermediate tree has VOS order — the same as `tobaBatakVOS.final`. -/
 theorem svo_passes_through_vos :
-    HeadFunction.leftSpine.phonYield (tobaBatakSVO.stageAt 5) = HeadFunction.leftSpine.phonYield tobaBatakVOS.final := by
-  -- TODO Phase 2: blocked on noncomputable phonYield + LCA linearize
-  sorry
+    (⟨tobaBatakSVO.initial, tobaBatakSVO.steps.take 5⟩ : Derivation).surfacePhon
+      = tobaBatakVOS.surfacePhon := by decide
 
 /-- The VOS Hypothesis predicts identical extraction restrictions for SVO:
     the DO is still inside the fronted VP, regardless of whether the
@@ -573,9 +566,7 @@ def englishPassive : Derivation :=
 
 /-- English passive yields patient-verb-agent surface order. -/
 theorem english_passive_order :
-    HeadFunction.leftSpine.phonYield englishPassive.final = ["the-boy", "was-injured", "by-himself"] := by
-  -- TODO Phase 2: blocked on noncomputable phonYield + LCA linearize
-  sorry
+    englishPassive.surfacePhon = ["the-boy", "was-injured", "by-himself"] := by decide
 
 -- ============================================================================
 -- § 13: Cross-Linguistic Binding Contrast (§7 of the paper)

--- a/Linglib/Studies/Erlewine2018.lean
+++ b/Linglib/Studies/Erlewine2018.lean
@@ -339,10 +339,7 @@ theorem nonDP_unrestricted :
     - [cole-hermon-2008]: VP moves to Spec,TP; subject stranded in Spec,vP
     - [erlewine-2018]: vP moves to Spec,CP; subject stranded in Spec,TP -/
 theorem predicate_fronting_yields_vi_order :
-    (HeadFunction.leftSpine.phonYield ColeHermon2008.tobaBatakVOS.final).head?
-      = some "mangatuk" := by
-  -- TODO Phase 2: blocked on noncomputable phonYield
-  sorry
+    ColeHermon2008.tobaBatakVOS.surfacePhon.head? = some "mangatuk" := by decide
 
 -- ============================================================================
 -- § 10: vP-to-Spec,CP Derivation
@@ -398,15 +395,11 @@ def erlewineDerivation : Derivation :=
 
 /-- Erlewine's derivation yields VOS word order. -/
 theorem erlewine_yields_vos :
-    HeadFunction.leftSpine.phonYield erlewineDerivation.final = ["mangatuk", "biangi", "dakdanakan"] := by
-  -- TODO Phase 2: blocked on noncomputable phonYield
-  sorry
+    erlewineDerivation.surfacePhon = ["mangatuk", "biangi", "dakdanakan"] := by decide
 
 /-- Both analyses agree on VOS surface order despite different structural heights. -/
 theorem cole_erlewine_agree_on_order :
-    HeadFunction.leftSpine.phonYield tobaBatakVOS.final = HeadFunction.leftSpine.phonYield erlewineDerivation.final := by
-  -- TODO Phase 2: blocked on noncomputable phonYield
-  sorry
+    tobaBatakVOS.surfacePhon = erlewineDerivation.surfacePhon := by decide
 
 /-- Erlewine has TWO movements (Subj → Spec,TP + vP → Spec,CP) vs
     [cole-hermon-2008]'s ONE (VP → Spec,TP). -/

--- a/Linglib/Syntax/Minimalist/Derivation.lean
+++ b/Linglib/Syntax/Minimalist/Derivation.lean
@@ -248,6 +248,14 @@ def Derivation.surfaceTokens (d : Derivation) : List LIToken :=
 def Derivation.surfaceCats (d : Derivation) : List Cat :=
   d.surfaceTokens.map (·.item.outerCat)
 
+/-- Surface phonological string of a derivation: pronounced forms left-to-right
+    (empty forms dropped). The derivation-grounded **computable** counterpart of
+    `HeadFunction.leftSpine.phonYield d.final` — and unlike the latter, it
+    recovers the *movement* order (it replays the steps), so word-order theorems
+    over moved structures are `decide`-checkable. -/
+def Derivation.surfacePhon (d : Derivation) : List String :=
+  d.surfaceTokens.filterMap fun t => let p := t.phonForm; if p.isEmpty then none else some p
+
 /-! ### Faithfulness: `externalize` projects to `final` (the Π bridge)
 
 Whenever `externalizeP?` succeeds, projecting it back (`FreeCommMagma.mk`)


### PR DESCRIPTION
Stage 1 of the `Quot.out` retirement. Adds `Derivation.surfacePhon` — the derivation-grounded **computable** surface string (it replays the steps via `externalize`, so it recovers *movement* order, unlike `leftSpine.phonYield d.final` which used the arbitrary `Quot.out` order).

Migrates the phonYield word-order theorems off the noncomputable section — they were **all `sorry`d** ("blocked on noncomputable phonYield") and are now **real, `decide`-checked**:
- `ColeHermon2008`: Toba Batak VOS, SVO, SVO-passes-through-VOS, English passive (5 theorems).
- `Erlewine2018`: predicate-fronting VOS, Cole/Erlewine agree-on-order (3).
- `Chomsky1995`: `models_svo_word_order` (1).

Remaining ColeHermon2008 sorries are unrelated (nodeCount / c-command). Sets up the section-method deletion in a later stage.