### PR TITLE
refactor(Phonology): hoist harmonyScore_eq_neg_sum, dedup foldl_sub

### DIFF
--- a/Linglib/Phonology/Constraints/Weighted.lean
+++ b/Linglib/Phonology/Constraints/Weighted.lean
@@ -41,6 +41,23 @@ structure WeightedConstraint (C : Type*) extends NamedConstraint C where
 def harmonyScore {C : Type*} (constraints : List (WeightedConstraint C)) (c : C) : ℚ :=
   constraints.foldl (λ acc con => acc - con.weight * (con.eval c : ℚ)) 0
 
+/-- A left-fold of subtractions telescopes to the initial value minus the
+    mapped sum. The shared algebraic identity behind `harmonyScore`. -/
+private theorem foldl_sub {α : Type*} (f : α → ℚ) (l : List α) (init : ℚ) :
+    l.foldl (fun acc x => acc - f x) init = init - (l.map f).sum := by
+  induction l generalizing init with
+  | nil => simp
+  | cons x xs ih => simp only [List.foldl_cons, List.map_cons, List.sum_cons, ih, sub_sub]
+
+/-- `harmonyScore` as a negated `List.sum`: `H(c) = -Σⱼ wⱼ · Cⱼ(c)`. Exposes
+    the score's `List.sum` structure so HG/MaxEnt/NHG proofs reason with
+    `List.sum` algebra instead of re-deriving the defining fold. -/
+theorem harmonyScore_eq_neg_sum {C : Type*}
+    (constraints : List (WeightedConstraint C)) (c : C) :
+    harmonyScore constraints c =
+      -(constraints.map (fun con => con.weight * (con.eval c : ℚ))).sum := by
+  rw [harmonyScore, foldl_sub, zero_sub]
+
 /-- Harmony score as a real number, for interfacing with `softmax` and
     other ℝ-valued machinery (rate-distortion bounds, `Real.exp`, etc.). -/
 noncomputable def harmonyScoreR {C : Type*}

--- a/Linglib/Phonology/HarmonicGrammar/NoisyHG.lean
+++ b/Linglib/Phonology/HarmonicGrammar/NoisyHG.lean
@@ -176,14 +176,6 @@ theorem maxent_iia {C : Type*} [Fintype C] [Nonempty C]
 -- § 5: Harmony Difference Decomposition
 -- ============================================================================
 
-/-- Helper: foldl with subtraction equals initial value minus the sum. -/
-private lemma foldl_sub_eq_init_sub_sum {α : Type*} (f : α → ℚ)
-    (l : List α) (init : ℚ) :
-    l.foldl (fun acc x => acc - f x) init = init - (l.map f).sum := by
-  induction l generalizing init with
-  | nil => simp
-  | cons _ _ ih => simp only [List.foldl, List.map, List.sum_cons]; rw [ih]; ring
-
 /-- **Harmony difference decomposition**: the harmony score difference
     equals the negated weighted sum of violation differences.
 
@@ -196,7 +188,7 @@ theorem harmonyScore_diff {C : Type*}
     harmonyScore constraints a - harmonyScore constraints b =
     -(constraints.map (fun con =>
         con.weight * ((con.eval a : ℚ) - (con.eval b : ℚ)))).sum := by
-  simp only [harmonyScore, foldl_sub_eq_init_sub_sum, zero_sub]
+  simp only [harmonyScore_eq_neg_sum]
   have h_sum : ∀ (l : List (WeightedConstraint C)),
       (l.map (fun con => con.weight * (con.eval a : ℚ))).sum -
       (l.map (fun con => con.weight * (con.eval b : ℚ))).sum =

--- a/Linglib/Phonology/HarmonicGrammar/OTLimit.lean
+++ b/Linglib/Phonology/HarmonicGrammar/OTLimit.lean
@@ -283,18 +283,6 @@ theorem lex_imp_lower_violations {n : Nat} (w : Fin n → ℚ) (M : Nat)
   -- Combine: w_k − M · Σ_{i>k} w_i > 0 from ExponentiallySeparated
   linarith [hw.2 k, hlt_zero]
 
-private lemma foldl_sub_map_sum {α : Type} (l : List α) (f : α → ℚ) (init : ℚ) :
-    l.foldl (fun acc x => acc - f x) init = init - (l.map f).sum := by
-  induction l generalizing init with
-  | nil => simp
-  | cons x xs ih =>
-    simp only [List.foldl_cons, List.map_cons, List.sum_cons]; rw [ih]; ring
-
-private lemma harmonyScore_eq_neg_sum {C : Type}
-    (cons : List (WeightedConstraint C)) (c : C) :
-    harmonyScore cons c = -((cons.map (λ con => con.weight * (con.eval c : ℚ))).sum) := by
-  unfold harmonyScore; rw [foldl_sub_map_sum]; ring
-
 private lemma mapIdx_sum_eq_fin_sum {α : Type} (l : List α) (f : ℕ → α → ℚ) :
     (l.mapIdx f).sum = ∑ i : Fin l.length, f i (l.get i) := by
   induction l generalizing f with

--- a/Linglib/Phonology/HarmonicGrammar/Separability.lean
+++ b/Linglib/Phonology/HarmonicGrammar/Separability.lean
@@ -414,14 +414,6 @@ theorem inverse_not_always_hz :
 -- connection formal, enabling separability results (independence → HZ,
 -- constraint rescaling) to be applied to any `WeightedConstraint` list.
 
-private lemma foldl_sub_eq' {α : Type*} (l : List α) (f : α → ℚ) (init : ℚ) :
-    l.foldl (fun acc x => acc - f x) init = init - (l.map f).sum := by
-  induction l generalizing init with
-  | nil => simp
-  | cons _ _ ih =>
-    simp only [List.foldl_cons, List.map_cons, List.sum_cons]
-    rw [ih]; ring
-
 private lemma list_map_sum_eq_finsum {α : Type*} (l : List α) (f : α → ℚ) :
     (l.map f).sum = ∑ i : Fin l.length, f (l.get i) := by
   induction l with
@@ -444,8 +436,8 @@ theorem harmonyScoreR_as_finsum {C : Type*}
     harmonyScoreR constraints c =
     -(∑ i : Fin constraints.length,
       ((constraints.get i).weight : ℝ) * ((constraints.get i).eval c : ℝ)) := by
-  simp only [harmonyScoreR, harmonyScore]
-  rw [foldl_sub_eq']
+  simp only [harmonyScoreR]
+  rw [harmonyScore_eq_neg_sum]
   push_cast [list_map_sum_eq_finsum]
   ring
 


### PR DESCRIPTION
Audit follow-up (dedup). Hoist `harmonyScore_eq_neg_sum` into `Constraints/Weighted.lean` (with a shared private `foldl_sub`), delete the three byte-identical `foldl_sub` copies (NoisyHG/OTLimit/Separability) + OTLimit's private `harmonyScore_eq_neg_sum`, and reroute the three consumers to the shared lemma. No behavior change (public API unchanged).