### PR TITLE
refactor(Phonology/Prosody): dissolve MetricalParse → canonical Footing

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1358,6 +1358,7 @@ import Linglib.Phonology.OptimalityTheory.Stratal
 import Linglib.Phonology.Prosody.Accent
 import Linglib.Phonology.Prosody.CompensatoryLengthening
 import Linglib.Phonology.Prosody.Foot
+import Linglib.Phonology.Prosody.Footing
 import Linglib.Phonology.Prosody.Mora
 import Linglib.Phonology.Prosody.Syllable
 import Linglib.Phonology.Prosody.Tree

--- a/Linglib/Phonology/Prosody/Foot.lean
+++ b/Linglib/Phonology/Prosody/Foot.lean
@@ -21,10 +21,8 @@ are *functions* that recover the same head.
 * `Foot.moraCount` — mora count under a weight reading (the quantity axis).
 * `Foot.IsSyllabicTrochee` / `IsMoraicTrochee` / `IsCanonicalIamb` — the *derived* inventory.
 * `Foot.toProsTree` / `Foot.toGrid` — re-representations that preserve the head.
-* `ParseElement` / `MetricalParse` — a metrical parse of a domain (legacy; the footing
-  work migrates this onto `Foot`/`Tree`).
-* `footMorae`, `ftBinViolations`, `parseSylViolations`, `allFt{Left,Right}Violations` —
-  parse-level OT constraints.
+* `footMorae` — mora count of a `Tree`-extracted weight-list foot (the flat metrical
+  parse is now `Prosody.Footing`).
 
 ## Main results
 
@@ -157,75 +155,13 @@ theorem headFlags_toProsTree (w : S → Syllable.Weight) (f : Foot S) :
 
 end Foot
 
-/-! ### Metrical parse
+/-! ### Foot mora count -/
 
-A flat parse of a prosodic domain. (Legacy weight-list representation; the footing
-work migrates this onto the headed `Foot`/`Tree` above.) -/
-
-/-- An element in a metrical parse: either a foot grouping syllables
-    or an unparsed (stray) syllable. The list preserves left-to-right
-    linear order within the prosodic domain. -/
-inductive ParseElement where
-  /-- A foot containing one or more syllables (represented by weight). -/
-  | foot : List Syllable.Weight → ParseElement
-  /-- An unparsed syllable not dominated by any foot. -/
-  | unfooted : Syllable.Weight → ParseElement
-  deriving DecidableEq, Repr
-
-/-- A metrical parse: a prosodic domain represented as a linear sequence
-    of footed and unfooted syllables. -/
-abbrev MetricalParse := List ParseElement
-
-/-- Extract all feet from a parse. -/
-def MetricalParse.feet (p : MetricalParse) : List (List Syllable.Weight) :=
-  p.filterMap λ | .foot ws => some ws | .unfooted _ => none
-
-/-- Mora count of a single foot (each weight *is* a mora count). -/
+/-- Mora count of a foot given as a weight-list (each weight *is* a mora count). The
+    moraic measure for `Tree`-extracted feet (`Phonology/Prosody/WordSize.lean`); for a
+    headed `Foot S`, use `Foot.moraCount`. -/
 def footMorae (ws : List Syllable.Weight) : Nat :=
   ws.foldl (· + ·) 0
