### PR TITLE
refactor(Studies/Krifka1998): golf toy proof, variable & open cleanup

### DIFF
--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -50,11 +50,12 @@ namespace Krifka1998
 
 open Features
 open _root_.Mereology
-open Semantics.ArgumentStructure (UP CumTheta IsCumThetaVerb)
-open Semantics.Aspect.Incremental (SINC IsSincVerb IsIncVerb)
+open Semantics.ArgumentStructure (IsCumThetaVerb)
+open Semantics.Aspect.Incremental (SINC IsSincVerb)
 open Semantics.Aspect.Cumulativity (VP cum_propagation qua_propagation)
 open Semantics.Spatial (Trace)
-open Features (forXPrediction inXPrediction)
+
+variable {α β : Type*}
 
 /-! ### K98 §3.3 propagation (typeclass form)
 
@@ -62,7 +63,7 @@ open Features (forXPrediction inXPrediction)
 
 section PropositionalPropagation
 
-variable {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
+variable [SemilatticeSup α] [SemilatticeSup β]
 
 /-- *eat apples* (K98 §3.3): a CUM object through any θ propagates to a CUM VP. -/
 theorem eat_apples_cum_propositional
@@ -156,7 +157,7 @@ end ToyEatInstance
 
 section Telicity
 
-variable {β : Type*} [PartialOrder β] (precedes : β → β → Prop)
+variable [PartialOrder β] (precedes : β → β → Prop)
 
 /-- K98 §2.5 eq. 36 INI: `e' ≤ e` and no part of `e` precedes `e'` (printed `≤D` read as `≤`). -/
 def IsInitialPart (e' e : β) : Prop :=
@@ -199,18 +200,18 @@ section K98PropositionalSubstrate
 open Semantics.ArgumentStructure (MO)
 
 /-- K98 §4.1 eq. 63 EXP: θ-arguments of temporally-ordered events do not overlap. -/
-def EXP {α β : Type*} [SemilatticeSup α]
+def EXP [PartialOrder α]
     (precedes : β → β → Prop) (θ : α → β → Prop) : Prop :=
   ∀ (x y : α) (e e' : β),
     θ x e → θ y e' → precedes e e' → ¬ Overlap x y
 
 /-- K98 §4.1 eq. 65 SEINC: strictly expansive incremental. EXP ∧ MO. -/
-def SEINC {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
+def SEINC [SemilatticeSup α] [SemilatticeSup β]
     (precedes : β → β → Prop) (θ : α → β → Prop) : Prop :=
   EXP precedes θ ∧ MO θ
 
 /-- K98 §4.2 eq. 68 ADJ: sub-event temporal adjacency ↔ sub-path spatial adjacency. -/
-def ADJ {α β : Type*} [PartialOrder α] [PartialOrder β]
+def ADJ [PartialOrder α] [PartialOrder β]
     (adjα : α → α → Prop) (adjβ : β → β → Prop)
     (θ : α → β → Prop) : Prop :=
   ∀ (x : α) (e : β) (y z : α) (e' e'' : β),
@@ -218,20 +219,18 @@ def ADJ {α β : Type*} [PartialOrder α] [PartialOrder β]
     θ y e' → θ z e'' → (adjβ e' e'' ↔ adjα y z)
 
 /-- K98 §4.2 eq. 69 SMR: ADJ + MO + first-arg constrained to paths. -/
-def SMR {α β : Type*} [PartialOrder α] [PartialOrder β]
-    [SemilatticeSup α] [SemilatticeSup β]
+def SMR [SemilatticeSup α] [SemilatticeSup β]
     (adjα : α → α → Prop) (adjβ : β → β → Prop)
     (isPath : α → Prop) (θ : α → β → Prop) : Prop :=
   ADJ adjα adjβ θ ∧ MO θ ∧ ∀ x e, θ x e → isPath x
 
 /-- K98 §4.3 eq. 71: smallest θ-extension closed under precedence-respecting sums. -/
-abbrev MovementClosure {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
+abbrev MovementClosure [SemilatticeSup α] [SemilatticeSup β]
     (precedes : β → β → Prop) (θ' : α → β → Prop) : α → β → Prop :=
   Semantics.Aspect.PrecedenceClosure precedes θ'
 
 /-- K98 §4.3 eq. 71 MR (TANG_H-free): θ is the `MovementClosure` of some SMR θ'. -/
-def MR {α β : Type*} [PartialOrder α] [PartialOrder β]
-    [SemilatticeSup α] [SemilatticeSup β]
+def MR [SemilatticeSup α] [SemilatticeSup β]
     (adjα : α → α → Prop) (adjβ : β → β → Prop) (precedes : β → β → Prop)
     (isPath : α → Prop) (θ : α → β → Prop) : Prop :=
   ∃ θ' : α → β → Prop,
@@ -239,8 +238,7 @@ def MR {α β : Type*} [PartialOrder α] [PartialOrder β]
     ∀ x e, θ x e ↔ MovementClosure precedes θ' x e
 
 /-- Every SMR is itself an MR, given closure under precedence-respecting sums. -/
-theorem mr_of_smr {α β : Type*} [PartialOrder α] [PartialOrder β]
-    [SemilatticeSup α] [SemilatticeSup β]
+theorem mr_of_smr [SemilatticeSup α] [SemilatticeSup β]
     {adjα : α → α → Prop} {adjβ : β → β → Prop} {precedes : β → β → Prop}
     {isPath : α → Prop} {θ : α → β → Prop}
     (h : SMR adjα adjβ isPath θ)
@@ -324,8 +322,7 @@ end MotionData
 
 section Expansiveness
 
-variable {α : Type*} [SemilatticeSup α]
-variable {Time : Type*} [LinearOrder Time]
+variable [SemilatticeSup α] {Time : Type*} [LinearOrder Time]
 
 /-- EXP-as-property of any θ : α → Event Time → Prop using `Event.precedes`. -/
 abbrev expEv (θ : α → Event Time → Prop) : Prop :=
@@ -346,7 +343,7 @@ open Semantics.Spatial.Path
 
 variable {Loc Time : Type*} [LinearOrder Time]
 variable [Event.Mereology Time] [ClassicalMereology (Event Time)]
-variable [PartialOrder (Path Loc)] [SemilatticeSup (Path Loc)]
+variable [SemilatticeSup (Path Loc)]
 
 /-- SMR specialized to paths and events with concrete adjacency. -/
 abbrev smrPath (θ : Path Loc → Event Time → Prop) : Prop :=

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -98,15 +98,6 @@ theorem durative_atelic_licenses_forX (c : VendlerClass)
 
 /-! ### Concrete `IsSincVerb` Toy + Applied Propagation -/
 
-/-! `eat_apples_cum_propositional` / `eat_two_apples_qua_propositional` are
-    parametric over abstract θ; here a constructive `IsSincVerb` instance
-    *fires* both, showing K98 §3.3's typeclass-bundled postulates admit
-    non-axiomatic realizations.
-
-    The toy: a 3-apple universe `Finset (Fin 3)` (⊔ = ∪, < = ⊊), with the
-    identity theme `eatThemeToy a e := a = e` giving the SINC bijection. It is
-    a toy, not a faithful denotation of *eat*. -/
-
 section ToyEatInstance
 
 /-- Toy 3-apple universe: `Finset (Fin 3)` with ⊔ = ∪ and ≤/< as ⊆/⊊. -/
@@ -120,48 +111,17 @@ def eatThemeToy (a : Apple) (e : EatEvent) : Prop := a = e
 
 /-- The SINC structure for `eatThemeToy`; every condition follows from the identity. -/
 private def eatThemeToy_sinc : SINC eatThemeToy where
-  mso := by
-    intro x e e' hθ hlt
-    refine ⟨e', ?_, rfl⟩
-    rw [hθ]; exact hlt
-  uo := by
-    intro x e e' hθ hle
-    refine ⟨e', ?_, rfl, ?_⟩
-    · rw [hθ]; exact hle
-    · intro z _ hz; exact hz
-  mse := by
-    intro x e y hθ hlt
-    refine ⟨y, ?_, rfl⟩
-    rw [← hθ]; exact hlt
-  ue := by
-    intro x e y hθ hle
-    refine ⟨y, ?_, rfl, ?_⟩
-    · rw [← hθ]; exact hle
-    · intro e'' _ he''; exact he''.symm
-  extended := by
-    refine ⟨{0, 1}, {0}, {0, 1}, {0}, ?_, ?_, rfl, rfl⟩ <;> decide
-
-/-- UP for `eatThemeToy`: identity-as-relation gives x = y trivially. -/
-private theorem eatThemeToy_up : UP eatThemeToy := by
-  intro x y e hx hy
-  show x = y
-  rw [hx, hy]
-
-/-- CumTheta for `eatThemeToy`: identity-as-relation preserves sums. -/
-private theorem eatThemeToy_cumTheta : CumTheta eatThemeToy := by
-  intro x y e e' hx hy
-  show x ⊔ y = e ⊔ e'
-  rw [hx, hy]
+  mso := fun x e e' hθ hlt => ⟨e', by rw [hθ]; exact hlt, rfl⟩
+  uo := fun x e e' hθ hle => ⟨e', by rw [hθ]; exact hle, rfl, fun z _ hz => hz⟩
+  mse := fun x e y hθ hlt => ⟨y, by rw [← hθ]; exact hlt, rfl⟩
+  ue := fun x e y hθ hle => ⟨y, by rw [← hθ]; exact hle, rfl, by intro e'' _ he''; exact he''.symm⟩
+  extended := ⟨{0, 1}, {0}, {0, 1}, {0}, by decide, by decide, rfl, rfl⟩
 
 /-- `eatThemeToy` is a strictly incremental verb-theme relation (via `IsSincVerb.mk'`). -/
 instance : IsSincVerb eatThemeToy :=
-  IsSincVerb.mk' eatThemeToy_sinc eatThemeToy_up eatThemeToy_cumTheta
-
-/-- `[IsIncVerb eatThemeToy]` synthesises from the `IsSincVerb` instance (K98 §3.6). -/
-example : IsIncVerb eatThemeToy := inferInstance
-
-/-- `[IsCumThetaVerb eatThemeToy]` synthesises transitively from `IsSincVerb`. -/
-example : IsCumThetaVerb eatThemeToy := inferInstance
+  IsSincVerb.mk' eatThemeToy_sinc
+    (by intro x y e hx hy; rw [hx, hy])
+    (by intro x y e e' hx hy; show x ⊔ y = e ⊔ e'; rw [hx, hy])
 
 /-! #### Concrete OBJ predicates -/
 
@@ -193,17 +153,6 @@ theorem eat_some_apples_toy_cum : CUM (VP eatThemeToy someApples) :=
   cum_propagation someApples_cum
 
 end ToyEatInstance
-
-/-! ## Part II — K98 §4: Telicity by Precedence and Adjacency -/
-
-/-! ### K98 §2.5 — Initial/final parts and telicity (TEL)
-
-K98 §2.5 eq. 36 defines the initial/final parts of an event via the precedence
-relation `«E`; eq. 37 defines telicity (TEL): every P-part of a P-event is both
-an initial and a final part of it. TEL is strictly weaker than `QUA` — every
-quantized predicate is telic (`isTelic_of_qua`), but not conversely (K98's
-3-to-4-pm predicate). Generic over a part order and a precedence relation,
-mirroring the §4 substrate; specialize with `Event.precedes`. -/
 
 section Telicity
 
@@ -329,11 +278,7 @@ theorem walked_towards_atelic_propositional
 
 end SpatialTracePullback
 
-/-! ### K98 §4.5 motion data: path shape predicts telicity
-
-    Each `Data.Examples.Krifka1998` motion VP row tags its path shape and the
-    paper's telicity judgment; the substrate `pathShapeToTelicity` reproduces
-    every judgment. -/
+/-! ### K98 §4.5 motion data: path shape predicts telicity -/
 
 section MotionData
 


### PR DESCRIPTION
More mathlib-quality polish on the K98 study (follow-up to #1012):

- Golfs the `eatThemeToy_sinc` SINC proof to term-mode one-liners, inlines `eatThemeToy_up`/`cumTheta` into the instance, drops two synthesis `example`s, and strips leftover prose section-comments.
- Hoists `variable {α β : Type*}` to the file top; weakens `EXP` to `[PartialOrder α]` and drops `[PartialOrder …]` made redundant by `[SemilatticeSup …]` in `SMR`/`MR`/`mr_of_smr`/`MovementInstances`; prunes now-dead `open`s.