### PR TITLE
refactor(Features/Possession): retire PossessionProfile bundle

### DIFF
--- a/Linglib/Features/Possession.lean
+++ b/Linglib/Features/Possession.lean
@@ -9,8 +9,8 @@ Authors: Robert Hawkins
 [stassen-2009] [stassen-2013b] [nichols-1986] [nichols-bickel-2013]
 [nichols-bickel-2013c] [heine-1997] [heine-2009] [aikhenvald-2012] [wals-2013]
 
-Theory-neutral classification enums for possession plus a per-language
-`PossessionProfile`, typed by Fragment data and consumed by
+Theory-neutral classification enums for possession. Per-language values are
+bare `def`s in `Fragments/<Lang>/Possession.lean`, consumed by
 `Studies/NicholsBickel2013`, `Studies/Heine1997`, and
 `Studies/KampanarouAlexiadou2026`. Bare-root `Possession` namespace under
 `Features/`, like `Features/Case`.
@@ -20,7 +20,9 @@ Theory-neutral classification enums for possession plus a per-language
 `Obligatoriness` (WALS 58A), `Classification` (59A), `AffixPosition` (57A),
 `PredicativeStrategy` ([stassen-2009] four-way; [stassen-2013b] adds Genitive),
 `AdnominalMarking` ([nichols-1986]), `Notion` and `Source` ([heine-1997]),
-`InalienabilityRank`, the neutral `Alienability` cut, and `PossessionProfile`.
+`InalienabilityRank`, and the neutral `Alienability` cut. Per-language values
+are bare `def`s in `Fragments/<Lang>/Possession.lean`; cross-linguistic
+aggregation uses a study-local row in `Studies/NicholsBickel2013.lean`.
 
 ## Notes
 
@@ -181,56 +183,5 @@ def Classification.drawsAlienabilityCut : Classification → Bool
 def InalienabilityRank.alienabilityAt (cut : InalienabilityRank) :
     InalienabilityRank → Alienability :=
   fun r => if cut.toNat ≤ r.toNat then .inalienable else .alienable
-
-/-! ### Per-language profile -/
-
-/-- A language's possession profile across WALS 57–59, predicative
-    ([stassen-2009]), and adnominal ([nichols-1986]) dimensions. -/
-structure PossessionProfile where
-  /-- Language name. -/
-  language : String
-  /-- Language family. -/
-  family : String
-  /-- ISO 639-3 code. -/
-  iso : String := ""
-  /-- WALS 58A: obligatory possessive inflection. -/
-  obligatoryPossession : Obligatoriness
-  /-- WALS 59A: morphosyntactic possession classification. -/
-  possessiveClassification : Classification
-  /-- Predicative strategy ("I have X"). -/
-  predicativeStrategy : PredicativeStrategy
-  /-- Adnominal marking ("my book"). -/
-  adnominalStrategy : AdnominalMarking
-  /-- WALS 57A: pronominal possessive affix position, if attested. -/
-  affixPosition : Option AffixPosition := .none
-  /-- Illustrative forms. -/
-  examples : List String := []
-  /-- Notes on the possession system. -/
-  notes : String := ""
-  deriving Repr, DecidableEq
-
-/-- Has obligatory possessive inflection? -/
-def PossessionProfile.hasObligatoryPossession (p : PossessionProfile) : Bool :=
-  p.obligatoryPossession == .exists_
-
-/-- Morphosyntactically classifies possession? -/
-def PossessionProfile.hasClassification (p : PossessionProfile) : Bool :=
-  p.possessiveClassification != .noClassification
-
-/-- Uses a have-verb predicative strategy? -/
-def PossessionProfile.usesHaveVerb (p : PossessionProfile) : Bool :=
-  p.predicativeStrategy == .haveVerb
-
-/-- Uses a locational/existential predicative strategy? -/
-def PossessionProfile.usesLocational (p : PossessionProfile) : Bool :=
-  p.predicativeStrategy == .locational
-
-/-- Uses head-marking for adnominal possession? -/
-def PossessionProfile.isHeadMarking (p : PossessionProfile) : Bool :=
-  p.adnominalStrategy == .headMarking
-
-/-- Uses dependent-marking for adnominal possession? -/
-def PossessionProfile.isDependentMarking (p : PossessionProfile) : Bool :=
-  p.adnominalStrategy == .dependentMarking
 
 end Possession

--- a/Linglib/Fragments/Arabic/ModernStandard/Possession.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Possession.lean
@@ -2,14 +2,19 @@ import Linglib.Features.Possession
 
 /-!
 # Arabic possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Arabic (ISO `arb`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
-`Studies/NicholsBickel2013.lean`.
+Bare per-language possession `def`s for Arabic (Afro-Asiatic, ISO `arb`),
+per the project's "per-language data flows through Fragments" rule.
+Substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming
+these values live in `Studies/NicholsBickel2013.lean`.
+
+Examples: ʿindii kitaab-un; kitaab-u l-walad-i. Preposition ʿinda for
+predicative possession (lit. 'at me [there is] a book'); construct state
+(iḍāfa) for adnominal possession — juxtaposition with the head noun in
+construct state (no nunation, no definite article) and the possessor in
+the genitive.
 -/
 
 set_option autoImplicit false
@@ -18,17 +23,10 @@ namespace Arabic.ModernStandard.Possession
 
 open _root_.Possession
 
-/-- Arabic possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Arabic"
-  , family := "Afro-Asiatic"
-  , iso := "arb"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .zeroMarking
-  , affixPosition := some .suffixes
-  , examples := ["ʿindii kitaab-un", "kitaab-u l-walad-i"]
-  , notes := "Preposition ʿinda for predicative possession (lit. 'at me [there is] a book'); construct state (iḍāfa) for adnominal possession — juxtaposition with the head noun in construct state (no nunation, no definite article) and the possessor in the genitive" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .locational
+def adnominalStrategy : AdnominalMarking := .zeroMarking
+def affixPosition : Option AffixPosition := some .suffixes
 
 end Arabic.ModernStandard.Possession

--- a/Linglib/Fragments/English/Possession.lean
+++ b/Linglib/Fragments/English/Possession.lean
@@ -2,13 +2,13 @@ import Linglib.Features.Possession
 
 /-!
 # English possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for English (ISO `eng`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
+Per-language possession values for English (Indo-European, ISO `eng`): forms
+`I have a book`, `John's book`, `the book of John`; genitive clitic -'s on the
+possessor, with an of-phrase alternative. Substrate types (`PredicativeStrategy`,
+`AdnominalMarking`, …) live in `Linglib/Features/Possession.lean`.
+Cross-linguistic theorems consuming these values live in
 `Studies/NicholsBickel2013.lean`.
 -/
 
@@ -18,17 +18,10 @@ namespace English.Possession
 
 open _root_.Possession
 
