### PR TITLE
feat(Phonology/Autosegmental): MultiAR + monoidal inclusion functor

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2733,6 +2733,9 @@ import Linglib.Phonology.Autosegmental.NonCrossing
 import Linglib.Phonology.Autosegmental.AR
 import Linglib.Phonology.Autosegmental.WellFormedAR
 import Linglib.Phonology.Autosegmental.Embedding
+import Linglib.Phonology.Autosegmental.MultiGraph
+import Linglib.Phonology.Autosegmental.Inclusion
+import Linglib.Phonology.Autosegmental.MultiAR
 import Linglib.Phonology.Prosodic.Syllable
 import Linglib.Phonology.Prosodic.Foot
 import Linglib.Phonology.Prosodic.NaturalClass

--- a/Linglib/Core/CategoryTheory/Monoidal/LabeledTuple.lean
+++ b/Linglib/Core/CategoryTheory/Monoidal/LabeledTuple.lean
@@ -85,6 +85,14 @@ def comp (f : Hom a b) (g : Hom b c) : Hom a c :=
 @[simp] theorem comp_toFun (f : Hom a b) (g : Hom b c) :
     (f.comp g).toFun = g.toFun ∘ f.toFun := rfl
 
+/-- A `Hom` is a label-preserving position map; bundle it as `FunLike` so `f i`
+    applies it and the mathlib hom machinery (`DFunLike.ext`, …) is available. -/
+instance : FunLike (Hom a b) (Fin a.len) (Fin b.len) where
+  coe := Hom.toFun
+  coe_injective _ _ h := Hom.ext h
+
+@[simp] theorem coe_toFun (f : Hom a b) : ⇑f = f.toFun := rfl
+
 end Hom
 
 instance : Category (LabeledTuple α) where

