### PR TITLE
feat(Studies/LiuRotter2025): force-indexed concord sign, real data

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2923,5 +2923,6 @@ import Linglib.Tactics.RSAPredict.ReflectBridge
 import Linglib.Tactics.RSAPredict.Reify
 import Linglib.Data.Examples.Guerrini2026
 import Linglib.Data.Examples.TonhauserBeaverDegen2018
+import Linglib.Data.Examples.LiuRotter2025
 
 

--- a/Linglib/Data/Examples/LiuRotter2025.json
+++ b/Linglib/Data/Examples/LiuRotter2025.json
@@ -1,0 +1,134 @@
+[
+ {
+  "id": "liurotter2025_poss_sm",
+  "source": {
+   "bibkey": "liu-rotter-2025",
+   "paperLabel": "(3) possibility SM"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "I may have gotten the wrong address.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "I may have gotten the wrong address.",
+  "context": "Somebody says S; participant rates speaker commitment (Q1) and grammaticality (Q2), then rates the speaker on social-background and persona dimensions. Possibility single-modal (SM) cell of the 2x2 FORCE x NUMBER design.",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   ["force", "possibility"],
+   ["number", "SM"],
+   ["commitment", "522"],
+   ["grammaticality", "645"],
+   ["ses", "487"],
+   ["education", "494"],
+   ["formality", "484"],
+   ["politeness", "545"],
+   ["confidence", "436"],
+   ["friendliness", "503"],
+   ["warmth", "494"],
+   ["coolness", "456"],
+   ["rebelliousness", "309"]
+  ],
+  "comment": "Cell means (x100) from Table 1, n=541 trials. Likert 1-7. Commitment=interpretation (Q1) M=5.22 SD=0.98; grammaticality M=6.45 SD=1.09; SES M=4.87 SD=1.11; education M=4.94 SD=1.12; formality M=4.84 SD=1.38; politeness M=5.45 SD=1.11; confidence M=4.36 SD=1.51; friendliness M=5.03 SD=1.14; warmth M=4.94 SD=1.16; coolness M=4.56 SD=1.27; rebelliousness M=3.09 SD=1.34. Data: osf.io/47rkg."
+ },
+ {
+  "id": "liurotter2025_poss_mc",
+  "source": {
+   "bibkey": "liu-rotter-2025",
+   "paperLabel": "(3) possibility MC"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "I may possibly have gotten the wrong address.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "I may possibly have gotten the wrong address.",
+  "context": "Somebody says S; participant rates speaker commitment (Q1) and grammaticality (Q2), then rates the speaker on social-background and persona dimensions. Possibility modal-concord (MC) cell of the 2x2 FORCE x NUMBER design.",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   ["force", "possibility"],
+   ["number", "MC"],
+   ["commitment", "511"],
+   ["grammaticality", "506"],
+   ["ses", "473"],
+   ["education", "469"],
+   ["formality", "473"],
+   ["politeness", "536"],
+   ["confidence", "403"],
+   ["friendliness", "492"],
+   ["warmth", "482"],
+   ["coolness", "429"],
+   ["rebelliousness", "311"]
+  ],
+  "comment": "Cell means (x100) from Table 1, n=542 trials. Likert 1-7. Commitment=interpretation (Q1) M=5.11 SD=0.96; grammaticality M=5.06 SD=2.05; SES M=4.73 SD=1.30; education M=4.69 SD=1.37; formality M=4.73 SD=1.61; politeness M=5.36 SD=1.17; confidence M=4.03 SD=1.61; friendliness M=4.92 SD=1.17; warmth M=4.82 SD=1.19; coolness M=4.29 SD=1.33; rebelliousness M=3.11 SD=1.33. Data: osf.io/47rkg."
+ },
+ {
+  "id": "liurotter2025_nece_sm",
+  "source": {
+   "bibkey": "liu-rotter-2025",
+   "paperLabel": "(3) necessity SM"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "I must have gotten the wrong address.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "I must have gotten the wrong address.",
+  "context": "Somebody says S; participant rates speaker commitment (Q1) and grammaticality (Q2), then rates the speaker on social-background and persona dimensions. Necessity single-modal (SM) cell of the 2x2 FORCE x NUMBER design.",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   ["force", "necessity"],
+   ["number", "SM"],
+   ["commitment", "612"],
+   ["grammaticality", "641"],
+   ["ses", "487"],
+   ["education", "489"],
+   ["formality", "476"],
+   ["politeness", "528"],
+   ["confidence", "519"],
+   ["friendliness", "497"],
+   ["warmth", "486"],
+   ["coolness", "453"],
+   ["rebelliousness", "312"]
+  ],
+  "comment": "Cell means (x100) from Table 1, n=539 trials. Likert 1-7. Commitment=interpretation (Q1) M=6.12 SD=0.85; grammaticality M=6.41 SD=1.16; SES M=4.87 SD=1.18; education M=4.89 SD=1.19; formality M=4.76 SD=1.40; politeness M=5.28 SD=1.15; confidence M=5.19 SD=1.39; friendliness M=4.97 SD=1.15; warmth M=4.86 SD=1.17; coolness M=4.53 SD=1.27; rebelliousness M=3.12 SD=1.36. Data: osf.io/47rkg."
+ },
+ {
+  "id": "liurotter2025_nece_mc",
+  "source": {
+   "bibkey": "liu-rotter-2025",
+   "paperLabel": "(3) necessity MC"
+  },
+  "reportedIn": null,
+  "language": "stan1293",
+  "primaryText": "I must certainly have gotten the wrong address.",
+  "discourseSegments": [],
+  "glossedTokens": [],
+  "translation": "I must certainly have gotten the wrong address.",
+  "context": "Somebody says S; participant rates speaker commitment (Q1) and grammaticality (Q2), then rates the speaker on social-background and persona dimensions. Necessity modal-concord (MC) cell of the 2x2 FORCE x NUMBER design.",
+  "judgment": "acceptable",
+  "alternatives": [],
+  "readings": [],
+  "paperFeatures": [
+   ["force", "necessity"],
+   ["number", "MC"],
+   ["commitment", "640"],
+   ["grammaticality", "490"],
+   ["ses", "485"],
+   ["education", "480"],
+   ["formality", "499"],
+   ["politeness", "539"],
+   ["confidence", "548"],
+   ["friendliness", "476"],
+   ["warmth", "462"],
+   ["coolness", "420"],
+   ["rebelliousness", "304"]
+  ],
+  "comment": "Cell means (x100) from Table 1, n=536 trials. Likert 1-7. Commitment=interpretation (Q1) M=6.40 SD=0.90; grammaticality M=4.90 SD=2.18; SES M=4.85 SD=1.40; education M=4.80 SD=1.46; formality M=4.99 SD=1.66; politeness M=5.39 SD=1.16; confidence M=5.48 SD=1.41; friendliness M=4.76 SD=1.21; warmth M=4.62 SD=1.25; coolness M=4.20 SD=1.32; rebelliousness M=3.04 SD=1.34. Data: osf.io/47rkg."
+ }
+]

