### PR TITLE
feat(Phonology/Autosegmental): ASL stringsets (realization + Free grammars)

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1334,6 +1334,7 @@ import Linglib.Studies.Veltman1996
 import Linglib.Studies.Moroney2021
 import Linglib.Studies.Jenks2018
 import Linglib.Studies.Jardine2016
+import Linglib.Studies.Jardine2019
 import Linglib.Studies.DongEtAl2026PMF
 import Linglib.Studies.TsvilodubEtAl2026
 import Linglib.Studies.Anderson2021
@@ -2738,6 +2739,8 @@ import Linglib.Phonology.Autosegmental.MultiGraph
 import Linglib.Phonology.Autosegmental.Inclusion
 import Linglib.Phonology.Autosegmental.MultiAR
 import Linglib.Phonology.Autosegmental.Correspondence
+import Linglib.Phonology.Autosegmental.Realization
+import Linglib.Phonology.Autosegmental.ASL
 import Linglib.Phonology.Prosodic.Syllable
 import Linglib.Phonology.Prosodic.Foot
 import Linglib.Phonology.Prosodic.NaturalClass

--- a/Linglib/Phonology/Autosegmental/ASL.lean
+++ b/Linglib/Phonology/Autosegmental/ASL.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Computability.Language
+import Linglib.Phonology.Autosegmental.Realization
+import Linglib.Phonology.Autosegmental.Embedding
+
+/-!
+# Autosegmental Strictly Local stringsets
+
+[jardine-2019]'s class `ASL^g`: a stringset described by a forbidden-subgraph grammar
+`B` over autosegmental representations, interpreted through a realization `g`
+(`Realization.lean`). A string is in the class iff its realization avoids every
+forbidden subgraph in `B`.
+
+This unifies the autosegmental and subregular layers. It is the *same construction* as
+the tier-based strictly local sets: both a subregular class as the **preimage of a
+local base condition along a free-monoid homomorphism**.
+
+```
+  TSL  =  tierProject ⁻¹' (SL-language)        -- string→tier-string projection
+  ASL  =  realize g₀  ⁻¹' { A | isFreeOf B A } -- string→AR realization
+```
+
+`tierProject` (`Phonology/TierProjection.lean`) and `realize` (`Realization.lean`) are
+both concat-distributing free-monoid homs; the difference is only the codomain — a
+tier string (discarding off-tier material) vs an AR (keeping the association lines).
+That extra structure is why [jardine-2019] finds `ASL` and `TSL` incomparable.
+-/
+
+namespace Autosegmental
+
+variable {S : Type*} {α β : Type*}
+
+/-- A banned-subgraph grammar as an AR **object-property**: the ARs free of every
+    forbidden pattern in `B` ([jardine-2016] Ch. 5's `L^NL_G`, packaged for `AR`). -/
+def isFreeOf (B : List (Graph α β)) (A : AR α β) : Prop := A.toGraph.Free B
+
+instance [DecidableEq α] [DecidableEq β] (B : List (Graph α β)) (A : AR α β) :
+    Decidable (isFreeOf B A) := inferInstanceAs (Decidable (A.toGraph.Free B))
+
+/-- **The Autosegmental Strictly Local stringset** of a realization `g₀` and a forbidden
+    grammar `B` ([jardine-2019]): the strings whose realization avoids `B`. The preimage
+    of the AR object-property `isFreeOf B` along `realize g₀` — the same shape as
+    `TSL.lang = tierProject ⁻¹' (SL-language)`, with the AR realization in place of the
+    tier projection. -/
+def ASL (g₀ : S → AR α β) (B : List (Graph α β)) : Language S :=
+  realize g₀ ⁻¹' { A | isFreeOf B A }
+
+@[simp] theorem mem_ASL (g₀ : S → AR α β) (B : List (Graph α β)) (w : List S) :
+    w ∈ ASL g₀ B ↔ isFreeOf B (realize g₀ w) := Iff.rfl
+
+instance [DecidableEq α] [DecidableEq β] (g₀ : S → AR α β) (B : List (Graph α β))
+    (w : List S) : Decidable (w ∈ ASL g₀ B) :=
+  inferInstanceAs (Decidable (isFreeOf B (realize g₀ w)))
+
+/-- A stringset is **autosegmental strictly local** when some realization and forbidden
+    grammar present it ([jardine-2019]). -/
+def IsASL (L : Language S) : Prop :=
+  ∃ (α β : Type) (g₀ : S → AR α β) (B : List (Graph α β)), L = ASL g₀ B
+
+end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Realization.lean
+++ b/Linglib/Phonology/Autosegmental/Realization.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Algebra.BigOperators.Group.List.Basic
+import Linglib.Phonology.Autosegmental.AR
+
+/-!
+# Autosegmental realization of strings
+
+The **realization** of a string maps each symbol to its autosegmental graph primitive
+and concatenates them ([jardine-2019]'s mapping `g`): `realize g₀ w = ∏ (w.map g₀)` in
+the concatenation monoid `Monoid (AR α β)`.
+
+This is a string→AR **monoid homomorphism** (`realize_append`), the exact analogue —
+one categorical level up — of the string→tier-string projection
+`TierProjection.apply` (= `List.filterMap`, also concat-distributing): both are
+free-monoid homomorphisms built from a per-symbol map, used to define a subregular
+class as a *preimage* (`Phonology/Autosegmental/ASL.lean` for the realization,
+`Subregular.Language.TierStrictlyLocal` for the projection). The realization keeps the
+association structure the tier projection discards — see [jardine-2019] on `ASL` vs
+`TSL`.
+-/
+
+namespace Autosegmental
+
+variable {S : Type*} {α β : Type*}
+
+/-- **Realize** a string as an autosegmental representation: concatenate the graph
+    primitives `g₀ a` of its symbols ([jardine-2019]'s `g`). -/
+def realize (g₀ : S → AR α β) (w : List S) : AR α β := (w.map g₀).prod
+
+@[simp] theorem realize_nil (g₀ : S → AR α β) : realize g₀ [] = AR.empty := rfl
+
+@[simp] theorem realize_cons (g₀ : S → AR α β) (a : S) (w : List S) :
+    realize g₀ (a :: w) = (g₀ a).concat (realize g₀ w) := rfl
+
+/-- **The realization is a monoid homomorphism**: it distributes over concatenation —
+    the string→AR analogue of `TierProjection.apply_append`. -/
+theorem realize_append (g₀ : S → AR α β) (xs ys : List S) :
+    realize g₀ (xs ++ ys) = (realize g₀ xs).concat (realize g₀ ys) := by
+  simp only [realize, List.map_append, List.prod_append]; rfl
+
+end Autosegmental

--- a/Linglib/Studies/Jardine2019.lean
+++ b/Linglib/Studies/Jardine2019.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Phonology.Autosegmental.ASL
+
+/-!
+# Jardine (2019): the expressivity of autosegmental grammars
+
+[jardine-2019] defines `ASL^g` — stringsets given by forbidden-subgraph grammars over
+autosegmental representations interpreted through a realization `g` — and places the
+tone class `ASL^{gT}` in the subregular hierarchy. This file instantiates the
+`Autosegmental.ASL` substrate with the tone realization `gT` (Fig. 23) and checks a
+banned-subgraph constraint over its realizations.
+
+## Scope
+
+`Autosegmental.realize` uses the project's *bridge-only* `concat` (the coproduct), so
+this captures patterns invariant under tonal merging (here: banning an `H-L-H` tone
+sequence, [jardine-2019]'s `*HLH`). [jardine-2019]'s full `g_T` uses the OCP-*merging*
+concat (`g_T(Hⁿ)` = one H node), which is what renders genuinely non-local patterns
+(unbounded tone plateauing) local in the AR; that merging realization (via the gluing
+concat / `OCP.collapse`) and the relation-level `L = ASL^{gT}` equivalences are
+deferred — see `Autosegmental/Realization.lean`.
+-/
+
+namespace Jardine2019
+
+open Autosegmental
+
+/-- The tone alphabet ([jardine-2019] §2): high, low, falling. -/
+inductive ToneSym | H | L | F
+  deriving DecidableEq, Repr
+
+/-- The tone-bearing unit (a mora). -/
+inductive Mora | μ
+  deriving DecidableEq, Repr
+
+/-- The tone realization `g_T` ([jardine-2019] (23)): `H`/`L` are a single tone on one
+    mora; the falling tone `F` is an `H-L` contour on one mora (multiple association). -/
+def gT : ToneSym → AR ToneSym Mora
+  | .H => ⟨⟨.ofList [.H], .ofList [.μ], {(0, 0)}⟩, by decide⟩
+  | .L => ⟨⟨.ofList [.L], .ofList [.μ], {(0, 0)}⟩, by decide⟩
+  | .F => ⟨⟨.ofList [.H, .L], .ofList [.μ], {(0, 0), (1, 0)}⟩, by decide⟩
+
+/-- The forbidden subgraph `*HLH` ([jardine-2019] (3)): an `H-L-H` tone sequence, three
+    tones each on their own mora. -/
+def hlh : Graph ToneSym Mora :=
+  ⟨.ofList [.H, .L, .H], .ofList [.μ, .μ, .μ], {(0, 0), (1, 1), (2, 2)}⟩
+
+/-- `HLH` is excluded: its realization contains the `*HLH` subgraph. -/
+theorem hlh_excluded : [ToneSym.H, .L, .H] ∉ ASL gT [hlh] := by decide
+
+/-- `HL` is admitted (no `H-L-H`). -/
+theorem hl_included : [ToneSym.H, .L] ∈ ASL gT [hlh] := by decide
+
+/-- `LHL` is admitted (no `H-L-H`). -/
+theorem lhl_included : [ToneSym.L, .H, .L] ∈ ASL gT [hlh] := by decide
+
+/-- And the constraint reaches inside longer strings: `HHLH` is excluded (the medial
+    `H-L-H` realizes the forbidden subgraph). -/
+theorem hhlh_excluded : [ToneSym.H, .H, .L, .H] ∉ ASL gT [hlh] := by decide
+
+end Jardine2019


### PR DESCRIPTION
Unify the autosegmental and subregular layers via [jardine-2019]'s autosegmental-strictly-local stringsets — a subregular class as the **preimage of a banned-subgraph grammar along a string→AR realization**, the exact analogue of `TSL`.

- `Realization.lean`: `realize g₀ w = (w.map g₀).prod` — the string→AR **monoid hom** (`realize_append`), one level up from `TierProjection.apply` (string→tier-string). Both are concat-distributing free-monoid homs.
- `ASL.lean`: `ASL g₀ B = realize g₀ ⁻¹' { A | A.toGraph.Free B }` — mirroring `TSL.lang = tierProject ⁻¹' (SL-language)`. So the subregular classes are one construction: *preimage of a local base along a free-monoid hom*, differing only in codomain (tier-string vs AR). `IsASL` + decidable membership.
- `Studies/Jardine2019.lean`: the tone realization `gT` (Fig. 23) and the `*HLH` constraint, `decide`-checked (`HLH`/`HHLH` excluded, `HL`/`LHL` admitted).
- Deferred (noted in-file): the OCP-*merging* realization (Jardine's `g_T`, `g_T(Hⁿ)`=one node) that makes non-local patterns local, and the `L = ASL^{gT}` / hierarchy-placement (`⊊ SF`) theorems.