### PR TITLE
refactor(Phonology): lift variable blocks in Constraints/OT core

### DIFF
--- a/Linglib/Phonology/Constraints/Defs.lean
+++ b/Linglib/Phonology/Constraints/Defs.lean
@@ -45,13 +45,15 @@ structure NamedConstraint (C : Type*) where
 -- § 1b: Constraint Constructors
 -- ============================================================================
 
+variable {C D : Type*}
+
 /-- Build a binary markedness constraint (violated → 1, otherwise 0).
 
     Takes a `Prop`-valued predicate with `[DecidablePred]` so that callers
     can use propositional equality (`=`) and other Prop predicates rather
     than `Bool`-valued operators (`==`). Decidability is required to evaluate
     the constraint on a candidate. -/
-def mkMark {C : Type*} (name : String) (P : C → Prop) [DecidablePred P] :
+def mkMark (name : String) (P : C → Prop) [DecidablePred P] :
     NamedConstraint C :=
   { name, family := .markedness, eval := fun c => if P c then 1 else 0 }
 
@@ -60,46 +62,48 @@ def mkMark {C : Type*} (name : String) (P : C → Prop) [DecidablePred P] :
     Takes a `Prop`-valued predicate with `[DecidablePred]` so that callers
     can use propositional equality (`=`) and other Prop predicates rather
     than `Bool`-valued operators (`==`). -/
-def mkFaith {C : Type*} (name : String) (P : C → Prop) [DecidablePred P] :
+def mkFaith (name : String) (P : C → Prop) [DecidablePred P] :
     NamedConstraint C :=
   { name, family := .faithfulness, eval := fun c => if P c then 1 else 0 }
 
 /-- Build a gradient markedness constraint with a Nat-valued violation count. -/
-def mkMarkGrad {C : Type*} (name : String) (violations : C → Nat) : NamedConstraint C :=
+def mkMarkGrad (name : String) (violations : C → Nat) : NamedConstraint C :=
   { name, family := .markedness, eval := violations }
 
 /-- Build a gradient faithfulness constraint with a Nat-valued violation count. -/
-def mkFaithGrad {C : Type*} (name : String) (violations : C → Nat) : NamedConstraint C :=
+def mkFaithGrad (name : String) (violations : C → Nat) : NamedConstraint C :=
   { name, family := .faithfulness, eval := violations }
 
 /-- Pull a `NamedConstraint D` back along a candidate map `f : C → D`. The
     name and family are inherited; the new `eval` composes the original
     with the projection. Lets paper-specific carrier types reuse a
     constraint defined on a more general carrier. -/
-def NamedConstraint.comap {C D : Type*} (f : C → D) (c : NamedConstraint D) :
+def NamedConstraint.comap (f : C → D) (c : NamedConstraint D) :
     NamedConstraint C :=
   { name := c.name, family := c.family, eval := c.eval ∘ f }
 
-@[simp] theorem NamedConstraint.comap_eval {C D : Type*} (f : C → D)
+@[simp] theorem NamedConstraint.comap_eval (f : C → D)
     (c : NamedConstraint D) (x : C) :
     (c.comap f).eval x = c.eval (f x) := rfl
 
-@[simp] theorem NamedConstraint.comap_name {C D : Type*} (f : C → D)
+@[simp] theorem NamedConstraint.comap_name (f : C → D)
     (c : NamedConstraint D) : (c.comap f).name = c.name := rfl
 
-@[simp] theorem NamedConstraint.comap_family {C D : Type*} (f : C → D)
+@[simp] theorem NamedConstraint.comap_family (f : C → D)
     (c : NamedConstraint D) : (c.comap f).family = c.family := rfl
+
+variable {α : Type*}
 
 /-- The zero-violation set of a `NamedConstraint` over list candidates,
 viewed as a `Language α`. Lets the OT-side `eval = 0` predicate compose
 with mathlib's `Language.IsRegular` and the project's
 `IsTierStrictlyLocal`/`IsBTC` classifiers. The dot-notation form
 `c.zeroSet` is the canonical access pattern. -/
-def NamedConstraint.zeroSet {α : Type*} (c : NamedConstraint (List α)) :
+def NamedConstraint.zeroSet (c : NamedConstraint (List α)) :
     Language α :=
   { w | c.eval w = 0 }
 
-lemma NamedConstraint.mem_zeroSet {α : Type*}
+lemma NamedConstraint.mem_zeroSet
     (c : NamedConstraint (List α)) (w : List α) :
     w ∈ c.zeroSet ↔ c.eval w = 0 := Iff.rfl
 

--- a/Linglib/Phonology/OptimalityTheory/Defs.lean
+++ b/Linglib/Phonology/OptimalityTheory/Defs.lean
@@ -33,36 +33,32 @@ open Core.Optimization.Evaluation
 fixed-length violation profile. -/
 abbrev Tableau (C : Type*) [DecidableEq C] (n : Nat) := LexMinProblem C n
 
+variable {C : Type*} [DecidableEq C] {n : Nat}
+
 /-- OT-named alias for `LexMinProblem.IsLexMin` — `c` is a lexicographic
 winner of `t`. -/
-abbrev Tableau.IsOptimal {C : Type*} [DecidableEq C] {n : Nat}
-    (t : Tableau C n) (c : C) : Prop :=
+abbrev Tableau.IsOptimal (t : Tableau C n) (c : C) : Prop :=
   LexMinProblem.IsLexMin t c
 
 /-- OT-named alias for `LexMinProblem.lexMins` — the winning candidates. -/