--- a/Linglib/Data/Examples/LiuRotter2025.lean
+++ b/Linglib/Data/Examples/LiuRotter2025.lean
@@ -1,0 +1,90 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `LiuRotter2025` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/LiuRotter2025.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace LiuRotter2025.Examples`.
+-/
+
+namespace LiuRotter2025.Examples
+
+open Data.Examples
+
+def poss_sm : LinguisticExample :=
+  { id := "liurotter2025_poss_sm"
+    source := ⟨"liu-rotter-2025", "(3) possibility SM"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I may have gotten the wrong address."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I may have gotten the wrong address."
+    context := "Somebody says S; participant rates speaker commitment (Q1) and grammaticality (Q2), then rates the speaker on social-background and persona dimensions. Possibility single-modal (SM) cell of the 2x2 FORCE x NUMBER design."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("force", "possibility"), ("number", "SM"), ("commitment", "522"), ("grammaticality", "645"), ("ses", "487"), ("education", "494"), ("formality", "484"), ("politeness", "545"), ("confidence", "436"), ("friendliness", "503"), ("warmth", "494"), ("coolness", "456"), ("rebelliousness", "309")]
+    comment := "Cell means (x100) from Table 1, n=541 trials. Likert 1-7. Commitment=interpretation (Q1) M=5.22 SD=0.98; grammaticality M=6.45 SD=1.09; SES M=4.87 SD=1.11; education M=4.94 SD=1.12; formality M=4.84 SD=1.38; politeness M=5.45 SD=1.11; confidence M=4.36 SD=1.51; friendliness M=5.03 SD=1.14; warmth M=4.94 SD=1.16; coolness M=4.56 SD=1.27; rebelliousness M=3.09 SD=1.34. Data: osf.io/47rkg."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def poss_mc : LinguisticExample :=
+  { id := "liurotter2025_poss_mc"
+    source := ⟨"liu-rotter-2025", "(3) possibility MC"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I may possibly have gotten the wrong address."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I may possibly have gotten the wrong address."
+    context := "Somebody says S; participant rates speaker commitment (Q1) and grammaticality (Q2), then rates the speaker on social-background and persona dimensions. Possibility modal-concord (MC) cell of the 2x2 FORCE x NUMBER design."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("force", "possibility"), ("number", "MC"), ("commitment", "511"), ("grammaticality", "506"), ("ses", "473"), ("education", "469"), ("formality", "473"), ("politeness", "536"), ("confidence", "403"), ("friendliness", "492"), ("warmth", "482"), ("coolness", "429"), ("rebelliousness", "311")]
+    comment := "Cell means (x100) from Table 1, n=542 trials. Likert 1-7. Commitment=interpretation (Q1) M=5.11 SD=0.96; grammaticality M=5.06 SD=2.05; SES M=4.73 SD=1.30; education M=4.69 SD=1.37; formality M=4.73 SD=1.61; politeness M=5.36 SD=1.17; confidence M=4.03 SD=1.61; friendliness M=4.92 SD=1.17; warmth M=4.82 SD=1.19; coolness M=4.29 SD=1.33; rebelliousness M=3.11 SD=1.33. Data: osf.io/47rkg."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def nece_sm : LinguisticExample :=
+  { id := "liurotter2025_nece_sm"
+    source := ⟨"liu-rotter-2025", "(3) necessity SM"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I must have gotten the wrong address."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I must have gotten the wrong address."
+    context := "Somebody says S; participant rates speaker commitment (Q1) and grammaticality (Q2), then rates the speaker on social-background and persona dimensions. Necessity single-modal (SM) cell of the 2x2 FORCE x NUMBER design."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("force", "necessity"), ("number", "SM"), ("commitment", "612"), ("grammaticality", "641"), ("ses", "487"), ("education", "489"), ("formality", "476"), ("politeness", "528"), ("confidence", "519"), ("friendliness", "497"), ("warmth", "486"), ("coolness", "453"), ("rebelliousness", "312")]
+    comment := "Cell means (x100) from Table 1, n=539 trials. Likert 1-7. Commitment=interpretation (Q1) M=6.12 SD=0.85; grammaticality M=6.41 SD=1.16; SES M=4.87 SD=1.18; education M=4.89 SD=1.19; formality M=4.76 SD=1.40; politeness M=5.28 SD=1.15; confidence M=5.19 SD=1.39; friendliness M=4.97 SD=1.15; warmth M=4.86 SD=1.17; coolness M=4.53 SD=1.27; rebelliousness M=3.12 SD=1.36. Data: osf.io/47rkg."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def nece_mc : LinguisticExample :=
+  { id := "liurotter2025_nece_mc"
+    source := ⟨"liu-rotter-2025", "(3) necessity MC"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I must certainly have gotten the wrong address."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I must certainly have gotten the wrong address."
+    context := "Somebody says S; participant rates speaker commitment (Q1) and grammaticality (Q2), then rates the speaker on social-background and persona dimensions. Necessity modal-concord (MC) cell of the 2x2 FORCE x NUMBER design."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("force", "necessity"), ("number", "MC"), ("commitment", "640"), ("grammaticality", "490"), ("ses", "485"), ("education", "480"), ("formality", "499"), ("politeness", "539"), ("confidence", "548"), ("friendliness", "476"), ("warmth", "462"), ("coolness", "420"), ("rebelliousness", "304")]
+    comment := "Cell means (x100) from Table 1, n=536 trials. Likert 1-7. Commitment=interpretation (Q1) M=6.40 SD=0.90; grammaticality M=4.90 SD=2.18; SES M=4.85 SD=1.40; education M=4.80 SD=1.46; formality M=4.99 SD=1.66; politeness M=5.39 SD=1.16; confidence M=5.48 SD=1.41; friendliness M=4.76 SD=1.21; warmth M=4.62 SD=1.25; coolness M=4.20 SD=1.32; rebelliousness M=3.04 SD=1.34. Data: osf.io/47rkg."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [poss_sm, poss_mc, nece_sm, nece_mc]
+
+end LiuRotter2025.Examples

--- a/Linglib/Studies/LiuRotter2025.lean
+++ b/Linglib/Studies/LiuRotter2025.lean
@@ -1,395 +1,217 @@
 import Linglib.Semantics.Modality.ModalTypes
-import Linglib.Studies.RotterLiu2025Concord
 import Linglib.Fragments.English.Auxiliaries
+import Linglib.Data.Examples.LiuRotter2025
+import Mathlib.Data.Sign.Defs
+import Mathlib.Algebra.Order.Field.Rat
 
 /-!
-# Modal Concord: Commitment and Social Meaning — [liu-rotter-2025]
-[liu-rotter-2025] [rotter-liu-2025] [zeijlstra-2007]
+# [liu-rotter-2025]: Linguistic and Social Meaning Match — modal concord
 
-Experimental data and analysis from "Non-redundant modal concord: Evidence
-from speaker commitment and social meaning" [liu-rotter-2025].
+Modal concord (MC) doubles two modal elements of the same force and flavor
+(*may possibly*, *must certainly*). The semantic-vacuity account
+([zeijlstra-2007]) treats one element as uninterpretable, so MC and the single
+modal (SM) should be truth-conditionally identical. [liu-rotter-2025] tests this
+in one 2×2 (FORCE × NUMBER) Latin-square experiment (93 of 104 US-English
+participants, Prolific) and finds MC is **not** vacuous: doubling *strengthens*
+speaker commitment for necessity but *weakens* it for possibility — a
+FORCE × NUMBER crossover (interaction β̂ = −1.85, χ²(1) = 41.51, p < .001;
+necessity sub-effect β̂ = +1.50, possibility β̂ = −0.35). The concord effect is
+thus a **sign indexed by force**, supporting the modal-spread analysis
+([giannakidou-mari-2018]).
 
-Modal concord (MC) is **not semantically vacuous**: necessity MC (*must
-certainly*) strengthens speaker commitment, while possibility MC (*may
-possibly*) weakens it. This FORCE × NUMBER interaction is not predicted by
-syntactic agreement, semantic identity, or the register approach. MC also
-carries social meaning mirroring the commitment direction: necessity MC
-signals competence, possibility MC signals warmth.
+This file formalizes that structure, not the regression tables: the effect of
+concord as a force-indexed `SignType`, the crossover as the property that
+distinguishes the spread account from vacuity, and the data as a sign-prediction
+target.
 
-* **Experiment 1** (n=160): 2 (FORCE: necessity/possibility) × 2 (NUMBER:
-  single/concord) between-subjects. DV: speaker commitment (7-point Likert).
-  Stimuli: *must/should/have to VP* vs *must certainly/should definitely/
-  have to necessarily VP*; *may/might/could VP* vs *may possibly/might
-  perhaps/could potentially VP*.
-* **Experiment 2** (n=160): same design. DVs: 7 social meaning dimensions.
-* **Section A**: each aux-adverb stimulus pair shares modal force when
-  projected to `ModalItem` — the structural precondition for concord.
-* **Section B**: modal force predicts the commitment direction.
-* **Section C**: connection to [rotter-liu-2025] — both studies find that
-  MC preserves modal force (single reading, not double).
-* **Section D**: modal concord as an instance of the general concord
-  pattern; possibility MC patterns with negative concord (solidarity),
-  necessity MC contrasts (competence).
+## Main definitions
+* `spreadEffect` — [giannakidou-mari-2018]'s account: the force-indexed sign of
+  the concord effect on commitment (+ for necessity, − for possibility).
+* `vacuityEffect` — [zeijlstra-2007]'s rival: the null effect, force-blind.
+* `warmthEffect` — the force-blind MC warmth penalty (a second, distinct profile).
+* `ShiftObservation`, `accountErrs` — score an account against the observed
+  MC − SM shift in `Data.Examples.LiuRotter2025`.
+
+## Main results
+* `spread_crossover` — the FORCE × NUMBER interaction as a sign reversal.
+* `spread_nonvacuous`, `spread_refutes_vacuity` — MC is non-vacuous; a sign that
+  reverses with force cannot be the agreement account's force-blind null.
+* `warmth_ne_spread` — the warmth penalty is constant across force, so it is a
+  NUMBER main effect, not the commitment crossover.
+* `vacuity_errs_on_shift` — vacuity errs on every cell with a real shift.
+
+## Implementation notes
+The effect of concord is a `SignType` (the magnitude is a model estimate, not a
+formal commitment); the rival accounts are `ModalForce → SignType`. Cell means
+live in `Data.Examples.LiuRotter2025` (×100, on the 1–7 scale); they do not
+reduce in the kernel (string-keyed `paperFeatures`, `ℚ` comparison), so concrete
+shifts are *computed* via `#eval` while the kernel-checkable content is each
+account's systematic error.
 -/
 
 namespace LiuRotter2025
 
