### PR TITLE
refactor(Phonology/Segmental): consolidate Basic; Sonority.Class API

### DIFF
--- a/Linglib/Fragments/Korean/Phonology.lean
+++ b/Linglib/Fragments/Korean/Phonology.lean
@@ -114,9 +114,9 @@ theorem k_matches_nasalization_target :
 
 /-- Vowels and nasals lack [-del.rel.], so they don't trigger nasalization. -/
 theorem a_not_nasalization_target :
-    a.Specified Feature.delayedRelease = false := by decide
+    a.Unspecified Feature.delayedRelease := by decide
 
 theorem m_not_nasalization_target :
-    m.Specified Feature.delayedRelease = false := by decide
+    m.Unspecified Feature.delayedRelease := by decide
 
 end Korean.Phonology

--- a/Linglib/Fragments/Tagalog/Phonology.lean
+++ b/Linglib/Fragments/Tagalog/Phonology.lean
@@ -153,20 +153,20 @@ theorem nasals_are_nasal :
 
 /-- All six stem-initial obstruents match the nasal-substitution target. -/
 theorem ns_target_matches_obstruents :
-    p.matchesPattern nasalSubstitution.target = true ∧
-    t.matchesPattern nasalSubstitution.target = true ∧
-    k.matchesPattern nasalSubstitution.target = true ∧
-    b.matchesPattern nasalSubstitution.target = true ∧
-    d.matchesPattern nasalSubstitution.target = true ∧
-    g.matchesPattern nasalSubstitution.target = true := by
+    nasalSubstitution.target ≤ p ∧
+    nasalSubstitution.target ≤ t ∧
+    nasalSubstitution.target ≤ k ∧
+    nasalSubstitution.target ≤ b ∧
+    nasalSubstitution.target ≤ d ∧
+    nasalSubstitution.target ≤ g := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
 
 /-- The three homorganic nasals do NOT match the obstruent target
     (sanity check: NS doesn't target nasals themselves). -/
 theorem ns_target_excludes_nasals :
-    m.matchesPattern nasalSubstitution.target = false ∧
-    n.matchesPattern nasalSubstitution.target = false ∧
-    ŋ.matchesPattern nasalSubstitution.target = false := by
+    ¬ nasalSubstitution.target ≤ m ∧
+    ¬ nasalSubstitution.target ≤ n ∧
+    ¬ nasalSubstitution.target ≤ ŋ := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
 end Tagalog.Phonology

--- a/Linglib/Fragments/Tarifit/Inventory.lean
+++ b/Linglib/Fragments/Tarifit/Inventory.lean
@@ -47,22 +47,22 @@ open Phonology
 structure TriconWord where
   ipa   : String
   gloss : String
-  c1    : SonorityClass
-  c2    : SonorityClass
-  c3    : SonorityClass
+  c1    : Sonority.Class
+  c2    : Sonority.Class
+  c3    : Sonority.Class
   deriving DecidableEq, Repr
 
 /-- C1–C2 sonority profile: rising (C1 less sonorous than C2). -/
 def TriconWord.isRising (w : TriconWord) : Bool :=
-  w.c1.parkerSonority < w.c2.parkerSonority
+  w.c1.parkerRank < w.c2.parkerRank
 
 /-- C1–C2 sonority profile: falling (C1 more sonorous than C2). -/
 def TriconWord.isFalling (w : TriconWord) : Bool :=
-  w.c1.parkerSonority > w.c2.parkerSonority
+  w.c1.parkerRank > w.c2.parkerRank
 
 /-- C1–C2 sonority profile: plateauing (equal sonority). -/
 def TriconWord.isPlateauing (w : TriconWord) : Bool :=
-  w.c1.parkerSonority == w.c2.parkerSonority
+  w.c1.parkerRank == w.c2.parkerRank
 
 -- ============================================================================
 -- § 2: Target Words

--- a/Linglib/Morphology/ConsonantalRoot.lean
+++ b/Linglib/Morphology/ConsonantalRoot.lean
@@ -7,7 +7,7 @@ Single source of truth for the Semitic-style notion of a *consonantal root*:
 an ordered melody of segments stored independently of vocalization or template.
 
 The segment type `α` is parametric. Studies of Tarifit Berber may instantiate
-`α := Phonology.SonorityClass` (sonority-class roots, used by
+`α := Phonology.Sonority.Class` (sonority-class roots, used by
 [afkir-zellou-2025]); studies of Hebrew or Amharic typically instantiate
 `α := String` for IPA symbols.
 

--- a/Linglib/Phonology/Segmental/Basic.lean
+++ b/Linglib/Phonology/Segmental/Basic.lean
@@ -26,20 +26,6 @@ namespace Segment
 
 variable (s : Segment)
 
-/-! ### Specification -/
-
-/-- Specification is the bundle notion of carrying more than the unspecified
-    bottom. -/
-theorem specified_iff_specifies (f : Feature) : s.Specified f ↔ BundleLike.Specifies s f := by
-  simp only [Segment.Specified, BundleLike.Specifies, BundleLike.val,
-    ne_eq, Option.isSome_iff_ne_none]
-  rfl
-
-/-- Specification and unspecification are mutually exclusive and exhaustive. -/
-theorem specified_iff_not_unspecified (f : Feature) : s.Specified f ↔ ¬ s.Unspecified f := by
-  unfold Specified Unspecified
-  cases s f <;> simp
-
 /-! ### Natural-class membership is subsumption -/
 
 /-- Matching a natural-class pattern is subsumption: `s` matches `p` exactly when

--- a/Linglib/Phonology/Segmental/Basic.lean
+++ b/Linglib/Phonology/Segmental/Basic.lean
@@ -9,13 +9,13 @@ import Linglib.Phonology.Segmental.Defs
 # Basic theory of segments
 
 This file develops the theory of the segments defined in
-`Phonology/Segmental/Defs.lean`: that natural-class membership is the unification
-subsumption order, how the feature-change operations behave, and that Parker's
-sonority ranking is injective.
+`Phonology/Segmental/Defs.lean`. Natural-class membership is just the bundle order
+— a pattern `p` matches `s` exactly when `p ≤ s` ([shieber-1986]; [carpenter-1992])
+— so the results here are about the feature-change operations and the injectivity
+of the Parker sonority ranking.
 
 ## Main results
 
-* `Segment.matchesPattern_iff_le` — natural-class membership is bundle subsumption.
 * `Segment.setFeature_hasValue` &c. — the feature-change operations act as specified.
 * `Sonority.Class.parkerRank_injective` — the Parker scale ranks classes distinctly.
 -/
@@ -25,20 +25,6 @@ namespace Phonology
 namespace Segment
 
 variable (s : Segment)
-
-/-! ### Natural-class membership is subsumption -/
-
-/-- Matching a natural-class pattern is subsumption: `s` matches `p` exactly when
-    `p` refines to `s` ([shieber-1986]; [carpenter-1992]). -/
-theorem matchesPattern_iff_le {s p : Segment} : s.matchesPattern p = true ↔ p ≤ s := by
-  simp only [Segment.matchesPattern, List.all_eq_true, decide_eq_true_eq, Pi.le_def]
-  exact ⟨fun h f => h f (allFeatures_complete f), fun h f _ => h f⟩
-
-@[simp] theorem matchesPattern_iff_le' {s p : Segment} : s.MatchesPattern p ↔ p ≤ s :=
-  matchesPattern_iff_le
-
-/-- Every segment matches itself as a pattern (reflexivity of subsumption). -/
-@[simp] theorem matchesPattern_self : s.matchesPattern s = true := matchesPattern_iff_le.mpr le_rfl
 
 /-! ### Feature changes -/
 

--- a/Linglib/Phonology/Segmental/Basic.lean
+++ b/Linglib/Phonology/Segmental/Basic.lean
@@ -35,6 +35,11 @@ theorem specified_iff_specifies (f : Feature) : s.Specified f ↔ BundleLike.Spe
     ne_eq, Option.isSome_iff_ne_none]
   rfl
 
+/-- Specification and unspecification are mutually exclusive and exhaustive. -/
+theorem specified_iff_not_unspecified (f : Feature) : s.Specified f ↔ ¬ s.Unspecified f := by
+  unfold Specified Unspecified
+  cases s f <;> simp
+
 /-! ### Natural-class membership is subsumption -/
 
 /-- Matching a natural-class pattern is subsumption: `s` matches `p` exactly when
@@ -61,13 +66,6 @@ theorem matchesPattern_iff_le {s p : Segment} : s.matchesPattern p = true ↔ p 
   funext f
   simp only [Segment.applyChanges, Features.Bundle.merge]
   cases change f <;> rfl
-
-/-! ### Underspecification -/
-
-/-- Specification and unspecification are mutually exclusive and exhaustive. -/
-theorem specified_iff_not_unspecified (f : Feature) : s.Specified f ↔ ¬ s.Unspecified f := by
-  unfold Specified Unspecified
-  cases s f <;> simp
 
 /-! ### Effect on the modified feature -/
 

--- a/Linglib/Phonology/Segmental/Basic.lean
+++ b/Linglib/Phonology/Segmental/Basic.lean
@@ -26,19 +26,6 @@ namespace Segment
 
 variable (s : Segment)
 
-/-! ### Feature changes -/
-
-/-- Applying the empty change list is the identity. -/
-@[simp] theorem applyChanges_ofSpecs_nil : s.applyChanges (Segment.ofSpecs []) = s := by
-  funext f; simp [Segment.applyChanges, Segment.ofSpecs, Features.Bundle.merge]
-
-/-- Applying the same change twice equals applying it once. -/
-@[simp] theorem applyChanges_idem (change : Segment) :
-    (s.applyChanges change).applyChanges change = s.applyChanges change := by
-  funext f
-  simp only [Segment.applyChanges, Features.Bundle.merge]
-  cases change f <;> rfl
-
 /-! ### Effect on the modified feature -/
 
 @[simp] theorem unsetFeature_unspecified (f : Feature) : (s.unsetFeature f).Unspecified f :=

--- a/Linglib/Phonology/Segmental/Basic.lean
+++ b/Linglib/Phonology/Segmental/Basic.lean
@@ -28,20 +28,8 @@ variable (s : Segment)
 
 /-! ### Effect on the modified feature -/
 
-@[simp] theorem unsetFeature_unspecified (f : Feature) : (s.unsetFeature f).Unspecified f :=
-  Function.update_self _ _ _
-
 @[simp] theorem setFeature_hasValue (f : Feature) (v : Bool) : (s.setFeature f v).HasValue f v :=
   Function.update_self _ _ _
-
-theorem fillFeature_hasValue_of_unspecified {f : Feature} (h : s.Unspecified f) (v : Bool) :
-    (s.fillFeature f v).HasValue f v := by
-  simp only [Segment.fillFeature, Segment.HasValue, Features.Bundle.merge,
-    Features.Bundle.single, show s f = none from h, Function.update_self]
-
-theorem fillFeature_apply_of_specified {f : Feature} {w : Bool} (h : s.HasValue f w) (v : Bool) :
-    (s.fillFeature f v) f = some w := by
-  simp only [Segment.fillFeature, Features.Bundle.merge, show s f = some w from h]
 
 theorem fillFromContext_apply_self_of_unspecified {f : Feature} (h : s.Unspecified f) (ctx : Segment) :
     (s.fillFromContext f ctx) f = ctx f := by
@@ -54,18 +42,9 @@ theorem fillFromContext_apply_self_of_specified {f : Feature} {w : Bool} (h : s.
 
 /-! ### Value preserved on other features -/
 
-@[simp] theorem unsetFeature_apply_of_ne {f g : Feature} (h : f ≠ g) : (s.unsetFeature f) g = s g :=
-  Function.update_of_ne (Ne.symm h) _ _
-
 @[simp] theorem setFeature_apply_of_ne {f g : Feature} (h : f ≠ g) (v : Bool) :
     (s.setFeature f v) g = s g :=
   Function.update_of_ne (Ne.symm h) _ _
-
-@[simp] theorem fillFeature_apply_of_ne {f g : Feature} (h : f ≠ g) (v : Bool) :
-    (s.fillFeature f v) g = s g := by
-  simp only [Segment.fillFeature, Features.Bundle.merge, Features.Bundle.single,
-    Function.update_of_ne (Ne.symm h)]
-  cases s g <;> rfl
 
 @[simp] theorem fillFromContext_apply_of_ne {f g : Feature} (h : f ≠ g) (ctx : Segment) :
     (s.fillFromContext f ctx) g = s g := by

--- a/Linglib/Phonology/Segmental/Basic.lean
+++ b/Linglib/Phonology/Segmental/Basic.lean
@@ -6,15 +6,18 @@ Authors: Robert Hawkins
 import Linglib.Phonology.Segmental.Defs
 
 /-!
-# Segments: basic theory
+# Basic theory of segments
 
-The theory of segments over the definitions in `Phonology/Segmental/Defs.lean`:
-that natural-class membership coincides with the bundle subsumption order, the
-behaviour of the feature-change operations, and the injectivity of the Parker
-sonority ranking.
+This file develops the theory of the segments defined in
+`Phonology/Segmental/Defs.lean`: that natural-class membership is the unification
+subsumption order, how the feature-change operations behave, and that Parker's
+sonority ranking is injective.
 
-[hayes-2009] [chomsky-halle-1968] [clements-1990] [parker-2002] [shieber-1986]
-[carpenter-1992]
+## Main results
+
+* `Segment.matchesPattern_iff_le` — natural-class membership is bundle subsumption.
+* `Segment.setFeature_hasValue` &c. — the feature-change operations act as specified.
+* `Sonority.Class.parkerRank_injective` — the Parker scale ranks classes distinctly.
 -/
 
 namespace Phonology
@@ -116,15 +119,15 @@ end Segment
 
 /-! ### Sonority -/
 
-namespace SonorityClass
+namespace Sonority.Class
 
-/-- The eight Parker classes receive distinct ranks: `parkerSonority` is injective
+/-- The eight Parker classes receive distinct ranks: `parkerRank` is injective
     ([parker-2002]). The ranking is Parker's reversible default, so this is the
-    faithful invariant — no fixed order on `SonorityClass` is implied. -/
-theorem parkerSonority_injective : Function.Injective parkerSonority := by
+    faithful invariant — no fixed order on `Sonority.Class` is implied. -/
+theorem parkerRank_injective : Function.Injective parkerRank := by
   intro a b h
-  cases a <;> cases b <;> simp_all [parkerSonority]
+  cases a <;> cases b <;> simp_all [parkerRank]
 
-end SonorityClass
+end Sonority.Class
 
 end Phonology

--- a/Linglib/Phonology/Segmental/Basic.lean
+++ b/Linglib/Phonology/Segmental/Basic.lean
@@ -10,7 +10,7 @@ import Linglib.Phonology.Segmental.Defs
 
 The theory of segments over the definitions in `Phonology/Segmental/Defs.lean`:
 that natural-class membership coincides with the bundle subsumption order, the
-behaviour of the feature-change operations, and the totality of the Parker
+behaviour of the feature-change operations, and the injectivity of the Parker
 sonority ranking.
 
 [hayes-2009] [chomsky-halle-1968] [clements-1990] [parker-2002] [shieber-1986]
@@ -19,12 +19,15 @@ sonority ranking.
 
 namespace Phonology
 
+namespace Segment
+
+variable (s : Segment)
+
 /-! ### Specification -/
 
 /-- Specification is the bundle notion of carrying more than the unspecified
     bottom. -/
-theorem Segment.specified_iff_specifies (s : Segment) (f : Feature) :
-    s.Specified f ↔ BundleLike.Specifies s f := by
+theorem specified_iff_specifies (f : Feature) : s.Specified f ↔ BundleLike.Specifies s f := by
   simp only [Segment.Specified, BundleLike.Specifies, BundleLike.val,
     ne_eq, Option.isSome_iff_ne_none]
   rfl
@@ -33,111 +36,95 @@ theorem Segment.specified_iff_specifies (s : Segment) (f : Feature) :
 
 /-- Matching a natural-class pattern is subsumption: `s` matches `p` exactly when
     `p` refines to `s` ([shieber-1986]; [carpenter-1992]). -/
-theorem Segment.matchesPattern_iff_le {s p : Segment} :
-    s.matchesPattern p = true ↔ p ≤ s := by
+theorem matchesPattern_iff_le {s p : Segment} : s.matchesPattern p = true ↔ p ≤ s := by
   simp only [Segment.matchesPattern, List.all_eq_true, decide_eq_true_eq, Pi.le_def]
   exact ⟨fun h f => h f (allFeatures_complete f), fun h f _ => h f⟩
 
-@[simp] theorem Segment.matchesPattern_iff_le' {s p : Segment} :
-    s.MatchesPattern p ↔ p ≤ s := matchesPattern_iff_le
+@[simp] theorem matchesPattern_iff_le' {s p : Segment} : s.MatchesPattern p ↔ p ≤ s :=
+  matchesPattern_iff_le
 
 /-- Every segment matches itself as a pattern (reflexivity of subsumption). -/
-@[simp] theorem Segment.matchesPattern_self (s : Segment) :
-    s.matchesPattern s = true :=
-  matchesPattern_iff_le.mpr le_rfl
+@[simp] theorem matchesPattern_self : s.matchesPattern s = true := matchesPattern_iff_le.mpr le_rfl
 
 /-! ### Feature changes -/
 
 /-- Applying the empty change list is the identity. -/
-@[simp] theorem Segment.applyChanges_ofSpecs_nil (s : Segment) :
-    s.applyChanges (Segment.ofSpecs []) = s := by
+@[simp] theorem applyChanges_ofSpecs_nil : s.applyChanges (Segment.ofSpecs []) = s := by
   funext f; simp [Segment.applyChanges, Segment.ofSpecs, Features.Bundle.merge]
 
 /-- Applying the same change twice equals applying it once. -/
-@[simp] theorem Segment.applyChanges_idem (s change : Segment) :
+@[simp] theorem applyChanges_idem (change : Segment) :
     (s.applyChanges change).applyChanges change = s.applyChanges change := by
   funext f
   simp only [Segment.applyChanges, Features.Bundle.merge]
   cases change f <;> rfl
 
-namespace Segment
-
 /-! ### Underspecification -/
 
 /-- Specification and unspecification are mutually exclusive and exhaustive. -/
-theorem specified_iff_not_unspecified (s : Segment) (f : Feature) :
-    s.Specified f ↔ ¬ s.Unspecified f := by
+theorem specified_iff_not_unspecified (f : Feature) : s.Specified f ↔ ¬ s.Unspecified f := by
   unfold Specified Unspecified
   cases s f <;> simp
 
 /-! ### Effect on the modified feature -/
 
-@[simp] theorem unsetFeature_unspecified (s : Segment) (f : Feature) :
-    (s.unsetFeature f).Unspecified f :=
+@[simp] theorem unsetFeature_unspecified (f : Feature) : (s.unsetFeature f).Unspecified f :=
   Function.update_self _ _ _
 
-@[simp] theorem setFeature_hasValue (s : Segment) (f : Feature) (v : Bool) :
-    (s.setFeature f v).HasValue f v :=
+@[simp] theorem setFeature_hasValue (f : Feature) (v : Bool) : (s.setFeature f v).HasValue f v :=
   Function.update_self _ _ _
 
-theorem fillFeature_hasValue_of_unspecified
-    (s : Segment) {f : Feature} (h : s.Unspecified f) (v : Bool) :
+theorem fillFeature_hasValue_of_unspecified {f : Feature} (h : s.Unspecified f) (v : Bool) :
     (s.fillFeature f v).HasValue f v := by
   simp only [Segment.fillFeature, Segment.HasValue, Features.Bundle.merge,
     Features.Bundle.single, show s f = none from h, Function.update_self]
 
-theorem fillFeature_apply_of_specified
-    (s : Segment) {f : Feature} {w : Bool} (h : s.HasValue f w) (v : Bool) :
+theorem fillFeature_apply_of_specified {f : Feature} {w : Bool} (h : s.HasValue f w) (v : Bool) :
     (s.fillFeature f v) f = some w := by
-  simp only [Segment.fillFeature, Features.Bundle.merge,
-    show s f = some w from h]
+  simp only [Segment.fillFeature, Features.Bundle.merge, show s f = some w from h]
 
-theorem fillFromContext_apply_self_of_unspecified
-    (s : Segment) {f : Feature} (h : s.Unspecified f) (ctx : Segment) :
+theorem fillFromContext_apply_self_of_unspecified {f : Feature} (h : s.Unspecified f) (ctx : Segment) :
     (s.fillFromContext f ctx) f = ctx f := by
   simp only [Segment.fillFromContext, Features.Bundle.merge,
     show s f = none from h, Function.update_self]
 
-theorem fillFromContext_apply_self_of_specified
-    (s : Segment) {f : Feature} {w : Bool} (h : s.HasValue f w) (ctx : Segment) :
-    (s.fillFromContext f ctx) f = some w := by
-  simp only [Segment.fillFromContext, Features.Bundle.merge,
-    show s f = some w from h]
+theorem fillFromContext_apply_self_of_specified {f : Feature} {w : Bool} (h : s.HasValue f w)
+    (ctx : Segment) : (s.fillFromContext f ctx) f = some w := by
+  simp only [Segment.fillFromContext, Features.Bundle.merge, show s f = some w from h]
 
 /-! ### Value preserved on other features -/
 
-@[simp] theorem unsetFeature_apply_of_ne
-    (s : Segment) {f g : Feature} (h : f ≠ g) :
-    (s.unsetFeature f) g = s g :=
+@[simp] theorem unsetFeature_apply_of_ne {f g : Feature} (h : f ≠ g) : (s.unsetFeature f) g = s g :=
   Function.update_of_ne (Ne.symm h) _ _
 
-@[simp] theorem setFeature_apply_of_ne
-    (s : Segment) {f g : Feature} (h : f ≠ g) (v : Bool) :
+@[simp] theorem setFeature_apply_of_ne {f g : Feature} (h : f ≠ g) (v : Bool) :
     (s.setFeature f v) g = s g :=
   Function.update_of_ne (Ne.symm h) _ _
 
-@[simp] theorem fillFeature_apply_of_ne
-    (s : Segment) {f g : Feature} (h : f ≠ g) (v : Bool) :
+@[simp] theorem fillFeature_apply_of_ne {f g : Feature} (h : f ≠ g) (v : Bool) :
     (s.fillFeature f v) g = s g := by
   simp only [Segment.fillFeature, Features.Bundle.merge, Features.Bundle.single,
     Function.update_of_ne (Ne.symm h)]
   cases s g <;> rfl
 
-@[simp] theorem fillFromContext_apply_of_ne
-    (s : Segment) {f g : Feature} (h : f ≠ g) (ctx : Segment) :
+@[simp] theorem fillFromContext_apply_of_ne {f g : Feature} (h : f ≠ g) (ctx : Segment) :
     (s.fillFromContext f ctx) g = s g := by
-  simp only [Segment.fillFromContext, Features.Bundle.merge,
-    Function.update_of_ne (Ne.symm h)]
+  simp only [Segment.fillFromContext, Features.Bundle.merge, Function.update_of_ne (Ne.symm h)]
   cases s g <;> rfl
 
 end Segment
 
 /-! ### Sonority -/
 
-/-- Parker sonority is strictly monotone: the ranking is a total order. -/
-theorem parker_strictly_monotone (a b : SonorityClass) (h : a ≠ b) :
-    SonorityClass.parkerSonority a < SonorityClass.parkerSonority b ∨
-    SonorityClass.parkerSonority a > SonorityClass.parkerSonority b := by
-  cases a <;> cases b <;> simp_all [SonorityClass.parkerSonority]
+namespace SonorityClass
+
+/-- The eight Parker classes receive distinct ranks: `parkerSonority` is injective
+    ([parker-2002]). The ranking is Parker's reversible default, so this is the
+    faithful invariant — no fixed order on `SonorityClass` is implied. -/
+theorem parkerSonority_injective : Function.Injective parkerSonority := by
+  intro a b h
+  cases a <;> cases b <;> simp_all [parkerSonority]
+
+end SonorityClass
 
 end Phonology

--- a/Linglib/Phonology/Segmental/Defs.lean
+++ b/Linglib/Phonology/Segmental/Defs.lean
@@ -134,20 +134,6 @@ def Segment.ofSpecs (specs : List (Feature × Bool)) : Segment :=
     | some (_, v) => some v
     | none => none
 
-/-- Bool: does segment `s` match natural-class pattern `p`? True when every
-    feature specified in `p` agrees with `s`; unspecified features in `p`
-    match anything — i.e. when `p` subsumes `s` (`matchesPattern_iff_le`). -/
-def Segment.matchesPattern (s : Segment) (p : Segment) : Bool :=
-  Feature.allFeatures.all fun f => decide (p f ≤ s f)
-
-/-- Prop wrapper around `matchesPattern` (mirrors `Segment.HasValue`). Lets
-    consumers write mathlib-style universally-quantified theorems with
-    Decidable inference via the Bool computation. -/
-def Segment.MatchesPattern (s p : Segment) : Prop := s.matchesPattern p = true
-
-instance (s p : Segment) : Decidable (Segment.MatchesPattern s p) :=
-  inferInstanceAs (Decidable (_ = _))
-
 /-- Merge feature changes from `change` into `s`: features specified in
     `change` override `s`'s values; unspecified features in `change` are
     preserved. Implements the SPE structural change `A → B` (when `B` is a

--- a/Linglib/Phonology/Segmental/Defs.lean
+++ b/Linglib/Phonology/Segmental/Defs.lean
@@ -198,7 +198,7 @@ instance (s : Segment) : Decidable s.IsGlide := by
 
 The segment-level operations are thin lifts of the shared `Features.Bundle`
 algebra. Three-valued (`+ / − / ∅`) specification is standard in [keating-1988],
-[inkelas-orgun-1995], and [steriade-1995]; `fillFeature` is default-fill,
+[inkelas-orgun-1995], and [steriade-1995]; `fillFromContext` is default-fill,
 preserving existing values, per [kiparsky-1982] [archangeli-1988], while
 `setFeature` overrides. The Latin coda /l/ analysis in [sen-2015] is a worked
 example. -/
@@ -211,24 +211,11 @@ def Unspecified (s : Segment) (f : Feature) : Prop := s f = none
 instance (s : Segment) (f : Feature) : Decidable (s.Unspecified f) :=
   inferInstanceAs (Decidable (_ = none))
 
-/-- Remove the specification of feature `f` from `s` (the
-    `Features.Bundle.delete` slot operation). The result is unspecified for `f`
-    and agrees with `s` on every other feature. -/
-def unsetFeature (s : Segment) (f : Feature) : Segment :=
-  Features.Bundle.delete f s
-
 /-- Set feature `f` to value `v`, overriding any existing specification
     (the `Features.Bundle.set` slot operation). For default-fill semantics that
-    only assigns when `f` is currently unspecified, use `fillFeature`. -/
+    only assigns when `f` is currently unspecified, use `fillFromContext`. -/
 def setFeature (s : Segment) (f : Feature) (v : Bool) : Segment :=
   Features.Bundle.set f v s
-
-/-- Fill feature `f` with value `v` only if `s` is currently unspecified
-    for `f`; existing specifications are preserved. This implements the
-    default-fill semantics of feature-filling rules in lexical phonology
-    [kiparsky-1982] [archangeli-1988]. -/
-def fillFeature (s : Segment) (f : Feature) (v : Bool) : Segment :=
-  Features.Bundle.merge s (Features.Bundle.single f v)
 
 /-- Categorical feature spreading from context: the target `s`, when
     unspecified for `f`, takes the `f`-value of `ctx`; already-specified

--- a/Linglib/Phonology/Segmental/Defs.lean
+++ b/Linglib/Phonology/Segmental/Defs.lean
@@ -290,7 +290,7 @@ end Segment
     |  5   | Vowel     |
 
     For the finer 8-level scale that splits obstruents by voice, see
-    `SonorityClass`. -/
+    `Sonority.Class`. -/
 inductive Sonority where
   | stop
   | fricative
@@ -320,8 +320,6 @@ def ofSegment (s : Segment) : Sonority :=
   else if s.HasValue .syllabic true then .vowel
   else .glide
 
-end Sonority
-
 /-! ### The Parker sonority scale -/
 
 /-- The 8-level Parker sonority partition ([parker-2002]) — a refinement of
@@ -334,7 +332,7 @@ end Sonority
     particular languages. The finer granularity is needed for sonority-
     conditioned gradient phenomena such as Tarifit intrusive vowels
     ([afkir-zellou-2025]). -/
-inductive SonorityClass where
+inductive Class where
   | vls    -- voiceless stops: [−son, −cont, −voice]
   | vds    -- voiced stops: [−son, −cont, +voice]
   | vlf    -- voiceless fricatives: [−son, +cont, −voice]
@@ -345,17 +343,15 @@ inductive SonorityClass where
   | vowel  -- vowels: [+son, +approx, −cons, +syll]
   deriving DecidableEq, Repr
 
-namespace SonorityClass
-
 /-- Parker's default universal 8-level ranking ([parker-2002]): voiced stops
     (`vds = 3`) outrank voiceless fricatives (`vlf = 2`). -/
-def parkerSonority : SonorityClass → Nat
+def Class.parkerRank : Class → Nat
   | .vls => 1 | .vlf => 2 | .vds => 3 | .vdf => 4
   | .nasal => 5 | .liquid => 6 | .glide => 7 | .vowel => 8
 
 /-- Classify a segment on the Parker 8-level scale: as `Sonority.ofSegment`,
     but additionally splitting obstruents by [±voice] ([parker-2002]). -/
-def ofSegment (s : Segment) : SonorityClass :=
+def Class.ofSegment (s : Segment) : Class :=
   if s.HasValue .sonorant false then
     if s.HasValue .continuant true then
       if s.HasValue .voice true then .vdf else .vlf
@@ -367,7 +363,7 @@ def ofSegment (s : Segment) : SonorityClass :=
   else .glide
 
 /-- Coarsen to the substance-free `Sonority`, collapsing the voicing split. -/
-def toSonority : SonorityClass → Sonority
+def Class.toSonority : Class → Sonority
   | .vls | .vds => .stop
   | .vlf | .vdf => .fricative
   | .nasal => .nasal
@@ -375,10 +371,6 @@ def toSonority : SonorityClass → Sonority
   | .glide => .glide
   | .vowel => .vowel
 
-end SonorityClass
-
-/-- Parker sonority of a segment (convenience). -/
-def parkerSonorityOf (s : Segment) : Nat :=
-  (SonorityClass.ofSegment s).parkerSonority
+end Sonority
 
 end Phonology

--- a/Linglib/Phonology/Segmental/Defs.lean
+++ b/Linglib/Phonology/Segmental/Defs.lean
@@ -116,13 +116,6 @@ theorem allFeatures_complete (f : Feature) : f ∈ Feature.allFeatures := by
     common to two segments is their meet. -/
 abbrev Segment := Feature → Flat Bool
 
-/-- Is feature `f` specified (either [+F] or [−F])? -/
-def Segment.Specified (s : Segment) (f : Feature) : Prop :=
-  (s f).isSome = true
-
-instance (s : Segment) : DecidablePred (Segment.Specified s) := fun _ =>
-  inferInstanceAs (Decidable (_ = true))
-
 /-- Does feature `f` have value `v`? -/
 def Segment.HasValue (s : Segment) (f : Feature) (v : Bool) : Prop :=
   s f = some v

--- a/Linglib/Phonology/Segmental/Defs.lean
+++ b/Linglib/Phonology/Segmental/Defs.lean
@@ -134,13 +134,6 @@ def Segment.ofSpecs (specs : List (Feature × Bool)) : Segment :=
     | some (_, v) => some v
     | none => none
 
-/-- Merge feature changes from `change` into `s`: features specified in
-    `change` override `s`'s values; unspecified features in `change` are
-    preserved. Implements the SPE structural change `A → B` (when `B` is a
-    partial bundle) as the shared `Features.Bundle.merge`. -/
-def Segment.applyChanges (s change : Segment) : Segment :=
-  Features.Bundle.merge change s
-
 /-! ### Natural-class predicates
 
 Language-neutral natural-class membership predicates, by the SPE feature

--- a/Linglib/Phonology/Subregular/LocalRewrite.lean
+++ b/Linglib/Phonology/Subregular/LocalRewrite.lean
@@ -103,7 +103,7 @@ def matchRightContext : List ContextElem → List Segment → Bool
   | [], _ => true
   | .wordBoundary :: rest, [] => matchRightContext rest []
   | .wordBoundary :: _, _ :: _ => false  -- expected end of word
-  | .seg p :: rest, s :: rs => s.matchesPattern p && matchRightContext rest rs
+  | .seg p :: rest, s :: rs => decide (p ≤ s) && matchRightContext rest rs
   | .seg _ :: _, [] => false  -- expected segment, none follows
 
 /-- Match a left-context list against the prefix `left` to the left of
@@ -131,7 +131,7 @@ where
   go : List Segment → List Segment → List Segment
     | _, [] => []
     | left, s :: right =>
-      if s.matchesPattern r.target
+      if decide (r.target ≤ s)
           && matchLeftContext r.leftContext left
           && matchRightContext r.rightContext right then
         match r.effect.apply s with

--- a/Linglib/Phonology/Subregular/LocalRewrite.lean
+++ b/Linglib/Phonology/Subregular/LocalRewrite.lean
@@ -73,7 +73,7 @@ inductive Effect where
 is deleted; `some s'` if features are merged into `s'`. -/
 def Effect.apply (e : Effect) (s : Segment) : Option Segment :=
   match e with
-  | .changeFeatures change => some (s.applyChanges change)
+  | .changeFeatures change => some (Features.Bundle.merge change s)
   | .delete => none
 
 /-! ### Rules -/

--- a/Linglib/Studies/AfkirZellou2025.lean
+++ b/Linglib/Studies/AfkirZellou2025.lean
@@ -80,9 +80,9 @@ inductive SurfaceForm where
 
 /-- A candidate pairs a word's consonant profile with a surface form. -/
 structure TarifitCandidate where
-  c1 : SonorityClass
-  c2 : SonorityClass
-  c3 : SonorityClass
+  c1 : Sonority.Class
+  c2 : Sonority.Class
+  c3 : Sonority.Class
   surface : SurfaceForm
   deriving DecidableEq, Repr
 
@@ -102,12 +102,12 @@ def maxV : Constraint TarifitCandidate :=
 /-- *SONO-CC (markedness): penalizes vowelless clusters proportional to
     consonant sonority. Higher-sonority consonants in a bare CC cluster
     are more marked because they expect a vocalic nucleus.
-    Violation count = c2.parkerSonority + c3.parkerSonority.
+    Violation count = c2.parkerRank + c3.parkerRank.
     Models the regression finding that lower C2/C3 sonority predicts
     more vowelless production ([afkir-zellou-2025] Figure 19). (Weight 1.) -/
 def sonoCC : Constraint TarifitCandidate :=
   fun c => match c.surface with
-    | .vowelless => c.c2.parkerSonority + c.c3.parkerSonority
+    | .vowelless => c.c2.parkerRank + c.c3.parkerRank
     | _ => 0
 
 /-- DEP-V (faithfulness): penalizes insertion of intrusive schwa.
@@ -125,7 +125,7 @@ def depV : Constraint TarifitCandidate :=
     Figure 21). (Weight 2 in `tarifitW`.) -/
 def sonoPeak : Constraint TarifitCandidate :=
   fun c => match c.surface with
-    | .intrusive => c.c1.parkerSonority - c.c2.parkerSonority
+    | .intrusive => c.c1.parkerRank - c.c2.parkerRank
     | _ => 0
 
 /-- *COMPLEX-ONSET (markedness): penalizes complex onsets with rising
@@ -136,7 +136,7 @@ def sonoPeak : Constraint TarifitCandidate :=
     (Weight 1 in `tarifitW`.) -/
 def complexOnset : Constraint TarifitCandidate :=
   fun c => match c.surface with
-    | .faithful => c.c2.parkerSonority - c.c1.parkerSonority
+    | .faithful => c.c2.parkerRank - c.c1.parkerRank
     | _ => 0
 
 /-- The MaxEnt constraint set for Tarifit schwa variation. -/
@@ -160,7 +160,7 @@ theorem qreb_intrusive_gt_faithful :
       (mkCandidate w_qreb .intrusive) (mkCandidate w_qreb .faithful) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_qreb, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_qreb, Sonority.Class.parkerRank]
   norm_num
 
 theorem qreb_faithful_gt_vowelless :
@@ -168,7 +168,7 @@ theorem qreb_faithful_gt_vowelless :
       (mkCandidate w_qreb .faithful) (mkCandidate w_qreb .vowelless) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_qreb, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_qreb, Sonority.Class.parkerRank]
   norm_num
 
 /-- /qməʕ/ (VLS–nasal, rise=4): intrusive > faithful.
