### PR TITLE
refactor(Phonology/Prosody): recut Word; drop dup MorphStatus

### DIFF
--- a/Linglib/Phonology/Prosody/Word.lean
+++ b/Linglib/Phonology/Prosody/Word.lean
@@ -1,235 +1,44 @@
-import Linglib.Phonology.Prosody.Foot
-import Linglib.Features.Prosody
+import Linglib.Phonology.Prosody.Syllable
 
 /-!
-# Prosodic Word (Word)
-[selkirk-1984]
+# Prosodic word (ω)
+[selkirk-1984] [mccarthy-prince-1993]
 
-The prosodic word (Word, ω) is the prosodic constituent immediately
-above the foot in the prosodic hierarchy:
+The prosodic word ω, the constituent above the foot in the prosodic hierarchy
+(σ < f < ω < φ < ι; the levels themselves live in `Features.Prosody`). This
+module gives ω's weight profile and the minimal-word constraint. The foot-parsed
+ω is `MetricalParse` (`Phonology/Prosody/Foot.lean`); the morphosyntax→prosody
+mapping that fixes ω boundaries is language-specific (Telugu: `Studies/Aitha2026.lean`).
 
-    σ < f < **ω** < φ < ι
+## Main definitions
 
-Word is the domain for a cluster of phonological processes:
-- **Stress assignment** and metrical parsing
-- **Vowel harmony** (progressive harmony in Telugu)
-- **Minimal word constraints** (bimoraic minimum)
-- **Obligatory hiatus resolution** (within Word; optional across Word)
-
-## Morphosyntax-Prosody Mapping
-
-Not all morphological elements are Word-internal. The mapping from
-morphosyntactic structure to prosodic structure determines which
-elements fall within the Word and which form their own domain:
-
-| Morphological status | Word membership | Example (Telugu)     |
-|----------------------|-----------------|----------------------|
-| Root                 | Internal        | samudr-              |
-| Derivational suffix  | Internal        | (not shown)          |
-| Inflectional suffix  | Internal        | -am, -ni, -ki        |
-| Agreement suffix     | Internal        | -ni (1SG), -vi (2SG) |
-| Postposition         | **External**    | -lō, -tō, -gurinci  |
-
-This boundary is diagnosed by vowel harmony scope, minimal word
-effects, and obligatory vs optional hiatus resolution
-([aitha-2026] §3.2).
-
-## Connection to Linglib
-
-`Features.Prosody` defines the prosodic hierarchy levels (σ, f, ω, φ, ι)
-and intonational structure. This module provides the *internal
-structure* of the prosodic word: syllable constituency, weight
-profiles, minimal word constraints, and the morphosyntax-prosody
-mapping that determines Word boundaries.
+* `Prosody.Word`: a prosodic word as a linear weight profile.
+* `Prosody.Word.ofSyllables`: the σ → ω bridge (weight profile of a syllable list).
+* `Prosody.Word.moraCount`: total mora count.
+* `Prosody.Word.satisfiesMinWord`: the minimal-word constraint.
 -/
 
 namespace Prosody
 
