### PR TITLE
refactor(Phonology/Prosody): PLabel→Constituent + isHead, smart ctors

### DIFF
--- a/Linglib/Features/Prosody.lean
+++ b/Linglib/Features/Prosody.lean
@@ -151,14 +151,6 @@ instance : LinearOrder ProsodicLevel :=
   LinearOrder.lift' ProsodicLevel.toNat
     (fun a b h => by cases a <;> cases b <;> simp_all [ProsodicLevel.toNat])
 
-/-- Head-prominence: each prosodic constituent has exactly one
-    prominent daughter (its head). K&S (32). -/
-structure ProsodicConstituent where
-  level : ProsodicLevel
-  /-- Whether this constituent is the head (most prominent) of its parent -/
-  isHead : Bool
-  deriving Repr
-
 -- ============================================================================
 -- § 4: Accent Specification Typology
 -- ============================================================================

--- a/Linglib/Phonology/Prosody/Tree.lean
+++ b/Linglib/Phonology/Prosody/Tree.lean
@@ -24,8 +24,9 @@ faithfulness machinery (`OptimalityTheory.Correspondence`, Max/Dep) — future w
 
 ## Main definitions
 
-* `Prosody.PLabel` — a node label: a `ProsodicLevel`, plus a mora weight (σ only).
-* `Prosody.Tree` — `RootedTree.Planar PLabel`; the prosodic constituent.
+* `Prosody.Constituent` — a node: a `ProsodicLevel`, a mora `weight` (σ only), and
+  `isHead`; with smart constructors `om`/`ph`/`ft`/`syl`.
+* `Prosody.Tree` — `RootedTree.Planar Constituent`; the prosodic constituent.
 * `Prosody.Tree.Containment` — child level ≤ parent level ([ito-mester-2003]).
 * `Prosody.Tree.recursionCount` — parses of one element into the same level
   (= No-Recursion violations); recursion is *representable*, its cost is a constraint.
@@ -36,16 +37,33 @@ namespace Prosody
 
 open RootedTree Features.Prosody
 
-/-- A prosodic node label: a hierarchy `level`, plus a mora `weight` that is
-    meaningful only at the σ level (terminals). -/
-structure PLabel where
+/-- A prosodic node: a hierarchy `level`, a mora `weight` (meaningful only at σ),
+    and `isHead` — whether it heads its parent (meaningful at σ/foot). Unifies the
+    former `PLabel` with the (now-removed) `Features.Prosody.ProsodicConstituent`.
+    `weight`/`isHead` are inert at levels where they don't apply (every algorithm
+    guards on `level`), so a flat record with defaults — built via the smart
+    constructors below — is preferred over a per-level sum. -/
+structure Constituent where
   level  : ProsodicLevel
   weight : Syllable.Weight := 0
+  isHead : Bool := false
   deriving DecidableEq, Repr
 
+namespace Constituent
+/-- ω, a prosodic word. -/
+abbrev om : Constituent := { level := .ω }
+/-- φ, a phonological phrase. -/
+abbrev ph : Constituent := { level := .φ }
+/-- A foot, optionally the head of its parent. -/
+abbrev ft (isHead : Bool := false) : Constituent := { level := .f, isHead := isHead }
+/-- A syllable of the given `weight`, optionally the head of its foot. -/
+abbrev syl (weight : Syllable.Weight := 0) (isHead : Bool := false) : Constituent :=
+  { level := .σ, weight := weight, isHead := isHead }
+end Constituent
+
 /-- A prosodic tree: the Core ordered rose tree `RootedTree.Planar` labeled by
-    prosodic levels. Ordered children give No-Tangling by construction. -/
-abbrev Tree := Planar PLabel
+    `Constituent`s. Ordered children give No-Tangling by construction. -/
+abbrev Tree := Planar Constituent
 
 namespace Tree
 

--- a/Linglib/Studies/Bennett2018.lean
+++ b/Linglib/Studies/Bennett2018.lean
@@ -49,17 +49,17 @@ open Prosody Features.Prosody RootedTree Core.Optimization.Evaluation
 /-! ### Candidate prosodifications of a high-prefix + stem -/
 
 /-- A high-attaching prefix syllable (light). -/
-def prefσ : Tree := .node ⟨.σ, 1⟩ []
+def prefσ : Tree := .node (.syl 1) []
 
 /-- The stem syllable (heavy). -/
-def stemσ : Tree := .node ⟨.σ, 2⟩ []
+def stemσ : Tree := .node (.syl 2) []
 
 /-- Flat parse `[ω HighPref Stem]`: no recursion, but the stem has no ω of its own. -/
-def flatParse : Tree := .node ⟨.ω, 0⟩ [prefσ, stemσ]
+def flatParse : Tree := .node .om [prefσ, stemσ]
 
 /-- Recursive parse `[ω HighPref [ω Stem]]`: the stem keeps its ω; the prefix
     adjoins to a dominating ω ([bennett-2018]). -/
-def recParse : Tree := .node ⟨.ω, 0⟩ [prefσ, .node ⟨.ω, 0⟩ [stemσ]]
+def recParse : Tree := .node .om [prefσ, .node .om [stemσ]]
 
 /-! ### `Match(Stem, ω)` (stand-in) -/
 