@@ -178,7 +178,7 @@ theorem qmes_intrusive_gt_faithful :
       (mkCandidate w_qmes .intrusive) (mkCandidate w_qmes .faithful) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_qmes, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_qmes, Sonority.Class.parkerRank]
   norm_num
 
 /-- /srəm/ (VLF–liquid, rise=3): intrusive > faithful.
@@ -188,7 +188,7 @@ theorem srem_intrusive_gt_faithful :
       (mkCandidate w_srem .intrusive) (mkCandidate w_srem .faithful) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_srem, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_srem, Sonority.Class.parkerRank]
   norm_num
 
 -- ============================================================================
@@ -203,7 +203,7 @@ theorem ntef_faithful_gt_vowelless :
       (mkCandidate w_ntef .faithful) (mkCandidate w_ntef .vowelless) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_ntef, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_ntef, Sonority.Class.parkerRank]
   norm_num
 
 theorem ntef_vowelless_gt_intrusive :
@@ -211,7 +211,7 @@ theorem ntef_vowelless_gt_intrusive :
       (mkCandidate w_ntef .vowelless) (mkCandidate w_ntef .intrusive) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_ntef, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_ntef, Sonority.Class.parkerRank]
   norm_num
 
 /-- /nqəβ/ (nasal–VLS, fall=4): faithful > vowelless.
