### PR TITLE
refactor(Phonology/HarmonicGrammar): dissolve SystemicConstraint record

### DIFF
--- a/Linglib/Phonology/HarmonicGrammar/MaxEnt.lean
+++ b/Linglib/Phonology/HarmonicGrammar/MaxEnt.lean
@@ -25,7 +25,9 @@ candidates by weighted constraint violations.
 - A classical MaxEnt grammar is a constraint set `con : CON (I × O) n` + weight
   vector `w` (from `Constraints.Defs`), realized as a `ConstraintSystem` via
   `CON.hgSystem`; its probability is `predict` (no grammar record).
-- `SystemicConstraint` evaluates *tuples* of outputs (different type signature)
+- `SystemicConstraint n O := (Fin n → O) → ℕ` scores a whole output *tuple* (the
+  systemic twin of `Constraint`); weights are a separate `Fin k → ℝ` vector —
+  no grammar record, mirroring the classical `con`/`w` split
 - `jointHarmonyScore` combines classical + systemic scores over the product space
 - `marginalProb` marginalizes the joint to recover individual mapping probabilities
 
@@ -57,132 +59,97 @@ jointly and so does not factor through the per-mapping `predict`. -/
 -- § 2: Systemic Constraints
 -- ============================================================================
 
-/-- A systemic constraint evaluates a *tuple* of outputs — one per input —
-    rather than individual input→output pairs.
+/-- A **systemic constraint** evaluates a whole output *tuple* — one output per
+    input — rather than an individual input→output pair, so it cannot be
+    decomposed into per-mapping evaluations (e.g. \*HOMOPHONY counts colliding
+    output pairs). Like a `Constraint`, it *is* its violation-counting function;
+    its weight is supplied separately (the systemic twin of an HG weight). -/
+abbrev SystemicConstraint (n : Nat) (O : Type*) := (Fin n → O) → ℕ
 
-    Example: \*HOMOPHONY counts pairs of distinct inputs that map to the same
-    output. This cannot be decomposed into per-mapping evaluations.
-
-    `n` is the number of inputs; the tuple `Fin n → O` assigns an output
-    to each input index. -/
-structure SystemicConstraint (n : Nat) (O : Type*) where
-  /-- Constraint name. -/
-  name : String
-  /-- Constraint weight. -/
-  weight : ℝ
-  /-- Evaluation function: how many violations does this output tuple incur? -/
-  eval : (Fin n → O) → Nat
-
-/-- \*HOMOPHONY: penalizes output tuples where distinct inputs receive the
-    same output. Counts the number of colliding pairs.
-
-    For n inputs, evaluates `|{(i,j) : i < j ∧ f(i) = f(j)}|`. -/
-def homophonyAvoidance {n : Nat} {O : Type*} [DecidableEq O]
-    (w : ℝ) : SystemicConstraint n O where
-  name := "*HOMOPHONY"
-  weight := w
-  eval := λ f =>
-    let pairs := do
-      let i ← (List.finRange n)
-      let j ← (List.finRange n)
-      if i < j && f i == f j then [1] else []
-    pairs.length
+/-- \*HOMOPHONY: penalizes output tuples where distinct inputs receive the same
+    output, counting the colliding pairs `|{(i, j) : i < j ∧ f i = f j}|`. -/
+def homophonyAvoidance {n : Nat} {O : Type*} [DecidableEq O] :
+    SystemicConstraint n O :=
+  fun f =>
+    (Finset.univ.filter fun p : Fin n × Fin n => p.1 < p.2 ∧ f p.1 = f p.2).card
 
 -- ============================================================================
 -- § 3: Joint Distribution with Systemic Constraints
 -- ============================================================================
 
