### PR TITLE
refactor(Studies): derive SpeasTenny2003 seat, surface Lakoff divergence

### DIFF
--- a/Linglib/Studies/Dayal2025.lean
+++ b/Linglib/Studies/Dayal2025.lean
@@ -33,10 +33,11 @@ This study file is the canonical home for:
   places the polar-Q-typing locus at `PolP` (via the
   `Features/AnsweringSystem.lean` typological parameter). Holmberg's
   analysis competes with Dayal's for the same matrix-polar facts.
-- **Speas-Tenny / `Syntax/Minimalist/SpeechActs.lean`** derives
-  `seatOfKnowledge` from a 2×2 feature matrix; Dayal places SoK in PerspP
-  with PRO. Both predict the Newari conjunct/disjunct flip; the bridge
-  theorem `SpeechActs.SoK ↔ PerspP-PRO over Newari` is unformalized.
+- **Speas-Tenny / `Studies/SpeasTenny2003.lean`** derives
+  `SpeasTenny2003.seatOfKnowledge` from a 2×2 feature matrix; Dayal places SoK
+  in PerspP with PRO. Both predict the Newari conjunct/disjunct flip; the bridge
+  theorem `SpeasTenny2003.seatOfKnowledge ↔ PerspP-PRO over Newari` is
+  unformalized.
 -/
 
 namespace Dayal2025

--- a/Linglib/Studies/SpeasTenny2003.lean
+++ b/Linglib/Studies/SpeasTenny2003.lean
@@ -1,37 +1,57 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.Minimalist.Basic
+import Linglib.Syntax.Minimalist.HeadFunction
 import Linglib.Syntax.Minimalist.Phase
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
-import Linglib.Semantics.Context.Basic
-import Linglib.Discourse.SpeechAct.Basic
+import Linglib.Semantics.Context.Tower
+import Linglib.Discourse.Roles
+import Linglib.Semantics.Mood.IllocutionaryMood
 import Linglib.Semantics.Mood.ClauseType
-import Linglib.Discourse.Commitment.Basic
+import Linglib.Semantics.Epistemicity
 import Linglib.Features.Evidentiality
 import Linglib.Fragments.English.Pronouns
-import Linglib.Features.Person.Decomposition
+import Linglib.Features.Person.Basic
 
 /-!
 # Configurational Point-of-View Roles
 
-Pragmatic roles (SPEAKER, HEARER, SEAT OF KNOWLEDGE) are configurationally
-determined by structural position in SAP, not primitive. Four moods derived
-from 2 binary features: [±finite] on utterance content × whether HEARER
-c-commands content.
+Formalizes [speas-tenny-2003]. Pragmatic roles (SPEAKER, HEARER, SEAT OF
+KNOWLEDGE) are configurationally determined by structural position in the
+Speech Act Phrase (SAP), not primitive. Four moods are derived from two binary
+features: [±finite] on the utterance content × whether the HEARER c-commands
+the content.
 
 ## Key Claims
 
-1. P-roles (SPEAKER, HEARER) are structural positions in SAP, not primitives
-2. 4 moods = 2×2 feature matrix: [±finite] × [±hearer-c-commands-content]
-3. SEAT OF KNOWLEDGE shifts by mood (speaker in decl, hearer in interrog)
-4. SAP is the highest phase → P-roles root-only
+1. P-roles (SPEAKER, HEARER) are structural positions in SAP, not primitives.
+2. 4 moods = 2×2 feature matrix: [±finite] × [±hearer-c-commands-content].
+3. SEAT OF KNOWLEDGE is the *highest argument* of the Point-of-View domain
+   (p.335): the HEARER exactly when the hearer c-commands the content. It is
+   therefore *derived* from the same feature that drives `deriveMood`, not
+   stipulated independently — so the matrix and the seat cannot disagree.
+4. SAP is the highest phase → P-role resolution is root-only (invariant under
+   context shift). Proved as `resolvePRole_shift_invariant`.
 
 ## Connections
 
