### PR TITLE
refactor(Phonology/Prosody): organize the Syllable API (Sonority, Syllable.Weight)

### DIFF
--- a/Linglib/Fragments/Japanese/Prosody.lean
+++ b/Linglib/Fragments/Japanese/Prosody.lean
@@ -35,7 +35,7 @@ namespace Japanese.Prosody
 
 open Features.Prosody
 open _root_.Prosody (defaultAccentAAR latinStressRule accentToTones
-  LevelTone shortN2CompoundAccent longN2CompoundAccent SyllWeight)
+  LevelTone shortN2CompoundAccent longN2CompoundAccent Syllable.Weight)
 open BeckmanPierrehumbert1986
 
 -- ============================================================================
@@ -312,7 +312,7 @@ theorem si_maintains_kami_contrast :
 structure JLoanwordEntry where
   entry : JProsodicEntry
   /-- Syllable weight profile (left to right) -/
-  weights : List SyllWeight
+  weights : List Syllable.Weight
   deriving Repr
 
 /-- *kurisumasu* 'Christmas' — accent on antepenultimate mora (su).

--- a/Linglib/Phonology/Prosody/Accent.lean
+++ b/Linglib/Phonology/Prosody/Accent.lean
@@ -30,10 +30,10 @@ namespace Prosody
 
 /-- The 0-indexed syllable containing mora `targetMora` (0-indexed), or
     `none` if `targetMora` exceeds the total mora count. -/
-def findSyllable (weights : List SyllWeight) (targetMora : Nat) : Option Nat :=
+def findSyllable (weights : List Syllable.Weight) (targetMora : Nat) : Option Nat :=
   go weights targetMora 0
 where
-  go : List SyllWeight → Nat → Nat → Option Nat
+  go : List Syllable.Weight → Nat → Nat → Option Nat
     | [], _, _ => none
     | w :: ws, target, idx =>
       if target < w.morae then some idx
@@ -44,7 +44,7 @@ where
 /-- The Antepenultimate Accent Rule ([mccawley-1968]): accent the syllable
     containing the antepenultimate (3rd-from-last) mora. Words with fewer than
     three morae accent the initial syllable. Returns the 0-indexed syllable. -/
-def defaultAccentAAR (weights : List SyllWeight) : Option Nat :=
+def defaultAccentAAR (weights : List Syllable.Weight) : Option Nat :=
   match weights with
   | [] => none
   | _ =>
@@ -58,7 +58,7 @@ def defaultAccentAAR (weights : List SyllWeight) : Option Nat :=
     (≥ 2μ), otherwise the antepenult. Monosyllables accent the only syllable;
     disyllables accent the penult (= initial). [kubozono-2006] argues this
     rule fits Japanese default accentuation better than `defaultAccentAAR`. -/
-def latinStressRule : List SyllWeight → Option Nat
+def latinStressRule : List Syllable.Weight → Option Nat
   | [] => none
   | [_] => some 0
   | [_, _] => some 0                    -- disyllable → always penult (= initial)

--- a/Linglib/Phonology/Prosody/Foot.lean
+++ b/Linglib/Phonology/Prosody/Foot.lean
@@ -20,7 +20,7 @@ trochees, final in iambs.
 
 ## Definitions
 
-- `SyllWeight.morae`: mora count from weight class
+- `Syllable.Weight.morae`: mora count from weight class
 - `FootType`: the three canonical foot types
 - `ParseElement`: element in a metrical parse (footed or unfooted)
 - `MetricalParse`: a complete metrical parse of a prosodic domain
@@ -29,7 +29,7 @@ trochees, final in iambs.
 
 namespace Prosody
 
--- `SyllWeight.morae` is now a field accessor — no separate function needed.
+-- `Syllable.Weight.morae` is now a field accessor — no separate function needed.
 
 -- ============================================================================
 -- § 1: Foot Type
@@ -60,9 +60,9 @@ inductive FootType where
     linear order within the prosodic domain. -/
 inductive ParseElement where
   /-- A foot containing one or more syllables (represented by weight). -/
-  | foot : List SyllWeight → ParseElement
+  | foot : List Syllable.Weight → ParseElement
   /-- An unparsed syllable not dominated by any foot. -/
-  | unfooted : SyllWeight → ParseElement
+  | unfooted : Syllable.Weight → ParseElement
   deriving DecidableEq, Repr
 
 /-- A metrical parse: a prosodic domain represented as a linear sequence
@@ -74,11 +74,11 @@ abbrev MetricalParse := List ParseElement
 -- ============================================================================
 
 /-- Extract all feet from a parse. -/