--- a/Linglib/Studies/ItoMester2009.lean
+++ b/Linglib/Studies/ItoMester2009.lean
@@ -71,18 +71,18 @@ def lexToOmegaViol (lex t : Tree) : Nat := if lexHasOmega lex t then 0 else 1
 /-! ### The four candidate prosodifications of *(fnc lex)* -/
 
 /-- The function word: one light syllable. -/
-def fncσ : Tree := .node ⟨.σ, .light⟩ []
+def fncσ : Tree := .node (.syl .light) []
 /-- The lexical word as a well-formed (bimoraic) ω. -/
-def lexω : Tree := .node ⟨.ω, 0⟩ [.node ⟨.f, 0⟩ [.node ⟨.σ, .heavy⟩ []]]
+def lexω : Tree := .node .om [.node .ft [.node (.syl .heavy) []]]
 
 /-- (a) full-ω: `[φ [ω fnc] [ω lex]]`. -/
-def fullOmega : Tree := .node ⟨.φ, 0⟩ [.node ⟨.ω, 0⟩ [fncσ], lexω]
+def fullOmega : Tree := .node .ph [.node .om [fncσ], lexω]
 /-- (b) amalgamated: `[ω fnc lex]` (lexical word loses its own ω). -/
-def amalgamated : Tree := .node ⟨.ω, 0⟩ [fncσ, .node ⟨.f, 0⟩ [.node ⟨.σ, .heavy⟩ []]]
+def amalgamated : Tree := .node .om [fncσ, .node .ft [.node (.syl .heavy) []]]
 /-- (c) ω-adjoined: `[ω fnc [ω lex]]` — recursive. -/
-def omegaAdjoined : Tree := .node ⟨.ω, 0⟩ [fncσ, lexω]
+def omegaAdjoined : Tree := .node .om [fncσ, lexω]
 /-- (d) φ-attached: `[φ fnc [ω lex]]`. -/
-def phiAttached : Tree := .node ⟨.φ, 0⟩ [fncσ, lexω]
+def phiAttached : Tree := .node .ph [fncσ, lexω]
 
 /-- Violation profile, ranked `FtBin, Lex-to-ω ≫ Parse-into-ω ≫ No-Recursion`. -/
 def profile (t : Tree) : List Nat :=

--- a/Linglib/Studies/Uchihara2021.lean
+++ b/Linglib/Studies/Uchihara2021.lean
@@ -40,11 +40,11 @@ def profile (t : Tree) : List Nat := [ftBinViol t, unfootedCount t]
 /-! ### Minimality: a monomoraic input lengthens to a bimoraic foot -/
 
 /-- `(taa)` — one heavy syllable footed: the bimoraic perfect word. -/
-def bimoraic : Tree := .node ⟨.ω, 0⟩ [.node ⟨.f, 0⟩ [.node ⟨.σ, .heavy⟩ []]]
+def bimoraic : Tree := .node .om [.node .ft [.node (.syl .heavy) []]]
 /-- `(ta)` — a degenerate monomoraic foot (`FtBin` violation). -/
-def degenerate : Tree := .node ⟨.ω, 0⟩ [.node ⟨.f, 0⟩ [.node ⟨.σ, .light⟩ []]]
+def degenerate : Tree := .node .om [.node .ft [.node (.syl .light) []]]
 /-- `[ta]` — an unfooted light syllable (`Parse` violation). -/
-def unfooted : Tree := .node ⟨.ω, 0⟩ [.node ⟨.σ, .light⟩ []]
+def unfooted : Tree := .node .om [.node (.syl .light) []]
 
 def minCandidates : Finset Tree := {bimoraic, degenerate, unfooted}
 
@@ -60,10 +60,10 @@ theorem minimality_optimum : argMinSet minCandidates profile LexLE = {bimoraic} 
 
 /-- `(taa.ta)` — a trimoraic foot (`FtBin` violation). -/
 def trimoraicFoot : Tree :=
-  .node ⟨.ω, 0⟩ [.node ⟨.f, 0⟩ [.node ⟨.σ, .heavy⟩ [], .node ⟨.σ, .light⟩ []]]
+  .node .om [.node .ft [.node (.syl .heavy) [], .node (.syl .light) []]]
 /-- `(taa).ta` — a bimoraic foot plus an unfooted syllable (`Parse` violation). -/
 def footPlusStray : Tree :=
-  .node ⟨.ω, 0⟩ [.node ⟨.f, 0⟩ [.node ⟨.σ, .heavy⟩ []], .node ⟨.σ, .light⟩ []]
+  .node .om [.node .ft [.node (.syl .heavy) []], .node (.syl .light) []]
 
 def maxCandidates : Finset Tree := {bimoraic, trimoraicFoot, footPlusStray}
 


### PR DESCRIPTION
Unify the prosodic-tree node label into one well-named type with foot headedness, the foundation for a metrical-footing API.

- Rename `PLabel` → `Prosody.Constituent` and fold in the dead `Features.Prosody.ProsodicConstituent` (which carried `isHead`) — one `{ level, weight := 0, isHead := false }` record, single source of truth for the level taxonomy.
- Add smart constructors `.om`/`.ph`/`.ft`/`.syl` (`abbrev`, default-honoring) so call sites are immune to future field-growth; rewrite the ~32 `⟨.σ, w⟩`-style sites in Bennett2018/Uchihara2021/ItoMester2009.
- `isHead` enables head-position constraints (Trochee/Iamb) for upcoming directional footing; inert at levels where it doesn't apply.