### PR TITLE
refactor(Syntax): graduate ExpressiveModifier (ANDL wh) from Typology

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2805,6 +2805,7 @@ import Linglib.Syntax.DependencyGrammar.LongDistance
 import Linglib.Syntax.DependencyGrammar.Nominal
 import Linglib.Syntax.DependencyGrammar.Projection
 import Linglib.Syntax.Determiner.Basic
+import Linglib.Syntax.ExpressiveModifier
 import Linglib.Syntax.Extraction
 import Linglib.Syntax.HPSG.Basic
 import Linglib.Syntax.HPSG.Binding
@@ -2897,7 +2898,6 @@ import Linglib.Tactics.RSAPredict.Helpers
 import Linglib.Tactics.RSAPredict.RSABuilder
 import Linglib.Tactics.RSAPredict.ReflectBridge
 import Linglib.Tactics.RSAPredict.Reify
-import Linglib.Typology.ExpressiveModifier
 import Linglib.Typology.Indefinite
 import Linglib.Typology.Negation
 import Linglib.Typology.Negation.ExpletiveNegation

--- a/Linglib/Fragments/Mandarin/Questions.lean
+++ b/Linglib/Fragments/Mandarin/Questions.lean
@@ -1,5 +1,5 @@
 import Linglib.Typology.Question
-import Linglib.Typology.ExpressiveModifier
+import Linglib.Syntax.ExpressiveModifier
 
 /-!
 # Mandarin Wh-Question Formation
@@ -34,7 +34,7 @@ the lexical entries with their typological parameters.
 namespace Mandarin.Questions
 
 open Typology.Question (WhInterpMechanism WhMovementStrategy)
-open Typology.ExpressiveModifier
+open ExpressiveModifier
   (ExpressiveWhModifier ANDLMovementType ANDLHostPosition)
 
 -- ============================================================================

--- a/Linglib/Fragments/Singlish/Questions.lean
+++ b/Linglib/Fragments/Singlish/Questions.lean
@@ -1,6 +1,6 @@
 import Linglib.Typology.Question
 import Linglib.Studies.ShenHuang2026
-import Linglib.Typology.ExpressiveModifier
+import Linglib.Syntax.ExpressiveModifier
 
 /-!
 # Singlish Question Formation Strategies
@@ -42,7 +42,7 @@ namespace Singlish.Questions
 
 open Typology.Question (WhInterpMechanism WhMovementStrategy)
 open ShenHuang2026 (WhDependencyType)
-open Typology.ExpressiveModifier
+open ExpressiveModifier
   (ExpressiveWhModifier ANDLMovementType ANDLHostPosition)
 
 -- ============================================================================
@@ -188,7 +188,7 @@ def ah : SentenceFinalParticle :=
 
     Parametric values: parasitic movement (must adjoin to wh-phrase;
     cannot move on its own), matrix-scope host requirement. -/
