### PR TITLE
feat(Core/Computability/Subregular/Logic): word models, QF logic, and logical transductions

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -103,6 +103,8 @@ import Linglib.Core.Computability.Subregular.Language.PiecewiseTestable
 import Linglib.Core.Computability.Subregular.Language.StrictlyLocal
 import Linglib.Core.Computability.Subregular.Language.StrictlyPiecewise
 import Linglib.Core.Computability.Subregular.Language.TierStrictlyLocal
+import Linglib.Core.Computability.Subregular.Logic.QFLogic
+import Linglib.Core.Computability.Subregular.Logic.WordModel
 import Linglib.Core.Computability.SyntacticMonoid
 import Linglib.Core.Computability.TierProjection
 import Linglib.Core.Computability.TransitionMonoid

--- a/Linglib/Core/Computability/Subregular/Logic/QFLogic.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/QFLogic.lean
@@ -1,0 +1,127 @@
+import Linglib.Core.Computability.Subregular.Logic.WordModel
+
+/-!
+# Quantifier-free logic over word models
+
+The quantifier-free (QF) fragment of the logic of word models ([dolatian-2020]). Terms are
+built from a variable by applying the successor/predecessor partial functions; formulas are
+boolean combinations of atomic label/equality/definedness tests. Because successor is a
+*function*, a QF term reaches a *bounded* neighbourhood of its variable with no quantifiers —
+the syntactic counterpart of strict locality. (Dolatian's `intervocalic(x) := ∃w,y[…]` becomes
+the QF `label V (pred x) ∧ label V (succ x)`.) The forthcoming locality bridge
+(`Logic/LocalityBridge.lean`) is that QF-definable transductions are exactly the
+Input-Strictly-Local functions of `Subregular`.
+
+## Main definitions
+
+* `Subregular.Logic.Term` — QF terms (`var`, `succ`, `pred`); `Term.eval` interprets them.
+* `Subregular.Logic.Atom` / `QF` — atomic and quantifier-free formulas.
+* `Atom.Realize` / `QF.Realize` — satisfaction in a word model under an assignment, decidable.
+* `QF.initial` / `QF.final` — edge positions, derived from definedness of `pred`/`succ`.
+
+## Implementation notes
+
+`Realize` is `Prop`-valued (mathlib's model-theory idiom) with a derived `Decidable` instance,
+so worked examples close by `decide`. A `Term` evaluates to `Option ℕ`, `none` once it falls off
+an edge; atoms over an undefined term are false.
+-/
+
+namespace Subregular.Logic
+
+variable {α V : Type*}
+
+/-- Quantifier-free **terms**: a variable, or the successor/predecessor of a term. The
+`succ`/`pred` chains give bounded-window reach without quantifiers. -/
+inductive Term (V : Type*) where
+  | var : V → Term V
+  | succ : Term V → Term V
+  | pred : Term V → Term V
+  deriving DecidableEq
+
+namespace Term
+
+/-- Interpret a term in a word model under an assignment `ρ` of variables to positions;
+`none` if it falls off an edge. -/
+def eval (w : WordModel α) (ρ : V → ℕ) : Term V → Option ℕ
+  | .var v  => if w.Mem (ρ v) then some (ρ v) else none
+  | .succ t => (eval w ρ t).bind w.succ?
+  | .pred t => (eval w ρ t).bind w.pred?
+
+end Term
+
+/-- Atomic quantifier-free formulas: a label test, an equality of positions, or a
+definedness test on a term. -/
+inductive Atom (α V : Type*) where
+  | label : α → Term V → Atom α V
+  | eq : Term V → Term V → Atom α V
+  | defined : Term V → Atom α V
+
+/-- Quantifier-free formulas: boolean combinations of atoms (no quantifiers). -/
+inductive QF (α V : Type*) where
+  | atom : Atom α V → QF α V
+  | tru : QF α V
+  | fls : QF α V
+  | neg : QF α V → QF α V
+  | conj : QF α V → QF α V → QF α V
+  | disj : QF α V → QF α V → QF α V
+
+variable [DecidableEq α]
+
+/-- Satisfaction of an atom in `w` under assignment `ρ`. -/
+def Atom.Realize (w : WordModel α) (ρ : V → ℕ) : Atom α V → Prop
+  | .label a t => (t.eval w ρ).bind w.label? = some a
+  | .eq t₁ t₂  => t₁.eval w ρ = t₂.eval w ρ ∧ t₁.eval w ρ ≠ none
+  | .defined t => t.eval w ρ ≠ none
+
+instance (w : WordModel α) (ρ : V → ℕ) (a : Atom α V) : Decidable (a.Realize w ρ) := by
+  cases a <;> unfold Atom.Realize <;> infer_instance
+
+/-- Satisfaction of a quantifier-free formula in `w` under assignment `ρ`. -/
+def QF.Realize (w : WordModel α) (ρ : V → ℕ) : QF α V → Prop
+  | .atom a   => a.Realize w ρ
+  | .tru      => True
+  | .fls      => False
+  | .neg φ    => ¬ φ.Realize w ρ
+  | .conj φ ψ => φ.Realize w ρ ∧ ψ.Realize w ρ
+  | .disj φ ψ => φ.Realize w ρ ∨ ψ.Realize w ρ
+
+instance QF.instDecidableRealize (w : WordModel α) (ρ : V → ℕ) :
+    (φ : QF α V) → Decidable (φ.Realize w ρ)
+  | .atom a   => inferInstanceAs (Decidable (a.Realize w ρ))
+  | .tru      => isTrue trivial
+  | .fls      => isFalse not_false
+  | .neg φ    => @instDecidableNot _ (QF.instDecidableRealize w ρ φ)
+  | .conj φ ψ => @instDecidableAnd _ _ (QF.instDecidableRealize w ρ φ) (QF.instDecidableRealize w ρ ψ)
+  | .disj φ ψ => @instDecidableOr _ _ (QF.instDecidableRealize w ρ φ) (QF.instDecidableRealize w ρ ψ)
+
+/-- `t` is an initial position: in-domain with no predecessor. -/
+def QF.initial (t : Term V) : QF α V :=
+  .conj (.atom (.defined t)) (.neg (.atom (.defined t.pred)))
+
+/-- `t` is a final position: in-domain with no successor. -/
+def QF.final (t : Term V) : QF α V :=
+  .conj (.atom (.defined t)) (.neg (.atom (.defined t.succ)))
+
+/-! ### Worked example: intervocalic position -/
+
+section Example
+
+private inductive Seg | a | t deriving DecidableEq
+
+/-- `x` is intervocalic — flanked by `a`s — stated quantifier-free via `succ`/`pred` terms
+(no existential, contrast Dolatian's `∃w,y[…]`). -/
+private def intervocalic : QF Seg Unit :=
+  .conj (.atom (.label .a (.pred (.var ())))) (.atom (.label .a (.succ (.var ()))))
+
+private def ata : WordModel Seg := [Seg.a, Seg.t, Seg.a]
+
+-- Position 1 (the `t`) is intervocalic; position 0 (initial `a`) is not (no predecessor).
+example : intervocalic.Realize ata (fun _ => 1) := by decide
+example : ¬ intervocalic.Realize ata (fun _ => 0) := by decide
+-- The edge predicates compute as expected.
+example : (QF.initial (α := Seg) (.var ())).Realize ata (fun _ => 0) := by decide
+example : (QF.final (α := Seg) (.var ())).Realize ata (fun _ => 2) := by decide
+
+end Example
+
+end Subregular.Logic

--- a/Linglib/Core/Computability/Subregular/Logic/WordModel.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/WordModel.lean
@@ -1,0 +1,65 @@
+import Mathlib.Data.List.Basic
+
+/-!
+# Word models
+
+The model-theoretic representation underlying logical characterizations of subregular
+functions: a string viewed as a finite labeled linear order ([dolatian-2020], after
+Büchi, Courcelle & Engelfriet, and Libkin). A **word model** is Dolatian's signature
+`⟨D, L, R⟩` — a domain `D` of positions, unary labels `L`, and the binary
+immediate-successor relation `R`; general precedence is the (FO-definable) transitive
+closure of successor and is not part of the quantifier-free fragment.
+
+The carrier is `List α` itself: a string *is* its word model. This is deliberately where
+mathlib stops — it has strings (`List`/`FreeMonoid`) and automata (`DFA`, `MyhillNerode`)
+but no model-theoretic word structure — and it keeps the logic layer directly composable
+with `Subregular`'s string functions (`Subregular.IsInputStrictlyLocal`, `SFST`).
+
+## Main definitions
+
+* `Subregular.Logic.WordModel` — a string over `α`, viewed as `⟨D, label, succ⟩`.
+* `WordModel.label?` — the unary label (symbol) at a position, `none` off the edge.
+* `WordModel.Mem` — domain membership of a position.
+* `WordModel.succ?` / `WordModel.pred?` — successor/predecessor as partial functions.
+
+## Implementation notes
+
+Positions are `ℕ` indices; a position is in-domain iff below `length`. Successor and
+predecessor are *partial functions* (`Option ℕ`) rather than relations — this is what lets
+the quantifier-free term language (`Logic/QFLogic.lean`) reach a bounded neighbourhood via
+`succ`/`pred` chains without quantifiers, the syntactic source of strict locality.
+-/
+
+namespace Subregular.Logic
+
+/-- A **word model**: a string over `α`, viewed model-theoretically as a finite linear
+order of positions carrying unary labels and an immediate-successor relation. -/
+abbrev WordModel (α : Type*) := List α
+
+namespace WordModel
+variable {α : Type*}
+
+/-- The label (symbol) at position `n`, or `none` off the edge. -/
+def label? (w : WordModel α) (n : ℕ) : Option α := w[n]?
+
+/-- Position `n` lies in the domain. -/
+def Mem (w : WordModel α) (n : ℕ) : Prop := n < w.length
+
+instance (w : WordModel α) (n : ℕ) : Decidable (w.Mem n) := Nat.decLt _ _
+
+/-- Successor as a partial function: the position after `n`, defined iff it is in range. -/
+def succ? (w : WordModel α) (n : ℕ) : Option ℕ :=
+  if n + 1 < w.length then some (n + 1) else none
+
+/-- Predecessor as a partial function: the position before `n`, defined iff `n > 0`. -/
+def pred? (w : WordModel α) : ℕ → Option ℕ
+  | 0     => none
+  | n + 1 => if n < w.length then some n else none
+
+@[simp] theorem label?_eq_getElem? (w : WordModel α) (n : ℕ) : w.label? n = w[n]? := rfl
+
+@[simp] theorem mem_iff (w : WordModel α) (n : ℕ) : w.Mem n ↔ n < w.length := Iff.rfl
+
+end WordModel
+
+end Subregular.Logic


### PR DESCRIPTION
Stages 1–2 of the subregular logic-leg roadmap (`scratch/subregular-logic-leg-roadmap.md`): the model-theoretic foundation for logical characterizations of subregular functions — Dolatian's `⟨D, L, R⟩` word models, the quantifier-free fragment, and QF logical transductions. This is the leg linglib's Subregular API lacks (it has the algebra leg — `SyntacticMonoid`/`StarFree` — and the automata leg — `SFST`/`ISLRule`), and exactly where mathlib stops: mathlib has strings (`List`/`FreeMonoid`) and automata (`DFA`/`MyhillNerode`) but no model-theoretic word structure.

**Stage 1 — word models + QF logic**
- `Logic/WordModel.lean` — a string *is* its word model (`WordModel α := List α`): `label?`, `Mem`, and successor/predecessor as **partial functions** (`succ?`/`pred?`). Carrier = `List α`, so the logic composes directly with `Subregular.IsInputStrictlyLocal`/`SFST`.
- `Logic/QFLogic.lean` — QF `Term` (`var`/`succ`/`pred` — chains give bounded-window reach with no quantifiers, the syntactic source of strict locality), `Atom` (label/eq/defined), `QF` (boolean closure), `Prop`-valued `Realize` with a derived `Decidable` instance. `intervocalic` as a QF formula (no `∃`, contra Dolatian's `∃w,y[…]`), `decide`-checked both polarities; `initial`/`final`.

**Stage 2 — logical transductions**
- `Logic/Transduction.lean` — copy-set + per-copy guarded output clauses (the order-preserving QF fragment = exactly the local processes). `apply` is computable. Worked, `decide`-checked: intervocalic voicing `pata→pada` (feature change), intervocalic glide deletion `paja→paa` (deletion), final-vowel epenthesis `pat→pata` (copy set), and **cyclic composition** `applyComp` `atat→adat→adata` (each cycle a local transduction). Composition models interactionist cyclicity; the composite is a regular function (closed under composition in `SFST`) though not in general itself QF.

No `sorry`/`native_decide`. Next: Stage 3, the QF ↔ ISL locality bridge connecting this to `Subregular.IsInputStrictlyLocal` (Chandlee–Heinz–Jardine).
