### PR TITLE
refactor(Studies/Krifka1998): cut data-check theorems, motion data→JSON

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2924,5 +2924,6 @@ import Linglib.Data.Examples.SolstadBott2024
 import Linglib.Data.Examples.RotterLiu2025
 import Linglib.Data.Examples.DegenTonhauser2021
 import Linglib.Data.Examples.BeltramaSchwarz2024
+import Linglib.Data.Examples.Krifka1998
 
 

--- a/Linglib/Data/Examples/Krifka1998.json
+++ b/Linglib/Data/Examples/Krifka1998.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "krifka1998_arrive_at_store",
+    "source": {"bibkey": "krifka-1998", "paperLabel": "§4.5 arrive (bounded path)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Mary arrived at the store in five minutes.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Mary arrived at the store in five minutes.",
+    "context": "Inherently directed motion with a specified goal: the path is bounded (has an endpoint), so the VP is telic and accepts the in-X adverbial.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["pathShape", "bounded"],
+      ["expectedTelicity", "telic"]
+    ],
+    "comment": "Migrated from the deleted MotionVPDatum table in Studies/Krifka1998.lean. UNVERIFIED paperLabel: section carried from prior Lean docstrings, eq. numbers dropped pending PDF check.",
+    "metaLanguage": "stan1293"
+  },
+  {
+    "id": "krifka1998_leave_the_house",
+    "source": {"bibkey": "krifka-1998", "paperLabel": "§4.5 leave (source path)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Mary left the house in a moment.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Mary left the house in a moment.",
+    "context": "Leave verb specifying a source: the path is bounded at its origin, so the VP is telic and accepts the in-X adverbial.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["pathShape", "source"],
+      ["expectedTelicity", "telic"]
+    ],
+    "comment": "Migrated from the deleted MotionVPDatum table in Studies/Krifka1998.lean. UNVERIFIED paperLabel: section carried from prior Lean docstrings.",
+    "metaLanguage": "stan1293"
+  },
+  {
+    "id": "krifka1998_run_to_park",
+    "source": {"bibkey": "krifka-1998", "paperLabel": "§4.5 run to (bounded PP)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Mary ran to the park in ten minutes.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Mary ran to the park in ten minutes.",
+    "context": "Manner-of-motion verb plus a goal PP: the directional to-PP supplies a bounded path, so the otherwise atelic verb yields a telic VP.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["pathShape", "bounded"],
+      ["expectedTelicity", "telic"]
+    ],
+    "comment": "Migrated from the deleted MotionVPDatum table in Studies/Krifka1998.lean. UNVERIFIED paperLabel: section carried from prior Lean docstrings.",
+    "metaLanguage": "stan1293"
+  },
+  {
+    "id": "krifka1998_run_towards_park",
+    "source": {"bibkey": "krifka-1998", "paperLabel": "§4.5 run towards (unbounded PP)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Mary ran towards the park for ten minutes.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Mary ran towards the park for ten minutes.",
+    "context": "Manner-of-motion verb plus a towards-PP: direction without a goal supplies an unbounded path, so the VP is atelic and takes for-X, not in-X.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["pathShape", "unbounded"],
+      ["expectedTelicity", "atelic"]
+    ],
+    "comment": "Migrated from the deleted MotionVPDatum table in Studies/Krifka1998.lean. UNVERIFIED paperLabel: section carried from prior Lean docstrings.",
+    "metaLanguage": "stan1293"
+  }
+]

--- a/Linglib/Data/Examples/Krifka1998.lean
+++ b/Linglib/Data/Examples/Krifka1998.lean
@@ -1,0 +1,90 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Krifka1998` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Krifka1998.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Krifka1998.Examples`.
+-/
+
+namespace Krifka1998.Examples
+
+open Data.Examples
+
+def arrive_at_store : LinguisticExample :=
+  { id := "krifka1998_arrive_at_store"
+    source := ⟨"krifka-1998", "§4.5 arrive (bounded path)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary arrived at the store in five minutes."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mary arrived at the store in five minutes."
+    context := "Inherently directed motion with a specified goal: the path is bounded (has an endpoint), so the VP is telic and accepts the in-X adverbial."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("pathShape", "bounded"), ("expectedTelicity", "telic")]
+    comment := "Migrated from the deleted MotionVPDatum table in Studies/Krifka1998.lean. UNVERIFIED paperLabel: section carried from prior Lean docstrings, eq. numbers dropped pending PDF check."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def leave_the_house : LinguisticExample :=
+  { id := "krifka1998_leave_the_house"
+    source := ⟨"krifka-1998", "§4.5 leave (source path)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary left the house in a moment."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mary left the house in a moment."
+    context := "Leave verb specifying a source: the path is bounded at its origin, so the VP is telic and accepts the in-X adverbial."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("pathShape", "source"), ("expectedTelicity", "telic")]
+    comment := "Migrated from the deleted MotionVPDatum table in Studies/Krifka1998.lean. UNVERIFIED paperLabel: section carried from prior Lean docstrings."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def run_to_park : LinguisticExample :=
+  { id := "krifka1998_run_to_park"
+    source := ⟨"krifka-1998", "§4.5 run to (bounded PP)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary ran to the park in ten minutes."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mary ran to the park in ten minutes."
+    context := "Manner-of-motion verb plus a goal PP: the directional to-PP supplies a bounded path, so the otherwise atelic verb yields a telic VP."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("pathShape", "bounded"), ("expectedTelicity", "telic")]
+    comment := "Migrated from the deleted MotionVPDatum table in Studies/Krifka1998.lean. UNVERIFIED paperLabel: section carried from prior Lean docstrings."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def run_towards_park : LinguisticExample :=
+  { id := "krifka1998_run_towards_park"
+    source := ⟨"krifka-1998", "§4.5 run towards (unbounded PP)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary ran towards the park for ten minutes."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mary ran towards the park for ten minutes."
+    context := "Manner-of-motion verb plus a towards-PP: direction without a goal supplies an unbounded path, so the VP is atelic and takes for-X, not in-X."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("pathShape", "unbounded"), ("expectedTelicity", "atelic")]
+    comment := "Migrated from the deleted MotionVPDatum table in Studies/Krifka1998.lean. UNVERIFIED paperLabel: section carried from prior Lean docstrings."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [arrive_at_store, leave_the_house, run_to_park, run_towards_park]
+
+end Krifka1998.Examples

--- a/Linglib/Studies/Krifka1989.lean
+++ b/Linglib/Studies/Krifka1989.lean
@@ -33,9 +33,8 @@ on abstract domains.
 
 * **K89 GRAD propositional chain**: `SINC + ExtMeasure + MeasureProportional →
   GRAD` was deleted in 0.231.55 (formerly in `Events/GradualChange.lean`,
-  zero-consumer). Bool-tag proxy `predictsGRAD` survives in
-  `Studies/Krifka1998.lean` § 7. Future K89 §4 propositional-faithfulness
-  pass needs to rebuild.
+  zero-consumer); the Bool-tag proxy in `Studies/Krifka1998.lean` is also gone.
+  A future K89 §4 propositional-faithfulness pass needs to rebuild it.
 * **K89↔Champollion `forAdverbial_subsumes_qmod` bridge**: also dropped in
   0.231.55 as dead. ~5 LOC over `forAdverbialMeaning` + `QMOD` to
   re-derive when a Champollion replication wants the cross-framework bridge.

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -2,14 +2,10 @@ import Linglib.Semantics.ArgumentStructure.Properties
 import Linglib.Semantics.Aspect.Incremental
 import Linglib.Semantics.Aspect.Cumulativity
 import Linglib.Semantics.Events.CEM