-/-- Systemic constraint score for an output tuple.
-    This is the coupling component: `Σₖ (-wₖ · Sₖ(f))`. -/
-def systemicScore {n : Nat} {O : Type*}
-    (systemicConstraints : List (SystemicConstraint n O))
-    (f : Fin n → O) : ℝ :=
-  systemicConstraints.foldl (λ acc sc => acc - sc.weight * (sc.eval f : ℝ)) 0
+/-- **Systemic harmony** of an output tuple: `-∑ⱼ swⱼ · sconⱼ(f)`, the negated
+    weighted sum of the systemic constraints' tuple-violation counts. The
+    systemic twin of `harmonyScore` — same negated-weighted-sum shape, but
+    scoring whole tuples; it is the coupling component of the joint score. -/
+def systemicScore {n k : Nat} {O : Type*}
+    (sw : Fin k → ℝ) (scon : Fin k → SystemicConstraint n O) (f : Fin n → O) : ℝ :=
+  -∑ j, sw j * (scon j f : ℝ)
 
-/-- Joint harmony score over the product space.
-    Combines classical per-mapping scores with systemic tuple-level scores.
-
-    H_joint(f) = Σᵢ H_classical(iᵢ, f(i)) + Σₖ (-wₖ · Sₖ(f))
-
-    where `f : Fin n → O` is the full output tuple. -/
-noncomputable def jointHarmonyScore {n m : Nat} {I O : Type*}
+/-- Joint harmony score over the product space, combining classical per-mapping
+    scores with the systemic tuple-level score:
+    `H_joint(f) = ∑ᵢ H(iᵢ, f i) + systemicScore sw scon f`. -/
+noncomputable def jointHarmonyScore {n m k : Nat} {I O : Type*}
     (inputs : Fin n → I)
     (classicalCon : CON (I × O) m) (classicalW : Fin m → ℝ)
-    (systemicConstraints : List (SystemicConstraint n O))
+    (sw : Fin k → ℝ) (scon : Fin k → SystemicConstraint n O)
     (f : Fin n → O) : ℝ :=
-  let classical := (List.finRange n).foldl
+  (List.finRange n).foldl
     (λ acc i => acc + harmonyScore classicalCon classicalW (inputs i, f i)) 0
-  classical + systemicScore systemicConstraints f
+  + systemicScore sw scon f
 
-/-- MaxEnt grammar with systemic constraints as a `CoupledSoftmax`.
-
-    - `componentScore i v = harmonyScore(classicalConstraints, (inputs i, v))`
-    - `couplingScore f = systemicScore(systemicConstraints, f)`
-
-    The joint probability is `softmax(totalScore, 1)` over all `Fin n → O`
-    output tuples. The marginal at position `i` recovers the individual
-    mapping probability under systemic pressure. -/
-noncomputable def maxEntCoupled {n m : Nat} {I O : Type*} [Fintype O] [DecidableEq O]
+/-- MaxEnt grammar with systemic constraints as a `CoupledSoftmax`:
+    `componentScore i v = harmonyScore classicalCon classicalW (inputs i, v)` and
+    `couplingScore f = systemicScore sw scon f`. The joint probability is a
+    softmax over all `Fin n → O` output tuples; its marginal at position `i`
+    recovers the individual mapping probability under systemic pressure. -/
+noncomputable def maxEntCoupled {n m k : Nat} {I O : Type*} [Fintype O] [DecidableEq O]
     (inputs : Fin n → I)
     (classicalCon : CON (I × O) m) (classicalW : Fin m → ℝ)
-    (systemicConstraints : List (SystemicConstraint n O)) :
+    (sw : Fin k → ℝ) (scon : Fin k → SystemicConstraint n O) :
     Core.CoupledSoftmax (Fin n) O :=
   Core.coupledSoftmaxOfMaxEnt inputs
     (fun p => harmonyScore classicalCon classicalW p)
-    (fun f => systemicScore systemicConstraints f)
+    (fun f => systemicScore sw scon f)
 
