### PR TITLE
refactor(Studies/Benua1997): fold TCT + StratalCorr into the study

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1348,8 +1348,6 @@ import Linglib.Phonology.OptimalityTheory.Grammar
 import Linglib.Phonology.OptimalityTheory.HarmonicSerialism
 import Linglib.Phonology.OptimalityTheory.Predict
 import Linglib.Phonology.OptimalityTheory.Stratal
-import Linglib.Phonology.OptimalityTheory.StratalCorr
-import Linglib.Phonology.OptimalityTheory.TCT
 import Linglib.Phonology.Prosody.Accent
 import Linglib.Phonology.Prosody.CompensatoryLengthening
 import Linglib.Phonology.Prosody.Foot
@@ -2028,7 +2026,9 @@ import Linglib.Studies.Belth2026
 import Linglib.Studies.Beltrama2025
 import Linglib.Studies.BeltramaSchwarz2024
 import Linglib.Studies.BeltramaSoltBurnett2022
-import Linglib.Studies.Benua1997
+import Linglib.Studies.Benua1997.Basic
+import Linglib.Studies.Benua1997.StratalCorr
+import Linglib.Studies.Benua1997.TCT
 import Linglib.Studies.Benz2025
 import Linglib.Studies.BenzSalzmann2025
 import Linglib.Studies.Berent2026

--- a/Linglib/Studies/Benua1997/Basic.lean
+++ b/Linglib/Studies/Benua1997/Basic.lean
@@ -1,7 +1,7 @@
 import Linglib.Phonology.OptimalityTheory.Correspondence
-import Linglib.Phonology.OptimalityTheory.TCT
+import Linglib.Studies.Benua1997.TCT
 import Linglib.Phonology.OptimalityTheory.Stratal
-import Linglib.Phonology.OptimalityTheory.StratalCorr
+import Linglib.Studies.Benua1997.StratalCorr
 import Linglib.Phonology.Constraints.Defs
 import Linglib.Phonology.OptimalityTheory.Basic
 
@@ -49,7 +49,7 @@ markedness constraint M₂ is satisfied or violated by the base output.
 ## Architectural integration
 
 Consumes:
