### PR TITLE
feat(Phonology/Prosody): canonical headed Word ω + Yield split

### DIFF
--- a/Linglib/Phonology/Prosody/Foot.lean
+++ b/Linglib/Phonology/Prosody/Foot.lean
@@ -125,9 +125,11 @@ theorem itl_gap : ∃ f : Foot ℕ, (f.IsIambic ∧ f.IsBinary) ∧ ¬ IsCanonic
 /-! ### Re-representations (preserving the head) -/
 
 /-- Re-represent as a prosodic tree ([selkirk-1980]; [ito-mester-2003]): a depth-1 `.f`
-    node over `.σ` leaves, the head σ marked via `Constituent.isHead`. -/
-def toProsTree (w : S → Syllable.Weight) (f : Foot S) : Tree :=
-  .node .ft ((List.finRange f.syllables.length).map (fun i =>
+    node over `.σ` leaves, the head σ marked via `Constituent.isHead`. The `.f` node
+    itself is marked `isHead` when the foot heads its ω (the `isHead` argument; see
+    `Word.toProsTree`). -/
+def toProsTree (w : S → Syllable.Weight) (f : Foot S) (isHead : Bool := false) : Tree :=
+  .node (.ft isHead) ((List.finRange f.syllables.length).map (fun i =>
     .node (.syl (w (f.syllables.get i)) (decide (i = f.head))) []))
 
 /-- Re-represent as a metrical-grid row ([hayes-1995]): a head mark per position. -/

--- a/Linglib/Phonology/Prosody/Syllable.lean
+++ b/Linglib/Phonology/Prosody/Syllable.lean
@@ -65,4 +65,27 @@ def ofCV (onset nucleus coda : List Segment) (wbp : Bool := true) : Syllable :=
 
 end Syllable
 
+/-! ### Yield -/
+
+/-- A **yield**: the terminal σ-weight string of a prosodic structure — the
+    unparsed input, or the leaves of a prosodic `Tree`. Distinct from the prosodic
+    word ω (`Prosody.Word`), which is a *headed constituent*: a yield is just the
+    weight profile, with no head and no constituency. -/
+abbrev Yield := List Syllable.Weight
+
+namespace Yield
+
+/-- The weight profile of fully-moraified syllables — the σ → yield bridge. -/
+def ofSyllables (σs : List Syllable) : Yield := σs.map Syllable.weight
+
+/-- Total mora count (each weight *is* a mora count). -/
+def moraCount (y : Yield) : Nat := y.sum
+
+/-- The minimal-word *size* constraint ([mccarthy-prince-1993]): at least
+    `minMorae` morae (default 2, the moraic-trochee minimum). The *structural*
+    minimal word — that an ω properly contains a foot — is `Word.feet_ne_nil`. -/
+abbrev satisfiesMinWord (y : Yield) (minMorae : Nat := 2) : Prop := minMorae ≤ y.moraCount
+
+end Yield
+
 end Prosody

--- a/Linglib/Phonology/Prosody/Tree.lean
+++ b/Linglib/Phonology/Prosody/Tree.lean
@@ -2,7 +2,6 @@ import Linglib.Core.Combinatorics.RootedTree.Planar
 import Linglib.Core.Combinatorics.RootedTree.DecEq
 import Linglib.Features.Prosody
 import Linglib.Phonology.Prosody.Syllable
-import Linglib.Phonology.Prosody.Word
 
 /-!
 # Prosodic trees
@@ -30,7 +29,7 @@ faithfulness machinery (`OptimalityTheory.Correspondence`, Max/Dep) — future w
 * `Prosody.Tree.Containment` — child level ≤ parent level ([ito-mester-2003]).
 * `Prosody.Tree.recursionCount` — parses of one element into the same level
   (= No-Recursion violations); recursion is *representable*, its cost is a constraint.
-* `Prosody.Tree.yield` — the terminal weight profile, as a `Word`.
+* `Prosody.Tree.yield` — the terminal weight profile, as a `Yield`.
 -/
 
 namespace Prosody
@@ -91,10 +90,10 @@ def recursionCountList : List Tree → Nat
   | t :: ts => recursionCount t + recursionCountList ts
 end
 
-/-- The terminal weight profile (σ-leaves, left to right) as a `Word` — the
-    σ → ω bridge to the unparsed weight profile. -/
-def yield (t : Tree) : Word :=
-  ⟨(t.nodes.filter (fun s => s.children.isEmpty)).map (fun s => s.label.weight)⟩
+/-- The terminal weight profile (σ-leaves, left to right) as a `Yield` — the
+    unparsed σ-weight string. (The headed ω parse is `Prosody.Word`.) -/
+def yield (t : Tree) : Yield :=
+  (t.nodes.filter (fun s => s.children.isEmpty)).map (fun s => s.label.weight)
 
 end Tree
 end Prosody

--- a/Linglib/Phonology/Prosody/Word.lean
+++ b/Linglib/Phonology/Prosody/Word.lean
@@ -1,44 +1,145 @@
-import Linglib.Phonology.Prosody.Syllable
+import Linglib.Phonology.Prosody.Foot
+import Linglib.Phonology.Prosody.Tree
 
 /-!
-# Prosodic word (ω)
-[selkirk-1984] [mccarthy-prince-1993]
+# Prosodic words (ω)
+[selkirk-1980] [nespor-vogel-1986] [liberman-prince-1977] [hayes-1995]
 
-The prosodic word ω, the constituent above the foot in the prosodic hierarchy
-(σ < f < ω < φ < ι; the levels themselves live in `Features.Prosody`). This
-module gives ω's weight profile and the minimal-word constraint. The foot-parsed
-ω is `MetricalParse` (`Phonology/Prosody/Foot.lean`); the morphosyntax→prosody
-mapping that fixes ω boundaries is language-specific (Telugu: `Studies/Aitha2026.lean`).
+The canonical prosodic word ([selkirk-1980]; [nespor-vogel-1986]; [hayes-1995]): a
+flat, **headed** constituent over feet and stray syllables — the level above the foot
+in the prosodic hierarchy (σ < f < ω). Like the foot it is headed; its head is a
+*foot* (the head foot), and its Designated Terminal Element — the primary-stressed σ —
+is the head σ of that head foot (the head chain projects two levels;
+[liberman-prince-1977]). Headedness is **definitional**: an ω always contains its head
+foot, so the *minimal word* ([mccarthy-prince-1993]) — that an ω properly contains a
+foot — holds by construction. Exhaustive parsing, foot binarity, and alignment are
+violable constraints, not part of the type; stray (unfooted) syllables are real
+([selkirk-1996]) and are exactly what `Parse-σ` penalizes.
+
+Encoded as a **zipper**: the head foot is a distinguished field, with the other
+daughters (a `Foot`, or an unfooted stray σ) to its left and right. The trochee/iamb
+inventory and weight live on `Foot`; recursion (ω-over-ω) lives on `Prosody.Tree`. The
+re-representations into the prosodic tree and the metrical grid recover the same head.
 
 ## Main definitions
 
-* `Prosody.Word`: a prosodic word as a linear weight profile.
-* `Prosody.Word.ofSyllables`: the σ → ω bridge (weight profile of a syllable list).
-* `Prosody.Word.moraCount`: total mora count.
-* `Prosody.Word.satisfiesMinWord`: the minimal-word constraint.
+* `Word` — a headed prosodic word: a head `Foot` with `before`/`after` daughters.
+* `Word.feet` / `strays` / `headFoot` / `headSyllable` — the daughters and the ω-DTE.
+* `Word.IsLeftHeaded` / `IsRightHeaded` / `IsExhaustive` — derived stress/parse predicates.
+* `Word.toProsTree` / `toGrid` — re-representations recovering the head.
+
+## Main results
+
+* `Word.feet_ne_nil` — the minimal word ([mccarthy-prince-1993]): every ω contains a
+  foot, free from definitional headedness.
 -/
 
 namespace Prosody
 
-/-- A prosodic word ω: a sequence of syllables by weight, forming a single
-    domain for stress and word-level phonology. E.g. Telugu *samudram* 'ocean'
-    has profile `[.light, .light, .heavy]` (sa.mu.dram). -/
-structure Word where
-  syllables : List Syllable.Weight
+open Features.Prosody
+
+/-- A grid prominence level ([liberman-prince-1977]; [hayes-1995]): the head σ of the
+    head foot is `primary` (the ω-DTE), other foot-heads `secondary`, the rest
+    `unstressed`. -/
+inductive StressLevel where
+  | unstressed | secondary | primary
   deriving DecidableEq, Repr
 
-/-- The weight profile of fully-moraified syllables — the σ → ω bridge. -/
-def Word.ofSyllables (σs : List Syllable) : Word := ⟨σs.map Syllable.weight⟩
+/-! ### The canonical prosodic word -/
 
-/-- Total mora count of a prosodic word (each weight *is* a mora count). -/
-def Word.moraCount (w : Word) : Nat :=
-  w.syllables.foldl (· + ·) 0
+/-- The canonical prosodic word ω ([selkirk-1980]; [hayes-1995]): a flat headed
+    constituent over feet and stray syllables, encoded as a zipper around its head
+    `head` foot. `before`/`after` carry the other daughters (a `Foot`, or an unfooted
+    stray σ); the head foot is always present, so an ω contains a foot by construction
+    (the minimal word). -/
+structure Word (S : Type*) where
+  before : List (Foot S ⊕ S)
+  head   : Foot S
+  after  : List (Foot S ⊕ S)
+  deriving DecidableEq, Repr
 
-/-- The minimal-word constraint ([mccarthy-prince-1993]): the smallest ω must
-    contain a foot — at least two morae for moraic-trochee languages (the
-    default). Syllabic-trochee minima are syllable-counted, not captured by the
-    default. -/
-abbrev Word.satisfiesMinWord (w : Word) (minMorae : Nat := 2) : Prop :=
-  w.moraCount ≥ minMorae
+namespace Word
+variable {S : Type*}
+
+/-- The daughters in linear order: a foot, or an unfooted stray σ. -/
+def daughters (w : Word S) : List (Foot S ⊕ S) := w.before ++ .inl w.head :: w.after
+
+/-- The feet (head foot included), left to right. -/
+def feet (w : Word S) : List (Foot S) := w.daughters.filterMap Sum.getLeft?
+
+/-- The stray (unfooted) syllables, left to right. -/
+def strays (w : Word S) : List S := w.daughters.filterMap Sum.getRight?
+
+/-- The head foot — the primary-stress bearer. -/
+def headFoot (w : Word S) : Foot S := w.head
+
+/-- The ω-DTE: the primary-stressed σ, the head σ of the head foot (the head chain,
+    two levels; [liberman-prince-1977]). -/
+def headSyllable (w : Word S) : S := w.head.headSyllable
+
+/-! ### Derived stress and parse predicates -/
+
+/-- Primary stress on the leftmost foot: no foot precedes the head foot (initial
+    stray σ are still allowed). -/
+def IsLeftHeaded (w : Word S) : Prop := w.before.filterMap Sum.getLeft? = []
+/-- Primary stress on the rightmost foot. -/
+def IsRightHeaded (w : Word S) : Prop := w.after.filterMap Sum.getLeft? = []
+/-- Fully parsed — no stray syllables (`Parse-σ`-clean; `Parse-σ` itself is violable). -/
+def IsExhaustive (w : Word S) : Prop := w.strays = []
+
+instance (w : Word S) : Decidable w.IsLeftHeaded := by unfold IsLeftHeaded; infer_instance
+instance (w : Word S) : Decidable w.IsRightHeaded := by unfold IsRightHeaded; infer_instance
+instance [DecidableEq S] (w : Word S) : Decidable w.IsExhaustive := by
+  unfold IsExhaustive; infer_instance
+
+/-- **The minimal word** ([mccarthy-prince-1993]), free from definitional headedness:
+    every ω contains a foot (its head foot). -/
+theorem feet_ne_nil (w : Word S) : w.feet ≠ [] := by
+  simp [feet, daughters, List.filterMap_append]
+
+/-! ### Re-representations (preserving the head) -/
+
+/-- A non-head daughter → a prosodic subtree: a (non-head) foot, or a stray σ-leaf. -/
+def daughterTree (wt : S → Syllable.Weight) : (Foot S ⊕ S) → Tree
+  | .inl f => Foot.toProsTree wt f
+  | .inr s => .node (.syl (wt s) false) []
+
+/-- Re-represent as a prosodic tree ([selkirk-1980]; [ito-mester-2003]): an `.ω` node
+    over the daughters' subtrees, the **head foot** marked `isHead`, stray σ as
+    `.σ`-leaves directly under ω ([selkirk-1996]; permitted by `Tree.Containment`).
+    Composes `Foot.toProsTree`. -/
+def toProsTree (wt : S → Syllable.Weight) (w : Word S) : Tree :=
+  .node .om (w.before.map (daughterTree wt)
+    ++ Foot.toProsTree wt w.head true :: w.after.map (daughterTree wt))
+
+/-- A non-head daughter's grid row (foot-head → `secondary`, the rest `unstressed`). -/
+def daughterGrid : (Foot S ⊕ S) → List StressLevel
+  | .inl f => (Foot.toGrid f).map (fun b => if b then .secondary else .unstressed)
+  | .inr _ => [.unstressed]
+
+/-- Re-represent as the metrical grid ([hayes-1995]; [liberman-prince-1977]): one
+    `StressLevel` per σ. The head foot's head σ is `primary` (the ω-DTE), other
+    foot-heads `secondary`, the rest `unstressed`. `Foot.toGrid` is the within-foot
+    row; this projects the word-head over it. -/
+def toGrid (w : Word S) : List StressLevel :=
+  w.before.flatMap daughterGrid
+    ++ (Foot.toGrid w.head).map (fun b => if b then .primary else .unstressed)
+    ++ w.after.flatMap daughterGrid
+
+end Word
+
+/-! ### Worked examples -/
+
+-- (ˈσσ)σ : a trochee heading the word, then a stray σ — Pintupi-style.
+private def w_trochStray : Word Nat := ⟨[], Foot.trochee 1 1, [.inr 1]⟩
+example : w_trochStray.IsLeftHeaded ∧ ¬ w_trochStray.IsExhaustive := by decide
+example : w_trochStray.feet = [Foot.trochee 1 1] := by decide
+-- the head σ is the unique primary; the foot's weak σ and the stray are unstressed.
+example : w_trochStray.toGrid = [.primary, .unstressed, .unstressed] := by decide
+
+-- (σσ)(ˈσσ) : two trochees, primary on the second — secondary on the first.
+private def w_twoFeet : Word Nat := ⟨[.inl (Foot.trochee 1 1)], Foot.trochee 1 1, []⟩
+example : w_twoFeet.IsRightHeaded := by decide
+example : w_twoFeet.toGrid = [.secondary, .unstressed, .primary, .unstressed] := by decide
 
 end Prosody

--- a/Linglib/Studies/Hayes1989.lean
+++ b/Linglib/Studies/Hayes1989.lean
@@ -1,5 +1,5 @@
 import Linglib.Phonology.Prosody.CompensatoryLengthening
-import Linglib.Phonology.Prosody.Word
+import Linglib.Phonology.Prosody.Syllable
 import Linglib.Phonology.Subregular.LocalRewrite
 
 /-!
@@ -135,7 +135,7 @@ def tale_σ₂ : Syllable := ⟨[l], [Mora.of e]⟩  -- schwa (using ⟨e⟩)
 def tale_input : List Syllable := [tale_σ₁, tale_σ₂]
 
 /-- Input ⟨talə⟩ has 2 total morae (one per syllable). -/
-theorem tale_input_morae : (Word.ofSyllables tale_input).moraCount = 2 := rfl
+theorem tale_input_morae : (Yield.ofSyllables tale_input).moraCount = 2 := rfl
 
 /-- Deleting σ₂'s schwa strands one mora. -/
 theorem tale_schwa_strands : strandedCount (strand tale_σ₂ 0) = 1 := rfl
@@ -159,7 +159,7 @@ def tale_output : Syllable := ⟨[t], [Mora.of a, ⟨[a, l]⟩]⟩
 
 /-- Conservation: input total morae = output morae. -/
 theorem tale_conservation :
-    (Word.ofSyllables tale_input).moraCount = tale_output.moraCount := rfl
+    (Yield.ofSyllables tale_input).moraCount = tale_output.moraCount := rfl
 
 end MiddleEnglishVowelLoss
 
@@ -231,18 +231,18 @@ def kaanus_form : List Syllable := [kaanus_σ₁, kasnus_σ₂]
 
 /-- CL output has the weight profile [heavy, heavy]. -/
 theorem kaanus_weight_profile :
-    Word.ofSyllables kaanus_form = ⟨[.heavy, .heavy]⟩ := rfl
+    Yield.ofSyllables kaanus_form = [.heavy, .heavy] := rfl
 
 /-- CL output satisfies the bimoraic minimal-word constraint (4μ ≥ 2μ). -/
 theorem kaanus_satisfies_minword :
-    (Word.ofSyllables kaanus_form).satisfiesMinWord := by decide
+    (Yield.ofSyllables kaanus_form).satisfiesMinWord := by decide
 
 /-- Middle English: CL preserves the bimoraic minimum across syllable
     restructuring. Input ⟨talə⟩ = [L, L] (2μ); output [ta:l] = [H] (2μ). Both
     satisfy the bimoraic minimum — a consequence of moraic conservation. -/
 theorem tale_minword_preserved :
-    (Word.ofSyllables tale_input).satisfiesMinWord ∧
-    (Word.ofSyllables [tale_output]).satisfiesMinWord :=
+    (Yield.ofSyllables tale_input).satisfiesMinWord ∧
+    (Yield.ofSyllables [tale_output]).satisfiesMinWord :=
   ⟨by decide, by decide⟩
 
 end ProsodicPipeline

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -22506,6 +22506,33 @@
   role      = {cited},
   sources   = {Phonology/Prosody/Foot.lean}
 }
+
+@article{liberman-prince-1977,
+  author    = {Liberman, Mark and Prince, Alan},
+  title     = {On Stress and Linguistic Rhythm},
+  year      = {1977},
+  journal   = {Linguistic Inquiry},
+  volume    = {8},
+  number    = {2},
+  pages     = {249--336},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Phonology/Prosody/Word.lean}
+}
+
+@incollection{selkirk-1996,
+  author    = {Selkirk, Elisabeth O.},
+  title     = {The Prosodic Structure of Function Words},
+  year      = {1996},
+  booktitle = {Signal to Syntax: Bootstrapping from Speech to Grammar in Early Acquisition},
+  editor    = {Morgan, James L. and Demuth, Katherine},
+  pages     = {187--214},
+  publisher = {Lawrence Erlbaum Associates},
+  address   = {Mahwah, NJ},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Phonology/Prosody/Word.lean}
+}
 % REF: Kager, R. (2007). Feet and metrical stress. In The Cambridge Handbook of Phonology. CUP.
 @incollection{kager-2007,
   author    = {Kager, Ren{\'e}},


### PR DESCRIPTION
The canonical prosodic word ([selkirk-1980]; [nespor-vogel-1986]; [hayes-1995]) as the primary object — modeled on the canonical `Foot` (#981): a flat **headed** constituent, head = a foot, with derived stress/grid re-representations.

- `Prosody.Word { before, head : Foot S, after }` — a **zipper** over `Foot ⊕ stray-σ` daughters, the head foot distinguished. Headedness is definitional, so the minimal word ([mccarthy-prince-1993]) is free (`feet_ne_nil`). Derived `Prop`+`Decidable` predicates `IsLeftHeaded`/`IsRightHeaded`/`IsExhaustive`; primary/secondary stress via `toGrid`. Stray σ are real ([selkirk-1996]) — what `Parse-σ` penalizes, not banned by the type. Recursion stays in `Prosody.Tree`.
- `toProsTree`/`toGrid` re-representations compose `Foot`'s and mark the head foot (one-line `isHead` param added to `Foot.toProsTree`); the ω-DTE is the head σ of the head foot ([liberman-prince-1977]).
- **Yield split**: the old flat `Word { weights }` was the σ-string *yield*, not a prosodic word — demoted to `Prosody.Yield := List Syllable.Weight` in `Syllable.lean` (`Tree.yield : Tree → Yield`); the canonical ω takes the `Word` name. Hayes1989 migrated (`Yield.ofSyllables`).

Builds on #981. The canonical `Word` is the Lamont footing representation (footing PR builds on it).