@@ -222,7 +222,7 @@ theorem nqeb_faithful_gt_vowelless :
       (mkCandidate w_nqeb .faithful) (mkCandidate w_nqeb .vowelless) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_nqeb, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_nqeb, Sonority.Class.parkerRank]
   norm_num
 
 /-- /ħkəm/ (VLF–VLS, fall=2): faithful > intrusive > vowelless (model).
@@ -235,7 +235,7 @@ theorem hkem_faithful_gt_intrusive :
       (mkCandidate w_hkem .faithful) (mkCandidate w_hkem .intrusive) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_hkem, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_hkem, Sonority.Class.parkerRank]
   norm_num
 
 theorem hkem_faithful_gt_vowelless :
@@ -243,7 +243,7 @@ theorem hkem_faithful_gt_vowelless :
       (mkCandidate w_hkem .faithful) (mkCandidate w_hkem .vowelless) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_hkem, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_hkem, Sonority.Class.parkerRank]
   norm_num
 
 -- ============================================================================
@@ -261,7 +261,7 @@ theorem skhef_faithful_gt_intrusive :
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
     sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_skhef,
-    SonorityClass.parkerSonority]
+    Sonority.Class.parkerRank]
   norm_num
 
 theorem skhef_faithful_gt_vowelless :
@@ -270,7 +270,7 @@ theorem skhef_faithful_gt_vowelless :
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
     sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_skhef,
