### PR TITLE
feat(Syntax/Minimalist/Phase): MCB-derived computable Phase API

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2232,8 +2232,8 @@ import Linglib.Syntax.Minimalist.Merge.Internal
 import Linglib.Syntax.Minimalist.Merge.Sideward
 import Linglib.Syntax.Minimalist.Merge.NoComplexityLoss
 import Linglib.Syntax.Minimalist.Merge.MinimalYield
-import Linglib.Syntax.Minimalist.Merge.Phase
-import Linglib.Syntax.Minimalist.Merge.PhaseCoproduct
+import Linglib.Syntax.Minimalist.Phase.Basic
+import Linglib.Syntax.Minimalist.Phase.Coproduct
 import Linglib.Syntax.Minimalist.Merge.MinimalSearch
 import Linglib.Syntax.Minimalist.SpellOut
 import Linglib.Morphology.DM.VocabSimple

--- a/Linglib/Phonology/OptimalityTheory/CophonologyByPhrase.lean
+++ b/Linglib/Phonology/OptimalityTheory/CophonologyByPhrase.lean
@@ -97,10 +97,10 @@ structure PhrasalCophonology (C : Type) where
   name          : String := ""
 
 /-- A phrasal cophonology activates on a phase iff its `phaseSelector`
-    matches the phase head. -/
+    matches the phase head (the head leaf `ph.head`, as a leaf SO). -/
 def PhrasalCophonology.appliesTo {C : Type}
     (pc : PhrasalCophonology C) (ph : Phase) : Bool :=
-  pc.phaseSelector ph.head
+  pc.phaseSelector (SyntacticObject.leaf ph.head)
 
 -- ============================================================================
 -- § 2: Phrasal Cophonological Evaluation

--- a/Linglib/Studies/Bruening2001.lean
+++ b/Linglib/Studies/Bruening2001.lean
@@ -167,41 +167,28 @@ def economyBlocksQR (e : ScopeEconomy) : Bool :=
 -- Phase Theory Derivation of QR Barriers
 -- ============================================================================
 
-/-- DP-as-barrier follows from PIC: D is a phase head (under the extended
-    phase inventory), so material inside DP's complement is frozen for QR.
+/-- DP-as-barrier follows from PIC: if `φ` is the D-phase whose complement is `b`
+    (D being a phase head under the extended inventory), then any `goal` contained
+    in `b` is frozen — `φ.Impenetrable goal`.
 
