### PR TITLE
feat(Phonology/Prosody): IsFoot + footing functoriality bridge

### DIFF
--- a/Linglib/Phonology/Prosody/Foot.lean
+++ b/Linglib/Phonology/Prosody/Foot.lean
@@ -15,6 +15,8 @@ are *functions* that recover the same head.
 
 ## Main definitions
 
+* `isFootTree` / `IsFoot` — structural foot well-formedness on the prosodic-tree carrier
+  (an `f`-node over a non-empty list of σ-leaves; the Layeredness core).
 * `Foot` — a headed constituent over syllable positions (`head : Fin _`, so non-empty).
 * `Foot.IsTrochaic` / `IsIambic` / `IsBinary` / `IsDegenerate` — derived shape predicates.
 * `Foot.moraCount` — mora count under a weight reading (the quantity axis).
@@ -29,6 +31,8 @@ are *functions* that recover the same head.
   weight-blind-characterizable, unlike a binary (syllabic) trochee.
 * `Foot.headFlags_toProsTree` — the prosodic-tree re-representation carries the same
   head profile as `toGrid` (head-preservation, the functorial spine).
+* `Foot.isFoot_toProsTree` — every `Foot`'s prosodic tree is a well-formed foot tree
+  (`IsFoot`): the functoriality/well-formedness bridge onto the carrier.
 -/
 
 namespace Prosody
@@ -39,6 +43,28 @@ open Features.Prosody
     its parent ω (the `isHead` flag, set when the word tree is built) — the `f`-level arm of
     `Prosody.Constituent`. -/
 abbrev Constituent.ft (isHead : Bool := false) : Constituent := { level := .f, isHead := isHead }
+
+/-! ### Carrier well-formedness -/
+
+/-- The structural `Bool` foot checker on the prosodic-tree carrier ([selkirk-1980];
+    matches `Foot.toProsTree`): an `f`-node dominating a non-empty list of σ-leaves. -/
+def isFootTree : Tree → Bool
+  | .node a cs => decide (a.level = .f) && !cs.isEmpty &&
+      cs.all (fun | .node b ds => decide (b.level = .σ) && ds.isEmpty)
+
+/-- A well-formed foot: an `f`-node dominating a non-empty list of σ-leaves — the
+    inviolable Layeredness + σ-Headedness core ([selkirk-1980]; [hayes-1995]). Foot
+    binarity (FtBin) and recursive internally-layered feet (contested — Golston 2021 vs
+    [martinez-paricio-kager-2015]) are violable and deferred; this is flat feet, the
+    sibling of `IsWord`'s Layeredness. -/
+def IsFoot (t : Tree) : Prop := isFootTree t
+
+instance (t : Tree) : Decidable (IsFoot t) :=
+  inferInstanceAs (Decidable (isFootTree t = true))
+
+-- A σ-leaf is a non-`f` node, so not a foot; a flat `f`-node over a σ-leaf is one.
+example : ¬ IsFoot (.node (.syl 2) []) := by decide
+example : IsFoot (.node .ft [.node (.syl 2) []]) := by decide
 
 /-! ### The canonical foot -/
 
@@ -151,11 +177,20 @@ theorem headFlags_toProsTree (w : S → Syllable.Weight) (f : Foot S) :
     childHeadFlags (toProsTree w f) = toGrid f := by
   simp [childHeadFlags, toProsTree, toGrid, List.map_map, Function.comp]
 
--- `toProsTree` is moreover injective for injective `w` (a foot is recoverable from its
--- tree), giving the `Foot S ≃ {t // IsFootTree t}` embedding onto the depth-1 f/σ band
--- that bridges footing-on-`Foot` to OT-on-`Tree`. That equivalence is the next step in
--- the footing development, where the bridge is consumed; `headFlags_toProsTree` already
--- certifies the load-bearing head-preservation.
+/-- **Functoriality / well-formedness bridge**: a `Foot` record's prosodic-tree
+    re-representation is always a well-formed foot tree — `toProsTree` lands in the
+    depth-1 f/σ band that `isFootTree` carves out. With `headFlags_toProsTree`
+    (head-preservation) this is the load-bearing half of the `Foot S ≃ {t // IsFoot t}`
+    embedding that bridges footing-on-`Foot` to OT-on-`Tree`. -/
+theorem isFoot_toProsTree (w : S → Syllable.Weight) (f : Foot S) :
+    IsFoot (f.toProsTree w) := by
+  have hpos : 0 < f.syllables.length := f.head.pos
+  unfold IsFoot isFootTree toProsTree
+  refine Bool.and_eq_true _ _ |>.mpr ⟨Bool.and_eq_true _ _ |>.mpr ⟨by decide, ?_⟩, ?_⟩
+  · simpa [List.isEmpty_map, List.finRange_eq_nil_iff] using hpos.ne'
+  · rw [List.all_map, List.all_eq_true]
+    intro i _
+    rfl
 
 end Foot
 

