### PR TITLE
feat(Pragmatics/RSA): rsa simp set for prediction decomposition

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1430,6 +1430,7 @@ import Linglib.Pragmatics.RSA.Monotonicity
 import Linglib.Pragmatics.RSA.Noisy
 import Linglib.Pragmatics.RSA.Operators
 import Linglib.Pragmatics.RSA.QUD
+import Linglib.Pragmatics.RSA.SimpAttr
 import Linglib.Pragmatics.RSA.Ranking
 import Linglib.Pragmatics.RSA.ReferenceGame
 import Linglib.Pragmatics.RSA.Sequential

--- a/Linglib/Pragmatics/RSA/Canonical.lean
+++ b/Linglib/Pragmatics/RSA/Canonical.lean
@@ -78,11 +78,13 @@ noncomputable def S1 (score : St → U → EReal) [ViableSpeaker score] (s : St)
 
 /-- **Cross-utterance prediction**: the speaker prefers `u₂` to `u₁` at state `s`
 iff `u₂` has the higher utility. The partition function cancels. -/
+@[rsa]
 theorem S1_prefers_iff (score : St → U → EReal) [ViableSpeaker score] (s : St) (u₁ u₂ : U) :
     S1 score s u₁ < S1 score s u₂ ↔ score s u₁ < score s u₂ :=
   PMF.softmax_lt_iff_score_lt (score s) (ViableSpeaker.no_top s) (ViableSpeaker.some_finite s) u₁ u₂
 
 /-- `≤` companion of `S1_prefers_iff`. -/
+@[rsa]
 theorem S1_prefers_le_iff (score : St → U → EReal) [ViableSpeaker score] (s : St) (u₁ u₂ : U) :
     S1 score s u₁ ≤ S1 score s u₂ ↔ score s u₁ ≤ score s u₂ :=
   PMF.softmax_le_iff_score_le (score s) (ViableSpeaker.no_top s) (ViableSpeaker.some_finite s) u₁ u₂
@@ -126,6 +128,7 @@ noncomputable def L1 (S : W × Lat → PMF U) (joint : PMF (W × Lat)) (u : U)
 
 /-- **Cross-world prediction**: marginalising the latent, `L1` favours world `w₂`
 over `w₁` iff the conditional-joint sums favour it. -/
+@[rsa]
 theorem L1_world_prefers_iff [DecidableEq W] (S : W × Lat → PMF U) (joint : PMF (W × Lat))
     (u : U) (h : PMF.marginal S joint u ≠ 0) (w₁ w₂ : W) :
     (L1 S joint u h).fst w₁ < (L1 S joint u h).fst w₂
