### PR TITLE
feat(Phonology/Prosody): recursive prosodic-word tree + Bennett2018

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1351,6 +1351,7 @@ import Linglib.Phonology.Prosody.CompensatoryLengthening
 import Linglib.Phonology.Prosody.Foot
 import Linglib.Phonology.Prosody.Mora
 import Linglib.Phonology.Prosody.Syllable
+import Linglib.Phonology.Prosody.Tree
 import Linglib.Phonology.Prosody.Word
 import Linglib.Phonology.Segment
 import Linglib.Phonology.Subregular.Agree
@@ -1993,6 +1994,7 @@ import Linglib.Studies.BaleSchwarz2022
 import Linglib.Studies.BaleSchwarz2026
 import Linglib.Studies.BarAsherSiegal2026
 import Linglib.Studies.BarLev2021
+import Linglib.Studies.Bennett2018
 import Linglib.Studies.BarLevFox2020
 import Linglib.Studies.Barker1995
 import Linglib.Studies.BarkerPullum1990

--- a/Linglib/Phonology/Prosody/Tree.lean
+++ b/Linglib/Phonology/Prosody/Tree.lean
@@ -1,0 +1,80 @@
+import Linglib.Core.Combinatorics.RootedTree.Planar
+import Linglib.Core.Combinatorics.RootedTree.DecEq
+import Linglib.Features.Prosody
+import Linglib.Phonology.Prosody.Syllable
+import Linglib.Phonology.Prosody.Word
+
+/-!
+# Prosodic trees
+
+The recursive prosodic constituent ([ito-mester-2003]): an ω/φ/… tree over the
+prosodic hierarchy. We do **not** define a new tree type — a prosodic tree *is*
+the Core labeled ordered rose tree `RootedTree.Planar` instantiated at the
+prosodic-level labels, so it inherits `Branching`, `DecidableEq`, `map`, and the
+`TreePath` dominance order for free. The prosody layer adds only the
+hierarchy-specific reading: containment, recursion, and the yield. (ω-min/ω-max
+projections land with the first study that targets prosodic domains.)
+
+The size/shape constraints and the syntax→prosody Match constraints
+([ishihara-kalivoda-2022]) are OT constraints over `ProsTree`,
+evaluated by the existing `OptimalityTheory` engine; they live in
+`Phonology/Prosody/Constraints.lean` and `Match.lean`.
+
+## Main definitions
+
+* `Prosody.PLabel` — a node label: a `ProsodicLevel`, plus a mora weight (σ only).
+* `Prosody.ProsTree` — `RootedTree.Planar PLabel`; the prosodic constituent.
+* `Prosody.ProsTree.Containment` — child level ≤ parent level ([ito-mester-2003]).
+* `Prosody.ProsTree.recursionCount` — parses of one element into the same level
+  (= No-Recursion violations); recursion is *representable*, its cost is a constraint.
+* `Prosody.ProsTree.yield` — the terminal weight profile, as a `Word`.
+-/
+
+namespace Prosody
+
+open RootedTree Features.Prosody
+
+/-- A prosodic node label: a hierarchy `level`, plus a mora `weight` that is
+    meaningful only at the σ level (terminals). -/
+structure PLabel where
+  level  : ProsodicLevel
+  weight : Syllable.Weight := 0
+  deriving DecidableEq, Repr
+
+/-- A prosodic tree: the Core ordered rose tree `RootedTree.Planar` labeled by
+    prosodic levels. Ordered children give No-Tangling by construction. -/
+abbrev ProsTree := Planar PLabel
+
+namespace ProsTree
+
+/-- All nodes of the tree (self + descendants), via the Core `Branching` API. -/
+def nodes (t : ProsTree) : List ProsTree := Core.Order.Branching.subtrees t
+
+/-- Containment / weak Strict Layer ([ito-mester-2003]): every child's level
+    is ≤ its parent's in the prosodic hierarchy. Equality (recursion) is allowed;
+    its cost is `recursionCount`, not a ban here. -/
+def Containment (t : ProsTree) : Prop :=
+  ∀ s ∈ t.nodes, ∀ c ∈ s.children, c.label.level ≤ s.label.level
+
+mutual
+/-- No-Recursion violation count ([ito-mester-2003]): parent–child pairs
+    that share a level (an element parsed twice into one category). Defined by
+    structural recursion (mutual with the list aux), so it reduces under `decide`
+    on concrete trees — unlike a `subtrees`-fold via `WellFounded.fix`. -/
+def recursionCount : ProsTree → Nat
+  | .node a cs =>
+      (cs.filter (fun c => decide (c.label.level = a.level))).length
+        + recursionCountList cs
+/-- Auxiliary: total recursion count across a list of subtrees. -/
+def recursionCountList : List ProsTree → Nat
+  | [] => 0
+  | t :: ts => recursionCount t + recursionCountList ts
+end
+
+/-- The terminal weight profile (σ-leaves, left to right) as a `Word` — the
+    σ → ω bridge to the unparsed weight profile. -/
+def yield (t : ProsTree) : Word :=
+  ⟨(t.nodes.filter (fun s => s.children.isEmpty)).map (fun s => s.label.weight)⟩
+
+end ProsTree
+end Prosody

