### PR TITLE
refactor(Phonology): cull dead constructors; fix OT citation hygiene

### DIFF
--- a/Linglib/Phonology/OptimalityTheory/Constraints.lean
+++ b/Linglib/Phonology/OptimalityTheory/Constraints.lean
@@ -28,7 +28,8 @@ def myMax := mkMax "MAX-V" (fun c => c.deleted)
 ```
 
 rather than manually assembling the `NamedConstraint` record each time. The
-constructors enforce the correct `Family` classification.
+constructors tag each constraint with its `Family`; the substantive
+faithfulness distinctions (MAX vs DEP vs IDENT) live in `Correspondence`.
 
 ## Contextual faithfulness
 
@@ -89,39 +90,6 @@ def mkIdent {C : Type*} (name : String) (P : C → Prop) [DecidablePred P] :
     family := .faithfulness
     eval := fun c => if P c then 1 else 0 }
 
--- ============================================================================
--- § 1b: Morpheme-Specific Constraint Constructors ([finley-2009])
--- ============================================================================
-
-/-- Build a LEFT-ANCHOR constraint: the morpheme's tonal specification must
-    be in correspondence with the left edge of the host.
-    `P c` holds when the left anchor is not satisfied.
-
-    Following [finley-2009]: morpheme-specific versions of
-    [mccarthy-prince-1995]'s ANCHOR constraints. -/
-def mkAnchorLeft {C : Type*} (name : String) (P : C → Prop) [DecidablePred P] :
-    NamedConstraint C :=
-  { name := name
-    family := .faithfulness
-    eval := λ c => if P c then 1 else 0 }
-
-/-- Build a RIGHT-ANCHOR constraint: the morpheme's tonal specification must
-    be in correspondence with the right edge of the host. -/
-def mkAnchorRight {C : Type*} (name : String) (P : C → Prop) [DecidablePred P] :
-    NamedConstraint C :=
-  { name := name
-    family := .faithfulness
-    eval := λ c => if P c then 1 else 0 }
-
-/-- Build an INTEGRITY constraint: the morpheme's tone must not have
-    multiple correspondents in the output.
-    Penalizes splitting of a single input tone across multiple output TBUs
-    when the one-to-one mapping is violated. -/
-def mkIntegrity {C : Type*} (name : String) (P : C → Prop) [DecidablePred P] :
-    NamedConstraint C :=
-  { name := name
-    family := .faithfulness
-    eval := λ c => if P c then 1 else 0 }
 
 -- ============================================================================
 -- § 2: Markedness Constraint Constructors (re-exported from Constraint)
@@ -182,8 +150,8 @@ def mkForbidSingletonOnTier {C α β : Type*} (name : String) (P : β → Prop)
 def adjacentIdentical {α : Type*} [DecidableEq α] : List α → Nat :=
   countAdjacent (· = ·)
 
-/-- Build an OCP constraint: penalizes adjacent identical elements on a tier.
-    `project` extracts the relevant tier from a candidate.
+/-- Build an OCP constraint ([mccarthy-1986]): penalizes adjacent identical
+    elements on a tier. `project` extracts the relevant tier from a candidate.
 
     The OCP is parametrically polymorphic over the feature type `α` — it
     operates on identity vs. non-identity of adjacent elements, regardless
@@ -207,7 +175,7 @@ def mkOCP {C α : Type*} [DecidableEq α] (name : String) (project : C → List 
     mirroring `mkAgreeOnTier`'s `R := (· ≠ ·)` specialization. The two
     sit in the same constraint algebra and the equivalence is `rfl`.
 
-    [goldsmith-1976] [berent-2026] -/
+    [goldsmith-1976] [mccarthy-1986] [berent-2026] -/
 def mkOCPOnTier {C α β : Type*} [DecidableEq β]
     (name : String) (T : TierProjection α β) (extract : C → List α) :
     NamedConstraint C :=
@@ -248,13 +216,6 @@ def mkAlign {C : Type*} (name : String) (P : C → Prop) [DecidablePred P] :
     family := .markedness
     eval := fun c => if P c then 1 else 0 }
 
-/-- Gradient ALIGN: counts edge-mismatch violations ([mccarthy-prince-1993]). -/
-def mkAlignGrad {C : Type*} (name : String) (violations : C → Nat) :
-    NamedConstraint C :=
-  { name := name
-    family := .markedness
-    eval := violations }
-
 -- ============================================================================
 -- § 3: Violation Bounds
 -- ============================================================================
@@ -288,13 +249,6 @@ open Constraints
 def mkMaxW {C : Type*} (name : String) (P : C → Prop) [DecidablePred P] (w : ℝ) :
     WeightedConstraint C :=
   { toNamedConstraint := mkMax name P, weight := w }
-
-/-- Build a weighted contextual MAX constraint. -/
-def mkMaxCtxW {C : Type*} (name : String)
-    (D : C → Prop) [DecidablePred D]
-    (Ctx : C → Prop) [DecidablePred Ctx] (w : ℝ) :
-    WeightedConstraint C :=
-  { toNamedConstraint := mkMaxCtx name D Ctx, weight := w }
 
 /-- Build a weighted DEP constraint. -/
 def mkDepW {C : Type*} (name : String) (P : C → Prop) [DecidablePred P] (w : ℝ) :

--- a/Linglib/Phonology/OptimalityTheory/Correspondence.lean
+++ b/Linglib/Phonology/OptimalityTheory/Correspondence.lean
@@ -602,7 +602,7 @@ faithful candidate `identity s` — the defining behaviour of a Correspondence-
 Theory faithfulness constraint ([mccarthy-prince-1995]). This is the content the
 `.faithfulness` tag abbreviates; the tag itself is documentary, so the math
 lives in these lemmas. Markedness is non-vacuously different
-(`exists_markedness_not_vanishesOnIdentity`). Anti-faithfulness ([alderete-1999])
+(`exists_markedness_not_vanishesOnIdentity`). Anti-faithfulness ([alderete-2001])
 is out of scope — it demands disparity and is *maximal* on `identity`. -/
 
 @[simp] theorem toMaxConstraint_eval_identity (label : String) (s : List α) :

--- a/Linglib/Phonology/OptimalityTheory/DirectionalTableau.lean
+++ b/Linglib/Phonology/OptimalityTheory/DirectionalTableau.lean
@@ -148,7 +148,7 @@ theorem optima_nonempty
 
 end DirectionalTableau
 
-/-! ### Smoke test (paper, fig. 3 — the divergent tie) -/
+/-! ### Smoke test ([lamont-2022b] — the divergent tie) -/
 
 section SmokeTest
 

--- a/Linglib/Phonology/OptimalityTheory/HarmonicSerialism.lean
+++ b/Linglib/Phonology/OptimalityTheory/HarmonicSerialism.lean
@@ -385,7 +385,7 @@ end HSDerivation
     carries a scalar `eval` for weighted aggregation; `Constraint C` carries a
     vector + term order, with which weighting is incoherent per Lamont 2022b).
 
-    The motivating consumer is paper, fig. 3 (`/kāk^H + rī^H + dō^H/`):
+    The motivating consumer is [mcpherson-lamont-2026] (`/kāk^H + rī^H + dō^H/`):
     parallel HS produces a divergent tie among three deletion candidates;
     directional `*FLOAT^→` breaks the tie by requiring leftmost-first
     deletion. -/

--- a/Linglib/Phonology/OptimalityTheory/TCT.lean
+++ b/Linglib/Phonology/OptimalityTheory/TCT.lean
@@ -34,14 +34,16 @@ modeling choice (one could equally have written
 *reflects* the architectural commitment of [benua-1997]'s "Priority
 of the Base", but does not *deduce* it.
 
-## TETRU schema
+## TETU-style misapplication schema (`TetruSchema`)
 
-The Emergence of the Relatively Unmarked: a constraint ranking of the
-form `M₁ ≫ OO-Ident ≫ M₂ ≫ IO-Faith` (Benua's analog of M&P's
-reduplicative TETU) produces *misapplication identity effects* —
-context-sensitive markedness `M₂` is violated in the derivative iff
-necessary to preserve OO-identity to the base. This unifies
+A constraint ranking of the form `M₁ ≫ OO-Ident ≫ M₂ ≫ IO-Faith` —
+[benua-1997]'s transderivational analog of [mccarthy-prince-1995]'s
+reduplicative TETU (The Emergence of The Unmarked) — produces *misapplication
+identity effects*: context-sensitive markedness `M₂` is violated in the
+derivative iff necessary to preserve OO-identity to the base. This unifies
 overapplication and underapplication as duals of a single mechanism.
+(`TetruSchema` / "TETRU" is this file's shorthand for the schema, not a term
+from [benua-1997].)
 
 The empirical case studies — Sundanese nasal harmony overapplication
 and Tiberian Hebrew spirantization underapplication — are formalized


### PR DESCRIPTION
Cleanup from the OptimalityTheory audit (non-relocation items).

- **Cull 5 dead constructors** (zero consumers repo-wide): `mkAnchorLeft`, `mkAnchorRight`, `mkIntegrity` (the whole `§1b` morpheme-specific section — all byte-identical to `mkFaith`), `mkAlignGrad`, `mkMaxCtxW`.
- **Citation hygiene**: add `[mccarthy-1986]` (canonical OCP-as-constraint) to the OCP constructors; repoint `[alderete-1999]`→`[alderete-2001]` (anti-faithfulness/TDAF) in Correspondence; fill the `paper, fig. 3` placeholders (→ `[lamont-2022b]` / `[mcpherson-lamont-2026]`, dropping the figure numbers per the no-memory-citations rule); soften the "constructors enforce the correct Family" overclaim; mark `TetruSchema`/"TETRU" as this file's shorthand rather than a Benua term (TETU correctly attributed to M&P).

Doc + dead-code only; no logic change. Green; all citation keys verified in the bib.