### PR TITLE
feat(Phonology/Autosegmental): correspondence-graph process relations

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1333,6 +1333,7 @@ import Linglib.Studies.DarwichePearl1997
 import Linglib.Studies.Veltman1996
 import Linglib.Studies.Moroney2021
 import Linglib.Studies.Jenks2018
+import Linglib.Studies.Jardine2016
 import Linglib.Studies.DongEtAl2026PMF
 import Linglib.Studies.TsvilodubEtAl2026
 import Linglib.Studies.Anderson2021
@@ -2736,6 +2737,7 @@ import Linglib.Phonology.Autosegmental.Embedding
 import Linglib.Phonology.Autosegmental.MultiGraph
 import Linglib.Phonology.Autosegmental.Inclusion
 import Linglib.Phonology.Autosegmental.MultiAR
+import Linglib.Phonology.Autosegmental.Correspondence
 import Linglib.Phonology.Prosodic.Syllable
 import Linglib.Phonology.Prosodic.Foot
 import Linglib.Phonology.Prosodic.NaturalClass

--- a/Linglib/Phonology/Autosegmental/Correspondence.lean
+++ b/Linglib/Phonology/Autosegmental/Correspondence.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Phonology.Autosegmental.Embedding
+
+/-!
+# Phonological transformations as correspondence-graph relations
+
+[jardine-2016] (Ch. 7) models a phonological *process* not as a function but as a
+**relation** between input and output, presented by a set of **correspondence graphs**
+and carved out of GEN by **banned-subgraph constraints** (markedness + faithfulness) —
+which is what makes the relation *local*.
+
+A string correspondence graph is exactly a bipartite `Graph S T` reinterpreted: the
+upper tier is the input string, the lower tier the output string, and the association
+links are the input↔output **correspondence arcs**. (Precedence is carried by the tier
+order; Jardine's separate precedence/correspondence arc-labeling `ℓ_A` is here the
+structural split between tier-order and links.) The banned-subgraph grammar is
+`Graph.Free` ([jardine-2016] Ch. 5's `L^NL_G`).
+
+This is the *process* layer of the substrate's three-layer spec (objects `AR`,
+precedence-morphisms `PrecAR`, processes here). The autosegmental case — correspondence
+between multi-tier APGs — extends it over `MultiGraph`.
+
+## Scope note
+
+`SubgraphEmbeds` matches contiguous blocks of *both* tiers plus links, so it expresses
+**correspondence** (input↔output) banned subgraphs directly. Jardine's *output-only*
+markedness constraints (e.g. forbid an output `apa` regardless of input) need the
+arc-labelled-subgraph refinement he flags in Ch. 7 fn. 7; that is deferred.
+
+## Main definitions
+
+* `Correspondence.input`/`output` — the two strings a correspondence graph relates.
+* `Correspondence.rel` — `R(CG)`, the string relation of a set of correspondence graphs
+  ([jardine-2016] Def. 25).
+* `Correspondence.specifiedBy` — `CG(φ)`, a process presented by a banned-subgraph grammar.
+* `Correspondence.IsLocal` — a relation presented by a finite banned-subgraph grammar.
+-/
+
+namespace Autosegmental
+namespace Correspondence
+
+variable {S T : Type*}
+
+/-- The **input** string of a correspondence graph: its upper tier. -/
+def input (G : Graph S T) : List S := G.upper.toList
+
+/-- The **output** string of a correspondence graph: its lower tier. -/
+def output (G : Graph S T) : List T := G.lower.toList
+
+/-- **R(CG)** ([jardine-2016] Def. 25): the string relation realized by a set `CG` of
+    correspondence graphs — the input/output pairs of its members. -/
+def rel (CG : Graph S T → Prop) (w : List S) (v : List T) : Prop :=
+  ∃ G, CG G ∧ input G = w ∧ output G = v
+
+/-- `R` is monotone: more correspondence graphs realize a larger relation. -/
+theorem rel_mono {CG CG' : Graph S T → Prop} (h : ∀ G, CG G → CG' G) {w v} :
+    rel CG w v → rel CG' w v := by
+  rintro ⟨G, hG, hi, ho⟩; exact ⟨G, h G hG, hi, ho⟩
+
+/-- A process **specified by banned subgraphs** `φ`: the correspondence graphs free of
+    every forbidden pattern (Jardine's `CG(φ)`; reuses `Graph.Free`, the `L^NL_G`
+    banned-subgraph grammar — markedness and faithfulness as forbidden correspondence
+    substructures). -/
+def specifiedBy (φ : List (Graph S T)) (G : Graph S T) : Prop := G.Free φ
+
+instance [DecidableEq S] [DecidableEq T] (φ : List (Graph S T)) (G : Graph S T) :
+    Decidable (specifiedBy φ G) := inferInstanceAs (Decidable (G.Free φ))
+
+/-- A string relation is **local** when presented by a finite banned-subgraph grammar
+    over correspondence graphs — the locality of phonological processes [jardine-2016]. -/
+def IsLocal (R : List S → List T → Prop) : Prop :=
+  ∃ φ : List (Graph S T), R = rel (specifiedBy φ)
+
+/-- Banned-subgraph grammars **compose by union**: `CG(φ ++ ψ) = CG(φ) ∩ CG(ψ)` — the
+    `L^NL_G` conjunction of two local constraint sets. -/
+theorem specifiedBy_append (φ ψ : List (Graph S T)) (G : Graph S T) :
+    specifiedBy (φ ++ ψ) G ↔ specifiedBy φ G ∧ specifiedBy ψ G := by
+  simp only [specifiedBy, Graph.Free, List.forall_mem_append]
+
+/-- The empty grammar specifies all of GEN. -/
+@[simp] theorem specifiedBy_nil (G : Graph S T) : specifiedBy [] G ↔ True := by
+  simp [specifiedBy, Graph.Free]
+
+end Correspondence
+end Autosegmental

