### PR TITLE
refactor(Phonology): tighten ElementTheory docstrings and golf proofs

### DIFF
--- a/Linglib/Phonology/ElementTheory.lean
+++ b/Linglib/Phonology/ElementTheory.lean
@@ -8,86 +8,40 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Order.Basic
 
 /-!
-# Element Theory: the Backley-six elements and Breit's melodic representations
-[backley-2011] [backley-2017] [breit-2013] [kaye-lowenstamm-vergnaud-1985]
-[harris-1994]
+# Element Theory
 
-Element Theory (ET) builds segments from a small set of **privative** primes
-called *elements*. This file formalises the **Standard ET** of [backley-2011]
-and [breit-2013], with the deep structure of [backley-2017], as one layered
-substrate that subsumes three otherwise-divergent strands of ET.
+Standard Element Theory ([backley-2011], [breit-2013]): segments built from six
+**privative** elements |A I U ʔ H L|, each a `Fundamental × Polarity` pairing
+[backley-2017]. A *melodic representation* (`MR`) is a `Finset Element` with an
+optional head (the Single Optional Headedness Condition); a `Segment` carries one
+`MR` per subsegmental node (manner / place / laryngeal), so one element may dock
+at different nodes in different segments [cavirani-vandenwyngaerd-2026].
 
-## The three layers
+## Main definitions
 
-1. **Elements** as a `Fundamental × Polarity` grid [backley-2017]. The six
-   elements |A I U ʔ H L| are exactly the pairing of three *fundamentals*
-   (colour, resonance, frequency) with two *polar values* (dark, light).
-   Antagonistic pairs and the dark/light split are *derived* from the grid,
-   not stipulated.
+* `Element`, `Fundamental`, `Polarity` — the six elements as a 3×2 grid;
+  `Antagonistic` — two elements sharing a fundamental (the marked combinations).
+* `MR` — a melodic representation, with `dock`/`compose`/`decompose` and the
+  refinement order `Refines`.
+* `Segment` — a node-structured `MR`, with `Refines`, `NoAntagonisticHeads`
+  (Backley's at-most-one-head-per-fundamental), and node-hosting `WellFormed`.
 
-2. **Melodic representations** (`MR`) as [breit-2013]'s set-theoretic objects:
-   a numeration `Finset Element` plus an optional head obeying the **Single
-   Optional Headedness Condition** (SOHC). A faithful Standard-ET segment, with
-   `head`/`ops`, set-merge constructors, compose/decompose, and an elemental
-   refinement order.
+## Implementation notes
 
-3. **Segments** as node-structured MRs (`Segment`): one MR per subsegmental
-   node (manner / place / laryngeal). This *generalises* (1)-(2):
-
-   * a single-node segment is a flat Standard-ET MR [breit-2013];
-   * per-node SOHC (each node's MR has ≤1 head, Breit's choice) bounds heads at
-     one *per node*; Backley's own headedness theory — multiple heads, but at
-     most one *per fundamental* ([backley-2011] §5.3.4, [backley-2017]) — is
-     carried separately as the `Segment.NoAntagonisticHeads` predicate;
-   * the *same* element may dock at different nodes in different segments
-     (|A| in the manner node of /r/ vs the place node of /s/), the contrastive
-     geometry of [cavirani-vandenwyngaerd-2026], which goes beyond Breit's
-     universal element-partition geometry.
-
-## Relation to the rest of the library
-
-The privative-element-with-headedness shape is the multiple-heads variant
-([backley-2011] §5.3.4, [backley-2017]) of a per-node MR, and corresponds to a
-`FeatureBundle Element Headedness` over `Phonology/Featural/Bundle.lean`; here
-we follow Breit's SOHC model instead, so headedness is *positional* (the `head`
-field) rather than a per-element value. The |H| and |L| primes are the coarse
-Backley tone primes (among many other roles [backley-2017]); the finer
-register-tier theory of tone lives in `Phonology/Tone`.
-
-## Inventory: Standard ET
-
-The six elements are those of **Standard ET** [backley-2011] [backley-2012] —
-the version Backley argues strikes the best balance between expressiveness and
-restrictiveness. Standard ET's distinctive move is to use *shared* elements
-where Conservative ET splits them, so the substrate inherits these commitments:
-
-* |L| carries nasality, obstruent voicing, *and* low tone (Conservative ET
-  splits nasality off as a separate |N|);
-* |U| carries both labial and velar resonance (Conservative ET splits velars
-  off as the neutral element |@|);
-* |H| carries frication, voicelessness, *and* high tone (older inventories add a
-  separate noise element |h| — hence the `noise`-to-`H` migration here);
-* ATR is derived from element compounds (Conservative ET posits a dedicated |Ɨ|).
-
-Conservative ET (more elements: |N| |@| |Ɨ| |R|) and Progressive ET (fewer —
-elements replaced by inter-element licensing structure) are documented
-alternatives [backley-2012]; the substrate does not implement them, but a
-`Studies/` file analysing a Con.ET or Prog.ET account would extend `Element`
-rather than reuse it.
+Headedness is positional (the `head` field), following Breit's SOHC rather than
+the multiple-heads variant of [backley-2017]. The inventory is Standard ET's, not
+Conservative or Progressive ET ([backley-2012]): elements are shared — |L| for
+nasality/voicing/low tone, |U| for labials/velars, |H| for
+frication/voicelessness/high tone.
 -/
 
 namespace ElementTheory
 
--- ============================================================================
--- § 1: Fundamentals, polarity, and the six elements
--- ============================================================================
+/-! ### Fundamentals, polarity, and the six elements -/
 
-/-- The three **fundamentals** of spoken language [backley-2017]: the polar
-    dimensions along which the six elements are organised. Van der Hulst's
-    Radical CV Phonology identifies them with the subsegmental nodes place /
-    manner / laryngeal, but a fundamental is *intrinsic* to an element, whereas
-    the `Node` an element
-    docks at (§4) is *contrastive*. -/
+/-- The three **fundamentals** of spoken language [backley-2017] organising the
+    six elements. A fundamental is *intrinsic* to an element, unlike the `Node`
+    it docks at, which is *contrastive*. -/
 inductive Fundamental
   /-- Colour: |U| (dark) vs |I| (light). Place properties in C and V. -/
   | colour
@@ -97,18 +51,15 @@ inductive Fundamental
   | frequency
   deriving DecidableEq, Repr
 
