### PR TITLE
feat(Syntax/Minimalist/Probe): transmission axis; applyAgree as φ-transmit

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2153,6 +2153,7 @@ import Linglib.Syntax.Minimalist.Probe.Basic
 import Linglib.Syntax.Minimalist.Probe.Phi
 import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Minimalist.Probe.Satisfaction
+import Linglib.Syntax.Minimalist.Probe.Transmission
 import Linglib.Syntax.Minimalist.Probe.Tree
 import Linglib.Syntax.Minimalist.Aspect
 import Linglib.Syntax.Minimalist.CyclicAgree

--- a/Linglib/Syntax/Minimalist/Agree.lean
+++ b/Linglib/Syntax/Minimalist/Agree.lean
@@ -1,6 +1,7 @@
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.Phase
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
+import Linglib.Syntax.Minimalist.Probe.Transmission
 
 /-!
 # Agree (Minimalist Feature Checking)
@@ -411,5 +412,31 @@ theorem neg_features_match :
 
 theorem rel_features_match :
     featuresMatch (.unvalued (.rel true)) (.valued (.rel false)) = true := rfl
+
+-- ============================================================================
+-- § N: `applyAgree` as a Probe transmission (retire into the Probe API)
+-- ============================================================================
+
+/-- The φ-probe: relativized search ([bejar-rezac-2003]/[preminger-2014]) for a
+    goal bearing a valued `ftype` feature. -/
+def phiProbe (ftype : FeatureVal) : Probe FeatureBundle :=
+  Probe.ofVis (fun gf => (getValuedFeature gf ftype).isSome)
+
+/-- **`applyAgree` is the φ goal→probe transmission.** A φ-Agree is
+    `Probe.transmit` of the φ-probe with the valuation `applyAgree`: search the
+    goal sequence for a `ftype`-bearing goal, then value the probe's features
+    from it. This recognizes the standalone `applyAgree` as the transmission
+    step of the unified Agree operation (`Probe/Transmission.lean`), rather than
+    a parallel mechanism. (The probe→goal direction — dependent case — and a
+    full clause's worth of valuations are *folds* of `transmit`s: the
+    composition axis, not a single transmit.) -/
+theorem applyAgree_is_phi_transmit (probeFeats : FeatureBundle) (ftype : FeatureVal)
+    {goals : List FeatureBundle} {gf : FeatureBundle}
+    (h : (phiProbe ftype).search goals = some gf) :
+    (phiProbe ftype).transmit (fun g pf => (applyAgree pf g ftype).getD pf)
+        probeFeats goals
+      = (applyAgree probeFeats gf ftype).getD probeFeats := by
+  unfold phiProbe at h ⊢
+  exact Probe.transmit_ofVis_eq_of_search h
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Probe/Transmission.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Transmission.lean
@@ -1,0 +1,62 @@
+import Linglib.Syntax.Minimalist.Probe.Basic
+
+/-!
+# Transmission: the Agree state-update on a found goal
+[chomsky-2000] [deal-2024]
+
+`Probe` (`Probe/Basic.lean`) models the *search* half of Agree. This file adds
+the *transmission* half — what a successful Agree does once a goal is found —
+realizing the `Probe.agreeWith` TODO. An **Agree operation** is a `Probe` plus a
+state-update `xmit`:
+
+`Probe.transmit p xmit init goals` searches `goals`; if the probe Agrees with an
+active goal `g`, it updates the state via `xmit g`; otherwise it leaves the state
+unchanged — **Agree fails gracefully**, no crash ([preminger-2014]).
+
+The *direction* of transmission is the choice of `xmit`/state, not a separate
+axis: goal→probe copy (φ-valuation; `Agree.applyAgree` is recognized as this
+instance in `Agree.lean`), probe→goal assignment (dependent case), or sharing.
+Multiple-goal assignment (a clause's worth of case) is a *fold* of `transmit`s —
+the composition axis (`cascade`/ordered stack), not a single transmit.
+-/
+
+namespace Minimalist
+
+variable {α σ : Type*}
+
+/-- An Agree operation: search (`Probe`) + a transmission `xmit` applied to the
+    active goal it finds. No active goal ⇒ state unchanged (graceful failure). -/
+def Probe.transmit (p : Probe α) (xmit : α → σ → σ) (init : σ) (goals : List α) :
+    σ :=
+  (p.agree goals).elim init (fun g => xmit g init)
+
+variable {p : Probe α} {xmit : α → σ → σ} {init : σ} {goals : List α}
+
+@[simp] theorem Probe.transmit_nil : p.transmit xmit init [] = init := rfl
+
+/-- **Agree fails gracefully**: with no goal to value the probe, the state is
+    left unchanged ([preminger-2014] — failure to Agree does not crash). -/
+theorem Probe.transmit_eq_init_of_agree_none (h : p.agree goals = none) :
+    p.transmit xmit init goals = init := by
+  rw [Probe.transmit, h]; rfl
+
+/-- An inactive closest goal absorbs the probe without transmission
+    ([deal-2024]: satisfaction without interaction). -/
+theorem Probe.transmit_eq_init_of_inactive {a : α}
+    (hs : p.search goals = some a) (ha : p.act a = false) :
+    p.transmit xmit init goals = init :=
+  Probe.transmit_eq_init_of_agree_none (Probe.agree_eq_none_of_inactive hs ha)
+
+/-- When the probe Agrees with `a`, transmission applies `xmit a` to the state. -/
+theorem Probe.transmit_eq_of_agree {a : α} (h : p.agree goals = some a) :
+    p.transmit xmit init goals = xmit a init := by
+  rw [Probe.transmit, h]; rfl
+
+/-- For a probe with no activity restriction (`ofVis`), transmission fires on
+    the structurally closest visible goal. -/
+theorem Probe.transmit_ofVis_eq_of_search {vis : α → Bool} {a : α}
+    (h : (Probe.ofVis vis).search goals = some a) :
+    (Probe.ofVis vis).transmit xmit init goals = xmit a init :=
+  Probe.transmit_eq_of_agree (by rw [Probe.agree_eq_search_of_act (fun _ => rfl), h])
+
+end Minimalist


### PR DESCRIPTION
First retirement of the ancient Agree stack into the unified Probe API: adds the *transmission* half of Agree (the `Probe.agreeWith` TODO) and recognizes the standalone `applyAgree` as its φ instance.

- New `Probe/Transmission.lean`: `Probe.transmit p xmit init goals` = search (`Probe`) + a state-update `xmit` on the active found goal; no active goal ⇒ state unchanged. Properties: `transmit_eq_init_of_agree_none` (**Agree fails gracefully**, [preminger-2014]), `transmit_eq_init_of_inactive` ([deal-2024] satisfaction-without-interaction), `transmit_eq_of_agree`, `transmit_ofVis_eq_of_search`. The transmission *direction* (goal→probe / probe→goal / share) is the choice of `xmit`/state, not a separate axis. Imports only `Probe.Basic` (stays general over `α`/`σ`).
- `Agree.lean`: `phiProbe` + `applyAgree_is_phi_transmit` — a φ-Agree is `Probe.transmit` of the φ-probe with `applyAgree` as the valuation; the ancient standalone `applyAgree` is now recognized as the goal→probe transmission step, not a parallel mechanism. Axiom-minimal (`propext`).

Honest scoping: `Poole2024.agreeAssigner` (dependent case) is a *multi-NP* assignment — a **fold** of probe→goal transmits (the composition/stack axis), not a single transmit — so it's deferred to the stack consolidation rather than force-fit here. Next retirements (gated on #779 `searchTree`): `Agree.closestGoal` → `searchTree`; `NestedAgree.runStack`/`agreementClass` → `cascade`; then migrate the 7 `applyAgree` consumers and delete the wrapper.