### PR TITLE
feat(Studies/Lamont2022c): directional-HS footing (Pintupi/Murinbata)

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1330,6 +1330,7 @@ import Linglib.Phonology.Autosegmental.Sharing
 import Linglib.Phonology.Autosegmental.WellFormedAR
 import Linglib.Phonology.Constraints.Basic
 import Linglib.Phonology.Constraints.Defs
+import Linglib.Phonology.Constraints.Directional
 import Linglib.Phonology.Constraints.Harmony
 import Linglib.Phonology.Constraints.Lift
 import Linglib.Phonology.Constraints.Profile
@@ -2435,6 +2436,7 @@ import Linglib.Studies.Labov2006
 import Linglib.Studies.Labov2012
 import Linglib.Studies.Ladusaw1979
 import Linglib.Studies.Lahiri1998
+import Linglib.Studies.Lamont2022c
 import Linglib.Studies.Lakoff1970
 import Linglib.Studies.Lambert2026
 import Linglib.Studies.Landau2015

--- a/Linglib/Phonology/Constraints/Directional.lean
+++ b/Linglib/Phonology/Constraints/Directional.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Phonology.Constraints.Defs
+
+/-!
+# Directional constraints as position-indexed blocks
+
+[lamont-2022b]'s **directional constraint evaluation**, realized in the canonical
+constraint substrate. A directional constraint maps each candidate to a per-position
+violation *vector* compared lexicographically (Eisner 2000; [lamont-2022b]). The key
+observation ([lamont-2022b] §1.3) is that "a locus at position `i` relates to one at
+`i+1` exactly as a higher-ranked constraint relates to a lower one … violation vectors
+are ordered lexicographically, which is exactly how candidates are ordered with respect
+to an entire constraint set in OT". So a directional constraint with **single-segment
+loci** over a **length-preserving** GEN *is* a position-indexed block of binary
+constraints, spliced into a ranking and compared under the canonical `ViolationProfile`
+lex order (`Core.Optimization.Evaluation.lexLE_ofFn`) — no new mechanism beyond the
+`CON`/`ViolationProfile` substrate already present.
+
+`directionalBlock n locus` is that block: at each position `i < n` it flags whether
+`locus i` holds. Splice it into a ranking forward for left-to-right evaluation (`⇒`),
+or `.reverse` for right-to-left (`⇐`) — "the positions are reversed in the violation
+vector" ([lamont-2022b] §1.3, Fig 1.9).
+
+## Main definitions
+
+* `directionalBlock` — the position-indexed block of binary constraints.
+
+## Consumers
+
+* `Tone.starFloatBlock` — `*FLOAT` directional float deletion ([mcpherson-lamont-2026]).
+* `Lamont2022c.parseSigmaBlock` — `Parse(σ)` directional footing ([lamont-2022c]).
+
+## Scope
+
+This covers the *single-segment-loci, length-preserving* case — both current consumers
+(a floating tone / an unfooted syllable is a single position, and neither GEN changes
+the position count). [lamont-2022b]'s general formulation additionally handles
+multi-segment loci (the opposite-edge projection that rules out "locus folding", §2.3)
+and length-changing GEN (step-relative positions, fn. 10); those are deferred until a
+consumer exercises them.
+-/
+
+namespace Constraints
+
+/-- A **directional constraint** with single-segment loci over length-preserving GEN
+([lamont-2022b]): the position-indexed block of binary constraints `i ↦ ⟦locus i⟧`,
+for positions `i < n`. Spliced into a ranking and compared under the canonical lex
+profile this is directional EVAL — `⇒` (left-to-right) for the forward block, `⇐` for
+`.reverse`. The block's `i`-th coordinate is exactly the directional violation vector's
+`i`-th entry, so the spliced profile equals the directional one
+(`Core.Optimization.Evaluation.lexLE_ofFn`). -/
+def directionalBlock {C : Type*} (n : ℕ) (locus : Fin n → C → Prop)
+    [∀ i, DecidablePred (locus i)] : List (Constraint C) :=
+  (List.finRange n).map (fun i => Constraint.binary (locus i))
+
+end Constraints

