### PR TITLE
feat(Morphology): per-language affix templates as Fragment data

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1105,6 +1105,7 @@ import Linglib.Fragments.Quechua.SaraguroKichwa.Evidentiality
 import Linglib.Fragments.Quechua.TenseAspect
 import Linglib.Fragments.Romance.Clitics
 import Linglib.Fragments.Romanian.MoodChoice
+import Linglib.Fragments.Sesotho.Morph
 import Linglib.Fragments.Shan.ClassifierSystem
 import Linglib.Fragments.Shan.Classifiers
 import Linglib.Fragments.Shan.Definiteness
@@ -1267,6 +1268,7 @@ import Linglib.Fragments.Yoruba.TenseAspect
 import Linglib.Fragments.ZarmaSonrai.Negation
 import Linglib.Fragments.Zulu.Phonology
 import Linglib.Fragments.Zulu.Plurals
+import Linglib.Morphology.AffixTemplate
 import Linglib.Morphology.Case.Allomorphy
 import Linglib.Morphology.Case.WALS
 import Linglib.Morphology.ConsonantalRoot

--- a/Linglib/Fragments/Japanese/Morph.lean
+++ b/Linglib/Fragments/Japanese/Morph.lean
@@ -1,11 +1,25 @@
 import Linglib.Morphology.MorphProfile
+import Linglib.Morphology.AffixTemplate
 
 /-!
 # Japanese Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2001] [kaiser-yamamoto-2013]
 
 WALS-derived profile for Japanese (ISO `jpn`). B&N 2001 places Japanese
 in the "agglutinating" cell (concatenative + nonflexive + separative).
+
+The verb suffix template (`verbAffixTemplate`) follows [kaiser-yamamoto-2013]
+and the UD segmentation: seven slots, stem-outward.
+
+| Slot | Category | Morpheme |
+|------|----------|----------|
+| 1 | derivation | -su (suru) |
+| 2 | valence | -(s)ase (causative) |
+| 3 | voice | -are, -rare (passive/potential) |
+| 4 | mood | -ta (desiderative) |
+| 5 | agreement | -mas (politeness, treated as subject agreement) |
+| 6 | negation | -na |
+| 7 | tense | -ta (past), -yoo (future) |
 -/
 
 namespace Japanese
@@ -28,5 +42,17 @@ example : morphProfile.iso = "jpn" ∧ morphProfile.language = "Japanese" := ⟨
 
 /-- B&N 2001 places Japanese in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
+
+/-- Japanese verb suffix template, stem-outward ([kaiser-yamamoto-2013], UD
+segmentation). Japanese is strongly suffixing, so there are no prefix slots. -/
+def verbAffixTemplate : AffixTemplate where
+  suffixSlots :=
+    [ .derivation       -- 1. -su (suru)
+    , .valence          -- 2. -(s)ase (causative)
+    , .voice            -- 3. -are, -rare (passive/potential)
+    , .mood             -- 4. -ta (desiderative)
+    , .agreement .subj  -- 5. -mas (politeness, treated as subject agreement)
+    , .negation         -- 6. -na (negation)
+    , .tense ]          -- 7. -ta, -yoo (past/future)
 
 end Japanese

--- a/Linglib/Fragments/Sesotho/Morph.lean
+++ b/Linglib/Fragments/Sesotho/Morph.lean
@@ -1,0 +1,43 @@
+import Linglib.Morphology.AffixTemplate
+
+/-!
+# Sesotho Morphological Profile
+[demuth-1992] [doke-mofokeng-1967]
+
+Verb affix template for Sesotho (Southern Sotho, ISO `sot`), from the reference
+grammars [demuth-1992] and [doke-mofokeng-1967].
+
+**Prefixes** (word-edge inward): subject agreement, negation, tense/aspect/mood,
+object agreement.
+
+**Suffixes** (stem-outward): a valence-changing inner layer (reversive,
+causative, neuter, applicative, completive), then voice (reciprocal, passive),
+then tense (perfect `-il-`), mood (imperative/subjunctive/indicative), and a
+final interrogative/relative (nonfinite) slot.
+-/
+
+namespace Sesotho
+
+open Morphology
+
+/-- Sesotho verb affix template ([demuth-1992], [doke-mofokeng-1967]). The
+suffix slots run stem-outward; the prefix slots run word-edge inward. -/
+def verbAffixTemplate : AffixTemplate where
+  suffixSlots :=
+    [ .valence    -- 1. reversive
+    , .valence    -- 2. causative
+    , .valence    -- 3. neuter
+    , .valence    -- 4. applicative
+    , .valence    -- 5. completive (applicative reduplication)
+    , .voice      -- 6. reciprocal
+    , .voice      -- 7. passive
+    , .tense      -- 8. perfect (-il-)
+    , .mood       -- 9. imperative/subjunctive/indicative
+    , .nonfinite ] -- 10. interrogative/relative
+  prefixSlots :=
+    [ .agreement .subj  -- 1. subject agreement
+    , .negation         -- 2. negation
+    , .tense            -- 3. tense/aspect/mood
+    , .agreement .obj ] -- 4. object agreement
+
+end Sesotho

