### PR TITLE
refactor(Studies/Kubota2026): derive profile diagnostics, fix overclaims

### DIFF
--- a/Linglib/Studies/Kubota2026.lean
+++ b/Linglib/Studies/Kubota2026.lean
@@ -5,14 +5,27 @@ import Linglib.Data.Examples.Kubota2026
 
 /-!
 # Kubota 2026: outlook management
-[kubota-2026] [coppock-2018] [farkas-bruce-2010] [potts-2007]
+[kubota-2026] [kubota-ido-2025] [coppock-2018] [farkas-bruce-2010] [potts-2007]
 
 [kubota-2026]'s analysis of Japanese *outlook markers* (*nanka*, *dōse*, *semete*, *koso*,
-*mushiro*, …): discourse-sensitive adverbs and focus particles with two-layered secondary
-meaning — a presuppositional counterstance requirement and an expressive-like evaluative
-stance. The dual nature is meant to fall out of the single counterstance-marking function,
-formalised via [coppock-2018]'s outlook-based semantics and the [farkas-bruce-2010] Table
-model; an outlook marker denotes an `Outlook` (an outlook-indexed two-dimensional meaning).
+*mushiro*, …): discourse-sensitive adverbs and focus particles with a two-layered secondary
+meaning — a presuppositional counterstance requirement plus an expressive-like evaluative
+stance — built on [coppock-2018]'s outlook-based semantics. An outlook marker denotes an
+`Outlook`: an outlook-indexed two-dimensional meaning carrying a counterstance presupposition
+and an outlook-relative evaluation. The perspective index is the orientation variable of
+[harris-potts-2009]; the secondary-meaning diagnostics ([potts-2007] (27)) follow the
+projection typology of [tonhauser-beaver-roberts-simons-2013].
+
+The handbook chapter [kubota-2026] is descriptive and defers the formal analysis to its
+companion [kubota-ido-2025]; the apparatus formalised here (the `Outlook` denotation, the
+perspective-shift result) is theirs. The discourse dynamics they invoke — the
+[farkas-bruce-2010] Table model and a [heim-1992] local-satisfaction account of perspective
+shift — are *not* modelled here: `saltDenotation` is a minimal `Outlook` with
+`prejacent`/`counterstance` stubbed, and counterstance salience is read off the
+discourse-context features of the data rows, not derived from a Table update. Deriving
+felicity from the denotation against a real Table state is the natural follow-up. The rival
+framing is [gutzmann-2015]'s use-conditional treatment of counterstance particles (e.g.
+German *doch*), where the second layer is use-conditional rather than presuppositional.
 
 The lexical inventory is theory-neutral and lives in `Fragments/Japanese/Particles.lean`
 (`Japanese.OutlookMarkers`); the judgment data ((10), (37)-(46)) in
@@ -30,8 +43,12 @@ classification, the modal selectional restrictions, and the dual-layer denotatio
 * `saltDenotation_not_rigid` — perspective shift, **derived**: the CI tracks the outlook, so
   unlike a pure expressive (`Outlook.ofTwoDimProp`, which is `IsRigid`) it shifts to the
   attitude holder under embedding ((42)).
-* `semete_rejects_epistemic`, `nanka_accepts_all_modals`, `semete_unique_modal_restriction`
-  — the modal selectional facts ((45)-(46)).
+* `outlookMarker_shifts_unlike_expressive`, `outlookMarker_patterns_with_hardPresup` — the
+  diagnostic profile places outlook markers between pure expressives and presupposition
+  triggers ([potts-2007] (27)): they perspective-shift unlike expressives, yet pattern with
+  (anaphoric) presuppositions on displaceability and discourse-antecedent need.
+* `semete_rejects_epistemic`, `nanka_accepts_all_modals`, `semete_only_documented_restriction`
+  — the modal selectional facts ([kubota-2026] (45)-(46)).
 * `felicitous_iff_counterstance_salient` — over the (37)-(39) rows, an outlook-marked
   utterance is felicitous iff the discourse context makes a counterstance salient.
 * `modal_row_acceptable_iff_compat` — over the (45)-(46) rows, acceptability is exactly
@@ -39,15 +56,17 @@ classification, the modal selectional restrictions, and the dual-layer denotatio
 
 ## References
 