--- a/Linglib/Studies/Jardine2016.lean
+++ b/Linglib/Studies/Jardine2016.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Phonology.Autosegmental.Correspondence
+
+/-!
+# Jardine (2016): transformations as correspondence-graph relations
+
+[jardine-2016] (Ch. 7) presents a phonological process as a **relation** between input
+and output, given by correspondence graphs carved out of GEN by banned-subgraph
+constraints. This file exercises the `Autosegmental.Correspondence` substrate on the
+intervocalic-voicing schema (Jardine's running example): a faithfulness constraint
+`*[p↔p]` — forbidding a `p` that corresponds to a `p` — admits the voicing
+correspondence `apa ↔ aba` and rejects the faithful `apa ↔ apa`.
+
+## Scope
+
+This demonstrates the constraint mechanism at the correspondence-graph level. The full
+relation-level result `R(CG(φ)) = R_voice` additionally requires GEN (`CG(Γ)`, the
+correspondence graphs built from primitives), which fixes the correspondence structure;
+and Jardine's *output-only* markedness `*VTV` needs the arc-labelled-subgraph refinement
+(Ch. 7 fn. 7). Both are deferred — see `Autosegmental/Correspondence.lean`.
+-/
+
+namespace Jardine2016
+
+open Autosegmental Correspondence
+
+/-- Toy alphabet for intervocalic voicing: a vowel `a`, voiceless `p`, voiced `b`. -/
+inductive Seg | a | p | b
+  deriving DecidableEq, Repr
+
+/-- A correspondence graph over the one alphabet (input and output both `Seg`). -/
+abbrev CGraph := Graph Seg Seg
+
+/-- The faithfulness banned subgraph `*[pⁱ↔p]`: a `p` corresponding to a `p`. Forbidding
+    it forces an intervocalic `p` to change. -/
+def noPP : CGraph := ⟨.ofList [Seg.p], .ofList [Seg.p], {(0, 0)}⟩
+
+/-- The voicing correspondence `apa ↔ aba`: identity positions, the medial `p`
+    corresponding to a `b`. -/
+def gVoice : CGraph :=
+  ⟨.ofList [Seg.a, .p, .a], .ofList [Seg.a, .b, .a], {(0, 0), (1, 1), (2, 2)}⟩
+
+/-- The faithful correspondence `apa ↔ apa`: the medial `p` stays `p`. -/
+def gFaithful : CGraph :=
+  ⟨.ofList [Seg.a, .p, .a], .ofList [Seg.a, .p, .a], {(0, 0), (1, 1), (2, 2)}⟩
+
+/-- `gVoice` reads input `apa`, output `aba`. -/
+theorem gVoice_io : input gVoice = [Seg.a, .p, .a] ∧ output gVoice = [Seg.a, .b, .a] := by
+  decide
+
+/-- The voicing correspondence is **admitted** by the `*[p↔p]` grammar (no `p↔p`). -/
+theorem gVoice_specified : specifiedBy [noPP] gVoice := by decide
+
+/-- The faithful correspondence is **rejected** — it contains a `p↔p`. -/
+theorem gFaithful_rejected : ¬ specifiedBy [noPP] gFaithful := by decide
+
+/-- Hence `apa ↔ aba` lies in the relation presented by the local grammar `*[p↔p]`,
+    witnessed by `gVoice` ([jardine-2016] Def. 25). -/
+theorem voicing_local : rel (specifiedBy [noPP]) [Seg.a, .p, .a] [Seg.a, .b, .a] :=
+  ⟨gVoice, gVoice_specified, by decide, by decide⟩
+
+end Jardine2016


### PR DESCRIPTION
Add the **process** layer of the autosegmental substrate: a phonological transformation as a relation presented by banned-subgraph constraints over correspondence graphs ([jardine-2016] Ch. 7).

- `Correspondence.lean`: a string correspondence graph is a bipartite `Graph S T` (upper = input, lower = output, links = input↔output correspondence arcs). `rel` (`R(CG)`, Def. 25), `specifiedBy` (`CG(φ)`, reusing `Graph.Free` = the `L^NL_G` banned-subgraph grammar), `IsLocal`, and `specifiedBy_append` (grammars compose by union).
- `Studies/Jardine2016.lean`: the intervocalic-voicing schema — the faithfulness constraint `*[p↔p]` admits the voicing correspondence `apa ↔ aba` and rejects the faithful `apa ↔ apa` (`decide`-checked).
- Reuses `Graph`/`Embedding` only (independent of the multi-tier substrate). The relation-level `R(CG(Γ,φ)) = R_voice` (needs GEN) and output-only markedness (needs arc-labelled subgraphs, Jardine fn. 7) are noted as deferred.