### PR TITLE
refactor(Phonology/Prosody): mathlib sections + verification examples

### DIFF
--- a/Linglib/Phonology/Prosody/Foot.lean
+++ b/Linglib/Phonology/Prosody/Foot.lean
@@ -18,24 +18,21 @@ rhythmic unit. [hayes-1995] identifies three canonical foot types:
 The foot's *head* (prominent syllable) determines stress: initial in
 trochees, final in iambs.
 
-## Definitions
+## Main definitions
 
-- `Syllable.Weight.morae`: mora count from weight class
-- `FootType`: the three canonical foot types
-- `ParseElement`: element in a metrical parse (footed or unfooted)
-- `MetricalParse`: a complete metrical parse of a prosodic domain
-- OT constraints: `ftBinViolations`, `parseSylViolations`, `allFtLeftViolations`
+* `FootType` — the three canonical foot types.
+* `ParseElement` / `MetricalParse` — an element of, and a complete, metrical
+  parse of a prosodic domain.
+* `footMorae`, `isWellFormedFoot`, `isDegenerate` — foot weight and shape.
+* `ftBinViolations`, `parseSylViolations`, `allFtLeftViolations`,
+  `allFtRightViolations` — OT metrical constraints.
 -/
 
 namespace Prosody
 
--- `Syllable.Weight.morae` is now a field accessor — no separate function needed.
+/-! ### Foot type -/
 
--- ============================================================================
--- § 1: Foot Type
--- ============================================================================
-
-/-- The three canonical foot types ([hayes-1995], Ch. 3). -/
+/-- The three canonical foot types ([hayes-1995]). -/
 inductive FootType where
   /-- Moraic trochee: bimoraic with initial prominence.
       Well-formed shapes: (H) = 2μ, (LL) = 2μ.
@@ -51,9 +48,7 @@ inductive FootType where
   | iamb
   deriving DecidableEq, Repr
 
--- ============================================================================
--- § 3: Metrical Parse
--- ============================================================================
+/-! ### Metrical parse -/
 
 /-- An element in a metrical parse: either a foot grouping syllables
     or an unparsed (stray) syllable. The list preserves left-to-right
@@ -69,9 +64,7 @@ inductive ParseElement where
     of footed and unfooted syllables. -/
 abbrev MetricalParse := List ParseElement
 
--- ============================================================================
--- § 4: Parse Properties
--- ============================================================================
+/-! ### Parse properties -/
 
 /-- Extract all feet from a parse. -/
 def MetricalParse.feet (p : MetricalParse) : List (List Syllable.Weight) :=
@@ -102,7 +95,7 @@ instance (ws : List Syllable.Weight) : Decidable (isDegenerate ws) := by
 /-- Is a foot well-formed for the given foot type?
 
     The iamb clause encodes Hayes' canonical right-prominent inventory
-    `{(H), (LL), (LH)}` ([hayes-1995], Ch. 6): a bimoraic monosyllable,
+    `{(H), (LL), (LH)}` ([hayes-1995]): a bimoraic monosyllable,
     or a disyllable that is right-heavy-or-even (first syllable no heavier
     than the second) with two or three morae. This excludes the degenerate
     monomoraic `(L)`, the left-heavy `(HL)`, and the trimoraic monosyllable
@@ -121,9 +114,7 @@ instance (ft : FootType) (ws : List Syllable.Weight) :
     Decidable (isWellFormedFoot ft ws) := by
   unfold isWellFormedFoot; cases ft <;> infer_instance
 
--- ============================================================================
--- § 5: OT Metrical Constraints
--- ============================================================================
+/-! ### OT metrical constraints -/
 
 /-- FT-BIN(μ): assign one violation for each foot that does not consist
     of exactly two morae ([kager-2007]).
@@ -166,77 +157,49 @@ def allFtRightViolations (p : MetricalParse) : Nat :=
     | .unfooted _ :: rest, pos => go rest (pos + 1)
   go p 0
 
--- ============================================================================
--- § 6: Verification Theorems
--- ============================================================================
+/-! ### Worked examples
 
--- Mora counts
+Anonymous `example`s rather than named lemmas: these lock in the non-trivial
+`isWellFormedFoot` inventory and the OT-constraint counts, but are not reusable
+API. -/
 
