### PR TITLE
refactor(Minimalist): mathlib polish of Applicative — Bool→Prop predicates

### DIFF
--- a/Linglib/Studies/Hewett2026.lean
+++ b/Linglib/Studies/Hewett2026.lean
@@ -401,45 +401,44 @@ instantiates them for the Semitic template space, paralleling the Icelandic
 asymmetry in `Wood2015.dative_voice_asymmetry`. -/
 
 /-- Does this template license a given applicative type? Composes the substrate's
-    `ApplHead.licensedWith` with `toVoiceHead`. -/
-def SemiticTemplate.licensesAppl (t : SemiticTemplate) (appl : ApplHead) : Bool :=
-  appl.licensedWith t.toVoiceHead
+    `ApplHead.Licensed` with `toVoiceHead`. -/
+def SemiticTemplate.licensesAppl (t : SemiticTemplate) (appl : ApplHead) : Prop :=
+  appl.Licensed t.toVoiceHead
+
+instance (t : SemiticTemplate) (appl : ApplHead) : Decidable (t.licensesAppl appl) :=
+  inferInstanceAs (Decidable (appl.Licensed t.toVoiceHead))
 
 /-- High-Appl licensing factors through `HasSemantics`. -/
 theorem high_appl_iff_hasSemantics (t : SemiticTemplate) :
-    t.licensesAppl applHigh = true ↔ t.toVoiceHead.HasSemantics := by
+    t.licensesAppl applHigh ↔ t.toVoiceHead.HasSemantics := by
   cases t <;> decide
 
 /-- A template that blocks high applicatives assigns no θ — via the substrate
     implication, not template enumeration. -/
 theorem high_appl_blocked_implies_no_theta (t : SemiticTemplate)
-    (h : t.licensesAppl applHigh = false) : ¬ t.toVoiceHead.AssignsTheta :=
-  fun hθ => Bool.noConfusion
-    (h.symm.trans (high_licensed_of_assignsTheta t.toVoiceHead hθ))
+    (h : ¬ t.licensesAppl applHigh) : ¬ t.toVoiceHead.AssignsTheta :=
+  fun hθ => h (high_licensed_of_assignsTheta t.toVoiceHead hθ)
 
 /-- A θ-assigning template licenses every applicative type. -/
 theorem theta_licenses_all_appl (t : SemiticTemplate) (appl : ApplHead)
-    (hθ : t.toVoiceHead.AssignsTheta) : t.licensesAppl appl = true := by
-  simp only [SemiticTemplate.licensesAppl, ApplHead.licensedWith]
-  split
-  · exact decide_eq_true hθ.hasSemantics
-  · rfl
+    (hθ : t.toVoiceHead.AssignsTheta) : t.licensesAppl appl :=
+  fun _ => hθ.hasSemantics
 
 /-- The Voice-predicate chain pulled back to the Semitic template space; both
     inclusions are strict: nXaYaZ licenses high Appl without assigning θ, and
     tXaYYaZ blocks high Appl. -/
 theorem voice_predicate_chain :
     (∀ t : SemiticTemplate,
-      t.toVoiceHead.AssignsTheta → t.licensesAppl applHigh = true) ∧
+      t.toVoiceHead.AssignsTheta → t.licensesAppl applHigh) ∧
     (∃ t : SemiticTemplate,
-      t.licensesAppl applHigh = true ∧ ¬ t.toVoiceHead.AssignsTheta) ∧
+      t.licensesAppl applHigh ∧ ¬ t.toVoiceHead.AssignsTheta) ∧
     (∀ t : SemiticTemplate,
-      t.licensesAppl applHigh = true → t.licensesAppl applLowRecipient = true) ∧
-    (∃ t : SemiticTemplate, t.licensesAppl applHigh = false) :=
+      t.licensesAppl applHigh → t.licensesAppl applLowRecipient) ∧
+    (∃ t : SemiticTemplate, ¬ t.licensesAppl applHigh) :=
   ⟨fun t hθ => high_licensed_of_assignsTheta t.toVoiceHead hθ,
     ⟨.nXaYaZ, by decide, by decide⟩,
     fun t _ => (low_licensed_with_any t.toVoiceHead).1,