--- a/Linglib/Studies/Lamont2022c.lean
+++ b/Linglib/Studies/Lamont2022c.lean
@@ -1,0 +1,153 @@
+import Linglib.Phonology.Prosody.Foot
+import Linglib.Phonology.Constraints.Directional
+import Linglib.Core.Optimization.Evaluation
+
+/-!
+# Lamont (2022): footing in directional Harmonic Serialism
+[lamont-2022c]
+
+[lamont-2022c] develops a theory of quantity-insensitive footing in Harmonic Serialism
+(HS; [prince-smolensky-1993]) where CON contains only **directionally evaluated**
+constraints ([lamont-2022b]; Eisner 2000): a constraint maps a candidate to a
+per-position violation *vector*, and candidates are ordered lexicographically by the
+*location* of violations rather than their total count. The central result is that
+`Parse(σ)` — penalising unfooted syllables — under directional evaluation both motivates
+iterative footing **and** decides where feet surface, obviating alignment constraints
+([mccarthy-prince-1993]); having `Trochee`/`Iamb` penalise monosyllabic feet additionally
+obviates `FtBin` ([martinez-paricio-kager-2015]).
+
+This file formalises the central QI result. GEN parses **one foot per step**
+([pruitt-2010]; [pruitt-2012]): a single unfooted σ into a monosyllabic foot, or two
+adjacent unfooted σ into a disyllabic foot. We reuse the canonical `Prosody.Foot`
+(`S = Unit`, since QI footing strips weight) assembled **flatly** — a footing is a
+sequence of feet and stray syllables with no designated head foot, because Lamont does
+not distinguish primary from secondary stress (so the headed `Prosody.Word` ω, which is
+a footing *plus* a head foot, is deliberately *not* the candidate type here). `Parse(σ)`
+is a `Constraints.directionalBlock` over σ-positions; `Trochee`/`Iamb` read the foot
+head off `Foot.head`.
+
+## Main results
+
+* `murinbata_exhaustive` / `pintupi_inexhaustive` — the headline contrast: the same
+  5σ step parses exhaustively under `Parse(σ) ≫ Trochee` ([street-mollinjin-1981]) but
+  stays faithful (final σ unfooted) under `Trochee ≫ Parse(σ)` ([hansen-hansen-1969]).
+* `ftbin_obviated` — a monosyllabic-foot candidate is harmonically bounded with no
+  `FtBin` in CON ([martinez-paricio-kager-2015]).
+
+## Deferred (prose)
+
+The paper's bidirectional Waorani case study (§3 — a head foot at the right edge with
+secondary feet built left-to-right) is its showcase and the natural next extension;
+Macedonian (`Hd(ω)`/`NonFinality`), Garawa, and Cayuvava ternarity (`*FootFoot`) each
+need further constraints; the software-computed factorial typology (§4) is a meta-claim,
+not a per-string prediction. All are noted here, not formalised.
+-/
+
+namespace Lamont2022c
+
+open Prosody Core.Optimization.Evaluation
+
+/-! ### Footings -/
+
+/-- A **footing**: a flat sequence of feet and unfooted (stray) syllables, with
+    zero-or-more feet and no designated head foot ([lamont-2022c], abstracting from
+    primary stress). Quantity-insensitive, so feet are `Foot Unit`. -/
+abbrev Footing := List (Foot Unit ⊕ Unit)
+
+/-- A monosyllabic foot `(σ́)`. -/
+def mono : Foot Unit := ⟨[()], 0⟩
+/-- A (left-headed) trochee `(σ́σ)`. -/
+def troch : Foot Unit := ⟨[(), ()], 0⟩
+/-- A (right-headed) iamb `(σσ́)`. -/
+def iamb : Foot Unit := ⟨[(), ()], 1⟩
+
+/-- The feet of a footing, left to right. -/
+def feet (fc : Footing) : List (Foot Unit) := fc.filterMap Sum.getLeft?
+
+/-- The total number of syllables (footed + stray). -/
+def size (fc : Footing) : Nat :=
+  fc.foldl (fun acc d => acc + match d with | .inl f => f.syllables.length | .inr _ => 1) 0
+
+/-- Per-position stray flag: `1` at each unfooted σ, `0` at each footed σ, left to right.
+    This is the directional `Parse(σ)` violation vector. -/
+def strayVec (fc : Footing) : List Nat :=
+  fc.flatMap (fun d => match d with
+    | .inl f => List.replicate f.syllables.length 0
+    | .inr _ => [1])
+
+/-! ### The directional constraints
+
+`Parse(σ)` ([lamont-2022c] (10)) is a `Constraints.directionalBlock`: a per-position
+block of binary constraints, `position i ↦ ⟦σ i is unfooted⟧`. `Trochee` (15) and
+`Iamb` (18) penalise feet by head position — `Trochee` a foot whose head is rightmost
+(= `Foot.IsIambic`, true of iambs and monosyllables), `Iamb` a foot whose head is
+leftmost (= `Foot.IsTrochaic`, true of trochees and monosyllables); a monosyllabic foot
+violates both, doing `FtBin`'s work. -/
+
+/-- `Parse(σ)` as a directional block over `n` σ-positions. -/
+def parse (n : Nat) : List (Constraints.Constraint Footing) :=
+  Constraints.directionalBlock n (fun (i : Fin n) (fc : Footing) => (strayVec fc).getD i.val 0 = 1)
+
+/-- `Trochee`: one violation per foot whose head is rightmost (= `Foot.IsIambic`). -/
+def trochee (fc : Footing) : Nat :=
+  ((feet fc).filter (fun f => decide (f.head.val + 1 = f.syllables.length))).length
+/-- `Iamb`: one violation per foot whose head is leftmost (= `Foot.IsTrochaic`). -/
+def iambC (fc : Footing) : Nat :=
+  ((feet fc).filter (fun f => decide (f.head.val = 0))).length
+
+/-- The violation vector of a footing under a ranking (a list of constraints), as the
+    concatenated per-constraint violations — ordered lexicographically (`LexLE`). -/
+def profile (ranking : List (Constraints.Constraint Footing)) (fc : Footing) : List Nat :=
+  ranking.map (fun c => c fc)
+
+/-- Murinbata ranking `Parse(σ) ≫ Trochee ≫ Iamb` ([street-mollinjin-1981]). -/
+def murinbata (n : Nat) : List (Constraints.Constraint Footing) :=
+  parse n ++ [fun fc => trochee fc, fun fc => iambC fc]
+/-- Pintupi ranking `Trochee ≫ Parse(σ) ≫ Iamb` ([hansen-hansen-1969]). -/
+def pintupi (n : Nat) : List (Constraints.Constraint Footing) :=
+  (fun fc => trochee fc) :: parse n ++ [fun fc => iambC fc]
+
+/-! ### The headline: exhaustive vs inexhaustive (the decisive step)
+
+The same 5σ string at the step from `(σ́σ)(σ́σ)σ`: GEN can parse the final stray σ into
+a monosyllabic foot (`exhaustive`) or leave it (`faithful`, converged). -/
+
+/-- `(σ́σ)(σ́σ)σ` — two trochees and a final unfooted σ. -/
+def faithful : Footing := [.inl troch, .inl troch, .inr ()]
+/-- `(σ́σ)(σ́σ)(σ́)` — the final σ parsed into a monosyllabic foot. -/
+def exhaustive : Footing := [.inl troch, .inl troch, .inl mono]
+
+/-- **Murinbata** ([street-mollinjin-1981]): under `Parse(σ) ≫ Trochee`, the exhaustive
+    parse wins — the final σ is footed into a monosyllable (final monosyllabic feet,
+    exhaustive parsing). -/
+theorem murinbata_exhaustive :
+    LexLE (profile (murinbata 5) exhaustive) (profile (murinbata 5) faithful)
+    ∧ ¬ LexLE (profile (murinbata 5) faithful) (profile (murinbata 5) exhaustive) := by decide
+
+/-- **Pintupi** ([hansen-hansen-1969]): under `Trochee ≫ Parse(σ)`, the faithful parse
+    wins — parsing a monosyllable would violate the dominant `Trochee`, so the final σ
+    stays unfooted (inexhaustive parsing). The derivation has converged. -/
+theorem pintupi_inexhaustive :
+    LexLE (profile (pintupi 5) faithful) (profile (pintupi 5) exhaustive)
+    ∧ ¬ LexLE (profile (pintupi 5) exhaustive) (profile (pintupi 5) faithful) := by decide
+
+/-! ### Parsimony: `FtBin` is obviated
+
+In even-parity `/σσσσ/`, the monosyllabic-foot candidate `(σ́)σσσ` is harmonically
+bounded by the disyllabic `(σ́σ)σσ` under `Parse(σ) ≫ Trochee ≫ Iamb` — *without* any
+`FtBin` in CON. `Trochee` and `Iamb` both penalising monosyllables do `FtBin`'s work
+([martinez-paricio-kager-2015]). -/
+
+/-- `(σ́σ)σσ` — one leftmost trochee in `/σσσσ/`. -/
+def disyll4 : Footing := [.inl troch, .inr (), .inr ()]
+/-- `(σ́)σσσ` — one leftmost monosyllable in `/σσσσ/`. -/
+def monosyll4 : Footing := [.inl mono, .inr (), .inr (), .inr ()]
+
+/-- **`FtBin` obviation**: the disyllabic-foot candidate strictly beats the
+    monosyllabic-foot candidate with no `FtBin` in CON — the monosyllable both fails
+    `Parse(σ)` more and violates `Trochee`. -/
+theorem ftbin_obviated :
+    LexLE (profile (murinbata 4) disyll4) (profile (murinbata 4) monosyll4)
+    ∧ ¬ LexLE (profile (murinbata 4) monosyll4) (profile (murinbata 4) disyll4) := by decide
+
+end Lamont2022c

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -26145,6 +26145,85 @@
   sources   = {Phonology/Constraint/OT/EvalMode.lean;Phonology/Constraint/OT/HarmonicSerialism.lean;Studies/McPhersonLamont2026.lean}
 }
 