-
-/-- Total syllable count in a parse. -/
-def MetricalParse.syllableCount (p : MetricalParse) : Nat :=
-  p.foldl (λ acc e => acc + match e with
-    | .foot ws => ws.length
-    | .unfooted _ => 1) 0
-
-/-- Number of unparsed syllables in a parse. -/
-def MetricalParse.unparsedCount (p : MetricalParse) : Nat :=
-  p.filter (λ | .unfooted _ => true | _ => false) |>.length
-
-/-! ### OT metrical constraints -/
-
-/-- FT-BIN(μ): assign one violation for each foot that does not consist
-    of exactly two morae ([kager-2007]). -/
-def ftBinViolations (p : MetricalParse) : Nat :=
-  p.feet.filter (λ ws => footMorae ws != 2) |>.length
-
-/-- PARSE-SYL: assign one violation for each syllable not parsed into
-    a foot ([kager-2007]). Drives exhaustive parsing. -/
-def parseSylViolations (p : MetricalParse) : Nat :=
-  p.unparsedCount
-
-/-- ALL-FT-LEFT: for each foot, count the syllables intervening between the
-    left edge of the domain and the left edge of the foot ([kager-2007]). -/
-def allFtLeftViolations (p : MetricalParse) : Nat :=
-  let rec go : List ParseElement → Nat → Nat
-    | [], _ => 0
-    | .foot ws :: rest, pos => pos + go rest (pos + ws.length)
-    | .unfooted _ :: rest, pos => go rest (pos + 1)
-  go p 0
-
-/-- ALL-FT-RIGHT: for each foot, count the syllables intervening between the
-    right edge of the foot and the right edge of the domain ([kager-2007]). -/
-def allFtRightViolations (p : MetricalParse) : Nat :=
-  let total := p.syllableCount
-  let rec go : List ParseElement → Nat → Nat
-    | [], _ => 0
-    | .foot ws :: rest, pos =>
-      let rightEdge := pos + ws.length
-      (total - rightEdge) + go rest rightEdge
-    | .unfooted _ :: rest, pos => go rest (pos + 1)
-  go p 0
 
 /-! ### Worked examples -/
 
@@ -239,21 +175,5 @@ example : (Foot.monosyllable 0).IsDegenerate := by decide
 -- The re-representations recover the head: a trochee marks position 0, an iamb 1.
 example : Foot.toGrid (Foot.trochee 1 1) = [true, false] := by decide
 example : Foot.toGrid (Foot.iamb 1 1) = [false, true] := by decide
-
--- OT metrical constraints on worked parses.
-/-- (ˈCV.CV).CV: one bimoraic foot (LL) + one stray light syllable. -/
-private abbrev parse_llU : MetricalParse := [.foot [.light, .light], .unfooted .light]
-example : ftBinViolations parse_llU = 0 := rfl
-example : parseSylViolations parse_llU = 1 := rfl
-example : allFtLeftViolations parse_llU = 0 := rfl
-
-/-- (ˈLL)(ˌH): two bimoraic feet — the Telugu stem parse of *samudr-am*. -/
-private abbrev parse_llH : MetricalParse := [.foot [.light, .light], .foot [.heavy]]
-example : ftBinViolations parse_llH = 0 := rfl
-example : parseSylViolations parse_llH = 0 := rfl
-example : allFtLeftViolations parse_llH = 2 := rfl
-
-private abbrev parse_lllH : MetricalParse := [.foot [.light], .foot [.light], .foot [.heavy]]
-example : ftBinViolations parse_lllH = 2 := rfl
 
 end Prosody

