### PR TITLE
feat(Syntax/Minimalist): toNonplanar_mul, discharge merge-bridge coherence

### DIFF
--- a/Linglib/Syntax/Minimalist/Merge/Defs.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Defs.lean
@@ -79,6 +79,39 @@ With the selection-induced section, leaves/traces reduce **definitionally**
 @[simp] theorem SyntacticObject.toNonplanar_trace (n : Nat) :
     (SyntacticObject.trace n).toNonplanar = Nonplanar.leaf (Sum.inr ()) := rfl
 
+/-- **Canonical-orientation coherence.** `toNonplanar` distributes over Merge:
+    the node is labeled with the genuine selector head (`leftmostLeafPlanar` of the
+    selection-induced embedding, [marcolli-chomsky-berwick-2025] Lemma 1.13.7) and
+    its children are exactly `{l.toNonplanar, r.toNonplanar}`. Holds because the
+    embedding's orientation is selection-determined (head-side) or, at exocentric
+    nodes, the canonical `smallerFirst` — never an arbitrary `Quot.out`. This is the
+    externalize-respect property the `mergeOp_*_matches_Step` bridges need. -/
+theorem SyntacticObject.toNonplanar_mul (l r : SyntacticObject) :
+    (l * r).toNonplanar =
+      Nonplanar.node (Sum.inl (leftmostLeafPlanar (selLinearize .initial (l * r))))
+        {l.toNonplanar, r.toNonplanar} := by
+  show planarToNonplanar .initial (selLinearize .initial (l * r)) = _
+  rw [selLinearize_mul]
+  -- the head label is uniform (`leftmostLeafPlanar`); only child orientation varies
+  split <;>
+    first
+    | (unfold smallerFirst
+       split <;>
+         simp only [planarToNonplanar, headLeafPlanar, leftmostLeafPlanar,
+           SyntacticObject.toNonplanar] <;>
+         try rw [Multiset.pair_comm])
+    | (simp only [placeHead, planarToNonplanar, headLeafPlanar, leftmostLeafPlanar,
+         SyntacticObject.toNonplanar] <;>
+       try rw [Multiset.pair_comm])
+
+/-- On the endocentric domain `Dom(h)`, the Merge node's head label is the genuine
+    **selector** `selHead` ([marcolli-chomsky-berwick-2025] Lemma 1.13.7). The form
+    the `mergeOp_*_matches_Step` bridges consume. -/
+theorem SyntacticObject.toNonplanar_mul_selHead (l r : SyntacticObject) (hd : LIToken)
+    (hsel : selHead (l * r) = some hd) :
+    (l * r).toNonplanar = Nonplanar.node (Sum.inl hd) {l.toNonplanar, r.toNonplanar} := by
+  rw [toNonplanar_mul, leftmost_selLinearize_eq_selHead _ _ hsel]
+
 /-! ### Singleton-class simp lemmas for `toNonplanarWith` (parameterized)
 
 All three lemmas reduce via the keystone `FreeCommMagma.Section.σ_of` helper:

--- a/Linglib/Syntax/Minimalist/Merge/External.lean
+++ b/Linglib/Syntax/Minimalist/Merge/External.lean
@@ -320,16 +320,16 @@ private noncomputable instance : DecidableEq (Nonplanar (LIToken ⊕ Unit)) :=
     `{current.toNonplanar, item.toNonplanar}` yields the singleton workspace of
     `.node (Sum.inl L) {current.toNonplanar, item.toNonplanar}` = `(Step.emR item).apply current`.
 