-- `Phonology.OptimalityTheory.TCT.Role` and `TetruSchema`
+- `Benua1997.TCT.Role` and `TetruSchema` (this paper's TCT framework, `TCT.lean`)
 - the local § 0 `diagramWithEdge` (general 3-role correspondence with explicit
   OO alignment), folded in from the former `ParadigmUniformity/Transderivational`
 - `Phonology.OptimalityTheory.Correspondence.Corr.identViol` (segmental)
@@ -64,7 +64,7 @@ machinery — the cross-linguistic point of [benua-1997] is that
 namespace Benua1997
 
 open OptimalityTheory.Correspondence (Corr)
-open OptimalityTheory.TCT (Role TetruSchema)
+open Benua1997.TCT (Role TetruSchema)
 open Constraints OptimalityTheory
 
 -- ============================================================================
@@ -489,8 +489,9 @@ the architecturally-distinct derivations producing identical phraseOutput.
 
 namespace StratalComparison
 
-open OptimalityTheory.Stratal (StratalDerivation StratalRole stratalDerivToCorr)
-open OptimalityTheory.StratalToTCT (project project_preserves_phrase_as_derivative
+open OptimalityTheory.Stratal (StratalDerivation)
+open Benua1997.StratalCorr (StratalRole stratalDerivToCorr)
+open Benua1997.StratalToTCT (project project_preserves_phrase_as_derivative
                              project_preserves_stem_as_base
                              project_preserves_underlying_as_input
                              project_oo_edge_eq_parallel)
@@ -568,7 +569,7 @@ theorem stratal_stem_is_tct_base :
     `(.base, .derivative)` correspondence. -/
 theorem stratal_chain_collapses_to_oo_edge :
     sundaneseStratalAsTCT.edge .base .derivative =
-      OptimalityTheory.Stratal.parallelEdge Sundanese.baseOutput
+      Benua1997.StratalCorr.parallelEdge Sundanese.baseOutput
         Sundanese.derivOutputOverapplied :=
   project_oo_edge_eq_parallel _ _ _ _
 

--- a/Linglib/Studies/Benua1997/StratalCorr.lean
+++ b/Linglib/Studies/Benua1997/StratalCorr.lean
@@ -1,10 +1,14 @@
 import Linglib.Phonology.OptimalityTheory.Correspondence
 import Linglib.Phonology.OptimalityTheory.Stratal
-import Linglib.Phonology.OptimalityTheory.TCT
+import Linglib.Studies.Benua1997.TCT
 
 /-!
-# Stratal OT ↔ Corr ↔ TCT — Architectural Bridge
+# Benua (1997): the stratal ↔ TCT architectural equivalence
 [kiparsky-2000] [benua-1997]
+
+The stratal-OT ↔ TCT correspondence that [benua-1997] argues for, formalized over
+the shared `Corr Role α` substrate. (Paper-anchored to [benua-1997]; consumed only
+by this study, so it lives in the study directory, not the OT theory layer.)
 
 The substrate-level integration between Stratal OT ([kiparsky-2000])
 and TCT ([benua-1997]) over the unifying `Corr Role α` substrate.
@@ -58,7 +62,7 @@ the grammar bridge in shared types — currently `StratalDerivation` and
 `Corr TCT.Role α` live in non-communicating namespaces.
 -/
 
-namespace OptimalityTheory.Stratal
+namespace Benua1997.StratalCorr
 
 open OptimalityTheory.Correspondence (Corr Side)
 
@@ -159,17 +163,17 @@ def stratalDerivToCorr {α : Type*}
     (input stemOut wordOut phraseOut : List α) :
     (stratalDerivToCorr input stemOut wordOut phraseOut).form .pOut = phraseOut := rfl
 
-end OptimalityTheory.Stratal
+end Benua1997.StratalCorr
 
 -- ============================================================================
 -- § 4: StratalRole → TCT.Role projection
 -- ============================================================================
 
-namespace OptimalityTheory.StratalToTCT
+namespace Benua1997.StratalToTCT
 
 open OptimalityTheory.Correspondence (Corr)
-open OptimalityTheory.Stratal (StratalRole stratalDerivToCorr parallelEdge)
-open OptimalityTheory.TCT (Role)
+open Benua1997.StratalCorr (StratalRole stratalDerivToCorr parallelEdge)
+open Benua1997.TCT (Role)
 
 /-- The canonical projection from stratal roles to TCT roles, encoding
     Benua's identification:
@@ -253,4 +257,4 @@ theorem project_oo_edge_eq_parallel {α : Type*}
   rw [Corr.diagram_edge_pos _ _ (by decide)]
   rfl
 
-end OptimalityTheory.StratalToTCT
+end Benua1997.StratalToTCT

--- a/Linglib/Studies/Benua1997/TCT.lean
+++ b/Linglib/Studies/Benua1997/TCT.lean
@@ -57,10 +57,13 @@ the misapplication-unification theorem. Concrete evaluation (sub-grammar
 selection, candidate generation) is paper-specific and lives in study
 files. The paradigm-uniformity face of TCT (`Corr`-style 3-role diagram
 constructors for within-paradigm OO-Faith) lives with the case studies in
-`Studies/Benua1997.lean`.
+`Studies/Benua1997/Basic.lean`.
+
+TCT is [benua-1997]'s own framework with no second consumer, so it is anchored to
+this paper's study directory rather than the OT theory layer.
 -/
 
-namespace OptimalityTheory.TCT
+namespace Benua1997.TCT
 
 open OptimalityTheory.Correspondence (Corr)
 open Constraints OptimalityTheory
@@ -207,4 +210,4 @@ theorem TetruSchema.misapplication_wins {C : Type*} (s : TetruSchema C)
     exact hM1.symm
   · exact hOO
 
-end OptimalityTheory.TCT
+end Benua1997.TCT


### PR DESCRIPTION
[benua-1997]'s single-paper TCT framework and the self-described "Architectural Bridge" `StratalCorr` file move out of the OT theory layer into `Studies/Benua1997/` (re-namespaced `OptimalityTheory.{TCT,Stratal,StratalToTCT}` → `Benua1997.{TCT,StratalCorr,StratalToTCT}`), per the anchoring discipline — both had `Benua1997` as their only consumer, and a "Bridge" file is the forbidden anti-pattern. `Studies/Benua1997.lean` becomes `Studies/Benua1997/{Basic,TCT,StratalCorr}.lean`. Pure move + re-namespace, no behavior change.