### PR TITLE
feat(Syntax/Minimalist): add FeatureType + assignment FeatureBundle

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -6,6 +6,7 @@ and their interfaces. See README.md for documentation links.
 -/
 -- Core
 import Linglib.Features.Basic
+import Linglib.Features.Slot
 import Linglib.Features.Agreement
 import Linglib.Features.Dimension
 import Linglib.Features.Gender.Basic

--- a/Linglib/Features/Slot.lean
+++ b/Linglib/Features/Slot.lean
@@ -1,0 +1,135 @@
+import Mathlib.Order.Basic
+import Mathlib.Order.BoundedOrder.Basic
+
+/-!
+# Feature-checking slots
+[chomsky-2000] [marcolli-chomsky-berwick-2025]
+
+A *feature-checking slot* records the state of one feature dimension on a
+lexical item. Unlike a plain determinate slot (`Core/Order/Flat.lean`'s `Flat`,
+which is two-state — bottom or a value), a feature dimension under Agree is in
+one of **three** states:
+
+- `absent` — the item lacks the dimension (the order bottom `⊥`);
+- `unvalued` — a **probe**: the dimension is present but valueless
+  ([chomsky-2000]'s unvalued/uninterpretable feature, which searches for a goal);
+- `valued v` — the dimension is present with value `v`.
+
+`FeatureSlot` is **polymorphic** in the value type `α`, so it is reusable across
+feature spaces (φ-features, case, categorial features, …) and carries no
+commitment to any particular inventory.
+
+## Why this is decoupled from the Merge carrier
+
+Per [marcolli-chomsky-berwick-2025] (book p. 13), the valued/unvalued
+feature-checking apparatus is the **Stabler-Minimalism** layer: label-matching
+makes Merge partially defined, forcing "an algebraically more complex Hopf
+algebra and … a family of right-ideal coideals … which keep track of the feature
+checking problem." MCB's own free-Merge core (the SMT) keeps `SO₀` features
+*atomic* — Merge is free, with no feature checking. So feature-checking slots are
+an Agree-layer structure, kept general here and **decoupled from the
+`SyntacticObject` carrier** rather than baked into it.
+
+## Subsumption order
+
+`absent (⊥) < unvalued < valued v`, with distinct `valued` values forming an
+antichain: a probe is more specified than an absent dimension and less specified
+than a value, and two values are incomparable. This is the per-slot order that
+the bundle subsumption order (`Features.BundleLike.Subsumes`) is built from.
+-/
+
+namespace Features
+
+/-- A feature-checking slot for value type `α`: `absent` / `unvalued` (probe) /
+`valued v`. See the module docstring. -/
+inductive FeatureSlot (α : Type*) where
+  | absent
+  | unvalued
+  | valued (v : α)
+  deriving Repr, DecidableEq
+
+namespace FeatureSlot
+
+variable {α : Type*}
+
+instance : Bot (FeatureSlot α) := ⟨absent⟩
+
+@[simp] theorem bot_eq_absent : (⊥ : FeatureSlot α) = absent := rfl
+
+/-- The slot specifies a (present) feature: it is not `absent`. -/
+def isSpecified : FeatureSlot α → Bool
+  | absent => false
+  | _ => true
+
+/-- The slot is a probe (present but unvalued). -/
+def isUnvalued : FeatureSlot α → Bool
+  | unvalued => true
+  | _ => false
+
+/-- The slot carries a value. -/
+def isValued : FeatureSlot α → Bool
+  | valued _ => true
+  | _ => false
+
+/-- The value, when the slot is `valued`. -/
+def value? : FeatureSlot α → Option α
+  | valued v => some v
+  | _ => none
+
+/-- Subsumption: `absent ≤ unvalued ≤ valued v`, with distinct values
+incomparable. The reflexive-transitive order on the three checking states. -/
+protected inductive LE : FeatureSlot α → FeatureSlot α → Prop
+  | absent_le (s) : FeatureSlot.LE absent s
+  | unvalued_le_unvalued : FeatureSlot.LE unvalued unvalued
+  | unvalued_le_valued (v) : FeatureSlot.LE unvalued (valued v)
+  | valued_le_valued (v) : FeatureSlot.LE (valued v) (valued v)
+
+instance : LE (FeatureSlot α) := ⟨FeatureSlot.LE⟩
+
+theorem le_def {a b : FeatureSlot α} : a ≤ b ↔ FeatureSlot.LE a b := Iff.rfl
+
+protected theorem le_refl (a : FeatureSlot α) : a ≤ a := by
+  cases a with
+  | absent => exact .absent_le _
+  | unvalued => exact .unvalued_le_unvalued
+  | valued v => exact .valued_le_valued v
+
+protected theorem le_trans {a b c : FeatureSlot α} (hab : a ≤ b) (hbc : b ≤ c) :
+    a ≤ c := by
+  cases hab with
+  | absent_le => exact .absent_le _
+  | unvalued_le_unvalued => exact hbc
+  | unvalued_le_valued v => cases hbc with | valued_le_valued => exact .unvalued_le_valued v
+  | valued_le_valued v => exact hbc
+
+protected theorem le_antisymm {a b : FeatureSlot α} (hab : a ≤ b) (hba : b ≤ a) :
+    a = b := by
+  cases hab <;> cases hba <;> rfl
+
+instance : PartialOrder (FeatureSlot α) where
+  le_refl := FeatureSlot.le_refl
+  le_trans _ _ _ := FeatureSlot.le_trans
+  le_antisymm _ _ := FeatureSlot.le_antisymm
+
+instance : OrderBot (FeatureSlot α) where
+  bot_le a := .absent_le a
+
+instance [DecidableEq α] (a b : FeatureSlot α) : Decidable (a ≤ b) :=
+  match a, b with
+  | absent, _ => isTrue (.absent_le _)
+  | unvalued, unvalued => isTrue .unvalued_le_unvalued
+  | unvalued, valued v => isTrue (.unvalued_le_valued v)
+  | unvalued, absent => isFalse (by rintro ⟨⟩)
+  | valued v, valued w =>
+    if h : v = w then isTrue (h ▸ .valued_le_valued v)
+    else isFalse (by rintro ⟨⟩; exact h rfl)
+  | valued _, absent => isFalse (by rintro ⟨⟩)
+  | valued _, unvalued => isFalse (by rintro ⟨⟩)
+
+@[simp] theorem isSpecified_iff_ne_bot {s : FeatureSlot α} :
+    s.isSpecified = true ↔ s ≠ ⊥ := by
+  cases s <;> simp [isSpecified]
+
+end FeatureSlot
+
+end Features

--- a/Linglib/Syntax/Minimalist/Features.lean
+++ b/Linglib/Syntax/Minimalist/Features.lean
@@ -1,7 +1,9 @@
+import Linglib.Features.Basic
 import Linglib.Features.Case.Basic
 import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Features.Number.Basic
+import Linglib.Features.Slot
 
 /-!
 # Feature Infrastructure for Minimalist Agree
@@ -211,6 +213,151 @@ def hasValuedFeature (fb : FeatureBundle) (ftype : FeatureVal) : Bool :=
     Uses `sameType` for type-level matching. -/
 def getValuedFeature (fb : FeatureBundle) (ftype : FeatureVal) : Option GramFeature :=
   fb.find? λ f => f.isValued && f.featureType.sameType ftype
+
+-- ============================================================================
+-- § 5b: Feature Bundles as Assignments ([marcolli-chomsky-berwick-2025])
+-- ============================================================================
+
+/-! The list representation `FeatureBundle = List GramFeature` admits
+junk — duplicate dimensions, conflicting values — and is not extensional,
+so it cannot be a `LawfulBundleLike` (the `Features/Basic.lean` Todo). The
+canonical bundle is instead a **total assignment** from feature dimensions
+to three-state checking slots (`Features.FeatureSlot`): one slot per
+dimension, `absent` / `unvalued` (probe) / `valued v`. This is the
+Agree-layer structure; per [marcolli-chomsky-berwick-2025] (book p. 13)
+the free-Merge core keeps `SO₀` features atomic, so the slot apparatus is
+decoupled from the `SyntacticObject` carrier and lives in `Features/Slot.lean`.
+
+`FeatureAssignment` is the replacement carrier; `ofGramFeatures` bridges
+the legacy list form for incremental migration. -/
+
+/-- The feature *dimensions* checked via Agree — the equivalence classes of
+`FeatureVal.sameType`. φ-features split into their three sub-dimensions
+(`person`, `number`, `gender`) so each is a slot in its own right. -/
+inductive FeatureType where
+  | person | number | gender
+  | case | wh | q | epp | tense | hon | finite | factive | neg | rel
+  | oblique | ellipsis | catN | catV | foc | pol | pov
+  | atomic | minimal | participant | author
+  deriving Repr, DecidableEq, Fintype
+
+/-- The dimension a feature value belongs to. Two values share a dimension
+iff `FeatureVal.sameType` holds. -/
+def FeatureVal.dimension : FeatureVal → FeatureType
+  | .phi (.person _) => .person
+  | .phi (.number _) => .number
+  | .phi (.gender _) => .gender
+  | .case _ => .case
+  | .wh _ => .wh
+  | .q _ => .q
+  | .epp _ => .epp
+  | .tense _ => .tense
+  | .hon _ => .hon
+  | .finite _ => .finite
+  | .factive _ => .factive
+  | .neg _ => .neg
+  | .rel _ => .rel
+  | .oblique _ => .oblique
+  | .ellipsis _ => .ellipsis
+  | .catN _ => .catN
+  | .catV _ => .catV
+  | .foc _ => .foc
+  | .pol _ => .pol
+  | .pov _ => .pov
+  | .atomic _ => .atomic
+  | .minimal _ => .minimal
+  | .participant _ => .participant
+  | .author _ => .author
+
+/-- The value space of a dimension: the canonical type a slot at that
+dimension carries (`person ↦ Person`, `number ↦ Number`, `gender ↦ Nat`,
+`case ↦ Case`, `hon ↦ HonLevel`, every binary dimension `↦ Bool`). -/
+@[reducible] def FeatureType.ValueOf : FeatureType → Type
+  | .person => Person
+  | .number => Number
+  | .gender => Nat
+  | .case => Case
+  | .hon => HonLevel
+  | .wh | .q | .epp | .tense | .finite | .factive | .neg | .rel
+  | .oblique | .ellipsis | .catN | .catV | .foc | .pol | .pov
+  | .atomic | .minimal | .participant | .author => Bool
+
+instance (t : FeatureType) : DecidableEq t.ValueOf := by
+  cases t <;> exact inferInstance
+
+/-- The value carried by a feature value, in its dimension's value space. -/
+def FeatureVal.value : (fv : FeatureVal) → fv.dimension.ValueOf
+  | .phi (.person p) => p
+  | .phi (.number n) => n
+  | .phi (.gender g) => g
+  | .case c => c
+  | .wh b => b
+  | .q b => b
+  | .epp b => b
+  | .tense b => b
+  | .hon hl => hl
+  | .finite b => b
+  | .factive b => b
+  | .neg b => b
+  | .rel b => b
+  | .oblique b => b
+  | .ellipsis b => b
+  | .catN b => b
+  | .catV b => b
+  | .foc b => b
+  | .pol b => b
+  | .pov b => b
+  | .atomic b => b
+  | .minimal b => b
+  | .participant b => b
+  | .author b => b
+
+/-- A feature bundle as a total assignment: each dimension maps to a
+three-state checking slot. The canonical extensional carrier — replacing
+`List GramFeature` — that is `LawfulBundleLike`. -/
+abbrev FeatureAssignment := (t : FeatureType) → Features.FeatureSlot t.ValueOf
+
+namespace FeatureAssignment
+
+instance : BundleLike FeatureAssignment FeatureType (λ t => Features.FeatureSlot t.ValueOf) :=
+  ⟨λ b => b⟩
+
+instance : LawfulBundleLike FeatureAssignment :=
+  ⟨λ _ _ h => h⟩
+
+/-- The bundle has a valued feature of the given dimension. -/
+def hasValuedFeature (a : FeatureAssignment) (t : FeatureType) : Bool :=
+  (a t).isValued
+
+/-- The bundle has an unvalued (probe) feature of the given dimension. -/
+def hasUnvaluedFeature (a : FeatureAssignment) (t : FeatureType) : Bool :=
+  (a t).isUnvalued
+
+/-- The value at the given dimension, when valued. -/
+def getValuedFeature (a : FeatureAssignment) (t : FeatureType) : Option t.ValueOf :=
+  (a t).value?
+
+/-- The assignment specifying exactly one valued dimension, all others absent. -/
+def single (t : FeatureType) (v : t.ValueOf) : FeatureAssignment :=
+  Function.update (⊥ : FeatureAssignment) t (.valued v)
+
+@[simp] theorem single_self (t : FeatureType) (v : t.ValueOf) :
+    single t v t = .valued v := by
+  simp [single]
+
+end FeatureAssignment
+
+/-- The checking slot a single grammatical feature contributes at its own
+dimension: `valued v ↦ valued v.value`, `unvalued _ ↦ unvalued`. -/
+def GramFeature.toSlot : (gf : GramFeature) → Features.FeatureSlot gf.featureType.dimension.ValueOf
+  | .valued v => .valued v.value
+  | .unvalued _ => .unvalued
+
+/-- Bridge from the legacy list representation: fold each feature into its
+dimension's slot, the list head taking precedence on duplicate dimensions
+(matching `getValuedFeature`/`find?` first-match semantics). -/
+def FeatureAssignment.ofGramFeatures (l : List GramFeature) : FeatureAssignment :=
+  l.foldr (λ gf a => Function.update a gf.featureType.dimension gf.toSlot) ⊥
 
 -- ============================================================================
 -- § 6: ±Interpretable Features


### PR DESCRIPTION
Additive P1 of the FeatureBundle retype. Introduces the assignment-based bundle alongside the legacy `List GramFeature` (no flip yet).

- `Features/Slot.lean`: polymorphic 3-state checking slot `absent < unvalued < valued v`, decoupled from the Merge carrier per [marcolli-chomsky-berwick-2025].
- `Minimalist.FeatureType` (24 dims) + `ValueOf` + `FeatureAssignment := (t) → FeatureSlot t.ValueOf`, with lawful `BundleLike` (discharges the `Features/Basic.lean` Todo), re-keyed query API, and `ofGramFeatures` bridge for incremental migration.