### PR TITLE
refactor(Syntax/Minimalist): unify chain-position structs on ChainPosition

### DIFF
--- a/Linglib/Studies/BhattPancheva2004.lean
+++ b/Linglib/Studies/BhattPancheva2004.lean
@@ -70,7 +70,7 @@ open Bresnan1973 (BresnanThanClauseAnalysis bresnanAnalysisOf)
 open Heim2001 (IntensionalVerbDatum intensionalVerbData)
 open Minimalist (lateMergerBleeds wlmBleedsCondC ChainPosition admissible_above_binder_bleeds)
 open Minimalist.DegreeMovement
-  (DegreeChainPosition degreeClauseLateMergerBleeds scopeOK_above_binder_bleeds
+  (degreeClauseLateMergerBleeds scopeOK_above_binder_bleeds
    ScopeBinding IsHeimKennedy not_isHeimKennedy_QP_above_bound_DegP
    isHeimKennedy_no_dependency isHeimKennedy_dependency_requires_high_DegP
    williams_scope_correlation williams_exempt_when_no_binding)
@@ -96,7 +96,7 @@ variable {Entity : Type*}
     encoding the §5.1 stimulus contrasts. We do not formalize those
     contrasts here. -/
 theorem degree_lm_bleeds_iff_scope_position_above
-    (chain : List DegreeChainPosition) (binderHeight h : Nat)
+    (chain : List ChainPosition) (binderHeight h : Nat)
     (hgt : h > binderHeight) :
     degreeClauseLateMergerBleeds (⟨h, true⟩ :: chain) binderHeight = true :=
   scopeOK_above_binder_bleeds chain binderHeight h hgt

--- a/Linglib/Studies/Gong2022.lean
+++ b/Linglib/Studies/Gong2022.lean
@@ -288,9 +288,9 @@ theorem lds_agrees_with_fragment_subj :
     bleeds Condition C, regardless of the binder's height. -/
 theorem lds_cp_edge_irrelevant :
     wlmForcesReconstruction
-      (successiveCyclicChain [⟨.C, 4, false⟩]) (binderHeight .io) = true ∧
+      (successiveCyclicChain [{ height := 4, admissible := false, phaseCat := .C }]) (binderHeight .io) = true ∧
     wlmForcesReconstruction
-      (successiveCyclicChain [⟨.C, 4, false⟩]) (binderHeight .subject) = true := by
+      (successiveCyclicChain [{ height := 4, admissible := false, phaseCat := .C }]) (binderHeight .subject) = true := by
   exact ⟨lds_cp_edge_alone_no_bleed 4 (binderHeight .io),
           lds_cp_edge_alone_no_bleed 4 (binderHeight .subject)⟩
 

--- a/Linglib/Syntax/Minimalist/DegreeMovement.lean
+++ b/Linglib/Syntax/Minimalist/DegreeMovement.lean
@@ -45,29 +45,21 @@ open Minimalist
 -- § 1. Degree-Clause Late-Merger Admissibility
 -- ════════════════════════════════════════════════════
 
-/-- A position on a movement chain that could host a degree clause.
-    `height` is structural position; `scopeOK` records whether merging
-    the degree clause at this position would yield a Heim-Kennedy-
-    compliant LF (i.e., DegP-scope is at or above any QP whose trace
-    it contains). -/
-structure DegreeChainPosition where
-  height : Nat
-  scopeOK : Bool
-  deriving DecidableEq, Repr
-
 /-- The B&P specialization of `lateMergerBleeds` for degree clauses:
     the degree clause can late-merge above a Condition-C-relevant
-    binder iff there is a *scope-licit* chain position above the
-    binder. -/
+    binder iff there is a *scope-licit* chain position above the binder.
+    Chain positions are the shared `ChainPosition`; here `admissible`
+    reads as "scope-licit" (Heim-Kennedy-compliant DegP scope) rather
+    than "case-available". -/
 def degreeClauseLateMergerBleeds
-    (chain : List DegreeChainPosition) (binderHeight : Nat) : Bool :=
-  lateMergerBleeds (·.scopeOK) DegreeChainPosition.height chain binderHeight
+    (chain : List ChainPosition) (binderHeight : Nat) : Bool :=
+  lateMergerBleeds (·.admissible) ChainPosition.height chain binderHeight
 
 /-- A scope-licit position above the binder bleeds Condition C for
     degree-clause late merger. Specialization of
     `admissible_above_binder_bleeds`. -/
 theorem scopeOK_above_binder_bleeds
-    (chain : List DegreeChainPosition) (binderHeight h : Nat)
+    (chain : List ChainPosition) (binderHeight h : Nat)
     (hgt : h > binderHeight) :
     degreeClauseLateMergerBleeds (⟨h, true⟩ :: chain) binderHeight = true :=
   admissible_above_binder_bleeds _ _ chain ⟨h, true⟩ binderHeight rfl hgt
@@ -75,8 +67,8 @@ theorem scopeOK_above_binder_bleeds
 /-- If no chain position is scope-licit, the degree clause is forced to
     reconstruct. Specialization of `no_admissible_no_bleed`. -/
 theorem no_scopeOK_forces_reconstruction
-    (chain : List DegreeChainPosition) (binderHeight : Nat)
-    (h : ∀ p ∈ chain, p.scopeOK = false) :
+    (chain : List ChainPosition) (binderHeight : Nat)
+    (h : ∀ p ∈ chain, p.admissible = false) :
     degreeClauseLateMergerBleeds chain binderHeight = false :=
   no_admissible_no_bleed _ _ chain binderHeight h
 

--- a/Linglib/Syntax/Minimalist/LateMerger.lean
+++ b/Linglib/Syntax/Minimalist/LateMerger.lean
@@ -137,11 +137,13 @@ theorem no_admissible_no_bleed {α : Type*}
 
 /-- A position on a movement chain.
     `height` encodes structural position (higher = larger Nat).
-    `caseAvailable` records whether case can be assigned at this position
-    (i.e., whether the Case Filter can be satisfied here). -/
+    `admissible` records whether this position is admissible for the
+    relevant late-merger licensing — case assignment (WLM / Condition C,
+    `wlmBleedsCondC`) or scope licensing (degree clauses,
+    `DegreeMovement.degreeClauseLateMergerBleeds`). -/
 structure ChainPosition where
   height : Nat
-  caseAvailable : Bool
+  admissible : Bool
   deriving DecidableEq, Repr
 
 -- ============================================================================
@@ -158,7 +160,7 @@ structure ChainPosition where
     movement chain permits a case position higher than the pronoun
     binder. -/
 def wlmBleedsCondC (chain : List ChainPosition) (binderHeight : Nat) : Bool :=
-  lateMergerBleeds (·.caseAvailable) ChainPosition.height chain binderHeight
+  lateMergerBleeds (·.admissible) ChainPosition.height chain binderHeight
 
 /-- WLM forces Condition C reconstruction when no case position
     on the chain is above the binder. The NP restrictor must merge
@@ -209,10 +211,10 @@ theorem wlm_bleeding_monotone
     regardless of heights. Specialization of `no_admissible_no_bleed`. -/
 theorem no_case_forces_reconstruction
     (chain : List ChainPosition) (binderHeight : Nat)
-    (h : ∀ cp ∈ chain, cp.caseAvailable = false) :
+    (h : ∀ cp ∈ chain, cp.admissible = false) :
     wlmForcesReconstruction chain binderHeight = true := by
   simp [wlmForcesReconstruction, wlmBleedsCondC,
-        no_admissible_no_bleed (·.caseAvailable) ChainPosition.height
+        no_admissible_no_bleed (·.admissible) ChainPosition.height
           chain binderHeight h]
 
 -- ============================================================================
@@ -244,15 +246,9 @@ def conditionCSatisfied (tree binder rExpr : SyntacticObject) : Bool :=
     phase edge the mover passes through ([chomsky-2000]).
     Whether case is available at the edge determines whether WLM
     can target that position ([gong-2022]). -/
-structure PhaseEdgePosition where
+structure PhaseEdgePosition extends ChainPosition where
   phaseCat : Cat
-  height : Nat
-  caseAvailable : Bool
   deriving DecidableEq, Repr
-
-/-- Convert a phase edge position to a chain position for WLM. -/
-def PhaseEdgePosition.toChainPosition (p : PhaseEdgePosition) : ChainPosition :=
-  ⟨p.height, p.caseAvailable⟩
 
 /-- Derive chain positions from successive-cyclic movement through
     phase edges. Each phase edge the mover passes through becomes a
@@ -264,7 +260,8 @@ def successiveCyclicChain (edges : List PhaseEdgePosition) : List ChainPosition 
     case; it passes tense/agreement features to T via Feature Inheritance
     ([chomsky-2008]). -/
 theorem cp_edge_no_case (h : Nat) :
-    (PhaseEdgePosition.mk .C h false).toChainPosition.caseAvailable = false := rfl
+    ({ height := h, admissible := false, phaseCat := .C : PhaseEdgePosition
+      }).toChainPosition.admissible = false := rfl
 
 /-- LDS chain template: movement from an embedded clause through the
     CP edge to a matrix clause position. The CP edge provides no case,
@@ -276,14 +273,14 @@ theorem cp_edge_no_case (h : Nat) :
 def ldsChainTemplate (cpEdgeHeight matrixHeight : Nat) (matrixCaseAvailable : Bool)
     : List ChainPosition :=
   successiveCyclicChain [
-    ⟨.C, cpEdgeHeight, false⟩,
-    ⟨.v, matrixHeight, matrixCaseAvailable⟩
+    { height := cpEdgeHeight, admissible := false, phaseCat := .C },
+    { height := matrixHeight, admissible := matrixCaseAvailable, phaseCat := .v }
   ]
 
 /-- A CP edge alone never bleeds Condition C: case is unavailable. -/
 theorem lds_cp_edge_alone_no_bleed (cpEdgeHeight binderHeight : Nat) :
     wlmForcesReconstruction
-      (successiveCyclicChain [⟨.C, cpEdgeHeight, false⟩])
+      (successiveCyclicChain [{ height := cpEdgeHeight, admissible := false, phaseCat := .C }])
       binderHeight = true := by
   apply no_case_forces_reconstruction
   simp [successiveCyclicChain, List.map, PhaseEdgePosition.toChainPosition]


### PR DESCRIPTION
Collapses three near-identical movement-chain position structs onto one. `ChainPosition` becomes `{height, admissible}` (the field generalises the old `caseAvailable`/`scopeOK`, whose case-vs-scope meaning now lives in the wrapper/theorem names + docstrings); `DegreeChainPosition` is deleted (degree-clause code uses `ChainPosition`); and `PhaseEdgePosition extends ChainPosition` (its `toChainPosition` is now the auto-generated parent projection). The shared `lateMergerBleeds` operation and the generic `admissible_*` lemmas were already polymorphic — this dedups the trivial domain structs that sat on top of them.