--- a/Linglib/Phonology/Prosody/Footing.lean
+++ b/Linglib/Phonology/Prosody/Footing.lean
@@ -1,0 +1,55 @@
+import Linglib.Phonology.Prosody.Foot
+
+/-!
+# Footings
+[lamont-2022c] [kager-2007]
+
+A **footing**: a flat parse of a syllable string into feet and stray (unfooted)
+syllables — the metrical parse, with no designated head ([lamont-2022c]). It is the
+canonical, headed-`Foot`-based replacement for the old weight-list `MetricalParse`:
+each foot is a `Prosody.Foot` (so headedness/binarity come from `Foot.head`), and an
+unfooted σ is a bare `S`.
+
+The footing is the more primitive object in the prosodic hierarchy; the headed prosodic
+word ω (`Prosody.Word`) is a footing *enriched with a head foot* (its `Word.daughters`
+is the underlying footing). Quantity-sensitivity is a property of the σ-type `S`: a
+quantity-insensitive footing uses `S = Unit` ([lamont-2022c]), a weight-sensitive one
+`S = Syllable.Weight`.
+
+## Main definitions
+
+* `Footing` — a flat sequence of feet and stray syllables, `List (Foot S ⊕ S)`.
+* `Footing.feet` / `strays` / `size` — the feet, the unfooted σ, the total σ count.
+* `Footing.strayMarks` — the per-position unfooted-σ vector (the `Parse(σ)` profile).
+-/
+
+namespace Prosody
+
+/-- A footing: a flat sequence of feet (`Foot S`) and stray (unfooted) syllables (`S`),
+    in linear order, with zero-or-more feet and no designated head ([lamont-2022c]). -/
+abbrev Footing (S : Type*) := List (Foot S ⊕ S)
+
+namespace Footing
+variable {S : Type*}
+
+/-- The feet, left to right. -/
+def feet (fc : Footing S) : List (Foot S) := fc.filterMap Sum.getLeft?
+
+/-- The stray (unfooted) syllables, left to right. -/
+def strays (fc : Footing S) : List S := fc.filterMap Sum.getRight?
+
+/-- The total number of syllables (footed + stray). -/
+def size (fc : Footing S) : Nat :=
+  (fc.map (fun d => match d with | .inl f => f.syllables.length | .inr _ => 1)).sum
+
+/-- The per-position unfooted-σ vector: `1` at each stray σ, `0` at each footed σ,
+    left to right. This is the directional `Parse(σ)` violation profile
+    ([lamont-2022c]). -/
+def strayMarks (fc : Footing S) : List Nat :=
+  fc.flatMap (fun d => match d with
+    | .inl f => List.replicate f.syllables.length 0
+    | .inr _ => [1])
+
+end Footing
+
+end Prosody

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -5,6 +5,7 @@ import Linglib.Morphology.Case.Allomorphy
 import Linglib.Phonology.OptimalityTheory.Basic
 import Linglib.Phonology.OptimalityTheory.Predict
 import Linglib.Phonology.Prosody.Foot
+import Linglib.Phonology.Prosody.Footing
 import Linglib.Morphology.DM.VocabularyInsertion
 import Linglib.Phonology.OptimalityTheory.Stratal
 import Linglib.Phonology.Prosody.CompensatoryLengthening
@@ -441,23 +442,32 @@ inductive StemCandidate where
   | ll_H
   deriving DecidableEq, Repr
 
-/-- Map each candidate to its `MetricalParse` representation. -/
-def StemCandidate.toParse : StemCandidate → MetricalParse
-  | .llU_H => [.foot [.light, .light], .unfooted .heavy]
-  | .l_l_H => [.foot [.light], .foot [.light], .foot [.heavy]]
-  | .ll_H  => [.foot [.light, .light], .foot [.heavy]]
+/-- Map each candidate to its canonical `Prosody.Footing` over weighted σ
+    (feet are `Prosody.Foot`s; an unfooted σ is a bare weight). -/
+def StemCandidate.toFooting : StemCandidate → Footing Syllable.Weight
+  | .llU_H => [.inl ⟨[.light, .light], 0⟩, .inr .heavy]
+  | .l_l_H => [.inl ⟨[.light], 0⟩, .inl ⟨[.light], 0⟩, .inl ⟨[.heavy], 0⟩]
+  | .ll_H  => [.inl ⟨[.light, .light], 0⟩, .inl ⟨[.heavy], 0⟩]
 