-    This derives the previously-stipulated `QRBarrier.dpPhase` from
-    deeper principles: if D is a phase head, then PIC makes
-    DP-internal material inaccessible to operations outside DP.
-
-    The SO is decomposed as `node (leaf tok) b` — the head is a leaf
-    (the D lexical item) and `b` is the complement. PIC freezes the
-    complement domain, not the head/edge.
-
-    **Phase 1.0 status.** The proof previously used `exact hcontains`
-    because under the planar `TraceTree` carrier `phaseComplement?`
-    reduced definitionally on `.node (leaf _) b` to `some b`. With the
-    nonplanar `FreeCommMagma` carrier, `phaseComplement?` picks the
-    right daughter of the `Quot.out` representative — which may be
-    either child after the swap quotient. The theorem statement
-    presupposes a planar choice that the substrate cannot make.
-
-    **Phase 2 plan.** Replace `phaseComplement?` with a head-function-
-    parameterized variant that picks the *complement* (the non-head
-    daughter) rather than "the right daughter of an arbitrary
-    representative." Once that lands, `dp_phase_barrier_from_pic` can
-    be re-proved by a head-function argument: if `tok` is the head,
-    the complement is `b`, so PIC freezes `b`'s contents. -/
-theorem dp_phase_barrier_from_pic (tok : LIToken) (b : SyntacticObject)
-    (_h_phase : isPhaseHeadOf .D (.node (.leaf tok) b) = true) :
-    ∀ (goal : SyntacticObject),
-      contains b goal →
-      phaseImpenetrable (.node (.leaf tok) b) goal := by
-  intro goal _hcontains
-  -- TODO Phase 2: blocked on head-function-aware `phaseComplement?`;
-  -- current `Quot.out`-based version doesn't reduce on a specific
-  -- planar shape.
-  sorry
+    This derives the previously-stipulated `QRBarrier.dpPhase` from deeper
+    principles: PIC makes DP-internal material inaccessible to operations outside
+    DP. **The former head-function-aware-complement TODO is now discharged**: the
+    MCB-faithful `Phase.complement` is the head's sister (Def 1.14.2) and the
+    interior *is* the complement (eq 1.14.3), so "goal in the complement ⟹ goal in
+    the interior" is immediate. The complement `b` is a hypothesis here because,
+    for an arbitrary `(head, complement)` pair, which daughter is the complement
+    is fixed by the head function's planar embedding, not by the bare tree. -/
+theorem dp_phase_barrier_from_pic (φ : Phase) {b goal : SyntacticObject}
+    (hZ : φ.complement = some b)
+    (hmem : goal ∈ φ.tree.subtrees)
+    (hgoal : containsOrEq b goal) :
+    φ.Impenetrable goal := by
+  have hZ' : Phase.phaseComplementZ φ.h φ.tree φ.head = some b := hZ
+  show goal ∈ φ.interior
+  unfold Phase.interior Phase.phaseInterior
+  rw [hZ', Multiset.mem_filter]
+  exact ⟨hmem, by simpa using hgoal⟩
 
 end Scope
 

--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -178,22 +178,18 @@ def voiceP_noSpec : SyntacticObject :=
 def voiceP_withSpec : SyntacticObject :=
   .node subjectAtSpecVoiceP (.node (.leaf voiceToken) vP_subjectMoved)
 
-/-- The Voice phase corresponding to `voiceP_noSpec`. Per substrate
-    intent (`Phase.head` = the lexical phase head terminal, `complement`
-    = the spelled-out domain), the head is the Voice token and the
-    complement is the entire vP. -/
+/-- The Voice phase for `voiceP_noSpec`: phase head `voiceToken`, tree
+    `voiceP_noSpec`. Its complement (the spelled-out vP), interior, and edge are
+    now **derived** from the head function (MCB §1.14), not stipulated — the
+    derived `complement` is `vP_subjectInSitu`. -/
 def voicePhase_noSpec : Phase :=
-  { head := .leaf voiceToken
-  , complement := vP_subjectInSitu
-  , edge := .leaf voiceToken }  -- vacuous edge when no Spec is projected
+  { h := HeadFunction.leftSpine, tree := voiceP_noSpec, head := voiceToken }
 
-/-- The Voice phase corresponding to `voiceP_withSpec`: head is the Voice
-    token, complement is the post-movement vP (containing only the
-    trace), edge is the moved subject at Spec,VoiceP. -/
+/-- The Voice phase for `voiceP_withSpec`: phase head `voiceToken`, whose maximal
+    projection is the inner VoiceP. The derived complement is the post-movement vP
+    (`vP_subjectMoved`); the moved subject at Spec,VoiceP is on the derived edge. -/
 def voicePhase_withSpec : Phase :=
-  { head := .leaf voiceToken
-  , complement := vP_subjectMoved
-  , edge := subjectAtSpecVoiceP }
+  { h := HeadFunction.leftSpine, tree := voiceP_withSpec, head := voiceToken }
 
 /-- The full Aux-V tree (T > Asp > Voice > vP) with subject in situ. -/
 def auxVTree_inSitu : SyntacticObject :=
@@ -213,19 +209,20 @@ end Sample
 The substantive content of Pietraszko 2026's analysis is that the
 *subject's accessibility to a higher probe* is determined by whether
 the subject sits inside the Voice-phase complement. We derive this
-from `phaseImpenetrable` rather than stipulate it. -/
+from the MCB-grounded `Phase.Impenetrable` (the interior = complement,
+eq 1.14.3) rather than stipulate it. -/
 
 open Sample
 
-/-- The subject is accessible to a probe above the Voice phase iff it is
-    NOT inside the phase's spelled-out complement (PIC). Reads `Phase`'s
-    `complement` field directly, per substrate intent. -/
+/-- The subject is accessible to a probe above the Voice phase iff it is NOT
+    frozen in the phase interior (= the spelled-out complement, PIC). This is the
+    negation of the MCB-derived `Phase.Impenetrable` — no stipulated complement. -/
 def IsSubjectAccessibleAcross (voicePhase : Phase) (subj : SyntacticObject) : Prop :=
-  ¬ contains voicePhase.complement subj
+  ¬ voicePhase.Impenetrable subj
 
 instance (vp : Phase) (s : SyntacticObject) :
     Decidable (IsSubjectAccessibleAcross vp s) :=
-  inferInstanceAs (Decidable (¬ contains vp.complement s))
+  inferInstanceAs (Decidable (¬ vp.Impenetrable s))
 
 /-- When subject is in situ (in vP, the Voice-phase complement), it is
     NOT accessible across the phase. Derived from `voicePhase_noSpec`'s

--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -299,9 +299,10 @@ def guebiePICMode : PICStrength := .linearizationBound
     goal at the phasehood layer; concrete crashes come from
     `SpelloutAndCheck` instead. The four-derivation theorem above
     confirms no derivation crashes. -/
-theorem guebie_PIC_admits_remnant_movement (phase goal : Minimalist.SyntacticObject) :
-    Minimalist.admitsExtraction guebiePICMode phase goal := by
-  unfold guebiePICMode; exact Minimalist.linearizationBound_admits_all phase goal
+theorem guebie_PIC_admits_remnant_movement (φ : Minimalist.Phase)
+    (goal : Minimalist.SyntacticObject) :
+    Minimalist.admitsExtraction guebiePICMode φ goal := by
+  unfold guebiePICMode; exact Minimalist.linearizationBound_admits_all φ goal
 
 -- ============================================================================
 -- § 7: Verb doubling diagnosed as syntactic (refutes Landau 2006 for Guébie)
@@ -411,7 +412,7 @@ theorem guebieVPCophonology_applies_to_v :
     let vTok : LIToken := ⟨.simple .v [], 99⟩
     let vHead : SyntacticObject := .leaf vTok
     let vPhase : Minimalist.Phase :=
-      { head := vHead, complement := vHead, edge := vHead }
+      { h := Minimalist.HeadFunction.leftSpine, tree := vHead, head := vTok }
     guebieVPCophonology.appliesTo vPhase = true := by decide
 
 /-! ### Guébie as a positive instance of `VerbDoublingIsSyntactic`

--- a/Linglib/Syntax/Minimalist/Agree.lean
+++ b/Linglib/Syntax/Minimalist/Agree.lean
@@ -337,17 +337,17 @@ def validAgreeWithActivity (a : AgreeRelation) (root : SyntacticObject) : Prop :
 
 /-- Valid Agree with Phase Impenetrability Condition.
 
-    Agree is blocked if the goal is inside a phase complement
-    (and thus inaccessible under PIC). The `strength` parameter
-    selects the PIC variant (PIC₁ vs PIC₂); see `PICStrength`. It is
-    not yet consumed by `phaseImpenetrable` itself but is retained on
-    the Agree-level interface so that derivational variants can wire
-    it in without breaking call sites. -/
+    Agree is blocked if the goal is frozen in a phase interior
+    (`Phase.Impenetrable`, MCB eq 1.14.3). The `strength` parameter is
+    **load-bearing**: `strong`/`weak` apply the PIC block, while
+    `linearizationBound` ([sande-clem-dabkowski-2026]) drops it (locality is then
+    enforced by Cyclic Linearization, not phasehood). -/
 def validAgreeWithPIC (strength : PICStrength) (phases : List Phase)
     (rel : AgreeRelation) (root : SyntacticObject) : Prop :=
-  let _ := strength
   validAgree rel root ∧
-    ¬∃ ph ∈ phases, phaseImpenetrable ph.head rel.goal
+    match strength with
+    | .linearizationBound => True
+    | .strong | .weak => ¬∃ ph ∈ phases, ph.Impenetrable rel.goal
 
 /-- PIC-bounded Agree with Activity Condition.
 
@@ -356,9 +356,10 @@ def validAgreeWithPIC (strength : PICStrength) (phases : List Phase)
     See `validAgreeWithPIC` for the role of `strength`. -/
 def fullAgree (strength : PICStrength) (phases : List Phase)
     (rel : AgreeRelation) (root : SyntacticObject) : Prop :=
-  let _ := strength
   validAgreeWithActivity rel root ∧
-    ¬∃ ph ∈ phases, phaseImpenetrable ph.head rel.goal
+    match strength with
+    | .linearizationBound => True
+    | .strong | .weak => ¬∃ ph ∈ phases, ph.Impenetrable rel.goal
 
 -- ============================================================================
 -- § 13: Clause-Typing Agree Configurations

--- a/Linglib/Syntax/Minimalist/HeadFunction.lean
+++ b/Linglib/Syntax/Minimalist/HeadFunction.lean
@@ -727,10 +727,34 @@ structure ComplementedHeadFunction extends HeadFunction where
 
 -- `decDom` instance is inherited via `extends HeadFunction` and the
 -- existing `attribute [instance] HeadFunction.decDom` at the top of this file.
---
--- Concrete complemented instances (over the selection-induced
--- `HeadFunction.leftSpine`/`rightSpine`) are built downstream in `Selection.lean`
--- with a custom `complementOf`; no `Quot.out`-based defaults are provided here.
+
+/-- The **complement daughter** of `v` under `h` — the structural realization of
+    MCB's `Z_v` ([marcolli-chomsky-berwick-2025] Def 1.14.2). At a binary node,
+    the head is one daughter (leftmost leaf under `.initial`, rightmost under
+    `.final`), and the complement is the **sister** — the other daughter. Leaves
+    and traces have no complement (`none`). Computable when `h.section_.σ` is.
+
+    This is the head-aware generalization of the right-daughter pick: `.initial`
+    returns the right daughter (head is left), `.final` the left daughter (head is
+    right), so it never misfires on head-final analyses. -/
+def HeadFunction.complementDaughter? (h : HeadFunction) (v : SyntacticObject) :
+    Option SyntacticObject :=
+  match h.section_.σ v with
+  | .of _ => none
+  | .mul l r =>
+    match h.headSide with
+    | .initial => some (FreeCommMagma.mk r)
+    | .final   => some (FreeCommMagma.mk l)
+
+/-- The **canonical complemented extension** of a head function: realizes the
+    abstract `complementOf` (MCB Def 1.14.2 `Z_v`) as the structural
+    `complementDaughter?` (the head's sister). The `T` index is ignored — the
+    complement of `v` depends only on `v` and `h`. This supersedes the deleted
+    `Quot.out`-based trivial instances: every head function now has a canonical,
+    head-side-aware complemented form. -/
+def HeadFunction.complemented (h : HeadFunction) : ComplementedHeadFunction where
+  toHeadFunction := h
+  complementOf _T v := h.complementDaughter? v
 
 -- ============================================================================
 -- § 9: MCB Lemma 1.13.4 counting (deferred — requires V^o(T) primitive)

--- a/Linglib/Syntax/Minimalist/Phase.lean
+++ b/Linglib/Syntax/Minimalist/Phase.lean
@@ -1,5 +1,6 @@
 import Linglib.Syntax.Minimalist.Labeling
 import Linglib.Syntax.Minimalist.Features
+import Linglib.Syntax.Minimalist.Phase.Basic
 
 /-!
 # Phase Theory
@@ -106,15 +107,13 @@ and [pietraszko-2026] (Ndebele, A-movement & φ-agreement). -/
     proposal that PIC strength is parametrized per interface module) are
     not yet operationalized in this enum.
 
-    TODO: the strong/weak distinction is not yet operationalized in
-    `phaseImpenetrable`, which currently models only the structural
-    "goal sits in the complement" check shared by both variants. The
-    real distinction lies in *when* the check fires relative to merge
-    of the next phase head — that requires a derivational timeline
-    that this static API doesn't yet expose. Callers using `strong`
-    or `weak` get the same structural answer; callers using
-    `linearizationBound` should consult `Cyclic.SpelloutAndCheck`
-    rather than `phaseImpenetrable`. -/
+    The mode is **load-bearing**: `strong`/`weak` select between
+    `Phase.inaccessible (strong := true)` (heads of lower phases also frozen,
+    MCB Remark 1.14.4) and the default `Phase.inaccessible` (heads in the edge);
+    `linearizationBound` drops structural opacity entirely (`admitsExtraction` is
+    then vacuously `True`, with locality delegated to Cyclic Linearization). The
+    cross-phase strong/weak split lives in `Phase.inaccessible`; the single-phase
+    complement check is `Phase.Impenetrable`. -/
 inductive PICStrength where
   | strong              -- PIC₁: complement frozen immediately
   | weak                -- PIC₂: complement accessible until next phase
@@ -122,147 +121,145 @@ inductive PICStrength where
   deriving Repr, DecidableEq
 
 -- The mode-aware extraction predicate `admitsExtraction` is defined in
--- §4 below, after `phaseImpenetrable` (which it dispatches on for the
--- strict-PIC modes).
+-- §4 below, after the `Phase` API (which it dispatches on for the strict modes).
 
 -- ============================================================================
--- Part 3: Phase Structure
+-- Part 3: Phase (MCB §1.14 — grounded in the head function)
 -- ============================================================================
 
-/-- A phase: a derivational cycle with head, complement, and edge.
+/-- A **phase** ([marcolli-chomsky-berwick-2025] §1.14): a phase-head leaf `head`
+    together with its grounding — the head function `h` (which determines
+    projection, head, and complement) and the containing tree `tree`. Phases are
+    tree-relative; nothing is stipulated. Every phase notion — complement `Z_ℓ`
+    (Def 1.14.2), interior `Φ°_ℓ` (eq 1.14.3), edge `∂Φ_ℓ` (eq 1.14.4),
+    inaccessibility `Υ_ℓ` (eq 1.14.5) — is a **derived accessor** over the
+    substrate in `Merge/Phase.lean`.
 
-    The phase head determines the domain boundary. Material in the
-    complement is shipped to PF/LF; material at the edge remains
-    accessible for further operations.
-
-    Per-analysis discipline determines which heads count as phase heads
-    — Keine 2020 (C-only), Chomsky 2000/2001 (C + v), Pietraszko 2026 +
-    Erlewine & Sommerlot 2025 (also Voice via `VoiceHead.IsPhasal`),
-    Citko 2014 (also D). The struct is intentionally permissive about
-    `head`'s category so all four can register `Phase` instances. -/
+    This replaces the earlier free-floating `{head, complement, edge}` record,
+    which stipulated a phase with no tree or head function and so had to guess the
+    complement structurally. Per-analysis discipline (Keine 2020 C-only; Chomsky
+    2000/2001 C+v; Pietraszko 2026 / Erlewine & Sommerlot 2025 also Voice; Citko
+    2014 also D) is expressed by *which leaf* a study supplies as `head`. -/
 structure Phase where
-  /-- The phase head (per-analysis: C, v, Voice, D, …) -/
-  head : SyntacticObject
-  /-- The complement domain (shipped to interfaces) -/
-  complement : SyntacticObject
-  /-- The edge (specifier, accessible for further operations) -/
-  edge : SyntacticObject
+  /-- The head function determining projection / head / complement. -/
+  h : HeadFunction
+  /-- The containing tree `T` (phases are `T`-relative, MCB §1.14). -/
+  tree : SyntacticObject
+  /-- The phase-head leaf `ℓ`; its maximal projection delimits the phase. -/
+  head : LIToken
+
+namespace Phase
+
+/-- The complement `Z_ℓ` — the head's sister at its mother node (MCB Def 1.14.2).
+    Computable when `φ.h`'s section is (e.g. `HeadFunction.leftSpine`). -/
+def complement (φ : Phase) : Option SyntacticObject :=
+  phaseComplementZ φ.h φ.tree φ.head
+
+/-- The whole phase `Φ_ℓ` — all accessible terms in the maximal projection
+    (MCB eq 1.14.2). -/
+noncomputable def content (φ : Phase) : Multiset SyntacticObject :=
+  phase φ.h φ.tree φ.head
+
+/-- The interior `Φ°_ℓ` — the complement and its accessible terms; the part the
+    PIC freezes (MCB eq 1.14.3, "Z is the interior of the phase"). Computable when
+    `φ.h`'s section is — so concrete PIC checks `decide`. -/
+def interior (φ : Phase) : Multiset SyntacticObject :=
+  phaseInterior φ.h φ.tree φ.head
+
+/-- The edge `∂Φ_ℓ` — head, specifiers, and modifiers; stays accessible
+    (MCB eq 1.14.4). -/
+noncomputable def edge (φ : Phase) : Multiset SyntacticObject :=
+  phaseEdge φ.h φ.tree φ.head
+
+/-- The inaccessibility set `Υ_ℓ` — terms frozen in the interiors of strictly
+    lower phases (MCB eq 1.14.5). With `strong := true`, also freezes the lower
+    phase heads (MCB Remark 1.14.4 — the head-movement-banning variant). -/
+noncomputable def inaccessible (φ : Phase) (strong : Bool := false) :
+    Multiset SyntacticObject :=
+  if strong then inaccessibleTerms_strong φ.h φ.tree φ.head
+  else inaccessibleTerms φ.h φ.tree φ.head
+
+/-- **Phase Impenetrability Condition**: `goal` is frozen in this phase iff it
+    lies in the interior (= the complement). True by construction — no bridge
+    theorem needed: the PIC *is* interior membership
+    ([marcolli-chomsky-berwick-2025] §1.14). -/
+def Impenetrable (φ : Phase) (goal : SyntacticObject) : Prop :=
+  goal ∈ φ.interior
+
+instance (φ : Phase) (goal : SyntacticObject) :
+    Decidable (φ.Impenetrable goal) :=
+  inferInstanceAs (Decidable (goal ∈ φ.interior))
+
+/-- A genuine phase: its head projects nontrivially — `head ∈ L_Φ(T)`, i.e. `γ_ℓ`
+    contains an internal vertex (MCB Def 1.14.3 eq 1.14.1). -/
+def IsWellFormed (φ : Phase) : Prop :=
+  φ.head ∈ phaseHeadLeaves φ.h φ.tree
+
+end Phase
 
 -- ============================================================================
--- Part 4: Phase Impenetrability Condition
+-- Part 4: Extraction under a PIC regime
 -- ============================================================================
 
-/-- The phase complement is the right daughter of the phase node under the
-    **selection-induced** head-initial embedding (`selLinearize .initial`,
-    [marcolli-chomsky-berwick-2025] Lemma 1.13.5): the phase head is the left
-    daughter, its complement the right. Computable; supersedes the arbitrary
-    `Quot.out` choice. `phaseComplementWith?` below takes an explicit head fn. -/
-def phaseComplement? : SyntacticObject → Option SyntacticObject :=
-  fun so => match selLinearize .initial so with
-    | .of _ => none
-    | .mul _ r => some (FreeCommMagma.mk r)
-
-/-- Parameterized phase-complement accessor: under harmonic head-initial
-    convention (head daughter to the LEFT of the planar representative),
-    the complement is the RIGHT daughter of `h.section_.σ so`. Computable
-    when `h.section_.σ` is.
-
-    Returns `none` when `h.section_.σ so` is a leaf or trace (no daughter
-    structure). For nodes, returns the right daughter as a `SyntacticObject`. -/
-def phaseComplementWith? (h : HeadFunction) (so : SyntacticObject) :
-    Option SyntacticObject :=
-  match h.section_.σ so with
-  | .of _ => none
-  | .mul _ r => some (FreeCommMagma.mk r)
-
-/-- Phase Impenetrability Condition: material inside a phase complement
-    is inaccessible to operations outside the phase.
-
-    The strong/weak (PIC₁/PIC₂) distinction is about *when* the check
-    fires relative to the merge of the next phase head; structurally
-    both variants ask the same question — is the goal sitting inside
-    the phase's complement? — so this predicate is currently
-    strength-agnostic. See `PICStrength` for the TODO. -/
-def phaseImpenetrable (phase goal : SyntacticObject) : Prop :=
-  match phaseComplement? phase with
-  | some complement => contains complement goal
-  | none => False
-
-noncomputable instance (phase goal : SyntacticObject) :
-    Decidable (phaseImpenetrable phase goal) := by
-  unfold phaseImpenetrable
-  cases phaseComplement? phase <;> classical infer_instance
-
-/-- A phase admits movement of `goal` out of `phase.complement` under
-    `strength`. For `strong`/`weak`, this is the negation of
-    `phaseImpenetrable`. For `linearizationBound`, the predicate is
-    vacuously `True` — actual constraint comes from the Cyclic
-    Linearization table, not from phasehood per se.
-
-    The point of the predicate is to make the SCD-2026 stance ("PIC
-    is too strong, Cyclic Linearization is enough") expressible as a
-    different `PICStrength` argument rather than a different theorem
-    statement. Callers who pick `linearizationBound` should also
-    feed the derivation through
-    `Minimalist.Linearization.SpelloutAndCheck` to confirm it does
-    not crash on ordering grounds. -/
-def admitsExtraction (strength : PICStrength)
-    (phase goal : SyntacticObject) : Prop :=
+/-- Phase `φ` admits extraction of `goal` under `strength`:
+    - `strong`/`weak`: `goal` is not frozen — `¬ φ.Impenetrable goal` (the
+      single-phase complement check; the strong/weak distinction of Remark 1.14.4
+      is *cross-phase* and lives in `Phase.inaccessible`, consumed by Agree).
+    - `linearizationBound`: vacuously `True` — no structural opacity; movement is
+      constrained only by Cyclic Linearization ([sande-clem-dabkowski-2026],
+      [fox-pesetsky-2005]). -/
+def admitsExtraction (strength : PICStrength) (φ : Phase)
+    (goal : SyntacticObject) : Prop :=
   match strength with
-  | .strong | .weak => ¬ phaseImpenetrable phase goal
+  | .strong | .weak => ¬ φ.Impenetrable goal
   | .linearizationBound => True
 
-noncomputable instance (strength : PICStrength) (phase goal : SyntacticObject) :
-    Decidable (admitsExtraction strength phase goal) := by
-  unfold admitsExtraction
-  cases strength <;> classical infer_instance
+noncomputable instance (strength : PICStrength) (φ : Phase) (goal : SyntacticObject) :
+    Decidable (admitsExtraction strength φ goal) := by
+  unfold admitsExtraction; cases strength <;> classical infer_instance
 
-/-- Under `linearizationBound`, every phase admits extraction at the
-    phasehood layer. Concrete crashes come from the linearization
-    table (see `Minimalist.Linearization.SpelloutAndCheck`). This is the
-    formal content of [sande-clem-dabkowski-2026]'s rejection of
-    strict PIC. -/
-theorem linearizationBound_admits_all (phase goal : SyntacticObject) :
-    admitsExtraction .linearizationBound phase goal := trivial
+/-- Under `linearizationBound`, every phase admits extraction at the phasehood
+    layer; concrete crashes come from the linearization table. This is the formal
+    content of [sande-clem-dabkowski-2026]'s rejection of strict PIC. -/
+theorem linearizationBound_admits_all (φ : Phase) (goal : SyntacticObject) :
+    admitsExtraction .linearizationBound φ goal := trivial
 
-/-- Strict PIC₁/PIC₂ both block extraction from a phase complement.
-    The mode-as-data design lets a study file pick its locality regime
-    by passing the `PICStrength` argument explicitly. -/
+/-- Strict PIC₁/PIC₂ both block extraction of a goal frozen in the phase interior. -/
 theorem strict_PIC_blocks {strength : PICStrength}
     (h : strength = .strong ∨ strength = .weak)
-    {phase goal : SyntacticObject}
-    (hp : phaseImpenetrable phase goal) :
-    ¬ admitsExtraction strength phase goal := by
+    {φ : Phase} {goal : SyntacticObject} (hp : φ.Impenetrable goal) :
+    ¬ admitsExtraction strength φ goal := by
   rcases h with h | h <;> simp [admitsExtraction, h, hp]
 
 -- ============================================================================
 -- Part 5: Transfer
 -- ============================================================================
 
-/-- Transfer: ship a phase complement to the interfaces (PF and LF).
+/-- Transfer: ship a phase's interior to the interfaces (PF and LF).
 
-    When a phase is complete, its complement domain is transferred:
+    When a phase is complete, its interior `Φ°_ℓ` (= the complement domain, MCB
+    eq 1.14.3) is transferred:
     - To PF for phonological computation (linearization, prosody)
     - To LF for semantic interpretation -/
 structure Transfer where
   /-- The phase being transferred -/
   phase : Phase
   /-- Material sent to PF (phonological form) -/
-  toPF : SyntacticObject
+  toPF : Multiset SyntacticObject
   /-- Material sent to LF (logical form) -/
-  toLF : SyntacticObject
-  /-- PF domain = complement -/
-  pf_is_complement : toPF = phase.complement
-  /-- LF domain = complement -/
-  lf_is_complement : toLF = phase.complement
+  toLF : Multiset SyntacticObject
+  /-- PF domain = interior -/
+  pf_is_interior : toPF = phase.interior
+  /-- LF domain = interior -/
+  lf_is_interior : toLF = phase.interior
 
-/-- Create a transfer from a phase (PF and LF receive the complement) -/
-def Transfer.fromPhase (ph : Phase) : Transfer :=
+/-- Create a transfer from a phase (PF and LF receive the interior). -/
+noncomputable def Transfer.fromPhase (ph : Phase) : Transfer :=
   { phase := ph
-    toPF := ph.complement
-    toLF := ph.complement
-    pf_is_complement := rfl
-    lf_is_complement := rfl }
+    toPF := ph.interior
+    toLF := ph.interior
+    pf_is_interior := rfl
+    lf_is_interior := rfl }
 
 -- ============================================================================
 -- Part 6: Feature Inheritance / Transfer ([chomsky-2008], [ouali-2008],
@@ -336,20 +333,19 @@ structure FeatureInheritance where
 -- Part 7: Phase-Bounded Locality
 -- ============================================================================
 
-/-- A movement is phase-bounded iff the mover does not cross a phase boundary.
+/-- A movement is phase-bounded iff the mover is not frozen in the interior of
+    any of the given phases.
 
-    Under PIC, an element inside a phase complement is inaccessible.
-    This means movement must target the edge before the phase is complete. -/
-def isPhaseBounded (mover target : SyntacticObject)
-    (phases : List Phase) : Prop :=
-  ¬∃ ph ∈ phases, phaseImpenetrable ph.head mover ∧
-    contains target ph.head
+    Under PIC, an element inside a phase interior (= complement) is inaccessible;
+    movement must reach the edge before the phase is complete. -/
+def isPhaseBounded (mover : SyntacticObject) (phases : List Phase) : Prop :=
+  ¬ ∃ ph ∈ phases, ph.Impenetrable mover
 
 -- Phase-bounded locality subsumes Relativized Minimality ([rizzi-1990])
 -- for Agree: if a goal is inside a phase complement, no probe outside can
 -- reach it. The actual blocking-of-Agree statement lives downstream of the
 -- Agree relation (see `Agree.validAgreeWithPIC`); a standalone theorem here
--- would just restate `phaseImpenetrable` as itself.
+-- would just restate `Phase.Impenetrable` as itself.
 
 -- ============================================================================
 -- Part 8: N/D-Incorporation and Phase Deactivation

--- a/Linglib/Syntax/Minimalist/Phase/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Basic.lean
@@ -1,12 +1,15 @@
 import Linglib.Syntax.Minimalist.HeadFunction
-import Linglib.Syntax.Minimalist.Merge.Defs
 
 /-!
-# Algebraic Phase Theory
+# Phase Theory — MCB §1.14 substrate
 [marcolli-chomsky-berwick-2025] §1.14
 
-Implements the MCB algebraic formulation of Phase Theory, building on
-the **vertex-keyed head function** `headAtVertex` from `HeadFunction.lean`.
+The head-function-derived foundation for Phase Theory: the `(h, T, ℓ)`-indexed
+primitives (`maximalProjection`, `phaseComplementZ`, `phaseInterior`, `phaseEdge`,
+`inaccessibleTerms`, …) that the bundled `Phase` API (`Syntax/Minimalist/Phase.lean`)
+and the phase coproduct Δ^c_Φ (`Phase/Coproduct.lean`) are built on. Everything is
+*derived* from the **vertex-keyed head function** `headAtVertex` (`HeadFunction.lean`),
+not stipulated.
 
 ## What MCB §1.14 says
 
@@ -43,18 +46,24 @@ Condition. Lemma 1.14.6 proves Δ^c_Φ is well-defined and coassociative.
 - **§1**: Lemma 1.14.1 substrate — `projectionPath`, `maximalProjection`,
   the chain-on-γ theorem (statement; proof requires §1.13.3 coherence).
 - **§2**: `phaseHeadLeaves` (L_Φ(T) of Def 1.14.3 eq 1.14.1).
-- **§3**: `phaseInterior` (Φ°_ℓ, eq 1.14.3) and `phaseEdge` (∂Φ_ℓ, eq 1.14.4).
-- **§4**: `inaccessibleTerms` (Y_ℓ, eq 1.14.5) and `phaseAccessibleAt`.
+- **§3**: `phaseComplementZ` (the head's complement Z_ℓ via `complementInPlanar`,
+  Def 1.14.2 / Def 1.14.3 step 3), `phase` (Φ_ℓ, eq 1.14.2), `phaseInterior`
+  (Φ°_ℓ = the complement, eq 1.14.3), `phaseEdge` (∂Φ_ℓ, eq 1.14.4).
+- **§4**: `inaccessibleTerms` (Υ_ℓ, eq 1.14.5), `inaccessibleTerms_strong`
+  (Remark 1.14.4), and `phaseAccessibleAt` (Φ_ℓ ∖ Υ_ℓ).
 
-## Out of scope (queued for Phase 3.C)
+## Notes
 
-- The **algebraic phase coproduct** Δ^c_Φ (Def 1.14.5 eq 1.14.6)
-- Coassociativity (Lemma 1.14.6)
-- Connection to `PICStrength` (Phase.lean's PIC strength enum)
-- `ComplementedHeadFunction` (Def 1.14.2) is in `HeadFunction.lean` (Phase 3.B.2)
+- The **interior is the complement** (MCB Def 1.14.3, "Z is the interior of the
+  phase"), via `phaseComplementZ` = the head's sister at its mother node. This
+  supersedes the earlier `T_{v_ℓ}` over-approximation (now `phase`, eq 1.14.2).
+- The **algebraic phase coproduct** Δ^c_Φ (Def 1.14.5 eq 1.14.6) + coassociativity
+  (Lemma 1.14.6) live downstream in `Merge/PhaseCoproduct.lean`.
+- `ComplementedHeadFunction` (Def 1.14.2) is in `HeadFunction.lean`; its canonical
+  structural realization is `HeadFunction.complementDaughter?`/`.complemented`.
 -/
 
-namespace Minimalist.Merge
+namespace Minimalist.Phase
 
 open Minimalist (HeadFunction ComplementedHeadFunction SyntacticObject LIToken)
 
@@ -273,70 +282,71 @@ noncomputable def phaseHeadLeaves (h : HeadFunction) (T : SyntacticObject) : Lis
 -- § 3: Phase Interior Φ°_ℓ and Edge ∂Φ_ℓ (Definitions 1.14.3, 1.14.4)
 -- ============================================================================
 
-/-- [marcolli-chomsky-berwick-2025] Definition 1.14.3 (eq 1.14.3):
-    For ℓ ∈ L_Φ(T) with maximal projection v_ℓ, the **interior** of
-    the phase Φ_ℓ is
+/-- Search a planar representative for the **complement** of head leaf `ℓ`: the
+    sister of `ℓ` at its mother node — the (unique) node on whose head side `ℓ`
+    appears as the direct leaf daughter. `side` says which daughter is the head
+    (left for `.initial`, right for `.final`); the complement is the other.
+    Returns the complement as a planar `FreeMagma`, or `none` if `ℓ` heads no
+    internal node. **Computable** — it walks the fixed planar embedding by
+    structural recursion, with no `Multiset`/`Quot` choice. -/
+def complementInPlanar (side : ConventionDir) (ℓ : LIToken) :
+    FreeMagma (LIToken ⊕ Nat) → Option (FreeMagma (LIToken ⊕ Nat))
+  | .of _ => none
+  | .mul l r =>
+    match side, l, r with
+    | .initial, .of (.inl t), _ =>
+        if t = ℓ then some r
+        else (complementInPlanar side ℓ l) <|> (complementInPlanar side ℓ r)
+    | .final, _, .of (.inl t) =>
+        if t = ℓ then some l
+        else (complementInPlanar side ℓ l) <|> (complementInPlanar side ℓ r)
+    | _, _, _ => (complementInPlanar side ℓ l) <|> (complementInPlanar side ℓ r)
 
-      Φ°_ℓ := {T_v ∈ Acc'(T) | T_v ⊆ T_{v_ℓ}}
+/-- The **complement** Z_ℓ of phase head `ℓ` ([marcolli-chomsky-berwick-2025]
+    Def 1.14.2, Def 1.14.3 step 3): the head's sister at its mother node — the
+    structure `ℓ` first selects. `none` for an empty complement (`ℓ` heads no
+    internal node). Head-side-aware, so correct under both head-initial and
+    head-final `h`. **Computable** when the section is (e.g. the selection-induced
+    `HeadFunction.leftSpine`), since it walks `h.section_.σ T` directly — so
+    concrete phase complements `decide`. -/
+def phaseComplementZ (h : HeadFunction) (T : SyntacticObject)
+    (ℓ : LIToken) : Option SyntacticObject :=
+  (complementInPlanar h.headSide ℓ (h.section_.σ T)).map FreeCommMagma.mk
 
-    — the accessible terms strictly inside the maximal projection.
-    Per MCB Remark 1.14.4, this is the part of the phase that becomes
-    inaccessible to further computation once a higher phase is built
-    via External Merge.
-
-    NB: the "complemented" version of this definition (Def 1.14.3 step 4,
-    using the complement Z_v from `ComplementedHeadFunction.complementOf`)
-    refines the interior to T_{s_ℓ} (the head's complement-side sister)
-    rather than all of T_{v_ℓ}. The simpler T_{v_ℓ} form here is the
-    bare-head version; the complemented refinement is Phase 3.B.3 work. -/
-noncomputable def phaseInterior (h : HeadFunction) (T : SyntacticObject)
+/-- [marcolli-chomsky-berwick-2025] Def 1.14.3 (eq 1.14.2): the **phase** Φ_ℓ =
+    {T_v ∈ Acc'(T) | T_v ⊆ T_{v_ℓ}} — all accessible terms within the maximal
+    projection `v_ℓ`. This is the *whole* phase; its interior is the complement
+    (`phaseInterior`) and its edge is head + specifiers + modifiers (`phaseEdge`). -/
+noncomputable def phase (h : HeadFunction) (T : SyntacticObject)
     (ℓ : LIToken) : Multiset SyntacticObject :=
   match maximalProjection h T ℓ with
   | none    => 0
-  | some vℓ =>
-    -- Acc'(T): all subtrees of T (per MCB notation)
-    -- restricted to those contained in T_{v_ℓ}
-    T.subtrees.filter (fun Tv => decide (Minimalist.contains vℓ Tv))
+  | some vℓ => T.subtrees.filter (fun Tv => decide (Minimalist.contains vℓ Tv))
 
-/-- [marcolli-chomsky-berwick-2025] Definition 1.14.3 (eq 1.14.4):
-    The **edge** ∂Φ_ℓ of phase Φ_ℓ, parameterized over a
-    `ComplementedHeadFunction`.
+/-- [marcolli-chomsky-berwick-2025] Def 1.14.3 (eq 1.14.3): the **interior**
+    Φ°_ℓ = {T_v ∈ Acc(T) | T_v ⊆ T_{s_ℓ}} — the complement `Z_ℓ` and all of its
+    accessible terms; `∅` when the complement is empty.
 
-    For ℓ ∈ L_Φ(T) with maximal projection v_ℓ and complement
-    `h.complementOf T v_ℓ = some Z_v` (non-empty case): the edge consists
-    of accessible terms contained in T_{v_ℓ} but NOT in `Z_v` (the complement
-    of the head):
+    Per MCB ("if H is a phase head with complement Z, then Z is the interior of
+    the phase"), the interior **is the complement** — NOT the whole maximal
+    projection. The head and any specifiers/modifiers sit at the *edge*. (This
+    corrects the earlier `T_{v_ℓ}` over-approximation, which is the *phase* Φ_ℓ
+    of eq 1.14.2, now named `phase`.) **Computable** (built on the computable
+    `phaseComplementZ` + subtree filter) — so concrete PIC checks `decide`. -/
+def phaseInterior (h : HeadFunction) (T : SyntacticObject)
+    (ℓ : LIToken) : Multiset SyntacticObject :=
+  match phaseComplementZ h T ℓ with
+  | none   => 0
+  | some Z => T.subtrees.filter (fun Tv => decide (Minimalist.containsOrEq Z Tv))
 
-      ∂Φ_ℓ := { T_v ∈ Acc'(T) | T_v ⊆ T_{v_ℓ} ∧ T_v ⊄ Z_v }
-
-    For `h.complementOf T v_ℓ = none` (exocentric head, no complement):
-    ∂Φ_ℓ = Φ_ℓ (the entire phase content is at the edge).
-
-    Note: this signature takes a `ComplementedHeadFunction` (extending
-    `HeadFunction` with complement info per MCB Def 1.14.2). For consumers
-    holding only a bare `HeadFunction`, extend it with a `complementOf`
-    field (e.g. over the selection-induced `HeadFunction.leftSpine`). -/
-noncomputable def phaseEdgeWith (h : ComplementedHeadFunction)
-    (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
-  match maximalProjection h.toHeadFunction T ℓ with
-  | none    => 0
-  | some vℓ =>
-    let phaseContent := T.subtrees.filter
-      (fun Tv => decide (Minimalist.contains vℓ Tv))
-    match h.complementOf T vℓ with
-    | none =>
-      -- Empty-complement case: edge = entire phase content
-      phaseContent
-    | some Zv =>
-      -- Non-empty complement: edge = phase content minus Zv-interior
-      phaseContent.filter (fun Tv => decide (¬ Minimalist.contains Zv Tv))
-
-/-- Bare `phaseEdge` for `HeadFunction`-only consumers: lifts to the trivial
-    `ComplementedHeadFunction` with `complementOf = none` (exocentric).
-    Returns the entire phase content per the empty-complement case. -/
+/-- [marcolli-chomsky-berwick-2025] Def 1.14.3 (eq 1.14.4): the **edge** ∂Φ_ℓ =
+    {T_v ∈ Acc'(T) | T_v ⊆ T_{v_ℓ} ∧ T_v ⊄ T_{s_ℓ}} — the phase content not in the
+    interior: the head, specifiers, and modifiers. `= Φ_ℓ` when the complement is
+    empty (everything is then at the edge). Computed as `phase ∖ interior`. -/
 noncomputable def phaseEdge (h : HeadFunction) (T : SyntacticObject)
     (ℓ : LIToken) : Multiset SyntacticObject :=
-  phaseEdgeWith ⟨h, fun _ _ => none⟩ T ℓ
+  let interior := phaseInterior h T ℓ
+  (phase h T ℓ).filter (fun Tv => decide (Tv ∉ interior))
 
 -- ============================================================================
 -- § 4: Inaccessibility Set Y_ℓ (eq 1.14.5)
@@ -366,17 +376,28 @@ noncomputable def inaccessibleTerms (h : HeadFunction) (T : SyntacticObject)
   -- Union of interiors of all lower phases (Multiset sum)
   (lowerPhases.map (phaseInterior h T)).foldr (· + ·) 0
 
-/-- The **accessible terms in phase Φ_ℓ**: the phase content minus the
-    inaccessibility set. These are the terms available for further
-    Merge computation when phase Φ_ℓ is being built or extended.
+/-- [marcolli-chomsky-berwick-2025] Remark 1.14.4: the **more restrictive**
+    inaccessibility set — the default `inaccessibleTerms` Υ_ℓ together with the
+    head leaves of all strictly-lower phases. MCB's default (eq 1.14.5) counts the
+    head in the *edge* (accessible, permitting head movement); the restrictive
+    Phase Theory that also bans head movement additionally freezes the lower heads.
+    Since the corrected `phaseInterior` (= complement) already excludes the head,
+    the head must be added back explicitly for the strong variant. -/
+noncomputable def inaccessibleTerms_strong (h : HeadFunction) (T : SyntacticObject)
+    (ℓ : LIToken) : Multiset SyntacticObject :=
+  let lowerHeads : Multiset SyntacticObject :=
+    ((phaseHeadLeaves h T).filter (fun ℓ' => isLowerPhaseThan h T ℓ' ℓ)).map
+      (fun ℓ' => SyntacticObject.leaf ℓ')
+  inaccessibleTerms h T ℓ + lowerHeads
 
-    This is the set summed over by the algebraic phase coproduct
-    Δ^c_Φ (Definition 1.14.5 eq 1.14.6) — the algebraic-side substrate
-    is queued for Phase 3.C. -/
+/-- The **accessible terms in phase Φ_ℓ**: the *phase* content minus the
+    inaccessibility set (MCB Def 1.14.5 eq 1.14.6: `Φ_ℓ ∖ Υ_ℓ`). These are the
+    terms available for further Merge computation when phase Φ_ℓ is being built or
+    extended; this is the set summed over by the algebraic phase coproduct
+    Δ^c_Φ (`Merge/PhaseCoproduct.lean`). -/
 noncomputable def phaseAccessibleAt (h : HeadFunction) (T : SyntacticObject)
     (ℓ : LIToken) : Multiset SyntacticObject :=
-  let interior := phaseInterior h T ℓ
   let inaccessible := inaccessibleTerms h T ℓ
-  interior.filter (fun Tv => decide (Tv ∉ inaccessible))
+  (phase h T ℓ).filter (fun Tv => decide (Tv ∉ inaccessible))
 
-end Minimalist.Merge
+end Minimalist.Phase

--- a/Linglib/Syntax/Minimalist/Phase/Coproduct.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Coproduct.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Minimalist.Merge.External
-import Linglib.Syntax.Minimalist.Merge.Phase
+import Linglib.Syntax.Minimalist.Phase.Basic
 import Linglib.Syntax.Minimalist.Phase
 
 /-!
@@ -53,7 +53,7 @@ accessible per [marcolli-chomsky-berwick-2025] Remark 1.14.4 (`comulPhaseC_weak`
 linearization gate enforced separately at externalization.
 -/
 
-namespace Minimalist.Merge
+namespace Minimalist.Phase
 
 open RootedTree RootedTree.ConnesKreimer
 open scoped TensorProduct
@@ -151,4 +151,4 @@ noncomputable def comulPICStrength (mode : PICStrength)
   | .weak                => comulPhaseC_weak h T ℓ
   | .linearizationBound  => comulC_unrestricted T
 
-end Minimalist.Merge
+end Minimalist.Phase

--- a/Linglib/Syntax/Minimalist/Phase/Coproduct.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Coproduct.lean
@@ -47,10 +47,11 @@ bijection in Lean is the substantive remaining work.
 ## PICStrength dispatch
 
 `comulPICStrength` selects the variant per `Phase.lean`'s `PICStrength`:
-`.strong` → strict `Y_ℓ` (`comulPhaseC`); `.weak` → relaxed `Y_ℓ` with phase-heads
-accessible per [marcolli-chomsky-berwick-2025] Remark 1.14.4 (`comulPhaseC_weak`);
-`.linearizationBound` → unrestricted Δ^c (`comulC_unrestricted`), with the
-linearization gate enforced separately at externalization.
+`.weak` → the default `Y_ℓ` (eq 1.14.5, heads in the edge — `comulPhaseC`);
+`.strong` → lower-phase heads also frozen per [marcolli-chomsky-berwick-2025]
+Remark 1.14.4 (`comulPhaseC_strong`); `.linearizationBound` → unrestricted Δ^c
+(`comulC_unrestricted`), with the linearization gate enforced separately at
+externalization.
 -/
 
 namespace Minimalist.Phase
@@ -105,41 +106,40 @@ noncomputable def comulC_unrestricted (T : SyntacticObject) :
       ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) :=
   comulTreeN T.toNonplanar
 
-/-! ### PICStrength dispatch (weak PIC) -/
+/-! ### PICStrength dispatch (strong PIC, Remark 1.14.4)
 
-/-- The **inaccessibility set `Y_ℓ` under WEAK PIC** ([marcolli-chomsky-berwick-2025]
-    Remark 1.14.4, book p. 136): the strict `Y_ℓ` minus the head leaves of the
-    lower phases, which remain accessible under the relaxed condition. -/
-noncomputable def inaccessibleTerms_weak (h : HeadFunction) (T : SyntacticObject)
-    (ℓ : LIToken) : Multiset SyntacticObject :=
-  let strict := inaccessibleTerms h T ℓ
-  let phaseHeadSOs : Multiset SyntacticObject :=
-    (phaseHeadLeaves h T).filter (fun ℓ' => isLowerPhaseThan h T ℓ' ℓ)
-      |>.map (fun ℓ' => SyntacticObject.leaf ℓ')
-      |> List.toFinset |>.val
-  strict.filter (fun Tv => decide (Tv ∉ phaseHeadSOs))
+The default `comulPhaseC` already uses the MCB default `Y_ℓ` (eq 1.14.5) where the
+*interior is the complement* (`Phase/Basic.lean`), so lower-phase **heads are in the
+edge and stay accessible** — this is the WEAK PIC. The STRONG variant additionally
+freezes those heads ([marcolli-chomsky-berwick-2025] Remark 1.14.4) via the
+substrate's `inaccessibleTerms_strong`. -/
 
-/-- WEAK-PIC analogue of `cutPhaseCompatible`: phase-heads of lower phases stay
-    accessible (`inaccessibleTerms_weak`). -/
-noncomputable def cutPhaseCompatible_weak (h : HeadFunction) (T : SyntacticObject)
+/-- STRONG-PIC analogue of `cutPhaseCompatible` ([marcolli-chomsky-berwick-2025]
+    Remark 1.14.4): the *more restrictive* condition that also freezes the head
+    leaves of the lower phases (`inaccessibleTerms_strong`), banning head movement
+    out of a closed phase. -/
+noncomputable def cutPhaseCompatible_strong (h : HeadFunction) (T : SyntacticObject)
     (ℓ : LIToken) (p : Forest (Nonplanar (LIToken ⊕ Unit)) × Nonplanar (LIToken ⊕ Unit)) :
     Prop :=
-  ∀ sub ∈ p.1, sub ∉ (inaccessibleTerms_weak h T ℓ).map SyntacticObject.toNonplanar
+  ∀ sub ∈ p.1, sub ∉ (inaccessibleTerms_strong h T ℓ).map SyntacticObject.toNonplanar
 
 noncomputable instance (h : HeadFunction) (T : SyntacticObject) (ℓ : LIToken) :
-    DecidablePred (cutPhaseCompatible_weak h T ℓ) := Classical.decPred _
+    DecidablePred (cutPhaseCompatible_strong h T ℓ) := Classical.decPred _
 
-/-- The **WEAK** tree-level phase coproduct Δ^c_Φ_weak (phase heads accessible). -/
-noncomputable def comulPhaseC_weak (h : HeadFunction) (T : SyntacticObject) (ℓ : LIToken) :
+/-- The **STRONG** tree-level phase coproduct Δ^c_Φ: a further restriction of
+    `comulPhaseC` that also drops cuts extracting a lower-phase head (Remark 1.14.4). -/
+noncomputable def comulPhaseC_strong (h : HeadFunction) (T : SyntacticObject) (ℓ : LIToken) :
     ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) ⊗[ℤ]
       ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) :=
-  comulTreeNFiltered T.toNonplanar (cutPhaseCompatible_weak h T ℓ)
+  comulTreeNFiltered T.toNonplanar (cutPhaseCompatible_strong h T ℓ)
 
-/-- The phase-coproduct under `PICStrength` dispatch.
+/-- The phase-coproduct under `PICStrength` dispatch ([marcolli-chomsky-berwick-2025]
+    Remark 1.14.4).
 
-    - `.strong`: strict `Y_ℓ` (`comulPhaseC`).
-    - `.weak`: relaxed `Y_ℓ` with phase-heads accessible (`comulPhaseC_weak`),
-      per [marcolli-chomsky-berwick-2025] Remark 1.14.4.
+    - `.strong`: lower-phase heads also frozen (`comulPhaseC_strong`,
+      `inaccessibleTerms_strong`).
+    - `.weak`: the default `Y_ℓ` (eq 1.14.5) — heads in the edge, accessible
+      (`comulPhaseC`).
     - `.linearizationBound`: unrestricted Δ^c (`comulC_unrestricted`); the
       linearization gate is enforced separately at externalization. -/
 noncomputable def comulPICStrength (mode : PICStrength)
@@ -147,8 +147,8 @@ noncomputable def comulPICStrength (mode : PICStrength)
     ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) ⊗[ℤ]
       ConnesKreimer ℤ (Nonplanar (LIToken ⊕ Unit)) :=
   match mode with
-  | .strong              => comulPhaseC h T ℓ
-  | .weak                => comulPhaseC_weak h T ℓ
+  | .strong              => comulPhaseC_strong h T ℓ
+  | .weak                => comulPhaseC h T ℓ
   | .linearizationBound  => comulC_unrestricted T
 
 end Minimalist.Phase


### PR DESCRIPTION
Phases are now derived from the head function (MCB §1.14): the interior is the complement (Def 1.14.3, correcting the over-broad maximal-projection form), exposed via a proper `Phase {h, tree, head}` API that replaces the stipulated `{head, complement, edge}` record. `phaseComplement?` and `phaseImpenetrable` are deleted.

- the complement→interior→`Impenetrable` path is computable (planar-walk `complementInPlanar`), so `decide`-based studies keep working; `PICStrength` is now load-bearing, with the coproduct's strong/weak realigned to Remark 1.14.4
- consolidated into `Syntax/Minimalist/Phase/` (`Basic` substrate + `Coproduct` Δ^c_Φ), out of the misnamed `Merge/`
- migrates Pietraszko2026 / SandeClemDabkowski2026 / Agree / CophonologyByPhrase; discharges Bruening2001's `sorry`