-/-- English possession profile. -/
-def possession : PossessionProfile :=
-  { language := "English"
-  , family := "Indo-European"
-  , iso := "eng"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .haveVerb
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := some .noAffix
-  , examples := ["I have a book", "John's book", "the book of John"]
-  , notes := "Genitive clitic -'s on possessor; of-phrase alternative" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .haveVerb
+def adnominalStrategy : AdnominalMarking := .dependentMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end English.Possession

--- a/Linglib/Fragments/Fijian/Possession.lean
+++ b/Linglib/Fragments/Fijian/Possession.lean
@@ -2,14 +2,17 @@ import Linglib.Features.Possession
 
 /-!
 # Fijian possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Fijian (ISO `fij`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
-`Studies/NicholsBickel2013.lean`.
+Bare per-language possession `def`s for Fijian (Austronesian, ISO `fij`),
+per the project's "per-language data flows through Fragments" rule.
+Substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming
+these values live in `Studies/NicholsBickel2013.lean`.
+
+Examples: na liga-qu (body-part); na ke-qu kakana (food); na me-qu ti
+(drink); na no-qu vale (house). Four-way possessive classification: direct
+(body/kin), ke- (edible), me- (drinkable), no- (general alienable).
 -/
 
 set_option autoImplicit false
@@ -18,17 +21,10 @@ namespace Fijian.Possession
 
 open _root_.Possession
 
-/-- Fijian possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Fijian"
-  , family := "Austronesian"
-  , iso := "fij"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .threeOrMore
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .headMarking
-  , affixPosition := some .suffixes
-  , examples := ["na liga-qu (body-part)", "na ke-qu kakana (food)", "na me-qu ti (drink)", "na no-qu vale (house)"]
-  , notes := "Four-way possessive classification: direct (body/kin), ke- (edible), me- (drinkable), no- (general alienable)" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .threeOrMore
+def predicativeStrategy : PredicativeStrategy := .locational
+def adnominalStrategy : AdnominalMarking := .headMarking
+def affixPosition : Option AffixPosition := some .suffixes
 
 end Fijian.Possession

--- a/Linglib/Fragments/Finnish/Possession.lean
+++ b/Linglib/Fragments/Finnish/Possession.lean
@@ -18,8 +18,7 @@ of the Location Schema reaching Stage III: the adessive in possessive
 use is no longer interpreted as locative by speakers
 ([heine-1997] Overlap Model).
 
-PossessionProfile bundle for Finnish (ISO `fin`), per the project's
-"per-language data flows through Fragments" rule. Substrate types live in
+Per-language possession defs for Finnish (ISO `fin`). Substrate enums live in
 `Linglib/Features/Possession.lean`. Heine 1997 prediction verification for
 Finnish lives in `Studies/Heine1997.lean`.
 
@@ -99,11 +98,11 @@ def possSuffix : FiPossPerson → FiPossNumber → String
 -- §4. Adnominal Possession Marking
 -- ============================================================================
 
-/-- Finnish marks possession on the possessum (head-marking) via the
-    possessive suffixes above. It also uses the genitive case on the
-    possessor NP (dependent-marking), giving a double-marking pattern
-    in formal registers: `Matti-n kirja-nsa` 'Matti-GEN book-POSS.3'. -/
-def adnominalStrategy : AdnominalMarking := .doubleMarking
+/-- Adnominal genitive on the possessor (dependent-marking); the optional
+    possessive suffix on the head (`Matti-n kirja-nsa` 'Matti-GEN book-POSS.3')
+    adds a double-marking pattern in formal registers, but WALS codes Finnish
+    as dependent-marking. -/
+def adnominalStrategy : AdnominalMarking := .dependentMarking
 
 -- ============================================================================
 -- §5. Schema-Notion Correlations
@@ -123,21 +122,11 @@ theorem covers_all_notions :
     expressibleNotions.length = 7 := rfl
 
 -- ============================================================================
--- §6. Finnish Possession Profile (PossessionProfile bundle)
+-- §6. Remaining typological dimensions
 -- ============================================================================
 
-/-- Finnish possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Finnish"
-  , family := "Uralic"
-  , iso := "fin"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := some .suffixes
-  , examples := ["minu-lla on kirja", "Matin kirja"]
-  , notes := "Adessive -lla for locational predicative possession; " ++
-             "genitive + optional possessive suffix on head" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def affixPosition : Option AffixPosition := some .suffixes
 
 end Finnish.Possession

--- a/Linglib/Fragments/Georgian/Possession.lean
+++ b/Linglib/Fragments/Georgian/Possession.lean
@@ -2,14 +2,16 @@ import Linglib.Features.Possession
 
 /-!
 # Georgian possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Georgian (ISO `kat`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
-`Studies/NicholsBickel2013.lean`.
+Bare per-language possession `def`s for Georgian (Kartvelian, ISO `kat`),
+per the project's "per-language data flows through Fragments" rule.
+Substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming
+these values live in `Studies/NicholsBickel2013.lean`.
+
+Examples: me m-akvs cigni; kac-is saxl-i. Dative experiencer + verb
+agreeing with possessum; genitive on possessor in adnominal constructions.
 -/
 
 set_option autoImplicit false
@@ -18,17 +20,10 @@ namespace Georgian.Possession
 
 open _root_.Possession
 
-/-- Georgian possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Georgian"
-  , family := "Kartvelian"
-  , iso := "kat"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .doubleMarking
-  , affixPosition := some .noAffix
-  , examples := ["me m-akvs cigni", "kac-is saxl-i"]
-  , notes := "Dative experiencer + verb agreeing with possessum; genitive on possessor in adnominal constructions" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .locational
+def adnominalStrategy : AdnominalMarking := .doubleMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Georgian.Possession

--- a/Linglib/Fragments/Greek/Grevena/Possession.lean
+++ b/Linglib/Fragments/Greek/Grevena/Possession.lean
@@ -6,8 +6,16 @@ import Linglib.Features.Possession
 [michelioudakis-chatzikyriakidis-spathas-2024]
 [kampanarou-alexiadou-2026]
 
-`PossessionProfile` bundle for Grevena Greek (GG; Northern Greek dialect),
-the genitive-loss endpoint within the Modern Greek dialect continuum.
+Per-language possession data for Grevena Greek (GG; Northern Greek dialect;
+Indo-European; ISO `ell`, shared macro-language code with SMG), as bare
+field-by-field `def`s — the genitive-loss endpoint within the Modern Greek
+dialect continuum.
+
+Examples: *tu vivliu ap tun ðimarxu* 'the book of the mayor' (apo-PP, no GEN
+on noun), *i piriγrafi ap tun ðimarxu ap ta piðja* (iterated apo-PPs,
+impossible in SMG), *tu spiti m* 'my house' (cliticised pronoun retains
+GEN). Inflectional genitive lost on common nouns; apo-PPs cover all genitive
+functions and can stack, front, and sub-extract (cf. Romance de/di).
 
 ## What makes GG different from SMG
 
@@ -58,32 +66,19 @@ def apoNotions : List Notion :=
     coverage is the dialect's defining feature. -/
 def genNotions : List Notion := []
 
-/-- Grevena Greek possession profile.
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .haveVerb
 
-    `adnominalStrategy := .zeroMarking` reflects the loss of inflectional
-    GEN on common nouns; the `apo`-PP variant carries the load. The label
-    is approximate — `juxtaposition` is the closest WALS-mapped category
-    for "no morphological possessor marking on the noun, possession encoded
-    by phrasal means" — but the genuine analysis (per Michelioudakis et al.)
+/-- `.zeroMarking` reflects the loss of inflectional GEN on common nouns;
+    the `apo`-PP variant carries the load. The label is approximate —
+    `juxtaposition` is the closest WALS-mapped category for "no morphological
+    possessor marking on the noun, possession encoded by phrasal means" — but
+    the genuine analysis (per [michelioudakis-chatzikyriakidis-spathas-2024])
     is *reduced relative clause adjunction*, which the substrate doesn't
-    distinguish from juxtaposition. -/
-def possession : PossessionProfile :=
-  { language := "Grevena Greek"
-  , family := "Indo-European"
-  , iso := "ell"  -- shares macro-language code with SMG
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .haveVerb
-  , adnominalStrategy := .zeroMarking
-  , affixPosition := some .noAffix
-  , examples :=
-      [ "tu vivliu ap tun ðimarxu"     -- 'the book of the mayor' (apo-PP, no GEN on noun)
-      , "i piriγrafi ap tun ðimarxu ap ta piðja"  -- iterated apo-PPs (impossible in SMG)
-      , "tu spiti m"                    -- 'my house' (cliticised pronoun retains GEN)
-      ]
-  , notes := "Inflectional genitive lost on common nouns; apo-PPs cover all genitive functions and\
- can stack, front, and sub-extract (cf. Romance de/di). Per Michelioudakis et al. 2024, GG apo-PPs\
- are reduced relative clauses — a structure SMG apo-PPs do NOT support (see Kampanarou & Alexiadou\
- 2026 §4)." }
+    distinguish from juxtaposition (a structure SMG apo-PPs do NOT support,
+    see [kampanarou-alexiadou-2026] §4). -/
+def adnominalStrategy : AdnominalMarking := .zeroMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Greek.Grevena.Possession

--- a/Linglib/Fragments/Greek/Smyrna/Possession.lean
+++ b/Linglib/Fragments/Greek/Smyrna/Possession.lean
@@ -5,9 +5,17 @@ import Linglib.Features.Possession
 [stassen-2009] [nichols-1986] [heine-1997]
 [liosis-2016] [kampanarou-alexiadou-2026]
 
-`PossessionProfile` bundle for Smyrna Greek (Aegean), the
-*genitive-over-extension* endpoint within the Modern Greek dialect
-continuum — the opposite direction from Grevena Greek.
+Per-language possession data for Smyrna Greek (Aegean; Indo-European;
+ISO `ell`, shared macro-language code with SMG), as bare field-by-field
+`def`s — the *genitive-over-extension* endpoint within the Modern Greek
+dialect continuum, the opposite direction from Grevena Greek.
+
+Examples: *tu luluðakju* 'little flower-DIM.SG.GEN' (SMG: *), *ton
+naftakjo(n)* 'little sailor-DIM.PL.GEN' (SMG: *). Same surface adnominal
+strategy as SMG (dependent-marking inflectional genitive), but with a more
+permissive paradigm: -aki diminutive nouns license inflectional genitive
+forms that SMG rejects as paradigm gaps ([liosis-2016], cited in
+[kampanarou-alexiadou-2026] fn 7).
 
 ## What makes Smyrna different from SMG
 
@@ -52,29 +60,16 @@ def genNotions : List Notion :=
 def apoNotions : List Notion :=
   [.inanimateInalienable, .inanimateAlienable]
 
-/-- Smyrna Greek possession profile.
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .haveVerb
 
-    Surface profile (`adnominalStrategy = .dependentMarking`) matches SMG;
-    the difference is *paradigm completeness*, not strategy choice — the
-    `-aki` diminutive class permits the genitive forms that SMG rejects
-    as paradigm gaps. -/
-def possession : PossessionProfile :=
-  { language := "Smyrna Greek"
-  , family := "Indo-European"
-  , iso := "ell"  -- shares macro-language code with SMG
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .haveVerb
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := some .noAffix
-  , examples :=
-      [ "tu luluðakju"          -- 'little flower-DIM.SG.GEN' (SMG: *)
-      , "ton naftakjo(n)"       -- 'little sailor-DIM.PL.GEN' (SMG: *)
-      ]
-  , notes := "Same surface adnominal strategy as SMG (dependent-marking inflectional genitive),\
- but with a more permissive paradigm: -aki diminutive nouns license inflectional genitive forms\
- that SMG rejects as paradigm gaps (per Liosis 2016, cited in Kampanarou & Alexiadou 2026 fn 7).\
- Establishes the bidirectionality of the Modern Greek dialect continuum: SMG sits between Smyrna's\
- over-extension and Grevena's complete loss." }
+/-- Surface strategy (`.dependentMarking`) matches SMG; the difference is
+    *paradigm completeness*, not strategy choice — the `-aki` diminutive
+    class permits the genitive forms that SMG rejects as paradigm gaps.
+    Establishes the bidirectionality of the Modern Greek dialect continuum:
+    SMG sits between Smyrna's over-extension and Grevena's complete loss. -/
+def adnominalStrategy : AdnominalMarking := .dependentMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Greek.Smyrna.Possession

--- a/Linglib/Fragments/Greek/StandardModern/Possession.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Possession.lean
@@ -6,10 +6,19 @@ import Linglib.Features.Possession
 [holton-mackridge-philippaki-warburton-spyropoulos-2012]
 [kampanarou-alexiadou-2026]
 
-`PossessionProfile` bundle for Standard Modern Greek (SMG; ISO `ell`), per
-the project's per-language data flows through Fragments rule. Substrate
-types live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consume this profile from `Studies/NicholsBickel2013.lean`.
+Per-language possession data for Standard Modern Greek (SMG; Indo-European;
+ISO `ell`), per the project's per-language data flows through Fragments
+rule, as bare field-by-field `def`s. Substrate types live in
+`Linglib/Features/Possession.lean`. Cross-linguistic theorems consume these
+values from `Studies/NicholsBickel2013.lean`.
+
+Examples: *to vivlio tu Jani* 'John's book' (inflectional GEN), *to pomolo
+apo tin porta* 'the door's handle' (apo-PP, part-whole), *to nero apo tin
+piji* 'the spring's water' (apo-PP, source), *exi pola vivlia* 'has many
+books' (predicative haveVerb). Inflectional genitive (head-suffix on
+possessor) is the broad-coverage strategy; the apo-PP alternates only in
+part-whole and source-like contexts and is degraded with animate
+possessors, pronouns, and proper names ([kampanarou-alexiadou-2026]).
 
 Greek is the canonical case of a language that **morphologically** has a
 single adnominal possession class (no alienable/inalienable split is marked
@@ -17,8 +26,8 @@ on the noun) yet **structurally** distinguishes the two via the position of
 the possessor (per [kampanarou-alexiadou-2026] §7, citing
 [alexiadou-2003]: inalienable possessors are introduced as complements
 of the possessee NP, alienable possessors in the specifier of a dedicated
-PossP). The structural distinction is not visible on `PossessionProfile`,
-which is a typological-surface bundle; it lives in
+PossP). The structural distinction is not visible in these
+typological-surface values; it lives in
 `Morphology/DM/NominalStructure.lean::PossessionType`.
 
 The `apo`-PP variant of the genitive (e.g., *to vivlio apo ton ðimarxo*
@@ -54,24 +63,10 @@ def genNotions : List Notion :=
 def apoNotions : List Notion :=
   [.inanimateInalienable, .inanimateAlienable]
 
-/-- Standard Modern Greek possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Greek"
-  , family := "Indo-European"
-  , iso := "ell"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .haveVerb
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := some .noAffix
-  , examples :=
-      [ "to vivlio tu Jani"        -- 'John's book' (inflectional GEN)
-      , "to pomolo apo tin porta"  -- 'the door's handle' (apo-PP, part-whole)
-      , "to nero apo tin piji"     -- 'the spring's water' (apo-PP, source)
-      , "exi pola vivlia"          -- 'has many books' (predicative haveVerb)
-      ]
-  , notes := "Inflectional genitive (head-suffix on possessor) is the broad-coverage strategy;\
- apo-PP alternates only in part-whole and source-like contexts and is degraded with animate possessors,\
- pronouns, and proper names (per Kampanarou & Alexiadou 2026)." }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .haveVerb
+def adnominalStrategy : AdnominalMarking := .dependentMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Greek.StandardModern.Possession

