### PR TITLE
feat(Syntax/Minimalist): reground so.out consumers on selLinearize

### DIFF
--- a/Linglib/Syntax/Minimalist/ExtendedProjection/Basic.lean
+++ b/Linglib/Syntax/Minimalist/ExtendedProjection/Basic.lean
@@ -290,18 +290,14 @@ private def computeEPSpinePlanar :
       [((FreeCommMagma.mk (.mul a b) : SyntacticObject),
          (leftmostLeafPlanar (.mul a b)).item.outerCat)]
 
-/-- Compute the EP spine from a syntactic object by walking the
-    leftmost-leaf head chain (harmonic head-initial convention per
-    [marcolli-chomsky-berwick-2025] §1.13). Returns pairs of
-    (SO, Cat) from the deepest lexical head up to the root.
-
-    For a non-leftmost-headed analysis, replace the recursion's `a`
-    with the daughter whose head leaf is the selector (`selHead`), or
-    rewrite this helper to take a head-side convention. Noncomputable
-    only because it picks a planar representative via `Quot.out`. -/
-noncomputable def computeEPSpine (so : SyntacticObject) :
+/-- Compute the EP spine from a syntactic object by walking the head chain of
+    the **selection-induced** head-initial embedding (`selLinearize .initial`,
+    [marcolli-chomsky-berwick-2025] Lemma 1.13.5). Returns pairs of (SO, Cat)
+    from the deepest lexical head up to the root. Computable, selection-faithful;
+    supersedes the arbitrary `Quot.out` representative. -/
+def computeEPSpine (so : SyntacticObject) :
     List (SyntacticObject × Cat) :=
-  computeEPSpinePlanar so.out
+  computeEPSpinePlanar (selLinearize .initial so)
 
 /-- Build an ExtendedProjection from a syntactic object using the
     leftmost-leaf head chain. -/

--- a/Linglib/Syntax/Minimalist/Phase.lean
+++ b/Linglib/Syntax/Minimalist/Phase.lean
@@ -152,12 +152,13 @@ structure Phase where
 -- Part 4: Phase Impenetrability Condition
 -- ============================================================================
 
-/-- The phase complement is the right daughter of the phase node, picked
-    via the planar `Quot.out` representative. Phase 1.0 noncomputable
-    placeholder; the parameterized version `phaseComplementWith?` below
-    takes a `HeadFunction` for explicit externalize choice. -/
-noncomputable def phaseComplement? : SyntacticObject → Option SyntacticObject :=
-  fun so => match so.out with
+/-- The phase complement is the right daughter of the phase node under the
+    **selection-induced** head-initial embedding (`selLinearize .initial`,
+    [marcolli-chomsky-berwick-2025] Lemma 1.13.5): the phase head is the left
+    daughter, its complement the right. Computable; supersedes the arbitrary
+    `Quot.out` choice. `phaseComplementWith?` below takes an explicit head fn. -/
+def phaseComplement? : SyntacticObject → Option SyntacticObject :=
+  fun so => match selLinearize .initial so with
     | .of _ => none
     | .mul _ r => some (FreeCommMagma.mk r)
 

--- a/Linglib/Syntax/Minimalist/Scope.lean
+++ b/Linglib/Syntax/Minimalist/Scope.lean
@@ -146,29 +146,21 @@ open Minimalist
     (the D lexical item) and `b` is the complement. PIC freezes the
     complement domain, not the head/edge.
 
-    **Phase 1.0 status.** The proof previously used `exact hcontains`
-    because under the planar `TraceTree` carrier `phaseComplement?`
-    reduced definitionally on `.node (leaf _) b` to `some b`. With the
-    nonplanar `FreeCommMagma` carrier, `phaseComplement?` picks the
-    right daughter of the `Quot.out` representative — which may be
-    either child after the swap quotient. The theorem statement
-    presupposes a planar choice that the substrate cannot make.
-
-    **Phase 2 plan.** Replace `phaseComplement?` with a head-function-
-    parameterized variant that picks the *complement* (the non-head
-    daughter) rather than "the right daughter of an arbitrary
-    representative." Once that lands, `dp_phase_barrier_from_pic` can
-    be re-proved by a head-function argument: if `tok` is the head,
-    the complement is `b`, so PIC freezes `b`'s contents. -/
+    **Status.** `phaseComplement?` is now the **selection-induced** complement
+    (right daughter of `selLinearize .initial`, [marcolli-chomsky-berwick-2025]
+    Lemma 1.13.5): when `tok` is the projecting head it returns `some b`. The
+    remaining gap to discharge this is connecting the hypothesis
+    `isPhaseHeadOf .D (node (leaf tok) b)` to *`tok` is the selector* (i.e. `tok`
+    c-selects `b`, so `selSide` picks the left/head daughter) — at which point
+    `phaseComplement? (node (leaf tok) b) = some b` and PIC freezes `b`. -/
 theorem dp_phase_barrier_from_pic (tok : LIToken) (b : SyntacticObject)
     (_h_phase : isPhaseHeadOf .D (.node (.leaf tok) b) = true) :
     ∀ (goal : SyntacticObject),
       contains b goal →
       phaseImpenetrable (.node (.leaf tok) b) goal := by
   intro goal _hcontains
