### PR TITLE
feat(Studies/ItoMester2009): function-word ω-adjunction via OT recursion

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2331,6 +2331,7 @@ import Linglib.Studies.ImelGuoST2026
 import Linglib.Studies.IppolitoKissWilliams2022
 import Linglib.Studies.IppolitoKissWilliams2025
 import Linglib.Studies.Israel2001
+import Linglib.Studies.ItoMester2009
 import Linglib.Studies.Izvorski1997
 import Linglib.Studies.Jaeger2007
 import Linglib.Studies.Jardine2016

--- a/Linglib/Phonology/Prosody/WordSize.lean
+++ b/Linglib/Phonology/Prosody/WordSize.lean
@@ -61,20 +61,35 @@ def feetList : List Tree → List (List Syllable.Weight)
 end
 
 mutual
-/-- Auxiliary for `unfootedCount`, threading whether we are already inside a foot. -/
-def unfootedAux (underFoot : Bool) : Tree → Nat
+/-- Auxiliary for `parseIntoViol`, threading whether we are already under an
+    `lvl`-node. -/
+def parseIntoAux (lvl : ProsodicLevel) (under : Bool) : Tree → Nat
   | .node a cs =>
-      let nowFoot := underFoot || decide (a.level = .f)
-      (if decide (a.level = .σ) && cs.isEmpty && !nowFoot then 1 else 0)
-        + unfootedAuxList nowFoot cs
+      let nowUnder := under || decide (a.level = lvl)
+      (if decide (a.level = .σ) && cs.isEmpty && !nowUnder then 1 else 0)
+        + parseIntoAuxList lvl nowUnder cs
 /-- Auxiliary over a list of subtrees. -/
-def unfootedAuxList (underFoot : Bool) : List Tree → Nat
+def parseIntoAuxList (lvl : ProsodicLevel) (under : Bool) : List Tree → Nat
   | []      => 0
-  | t :: ts => unfootedAux underFoot t + unfootedAuxList underFoot ts
+  | t :: ts => parseIntoAux lvl under t + parseIntoAuxList lvl under ts
 end
 
-/-- Syllables parsed into no foot (Parse-μ violations at the σ level). -/
-def unfootedCount (t : Tree) : Nat := unfootedAux false t
+/-- Parse-into-`lvl` violations ([ito-mester-2003]): syllables dominated by no
+    `lvl`-node. -/
+def parseIntoViol (lvl : ProsodicLevel) (t : Tree) : Nat := parseIntoAux lvl false t
+
+/-- Syllables parsed into no foot (Parse-μ at the σ level) — `parseIntoViol .f`. -/
+def unfootedCount (t : Tree) : Nat := parseIntoViol .f t
+
+mutual
+/-- Total mora count of a tree: the sum of its syllables' weights. -/
+def moraCount : Tree → Nat
+  | .node a cs => (if a.level = .σ then a.weight else 0) + moraCountList cs
+/-- Auxiliary over a list of subtrees. -/
+def moraCountList : List Tree → Nat
+  | []      => 0
+  | t :: ts => moraCount t + moraCountList ts
+end
 
 /-! ### Size predicates -/
 

