### PR TITLE
refactor(Core/Combinatorics): extract general antimatroid theory

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -59,6 +59,7 @@ import Linglib.Core.Algebra.RotaBaxterLaurent
 import Linglib.Core.Categorical.AgentCat
 import Linglib.Core.Categorical.PartitionCat
 import Linglib.Core.CategoryTheory.Monoidal.LabeledTuple
+import Linglib.Core.Combinatorics.Antimatroid
 import Linglib.Core.Combinatorics.RootedTree.Aut
 import Linglib.Core.Combinatorics.RootedTree.Counting
 import Linglib.Core.Combinatorics.RootedTree.DecEq

--- a/Linglib/Core/Combinatorics/Antimatroid.lean
+++ b/Linglib/Core/Combinatorics/Antimatroid.lean
@@ -1,0 +1,234 @@
+import Mathlib.Data.Set.Basic
+import Mathlib.Data.Set.Finite.Basic
+
+/-!
+# Antimatroids
+
+Antimatroids are combinatorial structures that generalize the notion of a partial
+order. They were first described by [dilworth-1940] in the context of lattice
+theory and have been rediscovered many times under different names
+([monjardet-1985]; see [korte-lovasz-schrader-1991] for a comprehensive survey).
+An antimatroid is uniquely determined by its *rooted circuits* ([dietrich-1987]).
+
+This file develops the framework-agnostic theory; the Optimality-Theory
+specialization (the ERC–antimatroid isomorphism of [merchant-riggle-2016]) lives
+in `Linglib.Phonology.OptimalityTheory.Antimatroid`.
+
+**[UPSTREAM]**: mathlib has `Matroid` but no `Antimatroid`/`Greedoid`. The design
+mirrors mathlib's `Matroid`: a bundled structure (not a typeclass) with a `Set α`
+ground set and `Prop` axioms.
+
+## Main definitions
+
+* `SetSystem` — a ground set `E` with a collection of feasible subsets.
+* `AccessibleSetSystem` — a set system with augmentation and removal.
+* `Antimatroid` — an accessible set system closed under union.
+* `Antimatroid.Finite` — finiteness of the ground set, as an inferable class.
+* `Antimatroid.free` — the free antimatroid on `E` (every subset feasible).
+* `Antimatroid.trace` — the trace `A : S`, restricting feasibility to `· ∩ S`.
+* `Antimatroid.RootedCircuit` — a minimal non-free trace, with a root.
+
+## References
+
+[dilworth-1940] — Lattices with unique irreducible decompositions
+[monjardet-1985] — A use for frequently rediscovering a concept (antimatroids)
+[dietrich-1987] — A circuit set characterization of antimatroids
+[korte-lovasz-schrader-1991] — Greedoids
+[merchant-riggle-2016] — OT grammars, beyond partial orders: ERC sets and antimatroids
+-/
+
+/-! ### Set systems -/
+
+/-- A **set system** `(G, F)` is a finite ground set `G` with a
+    collection `F` of subsets of `G`, called **feasible sets**.
+
+    Any subset of a power set is a set system. The feasible sets are
+    the subsets of `G` that the system "recognizes." -/
+structure SetSystem (α : Type*) where
+  /-- The ground set. -/
+  E : Set α
+  /-- The feasible set predicate: `IsFeasible S` means `S` is a
+      recognized subset of the ground set. -/
+  IsFeasible : Set α → Prop
+  /-- The empty set is always feasible. -/
+  empty_feasible : IsFeasible ∅
+  /-- Feasible sets are subsets of the ground set. -/
+  feasible_sub : ∀ S, IsFeasible S → S ⊆ E
+
+/-! ### Accessible set systems -/
+
+/-- An **accessible set system** is a set system with augmentation and
+    removal properties. Informally:
+
+    - **Augmentation**: any feasible set that isn't the full ground set
+      can be extended by adding one element to produce another feasible set.
+    - **Removal**: any non-empty feasible set can be shrunk by removing
+      one element to produce another feasible set.
+
+    The term "accessible" refers to the fact that both the empty set and
+    the ground set are reachable from any feasible set via single-element
+    additions or removals.
+
+    [merchant-riggle-2016] Definition 3. -/
+structure AccessibleSetSystem (α : Type*) extends SetSystem α where
+  /-- The ground set is feasible. -/
+  ground_feasible : IsFeasible E
+  /-- **Augmentation**: every feasible set that is not the ground set
+      can be extended by adding one element from `E` to produce another
+      feasible set. -/
+  augmentation : ∀ S, IsFeasible S → S ≠ E →
+    ∃ x ∈ E, x ∉ S ∧ IsFeasible (insert x S)
+  /-- **Removal**: every non-empty feasible set can be shrunk by
+      removing one element to produce another feasible set. -/
+  removal : ∀ S, IsFeasible S → S.Nonempty →
+    ∃ x ∈ S, IsFeasible (S \ {x})
+
+/-! ### Antimatroids -/
+
+/-- An **antimatroid** is an accessible set system that is closed under
+    union: the union of any two feasible sets is also feasible.
+
+    The three defining properties — accessibility (augmentation + removal)
+    and union closure — are what [merchant-riggle-2016] prove isomorphic to
+    consistent ERC sets.
+
+    The design follows mathlib's `Matroid`: bundled structure (not a
+    typeclass), `Set α` ground set, `Prop` axioms.
+
+    [merchant-riggle-2016] Definition 5. -/
+structure Antimatroid (α : Type*) extends AccessibleSetSystem α where
+  /-- **Union closure**: the union of any two feasible sets is feasible.
+
+      This property distinguishes antimatroids from arbitrary accessible
+      set systems. It corresponds to the fact that consistent ERC sets
+      have "disjunctive" ranking requirements — if two partial rankings
+      are consistent, their union (combining their requirements) is also
+      consistent. -/
+  union_closed : ∀ S T, IsFeasible S → IsFeasible T → IsFeasible (S ∪ T)
+
+/-! ### Finiteness -/
+
+/-- An antimatroid with a finite ground set. Following mathlib's
+    `Matroid.Finite`, this is a typeclass so it can be inferred. -/
+class Antimatroid.Finite {α : Type*} (A : Antimatroid α) : Prop where
+  ground_finite : A.E.Finite
+
+theorem Antimatroid.ground_finite {α : Type*} (A : Antimatroid α)
+    [A.Finite] : A.E.Finite :=
+  Antimatroid.Finite.ground_finite
+
+/-! ### Basic properties -/
+
+variable {α : Type*}
+
+/-- The ground set of an antimatroid is feasible. -/
+theorem Antimatroid.ground_isFeasible (A : Antimatroid α) :
+    A.IsFeasible A.E :=
+  A.ground_feasible
+
+/-- The empty set is feasible in any antimatroid. -/
+theorem Antimatroid.empty_isFeasible (A : Antimatroid α) :
+    A.IsFeasible ∅ :=
+  A.empty_feasible
+
+/-- Singletons in the ground set are feasible in any antimatroid.
+
+    Proof: the empty set is feasible and not equal to `E` (since `E`
+    contains `x`), so by augmentation there exists some `y ∈ E` with
+    `{y}` feasible. By induction (via removal from larger sets), every
+    singleton is feasible.
+
+    For now, we prove only the weaker statement that some singleton
+    exists. -/
+theorem Antimatroid.exists_singleton_feasible (A : Antimatroid α)
+    (hne : A.E.Nonempty) : ∃ x ∈ A.E, A.IsFeasible {x} := by
+  have hne_ground : (∅ : Set α) ≠ A.E := by
+    intro h; obtain ⟨x, hx⟩ := hne; simp [← h] at hx
+  obtain ⟨x, hx_mem, _, hx_feas⟩ := A.augmentation ∅ A.empty_feasible hne_ground
+  have : insert x (∅ : Set α) = {x} := by ext; simp
+  rw [this] at hx_feas
+  exact ⟨x, hx_mem, hx_feas⟩
+
+/-! ### The free antimatroid -/
+
+/-- The **free antimatroid** on a set `E`: every subset is feasible.
+
+    This corresponds to the OT system with no ranking requirements
+    (the empty ERC set) — all `n!` rankings are consistent.
+    [merchant-riggle-2016] Definition 8. -/
+def Antimatroid.free (E : Set α) : Antimatroid α where
+  E := E
+  IsFeasible := fun S => S ⊆ E
+  empty_feasible := Set.empty_subset E
+  feasible_sub := fun _ h => h
+  ground_feasible := Set.Subset.refl E
+  augmentation := fun S hS hne => by
+    obtain ⟨x, hxE, hxS⟩ : ∃ x, x ∈ E ∧ x ∉ S := by
+      by_contra h
+      apply hne
+      ext x
+      constructor
+      · intro hx; exact hS hx
+      · intro hx
+        by_contra hxS
+        exact h ⟨x, hx, hxS⟩
+    exact ⟨x, hxE, hxS, Set.insert_subset hxE hS⟩
+  removal := fun S hS hne => by
+    obtain ⟨x, hx⟩ := hne
+    exact ⟨x, hx, Set.sdiff_subset.trans hS⟩
+  union_closed := fun _ _ hS hT => Set.union_subset hS hT
+
+/-- The free antimatroid on `E` has `IsFeasible S ↔ S ⊆ E`. -/
+theorem Antimatroid.free_isFeasible (E : Set α) (S : Set α) :
+    (Antimatroid.free E).IsFeasible S ↔ S ⊆ E :=
+  Iff.rfl
+
+/-! ### Traces -/
+
+/-- The **trace** of antimatroid `A` on subset `S ⊆ E` is the
+    antimatroid `(S, {f ∩ S | f ∈ F})` — restricting the feasible
+    sets to their intersections with `S`.
+
+    Traces capture the ordering relations that the original antimatroid
+    places on the constraints in `S`.
+
+    [merchant-riggle-2016] Definition 7. -/
+def Antimatroid.trace (A : Antimatroid α) (S : Set α) (_hS : S ⊆ A.E) :
+    SetSystem α where
+  E := S
+  IsFeasible := fun T => ∃ F, A.IsFeasible F ∧ T = F ∩ S
+  empty_feasible := ⟨∅, A.empty_feasible, by simp⟩
+  feasible_sub := fun T ⟨F, _, hT⟩ => hT ▸ Set.inter_subset_right
+
+/-! ### Rooted circuits -/
+
+/-- A **rooted circuit** of antimatroid `A` on `S ⊆ E` is a trace
+    `A : S` such that every proper subset of `S` gives a free trace
+    (no ordering constraints), but `A : S` itself is not free.
+
+    Rooted circuits are the minimal subsets of `E` that encode actual
+    ranking requirements. Each rooted circuit corresponds to exactly
+    one ERC under the `RCErc` map.
+
+    The **root** of the circuit is the unique element `r ∈ S` such that
+    `{r}` is not feasible in `A : S`.
+
+    [merchant-riggle-2016] Definition 9. -/
+structure Antimatroid.RootedCircuit (A : Antimatroid α) where
+  /-- The set defining the circuit. -/
+  carrier : Set α
+  /-- The carrier is a subset of the ground set. -/
+  carrier_sub : carrier ⊆ A.E
+  /-- The root element. -/
+  root : α
+  /-- The root is in the carrier. -/
+  root_mem : root ∈ carrier
+  /-- The trace on the carrier is not free: `{root}` is not feasible
+      in the trace. -/
+  not_free : ¬ (A.trace carrier carrier_sub).IsFeasible {root}
+  /-- Every proper subset of the carrier gives a free trace:
+      for every `T ⊂ carrier` and `x ∈ T`, the singleton `{x}` is
+      feasible in the trace `A : T`. -/
+  proper_free : ∀ T : Set α, ∀ hT : T ⊂ carrier,
+    ∀ x ∈ T,
+      (A.trace T (hT.subset.trans carrier_sub)).IsFeasible {x}