-open RotterLiu2025Concord (LikertRating)
+open Semantics.Modality (ModalForce ModalItem)
 open English.Auxiliaries
-open Semantics.Modality (ModalForce ModalItem ConcordType ConcordType.fromModalForce)
-open Features.Register (SocialIndex)
+open Data.Examples (LinguisticExample)
 
-/-! ## Experimental design -/
+/-! ### The concord effect as a force-indexed sign -/
 
-/-- NUMBER factor: single modal vs modal concord (doubled). -/
-inductive Doubling where
-  | single   -- bare modal auxiliary
-  | concord  -- modal auxiliary + modal adverb
-  deriving DecidableEq, Repr
+/-- The modal-spread account ([giannakidou-mari-2018]): the modal adverb in an MC
+    construction is not vacuous; doubling reinforces the force, raising speaker
+    commitment for necessity (∀) and lowering it for possibility (∃). -/
+def spreadEffect : ModalForce → SignType
+  | .necessity     => 1
+  | .weakNecessity => 1
+  | .possibility   => -1
 
-/-- Experimental condition: FORCE × NUMBER. -/
-structure Condition where
-  force : ModalForce
-  doubling : Doubling
-  deriving DecidableEq, Repr
+/-- The semantic-vacuity / syntactic-agreement account ([zeijlstra-2007]): one
+    modal carries an uninterpretable feature and contributes no operator at LF,
+    so MC and SM are truth-conditionally identical — concord has no commitment
+    effect, whatever the force. -/
+def vacuityEffect : ModalForce → SignType := fun _ => 0
 
