### PR TITLE
feat(Core/Computability): star-free language class + SL ⊆ SF

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1909,8 +1909,10 @@ import Linglib.Core.Computability.NonRegular.AnBn
 import Linglib.Core.Computability.ContextFreeGrammar.Closure
 import Linglib.Core.Computability.ContextFreeGrammar.Weighted
 import Linglib.Core.Algebra.Free
+import Linglib.Core.Algebra.Group.Aperiodic
 import Linglib.Core.Algebra.Group.Idempotent
 import Linglib.Core.Algebra.IdempotentPower
+import Linglib.Core.Computability.StarFree
 import Linglib.Core.Computability.TransitionMonoid
 import Linglib.Core.Computability.SyntacticMonoid
 import Linglib.Core.Computability.Subregular.Language.Algebra.Equations

--- a/Linglib/Core/Algebra/Group/Aperiodic.lean
+++ b/Linglib/Core/Algebra/Group/Aperiodic.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.Group.Prod
+import Mathlib.Data.Nat.Init
+import Mathlib.Order.MinMax
 
 /-!
 # Aperiodic monoids
@@ -16,6 +18,16 @@ of the star-free / counter-free / `FO[<]`-definable languages ([pin-mfa],
 
 `[UPSTREAM]`: mathlib has `Monoid.IsTorsion` but no aperiodicity notion; this is a
 candidate for `Mathlib/Algebra/Group/`.
+
+## Main results
+
+* `Monoid.IsAperiodic.of_subsingleton` — subsingleton monoids are aperiodic.
+* `Monoid.IsAperiodic.pow_stabilizes` — once a stabilising power is reached, all higher
+  powers stabilise too.
+* `Monoid.IsAperiodic.of_surjective` — aperiodicity passes along surjective homs.
+* `Monoid.IsAperiodic.of_injective` — aperiodicity is inherited by submonoids.
+* `Monoid.IsAperiodic.prod` — a product of aperiodic monoids is aperiodic.
+* `Monoid.IsAperiodic.of_mulEquiv` — aperiodicity transports across isomorphisms.
 -/
 
 namespace Monoid
@@ -32,5 +44,40 @@ variable {M}
 /-- A subsingleton monoid is aperiodic (take `n = 0`). -/
 theorem IsAperiodic.of_subsingleton [Subsingleton M] : IsAperiodic M :=
   ⟨0, fun _ => Subsingleton.elim _ _⟩
+
+/-- If `x ^ (n + 1) = x ^ n` then the power stabilises at every `m ≥ n`. -/
+theorem IsAperiodic.pow_stabilizes {x : M} {n : ℕ} (h : x ^ (n + 1) = x ^ n) :
+    ∀ m, n ≤ m → x ^ (m + 1) = x ^ m := by
+  refine fun m hm => Nat.le_induction h (fun k _ hk => ?_) m hm
+  rw [pow_succ x (k + 1), hk, ← pow_succ, hk]
+
+/-- Aperiodicity passes along a surjective monoid hom: the same exponent works for the image. -/
+theorem IsAperiodic.of_surjective {N : Type*} [Monoid N] {f : M →* N}
+    (hf : Function.Surjective f) (hM : IsAperiodic M) : IsAperiodic N := by
+  obtain ⟨n, hn⟩ := hM
+  refine ⟨n, fun y => ?_⟩
+  obtain ⟨x, rfl⟩ := hf y
+  rw [← map_pow, ← map_pow, hn]
+
+/-- Aperiodicity is inherited by submonoids: if `f : M →* N` is injective and `N` is aperiodic
+then so is `M` (the same exponent works, pulled back through `f`). -/
+theorem IsAperiodic.of_injective {N : Type*} [Monoid N] {f : M →* N}
+    (hf : Function.Injective f) (hN : IsAperiodic N) : IsAperiodic M := by
+  obtain ⟨n, hn⟩ := hN
+  exact ⟨n, fun x => hf (by rw [map_pow, map_pow, hn])⟩
+
+/-- A binary product of aperiodic monoids is aperiodic (take the larger exponent). -/
+theorem IsAperiodic.prod {N : Type*} [Monoid N] (hM : IsAperiodic M) (hN : IsAperiodic N) :
+    IsAperiodic (M × N) := by
+  obtain ⟨nM, hnM⟩ := hM
+  obtain ⟨nN, hnN⟩ := hN
+  refine ⟨max nM nN, fun x => Prod.ext ?_ ?_⟩
+  · exact pow_stabilizes (hnM x.1) _ (le_max_left _ _)
+  · exact pow_stabilizes (hnN x.2) _ (le_max_right _ _)
+
+/-- Aperiodicity transports across a monoid isomorphism. -/
+theorem IsAperiodic.of_mulEquiv {N : Type*} [Monoid N] (e : M ≃* N) (hM : IsAperiodic M) :
+    IsAperiodic N :=
+  hM.of_surjective (f := e.toMonoidHom) e.surjective
 
 end Monoid

--- a/Linglib/Core/Algebra/Group/Aperiodic.lean
+++ b/Linglib/Core/Algebra/Group/Aperiodic.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Algebra.Group.Defs
+
+/-!
+# Aperiodic monoids
+
+A monoid is **aperiodic** (group-free) when some power stabilises every element:
+`∃ n, ∀ x, x ^ (n + 1) = x ^ n`. [schutzenberger-1965] introduced these as the monoids
+with only trivial subgroups (his condition `γ fⁿ = γ fⁿ⁺¹`); they are the algebraic side
+of the star-free / counter-free / `FO[<]`-definable languages ([pin-mfa],
+[mcnaughton-papert-1971]).
+
+`[UPSTREAM]`: mathlib has `Monoid.IsTorsion` but no aperiodicity notion; this is a
+candidate for `Mathlib/Algebra/Group/`.
+-/
+
+namespace Monoid
+
+variable (M : Type*) [Monoid M]
+
+/-- A monoid is **aperiodic** when some uniform power stabilises every element:
+`∃ n, ∀ x, x ^ (n + 1) = x ^ n` — equivalently, it has only trivial subgroups
+([schutzenberger-1965]). -/
+def IsAperiodic : Prop := ∃ n : ℕ, ∀ x : M, x ^ (n + 1) = x ^ n
+
+variable {M}
+
+/-- A subsingleton monoid is aperiodic (take `n = 0`). -/
+theorem IsAperiodic.of_subsingleton [Subsingleton M] : IsAperiodic M :=
+  ⟨0, fun _ => Subsingleton.elim _ _⟩
+
+end Monoid

--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -113,4 +113,32 @@ theorem IsStarFree.union {M : Language α} (hL : L.IsStarFree) (hM : M.IsStarFre
   rw [show L ⊔ M = (Lᶜ ⊓ Mᶜ)ᶜ by rw [compl_inf, compl_compl, compl_compl]]
   exact (hL.compl.inter hM.compl).compl
 
+/-! ### Recognition by a finite aperiodic monoid -/
+
+/-- **A language recognized by a finite aperiodic monoid is star-free** — the algebraic
+characterization of star-free ([schutzenberger-1965]). When `η : FreeMonoid α →* M` with `M`
+finite and aperiodic and `L = η ⁻¹' P`, the syntactic congruence is coarser than `ker η`
+(`η`-equal words share every context), so `L.syntacticMonoid` is a quotient of a submonoid of
+`M` — hence finite and aperiodic. This is the engine for placing a constraint class inside
+`SF`: exhibit a finite aperiodic recognizer. -/
+theorem IsStarFree.of_recognizes {M : Type*} [Monoid M] [Finite M]
+    (hM : Monoid.IsAperiodic M) (η : FreeMonoid α →* M) (P : Set M)
+    (hL : ∀ w : List α, w ∈ L ↔ η (FreeMonoid.ofList w) ∈ P) : L.IsStarFree := by
+  have hle : Con.ker η ≤ L.syntacticCon := by
+    rw [Con.le_def]
+    intro u v huv x y
+    rw [Con.ker_apply] at huv
+    rw [hL, hL, show η (FreeMonoid.ofList (x ++ u.toList ++ y))
+      = η (FreeMonoid.ofList (x ++ v.toList ++ y)) by
+        simp only [FreeMonoid.ofList_append, map_mul, FreeMonoid.ofList_toList, huv]]
+  have hker : Monoid.IsAperiodic (Con.ker η).Quotient :=
+    (hM.of_injective (MonoidHom.mrange η).subtype_injective).of_mulEquiv
+      (Con.quotientKerEquivRange η).symm
+  have hfin : Finite (Con.ker η).Quotient :=
+    Finite.of_equiv _ (Con.quotientKerEquivRange η).symm.toEquiv
+  have hsurj : Function.Surjective (Con.map (Con.ker η) L.syntacticCon hle) := fun y => by
+    obtain ⟨a, rfl⟩ := Con.mk'_surjective y; exact ⟨(Con.ker η).mk' a, rfl⟩
+  exact ⟨isRegular_of_finite_syntacticMonoid (Finite.of_surjective _ hsurj),
+    hker.of_surjective hsurj⟩
+
 end Language

--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Computability.SyntacticMonoid
+import Linglib.Core.Algebra.Group.Aperiodic
+
+/-!
+# Star-free languages
+
+A language is **star-free** when its syntactic monoid is finite and aperiodic
+([schutzenberger-1965]) — the algebraic characterization of the star-free regular
+expressions (built from finite sets by `∪`, `·`, complement, *no* Kleene star),
+equivalently the counter-free / `FO[<]`-definable stringsets ([mcnaughton-papert-1971]).
+Taking the syntactic-monoid characterization as the definition mirrors the project's
+treatment of regularity (`Language.isRegular_iff_finite_syntacticMonoid`).
+
+## Main definitions
+
+* `Language.IsStarFree` — regular with an aperiodic syntactic monoid.
+
+## Main results
+
+* `Language.IsStarFree.compl` — star-free languages are closed under complement.
+-/
+
+namespace Language
+
+variable {α : Type*} {L : Language α}
+
+/-- A language is **star-free** when it is regular and its syntactic monoid is aperiodic
+([schutzenberger-1965]). Star-free = `FO[<]`-definable = counter-free
+([mcnaughton-papert-1971]). -/
+def IsStarFree (L : Language α) : Prop :=
+  L.IsRegular ∧ Monoid.IsAperiodic L.syntacticMonoid
+
+theorem IsStarFree.isRegular (h : L.IsStarFree) : L.IsRegular := h.1
+
+theorem IsStarFree.isAperiodic (h : L.IsStarFree) :
+    Monoid.IsAperiodic L.syntacticMonoid := h.2
+
+/-- The syntactic congruence is complement-invariant: a two-sided context distinguishes
+`u` from `v` for `L` exactly when it does for `Lᶜ`. -/
+theorem syntacticCon_compl (L : Language α) : Lᶜ.syntacticCon = L.syntacticCon :=
+  Con.ext fun u v => by
+    rw [syntacticCon_iff, syntacticCon_iff]
+    exact forall_congr' fun _ => forall_congr' fun _ => not_iff_not
+
+/-- The syntactic monoid is complement-invariant. -/
+theorem syntacticMonoid_compl (L : Language α) : Lᶜ.syntacticMonoid = L.syntacticMonoid := by
+  unfold syntacticMonoid; rw [syntacticCon_compl]
+
+/-- **Star-free languages are closed under complement** — immediate from the
+complement-invariance of the syntactic monoid (`syntacticMonoid_compl`) and of regularity
+(`Language.IsRegular.compl`). -/
+theorem IsStarFree.compl (h : L.IsStarFree) : Lᶜ.IsStarFree := by
+  refine ⟨h.1.compl, ?_⟩
+  show Monoid.IsAperiodic (syntacticCon Lᶜ).Quotient
+  rw [syntacticCon_compl]
+  exact h.2
+
+end Language

--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -23,6 +23,8 @@ treatment of regularity (`Language.isRegular_iff_finite_syntacticMonoid`).
 ## Main results
 
 * `Language.IsStarFree.compl` — star-free languages are closed under complement.
+* `Language.IsStarFree.inter` — star-free languages are closed under intersection (`⊓`).
+* `Language.IsStarFree.union` — star-free languages are closed under union (`⊔`, via De Morgan).
 -/
 
 namespace Language
@@ -59,5 +61,56 @@ theorem IsStarFree.compl (h : L.IsStarFree) : Lᶜ.IsStarFree := by
   show Monoid.IsAperiodic (syntacticCon Lᶜ).Quotient
   rw [syntacticCon_compl]
   exact h.2
+
+/-! ### Closure under intersection and union
+
+`Language α` carries its `BooleanAlgebra`, so intersection/union are the lattice meet/join
+`⊓`/`⊔` (defeq to set intersection/union); these are the forms `Language.IsRegular.inf` uses. -/
+
+variable (L) in
+/-- The meet of the two syntactic congruences refines that of the intersection: if no `L`-context
+and no `M`-context distinguishes `u` from `v`, then no `(L ⊓ M)`-context does either. -/
+theorem inf_syntacticCon_le_syntacticCon_inf (M : Language α) :
+    L.syntacticCon ⊓ M.syntacticCon ≤ (L ⊓ M).syntacticCon := by
+  rw [Con.le_def]
+  intro u v huv x y
+  rw [Con.inf_iff_and, syntacticCon_iff, syntacticCon_iff] at huv
+  exact and_congr (huv.1 x y) (huv.2 x y)
+
+variable (L) in
+/-- The kernel of the pairing of the two syntactic morphisms is exactly the meet of the two
+syntactic congruences (a word's class in the product is the pair of its classes). -/
+theorem ker_prod_toSyntacticMonoid (M : Language α) :
+    Con.ker ((L.toSyntacticMonoid).prod M.toSyntacticMonoid) =
+      L.syntacticCon ⊓ M.syntacticCon :=
+  Con.ext fun u v => by
+    rw [Con.ker_apply, MonoidHom.prod_apply, MonoidHom.prod_apply, Prod.ext_iff,
+      toSyntacticMonoid_eq_iff, toSyntacticMonoid_eq_iff, Con.inf_iff_and]
+
+/-- **Star-free languages are closed under intersection.** The syntactic monoid of `L ⊓ M`
+is a quotient of a submonoid of `L.syntacticMonoid × M.syntacticMonoid`, which is aperiodic
+(`Monoid.IsAperiodic.prod`); regularity is `Language.IsRegular.inf`. -/
+theorem IsStarFree.inter {M : Language α} (hL : L.IsStarFree) (hM : M.IsStarFree) :
+    (L ⊓ M).IsStarFree := by
+  refine ⟨hL.1.inf hM.1, ?_⟩
+  set φ := (L.toSyntacticMonoid).prod M.toSyntacticMonoid with hφ
+  -- The product is aperiodic, hence so is its range submonoid, hence `(Con.ker φ).Quotient`.
+  have hprod : Monoid.IsAperiodic (L.syntacticMonoid × M.syntacticMonoid) := hL.2.prod hM.2
+  have hrange : Monoid.IsAperiodic (MonoidHom.mrange φ) :=
+    hprod.of_injective (MonoidHom.mrange φ).subtype_injective
+  have hker : Monoid.IsAperiodic (Con.ker φ).Quotient :=
+    hrange.of_mulEquiv (Con.quotientKerEquivRange φ).symm
+  -- The quotient map for `Con.ker φ ≤ (L ⊓ M).syntacticCon` is surjective.
+  have hle : Con.ker φ ≤ (L ⊓ M).syntacticCon := by
+    rw [hφ, ker_prod_toSyntacticMonoid]; exact inf_syntacticCon_le_syntacticCon_inf L M
+  refine hker.of_surjective (f := Con.map (Con.ker φ) _ hle) (fun y => ?_)
+  obtain ⟨a, rfl⟩ := Con.mk'_surjective y
+  exact ⟨(Con.ker φ).mk' a, rfl⟩
+
+/-- **Star-free languages are closed under union** — by De Morgan, `L ⊔ M = (Lᶜ ⊓ Mᶜ)ᶜ`. -/
+theorem IsStarFree.union {M : Language α} (hL : L.IsStarFree) (hM : M.IsStarFree) :
+    (L ⊔ M).IsStarFree := by
+  rw [show L ⊔ M = (Lᶜ ⊓ Mᶜ)ᶜ by rw [compl_inf, compl_compl, compl_compl]]
+  exact (hL.compl.inter hM.compl).compl
 
 end Language

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -31848,6 +31848,21 @@
   role      = {foundational}
 }
 
+% REF: Schützenberger (1965). On finite monoids having only trivial subgroups.
+% Information and Control 8(2), 190-194. (Star-free = aperiodic syntactic monoid.)
+@article{schutzenberger-1965,
+  author    = {Schützenberger, Marcel-Paul},
+  year      = {1965},
+  title     = {On finite monoids having only trivial subgroups},
+  journal   = {Information and Control},
+  volume    = {8},
+  number    = {2},
+  pages     = {190--194},
+  doi       = {10.1016/S0019-9958(65)90108-7},
+  subfield  = {phonology/subregular},
+  role      = {foundational}
+}
+
 % REF: Kleene (1951). Representation of events in nerve nets and finite
 % automata. RAND Research Memorandum RM-704.
 @techreport{kleene-1951,


### PR DESCRIPTION
The star-free (`SF`) class linglib (and mathlib) lacked, its closure algebra, the recognition characterization, and the first hierarchy inclusion — built on the existing `SyntacticMonoid`.

**Aperiodic monoids** (`Core/Algebra/Group/Aperiodic.lean`, `[UPSTREAM]`): `Monoid.IsAperiodic M := ∃ n, ∀ x, x^(n+1) = x^n` — [schutzenberger-1965]'s 'only trivial subgroups'. Toolkit: `of_surjective`, `of_injective`, `prod`, `of_mulEquiv`, `pow_stabilizes`.

**Star-free languages** (`Core/Computability/StarFree.lean`): `IsStarFree L := L.IsRegular ∧ Monoid.IsAperiodic L.syntacticMonoid` ([schutzenberger-1965]; = `FO[<]`/counter-free, [mcnaughton-papert-1971]).
- **Boolean algebra**: closed under `ᶜ`, `⊓`, `⊔`.
- **`of_recognizes`**: recognized by a finite aperiodic monoid ⟹ star-free (the Schützenberger algebraic characterization; the reduction engine).

**`IsStrictlyLocal.isStarFree`** (`Core/.../StrictlyLocalStarFree.lean`): **SL_k ⊆ SF** over a finite alphabet — the local window-scanner (last `k-1` symbols) is a finite aperiodic recognizer (aperiodic because it forgets old symbols, so `vⁿ`'s action stabilises for `n ≥ k-1`), fed to `of_recognizes`. `[Finite α]` essential. Validates the engine end-to-end and plants the 'hierarchy ⊆ SF' backdrop for the Jardine placement.

Adds the verified `schutzenberger-1965` reference. Axiom-clean throughout.