### PR TITLE
refactor(Core/Computability): relocate generic syntactic-monoid lemmas to SyntacticMonoid

### DIFF
--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -43,17 +43,6 @@ theorem IsStarFree.isRegular (h : L.IsStarFree) : L.IsRegular := h.1
 theorem IsStarFree.isAperiodic (h : L.IsStarFree) :
     Monoid.IsAperiodic L.syntacticMonoid := h.2
 
-/-- The syntactic congruence is complement-invariant: a two-sided context distinguishes
-`u` from `v` for `L` exactly when it does for `Lᶜ`. -/
-theorem syntacticCon_compl (L : Language α) : Lᶜ.syntacticCon = L.syntacticCon :=
-  Con.ext fun u v => by
-    rw [syntacticCon_iff, syntacticCon_iff]
-    exact forall_congr' fun _ => forall_congr' fun _ => not_iff_not
-
-/-- The syntactic monoid is complement-invariant. -/
-theorem syntacticMonoid_compl (L : Language α) : Lᶜ.syntacticMonoid = L.syntacticMonoid := by
-  unfold syntacticMonoid; rw [syntacticCon_compl]
-
 /-- **Star-free languages are closed under complement** — immediate from the
 complement-invariance of the syntactic monoid (`syntacticMonoid_compl`) and of regularity
 (`Language.IsRegular.compl`). -/
@@ -67,26 +56,6 @@ theorem IsStarFree.compl (h : L.IsStarFree) : Lᶜ.IsStarFree := by
 
 `Language α` carries its `BooleanAlgebra`, so intersection/union are the lattice meet/join
 `⊓`/`⊔` (defeq to set intersection/union); these are the forms `Language.IsRegular.inf` uses. -/
-
-variable (L) in
-/-- The meet of the two syntactic congruences refines that of the intersection: if no `L`-context
-and no `M`-context distinguishes `u` from `v`, then no `(L ⊓ M)`-context does either. -/
-theorem inf_syntacticCon_le_syntacticCon_inf (M : Language α) :
-    L.syntacticCon ⊓ M.syntacticCon ≤ (L ⊓ M).syntacticCon := by
-  rw [Con.le_def]
-  intro u v huv x y
-  rw [Con.inf_iff_and, syntacticCon_iff, syntacticCon_iff] at huv
-  exact and_congr (huv.1 x y) (huv.2 x y)
-
-variable (L) in
-/-- The kernel of the pairing of the two syntactic morphisms is exactly the meet of the two
-syntactic congruences (a word's class in the product is the pair of its classes). -/
-theorem ker_prod_toSyntacticMonoid (M : Language α) :
-    Con.ker ((L.toSyntacticMonoid).prod M.toSyntacticMonoid) =
-      L.syntacticCon ⊓ M.syntacticCon :=
-  Con.ext fun u v => by
-    rw [Con.ker_apply, MonoidHom.prod_apply, MonoidHom.prod_apply, Prod.ext_iff,
-      toSyntacticMonoid_eq_iff, toSyntacticMonoid_eq_iff, Con.inf_iff_and]
 
 /-- **Star-free languages are closed under intersection.** The syntactic monoid of `L ⊓ M`
 is a quotient of a submonoid of `L.syntacticMonoid × M.syntacticMonoid`, which is aperiodic

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -222,4 +222,38 @@ theorem isRegular_of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.I
 theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.syntacticMonoid :=
   ⟨finite_syntacticMonoid, isRegular_of_finite_syntacticMonoid⟩
 
+/-! ### Complement- and intersection-invariance
+
+Generic syntactic-monoid facts about boolean combinations, used by any class defined through the
+syntactic monoid (e.g. `Language.IsStarFree`, and `Monoid.Pseudovariety.langs` in general). -/
+
+/-- The syntactic congruence is complement-invariant: a two-sided context distinguishes `u` from
+`v` for `L` exactly when it does for `Lᶜ`. -/
+theorem syntacticCon_compl (L : Language α) : Lᶜ.syntacticCon = L.syntacticCon :=
+  Con.ext fun u v => by
+    rw [syntacticCon_iff, syntacticCon_iff]
+    exact forall_congr' fun _ => forall_congr' fun _ => not_iff_not
+
+/-- The syntactic monoid is complement-invariant. -/
+theorem syntacticMonoid_compl (L : Language α) : Lᶜ.syntacticMonoid = L.syntacticMonoid := by
+  unfold syntacticMonoid; rw [syntacticCon_compl]
+
+/-- The meet of the two syntactic congruences refines that of the intersection: if no `L`-context
+and no `M`-context distinguishes `u` from `v`, then no `(L ⊓ M)`-context does either. -/
+theorem inf_syntacticCon_le_syntacticCon_inf (L M : Language α) :
+    L.syntacticCon ⊓ M.syntacticCon ≤ (L ⊓ M).syntacticCon := by
+  rw [Con.le_def]
+  intro u v huv x y
+  rw [Con.inf_iff_and, syntacticCon_iff, syntacticCon_iff] at huv
+  exact and_congr (huv.1 x y) (huv.2 x y)
+
+/-- The kernel of the pairing of the two syntactic morphisms is exactly the meet of the two
+syntactic congruences (a word's class in the product is the pair of its classes). -/
+theorem ker_prod_toSyntacticMonoid (L M : Language α) :
+    Con.ker (L.toSyntacticMonoid.prod M.toSyntacticMonoid) =
+      L.syntacticCon ⊓ M.syntacticCon :=
+  Con.ext fun u v => by
+    rw [Con.ker_apply, MonoidHom.prod_apply, MonoidHom.prod_apply, Prod.ext_iff,
+      toSyntacticMonoid_eq_iff, toSyntacticMonoid_eq_iff, Con.inf_iff_and]
+
 end Language


### PR DESCRIPTION
PR 1 of the Eilenberg variety spine (blueprint: scratch/eilenberg-variety-spine-blueprint.md). Moves four *generic* (non-aperiodic) syntactic-monoid lemmas — `syntacticCon_compl`, `syntacticMonoid_compl`, `inf_syntacticCon_le_syntacticCon_inf`, `ker_prod_toSyntacticMonoid` — down from `StarFree.lean` into `SyntacticMonoid.lean`, where they belong: they are facts about the syntactic monoid of boolean combinations, used by any class defined through the syntactic monoid (the forthcoming `Monoid.Pseudovariety.langs` keystone, not just star-free). Names unchanged (`namespace Language`), so `StarFree` and all consumers are unaffected. No behavior change; no `sorry`.