-    `L` is the **head label** of the merged node; `h_coh` is the
-    externalize-respect property: the `Quot.out`-based `toNonplanar` on `current * item`
-    factors as `Nonplanar.node (Sum.inl L) {current.toNonplanar, item.toNonplanar}`, with the
-    SAME head label `L` that `mergeOp` grafts. Per MCB §1.12.3, this is the
-    local-coherence condition some sections satisfy at the merged node; consumers
-    supply it when the section is built to respect the merge. -/
+    `L` is the **head label** of the merged node. The externalize-respect property
+    — that `toNonplanar` on `current * item` factors as
+    `Nonplanar.node (Sum.inl L) {current.toNonplanar, item.toNonplanar}` with the
+    SAME `L` that `mergeOp` grafts — is now a *theorem* (`toNonplanar_mul_selHead`)
+    rather than a hypothesis: the selection-induced section is built to respect the
+    merge, and `L` is just the head selector. The consumer supplies only the simple,
+    decidable `selHead (current * item) = some L`. -/
 theorem mergeOp_emR_matches_Step
     (current item : Minimalist.SyntacticObject) (L : LIToken)
-    (h_coh : (current * item).toNonplanar =
-      Nonplanar.node (Sum.inl L) {current.toNonplanar, item.toNonplanar}) :
+    (hsel : Minimalist.selHead (current * item) = some L) :
     mergeOp (R := ℤ) (Sum.inl L) current.toNonplanar item.toNonplanar
         (of' ({current.toNonplanar, item.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit))))
       = of' (R := ℤ) ({((Step.emR item).apply current).toNonplanar}
@@ -337,7 +337,7 @@ theorem mergeOp_emR_matches_Step
   show mergeOp (R := ℤ) (Sum.inl L) current.toNonplanar item.toNonplanar
         (of' ({current.toNonplanar, item.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit))))
       = of' (R := ℤ) ({(current * item).toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit)))
-  rw [mergeOp_pair, ← h_coh]
+  rw [mergeOp_pair, ← Minimalist.SyntacticObject.toNonplanar_mul_selHead current item L hsel]
 
 /-- **External Merge bridge (left-specifier)** (M-C-B Lemma 1.4.1, F̂ = ∅,
     symmetric pair). `mergeOp (Sum.inl L) item.toNonplanar current.toNonplanar` applied to
@@ -345,8 +345,7 @@ theorem mergeOp_emR_matches_Step
     = `(Step.emL item).apply current`. -/
 theorem mergeOp_emL_matches_Step
     (item current : Minimalist.SyntacticObject) (L : LIToken)
-    (h_coh : (item * current).toNonplanar =
-      Nonplanar.node (Sum.inl L) {item.toNonplanar, current.toNonplanar}) :
+    (hsel : Minimalist.selHead (item * current) = some L) :
     mergeOp (R := ℤ) (Sum.inl L) item.toNonplanar current.toNonplanar
         (of' ({item.toNonplanar, current.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit))))
       = of' (R := ℤ) ({((Step.emL item).apply current).toNonplanar}
@@ -354,6 +353,6 @@ theorem mergeOp_emL_matches_Step
   show mergeOp (R := ℤ) (Sum.inl L) item.toNonplanar current.toNonplanar
         (of' ({item.toNonplanar, current.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit))))
       = of' (R := ℤ) ({(item * current).toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit)))
-  rw [mergeOp_pair, ← h_coh]
+  rw [mergeOp_pair, ← Minimalist.SyntacticObject.toNonplanar_mul_selHead item current L hsel]
 
 end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Merge/Internal.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Internal.lean
@@ -168,9 +168,10 @@ private noncomputable instance : DecidableEq (Nonplanar (LIToken ⊕ Unit)) :=
     the IM composition `mergeOp (Sum.inl L) mover.toNonplanar Q ∘ mergeOpUnit mover.toNonplanar`
     reproduces `((Step.im mover traceId).apply current).toNonplanar`.
 
-    `L` is the head label of the re-merged node; `h_coh` factors
-    `(mover * traced).toNonplanar` as `Nonplanar.node (Sum.inl L) {mover.toNonplanar, traced.toNonplanar}`
-    (the `planarToNonplanar` labeling convention), the same `L` that `mergeOp` grafts. -/
+    `L` is the head label of the re-merged node. The externalize-respect factoring of
+    `(mover * traced).toNonplanar` as `Nonplanar.node (Sum.inl L) {mover.toNonplanar,
+    traced.toNonplanar}` is now a *theorem* (`toNonplanar_mul_selHead`); the consumer
+    supplies only the simple `selHead (mover * traced) = some L`. -/
 theorem mergeOp_im_matches_Step
     (current mover : Minimalist.SyntacticObject) (traceId : Nat) (L : LIToken)
     (p0 : Forest (Nonplanar (LIToken ⊕ Unit)) × Nonplanar (LIToken ⊕ Unit))
@@ -178,9 +179,8 @@ theorem mergeOp_im_matches_Step
         (fun p => p.1 = ({mover.toNonplanar} : Forest (Nonplanar (LIToken ⊕ Unit)))) = {p0})
     (h_remainder : p0.2 = (current.replace mover (Minimalist.mkTrace traceId)).toNonplanar)
     (h_curr_ne_mover : current.toNonplanar ≠ mover.toNonplanar)
-    (h_coh : (mover * (current.replace mover (Minimalist.mkTrace traceId))).toNonplanar =
-      Nonplanar.node (Sum.inl L)
-        {mover.toNonplanar, (current.replace mover (Minimalist.mkTrace traceId)).toNonplanar}) :
+    (hsel : Minimalist.selHead
+      (mover * (current.replace mover (Minimalist.mkTrace traceId))) = some L) :
     mergeOp (R := ℤ) (Sum.inl L) mover.toNonplanar
         (current.replace mover (Minimalist.mkTrace traceId)).toNonplanar
         (mergeOpUnit (R := ℤ) mover.toNonplanar
@@ -197,6 +197,7 @@ theorem mergeOp_im_matches_Step
         : Forest (Nonplanar (LIToken ⊕ Unit)))
     = of' (R := ℤ) ({(mover * (current.replace mover (Minimalist.mkTrace traceId))).toNonplanar}
         : Forest (Nonplanar (LIToken ⊕ Unit)))
-  rw [← h_coh]
+  rw [← Minimalist.SyntacticObject.toNonplanar_mul_selHead
+        mover (current.replace mover (Minimalist.mkTrace traceId)) L hsel]
 
 end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Selection.lean
+++ b/Linglib/Syntax/Minimalist/Selection.lean
@@ -417,6 +417,17 @@ def selLinearize (s : ConventionDir) :
     SyntacticObject → FreeMagma (LIToken ⊕ Nat) :=
   FreeCommMagma.lift (selLinearizeAux s) (selLinearizeAux_respects s)
 
+/-- The selection-induced embedding distributes over Merge: the projecting
+    (selector) daughter is placed on the `s`-convention side, with the exocentric
+    fallback `smallerFirst`. Mirrors `selCheck_mul`. -/
+theorem selLinearize_mul (s : ConventionDir) (l r : SyntacticObject) :
+    selLinearize s (l * r) =
+      match selSide (selCheck l) (selCheck r) with
+      | some true  => placeHead s (selLinearize s l) (selLinearize s r)
+      | some false => placeHead s (selLinearize s r) (selLinearize s l)
+      | none       => smallerFirst (selLinearize s l) (selLinearize s r) := by
+  induction l, r using FreeCommMagma.inductionOn₂ with | _ a b => rfl
+
 /-- When `selStep` returns a head, that head is the projecting daughter's head,
     and `selSide` agrees on which daughter projects. The bridge between the
     residual-tracking `selStep` and the order-determining `selSide`. -/


### PR DESCRIPTION
Prove `toNonplanar_mul`: the carrier projection distributes over Merge with a **canonical** node label (`leftmostLeafPlanar` of the selection-induced embedding) and children `{l.toNonplanar, r.toNonplanar}`. The label is uniform; only the child-multiset orientation is case-dependent (`Multiset.pair_comm`). On `Dom(h)` the label is the genuine selector (`toNonplanar_mul_selHead`, via the agreement lemma).

This is the externalize-respect coherence the `mergeOp_*_matches_Step` bridges took as an opaque tree-equation hypothesis `h_coh`. Now discharged: the three bridges (emR/emL/im) instead take the simple, decidable `selHead (… * …) = some L` and prove `h_coh` internally via `toNonplanar_mul_selHead`. Axiom-clean (no sorry/native_decide). Spec: `scratch/tonon-mul-spec.md`.