### PR TITLE
feat(Studies/Jardine2019): link-free autosegmental SL sets are star-free

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -321,6 +321,7 @@ import Linglib.Core.Computability.Subregular.Language.StrictlyLocal
 import Linglib.Core.Computability.Subregular.Language.TierStrictlyLocal
 import Linglib.Core.Computability.Subregular.Language.StrictlyPiecewise
 import Linglib.Core.Computability.Subregular.Language.Aperiodicity
+import Linglib.Core.Computability.Subregular.Language.ContainsFactor
 import Linglib.Core.Computability.Subregular.Language.PiecewiseTestable
 import Linglib.Core.Computability.Subregular.Language.Definite
 import Linglib.Core.Computability.Subregular.Language.Multitier

--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Computability.SyntacticMonoid
 import Linglib.Core.Algebra.Group.Aperiodic
+import Mathlib.Algebra.Group.PUnit
 
 /-!
 # Star-free languages
@@ -149,5 +150,11 @@ theorem IsStarFree.comap {α β : Type*} {L : Language β} (h : L.IsStarFree)
     {m | ∃ u : FreeMonoid β, L.toSyntacticMonoid u = m ∧ u ∈ L} fun w => ?_
   refine ⟨fun hw => ⟨φ (FreeMonoid.ofList w), rfl, hw⟩, fun ⟨u, hu, hmem⟩ => ?_⟩
   exact (mem_iff_of_syntacticCon ((toSyntacticMonoid_eq_iff (L := L)).mp hu)).mp hmem
+
+/-- **The full language is star-free** — it is recognized by the trivial (one-element)
+monoid, which is aperiodic. -/
+theorem isStarFree_univ : IsStarFree (Set.univ : Language α) :=
+  IsStarFree.of_recognizes (M := PUnit.{1}) Monoid.IsAperiodic.of_subsingleton 1 Set.univ
+    (fun _ => iff_of_true (Set.mem_univ _) (Set.mem_univ _))
 
 end Language

