### PR TITLE
docs(Phonology/Featural): correct citations and add license headers

### DIFF
--- a/Linglib/Phonology/Featural/Bundle.lean
+++ b/Linglib/Phonology/Featural/Bundle.lean
@@ -1,17 +1,23 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Data.List.Forall2
 import Mathlib.Logic.Function.Basic
 
 /-!
 # Featural Bundles
 [lionnet-2022] [pulleyblank-1986] [yip-1980]
-[clements-1985] [reiss-2017]
+[clements-1985] [mielke-2008]
 
-A **feature bundle** is a partial assignment over a feature index space.
-This is the most general primitive of autosegmental / featural phonology:
-every concrete feature theory (Snider Register Tier Theory [snider-1999]
-[snider-1990]; Lionnet's subtonal features [lionnet-2022]; vowel
-or consonant harmony; nasal, laryngeal, place tiers) is a specialization
-of `FeatureBundle F V` for some feature index `F` and value type `V`.
+A **feature bundle** is a partial assignment over a feature index space — a
+general primitive of autosegmental / featural phonology: many feature theories
+(Snider Register Tier Theory [snider-1999] [snider-1990]; Lionnet's subtonal
+features [lionnet-2022]; vowel or consonant harmony; nasal, laryngeal, place
+tiers) specialize `FeatureBundle F V` for some feature index `F` and value type
+`V`. (Element Theory's privative elements fit as a finite `F`, but its
+headedness is *extra* structure carried separately — see `ElementTheory.lean`.)
 
 ## Design
 
@@ -32,9 +38,10 @@ The value type `V` is parametric:
 
 ## Why this is the right primitive
 
-1. [reiss-2017]'s Substance-Free Phonology argues features are
-   language-particular. Parameterising over `F` is exactly the right move:
-   the feature *space* is data, not built into the type.
+1. [mielke-2008]'s Emergent Feature Theory argues feature inventories are
+   language-particular (emergent from the contrasts a language draws).
+   Parameterising over `F` is exactly the right move: the feature *space* is
+   data, not built into the type.
 
 2. The autosegmental tier is just a sequence of bundles
    (`List (FeatureBundle F V)`). Association to bearers and

--- a/Linglib/Phonology/Featural/Features.lean
+++ b/Linglib/Phonology/Featural/Features.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+
 /-!
 # Phonological Features
 
@@ -38,41 +44,41 @@ namespace Phonology
     The flat `isMajorClass` predicate has no single geometric counterpart
     — see subsumption theorems in `FeatureGeometry.lean` §6.
 
-    The sonority hierarchy (Hayes Table 4.1) is decomposed as:
+    A feature decomposition consistent with Hayes's sonority discussion:
     [±sonorant] > [±approximant] > [±consonantal] > [±syllabic],
     yielding 5 natural classes (obstruent, nasal, liquid, glide, vowel). -/
 inductive Feature where
   -- Manner / root
-  | syllabic         -- [+syll] = vowels (Hayes §4.4.3)
-  | consonantal      -- [+cons] = oral constriction (Hayes §4.4.2)
-  | sonorant         -- [+son] = spontaneous voicing (Hayes §4.4.1)
-  | approximant      -- [+approx] = no turbulence (Hayes §4.4.1)
-  | continuant       -- [+cont] = airflow continues (Hayes §4.4.5)
-  | delayedRelease   -- [+del.rel.] = affricates (Hayes §4.4.7)
-  | nasal            -- [+nasal] = lowered velum (Hayes §4.4.8)
-  | lateral          -- [+lat] = lateral airflow (Hayes §4.4.9)
-  | strident         -- [+strid] = high-amplitude noise (Hayes §4.4.10)
-  | tap              -- [+tap] = ballistic gesture (Hayes §4.4.6)
-  | trill            -- [+trill] = aerodynamic vibration (Hayes §4.4.6)
+  | syllabic         -- [+syll] = vowels
+  | consonantal      -- [+cons] = oral constriction
+  | sonorant         -- [+son] = spontaneous voicing
+  | approximant      -- [+approx] = no turbulence
+  | continuant       -- [+cont] = airflow continues
+  | delayedRelease   -- [+del.rel.] = affricates
+  | nasal            -- [+nasal] = lowered velum
+  | lateral          -- [+lat] = lateral airflow
+  | strident         -- [+strid] = high-amplitude noise
+  | tap              -- [+tap] = ballistic gesture
+  | trill            -- [+trill] = aerodynamic vibration
   -- Laryngeal