--- a/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
+++ b/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
@@ -1,36 +1,18 @@
 import Linglib.Phonology.OptimalityTheory.ElementaryRankingCondition
-import Mathlib.Data.Set.Basic
-import Mathlib.Data.Set.Finite.Basic
+import Linglib.Core.Combinatorics.Antimatroid
 import Mathlib.Data.Fintype.Card
 import Mathlib.Tactic.Linarith
 
 /-!
-# OT — Antimatroids and the ERC–Antimatroid Isomorphism
+# OT — the ERC–Antimatroid isomorphism
 
-Antimatroids are combinatorial structures that generalize the notion of
-a partial order. They were first described by [dilworth-1940] in
-the context of lattice theory and have been rediscovered many times
-under different names (see [korte-lovasz-schrader-1991] for a
-comprehensive survey).
-
-For Optimality Theory, antimatroids are significant because
-[merchant-riggle-2016] prove that consistent ERC sets over `n`
-constraints are isomorphic to antimatroids on `Fin n`. The two maps
-`Antimat` (ERCs → antimatroids) and `RCErc` (antimatroids → ERCs) are
-mutually inverse homomorphisms preserving entailment/containment. Any
-result about antimatroids transfers immediately to OT: learning
-algorithms, typological classification, complexity bounds.
-
-## Definitions (general antimatroid theory)
-
-Following [merchant-riggle-2016] Definitions 2–5:
-
-- `SetSystem` — a ground set `G` with a collection `F` of feasible subsets
-- `AccessibleSetSystem` — augmentation + removal properties
-- `Antimatroid` — accessible set system closed under union
-
-The design follows mathlib's `Matroid` pattern: bundled structure with
-`Set α` ground set and `Prop` axioms.
+[merchant-riggle-2016] prove that consistent ERC sets over `n` constraints are
+isomorphic to antimatroids on `Fin n`. This file builds that correspondence on top
+of the framework-agnostic antimatroid theory in
+`Linglib.Core.Combinatorics.Antimatroid` (`SetSystem`, `Antimatroid`,
+`Antimatroid.free`/`trace`/`RootedCircuit`). The two maps `Antimat` (ERCs →
+antimatroids) and `RCErc` (antimatroids → ERCs) are mutually inverse homomorphisms
+preserving entailment/containment, so any antimatroid result transfers to OT.
 
 ## ERC → Antimatroid pipeline
 