--- a/Linglib/Fragments/Hawaiian/Possession.lean
+++ b/Linglib/Fragments/Hawaiian/Possession.lean
@@ -2,14 +2,17 @@ import Linglib.Features.Possession
 
 /-!
 # Hawaiian possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Hawaiian (ISO `haw`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
-`Studies/NicholsBickel2013.lean`.
+Bare per-language possession `def`s for Hawaiian (Austronesian, ISO `haw`),
+per the project's "per-language data flows through Fragments" rule.
+Substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming
+these values live in `Studies/NicholsBickel2013.lean`.
+
+Examples: ko'u makuahine (o-class); ka'u puke (a-class). Classic Oceanic
+alienable vs inalienable: a-class (alienable) vs o-class (inalienable body
+parts, kinship, clothing, land).
 -/
 
 set_option autoImplicit false
@@ -18,17 +21,10 @@ namespace Hawaiian.Possession
 
 open _root_.Possession
 
-/-- Hawaiian possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Hawaiian"
-  , family := "Austronesian"
-  , iso := "haw"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .twoWay
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := some .noAffix
-  , examples := ["ko'u makuahine (o-class)", "ka'u puke (a-class)"]
-  , notes := "Classic Oceanic alienable/inalienable: a-class (alienable) vs o-class (inalienable body parts, kinship, clothing, land)" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .twoWay
+def predicativeStrategy : PredicativeStrategy := .locational
+def adnominalStrategy : AdnominalMarking := .dependentMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Hawaiian.Possession