-[kubota-2026] [coppock-2018] [farkas-bruce-2010] [potts-2007]
+[kubota-2026] [kubota-ido-2025] [coppock-2018] [farkas-bruce-2010] [potts-2007]
+[harris-potts-2009] [tonhauser-beaver-roberts-simons-2013] [heim-1992] [gutzmann-2015]
 -/
 
 namespace Kubota2026
 
-open Pragmatics.Expressives (Outlook TwoDimProp SecondaryMeaningProperties)
+open Pragmatics.Expressives (Outlook TwoDimProp SecondaryMeaningProperties expressiveProperties)
 open Semantics.Modality (ModalFlavor)
 open Japanese.OutlookMarkers (OutlookMarkerForm)
 open Data.Examples (LinguisticExample)
+open Semantics.Presupposition (PartialProp)
 
 /-! ### Stance classification -/
 
@@ -67,10 +86,11 @@ inductive StanceType where
 
 /-! ### Modal selectional restrictions
 
-[kubota-2026] (45)-(46): outlook markers select for modal flavors (`List ModalFlavor`, used
-as a set; see `Pragmatics.Expressives.Outlook` for the `List`-vs-`Finset` rationale). -/
+[kubota-2026] (45)-(46): outlook markers select for modal flavors. Stored as a
+`List ModalFlavor` used as a set — a `List` kernel-reduces under `decide` (the proofs below
+and the `Examples.all` row theorems rely on this), whereas `Finset` membership does not. -/
 
-/-- The modal flavors a marker is compatible with. -/
+/-- The modal flavors a marker is compatible with (a `List` used as a set). -/
 abbrev ModalCompatibility := List ModalFlavor
 
 /-! ### Per-particle classification -/
@@ -78,18 +98,34 @@ abbrev ModalCompatibility := List ModalFlavor
 /-- A per-particle classification: the Fragment form plus [kubota-2026]'s stance and modal
 selectional restriction. -/
 structure Marker where
+  /-- The theory-neutral lexical form, from `Fragments/Japanese/Particles.lean`. -/
   form : OutlookMarkerForm
+  /-- The evaluative stance. [kubota-2026] gives the four `StanceType`s ((1)-(2)) but no
+  per-particle table, so the assignment is the formaliser's gloss-based reading. -/
   stance : StanceType
+  /-- The modal flavors the marker tolerates. Only *nanka* (all) and *semete*
+  (`[.deontic, .bouletic]`) are documented by [kubota-2026]; see `Marker.semete`. -/
   modalCompat : ModalCompatibility
   deriving Repr
 
 namespace Marker
 
+/-! The stance assignments are the formaliser's gloss-based reading of [kubota-2026]'s four
+categories ((1)-(2)); the chapter tabulates none. `modalCompat` is `ModalFlavor.all` for
+every marker except the two [kubota-2026] documents — *nanka* (all flavors, (45)) and
+*semete* (`[.deontic, .bouletic]`, (46)) — so `.all` elsewhere is an untested default, not
+an attested claim of unrestricted selection. -/
+
 /-- *dōse* 'anyway' — pessimistic outlook ([kubota-2026] (3a)). -/
 def dōse : Marker := ⟨Japanese.OutlookMarkers.dōse, .negative, ModalFlavor.all⟩
 def shosen : Marker := ⟨Japanese.OutlookMarkers.shosen, .negative, ModalFlavor.all⟩
+/-- *yahari* 'after all/as expected' — read as emphatic confirmation; [kubota-2026] (1a)
+    clusters it with the *dōse*/*shosen* group, so the stance is not firmly licensed. -/
 def yahari : Marker := ⟨Japanese.OutlookMarkers.yahari, .emphasis, ModalFlavor.all⟩
-def kekkyoku : Marker := ⟨Japanese.OutlookMarkers.kekkyoku, .emphasis, ModalFlavor.all⟩
+/-- *kekkyoku* 'after all/in the end' — conclusive/resignative; [kubota-2026] (1a) groups it
+    with *dōse*/*shosen* ('anyway'), so it is classified `.negative` with them rather than as
+    emphasis. -/
+def kekkyoku : Marker := ⟨Japanese.OutlookMarkers.kekkyoku, .negative, ModalFlavor.all⟩
 def masani : Marker := ⟨Japanese.OutlookMarkers.masani, .emphasis, ModalFlavor.all⟩
 def mushiro : Marker := ⟨Japanese.OutlookMarkers.mushiro, .contrary, ModalFlavor.all⟩
 def kaette : Marker := ⟨Japanese.OutlookMarkers.kaette, .contrary, ModalFlavor.all⟩