+@article{lamont-2022c,
+  author    = {Lamont, Andrew},
+  title     = {A Restrictive, Parsimonious Theory of Footing in Directional {Harmonic Serialism}},
+  year      = {2022},
+  journal   = {Phonology},
+  volume    = {39},
+  number    = {1},
+  pages     = {41--78},
+  doi       = {10.1017/S0952675722000082},
+  subfield  = {phonology},
+  role      = {formalized},
+  sources   = {Studies/Lamont2022c.lean}
+}
+
+@article{pruitt-2010,
+  author    = {Pruitt, Kathryn},
+  title     = {Serialism and Locality in Constraint-Based Metrical Parsing},
+  year      = {2010},
+  journal   = {Phonology},
+  volume    = {27},
+  pages     = {481--526},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Studies/Lamont2022c.lean}
+}
+
+@phdthesis{pruitt-2012,
+  author    = {Pruitt, Kathryn Ringler},
+  title     = {Stress in {Harmonic Serialism}},
+  year      = {2012},
+  school    = {University of Massachusetts Amherst},
+  url       = {https://scholarworks.umass.edu/open_access_dissertations/657/},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Studies/Lamont2022c.lean}
+}
+
+@article{martinez-paricio-kager-2015,
+  author    = {Mart{\'i}nez-Paricio, Violeta and Kager, Ren{\'e}},
+  title     = {The Binary-to-Ternary Rhythmic Continuum in Stress Typology: Layered Feet and Non-Intervention Constraints},
+  year      = {2015},
+  journal   = {Phonology},
+  volume    = {32},
+  number    = {3},
+  pages     = {459--504},
+  doi       = {10.1017/S0952675715000287},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Studies/Lamont2022c.lean}
+}
+
+@article{hansen-hansen-1969,
+  author    = {Hansen, Kenneth C. and Hansen, Lesley E.},
+  title     = {Pintupi Phonology},
+  year      = {1969},
+  journal   = {Oceanic Linguistics},
+  volume    = {8},
+  number    = {2},
+  pages     = {153--170},
+  doi       = {10.2307/3622818},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Studies/Lamont2022c.lean}
+}
+
+@incollection{street-mollinjin-1981,
+  author    = {Street, Chester S. and Mollinjin, G. P.},
+  title     = {The Phonology of Murinbata},
+  year      = {1981},
+  booktitle = {Australian Phonologies: Collected Papers},
+  editor    = {Waters, Bruce},
+  pages     = {183--244},
+  publisher = {Summer Institute of Linguistics, Australian Aborigines Branch},
+  address   = {Darwin},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Studies/Lamont2022c.lean}
+}
+
 % REF: McCarthy (2008). The gradual path to cluster simplification.
 % Phonology 25:271-319. Foundational HS paper. DOI deliberately omitted
 % pending verification.