-- **Core/Context.lean**: KContext.agent = SPEAKER, KContext.addressee = HEARER
-- **Phase.lean**: `isPhaseHeadOf .SA` — SAP is highest phase
-- **Allocutivity.lean**: `sa_based_aa_root_only` — root-only from SAP phase
-- **LeftPeriphery.lean**: `rogativeSAP` — "ask" selects full SAP with P-roles
-- **ExtendedProjection/Basic.lean**: `fValue.SA = 7` > `fValue.C = 6`
-- **RSA/YoonEtAl2020**: HEARER (structural) ↔ addressee in social utility
+- **Semantics/Context/Tower.lean**: `KContext.agent` = SPEAKER,
+  `KContext.addressee` = HEARER; P-roles resolve through the canonical
+  `Discourse.resolveRole` over a `ContextTower`.
+- **Phase.lean**: `isPhaseHeadOf .SA` — SAP is the highest phase.
+- **ExtendedProjection/Basic.lean**: `fValue .SA = 7 > fValue .C = 6`.
+- **Semantics/Mood/ClauseType.lean**: the configurational seat-of-knowledge
+  *diverges* from Lakoff's deontic `moodAuthority` on imperatives
+  (`seatOfKnowledge_diverges_from_authority_on_imperative`).
+- **Semantics/Epistemicity.lean**: EvalP-spec → `EpistemicProfile.authority`,
+  EvidP-spec → `EpistemicProfile.source`; S&T's seat is the speech-act-
+  participant restriction of `EpistemicAuthority` (`seat_never_nonparticipant`).
+
+S&T call SAP "the maximal structure"; the "highest phase" framing here is the
+formaliser's modernization.
 
 -/
 
@@ -39,11 +59,11 @@ c-commands content.
 namespace SpeasTenny2003
 
 open Minimalist
-open Semantics.Context (KContext)
+open Semantics.Context (KContext ContextTower ContextShift)
+open Semantics.Mood (IllocutionaryMood ClauseType)
+open Semantics.Epistemicity (EpistemicAuthority EpistemicProfile)
 
--- ============================================================================
--- Section A: Pragmatic Roles
--- ============================================================================
+/-! ### Pragmatic roles -/
 
 /-- Pragmatic roles determined by structural position in SAP.
 
@@ -55,21 +75,19 @@ open Semantics.Context (KContext)
 inductive PRole where
   | speaker          -- Spec-SAP (external argument)
   | hearer           -- Complement of SA (internal argument)
-  | seatOfKnowledge  -- Varies by mood: speaker in decl, hearer in interrog
+  | seatOfKnowledge  -- Highest argument of the POV domain; varies by mood
   deriving Repr, DecidableEq
 
--- ============================================================================
--- Section B: SAP Mood — 2×2 Feature Matrix
--- ============================================================================
+/-! ### SAP mood — the 2×2 feature matrix -/
 
 /-- Speas & Tenny's central result: 4 sentence moods from 2 binary features.
 
-    | contentFinite | hearerCCommands | Mood         |
-    |---------------|-----------------|--------------|
-    | true          | false           | declarative  |
-    | true          | true            | interrogative|
-    | false         | true            | imperative   |
-    | false         | false           | subjunctive  | -/
+    | contentFinite | hearerCCommands | Mood          |
+    |---------------|-----------------|---------------|
+    | true          | false           | declarative   |
+    | true          | true            | interrogative |
+    | false         | true            | imperative    |
+    | false         | false           | subjunctive   | -/
 inductive SAPMood where
   | declarative     -- [+finite, hearer does NOT c-command content]
   | interrogative   -- [+finite, hearer c-commands content]
@@ -85,27 +103,51 @@ def deriveMood (contentFinite hearerCCommandsContent : Bool) : SAPMood :=
   | false, true  => .imperative
   | false, false => .subjunctive
 
--- ============================================================================
--- Section B2: Bridge to ClauseType
--- ============================================================================
+/-- Feature 1 (subcategorization-like): is the utterance content finite?
+    (A genuine two-valued morphosyntactic feature value, not a predicate.) -/
+def SAPMood.contentFinite : SAPMood → Bool
+  | .declarative | .interrogative => true
+  | .imperative  | .subjunctive   => false
 
