### PR TITLE
feat(Phonology/OT): POC consistentTotalOrders = ERC linearExtensions

### DIFF
--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -1,4 +1,5 @@
 import Linglib.Phonology.HarmonicGrammar.Cumulativity
+import Linglib.Phonology.OptimalityTheory.ElementaryRankingCondition
 import Linglib.Core.Optimization.PermSubsetCombinatorics
 import Mathlib.Order.Extension.Linear
 
@@ -26,6 +27,10 @@ new content here is:
 - `PartialOrderConstraints n`: a partial order on `Fin n` (constraint indices).
 - `IsConsistent p σ`: σ is a linear extension of p.
 - `consistentTotalOrders p`: the (decidable, finite) set of linear extensions.
+- `toERCSet p` / `consistentTotalOrders_eq_linearExtensions`: the simple-ERC
+  (Hasse-edge) encoding of `p`, identifying its consistent total orders with the
+  lex-grounded `ERCSet.linearExtensions` — so POC's "linear extension" is the ERC
+  one, not a third re-stipulation ([merchant-riggle-2016]; [prince-2002]).
 - `pocPredict P p i o`: the probability that POC sampling under p selects
   output o for input i, computed as a ratio of consistent extensions
   realizing o vs. all consistent extensions.
@@ -158,6 +163,61 @@ theorem mem_consistentTotalOrders {p : PartialOrderConstraints n}
     {σ : Ranking n} :
     σ ∈ p.consistentTotalOrders ↔ p.IsConsistent σ := by
   simp [consistentTotalOrders]