--- a/Linglib/Morphology/AffixTemplate.lean
+++ b/Linglib/Morphology/AffixTemplate.lean
@@ -1,0 +1,39 @@
+import Linglib.Morphology.MorphRule
+
+/-!
+# Affix position-class templates
+
+A language's verb (or word) affix template: the ordered morpheme-category slots
+of its prefix and suffix strings. This is the per-language, Fragment-importable
+substrate that `RespectsRelevanceHierarchy` (in `Morphology/MorphRule.lean`)
+tests against [bybee-1985]'s relevance hierarchy — so a language's slot order
+lives once, as Fragment data, and study files derive their checks from it rather
+than re-typing the template.
+
+## Main definitions
+
+* `Morphology.AffixTemplate` — a language's prefix/suffix slots as `MorphCategory` lists.
+* `Morphology.AffixTemplate.suffixRespectsRelevance` — the suffix slots are sorted by relevance.
+-/
+
+namespace Morphology
+
+/-- A language's affix position-class template. `suffixSlots` runs stem-outward
+(innermost suffix first); `prefixSlots` is listed as the source grammar writes
+it, word-edge inward. Slots are `MorphCategory` tags, not exponents — the actual
+morphemes live in the citing grammar. -/
+structure AffixTemplate where
+  /-- Suffix slots, ordered stem-outward (innermost suffix first). -/
+  suffixSlots : List MorphCategory := []
+  /-- Prefix slots, ordered word-edge inward (outermost prefix first). -/
+  prefixSlots : List MorphCategory := []
+  deriving Repr, DecidableEq
+
+/-- The template's suffix order respects [bybee-1985]'s relevance hierarchy. -/
+def AffixTemplate.suffixRespectsRelevance (t : AffixTemplate) : Prop :=
+  RespectsRelevanceHierarchy t.suffixSlots
+
+instance (t : AffixTemplate) : Decidable t.suffixRespectsRelevance :=
+  inferInstanceAs (Decidable (RespectsRelevanceHierarchy _))
+
+end Morphology

--- a/Linglib/Studies/Bybee1985.lean
+++ b/Linglib/Studies/Bybee1985.lean
@@ -4,54 +4,62 @@ import Linglib.Fragments.English.Predicates.Verbal
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Bybee (1985): Morphology — A Study of the Relation Between Meaning and Form
-[bybee-1985]
+# Bybee (1985): the relevance hypothesis
 
-[bybee-1985] (Typological Studies in Language 9, John Benjamins) reports
-a 50-language sample (Perkins 1980 stratified probability sample) and tests
-three predictions of the **relevance hypothesis**: morpheme categories whose
-meaning is more directly relevant to the verb stem (a) occur more frequently
-as inflectional categories cross-linguistically, (b) occur closer to the stem
-in suffixal morphology, and (c) exhibit greater fusion with the stem.
+[bybee-1985] (*Morphology: A Study of the Relation Between Meaning and Form*,
+Typological Studies in Language 9) tests the **relevance hypothesis** on a
+50-language stratified probability sample (Perkins 1980): a morpheme category
+whose meaning is more relevant to the verb stem (a) occurs more often as
+inflection cross-linguistically, (b) sits closer to the stem in suffixal
+morphology, and (c) fuses more tightly with it.
 
-This study file formalizes the cross-linguistic data underlying claims (a)
-and (b) — Ch 2 §5 (frequency, Figs 1+2) and Ch 2 §6 (morpheme order, pp.
-34-35) — and connects them to the substrate's `MorphCategory.peripherality`
-ranking. Claim (c) (fusion) is qualitative in Ch 2 §7 and not formalized
-here.
+This file formalizes the data behind claims (a) and (b) — the Ch 2 §5 frequency
+surveys and the Ch 2 §6 morpheme-order counts — and grounds the substrate's
+relevance order (`MorphCategory.peripherality`, via `RelevanceLT` / `RelevanceLE`)
+in that evidence. Claim (c), fusion, is qualitative in the source and is not
+formalized.
 
-**What this file does NOT cover.** Ch 1 fusion/allomorphy/grammatical
-meaning, Ch 3 paradigm organization (basic-derived, local markedness),
-Ch 4 lexical-derivational-inflectional CONTINUUM (which contradicts the
-substrate's discrete `MorphStatus` enum — flagged for future work), Part
-II aspect/tense/mood detail (Ch 6-9). Bybee's Ch 2 §6 relevance ordering
-is independently exercised in `Studies/HahnDegenFutrell2021Morphology.lean`
-via the substrate's `RespectsRelevanceHierarchy` predicate (that file
-does not consume `orderPairs` directly); the `BybeeCategory` enum and
-`toMorphCategory` bridge below are consumed by
-`Studies/RathiHahnFutrell2026.lean`. Ch 5's **dynamic network model**
-substrate now lives in `Morphology/UsageBased/Network.lean`; the network
-section below uses it on the English irregular verb *eat/ate/eaten*.
+## Main definitions
 