-def necSM : Condition := ⟨.necessity, .single⟩
-def necMC : Condition := ⟨.necessity, .concord⟩
-def posSM : Condition := ⟨.possibility, .single⟩
-def posMC : Condition := ⟨.possibility, .concord⟩
+@[simp] theorem spreadEffect_necessity : spreadEffect .necessity = 1 := rfl
+@[simp] theorem spreadEffect_possibility : spreadEffect .possibility = -1 := rfl
+@[simp] theorem vacuityEffect_apply (f : ModalForce) : vacuityEffect f = 0 := rfl
 
-/-! ## Experiment 1: Speaker commitment
+/-- The FORCE × NUMBER interaction: the concord effect reverses sign with force. -/
+theorem spread_crossover : spreadEffect .necessity ≠ spreadEffect .possibility := by decide
 
-160 participants (40 per condition) rated speaker commitment on a
-7-point Likert scale ("How certain is the speaker that...").
+/-- MC is semantically non-vacuous: concord shifts commitment under both forces. -/
+theorem spread_nonvacuous :
+    spreadEffect .necessity ≠ 0 ∧ spreadEffect .possibility ≠ 0 := by decide
 
-FORCE × NUMBER interaction: β = 0.56, SE = 0.17, t = 3.31, p = .001. -/
+/-- Vacuity predicts no interaction: the (null) effect is the same for every force. -/
+theorem vacuity_no_interaction (f g : ModalForce) : vacuityEffect f = vacuityEffect g := rfl
 
-/-- Speaker commitment ratings (7-point Likert, 1=not at all certain,
-    7=completely certain). -/
-def commitmentRating : Condition → LikertRating
-  | ⟨.necessity, .single⟩      => ⟨449/100, 131/100⟩  -- M=4.49, SD=1.31
-  | ⟨.necessity, .concord⟩     => ⟨499/100, 121/100⟩  -- M=4.99, SD=1.21
-  | ⟨.weakNecessity, .single⟩  => ⟨449/100, 131/100⟩  -- not tested separately
-  | ⟨.weakNecessity, .concord⟩ => ⟨499/100, 121/100⟩  -- not tested separately
-  | ⟨.possibility, .single⟩    => ⟨384/100, 138/100⟩  -- M=3.84, SD=1.38
-  | ⟨.possibility, .concord⟩   => ⟨337/100, 149/100⟩  -- M=3.37, SD=1.49
+/-- The crossover refutes vacuity: the spread effect disagrees with the
+    agreement account's force-blind null already at necessity (+1 vs 0). -/
+theorem spread_refutes_vacuity : spreadEffect ≠ vacuityEffect :=
+  fun h => absurd (congrFun h .necessity) (by decide)
 
-/-- **Necessity MC strengthens commitment**: *must certainly* is rated
-    higher in speaker commitment than bare *must* (p = .03). -/
-theorem necessity_mc_strengthens :
-    (commitmentRating necMC).mean > (commitmentRating necSM).mean := by
-  native_decide
+/-! ### A second profile: the warmth penalty
 
-/-- **Possibility MC weakens commitment**: *may possibly* is rated
-    lower in speaker commitment than bare *may* (p = .04). -/
-theorem possibility_mc_weakens :
-    (commitmentRating posMC).mean < (commitmentRating posSM).mean := by
-  native_decide
+Beyond commitment, the social-meaning measures split in two ([liu-rotter-2025]
+Table 5). Confidence — and, for necessity, formality — *tracks commitment*,
+showing the same force-indexed crossover (the "match" of the title: meaning
+strength and social perception move together). Friendliness, warmth, and
+coolness instead show a force-blind main effect of NUMBER: MC is rated lower
+than SM regardless of force, a uniform social cost of doubling. -/
 