-def MetricalParse.feet (p : MetricalParse) : List (List SyllWeight) :=
+def MetricalParse.feet (p : MetricalParse) : List (List Syllable.Weight) :=
   p.filterMap λ | .foot ws => some ws | .unfooted _ => none
 
 /-- Mora count of a single foot. -/
-def footMorae (ws : List SyllWeight) : Nat :=
+def footMorae (ws : List Syllable.Weight) : Nat :=
   ws.foldl (· + ·.morae) 0
 
 /-- Total syllable count in a parse. -/
@@ -93,10 +93,10 @@ def MetricalParse.unparsedCount (p : MetricalParse) : Nat :=
 
 /-- Is a foot degenerate (subminimal)? A monomoraic foot (L) is
     degenerate — it fails to meet the bimoraic minimum. -/
-def isDegenerate (ws : List SyllWeight) : Prop :=
+def isDegenerate (ws : List Syllable.Weight) : Prop :=
   footMorae ws < 2
 
-instance (ws : List SyllWeight) : Decidable (isDegenerate ws) := by
+instance (ws : List Syllable.Weight) : Decidable (isDegenerate ws) := by
   unfold isDegenerate; infer_instance
 
 /-- Is a foot well-formed for the given foot type?
@@ -108,7 +108,7 @@ instance (ws : List SyllWeight) : Decidable (isDegenerate ws) := by
     monomoraic `(L)`, the left-heavy `(HL)`, and the trimoraic monosyllable
     `(SH)` — the Iambic/Trochaic-Law asymmetry that the moraic-trochee
     clause (`footMorae = 2`) lacks. -/
-def isWellFormedFoot (ft : FootType) (ws : List SyllWeight) : Prop :=
+def isWellFormedFoot (ft : FootType) (ws : List Syllable.Weight) : Prop :=
   match ft with
   | .moraicTrochee => footMorae ws = 2
   | .syllabicTrochee => ws.length = 2
@@ -117,7 +117,7 @@ def isWellFormedFoot (ft : FootType) (ws : List SyllWeight) : Prop :=
     (ws.length = 2 ∧ 2 ≤ footMorae ws ∧ footMorae ws ≤ 3 ∧
       (ws.headD ⟨0⟩).morae ≤ (ws.getLast?.getD ⟨0⟩).morae)
 
-instance (ft : FootType) (ws : List SyllWeight) :
+instance (ft : FootType) (ws : List Syllable.Weight) :
     Decidable (isWellFormedFoot ft ws) := by
   unfold isWellFormedFoot; cases ft <;> infer_instance
 

--- a/Linglib/Phonology/Prosody/Moraic.lean
+++ b/Linglib/Phonology/Prosody/Moraic.lean
@@ -135,15 +135,15 @@ def MoraicForm.totalMorae (f : MoraicForm) : Nat :=
   f.syllables.foldl (· + ·.moraCount) 0
 
 -- ============================================================================
--- § 6: Bridge to Syllable.SyllWeight and ProsodicWord
+-- § 6: Bridge to Syllable.Syllable.Weight and ProsodicWord
 -- ============================================================================
 
-/-- Convert moraic syllable to `SyllWeight` by extracting the mora count.
+/-- Convert moraic syllable to `Syllable.Weight` by extracting the mora count.
 
-    This is lossless: `σ.toSyllWeight.morae = σ.moraCount` by definition.
+    This is lossless: `σ.toWeight.morae = σ.moraCount` by definition.
     No classification into light/heavy/superheavy bins — the exact mora
     count passes through. -/
-def MoraicSyllable.toSyllWeight (σ : MoraicSyllable) : SyllWeight :=
+def MoraicSyllable.toWeight (σ : MoraicSyllable) : Syllable.Weight :=
   ⟨σ.moraCount⟩
 
 /-- Convert a moraic form to a `PrWd` (prosodic word) weight profile.
@@ -152,7 +152,7 @@ def MoraicSyllable.toSyllWeight (σ : MoraicSyllable) : SyllWeight :=
     enabling minimal word constraints, metrical parsing, and stress
     assignment to operate on moraically-derived weight profiles. -/
 def MoraicForm.toPrWd (f : MoraicForm) : PrWd :=
-  ⟨f.syllables.map MoraicSyllable.toSyllWeight⟩
+  ⟨f.syllables.map MoraicSyllable.toWeight⟩
 
 -- ============================================================================
 -- § 7: Bridge Theorems
@@ -188,51 +188,51 @@ theorem syllableToMoraic_moraCount_no_wbp (σ : Syllable) :
   simp [MoraCount.toNat]
 
 /-- **General bridge**: moraic weight classification agrees with segmental weight