--- a/Linglib/Phonology/Autosegmental/Inclusion.lean
+++ b/Linglib/Phonology/Autosegmental/Inclusion.lean
@@ -1,0 +1,239 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Tactic.FinCases
+import Mathlib.CategoryTheory.Monoidal.Functor
+import Linglib.Phonology.Autosegmental.Graph
+import Linglib.Phonology.Autosegmental.MultiGraph
+import Linglib.Phonology.Autosegmental.AR
+import Linglib.Phonology.Autosegmental.MultiAR
+
+/-!
+# The bipartite-to-multi-tier inclusion functor
+
+The strong monoidal functor `ι : AR α β ⥤ MultiAR (biTier α β)` realising the
+bipartite autosegmental category as the `n = 2` case: a bipartite graph is the
+2-tier multigraph associating only the `(0,1)` melody↔skeleton pair. Unit and
+tensor coherences are the object equalities `toMultiGraph_empty`/`toMultiGraph_concat`
+as `eqToIso`. ([goldsmith-1976], [jardine-heinz-2015])
+
+## Main definitions
+
+* `Graph.toMultiGraph`, `AR.toMultiAR` — the inclusion on objects.
+* `ι` — the inclusion functor; the `ι.Monoidal` instance makes it strong monoidal.
+-/
+
+namespace Autosegmental
+
+open CategoryTheory MonoidalCategory
+
+universe u
+
+variable {α β : Type u}
+
+/-- The two-tier family `![α, β]` indexing the bipartite case. -/
+abbrev biTier (α β : Type u) : Fin 2 → Type u := ![α, β]
+
+/-- **The inclusion on objects**: a bipartite `Graph α β` as the 2-tier
+    `MultiGraph ![α,β]` that associates only the `(0,1)` tier-pair (melody↔skeleton).
+    The dependent `Fin 2` tier-tuple is built with `Fin.cons` (`![·,·]` is
+    non-dependent and cannot host the heterogeneous `LabeledTuple α`/`LabeledTuple β`). -/
+def Graph.toMultiGraph (G : Graph α β) : MultiGraph (biTier α β) where
+  tiers := Fin.cons G.upper (Fin.cons G.lower finZeroElim)
+  links i j := if i = 0 ∧ j = 1 then G.links else ∅
+
+@[simp] theorem toMultiGraph_tiers_zero (G : Graph α β) : G.toMultiGraph.tiers 0 = G.upper := rfl
+@[simp] theorem toMultiGraph_tiers_one (G : Graph α β) : G.toMultiGraph.tiers 1 = G.lower := rfl
+@[simp] theorem toMultiGraph_links_01 (G : Graph α β) : G.toMultiGraph.links 0 1 = G.links := rfl
+
+/-- The inclusion sends a planar bipartite graph to a planar multigraph (and back):
+    the only nonempty pair is `(0,1)`, carrying `G.links`. -/
+@[simp] theorem toMultiGraph_isPlanar (G : Graph α β) :
+    G.toMultiGraph.IsPlanar ↔ G.IsPlanar := by
+  constructor
+  · intro h; exact h 0 1
+  · intro h i j
+    fin_cases i <;> fin_cases j <;> simp_all [Graph.toMultiGraph, Graph.IsPlanar, isNonCrossing_empty]
+
+/-- The inclusion preserves the empty graph (monoidal unit coherence). -/
+theorem toMultiGraph_empty : (Graph.empty : Graph α β).toMultiGraph = MultiGraph.empty := by
+  refine MultiGraph.ext (funext fun i => ?_) (funext fun i => funext fun j => ?_)
+  · fin_cases i <;> rfl
+  · fin_cases i <;> fin_cases j <;> simp [Graph.toMultiGraph, Graph.empty]
+
+/-- **The inclusion preserves concatenation** — the monoidal-functor coherence on
+    objects: `(A ⋆ B)` maps to `(toMultiGraph A) ⋆ (toMultiGraph B)`. -/
+theorem toMultiGraph_concat (A B : Graph α β) :
+    (A.concat B).toMultiGraph = A.toMultiGraph.concat B.toMultiGraph := by
+  refine MultiGraph.ext (funext fun i => ?_) (funext fun i => funext fun j => ?_)
+  · fin_cases i <;> rfl
+  · fin_cases i <;> fin_cases j <;> rfl
+
+/-! ### The inclusion functor on objects (in-bounds lift) -/
+
+/-- The bipartite `InBounds` lifts to the multigraph: the only nonempty link-pair of
+    `toMultiGraph` is `(0,1)`, where it carries `G.links` and the tier lengths are
+    `upper`/`lower`. -/
+theorem toMultiGraph_inBounds {A : AR α β} : A.toGraph.toMultiGraph.InBounds := by
+  intro i j p hp
+  simp only [Graph.toMultiGraph] at hp ⊢
+  split_ifs at hp with h
+  · obtain ⟨hi, hj⟩ := h; subst hi; subst hj
+    exact A.inBounds p hp
+  · simp at hp
+
+/-- **The inclusion on objects.** -/
+def AR.toMultiAR (A : AR α β) : MultiAR (biTier α β) where
+  toMultiGraph := A.toGraph.toMultiGraph
+  inBounds := toMultiGraph_inBounds
+
+@[simp] theorem AR.toMultiAR_toMultiGraph (A : AR α β) :
+    A.toMultiAR.toMultiGraph = A.toGraph.toMultiGraph := rfl
+
+/-! ### The inclusion on morphisms -/
+
+/-- The `Fin 2`-tuple of tier maps mirroring how `toMultiGraph.tiers` is built. -/
+def AR.Hom.toMultiFT {A B : AR α β} (f : AR.Hom A B) :
+    (i : Fin 2) → LabeledTuple.Hom (A.toMultiAR.tiers i) (B.toMultiAR.tiers i) :=
+  Fin.cons f.fU (Fin.cons f.fL finZeroElim)
+
+@[simp] theorem AR.Hom.toMultiFT_zero {A B : AR α β} (f : AR.Hom A B) :
+    f.toMultiFT 0 = f.fU := rfl
+
+@[simp] theorem AR.Hom.toMultiFT_one {A B : AR α β} (f : AR.Hom A B) :
+    f.toMultiFT 1 = f.fL := rfl
+
+/-- **The inclusion on morphisms.** -/
+def AR.Hom.toMultiAR {A B : AR α β} (f : AR.Hom A B) :
+    MultiAR.Hom A.toMultiAR B.toMultiAR where
+  fT := f.toMultiFT
+  links_preserve i j {p q} hp hq h := by
+    simp only [AR.toMultiAR, Graph.toMultiGraph] at h ⊢
+    split_ifs at h with hc
+    · obtain ⟨hi, hj⟩ := hc; subst hi; subst hj
+      rw [if_pos ⟨rfl, rfl⟩]
+      exact f.links_preserve hp hq h
+    · simp at h
+
+/-! ### The plain functor -/
+
+/-- **The inclusion functor** `AR α β ⥤ MultiAR (biTier α β)`. -/
+def ι : AR α β ⥤ MultiAR (biTier α β) where
+  obj A := A.toMultiAR
+  map f := f.toMultiAR
+  map_id A := by apply MultiAR.Hom.ext; funext i; fin_cases i <;> rfl
+  map_comp f g := by apply MultiAR.Hom.ext; funext i; fin_cases i <;> rfl
+
+@[simp] theorem ι_obj (A : AR α β) : ι.obj A = A.toMultiAR := rfl
+@[simp] theorem ι_map {A B : AR α β} (f : A ⟶ B) : ι.map f = f.toMultiAR := rfl
+
+/-! ### Monoidal coherence on objects (lifting to in-bounds `MultiAR`) -/
+
+/-- The inclusion preserves the tensor unit (monoidal unit object coherence). -/
+theorem toMultiAR_empty : (AR.empty : AR α β).toMultiAR = MultiAR.empty :=
+  MultiAR.ext_toMultiGraph toMultiGraph_empty
+
+/-- Every tier of the included unit is empty (length 0). -/
+@[simp] theorem toMultiAR_empty_tiers_len (i : Fin 2) :
+    ((AR.empty : AR α β).toMultiAR.tiers i).len = 0 := by
+  rw [show (AR.empty : AR α β).toMultiAR = MultiAR.empty from toMultiAR_empty]; rfl
+
+/-- The inclusion preserves the tensor (monoidal tensor object coherence). -/
+theorem toMultiAR_concat (A B : AR α β) :
+    (A.concat B).toMultiAR = A.toMultiAR.concat B.toMultiAR :=
+  MultiAR.ext_toMultiGraph (toMultiGraph_concat A.toGraph B.toGraph)
+
+@[simp] theorem toMultiAR_fT {A B : AR α β} (f : AR.Hom A B) :
+    (f.toMultiAR).fT = f.toMultiFT := rfl
+
+/-! ### The strong monoidal upgrade
+
+Via `Functor.CoreMonoidal` — `εIso`/`μIso` are the `eqToIso` of the object
+coherences — and `CoreMonoidal.toMonoidal`. -/
+
+/-- **The monoidal-functoriality bridge** (the `μ`-naturality crux): `ι` of a tensor
+    of morphisms is the tensor of the `ι`-images, conjugated by the object
+    coherence `eqToHom`s. -/
+theorem toMultiAR_concatMap {A A' B B' : AR α β} (f : AR.Hom A A') (g : AR.Hom B B') :
+    (AR.Hom.concatMap f g).toMultiAR =
+      eqToHom (toMultiAR_concat A B) ≫ MultiAR.Hom.concatMap f.toMultiAR g.toMultiAR
+        ≫ eqToHom (toMultiAR_concat A' B').symm := by
+  apply MultiAR.Hom.ext; funext i
+  apply LabeledTuple.Hom.ext; funext x
+  apply Fin.ext
+  fin_cases i <;>
+    simp only [MultiAR.comp_fT', MultiAR.Hom.concatMap_fT, AR.Hom.toMultiFT,
+      AR.Hom.toMultiAR, LabeledTuple.Hom.comp_toFun, LabeledTuple.Hom.concatMap_toFun,
+      MultiAR.eqToHom_fT_toFun, Function.comp_apply] <;>
+    rfl
+
+/-- The `Functor.CoreMonoidal` data for the inclusion: `εIso`/`μIso` are the
+    `eqToIso`s of the object coherences. -/
+def ι.coreMonoidal : (ι (α := α) (β := β)).CoreMonoidal where
+  εIso := eqToIso toMultiAR_empty.symm
+  μIso X Y := eqToIso (toMultiAR_concat X Y).symm
+  μIso_hom_natural_left {X Y} f X' := by
+    apply MultiAR.Hom.ext; funext i; apply LabeledTuple.Hom.ext; funext x; apply Fin.ext
+    fin_cases i <;>
+      simp only [ι_obj, ι_map, eqToIso.hom, MonoidalCategoryStruct.whiskerRight,
+        MultiAR.comp_fT', MultiAR.Hom.concatMap_fT, MultiAR.eqToHom_fT_toFun,
+        AR.Hom.toMultiFT, AR.Hom.toMultiAR, LabeledTuple.Hom.comp_toFun,
+        LabeledTuple.Hom.concatMap_toFun, Function.comp_apply] <;>
+      rfl
+  μIso_hom_natural_right {X Y} X' f := by
+    apply MultiAR.Hom.ext; funext i; apply LabeledTuple.Hom.ext; funext x; apply Fin.ext
+    fin_cases i <;>
+      simp only [ι_obj, ι_map, eqToIso.hom, MonoidalCategoryStruct.whiskerLeft,
+        MultiAR.comp_fT', MultiAR.Hom.concatMap_fT, MultiAR.eqToHom_fT_toFun,
+        AR.Hom.toMultiFT, AR.Hom.toMultiAR, LabeledTuple.Hom.comp_toFun,
+        LabeledTuple.Hom.concatMap_toFun, Function.comp_apply] <;>
+      rfl
+  associativity X Y Z := by
+    apply MultiAR.Hom.ext; funext i; apply LabeledTuple.Hom.ext; funext x; apply Fin.ext
+    fin_cases i <;>
+      simp only [ι_obj, eqToIso.hom, MonoidalCategoryStruct.whiskerRight,
+        MonoidalCategoryStruct.whiskerLeft, MonoidalCategoryStruct.associator,
+        MonoidalCategoryStruct.tensorObj, MultiAR.comp_fT', MultiAR.Hom.concatMap_fT,
+        MultiAR.eqToHom_fT_toFun, eqToHom_map, MultiAR.Hom.id_fT, LabeledTuple.Hom.id_toFun,
+        LabeledTuple.Hom.comp_toFun, LabeledTuple.Hom.concatMap_toFun, Function.comp_apply,
+        Fin.val_cast, Fin.appendMap_val, id_eq,
+        toMultiAR_concat, MultiAR.concat_tiers, LabeledTuple.concat_len] <;>
+      (split_ifs <;> omega)
+  left_unitality X := by
+    apply MultiAR.Hom.ext; funext i; apply LabeledTuple.Hom.ext; funext x; apply Fin.ext
+    fin_cases i <;>
+      · simp only [ι_obj, eqToIso.hom, MonoidalCategoryStruct.leftUnitor,
+          MonoidalCategoryStruct.whiskerRight, MonoidalCategoryStruct.tensorUnit,
+          MultiAR.comp_fT', MultiAR.Hom.concatMap_fT,
+          MultiAR.eqToHom_fT_toFun, eqToHom_map, MultiAR.Hom.id_fT, LabeledTuple.Hom.id_toFun,
+          LabeledTuple.Hom.comp_toFun, LabeledTuple.Hom.concatMap_toFun, Function.comp_apply,
+          Fin.val_cast, Fin.appendMap_val, id_eq,
+          MultiAR.empty, MultiGraph.empty, LabeledTuple.empty_len, toMultiAR_empty_tiers_len]
+        have hx := x.isLt
+        simp only [MonoidalCategoryStruct.tensorObj, MonoidalCategoryStruct.tensorUnit,
+          MultiAR.concat_tiers, LabeledTuple.concat_len, MultiAR.empty, MultiGraph.empty,
+          LabeledTuple.empty_len, Nat.zero_add] at hx
+        split_ifs <;> omega
+  right_unitality X := by
+    apply MultiAR.Hom.ext; funext i; apply LabeledTuple.Hom.ext; funext x; apply Fin.ext
+    fin_cases i <;>
+      · simp only [ι_obj, eqToIso.hom, MonoidalCategoryStruct.rightUnitor,
+          MonoidalCategoryStruct.whiskerLeft, MonoidalCategoryStruct.tensorUnit,
+          MultiAR.comp_fT', MultiAR.Hom.concatMap_fT,
+          MultiAR.eqToHom_fT_toFun, eqToHom_map, MultiAR.Hom.id_fT, LabeledTuple.Hom.id_toFun,
+          LabeledTuple.Hom.comp_toFun, LabeledTuple.Hom.concatMap_toFun, Function.comp_apply,
+          Fin.val_cast, Fin.appendMap_val, id_eq,
+          MultiAR.empty, MultiGraph.empty, LabeledTuple.empty_len]
+        have hx := x.isLt
+        simp only [MonoidalCategoryStruct.tensorObj, MonoidalCategoryStruct.tensorUnit,
+          MultiAR.concat_tiers, LabeledTuple.concat_len, MultiAR.empty, MultiGraph.empty,
+          LabeledTuple.empty_len, Nat.add_zero] at hx
+        split_ifs <;> omega
+
+/-- **The strong monoidal functor** `AR α β ⥤ MultiAR (biTier α β)`. -/
+instance : (ι (α := α) (β := β)).Monoidal := ι.coreMonoidal.toMonoidal
+
+end Autosegmental