-def theHell : Typology.ExpressiveModifier.ExpressiveWhModifier :=
+def theHell : ExpressiveModifier.ExpressiveWhModifier :=
   { form := "the hell"
   , gloss := "the-hell (ANDL intensifier)"
   , movementType := .parasitic

--- a/Linglib/Studies/ChanShen2026.lean
+++ b/Linglib/Studies/ChanShen2026.lean
@@ -1,7 +1,7 @@
 import Linglib.Fragments.Singlish.Questions
 import Linglib.Fragments.Mandarin.Questions
 import Linglib.Syntax.Minimalist.Features
-import Linglib.Typology.ExpressiveModifier
+import Linglib.Syntax.ExpressiveModifier
 import Linglib.Syntax.Minimalist.LeftPeriphery
 import Linglib.Studies.SprouseEtAl2012
 import Linglib.Studies.Ross1967
@@ -105,7 +105,7 @@ merged in matrix C, and Spec-head Agree as the licensing relation.
    to reach matrix Spec-CP. For independent modifiers (Mandarin *daodi*),
    the modifier moves on its own. -/
 
-open Typology.ExpressiveModifier (ExpressiveWhModifier Licensed)
+open ExpressiveModifier (ExpressiveWhModifier Licensed)
 
 /-- The unvalued POV feature [*ud*] borne by ANDL modifiers
     ([chou-2012]). A probe seeking a [+d] goal in a Spec-head
@@ -139,7 +139,7 @@ theorem pov_operator_valued :
       on its own — host reachability is irrelevant.
 
     This is the Minimalist instantiation of the theory-neutral
-    `Typology.ExpressiveModifier.Licensed`. The Minimalist version
+    `ExpressiveModifier.Licensed`. The Minimalist version
     doesn't add a separate condition — it identifies "modifier reaches
     Spec-CP" as the structural realization of "scope position reached". -/
 abbrev LicensedMinimalist (m : ExpressiveWhModifier)
@@ -154,7 +154,7 @@ open Singlish.Questions (WhStrategy fullMovement partialMovement
   whInSitu theHell)
 open Mandarin.Questions (daodi)
 open Typology.Question (WhInterpMechanism)
-open Typology.ExpressiveModifier
+open ExpressiveModifier
   (ExpressiveWhModifier ANDLMovementType Licensed)
 open Minimalist.ANDL
   (povUnvaluedFeature povOperatorFeature LicensedMinimalist)
@@ -181,7 +181,7 @@ instance (s : WhStrategy) : Decidable (TheHellLicensed s) := by
 theorem theHellLicensed_iff_reachesSpecCP (s : WhStrategy) :
     TheHellLicensed s ↔ s.ReachesMatrixSpecCP := by
   unfold TheHellLicensed LicensedMinimalist
-  exact Typology.ExpressiveModifier.parasitic_licensed_iff_host_reaches
+  exact ExpressiveModifier.parasitic_licensed_iff_host_reaches
     (m := theHell) rfl _
 
 -- ============================================================================
@@ -424,7 +424,7 @@ theorem theHell_daodi_movement_contrast :
     parameter, derived via `independent_matrix_always_licensed`. -/
 theorem daodi_licensed_insitu (P : Prop) :
     Licensed daodi P :=
-  Typology.ExpressiveModifier.independent_matrix_always_licensed
+  ExpressiveModifier.independent_matrix_always_licensed
     rfl rfl P
 
 end ChanShen2026

--- a/Linglib/Syntax/ExpressiveModifier.lean
+++ b/Linglib/Syntax/ExpressiveModifier.lean
@@ -1,5 +1,5 @@
 /-!
-# Typology.ExpressiveModifier
+# Expressive wh-modifiers: ANDL typology
 
 [pesetsky-1987] [chou-2012] [merchant-2002]
 [hoeksema-napoli-2008] [jackendoff-audring-2020]
@@ -48,7 +48,7 @@ possible-ignorance presupposition) lives in `Pragmatics/Expressives/`
 lexemes import only this file.
 -/
 
-namespace Typology.ExpressiveModifier
+namespace ExpressiveModifier
 
 /-- How an ANDL modifier reaches its scope-taking position.
 
@@ -137,4 +137,4 @@ theorem independent_matrix_always_licensed
     Licensed m P :=
   Or.inr ⟨hMov, hHost⟩
 
-end Typology.ExpressiveModifier
+end ExpressiveModifier


### PR DESCRIPTION
Graduates the aggressively-non-D-linked (ANDL) wh-modifier typology ([pesetsky-1987], [chan-shen-2026]) out of the dissolving `Typology/` to `Syntax/ExpressiveModifier.lean` (`namespace ExpressiveModifier`). The schema is the morphosyntactic wh-licensing dimension (movement type, scope, `Licensed` predicate) — semantics is deferred to `Pragmatics/Expressives` and framework analysis to `Syntax/Minimalist`, so the neutral schema is syntactic. The fragments define `ExpressiveWhModifier` values, so it stays fragment-importable. Routed 2 Question fragments + ChanShen2026; cone green; invariant holds.