-/-- **FORCE × NUMBER interaction**: The direction of the concord effect
-    reverses with force. Necessity MC strengthens, possibility MC weakens.
-    This is the paper's central finding (β = 0.56, p = .001). -/
-theorem force_number_interaction :
-    (commitmentRating necMC).mean > (commitmentRating necSM).mean ∧
-    (commitmentRating posMC).mean < (commitmentRating posSM).mean := by
-  constructor <;> native_decide
+/-- The warmth profile: a force-blind penalty. MC is perceived as less warm
+    (friendly, warm, cool) than SM under both forces — a NUMBER main effect with
+    no interaction, distinct from the commitment crossover. -/
+def warmthEffect : ModalForce → SignType := fun _ => -1
 
-/-- **MC is semantically non-vacuous**: Both necessity and possibility
-    MC differ from their single-modal counterparts. The syntactic
-    agreement approach, which treats one modal as
-    semantically vacuous, incorrectly predicts MC = SM. -/
-theorem mc_not_vacuous :
-    (commitmentRating necMC).mean ≠ (commitmentRating necSM).mean ∧
-    (commitmentRating posMC).mean ≠ (commitmentRating posSM).mean := by
-  constructor <;> native_decide
+theorem warmth_no_interaction (f g : ModalForce) : warmthEffect f = warmthEffect g := rfl
 
-/-- **Necessity above possibility**: Both SM and MC show higher
-    commitment for necessity than possibility. -/
-theorem necessity_above_possibility :
-    (commitmentRating necSM).mean > (commitmentRating posSM).mean ∧
-    (commitmentRating necMC).mean > (commitmentRating posMC).mean := by
-  constructor <;> native_decide
+theorem warmth_real_cost (f : ModalForce) : warmthEffect f ≠ 0 := by
+  show (-1 : SignType) ≠ 0; decide
 
-/-- **No main effect of NUMBER**: Grand means of SM and MC are close
-    (within 0.1 points). The concord effect appears only as an
-    interaction with FORCE (β = −0.03, p = .86). -/
-theorem no_main_effect_of_number :
-    let smMean := ((commitmentRating necSM).mean + (commitmentRating posSM).mean) / 2
-    let mcMean := ((commitmentRating necMC).mean + (commitmentRating posMC).mean) / 2
-    smMean - mcMean > -1/10 ∧ smMean - mcMean < 1/10 := by
-  constructor <;> native_decide
+/-- The warmth penalty is not the commitment crossover: it disagrees with the
+    spread effect at necessity (−1 vs +1), being constant where spread reverses. -/
+theorem warmth_ne_spread : warmthEffect ≠ spreadEffect :=
+  fun h => absurd (congrFun h .necessity) (by decide)
 
-/-! ## Experiment 2: Social meaning
+/-! ### The concord precondition in the fragment
 
-160 participants (40 per condition) rated speakers on 7 social
-dimensions (7-point Likert scale) after hearing sentences. -/
+Both MC stimulus pairs share concord-compatible force — the structural
+precondition for concord ([zeijlstra-2007]). The auxiliaries carry
+uninterpretable features in the fragment, so the agreement account's vacuous
+element is `must`/`may`; the crossover overturns its prediction that this
+element contributes nothing. -/
 
-/-- Social meaning dimensions (Experiment 2). -/
-inductive SocialDimension where
-  | ses          -- Socio-economic status
-  | education    -- Education level
-  | formality    -- Formality
-  | confidence   -- Confidence
-  | friendliness -- Friendliness
-  | warmth       -- Warmth
-  | coolness     -- Coolness
-  deriving DecidableEq, Repr
-
-/-- Competence/warmth classification.
-    Necessity MC increases competence dimensions, decreases warmth.
-    Possibility MC does the reverse. -/
-inductive DimensionClass where
-  | competence  -- Status, ability, expertise
-  | warmth      -- Sociability, friendliness
-  deriving DecidableEq, Repr
-
-/-- Classify each social dimension as competence or warmth. -/
-def SocialDimension.dimClass : SocialDimension → DimensionClass
-  | .ses          => .competence
-  | .education    => .competence
-  | .formality    => .competence
-  | .confidence   => .competence
-  | .friendliness => .warmth
-  | .warmth       => .warmth
-  | .coolness     => .competence  -- patterns with competence in the data
-
-def SocialDimension.all : List SocialDimension :=
-  [.ses, .education, .formality, .confidence, .friendliness, .warmth, .coolness]
-
-/-- FORCE × NUMBER interaction on a social dimension.
-    Positive β: necessity MC scores higher (competence pattern).
-    Negative β: necessity MC scores lower (warmth pattern). -/
-structure InteractionEffect where
-  beta : ℚ       -- Regression coefficient
-  se : ℚ         -- Standard error
-  significant : Bool  -- p < .05
-  deriving Repr, BEq
-
-/-- FORCE × NUMBER interaction results per social dimension.
-    All 7 dimensions show significant interactions (p < .05). -/
-def socialInteraction : SocialDimension → InteractionEffect
-  | .ses          => ⟨41/100,  16/100, true⟩   -- β=0.41, p=.01
-  | .education    => ⟨36/100,  15/100, true⟩   -- β=0.36, p=.02
-  | .formality    => ⟨51/100,  16/100, true⟩   -- β=0.51, p=.002
-  | .confidence   => ⟨43/100,  16/100, true⟩   -- β=0.43, p=.002
-  | .friendliness => ⟨-41/100, 16/100, true⟩   -- β=−0.41, p=.002
-  | .warmth       => ⟨-30/100, 15/100, true⟩   -- β=−0.30, p=.02
-  | .coolness     => ⟨33/100,  16/100, true⟩   -- β=0.33, p=.02
-
-/-- **All social dimensions show significant interaction**. -/
-theorem all_interactions_significant :
-    (socialInteraction .ses).significant = true ∧
-    (socialInteraction .education).significant = true ∧
-    (socialInteraction .formality).significant = true ∧
-    (socialInteraction .confidence).significant = true ∧
-    (socialInteraction .friendliness).significant = true ∧
-    (socialInteraction .warmth).significant = true ∧
-    (socialInteraction .coolness).significant = true :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
-
-/-- **Competence dimensions have positive interaction**: Necessity MC
-    increases perceived competence (SES, education, formality,
-    confidence, coolness). -/
-theorem competence_positive :
-    (socialInteraction .ses).beta > 0 ∧
-    (socialInteraction .education).beta > 0 ∧
-    (socialInteraction .formality).beta > 0 ∧
-    (socialInteraction .confidence).beta > 0 ∧
-    (socialInteraction .coolness).beta > 0 := by
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
-
-/-- **Warmth dimensions have negative interaction**: Necessity MC
-    decreases perceived warmth (friendliness, warmth). -/
-theorem warmth_negative :
-    (socialInteraction .friendliness).beta < 0 ∧
-    (socialInteraction .warmth).beta < 0 := by
-  constructor <;> native_decide
-
-/-- **Social meaning mirrors commitment**: Competence dimensions
-    have positive β (matching necessity strengthening), warmth
-    dimensions have negative β (matching possibility weakening).
-    This parallel suggests the social meaning *drives* the
-    commitment effect. -/
-theorem social_mirrors_commitment :
-    -- Competence: positive β
-    (socialInteraction .ses).beta > 0 ∧
-    (socialInteraction .education).beta > 0 ∧
-    (socialInteraction .formality).beta > 0 ∧
-    (socialInteraction .confidence).beta > 0 ∧
-    -- Warmth: negative β
-    (socialInteraction .friendliness).beta < 0 ∧
-    (socialInteraction .warmth).beta < 0 := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
-
-/-- **Formality shows the strongest interaction** among all
-    social dimensions (β = 0.51), consistent with the register
-    approach to modal concord. -/
-theorem formality_largest_competence :
-    (socialInteraction .formality).beta > (socialInteraction .ses).beta ∧
-    (socialInteraction .formality).beta > (socialInteraction .education).beta ∧
-    (socialInteraction .formality).beta > (socialInteraction .confidence).beta ∧
-    (socialInteraction .formality).beta > (socialInteraction .coolness).beta := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> native_decide
-
-/-! ## Section A: Semantic overlap via ModalItem
-
-Each aux-adverb pair from the stimuli shares concord-compatible force when
-projected to `ModalItem`. Both necessity and weak necessity map to the same
-concord class (necessity-type), so *should* (weak necessity) concords with
-*definitely* (necessity). -/
-
--- Necessity pairs
-
-/-- *must* + *certainly* share necessity-type concord force. -/
+/-- *must* + *certainly* (the necessity MC stimulus) share necessity-type force. -/
 theorem must_certainly_share :
