### PR TITLE
feat(Studies): GPP projection-prediction substrate across two papers

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2921,5 +2921,6 @@ import Linglib.Tactics.RSAPredict.RSABuilder
 import Linglib.Tactics.RSAPredict.ReflectBridge
 import Linglib.Tactics.RSAPredict.Reify
 import Linglib.Data.Examples.Guerrini2026
+import Linglib.Data.Examples.TonhauserBeaverDegen2018
 
 

--- a/Linglib/Core/Order/Rat01.lean
+++ b/Linglib/Core/Order/Rat01.lean
@@ -2,6 +2,8 @@ import Mathlib.Data.Set.Basic
 import Mathlib.Data.Rat.Defs
 import Mathlib.Algebra.Order.Ring.Unbundled.Rat
 import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Linarith
+import Mathlib.Order.Monotone.Basic
 
 /-!
 # Core/Scales/Rat01.lean — rational unit interval
@@ -58,6 +60,29 @@ def exceeds (d θ : Rat01) : Prop := θ.val < d.val
 
 instance (d θ : Rat01) : Decidable (exceeds d θ) :=
   inferInstanceAs (Decidable (θ.val < d.val))
+
+/-- The complement `1 - r`, again in `[0, 1]`.
+
+    Models the relationship between a gradient property and its dual on the
+    same scale — e.g. not-at-issueness as the complement of at-issueness. -/
+def compl (r : Rat01) : Rat01 :=
+  ⟨1 - r.val, by linarith [r.le_one], by linarith [r.nonneg]⟩
+
+@[simp] theorem compl_val (r : Rat01) : (compl r).val = 1 - r.val := rfl
+
+@[simp] theorem compl_compl (r : Rat01) : compl (compl r) = r := by
+  apply Subtype.ext; simp
+
+theorem compl_zero : compl zero = one := by apply Subtype.ext; simp [zero, one]
+
+theorem compl_one : compl one = zero := by apply Subtype.ext; simp [zero, one]
+
+/-- The complement is order-reversing: a larger value has a smaller complement. -/
+theorem compl_antitone : Antitone compl := by
+  intro a b h
+  show 1 - b.val ≤ 1 - a.val
+  have : a.val ≤ b.val := h
+  linarith
 
 end Rat01
 