-theorem heavy_foot_bimoraic : footMorae [.heavy] = 2 := rfl
-theorem ll_foot_bimoraic : footMorae [.light, .light] = 2 := rfl
-theorem light_foot_monomoraic : footMorae [.light] = 1 := rfl
-theorem superheavy_foot_trimoraic : footMorae [.superheavy] = 3 := rfl
+-- Moraic trochee: the canonical {(H), (LL)} inventory.
+example : isWellFormedFoot .moraicTrochee [.heavy] := by decide
+example : isWellFormedFoot .moraicTrochee [.light, .light] := by decide
+example : ¬ isWellFormedFoot .moraicTrochee [.light] := by decide
 
--- Well-formedness
+-- Iamb: the canonical right-prominent inventory {(H), (LL), (LH)} only —
+-- excluding the degenerate (L), the left-heavy (HL), and the trimoraic (SH).
+example : isWellFormedFoot .iamb [.heavy] := by decide
+example : isWellFormedFoot .iamb [.light, .light] := by decide
+example : isWellFormedFoot .iamb [.light, .heavy] := by decide
+example : ¬ isWellFormedFoot .iamb [.light] := by decide
+example : ¬ isWellFormedFoot .iamb [.heavy, .light] := by decide
+example : ¬ isWellFormedFoot .iamb [.superheavy] := by decide
 
-theorem heavy_wellformed_mt :
-    isWellFormedFoot .moraicTrochee [.heavy] := by decide
+-- Degeneracy: only the monomoraic (L) foot is subminimal.
+example : isDegenerate [.light] := by decide
+example : ¬ isDegenerate [.heavy] := by decide
+example : ¬ isDegenerate [.light, .light] := by decide
 
-theorem ll_wellformed_mt :
-    isWellFormedFoot .moraicTrochee [.light, .light] := by decide
+-- OT metrical constraints on worked parses.
+/-- (ˈCV.CV).CV: one bimoraic foot (LL) + one stray light syllable. -/
+private abbrev parse_llU : MetricalParse := [.foot [.light, .light], .unfooted .light]
+example : ftBinViolations parse_llU = 0 := rfl
+example : parseSylViolations parse_llU = 1 := rfl
+example : allFtLeftViolations parse_llU = 0 := rfl
 
-theorem l_not_wellformed_mt :
-    ¬ isWellFormedFoot .moraicTrochee [.light] := by decide
+/-- (ˈLL)(ˌH): two bimoraic feet — the Telugu stem parse of *samudr-am*. -/
+private abbrev parse_llH : MetricalParse := [.foot [.light, .light], .foot [.heavy]]
+example : ftBinViolations parse_llH = 0 := rfl
+example : parseSylViolations parse_llH = 0 := rfl
+example : allFtLeftViolations parse_llH = 2 := rfl
 