+* `BybeeCategory` — the verbal-inflectional categories of Ch 2, in relevance order.
+* `inflectionalCount50`, `derivOrInflCount50` — the Ch 2 §5 frequency surveys (Figs 1+2).
+* `orderPairs` — the Ch 2 §6 morpheme-order counts, one `OrderPair` per tested category pair.
+* `toMorphCategory` — the embedding of `BybeeCategory` into the substrate `MorphCategory`.
+* `SurveyedCloser` — the stem-proximity order *derived from* `orderPairs`.
+* `verbToBybeeNetwork` — a verb's Ch 5 paradigm network, derived from a Fragment `VerbEntry`.
+
+## Main results
+
+* `mood_highest_when_inflectional`, `gender_lowest_when_derivOrInfl` — the frequency predictions.
+* `predicted_outnumbers_counter`, `aspect_categorical_against_tense_and_mood` — the order predictions.
+* `survey_order_iso_relevance` — on the surveyed categories `SurveyedCloser` and the substrate
+  `RelevanceLT` coincide via `toMorphCategory`: the hierarchy is the order the §6 survey forces,
+  not a stipulated table.
+* `bybeeSurveyedSlots_respects_hierarchy` — closes the loop to `RespectsRelevanceHierarchy`.
+
+## Implementation notes
+
+Out of scope: Ch 1 fusion/allomorphy, Ch 3 paradigm organization, Ch 4's
+lexical-derivational-inflectional continuum (which the discrete `MorphStatus`
+enum cannot express — flagged for future work), and Part II tense/aspect/mood
+detail (Ch 6-9). `MorphCategory.RelevanceLT` is exercised independently by
+`Studies/HahnDegenFutrell2021Morphology.lean`; the `BybeeCategory` enum and
+`toMorphCategory` bridge feed `Studies/RathiHahnFutrell2026.lean`. The Ch 5
+network substrate lives in `Morphology/UsageBased/Network.lean`; §5 below uses
+it on the English *eat/ate/eaten* paradigm.
 -/
 
 namespace Bybee1985
 
 open Morphology
 
-/-! ### Bybee's verbal categories (Ch 2 §3, p. 20-23) -/
+/-! ### Verbal categories (Ch 2 §3)
 
-/-! Bybee discusses six core verbal-inflectional categories ordered by
-relevance to the verb stem (most relevant first): valence, voice, aspect,
-tense, mood, agreement. Number, person, and gender are sub-types of
-agreement; object-person is reported separately in the survey data. -/
+Bybee's six core categories in relevance order: valence, voice, aspect, tense,
+mood, agreement (number/person/gender are agreement sub-types). -/
 
-/-- The verbal-inflectional categories Bybee surveys in Ch 2.
-
-The constructors are listed in Bybee's relevance order (most relevant to
-verb stem first; cf. Ch 2 §3 p. 20 which orders "valence, voice, aspect,
-tense, mood and agreement"). Object-person, number-as-agreement, and
-gender are reported separately in Figs 1+2 (p. 30-31). -/
+/-- Bybee's Ch 2 verbal-inflectional categories, in her relevance order (stem
+first). Object agreement, number, and gender are tracked separately. -/
 inductive BybeeCategory where
   | valence
   | voice
@@ -64,17 +72,13 @@ inductive BybeeCategory where
   | genderAgr
   deriving DecidableEq, Repr, Fintype
 
-/-! ### Cross-linguistic frequency data (Ch 2 §5, Figures 1 + 2, pp. 30-31) -/
+/-! ### Cross-linguistic frequency (Ch 2 §5, Figs 1+2)
 
-/-! Figure 1 (p. 30) reports the percentage of the 50-language sample with
-**inflectional** expression of each category. Figure 2 (p. 31) reports the
-same categories counting **both inflectional and derivational** affixes.
-The raw counts (percentage × 50 / 100) are integers because the sample is
-exactly 50 languages. -/
+Fig 1 counts the 50-sample languages with *inflectional* expression of a
+category; Fig 2 counts those with inflectional *or* derivational expression.
+Counts are integers because the sample is exactly 50 (count = percentage / 2). -/
 
-/-- Number of languages (out of 50) that have *inflectional* expression of
-the given category. Verified directly against [bybee-1985] Fig 1
-(p. 30). The raw counts equal `0.01 × percentage × 50`. -/
+/-- Languages (of 50) with *inflectional* expression of `c` (Fig 1). -/
 def inflectionalCount50 : BybeeCategory → Nat
   | .valence       => 3   -- 6%
   | .voice         => 13  -- 26%
@@ -86,12 +90,9 @@ def inflectionalCount50 : BybeeCategory → Nat
   | .personAgrObj  => 14  -- 28%
   | .genderAgr     => 8   -- 16%
 
-/-- Number of languages (out of 50) with *inflectional or derivational*
-expression of the category. Fig 2 (p. 31). Valence's 90% reflects the
-near-universality of valence-changing morphology (Ch 2 §5 p. 29) when
-derivational expression is included; only Haitian, Karankawa, Navaho,
-Serbo-Croatian, and Vietnamese show no such morphology in Bybee's
-sources. -/
+/-- Languages (of 50) with *inflectional or derivational* expression of `c`
+(Fig 2). Valence reaches 90% once valence-changing derivation is counted; only
+Haitian, Karankawa, Navaho, Serbo-Croatian, and Vietnamese lack it. -/
 def derivOrInflCount50 : BybeeCategory → Nat
   | .valence       => 45  -- 90%
   | .voice         => 28  -- 56%
@@ -103,53 +104,37 @@ def derivOrInflCount50 : BybeeCategory → Nat
   | .personAgrObj  => 14  -- 28%
   | .genderAgr     => 8   -- 16%
 
-/-- Bybee's first prediction (Ch 2 §5 p. 29-30): when both inflectional and
-derivational expression are counted, valence shows the highest cross-
-linguistic frequency, reflecting its near-universality as a derivational
-process even in languages with sparse verbal morphology. -/
+/-- Prediction (a), deriv+infl: valence is the most frequent category,
+reflecting near-universal valence-changing morphology. -/
 theorem valence_highest_when_derivOrInfl :
     ∀ c : BybeeCategory, derivOrInflCount50 c ≤ derivOrInflCount50 .valence := by
   decide
 