-
-/-! ### Morphological status and Word membership -/
-
-/-- Morphological status of an element relative to the prosodic word,
-    decomposed into **orthogonal Boolean axes** rather than a flat
-    enumeration of named cases. The previous inductive design with cases
-    `root | derivational | ... | clitic` conflated three independent
-    dimensions and made it impossible to add new combinations (e.g., a
-    "free" vs. "bound" N2 in a Japanese compound, which is the moderator
-    in [breiss-katsuda-kawahara-2026]) without doubling the case
-    enumeration.
-
-    The three axes:
-
-    - `prWdInternal` — is this element parsed inside the prosodic word
-      with the stem? Empirically diagnosed by vowel-harmony scope,
-      minimal-word effects, and hiatus-resolution obligation
-      ([aitha-2026] §3.2).
-    - `free` — can this element stand alone as a wordform? Roots and
-      free morphemes are `true`; bound roots, inflectional suffixes,
-      and most clitics are `false`. **The Breiss N2 free-vs-bound
-      distinction lives on this axis.**
-    - `affixal` — is this element morphologically bound to a stem
-      (vs. a separate lexical word)? Roots are `false`; affixes,
-      clitics, and bound morphemes are `true`.
-
-    Named constructors below recover the old enum cases. -/
-structure MorphStatus where
-  prWdInternal : Bool
-  free         : Bool
-  affixal      : Bool
-  deriving DecidableEq, Repr
-
-namespace MorphStatus
-
-/-- Root morpheme: Word-internal, free-standing, not affixal. -/
-def root         : MorphStatus := ⟨true,  true,  false⟩
-/-- Derivational affix: Word-internal with the stem, bound, affixal. -/
-def derivational : MorphStatus := ⟨true,  false, true⟩
-/-- Inflectional affix (case, number, tense): Word-internal, bound. -/
-def inflectional : MorphStatus := ⟨true,  false, true⟩
-/-- Agreement marker: Word-internal (crucially, for Telugu nominal
-    predicative agreement; [aitha-2026] §3.1). -/
-def agreement    : MorphStatus := ⟨true,  false, true⟩
-/-- Postposition: forms a **separate** Word. Evidence: not subject to
-    progressive vowel harmony, obeys minimal word constraint
-    independently, hiatus resolution across boundary is optional
-    ([aitha-2026] §3.2). Free-standing in many languages. -/
-def postposition : MorphStatus := ⟨false, true,  false⟩
-/-- Clitic: Word-external boundary element; phonologically bound but
-    syntactically not an affix. -/
-def clitic       : MorphStatus := ⟨false, false, true⟩
-
-/-- Bound free-standing morpheme that occurs only inside compounds —
-    e.g., the "bound" N2 in Japanese compound nominals. Word-internal,
-    not free, not strictly affixal (it's a stem-class member, just one
-    that never surfaces alone). -/
-def boundStem    : MorphStatus := ⟨true,  false, false⟩
-
-end MorphStatus
-
-/-- Is this morphological element parsed inside the Word with the stem?
-    Direct projection of the `prWdInternal` axis. -/
-def MorphStatus.isPrWdInternal (s : MorphStatus) : Bool := s.prWdInternal
-
-/-! ### Prosodic word structure -/
-
-/-- A prosodic word: a sequence of syllables (by weight) that forms a
-    single domain for stress assignment and phonological processes.
-
-    The `syllables` field gives the weight profile in linear order.
-    For example, Telugu *samudram* 'ocean' has profile [L, L, H]
-    (sa.mu.dram). -/
+/-- A prosodic word ω: a sequence of syllables by weight, forming a single
+    domain for stress and word-level phonology. E.g. Telugu *samudram* 'ocean'
+    has profile `[.light, .light, .heavy]` (sa.mu.dram). -/
 structure Word where
   syllables : List Syllable.Weight
   deriving DecidableEq, Repr
 
-/-- The weight profile of a sequence of fully-moraified syllables — the bridge
-    from the structural σ level (`Syllable`) up to the prosodic word. -/
+/-- The weight profile of fully-moraified syllables — the σ → ω bridge. -/
 def Word.ofSyllables (σs : List Syllable) : Word := ⟨σs.map Syllable.weight⟩
 
 /-- Total mora count of a prosodic word (each weight *is* a mora count). -/
 def Word.moraCount (w : Word) : Nat :=
   w.syllables.foldl (· + ·) 0
 
-/-- Number of syllables. -/
-def Word.syllableCount (w : Word) : Nat :=
-  w.syllables.length
-
-/-! ### Minimal word constraint -/
-
-/-- Does a prosodic word satisfy the minimal word constraint?
-
-    [mccarthy-prince-1993]: the smallest prosodic word must
-    contain at least one foot, which requires at least two morae
-    (for moraic trochee languages) or two syllables (for syllabic
-    trochee languages).
-
-    Telugu requires a bimoraic minimum ([aitha-2026] §3.2):
-    the shortest standalone words are informal 2SG imperatives like
-    *rā* 'come' (CVV = 2μ) and *pō* 'go' (CVV = 2μ). No word
-    consists of a single light syllable. -/
+/-- The minimal-word constraint ([mccarthy-prince-1993]): the smallest ω must
+    contain a foot — at least two morae for moraic-trochee languages (the
+    default). Syllabic-trochee minima are syllable-counted, not captured by the
+    default. -/
 abbrev Word.satisfiesMinWord (w : Word) (minMorae : Nat := 2) : Prop :=
   w.moraCount ≥ minMorae