### PR DESCRIPTION
Formalizes [lamont-2022c]'s central result: quantity-insensitive footing in directional Harmonic Serialism, where CON has only **directionally-evaluated** constraints (violation *vectors* ordered lexicographically by locus, via `Constraints.directionalBlock`).

- A footing is a flat `List (Foot Unit ⊕ stray-σ)` — reusing the canonical #981 `Foot` (QI ⟹ `S = Unit`), zero-or-more feet, **no** head foot (Lamont abstracts from primary stress; the headed ω `Word` #984 is a footing *plus* a head foot, so it's deliberately not the candidate type).
- `Parse(σ)` = a `directionalBlock` over σ-positions (this study is its first consumer); `Trochee`/`Iamb` read `Foot.head` (`head = last` = `IsIambic`, `head = 0` = `IsTrochaic`), so monosyllables violate both → `FtBin` obviated.
- Headline (`by decide`): the same 5σ step parses exhaustively under `Parse(σ) ≫ Trochee` ([street-mollinjin-1981], Murinbata) but stays faithful — final σ unfooted — under `Trochee ≫ Parse(σ)` ([hansen-hansen-1969], Pintupi); `ftbin_obviated` shows a monosyllabic-foot candidate harmonically bounded with no `FtBin`.
- Waorani (§3 bidirectional), the factorial typology (§4), Macedonian/Garawa/Cayuvava are prose-noted, not formalized.

Builds on #981 (`Foot`) + #984 (`Word`). +6 bib entries (`lamont-2022c` + data sources, verified).