--- Iamb: canonical inventory {(H), (LL), (LH)} only
-
-theorem h_wellformed_iamb : isWellFormedFoot .iamb [.heavy] := by decide
-theorem ll_wellformed_iamb : isWellFormedFoot .iamb [.light, .light] := by decide
-theorem lh_wellformed_iamb : isWellFormedFoot .iamb [.light, .heavy] := by decide
-
-theorem l_not_wellformed_iamb : ¬ isWellFormedFoot .iamb [.light] := by decide
-theorem hl_not_wellformed_iamb : ¬ isWellFormedFoot .iamb [.heavy, .light] := by decide
-theorem sh_not_wellformed_iamb : ¬ isWellFormedFoot .iamb [.superheavy] := by decide
-
--- Degeneracy
-
-theorem light_degenerate : isDegenerate [.light] := by decide
-theorem heavy_not_degenerate : ¬ isDegenerate [.heavy] := by decide
-theorem ll_not_degenerate : ¬ isDegenerate [.light, .light] := by decide
-
--- Example parses
-
-/-- (ˈCV.CV).CV: one bimoraic foot (LL) + one unparsed light syllable.
-    Models odd-numbered light-syllable strings with left-to-right
-    moraic trochees: the final syllable is stranded. -/
-private abbrev parse_llU : MetricalParse :=
-  [.foot [.light, .light], .unfooted .light]
-
-theorem llU_ftbin : ftBinViolations parse_llU = 0 := rfl
-theorem llU_parsesyl : parseSylViolations parse_llU = 1 := rfl
-theorem llU_allftleft : allFtLeftViolations parse_llU = 0 := rfl
-
-/-- (ˈLL)(ˌH): two bimoraic feet. Models the Telugu stem-level parse
-    of *samudr-am* 'ocean-n': (ˈsa.mu).(ˌdram). -/
-private abbrev parse_llH : MetricalParse :=
-  [.foot [.light, .light], .foot [.heavy]]
-
-theorem llH_ftbin : ftBinViolations parse_llH = 0 := rfl
-theorem llH_parsesyl : parseSylViolations parse_llH = 0 := rfl
-theorem llH_allftleft : allFtLeftViolations parse_llH = 2 := rfl
-
-/-- Competing parse: (ˈsa.mu).dram with final syllable unfooted.
-    Worse on PARSE-SYL than (ˈsa.mu).(ˌdram). -/
-private abbrev parse_llU_heavy : MetricalParse :=
-  [.foot [.light, .light], .unfooted .heavy]
-
-theorem llU_heavy_parsesyl : parseSylViolations parse_llU_heavy = 1 := rfl
-
-/-- Competing parse: two monomoraic feet (ˈsa).(ˌmu).(ˌdram).
-    Violates FT-BIN twice. -/
-private abbrev parse_lllH : MetricalParse :=
-  [.foot [.light], .foot [.light], .foot [.heavy]]
-
-theorem lllH_ftbin : ftBinViolations parse_lllH = 2 := rfl
+/-- Competing parses: a stray heavy (worse on PARSE-SYL), and three degenerate
+    feet (worse on FT-BIN). -/
+private abbrev parse_llU_heavy : MetricalParse := [.foot [.light, .light], .unfooted .heavy]
+example : parseSylViolations parse_llU_heavy = 1 := rfl
+private abbrev parse_lllH : MetricalParse := [.foot [.light], .foot [.light], .foot [.heavy]]
+example : ftBinViolations parse_lllH = 2 := rfl
 
 end Prosody

--- a/Linglib/Phonology/Prosody/NaturalClass.lean
+++ b/Linglib/Phonology/Prosody/NaturalClass.lean
@@ -39,9 +39,7 @@ namespace Prosody
 
 open Phonology (Segment)
 
--- ============================================================================
--- § 1: Natural Class Type
--- ============================================================================
+/-! ### Natural class -/
 
 /-- Natural-class partition for the 8-level Parker sonority scale.
     Refines the Clements 6-level hierarchy by splitting obstruents
@@ -64,9 +62,7 @@ def NatClass.parkerSonority : NatClass → Nat
   | .vls => 1 | .vlf => 2 | .vds => 3 | .vdf => 4
   | .nasal => 5 | .liquid => 6 | .glide => 7 | .vowel => 8
 
--- ============================================================================
--- § 2: Segment Classification
--- ============================================================================
+/-! ### Segment classification -/
 
 /-- Classify a segment into the Parker 8-level scale.
     Follows the feature decomposition of `Sonority` but additionally
@@ -87,9 +83,7 @@ def natClassOf (s : Segment) : NatClass :=
 def parkerSonorityOf (s : Segment) : Nat :=
   (natClassOf s).parkerSonority
 
--- ============================================================================
--- § 3: Verification
--- ============================================================================
+/-! ### Bridge to the sonority hierarchy -/
 
 /-- Map NatClass to the abstract `Sonority`. This collapses the Parker
     voicing distinction within obstruents (vls/vds → stop, vlf/vdf → fricative),

--- a/Linglib/Phonology/Prosody/Word.lean
+++ b/Linglib/Phonology/Prosody/Word.lean
@@ -46,9 +46,7 @@ mapping that determines Word boundaries.
 namespace Prosody
 
 
--- ============================================================================
--- § 1: Morphological Status and Word Membership
--- ============================================================================
+/-! ### Morphological status and Word membership -/
 
 /-- Morphological status of an element relative to the prosodic word,
     decomposed into **orthogonal Boolean axes** rather than a flat