--- a/Linglib/Core/Computability/Subregular/Language/ContainsFactor.lean
+++ b/Linglib/Core/Computability/Subregular/Language/ContainsFactor.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Computability.StarFree
+import Linglib.Core.Computability.Subregular.Language.Aperiodicity
+
+/-!
+# Containing (and avoiding) a fixed factor is star-free
+
+For any list `c` over an *arbitrary* alphabet `α`, the language of words that contain `c` as a
+contiguous factor (`{x | c <:+: x}`) is star-free, as is its complement (the words that *avoid*
+`c`). This is the workhorse fact behind forbidden-substring constraints: each forbidden factor
+cuts out a star-free set, and `SF` is closed under the finite Boolean operations.
+
+Over a *finite* alphabet `c` avoidance is plainly strictly local (`SL_{|c|}` with the single
+forbidden factor `c`), hence star-free by `Language.IsStrictlyLocal.isStarFree`. The substance
+here is removing the finiteness hypothesis: an arbitrary `α` is collapsed onto the finite
+alphabet `Fin |c| → Bool` by the **diagonal encoding** `enc a i = (a = c[i])`, which records, for
+each position of `c`, whether `a` matches it. This loses almost all information about `α` yet is
+faithful enough to detect occurrences of `c`: `c <:+: x ↔ (c.map enc) <:+: (x.map enc)`
+(`containsFactor_iff_map`), because at a matched window the diagonal forces `x[j] = c[i]`. The
+finite-alphabet result then transfers back by inverse homomorphism (`Language.IsStarFree.comap`).
+
+Star-free = `FO[<]`-definable = counter-free ([schutzenberger-1965] [mcnaughton-papert-1971]).
+
+## Main results
+
+* `Language.isStarFree_containsFactor` — `{x | c <:+: x}` is star-free, `α` arbitrary.
+* `Language.isStarFree_avoidsFactor` — `{x | ¬ c <:+: x}` is star-free, `α` arbitrary.
+-/
+
+open Subregular
+
+namespace Language.ContainsFactor
+
+/-! ### Generic list lemmas (no alphabet assumptions) -/
+
+variable {α β : Type*}
+
+/-- Window decomposition: a list splits at offsets `a` and `a + b` into prefix, window, suffix. -/
+private theorem window_decomp (a b : ℕ) (t : List α) :
+    t = t.take a ++ (t.drop a).take b ++ t.drop (a + b) := by
+  rw [List.append_assoc, ← List.drop_drop, List.take_append_drop, List.take_append_drop]
+
+/-- Infix is reflected by an injective map (and preserved by `List.IsInfix.map`). -/
+private theorem infix_map_iff {f : α → β} (hf : Function.Injective f) (s t : List α) :
+    s.map f <:+: t.map f ↔ s <:+: t := by
+  refine ⟨fun h => ?_, fun h => h.map f⟩
+  obtain ⟨u, v, huv⟩ := h
+  have hlent : u.length + s.length + v.length = t.length := by
+    simpa [Nat.add_assoc] using congrArg List.length huv
+  set p := t.take u.length with hp
+  set mid := (t.drop u.length).take s.length with hmid
+  set q := t.drop (u.length + s.length) with hq
+  have hdecomp : t = p ++ mid ++ q := window_decomp _ _ t
+  have hpl : p.length = u.length := by rw [hp, List.length_take]; omega
+  have hmidl : mid.length = s.length := by rw [hmid, List.length_take, List.length_drop]; omega
+  rw [show t.map f = p.map f ++ mid.map f ++ q.map f by
+    rw [← List.map_append, ← List.map_append, ← hdecomp]] at huv
+  have hul : u.length = (p.map f).length := by simp [hpl]
+  have h2 : u ++ s.map f = p.map f ++ mid.map f :=
+    List.append_inj_left huv (by simp [hpl, hmidl])
+  have : mid = s := List.map_injective_iff.mpr hf (List.append_inj_right h2 hul).symm
+  rw [hdecomp, this]; exact ⟨p, q, rfl⟩
+
+/-- Stripping `some`: an infix relation is reflected by `List.map some`. -/
+private theorem mapSome_infix_iff (s t : List α) :
+    s.map some <:+: t.map some ↔ s <:+: t :=
+  infix_map_iff (Option.some_injective α) s t
+
+/-- Filtering the boundary form to its `some` positions recovers the core. -/
+private theorem filter_isSome_boundary (m : ℕ) (y : List α) :
+    (boundary m y).filter (fun b => b.isSome) = y.map some := by
+  simp [boundary, List.filter_append, List.filter_map, Function.comp_def]
+
+/-- Boundary stripping: an all-`some` factor of the boundary-augmented form sits in the core. -/
+private theorem mapSome_infix_boundary_iff (m : ℕ) (y d : List α) :
+    d.map some <:+: boundary m y ↔ d <:+: y := by
+  rw [← mapSome_infix_iff d y]
+  refine ⟨fun h => ?_, fun h => h.trans (List.infix_append _ _ _)⟩
+  have := h.filter (fun b => b.isSome)
+  rwa [filter_isSome_boundary, List.filter_map, Function.comp_def,
+    show (fun a : α => (some a).isSome) = fun _ => true from rfl, List.filter_true] at this
+
+/-! ### Containment over a finite alphabet -/
+
+variable {γ : Type*} [Finite γ]
+
+omit [Finite γ] in
+/-- The `SL` grammar forbidding the single factor `d.map some` generates the avoidance language:
+its forbidden window can only complete on an all-`some` occurrence of `d`. -/
+private theorem ofForbidden_language_eq (d : List γ) :
+    (SLGrammar.ofForbidden {d.map some}).language d.length
+      = ({y : List γ | ¬ d <:+: y} : Language γ) := by
+  ext y
+  simp only [SLGrammar.mem_ofForbidden_language, Set.mem_singleton_iff]
+  refine ⟨fun h hc => ?_, fun h f hf heq => ?_⟩
+  · exact h (d.map some)
+      (List.mem_kFactors.mpr ⟨(mapSome_infix_boundary_iff _ _ d).mpr hc, by simp⟩) rfl
+  · subst heq
+    exact h ((mapSome_infix_boundary_iff _ _ d).mp (List.mem_kFactors.mp hf).1)
+
+/-- Over a finite alphabet, containing the fixed factor `d` is star-free: it is the complement of
+the strictly-local avoidance language. -/
+private theorem isStarFree_containsFactor_finite (d : List γ) :
+    Language.IsStarFree ({y : List γ | d <:+: y} : Language γ) := by
+  have hsl : Language.IsStarFree ({y : List γ | ¬ d <:+: y} : Language γ) :=
+    Language.IsStrictlyLocal.isStarFree ⟨_, ofForbidden_language_eq d⟩
+  rw [show ({y : List γ | d <:+: y} : Language γ)
+    = ({y : List γ | ¬ d <:+: y} : Language γ)ᶜ from by ext y; simp]
+  exact hsl.compl
+
+/-! ### The diagonal encoding onto a finite alphabet -/
+
+variable [DecidableEq α] (c : List α)
+
+/-- The **diagonal encoding** `enc c a i = (a = c[i])`: faithful enough to detect `c`. -/
+private def enc : α → (Fin c.length → Bool) := fun a i => decide (a = c.get i)
+
+/-- Diagonal injectivity: same-length lists with equal `enc`-images are equal — at each position
+`enc` records whether the symbol matches `c` there, which pins it down on the diagonal. -/
+private theorem map_enc_eq_iff (m : List α) (hlen : m.length = c.length) :
+    m.map (enc c) = c.map (enc c) ↔ m = c := by
+  refine ⟨fun h => List.ext_getElem hlen fun i h1 h2 => ?_, fun h => h ▸ rfl⟩
+  have hi : enc c m[i] = enc c c[i] := by
+    simpa [List.getElem?_map, h1, h2] using congrArg (·[i]?) h
+  have := congrFun hi ⟨i, h2⟩
+  simpa [enc, List.get_eq_getElem] using this
+
+/-- **K1**: containment over `α` transfers to and from containment of the diagonal-encoded factor
+over the finite alphabet `Fin |c| → Bool`. -/
+private theorem containsFactor_iff_map (x : List α) :
+    c <:+: x ↔ c.map (enc c) <:+: x.map (enc c) := by
+  refine ⟨fun h => h.map (enc c), fun h => ?_⟩
+  obtain ⟨s, t, hst⟩ := h
+  have hlenx : s.length + c.length + t.length = x.length := by
+    simpa [Nat.add_assoc] using congrArg List.length hst
+  set p := x.take s.length with hp
+  set mid := (x.drop s.length).take c.length with hmid
+  set q := x.drop (s.length + c.length) with hq
+  have hdecomp : x = p ++ mid ++ q := window_decomp _ _ x
+  have hpl : p.length = s.length := by rw [hp, List.length_take]; omega
+  have hmidl : mid.length = c.length := by rw [hmid, List.length_take, List.length_drop]; omega
+  rw [show x.map (enc c) = p.map (enc c) ++ mid.map (enc c) ++ q.map (enc c) by
+    rw [← List.map_append, ← List.map_append, ← hdecomp]] at hst
+  have hsl : s.length = (p.map (enc c)).length := by simp [hpl]
+  have h2 : s ++ c.map (enc c) = p.map (enc c) ++ mid.map (enc c) :=
+    List.append_inj_left hst (by simp [hpl, hmidl])
+  have : mid = c := (map_enc_eq_iff c mid hmidl).mp (List.append_inj_right h2 hsl).symm
+  rw [hdecomp, this]; exact ⟨p, q, rfl⟩
+
+end Language.ContainsFactor
+
+namespace Language
+
+open Language.ContainsFactor
+
+variable {α : Type*}
+
+/-- **Containing a fixed factor is star-free** over an arbitrary alphabet ([schutzenberger-1965]
+[mcnaughton-papert-1971]). For any `c`, the words containing `c` as a contiguous factor form a
+star-free language. Over a finite alphabet this is strictly local; the diagonal encoding
+`enc c a i = (a = c[i])` collapses an arbitrary alphabet onto the finite `Fin |c| → Bool` while
+preserving occurrences of `c`, and `SF` is closed under inverse homomorphism. -/
+theorem isStarFree_containsFactor (c : List α) :
+    Language.IsStarFree {x : List α | c <:+: x} := by
+  classical
+  rw [show ({x : List α | c <:+: x} : Language α) = {w : List α |
+      (FreeMonoid.map (enc c)) (FreeMonoid.ofList w) ∈ ({y | c.map (enc c) <:+: y} : Language _)}
+    from by
+      ext x
+      simp only [Set.mem_setOf_eq, ← FreeMonoid.ofList_map]
+      exact containsFactor_iff_map c x]
+  exact (isStarFree_containsFactor_finite (c.map (enc c))).comap (FreeMonoid.map (enc c))
+
+/-- **Avoiding a fixed factor is star-free** over an arbitrary alphabet ([schutzenberger-1965]
+[mcnaughton-papert-1971]) — the complement of `isStarFree_containsFactor`. -/
+theorem isStarFree_avoidsFactor (c : List α) :
+    Language.IsStarFree {x : List α | ¬ c <:+: x} := by
+  rw [show ({x : List α | ¬ c <:+: x} : Language α) = ({x : List α | c <:+: x} : Language α)ᶜ
+    from by ext x; simp]
+  exact (isStarFree_containsFactor c).compl
+
+end Language