-open Semantics.Mood (IllocutionaryMood ClauseType)
+/-- Feature 2 (spec-head / promotion): does the HEARER c-command the content?
+    True for interrogatives/imperatives (hearer promoted), false otherwise. -/
+def SAPMood.hearerCCommandsContent : SAPMood → Bool
+  | .interrogative | .imperative => true
+  | .declarative   | .subjunctive => false
+
+/-- The 2×2 matrix is a genuine bijection (left inverse): recovering the two
+    features of a mood and re-deriving returns the same mood. -/
+theorem deriveMood_features (m : SAPMood) :
+    deriveMood m.contentFinite m.hearerCCommandsContent = m := by
+  cases m <;> rfl
+
+/-- The 2×2 matrix is a genuine bijection (right inverse): every feature pair
+    is recovered from its derived mood. Together with `deriveMood_features`
+    this shows the four moods exhaust `Bool × Bool` bijectively (replacing the
+    vacuous "exhaustiveness" claim — every total map into a 4-constructor type
+    is "exhaustive"). -/
+theorem features_deriveMood (f h : Bool) :
+    (deriveMood f h).contentFinite = f ∧ (deriveMood f h).hearerCCommandsContent = h := by
+  cases f <;> cases h <;> exact ⟨rfl, rfl⟩
+
+/-! ### Bridge to ClauseType -/
 
 /-- Map configurational mood to a framework-agnostic `ClauseType`
-    (illocutionary force × grammatical mood). S&T's `.subjunctive`
-    is configurational [-finite, hearer does NOT c-command content];
-    its closest framework-agnostic match is a declarative-subjunctive
-    clause, NOT the illocutionary `.promissive` (a previous mapping
-    that conflated S&T's terminology with Searle's commissive class).
+    (illocutionary force × grammatical mood).
 
     The four mappings:
-    - `.declarative`  → ⟨declarative, indicative⟩
+    - `.declarative`   → ⟨declarative, indicative⟩
     - `.interrogative` → ⟨interrogative, indicative⟩
-    - `.imperative`   → ⟨imperative, indicative⟩  (mood often neutralized)
-    - `.subjunctive`  → ⟨declarative, subjunctive⟩
+    - `.imperative`    → ⟨imperative, indicative⟩  (mood often neutralized)
+    - `.subjunctive`   → ⟨declarative, subjunctive⟩
 
