### PR TITLE
refactor(Phonology/Segmental): polish Geometry, GeomNode→Node

### DIFF
--- a/Linglib/Fragments/Finnish/VowelHarmony.lean
+++ b/Linglib/Fragments/Finnish/VowelHarmony.lean
@@ -38,7 +38,7 @@ are skipped by `triggerValue` (not triggers) and `harmonizeOne` (not targets).
 namespace Finnish.VowelHarmony
 
 open Phonology (Segment Feature)
-open Phonology.FeatureGeometry (GeomNode)
+open Phonology.FeatureGeometry (Node)
 open Autosegmental (SharingRep agreeAt)
 open Subregular.Harmony (System HarmonyDir triggerValue
   harmonizeOne spreadSuffix)

--- a/Linglib/Phonology/Autosegmental/Sharing.lean
+++ b/Linglib/Phonology/Autosegmental/Sharing.lean
@@ -63,12 +63,12 @@ two distinct elements cannot be identical to the same time point.
 namespace Autosegmental
 
 open Phonology (Segment Feature)
-open Phonology.FeatureGeometry (GeomNode)
+open Phonology.FeatureGeometry (Node)
 
 /-! ### Feature agreement -/
 
 /-- Do `s1` and `s2` agree on all features dominated by node `n`? -/
-def agreeAt (s1 s2 : Segment) (n : GeomNode) : Bool :=
+def agreeAt (s1 s2 : Segment) (n : Node) : Bool :=
   n.features.all fun f => s1 f == s2 f
 
 /-- Place assimilation: agreement on all place features. -/
@@ -83,7 +83,7 @@ def totalAssimilation (s1 s2 : Segment) : Bool := agreeAt s1 s2 .supralaryngeal
     dominated by `node`. -/
 structure Sharing where
   left : Nat
-  node : GeomNode
+  node : Node
   deriving DecidableEq, Repr
 
 /-! ### Autosegmental representation -/
@@ -108,12 +108,12 @@ def SharingRep.consistent (r : SharingRep) : Bool :=
 /-! ### Operations -/
 
 /-- Spread node `n` rightward from position `pos`. -/
-def SharingRep.spread (r : SharingRep) (pos : Nat) (n : GeomNode) :
+def SharingRep.spread (r : SharingRep) (pos : Nat) (n : Node) :
     SharingRep :=
   { r with sharing := ⟨pos, n⟩ :: r.sharing }
 
 /-- Remove sharing at position `pos` for node `n`. -/
-def SharingRep.delink (r : SharingRep) (pos : Nat) (n : GeomNode) :
+def SharingRep.delink (r : SharingRep) (pos : Nat) (n : Node) :
     SharingRep :=
   { r with sharing := r.sharing.filter fun s =>
       !(s.left == pos && s.node == n) }
@@ -125,13 +125,13 @@ def SharingRep.delink (r : SharingRep) (pos : Nat) (n : GeomNode) :
     assimilation): the entire node — including features `src` leaves
     unspecified — is copied. (The node-spreading analysis; single-feature
     spreading and underspecification-sensitive variants behave differently.) -/
-def copyFeaturesUnder (tgt src : Segment) (n : GeomNode) : Segment :=
+def copyFeaturesUnder (tgt src : Segment) (n : Node) : Segment :=
   fun f => if decide (f.DominatedBy n) then src f else tgt f
 
 /-- Spread node `n` from position `pos + 1` onto position `pos`, replacing
     the target's features under `n` with the trigger's values and recording
     the sharing link. -/
-def SharingRep.spreadFeatures (r : SharingRep) (pos : Nat) (n : GeomNode) :
+def SharingRep.spreadFeatures (r : SharingRep) (pos : Nat) (n : Node) :
     SharingRep :=
   match r.segments[pos]?, r.segments[pos + 1]? with
   | some tgt, some src =>
@@ -156,9 +156,9 @@ private theorem all_filter_if_beq_self {α β : Type*} [BEq β] [LawfulBEq β]
 
 /-- After copying features under node `n`, the result agrees with the source
     at that node. -/
-theorem copyFeaturesUnder_agreeAt (tgt src : Segment) (n : GeomNode) :
+theorem copyFeaturesUnder_agreeAt (tgt src : Segment) (n : Node) :
     agreeAt (copyFeaturesUnder tgt src n) src n = true := by