-
-/-! ### Morphological element -/
-
-/-- A morphological element with its prosodic properties.
-    Used to determine how it interacts with the stem's Word. -/
-structure MorphElement where
-  /-- Surface form (for documentation). -/
-  form : String
-  /-- Morphological status (determines Word membership). -/
-  status : MorphStatus
-  /-- Weight of the initial syllable. Relevant for the Telugu weak
-      alternation: the long form is triggered when a *light* initial
-      syllable follows within the Word ([aitha-2026] §3.2). -/
-  initialWeight : Syllable.Weight
-  deriving DecidableEq, Repr
-
-/-- Does this element trigger the long stem form in Telugu weak nouns?
-
-    The long form (-āni) surfaces when the element is:
-    1. Word-internal (inflectional suffix or agreement marker), AND
-    2. Its initial syllable is light (CV = 1μ)
-
-    Postpositions never trigger the long form, even if they begin with
-    a light syllable (e.g., *-gurinci* 'about', *-eduru* 'in front of'),
-    because they are Word-external. -/
-abbrev MorphElement.triggersLongForm (m : MorphElement) : Prop :=
-  m.status.isPrWdInternal ∧ m.initialWeight = .light
-
-/-! ### Word-sensitive phonological processes -/
-
-/-- Hiatus resolution obligation: within a Word, hiatus resolution
-    is **obligatory**; across Word boundaries, it is **optional**.
-
-    [aitha-2026] §3.2: Telugu *koṭṭu* 'to hit' + *-āli* 'OBLIG'
-    → *koṭṭāli* (obligatory deletion of /u/ word-internally), but
-    *kukka eduru* 'in front of the dog' allows optional retention. -/
-inductive HiatusObligation where
-  | obligatory   -- within Word
-  | optional     -- across Word boundary
-  deriving DecidableEq, Repr
-
-/-- Determine hiatus resolution obligation from the morphological
-    status of the following element. -/
-def hiatusObligation (following : MorphStatus) : HiatusObligation :=
-  if following.isPrWdInternal then .obligatory else .optional
-
-/-! ### Worked examples
-
-Anonymous `example`s lock in the morphological-status classification, the
-minimal-word constraint, and the Telugu long-form trigger;
-`agr_1sg_triggers_long` is named because it is reused elsewhere. -/
-
--- Morphological status: roots/inflection/agreement are Word-internal,
--- postpositions external.
-example : MorphStatus.root.isPrWdInternal = true := rfl
-example : MorphStatus.inflectional.isPrWdInternal = true := rfl
-example : MorphStatus.agreement.isPrWdInternal = true := rfl
-example : MorphStatus.postposition.isPrWdInternal = false := rfl
-
--- Minimal word (bimoraic): a heavy, or two lights, satisfies it; a single
--- light does not. Telugu postpositions satisfy it independently — *-lō*
--- (CVV = 2μ), *-kinda* (3μ).
-example : (Word.mk [.heavy]).satisfiesMinWord := by decide
-example : ¬ (Word.mk [.light]).satisfiesMinWord := by decide
-example : (Word.mk [.light, .light]).satisfiesMinWord := by decide
-example : (Word.mk [.heavy, .light]).satisfiesMinWord := by decide
-
--- Hiatus obligation: obligatory Word-internally, optional across a boundary.
-example : hiatusObligation .inflectional = .obligatory := rfl
-example : hiatusObligation .postposition = .optional := rfl
-
--- Long-form trigger: Word-internal + light initial triggers it (ACC *-ni*,
--- DAT *-ki*); postpositions never do, even *-gurinci* (light initial *gu-*).
-example : (MorphElement.mk "-ni" .inflectional .light).triggersLongForm := by decide
-example : (MorphElement.mk "-ki" .inflectional .light).triggersLongForm := by decide
-example : ¬ (MorphElement.mk "-lō" .postposition .heavy).triggersLongForm := by decide
-example : ¬ (MorphElement.mk "-gurinci" .postposition .light).triggersLongForm := by decide
-
-/-- 1SG *-ni*: Word-internal (agreement), light → triggers the long form. Named
-    because it is reused (the Telugu predicative-agreement argument). -/
-theorem agr_1sg_triggers_long :
-    (MorphElement.mk "-ni" .agreement .light).triggersLongForm := by decide
 
 end Prosody

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -7,7 +7,6 @@ import Linglib.Phonology.OptimalityTheory.Predict
 import Linglib.Phonology.Prosody.Foot
 import Linglib.Morphology.DM.VocabularyInsertion
 import Linglib.Phonology.OptimalityTheory.Stratal
-import Linglib.Phonology.Prosody.Word
 import Linglib.Phonology.Prosody.CompensatoryLengthening
 open Morphology.Case.Allomorphy
 
@@ -851,10 +850,30 @@ section PrWdIntegration
 
 open Prosody
 