--- a/Linglib/Core/Data/List/Factors.lean
+++ b/Linglib/Core/Data/List/Factors.lean
@@ -35,6 +35,31 @@ lemma take_append_take (n : ℕ) (X Y : List α) :
     (X ++ Y.take n).take n = (X ++ Y).take n := by
   rw [take_append, take_append, take_take, min_eq_left (by omega)]
 
+/-- A list is an infix of another iff some shift aligns every position of `S` with
+`A` (`getElem?`-wise): `S <:+: A` exactly when there is an offset `δ ≤ A.length` with
+`A[i + δ]? = S[i]?` for every `i < S.length`. The positional companion of
+`mem_kFactors`. -/
+theorem isInfix_iff_exists_offset (S A : List α) :
+    S <:+: A ↔ ∃ δ ≤ A.length, ∀ i < S.length, A[i + δ]? = S[i]? := by
+  constructor
+  · rintro ⟨s, t, rfl⟩
+    refine ⟨s.length, by simp, fun i hi => ?_⟩
+    rw [List.append_assoc, List.getElem?_append_right (by omega), Nat.add_sub_cancel,
+      List.getElem?_append_left hi]
+  · rintro ⟨δ, hδ, hmatch⟩
+    rcases Nat.eq_zero_or_pos S.length with h0 | hpos
+    · obtain rfl : S = [] := List.length_eq_zero_iff.mp h0
+      exact List.nil_infix
+    · have hS : (A.drop δ).take S.length = S := by
+        apply List.ext_getElem?
+        intro i
+        rcases lt_or_ge i S.length with hi | hi
+        · rw [List.getElem?_take_of_lt hi, List.getElem?_drop, Nat.add_comm δ i]; exact hmatch i hi
+        · rw [List.getElem?_take_eq_none hi, List.getElem?_eq_none hi]
+      refine ⟨A.take δ, A.drop (δ + S.length), ?_⟩
+      conv_rhs => rw [← List.take_append_drop δ A, ← List.take_append_drop S.length (A.drop δ)]
+      rw [hS, List.drop_drop, List.append_assoc]
+
 section KFactors
 
 variable (k : ℕ) (xs : List α)