-  simp only [agreeAt, copyFeaturesUnder, GeomNode.features]
+  simp only [agreeAt, copyFeaturesUnder, Node.features]
   exact all_filter_if_beq_self Feature.allFeatures
     (fun f => decide (f.DominatedBy n)) src tgt
 
@@ -172,18 +172,18 @@ private theorem list_all_beq_self {α : Type*} [BEq α] [LawfulBEq α]
   | cons _ _ ih => simp [List.all_cons]
 
 /-- Agreement is reflexive. -/
-theorem agreeAt_refl (s : Segment) (n : GeomNode) :
+theorem agreeAt_refl (s : Segment) (n : Node) :
     agreeAt s s n = true :=
   list_all_beq_self n.features s
 
 /-- Place assimilation checks 14 features (the place node's natural class). -/
 theorem place_assimilation_checks_14 :
-    GeomNode.place.features.length = 14 := by decide
+    Node.place.features.length = 14 := by decide
 
 /-- Total assimilation checks 16 features (the supralaryngeal node's natural class,
     including [nasal] via the soft palate node). -/
 theorem total_assimilation_checks_16 :
-    GeomNode.supralaryngeal.features.length = 16 := by decide
+    Node.supralaryngeal.features.length = 16 := by decide
 
 private theorem filter_all_pass (l : List Sharing) (p : Sharing → Bool)
     (h : l.all p = true) : l.filter p = l := by
@@ -197,7 +197,7 @@ private theorem filter_all_pass (l : List Sharing) (p : Sharing → Bool)
 
 /-- Spreading and then delinking returns the original representation when the
     position/node pair was not already present in the sharing list. -/
-theorem spread_delink_not_present (r : SharingRep) (pos : Nat) (n : GeomNode)
+theorem spread_delink_not_present (r : SharingRep) (pos : Nat) (n : Node)
     (h : (r.sharing.all fun s => !(s.left == pos && s.node == n)) = true) :
     (r.spread pos n).delink pos n = r := by
   cases r with | mk segs shs =>

--- a/Linglib/Phonology/Segmental/Geometry.lean
+++ b/Linglib/Phonology/Segmental/Geometry.lean
@@ -2,7 +2,8 @@ import Linglib.Phonology.Segmental.Defs
 import Mathlib.Logic.Relation
 
 /-!
-# Feature Geometry [clements-1985] [sagey-1986]
+# Feature geometry
+[clements-1985] [sagey-1986]
 
 The hierarchical organization of phonological features as autosegmental class
 nodes ([clements-hume-1995]):
@@ -17,39 +18,64 @@ nodes ([clements-hume-1995]):
             └── Dorsal [±dor, ±high, ±low, ±front, ±back, ±tense]
 
 The constituency from Root down to the three Place articulators is the consensus
-of [clements-1985] and [sagey-1986]. The placement of the individual terminal
-features — notably `[continuant]`, `[nasal]`, and `[lateral]`/`[strident]` — is
-theory-specific and contested: [sagey-1986] argues `[continuant]` is an
-articulator-level property, against its Supralaryngeal placement here. That
-divergence is formalized in `Studies/Sagey1986.lean`.
+of [clements-1985] and [sagey-1986]. The placement of individual terminals —
+notably `[continuant]`, `[nasal]`, and `[lateral]`/`[strident]` — is theory-specific
+and contested: [sagey-1986] argues `[continuant]` is articulator-level, against its
+Supralaryngeal placement here (the divergence is formalized in `Studies/Sagey1986.lean`).
+A feature's geometric node is also distinct from its manner-class (`Feature.category`):
+`[lateral]` attaches under Coronal yet is a manner feature, so the flat predicates
+(`Feature.IsPlace` &c.) do not coincide with single-node dominance.
 
-A feature's geometric node is distinct from its manner-class (`Feature.category`):
-a manner feature like `[lateral]` attaches geometrically under Coronal, so the
-flat predicates (`Feature.IsPlace` &c.) do not coincide with single-node
-dominance — see the subsumption theorems below.
+## Main definitions
+
+* `Node`, `Node.parent`, `Node.Dominates` — the class nodes, the tree,
+  and the reflexive-transitive ancestor relation.
+* `Feature.node` — each feature's dominating node (this geometry's assignment;
+  rivals live in their study files).
+* `Node.features` — the natural class a node dominates.
+* `Node.IsArticulator`, `Segment.activeArticulators`, `Segment.IsComplex` — the
+  place articulators and a segment's simultaneous (complex) articulations.
+
+## Main results
+
+* `Node.dominates_iff` — dominance unrolls to the depth-≤ 3 parent chain, the
+  decidable face the `decide` facts run through.
+* `IsLaryngeal_iff_laryngeal_DominatedBy`, `IsDorsal_iff_dorsal_DominatedBy` — two
+  flat predicates coincide with single-node dominance; `IsPlace` is only a subset.
+* `Segment.activeArticulators_nodup` — complex-segment well-formedness holds by
+  construction ([sagey-1986]).
 -/
 
 namespace Phonology.FeatureGeometry
 
 /-! ### Geometric nodes -/
 