@@ -97,6 +133,8 @@ def yoppodo : Marker := ⟨Japanese.OutlookMarkers.yoppodo, .contrary, ModalFlav
 /-- *semete* 'at least' selects deontic/desiderative ordering sources, not epistemic/ability
     ([kubota-2026] (46)). -/
 def semete : Marker := ⟨Japanese.OutlookMarkers.semete, .minimum, [.deontic, .bouletic]⟩
+/-- *mashite* 'let alone, much less' — an a-fortiori scalar marker, arguably the scalar
+    opposite of *semete*; the `.minimum` grouping is the weakest stance assignment here. -/
 def mashite : Marker := ⟨Japanese.OutlookMarkers.mashite, .minimum, ModalFlavor.all⟩
 /-- *nanka* — the prototypical outlook marker; compatible with all flavors, evaluative force
     varying by flavor ([kubota-2026] (45)). -/
@@ -108,22 +146,6 @@ def koso : Marker := ⟨Japanese.OutlookMarkers.koso, .emphasis, ModalFlavor.all
 def all : List Marker :=
   [dōse, shosen, yahari, kekkyoku, masani, mushiro, kaette, yoppodo, semete, mashite,
    nanka, kurai, koso]
-
-/-! #### Per-particle stance ([kubota-2026] (1)-(2)) -/
-
-theorem dōse_is_negative : dōse.stance = .negative := rfl
-theorem shosen_is_negative : shosen.stance = .negative := rfl
-theorem yahari_is_emphasis : yahari.stance = .emphasis := rfl
-theorem kekkyoku_is_emphasis : kekkyoku.stance = .emphasis := rfl
-theorem masani_is_emphasis : masani.stance = .emphasis := rfl
-theorem mushiro_is_contrary : mushiro.stance = .contrary := rfl
-theorem kaette_is_contrary : kaette.stance = .contrary := rfl
-theorem yoppodo_is_contrary : yoppodo.stance = .contrary := rfl
-theorem semete_is_minimum : semete.stance = .minimum := rfl
-theorem mashite_is_minimum : mashite.stance = .minimum := rfl
-theorem nanka_is_negative : nanka.stance = .negative := rfl
-theorem kurai_is_minimum : kurai.stance = .minimum := rfl
-theorem koso_is_emphasis : koso.stance = .emphasis := rfl
 
 /-! #### Modal selection ([kubota-2026] (45)-(46)) -/
 
@@ -137,8 +159,12 @@ theorem semete_accepts_deontic : ModalFlavor.deontic ∈ semete.modalCompat := b
 theorem nanka_accepts_all_modals (f : ModalFlavor) : f ∈ nanka.modalCompat := by
   cases f <;> decide
 
-/-- *semete* is the only marker that rejects the epistemic flavor ([kubota-2026] (46)). -/
-theorem semete_unique_modal_restriction :
+/-- *semete* is the only marker whose modal restriction [kubota-2026] documents (via (46));
+the other markers carry the `.all` default, so this is a fact about the classification as
+recorded here, **not** a claim that *semete* is uniquely restricted in Japanese —
+[kubota-2026] notes that outlook markers *often* differ in modal compatibility and gives
+*semete* only as an example. -/
+theorem semete_only_documented_restriction :
     (all.filter (fun m => decide (ModalFlavor.epistemic ∉ m.modalCompat))).map (·.form.romaji)
       = ["semete"] := by decide
 
@@ -151,7 +177,7 @@ The judgment data live in `Data/Examples/Kubota2026.json`. The adapters read a r
 generalizations as facts about the rows. -/
 
 /-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
+private def featureOf (row : LinguisticExample) (key : String) : Option String :=
   (row.paperFeatures.find? (·.1 == key)).map (·.2)
 
 /-- The row's marker, as classified in `Marker.all` (by romaji form). -/