-    classification for WBP languages. This connects `MoraicSyllable.toSyllWeight`
+    classification for WBP languages. This connects `MoraicSyllable.toWeight`
     to `Syllable.weight` — two independently defined weight functions that
     must agree for the moraic theory to be consistent with the segmental view. -/
 theorem syllableToMoraic_weight_wbp (σ : Syllable) :
-    (syllableToMoraic { wbp := true } σ).toSyllWeight = σ.weight true := by
-  unfold MoraicSyllable.toSyllWeight Syllable.weight
+    (syllableToMoraic { wbp := true } σ).toWeight = σ.weight true := by
+  unfold MoraicSyllable.toWeight Syllable.weight
   congr 1; exact syllableToMoraic_moraCount_wbp σ
 
 /-- General bridge for non-WBP languages. -/
 theorem syllableToMoraic_weight_no_wbp (σ : Syllable) :
-    (syllableToMoraic { wbp := false } σ).toSyllWeight = σ.weight false := by
-  unfold MoraicSyllable.toSyllWeight Syllable.weight
+    (syllableToMoraic { wbp := false } σ).toWeight = σ.weight false := by
+  unfold MoraicSyllable.toWeight Syllable.weight
   congr 1; exact syllableToMoraic_moraCount_no_wbp σ
 
 /-- `syllableToMoraic` preserves CV = light regardless of WBP. -/
 theorem syllableToMoraic_cv_light (params : MoraicParams) (o n : Segment) :
