### PR TITLE
feat(Phonology/Prosody): word-size theory over unified Tree carrier

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1354,6 +1354,7 @@ import Linglib.Phonology.Prosody.Mora
 import Linglib.Phonology.Prosody.Syllable
 import Linglib.Phonology.Prosody.Tree
 import Linglib.Phonology.Prosody.Word
+import Linglib.Phonology.Prosody.WordSize
 import Linglib.Phonology.Segment
 import Linglib.Phonology.Subregular.Agree
 import Linglib.Phonology.Subregular.ForbidPairs
@@ -2686,6 +2687,7 @@ import Linglib.Studies.TsiliaZhao2026
 import Linglib.Studies.TsvilodubEtAl2026
 import Linglib.Studies.TurcoBraunDimroth2014
 import Linglib.Studies.TurkHirsch2026
+import Linglib.Studies.Uchihara2021
 import Linglib.Studies.Umbach2004
 import Linglib.Studies.VanDerAuweraVanAlsenoy2016
 import Linglib.Studies.VanDerLeer2026

--- a/Linglib/Phonology/Prosody/Tree.lean
+++ b/Linglib/Phonology/Prosody/Tree.lean
@@ -15,7 +15,7 @@ prosodic-level labels, so it inherits `Branching`, `DecidableEq`, `map`, and the
 hierarchy-specific reading: containment, recursion, and the yield. (ω-min/ω-max
 projections land with the first study that targets prosodic domains.)
 