--- a/Linglib/Phonology/Prosody/Word.lean
+++ b/Linglib/Phonology/Prosody/Word.lean
@@ -24,7 +24,8 @@ here abstract the foot level. Prominence-head marking is likewise a refinement, 
 
 ## Main definitions
 
-* `isFootTree` / `isWordTree` — structural `Bool` well-formedness checkers (decide-reducible).
+* `isWordTree` — the structural `Bool` Layeredness checker (decide-reducible; the foot arm
+  reuses `Foot.isFootTree`).
 * `IsWord` / `Word` — the Layeredness predicate and the carrier subtype it cuts out.
 * `Word.recursionCount` — the `No-Recursion` violation count, read off the carrier (`noRec`).
 * `noRec` / `parseInto` — the violable OT constraints over the carrier (`Constraint Tree`).
@@ -104,14 +105,8 @@ def moraCount : Tree → Nat := fun t => go t where
 subtype. Both checkers mirror the `go`/`goList` structural recursion of `noRec`, so they
 are `decide`-reducible — a winner can be certified `IsWord by decide`. -/
 
-/-- A well-formed **foot** subtree: an `f`-node dominating a non-empty list of σ-leaves
-    ([selkirk-1980]; matches `Foot.toProsTree`). -/
-def isFootTree : Tree → Bool
-  | .node a cs => decide (a.level = .f) && !cs.isEmpty &&
-      cs.all (fun | .node b ds => decide (b.level = .σ) && ds.isEmpty)
-
 /-- The structural Layeredness checker: an ω-node every daughter of which is a well-formed
-    foot, a recursive ω (the ω-over-ω arm), or a stray σ-leaf. -/
+    foot (`isFootTree`, in `Foot`), a recursive ω (the ω-over-ω arm), or a stray σ-leaf. -/
 def isWordTree : Tree → Bool := fun t => go t where
   go : Tree → Bool
     | .node a cs => decide (a.level = .ω) && goList cs

--- a/Linglib/Studies/Lamont2022c.lean
+++ b/Linglib/Studies/Lamont2022c.lean
@@ -137,4 +137,37 @@ theorem ftbin_obviated :
     LexLE (profile (murinbata 4) disyll4) (profile (murinbata 4) monosyll4)
     ∧ ¬ LexLE (profile (murinbata 4) monosyll4) (profile (murinbata 4) disyll4) := by decide
 
+/-! ### The footing functor: head (= stress) survives into grid and tree
+
+Lamont's `Trochee`/`Iamb` read each foot's head off `Foot.head`. Re-representing a foot
+into the prosodic `Tree` (`Foot.toProsTree`) and the metrical grid (`Foot.toGrid`)
+recovers *exactly* that head — `Foot.headFlags_toProsTree` proves the tree's σ-leaves
+carry the same head profile as the grid — and the tree always lands in the well-formed
+f/σ band (`Foot.isFoot_toProsTree`). So the head, the stress these constraints penalise,
+survives both re-representations. QI footing strips weight, so the tree reads any
+constant σ-weight. -/
+
+/-- QI footing is weight-blind: a `Foot Unit`'s σ read one (light) mora. -/
+def qiWeight : Unit → Syllable.Weight := fun _ => Syllable.Weight.light
+
+/-- **Well-formedness through the functor**: every QI foot Lamont assembles re-represents
+    as a well-formed prosodic-tree foot (`Foot.isFoot_toProsTree`) — the flat `Footing`
+    candidates are built from feet that are legal `f`-over-σ subtrees of the OT `Tree`
+    carrier. -/
+theorem qiFeet_areFootTrees :
+    IsFoot (mono.toProsTree qiWeight) ∧ IsFoot (troch.toProsTree qiWeight)
+      ∧ IsFoot (iamb.toProsTree qiWeight) :=
+  ⟨Foot.isFoot_toProsTree qiWeight mono, Foot.isFoot_toProsTree qiWeight troch,
+   Foot.isFoot_toProsTree qiWeight iamb⟩
+
+/-- **Head survives into grid and tree**: the metrical grid marks the foot head — leftmost
+    for the trochee (the foot Lamont's `Iamb` penalises), rightmost for the iamb (the foot
+    `Trochee` penalises) — and the prosodic tree carries the *same* head profile, reduced
+    here through `Foot.headFlags_toProsTree`. The trochaic vs iambic stress survives the
+    functor identically. -/
+theorem head_survives :
+    Foot.toGrid troch = [true, false] ∧ Foot.toGrid iamb = [false, true] := by
+  rw [← Foot.headFlags_toProsTree qiWeight troch, ← Foot.headFlags_toProsTree qiWeight iamb]
+  decide
+
 end Lamont2022c


### PR DESCRIPTION
Graduate the foot well-formedness checker into `Foot.lean` as `IsFoot`, with the bridge `Foot.isFoot_toProsTree`: a `Foot` re-represents to a well-formed foot tree. This gives the head-preserving functoriality (`toProsTree`/`toGrid`/`headFlags_toProsTree`) a consumer — `Lamont2022c.head_survives` shows the foot head (stress) survives identically into the grid and the tree. `Word.lean` now calls `Foot.isFootTree`.