-    must.toModalItem.sharesConcordForce certainly.toModalItem = true := by native_decide
+    must.toModalItem.sharesConcordForce certainly.toModalItem = true := by decide
 
-/-- *should* + *definitely* share necessity-type concord force.
-    *should* is weak necessity, *definitely* is strong necessity — both are
-    necessity-type for concord purposes. -/
-theorem should_definitely_share :
-    should.toModalItem.sharesConcordForce definitely.toModalItem = true := by native_decide
-
-/-- *have to* + *necessarily* share necessity-type concord force. -/
-theorem haveTo_necessarily_share :
-    haveTo.toModalItem.sharesConcordForce necessarily.toModalItem = true := by native_decide
-
--- Possibility pairs
-
-/-- *may* + *possibly* share possibility force. -/
+/-- *may* + *possibly* (the possibility MC stimulus) share possibility force. -/
 theorem may_possibly_share :
-    may.toModalItem.sharesConcordForce possibly.toModalItem = true := by native_decide
+    may.toModalItem.sharesConcordForce possibly.toModalItem = true := by decide
 
-/-- *might* + *perhaps* share possibility force. -/
-theorem might_perhaps_share :
-    might.toModalItem.sharesConcordForce perhaps.toModalItem = true := by native_decide
+/-- Zeijlstra's vacuous element: the modal auxiliaries are uninterpretable in
+    the fragment, so under the agreement account they contribute no operator. -/
+theorem stimulus_auxiliaries_uninterpretable :
+    must.interpretability = some .uninterpretable ∧
+    may.interpretability = some .uninterpretable := ⟨rfl, rfl⟩
 
-/-- *could* + *potentially* share possibility force. -/
-theorem could_potentially_share :
-    could.toModalItem.sharesConcordForce potentially.toModalItem = true := by native_decide
+/-! ### Predicting against the data
 
-/-- **All six stimulus pairs share concord-compatible force**. -/
-theorem all_pairs_share_force :
-    must.toModalItem.sharesConcordForce certainly.toModalItem = true ∧
-    should.toModalItem.sharesConcordForce definitely.toModalItem = true ∧
-    haveTo.toModalItem.sharesConcordForce necessarily.toModalItem = true ∧
-    may.toModalItem.sharesConcordForce possibly.toModalItem = true ∧
-    might.toModalItem.sharesConcordForce perhaps.toModalItem = true ∧
-    could.toModalItem.sharesConcordForce potentially.toModalItem = true := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
+The four condition cells (`Data.Examples.LiuRotter2025`) carry the Table 1 means
+(×100, on the 1–7 Likert scale) for every measure. An account predicts the
+*sign* of the concord shift MC − SM per force; the observed sign is read off the
+cell means. -/
 
--- Register variants
+/-- An observed concord shift for one measure under one force: the MC and SM
+    cell means. -/
+structure ShiftObservation where
+  force  : ModalForce
+  mcMean : ℚ
+  smMean : ℚ
 
-/-- *must* (formal) and *certainly* (formal) are NOT register variants —
-    they share the same register level. Concord here is not register mixing
-    but force agreement between syntactically distinct categories. -/
-theorem must_certainly_same_register :
-    ¬ must.toModalItem.areRegisterVariants certainly.toModalItem := by decide
+/-- The observed sign of the concord shift (MC − SM). -/
+def ShiftObservation.observedSign (o : ShiftObservation) : SignType :=
+  SignType.sign (o.mcMean - o.smMean)
 