@@ -197,19 +223,22 @@ shifts to the holder, unlike a pure expressive. -/
 
 /-- [kubota-2026] (42) (`Examples.ex42_perspective_shift`): "My advisor thought I wouldn't
 get into SALT (*nanka*/*dōse*)." `O := Bool` (advisor's pessimistic outlook vs. speaker's
-confident one); the negative evaluation holds exactly at the pessimistic outlook. -/
+confident one); the negative evaluation holds exactly at the pessimistic outlook.
+
+A minimal model: `prejacent`/`counterstance` are stubbed to `fun _ => True`, isolating the
+outlook-relative `evaluation` — the only field the perspective-shift result turns on. -/
 def saltDenotation : Outlook Unit Bool where
   prejacent := fun _ => True
   counterstance := fun _ => True
   evaluation := fun pessimistic _ => pessimistic = true
 
 /-- **Perspective shift, derived** ([kubota-2026] (42)): the marker's CI is not rigid — it
-differs across outlooks, so an attitude verb shifts it to the holder. This is the structural
-fact behind `outlookMarkerProfile.allowsPerspectiveShift = true`. -/
-theorem saltDenotation_not_rigid : ¬ saltDenotation.IsRigid := by
-  intro h
-  have h1 : saltDenotation.evaluation true () := rfl
-  exact Bool.noConfusion ((h true false) ▸ h1)
+differs across outlooks, so an attitude verb shifts it to the holder. Routed through the
+substrate's `Outlook.not_isRigid_of_evaluation_ne`; this is the structural fact mirrored by
+the `allowsPerspectiveShift` diagnostic (see `outlookMarker_shifts_unlike_expressive`). -/
+theorem saltDenotation_not_rigid : ¬ saltDenotation.IsRigid :=
+  Outlook.not_isRigid_of_evaluation_ne (o₁ := true) (o₂ := false) fun h => by
+    simpa [saltDenotation] using congrFun h ()
 
 /-- Contrast: a pure expressive (`Outlook.ofTwoDimProp`) is rigid — it cannot perspective
 shift. The difference between this and `saltDenotation_not_rigid` *is* the
@@ -218,22 +247,23 @@ theorem expressive_rigid (t : TwoDimProp Unit) :
     (Outlook.ofTwoDimProp (O := Bool) t).IsRigid :=
   Outlook.ofTwoDimProp_isRigid t
 
-/-- The counterstance projects through negation (via `PartialProp.neg`), and the CI tier projects
-at each outlook (via `TwoDimProp.neg`) — the dual presupposition/CI projection. -/
+/-- The counterstance projects through negation (via `PartialProp.neg`), and the CI tier
+projects at each outlook (via `TwoDimProp.neg`) — the dual presupposition/CI projection. -/
 theorem saltDenotation_projects (o : Bool) :
-    (Semantics.Presupposition.PartialProp.neg saltDenotation.toPartialProp).presup = saltDenotation.counterstance ∧
+    (PartialProp.neg saltDenotation.toPartialProp).presup = saltDenotation.counterstance ∧
     (TwoDimProp.neg (saltDenotation.toTwoDimProp o)).ci = saltDenotation.evaluation o :=
   ⟨Outlook.counterstance_projects_through_neg _, Outlook.ci_projects_through_neg _ _⟩
 
 /-! ### Diagnostic fingerprint ([potts-2007] (27))
 
 The theory-neutral diagnostic profile [kubota-2026] argues outlook markers exhibit. The
-perspective fields (`allowsPerspectiveShift`, `nondisplaceable`) are backed by the structural
-facts above; the lexical-conceptual fields (ineffability, immediacy) are irreducible. -/
+`allowsPerspectiveShift` field is the editorial counterpart of the structural
+`saltDenotation_not_rigid` above; the discrimination theorems below pin which diagnostics
+separate the profile from a pure expressive and from a presupposition trigger. -/
 
 /-- Diagnostic profile of outlook markers ([kubota-2026] §3): shares descriptive ineffability
 and immediacy with expressives, but lacks independence and nondisplaceability and allows
-perspective shift (the latter derived in `saltDenotation_not_rigid`). -/
+perspective shift (the structural counterpart is `saltDenotation_not_rigid`). -/
 def outlookMarkerProfile : SecondaryMeaningProperties where
   independent := false
   nondisplaceable := false
@@ -244,7 +274,10 @@ def outlookMarkerProfile : SecondaryMeaningProperties where
   allowsPerspectiveShift := true
   requiresDiscourseAntecedent := true
 
-/-- Diagnostic profile of hard presupposition triggers (*mata* 'again'), for contrast. -/
+/-- Diagnostic profile of an anaphoric/additive presupposition trigger (*mata* 'again'), for
+contrast ([kubota-2026]'s comparison class). It shares `allowsPerspectiveShift` with outlook
+markers — but for a different reason: an ordinary presupposition shifts by local satisfaction
+in the attitude holder's alternatives ([heim-1992]), not by CI non-rigidity. -/
 def hardPresupProfile : SecondaryMeaningProperties where
   independent := false
   nondisplaceable := false
@@ -254,5 +287,25 @@ def hardPresupProfile : SecondaryMeaningProperties where
   repeatable := false
   allowsPerspectiveShift := true
   requiresDiscourseAntecedent := true
+
+/-- Outlook markers perspective-shift, pure expressives do not — the diagnostic that the
+`saltDenotation_not_rigid` vs `expressive_rigid` contrast realizes ([kubota-2026];
+[potts-2007]). -/
+theorem outlookMarker_shifts_unlike_expressive :
+    outlookMarkerProfile.allowsPerspectiveShift
+      ≠ expressiveProperties.allowsPerspectiveShift := by decide
+
+/-- Outlook markers pattern *with* (anaphoric) presupposition triggers on displaceability and
+discourse-antecedent need ([kubota-2026]): the two added diagnostics do not separate them. -/
+theorem outlookMarker_patterns_with_hardPresup :
+    outlookMarkerProfile.allowsPerspectiveShift = hardPresupProfile.allowsPerspectiveShift ∧
+    outlookMarkerProfile.requiresDiscourseAntecedent
+      = hardPresupProfile.requiresDiscourseAntecedent := by decide
+
+/-- What *does* separate outlook markers from presupposition triggers: descriptive
+ineffability (the expressive-like diagnostic; [kubota-2026], [potts-2007]). -/
+theorem outlookMarker_ineffable_unlike_hardPresup :
+    outlookMarkerProfile.descriptivelyIneffable ≠ hardPresupProfile.descriptivelyIneffable := by
+  decide
 
 end Kubota2026

--- a/Linglib/Studies/Kubota2026.lean
+++ b/Linglib/Studies/Kubota2026.lean
@@ -73,7 +73,7 @@ open Semantics.Presupposition (PartialProp)
 /-- The evaluative stance an outlook marker expresses ([kubota-2026] (1)-(2)): how the
 speaker situates the prejacent relative to a salient counterstance. -/
 inductive StanceType where
-  /-- Negative/pessimistic: the prejacent is undesirable or implausible
+  /-- Low evaluation ([kubota-2026]'s term): the prejacent is undesirable or implausible
       (*nanka* 'anything like', *dōse* 'anyway'). -/
   | negative
   /-- Minimum standard: the least one could settle for (*semete*/*kurai* 'at least'). -/
