### PR TITLE
docs(Phonology/HarmonicGrammar): section headers + docstring fixes

### DIFF
--- a/Linglib/Core/Optimization/Evaluation.lean
+++ b/Linglib/Core/Optimization/Evaluation.lean
@@ -571,7 +571,7 @@ noncomputable instance (n : Nat) :
     `Tropical (WithTop (Lex (Fin n → Nat)))` is a `CommSemiring` where
     addition is `min` (under the lex order) and multiplication is
     componentwise `+`. Derived, not stipulated. Linguistic packaging:
-    `Phonology/Constraint/Dequantization/ViolationSemiring.lean` after
+    `Phonology/HarmonicGrammar/ViolationSemiring.lean` after
     [riggle-2009]. -/
 noncomputable example (n : Nat) :
     CommSemiring (Tropical (WithTop (Lex (Fin n → Nat)))) :=

--- a/Linglib/Phonology/HarmonicGrammar/Deformation.lean
+++ b/Linglib/Phonology/HarmonicGrammar/Deformation.lean
@@ -29,18 +29,18 @@ two independent dequantization axes:
 ```
 
 - **Vertical axis** (temperature, `α → ∞`): Maslov dequantization of
-  the warped semiring (`Constraint/LogSumExp/Limit.lean`).
+  the warped semiring (`Core/Optimization/Dequantization/LogSumExp/Limit.lean`).
   `lseFinset α cands score → cands.sup' hne score`. The soft
   aggregator (sum-of-exponentials) becomes the hard one (max).
 - **Horizontal axis** (weight separation): exponential separation of
-  HG weights (`Constraint/OTLimit.lean`, `ViolationSemiring.lean`).
+  HG weights (`OTLimit.lean`, `ViolationSemiring.lean`).
   The weight map V → T preserves not just ⊗ but also ⊕, so the
   HG argmax coincides with the OT lex-min.
 
 Going around the lattice diagonally — MaxEnt → OT — is then the
 composition: dequantize the temperature *and* exponentially separate
 the weights. The composite limit theorem is `maxent_ot_limit` in
-`Constraint/OTLimit.lean`.
+`OTLimit.lean`.
 
 ## What this file adds
 
@@ -72,9 +72,7 @@ open Core.Optimization
 open Real Filter Topology Finset
 open Constraints
 
--- ============================================================================
--- § 1: The Soft Aggregator on Harmony Scores
--- ============================================================================
+/-! ### The Soft Aggregator on Harmony Scores -/
 
 /-- The `lseFinset α` aggregator applied to harmony scores converges to
     the OT winner's harmony as `α → ∞`.
@@ -90,7 +88,7 @@ open Constraints
     1. `ot_lex_imp_higher_harmony` (HG–OT agreement under exponentially
        separated weights)
     2. `argmax_winner_iff_lse_max_limit` (the dequantized argmax bridge,
-       § 4 of `Constraint/Semiring.lean`) -/
+       § 4 of `Core/Optimization/Semiring.lean`) -/
 theorem lse_aggregator_tendsto_winner_harmony {C : Type*} [DecidableEq C]
     (ranking : List (Constraint C)) (M : Nat) (hM : 0 < M)
     (cands : Finset C) (c_opt : C) (hc_opt : c_opt ∈ cands)

--- a/Linglib/Phonology/HarmonicGrammar/MaxEnt.lean
+++ b/Linglib/Phonology/HarmonicGrammar/MaxEnt.lean
@@ -41,9 +41,7 @@ namespace HarmonicGrammar
 
 open Constraints Core
 
--- ============================================================================
--- § 1: Classical MaxEnt
--- ============================================================================
+/-! ### Classical MaxEnt -/
 
 /-! Classical MaxEnt assigns `P(o ∣ i) ∝ exp(-harmonyScore con w (i, o))`. There is
 **no grammar record**: a MaxEnt grammar is a constraint set `con : CON (I × O) n`
@@ -53,9 +51,7 @@ softmax-decoded harmony, via the shared `Core.Optimization.ConstraintSystem`
 (`CON.hgSystem` below). The systemic extension (§2–4) scores output *tuples*
 jointly and so does not factor through the per-mapping `predict`. -/
 
--- ============================================================================
--- § 2: Systemic Constraints
--- ============================================================================
+/-! ### Systemic Constraints -/
 
 /-- A systemic constraint evaluates a *tuple* of outputs — one per input —
     rather than individual input→output pairs.
