### PR TITLE
feat(Syntax/Minimalist): retype FeatureBundle as a slot assignment

### DIFF
--- a/Linglib/Fragments/Basque/Postsyntax.lean
+++ b/Linglib/Fragments/Basque/Postsyntax.lean
@@ -48,22 +48,24 @@ open Minimalist
     The trigger of [middleton-2026] (16) Participant
     Dissimilation. -/
 def abs1pAuthor : FeatureBundle :=
-  [.valued (.case .abs),
-   .valued (.participant true),
-   .valued (.author true)]
+  .ofGramFeatures
+    [.valued (.case .abs),
+     .valued (.participant true),
+     .valued (.author true)]
 
 /-- A 2nd-person ergative clitic: `[CL ERG +participant −author]`.
     The right-context of [middleton-2026] (16) — the participant
     ergative that licenses deletion of `abs1pAuthor`. -/
 def erg2s : FeatureBundle :=
-  [.valued (.case .erg),
-   .valued (.participant true),
-   .valued (.author false)]
+  .ofGramFeatures
+    [.valued (.case .erg),
+     .valued (.participant true),
+     .valued (.author false)]
 
 /-- A T head with `[+tense]`. The leftmost-position trigger and
     swap-source of [middleton-2026] (13) Ergative Metathesis. -/
 def tPast : FeatureBundle :=
-  [.valued (.tense true)]
+  .ofGramFeatures [.valued (.tense true)]
 
 -- ============================================================================
 -- § 2: Terminal Predicates
@@ -71,30 +73,29 @@ def tPast : FeatureBundle :=
 
 /-- Does the bundle bear `[+tense]`? Diagnoses a T head. -/
 def isT (fb : FeatureBundle) : Bool :=
-  fb.any (λ f => f.featureType.sameType (.tense true))
+  (fb .tense).isSpecified
 
 /-- Does the bundle bear an ergative case marker? Diagnoses an ERG
-    clitic. -/
+    clitic. (Matching is by dimension — any valued/unvalued case feature.) -/
 def isErgClitic (fb : FeatureBundle) : Bool :=
-  fb.any (λ f => f.featureType.sameType (.case .erg))
+  (fb .case).isSpecified
 
 /-- Does the bundle bear an absolutive case marker? Diagnoses an ABS
-    clitic. -/
+    clitic. (Matching is by dimension — any valued/unvalued case feature.) -/
 def isAbsClitic (fb : FeatureBundle) : Bool :=
-  fb.any (λ f => f.featureType.sameType (.case .abs))
+  (fb .case).isSpecified
 
 /-- Does the bundle bear `[+participant]`? -/
 def isParticipant (fb : FeatureBundle) : Bool :=
-  hasValuedFeature fb (.participant true) &&
-  fb.any (λ f => match f with
-    | .valued (.participant true) => true
-    | _ => false)
+  match fb .participant with
+  | .valued true => true
+  | _ => false
 
 /-- Does the bundle bear `[+author]`? -/
 def isAuthor (fb : FeatureBundle) : Bool :=
-  fb.any (λ f => match f with
-    | .valued (.author true) => true
-    | _ => false)
+  match fb .author with
+  | .valued true => true
+  | _ => false
 
 /-- A 1st-person absolutive clitic — `[CL ABS +participant +author]`,
     the deletion target of Participant Dissimilation. -/

--- a/Linglib/Fragments/Taos/Agreement.lean
+++ b/Linglib/Fragments/Taos/Agreement.lean
@@ -93,7 +93,7 @@ def numPl : List FeatureVal := [fAtomic false, fMinimal false]
     aligned per the Taos ordering convention `[±part]:[±auth]:[±atom]:[±min]`
     ([middleton-2026] ex. 4 and 5). -/
 def argBundle (person number : List FeatureVal) : FeatureBundle :=
-  (person ++ number).map .valued
+  .ofGramFeatures ((person ++ number).map .valued)
 
 -- ============================================================================
 -- § 4: Diagnostic Prefixes (Middleton 2026, Tables 1, 22, 25)

--- a/Linglib/Morphology/DM/Impoverishment.lean
+++ b/Linglib/Morphology/DM/Impoverishment.lean
@@ -135,9 +135,10 @@ def syntagmatic (cond : Neighborhood → Bool) (target : FeatureVal) :
 -- § 5: Applying Impoverishment
 -- ============================================================================
 
-/-- Delete all features matching `target` from a bundle. -/
+/-- Delete all features matching `target` from a bundle: set its dimension's
+slot to `absent`. -/
 def deleteFeature (fb : FeatureBundle) (target : FeatureVal) : FeatureBundle :=
-  fb.filter (λ f => !f.featureType.sameType target)
+  Function.update fb target.dimension .absent
 
 /-- Apply an Impoverishment rule at a neighborhood: when the condition
     holds, return the focus with `target` deleted; otherwise return the
@@ -208,7 +209,7 @@ def allRecoverable (recoverable pronFeatures : List FeatureVal) : Bool :=
 def redundancyRule (source : List FeatureVal) (target : FeatureVal) :
     ImpoverishmentRule :=
   paradigmatic
-    (λ fb => allRecoverable source (fb.map GramFeature.featureType))
+    (λ fb => allRecoverable source ((FeatureBundle.toGramFeatures fb).map GramFeature.featureType))
     target
 
 /-- Redundancy rules are paradigmatic. -/
@@ -224,9 +225,6 @@ theorem redundancyRule_isParadigmatic (source : List FeatureVal)
     (Filter is idempotent when the predicate is stable.) -/
 theorem deleteFeature_idempotent (fb : FeatureBundle) (target : FeatureVal) :
     deleteFeature (deleteFeature fb target) target = deleteFeature fb target := by
-  simp only [deleteFeature, List.filter_filter]
-  congr 1
-  ext f
-  simp only [Bool.and_self]
+  simp only [deleteFeature, Function.update_idem]
 
 end Morphology.DM.Impoverishment

--- a/Linglib/Morphology/DM/VocabSimple.lean
+++ b/Linglib/Morphology/DM/VocabSimple.lean
@@ -54,7 +54,8 @@ structure VocabEntry where
     type) in the target bundle. This is subset matching — the entry
     need not specify all features of the target. -/
 def VocabEntry.MatchesFeatures (entry : VocabEntry) (target : FeatureBundle) : Prop :=
-  entry.features.all (λ ef => target.any (λ tf => ef == tf)) = true
+  (FeatureBundle.toGramFeatures entry.features).all
+    (λ ef => (FeatureBundle.toGramFeatures target).any (λ tf => ef == tf)) = true
 
 instance (entry : VocabEntry) (target : FeatureBundle) :
     Decidable (entry.MatchesFeatures target) :=
@@ -75,7 +76,7 @@ instance (entry : VocabEntry) (target : FeatureBundle) (ctx : Option Cat) :
 /-- Specificity of a vocabulary entry: the number of features it specifies.
     Used for Elsewhere ordering — more specific entries take priority. -/
 def VocabEntry.specificity (entry : VocabEntry) : Nat :=
-  entry.features.length
+  (FeatureBundle.toGramFeatures entry.features).length
 
 -- ============================================================================
 -- § 2: Vocabulary and Spellout
@@ -113,9 +114,10 @@ def spellout (vocab : Vocabulary) (target : FeatureBundle) (ctx : Option Cat) : 
 
 /-- A vocabulary entry with no features matches any target (Elsewhere entry). -/
 theorem empty_features_matches_any (entry : VocabEntry)
-    (h : entry.features = []) (target : FeatureBundle) :
+    (h : entry.features = ⊥) (target : FeatureBundle) :
     entry.MatchesFeatures target := by
-  simp only [VocabEntry.MatchesFeatures, h, List.all_nil]
+  have hb : FeatureBundle.toGramFeatures entry.features = [] := by rw [h]; rfl
+  simp only [VocabEntry.MatchesFeatures, hb, List.all_nil]
 
 -- ============================================================================
 -- § 4: Vocabulary Builders
@@ -138,7 +140,7 @@ def _root_.Agreement.Cell.toPhiFeatures (c : Agreement.Cell) : List PhiFeature :
 def makePersonVocab {PN : Type*} (cells : List PN) (toPhi : PN → List PhiFeature)
     (exponentOf : PN → String) (ctx : Option Cat := none) : Vocabulary :=
   cells.map λ pn =>
