### PR TITLE
refactor(Phonology): state real Antimatroid theorems, cull dead OT code

### DIFF
--- a/Linglib/Phonology/Constraints/Profile.lean
+++ b/Linglib/Phonology/Constraints/Profile.lean
@@ -18,7 +18,6 @@ than the generic `Lex (Fin n → Nat)` / `lexFinNatOf` spellings.
 * `ViolationProfile n` — `Lex (Fin n → Nat)`, a fixed-length violation vector.
 * `buildViolationProfile` — assemble a profile from a constraint vector.
 * `mkProfile` — assemble a profile from a ranked `NamedConstraint` list.
-* `vpOfList` — a profile from a `List Nat` literal (for readable comparisons).
 
 ## Main results
 
@@ -61,17 +60,6 @@ constraints. The fixed-length analog of the profile computation inside
 tableau context. -/
 def mkProfile {C : Type*} (ranking : List (NamedConstraint C)) (c : C) :
     ViolationProfile ranking.length :=
-  buildViolationProfile (fun i c => (ranking.get i).eval c) c
-
-/-- Create a `ViolationProfile n` from a `List Nat` literal.
-
-The length proof defaults to `by decide`, so study files can write readable
-profile comparisons without an explicit proof:
-```
-theorem t24a_profile : mkProfile ranking c = vpOfList [2, 2, 0] := by decide
-``` -/
-def vpOfList {n : Nat} (vs : List Nat) (h : vs.length = n := by decide) :
-    ViolationProfile n :=
-  toLex fun (i : Fin n) => vs.get ⟨i.val, by omega⟩
+  buildViolationProfile (fun i => (ranking.get i).eval) c
 
 end Constraints

--- a/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
+++ b/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
@@ -46,9 +46,9 @@ The design follows mathlib's `Matroid` pattern: bundled structure with
 ## Theorems
 
 - `Antimat_entailment` — Theorem 3: entailment → containment (proved)
-- `Antimat_RCErc_inv` — Theorem 1 (placeholder)
-- `RCErc_Antimat_inv` — Theorem 2 (placeholder)
-- `RCErc_entailment` — Theorem 4 (placeholder)
+- `Antimat_RCErc_inv` — Theorem 1: `Antimat ∘ RCErc = id` (stated; proof `sorry`)
+- `RCErc_Antimat_inv` — Theorem 2: `RCErc ∘ Antimat = id` (stated; proof `sorry`)
+- `RCErc_entailment` — Theorem 4: containment → entailment (stated; proof `sorry`)
 
 ## References
 
@@ -213,7 +213,7 @@ def Antimatroid.free (E : Set α) : Antimatroid α where
     exact ⟨x, hxE, hxS, Set.insert_subset hxE hS⟩
   removal := fun S hS hne => by
     obtain ⟨x, hx⟩ := hne
-    exact ⟨x, hx, Set.diff_subset.trans hS⟩
+    exact ⟨x, hx, Set.sdiff_subset.trans hS⟩
   union_closed := fun _ _ hS hT => Set.union_subset hS hT
 
 /-- The free antimatroid on `E` has `IsFeasible S ↔ S ⊆ E`. -/
@@ -608,7 +608,7 @@ def Antimat {n : Nat} (E : List (ERC n)) (hcons : ERCSet.consistent E) :
     · -- r(k-1) ∈ S: its rank position is k-1 < k
       rw [← hk]; simp only [maximalChain, Set.mem_setOf_eq, Equiv.symm_apply_apply]; omega
     · -- S \ {r(k-1)} = maximalChain r (k-1)
-      rw [← hk]; ext i; simp only [maximalChain, Set.mem_diff, Set.mem_setOf_eq, Set.mem_singleton_iff]
+      rw [← hk]; ext i; simp only [maximalChain, Set.mem_sdiff, Set.mem_setOf_eq, Set.mem_singleton_iff]
       constructor
       · intro h
         exact ⟨by omega, fun heq => by rw [heq] at h; simp only [Equiv.symm_apply_apply] at h; omega⟩
@@ -640,29 +640,46 @@ noncomputable def RCErc_single {n : Nat} (A : Antimatroid (Fin n))
     else if k = rc.root then .L
     else .e
 
