### PR TITLE
refactor(Core): mathlib-idiom polish on star-free + aperiodic

### DIFF
--- a/Linglib/Core/Algebra/Group/Aperiodic.lean
+++ b/Linglib/Core/Algebra/Group/Aperiodic.lean
@@ -22,7 +22,7 @@ candidate for `Mathlib/Algebra/Group/`.
 ## Main results
 
 * `Monoid.IsAperiodic.of_subsingleton` — subsingleton monoids are aperiodic.
-* `Monoid.IsAperiodic.pow_stabilizes` — once a stabilising power is reached, all higher
+* `Monoid.pow_succ_stabilizes` — once a stabilising power is reached, all higher
   powers stabilise too.
 * `Monoid.IsAperiodic.of_surjective` — aperiodicity passes along surjective homs.
 * `Monoid.IsAperiodic.of_injective` — aperiodicity is inherited by submonoids.
@@ -35,23 +35,27 @@ namespace Monoid
 variable (M : Type*) [Monoid M]
 
 /-- A monoid is **aperiodic** when some uniform power stabilises every element:
-`∃ n, ∀ x, x ^ (n + 1) = x ^ n` — equivalently, it has only trivial subgroups
-([schutzenberger-1965]). -/
+`∃ n, ∀ x, x ^ (n + 1) = x ^ n`. Introduced by [schutzenberger-1965] as the monoids with
+only trivial subgroups. -/
+@[to_additive]
 def IsAperiodic : Prop := ∃ n : ℕ, ∀ x : M, x ^ (n + 1) = x ^ n
 
 variable {M}
 
 /-- A subsingleton monoid is aperiodic (take `n = 0`). -/
+@[to_additive]
 theorem IsAperiodic.of_subsingleton [Subsingleton M] : IsAperiodic M :=
   ⟨0, fun _ => Subsingleton.elim _ _⟩
 
 /-- If `x ^ (n + 1) = x ^ n` then the power stabilises at every `m ≥ n`. -/
-theorem IsAperiodic.pow_stabilizes {x : M} {n : ℕ} (h : x ^ (n + 1) = x ^ n) :
+@[to_additive]
+theorem pow_succ_stabilizes {x : M} {n : ℕ} (h : x ^ (n + 1) = x ^ n) :
     ∀ m, n ≤ m → x ^ (m + 1) = x ^ m := by
   refine fun m hm => Nat.le_induction h (fun k _ hk => ?_) m hm
   rw [pow_succ x (k + 1), hk, ← pow_succ, hk]
 
 /-- Aperiodicity passes along a surjective monoid hom: the same exponent works for the image. -/
+@[to_additive]
 theorem IsAperiodic.of_surjective {N : Type*} [Monoid N] {f : M →* N}
     (hf : Function.Surjective f) (hM : IsAperiodic M) : IsAperiodic N := by
   obtain ⟨n, hn⟩ := hM
@@ -61,21 +65,24 @@ theorem IsAperiodic.of_surjective {N : Type*} [Monoid N] {f : M →* N}
 
 /-- Aperiodicity is inherited by submonoids: if `f : M →* N` is injective and `N` is aperiodic
 then so is `M` (the same exponent works, pulled back through `f`). -/
+@[to_additive]
 theorem IsAperiodic.of_injective {N : Type*} [Monoid N] {f : M →* N}
     (hf : Function.Injective f) (hN : IsAperiodic N) : IsAperiodic M := by
   obtain ⟨n, hn⟩ := hN
   exact ⟨n, fun x => hf (by rw [map_pow, map_pow, hn])⟩
 
 /-- A binary product of aperiodic monoids is aperiodic (take the larger exponent). -/
+@[to_additive]
 theorem IsAperiodic.prod {N : Type*} [Monoid N] (hM : IsAperiodic M) (hN : IsAperiodic N) :
     IsAperiodic (M × N) := by
   obtain ⟨nM, hnM⟩ := hM
   obtain ⟨nN, hnN⟩ := hN
   refine ⟨max nM nN, fun x => Prod.ext ?_ ?_⟩
-  · exact pow_stabilizes (hnM x.1) _ (le_max_left _ _)
-  · exact pow_stabilizes (hnN x.2) _ (le_max_right _ _)
+  · exact pow_succ_stabilizes (hnM x.1) _ (le_max_left _ _)
+  · exact pow_succ_stabilizes (hnN x.2) _ (le_max_right _ _)
 
 /-- Aperiodicity transports across a monoid isomorphism. -/
