### PR TITLE
refactor(Studies): anchor NC bridge to VanDerAuweraVanAlsenoy2016 study

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1288,9 +1288,11 @@ import Linglib.Morphology.MorphRule
 import Linglib.Morphology.MorphWord
 import Linglib.Morphology.Nanosyntax.Basic
 import Linglib.Morphology.Nanosyntax.TreeSpellout
+import Linglib.Morphology.Number
 import Linglib.Morphology.Paradigm
 import Linglib.Morphology.RootFamily
 import Linglib.Morphology.RootTypology
+import Linglib.Morphology.TenseAspect
 import Linglib.Morphology.TheorySpace
 import Linglib.Morphology.Typology
 import Linglib.Morphology.Unification
@@ -2694,6 +2696,7 @@ import Linglib.Studies.TsvilodubEtAl2026
 import Linglib.Studies.TurcoBraunDimroth2014
 import Linglib.Studies.TurkHirsch2026
 import Linglib.Studies.Umbach2004
+import Linglib.Studies.VanDerAuweraVanAlsenoy2016
 import Linglib.Studies.VanDerLeer2026
 import Linglib.Studies.VanDerSandtMaier2003
 import Linglib.Studies.VanRooy2003
@@ -2910,5 +2913,3 @@ import Linglib.Tactics.RSAPredict.ReflectBridge
 import Linglib.Tactics.RSAPredict.Reify
 
 
-import Linglib.Morphology.Number
-import Linglib.Morphology.TenseAspect

--- a/Linglib/Studies/VanDerAuweraVanAlsenoy2016.lean
+++ b/Linglib/Studies/VanDerAuweraVanAlsenoy2016.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Negation
+import Linglib.Features.NegativeConcord
+
+/-!
+# [van-der-auwera-van-alsenoy-2016] — negative concord ↔ n-word status
+
+The cross-linguistic bridge between a language's WALS 115A negative-indefinite
+*strategy* ([haspelmath-2013], typed in `Syntax.Negation`) and the item-level
+*n-word status* of its negation-sensitive indefinites ([giannakidou-2000], typed
+in `Features.NegativeConcord`): an n-word needs a negative-concord system, an
+inherently negative quantifier needs a non-concord (double-negation /
+neg-existential) one, and an NPI is admitted by either.
+
+Anchored here (rather than left in `Syntax.Negation` substrate) because it is a
+paper-specific prediction with no other consumer; keeping it study-local lets
+`Syntax.Negation` stay free of the `Features.NegativeConcord` import.
+
+## Main definitions
+
+* `hasNegativeConcord` — whether a WALS 115A strategy is a concord system.
+* `admits` — whether an n-word status is consistent with a strategy.
+-/
+
+namespace VanDerAuweraVanAlsenoy2016
+
+open Syntax.Negation (NegIndefiniteStrategy)
+open Features.NegativeConcord (NWordStatus)
+
+/-- Whether the negative-indefinite system shows negative concord
+    ([van-der-auwera-van-alsenoy-2016]): WALS 115A `cooccur` (concord) and `mixed`
+    (position-dependent) do; `preclude` (double negation) and `negExistential` do not.
+    Broader than `NegationProfile.hasNegConcord`, which tests `cooccur` only. -/
+def hasNegativeConcord : NegIndefiniteStrategy → Bool
+  | .cooccur | .mixed => true
+  | .preclude | .negExistential => false
+
+/-- Whether an item-level n-word status is consistent with a language's WALS 115A
+    negative-indefinite strategy: an n-word needs a concord system, an inherently
+    negative quantifier a non-concord (double-negation / neg-existential) one, an NPI
+    any ([van-der-auwera-van-alsenoy-2016]). -/
+def admits : NegIndefiniteStrategy → NWordStatus → Bool
+  | strat, .nWord => hasNegativeConcord strat
+  | strat, .negQuantifier => !hasNegativeConcord strat
+  | _, .npi => true
+
+/-- N-words live in negative-concord systems, inherently negative quantifiers in
+    double-negation ones ([van-der-auwera-van-alsenoy-2016]). -/
+theorem nWord_vs_negQuantifier :
+    admits .cooccur .nWord = true ∧
+    admits .preclude .nWord = false ∧
+    admits .preclude .negQuantifier = true := by decide
+
+end VanDerAuweraVanAlsenoy2016