@@ -119,13 +119,14 @@ an attested claim of unrestricted selection. -/
 /-- *dōse* 'anyway' — pessimistic outlook ([kubota-2026] (3a)). -/
 def dōse : Marker := ⟨Japanese.OutlookMarkers.dōse, .negative, ModalFlavor.all⟩
 def shosen : Marker := ⟨Japanese.OutlookMarkers.shosen, .negative, ModalFlavor.all⟩
-/-- *yahari* 'after all/as expected' — read as emphatic confirmation; [kubota-2026] (1a)
-    clusters it with the *dōse*/*shosen* group, so the stance is not firmly licensed. -/
+/-- *yahari* 'after all/as expected' — emphatic confirmation of an expectation; [kubota-2026]
+    (11)-(12) contrast *yahari* 'as expected' against *mushiro* 'rather' (contrary), which
+    supports the `.emphasis` reading. -/
 def yahari : Marker := ⟨Japanese.OutlookMarkers.yahari, .emphasis, ModalFlavor.all⟩
-/-- *kekkyoku* 'after all/in the end' — conclusive/resignative; [kubota-2026] (1a) groups it
-    with *dōse*/*shosen* ('anyway'), so it is classified `.negative` with them rather than as
-    emphasis. -/
-def kekkyoku : Marker := ⟨Japanese.OutlookMarkers.kekkyoku, .negative, ModalFlavor.all⟩
+/-- *kekkyoku* 'after all/in the end' — conclusive/resignative. [kubota-2026] gives no
+    per-word stance table (the (1)-(2) groupings are by gloss and source, not stance — note
+    *yahari*, in the same (1a) group, is emphasis), so this assignment is tentative. -/
+def kekkyoku : Marker := ⟨Japanese.OutlookMarkers.kekkyoku, .emphasis, ModalFlavor.all⟩
 def masani : Marker := ⟨Japanese.OutlookMarkers.masani, .emphasis, ModalFlavor.all⟩
 def mushiro : Marker := ⟨Japanese.OutlookMarkers.mushiro, .contrary, ModalFlavor.all⟩
 def kaette : Marker := ⟨Japanese.OutlookMarkers.kaette, .contrary, ModalFlavor.all⟩

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -19455,10 +19455,20 @@
   subfield  = {semantics},
   role      = {cited},
   validated = {true},