+/-- `RCErc A` is the ERC set of antimatroid `A`: the image of `A`'s rooted
+    circuits under `RCErc_single`. This is the inverse of `Antimat`
+    ([merchant-riggle-2016] Theorems 1–2).
+
+    Represented as a `Set (ERC n)`; a ranking `r` *satisfies* `RCErc A` when
+    `∀ α ∈ RCErc A, ERC.satisfiedBy r α` — the `Set` analogue of
+    `ERCSet.satisfiedBy`, used to state the isomorphism theorems below. -/
+noncomputable def RCErc {n : Nat} (A : Antimatroid (Fin n)) : Set (ERC n) :=
+  Set.range (RCErc_single A)
+
 -- ============================================================================
 -- § 14: Isomorphism Theorems
 -- ============================================================================
 
-/-- **Theorem 1** ([merchant-riggle-2016]): `MChain` is the
-    inverse of `RCErc`.
+/-- **Theorem 1** ([merchant-riggle-2016]): `Antimat` is a left inverse of
+    `RCErc`. For any antimatroid `A`, rebuilding from `A`'s rooted-circuit
+    ERCs recovers `A` — stated at the feasible-set level (`Antimat (RCErc A)`
+    and `A` have the same feasible sets), since `Antimat`'s feasible sets are
+    by definition the maximal chains satisfying the ERC set. -/
+theorem Antimat_RCErc_inv {n : Nat} (A : Antimatroid (Fin n)) (S : Set (Fin n)) :
+    A.IsFeasible S ↔
+      ∃ r : Ranking n, (∀ α ∈ RCErc A, ERC.satisfiedBy r α) ∧
+        ∃ k, maximalChain r k = S := by
+  -- TODO: [merchant-riggle-2016] Theorem 1 (antimatroid → ERC direction of
+  -- the isomorphism). Show A's feasible sets are exactly the maximal chains
+  -- consistent with A's rooted-circuit ERCs. Requires characterizing the
+  -- rooted circuits of A (the hard direction the paper proves via traces).
+  sorry
 
-    For any antimatroid `A`, `Antimat(RCErc(A)) = A`. That is, if we
-    extract the rooted circuits of `A`, convert them to ERCs, and then
-    build the antimatroid from those ERCs, we recover `A` exactly. -/
-theorem Antimat_RCErc_inv {n : Nat} (_A : Antimatroid (Fin n))
-    -- TODO: requires stating RCErc on full antimatroids,
-    -- not just single rooted circuits
-    : True := trivial
-
-/-- **Theorem 2** ([merchant-riggle-2016]): `RCErc` is the
-    inverse of `Antimat`.
-
-    For any consistent ERC set `E`, `RCErc(Antimat(E)) = E`. -/
-theorem RCErc_Antimat_inv {n : Nat} (_E : List (ERC n))
-    (_hcons : ERCSet.consistent _E)
-    -- TODO: requires full RCErc definition
-    : True := trivial
+/-- **Theorem 2** ([merchant-riggle-2016]): `RCErc` is a left inverse of
+    `Antimat`. For a consistent ERC set `E`, the rooted-circuit ERCs of
+    `Antimat E` are exactly `E`. -/
+theorem RCErc_Antimat_inv {n : Nat} (E : List (ERC n))
+    (hcons : ERCSet.consistent E) :
+    RCErc (Antimat E hcons) = { α | α ∈ E } := by
+  -- TODO: [merchant-riggle-2016] Theorem 2. Verify the faithful form before
+  -- discharging: the paper's inverse holds for ERC sets in rooted-circuit
+  -- canonical form, so this may be equality up to entailment-equivalence
+  -- rather than literal set equality.
+  sorry
 
 /-- **Theorem 3** ([merchant-riggle-2016]): `Antimat` preserves
     entailment.
@@ -682,9 +699,13 @@ theorem Antimat_entailment {n : Nat} (E F : List (ERC n))
 
     If antimatroid `A ⊆ B` (every feasible set of `A` is feasible in
     `B`), then `RCErc(A)` entails `RCErc(B)`. -/