--- a/Linglib/Fragments/HindiUrdu/Possession.lean
+++ b/Linglib/Fragments/HindiUrdu/Possession.lean
@@ -2,13 +2,14 @@ import Linglib.Features.Possession
 
 /-!
 # Hindiurdu possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Hindiurdu (ISO `hin`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
+Per-language possession values for Hindi-Urdu (Indo-European, ISO `hin`): forms
+`mere paas kitaab hai`, `Raam kaa ghar`; postposition `paas` 'near' for
+predicative possession, and the agreeing genitive postposition kaa ~ ke ~ kii
+for adnominal possession. Substrate types (`PredicativeStrategy`,
+`AdnominalMarking`, …) live in `Linglib/Features/Possession.lean`.
+Cross-linguistic theorems consuming these values live in
 `Studies/NicholsBickel2013.lean`.
 -/
 
@@ -18,17 +19,10 @@ namespace HindiUrdu.Possession
 
 open _root_.Possession
 
-/-- Hindiurdu possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Hindiurdu"
-  , family := "Indo-European"
-  , iso := "hin"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := Option.none
-  , examples := ["mere paas kitaab hai", "Raam kaa ghar"]
-  , notes := "Postposition paas 'near' for predicative; kaa/ke/kii agreeing genitive postposition for adnominal" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .locational
+def adnominalStrategy : AdnominalMarking := .dependentMarking
+def affixPosition : Option AffixPosition := Option.none
 
 end HindiUrdu.Possession

--- a/Linglib/Fragments/Hungarian/Possession.lean
+++ b/Linglib/Fragments/Hungarian/Possession.lean
@@ -5,12 +5,16 @@ import Linglib.Features.Possession
 [stassen-2009] [nichols-1986] [heine-1997]
 [kenesei-vago-fenyvesi-1998] [rounds-2001]
 
-PossessionProfile bundle for Hungarian (ISO `hun`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
+Per-language possession data for Hungarian (Uralic; ISO `hun`), per the
+project's "per-language data flows through Fragments" rule, as bare
+field-by-field `def`s. Substrate types (`PredicativeStrategy`,
+`AdnominalMarking`, …) live in `Linglib/Features/Possession.lean`.
+Cross-linguistic theorems consuming these values live in
 `Studies/NicholsBickel2013.lean`.
+
+Examples: *nekem van konyvem*, *Janos kalap-ja*. Dative possessor + *van*
+'exists' + head-marked possessum; possessive suffixes obligatory on
+relational nouns.
 
 The `adnominalStrategy := .headMarking` choice is consistent with both
 standard reference grammars: [kenesei-vago-fenyvesi-1998] §1.10
@@ -30,17 +34,10 @@ namespace Hungarian.Possession
 
 open _root_.Possession
 
-/-- Hungarian possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Hungarian"
-  , family := "Uralic"
-  , iso := "hun"
-  , obligatoryPossession := .exists_
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .headMarking
-  , affixPosition := some .suffixes
-  , examples := ["nekem van konyvem", "Janos kalap-ja"]
-  , notes := "Dative possessor + van 'exists' + head-marked possessum; possessive suffixes obligatory on relational nouns" }
+def obligatoryPossession : Obligatoriness := .exists_
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .locational
+def adnominalStrategy : AdnominalMarking := .headMarking
+def affixPosition : Option AffixPosition := some .suffixes
 
 end Hungarian.Possession

--- a/Linglib/Fragments/Irish/Possession.lean
+++ b/Linglib/Fragments/Irish/Possession.lean
@@ -2,14 +2,14 @@ import Linglib.Features.Possession
 
 /-!
 # Irish possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Irish (ISO `gle`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