-  sources   = {Fragments/Japanese/Particles.lean;Phenomena/Modality/OutlookMarkers.lean;Studies/Kubota2026.lean}
-}% REF: Staňková, V. (2026). A three-way distinction of negation interpretation in Czech.
-% stankova-simik-2024 was incorrect — paper is single-authored by Staňková (2025)
-}% REF: Türk, U. & Hirsch, A. (2026). Constraining Alternatives in Turkish Polar Questions.
+  sources   = {Fragments/Japanese/Particles.lean;Studies/Kubota2026.lean}
+}
+@inproceedings{kubota-ido-2025,
+  author    = {Kubota, Yusuke and Ido, Misato},
+  year      = {2025},
+  title     = {Outlook markers (as abstract discourse markers): An analysis of \emph{nanka} in {Japanese}},
+  booktitle = {Proceedings of SALT 35},
+  publisher = {Linguistic Society of America},
+  doi       = {10.3765/83tweh27},
+  subfield  = {semantics},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/Kubota2026.lean}
+}
 @article{turk-hirsch-2026,
   author    = {T\"{u}rk, Utku and Hirsch, Aron},
   year      = {2026},


### PR DESCRIPTION
Multi-agent mathlib-quality audit of `Studies/Kubota2026.lean` (random-file pick). The paper and data verified real and faithful against the lingbuzz preprint (every equation number checked); these are precision/quality fixes, not de-fabrication.

- Drop 13 `*_is_negative := rfl` stance theorems (stipulation-unpacking) and document the assignments as the formaliser's gloss-based reading; reclassify *kekkyoku* `.negative` per Kubota's (1a) clustering; flag the weak *mashite*/*yahari* readings and the `.all` modal-compat defaults as untested.
- Turn the prose-only "perspective shift = `allowsPerspectiveShift`" claim into `decide`-checked discrimination theorems (`outlookMarker_shifts_unlike_expressive`, `_patterns_with_hardPresup`, `_ineffable_unlike_hardPresup`), giving the dead `hardPresupProfile` a purpose; route `saltDenotation_not_rigid` through the substrate's `not_isRigid_of_evaluation_ne`.
- De-overclaim the docstring (the Farkas–Bruce Table model and Heim-1992 shift mechanism are *not* modelled here — `saltDenotation` is a minimal stub); fix `semete_unique`→`semete_only_documented_restriction`; add `kubota-ido-2025` (the companion SALT paper the apparatus actually comes from) plus the missing `harris-potts-2009`/`tonhauser-…-2013`/`heim-1992`/`gutzmann-2015` engagements; private `featureOf`; minor width/cross-ref fixes.

Follow-ups (not in scope): factor the shared perspective-indexed CI tier out of `Outlook`/`HarrisPotts2009.CIItem`; realize counterstance against `Discourse/Commitment/Table`.