### PR TITLE
refactor(Morphology): graduate Plurals + TenseAspect typology from Typology

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2904,11 +2904,11 @@ import Linglib.Typology.Negation.ExpletiveNegation
 import Linglib.Typology.NegativeConcord
 import Linglib.Typology.Numeral.Basic
 import Linglib.Typology.Phonology
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 import Linglib.Typology.PolarityItem
 import Linglib.Typology.PolarityMarking
 import Linglib.Typology.Profile
 import Linglib.Typology.Pronoun.WALS
 import Linglib.Typology.Question
 import Linglib.Typology.TemporalConnectives
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect

--- a/Linglib/Fragments/Arabic/Egyptian/TenseAspect.lean
+++ b/Linglib/Fragments/Arabic/Egyptian/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Arabic (Egyptian) tense-aspect profile (WALS Chs 65–69)
@@ -11,7 +11,7 @@ namespace Arabic.Egyptian
     (*katab*/*yiktib*); inflectional past (perfective form encodes past);
     no inflectional future (uses preverbal particles); no distinct perfect;
     suffixing. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Arabic (Egyptian)", iso := "arz", family := "Afro-Asiatic"
   , aspect := .grammatical, past := .marked, future := .none
   , perfect := .none, affixPosition := .suffixing }

--- a/Linglib/Fragments/Arabic/ModernStandard/Plurals.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Arabic plurality profile (WALS Chs 33–36)
@@ -11,7 +11,7 @@ namespace Arabic.ModernStandard
     (*-aat*, *-uun*) and "broken" stem-internal changes are productive,
     neither clearly primary. Obligatory on all nouns; person-number stem in
     pronouns (*ana*/*nahnu*); associative plural same as additive. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Arabic"
   , iso := "arb"
   , coding := .mixedMorphological

--- a/Linglib/Fragments/English/Plurals.lean
+++ b/Linglib/Fragments/English/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # English plurality profile (WALS Chs 33–36)
@@ -9,7 +9,7 @@ namespace English
 
 /-- English: suffix plural (-s), obligatory on all nouns, person-number
     stems in pronouns, no productive associative plural. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "English"
   , iso := "eng"
   , coding := .suffix

--- a/Linglib/Fragments/English/TenseAspect.lean
+++ b/Linglib/Fragments/English/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # English tense-aspect profile (WALS Chs 65–69, 78)
@@ -11,7 +11,7 @@ namespace English
     vs progressive); inflectional past (*-ed*); no inflectional future
     (uses *will*); 'have'-perfect; suffixing (*-ed*, *-ing*); no grammatical
     evidentiality. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "English", iso := "eng", family := "Indo-European"
   , aspect := .grammatical, past := .marked, future := .none
   , perfect := .fromPossessive, affixPosition := .suffixing