-`Studies/NicholsBickel2013.lean`.
+Per-language possession values for Irish (Indo-European, ISO `gle`): forms
+`ta leabhar agam`, `teach an fhir`; Celtic at-possession (ta X ag-PRON) with
+genitive case on the possessor in adnominal possession. Substrate types
+(`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming these
+values live in `Studies/NicholsBickel2013.lean`.
 -/
 
 set_option autoImplicit false
@@ -18,17 +18,10 @@ namespace Irish.Possession
 
 open _root_.Possession
 
-/-- Irish possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Irish"
-  , family := "Indo-European"
-  , iso := "gle"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := some .noAffix
-  , examples := ["ta leabhar agam", "teach an fhir"]
-  , notes := "Celtic at-possession: ta X ag-PRON; genitive case on possessor in adnominal" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .locational
+def adnominalStrategy : AdnominalMarking := .dependentMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Irish.Possession

--- a/Linglib/Fragments/Japanese/Possession.lean
+++ b/Linglib/Fragments/Japanese/Possession.lean
@@ -2,14 +2,14 @@ import Linglib.Features.Possession
 
 /-!
 # Japanese possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Japanese (ISO `jpn`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
-`Studies/NicholsBickel2013.lean`.
+Per-language possession values for Japanese (Japonic, ISO `jpn`): forms
+`watashi-ni-wa hon-ga aru`, `Tanaka-no hon`; topic-comment predication
+(possessor-DAT-TOP possessum-NOM aru/iru) with genitive `no` for adnominal
+possession. Substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live
+in `Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming these
+values live in `Studies/NicholsBickel2013.lean`.
 -/
 
 set_option autoImplicit false
@@ -18,17 +18,10 @@ namespace Japanese.Possession
 
 open _root_.Possession
 
-/-- Japanese possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Japanese"
-  , family := "Japonic"
-  , iso := "jpn"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .topic
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := some .noAffix
-  , examples := ["watashi-ni-wa hon-ga aru", "Tanaka-no hon"]
-  , notes := "Topic-comment: possessor-DAT-TOP possessum-NOM aru/iru; genitive no for adnominal" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .topic
+def adnominalStrategy : AdnominalMarking := .dependentMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Japanese.Possession

--- a/Linglib/Fragments/Korean/Possession.lean
+++ b/Linglib/Fragments/Korean/Possession.lean
@@ -2,14 +2,14 @@ import Linglib.Features.Possession
 
 /-!
 # Korean possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Korean (ISO `kor`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
-`Studies/NicholsBickel2013.lean`.
+Per-language possession values for Korean (Koreanic, ISO `kor`): forms
+`na-ege chaek-i iss-da`, `Yeonghui-ui chaek`; dative possessor plus existential
+`iss-da`, with genitive -ui for adnominal possession. Substrate types
+(`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming these
+values live in `Studies/NicholsBickel2013.lean`.
 -/
 
 set_option autoImplicit false
@@ -18,17 +18,10 @@ namespace Korean.Possession
 
 open _root_.Possession
 
-/-- Korean possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Korean"
-  , family := "Koreanic"
-  , iso := "kor"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := Option.none
-  , examples := ["na-ege chaek-i iss-da", "Yeonghui-ui chaek"]
-  , notes := "Dative possessor + existential iss-da; genitive -ui for adnominal possession" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .locational
+def adnominalStrategy : AdnominalMarking := .dependentMarking
+def affixPosition : Option AffixPosition := Option.none
 
 end Korean.Possession

--- a/Linglib/Fragments/Mandarin/Possession.lean
+++ b/Linglib/Fragments/Mandarin/Possession.lean
@@ -2,14 +2,14 @@ import Linglib.Features.Possession
 
 /-!
 # Mandarin possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Mandarin (ISO `cmn`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
-`Studies/NicholsBickel2013.lean`.
+Per-language possession values for Mandarin (Sino-Tibetan, ISO `cmn`): forms
+`wo you yi-ben shu`, `wo de shu`, `wo mama`; have-verb `you`, and `de` marks
+adnominal possession but drops with inalienable/close relations. Substrate types
+(`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming these
+values live in `Studies/NicholsBickel2013.lean`.
 -/
 
 set_option autoImplicit false
@@ -18,17 +18,10 @@ namespace Mandarin.Possession
 
 open _root_.Possession
 
-/-- Mandarin possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Mandarin"
-  , family := "Sino-Tibetan"
-  , iso := "cmn"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .haveVerb
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := some .noAffix
-  , examples := ["wo you yi-ben shu", "wo de shu", "wo mama"]
-  , notes := "Have-verb you; de marks adnominal possession but drops with inalienable/close relations" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .haveVerb
+def adnominalStrategy : AdnominalMarking := .dependentMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Mandarin.Possession

--- a/Linglib/Fragments/Mayan/Tseltal/Possession.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Possession.lean
@@ -4,12 +4,17 @@ import Linglib.Features.Possession
 # Tseltal possession profile
 [stassen-2009] [nichols-1986] [heine-1997] [aissen-polian-2025]
 
-PossessionProfile bundle for Tseltal (ISO `tzh`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
+Per-language possession data for Tseltal (Mayan; ISO `tzh`), per the
+project's "per-language data flows through Fragments" rule, as bare
+field-by-field `def`s. Substrate types (`PredicativeStrategy`,
+`AdnominalMarking`, …) live in `Linglib/Features/Possession.lean`.
+Cross-linguistic theorems consuming these values live in
 `Studies/NicholsBickel2013.lean`.
+
+Examples: *ay chenek' ta oxom* 'EXIS bean P pot', *s-be-lal te j-na=e*
+'A3-road-NCLS DET A1-house=ENC'. Existential *ay* + possessive pivot for
+predicative; Set A prefixes on possessum for adnominal (head-marking);
+three noun classes as in Tsotsil [aissen-polian-2025].
 -/
 
 set_option autoImplicit false
@@ -18,17 +23,10 @@ namespace Tseltal.Possession
 
 open _root_.Possession
 
-/-- Tseltal possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Tseltal"
-  , family := "Mayan"
-  , iso := "tzh"
-  , obligatoryPossession := .exists_
-  , possessiveClassification := .threeOrMore
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .headMarking
-  , affixPosition := some .prefixes
-  , examples := ["ay chenek' ta oxom 'EXIS bean P pot'", "s-be-lal te j-na=e 'A3-road-NCLS DET A1-house=ENC'"]
-  , notes := "Existential ay + possessive pivot for predicative; Set A prefixes on possessum for adnominal (head-marking); three noun classes as in Tsotsil (Aissen-Polian 2025)" }
+def obligatoryPossession : Obligatoriness := .exists_
+def possessiveClassification : Classification := .threeOrMore
+def predicativeStrategy : PredicativeStrategy := .locational
+def adnominalStrategy : AdnominalMarking := .headMarking
+def affixPosition : Option AffixPosition := some .prefixes
 
 end Tseltal.Possession

--- a/Linglib/Fragments/Mayan/Tsotsil/Possession.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Possession.lean
@@ -4,12 +4,18 @@ import Linglib.Features.Possession
 # Tsotsil possession profile
 [stassen-2009] [nichols-1986] [heine-1997] [aissen-polian-2025]
 
-PossessionProfile bundle for Tsotsil (ISO `tzo`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
+Per-language possession data for Tsotsil (Mayan; ISO `tzo`), per the
+project's "per-language data flows through Fragments" rule, as bare
+field-by-field `def`s. Substrate types (`PredicativeStrategy`,
+`AdnominalMarking`, …) live in `Linglib/Features/Possession.lean`.
+Cross-linguistic theorems consuming these values live in
 `Studies/NicholsBickel2013.lean`.
+
+Examples: *oy s-k'ox barko* 'EXIS A3-little.boat', *s-me' Xun* 'A3-mother
+Juan' = "Juan's mother", *y-ak'-il li mok=e* 'A3-vine-NCLS DET fence=ENC'.
+Existential *oy* + possessive pivot for predicative; Set A prefixes on
+possessum for adnominal (head-marking); three noun classes: must/may/cannot
+be possessed [aissen-polian-2025].
 -/
 
 set_option autoImplicit false
@@ -18,17 +24,10 @@ namespace Tsotsil.Possession
 
 open _root_.Possession
 
-/-- Tsotsil possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Tsotsil"
-  , family := "Mayan"
-  , iso := "tzo"
-  , obligatoryPossession := .exists_
-  , possessiveClassification := .threeOrMore
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .headMarking
-  , affixPosition := some .prefixes
-  , examples := ["oy s-k'ox barko 'EXIS A3-little.boat'", "s-me' Xun 'A3-mother Juan' = 'Juan's mother'", "y-ak'-il li mok=e 'A3-vine-NCLS DET fence=ENC'"]
-  , notes := "Existential oy + possessive pivot for predicative; Set A prefixes on possessum for adnominal (head-marking); three noun classes: must/may/cannot be possessed (Aissen-Polian 2025)" }
+def obligatoryPossession : Obligatoriness := .exists_
+def possessiveClassification : Classification := .threeOrMore
+def predicativeStrategy : PredicativeStrategy := .locational
+def adnominalStrategy : AdnominalMarking := .headMarking
+def affixPosition : Option AffixPosition := some .prefixes
 
 end Tsotsil.Possession

--- a/Linglib/Fragments/Quechua/Possession.lean
+++ b/Linglib/Fragments/Quechua/Possession.lean
@@ -2,14 +2,17 @@ import Linglib.Features.Possession
 
 /-!
 # Quechua possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Quechua (ISO `que`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
-`Studies/NicholsBickel2013.lean`.
+Bare per-language possession `def`s for Quechua (Quechuan, ISO `que`),
+per the project's "per-language data flows through Fragments" rule.
+Substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming
+these values live in `Studies/NicholsBickel2013.lean`.
+
+Examples: Hwan-pa wasi-n ka-n; mama-y; Hwan-pa wasi-n. Possessive suffixes
+obligatory on kinship and body-part nouns; -yuq 'having' for predicative;
+GEN + POSS double-marking.
 -/
 
 set_option autoImplicit false
@@ -18,17 +21,10 @@ namespace Quechua.Possession
 
 open _root_.Possession
 
-/-- Quechua possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Quechua"
-  , family := "Quechuan"
-  , iso := "que"
-  , obligatoryPossession := .exists_
-  , possessiveClassification := .twoWay
-  , predicativeStrategy := .haveVerb
-  , adnominalStrategy := .doubleMarking
-  , affixPosition := some .noAffix
-  , examples := ["Hwan-pa wasi-n ka-n", "mama-y", "Hwan-pa wasi-n"]
-  , notes := "Possessive suffixes obligatory on kinship/body-part nouns; -yuq 'having' for predicative; GEN + POSS double-marking" }
+def obligatoryPossession : Obligatoriness := .exists_
+def possessiveClassification : Classification := .twoWay
+def predicativeStrategy : PredicativeStrategy := .haveVerb
+def adnominalStrategy : AdnominalMarking := .doubleMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Quechua.Possession

--- a/Linglib/Fragments/Slavic/Russian/Possession.lean
+++ b/Linglib/Fragments/Slavic/Russian/Possession.lean
@@ -18,8 +18,7 @@ Schema encodes the possessee as subject.
 Russian also has a secondary, less common Action Schema construction
 using `imet'` 'to have' (< `*em-` 'take'), where the possessor is subject.
 
-PossessionProfile bundle for Russian (ISO `rus`), per the project's
-"per-language data flows through Fragments" rule. Substrate types live in
+Per-language possession defs for Russian (ISO `rus`). Substrate enums live in
 `Linglib/Features/Possession.lean`. Heine 1997 prediction verification for
 Russian lives in `Studies/Heine1997.lean`.
 
@@ -99,20 +98,13 @@ def imetNotions : List Notion :=
   [.abstract, .permanent]
 
 -- ============================================================================
--- §5. Russian Possession Profile (PossessionProfile bundle)
+-- §5. Remaining typological dimensions
 -- ============================================================================
 
-/-- Russian possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Russian"
-  , family := "Indo-European"
-  , iso := "rus"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .locational
-  , adnominalStrategy := .dependentMarking
-  , affixPosition := some .noAffix
-  , examples := ["u menja est' kniga", "kniga Ivana"]
-  , notes := "Locational: u + GEN + est'; adnominal: NP-GEN" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+/-- Adnominal NP-GEN (`kniga Ivana`): dependent-marking. -/
+def adnominalStrategy : AdnominalMarking := .dependentMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Russian.Possession

--- a/Linglib/Fragments/Swahili/Possession.lean
+++ b/Linglib/Fragments/Swahili/Possession.lean
@@ -15,14 +15,12 @@ Swahili also has locative noun classes 16 (`pa-`), 17 (`ku-`), and 18 (`mu-`)
 that are relevant to possession via the Location Schema, and an Equation
 Schema belong-construction using the associative `-a`.
 
-PossessionProfile bundle for Swahili (ISO `swh`), per the project's
-"per-language data flows through Fragments" rule. Substrate types live in
+Per-language possession defs for Swahili (ISO `swh`). Substrate enums live in
 `Linglib/Features/Possession.lean`. Heine 1997 prediction verification for
-Swahili lives in `Studies/Heine1997.lean`. The
-`PossessionProfile.adnominalStrategy = .headMarking` here flattens the
-[nichols-1986] categorisation; Swahili's Bantu noun-class concord is
-strictly head-marking only in the agreement sense, with the associative
-particle `a` carrying class agreement to the possessum.
+Swahili lives in `Studies/Heine1997.lean`. The `adnominalStrategy := .headMarking`
+here flattens the [nichols-1986] categorisation; Swahili's Bantu noun-class
+concord is strictly head-marking only in the agreement sense, with the
+associative particle `a` carrying class agreement to the possessum.
 
 ## Possessive paradigm
 
@@ -117,27 +115,16 @@ theorem covers_all_notions :
     expressibleNotions.length = 7 := rfl
 
 -- ============================================================================
--- §6. Swahili Possession Profile (PossessionProfile bundle)
+-- §6. Remaining typological dimensions
 -- ============================================================================
 
-/-- Swahili possession profile.
-
-    Adnominal strategy is encoded as `.headMarking` to match Bantu
-    noun-class concord (the associative particle `a` agrees with the
-    possessum in class). The strict [nichols-1986] typology would
-    classify it differently in some descriptions; we follow the WALS
-    convention here. -/
-def possession : PossessionProfile :=
-  { language := "Swahili"
-  , family := "Niger-Congo"
-  , iso := "swh"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .comitative
-  , adnominalStrategy := .headMarking
-  , affixPosition := some .suffixes
-  , examples := ["nina kitabu", "kitabu ch-angu"]
-  , notes := "Comitative na- for predicative possession; " ++
-             "noun-class agreement on possessive for adnominal" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+/-- Bantu noun-class concord: the associative particle `a` agrees with the
+    possessum in class, so we follow WALS in coding adnominal as head-marking
+    (the strict [nichols-1986] typology classifies it differently in some
+    descriptions). -/
+def adnominalStrategy : AdnominalMarking := .headMarking
+def affixPosition : Option AffixPosition := some .suffixes
 
 end Swahili.Possession

--- a/Linglib/Fragments/Turkish/Possession.lean
+++ b/Linglib/Fragments/Turkish/Possession.lean
@@ -15,8 +15,7 @@ Schema** ("X's Y exists" → "X has Y"). The construction consists of:
 Turkish also has a Goal Schema variant using dative (`-A`) with
 existential `var`, and the Equation Schema for belong-constructions.
 
-PossessionProfile bundle for Turkish (ISO `tur`), per the project's
-"per-language data flows through Fragments" rule. Substrate types live in
+Per-language possession defs for Turkish (ISO `tur`). Substrate enums live in
 `Linglib/Features/Possession.lean`. Heine 1997 prediction verification for
 Turkish lives in `Studies/Heine1997.lean`.
 
@@ -135,25 +134,14 @@ theorem location_not_inalienable :
     ¬locationNotions.contains .inalienable := by decide
 
 -- ============================================================================
--- §6. Turkish Possession Profile (PossessionProfile bundle)
+-- §6. Remaining typological dimensions
 -- ============================================================================
 
-/-- Turkish possession profile.
-
-    Note: Turkish's primary construction (`Hasan-ın inek-i var`) is
-    [heine-1997]'s Genitive Schema, encoded as `.genitive`
-    in [stassen-2009]'s WALS Ch 117 typology. -/
-def possession : PossessionProfile :=
-  { language := "Turkish"
-  , family := "Turkic"
-  , iso := "tur"
-  , obligatoryPossession := .exists_
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .genitive
-  , adnominalStrategy := .doubleMarking
-  , affixPosition := some .suffixes
-  , examples := ["(benim) kitab-im var", "Ali-nin kitab-i"]
-  , notes := "var/yok existential predicate; GEN on possessor + " ++
-             "possessive suffix on head (double-marking)" }
+/-- Obligatory possessive inflection (the `-(s)I` suffix on the possessum). -/
+def obligatoryPossession : Obligatoriness := .exists_
+def possessiveClassification : Classification := .noClassification
+/-- GEN on possessor + possessive suffix on the head (`Ali-nin kitab-i`). -/
+def adnominalStrategy : AdnominalMarking := .doubleMarking
+def affixPosition : Option AffixPosition := some .suffixes
 
 end Turkish.Possession

--- a/Linglib/Fragments/Yoruba/Possession.lean
+++ b/Linglib/Fragments/Yoruba/Possession.lean
@@ -2,14 +2,16 @@ import Linglib.Features.Possession
 
 /-!
 # Yoruba possession profile
-[stassen-2009] [nichols-1986] [heine-1997] 
+[stassen-2009] [nichols-1986] [heine-1997]
 
-PossessionProfile bundle for Yoruba (ISO `yor`), per the
-project's "per-language data flows through Fragments" rule. Substrate
-types (`PossessionProfile`, `PredicativeStrategy`, `AdnominalMarking`,
-…) live in `Linglib/Features/Possession.lean`. Cross-linguistic theorems
-consuming this profile live in
-`Studies/NicholsBickel2013.lean`.
+Bare per-language possession `def`s for Yoruba (Niger-Congo, ISO `yor`),
+per the project's "per-language data flows through Fragments" rule.
+Substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming
+these values live in `Studies/NicholsBickel2013.lean`.
+
+Examples: mo ni iwe; iwe mi. Have-verb ni; juxtaposition for adnominal
+(possessum-possessor).
 -/
 
 set_option autoImplicit false
@@ -18,17 +20,10 @@ namespace Yoruba.Possession
 
 open _root_.Possession
 
-/-- Yoruba possession profile. -/
-def possession : PossessionProfile :=
-  { language := "Yoruba"
-  , family := "Niger-Congo"
-  , iso := "yor"
-  , obligatoryPossession := .noObligatory
-  , possessiveClassification := .noClassification
-  , predicativeStrategy := .haveVerb
-  , adnominalStrategy := .zeroMarking
-  , affixPosition := some .noAffix
-  , examples := ["mo ni iwe", "iwe mi"]
-  , notes := "Have-verb ni; juxtaposition for adnominal (possessum-possessor)" }
+def obligatoryPossession : Obligatoriness := .noObligatory
+def possessiveClassification : Classification := .noClassification
+def predicativeStrategy : PredicativeStrategy := .haveVerb
+def adnominalStrategy : AdnominalMarking := .zeroMarking
+def affixPosition : Option AffixPosition := some .noAffix
 
 end Yoruba.Possession

--- a/Linglib/Studies/KampanarouAlexiadou2026.lean
+++ b/Linglib/Studies/KampanarouAlexiadou2026.lean
@@ -405,7 +405,7 @@ theorem ka2026_refutes_myler_VI_for_smg :
     -- to be accusative-syncretic, which apo-PPs are not.
     -- Stated structurally: the SMG distinction tracks SYNTAX (analyses
     -- 41/43/47), not phonology.
-    Greek.StandardModern.Possession.possession.adnominalStrategy
+    Greek.StandardModern.Possession.adnominalStrategy
       = .dependentMarking := by
   refine ⟨rfl, rfl⟩
 
@@ -435,10 +435,10 @@ theorem apo_PP_cannot_extract_per_ka2026 :
     asymmetry encoded in the Fragment files. -/
 theorem gg_uses_reduced_relative_smg_does_not :
     -- GG: apo-PP is the dominant adnominal strategy (genitive lost on common nouns)
-    Greek.Grevena.Possession.possession.adnominalStrategy
+    Greek.Grevena.Possession.adnominalStrategy
       = .zeroMarking ∧
     -- SMG: apo-PP coexists with inflectional genitive (NOT a reduced relative)
-    Greek.StandardModern.Possession.possession.adnominalStrategy
+    Greek.StandardModern.Possession.adnominalStrategy
       = .dependentMarking := by
   refine ⟨rfl, rfl⟩
 

--- a/Linglib/Studies/NicholsBickel2013.lean
+++ b/Linglib/Studies/NicholsBickel2013.lean
@@ -33,20 +33,17 @@ The four WALS chapters by Nichols & Bickel (2013):
 - Ch 59A: Possessive Classification
 
 This study file holds **cross-linguistic generalisations** that consume the
-Fragment-side `def possession : PossessionProfile` data with non-trivial
-semantic content (`oceanic_have_classification`, `head_marking_mostly_complex`,
-`have_verb_implies_not_head_marking`, etc.), plus corpus-level WALS
-distribution claims that depend on filtering by chapter value.
+per-language Fragment possession `def`s (projected into the study-local `Lang`
+row) with non-trivial semantic content (`oceanic_have_classification`,
+`head_marking_mostly_complex`, `have_verb_implies_not_head_marking`, etc.),
+plus corpus-level WALS distribution claims that depend on filtering by chapter
+value.
 
 Per-language Fragment-vs-WALS data-equality theorems are **deliberately
-absent** — verifying that `X.Possession.possession.field` equals
+absent** — verifying that `X.Possession.predicativeStrategy` equals
 `Data.WALS.lookup "iso"` is "encoding conclusions as definitions": the
 two would have to silently diverge for the theorem to fail, and the typed
 Fragment value already encodes the WALS coding at definition site.
-
-The WALS-aggregate sample-size and dominance theorems live in the substrate
-(`Linglib/Features/Possession.lean`) per the project's "WALS goes to
-`Linglib/Typology/`" rule.
 -/
 
 set_option autoImplicit false
@@ -62,36 +59,75 @@ private abbrev ch59 := Data.WALS.F59A.allData
 -- §1. The 19-language Fragment sample
 -- ============================================================================
 
-/-- The 19-language sample drawn from per-language Fragment Possession files. -/
-def allLanguages : List PossessionProfile :=
-  [ English.Possession.possession
-  , Russian.Possession.possession
-  , Japanese.Possession.possession
-  , Turkish.Possession.possession
-  , HindiUrdu.Possession.possession
-  , Mandarin.Possession.possession
-  , Finnish.Possession.possession
-  , Hungarian.Possession.possession
-  , Irish.Possession.possession
-  , Swahili.Possession.possession
-  , Korean.Possession.possession
-  , Arabic.ModernStandard.Possession.possession
-  , Quechua.Possession.possession
-  , Yoruba.Possession.possession
-  , Georgian.Possession.possession
-  , Hawaiian.Possession.possession
-  , Fijian.Possession.possession
-  , Tsotsil.Possession.possession
-  , Tseltal.Possession.possession ]
+/-- Study-local row: the four typological dimensions Nichols & Bickel's WALS
+    chapters cross-tabulate over the sample, projected from per-language
+    Fragment defs (the bundle `PossessionProfile` was retired). -/
+structure Lang where
+  predicativeStrategy : PredicativeStrategy
+  adnominalStrategy : AdnominalMarking
+  possessiveClassification : Classification
+  obligatoryPossession : Obligatoriness
+  deriving DecidableEq, Repr
+
+def Lang.hasObligatoryPossession (p : Lang) : Bool := p.obligatoryPossession == .exists_
+def Lang.hasClassification (p : Lang) : Bool := p.possessiveClassification != .noClassification
+def Lang.usesHaveVerb (p : Lang) : Bool := p.predicativeStrategy == .haveVerb
+def Lang.usesLocational (p : Lang) : Bool := p.predicativeStrategy == .locational
+def Lang.isHeadMarking (p : Lang) : Bool := p.adnominalStrategy == .headMarking
+
+/-- A row built from a Fragment's four possession dimensions. -/
+private def ofFragment (pr : PredicativeStrategy) (ad : AdnominalMarking)
+    (cl : Classification) (ob : Obligatoriness) : Lang := ⟨pr, ad, cl, ob⟩
+
+/-- The 19-language sample, each row projected from its Fragment defs. -/
+def allLanguages : List Lang :=
+  [ ofFragment English.Possession.predicativeStrategy English.Possession.adnominalStrategy
+      English.Possession.possessiveClassification English.Possession.obligatoryPossession
+  , ofFragment Russian.Possession.predicativeStrategy Russian.Possession.adnominalStrategy
+      Russian.Possession.possessiveClassification Russian.Possession.obligatoryPossession
+  , ofFragment Japanese.Possession.predicativeStrategy Japanese.Possession.adnominalStrategy
+      Japanese.Possession.possessiveClassification Japanese.Possession.obligatoryPossession
+  , ofFragment Turkish.Possession.predicativeStrategy Turkish.Possession.adnominalStrategy
+      Turkish.Possession.possessiveClassification Turkish.Possession.obligatoryPossession
+  , ofFragment HindiUrdu.Possession.predicativeStrategy HindiUrdu.Possession.adnominalStrategy
+      HindiUrdu.Possession.possessiveClassification HindiUrdu.Possession.obligatoryPossession
+  , ofFragment Mandarin.Possession.predicativeStrategy Mandarin.Possession.adnominalStrategy
+      Mandarin.Possession.possessiveClassification Mandarin.Possession.obligatoryPossession
+  , ofFragment Finnish.Possession.predicativeStrategy Finnish.Possession.adnominalStrategy
+      Finnish.Possession.possessiveClassification Finnish.Possession.obligatoryPossession
+  , ofFragment Hungarian.Possession.predicativeStrategy Hungarian.Possession.adnominalStrategy
+      Hungarian.Possession.possessiveClassification Hungarian.Possession.obligatoryPossession
+  , ofFragment Irish.Possession.predicativeStrategy Irish.Possession.adnominalStrategy
+      Irish.Possession.possessiveClassification Irish.Possession.obligatoryPossession
+  , ofFragment Swahili.Possession.predicativeStrategy Swahili.Possession.adnominalStrategy
+      Swahili.Possession.possessiveClassification Swahili.Possession.obligatoryPossession
+  , ofFragment Korean.Possession.predicativeStrategy Korean.Possession.adnominalStrategy
+      Korean.Possession.possessiveClassification Korean.Possession.obligatoryPossession
+  , ofFragment Arabic.ModernStandard.Possession.predicativeStrategy
+      Arabic.ModernStandard.Possession.adnominalStrategy
+      Arabic.ModernStandard.Possession.possessiveClassification
+      Arabic.ModernStandard.Possession.obligatoryPossession
+  , ofFragment Quechua.Possession.predicativeStrategy Quechua.Possession.adnominalStrategy
+      Quechua.Possession.possessiveClassification Quechua.Possession.obligatoryPossession
+  , ofFragment Yoruba.Possession.predicativeStrategy Yoruba.Possession.adnominalStrategy
+      Yoruba.Possession.possessiveClassification Yoruba.Possession.obligatoryPossession
+  , ofFragment Georgian.Possession.predicativeStrategy Georgian.Possession.adnominalStrategy
+      Georgian.Possession.possessiveClassification Georgian.Possession.obligatoryPossession
+  , ofFragment Hawaiian.Possession.predicativeStrategy Hawaiian.Possession.adnominalStrategy
+      Hawaiian.Possession.possessiveClassification Hawaiian.Possession.obligatoryPossession
+  , ofFragment Fijian.Possession.predicativeStrategy Fijian.Possession.adnominalStrategy
+      Fijian.Possession.possessiveClassification Fijian.Possession.obligatoryPossession
+  , ofFragment Tsotsil.Possession.predicativeStrategy Tsotsil.Possession.adnominalStrategy
+      Tsotsil.Possession.possessiveClassification Tsotsil.Possession.obligatoryPossession
+  , ofFragment Tseltal.Possession.predicativeStrategy Tseltal.Possession.adnominalStrategy
+      Tseltal.Possession.possessiveClassification Tseltal.Possession.obligatoryPossession ]
 
 /-- Count of languages in the sample with a given predicative strategy. -/
-def countByPredicative (langs : List PossessionProfile)
-    (s : PredicativeStrategy) : Nat :=
+def countByPredicative (langs : List Lang) (s : PredicativeStrategy) : Nat :=
   (langs.filter (·.predicativeStrategy == s)).length
 
 /-- Count of languages in the sample with a given adnominal strategy. -/
-def countByAdnominal (langs : List PossessionProfile)
-    (s : AdnominalMarking) : Nat :=
+def countByAdnominal (langs : List Lang) (s : AdnominalMarking) : Nat :=
   (langs.filter (·.adnominalStrategy == s)).length
 
 -- ============================================================================
@@ -251,9 +287,11 @@ theorem locational_count :
     have possessive classification (two-way or three-or-more). Possessive
     classification is an areal feature of the Pacific: the
     alienable/inalienable distinction is nearly universal in Oceanic. -/
-def oceanicLanguages : List PossessionProfile :=
-  [ Hawaiian.Possession.possession
-  , Fijian.Possession.possession ]
+def oceanicLanguages : List Lang :=
+  [ ofFragment Hawaiian.Possession.predicativeStrategy Hawaiian.Possession.adnominalStrategy
+      Hawaiian.Possession.possessiveClassification Hawaiian.Possession.obligatoryPossession
+  , ofFragment Fijian.Possession.predicativeStrategy Fijian.Possession.adnominalStrategy
+      Fijian.Possession.possessiveClassification Fijian.Possession.obligatoryPossession ]
 
 theorem oceanic_have_classification :
     oceanicLanguages.all (·.hasClassification) = true := by

--- a/Linglib/Typology/Negation.lean
+++ b/Linglib/Typology/Negation.lean
@@ -47,8 +47,7 @@ substrate carries (a) per-paradigm-entry schema (`NegMarkerEntry`,
   (`toGramStage`), and WALS Ch 112 (`toNegMorphemeType`).
 - `NegationProfile` — sibling per-language schema bundling Ch 112-115 +
   Greco's `negIsHead` + JinKoenig's `enAttested`. Each Fragment exposes
-  `def negationProfile : NegationProfile` alongside `def negationSystem`.
-  Sibling pattern (mirrors `Features/Possession.lean::PossessionProfile`):
+  `def negationProfile : NegationProfile` alongside `def negationSystem`:
   the marker-side joint is independent from the typology-feature joint.
 - `ofWALS112A`/`fromWALS113A`/`114A`/`115A`/`143A` converters.
 - `countByMorphemeType`/`countBySymmetry` sample-counting helpers (consumed by
@@ -250,8 +249,7 @@ structure NegationSystem where
     `Fragments/{Lang}/Negation.lean` exposes `def negationProfile :
     NegationProfile`. The two joints are independent because the data
     partition is real: `negationSystem.markers` is consumed by lexical
-    code; `negationProfile` is consumed by typology studies. Mirrors
-    `Features/Possession.lean::PossessionProfile`. -/
+    code; `negationProfile` is consumed by typology studies. -/
 structure NegationProfile where
   /-- Language name. -/
   language : String


### PR DESCRIPTION
Retires the `PossessionProfile` bundle struct, attaching possession features to Fragments as bare field-by-field `def`s — the established profile-bundle-sweep pattern (`Case` first). Cone builds green (1888 jobs).

- 22 Fragments: `def possession : PossessionProfile := {…}` → bare `def predicativeStrategy/adnominalStrategy/possessiveClassification/obligatoryPossession/affixPosition`; String metadata (`language`/`family`/`iso`/`examples`/`notes`) moves to docstrings (no theorem read it). Rich fragments' standalone defs (`predicativeStrategy`, `sourceSchema`) become canonical, collapsing the bundle's duplication.
- `Features/Possession.lean`: delete `PossessionProfile` + the 6 `Bool` helpers; keep every enum + function.
- `NicholsBickel2013`: study-local `structure Lang` (the 4 read dimensions) with the helpers rehomed, `allLanguages`/`oceanicLanguages` projected from the Fragment defs (à la `Baker2015`'s `NPInDomain`). All counts unchanged.
- `KampanarouAlexiadou2026`: 3 `.possession.adnominalStrategy` reads retargeted to the bare def.
- Finnish: collapsing exposed a contradiction the bundle masked (dead standalone `.doubleMarking` vs consumed `.dependentMarking`); pinned to `.dependentMarking` (the WALS coding `adnominal_distribution` counts), double-marking register noted in the docstring.

Next in the sweep: `WordOrderProfile`, the Numeral/RelativeClause WALS `Profile`s, `Person/Resolve.Profile`.