### PR TITLE
feat(Syntax/Minimalist/Merge): Minimal Yield as Birkhoff factorization

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2847,6 +2847,7 @@ import Linglib.Syntax.Minimalist.Merge.MinimalSearch
 import Linglib.Syntax.Minimalist.Merge.MinimalYield
 import Linglib.Syntax.Minimalist.Merge.MinimalYieldGrading
 import Linglib.Syntax.Minimalist.Merge.MinimalYieldCharacter
+import Linglib.Syntax.Minimalist.Merge.MinimalYieldBirkhoff
 import Linglib.Syntax.Minimalist.Merge.NoComplexityLoss
 import Linglib.Syntax.Minimalist.Merge.Sideward
 import Linglib.Syntax.Minimalist.MinimalPronoun

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -54,6 +54,7 @@ import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridge
 import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridgePairing
 import Linglib.Core.Algebra.RootedTree.PreLie.Path
 import Linglib.Core.Algebra.RotaBaxter
+import Linglib.Core.Algebra.RotaBaxterLaurent
 import Linglib.Core.Categorical.AgentCat
 import Linglib.Core.Categorical.PartitionCat
 import Linglib.Core.CategoryTheory.Monoidal.LabeledTuple

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2847,6 +2847,7 @@ import Linglib.Syntax.Minimalist.Merge.Internal
 import Linglib.Syntax.Minimalist.Merge.MinimalSearch
 import Linglib.Syntax.Minimalist.Merge.MinimalYield
 import Linglib.Syntax.Minimalist.Merge.MinimalYieldGrading
+import Linglib.Syntax.Minimalist.Merge.MinimalYieldPsi
 import Linglib.Syntax.Minimalist.Merge.MinimalYieldCharacter
 import Linglib.Syntax.Minimalist.Merge.MinimalYieldBirkhoff
 import Linglib.Syntax.Minimalist.Merge.NoComplexityLoss

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2845,6 +2845,7 @@ import Linglib.Syntax.Minimalist.Merge.External
 import Linglib.Syntax.Minimalist.Merge.Internal
 import Linglib.Syntax.Minimalist.Merge.MinimalSearch
 import Linglib.Syntax.Minimalist.Merge.MinimalYield
+import Linglib.Syntax.Minimalist.Merge.MinimalYieldGrading
 import Linglib.Syntax.Minimalist.Merge.NoComplexityLoss
 import Linglib.Syntax.Minimalist.Merge.Sideward
 import Linglib.Syntax.Minimalist.MinimalPronoun

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2846,6 +2846,7 @@ import Linglib.Syntax.Minimalist.Merge.Internal
 import Linglib.Syntax.Minimalist.Merge.MinimalSearch
 import Linglib.Syntax.Minimalist.Merge.MinimalYield
 import Linglib.Syntax.Minimalist.Merge.MinimalYieldGrading
+import Linglib.Syntax.Minimalist.Merge.MinimalYieldCharacter
 import Linglib.Syntax.Minimalist.Merge.NoComplexityLoss
 import Linglib.Syntax.Minimalist.Merge.Sideward
 import Linglib.Syntax.Minimalist.MinimalPronoun

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -17,6 +17,7 @@ import Linglib.Core.Algebra.PreLie.OudomGuinCircConstruct
 import Linglib.Core.Algebra.PreLie.OudomGuinCircTotal
 import Linglib.Core.Algebra.RootedTree.BMinus
 import Linglib.Core.Algebra.RootedTree.BirkhoffFactorization
+import Linglib.Core.Algebra.RootedTree.BirkhoffLaurent
 import Linglib.Core.Algebra.RootedTree.BirkhoffFactorizationSemiring
 import Linglib.Core.Algebra.RootedTree.ConnesKreimer
 import Linglib.Core.Algebra.RootedTree.Coproduct.Conservation

