### PR TITLE
refactor(Syntax/Minimalist): rename toHc → toNonplanar

### DIFF
--- a/Linglib/Core/Algebra/Free.lean
+++ b/Linglib/Core/Algebra/Free.lean
@@ -850,7 +850,7 @@ noncomputable def out : Section α where
     `FreeMagma.of a` shape: `s.σ (of a) = of a`.
 
     **Why this lemma exists**: downstream consumers (e.g. `HeadFunction.head_leaf`,
-    `outerCat_leaf`, `checkedSel_leaf`, `toHc_leaf`, ...) repeatedly need to prove
+    `outerCat_leaf`, `checkedSel_leaf`, `toNonplanar_leaf`, ...) repeatedly need to prove
     `f (s.σ (of a)) = expected` by case-analysis on `s.σ (of a)`'s `FreeMagma`
     shape — leveraging that the equivalence class of `of a` under `CommRel` is a
     singleton (no swap fires on `.of _`). Without this lemma, every consumer

--- a/Linglib/Syntax/Minimalist/Merge/Defs.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Defs.lean
@@ -3,7 +3,7 @@ import Linglib.Syntax.Minimalist.HeadFunction
 import Linglib.Core.Combinatorics.RootedTree.Nonplanar
 
 /-!
-# Carrier projection `toHc`: Linguistic Specialization
+# Carrier projection `toNonplanar`: Linguistic Specialization
 [marcolli-chomsky-berwick-2025]
 
 Specialization of the canonical Connes-Kreimer substrate to the Minimalism