--- a/Linglib/Studies/ItoMester2009.lean
+++ b/Linglib/Studies/ItoMester2009.lean
@@ -1,0 +1,108 @@
+import Linglib.Phonology.Prosody.WordSize
+import Linglib.Core.Optimization.Evaluation
+
+/-!
+# Itô & Mester 2009: the extended prosodic word
+[ito-mester-2009]
+
+Itô, J. & Mester, A. (2009). The extended prosodic word. In J. Grijzenhout & B.
+Kabak (eds.), *Phonological Domains: Universals and Deviations*. Berlin: De
+Gruyter Mouton.
+
+A function-word + lexical-word complex (English *the dinosaurs*, German *ne
+Zigarette*) has four conceivable prosodifications, arising from the factorial
+interaction of `FtBin`, `Lex-to-ω`, `Parse-into-ω`, and `No-Recursion`:
+
+* **full-ω** `[φ [ω fnc] [ω lex]]` — the function word is its own ω (violates
+  `FtBin`: a subminimal ω);
+* **amalgamated** `[ω fnc lex]` — fused into one ω (violates `Lex-to-ω`: the
+  lexical word has no ω of its own);
+* **ω-adjoined** `[ω fnc [ω lex]]` — the function word adjoins, the lexical word
+  keeps its ω (violates `No-Recursion`: ω over ω);
+* **φ-attached** `[φ fnc [ω lex]]` — attached straight to φ (violates
+  `Parse-into-ω`: the function word is in no ω).
+
+With `FtBin`, `Lex-to-ω ≫ Parse-into-ω ≫ No-Recursion`, the **ω-adjoined**
+(recursive) structure is the optimum — Itô & Mester's central claim, that English
+and German function-word complexes use ω-adjunction, *contra* Selkirk's
+φ-attachment. This is a second OT consumer of prosodic-word recursion alongside
+`Studies/Bennett2018.lean` (Kaqchikel).
+
+Candidates are `Prosody.Tree`s; EVAL is mathlib's lexicographic minimum
+(`Core.Optimization`'s `argMinSet`, no OT-engine wrapper). `No-Recursion` is
+`Tree.recursionCount` and `Parse-into-ω` is `parseIntoViol .ω` from the shared
+machinery; `FtBin`-at-ω and `Lex-to-ω` are the function-word constraints below.
+-/
+
+namespace ItoMester2009
+
+open Prosody Features.Prosody RootedTree Core.Optimization.Evaluation
+
+/-! ### Function-word constraints -/
+
+mutual
+/-- `FtBin`-at-ω violations: ω-nodes whose mora count is below a foot (< 2). A
+    subminimal function word parsed as its own ω is penalised. -/
+def subminimalOmegaViol : Tree → Nat
+  | .node a cs =>
+      (if decide (a.level = .ω) && decide (moraCount (.node a cs) < 2) then 1 else 0)
+        + subminimalOmegaViolList cs
+/-- Auxiliary over a list of subtrees. -/
+def subminimalOmegaViolList : List Tree → Nat
+  | []      => 0
+  | t :: ts => subminimalOmegaViol t + subminimalOmegaViolList ts
+end
+
+mutual
+/-- Is the lexical word `lex` realised as its own ω-node somewhere in the tree? -/
+def lexHasOmega (lex : Tree) : Tree → Bool
+  | .node a cs =>
+      (decide (a.level = .ω) && decide ((.node a cs : Tree) = lex)) || lexHasOmegaList lex cs
+/-- Auxiliary over a list of subtrees. -/
+def lexHasOmegaList (lex : Tree) : List Tree → Bool
+  | []      => false
+  | t :: ts => lexHasOmega lex t || lexHasOmegaList lex ts
+end
+
+/-- `Lex-to-ω` violation ([ito-mester-2009], after [mccarthy-prince-1993]'s
+    `Align(Lex, ω)`): 1 if the lexical word is not aligned with an ω of its own. -/
+def lexToOmegaViol (lex t : Tree) : Nat := if lexHasOmega lex t then 0 else 1
+
+/-! ### The four candidate prosodifications of *(fnc lex)* -/
+
+/-- The function word: one light syllable. -/
+def fncσ : Tree := .node ⟨.σ, .light⟩ []
+/-- The lexical word as a well-formed (bimoraic) ω. -/
+def lexω : Tree := .node ⟨.ω, 0⟩ [.node ⟨.f, 0⟩ [.node ⟨.σ, .heavy⟩ []]]
+
+/-- (a) full-ω: `[φ [ω fnc] [ω lex]]`. -/
+def fullOmega : Tree := .node ⟨.φ, 0⟩ [.node ⟨.ω, 0⟩ [fncσ], lexω]
+/-- (b) amalgamated: `[ω fnc lex]` (lexical word loses its own ω). -/
+def amalgamated : Tree := .node ⟨.ω, 0⟩ [fncσ, .node ⟨.f, 0⟩ [.node ⟨.σ, .heavy⟩ []]]
+/-- (c) ω-adjoined: `[ω fnc [ω lex]]` — recursive. -/
+def omegaAdjoined : Tree := .node ⟨.ω, 0⟩ [fncσ, lexω]
+/-- (d) φ-attached: `[φ fnc [ω lex]]`. -/
+def phiAttached : Tree := .node ⟨.φ, 0⟩ [fncσ, lexω]
+
+/-- Violation profile, ranked `FtBin, Lex-to-ω ≫ Parse-into-ω ≫ No-Recursion`. -/
+def profile (t : Tree) : List Nat :=
+  [subminimalOmegaViol t, lexToOmegaViol lexω t, parseIntoViol .ω t, Tree.recursionCount t]
+
+-- Each candidate violates exactly one constraint (the factorial typology).
+example : profile fullOmega    = [1, 0, 0, 0] := by decide
+example : profile amalgamated  = [0, 1, 0, 0] := by decide
+example : profile omegaAdjoined = [0, 0, 0, 1] := by decide
+example : profile phiAttached  = [0, 0, 1, 0] := by decide
+
+def candidates : Finset Tree := {fullOmega, amalgamated, omegaAdjoined, phiAttached}
+
+/-- The function-word complex is prosodified by **ω-adjunction** — the recursive
+    `[ω fnc [ω lex]]` is the unique optimum, beating φ-attachment because
+    `Parse-into-ω ≫ No-Recursion` ([ito-mester-2009], contra Selkirk's φ-attached). -/
+theorem omegaAdjunction_optimum :
+    argMinSet candidates profile LexLE = {omegaAdjoined} := by decide
+
+/-- The winning structure is recursive: ω dominates ω. -/
+theorem winner_is_recursive : Tree.recursionCount omegaAdjoined = 1 := by decide
+
+end ItoMester2009

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -26318,6 +26318,19 @@
   sources   = {Phenomena/Phonology/Studies/BreissKatsudaKawahara2026.lean}
 }
 
+@incollection{ito-mester-2009,
+  author    = {It{\^o}, Junko and Mester, Armin},
+  year      = {2009},
+  title     = {The Extended Prosodic Word},
+  booktitle = {Phonological Domains: Universals and Deviations},
+  editor    = {Grijzenhout, Janet and Kabak, Bar{\i}{\c{s}}},
+  publisher = {De Gruyter Mouton},
+  address   = {Berlin},
+  subfield  = {phonology},
+  role      = {foundational},
+  sources   = {Studies/ItoMester2009.lean}
+}
+
 @article{bennett-2018,
   author    = {Bennett, Ryan},
   year      = {2018},


### PR DESCRIPTION
The extended prosodic word ([ito-mester-2009]) — the second OT consumer of prosodic-word **recursion**, alongside `Bennett2018` (Kaqchikel).

A function-word + lexical-word complex (*the dinosaurs*) has four prosodifications, from the factorial interaction of `FtBin`, `Lex-to-ω`, `Parse-into-ω`, `No-Recursion`: full-ω (violates FtBin), amalgamated (violates Lex-to-ω), **ω-adjoined** `[ω fnc [ω lex]]` (violates No-Recursion), φ-attached (violates Parse-into-ω). With `FtBin, Lex-to-ω ≫ Parse-into-ω ≫ No-Recursion`, the **ω-adjoined (recursive)** structure is the unique optimum — Itô & Mester's claim that English/German use ω-adjunction, contra Selkirk's φ-attachment.

- Candidates are `Prosody.Tree`s; EVAL is mathlib's lex-minimum (`argMinSet`, no OT-engine wrapper). `No-Recursion` = `Tree.recursionCount`, `Parse-into-ω` = `parseIntoViol .ω` from the shared machinery; `FtBin`-at-ω and `Lex-to-ω` (a Match-style `Align(Lex,ω)`) are the study's function-word constraints.
- `omegaAdjunction_optimum : argMinSet candidates profile LexLE = {omegaAdjoined}` and `winner_is_recursive` — all `decide`-checked; no `sorry`/`native_decide`.
- Generalizes `WordSize`'s `unfootedCount` to the reusable `parseIntoViol (lvl)` (Parse-into-X family) and adds `moraCount`.

Bib: added `ito-mester-2009` (incollection; pages/DOI omitted as unverified). Built in the worktree off updated `main` (post-#943).