-/-- Class nodes in the feature geometry tree. -/
-inductive GeomNode where
-  | root           -- Root node (dominates everything)
-  | laryngeal      -- Laryngeal node ([clements-1985])
-  | supralaryngeal -- Supralaryngeal node ([clements-1985])
-  | softPalate     -- Soft palate node ([sagey-1986])
-  | place          -- Place node ([clements-1985])
-  | labial         -- Labial articulator ([sagey-1986])
-  | coronal        -- Coronal articulator ([sagey-1986])
-  | dorsal         -- Dorsal articulator ([sagey-1986])
+/-- The class nodes of the feature-geometry tree ([clements-1985]; [sagey-1986]). -/
+inductive Node where
+  /-- The root node, dominating all others. -/
+  | root
+  /-- The laryngeal node: voicing and glottal features. -/
+  | laryngeal
+  /-- The supralaryngeal node, mediating root and place. -/
+  | supralaryngeal
+  /-- The soft-palate (velum) node: nasality. -/
+  | softPalate
+  /-- The place node, over the three oral articulators. -/
+  | place
+  /-- The labial articulator (the lips). -/
+  | labial
+  /-- The coronal articulator (the tongue blade/tip). -/
+  | coronal
+  /-- The dorsal articulator (the tongue body). -/
+  | dorsal
   deriving DecidableEq, Repr
+
+variable (n m : Node)
 
 /-! ### Tree structure -/
 
-/-- Parent of each node in the geometry tree. The supralaryngeal node
-    ([clements-1985]) mediates between root and place. -/
-def GeomNode.parent : GeomNode → Option GeomNode
+/-- The parent of each node; `root` alone has none. -/
+def Node.parent : Node → Option Node
   | .root           => none
   | .laryngeal      => some .root
   | .supralaryngeal => some .root
@@ -59,31 +85,26 @@ def GeomNode.parent : GeomNode → Option GeomNode
   | .coronal        => some .place
   | .dorsal         => some .place
 
-/-- All geometric nodes. -/
-def GeomNode.allNodes : List GeomNode :=
+/-- All eight nodes. -/
+def Node.allNodes : List Node :=
   [.root, .laryngeal, .supralaryngeal, .softPalate, .place, .labial, .coronal, .dorsal]
 
-/-- Children of a node: nodes whose parent is `n`. -/
-def GeomNode.children (n : GeomNode) : List GeomNode :=
-  GeomNode.allNodes.filter (λ m => m.parent == some n)
+/-- The children of `n`: the nodes whose parent is `n`. -/
+def Node.children : List Node := allNodes.filter (λ k => k.parent == some n)
 
 /-! ### Dominance -/
 
-/-- `n` dominates `m`: `n` is `m` or one of its ancestors — the reflexive-
-    transitive closure of "is the parent of", reached by walking up from `m`.
-    Depth-agnostic, unlike a fixed unrolling. -/
-def GeomNode.Dominates (n m : GeomNode) : Prop :=
-  Relation.ReflTransGen (fun a b => a.parent = some b) m n
+/-- `n` dominates `m`: it is `m` or one of its ancestors — the reflexive-transitive
+    closure of "is the parent of", walked up from `m`. Depth-agnostic. -/
+def Node.Dominates : Prop := Relation.ReflTransGen (λ a b => a.parent = some b) m n
 