-    (syllableToMoraic params ⟨[o], [n], []⟩).toSyllWeight = .light := by
-  simp only [syllableToMoraic, MoraicSyllable.toSyllWeight,
+    (syllableToMoraic params ⟨[o], [n], []⟩).toWeight = .light := by
+  simp only [syllableToMoraic, MoraicSyllable.toWeight,
     MoraicSyllable.moraCount, MoraCount.toNat, List.map, List.append_nil,
     List.foldl]
 
 /-- A CV syllable (one monomoraic vowel, no coda) is light. -/
 theorem cv_moraic_light (v : Segment) :
-    (MoraicSyllable.mk [] [⟨v, .one⟩]).toSyllWeight = .light := rfl
+    (MoraicSyllable.mk [] [⟨v, .one⟩]).toWeight = .light := rfl
 
 /-- A CVV syllable (one bimoraic vowel) is heavy. -/
 theorem cvv_moraic_heavy (v : Segment) :
-    (MoraicSyllable.mk [] [⟨v, .two⟩]).toSyllWeight = .heavy := rfl
+    (MoraicSyllable.mk [] [⟨v, .two⟩]).toWeight = .heavy := rfl
 
 /-- A CVC syllable with WBP (coda has one mora) is heavy. -/
 theorem cvc_wbp_heavy (v c₁ c₂ : Segment) :
-    (MoraicSyllable.mk [c₁] [⟨v, .one⟩, ⟨c₂, .one⟩]).toSyllWeight = .heavy := rfl
+    (MoraicSyllable.mk [c₁] [⟨v, .one⟩, ⟨c₂, .one⟩]).toWeight = .heavy := rfl
 
 /-- A CVC syllable without WBP (coda has zero morae) is light. -/
 theorem cvc_no_wbp_light (v c₁ c₂ : Segment) :
-    (MoraicSyllable.mk [c₁] [⟨v, .one⟩, ⟨c₂, .zero⟩]).toSyllWeight = .light := rfl
+    (MoraicSyllable.mk [c₁] [⟨v, .one⟩, ⟨c₂, .zero⟩]).toWeight = .light := rfl
 
 /-- A CVVC syllable (long vowel + moraic coda) is superheavy. -/
 theorem cvvc_superheavy (v c₁ c₂ : Segment) :
-    (MoraicSyllable.mk [c₁] [⟨v, .two⟩, ⟨c₂, .one⟩]).toSyllWeight = .superheavy := rfl
+    (MoraicSyllable.mk [c₁] [⟨v, .two⟩, ⟨c₂, .one⟩]).toWeight = .superheavy := rfl
 
 /-- Geminate: one segment linked to two morae, straddling a syllable boundary.
     The first half contributes its mora(e) to the coda of σ₁. -/
 theorem geminate_makes_heavy (v seg : Segment) :
-    (MoraicSyllable.mk [] [⟨v, .one⟩, ⟨seg, .one⟩]).toSyllWeight = .heavy := rfl
+    (MoraicSyllable.mk [] [⟨v, .one⟩, ⟨seg, .one⟩]).toWeight = .heavy := rfl
 
 /-- The moraic minimal word: `satisfiesMinWord` holds iff there are ≥ 2 morae
     (the default). This connects moraic representations to PrWd's bimoraic
@@ -240,9 +240,9 @@ theorem geminate_makes_heavy (v seg : Segment) :
 theorem moraic_minword (f : MoraicForm) :
     f.toPrWd.satisfiesMinWord ↔ f.toPrWd.moraCount ≥ 2 := Iff.rfl
 
-/-- **Round-trip fidelity**: `toSyllWeight.morae` recovers the exact mora count.
-    No bounds needed — `SyllWeight` is now a `Nat` wrapper, not a lossy enum. -/
-theorem toSyllWeight_morae_faithful (σ : MoraicSyllable) :
-    σ.toSyllWeight.morae = σ.moraCount := rfl
+/-- **Round-trip fidelity**: `toWeight.morae` recovers the exact mora count.
+    No bounds needed — `Syllable.Weight` is now a `Nat` wrapper, not a lossy enum. -/
+theorem toWeight_morae_faithful (σ : MoraicSyllable) :
+    σ.toWeight.morae = σ.moraCount := rfl
 
 end Prosody

--- a/Linglib/Phonology/Prosody/NaturalClass.lean
+++ b/Linglib/Phonology/Prosody/NaturalClass.lean
@@ -21,7 +21,7 @@ and [±voice]:
 | Vowels             |  +  |  +   |  ±    |  8   |
 
 Sonorants (ranks 5–8) are distinguished by [±approximant], [±consonantal],
-and [±syllabic], exactly as in the Clements scale (`SonorityRank`). The
+and [±syllabic], exactly as in the Clements scale (`Sonority`). The
 Parker refinement adds [±voice] only within obstruents.
 
 Crucially, [parker-2002] ranks **voiced stops above voiceless fricatives**
@@ -69,7 +69,7 @@ def NatClass.parkerSonority : NatClass → Nat
 -- ============================================================================
 
 /-- Classify a segment into the Parker 8-level scale.
-    Follows the feature decomposition of `SonorityRank` but additionally
+    Follows the feature decomposition of `Sonority` but additionally
     splits obstruents by [±voice] ([parker-2002]). -/
 def natClassOf (s : Segment) : NatClass :=
   if s.HasValue .sonorant false then
@@ -91,11 +91,11 @@ def parkerSonorityOf (s : Segment) : Nat :=
 -- § 3: Verification
 -- ============================================================================
 
-/-- Map NatClass to the abstract `SonorityRank`. This collapses the Parker
+/-- Map NatClass to the abstract `Sonority`. This collapses the Parker
     voicing distinction within obstruents (vls/vds → stop, vlf/vdf → fricative),
     connecting the fine-grained 8-level scale to the substance-free 6-level
     hierarchy that the grammar operates on. -/
-def NatClass.toSonorityRank : NatClass → SonorityRank
+def NatClass.toSonority : NatClass → Sonority
   | .vls | .vds => .stop
   | .vlf | .vdf => .fricative
   | .nasal => .nasal

--- a/Linglib/Phonology/Prosody/Syllable.lean
+++ b/Linglib/Phonology/Prosody/Syllable.lean
@@ -4,35 +4,35 @@ import Linglib.Phonology.Segment
 /-!
 # Syllable structure
 
-Syllable constituency (onset–nucleus–coda), the sonority scale, and moraic
-weight, following the syllable chapter of *The Handbook of Phonological Theory*
+The syllable as a phonological object — sonority, constituency, and weight —
+following the syllable chapter of *The Handbook of Phonological Theory*
 ([goldsmith-2011]) and [hayes-2009].
 
 ## Main definitions
 
-* `SonorityRank` — the abstract sonority hierarchy, ordered as a `LinearOrder`.
-* `sonorityOf` — grounds a `Segment` in `SonorityRank` via its features.
-* `Syllable` — an onset–nucleus–coda triple.
-* `SyllWeight`, `Syllable.weight` — syllable weight as a mora count.
+* `Sonority` — the abstract sonority hierarchy (a `LinearOrder`);
+  `Sonority.ofSegment` grounds a `Segment` in it via its features.
+* `Syllable` — an onset–nucleus–coda triple, with `Syllable.moraCount`,
+  `Syllable.weight`, and the nested weight object `Syllable.Weight`.
+* `SyllabifiedForm` — a word parsed into syllables.
 
 ## Implementation notes
 
-Following [berent-2026], the sonority hierarchy is an abstract ordered type
-rather than a bundle of articulatory features: the synchronic grammar operates
-on the ordering alone, and the correlation with phonetic features ([±sonorant],
-[±approximant], …) is a diachronic fact. `sonorityOf` is the only place those
-features enter.
+Following [berent-2026], sonority is an abstract ordered type rather than a
+bundle of articulatory features: the grammar operates on the ordering alone,
+and `Sonority.ofSegment` is the only place phonetic features ([±sonorant],
+[±approximant], …) enter.
 -/
 
 namespace Prosody
 
 open Phonology (Segment)
 
-/-! ### Sonority scale -/
+/-! ### Sonority -/
 
 /-- The abstract sonority hierarchy: what the synchronic grammar operates on.
 
-    | Rank | Category  |
+    | Rank | Class     |
     |------|-----------|
     |  0   | Stop      |
     |  1   | Fricative |
@@ -44,7 +44,7 @@ open Phonology (Segment)
     The six levels follow [clements-1990]'s refinement of the basic 5-class
     hierarchy (splitting obstruents by [±continuant]); see
     `NatClass.parkerSonority` for the finer 8-level Parker scale. -/
-inductive SonorityRank where
+inductive Sonority where
   | stop
   | fricative
   | nasal
@@ -53,30 +53,19 @@ inductive SonorityRank where
   | vowel
   deriving DecidableEq, Repr
 
-namespace SonorityRank
+namespace Sonority
 
 /-- Numeric rank (0 = least sonorous). -/
-def rank : SonorityRank → Nat
+def rank : Sonority → Nat
   | .stop => 0 | .fricative => 1 | .nasal => 2
   | .liquid => 3 | .glide => 4 | .vowel => 5
 
-/-- `SonorityRank.rank` is injective. -/
-theorem rank_injective : Function.Injective SonorityRank.rank :=
-  fun a b h => by cases a <;> cases b <;> simp_all [SonorityRank.rank]
+instance : LinearOrder Sonority :=
+  LinearOrder.lift' rank fun a b h => by cases a <;> cases b <;> simp_all [rank]
 
-/-- The linear order on sonority ranks, lifted from the numeric ranking. -/
-instance : LinearOrder SonorityRank :=
-  LinearOrder.lift' SonorityRank.rank rank_injective
-
-end SonorityRank
-
-/-- Ground a segment in the sonority hierarchy by its phonetic features.
-
-    Following [hayes-2009], the hierarchy is decomposed by four features
-    ([±sonorant] > [±approximant] > [±consonantal] > [±syllabic]), with
-    [clements-1990]'s refinement splitting obstruents by [±continuant]. This is
-    the only bridge from phonetic substance to the abstract `SonorityRank`. -/
-def sonorityOf (s : Segment) : SonorityRank :=
+/-- The sonority of a segment, read off its phonetic features
+    ([hayes-2009], [clements-1990]). -/
+def ofSegment (s : Segment) : Sonority :=
   if s.HasValue .sonorant false then
     if s.HasValue .continuant true then .fricative else .stop
   else if s.HasValue .approximant false then .nasal
@@ -84,7 +73,9 @@ def sonorityOf (s : Segment) : SonorityRank :=
   else if s.HasValue .syllabic true then .vowel
   else .glide
 
-/-! ### Syllable constituents -/
+end Sonority
+
+/-! ### Syllables -/
 
 /-- A syllable: onset, nucleus, coda. -/
 structure Syllable where
@@ -92,34 +83,36 @@ structure Syllable where
   nucleus : List Segment
   coda    : List Segment
 
-/-! ### Syllable weight -/
+namespace Syllable
 
-/-- Syllable weight as a mora count. `SyllWeight` wraps the actual count rather
-    than a lossy 3-value enum, so the `MoraicSyllable → SyllWeight → PrWd`
-    pipeline preserves exact mora counts. The names `.light` (1μ), `.heavy` (2μ),
-    and `.superheavy` (3μ) abbreviate the common values. -/
-structure SyllWeight where
+/-- Syllable weight as a mora count. `Weight` wraps the actual count rather
+    than a lossy 3-value enum, so the `MoraicSyllable → Syllable.Weight → PrWd`
+    pipeline preserves exact mora counts. The names `.light` (1μ), `.heavy`
+    (2μ), and `.superheavy` (3μ) abbreviate the common values. -/
+structure Weight where
   /-- The mora count: 1μ = light (CV), 2μ = heavy (CVV, CVC),
       3μ = superheavy (CVVC, CVCC). -/
   morae : Nat
   deriving DecidableEq, Repr
 
-namespace SyllWeight
-abbrev light : SyllWeight := ⟨1⟩
-abbrev heavy : SyllWeight := ⟨2⟩
-abbrev superheavy : SyllWeight := ⟨3⟩
-end SyllWeight
+namespace Weight
+abbrev light : Weight := ⟨1⟩
+abbrev heavy : Weight := ⟨2⟩
+abbrev superheavy : Weight := ⟨3⟩
+end Weight
 
 /-- Mora count. `codaMoraic = true` means coda consonants contribute weight
     (the Weight-by-Position parameter of [hayes-1989]). -/
-def Syllable.moraCount (σ : Syllable) (codaMoraic : Bool := true) : Nat :=
+def moraCount (σ : Syllable) (codaMoraic : Bool := true) : Nat :=
   σ.nucleus.length + if codaMoraic then σ.coda.length else 0
 
 /-- Weight from the mora count. -/
-def Syllable.weight (σ : Syllable) (codaMoraic : Bool := true) : SyllWeight :=
+def weight (σ : Syllable) (codaMoraic : Bool := true) : Weight :=
   ⟨σ.moraCount codaMoraic⟩
 
-/-! ### Syllabified form -/
+end Syllable
+
+/-! ### Syllabified forms -/
 
 /-- A word parsed into syllables. -/
 structure SyllabifiedForm where

--- a/Linglib/Phonology/Prosody/Word.lean
+++ b/Linglib/Phonology/Prosody/Word.lean
@@ -123,7 +123,7 @@ def MorphStatus.isPrWdInternal (s : MorphStatus) : Bool := s.prWdInternal
     For example, Telugu *samudram* 'ocean' has profile [L, L, H]
     (sa.mu.dram). -/
 structure PrWd where
-  syllables : List SyllWeight
+  syllables : List Syllable.Weight
   deriving DecidableEq, Repr
 
 /-- Total mora count of a prosodic word. -/
@@ -166,7 +166,7 @@ structure MorphElement where
   /-- Weight of the initial syllable. Relevant for the Telugu weak
       alternation: the long form is triggered when a *light* initial
       syllable follows within the PrWd ([aitha-2026] §3.2). -/
-  initialWeight : SyllWeight
+  initialWeight : Syllable.Weight
   deriving DecidableEq, Repr
 
 /-- Does this element trigger the long stem form in Telugu weak nouns?

--- a/Linglib/Studies/Berent2026.lean
+++ b/Linglib/Studies/Berent2026.lean
@@ -15,7 +15,7 @@ algebraic, and amodal:
 1. **Abstract**: syllable structure constraints (sonority sequencing) persist
    under articulatory suppression (TMS, mechanical) and in print reading,
    engaging Broca's area rather than motor cortex. Formalized as gradient
-   markedness over the abstract `SonorityRank` type — the grammar sees only
+   markedness over the abstract `Sonority` type — the grammar sees only
    the ordering, not the articulatory features that correlate with it.
 
 2. **Algebraic**: identity restrictions (*XX ban, OCP) generalize to novel
@@ -36,7 +36,7 @@ The paper's central claims are metatheoretical — they argue about the
 machinery. The deepest formalization insight is that Lean's type system
 already embodies the distinctions Berent draws:
 
-- **Substance-free** = `SonorityRank` is an abstract ordered type, not
+- **Substance-free** = `Sonority` is an abstract ordered type, not
   defined by articulatory features (refactored in `Syllable.lean`)
 - **Algebraic** = `mkOCP` is parametrically polymorphic over `α`
   (added to `Constraints.lean`)
@@ -51,7 +51,7 @@ data supporting the doubling reversal is in
 [berent-2026]
 -/
 
-open Prosody (SonorityRank)
+open Prosody (Sonority)
 open OptimalityTheory
 open OptimalityTheory.Doubling
 
@@ -68,7 +68,7 @@ open Core.Optimization Constraints OptimalityTheory
 
     The behavioral gradient rise > plateau > fall ([berent-2026],
     Figure 1A; data from Berent et al. 2007) maps directly to this
-    classification on the abstract `SonorityRank` type. -/
+    classification on the abstract `Sonority` type. -/
 inductive OnsetProfile where
   | rise     -- C1 < C2: e.g. /bl/, /pr/ — least marked
   | plateau  -- C1 = C2: e.g. /bd/ — intermediate
@@ -76,9 +76,9 @@ inductive OnsetProfile where
   deriving DecidableEq, Repr
 
 /-- Classify a two-segment onset by its sonority profile.
-    Operates on `SonorityRank` — the abstract hierarchy — not on
+    Operates on `Sonority` — the abstract hierarchy — not on
     articulatory features. -/
-def onsetProfile (c1 c2 : SonorityRank) : OnsetProfile :=
+def onsetProfile (c1 c2 : Sonority) : OnsetProfile :=
   if c1.rank < c2.rank then .rise
   else if c1.rank == c2.rank then .plateau
   else .fall
@@ -89,7 +89,7 @@ def onsetProfile (c1 c2 : SonorityRank) : OnsetProfile :=
     Rise = 0 violations, plateau = 1, fall = 2. This captures the
     behavioral gradient (blif > bnif > bdif > lbif; [berent-2026],
     data from Berent et al. 2007). The gradient is determined entirely
-    by the abstract `SonorityRank` ordering — the grammar does not inspect
+    by the abstract `Sonority` ordering — the grammar does not inspect
     whether "rise" means "stop-before-liquid" vs. "nasal-before-vowel". -/
 def onsetSSP : NamedConstraint OnsetProfile :=
   mkMarkGrad "SSP-ONSET" fun
@@ -109,9 +109,9 @@ theorem plateau_lt_fall : onsetMarkedness .plateau < onsetMarkedness .fall := by
 theorem rise_unmarked : onsetMarkedness .rise = 0 := rfl
 
 /-- The sonority gradient is determined by abstract rank, not by features.
-    Two segments with the same `SonorityRank` are treated identically
+    Two segments with the same `Sonority` are treated identically
     regardless of their articulatory specification. -/
-theorem sonority_gradient_abstract (r1 r2 : SonorityRank) :
+theorem sonority_gradient_abstract (r1 r2 : Sonority) :
     onsetMarkedness (onsetProfile r1 r2) =
     if r1.rank < r2.rank then 0
     else if r1.rank == r2.rank then 1

--- a/Linglib/Studies/Hayes1989.lean
+++ b/Linglib/Studies/Hayes1989.lean
@@ -84,7 +84,7 @@ def kasnus_σ₂ : MoraicSyllable := ⟨[n], [⟨u, .one⟩, ⟨s, .one⟩]⟩
 def kasnus : MoraicForm := ⟨[kasnus_σ₁, kasnus_σ₂]⟩
 
 /-- σ₁ of *kasnus is heavy (2 morae: nucleus + coda with WBP). -/
-theorem kasnus_σ₁_heavy : kasnus_σ₁.toSyllWeight = .heavy := rfl
+theorem kasnus_σ₁_heavy : kasnus_σ₁.toWeight = .heavy := rfl
 
 /-- After ⟨s⟩-deletion from σ₁, one mora is stranded. -/
 theorem kasnus_s_deletion_strands :
@@ -96,7 +96,7 @@ def kaanus_σ₁ : MoraicSyllable :=
   let (σ_del, stranded) := deleteMoraic kasnus_σ₁ 1
   spreadToFill σ_del stranded .left
 
-theorem kaanus_σ₁_heavy : kaanus_σ₁.toSyllWeight = .heavy := rfl
+theorem kaanus_σ₁_heavy : kaanus_σ₁.toWeight = .heavy := rfl
 
 /-- Moraic conservation: *kasnus σ₁ and ka:nus σ₁ have the same mora count. -/
 theorem kasnus_conservation : kasnus_σ₁.moraCount = kaanus_σ₁.moraCount := rfl
@@ -127,7 +127,7 @@ theorem smereo_onset_no_cl :
 
 /-- The mora count after onset deletion is still 1 (light syllable). -/
 theorem smereo_remains_light :
-    (deleteOnset smereo_σ₁ 0).toSyllWeight = .light := rfl
+    (deleteOnset smereo_σ₁ 0).toWeight = .light := rfl
 
 end LatinOnsetDeletion
 
@@ -174,7 +174,7 @@ section WeightPrerequisite
 def lardil_cvc : MoraicSyllable :=
   syllableToMoraic { wbp := false } ⟨[t], [a], [k]⟩
 
-theorem lardil_cvc_is_light : lardil_cvc.toSyllWeight = .light := rfl
+theorem lardil_cvc_is_light : lardil_cvc.toWeight = .light := rfl
 
 theorem lardil_no_cl_from_coda :
     (deleteMoraic lardil_cvc 1).2 = 0 := rfl
@@ -184,7 +184,7 @@ theorem lardil_no_cl_from_coda :
 def latin_cvc : MoraicSyllable :=
   syllableToMoraic { wbp := true } ⟨[t], [a], [k]⟩
 
-theorem latin_cvc_is_heavy : latin_cvc.toSyllWeight = .heavy := rfl
+theorem latin_cvc_is_heavy : latin_cvc.toWeight = .heavy := rfl
 
 theorem latin_cl_from_coda :
     (deleteMoraic latin_cvc 1).2 = 1 := rfl
@@ -210,9 +210,9 @@ def estonian_q1 : MoraicSyllable := ⟨[k], [⟨a, .one⟩]⟩           -- Q1: 
 def estonian_q2 : MoraicSyllable := ⟨[k], [⟨a, .two⟩]⟩           -- Q2: heavy
 def estonian_q3 : MoraicSyllable := ⟨[k], [⟨a, .two⟩, ⟨l, .one⟩]⟩ -- Q3: superheavy
 
-theorem q1_is_light : estonian_q1.toSyllWeight = .light := rfl
-theorem q2_is_heavy : estonian_q2.toSyllWeight = .heavy := rfl
-theorem q3_is_superheavy : estonian_q3.toSyllWeight = .superheavy := rfl
+theorem q1_is_light : estonian_q1.toWeight = .light := rfl
+theorem q2_is_heavy : estonian_q2.toWeight = .heavy := rfl
+theorem q3_is_superheavy : estonian_q3.toWeight = .superheavy := rfl
 
 /-- Q3 → Q2 grade shift: removing the third mora.
     The moraic account: Q3 has 3 morae, Q2 has 2. The shift is simply
@@ -241,7 +241,7 @@ section ProsodicPipeline
     moraic syllabification → weight profile → prosodic word.
 
     This demonstrates the chain that moraic theory creates:
-    segments + WBP → `MoraicSyllable` → `SyllWeight` → `PrWd`
+    segments + WBP → `MoraicSyllable` → `Syllable.Weight` → `PrWd`
 
     CL output: σ₁ = [ka:] (bimoraic = heavy), σ₂ = [nus] (bimoraic = heavy).
     Weight profile: [H, H]. -/

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -163,6 +163,6 @@ theorem long_n2_initial_avoids_final :
 theorem japanese_wbp_active (o n c : Phonology.Segment) :
     -- CVC with WBP is heavy (e.g., /tan/ = 2μ)
     (Prosody.syllableToMoraic { wbp := true }
-      ⟨[o], [n], [c]⟩).toSyllWeight = .heavy := rfl
+      ⟨[o], [n], [c]⟩).toWeight = .heavy := rfl
 
 end Kawahara2015