-    { features := (toPhi pn).map (λ p => .valued (.phi p))
+    { features := .ofGramFeatures ((toPhi pn).map (λ p => .valued (.phi p)))
     , exponent := exponentOf pn
     , context := ctx }
 

--- a/Linglib/Studies/AdamsonZompi2025.lean
+++ b/Linglib/Studies/AdamsonZompi2025.lean
@@ -465,12 +465,12 @@ theorem pconstraint_allows_imposter :
 /-- A feature bundle for a 3rd person DP (LEI's agreement features).
     The probe sees [Person:3rd]. -/
 private def lei_agreement_bundle : Minimalist.FeatureBundle :=
-  [.valued (.phi (.person .third))]
+  .ofGramFeatures [.valued (.phi (.person .third))]
 
 /-- A feature bundle for a 2nd person DP (LEI's interpretable features).
     The probe sees [Person:2nd]. -/
 private def lei_interpretable_bundle : Minimalist.FeatureBundle :=
-  [.valued (.phi (.person .second))]
+  .ofGramFeatures [.valued (.phi (.person .second))]
 
 /-- A probe seeking person features finds them on both bundles — the
     probe can Agree with either. The issue is WHICH person value it sees. -/

--- a/Linglib/Studies/AlokBhalla2026.lean
+++ b/Linglib/Studies/AlokBhalla2026.lean
@@ -158,12 +158,12 @@ structure AllocAgree where
 
 /-- Probe features for allocutive agreement: unvalued [uHON]. -/
 def allocProbeFeatures (level : HonLevel) : FeatureBundle :=
-  [.unvalued (.hon level)]
+  .ofGramFeatures [.unvalued (.hon level)]
 
 /-- Addressee DP features: valued [iHON] and [person:2].
     The addressee is always 2nd person. -/
 def addresseeDPFeatures (level : HonLevel) : FeatureBundle :=
-  [.valued (.hon level), .valued (.phi (.person .second))]
+  .ofGramFeatures [.valued (.hon level), .valued (.phi (.person .second))]
 
 -- ============================================================================
 -- Section B: Embeddability from Probe Location
@@ -282,7 +282,7 @@ theorem hon_features_match (level : HonLevel) :
     with [uHON] against an addressee with [iHON] values the probe. -/
 theorem hon_agree_values (level : HonLevel) :
     applyAgree (allocProbeFeatures level) (addresseeDPFeatures level) (.hon level)
-      = some [.valued (.hon level)] := by
+      = some (.ofGramFeatures [.valued (.hon level)]) := by
   cases level <;> native_decide
 
 /-- Bridge to Studies/BhattDayal2020: SAP unembeddability

--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -616,18 +616,18 @@ def keSatisfaction : SatisfactionCond :=
     `sameType` matching in Agree.lean). -/
 theorem ke_satisfied_by_phi :
     keSatisfaction.isSatisfied
-      [.valued (.phi (.person .first))]
-      none = true := by rfl
+      (.ofGramFeatures [.valued (.phi (.person .first))])
+      none = true := by decide
 
 /-- *ke* is satisfied by encountering the TP boundary even with no φ-features
     on the goal — the disjunctive escape that yields null surface agreement. -/
 theorem ke_satisfied_by_head_encounter :
-    keSatisfaction.isSatisfied [] (some .T) = true := by rfl
+    keSatisfaction.isSatisfied ⊥ (some .T) = true := by decide
 
 /-- The head-encounter satisfaction copies no features (default null surface
     agreement when subject lacks φ). -/
 theorem ke_head_encounter_no_copy :
-    keSatisfaction.copiedFeatures [] (some .T) = false := by rfl
+    keSatisfaction.copiedFeatures ⊥ (some .T) = false := by decide
 
 -- ============================================================================
 -- §7. Internal-Ā-dependency profile

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -153,7 +153,7 @@ the theory-neutral `mamVoiceSystem : VoiceSystemProfile`.
 def mamVoice : VoiceHead :=
   { flavor := .agentive
   , hasD := true
-  , features := [.unvalued (.oblique false)] }
+  , features := .ofGramFeatures [.unvalued (.oblique false)] }
 
 /-- Mam transitive clause spine: full CP with Voice. -/
 def mamTransitiveSpine : ClauseSpine := ClauseSpine.cP
@@ -182,7 +182,7 @@ structure MamDirHead where
 
 /-- Dir⁰'s probe features when it carries [uOblique]. -/
 def MamDirHead.features (d : MamDirHead) : FeatureBundle :=
-  if d.hasUOblique then [.unvalued (.oblique false)] else []
+  if d.hasUOblique then .ofGramFeatures [.unvalued (.oblique false)] else ⊥
 
 /-- Cislocative directional with [uOblique]. -/
 def dirCis : MamDirHead := { cislocative := true, hasUOblique := true }
@@ -192,7 +192,7 @@ def dirTrans : MamDirHead := { cislocative := false, hasUOblique := true }
 
 /-- Vocabulary entry for =(y)a': maps [+oblique] on Voice⁰ to "=(y)a'". -/
 def eqYaVocab : VocabEntry :=
-  { features := [.valued (.oblique true)]
+  { features := .ofGramFeatures [.valued (.oblique true)]
   , exponent := "=(y)a'"
   , context := some .Voice }
 
@@ -205,14 +205,14 @@ def mamVoiceVocab : Vocabulary := [eqYaVocab]
 def mamPassiveVoice : VoiceHead :=
   { flavor := .nonThematic
   , hasD := false
-  , features := [.unvalued (.oblique false)] }
+  , features := .ofGramFeatures [.unvalued (.oblique false)] }
 
 /-- Mam antipassive Voice head ([scott-2023] §2.5.4.1).
     Subject gets ABS not ERG; not a phase head. -/
 def mamAntipassiveVoice : VoiceHead :=
   { flavor := .antipassive
   , hasD := true
-  , features := [] }
+  , features := ⊥ }
 
 -- ── Substrate-level theorems ─────────────────────────────────────────
 
@@ -274,18 +274,18 @@ theorem antipassive_vs_agentive :
 
 /-- Valued [+oblique] on Voice spells out as =(y)a'. -/
 theorem spellout_oblique_voice :
-    spellout mamVoiceVocab [.valued (.oblique true)] (some .Voice) = some "=(y)a'" := by
+    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) (some .Voice) = some "=(y)a'" := by
   decide
 
 /-- Without [+oblique], Voice has no exponent from this vocabulary. -/
 theorem spellout_no_oblique :
-    spellout mamVoiceVocab [.valued (.oblique false)] (some .Voice) = none := by
+    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique false)]) (some .Voice) = none := by
   decide
 
 /-- [+oblique] on a non-Voice head does not yield =(y)a'
     (context restriction blocks insertion). -/
 theorem spellout_oblique_wrong_context :
-    spellout mamVoiceVocab [.valued (.oblique true)] (some .T) = none := by
+    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) (some .T) = none := by
   decide
 
 -- ============================================================================
@@ -433,7 +433,7 @@ theorem dir_probe_matches_voice :
 
 /-- Dir⁰ with valued [+oblique] also spells out as =(y)a'. -/
 theorem dir_spellout_eqya :
-    spellout mamVoiceVocab [.valued (.oblique true)] (some .Voice) = some "=(y)a'" := by
+    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) (some .Voice) = some "=(y)a'" := by
   decide
 
 -- ============================================================================
@@ -461,17 +461,17 @@ theorem voice_has_uOblique :
     hasUnvaluedFeature mamVoice.features (.oblique false) = true := by
   decide
 
-private def oblique_goal_features : FeatureBundle := [.valued (.oblique true)]
+private def oblique_goal_features : FeatureBundle := .ofGramFeatures [.valued (.oblique true)]
 
 /-- Agree at Voice: [uOblique] valued by oblique DP's [+oblique]. -/
 theorem voice_agree_values_oblique :
     applyAgree mamVoice.features oblique_goal_features (.oblique false) =
-    some [.valued (.oblique true)] := by
+    some (.ofGramFeatures [.valued (.oblique true)]) := by
   decide
 
 /-- Spellout: valued [+oblique] on Voice maps to "=(y)a'". -/
 theorem voice_spellout_eqya :
-    spellout mamVoiceVocab [.valued (.oblique true)] (some .Voice) =
+    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) (some .Voice) =
     some "=(y)a'" := by
   decide
 
@@ -511,8 +511,8 @@ private def voiceOblProbe : FeatureBundle := mamVoice.features
 
 /-- Both Voice probes are unvalued features. -/
 theorem both_probes_unvalued :
-    voiceProbe.all GramFeature.isUnvalued = true ∧
-    voiceOblProbe.all GramFeature.isUnvalued = true := by
+    (Minimalist.FeatureBundle.toGramFeatures voiceProbe).all GramFeature.isUnvalued = true ∧
+    (Minimalist.FeatureBundle.toGramFeatures voiceOblProbe).all GramFeature.isUnvalued = true := by
   exact ⟨by native_decide, by native_decide⟩
 
 /-- φ-Agree (Scott 2023) and oblique-Agree (this paper) are parallel
@@ -524,9 +524,9 @@ theorem phi_and_oblique_agree_parallel :
       (λ fb => applyAgree fb dp3sg (.phi (.number .singular))) = some voiceFullyAgreed ∧
     spellout setAVocab voiceFullyAgreed (some .v) = some "t-" ∧
     -- Oblique-Agree pipeline: value oblique, then spellout
-    applyAgree voiceOblProbe [.valued (.oblique true)] (.oblique false) =
-      some [.valued (.oblique true)] ∧
-    spellout [eqYaVocab] [.valued (.oblique true)] (some .Voice) = some "=(y)a'" := by
+    applyAgree voiceOblProbe (.ofGramFeatures [.valued (.oblique true)]) (.oblique false) =
+      some (.ofGramFeatures [.valued (.oblique true)]) ∧
+    spellout [eqYaVocab] (.ofGramFeatures [.valued (.oblique true)]) (some .Voice) = some "=(y)a'" := by
   exact ⟨by native_decide, by native_decide, by native_decide, by native_decide⟩
 
 end UnifiedAgree

--- a/Linglib/Studies/Middleton2026.lean
+++ b/Linglib/Studies/Middleton2026.lean
@@ -96,9 +96,9 @@ def focusRule (focusCheck : FeatureBundle → Bool)
   swapFst := swapFst
   swapSnd := swapSnd
 
-/-- Index of the first feature in `fb` whose type matches `fv`. -/
-def indexOfType (fb : FeatureBundle) (fv : FeatureVal) : Option Nat :=
-  fb.findIdx? (λ f => f.featureType.sameType fv)
+/-- Index of the first feature in `l` whose type matches `fv`. -/
+def indexOfType (l : List GramFeature) (fv : FeatureVal) : Option Nat :=
+  l.findIdx? (λ f => f.featureType.sameType fv)
 
 /-- Swap the elements at positions `i` and `j` in a list. Out-of-bounds
     indices leave the list unchanged. -/
@@ -107,15 +107,33 @@ def swapAt {α : Type _} (l : List α) (i j : Nat) : List α :=
   | some xi, some xj => (l.set i xj).set j xi
   | _, _ => l
 
-/-- Apply a metathesis rule at a neighborhood: when the condition holds,
-    locate the first occurrences of `swapFst` and `swapSnd` in the focus
-    and exchange their positions; otherwise return the focus unchanged. -/
+/-- Reorder the focus exponents by swapping the first occurrences of
+    `swapFst` and `swapSnd` (their *linear positions* in the terminal's
+    exponent string). Metathesis is inherently an operation on linear
+    order, so it acts on the ordered `toGramFeatures` view. -/
+def swapInBundle (fb : FeatureBundle) (swapFst swapSnd : FeatureVal) :
+    List GramFeature :=
+  let l := FeatureBundle.toGramFeatures fb
+  match indexOfType l swapFst, indexOfType l swapSnd with
+  | some i, some j => swapAt l i j
+  | _, _ => l
+
+/-- Apply a metathesis rule at a neighborhood, returning the resulting
+    *bundle*. When the condition holds, swap the positions of `swapFst`
+    and `swapSnd` in the focus exponent string.
+
+    NB: the canonical `FeatureBundle` is a total assignment keyed by feature
+    *dimension*, hence order-insensitive; folding the swapped exponent list
+    back via `ofGramFeatures` therefore launders the reordering away. The
+    bundle-level result is thus a no-op whenever the swapped types differ,
+    which is correct for the *pipeline* below (`runStrict`/`runInterleaved`
+    only ever carry an empty metathesis chain). The empirically contentful,
+    order-sensitive focus-level metathesis of [middleton-2026] is stated on
+    the exponent-string view directly (`derivIM`/`derivMI`). -/
 def applyMetathesis (rule : MetathesisRule) (n : Neighborhood) :
     FeatureBundle :=
   if rule.condition n then