-/-- Dominance unrolls to the bounded parent-chain: the geometry has depth ≤ 3,
-    so `n` dominates `m` iff `n` is reached within three steps up. This is the
-    decidable face of `Dominates` that the `decide`-checked facts below run
-    through. -/
-theorem GeomNode.dominates_iff (n m : GeomNode) :
+/-- Dominance unrolls to the depth-≤ 3 parent chain — the decidable face the
+    `decide` facts below run through. -/
+theorem Node.dominates_iff :
     n.Dominates m ↔ n = m ∨ m.parent = some n ∨
-      (m.parent.bind GeomNode.parent) = some n ∨
-      ((m.parent.bind GeomNode.parent).bind GeomNode.parent) = some n := by
-  unfold GeomNode.Dominates
+      (m.parent.bind Node.parent) = some n ∨
+      ((m.parent.bind Node.parent).bind Node.parent) = some n := by
+  unfold Node.Dominates
   constructor
   · intro h
     induction h with
@@ -98,13 +119,12 @@ theorem GeomNode.dominates_iff (n m : GeomNode) :
     · exact .refl
     · exact .single h
     · obtain ⟨p, hmp, hpn⟩ := Option.bind_eq_some_iff.mp h
-      exact Relation.ReflTransGen.tail (.single hmp) hpn
+      exact .tail (.single hmp) hpn
     · obtain ⟨q, hq, hqn⟩ := Option.bind_eq_some_iff.mp h
       obtain ⟨p, hmp, hpq⟩ := Option.bind_eq_some_iff.mp hq
-      exact Relation.ReflTransGen.tail (.tail (.single hmp) hpq) hqn
+      exact .tail (.tail (.single hmp) hpq) hqn
 
-instance : DecidableRel GeomNode.Dominates := fun n m =>
-  decidable_of_iff _ (GeomNode.dominates_iff n m).symm
+instance : DecidableRel Node.Dominates := λ n m => decidable_of_iff _ (Node.dominates_iff n m).symm
 
 end Phonology.FeatureGeometry
 
@@ -112,18 +132,11 @@ end Phonology.FeatureGeometry
 
 namespace Phonology
 
-open FeatureGeometry in
-/-- Each terminal feature maps to its dominating class node.
+open FeatureGeometry
 
-    - Root: [syllabic], [consonantal], [sonorant], [approximant],
-      [delayedRelease], [tap], [trill]
-    - Laryngeal: [voice], [spreadGlottis], [constrGlottis]
-    - Supralaryngeal: [continuant]
-    - Soft Palate: [nasal]
-    - Labial: [labial], [round], [labiodental]
-    - Coronal: [coronal], [anterior], [distributed], [lateral], [strident]
-    - Dorsal: [dorsal], [high], [low], [front], [back], [tense] -/
-def Feature.node : Feature → GeomNode
+/-- Each terminal feature's dominating class node — this geometry's assignment
+    (contested for `[continuant]`/`[nasal]`/`[lateral]`; see the module docstring). -/
+def Feature.node : Feature → Node
   | .syllabic | .consonantal | .sonorant | .approximant
   | .delayedRelease | .tap | .trill => .root
   | .voice | .spreadGlottis | .constrGlottis => .laryngeal
@@ -133,201 +146,145 @@ def Feature.node : Feature → GeomNode
   | .coronal | .anterior | .distributed | .lateral | .strident => .coronal
   | .dorsal | .high | .low | .front | .back | .tense => .dorsal
 
-open FeatureGeometry in
-/-- Does node `n` dominate the node that feature `f` belongs to? -/
-@[reducible] def Feature.DominatedBy (f : Feature) (n : GeomNode) : Prop :=
-  GeomNode.Dominates n f.node
+/-- Does node `n` dominate the node feature `f` belongs to? -/
+@[reducible] def Feature.DominatedBy (f : Feature) (n : Node) : Prop := n.Dominates f.node
 
 end Phonology
 
 namespace Phonology.FeatureGeometry
 
+variable (n : Node) (f : Feature)
+
 /-! ### Natural classes -/
 
