### PR TITLE
feat(Morphology): relevance order foundation grounded in Bybee §6 survey

### DIFF
--- a/Linglib/Fragments/Finnish/Negation.lean
+++ b/Linglib/Fragments/Finnish/Negation.lean
@@ -129,8 +129,7 @@ theorem connegative_negates : connegativeRule.semEffect true = false := rfl
 /-- Negation (rank 7) hosts agreement (rank 8) on the negative auxiliary —
     respecting Bybee's hierarchy within the neg aux word. -/
 theorem neg_aux_respects_bybee :
-    MorphCategory.peripherality .negation <
-    MorphCategory.peripherality (.agreement .subj) := by decide
+    MorphCategory.RelevanceLT .negation (.agreement .subj) := by decide
 
 /-- Finnish negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
 def negationProfile : Syntax.Negation.NegationProfile :=

--- a/Linglib/Morphology/MorphRule.lean
+++ b/Linglib/Morphology/MorphRule.lean
@@ -277,10 +277,60 @@ def MorphCategory.peripherality : MorphCategory → Nat
   | .agreement _ => 8  -- any controller role lands at Bybee rank 8
   | .nonfinite   => 9
 
-/-- A morpheme ordering respects the relevance hierarchy if peripherality
-is non-decreasing from stem outward (stem-adjacent first). -/
+/-! ### The relevance order
+
+`peripherality` is a *rank function* — a numeric embedding. The object the
+hierarchy is really about is the **order** it induces: which categories are
+more stem-relevant than which. All relevance-hierarchy code — this file's
+`RespectsRelevanceHierarchy` and the consumers in `Studies/` — speaks in that
+order via `RelevanceLE` / `RelevanceLT`; the specific ℕ values of
+`peripherality` are an implementation detail (only their comparisons carry
+meaning, as `relevanceLE_iff_peripherality` records). -/
+
+/-- `a` is at least as stem-relevant as `b`: the rank order induced by
+`peripherality`. This is the unified relation relevance-hierarchy code uses. -/
+def MorphCategory.RelevanceLE (a b : MorphCategory) : Prop :=
+  a.peripherality ≤ b.peripherality
+
+/-- `a` is strictly more stem-relevant than `b`. -/
+def MorphCategory.RelevanceLT (a b : MorphCategory) : Prop :=
+  a.peripherality < b.peripherality
+
+instance : DecidableRel MorphCategory.RelevanceLE :=
+  fun a b => inferInstanceAs (Decidable (a.peripherality ≤ b.peripherality))
+
+instance : DecidableRel MorphCategory.RelevanceLT :=
+  fun a b => inferInstanceAs (Decidable (a.peripherality < b.peripherality))
+
+/-- The relevance order is reflexive. -/
+@[refl] theorem MorphCategory.RelevanceLE.refl (a : MorphCategory) : a.RelevanceLE a :=
+  le_refl _
+
+/-- The relevance order is transitive. -/
+theorem MorphCategory.RelevanceLE.trans {a b c : MorphCategory}
+    (h₁ : a.RelevanceLE b) (h₂ : b.RelevanceLE c) : a.RelevanceLE c :=
+  le_trans h₁ h₂
+
+/-- The relevance order is total: any two categories are comparable. -/
+theorem MorphCategory.RelevanceLE.total (a b : MorphCategory) :
+    a.RelevanceLE b ∨ b.RelevanceLE a :=
+  le_total _ _
+
+/-- Strict relevance order is the strict part of the order, as expected. -/
+theorem MorphCategory.RelevanceLT_iff {a b : MorphCategory} :
+    a.RelevanceLT b ↔ a.RelevanceLE b ∧ ¬ b.RelevanceLE a := by
+  unfold MorphCategory.RelevanceLT MorphCategory.RelevanceLE; omega
+
+/-- `peripherality` reflects the relevance order exactly: it is the canonical
+rank realizing the order, so the order carries precisely the information the
+rank does. -/
+theorem MorphCategory.relevanceLE_iff_peripherality {a b : MorphCategory} :
+    a.RelevanceLE b ↔ a.peripherality ≤ b.peripherality := Iff.rfl
+
+/-- A morpheme ordering respects the relevance hierarchy when its categories
+are sorted stem-outward by the relevance order. -/
 def RespectsRelevanceHierarchy (slots : List MorphCategory) : Prop :=
-  (slots.map MorphCategory.peripherality).Pairwise (· ≤ ·)
+  slots.Pairwise MorphCategory.RelevanceLE
 
 instance : DecidablePred RespectsRelevanceHierarchy := fun _ => by
   unfold RespectsRelevanceHierarchy; exact inferInstance

--- a/Linglib/Studies/Baker1985.lean
+++ b/Linglib/Studies/Baker1985.lean
@@ -153,7 +153,7 @@ instance : DecidablePred MorphDomain.InScope := fun d => by
 
 /-- GF-rule morphemes are inside agreement per Bybee's hierarchy. -/
 theorem gfRule_inside_agreement (r : GFRuleType) :