-theorem RCErc_entailment {n : Nat}
-    (_A _B : Antimatroid (Fin n))
-    -- TODO: requires full RCErc definition
-    : True := trivial
+theorem RCErc_entailment {n : Nat} (A B : Antimatroid (Fin n))
+    (h : ∀ S, A.IsFeasible S → B.IsFeasible S) :
+    ∀ r : Ranking n, (∀ α ∈ RCErc A, ERC.satisfiedBy r α) →
+      (∀ α ∈ RCErc B, ERC.satisfiedBy r α) := by
+  -- TODO: [merchant-riggle-2016] Theorem 4 (mirror of `Antimat_entailment`).
+  -- Feasible-set containment A ⊆ B becomes ERC entailment RCErc A ⊨ RCErc B;
+  -- needs the rooted-circuit ↔ feasible-set correspondence from Theorem 1.
+  sorry
 
 end OptimalityTheory

--- a/Linglib/Phonology/OptimalityTheory/Doubling.lean
+++ b/Linglib/Phonology/OptimalityTheory/Doubling.lean
@@ -1,7 +1,6 @@
 import Linglib.Phonology.Constraints.Defs
 import Linglib.Phonology.OptimalityTheory.Basic
 import Linglib.Phonology.OptimalityTheory.Constraints
-import Linglib.Morphology.MorphProfile
 
 /-!
 # Doubling Theory: Identity vs. Reduplication
@@ -219,8 +218,6 @@ theorem redupFor_not_monotone :
 -- ============================================================================
 -- § 2d: Bridge to MorphProfile
 -- ============================================================================
-
-open Morphology (Reduplication)
 
 /-- Languages without productive reduplication (WALS Ch 27) have no
     reduplication for any `DoublingFunction`.

--- a/Linglib/Phonology/OptimalityTheory/Stratal.lean
+++ b/Linglib/Phonology/OptimalityTheory/Stratal.lean
@@ -1,149 +1,42 @@
-import Mathlib.Order.Nat
-import Mathlib.Data.List.Dedup
-import Mathlib.Logic.Relation
 import Linglib.Phonology.Constraints.Defs
-import Linglib.Phonology.OptimalityTheory.Basic
-import Linglib.Core.Relation.ReflTransGen
 
 /-!
 # Stratal Optimality Theory
 [kiparsky-2000]
 
-Stratal OT is a theory of the phonology-morphology interface where
+Stratal OT is a theory of the phonology–morphology interface where
 phonological computation is **cyclic**: it applies at multiple levels
-(strata) of morphological structure, with the output of each stratum
-feeding the next as input.
+(strata) of morphological structure (Stem → Word → Phrase), with the output
+of each stratum feeding the next as input. The crucial property is
+**constraint reranking**: the same constraint can occupy different positions
+in different strata's rankings, capturing level-ordering effects without ad
+hoc rules or extrinsic ordering.
 
-## Architecture
+Per-stratum evaluation uses `OptimalityTheory.mkTableau` / `Tableau.optimal`
+in the consuming study file (e.g. the Telugu weak alternation, [aitha-2026]).
+This module provides the cross-stratal vocabulary: a `StratalDerivation`
+record of the per-stratum outputs, and the reranking predicates. The latter
+are *cross-stratum* because strata typically score different candidate types
+— the constraint inventory is shared by *name*, not by candidate type.
 
-The derivation proceeds through ordered strata:
+## Main definitions
 