-    ⟨.tXaYYaZ, rfl⟩⟩
+    ⟨.tXaYYaZ, by decide⟩⟩
 
 /-! ### Feature activation
 

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -1240,9 +1240,9 @@ theorem high_appl_licenses_unergative_denotational
   toEvent_licenses_all _
 
 /-! ## §16. Voice × Appl licensing matrix
-    (`Syntax/Minimalism/Applicative.lean.licensedWith`)
+    (`Syntax/Minimalism/Applicative.lean.Licensed`)
 
-`ApplHead.licensedWith` (in `Applicative.lean`) checks whether a
+`ApplHead.Licensed` (in `Applicative.lean`) checks whether a
 particular Appl head is licensed with a given Voice head: high
 applicatives require event-introducing Voice (`hasSemantics = true`);
 low applicatives are licensed with any Voice. Cross [pylkkanen-2008]'s
@@ -1260,14 +1260,12 @@ Appl typology in a single matrix. -/
     and so don't license high Appl. -/
 theorem voice_appl_licensing_matrix :
     -- High Appl licensed with event-bearing Voice flavors:
-    Minimalist.applHigh.licensedWith Minimalist.voiceAgent = true ∧
-    Minimalist.applHigh.licensedWith Minimalist.voiceCauser = true ∧
+    Minimalist.applHigh.Licensed Minimalist.voiceAgent ∧
+    Minimalist.applHigh.Licensed Minimalist.voiceCauser ∧
     -- Low Appl is always licensed (independent of Voice semantics):
-    Minimalist.applLowRecipient.licensedWith Minimalist.voiceAgent = true ∧
-    Minimalist.applLowRecipient.licensedWith Minimalist.voicePassive = true ∧
-    Minimalist.applLowSource.licensedWith Minimalist.voiceAnticausative = true := by
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩ <;>
-    (unfold Minimalist.ApplHead.licensedWith; decide)
+    Minimalist.applLowRecipient.Licensed Minimalist.voiceAgent ∧
+    Minimalist.applLowRecipient.Licensed Minimalist.voicePassive ∧
+    Minimalist.applLowSource.Licensed Minimalist.voiceAnticausative := by decide
 
 /-! ## §17. WALS-vs-Pylkkänen divergence on English/Japanese applicatives
 

--- a/Linglib/Studies/Wood2015.lean
+++ b/Linglib/Studies/Wood2015.lean
@@ -348,30 +348,30 @@ theorem parametric_diversity :
     Ch. 5 argues Icelandic lacks true high applicatives; the asymmetry
     formalized here follows the cross-linguistic typology. -/
 theorem ethical_blocked_in_middle :
-    applHigh.licensedWith voiceMiddle = false := rfl
+    ¬ applHigh.Licensed voiceMiddle := by decide
 
 /-- Low applicatives survive when Voice has no event semantics
     because they relate to the theme, not the event
     ([pylkkanen-2008]). -/
 theorem possessive_survives_middle :
-    applLowRecipient.licensedWith voiceMiddle = true := rfl
+    applLowRecipient.Licensed voiceMiddle := by decide
 
 /-- In anticausatives, possessive datives also survive. -/
 theorem possessive_survives_anticausative :
-    applLowRecipient.licensedWith voiceAnticausative = true := rfl
+    applLowRecipient.Licensed voiceAnticausative := by decide
 
 /-- High applicatives ARE licensed with agentive Voice. -/
 theorem ethical_ok_in_active :
-    applHigh.licensedWith voiceAgent = true := rfl
+    applHigh.Licensed voiceAgent := by decide
 
 /-- The full asymmetry: high applicatives require Voice with event
     semantics; low applicatives are independent of Voice
     ([pylkkanen-2008], [schaefer-2008]). -/
 theorem dative_voice_asymmetry :
