### PR TITLE
feat(Studies/Kalin2018): Senaya DOM + divergence from Marantz

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1586,6 +1586,7 @@ import Linglib.Studies.ODonnell2015
 import Linglib.Studies.Bybee1985
 import Linglib.Studies.ZwickyPullum1983
 import Linglib.Studies.KalinBjorkmanEtAl2026
+import Linglib.Studies.Kalin2018
 import Linglib.Studies.Baker1985
 import Linglib.Studies.HalleMarantz1993
 import Linglib.Studies.Halpert2012

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2159,6 +2159,7 @@ import Linglib.Syntax.Minimalist.Phi.Articulation
 import Linglib.Syntax.Minimalist.PConstraint
 import Linglib.Syntax.Minimalist.ObligatoryOperations
 import Linglib.Syntax.Case.Alignment
+import Linglib.Syntax.Case.Assigner
 import Linglib.Syntax.Case.Filter
 import Linglib.Syntax.Case.Dependent
 import Linglib.Syntax.Case.Licensing

--- a/Linglib/Studies/Kalin2018.lean
+++ b/Linglib/Studies/Kalin2018.lean
@@ -1,0 +1,128 @@
+import Linglib.Syntax.Case.Assigner
+
+/-!
+# Kalin (2018) — Licensing and Differential Object Marking
+[kalin-2018] [marantz-1991]
+
+[kalin-2018] derives differential object marking (DOM) from nominal
+*licensing* rather than object visibility, raising, or differentiation. Two
+parameters interact: (i) which nominals *require* licensing (in Senaya, only
+*specific* ones), and (ii) where the licensers are — every clause has one
+obligatory **primary** licenser (always merged, licensing the closest
+nominal) plus **secondary** licensers that merge only as a last resort, when
+their absence would leave some needy nominal unlicensed. DOM is the visible
+signature of a secondary licenser activating.
+
+The motivating data are from the Neo-Aramaic language **Senaya**, where DOM
+surfaces as differential verbal *agreement* (an L-suffix), not case — and
+[kalin-2018] argues case and agreement are two reflexes of one licensing
+process, so we model the agreement marking abstractly through the licensing
+substrate's outcome (`Syntax/Case/Licensing.lean`). The Senaya facts (paper
+examples around the object-agreement and aspect-split data): a *specific*
+object triggers agreement, a *nonspecific* one does not, and — the crux — in
+the **perfective** base the object position is *unlicensed*, so a specific
+object (which needs licensing) is banned there entirely.
+
+That perfective ban is [kalin-2018]'s argument *against* a no-licensing view
+of case ([marantz-1991], [preminger-2014]): if nominals never needed abstract
+licensing, the ban would be unexplained. The flagship theorem below states
+this divergence formally, via the shared `Assigner` harness
+(`Syntax/Case/Assigner.lean`): on the perfective object, a Marantz-style
+total configurational account assigns a case, while Kalin licensing crashes —
+the two accounts disagree precisely where licensing is unavailable.
+-/
+
+namespace Kalin2018
+
+open Syntax.Case
+open Syntax.Case.Licensing (ClauseLicensers Licenser LicensingOutcome LicensedNP
+  licenseNPs getOutcomeOf)
+
+/-! ### Senaya clause configurations
+
+The aspect split as licenser availability: the imperfective base offers a
+secondary licenser for a specific object (yielding DOM agreement); the
+perfective base offers none (so a specific object cannot be licensed). The
+`assignedCase` fields abstract the agreement marking — `nom` for the primary
+(subject) relation, `acc` for the object relation. -/
+
+/-- Imperfective base: a secondary licenser is available for a specific
+    object. -/
+def imperfectiveClause : ClauseLicensers :=
+  { primary := { kind := .primary, head := "Asp.ipfv", assignedCase := .nom }
+  , secondaries := [{ kind := .secondary, head := "v", assignedCase := .acc }] }
+
+/-- Perfective base: no secondary licenser — the object position is
+    unlicensed ([kalin-2018]'s central Senaya claim). -/
+def perfectiveClause : ClauseLicensers :=
+  { primary := { kind := .primary, head := "Asp.pfv", assignedCase := .nom }
+  , secondaries := [] }
+
+/-- A transitive clause with a **specific** object: both nominals carry the
+    licensing requirement. -/
+def specificObjectClause : List LicensedNP :=
+  [ { label := "subj", lexicalCase := none, needsLicensing := true }
+  , { label := "obj",  lexicalCase := none, needsLicensing := true } ]
+
+/-- A transitive clause with a **nonspecific** object: the object lacks the
+    licensing requirement, so it is interpretable in situ. -/
+def nonspecificObjectClause : List LicensedNP :=
+  [ { label := "subj", lexicalCase := none, needsLicensing := true }
+  , { label := "obj",  lexicalCase := none, needsLicensing := false } ]
+
+/-! ### The Senaya DOM pattern -/
+
+/-- Imperfective: a specific object is licensed by the secondary licenser,
+    surfacing as DOM agreement. -/
+theorem specificObject_licensed_imperfective :
+    getOutcomeOf "obj" (licenseNPs imperfectiveClause specificObjectClause)
+      = some (.bySecondary "v" .acc) := by decide
+
+/-- Perfective: a specific object **cannot be licensed** (no secondary
+    licenser available) and crashes — Senaya's ban on specific objects in
+    the perfective base. -/
+theorem specificObject_unlicensed_perfective :
+    getOutcomeOf "obj" (licenseNPs perfectiveClause specificObjectClause)
+      = some .unlicensed := by decide
+
+/-- A nonspecific object does not need licensing, so it is fine in the
+    perfective (licensed trivially by the primary, no DOM marking). -/
+theorem nonspecificObject_fine_perfective :
+    getOutcomeOf "obj" (licenseNPs perfectiveClause nonspecificObjectClause)
+      = some (.byPrimary "Asp.pfv" .nom) := by decide
+
+/-- Subjects are *not* differential: the closest nominal to the obligatory
+    primary licenser is always licensed, in either aspect. -/
+theorem subject_always_licensed :
+    getOutcomeOf "subj" (licenseNPs perfectiveClause specificObjectClause)
+      = some (.byPrimary "Asp.pfv" .nom) ∧
+    getOutcomeOf "subj" (licenseNPs imperfectiveClause specificObjectClause)
+      = some (.byPrimary "Asp.ipfv" .nom) := by
+  exact ⟨by decide, by decide⟩
+
+/-! ### The flagship divergence: licensing vs. no-licensing -/
+
+/-- On the perfective object, the two accounts assign **incompatible
+    verdicts**: a Marantz-style total configurational account gives it a
+    structural accusative, while Kalin licensing crashes it (`uncased`,
+    caseless). This is the witness behind the divergence. -/
+theorem perfective_object_verdicts :
+    dependentAssigner .accusative specificObjectClause "obj"
+      = some ⟨.structural, some .acc⟩ ∧
+    kalinAssigner perfectiveClause specificObjectClause "obj"
+      = some ⟨.uncased, none⟩ := by
+  exact ⟨by decide, by decide⟩
+
+/-- **Licensing diverges from total configurational case assignment**
+    ([kalin-2018] vs [marantz-1991]). The two accounts disagree on the
+    surface case of the perfective object: the dependent-case account assigns
+    it accusative (case assignment is total — it never crashes), whereas
+    Kalin licensing leaves it unlicensed. [kalin-2018]'s point: under a
+    no-licensing view the perfective ban on specific objects is unexplained;
+    under licensing it follows, because the perfective object position offers
+    no licenser. -/
+theorem dependentCase_vs_licensing_diverge_on_perfective_object :
+    ¬ AgreesOnCase (dependentAssigner .accusative)
+        (kalinAssigner perfectiveClause) specificObjectClause := by decide
+
+end Kalin2018

--- a/Linglib/Syntax/Case/Assigner.lean
+++ b/Linglib/Syntax/Case/Assigner.lean
@@ -1,0 +1,113 @@
+import Linglib.Features.Case.Source
+import Linglib.Syntax.Case.Dependent
+import Linglib.Syntax.Case.Licensing
+
+/-!
+# Case assigners — one signature for comparing rival theories
+[marantz-1991] [kalin-2018]
+
+The rival accounts of case assignment (`Dependent.lean`, `Licensing.lean`)
+each run on their own input type and produce their own result type, so they
+cannot be applied to a *common* stimulus — which is exactly what comparing
+them requires. This file gives them one shared signature.
+
+* The shared stimulus is `List LicensedNP` — the richest of the rivals'
+  inputs (`LicensedNP extends NPInDomain`), so a configural account reads its
+  `NPInDomain` projection and ignores `needsLicensing`, while a licensing
+  account reads the whole thing.
+* An `Assigner` maps that stimulus to a per-label `Verdict` (a surface case
+  plus its neutral `Case.Source` provenance). This is the `Predict`-style
+  function signature, *not* a typeclass: rivals are ordinary `def`s, so two
+  accounts with the same input/output types coexist (which a typeclass could
+  not host).
+* `AgreesOnCase` / `AgreesOnSource` compare two accounts per projection.
+  Divergence is the negation, witnessed by a stimulus — generalizing the
+  `agree_on_…`/`diverge_on_…` pattern of `Studies/Woolford1997.lean` and
+  `Studies/Baker2015.lean`.
+
+The Chomskyan Case Filter (`Syntax/Case/Filter.lean`) is a *checker*, not an
+assigner, and is bridged separately. The paper-anchored dependent-case ⟺
+licensing DOM divergence belongs in the later paper's study file
+(`Studies/Kalin2018.lean`); the `example`s here only validate that the harness
+is non-vacuous.
+-/
+
+namespace Syntax.Case
+
+open Licensing (LicensedNP ClauseLicensers Licenser licenseNPs LicensingOutcome)
+
+/-- What a case account predicts for one nominal: its surface case (`none`
+    exactly when the provenance is the crash `uncased`) and its neutral
+    `Case.Source` provenance. -/
+structure Verdict where
+  source : _root_.Case.Source
+  surfaceCase : Option _root_.Case
+  deriving DecidableEq, Repr
+
+/-- A case-assignment account as a function from the shared stimulus to a
+    per-label verdict (`none` = no nominal with that label). The signature
+    that makes rival theories runnable on one input. -/
+abbrev Assigner := List LicensedNP → String → Option Verdict
+
+/-- Marantz dependent case as an `Assigner`: it reads the configural
+    projection (`needsLicensing` ignored) and is total, so it never produces
+    the crash `uncased`. -/
+def dependentAssigner (lang : CaseLanguageType) : Assigner := fun nps label =>
+  ((assignCases lang (nps.map (·.toNPInDomain))).find? (·.label == label)).map
+    fun r => ⟨r.source.toNeutral, some r.case⟩
+
+/-- Kalin hybrid licensing as an `Assigner`: an unlicensed nominal crashes to
+    `⟨uncased, none⟩`. -/
+def kalinAssigner (cl : ClauseLicensers) : Assigner := fun nps label =>
+  ((licenseNPs cl nps).find? (·.label == label)).map
+    fun r => ⟨r.outcome.toNeutral, r.outcome.assignedCase⟩
+
+/-- Two accounts agree on the **surface case** of every nominal in the
+    stimulus. -/
+def AgreesOnCase (a b : Assigner) (nps : List LicensedNP) : Prop :=
+  ∀ np ∈ nps, (a nps np.label).map Verdict.surfaceCase
+            = (b nps np.label).map Verdict.surfaceCase
+
+/-- Two accounts agree on the **provenance** of every nominal in the
+    stimulus. Two accounts can agree on case yet diverge here. -/
+def AgreesOnSource (a b : Assigner) (nps : List LicensedNP) : Prop :=
+  ∀ np ∈ nps, (a nps np.label).map Verdict.source
+            = (b nps np.label).map Verdict.source
+
+instance (a b : Assigner) (nps : List LicensedNP) : Decidable (AgreesOnCase a b nps) := by
+  unfold AgreesOnCase; infer_instance
+
+instance (a b : Assigner) (nps : List LicensedNP) : Decidable (AgreesOnSource a b nps) := by
+  unfold AgreesOnSource; infer_instance
+
+/-! ### Non-vacuity: the harness on a transitive clause
+
+A `[subj, obj]` transitive (both nominals active, no lexical case) in an
+accusative language with a Turkish-style primary-T / secondary-AGRO clause.
+Dependent case and hybrid licensing **agree on the surface case** (subj NOM,
+obj ACC) but **diverge on the provenance** of the subject — dependent case
+calls it `default` (unmarked last resort), licensing calls it `structural`
+(valued by primary T). The shape of the eventual `Studies/Kalin2018.lean`
+divergence, here only to confirm the harness is not vacuous. -/
+
+private def transitiveStimulus : List LicensedNP :=
+  [ { label := "subj", lexicalCase := none, needsLicensing := true }
+  , { label := "obj",  lexicalCase := none, needsLicensing := true } ]
+
+private def turkishLikeClause : ClauseLicensers :=
+  { primary := { kind := .primary, head := "T", assignedCase := .nom }
+  , secondaries := [{ kind := .secondary, head := "AGRO", assignedCase := .acc }] }
+
+example : dependentAssigner .accusative transitiveStimulus "obj"
+    = some ⟨.structural, some .acc⟩ := by decide
+
+example : kalinAssigner turkishLikeClause transitiveStimulus "obj"
+    = some ⟨.structural, some .acc⟩ := by decide
+
+example : AgreesOnCase (dependentAssigner .accusative)
+    (kalinAssigner turkishLikeClause) transitiveStimulus := by decide
+
+example : ¬ AgreesOnSource (dependentAssigner .accusative)
+    (kalinAssigner turkishLikeClause) transitiveStimulus := by decide
+
+end Syntax.Case


### PR DESCRIPTION
Keystone PR-3: the paper-anchored payoff — [kalin-2018]'s licensing account of Senaya DOM and its flagship divergence from a no-licensing (Marantz) view, via the `Assigner` harness. Also gives the previously-orphaned `Syntax/Case/Licensing.lean` its first Study consumer.

- Senaya as licenser availability: the imperfective base offers a secondary licenser for a specific object (DOM agreement); the perfective base offers none. Theorems: a specific object is licensed in the imperfective but **crashes** in the perfective (Senaya's ban), nonspecific objects are fine, and subjects are non-differential (always licensed by the primary). Senaya marks DOM by *agreement*, modeled abstractly via the licensing outcome (Kalin: case and agreement are two reflexes of one licensing process).
- `dependentCase_vs_licensing_diverge_on_perfective_object`: on the perfective object the two accounts give incompatible verdicts — Marantz-style total assignment gives accusative, Kalin licensing crashes (`uncased`). [kalin-2018]'s argument: under no-licensing the perfective ban is unexplained; under licensing it follows. Axiom-free.

Depends on #772 (the `Assigner` harness), which depends on #771 (`Case.Source`).