@@ -12,8 +12,9 @@ instantiation with leaf alphabet `LIToken ⊕ Unit`: the projection of a plain
 Unit)` (lexical leaves `Sum.inl`, trace leaves `Sum.inr ()`). The Merge
 operators on `ConnesKreimer R (Nonplanar α)` live in `Merge/Basic.lean`.
 
-`SyntacticObject.toHc` and `HeadFunction.toHcWith` perform the projection. Since
-`Nonplanar` nodes carry a label, each internal node is decorated with its **head
+`SyntacticObject.toNonplanar` and `HeadFunction.toNonplanarWith` perform the
+projection. Since `Nonplanar` nodes carry a label, each internal node is
+decorated with its **head
 leaf** (`headLeafPlanar`, MCB Lemma 1.13.5) under the chosen side convention;
 this labeling convention is validated in `Merge.External`'s `matches_Step`
 bridges, which apply `mergeOp` with that same head label.
@@ -25,59 +26,59 @@ open RootedTree
 
 /-- Head leaf of a planar representative under a side convention
     (MCB Lemma 1.13.5): leftmost leaf for `.initial`, rightmost for `.final`.
-    Used to label internal `Nonplanar` nodes in `toHcPlanarN`. -/
+    Used to label internal `Nonplanar` nodes in `planarToNonplanar`. -/
 def headLeafPlanar : ConventionDir → FreeMagma (LIToken ⊕ Nat) → LIToken
   | .initial, t => leftmostLeafPlanar t
   | .final,   t => rightmostLeafPlanar t
 
-/-- Underlying `FreeMagma`-side toHc on a planar representative, into the
+/-- Underlying `FreeMagma`-side toNonplanar on a planar representative, into the
     canonical nonplanar carrier. Lexical leaves go to `Sum.inl`, trace leaves
     to `Sum.inr ()`; each internal node is labeled with its head leaf
     (`headLeafPlanar side`) since `Nonplanar.node` requires a label.
 
     `noncomputable` because `Nonplanar.node` is a noncomputable smart
-    constructor. Public so `HeadFunction.toHcWith` can compose it with a
+    constructor. Public so `HeadFunction.toNonplanarWith` can compose it with a
     chosen section. -/
-noncomputable def toHcPlanarN (side : ConventionDir) :
+noncomputable def planarToNonplanar (side : ConventionDir) :
     FreeMagma (LIToken ⊕ Nat) → Nonplanar (LIToken ⊕ Unit)
   | .of (.inl tok) => Nonplanar.leaf (Sum.inl tok)
   | .of (.inr _)   => Nonplanar.leaf (Sum.inr ())
   | .mul l r       => Nonplanar.node (Sum.inl (headLeafPlanar side (.mul l r)))
-                        {toHcPlanarN side l, toHcPlanarN side r}
+                        {planarToNonplanar side l, planarToNonplanar side r}
 
 /-- Project a `SyntacticObject` directly to the bialgebra carrier
     `Nonplanar (LIToken ⊕ Unit)`.
 
     Since `SyntacticObject := FreeCommMagma (LIToken ⊕ Nat)`, this picks a
     representative via `Quot.out` and projects under the head-initial
-    convention. Noncomputable; the parameterized `HeadFunction.toHcWith`
+    convention. Noncomputable; the parameterized `HeadFunction.toNonplanarWith`
     takes an explicit section + side. -/
-noncomputable def SyntacticObject.toHc (so : SyntacticObject) :
+noncomputable def SyntacticObject.toNonplanar (so : SyntacticObject) :
     Nonplanar (LIToken ⊕ Unit) :=
-  toHcPlanarN .initial so.out
+  planarToNonplanar .initial so.out
 
-/-- Parameterized projection: `toHc` under head function `h`, using
+/-- Parameterized projection: `toNonplanar` under head function `h`, using
     `h.section_.σ` to pick the planar representative and `h.headSide` for
     the node-labeling convention. -/
-noncomputable def HeadFunction.toHcWith (h : HeadFunction) (so : SyntacticObject) :
+noncomputable def HeadFunction.toNonplanarWith (h : HeadFunction) (so : SyntacticObject) :
     Nonplanar (LIToken ⊕ Unit) :=
-  toHcPlanarN h.headSide (h.section_.σ so)
+  planarToNonplanar h.headSide (h.section_.σ so)
 
 /-! ### Singleton-class simp lemmas
 
-`toHc_leaf` / `toHc_trace` are recoverable as `simp` lemmas because
+`toNonplanar_leaf` / `toNonplanar_trace` are recoverable as `simp` lemmas because
 leaf-only equivalence classes under `FreeMagma.CommRel` are singletons
 (no `swap` constructor fires on `.of _`). The proof routes through
 `Quot.out_eq` + `mk_eq_iff_commEqv` + the singleton structure of `.of`.
 
-`toHc_mul` does NOT recover at this level: `(l * r).out` may pick
+`toNonplanar_mul` does NOT recover at this level: `(l * r).out` may pick
 either `mul l.out r.out` or `mul r.out l.out`, and `Nonplanar.node`'s
 head label depends on which planar representative is chosen. The
-`HeadFunction`-parameterized `toHcWith` canonicalizes the orientation. -/
+`HeadFunction`-parameterized `toNonplanarWith` canonicalizes the orientation. -/
 
-@[simp] theorem SyntacticObject.toHc_leaf (tok : LIToken) :
-    (SyntacticObject.leaf tok).toHc = Nonplanar.leaf (Sum.inl tok) := by
-  show toHcPlanarN .initial (SyntacticObject.leaf tok).out = _
+@[simp] theorem SyntacticObject.toNonplanar_leaf (tok : LIToken) :
+    (SyntacticObject.leaf tok).toNonplanar = Nonplanar.leaf (Sum.inl tok) := by
+  show planarToNonplanar .initial (SyntacticObject.leaf tok).out = _
   have hmk :
       (Quot.mk FreeMagma.CommRel (SyntacticObject.leaf tok).out : SyntacticObject)
         = FreeCommMagma.mk (FreeMagma.of (Sum.inl tok)) := Quot.out_eq _
@@ -85,10 +86,10 @@ head label depends on which planar representative is chosen. The
   match h : (SyntacticObject.leaf tok).out with
   | .of x =>
     rw [h] at hmk
-    show toHcPlanarN .initial (.of x) = _
+    show planarToNonplanar .initial (.of x) = _
     cases x with
     | inl t =>
-      simp only [toHcPlanarN]
+      simp only [planarToNonplanar]
       exact congrArg (fun tk => Nonplanar.leaf (Sum.inl tk))
         (Sum.inl.inj (hmk : Sum.inl t = Sum.inl tok))
     | inr n => exact absurd (hmk : Sum.inr n = Sum.inl tok) (by intro; contradiction)
@@ -96,9 +97,9 @@ head label depends on which planar representative is chosen. The
     rw [h] at hmk
     exact absurd hmk (by simp [FreeMagma.CommEqv])
 
-@[simp] theorem SyntacticObject.toHc_trace (n : Nat) :
-    (SyntacticObject.trace n).toHc = Nonplanar.leaf (Sum.inr ()) := by
-  show toHcPlanarN .initial (SyntacticObject.trace n).out = _
+@[simp] theorem SyntacticObject.toNonplanar_trace (n : Nat) :
+    (SyntacticObject.trace n).toNonplanar = Nonplanar.leaf (Sum.inr ()) := by
+  show planarToNonplanar .initial (SyntacticObject.trace n).out = _
   have hmk :
       (Quot.mk FreeMagma.CommRel (SyntacticObject.trace n).out : SyntacticObject)
         = FreeCommMagma.mk (FreeMagma.of (Sum.inr n)) := Quot.out_eq _
@@ -106,30 +107,30 @@ head label depends on which planar representative is chosen. The
   match h : (SyntacticObject.trace n).out with
   | .of x =>
     rw [h] at hmk
-    show toHcPlanarN .initial (.of x) = _
+    show planarToNonplanar .initial (.of x) = _
     cases x with
     | inl t => exact absurd (hmk : Sum.inl t = Sum.inr n) (by intro; contradiction)
-    | inr m => simp only [toHcPlanarN]
+    | inr m => simp only [planarToNonplanar]
   | .mul _ _ =>
     rw [h] at hmk
     exact absurd hmk (by simp [FreeMagma.CommEqv])
 
-/-! ### Singleton-class simp lemmas for `toHcWith`/`toHWith` (parameterized)
+/-! ### Singleton-class simp lemmas for `toNonplanarWith` (parameterized)
 
 All three lemmas reduce via the keystone `FreeCommMagma.Section.σ_of` helper:
 the section's image of `FreeCommMagma.of x` is exactly `FreeMagma.of x`. -/
 
-/-- `toHcWith h` on a leaf returns the corresponding `Nonplanar.leaf`. -/
-@[simp] theorem HeadFunction.toHcWith_leaf (h : HeadFunction) (tok : LIToken) :
-    h.toHcWith (.leaf tok) = Nonplanar.leaf (Sum.inl tok) := by
-  show toHcPlanarN h.headSide (h.section_.σ (FreeCommMagma.of (.inl tok))) = _
+/-- `toNonplanarWith h` on a leaf returns the corresponding `Nonplanar.leaf`. -/
+@[simp] theorem HeadFunction.toNonplanarWith_leaf (h : HeadFunction) (tok : LIToken) :
+    h.toNonplanarWith (.leaf tok) = Nonplanar.leaf (Sum.inl tok) := by
+  show planarToNonplanar h.headSide (h.section_.σ (FreeCommMagma.of (.inl tok))) = _
   rw [h.section_.σ_of]
   cases h.headSide <;> rfl
 
-/-- `toHcWith h` on a trace returns `Nonplanar.leaf (Sum.inr ())`. -/
-@[simp] theorem HeadFunction.toHcWith_trace (h : HeadFunction) (n : Nat) :
-    h.toHcWith (.trace n) = Nonplanar.leaf (Sum.inr ()) := by
-  show toHcPlanarN h.headSide (h.section_.σ (FreeCommMagma.of (.inr n))) = _
+/-- `toNonplanarWith h` on a trace returns `Nonplanar.leaf (Sum.inr ())`. -/
+@[simp] theorem HeadFunction.toNonplanarWith_trace (h : HeadFunction) (n : Nat) :
+    h.toNonplanarWith (.trace n) = Nonplanar.leaf (Sum.inr ()) := by
+  show planarToNonplanar h.headSide (h.section_.σ (FreeCommMagma.of (.inr n))) = _
   rw [h.section_.σ_of]
   cases h.headSide <;> rfl
 
@@ -139,7 +140,7 @@ end Minimalist
 theorem Minimalist.isTrace_mkTrace (n : Nat) :
     Minimalist.isTrace (Minimalist.mkTrace n) = some n := rfl
 
-/-- `(mkTrace n).toHc = Nonplanar.leaf (Sum.inr ())` — the IM bridge identity. -/
-theorem Minimalist.mkTrace_toHc (n : Nat) :
-    (Minimalist.mkTrace n).toHc = RootedTree.Nonplanar.leaf (Sum.inr ()) :=
-  Minimalist.SyntacticObject.toHc_trace n
+/-- `(mkTrace n).toNonplanar = Nonplanar.leaf (Sum.inr ())` — the IM bridge identity. -/
+theorem Minimalist.mkTrace_toNonplanar (n : Nat) :
+    (Minimalist.mkTrace n).toNonplanar = RootedTree.Nonplanar.leaf (Sum.inr ()) :=
+  Minimalist.SyntacticObject.toNonplanar_trace n

--- a/Linglib/Syntax/Minimalist/Merge/External.lean
+++ b/Linglib/Syntax/Minimalist/Merge/External.lean
@@ -37,9 +37,9 @@ w`, isolating the surviving empty-cut summand of `comulTreeN T` via
 
 The Minimalism-specific bridges (`mergeOp_emR/emL_matches_Step`) specialize to
 `R = ℤ`, `α = LIToken ⊕ Unit`. They take the **head label** `L` of the merged