--- a/Linglib/Phonology/Autosegmental/Embedding.lean
+++ b/Linglib/Phonology/Autosegmental/Embedding.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.CategoryTheory.Widesubcategory
+import Linglib.Core.Data.List.Factors
 import Linglib.Phonology.Autosegmental.AR
 
 /-!
@@ -141,6 +142,37 @@ def Free (G : Graph α β) (fs : List (Graph α β)) : Prop :=
 
 instance [DecidableEq α] [DecidableEq β] (G : Graph α β) (fs : List (Graph α β)) :
     Decidable (G.Free fs) := by unfold Free; infer_instance
+
+/-! #### Link-free embedding reduces to per-tier factor occurrence
+
+A forbidden subgraph with no association lines decouples: the two tiers impose
+independent contiguous-factor constraints, with no link to fix their relative offset.
+This is the structural fact behind the link-free fragment of the autosegmental →
+star-free placement (`Studies.Jardine2019`): a link-free forbidden grammar reads as a
+Boolean combination of per-tier factor constraints. -/
+
+/-- A `LabeledTuple` offset-match is exactly a `toList` infix (positional companion
+`List.isInfix_iff_exists_offset`). -/
+private theorem exists_offset_iff_infix {γ : Type*} (a b : LabeledTuple γ) :
+    (∃ δ ≤ b.len, ∀ i < a.len, b.get? (i + δ) = a.get? i) ↔ a.toList <:+: b.toList := by
+  rw [List.isInfix_iff_exists_offset]
+  simp only [LabeledTuple.get?_eq_getElem?, LabeledTuple.toList_length]
+
+/-- For a forbidden subgraph **with no association lines**, embedding reduces to two
+independent tier-factor occurrences: `F` subgraph-embeds in `G` iff `F`'s upper tier is
+a contiguous factor of `G`'s upper tier and `F`'s lower tier is a contiguous factor of
+`G`'s lower tier. The tiers are unconstrained relative to each other precisely because
+there are no links to couple their offsets. -/
+theorem subgraphEmbeds_iff_infix_of_links_empty (F G : Graph α β) (hF : F.links = ∅) :
+    SubgraphEmbeds F G ↔
+      F.upper.toList <:+: G.upper.toList ∧ F.lower.toList <:+: G.lower.toList := by
+  unfold SubgraphEmbeds IsSubgraphAt
+  simp only [Finset.mem_range, Nat.lt_succ_iff, hF, Finset.notMem_empty, false_implies,
+    forall_const, and_true]
+  rw [← exists_offset_iff_infix F.upper G.upper, ← exists_offset_iff_infix F.lower G.lower]
+  constructor
+  · rintro ⟨δᵤ, hδᵤ, δₗ, hδₗ, hu, hl⟩; exact ⟨⟨δᵤ, hδᵤ, hu⟩, ⟨δₗ, hδₗ, hl⟩⟩
+  · rintro ⟨⟨δᵤ, hδᵤ, hu⟩, ⟨δₗ, hδₗ, hl⟩⟩; exact ⟨δᵤ, hδᵤ, δₗ, hδₗ, hu, hl⟩
 
 end Graph
 