--- a/Linglib/Syntax/Negation.lean
+++ b/Linglib/Syntax/Negation.lean
@@ -6,7 +6,6 @@ import Linglib.Data.WALS.Features.F115A
 import Linglib.Data.WALS.Features.F143A
 import Linglib.Data.WALS.Features.F144A
 import Linglib.Syntax.AuxiliaryVerbs
-import Linglib.Features.NegativeConcord
 import Linglib.Morphology.Grammaticalization
 
 /-!
@@ -51,8 +50,7 @@ substrate carries (a) per-paradigm-entry schema (`NegMarkerEntry`,
   the marker-side joint is independent from the typology-feature joint.
 - `ofWALS112A`/`fromWALS113A`/`114A`/`115A`/`143A` converters.
 - `countByMorphemeType`/`countBySymmetry` sample-counting helpers (consumed by
-  `Studies/Dryer2013Negation.lean`) and the `NegIndefiniteStrategy.admits`
-  negative-concord bridge.
+  `Studies/Dryer2013Negation.lean`).
 
 ## Theory-laden caveats
 
@@ -390,34 +388,6 @@ def countByMorphemeType (langs : List NegationProfile)
 /-- Count of languages in a sample with a given symmetry type. -/
 def countBySymmetry (langs : List NegationProfile) (s : NegSymmetry) : Nat :=
   (langs.filter (·.symmetry == s)).length
-
-/-! ### Negative concord: WALS 115A strategy ↔ item-level n-word status -/
-
-open Features.NegativeConcord (NWordStatus)
-
-/-- Whether the negative-indefinite system shows negative concord
-    ([van-der-auwera-van-alsenoy-2016]): WALS 115A `cooccur` (concord) and `mixed`
-    (position-dependent) do; `preclude` (double negation) and `negExistential` do not.
-    Broader than `NegationProfile.hasNegConcord`, which tests `cooccur` only. -/
-def NegIndefiniteStrategy.hasNegativeConcord : NegIndefiniteStrategy → Bool
-  | .cooccur | .mixed => true
-  | .preclude | .negExistential => false
-
-/-- Whether an item-level n-word status is consistent with a language's WALS 115A
-    negative-indefinite strategy: an n-word needs a concord system, an inherently
-    negative quantifier a non-concord (double-negation / neg-existential) one, an NPI
-    any ([van-der-auwera-van-alsenoy-2016]). -/
-def NegIndefiniteStrategy.admits : NegIndefiniteStrategy → NWordStatus → Bool
-  | strat, .nWord => strat.hasNegativeConcord
-  | strat, .negQuantifier => !strat.hasNegativeConcord
-  | _, .npi => true
-
-/-- N-words live in negative-concord systems, inherently negative quantifiers in
-    double-negation ones ([van-der-auwera-van-alsenoy-2016]). -/
-theorem nWord_vs_negQuantifier :
-    (NegIndefiniteStrategy.cooccur).admits .nWord = true ∧
-    (NegIndefiniteStrategy.preclude).admits .nWord = false ∧
-    (NegIndefiniteStrategy.preclude).admits .negQuantifier = true := by decide
 
 /-! ### Negation strategy and the AVC bridge
 [anderson-2006] [heine-1993] [miestamo-2005]


### PR DESCRIPTION
Negation/polarity panel roadmap, bridge-anchoring increment.

The `NegIndefiniteStrategy.admits` / `.hasNegativeConcord` / `nWord_vs_negQuantifier` cluster (the WALS-115A-strategy ↔ item-level n-word-status bridge) had **zero external consumers** and was the *sole* reason `Syntax/Negation.lean` imported `Features.NegativeConcord`. Moved it to a new paper-anchored `Studies/VanDerAuweraVanAlsenoy2016.lean` (study-local functions, not substrate-API methods) — this makes the negation↔negative-concord prediction a legible paper-anchored theorem and lets `Syntax/Negation` shed the `Features.NegativeConcord` import.

Also tidies `Linglib.lean`: moves `Morphology.Number`/`Morphology.TenseAspect` from the leftover Typology alpha-block (an in-place-rename artifact of the dissolution) into the Morphology block.

Cone green (843 jobs); invariant 2906.

(Remaining roadmap, optional/deferred: Greco `PolarityClass.toPolarityType?` → Greco2020 — lower value, sheds no import; the veridicality licensing axis + Jespersen's cycle — substantive content, not cleanup.)