-    applHigh.licensedWith voiceMiddle = false ∧
-    applHigh.licensedWith voiceAgent = true ∧
-    applLowRecipient.licensedWith voiceMiddle = true ∧
-    applLowRecipient.licensedWith voiceAgent = true := ⟨rfl, rfl, rfl, rfl⟩
+    ¬ applHigh.Licensed voiceMiddle ∧
+    applHigh.Licensed voiceAgent ∧
+    applLowRecipient.Licensed voiceMiddle ∧
+    applLowRecipient.Licensed voiceAgent := by decide
 
 -- ============================================================================
 -- § 5: Theta Role Predictions
@@ -401,14 +401,14 @@ theorem middle_predicts_none :
     SpecApplP because Appl assigns dative case and *-st* lacks case
     features. -/
 theorem st_blocked_from_specApplP :
-    applLowRecipient.specCanBearCase (none : Option Case) = false ∧
-    applLowRecipient.specCanBearCase (some Case.dat) = true := ⟨rfl, rfl⟩
+    ¬ applLowRecipient.SpecCanBearCase (none : Option Case) ∧
+    applLowRecipient.SpecCanBearCase (some Case.dat) := by decide
 
 /-- In ditransitive *-st* alternations, Appl datives are retained
     because Appl assigns case independently of Voice
     ([wood-2015] Ch. 5, §5.3.1). -/
 theorem appl_dative_retained_with_st :
-    applLowRecipient.licensedWith voiceAnticausative = true := rfl
+    applLowRecipient.Licensed voiceAnticausative := by decide
 
 -- ============================================================================
 -- § 7: -st/-na Complementary Distribution (Ch. 3)

--- a/Linglib/Syntax/Minimalist/Applicative.lean
+++ b/Linglib/Syntax/Minimalist/Applicative.lean
@@ -9,253 +9,211 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Selection
 # Applicative Heads
 [cuervo-2003] [pylkkanen-2008] [wood-2015]
 
-Applicative heads introduce applied arguments (benefactives, goals,
-sources) into the verbal structure. The high/low distinction determines
-whether the applied argument relates to the event as a whole (high)
-or to the theme (low).
+Applicative heads introduce applied arguments (benefactives, goals, sources) into the
+verbal structure. The high/low distinction determines whether the applied argument relates
+to the event as a whole (high) or to the theme (low); low applicatives further split into
+**recipient** (transfer *to*) and **source** (transfer *from*), following [pylkkanen-2008].
 
-Low applicatives further split into **recipient** (transfer *to*) and
-**source** (transfer *from*), following [pylkkanen-2008] Table 1.1.
+## Semantic denotations ([pylkkanen-2008])
 