--- a/Linglib/Phonology/Autosegmental/MultiAR.lean
+++ b/Linglib/Phonology/Autosegmental/MultiAR.lean
@@ -1,0 +1,228 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.CategoryTheory.EqToHom
+import Mathlib.CategoryTheory.Monoidal.Category
+import Linglib.Core.Data.Fin.Tuple.Basic
+import Linglib.Phonology.Autosegmental.MultiGraph
+
+/-!
+# The multi-tier autosegmental category `MultiAR τ`
+
+`MultiAR τ` is the category of **in-bounds multi-tier autosegmental graphs**: the
+general-arity counterpart of the bipartite `AR α β` (`AR.lean`). An object is a
+`MultiGraph τ` whose links are in bounds; a morphism is a **family of per-tier
+label-preserving position maps** (`fT i : LabeledTuple.Hom (A.tiers i) (B.tiers i)`)
+that preserves association lines.
+
+The monoidal product is morpheme concatenation (`MultiGraph.concat`,
+[jardine-heinz-2015]), built via `MonoidalCategory.ofTensorHom` exactly as `AR`'s
+is — the dependent tiers add only a `funext i` to each coherence proof. The planar
+full monoidal subcategory (Goldsmith's NCC, [goldsmith-1976]) would follow
+`WellFormedAR.lean`'s `IsPlanar.FullSubcategory` pattern.
+
+The bipartite `AR α β` includes into `MultiAR ![α,β]` by a monoidal functor (the
+object coherence is `Inclusion.lean`'s `toMultiGraph_concat`/`toMultiGraph_empty`).
+-/
+
+namespace Autosegmental
+
+open CategoryTheory MonoidalCategory
+
+universe u
+variable {n : ℕ} {τ : Fin n → Type u}
+
+/-- An **in-bounds multi-tier autosegmental graph** — the base object. -/
+structure MultiAR {n : ℕ} (τ : Fin n → Type u) extends MultiGraph τ where
+  inBounds : toMultiGraph.InBounds
+
+namespace MultiAR
+
+/-! ### Morphisms -/
+
+/-- A label- and link-preserving morphism: a family of `LabeledTuple.Hom`s, one per
+    tier, plus link preservation routing each link's endpoints through the maps for
+    its two tiers. -/
+@[ext]
+structure Hom (A B : MultiAR τ) where
+  /-- Per-tier vertex maps. -/
+  fT : (i : Fin n) → LabeledTuple.Hom (A.tiers i) (B.tiers i)
+  /-- Association lines are preserved (per tier-pair). -/
+  links_preserve : ∀ (i j : Fin n) {p q : ℕ} (hp : p < (A.tiers i).len) (hq : q < (A.tiers j).len),
+    (p, q) ∈ A.links i j → (((fT i).toFun ⟨p, hp⟩ : ℕ), ((fT j).toFun ⟨q, hq⟩ : ℕ)) ∈ B.links i j
+
+namespace Hom
+variable {A B C : MultiAR τ}
+
+/-- The identity morphism. -/
+def id (A : MultiAR τ) : Hom A A where
+  fT i := LabeledTuple.Hom.id (A.tiers i)
+  links_preserve _ _ {_ _} _ _ h := h
+
+/-- Composition (per tier). -/
+def comp (f : Hom A B) (g : Hom B C) : Hom A C where
+  fT i := (f.fT i).comp (g.fT i)
+  links_preserve i j {p q} hp hq h := by
+    have hf := f.links_preserve i j hp hq h
+    have hg := g.links_preserve i j ((f.fT i).toFun ⟨_, hp⟩).isLt ((f.fT j).toFun ⟨_, hq⟩).isLt hf
+    simpa [LabeledTuple.Hom.comp] using hg
+
+@[simp] theorem id_fT (A : MultiAR τ) (i : Fin n) :
+    (Hom.id A).fT i = LabeledTuple.Hom.id (A.tiers i) := rfl
+@[simp] theorem comp_fT (f : Hom A B) (g : Hom B C) (i : Fin n) :
+    (f.comp g).fT i = (f.fT i).comp (g.fT i) := rfl
+
+end Hom
+
+instance : CategoryStruct (MultiAR τ) where
+  Hom := Hom
+  id := Hom.id
+  comp f g := f.comp g
+
+instance : Category (MultiAR τ) where
+  id_comp _ := by apply Hom.ext; funext i; rfl
+  comp_id _ := by apply Hom.ext; funext i; rfl
+  assoc _ _ _ := by apply Hom.ext; funext i; rfl
+
+@[simp] theorem id_fT' (A : MultiAR τ) (i : Fin n) :
+    (𝟙 A : Hom A A).fT i = 𝟙 (A.tiers i) := rfl
+@[simp] theorem comp_fT' {A B C : MultiAR τ} (f : A ⟶ B) (g : B ⟶ C) (i : Fin n) :
+    (f ≫ g).fT i = (f.fT i).comp (g.fT i) := rfl
+
+/-! ### Concatenation: the tensor object -/
+
+/-- The monoidal product: tier-wise concatenation, preserving in-bounds. -/
+def concat (A B : MultiAR τ) : MultiAR τ where
+  toMultiGraph := A.toMultiGraph.concat B.toMultiGraph
+  inBounds := MultiGraph.inBounds_concat A.inBounds B.inBounds
+
+@[simp] theorem concat_toMultiGraph (A B : MultiAR τ) :
+    (A.concat B).toMultiGraph = A.toMultiGraph.concat B.toMultiGraph := rfl
+
+@[simp] theorem concat_tiers (A B : MultiAR τ) (i : Fin n) :
+    (A.concat B).tiers i = (A.tiers i).concat (B.tiers i) := rfl
+
+@[simp] theorem concat_links (A B : MultiAR τ) (i j : Fin n) :
+    (A.concat B).links i j =
+      A.links i j ∪ (B.links i j).image
+        (MultiGraph.shiftLink (A.tiers i).len (A.tiers j).len) := rfl
+
+/-- The tensor unit. -/
+def empty : MultiAR τ where
+  toMultiGraph := MultiGraph.empty
+  inBounds := MultiGraph.inBounds_empty
+
+/-- An in-bounds graph is determined by its underlying `MultiGraph`. -/
+theorem ext_toMultiGraph {A B : MultiAR τ} (h : A.toMultiGraph = B.toMultiGraph) : A = B := by
+  cases A; cases B; simp only at h; subst h; rfl
+
+instance instMonoid : Monoid (MultiAR τ) where
+  mul := concat
+  one := empty
+  mul_assoc A B C :=
+    ext_toMultiGraph (MultiGraph.concat_assoc A.toMultiGraph B.toMultiGraph C.toMultiGraph)
+  one_mul A := ext_toMultiGraph (MultiGraph.empty_concat A.toMultiGraph)
+  mul_one A := ext_toMultiGraph (MultiGraph.concat_empty A.toMultiGraph)
+
+@[simp] theorem mul_eq_concat (A B : MultiAR τ) : A * B = A.concat B := rfl
+@[simp] theorem one_eq_empty : (1 : MultiAR τ) = empty := rfl
+
+/-! ### `tensorHom`: the concatenation bifunctor on morphisms -/
+
+namespace Hom
+variable {A A' B B' : MultiAR τ}
+
+/-- `tensorHom`: per-tier `LabeledTuple.Hom.concatMap`. A link on `(i,j)` routes its
+    first endpoint through tier `i`'s map, its second through tier `j`'s map. -/
+def concatMap (f : Hom A A') (g : Hom B B') : Hom (A.concat B) (A'.concat B') where
+  fT i := LabeledTuple.Hom.concatMap (f.fT i) (g.fT i)
+  links_preserve i j {p q} hp hq h := by
+    simp only [concat_links, Finset.mem_union, Finset.mem_image, MultiGraph.shiftLink,
+      Prod.exists, Prod.mk.injEq, LabeledTuple.Hom.concatMap_toFun] at h ⊢
+    rcases h with hA | ⟨a, b, hab, hai, hbj⟩
+    · obtain ⟨hpi, hqj⟩ := A.inBounds i j (p, q) hA
+      left
+      rw [Fin.appendMap_val, dif_pos hpi, Fin.appendMap_val, dif_pos hqj]
+      exact f.links_preserve i j hpi hqj hA
+    · obtain ⟨hau, hbl⟩ := B.inBounds i j (a, b) hab
+      subst hai hbj
+      right
+      refine ⟨((g.fT i).toFun ⟨a, hau⟩ : ℕ), ((g.fT j).toFun ⟨b, hbl⟩ : ℕ),
+        g.links_preserve i j hau hbl hab, ?_, ?_⟩
+      · rw [Fin.appendMap_val, dif_neg (show ¬ (a + (A.tiers i).len) < (A.tiers i).len by omega)]
+        congr 2; apply Fin.ext; simp
+      · rw [Fin.appendMap_val, dif_neg (show ¬ (b + (A.tiers j).len) < (A.tiers j).len by omega)]
+        congr 2; apply Fin.ext; simp
+
+@[simp] theorem concatMap_fT (f : Hom A A') (g : Hom B B') (i : Fin n) :
+    (concatMap f g).fT i = LabeledTuple.Hom.concatMap (f.fT i) (g.fT i) := rfl
+
+theorem concatMap_id (A B : MultiAR τ) :
+    concatMap (Hom.id A) (Hom.id B) = Hom.id (A.concat B) := by
+  apply Hom.ext; funext i
+  simp only [concatMap_fT, id_fT, LabeledTuple.Hom.concatMap_id, concat_tiers]
+
+theorem concatMap_comp {A A' A'' B B' B'' : MultiAR τ}
+    (f : Hom A A') (f' : Hom A' A'') (g : Hom B B') (g' : Hom B' B'') :
+    (concatMap f g).comp (concatMap f' g') = concatMap (f.comp f') (g.comp g') := by
+  apply Hom.ext; funext i
+  simp only [comp_fT, concatMap_fT]
+  exact (LabeledTuple.Hom.concatMap_comp (f.fT i) (f'.fT i) (g.fT i) (g'.fT i)).symm
+
+end Hom
+
+/-! ### `eqToHom` algebra -/
+
+/-- The `i`-th tier map of an `eqToHom`, as a function: a length-cast `Fin.cast`. -/
+@[simp] theorem eqToHom_fT_toFun {A B : MultiAR τ} (h : A = B) (i : Fin n) :
+    ((eqToHom h).fT i).toFun = Fin.cast (congrArg (fun X => (X.tiers i).len) h) := by
+  cases h; rfl
+
+@[simp] theorem concatMap_id_eqToHom {W X Y : MultiAR τ} (h : X = Y) :
+    Hom.concatMap (𝟙 W) (eqToHom h) = eqToHom (congrArg (W.concat ·) h) := by
+  cases h; simp only [eqToHom_refl]; exact Hom.concatMap_id W X
+
+@[simp] theorem concatMap_eqToHom_id {W X Y : MultiAR τ} (h : X = Y) :
+    Hom.concatMap (eqToHom h) (𝟙 W) = eqToHom (congrArg (·.concat W) h) := by
+  cases h; simp only [eqToHom_refl]; exact Hom.concatMap_id X W
+
+/-! ### Monoidal category -/
+
+@[simps] instance instMonoidalStruct : MonoidalCategoryStruct (MultiAR τ) where
+  tensorObj := MultiAR.concat
+  tensorUnit := MultiAR.empty
+  tensorHom f g := Hom.concatMap f g
+  whiskerLeft X _ _ f := Hom.concatMap (Hom.id X) f
+  whiskerRight f Y := Hom.concatMap f (Hom.id Y)
+  associator A B C := eqToIso (mul_assoc A B C)
+  leftUnitor X := eqToIso (one_mul X)
+  rightUnitor X := eqToIso (mul_one X)
+
+instance : MonoidalCategory (MultiAR τ) :=
+  MonoidalCategory.ofTensorHom
+    (id_tensorHom_id := Hom.concatMap_id)
+    (id_tensorHom := fun _ _ _ _ => rfl)
+    (tensorHom_id := fun _ _ => rfl)
+    (tensorHom_comp_tensorHom := fun f₁ f₂ g₁ g₂ => Hom.concatMap_comp f₁ g₁ f₂ g₂)
+    (associator_naturality := by
+      intro X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃
+      apply Hom.ext; funext i; apply LabeledTuple.Hom.ext; funext x; apply Fin.ext
+      simp [Fin.appendMap_val, Nat.sub_sub]
+      split_ifs <;> omega)
+    (leftUnitor_naturality := by
+      intro X Y f
+      apply Hom.ext; funext i; apply LabeledTuple.Hom.ext; funext x; apply Fin.ext
+      simp [Fin.appendMap_val, empty, MultiGraph.empty]
+      rfl)
+    (rightUnitor_naturality := by
+      intro X Y f
+      apply Hom.ext; funext i; apply LabeledTuple.Hom.ext; funext x; apply Fin.ext
+      simp [Fin.appendMap_val, empty, MultiGraph.empty])
+    (pentagon := by intros; simp [eqToHom_trans])
+    (triangle := by intros; simp [eqToHom_trans])
+
+end MultiAR
+
+end Autosegmental

--- a/Linglib/Phonology/Autosegmental/MultiGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MultiGraph.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Finset.Image
+import Mathlib.Data.Fintype.Pi
+import Linglib.Core.CategoryTheory.Monoidal.LabeledTuple
+import Linglib.Phonology.Autosegmental.NonCrossing
+
+/-!
+# Multi-tier autosegmental graphs
+
+`MultiGraph τ` is the autosegmental representation at **general tier arity**:
+`n` heterogeneously-typed ordered **tiers** (`tiers i : LabeledTuple (τ i)`, with
+`τ : Fin n → Type u`) plus, for every ordered tier-pair `(i, j)`, a `Finset (ℕ × ℕ)`
+of association **links** (`links i j`; empty ⇒ the pair does not associate). This is
+[jardine-2017]'s autosegmental phonological graph at arbitrary arity, and the home
+of [lionnet-2022]'s register-tier tone geometry (subtonal-feature tiers + a mora
+tier around a Tonal Root Node hub).
+
+The classical **bipartite** `Graph α β` (`Graph.lean`) is the `n = 2` case. It is a
+*separate first-class structure* (so it keeps `extends`/`.toGraph`/anonymous-
+constructor ergonomics and independent universes); the two are related by the
+**monoidal inclusion functor** rather than a defeq view — see `Inclusion.lean`.
+
+## Design (three-reviewer mathlib panel, 2026-06-24)
+
+* **Heterogeneous tiers** `τ : Fin n → Type u` — per-tier static typing, fiberwise.
+* **Links per ordered tier-pair** `(i j) → Finset (ℕ × ℕ)` — keeps `concat`'s shift
+  fiberwise; the associating topology is `{(i,j) | links i j ≠ ∅}`.
+* **Planarity stays binary, per pair** (`IsPlanar := ∀ i j, IsNonCrossing (links i j)`):
+  the existing `MonovaryOn`-based NCC reused pointwise — no N-ary planarity theory.
+-/
+
+namespace Autosegmental
+
+universe u
+
+/-- A **multi-tier autosegmental graph**: `n` heterogeneously-typed ordered tiers
+    plus a `Finset (ℕ × ℕ)` of association links on each ordered tier-pair. -/
+@[ext]
+structure MultiGraph {n : ℕ} (τ : Fin n → Type u) where
+  /-- The `n` heterogeneously-typed ordered tiers. -/
+  tiers : (i : Fin n) → LabeledTuple (τ i)
+  /-- Association links per ordered tier-pair; empty ⇒ the pair does not associate. -/
+  links : (i j : Fin n) → Finset (ℕ × ℕ)
+
+namespace MultiGraph
+
+variable {n : ℕ} {τ : Fin n → Type u}
+
+instance [∀ i, DecidableEq (τ i)] : DecidableEq (MultiGraph τ) := fun _ _ =>
+  decidable_of_iff _ MultiGraph.ext_iff.symm
+
+/-! ### Well-formedness predicates -/
+
+/-- **Planarity**: every tier-pair's link set is non-crossing — the binary
+    `MonovaryOn` NCC applied pointwise per pair (no N-ary generalization). -/
+def IsPlanar (G : MultiGraph τ) : Prop := ∀ i j, IsNonCrossing (G.links i j)
+
+instance (G : MultiGraph τ) : Decidable G.IsPlanar :=
+  inferInstanceAs (Decidable (∀ _ _, _))
+
+/-- **In-bounds**: every link's endpoints fall within the respective tier lengths. -/
+def InBounds (G : MultiGraph τ) : Prop :=
+  ∀ i j, ∀ p ∈ G.links i j, p.1 < (G.tiers i).len ∧ p.2 < (G.tiers j).len
+
+instance (G : MultiGraph τ) : Decidable G.InBounds :=
+  inferInstanceAs (Decidable (∀ _ _, _))
+
+/-! ### The empty graph -/
+
+/-- The empty multigraph: every tier empty, no links. -/
+def empty : MultiGraph τ where
+  tiers _ := LabeledTuple.empty
+  links _ _ := ∅
+
+@[simp] theorem empty_tiers (i : Fin n) : (empty : MultiGraph τ).tiers i = LabeledTuple.empty := rfl
+@[simp] theorem empty_links (i j : Fin n) : (empty : MultiGraph τ).links i j = ∅ := rfl
+
+theorem isPlanar_empty : (empty : MultiGraph τ).IsPlanar := by
+  intro i j; simp [empty, isNonCrossing_empty]
+
+theorem inBounds_empty : (empty : MultiGraph τ).InBounds := by
+  intro i j p hp; simp at hp
+
+/-! ### Shift algebra -/
+
+/-- Shift a link by `(δ₁, δ₂)`. -/
+def shiftLink (δ₁ δ₂ : ℕ) (p : ℕ × ℕ) : ℕ × ℕ := (p.1 + δ₁, p.2 + δ₂)
+
+@[simp] theorem shiftLink_apply (δ₁ δ₂ : ℕ) (p : ℕ × ℕ) :
+    shiftLink δ₁ δ₂ p = (p.1 + δ₁, p.2 + δ₂) := rfl
+
+@[simp] theorem shiftLink_zero : shiftLink 0 0 = (id : ℕ × ℕ → ℕ × ℕ) := by funext p; simp
+
+theorem shiftLink_comp (a₁ a₂ b₁ b₂ : ℕ) :
+    shiftLink a₁ a₂ ∘ shiftLink b₁ b₂ = shiftLink (a₁ + b₁) (a₂ + b₂) := by
+  funext p; simp only [Function.comp_apply, shiftLink_apply, Prod.mk.injEq]; omega
+
+/-- Shifting a link set preserves non-crossing. -/
+theorem isNonCrossing_image_shiftLink (s : Finset (ℕ × ℕ)) (δ₁ δ₂ : ℕ) :
+    IsNonCrossing (s.image (shiftLink δ₁ δ₂)) ↔ IsNonCrossing s := by
+  grind [IsNonCrossing, Finset.coe_image, monovaryOn_image, MonovaryOn, shiftLink]
+
+/-! ### Concatenation ([jardine-heinz-2015], fiberwise coproduct) -/
+
+/-- Concatenation: tier-wise `LabeledTuple.concat`, and per-pair link union with
+    `B`'s links shifted past `A`'s tier lengths on each coordinate. -/
+def concat (A B : MultiGraph τ) : MultiGraph τ where
+  tiers i := (A.tiers i).concat (B.tiers i)
+  links i j := A.links i j ∪ (B.links i j).image (shiftLink (A.tiers i).len (A.tiers j).len)
+
+@[simp] theorem concat_tiers (A B : MultiGraph τ) (i : Fin n) :
+    (A.concat B).tiers i = (A.tiers i).concat (B.tiers i) := rfl
+
+@[simp] theorem concat_links (A B : MultiGraph τ) (i j : Fin n) :
+    (A.concat B).links i j =
+      A.links i j ∪ (B.links i j).image (shiftLink (A.tiers i).len (A.tiers j).len) := rfl
+
+/-! #### Monoid laws -/
+
+theorem empty_concat (A : MultiGraph τ) : empty.concat A = A := by
+  refine MultiGraph.ext ?_ ?_
+  · funext i; simpa using LabeledTuple.empty_concat (A.tiers i)
+  · funext i j; simp [concat_links, empty, shiftLink_zero]
+
+theorem concat_empty (A : MultiGraph τ) : A.concat empty = A := by
+  refine MultiGraph.ext ?_ ?_
+  · funext i; simpa using LabeledTuple.concat_empty (A.tiers i)
+  · funext i j; simp [concat_links, empty]
+
+theorem concat_assoc (A B C : MultiGraph τ) :
+    (A.concat B).concat C = A.concat (B.concat C) := by
+  refine MultiGraph.ext ?_ ?_
+  · funext i; simp only [concat_tiers, LabeledTuple.concat_assoc]
+  · funext i j
+    simp only [concat_links, concat_tiers, LabeledTuple.concat_len, Finset.image_union,
+      Finset.image_image, shiftLink_comp]
+    rw [Finset.union_assoc]
+
+instance : Monoid (MultiGraph τ) where
+  mul := concat
+  one := empty
+  mul_assoc := concat_assoc
+  one_mul := empty_concat
+  mul_one := concat_empty
+
+/-! #### Predicate preservation -/
+
+/-- Concatenation preserves planarity, given `A.InBounds`. -/
+theorem isPlanar_concat {A B : MultiGraph τ} (hAib : A.InBounds)
+    (hA : A.IsPlanar) (hB : B.IsPlanar) : (A.concat B).IsPlanar := by
+  intro i j
+  have hAij := hA i j; have hBij := hB i j; have hAibij := hAib i j
+  grind [IsPlanar, IsNonCrossing, InBounds, MonovaryOn, concat_links, Finset.coe_union,
+    monovaryOn_union, isNonCrossing_image_shiftLink, shiftLink]
+
+/-- Concatenation preserves in-bounds. -/
+theorem inBounds_concat {A B : MultiGraph τ}
+    (hA : A.InBounds) (hB : B.InBounds) : (A.concat B).InBounds := by
+  intro i j p hp
+  simp only [concat_links, Finset.mem_union, Finset.mem_image, concat_tiers,
+    LabeledTuple.concat_len] at hp ⊢
+  obtain hp | ⟨q, hq, rfl⟩ := hp
+  · have := hA i j p hp; omega
+  · have := hB i j q hq; simp only [shiftLink]; omega
+
+end MultiGraph
+
+end Autosegmental

--- a/Linglib/Studies/Lionnet2022Laal.lean
+++ b/Linglib/Studies/Lionnet2022Laal.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Tone.Basic
 import Linglib.Phonology.OCP
+import Linglib.Phonology.Autosegmental.MultiAR
 import Linglib.Fragments.Laal.Prosody
 
 /-!
@@ -146,5 +147,63 @@ merger face of the same OCP principle whose prohibition (TSL₂) face lives in
 theorem ocp_raised_merge_clean (tier : List TRN) :
     OCP.IsClean (OCP.collapse (tier.map (·.raised))) :=
   OCP.collapse_clean _
+
+/-! ### The register-tier geometry on the multi-tier substrate (§5–§6)
+
+[lionnet-2022]'s geometry (ex. 52) is a hub-and-spoke around the **Tonal Root Node**:
+the `[±upper]` register tier, the `[±raised]` tier, and the mora (TBU) tier each
+associate to the TRN. On the general substrate `Autosegmental.MultiAR` this is a
+four-tier graph. Its point over the `TRN` *bundle* used above: each subtonal feature
+is a tier of its own, so it can be manipulated **independently of the whole TRN** —
+[lionnet-2022]'s *partial activity* (§5, e.g. `[−raised]` assimilation) — which a
+bundled `TRN` record cannot structurally express. Whole-TRN operations (§6) act on
+the TRN↔mora layer; both live on one object. -/
+
+open Autosegmental
+
+/-- The four Laal tone tiers: `[±upper]` register, `[±raised]`, the TRN, the mora. -/
+abbrev laalTier : Fin 4 → Type := ![Option Bool, Option Bool, Unit, Unit]
+
+/-- A one-TRN M-toned form (`M = [−upper, +raised]`, [lionnet-2022] ex. 51): the
+    register `[−upper]` and `[+raised]` features and the single mora each associate to
+    the one TRN. -/
+def mForm : MultiAR laalTier where
+  tiers := Fin.cons (.ofList [some false]) (Fin.cons (.ofList [some true])
+    (Fin.cons (.ofList [()]) (Fin.cons (.ofList [()]) finZeroElim)))
+  links i j := match i, j with
+    | 0, 2 => {(0, 0)}    -- register ↔ TRN
+    | 1, 2 => {(0, 0)}    -- [raised] ↔ TRN
+    | 2, 3 => {(0, 0)}    -- TRN ↔ mora
+    | _, _ => ∅
+  inBounds := by decide
+
+/-- The form is planar — each spoke's single association is non-crossing (per-pair NCC). -/
+theorem mForm_planar : mForm.IsPlanar := by decide
+
+/-- The links of `delinkRaised`: the `[raised]`↔TRN pair `(1,2)` emptied. -/
+private def delinkedLinks (G : MultiAR laalTier) (i j : Fin 4) : Finset (ℕ × ℕ) :=
+  if (i, j) = (1, 2) then ∅ else G.links i j
+
+/-- **Partial activity** (§5): delinking the `[−raised]` feature acts on the
+    `[raised]`↔TRN layer (tier-pair `(1,2)`) alone. -/
+def delinkRaised (G : MultiAR laalTier) : MultiAR laalTier where
+  toMultiGraph := { G.toMultiGraph with links := delinkedLinks G }
+  inBounds := by
+    intro i j p hp
+    simp only [delinkedLinks] at hp
+    split_ifs at hp with h
+    · exact absurd hp (by simp)
+    · exact G.inBounds i j p hp
+
+/-- Delinking the subtonal `[−raised]` feature leaves the **whole-TRN** layer
+    (TRN↔mora, tier-pair `(2,3)`) untouched: partial activity is independent of full
+    activity — the structural content of [lionnet-2022]'s subtonal-feature autonomy,
+    impossible to state on a bundled `TRN`. -/
+theorem partial_indep_of_full (G : MultiAR laalTier) :
+    (delinkRaised G).links 2 3 = G.links 2 3 := by simp [delinkRaised, delinkedLinks]
+
+/-- And it does remove the `[raised]`↔TRN association. -/
+theorem delinkRaised_erases (G : MultiAR laalTier) :
+    (delinkRaised G).links 1 2 = ∅ := by simp [delinkRaised, delinkedLinks]
 
 end Lionnet2022Laal


### PR DESCRIPTION
Generalize the autosegmental representation to arbitrary tier arity and relate it to the bipartite case by a monoidal functor (not a leaky view), grounded in a real consumer.

- `MultiGraph`/`MultiAR`: the general N-tier object + category + `MonoidalCategory` (tensor = concatenation, per-pair binary NCC). The bipartite `Graph`/`AR` and all existing consumers are **untouched** — every piece is additive.
- `ι : AR α β ⥤ MultiAR ![α,β]`: a faithful **strong monoidal functor** (`Functor.CoreMonoidal` → `.Monoidal`; unit/tensor coherences are the object equalities as `eqToIso`). `LabeledTuple.Hom` is now `FunLike`.
- `Studies/Lionnet2022Laal`: the register-tier tone geometry ([lionnet-2022]) on `MultiAR` — a subtonal feature manipulated independently of the whole TRN (partial- vs full-activity on one geometry), which the `TRN` bundle cannot structurally express.