-    r.toMorphCategory.peripherality < (MorphCategory.agreement .subj).peripherality := by
+    r.toMorphCategory.RelevanceLT (.agreement .subj) := by
   cases r <;> decide
 
 end Morphology.MirrorPrinciple

--- a/Linglib/Studies/Bybee1985.lean
+++ b/Linglib/Studies/Bybee1985.lean
@@ -24,11 +24,14 @@ here.
 meaning, Ch 3 paradigm organization (basic-derived, local markedness),
 Ch 4 lexical-derivational-inflectional CONTINUUM (which contradicts the
 substrate's discrete `MorphStatus` enum — flagged for future work), Part
-II aspect/tense/mood detail (Ch 6-9). See `Studies/
-HahnDegenFutrell2021.lean` for a downstream consumer of the §6 ordering
-data via `RespectsRelevanceHierarchy`. Ch 5's **dynamic network model**
-substrate now lives in `Morphology/UsageBased/Network.lean`;
-§5 below uses it on an English sing/sang/sung instance.
+II aspect/tense/mood detail (Ch 6-9). Bybee's Ch 2 §6 relevance ordering
+is independently exercised in `Studies/HahnDegenFutrell2021Morphology.lean`
+via the substrate's `RespectsRelevanceHierarchy` predicate (that file
+does not consume `orderPairs` directly); the `BybeeCategory` enum and
+`toMorphCategory` bridge below are consumed by
+`Studies/RathiHahnFutrell2026.lean`. Ch 5's **dynamic network model**
+substrate now lives in `Morphology/UsageBased/Network.lean`; the network
+section below uses it on the English irregular verb *eat/ate/eaten*.
 
 -/
 
@@ -36,9 +39,7 @@ namespace Bybee1985
 
 open Morphology
 
--- ============================================================================
--- §1: Bybee's Verbal Categories (Ch 2 §3, p. 20-23)
--- ============================================================================
+/-! ### Bybee's verbal categories (Ch 2 §3, p. 20-23) -/
 
 /-! Bybee discusses six core verbal-inflectional categories ordered by
 relevance to the verb stem (most relevant first): valence, voice, aspect,
@@ -63,9 +64,7 @@ inductive BybeeCategory where
   | genderAgr
   deriving DecidableEq, Repr, Fintype
 
--- ============================================================================
--- §2: Cross-Linguistic Frequency Data (Ch 2 §5, Figures 1 + 2, pp. 30-31)
--- ============================================================================
+/-! ### Cross-linguistic frequency data (Ch 2 §5, Figures 1 + 2, pp. 30-31) -/
 
 /-! Figure 1 (p. 30) reports the percentage of the 50-language sample with
 **inflectional** expression of each category. Figure 2 (p. 31) reports the
@@ -130,9 +129,7 @@ theorem gender_lowest_when_derivOrInfl :
     ∀ c : BybeeCategory, derivOrInflCount50 .genderAgr ≤ derivOrInflCount50 c := by
   decide
 
--- ============================================================================
--- §3: Morpheme-Order Data (Ch 2 §6, pp. 34-35)
--- ============================================================================
+/-! ### Morpheme-order data (Ch 2 §6, pp. 34-35) -/
 
 /-! Bybee's second prediction (Ch 2 §6 p. 33): the morpheme-order corollary.
 "The most relevant to occur closest to the verb stem, and the least
@@ -198,16 +195,17 @@ examples in the entire 50-language sample. Bybee's summary (p. 35):
 categories, and between tense and the other categories, where there are
 almost no counter-examples to the predicted ordering." -/
 theorem aspect_categorical_against_tense_and_mood :
-    (orderPairs.head?.map (·.furtherCount) = some 0) ∧
-    (orderPairs[1]?.map (·.furtherCount) = some 0) := by
+    ∀ p ∈ orderPairs,
+      p.closer = .aspect → (p.further = .tense ∨ p.further = .mood) →
+      p.furtherCount = 0 := by
   decide
 
-/-- Mood-person ordering is genuinely freer: the mood-person pair is the
-*only* one in the survey where the predicted-counter / total ratio
-exceeds 1/10. -/
+/-- Mood-person ordering is genuinely freer: a pair's predicted-counter /
+total ratio exceeds 1/10 *iff* it is the mood-person pair — i.e. mood-
+person is the only pair in the survey above that threshold. -/
 theorem mood_person_ordering_is_freer :
-    ∀ p ∈ orderPairs, p.further = .personAgr ∧ p.closer = .mood
-      ∨ 10 * p.furtherCount ≤ p.total := by
+    ∀ p ∈ orderPairs,
+      p.total < 10 * p.furtherCount ↔ (p.closer = .mood ∧ p.further = .personAgr) := by
   decide
 
 /-- Across all six tested pairs, the predicted direction outnumbers the