@@ -134,6 +137,7 @@ theorem L1_world_prefers_iff [DecidableEq W] (S : W × Lat → PMF U) (joint : P
   PMF.posterior_fst_lt_iff S joint u h w₁ w₂
 
 /-- `≤` companion of `L1_world_prefers_iff`. -/
+@[rsa]
 theorem L1_world_prefers_le_iff [DecidableEq W] (S : W × Lat → PMF U)
     (joint : PMF (W × Lat)) (u : U) (h : PMF.marginal S joint u ≠ 0) (w₁ w₂ : W) :
     (L1 S joint u h).fst w₁ ≤ (L1 S joint u h).fst w₂
@@ -143,6 +147,7 @@ theorem L1_world_prefers_le_iff [DecidableEq W] (S : W × Lat → PMF U)
 
 /-- **Cross-latent prediction**: marginalising the world, `L1` favours latent `l₂`
 over `l₁` iff the conditional-joint sums favour it. -/
+@[rsa]
 theorem L1_latent_prefers_iff [DecidableEq Lat] (S : W × Lat → PMF U)
     (joint : PMF (W × Lat)) (u : U) (h : PMF.marginal S joint u ≠ 0) (l₁ l₂ : Lat) :
     (L1 S joint u h).snd l₁ < (L1 S joint u h).snd l₂
@@ -272,6 +277,7 @@ end PowSpeaker
 /-- Posterior-mass comparison over events of the joint listener reduces to
 comparing prior-weighted speaker sums — `PMF.posterior_toOuterMeasure_lt_iff_finset_score_lt`
 in the `L1` vocabulary. -/
+@[rsa]
 theorem L1_event_lt_iff {W Lat U : Type*} [Fintype (W × Lat)]
     (S : W × Lat → PMF U) (joint : PMF (W × Lat)) (u : U)
     (h : PMF.marginal S joint u ≠ 0) (A B : Finset (W × Lat)) :
@@ -281,6 +287,7 @@ theorem L1_event_lt_iff {W Lat U : Type*} [Fintype (W × Lat)]
 
 /-- At a uniform joint prior the prior cancels: event comparison reduces to
 comparing summed speaker probabilities. -/
+@[rsa]
 theorem L1_uniform_event_lt_iff {W Lat U : Type*} [Fintype W] [Fintype Lat]
     [Nonempty (W × Lat)] (S : W × Lat → PMF U) (u : U)
     (h : PMF.marginal S (PMF.uniformOfFintype (W × Lat)) u ≠ 0)

--- a/Linglib/Pragmatics/RSA/Operators.lean
+++ b/Linglib/Pragmatics/RSA/Operators.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Probability.Posterior
+import Linglib.Pragmatics.RSA.SimpAttr
 import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Probability.Distributions.Uniform
@@ -61,6 +62,16 @@ Phase 1 of the RSA → mathlib-PMF migration: this file is a pure addition.
 code is unchanged. A subsequent phase migrates one RSA study end-to-end
 to demonstrate that `rsa_predict` reflection still applies to operator
 applications.
+
+## The `rsa` simp set
+
+The decomposition lemmas below are tagged `@[rsa]`. `simp [rsa]` rewrites an
+`S1`/`L1` *preference* goal to its structural score/posterior comparison — the
+partition factor cancels by rewriting, not by evaluating a normalisation. This is
+the migration API that replaces `rsa_predict` reflection with simplification: a
+migrated prediction is `by simp [rsa]` down to a condition closed by a *theorem*,
+not a `decide`/`norm_num` over a state-space sum. The set itself is registered in
+`RSA/SimpAttr.lean`.
 -/
 
 set_option autoImplicit false
@@ -172,6 +183,7 @@ on `u`, so it cancels.
 
 Direct lift from `PMF.normalize_lt_iff_lt`. The workhorse decomposition
 lemma for "speaker prefers `u₂` over `u₁` at world `w`" proofs. -/
+@[rsa]
 theorem S1Belief_apply_lt_iff_score_lt (L0 : U → PMF W) (costFactor : U → ℝ≥0∞)
     (α : ℝ) (w : W)
     (h0 : ∑' u, (L0 u w : ℝ≥0∞) ^ α * costFactor u ≠ 0)
@@ -182,6 +194,7 @@ theorem S1Belief_apply_lt_iff_score_lt (L0 : U → PMF W) (costFactor : U → �
   PMF.normalize_lt_iff_lt _ _ _ _ _
 
 /-- The `≤` companion of `S1Belief_apply_lt_iff_score_lt`. -/
+@[rsa]
 theorem S1Belief_apply_le_iff_score_le (L0 : U → PMF W) (costFactor : U → ℝ≥0∞)
     (α : ℝ) (w : W)
     (h0 : ∑' u, (L0 u w : ℝ≥0∞) ^ α * costFactor u ≠ 0)

--- a/Linglib/Pragmatics/RSA/SimpAttr.lean
+++ b/Linglib/Pragmatics/RSA/SimpAttr.lean
@@ -1,0 +1,21 @@
+import Mathlib.Tactic.Simps.Basic
+
+/-!
+# The `rsa` simp set
+
+Registered here, separately from the lemmas it tags: Lean cannot use an attribute
+in the same file where it is declared (the same split as `pmf_eval_simps` in
+`Core/Probability/Eval.lean`, and mathlib's `Mathlib/Tactic/Attr/Register.lean`).
+
+The partition-cancelling RSA decomposition lemmas in `RSA/Operators.lean` and
+`RSA/Canonical.lean` are tagged `@[rsa]`. `simp [rsa]` rewrites an `S1`/`L1`
+*preference* goal (`S1 x < S1 y`, `(L1 …).fst w₁ < …`) to its structural
+score/posterior comparison — the normalisation factor cancels by rewriting, not by
+evaluating a state-space sum. This is the migration API replacing `rsa_predict`
+reflection with simplification: a migrated prediction is `by simp [rsa]` down to a
+condition closed by a *theorem*, not a `decide`/`norm_num` over a sum.
+-/
+
+/-- Simp set of the partition-cancelling RSA decomposition lemmas
+(`S1`/`L1` preference ↔ score/posterior comparison). -/
+register_simp_attr rsa


### PR DESCRIPTION
Adds the `rsa` simp set — the migration API for taking RSA studies off the `rsa_predict` reflection tactic by *rewriting* rather than *computing*.

`simp [rsa]` rewrites an RSA **prediction** to its **structural condition**: the normalisation/partition factor cancels by simplification, not by evaluating a state-space sum. A migrated prediction becomes `by simp [rsa]` down to a goal closed by a *theorem* (a monotonicity/asymmetry/mean law), not a `decide`/`norm_num` over a sum — which is what made the naive migration slow.

- New `RSA/SimpAttr.lean` registers the set (separate file, since Lean can't use an attribute where it's declared — same split as `pmf_eval_simps` and mathlib's `Tactic/Attr/Register.lean`).
- Tags the existing partition-cancelling decomposition lemmas `@[rsa]`: `S1Belief_apply_{lt,le}_iff_score_lt` (Operators) and `S1_prefers_{,le_}iff`, `L1_world_prefers_{,le_}iff`, `L1_latent_prefers_iff`, `L1_event_lt_iff`, `L1_uniform_event_lt_iff` (Canonical).

Purely additive — `rsa` is a *named* set, so default `simp` is unchanged. Validated that all three reduction shapes fire: speaker `S1 x < S1 y ↝ score x < score y`, belief-speaker `S1Belief … ↝ (L0 u w)^α·cost u …`, and listener `(L1 …).fst w₁ < … ↝ ∑ joint·S …`. Per-file conversions (DegenEtAl2020 #977, Tessler #979) follow once those land on main.