### PR TITLE
refactor(Features): per-slot φ-compatibility projections; fix DG case

### DIFF
--- a/Linglib/Data/UD/Basic.lean
+++ b/Linglib/Data/UD/Basic.lean
@@ -347,7 +347,7 @@ def MorphFeatures.compatible (f1 f2 : MorphFeatures) : Bool :=
 private theorem MorphFeatures.compatible_clause_comm {α : Type _} [BEq α] [LawfulBEq α]
     (a b : Option α) :
     (a.isNone || b.isNone || a == b) = (b.isNone || a.isNone || b == a) := by
-  cases a <;> cases b <;> simp [beq_iff_eq, eq_comm]
+  cases a <;> cases b <;> simp [eq_comm]
 
 /-- Feature compatibility is symmetric. -/
 theorem MorphFeatures.compatible_comm (f1 f2 : MorphFeatures) :
@@ -360,6 +360,39 @@ theorem MorphFeatures.compatible_comm (f1 f2 : MorphFeatures) :
       compatible_clause_comm f1.tense, compatible_clause_comm f1.aspect,
       compatible_clause_comm f1.mood, compatible_clause_comm f1.voice,
       compatible_clause_comm f1.polarity]
+
+/-! ### Per-slot projections of `compatible`
+
+φ-compatibility is a conjunction over all slots; these project it onto a single
+slot's clause. They confine the coupling to `compatible`'s clause layout to this
+one site, beside the definition, so the per-feature faithfulness theorems
+(`HasX.compatible_hasX` in `Features/{Person,Number,Gender,Case}/Capabilities.lean`)
+consume a named edge rather than each re-`unfold`ing the definition. Only the
+four φ-slots that carry a `HasX` mixin are projected. -/
+
+/-- Project φ-compatibility onto its number clause. -/
+theorem MorphFeatures.compatible_number {f1 f2 : MorphFeatures}
+    (h : f1.compatible f2 = true) :
+    (f1.number.isNone || f2.number.isNone || f1.number == f2.number) = true := by
+  grind [MorphFeatures.compatible]
+
+/-- Project φ-compatibility onto its gender clause. -/
+theorem MorphFeatures.compatible_gender {f1 f2 : MorphFeatures}
+    (h : f1.compatible f2 = true) :
+    (f1.gender.isNone || f2.gender.isNone || f1.gender == f2.gender) = true := by
+  grind [MorphFeatures.compatible]
+
+/-- Project φ-compatibility onto its case clause. -/
+theorem MorphFeatures.compatible_case {f1 f2 : MorphFeatures}
+    (h : f1.compatible f2 = true) :
+    (f1.case_.isNone || f2.case_.isNone || f1.case_ == f2.case_) = true := by
+  grind [MorphFeatures.compatible]
+
+/-- Project φ-compatibility onto its person clause. -/
+theorem MorphFeatures.compatible_person {f1 f2 : MorphFeatures}
+    (h : f1.compatible f2 = true) :
+    (f1.person.isNone || f2.person.isNone || f1.person == f2.person) = true := by
+  grind [MorphFeatures.compatible]
 
 /-- The information-join of two bundles, field-by-field: keep every committed value
     (left-biased per field, which on `compatible` inputs is symmetric since doubly

--- a/Linglib/Features/Case/Capabilities.lean
+++ b/Linglib/Features/Case/Capabilities.lean
@@ -8,9 +8,26 @@ import Linglib.Features.Case.Basic
 
 The typeclass mixin for carriers that bear grammatical case — the case
 analogue of `HasPerson` (`Features/Person/Capabilities.lean`). `caseOf`
-extracts the carrier's analytical case value; `Compatible` is the
-concord-checking relation. Carriers that store UD realization
-(`UD.MorphFeatures`) lift through `Case.fromUD`.
+extracts the carrier's analytical case value; carriers that store UD
+realization (`UD.MorphFeatures`) lift through `Case.fromUD`.
+
+`Compatible` is the **case-concord** relation: symmetric, agree-or-wildcard
+slot compatibility (NP-internal agreement in case, e.g. Slavic/Latin
+adjective–noun). It is *not* case **government/assignment** — the asymmetric,
+head-to-dependent relation by which case enters an NP in the first place —
+which lives in `Syntax/Case/Dependent.lean` (Marantz dependent case) and
+`Syntax/Case/Licensing.lean` (Kalin licensing). Unlike person/number/gender,
+case is a *non-canonical* agreement feature ([corbett-2006]): the controller of
+case concord is itself the target of some other case relation; Blake's
+treatment of case assignment and concord ([blake-1994]) is the typological
+anchor.
+
+The carrier is single-valued (`Option Case`), so syncretism (one form
+realizing several cases), case-stacking/Suffixaufnahme, and coordinate case
+resolution are out of scope — a faithful treatment of those would carry a
+`Finset Case` and check nonempty intersection. The present consumer
+(`Studies/WechslerZlatic2000.lean`, concord) treats concord case as
+single-valued, for which this carrier is adequate.
 -/
 
 set_option autoImplicit false
@@ -43,15 +60,6 @@ variable {α β : Type*} [HasCase α] [HasCase β]
 abbrev Compatible (a : α) (b : β) : Prop :=
   Compat (α := Flat Case) (caseOf a) (caseOf b)
 
-theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
-    Compatible b a :=
-  h.symm
-
-theorem compatible_of_none {a : α} (h : caseOf a = none) (b : β) :
-    Compatible a b := by
-  show Compat (α := Flat Case) (caseOf a) (caseOf b)
-  rw [h]; exact bot_compat _
-
 end HasCase
 
 /-- φ-compatibility entails case compatibility: the `HasCase` mixin
@@ -61,7 +69,4 @@ end HasCase
 theorem UD.MorphFeatures.compatible_hasCase {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasCase.Compatible f1 f2 :=
-  Features.compat_of_clause_map Case.fromUD <| by
-    unfold UD.MorphFeatures.compatible at h
-    simp only [Bool.and_eq_true] at h
-    tauto
+  Features.compat_of_clause_map Case.fromUD (UD.MorphFeatures.compatible_case h)

--- a/Linglib/Features/Gender/Capabilities.lean
+++ b/Linglib/Features/Gender/Capabilities.lean
@@ -50,16 +50,6 @@ variable {α : Type*} {β : Type*} [HasGender α] [HasGender β]
 abbrev Compatible (a : α) (b : β) : Prop :=
   Compat (α := Flat Gender) (genderOf a) (genderOf b)
 
-theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
-    Compatible b a :=
-  h.symm
-
-/-- An unvalued carrier is compatible with everything. -/
-theorem compatible_of_none {a : α} (h : genderOf a = none) (b : β) :
-    Compatible a b := by
-  show Compat (α := Flat Gender) (genderOf a) (genderOf b)
-  rw [h]; exact bot_compat _
-
 end HasGender
 
 /-- φ-compatibility entails gender compatibility: the `HasGender` mixin never
@@ -68,7 +58,4 @@ end HasGender
 theorem UD.MorphFeatures.compatible_hasGender {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasGender.Compatible f1 f2 :=
-  Features.compat_of_clause_map Gender.fromUD <| by
-    unfold UD.MorphFeatures.compatible at h
-    simp only [Bool.and_eq_true] at h
-    tauto
+  Features.compat_of_clause_map Gender.fromUD (UD.MorphFeatures.compatible_gender h)

--- a/Linglib/Features/Number/Capabilities.lean
+++ b/Linglib/Features/Number/Capabilities.lean
@@ -57,16 +57,6 @@ variable {α : Type*} {β : Type*} [HasNumber α] [HasNumber β]
 abbrev Compatible (a : α) (b : β) : Prop :=
   Compat (α := Flat Number) (numberOf a) (numberOf b)
 
-theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
-    Compatible b a :=
-  h.symm
-
-/-- An unvalued carrier is compatible with everything. -/
-theorem compatible_of_none {a : α} (h : numberOf a = none) (b : β) :
-    Compatible a b := by
-  show Compat (α := Flat Number) (numberOf a) (numberOf b)
-  rw [h]; exact bot_compat _
-
 end HasNumber
 
 /-- φ-compatibility entails number compatibility: the `HasNumber` mixin never
@@ -75,7 +65,4 @@ end HasNumber
 theorem UD.MorphFeatures.compatible_hasNumber {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasNumber.Compatible f1 f2 :=
-  Features.compat_of_clause Number.fromUD <| by
-    unfold UD.MorphFeatures.compatible at h
-    simp only [Bool.and_eq_true] at h
-    tauto
+  Features.compat_of_clause Number.fromUD (UD.MorphFeatures.compatible_number h)

--- a/Linglib/Features/Person/Capabilities.lean
+++ b/Linglib/Features/Person/Capabilities.lean
@@ -40,15 +40,6 @@ variable {α β : Type*} [HasPerson α] [HasPerson β]
 abbrev Compatible (a : α) (b : β) : Prop :=
   Compat (α := Flat Person) (personOf a) (personOf b)
 
-theorem compatible_comm {a : α} {b : β} (h : Compatible a b) :
-    Compatible b a :=
-  h.symm
-
-theorem compatible_of_none {a : α} (h : personOf a = none) (b : β) :
-    Compatible a b := by
-  show Compat (α := Flat Person) (personOf a) (personOf b)
-  rw [h]; exact bot_compat _
-
 end HasPerson
 
 /-- φ-compatibility entails person compatibility: the `HasPerson` mixin
@@ -58,7 +49,4 @@ end HasPerson
 theorem UD.MorphFeatures.compatible_hasPerson {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasPerson.Compatible f1 f2 :=
-  Features.compat_of_clause_map Person.fromUD <| by
-    unfold UD.MorphFeatures.compatible at h
-    simp only [Bool.and_eq_true] at h
-    tauto
+  Features.compat_of_clause_map Person.fromUD (UD.MorphFeatures.compatible_person h)

--- a/Linglib/Syntax/DependencyGrammar/Formal/Government.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/Government.lean
@@ -99,15 +99,21 @@ def englishGovRequirements : List GovRequirement :=
 
 /-- Does the word `w` carry the value `reqVal` of feature `feat`?
     Returns `true` when the relevant feature slot is unspecified
-    (vacuous satisfaction). -/
+    (vacuous satisfaction); a *marked* slot whose value differs from the
+    requirement fails. -/
 def matchGovFeature (w : Word) (feat : GovernedFeature) (reqVal : GovernedValue) : Bool :=
   match feat with
   | .Case =>
-    match w.features.case_ with
-    | some .Acc => reqVal = .acc
-    | some .Nom => reqVal = .nom
-    | some .Gen => reqVal = .gen
-    | _ => true
+    -- Route case extraction through the `HasCase` mixin (analytical
+    -- inventory), not raw UD constructors. An unmarked slot is vacuously
+    -- satisfied; a marked case that differs from the requirement fails — so
+    -- e.g. a dative object does *not* satisfy an accusative requirement.
+    match HasCase.caseOf w, reqVal with
+    | none, _ => true
+    | some c, .acc => c = .acc
+    | some c, .nom => c = .nom
+    | some c, .gen => c = .gen
+    | some _, _ => true
   | .VForm =>
     match w.features.verbForm with
     | some .Inf => reqVal = .infinitive
@@ -169,6 +175,16 @@ def exWithHe : DepTree :=
     deps := [⟨0, 1, .obj⟩]
     rootIdx := 0 }
 
+/-- Regression guard for `matchGovFeature`: a preposition's `obj` bearing a
+    *marked* case other than the required accusative (here dative) violates
+    government. The earlier checker fell through to `true` for any case outside
+    {nom, acc, gen}, so a dative object spuriously satisfied `govPrepAcc`. -/
+def exPrepDatObj : DepTree :=
+  { words := [ { form :="with", cat := .ADP, features := {}}
+             , { form :="X", cat := .PRON, features := { case_ := some .Dat }} ]
+    deps := [⟨0, 1, .obj⟩]
+    rootIdx := 0 }
+
 /-! ### Checker behaviour on the fixtures -/
 
 theorem withHim_govOk :
@@ -176,6 +192,9 @@ theorem withHim_govOk :
 
 theorem withHe_govFail :
     checkGovernment exWithHe [govPrepAcc] = false := by decide
+
+theorem prepDatObj_govFail :
+    checkGovernment exPrepDatObj [govPrepAcc] = false := by decide
 
 theorem wantsToGo_govOk :
     checkGovernment exSheWantsToGo [govVerbInfinitive] = true := by decide


### PR DESCRIPTION
Factor `UD.MorphFeatures.compatible` into per-slot projection lemmas next to its definition and consume them from the φ-feature capability mixins; fix a case-government bug surfaced en route.

- Add `MorphFeatures.compatible_{number,gender,case,person}` (one site coupled to the conjunction's clause layout); rewire the four `HasX.compatible_hasX` faithfulness theorems to one-line `exact`s, dropping the per-file `unfold; simp only; tauto`.
- Delete dead `compatible_comm`/`compatible_of_none` across the four capability files — renames of `Compat.symm`/`bot_compat` with zero consumers (reachable directly through the `Compatible` abbrev).
- Fix `DepGrammar.Government.matchGovFeature`: route case extraction through `HasCase.caseOf` and make a *marked* case that differs from the requirement fail — previously any case outside {nom,acc,gen} vacuously satisfied government (a dative object passed an accusative requirement). Adds a `prepDatObj_govFail` regression guard.