### PR TITLE
feat(Core/Computability): star-free closed under inverse hom; TSL ⊆ SF

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -320,6 +320,7 @@ import Linglib.Core.Computability.Subregular.Language.Boundary
 import Linglib.Core.Computability.Subregular.Language.StrictlyLocal
 import Linglib.Core.Computability.Subregular.Language.StrictlyLocalStarFree
 import Linglib.Core.Computability.Subregular.Language.TierStrictlyLocal
+import Linglib.Core.Computability.Subregular.Language.TierStrictlyLocalStarFree
 import Linglib.Core.Computability.Subregular.Language.StrictlyPiecewise
 import Linglib.Core.Computability.Subregular.Language.PiecewiseTestable
 import Linglib.Core.Computability.Subregular.Language.Definite

--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -141,4 +141,19 @@ theorem IsStarFree.of_recognizes {M : Type*} [Monoid M] [Finite M]
   exact ⟨isRegular_of_finite_syntacticMonoid (Finite.of_surjective _ hsurj),
     hker.of_surjective hsurj⟩
 
+/-- **Star-free languages are closed under inverse homomorphism.** If `L` over `β` is star-free
+and `φ : FreeMonoid α →* FreeMonoid β` is any monoid hom, then the preimage language
+`{w | φ w ∈ L}` over `α` is star-free. The recognizer is `L.toSyntacticMonoid.comp φ` into the
+finite aperiodic `L.syntacticMonoid`, with `P` the set of `L`-classes containing a word of `L`
+(saturation of `L` by its syntactic congruence). This is the engine for transferring a star-free
+upper bound across a string-rewriting projection (e.g. tier erasure: `TSL ⊆ SF`). -/
+theorem IsStarFree.comap {α β : Type*} {L : Language β} (h : L.IsStarFree)
+    (φ : FreeMonoid α →* FreeMonoid β) :
+    Language.IsStarFree {w : List α | φ (FreeMonoid.ofList w) ∈ L} := by
+  have : Finite L.syntacticMonoid := finite_syntacticMonoid h.1
+  refine IsStarFree.of_recognizes (M := L.syntacticMonoid) h.2 (L.toSyntacticMonoid.comp φ)
+    {m | ∃ u : FreeMonoid β, L.toSyntacticMonoid u = m ∧ u ∈ L} fun w => ?_
+  refine ⟨fun hw => ⟨φ (FreeMonoid.ofList w), rfl, hw⟩, fun ⟨u, hu, hmem⟩ => ?_⟩
+  exact (mem_iff_of_syntacticCon ((toSyntacticMonoid_eq_iff (L := L)).mp hu)).mp hmem
+
 end Language

--- a/Linglib/Core/Computability/Subregular/Language/TierStrictlyLocalStarFree.lean
+++ b/Linglib/Core/Computability/Subregular/Language/TierStrictlyLocalStarFree.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Computability.Subregular.Language.StrictlyLocalStarFree
+import Linglib.Core.Computability.Subregular.Language.TierStrictlyLocal
+
+/-!
+# Tier-based strictly local languages are star-free
+
+Over a finite alphabet, every tier-based strictly `k`-local language is star-free:
+`Language.IsTierStrictlyLocal.isStarFree`. This places `TSL_k ⊆ SF` inside the subregular
+hierarchy ([heinz-rawal-tanner-2011]), completing `SL_k ⊆ TSL_k ⊆ SF` (the first inclusion is
+`Language.IsStrictlyLocal.toIsTierStrictlyLocal`).
+
+## Construction
+
+A TSL grammar's language is the preimage `tierProject T ⁻¹' (permitted.language k)` under tier
+erasure. Tier erasure is `List.filter`, hence a **monoid hom** `Subregular.tierProjectHom`
+(`map_mul'` is `List.filter_append`). The permitted-factor language is `SL_k`, so star-free by
+`Language.IsStrictlyLocal.isStarFree`; star-freeness is closed under inverse homomorphism
+(`Language.IsStarFree.comap`), so the preimage is star-free.
+
+`[Finite α]` flows in from `IsStrictlyLocal.isStarFree`: SL (and so TSL) over an infinite
+alphabet need not even be regular.
+
+## Main results
+
+* `Subregular.tierProjectHom` — tier erasure bundled as `FreeMonoid α →* FreeMonoid α`.
+* `Language.IsTierStrictlyLocal.isStarFree` — `IsTierStrictlyLocal k L → IsStarFree L` (finite `α`).
+-/
+
+namespace Subregular
+
+variable {α : Type*} (T : α → Prop) [DecidablePred T]
+
+/-- **Tier erasure as a monoid hom** `FreeMonoid α →* FreeMonoid α`: `tierProject T` is
+`List.filter`, which preserves `1` (`[]`) and `*` (`++`, via `List.filter_append`). -/
+def tierProjectHom : FreeMonoid α →* FreeMonoid α where
+  toFun := tierProject T
+  map_one' := tierProject_nil T
+  map_mul' u v := List.filter_append u v
+
+@[simp] lemma tierProjectHom_apply (w : FreeMonoid α) :
+    tierProjectHom T w = tierProject T w := rfl
+
+end Subregular
+
+namespace Language
+
+variable {α : Type*} [Finite α] {k : ℕ} {L : Language α}
+
+open Subregular
+
+/-- **Tier-based strictly local languages are star-free** ([heinz-rawal-tanner-2011]). Over a
+finite alphabet, a TSL language is the inverse image of an `SL_k` language under the
+tier-erasure homomorphism, and star-freeness is closed under inverse homomorphism
+(`IsStarFree.comap`), so `TSL_k ⊆ SF`. -/
+theorem IsTierStrictlyLocal.isStarFree (h : IsTierStrictlyLocal k L) : L.IsStarFree := by
+  obtain ⟨G, rfl⟩ := h
+  have hsf : (G.permitted.language k).IsStarFree :=
+    IsStrictlyLocal.isStarFree ⟨G.permitted, rfl⟩
+  have := hsf.comap (tierProjectHom G.tier)
+  rwa [show {w : List α | tierProjectHom G.tier (FreeMonoid.ofList w) ∈ G.permitted.language k}
+      = G.lang from rfl] at this
+
+end Language


### PR DESCRIPTION
Extends the 'subregular hierarchy ⊆ SF' backdrop, reusing `of_recognizes`.

- **`IsStarFree.comap`**: star-free is closed under inverse homomorphism — for `φ : FreeMonoid α →* FreeMonoid β` and star-free `L : Language β`, the preimage `{w | φ (ofList w) ∈ L}` is star-free. The syntactic monoid of `L` (finite + aperiodic) recognizes the preimage via `L.toSyntacticMonoid ∘ φ` (`L` saturated by its syntactic congruence). A fundamental closure property, 4 lines via `of_recognizes`.
- **`IsTierStrictlyLocal.isStarFree`** (`TierStrictlyLocalStarFree.lean`): **TSL_k ⊆ SF** over a finite alphabet — `TSL = tierProject⁻¹'(SL)`, `tierProject` bundles as a monoid hom (`tierProjectHom`, via `List.filter_append`), so `TSL = comap tierProjectHom (SL-language)` and the result falls out of `comap` + `IsStrictlyLocal.isStarFree`.

Same preimage-along-a-hom shape as the autosegmental `ASL`. Axiom-clean.