-/-- Features dominated by node `n` — a natural class in the feature-geometric
-    sense: the features that pattern together under processes targeting `n`. -/
-def GeomNode.features (n : GeomNode) : List Feature :=
-  Feature.allFeatures.filter (λ f => decide (GeomNode.Dominates n f.node))
+/-- The features dominated by `n` — its natural class, the features that pattern
+    together under processes targeting `n`. -/
+def Node.features : List Feature := Feature.allFeatures.filter (λ g => decide (n.Dominates g.node))
 
-/-! ### Verification theorems -/
+/-! ### Tree structure (verification) -/
 
--- Tree structure
+theorem root_has_no_parent : Node.root.parent = none := rfl
 
-theorem root_has_no_parent : GeomNode.root.parent = none := rfl
+theorem nonroot_has_parent (h : n ≠ .root) : n.parent.isSome = true := by
+  cases n <;> simp_all [Node.parent]
 
-theorem nonroot_has_parent (n : GeomNode) (h : n ≠ .root) :
-    n.parent.isSome = true := by
-  cases n <;> simp_all [GeomNode.parent]
+theorem allNodes_complete : n ∈ Node.allNodes := by cases n <;> simp [Node.allNodes]
 
-theorem allNodes_complete (n : GeomNode) : n ∈ GeomNode.allNodes := by
-  cases n <;> simp [GeomNode.allNodes]
+/-! ### Natural class sizes
+[hayes-2009]'s complete 26-feature inventory. -/
 
--- Natural class counts ([hayes-2009] complete inventory: 26 features)
+theorem root_features_count : Node.root.features.length = 26 := rfl
+theorem laryngeal_features_count : Node.laryngeal.features.length = 3 := rfl
+theorem supralaryngeal_features_count : Node.supralaryngeal.features.length = 16 := rfl
+theorem softPalate_features_count : Node.softPalate.features.length = 1 := rfl
+theorem place_features_count : Node.place.features.length = 14 := rfl
+theorem labial_features_count : Node.labial.features.length = 3 := rfl
+theorem coronal_features_count : Node.coronal.features.length = 5 := rfl
+theorem dorsal_features_count : Node.dorsal.features.length = 6 := rfl
 
-theorem root_features_count : GeomNode.root.features.length = 26 := rfl
-theorem laryngeal_features_count : GeomNode.laryngeal.features.length = 3 := rfl
-theorem supralaryngeal_features_count :
-    GeomNode.supralaryngeal.features.length = 16 := rfl
-theorem softPalate_features_count :
-    GeomNode.softPalate.features.length = 1 := rfl
-theorem place_features_count : GeomNode.place.features.length = 14 := rfl
-theorem labial_features_count : GeomNode.labial.features.length = 3 := rfl
-theorem coronal_features_count : GeomNode.coronal.features.length = 5 := rfl
-theorem dorsal_features_count : GeomNode.dorsal.features.length = 6 := rfl
+/-! ### Flat-predicate subsumption
 
--- Subsumption of existing flat predicates
---
--- isLaryngeal matches the geometry exactly.
--- isDorsal matches the geometry exactly.
--- isPlace now matches the geometry exactly (includes labiodental, front, tense).
--- The manner/root features have no single geometric counterpart: they are
--- distributed across root, supralaryngeal, softPalate, and coronal.
+`IsLaryngeal`/`IsDorsal` coincide with single-node dominance; `IsPlace` is only a
+*subset* (manner features like `[lateral]`/`[strident]` sit geometrically under Coronal). -/
 
-theorem IsLaryngeal_iff_laryngeal_DominatedBy (f : Feature) :
-    f.IsLaryngeal ↔ f.DominatedBy .laryngeal := by
+theorem IsLaryngeal_iff_laryngeal_DominatedBy : f.IsLaryngeal ↔ f.DominatedBy .laryngeal := by
   cases f <;> decide
 
-theorem IsDorsal_iff_dorsal_DominatedBy (f : Feature) :
-    f.IsDorsal ↔ f.DominatedBy .dorsal := by
-  cases f <;> decide
+theorem IsDorsal_iff_dorsal_DominatedBy : f.IsDorsal ↔ f.DominatedBy .dorsal := by cases f <;> decide
 
--- IsPlace is a strict subset of geometric place dominance
--- (manner features like lateral and strident are geometrically under coronal)
-theorem IsPlace_implies_place_DominatedBy (f : Feature) :
-    f.IsPlace → f.DominatedBy .place := by
-  cases f <;> decide
+theorem IsPlace_implies_place_DominatedBy : f.IsPlace → f.DominatedBy .place := by cases f <;> decide
 