-    `.exclamative` has no `SAPMood` counterpart (exclamatives are not
-    derived in S&T's 2×2 matrix). -/
+    The subjunctive mapping is a *lossy placeholder*: `IllocutionaryMood` has
+    no token for S&T's configurational subjunctive (Latin promise/wish/jussive;
+    the speaker is "responsible for choosing the preferred world", p.335), so
+    the force component falls back to `.declarative`. (The earlier `.promissive`
+    mapping was wrong in the other direction — it conflated S&T's terminology
+    with Searle's commissive class.) `.exclamative` has no `SAPMood`
+    counterpart (exclamatives are not derived in the 2×2 matrix). -/
 def SAPMood.toClauseType : SAPMood → ClauseType
   | .declarative    => { force := .declarative,   mood := .indicative }
   | .interrogative  => { force := .interrogative, mood := .indicative }
@@ -116,20 +158,23 @@ def SAPMood.toClauseType : SAPMood → ClauseType
 def SAPMood.toForce (m : SAPMood) : IllocutionaryMood :=
   m.toClauseType.force
 
--- ============================================================================
--- Section C: Seat of Knowledge
--- ============================================================================
+/-! ### Seat of knowledge (derived) -/
 
-/-- The SEAT OF KNOWLEDGE role shifts by mood.
-
-    In declaratives, the speaker holds knowledge of the content.
-    In interrogatives, the hearer is assumed to have knowledge.
-    In imperatives and subjunctives, the speaker determines the desired action. -/
-def seatOfKnowledge : SAPMood → PRole
-  | .declarative   => .speaker   -- speaker knows content
-  | .interrogative => .hearer    -- speaker asks hearer (hearer knows)
-  | .imperative    => .speaker   -- speaker knows desired action
-  | .subjunctive   => .speaker   -- speaker commits
+/-- The SEAT OF KNOWLEDGE is the *highest argument* of the Point-of-View
+    domain ([speas-tenny-2003] p.335: "the seat of knowledge is controlled by
+    the highest argument"), which is the HEARER exactly when the hearer
+    c-commands the utterance content. Derived from `hearerCCommandsContent` —
+    the *same* feature that drives `deriveMood` — so the seat cannot disagree
+    with the matrix:
+    - declarative   → speaker  (content c-commands hearer)
+    - interrogative → hearer   (hearer promoted, c-commands content)
+    - imperative    → hearer   (passive-like promotion; the hearer is
+                                responsible for realizing the unrealized
+                                proposition, p.335)
+    - subjunctive   → speaker  (speaker is highest; responsible for the
+                                preferred world) -/
+def seatOfKnowledge (m : SAPMood) : PRole :=
+  if m.hearerCCommandsContent then .hearer else .speaker
 
 /-- Map P-roles to framework-agnostic discourse roles.
     SPEAKER → speaker, HEARER → addressee, SEAT OF KNOWLEDGE → speaker
@@ -139,121 +184,105 @@ def PRole.toDiscourseRole : PRole → Discourse.DiscourseRole
   | .hearer          => .addressee
   | .seatOfKnowledge => .speaker  -- default; varies by mood
 
-/-- `seatOfKnowledge` (Speas & Tenny, configurational) agrees with
-    `ClauseType.authority` (Semantics/Mood/ClauseType.lean, framework-agnostic)
-    via the `toClauseType` bridge. Both encode the same generalization:
-    declarative/imperative/subjunctive → speaker, interrogative → addressee. -/
-theorem seat_of_knowledge_agrees_with_mood_authority (m : SAPMood) :
-    (seatOfKnowledge m).toDiscourseRole =
-    m.toClauseType.authority := by
-  cases m <;> rfl
+/-- Map P-roles to egophoric `EpistemicAuthority` ([tournadre-2008],
+    [floyd-2018]): SPEAKER → ego, HEARER → allocutive, SEAT OF KNOWLEDGE → ego
+    (default). The image never includes `.nonparticipant`. -/
+def PRole.toEpistemicAuthority : PRole → EpistemicAuthority
+  | .speaker         => .ego
+  | .hearer          => .allocutive
+  | .seatOfKnowledge => .ego
 
--- ============================================================================
--- Section D: Context Grounding
--- ============================================================================
-
-/-- Resolve a P-role to a discourse participant via KContext.
-
-    SPEAKER = context agent, HEARER = context addressee.
-    SEAT OF KNOWLEDGE defaults to agent (use `resolveRoleInMood` for
-    mood-sensitive resolution). -/
-def resolveRole {W E P T : Type*} (ctx : KContext W E P T) : PRole → E
-  | .speaker         => ctx.agent
-  | .hearer          => ctx.addressee
-  | .seatOfKnowledge => ctx.agent  -- default; varies by mood
-
-/-- Mood-sensitive role resolution: SEAT OF KNOWLEDGE is resolved through
-    `seatOfKnowledge` before mapping to a KContext participant. -/
-def resolveRoleInMood {W E P T : Type*} (ctx : KContext W E P T) (m : SAPMood) : PRole → E
-  | .seatOfKnowledge => resolveRole ctx (seatOfKnowledge m)
-  | r => resolveRole ctx r
-
--- ============================================================================
--- Section E: Bridge Theorems
--- ============================================================================
-
--- E1: Mood derivation is exhaustive (all 4 combinations covered)
-theorem deriveMood_exhaustive :
-    ∀ (f h : Bool), deriveMood f h = .declarative ∨
-                     deriveMood f h = .interrogative ∨
-                     deriveMood f h = .imperative ∨
-                     deriveMood f h = .subjunctive := by
+/-- **Divergence (the empirical content).** S&T's configurational
+    seat-of-knowledge and Lakoff's deontic `moodAuthority`
+    ([lakoff-1970], via `ClauseType.authority`) DISAGREE on imperatives:
+    S&T locate the seat with the HEARER (who must realize the unrealized
+    proposition, p.335), Lakoff with the SPEAKER (who has authority to
+    command). -/
+theorem seatOfKnowledge_diverges_from_authority_on_imperative :
+    (seatOfKnowledge .imperative).toDiscourseRole ≠
+      (SAPMood.imperative.toClauseType).authority := by
   decide
 
--- E2: Declarative = speaker knows
-theorem declarative_speaker_knows :
-    seatOfKnowledge .declarative = .speaker := rfl
+/-- Off imperatives the two notions agree: declarative/subjunctive → speaker,
+    interrogative → addressee. The disagreement is isolated to imperatives. -/
+theorem seatOfKnowledge_agrees_with_authority_off_imperative
+    (m : SAPMood) (h : m ≠ .imperative) :
+    (seatOfKnowledge m).toDiscourseRole = m.toClauseType.authority := by
+  cases m <;> first | exact absurd rfl h | rfl
 
--- E3: Interrogative = hearer knows
-theorem interrogative_hearer_knows :
-    seatOfKnowledge .interrogative = .hearer := rfl
+/-! ### Context grounding -/
 
--- E4: SPEAKER is the KContext agent
-theorem speaker_is_agent {W E P T : Type*} (ctx : KContext W E P T) :
-    resolveRole ctx .speaker = ctx.agent := rfl
+/-- Resolve a P-role to a discourse participant through a `ContextTower`,
+    reusing the canonical `Discourse.resolveRole` (which reads from the
+    speech-act origin). SEAT OF KNOWLEDGE resolves through its default
+    discourse role; use `resolvePRoleInMood` for mood-sensitive resolution. -/
+def resolvePRole {W E P T : Type*} (tower : ContextTower (KContext W E P T)) (r : PRole) : E :=
+  Discourse.resolveRole tower r.toDiscourseRole
 
--- E5: HEARER is the KContext addressee
-theorem hearer_is_addressee {W E P T : Type*} (ctx : KContext W E P T) :
-    resolveRole ctx .hearer = ctx.addressee := rfl
+/-- Mood-sensitive role resolution: SEAT OF KNOWLEDGE is resolved through
+    `seatOfKnowledge` before mapping to a participant. -/
+def resolvePRoleInMood {W E P T : Type*} (tower : ContextTower (KContext W E P T))
+    (m : SAPMood) : PRole → E
+  | .seatOfKnowledge => resolvePRole tower (seatOfKnowledge m)
+  | r => resolvePRole tower r
 
--- E6: Finite content with/without hearer c-command yields declarative/interrogative.
---     Structural observation: rogativeSAP (LeftPeriphery.lean) selects full SAP,
---     so SAP-layer P-roles are syntactically active only in rogativeSAP
---     complements (e.g., "ask").
-theorem deriveMood_finite :
-    deriveMood true false = .declarative ∧
-    deriveMood true true = .interrogative := ⟨rfl, rfl⟩
+/-- SPEAKER resolves to the speech-act origin's agent. -/
+theorem resolvePRole_speaker {W E P T : Type*} (tower : ContextTower (KContext W E P T)) :
+    resolvePRole tower .speaker = tower.origin.agent := rfl
 
--- E7: Bridge to Allocutivity — SA-based allocutive agreement probes from
---     SAP → root-only follows from SAP = highest phase.
---     (Proved in Allocutivity.lean: `sa_based_aa_root_only`)
+/-- HEARER resolves to the speech-act origin's addressee. -/
+theorem resolvePRole_hearer {W E P T : Type*} (tower : ContextTower (KContext W E P T)) :
+    resolvePRole tower .hearer = tower.origin.addressee := rfl
+
+/-- **Key Claim 4 as a theorem.** P-roles are resolved from the SPEECH-ACT
+    context (SAP is the highest phase), so resolution is invariant under
+    context shift / embedding — inherited from
+    `Discourse.resolveRole_shift_invariant`. -/
+theorem resolvePRole_shift_invariant {W E P T : Type*}
+    (tower : ContextTower (KContext W E P T)) (σ : ContextShift (KContext W E P T))
+    (r : PRole) :
+    resolvePRole (tower.push σ) r = resolvePRole tower r := by
+  simp only [resolvePRole, Discourse.resolveRole_shift_invariant]
+
+/-- In declaratives the seat of knowledge resolves to the speaker (agent). -/
+theorem seatOfKnowledge_declarative_resolves {W E P T : Type*}
+    (tower : ContextTower (KContext W E P T)) :
+    resolvePRoleInMood tower .declarative .seatOfKnowledge = tower.origin.agent := rfl
+
+/-- In interrogatives the seat of knowledge resolves to the hearer (addressee). -/
+theorem seatOfKnowledge_interrogative_resolves {W E P T : Type*}
+    (tower : ContextTower (KContext W E P T)) :
+    resolvePRoleInMood tower .interrogative .seatOfKnowledge = tower.origin.addressee := rfl
+
+/-- In imperatives the seat of knowledge resolves to the hearer (addressee) —
+    the corrected value (p.335), where the hearer realizes the proposition. -/
+theorem seatOfKnowledge_imperative_resolves {W E P T : Type*}
+    (tower : ContextTower (KContext W E P T)) :
+    resolvePRoleInMood tower .imperative .seatOfKnowledge = tower.origin.addressee := rfl
+
+/-! ### SAP as a phase, and the F-hierarchy -/
+
+/-- SA is a phase head: if the head category along the left spine is SA,
+    then `isPhaseHeadOf .SA` holds. -/
 theorem sa_is_phase_head (so : SyntacticObject)
     (h : HeadFunction.leftSpine.outerCat so = .SA) :
     isPhaseHeadOf .SA so = true := by
   simp only [isPhaseHeadOf, h, beq_self_eq_true]
 
--- E8: Bridge to YoonEtAl2020 — the HEARER P-role (structural, S&T)
---     corresponds to the addressee in social utility φ-weighting (pragmatic,
---     Yoon et al.). Both encode the hearer as a discourse participant whose
---     face/knowledge matters.
-theorem hearer_is_addressee_in_context {W E P T : Type*} (ctx : KContext W E P T) :
-    resolveRole ctx .hearer = ctx.addressee ∧
-    resolveRole ctx .speaker = ctx.agent := ⟨rfl, rfl⟩
-
--- E9: Bridge to Phase.lean — `isPhaseHeadOf .SA` identifies SA as a phase.
---     SAP is derivation-final (highest phase).
+/-- SAP is derivation-final (the highest phase). -/
 theorem sa_phase_derivation_final :
     isPhaseHeadOf .SA (mkLeaf .SA [] 0) = true := by
   unfold isPhaseHeadOf mkLeaf
   rw [HeadFunction.outerCat_leaf]
   rfl
 
--- E10: fValue is injective on the canonical verbal EP spine (one head per
---      F-level: V=0, v=1, T=2, Fin=3, Foc=4, Top=5, C=6, SA=7).
---      Globally, fValue is NOT injective — multiple categories intentionally
---      share an F-level (e.g., T/Neg/Pol are all F2). This restriction to
---      the canonical spine captures the intended hierarchy; any pairwise
---      comparison (e.g., SA > C) follows by omega.
-private def canonicalVerbalSpine : List Cat := [.V, .v, .T, .Fin, .Foc, .Top, .C, .SA]
+/-- SAP outranks CP on the extended-projection F-hierarchy
+    (`fValue .SA = 7 > fValue .C = 6`): the speech-act layer sits above the
+    complementizer layer. (`fValue` is globally non-injective — T/Neg/Pol all
+    share F2 — so the only S&T-relevant fact is this pairwise inequality.) -/
+theorem sa_outranks_c : fValue Cat.SA > fValue Cat.C := by decide
 
-theorem fValue_injective_on_canonical_verbal_spine (c1 c2 : Cat)
-    (h1 : c1 ∈ canonicalVerbalSpine) (h2 : c2 ∈ canonicalVerbalSpine)
-    (hf : fValue c1 = fValue c2) : c1 = c2 := by
-  simp only [canonicalVerbalSpine, List.mem_cons, List.mem_nil_iff, or_false] at h1 h2
-  rcases h1 with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
-  rcases h2 with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
-  simp_all [fValue]
-
--- Mood-sensitive seat of knowledge resolves correctly in context
-theorem seat_of_knowledge_declarative {W E P T : Type*} (ctx : KContext W E P T) :
-    resolveRoleInMood ctx .declarative .seatOfKnowledge = ctx.agent := rfl
-
-theorem seat_of_knowledge_interrogative {W E P T : Type*} (ctx : KContext W E P T) :
-    resolveRoleInMood ctx .interrogative .seatOfKnowledge = ctx.addressee := rfl
-
--- ============================================================================
--- Section F: Person → P-Role Mapping (theory-side)
--- ============================================================================
+/-! ### Person → P-role mapping -/
 
 /-- Map grammatical person to SAP P-role.
 
@@ -271,98 +300,102 @@ def personToRole : Person → Option PRole
 def pronounDiscourseRole (p : PersonalPronoun) : Option PRole :=
   p.person.bind personToRole
 
-open English.Pronouns in
+section Pronouns
+open English.Pronouns
+
 theorem first_person_are_speakers :
     (pronounDiscourseRole i = some .speaker) ∧
     (pronounDiscourseRole me = some .speaker) ∧
     (pronounDiscourseRole we = some .speaker) ∧
     (pronounDiscourseRole us = some .speaker) := ⟨rfl, rfl, rfl, rfl⟩
 
-open English.Pronouns in
 theorem second_person_are_hearers :
     (pronounDiscourseRole you = some .hearer) ∧
     (pronounDiscourseRole you_pl = some .hearer) := ⟨rfl, rfl⟩
 
-open English.Pronouns in
 theorem third_person_no_role :
     (pronounDiscourseRole he = none) ∧
     (pronounDiscourseRole she = none) ∧
     (pronounDiscourseRole it = none) := ⟨rfl, rfl, rfl⟩
 
-/-- Discourse role is determined entirely by person feature. -/
+end Pronouns
+
+/-- Discourse role is determined entirely by the person feature. -/
 theorem discourse_role_from_person (p : PersonalPronoun)
     (per : Person) (hp : p.person = some per) :
     pronounDiscourseRole p = personToRole per := by
   simp [pronounDiscourseRole, hp]
 
--- ============================================================================
--- Section G: Sentience Domain ([speas-tenny-2003], §2)
--- ============================================================================
+/-! ### Sentience domain ([speas-tenny-2003] §2) -/
 
 /-- Functional projections in the Sentience Domain.
 
-    Below SAP, the Sentience Domain mediates between the speech act layer
-    and the propositional content. It hosts two projections:
+    Below SAP, the Sentience Domain mediates between the speech-act layer and
+    propositional content. It hosts two projections:
 
     - **EvalP** (Evaluation Phrase): specifier = SEAT OF KNOWLEDGE, the
       sentient mind that evaluates the proposition's truth.
     - **EvidP** (Evidential Phrase): specifier = EVIDENCE, the type of
       evidence supporting the evaluation.
 
-    Hierarchy (structure 34 in S&T):
-
-        SAP > EvalP > EvidP > episP (= TP)
+    Sentience Phrase (structure 34): `EvalP > EvidP > S(episP)`; the SAP scopes
+    above it (p.333), so overall `SAP > EvalP > EvidP > S`. (S&T label the base
+    `S(episP)`; equating it with TP is the formaliser's gloss.)
 
     The Sentience Domain captures "judgements and evaluations by a sentient
-    mind on the truth-value of the proposition" (p.333). -/
+    mind on the truth-value of the proposition" (p.333).
+
+    Cross-framework note: the canonical `Cat.Evid` of the extended projection
+    is Cinque's evaluative/evidential head at F-level 2 (above T, below Fin) —
+    structurally *lower* than S&T's EvidP, which sits in the Sentience Domain
+    just above TP. Two cited evidential projections at different heights. -/
 inductive SentienceProjection where
   | EvidP   -- Evidential Phrase: hosts EVIDENCE
   | EvalP   -- Evaluation Phrase: hosts SEAT OF KNOWLEDGE
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Fintype
 
-/-- Rank ordering of Sentience Domain projections.
-    EvidP < EvalP < SAP (the SAP itself is above the Sentience Domain). -/
+/-- Rank ordering of Sentience Domain projections: EvidP < EvalP < SAP. -/
 def SentienceProjection.rank : SentienceProjection → Nat
   | .EvidP => 0
   | .EvalP => 1
 
-/-- The rank function on the Sentience Domain is injective: distinct
-    projections (EvidP, EvalP) have distinct ranks (0, 1). -/
+/-- The rank function is injective: distinct projections have distinct ranks. -/
 theorem rank_injective : Function.Injective SentienceProjection.rank := by
-  intro a b h; cases a <;> cases b <;> simp_all [SentienceProjection.rank]
+  decide
 
-/-- The specifier of EvalP hosts a P-role: SEAT OF KNOWLEDGE.
+/-- The specifier of EvalP hosts a P-role: SEAT OF KNOWLEDGE (the sentient
+    mind performing the evaluation), same as `seatOfKnowledge`. -/
+abbrev evalPSpecifier : SAPMood → PRole := seatOfKnowledge
 
-    This is the sentient mind performing the evaluation. In declaratives,
-    this is the SPEAKER; in interrogatives, the HEARER (same as
-    `seatOfKnowledge`, since EvalP is where the seat is structurally
-    projected). -/
-def evalPSpecifier : SAPMood → PRole := seatOfKnowledge
-
-/-- The specifier of EvidP hosts the evidence type.
-
-    Maps S&T's EVIDENCE argument to the framework-agnostic
-    `CoarseSource` from `Features/Evidentiality.lean`:
-    - direct → sensory observation
-    - inference → reasoning from effects
-    - hearsay → reported evidence -/
+/-- The specifier of EvidP hosts the evidence type, mapped to the
+    framework-agnostic `CoarseSource` of `Features/Evidentiality.lean`
+    (direct / inference / hearsay). NB this three-way coarsening merges S&T's
+    top tier (personal experience) into "direct"; the paper's full evidence
+    hierarchy is personal experience ≫ direct ≫ indirect ≫ hearsay (p.327). -/
 abbrev EvidPSpecifier := Features.Evidentiality.CoarseSource
 
-/-- Bridge to `Core/Epistemicity.lean`: the Sentience Domain's
-    two specifiers (SEAT OF KNOWLEDGE + EVIDENCE) correspond to
-    `EpistemicProfile`'s two main fields (authority + source).
+/-- **Real bridge to `Semantics/Epistemicity.lean`.** The Sentience Domain's
+    two specifiers ARE the two main fields of an `EpistemicProfile`:
+    EvalP-spec (SEAT OF KNOWLEDGE) → `authority`, EvidP-spec (EVIDENCE) →
+    `source`. The structural hierarchy EvalP > EvidP corresponds to authority
+    scoping over source. -/
+def sentienceProfile (m : SAPMood) (ev : EvidPSpecifier) : EpistemicProfile :=
+  { source := ev, authority := (evalPSpecifier m).toEpistemicAuthority }
 
-    | S&T Sentience Domain | Semantics.Epistemicity     |
-    |----------------------|-----------------------|
-    | EvalP spec (Seat)    | EpistemicProfile.authority |
-    | EvidP spec (Evidence)| EpistemicProfile.source    |
+/-- The EvidP specifier IS the profile's evidential source (shared `CoarseSource`). -/
+@[simp] theorem sentienceProfile_source (m : SAPMood) (ev : EvidPSpecifier) :
+    (sentienceProfile m ev).source = ev := rfl
 
-    The structural hierarchy (EvalP > EvidP) corresponds to authority
-    scoping over source: WHO evaluates is determined before HOW they know. -/
-theorem sentience_domain_bridges_to_epistemicity :
-    -- EvalP specifier for declarative = speaker = ego authority
-    evalPSpecifier .declarative = .speaker ∧
-    -- EvalP specifier for interrogative = hearer = allocutive authority
-    evalPSpecifier .interrogative = .hearer := ⟨rfl, rfl⟩
+/-- The EvalP specifier's epistemic authority IS the profile's authority. -/
+@[simp] theorem sentienceProfile_authority (m : SAPMood) (ev : EvidPSpecifier) :
+    (sentienceProfile m ev).authority = (evalPSpecifier m).toEpistemicAuthority := rfl
+
+/-- **Asymmetry made visible.** S&T's two-participant seat-of-knowledge never
+    projects `.nonparticipant` authority, which the egophoric inventory
+    ([tournadre-2008], [floyd-2018]) carries for third-party access. S&T's role
+    space is the speech-act-participant restriction of `EpistemicAuthority`. -/
+theorem seat_never_nonparticipant (m : SAPMood) :
+    (evalPSpecifier m).toEpistemicAuthority ≠ .nonparticipant := by
+  cases m <;> decide
 
 end SpeasTenny2003

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -1347,10 +1347,10 @@
   publisher = {John Benjamins},
   doi       = {10.1075/la.57.15spe},
   pages     = {315--344},
-  subfield  = {pragmatics/rsa},
-  role      = {cited},
+  subfield  = {syntax},
+  role      = {formalized},
   validated = {true},
-  sources   = {Core/Discourse/DiscourseRole.lean;Phenomena/Politeness/Minimalism_AllocutivityBridge.lean;Syntax/Minimalist/SpeechActs.lean}
+  sources   = {Studies/SpeasTenny2003.lean;Syntax/Minimalist/ExtendedProjection/Basic.lean}
 }
 @article{speas-2004,
   author    = {Speas, Margaret},


### PR DESCRIPTION
Reground the Speas & Tenny (2003) study file after a PDF-checked multi-agent audit.

- Derive `seatOfKnowledge` from the `hearerCCommandsContent` feature — fixes the imperative value (paper p.335; hearer, not speaker) instead of stipulating a parallel table that had drifted.
- Replace the false `seat ≡ moodAuthority` agreement theorem with the real S&T-vs-Lakoff divergence (`seatOfKnowledge_diverges_from_authority_on_imperative` + off-imperative agreement).
- Replace the fake epistemicity "bridge" with a genuine `EpistemicProfile` (`sentienceProfile`, `seat_never_nonparticipant`); resolve P-roles via canonical `Discourse.resolveRole`, with root-only invariance proved (`resolvePRole_shift_invariant`).

Also repairs the `Dayal2025` back-reference and the `references.bib` subfield/sources.

Depends on `minimalist-a1-namespaces` (imports `Minimalist/Basic.lean` + `HeadFunction.lean`, which only exist on that branch). Retarget to `main` once it lands.
