### PR TITLE
fix(Studies): repair result trees weakened by the SO carrier flip

### DIFF
--- a/Linglib/Studies/ColeHermon2008.lean
+++ b/Linglib/Studies/ColeHermon2008.lean
@@ -591,6 +591,7 @@ private def tok_injured    : LIToken := ⟨.simple .V [] (phonForm := "was-injur
 private def tok_boy        : LIToken := ⟨.simple .N [] (phonForm := "the-boy"), 22⟩
 private def tok_by_himself : LIToken := ⟨.simple .N [] (phonForm := "by-himself"), 23⟩
 private def tok_v_pass     : LIToken := ⟨.simple .v [.V], 24⟩
+private def tok_t_pass     : LIToken := ⟨.simple .T [.v], 25⟩
 
 /-- The passive VP: `[VP patient [V' V agent-PP]]`. Built planar-first. -/
 def vp_passive : SyntacticObject :=
@@ -622,7 +623,7 @@ def englishPassive : SO.Derivation :=
 def englishPassiveDerivedTree : SyntacticObject :=
   SO.ofPlanar
     (SO.nodeP (SO.leafP tok_boy)
-      (SO.nodeP (SO.leafP tok_t)
+      (SO.nodeP (SO.leafP tok_t_pass)
         (SO.nodeP (SO.leafP tok_v_pass)
           (SO.nodeP SO.traceP
             (SO.nodeP (SO.leafP tok_injured) (SO.leafP tok_by_himself))))))

--- a/Linglib/Studies/Larson1988.lean
+++ b/Linglib/Studies/Larson1988.lean
@@ -469,14 +469,23 @@ def indirectPassive : SO.Derivation :=
       .im DP_mary2     -- PASSIVE: Mary to outer Spec (subject)
     ] }
 
-/-- The indirect-passive result tree: Mary (twice-promoted) at the top
-    edge, above the stranded direct object. `[Mary [letter [sent [to t]]]]`. -/
+/-- The indirect-passive result tree, exactly as `indirectPassive` produces it.
+    Mary moves successive-cyclically (Dative Shift then Passive), so each
+    `SO.Step.im` leaves a trace at its extraction site: one at the inner Spec
+    (the intermediate Dative-Shift landing site) and one in the *to*-complement.
+    `[Mary [t [letter [sent [to t]]]]]` — Mary at the top edge above the
+    intermediate trace and the stranded direct object.
+
+    (The single-trace abbreviation `[Mary [letter [sent [to t]]]]` collapses the
+    intermediate landing site; it gives the same Mary-c-commands-letter
+    asymmetry but is *not* what the two-step derivation emits.) -/
 def indirectPassiveTree : SO :=
   SO.ofPlanar
     (SO.nodeP (SO.leafP tok_mary2)
-      (SO.nodeP (SO.leafP tok_letter2)
-        (SO.nodeP (SO.leafP tok_sent)
-          (SO.nodeP (SO.leafP tok_to2) SO.traceP))))
+      (SO.nodeP SO.traceP
+        (SO.nodeP (SO.leafP tok_letter2)
+          (SO.nodeP (SO.leafP tok_sent)
+            (SO.nodeP (SO.leafP tok_to2) SO.traceP)))))
 
 /-- In the indirect passive, the promoted IO (Mary) c-commands the
     stranded DO (a letter). -/

--- a/Linglib/Studies/Newman2024.lean
+++ b/Linglib/Studies/Newman2024.lean
@@ -381,6 +381,39 @@ private def isKLeaf (s : SyntacticObject) : Bool :=
 private def isKP (s : SyntacticObject) : Prop :=
   ∃ d, SO.immediatelyContains s d ∧ isKLeaf d
 
+/-! #### `isKP` detection — positive and negative witnesses
+
+`isKP`'s existential ranges over *all* `SO` (no `DecidablePred` instance), so it
+is exercised by explicit witnesses rather than `decide`. A KP node `[K DP]` is
+detected; a non-K node `[V DP]` and a bare K leaf (no daughters) are rejected.
+The tokens are local probes (ids 900–902) for these checks only. -/
+
+private def kProbeK  : LIToken := ⟨.simple .K [.D] (phonForm := "K"), 900⟩
+private def kProbeD  : LIToken := ⟨.simple .D [] (phonForm := "the dog"), 901⟩
+private def kProbeV  : LIToken := ⟨.simple .V [.D] (phonForm := "see"), 902⟩
+
+/-- A K-headed leaf is detected by `isKLeaf`; a D-headed leaf is not. -/
+private theorem isKLeaf_detects :
+    isKLeaf (SO.lexLeaf kProbeK) = true ∧ isKLeaf (SO.lexLeaf kProbeD) = false := by
+  decide
+
+/-- Positive: `[K DP]` (a K daughter present) is a KP. -/
+private theorem isKP_detects_kp :
+    isKP (SO.node (SO.lexLeaf kProbeK) (SO.lexLeaf kProbeD)) :=
+  ⟨SO.lexLeaf kProbeK, (SO.immediatelyContains_node _ _ _).mpr (Or.inl rfl), by decide⟩
+
+/-- Negative: `[V DP]` (no K daughter) is not a KP. -/
+private theorem isKP_rejects_non_kp :
+    ¬ isKP (SO.node (SO.lexLeaf kProbeV) (SO.lexLeaf kProbeD)) := by
+  rintro ⟨d, hd, hk⟩
+  rw [SO.immediatelyContains_node] at hd
+  rcases hd with rfl | rfl <;> exact absurd hk (by decide)
+
+/-- Negative: a bare K *leaf* is a K head, not a KP — it has no daughters. -/
+private theorem isKP_rejects_bare_K_leaf : ¬ isKP (SO.lexLeaf kProbeK) := by
+  rintro ⟨d, hd, _⟩
+  exact (SO.immediatelyContains_lexLeaf kProbeK d) hd
+
 -- ============================================================================
 -- § 9: Anti-Redundancy in Agreement
 -- ============================================================================


### PR DESCRIPTION
Faithfulness audit of the studies migrated in #807 — caught two silently-weakened theorems where a rebuilt result tree didn't match the derivation that produces it.

- `ColeHermon2008`: `englishPassiveDerivedTree` used the Toba-Batak T token instead of the passive's T head; added the correct `tok_t_pass`.
- `Larson1988`: `indirectPassiveTree` was a 5-leaf abbreviation, but the two-`im` indirect-passive derivation yields a 6-leaf tree (intermediate trace); rebuilt to match.
- `Newman2024`: the rewritten `isKLeaf`/`isKP` had no test; added four witness theorems.

All other migrated studies audited FAITHFUL (verified with #eval + negative controls).