-theorem lateral_geometrically_under_place :
-    Feature.lateral.DominatedBy .place := by decide
+theorem lateral_geometrically_under_place : Feature.lateral.DominatedBy .place := by decide
 
-theorem strident_geometrically_under_place :
-    Feature.strident.DominatedBy .place := by decide
-
-end Phonology.FeatureGeometry
+theorem strident_geometrically_under_place : Feature.strident.DominatedBy .place := by decide
 
 /-!
-## Complex and contour segments [sagey-1986]
+## Complex and contour segments
+[sagey-1986]
 
-Segments with multiple simultaneous or sequential articulations.
+**Complex segments** have one root node with several *place* articulators active
+simultaneously (e.g. labiovelars [k͡p]); they fill one timing slot and their
+articulations are unordered. **Contour segments** have two root nodes on one timing
+slot, with articulations in sequence (e.g. affricates [ts]). A single-bundle
+`Segment` has one value per feature, so it can host only complex (one-root)
+segments, via `activeArticulators`; sequential contours need the multi-anchor
+autosegmental representation (`Autosegmental/`).
 
-**Complex segments** have one root node with multiple *place* articulator
-nodes active simultaneously (e.g., labiovelars [k͡p], [g͡b]; corono-velar
-clicks). They occupy a single timing slot and their articulations are
-unordered. The soft palate is an articulator in the vocal tract but sits
-outside the place node, so nasal + place combinations (e.g., [ŋ]) are
-simple segments, not complex ones.
-
-**Contour segments** have two root nodes linked to a single timing slot,
-with articulations in sequence (e.g., affricates [ts], [tʃ]; prenasalized
-stops [ⁿd], [ᵐb]). A single-bundle `Segment` has one value per feature and so
-cannot host two root nodes: only *complex* (simultaneous, one-root) segments are
-modeled here, via `activeArticulators`. Sequential contour structures need the
-multi-anchor autosegmental representation (`Autosegmental/`), where they belong
-([sagey-1986]).
-
-The feature geometry predicts which complex segments are possible: only those
-combining *distinct* articulator nodes. Palatal–velar stops are impossible
-because both use the dorsal articulator; labio-velars are possible because
-labial and dorsal are independent.
+The geometry predicts which complex segments are possible: only those combining
+*distinct* articulators. Palatal–velar stops are impossible (both are dorsal);
+labiovelars are possible (labial and dorsal are independent).
 -/
-
-namespace Phonology.FeatureGeometry
 
 /-! ### Articulator nodes -/
 
-/-- Is this a place articulator node? The three place articulators —
-    labial (lips), coronal (tongue blade/tip), dorsal (tongue body) —
-    are the independent articulators whose combinations give rise to
-    complex segments ([sagey-1986]). The soft palate is an
-    articulator in the vocal tract but sits outside the place node
-    (as a sibling under supralaryngeal), so it does not participate
-    in complex segment formation: a velar nasal [ŋ] is simple despite
-    activating both dorsal and soft palate. -/
-def GeomNode.IsArticulator : GeomNode → Prop
+/-- A place articulator — labial, coronal, or dorsal — the independent articulators
+    whose distinct combinations give complex segments ([sagey-1986]). -/
+def Node.IsArticulator : Node → Prop
   | .labial | .coronal | .dorsal => True
   | _ => False
 
-instance : DecidablePred GeomNode.IsArticulator := fun n => by
-  cases n <;> unfold GeomNode.IsArticulator <;> infer_instance
+instance : DecidablePred Node.IsArticulator :=
+  λ n => by cases n <;> unfold Node.IsArticulator <;> infer_instance
 
-/-- The articulator nodes in the geometry. -/
-def articulatorNodes : List GeomNode :=
-  GeomNode.allNodes.filter (fun n => decide (GeomNode.IsArticulator n))
-
-theorem articulatorNodes_count : articulatorNodes.length = 3 := rfl
+/-- The articulator nodes. -/
+def articulatorNodes : List Node := Node.allNodes.filter (λ n => decide n.IsArticulator)
 
 /-! ### Articulator geometry (verification) -/
 