--- a/Linglib/Fragments/Finnish/Plurals.lean
+++ b/Linglib/Fragments/Finnish/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Finnish plurality profile (WALS Chs 33–36)
@@ -10,7 +10,7 @@ namespace Finnish
 /-- Finnish: suffix plural (*-t* nominative, *-i-* oblique), obligatory on all
     nouns; person-number stem + pronominal affix in pronouns (*minä*/*me*);
     no productive associative plural. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Finnish"
   , iso := "fin"
   , coding := .suffix

--- a/Linglib/Fragments/Finnish/TenseAspect.lean
+++ b/Linglib/Fragments/Finnish/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Finnish tense-aspect profile (WALS Chs 65–69)
@@ -10,7 +10,7 @@ namespace Finnish
 /-- Finnish (Uralic): no grammatical perfective/imperfective; inflectional
     past (*-i*); no inflectional future (present used for future reference);
     perfect (*on* + past participle, 'be'-type); suffixing. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Finnish", iso := "fin", family := "Uralic"
   , aspect := .none, past := .marked, future := .none
   , perfect := .other, affixPosition := .suffixing }

--- a/Linglib/Fragments/French/TenseAspect.lean
+++ b/Linglib/Fragments/French/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # French tense-aspect profile (WALS Chs 65–69)
@@ -11,7 +11,7 @@ namespace French
     distinction; inflectional past (*passé simple*); inflectional future
     (*-ai*, *-as*, *-a*…); 'have'-perfect (*avoir* + past participle);
     suffixing. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "French", iso := "fra", family := "Indo-European"
   , aspect := .grammatical, past := .marked, future := .inflectional
   , perfect := .fromPossessive, affixPosition := .suffixing }

--- a/Linglib/Fragments/Hawaiian/Plurals.lean
+++ b/Linglib/Fragments/Hawaiian/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Hawaiian plurality profile (WALS Chs 33–36)
@@ -9,7 +9,7 @@ namespace Hawaiian
 
 /-- Hawaiian: plural word (*mau*, prenominal), optional on all nouns;
     person-number stems in pronouns; associative plural absent. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Hawaiian"
   , iso := "haw"
   , coding := .pluralWord

--- a/Linglib/Fragments/Hindi/Plurals.lean
+++ b/Linglib/Fragments/Hindi/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Hindi plurality profile (WALS Chs 33–36)
@@ -10,7 +10,7 @@ namespace Hindi
 /-- Hindi: suffix plural (*-e*, *-en*, *-iya*), obligatory on all nouns;
     person-number stems in pronouns (*main* vs *ham*); associative plural
     uses the same plural marker (*Sharma-log* 'Sharma and family'). -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Hindi"
   , iso := "hin"
   , coding := .suffix

--- a/Linglib/Fragments/Hindi/TenseAspect.lean
+++ b/Linglib/Fragments/Hindi/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Hindi tense-aspect profile (WALS Chs 65–69)
@@ -10,7 +10,7 @@ namespace Hindi
 /-- Hindi (Indo-European, Indo-Aryan): perfective/imperfective (*-aa*,
     *-taa*); inflectional past; inflectional future (*-egaa*); other perfect;
     suffixing. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Hindi", iso := "hin", family := "Indo-European"
   , aspect := .grammatical, past := .marked, future := .inflectional
   , perfect := .other, affixPosition := .suffixing }

--- a/Linglib/Fragments/Hungarian/Plurals.lean
+++ b/Linglib/Fragments/Hungarian/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Hungarian plurality profile (WALS Chs 33–36)
@@ -11,7 +11,7 @@ namespace Hungarian
     stem + nominal plural affix on pronouns (*én* vs *mi*, with `-k` also on
     nouns); unique affixal associative plural (`-ék`: *Pál-ék* 'Paul and
     associates', distinct from additive `-k`/`-ak`). -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Hungarian"
   , iso := "hun"
   , coding := .suffix

--- a/Linglib/Fragments/Indonesian/Plurals.lean
+++ b/Linglib/Fragments/Indonesian/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Indonesian plurality profile (WALS Chs 33–36)
@@ -10,7 +10,7 @@ namespace Indonesian
 /-- Indonesian: complete reduplication (*rumah-rumah* 'houses'); plural marking
     optional on all nouns; person-number stems in pronouns (*saya*/*kami*);
     no productive associative plural. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Indonesian"
   , iso := "ind"
   , coding := .reduplication

--- a/Linglib/Fragments/Indonesian/TenseAspect.lean
+++ b/Linglib/Fragments/Indonesian/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Indonesian tense-aspect profile (WALS Chs 65–69)
@@ -12,7 +12,7 @@ namespace Indonesian
     *air itu dingin* = 'the water is/was cold'). Minor repetitive suffix
     (*-i*) exists, marking it as `.suffixing` in WALS coding despite the
     overall pattern. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Indonesian", iso := "ind", family := "Austronesian"
   , aspect := .none, past := .none, future := .none
   , perfect := .none, affixPosition := .suffixing }

--- a/Linglib/Fragments/Japanese/Plurals.lean
+++ b/Linglib/Fragments/Japanese/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Japanese plurality profile (WALS Chs 33–36)
@@ -11,7 +11,7 @@ namespace Japanese
     optional (suffix `-tachi` is limited and optional); person-number stems in
     pronouns; unique periphrastic associative plural (`-tachi` on proper names:
     *Tanaka-tachi* 'Tanaka and associates'). -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Japanese"
   , iso := "jpn"
   , coding := .noPlural