-    SonorityClass.parkerSonority]
+    Sonority.Class.parkerRank]
   norm_num
 
 /-- /sfən/ (VLF–VLF, plateau): faithful > intrusive > vowelless.
@@ -281,7 +281,7 @@ theorem sfen_faithful_gt_intrusive :
       (mkCandidate w_sfen .faithful) (mkCandidate w_sfen .intrusive) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_sfen, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_sfen, Sonority.Class.parkerRank]
   norm_num
 
 theorem sfen_faithful_gt_vowelless :
@@ -289,7 +289,7 @@ theorem sfen_faithful_gt_vowelless :
       (mkCandidate w_sfen .faithful) (mkCandidate w_sfen .vowelless) := by
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
-    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_sfen, SonorityClass.parkerSonority]
+    sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_sfen, Sonority.Class.parkerRank]
   norm_num
 
 -- ============================================================================
@@ -309,7 +309,7 @@ theorem vowelless_more_accessible_low_sonority :
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
     sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_qreb, w_ntef,
-    SonorityClass.parkerSonority]
+    Sonority.Class.parkerRank]
   norm_num
 
 /-- Among vowelless candidates, all-obstruent clusters have the highest
@@ -321,7 +321,7 @@ theorem vowelless_obstruent_gt_sonorant :
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
     sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_srem, w_skhef,