-    Stem → Word → Phrase
-
-Each stratum has:
-1. A **constraint ranking** (which may differ from other strata)
-2. A **GEN function** (producing candidates from the previous output)
-3. An **EVAL function** (selecting the optimal candidate)
-
-The crucial property is **constraint reranking**: the same constraint
-can occupy different positions in different strata's rankings. This
-captures level-ordering effects — e.g., compensatory lengthening is
-optimal at the Word level but not at the Phrase level — without ad hoc
-rules or extrinsic ordering.
-
-## Sibling derivational architectures
-
-Stratal OT keeps a derivational architecture (strata) inside an
-otherwise constraint-based framework. Linglib's siblings:
-
-* `Phonology/Subregular/LocalRewrite.lean` — full extrinsic-
-  ordering derivation via local rewrite rules; the modern subregular
-  characterization grounds these as Input Strictly Local functions
-  ([chandlee-heinz-2018]).
-* `Phonology/Constraint/OT/HarmonicSerialism.lean` — gradual constraint
-  optimization, no strata.
-* `Core/Computability/Subregular/Function/` — function-level subregular
-  hierarchy (ISL ⊊ OSL ⊊ Subsequential ⊊ Weakly Deterministic) that
-  classifies what each architecture can express
-  ([aksenova-rawski-graf-heinz-2020];
-  [meinhardt-mai-bakovic-mccollum-2024]).
-
-## Connection to Linglib
-
-Each individual stratum is evaluated using `OptimalityTheory.mkTableau` and
-`Tableau.optimal`. This module adds the stratal architecture:
-strata ordering, cross-stratal chaining, and reranking specification.
-
-The Telugu weak alternation ([aitha-2026]) is a key application:
-the interaction of IDENT-STRESS with FT-BIN across Stem, Word, and
-Phrase strata derives the *-am*/*-āni* alternation from a single
-underlying form.
+* `StratalDerivation` — the per-stratum input/output record.
+* `findRank` — the rank (0 = highest) of a constraint by name in a ranking.
+* `isPromotedAcross` / `isDemotedAcross` — cross-stratum reranking predicates.
 -/
 
 namespace OptimalityTheory.Stratal
 
-open Constraints OptimalityTheory
-open Core.Optimization.Evaluation
+open Constraints
 
--- ============================================================================
--- § 1: Strata
--- ============================================================================
+/-! ### Stratal derivation record -/
 
-/-- The three phonological strata of Stratal OT ([kiparsky-2000]).
-
-    | Stratum | Domain                  | Morphological boundary      |
-    |---------|-------------------------|-----------------------------|
-    | Stem    | Root + derivational mfx | Innermost cycle             |
-    | Word    | Stem + inflectional sfx | Prosodic word (PrWd) edge   |
-    | Phrase  | Words + clitics + P     | Phonological phrase edge    |
-
-    Each stratum corresponds to a morphological domain. The Stem–Word
-    boundary typically aligns with the edge of the prosodic word. -/
-inductive Stratum where
-  | stem
-  | word
-  | phrase
-  deriving DecidableEq, Repr
-
-/-- Strata are linearly ordered: stem < word < phrase.
-    This ordering reflects the direction of morphological derivation
-    (innermost to outermost) and determines the feeding relation. -/
-def Stratum.rank : Stratum → Nat
-  | .stem => 0
-  | .word => 1
-  | .phrase => 2
-
-instance : LinearOrder Stratum :=
-  LinearOrder.lift' Stratum.rank
-    (fun a b h => by cases a <;> cases b <;> simp_all [Stratum.rank])
-
--- ============================================================================
--- § 2: Stratal Evaluation
--- ============================================================================
-
-/-- Evaluate a single stratum: select optimal candidates from a
-    candidate set under a constraint ranking.
-
-    Thin wrapper around `mkTableau` + `optimal` that labels the
-    evaluation with its stratum. -/
-def evalStratum {C : Type*} [DecidableEq C]
-    (_stratum : Stratum)
-    (candidates : List C)
-    (ranking : List (NamedConstraint C))
-    (h : candidates ≠ [] := by decide) : Finset C :=
-  (mkTableau candidates ranking h).optimal
-
-/-- Chain two strata: take the optimal output of stratum s₁, transform
-    it into candidates for stratum s₂ via a bridge function, and evaluate
-    under s₂'s ranking.
-
-    The `bridge` function is language-specific: it adds morphological
-    material from the next layer (e.g., inflectional suffixes at the Word
-    level, postpositions at the Phrase level) and generates candidate
-    representations. -/
-def chainEval {C₁ C₂ : Type*} [DecidableEq C₂]
-    (_stratum : Stratum)
-    (s₁Output : C₁)
-    (bridge : C₁ → List C₂)
-    (ranking : List (NamedConstraint C₂))
-    (hBridge : (bridge s₁Output) ≠ []) : Finset C₂ :=
-  (mkTableau (bridge s₁Output) ranking hBridge).optimal
-
--- ============================================================================
--- § 3: Stratal Derivation Record
--- ============================================================================
-
-/-- The full derivational history across all three strata.
-    Records the input and output at each level.
-
-    Type parameters:
-    - `S`: candidate type at the Stem level
-    - `W`: candidate type at the Word level
-    - `P`: candidate type at the Phrase level
-
-    Candidate types differ across strata because GEN produces different
-    representations at each level (e.g., metrical parses at Stem level,
-    segmental modifications at Word level). -/
+/-- The full derivational history across all three strata, recording the
+    input and output at each level. Candidate types differ across strata
+    because GEN produces different representations at each level (e.g.
+    metrical parses at the Stem level, segmental modifications at the Word
+    level). -/
 structure StratalDerivation (S W P : Type*) where
   /-- Underlying representation (input to the Stem stratum). -/
   underlyingForm : S
@@ -154,34 +47,11 @@ structure StratalDerivation (S W P : Type*) where
   /-- Optimal output of the Phrase stratum (= surface form). -/
   phraseOutput : P
 
-/-- The surface form is the output of the final (Phrase) stratum. -/
-def StratalDerivation.surface {S W P : Type*}
-    (d : StratalDerivation S W P) : P :=
-  d.phraseOutput
-
--- ============================================================================
--- § 4: Constraint Reranking
--- ============================================================================
-
-/-- A constraint identity: name and family, independent of ranking
-    position. The same `ConstraintId` can appear at different positions
-    in different strata's rankings — this is the core mechanism of
-    Stratal OT.
-
-    Contrast with `NamedConstraint`, which bundles the identity with an
-    evaluation function (tied to a specific candidate type). -/
-structure ConstraintId where
-  name : String
-  family : ConstraintFamily
-  deriving DecidableEq, Repr
-
-/-- Extract the identity from a named constraint. -/
-def NamedConstraint.toId {C : Type*} (nc : NamedConstraint C) : ConstraintId :=
-  ⟨nc.name, nc.family⟩
+/-! ### Constraint reranking -/
 
 /-- Find the rank (position) of a constraint by name within a ranking.
-    Position 0 = highest-ranked. Returns `none` if the constraint
-    is not active at this stratum. -/
+    Position 0 = highest-ranked. Returns `none` if the constraint is not
+    active at this stratum. -/
 def findRank {C : Type*} (name : String)
     (ranking : List (NamedConstraint C)) : Option Nat :=
   go ranking 0
@@ -190,47 +60,11 @@ where
     | [], _ => none
     | c :: cs, i => if c.name == name then some i else go cs (i + 1)
 
-/-- Is constraint `name` ranked higher (closer to position 0) in
-    ranking `r₁` than in `r₂`? Captures **promotion** across strata.
-
-    Example: ONSET is promoted from Word to Phrase level in Telugu
-    ([aitha-2026] §5.3), switching from below IDENT-STRESS to
-    above it. -/
-def isPromoted {C : Type*} (name : String)
-    (r₁ r₂ : List (NamedConstraint C)) : Prop :=
-  match findRank name r₁, findRank name r₂ with
-  | some p₁, some p₂ => p₁ < p₂
-  | _, _ => False
-
-instance {C : Type*} (name : String) (r₁ r₂ : List (NamedConstraint C)) :
-    Decidable (isPromoted name r₁ r₂) := by
-  unfold isPromoted; split <;> infer_instance
-
-/-- Is constraint `name` ranked lower in `r₁` than in `r₂`?
-    Captures **demotion** across strata.
-
-    Example: *DIST-0 is demoted from Word to Phrase level in Telugu
-    ([aitha-2026] §5.3), allowing consonant retention at phrase
-    boundaries. -/
-def isDemoted {C : Type*} (name : String)
-    (r₁ r₂ : List (NamedConstraint C)) : Prop :=
-  isPromoted name r₂ r₁
-
-instance {C : Type*} (name : String) (r₁ r₂ : List (NamedConstraint C)) :
-    Decidable (isDemoted name r₁ r₂) := by
-  unfold isDemoted; infer_instance
-
 /-- Cross-stratum promotion: `name` is ranked higher (closer to 0) in
     `r₁ : List (NamedConstraint C₁)` than in `r₂ : List (NamedConstraint C₂)`.
-    Generalises `isPromoted` to permit different candidate types between
-    strata, which is the typical case in Stratal OT — e.g. Word-stratum
-    candidates carry segmental modifications while Phrase-stratum
-    candidates carry boundary-prosody modifications. The constraint
-    inventory is shared by *name*, not by candidate type.
-
-    Example: ONSET is promoted from Word to Phrase level in Telugu
-    ([aitha-2026] §5.3), even though the Word and Phrase strata
-    score different candidate types. -/
+    Different candidate types between strata are permitted — the constraint
+    inventory is shared by *name*, not by candidate type (e.g. ONSET is
+    promoted from Word to Phrase level in Telugu, [aitha-2026] §5.3). -/
 def isPromotedAcross {C₁ C₂ : Type*} (name : String)
     (r₁ : List (NamedConstraint C₁)) (r₂ : List (NamedConstraint C₂)) : Prop :=
   match findRank name r₁, findRank name r₂ with
@@ -242,11 +76,8 @@ instance {C₁ C₂ : Type*} (name : String)
     Decidable (isPromotedAcross name r₁ r₂) := by
   unfold isPromotedAcross; split <;> infer_instance
 
-/-- Cross-stratum demotion. Dual of `isPromotedAcross`.
-
-    Example: `*DIST-0` is demoted from Word to Phrase level in Telugu
-    ([aitha-2026] §5.3), permitting consonant retention at phrase
-    boundaries that would otherwise trigger compensatory lengthening. -/
+/-- Cross-stratum demotion. Dual of `isPromotedAcross` (e.g. `*DIST-0` is
+    demoted from Word to Phrase level in Telugu, [aitha-2026] §5.3). -/
 def isDemotedAcross {C₁ C₂ : Type*} (name : String)
     (r₁ : List (NamedConstraint C₁)) (r₂ : List (NamedConstraint C₂)) : Prop :=
   isPromotedAcross name r₂ r₁
@@ -255,82 +86,5 @@ instance {C₁ C₂ : Type*} (name : String)
     (r₁ : List (NamedConstraint C₁)) (r₂ : List (NamedConstraint C₂)) :
     Decidable (isDemotedAcross name r₁ r₂) := by
   unfold isDemotedAcross; infer_instance
-
--- ============================================================================
--- § 5: Ranking Specification
--- ============================================================================
-
-/-- A Hasse pair (a, b) means constraint a strictly dominates constraint b
-    (a ≫ b). Lists of such pairs specify a partial order on constraints.
-
-    For classical OT, the transitive closure must be a total order. For
-    comparative tableaux ([prince-2002]), partial specifications
-    suffice.
-
-    Example: the Stem-level ranking in Telugu ([aitha-2026] §5.1)
-    is specified as:
-    ```
-    [("FT-BIN(μ)", "PARSE-SYL"), ("PARSE-SYL", "ALL-FT-LEFT")]
-    ``` -/
-abbrev RankingSpec := List (String × String)
-
-/-- Does constraint `a` immediately dominate `b` in the specification? -/
-def immediatelyDominates (spec : RankingSpec) (a b : String) : Prop :=
-  ∃ p ∈ spec, p.1 = a ∧ p.2 = b
-
-instance (spec : RankingSpec) (a b : String) :
-    Decidable (immediatelyDominates spec a b) := by
-  unfold immediatelyDominates; infer_instance
-
-/-- Does constraint `a` dominate `b`? Reflexive-transitive closure of
-    `immediatelyDominates`, decidable on any concrete `spec` via the
-    `Core.Relation.ReflTransGen` substrate using the spec's vertex
-    universe as the finite carrier. Captures dominance chains of any
-    length (the previous depth-3 hardcoded version was incomplete for
-    longer chains). -/
-def dominates (spec : RankingSpec) : String → String → Prop :=
-  Relation.ReflTransGen (immediatelyDominates spec)
-
-/-- All constraints mentioned by `spec` — the finite universe for the
-    substrate's `decidable_of_finite`. -/
-private def specVerts (spec : RankingSpec) : List String :=
-  (spec.map (·.1) ++ spec.map (·.2)).dedup
-
-private theorem immediatelyDominates_dst_mem_specVerts (spec : RankingSpec) :
-    ∀ a b, immediatelyDominates spec a b → b ∈ specVerts spec := by
-  intro a b ⟨p, hp, _, hp2⟩
-  simp only [specVerts, List.mem_dedup, List.mem_append, List.mem_map]
-  exact Or.inr ⟨p, hp, hp2⟩
-
-instance (spec : RankingSpec) (a b : String) :
-    Decidable (dominates spec a b) :=
-  Relation.ReflTransGen.decidable_of_finite (r := immediatelyDominates spec)
-    (specVerts spec) (immediatelyDominates_dst_mem_specVerts spec) a b
-
--- ============================================================================
--- § 6: Cross-Stratal Properties
--- ============================================================================
-
-/-- Output feeding: the output of stratum s is well-formed input for
-    stratum s+1. This is the fundamental architectural claim of
-    Stratal OT — phonological computation is *cyclic*, and each cycle
-    can change the representation in ways that feed or bleed processes
-    at the next cycle.
-
-    Key empirical consequence ([aitha-2026]): compensatory
-    lengthening is optimal at the Word level (MAX ≫ ALIGN-RIGHT) but
-    not at the Phrase level (constraint reranking), producing different
-    outputs for the same segmental configuration at different strata. -/
-def isOutputFeeding (s : Stratum) : Stratum → Prop
-  | .stem => s = .stem     -- Stem feeds itself (no prior stratum)
-  | .word => s = .stem     -- Word is fed by Stem
-  | .phrase => s = .word   -- Phrase is fed by Word
-
-instance (s t : Stratum) : Decidable (isOutputFeeding s t) := by
-  cases t <;> unfold isOutputFeeding <;> infer_instance
-
-theorem stem_feeds_word : isOutputFeeding .stem .word := rfl
-theorem word_feeds_phrase : isOutputFeeding .word .phrase := rfl
-theorem stem_not_feeds_phrase : ¬ isOutputFeeding .stem .phrase := by decide
 
 end OptimalityTheory.Stratal

--- a/Linglib/Phonology/OptimalityTheory/TCT.lean
+++ b/Linglib/Phonology/OptimalityTheory/TCT.lean
@@ -199,13 +199,4 @@ theorem TetruSchema.misapplication_wins {C : Type} (s : TetruSchema C)
     s.ooIdent.eval misapplied < s.ooIdent.eval canonical :=
   ⟨hM1, hOO⟩
 
-/-- Symmetric form: when two candidates tie on M₁, OO-Ident is the
-    deciding constraint. The OO-Ident-better candidate has strictly
-    fewer violations at the second-highest-ranked position. -/
-theorem TetruSchema.oo_decides_when_m1_ties {C : Type} (s : TetruSchema C)
-    (cand₁ cand₂ : C)
-    (_hM1 : s.m1.eval cand₁ = s.m1.eval cand₂)
-    (hOO : s.ooIdent.eval cand₁ < s.ooIdent.eval cand₂) :
-    s.ooIdent.eval cand₁ < s.ooIdent.eval cand₂ := hOO
-
 end OptimalityTheory.TCT

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -2,6 +2,7 @@ import Linglib.Features.Case.Basic
 import Linglib.Features.Case.Basic
 import Linglib.Syntax.Case.Order
 import Linglib.Morphology.Case.Allomorphy
+import Linglib.Phonology.OptimalityTheory.Basic
 import Linglib.Phonology.OptimalityTheory.Predict
 import Linglib.Phonology.Prosodic.Foot
 import Linglib.Morphology.DM.VocabularyInsertion


### PR DESCRIPTION
Audit follow-up: make `Antimatroid` honest and cull verified-dead OT code.

- `Antimatroid`: replace three `: True := trivial` placeholders (Merchant–Riggle [merchant-riggle-2016] Theorems 1/2/4) with the paper's real statements + `sorry`/`TODO`, and add `RCErc` on whole antimatroids — strictly better than the prior fake-green proofs; also fixes two deprecations
- cull verified-dead OT code: `Stratal` 336→90 lines (drops 5 imports), `vpOfList`, `TCT.oo_decides_when_m1_ties`, `Doubling`'s dead `MorphProfile` import