-  | voice            -- [+voice] = vocal cord vibration (Hayes §4.7)
-  | spreadGlottis    -- [+s.g.] = aspiration (Hayes §4.7)
-  | constrGlottis    -- [+c.g.] = glottal constriction (Hayes §4.7)
+  | voice            -- [+voice] = vocal cord vibration
+  | spreadGlottis    -- [+s.g.] = aspiration
+  | constrGlottis    -- [+c.g.] = glottal constriction
   -- Place: Labial
-  | labial           -- [+lab] = lips involved (Hayes §4.6.1)
-  | round            -- [+round] = lip rounding (Hayes §4.6.1)
-  | labiodental      -- [+labiodental] = lower lip to upper teeth (Hayes §4.6.1)
+  | labial           -- [+lab] = lips involved
+  | round            -- [+round] = lip rounding
+  | labiodental      -- [+labiodental] = lower lip to upper teeth
   -- Place: Coronal
-  | coronal          -- [+cor] = tongue blade/tip (Hayes §4.6.2)
-  | anterior         -- [+ant] = alveolar ridge or forward (Hayes §4.6.2)
-  | distributed      -- [+dist] = laminal contact (Hayes §4.6.2)
+  | coronal          -- [+cor] = tongue blade/tip
+  | anterior         -- [+ant] = alveolar ridge or forward
+  | distributed      -- [+dist] = laminal contact
   -- Place: Dorsal
-  | dorsal           -- [+dor] = tongue body (Hayes §4.6.3)
-  | high             -- tongue body raised (Hayes §4.5.1)
-  | low              -- tongue body lowered (Hayes §4.5.1)
-  | front            -- tongue body fronted (Hayes §4.5.1)
-  | back             -- tongue body backed (Hayes §4.5.1)
-  | tense            -- tense vowel quality (Hayes §4.5.3)
+  | dorsal           -- [+dor] = tongue body
+  | high             -- tongue body raised
+  | low              -- tongue body lowered
+  | front            -- tongue body fronted
+  | back             -- tongue body backed
+  | tense            -- tense vowel quality
   deriving DecidableEq, Repr
 
 /-- A feature value: `some true` = [+F], `some false` = [−F], `none` = unspecified. -/

--- a/Linglib/Phonology/Featural/Features.lean
+++ b/Linglib/Phonology/Featural/Features.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Phonology.Featural.Bundle
 
 /-!
 # Phonological Features
@@ -144,10 +145,10 @@ instance : DecidablePred Feature.IsDorsal := fun f => by
 -- § 3: Segment Representation
 -- ============================================================================
 
-/-- A segment represented as a (partial) specification of features.
-    Unspecified features return `none`. -/
+/-- A segment: a `FeatureBundle Feature Bool` — a partial binary-feature
+    specification (`none` = unspecified). -/
 structure Segment where
-  spec : Feature → FeatureVal
+  spec : FeatureBundle Feature Bool
 
 /-- Is feature `f` specified (either [+F] or [−F])? -/
 def Segment.Specified (s : Segment) (f : Feature) : Prop :=
@@ -186,11 +187,6 @@ theorem allFeatures_complete (f : Feature) : f ∈ Feature.allFeatures := by
 -- ============================================================================
 -- § 5: Segment Equality
 -- ============================================================================
-
-/-- Segment equality by checking all 26 features.
-    Two segments are BEq-equal iff they agree on every feature value. -/
-instance : BEq Segment where
-  beq s1 s2 := Feature.allFeatures.all λ f => s1.spec f == s2.spec f
 
 /-- Decidable equality on segments via exhaustive feature comparison.
     Enables `decide` on segment-level goals and OT tableaux
@@ -237,10 +233,8 @@ instance (s p : Segment) : Decidable (Segment.MatchesPattern s p) :=
     `change` override `s`'s values; unspecified features in `change` are
     preserved. Implements the SPE structural change `A → B` when `B` is a
     partial feature bundle. -/
-def Segment.applyChanges (s : Segment) (change : Segment) : Segment where
-  spec f := match change.spec f with
-    | some v => some v
-    | none => s.spec f
+def Segment.applyChanges (s change : Segment) : Segment :=
+  ⟨FeatureBundle.merge change.spec s.spec⟩
 
 /-- Two segments are equal iff their `spec` functions agree on every feature. -/
 @[ext] theorem Segment.ext {s t : Segment} (h : ∀ f, s.spec f = t.spec f) :