-/-- *may* (neutral) and *possibly* (neutral) are also not register variants. -/
-theorem may_possibly_same_register :
-    ¬ may.toModalItem.areRegisterVariants possibly.toModalItem := by decide
+/-- An account errs on an observation when its predicted sign disagrees with the
+    observed shift sign. -/
+def accountErrs (acc : ModalForce → SignType) (o : ShiftObservation) : Prop :=
+  acc o.force ≠ o.observedSign
 
-/-! ## Section B: Force determines commitment direction
+/-- The agreement account errs on every cell with a real shift: predicting a
+    null effect, it cannot match any nonzero MC − SM difference. -/
+theorem vacuity_errs_on_shift (o : ShiftObservation) (h : o.mcMean ≠ o.smMean) :
+    accountErrs vacuityEffect o := by
+  show (0 : SignType) ≠ SignType.sign (o.mcMean - o.smMean)
+  exact (sign_ne_zero.mpr (sub_ne_zero.mpr h)).symm
 
-The paper's central finding — that necessity MC strengthens while
-possibility MC weakens — can be encoded as a function from modal
-force to predicted direction. -/
+/-- When the observed shift carries the sign the spread account predicts, the
+    account does not err — the content the agreement account cannot deliver. -/
+theorem spread_correct_of_match (o : ShiftObservation)
+    (h : o.observedSign = spreadEffect o.force) : ¬ accountErrs spreadEffect o := by
+  simp only [accountErrs, not_not]; exact h.symm
 
-/-- Predicted commitment effect of concord given modal force.
-    `true` = strengthening (MC > SM), `false` = weakening (MC < SM).
-    Both necessity and weak necessity concord strengthen. -/
-def concordStrengthens : ModalForce → Bool
-  | .necessity     => true
-  | .weakNecessity => true
-  | .possibility   => false
+/-! ### The observed shifts
 
-/-- The data matches the force-based prediction for necessity. -/
-theorem necessity_matches_prediction :
-    concordStrengthens .necessity = true ∧
-    (commitmentRating necMC).mean > (commitmentRating necSM).mean :=
-  ⟨rfl, necessity_mc_strengthens⟩
+`forceKey`/`findCell`/`observedShift` join the MC and SM cells of `Examples.all`
+to read the observed sign for any measure. The `#eval`s exhibit the paper's
+findings: the spread sign predicts both commitment and confidence (the
+crossover, ±1 by force), while warmth is a uniform penalty (−1 under both
+forces). Means do not reduce in the kernel, so these are computed, not proved. -/
 
-/-- The data matches the force-based prediction for possibility. -/
-theorem possibility_matches_prediction :
-    concordStrengthens .possibility = false ∧
-    (commitmentRating posMC).mean < (commitmentRating posSM).mean :=
-  ⟨rfl, possibility_mc_weakens⟩
+/-- The `paperFeatures` `force` value for a modal force. -/
+def forceKey : ModalForce → String
+  | .necessity     => "necessity"
+  | .weakNecessity => "necessity"
+  | .possibility   => "possibility"
 
-/-! ## Section C: Connection to [rotter-liu-2025]
+/-- The cell with the given force and number (`"MC"`/`"SM"`) values. -/
+def findCell (force number : String) : Option LinguisticExample :=
+  Examples.all.find? fun e =>
+    e.paperFeatures.lookup "force" == some force &&
+    e.paperFeatures.lookup "number" == some number
 
-Both studies agree that MC preserves modal force (single reading). -/
+/-- Read a Likert mean (stored ×100) for `measure` from a cell's features. -/
+def cellMean (measure : String) (e : LinguisticExample) : Option ℚ :=
+  (e.paperFeatures.lookup measure).bind fun s => s.toNat?.map fun n => (n : ℚ) / 100
 
-/-- Both studies: necessity MC yields single necessity. -/
-theorem both_studies_single_necessity :
-    (RotterLiu2025Concord.meaningRating .must).mean -
-    (RotterLiu2025Concord.meaningRating .mustHaveTo).mean < 1/2 ∧
-    (commitmentRating necMC).mean > 4 := by
-  constructor <;> native_decide
+/-- The observed MC − SM shift for `measure` under `force`, joining the cells. -/
+def observedShift (measure : String) (force : ModalForce) : Option ShiftObservation := do
+  let mc ← findCell (forceKey force) "MC"
+  let sm ← findCell (forceKey force) "SM"
+  let mcv ← cellMean measure mc
+  let smv ← cellMean measure sm
+  pure { force := force, mcMean := mcv, smMean := smv }
 
