### PR TITLE
refactor(Phonology): graduate phonological-inventory typology from Typology

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1327,6 +1327,7 @@ import Linglib.Phonology.HarmonicGrammar.OTLimit
 import Linglib.Phonology.HarmonicGrammar.PartiallyOrderedConstraints
 import Linglib.Phonology.HarmonicGrammar.Separability
 import Linglib.Phonology.HarmonicGrammar.ViolationSemiring
+import Linglib.Phonology.Inventory
 import Linglib.Phonology.ItemSpecificity.Defs
 import Linglib.Phonology.ItemSpecificity.IndexedConstraints
 import Linglib.Phonology.ItemSpecificity.RepresentationStrength
@@ -2906,7 +2907,7 @@ import Linglib.Tactics.RSAPredict.Reify
 
 import Linglib.Typology.Negation
 import Linglib.Typology.Negation.ExpletiveNegation
-import Linglib.Typology.Phonology
+
 import Linglib.Morphology.Number
 import Linglib.Typology.PolarityItem
 import Linglib.Typology.Pronoun.WALS

--- a/Linglib/Phonology/Inventory.lean
+++ b/Linglib/Phonology/Inventory.lean
@@ -89,7 +89,7 @@ Bridge theorems WALS↔PHOIBLE live in
 
 set_option autoImplicit false
 
-namespace Typology.Phonology
+namespace Phonology.Inventory
 
 private abbrev ch1   := Data.WALS.F1A.allData
 private abbrev ch2   := Data.WALS.F2A.allData

--- a/Linglib/Studies/Hyman2006.lean
+++ b/Linglib/Studies/Hyman2006.lean
@@ -1,5 +1,5 @@
 import Linglib.Phonology.Tone.Basic
-import Linglib.Typology.Phonology
+import Linglib.Phonology.Inventory
 
 /-!
 # Hyman 2006: Word-prosodic typology
@@ -48,7 +48,7 @@ Hyman's SA dimension.
 namespace Hyman2006
 
 open Tone
-open Typology.Phonology
+open Phonology.Inventory
 
 -- ============================================================================
 -- § 1: Two Prototypes

--- a/Linglib/Studies/Maddieson2013.lean
+++ b/Linglib/Studies/Maddieson2013.lean
@@ -1,4 +1,4 @@
-import Linglib.Typology.Phonology
+import Linglib.Phonology.Inventory
 import Linglib.Fragments.English.Phonology
 import Linglib.Fragments.German.Phonology
 import Linglib.Fragments.Finnish.Phonology
@@ -69,7 +69,7 @@ set_option autoImplicit false
 
 namespace Maddieson2013
 
-open Typology.Phonology
+open Phonology.Inventory
 open Data.PHOIBLE
 
 /-- Whether a consonant count falls in the WALS Ch 1 bin for a given


### PR DESCRIPTION
Graduates the WALS phonological-typology survey (segment inventories + suprasegmentals; WALS Chs 1–19, [maddieson-2013] + [hyman-2006]) out of the dissolving `Typology/` to `Phonology/Inventory.lean` (`namespace Phonology.Inventory`). WALS-grounded, so it sits in the `Phonology/` theory layer (like Syntax/Morphology WALS typologies), not the WALS-free `Features/`. Routed Hyman2006 + Maddieson2013; cone green; invariant holds.