--- a/Linglib/Fragments/Japanese/TenseAspect.lean
+++ b/Linglib/Fragments/Japanese/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Japanese tense-aspect profile (WALS Chs 65–69)
@@ -10,7 +10,7 @@ namespace Japanese
 /-- Japanese (Japonic): perfective/imperfective (*ta*-form vs *te-iru*);
     inflectional past (*-ta*, *-da*); no inflectional future; no distinct
     perfect; suffixing. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Japanese", iso := "jpn", family := "Japonic"
   , aspect := .grammatical, past := .marked, future := .none
   , perfect := .none, affixPosition := .suffixing }

--- a/Linglib/Fragments/Korean/Plurals.lean
+++ b/Linglib/Fragments/Korean/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Korean plurality profile (WALS Chs 33–36)
@@ -10,7 +10,7 @@ namespace Korean
 /-- Korean: suffix plural (*-tul*), optional on all nouns (number-neutral bare
     forms are common); person-number stems in pronouns (*na*/*uri*);
     associative plural uses the same `-tul` marker. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Korean"
   , iso := "kor"
   , coding := .suffix

--- a/Linglib/Fragments/Korean/TenseAspect.lean
+++ b/Linglib/Fragments/Korean/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Korean tense-aspect profile (WALS Chs 65–69, 78)
@@ -12,7 +12,7 @@ namespace Korean
     perfect; suffixing. Evidentiality via verbal suffixes (*-te*
     retrospective, *-ney* contemporaneous; [cumming-2026] analyzes
     these as tense-evidential interactions). -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Korean", iso := "kor", family := "Koreanic"
   , aspect := .grammatical, past := .marked, future := .inflectional
   , perfect := .none, affixPosition := .suffixing

--- a/Linglib/Fragments/Lango/TenseAspect.lean
+++ b/Linglib/Fragments/Lango/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Lango tense-aspect profile (WALS Chs 65–69)
@@ -10,7 +10,7 @@ namespace Lango
 /-- Lango (Nilotic, Eastern Sudanic): perfective/imperfective/progressive
     marked primarily by tone; past tense marking; no inflectional future;
     other perfect; tonal T/A marking. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Lango", iso := "laj", family := "Nilo-Saharan"
   , aspect := .grammatical, past := .marked, future := .none
   , perfect := .other, affixPosition := .tonal }

--- a/Linglib/Fragments/Lezgian/Plurals.lean
+++ b/Linglib/Fragments/Lezgian/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Lezgian plurality profile (WALS Chs 33–36)
@@ -10,7 +10,7 @@ namespace Lezgian
 /-- Lezgian (Daghestanian): suffix plural (*-ar*, *-er*), obligatory on all
     nouns (but absent with numerals); person-number stems in pronouns;
     associative plural uses the same suffix. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Lezgian"
   , iso := "lez"
   , coding := .suffix

--- a/Linglib/Fragments/Mandarin/Plurals.lean
+++ b/Linglib/Fragments/Mandarin/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Mandarin plurality profile (WALS Chs 33–36)
@@ -10,7 +10,7 @@ namespace Mandarin
 /-- Mandarin Chinese: no morphological plural on common nouns (bare nouns are
     number-neutral); person stem + nominal plural affix `-men` on pronouns
     (*wo* / *wo-men* 'I/we'); associative plural uses the same `-men` marker. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Mandarin"
   , iso := "cmn"
   , coding := .noPlural

--- a/Linglib/Fragments/Mandarin/TenseAspect.lean
+++ b/Linglib/Fragments/Mandarin/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Mandarin tense-aspect profile (WALS Chs 65–69, 78)
@@ -11,7 +11,7 @@ namespace Mandarin
     particles (not inflectional); no inflectional past or future; no distinct
     perfect; no tense-aspect inflection (quintessential isolating language);
     no grammatical evidentiality. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Mandarin Chinese", iso := "cmn", family := "Sino-Tibetan"
   , aspect := .grammatical, past := .none, future := .none
   , perfect := .none, affixPosition := .noInflection

--- a/Linglib/Fragments/Quechua/TenseAspect.lean
+++ b/Linglib/Fragments/Quechua/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Quechua tense-aspect profile (WALS Chs 65–69, 78)
@@ -12,7 +12,7 @@ namespace Quechua
     inflectional future (*-saq*); other perfect (*-sqa* resultative);
     suffixing. Evidentiality via verbal suffixes (*-mi* direct, *-si*
     hearsay, *-chá* conjecture). -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Quechua", iso := "que", family := "Quechuan"
   , aspect := .none, past := .markedRemoteness2_3, future := .inflectional
   , perfect := .other, affixPosition := .suffixing

--- a/Linglib/Fragments/Slavic/Russian/Plurals.lean
+++ b/Linglib/Fragments/Slavic/Russian/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Russian plurality profile (WALS Chs 33–36)
@@ -10,7 +10,7 @@ namespace Russian
 /-- Russian: suffix plural (*-y*, *-i*, *-a*), obligatory on all nouns;
     person-number stem + nominal plural affix in pronouns (*ja* vs *m-y*);
     no productive associative plural. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Russian"
   , iso := "rus"
   , coding := .suffix

--- a/Linglib/Fragments/Slavic/Russian/TenseAspect.lean
+++ b/Linglib/Fragments/Slavic/Russian/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Russian tense-aspect profile (WALS Chs 65–69)
@@ -11,7 +11,7 @@ namespace Russian
     via prefixation); inflectional past; no inflectional future (periphrastic
     *budet* + infinitive for imperfective; perfective present = future); no
     perfect; suffixing (*-l*, *-la* for past). -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Russian", iso := "rus", family := "Indo-European"
   , aspect := .grammatical, past := .marked, future := .none
   , perfect := .none, affixPosition := .suffixing }

--- a/Linglib/Fragments/Spanish/TenseAspect.lean
+++ b/Linglib/Fragments/Spanish/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Spanish tense-aspect profile (WALS Chs 65–69)
@@ -9,7 +9,7 @@ namespace Spanish
 
 /-- Spanish (Indo-European, Romance): *imperfecto*/*pretérito*; inflectional
     past and future; 'have'-perfect (*haber* + participle); suffixing. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Spanish", iso := "spa", family := "Indo-European"
   , aspect := .grammatical, past := .marked, future := .inflectional
   , perfect := .fromPossessive, affixPosition := .suffixing }