@@ -49,13 +31,10 @@ The design follows mathlib's `Matroid` pattern: bundled structure with
   coincide (Birkhoff order-ideal ↔ linear-extension-prefix correspondence)
 - `Antimat.ofSimple` — the resulting decidable antimatroid on a simple ERC set
 
-## Lemmas
+## Lemmas and theorems
 
 - `maximalChain_dominance` — prefix sets are downward-closed under dominance
 - `MChain.union_closed` — Lemma 3: MChain is union-closed
-
-## Theorems
-
 - `Antimat_entailment` — Theorem 3: entailment → containment (proved)
 - `RCErc_single_eq_simpleERC` — two-element rooted circuits are simple ERCs (proved)
 - `Antimat_RCErc_inv` — Theorem 1: `Antimat ∘ RCErc = id` (stated; proof `sorry`)
@@ -68,230 +47,13 @@ The three `sorry`s are the general antimatroid → ERC direction, which rests on
 
 ## References
 
-[dilworth-1940] — Lattices with unique irreducible decompositions
-[monjardet-1985] — A use for frequently rediscovering a concept (antimatroids)
 [dietrich-1987] — A circuit set characterization of antimatroids
-[korte-lovasz-schrader-1991] — Greedoids
 [merchant-riggle-2016] — OT grammars, beyond partial orders:
 ERC sets and antimatroids
 -/
 
 namespace OptimalityTheory
 open Constraints