-node and a coherence hypothesis `h_coh` factoring `(current * item).toHc` as
-`Nonplanar.node (Sum.inl L) {current.toHc, item.toHc}` — the labeling convention
-fixed in `Merge.Defs`'s `toHcPlanarN` (each internal node decorated with its head
+node and a coherence hypothesis `h_coh` factoring `(current * item).toNonplanar` as
+`Nonplanar.node (Sum.inl L) {current.toNonplanar, item.toNonplanar}` — the labeling convention
+fixed in `Merge.Defs`'s `planarToNonplanar` (each internal node decorated with its head
 leaf). This is the coupling point that validates the carrier bridge's design.
 
 ## Deferred (substrate gap)
@@ -316,44 +316,44 @@ private noncomputable instance : DecidableEq (Nonplanar (LIToken ⊕ Unit)) :=
   Classical.decEq _
 
 /-- **External Merge bridge (right-complement)** (M-C-B Lemma 1.4.1, F̂ = ∅).
-    `mergeOp (Sum.inl L) current.toHc item.toHc` applied to the 2-tree workspace
-    `{current.toHc, item.toHc}` yields the singleton workspace of
-    `.node (Sum.inl L) {current.toHc, item.toHc}` = `(Step.emR item).apply current`.
+    `mergeOp (Sum.inl L) current.toNonplanar item.toNonplanar` applied to the 2-tree workspace
+    `{current.toNonplanar, item.toNonplanar}` yields the singleton workspace of
+    `.node (Sum.inl L) {current.toNonplanar, item.toNonplanar}` = `(Step.emR item).apply current`.
 
     `L` is the **head label** of the merged node; `h_coh` is the