--- a/Linglib/Fragments/Swahili/Plurals.lean
+++ b/Linglib/Fragments/Swahili/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Swahili plurality profile (WALS Chs 33–36)
@@ -10,7 +10,7 @@ namespace Swahili
 /-- Swahili: plural marked by noun class prefixes (*wa-*, *vi-*, *mi-*, *ma-*),
     obligatory on all nouns; person-number stems in pronouns (*mimi*/*sisi*);
     no productive associative plural. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Swahili"
   , iso := "swh"
   , coding := .prefix

--- a/Linglib/Fragments/Swahili/TenseAspect.lean
+++ b/Linglib/Fragments/Swahili/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Swahili tense-aspect profile (WALS Chs 65–69)
@@ -10,7 +10,7 @@ namespace Swahili
 /-- Swahili (Niger-Congo, Bantu): perfective/imperfective (*-li-*, *-na-*);
     past marking; no inflectional future; other perfect (*-me-*); prefixing
     (T/A markers are verbal prefixes). -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Swahili", iso := "swh", family := "Niger-Congo"
   , aspect := .grammatical, past := .marked, future := .none
   , perfect := .other, affixPosition := .prefixing }

--- a/Linglib/Fragments/Tagalog/Plurals.lean
+++ b/Linglib/Fragments/Tagalog/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Tagalog plurality profile (WALS Chs 33–36)
@@ -69,7 +69,7 @@ Coding (Ch 33): plural word *mga*. Occurrence (Ch 34): all nouns, always
 optional. Pronoun plurality (Ch 35): person-number stem (refined to
 minimal-augmented in `Tagalog.clusivitySystem`). Associative
 (Ch 36): unique periphrastic — *sina* on personal names. -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Tagalog"
   , iso := "tgl"
   , coding := .pluralWord

--- a/Linglib/Fragments/Tagalog/TenseAspect.lean
+++ b/Linglib/Fragments/Tagalog/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Tagalog tense-aspect profile (WALS Chs 65–69)
@@ -11,7 +11,7 @@ namespace Tagalog
     (completed vs contemplated aspect); no inflectional past or future
     (aspect-based system); no distinct perfect; prefixing
     (*mag-*, *nag-*, *-um-* etc.). -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Tagalog", iso := "tgl", family := "Austronesian"
   , aspect := .grammatical, past := .none, future := .none
   , perfect := .none, affixPosition := .prefixing }

--- a/Linglib/Fragments/Thai/TenseAspect.lean
+++ b/Linglib/Fragments/Thai/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Thai tense-aspect profile (WALS Chs 65–69)
@@ -9,7 +9,7 @@ namespace Thai
 
 /-- Thai (Tai-Kadai): no grammatical perfective/imperfective; no inflectional
     past or future; no perfect. SE Asian isolating type. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Thai", iso := "tha", family := "Tai-Kadai"
   , aspect := .none, past := .none, future := .none
   , perfect := .none, affixPosition := .noInflection }

--- a/Linglib/Fragments/Turkish/Plurals.lean
+++ b/Linglib/Fragments/Turkish/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Turkish plurality profile (WALS Chs 33–36)
@@ -11,7 +11,7 @@ namespace Turkish
     all nouns (except after numerals); person-number stems in pronouns
     (*ben*/*biz*, *sen*/*siz*); associative plural uses the same `-ler` marker
     (*Ali-ler* 'Ali and associates'). -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Turkish"
   , iso := "tur"
   , coding := .suffix

--- a/Linglib/Fragments/Turkish/TenseAspect.lean
+++ b/Linglib/Fragments/Turkish/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Turkish tense-aspect profile (WALS Chs 65–69, 78)
@@ -11,7 +11,7 @@ namespace Turkish
     past; inflectional future (*-ecek*); other perfect (*-miş*, from
     evidential/inferential); suffixing. Evidentiality is part of the tense
     paradigm: *-miş* marks indirect (hearsay/inference) vs *-di* (direct). -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Turkish", iso := "tur", family := "Turkic"
   , aspect := .grammatical, past := .marked, future := .inflectional
   , perfect := .other, affixPosition := .suffixing

--- a/Linglib/Fragments/Vietnamese/TenseAspect.lean
+++ b/Linglib/Fragments/Vietnamese/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Vietnamese tense-aspect profile (WALS Chs 65–69)
@@ -10,7 +10,7 @@ namespace Vietnamese
 /-- Vietnamese (Austroasiatic): no grammatical perfective/imperfective; no
     inflectional past or future; no perfect. Tense-aspect via separate
     particles (*đã*, *sẽ*); part of the SE Asian isolating area. -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Vietnamese", iso := "vie", family := "Austroasiatic"
   , aspect := .none, past := .none, future := .none
   , perfect := .none, affixPosition := .noInflection }

--- a/Linglib/Fragments/Yoruba/TenseAspect.lean
+++ b/Linglib/Fragments/Yoruba/TenseAspect.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.TenseAspect
+import Linglib.Morphology.TenseAspect
 
 /-!
 # Yoruba tense-aspect profile (WALS Chs 65–69)
@@ -10,7 +10,7 @@ namespace Yoruba
 /-- Yoruba (Niger-Congo, Atlantic-Congo): perfective/imperfective distinction;
     no past tense marking; no inflectional future; perfect from 'already'
     (*ti*); no tense-aspect inflection (preverbal particles). -/
-def tenseAspectProfile : Typology.TAProfile :=
+def tenseAspectProfile : Morphology.TenseAspect.TAProfile :=
   { language := "Yoruba", iso := "yor", family := "Niger-Congo"
   , aspect := .grammatical, past := .none, future := .none
   , perfect := .fromFinishAlready, affixPosition := .noInflection }

--- a/Linglib/Fragments/Zulu/Plurals.lean
+++ b/Linglib/Fragments/Zulu/Plurals.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Plurals
+import Linglib.Morphology.Number
 
 /-!
 # Zulu plurality profile (WALS Chs 33–36)
@@ -10,7 +10,7 @@ namespace Zulu
 /-- Zulu (Bantu): prefix plural (class prefixes: *umu-ntu*/*aba-ntu*),
     obligatory on all nouns; person-number stems in pronouns; associative
     plural uses the same prefix system (*o-Faku* 'Faku and company'). -/