--- a/Linglib/Data/Examples/TonhauserBeaverDegen2018.json
+++ b/Linglib/Data/Examples/TonhauserBeaverDegen2018.json
@@ -1,0 +1,930 @@
+[
+ {
+  "id": "tbd2018_1a_nrrc",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1a (12.1), NRRC"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "These muffins, which have blueberries in them, are gluten-free and low-fat.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "These muffins, which have blueberries in them, are gluten-free and low-fat.",
+  "context": "Projective content 'These muffins have blueberries in them.' under the certain-that / asking-whether diagnostics (Exp 1a).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "NRRC"
+   ],
+   [
+    "experiment",
+    "1a"
+   ],
+   [
+    "triggerClass",
+    "B"
+   ],
+   [
+    "projectivity",
+    "96"
+   ],
+   [
+    "notAtIssueness",
+    "97"
+   ]
+  ],
+  "comment": "Mean projectivity .96 and not-at-issueness .97 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'These muffins have blueberries in them.'"
+ },
+ {
+  "id": "tbd2018_1a_nominalAppositive",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1a (12.2), nominal appositive"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Martha's new car, a BMW, was expensive.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Martha's new car, a BMW, was expensive.",
+  "context": "Projective content 'Martha's new car is a BMW.' under the certain-that / asking-whether diagnostics (Exp 1a).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "nominalAppositive"
+   ],
+   [
+    "experiment",
+    "1a"
+   ],
+   [
+    "triggerClass",
+    "B"
+   ],
+   [
+    "projectivity",
+    "95"
+   ],
+   [
+    "notAtIssueness",
+    "96"
+   ]
+  ],
+  "comment": "Mean projectivity .95 and not-at-issueness .96 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Martha's new car is a BMW.'"
+ },
+ {
+  "id": "tbd2018_1a_possessiveNP",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1a (12.3), possessive NP"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Martha's new BMW was expensive.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Martha's new BMW was expensive.",
+  "context": "Projective content 'Martha has a new BMW.' under the certain-that / asking-whether diagnostics (Exp 1a).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "possessiveNP"
+   ],
+   [
+    "experiment",
+    "1a"
+   ],
+   [
+    "triggerClass",
+    "B"
+   ],
+   [
+    "projectivity",
+    "94"
+   ],
+   [
+    "notAtIssueness",
+    "97"
+   ]
+  ],
+  "comment": "Mean projectivity .94 and not-at-issueness .97 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Martha has a new BMW.'"
+ },
+ {
+  "id": "tbd2018_1a_annoyed",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1a (12.4), be annoyed"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Martha's neighbor is annoyed that Martha has a new BMW.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Martha's neighbor is annoyed that Martha has a new BMW.",
+  "context": "Projective content 'Martha has a new BMW.' under the certain-that / asking-whether diagnostics (Exp 1a).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "annoyed"
+   ],
+   [
+    "experiment",
+    "1a"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "96"
+   ],
+   [
+    "notAtIssueness",
+    "97"
+   ]
+  ],
+  "comment": "Mean projectivity .96 and not-at-issueness .97 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Martha has a new BMW.'"
+ },
+ {
+  "id": "tbd2018_1a_discover",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1a (12.5), discover"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Mary discovered that her daughter has been biting her nails.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Mary discovered that her daughter has been biting her nails.",
+  "context": "Projective content 'Mary's daughter has been biting her nails.' under the certain-that / asking-whether diagnostics (Exp 1a).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "discover"
+   ],
+   [
+    "experiment",
+    "1a"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "86"
+   ],
+   [
+    "notAtIssueness",
+    "87"
+   ]
+  ],
+  "comment": "Mean projectivity .86 and not-at-issueness .87 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Mary's daughter has been biting her nails.'"
+ },
+ {
+  "id": "tbd2018_1a_know",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1a (12.6), know"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Billy knows that Martha has a new BMW.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Billy knows that Martha has a new BMW.",
+  "context": "Projective content 'Martha has a new BMW.' under the certain-that / asking-whether diagnostics (Exp 1a).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "know"
+   ],
+   [
+    "experiment",
+    "1a"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "92"
+   ],
+   [
+    "notAtIssueness",
+    "91"
+   ]
+  ],
+  "comment": "Mean projectivity .92 and not-at-issueness .91 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Martha has a new BMW.'"
+ },
+ {
+  "id": "tbd2018_1a_only",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1a (12.7), only"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "These muffins only have blueberries in them.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "These muffins only have blueberries in them.",
+  "context": "Projective content 'These muffins have blueberries in them.' under the certain-that / asking-whether diagnostics (Exp 1a).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "only"
+   ],
+   [
+    "experiment",
+    "1a"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "76"
+   ],
+   [
+    "notAtIssueness",
+    "72"
+   ]
+  ],
+  "comment": "Mean projectivity .76 and not-at-issueness .72 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'These muffins have blueberries in them.'"
+ },
+ {
+  "id": "tbd2018_1a_stop",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1a (12.8), stop"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Mary's daughter stopped biting her nails.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Mary's daughter stopped biting her nails.",
+  "context": "Projective content 'Mary's daughter has been biting her nails.' under the certain-that / asking-whether diagnostics (Exp 1a).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "stop"
+   ],
+   [
+    "experiment",
+    "1a"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "87"
+   ],
+   [
+    "notAtIssueness",
+    "71"
+   ]
+  ],
+  "comment": "Mean projectivity .87 and not-at-issueness .71 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Mary's daughter has been biting her nails.'"
+ },
+ {
+  "id": "tbd2018_1a_stupid",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1a (12.9), be stupid to"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Mary's daughter is stupid to be biting her nails.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Mary's daughter is stupid to be biting her nails.",
+  "context": "Projective content 'Mary's daughter has been biting her nails.' under the certain-that / asking-whether diagnostics (Exp 1a).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "stupid"
+   ],
+   [
+    "experiment",
+    "1a"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "85"
+   ],
+   [
+    "notAtIssueness",
+    "88"
+   ]
+  ],
+  "comment": "Mean projectivity .85 and not-at-issueness .88 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Mary's daughter has been biting her nails.'"
+ },
+ {
+  "id": "tbd2018_1b_amused",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, be amused"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley is amused that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley is amused that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "amused"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "91"
+   ],
+   [
+    "notAtIssueness",
+    "94"
+   ]
+  ],
+  "comment": "Mean projectivity .91 and not-at-issueness .94 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_annoyed",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, be annoyed"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley is annoyed that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley is annoyed that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "annoyed"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "92"
+   ],
+   [
+    "notAtIssueness",
+    "94"
+   ]
+  ],
+  "comment": "Mean projectivity .92 and not-at-issueness .94 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_aware",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, be aware"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley is aware that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley is aware that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "aware"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "92"
+   ],
+   [
+    "notAtIssueness",
+    "94"
+   ]
+  ],
+  "comment": "Mean projectivity .92 and not-at-issueness .94 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_confess",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, confess"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley confessed that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley confessed that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "confess"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "69"
+   ],
+   [
+    "notAtIssueness",
+    "81"
+   ]
+  ],
+  "comment": "Mean projectivity .69 and not-at-issueness .81 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_discover",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, discover"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Samuel discovered that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Samuel discovered that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "discover"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "85"
+   ],
+   [
+    "notAtIssueness",
+    "89"
+   ]
+  ],
+  "comment": "Mean projectivity .85 and not-at-issueness .89 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_establish",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, establish"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley established that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley established that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "establish"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "42"
+   ],
+   [
+    "notAtIssueness",
+    "61"
+   ]
+  ],
+  "comment": "Mean projectivity .42 and not-at-issueness .61 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_findOut",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, find out"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley found out that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley found out that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "findOut"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "88"
+   ],
+   [
+    "notAtIssueness",
+    "91"
+   ]
+  ],
+  "comment": "Mean projectivity .88 and not-at-issueness .91 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_learn",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, learn"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley learned that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley learned that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "learn"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "88"
+   ],
+   [
+    "notAtIssueness",
+    "90"
+   ]
+  ],
+  "comment": "Mean projectivity .88 and not-at-issueness .90 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_notice",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, notice"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley noticed that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley noticed that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "notice"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "92"
+   ],
+   [
+    "notAtIssueness",
+    "92"
+   ]
+  ],
+  "comment": "Mean projectivity .92 and not-at-issueness .92 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_realize",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, realize"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley realized that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley realized that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "realize"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "91"
+   ],
+   [
+    "notAtIssueness",
+    "92"
+   ]
+  ],
+  "comment": "Mean projectivity .91 and not-at-issueness .92 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_reveal",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, reveal"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley revealed that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley revealed that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "reveal"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "78"
+   ],
+   [
+    "notAtIssueness",
+    "87"
+   ]
+  ],
+  "comment": "Mean projectivity .78 and not-at-issueness .87 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1b_see",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b, see"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Shirley saw that Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Shirley saw that Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "see"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "C"
+   ],
+   [
+    "projectivity",
+    "89"
+   ],
+   [
+    "notAtIssueness",
+    "89"
+   ]
+  ],
+  "comment": "Mean projectivity .89 and not-at-issueness .89 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ },
+ {
+  "id": "tbd2018_1a_mc",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1a (15), main-clause control"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Richie is a stuntman.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Richie is a stuntman.",
+  "context": "Projective content 'Richie is a stuntman.' under the certain-that / asking-whether diagnostics (Exp 1a).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "mainClause"
+   ],
+   [
+    "experiment",
+    "1a"
+   ],
+   [
+    "triggerClass",
+    "control"
+   ],
+   [
+    "projectivity",
+    "5"
+   ],
+   [
+    "notAtIssueness",
+    "2"
+   ],
+   [
+    "control",
+    "true"
+   ]
+  ],
+  "comment": "Mean projectivity .05 and not-at-issueness .02 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Richie is a stuntman.'"
+ },
+ {
+  "id": "tbd2018_1b_mc",
+  "source": {
+   "bibkey": "tonhauser-beaver-degen-2018",
+   "paperLabel": "Exp 1b (17), main-clause control"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "Raul was drinking chamomile tea.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "Raul was drinking chamomile tea.",
+  "context": "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b).",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   [
+    "expression",
+    "mainClause"
+   ],
+   [
+    "experiment",
+    "1b"
+   ],
+   [
+    "triggerClass",
+    "control"
+   ],
+   [
+    "projectivity",
+    "6"
+   ],
+   [
+    "notAtIssueness",
+    "3"
+   ],
+   [
+    "control",
+    "true"
+   ]
+  ],
+  "comment": "Mean projectivity .06 and not-at-issueness .03 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+ }
+]