-/-- Articulators are exactly the leaf-level nodes (no children). -/
-theorem articulators_are_leaves :
-    ∀ n ∈ articulatorNodes, n.children = [] := by decide
+theorem articulatorNodes_count : articulatorNodes.length = 3 := rfl
+
+/-- Articulators are exactly the leaf nodes. -/
+theorem articulators_are_leaves : ∀ n ∈ articulatorNodes, n.children = [] := by decide
 
 /-- Every articulator is dominated by root. -/
-theorem articulators_under_root :
-    ∀ n ∈ articulatorNodes, GeomNode.Dominates .root n := by decide
+theorem articulators_under_root : ∀ n ∈ articulatorNodes, Node.root.Dominates n := by decide
 
-/-- Labial and dorsal are distinct (required for labiovelars). -/
-theorem labial_ne_dorsal : GeomNode.labial ≠ GeomNode.dorsal := by decide
+/-- Every articulator is dominated by place. -/
+theorem articulators_under_place : ∀ n ∈ articulatorNodes, Node.place.Dominates n := by decide
 
-/-- Soft palate is not a place node — it is a sibling of Place under
-    Supralaryngeal, not a child. This means nasal assimilation (spreading
-    soft palate) is independent of place assimilation (spreading place). -/
-theorem softPalate_not_under_place :
-    ¬ GeomNode.Dominates .place .softPalate := by decide
-
-/-- Soft palate is not a place articulator — nasals are simple segments
-    even though they involve velum lowering plus an oral place of
-    articulation. This follows from `softPalate` being a sibling of
-    `place` under `supralaryngeal`, not a child of `place`. -/
-theorem softPalate_not_articulator :
-    ¬ GeomNode.IsArticulator .softPalate := by decide
-
-/-- The three place articulators are all distinct from each other —
-    this gives rise to three possible complex segment types:
-    labio-coronal, labio-dorsal, corono-dorsal. -/
+/-- The three place articulators are pairwise distinct — giving three complex types
+    (labio-coronal, labio-dorsal, corono-dorsal). -/
 theorem place_articulators_distinct :
-    GeomNode.labial ≠ GeomNode.coronal ∧
-    GeomNode.labial ≠ GeomNode.dorsal ∧
-    GeomNode.coronal ≠ GeomNode.dorsal := by decide
+    Node.labial ≠ .coronal ∧ Node.labial ≠ .dorsal ∧ Node.coronal ≠ .dorsal := by decide
 
-/-- Every place articulator is under the place node. -/
-theorem articulators_under_place :
-    ∀ n ∈ articulatorNodes, GeomNode.Dominates .place n := by decide
+/-- The soft palate is a *sibling* of place, not under it — so nasal assimilation
+    (spreading soft palate) is independent of place assimilation. -/
+theorem softPalate_not_under_place : ¬ Node.place.Dominates .softPalate := by decide
+
+/-- The soft palate is not an articulator — a velar nasal [ŋ] is simple despite
+    activating both dorsal and soft palate. -/
+theorem softPalate_not_articulator : ¬ Node.softPalate.IsArticulator := by decide
 
 end Phonology.FeatureGeometry
 
 namespace Phonology
 
-open Phonology.FeatureGeometry (GeomNode articulatorNodes)
+open FeatureGeometry (Node articulatorNodes)
 
-/-! ### Active articulators of a segment -/
+variable (s : Segment)
 
-/-- Which articulator nodes have at least one specified feature in segment `s`? -/
-def Segment.activeArticulators (s : Segment) : List GeomNode :=
-  articulatorNodes.filter λ n =>
-    n.features.any λ f => s f |>.isSome
+/-! ### Active articulators -/
 
-/-- Number of active articulator nodes in a segment. -/
-def Segment.articulatorCount (s : Segment) : Nat :=
-  s.activeArticulators.length
+/-- The articulator nodes with at least one specified feature in `s`. -/
+def Segment.activeArticulators : List Node :=
+  articulatorNodes.filter (λ n => n.features.any (λ g => (s g).isSome))
 
-/-! ### Segment classification and well-formedness -/
+/-- The number of active articulator nodes in `s`. -/
+def Segment.articulatorCount : Nat := s.activeArticulators.length
 