-def pluralityProfile : Typology.PluralityProfile :=
+def pluralityProfile : Morphology.Number.PluralityProfile :=
   { language := "Zulu"
   , iso := "zul"
   , coding := .prefix

--- a/Linglib/Morphology/Number.lean
+++ b/Linglib/Morphology/Number.lean
@@ -1,7 +1,7 @@
 import Linglib.Typology.Pronoun.WALS
 
 /-!
-# Plural-marking typology — substrate types
+# Number: nominal plurality typology (WALS Chs 33-36)
 [wals-2013] (Chs 33-36)
 
 Type-level enums + per-language profile struct for nominal and pronominal
@@ -33,7 +33,7 @@ No Fragment imports.
 
 set_option autoImplicit false
 
-namespace Typology
+namespace Morphology.Number
 
 /-- WALS Ch 33: how plurality is morphologically coded on full nouns.
     Nine values cross morphological strategy with absence-of-marking. -/
@@ -101,9 +101,9 @@ structure PluralityProfile where
   /-- Ch 34: when plural marking occurs. -/
   occurrence : PluralOccurrence
   /-- Ch 35: pronoun plurality type (canonical type in `Typology/Pronoun/WALS.lean`). -/
-  pronounPlurality : Pronoun.Plurality
+  pronounPlurality : _root_.Pronoun.Plurality
   /-- Ch 36: associative plural strategy. -/
   associativePlural : AssociativePlural
   deriving Repr, DecidableEq
 
-end Typology
+end Morphology.Number

--- a/Linglib/Morphology/TenseAspect.lean
+++ b/Linglib/Morphology/TenseAspect.lean
@@ -37,7 +37,7 @@ round-tripping should use `Aikhenvald2004.EvidentialCoding`.
 
 set_option autoImplicit false
 
-namespace Typology
+namespace Morphology.TenseAspect
 
 -- ============================================================================
 -- WALS Ch 65: Perfective/imperfective aspect
@@ -369,4 +369,4 @@ theorem remoteness_uncommon :
 theorem extreme_remoteness_very_rare :
     walsCh66.markedRemoteness4plus = 2 := by decide
 
-end Typology
+end Morphology.TenseAspect

--- a/Linglib/Typology/Pronoun/WALS.lean
+++ b/Linglib/Typology/Pronoun/WALS.lean
@@ -38,7 +38,7 @@ theorem over the accessor in that study file.
   ([nichols-peterson-2013]).
 * `Pronoun.Plurality` — how independent personal pronouns encode number,
   WALS Ch 35. The canonical home for this pronoun-paradigm feature; the
-  per-language values are carried by `Typology.PluralityProfile` (which bundles
+  per-language values are carried by `Morphology.Number.PluralityProfile` (which bundles
   it with the nominal-plurality Chs 33/34/36).
 -/
 
@@ -401,7 +401,7 @@ end Pronoun
 namespace Pronoun
 
 /-- WALS Ch 35: how independent personal pronouns encode number. The canonical
-    home for this pronoun-paradigm feature; `Typology.PluralityProfile` carries
+    home for this pronoun-paradigm feature; `Morphology.Number.PluralityProfile` carries
     the per-language values alongside the nominal-plurality chapters (33/34/36). -/
 inductive Plurality where
   /-- No independent subject pronouns (e.g., Acoma). -/


### PR DESCRIPTION
Graduates two WALS-grounded inflectional-marking typologies out of the dissolving `Typology/`. Both are morphological marking typology (nominal plurality Chs 33–36; verbal TAM Chs 65–69/78) consumed by one study each via fragment field-access (Corbett2000, Smith1997) — so they land in `Morphology/` (which, unlike `Features/`/`Semantics/`, imports WALS).

- `Typology/Plurals.lean` → `Morphology/Number.lean` (`namespace Morphology.Number`); requalified the `Pronoun.Plurality` field ref.
- `Typology/TenseAspect.lean` → `Morphology/TenseAspect.lean` (`namespace Morphology.TenseAspect`).
- Routed 35 fragments (`Typology.{PluralityProfile,TAProfile}` → `Morphology.{Number,TenseAspect}.*`); studies need no routing (field-access with inferred enums). Cone green; invariant 2907.