--- a/Linglib/Data/Examples/TonhauserBeaverDegen2018.lean
+++ b/Linglib/Data/Examples/TonhauserBeaverDegen2018.lean
@@ -1,0 +1,432 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `TonhauserBeaverDegen2018` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/TonhauserBeaverDegen2018.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace TonhauserBeaverDegen2018.Examples`.
+-/
+
+namespace TonhauserBeaverDegen2018.Examples
+
+open Data.Examples
+
+def tbd2018_1a_nrrc : LinguisticExample :=
+  { id := "tbd2018_1a_nrrc"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1a (12.1), NRRC"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "These muffins, which have blueberries in them, are gluten-free and low-fat."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "These muffins, which have blueberries in them, are gluten-free and low-fat."
+    context := "Projective content 'These muffins have blueberries in them.' under the certain-that / asking-whether diagnostics (Exp 1a)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "NRRC"), ("experiment", "1a"), ("triggerClass", "B"), ("projectivity", "96"), ("notAtIssueness", "97")]
+    comment := "Mean projectivity .96 and not-at-issueness .97 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'These muffins have blueberries in them.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1a_nominalAppositive : LinguisticExample :=
+  { id := "tbd2018_1a_nominalAppositive"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1a (12.2), nominal appositive"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Martha's new car, a BMW, was expensive."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Martha's new car, a BMW, was expensive."
+    context := "Projective content 'Martha's new car is a BMW.' under the certain-that / asking-whether diagnostics (Exp 1a)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "nominalAppositive"), ("experiment", "1a"), ("triggerClass", "B"), ("projectivity", "95"), ("notAtIssueness", "96")]
+    comment := "Mean projectivity .95 and not-at-issueness .96 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Martha's new car is a BMW.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1a_possessiveNP : LinguisticExample :=
+  { id := "tbd2018_1a_possessiveNP"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1a (12.3), possessive NP"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Martha's new BMW was expensive."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Martha's new BMW was expensive."
+    context := "Projective content 'Martha has a new BMW.' under the certain-that / asking-whether diagnostics (Exp 1a)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "possessiveNP"), ("experiment", "1a"), ("triggerClass", "B"), ("projectivity", "94"), ("notAtIssueness", "97")]
+    comment := "Mean projectivity .94 and not-at-issueness .97 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Martha has a new BMW.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1a_annoyed : LinguisticExample :=
+  { id := "tbd2018_1a_annoyed"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1a (12.4), be annoyed"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Martha's neighbor is annoyed that Martha has a new BMW."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Martha's neighbor is annoyed that Martha has a new BMW."
+    context := "Projective content 'Martha has a new BMW.' under the certain-that / asking-whether diagnostics (Exp 1a)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "annoyed"), ("experiment", "1a"), ("triggerClass", "C"), ("projectivity", "96"), ("notAtIssueness", "97")]
+    comment := "Mean projectivity .96 and not-at-issueness .97 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Martha has a new BMW.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1a_discover : LinguisticExample :=
+  { id := "tbd2018_1a_discover"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1a (12.5), discover"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary discovered that her daughter has been biting her nails."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mary discovered that her daughter has been biting her nails."
+    context := "Projective content 'Mary's daughter has been biting her nails.' under the certain-that / asking-whether diagnostics (Exp 1a)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "discover"), ("experiment", "1a"), ("triggerClass", "C"), ("projectivity", "86"), ("notAtIssueness", "87")]
+    comment := "Mean projectivity .86 and not-at-issueness .87 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Mary's daughter has been biting her nails.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1a_know : LinguisticExample :=
+  { id := "tbd2018_1a_know"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1a (12.6), know"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Billy knows that Martha has a new BMW."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Billy knows that Martha has a new BMW."
+    context := "Projective content 'Martha has a new BMW.' under the certain-that / asking-whether diagnostics (Exp 1a)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "know"), ("experiment", "1a"), ("triggerClass", "C"), ("projectivity", "92"), ("notAtIssueness", "91")]
+    comment := "Mean projectivity .92 and not-at-issueness .91 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Martha has a new BMW.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1a_only : LinguisticExample :=
+  { id := "tbd2018_1a_only"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1a (12.7), only"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "These muffins only have blueberries in them."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "These muffins only have blueberries in them."
+    context := "Projective content 'These muffins have blueberries in them.' under the certain-that / asking-whether diagnostics (Exp 1a)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "only"), ("experiment", "1a"), ("triggerClass", "C"), ("projectivity", "76"), ("notAtIssueness", "72")]
+    comment := "Mean projectivity .76 and not-at-issueness .72 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'These muffins have blueberries in them.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1a_stop : LinguisticExample :=
+  { id := "tbd2018_1a_stop"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1a (12.8), stop"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary's daughter stopped biting her nails."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mary's daughter stopped biting her nails."
+    context := "Projective content 'Mary's daughter has been biting her nails.' under the certain-that / asking-whether diagnostics (Exp 1a)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "stop"), ("experiment", "1a"), ("triggerClass", "C"), ("projectivity", "87"), ("notAtIssueness", "71")]
+    comment := "Mean projectivity .87 and not-at-issueness .71 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Mary's daughter has been biting her nails.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1a_stupid : LinguisticExample :=
+  { id := "tbd2018_1a_stupid"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1a (12.9), be stupid to"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary's daughter is stupid to be biting her nails."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mary's daughter is stupid to be biting her nails."
+    context := "Projective content 'Mary's daughter has been biting her nails.' under the certain-that / asking-whether diagnostics (Exp 1a)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "stupid"), ("experiment", "1a"), ("triggerClass", "C"), ("projectivity", "85"), ("notAtIssueness", "88")]
+    comment := "Mean projectivity .85 and not-at-issueness .88 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Mary's daughter has been biting her nails.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_amused : LinguisticExample :=
+  { id := "tbd2018_1b_amused"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, be amused"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley is amused that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley is amused that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "amused"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "91"), ("notAtIssueness", "94")]
+    comment := "Mean projectivity .91 and not-at-issueness .94 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_annoyed : LinguisticExample :=
+  { id := "tbd2018_1b_annoyed"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, be annoyed"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley is annoyed that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley is annoyed that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "annoyed"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "92"), ("notAtIssueness", "94")]
+    comment := "Mean projectivity .92 and not-at-issueness .94 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_aware : LinguisticExample :=
+  { id := "tbd2018_1b_aware"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, be aware"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley is aware that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley is aware that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "aware"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "92"), ("notAtIssueness", "94")]
+    comment := "Mean projectivity .92 and not-at-issueness .94 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_confess : LinguisticExample :=
+  { id := "tbd2018_1b_confess"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, confess"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley confessed that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley confessed that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "confess"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "69"), ("notAtIssueness", "81")]
+    comment := "Mean projectivity .69 and not-at-issueness .81 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_discover : LinguisticExample :=
+  { id := "tbd2018_1b_discover"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, discover"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Samuel discovered that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Samuel discovered that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "discover"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "85"), ("notAtIssueness", "89")]
+    comment := "Mean projectivity .85 and not-at-issueness .89 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_establish : LinguisticExample :=
+  { id := "tbd2018_1b_establish"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, establish"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley established that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley established that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "establish"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "42"), ("notAtIssueness", "61")]
+    comment := "Mean projectivity .42 and not-at-issueness .61 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_findOut : LinguisticExample :=
+  { id := "tbd2018_1b_findOut"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, find out"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley found out that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley found out that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "findOut"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "88"), ("notAtIssueness", "91")]
+    comment := "Mean projectivity .88 and not-at-issueness .91 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_learn : LinguisticExample :=
+  { id := "tbd2018_1b_learn"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, learn"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley learned that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley learned that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "learn"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "88"), ("notAtIssueness", "90")]
+    comment := "Mean projectivity .88 and not-at-issueness .90 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_notice : LinguisticExample :=
+  { id := "tbd2018_1b_notice"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, notice"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley noticed that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley noticed that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "notice"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "92"), ("notAtIssueness", "92")]
+    comment := "Mean projectivity .92 and not-at-issueness .92 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_realize : LinguisticExample :=
+  { id := "tbd2018_1b_realize"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, realize"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley realized that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley realized that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "realize"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "91"), ("notAtIssueness", "92")]
+    comment := "Mean projectivity .91 and not-at-issueness .92 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_reveal : LinguisticExample :=
+  { id := "tbd2018_1b_reveal"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, reveal"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley revealed that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley revealed that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "reveal"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "78"), ("notAtIssueness", "87")]
+    comment := "Mean projectivity .78 and not-at-issueness .87 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_see : LinguisticExample :=
+  { id := "tbd2018_1b_see"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b, see"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Shirley saw that Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Shirley saw that Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "see"), ("experiment", "1b"), ("triggerClass", "C"), ("projectivity", "89"), ("notAtIssueness", "89")]
+    comment := "Mean projectivity .89 and not-at-issueness .89 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1a_mc : LinguisticExample :=
+  { id := "tbd2018_1a_mc"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1a (15), main-clause control"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Richie is a stuntman."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Richie is a stuntman."
+    context := "Projective content 'Richie is a stuntman.' under the certain-that / asking-whether diagnostics (Exp 1a)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "mainClause"), ("experiment", "1a"), ("triggerClass", "control"), ("projectivity", "5"), ("notAtIssueness", "2"), ("control", "true")]
+    comment := "Mean projectivity .05 and not-at-issueness .02 (proportion of projecting / not-at-issue coded responses, n=210), computed from results/exp1a/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Richie is a stuntman.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def tbd2018_1b_mc : LinguisticExample :=
+  { id := "tbd2018_1b_mc"
+    source := ⟨"tonhauser-beaver-degen-2018", "Exp 1b (17), main-clause control"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Raul was drinking chamomile tea."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Raul was drinking chamomile tea."
+    context := "Projective content 'Raul was drinking chamomile tea.' under the certain-that / asking-whether diagnostics (Exp 1b)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("expression", "mainClause"), ("experiment", "1b"), ("triggerClass", "control"), ("projectivity", "6"), ("notAtIssueness", "3"), ("control", "true")]
+    comment := "Mean projectivity .06 and not-at-issueness .03 (proportion of projecting / not-at-issue coded responses, n=235), computed from results/exp1b/data/data_preprocessed.csv at github.com/judith-tonhauser/how-projective (footnote 8). Projective content: 'Raul was drinking chamomile tea.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [tbd2018_1a_nrrc, tbd2018_1a_nominalAppositive, tbd2018_1a_possessiveNP, tbd2018_1a_annoyed, tbd2018_1a_discover, tbd2018_1a_know, tbd2018_1a_only, tbd2018_1a_stop, tbd2018_1a_stupid, tbd2018_1b_amused, tbd2018_1b_annoyed, tbd2018_1b_aware, tbd2018_1b_confess, tbd2018_1b_discover, tbd2018_1b_establish, tbd2018_1b_findOut, tbd2018_1b_learn, tbd2018_1b_notice, tbd2018_1b_realize, tbd2018_1b_reveal, tbd2018_1b_see, tbd2018_1a_mc, tbd2018_1b_mc]
+
+end TonhauserBeaverDegen2018.Examples

--- a/Linglib/Studies/TonhauserBeaverDegen2018.lean
+++ b/Linglib/Studies/TonhauserBeaverDegen2018.lean
@@ -1,436 +1,252 @@
 import Linglib.Discourse.AtIssueness
+import Linglib.Pragmatics.Expressives.Basic
+import Linglib.Data.Examples.TonhauserBeaverDegen2018
 
 /-!
 # [tonhauser-beaver-degen-2018]: How Projective Is Projective Content?
-[tonhauser-beaver-degen-2018] [potts-2005] [tonhauser-beaver-roberts-simons-2013]Empirical data from "How projective is projective content? Gradience in
-projectivity and at-issueness." Journal of Semantics 35(3): 495–542.
 
-## Key Findings
+The paper's central contribution is the **Gradient Projection Principle** (GPP):
 
-1. **Projectivity is gradient**, not binary. Even "strong" projective triggers
-   like NRRCs show mean projectivity ≈ .96, not 1.0.
-2. **Not-at-issueness is gradient** and **positively correlated** with
-   projectivity: r = .85 across 9 expression types (Exp 1a), r = .99
-   across 12 predicates (Exp 1b).
-3. **Appositives are not maximally projective**, contra [potts-2005].
-4. **Within-type variation**: different lexical items of the same type
-   yield different ratings.
+> "If content C is expressed by a constituent embedded under an
+> entailment-canceling operator, then C projects to the extent that it is not
+> at-issue."
 
-## Gradient Projection Principle (GPP)
+It makes gradient the binary *Projection Principle* of the pragmatic account
+([simons-tonhauser-beaver-roberts-2010], [roberts-2012]) — "projects iff not
+at-issue". This file formalizes the principle and its structural consequences,
+not the experimental tables, taking the tight reading of "to the extent that":
+projection degree equals not-at-issueness. The empirical claim is a gradient
+correlation with item-level variance, not this identity (cf. the dependency's
+`MonotoneAntiCorrelation` docstring).
 
-The paper's central theoretical contribution (p. 497, ex. 7):
+## Main definitions
+* `gppProjection` — the GPP map, the complement of at-issueness (`Rat01.compl`).
+* `pottsProjection` — [potts-2005]'s rival: CI projects maximally, at-issueness-blind.
+* `ProjectionAccount` / `ProjectionDatum` / `allData` — the predict signature a
+  theory implements and the artifact-sourced pool it runs against.
 
-  "If content C is expressed by a constituent embedded under an
-   entailment-canceling operator, then C projects to the extent that
-   it is not at-issue."
+## Main results
+* `gppProjection_antitone` — the GPP as order-reversal.
+* `gpp_excludes_atIssue` — recovers the binary Projection Principle as a threshold collapse.
+* `gpp_below_potts_of_atIssue`, `gpp_eq_potts_iff_backgrounded` — contra
+  [potts-2005]: the accounts agree only on fully-backgrounded content.
+* `gpp_beats_potts_below_diagonal` — on low-projectivity items the GPP beats Potts.
 
-This generalizes Simons et al.'s (2010) Pragmatic Account by replacing
-the binary at-issue/not-at-issue distinction with a gradient one.
-
-## Experiments
-
-- **Exp 1a**: 9 expression types — projectivity + not-at-issueness
-  (asking whether diagnostic). 190 participants.
-- **Exp 1b**: 12 clause-embedding predicates — same diagnostics.
-  235 participants (after exclusions).
-- **Exp 2a/2b**: Replications with direct dissent diagnostic (not formalized here).
-
-## Data
-
-Values are approximate means read from Figures 3 and 6. The paper reports
-ranges in text (e.g., projectivity .76–.96 for Exp 1a) but does not
-provide a table of exact per-expression means. Textually confirmed values
-are annotated.
-
-The scale is 0–1 (proportion of "yes" responses). The paper measures
-**not-at-issueness** via the "asking whether" diagnostic: higher values
-mean the content is MORE not-at-issue (more backgrounded).
-
+## Implementation notes
+Degrees and thresholds are the `Rat01` types from `Discourse.AtIssueness`; the GPP
+map is the `Rat01` complement. Potts's maximal projection is grounded in
+`Pragmatics.Expressives.TwoDimProp.ci_projects_through_neg`.
 -/
 
 namespace TonhauserBeaverDegen2018
 
--- ════════════════════════════════════════════════════
--- § Experiment 1a: Nine Expression Types
--- ════════════════════════════════════════════════════
-
-/-- The 9 expression types tested in Experiment 1a.
-
-    All are **non-SCF** (Strong Contextual Felicity = no), chosen to
-    isolate projectivity and at-issueness variation (p. 504).
-
-    - Class B (SCF=no, OLE=no): NRRC, nominal appositive, possessive NP
-    - Class C (SCF=no, OLE=yes): discover, know, be annoyed, stop
-    - Focus-sensitive: only
-    - Evaluative adjective: be stupid to -/
-inductive ExpressionType where
-  | nrrc              -- non-restrictive relative clause
-  | nominalAppositive -- nominal appositive
-  | possessiveNP      -- possessive NP (existence of possessor)
-  | discover          -- factive verb "discover"
-  | know              -- factive verb "know"
-  | annoyed           -- emotive factive "be annoyed"
-  | stop              -- change-of-state "stop"
-  | only              -- focus-sensitive "only"
-  | stupid            -- evaluative adjective "be stupid to"
-  deriving DecidableEq, Repr
-
-/-- Mean projectivity rating from Experiment 1a (0–1 scale).
-
-    Values approximate means from Figure 3. Text (p. 507) confirms:
-    - only = .76 (minimum)
-    - NRRC = .96 and be annoyed = .96 (maximum, "close to ceiling") -/
-def projectivityRating : ExpressionType → ℚ
-  | .nrrc              => 96/100  -- text: .96
-  | .nominalAppositive => 94/100
-  | .possessiveNP      => 93/100
-  | .discover          => 88/100
-  | .know              => 91/100
-  | .annoyed           => 96/100  -- text: .96
-  | .stop              => 88/100
-  | .only              => 76/100  -- text: .76
-  | .stupid            => 86/100
-
-/-- Mean not-at-issueness rating from Experiment 1a (0–1 scale).
-    Measured via the "asking whether" diagnostic.
-
-    Higher = more not-at-issue (more backgrounded).
-
-    Values approximate means from Figure 3. Text (p. 508) confirms:
-    - only = .73 (minimum)
-    - NRRC = .96 (maximum) -/
-def notAtIssuenessRating : ExpressionType → ℚ
-  | .nrrc              => 96/100  -- text: .96
-  | .nominalAppositive => 91/100
-  | .possessiveNP      => 93/100
-  | .discover          => 84/100
-  | .know              => 88/100
-  | .annoyed           => 94/100
-  | .stop              => 78/100
-  | .only              => 73/100  -- text: .73
-  | .stupid            => 82/100
-
-/-- At-issueness = 1 − not-at-issueness. Higher = more at-issue.
-    Derived from the paper's direct measurements. -/
-def atIssuenessRating (e : ExpressionType) : ℚ := 1 - notAtIssuenessRating e
-
--- ════════════════════════════════════════════════════
--- § Experiment 1b: Twelve Clause-Embedding Predicates
--- ════════════════════════════════════════════════════
-
-/-- The 12 clause-embedding predicates from Experiment 1b (p. 511).
-
-    Semantic classes (per paper):
-    - Emotive: be amused, be annoyed
-    - Cognitive: be aware, discover, find out, learn, notice, realize, establish
-    - Sensory: see
-    - Communication: confess, reveal -/
-inductive Predicate where
-  | beAmused
-  | beAnnoyed
-  | beAware
-  | confess
-  | discover
-  | establish
-  | findOut
-  | learn
-  | notice
-  | realize
-  | reveal
-  | see
-  deriving DecidableEq, Repr
-
-/-- Mean projectivity ratings for the 12 predicates from Exp 1b (0–1 scale).
-    Values approximate means from Figure 6. -/
-def verbProjectivity : Predicate → ℚ
-  | .establish  => 43/100
-  | .confess    => 65/100
-  | .reveal     => 77/100
-  | .learn      => 82/100
-  | .discover   => 86/100
-  | .findOut    => 90/100
-  | .see        => 90/100
-  | .beAmused   => 92/100
-  | .realize    => 92/100
-  | .beAware    => 93/100
-  | .notice     => 94/100
-  | .beAnnoyed  => 94/100
-
-/-- Mean not-at-issueness ratings for the 12 predicates from Exp 1b (0–1 scale).
-    Values approximate means from Figure 6. -/
-def verbNotAtIssueness : Predicate → ℚ
-  | .establish  => 47/100
-  | .confess    => 56/100
-  | .reveal     => 68/100
-  | .learn      => 73/100
-  | .discover   => 78/100
-  | .findOut    => 82/100
-  | .see        => 83/100
-  | .beAmused   => 85/100
-  | .realize    => 86/100
-  | .beAware    => 87/100
-  | .notice     => 88/100
-  | .beAnnoyed  => 89/100
-
-/-- At-issueness = 1 − not-at-issueness for predicates. -/
-def verbAtIssueness (p : Predicate) : ℚ := 1 - verbNotAtIssueness p
-
--- ════════════════════════════════════════════════════
--- § Regression Coefficients
--- ════════════════════════════════════════════════════
-
-/-- Regression coefficient: not-at-issueness predicts projectivity.
-    Exp 1a (p. 508–509): β = 0.37, SE = 0.10, t = 3.70, p < .003.
-    Exp 1b (p. 514): β = 0.34, SE = 0.04, t = 9.31, p < .0001.
-
-    The effect is significant in both experiments. -/
-structure RegressionEffect where
-  beta : ℚ
-  se : ℚ
-  deriving Repr
-
-def exp1aRegression : RegressionEffect := ⟨37/100, 10/100⟩
-def exp1bRegression : RegressionEffect := ⟨34/100, 4/100⟩
-
--- ════════════════════════════════════════════════════
--- § Correlation Coefficients
--- ════════════════════════════════════════════════════
-
-/-- Pearson r for not-at-issueness × projectivity (positive correlation).
-    "Collapsing" = computed over expression-type/predicate means.
-    "Not collapsing" = computed over individual items.
-
-    Exp 1a (p. 508): r = .85 (collapsing), r = .45 (not collapsing)
-    Exp 1b (p. 514): r = .99 (collapsing), r = .44 (not collapsing) -/
-structure CorrelationData where
-  collapsing : ℚ
-  notCollapsing : ℚ
-  deriving Repr
-
-def exp1aCorrelation : CorrelationData := ⟨85/100, 45/100⟩
-def exp1bCorrelation : CorrelationData := ⟨99/100, 44/100⟩
-
--- ════════════════════════════════════════════════════
--- § Verification Theorems: Exp 1a
--- ════════════════════════════════════════════════════
-
-/-- NRRC and be annoyed are tied for most projective (text: .96). -/
-theorem nrrc_annoyed_most_projective : ∀ e : ExpressionType,
-    projectivityRating e ≤ projectivityRating .nrrc := by
-  intro e; cases e <;> native_decide
-
-/-- only is the least projective at .76 (text confirms). -/
-theorem only_least_projective : ∀ e : ExpressionType,
-    projectivityRating .only ≤ projectivityRating e := by
-  intro e; cases e <;> native_decide
-
-/-- NRRC has the highest not-at-issueness at .96 (text confirms). -/
-theorem nrrc_most_notAtIssue : ∀ e : ExpressionType,
-    notAtIssuenessRating e ≤ notAtIssuenessRating .nrrc := by
-  intro e; cases e <;> native_decide
-
-/-- only has the lowest not-at-issueness at .73 (text confirms). -/
-theorem only_least_notAtIssue : ∀ e : ExpressionType,
-    notAtIssuenessRating .only ≤ notAtIssuenessRating e := by
-  intro e; cases e <;> native_decide
-
-/-- Appositives are not maximally projective, contra [potts-2005].
-    Potts predicted CI content (including appositives) should project
-    obligatorily. The data shows 94/100 — high but not 1.0. -/
-theorem appositives_not_maximally_projective :
-    projectivityRating .nominalAppositive < 1 := by native_decide
-
-/-- Within-type variation: factive predicates differ in projectivity.
-    discover (.88) vs know (.91) — both traditionally "factive" but
-    different ratings. -/
-theorem within_type_variation :
-    projectivityRating .discover ≠ projectivityRating .know := by
-  native_decide
-
-/-- GPP supported for Exp 1a extremes: only has highest at-issueness
-    and lowest projectivity; NRRC has lowest at-issueness and highest
-    projectivity. -/
-theorem gpp_extreme_pair_exp1a :
-    atIssuenessRating .only > atIssuenessRating .nrrc ∧
-    projectivityRating .only < projectivityRating .nrrc := by
-  native_decide
-
--- ════════════════════════════════════════════════════
--- § Verification Theorems: Exp 1b
--- ════════════════════════════════════════════════════
-
-/-- be annoyed has the highest projectivity among the 12 predicates.
-    (Tied with notice at .94.) -/
-theorem beAnnoyed_highest_verb_projectivity :
-    ∀ p : Predicate, verbProjectivity p ≤ verbProjectivity .beAnnoyed := by
-  intro p; cases p <;> native_decide
-
-/-- establish has the lowest projectivity (.43) — notably below .50,
-    suggesting it may not even be a projective trigger. -/
-theorem establish_lowest_verb_projectivity :
-    ∀ p : Predicate, verbProjectivity .establish ≤ verbProjectivity p := by
-  intro p; cases p <;> native_decide
-
-/-- establish is the only predicate with projectivity below the
-    midpoint .50, suggesting it may not be a projective trigger. -/
-theorem establish_below_midpoint :
-    verbProjectivity .establish < 1/2 := by native_decide
-
-/-- GPP supported for Exp 1b extremes: establish has highest
-    at-issueness and lowest projectivity. -/
-theorem gpp_extreme_pair_exp1b :
-    verbAtIssueness .establish > verbAtIssueness .beAnnoyed ∧
-    verbProjectivity .establish < verbProjectivity .beAnnoyed := by
-  native_decide
-
-/-- All predicates except establish have projectivity ≥ .65. -/
-theorem non_establish_above_65 : ∀ p : Predicate,
-    p ≠ .establish → 65/100 ≤ verbProjectivity p := by
-  intro p hp; cases p <;> first | native_decide | exact absurd rfl hp
-
--- ════════════════════════════════════════════════════
--- § Tukey Groupings
--- ════════════════════════════════════════════════════
-
-/-- The top group of Exp 1a (Table 1): {NRRC, annoyed, NomApp, possNP, know}
-    show no significant pairwise differences in projectivity.
-    These form the "high projectivity" cluster (.91–.96). -/
-theorem exp1a_top_group_tight_range :
-    projectivityRating .nrrc - projectivityRating .know ≤ 6/100 := by
-  native_decide
-
-/-- only is significantly different from all other expression types
-    (Table 1: all pairwise comparisons significant at p < .001). -/
-theorem only_separated_from_top :
-    projectivityRating .nrrc - projectivityRating .only ≥ 15/100 := by
-  native_decide
-
-/-- The top group of Exp 1b (Table 3): {annoyed, notice, aware, realize,
-    amused, findOut} show no significant pairwise differences.
-    These form the "high projectivity" cluster (.90–.94). -/
-theorem exp1b_top_group_tight_range :
-    verbProjectivity .beAnnoyed - verbProjectivity .findOut ≤ 5/100 := by
-  native_decide
-
-/-- establish is clearly separated from the top group
-    (Table 3: all pairwise comparisons significant at p < .001). -/
-theorem establish_separated_from_top :
-    verbProjectivity .beAnnoyed - verbProjectivity .establish ≥ 40/100 := by
-  native_decide
-
--- ════════════════════════════════════════════════════
--- § Bridge: Gradient At-Issueness ↔ Infrastructure
--- ════════════════════════════════════════════════════
-
 open Discourse.AtIssueness
+open Core.Order (Rat01)
+open Pragmatics.Expressives
+open Data.Examples (LinguisticExample SourceRef)
 
-/-- Lift an expression type's projectivity rating to a bounded degree. -/
-def ExpressionType.toProjectivityDegree (e : ExpressionType) : ProjectivityDegree :=
-  ⟨projectivityRating e,
-   by cases e <;> native_decide,
-   by cases e <;> native_decide⟩
+/-! ### The Gradient Projection Principle -/
 
-/-- Lift an expression type's at-issueness to a bounded degree. -/
-def ExpressionType.toAtIssuenessDegree (e : ExpressionType) : AtIssuenessDegree :=
-  ⟨atIssuenessRating e,
-   by cases e <;> native_decide,
-   by cases e <;> native_decide⟩
+/-- The GPP map: projection degree is the complement of at-issueness — content
+    projects to the extent it is not at-issue ([tonhauser-beaver-degen-2018]). -/
+def gppProjection (ai : AtIssuenessDegree) : ProjectivityDegree := Rat01.compl ai
 
-/-- Lift a predicate's projectivity rating to a bounded degree. -/
-def Predicate.toProjectivityDegree (p : Predicate) : ProjectivityDegree :=
-  ⟨verbProjectivity p,
-   by cases p <;> native_decide,
-   by cases p <;> native_decide⟩
+/-- The GPP as order-reversal: more at-issue content is no more projective. -/
+theorem gppProjection_antitone : Antitone gppProjection := Rat01.compl_antitone
 
-/-- Lift a predicate's at-issueness to a bounded degree. -/
-def Predicate.toAtIssuenessDegree (p : Predicate) : AtIssuenessDegree :=
-  ⟨verbAtIssueness p,
-   by cases p <;> native_decide,
-   by cases p <;> native_decide⟩
+/-- Fully not-at-issue content (at-issueness `0`) projects maximally. -/
+theorem gppProjection_zero : gppProjection Rat01.zero = Rat01.one := by
+  apply Subtype.ext; simp [gppProjection, Rat01.zero, Rat01.one]
 
-/-- Mean projectivity for Class B triggers (NRRC, appositive, possessive NP). -/
-def classBMeanProjectivity : ℚ :=
-  (projectivityRating ExpressionType.nrrc +
-   projectivityRating ExpressionType.nominalAppositive +
-   projectivityRating ExpressionType.possessiveNP) / 3
+/-- Fully at-issue content (at-issueness `1`) does not project. -/
+theorem gppProjection_one : gppProjection Rat01.one = Rat01.zero := by
+  apply Subtype.ext; simp [gppProjection, Rat01.zero, Rat01.one]
 
-/-- Mean projectivity for Class C triggers (discover, know, annoyed, stop). -/
-def classCMeanProjectivity : ℚ :=
-  (projectivityRating ExpressionType.discover +
-   projectivityRating ExpressionType.know +
-   projectivityRating ExpressionType.annoyed +
-   projectivityRating ExpressionType.stop) / 4
+/-! ### Recovering the binary Projection Principle
 
-/-- Class B triggers have higher mean projectivity than Class C triggers. -/
-theorem classB_higher_projectivity_than_classC :
-    classCMeanProjectivity < classBMeanProjectivity := by native_decide
+The binary principle ([simons-tonhauser-beaver-roberts-2010]) — projects iff not
+at-issue — is the threshold collapse of the gradient GPP. -/
 
-/-- Mean not-at-issueness for Class B triggers. -/
-def classBMeanNotAtIssueness : ℚ :=
-  (notAtIssuenessRating ExpressionType.nrrc +
-   notAtIssuenessRating ExpressionType.nominalAppositive +
-   notAtIssuenessRating ExpressionType.possessiveNP) / 3
+/-- The GPP projects past `θ` iff at-issueness is below the complementary threshold. -/
+theorem gpp_projects_iff (ai θ : Rat01) :
+    isProjective (gppProjection ai) θ ↔ ai.val < (Rat01.compl θ).val := by
+  simp only [isProjective, Rat01.exceeds, gppProjection, Rat01.compl_val]
+  constructor <;> intro h <;> linarith
 
-/-- Mean not-at-issueness for Class C triggers. -/
-def classCMeanNotAtIssueness : ℚ :=
-  (notAtIssuenessRating ExpressionType.discover +
-   notAtIssuenessRating ExpressionType.know +
-   notAtIssuenessRating ExpressionType.annoyed +
-   notAtIssuenessRating ExpressionType.stop) / 4
+/-- The binary Projection Principle: never both at-issue and projecting at
+    complementary thresholds. -/
+theorem gpp_excludes_atIssue (ai θ : Rat01) :
+    ¬ (isAtIssue ai (Rat01.compl θ) ∧ isProjective (gppProjection ai) θ) := by
+  rintro ⟨ha, hp⟩
+  simp only [isAtIssue, Rat01.exceeds, Rat01.compl_val] at ha
+  rw [gpp_projects_iff, Rat01.compl_val] at hp
+  linarith
 
-/-- Class B triggers are more not-at-issue than Class C triggers. -/
-theorem classB_higher_notAtIssueness_than_classC :
-    classCMeanNotAtIssueness < classBMeanNotAtIssueness := by native_decide
+/-! ### Contra Potts
 
-/-- With the default threshold of 0.5, all 9 expression types are
-    classified as not-at-issue. -/
-theorem all_expression_types_not_at_issue :
-    ∀ e : ExpressionType,
-      toClassical (ExpressionType.toAtIssuenessDegree e) defaultThreshold
-        = .notAtIssue := by
-  intro e; cases e <;> native_decide
+[potts-2005] predicts CI content (appositives, NRRCs, expressives) projects
+maximally and obligatorily — its CI dimension is unchanged by every
+entailment-canceling operator. The GPP ties projection to at-issueness, so any
+at-issue content projects below the ceiling; the two agree only for
+fully-backgrounded content. -/
 
-/-- For Exp 1b predicates, only establish is classified as at-issue
-    with the default threshold. -/
-theorem establish_at_issue_default :
-    toClassical (Predicate.toAtIssuenessDegree .establish) defaultThreshold
-      = .atIssue := by
-  native_decide
+/-- [potts-2005]'s prediction: CI content projects maximally (degree `1`),
+    regardless of at-issueness. -/
+def pottsProjection (_ : AtIssuenessDegree) : ProjectivityDegree := Rat01.one
 
-/-- All predicates except establish are classified as not-at-issue. -/
-theorem non_establish_not_at_issue (p : Predicate) (h : p ≠ .establish) :
-    toClassical (Predicate.toAtIssuenessDegree p) defaultThreshold
-      = .notAtIssue := by
-  cases p <;> first | native_decide | exact absurd rfl h
+@[simp] theorem pottsProjection_val (ai : AtIssuenessDegree) :
+    (pottsProjection ai).val = 1 := rfl
 
-/-- The GPP anti-monotonicity property holds for Exp 1b verb data. -/
-theorem exp1b_gpp_antimonotone :
-    ∀ (p q : Predicate),
-      verbAtIssueness p < verbAtIssueness q →
-      verbProjectivity q ≤ verbProjectivity p := by
-  intro p q; cases p <;> cases q <;> native_decide
+/-- Potts's prediction is at-issueness-blind — the same for all content, which
+    the GPP denies. -/
+theorem potts_atIssue_blind (ai₁ ai₂ : AtIssuenessDegree) :
+    pottsProjection ai₁ = pottsProjection ai₂ := rfl
 
-/-- Exp 1a is NOT fully anti-monotone: possNP and NomApp are non-monotone. -/
-theorem exp1a_non_monotone_witness :
-    notAtIssuenessRating ExpressionType.possessiveNP >
-      notAtIssuenessRating ExpressionType.nominalAppositive ∧
-    projectivityRating ExpressionType.possessiveNP <
-      projectivityRating ExpressionType.nominalAppositive := by
-  native_decide
+/-- Potts's maximal projection abstracts the operator-invariance of the CI
+    dimension: negation leaves CI content unchanged ([potts-2005]). -/
+theorem potts_ci_invariant_under_neg {W : Type*} (p : TwoDimProp W) :
+    (TwoDimProp.neg p).ci = p.ci := TwoDimProp.ci_projects_through_neg p
 
-/-- Among shared predicates, discover shows intermediate at-issueness. -/
-theorem shared_predicates_gradient :
-    verbProjectivity Predicate.beAnnoyed > 1/2 ∧
-    verbProjectivity Predicate.discover > 1/2 ∧
-    verbProjectivity Predicate.reveal > 1/2 ∧
-    verbProjectivity Predicate.see > 1/2 := by
-  native_decide
+/-- Contra [potts-2005]: any at-issue content (at-issueness `> 0`) projects
+    strictly below Potts's ceiling — the structural form of "appositives are not
+    maximally projective". -/
+theorem gpp_below_potts_of_atIssue {ai : AtIssuenessDegree} (h : 0 < ai.val) :
+    (gppProjection ai).val < (pottsProjection ai).val := by
+  simp only [gppProjection, pottsProjection, Rat01.compl_val, Rat01.one]; linarith
 
-theorem shared_predicates_intermediate_atissueness :
-    verbAtIssueness Predicate.discover > 0 ∧
-    verbAtIssueness Predicate.discover < 1/2 ∧
-    verbAtIssueness Predicate.beAnnoyed > 0 ∧
-    verbAtIssueness Predicate.beAnnoyed < 1/2 := by
-  native_decide
+/-- The GPP and Potts agree iff the content is fully backgrounded (at-issueness `0`). -/
+theorem gpp_eq_potts_iff_backgrounded (ai : AtIssuenessDegree) :
+    gppProjection ai = pottsProjection ai ↔ ai = Rat01.zero := by
+  constructor
+  · intro h
+    apply Subtype.ext
+    have hv : (gppProjection ai).val = (pottsProjection ai).val := by rw [h]
+    simp only [gppProjection, pottsProjection, Rat01.compl_val, Rat01.one] at hv
+    simp only [Rat01.zero]; linarith
+  · intro h; subst h; apply Subtype.ext
+    simp [gppProjection, pottsProjection, Rat01.zero, Rat01.one]
+
+/-- Potts files appositives in the independent CI dimension — the source of the
+    maximal-projection prediction the GPP refines. -/
+theorem appositive_potts_independent : appositiveProperties.independent = true := rfl
+
+/-! ### The GPP as a `MonotoneAntiCorrelation`
+
+`Discourse.AtIssueness.MonotoneAntiCorrelation` (built for this paper, consumed by
+`Studies/SolstadBott2024`) bundles anti-correlated pairs; the GPP produces one
+from any list of at-issueness values. -/
+
+/-- Any list of at-issueness values, paired with their GPP projection, forms a
+    `MonotoneAntiCorrelation`. -/
+def gppAntiCorrelation (ais : List ℚ) : MonotoneAntiCorrelation where
+  pairs := ais.map (fun a => ⟨a, 1 - a⟩)
+  anticorrelated := by
+    intro i j h
+    simp only [List.get_eq_getElem, List.getElem_map] at h ⊢
+    linarith
+
+/-! ### Illustrations from the paper
+
+The paper's qualitative findings instantiate the GPP: stated as hypotheses on
+at-issueness, the projectivity ordering follows from `gppProjection_antitone`. -/
+
+/-- Since `only` is more at-issue than an NRRC, the GPP predicts it projects no
+    more ([tonhauser-beaver-degen-2018]). -/
+theorem only_no_more_projective_than_nrrc
+    {onlyAI nrrcAI : AtIssuenessDegree} (h : nrrcAI ≤ onlyAI) :
+    gppProjection onlyAI ≤ gppProjection nrrcAI :=
+  gppProjection_antitone h
+
+/-- At-issue appositive content projects sub-maximally — the GPP reading of the
+    central result against [potts-2005]. -/
+theorem appositive_not_maximally_projective
+    {apposAI : AtIssuenessDegree} (h : 0 < apposAI.val) :
+    (gppProjection apposAI).val < 1 := by
+  have := gpp_below_potts_of_atIssue h
+  simpa [pottsProjection, Rat01.one] using this
+
+/-! ### Representing the data for theories to predict against
+
+The per-expression means (Exps 1a/1b plus main-clause controls) are
+artifact-sourced rows in `Data.Examples.TonhauserBeaverDegen2018`; `fromExample`
+lifts them to the `allData` pool any `ProjectionAccount` runs against. The means
+are continuous, so per-row predictions are *computed* (string `paperFeatures` and
+`ℚ` do not reduce in the kernel); the *provable* content is each account's
+systematic error — the GPP over-predicts content projecting below its
+not-at-issueness, Potts over-predicts everything sub-ceiling, and where both do
+the GPP is closer. -/
+
+/-- A theory of projection: predict a content's projectivity from its at-issueness. -/
+abbrev ProjectionAccount := AtIssuenessDegree → ProjectivityDegree
+
+/-- Observed projectivity and not-at-issueness means for one expression. -/
+structure ProjectionDatum where
+  expression     : String
+  projectivity   : ProjectivityDegree
+  notAtIssueness : Rat01
+  source         : SourceRef
+  deriving Repr
+
+/-- Parse a percent-integer string (e.g. `"96"`) into a `Rat01`; `none` if
+    non-numeric or out of range. -/
+def parsePercent (s : String) : Option Rat01 :=
+  match s.toNat? with
+  | some n =>
+      if h : n ≤ 100 then
+        some (ofPercent (n : ℚ) (by exact_mod_cast Nat.zero_le n) (by exact_mod_cast h))
+      else none
+  | none => none
+
+/-- Lift a `LinguisticExample` to a `ProjectionDatum` via its `expression`,
+    `projectivity`, and `notAtIssueness` keys; `none` if any is missing. -/
+def fromExample (e : LinguisticExample) : Option ProjectionDatum :=
+  match e.paperFeatures.lookup "expression",
+        (e.paperFeatures.lookup "projectivity").bind parsePercent,
+        (e.paperFeatures.lookup "notAtIssueness").bind parsePercent with
+  | some expr, some p, some na =>
+      some { expression := expr, projectivity := p, notAtIssueness := na, source := e.source }
+  | _, _, _ => none
+
+/-- The observed projection pool, derived from the generated `Examples.all` rows. -/
+def allData : List ProjectionDatum :=
+  Examples.all.filterMap fromExample
+
+/-- An account's absolute error on an observation. -/
+def predictionError (acc : ProjectionAccount) (d : ProjectionDatum) : ℚ :=
+  |(acc (Rat01.compl d.notAtIssueness)).val - d.projectivity.val|
+
+/-- An account predicts an observation within tolerance `ε`. -/
+def predictsWithin (ε : ℚ) (acc : ProjectionAccount) (d : ProjectionDatum) : Prop :=
+  predictionError acc d ≤ ε
+
+instance (ε : ℚ) (acc : ProjectionAccount) (d : ProjectionDatum) :
+    Decidable (predictsWithin ε acc d) :=
+  inferInstanceAs (Decidable (_ ≤ _))
+
+/-- The GPP over-predicts every content projecting below its not-at-issueness —
+    the `establish`, `reveal`, and `confess` rows. -/
+theorem gpp_errs_below_diagonal (d : ProjectionDatum)
+    (h : d.projectivity.val < d.notAtIssueness.val) :
+    0 < predictionError gppProjection d := by
+  rw [predictionError, gppProjection, Rat01.compl_compl, abs_pos]
+  intro hc; linarith [sub_eq_zero.mp hc]
+
+/-- Potts over-predicts every content below the ceiling (projectivity `< 1`). -/
+theorem potts_errs_subceiling (d : ProjectionDatum)
+    (h : d.projectivity.val < 1) :
+    0 < predictionError pottsProjection d := by
+  rw [predictionError, abs_pos]
+  simp only [pottsProjection_val]
+  intro hc; linarith [sub_eq_zero.mp hc]
+
+/-- Below both its not-at-issueness and the ceiling, the GPP is strictly closer to
+    the observation than Potts — the low-projectivity items the paper highlights. -/
+theorem gpp_beats_potts_below_diagonal (d : ProjectionDatum)
+    (h1 : d.projectivity.val < d.notAtIssueness.val) (h2 : d.notAtIssueness.val < 1) :
+    predictionError gppProjection d < predictionError pottsProjection d := by
+  rw [predictionError, predictionError, gppProjection, Rat01.compl_compl]
+  simp only [pottsProjection_val]
+  rw [abs_of_pos (by linarith), abs_of_pos (by linarith)]
+  linarith
 
 end TonhauserBeaverDegen2018


### PR DESCRIPTION
Audit-driven rewrite of two same-era projective-content study files around the Gradient Projection Principle, plus a shared `Data/Generalizations/Projectivity` hub for rival accounts to predict against. Both papers' data verified against their PDFs (TBD2018 also recomputed from the public CSV).

- **TonhauserBeaverDegen2018**: rewritten as derived GPP structure (`gppProjection = Rat01.compl`, antitone); binary Projection Principle recovered as its threshold-collapse; contra-Potts as a structural theorem. Replaces ~33 `native_decide` + eyeballed data tables (several were wrong, e.g. `establish` not-at-issueness .47→.61).
- **SolstadBott2024** (occasion verbs): drops the regression/Datum stats structs + `native_decide`; keeps the genuine structural theory (symmetric filtering, cataphoric resolution via `FilteringDirection`/`ContextPolarity`, Class C, Heim/Schlenker, the IC bridge); adds the cross-paper result that occasion verbs project *above* the GPP diagonal (mirror of `establish`). 558→265 lines.
- **Data/Generalizations/Projectivity**: theory-neutral pool (`ProjectionAccount` signature, `ProjectionDatum` adapter, 27 artifact-sourced rows from both papers' `Data/Examples` JSON) that `gppProjection`/`pottsProjection` are scored against. Bib: adds verified `mandelkern-etal-2020`; fixes two stale `sources` paths.

No `native_decide`/`sorry`; axiom-clean. CI runs the authoritative full build.