-    match indexOfType n.focus rule.swapFst, indexOfType n.focus rule.swapSnd with
-    | some i, some j => swapAt n.focus i j
-    | _, _ => n.focus
+    FeatureBundle.ofGramFeatures (swapInBundle n.focus rule.swapFst rule.swapSnd)
   else n.focus
 
 /-- Apply a sequence of metathesis rules left-to-right. Each rule sees
@@ -294,8 +312,8 @@ theorem runImpov_neq_runMeta_of_diverges
 def paraAtomicRule : ImpoverishmentRule :=
   paradigmatic
     (λ fb =>
-      fb.any (λ f => f.featureType.sameType (fAuthor true)) &&
-      fb.any (λ f => f.featureType.sameType (fMinimal true)))
+      (FeatureBundle.toGramFeatures fb).any (λ f => f.featureType.sameType (fAuthor true)) &&
+      (FeatureBundle.toGramFeatures fb).any (λ f => f.featureType.sameType (fMinimal true)))
     (fAtomic true)
 
 theorem paraAtomicRule_isParadigmatic : Paradigmatic paraAtomicRule :=
@@ -310,7 +328,7 @@ theorem paraAtomicRule_isParadigmatic : Paradigmatic paraAtomicRule :=
     proves it. -/
 def synMinimalRule : ImpoverishmentRule where
   condition n :=
-    (n.focus.any (λ f => f.featureType.sameType (fAtomic true)) = true)
+    ((FeatureBundle.toGramFeatures n.focus).any (λ f => f.featureType.sameType (fAtomic true)) = true)
     ∧ (n.rightCtx.length > 0)
   decCond _ := inferInstance
   target := fMinimal true
@@ -321,7 +339,8 @@ def synMinimalRule : ImpoverishmentRule where
     `rightCtx`. -/
 theorem synMinimalRule_isSyntagmatic : Syntagmatic synMinimalRule := by
   intro hPara
-  let fb : FeatureBundle := [.valued (fAtomic true), .valued (fMinimal true)]
+  let fb : FeatureBundle :=
+    .ofGramFeatures [.valued (fAtomic true), .valued (fMinimal true)]
   let n₁ : Neighborhood :=
     { focus := fb, leftCtx := [], rightCtx := [argBundle person3 numSg] }
   let n₂ : Neighborhood := { focus := fb, leftCtx := [], rightCtx := [] }
@@ -336,9 +355,10 @@ theorem synMinimalRule_isSyntagmatic : Syntagmatic synMinimalRule := by
 /-- Witness focus: a 1s-style bundle `[+author, +atomic, +minimal]`
     (suppressing `[+participant]`, which is irrelevant to either rule). -/
 def witnessFocus : FeatureBundle :=
-  [.valued (fAuthor true),
-   .valued (fAtomic true),
-   .valued (fMinimal true)]
+  .ofGramFeatures
+    [.valued (fAuthor true),
+     .valued (fAtomic true),
+     .valued (fMinimal true)]
 
 /-- Witness neighborhood: the 1s-style focus, with a real 3s
     bundle to the right standing in for the Taos object slot
@@ -364,7 +384,7 @@ def stripSynPara : FeatureBundle :=
     The `[+minimal]` survives. -/
 theorem stripParaSyn_eq :
     stripParaSyn =
-      [.valued (fAuthor true), .valued (fMinimal true)] := by
+      .ofGramFeatures [.valued (fAuthor true), .valued (fMinimal true)] := by
   decide
 
 /-- Syn-then-para (= Middleton): `synMinimalRule` fires first (focus
@@ -373,7 +393,7 @@ theorem stripParaSyn_eq :
     The `[+atomic]` survives instead. -/
 theorem stripSynPara_eq :
     stripSynPara =
-      [.valued (fAuthor true), .valued (fAtomic true)] := by
+      .ofGramFeatures [.valued (fAuthor true), .valued (fAtomic true)] := by
   decide
 
 /-- The two orders produce different feature bundles at this
@@ -402,7 +422,7 @@ def middletonPostsyntax : InterleavedPostsyntax :=
 /-- A&N's pipeline computes the para-first answer at the witness. -/
 theorem arregiNevins_witness :
     runStrict arregiNevinsPostsyntax witness =
-      [.valued (fAuthor true), .valued (fMinimal true)] := by
+      .ofGramFeatures [.valued (fAuthor true), .valued (fMinimal true)] := by
   show runStrict { paradigmatic := [paraAtomicRule]
                    syntagmatic := [synMinimalRule]
                    metathesis := [] } witness = _
@@ -412,7 +432,7 @@ theorem arregiNevins_witness :
 /-- Middleton's pipeline computes the (different) syn-first answer. -/
 theorem middleton_witness :
     runInterleaved middletonPostsyntax witness =
-      [.valued (fAuthor true), .valued (fAtomic true)] := by
+      .ofGramFeatures [.valued (fAuthor true), .valued (fAtomic true)] := by
   show runInterleaved { impoverishment := [synMinimalRule, paraAtomicRule]
                         metathesis := [] } witness = _
   rw [runInterleaved_admits_synPara paraAtomicRule synMinimalRule witness]
@@ -444,26 +464,63 @@ theorem arregiNevins_neq_middleton_at_witness :
 def authorAtomicMetathesis : MetathesisRule :=
   focusRule
     (λ fb =>
-      fb.any (λ f => f.featureType.sameType (fAuthor true)) &&
-      fb.any (λ f => f.featureType.sameType (fAtomic true)) &&
-      fb.any (λ f => f.featureType.sameType (fMinimal true)))
+      (FeatureBundle.toGramFeatures fb).any (λ f => f.featureType.sameType (fAuthor true)) &&
+      (FeatureBundle.toGramFeatures fb).any (λ f => f.featureType.sameType (fAtomic true)) &&
+      (FeatureBundle.toGramFeatures fb).any (λ f => f.featureType.sameType (fMinimal true)))
     (fAuthor true)
     (fAtomic true)
 
-/-- Impoverishment-then-metathesis (Middleton's and A&N's shared
-    order). -/
-def derivIM : FeatureBundle :=
-  applyMetathesisChain [authorAtomicMetathesis]
-    { witness with focus := applyImpoverishmentChain [synMinimalRule] witness }
+/-! Metathesis reorders the *exponent string* of a terminal; the canonical
+`FeatureBundle` (a dimension-keyed total assignment) is order-insensitive
+and cannot witness that reordering. The order-sensitive content of
+[middleton-2026]'s "metathesis must follow impoverishment" claim is
+therefore stated on the ordered exponent view `List GramFeature`. (The
+whole-terminal Basque half below, where order lives at the *phrase* level
+in `List FeatureBundle`, is unaffected and witnesses the same claim with a
+different rule shape.) -/
 
-/-- Metathesis-then-impoverishment (the order both authors reject). -/
-def derivMI : FeatureBundle :=
-  applyImpoverishmentChain [synMinimalRule]
-    { witness with focus := applyMetathesisChain [authorAtomicMetathesis] witness }
+/-- Apply a metathesis rule to an ordered exponent string: when the rule's
+    condition holds at the corresponding bundle, swap the first occurrences
+    of `swapFst` and `swapSnd` in the list; otherwise leave it unchanged. -/
+def applyMetathesisExp (rule : MetathesisRule) (l : List GramFeature) :
+    List GramFeature :=
+  if rule.condition (Neighborhood.ofBundle (.ofGramFeatures l)) then
+    match indexOfType l rule.swapFst, indexOfType l rule.swapSnd with
+    | some i, some j => swapAt l i j
+    | _, _ => l
+  else l
+
+/-- Apply an impoverishment rule to an ordered exponent string in the
+    witness context: when the rule fires, drop every exponent of the
+    target's dimension, preserving the order of the survivors. -/
+def applyImpovExp (rule : ImpoverishmentRule) (l : List GramFeature) :
+    List GramFeature :=
+  if rule.condition { witness with focus := .ofGramFeatures l } then
+    l.filter (λ f => ! f.featureType.sameType rule.target)
+  else l
+
+/-- Witness exponent string: `[+author, +atomic, +minimal]`, the ordered
+    view of `witnessFocus`. -/
+def witnessExp : List GramFeature :=
+  FeatureBundle.toGramFeatures witnessFocus
+
+/-- Impoverishment-then-metathesis (Middleton's and A&N's shared
+    order), on the exponent string. -/
+def derivIM : List GramFeature :=
+  applyMetathesisExp authorAtomicMetathesis (applyImpovExp synMinimalRule witnessExp)
+
+/-- Metathesis-then-impoverishment (the order both authors reject), on the
+    exponent string. -/
+def derivMI : List GramFeature :=
+  applyImpovExp synMinimalRule (applyMetathesisExp authorAtomicMetathesis witnessExp)
 
 /-- The two orders of impoverishment vs. metathesis genuinely diverge
     at the witness, witnessing the architectural fact that metathesis
-    must follow impoverishment. -/
+    must follow impoverishment. In `derivIM`, `synMinimalRule` first
+    deletes `[+minimal]`, bleeding the metathesis condition, so the
+    exponents stay in `[+author, +atomic]` order; in `derivMI`,
+    metathesis fires first and swaps them to `[+atomic, +author]` before
+    `[+minimal]` is deleted. -/
 theorem impov_before_meta_diverges_from_meta_before_impov :
     derivIM ≠ derivMI := by
   decide
@@ -498,7 +555,8 @@ def viSet : List (FeatureVI FeatureVal String) :=
     Principle selects the `[+author, +minimal]` entry over the
     elsewhere `ô`. Surface form: `n`. -/
 theorem arregiNevinsOutput_inserts_n :
-    subsetPrinciple viSet (arregiNevinsOutput.map GramFeature.featureType) =
+    subsetPrinciple viSet
+        ((FeatureBundle.toGramFeatures arregiNevinsOutput).map GramFeature.featureType) =
       some Morpheme.n.surface := by
   decide
 
