### PR TITLE
feat(Core/Computability/Subregular/Logic): prove QF→Left-ISL bridge (discharge sorry)

### DIFF
--- a/Linglib/Core/Computability/Subregular/Logic/LocalityBridge.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/LocalityBridge.lean
@@ -22,6 +22,8 @@ backward guard at `n` depends only on the `r + 1` symbols ending at `n` — the 
 ## Main results
 
 * `Term.eval_backward` — a backward term of depth `j` at position `n` evaluates to `n - j`.
+* `Transduction.leftLocal_isLeftISL` — a backward-bounded (radius `r`) transduction is
+  `(r+1)`-Left-Input-Strictly-Local.
 -/
 
 namespace Subregular.Logic
@@ -104,18 +106,190 @@ transduction's `emitAt` on `window ++ [x]` at its final position. -/
 def Transduction.toISLRule [DecidableEq α] (T : Transduction α β) (r : ℕ) : ISLRule (r + 1) α β where
   windowOutput window x := T.emitAt (window ++ [x]) window.length
 
+/-! ### Locality of `emitAt` and the window-threading invariant
+
+The bridge reduces to two facts: a backward-bounded guard reads only the `r + 1` symbols ending at
+its position (`emitAt` agrees on positions with matching bounded left context), and the ISL window
+threaded by `applyAux` stays exactly that bounded left context. -/
+
+/-- A backward-bounded atom reads only the `r + 1` symbols ending at its position: it has the same
+truth value at `(w, n)` and `(w', n')` whenever their bounded left contexts (the labels at offsets
+`0 … r`, and which of those offsets stay in range) agree. -/
+private theorem Atom.realize_eq_of_agree [DecidableEq α] {r : ℕ} {a : Atom α (Fin 1)}
+    (ha : a.BackBounded r) {w w' : WordModel α} {n n' : ℕ}
+    (hn : n < w.length) (hn' : n' < w'.length)
+    (hlbl : ∀ j ≤ r, w.label? (n - j) = w'.label? (n' - j))
+    (hedge : ∀ j ≤ r, (j ≤ n ↔ j ≤ n')) :
+    a.Realize w (fun _ => n) ↔ a.Realize w' (fun _ => n') := by
+  cases a with
+  | label c t =>
+    obtain ⟨ht, hb⟩ := ha
+    simp only [Atom.Realize, Term.eval_backward hn ht, Term.eval_backward hn' ht]
+    by_cases h : t.pdepth ≤ n
+    · rw [if_pos h, if_pos ((hedge t.pdepth hb).mp h)]
+      simp only [Option.bind_some]
+      rw [hlbl t.pdepth hb]
+    · rw [if_neg h, if_neg (fun hh => h ((hedge t.pdepth hb).mpr hh)),
+          Option.bind_none, Option.bind_none]
+  | eq t₁ t₂ =>
+    obtain ⟨⟨ht₁, hb₁⟩, ht₂, hb₂⟩ := ha
+    have e1 := hedge t₁.pdepth hb₁
+    have e2 := hedge t₂.pdepth hb₂
+    simp only [Atom.Realize, Term.eval_backward hn ht₁, Term.eval_backward hn ht₂,
+               Term.eval_backward hn' ht₁, Term.eval_backward hn' ht₂]
+    by_cases h₁ : t₁.pdepth ≤ n
+    · by_cases h₂ : t₂.pdepth ≤ n
+      · rw [if_pos h₁, if_pos h₂, if_pos (e1.mp h₁), if_pos (e2.mp h₂)]
+        have := e1.mp h₁; have := e2.mp h₂
+        simp only [Option.some.injEq, ne_eq, reduceCtorEq, not_false_eq_true, and_true]
+        omega
+      · rw [if_pos h₁, if_neg h₂, if_pos (e1.mp h₁), if_neg (fun hh => h₂ (e2.mpr hh))]; simp
+    · by_cases h₂ : t₂.pdepth ≤ n
+      · rw [if_neg h₁, if_pos h₂, if_neg (fun hh => h₁ (e1.mpr hh)), if_pos (e2.mp h₂)]; simp
+      · rw [if_neg h₁, if_neg h₂, if_neg (fun hh => h₁ (e1.mpr hh)),
+            if_neg (fun hh => h₂ (e2.mpr hh))]
+  | defined t =>
+    obtain ⟨ht, hb⟩ := ha
+    simp only [Atom.Realize, Term.eval_backward hn ht, Term.eval_backward hn' ht]
+    by_cases h : t.pdepth ≤ n
+    · rw [if_pos h, if_pos ((hedge t.pdepth hb).mp h)]; simp
+    · rw [if_neg h, if_neg (fun hh => h ((hedge t.pdepth hb).mpr hh))]
+
+/-- A backward-bounded quantifier-free formula reads only the `r + 1` symbols ending at its
+position — the boolean-combination lift of `Atom.realize_eq_of_agree`. -/
+private theorem QF.realize_eq_of_agree [DecidableEq α] {r : ℕ}
+    {w w' : WordModel α} {n n' : ℕ}
+    (hn : n < w.length) (hn' : n' < w'.length)
+    (hlbl : ∀ j ≤ r, w.label? (n - j) = w'.label? (n' - j))
+    (hedge : ∀ j ≤ r, (j ≤ n ↔ j ≤ n')) :
+    ∀ {φ : QF α (Fin 1)}, φ.BackBounded r →
+      (φ.Realize w (fun _ => n) ↔ φ.Realize w' (fun _ => n')) := by
+  intro φ
+  induction φ with
+  | atom a => exact fun hφ => Atom.realize_eq_of_agree hφ hn hn' hlbl hedge
+  | tru => intro _; simp [QF.Realize]
+  | fls => intro _; simp [QF.Realize]
+  | neg φ ih => intro hφ; simp only [QF.Realize, ih hφ]
+  | conj φ ψ ihφ ihψ => intro hφ; obtain ⟨h1, h2⟩ := hφ; simp only [QF.Realize, ihφ h1, ihψ h2]
+  | disj φ ψ ihφ ihψ => intro hφ; obtain ⟨h1, h2⟩ := hφ; simp only [QF.Realize, ihφ h1, ihψ h2]
+
+/-- Pointwise congruence for `List.findSome?`: agreeing on the list's members suffices. -/
+private theorem findSome?_congr {γ δ : Type*} {f g : γ → Option δ} :
+    ∀ {l : List γ}, (∀ x ∈ l, f x = g x) → l.findSome? f = l.findSome? g := by
+  intro l
+  induction l with
+  | nil => intro _; rfl
+  | cons a as ih =>
+    intro h
+    rw [List.findSome?_cons, List.findSome?_cons, h a List.mem_cons_self]
+    cases g a with
+    | none => exact ih (fun x hx => h x (List.mem_cons_of_mem a hx))
+    | some b => rfl
+
+/-- A left-local transduction emits the same block at positions whose bounded left contexts agree:
+every clause guard is backward-bounded, so its firing is determined by that context. -/
+private theorem Transduction.emitAt_eq_of_agree [DecidableEq α] {r : ℕ} {T : Transduction α β}
+    (hT : T.LeftLocal r) {w w' : WordModel α} {n n' : ℕ}
+    (hn : n < w.length) (hn' : n' < w'.length)
+    (hlbl : ∀ j ≤ r, w.label? (n - j) = w'.label? (n' - j))
+    (hedge : ∀ j ≤ r, (j ≤ n ↔ j ≤ n')) :
+    T.emitAt w n = T.emitAt w' n' := by
+  unfold Transduction.emitAt
+  apply List.filterMap_congr
+  intro c _
+  apply findSome?_congr
+  intro cl hcl
+  have hb := hT c cl hcl
+  by_cases h : cl.1.Realize w (fun _ => n)
+  · rw [if_pos h, if_pos ((QF.realize_eq_of_agree hn hn' hlbl hedge hb).mp h)]
+  · rw [if_neg h, if_neg (fun hh => h ((QF.realize_eq_of_agree hn hn' hlbl hedge hb).mpr hh))]
+
+/-- The block a left-local transduction emits at position `p` depends only on the `r + 1` input
+symbols ending at `p`: it equals the block emitted at the last position of that window. -/
+private theorem Transduction.emitAt_local [DecidableEq α] {r : ℕ} {T : Transduction α β}
+    (hT : T.LeftLocal r) {input : WordModel α} {p : ℕ} (hp : p < input.length) :
+    T.emitAt input p = T.emitAt ((input.take (p + 1)).rtake (r + 1)) (min r p) := by
+  apply Transduction.emitAt_eq_of_agree hT hp
+  · rw [List.length_rtake, List.length_take]; omega
+  · intro j hj
+    have hlen : (input.take (p + 1)).length = p + 1 := by rw [List.length_take]; omega
+    simp only [WordModel.label?_eq_getElem?]
+    rw [show (input.take (p + 1)).rtake (r + 1)
+          = (input.take (p + 1)).drop ((input.take (p + 1)).length - (r + 1)) from rfl,
+        List.getElem?_drop, hlen, List.getElem?_take, if_pos (by omega)]
+    congr 1
+    omega
+  · intro j hj; omega
+
+/-- Two nested tail-takes collapse to one: `(l.rtake m).rtake n = l.rtake (min n m)`. -/
+private theorem rtake_rtake {γ : Type*} (l : List γ) (m n : ℕ) :
+    (l.rtake m).rtake n = l.rtake (min n m) := by
+  simp only [List.rtake_eq_reverse_take_reverse, List.reverse_reverse, List.take_take]
+
+/-- Tail-taking a length-`r` window extended by one symbol re-takes the underlying list extended by
+that symbol — the step that keeps the threaded ISL window equal to the bounded left context. -/
+private theorem rtake_concat_rtake {γ : Type*} (l : List γ) (x : γ) (r : ℕ) :
+    (l.rtake r ++ [x]).rtake r = (l ++ [x]).rtake r := by
+  cases r with
+  | zero => simp [List.rtake_zero]
+  | succ r' =>
+    rw [List.rtake_concat_succ, List.rtake_concat_succ, rtake_rtake,
+        Nat.min_eq_left (Nat.le_succ r')]
+
+/-- `toISLRule`'s window output is, by definition, `emitAt` on the window plus the current symbol. -/
+private theorem Transduction.windowOutput_toISLRule [DecidableEq α] {r : ℕ} (T : Transduction α β)
+    (window : List α) (x : α) :
+    (T.toISLRule r).windowOutput window x = T.emitAt (window ++ [x]) window.length := rfl
+
+/-- **Window-threading invariant.** Running the induced ISL rule from the bounded left context
+`(input.take p).rtake r` over the remaining suffix `s` reproduces the transduction's own block
+sequence over the input positions `p, p+1, …`. The induction maintains that the threaded window
+stays exactly the `r`-symbol left context. -/
+private theorem Transduction.applyAux_toISLRule_eq [DecidableEq α] {r : ℕ} {T : Transduction α β}
+    (hT : T.LeftLocal r) (input : WordModel α) :
+    ∀ (s : WordModel α) (p : ℕ), input = input.take p ++ s → p = (input.take p).length →
+      ISLRule.applyAux (T.toISLRule r) ((input.take p).rtake r) s
+        = (List.range' p s.length).flatMap (T.emitAt input) := by
+  intro s
+  induction s with
+  | nil => intro p _ _; simp
+  | cons x s' ih =>
+    intro p hsplit hplen
+    have hp : p < input.length := by
+      have hcl := congrArg List.length hsplit
+      simp only [List.length_append, List.length_cons] at hcl
+      omega
+    have hx : input[p]? = some x := by
+      rw [hsplit, List.getElem?_append_right (by omega)]
+      simp [← hplen]
+    have hpx : input.take (p + 1) = input.take p ++ [x] := by
+      rw [List.take_add_one, hx]; rfl
+    have hwin : ((input.take p).rtake r ++ [x]).rtake r = (input.take (p + 1)).rtake r := by
+      rw [rtake_concat_rtake, hpx]
+    have hw2 : (input.take (p + 1)).rtake (r + 1) = (input.take p).rtake r ++ [x] := by
+      rw [hpx, List.rtake_concat_succ]
+    have hlen : ((input.take p).rtake r).length = min r p := by
+      rw [List.length_rtake, ← hplen]
+    have hsplit' : input = input.take (p + 1) ++ s' := by
+      rw [hpx, List.append_assoc, List.singleton_append]; exact hsplit
+    have hplen' : p + 1 = (input.take (p + 1)).length := by
+      rw [List.length_take]; omega
+    rw [ISLRule.applyAux_cons, Transduction.windowOutput_toISLRule, Nat.add_sub_cancel, hlen, hwin,
+        ih (p + 1) hsplit' hplen', List.length_cons, List.range'_succ, List.flatMap_cons]
+    congr 1
+    rw [Transduction.emitAt_local hT hp, hw2]
+
 /-- **Locality bridge** (left half), [dolatian-2020] after Chandlee–Heinz–Jardine: a transduction
 whose guards look only backward with predecessor depth `≤ r` is `(r+1)`-Left-Input-Strictly-Local —
 its output depends on a bounded left window, the defining property of strict locality. -/
 theorem Transduction.leftLocal_isLeftISL [DecidableEq α] {r : ℕ} {T : Transduction α β}
     (hT : T.LeftLocal r) : IsLeftInputStrictlyLocal (r + 1) T.apply := by
   refine ⟨T.toISLRule r, ?_⟩
-  -- TODO(stage-3 assembly): `(T.toISLRule r).apply = T.apply`. The local-determination crux is
-  -- `Term.eval_backward` (proven): a backward guard of pdepth ≤ r at position `n` reads only
-  -- positions `[n-r, n]`, so `emitAt` agrees on the `rtake r` window. What remains is the
-  -- `ISLRule.applyAux` window invariant — that the threaded window stays `(w.take p).rtake r` —
-  -- which needs `rtake` append/idempotence lemmas not yet in `Core.Data.List.DropRight`.
-  sorry
+  funext input
+  have h := Transduction.applyAux_toISLRule_eq hT input input 0 (by simp) (by simp)
+  rw [List.take_zero, List.rtake_nil] at h
+  rw [ISLRule.apply, Transduction.apply, List.range_eq_range']
+  exact h
 
 /-! ### Worked example: the bridge on a concrete left-local process -/
 


### PR DESCRIPTION
Discharges the `sorry` in `Transduction.leftLocal_isLeftISL` left by #947's squash (the proof commit landed on the branch after the merge snapshot, so `main` shipped the unproven state). Now fully proven, axiom-clean (`propext`/`Classical.choice`/`Quot.sound`).

A backward-bounded (radius `r`) QF transduction is `(r+1)`-Left-Input-Strictly-Local. Adds the locality layer (`realize_eq_of_agree` → `emitAt_eq_of_agree` → `emitAt_local`), the `rtake` algebra (`rtake_rtake`, `rtake_concat_rtake`) and `findSome?_congr`, and the window-threading invariant (`applyAux`'s threaded window stays `(input.take p).rtake r`).

No `sorry`, no `native_decide`.