-/-- Marginal probability: marginalize the joint distribution to get
-    the probability of a specific input→output mapping.
-
-    P_marginal(oᵢ | iᵢ) = Σ_{f : f(i) = oᵢ} P_joint(f)
-
-    This is Storme's key equation: the marginal recovers individual mapping
-    probabilities that reflect systemic pressure. Defined through
+/-- Marginal probability `P(oᵢ ∣ iᵢ) = ∑_{f : f i = oᵢ} P_joint(f)`: marginalize
+    the joint distribution to recover a specific mapping's probability under
+    systemic pressure ([storme-2026]'s key equation). Defined through
     `CoupledSoftmax.marginal` so that factorization follows from
     `marginal_eq_independent_when_uncoupled`. -/
-noncomputable def marginalProb {n m : Nat} {I O : Type*} [Fintype O] [DecidableEq O]
+noncomputable def marginalProb {n m k : Nat} {I O : Type*} [Fintype O] [DecidableEq O]
     [Nonempty O]
     (inputs : Fin n → I)
     (classicalCon : CON (I × O) m) (classicalW : Fin m → ℝ)
-    (systemicConstraints : List (SystemicConstraint n O))
+    (sw : Fin k → ℝ) (scon : Fin k → SystemicConstraint n O)
     (i : Fin n) (o : O) : ℝ :=
-  (maxEntCoupled inputs classicalCon classicalW systemicConstraints).marginal i o
+  (maxEntCoupled inputs classicalCon classicalW sw scon).marginal i o
 
 -- ============================================================================
 -- § 4: Factorization Theorem
 -- ============================================================================
 
-/-- When all systemic constraint weights are zero, the systemic score
-    is zero for every output tuple. -/
-private lemma systemicScore_zero {n : Nat} {O : Type*}
-    {systemicConstraints : List (SystemicConstraint n O)}
-    (h_zero : ∀ sc ∈ systemicConstraints, sc.weight = 0)
-    (f : Fin n → O) :
-    systemicScore systemicConstraints f = 0 := by
-  induction systemicConstraints with
-  | nil => rfl
-  | cons sc rest ih =>
-    simp only [systemicScore, List.foldl_cons]
-    have hw : sc.weight = 0 := h_zero sc (.head _)
-    rw [hw, zero_mul, sub_zero]
-    exact ih (fun sc' hsc' => h_zero sc' (.tail _ hsc'))
+/-- When all systemic weights are zero, the systemic score vanishes on every
+    output tuple. -/
+private lemma systemicScore_zero {n k : Nat} {O : Type*}
+    {sw : Fin k → ℝ} (h_zero : ∀ j, sw j = 0)
+    (scon : Fin k → SystemicConstraint n O) (f : Fin n → O) :
+    systemicScore sw scon f = 0 := by
+  simp only [systemicScore, h_zero, zero_mul, Finset.sum_const_zero, neg_zero]
 
-/-- **Factorization**: when systemic constraint weights are all zero,
-    the marginal equals the classical MaxEnt probability.
-
-    With zero systemic weights, the coupling score is constant (= 0),
-    so `marginal_eq_independent_when_uncoupled` applies: the joint
-    factorizes and each marginal equals its independent per-item softmax. -/
-theorem marginal_eq_classical_when_no_systemic {n m : Nat} {I O : Type*}
+/-- **Factorization**: when systemic weights are all zero, the marginal equals
+    the classical MaxEnt probability. The coupling score is then constant (= 0),
+    so `marginal_eq_independent_when_uncoupled` applies: the joint factorizes and
+    each marginal equals its independent per-item softmax. -/
+theorem marginal_eq_classical_when_no_systemic {n m k : Nat} {I O : Type*}
     [Fintype O] [DecidableEq O] [Nonempty O]
     (inputs : Fin n → I)
     (classicalCon : CON (I × O) m) (classicalW : Fin m → ℝ)
-    (systemicConstraints : List (SystemicConstraint n O))
-    (h_zero : ∀ sc ∈ systemicConstraints, sc.weight = 0)
+    (sw : Fin k → ℝ) (scon : Fin k → SystemicConstraint n O)
+    (h_zero : ∀ j, sw j = 0)
     (i : Fin n) (o : O) :
-    marginalProb inputs classicalCon classicalW systemicConstraints i o =
+    marginalProb inputs classicalCon classicalW sw scon i o =
     softmax (λ o' => harmonyScore classicalCon classicalW (inputs i, o')) o :=
