### PR TITLE
refactor(Phonology/OptimalityTheory): Tableau.ofRanking + ofPerm

### DIFF
--- a/Linglib/Phonology/Constraints/Profile.lean
+++ b/Linglib/Phonology/Constraints/Profile.lean
@@ -54,7 +54,7 @@ theorem ViolationProfile.le_apply_zero
   lexFinNat_le_apply_zero h
 
 /-- Build a `ViolationProfile ranking.length` from a ranked `Constraint`
-    list — the fixed-length analog of the profile inside `OptimalityTheory.mkTableau`. -/
+    list — the fixed-length analog of the profile inside `OptimalityTheory.Tableau.ofRanking`. -/
 def mkProfile (ranking : List (Constraint C)) (c : C) :
     ViolationProfile ranking.length :=
   buildViolationProfile (fun i => ranking.get i) c

--- a/Linglib/Phonology/OptimalityTheory/Basic.lean
+++ b/Linglib/Phonology/OptimalityTheory/Basic.lean
@@ -1,29 +1,33 @@
 import Linglib.Phonology.Constraints.Defs
 import Linglib.Phonology.Constraints.Profile
 import Linglib.Phonology.OptimalityTheory.Defs
+import Mathlib.Data.List.Permutation
 
 /-!
 # Tableau Construction and Factorial Typology
 
 The OT evaluation machinery built on the `Tableau` type (`OptimalityTheory.Defs`)
-and the violation-profile vocabulary (`Constraints.Profile`): a smart constructor
-for tableaux from ranked constraint lists, the structural optimality theorems,
-and factorial-typology computation.
+and the violation-profile vocabulary (`Constraints.Profile`): smart constructors
+for tableaux, the structural optimality theorems, and factorial-typology
+computation.
 
 ## Main definitions
 
-* `mkTableau` — build a `Tableau` from a candidate list and a ranked constraint
-  list.
-* `permutations` — all rankings of a constraint list (factorial typology).
+* `Tableau.ofRanking` — build a `Tableau` from a candidate list and a ranked
+  constraint list (list order = priority, position `0` most dominant).
+* `Tableau.ofPerm` — build a `Tableau` from a fixed constraint set `CON C n` under
+  a ranking `r : Ranking n` (priority position `p` reads constraint `r p`); the
+  `Equiv.Perm`-indexed form, definitionally the identity case of `ofRanking`.
 * `mkFactorialOptima` / `mkFactorialTypologySize` — the distinct optimal sets
-  predicted across all rankings, and their count.
+  predicted across all rankings (`List.permutations'`), and their count.
 
 ## Main results
 
-* `mkTableau_zero_isOptimal` / `mkTableau_zero_optimal_allRankings` — a
-  candidate with no violations wins under any (every) ranking.
-* `mkTableau_isOptimal_zero_first` — a satisfiable top constraint forces all
-  winners to satisfy it.
+* `Tableau.ofRanking_zero_isOptimal` / `Tableau.ofPerm_zero_isOptimal` /
+  `Tableau.ofRanking_zero_optimal_allRankings` — a candidate with no violations
+  wins under any (every) ranking.
+* `Tableau.ofRanking_isOptimal_zero_first` — a satisfiable top constraint forces
+  all winners to satisfy it.
 -/
 
 namespace OptimalityTheory
@@ -36,89 +40,28 @@ open Constraints
 
 variable {α : Type*}
 