-    SonorityClass.parkerSonority]
+    Sonority.Class.parkerRank]
   norm_num
 
 /-- /sχəf/ (all VLF) has higher vowelless harmony than /sfən/ (VLF–VLF–N),
@@ -332,7 +332,7 @@ theorem vowelless_all_obstruent_gt_mixed :
   simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero,
     Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV,
     sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_skhef, w_sfen,
-    SonorityClass.parkerSonority]
+    Sonority.Class.parkerRank]
   norm_num
 
 -- ============================================================================
@@ -347,14 +347,14 @@ theorem falling_faithful_zero :
     harmonyScore tarifitCon tarifitW (mkCandidate w_ntef .faithful) = 0 := by
   simp only [harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
     Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV, sonoPeak, complexOnset,
-    Constraint.binary, mkCandidate, w_ntef, SonorityClass.parkerSonority]
+    Constraint.binary, mkCandidate, w_ntef, Sonority.Class.parkerRank]
   norm_num
 
 theorem plateauing_faithful_zero :
     harmonyScore tarifitCon tarifitW (mkCandidate w_skhef .faithful) = 0 := by
   simp only [harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
     Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV, sonoPeak, complexOnset,
-    Constraint.binary, mkCandidate, w_skhef, SonorityClass.parkerSonority]
+    Constraint.binary, mkCandidate, w_skhef, Sonority.Class.parkerRank]
   norm_num
 
 /-- Rising onset intrusive: harmony = -2 (only DEP-V violation).