-  -- TODO Phase 2: blocked on head-function-aware `phaseComplement?`;
-  -- current `Quot.out`-based version doesn't reduce on a specific
-  -- planar shape.
+  -- TODO: needs `tok` selects `b` (so `selSide` picks the head-left daughter and
+  -- `phaseComplement? (node (leaf tok) b) = some b`) from `isPhaseHeadOf .D`.
   sorry
 
 end PhaseBridge

--- a/Linglib/Syntax/Minimalist/SmallClause.lean
+++ b/Linglib/Syntax/Minimalist/SmallClause.lean
@@ -128,17 +128,14 @@ def IsSmallClausePredicate (so : SyntacticObject) : Prop :=
 instance : DecidablePred IsSmallClausePredicate :=
   fun so => by unfold IsSmallClausePredicate; infer_instance
 
-/-- The "right daughter" of an SO under planar `Quot.out`. Phase 1.0
-    placeholder — Phase 2 will replace with an `HeadFunction`-aware
-    selection of the predicate-side daughter.
-
-    Retained as a noncomputable accessor for downstream code that
-    actively wants the planar choice. The `IsSmallClause` predicate
-    no longer routes through this — see below for the swap-respecting
-    Multiset reformulation. -/
-noncomputable def SyntacticObject.rightDaughter? (so : SyntacticObject) :
+/-- The "right daughter" of an SO: the **complement** side of the
+    selection-induced head-initial embedding (`selLinearize .initial`,
+    [marcolli-chomsky-berwick-2025] Lemma 1.13.5) — the head is the left
+    daughter, so the right daughter is its complement. Computable; supersedes
+    the arbitrary `Quot.out` planar choice. -/
+def SyntacticObject.rightDaughter? (so : SyntacticObject) :
     Option SyntacticObject :=
-  match so.out with
+  match selLinearize .initial so with
   | .of _ => none
   | .mul _ r => some (FreeCommMagma.mk r)
 

--- a/Linglib/Syntax/Minimalist/SpellOut.lean
+++ b/Linglib/Syntax/Minimalist/SpellOut.lean
@@ -40,6 +40,7 @@ for the full admissibility conditions.
 
 import Linglib.Syntax.Minimalist.Basic
 import Linglib.Syntax.Minimalist.HeadFunction
+import Linglib.Syntax.Minimalist.Selection
 import Linglib.Syntax.Tree.Cat
 
 namespace Minimalist
@@ -64,21 +65,20 @@ private def toLFTreePlanar : FreeMagma (LIToken ⊕ Nat) → Tree Unit String
     - Binary nodes → `Tree.bin left right` (preserving structure)
 
     `Tree` is planar (`.bin a b ≠ .bin b a` in general); this transfer
-    therefore depends on a planar representative of the underlying
-    `FreeCommMagma`. Phase 1.0 placeholder via `Quot.out`; Phase 2 will
-    replace with LCA-derived linearization parameterized by head
-    directionality. -/
-noncomputable def SyntacticObject.toLFTree (so : SyntacticObject) : Tree Unit String :=
-  toLFTreePlanar so.out
+    therefore depends on a planar representative. We use the **selection-induced**
+    head-initial embedding (`selLinearize .initial`,
+    [marcolli-chomsky-berwick-2025] Lemma 1.13.5) — computable, selection-faithful,
+    superseding the arbitrary `Quot.out` representative. -/
+def SyntacticObject.toLFTree (so : SyntacticObject) : Tree Unit String :=
+  toLFTreePlanar (selLinearize .initial so)
 
-/-- The PF branch of Spell-Out: the leaf tokens of `so` in the
-    left-to-right order of a planar representative (harmonic head-initial).
-    Reads the order off a `Quot.out` representative — a Phase 1.0
-    placeholder, awaiting the selection-induced computable linearization
-    (MCB Lemma 1.13.5). For derivation-based PF that recovers movement
-    order, use `Derivation.surfaceTokens` instead. -/
-noncomputable def SyntacticObject.toPF (so : SyntacticObject) : List LIToken :=
-  linearizePlanar so.out
+/-- The PF branch of Spell-Out: the leaf tokens of `so` in the left-to-right
+    order of the **selection-induced** head-initial embedding (`selLinearize
+    .initial`, [marcolli-chomsky-berwick-2025] Lemma 1.13.5) — computable,
+    selection-faithful. For derivation-based PF that recovers movement order,
+    use `Derivation.surfaceTokens` instead. -/
+def SyntacticObject.toPF (so : SyntacticObject) : List LIToken :=
+  linearizePlanar (selLinearize .initial so)
 
 /-! ## Structural preservation — Phase 2 TODO
 


### PR DESCRIPTION
Migrate the remaining `Quot.out`/`so.out` planar-representative consumers onto the **selection-induced** embedding `selLinearize .initial` (head-initial: head left, complement right), like the Pesetsky `caseStackAt` and `toNonplanar` regroundings:

- `SmallClause.rightDaughter?`, `Phase.phaseComplement?` — the right daughter is now the genuine *complement* of the selection-induced order, not an arbitrary representative's
- `SpellOut.toLFTree` / `toPF`, `ExtendedProjection.computeEPSpine` — selection-faithful linearization/spine

All five **drop `noncomputable`** (`selLinearize` is computable). No code consumers (only prose), so no value-dependent theorems shift. Also updates `Scope.lean`'s stale `phaseComplement?` prose; its `dp_phase_barrier_from_pic` sorry now needs only the endocentricity link (`tok` selects `b`), noted in the TODO.