### PR TITLE
refactor(Phonology/Autosegmental): Crosses relation + general IndexCrosses

### DIFF
--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -214,11 +214,11 @@ def deleteLink (k : TierIdx) (i : SegIdx) : FloatingForm S T :=
 /-! ### Well-formedness: no crossing lines -/
 
 /-- A candidate link `(k, i)` would **cross** an existing surface link.
-    Wraps the substrate `IndexCrosses` defined over `Finset (ℕ × ℕ)`;
+    Wraps the substrate `IndexCrosses` on the candidate link `(k, i)`;
     `IsNonCrossing` (via mathlib's `MonovaryOn`) provides the set-level
     NCC and inherits mathlib's lemma library. -/
 abbrev Crosses (k : TierIdx) (i : SegIdx) : Prop :=
-  IndexCrosses f.surfaceLinks k i
+  IndexCrosses f.surfaceLinks (k, i)
 
 /-! ### GEN: one-step candidate generation -/
 

--- a/Linglib/Phonology/Autosegmental/Graph.lean
+++ b/Linglib/Phonology/Autosegmental/Graph.lean
@@ -179,7 +179,7 @@ def eraseLink (i j : ℕ) : Graph α β :=
 
 /-- `insertLink` preserves planarity if the new link crosses nothing. -/
 theorem isPlanar_insertLink {i j : ℕ}
-    (hP : r.IsPlanar) (hNX : ¬ IndexCrosses r.links i j) :
+    (hP : r.IsPlanar) (hNX : ¬ IndexCrosses r.links (i, j)) :
     (r.insertLink i j).IsPlanar :=
   IsNonCrossing.insert_of_not_indexCrosses hP hNX
 
@@ -275,10 +275,10 @@ theorem concat_assoc (A B C : Graph α β) :
 /-! #### Planarity preservation ([jardine-heinz-2015] Theorem 4) -/
 
 /-- Shifting a link set preserves non-crossing: `shiftLink` is a coordinatewise
-    order-embedding, so by `monovaryOn_image` it preserves monovariance. -/
+    order-embedding, so via `isNonCrossing_image` it preserves monovariance. -/
 theorem isNonCrossing_image_shiftLink (s : Finset (ℕ × ℕ)) (δᵤ δₗ : ℕ) :
     IsNonCrossing (s.image (shiftLink δᵤ δₗ)) ↔ IsNonCrossing s := by
-  grind [IsNonCrossing, Finset.coe_image, monovaryOn_image, MonovaryOn, shiftLink]
+  grind [isNonCrossing_image, IsNonCrossing, MonovaryOn, shiftLink]
 
 /-- Concatenation preserves planarity, given `A.InBounds`: `A.links` and the
     shifted `B.links` are each non-crossing (`monovaryOn_union` +

--- a/Linglib/Phonology/Autosegmental/MultiGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MultiGraph.lean
@@ -99,10 +99,10 @@ theorem shiftLink_comp (a₁ a₂ b₁ b₂ : ℕ) :
     shiftLink a₁ a₂ ∘ shiftLink b₁ b₂ = shiftLink (a₁ + b₁) (a₂ + b₂) := by
   funext p; simp only [Function.comp_apply, shiftLink_apply, Prod.mk.injEq]; omega
 
-/-- Shifting a link set preserves non-crossing. -/
+/-- Shifting a link set preserves non-crossing (via `isNonCrossing_image`). -/
 theorem isNonCrossing_image_shiftLink (s : Finset (ℕ × ℕ)) (δ₁ δ₂ : ℕ) :
     IsNonCrossing (s.image (shiftLink δ₁ δ₂)) ↔ IsNonCrossing s := by
-  grind [IsNonCrossing, Finset.coe_image, monovaryOn_image, MonovaryOn, shiftLink]
+  grind [isNonCrossing_image, IsNonCrossing, MonovaryOn, shiftLink]
 
 /-! ### Concatenation ([jardine-heinz-2015], fiberwise coproduct) -/
 

--- a/Linglib/Phonology/Autosegmental/NonCrossing.lean
+++ b/Linglib/Phonology/Autosegmental/NonCrossing.lean
@@ -18,41 +18,40 @@ absence of crossing segments. This is the discrete-index
 [goldsmith-1976] / [sagey-1986] No-Crossing Constraint and the canonical
 filter on autosegmental GEN.
 
-## Main declarations
+## Main definitions
 
 * `IsNonCrossing links`: the link set monovaries (`[Preorder]`-general).
-* `IndexCrosses links k i`: `(k, i)` crosses an existing link — decidable, `ℕ`-indexed GEN filter.
+* `Crosses a b` / `IndexCrosses links p`: two links cross; `p` crosses some link
+  already in `links` — the decidable GEN filter.
 
 ## Main results
 
-* `isNonCrossing_iff`: the elementary `∀∀→` form of `IsNonCrossing`.
-* `IsNonCrossing.subset`: subset closure.
-* `isNonCrossing_insert_iff'`: the insert-algebra — `insert p` stays
-  non-crossing iff `p` is pairwise non-crossing with every existing link.
-* `indexCrosses_iff`: the elementary index-ordering form of `IndexCrosses`.
-* `isNonCrossing_insert_iff`: a candidate may be added iff it crosses
-  nothing; `IsNonCrossing.insert_of_not_indexCrosses` is the GEN direction.
+* `isNonCrossing_insert_iff_not_indexCrosses`: a candidate may be added iff it
+  crosses nothing (`IsNonCrossing.insert_of_not_indexCrosses` is the GEN direction).
+* `isNonCrossing_image` / `IsNonCrossing.image_monotone`: `IsNonCrossing` commutes
+  with `Finset.image`, and survives monotone reindexing of the upper coordinate.
 -/
 
 namespace Autosegmental
 
+variable {ι ι' κ κ' : Type*}
+
 /-! ### Set-level non-crossing property (via mathlib `MonovaryOn`) -/
 
-section
-variable {ι κ : Type*} [Preorder ι] [Preorder κ] (links : Finset (ι × κ))
+section Preorder
+variable [Preorder ι] [Preorder κ] {links : Finset (ι × κ)}
 
 /-- The link set has no crossings: its two index coordinates monovary. -/
-def IsNonCrossing : Prop := MonovaryOn Prod.snd Prod.fst (↑links : Set (ι × κ))
+def IsNonCrossing (links : Finset (ι × κ)) : Prop :=
+  MonovaryOn Prod.snd Prod.fst (↑links : Set (ι × κ))
 
 /-- `IsNonCrossing` in elementary form. -/
 theorem isNonCrossing_iff : IsNonCrossing links ↔
-    ∀ l₁ ∈ links, ∀ l₂ ∈ links, l₁.fst < l₂.fst → l₁.snd ≤ l₂.snd := Iff.rfl
+    ∀ l₁ ∈ links, ∀ l₂ ∈ links, l₁.1 < l₂.1 → l₁.2 ≤ l₂.2 := Iff.rfl
 
-@[simp] theorem isNonCrossing_empty : IsNonCrossing (∅ : Finset (ι × κ)) := by
-  simp [IsNonCrossing]
+@[simp] theorem isNonCrossing_empty : IsNonCrossing (∅ : Finset (ι × κ)) := by simp [IsNonCrossing]
 
-@[simp] theorem isNonCrossing_singleton (p : ι × κ) : IsNonCrossing {p} := by
-  simp [IsNonCrossing]
+@[simp] theorem isNonCrossing_singleton (p : ι × κ) : IsNonCrossing {p} := by simp [IsNonCrossing]
 
 /-- A pair is non-crossing iff its two links agree in tier- and backbone-order. -/
 theorem isNonCrossing_pair [DecidableEq ι] [DecidableEq κ] (a b : ι × κ) :
@@ -64,79 +63,107 @@ theorem IsNonCrossing.subset {s t : Finset (ι × κ)} (hst : s ⊆ t)
     (h : IsNonCrossing t) : IsNonCrossing s :=
   MonovaryOn.subset (Finset.coe_subset.mpr hst) h
 
+/-- Inserting `p` keeps non-crossing iff `p` crosses no existing link: the
+    insert-algebra form, `Set.pairwise_insert` specialised to `IsNonCrossing`
+    via `monovaryOn_insert`. -/
+theorem isNonCrossing_insert_iff [DecidableEq ι] [DecidableEq κ] (p : ι × κ) :
+    IsNonCrossing (insert p links) ↔
+      IsNonCrossing links ∧ ∀ q ∈ links, IsNonCrossing {p, q} := by
+  simp [IsNonCrossing, monovaryOn_insert]
+
+instance [DecidableLT ι] [DecidableLE κ] : Decidable (IsNonCrossing links) :=
+  decidable_of_iff _ isNonCrossing_iff.symm
+
+end Preorder
+
+/-! ### Reindexing along `Finset.image` -/
+
+section Image
+variable [Preorder ι'] [Preorder κ'] [DecidableEq ι'] [DecidableEq κ'] {links : Finset (ι × κ)}
+
+/-- `IsNonCrossing` transports across a `Finset.image`: the image link set is
+    non-crossing iff the index coordinates monovary after reindexing by `f`. The
+    `Finset` companion of `monovaryOn_image`, and the single place the definition
+    is unfolded against an image. -/
+theorem isNonCrossing_image (f : ι × κ → ι' × κ') :
+    IsNonCrossing (links.image f) ↔
+      MonovaryOn (Prod.snd ∘ f) (Prod.fst ∘ f) (↑links : Set (ι × κ)) := by
+  simp only [IsNonCrossing, Finset.coe_image, monovaryOn_image]
+
+end Image
+
+section ImageMonotone
+variable [LinearOrder ι] [Preorder ι'] [Preorder κ] [DecidableEq ι'] [DecidableEq κ]
+  {links : Finset (ι × κ)} {ρ : ι → ι'}
+
 /-- Pushing a non-crossing link set forward along a **monotone** map on the upper
     (first) coordinate keeps it non-crossing: the autosegmental analogue of
     `SimpleGraph.map` along a monotone vertex map. The upper index needs a
     `LinearOrder` (the run-collapse domain is `ℕ`) so that `ρ` reflects `<`. Used to
     lift planarity through the OCP run-collapse `ρ` (`Autosegmental/Collapse.lean`). -/
-theorem IsNonCrossing.image_monotone {ι ι' κ : Type*} [LinearOrder ι] [Preorder ι']
-    [Preorder κ] [DecidableEq ι'] [DecidableEq κ] {links : Finset (ι × κ)}
-    {ρ : ι → ι'} (hρ : Monotone ρ) (h : IsNonCrossing links) :
+theorem IsNonCrossing.image_monotone (hρ : Monotone ρ) (h : IsNonCrossing links) :
     IsNonCrossing (links.image (Prod.map ρ id)) := by
-  rw [isNonCrossing_iff] at h ⊢
-  rintro _ hl₁ _ hl₂ hlt
-  simp only [Finset.mem_image, Prod.exists, Prod.map_apply, id_eq] at hl₁ hl₂
-  obtain ⟨k₁, i₁, hp₁, rfl⟩ := hl₁
-  obtain ⟨k₂, i₂, hp₂, rfl⟩ := hl₂
-  have hlt' : ρ k₁ < ρ k₂ := hlt
-  exact h _ hp₁ _ hp₂ (hρ.reflect_lt hlt')
+  rw [isNonCrossing_image]; grind [IsNonCrossing, MonovaryOn, Monotone.reflect_lt]
 
-/-- Inserting `p` keeps non-crossing iff `p` crosses no existing link: the
-    insert-algebra form, `Set.pairwise_insert` specialised to `IsNonCrossing`
-    via `monovaryOn_insert`. -/
-theorem isNonCrossing_insert_iff' [DecidableEq ι] [DecidableEq κ] (p : ι × κ) :
-    IsNonCrossing (insert p links) ↔
-      IsNonCrossing links ∧ ∀ q ∈ links, IsNonCrossing {p, q} := by
-  simp [IsNonCrossing, monovaryOn_insert]
+end ImageMonotone
 
-instance [DecidableLT ι] [DecidableLE κ] :
-    Decidable (IsNonCrossing links) :=
-  decidable_of_iff _ (isNonCrossing_iff links).symm
+/-! ### The crossing relation and the GEN filter -/
 
-end
+section Candidate
+variable [Preorder ι] [Preorder κ] [DecidableEq ι] [DecidableEq κ]
+  {links : Finset (ι × κ)} {a b p : ι × κ}
 
-/-! ### Candidate-level crossing predicate (`ℕ`-indexed GEN filter) -/
+/-- Two links **cross**: as a pair they fail to be non-crossing (equivalently their
+    endpoints straddle in opposite tier- and backbone-order — `crosses_iff`). -/
+def Crosses (a b : ι × κ) : Prop := ¬ IsNonCrossing {a, b}
 
-section
-variable (links : Finset (ℕ × ℕ)) (k i : ℕ)
+/-- `p` crosses some link already in `links` — the decidable GEN filter. -/
+def IndexCrosses (links : Finset (ι × κ)) (p : ι × κ) : Prop := ∃ l ∈ links, Crosses p l
 
-/-- `(k, i)` crosses some link in `links` — the decidable GEN filter. -/
-def IndexCrosses : Prop :=
-  ∃ l ∈ links, ¬ IsNonCrossing {(k, i), l}
+instance [DecidableLT ι] [DecidableLE κ] : Decidable (Crosses a b) :=
+  inferInstanceAs (Decidable (¬ IsNonCrossing {a, b}))
 
-instance : Decidable (IndexCrosses links k i) := by unfold IndexCrosses; infer_instance
+instance [DecidableLT ι] [DecidableLE κ] : Decidable (IndexCrosses links p) :=
+  inferInstanceAs (Decidable (∃ l ∈ links, Crosses p l))
+
+/-- Crossing is symmetric: `{a, b}` is the same pair as `{b, a}`. -/
+theorem crosses_comm : Crosses a b ↔ Crosses b a := by rw [Crosses, Crosses, Finset.pair_comm]
+
+/-- `p` crosses nothing iff it is pairwise non-crossing with every existing link. -/
+theorem not_indexCrosses_iff :
+    ¬ IndexCrosses links p ↔ ∀ l ∈ links, IsNonCrossing {p, l} := by
+  simp only [IndexCrosses, Crosses, not_exists, not_and, not_not]
+
+/-- Adding `p` keeps non-crossing iff it crosses no existing link: the GEN-filter
+    form of `isNonCrossing_insert_iff`. -/
+theorem isNonCrossing_insert_iff_not_indexCrosses :
+    IsNonCrossing (insert p links) ↔ IsNonCrossing links ∧ ¬ IndexCrosses links p := by
+  rw [isNonCrossing_insert_iff, not_indexCrosses_iff]
+
+/-- GEN direction of `isNonCrossing_insert_iff_not_indexCrosses`. -/
+theorem IsNonCrossing.insert_of_not_indexCrosses
+    (hNC : IsNonCrossing links) (hNX : ¬ IndexCrosses links p) :
+    IsNonCrossing (insert p links) :=
+  isNonCrossing_insert_iff_not_indexCrosses.mpr ⟨hNC, hNX⟩
+
+end Candidate
+
+section CandidateLinear
+variable [Preorder ι] [LinearOrder κ] [DecidableEq ι] [DecidableEq κ]
+  {links : Finset (ι × κ)} {a b p : ι × κ}
+
+/-- `Crosses` in elementary order form: one link's endpoints straddle the other's
+    in opposite order. -/
+theorem crosses_iff :
+    Crosses a b ↔ (a.1 < b.1 ∧ b.2 < a.2) ∨ (b.1 < a.1 ∧ a.2 < b.2) := by
+  rw [Crosses, isNonCrossing_pair]; grind
 
 /-- `IndexCrosses` in elementary index-ordering form. -/
 theorem indexCrosses_iff :
-    IndexCrosses links k i ↔
-      ∃ l ∈ links, (k < l.fst ∧ l.snd < i) ∨ (l.fst < k ∧ i < l.snd) := by
-  simp only [IndexCrosses, isNonCrossing_pair]
-  exact exists_congr fun _ => and_congr_right fun _ => by omega
+    IndexCrosses links p ↔
+      ∃ l ∈ links, (p.1 < l.1 ∧ l.2 < p.2) ∨ (l.1 < p.1 ∧ p.2 < l.2) := by
+  simp only [IndexCrosses, crosses_iff]
 
-end
-
-section
-variable {links : Finset (ℕ × ℕ)} {k i : ℕ}
-
-/-- `(k, i)` crosses nothing iff it is pairwise non-crossing with every link. -/
-theorem not_indexCrosses_iff :
-    ¬ IndexCrosses links k i ↔ ∀ l ∈ links, IsNonCrossing {(k, i), l} := by
-  simp only [IndexCrosses, not_exists, not_and, not_not]
-
-/-- Adding `(k, i)` keeps non-crossing iff it crosses no existing link. The two
-    structural facts: `isNonCrossing_insert_iff'` (the insert-algebra) and
-    `not_indexCrosses_iff` (the De Morgan dual of the GEN filter). -/
-theorem isNonCrossing_insert_iff :
-    IsNonCrossing (insert (k, i) links) ↔
-      IsNonCrossing links ∧ ¬ IndexCrosses links k i := by
-  rw [isNonCrossing_insert_iff', not_indexCrosses_iff]
-
-/-- GEN direction of `isNonCrossing_insert_iff`. -/
-theorem IsNonCrossing.insert_of_not_indexCrosses
-    (hNC : IsNonCrossing links) (hNX : ¬ IndexCrosses links k i) :
-    IsNonCrossing (insert (k, i) links) :=
-  isNonCrossing_insert_iff.mpr ⟨hNC, hNX⟩
-
-end
+end CandidateLinear
 
 end Autosegmental


### PR DESCRIPTION
Recut `NonCrossing.lean`: factor a symmetric `Crosses a b := ¬ IsNonCrossing {a, b}` pair relation, and generalize `IndexCrosses links p := ∃ l ∈ links, Crosses p l` off `ℕ` to `[Preorder]` over a single candidate link.

- Add the `isNonCrossing_image` Finset-image bridge (consumed by `image_monotone` and the `shiftLink` lemmas), so the image plumbing is unfolded in one place.
- Tier the file into Preorder / Image / Candidate(+Linear) sections; rename `isNonCrossing_insert_iff'` → `isNonCrossing_insert_iff` (general pairwise) and the GEN-filter form → `isNonCrossing_insert_iff_not_indexCrosses`.