-/-- Among purely **inflectional** categories, mood shows the highest
-frequency (Fig 1, p. 30: 68%). The valence drop from 90% (deriv+infl) to
-6% (infl only) is Bybee's central observation that valence-changing
-morphology is "almost always derivational" (Ch 2 §5 p. 30). -/
+/-- Among purely *inflectional* categories, mood is the most frequent (Fig 1,
+68%). Valence's drop from 90% to 6% is Bybee's point that valence-changing
+morphology is almost always derivational. -/
 theorem mood_highest_when_inflectional :
     ∀ c : BybeeCategory, inflectionalCount50 c ≤ inflectionalCount50 .mood := by
   decide
 
-/-- In the deriv+infl survey (Fig 2), gender agreement is the lowest-
-frequency category — consistent with Bybee's claim (Ch 2 §3 p. 23) that
-gender agreement has least relevance to the verb. (In Fig 1 inflection-
-only, valence drops to 6% — *below* gender's 16% — because valence is
-near-totally suppressed as inflection while remaining 90% as derivation.
-The Fig 2 ranking is the relevance-faithful one.) -/
+/-- In the deriv+infl survey (Fig 2), gender agreement is the least frequent
+category — Bybee's least-relevant verbal category. (Inflection-only, valence
+drops *below* gender, so Fig 2 is the relevance-faithful ranking.) -/
 theorem gender_lowest_when_derivOrInfl :
     ∀ c : BybeeCategory, derivOrInflCount50 .genderAgr ≤ derivOrInflCount50 c := by
   decide
 
-/-! ### Morpheme-order data (Ch 2 §6, pp. 34-35) -/
+/-! ### Morpheme order (Ch 2 §6)
 
-/-! Bybee's second prediction (Ch 2 §6 p. 33): the morpheme-order corollary.
-"The most relevant to occur closest to the verb stem, and the least
-relevant to occur at the greatest distance from the verb stem." Tested
-on the four most frequent categories — aspect, tense, mood, person — by
-counting, for each pair, in how many languages one is closer to the
-stem than the other.
+Prediction (b): the most relevant categories sit closest to the stem, the least
+relevant furthest. Bybee tests the four most frequent — aspect, tense, mood,
+person — counting, per pair, how many languages place one closer than the other.
+A pair is excluded when the morphemes are portmanteau, on opposite sides of the
+stem, mutually exclusive in one slot, or realized by stem modification. -/
 
-Cases were excluded when (a) the morphemes were portmanteau, (b) they
-appeared on different sides of the stem (unless one was adjacent and
-the other was not), (c) they were mutually exclusive in the same slot,
-or (d) one was expressed via stem modification (counted as closer). -/
-
-/-- A morpheme-order pair from Ch 2 §6. The fields record:
-- `closer` — the category Bybee predicts to be closer to the stem
-- `further` — the category Bybee predicts to be further from the stem
-- `closerCount` — # languages where `closer` is closer to stem (predicted)
-- `furtherCount` — # languages where `further` is closer to stem (counter-ex)
-- `total` — total # languages where the pair is testable (Ch 2 §6 p. 34-35)
--/
+/-- A Ch 2 §6 morpheme-order pair: `closer` / `further` are the predicted
+nearer / farther categories, `closerCount` / `furtherCount` the languages
+confirming / contradicting it, and `total` the languages where it is testable. -/
 structure OrderPair where
   closer : BybeeCategory
   further : BybeeCategory
@@ -158,8 +143,8 @@ structure OrderPair where
   total : Nat
   deriving Repr
 