@@ -215,7 +213,7 @@ counter-direction in every case (Ch 2 §6 summary, p. 35: "striking
 confirmation of the hierarchical ordering of aspect, tense, mood and
 person"). -/
 theorem predicted_outnumbers_counter :
-    orderPairs.all (λ p => p.furtherCount < p.closerCount) = true := by
+    ∀ p ∈ orderPairs, p.furtherCount < p.closerCount := by
   decide
 
 /-- Total testable observations across all six pairs: 125 language-pair
@@ -230,11 +228,9 @@ theorem ch2_section6_aggregate_counts :
     (orderPairs.map (·.furtherCount)).sum = 8 := by
   decide
 
--- ============================================================================
--- §4: Connection to Substrate `MorphCategory.peripherality`
--- ============================================================================
+/-! ### Connection to substrate `MorphCategory.peripherality` -/
 
-/-! `Core/Lexical/MorphRule.lean::MorphCategory.peripherality` numerically
+/-! `Morphology/MorphRule.lean::MorphCategory.peripherality` numerically
 encodes Bybee's relevance hierarchy: lower number = closer to stem = more
 relevant. The substrate is faithful to Bybee Ch 2 §3 (p. 20-23) for the
 six core categories Bybee discusses (valence < voice < aspect < tense <
@@ -242,47 +238,137 @@ mood < agreement). The substrate adds extensions (`derivation`, `degree`,
 `negation`, `nonfinite`) that are not part of Bybee's verbal hierarchy —
 those are flagged in `MorphRule.lean`'s docstring as linglib extensions. -/
 
-/-- Map Bybee's category enum to the substrate's `MorphCategory`. Object
-agreement and number-as-agreement collapse to the substrate's
-`.agreement` and `.number` respectively. -/
+/-- Map Bybee's category enum to the substrate's `MorphCategory`. All four
+agreement subtypes (`personAgr`, `numberAgr`, `genderAgr`, `personAgrObj`)
+collapse to `.agreement` — Bybee's verbal-number agreement belongs at the
+low-relevance (rank-8) end with person and gender, *not* with nominal
+`.number` (rank 3, "number marking on nouns"). Subject vs object agreement
+is preserved via the controller role. -/
 def toMorphCategory : BybeeCategory → MorphCategory
   | .valence       => .valence
   | .voice         => .voice
   | .aspect        => .aspect
   | .tense         => .tense
   | .mood          => .mood
-  | .numberAgr     => .number
+  | .numberAgr     => .agreement .subj
   | .personAgr     => .agreement .subj
   | .personAgrObj  => .agreement .obj
   | .genderAgr     => .agreement .subj
 
-/-- The substrate's `peripherality` ordering is **strictly monotonic** on
-the six categories Bybee discusses in Ch 2 §3 (excluding the agreement
-sub-types which collapse to a single rank). In other words, the
-substrate faithfully reproduces Bybee's high-relevance-end ordering:
+/-- The substrate's relevance order is **strictly increasing** along the six
+categories Bybee discusses in Ch 2 §3 (one agreement sub-type stands for the
+collapsed agreement rank). In other words, the substrate faithfully reproduces
+Bybee's high-relevance-end ordering:
 valence < voice < aspect < tense < mood < agreement. -/
 theorem substrate_matches_bybee_hierarchy :
-    List.Pairwise (· < ·)
+    List.Pairwise MorphCategory.RelevanceLT
       ([BybeeCategory.valence, .voice, .aspect, .tense, .mood, .personAgr].map
-        (λ c => (toMorphCategory c).peripherality)) := by
+        toMorphCategory) := by
   decide
 
-/-- The §6 morpheme-order data is exactly what `RespectsRelevanceHierarchy`
-predicts: when Bybee's predicted-closer category has lower
-peripherality than the predicted-further one, the substrate predicate
-agrees with the empirical-majority direction. -/
+/-- The Ch 2 §6 morpheme-order data is exactly what `RespectsRelevanceHierarchy`
+predicts: in the substrate relevance order, Bybee's predicted-closer category is
+never less stem-relevant than the predicted-further one, so the order agrees
+with the empirical-majority direction on every tested pair. -/
 theorem orderPairs_consistent_with_substrate :
-    orderPairs.all (λ p =>
-      decide ((toMorphCategory p.closer).peripherality
-              < (toMorphCategory p.further).peripherality)
-      || decide ((toMorphCategory p.closer).peripherality
-                 = (toMorphCategory p.further).peripherality))
-    = true := by
+    ∀ p ∈ orderPairs,
+      (toMorphCategory p.closer).RelevanceLE (toMorphCategory p.further) := by
   decide
 