-/-- FT-BIN(μ): penalizes non-bimoraic feet. -/
+/-- ALL-FT-LEFT: per foot, the σ intervening from the left edge of the domain. -/
+def allFtLeftOf (fc : Footing Syllable.Weight) : Nat :=
+  let rec go : Footing Syllable.Weight → Nat → Nat
+    | [], _ => 0
+    | .inl f :: rest, pos => pos + go rest (pos + f.syllables.length)
+    | .inr _ :: rest, pos => go rest (pos + 1)
+  go fc 0
+
+/-- FT-BIN(μ): penalizes non-bimoraic feet (a foot whose morae ≠ 2). -/
 def cFtBin : Constraint StemCandidate :=
-  λ c => ftBinViolations c.toParse
+  λ c => (c.toFooting.feet.filter (fun f => decide (Foot.moraCount id f ≠ 2))).length
 
-/-- PARSE-SYL: penalizes unparsed syllables. -/
+/-- PARSE-SYL: penalizes unparsed (stray) syllables. -/
 def cParseSyl : Constraint StemCandidate :=
-  λ c => parseSylViolations c.toParse
+  λ c => c.toFooting.strays.length
 
 /-- ALL-FT-LEFT: penalizes feet distant from the left edge. -/
 def cAllFtLeft : Constraint StemCandidate :=
-  λ c => allFtLeftViolations c.toParse
+  λ c => allFtLeftOf c.toFooting
 
 /-- Stem-level constraint ranking: FT-BIN ≫ PARSE-SYL ≫ ALL-FT-LEFT.
 
@@ -477,16 +487,16 @@ theorem stemCandidates_ne : stemCandidates ≠ [] := by decide
     | (ˈsa).(ˌmu).(ˌdram)|   2*   |    0      |     0+1+2   |
     | ☞ (ˈsa.mu).(ˌdram) |   0    |    0      |     0+2     | -/
 theorem stem_ftbin_violations :
-    stemCandidates.map cFtBin = [0, 2, 0] := by native_decide
+    stemCandidates.map cFtBin = [0, 2, 0] := by decide
 
 theorem stem_parsesyl_violations :
-    stemCandidates.map cParseSyl = [1, 0, 0] := by native_decide
+    stemCandidates.map cParseSyl = [1, 0, 0] := by decide
 
 /-- The optimal Stem-level parse is (ˈsa.mu).(ˌdram): two well-formed
     moraic trochees, (LL)(H), with no unparsed syllables. -/
 theorem stem_optimal :
     (Tableau.ofRanking stemCandidates stemRanking stemCandidates_ne).optimal
-      = {.ll_H} := by native_decide
+      = {.ll_H} := by decide
 
 -- ============================================================================
 -- § 5: Word-Level Phonology (Stratal OT)


### PR DESCRIPTION
Dissolves the legacy weight-list `MetricalParse` cluster, finishing the prosody migration onto the canonical `Foot`-based substrate.

- New `Prosody.Footing (S) := List (Foot S ⊕ S)` — the canonical flat footing (feet are `Prosody.Foot`s, an unfooted σ is a bare `S`), the headed-`Foot` replacement for `MetricalParse`. It is the more primitive object the headed ω `Word` enriches (`Word.daughters` is a footing).
- **Aitha2026 §4** migrated onto `Footing Syllable.Weight`: `toParse → toFooting`, `cFtBin`/`cParseSyl`/`cAllFtLeft` re-expressed via `Foot.moraCount`/`Footing.strays`. Because the canonical `moraCount` reduces (unlike the old `footMorae` foldl), all three stem theorems — including `stem_optimal`'s `Tableau.optimal = {.ll_H}` — now go through by **`decide`** instead of `native_decide`. Verified against [aitha-2026]'s tableau (49): FtBin ≫ Parse-Syl ≫ AllFtLeft → (LL)(H).
- `MetricalParse`/`ParseElement`/`ftBinViolations`/`parseSylViolations`/`allFt{Left,Right}Violations` deleted from Foot.lean; `footMorae` kept (WordSize/Uchihara measure).

Follow-up: Lamont2022c's study-local footing can consolidate onto `Prosody.Footing` (a clean de-dup, separate from this dissolution).