@@ -88,9 +84,7 @@ def homophonyAvoidance {n : Nat} {O : Type*} [DecidableEq O]
       if i < j && f i == f j then [1] else []
     pairs.length
 
--- ============================================================================
--- § 3: Joint Distribution with Systemic Constraints
--- ============================================================================
+/-! ### Joint Distribution with Systemic Constraints -/
 
 /-- Systemic constraint score for an output tuple.
     This is the coupling component: `Σₖ (-wₖ · Sₖ(f))`. -/
@@ -148,9 +142,7 @@ noncomputable def marginalProb {n m : Nat} {I O : Type*} [Fintype O] [DecidableE
     (i : Fin n) (o : O) : ℝ :=
   (maxEntCoupled inputs classicalCon classicalW systemicConstraints).marginal i o
 
--- ============================================================================
--- § 4: Factorization Theorem
--- ============================================================================
+/-! ### Factorization Theorem -/
 
 /-- When all systemic constraint weights are zero, the systemic score
     is zero for every output tuple. -/

--- a/Linglib/Phonology/HarmonicGrammar/NoisyHG.lean
+++ b/Linglib/Phonology/HarmonicGrammar/NoisyHG.lean
@@ -46,9 +46,7 @@ open Core Real Constraints
 
 variable {C : Type*} {n : Nat}
 
--- ============================================================================
--- § 1: NHG Noise Variance
--- ============================================================================
+/-! ### NHG Noise Variance -/
 
 /-- Sum of squared violation differences between two candidates.
     This determines the NHG noise variance: σ_d² = σ² · violationDiffSqSum. -/
@@ -68,9 +66,7 @@ def violationDiffSqSumQ (con : CON C n) (a b : C) : ℚ :=
 noncomputable def nhgSigmaD (con : CON C n) (sigma : ℝ) (a b : C) : ℝ :=
   sigma * Real.sqrt (violationDiffSqSum con a b)
 
--- ============================================================================
--- § 2: NHG binary choice (Gaussian random utility model)
--- ============================================================================
+/-! ### NHG binary choice (Gaussian random utility model) -/
 
 /-- **NHG binary choice probability** ([flemming-2021]):
     `P(a ≻ b) = Φ((H(a) − H(b)) / σ_d)`.
@@ -91,9 +87,7 @@ theorem nhg_choiceProb_eq (con : CON C n) (w : Fin n → ℝ) (sigma : ℝ) (a b
                nhgSigmaD con sigma a b) := by
   simp only [nhgChoiceProb, gaussianChoiceProb]
 
--- ============================================================================
--- § 3: Normal MaxEnt
--- ============================================================================
+/-! ### Normal MaxEnt -/
 
 /-- Normal MaxEnt noise standard deviation: σ_d = ε√2 (constant).
 
@@ -124,9 +118,7 @@ theorem normalMaxEnt_choiceProb_eq (con : CON C n) (w : Fin n → ℝ)
                normalMaxEntSigmaD epsilon) := by
   simp only [normalMaxEntChoiceProb, gaussianChoiceProb]
 
--- ============================================================================
--- § 4: MaxEnt Logit-Harmony Identity
--- ============================================================================
+/-! ### MaxEnt Logit-Harmony Identity -/
 
 /-- **Logit uniformity** (MaxEnt diagnostic; [flemming-2021] §5.1):
     for softmax with α = 1, the log-odds between any two alternatives
@@ -172,9 +164,7 @@ theorem maxent_iia [Fintype C] [Nonempty C]
     exp (harmonyScore con w a - harmonyScore con w b) := by
   rw [softmax_odds]
 
--- ============================================================================
--- § 5: Harmony Difference Decomposition
--- ============================================================================
+/-! ### Harmony Difference Decomposition -/
 
 /-- **Harmony difference decomposition**: the harmony score difference
     equals the negated weighted sum of violation differences.
@@ -190,9 +180,7 @@ theorem harmonyScore_diff (con : CON C n) (w : Fin n → ℝ) (a b : C) :
   simp only [mul_sub, Finset.sum_sub_distrib]
   ring
 
--- ============================================================================
--- § 6: Censored NHG ([flemming-2021] §7.3)
--- ============================================================================
+/-! ### Censored NHG ([flemming-2021] §7.3) -/
 
 /-- Censored weight: noise is clamped so weights never go negative.
 
@@ -225,9 +213,7 @@ theorem censored_nhg_weight_sensitivity (w₁ w₂ : ℝ) (hw : w₁ < w₂) :
   rw [max_eq_right (le_of_lt h_pos)]
   exact ne_of_lt h_pos
 