--- a/Linglib/Studies/Bennett2018.lean
+++ b/Linglib/Studies/Bennett2018.lean
@@ -1,0 +1,105 @@
+import Linglib.Phonology.Prosody.Tree
+import Linglib.Phonology.OptimalityTheory.DirectionalTableau
+
+/-!
+# Bennett 2018: recursion of the prosodic word in Kaqchikel
+[bennett-2018]
+
+Bennett, R. (2018). Recursive prosodic words in Kaqchikel (Mayan).
+*Glossa: a journal of general linguistics* 3(1): 67, 1–33.
+
+Kaqchikel splits prefixes into **low-attaching** (parsed inside the stem's ω,
+`[ω LowPref-Stem]`) and **high-attaching** (parsed outside it). Two diagnostics
+converge on this cut: initial glottal-stop insertion (`/V…/ → [ʔV…]`, bled by
+low prefixes but co-occurring with high ones) and degemination (triggered across
+a low-prefix juncture but not a high-prefix one). Bennett argues the
+high-attaching structure is **recursive**, `[ω HighPref [ω Stem]]`: the stem
+keeps its own ω, and the prefix adjoins to a dominating ω. A non-recursive
+analysis must invent an *ad hoc* Clitic/Composite Group, and derivational or
+transderivational alternatives fail on morphological grounds. The conclusion:
+ω-recursion is indispensable.
+
+Formally this is one ranking fact: a `Match(X⁰, ω)` faithfulness constraint
+([ishihara-kalivoda-2022], recasting Selkirk's Match as Max/Dep) outranks
+`NoRecursion` ([ito-mester-2003]). The recursive parse violates `NoRecursion`
+once but satisfies `Match`; the flat parse satisfies `NoRecursion` but violates
+`Match`. With `Match ≫ NoRecursion`, the recursive parse is the optimum — a
+prediction the flat `List`-of-weights `Word` could not even state.
+
+The prosodic candidates are `ProsTree`s (`Phonology/Prosody/Tree.lean`) and the
+prediction is computed by the existing OT engine (`DirectionalTableau.optima`).
+
+## Implementation note
+
+`matchStemViol` here is a stand-in for the full `Match(X⁰, ω)` constraint: it
+penalises the stem morpheme not surfacing as its own ω, with the stem supplied
+as a parameter (the morpheme under analysis). The general syntax↔prosody Match,
+built on `OptimalityTheory.Correspondence`, is future work.
+-/
+
+namespace Bennett2018
+
+open Prosody Features.Prosody RootedTree OptimalityTheory
+
+/-! ### Candidate prosodifications of a high-prefix + stem -/
+
+/-- A high-attaching prefix syllable (light). -/
+def prefσ : ProsTree := .node ⟨.σ, 1⟩ []
+
+/-- The stem syllable (heavy). -/
+def stemσ : ProsTree := .node ⟨.σ, 2⟩ []
+
+/-- Flat parse `[ω HighPref Stem]`: no recursion, but the stem has no ω of its own. -/
+def flatParse : ProsTree := .node ⟨.ω, 0⟩ [prefσ, stemσ]
+
+/-- Recursive parse `[ω HighPref [ω Stem]]`: the stem keeps its ω; the prefix
+    adjoins to a dominating ω ([bennett-2018]). -/
+def recParse : ProsTree := .node ⟨.ω, 0⟩ [prefσ, .node ⟨.ω, 0⟩ [stemσ]]
+
+/-! ### `Match(Stem, ω)` (stand-in) -/
+
+mutual
+/-- Does some ω-node dominate exactly the stem (i.e. have children `[stem]`)? -/
+def hasOmegaOver (stem : ProsTree) : ProsTree → Bool
+  | .node a cs => (decide (a.level = .ω) && decide (cs = [stem])) || hasOmegaOverList stem cs
+/-- Auxiliary over a list of subtrees. -/
+def hasOmegaOverList (stem : ProsTree) : List ProsTree → Bool
+  | [] => false
+  | t :: ts => hasOmegaOver stem t || hasOmegaOverList stem ts
+end
+
+/-- `Match(Stem, ω)` violation: 1 if the stem is not exhaustively matched by an
+    ω of its own, else 0. -/
+def matchStemViol (stem t : ProsTree) : Nat := if hasOmegaOver stem t then 0 else 1
+
+/-! ### The ranking and the prediction -/
+
+/-- `Match(Stem, ω)` — a faithfulness constraint. -/
+def matchStem : Constraint ProsTree := .ofCount "Match(Stem,ω)" .faithfulness (matchStemViol stemσ)
+
+/-- `NoRecursion` — a markedness constraint. -/
+def noRec : Constraint ProsTree := .ofCount "NoRecursion" .markedness ProsTree.recursionCount
+
+/-- The Kaqchikel high-prefix tableau, ranked `Match ≫ NoRecursion`. -/
+def tableau : DirectionalTableau ProsTree where
+  candidates := {recParse, flatParse}
+  ranking := [matchStem, noRec]
+  nonempty := by decide
+
+-- The violation contrast: recursion costs `NoRecursion`, the flat parse costs `Match`.
+example : ProsTree.recursionCount recParse = 1 := by decide
+example : ProsTree.recursionCount flatParse = 0 := by decide
+example : matchStemViol stemσ recParse = 0 := by decide
+example : matchStemViol stemσ flatParse = 1 := by decide
+
+/-- Under `Match(X⁰,ω) ≫ NoRecursion`, the **recursive** parse is the optimum —
+    Bennett's central result, that ω-recursion is forced. -/
+theorem recParse_optimal : tableau.IsOptimal recParse := by decide
+
+/-- The flat (non-recursive) parse is *not* optimal under this ranking. -/
+theorem flatParse_not_optimal : ¬ tableau.IsOptimal flatParse := by decide
+
+/-- Equivalently: the optimal set is exactly the recursive parse. -/
+theorem optima_eq : tableau.optima = {recParse} := by decide
+
+end Bennett2018

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -26264,6 +26264,33 @@
   sources   = {Phenomena/Phonology/Studies/BreissKatsudaKawahara2026.lean}
 }
 