@@ -508,7 +566,8 @@ theorem arregiNevinsOutput_inserts_n :
     the same input — the empirical bite of the architectural
     divergence. -/
 theorem middletonOutput_inserts_o :
-    subsetPrinciple viSet (middletonOutput.map GramFeature.featureType) =
+    subsetPrinciple viSet
+        ((FeatureBundle.toGramFeatures middletonOutput).map GramFeature.featureType) =
       some Morpheme.o.surface := by
   decide
 
@@ -516,8 +575,10 @@ theorem middletonOutput_inserts_o :
     exponents, not just feature bundles: the same input neighborhood
     yields different morphemes under the two pipelines. -/
 theorem arregiNevins_vs_middleton_surface :
-    subsetPrinciple viSet (arregiNevinsOutput.map GramFeature.featureType) ≠
-      subsetPrinciple viSet (middletonOutput.map GramFeature.featureType) := by
+    subsetPrinciple viSet
+        ((FeatureBundle.toGramFeatures arregiNevinsOutput).map GramFeature.featureType) ≠
+      subsetPrinciple viSet
+        ((FeatureBundle.toGramFeatures middletonOutput).map GramFeature.featureType) := by
   rw [arregiNevinsOutput_inserts_n, middletonOutput_inserts_o]
   decide
 