@@ -260,15 +254,13 @@ def Segment.applyChanges (s : Segment) (change : Segment) : Segment where
 /-- Applying the empty change list is the identity. -/
 @[simp] theorem Segment.applyChanges_ofSpecs_nil (s : Segment) :
     s.applyChanges (Segment.ofSpecs []) = s := by
-  ext f
-  unfold Segment.applyChanges Segment.ofSpecs
-  rfl
+  ext f; simp [Segment.applyChanges, Segment.ofSpecs, FeatureBundle.merge]
 
 /-- Applying the same change twice equals applying it once. -/
 @[simp] theorem Segment.applyChanges_idem (s change : Segment) :
     (s.applyChanges change).applyChanges change = s.applyChanges change := by
   ext f
-  simp only [Segment.applyChanges]
+  simp only [Segment.applyChanges, FeatureBundle.merge]
   cases change.spec f <;> rfl
 
 end Phonology

--- a/Linglib/Phonology/Featural/Underspecification.lean
+++ b/Linglib/Phonology/Featural/Underspecification.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Phonology.Featural.Features
 import Linglib.Phonology.Featural.Bundle
 
@@ -107,14 +112,13 @@ def fillFeature (s : Segment) (f : Feature) (v : Bool) : Segment :=
     targets and features other than `f` are untouched. When `ctx` is
     itself unspecified for `f`, the target stays unspecified.
 
-    This is a [keating-1988] *context rule* (§1.2, p. 277) — case
-    (b) of her schema (2) p. 287, where the target acquires a categorical
+    This is a [keating-1988] *context rule*: the target acquires a categorical
     feature value from its neighbour and that value blocks further
-    interactions. It is **distinct from** her case (c) gradient phonetic
-    interpolation (the /h/ example in §3.1), in which an unspecified
-    segment remains unspecified and the phonetics builds a continuous
-    trajectory through it; gradient phonetic interpolation is out of
-    scope at this categorical-featural substrate. -/
+    interactions. It is **distinct from** her gradient phonetic interpolation
+    (her unspecified /h/ example), in which an unspecified segment stays
+    unspecified and the phonetics builds a continuous trajectory through it;
+    gradient phonetic interpolation is out of scope at this categorical-featural
+    substrate. -/
 def fillFromContext (s : Segment) (f : Feature) (ctx : Segment) : Segment :=
   ⟨FeatureBundle.merge s.spec
     (Function.update (FeatureBundle.empty : FeatureBundle Feature Bool)

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -28927,6 +28927,18 @@
   role      = {foundational}
 }
 
+@article{archangeli-1988,
+  author    = {Archangeli, Diana},
+  year      = {1988},
+  title     = {Aspects of underspecification theory},
+  journal   = {Phonology},
+  volume    = {5},
+  number    = {2},
+  pages     = {183--207},
+  subfield  = {phonology/underspecification},
+  role      = {foundational}
+}
+
 @book{archangeli-pulleyblank-1994,
   author    = {Archangeli, Diana and Pulleyblank, Douglas},
   year      = {1994},
@@ -28934,6 +28946,16 @@
   publisher = {MIT Press},
   address   = {Cambridge, MA},
   subfield  = {phonology},
+  role      = {foundational}
+}
+
+@book{mielke-2008,
+  author    = {Mielke, Jeff},
+  year      = {2008},
+  title     = {The Emergence of Distinctive Features},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  subfield  = {phonology/features},
   role      = {foundational}
 }
 


### PR DESCRIPTION
Audit-flagged citation corrections in the oldest Phonology files; no behaviour change.

- `Bundle.lean`: the language-particularity claim is Mielke 2008's emergent-feature view, **not** Reiss (whose substance-free phonology argues features are innate/universal). Also narrows the over-broad "subsumes every feature theory" claim with an Element-Theory caveat.
- `Features.lean`: drop fabricated per-feature Hayes `§4.x.x` numbers (several misplaced `[lateral]`/`[strident]` in the manner block — they're coronal-place features); the module already cites `[hayes-2009]` Ch 4. Soften the "Hayes Table 4.1" sonority attribution.
- `Underspecification.lean`: soften unverifiable Keating section/page locators to content.
- Add bib entries `mielke-2008`, `archangeli-1988` (the latter previously dangling); Apache headers on the three pre-convention files.