--- ============================================================================
--- § 7: Multi-Candidate NHG Covariance
--- ============================================================================
+/-! ### Multi-Candidate NHG Covariance -/
 
 /-- NHG noise covariance between two score differences relative to a
     reference candidate `a`:

--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -68,9 +68,7 @@ open Core.Optimization OptimalityTheory
 
 open Finset
 
--- ============================================================================
--- § 1: Auxiliary — Strictly Monotone Bijection on Fin n is the Identity
--- ============================================================================
+/-! ### Auxiliary — Strictly Monotone Bijection on Fin n is the Identity -/
 
 /-- A strictly monotone endo-function on `Fin n` is the identity. Both
     inequalities `id ≤ f` and `f ≤ id` follow from `StrictMono.id_le` (using
@@ -96,9 +94,7 @@ private theorem fin_monotone_bij_eq_id {n : ℕ}
     · exact absurd (hbij.injective h) hab.ne
   exact fin_strictMono_eq_id f hstrict
 
--- ============================================================================
--- § 2: PartialOrderConstraints
--- ============================================================================
+/-! ### PartialOrderConstraints -/
 
 /-- A partial order on `Fin n` constraint indices. The OT case is a total
     order; the POC case allows incomparable pairs (multiple consistent
@@ -380,9 +376,7 @@ Birkhoff correspondence, made concrete and decidable. -/
 
 end PartialOrderConstraints
 
--- ============================================================================
--- § 3: POC Realizability of SystemicProblem
--- ============================================================================
+/-! ### POC Realizability of SystemicProblem -/
 
 namespace SystemicProblem
 
@@ -404,9 +398,7 @@ def IsPOCRealizable (P : SystemicProblem Input Output n) : Prop :=
 
 end SystemicProblem
 
--- ============================================================================
--- § 4: Containments — OT ⊆ POC, POC ⊆ OT (categorical)
--- ============================================================================
+/-! ### Containments — OT ⊆ POC, POC ⊆ OT (categorical) -/
 
 /-- **Trivial direction**: every POC-realized target is OT-realized
     (pick any single consistent extension). -/
@@ -438,9 +430,7 @@ theorem isOTRealizable_iff_isPOCRealizable {Input Output : Type*} {n : ℕ}
   ⟨ot_realizable_imp_poc_realizable P,
    poc_realizable_imp_ot_realizable P⟩
 
--- ============================================================================
--- § 5: Probabilistic POC — pocPredict
--- ============================================================================
+/-! ### Probabilistic POC — pocPredict -/
 
 namespace PartialOrderConstraints
 
@@ -502,9 +492,7 @@ theorem pocPredict_discrete
 
 end PartialOrderConstraints
 
--- ============================================================================
--- § 6: Bridge — PicksAt for binary candidates ↔ head-in-Y on permDList
--- ============================================================================
+/-! ### Bridge — PicksAt for binary candidates ↔ head-in-Y on permDList -/
 
 /-! For binary candidate sets `cands i = {chosen, other}`, `PicksAt σ i chosen`
 reduces to lex domination of `vp i chosen ∘ σ` over `vp i other ∘ σ` (the
@@ -635,9 +623,7 @@ theorem picksAt_binary_iff_permDList_head_lt {Output : Type*} [DecidableEq Outpu
       rw [h_σk_x]
       exact (h_Y_iff x).mp hx_Y
 
--- ============================================================================
--- § 7: Closed-form rate for binary candidates
--- ============================================================================
+/-! ### Closed-form rate for binary candidates -/
 
 variable {Input Output : Type*} [DecidableEq Output] {n : ℕ}
 

--- a/Linglib/Phonology/HarmonicGrammar/Separability.lean
+++ b/Linglib/Phonology/HarmonicGrammar/Separability.lean
@@ -61,12 +61,10 @@ namespace HarmonicGrammar
 
 open Core Real Finset Constraints
 
--- ============================================================================
--- § 1: The 2×2 Square of Underlying Forms (§2.4)
--- ============================================================================
+/-! ### The 2×2 Square of Underlying Forms (§2.4) -/
 
 /-- A **square** of four underlying forms indexed by two binary factors
-    (row = top/bottom, column = left/right). This is's
+    (row = top/bottom, column = left/right). This is [magri-2025]'s
     eq. (12): the four forms `x^{TL}, x^{TR}, x^{BL}, x^{BR}` arranged
     so that rows and columns correspond to independent phonological
     dimensions (e.g., prefix identity × stem-initial obstruent quality).
@@ -82,9 +80,7 @@ structure Square (X : Type*) where
   /-- Bottom-right form (e.g., /paŋ+k/). -/
   br : X
 
--- ============================================================================
--- § 2: Constraint Independence (§2.4, Figure 4)
--- ============================================================================
+/-! ### Constraint Independence (§2.4, Figure 4) -/
 
 /-- A constraint `C` is **insensitive to the row dimension** of a square:
     it assigns the same violation count to forms that share a column.
@@ -108,9 +104,7 @@ def ConstraintIndependence {n : ℕ} {X : Type*}
   ∀ k : Fin n,
     InsensitiveToRow (constraints k) sq ∨ InsensitiveToCol (constraints k) sq
 
--- ============================================================================
--- § 3: HZ's Generalization as Constant Logit-Rate Differences (§2.2)
--- ============================================================================
+/-! ### HZ's Generalization as Constant Logit-Rate Differences (§2.2) -/
 
 /-- **HZ's generalization** (eq. 13): the difference between logit rates
     of application for two underlying forms in the same row (or column)
@@ -121,9 +115,7 @@ def ConstraintIndependence {n : ℕ} {X : Type*}
 def ConstantLogitDiff {X : Type*} (LR : X → ℝ) (sq : Square X) : Prop :=
   LR sq.tl - LR sq.tr = LR sq.bl - LR sq.br
 
--- ============================================================================
--- § 4: ME Predicts HZ's Generalization (§3)
--- ============================================================================
+/-! ### ME Predicts HZ's Generalization (§3) -/
 
 /-- **Independence of violation differences**: if a constraint is
     insensitive to a dimension, its violation differences are too.
@@ -167,9 +159,7 @@ theorem me_predicts_hz {n : ℕ} {X : Type*}
   · -- Column-insensitive: Δₖ(tl) = Δₖ(tr), Δₖ(bl) = Δₖ(br)
     simp only [hcol_t, hcol_b, sub_self]
 
--- ============================================================================
--- § 5: Separable Harmonies (§5.1)
--- ============================================================================
+/-! ### Separable Harmonies (§5.1) -/
 
 /-- An *n*-ary harmony function `H` is **separable** if it decomposes
     into a product of powers of unary functions, each attending to a
@@ -201,9 +191,7 @@ theorem SeparableHarmony.eval_zero {n : ℕ} (H : SeparableHarmony n) :
     H.eval (fun _ => 0) = 1 := by
   simp only [SeparableHarmony.eval, H.h_norm, one_rpow, prod_const_one]
 
--- ============================================================================
--- § 6: ME Harmony Is Separable (§5.1, eq. 29)
--- ============================================================================
+/-! ### ME Harmony Is Separable (§5.1, eq. 29) -/
 
 /-- The **ME separable harmony**: each `hₖ(x) = exp(−x)` (the
     exponential-of-opposite function from Figure 5a).
@@ -236,9 +224,7 @@ theorem me_separable_eval {n : ℕ} (w : Fin n → ℝ)
   rw [← sum_neg_distrib]
   congr 1; ext k; ring
 
--- ============================================================================
--- § 7: Constraint Rescaling (§5.3, eq. 33–34)
--- ============================================================================
+/-! ### Constraint Rescaling (§5.3, eq. 33–34) -/
 
 /-- **Constraint rescaling** (eq. 33): given a separable
     harmony with unary functions `hₖ`, the rescaled constraint is
@@ -294,9 +280,7 @@ theorem separable_eq_me_rescaled {n : ℕ} (H : SeparableHarmony n)
   rw [← sum_neg_distrib]
   congr 1; ext k; ring
 
--- ============================================================================
--- § 8: Forward Direction — Separable ⟹ HZ (§5.4)
--- ============================================================================
+/-! ### Forward Direction — Separable ⟹ HZ (§5.4) -/
 
 /-- **Separable harmonies predict HZ** (§5.4):
     for *any* separable harmony `H`, if the rescaled violation differences
@@ -331,9 +315,7 @@ theorem separable_predicts_hz {n : ℕ} {X : Type*}
     neg_sub_neg, ← sum_sub_distrib]
   congr 1; ext k; ring
 
--- ============================================================================
--- § 9: Backward Direction — HZ ⟹ Separable (§5.5, online appendices)
--- ============================================================================
+/-! ### Backward Direction — HZ ⟹ Separable (§5.5, online appendices) -/
 
 -- **HZ implies separability** (main result, §5.5):
 -- if an n-ary harmony function H predicts HZ's generalization for
@@ -347,9 +329,7 @@ theorem separable_predicts_hz {n : ℕ} {X : Type*}
 -- independent constraint sets" as a universal quantification over
 -- constraint sets and squares, which is deferred.
 
--- ============================================================================
--- § 10: Counterexample — Inverse Function (§4.4)
--- ============================================================================
+/-! ### Counterexample — Inverse Function (§4.4) -/
 
 /-- The **inverse function** `h(x) = 1/(1+x)` used in the non-separable
     harmony `H(v) = 1 / (1 + Σ wₖvₖ)` (eq. 27).
@@ -407,9 +387,7 @@ theorem inverse_not_always_hz :
   simp only [inverseFunction]
   norm_num
 
--- ============================================================================
--- § 11: Bridge — MaxEnt harmony ↔ Separable harmony
--- ============================================================================
+/-! ### Bridge — MaxEnt harmony ↔ Separable harmony -/
 
 -- `harmonyScore con w` is natively the negated Fin-indexed weighted-violation
 -- sum (`harmonyScore_eq_neg_sum`), so a MaxEnt grammar `(con, w)` is the
@@ -442,9 +420,7 @@ theorem maxent_logit_as_finsum {C : Type*} [Fintype C] [Nonempty C] {n : ℕ}
     -∑ i, w i * ((con i a : ℝ) - (con i b : ℝ)) := by
   rw [maxent_logit_harmony, harmonyScore_diff]
 
--- ============================================================================
--- § 12: Consistent Ordering from Monotone Transforms
--- ============================================================================
+/-! ### Consistent Ordering from Monotone Transforms -/
 
 /-- **Consistent ordering from constant logit-rate differences**: if a score
     function `d` satisfies `ConstantLogitDiff` and `f` is strictly monotone,

--- a/Linglib/Phonology/HarmonicGrammar/ViolationSemiring.lean
+++ b/Linglib/Phonology/HarmonicGrammar/ViolationSemiring.lean
@@ -47,9 +47,7 @@ namespace HarmonicGrammar.ViolationSemiring
 
 open Core.Optimization.Evaluation Constraints
 
--- ============================================================================
--- § 1: The Violation Semiring V
--- ============================================================================
+/-! ### The Violation Semiring V -/
 
 /-- The **violation semiring** ([riggle-2009] Definition 2, Example 2):
     `Tropical (WithTop (ViolationProfile n))` for n ranked constraints.
@@ -66,36 +64,24 @@ abbrev VS (n : Nat) := Tropical (WithTop (ViolationProfile n))
 /-- The violation semiring is a commutative semiring. -/
 noncomputable instance (n : Nat) : CommSemiring (VS n) := inferInstance
 
--- ============================================================================
--- § 2: Monotonicity — Dijkstra's Principle
--- ============================================================================
+/-! ### Monotonicity — Dijkstra's Principle -/
 
 /-- **Dijkstra's principle** for violation profiles
     ([riggle-2009] §4, [dijkstra-1959]):
     merging violations can only make things worse (or keep them equal).
 
-    In Riggle's terms: the ⊎ (merge) operator is **monotone** —
-    A ⊎ B ≥ A for all violation profiles A, B. Equivalently, the
-    ⊗ (min) operator is **idempotent** — A ⊗ A = A.
-
-    This is the structural property that makes shortest-path algorithms
-    applicable to OT optimization: "every piece of an optimal
+    In Riggle's terms: the ⊗ (merge) operator is **monotone** —
+    A ⊗ B ≥ A for all violation profiles A, B. Equivalently, the
+    ⊕ (min) operator is **idempotent** — A ⊕ A = A (`min_self`). An
+    idempotent ⊕ together with a monotone ⊗ make the violation semiring an
+    **idempotent semiring** (dioid) — the structure that makes shortest-path
+    algorithms applicable to OT optimization: "every piece of an optimal
     input–output mapping is itself an optimal mapping." -/
 theorem merge_monotone (n : Nat) (a b : ViolationProfile n) :
     a ≤ a + b :=
   le_add_of_nonneg_right (ViolationProfile.zero_le b)
 
-/-- The ⊗ (min) operation is idempotent: A ⊗ A = A. This is a direct
-    consequence of `LinearOrder` and is the property Riggle identifies
-    as guaranteeing reflexivity and antisymmetry of the harmonic ordering.
-    Idempotency of ⊗ together with monotonicity of ⊎ make the violation
-    semiring a **Kleene algebra** suitable for shortest-path computation. -/
-noncomputable example (n : Nat) (a : ViolationProfile n) :
-    min a a = a := min_self a
-
--- ============================================================================
--- § 3: Weight Map V → ℝ (AddMonoidHom)
--- ============================================================================
+/-! ### Weight Map V → ℝ (AddMonoidHom) -/
 
 /-- The **weight map** ([riggle-2009] §4): an additive monoid
     homomorphism from the violation semiring's underlying monoid
@@ -124,9 +110,7 @@ def weightMap {n : Nat} (w : Fin n → ℝ) : ViolationProfile n →+ ℝ where
     show w i * ((a i + b i : Nat) : ℝ) = w i * (a i : ℝ) + w i * (b i : ℝ)
     push_cast; ring
 
--- ============================================================================
--- § 4: Bridge to Existing HG Code
--- ============================================================================
+/-! ### Bridge to Existing HG Code -/
 
 /-- `weightMap` is definitionally equal to `weightedViolations`
     from `HarmonicGrammar.OTLimit`.
@@ -138,9 +122,7 @@ theorem weightMap_eq_weightedViolations {n : Nat}
     (w : Fin n → ℝ) (v : ViolationProfile n) :
     weightMap w v = weightedViolations w v := rfl
 
--- ============================================================================
--- § 5: Order-Preservation (⊕-compatibility)
--- ============================================================================
+/-! ### Order-Preservation (⊕-compatibility) -/
 
 /-- **The weight map is strictly order-preserving** when weights are
     exponentially separated ([riggle-2009] §4,

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -11666,6 +11666,19 @@
   role      = {formalized},
   sources   = {Semantics/Lexical/Determiner/DomainRestriction.lean;Phenomena/Quantification/Studies/RitchieSchiller2024.lean}
 }% REF: Riggle, J. (2009). Violation Semirings in Optimality Theory. Research on Language and Computation.
+% REF: Litvinov, G. L. (2005). The Maslov dequantization, idempotent and
+% tropical mathematics: a brief introduction. arXiv:math/0507014.
+@unpublished{litvinov-2005,
+  author    = {Litvinov, Grigory L.},
+  year      = {2005},
+  title     = {The {Maslov} Dequantization, Idempotent and Tropical Mathematics: A Brief Introduction},
+  note      = {arXiv:math/0507014; published in Journal of Mathematical Sciences 140(3), 2007},
+  url       = {https://arxiv.org/abs/math/0507014},
+  subfield  = {phonology/formal},
+  role      = {cited},
+  sources   = {Phonology/HarmonicGrammar/Deformation.lean}
+}
+
 @article{riggle-2009,
   author    = {Riggle, Jason},
   year      = {2009},
@@ -26579,6 +26592,21 @@
 % REF: Itô & Mester (1996). The phonological lexicon. Manuscript, UCSC.
 % Earlier statement of the constraint-based account of Japanese velar
 % nasalisation that BKK (2026) builds on.
+% REF: Itô & Mester (1986). The Phonology of Voicing in Japanese.
+% Linguistic Inquiry 17(1), 49–73.
+@article{ito-mester-1986,
+  author    = {It{\^o}, Junko and Mester, Armin},
+  year      = {1986},
+  title     = {The Phonology of Voicing in {Japanese}},
+  journal   = {Linguistic Inquiry},
+  volume    = {17},
+  number    = {1},
+  pages     = {49--73},
+  subfield  = {phonology},
+  role      = {foundational},
+  sources   = {Phonology/HarmonicGrammar/Cumulativity.lean}
+}
+
 @unpublished{ito-mester-1996,
   author    = {It{\^o}, Junko and Mester, Armin},
   year      = {1996},


### PR DESCRIPTION
Mathlib-quality polish of the HarmonicGrammar API — no API changes.

- ASCII `§N` banners → mathlib `/-! ### -/` headers (36, across 6 files)
- `ViolationSemiring`: fix ⊕/⊗ symbol swap, downgrade "Kleene algebra" → idempotent semiring (dioid), drop throwaway anonymous `example`
- repair dropped `[magri-2025]` citation; fix 5 stale `Phonology/Constraint/…` doc paths
- add missing bib entries `ito-mester-1986`, `litvinov-2005`