@@ -112,9 +110,7 @@ end MorphStatus
     Direct projection of the `prWdInternal` axis. -/
 def MorphStatus.isPrWdInternal (s : MorphStatus) : Bool := s.prWdInternal
 
--- ============================================================================
--- § 2: Prosodic Word Structure
--- ============================================================================
+/-! ### Prosodic word structure -/
 
 /-- A prosodic word: a sequence of syllables (by weight) that forms a
     single domain for stress assignment and phonological processes.
@@ -138,9 +134,7 @@ def Word.moraCount (w : Word) : Nat :=
 def Word.syllableCount (w : Word) : Nat :=
   w.syllables.length
 
--- ============================================================================
--- § 3: Minimal Word Constraint
--- ============================================================================
+/-! ### Minimal word constraint -/
 
 /-- Does a prosodic word satisfy the minimal word constraint?
 
@@ -156,9 +150,7 @@ def Word.syllableCount (w : Word) : Nat :=
 abbrev Word.satisfiesMinWord (w : Word) (minMorae : Nat := 2) : Prop :=
   w.moraCount ≥ minMorae
 
--- ============================================================================
--- § 4: Morphological Element
--- ============================================================================
+/-! ### Morphological element -/
 
 /-- A morphological element with its prosodic properties.
     Used to determine how it interacts with the stem's Word. -/
@@ -185,9 +177,7 @@ structure MorphElement where
 abbrev MorphElement.triggersLongForm (m : MorphElement) : Prop :=
   m.status.isPrWdInternal ∧ m.initialWeight = .light
 
--- ============================================================================
--- § 5: Word-Sensitive Phonological Processes
--- ============================================================================
+/-! ### Word-sensitive phonological processes -/
 
 /-- Hiatus resolution obligation: within a Word, hiatus resolution
     is **obligatory**; across Word boundaries, it is **optional**.
@@ -205,65 +195,41 @@ inductive HiatusObligation where
 def hiatusObligation (following : MorphStatus) : HiatusObligation :=
   if following.isPrWdInternal then .obligatory else .optional
 
--- ============================================================================
--- § 6: Verification
--- ============================================================================
+/-! ### Worked examples
 
--- Morphological status classification
+Anonymous `example`s lock in the morphological-status classification, the
+minimal-word constraint, and the Telugu long-form trigger;
+`agr_1sg_triggers_long` is named because it is reused elsewhere. -/
 
-theorem root_is_internal : MorphStatus.root.isPrWdInternal = true := rfl
-theorem infl_is_internal : MorphStatus.inflectional.isPrWdInternal = true := rfl
-theorem agr_is_internal : MorphStatus.agreement.isPrWdInternal = true := rfl
-theorem postp_is_external : MorphStatus.postposition.isPrWdInternal = false := rfl
+-- Morphological status: roots/inflection/agreement are Word-internal,
+-- postpositions external.
+example : MorphStatus.root.isPrWdInternal = true := rfl
+example : MorphStatus.inflectional.isPrWdInternal = true := rfl
+example : MorphStatus.agreement.isPrWdInternal = true := rfl
+example : MorphStatus.postposition.isPrWdInternal = false := rfl
 
--- Minimal word examples
+-- Minimal word (bimoraic): a heavy, or two lights, satisfies it; a single
+-- light does not. Telugu postpositions satisfy it independently — *-lō*
+-- (CVV = 2μ), *-kinda* (3μ).
+example : (Word.mk [.heavy]).satisfiesMinWord := by decide
+example : ¬ (Word.mk [.light]).satisfiesMinWord := by decide
+example : (Word.mk [.light, .light]).satisfiesMinWord := by decide
+example : (Word.mk [.heavy, .light]).satisfiesMinWord := by decide
 
-/-- A single heavy syllable (CVV or CVC) = 2μ: satisfies bimoraic min. -/
-theorem heavy_satisfies_min : (Word.mk [.heavy]).satisfiesMinWord := by decide
+-- Hiatus obligation: obligatory Word-internally, optional across a boundary.
+example : hiatusObligation .inflectional = .obligatory := rfl
+example : hiatusObligation .postposition = .optional := rfl
 
