### PR TITLE
feat(Studies/CoonKeine2021): articulated probe is its segment cascade

### DIFF
--- a/Linglib/Studies/CoonKeine2021.lean
+++ b/Linglib/Studies/CoonKeine2021.lean
@@ -226,6 +226,20 @@ def Probe.Articulated.toProbes {α : Type*} (P : Probe.Articulated)
     (bears : Segment → α → Bool) : List (Probe α) :=
   P.segments.map (fun s => .ofVis (bears s))
 
+/-- **An articulated probe's behaviour is the cascade of its segment probes.**
+Cascading the denoted segment probes (`toProbes`) reduces to a segment-ordered
+search: the first segment in articulation order that bears some goal delivers
+that goal ([bejar-rezac-2009]; [coon-keine-2021] (14)). This connects the
+bundled specification (`Probe.Articulated`) to the substrate cascade semantics
+(`Probe.cascade`). -/
+theorem Probe.Articulated.toProbes_cascade {α : Type*} (P : Probe.Articulated)
+    (bears : Segment → α → Bool) (goals : List α) :
+    Probe.cascade (P.toProbes bears) goals
+      = P.segments.findSome? (fun s => goals.find? (bears s)) := by
+  unfold Probe.cascade Probe.Articulated.toProbes
+  rw [List.findSome?_map]
+  rfl
+
 /-! #### The probe-specification hierarchy ([coon-keine-2021] (40)) -/
 
 /-- The (40) hierarchy as a type:

--- a/Linglib/Syntax/Minimalist/Probe/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Basic.lean
@@ -45,8 +45,6 @@ a separate concern (`Agree.applyAgree`). This is the general core: the
   add a direction parameter for Bjorkman & Zeijlstra (2019)-style upward Agree.
 - **`Preorder (Probe α)`** by pointwise `vis`-refinement, so
   `outcome_valued_mono` / `Deal2024.probe_vis_antitone` become order facts.
-- **`Articulated.toProbes` ↔ `cascade` bridge**: prove an articulated
-  probe's behaviour is the cascade of its segment probes.
 - **`HalpertHammerly2026.agreementClass`**: re-stipulated relativized
   search; should be two `Probe` searches with a `_eq_derived` theorem.
 -/


### PR DESCRIPTION
Discharges the `Probe/Basic.lean` cascade-bridge TODO: `Probe.Articulated.toProbes_cascade` proves that cascading an articulated probe's denoted segment probes reduces to a segment-ordered search — the first segment (in articulation order) bearing a goal delivers it. Connects the bundled `Probe.Articulated` spec to the substrate `Probe.cascade`. Axiom-clean (`propext`).