-Scoring functions are plain `ProsTree → ℕ` (e.g. `recursionCount`); a grammar is
+Scoring functions are plain `Tree → ℕ` (e.g. `recursionCount`); a grammar is
 the lex-minimum of the candidates under their violation profile — mathlib's
 `Order.Minimal` (computably, `Core.Optimization`'s `argMinSet`) under
 `Order.Preimage profile LexLE`, with no bespoke constraint/tableau structure.
@@ -25,11 +25,11 @@ faithfulness machinery (`OptimalityTheory.Correspondence`, Max/Dep) — future w
 ## Main definitions
 
 * `Prosody.PLabel` — a node label: a `ProsodicLevel`, plus a mora weight (σ only).
-* `Prosody.ProsTree` — `RootedTree.Planar PLabel`; the prosodic constituent.
-* `Prosody.ProsTree.Containment` — child level ≤ parent level ([ito-mester-2003]).
-* `Prosody.ProsTree.recursionCount` — parses of one element into the same level
+* `Prosody.Tree` — `RootedTree.Planar PLabel`; the prosodic constituent.
+* `Prosody.Tree.Containment` — child level ≤ parent level ([ito-mester-2003]).
+* `Prosody.Tree.recursionCount` — parses of one element into the same level
   (= No-Recursion violations); recursion is *representable*, its cost is a constraint.
-* `Prosody.ProsTree.yield` — the terminal weight profile, as a `Word`.
+* `Prosody.Tree.yield` — the terminal weight profile, as a `Word`.
 -/
 
 namespace Prosody
@@ -45,17 +45,17 @@ structure PLabel where
 
 /-- A prosodic tree: the Core ordered rose tree `RootedTree.Planar` labeled by
     prosodic levels. Ordered children give No-Tangling by construction. -/
-abbrev ProsTree := Planar PLabel
+abbrev Tree := Planar PLabel
 
-namespace ProsTree
+namespace Tree
 
 /-- All nodes of the tree (self + descendants), via the Core `Branching` API. -/
-def nodes (t : ProsTree) : List ProsTree := Core.Order.Branching.subtrees t
+def nodes (t : Tree) : List Tree := Core.Order.Branching.subtrees t
 
 /-- Containment / weak Strict Layer ([ito-mester-2003]): every child's level
     is ≤ its parent's in the prosodic hierarchy. Equality (recursion) is allowed;
     its cost is `recursionCount`, not a ban here. -/
-def Containment (t : ProsTree) : Prop :=
+def Containment (t : Tree) : Prop :=
   ∀ s ∈ t.nodes, ∀ c ∈ s.children, c.label.level ≤ s.label.level
 
 mutual
@@ -63,20 +63,20 @@ mutual
     that share a level (an element parsed twice into one category). Defined by
     structural recursion (mutual with the list aux), so it reduces under `decide`
     on concrete trees — unlike a `subtrees`-fold via `WellFounded.fix`. -/
-def recursionCount : ProsTree → Nat
+def recursionCount : Tree → Nat
   | .node a cs =>
       (cs.filter (fun c => decide (c.label.level = a.level))).length
         + recursionCountList cs
 /-- Auxiliary: total recursion count across a list of subtrees. -/
-def recursionCountList : List ProsTree → Nat
+def recursionCountList : List Tree → Nat
   | [] => 0
   | t :: ts => recursionCount t + recursionCountList ts
 end
 
 /-- The terminal weight profile (σ-leaves, left to right) as a `Word` — the
     σ → ω bridge to the unparsed weight profile. -/
-def yield (t : ProsTree) : Word :=
+def yield (t : Tree) : Word :=
   ⟨(t.nodes.filter (fun s => s.children.isEmpty)).map (fun s => s.label.weight)⟩
 
-end ProsTree
+end Tree
 end Prosody

--- a/Linglib/Phonology/Prosody/WordSize.lean
+++ b/Linglib/Phonology/Prosody/WordSize.lean
@@ -1,0 +1,137 @@
+import Linglib.Phonology.Prosody.Tree
+import Linglib.Phonology.Prosody.Foot
+
+/-!
+# Prosodic word size: minimality, maximality, and the perfect word
+
+Size restrictions on the prosodic word, stated over the single carrier
+`Prosody.Tree` (`Phonology/Prosody/Tree.lean`) and reusing the *carrier-agnostic*
+foot kernel from `Foot.lean` (`isWellFormedFoot`/`footMorae`, defined over
+weight-lists). The feet of a tree are the σ-weight contents of its `f`-labelled
+nodes, so the size theory composes with the recursive prosodic representation
+rather than duplicating a flat foot parse.
+
+The three notions form a `≤`-chain: a *minimal* word contains a foot, a *maximal*
+one is bounded by a foot, a *perfect* one is exactly a foot (Itô & Mester's
+perfect prosodic word, ω coextensive with f). The reductionist result
+([mccarthy-prince-1993], [uchihara-mendozaruiz-2021]) is that one constraint set
+(`FtBin`, `AllFeetRight`, `Parse`) derives *both* bounds, with the typological
+consequence that maximality entails minimality but not conversely.
+
+## Main definitions
+
+* `Prosody.feet` — the σ-weight content of each `f`-node (the tree's feet).
+* `Prosody.unfootedCount` — syllables parsed into no foot.
+* `Prosody.MinimalWord` / `MaximalWord` / `PerfectWord` — the size predicates.
+
+## Implementation notes
+
+Size predicates are theory-neutral structural facts (no OT import); the OT
+derivation that the bimoraic foot is the optimum lives in the consuming study
+(`Studies/Uchihara2021.lean`), composing the foot measures with
+`Core.Optimization`'s `argMinSet`. `feet`/`unfootedCount` use structural mutual
+recursion (mirroring `Planar.weight`), so the predicates reduce under `decide`.
+
+## References
+
+[mccarthy-prince-1993] [uchihara-mendozaruiz-2021]
+-/
+
+namespace Prosody
+
+open RootedTree Features.Prosody
+
+/-! ### Feet of a prosodic tree -/
+
+/-- The σ-weight content of a foot node's direct syllable daughters. -/
+def footContent (cs : List Tree) : List Syllable.Weight :=
+  cs.filterMap fun c => match c with
+    | .node a [] => if a.level = .σ then some a.weight else none
+    | _          => none
+
+mutual
+/-- The feet of a prosodic tree: the syllable-weight content of every
+    `f`-labelled node. -/
+def feet : Tree → List (List Syllable.Weight)
+  | .node a cs => (if a.level = .f then [footContent cs] else []) ++ feetList cs
+/-- Auxiliary: feet across a list of subtrees. -/
+def feetList : List Tree → List (List Syllable.Weight)
+  | []      => []
+  | t :: ts => feet t ++ feetList ts
+end
+
+mutual
+/-- Auxiliary for `unfootedCount`, threading whether we are already inside a foot. -/
+def unfootedAux (underFoot : Bool) : Tree → Nat
+  | .node a cs =>
+      let nowFoot := underFoot || decide (a.level = .f)
+      (if decide (a.level = .σ) && cs.isEmpty && !nowFoot then 1 else 0)
+        + unfootedAuxList nowFoot cs
+/-- Auxiliary over a list of subtrees. -/
+def unfootedAuxList (underFoot : Bool) : List Tree → Nat
+  | []      => 0
+  | t :: ts => unfootedAux underFoot t + unfootedAuxList underFoot ts
+end
+
+/-- Syllables parsed into no foot (Parse-μ violations at the σ level). -/
+def unfootedCount (t : Tree) : Nat := unfootedAux false t
+
+/-! ### Size predicates -/
+
+variable {ft : FootType} {t : Tree}
+
+/-- Minimal word ([mccarthy-prince-1993]): the tree contains a well-formed foot —
+    the smallest licit ω properly contains a foot (PrWd ⊇ Ft). -/
+def MinimalWord (ft : FootType) (t : Tree) : Prop :=
+  ∃ f ∈ feet t, isWellFormedFoot ft f
+
+instance : Decidable (MinimalWord ft t) := by unfold MinimalWord; infer_instance
+
+/-- Maximal word ([uchihara-mendozaruiz-2021]): no larger than one well-formed
+    foot, exhaustively parsed — the upper size bound. -/
+def MaximalWord (ft : FootType) (t : Tree) : Prop :=
+  (feet t).length ≤ 1 ∧ unfootedCount t = 0 ∧ ∀ f ∈ feet t, isWellFormedFoot ft f
+
+instance : Decidable (MaximalWord ft t) := by unfold MaximalWord; infer_instance
+
+/-- The perfect prosodic word (Itô & Mester): ω coextensive with one well-formed
+    foot — exactly one foot, well-formed, nothing unfooted. -/
+def PerfectWord (ft : FootType) (t : Tree) : Prop :=
+  (feet t).length = 1 ∧ (∀ f ∈ feet t, isWellFormedFoot ft f) ∧ unfootedCount t = 0
+
+instance : Decidable (PerfectWord ft t) := by unfold PerfectWord; infer_instance
+
+/-! ### Verification theorems -/
+
+/-- A perfect word is minimal. -/
+theorem PerfectWord.minimal (h : PerfectWord ft t) : MinimalWord ft t := by
+  obtain ⟨hlen, hwf, _⟩ := h
+  rcases hfeet : feet t with _ | ⟨f, fs⟩
+  · rw [hfeet] at hlen; simp at hlen
+  · exact ⟨f, by rw [hfeet]; simp, hwf f (by rw [hfeet]; simp)⟩
+
+/-- A perfect word is maximal. -/
+theorem PerfectWord.maximal (h : PerfectWord ft t) : MaximalWord ft t := by
+  obtain ⟨hlen, hwf, hu⟩ := h
+  exact ⟨hlen.le, hu, hwf⟩
+
+/-- The perfect word is exactly minimal-and-maximal: a word that both contains a
+    foot and is bounded by one is coextensive with that foot. -/
+theorem perfectWord_iff_minimal_and_maximal :
+    PerfectWord ft t ↔ MinimalWord ft t ∧ MaximalWord ft t := by
+  refine ⟨fun h => ⟨h.minimal, h.maximal⟩, ?_⟩
+  rintro ⟨⟨f, hf, _⟩, hle, hu, hwf⟩
+  have h1 : 0 < (feet t).length := List.length_pos_of_mem hf
+  exact ⟨le_antisymm hle (by omega), hwf, hu⟩
+
+/-- Typological direction ([uchihara-mendozaruiz-2021]): for a footed word,
+    maximality entails minimality (the converse fails — a minimal word may exceed
+    one foot). -/
+theorem MaximalWord.minimal (hne : feet t ≠ []) (h : MaximalWord ft t) :
+    MinimalWord ft t := by
+  obtain ⟨_, _, hwf⟩ := h
+  rcases hfeet : feet t with _ | ⟨f, fs⟩
+  · exact absurd hfeet hne
+  · exact ⟨f, by rw [hfeet]; simp, hwf f (by rw [hfeet]; simp)⟩
+
+end Prosody

--- a/Linglib/Studies/Bennett2018.lean
+++ b/Linglib/Studies/Bennett2018.lean
@@ -26,10 +26,10 @@ once but satisfies `Match`; the flat parse satisfies `NoRecursion` but violates
 `Match`. With `Match ≫ NoRecursion`, the recursive parse is the optimum — a
 prediction the flat `List`-of-weights `Word` could not even state.
 
-The prosodic candidates are `ProsTree`s (`Phonology/Prosody/Tree.lean`); EVAL is
+The prosodic candidates are `Tree`s (`Phonology/Prosody/Tree.lean`); EVAL is
 mathlib's lexicographic minimum — `Core.Optimization`'s `argMinSet`, the
 computable form of `Order.Minimal` under the profile pullback
-`Order.Preimage profile LexLE`. Constraints are plain `ProsTree → ℕ` functions;
+`Order.Preimage profile LexLE`. Constraints are plain `Tree → ℕ` functions;
 the ranking is the order of entries in the profile. No `Constraint`/tableau
 wrapper is needed (cf. how mathlib selects optima — `Order.Minimal` + `Order.Lex`,
 not a bespoke decorated structure).
@@ -49,33 +49,33 @@ open Prosody Features.Prosody RootedTree Core.Optimization.Evaluation
 /-! ### Candidate prosodifications of a high-prefix + stem -/
 
 /-- A high-attaching prefix syllable (light). -/
-def prefσ : ProsTree := .node ⟨.σ, 1⟩ []
+def prefσ : Tree := .node ⟨.σ, 1⟩ []
 
 /-- The stem syllable (heavy). -/
-def stemσ : ProsTree := .node ⟨.σ, 2⟩ []
+def stemσ : Tree := .node ⟨.σ, 2⟩ []
 
 /-- Flat parse `[ω HighPref Stem]`: no recursion, but the stem has no ω of its own. -/
-def flatParse : ProsTree := .node ⟨.ω, 0⟩ [prefσ, stemσ]
+def flatParse : Tree := .node ⟨.ω, 0⟩ [prefσ, stemσ]
 
 /-- Recursive parse `[ω HighPref [ω Stem]]`: the stem keeps its ω; the prefix
     adjoins to a dominating ω ([bennett-2018]). -/
-def recParse : ProsTree := .node ⟨.ω, 0⟩ [prefσ, .node ⟨.ω, 0⟩ [stemσ]]
+def recParse : Tree := .node ⟨.ω, 0⟩ [prefσ, .node ⟨.ω, 0⟩ [stemσ]]
 
 /-! ### `Match(Stem, ω)` (stand-in) -/
 
 mutual
 /-- Does some ω-node dominate exactly the stem (i.e. have children `[stem]`)? -/
-def hasOmegaOver (stem : ProsTree) : ProsTree → Bool
+def hasOmegaOver (stem : Tree) : Tree → Bool
   | .node a cs => (decide (a.level = .ω) && decide (cs = [stem])) || hasOmegaOverList stem cs
 /-- Auxiliary over a list of subtrees. -/
-def hasOmegaOverList (stem : ProsTree) : List ProsTree → Bool
+def hasOmegaOverList (stem : Tree) : List Tree → Bool
   | [] => false
   | t :: ts => hasOmegaOver stem t || hasOmegaOverList stem ts
 end
 
 /-- `Match(Stem, ω)` violation: 1 if the stem is not exhaustively matched by an
     ω of its own, else 0. -/
-def matchStemViol (stem t : ProsTree) : Nat := if hasOmegaOver stem t then 0 else 1
+def matchStemViol (stem t : Tree) : Nat := if hasOmegaOver stem t then 0 else 1
 
 /-! ### The ranking and the prediction
 
@@ -87,10 +87,10 @@ the entry order in the profile. -/
 
 /-- Violation profile, ranked `Match(X⁰,ω) ≫ NoRecursion`: a plain `ℕ`-vector
     of the two constraint functions, compared by `LexLE`. -/
-def profile (t : ProsTree) : List Nat := [matchStemViol stemσ t, ProsTree.recursionCount t]
+def profile (t : Tree) : List Nat := [matchStemViol stemσ t, Tree.recursionCount t]
 
 /-- The two candidate prosodifications. -/
-def candidates : Finset ProsTree := {recParse, flatParse}
+def candidates : Finset Tree := {recParse, flatParse}
 
 -- The violation contrast: recursion costs `NoRecursion`, the flat parse costs `Match`.
 example : profile recParse = [0, 1] := by decide

--- a/Linglib/Studies/Uchihara2021.lean
+++ b/Linglib/Studies/Uchihara2021.lean
@@ -1,0 +1,91 @@
+import Linglib.Phonology.Prosody.WordSize
+import Linglib.Core.Optimization.Evaluation
+
+/-!
+# Uchihara & Mendoza Ruiz 2021: minimality, maximality, and the perfect word in Mixtec
+[uchihara-mendozaruiz-2021]
+
+Uchihara, H. & Mendoza Ruiz, J. (2021). Minimality, maximality and perfect
+prosodic word in Alcozauca Mixtec. *Natural Language & Linguistic Theory* 40,
+599–649.
+
+In Alcozauca Mixtec the prosodic word is ideally both minimally *and* maximally
+bimoraic: monosyllabic stems lengthen to bimoraic (CVV), and over-long words
+truncate to fit the bimoraic template. The paper's reductionist claim is that one
+constraint set — `FtBin`, `Parse(μ)`, `AllFeetRight` — derives *both* bounds, so
+the ideal word is the **perfect prosodic word**: ω coextensive with a single
+well-formed (bimoraic) foot. The typological prediction is that maximality always
+entails minimality, not conversely.
+
+We exercise the unified prosodic machinery: candidates are `Prosody.Tree`s, size
+notions come from `Phonology/Prosody/WordSize.lean`, and EVAL is mathlib's
+lexicographic minimum (`Core.Optimization`'s `argMinSet`, no OT-engine wrapper).
+The *same* profile `FtBin ≫ Parse` selects the bimoraic foot for both a too-small
+input (lengthening) and a too-big one (truncation); the winner is a `PerfectWord`.
+-/
+
+namespace Uchihara2021
+
+open Prosody Features.Prosody RootedTree Core.Optimization.Evaluation
+
+/-! ### Constraint profile -/
+
+/-- `FtBin` violations over a tree: feet whose mora count is not 2. -/
+def ftBinViol (t : Tree) : Nat :=
+  ((feet t).filter (fun f => footMorae f != 2)).length
+
+/-- Violation profile, ranked `FtBin ≫ Parse(μ)` (unfooted syllables). -/
+def profile (t : Tree) : List Nat := [ftBinViol t, unfootedCount t]
+
+/-! ### Minimality: a monomoraic input lengthens to a bimoraic foot -/
+
+/-- `(taa)` — one heavy syllable footed: the bimoraic perfect word. -/
+def bimoraic : Tree := .node ⟨.ω, 0⟩ [.node ⟨.f, 0⟩ [.node ⟨.σ, .heavy⟩ []]]
+/-- `(ta)` — a degenerate monomoraic foot (`FtBin` violation). -/
+def degenerate : Tree := .node ⟨.ω, 0⟩ [.node ⟨.f, 0⟩ [.node ⟨.σ, .light⟩ []]]
+/-- `[ta]` — an unfooted light syllable (`Parse` violation). -/
+def unfooted : Tree := .node ⟨.ω, 0⟩ [.node ⟨.σ, .light⟩ []]
+
+def minCandidates : Finset Tree := {bimoraic, degenerate, unfooted}
+
+example : profile bimoraic = [0, 0] := by decide
+example : profile degenerate = [1, 0] := by decide
+example : profile unfooted = [0, 1] := by decide
+
+/-- Minimality: from a monomoraic input the bimoraic foot is the unique optimum
+    (lengthening beats both the degenerate foot and the unfooted syllable). -/
+theorem minimality_optimum : argMinSet minCandidates profile LexLE = {bimoraic} := by decide
+
+/-! ### Maximality: a trimoraic input truncates to a bimoraic foot -/
+
+/-- `(taa.ta)` — a trimoraic foot (`FtBin` violation). -/
+def trimoraicFoot : Tree :=
+  .node ⟨.ω, 0⟩ [.node ⟨.f, 0⟩ [.node ⟨.σ, .heavy⟩ [], .node ⟨.σ, .light⟩ []]]
+/-- `(taa).ta` — a bimoraic foot plus an unfooted syllable (`Parse` violation). -/
+def footPlusStray : Tree :=
+  .node ⟨.ω, 0⟩ [.node ⟨.f, 0⟩ [.node ⟨.σ, .heavy⟩ []], .node ⟨.σ, .light⟩ []]
+
+def maxCandidates : Finset Tree := {bimoraic, trimoraicFoot, footPlusStray}
+
+example : profile trimoraicFoot = [1, 0] := by decide
+example : profile footPlusStray = [0, 1] := by decide
+
+/-- Maximality: from a trimoraic input the bimoraic foot is again the unique
+    optimum (truncation beats the trimoraic foot and the foot-plus-stray) — the
+    *same* `FtBin ≫ Parse` profile, hence "maximality from the minimality
+    constraints" ([uchihara-mendozaruiz-2021]). -/
+theorem maximality_optimum : argMinSet maxCandidates profile LexLE = {bimoraic} := by decide
+
+/-! ### The winner is the perfect prosodic word -/
+
+/-- The shared optimum is the perfect prosodic word: ω coextensive with one
+    well-formed (moraic-trochee) foot. -/
+theorem winner_perfect : PerfectWord .moraicTrochee bimoraic := by decide
+
+/-- Hence the optimum is both minimal and maximal (Itô & Mester's perfect word =
+    minimal ∧ maximal). -/
+theorem winner_minimal_and_maximal :
+    MinimalWord .moraicTrochee bimoraic ∧ MaximalWord .moraicTrochee bimoraic :=
+  ⟨winner_perfect.minimal, winner_perfect.maximal⟩
+
+end Uchihara2021

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -26345,6 +26345,19 @@
   sources   = {Phonology/Prosody/Tree.lean, Studies/Bennett2018.lean}
 }
 
+@article{uchihara-mendozaruiz-2021,
+  author    = {Uchihara, Hiroto and Mendoza Ruiz, Juana},
+  year      = {2021},
+  title     = {Minimality, Maximality and Perfect Prosodic Word in {Alcozauca Mixtec}},
+  journal   = {Natural Language \& Linguistic Theory},
+  volume    = {40},
+  pages     = {599--649},
+  doi       = {10.1007/s11049-021-09517-y},
+  subfield  = {phonology},
+  role      = {empirical},
+  sources   = {Phonology/Prosody/WordSize.lean, Studies/Uchihara2021.lean}
+}
+
 % REF: Hibiya (1995). The velar nasal in Tokyo Japanese: A
 % sociolinguistic study. PhD dissertation, University of Pennsylvania.
 @phdthesis{hibiya-1995,


### PR DESCRIPTION
Unifies the prosodic machinery onto a single carrier and adds the word-size theory + its first OT consumer. Built in an isolated worktree (a parallel session was mid a `Segmental/` reorg in the shared checkout).

- **Rename `Prosody.ProsTree` → `Prosody.Tree`** — kills the `Prosody.Pros…` stutter and parallels the existing `Syntax.Tree`; builds clean (no collision with mathlib's binary `Tree`, namespace resolves it). One carrier for the prosodic hierarchy; `MetricalParse` (foot view) and `Word` (yield) are derived views.
- **`Phonology/Prosody/WordSize.lean`** — minimality / maximality / perfect-word theory over `Tree`, modeled on the `autosegmental/` layout. `feet`/`unfootedCount` are structural (decide-reducible); the foot kernel (`isWellFormedFoot`/`footMorae`, carrier-agnostic over weight-lists) is reused, not duplicated. Theorems: `PerfectWord.minimal`/`.maximal`, `perfectWord_iff_minimal_and_maximal`, `MaximalWord.minimal` (the maximality⇒minimality typological direction).
- **`Studies/Uchihara2021.lean`** — Alcozauca Mixtec ([uchihara-mendozaruiz-2021]). The bimoraic perfect word is the `argMinSet` optimum (mathlib-pure EVAL, no OT-engine wrapper) for *both* a too-small input (minimality / lengthening) and a too-big one (maximality / truncation), via the *same* `FtBin ≫ Parse` profile; the winner is a `PerfectWord`. All `decide`-checked; no `sorry`/`native_decide`.

Layering: `Tree`/`WordSize` import no OT engine (size predicates are structural); the study composes them with `Core.Optimization`'s `argMinSet`. Bib: added `uchihara-mendozaruiz-2021` (DOI verified).