-## Semantic Denotations ([pylkkanen-2008])
+- **High Appl**: `λx.λe. Appl(e, x)` — relates an individual to the event
+  (ethical datives: "he ate food on-me").
+- **Low Appl (recipient)**: `λx.λy. HAVE(x, y)` — transfer TO (English DOC: "I sent him a
+  letter").
+- **Low Appl (source)**: `λx.λy. HAVE-FROM(y, x)` — transfer FROM (possessive datives:
+  "they broke his arm").
 
-- **High Appl**: λx.λe. Appl(e, x) — relates individual to event
-  (ethical datives: "he ate food on-me")
-- **Low Appl (recipient)**: λx.λy. HAVE(x, y) — transfer TO
-  (English DOC: "I sent him a letter")
-- **Low Appl (source)**: λx.λy. HAVE-FROM(y, x) — transfer FROM
-  (possessive datives: "they broke his arm")
+## High/low asymmetry ([pylkkanen-2008], [schaefer-2008])
 
-## High/Low Asymmetry ([pylkkanen-2008], [schaefer-2008])
-
-High applicatives require Voice with event semantics; low applicatives
-are independent of Voice. This predicts high Appl is blocked when
-Voice is semantically null (middles, anticausatives).
-
-Note: [wood-2015] Ch. 5 argues that Icelandic lacks true high
-applicatives entirely. The high/low interaction modeled here follows
-the cross-linguistic typology of [pylkkanen-2008].
+High applicatives require Voice with event semantics; low applicatives are independent of
+Voice. This predicts high Appl is blocked when Voice is semantically null (middles,
+anticausatives). [wood-2015] argues that Icelandic lacks true high applicatives entirely;
+the interaction modeled here follows [pylkkanen-2008]'s cross-linguistic typology.
 -/
 
 namespace Minimalist
 
-/-- High vs low applicatives ([pylkkanen-2008], Table 1.1).
+/-! ### Applicative type and its Merge complement -/
 
-    - **High**: Above VP, relates applied argument to the event
-      (benefactive: Chaga "he ate food for wife")
-    - **Low recipient**: Below VP, transfer-of-possession *to* the
-      applied argument (English DOC: "I sent him a letter")
-    - **Low source**: Below VP, transfer-of-possession *from* the
-      applied argument (Korean, Hebrew possessor datives, Japanese
-      adversity passives) -/
+/-- High vs low applicatives ([pylkkanen-2008]).
+
+    - **High**: above VP, relates the applied argument to the event
+      (benefactive: Chaga "he ate food for wife").
+    - **Low recipient**: below VP, transfer-of-possession *to* the applied argument
+      (English DOC: "I sent him a letter").
+    - **Low source**: below VP, transfer-of-possession *from* the applied argument
+      (Korean, Hebrew possessor datives, Japanese adversity passives). -/
 inductive ApplType where
-  | high          -- Above VP: individual-event relation ([pylkkanen-2008])
-  | lowRecipient  -- Below VP: transfer TO applied arg ([pylkkanen-2008])
-  | lowSource     -- Below VP: transfer FROM applied arg ([pylkkanen-2008] §2.2, §2.3)
+  /-- Above VP: relates the applied argument to the event. -/
+  | high
+  /-- Below VP: transfer-of-possession *to* the applied argument. -/
+  | lowRecipient
+  /-- Below VP: transfer-of-possession *from* the applied argument. -/
+  | lowSource
   deriving DecidableEq, Repr
 
 /-- The category of the constituent an applicative Merges with — its complement.
-    This **is** [pylkkanen-2008]'s high/low distinction (Merge position): a high
-    applicative merges with the event projection (the `v`P, `[+V]`); a low
-    applicative merges with the theme (a `D`P, `[+N]`). The structural predicates
-    below are read off this complement via `catFeatures`, not stipulated from the
-    constructor — Pylkkänen's typology *follows from* attachment height. -/
+    This **is** [pylkkanen-2008]'s high/low distinction (Merge position): a high applicative
+    merges with the event projection (the `v`P, `[+V]`); a low applicative merges with the
+    theme (a `D`P, `[+N]`). The structural predicates below are read off this complement —
+    Pylkkänen's typology *follows from* attachment height. -/
 def ApplType.complement : ApplType → Cat
   | .high         => .v    -- the event (vP)
   | .lowRecipient => .D    -- the theme (DP)
   | .lowSource    => .D    -- the theme (DP)
 
-/-- The complement an applicative Merges with, as an actual `SO` constituent: a leaf
-    headed by `a.complement` (the event for high, the theme for low). The Merge itself is
+/-- The complement an applicative Merges with, as an actual `SO` constituent: a leaf headed
+    by `a.complement` (the event for high, the theme for low). The Merge itself is
     `ApplType.toSO`, whose right child is this. -/
 def ApplType.complementSO (a : ApplType) (id : Nat := 0) : SO :=
   SO.mkLeaf a.complement [] id
 
 /-- The categorial features of the actual Merge complement, **read off the `SO` via the
     §1.13 head function** `SO.outerCatC`. The high/low typology below is this read, by
-    construction — Pylkkänen's attachment claim is the definition, not a `Cat` table and
-    not a separate predicate bridged to the structure. -/
+    construction — Pylkkänen's attachment claim is the definition, not a `Cat` table and not
+    a separate predicate bridged to the structure. -/
 def ApplType.complementFeatures (a : ApplType) : CatFeatures :=
   a.complementSO.outerCatC.elim ⟨false, false⟩ catFeatures
 
 /-- Low iff the applicative Merges with a nominal (theme) complement. -/
-def ApplType.IsLow (a : ApplType) : Prop :=
-  a.complementFeatures.plusN = true
+def ApplType.IsLow (a : ApplType) : Prop := a.complementFeatures.plusN = true
 
-instance : DecidablePred ApplType.IsLow :=
+instance : DecidablePred ApplType.IsLow := fun _ => inferInstanceAs (Decidable (_ = true))
+
+/-- Requires event semantics from Voice iff the applicative Merges with the verbal (event)
+    complement — i.e. iff it is high. A low applicative Merges with the theme and is
+    independent of Voice. -/
+def ApplType.RequiresEventSemantics (a : ApplType) : Prop := a.complementFeatures.plusV = true
+
+instance : DecidablePred ApplType.RequiresEventSemantics :=
   fun _ => inferInstanceAs (Decidable (_ = true))
 
--- ============================================================================
--- § 2: Semantic Relations
--- ============================================================================
+/-- Requires an unsaturated theme in its complement iff it is low. This drives
+    [pylkkanen-2008]'s transitivity restriction: low applicatives cannot combine with
+    unergatives, whose VPs lack an unsaturated theme — combining the two would identify the
+    applied argument as both agent and theme of one event, a contradiction. -/
+def ApplType.RequiresThemeInComplement (a : ApplType) : Prop := a.IsLow
 
-/-- The semantic relation an applicative head contributes.
+instance : DecidablePred ApplType.RequiresThemeInComplement :=
+  fun a => inferInstanceAs (Decidable a.IsLow)
 
-    - `eventRelation`: λx.λe. R(e, x) — relates individual to event (high Appl)
-    - `possessionTo`: λx.λy. HAVE(x, y) — transfer-to (low recipient)
-    - `possessionFrom`: λx.λy. HAVE-FROM(y, x) — transfer-from (low source) -/
+/-! ### Semantic relations -/
+
+/-- The semantic relation an applicative head contributes ([pylkkanen-2008]).
+
+    - `eventRelation`: `λx.λe. R(e, x)` — relates an individual to the event (high Appl).
+    - `possessionTo`: `λx.λy. HAVE(x, y)` — transfer-to (low recipient).
+    - `possessionFrom`: `λx.λy. HAVE-FROM(y, x)` — transfer-from (low source). -/
 inductive ApplSemantics where
-  | eventRelation   -- High: individual-event (ethical dative, benefactive)
-  | possessionTo    -- Low recipient: HAVE relation
-  | possessionFrom  -- Low source: HAVE-FROM relation
+  /-- Individual–event relation (high Appl: ethical dative, benefactive). -/
+  | eventRelation
+  /-- `HAVE` relation (low recipient). -/
+  | possessionTo
+  /-- `HAVE-FROM` relation (low source). -/
+  | possessionFrom
   deriving DecidableEq, Repr
 
-/-- Map each applicative type to its semantic contribution. -/
+/-- The semantic contribution of each applicative type. -/
 def ApplType.semantics : ApplType → ApplSemantics
   | .high         => .eventRelation
   | .lowRecipient => .possessionTo
   | .lowSource    => .possessionFrom
 
-/-- Does this applicative type require event-level semantics from Voice?
-    A high applicative Merges with the event projection (a `[+V]` complement), so it needs
-    Voice to contribute event semantics; a low applicative Merges with the theme and is
-    independent of Voice. Read off the Merge complement (`complementFeatures`). -/
-def ApplType.RequiresEventSemantics (a : ApplType) : Prop :=
-  a.complementFeatures.plusV = true
+/-! ### The applicative head -/
 
-instance : DecidablePred ApplType.RequiresEventSemantics :=
-  fun _ => inferInstanceAs (Decidable (_ = true))
-
-/-- Does this applicative type require its complement to provide an
-    unsaturated theme argument? Low applicatives do — they relate the
-    applied argument to the theme via transfer-of-possession. High
-    applicatives don't — they relate the applied argument to the event
-    described by the verb, not to a theme.
-
-    This predicate is the source of [pylkkanen-2008]'s
-    transitivity restriction (Diagnostic 1, eq. 17 of book): low
-    applicatives cannot combine with unergatives because unergative
-    VPs lack an unsaturated theme. The semantic mismatch is shown
-    in eq. 103 (page 55): combining low Appl with an unergative VP
-    yields `agent(e, x) ∧ theme(e, x)` — a contradiction. -/
-def ApplType.RequiresThemeInComplement (a : ApplType) : Prop :=
-  a.IsLow
-
-instance : DecidablePred ApplType.RequiresThemeInComplement :=
-  fun a => inferInstanceAs (Decidable a.IsLow)
-
--- ============================================================================
--- § 3: Applicative Head Structure
--- ============================================================================
-
-/-- An applicative head with its type and properties. -/
+/-- An applicative head: its type, plus whether it assigns dative case to its specifier. -/
 structure ApplHead where
-  /-- High or low (recipient/source) -/
+  /-- High or low (recipient/source). -/
   applType : ApplType
-  /-- Does the applied argument get dative case? -/
+  /-- Whether the applied argument receives dative case. -/
   assignsDative : Bool := true
   deriving DecidableEq, Repr
 
 /-- Canonical high applicative (ethical dative). -/
-def applHigh : ApplHead :=
-  { applType := .high }
+def applHigh : ApplHead := { applType := .high }
 
 /-- Canonical low recipient applicative (DOC, possessive dative). -/
-def applLowRecipient : ApplHead :=
-  { applType := .lowRecipient }
+def applLowRecipient : ApplHead := { applType := .lowRecipient }
 
 /-- Canonical low source applicative. -/
-def applLowSource : ApplHead :=
-  { applType := .lowSource }
+def applLowSource : ApplHead := { applType := .lowSource }
 
--- ============================================================================
--- § 4: Voice–Applicative Interaction ([pylkkanen-2008], [schaefer-2008])
--- ============================================================================
+/-! ### Voice–applicative licensing ([pylkkanen-2008], [schaefer-2008]) -/
 
-/-- Is this applicative licensed in the context of a given Voice head?
+/-- An applicative is **licensed** by a Voice head iff, when it requires event semantics
+    (high Appl), that Voice supplies them. Low applicatives relate to the theme and so are
+    licensed under any Voice; high applicatives are blocked when Voice is semantically null
+    (middles, anticausatives). -/
+def ApplHead.Licensed (appl : ApplHead) (voice : VoiceHead) : Prop :=
+  appl.applType.RequiresEventSemantics → voice.HasSemantics
 
-    High applicatives require Voice with event semantics; when Voice is
-    semantically null (middles, anticausatives), high Appl is blocked.
-    Low applicatives relate to the theme and are always licensed
-    ([pylkkanen-2008]). -/
-def ApplHead.licensedWith (appl : ApplHead) (voice : VoiceHead) : Bool :=
-  if appl.applType.RequiresEventSemantics then decide voice.HasSemantics
-  else true
+instance (appl : ApplHead) (voice : VoiceHead) : Decidable (appl.Licensed voice) :=
+  inferInstanceAs (Decidable (_ → _))
 
--- ============================================================================
--- § 5: Verification Theorems
--- ============================================================================
+/-! ### Licensing predictions -/
 
-/-- High applicatives require event semantics. -/
-theorem high_requires_event :
-    ApplType.RequiresEventSemantics .high := by decide
+variable (v : VoiceHead)
 
-/-- Low applicatives do not require event semantics. -/
+/-- High applicatives require event semantics; low applicatives do not. -/
+theorem high_requires_event : ApplType.RequiresEventSemantics .high := by decide
+
 theorem low_no_event_requirement :
     ¬ ApplType.RequiresEventSemantics .lowRecipient ∧
-    ¬ ApplType.RequiresEventSemantics .lowSource := ⟨by decide, by decide⟩
+    ¬ ApplType.RequiresEventSemantics .lowSource := by decide
 
 /-- Low applicatives are licensed under any Voice head ([pylkkanen-2008]). -/
-theorem low_licensed_with_any (v : VoiceHead) :
-    applLowRecipient.licensedWith v = true ∧
-    applLowSource.licensedWith v = true := ⟨rfl, rfl⟩
+theorem low_licensed_with_any :
+    applLowRecipient.Licensed v ∧ applLowSource.Licensed v :=
+  ⟨fun h => absurd h (by decide), fun h => absurd h (by decide)⟩
 
-/-- θ-assigning Voice licenses high applicatives: θ-assignment entails event
-    semantics (`VoiceHead.AssignsTheta.hasSemantics`), which is all high Appl
-    requires. -/
-theorem high_licensed_of_assignsTheta (v : VoiceHead) (h : v.AssignsTheta) :
-    applHigh.licensedWith v = true := by
-  unfold ApplHead.licensedWith
-  split
-  · exact decide_eq_true h.hasSemantics
-  · rfl
+/-- θ-assigning Voice licenses high applicatives: θ-assignment entails event semantics
+    (`VoiceHead.AssignsTheta.hasSemantics`), which is all high Appl requires. -/
+theorem high_licensed_of_assignsTheta (h : v.AssignsTheta) : applHigh.Licensed v :=
+  fun _ => h.hasSemantics
 
 /-- Ethical datives (high Appl) are licensed with agentive Voice. -/
-theorem ethical_dative_with_agent :
-    applHigh.licensedWith voiceAgent = true := rfl
+theorem ethical_dative_with_agent : applHigh.Licensed voiceAgent := by decide
 
-/-- High Appl is BLOCKED with middle Voice (no event semantics)
-    ([pylkkanen-2008]). -/
-theorem ethical_dative_blocked_in_middle :
-    applHigh.licensedWith voiceMiddle = false := rfl
+/-- High Appl is blocked with middle Voice (no event semantics) ([pylkkanen-2008]). -/
+theorem ethical_dative_blocked_in_middle : ¬ applHigh.Licensed voiceMiddle := by decide
 
 /-- Possessive datives (low Appl) survive in middles. -/
-theorem possessive_dative_survives_middle :
-    applLowRecipient.licensedWith voiceMiddle = true := rfl
+theorem possessive_dative_survives_middle : applLowRecipient.Licensed voiceMiddle := by decide
 
 /-- Possessive datives survive in anticausatives. -/
 theorem possessive_dative_survives_anticausative :
-    applLowRecipient.licensedWith voiceAnticausative = true := rfl
+    applLowRecipient.Licensed voiceAnticausative := by decide
 
 /-- The asymmetry: ethical blocked but possessive survives in middles. -/
 theorem ethical_possessive_middle_asymmetry :
-    applHigh.licensedWith voiceMiddle = false ∧
-    applLowRecipient.licensedWith voiceMiddle = true := ⟨rfl, rfl⟩
+    ¬ applHigh.Licensed voiceMiddle ∧ applLowRecipient.Licensed voiceMiddle := by decide
 
--- ============================================================================
--- § 6: Case-Based Blocking of SpecApplP ([wood-2015] Ch. 5, §5.3.2)
--- ============================================================================
+/-! ### Case-based blocking of SpecApplP ([wood-2015]) -/
 
-/-- Can a given element merge in SpecApplP?
+/-- An element can occupy SpecApplP iff, when Appl assigns dative, it bears case.
+    [wood-2015]: Appl assigns dative to its specifier, so only case-bearing elements
+    (`caseOf ≠ none`) qualify — the caseless Icelandic clitic -st is blocked from SpecApplP
+    though it can occupy SpecVoiceP / Spec-p, where no case is assigned to the specifier. -/
+def ApplHead.SpecCanBearCase {α : Type*} [HasCase α] (appl : ApplHead) (x : α) : Prop :=
+  appl.assignsDative = true → (HasCase.caseOf x).isSome = true
 
-    [wood-2015] Ch. 5 (§5.3.2): Appl assigns **dative case** to its
-    specifier. Therefore only case-bearing elements (`HasCase` carriers
-    with `caseOf ≠ none`) can merge in SpecApplP. The Icelandic clitic
-    -st lacks case features and is thus blocked from SpecApplP, even
-    though it can merge in SpecVoiceP and SpecpP (where no case is
-    assigned to the specifier). -/
-def ApplHead.specCanBearCase {α : Type*} [HasCase α] (appl : ApplHead)
-    (x : α) : Bool :=
-  if appl.assignsDative then (HasCase.caseOf x).isSome
-  else true
+instance {α : Type*} [HasCase α] (appl : ApplHead) (x : α) :
+    Decidable (appl.SpecCanBearCase x) := inferInstanceAs (Decidable (_ → _))
 
-/-- -st (caseless: `caseOf = none`) cannot merge in SpecApplP
-    ([wood-2015] §5.3.2). -/
+/-- The caseless clitic -st (`caseOf = none`) cannot occupy SpecApplP ([wood-2015]). -/
 theorem caseless_blocked_in_specAppl :
-    applLowRecipient.specCanBearCase (none : Option Case) = false := rfl
+    ¬ applLowRecipient.SpecCanBearCase (none : Option Case) := by decide
 
-/-- A case-bearing DP CAN merge in SpecApplP. -/
+/-- A case-bearing DP can occupy SpecApplP. -/
 theorem caseful_ok_in_specAppl :
-    applLowRecipient.specCanBearCase (some Case.dat) = true := rfl
+    applLowRecipient.SpecCanBearCase (some Case.dat) := by decide
 
--- ============================================================================
--- § 7: The applicative as an actual Merge
--- ============================================================================
+/-! ### The applicative as a Merge -/
 
 /-- An applicative of type `a` realized as an actual Merge: the `Appl` head (selecting
     `a.complement`) `SO.merge`d with its complement. Its right child is `a.complementSO`,
-    the very constituent whose head category `RequiresEventSemantics`/`IsLow` read off —
-    so the typology *is* a property of this derivation, by construction. -/
+    the very constituent whose head category `RequiresEventSemantics`/`IsLow` read off — so
+    the typology *is* a property of this derivation, by construction. -/
 noncomputable def ApplType.toSO (a : ApplType) (applId complId : Nat := 0) : SO :=
   SO.merge (SO.mkLeaf .Appl [a.complement] applId) (a.complementSO complId)
 


### PR DESCRIPTION
Mathlib-quality pass over `Syntax/Minimalist/Applicative.lean` (follow-up to #830/#832).

- **`Bool` → `Prop` for predicate-shape defs.** `ApplHead.licensedWith` → `Licensed` (a clean implication `RequiresEventSemantics → voice.HasSemantics`) and `specCanBearCase` → `SpecCanBearCase`, each with a `Decidable` instance — `Bool` is for genuine boolean data, not predicates. Consumers (Wood2015, Pylkkanen2008, Hewett2026 incl. its `licensesAppl`) migrated off `= true`/`= false`; several proofs got shorter (`fun _ => hθ.hasSemantics` etc.).
- **`/-! ### -/` section headers** replacing `-- § N:` ASCII dividers; per-constructor doc-comments.
- Softened hallucination-risk location citations (`eq. 17`, `eq. 103 (page 55)`, `§5.3.2`) to content descriptions.
- Golfed proofs (`by decide`, vacuous-implication terms); lifted `variable (v : VoiceHead)`.

Axiom-clean (`propext`, `Quot.sound`); all 9 importers green.