-/-- A single light syllable (CV) = 1μ: violates bimoraic min. -/
-theorem light_violates_min : ¬ (Word.mk [.light]).satisfiesMinWord := by decide
+-- Long-form trigger: Word-internal + light initial triggers it (ACC *-ni*,
+-- DAT *-ki*); postpositions never do, even *-gurinci* (light initial *gu-*).
+example : (MorphElement.mk "-ni" .inflectional .light).triggersLongForm := by decide
+example : (MorphElement.mk "-ki" .inflectional .light).triggersLongForm := by decide
+example : ¬ (MorphElement.mk "-lō" .postposition .heavy).triggersLongForm := by decide
+example : ¬ (MorphElement.mk "-gurinci" .postposition .light).triggersLongForm := by decide
 
-/-- Two light syllables (CV.CV) = 2μ: satisfies bimoraic min. -/
-theorem ll_satisfies_min : (Word.mk [.light, .light]).satisfiesMinWord := by decide
-
--- Telugu postpositions satisfy min word independently
-
-/-- *-lō* 'in' (CVV = 2μ): satisfies min word as a separate Word. -/
-theorem lo_satisfies_min : (Word.mk [.heavy]).satisfiesMinWord := by decide
-
-/-- *-kinda* 'below' (CVC.CV = 3μ): satisfies min word. -/
-theorem kinda_satisfies_min : (Word.mk [.heavy, .light]).satisfiesMinWord := by decide
-
--- Hiatus obligation
-
-theorem infl_hiatus_obligatory :
-    hiatusObligation .inflectional = .obligatory := rfl
-
-theorem postp_hiatus_optional :
-    hiatusObligation .postposition = .optional := rfl
-
--- Triggering the long form
-
-/-- ACC *-ni*: Word-internal, light → triggers long form. -/
-theorem acc_ni_triggers_long :
-    (MorphElement.mk "-ni" .inflectional .light).triggersLongForm := by decide
-
-/-- DAT *-ki*: Word-internal, light → triggers long form. -/
-theorem dat_ki_triggers_long :
-    (MorphElement.mk "-ki" .inflectional .light).triggersLongForm := by decide
-
-/-- 1SG *-ni*: Word-internal (agreement), light → triggers long form. -/
+/-- 1SG *-ni*: Word-internal (agreement), light → triggers the long form. Named
+    because it is reused (the Telugu predicative-agreement argument). -/
 theorem agr_1sg_triggers_long :
     (MorphElement.mk "-ni" .agreement .light).triggersLongForm := by decide
-
-/-- P *-lō* 'in': Word-external → does NOT trigger long form. -/
-theorem postp_lo_no_long :
-    ¬ (MorphElement.mk "-lō" .postposition .heavy).triggersLongForm := by decide
-
-/-- P *-gurinci* 'about': Word-external → does NOT trigger long form,
-    even though its initial syllable *gu-* is light. -/
-theorem postp_gurinci_no_long :
-    ¬ (MorphElement.mk "-gurinci" .postposition .light).triggersLongForm := by decide
 
 end Prosody


### PR DESCRIPTION
Follow-up polish on the metrical/word layers after the #919 unification.

- **Foot/Word/NaturalClass**: replace ASCII `-- § N:` banners with `/-! ### -/` section headers and tidy module docstrings (`## Main definitions`).
- **Verification point-checks → `example`**: the 0-use `theorem`s (foot well-formedness / iamb inventory, minimal-word, hiatus, long-form triggers) become anonymous `example`s — they still lock in the non-trivial `isWellFormedFoot` / OT-constraint / `triggersLongForm` behaviour at compile time but no longer pollute the namespace. The four trivial `footMorae` arithmetic checks are dropped; `agr_1sg_triggers_long` stays a named theorem (reused externally).
- **Citations**: drop the cited-from-memory `[hayes-1995], Ch. 3/Ch. 6` location refs (CLAUDE.md bans from-memory section/chapter numbers). Relabel NaturalClass's mis-titled "Verification" section — it's actually the `NatClass.toSonority` bridge + the general `parker_strictly_monotone` lemma.