### PR TITLE
feat(Studies/Dolatian2020): pre-inflectional DHR via the Prosodic Stem

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2165,6 +2165,7 @@ import Linglib.Studies.DenicEtAl2021
 import Linglib.Studies.Deo2025
 import Linglib.Studies.DeoThomas2025
 import Linglib.Studies.Dixon1994
+import Linglib.Studies.Dolatian2020
 import Linglib.Studies.DongEtAl2026PMF
 import Linglib.Studies.Downing1996
 import Linglib.Studies.Dowty1991

--- a/Linglib/Studies/Dolatian2020.lean
+++ b/Linglib/Studies/Dolatian2020.lean
@@ -1,0 +1,112 @@
+import Mathlib.Data.List.Basic
+
+/-!
+# Dolatian 2020: pre-inflectional vowel reduction and the Prosodic Stem
+[dolatian-2020]
+
+Dolatian, H. (2020). *Computational locality of cyclic phonology in Armenian.*
+PhD dissertation, Stony Brook University.
+
+Eastern Armenian Destressed High Vowel Reduction (DHR) overapplies *before
+V-initial inflection* but not *before C-initial inflection*: *amusín* 'husband'
+→ *amusn-óv* (INST, V-initial: reduces) vs *amusin-nér* (PL, C-initial: no
+reduction). Dolatian argues the conditioning constituent is neither the foot
+(§2.5.3.1, fails) nor a (recursive) prosodic word (§2.5.3.2, argued *against*),
+but Downing's **Prosodic Stem** (PStem), an intermediate constituent mapped from
+the morphological stem. Before V-initial inflection the PStem is *misaligned*
+from syllable boundaries (onset maximization resyllabifies the stem-final
+consonant) and *expands*; expansion triggers the PStem-level cophonology, which
+in Eastern Armenian reduces, in Western Armenian only shifts stress (§2.5.4 (76),
+(78)). Before C-initial inflection the PStem stays isomorphic with the MStem, so
+nothing triggers.
+
+This is **not** an OT analysis: Dolatian formalizes it as a serial/cyclic
+derivation (and computationally as MSO logical transductions), explicitly noting
+(fn. 20) that an OT/Match-theoretic formalization is an *alternative* he does not
+adopt. We therefore model the mechanism derivationally — onset-maximization
+syllabification → PStem misalignment → PStem-cophonology → DHR — rather than as
+constraint optimization. DHR is *derived* from the mechanism (see `dhr_iff`), not
+stipulated as a dialect × inflection table.
+
+## Main definitions
+
+* `Dolatian2020.pstemMisaligned` — the MStem boundary no longer coincides with a
+  syllable boundary (V-initial suffix resyllabified the stem-final consonant).
+* `Dolatian2020.dhrApplies` — DHR derived from PStem expansion × dialect cophonology.
+-/
+
+namespace Dolatian2020
+
+/-- Coarse segment type — enough for onset-maximization syllabification. -/
+inductive Seg | C | V
+  deriving DecidableEq, Repr
+
+/-- An inflectional suffix, as a segment string (only its initial segment matters
+    for syllabification/misalignment). -/
+abbrev Suffix := List Seg
+
+/-- Western vs Eastern Armenian. The dialects share the morphology and the PStem;
+    they differ only in the PStem-level cophonology ([dolatian-2020] §2.5.4 (76)). -/
+inductive Dialect | eArm | wArm
+  deriving DecidableEq, Repr
+
+/-- The PStem-level cophonology: Eastern Armenian's PStem triggers stress *and*
+    DHR; Western Armenian's triggers only stress ([dolatian-2020] (76)). -/
+def Dialect.pstemReduces : Dialect → Bool
+  | .eArm => true
+  | .wArm => false
+
+/-- Onset maximization: a V-initial suffix pulls a single stem-final consonant
+    into its onset, resyllabifying it across the MStem boundary. A C-initial
+    suffix leaves the boundary at a syllable edge. -/
+def resyllabifiesAcrossStemBoundary (stem : List Seg) (suf : Suffix) : Bool :=
+  (stem.getLast? == some .C) && (suf.head? == some .V)
+
+/-- PStem misalignment ([dolatian-2020] §2.5.3): the MStem boundary no longer
+    coincides with a syllable boundary, because a V-initial suffix resyllabified
+    the stem-final consonant. -/
+def pstemMisaligned (stem : List Seg) (suf : Suffix) : Bool :=
+  resyllabifiesAcrossStemBoundary stem suf
+
+/-- The PStem-level cophonology is triggered exactly when the PStem is
+    misaligned and so expands by incorporating the V-initial suffix
+    ([dolatian-2020]: the PStem cophonology applies *only* to misaligned PStems). -/
+def pstemCophonologyTriggered (stem : List Seg) (suf : Suffix) : Bool :=
+  pstemMisaligned stem suf
+
+/-- Destressed High Vowel Reduction applies iff the expanded PStem-level
+    cophonology is triggered **and** the dialect's PStem reduces. The pattern is
+    *derived* from the cyclic mechanism, not a stipulated table (see `dhr_iff`). -/
+def dhrApplies (d : Dialect) (stem : List Seg) (suf : Suffix) : Bool :=
+  pstemCophonologyTriggered stem suf && d.pstemReduces
+
+/-! ### Worked forms: *amusin* 'husband' with V- and C-initial inflection -/
+
+/-- *amusin* = a.mu.sin, consonant-final. -/
+def amusin : List Seg := [.V, .C, .V, .C, .V, .C]
+/-- *-ov* (INST): V-initial. -/
+def sufOv  : Suffix := [.V, .C]
+/-- *-ner* (PL): C-initial. -/
+def sufNer : Suffix := [.C, .V, .C]
+
+-- The misalignment contrast is the V- vs C-initial discriminator, prior to DHR.
+theorem ov_misaligns  : pstemMisaligned amusin sufOv  = true  := by decide
+theorem ner_aligned   : pstemMisaligned amusin sufNer = false := by decide
+
+-- The faithful 2×2 ([dolatian-2020] (78)): DHR overapplies only in EArm before
+-- V-initial inflection.
+theorem earm_ov_reduces  : dhrApplies .eArm amusin sufOv  = true  := by decide  -- amusn-óv
+theorem earm_ner_blocks  : dhrApplies .eArm amusin sufNer = false := by decide  -- amusin-nér
+theorem warm_ov_blocks   : dhrApplies .wArm amusin sufOv  = false := by decide  -- amusin-óv (stress only)
+theorem warm_ner_blocks  : dhrApplies .wArm amusin sufNer = false := by decide
+
+/-- Characterization: pre-inflectional DHR is exactly Eastern Armenian with a
+    misaligned PStem. The V- vs C-initial split falls out of onset-maximization
+    syllabification; the dialect split out of the PStem cophonology — neither is
+    stipulated as a lookup table. -/
+theorem dhr_iff (d : Dialect) (stem : List Seg) (suf : Suffix) :
+    dhrApplies d stem suf = true ↔ d = .eArm ∧ pstemMisaligned stem suf = true := by
+  cases d <;>
+    simp [dhrApplies, Dialect.pstemReduces, pstemCophonologyTriggered]
+
+end Dolatian2020


### PR DESCRIPTION
Eastern Armenian DHR overapplies before V-initial inflection (*amusn-óv*) but not C-initial (*amusin-nér*) ([dolatian-2020]). Formalized **faithfully to the paper's framework**: a serial/cyclic derivation over the **Prosodic Stem**, *not* OT.

- Dolatian argues the domain is neither the foot (§2.5.3.1) nor a recursive PWord (§2.5.3.2, argued *against*) but Downing's PStem; his formalization is serial (and MSO transductions), with OT/Match explicitly named (fn. 20) as an alternative he declines. So this study uses **no OT engine and no recursive-ω substrate** — a distinct derivational mechanism.
- Mechanism, derived not stipulated: onset-maximization resyllabification → PStem misalignment → PStem-cophonology → DHR (Eastern Armenian reduces, Western only shifts stress, §2.5.4 (76)). The theorem `dhr_iff` proves DHR ⟺ (Eastern Armenian ∧ misaligned PStem); the V/C split falls out of syllabification, the dialect split out of the cophonology.
- The faithful 2×2 ((78)) is `decide`-checked on *amusin* + *-ov* / *-ner*. No `sorry` / `native_decide`.

Bib: `dolatian-2020` already present.