-/-- The two **polar values** of every fundamental [backley-2017]: dark elements
-    concentrate acoustic energy at low frequencies, light elements at
-    high/dispersed frequencies. -/
+/-- The two polar values of a fundamental [backley-2017]: dark (low frequency)
+    vs light (high). -/
 inductive Polarity
   | dark
   | light
   deriving DecidableEq, Repr
 
-/-- The six elements of Standard Element Theory [backley-2011] [breit-2013]: the
-    privative melodic primes. Named for their conventional symbols |A I U ʔ H L|.
-    `glottal` is |ʔ| (the occlusion / "edge" element; its glyph is not a valid
-    Lean identifier). -/
+/-- The six privative elements |A I U ʔ H L| of Standard ET [backley-2011]
+    [breit-2013]; `glottal` is |ʔ| (its glyph is not a Lean identifier). -/
 inductive Element
   /-- |A| — resonance, dark. Aperture; high F1. -/
   | A
@@ -158,9 +109,8 @@ def Element.IsDark (e : Element) : Prop := e.polarity = .dark
 instance : DecidablePred Element.IsDark :=
   fun e => inferInstanceAs (Decidable (e.polarity = .dark))
 
-/-- Two distinct elements form an **antagonistic pair** [backley-2011]
-    [backley-2017] iff they share a fundamental (hence opposite polarity):
-    |U|+|I|, |A|+|ʔ|, |L|+|H|. These are the marked element combinations (front
+/-- Two distinct elements are **antagonistic** [backley-2011] iff they share a
+    fundamental: |U|+|I|, |A|+|ʔ|, |L|+|H| — the marked combinations (front
     rounded vowels, uvular stops, voiced aspirates). -/
 def Antagonistic (e₁ e₂ : Element) : Prop :=
   e₁ ≠ e₂ ∧ e₁.fundamental = e₂.fundamental
@@ -178,20 +128,10 @@ example : Antagonistic .L .H := by decide
 example : ¬ Antagonistic .U .A := by decide   -- different fundamentals
 example : ¬ Antagonistic .A .A := by decide   -- not distinct
 
--- ============================================================================
--- § 2: Melodic representations (Breit's set-theoretic segment)
--- ============================================================================
+/-! ### Melodic representations -/
 
-/-- A **melodic representation** (MR) [breit-2013]: the set-theoretic object of
-    Standard Element Theory. An MR is a *numeration* `elements` together with an
-    *optional head* drawn from that numeration. The **Single Optional Headedness
-    Condition** (SOHC) — at most one head — is built in by `Option`; `head_mem`
-    enforces `head ⊆ elements`. MRs are **achiral** (distinguished solely by
-    elements + head), which is exactly structure equality here.
-
-    Breit encodes this as nested sets `{H, C}` with `H ⊆ C`, `|H| ≤ 1`; this
-    structure carries the same data with `head : Option Element` for the head
-    position `H` and `elements : Finset Element` for the complement position `C`. -/
+/-- A **melodic representation** [breit-2013]: a numeration `elements` with an
+    optional `head` ⊆ `elements` (the Single Optional Headedness Condition). -/
 @[ext]
 structure MR where
   /-- The numeration — Breit's complement-position `C`: every element present. -/
@@ -204,17 +144,19 @@ structure MR where
 
 namespace MR
 
+variable (m : MR) (e : Element)
+
 /-! ### Set-merge constructors [breit-2013] -/
 
 /-- The empty MR | | [breit-2013]: the empty representation (usually [ə]). -/
 def empty : MR := ⟨∅, none, by simp⟩
 
 /-- The **unheaded simplex** |e|: a single bare element. -/
-def simplex (e : Element) : MR := ⟨{e}, none, by simp⟩
+def simplex : MR := ⟨{e}, none, by simp⟩
 
 /-- The **headed simplex** (singleton) |e̲|: a single element that is also the
     head [breit-2013]. -/
-def headedSimplex (e : Element) : MR := ⟨{e}, some e, by simp⟩
+def headedSimplex : MR := ⟨{e}, some e, by simp⟩
 
 /-- |h̲ op|: a head `h` with one operator `op` [breit-2013]. -/
 def headPlusOp (h op : Element) : MR := ⟨{h, op}, some h, by simp⟩
@@ -226,60 +168,52 @@ def numeration (es : Finset Element) : MR := ⟨es, none, by simp⟩
 /-! ### Head, complement, operators -/
 
 /-- `e` is present in the MR (head or operator): Breit's complement membership. -/
-def HasElement (m : MR) (e : Element) : Prop := e ∈ m.elements
+def HasElement : Prop := e ∈ m.elements
 
-instance (m : MR) (e : Element) : Decidable (m.HasElement e) :=
+instance : Decidable (m.HasElement e) :=
   inferInstanceAs (Decidable (e ∈ m.elements))
 
 /-- `e` is the head of the MR. -/
-def IsHead (m : MR) (e : Element) : Prop := m.head = some e
+def IsHead : Prop := m.head = some e
 
-instance (m : MR) (e : Element) : Decidable (m.IsHead e) :=
+instance : Decidable (m.IsHead e) :=
   inferInstanceAs (Decidable (m.head = some e))
 
 /-- The MR has a head. -/
-def IsHeaded (m : MR) : Prop := m.head.isSome
+def IsHeaded : Prop := m.head.isSome
 
 /-- The **operators** (dependents) [breit-2013] [kaye-lowenstamm-vergnaud-1985]:
     all elements except the head. -/
-def ops (m : MR) : Finset Element :=
+def ops : Finset Element :=
   match m.head with
   | none => m.elements
   | some h => m.elements.erase h
 
 /-! ### Basic theorems -/
 
-@[simp] theorem headedSimplex_isHead (e : Element) :
-    (headedSimplex e).IsHead e := rfl
+@[simp] theorem headedSimplex_isHead : (headedSimplex e).IsHead e := rfl
 
-@[simp] theorem simplex_hasElement (e : Element) :
-    (simplex e).HasElement e := by simp [simplex, HasElement]
+@[simp] theorem simplex_hasElement : (simplex e).HasElement e :=
+  Finset.mem_singleton_self e
 
-theorem simplex_not_headed (e : Element) : ¬ (simplex e).IsHeaded := by
-  simp [simplex, IsHeaded]
+theorem simplex_not_headed : ¬ (simplex e).IsHeaded := by simp [simplex, IsHeaded]
 
 theorem empty_not_headed : ¬ empty.IsHeaded := by simp [empty, IsHeaded]
 
-/-- Every element has a headed simplex |e̲| — Breit's existence theorem for
-    singletons, here by construction. -/
-theorem exists_headedSimplex (e : Element) : ∃ m : MR, m.IsHead e :=
-  ⟨headedSimplex e, rfl⟩
+/-- Every element has a headed simplex |e̲| [breit-2013]. -/
+theorem exists_headedSimplex : ∃ m : MR, m.IsHead e := ⟨headedSimplex e, rfl⟩
 
-/-! ### Compose and decompose [breit-2013]
-
-The four element-level operations on MRs: add/remove an element from the
-complement (`compose`/`decompose`), or set/clear the head (`headCompose`/
-`headDecompose`). -/
+/-! ### Compose and decompose [breit-2013] -/
 
 /-- Add element `e` as an operator (Breit's complement-composition). -/
-def compose (m : MR) (e : Element) : MR where
+def compose : MR where
   elements := insert e m.elements
   head := m.head
   head_mem := fun x hx => Finset.mem_insert_of_mem (m.head_mem x hx)
 
 /-- Remove element `e`, demoting it from head if necessary (Breit's
     complement-decomposition). -/
-def decompose (m : MR) (e : Element) : MR where
+def decompose : MR where
   elements := m.elements.erase e
   head := if m.head = some e then none else m.head
   head_mem := by
@@ -292,7 +226,7 @@ def decompose (m : MR) (e : Element) : MR where
       exact h hx
 
 /-- Promote `e` to head, adding it if absent (Breit's head-composition). -/
-def headCompose (m : MR) (e : Element) : MR where
+def headCompose : MR where
   elements := insert e m.elements
   head := some e
   head_mem := by
@@ -302,13 +236,10 @@ def headCompose (m : MR) (e : Element) : MR where
     exact Finset.mem_insert_self _ _
 
 /-- Remove the head, leaving the elements bare (Breit's head-decomposition). -/
-def headDecompose (m : MR) : MR := ⟨m.elements, none, by simp⟩
+def headDecompose : MR := ⟨m.elements, none, by simp⟩
 
-/-- **Dock** a floating MR onto a host (floating-element association): union the
-    elements; the floater's head, if any, overrides (a floating headed element
-    heads the result). This is *not* the order's join — head-override is
-    non-monotone when the two heads differ — so it is its own operation. Drives
-    palatalisation and spreading analyses. -/
+/-- Union `host` and `floater`, the floater's head overriding (floating-element
+    association; not the order-join, as head-override is non-monotone). -/
 def dock (host floater : MR) : MR where
   elements := host.elements ∪ floater.elements
   head := match floater.head with
@@ -321,31 +252,26 @@ def dock (host floater : MR) : MR where
     · left; rw [hh] at he; exact host.head_mem e he
     · right; apply floater.head_mem; rw [hh] at he ⊢; exact he
 
-/-- An MR is **antagonism-free** if no two co-present elements form an
-    antagonistic pair ([backley-2011] §5.3.1): the element-level analogue of
-    `Segment.NoAntagonisticHeads` (which bounds *heads*; this bounds co-present
-    *operators*). A node hosting an antagonistic pair such as |U I| is marked,
-    and in many languages ill-formed. -/
-def AntagonismFree (m : MR) : Prop :=
+/-- No two co-present elements are antagonistic [backley-2011] — the element-level
+    analogue of `Segment.NoAntagonisticHeads` (e.g. a place node cannot host
+    both |U| and |I|). -/
+def AntagonismFree : Prop :=
   ∀ e₁ ∈ m.elements, ∀ e₂ ∈ m.elements, ¬ Antagonistic e₁ e₂
 
-instance (m : MR) : Decidable (AntagonismFree m) := by
+instance : Decidable (AntagonismFree m) := by
   unfold AntagonismFree; infer_instance
 
-/-! ### Elemental refinement order
+/-! ### Elemental refinement order -/
 
-`m₁ ⊑ m₂` — `m₂` is at least as complex: it has all of `m₁`'s elements, and
-preserves `m₁`'s head if any. The three Czech palatalisers
-[cavirani-vandenwyngaerd-2026] form a chain in this order. -/
-
-/-- `m₁` refines to `m₂`: more elements, head preserved if present. -/
+/-- `m₁` refines to `m₂`: more elements, head preserved if present
+    [cavirani-vandenwyngaerd-2026]. -/
 def Refines (m₁ m₂ : MR) : Prop :=
   m₁.elements ⊆ m₂.elements ∧ (m₁.head = none ∨ m₁.head = m₂.head)
 
 instance (m₁ m₂ : MR) : Decidable (Refines m₁ m₂) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
-theorem Refines.refl (m : MR) : Refines m m := ⟨Finset.Subset.refl _, Or.inr rfl⟩
+theorem Refines.refl : Refines m m := ⟨Finset.Subset.refl _, Or.inr rfl⟩
 
 theorem Refines.trans {a b c : MR} (hab : Refines a b) (hbc : Refines b c) :
     Refines a c := by
@@ -376,34 +302,22 @@ instance (m₁ m₂ : MR) : Decidable (m₁ ≤ m₂) :=
 
 example : (simplex .I) ≤ (headPlusOp .H .I) := by decide
 
--- ============================================================================
--- § 3: The subsegmental geometry — nodes
--- ============================================================================
-
 end MR
 
-/-- The three subsegmental **nodes** of the Element-Theory geometry
-    [harris-1994] [breit-2013] (consonant structure): the manner, place, and
-    laryngeal nodes dominated by the root node. Unlike a `Fundamental`, a node
-    is a *docking site* — the same element may sit at different nodes in
-    different segments (|A| in the manner node of /r/ vs the place node of /s/,
-    [cavirani-vandenwyngaerd-2026]). -/
+/-! ### Nodes: the subsegmental geometry -/
+
+/-- The three subsegmental nodes [harris-1994] [breit-2013]: a *docking site*
+    (contrastive, unlike a `Fundamental`) [cavirani-vandenwyngaerd-2026]. -/
 inductive Node
   | manner
   | place
   | laryngeal
   deriving DecidableEq, Repr
 
--- ============================================================================
--- § 4: Segments — node-structured melodic representations
--- ============================================================================
+/-! ### Segments: node-structured melodic representations -/
 
-/-- A **segment**: the node-structured melodic representation. Each node carries
-    its own `MR` (per-node SOHC), so a segment has up to three heads — one per
-    node. Backley's own headedness constraint (multiple heads, but at most one
-    per fundamental; [backley-2011] §5.3.4) is `NoAntagonisticHeads` below. A
-    single-node segment is a Standard-ET MR [breit-2013]; the same element may
-    sit at different nodes [cavirani-vandenwyngaerd-2026]. -/
+/-- A **segment**: one `MR` per node (per-node SOHC), so up to three heads — one
+    per node [cavirani-vandenwyngaerd-2026]. -/
 @[ext]
 structure Segment where
   manner : MR
@@ -413,81 +327,71 @@ structure Segment where
 
 namespace Segment
 
+variable (s : Segment)
+
 /-- The MR at a given node. -/
-def atNode (s : Segment) : Node → MR
+def atNode : Node → MR
   | .manner => s.manner
   | .place => s.place
   | .laryngeal => s.laryngeal
 
 /-- All elements across all nodes. -/
-def allElements (s : Segment) : Finset Element :=
+def allElements : Finset Element :=
   s.manner.elements ∪ s.place.elements ∪ s.laryngeal.elements
 
 /-- The number of headed nodes (0–3): a segment's total head count. -/
-def headCount (s : Segment) : ℕ :=
+def headCount : ℕ :=
   (if s.manner.head.isSome then 1 else 0)
     + (if s.place.head.isSome then 1 else 0)
     + (if s.laryngeal.head.isSome then 1 else 0)
 
-/-- A segment has at most three heads — one per node (each node is per-node
-    SOHC). Backley's stronger ≤1-head-*per-fundamental* bound is
-    `NoAntagonisticHeads`. -/
-theorem headCount_le_three (s : Segment) : s.headCount ≤ 3 := by
+/-- At most three heads — one per node. -/
+theorem headCount_le_three : s.headCount ≤ 3 := by
   unfold headCount; split_ifs <;> omega
 
 /-- The headed elements across all nodes (0–3 of them). -/
-def headList (s : Segment) : List Element :=
+def headList : List Element :=
   [s.manner.head, s.place.head, s.laryngeal.head].filterMap id
 
-/-- **Backley's headedness constraint** [backley-2011] §5.3.4: an
-    expression may have several heads, but no two headed elements may come from
-    the same antagonistic pair (`*|A̲ʔ̲|`, `*|L̲H̲|`, `*|I̲U̲|`). Heads from
-    *different* fundamentals are fine (`[pʼ] = |U̲ H ʔ̲|`, `[ʃ] = |I̲ H̲|`), so a
-    well-formed segment has at most one head per fundamental — [backley-2017]'s
-    "up to three heads, one per fundamental". -/
-def NoAntagonisticHeads (s : Segment) : Prop :=
+/-- **Backley's headedness constraint** [backley-2011]: no two heads are
+    antagonistic, i.e. at most one head per fundamental [backley-2017]. -/
+def NoAntagonisticHeads : Prop :=
   ∀ e₁ ∈ s.headList, ∀ e₂ ∈ s.headList, ¬ Antagonistic e₁ e₂
 
-instance (s : Segment) : Decidable (NoAntagonisticHeads s) :=
-  inferInstanceAs (Decidable (∀ _ ∈ _, ∀ _ ∈ _, _))
+instance : Decidable (NoAntagonisticHeads s) := by
+  unfold NoAntagonisticHeads; infer_instance
 
-/-- Heads from different fundamentals are licit ([pʼ]-style |U̲ … ʔ̲| would be,
-    here |A̲| manner + |I̲| place — resonance vs colour). -/
+/-- Heads from different fundamentals (|A̲| manner, |I̲| place) are licit. -/
 example : NoAntagonisticHeads ⟨MR.headedSimplex .A, MR.headedSimplex .I, .empty⟩ := by
   decide
 
-/-- Two heads from the same antagonistic pair are illicit (|A̲| and |ʔ̲| both
-    head the resonance fundamental — `*|A̲ʔ̲|`). -/
+/-- Two heads from one antagonistic pair (|A̲|, |ʔ̲|) are illicit. -/
 example : ¬ NoAntagonisticHeads ⟨MR.headedSimplex .glottal, MR.headedSimplex .A, .empty⟩ := by
   decide
 
-/-- Embed a Standard-ET MR at a single node (the others empty): the single-node
-    segment recovers [breit-2013]'s flat melodic representation. -/
+/-- Embed an `MR` at a single node (others empty); recovers a flat ET MR
+    [breit-2013]. -/
 def ofMR (m : MR) : Node → Segment
   | .manner => ⟨m, .empty, .empty⟩
   | .place => ⟨.empty, m, .empty⟩
   | .laryngeal => ⟨.empty, .empty, m⟩
 
-/-- Dock a floating segment onto a host, node by node (`MR.dock` lifted across
-    the three nodes). -/
+/-- `MR.dock` lifted node-by-node. -/
 def dock (host floater : Segment) : Segment :=
   ⟨host.manner.dock floater.manner, host.place.dock floater.place,
    host.laryngeal.dock floater.laryngeal⟩
 
-/-- **Node-hosting well-formedness** [harris-1994] [breit-2013] (the consensus
-    consonant geometry), [cavirani-vandenwyngaerd-2026] (eq. 6): the place node
-    hosts only |I U A|,
-    the laryngeal node only |L H|, the manner node only |ʔ H L A|. -/
-def WellFormed (s : Segment) : Prop :=
+/-- Node-hosting well-formedness [harris-1994] [cavirani-vandenwyngaerd-2026]:
+    place hosts |I U A|, laryngeal |L H|, manner |ʔ H L A|. -/
+def WellFormed : Prop :=
   (∀ e ∈ s.place.elements, e = .I ∨ e = .U ∨ e = .A) ∧
   (∀ e ∈ s.laryngeal.elements, e = .L ∨ e = .H) ∧
   (∀ e ∈ s.manner.elements, e = .glottal ∨ e = .H ∨ e = .L ∨ e = .A)
 
-instance (s : Segment) : Decidable (WellFormed s) :=
+instance : Decidable (WellFormed s) :=
   inferInstanceAs (Decidable (_ ∧ _ ∧ _))
 
-/-- **Segment refinement**: pointwise MR-refinement across all three nodes. The
-    Czech palatalisers PAL₁ ⊑ PAL₂ ⊑ PAL₃ form a chain in this order
+/-- Pointwise MR-refinement across nodes; the palatalisers form a chain
     [cavirani-vandenwyngaerd-2026]. -/
 def Refines (s₁ s₂ : Segment) : Prop :=
   s₁.manner ≤ s₂.manner ∧ s₁.place ≤ s₂.place ∧ s₁.laryngeal ≤ s₂.laryngeal

--- a/Linglib/Studies/CaviraniVandenWyngaerd2026.lean
+++ b/Linglib/Studies/CaviraniVandenWyngaerd2026.lean
@@ -6,80 +6,41 @@ Authors: Robert Hawkins
 import Linglib.Phonology.ElementTheory
 
 /-!
-# Cavirani & Vanden Wyngaerd (2026): A representational analysis of Czech palatalisation
+# Cavirani & Vanden Wyngaerd (2026): Czech palatalisation
 [cavirani-vandenwyngaerd-2026]
 
-Czech has three patterns of palatalisation, each triggered by a different set of
-suffixes. The paper's central claim is that the trigger is **not** the front
-vowel of the suffix but a set of **floating melodic elements** that the suffix
-carries, and that the three triggers — which the paper calls PAL₁, PAL₂, PAL₃
-("small", "medium", "big" palatalisation) — stand in a **containment relation**:
+Czech has three palatalisation patterns triggered by different suffixes. The
+trigger is not the suffix's front vowel but a set of **floating elements** the
+suffix carries; the triggers (`PAL₁` ⊏ `PAL₂` ⊏ `PAL₃`, "small/medium/big")
+stand in a **containment relation** — PAL₁ adds |I|, PAL₂ adds |H| + |I|, PAL₃
+adds |H| + headed |I̲| — which is exactly the substrate's `Segment.Refines` order
+(`palataliser_chain`).
 
-| palataliser | adds       | example suffix          |
-| PAL₁        | I          | `-ě` (LOC/DAT.F.SG)     |
-| PAL₂        | H.I        | `-ěj` (CMPR), `-i` (CAUS) |
-| PAL₃        | H.I̲ (headed I) | `-ěn` (PASS.PTCP)   |
+Floating elements `dock` onto a base; the substance-free `interpret : Segment →
+CzechPhone` reproduces the paper's tables (`velar_derivations`,
+`coronal_derivations`), is non-injective (`interpret_not_injective`), and reads
+the |I|-vs-|I̲| contrast differently on velars vs /s/. Labial output-invisibility
+and lateral resistance follow from the |U|⊕|I| antagonism
+(`labial_output_invisible`, `lateral_resists`).
 
-(In the dot notation, the element(s) before the dot sit in the manner node and
-those after it in the place node.) PAL₁ ⊏ PAL₂ adds the manner element |H|;
-PAL₂ ⊏ PAL₃ promotes the place element |I| to headed |I̲|. The increasing
-elemental complexity is *exactly* the [element-theoretic refinement order]
-(`ElementTheory.Segment.Refines`) of the substrate.
+## Scope
 
-## What this file formalizes
-
-* **§1** the plain Czech consonant inventory as `Segment`s (paper Tables 9, 11,
-  13; voiceless members only, per the paper's simplification);
-* **§2** the three palatalisers and the suffix morphemes that carry them
-  (Table 8);
-* **§3** `palatalise` — floating elements dock onto the base, per-node;
-* **§4** `palataliser_chain`: PAL₁ ⊏ PAL₂ ⊏ PAL₃ (the headline);
-* **§5** the substance-free phonetic interpretation `interpret : Segment →
-  CzechPhone` (lexical access; [backley-2011]-style), and the velar/coronal
-  derivation tables (Tables 11, 13);
-* **§6** the small/medium/big distinction (Table 4b), diagnosed by /k/ and /t/;
-* **§7** the substance-free payoff: `interpret` is non-injective (one phone, many
-  structures — Table 12), and the |I|-vs-|I̲| contrast is phonetically *invisible*
-  on velars yet *visible* on /s/;
-* **§8** labial **output invisibility** and **lateral resistance**, both derived
-  from the |U|⊕|I| antagonism (`ElementTheory.Antagonistic`): a place node that
-  already hosts |U| cannot also host the palatalising |I|.
-
-## What this file does NOT formalize
-
-* The strict-CV skeleton and the government/licensing lateral relations that
-  drive the *derivations* (which root node a floating element docks at, when a
-  final empty V is a proper governor). The paper develops these in strict CV
-  ([lowenstamm-1996], [scheer-2004]); here we model the *representational
-  output* — which elements end up in which node — not the slot-by-slot
-  association. (`Studies/FaustLampitelli2026.lean` inlines a `StrictCV`
-  substrate; a shared graduation is the natural next step, this being its second
-  consumer.)
-* Whether a blocked labial palataliser surfaces as a glide [j] (CMPR `-ěj`) or
-  is fully output-invisible (CAUS `-i`, PASS.PTCP `-ěn`): the paper ties this to
-  the CV profile of the suffix (whether its initial vowel is associated with a
-  V-slot), which is the strict-CV part set aside above. We model the shared
-  cause — the colour clash — not the suffix-specific outcome.
-* The nasal-spreading detail /m/ + palataliser → [mɲ] (paper §4.3.3): the |L| of
-  /m/ spreads to a following C-slot, surfacing as a separate [ɲ]. Modelling the
-  extra segment needs the strict-CV adjacency; we capture only that /m|'s place
-  |U| blocks the palatalising |I| (the output-invisibility part).
+Representational output only — which elements end up in which node. The strict-CV
+skeleton and government/licensing driving the slot-by-slot derivations
+([lowenstamm-1996], [scheer-2004]), the glide-vs-invisible labial split, and the
+/m/ → [mɲ] nasal spreading are not modelled. (`Studies/FaustLampitelli2026.lean`
+inlines a `StrictCV` substrate; this is its second consumer — a shared graduation
+is the natural next step.)
 -/
 
 namespace CaviraniVandenWyngaerd2026
 
 open ElementTheory
 
--- ============================================================================
--- § 1: The plain Czech consonant inventory (Tables 9, 11, 13)
--- ============================================================================
+/-! ### Plain consonants (Tables 9, 11, 13; voiceless members only)
 
-/-! Element decompositions, voiceless members only (the paper sets voicing
-aside: a voiced consonant adds |L| in the laryngeal node, which is orthogonal to
-palatalisation). The dot convention: manner node `.` place node. Velars are
-**placeless** ([cavirani-vandenwyngaerd-2026] §4.3.1). /r/ has |A| in the
-*manner* node (it is a liquid), whereas /s/ has |A| in the *place* node — the
-contrast that the node geometry is needed for. -/
+The dot convention is manner node `.` place node. /r/ has |A| in the *manner*
+node whereas /s/ has |A| in the *place* node — the contrast the geometry is for. -/
 
 /-- /k/ = |ʔ| — a placeless velar stop. -/
 def k : Segment := ⟨MR.simplex .glottal, .empty, .empty⟩
@@ -91,7 +52,7 @@ def t : Segment := ⟨MR.simplex .glottal, MR.simplex .A, .empty⟩
 def s : Segment := ⟨MR.simplex .H, MR.numeration {.A, .I}, .empty⟩
 /-- /n/ = |L.A| — coronal nasal (|L| manner, |A| place). -/
 def n : Segment := ⟨MR.simplex .L, MR.simplex .A, .empty⟩
-/-- /r/ = |A| — a rhotic, |A| in the *manner* node and nothing in place. -/
+/-- /r/ = |A| — a rhotic, |A| in the *manner* node. -/
 def r : Segment := ⟨MR.simplex .A, .empty, .empty⟩
 
 /-- /p/ = |ʔ.U| — labial stop (|ʔ| manner, |U| place). -/
@@ -100,27 +61,21 @@ def p : Segment := ⟨MR.simplex .glottal, MR.simplex .U, .empty⟩
 def f : Segment := ⟨MR.simplex .H, MR.simplex .U, .empty⟩
 /-- /m/ = |L.U| — labial nasal. -/
 def m : Segment := ⟨MR.simplex .L, MR.simplex .U, .empty⟩
-/-- /l/ = |A.U| — the lateral. It patterns with the labials because it contains
-    |U| in its place node ([cavirani-vandenwyngaerd-2026] §4.3.4), which is why
-    it resists palatalisation. -/
+/-- /l/ = |A.U| — the lateral; its |U| place makes it pattern with the labials
+    [cavirani-vandenwyngaerd-2026]. -/
 def l : Segment := ⟨MR.simplex .A, MR.simplex .U, .empty⟩
 
--- ============================================================================
--- § 2: The three palatalisers (Table 8) and their suffix morphemes
--- ============================================================================
+/-! ### The three palatalisers (Table 8) and their suffixes -/
 
-/-- **PAL₁** ("small"): a floating |I| that docks in the place node. -/
+/-- **PAL₁** ("small"): a floating |I| in the place node. -/
 def PAL₁ : Segment := ⟨.empty, MR.simplex .I, .empty⟩
 /-- **PAL₂** ("medium"): floating |H| (manner) + |I| (place). -/
 def PAL₂ : Segment := ⟨MR.simplex .H, MR.simplex .I, .empty⟩
-/-- **PAL₃** ("big"): floating |H| (manner) + headed |I̲| (place). The headed |I|
-    is the only difference from PAL₂. -/
+/-- **PAL₃** ("big"): floating |H| (manner) + headed |I̲| (place). -/
 def PAL₃ : Segment := ⟨MR.simplex .H, MR.headedSimplex .I, .empty⟩
 
-/-- The suffixes that trigger palatalisation. Empirically, look-alike suffixes
-    can differ in their palatalising element (the paper's core point): the hard
-    vs soft agreement markers `-ý`/`-í` have identical vowels [iː] but only `-í`
-    palatalises (`mladý` 'young.M.SG' vs `mladí` 'young.M.ANIM.PL'). -/
+/-- The palatalising suffixes; look-alikes split by their floating element, not
+    their vowel (`-ý`/`-í` are both [iː] but only `-í` palatalises). -/
 inductive Suffix
   /-- `-ě` LOC/DAT.F.SG, e.g. `louka` 'meadow' ~ `louce`. -/
   | locDatFSg
@@ -132,62 +87,44 @@ inductive Suffix
   | passPtcp
   deriving DecidableEq, Repr
 
-/-- Which palataliser each suffix carries (the paper's analysis, §4.2 / Table 8;
-    the raw alternations are Tables 1–3). The comparative and causative both
-    carry PAL₂; the passive participle carries the stronger PAL₃. -/
+/-- The palataliser each suffix carries (§4.2 / Table 8). -/
 def Suffix.palataliser : Suffix → Segment
   | .locDatFSg   => PAL₁
   | .comparative => PAL₂
   | .causative   => PAL₂
   | .passPtcp    => PAL₃
 
--- ============================================================================
--- § 3: Palatalisation — floating elements dock onto the base
--- ============================================================================
+/-! ### Palatalisation -/
 
-/-- **Palatalisation**: the floating palataliser elements scan the base and
-    dock, node by node ([cavirani-vandenwyngaerd-2026] §4.3, the association
-    convention (13)) — the substrate's `Segment.dock` (per-node element-union,
-    the palatalising |I̲| of PAL₃ overriding as the place head). -/
+/-- Palatalisation: the floating palataliser `dock`s onto the base node-by-node
+    ([cavirani-vandenwyngaerd-2026] §4.3, convention (13)). -/
 def palatalise (base pal : Segment) : Segment := base.dock pal
 
--- ============================================================================
--- § 4: The palataliser containment chain (the headline)
--- ============================================================================
+/-! ### The palataliser containment chain -/
 
-/-- **PAL₁ ⊏ PAL₂ ⊏ PAL₃** — the three palatalisers form a chain in the
-    elemental refinement order ([cavirani-vandenwyngaerd-2026]: small ⊏ medium ⊏
-    big). PAL₁ ⊏ PAL₂ adds the manner element |H|; PAL₂ ⊏ PAL₃ promotes the
-    place |I| to headed |I̲|. -/
+/-- **PAL₁ ⊏ PAL₂ ⊏ PAL₃** in the refinement order [cavirani-vandenwyngaerd-2026]:
+    PAL₁ ⊏ PAL₂ adds |H|; PAL₂ ⊏ PAL₃ heads |I|. -/
 theorem palataliser_chain : PAL₁ ≤ PAL₂ ∧ PAL₂ ≤ PAL₃ := by decide
 
-/-- The three palatalisers are genuinely distinct (increasing complexity). -/
+/-- The three palatalisers are distinct. -/
 theorem palatalisers_distinct : PAL₁ ≠ PAL₂ ∧ PAL₂ ≠ PAL₃ ∧ PAL₁ ≠ PAL₃ := by decide
 
-/-- The chain is therefore **strict**: PAL₁ ⊏ PAL₂ ⊏ PAL₃. -/
+/-- The chain is therefore strict: PAL₁ ⊏ PAL₂ ⊏ PAL₃. -/
 theorem palataliser_chain_strict : PAL₁ < PAL₂ ∧ PAL₂ < PAL₃ :=
   ⟨lt_of_le_of_ne palataliser_chain.1 palatalisers_distinct.1,
    lt_of_le_of_ne palataliser_chain.2 palatalisers_distinct.2.1⟩
 
--- ============================================================================
--- § 5: Phonetic interpretation and the derivation tables (Tables 11, 13)
--- ============================================================================
+/-! ### Phonetic interpretation and derivation tables (Tables 11, 13) -/
 
-/-- The voiceless Czech phones appearing in the palatalisation tables. ASCII
-    constructor names stand in for the IPA: `tsh` = [t͡ʃ], `sh` = [ʃ],
-    `nj` = [ɲ], `rj` = [r̝]. -/
+/-- The voiceless Czech phones; ASCII for IPA: `tsh`=[t͡ʃ], `sh`=[ʃ], `nj`=[ɲ],
+    `rj`=[r̝]. -/
 inductive CzechPhone
   | k | x | t | s | n | r          -- plain
   | ts | tsh | c | sh | nj | rj    -- palatalised
   deriving DecidableEq, Repr
 
-/-- **Substance-free phonetic interpretation** (lexical access,
-    [backley-2011]-style; [cavirani-vandenwyngaerd-2026] §4.1). A Czech
-    consonant's surface phone is read off the elements in its manner and place
-    nodes. The interpretation is *language-particular* and *context-dependent*:
-    the |I|-vs-|I̲| distinction is read differently on velars (no effect) than on
-    coronal /s/ ([s] vs [ʃ]) — see §7. Its domain is the **non-labial**
-    inventory: labials are output-invisible (§8) and not interpreted here. -/
+/-- Substance-free phonetic interpretation (lexical access, [backley-2011]-style;
+    [cavirani-vandenwyngaerd-2026] §4.1); domain is the non-labial inventory. -/
 def interpret (seg : Segment) : CzechPhone :=
   if seg.manner.HasElement .glottal then                         -- stop / affricate
     if seg.place.HasElement .I then
@@ -207,13 +144,12 @@ def interpret (seg : Segment) : CzechPhone :=
     else .x
   else .x
 
-/-- The plain consonants are interpreted as themselves. -/
+/-- The plain consonants interpret as themselves. -/
 theorem plain_interpretation :
     interpret k = .k ∧ interpret x = .x ∧ interpret t = .t ∧
     interpret s = .s ∧ interpret n = .n ∧ interpret r = .r := by decide
 
-/-- **Velar derivations** (Table 11): /k/ shows the full small/medium/big split
-    (ts ~ tʃ ~ tʃ), /x/ neutralises to [ʃ] throughout. -/
+/-- **Velar derivations** (Table 11): /k/ ts ~ tʃ ~ tʃ; /x/ neutralises to [ʃ]. -/
 theorem velar_derivations :
     interpret (palatalise k PAL₁) = .ts ∧
     interpret (palatalise k PAL₂) = .tsh ∧
@@ -222,9 +158,8 @@ theorem velar_derivations :
     interpret (palatalise x PAL₂) = .sh ∧
     interpret (palatalise x PAL₃) = .sh := by decide
 
-/-- **Coronal derivations** (Table 13). /t/: c ~ c ~ ts (big is the odd one
-    out). /s/: s ~ s ~ ʃ (only big has a visible effect). /n/ and /r/ palatalise
-    uniformly to [ɲ] and [r̝]. -/
+/-- **Coronal derivations** (Table 13): /t/ c ~ c ~ ts; /s/ s ~ s ~ ʃ; /n/, /r/
+    uniform [ɲ], [r̝]. -/
 theorem coronal_derivations :
     interpret (palatalise t PAL₁) = .c ∧
     interpret (palatalise t PAL₂) = .c ∧
@@ -239,107 +174,81 @@ theorem coronal_derivations :
     interpret (palatalise r PAL₂) = .rj ∧
     interpret (palatalise r PAL₃) = .rj := by decide
 
--- ============================================================================
--- § 6: Small / medium / big (Table 4b)
--- ============================================================================
+/-! ### Small / medium / big (Table 4b) -/
 
-/-- Surface phone produced by applying a suffix's palataliser to a base. -/
+/-- Surface phone of a suffix's palataliser applied to a base. -/
 def applySuffix (base : Segment) (suf : Suffix) : CzechPhone :=
   interpret (palatalise base suf.palataliser)
 
-/-- The actual suffixes' outcomes on the diagnostic velar /k/: `-ě` (LOC/DAT.F.SG)
-    gives small [ts]; `-ěj` (CMPR) and `-i` (CAUS) give medium [tʃ]; `-ěn`
-    (PASS.PTCP) gives big [tʃ] — look-alike front-vowel suffixes splitting by the
-    floating element they carry, not by their vowel. -/
+/-- The suffixes' outcomes on the diagnostic velar /k/: `-ě` [ts]; `-ěj`/`-i`
+    [tʃ]; `-ěn` [tʃ] — look-alikes splitting by floating element, not vowel. -/
 theorem suffix_outcomes_on_k :
     applySuffix k .locDatFSg = .ts ∧
     applySuffix k .comparative = .tsh ∧
     applySuffix k .causative = .tsh ∧
     applySuffix k .passPtcp = .tsh := by decide
 
-/-- /k/ is the diagnostic for **small vs medium**: PAL₁ gives [ts] but PAL₂
-    gives [tʃ]. -/
+/-- /k/ diagnoses **small vs medium**: PAL₁ [ts] ≠ PAL₂ [tʃ]. -/
 theorem k_small_vs_medium :
     interpret (palatalise k PAL₁) ≠ interpret (palatalise k PAL₂) := by decide
 
-/-- /t/ is the diagnostic for **medium vs big**: PAL₂ gives [c] but PAL₃ gives
-    [ts]. -/
+/-- /t/ diagnoses **medium vs big**: PAL₂ [c] ≠ PAL₃ [ts]. -/
 theorem t_medium_vs_big :
     interpret (palatalise t PAL₂) ≠ interpret (palatalise t PAL₃) := by decide
 
-/-- The three patterns are genuinely three: there is a base separating small
-    from medium (/k/) and a base separating medium from big (/t/), so no two of
-    the palatalisers are interpretationally collapsible. -/
+/-- The three patterns are genuinely three (separated by /k/ and /t/). -/
 theorem three_distinct_patterns :
     (∃ base, interpret (palatalise base PAL₁) ≠ interpret (palatalise base PAL₂)) ∧
     (∃ base, interpret (palatalise base PAL₂) ≠ interpret (palatalise base PAL₃)) :=
   ⟨⟨k, k_small_vs_medium⟩, ⟨t, t_medium_vs_big⟩⟩
 
--- ============================================================================
--- § 7: The substance-free payoff
--- ============================================================================
+/-! ### The substance-free payoff -/
 
-/-- **`interpret` is non-injective** (Table 12: "/ʃ/ corresponds to four
-    different underlying representations"). Palatalised /x/ (|H.I|) and big-
-    palatalised /s/ (|H.A I̲|) are *different* element structures that the
-    phonetic module maps onto the *same* phone [ʃ] — the hallmark of
-    substance-free phonology. -/
+/-- **`interpret` is non-injective** (Table 12): palatalised /x/ (|H.I|) and
+    big-palatalised /s/ (|H.A I̲|) are different structures, both [ʃ]. -/
 theorem interpret_not_injective :
     interpret (palatalise x PAL₁) = .sh ∧
     interpret (palatalise s PAL₃) = .sh ∧
     (palatalise x PAL₁).place.elements ≠ (palatalise s PAL₃).place.elements := by
   decide
 
-/-- The headedness of |I| is **phonetically invisible on velars**: |ʔH.I| (PAL₂)
-    and |ʔH.I̲| (PAL₃) are different representations (different place head) but
-    both surface as [tʃ]. -/
+/-- Headedness of |I| is **invisible on velars**: PAL₂ and PAL₃ differ in the
+    place head but both surface as [tʃ]. -/
 theorem headedness_invisible_on_velars :
     interpret (palatalise k PAL₂) = interpret (palatalise k PAL₃) ∧
     (palatalise k PAL₂).place.head ≠ (palatalise k PAL₃).place.head := by decide
 
-/-- …yet the *same* |I|-vs-|I̲| difference is **visible on /s/**: |H.AI| (PAL₂)
-    surfaces as [s] while |H.A I̲| (PAL₃) surfaces as [ʃ]. One structural
-    distinction, two context-dependent interpretations. -/
+/-- …yet the same |I|-vs-|I̲| difference is **visible on /s/**: [s] vs [ʃ]. -/
 theorem headedness_visible_on_coronal_s :
     interpret (palatalise s PAL₂) ≠ interpret (palatalise s PAL₃) := by decide
 
--- ============================================================================
--- § 8: Labial output invisibility and lateral resistance (the |U|⊕|I| clash)
--- ============================================================================
+/-! ### Labial output-invisibility and lateral resistance (the |U|⊕|I| clash) -/
 
-/-- A **colour clash** in the place node: |U| and |I| — an antagonistic pair
-    ([backley-2011] §5.3.4) — both present. Czech does not allow a complex |I U|
-    place ([cavirani-vandenwyngaerd-2026] §4.3.3, after [janku-2022]), so a
-    place node carrying |U| cannot also host the palatalising |I|; the
-    palataliser is then output-invisible (or surfaces as a separate glide). -/
+/-- A **colour clash**: |U| and |I| (antagonistic) both in the place node — which
+    Czech forbids ([cavirani-vandenwyngaerd-2026] §4.3.3, after [janku-2022]). -/
 def PlaceColourClash (seg : Segment) : Prop := ¬ seg.place.AntagonismFree
 
 instance (seg : Segment) : Decidable (PlaceColourClash seg) := by
   unfold PlaceColourClash; infer_instance
 
-/-- **Labial output invisibility**: docking the palatalising |I| onto a labial
-    (place |U|) would create the forbidden |U I| place — the representational
-    reason labials never fully palatalise. -/
+/-- **Labial output-invisibility**: docking |I| onto a labial (place |U|) would
+    forge the forbidden |U I| place — so labials never fully palatalise. -/
 theorem labial_output_invisible : PlaceColourClash (palatalise p PAL₁) := by decide
 
-/-- The fricative /f/ and nasal /m/ behave the same way — all labials carry |U|
-    in place. -/
+/-- /f/ and /m/ clash too — all labials carry |U| in place. -/
 theorem all_labials_clash :
     PlaceColourClash (palatalise f PAL₁) ∧ PlaceColourClash (palatalise m PAL₁) := by
   decide
 
-/-- **Lateral resistance**: /l/ carries |U| in place too, so it clashes exactly
-    as the labials do — the paper's explanation for why /l/ never palatalises
-    ([cavirani-vandenwyngaerd-2026] §4.3.4). -/
+/-- **Lateral resistance**: /l/ carries |U| in place, so it clashes like the
+    labials — why /l/ never palatalises ([cavirani-vandenwyngaerd-2026] §4.3.4). -/
 theorem lateral_resists : PlaceColourClash (palatalise l PAL₁) := by decide
 
-/-- By contrast, a velar (placeless) takes the palatalising |I| into an
-    **antagonism-free** place node — which is why velars palatalise freely. -/
+/-- A velar (placeless) keeps an antagonism-free place node — so velars
+    palatalise freely. -/
 theorem velar_no_clash : (palatalise k PAL₁).place.AntagonismFree := by decide
 
-/-- The clash is colour-specific: it is exactly the |U|–|I| antagonism. The
-    coronals, whose place hosts |A| (and |I|), keep an antagonism-free place
-    node under palatalisation. -/
+/-- The clash is colour-specific: coronals (place |A I|) stay antagonism-free. -/
 theorem coronal_no_clash :
     (palatalise t PAL₁).place.AntagonismFree ∧ (palatalise s PAL₁).place.AntagonismFree := by
   decide


### PR DESCRIPTION
Polish pass on the just-landed Element Theory substrate (#752): mathlib-terse docstrings (one-liners; cut module docs), `/-! ### -/` section headers, proof golf, and lifted `variable` blocks. No behaviour or signature change — the public API is identical and the cone is axiom-clean.