-
-
--- ============================================================================
--- § 1: Set System (Definition 2)
--- ============================================================================
-
-/-- A **set system** `(G, F)` is a finite ground set `G` with a
-    collection `F` of subsets of `G`, called **feasible sets**.
-
-    Any subset of a power set is a set system. The feasible sets are
-    the subsets of `G` that the system "recognizes." -/
-structure SetSystem (α : Type*) where
-  /-- The ground set. -/
-  E : Set α
-  /-- The feasible set predicate: `IsFeasible S` means `S` is a
-      recognized subset of the ground set. -/
-  IsFeasible : Set α → Prop
-  /-- The empty set is always feasible. -/
-  empty_feasible : IsFeasible ∅
-  /-- Feasible sets are subsets of the ground set. -/
-  feasible_sub : ∀ S, IsFeasible S → S ⊆ E
-
--- ============================================================================
--- § 2: Accessible Set System (Definition 3)
--- ============================================================================
-
-/-- An **accessible set system** is a set system with augmentation and
-    removal properties. Informally:
-
-    - **Augmentation**: any feasible set that isn't the full ground set
-      can be extended by adding one element to produce another feasible set.
-    - **Removal**: any non-empty feasible set can be shrunk by removing
-      one element to produce another feasible set.
-
-    The term "accessible" refers to the fact that both the empty set and
-    the ground set are reachable from any feasible set via single-element
-    additions or removals.
-
-    [merchant-riggle-2016] Definition 3. -/
-structure AccessibleSetSystem (α : Type*) extends SetSystem α where
-  /-- The ground set is feasible. -/
-  ground_feasible : IsFeasible E
-  /-- **Augmentation**: every feasible set that is not the ground set
-      can be extended by adding one element from `E` to produce another
-      feasible set. -/
-  augmentation : ∀ S, IsFeasible S → S ≠ E →
-    ∃ x ∈ E, x ∉ S ∧ IsFeasible (insert x S)
-  /-- **Removal**: every non-empty feasible set can be shrunk by
-      removing one element to produce another feasible set. -/
-  removal : ∀ S, IsFeasible S → S.Nonempty →
-    ∃ x ∈ S, IsFeasible (S \ {x})
-
--- ============================================================================
--- § 3: Antimatroid (Definition 5)
--- ============================================================================
-
-/-- An **antimatroid** is an accessible set system that is closed under
-    union: the union of any two feasible sets is also feasible.
-
-    This is the structure that [merchant-riggle-2016] prove is
-    isomorphic to consistent ERC sets. The three defining properties —
-    accessibility (augmentation + removal) and union closure — correspond
-    exactly to the combinatorial structure of OT ranking spaces.
-
-    The design follows mathlib's `Matroid`: bundled structure (not a
-    typeclass), `Set α` ground set, `Prop` axioms.
-
-    [merchant-riggle-2016] Definition 5. -/
-structure Antimatroid (α : Type*) extends AccessibleSetSystem α where
-  /-- **Union closure**: the union of any two feasible sets is feasible.
-
-      This property distinguishes antimatroids from arbitrary accessible
-      set systems. It corresponds to the fact that consistent ERC sets
-      have "disjunctive" ranking requirements — if two partial rankings
-      are consistent, their union (combining their requirements) is also
-      consistent. -/
-  union_closed : ∀ S T, IsFeasible S → IsFeasible T → IsFeasible (S ∪ T)
-
--- ============================================================================
--- § 4: Finiteness
--- ============================================================================
-
-/-- An antimatroid with a finite ground set. Following mathlib's
-    `Matroid.Finite`, this is a typeclass so it can be inferred. -/
-class Antimatroid.Finite {α : Type*} (A : Antimatroid α) : Prop where
-  ground_finite : A.E.Finite
-
-theorem Antimatroid.ground_finite {α : Type*} (A : Antimatroid α)
-    [A.Finite] : A.E.Finite :=
-  Antimatroid.Finite.ground_finite
-
--- ============================================================================
--- § 5: Basic Properties
--- ============================================================================
-
-variable {α : Type*}
-
-/-- The ground set of an antimatroid is feasible. -/
-theorem Antimatroid.ground_isFeasible (A : Antimatroid α) :
-    A.IsFeasible A.E :=
-  A.ground_feasible
-
-/-- The empty set is feasible in any antimatroid. -/
-theorem Antimatroid.empty_isFeasible (A : Antimatroid α) :
-    A.IsFeasible ∅ :=
-  A.empty_feasible
-
-/-- Singletons in the ground set are feasible in any antimatroid.
-
-    Proof: the empty set is feasible and not equal to `E` (since `E`
-    contains `x`), so by augmentation there exists some `y ∈ E` with
-    `{y}` feasible. By induction (via removal from larger sets), every
-    singleton is feasible.
-
-    For now, we prove only the weaker statement that some singleton
-    exists. -/
-theorem Antimatroid.exists_singleton_feasible (A : Antimatroid α)
-    (hne : A.E.Nonempty) : ∃ x ∈ A.E, A.IsFeasible {x} := by
-  have hne_ground : (∅ : Set α) ≠ A.E := by
-    intro h; obtain ⟨x, hx⟩ := hne; simp [← h] at hx
-  obtain ⟨x, hx_mem, _, hx_feas⟩ := A.augmentation ∅ A.empty_feasible hne_ground
-  have : insert x (∅ : Set α) = {x} := by ext; simp
-  rw [this] at hx_feas
-  exact ⟨x, hx_mem, hx_feas⟩
-
--- ============================================================================
--- § 6: The Free Antimatroid
--- ============================================================================
-
-/-- The **free antimatroid** on a set `E`: every subset is feasible.
-
-    This corresponds to the OT system with no ranking requirements
-    (the empty ERC set) — all `n!` rankings are consistent.
-    [merchant-riggle-2016] Definition 8. -/
-def Antimatroid.free (E : Set α) : Antimatroid α where
-  E := E
-  IsFeasible := fun S => S ⊆ E
-  empty_feasible := Set.empty_subset E
-  feasible_sub := fun _ h => h
-  ground_feasible := Set.Subset.refl E
-  augmentation := fun S hS hne => by
-    obtain ⟨x, hxE, hxS⟩ : ∃ x, x ∈ E ∧ x ∉ S := by
-      by_contra h
-      apply hne
-      ext x
-      constructor
-      · intro hx; exact hS hx
-      · intro hx
-        by_contra hxS
-        exact h ⟨x, hx, hxS⟩
-    exact ⟨x, hxE, hxS, Set.insert_subset hxE hS⟩
-  removal := fun S hS hne => by
-    obtain ⟨x, hx⟩ := hne
-    exact ⟨x, hx, Set.sdiff_subset.trans hS⟩
-  union_closed := fun _ _ hS hT => Set.union_subset hS hT
-
-/-- The free antimatroid on `E` has `IsFeasible S ↔ S ⊆ E`. -/
-theorem Antimatroid.free_isFeasible (E : Set α) (S : Set α) :
-    (Antimatroid.free E).IsFeasible S ↔ S ⊆ E :=
-  Iff.rfl
-
--- ============================================================================
--- § 7: Traces (Definition 7)
--- ============================================================================
-
-/-- The **trace** of antimatroid `A` on subset `S ⊆ E` is the
-    antimatroid `(S, {f ∩ S | f ∈ F})` — restricting the feasible
-    sets to their intersections with `S`.
-
-    Traces capture the ordering relations that the original antimatroid
-    places on the constraints in `S`.
-
-    [merchant-riggle-2016] Definition 7. -/
-def Antimatroid.trace (A : Antimatroid α) (S : Set α) (_hS : S ⊆ A.E) :
-    SetSystem α where
-  E := S
-  IsFeasible := fun T => ∃ F, A.IsFeasible F ∧ T = F ∩ S
-  empty_feasible := ⟨∅, A.empty_feasible, by simp⟩
-  feasible_sub := fun T ⟨F, _, hT⟩ => hT ▸ Set.inter_subset_right
-
--- ============================================================================
--- § 8: Rooted Circuits (Definition 9)
--- ============================================================================
-
-/-- A **rooted circuit** of antimatroid `A` on `S ⊆ E` is a trace
-    `A : S` such that every proper subset of `S` gives a free trace
-    (no ordering constraints), but `A : S` itself is not free.
-
-    Rooted circuits are the minimal subsets of `E` that encode actual
-    ranking requirements. Each rooted circuit corresponds to exactly
-    one ERC under the `RCErc` map.
-
-    The **root** of the circuit is the unique element `r ∈ S` such that
-    `{r}` is not feasible in `A : S`.
-
-    [merchant-riggle-2016] Definition 9. -/
-structure Antimatroid.RootedCircuit (A : Antimatroid α) where
-  /-- The set defining the circuit. -/
-  carrier : Set α
-  /-- The carrier is a subset of the ground set. -/
-  carrier_sub : carrier ⊆ A.E
-  /-- The root element. -/
-  root : α
-  /-- The root is in the carrier. -/
-  root_mem : root ∈ carrier
-  /-- The trace on the carrier is not free: `{root}` is not feasible
-      in the trace. -/
-  not_free : ¬ (A.trace carrier carrier_sub).IsFeasible {root}
-  /-- Every proper subset of the carrier gives a free trace:
-      for every `T ⊂ carrier` and `x ∈ T`, the singleton `{x}` is
-      feasible in the trace `A : T`. -/
-  proper_free : ∀ T : Set α, ∀ hT : T ⊂ carrier,
-    ∀ x ∈ T,
-      (A.trace T (hT.subset.trans carrier_sub)).IsFeasible {x}
 
 -- ============================================================================
 -- § 9: Maximal Chains (Definition 1)


### PR DESCRIPTION
Splits the framework-agnostic antimatroid theory out of the OT file into `Core/Combinatorics/Antimatroid.lean`, giving it a reusable, upstreamable home (mathlib has `Matroid` but no `Antimatroid`/`Greedoid`).

- **New `Core/Combinatorics/Antimatroid.lean`** (sorry-free, root namespace, marked `[UPSTREAM]`): `SetSystem`, `AccessibleSetSystem`, `Antimatroid`, `Antimatroid.Finite`, `free`, `trace`, `RootedCircuit`, and the basic properties — all the general structures, over `Type*`, depending only on `Mathlib.Data.Set.{Basic,Finite}`.
- **`Phonology/OptimalityTheory/Antimatroid.lean`** now imports the Core file and keeps only the OT-specific content (`MChain`, `Antimat`, `Feasible`/`FeasiblePrefix`, the simple-ERC Birkhoff fragment, `RCErc`, the isomorphism theorems). The three honest `sorry`s (general antimatroid → ERC, resting on [dietrich-1987]) stay here.

Pure relocation — no logic changes. Cone builds green, including the `pocAntimatroid` consumer and the POC study files (CoetzeePater2011, Zuraw2010, Anttila1997).