### PR TITLE
refactor(Syntax/Adposition): graduate AdpositionOrder from Typology

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2790,6 +2790,7 @@ import Linglib.Studies.Zuraw2010
 import Linglib.Studies.ZurawHayes2017
 import Linglib.Studies.ZwickyPullum1983
 import Linglib.Syntax.Adposition.Basic
+import Linglib.Syntax.Adposition.Order
 import Linglib.Syntax.Adposition.Spatial
 import Linglib.Syntax.Agreement.AdjAgreement
 import Linglib.Syntax.Agreement.Basic
@@ -2936,7 +2937,6 @@ import Linglib.Tactics.RSAPredict.Helpers
 import Linglib.Tactics.RSAPredict.RSABuilder
 import Linglib.Tactics.RSAPredict.ReflectBridge
 import Linglib.Tactics.RSAPredict.Reify
-import Linglib.Typology.Adposition
 import Linglib.Typology.Alignment
 import Linglib.Typology.ArgumentStructure
 import Linglib.Typology.AuxiliaryVerbs

--- a/Linglib/Fragments/Arabic/ModernStandard/Adposition.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Arabic adposition order
@@ -10,7 +10,7 @@ WALS Ch 85 classifies Arabic as prepositional.
 namespace Arabic.ModernStandard
 
 /-- Arabic adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "arb"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "arb"
 
 end Arabic.ModernStandard

--- a/Linglib/Fragments/Basque/Adposition.lean
+++ b/Linglib/Fragments/Basque/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Basque adposition order
@@ -10,7 +10,7 @@ classifies Basque as postpositional.
 namespace Basque
 
 /-- Basque adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "eus"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "eus"
 
 end Basque

--- a/Linglib/Fragments/English/Adposition.lean
+++ b/Linglib/Fragments/English/Adposition.lean
@@ -1,17 +1,17 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # English adposition order
 
 WALS-derived adposition order for English (ISO `eng`). Pure pass-through
-of `Typology.Adposition.AdpositionOrder.ofWALS "eng"`. WALS Ch 85 classifies
+of `Adposition.AdpositionOrder.ofWALS "eng"`. WALS Ch 85 classifies
 English as prepositional.
 -/
 
 namespace English
 
 /-- English adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "eng"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "eng"
 
 end English

--- a/Linglib/Fragments/HindiUrdu/Adposition.lean
+++ b/Linglib/Fragments/HindiUrdu/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Hindi/Urdu adposition order
@@ -10,7 +10,7 @@ classifies Hindi as postpositional.
 namespace HindiUrdu
 
 /-- Hindi adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "hin"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "hin"
 
 end HindiUrdu

--- a/Linglib/Fragments/Hixkaryana/Adposition.lean
+++ b/Linglib/Fragments/Hixkaryana/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Hixkaryana adposition order
@@ -10,7 +10,7 @@ classifies Hixkaryana as postpositional.
 namespace Hixkaryana
 
 /-- Hixkaryana adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "hix"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "hix"
 
 end Hixkaryana

--- a/Linglib/Fragments/Indonesian/Adposition.lean
+++ b/Linglib/Fragments/Indonesian/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Indonesian adposition order
@@ -10,7 +10,7 @@ classifies Indonesian as prepositional.
 namespace Indonesian
 
 /-- Indonesian adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "ind"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "ind"
 
 end Indonesian

--- a/Linglib/Fragments/Irish/Adposition.lean
+++ b/Linglib/Fragments/Irish/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Irish adposition order
@@ -10,7 +10,7 @@ classifies Irish as prepositional.
 namespace Irish
 
 /-- Irish adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "gle"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "gle"
 
 end Irish

--- a/Linglib/Fragments/Japanese/Adposition.lean
+++ b/Linglib/Fragments/Japanese/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Japanese adposition order
@@ -10,7 +10,7 @@ classifies Japanese as postpositional.
 namespace Japanese
 
 /-- Japanese adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "jpn"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "jpn"
 
 end Japanese