-import Linglib.Semantics.Spatial.Trace
-import Linglib.Semantics.Lexical.LevinClass
 import Linglib.Semantics.Events.Adjacency
 import Linglib.Semantics.Aspect.PrecedenceClosure
+import Linglib.Semantics.Spatial.Trace
 import Linglib.Features.Aktionsart
-import Linglib.Fragments.English.Predicates.Verbal
-import Linglib.Features.Aktionsart
-import Linglib.Studies.Krifka1989
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Lattice.Basic
 import Mathlib.Data.Fintype.Basic
@@ -17,273 +13,55 @@ import Mathlib.Data.Fintype.Basic
 /-!
 # [krifka-1998] *The Origins of Telicity*
 
-K98's two distinctive contributions, formalized end-to-end:
+Exercises the K98 incrementality (§3) and movement (§4) substrate with the
+paper's deepest results: CUM/QUA propagation, telicity by initial/final parts,
+and the path-bounded movement-relation analysis.
 
-* **Part I — §3 Incrementality** (CUM/QUA propagation through SINC/INC
-  verbs; Vendler classification; for/in diagnostics).
-* **Part II — §4 Movement** (path/movement extension of mereological
-  telicity: a movement event is telic iff its path is bounded; EXP /
-  SEINC / ADJ / SMR / MovementClosure / MR propositional substrate).
-
-The substrate predicates (SUM, UO, UE, MO, MSO, MSE, GUE, SINC, INC,
-CumTheta — K98 §3.2 eq. 43-52, eq. 59) live in
-`Semantics/Events/{Incrementality,ThematicRoleProperties}.lean`;
-the σ-trace pullback machinery in `Semantics/Spatial/Trace.lean`.
-This file exercises both on the English fragment and inlines the §4
-movement-relation predicates (formerly in
+The substrate predicates (MO, MSO, MSE, SINC, INC, CumTheta — K98 §3.2) live
+in `Semantics/Events/`; the σ-trace pullback in `Semantics/Spatial/Trace.lean`.
+This file inlines the §4 movement-relation predicates (formerly in
 `Semantics/Events/MovementRelations.lean`).
 
 ## Main definitions
 
-Part I (§3 incrementality):
+* `IsInitialPart` / `IsFinalPart` / `IsTelic` — K98 §2.5 telicity, with
+  `isTelic_of_qua` the `QUA → TEL` direction.
+* `EXP` / `SEINC` / `ADJ` / `SMR` / `MovementClosure` / `MR` — K98 §4 movement
+  substrate (TANG_H-free), with `mr_of_smr` and the `Event Time` instantiations
+  `expEv` / `seincEv` / `smrPath` / `mrPath`.
 
-* Per-verb `*_sinc` / `*_inc` / `*_cumOnly` tripwire theorems
-* VendlerClass → MereoTag bridge via `Telicity.toMereoTag`
-* `eat_two_apples_qua_propositional` / `eat_apples_cum_propositional` —
-  K98 §3.3 propagation invoked on abstract θ
-* `IsSincVerb (eatThemeToy)` instance + applied propagation theorems
-  (the constructive witness that the typeclass admits non-axiomatic
-  realizations)
-* K89 ↔ K98 sister-paper refinement bridge (uses
-  `K89ThematicClass.toVerbIncClass` from `Studies/Krifka1989.lean`)
+## Main statements
 
-Part II (§4 movement):
-
-* `EXP` / `SEINC` / `ADJ` / `SMR` — K98 §4 propositional predicates
-* `MovementClosure` / `MR` — K98 §4.3 closure substrate (TANG_H-free)
-* `expEv` / `seincEv` / `smrPath` / `mrPath` — `Event Time` instantiations
-* `MotionVPDatum` / `motionData` — Bool-tag-level VP data
-* `walked_from_to_telic_propositional` /
-  `walked_towards_atelic_propositional` — σ-pullback theorems backing
-  the K98 §4.5 *walked from X to Y* / *walked towards X* analyses
-
-The `### K98 §2.5` section defines the INI/FIN initial/final-part predicates
-and the propositional `TEL` predicate (`IsTelic`), with `isTelic_of_qua`
-giving Krifka's `QUA → TEL` direction; `Telicity.toMereoTag .telic = .qua`
-remains the coarse tag-level collapse used by the Vendler bridge.
+* `eat_apples_cum_propositional` / `eat_two_apples_qua_propositional` — K98 §3.3
+  CUM/QUA propagation on abstract θ, fired on a constructive `IsSincVerb` toy
+  (`eat_two_apples_toy_qua`, `eat_some_apples_toy_cum`).
+* `telic_licenses_inX` / `durative_atelic_licenses_forX` — §3 for/in diagnostics.
+* `walked_from_to_telic_propositional` / `walked_towards_atelic_propositional` —
+  σ-pullback backing the *walked from X to Y* / *walked towards X* analyses.
 
 ## TODO
 
-* **TEL ⊋ QUA strict witness**: the telic-but-not-QUA half of K98 §2.5
-  (the run-time-3-to-4-pm predicate) needs a concrete event model and is
-  not yet exhibited; `isTelic_of_qua` proves only the `QUA → TEL` half.
-* **TANG_H tangentiality** (K98 eq. 17) on directed paths. Without it,
-  `MR` admits telekinetic non-meeting concatenations (K98 eq. 70.c).
-  Adding TANG_H requires a `DirectedPath` substrate not yet in linglib.
-* **Cross-dimensional movements** (K98 §4.6: heat, bake, whip — eq. 76-77).
-  Structurally identical to spatial movements; require the same
-  `DirectedPath` generalization.
-* **Full ADJ axioms** on adjacency (K98 §2.3 eq. 14.b). The concrete
-  `Path.adjacent` + `Event.adjacent` satisfy them but the propositional
-  theorems are not added.
-* **`cumOnly` is the formaliser's term, not K98's.** K98 distinguishes
-  verbs that are merely cumulative (CUM, eq. 44) without strict
-  incrementality (¬SINC, ¬MSE). The `VerbIncClass.cumOnly` constructor
-  name is anachronistic shorthand.
-
-## What this file is NOT
-
-* Not a critique of K98's classification — that's `Studies/Filip2012.lean`
-  (three-way CUM / QUA / ¬CUM ∧ ¬QUA via K98 §3.3 propagation).
-* Not a fragment-only verb-annotation file — fragment annotations in
-  `Fragments/English/Predicates/Verbal.lean` are tested per-verb here
-  as a tripwire layer.
-
-## References
-
-* [krifka-1998] (primary, both §3 and §4 covered)
-* [krifka-1989] (sister paper: `Studies/Krifka1989.lean`)
-* [vendler-1957] (Vendler classes used in Part I § 6)
-* [filip-2012] (downstream critique: `Studies/Filip2012.lean`)
+* TEL ⊋ QUA strict witness: a telic non-QUA predicate (K98's 3-to-4-pm case)
+  needs a concrete event model; `isTelic_of_qua` covers only `QUA → TEL`.
+* TANG_H tangentiality (K98 eq. 17) on directed paths, without which `MR`
+  admits telekinetic concatenations (K98 eq. 70.c).
+* Cross-dimensional movements (K98 §4.6: heat, bake, whip).
+* Full ADJ axioms on adjacency (K98 §2.3 eq. 14.b).
 -/
 
 namespace Krifka1998
 
-open English.Predicates.Verbal
 open Features
-open Semantics.Lexical
 open _root_.Mereology
 open Semantics.ArgumentStructure (UP CumTheta IsCumThetaVerb)
-open Semantics.Aspect.Incremental (SINC VerbIncClass IsSincVerb IsIncVerb)
+open Semantics.Aspect.Incremental (SINC IsSincVerb IsIncVerb)
 open Semantics.Aspect.Cumulativity (VP cum_propagation qua_propagation)
 open Semantics.Spatial (Trace)
-open Semantics.Spatial.Trace (pathShapeToTelicity)
-open Semantics.Spatial.Path (PathShape)
-open Core.Order (LicensingPipeline)
-open Features (forXPrediction inXPrediction DiagnosticResult)
+open Features (forXPrediction inXPrediction)
 
-/-! ### Per-Verb Incrementality Verification -/
+/-! ### K98 §3.3 propagation (typeclass form)
 
-/-! Each verb's `verbIncClass` annotation is verified by `rfl`. Changing
-    any annotation breaks exactly one theorem here. These earn their
-    place as fragment-annotation tripwires; mathlib would call them
-    `example`s, but as `theorem`s they're discoverable via `#check`. -/
-
-/-- "eat" is strictly incremental (consumption: bijective theme-event map). -/
-theorem eat_sinc : eat.toVerb.verbIncClass = some .sinc := rfl
-
-/-- "devour" is strictly incremental (consumption variant of eat). -/
-theorem devour_sinc : devour.toVerb.verbIncClass = some .sinc := rfl
-
-/-- "build" is strictly incremental (creation: bijective theme-event map). -/
-theorem build_sinc : build.toVerb.verbIncClass = some .sinc := rfl
-
-/-- "write" is strictly incremental (creation verb). -/
-theorem write_sinc : write.toVerb.verbIncClass = some .sinc := rfl
-
-/-- "read" is incremental but not strictly so (allows re-reading per K98 §3.6). -/
-theorem read_inc : read.toVerb.verbIncClass = some .inc := rfl
-
-/-- "push" is cumulative only (no incremental theme — the formaliser's
-    "cumOnly" is shorthand; K98 calls it CUM-without-MSE/MSO). -/
-theorem push_cumOnly : push.toVerb.verbIncClass = some .cumOnly := rfl
-
-/-- "pull" is cumulative only. -/
-theorem pull_cumOnly : pull.toVerb.verbIncClass = some .cumOnly := rfl
-
-/-- "carry" is cumulative only. -/
-theorem carry_cumOnly : carry.toVerb.verbIncClass = some .cumOnly := rfl
-
-/-- "drag" is cumulative only. -/
-theorem drag_cumOnly : drag.toVerb.verbIncClass = some .cumOnly := rfl
-
-/-- Intransitives have no incremental theme. -/
-theorem sleep_no_inc : sleep.toVerb.verbIncClass = none := rfl
-theorem run_no_inc : run.toVerb.verbIncClass = none := rfl
-
-/-- Unaccusatives have no incremental theme. -/
-theorem arrive_no_inc : arrive.toVerb.verbIncClass = none := rfl
-
-/-- Contact verbs have no incremental theme. -/
-theorem kick_no_inc : kick.toVerb.verbIncClass = none := rfl
-
-/-! ### Per-Verb Vendler Class Verification -/
-
-/-- "sleep" is a state. -/
-theorem sleep_state : sleep.toVerb.vendlerClass = some .state := rfl
-
-/-- "run" is an activity. -/
-theorem run_activity : run.toVerb.vendlerClass = some .activity := rfl
-
-/-- "arrive" is an achievement. -/
-theorem arrive_achievement : arrive.toVerb.vendlerClass = some .achievement := rfl
-
-/-- "eat" is an accomplishment (with quantized object). -/
-theorem eat_accomplishment : eat.toVerb.vendlerClass = some .accomplishment := rfl
-
-/-- "build" is an accomplishment. -/
-theorem build_accomplishment : build.toVerb.vendlerClass = some .accomplishment := rfl
-
-/-- "read" is an accomplishment. -/
-theorem read_accomplishment : read.toVerb.vendlerClass = some .accomplishment := rfl
-
-/-- "write" is an accomplishment. -/
-theorem write_accomplishment : write.toVerb.vendlerClass = some .accomplishment := rfl
-
-/-- "kick" is an activity (semelfactive/contact). -/
-theorem kick_activity : kick.toVerb.vendlerClass = some .activity := rfl
-
-/-- "see" is a state (perception). -/
-theorem see_state : see.toVerb.vendlerClass = some .state := rfl
-
-/-- "leave" is an achievement. -/
-theorem leave_achievement : leave.toVerb.vendlerClass = some .achievement := rfl
-
-/-- "push" is an activity. -/
-theorem push_activity : push.toVerb.vendlerClass = some .activity := rfl
-
-/-- "love" is a state. -/
-theorem love_state : love.toVerb.vendlerClass = some .state := rfl
-
-/-! ### VendlerClass → MereoTag Bridge -/
-
-/-! These connect the Vendler classification to K89's CUM/QUA distinction
-    via `Telicity.toMereoTag`. The chain is:
-    VendlerClass → Telicity → MereoTag → CUM/QUA mereological property.
-
-    **Caveat: TEL ⊋ QUA in K98, but collapsed here.** K98 §2.5 eq. 37
-    defines TEL_E (telicity) strictly weaker than QUA (quantization):
-    every QUA predicate is TEL, but not every TEL predicate is QUA (K98
-    gives the run-time-3-to-4-pm counterexample). The
-    `Telicity.toMereoTag .telic = .qua` collapse used here is faithful for
-    the typical Vendler-class accomplishments and achievements (which are
-    both TEL and QUA): `isTelic_of_qua` proves the `QUA → TEL` direction
-    those classes rely on. The full TEL ⊋ QUA gap (a telic non-QUA
-    predicate) is not collapsed by `toMereoTag`; the `IsTelic` predicate in
-    the `### K98 §2.5` section above states the distinct, weaker notion. -/
-
-/-- Accomplishments are telic, hence (under the TEL = QUA collapse) QUA. -/
-theorem accomplishment_is_qua :
-    VendlerClass.accomplishment.telicity.toMereoTag = .qua := rfl
-
-/-- Achievements are telic, hence QUA. -/
-theorem achievement_is_qua :
-    VendlerClass.achievement.telicity.toMereoTag = .qua := rfl
-
-/-- Activities are atelic, hence CUM. -/
-theorem activity_is_cum :
-    VendlerClass.activity.telicity.toMereoTag = .cum := rfl
-
-/-- States are atelic, hence CUM. -/
-theorem state_is_cum :
-    VendlerClass.state.telicity.toMereoTag = .cum := rfl
-
-/-! ### Compositional Telicity (VP = verb + NP) -/
-
-/-! The payoff: verb incrementality + NP reference property → VP telicity.
-    These instantiate K98 §3.3 (eq. 53-54) for concrete verb entries.
-
-    Round-1 audit additions: propositional invocations of K98 theory's
-    `cum_propagation` and `qua_propagation` on abstract θ instances
-    (parallel to K89 study §3's `qmod_of_cum_is_qua` calls), making the
-    Bool-tag conjunctions below into substrate-honest derivations
-    rather than stipulated `⟨rfl, rfl⟩`. -/
-
-/-- "eat apples": sinc verb + CUM NP → CUM VP (atelic).
-    K98 §3.3: CumTheta(θ) ∧ CUM(OBJ) → CUM(VP θ OBJ).
-    The verb's incrementality class is sinc, and bare plurals are CUM. -/
-theorem eat_apples_atelic :
-    eat.toVerb.verbIncClass = some .sinc ∧
-    VendlerClass.activity.telicity.toMereoTag = .cum := ⟨rfl, rfl⟩
-
-/-- "eat two apples": sinc verb + QUA NP → QUA VP (telic).
-    K98 §3.3: SINC(θ) ∧ QUA(OBJ) → QUA(VP θ OBJ).
-    The verb's incrementality class is sinc, and "two apples" is QUA. -/
-theorem eat_two_apples_telic :
-    eat.toVerb.verbIncClass = some .sinc ∧
-    VendlerClass.accomplishment.telicity.toMereoTag = .qua := ⟨rfl, rfl⟩
-
-/-- "build a house": sinc verb + QUA NP → QUA VP (telic). -/
-theorem build_a_house_telic :
-    build.toVerb.verbIncClass = some .sinc ∧
-    VendlerClass.accomplishment.telicity.toMereoTag = .qua := ⟨rfl, rfl⟩
-
-/-- "read the book": inc verb + QUA NP → VP is telic
-    (INC is weaker than SINC, but still transmits QUA from NP to VP
-    when the object is quantized, K98 §3.6). -/
-theorem read_the_book_telic :
-    read.toVerb.verbIncClass = some .inc ∧
-    VendlerClass.accomplishment.telicity.toMereoTag = .qua := ⟨rfl, rfl⟩
-
-/-- "push the cart": cumOnly verb → no telicity transfer from NP.
-    Regardless of the NP's reference property, cumOnly verbs yield
-    atelic (CUM) VPs. -/
-theorem push_the_cart_atelic :
-    push.toVerb.verbIncClass = some .cumOnly := rfl
-
-/-- "write a letter": sinc verb + QUA NP → QUA VP (telic). -/
-theorem write_a_letter_telic :
-    write.toVerb.verbIncClass = some .sinc ∧
-    VendlerClass.accomplishment.telicity.toMereoTag = .qua := ⟨rfl, rfl⟩
-
-/-! ### §4.5 Propositional propagation invocations (typeclass form)
-
-    The Bool-tag conjunctions above check fragment annotations and tag
-    composition; the theorems below actually invoke K98 theory's
-    `cum_propagation` and `qua_propagation` (typeclass-canonical
-    forms) on abstract θ + OBJ instances. This is the same shape as
-    K89 study §3's calls of `qmod_of_cum_is_qua` — making the
-    substrate-bridge promise concrete rather than rhetorical. -/
+    `cum_propagation` / `qua_propagation` on abstract θ + OBJ instances. -/
 
 section PropositionalPropagation
 
@@ -311,16 +89,8 @@ end PropositionalPropagation
 
 /-! ### Diagnostic Bridge -/
 
-/-! Connect CUM/QUA → for/in diagnostic compatibility.
-    Atelic (CUM) VPs accept "for X"; telic (QUA) VPs accept "in X".
-
-    Round-1 audit deletions: 6 per-verb `inXPrediction .X = .accept := rfl`
-    theorems removed — they were tautological restatements of the
-    `Diagnostics.inXPrediction` definition (since `eat_two_apples_licenses_inX`
-    and `build_a_house_licenses_inX` had identical statements, both
-    passing `.accomplishment`, neither was about a specific verb). The
-    general `telic_licenses_inX` and `durative_atelic_licenses_forX`
-    below carry the diagnostic bridge work. -/
+/-! CUM/QUA → for/in diagnostic compatibility: atelic (CUM) VPs accept
+    "for X", telic (QUA) VPs accept "in X". -/
 
 /-- Telic VPs (QUA) license "in X" adverbials. -/
 theorem telic_licenses_inX (c : VendlerClass) (h : c.telicity = .telic) :
@@ -334,267 +104,16 @@ theorem durative_atelic_licenses_forX (c : VendlerClass)
     forXPrediction c = .accept := by
   cases c <;> simp_all [VendlerClass.telicity, VendlerClass.duration, forXPrediction]
 
-/-! ### Cross-Verification: Incrementality × Vendler -/
-
-/-! Verify that incrementality annotations are consistent with Vendler
-    classes: only accomplishments can have non-none verbIncClass. -/
-
-/-- All sinc-annotated verbs are accomplishments. -/
-theorem sinc_verbs_are_accomplishments :
-    eat.toVerb.vendlerClass = some .accomplishment ∧
-    devour.toVerb.vendlerClass = some .accomplishment ∧
-    build.toVerb.vendlerClass = some .accomplishment ∧
-    write.toVerb.vendlerClass = some .accomplishment := ⟨rfl, rfl, rfl, rfl⟩
-
-/-- The inc-annotated verb "read" is an accomplishment. -/
-theorem inc_verb_is_accomplishment :
-    read.toVerb.vendlerClass = some .accomplishment := rfl
-
-/-- All cumOnly-annotated verbs are activities. -/
-theorem cumOnly_verbs_are_activities :
-    push.toVerb.vendlerClass = some .activity ∧
-    pull.toVerb.vendlerClass = some .activity ∧
-    carry.toVerb.vendlerClass = some .activity ∧
-    drag.toVerb.vendlerClass = some .activity := ⟨rfl, rfl, rfl, rfl⟩
-
-/-! ## Gradual Change (GRAD) Predictions -/
-
-/-! Connects GRAD theory to concrete verb entries.
-
-    Round-1 audit fixes: `GRADDatum.verb : String` and
-    `GRADDatum.objectMeasure : String` were the round-2-K89 String-field
-    anti-pattern recreated; replaced with `GRADVerb` enum +
-    `GRADObjectMeasure` enum. `native_decide` on `all_grad_data_matches`
-    eliminated by structurally lifting the verb match into the enum's
-    `toIncClass` projection. -/
-
-/-- Verbs covered by the GRAD-prediction data. -/
-inductive GRADVerb where
-  | eat | build | read | push | kick
-  deriving DecidableEq, Repr
-
-/-- English lemma for each GRAD verb. -/
-def GRADVerb.lemma : GRADVerb → String
-  | .eat => "eat"
-  | .build => "build"
-  | .read => "read"
-  | .push => "push"
-  | .kick => "kick"
-
-/-- Each verb's expected `VerbIncClass` per K98. Defined as literal
-    constructors so that `decide` can close `all_grad_data_matches`
-    structurally; the fragment-annotation tripwire is the separate
-    `gradVerb_matches_fragment` theorem below. -/
-def GRADVerb.expectedIncClass : GRADVerb → Option VerbIncClass
-  | .eat => some .sinc
-  | .build => some .sinc
-  | .read => some .inc
-  | .push => some .cumOnly
-  | .kick => none
-
-/-- Tripwire: each `GRADVerb.expectedIncClass` matches the fragment's
-    `verbIncClass` annotation. If a fragment annotation drifts, this
-    theorem breaks per-verb (one conjunct per verb). The
-    `expectedIncClass` literal is what `decide` consumes for
-    `all_grad_data_matches`; this theorem keeps the literal in sync
-    with the fragment. -/
-theorem gradVerb_matches_fragment :
-    GRADVerb.eat.expectedIncClass = eat.toVerb.verbIncClass ∧
-    GRADVerb.build.expectedIncClass = build.toVerb.verbIncClass ∧
-    GRADVerb.read.expectedIncClass = read.toVerb.verbIncClass ∧
-    GRADVerb.push.expectedIncClass = push.toVerb.verbIncClass ∧
-    GRADVerb.kick.expectedIncClass = kick.toVerb.verbIncClass :=
-  ⟨rfl, rfl, rfl, rfl, rfl⟩
-
-/-- The dimension along which a verb's GRAD measure operates. -/
-inductive GRADObjectMeasure where
-  | weightOrVolume    -- consumption verbs
-  | proportionDone    -- creation verbs
-  | pages             -- read
-  | weight            -- push
-  | force             -- kick (no GRAD)
-  deriving DecidableEq, Repr
-
-structure GRADDatum where
-  verb : GRADVerb
-  objectMeasure : GRADObjectMeasure
-  expectsGRAD : Bool
-  deriving Repr, DecidableEq
-
-def eatGRAD : GRADDatum :=
-  { verb := .eat, objectMeasure := .weightOrVolume, expectsGRAD := true }
-def buildGRAD : GRADDatum :=
-  { verb := .build, objectMeasure := .proportionDone, expectsGRAD := true }
-def readGRAD : GRADDatum :=
-  { verb := .read, objectMeasure := .pages, expectsGRAD := true }
-def pushNoGRAD : GRADDatum :=
-  { verb := .push, objectMeasure := .weight, expectsGRAD := false }
-def kickNoGRAD : GRADDatum :=
-  { verb := .kick, objectMeasure := .force, expectsGRAD := false }
-
-def gradData : List GRADDatum :=
-  [eatGRAD, buildGRAD, readGRAD, pushNoGRAD, kickNoGRAD]
-
-/-- Whether a verb's incrementality class predicts GRAD.
-
-    This is a Bool projection of K98 theory's propositional `GRAD`
-    predicate; the
-    propositional version is what `grad_of_sinc` proves. Keeping the
-    Bool-tag projection here as a quick-check; consumers needing the
-    propositional content should use `grad_of_sinc` directly on
-    abstract θ instances. -/
-def predictsGRAD : Option VerbIncClass → Bool
-  | some .sinc => true
-  | some .inc => true
-  | some .cumOnly => false
-  | none => false
-
--- Per-verb GRAD verification (fragment-tripwire)
-
-theorem eat_predicts_grad :
-    predictsGRAD eat.toVerb.verbIncClass = true := rfl
-theorem build_predicts_grad :
-    predictsGRAD build.toVerb.verbIncClass = true := rfl
-theorem read_predicts_grad :
-    predictsGRAD read.toVerb.verbIncClass = true := rfl
-theorem push_no_grad :
-    predictsGRAD push.toVerb.verbIncClass = false := rfl
-theorem kick_no_grad :
-    predictsGRAD kick.toVerb.verbIncClass = false := rfl
-
-/-- All GRAD data matches the K98-expected verb classification. The
-    `decide` closure works because `verb.expectedIncClass` is
-    structurally reducible (literal-tag enum), unlike a fragment-
-    projection that goes through `Verbal.lean`'s `VerbEntry`. The
-    fragment-annotation tripwire is `gradVerb_matches_fragment`. -/
-theorem all_grad_data_matches :
-    gradData.all (fun d => predictsGRAD d.verb.expectedIncClass == d.expectsGRAD) = true := by
-  decide
-
-/-! ### K98 §3.5 Eq. 58: Mary ate peanuts in 0.43 seconds -/
-
-/-! K98 §3.5 (page 18, eq. 58) introduces *Mary is an incredibly fast
-    eater. Yesterday she ate peanuts in 0.43 seconds!* — K98's own
-    version of K89 §5's *Ann drank wine in 0.43 sec*. K98 uses it to
-    argue that **temporal atomicity** (not quantization) is what
-    licenses *in*-X adverbials: "even though *eat peanuts* is not
-    quantized, it can be understood as temporally atomic. One chewing
-    move may be a part of an event of eating peanuts, but not yet an
-    event of eating peanuts."
-
-    The K89 study has an analogous ATM section (citing K89 T4); this
-    file mirrors it for K98 §3.5. The substrate-witness theorem
-    (showing a CUM-but-temporally-atomic predicate accepts *in*-X)
-    requires event-CEM atom infrastructure beyond this file's scope;
-    documented as data + linguistic motivation. -/
-
-/-- The K98 §3.5 atomicity-vs-quantization argument has three structural
-    parts: the object NP's mereological reference type, the VP's
-    licensing condition for *in*-X, and the temporal-atomicity flag
-    that licenses *in*-X even when QUA fails. Captured here as a
-    structure with enum-typed fields (`MereoTag`, `DiagnosticResult`)
-    rather than a triple of `Bool`s — Bool tags would be the round-2
-    K89 anti-pattern. -/
-structure K98AtomicityDatum where
-  sentence : String
-  objectNP : String
-  /-- Object NP's mereo reference type per K98 §3.3 (CUM or QUA). -/
-  objectRef : Core.Order.MereoTag
-  /-- Diagnostic acceptance per K98 §3.4. -/
-  inXAcceptance : DiagnosticResult
-  deriving Repr
-
-/-- *Mary ate peanuts in 0.43 seconds* (K98 §3.5 eq. 58). The peanuts
-    NP is CUM (mass-bare-plural — bare plurals are CUM via algebraic
-    closure, cf. K89 §3 / `Krifka1989.applesNP`). The bounded-duration
-    eating predicate is temporally atomic — no sub-event of a 0.43-second
-    peanut-eating is also a 0.43-second peanut-eating. K98 §3.5 argues
-    this licenses *in*-X via temporal atomicity, not quantization. -/
-def maryAtePeanutsIn043Sec : K98AtomicityDatum :=
-  { sentence := "Mary ate peanuts in 0.43 seconds",
-    objectNP := "peanuts",
-    objectRef := .cum,
-    inXAcceptance := .accept }
-
-/-- The K98 §3.5 eq. 58 witness pattern: CUM object + accepted *in*-X.
-    The combination is unusual — typical *in*-X licensing requires QUA
-    objects via the K98 §3.3 propagation chain. K98 introduces this
-    case to motivate temporal atomicity as an alternative licensing
-    pathway. K89 §5 makes the parallel point with *Ann drank wine in
-    0.43 sec* (formalized in `Krifka1989.annDrankWineInSeconds`); this
-    is K98's same observation reformulated as temporal atomicity. The
-    propositional ATM-but-not-QUA witness is deferred (requires
-    event-CEM atom infrastructure beyond this file's scope, as
-    documented in K89 study §5). -/
-theorem k98_eq58_cum_object_accepts_inX :
-    maryAtePeanutsIn043Sec.objectRef = Core.Order.MereoTag.cum ∧
-    maryAtePeanutsIn043Sec.inXAcceptance = DiagnosticResult.accept := ⟨rfl, rfl⟩
-
-/-! ### K89 ↔ K98 Sister-Paper Bridge -/
-
-/-! K89 (1989) and K98 (1998) are the same author refining the same
-    theory at two stages. K89 study now defines
-    `K89ThematicClass.toVerbIncClass` in `Studies/Krifka1989.lean`,
-    mapping K89's table-14 thematic-relation classes to K98's
-    `VerbIncClass`. This section provides the K98-side acknowledgement
-    of the bridge: every K89 thematic class corresponds to exactly one
-    K98 VerbIncClass, and the refinement is consistent with K89's GRAD
-    distinction (gradual classes → sinc/inc, non-gradual → cumOnly).
-
-    The K89 study's `k89Table14_refines_k98_consistently` provides the
-    propositional bridge; this section adds K98-side documentation and
-    a fragment-verb ↔ K89-class consistency theorem for *eat*. -/
-
-/-- K89's *eat an apple* (gradual-consumed-patient) refines to K98 sinc
-    (consumption verb), which matches the *eat* fragment annotation.
-    Cross-paper consistency for the eat verb across K89 §4, K98 §3,
-    and the fragment. -/
-theorem eat_refinement_chain :
-    Krifka1989.eatAnApple.thematicClass = .gradualConsumedPatient ∧
-    Krifka1989.eatAnApple.thematicClass.toVerbIncClass = .sinc ∧
-    eat.toVerb.verbIncClass = some .sinc := ⟨rfl, rfl, rfl⟩
-
-/-- K89's *write a letter* (gradual-effected-patient) refines to K98
-    sinc, matching *write*'s fragment annotation. K89's distinction
-    between effected (creation) and consumed (consumption) patients
-    is finer than K98's binary sinc/non-sinc; both collapse to sinc
-    here. -/
-theorem write_refinement_chain :
-    Krifka1989.writeALetter.thematicClass = .gradualEffectedPatient ∧
-    Krifka1989.writeALetter.thematicClass.toVerbIncClass = .sinc ∧
-    write.toVerb.verbIncClass = some .sinc := ⟨rfl, rfl, rfl⟩
-
-/-- K89's *read a letter* (gradual-patient, lacks UNI-E) refines to
-    K98 inc — matching *read*'s fragment annotation, which K98 §3.6
-    eq. 59 motivates by appeal to backups (re-reading). -/
-theorem read_refinement_chain :
-    Krifka1989.readALetter.thematicClass = .gradualPatient ∧
-    Krifka1989.readALetter.thematicClass.toVerbIncClass = .inc ∧
-    read.toVerb.verbIncClass = some .inc := ⟨rfl, rfl, rfl⟩
-
 /-! ### Concrete `IsSincVerb` Toy + Applied Propagation -/
 
-/-! §4.5's `eat_apples_cum_propositional` and `eat_two_apples_qua_propositional`
-    are parametric over an abstract θ. This section provides a
-    constructive `IsSincVerb` instance and *fires* both propagation
-    theorems on it, demonstrating that K98 §3.3's typeclass-bundled
-    meaning postulates admit real (non-axiomatic) realizations.
+/-! `eat_apples_cum_propositional` / `eat_two_apples_qua_propositional` are
+    parametric over abstract θ; here a constructive `IsSincVerb` instance
+    *fires* both, showing K98 §3.3's typeclass-bundled postulates admit
+    non-axiomatic realizations.
 
-    The toy: a 3-apple universe modelled as `Finset (Fin 3)` (powerset
-    lattice; ⊔ = ∪, < = ⊊). The eating relation is the identity
-    `eatThemeToy a e := a = e` — the eating event is identified with
-    the apple set eaten. Each subevent of an eating-of-{0,1}
-    corresponds bijectively to a subobject (the apples eaten in that
-    subevent), which is exactly the SINC bijection.
-
-    Lexical commitment: this is a TOY model, not a faithful denotation
-    of *eat*. A real denotation would (i) use a richer event type with
-    manner/agent/time information, (ii) admit non-trivial UO failures
-    (two distinct eatings of the same apple), and (iii) interact with
-    `Fragments/English/Predicates/Verbal.lean`'s `eat.semantics`. The
-    purpose here is to demonstrate that the typeclass admits
-    constructive instances — bridging the gap that prior `class
-    VerbIncrementality` attempts left open. -/
+    The toy: a 3-apple universe `Finset (Fin 3)` (⊔ = ∪, < = ⊊), with the
+    identity theme `eatThemeToy a e := a = e` giving the SINC bijection. It is
+    a toy, not a faithful denotation of *eat*. -/
 
 section ToyEatInstance
 
@@ -613,10 +132,8 @@ abbrev EatEvent : Type := Finset (Fin 3)
     sub-objects (subsets of `a`) and proper sub-events. -/
 def eatThemeToy (a : Apple) (e : EatEvent) : Prop := a = e
 
-/-- The SINC structure for `eatThemeToy`. All five component conditions
-    (MSO / UO / MSE / UE / extended) follow from the identity nature
-    of the relation. The non-degeneracy condition `extended` is
-    witnessed by `{0, 1}` (whole) and `{0}` (proper part). -/
+/-- The SINC structure for `eatThemeToy`: all five conditions follow from
+    the identity, with `extended` witnessed by `{0} ⊂ {0, 1}`. -/
 private def eatThemeToy_sinc : SINC eatThemeToy where
   mso := by
     intro x e e' hθ hlt
@@ -637,15 +154,7 @@ private def eatThemeToy_sinc : SINC eatThemeToy where
     · rw [← hθ]; exact hle
     · intro e'' _ he''; exact he''.symm
   extended := by
-    refine ⟨{0, 1}, {0}, {0, 1}, {0}, ?_, ?_, rfl, rfl⟩
-    · refine Finset.ssubset_iff_of_subset ?_ |>.mpr ⟨1, ?_, ?_⟩
-      · intro a ha; simp at ha; subst ha; simp
-      · simp
-      · simp
-    · refine Finset.ssubset_iff_of_subset ?_ |>.mpr ⟨1, ?_, ?_⟩
-      · intro a ha; simp at ha; subst ha; simp
-      · simp
-      · simp
+    refine ⟨{0, 1}, {0}, {0, 1}, {0}, ?_, ?_, rfl, rfl⟩ <;> decide
 
 /-- UP for `eatThemeToy`: identity-as-relation gives x = y trivially. -/
 private theorem eatThemeToy_up : UP eatThemeToy := by
@@ -720,139 +229,14 @@ end ToyEatInstance
 
 /-! ## Part II — K98 §4: Telicity by Precedence and Adjacency -/
 
-/-! ### Per-verb path specification (K98 §4.5 eq. 73) -/
-
-/-- "arrive" is inherently directed motion (K98 §4.7 eq. 78). -/
-theorem arrive_levinClass :
-    arrive.toVerb.levinClass = some .inherentlyDirectedMotion := rfl
-
-/-- Inherently directed motion → bounded path (K98 §4.5 GOAL specified). -/
-theorem arrive_pathSpec :
-    LevinClass.inherentlyDirectedMotion.pathSpec = some .bounded := rfl
-
-/-- "leave" is a leave verb (K98 §4.5 SOURCE-only). -/
-theorem leave_levinClass :
-    leave.toVerb.levinClass = some .leave := rfl
-
-/-- Leave verbs → source path. -/
-theorem leave_pathSpec :
-    LevinClass.leave.pathSpec = some .source := rfl
-
-/-- "run" is manner-of-motion (K98 §4.5 path-neutral; PP supplies path). -/
-theorem run_levinClass :
-    run.toVerb.levinClass = some .mannerOfMotion := rfl
-
-/-- Manner-of-motion verbs are path-neutral (path comes from PP). -/
-theorem run_pathSpec :
-    LevinClass.mannerOfMotion.pathSpec = none := rfl
-
--- Fragment-grounding drift sentries: changing a fragment annotation in
--- `Fragments/English/Predicates/Verbal.lean` breaks exactly one theorem.
-
-/-- *arrive* is annotated as an achievement Vendler class. -/
-theorem arrive_vendlerClass_achievement :
-    arrive.toVerb.vendlerClass = some .achievement := rfl
-
-/-- *sleep* is annotated as a state Vendler class. -/
-theorem sleep_vendlerClass_state :
-    sleep.toVerb.vendlerClass = some .state := rfl
-
-/-! ### PathShape → Telicity → Licensing (K98 §4 MR eq. 71) -/
-
-/-- Bounded path → telic → licensed. K98 §4 eq. 74 *walked from X to Y*. -/
-theorem bounded_pipeline :
-    pathShapeToTelicity .bounded = .telic ∧
-    LicensingPipeline.IsLicensed PathShape.bounded := ⟨rfl, trivial⟩
-
-/-- Source path → telic → licensed. K98 §4 eq. 73 *Mary left the house*. -/
-theorem source_pipeline :
-    pathShapeToTelicity .source = .telic ∧
-    LicensingPipeline.IsLicensed PathShape.source := ⟨rfl, trivial⟩
-
-/-- Unbounded path → atelic → blocked. K98 §4 eq. 75 *walked towards X*. -/
-theorem unbounded_pipeline :
-    pathShapeToTelicity .unbounded = .atelic ∧
-    ¬ LicensingPipeline.IsLicensed PathShape.unbounded := ⟨rfl, id⟩
-
-/-! ### Motion VP data (K98 §4.5 eq. 74-75) -/
-
-/-- A motion VP datum: verb + PP + path shape + expected telicity. -/
-structure MotionVPDatum where
-  verb : String
-  pp : String
-  pathShape : PathShape
-  expectedTelicity : Telicity
-  deriving Repr, DecidableEq
-
-/-- "arrive at the store" — bounded → telic → "in X" ✓. K98 §4.7 eq. 78. -/
-def arriveAtStore : MotionVPDatum :=
-  { verb := "arrive", pp := "at the store",
-    pathShape := .bounded, expectedTelicity := .telic }
-
-/-- "leave the house" — source → telic → "in X" ✓. K98 §4.5 eq. 73. -/
-def leaveTheHouse : MotionVPDatum :=
-  { verb := "leave", pp := "the house",
-    pathShape := .source, expectedTelicity := .telic }
-
-/-- "run to the park" — manner + bounded PP → telic → "in X" ✓. K98 eq. 74. -/
-def runToThePark : MotionVPDatum :=
-  { verb := "run", pp := "to the park",
-    pathShape := .bounded, expectedTelicity := .telic }
-
-/-- "run towards the park" — manner + unbounded PP → atelic → "for X" ✓.
-    K98 §4.5 eq. 75 *walked towards Y* — direction without goal. -/
-def runTowardsThePark : MotionVPDatum :=
-  { verb := "run", pp := "towards the park",
-    pathShape := .unbounded, expectedTelicity := .atelic }
-
-def motionData : List MotionVPDatum :=
-  [arriveAtStore, leaveTheHouse, runToThePark, runTowardsThePark]
-
-/-- Path shape determines telicity for all motion data per K98 §4. -/
-theorem all_motion_data_correct :
-    motionData.all (fun d =>
-      pathShapeToTelicity d.pathShape == d.expectedTelicity) = true := by
-  decide
-
-/-! ### §3 ↔ §4 diagnostic bridge (K98 §3 in/for) -/
-
-/-- "arrive" (achievement, bounded path) licenses "in X". -/
-theorem arrive_inX :
-    arrive.toVerb.vendlerClass = some .achievement ∧
-    inXPrediction .achievement = .accept := ⟨rfl, rfl⟩
-
-/-- "leave" (achievement, source path) licenses "in X". -/
-theorem leave_inX :
-    leave.toVerb.vendlerClass = some .achievement ∧
-    inXPrediction .achievement = .accept := ⟨rfl, rfl⟩
-
-/-- "run" (activity, path-neutral) licenses "for X". -/
-theorem run_forX :
-    run.toVerb.vendlerClass = some .activity ∧
-    forXPrediction .activity = .accept := ⟨rfl, rfl⟩
-
-/-- Motion verb VendlerClass × LevinClass coherence: bounded-path motion
-    verbs are achievements, path-neutral ones are activities. -/
-theorem motion_vendler_path_coherence :
-    (arrive.toVerb.vendlerClass = some .achievement ∧
-      LevinClass.inherentlyDirectedMotion.pathSpec = some .bounded) ∧
-    (leave.toVerb.vendlerClass = some .achievement ∧
-      LevinClass.leave.pathSpec = some .source) ∧
-    (run.toVerb.vendlerClass = some .activity ∧
-      LevinClass.mannerOfMotion.pathSpec = none) :=
-  ⟨⟨rfl, rfl⟩, ⟨rfl, rfl⟩, ⟨rfl, rfl⟩⟩
-
 /-! ### K98 §2.5 — Initial/final parts and telicity (TEL)
 
-K98 §2.5 eq. 36 defines the initial and final parts of an event via the
-precedence relation `«E`; eq. 37 defines telicity (TEL) of a predicate:
-every P-part of a P-event is both an initial and a final part of it. TEL is
-strictly weaker than `QUA` — every quantized predicate is telic
-(`isTelic_of_qua`), but not conversely: K98's run-time-3-to-4-pm predicate
-is telic without being quantized. Generic over a part order and a
-precedence relation, mirroring the §4 substrate below; specialize with
-`Event.precedes`. (Migrated here from the orphaned
-`Semantics/Events/InitialFinalParts.lean`, which no module imported.) -/
+K98 §2.5 eq. 36 defines the initial/final parts of an event via the precedence
+relation `«E`; eq. 37 defines telicity (TEL): every P-part of a P-event is both
+an initial and a final part of it. TEL is strictly weaker than `QUA` — every
+quantized predicate is telic (`isTelic_of_qua`), but not conversely (K98's
+3-to-4-pm predicate). Generic over a part order and a precedence relation,
+mirroring the §4 substrate; specialize with `Event.precedes`. -/
 
 section Telicity
 
@@ -880,24 +264,17 @@ theorem isFinalPart_self (e : β) (h : ¬ ∃ e'', e'' ≤ e ∧ precedes e e'')
     IsFinalPart precedes e e :=
   ⟨le_rfl, h⟩
 
-/-- K98 §2.5 eq. 37 propositional telicity (TEL): a predicate `P` is telic
-    iff every P-instance `e'` that is part of a P-instance `e` is both an
-    initial and a final part of `e`. K98: "all parts of e that fall under X
-    are initial and final parts of e." Telicity is a property of the
-    predicate `P`, not of any particular event. -/
+/-- K98 §2.5 eq. 37 telicity (TEL): a predicate `P` is telic iff every P-part
+    `e'` of a P-instance `e` is both an initial and a final part of `e`.
+    Telicity is a property of `P`, not of any particular event. -/
 def IsTelic (P : β → Prop) : Prop :=
   ∀ e e', P e → P e' → e' ≤ e → IsInitialPart precedes e' e ∧ IsFinalPart precedes e' e
 
-/-- K98 §2.5: "it is obvious that quantized predicates are telic" — the `⊇`
-    half of TEL ⊋ QUA. A `QUA` predicate has no proper P-parts, so its only
-    P-part `e' ≤ e` is `e` itself, which is its own initial and final part —
-    *provided* no part of `e` precedes `e`. That proviso is K98 eq. 35
-    (mereologically comparable events never precede each other), supplied
-    here as `hax`. The strict witness (a telic non-QUA predicate, K98's
-    3-to-4-pm case) needs a concrete event model and is not proved here.
-    Note `Event.precedes` does *not* satisfy `hax` — `isBefore` uses `≤`, so
-    it is reflexive on punctual events; a Krifka-faithful strict precedence
-    (`isBefore` with `<`) would. -/
+/-- K98 §2.5: quantized predicates are telic (the `QUA → TEL` half of
+    TEL ⊋ QUA). A `QUA` predicate's only P-part of `e` is `e` itself, which is
+    its own initial and final part provided no part of `e` precedes it — K98
+    eq. 35, here `hax`. `Event.precedes` does not satisfy `hax` (`isBefore`
+    uses `≤`, so it is reflexive on points; the strict `<` form would). -/
 theorem isTelic_of_qua {P : β → Prop}
     (hax : ∀ a b : β, a ≤ b → ¬ precedes a b ∧ ¬ precedes b a) (hQ : QUA P) :
     IsTelic precedes P := by

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -6,6 +6,7 @@ import Linglib.Semantics.Events.Adjacency
 import Linglib.Semantics.Aspect.PrecedenceClosure
 import Linglib.Semantics.Spatial.Trace
 import Linglib.Features.Aktionsart
+import Linglib.Data.Examples.Krifka1998
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Lattice.Basic
 import Mathlib.Data.Fintype.Basic
@@ -38,6 +39,8 @@ This file inlines the §4 movement-relation predicates (formerly in
 * `telic_licenses_inX` / `durative_atelic_licenses_forX` — §3 for/in diagnostics.
 * `walked_from_to_telic_propositional` / `walked_towards_atelic_propositional` —
   σ-pullback backing the *walked from X to Y* / *walked towards X* analyses.
+* `pathShapeToTelicity_matches_motionData` — the substrate reproduces the §4.5
+  path-shape → telicity judgments of the `Data.Examples.Krifka1998` motion rows.
 
 ## TODO
 
@@ -380,6 +383,54 @@ theorem walked_towards_atelic_propositional
   Trace.unbounded_path_atelic hP
 
 end SpatialTracePullback
+
+/-! ### K98 §4.5 motion data: path shape predicts telicity
+
+    Each `Data.Examples.Krifka1998` motion VP row tags its path shape and the
+    paper's telicity judgment; the substrate `pathShapeToTelicity` reproduces
+    every judgment. -/
+
+section MotionData
+
+open Data.Examples (LinguisticExample)
+open Semantics.Spatial.Path (PathShape)
+open Semantics.Spatial.Trace (pathShapeToTelicity)
+
+/-- A motion VP datum: the path shape K98 assigns and the telicity it predicts. -/
+structure MotionDatum where
+  pathShape : PathShape
+  expectedTelicity : Telicity
+  deriving DecidableEq, Repr
+
+private def parsePathShape : String → Option PathShape
+  | "bounded" => some .bounded
+  | "source" => some .source
+  | "unbounded" => some .unbounded
+  | _ => none
+
+private def parseTelicity : String → Option Telicity
+  | "telic" => some .telic
+  | "atelic" => some .atelic
+  | _ => none
+
+/-- Lift a `Data.Examples.Krifka1998` row to a `MotionDatum` via its
+    `pathShape` / `expectedTelicity` paper features. -/
+def fromExample (e : LinguisticExample) : Option MotionDatum := do
+  let ps ← parsePathShape (← e.paperFeatures.lookup "pathShape")
+  let tel ← parseTelicity (← e.paperFeatures.lookup "expectedTelicity")
+  some { pathShape := ps, expectedTelicity := tel }
+
+/-- The K98 §4.5 motion VP data, lifted from the JSON example rows. -/
+def motionData : List MotionDatum :=
+  Examples.all.filterMap fromExample
+
+/-- Substrate prediction: `pathShapeToTelicity` reproduces the paper's telicity
+    judgment for every motion VP (bounded/source → telic, unbounded → atelic). -/
+theorem pathShapeToTelicity_matches_motionData :
+    ∀ d ∈ motionData, pathShapeToTelicity d.pathShape = d.expectedTelicity := by
+  decide
+
+end MotionData
 
 /-! ### EXP / SEINC instances on `Event Time` (K98 §4.1) -/
 


### PR DESCRIPTION
Slims the K98 study (1048→474 lines) to mathlib quality: deletes the unused `:= rfl` / `decide`-over-hand-data tripwire theorems (fragment-annotation restatements nothing consumed) and strips process-narration docstrings, keeping the substrate-exercising results — §3.3 propagation, the constructive `IsSincVerb` toy, §2.5 `isTelic_of_qua`, the §4 movement substrate, and the σ-pullback.

- §4.5 motion VP data → `Data/Examples/Krifka1998.json`; `pathShapeToTelicity_matches_motionData` exercises the substrate over the JSON rows.
- Fixes a now-stale `predictsGRAD` cross-reference in `Krifka1989.lean`.