-/-- The six pairs Bybee tests in Ch 2 §6 (pp. 34-35). All counts verified
-directly against the book. -/
+/-- The six pairs Bybee tests in Ch 2 §6; counts verified against the book, each
+inline comment quoting its source passage. -/
 def orderPairs : List OrderPair := [
   -- p. 34: "Aspect markers were found to be closer to the stem than tense
   -- markers in 8 languages, while the opposite order did not occur in the
@@ -189,61 +174,47 @@ def orderPairs : List OrderPair := [
   ⟨.mood, .personAgr, 13, 5, 26⟩
 ]
 
-/-- Aspect vs. tense and aspect vs. mood are categorical: zero counter-
-examples in the entire 50-language sample. Bybee's summary (p. 35):
-"the strongest differences are found between aspect and the other
-categories, and between tense and the other categories, where there are
-almost no counter-examples to the predicted ordering." -/
+/-- Aspect vs. tense and aspect vs. mood are categorical: zero counterexamples
+in the whole sample, the strongest confirmations Bybee reports. -/
 theorem aspect_categorical_against_tense_and_mood :
     ∀ p ∈ orderPairs,
       p.closer = .aspect → (p.further = .tense ∨ p.further = .mood) →
       p.furtherCount = 0 := by
   decide
 
-/-- Mood-person ordering is genuinely freer: a pair's predicted-counter /
-total ratio exceeds 1/10 *iff* it is the mood-person pair — i.e. mood-
-person is the only pair in the survey above that threshold. -/
+/-- Mood vs. person is the freest pair: the only one whose
+counterexample-to-total ratio exceeds 1/10. -/
 theorem mood_person_ordering_is_freer :
     ∀ p ∈ orderPairs,
       p.total < 10 * p.furtherCount ↔ (p.closer = .mood ∧ p.further = .personAgr) := by
   decide
 
-/-- Across all six tested pairs, the predicted direction outnumbers the
-counter-direction in every case (Ch 2 §6 summary, p. 35: "striking
-confirmation of the hierarchical ordering of aspect, tense, mood and
-person"). -/
+/-- In every one of the six pairs the predicted direction outnumbers the
+counter-direction (Ch 2 §6 summary). -/
 theorem predicted_outnumbers_counter :
     ∀ p ∈ orderPairs, p.furtherCount < p.closerCount := by
   decide
 
-/-- Total testable observations across all six pairs: 125 language-pair
-observations contributed to the hierarchy test. The predicted
-direction holds in 59 of them; the counter-direction in 8; the
-remaining 58 are non-relevant (portmanteau, opposite-side, mutually-
-exclusive, or stem-modification cases per Bybee's exclusion criteria
-on p. 34). -/
+/-- Aggregate Ch 2 §6 counts: 125 testable observations, 59 in the predicted
+direction and 8 against (the other 58 are non-relevant under the exclusion
+criteria above). -/
 theorem ch2_section6_aggregate_counts :
     (orderPairs.map (·.total)).sum = 125 ∧
     (orderPairs.map (·.closerCount)).sum = 59 ∧
     (orderPairs.map (·.furtherCount)).sum = 8 := by
   decide
 
-/-! ### Connection to substrate `MorphCategory.peripherality` -/
+/-! ### Connection to substrate `MorphCategory.peripherality`
 
-/-! `Morphology/MorphRule.lean::MorphCategory.peripherality` numerically
-encodes Bybee's relevance hierarchy: lower number = closer to stem = more
-relevant. The substrate is faithful to Bybee Ch 2 §3 (p. 20-23) for the
-six core categories Bybee discusses (valence < voice < aspect < tense <
-mood < agreement). The substrate adds extensions (`derivation`, `degree`,
-`negation`, `nonfinite`) that are not part of Bybee's verbal hierarchy —
-those are flagged in `MorphRule.lean`'s docstring as linglib extensions. -/
+`MorphCategory.peripherality` (in `Morphology/MorphRule.lean`) numerically
+encodes the hierarchy — lower = closer to stem = more relevant — faithfully to
+Ch 2 §3 for the six core categories. Its extensions (`derivation`, `degree`,
+`negation`, `nonfinite`) are linglib additions, not Bybee's. -/
 
-/-- Map Bybee's category enum to the substrate's `MorphCategory`. All four
-agreement subtypes (`personAgr`, `numberAgr`, `genderAgr`, `personAgrObj`)
-collapse to `.agreement` — Bybee's verbal-number agreement belongs at the
-low-relevance (rank-8) end with person and gender, *not* with nominal
-`.number` (rank 3, "number marking on nouns"). Subject vs object agreement
-is preserved via the controller role. -/
+/-- Embed `BybeeCategory` into the substrate `MorphCategory`. All four agreement
+subtypes collapse to `.agreement`: Bybee's verbal-number agreement sits at the
+low-relevance (rank-8) end with person and gender, *not* with nominal `.number`
+(rank 3). Subject vs object is preserved via the controller role. -/
 def toMorphCategory : BybeeCategory → MorphCategory
   | .valence       => .valence
   | .voice         => .voice
@@ -255,11 +226,8 @@ def toMorphCategory : BybeeCategory → MorphCategory
   | .personAgrObj  => .agreement .obj
   | .genderAgr     => .agreement .subj
 
-/-- The substrate's relevance order is **strictly increasing** along the six
-categories Bybee discusses in Ch 2 §3 (one agreement sub-type stands for the
-collapsed agreement rank). In other words, the substrate faithfully reproduces
-Bybee's high-relevance-end ordering:
-valence < voice < aspect < tense < mood < agreement. -/
+/-- The substrate relevance order is strictly increasing along the six Ch 2 §3
+categories: it reproduces valence < voice < aspect < tense < mood < agreement. -/
 theorem substrate_matches_bybee_hierarchy :
     List.Pairwise MorphCategory.RelevanceLT
       ([BybeeCategory.valence, .voice, .aspect, .tense, .mood, .personAgr].map
@@ -277,13 +245,11 @@ theorem orderPairs_consistent_with_substrate :
 
 /-! ### Grounding the hierarchy in the survey
 
-The substrate's relevance order (`MorphCategory.RelevanceLT`, realized by the
-`peripherality` rank) is, on the four categories Bybee surveyed in Ch 2 §6
-(aspect, tense, mood, person), not a free choice. `SurveyedCloser` — the
-dominance order *derived from* `orderPairs` — coincides with it via
-`toMorphCategory` (`survey_order_iso_relevance`). So a consumer's
-`RespectsRelevanceHierarchy` check over these categories is grounded in Bybee's
-evidence by an order isomorphism, not by trust in a stipulated table. -/
+On the four categories Bybee surveyed (aspect, tense, mood, person), the
+substrate order is not a free choice: `SurveyedCloser`, derived from
+`orderPairs`, coincides with `RelevanceLT` via `toMorphCategory`
+(`survey_order_iso_relevance`). So a `RespectsRelevanceHierarchy` check over
+these categories rests on an order isomorphism, not a stipulated table. -/
 
 /-- `a` is *surveyed closer to the stem than* `b` when some tested Ch 2 §6 pair
 predicts `a` closer than `b` and the language counts confirm that direction
@@ -320,31 +286,26 @@ theorem surveyedCloser_total : ∀ a b : BybeeCategory,
     Surveyed a → Surveyed b → a ≠ b → SurveyedCloser a b ∨ SurveyedCloser b a := by
   decide
 
-/-- **Grounding theorem.** The substrate's relevance order *strictly* honors
-every confirmed §6 dominance: whenever the survey places `a` closer than `b`,
-the substrate ranks `a` strictly more stem-relevant. So `toMorphCategory` is a
-strictly monotone map from the surveyed order into the relevance order. -/
+/-- Grounding theorem: whenever the survey places `a` closer than `b`, the
+substrate ranks `a` strictly more stem-relevant — so `toMorphCategory` is
+strictly monotone from the surveyed order into the relevance order. -/
 theorem relevance_honors_survey : ∀ a b : BybeeCategory,
     SurveyedCloser a b →
       (toMorphCategory a).RelevanceLT (toMorphCategory b) := by
   decide
 
-/-- **Order isomorphism.** On the categories Bybee surveyed in Ch 2 §6, the
-data-derived `SurveyedCloser` order and the substrate's `RelevanceLT` order
-*coincide* via `toMorphCategory`: each holds exactly when the other does. The
-substrate hierarchy, restricted to the surveyed categories, is not merely
-consistent with Bybee's evidence — it *is* the order the §6 survey determines.
-This is the structural grounding the stipulated table only gestured at. -/
+/-- Order isomorphism: on the surveyed categories, `SurveyedCloser` and the
+substrate `RelevanceLT` coincide via `toMorphCategory`. The hierarchy there is
+not merely consistent with Bybee's evidence — it *is* the order the §6 survey
+determines. -/
 theorem survey_order_iso_relevance : ∀ a b : BybeeCategory,
     Surveyed a → Surveyed b →
       (SurveyedCloser a b ↔ (toMorphCategory a).RelevanceLT (toMorphCategory b)) := by
   decide
 
-/-- The canonical stem-outward ordering of the surveyed categories. Written as
-a literal but *validated against the data* below: it is fully sorted by
-`SurveyedCloser` (`bybeeSurveyedOrder_sorted`) and lists exactly the surveyed
-categories without repeats (`bybeeSurveyedOrder_complete`, `_nodup`), hence the
-unique enumeration the §6 survey forces. -/
+/-- The stem-outward ordering of the surveyed categories — a literal, but
+validated below as fully `SurveyedCloser`-sorted (`bybeeSurveyedOrder_sorted`)
+and exactly the surveyed categories without repeats (`_complete`, `_nodup`). -/
 def bybeeSurveyedOrder : List BybeeCategory :=
   [.aspect, .tense, .mood, .personAgr]
 
@@ -356,10 +317,9 @@ theorem bybeeSurveyedOrder_complete : ∀ c : BybeeCategory,
 
 theorem bybeeSurveyedOrder_nodup : bybeeSurveyedOrder.Nodup := by decide
 
-/-- The surveyed order, mapped to substrate categories — exposed for consumers
-(`HahnDegenFutrell2021Morphology`, `Karlsson2017`, `RathiHahnFutrell2026`) to
-check their slot orders against Bybee's surveyed evidence rather than
-re-asserting the hierarchy. -/
+/-- The surveyed order mapped to substrate categories — exposed so consumers
+(`HahnDegenFutrell2021Morphology`, `Karlsson2017`, `RathiHahnFutrell2026`) check
+their slot orders against the survey rather than re-asserting the hierarchy. -/
 def bybeeSurveyedSlots : List MorphCategory :=
   bybeeSurveyedOrder.map toMorphCategory
 
@@ -368,43 +328,29 @@ the loop between Bybee's §6 evidence and `RespectsRelevanceHierarchy`. -/
 theorem bybeeSurveyedSlots_respects_hierarchy :
     RespectsRelevanceHierarchy bybeeSurveyedSlots := by decide
 
-/-! ### Ch 5 dynamic network model — derived from English Fragment -/
+/-! ### Ch 5 dynamic network, derived from the English Fragment
 
-/-! Bybee Ch 5 §8 (p. 124) illustrates the network architecture with
-the Spanish *dormir* paradigm: three stem allomorphs (`dwerm`, `dorm`,
-`durmy`) connected by morphological relations across persons/numbers/
-tenses. We use the English irregular verb *eat/ate/eaten* as a smaller
-instance — but rather than declaring fabricated `LexicalEntry` strings,
-we **derive** the network from the actual `eat : VerbEntry` in
-`Fragments/English/Predicates/Verbal.lean`. Per CLAUDE.md "derive don't
-duplicate": changing `eat.formPast` in the Fragment automatically
-updates this network; the connection between Fragment data and
-Bybee-network claims is true by construction.
-
-Token frequencies default to 0 in the bridge — Bybee's verified per-
-lexeme counts (Francis & Kučera 1982) live in
-`Morphology/UsageBased/Network.lean`'s `strongStillStrong`
-/ `strongRegularized` datasets, which support its Ch 5 §6 irregularity-
-vs-frequency theorem `strong_verbs_higher_frequency_than_regularized`
-(Bybee p. 120, counts across Sweet's Anglo Saxon Primer Class I/II/VII). -/
+Bybee Ch 5 §8 illustrates the network architecture with the Spanish *dormir*
+paradigm. We use English *eat/ate/eaten* and, rather than stipulating
+`LexicalEntry` strings, **derive** the network from `eat : VerbEntry` in
+`Fragments/English/Predicates/Verbal.lean`: changing `eat.formPast` there
+updates the network (CLAUDE.md "derive, don't duplicate"). Token frequencies
+default to 0; Bybee's verified counts (Francis & Kučera 1982) live in
+`Morphology/UsageBased/Network.lean`. -/
 
 open Morphology.UsageBased
 open English.Predicates.Verbal
 
-/-- Extract a verb's five inflected forms as Bybee `LexicalEntry`
-    instances. Token frequencies default to 0; the Fragment doesn't
-    carry per-form frequencies. -/
+/-- A verb's five inflected forms as Bybee `LexicalEntry` instances (token
+frequencies default to 0; the Fragment carries none). -/
 def verbToLexicalEntries (v : VerbEntry) : List (LexicalEntry Unit) :=
   [⟨v.form, (), 0⟩, ⟨v.form3sg, (), 0⟩, ⟨v.formPast, (), 0⟩,
    ⟨v.formPastPart, (), 0⟩, ⟨v.formPresPart, (), 0⟩]
 
-/-- Construct the Bybee network of a verb's paradigm from its Fragment
-    `VerbEntry`. All inflected forms receive pairwise semantic
-    connections (they share the verb's meaning, modulated by tense/
-    aspect/agreement). Pairwise phonological connections approximate
-    Bybee's "shared phonological skeleton" relation; a real
-    similarity metric would gate this more selectively (e.g. eat/ate
-    share /e_t/ but not /eating/ proper). -/
+/-- The Bybee network of a verb's paradigm, built from its Fragment `VerbEntry`.
+Every form pair gets a semantic edge (shared meaning) and a phonological edge —
+the latter approximating Bybee's "shared phonological skeleton"; a real
+similarity metric would gate it more selectively. -/
 def verbToBybeeNetwork (v : VerbEntry) : Network Unit :=
   let entries := verbToLexicalEntries v
   let forms := entries.map (·.form)
@@ -414,42 +360,31 @@ def verbToBybeeNetwork (v : VerbEntry) : Network Unit :=
     [⟨a, b, .semantic⟩, ⟨a, b, .phonological⟩])
   { entries := entries, connections := connections }
 
-/-- The Bybee network of the English irregular verb *eat* — derived
-    from the Fragment, NOT stipulated. -/
+/-- The network of the English irregular *eat*, derived from the Fragment. -/
 def eatNetwork : Network Unit := verbToBybeeNetwork eat
 
-/-- Sanity check: *eat*'s past form is present in the network as an entry,
-    derived from the Fragment's `eat.formPast` field (no string literal).
-    If `eat.formPast` changed in `Verbal.lean`, the `decide` tracks the
-    new value. -/
+/-- Sanity check: *eat*'s past form appears as a network entry, read off
+`eat.formPast` (no string literal), so `decide` tracks that field. -/
 theorem eat_past_in_network :
     ∃ e ∈ eatNetwork.entries, e.form = eat.formPast := by decide
 
-/-- **Caveat on these relation theorems.** `verbToBybeeNetwork` connects
-    *every* pair of paradigm forms with both a semantic and a phonological
-    edge, so `HasMorphologicalRelation` holds for any two distinct forms of
-    the same verb by construction — it does not yet apply a real
-    shared-phonological-skeleton gate (see `verbToBybeeNetwork`). What the
-    theorems below genuinely test is that the network is *built from the
-    Fragment*: the related forms are `eat`'s actual fields (no string
-    literals), and a form outside the paradigm is correctly unrelated.
+/-- *eat* and its past form are morphologically related (Ch 5 §5), derived from
+`eat.formPast` rather than a literal.
 