-/-- Predict the weak stem form from the following morphological element.
-    Uses `MorphElement.triggersLongForm` from `ProsodicWord`: the long
-    form surfaces iff the following element is Word-internal AND begins
-    with a light syllable. -/
+/-- Prosodic-word membership of a following element: parsed inside the host ω
+    (stem, derivational/inflectional/agreement suffixes) or forming its own ω
+    (postpositions). The conditioning dimension is prosodic, not morphosyntactic
+    ([aitha-2026] §3.2). -/
+inductive WordMembership where
+  | internal | external
+  deriving DecidableEq, Repr
+
+/-- A following morphological element: its ω-membership and the weight of its
+    initial syllable — the Telugu weak-noun long-form conditioning. -/
+structure MorphElement where
+  membership    : WordMembership
+  initialWeight : Syllable.Weight
+  deriving DecidableEq, Repr
+
+/-- The long stem form surfaces iff the following element is ω-internal and
+    begins with a light syllable; ω-external postpositions never trigger it,
+    even with a light initial syllable. -/
+abbrev MorphElement.triggersLongForm (m : MorphElement) : Prop :=
+  m.membership = .internal ∧ m.initialWeight = .light
+
+/-- Predict the weak stem form from the following morphological element: the
+    long form surfaces iff the following element is ω-internal AND begins with a
+    light syllable. -/
 def weakSurfaceFromPrWd : Option MorphElement → WeakStemForm
   | some m => if m.triggersLongForm then .long else .short
   | none   => .short  -- no following element → Word-final → short
@@ -862,10 +881,10 @@ def weakSurfaceFromPrWd : Option MorphElement → WeakStemForm
 -- Case suffixes
 
 theorem acc_ni_long :
-    weakSurfaceFromPrWd (some ⟨"-ni", .inflectional, .light⟩) = .long := rfl
+    weakSurfaceFromPrWd (some ⟨.internal, .light⟩) = .long := rfl
 
 theorem dat_ki_long :
-    weakSurfaceFromPrWd (some ⟨"-ki", .inflectional, .light⟩) = .long := rfl
+    weakSurfaceFromPrWd (some ⟨.internal, .light⟩) = .long := rfl
 
 theorem nom_null_short :
     weakSurfaceFromPrWd none = .short := rfl
@@ -876,42 +895,42 @@ theorem gen_null_short :
 -- Agreement suffixes (the decisive diagnostic)
 
 theorem agr_1sg_ni_long :
-    weakSurfaceFromPrWd (some ⟨"-ni", .agreement, .light⟩) = .long := rfl
+    weakSurfaceFromPrWd (some ⟨.internal, .light⟩) = .long := rfl
 
 theorem agr_2sg_vi_long :
-    weakSurfaceFromPrWd (some ⟨"-vi", .agreement, .light⟩) = .long := rfl
+    weakSurfaceFromPrWd (some ⟨.internal, .light⟩) = .long := rfl
 
 -- Postpositions (Word-external → always short)
 
 theorem postp_lo_short :
-    weakSurfaceFromPrWd (some ⟨"-lō", .postposition, .heavy⟩) = .short := rfl
+    weakSurfaceFromPrWd (some ⟨.external, .heavy⟩) = .short := rfl
 
 /-- Postposition *-gurinci* 'about' begins with a light syllable, yet
     triggers the short form — because it is Word-external. This is
     the key evidence that the conditioning is Word membership, not
     syllable weight alone. -/
 theorem postp_gurinci_short :
-    weakSurfaceFromPrWd (some ⟨"-gurinci", .postposition, .light⟩) = .short := rfl
+    weakSurfaceFromPrWd (some ⟨.external, .light⟩) = .short := rfl
 
 /-- The Word-based prediction matches the original paradigm data for
     all five cases in the canonical weak paradigm. -/
 theorem prwd_matches_paradigm :
-    weakSurfaceFromPrWd (some ⟨"-ni", .inflectional, .light⟩) = .long ∧
-    weakSurfaceFromPrWd (some ⟨"-ki", .inflectional, .light⟩) = .long ∧
+    weakSurfaceFromPrWd (some ⟨.internal, .light⟩) = .long ∧
+    weakSurfaceFromPrWd (some ⟨.internal, .light⟩) = .long ∧
     weakSurfaceFromPrWd none = .short ∧
     weakSurfaceFromPrWd none = .short ∧
-    weakSurfaceFromPrWd (some ⟨"-lō", .postposition, .heavy⟩) = .short :=
+    weakSurfaceFromPrWd (some ⟨.external, .heavy⟩) = .short :=
   ⟨rfl, rfl, rfl, rfl, rfl⟩
 
 /-- The Word-based prediction agrees with the original `weakParadigm`
     for all five cases. This closes the gap between the phonological
     derivation (OT + Word) and the empirical data (paradigm). -/
 theorem prwd_agrees_with_paradigm :