+@[to_additive]
 theorem IsAperiodic.of_mulEquiv {N : Type*} [Monoid N] (e : M ≃* N) (hM : IsAperiodic M) :
     IsAperiodic N :=
   hM.of_surjective (f := e.toMonoidHom) e.surjective

--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -9,7 +9,7 @@ import Linglib.Core.Algebra.Group.Aperiodic
 /-!
 # Star-free languages
 
-A language is **star-free** when its syntactic monoid is finite and aperiodic
+A language is **star-free** when it is regular with an aperiodic syntactic monoid
 ([schutzenberger-1965]) — the algebraic characterization of the star-free regular
 expressions (built from finite sets by `∪`, `·`, complement, *no* Kleene star),
 equivalently the counter-free / `FO[<]`-definable stringsets ([mcnaughton-papert-1971]).
@@ -103,9 +103,8 @@ theorem IsStarFree.inter {M : Language α} (hL : L.IsStarFree) (hM : M.IsStarFre
   -- The quotient map for `Con.ker φ ≤ (L ⊓ M).syntacticCon` is surjective.
   have hle : Con.ker φ ≤ (L ⊓ M).syntacticCon := by
     rw [hφ, ker_prod_toSyntacticMonoid]; exact inf_syntacticCon_le_syntacticCon_inf L M
-  refine hker.of_surjective (f := Con.map (Con.ker φ) _ hle) (fun y => ?_)
-  obtain ⟨a, rfl⟩ := Con.mk'_surjective y
-  exact ⟨(Con.ker φ).mk' a, rfl⟩
+  exact hker.of_surjective (f := Con.map (Con.ker φ) _ hle)
+    (Con.lift_surjective_of_surjective _ Con.mk'_surjective)
 
 /-- **Star-free languages are closed under union** — by De Morgan, `L ⊔ M = (Lᶜ ⊓ Mᶜ)ᶜ`. -/
 theorem IsStarFree.union {M : Language α} (hL : L.IsStarFree) (hM : M.IsStarFree) :
@@ -124,20 +123,15 @@ finite and aperiodic and `L = η ⁻¹' P`, the syntactic congruence is coarser 
 theorem IsStarFree.of_recognizes {M : Type*} [Monoid M] [Finite M]
     (hM : Monoid.IsAperiodic M) (η : FreeMonoid α →* M) (P : Set M)
     (hL : ∀ w : List α, w ∈ L ↔ η (FreeMonoid.ofList w) ∈ P) : L.IsStarFree := by
-  have hle : Con.ker η ≤ L.syntacticCon := by
-    rw [Con.le_def]
-    intro u v huv x y
-    rw [Con.ker_apply] at huv
-    rw [hL, hL, show η (FreeMonoid.ofList (x ++ u.toList ++ y))
-      = η (FreeMonoid.ofList (x ++ v.toList ++ y)) by
-        simp only [FreeMonoid.ofList_append, map_mul, FreeMonoid.ofList_toList, huv]]
+  have hle : Con.ker η ≤ L.syntacticCon :=
+    ker_le_syntacticCon_of_recognizes ⟨P, Set.ext hL⟩
   have hker : Monoid.IsAperiodic (Con.ker η).Quotient :=
     (hM.of_injective (MonoidHom.mrange η).subtype_injective).of_mulEquiv
       (Con.quotientKerEquivRange η).symm
   have hfin : Finite (Con.ker η).Quotient :=
     Finite.of_equiv _ (Con.quotientKerEquivRange η).symm.toEquiv
-  have hsurj : Function.Surjective (Con.map (Con.ker η) L.syntacticCon hle) := fun y => by
-    obtain ⟨a, rfl⟩ := Con.mk'_surjective y; exact ⟨(Con.ker η).mk' a, rfl⟩
+  have hsurj : Function.Surjective (Con.map (Con.ker η) L.syntacticCon hle) :=
+    Con.lift_surjective_of_surjective _ Con.mk'_surjective
   exact ⟨isRegular_of_finite_syntacticMonoid (Finite.of_surjective _ hsurj),
     hker.of_surjective hsurj⟩
 

--- a/Linglib/Core/Computability/Subregular/Language/StrictlyLocalStarFree.lean
+++ b/Linglib/Core/Computability/Subregular/Language/StrictlyLocalStarFree.lean
@@ -76,10 +76,6 @@ private noncomputable def scanDFA : DFA (Option α) (Option (Win α n)) where
   | nil => rfl
   | cons a xs ih => rw [DFA.evalFrom_cons]; simpa [step] using ih
 
-private lemma take_append_take {β : Type*} (X Y : List β) :
-    (X ++ Y.take n).take n = (X ++ Y).take n := by
-  rw [take_append, take_append, take_take, min_eq_left (by omega)]
-
 /-- Window after an alive run of `xs`: the reversed window is the last `n` symbols of
 `xs.reverse ++ w` (most recent first). -/
 private lemma evalFrom_alive_window (w : Win α n) (xs : List (Option α)) :
@@ -97,7 +93,8 @@ private lemma evalFrom_alive_window (w : Win α n) (xs : List (Option α)) :
       simpa using take_append_take n xs.reverse (a :: w.val)
 
 /-- A forbidden completed window: some `(n+1)`-factor of `S` is not permitted. -/
-private def BadF (S : List (Option α)) : Prop := ∃ f, f <:+: S ∧ f.length = n + 1 ∧ f ∉ G
+private def IsForbiddenWindow (S : List (Option α)) : Prop :=
+  ∃ f, f <:+: S ∧ f.length = n + 1 ∧ f ∉ G
 
 variable {β : Type*}
 
@@ -105,13 +102,6 @@ variable {β : Type*}
 private lemma scanned_step_lt (w : List β) (a : β) (xs : List β) (h : w.length < n) :
     (take n (a :: w)).reverse ++ xs = w.reverse ++ a :: xs := by
   rw [List.take_of_length_le (by simp; omega)]; simp
-
-/-- A nonempty infix is a prefix or an infix of the tail. -/
-private lemma infix_prefix_or_tail (f S : List β) (hf : f <:+: S) (hne : f ≠ []) :
-    f <+: S ∨ f <:+: S.tail := by
-  match S, hf with
-  | [], hf => exact absurd (List.eq_nil_of_infix_nil hf) hne
-  | _ :: _, hf => simpa using List.infix_cons_iff.mp hf
 
 /-- For a full window, the `(n+1)`-prefix of the scanned string is the completed window. -/
 private lemma take_prefix_full (w : List β) (a : β) (xs : List β) (h : w.length = n) :
@@ -134,7 +124,7 @@ private lemma scanned_step_eq (w : List β) (a : β) (xs : List β) (h : w.lengt
 /-- Dead-status: scanning `xs` from window `w` dies iff some forbidden `(n+1)`-window is
 completed — exactly the forbidden `(n+1)`-factors of `w.reverse ++ xs`. -/
 private lemma evalFrom_eq_none_iff (w : Win α n) (xs : List (Option α)) :
-    (scanDFA G n).evalFrom (some w) xs = none ↔ BadF G n (w.val.reverse ++ xs) := by
+    (scanDFA G n).evalFrom (some w) xs = none ↔ IsForbiddenWindow G n (w.val.reverse ++ xs) := by
   induction xs generalizing w with
   | nil =>
     simp only [DFA.evalFrom_nil, append_nil]
@@ -155,7 +145,8 @@ private lemma evalFrom_eq_none_iff (w : Win α n) (xs : List (Option α)) :
       exact List.prefix_append _ _
     · rename_i halive
       rw [ih]
-      show BadF G n ((take n (a :: w.val)).reverse ++ xs) ↔ BadF G n (w.val.reverse ++ a :: xs)
+      show IsForbiddenWindow G n ((take n (a :: w.val)).reverse ++ xs)
+        ↔ IsForbiddenWindow G n (w.val.reverse ++ a :: xs)
       rcases lt_or_eq_of_le w.2 with hlt | heq
       · rw [scanned_step_lt n w.val a xs hlt]
       · rw [scanned_step_eq n w.val a xs heq]
@@ -163,7 +154,12 @@ private lemma evalFrom_eq_none_iff (w : Win α n) (xs : List (Option α)) :
           by_contra hc; exact halive ⟨hc, by simpa using heq⟩
         refine ⟨fun ⟨f, hf, hlen, hbad⟩ => ⟨f, hf.trans (List.tail_suffix _).isInfix, hlen, hbad⟩,
           fun ⟨f, hf, hlen, hbad⟩ => ?_⟩
-        rcases infix_prefix_or_tail f _ hf (by rw [← List.length_pos_iff]; omega) with hpre | hinf
+        have hsplit : f <+: (w.val.reverse ++ a :: xs)
+            ∨ f <:+: (w.val.reverse ++ a :: xs).tail := by
+          match w.val.reverse ++ a :: xs, hf with
+          | [], hf => simp [List.eq_nil_of_infix_nil hf] at hlen
+          | _ :: _, hf => simpa using List.infix_cons_iff.mp hf
+        rcases hsplit with hpre | hinf
         · refine absurd ?_ hbad
           rw [List.prefix_iff_eq_take.mp hpre, hlen, take_prefix_full n w.val a xs heq]
           exact hgood
@@ -259,8 +255,10 @@ private noncomputable def scanHom : FreeMonoid α →* (scanDFA G n).transitionM
 private def startWin : Win α n := ⟨List.replicate n none, by simp⟩
 
 @[simp] private lemma scanHom_unop_apply (w : List α) (s : Option (Win α n)) :
-    ((scanHom G n (FreeMonoid.ofList w)).val.unop) s = (scanDFA G n).evalFrom s (w.map Option.some) := by
-  simp only [scanHom, MonoidHom.codRestrict_apply, MonoidHom.comp_apply, DFA.unop_transitionHom_apply]
+    ((scanHom G n (FreeMonoid.ofList w)).val.unop) s
+      = (scanDFA G n).evalFrom s (w.map Option.some) := by
+  simp only [scanHom, MonoidHom.codRestrict_apply, MonoidHom.comp_apply,
+    DFA.unop_transitionHom_apply]
   congr 1
 
 /-- The scanner run over `w` (with both boundaries folded in) is alive iff `w` lies in the
@@ -270,8 +268,8 @@ private lemma alive_iff_mem_language (w : List α) :
     (scanDFA G n).evalFrom (some (startWin n)) (w.map Option.some ++ List.replicate n none) ≠ none
       ↔ w ∈ G.language (n + 1) := by
   rw [Ne, evalFrom_eq_none_iff]
-  simp only [startWin, List.reverse_replicate, SLGrammar.mem_language, BadF, not_exists, not_and,
-    not_not]
+  simp only [startWin, List.reverse_replicate, SLGrammar.mem_language, IsForbiddenWindow,
+    not_exists, not_and, not_not]
   rw [show List.replicate n none ++ (w.map Option.some ++ List.replicate n none)
         = boundary (n + 1) w by simp [boundary]]
   refine ⟨fun h f hf => ?_, fun h f hinf hlen => h f (List.mem_kFactors.mpr ⟨hinf, hlen⟩)⟩

--- a/Linglib/Core/Data/List/Factors.lean
+++ b/Linglib/Core/Data/List/Factors.lean
@@ -21,11 +21,19 @@ domain content; used by the subregular hierarchy and a candidate for
 
 * `List.mem_kFactors` — `f` is a `k`-factor of `xs` iff it is a length-`k` infix
   (the infix analog of `List.mem_sublistsLen`).
+* `List.take_append_take` — truncating the right operand of an append before taking
+  a length-`n` prefix is a no-op (a candidate for `Mathlib/Data/List/`).
 -/
 
 namespace List
 
 variable {α : Type*}
+
+/-- Truncating the right operand to length `n` before taking the length-`n` prefix of an
+append is a no-op: the prefix already ignores everything past position `n`. -/
+lemma take_append_take (n : ℕ) (X Y : List α) :
+    (X ++ Y.take n).take n = (X ++ Y).take n := by
+  rw [take_append, take_append, take_take, min_eq_left (by omega)]
 
 section KFactors
 


### PR DESCRIPTION
A 3-reviewer mathlib-PR audit of the just-landed star-free arc (#768/#774), applying the idiom fixes:

- **`Aperiodic.lean`**: `@[to_additive]` on `Monoid.IsAperiodic` + the whole toolkit (mirrors `Monoid.IsTorsion`; generates `AddMonoid.IsAperiodic` etc.); lifted `pow_stabilizes` out of the `IsAperiodic` namespace to `Monoid.pow_succ_stabilizes` (a pure pow fact, and dot-namespacing it broke `to_additive`); docstring de-asserts the unproven 'trivial subgroups' equivalence (historical motivation instead).
- **`StarFree.lean`**: `of_recognizes` now consumes `ker_le_syntacticCon_of_recognizes` instead of re-deriving the kernel-refinement (derive, don't duplicate); the `Con.map … surjective` boilerplate (2 sites) collapses to `Con.lift_surjective_of_surjective _ Con.mk'_surjective`; docstring aligned to the `regular ∧ aperiodic` def.
- **`StrictlyLocalStarFree.lean`**: inlined a trivial `List.infix_cons_iff` wrapper; renamed `BadF` → `IsForbiddenWindow` (directory `Is`-predicate convention); wrapped two >100-col lines.
- **`Factors.lean`**: promoted `List.take_append_take` to a public `[UPSTREAM]` lemma (was private scaffolding).

Axiom-clean (`Monoid.IsAperiodic.prod` is now `Classical.choice`-free); all consumers build.