-/-- Insert element `a` at every position in list `l`. -/
-private def insertEverywhere (a : α) : List α → List (List α)
-  | [] => [[a]]
-  | x :: xs =>
-    (a :: x :: xs) :: (insertEverywhere a xs).map (x :: ·)
-
-/-- All permutations of a list. -/
-def permutations : List α → List (List α)
-  | [] => [[]]
-  | x :: xs => (permutations xs).flatMap (insertEverywhere x)
-
-/-- Elements of `insertEverywhere a l` contain exactly `a` and the
-    elements of `l`. -/
-private theorem mem_of_mem_insertEverywhere (a : α) :
-    ∀ (l : List α) (l' : List α), l' ∈ insertEverywhere a l →
-      ∀ x, x ∈ l' → x = a ∨ x ∈ l := by
-  intro l
-  induction l with
-  | nil =>
-    intro l' h x hx
-    simp [insertEverywhere] at h
-    subst h
-    simp at hx
-    exact Or.inl hx
-  | cons y ys ih =>
-    intro l' h x hx
-    simp only [insertEverywhere, List.mem_cons, List.mem_map] at h
-    rcases h with rfl | ⟨t, ht, rfl⟩
-    · -- l' = a :: y :: ys
-      simp [List.mem_cons] at hx
-      rcases hx with rfl | rfl | hx
-      · exact Or.inl rfl
-      · exact Or.inr (.head _)
-      · exact Or.inr (.tail _ hx)
-    · -- l' = y :: t, where t ∈ insertEverywhere a ys
-      simp [List.mem_cons] at hx
-      rcases hx with rfl | hx
-      · exact Or.inr (.head _)
-      · rcases ih t ht x hx with rfl | hm
-        · exact Or.inl rfl
-        · exact Or.inr (.tail _ hm)
-
-/-- Elements of any permutation of `l` are elements of `l`. -/
-theorem mem_of_mem_permutations {x : α} :
-    ∀ {l l' : List α}, l' ∈ permutations l → x ∈ l' → x ∈ l := by
-  intro l
-  induction l with
-  | nil =>
-    intro l' hp hx
-    simp [permutations] at hp
-    subst hp; simp at hx
-  | cons y ys ih =>
-    intro l' hp hx
-    simp only [permutations, List.mem_flatMap] at hp
-    obtain ⟨p, hp_mem, hp_ins⟩ := hp
-    rcases mem_of_mem_insertEverywhere y p l' hp_ins x hx with rfl | hm
-    · exact .head _
-    · exact .tail _ (ih hp_mem hm)
-
-/-- A permutation of `constraints` has the same elements, so any
-    `con ∈ ranking` for `ranking ∈ permutations constraints` satisfies
-    `con ∈ constraints`. -/
-theorem permutations_subset {l l' : List α}
-    (hp : l' ∈ permutations l) : ∀ x ∈ l', x ∈ l :=
-  fun _ hx => mem_of_mem_permutations hp hx
+/-- A permutation of `l` — an element of mathlib's `List.permutations'` (the
+    structurally-recursive insert-everywhere enumeration that, unlike
+    `List.permutations`, reduces under `decide`) — has the same elements as `l`.
+    The factorial-typology layer ranges over `List.permutations'`; this lemma
+    feeds the all-rankings optimality result. -/
+theorem permutations_subset {l l' : List α} (hp : l' ∈ l.permutations') :
+    ∀ x ∈ l', x ∈ l :=
+  fun _ hx => (List.mem_permutations'.mp hp).mem_iff.mp hx
 
 -- ============================================================================
--- § 2: Tableau Construction
+-- § 2: Tableau Constructors
 -- ============================================================================
 
-variable {C : Type*} [DecidableEq C]
+variable {C : Type*} [DecidableEq C] {n : Nat}
 
-/-- Build a `Tableau C ranking.length` from a candidate list and ranking.
+/-- Build a `Tableau C ranking.length` from a candidate list and a ranked
+    constraint list: list order is priority (position `0` most dominant).
 
-    Candidates are deduplicated via `List.toFinset`; profiles are
-    fixed-length `ViolationProfile n` built via `buildViolationProfile`.
-
-    Study files use this as:
-    ```
-    (mkTableau candidates ranking h).optimal = {.winner}
-    ```
-    where `{.winner}` is a `Finset` literal. -/
-def mkTableau (candidates : List C)
+    Candidates are deduplicated via `List.toFinset`; profiles are fixed-length
+    `ViolationProfile` built via `buildViolationProfile`. Study files use this as
+    `(Tableau.ofRanking candidates ranking h).optimal = {.winner}`. -/
+def Tableau.ofRanking (candidates : List C)
     (ranking : List (Constraint C))
     (h : candidates ≠ [] := by decide) : Tableau C ranking.length :=
   { candidates := candidates.toFinset
@@ -129,11 +72,33 @@ def mkTableau (candidates : List C)
       | nil => contradiction
       | cons a _ => exact ⟨a, by simp⟩ }
 
-/-- Candidates in `mkTableau ... .optimal` belong to the original list. -/
-theorem mkTableau_optimal_mem
+/-- Build a `Tableau C n` from a fixed constraint set `con : CON C n` under a
+    ranking `r : Ranking n`: priority position `p` reads constraint `r p`, so
+    coordinate `0` of the lexicographic profile is the most dominant constraint.
+    The `Equiv.Perm`-indexed evaluation that the `ElementaryRankingCondition`
+    apparatus (`tableauERC`, `ERC.satisfiedBy`) ranges over. -/
+def Tableau.ofPerm (con : CON C n) (r : Ranking n)
+    (candidates : List C)
+    (h : candidates ≠ [] := by decide) : Tableau C n :=
+  { candidates := candidates.toFinset
+    profile := fun c => buildViolationProfile (fun p => con (r p)) c
+    nonempty := by
+      cases candidates with
+      | nil => contradiction
+      | cons a _ => exact ⟨a, by simp⟩ }
+
+/-- A list ranking is its own `CON` (via `List.get`) under the identity
+    permutation: the two constructors agree, definitionally. -/
+theorem Tableau.ofRanking_eq_ofPerm (candidates : List C)
+    (ranking : List (Constraint C)) (h : candidates ≠ []) :
+    Tableau.ofRanking candidates ranking h =
+      Tableau.ofPerm (fun j => ranking.get j) (Equiv.refl _) candidates h := rfl
+
+/-- Candidates in `(Tableau.ofRanking ...).optimal` belong to the original list. -/
+theorem Tableau.ofRanking_optimal_mem
     (candidates : List C) (ranking : List (Constraint C))
     (h : candidates ≠ []) (c : C) :
-    c ∈ (mkTableau candidates ranking h).optimal → c ∈ candidates :=
+    c ∈ (Tableau.ofRanking candidates ranking h).optimal → c ∈ candidates :=
   fun hc => List.mem_toFinset.mp (Tableau.optimal_subset _ c hc)
 
 -- ============================================================================
@@ -148,12 +113,12 @@ theorem mkTableau_optimal_mem
     the ranking, it forces all winners to satisfy it perfectly. Uses
     `ViolationProfile.le_apply_zero` to extract the first component
     of the lexicographic comparison. -/
-theorem mkTableau_isOptimal_zero_first
+theorem Tableau.ofRanking_isOptimal_zero_first
     (candidates : List C) (con : Constraint C)
     (rest : List (Constraint C))
     (h : candidates ≠ [])
     (hExists : ∃ c₀ ∈ candidates, con c₀ = 0)
-    : ∀ c, (mkTableau candidates (con :: rest) h).IsOptimal c →
+    : ∀ c, (Tableau.ofRanking candidates (con :: rest) h).IsOptimal c →
         con c = 0 := by
   intro c ⟨_, hc_all⟩
   obtain ⟨c₀, hc₀_mem, hc₀_zero⟩ := hExists
@@ -164,27 +129,27 @@ theorem mkTableau_isOptimal_zero_first
   rw [hc₀_zero] at h0
   exact Nat.le_zero.mp h0
 
-/-- `∈ .optimal` version of `mkTableau_isOptimal_zero_first`. -/
-theorem mkTableau_optimal_zero_first
+/-- `∈ .optimal` version of `Tableau.ofRanking_isOptimal_zero_first`. -/
+theorem Tableau.ofRanking_optimal_zero_first
     (candidates : List C) (con : Constraint C)
     (rest : List (Constraint C))
     (h : candidates ≠ [])
     (hExists : ∃ c₀ ∈ candidates, con c₀ = 0)
-    : ∀ c ∈ (mkTableau candidates (con :: rest) h).optimal,
+    : ∀ c ∈ (Tableau.ofRanking candidates (con :: rest) h).optimal,
         con c = 0 :=
-  fun c hc => mkTableau_isOptimal_zero_first candidates con rest h hExists c
+  fun c hc => Tableau.ofRanking_isOptimal_zero_first candidates con rest h hExists c
     ((Tableau.mem_optimal_iff _ c).mp hc)
 
-/-- If a candidate in `mkTableau` has 0 violations on every constraint,
+/-- If a candidate in `Tableau.ofRanking` has 0 violations on every constraint,
     it is optimal. -/
-theorem mkTableau_zero_isOptimal
+theorem Tableau.ofRanking_zero_isOptimal
     (candidates : List C) (ranking : List (Constraint C))
     (h : candidates ≠ []) (c : C) (hc : c ∈ candidates)
     (hzero : ∀ con ∈ ranking, con c = 0) :
-    c ∈ (mkTableau candidates ranking h).optimal := by
+    c ∈ (Tableau.ofRanking candidates ranking h).optimal := by
   rw [Tableau.mem_optimal_iff]
   refine ⟨List.mem_toFinset.mpr hc, fun c' _ => ?_⟩
-  suffices hsuff : (mkTableau candidates ranking h).profile c = 0 by
+  suffices hsuff : (Tableau.ofRanking candidates ranking h).profile c = 0 by
     rw [hsuff]; exact ViolationProfile.zero_le _
   show buildViolationProfile (fun i => ranking.get i) c = 0
   funext i
@@ -193,38 +158,51 @@ theorem mkTableau_zero_isOptimal
 /-- If a candidate has 0 violations on every constraint in a set, it is
     optimal under **every** permutation of those constraints.
 
-    This is the structural backbone of `adj_always_initial` in Marco &
-    Rasin (2026): the uniform-initial adjective paradigm has [0,0,0,0]
-    on all four OP constraints, so it wins regardless of ranking. The
-    proof reduces to `mkTableau_zero_isOptimal` after using
-    `permutations_subset` to show that elements of a permutation are
-    elements of the original list. -/
-theorem mkTableau_zero_optimal_allRankings
+    The structural backbone of `adj_always_initial` in [marco-rasin-2026]: the
+    uniform-initial adjective paradigm has [0,…,0] on all OP constraints, so it
+    wins regardless of ranking. Reduces to `Tableau.ofRanking_zero_isOptimal`
+    after `permutations_subset`. -/
+theorem Tableau.ofRanking_zero_optimal_allRankings
     (candidates : List C) (constraints : List (Constraint C))
     (h : candidates ≠ []) (c : C) (hc : c ∈ candidates)
     (hzero : ∀ con ∈ constraints, con c = 0) :
-    ∀ ranking ∈ permutations constraints,
-      c ∈ (mkTableau candidates ranking h).optimal :=
-  fun ranking hp => mkTableau_zero_isOptimal candidates ranking h c hc
+    ∀ ranking ∈ constraints.permutations',
+      c ∈ (Tableau.ofRanking candidates ranking h).optimal :=
+  fun ranking hp => Tableau.ofRanking_zero_isOptimal candidates ranking h c hc
     (fun con hcon => hzero con (permutations_subset hp con hcon))
+
+/-- The `Equiv.Perm`-indexed analogue: a candidate with 0 violations on every
+    constraint of `con` is optimal in `Tableau.ofPerm con r` under **every**
+    ranking `r` — permuting the coordinates of the all-zero profile leaves it
+    zero. n-agnostic and enumeration-free (no `decide`). -/
+theorem Tableau.ofPerm_zero_isOptimal
+    (con : CON C n) (candidates : List C)
+    (h : candidates ≠ []) (c : C) (hc : c ∈ candidates)
+    (hzero : ∀ i, con i c = 0) (r : Ranking n) :
+    c ∈ (Tableau.ofPerm con r candidates h).optimal := by
+  rw [Tableau.mem_optimal_iff]
+  refine ⟨List.mem_toFinset.mpr hc, fun c' _ => ?_⟩
+  suffices hsuff : (Tableau.ofPerm con r candidates h).profile c = 0 by
+    rw [hsuff]; exact ViolationProfile.zero_le _
+  show buildViolationProfile (fun p => con (r p)) c = 0
+  funext p
+  exact hzero (r p)
 
 -- ============================================================================
 -- § 4: Factorial Typology
 -- ============================================================================
 
-/-- For each permutation of `constraints`, compute the set of optimal
-    candidates as a `Finset`. Return the list of distinct optimal sets.
-
-    This is the core of OT factorial typology: the number of distinct
-    optimal sets equals the number of language types predicted by the
-    constraint set. -/
+/-- For each ranking (permutation, via `List.permutations'`) of `constraints`,
+    the set of optimal candidates as a `Finset`; the list of distinct optimal
+    sets. The number of distinct sets is the number of language types the
+    constraint set predicts. -/
 def mkFactorialOptima
     (candidates : List C)
     (constraints : List (Constraint C))
     (h : candidates ≠ [] := by decide) : List (Finset C) :=
-  let allRankings := permutations constraints
+  let allRankings := constraints.permutations'
   let optima := allRankings.map fun ranking =>
-    (mkTableau candidates ranking h).optimal
+    (Tableau.ofRanking candidates ranking h).optimal
   optima.eraseDups
 
 /-- Number of distinct language types predicted by the factorial typology.

--- a/Linglib/Phonology/OptimalityTheory/CophonologyByPhrase.lean
+++ b/Linglib/Phonology/OptimalityTheory/CophonologyByPhrase.lean
@@ -127,7 +127,7 @@ theorem phrasalCophonologicalEval_empty_sub {C : Type*} [DecidableEq C]
     (candidates : List C) (h : candidates ≠ [])
     (hsub : pc.subranking = []) :
     phrasalCophonologicalEval defaultRanking pc candidates h
-      = (OptimalityTheory.mkTableau candidates (defaultRanking.map (·.2)) h).optimal := by
+      = (OptimalityTheory.Tableau.ofRanking candidates (defaultRanking.map (·.2)) h).optimal := by
   unfold phrasalCophonologicalEval
   rw [hsub]
   exact cophonologicalEval_empty_sub defaultRanking candidates h

--- a/Linglib/Phonology/OptimalityTheory/CophonologyTheory.lean
+++ b/Linglib/Phonology/OptimalityTheory/CophonologyTheory.lean
@@ -119,7 +119,7 @@ def cophonologicalEval {C : Type*} [DecidableEq C]
     (candidates : List C)
     (h : candidates ≠ [] := by decide) : Finset C :=
   let effective := mergeRanking defaultRanking subranking
-  (mkTableau candidates (effective.map (·.2)) h).optimal
+  (Tableau.ofRanking candidates (effective.map (·.2)) h).optimal
 
 /-- When the subranking is empty, cophonological evaluation reduces to
     standard OT evaluation. CPT is a proper generalization of OT. -/
@@ -127,8 +127,8 @@ theorem cophonologicalEval_empty_sub {C : Type*} [DecidableEq C]
     (defaultRanking : List (String × Constraint C))
     (candidates : List C) (h : candidates ≠ []) :
     cophonologicalEval defaultRanking [] candidates h =
-    (mkTableau candidates (defaultRanking.map (·.2)) h).optimal := by
-  show (mkTableau candidates ((mergeRanking defaultRanking []).map (·.2)) h).optimal = _
+    (Tableau.ofRanking candidates (defaultRanking.map (·.2)) h).optimal := by
+  show (Tableau.ofRanking candidates ((mergeRanking defaultRanking []).map (·.2)) h).optimal = _
   rw [mergeRanking_empty_sub]
 
 end OptimalityTheory.CophonologyTheory

--- a/Linglib/Phonology/OptimalityTheory/Doubling.lean
+++ b/Linglib/Phonology/OptimalityTheory/Doubling.lean
@@ -352,23 +352,23 @@ theorem l1CandidatesFor_ne (g : DoublingGrammar) (f : DoublingFunction) :
     OCP-XX bans identity; *RED is irrelevant since reduplication
     is not a candidate. -/
 theorem phon_prefers_XY :
-    (mkTableau phonCandidates phonRanking).optimal
+    (Tableau.ofRanking phonCandidates phonRanking).optimal
     = {.nonidentical} := by decide
 
 /-- In morphological contexts where reduplication is available,
     reduplication wins. OCP-XX bans identity; REALIZE-MORPH bans
     nonidentical; reduplication violates only low-ranked *RED. -/
 theorem morph_prefers_reduplication :
-    (mkTableau morphCandidates morphRanking).optimal
+    (Tableau.ofRanking morphCandidates morphRanking).optimal
     = {.reduplication} := by decide
 
 /-- The phonology--morphology reversal: context determines which
     constraints are active, producing opposite surface preferences
     from the same underlying OCP-XX. -/
 theorem doubling_reversal :
-    (mkTableau phonCandidates phonRanking).optimal
+    (Tableau.ofRanking phonCandidates phonRanking).optimal
       = {.nonidentical} ∧
-    (mkTableau morphCandidates morphRanking).optimal
+    (Tableau.ofRanking morphCandidates morphRanking).optimal
       = {.reduplication} := by
   exact ⟨phon_prefers_XY, morph_prefers_reduplication⟩
 

--- a/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
+++ b/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
@@ -1,5 +1,6 @@
 import Linglib.Phonology.Constraints.Profile
 import Linglib.Phonology.OptimalityTheory.Defs
+import Linglib.Phonology.OptimalityTheory.Basic
 import Mathlib.GroupTheory.Perm.Basic
 import Mathlib.Data.Sign.Basic
 import Mathlib.Data.Fintype.Perm
@@ -328,6 +329,25 @@ theorem isOptimal_iff_forall_satisfiedBy {C : Type*} [DecidableEq C]
     exact ⟨hmem, fun l hl => (tableauERC_satisfiedBy_id_iff t w l).mpr (hmin l hl)⟩
   · rintro ⟨hmem, hsat⟩
     exact ⟨hmem, fun l hl => (tableauERC_satisfiedBy_id_iff t w l).mp (hsat l hl)⟩
+
+/-- **The `Sₙ` action on a fixed `CON` is the ERC theory.** A candidate `w` is the
+optimum of `Tableau.ofPerm con r` iff, for every competitor, the winner–loser ERC
+of the *canonical* (identity-ranked) tableau is satisfied by `r`. So factorial
+typology (`r` ranging over all rankings of `con`) and ERC consistency are two
+readouts of one symmetric-group action on `con` — `Tableau.ofPerm con r` is the
+shared object. -/
+theorem Tableau.ofPerm_isOptimal_iff_satisfiedBy {C : Type*} [DecidableEq C] {n : ℕ}
+    (con : CON C n) (r : Ranking n) (candidates : List C) (h : candidates ≠ [])
+    (w : C) :
+    (Tableau.ofPerm con r candidates h).IsOptimal w ↔
+      w ∈ candidates.toFinset ∧
+        ∀ l ∈ candidates.toFinset,
+          (tableauERC (Tableau.ofPerm con (Equiv.refl _) candidates h) w l).satisfiedBy r := by
+  constructor
+  · rintro ⟨hmem, hmin⟩
+    exact ⟨hmem, fun l hl => (tableauERC_satisfiedBy_iff _ r w l).mpr (hmin l hl)⟩
+  · rintro ⟨hmem, hsat⟩
+    exact ⟨hmem, fun l hl => (tableauERC_satisfiedBy_iff _ r w l).mp (hsat l hl)⟩
 
 /-! ### Simple ERCs -/
 

--- a/Linglib/Phonology/OptimalityTheory/HarmonicSerialism.lean
+++ b/Linglib/Phonology/OptimalityTheory/HarmonicSerialism.lean
@@ -13,7 +13,7 @@ Bundles a one-step `gen` function and a constraint ranking into an
 `HSDerivation`. Owns the serial GEN/EVAL iteration combinator (§ 1 — a
 bespoke fuel-bounded search; the generic fixed-point / well-founded-
 termination theory it instantiates is mathlib's) and reuses the existing
-parallel `Tableau`/`mkTableau` machinery from `Basic.lean` (Layered
+parallel `Tableau`/`Tableau.ofRanking` machinery from `Basic.lean` (Layered
 Grounding — does not duplicate parallel optimization).
 
 ## NOTE on theoretical scope

--- a/Linglib/Phonology/OptimalityTheory/Stratal.lean
+++ b/Linglib/Phonology/OptimalityTheory/Stratal.lean
@@ -12,7 +12,7 @@ of each stratum feeding the next as input. The crucial property is
 in different strata's rankings, capturing level-ordering effects without ad
 hoc rules or extrinsic ordering.
 
-Per-stratum evaluation uses `OptimalityTheory.mkTableau` / `Tableau.optimal`
+Per-stratum evaluation uses `OptimalityTheory.Tableau.ofRanking` / `Tableau.optimal`
 in the consuming study file (e.g. the Telugu weak alternation, [aitha-2026]).
 This module provides the cross-stratal vocabulary: a `StratalDerivation`
 record of the per-stratum outputs, and the reranking predicates. The latter

--- a/Linglib/Semantics/Presupposition/MaximizePresupposition.lean
+++ b/Linglib/Semantics/Presupposition/MaximizePresupposition.lean
@@ -160,15 +160,15 @@ theorem mp_selects_strongest {C : Type} [DecidableEq C] (candidates : List C)
     (hNE : candidates ≠ [])
     (hBound : ∀ c ∈ candidates, strength c ≤ maxStrength)
     (hExists : ∃ c₀ ∈ candidates, strength c₀ = maxStrength) :
-    ∀ c ∈ (mkTableau candidates
+    ∀ c ∈ (Tableau.ofRanking candidates
       (mpConstraintOf maxStrength strength :: rest) hNE).optimal,
       strength c = maxStrength := by
   intro c hc
-  have hZero := mkTableau_optimal_zero_first candidates
+  have hZero := Tableau.ofRanking_optimal_zero_first candidates
     (mpConstraintOf maxStrength strength) rest hNE
     (by obtain ⟨c₀, hm, hs⟩ := hExists
         exact ⟨c₀, hm, mp_zero_at_max maxStrength strength c₀ hs⟩) c hc
-  have hcBound := hBound c (mkTableau_optimal_mem candidates _ hNE c hc)
+  have hcBound := hBound c (Tableau.ofRanking_optimal_mem candidates _ hNE c hc)
   simp only [mpConstraintOf] at hZero; omega
 
 /-- **Markedness dominant → weakest wins**: when a markedness constraint
@@ -180,11 +180,11 @@ theorem markedness_selects_weakest {C : Type} [DecidableEq C] (candidates : List
     (rest : List (Constraint C))
     (hNE : candidates ≠ [])
     (hExists : ∃ c₀ ∈ candidates, strength c₀ = 0) :
-    ∀ c ∈ (mkTableau candidates
+    ∀ c ∈ (Tableau.ofRanking candidates
       (markednessPenalty strength :: rest) hNE).optimal,
       strength c = 0 := by
   intro c hc
-  have hZero := mkTableau_optimal_zero_first candidates
+  have hZero := Tableau.ofRanking_optimal_zero_first candidates
     (markednessPenalty strength) rest hNE
     (by obtain ⟨c₀, hm, hs⟩ := hExists
         exact ⟨c₀, hm, markedness_zero_at_min strength c₀ hs⟩) c hc
@@ -266,7 +266,7 @@ theorem phi_mp_selects_maximal (candidates : List ContainmentPair)
     (hNE : candidates ≠ [])
     (hWF : ∀ c ∈ candidates, c.WellFormed)
     (hMax : ContainmentPair.maximal ∈ candidates) :
-    ∀ c ∈ (mkTableau candidates (phiMP :: rest) hNE).optimal,
+    ∀ c ∈ (Tableau.ofRanking candidates (phiMP :: rest) hNE).optimal,
       presupStrength c = ContainmentPair.maximal.specLevel :=
   mp_selects_strongest candidates _ presupStrength rest hNE
     (fun c hc => wellFormed_specLevel_le_two c (hWF c hc))

--- a/Linglib/Studies/Aissen2003.lean
+++ b/Linglib/Studies/Aissen2003.lean
@@ -303,7 +303,7 @@ theorem rankings2_count : rankings2.length = 6 := by native_decide
 /-- Compute optima for each consistent ranking. -/
 def optima2 : List (Finset Scale2Cand) :=
   rankings2.map λ ranking =>
-    (mkTableau scale2Cands ranking).optimal
+    (Tableau.ofRanking scale2Cands ranking).optimal
 
 /-- Distinct language types. -/
 def types2 : List (Finset Scale2Cand) := optima2.eraseDups
@@ -373,7 +373,7 @@ theorem anim_rankings_count : animRankings.length = 20 := by native_decide
 /-- Compute optima for each consistent ranking. -/
 def animOptima : List (Finset AnimCand) :=
   animRankings.map λ ranking =>
-    (mkTableau animCands ranking).optimal
+    (Tableau.ofRanking animCands ranking).optimal
 
 /-- Distinct language types. -/
 def animTypes : List (Finset AnimCand) := animOptima.eraseDups

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -485,7 +485,7 @@ theorem stem_parsesyl_violations :
 /-- The optimal Stem-level parse is (ˈsa.mu).(ˌdram): two well-formed
     moraic trochees, (LL)(H), with no unparsed syllables. -/
 theorem stem_optimal :
-    (mkTableau stemCandidates stemRanking stemCandidates_ne).optimal
+    (Tableau.ofRanking stemCandidates stemRanking stemCandidates_ne).optimal
       = {.ll_H} := by native_decide
 
 -- ============================================================================
@@ -578,7 +578,7 @@ theorem wordNomCands_ne : wordNomCands ≠ [] := by decide
 /-- Word level, NOM: Word-final stressed *-ni* is deleted.
     Surface: *samudr-am* (short form). -/
 theorem wordNom_optimal :
-    (mkTableau wordNomCands wordNomRanking wordNomCands_ne).optimal
+    (Tableau.ofRanking wordNomCands wordNomRanking wordNomCands_ne).optimal
       = {.deleteNi} := by native_decide
 
 -- ────────────────────────────────────────────────────────────────────
@@ -624,7 +624,7 @@ theorem wordDatCands_ne : wordDatCands ≠ [] := by decide
 /-- Word level, DAT: /mn/ boundary repaired by compensatory lengthening.
     Surface: *samudr-āni-ki* (long form). -/
 theorem wordDat_optimal :
-    (mkTableau wordDatCands (wordDatRanking.map (·.2)) wordDatCands_ne).optimal
+    (Tableau.ofRanking wordDatCands (wordDatRanking.map (·.2)) wordDatCands_ne).optimal
       = {.compLengthen} := by native_decide
 
 -- ────────────────────────────────────────────────────────────────────
@@ -642,9 +642,9 @@ theorem wordDat_optimal :
     (§3) stipulates: the alternation is now DERIVED from OT constraint
     interaction, not encoded by fiat. -/
 theorem word_level_derives_alternation :
-    (mkTableau wordNomCands wordNomRanking wordNomCands_ne).optimal
+    (Tableau.ofRanking wordNomCands wordNomRanking wordNomCands_ne).optimal
       = {.deleteNi} ∧
-    (mkTableau wordDatCands (wordDatRanking.map (·.2)) wordDatCands_ne).optimal
+    (Tableau.ofRanking wordDatCands (wordDatRanking.map (·.2)) wordDatCands_ne).optimal
       = {.compLengthen} :=
   ⟨wordNom_optimal, wordDat_optimal⟩
 
@@ -729,7 +729,7 @@ theorem phrasePostpCands_ne : phrasePostpCands ≠ [] := by decide
     `*DIST-0` is demoted below MAX at Phrase level, so m-n contact
     is tolerated rather than repaired. Surface: *samudram nunci*. -/
 theorem phrasePostp_optimal :
-    (mkTableau phrasePostpCands (phrasePostpRanking.map (·.2)) phrasePostpCands_ne).optimal
+    (Tableau.ofRanking phrasePostpCands (phrasePostpRanking.map (·.2)) phrasePostpCands_ne).optimal
       = {.faithful} := by native_decide
 
 end PhraseLevel
@@ -1023,7 +1023,7 @@ open Core.Optimization Constraints
 
 /-- Stem-level metrical parse tableau as a generic `ConstraintSystem`. -/
 noncomputable def stemSystem : ConstraintSystem StemCandidate (LexProfile Nat 3) :=
-  tableauSystem (mkTableau stemCandidates stemRanking stemCandidates_ne)
+  tableauSystem (Tableau.ofRanking stemCandidates stemRanking stemCandidates_ne)
 
 /-- Probability 1 on (LL)(H): two well-formed moraic trochees. -/
 theorem stemSystem_predict_ll_H :
@@ -1032,7 +1032,7 @@ theorem stemSystem_predict_ll_H :
 
 /-- Word-level NOM tableau as a generic `ConstraintSystem`. -/
 noncomputable def wordNomSystem : ConstraintSystem WordCandNom (LexProfile Nat 6) :=
-  tableauSystem (mkTableau wordNomCands wordNomRanking wordNomCands_ne)
+  tableauSystem (Tableau.ofRanking wordNomCands wordNomRanking wordNomCands_ne)
 
 /-- Probability 1 on `deleteNi`: Word-final stressed *-ni* is deleted. -/
 theorem wordNomSystem_predict_deleteNi :
@@ -1041,7 +1041,7 @@ theorem wordNomSystem_predict_deleteNi :
 
 /-- Word-level DAT tableau as a generic `ConstraintSystem`. -/
 noncomputable def wordDatSystem : ConstraintSystem WordCandDat (LexProfile Nat 6) :=
-  tableauSystem (mkTableau wordDatCands (wordDatRanking.map (·.2)) wordDatCands_ne)
+  tableauSystem (Tableau.ofRanking wordDatCands (wordDatRanking.map (·.2)) wordDatCands_ne)
 
 /-- Probability 1 on `compLengthen`: /m/ deletion + CL yields *-āni*. -/
 theorem wordDatSystem_predict_compLengthen :

--- a/Linglib/Studies/AkinboFwangwar2026.lean
+++ b/Linglib/Studies/AkinboFwangwar2026.lean
@@ -759,10 +759,10 @@ theorem dominant_coph_selects_basemap_faithful
     obtain ⟨c₀, hc₀_mem, hc₀_eq⟩ := hFaithful
     exact ⟨c₀, hc₀_mem, by simp [mxbmc, mkBasemapConstraint, hc₀_eq,
       basemapViolations_self_eq_zero]⟩
-  have hZero := mkTableau_optimal_zero_first candidates mxbmc _ h hExists c hc
+  have hZero := Tableau.ofRanking_optimal_zero_first candidates mxbmc _ h hExists c hc
   simp only [mxbmc, mkBasemapConstraint] at hZero
   exact basemapViolations_eq_zero_imp (extractTier c) basemapTier
-    (hLen c (mkTableau_optimal_mem candidates _ h c hc)) hZero
+    (hLen c (Tableau.ofRanking_optimal_mem candidates _ h c hc)) hZero
 
 /-- **Dominant cophonology agrees with tonalOverwrite**: for whole-word
     single-tone replacement, OT evaluation under the dominant cophonology

--- a/Linglib/Studies/Belth2026.lean
+++ b/Linglib/Studies/Belth2026.lean
@@ -404,33 +404,33 @@ theorem latinTSL_correct :
     [r] wins. -/
 theorem popularis_optimal_is_r :
     substL .r popularis_ur ∈
-      (mkTableau (latCands popularis_ur) latinRanking).optimal := by decide
+      (Tableau.ofRanking (latCands popularis_ur) latinRanking).optimal := by decide
 
 theorem popularis_loser_is_l :
     substL .l popularis_ur ∉
-      (mkTableau (latCands popularis_ur) latinRanking).optimal := by decide
+      (Tableau.ofRanking (latCands popularis_ur) latinRanking).optimal := by decide
 
 /-- *pluvalis*: same OCP-ranking-decides pattern as *popularis* (the
     consonant tier of `/pluv-a/` is `[p, l]`, so substituting `L → l`
     creates a tier-adjacent `(l, l)`). -/
 theorem pluvalis_optimal_is_r :
     substL .r pluvalis_ur ∈
-      (mkTableau (latCands pluvalis_ur) latinRanking).optimal := by decide
+      (Tableau.ofRanking (latCands pluvalis_ur) latinRanking).optimal := by decide
 
 /-- *navalis*, *floralis*, *legalis*: the [l]-candidate has OCP=0 (no
     tier-adjacent laterals) and \*r=0; the [r]-candidate has \*r=1.
     \*r breaks the tie in favour of [l]. -/
 theorem navalis_optimal_is_l :
     substL .l navalis_ur ∈
-      (mkTableau (latCands navalis_ur) latinRanking).optimal := by decide
+      (Tableau.ofRanking (latCands navalis_ur) latinRanking).optimal := by decide
 
 theorem floralis_optimal_is_l :
     substL .l floralis_ur ∈
-      (mkTableau (latCands floralis_ur) latinRanking).optimal := by decide
+      (Tableau.ofRanking (latCands floralis_ur) latinRanking).optimal := by decide
 
 theorem legalis_optimal_is_l :
     substL .l legalis_ur ∈
-      (mkTableau (latCands legalis_ur) latinRanking).optimal := by decide
+      (Tableau.ofRanking (latCands legalis_ur) latinRanking).optimal := by decide
 
 /-- *lunaris*: the OT analysis selects [l], not the empirical [r] —
     the same error the rule makes (§5). Both candidates have OCP=0
@@ -439,7 +439,7 @@ theorem legalis_optimal_is_l :
     [l]-candidate. -/
 theorem lunaris_optimal_is_l_INCORRECT :
     substL .l lunaris_ur ∈
-      (mkTableau (latCands lunaris_ur) latinRanking).optimal := by decide
+      (Tableau.ofRanking (latCands lunaris_ur) latinRanking).optimal := by decide
 
 -- ---- ERC analysis ----------------------------------------------------------
 
@@ -447,28 +447,28 @@ theorem lunaris_optimal_is_l_INCORRECT :
     the winner (W on constraint 0); \*r prefers the loser (L on constraint
     1). The full vector is ⟨W, L⟩ = `simpleERC 0 1`. -/
 def popularisERC : ERC 2 :=
-  tableauERC (mkTableau (latCands popularis_ur) latinRanking)
+  tableauERC (Tableau.ofRanking (latCands popularis_ur) latinRanking)
     (substL .r popularis_ur) (substL .l popularis_ur)
 
 /-- The ERC induced by *pluvalis*: same shape as popularis. -/
 def pluvalisERC : ERC 2 :=
-  tableauERC (mkTableau (latCands pluvalis_ur) latinRanking)
+  tableauERC (Tableau.ofRanking (latCands pluvalis_ur) latinRanking)
     (substL .r pluvalis_ur) (substL .l pluvalis_ur)
 
 /-- The ERC induced by *navalis* (winner [l], loser [r]): OCP indifferent,
     \*r prefers the winner. ⟨e, W⟩ — trivial (no L). -/
 def navalisERC : ERC 2 :=
-  tableauERC (mkTableau (latCands navalis_ur) latinRanking)
+  tableauERC (Tableau.ofRanking (latCands navalis_ur) latinRanking)
     (substL .l navalis_ur) (substL .r navalis_ur)
 
 /-- The ERC induced by *floralis*. -/
 def floralisERC : ERC 2 :=
-  tableauERC (mkTableau (latCands floralis_ur) latinRanking)
+  tableauERC (Tableau.ofRanking (latCands floralis_ur) latinRanking)
     (substL .l floralis_ur) (substL .r floralis_ur)
 
 /-- The ERC induced by *legalis*. -/
 def legalisERC : ERC 2 :=
-  tableauERC (mkTableau (latCands legalis_ur) latinRanking)
+  tableauERC (Tableau.ofRanking (latCands legalis_ur) latinRanking)
     (substL .l legalis_ur) (substL .r legalis_ur)
 
 /-- The ERC induced by *lunaris* (taking the empirical [r] as the winner):
@@ -477,7 +477,7 @@ def legalisERC : ERC 2 :=
     No ranking on the inventory ⟨OCP, \*r⟩ can satisfy this; the OT
     formulation thus reproduces exactly the rule's empirical limit. -/
 def lunarisERC : ERC 2 :=
-  tableauERC (mkTableau (latCands lunaris_ur) latinRanking)
+  tableauERC (Tableau.ofRanking (latCands lunaris_ur) latinRanking)
     (substL .r lunaris_ur) (substL .l lunaris_ur)
 
 theorem popularisERC_is_simple :

--- a/Linglib/Studies/Berent2026.lean
+++ b/Linglib/Studies/Berent2026.lean
@@ -168,9 +168,9 @@ theorem ocp_passes_ab {α : Type} [DecidableEq α] (a b : α) (rest : List α)
     and [berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016] for
     the experimental evidence. -/
 theorem amodal_doubling_reversal :
-    (mkTableau phonCandidates phonRanking).optimal
+    (Tableau.ofRanking phonCandidates phonRanking).optimal
       = {DoublingParse.nonidentical} ∧
-    (mkTableau morphCandidates morphRanking).optimal
+    (Tableau.ofRanking morphCandidates morphRanking).optimal
       = {DoublingParse.reduplication} :=
   doubling_reversal
 
@@ -189,7 +189,7 @@ open Core.Optimization Constraints
 
 /-- Phonological-context tableau as a generic `ConstraintSystem`. -/
 noncomputable def phonSystem : ConstraintSystem DoublingParse (LexProfile Nat 2) :=
-  tableauSystem (mkTableau phonCandidates phonRanking)
+  tableauSystem (Tableau.ofRanking phonCandidates phonRanking)
 
 /-- In phonological contexts, `.nonidentical` has probability 1. -/
 theorem phonSystem_predict_nonidentical :
@@ -198,7 +198,7 @@ theorem phonSystem_predict_nonidentical :
 
 /-- Morphological-context tableau as a generic `ConstraintSystem`. -/
 noncomputable def morphSystem : ConstraintSystem DoublingParse (LexProfile Nat 3) :=
-  tableauSystem (mkTableau morphCandidates morphRanking)
+  tableauSystem (Tableau.ofRanking morphCandidates morphRanking)
 
 /-- In morphological contexts where reduplication is available,
     `.reduplication` has probability 1. -/

--- a/Linglib/Studies/BerentEtAl2016.lean
+++ b/Linglib/Studies/BerentEtAl2016.lean
@@ -124,7 +124,7 @@ theorem hebrew_diminutive_available :
     in a plurality context. The categorical prediction captures the
     direction of this gradient effect. -/
 theorem english_plurality_prefers_XX :
-    (mkTableau
+    (Tableau.ofRanking
       (l1CandidatesFor englishGrammar .plurality)
       (l1RankingFor englishGrammar .plurality)
       (l1CandidatesFor_ne englishGrammar .plurality)).optimal
@@ -136,7 +136,7 @@ theorem english_plurality_prefers_XX :
     predicts XY wins categorically; the data show absence of the
     XX preference seen in the plurality condition. -/
 theorem english_diminutive_prefers_XY :
-    (mkTableau
+    (Tableau.ofRanking
       (l1CandidatesFor englishGrammar .diminutive)
       (l1RankingFor englishGrammar .diminutive)
       (l1CandidatesFor_ne englishGrammar .diminutive)).optimal
@@ -149,7 +149,7 @@ theorem english_diminutive_prefers_XY :
     XY categorically; the data show attenuation or absence of the
     XX preference relative to the diminutive condition. -/
 theorem hebrew_plurality_prefers_XY :
-    (mkTableau
+    (Tableau.ofRanking
       (l1CandidatesFor hebrewGrammar .plurality)
       (l1RankingFor hebrewGrammar .plurality)
       (l1CandidatesFor_ne hebrewGrammar .plurality)).optimal
@@ -161,7 +161,7 @@ theorem hebrew_plurality_prefers_XY :
     transfer makes the reduplication parse available. The categorical
     prediction captures the direction of the effect. -/
 theorem hebrew_diminutive_prefers_XX :
-    (mkTableau
+    (Tableau.ofRanking
       (l1CandidatesFor hebrewGrammar .diminutive)
       (l1RankingFor hebrewGrammar .diminutive)
       (l1CandidatesFor_ne hebrewGrammar .diminutive)).optimal
@@ -184,23 +184,23 @@ theorem hebrew_diminutive_prefers_XX :
     encodes both positive and negative transfer from L1 morphology. -/
 theorem doubling_dissociation :
     -- English: prefer XX for plurality, XY for diminutive
-    (mkTableau
+    (Tableau.ofRanking
       (l1CandidatesFor englishGrammar .plurality)
       (l1RankingFor englishGrammar .plurality)
       (l1CandidatesFor_ne englishGrammar .plurality)).optimal
       = {.reduplication} ∧
-    (mkTableau
+    (Tableau.ofRanking
       (l1CandidatesFor englishGrammar .diminutive)
       (l1RankingFor englishGrammar .diminutive)
       (l1CandidatesFor_ne englishGrammar .diminutive)).optimal
       = {.nonidentical} ∧
     -- Hebrew: prefer XY for plurality, XX for diminutive
-    (mkTableau
+    (Tableau.ofRanking
       (l1CandidatesFor hebrewGrammar .plurality)
       (l1RankingFor hebrewGrammar .plurality)
       (l1CandidatesFor_ne hebrewGrammar .plurality)).optimal
       = {.nonidentical} ∧
-    (mkTableau
+    (Tableau.ofRanking
       (l1CandidatesFor hebrewGrammar .diminutive)
       (l1RankingFor hebrewGrammar .diminutive)
       (l1CandidatesFor_ne hebrewGrammar .diminutive)).optimal

--- a/Linglib/Studies/CoetzeePater2011.lean
+++ b/Linglib/Studies/CoetzeePater2011.lean
@@ -551,7 +551,7 @@ theorem framework_separation :
 theorem max_dominates_implies_no_deletion :
     ∀ ctx : Context,
     let ranking := [maxC, maxPreV, maxFinal, starCT]
-    let tab := mkTableau (candidatesFor ctx) ranking
+    let tab := Tableau.ofRanking (candidatesFor ctx) ranking
       (by simp [candidatesFor])
     tab.optimal = {⟨ctx, .retain⟩} := by
   intro ctx; cases ctx <;> decide
@@ -561,7 +561,7 @@ theorem max_dominates_implies_no_deletion :
 theorem ct_dominates_implies_deletion :
     ∀ ctx : Context,
     let ranking := [starCT, maxC, maxPreV, maxFinal]
-    let tab := mkTableau (candidatesFor ctx) ranking
+    let tab := Tableau.ofRanking (candidatesFor ctx) ranking
       (by simp [candidatesFor])
     tab.optimal = {⟨ctx, .delete⟩} := by
   intro ctx; cases ctx <;> decide

--- a/Linglib/Studies/Erlewine2016.lean
+++ b/Linglib/Studies/Erlewine2016.lean
@@ -188,7 +188,7 @@ theorem candidates_differ :
     that avoids anti-locality wins, even though it loses Set A agreement.
     This is the central result of [erlewine-2016]. -/
 theorem af_is_optimal :
-    (mkTableau afCandidates afRanking).optimal =
+    (Tableau.ofRanking afCandidates afRanking).optimal =
       {AFCandidate.agentFocusExtraction} := by
   native_decide
 
@@ -246,7 +246,7 @@ theorem antilocality_grounded :
     by not placing the agent in Spec,TP at all. -/
 theorem antilocality_drives_af :
     ssalConstraint .agentFocusExtraction = 0 ∧
-    (mkTableau afCandidates afRanking).optimal =
+    (Tableau.ofRanking afCandidates afRanking).optimal =
       {AFCandidate.agentFocusExtraction} :=
   ⟨rfl, af_is_optimal⟩
 

--- a/Linglib/Studies/Faust2026.lean
+++ b/Linglib/Studies/Faust2026.lean
@@ -967,7 +967,7 @@ theorem kljCandidates_ne : kljCandidates ≠ [] := by decide
     `isMisaligned`/`allCSlotsFilled` computations on the `RootTemplateMatch`
     values — no stipulated violation tables. -/
 theorem kala_wins_under_misalign_over_fill :
-    (mkTableau kljCandidates [starMisalign, fill] kljCandidates_ne).optimal
+    (Tableau.ofRanking kljCandidates [starMisalign, fill] kljCandidates_ne).optimal
     = {hebrewKlj_kala} := by decide
 
 /-- **Reversed ranking** FILL >> \*Misalign predicts the spreading
@@ -976,7 +976,7 @@ theorem kala_wins_under_misalign_over_fill :
     dominance is doing the empirical work; without it, template
     satisfaction would force the wrong winner. -/
 theorem kalal_predicted_under_reversed_ranking :
-    (mkTableau kljCandidates [fill, starMisalign] kljCandidates_ne).optimal
+    (Tableau.ofRanking kljCandidates [fill, starMisalign] kljCandidates_ne).optimal
     = {hebrewKlj_kalal} := by decide
 
 /-- **Factorial typology over {\*Misalign, FILL}**: the two rankings
@@ -1000,7 +1000,7 @@ when the third radical is /j/. -/
     is filled and \*Misalignment is satisfied — both constraints have
     zero violations, so it wins under any ranking. -/
 theorem kalat_unique_optimum :
-    (mkTableau [hebrewKlt_kalat] [starMisalign, fill]
+    (Tableau.ofRanking [hebrewKlt_kalat] [starMisalign, fill]
       (by decide)).optimal = {hebrewKlt_kalat} := by decide
 
 /-- (3b) [kalal] from √kll likewise wins as the unique optimum: the
@@ -1010,7 +1010,7 @@ theorem kalat_unique_optimum :
     \*[kalal] derivation from √klj — only the underlying root index
     differs, and that's exactly what \*Misalignment is sensitive to. -/
 theorem kalal_from_kll_unique_optimum :
-    (mkTableau [hebrewKll_kalal] [starMisalign, fill]
+    (Tableau.ofRanking [hebrewKll_kalal] [starMisalign, fill]
       (by decide)).optimal = {hebrewKll_kalal} := by decide
 
 /-! ### The Hebrew taQTiL intrusion case as a three-candidate tableau
@@ -1043,14 +1043,14 @@ theorem taqtilCandidates_ne : taqtilCandidates ≠ [] := by decide
     wins. This is [faust-2026]'s core analytical point about (10):
     intrusion lets the grammar "have it both ways". -/
 theorem tadmit_wins_under_misalign_over_fill :
-    (mkTableau taqtilCandidates [starMisalign, fill]
+    (Tableau.ofRanking taqtilCandidates [starMisalign, fill]
       taqtilCandidates_ne).optimal = {hebrewDmj_tadmit} := by decide
 
 /-- And it wins under the reversed ranking too — because intrusion
     satisfies *both* constraints, the ranking between them is irrelevant
     once the intrusion candidate is in the candidate set. -/
 theorem tadmit_wins_under_fill_over_misalign :
-    (mkTableau taqtilCandidates [fill, starMisalign]
+    (Tableau.ofRanking taqtilCandidates [fill, starMisalign]
       taqtilCandidates_ne).optimal = {hebrewDmj_tadmit} := by decide
 
 /-- The taQTiL factorial typology collapses to **one** language: when an

--- a/Linglib/Studies/MarcoRasin2026.lean
+++ b/Linglib/Studies/MarcoRasin2026.lean
@@ -187,13 +187,13 @@ set_option maxHeartbeats 800000 in
     Majority Rules in action — the bare form aligns with the C-initial
     majority (5 medial vs 2 initial members). -/
 theorem op_correct_verbs :
-    (mkTableau verbCands mccarthyRanking verbCands_ne).optimal =
+    (Tableau.ofRanking verbCands mccarthyRanking verbCands_ne).optimal =
       {vA} := by decide
 
 /-- OP correctly selects CəCC for nouns (when C₂ > C₃). Single-member
     paradigm, so OP-MAX-V is vacuous; SONCON decides. -/
 theorem op_correct_nouns :
-    (mkTableau nounCands mccarthyRanking nounCands_ne).optimal =
+    (Tableau.ofRanking nounCands mccarthyRanking nounCands_ne).optimal =
       {nI} := by decide
 
 set_option maxHeartbeats 800000 in
@@ -202,13 +202,13 @@ set_option maxHeartbeats 800000 in
     cannot force medial schwa in the bare form. SONCON then favors
     initial. -/
 theorem op_wrong_adjectives :
-    (mkTableau adjCands mccarthyRanking adjCands_ne).optimal =
+    (Tableau.ofRanking adjCands mccarthyRanking adjCands_ne).optimal =
       {adjOPpred} := by decide
 
 set_option maxHeartbeats 800000 in
 /-- The attested adjective paradigm (bare=CCəC) is NOT selected by OP. -/
 theorem op_fails_adjectives :
-    (mkTableau adjCands mccarthyRanking adjCands_ne).optimal ≠
+    (Tableau.ofRanking adjCands mccarthyRanking adjCands_ne).optimal ≠
       {adjAttested} := by decide
 
 -- ============================================================================
@@ -236,15 +236,15 @@ theorem adjOPpred_zero_viols :
 
 /-- Structural consequence of `adjOPpred_zero_viols`: the uniform-initial
     paradigm is optimal under **every** permutation of the four OP
-    constraints. Uses `mkTableau_zero_optimal_allRankings` from the
+    constraints. Uses `Tableau.ofRanking_zero_optimal_allRankings` from the
     general OT infrastructure — no finitary enumeration needed. -/
 private theorem adjOPpred_mem : adjOPpred ∈ adjCands := by
   simp only [adjCands, adjOPpred, List.mem_cons]; tauto
 
 theorem adjOPpred_always_optimal :
-    ∀ ranking ∈ permutations opConstraints,
-      adjOPpred ∈ (mkTableau adjCands ranking adjCands_ne).optimal :=
-  mkTableau_zero_optimal_allRankings adjCands opConstraints adjCands_ne
+    ∀ ranking ∈ opConstraints.permutations',
+      adjOPpred ∈ (Tableau.ofRanking adjCands ranking adjCands_ne).optimal :=
+  Tableau.ofRanking_zero_optimal_allRankings adjCands opConstraints adjCands_ne
     adjOPpred adjOPpred_mem adjOPpred_zero_viols
 
 set_option maxHeartbeats 4000000 in
@@ -266,8 +266,8 @@ set_option maxHeartbeats 4000000 in
     derive category-distinct phonological behavior when two categories share
     paradigm structure but differ phonologically. -/
 theorem adj_always_initial :
-    ∀ ranking ∈ permutations opConstraints,
-      (mkTableau adjCands ranking adjCands_ne).optimal = {adjOPpred} := by
+    ∀ ranking ∈ opConstraints.permutations',
+      (Tableau.ofRanking adjCands ranking adjCands_ne).optimal = {adjOPpred} := by
   decide
 
 -- ============================================================================
@@ -280,13 +280,13 @@ theorem adj_always_initial :
     `op_wrong_adjectives` (tableau (19)), this shows OP fails
     **regardless of what constitutes a paradigm** for JTA adjectives. -/
 theorem op_wrong_adj_bare :
-    (mkTableau nounCands mccarthyRanking nounCands_ne).optimal =
+    (Tableau.ofRanking nounCands mccarthyRanking nounCands_ne).optimal =
       {nI} := op_correct_nouns
 
 /-- The attested adjective form (CCəC = medial) is NOT selected when
     adjectives are treated as having no paradigm. -/
 theorem op_wrong_adj_bare_not_attested :
-    (mkTableau nounCands mccarthyRanking nounCands_ne).optimal ≠
+    (Tableau.ofRanking nounCands mccarthyRanking nounCands_ne).optimal ≠
       {nM} := by decide
 
 -- ============================================================================
@@ -320,12 +320,12 @@ def verbTemplateCands : List (List JTAForm) := [verbUnifM, verbUnifI]
 theorem verbTemplateCands_ne : verbTemplateCands ≠ [] := by simp [verbTemplateCands]
 
 theorem template_correct_verbs :
-    (mkTableau verbTemplateCands (templateRanking .verb) verbTemplateCands_ne).optimal =
+    (Tableau.ofRanking verbTemplateCands (templateRanking .verb) verbTemplateCands_ne).optimal =
       {verbUnifM} := by decide
 
 /-- Template correctly selects initial (CəCC) for nouns (template inactive). -/
 theorem template_correct_nouns :
-    (mkTableau nounCands (templateRanking .noun) nounCands_ne).optimal =
+    (Tableau.ofRanking nounCands (templateRanking .noun) nounCands_ne).optimal =
       {nI} := by decide
 
 /-- Template correctly selects the attested adjective paradigm — the case
@@ -337,7 +337,7 @@ def adjTemplateCands : List (List JTAForm) :=
 theorem adjTemplateCands_ne : adjTemplateCands ≠ [] := by simp [adjTemplateCands]
 
 theorem template_correct_adjectives :
-    (mkTableau adjTemplateCands (templateRanking .adj) adjTemplateCands_ne).optimal =
+    (Tableau.ofRanking adjTemplateCands (templateRanking .adj) adjTemplateCands_ne).optimal =
       {mkP [.medial, .medial, .medial] aSuf} := by decide
 
 -- ============================================================================
@@ -354,7 +354,7 @@ open Core.Optimization Constraints
 
 /-- Verbal paradigm under McCarthy's OP ranking. -/
 noncomputable def verbSystem : ConstraintSystem (List JTAForm) (LexProfile Nat 4) :=
-  tableauSystem (mkTableau verbCands mccarthyRanking verbCands_ne)
+  tableauSystem (Tableau.ofRanking verbCands mccarthyRanking verbCands_ne)
 
 /-- OP correctly predicts the attested bare-medial verbal paradigm (10a). -/
 theorem verbSystem_predict_vA : verbSystem.predict vA = 1 :=
@@ -362,7 +362,7 @@ theorem verbSystem_predict_vA : verbSystem.predict vA = 1 :=
 
 /-- Nominal paradigm under McCarthy's OP ranking. -/
 noncomputable def nounSystem : ConstraintSystem (List JTAForm) (LexProfile Nat 4) :=
-  tableauSystem (mkTableau nounCands mccarthyRanking nounCands_ne)
+  tableauSystem (Tableau.ofRanking nounCands mccarthyRanking nounCands_ne)
 
 /-- OP correctly predicts CəCC for nouns when C₂ > C₃. -/
 theorem nounSystem_predict_nI : nounSystem.predict nI = 1 :=
@@ -372,7 +372,7 @@ theorem nounSystem_predict_nI : nounSystem.predict nI = 1 :=
     prediction here is the *wrong* uniform-initial paradigm — the formal
     content of [marco-rasin-2026]'s challenge. -/
 noncomputable def adjSystem : ConstraintSystem (List JTAForm) (LexProfile Nat 4) :=
-  tableauSystem (mkTableau adjCands mccarthyRanking adjCands_ne)
+  tableauSystem (Tableau.ofRanking adjCands mccarthyRanking adjCands_ne)
 
 /-- OP wrongly assigns probability 1 to the uniform-initial adjective
     paradigm. The attested CCəC pattern receives probability 0 — the
@@ -389,7 +389,7 @@ theorem adjSystem_predict_attested_zero :
 /-- Verbal paradigm under the category-specific template ranking. -/
 noncomputable def verbTemplateSystem :
     ConstraintSystem (List JTAForm) (LexProfile Nat 2) :=
-  tableauSystem (mkTableau verbTemplateCands (templateRanking .verb) verbTemplateCands_ne)
+  tableauSystem (Tableau.ofRanking verbTemplateCands (templateRanking .verb) verbTemplateCands_ne)
 
 theorem verbTemplateSystem_predict_unifM :
     verbTemplateSystem.predict verbUnifM = 1 :=
@@ -399,7 +399,7 @@ theorem verbTemplateSystem_predict_unifM :
     now correctly predicting the attested medial pattern with probability 1. -/
 noncomputable def adjTemplateSystem :
     ConstraintSystem (List JTAForm) (LexProfile Nat 2) :=
-  tableauSystem (mkTableau adjTemplateCands (templateRanking .adj) adjTemplateCands_ne)
+  tableauSystem (Tableau.ofRanking adjTemplateCands (templateRanking .adj) adjTemplateCands_ne)
 
 theorem adjTemplateSystem_predict_medial :
     adjTemplateSystem.predict (mkP [.medial, .medial, .medial] aSuf) = 1 :=

--- a/Linglib/Studies/McCarthyPrince1995.lean
+++ b/Linglib/Studies/McCarthyPrince1995.lean
@@ -98,7 +98,7 @@ theorem javCandidates_ne : javCandidates ≠ [] := by simp [javCandidates]
     output sacrifices faithfulness to achieve both identity and
     phonological well-formedness. -/
 theorem javanese_overapplication :
-    (mkTableau javCandidates javRanking javCandidates_ne).optimal
+    (Tableau.ofRanking javCandidates javRanking javCandidates_ne).optimal
     = {JavaneseCand.over} := by decide
 
 -- ============================================================================
@@ -273,7 +273,7 @@ theorem balCandidates_ne : balCandidates ≠ [] := by simp [balCandidates]
     generally permit codas — because B-R identity (MAX-BR) is low-ranked,
     the unmarked (coda-free) structure emerges in the reduplicant. -/
 theorem balangao_emergence_unmarked :
-    (mkTableau balCandidates balRanking balCandidates_ne).optimal
+    (Tableau.ofRanking balCandidates balRanking balCandidates_ne).optimal
     = {.partialRedup} := by decide
 
 -- ============================================================================
@@ -394,39 +394,39 @@ theorem basicCandidates_ne : basicCandidates ≠ [] := by simp [basicCandidates]
 /-- Non-application ranking (ex. 104): IO-Faith, BR-Id >> Phono.
     The faithful candidate wins — phonology cannot affect anything. -/
 theorem nonapplication_io_br_phono :
-    (mkTableau basicCandidates [basicIOFaith, basicBRId, basicPhono]
+    (Tableau.ofRanking basicCandidates [basicIOFaith, basicBRId, basicPhono]
       basicCandidates_ne).optimal = {.faithful} := by decide
 
 /-- Non-application (symmetric): BR-Id, IO-Faith >> Phono.
     Same outcome — faithful candidate wins regardless of IO/BR order. -/
 theorem nonapplication_br_io_phono :
-    (mkTableau basicCandidates [basicBRId, basicIOFaith, basicPhono]
+    (Tableau.ofRanking basicCandidates [basicBRId, basicIOFaith, basicPhono]
       basicCandidates_ne).optimal = {.faithful} := by decide
 
 /-- Emergence of the unmarked (ex. 105): IO-Faith >> Phono >> BR-Id.
     The normal candidate wins — phonology affects the reduplicant
     (low BR-Id), but the base is protected (high IO-Faith). -/
 theorem emergence_unmarked :
-    (mkTableau basicCandidates [basicIOFaith, basicPhono, basicBRId]
+    (Tableau.ofRanking basicCandidates [basicIOFaith, basicPhono, basicBRId]
       basicCandidates_ne).optimal = {BasicCand.normal} := by decide
 
 /-- Overapplication: Phono >> IO-Faith >> BR-Id.
     The over candidate wins — phonological unmarking applies to both
     B and R, sacrificing IO faithfulness. -/
 theorem overapplication_phono_io_br :
-    (mkTableau basicCandidates [basicPhono, basicIOFaith, basicBRId]
+    (Tableau.ofRanking basicCandidates [basicPhono, basicIOFaith, basicBRId]
       basicCandidates_ne).optimal = {BasicCand.over} := by decide
 
 /-- Overapplication: Phono >> BR-Id >> IO-Faith.
     Same outcome — phonology dominates. -/
 theorem overapplication_phono_br_io :
-    (mkTableau basicCandidates [basicPhono, basicBRId, basicIOFaith]
+    (Tableau.ofRanking basicCandidates [basicPhono, basicBRId, basicIOFaith]
       basicCandidates_ne).optimal = {BasicCand.over} := by decide
 
 /-- Overapplication: BR-Id >> Phono >> IO-Faith.
     B-R identity copies phonological effects to both B and R. -/
 theorem overapplication_br_phono_io :
-    (mkTableau basicCandidates [basicBRId, basicPhono, basicIOFaith]
+    (Tableau.ofRanking basicCandidates [basicBRId, basicPhono, basicIOFaith]
       basicCandidates_ne).optimal = {BasicCand.over} := by decide
 
 /-- **Factorial typology summary**: all 6 rankings of 3 constraints produce
@@ -590,7 +590,7 @@ theorem akanCandidates_ne : akanCandidates ≠ [] := by simp [akanCandidates]
     OCP blocks overapplication, IDENT-BR blocks normal application,
     leaving underapplication as the only surviving candidate. -/
 theorem akan_underapplication :
-    (mkTableau akanCandidates akanRanking akanCandidates_ne).optimal
+    (Tableau.ofRanking akanCandidates akanRanking akanCandidates_ne).optimal
     = {AkanCand.under} := by decide
 
 -- ============================================================================
@@ -749,7 +749,7 @@ open Core.Optimization Constraints
 
 /-- Javanese overapplication tableau as a generic `ConstraintSystem`. -/
 noncomputable def javaneseSystem : ConstraintSystem JavaneseCand (LexProfile Nat 3) :=
-  tableauSystem (mkTableau javCandidates javRanking javCandidates_ne)
+  tableauSystem (Tableau.ofRanking javCandidates javRanking javCandidates_ne)
 
 /-- The OT prediction lifts: the overapplicational candidate is assigned
     probability 1 under IDENT-BR, *VhV >> MAX-IO. -/
@@ -759,7 +759,7 @@ theorem javaneseSystem_predict_over :
 
 /-- Balangao emergence-of-the-unmarked tableau as a generic `ConstraintSystem`. -/
 noncomputable def balangaoSystem : ConstraintSystem BalangaoCand (LexProfile Nat 3) :=
-  tableauSystem (mkTableau balCandidates balRanking balCandidates_ne)
+  tableauSystem (Tableau.ofRanking balCandidates balRanking balCandidates_ne)
 
 /-- The OT prediction lifts: the partial-reduplicant candidate is assigned
     probability 1 under MAX-IO >> NO-CODA >> MAX-BR. -/
@@ -769,7 +769,7 @@ theorem balangaoSystem_predict_partial :
 
 /-- Akan underapplication tableau as a generic `ConstraintSystem`. -/
 noncomputable def akanSystem : ConstraintSystem AkanCand (LexProfile Nat 4) :=
-  tableauSystem (mkTableau akanCandidates akanRanking akanCandidates_ne)
+  tableauSystem (Tableau.ofRanking akanCandidates akanRanking akanCandidates_ne)
 
 /-- The OT prediction lifts: the underapplicational candidate is assigned
     probability 1 under OCP(+cor) >> IDENT-BR(−cor) >> PAL >> IDENT-IO(−cor). -/

--- a/Linglib/Studies/Sauerland2003.lean
+++ b/Linglib/Studies/Sauerland2003.lean
@@ -161,7 +161,7 @@ theorem sg_strictly_stronger {E : Type*} [PartialOrder E]
 theorem mp_selects_sg
     (rest : List (Constraint ContainmentPair))
     (hNE : [ContainmentPair.maximal, .minimal] ≠ []) :
-    ∀ c ∈ (mkTableau [.maximal, .minimal]
+    ∀ c ∈ (Tableau.ofRanking [.maximal, .minimal]
       (phiMP :: rest) hNE).optimal,
     presupStrength c = ContainmentPair.maximal.specLevel :=
   phi_mp_selects_maximal _ rest hNE (by decide) (.head _)

--- a/Linglib/Studies/SiptarTorkenczy2000.lean
+++ b/Linglib/Studies/SiptarTorkenczy2000.lean
@@ -15,7 +15,7 @@ End-to-end OT analysis of Hungarian vowel harmony, connecting:
 2. **Harmony system** (`Subregular.Harmony`) — trigger/target/transparent predicates
 3. **OT constraints** (below) — SPREAD and IDENT derived from
    `System` (folded in from the former `Harmony/OT.lean`, this file's sole consumer)
-4. **Tableaux** (`Constraint`) — `mkTableau` + `optimal` select winner
+4. **Tableaux** (`Constraint`) — `Tableau.ofRanking` + `optimal` select winner
 5. **Hungarian fragments** (`Hungarian.VowelHarmony`) — concrete
    vowel segments and `hungarianPalatalHarmony`
 
@@ -253,20 +253,20 @@ theorem papírCands_ne : papírCands ≠ [] := by simp [papírCands]
 /-- *ház*: SPREAD ≫ IDENT selects back-harmonized suffix as unique winner.
     [siptar-torkenczy-2000] §3.2.2, class IA-b. -/
 theorem ház_back_optimal :
-    (mkTableau házCands spreadDominant házCands_ne).optimal
+    (Tableau.ofRanking házCands spreadDominant házCands_ne).optimal
       = {ház_back} := by native_decide
 
 /-- *tűz*: SPREAD ≫ IDENT selects front-harmonized suffix as unique winner.
     [siptar-torkenczy-2000] §3.2.2, class IA-f. -/
 theorem tűz_front_optimal :
-    (mkTableau tűzCands spreadDominant tűzCands_ne).optimal
+    (Tableau.ofRanking tűzCands spreadDominant tűzCands_ne).optimal
       = {tűz_front} := by native_decide
 
 /-- *papír*: neutral /i/ is transparent — back harmony passes through.
     SPREAD ≫ IDENT selects back-harmonized suffix, same as *ház*.
     [siptar-torkenczy-2000] §3.2.2, class IIB-b. -/
 theorem papír_transparency_optimal :
-    (mkTableau papírCands spreadDominant papírCands_ne).optimal
+    (Tableau.ofRanking papírCands spreadDominant papírCands_ne).optimal
       = {papír_back} := by native_decide
 
 -- ============================================================================
@@ -276,7 +276,7 @@ theorem papír_transparency_optimal :
 /-- Under IDENT ≫ SPREAD, the faithful candidate wins — no harmony applies.
     This is the predicted grammar for a language without vowel harmony. -/
 theorem faithful_wins_reversed :
-    (mkTableau házCands identDominant házCands_ne).optimal
+    (Tableau.ofRanking házCands identDominant házCands_ne).optimal
       = {ház_faithful} := by native_decide
 
 -- ============================================================================
@@ -299,7 +299,7 @@ theorem factorial_two_types :
 /-- The OT-optimal candidate for *ház* is identical to the output of
     `spreadSuffix` — the direct computation and the OT analysis agree. -/
 theorem ház_ot_matches_direct :
-    (mkTableau házCands spreadDominant házCands_ne).optimal
+    (Tableau.ofRanking házCands spreadDominant házCands_ne).optimal
       = {⟨[a_vowel], [archiphoneU],
           spreadSuffix hungarianPalatalHarmony true [archiphoneU]⟩} := by
   native_decide
@@ -308,7 +308,7 @@ theorem ház_ot_matches_direct :
     the trigger value extracted from the stem. Transparency is derived:
     `triggerValue` skips neutral /i/ and finds /a/. -/
 theorem papír_ot_matches_direct :
-    (mkTableau papírCands spreadDominant papírCands_ne).optimal
+    (Tableau.ofRanking papírCands spreadDominant papírCands_ne).optimal
       = {⟨[a_vowel, i_vowel], [archiphoneU],
           spreadSuffix hungarianPalatalHarmony true [archiphoneU]⟩} := by
   native_decide
@@ -327,7 +327,7 @@ open Core.Optimization Constraints
 
 /-- *ház* SPREAD ≫ IDENT tableau as a generic `ConstraintSystem`. -/
 noncomputable def házSystem : ConstraintSystem VHCandidate (LexProfile Nat 2) :=
-  tableauSystem (mkTableau házCands spreadDominant házCands_ne)
+  tableauSystem (Tableau.ofRanking házCands spreadDominant házCands_ne)
 
 /-- The OT prediction lifts to a probability claim: under SPREAD ≫ IDENT,
     the back-harmonized candidate is assigned probability 1. -/
@@ -343,7 +343,7 @@ theorem házSystem_predict_faithful_zero :
 
 /-- *tűz* under SPREAD ≫ IDENT: front-harmonized winner gets probability 1. -/
 noncomputable def tűzSystem : ConstraintSystem VHCandidate (LexProfile Nat 2) :=
-  tableauSystem (mkTableau tűzCands spreadDominant tűzCands_ne)
+  tableauSystem (Tableau.ofRanking tűzCands spreadDominant tűzCands_ne)
 
 theorem tűzSystem_predict_front :
     tűzSystem.predict tűz_front = 1 :=

--- a/Linglib/Studies/Stojkovic2026.lean
+++ b/Linglib/Studies/Stojkovic2026.lean
@@ -277,17 +277,17 @@ def uvRanking : List (Constraint VBLZCandidate) :=
 
 /-- The [ov]-group ranking selects [ov] as the unique optimum. -/
 theorem ov_optimal :
-    (mkTableau allCandidates ovRanking).optimal = {.ov} := by decide
+    (Tableau.ofRanking allCandidates ovRanking).optimal = {.ov} := by decide
 
 /-- The [ov]/[ev] ranking selects [ev] in the palatal context. (Non-palatally,
     [ev] and [iv] are unavailable — no palatal to share [−back] — and [ov] wins;
     that contextual split is not modelled in this single tableau.) -/
 theorem ev_optimal :
-    (mkTableau allCandidates ovEvRanking).optimal = {.ev} := by decide
+    (Tableau.ofRanking allCandidates ovEvRanking).optimal = {.ev} := by decide
 
 /-- The [uv]-group ranking selects [uv] as the unique optimum. -/
 theorem uv_optimal :
-    (mkTableau allCandidates uvRanking).optimal = {.uv} := by decide
+    (Tableau.ofRanking allCandidates uvRanking).optimal = {.uv} := by decide
 
 /-! ### Factorial typology -/
 

--- a/Linglib/Studies/Wang2023.lean
+++ b/Linglib/Studies/Wang2023.lean
@@ -246,7 +246,7 @@ private theorem binaryCandidates_ne : binaryCandidates ≠ [] := by
     constraints (ToD from politeness, MP! from presupposition theory)
     evaluated over the `ContainmentPair` structure from [harbour-2016]. -/
 theorem tod_mp_selects_minimal :
-    (mkTableau binaryCandidates [todConstraint, mpConstraint]
+    (Tableau.ofRanking binaryCandidates [todConstraint, mpConstraint]
       binaryCandidates_ne).optimal = {ContainmentPair.minimal} := by
   native_decide
 
@@ -254,13 +254,13 @@ theorem tod_mp_selects_minimal :
     Non-respect speech uses the strongest presupposition.
     This is the standard Maximize Presupposition from [heim-1991]. -/
 theorem mp_tod_selects_maximal :
-    (mkTableau binaryCandidates [mpConstraint, todConstraint]
+    (Tableau.ofRanking binaryCandidates [mpConstraint, todConstraint]
       binaryCandidates_ne).optimal = {ContainmentPair.maximal} := by
   native_decide
 
 /-- The optimal candidate under ToD >> MP! is semantically unmarked. -/
 theorem tod_mp_optimal_is_unmarked :
-    ∀ c ∈ (mkTableau binaryCandidates [todConstraint, mpConstraint]
+    ∀ c ∈ (Tableau.ofRanking binaryCandidates [todConstraint, mpConstraint]
       binaryCandidates_ne).optimal,
       isSemanticUnmarked c = true := by
   decide
@@ -320,7 +320,7 @@ theorem stod_eval_eq_tod (c : ContainmentPair) :
 /-- WToD >> MP! >> SToD selects the intermediate (dual) cell.
     Moderate respect in articulated number systems. -/
 theorem wtod_mp_stod_selects_dual :
-    (mkTableau ternaryCandidates
+    (Tableau.ofRanking ternaryCandidates
       [wtodConstraint, mpConstraint, todConstraint]
       ternaryCandidates_ne).optimal = {ContainmentPair.intermediate} := by
   native_decide
@@ -328,7 +328,7 @@ theorem wtod_mp_stod_selects_dual :
 /-- SToD >> MP! >> WToD selects the minimal (plural) cell.
     Maximal respect (French/Slovenian-type pattern). -/
 theorem stod_mp_wtod_selects_plural :
-    (mkTableau ternaryCandidates
+    (Tableau.ofRanking ternaryCandidates
       [todConstraint, mpConstraint, wtodConstraint]
       ternaryCandidates_ne).optimal = {ContainmentPair.minimal} := by
   native_decide
@@ -336,7 +336,7 @@ theorem stod_mp_wtod_selects_plural :
 /-- MP! >> SToD >> WToD selects the maximal (singular) cell.
     Normal non-honorific speech. -/
 theorem mp_stod_wtod_selects_singular :
-    (mkTableau ternaryCandidates
+    (Tableau.ofRanking ternaryCandidates
       [mpConstraint, todConstraint, wtodConstraint]
       ternaryCandidates_ne).optimal = {ContainmentPair.maximal} := by
   native_decide
@@ -388,7 +388,7 @@ locus, embeddability) is orthogonal — [iHON] may play a role in the
     2. The minimal cell is semantically unmarked
     3. All attested strategies target the minimal cell -/
 theorem ihon_redundant_for_recruitment :
-    (mkTableau binaryCandidates [todConstraint, mpConstraint]
+    (Tableau.ofRanking binaryCandidates [todConstraint, mpConstraint]
       binaryCandidates_ne).optimal = {ContainmentPair.minimal} ∧
     isSemanticUnmarked .minimal = true ∧
     (∀ s : HonStrategy, honStrategyCell s = .minimal) :=
@@ -470,12 +470,12 @@ theorem tod_mp_only_minimal (candidates : List ContainmentPair)
     (hWF : ∀ c ∈ candidates, c.WellFormed)
     (hMin : ContainmentPair.minimal ∈ candidates)
     (hNE : candidates ≠ []) :
-    ∀ c ∈ (mkTableau candidates [todConstraint, mpConstraint] hNE).optimal,
+    ∀ c ∈ (Tableau.ofRanking candidates [todConstraint, mpConstraint] hNE).optimal,
       c = .minimal := by
   intro c hc
-  have hZero := mkTableau_optimal_zero_first candidates todConstraint [mpConstraint] hNE
+  have hZero := Tableau.ofRanking_optimal_zero_first candidates todConstraint [mpConstraint] hNE
     ⟨.minimal, hMin, rfl⟩ c hc
-  have hcWF := hWF c (mkTableau_optimal_mem candidates _ hNE c hc)
+  have hcWF := hWF c (Tableau.ofRanking_optimal_mem candidates _ hNE c hc)
   rcases ContainmentPair.classification c hcWF with rfl | rfl | rfl
   · exact absurd hZero (by decide)
   · exact absurd hZero (by decide)
@@ -487,10 +487,10 @@ theorem tod_mp_minimal_is_optimal (candidates : List ContainmentPair)
     (hMin : ContainmentPair.minimal ∈ candidates)
     (hNE : candidates ≠ []) :
     ContainmentPair.minimal ∈
-      (mkTableau candidates [todConstraint, mpConstraint] hNE).optimal := by
+      (Tableau.ofRanking candidates [todConstraint, mpConstraint] hNE).optimal := by
   rw [Tableau.mem_optimal_iff]
   refine ⟨List.mem_toFinset.mpr hMin, fun c' _ => ?_⟩
-  simp only [mkTableau, buildViolationProfile]
+  simp only [Tableau.ofRanking, buildViolationProfile]
   -- Goal: toLex (fun i => ..minimal..) ≤ toLex (fun i => ..c'..)
   -- Strategy: show ¬ (c' profile < minimal profile) using Pi.Lex
   apply not_lt.mp
@@ -531,8 +531,8 @@ theorem tod_mp_general (candidates : List ContainmentPair)
     (hMin : ContainmentPair.minimal ∈ candidates)
     (hNE : candidates ≠ []) :
     ContainmentPair.minimal ∈
-      (mkTableau candidates [todConstraint, mpConstraint] hNE).optimal ∧
-    ∀ c ∈ (mkTableau candidates [todConstraint, mpConstraint] hNE).optimal,
+      (Tableau.ofRanking candidates [todConstraint, mpConstraint] hNE).optimal ∧
+    ∀ c ∈ (Tableau.ofRanking candidates [todConstraint, mpConstraint] hNE).optimal,
       c = .minimal :=
   ⟨tod_mp_minimal_is_optimal candidates hMin hNE,
    tod_mp_only_minimal candidates hWF hMin hNE⟩
@@ -632,8 +632,8 @@ theorem ihon_structurally_redundant :
        (_ : ContainmentPair.minimal ∈ candidates)
        (hNE : candidates ≠ []),
        ContainmentPair.minimal ∈
-         (mkTableau candidates [todConstraint, mpConstraint] hNE).optimal ∧
-       ∀ c ∈ (mkTableau candidates [todConstraint, mpConstraint] hNE).optimal,
+         (Tableau.ofRanking candidates [todConstraint, mpConstraint] hNE).optimal ∧
+       ∀ c ∈ (Tableau.ofRanking candidates [todConstraint, mpConstraint] hNE).optimal,
          c = .minimal) :=
   ⟨rfl, rfl, honLevel_all_wellFormed, tod_mp_general⟩
 


### PR DESCRIPTION
Rename the tableau constructor `mkTableau → Tableau.ofRanking` (mathlib `of`-style; the `List` argument is the ranking), and add the `Equiv.Perm`-indexed `Tableau.ofPerm con r` (priority `p` reads `con (r p)`) as the ranking currency for the abstract layer.

- Replace the bespoke `permutations`/`insertEverywhere` (~70 lines reinventing `List.permutations'`) with mathlib's `List.permutations'` + `mem_permutations'`; `by decide` factorial typology is preserved (`List.permutations` and `Finset.univ : Finset (Equiv.Perm _)` both `decide`-stick or are prohibitively slow on real studies).
- `Tableau.ofPerm_isOptimal_iff_satisfiedBy` connects the `Sₙ` action on a fixed `CON` to ERC consistency (`tableauERC`); `Tableau.ofPerm_zero_isOptimal` is the n-agnostic harmonic-bounding result.