-    (weakSurfaceFromPrWd (some ⟨"-ni", .inflectional, .light⟩) = weakParadigm .acc) ∧
-    (weakSurfaceFromPrWd (some ⟨"-ki", .inflectional, .light⟩) = weakParadigm .dat) ∧
+    (weakSurfaceFromPrWd (some ⟨.internal, .light⟩) = weakParadigm .acc) ∧
+    (weakSurfaceFromPrWd (some ⟨.internal, .light⟩) = weakParadigm .dat) ∧
     (weakSurfaceFromPrWd none = weakParadigm .nom) ∧
     (weakSurfaceFromPrWd none = weakParadigm .gen) ∧
-    (weakSurfaceFromPrWd (some ⟨"-lō", .postposition, .heavy⟩) = weakParadigm .loc) :=
+    (weakSurfaceFromPrWd (some ⟨.external, .heavy⟩) = weakParadigm .loc) :=
   ⟨rfl, rfl, rfl, rfl, rfl⟩
 
 end PrWdIntegration

--- a/Linglib/Studies/KalinBjorkmanEtAl2026.lean
+++ b/Linglib/Studies/KalinBjorkmanEtAl2026.lean
@@ -1,7 +1,6 @@
 import Linglib.Morphology.TheorySpace
 import Linglib.Morphology.MorphRule
 import Linglib.Studies.ZwickyPullum1983
-import Linglib.Phonology.Prosody.Word
 import Linglib.Morphology.Containment.Superset
 
 -- ============================================================================
@@ -262,34 +261,6 @@ theorem clitic_implies_ms_free (s : MorphStatus) (h : s.IsClitic) :
 /-- Map Word membership to p-boundedness. -/
 def prWdMembershipToPBound (isPrWdInternal : Bool) : PBoundedness :=
   if isPrWdInternal then .bound else .free
-
-open Prosody in
-theorem inflectional_is_p_bound :
-    prWdMembershipToPBound MorphStatus.inflectional.isPrWdInternal = .bound := rfl
-
-open Prosody in
-theorem agreement_is_p_bound :
-    prWdMembershipToPBound MorphStatus.agreement.isPrWdInternal = .bound := rfl
-
-open Prosody in
-theorem derivational_is_p_bound :
-    prWdMembershipToPBound MorphStatus.derivational.isPrWdInternal = .bound := rfl
-
-open Prosody in
-theorem postposition_is_p_free :
-    prWdMembershipToPBound MorphStatus.postposition.isPrWdInternal = .free := rfl
-
-open Prosody in
-theorem inflAffix_prWdInternal_is_canonicalAffix :
-    (wordhoodProfile .inflAffix
-      (prWdMembershipToPBound MorphStatus.inflectional.isPrWdInternal)
-    ).classify = .canonicalAffix := rfl
-
-open Prosody in
-theorem postposition_prWdExternal_is_canonicalWord :
-    (wordhoodProfile .freeWord
-      (prWdMembershipToPBound MorphStatus.postposition.isPrWdInternal)
-    ).classify = .canonicalWord := rfl
 
 end Morphology.WordhoodBridge
 


### PR DESCRIPTION
Recut `Phonology/Prosody/Word.lean` after a 3-lens design review. It had welded together genuine substrate, a duplicate type, and a single-paper Telugu study.

- **Deleted `Prosody.MorphStatus`** — it duplicated the canonical `Morphology.MorphStatus`, had dead `free`/`affixal` fields, and collapsing constructors (`derivational`=`inflectional`=`agreement`), forcing `KalinBjorkmanEtAl2026` into per-theorem `open Prosody in` juggling.
- **Moved the Telugu apparatus to `Studies/Aitha2026.lean`**: `MorphElement` (now keyed on a study-local `WordMembership` enum, `String form` field dropped) + `triggersLongForm`. Deleted dead `HiatusObligation`/`hiatusObligation`, `Word.syllableCount`, and `agr_1sg_triggers_long` (its "reused elsewhere" docstring was false — Aitha proves its own).
- **Kept the slim `Word` substrate** (`ofSyllables`/`moraCount`/`satisfiesMinWord`) used by `Hayes1989`; fixed two false import edges (`Foot`→`Syllable`; dropped docstring-only `Features.Prosody`); trimmed the docstring to mathlib shape.
- **Kalin**: deleted the 6 redundant `open Prosody in` theorems (duplicates of its §2c); `PBoundedness` left intact (faithful to the paper's Table 3).

Deliberately did NOT graduate a shared `WordMembership` to `Features/Prosody` or retarget Kalin's `PBoundedness`: post-recut it would be a single-consumer substrate type, and retargeting Kalin would reduce fidelity to its source. Membership stays study-local until a second consumer lands.

Net −200 lines; full cone (Word, Hayes1989, Aitha2026, Kalin) builds clean.