--- ============================================================================
--- §5: Ch 5 Dynamic Network Model — derived from English Fragment
--- ============================================================================
+/-! ### Grounding the hierarchy in the survey
+
+The substrate's relevance order (`MorphCategory.RelevanceLT`, realized by the
+`peripherality` rank) is, on the four categories Bybee surveyed in Ch 2 §6
+(aspect, tense, mood, person), not a free choice. `SurveyedCloser` — the
+dominance order *derived from* `orderPairs` — coincides with it via
+`toMorphCategory` (`survey_order_iso_relevance`). So a consumer's
+`RespectsRelevanceHierarchy` check over these categories is grounded in Bybee's
+evidence by an order isomorphism, not by trust in a stipulated table. -/
+
+/-- `a` is *surveyed closer to the stem than* `b` when some tested Ch 2 §6 pair
+predicts `a` closer than `b` and the language counts confirm that direction
+(predicted majority). Derived from `orderPairs`, not stipulated. -/
+def SurveyedCloser (a b : BybeeCategory) : Prop :=
+  ∃ p ∈ orderPairs, p.closer = a ∧ p.further = b ∧ p.furtherCount < p.closerCount
+
+instance : DecidableRel SurveyedCloser := fun _ _ => by
+  unfold SurveyedCloser; exact inferInstance
+
+/-- A category is *surveyed* if it appears in any tested Ch 2 §6 pair. -/
+def Surveyed (c : BybeeCategory) : Prop :=
+  ∃ p ∈ orderPairs, p.closer = c ∨ p.further = c
+
+instance : DecidablePred Surveyed := fun _ => by
+  unfold Surveyed; exact inferInstance
+
+/-- `SurveyedCloser` is irreflexive: no tested pair ranks a category against
+itself. -/
+theorem surveyedCloser_irrefl : ∀ a : BybeeCategory, ¬ SurveyedCloser a a := by
+  decide
+
+/-- `SurveyedCloser` is transitive — the §6 survey tested every pair among its
+categories, so the confirmed dominances compose. -/
+theorem surveyedCloser_trans : ∀ a b c : BybeeCategory,
+    SurveyedCloser a b → SurveyedCloser b c → SurveyedCloser a c := by
+  decide
+
+/-- `SurveyedCloser` is total on the surveyed categories: any two distinct
+surveyed categories are ordered by the §6 data in exactly one direction. With
+irreflexivity and transitivity, the survey *alone* determines a strict total
+order on its four categories. -/
+theorem surveyedCloser_total : ∀ a b : BybeeCategory,
+    Surveyed a → Surveyed b → a ≠ b → SurveyedCloser a b ∨ SurveyedCloser b a := by
+  decide
+
+/-- **Grounding theorem.** The substrate's relevance order *strictly* honors
+every confirmed §6 dominance: whenever the survey places `a` closer than `b`,
+the substrate ranks `a` strictly more stem-relevant. So `toMorphCategory` is a
+strictly monotone map from the surveyed order into the relevance order. -/
+theorem relevance_honors_survey : ∀ a b : BybeeCategory,
+    SurveyedCloser a b →
+      (toMorphCategory a).RelevanceLT (toMorphCategory b) := by
+  decide
+
+/-- **Order isomorphism.** On the categories Bybee surveyed in Ch 2 §6, the
+data-derived `SurveyedCloser` order and the substrate's `RelevanceLT` order
+*coincide* via `toMorphCategory`: each holds exactly when the other does. The
+substrate hierarchy, restricted to the surveyed categories, is not merely
+consistent with Bybee's evidence — it *is* the order the §6 survey determines.
+This is the structural grounding the stipulated table only gestured at. -/
+theorem survey_order_iso_relevance : ∀ a b : BybeeCategory,
+    Surveyed a → Surveyed b →
+      (SurveyedCloser a b ↔ (toMorphCategory a).RelevanceLT (toMorphCategory b)) := by
+  decide
+
+/-- The canonical stem-outward ordering of the surveyed categories. Written as
+a literal but *validated against the data* below: it is fully sorted by
+`SurveyedCloser` (`bybeeSurveyedOrder_sorted`) and lists exactly the surveyed
+categories without repeats (`bybeeSurveyedOrder_complete`, `_nodup`), hence the
+unique enumeration the §6 survey forces. -/
+def bybeeSurveyedOrder : List BybeeCategory :=
+  [.aspect, .tense, .mood, .personAgr]
+
+theorem bybeeSurveyedOrder_sorted : bybeeSurveyedOrder.Pairwise SurveyedCloser := by
+  decide
+
+theorem bybeeSurveyedOrder_complete : ∀ c : BybeeCategory,
+    Surveyed c → c ∈ bybeeSurveyedOrder := by decide
+
+theorem bybeeSurveyedOrder_nodup : bybeeSurveyedOrder.Nodup := by decide
+
+/-- The surveyed order, mapped to substrate categories — exposed for consumers
+(`HahnDegenFutrell2021Morphology`, `Karlsson2017`, `RathiHahnFutrell2026`) to
+check their slot orders against Bybee's surveyed evidence rather than
+re-asserting the hierarchy. -/
+def bybeeSurveyedSlots : List MorphCategory :=
+  bybeeSurveyedOrder.map toMorphCategory
+
+/-- The data-derived surveyed order satisfies the substrate predicate, closing
+the loop between Bybee's §6 evidence and `RespectsRelevanceHierarchy`. -/
+theorem bybeeSurveyedSlots_respects_hierarchy :
+    RespectsRelevanceHierarchy bybeeSurveyedSlots := by decide
+
+/-! ### Ch 5 dynamic network model — derived from English Fragment -/
 
 /-! Bybee Ch 5 §8 (p. 124) illustrates the network architecture with
 the Spanish *dormir* paradigm: three stem allomorphs (`dwerm`, `dorm`,
@@ -298,8 +384,9 @@ Bybee-network claims is true by construction.
 Token frequencies default to 0 in the bridge — Bybee's verified per-
 lexeme counts (Francis & Kučera 1982) live in
 `Morphology/UsageBased/Network.lean`'s `strongStillStrong`
-/ `strongRegularized` datasets, which support the Ch 5 §6 irregularity-
-vs-frequency theorem. -/
+/ `strongRegularized` datasets, which support its Ch 5 §6 irregularity-
+vs-frequency theorem `strong_verbs_higher_frequency_than_regularized`
+(Bybee p. 120, counts across Sweet's Anglo Saxon Primer Class I/II/VII). -/
 
 open Morphology.UsageBased
 open English.Predicates.Verbal
@@ -331,43 +418,39 @@ def verbToBybeeNetwork (v : VerbEntry) : Network Unit :=
     from the Fragment, NOT stipulated. -/
 def eatNetwork : Network Unit := verbToBybeeNetwork eat
 
-/-- Sanity check: *eat*'s past form is *ate* (verified via the network's
-    presence test, which derives from the Fragment's `eat.formPast`
-    field). If `eat.formPast` were changed in `Verbal.lean` from "ate"
-    to anything else, this theorem would fail to type-check. -/
+/-- Sanity check: *eat*'s past form is present in the network as an entry,
+    derived from the Fragment's `eat.formPast` field (no string literal).
+    If `eat.formPast` changed in `Verbal.lean`, the `decide` tracks the
+    new value. -/
 theorem eat_past_in_network :
-    eatNetwork.entries.any (·.form == "ate") := by decide
+    ∃ e ∈ eatNetwork.entries, e.form = eat.formPast := by decide
 
-/-- *eat* and *ate* bear a morphological relation in `eat`'s network
-    (parallel semantic + phonological connections, Ch 5 §5 p. 118).
-    Derived from `eat`'s Fragment fields — the connection between
-    "eat" and "ate" exists *because* `eat.formPast = "ate"`. -/
-theorem eat_ate_morphologically_related :
-    eatNetwork.HasMorphologicalRelation "eat" "ate" := by decide
+/-- **Caveat on these relation theorems.** `verbToBybeeNetwork` connects
+    *every* pair of paradigm forms with both a semantic and a phonological
+    edge, so `HasMorphologicalRelation` holds for any two distinct forms of
+    the same verb by construction — it does not yet apply a real
+    shared-phonological-skeleton gate (see `verbToBybeeNetwork`). What the
+    theorems below genuinely test is that the network is *built from the
+    Fragment*: the related forms are `eat`'s actual fields (no string
+    literals), and a form outside the paradigm is correctly unrelated.
 
