### PR TITLE
refactor(Core/Computability/Subregular/Logic): keep the layer domain-general

### DIFF
--- a/Linglib/Core/Computability/Subregular/Logic/LocalityBridge.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/LocalityBridge.lean
@@ -4,9 +4,9 @@ import Linglib.Core.Computability.Subregular.Function.ISL
 /-!
 # The locality bridge: quantifier-free ⟹ strictly local
 
-The load-bearing subregular result ([dolatian-2020], after Chandlee, Heinz & Jardine): a
-quantifier-free logical transduction whose guards look only at a *bounded* context is
-**strictly local**. Here we prove the left-directed half against `Subregular`'s
+The load-bearing subregular result ([chandlee-2014], [chandlee-jardine-2019]): a quantifier-free
+logical transduction whose guards look only at a *bounded* context is **strictly local**. Here we
+prove the left-directed half against `Subregular`'s
 `IsLeftInputStrictlyLocal`: a transduction whose guards are *backward* (built from the variable
 and predecessors, no successor) with predecessor depth `≤ r` is `IsLeftInputStrictlyLocal (r + 1)`.
 
@@ -279,9 +279,9 @@ private theorem Transduction.applyAux_toISLRule_eq [DecidableEq α] {r : ℕ} {T
     congr 1
     rw [Transduction.emitAt_local hT hp, hw2]
 
-/-- **Locality bridge** (left half), [dolatian-2020] after Chandlee–Heinz–Jardine: a transduction
-whose guards look only backward with predecessor depth `≤ r` is `(r+1)`-Left-Input-Strictly-Local —
-its output depends on a bounded left window, the defining property of strict locality. -/
+/-- **Locality bridge** (left half), [chandlee-2014], [chandlee-jardine-2019]: a transduction whose
+guards look only backward with predecessor depth `≤ r` is `(r+1)`-Left-Input-Strictly-Local — its
+output depends on a bounded left window, the defining property of strict locality. -/
 theorem Transduction.leftLocal_isLeftISL [DecidableEq α] {r : ℕ} {T : Transduction α β}
     (hT : T.LeftLocal r) : IsLeftInputStrictlyLocal (r + 1) T.apply := by
   refine ⟨T.toISLRule r, ?_⟩
@@ -295,22 +295,22 @@ theorem Transduction.leftLocal_isLeftISL [DecidableEq α] {r : ℕ} {T : Transdu
 
 section Example
 
-private inductive Seg | t | d | a
+private inductive Sym | a | b | c
   deriving DecidableEq
 
 private def xv : Term (Fin 1) := .var 0
 
-/-- Post-vocalic stop voicing `t → d`: the guard looks only left (a predecessor vowel), so it is
-backward with radius 1. -/
-private def postVoicing : Transduction Seg Seg where
+/-- Relabel `b → c` immediately after an `a`: the guard looks only left (a predecessor `a`), so it
+is backward with radius 1. -/
+private def afterA : Transduction Sym Sym where
   copies := 1
-  clause _ := [(QF.conj (.atom (.label .a xv.pred)) (.atom (.label .t xv)), .d),
-               (.atom (.label .t xv), .t), (.atom (.label .d xv), .d), (.atom (.label .a xv), .a)]
+  clause _ := [(QF.conj (.atom (.label .a xv.pred)) (.atom (.label .b xv)), .c),
+               (.atom (.label .b xv), .b), (.atom (.label .c xv), .c), (.atom (.label .a xv), .a)]
 
 -- The induced 2-Left-ISL rule computes the same function on a sample — the bridge, concretely.
-example : (postVoicing.toISLRule 1).apply [Seg.a, .t, .a, .t]
-            = postVoicing.apply [Seg.a, .t, .a, .t] := by decide
-example : postVoicing.apply [Seg.a, .t, .a, .t] = [Seg.a, .d, .a, .d] := by decide
+example : (afterA.toISLRule 1).apply [Sym.a, .b, .a, .b]
+            = afterA.apply [Sym.a, .b, .a, .b] := by decide
+example : afterA.apply [Sym.a, .b, .a, .b] = [Sym.a, .c, .a, .c] := by decide
 
 end Example
 

--- a/Linglib/Core/Computability/Subregular/Logic/QFLogic.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/QFLogic.lean
@@ -3,14 +3,14 @@ import Linglib.Core.Computability.Subregular.Logic.WordModel
 /-!
 # Quantifier-free logic over word models
 
-The quantifier-free (QF) fragment of the logic of word models ([dolatian-2020]). Terms are
-built from a variable by applying the successor/predecessor partial functions; formulas are
-boolean combinations of atomic label/equality/definedness tests. Because successor is a
-*function*, a QF term reaches a *bounded* neighbourhood of its variable with no quantifiers —
-the syntactic counterpart of strict locality. (Dolatian's `intervocalic(x) := ∃w,y[…]` becomes
-the QF `label V (pred x) ∧ label V (succ x)`.) The forthcoming locality bridge
-(`Logic/LocalityBridge.lean`) is that QF-definable transductions are exactly the
-Input-Strictly-Local functions of `Subregular`.
+The quantifier-free (QF) fragment of the logic of word models. Terms are built from a variable
+by applying the successor/predecessor partial functions; formulas are boolean combinations of
+atomic label/equality/definedness tests. Because successor is a *function*, a QF term reaches a
+*bounded* neighbourhood of its variable with no quantifiers — the syntactic counterpart of
+strict locality (an existential like `∃w,y[succ w x ∧ succ x y ∧ …]` collapses to the
+quantifier-free `… (pred x) ∧ … (succ x)`). The locality bridge (`Logic/LocalityBridge.lean`)
+makes this precise: QF-definable transductions are exactly the Input-Strictly-Local functions of
+`Subregular` ([chandlee-2014], [chandlee-jardine-2019]).
 
 ## Main definitions
 
@@ -102,25 +102,25 @@ def QF.initial (t : Term V) : QF α V :=
 def QF.final (t : Term V) : QF α V :=
   .conj (.atom (.defined t)) (.neg (.atom (.defined t.succ)))
 
-/-! ### Worked example: intervocalic position -/
+/-! ### Worked example -/
 
 section Example
 
-private inductive Seg | a | t deriving DecidableEq
+private inductive Sym | a | b deriving DecidableEq
 
-/-- `x` is intervocalic — flanked by `a`s — stated quantifier-free via `succ`/`pred` terms
-(no existential, contrast Dolatian's `∃w,y[…]`). -/
-private def intervocalic : QF Seg Unit :=
+/-- `x` is flanked by `a`s — a bounded two-sided context stated quantifier-free via `succ`/`pred`
+terms, with no existential. -/
+private def flankedByA : QF Sym Unit :=
   .conj (.atom (.label .a (.pred (.var ())))) (.atom (.label .a (.succ (.var ()))))
 
-private def ata : WordModel Seg := [Seg.a, Seg.t, Seg.a]
+private def aba : WordModel Sym := [Sym.a, Sym.b, Sym.a]
 
--- Position 1 (the `t`) is intervocalic; position 0 (initial `a`) is not (no predecessor).
-example : intervocalic.Realize ata (fun _ => 1) := by decide
-example : ¬ intervocalic.Realize ata (fun _ => 0) := by decide
+-- Position 1 (the `b`) is flanked by `a`s; position 0 is not (no predecessor).
+example : flankedByA.Realize aba (fun _ => 1) := by decide
+example : ¬ flankedByA.Realize aba (fun _ => 0) := by decide
 -- The edge predicates compute as expected.
-example : (QF.initial (α := Seg) (.var ())).Realize ata (fun _ => 0) := by decide
-example : (QF.final (α := Seg) (.var ())).Realize ata (fun _ => 2) := by decide
+example : (QF.initial (α := Sym) (.var ())).Realize aba (fun _ => 0) := by decide
+example : (QF.final (α := Sym) (.var ())).Realize aba (fun _ => 2) := by decide
 
 end Example
 

--- a/Linglib/Core/Computability/Subregular/Logic/Transduction.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/Transduction.lean
@@ -3,21 +3,20 @@ import Linglib.Core.Computability.Subregular.Logic.QFLogic
 /-!
 # Logical transductions
 
-Quantifier-free graph-to-graph **logical transductions** ([dolatian-2020], after Courcelle and
-Engelfriet & Hoogeboom): a phonological process as a map from an input word model to an output
-word model, defined by a **copy set** and, per copy, **output formulas** (Dolatian's `φ_lab(xᶜ)`).
-A copy set of size `k` lets the output be larger than the input (epenthesis); per-copy guards that
-match nothing delete (deletion); relabelling copies change features (feature change).
+Quantifier-free graph-to-graph **logical transductions**: a map from an input word model to an
+output word model, defined by a **copy set** and, per copy, **output formulas** (`φ_lab(xᶜ)`). A
+copy set of size `k` lets the output be larger than the input (insertion); per-copy guards that
+match nothing delete; relabelling copies rewrite a symbol in place.
 
 We formalize the **order-preserving** fragment: the output is read off in the order
 `(input position, copy index)`, so the output successor is induced rather than given by an explicit
-`φ_succ(xᶜ, yᵈ)`. This is exactly the local fragment relevant to strict locality — feature change,
-deletion, and epenthesis. Non-order-preserving processes (metathesis via an explicit successor
-formula) are the non-local extension and are deliberately out of scope here.
+`φ_succ(xᶜ, yᵈ)`. This is exactly the local fragment relevant to strict locality — relabelling,
+deletion, and insertion. Non-order-preserving maps (reordering via an explicit successor formula)
+are the non-local extension and are deliberately out of scope here.
 
-Cyclic / interactionist phonology is **composition** of transductions (`applyComp`): each cycle is
-a local transduction; the whole derivation is their composite (a regular function — closed under
-composition in `SFST` — though not in general itself quantifier-free).
+Composition of transductions (`applyComp`) models an iterated derivation: each step is a local
+transduction; the composite is a regular function (closed under composition in `SFST`) though not
+in general itself quantifier-free.
 
 ## Main definitions
 
@@ -74,55 +73,52 @@ end Transduction
 
 section Example
 
-private inductive Seg | p | t | d | j | a
+private inductive Sym | a | b | c
   deriving DecidableEq
 
 open Term QF
 
 private def x : Term (Fin 1) := var 0
-private def vowelAt (t : Term (Fin 1)) : QF Seg (Fin 1) := .atom (.label .a t)
-/-- A consonant: any non-vowel symbol of the demo alphabet. -/
-private def consAt (t : Term (Fin 1)) : QF Seg (Fin 1) :=
-  .disj (.atom (.label .p t)) (.disj (.atom (.label .t t))
-    (.disj (.atom (.label .d t)) (.atom (.label .j t))))
-/-- The variable position is intervocalic (flanked by vowels), quantifier-free. -/
-private def interV : QF Seg (Fin 1) := .conj (vowelAt x.pred) (vowelAt x.succ)
+private def isA (t : Term (Fin 1)) : QF Sym (Fin 1) := .atom (.label .a t)
+/-- Any non-`a` symbol of the demo alphabet. -/
+private def nonA (t : Term (Fin 1)) : QF Sym (Fin 1) :=
+  .disj (.atom (.label .b t)) (.atom (.label .c t))
+/-- The variable position is flanked by `a`s. -/
+private def flankedA : QF Sym (Fin 1) := .conj (isA x.pred) (isA x.succ)
 
-/-- **Feature change** — intervocalic stop voicing `t → d`: the `t → d` clause precedes the
-faithful `t → t` clause, so it wins between vowels. -/
-private def voicing : Transduction Seg Seg where
+/-- **Relabelling** — rewrite `b → c` between `a`s: the `b → c` clause precedes the faithful
+`b → b` clause, so it wins in that context. -/
+private def relabelBC : Transduction Sym Sym where
   copies := 1
-  clause _ := [(interV.conj (.atom (.label .t x)), .d), (.atom (.label .t x), .t),
-               (.atom (.label .p x), .p), (.atom (.label .a x), .a), (.atom (.label .d x), .d)]
+  clause _ := [(flankedA.conj (.atom (.label .b x)), .c), (.atom (.label .b x), .b),
+               (.atom (.label .a x), .a), (.atom (.label .c x), .c)]
 
-example : voicing.apply [Seg.p, .a, .t, .a] = [Seg.p, .a, .d, .a] := by decide
+example : relabelBC.apply [Sym.a, .b, .a] = [Sym.a, .c, .a] := by decide
 
-/-- **Deletion** — intervocalic glide `j` deletion: `j` is emitted only when *not* intervocalic, so
-an intervocalic `j` matches no clause and is dropped. -/
-private def glideDeletion : Transduction Seg Seg where
+/-- **Deletion** — delete `b` between `a`s: `b` is emitted only when *not* flanked, so a flanked
+`b` matches no clause and is dropped. -/
+private def deleteFlanked : Transduction Sym Sym where
   copies := 1
-  clause _ := [(.atom (.label .p x), .p), (.atom (.label .a x), .a), (.atom (.label .t x), .t),
-               (.atom (.label .d x), .d), (QF.conj (.atom (.label .j x)) interV.neg, .j)]
+  clause _ := [(.atom (.label .a x), .a), (.atom (.label .c x), .c),
+               (QF.conj (.atom (.label .b x)) flankedA.neg, .b)]
 
-example : glideDeletion.apply [Seg.p, .a, .j, .a] = [Seg.p, .a, .a] := by decide
+example : deleteFlanked.apply [Sym.a, .b, .a] = [Sym.a, .a] := by decide
 
-/-- **Epenthesis** — insert a final vowel after a word-final consonant: copy 0 is faithful, copy 1
-emits `a` only after a final consonant. -/
-private def finalEpenthesis : Transduction Seg Seg where
+/-- **Insertion** — insert `a` after a final non-`a` symbol: copy 0 is faithful, copy 1 emits `a`
+only after a final non-`a` (a copy with no firing clause is absent). -/
+private def insertA : Transduction Sym Sym where
   copies := 2
-  clause c :=
-    if c = 0 then
-      [(.atom (.label .p x), .p), (.atom (.label .t x), .t), (.atom (.label .d x), .d),
-       (.atom (.label .j x), .j), (.atom (.label .a x), .a)]
+  clause k :=
+    if k = 0 then
+      [(.atom (.label .a x), .a), (.atom (.label .b x), .b), (.atom (.label .c x), .c)]
     else
-      [(consAt x |>.conj (QF.final x), .a)]
+      [(nonA x |>.conj (QF.final x), .a)]
 
-example : finalEpenthesis.apply [Seg.p, .a, .t] = [Seg.p, .a, .t, .a] := by decide
+example : insertA.apply [Sym.a, .b] = [Sym.a, .b, .a] := by decide
 
-/-- **Cyclicity** — composition of two local transductions: intervocalic voicing then final
-epenthesis. On `atat`: the first `t` voices (between vowels), the final `t` does not, then the
-final consonant triggers epenthesis. -/
-example : finalEpenthesis.applyComp voicing [Seg.a, .t, .a, .t] = [Seg.a, .d, .a, .t, .a] := by
+/-- **Composition** — relabelling then insertion. On `abab`: the first `b` (between `a`s) becomes
+`c`, the final `b` does not, then the final non-`a` triggers insertion. -/
+example : insertA.applyComp relabelBC [Sym.a, .b, .a, .b] = [Sym.a, .c, .a, .b, .a] := by
   decide
 
 end Example

--- a/Linglib/Core/Computability/Subregular/Logic/TreeModel.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/TreeModel.lean
@@ -3,17 +3,14 @@ import Linglib.Core.Combinatorics.RootedTree.Planar
 /-!
 # Tree models and quantifier-free logic over them
 
-The hierarchical counterpart of `Logic/WordModel.lean` ([dolatian-2020] §4.5, after Courcelle's
-relational tree models): morphological and prosodic structure as labeled trees, with the *same*
-model-theoretic apparatus used for strings. A **tree model** is a `RootedTree.Planar L` — a node-
-labeled rose tree — addressed by Gorn indices (`List ℕ`); its relations are dominance (parent/child)
-and sibling precedence. Quantifier-free terms navigate by `parent`/`child`/`sibSucc`/`sibPred`
-partial functions, giving the bounded reach that, as on strings, underlies tree-local computation.
+The hierarchical counterpart of `Logic/WordModel.lean`: the model-theoretic representation of finite
+labeled trees, the foundation for logical characterizations of tree-to-tree subregular maps. A
+**tree model** is a `RootedTree.Planar L` — a node-labeled rose tree — addressed by Gorn indices
+(`List ℕ`); its relations are dominance (parent/child) and sibling precedence. Quantifier-free terms
+navigate by `parent`/`child`/`sibSucc`/`sibPred` partial functions, giving the bounded reach that,
+as on strings, underlies tree-local computation.
 
-The model is generic over the label type `L`, so it instantiates uniformly to morphological
-structure (a tree of `root`/`stem`/`word`/affix categories) and to prosody (`Prosody.Tree`, a
-`Planar` of prosodic labels — that instantiation lives downstream, since `Core` cannot import
-`Phonology`). This genericity is Dolatian's point: one hierarchical apparatus for both.
+The model is generic over the label type `L`; downstream layers instantiate it.
 
 ## Main definitions
 
@@ -133,28 +130,28 @@ instance TreeQF.instDecidableRealize (t : TreeModel L) (ρ : V → List ℕ) :
 def TreeQF.isRoot (s : TreeTerm V) : TreeQF L V :=
   .conj (.atom (.defined s)) (.neg (.atom (.defined s.parent)))
 
-/-! ### Worked example: a morphological structure -/
+/-! ### Worked example -/
 
 section Example
 
-private inductive Cat | word | stem | root | affix
+private inductive Sym | a | b | c
   deriving DecidableEq
 
 open TreeTerm Planar
 
-/-- `[word [stem root affix] affix]` — a stem (root + suffix) with an outer suffix. -/
-private def w : TreeModel Cat :=
-  .node .word [.node .stem [.node .root [], .node .affix []], .node .affix []]
+/-- The tree `a[ b[c c], b ]`. -/
+private def t : TreeModel Sym :=
+  .node .a [.node .b [.node .c [], .node .c []], .node .b []]
 
 private def x : TreeTerm (Fin 1) := var 0
 
--- The node at `[0,0]` is a root whose mother is a stem; its right sibling is an affix.
-example : (TreeQF.atom (.label .root x)).Realize w (fun _ => [0, 0]) := by decide
-example : (TreeQF.atom (.label .stem x.parent)).Realize w (fun _ => [0, 0]) := by decide
-example : (TreeQF.atom (.label .affix x.sibSucc)).Realize w (fun _ => [0, 0]) := by decide
--- The root has no further-out sibling, and the word node is the root of the tree.
-example : ¬ (TreeQF.atom (.defined x.sibPred)).Realize w (fun _ => [0, 0]) := by decide
-example : (TreeQF.isRoot (L := Cat) x).Realize w (fun _ => []) := by decide
+-- The node at `[0,0]` is labelled `c`, its parent `b`, its right sibling `c`.
+example : (TreeQF.atom (.label .c x)).Realize t (fun _ => [0, 0]) := by decide
+example : (TreeQF.atom (.label .b x.parent)).Realize t (fun _ => [0, 0]) := by decide
+example : (TreeQF.atom (.label .c x.sibSucc)).Realize t (fun _ => [0, 0]) := by decide
+-- It has no left sibling, and the address `[]` names the root.
+example : ¬ (TreeQF.atom (.defined x.sibPred)).Realize t (fun _ => [0, 0]) := by decide
+example : (TreeQF.isRoot (L := Sym) x).Realize t (fun _ => []) := by decide
 
 end Example
 

--- a/Linglib/Core/Computability/Subregular/Logic/WordModel.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/WordModel.lean
@@ -4,10 +4,9 @@ import Mathlib.Data.List.Basic
 # Word models
 
 The model-theoretic representation underlying logical characterizations of subregular
-functions: a string viewed as a finite labeled linear order ([dolatian-2020], after
-Büchi, Courcelle & Engelfriet, and Libkin). A **word model** is Dolatian's signature
-`⟨D, L, R⟩` — a domain `D` of positions, unary labels `L`, and the binary
-immediate-successor relation `R`; general precedence is the (FO-definable) transitive
+functions: a string viewed as a finite labeled linear order. A **word model** is the
+relational signature `⟨D, L, R⟩` — a domain `D` of positions, unary labels `L`, and the
+binary immediate-successor relation `R`; general precedence is the (FO-definable) transitive
 closure of successor and is not part of the quantifier-free fragment.
 
 The carrier is `List α` itself: a string *is* its word model. This is deliberately where


### PR DESCRIPTION
`Core` is upstreamable-to-mathlib, so it must carry no linguistic content. The subregular *machinery* in `Core/Computability/Subregular/Logic` (word/tree models, QF logic, transductions, the QF→ISL theorem) is general formal-language theory and belongs there — but the linguistic *examples* and framing that landed with it do not.

This replaces them with abstract examples (generic symbols `a`/`b`/`c`, generic tree labels) and re-anchors the QF→ISL bridge on its formal-language sources (`[chandlee-2014]`, `[chandlee-jardine-2019]`) instead of the phonology dissertation. Removed across all five files: phonological-process framing, intervocalic/voicing/deletion/epenthesis examples, morphological `root`/`stem`/`affix` trees, and the `[dolatian-2020]` anchor.

The linguistic instances (intervocalic voicing, Armenian DHR, prosodic trees) belong downstream in `Studies/` — they arrive with Stage 5 (grounding `Dolatian2020` on this machinery). No definitions, theorems, or proofs changed; examples and docstrings only. No `sorry`, no `native_decide`.