+@article{bennett-2018,
+  author    = {Bennett, Ryan},
+  year      = {2018},
+  title     = {Recursive Prosodic Words in {Kaqchikel} ({Mayan})},
+  journal   = {Glossa: a journal of general linguistics},
+  volume    = {3},
+  number    = {1},
+  pages     = {1--33},
+  doi       = {10.5334/gjgl.550},
+  subfield  = {phonology},
+  role      = {empirical},
+  sources   = {Studies/Bennett2018.lean}
+}
+
+@article{ishihara-kalivoda-2022,
+  author    = {Ishihara, Shinichiro and Kalivoda, Nick},
+  year      = {2022},
+  title     = {{Match Theory}: An Overview},
+  journal   = {Language and Linguistics Compass},
+  volume    = {16},
+  pages     = {e12446},
+  doi       = {10.1111/lnc3.12446},
+  subfield  = {phonology},
+  role      = {foundational},
+  sources   = {Phonology/Prosody/Tree.lean, Studies/Bennett2018.lean}
+}
+
 % REF: Hibiya (1995). The velar nasal in Tokyo Japanese: A
 % sociolinguistic study. PhD dissertation, University of Pennsylvania.
 @phdthesis{hibiya-1995,


### PR DESCRIPTION
Foundation for the recursive prosodic word, designed entirely as an *instantiation* of existing machinery — nothing new in `Core` or `OptimalityTheory`.

- **`Phonology/Prosody/Tree.lean`**: a prosodic tree *is* `RootedTree.Planar PLabel` (the Core ordered labeled rose tree), inheriting `Branching`, `DecidableEq`, `map`, and the `TreePath` dominance order. The prosody layer adds only the hierarchy reading: `nodes`, `Containment` (weak Strict Layer, [ito-mester-2003]), `recursionCount` (No-Recursion — structural so it reduces under `decide`), and `yield` (σ→ω bridge to `Word`).
- **`Studies/Bennett2018.lean`**: Kaqchikel ([bennett-2018]). The recursive parse `[ω HighPref [ω Stem]]` vs the flat `[ω HighPref Stem]`, scored by the existing `DirectionalTableau` engine. `decide`-checked: under `Match(X⁰,ω) ≫ NoRecursion` the recursive parse is the optimum (`optima_eq : tableau.optima = {recParse}`) — a prediction the flat `Word` profile cannot state.

EVAL is the existing `ViolationProfile` lex/monomial order; Match is a structural stand-in for the `Correspondence`-based `Match(X⁰,ω)` (Max/Dep, [ishihara-kalivoda-2022]), to be generalized next. No `sorry`/`native_decide`.

Bib: added `bennett-2018`, `ishihara-kalivoda-2022` (DOIs verified).