-    *eat* and its past form bear a morphological relation (parallel
-    semantic + phonological connections, Ch 5 §5 p. 118), derived from
-    `eat`'s Fragment fields — if `eat.formPast` changed, the statement
-    would refer to the new value. -/
+Caveat: `verbToBybeeNetwork` connects *every* paradigm-form pair, so this holds
+for any two distinct forms by construction — there is no shared-skeleton gate
+yet. What the theorems here test is that the network is built from the Fragment
+and that a non-paradigm form is correctly unrelated. -/
 theorem eat_form_related_to_past_form :
     eatNetwork.HasMorphologicalRelation eat.form eat.formPast := by decide
 
-/-- *eat* and its past-participle form are likewise related, again derived
-    from the Fragment (`eat.formPastPart`) rather than a literal. -/
+/-- *eat* and its past-participle form are likewise related, derived from
+`eat.formPastPart`. -/
 theorem eat_form_related_to_pastPart_form :
     eatNetwork.HasMorphologicalRelation eat.form eat.formPastPart := by decide
 
-/-- Negative rejection test: a form outside *eat*'s paradigm bears no
-    morphological relation to it. The relation genuinely requires both
-    endpoints to be connected forms in the network — it is not vacuously
-    true of arbitrary string pairs. -/
+/-- Negative test: a form outside *eat*'s paradigm bears no relation to it — the
+relation is not vacuously true of arbitrary string pairs. -/
 theorem eat_unrelated_to_nonparadigm_form :
     ¬ eatNetwork.HasMorphologicalRelation eat.form "swim" := by decide
 