-    externalize-respect property: the `Quot.out`-based `toHc` on `current * item`
-    factors as `Nonplanar.node (Sum.inl L) {current.toHc, item.toHc}`, with the
+    externalize-respect property: the `Quot.out`-based `toNonplanar` on `current * item`
+    factors as `Nonplanar.node (Sum.inl L) {current.toNonplanar, item.toNonplanar}`, with the
     SAME head label `L` that `mergeOp` grafts. Per MCB §1.12.3, this is the
     local-coherence condition some sections satisfy at the merged node; consumers
     supply it when the section is built to respect the merge. -/
 theorem mergeOp_emR_matches_Step
     (current item : Minimalist.SyntacticObject) (L : LIToken)
-    (h_coh : (current * item).toHc =
-      Nonplanar.node (Sum.inl L) {current.toHc, item.toHc}) :
-    mergeOp (R := ℤ) (Sum.inl L) current.toHc item.toHc
-        (of' ({current.toHc, item.toHc} : Forest (Nonplanar (LIToken ⊕ Unit))))
-      = of' (R := ℤ) ({((Step.emR item).apply current).toHc}
+    (h_coh : (current * item).toNonplanar =
+      Nonplanar.node (Sum.inl L) {current.toNonplanar, item.toNonplanar}) :
+    mergeOp (R := ℤ) (Sum.inl L) current.toNonplanar item.toNonplanar
+        (of' ({current.toNonplanar, item.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit))))
+      = of' (R := ℤ) ({((Step.emR item).apply current).toNonplanar}
         : Forest (Nonplanar (LIToken ⊕ Unit))) := by
-  show mergeOp (R := ℤ) (Sum.inl L) current.toHc item.toHc
-        (of' ({current.toHc, item.toHc} : Forest (Nonplanar (LIToken ⊕ Unit))))
-      = of' (R := ℤ) ({(current * item).toHc} : Forest (Nonplanar (LIToken ⊕ Unit)))
+  show mergeOp (R := ℤ) (Sum.inl L) current.toNonplanar item.toNonplanar
+        (of' ({current.toNonplanar, item.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit))))
+      = of' (R := ℤ) ({(current * item).toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit)))
   rw [mergeOp_pair, ← h_coh]
 
 /-- **External Merge bridge (left-specifier)** (M-C-B Lemma 1.4.1, F̂ = ∅,
-    symmetric pair). `mergeOp (Sum.inl L) item.toHc current.toHc` applied to
-    `{item.toHc, current.toHc}` yields `.node (Sum.inl L) {item.toHc, current.toHc}`
+    symmetric pair). `mergeOp (Sum.inl L) item.toNonplanar current.toNonplanar` applied to
+    `{item.toNonplanar, current.toNonplanar}` yields `.node (Sum.inl L) {item.toNonplanar, current.toNonplanar}`
     = `(Step.emL item).apply current`. -/
 theorem mergeOp_emL_matches_Step
     (item current : Minimalist.SyntacticObject) (L : LIToken)
-    (h_coh : (item * current).toHc =
-      Nonplanar.node (Sum.inl L) {item.toHc, current.toHc}) :
-    mergeOp (R := ℤ) (Sum.inl L) item.toHc current.toHc
-        (of' ({item.toHc, current.toHc} : Forest (Nonplanar (LIToken ⊕ Unit))))
-      = of' (R := ℤ) ({((Step.emL item).apply current).toHc}
+    (h_coh : (item * current).toNonplanar =
+      Nonplanar.node (Sum.inl L) {item.toNonplanar, current.toNonplanar}) :
+    mergeOp (R := ℤ) (Sum.inl L) item.toNonplanar current.toNonplanar
+        (of' ({item.toNonplanar, current.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit))))
+      = of' (R := ℤ) ({((Step.emL item).apply current).toNonplanar}
         : Forest (Nonplanar (LIToken ⊕ Unit))) := by
-  show mergeOp (R := ℤ) (Sum.inl L) item.toHc current.toHc
-        (of' ({item.toHc, current.toHc} : Forest (Nonplanar (LIToken ⊕ Unit))))
-      = of' (R := ℤ) ({(item * current).toHc} : Forest (Nonplanar (LIToken ⊕ Unit)))
+  show mergeOp (R := ℤ) (Sum.inl L) item.toNonplanar current.toNonplanar
+        (of' ({item.toNonplanar, current.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit))))
+      = of' (R := ℤ) ({(item * current).toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit)))
   rw [mergeOp_pair, ← h_coh]
 
 end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Merge/Internal.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Internal.lean
@@ -24,7 +24,7 @@ performs External Merge between mover and the deletion-quotient.
   theorem. Under the unique-cut hypothesis, the two-stage pipeline reduces to EM
   Case 1 (`mergeOp_pair`).
 - `mergeOp_im_matches_Step`: bridge to linguistic `Step.im` via
-  `((Step.im mover traceId).apply current).toHc`.
+  `((Step.im mover traceId).apply current).toNonplanar`.
 
 ## Deferred (substrate gap)
 
@@ -163,39 +163,39 @@ private noncomputable instance : DecidableEq (Nonplanar (LIToken ⊕ Unit)) :=
   Classical.decEq _
 
 /-- **Step.im algebraic bridge (M-C-B Prop 1.4.2 specialization).** Given the cut
-    data `p0` linking the algebraic Δ^ρ deletion-quotient on `current.toHc` to the
-    trace-replaced linguistic quotient `(current.replace mover (mkTrace traceId)).toHc`,
-    the IM composition `mergeOp (Sum.inl L) mover.toHc Q ∘ mergeOpUnit mover.toHc`
-    reproduces `((Step.im mover traceId).apply current).toHc`.
+    data `p0` linking the algebraic Δ^ρ deletion-quotient on `current.toNonplanar` to the
+    trace-replaced linguistic quotient `(current.replace mover (mkTrace traceId)).toNonplanar`,
+    the IM composition `mergeOp (Sum.inl L) mover.toNonplanar Q ∘ mergeOpUnit mover.toNonplanar`
+    reproduces `((Step.im mover traceId).apply current).toNonplanar`.
 
     `L` is the head label of the re-merged node; `h_coh` factors
-    `(mover * traced).toHc` as `Nonplanar.node (Sum.inl L) {mover.toHc, traced.toHc}`
-    (the `toHcPlanarN` labeling convention), the same `L` that `mergeOp` grafts. -/
+    `(mover * traced).toNonplanar` as `Nonplanar.node (Sum.inl L) {mover.toNonplanar, traced.toNonplanar}`
+    (the `planarToNonplanar` labeling convention), the same `L` that `mergeOp` grafts. -/
 theorem mergeOp_im_matches_Step
     (current mover : Minimalist.SyntacticObject) (traceId : Nat) (L : LIToken)
     (p0 : Forest (Nonplanar (LIToken ⊕ Unit)) × Nonplanar (LIToken ⊕ Unit))
-    (h_filter : (cutSummandsN current.toHc).filter
-        (fun p => p.1 = ({mover.toHc} : Forest (Nonplanar (LIToken ⊕ Unit)))) = {p0})
-    (h_remainder : p0.2 = (current.replace mover (Minimalist.mkTrace traceId)).toHc)
-    (h_curr_ne_mover : current.toHc ≠ mover.toHc)
-    (h_coh : (mover * (current.replace mover (Minimalist.mkTrace traceId))).toHc =
+    (h_filter : (cutSummandsN current.toNonplanar).filter
+        (fun p => p.1 = ({mover.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit)))) = {p0})
+    (h_remainder : p0.2 = (current.replace mover (Minimalist.mkTrace traceId)).toNonplanar)
+    (h_curr_ne_mover : current.toNonplanar ≠ mover.toNonplanar)
+    (h_coh : (mover * (current.replace mover (Minimalist.mkTrace traceId))).toNonplanar =
       Nonplanar.node (Sum.inl L)
-        {mover.toHc, (current.replace mover (Minimalist.mkTrace traceId)).toHc}) :
-    mergeOp (R := ℤ) (Sum.inl L) mover.toHc
-        (current.replace mover (Minimalist.mkTrace traceId)).toHc
-        (mergeOpUnit (R := ℤ) mover.toHc
-          (of' ({current.toHc} : Forest (Nonplanar (LIToken ⊕ Unit)))))
-      = of' (R := ℤ) ({((Step.im mover traceId).apply current).toHc}
+        {mover.toNonplanar, (current.replace mover (Minimalist.mkTrace traceId)).toNonplanar}) :
+    mergeOp (R := ℤ) (Sum.inl L) mover.toNonplanar
+        (current.replace mover (Minimalist.mkTrace traceId)).toNonplanar
+        (mergeOpUnit (R := ℤ) mover.toNonplanar
+          (of' ({current.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit)))))
+      = of' (R := ℤ) ({((Step.im mover traceId).apply current).toNonplanar}
         : Forest (Nonplanar (LIToken ⊕ Unit))) := by
-  rw [mergeOp_im_composition_moverLeft (Sum.inl L) mover.toHc current.toHc
-        (current.replace mover (Minimalist.mkTrace traceId)).toHc
+  rw [mergeOp_im_composition_moverLeft (Sum.inl L) mover.toNonplanar current.toNonplanar
+        (current.replace mover (Minimalist.mkTrace traceId)).toNonplanar
         p0 h_filter h_remainder h_curr_ne_mover]
   -- (Step.im mover traceId).apply current = mover * (current.replace mover (mkTrace traceId))
   show of' (R := ℤ)
       ({Nonplanar.node (Sum.inl L)
-          {mover.toHc, (current.replace mover (Minimalist.mkTrace traceId)).toHc}}
+          {mover.toNonplanar, (current.replace mover (Minimalist.mkTrace traceId)).toNonplanar}}
         : Forest (Nonplanar (LIToken ⊕ Unit)))
-    = of' (R := ℤ) ({(mover * (current.replace mover (Minimalist.mkTrace traceId))).toHc}
+    = of' (R := ℤ) ({(mover * (current.replace mover (Minimalist.mkTrace traceId))).toNonplanar}
         : Forest (Nonplanar (LIToken ⊕ Unit)))
   rw [← h_coh]
 

--- a/Linglib/Syntax/Minimalist/Merge/PhaseCoproduct.lean
+++ b/Linglib/Syntax/Minimalist/Merge/PhaseCoproduct.lean
@@ -23,17 +23,17 @@ The phase substrate (`Merge/Phase.lean`) names the inaccessibility set `Y_ℓ` a
 `Multiset SyntacticObject`; the carrier is `ConnesKreimer ℤ (Nonplanar (LIToken ⊕
 Unit))`. To ask whether an admissible cut extracts an inaccessible subtree we
 compare on the **carrier** side: map `Y_ℓ` forward through the total embedding
-`SyntacticObject.toHc` and test crown membership there. This avoids any partial
+`SyntacticObject.toNonplanar` and test crown membership there. This avoids any partial
 `Nonplanar → SyntacticObject` recovery (which is ill-defined past binary trees,
 since `SyntacticObject = FreeCommMagma _` is commutative but non-associative);
-`toHc` is total and clean.
+`toNonplanar` is total and clean.
 
 ## Implementation
 
 `comulPhaseC` routes through the substrate primitive `comulTreeNFiltered`
 (`Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean`), the filtered Δ^ρ
 that also yields `comulTreeN` in the `pred = always-true` limit. The phase case
-filters `cutSummandsN T.toHc` by `cutPhaseCompatible`.
+filters `cutSummandsN T.toNonplanar` by `cutPhaseCompatible`.
 
 ## Coassociativity (MCB Lemma 1.14.6) — deferred
 
@@ -61,16 +61,16 @@ open Minimalist (HeadFunction ComplementedHeadFunction SyntacticObject LIToken P
 
 /-! ### Phase-compatibility predicate on cut summands -/
 
-/-- A Δ^ρ cut summand `p` of `T.toHc` is **phase-compatible** with phase `Φ_ℓ`
-    on `T` iff none of its crown components `p.1` is the `toHc`-image of an
+/-- A Δ^ρ cut summand `p` of `T.toNonplanar` is **phase-compatible** with phase `Φ_ℓ`
+    on `T` iff none of its crown components `p.1` is the `toNonplanar`-image of an
     inaccessible term (a vertex in `Y_ℓ`).
 
-    This is the predicate that filters `cutSummandsN T.toHc` to obtain Δ^c_Φ
+    This is the predicate that filters `cutSummandsN T.toNonplanar` to obtain Δ^c_Φ
     ([marcolli-chomsky-berwick-2025] Definition 1.14.5 eq 1.14.6). -/
 noncomputable def cutPhaseCompatible (h : HeadFunction) (T : SyntacticObject)
     (ℓ : LIToken) (p : Forest (Nonplanar (LIToken ⊕ Unit)) × Nonplanar (LIToken ⊕ Unit)) :
     Prop :=
-  ∀ sub ∈ p.1, sub ∉ (inaccessibleTerms h T ℓ).map SyntacticObject.toHc
+  ∀ sub ∈ p.1, sub ∉ (inaccessibleTerms h T ℓ).map SyntacticObject.toNonplanar
 
 /-- `inaccessibleTerms` is noncomputable, so phase-compatibility is decided
     classically (the phase coproduct is noncomputable regardless). -/
@@ -81,29 +81,29 @@ noncomputable instance (h : HeadFunction) (T : SyntacticObject) (ℓ : LIToken) 
 
 /-- The **tree-level phase coproduct** Δ^c_Φ
     ([marcolli-chomsky-berwick-2025] Definition 1.14.5 eq 1.14.6), as the
-    `comulTreeNFiltered` of `T.toHc` filtered by `cutPhaseCompatible`. Sums the
+    `comulTreeNFiltered` of `T.toNonplanar` filtered by `cutPhaseCompatible`. Sums the
     `T ⊗ 1` primitive plus the phase-compatible cut summands; cuts extracting an
     inaccessible (`Y_ℓ`) subtree are dropped. -/
 noncomputable def comulPhaseC (h : HeadFunction) (T : SyntacticObject) (ℓ : LIToken) :
     ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) ⊗[ℤ]
       ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) :=
-  comulTreeNFiltered T.toHc (cutPhaseCompatible h T ℓ)
+  comulTreeNFiltered T.toNonplanar (cutPhaseCompatible h T ℓ)
 
 /-- **Unrestricted-limit recovery**: when every cut is phase-compatible, Δ^c_Φ
     recovers the full Δ^ρ `comulTreeN`. Δ^c_Φ is a *restriction* of the
     coproduct, not a parallel definition. -/
 theorem comulPhaseC_eq_comulTreeN_of_no_filter
     (h : HeadFunction) (T : SyntacticObject) (ℓ : LIToken)
-    (hAll : ∀ p ∈ cutSummandsN T.toHc, cutPhaseCompatible h T ℓ p) :
-    comulPhaseC h T ℓ = comulTreeN T.toHc :=
-  comulTreeNFiltered_eq_comulTreeN T.toHc (cutPhaseCompatible h T ℓ) hAll
+    (hAll : ∀ p ∈ cutSummandsN T.toNonplanar, cutPhaseCompatible h T ℓ p) :
+    comulPhaseC h T ℓ = comulTreeN T.toNonplanar :=
+  comulTreeNFiltered_eq_comulTreeN T.toNonplanar (cutPhaseCompatible h T ℓ) hAll
 
 /-- Unrestricted Δ^ρ on `T`'s embedding, in the same shape as `comulPhaseC`.
     The `.linearizationBound` PIC mode and the comparison baseline. -/
 noncomputable def comulC_unrestricted (T : SyntacticObject) :
     ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) ⊗[ℤ]
       ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) :=
-  comulTreeN T.toHc
+  comulTreeN T.toNonplanar
 
 /-! ### PICStrength dispatch (weak PIC) -/
 
@@ -124,7 +124,7 @@ noncomputable def inaccessibleTerms_weak (h : HeadFunction) (T : SyntacticObject
 noncomputable def cutPhaseCompatible_weak (h : HeadFunction) (T : SyntacticObject)
     (ℓ : LIToken) (p : Forest (Nonplanar (LIToken ⊕ Unit)) × Nonplanar (LIToken ⊕ Unit)) :
     Prop :=
-  ∀ sub ∈ p.1, sub ∉ (inaccessibleTerms_weak h T ℓ).map SyntacticObject.toHc
+  ∀ sub ∈ p.1, sub ∉ (inaccessibleTerms_weak h T ℓ).map SyntacticObject.toNonplanar
 
 noncomputable instance (h : HeadFunction) (T : SyntacticObject) (ℓ : LIToken) :
     DecidablePred (cutPhaseCompatible_weak h T ℓ) := Classical.decPred _
@@ -133,7 +133,7 @@ noncomputable instance (h : HeadFunction) (T : SyntacticObject) (ℓ : LIToken) 
 noncomputable def comulPhaseC_weak (h : HeadFunction) (T : SyntacticObject) (ℓ : LIToken) :
     ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) ⊗[ℤ]
       ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) :=
-  comulTreeNFiltered T.toHc (cutPhaseCompatible_weak h T ℓ)
+  comulTreeNFiltered T.toNonplanar (cutPhaseCompatible_weak h T ℓ)
 
 /-- The phase-coproduct under `PICStrength` dispatch.
 


### PR DESCRIPTION
Rename the opaque `toHc` family to the mathlib-idiomatic `toNonplanar` (named after the target type `RootedTree.Nonplanar`, like `toList`/`toFinset`). The `Hc` ('Hopf-algebra carrier') abbreviation followed Connes–Kreimer notation but isn't self-documenting.

- `SyntacticObject.toHc` → `toNonplanar`, `HeadFunction.toHcWith` → `toNonplanarWith`, `toHcPlanarN` → `planarToNonplanar` (+ `toHc_leaf`/`_trace`/`_mul`, `mkTrace_toHc` lemmas). Pure mechanical rename across Merge/{Defs,External,Internal,PhaseCoproduct} + one stale docstring example in Core/Algebra/Free.