--- a/Linglib/Phonology/Autosegmental/Realization.lean
+++ b/Linglib/Phonology/Autosegmental/Realization.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Algebra.BigOperators.Group.List.Basic
+import Mathlib.Algebra.FreeMonoid.Basic
 import Linglib.Phonology.Autosegmental.AR
 
 /-!
@@ -41,5 +42,53 @@ def realize (g₀ : S → AR α β) (w : List S) : AR α β := (w.map g₀).prod
 theorem realize_append (g₀ : S → AR α β) (xs ys : List S) :
     realize g₀ (xs ++ ys) = (realize g₀ xs).concat (realize g₀ ys) := by
   simp only [realize, List.map_append, List.prod_append]; rfl
+
+/-! ### Tier projections
+
+The realization composed with a tier accessor is itself a free-monoid hom into that
+tier's free monoid: `upperProj g₀` sends a string to the concatenation of its symbols'
+upper tiers (the underlying list of `realize g₀ w`'s upper tier), and likewise
+`lowerProj`. These factor the realization's tier content through `FreeMonoid` and are
+the bridge used to place link-free `ASL` sets in `SF` (`Studies.Jardine2019`): a
+per-tier factor constraint on the realization is the `comap` of a factor language along
+the tier projection. -/
+
+/-- The upper-tier realization as a free-monoid hom `FreeMonoid S →* FreeMonoid α`:
+each symbol maps to its primitive's upper tier, concatenated. -/
+def upperProj (g₀ : S → AR α β) : FreeMonoid S →* FreeMonoid α :=
+  FreeMonoid.lift (fun s => FreeMonoid.ofList (g₀ s).upper.toList)
+
+/-- The lower-tier realization as a free-monoid hom `FreeMonoid S →* FreeMonoid β`. -/
+def lowerProj (g₀ : S → AR α β) : FreeMonoid S →* FreeMonoid β :=
+  FreeMonoid.lift (fun s => FreeMonoid.ofList (g₀ s).lower.toList)
+
+@[simp] theorem upperProj_of (g₀ : S → AR α β) (s : S) :
+    upperProj g₀ (FreeMonoid.of s) = FreeMonoid.ofList (g₀ s).upper.toList :=
+  FreeMonoid.lift_eval_of _ _
+
+@[simp] theorem lowerProj_of (g₀ : S → AR α β) (s : S) :
+    lowerProj g₀ (FreeMonoid.of s) = FreeMonoid.ofList (g₀ s).lower.toList :=
+  FreeMonoid.lift_eval_of _ _
+
+/-- The upper tier of a realization is its upper projection: `(realize g₀ w).upper`'s
+underlying list is `upperProj g₀ w`. -/
+theorem realize_upper_toList (g₀ : S → AR α β) (w : List S) :
+    (realize g₀ w).upper.toList = upperProj g₀ (FreeMonoid.ofList w) := by
+  induction w with
+  | nil => rw [realize_nil, show FreeMonoid.ofList ([] : List S) = 1 from rfl, map_one]; rfl
+  | cons s w ih =>
+    rw [realize_cons, AR.concat_upper, LabeledTuple.toList_concat, ih, FreeMonoid.ofList_cons,
+      map_mul, upperProj_of]
+    rfl
+
+/-- The lower tier of a realization is its lower projection. -/
+theorem realize_lower_toList (g₀ : S → AR α β) (w : List S) :
+    (realize g₀ w).lower.toList = lowerProj g₀ (FreeMonoid.ofList w) := by
+  induction w with
+  | nil => rw [realize_nil, show FreeMonoid.ofList ([] : List S) = 1 from rfl, map_one]; rfl
+  | cons s w ih =>
+    rw [realize_cons, AR.concat_lower, LabeledTuple.toList_concat, ih, FreeMonoid.ofList_cons,
+      map_mul, lowerProj_of]
+    rfl
 
 end Autosegmental

--- a/Linglib/Studies/Jardine2019.lean
+++ b/Linglib/Studies/Jardine2019.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Autosegmental.ASL
 import Linglib.Phonology.Autosegmental.Collapse
+import Linglib.Core.Computability.Subregular.Language.ContainsFactor
 
 /-!
 # Jardine (2019): the expressivity of autosegmental grammars
@@ -28,8 +29,72 @@ Two realizations are checked, against the same forbidden tone melody `*HLH`:
   plateau widths, because the plateaus collapse to single nodes before the melody is
   read (`hlhTier_merged_excludes_plateau` vs `hlhTier_unmerged_admits_plateau`).
 
+## Subregular placement
+
+[jardine-2019] places the bridge-only class `ASL` strictly inside the star-free
+languages. We prove the **link-free fragment**: when no forbidden subgraph carries
+association lines, `ASL g₀ B` is star-free (`Autosegmental.ASL.isStarFree_of_links_empty`)
+— over any alphabet, no `[Finite S]` needed — because such a grammar is a Boolean
+combination of per-tier factor constraints, each the inverse image of a star-free
+contains-factor language ([schutzenberger-1965] [mcnaughton-papert-1971]) along a tier
+projection. The `*HLH` tonal-tier melody `hlhTier` is one such constraint
+(`hlhTier_isStarFree`).
+
+The genuinely autosegmental case — links coupling the two tiers — is deeper: a forbidden
+subgraph can match with an unlinked run-end arbitrarily far from its linked core, so a
+bounded sliding-window scanner over the realization is unsound; a two-tape synchronising
+aperiodic recognizer is needed, and is left to future work.
+
 The relation-level `L = ASL^{gT}` equivalences ([jardine-2019]) remain future work.
 -/
+
+namespace Autosegmental
+
+open Graph
+
+variable {S α β : Type*}
+
+/-- For a single **link-free** forbidden subgraph `F`, the strings whose realization
+contains `F` form a star-free language: the intersection of two per-tier
+factor-occurrence constraints, each the inverse image (`comap`) of a star-free
+contains-factor language along a tier projection. -/
+theorem isStarFree_occur_of_links_empty (g₀ : S → AR α β) (F : Graph α β) (hF : F.links = ∅) :
+    Language.IsStarFree {w : List S | SubgraphEmbeds F (realize g₀ w).toGraph} := by
+  have hset : {w : List S | SubgraphEmbeds F (realize g₀ w).toGraph}
+      = {w : List S | F.upper.toList <:+: upperProj g₀ (FreeMonoid.ofList w)}
+        ∩ {w : List S | F.lower.toList <:+: lowerProj g₀ (FreeMonoid.ofList w)} := by
+    ext w
+    simp only [Set.mem_setOf_eq, Set.mem_inter_iff]
+    rw [subgraphEmbeds_iff_infix_of_links_empty F (realize g₀ w).toGraph hF,
+      realize_upper_toList, realize_lower_toList]
+  rw [hset]
+  exact ((Language.isStarFree_containsFactor F.upper.toList).comap (upperProj g₀)).inter
+        ((Language.isStarFree_containsFactor F.lower.toList).comap (lowerProj g₀))
+
+/-- **Link-free autosegmental SL sets are star-free.** When every forbidden subgraph in
+`B` has no association lines, `ASL g₀ B` is star-free — over *any* symbol alphabet, with
+no `[Finite S]` hypothesis, since each tier's contains-factor recognizer is a fixed
+finite aperiodic monoid. A link-free forbidden grammar is exactly a Boolean combination
+of per-tier factor constraints; the genuinely autosegmental case (links coupling the
+tiers) is the deeper part of [jardine-2019]'s placement and is not covered here. -/
+theorem ASL.isStarFree_of_links_empty (g₀ : S → AR α β) (B : List (Graph α β))
+    (hB : ∀ F ∈ B, F.links = ∅) : (ASL g₀ B).IsStarFree := by
+  induction B with
+  | nil =>
+    have : ASL g₀ [] = Set.univ := by ext w; simp [ASL, isFreeOf, Graph.Free]
+    rw [this]; exact Language.isStarFree_univ
+  | cons F B' ih =>
+    have hFmem : F.links = ∅ := hB F (List.mem_cons_self ..)
+    have ih' := ih (fun F' hF' => hB F' (List.mem_cons_of_mem _ hF'))
+    have hset : ASL g₀ (F :: B') =
+        {w : List S | SubgraphEmbeds F (realize g₀ w).toGraph}ᶜ ∩ ASL g₀ B' := by
+      ext w
+      show (∀ G ∈ F :: B', ¬ SubgraphEmbeds G (realize g₀ w).toGraph) ↔ _
+      rw [List.forall_mem_cons]; exact Iff.rfl
+    rw [hset]
+    exact (isStarFree_occur_of_links_empty g₀ F hFmem).compl.inter ih'
+
+end Autosegmental
 
 namespace Jardine2019
 
@@ -113,5 +178,13 @@ theorem hlhTier_merged_excludes_plateau :
     expressivity OCP merging adds — the local `hlh_excluded` constraint cannot see it. -/
 theorem hlhTier_unmerged_admits_plateau :
     [ToneSym.H, .H, .L, .L, .H, .H] ∈ ASL gT [hlhTier] := by decide
+
+/-- **The `*HLH` tonal-tier melody set is star-free.** `hlhTier` carries no association
+lines, so `ASL gT [hlhTier]` falls in the link-free fragment
+(`ASL.isStarFree_of_links_empty`): a concrete instance of [jardine-2019]'s `ASL ⊊ SF`
+placement that the bridge-only realization already settles. -/
+theorem hlhTier_isStarFree : (ASL gT [hlhTier]).IsStarFree :=
+  ASL.isStarFree_of_links_empty gT [hlhTier] (fun F hF => by
+    rw [List.mem_singleton] at hF; subst hF; rfl)
 
 end Jardine2019


### PR DESCRIPTION
The link-free fragment of [jardine-2019]'s `ASL ⊊ SF` placement: when no forbidden subgraph carries association lines, `ASL g₀ B` is star-free — over any alphabet, no `[Finite S]` — since such a grammar is a Boolean combination of per-tier factor constraints, each the `comap` of a contains-factor language along a tier projection.

- New reusable lemmas: `Language.isStarFree_containsFactor` (a word containing a fixed factor is star-free over any alphabet, via a finite-alphabet encoding + `comap`, reusing `SL ⊆ SF`), `Language.isStarFree_univ`, `List.isInfix_iff_exists_offset`, tier-projection homs `upperProj`/`lowerProj`, and `Graph.subgraphEmbeds_iff_infix_of_links_empty`.
- The genuinely autosegmental case (links coupling the tiers) needs a two-tape synchronising aperiodic recognizer — a bounded sliding-window scanner is unsound — and is left as future work.