@@ -363,7 +363,7 @@ theorem rising_intrusive_base_cost :
     harmonyScore tarifitCon tarifitW (mkCandidate w_qreb .intrusive) = -2 := by
   simp only [harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
     Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV, sonoPeak, complexOnset,
-    Constraint.binary, mkCandidate, w_qreb, SonorityClass.parkerSonority]
+    Constraint.binary, mkCandidate, w_qreb, Sonority.Class.parkerRank]
   norm_num
 
 /-- Falling onset intrusive: additional *SONO-PEAK penalty.
@@ -372,7 +372,7 @@ theorem falling_intrusive_penalized :
     harmonyScore tarifitCon tarifitW (mkCandidate w_ntef .intrusive) = -10 := by
   simp only [harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
     Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV, sonoPeak, complexOnset,
-    Constraint.binary, mkCandidate, w_ntef, SonorityClass.parkerSonority]
+    Constraint.binary, mkCandidate, w_ntef, Sonority.Class.parkerRank]
   norm_num
 
 /-- Rising onset faithful: *COMPLEX-ONSET penalty proportional to rise.
@@ -381,7 +381,7 @@ theorem rising_faithful_penalized :
     harmonyScore tarifitCon tarifitW (mkCandidate w_qreb .faithful) = -5 := by
   simp only [harmonyScore_eq_neg_sum, Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
     Matrix.cons_val_succ, tarifitCon, tarifitW, maxV, sonoCC, depV, sonoPeak, complexOnset,
-    Constraint.binary, mkCandidate, w_qreb, SonorityClass.parkerSonority]
+    Constraint.binary, mkCandidate, w_qreb, Sonority.Class.parkerRank]
   norm_num
 
 -- ============================================================================