-abbrev Tableau.optimal {C : Type*} [DecidableEq C] {n : Nat}
-    (t : Tableau C n) : Finset C :=
+abbrev Tableau.optimal (t : Tableau C n) : Finset C :=
   LexMinProblem.lexMins t
 
 /-- OT-named alias for `LexMinProblem.exists_lexMin`. -/
-theorem Tableau.exists_optimal {C : Type*} [DecidableEq C] {n : Nat}
-    (t : Tableau C n) : ∃ c, t.IsOptimal c :=
+theorem Tableau.exists_optimal (t : Tableau C n) : ∃ c, t.IsOptimal c :=
   LexMinProblem.exists_lexMin t
 
 /-- OT-named alias for `LexMinProblem.mem_lexMins_iff`. -/
-theorem Tableau.mem_optimal_iff {C : Type*} [DecidableEq C] {n : Nat}
-    (t : Tableau C n) (c : C) :
+theorem Tableau.mem_optimal_iff (t : Tableau C n) (c : C) :
     c ∈ t.optimal ↔ t.IsOptimal c :=
   LexMinProblem.mem_lexMins_iff t c
 
 /-- OT-named alias for `LexMinProblem.lexMins_nonempty`. -/
-theorem Tableau.optimal_nonempty {C : Type*} [DecidableEq C] {n : Nat}
-    (t : Tableau C n) : t.optimal.Nonempty :=
+theorem Tableau.optimal_nonempty (t : Tableau C n) : t.optimal.Nonempty :=
   LexMinProblem.lexMins_nonempty t
 
 /-- OT-named alias for `LexMinProblem.lexMins_subset`. -/
-theorem Tableau.optimal_subset {C : Type*} [DecidableEq C] {n : Nat}
-    (t : Tableau C n) (c : C) :
+theorem Tableau.optimal_subset (t : Tableau C n) (c : C) :
     c ∈ t.optimal → c ∈ t.candidates :=
   LexMinProblem.lexMins_subset t c
 

--- a/Linglib/Phonology/OptimalityTheory/Predict.lean
+++ b/Linglib/Phonology/OptimalityTheory/Predict.lean
@@ -31,11 +31,13 @@ namespace OptimalityTheory
 open Core.Optimization
 open Core.Optimization.Evaluation
 
+variable {C : Type*} [DecidableEq C] {n : Nat}
+
 /-- An OT tableau viewed as a generic `ConstraintSystem`. The score type
     `LexProfile Nat n` is definitionally `ViolationProfile n`, so the
     `argminDecoder`'s `LinearOrder` requirement is satisfied by the
     standard `Pi.Lex` instance. -/
-noncomputable def tableauSystem {C : Type*} [DecidableEq C] {n : Nat}
+noncomputable def tableauSystem
     (t : Tableau C n) : ConstraintSystem C (LexProfile Nat n) where
   candidates := t.candidates
   score := t.profile
@@ -45,7 +47,7 @@ noncomputable def tableauSystem {C : Type*} [DecidableEq C] {n : Nat}
     `Tableau.optimal`. Since `Tableau.optimal` IS the argmin filter set
     by definition, the `argminDecoder` reduces to the standard "uniform
     over winners" formula. All other bridge results follow. -/
-theorem tableauSystem_predict_eq {C : Type*} [DecidableEq C] {n : Nat}
+theorem tableauSystem_predict_eq
     (t : Tableau C n) (c : C) :
     (tableauSystem t).predict c =
       (if c ∈ t.optimal then ((t.optimal.card : ℝ))⁻¹ else 0) := by
@@ -61,7 +63,7 @@ theorem tableauSystem_predict_eq {C : Type*} [DecidableEq C] {n : Nat}
 
 /-- A candidate is in the support of the `tableauSystem` distribution
     iff it is in the tableau's optimal set. -/
-theorem tableauSystem_predict_pos_iff_optimal {C : Type*} [DecidableEq C] {n : Nat}
+theorem tableauSystem_predict_pos_iff_optimal
     (t : Tableau C n) (c : C) :
     0 < (tableauSystem t).predict c ↔ c ∈ t.optimal := by
   rw [tableauSystem_predict_eq]
@@ -74,13 +76,13 @@ theorem tableauSystem_predict_pos_iff_optimal {C : Type*} [DecidableEq C] {n : N
 /-- When `Tableau.optimal = {winner}` (the typical deterministic-OT pattern
     used in study files via `by decide`), the unified `predict` view assigns
     probability 1 to the winner. -/
-theorem tableauSystem_predict_unique_winner {C : Type*} [DecidableEq C] {n : Nat}
+theorem tableauSystem_predict_unique_winner
     (t : Tableau C n) (winner : C) (h : t.optimal = {winner}) :
     (tableauSystem t).predict winner = 1 := by
   rw [tableauSystem_predict_eq, h]; simp
 
 /-- And losers in a unique-winner tableau receive probability 0. -/
-theorem tableauSystem_predict_loser {C : Type*} [DecidableEq C] {n : Nat}
+theorem tableauSystem_predict_loser
     (t : Tableau C n) (winner loser : C) (hne : loser ≠ winner)
     (h : t.optimal = {winner}) :
     (tableauSystem t).predict loser = 0 := by


### PR DESCRIPTION
Audit cleanup — `variable`-block discipline (the audit's largest mechanical deviation). Lift repeated implicit binders to section `variable`s in `Constraints/Defs` and `OptimalityTheory/{Defs,Predict}`; resulting declaration signatures are identical (verified — the whole Constraints/OT/HG cone builds unchanged). `Profile`/`Weighted`/`System`/`Basic` deferred (Profile is in #881; the rest a mechanical follow-up).