--- a/Linglib/Studies/HahnDegenFutrell2021Morphology.lean
+++ b/Linglib/Studies/HahnDegenFutrell2021Morphology.lean
@@ -1,5 +1,7 @@
 import Linglib.Processing.MemorySurprisal.Basic
 import Linglib.Fragments.Japanese.Predicates
+import Linglib.Fragments.Japanese.Morph
+import Linglib.Fragments.Sesotho.Morph
 import Linglib.Morphology.MorphRule
 import Linglib.Studies.Bybee1985
 
@@ -58,30 +60,15 @@ open Morphology (MorphCategory RespectsRelevanceHierarchy)
 
 /-! ### Japanese verb suffixes
 
-From SI §4.1, ordered from stem outward. The numbering follows
-[kaiser-yamamoto-2013] and the UD segmentation used in the paper.
+SI §4.1's Japanese suffix order ([kaiser-yamamoto-2013], UD segmentation) is the
+language's affix template, so it lives as Fragment data in
+`Fragments/Japanese/Morph.lean` (`Japanese.verbAffixTemplate`); here we derive
+the slot list from it rather than re-typing it. -/
 
-| Slot | Category | Morpheme | Example |
-|------|----------|----------|---------|
-| 1 | derivation | -su (suru) | derives verbs from Sino-Japanese |
-| 2 | valence | -(s)ase | causative |
-| 3 | voice | -are, -rare | passive/potential |
-| 4 | mood | -ta (desiderative) | "want to" |
-| 5 | agreement | -mas | politeness |
-| 6 | negation | -na | negation |
-| 7 | tense | -ta (past), -yoo | past/future |
--/
-
-/-- Japanese suffix slots from stem outward (SI Table 2). -/
+/-- Japanese suffix slots from stem outward, derived from the Fragment template
+`Japanese.verbAffixTemplate` (SI §4.1, [kaiser-yamamoto-2013]). -/
 def japaneseSuffixSlots : List MorphCategory :=