-/-- Register and commitment are complementary diagnostics. -/
-theorem complementary_diagnostics :
-    (RotterLiu2025Concord.formalityRating .haveTo).mean <
-    (RotterLiu2025Concord.formalityRating .mustHaveTo).mean ∧
-    (commitmentRating necMC).mean ≠ (commitmentRating necSM).mean := by
-  constructor <;> native_decide
-
-/-! ## Section D: Cross-phenomenon concord
-
-Modal concord is an instance of the general `ConcordType` from
-`Core/ModalLogic.lean`. The social indexation of MC depends on force:
-necessity MC → competence, possibility MC → solidarity. This connects
-to negative concord, which also indexes solidarity.
-
-The `socialIndex` mapping is defined here (not in Core) because it
-encodes an empirical claim from [rotter-liu-2025] §4. -/
-
-/-- Social indexation of each concord type.
-    NC and MC possibility both index solidarity;
-    MC necessity indexes competence ([rotter-liu-2025] §4). -/
-def socialIndex : ConcordType → SocialIndex
-  | .negation         => .solidarity
-  | .modalNecessity   => .competence
-  | .modalPossibility => .solidarity
-
-/-- Necessity MC is a competence-indexing concord phenomenon. -/
-theorem necessity_mc_competence :
-    socialIndex (ConcordType.fromModalForce .necessity) = .competence := rfl
-
-/-- Possibility MC is a solidarity-indexing concord phenomenon. -/
-theorem possibility_mc_solidarity :
-    socialIndex (ConcordType.fromModalForce .possibility) = .solidarity := rfl
-
-/-- **Possibility MC patterns with negative concord**: Both are
-    solidarity-indexing concord phenomena. This is the cross-phenomenon
-    generalization from [rotter-liu-2025] §4. -/
-theorem possibility_mc_like_nc :
-    socialIndex (ConcordType.fromModalForce .possibility) =
-    socialIndex .negation := rfl
-
-/-- **Necessity MC contrasts with negative concord**. -/
-theorem necessity_mc_unlike_nc :
-    socialIndex (ConcordType.fromModalForce .necessity) ≠
-    socialIndex .negation := by decide
-
-/-- **Force determines social meaning**: Necessity and possibility
-    modal concord receive opposite social indexation. -/
-theorem force_determines_social_index :
-    socialIndex .modalNecessity ≠
-    socialIndex .modalPossibility := by decide
-
-/-- **Social meaning mirrors commitment direction**: The concord type's
-    social index aligns with the commitment data — competence-indexing
-    necessity MC strengthens commitment, solidarity-indexing possibility
-    MC weakens it. -/
-theorem social_index_aligns_with_commitment :
-    -- Necessity: competence index + strengthening
-    socialIndex (ConcordType.fromModalForce .necessity) = .competence ∧
-    (commitmentRating necMC).mean > (commitmentRating necSM).mean ∧
-    -- Possibility: solidarity index + weakening
-    socialIndex (ConcordType.fromModalForce .possibility) = .solidarity ∧
-    (commitmentRating posMC).mean < (commitmentRating posSM).mean := by
-  refine ⟨rfl, ?_, rfl, ?_⟩ <;> native_decide
+-- Commitment: necessity MC strengthens (+1), possibility MC weakens (−1).
+#eval (observedShift "commitment" .necessity).map fun o => (o.observedSign : ℤ)   -- some 1
+#eval (observedShift "commitment" .possibility).map fun o => (o.observedSign : ℤ) -- some -1
+-- Confidence tracks commitment — the "match".
+#eval (observedShift "confidence" .necessity).map fun o => (o.observedSign : ℤ)   -- some 1
+#eval (observedShift "confidence" .possibility).map fun o => (o.observedSign : ℤ) -- some -1
+-- Warmth: a uniform penalty, −1 under both forces.
+#eval (observedShift "warmth" .necessity).map fun o => (o.observedSign : ℤ)       -- some -1
+#eval (observedShift "warmth" .possibility).map fun o => (o.observedSign : ℤ)     -- some -1
 
 end LiuRotter2025

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -7773,7 +7773,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {formalized},
-  sources   = {Phenomena/Modality/ModalConcord/Data.lean;Phenomena/Modality/ModalConcord/Bridge.lean}
+  sources   = {Studies/RotterLiu2025Concord.lean}
 }
 @inproceedings{liu-rotter-2025,
   author    = {Liu, Mingya and Rotter, Stephanie},
@@ -7786,7 +7786,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {formalized},
-  sources   = {Phenomena/Modality/ModalConcord/LiuRotter2025.lean;Phenomena/Modality/ModalConcord/LiuRotter2025Bridge.lean}
+  sources   = {Studies/LiuRotter2025.lean}
 }
 @incollection{de-haan-2013,
   author    = {de Haan, Ferdinand},
@@ -10300,6 +10300,19 @@
   subfield  = {semantics/modality},
   role      = {cited},
   sources   = {crossref}
+}
+@article{giannakidou-mari-2018,
+  author    = {Giannakidou, Anastasia and Mari, Alda},
+  year      = {2018},
+  title     = {The Semantic Roots of Positive Polarity: Epistemic Modal Verbs and Adverbs in {E}nglish, {G}reek and {I}talian},
+  journal   = {Linguistics and Philosophy},
+  volume    = {41},
+  number    = {6},
+  pages     = {623--664},
+  doi       = {10.1007/s10988-018-9235-1},
+  subfield  = {semantics/modality},
+  role      = {cited},
+  sources   = {Studies/LiuRotter2025.lean}
 }
 @article{greco-2020,
   author    = {Greco, Matteo},


### PR DESCRIPTION
Overhaul of `Studies/LiuRotter2025.lean` ([liu-rotter-2025], ELM 3:224–235), audited against the paper PDF: the file's commitment means, interaction stats, and social-dimension coefficients were fabricated (e.g. necessity SM/MC means were 4.49/4.99 vs the real 6.12/6.40; the "interaction β=0.56, t=3.31" is the real β̂=−1.85, χ²=41.51; the "competence+/warmth−" split had inverted signs).

- Rewrite around the deep structure: the concord effect as a force-indexed `SignType` — `spreadEffect` ([giannakidou-mari-2018] modal spread) vs `vacuityEffect` ([zeijlstra-2007] agreement); the FORCE×NUMBER crossover (`spread_crossover`) is what `spread_refutes_vacuity` turns on. `warmthEffect` captures the second, force-blind MC-penalty profile. Drops ~25 `native_decide` and all eyeballed stat tables.
- Real Table 1 means → `Data/Examples/LiuRotter2025.json` (4 condition cells) + generated module; study-local sign-prediction layer (`#eval` confirms commitment & confidence cross over, warmth is uniform).
- Bib: add verified `giannakidou-mari-2018`; fix stale `Phenomena/...` source paths for both modal-concord entries. Decouples from the (also-fabricated) `RotterLiu2025Concord` sibling.