--- a/Linglib/Studies/MarcoRasin2026.lean
+++ b/Linglib/Studies/MarcoRasin2026.lean
@@ -46,7 +46,7 @@ namespace MarcoRasin2026
 open Core.Optimization Constraints OptimalityTheory
 open OptimalityTheory
 open OptimalityTheory.ParadigmUniformity
-open Prosody (SonorityRank)
+open Prosody (Sonority)
 
 -- ============================================================================
 -- § 1: Data Types
@@ -93,8 +93,8 @@ def starSchwaOpen : NamedConstraint (List JTAForm) :=
 
 /-- SONCON: assign * for a CCəC (medial) form when C₂ > C₃ in sonority.
     Parametrized over the sonority ranks of C₂ and C₃, using the
-    `LinearOrder SonorityRank` instance from `Syllable`. -/
-def sonCon (c2 c3 : Prosody.SonorityRank) :
+    `LinearOrder Sonority` instance from `Syllable`. -/
+def sonCon (c2 c3 : Prosody.Sonority) :
     NamedConstraint (List JTAForm) :=
   liftPerMember "SONCON" .markedness fun f =>
     if c2 > c3 && f.schwa == .medial then 1 else 0


### PR DESCRIPTION
Reorganizes the syllable layer into owner-relative, mathlib-idiomatic object APIs (the reorg intended for #911, which squash-merged at the strip-only state).

- `SonorityRank` → **`Sonority`** — the sonority object, with `Sonority.rank`, `Sonority.ofSegment` (was the loose `sonorityOf`), and `LinearOrder Sonority`; `rank_injective` folds into the instance.
- `SyllWeight` → **`Syllable.Weight`** — weight nested under its owner; `MoraicSyllable.toSyllWeight` → `.toWeight`, `NatClass.toSonorityRank` → `.toSonority`.
- `Syllable.lean` grouped into `Sonority` / `Syllable` / `Syllable.Weight` namespaces.

Renames propagated across Foot, Word, Accent, Moraic, NaturalClass, Berent2026, Hayes1989, Kawahara2015, MarcoRasin2026, Japanese.

Follow-up: `Moraic.lean` → `Mora.lean`, reorganized as the moraic-representation object API (the next file in the pass).