-theorem eat_eaten_morphologically_related :
-    eatNetwork.HasMorphologicalRelation "eat" "eaten" := by decide
-
-theorem ate_eaten_morphologically_related :
-    eatNetwork.HasMorphologicalRelation "ate" "eaten" := by decide
-
-/-- Maximally derive-don't-duplicate: even the form *strings* come
-    from Fragment fields. This theorem makes no string-literal
-    reference to "eat" or "ate" — if the Fragment fields change,
-    the theorem statement refers to whatever the new fields denote. -/
+    *eat* and its past form bear a morphological relation (parallel
+    semantic + phonological connections, Ch 5 §5 p. 118), derived from
+    `eat`'s Fragment fields — if `eat.formPast` changed, the statement
+    would refer to the new value. -/
 theorem eat_form_related_to_past_form :
     eatNetwork.HasMorphologicalRelation eat.form eat.formPast := by decide
 
-/-- The empirical anchor for Ch 5 §6's central claim — that high-
-    frequency Strong Verbs maintained their irregularity while low-
-    frequency ones regularized — lives in the substrate file as
-    `strong_verbs_higher_frequency_than_regularized` (Bybee p. 120,
-    verified Francis & Kučera 1982 counts across Sweet's Anglo Saxon
-    Primer Class I/II/VII). Re-stated here so the study file's
-    coverage is self-documenting. -/
-theorem ch5_section6_anchor_lives_in_substrate :
-    (strongStillStrong.map (·.tokenFreq)).sum * strongRegularized.length
-    > (strongRegularized.map (·.tokenFreq)).sum * strongStillStrong.length :=
-  strong_verbs_higher_frequency_than_regularized
+/-- *eat* and its past-participle form are likewise related, again derived
+    from the Fragment (`eat.formPastPart`) rather than a literal. -/
+theorem eat_form_related_to_pastPart_form :
+    eatNetwork.HasMorphologicalRelation eat.form eat.formPastPart := by decide
+
+/-- Negative rejection test: a form outside *eat*'s paradigm bears no
+    morphological relation to it. The relation genuinely requires both
+    endpoints to be connected forms in the network — it is not vacuously
+    true of arbitrary string pairs. -/
+theorem eat_unrelated_to_nonparadigm_form :
+    ¬ eatNetwork.HasMorphologicalRelation eat.form "swim" := by decide
 
 end Bybee1985