-  (maxEntCoupled inputs classicalCon classicalW systemicConstraints).marginal_eq_independent_when_uncoupled
-    ⟨0, systemicScore_zero h_zero⟩ i o
+  (maxEntCoupled inputs classicalCon classicalW sw scon).marginal_eq_independent_when_uncoupled
+    ⟨0, systemicScore_zero h_zero scon⟩ i o
 
 end HarmonicGrammar

--- a/Linglib/Studies/Storme2026.lean
+++ b/Linglib/Studies/Storme2026.lean
@@ -3,6 +3,7 @@ import Linglib.Phonology.HarmonicGrammar.MaxEnt
 import Linglib.Phonology.Constraints.Basic
 import Linglib.Phonology.OptimalityTheory.Basic
 import Linglib.Fragments.Farsi.Phonology
+import Mathlib.Data.Fin.VecNotation
 
 /-!
 # [storme-2026]: Systemic Constraints in MaxEnt Grammars
@@ -162,7 +163,7 @@ def inputsIndexed : Fin 4 → HiatusInput
 /-- \*HOMOPHONY for the Persian hiatus paradigm:
     penalizes output tuples where distinct inputs produce identical outputs. -/
 def starHomophony : SystemicConstraint 4 HiatusOutput :=
-  homophonyAvoidance (w := 1)
+  homophonyAvoidance
 
 -- ============================================================================
 -- § 4: Joint Distribution
@@ -171,7 +172,7 @@ def starHomophony : SystemicConstraint 4 HiatusOutput :=
 /-- Joint harmony score for a complete output tuple, combining classical
     per-mapping scores with the systemic \*HOMOPHONY penalty. -/
 noncomputable def persianJointScore (f : Fin 4 → HiatusOutput) : ℝ :=
-  jointHarmonyScore inputsIndexed classicalCon classicalW [starHomophony] f
+  jointHarmonyScore inputsIndexed classicalCon classicalW ![1] ![starHomophony] f
 
 -- ============================================================================
 -- § 5: Symmetry-Breaking Prediction
@@ -198,15 +199,15 @@ def homophonousTuple : Fin 4 → HiatusOutput
     - homophonousTuple: all 4 positions use deleteV1 → C(4,2) = 6 collisions
     - diverseTuple: 3 positions use deleteV1, 1 uses deleteV2 → 3 collisions -/
 theorem homophony_violation_counts :
-    starHomophony.eval homophonousTuple = 6 ∧
-    starHomophony.eval diverseTuple = 3 := by decide
+    starHomophony homophonousTuple = 6 ∧
+    starHomophony diverseTuple = 3 := by decide
 
 /-- \*HOMOPHONY incurs more violations on the homophonous tuple than
     on the diverse tuple. This is the core mechanism by which systemic
     constraints break symmetry. -/
 theorem homophony_penalizes_uniform :
-    starHomophony.eval homophonousTuple ≥
-    starHomophony.eval diverseTuple := by decide
+    starHomophony homophonousTuple ≥
+    starHomophony diverseTuple := by decide
 
 /-- The diverse tuple has at least as high joint harmony as the
     homophonous tuple, because it incurs fewer \*HOMOPHONY violations


### PR DESCRIPTION
Dissolves the lawless `SystemicConstraint {name, weight, eval}` record (with its dead `name : String` field) — the lone named-constraint holdout the `Constraints` re-foundation never reached.

- `SystemicConstraint n O := (Fin n → O) → ℕ` (abbrev) — the systemic twin of `Constraint`; weights move to a separate `Fin k → ℝ` vector, mirroring the classical `con`/`w` split. `systemicScore` becomes `-∑ⱼ swⱼ·sconⱼ(f)`, matching `harmonyScore`'s shape, and `systemicScore_zero` collapses to one `simp only`.
- `homophonyAvoidance`: Bool `&&`/`==` + List-monad → Prop-native `Finset.card` (`decide`-preserving; verified).
- Sole consumer `Studies/Storme2026.lean` updated; all `decide` theorems still pass (the two `sorry`s there are pre-existing).

Touches `MaxEnt.lean` alongside #1000 (disjoint regions — banner headers vs declaration bodies; merges cleanly either order, no hard dependency).