--- a/Linglib/Fragments/Korean/Adposition.lean
+++ b/Linglib/Fragments/Korean/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Korean adposition order
@@ -10,7 +10,7 @@ classifies Korean as postpositional.
 namespace Korean
 
 /-- Korean adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "kor"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "kor"
 
 end Korean

--- a/Linglib/Fragments/Mandarin/Adposition.lean
+++ b/Linglib/Fragments/Mandarin/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Mandarin adposition order
@@ -11,7 +11,7 @@ classifies Mandarin as having both prepositions and postpositions
 namespace Mandarin
 
 /-- Mandarin adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "cmn"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "cmn"
 
 end Mandarin

--- a/Linglib/Fragments/Mayan/Kiche/Adposition.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # K'iche' adposition order [mondloch-2017] [clemens-coon-2018]
@@ -33,6 +33,6 @@ namespace Kiche
     Ch 85 — direct override rather than `AdpositionOrder.ofWALS "quc"`
     (which would return `.notInWALS`). The `.prepositional` choice is
     contested across Mayanist literature; see module docstring. -/
-def adposition : Typology.Adposition.AdpositionOrder := .prepositional
+def adposition : Adposition.AdpositionOrder := .prepositional
 
 end Kiche

--- a/Linglib/Fragments/Slavic/Russian/Adposition.lean
+++ b/Linglib/Fragments/Slavic/Russian/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Russian adposition order
@@ -10,7 +10,7 @@ classifies Russian as prepositional.
 namespace Russian
 
 /-- Russian adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "rus"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "rus"
 
 end Russian

--- a/Linglib/Fragments/Swahili/Adposition.lean
+++ b/Linglib/Fragments/Swahili/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Swahili adposition order
@@ -10,7 +10,7 @@ classifies Swahili as prepositional.
 namespace Swahili
 
 /-- Swahili adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "swh"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "swh"
 
 end Swahili

--- a/Linglib/Fragments/Turkish/Adposition.lean
+++ b/Linglib/Fragments/Turkish/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Turkish adposition order
@@ -10,7 +10,7 @@ classifies Turkish as postpositional.
 namespace Turkish
 
 /-- Turkish adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "tur"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "tur"
 
 end Turkish

--- a/Linglib/Fragments/Tzotzil/Adposition.lean
+++ b/Linglib/Fragments/Tzotzil/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Tzotzil adposition order
@@ -10,7 +10,7 @@ classifies Tzotzil as prepositional.
 namespace Tzotzil
 
 /-- Tzotzil adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "tzo"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "tzo"
 
 end Tzotzil

--- a/Linglib/Fragments/Welsh/Adposition.lean
+++ b/Linglib/Fragments/Welsh/Adposition.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 
 /-!
 # Welsh adposition order
@@ -10,7 +10,7 @@ classifies Welsh as prepositional.
 namespace Welsh
 
 /-- Welsh adposition order (WALS Ch 85 by ISO lookup). -/
-def adposition : Typology.Adposition.AdpositionOrder :=
-  Typology.Adposition.AdpositionOrder.ofWALS "cym"
+def adposition : Adposition.AdpositionOrder :=
+  Adposition.AdpositionOrder.ofWALS "cym"
 
 end Welsh

--- a/Linglib/Studies/BroekhuisCorver2026.lean
+++ b/Linglib/Studies/BroekhuisCorver2026.lean
@@ -1,6 +1,6 @@
 import Linglib.Fragments.Dutch.Adpositions
 import Linglib.Syntax.Minimalist.ExtendedProjection.Properties
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 import Linglib.Studies.Dendikken1995ParticleVerbs
 import Linglib.Typology.AuxiliaryVerbs
 import Linglib.Semantics.Spatial.Trace
@@ -293,10 +293,10 @@ theorem no_rPron_not_postP :
 
 set_option maxRecDepth 4096 in
 /-- Dutch is classified as prepositional in WALS Ch 85, via the