--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -95,13 +95,13 @@ namespace Sample
     (`phaseOverride := some true`); the variation is on the EPP feature. -/
 def voiceWithEPP : VoiceHead :=
   { flavor := .agentive, hasD := true, phaseOverride := some true
-  , features := [.valued (.epp true)] }
+  , features := .ofGramFeatures [.valued (.epp true)] }
 
 /-- Voice without EPP: subject trapped in vP, invisible to higher probes
     via PIC at the Voice phase boundary. -/
 def voiceWithoutEPP : VoiceHead :=
   { flavor := .agentive, hasD := true, phaseOverride := some true
-  , features := [] }
+  , features := ⊥ }
 
 /-- Token id namespace (each lexical position in the derivation
     gets a distinct id; needed because `LIToken` distinguishes

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -159,7 +159,7 @@ theorem isParticipant_of_isAuthor (c : Agreement.Cell) :
 /-- The valued feature bundle a probe carries after agreeing with a
     DP in cell `c`. -/
 private def cellBundle (c : Agreement.Cell) : FeatureBundle :=
-  c.toPhiFeatures.map (λ p => .valued (.phi p))
+  .ofGramFeatures (c.toPhiFeatures.map (λ p => .valued (.phi p)))
 
 /-- Set A as DM Vocabulary entries, contextualized to Voice/v.
     All six cells have overt exponents. -/
@@ -175,7 +175,7 @@ def setBVocab : Vocabulary :=
   makePersonVocab (Agreement.Cell.pnCells.filter (· != .pn .third .Sing))
     Agreement.Cell.toPhiFeatures
     (fun c => (setBExponent.realize c).getD "") (some .T) ++
-  [{ features := [], exponent := "∅", context := some .T }]
+  [{ features := ⊥, exponent := "∅", context := some .T }]
 
 /-- Vocabulary insertion recovers the fragment's paradigms: spelling
     out each cell's valued bundle yields the fragment's exponent — for
@@ -275,7 +275,7 @@ def afAgreementTarget (subj obj : Agreement.Cell) : Option Agreement.Cell :=
 def afMarker (subj obj : Agreement.Cell) : Option String :=
   if PLC Prod.snd ([(.A, subj), (.P, obj)] : List (ArgPosition × Agreement.Cell)) then
     ((afAgreementTarget subj obj).bind setBExponent.realize) <|>
-      spellout setBVocab [] (some .T)
+      spellout setBVocab ⊥ (some .T)
   else none
 
 /-- The rank encoding (`probeResolutionRank`, [bejar-rezac-2003]
@@ -400,7 +400,7 @@ theorem failed_agree_tolerated :
       (afProbe.Outcome (.pn .third .Sing) (.pn .third .Sing)) = true ∧
     (afProbe.Outcome (.pn .third .Sing) (.pn .third .Sing)).pfRealization
       = .elsewhere ∧
-    spellout setBVocab [] (some .T) = some "∅" ∧
+    spellout setBVocab ⊥ (some .T) = some "∅" ∧
     afMarker (.pn .third .Sing) (.pn .third .Sing) = some "∅" := by
   decide
 

--- a/Linglib/Studies/Scott2021.lean
+++ b/Linglib/Studies/Scott2021.lean
@@ -187,32 +187,41 @@ def terminalToFeature : DPCat → String → Option FeatureVal
   | _, _ => none
 
 mutual
-/-- Collect all features from a tree's terminals.
+/-- Collect all features from a tree's terminals as a list of `GramFeature`s,
+    in depth-first traversal order. The list traversal is the natural shape;
+    `extractFeatures` wraps it into a `FeatureBundle` assignment.
     Uses mutual recursion for definitional reduction. -/
-def extractFeatures : Tree DPCat String → FeatureBundle
+def extractFeatureList : Tree DPCat String → List Minimalist.GramFeature
   | .terminal c w => match terminalToFeature c w with
     | some fv => [.valued fv]
     | none => []
-  | .node _ children => extractFeaturesList children
+  | .node _ children => extractFeatureListAux children
   | .trace _ _ => []
-  | .bind _ _ body => extractFeatures body
+  | .bind _ _ body => extractFeatureList body
 
-private def extractFeaturesList : List (Tree DPCat String) → FeatureBundle
+private def extractFeatureListAux :
+    List (Tree DPCat String) → List Minimalist.GramFeature
   | [] => []
-  | t :: ts => extractFeatures t ++ extractFeaturesList ts
+  | t :: ts => extractFeatureList t ++ extractFeatureListAux ts
 end
+
+/-- The feature bundle of a pronoun tree: fold its terminal features into the
+    total assignment. Each pronoun structure has at most one feature per
+    dimension, so no information is lost in the fold. -/
+def extractFeatures (t : Tree DPCat String) : FeatureBundle :=
+  Minimalist.FeatureBundle.ofGramFeatures (extractFeatureList t)
 
 /-- 1SG pronoun has features: [number:sg, gender:anim, person:1].
     (Order follows depth-first tree traversal.) -/
 theorem features_1sg :
-    extractFeatures pronTree1sg =
+    extractFeatureList pronTree1sg =
     [.valued (.phi (.number .singular)),
      .valued (.phi (.gender 1)),
      .valued (.phi (.person .first))] := by decide
 
 /-- After PersP deletion, features are: [number:sg, gender:anim] — no person. -/
 theorem features_after_deletion :
-    extractFeatures (deletePersP pronTree1sg) =
+    extractFeatureList (deletePersP pronTree1sg) =
     [.valued (.phi (.number .singular)),
      .valued (.phi (.gender 1))] := by decide
 
@@ -222,25 +231,25 @@ theorem features_after_deletion :
 
 /-- Helper: does a feature bundle contain a person feature? -/
 def hasPerson (fb : FeatureBundle) : Bool :=
-  fb.any fun f => match f with
+  (Minimalist.FeatureBundle.toGramFeatures fb).any fun f => match f with
     | .valued (.phi (.person _)) => true
     | _ => false
 
 /-- Helper: extract the person level if present. -/
 def getPerson (fb : FeatureBundle) : Option Person :=
-  fb.findSome? fun f => match f with
+  (Minimalist.FeatureBundle.toGramFeatures fb).findSome? fun f => match f with
     | .valued (.phi (.person p)) => some p
     | _ => none
 
 /-- Helper: is the number singular? -/
 def isSg (fb : FeatureBundle) : Bool :=
-  fb.any fun f => match f with
+  (Minimalist.FeatureBundle.toGramFeatures fb).any fun f => match f with
     | .valued (.phi (.number .singular)) => true
     | _ => false
 
 /-- Helper: does the bundle contain animacy? -/
 def isAnim (fb : FeatureBundle) : Bool :=
-  fb.any fun f => match f with
+  (Minimalist.FeatureBundle.toGramFeatures fb).any fun f => match f with
     | .valued (.phi (.gender 1)) => true
     | _ => false
 
@@ -466,8 +475,8 @@ theorem bound_retains_person :
     the movement resumptive is featurally a proper subset of the
     bound resumptive (chain reduction only deletes). -/
 theorem movement_is_subset :
-    let fullFeats := extractFeatures pronTree1sg
-    let reducedFeats := extractFeatures (deletePersP pronTree1sg)
+    let fullFeats := extractFeatureList pronTree1sg
+    let reducedFeats := extractFeatureList (deletePersP pronTree1sg)
     reducedFeats.length < fullFeats.length ∧
     reducedFeats.all (· ∈ fullFeats) := by
   constructor <;> decide

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -194,7 +194,7 @@ def setAVocab : Vocabulary :=
 def setBVocab : Vocabulary :=
   makePersonVocab setBSpecificCells Agreement.Cell.toPhiFeatures
     (fun c => (setBExponent.realize c).getD "") (some .T) ++
-    [{ features := [], exponent := defaultSetB, context := some .T }]
+    [{ features := ⊥, exponent := defaultSetB, context := some .T }]
 
 /-- Which Minimalist head φ-Agrees with each argument position.
     Ditransitive R/T default to none (not modeled). -/
@@ -212,13 +212,13 @@ def agreeProbe : ArgPosition → Option Cat
     Placeholder values (.third, .Sing) are irrelevant — `sameType` matching
     ensures any Person/Number goal is found regardless. -/
 def voiceProbe : FeatureBundle :=
-  [.unvalued (.phi (.person .third)), .unvalued (.phi (.number .singular))]
+  .ofGramFeatures [.unvalued (.phi (.person .third)), .unvalued (.phi (.number .singular))]
 
 /-- Infl's probe features: [uPerson, uNumber].
     In intransitives, these are valued by S. In transitives, the probe
     is blocked by Voice_TR before reaching any DP. -/
 def inflProbe : FeatureBundle :=
-  [.unvalued (.phi (.person .third)), .unvalued (.phi (.number .singular))]
+  .ofGramFeatures [.unvalued (.phi (.person .third)), .unvalued (.phi (.number .singular))]
 
 -- ============================================================================
 -- § 2: Goal Feature Bundles (3SG test case)
@@ -226,7 +226,7 @@ def inflProbe : FeatureBundle :=
 
 /-- A 3SG DP's features: [Person:3, Number:sg]. -/
 def dp3sg : FeatureBundle :=
-  [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
+  .ofGramFeatures [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
 
 -- ============================================================================
 -- § 3: Agree Valuation — Voice agrees with agent
@@ -235,20 +235,23 @@ def dp3sg : FeatureBundle :=
 /-- Voice's [uPerson] is valued as [Person:3] from a 3SG agent. -/
 theorem voice_agrees_person :
     applyAgree voiceProbe dp3sg (.phi (.person .third)) =
-    some [.valued (.phi (.person .third)), .unvalued (.phi (.number .singular))] := by
+    some (.ofGramFeatures
+      [.valued (.phi (.person .third)), .unvalued (.phi (.number .singular))]) := by
   native_decide
 
 /-- After person agreement, Voice's [uNumber] is valued as [Number:sg].
     This is the second step of φ-Agree: person first, then number. -/
 theorem voice_agrees_number :
-    let afterPerson := [.valued (.phi (.person .third)), .unvalued (.phi (.number .singular))]
+    let afterPerson : FeatureBundle := .ofGramFeatures
+      [.valued (.phi (.person .third)), .unvalued (.phi (.number .singular))]
     applyAgree afterPerson dp3sg (.phi (.number .singular)) =
-    some [.valued (.phi (.person .third)), .valued (.phi (.number .singular))] := by
+    some (.ofGramFeatures
+      [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]) := by
   native_decide
 
 /-- Full φ-valuation of Voice by a 3SG agent: both person and number valued. -/
 def voiceFullyAgreed : FeatureBundle :=
-  [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
+  .ofGramFeatures [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
 
 /-- The two-step Agree pipeline produces a fully valued bundle. -/
 theorem voice_agree_pipeline :
@@ -268,7 +271,7 @@ theorem setA_spellout_3sg :
 
 /-- Set A spellout for 1SG: Voice with [Person:1, Number:sg] yields A1SG marker. -/
 theorem setA_spellout_1sg :
-    let v1sg : FeatureBundle :=
+    let v1sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     spellout setAVocab v1sg (some .v) = some "n-/w-" := by
   native_decide
@@ -282,7 +285,7 @@ theorem setA_spellout_1sg :
     (1SG=chin, 1PL=qo, 2/3PL=chi — none match 3SG), so the Elsewhere
     entry is selected: "tz'=". -/
 theorem setB_intransitive_3sg :
-    let inflAgreed : FeatureBundle :=
+    let inflAgreed : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
     spellout setBVocab inflAgreed (some .T) = some "tz'=" := by
   native_decide
@@ -295,7 +298,7 @@ theorem setB_intransitive_3sg :
     This is the DEFAULT Set B — it appears in transitives regardless of
     the object's person/number features. -/
 theorem setB_transitive_default :
-    let inflBlocked : FeatureBundle := []
+    let inflBlocked : FeatureBundle := ⊥
     spellout setBVocab inflBlocked (some .T) = some "tz'=" := by
   native_decide
 
@@ -303,9 +306,9 @@ theorem setB_transitive_default :
     identical even though the underlying mechanism differs (real agreement
     vs. probe failure). -/
 theorem setB_same_surface :
-    let inflAgreed3sg : FeatureBundle :=
+    let inflAgreed3sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
-    let inflBlocked : FeatureBundle := []
+    let inflBlocked : FeatureBundle := ⊥
     spellout setBVocab inflAgreed3sg (some .T) =
     spellout setBVocab inflBlocked (some .T) := by
   native_decide
@@ -314,7 +317,7 @@ theorem setB_same_surface :
     from S, yielding "chin" — NOT the Elsewhere form. This is real
     agreement, producing a distinct exponent. -/
 theorem setB_intransitive_1sg :
-    let t1sg : FeatureBundle :=
+    let t1sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     spellout setBVocab t1sg (some .T) = some "chin" := by
   native_decide
@@ -324,10 +327,10 @@ theorem setB_intransitive_1sg :
     so the object's 1SG features are never copied to Infl. -/
 theorem setB_transitive_ignores_object :
     -- Even though the object is 1SG, Infl shows default "tz'=", not "chin"
-    let inflBlocked : FeatureBundle := []
+    let inflBlocked : FeatureBundle := ⊥
     spellout setBVocab inflBlocked (some .T) = some "tz'=" ∧
     -- Compare: a 1SG intransitive S would trigger "chin"
-    let inflAgreed1sg : FeatureBundle :=
+    let inflAgreed1sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     spellout setBVocab inflAgreed1sg (some .T) = some "chin" := by
   exact ⟨by native_decide, by native_decide⟩
@@ -352,10 +355,11 @@ theorem setB_transitive_ignores_object :
     table below for the search-level statement). -/
 theorem probe_restriction_yields_default :
     -- Transitive: probe blocked → empty → Elsewhere
-    spellout setBVocab ([] : FeatureBundle) (some .T) = some "tz'=" ∧
+    spellout setBVocab (⊥ : FeatureBundle) (some .T) = some "tz'=" ∧
     -- Intransitive 1SG: probe succeeds → "chin" (not default)
     spellout setBVocab
-      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
+      (.ofGramFeatures
+        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
       (some .T) = some "chin" := by
   exact ⟨by native_decide, by native_decide⟩
 
@@ -369,15 +373,19 @@ theorem probe_restriction_yields_default :
 theorem intransitive_pipeline_1sg :
     -- Infl Agrees with 1SG S
     (applyAgree inflProbe
-      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
+      (.ofGramFeatures
+        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
       (.phi (.person .third))).bind
       (λ fb => applyAgree fb
-        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
+        (.ofGramFeatures
+          [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
         (.phi (.number .singular))) =
-    some [.valued (.phi (.person .first)), .valued (.phi (.number .singular))] ∧
+    some (.ofGramFeatures
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]) ∧
     -- Spells out as "chin" (not default "tz'=")
     spellout setBVocab
-      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
+      (.ofGramFeatures
+        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
       (some .T) = some "chin" := by
   exact ⟨by native_decide, by native_decide⟩
 
@@ -398,7 +406,7 @@ theorem full_pipeline_3sg_transitive :
       (λ fb => applyAgree fb dp3sg (.phi (.number .singular))) = some voiceFullyAgreed ∧
     spellout setAVocab voiceFullyAgreed (some .v) = some "t-" ∧
     -- Step 3-4: Infl probe blocked → default Set B
-    spellout setBVocab ([] : FeatureBundle) (some .T) = some "tz'=" ∧
+    spellout setBVocab (⊥ : FeatureBundle) (some .T) = some "tz'=" ∧
     -- Step 5: patient is not eligible for reduction → overt pronoun
     ¬ ArgPosition.CanBeReduced .P := by
   refine ⟨?_, ?_, ?_, ?_⟩
@@ -478,14 +486,15 @@ theorem different_probe_heads :
     DP with matching φ-features. `attemptAgree` maps the `none` result from
     `applyAgree` to `Probe.Outcome.unvalued`. -/
 theorem transitive_is_probe_failure :
-    attemptAgree inflProbe [] (.phi (.person .third)) = .unvalued := by
+    attemptAgree inflProbe ⊥ (.phi (.person .third)) = .unvalued := by
   native_decide
 
 /-- The intransitive case is real agreement: Infl's probe finds S and copies
     its φ-features. `attemptAgree` maps the `some _` result to `.valued`. -/
 theorem intransitive_is_real_agreement :
     attemptAgree inflProbe
-      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
+      (.ofGramFeatures
+        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
       (.phi (.person .third)) = .valued := by
   native_decide
 
@@ -515,15 +524,16 @@ theorem probe_failure_converges_with_elsewhere :
     (head encounter .v) and copies no features — matching the Fragment's
     `¬ IsPhiAgreed .P`. -/
 theorem satisfaction_derives_patient_no_agree :
-    mamInflSatisfaction.isSatisfied [] (some .v) = true ∧
-    mamInflSatisfaction.copiedFeatures [] (some .v) = false ∧
+    mamInflSatisfaction.isSatisfied ⊥ (some .v) = true ∧
+    mamInflSatisfaction.copiedFeatures ⊥ (some .v) = false ∧
     ¬ ArgPosition.IsPhiAgreed .P :=
   ⟨by native_decide, by native_decide, by decide⟩
 
 /-- In an intransitive clause, `mamInflSatisfaction` is satisfied by
     φ-features and DOES copy them — matching `IsPhiAgreed .S`. -/
 theorem satisfaction_derives_intranS_agree :
-    let dp1sg := [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
+    let dp1sg : FeatureBundle := .ofGramFeatures
+      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     mamInflSatisfaction.isSatisfied dp1sg none = true ∧
     mamInflSatisfaction.copiedFeatures dp1sg none = true ∧
     ArgPosition.IsPhiAgreed .S :=
@@ -534,10 +544,11 @@ theorem satisfaction_derives_intranS_agree :
     - patient (transitive): copiedFeatures = false ↔ ¬ IsPhiAgreed .P
     - intranS (intransitive): copiedFeatures = true ↔ IsPhiAgreed .S -/
 theorem satisfaction_matches_fragment :
-    (mamInflSatisfaction.copiedFeatures [] (some .v) = true ↔
+    (mamInflSatisfaction.copiedFeatures ⊥ (some .v) = true ↔
       ArgPosition.IsPhiAgreed .P) ∧
     (mamInflSatisfaction.copiedFeatures
-      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
+      (.ofGramFeatures
+        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
       none = true ↔
       ArgPosition.IsPhiAgreed .S) := by
   refine ⟨?_, ?_⟩
@@ -586,7 +597,7 @@ def agreesWith (cond : SatisfactionCond) (goals : List Encounter) :
 
 /-- Transitive Voice as an encounter: a head of category `.v`, no
     φ-features visible to the probe. -/
-def voiceTR : Encounter := ⟨none, [], some .v⟩
+def voiceTR : Encounter := ⟨none, ⊥, some .v⟩
 
 /-- A DP goal realizing position `p` with φ-bundle `φ`. -/
 def dpGoal (p : ArgPosition) (φ : FeatureBundle) : Encounter := ⟨some p, φ, none⟩
@@ -736,7 +747,7 @@ def mamImpoverishmentRule : Morphology.DM.Impoverishment.ImpoverishmentRule :=
     -- Check for [+author] (= valued first person): the F diacritic
     -- condition is modeled by this rule only being applied in
     -- agreed-with contexts (subj/poss position, not objects).
-    (λ fb => fb.any (λ f => match f with
+    (λ fb => (Minimalist.FeatureBundle.toGramFeatures fb).any (λ f => match f with
       | .valued (.phi (.person .first)) => true
       | _ => false))
     (.phi (.number .singular))
@@ -750,29 +761,34 @@ theorem mamImpoverishment_paradigmatic :
 theorem impoverishment_fires_1sg :
     mamImpoverishmentRule.condition
       (Morphology.DM.Impoverishment.Neighborhood.ofBundle
-        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]) := by
+        (.ofGramFeatures
+          [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])) := by
   decide
 
 /-- The impoverishment rule does NOT fire for 3rd person bundles. -/
 theorem impoverishment_blocked_3sg :
     ¬ mamImpoverishmentRule.condition
         (Morphology.DM.Impoverishment.Neighborhood.ofBundle
-          [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]) := by
+          (.ofGramFeatures
+            [.valued (.phi (.person .third)), .valued (.phi (.number .singular))])) := by
   decide
 
 /-- After impoverishment, the number feature is deleted from 1st
     person bundles, bleeding insertion of the base morpheme *qin*. -/
 theorem impoverishment_deletes_number :
     mamImpoverishmentRule.applyToBundle
-      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))] =
-    [.valued (.phi (.person .first))] := by
+      (.ofGramFeatures
+        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]) =
+    .ofGramFeatures [.valued (.phi (.person .first))] := by
   decide
 
 /-- Without impoverishment (3rd person), the number feature survives. -/
 theorem no_impoverishment_preserves :
     mamImpoverishmentRule.applyToBundle
-      [.valued (.phi (.person .third)), .valued (.phi (.number .singular))] =
-    [.valued (.phi (.person .third)), .valued (.phi (.number .singular))] := by
+      (.ofGramFeatures
+        [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]) =
+    .ofGramFeatures
+      [.valued (.phi (.person .third)), .valued (.phi (.number .singular))] := by
   decide
 
 end AgreeSpellout

--- a/Linglib/Studies/Storment2026.lean
+++ b/Linglib/Studies/Storment2026.lean
@@ -356,27 +356,40 @@ open Minimalist (FeatureBundle)
 
 /-- A goal `G` is **defective** w.r.t. a probe `P` iff `G`'s formal
     features are a proper subset of `P`'s, so checking is incomplete
-    ([roberts-2010], ch. 2; eq. (49) in [storment-2026]). -/
+    ([roberts-2010], ch. 2; eq. (49) in [storment-2026]). The feature
+    comparison is over the bundles' grammatical-feature lists
+    (`FeatureBundle.toGramFeatures`). -/
 def DefectiveGoal (probe goal : FeatureBundle) : Prop :=
-  goal ⊆ probe ∧ ∃ f ∈ probe, f ∉ goal
+  goal.toGramFeatures ⊆ probe.toGramFeatures ∧
+    ∃ f ∈ probe.toGramFeatures, f ∉ goal.toGramFeatures
 
 instance (probe goal : FeatureBundle) : Decidable (DefectiveGoal probe goal) := by
   unfold DefectiveGoal; infer_instance
 
 /-- The empty goal is defective w.r.t. any nonempty probe. -/
 theorem DefectiveGoal.empty_of_nonempty (probe : FeatureBundle)
-    (h : probe ≠ []) : DefectiveGoal probe [] := by
+    (h : probe ≠ ⊥) : DefectiveGoal probe ⊥ := by
   refine ⟨List.nil_subset _, ?_⟩
-  match probe, h with
+  have hne : probe.toGramFeatures ≠ [] := by
+    intro he
+    refine h (funext λ t => ?_)
+    have hnone := (List.filterMap_eq_nil_iff.mp he) t (by cases t <;> decide)
+    cases hp : probe t with
+    | absent => rfl
+    | unvalued => rw [hp] at hnone; exact absurd hnone (by simp)
+    | valued v => rw [hp] at hnone; exact absurd hnone (by simp)
+  match hp : probe.toGramFeatures, hne with
   | f :: _, _ => exact ⟨f, List.mem_cons_self, List.not_mem_nil⟩
 
 /-- A defective goal is missing some feature the probe has. -/
 theorem DefectiveGoal.exists_missing {probe goal : FeatureBundle}
-    (h : DefectiveGoal probe goal) : ∃ f ∈ probe, f ∉ goal := h.2
+    (h : DefectiveGoal probe goal) :
+    ∃ f ∈ probe.toGramFeatures, f ∉ goal.toGramFeatures := h.2
 
 /-- A defective goal's features are all in the probe. -/
 theorem DefectiveGoal.subset {probe goal : FeatureBundle}
-    (h : DefectiveGoal probe goal) : goal ⊆ probe := h.1
+    (h : DefectiveGoal probe goal) :
+    goal.toGramFeatures ⊆ probe.toGramFeatures := h.1
 
 /-- No goal is defective w.r.t. itself. -/
 theorem DefectiveGoal.irrefl (fb : FeatureBundle) : ¬ DefectiveGoal fb fb := by

--- a/Linglib/Syntax/Case/Filter.lean
+++ b/Linglib/Syntax/Case/Filter.lean
@@ -32,19 +32,19 @@ open Features.Prominence
 /-- Nominative Case is assigned by T.
     T has [uCase:nom], assigns to closest DP in Spec-TP. -/
 def tAssignsNominative : FeatureBundle :=
-  [.unvalued (.case .nom)]
+  .ofGramFeatures [.unvalued (.case .nom)]
 
 /-- Accusative Case is assigned by v (transitive light verb).
     v has [uCase:acc], assigns to closest DP (object). -/
 def vAssignsAccusative : FeatureBundle :=
-  [.unvalued (.case .acc)]
+  .ofGramFeatures [.unvalued (.case .acc)]
 
 /-- DP needs Case (Case Filter).
     All DPs have [uCase], must be valued by Agree. The `.dat` value here
     is a placeholder — `featuresMatch` ignores values for unvalued probes,
     so any `Case` would work; `.dat` is conventional. -/
 def dpNeedsCase : FeatureBundle :=
-  [.unvalued (.case .dat)]
+  .ofGramFeatures [.unvalued (.case .dat)]
 
 -- ============================================================================
 -- § 2: DP Feature Structures
@@ -80,7 +80,7 @@ def satisfiesCaseFilter (dp : DPFeatures) : Bool :=
 
 /-- Convert DPFeatures to a FeatureBundle. -/
 def DPFeatures.toBundle (dp : DPFeatures) : FeatureBundle :=
-  dp.phi.map (λ p => .valued (.phi p)) ++ [dp.caseFeature]
+  .ofGramFeatures (dp.phi.map (λ p => .valued (.phi p)) ++ [dp.caseFeature])
 
 -- ============================================================================
 -- § 3: Case Filter Predicate

--- a/Linglib/Syntax/Minimalist/Agree.lean
+++ b/Linglib/Syntax/Minimalist/Agree.lean
@@ -63,7 +63,7 @@ def ExtendedLI.fromSimple (cat : Cat) (sel : SelStack) (feats : FeatureBundle) :
 
 /-- Is this LI a probe (has unvalued features)? -/
 def ExtendedLI.isProbe (li : ExtendedLI) : Bool :=
-  li.features.any GramFeature.isUnvalued
+  FeatureType.all.any λ t => (li.features t).isUnvalued
 
 /-- Is this LI a potential goal for a given feature type? -/
 def ExtendedLI.isGoalFor (li : ExtendedLI) (ftype : FeatureVal) : Bool :=
@@ -169,27 +169,19 @@ def behindHorizonB (root probe target : SyntacticObject)
 -- § 4: Feature Valuation
 -- ============================================================================
 
-/-- Value an unvalued feature by copying from a valued one -/
-def valueFeature (unvalued valued : GramFeature) : Option GramFeature :=
-  match unvalued, valued with
-  | .unvalued _, .valued v => some (.valued v)
-  | _, _ => none
-
 /-- Apply Agree: value the probe's feature from the goal.
-    Uses `sameType` for matching, so a probe with [uPerson:_] will
-    be valued by a goal with [Person:3rd] — the placeholder value is
-    irrelevant, only the feature type matters. -/
+    Matching is by *dimension* (`ftype.dimension`), so a probe with
+    `[uPerson:_]` is valued by a goal with `[Person:3rd]` — the placeholder
+    value is irrelevant. If the goal has a valued feature at the dimension and
+    the probe's slot there is unvalued, the probe's slot is set to that value. -/
 def applyAgree (probeFeats goalFeats : FeatureBundle) (ftype : FeatureVal) :
     Option FeatureBundle :=
   match getValuedFeature goalFeats ftype with
   | none => none
-  | some goalFeat =>
-    some (probeFeats.map λ f =>
-      if f.isUnvalued && f.featureType.sameType ftype then
-        match valueFeature f goalFeat with
-        | some v => v
-        | none => f
-      else f)
+  | some v =>
+    some <| if (probeFeats ftype.dimension).isUnvalued
+            then Function.update probeFeats ftype.dimension (.valued v)
+            else probeFeats
 
 -- ============================================================================
 -- § 5: Common Agree Configurations
@@ -235,10 +227,10 @@ structure CAgree where
     When a head has [EPP], Agree is not enough - the goal must MOVE
     to the specifier position of the agreeing head. -/
 def hasEPP (fb : FeatureBundle) : Bool :=
-  fb.any λ f => match f with
-    | .valued (.epp true) => true
-    | .unvalued (.epp true) => true
-    | _ => false
+  match fb .epp with
+  | .valued b => b
+  | .unvalued => true
+  | .absent => false
 
 /-- T-to-C movement is triggered by [uQ] + [EPP] on C
 
@@ -255,11 +247,11 @@ def tToCTriggered (cFeats : FeatureBundle) : Bool :=
 
 /-- Matrix C features: [uQ, EPP] -/
 def matrixCFeatures : FeatureBundle :=
-  [.unvalued (.q false), .valued (.epp true)]
+  .ofGramFeatures [.unvalued (.q false), .valued (.epp true)]
 
 /-- Embedded C features: [uQ] only (satisfied by wh-movement) -/
 def embeddedCFeatures : FeatureBundle :=
-  [.unvalued (.q false)]
+  .ofGramFeatures [.unvalued (.q false)]
 
 /-- Matrix C triggers T-to-C -/
 theorem matrix_triggers_t_to_c : tToCTriggered matrixCFeatures = true := rfl
@@ -276,19 +268,15 @@ theorem embedded_no_t_to_c : tToCTriggered embeddedCFeatures = false := rfl
     An element is active iff it has at least one unvalued feature.
     Typically, DPs are active when they have unvalued Case. -/
 def isActive (fb : FeatureBundle) : Bool :=
-  fb.any GramFeature.isUnvalued
+  FeatureType.all.any λ t => (fb t).isUnvalued
 
 /-- An element needs Case (has unvalued Case feature) -/
 def needsCase (fb : FeatureBundle) : Bool :=
-  fb.any λ f => f.isUnvalued && match f.featureType with
-    | .case _ => true
-    | _ => false
+  (fb .case).isUnvalued
 
 /-- An element has valued Case -/
 def hasCase (fb : FeatureBundle) : Bool :=
-  fb.any λ f => f.isValued && match f.featureType with
-    | .case _ => true
-    | _ => false
+  (fb .case).isValued
 
 /-- Activity is typically determined by Case:
     A DP is active iff it lacks Case
@@ -296,25 +284,17 @@ def hasCase (fb : FeatureBundle) : Bool :=
     When a feature bundle contains only Case features, the bundle is active
     (has unvalued features) iff it needs Case (has unvalued Case). -/
 theorem activity_via_case (fb : FeatureBundle)
-    (h : fb.all λ f => match f.featureType with | .case _ => true | _ => false) :
+    (h : ∀ t, t ≠ .case → fb t = .absent) :
     isActive fb ↔ needsCase fb := by
+  unfold isActive needsCase
+  simp only [List.any_eq_true]
   constructor
-  · intro hActive
-    simp only [isActive, List.any_eq_true] at hActive
-    simp only [needsCase, List.any_eq_true]
-    obtain ⟨f, hfMem, hfUnval⟩ := hActive
-    use f, hfMem
-    simp only [Bool.and_eq_true]
-    constructor
-    · exact hfUnval
-    · simp only [List.all_eq_true] at h
-      exact h f hfMem
+  · rintro ⟨t, _, hUnval⟩
+    by_cases ht : t = .case
+    · exact ht ▸ hUnval
+    · rw [h t ht] at hUnval; simp [Features.FeatureSlot.isUnvalued] at hUnval
   · intro hNeeds
-    simp only [needsCase, List.any_eq_true] at hNeeds
-    simp only [isActive, List.any_eq_true]
-    obtain ⟨f, hfMem, hfCond⟩ := hNeeds
-    simp only [Bool.and_eq_true] at hfCond
-    exact ⟨f, hfMem, hfCond.1⟩
+    exact ⟨.case, by decide, hNeeds⟩
 
 -- ============================================================================
 -- § 9: Active Goal (for Agree with Activity)
@@ -386,19 +366,19 @@ def fullAgree (strength : PICStrength) (phases : List Phase)
 
 /-- Fin-Agree: Fin probes for [±finite] on its complement (TP). -/
 def finAgreeFeatures (isFinite : Bool) : FeatureBundle :=
-  [.unvalued (.finite isFinite)]
+  .ofGramFeatures [.unvalued (.finite isFinite)]
 
 /-- Force-Fin-Agree: Force/C probes for clause-type features on Fin. -/
 def forceFinAgreeFeatures (isFactive : Bool) : FeatureBundle :=
-  [.unvalued (.factive isFactive)]
+  .ofGramFeatures [.unvalued (.factive isFactive)]
 
 /-- Neg-Agree: Neg probes for [±neg], licensing sentential negation. -/
 def negAgreeFeatures : FeatureBundle :=
-  [.unvalued (.neg true)]
+  .ofGramFeatures [.unvalued (.neg true)]
 
 /-- Rel-Agree: Rel probes for [±rel], licensing relative clause formation. -/
 def relAgreeFeatures : FeatureBundle :=
-  [.unvalued (.rel true)]
+  .ofGramFeatures [.unvalued (.rel true)]
 
 /-- Clause-typing features match correctly. -/
 theorem finite_features_match :

--- a/Linglib/Syntax/Minimalist/Aspect.lean
+++ b/Linglib/Syntax/Minimalist/Aspect.lean
@@ -150,7 +150,7 @@ structure AspHead where
   probe : Option Probe.Profile := none
   /-- Agree-relevant features on the head (e.g., `[+EXP]` for experiential AspO,
       `[uD]` for the AspO that triggers *you*-movement). -/
-  features : FeatureBundle := []
+  features : FeatureBundle := ⊥
   deriving Repr
 
 /-- Convenience constructor: a bare outer-aspect head with no selectional

--- a/Linglib/Syntax/Minimalist/Features.lean
+++ b/Linglib/Syntax/Minimalist/Features.lean
@@ -193,43 +193,24 @@ def featuresMatch (f1 f2 : GramFeature) : Bool :=
   f1.featureType.sameType f2.featureType
 
 -- ============================================================================
--- § 5: Feature Bundles
+-- § 5: Feature Bundles as Assignments ([marcolli-chomsky-berwick-2025])
 -- ============================================================================
 
-/-- A feature bundle: list of grammatical features -/
-abbrev FeatureBundle := List GramFeature
+/-! A feature bundle is a **total assignment** from feature dimensions to
+three-state checking slots (`Features.FeatureSlot`): one slot per dimension,
+`absent` / `unvalued` (probe) / `valued v`. This replaces the earlier list
+representation (`List GramFeature`), which admitted junk — duplicate
+dimensions, conflicting values — and was not extensional, so it could not be
+a `LawfulBundleLike` (the `Features/Basic.lean` Todo).
 
-/-- Does the bundle have an unvalued feature of a given type?
-    Uses `sameType` so that e.g. [uPerson:_] matches ftype [Person:_]. -/
-def hasUnvaluedFeature (fb : FeatureBundle) (ftype : FeatureVal) : Bool :=
-  fb.any λ f => f.isUnvalued && f.featureType.sameType ftype
+This is the Agree-layer structure; per [marcolli-chomsky-berwick-2025] (book
+p. 13) the free-Merge core keeps `SO₀` features atomic, so the slot apparatus
+is decoupled from the `SyntacticObject` carrier and lives in
+`Features/Slot.lean`.
 
-/-- Does the bundle have a valued feature of a given type?
-    Uses `sameType` so that e.g. [Person:3] matches ftype [Person:_]. -/
-def hasValuedFeature (fb : FeatureBundle) (ftype : FeatureVal) : Bool :=
-  fb.any λ f => f.isValued && f.featureType.sameType ftype
-
-/-- Get the valued feature of a given type (if present).
-    Uses `sameType` for type-level matching. -/
-def getValuedFeature (fb : FeatureBundle) (ftype : FeatureVal) : Option GramFeature :=
-  fb.find? λ f => f.isValued && f.featureType.sameType ftype
-
--- ============================================================================
--- § 5b: Feature Bundles as Assignments ([marcolli-chomsky-berwick-2025])
--- ============================================================================
-
-/-! The list representation `FeatureBundle = List GramFeature` admits
-junk — duplicate dimensions, conflicting values — and is not extensional,
-so it cannot be a `LawfulBundleLike` (the `Features/Basic.lean` Todo). The
-canonical bundle is instead a **total assignment** from feature dimensions
-to three-state checking slots (`Features.FeatureSlot`): one slot per
-dimension, `absent` / `unvalued` (probe) / `valued v`. This is the
-Agree-layer structure; per [marcolli-chomsky-berwick-2025] (book p. 13)
-the free-Merge core keeps `SO₀` features atomic, so the slot apparatus is
-decoupled from the `SyntacticObject` carrier and lives in `Features/Slot.lean`.
-
-`FeatureAssignment` is the replacement carrier; `ofGramFeatures` bridges
-the legacy list form for incremental migration. -/
+`GramFeature` survives as a literal-builder DSL: `ofGramFeatures` folds a list
+of valued/unvalued features into the assignment, the list head winning on
+duplicate dimensions. -/
 
 /-- The feature *dimensions* checked via Agree — the equivalence classes of
 `FeatureVal.sameType`. φ-features split into their three sub-dimensions
@@ -240,6 +221,13 @@ inductive FeatureType where
   | oblique | ellipsis | catN | catV | foc | pol | pov
   | atomic | minimal | participant | author
   deriving Repr, DecidableEq, Fintype
+
+/-- All feature dimensions, for computable enumeration
+(`Finset.univ.toList` is noncomputable). -/
+def FeatureType.all : List FeatureType :=
+  [.person, .number, .gender, .case, .wh, .q, .epp, .tense, .hon, .finite,
+   .factive, .neg, .rel, .oblique, .ellipsis, .catN, .catV, .foc, .pol, .pov,
+   .atomic, .minimal, .participant, .author]
 
 /-- The dimension a feature value belongs to. Two values share a dimension
 iff `FeatureVal.sameType` holds. -/
@@ -285,6 +273,9 @@ dimension carries (`person ↦ Person`, `number ↦ Number`, `gender ↦ Nat`,
 instance (t : FeatureType) : DecidableEq t.ValueOf := by
   cases t <;> exact inferInstance
 
+instance (t : FeatureType) : Repr t.ValueOf := by
+  cases t <;> exact inferInstance
+
 /-- The value carried by a feature value, in its dimension's value space. -/
 def FeatureVal.value : (fv : FeatureVal) → fv.dimension.ValueOf
   | .phi (.person p) => p
@@ -315,37 +306,51 @@ def FeatureVal.value : (fv : FeatureVal) → fv.dimension.ValueOf
 /-- A feature bundle as a total assignment: each dimension maps to a
 three-state checking slot. The canonical extensional carrier — replacing
 `List GramFeature` — that is `LawfulBundleLike`. -/
-abbrev FeatureAssignment := (t : FeatureType) → Features.FeatureSlot t.ValueOf
+abbrev FeatureBundle := (t : FeatureType) → Features.FeatureSlot t.ValueOf
 
-namespace FeatureAssignment
+namespace FeatureBundle
 
-instance : BundleLike FeatureAssignment FeatureType (λ t => Features.FeatureSlot t.ValueOf) :=
+instance : BundleLike FeatureBundle FeatureType (λ t => Features.FeatureSlot t.ValueOf) :=
   ⟨λ b => b⟩
 
-instance : LawfulBundleLike FeatureAssignment :=
+instance : LawfulBundleLike FeatureBundle :=
   ⟨λ _ _ h => h⟩
 
 /-- The bundle has a valued feature of the given dimension. -/
-def hasValuedFeature (a : FeatureAssignment) (t : FeatureType) : Bool :=
+def hasValuedFeature (a : FeatureBundle) (t : FeatureType) : Bool :=
   (a t).isValued
 
 /-- The bundle has an unvalued (probe) feature of the given dimension. -/
-def hasUnvaluedFeature (a : FeatureAssignment) (t : FeatureType) : Bool :=
+def hasUnvaluedFeature (a : FeatureBundle) (t : FeatureType) : Bool :=
   (a t).isUnvalued
 
 /-- The value at the given dimension, when valued. -/
-def getValuedFeature (a : FeatureAssignment) (t : FeatureType) : Option t.ValueOf :=
+def getValuedFeature (a : FeatureBundle) (t : FeatureType) : Option t.ValueOf :=
   (a t).value?
 
 /-- The assignment specifying exactly one valued dimension, all others absent. -/
-def single (t : FeatureType) (v : t.ValueOf) : FeatureAssignment :=
-  Function.update (⊥ : FeatureAssignment) t (.valued v)
+def single (t : FeatureType) (v : t.ValueOf) : FeatureBundle :=
+  Function.update (⊥ : FeatureBundle) t (.valued v)
 
 @[simp] theorem single_self (t : FeatureType) (v : t.ValueOf) :
     single t v t = .valued v := by
   simp [single]
 
-end FeatureAssignment
+/-- The everywhere-`absent` bundle is the default. -/
+instance : Inhabited FeatureBundle := ⟨⊥⟩
+
+instance : DecidableEq FeatureBundle :=
+  inferInstanceAs (DecidableEq ((t : FeatureType) → Features.FeatureSlot t.ValueOf))
+
+/-- Render a bundle by its specified (non-`absent`) dimensions. The function
+carrier has no structural `Repr`, so containing structures that `deriving Repr`
+rely on this. -/
+instance : Repr FeatureBundle where
+  reprPrec fb _ :=
+    repr <| FeatureType.all.filterMap λ t =>
+      if (fb t).isSpecified then some (reprStr t, reprStr (fb t)) else none
+
+end FeatureBundle
 
 /-- The checking slot a single grammatical feature contributes at its own
 dimension: `valued v ↦ valued v.value`, `unvalued _ ↦ unvalued`. -/
@@ -356,8 +361,77 @@ def GramFeature.toSlot : (gf : GramFeature) → Features.FeatureSlot gf.featureT
 /-- Bridge from the legacy list representation: fold each feature into its
 dimension's slot, the list head taking precedence on duplicate dimensions
 (matching `getValuedFeature`/`find?` first-match semantics). -/
-def FeatureAssignment.ofGramFeatures (l : List GramFeature) : FeatureAssignment :=
+def FeatureBundle.ofGramFeatures (l : List GramFeature) : FeatureBundle :=
   l.foldr (λ gf a => Function.update a gf.featureType.dimension gf.toSlot) ⊥
+
+/-- Reconstruct a `FeatureVal` at dimension `t` from a value. -/
+def FeatureType.toFeatureVal : (t : FeatureType) → t.ValueOf → FeatureVal
+  | .person, p => .phi (.person p)
+  | .number, n => .phi (.number n)
+  | .gender, g => .phi (.gender g)
+  | .case, c => .case c
+  | .hon, hl => .hon hl
+  | .wh, b => .wh b
+  | .q, b => .q b
+  | .epp, b => .epp b
+  | .tense, b => .tense b
+  | .finite, b => .finite b
+  | .factive, b => .factive b
+  | .neg, b => .neg b
+  | .rel, b => .rel b
+  | .oblique, b => .oblique b
+  | .ellipsis, b => .ellipsis b
+  | .catN, b => .catN b
+  | .catV, b => .catV b
+  | .foc, b => .foc b
+  | .pol, b => .pol b
+  | .pov, b => .pov b
+  | .atomic, b => .atomic b
+  | .minimal, b => .minimal b
+  | .participant, b => .participant b
+  | .author, b => .author b
+
+/-- A conventional placeholder value per dimension (for `unvalued`-feature
+reconstruction, where the value is semantically irrelevant). -/
+def FeatureType.placeholderValue : (t : FeatureType) → t.ValueOf
+  | .person => .third
+  | .number => .singular
+  | .gender => 0
+  | .case => .nom
+  | .hon => .nh
+  | .wh | .q | .epp | .tense | .finite | .factive | .neg | .rel
+  | .oblique | .ellipsis | .catN | .catV | .foc | .pol | .pov
+  | .atomic | .minimal | .participant | .author => false
+
+/-- Bridge back to the legacy list representation: one `GramFeature` per
+specified dimension. The placeholder value on `unvalued` features is
+semantically inert (`ofGramFeatures` discards it via `toSlot`), so
+`ofGramFeatures ∘ toGramFeatures` round-trips. -/
+def FeatureBundle.toGramFeatures (fb : FeatureBundle) : List GramFeature :=
+  FeatureType.all.filterMap λ t =>
+    match fb t with
+    | .absent => none
+    | .unvalued => some (.unvalued (t.toFeatureVal t.placeholderValue))
+    | .valued v => some (.valued (t.toFeatureVal v))
+
+/-! ### `FeatureVal`-keyed query wrappers
+
+Convenience over the `FeatureType`-keyed methods: pass a sample `FeatureVal`
+(its carried value is ignored, only the dimension matters — the old
+`sameType` semantics). These keep probe-spec call sites that pass a
+placeholder feature (`.phi (.person .third)`) unchanged. -/
+
+/-- The bundle has a valued feature of `fv`'s dimension. -/
+def hasValuedFeature (fb : FeatureBundle) (fv : FeatureVal) : Bool :=
+  FeatureBundle.hasValuedFeature fb fv.dimension
+
+/-- The bundle has an unvalued (probe) feature of `fv`'s dimension. -/
+def hasUnvaluedFeature (fb : FeatureBundle) (fv : FeatureVal) : Bool :=
+  FeatureBundle.hasUnvaluedFeature fb fv.dimension
+
+/-- The value at `fv`'s dimension, when valued. -/
+def getValuedFeature (fb : FeatureBundle) (fv : FeatureVal) : Option fv.dimension.ValueOf :=
+  FeatureBundle.getValuedFeature fb fv.dimension
 
 -- ============================================================================
 -- § 6: ±Interpretable Features

--- a/Linglib/Syntax/Minimalist/Phase.lean
+++ b/Linglib/Syntax/Minimalist/Phase.lean
@@ -330,7 +330,7 @@ structure FeatureInheritance where
       [chomsky-2008] donate). -/
   style : TransferStyle := .donate
   /-- The features transferred (default: none specified at this layer). -/
-  transferred : FeatureBundle := []
+  transferred : FeatureBundle := ⊥
 
 -- ============================================================================
 -- Part 7: Phase-Bounded Locality

--- a/Linglib/Syntax/Minimalist/Probe/Satisfaction.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Satisfaction.lean
@@ -117,23 +117,23 @@ def mamInflSatisfaction : SatisfactionCond :=
     (no Voice_TR in the way). Feature match is satisfied → real agreement. -/
 theorem mam_intransitive_satisfied :
     mamInflSatisfaction.isSatisfied
-      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
-      none = true := by rfl
+      (.ofGramFeatures [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
+      none = true := by decide
 
 /-- Transitive environment: the probe encounters Voice_TR (category.v).
     Head encounter is satisfied → probe stops without copying features. -/
 theorem mam_transitive_satisfied :
-    mamInflSatisfaction.isSatisfied [] (some .v) = true := by rfl
+    mamInflSatisfaction.isSatisfied ⊥ (some .v) = true := by decide
 
 /-- In the transitive case, no features are copied — yielding default. -/
 theorem mam_transitive_no_copy :
-    mamInflSatisfaction.copiedFeatures [] (some .v) = false := by rfl
+    mamInflSatisfaction.copiedFeatures ⊥ (some .v) = false := by decide
 
 /-- In the intransitive case, features ARE copied — yielding real agreement. -/
 theorem mam_intransitive_copies :
     mamInflSatisfaction.copiedFeatures
-      [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
-      none = true := by rfl
+      (.ofGramFeatures [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
+      none = true := by decide
 
 /-- Infl's satisfaction condition, unfolded: φ-match or Voice_TR encounter. -/
 theorem mamInflSatisfaction_isSatisfied (fb : FeatureBundle) (ctx : Option Cat) :

--- a/Linglib/Syntax/Minimalist/Voice.lean
+++ b/Linglib/Syntax/Minimalist/Voice.lean
@@ -126,7 +126,7 @@ structure VoiceHead where
   checksCase : Bool := false
   /-- Agree-relevant features on Voice (e.g., [uOblique] for Mam =(y)a').
       Default empty — most Voice heads carry no probe features. -/
-  features : FeatureBundle := []
+  features : FeatureBundle := ⊥
   deriving DecidableEq, Repr
 
 /-! ### Predicate API (mathlib-style, Prop with `Decidable`)


### PR DESCRIPTION
C2 P2 (the flip): `Minimalist.FeatureBundle` is now the total assignment `(t : FeatureType) → FeatureSlot t.ValueOf` (was `List GramFeature`), extending the P1 infrastructure (#788).

- Lawful `BundleLike` carrier with `Repr`/`DecidableEq`/`Inhabited`; `GramFeature` retained as a construction DSL via `ofGramFeatures`/`toGramFeatures` bridges; `FeatureVal`-keyed query wrappers keep call sites stable.
- `applyAgree` rewritten as a slot update (its `= Probe.transmit` proof is structure-agnostic); query defs re-expressed as slot access; all 21 consumers (Agree core, DM, Case, Fragments, 10 Studies) migrated.
- Order-sensitive sub-theories (Scott2021 feature-list content; Middleton2026 metathesis divergence) kept on the ordered `List GramFeature` view to preserve their exact truth. No `sorry`; full library build green (6466 jobs).