--- a/Linglib/Studies/HahnDegenFutrell2021Morphology.lean
+++ b/Linglib/Studies/HahnDegenFutrell2021Morphology.lean
@@ -89,7 +89,7 @@ matches the relevance hierarchy. Negation and tense come after mood,
 which is also consistent. -/
 theorem japanese_partial_bybee :
     let slots := [MorphCategory.derivation, .valence, .voice, .mood]
-    RespectsRelevanceHierarchy slots := by native_decide
+    RespectsRelevanceHierarchy slots := by decide
 
 -- ============================================================================
 -- §3: Sesotho Verb Template (SI §4.2)
@@ -143,7 +143,7 @@ def sesothoPrefixSlots : List MorphCategory :=
 /-- Sesotho suffixes respect the relevance hierarchy:
 valence < voice < tense < mood < nonfinite. -/
 theorem sesotho_suffixes_respect_bybee :
-    RespectsRelevanceHierarchy sesothoSuffixSlots := by native_decide
+    RespectsRelevanceHierarchy sesothoSuffixSlots := by decide
 
 -- ============================================================================
 -- §4: Memory-Surprisal Efficiency (SI Figures 6, 8)
@@ -213,13 +213,12 @@ functional suffix after derivation. This is consistent with both:
 
 /-- Japanese causative -(s)ase is in the valence slot (slot 2). -/
 theorem japanese_causative_is_valence :
-    japaneseSuffixSlots[1]? = some .valence := by native_decide
+    japaneseSuffixSlots[1]? = some .valence := by decide
 
 /-- The valence slot is the first functional slot (after derivation). -/
 theorem valence_is_innermost_functional :
     japaneseSuffixSlots[0]? = some .derivation ∧
-    japaneseSuffixSlots[1]? = some .valence := by
-  constructor <;> native_decide
+    japaneseSuffixSlots[1]? = some .valence := by decide
 
 /-! ### Bridge: Japanese -(s)ase = Song's COMPACT morphological causative
 
@@ -255,6 +254,6 @@ theorem relevance_hierarchy_implies_locality :
     -- are also efficient in memory-surprisal terms
     RespectsRelevanceHierarchy sesothoSuffixSlots ∧
     sesothoRealAUC100 < sesothoRandomAUC100 :=
-  ⟨by native_decide, by native_decide⟩
+  ⟨by decide, by native_decide⟩
 
 end HahnDegenFutrell2021

--- a/Linglib/Studies/HahnDegenFutrell2021Morphology.lean
+++ b/Linglib/Studies/HahnDegenFutrell2021Morphology.lean
@@ -1,6 +1,7 @@
 import Linglib.Processing.MemorySurprisal.Basic
 import Linglib.Fragments.Japanese.Predicates
 import Linglib.Morphology.MorphRule
+import Linglib.Studies.Bybee1985
 
 /-!
 # Study 3: Morpheme Order Optimization (Japanese & Sesotho)
@@ -82,14 +83,26 @@ def japaneseSuffixSlots : List MorphCategory :=
   , .tense        -- 7. -ta, -yoo (past/future)
   ]
 
-/-- Japanese suffix order respects Bybee's hierarchy through the voice slot.
-
-The ordering is: derivation < valence < voice < mood, which
-matches the relevance hierarchy. Negation and tense come after mood,
-which is also consistent. -/
+/-- Japanese suffix order respects Bybee's hierarchy through the mood slot:
+derivation < valence < voice < mood. Beyond mood the order *breaks* —
+politeness (agreement), negation, then tense — so only this stem-adjacent
+prefix is checked; the full-order violation is `japanese_violates_surveyed_relevance`. -/
 theorem japanese_partial_bybee :
     let slots := [MorphCategory.derivation, .valence, .voice, .mood]
     RespectsRelevanceHierarchy slots := by decide