-  [ .derivation   -- 1. -su (suru)
-  , .valence      -- 2. -(s)ase (causative)
-  , .voice        -- 3. -are, -rare (passive/potential)
-  , .mood         -- 4. -ta (desiderative)
-  , .agreement .subj    -- 5. -mas (politeness, treated as subj agreement)
-  , .negation     -- 6. -na (negation)
-  , .tense        -- 7. -ta, -yoo (past/future)
-  ]
+  Japanese.verbAffixTemplate.suffixSlots
 
 /-- Japanese suffix order respects Bybee's hierarchy through the mood slot:
 derivation < valence < voice < mood. Beyond mood the order *breaks* —
@@ -110,48 +97,19 @@ theorem japanese_violates_surveyed_relevance :
 
 /-! ### Sesotho verb affixes
 
-From SI §4.2 and [demuth-1992], [doke-mofokeng-1967].
+SI §4.2's Sesotho affix order ([demuth-1992], [doke-mofokeng-1967]) lives as
+Fragment data in `Fragments/Sesotho/Morph.lean` (`Sesotho.verbAffixTemplate`);
+the slot lists below are derived from it. -/
 
-**Prefixes** (from word edge inward toward stem):
-1. Subject agreement (sm)
-2. Negation (-sa-)
-3. Tense/Aspect/Mood (t')
-4. Object agreement (om) / Reflexive (rf)
-
-**Suffixes** (from stem outward):
-1. Reversive (rv) — valence
-2. Causative (c) — valence
-3. Neuter (nt) — valence
-4. Applicative (ap) — valence
-5. Completive (cl) — valence (reduplication of applicative)
-6. Reciprocal (rc) — voice
-7. Passive (p) — voice
-8. Tense (t^) — tense (perfect -il-)
-9. Mood (m^) — mood (imperative, subjunctive, indicative)
-10. Interrogative/Relative (wh/rl) — nonfinite
--/
-
-/-- Sesotho suffix template: morpheme categories from stem outward (SI §4.2). -/
+/-- Sesotho suffix template, stem-outward, from the Fragment
+`Sesotho.verbAffixTemplate` (SI §4.2). -/
 def sesothoSuffixSlots : List MorphCategory :=
-  [ .valence      -- 1. reversive
-  , .valence      -- 2. causative
-  , .valence      -- 3. neuter
-  , .valence      -- 4. applicative
-  , .valence      -- 5. completive (applicative reduplication)
-  , .voice        -- 6. reciprocal
-  , .voice        -- 7. passive
-  , .tense        -- 8. perfect (-il-)
-  , .mood         -- 9. imperative/subjunctive/indicative
-  , .nonfinite    -- 10. interrogative/relative
-  ]
+  Sesotho.verbAffixTemplate.suffixSlots
 
-/-- Sesotho prefix template: morpheme categories from word edge inward. -/
+/-- Sesotho prefix template, word-edge inward, from the Fragment
+`Sesotho.verbAffixTemplate`. -/
 def sesothoPrefixSlots : List MorphCategory :=
-  [ .agreement .subj    -- 1. subject agreement
-  , .negation     -- 2. negation
-  , .tense        -- 3. tense/aspect/mood
-  , .agreement .obj    -- 4. object agreement
-  ]
+  Sesotho.verbAffixTemplate.prefixSlots
 
 /-- Sesotho suffixes respect the relevance hierarchy
 (valence < voice < tense < mood < nonfinite) — sorted by the substrate


### PR DESCRIPTION
New `Morphology.AffixTemplate` lets per-language verb affix orders live as Fragment data instead of hand-typed lists in study files.

- `Fragments/Japanese/Morph.lean` + new `Fragments/Sesotho/Morph.lean`: `verbAffixTemplate` slot orders with grammar provenance.
- `Studies/HahnDegenFutrell2021Morphology`: slot lists now derive from the fragments; theorems unchanged.
- Also tidies `Studies/Bybee1985` docstrings to mathlib style.