-/-- A complex segment has two or more simultaneously active articulator
-    nodes — e.g., labiovelars [k͡p] (labial + dorsal). -/
-def Segment.IsComplex (s : Segment) : Prop :=
-  s.articulatorCount ≥ 2
+/-! ### Complex segments -/
 
-instance : DecidablePred Segment.IsComplex := fun _ =>
-  inferInstanceAs (Decidable (_ ≥ _))
+/-- A complex segment has two or more simultaneously active articulators — e.g. a
+    labiovelar [k͡p] (labial + dorsal). -/
+def Segment.IsComplex : Prop := s.articulatorCount ≥ 2
 
-/-- **The complex-segment well-formedness condition holds by construction**: a
-    segment's active articulators are always distinct, because they are filtered
-    from the duplicate-free `articulatorNodes`. The condition that articulations
-    occupy distinct articulator nodes is therefore not a separate constraint but a
-    theorem ([sagey-1986]). -/
-theorem Segment.activeArticulators_nodup (s : Segment) :
-    s.activeArticulators.Nodup := by
+instance : DecidablePred Segment.IsComplex := λ _ => inferInstanceAs (Decidable (_ ≥ _))
+
+/-- **Complex-segment well-formedness holds by construction**: a segment's active
+    articulators are always distinct, being filtered from the duplicate-free
+    `articulatorNodes`. The distinct-articulator condition is a theorem, not a
+    separate constraint ([sagey-1986]). -/
+theorem Segment.activeArticulators_nodup : s.activeArticulators.Nodup := by
   unfold Segment.activeArticulators
   exact (by decide : articulatorNodes.Nodup).filter _
 

--- a/Linglib/Studies/Clements1985.lean
+++ b/Linglib/Studies/Clements1985.lean
@@ -18,7 +18,7 @@ labial assimilation (/n/ + /p/ → [mp]).
 namespace Clements1985
 
 open Phonology
-open Phonology.FeatureGeometry (GeomNode)
+open Phonology.FeatureGeometry (Node)
 open Autosegmental
 open English.Phonology
 

--- a/Linglib/Studies/Sagey1986.lean
+++ b/Linglib/Studies/Sagey1986.lean
@@ -40,7 +40,7 @@ the consensus geometry:
 -/
 
 open Phonology (Segment Feature)
-open Phonology.FeatureGeometry (GeomNode)
+open Phonology.FeatureGeometry (Node)
 open Autosegmental (agreeAt)
 
 namespace Autosegmental
@@ -285,8 +285,8 @@ namespace Sagey1986
     marked, not reducible to anterior/posterior order. This distinction is
     Sagey-specific — modern phonology does not uniformly adopt it. -/
 structure MajorMinor where
-  major : GeomNode
-  minor : GeomNode
+  major : Node
+  minor : Node
   major_is_articulator : major.IsArticulator
   minor_is_articulator : minor.IsArticulator
   distinct : major ≠ minor
@@ -328,7 +328,7 @@ inductive DegreeOfClosure where
     specification; the anterior closure's is predictable ([sagey-1986] §3.4,
     p.258). -/
 structure ArticulatorSpec where
-  node : GeomNode
+  node : Node
   closure : DegreeOfClosure
   node_is_articulator : node.IsArticulator = true
 
@@ -354,7 +354,7 @@ def click_posterior : ArticulatorSpec where
     cross-linguistically simpler and more common than place assimilation:
     it involves spreading a smaller constituent. -/
 theorem nasal_assimilation_scope :
-    GeomNode.softPalate.features.length < GeomNode.place.features.length := by
+    Node.softPalate.features.length < Node.place.features.length := by
   decide
 
 /-- Nasality is NOT under the place node — spreading place does not


### PR DESCRIPTION
Close mathlib pass on the feature-geometry file (modeled on `Prosody/Foot.lean`).

- `GeomNode` → `Node` — de-stutter under the `FeatureGeometry` namespace; the 3 consumers' selective `open`s updated.
- Consolidated the `FeatureGeometry`↔`Phonology` namespace ping-pong (5 blocks → 4), added `variable` blocks, `## Main definitions`/`Main results`, `/-- -/` constructor docstrings, one-lined decls, and tersed the verbose docstrings.
- No semantic change; `Feature.node` stays a theory-homed function (not a `Defs` field — its node assignment is contested).