+
+/-- **Structural divergence from the survey.** Bybee's Ch 2 §6 data ranks tense
+more stem-relevant than mood (`Bybee1985.SurveyedCloser .tense .mood`, which by
+`Bybee1985.survey_order_iso_relevance` *is* the substrate relevance order on
+these categories), yet Japanese's causative/desiderative layering places `mood`
+closer to the stem than `tense` (slots 4 vs 7) — so its full suffix order is not
+sorted by the relevance hierarchy. A genuine cross-linguistic counterexample to
+the §6 morpheme-order corollary, stated as a failure of the substrate predicate,
+not a positional count. -/
+theorem japanese_violates_surveyed_relevance :
+    Bybee1985.SurveyedCloser .tense .mood ∧
+    ¬ RespectsRelevanceHierarchy japaneseSuffixSlots := by
+  decide
 
 -- ============================================================================
 -- §3: Sesotho Verb Template (SI §4.2)
@@ -140,8 +153,11 @@ def sesothoPrefixSlots : List MorphCategory :=
   , .agreement .obj    -- 4. object agreement
   ]
 
-/-- Sesotho suffixes respect the relevance hierarchy:
-valence < voice < tense < mood < nonfinite. -/
+/-- Sesotho suffixes respect the relevance hierarchy
+(valence < voice < tense < mood < nonfinite) — sorted by the substrate
+relevance order, which on the surveyed categories *is* Bybee's §6 order
+(`Bybee1985.survey_order_iso_relevance`). Contrast
+`japanese_violates_surveyed_relevance`: same surveyed order, opposite outcome. -/
 theorem sesotho_suffixes_respect_bybee :
     RespectsRelevanceHierarchy sesothoSuffixSlots := by decide
 

--- a/Linglib/Studies/HalleMarantz1993.lean
+++ b/Linglib/Studies/HalleMarantz1993.lean
@@ -470,8 +470,8 @@ def EngInflFeature.toMorphCategory : EngInflFeature → MorphCategory
     converge — connecting [baker-1985], [bybee-1985],
     and [halle-marantz-1993]. -/
 theorem tnsAgr_outside_gfRules (f : EngInflFeature) (r : GFRuleType) :
-    r.toMorphCategory.peripherality < f.toMorphCategory.peripherality := by
-  cases f <;> cases r <;> native_decide
+    r.toMorphCategory.RelevanceLT f.toMorphCategory := by
+  cases f <;> cases r <;> decide
 
 /-- English verb inflection is concatenative: affixes are linearly
     concatenated to the stem. This places it within the scope of

--- a/Linglib/Studies/Karlsson2017.lean
+++ b/Linglib/Studies/Karlsson2017.lean
@@ -213,7 +213,6 @@ theorem clitic_no_bybee_category :
 /-- Number (rank 3) is more stem-relevant than possessive agreement (rank 8),
     consistent with number appearing closer to the stem in Finnish. -/
 theorem number_closer_than_agreement :
-    MorphCategory.peripherality .number <
-    MorphCategory.peripherality (.agreement .poss) := by decide
+    MorphCategory.RelevanceLT .number (.agreement .poss) := by decide
 
 end Karlsson2017

--- a/Linglib/Studies/Karlsson2017.lean
+++ b/Linglib/Studies/Karlsson2017.lean
@@ -187,19 +187,19 @@ def bybeeSlots : List MorphCategory :=
 -- ============================================================================
 
 /-- Finnish nominal morphology has exactly 5 suffix slots. -/
-theorem five_slots : finnishNominalOrder.length = 5 := by native_decide
+theorem five_slots : finnishNominalOrder.length = 5 := by decide
 
 /-- Only 3 of 5 nominal slots have Bybee equivalents (stem, number, agreement). -/
-theorem three_bybee_mappable : bybeeSlots.length = 3 := by native_decide
+theorem three_bybee_mappable : bybeeSlots.length = 3 := by decide
 
 /-- The Bybee-mappable slots are: stem, number, agreement. -/
 theorem bybee_slots_are :
-    bybeeSlots = [.stem, .number, .agreement .poss] := by native_decide
+    bybeeSlots = [.stem, .number, .agreement .poss] := by decide
 
 /-- The Bybee-mappable nominal slots respect the relevance hierarchy:
     stem (0) < number (3) < agreement (8). -/
 theorem nominal_respects_bybee :
-    RespectsRelevanceHierarchy bybeeSlots := by native_decide
+    RespectsRelevanceHierarchy bybeeSlots := by decide
 
 /-- Case has no Bybee category — this is the gap that Finnish nominal
     morphology reveals in Bybee's verb-centric hierarchy. -/

--- a/Linglib/Studies/RathiHahnFutrell2026.lean
+++ b/Linglib/Studies/RathiHahnFutrell2026.lean
@@ -422,9 +422,9 @@ semantic relevance drives co-occurrence regularity, but they are distinct
 constructs and can in principle diverge.
 
 The substrate's `Morphology.MorphCategory.peripherality` numerically
