### PR TITLE
refactor(Phonology): rename {OT,HG,POC}Realizes to realizedBy*

### DIFF
--- a/Linglib/Phonology/HarmonicGrammar/Cumulativity.lean
+++ b/Linglib/Phonology/HarmonicGrammar/Cumulativity.lean
@@ -23,10 +23,10 @@ shared global ranking/weighting.
 - `SystemicProblem Input Output n` packages multi-input optimization data:
   inputs, candidates per input, n-dimensional violation profile, and the
   target mapping the grammar must realize.
-- `HGRealizes` / `IsHGRealizable`: existence of a non-negative weighting
+- `realizedByWeighting` / `IsHGRealizable`: existence of a non-negative weighting
   under which the target output strictly minimizes weighted violations
   for every input.
-- `OTRealizes` / `IsOTRealizable`: existence of a constraint permutation
+- `realizedByRanking` / `IsOTRealizable`: existence of a constraint permutation
   under which the target output strictly lex-dominates every alternative
   for every input.
 
@@ -82,7 +82,7 @@ variable {Input Output : Type*} {n : ℕ}
 
 /-- A weighting `w` **HG-realizes** the target if, for every input, the target
     output strictly minimizes the weighted violation sum among candidates. -/
-def HGRealizes (P : SystemicProblem Input Output n) (w : Fin n → ℝ) : Prop :=
+def realizedByWeighting (P : SystemicProblem Input Output n) (w : Fin n → ℝ) : Prop :=
   ∀ i ∈ P.inputs, ∀ o ∈ P.cands i, o ≠ P.target i →
     weightedViolations w (P.vp i (P.target i)) <
     weightedViolations w (P.vp i o)
@@ -92,12 +92,12 @@ def HGRealizes (P : SystemicProblem Input Output n) (w : Fin n → ℝ) : Prop :
     standard HG framework; [coetzee-pater-2011] §4.4 discusses the
     consequences of admitting negative weights (e.g., Tejano' realizability). -/
 def IsHGRealizable (P : SystemicProblem Input Output n) : Prop :=
-  ∃ w : Fin n → ℝ, (∀ k, 0 ≤ w k) ∧ P.HGRealizes w
+  ∃ w : Fin n → ℝ, (∀ k, 0 ≤ w k) ∧ P.realizedByWeighting w
 
 /-- A constraint permutation `σ` **OT-realizes** the target if, for every
     input, the target output strictly lex-dominates every alternative under
     the ranking `σ` (smallest σ-index = highest-ranked constraint). -/
-def OTRealizes (P : SystemicProblem Input Output n) (σ : Ranking n) : Prop :=
+def realizedByRanking (P : SystemicProblem Input Output n) (σ : Ranking n) : Prop :=
   ∀ i ∈ P.inputs, ∀ o ∈ P.cands i, o ≠ P.target i →
     toLex (fun k : Fin n => P.vp i (P.target i) (σ k)) <
     toLex (fun k : Fin n => P.vp i o (σ k))
@@ -105,15 +105,15 @@ def OTRealizes (P : SystemicProblem Input Output n) (σ : Ranking n) : Prop :=
 /-- A problem is **OT-realizable** if some constraint ranking realizes
     the target. -/
 def IsOTRealizable (P : SystemicProblem Input Output n) : Prop :=
-  ∃ σ : Ranking n, P.OTRealizes σ
+  ∃ σ : Ranking n, P.realizedByRanking σ
 
 /-- **OT-realization is sole-winner per input.** `σ` OT-realizes `P` iff, for
     every input, the target is the unique optimum of the OT tableau ranking that
     input's candidates by their σ-permuted violation profiles — anchoring
-    `OTRealizes` to `Tableau.optimal`. -/
-theorem otRealizes_iff_optimal [DecidableEq Output]
+    `realizedByRanking` to `Tableau.optimal`. -/
+theorem realizedByRanking_iff_optimal [DecidableEq Output]
     (P : SystemicProblem Input Output n) (σ : Ranking n) :
-    P.OTRealizes σ ↔ ∀ i (hi : i ∈ P.inputs),
+    P.realizedByRanking σ ↔ ∀ i (hi : i ∈ P.inputs),
       Tableau.optimal ⟨P.cands i, fun o => toLex (fun k => P.vp i o (σ k)),
         ⟨P.target i, P.target_mem i hi⟩⟩ = {P.target i} := by
   refine ⟨fun h i hi => ?_, fun h i hi o ho hne => ?_⟩

--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -20,8 +20,8 @@ cardinalities — a clean computation, no measure theory required.
 ## Architecture
 
 POC sits in the substrate alongside `Cumulativity.SystemicProblem`, sharing
-its multi-input optimization model and its `OTRealizes` definition. The new
-content here is:
+its multi-input optimization model and its `realizedByRanking` definition. The
+new content here is:
 
 - `PartialOrderConstraints n`: a partial order on `Fin n` (constraint indices).
 - `IsConsistent p σ`: σ is a linear extension of p.
@@ -275,14 +275,14 @@ variable {Input Output : Type*} {n : ℕ}
     (`consistentTotalOrders_nonempty`), so this genuinely means target
     probability = 1 under POC sampling — not the vacuous empty case, which is
     why no explicit nonemptiness conjunct is needed. -/
-def POCRealizes (P : SystemicProblem Input Output n)
+def realizedByPOC (P : SystemicProblem Input Output n)
     (p : PartialOrderConstraints n) : Prop :=
-  ∀ σ ∈ p.consistentTotalOrders, P.OTRealizes σ
+  ∀ σ ∈ p.consistentTotalOrders, P.realizedByRanking σ
 
 /-- A `SystemicProblem` is **POC-realizable** if some partial order
     categorically realizes the target. -/
 def IsPOCRealizable (P : SystemicProblem Input Output n) : Prop :=
-  ∃ p : PartialOrderConstraints n, P.POCRealizes p
+  ∃ p : PartialOrderConstraints n, P.realizedByPOC p
 
 end SystemicProblem
 
@@ -307,7 +307,7 @@ theorem ot_realizable_imp_poc_realizable {Input Output : Type*} {n : ℕ}
     P.IsOTRealizable → P.IsPOCRealizable := by
   rintro ⟨σ, hσ⟩
   refine ⟨PartialOrderConstraints.fromPermutation σ, ?_⟩
-  simpa [SystemicProblem.POCRealizes,
+  simpa [SystemicProblem.realizedByPOC,
     PartialOrderConstraints.consistentTotalOrders_fromPermutation] using hσ
 
 /-- **Categorical equivalence**: under categorical realizability,


### PR DESCRIPTION
Follow-up to #918: the `OTRealizes`/`HGRealizes`/`POCRealizes` predicates read subject-backwards (`P.OTRealizes σ`, but it's σ that realizes P) and glue an acronym onto the verb.

Renamed the predicate pair (existentials `IsOTRealizable`/`IsHGRealizable` unchanged):
- `OTRealizes` → `realizedByRanking`  (`P.realizedByRanking σ`)
- `HGRealizes` → `realizedByWeighting`
- `POCRealizes` → `realizedByPOC`
- `otRealizes_iff_optimal` → `realizedByRanking_iff_optimal`

Identifier-only; no logic change. Green.