--- a/Linglib/Core/Algebra/RootedTree/BirkhoffLaurent.lean
+++ b/Linglib/Core/Algebra/RootedTree/BirkhoffLaurent.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Algebra.RootedTree.BirkhoffFactorization
+import Linglib.Core.Algebra.RotaBaxterLaurent
+
+/-!
+# Birkhoff renormalization of Laurent-series characters  `[UPSTREAM]`
+
+The Birkhoff factorization (`BirkhoffFactorization.lean`) of a character `φ : H → A⸨X⸩` from the
+Connes–Kreimer Hopf algebra of nonplanar rooted forests into a ring of Laurent series, with respect
+to the **polar-part Rota–Baxter operator** `rotaBaxterPolar` (`RotaBaxterLaurent.lean`) — the
+minimal-subtraction scheme of Connes–Kreimer renormalization. Two framework-agnostic facts:
+
+* the renormalized part `φ₊ = (1−R)φ̃` always lands in the **nonpolar subring** `A[[t]]`, since `1−R`
+  projects onto it (`polarHahn_birkhoffPlusTree`, `polarHahn_birkhoffPlus_of'`);
+* a character that is already nonpolar on every tree has a **trivial** negative part `φ₋ = 0`
+  (`birkhoffMinusTree_eq_zero_of_nonpolar`) — no divergence to subtract.
+
+These are the algebraic core of [marcolli-chomsky-berwick-2025]'s "Minimal Yield as Birkhoff
+factorization" (§3.5.2); the syntactic interpretation (the Minimal-Yield character and its grading)
+lives downstream in `Syntax/Minimalist/Merge/`.
+
+## Main results
+
+- `birkhoffMinusTree_eq_zero_of_nonpolar`: a nonpolar character has trivial Bogolyubov negative part.
+- `polarHahn_birkhoffPlusTree` / `polarHahn_birkhoffPlus_of'`: the renormalized part is nonpolar.
+
+## References
+
+[marcolli-chomsky-berwick-2025] (§3.5.2, Prop. 3.1.7, Prop. 3.5.6)
+-/
+
+namespace RootedTree.ConnesKreimer
+
+open LaurentSeries
+
+variable {R : Type*} [CommRing R] {α : Type*}
+  (φ : ConnesKreimer R (Nonplanar α) →ₐ[R] LaurentSeries R)
+
+/-! ### A nonpolar character has trivial Bogolyubov negative part -/
+
+/-- If a character `φ` is **nonpolar** on every tree (`R·φ(ofTree T) = 0`), its Bogolyubov negative
+    part under the polar-projection Rota–Baxter operator vanishes: `φ₋(T) = 0`. By strong recursion
+    on `T.depth`: every nontrivial cut's pruned forest contains a subtree of smaller depth, where
+    `φ₋` is `0` by the recursive hypothesis — killing that term — and the trivial cut contributes the
+    nonpolar trunk value `φ(ofTree …)`, so `R` annihilates the whole Bogolyubov preparation. -/
+theorem birkhoffMinusTree_eq_zero_of_nonpolar
+    (hφ : ∀ T : Nonplanar α, polarHahn (φ (ofTree T)) = 0) (T : Nonplanar α) :
+    birkhoffMinusTree φ.toLinearMap rotaBaxterPolar T = 0 := by
+  rw [birkhoffMinusTree_eq_neg_op_prep, birkhoffPrepTree_unfold, neg_eq_zero, map_multiset_sum]
+  apply Multiset.sum_eq_zero
+  intro x hx
+  obtain ⟨y, hy, rfl⟩ := Multiset.mem_map.mp hx
+  obtain ⟨p, hp, rfl⟩ := Multiset.mem_map.mp hy
+  rw [rotaBaxterPolar_op_apply]
+  rcases eq_or_ne p.1 0 with hempty | hne
+  · rw [hempty, Multiset.map_zero, Multiset.prod_zero, one_mul, AlgHom.toLinearMap_apply]
+    exact hφ p.2
+  · obtain ⟨Tᵢ, hTᵢ⟩ := Multiset.exists_mem_of_ne_zero hne
+    rw [Multiset.prod_eq_zero (Multiset.mem_map.mpr
+        ⟨Tᵢ, hTᵢ, birkhoffMinusTree_eq_zero_of_nonpolar hφ Tᵢ⟩), zero_mul, polarHahn_zero]
+termination_by T.depth
+decreasing_by exact cutSummandsN_subtree_depth_lt T p.1 p.2 hp Tᵢ hTᵢ
+
+/-! ### The renormalized part always lands in the nonpolar subring -/
+
+/-- **The renormalized character lands in `A[[t]]`** ([marcolli-chomsky-berwick-2025] Prop. 3.5.6's
+    `ψt,+ : H → DM[[t]]`): for *any* character `φ`, the renormalized part `φ₊(T) = (1−R)(φ̃(T))` is
+    **nonpolar** — `R·φ₊(T) = 0` — because `R` is idempotent, so `φ₊` is in the range of `1 − R`. -/
+theorem polarHahn_birkhoffPlusTree (T : Nonplanar α) :
+    polarHahn (birkhoffPlusTree φ.toLinearMap rotaBaxterPolar T) = 0 := by
+  unfold birkhoffPlusTree
+  rw [rotaBaxterPolar_op_apply, polarHahn_sub_self]
+
+/-- **`φ₊ : H → A[[t]]` on every workspace** (Prop. 3.5.6, forest level): the renormalized character
+    is nonpolar on each forest basis element, being the product of the nonpolar per-tree renormalized
+    parts (the nonpolar series form a subalgebra). -/
+theorem polarHahn_birkhoffPlus_of' (F : Forest (Nonplanar α)) :
+    polarHahn (birkhoffPlus φ.toLinearMap rotaBaxterPolar (of' F)) = 0 := by
+  rw [birkhoffPlus_apply_of']
+  induction F using Multiset.induction with
+  | empty => rw [Multiset.map_zero, Multiset.prod_zero, polarHahn_one]
+  | cons T F ih =>
+    rw [Multiset.map_cons, Multiset.prod_cons]
+    exact polarHahn_mul _ _ (polarHahn_birkhoffPlusTree φ T) ih
+
+end RootedTree.ConnesKreimer

--- a/Linglib/Core/Algebra/RotaBaxterLaurent.lean
+++ b/Linglib/Core/Algebra/RotaBaxterLaurent.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Algebra.RotaBaxter
+import Mathlib.RingTheory.LaurentSeries
+
+/-!
+# The polar-part Rota–Baxter operator on Laurent series  `[UPSTREAM]`
+
+The **prototype** Rota–Baxter operator of weight `-1` ([marcolli-chomsky-berwick-2025] Prop. 3.5.2,
+eq. (3.5.4)) — the minimal-subtraction operator of Connes–Kreimer renormalization in physics. On the
+Laurent series `LaurentSeries A = HahnSeries ℤ A`, the projection onto the **polar part** (the
+strictly-negative-degree coefficients),
+
+  `R(Σ aᵢ tⁱ) = Σ_{i < 0} aᵢ tⁱ`,
+
+is a Rota–Baxter operator of weight `-1`. This realizes the example named in `RotaBaxter.lean`'s
+docstring (the Laurent-series polar projection) and is the operator
+[marcolli-chomsky-berwick-2025] §3.5.2 use to recast Minimal Yield as a Birkhoff factorization
+(Sideward Merge appears as the polar/divergent part, removed by the renormalized character).
+
+The Rota–Baxter identity is proved from the splitting `LaurentSeries A = R ⊕ (1 − R)` into the two
+**subalgebras** of polar (support `< 0`) and non-polar (support `≥ 0`) series: `R` fixes products of
+polar parts and kills products of non-polar parts, because `support (x * y) ⊆ support x + support y`
+(`HahnSeries.support_mul_subset`).
+
+## Implementation notes
+
+The lemmas are stated at the *coefficient function* level (`polarHahn`, not a packaged `LinearMap`)
+and the `op` field of `rotaBaxterPolar` is constructed **inline**, so its module is the expected
+`Algebra.toModule` rather than `HahnSeries.instModule`. This avoids the `Module`-instance diamond on
+`LaurentSeries A` (the two modules are defeq but distinct *terms*, and reconciling them runs `isDefEq`
+through the noncomputable Laurent multiplication) — the same way mathlib proves the `HahnSeries` ring
+axioms directly at the coefficient level rather than by transporting packaged maps.
+
+## Main definitions
+
+- `LaurentSeries.polarHahn`: the polar projection on coefficients.
+- `LaurentSeries.rotaBaxterPolar`: the weight-`-1` Rota–Baxter operator structure.
+
+## References
+
+[marcolli-chomsky-berwick-2025] (Prop. 3.5.2, eq. (3.5.4))
+-/
+
+namespace LaurentSeries
+
+variable {k A : Type*} [CommRing k] [CommRing A] [Algebra k A]
+
+/-- The coefficient function of the polar part: keep the strictly-negative degrees. -/
+private def polarCoeff (s : LaurentSeries A) : ℤ → A := fun i => if i < 0 then s.coeff i else 0
+
+private theorem polarCoeff_support_subset (s : LaurentSeries A) :
+    Function.support (polarCoeff s) ⊆ Function.support s.coeff := fun i hi => by
+  simp only [polarCoeff, Function.mem_support] at hi ⊢
+  exact fun h => hi (by simp [h])
+
+/-- The **polar part** of a Laurent series: the strictly-negative-degree part
+    ([marcolli-chomsky-berwick-2025] eq. (3.5.4)). -/
+def polarHahn (s : LaurentSeries A) : LaurentSeries A where
+  coeff := polarCoeff s
+  isPWO_support' := s.isPWO_support'.mono (polarCoeff_support_subset s)
+
+@[simp] theorem coeff_polarHahn (s : LaurentSeries A) (i : ℤ) :
+    (polarHahn s).coeff i = if i < 0 then s.coeff i else 0 := rfl
+
+theorem polarHahn_add (x y : LaurentSeries A) :
+    polarHahn (x + y) = polarHahn x + polarHahn y :=
+  HahnSeries.coeff_inj.mp <| funext fun i => by
+    simp only [coeff_polarHahn, HahnSeries.coeff_add]; split_ifs <;> simp
+
+theorem polarHahn_sub (x y : LaurentSeries A) :
+    polarHahn (x - y) = polarHahn x - polarHahn y :=
+  HahnSeries.coeff_inj.mp <| funext fun i => by
+    simp only [coeff_polarHahn, HahnSeries.coeff_sub]; split_ifs <;> simp
+
+/-! ### The two subalgebras of the splitting -/
+
+/-- `R` fixes a series supported on strictly-negative degrees. -/
+theorem polarHahn_eq_self (s : LaurentSeries A) (h : ∀ i : ℤ, 0 ≤ i → s.coeff i = 0) :
+    polarHahn s = s :=
+  HahnSeries.coeff_inj.mp <| funext fun i => by
+    rw [coeff_polarHahn]; split_ifs with hlt
+    · rfl
+    · exact (h i (not_lt.mp hlt)).symm
+
+/-- `R` kills a series supported on non-negative degrees. -/
+theorem polarHahn_eq_zero (s : LaurentSeries A) (h : ∀ i : ℤ, i < 0 → s.coeff i = 0) :
+    polarHahn s = 0 :=
+  HahnSeries.coeff_inj.mp <| funext fun i => by
+    rw [coeff_polarHahn, HahnSeries.coeff_zero]; split_ifs with hlt
+    · exact h i hlt
+    · rfl
+
+/-- The polar part is supported on strictly-negative degrees. -/
+theorem support_polarHahn_subset (s : LaurentSeries A) :
+    (polarHahn s).support ⊆ {i : ℤ | i < 0} := fun i hi => by
+  rw [HahnSeries.mem_support, coeff_polarHahn] at hi
+  show i < 0
+  by_contra h
+  rw [if_neg h] at hi
+  exact hi rfl
+
+/-- The complementary part `1 − R` is supported on non-negative degrees. -/
+theorem support_sub_polarHahn_subset (s : LaurentSeries A) :
+    (s - polarHahn s).support ⊆ {i : ℤ | 0 ≤ i} := fun i hi => by
+  rw [HahnSeries.mem_support, HahnSeries.coeff_sub, coeff_polarHahn] at hi
+  show 0 ≤ i
+  by_contra h
+  rw [if_pos (not_le.mp h), sub_self] at hi
+  exact hi rfl
+
+/-- A product of polar parts has no non-negative-degree coefficients (the polar series form a
+    subalgebra). -/
+theorem polarMul_coeff_eq_zero_of_nonneg (a b : LaurentSeries A) {i : ℤ} (hi : 0 ≤ i) :
+    (polarHahn a * polarHahn b).coeff i = 0 := by
+  by_contra hne
+  obtain ⟨j, hj, l, hl, hjl⟩ :=
+    Set.mem_add.mp (HahnSeries.support_mul_subset ((HahnSeries.mem_support _ _).mpr hne))
+  have hj' := support_polarHahn_subset a hj
+  have hl' := support_polarHahn_subset b hl
+  simp only [Set.mem_setOf_eq] at hj' hl'
+  omega
+
+/-- A product of non-polar parts has no strictly-negative-degree coefficients (the non-polar series
+    form a subalgebra). -/
+theorem coPolarMul_coeff_eq_zero_of_neg (a b : LaurentSeries A) {i : ℤ} (hi : i < 0) :
+    ((a - polarHahn a) * (b - polarHahn b)).coeff i = 0 := by
+  by_contra hne
+  obtain ⟨j, hj, l, hl, hjl⟩ :=
+    Set.mem_add.mp (HahnSeries.support_mul_subset ((HahnSeries.mem_support _ _).mpr hne))
+  have hj' := support_sub_polarHahn_subset a hj
+  have hl' := support_sub_polarHahn_subset b hl
+  simp only [Set.mem_setOf_eq] at hj' hl'
+  omega
+
+/-! ### The Rota–Baxter operator -/
+
+/-- **The polar-projection Rota–Baxter identity** (weight `-1`, sub-form)
+    ([marcolli-chomsky-berwick-2025] Prop. 3.5.2): `R(a)R(b) = R(R(a)b + aR(b) − ab)`, from the ring
+    identity `R(a)b + aR(b) − ab = R(a)R(b) − (a−R(a))(b−R(b))` and the splitting into the two
+    subalgebras (`R` fixes `R(a)R(b)`, kills `(a−R(a))(b−R(b))`). -/
+theorem polarHahn_rotaBaxter (a b : LaurentSeries A) :
+    polarHahn a * polarHahn b = polarHahn (polarHahn a * b + a * polarHahn b - a * b) := by
+  have key : polarHahn a * b + a * polarHahn b - a * b
+           = polarHahn a * polarHahn b - (a - polarHahn a) * (b - polarHahn b) := by ring
+  rw [key, polarHahn_sub,
+    polarHahn_eq_self _ (fun i hi => polarMul_coeff_eq_zero_of_nonneg a b hi),
+    polarHahn_eq_zero _ (fun i hi => coPolarMul_coeff_eq_zero_of_neg a b hi), sub_zero]
+
+/-- The coefficient of `algebraMap c * y`: the `LaurentSeries` algebra map (resolved via
+    `HahnSeries.powerSeriesAlgebra`, `k → PowerSeries A → LaurentSeries A`) is the constant series
+    `single 0 (algebraMap k A c)`, so the action is coefficient-wise. -/
+private theorem coeff_algebraMap_mul (c : k) (y : LaurentSeries A) (i : ℤ) :
+    (algebraMap k (LaurentSeries A) c * y).coeff i = algebraMap k A c * y.coeff i := by
+  have e : algebraMap k (LaurentSeries A) c = HahnSeries.single 0 (algebraMap k A c) := by
+    rw [HahnSeries.algebraMap_apply', PowerSeries.algebraMap_apply, HahnSeries.ofPowerSeries_C,
+      HahnSeries.C_apply]
+  rw [e, HahnSeries.coeff_single_zero_mul]
+
+/-- **The polar projection is a Rota–Baxter operator of weight `-1`** on `LaurentSeries A`
+    ([marcolli-chomsky-berwick-2025] Prop. 3.5.2): the prototype minimal-subtraction operator. The
+    `op` linear map is built inline with `letI := Algebra.toModule` to pin the expected module (see
+    the implementation note); `map_smul'` is then over the algebra action `c • x = algebraMap c * x`. -/
+noncomputable def rotaBaxterPolar : RotaBaxter k (LaurentSeries A) (-1) where
+  op := by
+    letI : Module k (LaurentSeries A) := Algebra.toModule
+    exact
+    { toFun := polarHahn
+      map_add' := polarHahn_add
+      map_smul' := fun c x => by
+        refine HahnSeries.coeff_inj.mp (funext fun i => ?_)
+        rw [coeff_polarHahn, RingHom.id_apply, Algebra.smul_def, Algebra.smul_def,
+          coeff_algebraMap_mul, coeff_algebraMap_mul, coeff_polarHahn]
+        split_ifs <;> ring }
+  rotaBaxter a b := by
+    letI : Module k (LaurentSeries A) := Algebra.toModule
+    simp only [LinearMap.coe_mk, AddHom.coe_mk]
+    rw [neg_one_smul, ← sub_eq_add_neg]
+    exact polarHahn_rotaBaxter a b
+
+end LaurentSeries

--- a/Linglib/Core/Algebra/RotaBaxterLaurent.lean
+++ b/Linglib/Core/Algebra/RotaBaxterLaurent.lean
@@ -66,6 +66,9 @@ def polarHahn (s : LaurentSeries A) : LaurentSeries A where
 @[simp] theorem coeff_polarHahn (s : LaurentSeries A) (i : ℤ) :
     (polarHahn s).coeff i = if i < 0 then s.coeff i else 0 := rfl
 
+@[simp] theorem polarHahn_zero : polarHahn (0 : LaurentSeries A) = 0 :=
+  HahnSeries.coeff_inj.mp <| funext fun i => by simp only [coeff_polarHahn]; split_ifs <;> rfl
+
 theorem polarHahn_add (x y : LaurentSeries A) :
     polarHahn (x + y) = polarHahn x + polarHahn y :=
   HahnSeries.coeff_inj.mp <| funext fun i => by
@@ -180,5 +183,9 @@ noncomputable def rotaBaxterPolar : RotaBaxter k (LaurentSeries A) (-1) where
     simp only [LinearMap.coe_mk, AddHom.coe_mk]
     rw [neg_one_smul, ← sub_eq_add_neg]
     exact polarHahn_rotaBaxter a b
+
+@[simp] theorem rotaBaxterPolar_op_apply (s : LaurentSeries A) :
+    (rotaBaxterPolar (k := k)).op s = polarHahn s := by
+  simp only [rotaBaxterPolar, LinearMap.coe_mk, AddHom.coe_mk]
 
 end LaurentSeries

--- a/Linglib/Core/Algebra/RotaBaxterLaurent.lean
+++ b/Linglib/Core/Algebra/RotaBaxterLaurent.lean
@@ -79,6 +79,16 @@ theorem polarHahn_sub (x y : LaurentSeries A) :
   HahnSeries.coeff_inj.mp <| funext fun i => by
     simp only [coeff_polarHahn, HahnSeries.coeff_sub]; split_ifs <;> simp
 
+/-- `R` is **idempotent**: projecting onto the polar part twice is projecting once. -/
+@[simp] theorem polarHahn_polarHahn (s : LaurentSeries A) :
+    polarHahn (polarHahn s) = polarHahn s :=
+  HahnSeries.coeff_inj.mp <| funext fun i => by simp only [coeff_polarHahn]; split_ifs <;> rfl
+
+/-- The complement `(1 − R) s = s − R s` is **nonpolar**: `R` annihilates it. So `1 − R` projects
+    onto the nonpolar subring `DM[[t]]`. -/
+@[simp] theorem polarHahn_sub_self (s : LaurentSeries A) : polarHahn (s - polarHahn s) = 0 := by
+  rw [polarHahn_sub, polarHahn_polarHahn, sub_self]
+
 /-! ### The two subalgebras of the splitting -/
 
 /-- `R` fixes a series supported on strictly-negative degrees. -/
@@ -96,6 +106,31 @@ theorem polarHahn_eq_zero (s : LaurentSeries A) (h : ∀ i : ℤ, i < 0 → s.co
     rw [coeff_polarHahn, HahnSeries.coeff_zero]; split_ifs with hlt
     · exact h i hlt
     · rfl
+
+/-- `1 = t⁰` is nonpolar. -/
+@[simp] theorem polarHahn_one : polarHahn (1 : LaurentSeries A) = 0 :=
+  polarHahn_eq_zero _ fun i hi => by rw [HahnSeries.coeff_one, if_neg (by omega)]
+
+/-- A nonpolar series (`R s = 0`) is supported on non-negative degrees. -/
+theorem support_subset_nonneg (s : LaurentSeries A) (hs : polarHahn s = 0) :
+    s.support ⊆ {i : ℤ | 0 ≤ i} := fun i hi => by
+  show 0 ≤ i
+  by_contra h
+  have hc : s.coeff i = (polarHahn s).coeff i := by rw [coeff_polarHahn, if_pos (not_le.mp h)]
+  rw [hs, HahnSeries.coeff_zero] at hc
+  exact (HahnSeries.mem_support _ _).mp hi hc
+
+/-- The **nonpolar series form a subalgebra**: a product of nonpolar series is nonpolar. -/
+theorem polarHahn_mul (a b : LaurentSeries A) (ha : polarHahn a = 0) (hb : polarHahn b = 0) :
+    polarHahn (a * b) = 0 :=
+  polarHahn_eq_zero _ fun i hi => by
+    by_contra hne
+    obtain ⟨j, hj, l, hl, hjl⟩ :=
+      Set.mem_add.mp (HahnSeries.support_mul_subset ((HahnSeries.mem_support _ _).mpr hne))
+    have hja := support_subset_nonneg a ha hj
+    have hlb := support_subset_nonneg b hb hl
+    simp only [Set.mem_setOf_eq] at hja hlb
+    omega
 
 /-- The polar part is supported on strictly-negative degrees. -/
 theorem support_polarHahn_subset (s : LaurentSeries A) :

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldBirkhoff.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldBirkhoff.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Minimalist.Merge.MinimalYieldCharacter
+import Linglib.Core.Algebra.RootedTree.BirkhoffFactorization
+
+/-!
+# Birkhoff renormalization of the Minimal-Yield character (MCB Prop. 3.5.6)
+[marcolli-chomsky-berwick-2025] §3.5.2.2
+
+The payoff of MCB §3.5.2: the Birkhoff factorization of a Minimal-Yield character with respect to the
+polar-part Rota–Baxter operator (`rotaBaxterPolar`, the Phase-1 minimal-subtraction operator)
+renormalizes it — the Bogolyubov negative part `φ₋` is the divergent (Sideward) content subtracted.
+
+For the **simple** character `ϕt = gradingChar` (MCB Prop. 3.5.3), Lemma 3.5.5 says `ϕt` is entirely
+nonpolar; we make this concrete in the Birkhoff language: **`birkhoffMinusTree(ϕt) = 0`** — there is
+no divergence to subtract, so `ϕt` is its own renormalization. This is *exactly why* `ϕt` cannot
+separate Internal/External from Sideward Merge (MCB's remark after Lemma 3.5.5): one must instead use
+the intermediate-derivation character `ψt` (Cor. 3.5.4, eq. 3.5.7), whose nontrivial polar part the
+**full** Birkhoff factorization — not plain `1 − R`, since `R` is a Rota–Baxter operator and *not* an
+algebra homomorphism — eliminates (Prop. 3.5.6). Building `ψt` (a sum over all intermediate
+derivation pairs `(F, F')`) is left to future work; the renormalization machinery and the `ϕt` base
+case are here.
+
+## Main results
+
+- `birkhoffMinusTree_eq_zero_of_nonpolar`: a nonpolar character has trivial Bogolyubov negative part.
+- `birkhoffMinusTree_gradingChar`: `ϕt` is trivially renormalized (Lemma 3.5.5, Birkhoff form).
+- `renormGradingChar` / `birkhoffFactorization_gradingChar`: the renormalized character `ϕt,+` and
+  its factorization `ϕt,+ = ϕt,− ⋆ ϕt`.
+
+## References
+
+[marcolli-chomsky-berwick-2025] (Prop. 3.5.3, Lemma 3.5.5, Prop. 3.5.6; Prop. 3.1.7)
+-/
+
+namespace Minimalist.Merge
+
+open RootedTree RootedTree.ConnesKreimer LaurentSeries
+open scoped TensorProduct
+
+variable {α : Type*} {R : Type*} [CommRing R]
+
+/-! ### A nonpolar character has trivial Bogolyubov negative part -/
+
+/-- If a character `φ` is **nonpolar** on every tree (`R·φ(T) = 0`), its Bogolyubov negative part
+    under the polar-projection Rota–Baxter operator vanishes: `φ₋(T) = 0`. By strong recursion on
+    `T.depth`: every nontrivial cut's pruned forest contains a subtree of smaller depth, where `φ₋`
+    is `0` by the recursive hypothesis — killing that term — and the trivial cut contributes the
+    nonpolar trunk value `φ(ofTree …)`, so `R` annihilates the whole Bogolyubov preparation. -/
+theorem birkhoffMinusTree_eq_zero_of_nonpolar
+    (φ : ConnesKreimer R (Nonplanar α) →ₐ[R] LaurentSeries R)
+    (hφ : ∀ T : Nonplanar α, polarHahn (φ (ofTree T)) = 0)
+    (T : Nonplanar α) :
+    birkhoffMinusTree φ.toLinearMap rotaBaxterPolar T = 0 := by
+  rw [birkhoffMinusTree_eq_neg_op_prep, birkhoffPrepTree_unfold, neg_eq_zero, map_multiset_sum]
+  apply Multiset.sum_eq_zero
+  intro x hx
+  obtain ⟨y, hy, rfl⟩ := Multiset.mem_map.mp hx
+  obtain ⟨p, hp, rfl⟩ := Multiset.mem_map.mp hy
+  rw [rotaBaxterPolar_op_apply]
+  rcases eq_or_ne p.1 0 with hempty | hne
+  · rw [hempty, Multiset.map_zero, Multiset.prod_zero, one_mul, AlgHom.toLinearMap_apply]
+    exact hφ p.2
+  · obtain ⟨Tᵢ, hTᵢ⟩ := Multiset.exists_mem_of_ne_zero hne
+    rw [Multiset.prod_eq_zero (Multiset.mem_map.mpr
+        ⟨Tᵢ, hTᵢ, birkhoffMinusTree_eq_zero_of_nonpolar φ hφ Tᵢ⟩), zero_mul, polarHahn_zero]
+termination_by T.depth
+decreasing_by exact cutSummandsN_subtree_depth_lt T p.1 p.2 hp Tᵢ hTᵢ
+
+/-! ### ϕt is trivially renormalized (MCB Lemma 3.5.5, Birkhoff form) -/
+
+/-- **`ϕt` is its own renormalization** (MCB Lemma 3.5.5 in Birkhoff form): the Bogolyubov negative
+    part of the Minimal-Yield character `ϕt = gradingChar` vanishes on every tree, because `ϕt` is
+    nonpolar (`polarHahn_gradingChar_ofTree`). There is no divergence to subtract — which is why `ϕt`
+    cannot detect Sideward Merge. -/
+theorem birkhoffMinusTree_gradingChar (T : Nonplanar α) :
+    birkhoffMinusTree (gradingChar (R := R)).toLinearMap rotaBaxterPolar T = 0 :=
+  birkhoffMinusTree_eq_zero_of_nonpolar gradingChar (fun T => polarHahn_gradingChar_ofTree T) T
+
+/-! ### The renormalized character -/
+
+/-- The renormalized Minimal-Yield character `ϕt,+ = (1−R)ϕ̃t = birkhoffPlus(ϕt)`. -/
+noncomputable def renormGradingChar : ConnesKreimer R (Nonplanar α) →ₐ[R] LaurentSeries R :=
+  birkhoffPlus (gradingChar (R := R)).toLinearMap rotaBaxterPolar
+
+/-- **`ϕt,+ = ϕ̃t`** on every tree: since `ϕt` carries no divergence (`birkhoffMinusTree_gradingChar`),
+    the renormalized part of `ϕt` equals its Bogolyubov preparation — nothing is subtracted. The
+    Birkhoff factorization does no work on `ϕt`, the concrete form of MCB Lemma 3.5.5. -/
+theorem birkhoffPlusTree_gradingChar (T : Nonplanar α) :
+    birkhoffPlusTree (gradingChar (R := R)).toLinearMap rotaBaxterPolar T
+      = birkhoffPrepTree (gradingChar (R := R)).toLinearMap rotaBaxterPolar T := by
+  rw [birkhoffPlusTree_eq_prep_add_minus, birkhoffMinusTree_gradingChar, add_zero]
+
+end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldBirkhoff.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldBirkhoff.lean
@@ -4,71 +4,40 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Syntax.Minimalist.Merge.MinimalYieldCharacter
-import Linglib.Core.Algebra.RootedTree.BirkhoffFactorization
+import Linglib.Core.Algebra.RootedTree.BirkhoffLaurent
 
 /-!
 # Birkhoff renormalization of the Minimal-Yield character (MCB Prop. 3.5.6)
 [marcolli-chomsky-berwick-2025] §3.5.2.2
 
-The payoff of MCB §3.5.2: the Birkhoff factorization of a Minimal-Yield character with respect to the
-polar-part Rota–Baxter operator (`rotaBaxterPolar`, the Phase-1 minimal-subtraction operator)
-renormalizes it — the Bogolyubov negative part `φ₋` is the divergent (Sideward) content subtracted.
+The payoff of MCB §3.5.2, instantiating the framework-agnostic Birkhoff-renormalization machinery of
+`Core/Algebra/RootedTree/BirkhoffLaurent.lean` at the **Minimal-Yield character** `ϕt = gradingChar`.
 
-For the **simple** character `ϕt = gradingChar` (MCB Prop. 3.5.3), Lemma 3.5.5 says `ϕt` is entirely
-nonpolar; we make this concrete in the Birkhoff language: **`birkhoffMinusTree(ϕt) = 0`** — there is
-no divergence to subtract, so `ϕt` is its own renormalization. This is *exactly why* `ϕt` cannot
-separate Internal/External from Sideward Merge (MCB's remark after Lemma 3.5.5): one must instead use
-the intermediate-derivation character `ψt` (Cor. 3.5.4, eq. 3.5.7), whose nontrivial polar part the
-**full** Birkhoff factorization — not plain `1 − R`, since `R` is a Rota–Baxter operator and *not* an
-algebra homomorphism — eliminates (Prop. 3.5.6). Building `ψt` (a sum over all intermediate
-derivation pairs `(F, F')`) is left to future work; the renormalization machinery and the `ϕt` base
-case are here.
+By Lemma 3.5.5, `ϕt` is entirely nonpolar; in the Birkhoff language this means
+**`birkhoffMinusTree(ϕt) = 0`** — there is no divergence to subtract, so `ϕt` is its own
+renormalization. This is *exactly why* `ϕt` cannot separate Internal/External from Sideward Merge:
+one must instead use the intermediate-derivation character `ψt` (Cor. 3.5.4, eq. 3.5.7), whose
+nontrivial polar part the **full** Birkhoff factorization — not plain `1 − R`, since `R` is a
+Rota–Baxter operator and *not* an algebra homomorphism — eliminates (Prop. 3.5.6). The renormalized
+part always lands in the nonpolar subring `DM[[t]]` (`polarHahn_birkhoffPlus_of'`, in Core); for `ψt`
+that is where the polar Sideward content is removed. Building `ψt` (a sum over all intermediate
+derivation pairs `(F, F')`) is left to future work.
 
 ## Main results
 
-- `birkhoffMinusTree_eq_zero_of_nonpolar`: a nonpolar character has trivial Bogolyubov negative part.
 - `birkhoffMinusTree_gradingChar`: `ϕt` is trivially renormalized (Lemma 3.5.5, Birkhoff form).
-- `renormGradingChar` / `birkhoffFactorization_gradingChar`: the renormalized character `ϕt,+` and
-  its factorization `ϕt,+ = ϕt,− ⋆ ϕt`.
+- `renormGradingChar`: the renormalized Minimal-Yield character `ϕt,+`.
 
 ## References
 
-[marcolli-chomsky-berwick-2025] (Prop. 3.5.3, Lemma 3.5.5, Prop. 3.5.6; Prop. 3.1.7)
+[marcolli-chomsky-berwick-2025] (Prop. 3.5.3, Lemma 3.5.5, Prop. 3.5.6)
 -/
 
 namespace Minimalist.Merge
 
 open RootedTree RootedTree.ConnesKreimer LaurentSeries
-open scoped TensorProduct
 
 variable {α : Type*} {R : Type*} [CommRing R]
-
-/-! ### A nonpolar character has trivial Bogolyubov negative part -/
-
-/-- If a character `φ` is **nonpolar** on every tree (`R·φ(T) = 0`), its Bogolyubov negative part
-    under the polar-projection Rota–Baxter operator vanishes: `φ₋(T) = 0`. By strong recursion on
-    `T.depth`: every nontrivial cut's pruned forest contains a subtree of smaller depth, where `φ₋`
-    is `0` by the recursive hypothesis — killing that term — and the trivial cut contributes the
-    nonpolar trunk value `φ(ofTree …)`, so `R` annihilates the whole Bogolyubov preparation. -/
-theorem birkhoffMinusTree_eq_zero_of_nonpolar
-    (φ : ConnesKreimer R (Nonplanar α) →ₐ[R] LaurentSeries R)
-    (hφ : ∀ T : Nonplanar α, polarHahn (φ (ofTree T)) = 0)
-    (T : Nonplanar α) :
-    birkhoffMinusTree φ.toLinearMap rotaBaxterPolar T = 0 := by
-  rw [birkhoffMinusTree_eq_neg_op_prep, birkhoffPrepTree_unfold, neg_eq_zero, map_multiset_sum]
-  apply Multiset.sum_eq_zero
-  intro x hx
-  obtain ⟨y, hy, rfl⟩ := Multiset.mem_map.mp hx
-  obtain ⟨p, hp, rfl⟩ := Multiset.mem_map.mp hy
-  rw [rotaBaxterPolar_op_apply]
-  rcases eq_or_ne p.1 0 with hempty | hne
-  · rw [hempty, Multiset.map_zero, Multiset.prod_zero, one_mul, AlgHom.toLinearMap_apply]
-    exact hφ p.2
-  · obtain ⟨Tᵢ, hTᵢ⟩ := Multiset.exists_mem_of_ne_zero hne
-    rw [Multiset.prod_eq_zero (Multiset.mem_map.mpr
-        ⟨Tᵢ, hTᵢ, birkhoffMinusTree_eq_zero_of_nonpolar φ hφ Tᵢ⟩), zero_mul, polarHahn_zero]
-termination_by T.depth
-decreasing_by exact cutSummandsN_subtree_depth_lt T p.1 p.2 hp Tᵢ hTᵢ
 
 /-! ### ϕt is trivially renormalized (MCB Lemma 3.5.5, Birkhoff form) -/
 

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldCharacter.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldCharacter.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Minimalist.Merge.MinimalYieldGrading
+import Linglib.Core.Algebra.RootedTree.HopfAlgebraNonplanar
+
+/-!
+# The Minimal-Yield character ϕt : H → Laurent series (MCB Prop. 3.5.3, Lemma 3.5.5)
+[marcolli-chomsky-berwick-2025] §3.5.2.2
+
+The character `ϕt` of MCB Prop. 3.5.3 (eq. 3.5.6) as an **algebra homomorphism** from the Hopf
+algebra `H = ConnesKreimer R (Nonplanar α)` of nonplanar rooted forests to the Laurent-series ring,
+in the **lean t-grading model**: rather than coefficients in the full algebra `DM` of free Merge
+derivations (Def. 3.5.1), we record only the grading `tᵟ`. With `δ = δα`, the grading of the
+canonical construction `L(F) → F` is exactly `α(F) = Forest.alpha F` (the leaves carry `α = 0`), so
+
+  `ϕt(F) = t^{α(F)}`.
+
+Since `α(F) ≥ 0`, `ϕt` lands entirely in the **nonpolar** subring `DM[[t]] = (1 − R)·DM[t⁻¹][[t]]`
+(**MCB Lemma 3.5.5**): `R·ϕt(F) = 0` for every forest `F`. This is exactly why `ϕt` alone cannot
+detect Sideward Merge — the intermediate-derivation character `ψt` (Cor. 3.5.4) and the full Birkhoff
+factorization (Prop. 3.5.6) are needed to separate Internal/External from Sideward Merge.
+
+## Main definitions
+
+- `Minimalist.Merge.gradingChar`: the algebra hom `ϕt : H →ₐ[R] LaurentSeries R`.
+
+## References
+
+[marcolli-chomsky-berwick-2025] (Prop. 3.5.3, eq. 3.5.6, Lemma 3.5.5)
+-/
+
+namespace Minimalist.Merge
+
+open RootedTree RootedTree.ConnesKreimer LaurentSeries
+
+variable {α : Type*} {R : Type*} [CommRing R]
+
+/-! ### `gradeMonomial` is a multiplicative grading -/
+
+@[simp] theorem gradeMonomial_zero : gradeMonomial (A := R) 0 = 1 := rfl
+
+/-- `tᵃ · tᵇ = tᵃ⁺ᵇ`: the grading monomials multiply by adding exponents. -/
+theorem gradeMonomial_mul (a b : ℤ) :
+    gradeMonomial (A := R) a * gradeMonomial b = gradeMonomial (a + b) := by
+  rw [gradeMonomial, gradeMonomial, gradeMonomial, HahnSeries.single_mul_single, one_mul]
+
+/-! ### The character ϕt (MCB Prop. 3.5.3, `δα` grading) -/
+
+/-- The per-tree value of `ϕt`: `t^{α(T)} = t^{accCount T}` (the `δα` grading of `L(T) → T`). -/
+noncomputable def gradingMonomialTree (T : Nonplanar α) : LaurentSeries R :=
+  gradeMonomial (T.accCount : ℤ)
+
+/-- `ϕt` extended multiplicatively to forests (`ϕt(F ⊔ F') = ϕt(F)·ϕt(F')`); mirrors
+    `antipodeMonoidHomN`. -/
+noncomputable def gradingMonoidHom :
+    Multiplicative (Forest (Nonplanar α)) →* LaurentSeries R where
+  toFun F := (F.toAdd.map (gradingMonomialTree (R := R))).prod
+  map_one' := by
+    show ((0 : Forest (Nonplanar α)).map _).prod = 1
+    rw [Multiset.map_zero, Multiset.prod_zero]
+  map_mul' F G := by
+    show ((F.toAdd + G.toAdd).map (gradingMonomialTree (R := R))).prod =
+         (F.toAdd.map _).prod * (G.toAdd.map _).prod
+    rw [Multiset.map_add, Multiset.prod_add]
+
+/-- **The Minimal-Yield character** `ϕt : H →ₐ[R] DM[t⁻¹][[t]]` (MCB Prop. 3.5.3, eq. 3.5.6) in the
+    lean t-grading model. -/
+noncomputable def gradingChar : ConnesKreimer R (Nonplanar α) →ₐ[R] LaurentSeries R :=
+  AddMonoidAlgebra.lift R (LaurentSeries R) (Forest (Nonplanar α)) gradingMonoidHom
+
+@[simp] theorem gradingChar_apply_of' (F : Forest (Nonplanar α)) :
+    gradingChar (R := R) (of' F) = (F.map (gradingMonomialTree (R := R))).prod := by
+  show AddMonoidAlgebra.lift R (LaurentSeries R) (Forest (Nonplanar α)) gradingMonoidHom
+      (AddMonoidAlgebra.of R (Forest (Nonplanar α)) (Multiplicative.ofAdd F)) = _
+  rw [AddMonoidAlgebra.lift_of]
+  rfl
+
+/-- `ϕt(F) = t^{α(F)}`: the forest value is the single grading monomial at the accessible-term
+    count (the product of per-tree monomials collapses since `α` is additive). -/
+theorem prod_gradingMonomialTree (F : Forest (Nonplanar α)) :
+    (F.map (gradingMonomialTree (R := R))).prod = gradeMonomial (Forest.alpha F : ℤ) := by
+  induction F using Multiset.induction with
+  | empty => rw [Multiset.map_zero, Multiset.prod_zero, Forest.alpha_zero]; rfl
+  | cons T F ih =>
+    rw [Multiset.map_cons, Multiset.prod_cons, ih, gradingMonomialTree, gradeMonomial_mul,
+      Forest.alpha_cons]
+    push_cast; rfl
+
+theorem gradingChar_apply_of'_eq (F : Forest (Nonplanar α)) :
+    gradingChar (R := R) (of' F) = gradeMonomial (Forest.alpha F : ℤ) := by
+  rw [gradingChar_apply_of', prod_gradingMonomialTree]
+
+@[simp] theorem gradingChar_apply_ofTree (T : Nonplanar α) :
+    gradingChar (R := R) (ofTree T) = gradeMonomial (T.accCount : ℤ) := by
+  unfold ofTree
+  rw [gradingChar_apply_of', Multiset.map_singleton, Multiset.prod_singleton]
+  rfl
+
+/-! ### MCB Lemma 3.5.5: ϕt is entirely nonpolar -/
+
+/-- **MCB Lemma 3.5.5**: `ϕt(F)` always lies in the nonpolar subring — `R·ϕt(F) = 0` — because the
+    `δα`-grading `α(F) ≥ 0`. Hence `ϕt` cannot detect Sideward Merge (regardless of which Merge
+    operations build `F`), motivating the intermediate-derivation character `ψt`. -/
+theorem polarHahn_gradingChar_of' (F : Forest (Nonplanar α)) :
+    polarHahn (gradingChar (R := R) (of' F)) = 0 := by
+  rw [gradingChar_apply_of'_eq, polarHahn_gradeMonomial,
+    if_neg (by omega : ¬ ((Forest.alpha F : ℤ) < 0))]
+
+/-- Lemma 3.5.5 on a single tree: `R·ϕt(T) = 0`. -/
+theorem polarHahn_gradingChar_ofTree (T : Nonplanar α) :
+    polarHahn (gradingChar (R := R) (ofTree T)) = 0 := by
+  rw [gradingChar_apply_ofTree, polarHahn_gradeMonomial,
+    if_neg (by omega : ¬ ((T.accCount : ℤ) < 0))]
+
+end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldGrading.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldGrading.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Minimalist.Merge.MinimalYield
+import Linglib.Core.Algebra.RotaBaxterLaurent
+
+/-!
+# The δ-grading of Minimal Yield and the polar part (MCB §3.5.2.1)
+[marcolli-chomsky-berwick-2025] §3.5.2.1, book p. 267
+
+MCB's §3.5.2 recasts Minimal Yield (Def. 1.6.1) as a Birkhoff factorization in a ring of **Laurent
+series** `DM[t⁻¹][[t]]` with coefficients in the algebra of free Merge derivations, weighting each
+derivation `F → F'` by `tᵟ` for a **grading** `δ ∈ {δb₀, δα, δσ}`. This file is the grading layer
+between `MinimalYield.lean`'s size measures `b₀/α/σ` and the polar-part Rota–Baxter operator
+`LaurentSeries.polarHahn` of `RotaBaxterLaurent.lean` (MCB Prop. 3.5.2).
+
+The signed deltas (MCB §3.5.2.1) of a transformation `F → F'`:
+
+  `δb₀ = b₀ F − b₀ F'`,  `δα = α F' − α F`,  `δσ = σ F' − σ F`,
+
+with `σ = b₀ + α` giving `δσ = δα − δb₀`. Minimal Yield (Def. 1.6.1) is exactly
+`δb₀ ≥ 0 ∧ δα ≥ 0 ∧ δσ = 1` (no divergence / no information loss / minimality of yield).
+
+The bridge to the polar projection: a derivation graded `tᵟ` lands in the **polar** part (`δ < 0`,
+fixed by `R = polarHahn`, the divergent part Birkhoff factorization removes) iff its grading is
+negative. Minimal-Yield-respecting steps (External/Internal Merge) have `δ ≥ 0`, hence **nonpolar**
+(the per-merge shadow of MCB Lemma 3.5.5); the divergent Sideward Merge steps 3(a)/3(b) have
+`δb₀ = −1 < 0`, hence **polar** — the derivations MCB Prop. 3.5.6's factorization eliminates.
+
+## Main definitions
+
+- `Minimalist.Merge.δb₀ / δα / δσ`: the signed `ℤ`-valued gradings.
+- `Minimalist.Merge.gradeMonomial`: the Laurent monomial `tᵈ` whose polarity tracks `d`.
+
+## References
+
+[marcolli-chomsky-berwick-2025] (§3.5.2.1, Prop. 3.5.2, Lemma 3.5.5, Prop. 3.5.6)
+-/
+
+namespace Minimalist.Merge
+
+open RootedTree LaurentSeries
+
+variable {α β : Type*}
+
+/-! ### The δ-grading (MCB §3.5.2.1) -/
+
+/-- `δb₀ = b₀ F − b₀ F'` (MCB §3.5.2.1): divergence; `≥ 0` is "no divergence". -/
+def δb₀ (F F' : Forest (Nonplanar (α ⊕ β))) : ℤ := (Forest.b₀ F : ℤ) - Forest.b₀ F'
+
+/-- `δα = α F' − α F` (MCB §3.5.2.1): information gain; `≥ 0` is "no information loss". -/
+def δα (F F' : Forest (Nonplanar (α ⊕ β))) : ℤ := (Forest.alpha F' : ℤ) - Forest.alpha F
+
+/-- `δσ = σ F' − σ F` (MCB §3.5.2.1): yield; `= 1` is "minimality of yield". -/
+def δσ (F F' : Forest (Nonplanar (α ⊕ β))) : ℤ := (Forest.sigma F' : ℤ) - Forest.sigma F
+
+/-- The grading consistency relation `δσ = δα − δb₀`, from `σ = b₀ + α`. -/
+theorem δσ_eq (F F' : Forest (Nonplanar (α ⊕ β))) : δσ F F' = δα F F' - δb₀ F F' := by
+  simp only [δσ, δα, δb₀, Forest.sigma]; push_cast; ring
+
+/-! ### Minimal Yield as the grading conditions (MCB §3.5.2.1) -/
+
+/-- Weak Minimal Yield is exactly `δb₀ ≥ 0 ∧ δα ≥ 0` (MCB §3.5.2.1, "no divergence / no
+    information loss"). -/
+theorem minimalYieldWeak_iff (F F' : Forest (Nonplanar (α ⊕ β))) :
+    MinimalYieldWeak F F' ↔ 0 ≤ δb₀ F F' ∧ 0 ≤ δα F F' := by
+  simp only [δb₀, δα]
+  constructor
+  · rintro ⟨hb, ha⟩; exact ⟨by omega, by omega⟩
+  · rintro ⟨hb, ha⟩; exact ⟨by omega, by omega⟩
+
+/-- Minimal Yield is exactly `δb₀ ≥ 0 ∧ δα ≥ 0 ∧ δσ = 1` (MCB §3.5.2.1). -/
+theorem minimalYield_iff (F F' : Forest (Nonplanar (α ⊕ β))) :
+    MinimalYield F F' ↔ 0 ≤ δb₀ F F' ∧ 0 ≤ δα F F' ∧ δσ F F' = 1 := by
+  constructor
+  · intro h
+    obtain ⟨hb, ha⟩ := (minimalYieldWeak_iff F F').mp h.toMinimalYieldWeak
+    have hs := h.minimalYield
+    exact ⟨hb, ha, by simp only [δσ]; omega⟩
+  · rintro ⟨hb, ha, hs⟩
+    refine ⟨(minimalYieldWeak_iff F F').mpr ⟨hb, ha⟩, ?_⟩
+    simp only [δσ] at hs; omega
+
+/-! ### The grading monomial and the polar part (bridge to MCB Prop. 3.5.2) -/
+
+variable {A : Type*} [CommRing A]
+
+/-- The Laurent grading monomial `tᵈ` (MCB eq. 3.5.6, coefficient `1`): a derivation graded by `d`
+    contributes `tᵈ` to the Laurent-series character. -/
+noncomputable def gradeMonomial (d : ℤ) : LaurentSeries A := HahnSeries.single d 1
+
+/-- A graded monomial is **polar** (fixed by `R = polarHahn`) iff its grading is negative, and is
+    annihilated by `R` otherwise — the divergent/convergent split of MCB Prop. 3.5.2. -/
+theorem polarHahn_gradeMonomial (d : ℤ) :
+    polarHahn (gradeMonomial (A := A) d) = if d < 0 then gradeMonomial d else 0 := by
+  unfold gradeMonomial
+  split_ifs with hd
+  · exact polarHahn_eq_self _ fun i hi => HahnSeries.coeff_single_of_ne (by omega)
+  · exact polarHahn_eq_zero _ fun i hi => HahnSeries.coeff_single_of_ne (by omega)
+
+/-! ### Per-merge polarity: Minimal Yield is nonpolar, divergent Sideward is polar -/
+
+/-- A weak-Minimal-Yield step is **nonpolar** in the `δb₀` grading: `R` annihilates its monomial
+    (`δb₀ ≥ 0`). The External/Internal-Merge shadow of MCB Lemma 3.5.5. -/
+theorem polarHahn_gradeMonomial_of_minimalYieldWeak
+    (F F' : Forest (Nonplanar (α ⊕ β))) (h : MinimalYieldWeak F F') :
+    polarHahn (gradeMonomial (A := A) (δb₀ F F')) = 0 := by
+  rw [polarHahn_gradeMonomial, if_neg]
+  obtain ⟨hb, _⟩ := (minimalYieldWeak_iff F F').mp h
+  omega
+
+/-- External Merge is nonpolar (MCB Lemma 3.5.5): `δb₀ = +1 ≥ 0`, so `R` annihilates its monomial. -/
+theorem polarHahn_gradeMonomial_em (lbl : α) (S S' : Nonplanar (α ⊕ β)) :
+    polarHahn (gradeMonomial (A := A)
+        (δb₀ ({S, S'} : Forest (Nonplanar (α ⊕ β))) {Nonplanar.node (Sum.inl lbl) {S, S'}})) = 0 :=
+  polarHahn_gradeMonomial_of_minimalYieldWeak _ _
+    (em_pair_satisfiesMinimalYield lbl S S').toMinimalYieldWeak
+
+/-- Sideward Merge 3(a) has divergent grading `δb₀ = −1` (`b₀` increases by one). -/
+theorem δb₀_sideward_3a (T_i Tnode T_iq : Nonplanar (α ⊕ β)) :
+    δb₀ ({T_i} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq} = -1 := by
+  simp only [δb₀, sideward_3a_b₀_increases T_i Tnode T_iq]; push_cast; ring
+
+/-- Sideward Merge 3(b) has divergent grading `δb₀ = −1` (`b₀` increases by one). -/
+theorem δb₀_sideward_3b (T_i T_j Tnode T_iq T_jq : Nonplanar (α ⊕ β)) :
+    δb₀ ({T_i, T_j} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq, T_jq} = -1 := by
+  simp only [δb₀, sideward_3b_b₀_increases T_i T_j Tnode T_iq T_jq]; push_cast; ring
+
+/-- Sideward Merge 3(a) is **polar** in the `δb₀` grading: `R` fixes its monomial (`δb₀ = −1 < 0`) —
+    the divergent derivation MCB Prop. 3.5.6's Birkhoff factorization eliminates. -/
+theorem polarHahn_gradeMonomial_sideward_3a (T_i Tnode T_iq : Nonplanar (α ⊕ β)) :
+    polarHahn (gradeMonomial (A := A)
+        (δb₀ ({T_i} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq}))
+      = gradeMonomial (δb₀ ({T_i} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq}) := by
+  rw [polarHahn_gradeMonomial, δb₀_sideward_3a, if_pos (by norm_num : (-1 : ℤ) < 0)]
+
+/-- Sideward Merge 3(b) is **polar** in the `δb₀` grading (`δb₀ = −1 < 0`). -/
+theorem polarHahn_gradeMonomial_sideward_3b (T_i T_j Tnode T_iq T_jq : Nonplanar (α ⊕ β)) :
+    polarHahn (gradeMonomial (A := A)
+        (δb₀ ({T_i, T_j} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq, T_jq}))
+      = gradeMonomial (δb₀ ({T_i, T_j} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq, T_jq}) := by
+  rw [polarHahn_gradeMonomial, δb₀_sideward_3b, if_pos (by norm_num : (-1 : ℤ) < 0)]
+
+end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldPsi.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldPsi.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Minimalist.Merge.MinimalYieldGrading
+
+/-!
+# The intermediate-derivation character ψt and Sideward detection (MCB Cor. 3.5.4)
+[marcolli-chomsky-berwick-2025] §3.5.2.2, eq. (3.5.7)
+
+The character `ϕt` of Prop. 3.5.3 only weights the *complete* construction `L(T) → T`, whose grading
+is always `≥ 0` (MCB Lemma 3.5.5) — so `ϕt` is nonpolar and cannot detect Sideward Merge. Cor. 3.5.4
+introduces
+
+  `ψt(T) = Σ_{(F,F') ∈ FT} (F → F') · t^{δ(F→F')}`,
+
+summing over **all intermediate derivation pairs** `(F, F')` in the construction of `T` (forests with
+`L(F) = L(F') = L(T)` lying on some chain `L(T) → ⋯ → F → ⋯ → F' → ⋯ → T`). Since `δ` depends only on
+the endpoints (`δb₀(F→F') = b₀ F − b₀ F'`, etc.), each segment contributes a single grading monomial.
+
+This file is the **lean t-grading model** of `ψt`, parameterized by the multiset of intermediate
+segments `S` (the full `FT`-enumeration engine — derivation reachability for a target — is deferred;
+here `S` is the input). The essential content of Cor. 3.5.4 — and the reason `ψt` succeeds where `ϕt`
+fails — is captured by `polarHahn_psiSeries`: **the polar (divergent) part of `ψt` is exactly the sum
+over its Sideward-divergent segments** (`δb₀ < 0`, where `b₀` increases — MCB's Sideward types
+3(a)/3(b)). A single Sideward segment already makes `ψt` polar (`polarHahn_psiSeries_sideward_3a`),
+which the Birkhoff factorization then renormalizes away (`Core/Algebra/RootedTree/BirkhoffLaurent`).
+
+## Main definitions
+
+- `Minimalist.Merge.psiSeries`: `ψt` as a graded sum over a given segment multiset.
+
+## References
+
+[marcolli-chomsky-berwick-2025] (Cor. 3.5.4, eq. 3.5.7; Lemma 3.5.5; Prop. 3.5.6)
+-/
+
+namespace Minimalist.Merge
+
+open RootedTree LaurentSeries
+
+variable {α β : Type*} {R : Type*} [CommRing R]
+
+/-- A workspace transformation (intermediate derivation segment) `F → F'`. -/
+abbrev Segment (α β : Type*) :=
+  Forest (Nonplanar (α ⊕ β)) × Forest (Nonplanar (α ⊕ β))
+
+/-- **`ψt` in the lean t-grading model** (MCB eq. 3.5.7, `δ = δb₀`): a graded sum `Σ tᵟ` over the
+    multiset `S` of intermediate derivation segments of a target. -/
+noncomputable def psiSeries (S : Multiset (Segment α β)) : LaurentSeries R :=
+  (S.map (fun p => gradeMonomial (δb₀ p.1 p.2))).sum
+
+@[simp] theorem psiSeries_zero : psiSeries (R := R) (0 : Multiset (Segment α β)) = 0 := by
+  simp [psiSeries]
+
+@[simp] theorem psiSeries_cons (p : Segment α β) (S : Multiset (Segment α β)) :
+    psiSeries (R := R) (p ::ₘ S) = gradeMonomial (δb₀ p.1 p.2) + psiSeries S := by
+  simp [psiSeries]
+
+@[simp] theorem psiSeries_singleton (p : Segment α β) :
+    psiSeries (R := R) {p} = gradeMonomial (δb₀ p.1 p.2) := by simp [psiSeries]
+
+@[simp] theorem psiSeries_add (S T : Multiset (Segment α β)) :
+    psiSeries (R := R) (S + T) = psiSeries S + psiSeries T := by
+  simp [psiSeries, Multiset.map_add, Multiset.sum_add]
+
+/-! ### The polar part of ψt is exactly the divergent (Sideward) segments -/
+
+/-- **The polar (divergent) part of `ψt`** (MCB §3.5.2.2): `R·ψt` is the sum of grading monomials
+    over exactly the **Sideward-divergent** segments (`δb₀ < 0`, i.e. `b₀` increases). The polar part
+    detects Sideward Merge — the property `ϕt` lacks (Lemma 3.5.5). -/
+theorem polarHahn_psiSeries (S : Multiset (Segment α β)) :
+    polarHahn (psiSeries (R := R) S) = psiSeries (S.filter (fun p => δb₀ p.1 p.2 < 0)) := by
+  induction S using Multiset.induction with
+  | empty => simp
+  | cons p S ih =>
+    rw [psiSeries_cons, polarHahn_add, ih, polarHahn_gradeMonomial]
+    by_cases h : δb₀ p.1 p.2 < 0 <;> simp [h]
+
+/-- If every intermediate segment respects no-divergence (`δb₀ ≥ 0`), then `ψt` is **nonpolar** —
+    the `ϕt`-like case (a construction using only External/Internal Merge). -/
+theorem polarHahn_psiSeries_eq_zero (S : Multiset (Segment α β))
+    (h : ∀ p ∈ S, 0 ≤ δb₀ p.1 p.2) : polarHahn (psiSeries (R := R) S) = 0 := by
+  rw [polarHahn_psiSeries,
+    Multiset.filter_eq_nil.mpr fun p hp => not_lt.mpr (h p hp), psiSeries_zero]
+
+/-- **The nonpolar projection `(1 − R)·ψt` keeps exactly the non-divergent segments** (`δb₀ ≥ 0` —
+    the External/Internal/Minimal-Yield-respecting derivations). At the level of a single target's
+    series this projection already separates the good derivations from the Sideward-divergent ones;
+    the subtlety MCB Prop. 3.5.6 addresses is that `1 − R` fails to do this on the *character* level
+    (products of series), where the full Birkhoff factorization is needed because `R` is not an
+    algebra homomorphism. -/
+theorem psiSeries_sub_polarHahn (S : Multiset (Segment α β)) :
+    psiSeries (R := R) S - polarHahn (psiSeries S)
+      = psiSeries (S.filter (fun p => ¬ δb₀ p.1 p.2 < 0)) := by
+  have hpart : psiSeries (R := R) S
+      = psiSeries (S.filter (fun p => δb₀ p.1 p.2 < 0))
+        + psiSeries (S.filter (fun p => ¬ δb₀ p.1 p.2 < 0)) := by
+    rw [← psiSeries_add, Multiset.filter_add_not]
+  rw [polarHahn_psiSeries, hpart]; abel
+
+/-- **A single Sideward 3(a) segment already makes `ψt` polar** (`δb₀ = −1`): its whole value is the
+    divergent monomial `t⁻¹`. This is the contrast with `ϕt` (always nonpolar) — `ψt` sees the
+    Sideward Merge, which the Birkhoff factorization then removes. -/
+theorem polarHahn_psiSeries_sideward_3a (T_i Tnode T_iq : Nonplanar (α ⊕ β)) :
+    polarHahn (psiSeries (R := R)
+        {(({T_i} : Forest (Nonplanar (α ⊕ β))), ({Tnode, T_iq} : Forest (Nonplanar (α ⊕ β))))})
+      = gradeMonomial (-1 : ℤ) := by
+  rw [psiSeries, Multiset.map_singleton, Multiset.sum_singleton, δb₀_sideward_3a,
+    polarHahn_gradeMonomial, if_pos (by norm_num : (-1 : ℤ) < 0)]
+
+end Minimalist.Merge


### PR DESCRIPTION
Formalizes MCB §3.5.2 "Minimal Yield as Birkhoff Factorization".

- `Core/Algebra`: polar-part Rota–Baxter operator (Prop. 3.5.2) + generic Birkhoff-Laurent renormalization (φ₊ lands in the nonpolar subring; a nonpolar character has trivial φ₋).
- `Syntax/Minimalist/Merge`: the δ-grading bridge (§3.5.2.1), the ϕt character (nonpolar, Lemma 3.5.5) and its trivial renormalization, and the ψt model whose polar part detects Sideward Merge (Cor. 3.5.4).
- The ψt `FT`-enumeration / ψt-as-character is future work (the segment multiset is an input).