-encodes Bybee's hierarchy as constants (`MorphRule.lean:264-276`). The
-bridge `Bybee1985.toMorphCategory : BybeeCategory → MorphCategory`
-(`Bybee1985.lean:248-257`) connects the paper-typed enum to the substrate.
+encodes Bybee's hierarchy as constants in `MorphRule.lean`. The bridge
+`Bybee1985.toMorphCategory : BybeeCategory → MorphCategory` connects the
+paper-typed enum to the substrate.
 [rathi-hahn-futrell-2026]'s reframing makes those constants
 potentially derivable from MI on a large multilingual corpus.
 
@@ -434,29 +434,31 @@ data through `toMorphCategory ∘ peripherality`, so editing the data table
 drives the theorem (strong test: adding a feature group containing
 `nonfinite` (rank 9) breaks the theorem). -/
 
-/-- Polyexponent feature groups stay within the **core inflectional band**:
-    every category appearing in `polyexponentGroups` has substrate
-    peripherality ≤ 8 (the agreement rank). None involves the linglib-
-    extension categories `nonfinite` (rank 9), the lexical-derivational
-    `derivation` (rank 1), or the adjectival `degree` (rank 5).
+/-- Polyexponent feature groups stay within the **core verbal-inflectional
+    band** of the relevance order: every category appearing in
+    `polyexponentGroups` is no more stem-relevant than `aspect` and no less
+    stem-relevant than `agreement`. None falls at the stem-adjacent end
+    (`derivation`, `valence`, nominal `number`) or beyond agreement
+    (`nonfinite`).
 
-    The theorem engages the substrate primitives directly via
-    `toMorphCategory ∘ peripherality`, so:
-    - **Strong test passes**: adding a category with `peripherality > 8`
-      to any `polyexponentGroups` entry breaks compilation.
-    - **No silent disagreement**: the rank values come from
-      `MorphCategory.peripherality`, not a duplicate local table.
+    The theorem engages the substrate via `RelevanceLE`, so:
+    - **Strong test passes**: a category outside the `aspect..agreement` band
+      — nominal `.number` (more stem-relevant than aspect) or `.nonfinite`
+      (less relevant than agreement) — fails the `decide`. The lower bound
+      guards the bridge in particular: were `numberAgr` to map to nominal
+      `.number` rather than `.agreement`, this theorem would break.
+    - **No silent disagreement**: the order comes from the substrate
+      `RelevanceLE`, not a duplicate local table.
 
-    Note: in the substrate, all four agreement subtypes
-    (`personAgr`/`numberAgr`/`genderAgr`/`personAgrObj`) collapse to
-    `MorphCategory.agreement _` at rank 8. This is faithful to Bybee
-    (Ch 2 §3 collapses agreement subtypes; only object-person is reported
-    separately, and number-as-agreement vs nominal number is a
-    separate distinction the substrate flags). -/
+    Note: all four agreement subtypes (`personAgr`/`numberAgr`/`genderAgr`/
+    `personAgrObj`) collapse to `MorphCategory.agreement _` — faithful to
+    Bybee, who places verbal-number agreement at the low-relevance end with
+    person and gender (Ch 2 §3), distinct from nominal number, which the
+    substrate ranks separately, more stem-relevant. -/
 theorem polyexponent_categories_in_core_inflectional_range :
-    polyexponentGroups.all (fun g =>
-      g.categories.all (fun c => (toMorphCategory c).peripherality ≤ 8))
-    = true := by decide
+    ∀ g ∈ polyexponentGroups, ∀ c ∈ g.categories,
+      MorphCategory.RelevanceLE .aspect (toMorphCategory c)
+        ∧ (toMorphCategory c).RelevanceLE (.agreement .subj) := by decide
 
 /-! ### Mirror Principle ↔ ETH
 


### PR DESCRIPTION
Recasts the morpheme-relevance hierarchy as a genuine order, derives it from Bybee's §6 survey data, and unifies all consumers onto it.

- **Substrate:** `MorphCategory.RelevanceLE`/`RelevanceLT` (total preorder; `refl`/`trans`/`total`) is now the primitive; `peripherality` is demoted to the rank realizing it; `RespectsRelevanceHierarchy` = sorted by the order.
- **Grounding:** `Bybee1985.survey_order_iso_relevance` proves the data-derived `SurveyedCloser` order and the substrate `RelevanceLT` order coincide on the surveyed categories — an order isomorphism, not a consistency check. Includes audit fixes found en route (the `numberAgr → .number` mis-mapping, `mood_person` iff, Bool→Prop).
- **Consumers:** all six speak the relevance order; Japanese divergence is now `¬ RespectsRelevanceHierarchy` (structural); `native_decide → decide` for morpheme-order checks.