@@ -464,7 +464,7 @@ theorem tarifitSystem_ntef_faithful_gt_intrusive :
       simp only [harmonyDominates_iff, harmonyScore_eq_neg_sum, Fin.sum_univ_succ,
         Fin.sum_univ_zero, Matrix.cons_val_zero, Matrix.cons_val_succ, tarifitCon, tarifitW,
         maxV, sonoCC, depV, sonoPeak, complexOnset, Constraint.binary, mkCandidate, w_ntef,
-        SonorityClass.parkerSonority]
+        Sonority.Class.parkerRank]
       norm_num)
 
 /-- The softmax decoder is a probability decoder, so the per-word system's

--- a/Linglib/Studies/HayesWilson2008.lean
+++ b/Linglib/Studies/HayesWilson2008.lean
@@ -65,7 +65,7 @@ private def son_dors_pat : Segment :=
   Segment.ofSpecs [(Feature.sonorant, true), (Feature.dorsal, true)]
 
 private def matchesPat (s : Segment) (p : Segment) : Bool :=
-  s.matchesPattern p
+  decide (p ≤ s)
 
 /-- Constraint #1 from Table (4): *[+sonorant, +dorsal]. Weight 5.64. -/
 def c1_star_son_dors : Constraint Onset :=


### PR DESCRIPTION
Consolidates the segment theory file onto canonical objects and redesigns the Sonority API.

- **Sonority API:** `SonorityClass` → `Sonority.Class`, `parkerSonority` → `Sonority.Class.parkerRank` (nested under `namespace Sonority` beside the coarse `Sonority`/`rank`); dropped dead `parkerSonorityOf`. `parker_strictly_monotone` → `Sonority.Class.parkerRank_injective` (the `< ∨ >` disjunction was injectivity — "monotone" was wrong, no order on the type).
- **Dissolved tautological wrappers** into the canonical objects they restate: `Segment.Specified` → `Unspecified` (its negation), `matchesPattern` → the bundle order `p ≤ s`, `applyChanges` → `Bundle.merge`; pruned the dead `unsetFeature`/`fillFeature` ops. Kept the live `setFeature`/`fillFromContext`.
- **Basic.lean cleanup:** consolidated the `Segment.*` lemmas into one `namespace Segment` + `variable (s : Segment)`; rewrote the module docstring (Main-results section, citations inline on their declarations).

Consumers migrated: Tarifit, AfkirZellou2025, ConsonantalRoot, Korean, LocalRewrite, Tagalog, HayesWilson2008, Sen2015.