+
+/-! ### Grounding in the ERC lex API
+
+A partial order is a set of dominance requirements; each strict related pair
+`a ≠ b` with `rel a b` is the Hasse-style ERC `a ≫ b` (`simpleERC a b`,
+[merchant-riggle-2016]'s simple ERCs). Encoding `p` this way shows
+`consistentTotalOrders p` *is* the ERC linear-extension set
+`ERCSet.linearExtensions`, so the POC notion of "consistent total order" is not a
+third re-stipulation of "linear extension" but the lex-grounded ERC one
+([prince-2002]). -/
+
+/-- The simple-ERC encoding of a partial order: one ERC `a ≫ b` (`simpleERC a b`)
+for each strict related pair (`a ≠ b` with `rel a b`). Transitively-implied pairs
+are included as well; they are entailed by the covering pairs, so this set has the
+same linear extensions as the Hasse-edge encoding. Built by computable enumeration
+over `List.finRange` so it carries no `noncomputable` marker. -/
+def toERCSet (p : PartialOrderConstraints n) : ERCSet n :=
+  (List.finRange n).flatMap fun a =>
+    (List.finRange n).filterMap fun b =>
+      if a ≠ b ∧ p.rel a b then some (simpleERC a b) else none
+
+theorem mem_toERCSet {p : PartialOrderConstraints n} {α : ERC n} :
+    α ∈ p.toERCSet ↔ ∃ a b, a ≠ b ∧ p.rel a b ∧ simpleERC a b = α := by
+  simp only [toERCSet, List.mem_flatMap, List.mem_filterMap, List.mem_finRange, true_and]
+  constructor
+  · rintro ⟨a, b, hif⟩
+    split_ifs at hif with hc
+    exact ⟨a, b, hc.1, hc.2, Option.some.inj hif⟩
+  · rintro ⟨a, b, hab, hrel, rfl⟩
+    exact ⟨a, b, by rw [if_pos ⟨hab, hrel⟩]⟩
+
+/-- A ranking satisfies `p.toERCSet` exactly when it is a linear extension of `p`:
+the `a ≫ b` ERCs are the strict dominance requirements, and reflexive pairs impose
+nothing. -/
+theorem satisfiedBy_toERCSet {p : PartialOrderConstraints n} {σ : Ranking n} :
+    ERCSet.satisfiedBy σ p.toERCSet ↔ p.IsConsistent σ := by
+  constructor
+  · intro h a b hrel
+    rcases eq_or_ne a b with rfl | hab
+    · exact le_refl _
+    · exact le_of_lt ((simpleERC_satisfiedBy_iff hab σ).mp
+        (h _ (mem_toERCSet.mpr ⟨a, b, hab, hrel, rfl⟩)))
+  · intro hcons α hα
+    obtain ⟨a, b, hab, hrel, rfl⟩ := mem_toERCSet.mp hα
+    exact (simpleERC_satisfiedBy_iff hab σ).mpr
+      (lt_of_le_of_ne (hcons a b hrel) (fun heq => hab (σ.symm.injective heq)))
+
+/-- **POC consistency is ERC linear extension.** The consistent total orders of a
+partial order are exactly the linear extensions of its simple-ERC encoding —
+collapsing the POC `consistentTotalOrders` into the lex-grounded
+`ERCSet.linearExtensions` ([merchant-riggle-2016]; [prince-2002]). -/
+theorem consistentTotalOrders_eq_linearExtensions (p : PartialOrderConstraints n) :
+    p.consistentTotalOrders = p.toERCSet.linearExtensions := by
+  ext σ
+  rw [mem_consistentTotalOrders, ERCSet.mem_linearExtensions, satisfiedBy_toERCSet]
 
 /-- For the discrete partial order, every permutation is a linear extension. -/
 theorem consistentTotalOrders_discrete (n : ℕ) :

--- a/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
+++ b/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
@@ -31,6 +31,7 @@ some `W`-constraint ([prince-2002] §0 (3)/(4)).
 * `ercOfProfiles` — the sign of a winner/loser violation-profile difference.
 * `ERC.satisfiedBy`, `ERCSet.consistent`, `ERCSet.entails` — the
   satisfaction/consistency/entailment algebra.
+* `ERCSet.linearExtensions` — the (decidable) `Finset` of satisfying rankings.
 * `satisfiedBy_ercOfProfiles_iff_le` — the bridge to the Core lex order.
 * `tableauERC` — the ERC of a winner-loser pair in a tableau.
 * `simpleERC` — a single-`W`/single-`L` ERC, one Hasse edge `i ≫ j`.
@@ -231,10 +232,17 @@ def ERCSet.consistent (E : ERCSet n) : Prop :=
 instance (E : ERCSet n) : Decidable (ERCSet.consistent E) :=
   Fintype.decidableExistsFintype
 
-/-- The rankings consistent with an ERC set — its *linear extensions* in the
-terminology of [merchant-riggle-2016]. -/
-def ERCSet.linearExtensions (E : ERCSet n) : Set (Ranking n) :=
-  { r | ERCSet.satisfiedBy r E }
+/-- The rankings consistent with an ERC set, as a `Finset` — its *linear
+extensions* in the terminology of [merchant-riggle-2016]. Decidable (hence a
+`Finset`) because `satisfiedBy` is. This is the canonical "satisfying rankings"
+object that partial-order grammars reduce to via
+`PartialOrderConstraints.consistentTotalOrders_eq_linearExtensions`. -/
+def ERCSet.linearExtensions (E : ERCSet n) : Finset (Ranking n) :=
+  Finset.univ.filter (fun r => ERCSet.satisfiedBy r E)
+
+@[simp] theorem ERCSet.mem_linearExtensions {E : ERCSet n} {r : Ranking n} :
+    r ∈ E.linearExtensions ↔ ERCSet.satisfiedBy r E := by
+  simp [ERCSet.linearExtensions]
 
 /-! ### Entailment -/
 


### PR DESCRIPTION
Collapses a duplicated notion of "linear extension" into the lex-grounded ERC API.

- `ERCSet.linearExtensions` was a dead orphan (a `Set`, zero consumers). Resurrected as a decidable `Finset` (`Finset.univ.filter satisfiedBy`) with `mem_linearExtensions`.
- `PartialOrderConstraints.toERCSet` — the simple-ERC (Hasse-edge) encoding of a partial order: `simpleERC a b` for each strict related pair `a ≠ b`, `rel a b`. Computable (`List.finRange`/`filterMap`, no `noncomputable`).
- `satisfiedBy_toERCSet` / `consistentTotalOrders_eq_linearExtensions` — POC's `consistentTotalOrders p` *is* `p.toERCSet.linearExtensions`, so POC's "linear extension" is the ERC one, not a third re-stipulation of the same concept.

Sorry-free, axiom-clean. The three POC study consumers (CoetzeePater2011, Zuraw2010, Anttila1997) build unchanged — they use `consistentTotalOrders`/`pocPredict`, untouched.