-    substrate `Typology.Adposition.AdpositionOrder.ofWALS` lookup
+    substrate `Adposition.AdpositionOrder.ofWALS` lookup
     (Dutch ISO 639-3 = `nld`; the WALS-internal code is `dut`). -/
 theorem dutch_wals_prepositions :
-    Typology.Adposition.AdpositionOrder.ofWALS "nld"
+    Adposition.AdpositionOrder.ofWALS "nld"
     = .prepositional := by decide
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Greenberg1963.lean
+++ b/Linglib/Studies/Greenberg1963.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.WordOrder
-import Linglib.Typology.Adposition
+import Linglib.Syntax.Adposition.Order
 import Linglib.Typology.Universal
 import Linglib.Fragments.English.WordOrder
 import Linglib.Fragments.English.Adposition
@@ -79,7 +79,7 @@ structure SampleEntry where
   iso : String
   name : String
   wordOrder : _root_.WordOrder.WordOrderProfile
-  adposition : _root_.Typology.Adposition.AdpositionOrder
+  adposition : _root_.Adposition.AdpositionOrder
   deriving Repr, DecidableEq
 
 /-- Hand-verified 15-language sample spanning the four major basic-order

--- a/Linglib/Syntax/Adposition/Basic.lean
+++ b/Linglib/Syntax/Adposition/Basic.lean
@@ -51,7 +51,7 @@ inductive RelationType where
 
 /-- A linearization of an adposition with respect to its complement
     (criterion 4). The per-lexeme companion to the language-level
-    `Typology.Adposition.AdpositionOrder`. -/
+    `Adposition.AdpositionOrder`. -/
 inductive Linearization where
   /-- Preposition: P precedes the complement. -/
   | pre

--- a/Linglib/Syntax/Adposition/Order.lean
+++ b/Linglib/Syntax/Adposition/Order.lean
@@ -7,9 +7,10 @@ import Linglib.Features.WordOrder
 [dryer-2013-wals] [greenberg-1963] [dryer-1992]
 
 Framework-agnostic enum for storing per-language adposition order
-(WALS Ch 85). Lives in `Typology/` so both `Fragments/` (per-language
-profiles) and `Studies/` (cross-linguistic generalisations) can
-import without violating the layered dependency hierarchy.
+(WALS Ch 85). The adposition-order facet of the bare-root `Adposition`
+namespace (sibling of `Syntax/Adposition/Basic.lean`'s PP structure);
+both `Fragments/` (per-language profiles) and `Studies/` (cross-linguistic
+generalisations) import it.
 
 Sister substrate to `WordOrder` — same shape (enum with
 WALS-attested cases plus epistemic-distinction cases, namespaced
@@ -46,7 +47,7 @@ both `IsPrepositional`/`IsPostpositional` (Greenberg-style
 predicates) and `headDirection` (Dryer-style projection).
 -/
 
-namespace Typology.Adposition
+namespace Adposition
 
 /-- WALS Ch 85 plus the absence-from-WALS case. -/
 inductive AdpositionOrder where
@@ -113,4 +114,4 @@ def headDirection : AdpositionOrder → Option HeadDirection
 
 end AdpositionOrder
 
-end Typology.Adposition
+end Adposition


### PR DESCRIPTION
Graduates the adposition-order substrate out of the dissolving `Typology/` into the existing `Syntax/Adposition/` theory home (joining `Basic.lean`'s PP structure + `Spatial.lean`), as the `Order.lean` facet.

- `Typology/Adposition.lean` → `Syntax/Adposition/Order.lean`, `namespace Typology.Adposition` → bare-root `Adposition` (matching `Syntax/Adposition/Basic.lean`).
- `AdpositionOrder` is a clean enum (WALS Ch 85 + epistemic cases) with `ofWALS` converters, `IsPrepositional`/`IsPostpositional`, and a `headDirection` projection — no bundle to retire.
- Routes 16 fragments + `Greenberg1963` + `BroekhuisCorver2026`. Cone builds green (1871 jobs); invariant holds (2964).