### PR TITLE
feat(Core/RootedTree): Planar.fold paramorphism; refound Prosody head terminals on it

### DIFF
--- a/Linglib/Core/Combinatorics/RootedTree/Planar.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Planar.lean
@@ -228,6 +228,53 @@ theorem mapList_eq_listMap {β : Type*} (f : α → β) (cs : List (Planar α)) 
 theorem map_leaf {β : Type*} (f : α → β) (a : α) :
     map f (leaf a) = leaf (f a) := rfl
 
+/-! ### Paramorphism
+
+The general structural-recursion combinator for planar trees. `fold f t` recurses with `f` seeing
+the root label and each child *paired with its own fold* — the pairing (paramorphism, not a bare
+catamorphism `α → List β → β`) lets `f` branch on child labels, e.g. follow a distinguished child.
+Downstream rose-tree folds are then one-liners (`Planar.fold …`) rather than hand-rolled `mutual`
+pairs.
+
+Structural (mutual with the child-list aux), so it reduces — `decide`/`rfl` compute through it. The
+result `β` shares the label universe (so the paired aux `List (Planar α × β)` stays in one
+universe); ample for the usual `β = List (Planar α)`. -/
+
+universe u
+
+mutual
+/-- Paramorphism on a planar tree: `f` receives the root label and each child paired with its
+    `fold`. -/
+def fold {α β : Type u} (f : α → List (Planar α × β) → β) : Planar α → β
+  | .node a cs => f a (foldList f cs)
+/-- Auxiliary: each child paired with its `fold`. -/
+def foldList {α β : Type u} (f : α → List (Planar α × β) → β) :
+    List (Planar α) → List (Planar α × β)
+  | [] => []
+  | c :: cs => (c, fold f c) :: foldList f cs
+end
+
+@[simp] theorem foldList_nil {α β : Type u} (f : α → List (Planar α × β) → β) :
+    foldList f ([] : List (Planar α)) = [] := rfl
+
+@[simp] theorem foldList_cons {α β : Type u} (f : α → List (Planar α × β) → β)
+    (c : Planar α) (cs : List (Planar α)) :
+    foldList f (c :: cs) = (c, fold f c) :: foldList f cs := rfl
+
+/-- `foldList f` pairs each child with its `fold`. Bridge to `List.map`. -/
+theorem foldList_eq {α β : Type u} (f : α → List (Planar α × β) → β) (cs : List (Planar α)) :
+    foldList f cs = cs.map (fun c => (c, fold f c)) := by
+  induction cs with
+  | nil => rfl
+  | cons c cs ih => simp only [foldList_cons, List.map_cons, ih]
+
+/-- The defining recursion of `fold`: at a node, apply `f` to the label and the children paired
+    with their folds. -/
+@[simp] theorem fold_node {α β : Type u} (f : α → List (Planar α × β) → β) (a : α)
+    (cs : List (Planar α)) :
+    fold f (Planar.node a cs) = f a (cs.map fun c => (c, fold f c)) := by
+  rw [show fold f (Planar.node a cs) = f a (foldList f cs) from rfl, foldList_eq]
+
 mutual
 /-- Functoriality: `map id = id`. -/
 @[simp] theorem map_id : ∀ (t : Planar α), map id t = t

--- a/Linglib/Phonology/Prosody/Grid.lean
+++ b/Linglib/Phonology/Prosody/Grid.lean
@@ -10,245 +10,200 @@ syllable, taller standing for greater relative prominence (primary > secondary >
 read off a `Prosody.Tree` by the *Relative Prominence Projection Rule* ([liberman-prince-1977],
 canonized in [prince-1983]) — one mark per syllable, one more per layer of headedness above it.
 
-The fold underneath is `gridColumnsLive`, the **head-projection** computation: each `Column` is
+The fold underneath is `Grid.columnsLive`, the **head-projection** computation: each `Grid.Column` is
 tagged `live` while its leaf is still the **head terminal** (Liberman & Prince's *designated
-terminal element*) of every node up to the root. `gridColumns` is its height projection, *by
-definition* (`gridColumns_eq_live`); `headHeights`/`headTerminals` read the live columns' heights
-and leaves. This is the *determinate* bracketed grid of Halle & Vergnaud 1987 / [hayes-1995] — our
-`Tree` *is* the bracketed grid, `toGrid` the forgetful map onto the pure grid. What it forgets is
-*theorem*-shaped: constituency (`toGrid_not_injective`) and, under recursion,
-[liberman-prince-1977]'s order-invariant culminativity (`grid_not_culminative_under_recursion`).
+terminal element*) of every node up to the root. `Grid.columns` is its height projection;
+`Grid.headHeights`/`Grid.headTerminals` read the live columns' heights and leaves. This is the *determinate*
+bracketed grid of Halle & Vergnaud 1987 / [hayes-1995] — our
+`Tree` *is* the bracketed grid, `Grid.ofTree` the forgetful map onto the pure grid. What it forgets is
+*theorem*-shaped: constituency (`Grid.ofTree_not_injective`) and, under recursion,
+[liberman-prince-1977]'s order-invariant culminativity (`Grid.not_culminative_under_recursion`).
 
 ## Main definitions
-* `gridColumnsLive` — the head-projection fold; each `Column` carries its leaf, height, and `live`
+* `Grid.columnsLive` — the head-projection fold; each `Grid.Column` carries its leaf, height, and `live`
   bit (whether its leaf is a head terminal).
-* `gridColumns` / `gridPeak` / `toGrid` — its height image: heights, the peak (the head terminal's
+* `Grid.columns` / `Grid.peak` / `Grid.ofTree` — its height image: heights, the peak (the head terminal's
   prominence), the stacked rows.
-* `headTerminals` / `headHeights` / `IsHeaded` — the head terminals (DTEs) as nodes / as heights,
+* `Grid.headTerminals` / `Grid.headHeights` / `IsHeaded` — the head terminals (DTEs) as nodes / as heights,
   and the unique-head-terminal predicate.
-* `IsContinuous` / `IsCulminative` — the grid well-formedness invariants.
+* `Grid.IsContinuous` / `IsCulminative` — the grid well-formedness invariants.
 
 ## Main results
-* `gridColumns_eq_live` — the **projection law**: `gridColumns` is the height image of
-  `gridColumnsLive` (definitional).
-* `toGrid_isContinuous` — the **Continuous Column Constraint**, by construction.
-* `gridColumns_toProsTree` / `foot_headRow` / `gridPeak_toProsTree` — **head-preservation**.
-* `headHeights_eq_peak` — the **peak is the head terminal** on a non-recursive headed word.
-* `toGrid_not_injective` / `grid_not_culminative_under_recursion` — what the projection
-  **forgets**.
+* `Grid.ofTree_isContinuous` — the Continuous Column Constraint, by construction.
+* `Grid.columns_toProsTree` / `Grid.foot_headRow` / `Grid.peak_toProsTree` — head-preservation.
+* `Grid.headHeights_eq_peak` — the peak is the head terminal on a non-recursive headed word.
+* `Grid.ofTree_not_injective` / `Grid.not_culminative_under_recursion` — what the projection forgets.
 -/
 
 namespace Prosody
 
 /-! ### The grid -/
 
-/-- A metrical grid: rows of head-marks, bottom first (row `r`, position `i` is `true` iff
-    syllable `i` reaches level `r`). -/
+/-- A metrical grid: rows of head-marks, bottom row first. -/
 abbrev Grid := List (List Bool)
 
-/-- One metrical-grid column: a σ-leaf, its head-projection height, and `live` — whether that leaf
-    is the head of every node up to the root (its head-projection chain is unbroken). -/
-structure Column where
+/-- A metrical-grid column: a σ-leaf with its head-projection height and liveness. -/
+structure Grid.Column where
   /-- The σ-leaf carrying the column. -/
   leaf : Tree
-  /-- The column height: `1` plus the contiguous run of head-edges above the leaf. -/
+  /-- The column's head-projection height. -/
   height : ℕ
-  /-- Whether the head-projection chain reaches the root — the leaf is a **head terminal**. -/
+  /-- Whether the leaf is a head terminal. -/
   live : Bool
 
-/-- Carry a column through one edge: the leaf passes through, a head edge over a live column adds a
-    mark and stays live, any non-head edge ends the chain. -/
-private def bumpLive (isHead : Bool) : Column → Column :=
+/-- Carry a column up one edge, bumping its height and liveness. -/
+private def Grid.bumpLive (isHead : Bool) : Grid.Column → Grid.Column :=
   fun c => { c with height := c.height + (if isHead && c.live then 1 else 0), live := isHead && c.live }
 
-/-- The live grid: each σ-leaf column carries its leaf, height, and `live` bit — whether the leaf
-    is the head terminal (Liberman & Prince's *designated terminal element*) of every node up to
-    the root. The single fold the grid, its heights, its peak, and the head terminals
-    (`gridColumns`/`headHeights`/`headTerminals`) all project from. -/
-def gridColumnsLive (t : Tree) : List Column := go t where
-  go : Tree → List Column
+variable (t : Tree)
+
+/-- The live grid: one `Grid.Column` per σ-leaf, tracking head-terminal liveness. -/
+def Grid.columnsLive : List Grid.Column := go t where
+  go : Tree → List Grid.Column
     | .node a cs => if a.isSyl && cs.isEmpty then [⟨.node a cs, 1, true⟩] else goList cs
-  goList : List Tree → List Column
+  goList : List Tree → List Grid.Column
     | []      => []
-    | c :: cs => (go c).map (bumpLive c.label.isHead) ++ goList cs
+    | c :: cs => (go c).map (Grid.bumpLive c.label.isHead) ++ goList cs
 
-/-- The `goList` fold as a `flatMap` over children. -/
-private theorem gridColumnsLive.goList_eq (cs : List Tree) :
-    gridColumnsLive.goList cs
-      = cs.flatMap (fun c => (gridColumnsLive.go c).map (bumpLive c.label.isHead)) := by
-  induction cs with
-  | nil => rfl
-  | cons c cs ih => simp only [gridColumnsLive.goList, List.flatMap_cons, ih]
+/-- **The fold's recursion** ([liberman-prince-1977]): a σ-leaf is its own column; every other
+    node's columns are its children's, each carried up (`bumpLive`) along the edge to it. -/
+@[simp] theorem Grid.columnsLive_node (a : Constituent) (cs : List Tree) :
+    Grid.columnsLive (.node a cs)
+      = if a.isSyl ∧ cs = [] then [⟨.node a cs, 1, true⟩]
+        else cs.flatMap (fun c => (Grid.columnsLive c).map (Grid.bumpLive c.label.isHead)) := by
+  have hg : ∀ ds : List Tree, Grid.columnsLive.goList ds
+      = ds.flatMap (fun c => (Grid.columnsLive c).map (Grid.bumpLive c.label.isHead)) := fun ds => by
+    induction ds with
+    | nil => rfl
+    | cons c ds ih => simp only [Grid.columnsLive.goList, List.flatMap_cons, ih, Grid.columnsLive]
+  by_cases h : a.isSyl = true ∧ cs = []
+  · obtain ⟨hσ, rfl⟩ := h
+    simp [Grid.columnsLive, Grid.columnsLive.go, hσ]
+  · rw [if_neg h]
+    have hb : (a.isSyl && cs.isEmpty) = false := by
+      rcases Bool.eq_false_or_eq_true (a.isSyl && cs.isEmpty) with h' | h'
+      · rw [Bool.and_eq_true, List.isEmpty_iff] at h'; exact absurd h' h
+      · exact h'
+    rw [show Grid.columnsLive (.node a cs) = Grid.columnsLive.goList cs from by
+          simp [Grid.columnsLive, Grid.columnsLive.go, hb], hg]
 
-/-- **Grid-column heights** of the σ-frontier ([liberman-prince-1977]): the height projection of
-    the live grid. A leaf's height is `1` plus its contiguous run of head-edges. -/
-def gridColumns (t : Tree) : List ℕ := (gridColumnsLive t).map (·.height)
+/-- The grid-column heights of a tree. -/
+def Grid.columns : List ℕ := (Grid.columnsLive t).map (·.height)
 
-/-- **The projection law** ([liberman-prince-1977]): the grid is the height projection of the live
-    grid — definitional; a column of height `h` is a head-projection chain of `h` nodes. -/
-theorem gridColumns_eq_live (t : Tree) : gridColumns t = (gridColumnsLive t).map (·.height) := rfl
+/-- The tallest grid column. -/
+def Grid.peak : ℕ := (Grid.columns t).foldr max 0
 
-/-- The tallest column — the head terminal's prominence ([liberman-prince-1977]); `0` on an empty
-    σ-frontier. -/
-def gridPeak (t : Tree) : ℕ := (gridColumns t).foldr max 0
+/-- The head terminals' prominences. -/
+def Grid.headHeights : List ℕ := ((Grid.columnsLive t).filter (·.live)).map (·.height)
 
-/-- The **head-terminal prominences** ([liberman-prince-1977]): the heights of the *live* columns
-    — the σ-positions whose head-projection chain reaches the root. The height projection of
-    `gridColumnsLive`'s live sublist (cf. `gridColumns`, its full image; `headTerminals`, the same
-    sublist's node projection). A headed word has exactly one; under recursion it can sit *below*
-    the tallest column (`head_below_peak_under_recursion`). -/
-def headHeights (t : Tree) : List ℕ := ((gridColumnsLive t).filter (·.live)).map (·.height)
+/-- A tree is headed when it has a unique head terminal. -/
+def IsHeaded : Prop := (Grid.headHeights t).length = 1
 
-/-- A tree is **headed** when it has a unique head terminal — one unbroken head-projection chain to
-    the root (Liberman & Prince's Culminativity, head version; strictly stronger than
-    `IsCulminative`, which sees only heights). -/
-def IsHeaded (t : Tree) : Prop := (headHeights t).length = 1
+instance : Decidable (IsHeaded t) := by unfold IsHeaded; infer_instance
 
-instance (t : Tree) : Decidable (IsHeaded t) := by unfold IsHeaded; infer_instance
+/-- `leaf` is a head terminal of `t`, reached from the root by an all-head descent. -/
+inductive Grid.IsHeadTerminal : Tree → Tree → Prop
+  | leaf (wt hd) : Grid.IsHeadTerminal (.node (.syl wt hd) []) (.node (.syl wt hd) [])
+  | head {a cs c leaf} : c ∈ cs → c.label.isHead →
+      Grid.IsHeadTerminal c leaf → Grid.IsHeadTerminal (.node a cs) leaf
 
-/-- The **head terminals** ([liberman-prince-1977]): the σ-leaves whose head-projection chain
-    reaches the root — Liberman & Prince's *designated terminal elements* as nodes. The node
-    projection of `gridColumnsLive`'s live sublist — the very sublist `headHeights` reads for
-    heights, so the two are bijective by construction. -/
-def headTerminals (t : Tree) : List Tree := ((gridColumnsLive t).filter (·.live)).map (·.leaf)
+/-- The **head terminals** (DTEs) — Liberman & Prince's *designated terminal elements*: the
+    σ-leaves reached from the root by an all-head descent. The head-child recursion mirroring
+    `Grid.IsHeadTerminal`, structural (so `decide` computes it) via `Planar.fold`. -/
+def Grid.headTerminals (t : Tree) : List Tree :=
+  t.fold fun a ps =>
+    if a.isSyl ∧ ps = [] then [.node a []]
+    else (ps.filter (·.1.label.isHead)).flatMap (·.2)
 
-/-- The head terminal as one element, when the word is headed (`IsHeaded`); `none` otherwise. -/
-def headTerminal (t : Tree) : Option Tree := (headTerminals t).head?
+/-- Head terminals recurse through the head children: a σ-leaf is its own; otherwise a non-head
+    edge drops a child's terminals while a head edge keeps them. -/
+@[simp] theorem Grid.headTerminals_node (a : Constituent) (cs : List Tree) :
+    Grid.headTerminals (.node a cs)
+      = if a.isSyl ∧ cs = [] then [.node a []]
+        else (cs.filter (·.label.isHead)).flatMap Grid.headTerminals := by
+  conv_lhs => rw [Grid.headTerminals, RootedTree.Planar.fold_node]
+  simp only [List.map_eq_nil_iff]
+  split
+  · rfl
+  · rw [List.filter_map, List.flatMap_map]; rfl
 
-/-- **Headedness read on the node image** ([liberman-prince-1977]): a tree is headed iff it has a
-    single head terminal. `headTerminals` and `headHeights` are the node and height projections of
-    one live sublist, so this is `IsHeaded` re-read, not a second notion. -/
-theorem isHeaded_iff_headTerminals (t : Tree) : IsHeaded t ↔ (headTerminals t).length = 1 := by
-  simp only [IsHeaded, headHeights, headTerminals, List.length_map]
+/-- The head terminal as a single element, if the tree is headed. -/
+def Grid.headTerminal (t : Tree) : Option Tree := (Grid.headTerminals t).head?
 
-/-- **Head terminal, declaratively** ([liberman-prince-1977]): `leaf` is a head terminal of `t`
-    when it is a σ-leaf reached from the root by an **all-head descent** — Liberman & Prince's
-    *designated terminal element* as a relation rather than a computed list. The decidable grid
-    fold realizes it (`mem_headTerminals_iff`). -/
-inductive IsHeadTerminal : Tree → Tree → Prop
-  | leaf (wt hd) :
-      IsHeadTerminal (.node (Constituent.syl wt hd) []) (.node (Constituent.syl wt hd) [])
-  | head {a : Constituent} {cs : List Tree} {c leaf : Tree} :
-      c ∈ cs → c.label.isHead = true → IsHeadTerminal c leaf → IsHeadTerminal (.node a cs) leaf
-
-/-- A bumped column keeps its leaf — `bumpLive` only retags height and liveness. -/
-private theorem bumpLive_leaf (b : Bool) (c : Column) : (bumpLive b c).leaf = c.leaf := rfl
-
-/-- A bumped column is live iff the edge is a head edge over a still-live column. -/
-private theorem bumpLive_live (b : Bool) (c : Column) :
-    (bumpLive b c).live = (b && c.live) := rfl
-
-/-- The live grid of a node that is **not** a σ-leaf — either a non-σ node, or a σ-labelled node
-    that still has children — is the bumped concatenation of its children's grids. The general
-    node step (`gridColumnsLive.node_of_ne_σ` is the `a.level ≠ .σ` special case). -/
-private theorem gridColumnsLive.node_else {a : Constituent} {cs : List Tree}
-    (h : ¬ (a.isSyl = true ∧ cs = [])) :
-    gridColumnsLive (.node a cs)
-      = cs.flatMap (fun c => (gridColumnsLive.go c).map (bumpLive c.label.isHead)) := by
-  have hcond : (a.isSyl && cs.isEmpty) = false := by
-    rcases Bool.eq_false_or_eq_true (a.isSyl && cs.isEmpty) with h' | h'
-    · rw [Bool.and_eq_true, List.isEmpty_iff] at h'
-      exact absurd h' h
-    · exact h'
-  have hgo : gridColumnsLive (.node a cs) = gridColumnsLive.goList cs := by
-    simp [gridColumnsLive, gridColumnsLive.go, hcond]
-  rw [hgo, gridColumnsLive.goList_eq]
-
-/-- A leaf lies in a non-σ-leaf node's head terminals iff some **head** child carries it as a head
-    terminal: the live-column bookkeeping of `gridColumnsLive` pushed one edge down. The recursive
-    content of `mem_headTerminals_iff`. -/
-private theorem mem_headTerminals_node_else {a : Constituent} {cs : List Tree} {leaf : Tree}
-    (hcond : ¬ (a.isSyl = true ∧ cs = [])) :
-    leaf ∈ headTerminals (.node a cs)
-      ↔ ∃ c ∈ cs, c.label.isHead = true ∧ leaf ∈ headTerminals c := by
-  rw [headTerminals, gridColumnsLive.node_else hcond]
-  constructor
-  · intro hmem
-    rw [List.mem_map] at hmem
-    obtain ⟨col, hcolf, hleaf⟩ := hmem
-    rw [List.mem_filter, List.mem_flatMap] at hcolf
-    obtain ⟨⟨c, hc, hcolm⟩, hlive⟩ := hcolf
-    rw [List.mem_map] at hcolm
-    obtain ⟨col0, hcol0, rfl⟩ := hcolm
-    rw [bumpLive_live, Bool.and_eq_true] at hlive
-    rw [bumpLive_leaf] at hleaf
-    refine ⟨c, hc, hlive.1, ?_⟩
-    rw [headTerminals, List.mem_map]
-    exact ⟨col0, List.mem_filter.mpr ⟨hcol0, hlive.2⟩, hleaf⟩
-  · rintro ⟨c, hc, hhead, hmem⟩
-    rw [headTerminals, List.mem_map] at hmem
-    obtain ⟨col0, hcol0f, hleaf⟩ := hmem
-    rw [List.mem_filter] at hcol0f
-    rw [List.mem_map]
-    refine ⟨bumpLive c.label.isHead col0, ?_, ?_⟩
-    · rw [List.mem_filter, List.mem_flatMap]
-      refine ⟨⟨c, hc, ?_⟩, ?_⟩
-      · rw [List.mem_map]; exact ⟨col0, hcol0f.1, rfl⟩
-      · rw [bumpLive_live, Bool.and_eq_true]; exact ⟨hhead, hcol0f.2⟩
-    · rw [bumpLive_leaf]; exact hleaf
-
-/-- **The grid fold realizes the head terminal** ([liberman-prince-1977]): a leaf is in
-    `headTerminals t` iff `IsHeadTerminal t leaf`. The decidable head-projection fold computes the
-    declarative all-head descent — the spec↔implementation bridge. -/
-theorem mem_headTerminals_iff {t leaf : Tree} :
-    leaf ∈ headTerminals t ↔ IsHeadTerminal t leaf := by
+/-- The fold `Grid.headTerminals` computes the relation `Grid.IsHeadTerminal`. -/
+theorem Grid.mem_headTerminals_iff {t leaf : Tree} :
+    leaf ∈ Grid.headTerminals t ↔ Grid.IsHeadTerminal t leaf := by
   induction t using Core.Order.Branching.inductionOn with
   | ih t IH =>
     obtain ⟨a, cs⟩ := t
-    by_cases hcond : a.isSyl = true ∧ cs = []
-    · obtain ⟨hσ, rfl⟩ := hcond
-      cases a with
-      | syl w hd =>
-        have hht : headTerminals (.node (Constituent.syl w hd) []) = [.node (Constituent.syl w hd) []] := by
-          simp [headTerminals, gridColumnsLive, gridColumnsLive.go, Constituent.isSyl]
-        rw [hht, List.mem_singleton]
-        constructor
-        · rintro rfl
-          exact .leaf w hd
-        · intro h
-          cases h with
-          | leaf wt hd => rfl
-          | head hc _ _ => exact absurd hc List.not_mem_nil
-      | ft hd => simp [Constituent.isSyl] at hσ
-      | om => simp [Constituent.isSyl] at hσ
-      | ph => simp [Constituent.isSyl] at hσ
-    · rw [mem_headTerminals_node_else hcond]
+    rw [Grid.headTerminals_node]
+    split
+    · rename_i hσ; obtain ⟨hσ, rfl⟩ := hσ
+      obtain ⟨w, hd, rfl⟩ : ∃ w hd, a = .syl w hd := by cases a <;> simp_all [Constituent.isSyl]
+      simp only [List.mem_singleton]
       constructor
-      · rintro ⟨c, hc, hhead, hmem⟩
+      · rintro rfl; exact .leaf w hd
+      · intro h; cases h with
+        | leaf _ _ => rfl
+        | head hc _ _ => exact absurd hc List.not_mem_nil
+    · rename_i hcond
+      simp only [List.mem_flatMap, List.mem_filter]
+      constructor
+      · rintro ⟨c, ⟨hc, hhead⟩, hmem⟩
         exact .head hc hhead ((IH c (by simpa using hc)).mp hmem)
-      · intro h
-        cases h with
-        | leaf wt hd => exact absurd ⟨rfl, rfl⟩ hcond
-        | head hc hhead hsub =>
-          exact ⟨_, hc, hhead, (IH _ (by simpa using hc)).mpr hsub⟩
+      · intro h; cases h with
+        | leaf _ _ => exact absurd ⟨rfl, rfl⟩ hcond
+        | head hc hhead hsub => exact ⟨_, ⟨hc, hhead⟩, (IH _ (by simpa using hc)).mpr hsub⟩
 
-/-- The grid as stacked rows ([liberman-prince-1977]): row `r` marks columns exceeding `r`,
-    `gridPeak t` rows in all (determinate Halle & Vergnaud / [hayes-1995] indexing). -/
-def toGrid (t : Tree) : Grid :=
-  (List.range (gridPeak t)).map
-    (fun r => (gridColumns t).map (fun h => decide (r < h)))
+/-- `(l.filter p).flatMap f` drops the elements failing `p`. -/
+private theorem List.filter_flatMap_eq {β γ : Type*} (p : β → Bool) (f : β → List γ)
+    (l : List β) : (l.filter p).flatMap f = l.flatMap (fun x => if p x then f x else []) := by
+  induction l with
+  | nil => rfl
+  | cons x l ih => by_cases h : p x <;> simp [List.filter_cons, h, ih]
+
+/-- The structural head terminals are exactly the leaves of the *live* grid columns: the all-head
+    descent and `columnsLive`'s `live` bit pick out the same σ-leaves. -/
+private theorem Grid.headTerminals_eq_live :
+    Grid.headTerminals t = ((Grid.columnsLive t).filter (·.live)).map (·.leaf) := by
+  induction t using Core.Order.Branching.inductionOn with
+  | ih t IH =>
+    obtain ⟨a, cs⟩ := t
+    rw [Grid.headTerminals_node, Grid.columnsLive_node]
+    by_cases h : a.isSyl = true ∧ cs = []
+    · obtain ⟨hσ, rfl⟩ := h; simp [hσ]
+    · rw [if_neg h, if_neg h, List.filter_flatMap_eq, List.filter_flatMap, List.map_flatMap]
+      refine List.flatMap_congr fun c hc => ?_
+      rw [List.filter_map, List.map_map]
+      cases hh : c.label.isHead <;>
+        simp [Grid.bumpLive, Function.comp_def, IH c (by simpa using hc)]
+
+/-- A tree is headed iff it has a single head terminal. -/
+theorem isHeaded_iff_headTerminals : IsHeaded t ↔ (Grid.headTerminals t).length = 1 := by
+  rw [IsHeaded, Grid.headHeights, List.length_map, Grid.headTerminals_eq_live, List.length_map]
+
+/-- The metrical grid of a tree, as stacked rows. -/
+def Grid.ofTree : Grid :=
+  (List.range (Grid.peak t)).map
+    (fun r => (Grid.columns t).map (fun h => decide (r < h)))
 
 /-! ### The Continuous Column Constraint -/
 
-/-- One row is a submask of the row below (every mark above is marked below). -/
-private def rowSubmask (upper lower : List Bool) : Bool :=
+/-- Whether one row is a submask of the row below. -/
+private def Grid.rowSubmask (upper lower : List Bool) : Bool :=
   (upper.zip lower).all (fun p => !p.1 || p.2)
 
-/-- The **Continuous Column Constraint** ([prince-1983]; [hayes-1995]): no column has a gap — a
-    mark at level `r` forces one at every lower level. Equivalently the rows form a chain, each a
-    submask of the one below. A *theorem* of `toGrid` (`toGrid_isContinuous`), not a filter. -/
-def IsContinuous (g : Grid) : Prop := g.IsChain (fun lower upper => rowSubmask upper lower = true)
+/-- The Continuous Column Constraint ([prince-1983]; [hayes-1995]): no column has a gap. -/
+def Grid.IsContinuous (g : Grid) : Prop := g.IsChain (fun lower upper => Grid.rowSubmask upper lower = true)
 
-instance (g : Grid) : Decidable (IsContinuous g) := by unfold IsContinuous; infer_instance
+instance (g : Grid) : Decidable (Grid.IsContinuous g) := by unfold Grid.IsContinuous; infer_instance
 
-/-- **The CCC holds by construction** ([prince-1983]; [hayes-1995]): every `toGrid` grid is
-    gapless — its rows are the decreasing chain `· > r`, each a submask of the one below
-    (a `> r+1` mark needs a `> r` mark, i.e. `r+1 < h → r < h`). -/
-theorem toGrid_isContinuous (t : Tree) : IsContinuous (toGrid t) := by
-  rw [IsContinuous, toGrid, List.isChain_map, List.isChain_iff_getElem]
+/-- `Grid.ofTree` always satisfies the Continuous Column Constraint ([prince-1983]; [hayes-1995]). -/
+theorem Grid.ofTree_isContinuous (t : Tree) : Grid.IsContinuous (Grid.ofTree t) := by
+  rw [Grid.IsContinuous, Grid.ofTree, List.isChain_map, List.isChain_iff_getElem]
   intro i _
   simp only [List.getElem_range]
-  rw [rowSubmask, List.zip_map', List.all_map, List.all_eq_true]
+  rw [Grid.rowSubmask, List.zip_map', List.all_map, List.all_eq_true]
   intro h _
   by_cases hr : i + 1 < h <;> simp [hr]
   omega
@@ -257,46 +212,49 @@ theorem toGrid_isContinuous (t : Tree) : IsContinuous (toGrid t) := by
 
 Re-representing a `Foot` as a tree and reading its grid recovers its head — the depth-1 core. -/
 
-/-- On a σ-leaf the live fold emits the leaf at height `1`, live (the fold's leaf step). -/
-private theorem gridColumnsLive.go_syl (wt : Syllable.Weight) (hd : Bool) :
-    gridColumnsLive.go (.node (Constituent.syl wt hd) [])
+/-- The live fold on a σ-leaf: one live column at height `1`. -/
+private theorem Grid.columnsLive.go_syl (wt : Syllable.Weight) (hd : Bool) :
+    Grid.columnsLive.go (.node (Constituent.syl wt hd) [])
       = [⟨.node (Constituent.syl wt hd) [], 1, true⟩] := rfl
 
-/-- The live grid of a non-σ node is the bumped concatenation of its children's grids — the
-    fold's node step (`goList_eq` is its list step, `go_syl` its leaf step). -/
-private theorem gridColumnsLive.node_of_ne_σ {a : Constituent} {cs : List Tree}
-    (ha : a.isSyl = false) :
-    gridColumnsLive (.node a cs)
-      = cs.flatMap (fun c => (gridColumnsLive.go c).map (bumpLive c.label.isHead)) := by
-  rw [← gridColumnsLive.goList_eq]
-  simp [gridColumnsLive, gridColumnsLive.go, ha]
+/-- The `goList` fold as a `flatMap` over children. -/
+private theorem Grid.columnsLive.goList_eq (cs : List Tree) :
+    Grid.columnsLive.goList cs
+      = cs.flatMap (fun c => (Grid.columnsLive.go c).map (Grid.bumpLive c.label.isHead)) := by
+  induction cs with
+  | nil => rfl
+  | cons c cs ih => simp only [Grid.columnsLive.goList, List.flatMap_cons, ih]
 
-/-- **Head-preservation through the grid** (the foot case, generalizing
-    `Foot.headFlags_toProsTree`): a foot's tree projects to columns `2` at the head σ, `1`
-    elsewhere — the grid records its headedness. -/
-theorem gridColumns_toProsTree {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
-    gridColumns (f.toProsTree w) = (Foot.toGrid f).map (fun b => if b then 2 else 1) := by
-  rw [gridColumns, Foot.toProsTree,
-      gridColumnsLive.node_of_ne_σ (a := Constituent.ft false) (by decide), List.flatMap_map]
-  simp only [gridColumnsLive.go_syl, RootedTree.Planar.label_node, Constituent.isHead,
-    List.map_cons, List.map_nil, bumpLive]
+/-- The live grid of a non-σ node is the bumped concatenation of its children's. -/
+private theorem Grid.columnsLive.node_of_ne_σ {a : Constituent} {cs : List Tree}
+    (ha : a.isSyl = false) :
+    Grid.columnsLive (.node a cs)
+      = cs.flatMap (fun c => (Grid.columnsLive.go c).map (Grid.bumpLive c.label.isHead)) := by
+  rw [← Grid.columnsLive.goList_eq]
+  simp [Grid.columnsLive, Grid.columnsLive.go, ha]
+
+/-- A foot's grid is `2` at the head σ, `1` elsewhere. -/
+theorem Grid.columns_toProsTree {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
+    Grid.columns (f.toProsTree w) = (Foot.toGrid f).map (fun b => if b then 2 else 1) := by
+  rw [Grid.columns, Foot.toProsTree,
+      Grid.columnsLive.node_of_ne_σ (a := Constituent.ft false) (by decide), List.flatMap_map]
+  simp only [Grid.columnsLive.go_syl, RootedTree.Planar.label_node, Constituent.isHead,
+    List.map_cons, List.map_nil, Grid.bumpLive]
   rw [← List.map_eq_flatMap, Foot.toGrid, List.map_map, List.map_map]
   refine List.map_congr_left fun i _ => ?_
   by_cases hi : i = f.head <;> simp [hi]
 
-/-- The grid's `> 1` head row equals `Foot.toGrid f`: with `Foot.headFlags_toProsTree`, the grid
-    recovers the foot's head — head-preservation through the grid, not the tree. -/
-theorem foot_headRow {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
-    (gridColumns (f.toProsTree w)).map (fun h => decide (1 < h)) = Foot.toGrid f := by
-  rw [gridColumns_toProsTree, List.map_map]
+/-- The grid's head row recovers `Foot.toGrid`. -/
+theorem Grid.foot_headRow {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
+    (Grid.columns (f.toProsTree w)).map (fun h => decide (1 < h)) = Foot.toGrid f := by
+  rw [Grid.columns_toProsTree, List.map_map]
   refine List.map_id'' (fun b => ?_) _
   cases b <;> rfl
 
-/-- A foot's tree peaks at `2` ([liberman-prince-1977]): its head σ is the unique tallest column,
-    one head-edge above the floor — the height member of the head-preservation family. -/
-theorem gridPeak_toProsTree {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
-    gridPeak (f.toProsTree w) = 2 := by
-  rw [gridPeak, gridColumns_toProsTree]
+/-- A foot's grid peaks at `2`. -/
+theorem Grid.peak_toProsTree {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
+    Grid.peak (f.toProsTree w) = 2 := by
+  rw [Grid.peak, Grid.columns_toProsTree]
   refine Nat.le_antisymm (List.max_le_of_forall_le _ 2 ?_) (List.le_max_of_le' 0 ?_ le_rfl)
   · rintro x hx
     obtain ⟨b, _, rfl⟩ := List.mem_map.mp hx
@@ -306,49 +264,43 @@ theorem gridPeak_toProsTree {S : Type*} (w : S → Syllable.Weight) (f : Foot S)
 
 /-! ### What the grid forgets
 
-The projection is one-way: it drops constituency (`toGrid_not_injective`) and, under recursion,
-[liberman-prince-1977]'s order-invariant culminativity (`grid_not_culminative_under_recursion`). -/
+The projection is one-way: it drops constituency (`Grid.ofTree_not_injective`) and, under recursion,
+[liberman-prince-1977]'s order-invariant culminativity (`Grid.not_culminative_under_recursion`). -/
 
-/-- **The grid loses constituency** ([liberman-prince-1977]): `toGrid` is not injective — a
-    footed vs. a bare σ both give `[1]`, so the grid can't recover bracketing. -/
-theorem toGrid_not_injective :
-    ∃ t₁ t₂ : Tree, t₁ ≠ t₂ ∧ toGrid t₁ = toGrid t₂ :=
+/-- `Grid.ofTree` is not injective: the grid forgets constituency. -/
+theorem Grid.ofTree_not_injective :
+    ∃ t₁ t₂ : Tree, t₁ ≠ t₂ ∧ Grid.ofTree t₁ = Grid.ofTree t₂ :=
   ⟨.node .om [.node .ft [.node (.syl 1) []]], .node .om [.node (.syl 1) []],
     by decide, by decide⟩
 
-/-- **Culminativity** ([liberman-prince-1977]; [hayes-1995]): exactly one column is tallest — a
-    unique primary stress (one head terminal per domain). -/
+/-- Culminativity ([liberman-prince-1977]): exactly one column is tallest. -/
 def IsCulminative (cols : List ℕ) : Prop :=
   (cols.filter (· = cols.foldr max 0)).length = 1
 
 instance (cols : List ℕ) : Decidable (IsCulminative cols) := by
   unfold IsCulminative; infer_instance
 
-/-- **Recursion breaks culminativity** ([liberman-prince-1977]): an ω-over-ω word's embedded
-    weak DTE ties the matrix head (columns `[3, 3]`), leaving no unique peak — the prominence
-    sibling of `toGrid_not_injective`. -/
-theorem grid_not_culminative_under_recursion :
-    ∃ t : Tree, IsWord t ∧ ¬ IsCulminative (gridColumns t) :=
+/-- Recursion can break culminativity. -/
+theorem Grid.not_culminative_under_recursion :
+    ∃ t : Tree, IsWord t ∧ ¬ IsCulminative (Grid.columns t) :=
   ⟨.node .om
       [ .node (.ft true) [.node (.syl 1 true) []],
         .node .om [.node (.ft true) [.node (.syl 1 true) []]] ],
     by decide, by decide⟩
 
-/-- A flat word (head foot beside weak foot) keeps a unique peak (`[3, 2]`): culminativity
-    without recursion. -/
-theorem grid_culminative_flat :
-    IsCulminative (gridColumns
+/-- A flat word stays culminative. -/
+theorem Grid.culminative_flat :
+    IsCulminative (Grid.columns
       (.node .om [ .node (.ft true)  [.node (.syl 1 true) []],
                    .node (.ft false) [.node (.syl 1 true) []] ])) := by decide
 
 /-! ### The word peak and the head terminal
 
-The ω analogue of `gridPeak_toProsTree`: on a non-recursive headed word the grid peak *is* the
+The ω analogue of `Grid.peak_toProsTree`: on a non-recursive headed word the grid peak *is* the
 head terminal (Liberman & Prince's designated terminal element) — primary stress reads off the
 grid. Recursion is the sole obstruction, and (unlike the foot) culminativity alone is not enough. -/
 
-/-- `isWordTree.goList` as a `List.all` over children — the list step of the Layeredness
-    checker (cf. `gridColumnsLive.goList_eq`). -/
+/-- `isWordTree.goList` as a `List.all` over children. -/
 private theorem isWordTree.goList_all (cs : List Tree) :
     isWordTree.goList cs
       = cs.all (fun c => isFootTree c || isWordTree.go c
@@ -357,9 +309,7 @@ private theorem isWordTree.goList_all (cs : List Tree) :
   | nil => rfl
   | cons c cs ih => simp only [isWordTree.goList, List.all_cons, ih]
 
-/-- On a non-recursive word (`IsWord` + `noRec = 0`) the root is an ω each daughter of which
-    is either a well-formed foot or a stray σ-leaf — the ω-over-ω arm of `isWordTree` is killed
-    by `noRec = 0`. This is the depth-≤-2 structure `headHeights_eq_peak` rests on. -/
+/-- A non-recursive word is an ω over well-formed feet and stray σ-leaves. -/
 private theorem isWord_children {a : Constituent} {cs : List Tree}
     (hw : IsWord (.node a cs)) (hr : noRec (.node a cs) = 0) :
     a.isOm = true ∧ ∀ c ∈ cs, isFootTree c = true ∨ (c.label.isSyl = true ∧ c.children = []) := by
@@ -395,23 +345,19 @@ private theorem isWord_children {a : Constituent} {cs : List Tree}
   · exact Or.inl h
   · exact Or.inr h
 
-/-- The live fold emits any σ-labelled childless node at height `1`, live — the general form
-    of `gridColumnsLive.go_syl`. -/
-private theorem gridColumnsLive.go_leaf {sb : Constituent} (h : sb.isSyl = true) :
-    gridColumnsLive.go (.node sb []) = [⟨.node sb [], 1, true⟩] := by
-  simp [gridColumnsLive.go, h]
+/-- The live fold on any σ-leaf: one live column at height `1`. -/
+private theorem Grid.columnsLive.go_leaf {sb : Constituent} (h : sb.isSyl = true) :
+    Grid.columnsLive.go (.node sb []) = [⟨.node sb [], 1, true⟩] := by
+  simp [Grid.columnsLive.go, h]
 
-/-- **Bounded columns** under Layeredness + No-Recursion: on a word with `noRec = 0` every grid
-    column has height `≤ 3`, every *live* column height `≥ 2`, and any height-`3` column is live
-    (the head-foot's head σ). The depth-≤-2 structure, pinned per column — the engine of
-    `headHeights_eq_peak`. -/
-private theorem gridColumnsLive_bounded {t : Tree} (hw : IsWord t) (hr : noRec t = 0) :
-    ∀ col ∈ gridColumnsLive t,
+/-- Column-height bounds for a non-recursive word: `≤ 3`, live `≥ 2`, and height `3` ⇒ live. -/
+private theorem Grid.columnsLive_bounded {t : Tree} (hw : IsWord t) (hr : noRec t = 0) :
+    ∀ col ∈ Grid.columnsLive t,
       col.height ≤ 3 ∧ (col.live = true → 2 ≤ col.height) ∧ (col.height = 3 → col.live = true) := by
   obtain ⟨a, cs⟩ := t
   obtain ⟨ha, hchild⟩ := isWord_children hw hr
   intro col hcol
-  rw [gridColumnsLive.node_of_ne_σ (a := a) (Constituent.isSyl_eq_false_of_isOm ha),
+  rw [Grid.columnsLive.node_of_ne_σ (a := a) (Constituent.isSyl_eq_false_of_isOm ha),
     List.mem_flatMap] at hcol
   obtain ⟨c, hc, hcol⟩ := hcol
   rw [List.mem_map] at hcol
@@ -420,9 +366,9 @@ private theorem gridColumnsLive_bounded {t : Tree} (hw : IsWord t) (hr : noRec t
   · obtain ⟨cl, ccs⟩ := c
     simp only [isFootTree, Bool.and_eq_true] at hfoot
     obtain ⟨⟨hclf, _⟩, hleaves⟩ := hfoot
-    have hgoc : gridColumnsLive.go (.node cl ccs)
-        = ccs.flatMap (fun s => (gridColumnsLive.go s).map (bumpLive s.label.isHead)) :=
-      gridColumnsLive.node_of_ne_σ (a := cl) (Constituent.isSyl_eq_false_of_isFt hclf)
+    have hgoc : Grid.columnsLive.go (.node cl ccs)
+        = ccs.flatMap (fun s => (Grid.columnsLive.go s).map (Grid.bumpLive s.label.isHead)) :=
+      Grid.columnsLive.node_of_ne_σ (a := cl) (Constituent.isSyl_eq_false_of_isFt hclf)
     rw [hgoc, List.mem_flatMap] at hcol0
     obtain ⟨s, hs, hcol0⟩ := hcol0
     have hsleaf := List.all_eq_true.mp hleaves s hs
@@ -430,35 +376,30 @@ private theorem gridColumnsLive_bounded {t : Tree} (hw : IsWord t) (hr : noRec t
     simp only [Bool.and_eq_true, List.isEmpty_iff] at hsleaf
     obtain ⟨hsσ, hsds⟩ := hsleaf
     subst hsds
-    rw [gridColumnsLive.go_leaf hsσ, List.map_cons, List.map_nil, List.mem_singleton] at hcol0
+    rw [Grid.columnsLive.go_leaf hsσ, List.map_cons, List.map_nil, List.mem_singleton] at hcol0
     subst hcol0
     cases hclh : cl.isHead <;> cases hsbh : sb.isHead <;>
-      simp [bumpLive, RootedTree.Planar.label_node, hclh, hsbh]
+      simp [Grid.bumpLive, RootedTree.Planar.label_node, hclh, hsbh]
   · obtain ⟨cb, cbs⟩ := c
     simp only [RootedTree.Planar.label_node] at hlev
     simp only [RootedTree.Planar.children_node] at hchildren
     subst hchildren
-    rw [gridColumnsLive.go_leaf hlev, List.mem_singleton] at hcol0
+    rw [Grid.columnsLive.go_leaf hlev, List.mem_singleton] at hcol0
     subst hcol0
     cases hcbh : cb.isHead <;>
-      simp [bumpLive, RootedTree.Planar.label_node, hcbh]
+      simp [Grid.bumpLive, RootedTree.Planar.label_node, hcbh]
 
-/-- **The peak is the head terminal** ([liberman-prince-1977]; the ω analogue of
-    `gridPeak_toProsTree`): in a non-recursive headed *word* the head terminal's prominence *is*
-    the grid peak, so primary stress reads off the grid. Both **Layeredness** (`IsWord`) and
-    **No-Recursion** are essential — without Layeredness a deep dead column can outrank the head
-    terminal (`head_below_peak_unlayered`), and recursion divorces the two
-    (`head_below_peak_under_recursion`); culminativity alone suffices for neither. -/
-theorem headHeights_eq_peak {t : Tree} (hw : IsWord t) (hh : IsHeaded t) (hr : noRec t = 0) :
-    headHeights t = [gridPeak t] := by
-  have facts := gridColumnsLive_bounded hw hr
-  rw [IsHeaded, headHeights, List.length_map] at hh
+/-- On a non-recursive headed word, the head terminal is the grid peak ([liberman-prince-1977]). -/
+theorem Grid.headHeights_eq_peak {t : Tree} (hw : IsWord t) (hh : IsHeaded t) (hr : noRec t = 0) :
+    Grid.headHeights t = [Grid.peak t] := by
+  have facts := Grid.columnsLive_bounded hw hr
+  rw [IsHeaded, Grid.headHeights, List.length_map] at hh
   obtain ⟨c0, hc0⟩ := List.length_eq_one_iff.mp hh
-  have hc0mf : c0 ∈ (gridColumnsLive t).filter (·.live) := by rw [hc0]; simp
+  have hc0mf : c0 ∈ (Grid.columnsLive t).filter (·.live) := by rw [hc0]; simp
   rw [List.mem_filter] at hc0mf
   obtain ⟨hc0mem, hc0live⟩ := hc0mf
-  have hpeak : c0.height = gridPeak t := by
-    rw [gridPeak, gridColumns]
+  have hpeak : c0.height = Grid.peak t := by
+    rw [Grid.peak, Grid.columns]
     refine le_antisymm
       (List.le_max_of_le' 0 (List.mem_map.mpr ⟨c0, hc0mem, rfl⟩) (le_refl c0.height))
       (List.max_le_of_forall_le _ c0.height fun x hx => ?_)
@@ -468,32 +409,24 @@ theorem headHeights_eq_peak {t : Tree} (hw : IsWord t) (hh : IsHeaded t) (hr : n
     obtain ⟨hle3, _, h3⟩ := facts col hcm
     rcases (show col.height ≤ 2 ∨ col.height = 3 by omega) with h2 | h3eq
     · exact le_trans h2 (hc0ge2 hc0live)
-    · have hmem : col ∈ (gridColumnsLive t).filter (·.live) :=
+    · have hmem : col ∈ (Grid.columnsLive t).filter (·.live) :=
         List.mem_filter.mpr ⟨hcm, h3 h3eq⟩
       rw [hc0, List.mem_singleton] at hmem
-      exact le_of_eq (congrArg Column.height hmem)
-  rw [headHeights, hc0]; simp [hpeak]
+      exact le_of_eq (congrArg Grid.Column.height hmem)
+  rw [Grid.headHeights, hc0]; simp [hpeak]
 
-/-- **Recursion divorces the peak from the head terminal** ([ito-mester-2009]): even a
-    *culminative*, headed ω-over-ω word can peak on a recessive embedded column, not its head
-    terminal. Here the head stray-σ is live at `2`, while the embedded word's head-σ chains to `3`
-    before dying at the outer-ω edge — columns `[2, 3]`, peak `3`, but `headHeights = [2]`. The
-    sharper sibling of `grid_not_culminative_under_recursion`: it is why `headHeights_eq_peak` must
-    assume No-Recursion rather than `IsCulminative`. -/
-theorem head_below_peak_under_recursion :
-    ∃ t : Tree, IsWord t ∧ IsHeaded t ∧ IsCulminative (gridColumns t)
-      ∧ headHeights t ≠ [gridPeak t] :=
+/-- Under recursion the peak can desert the head terminal, even when culminative
+    ([ito-mester-2009]). -/
+theorem Grid.head_below_peak_under_recursion :
+    ∃ t : Tree, IsWord t ∧ IsHeaded t ∧ IsCulminative (Grid.columns t)
+      ∧ Grid.headHeights t ≠ [Grid.peak t] :=
   ⟨.node .om [ .node (.syl 1 true) [],
                .node .om [.node (.ft true) [.node (.syl 1 true) []]] ],
     by decide, by decide, by decide, by decide⟩
 
-/-- **Layeredness is essential too**: an anti-Layered tree (`ω` dominating a `φ`!) hides a
-    height-`3` *dead* column under a non-head edge beside a height-`2` live head terminal —
-    `IsHeaded` and `noRec = 0` both hold, yet `headHeights = [2] ≠ [3] = [gridPeak]`. The
-    Layeredness sibling of `head_below_peak_under_recursion`, and why `headHeights_eq_peak` needs
-    `IsWord`. -/
-theorem head_below_peak_unlayered :
-    ∃ t : Tree, IsHeaded t ∧ noRec t = 0 ∧ ¬ IsWord t ∧ headHeights t ≠ [gridPeak t] :=
+/-- Without Layeredness the peak can desert the head terminal too. -/
+theorem Grid.head_below_peak_unlayered :
+    ∃ t : Tree, IsHeaded t ∧ noRec t = 0 ∧ ¬ IsWord t ∧ Grid.headHeights t ≠ [Grid.peak t] :=
   ⟨.node .om [ .node Constituent.ph [.node (.ft true) [.node (.syl 1 true) []]],
                .node (.syl 1 true) [] ],
     by decide, by decide, by decide, by decide⟩
@@ -509,10 +442,10 @@ private def exWord : Tree :=
       .node (.ft false) [.node (.syl 1 true) []],
       .node (.syl 1 false) [] ]
 
-example : gridColumns exWord = [3, 2, 1] := by decide
-example : gridPeak exWord = 3 := by decide
-example : toGrid exWord =
+example : Grid.columns exWord = [3, 2, 1] := by decide
+example : Grid.peak exWord = 3 := by decide
+example : Grid.ofTree exWord =
     [[true, true, true], [true, true, false], [true, false, false]] := by decide
-example : IsContinuous (toGrid exWord) := by decide
+example : Grid.IsContinuous (Grid.ofTree exWord) := by decide
 
 end Prosody

--- a/Linglib/Phonology/Prosody/Grid.lean
+++ b/Linglib/Phonology/Prosody/Grid.lean
@@ -24,9 +24,9 @@ bracketed grid of Halle & Vergnaud 1987 / [hayes-1995] — our
   bit (whether its leaf is a head terminal).
 * `Grid.columns` / `Grid.peak` / `Grid.ofTree` — its height image: heights, the peak (the head terminal's
   prominence), the stacked rows.
-* `Grid.headTerminals` / `Grid.headHeights` / `IsHeaded` — the head terminals (DTEs) as nodes / as heights,
-  and the unique-head-terminal predicate.
-* `Grid.IsContinuous` / `IsCulminative` — the grid well-formedness invariants.
+* `Grid.headTerminals` / `Grid.headHeights` / `Grid.IsHeaded` — the head terminals (DTEs) as nodes /
+  as heights, and the unique-head-terminal predicate.
+* `Grid.IsContinuous` / `Grid.IsCulminative` — the grid well-formedness invariants.
 
 ## Main results
 * `Grid.ofTree_isContinuous` — the Continuous Column Constraint, by construction.
@@ -42,8 +42,10 @@ namespace Prosody
 /-- A metrical grid: rows of head-marks, bottom row first. -/
 abbrev Grid := List (List Bool)
 
+namespace Grid
+
 /-- A metrical-grid column: a σ-leaf with its head-projection height and liveness. -/
-structure Grid.Column where
+structure Column where
   /-- The σ-leaf carrying the column. -/
   leaf : Tree
   /-- The column's head-projection height. -/
@@ -52,91 +54,91 @@ structure Grid.Column where
   live : Bool
 
 /-- Carry a column up one edge, bumping its height and liveness. -/
-private def Grid.bumpLive (isHead : Bool) : Grid.Column → Grid.Column :=
+private def bumpLive (isHead : Bool) : Column → Column :=
   fun c => { c with height := c.height + (if isHead && c.live then 1 else 0), live := isHead && c.live }
 
 variable (t : Tree)
 
-/-- The live grid: one `Grid.Column` per σ-leaf, tracking head-terminal liveness. -/
-def Grid.columnsLive : List Grid.Column := go t where
-  go : Tree → List Grid.Column
+/-- The live grid: one `Column` per σ-leaf, tracking head-terminal liveness. -/
+def columnsLive : List Column := go t where
+  go : Tree → List Column
     | .node a cs => if a.isSyl && cs.isEmpty then [⟨.node a cs, 1, true⟩] else goList cs
-  goList : List Tree → List Grid.Column
+  goList : List Tree → List Column
     | []      => []
-    | c :: cs => (go c).map (Grid.bumpLive c.label.isHead) ++ goList cs
+    | c :: cs => (go c).map (bumpLive c.label.isHead) ++ goList cs
 
 /-- **The fold's recursion** ([liberman-prince-1977]): a σ-leaf is its own column; every other
     node's columns are its children's, each carried up (`bumpLive`) along the edge to it. -/
-@[simp] theorem Grid.columnsLive_node (a : Constituent) (cs : List Tree) :
-    Grid.columnsLive (.node a cs)
+@[simp] theorem columnsLive_node (a : Constituent) (cs : List Tree) :
+    columnsLive (.node a cs)
       = if a.isSyl ∧ cs = [] then [⟨.node a cs, 1, true⟩]
-        else cs.flatMap (fun c => (Grid.columnsLive c).map (Grid.bumpLive c.label.isHead)) := by
-  have hg : ∀ ds : List Tree, Grid.columnsLive.goList ds
-      = ds.flatMap (fun c => (Grid.columnsLive c).map (Grid.bumpLive c.label.isHead)) := fun ds => by
+        else cs.flatMap (fun c => (columnsLive c).map (bumpLive c.label.isHead)) := by
+  have hg : ∀ ds : List Tree, columnsLive.goList ds
+      = ds.flatMap (fun c => (columnsLive c).map (bumpLive c.label.isHead)) := fun ds => by
     induction ds with
     | nil => rfl
-    | cons c ds ih => simp only [Grid.columnsLive.goList, List.flatMap_cons, ih, Grid.columnsLive]
+    | cons c ds ih => simp only [columnsLive.goList, List.flatMap_cons, ih, columnsLive]
   by_cases h : a.isSyl = true ∧ cs = []
   · obtain ⟨hσ, rfl⟩ := h
-    simp [Grid.columnsLive, Grid.columnsLive.go, hσ]
+    simp [columnsLive, columnsLive.go, hσ]
   · rw [if_neg h]
     have hb : (a.isSyl && cs.isEmpty) = false := by
       rcases Bool.eq_false_or_eq_true (a.isSyl && cs.isEmpty) with h' | h'
       · rw [Bool.and_eq_true, List.isEmpty_iff] at h'; exact absurd h' h
       · exact h'
-    rw [show Grid.columnsLive (.node a cs) = Grid.columnsLive.goList cs from by
-          simp [Grid.columnsLive, Grid.columnsLive.go, hb], hg]
+    rw [show columnsLive (.node a cs) = columnsLive.goList cs from by
+          simp [columnsLive, columnsLive.go, hb], hg]
 
 /-- The grid-column heights of a tree. -/
-def Grid.columns : List ℕ := (Grid.columnsLive t).map (·.height)
+def columns : List ℕ := (columnsLive t).map (·.height)
 
 /-- The tallest grid column. -/
-def Grid.peak : ℕ := (Grid.columns t).foldr max 0
+def peak : ℕ := (columns t).foldr max 0
 
 /-- The head terminals' prominences. -/
-def Grid.headHeights : List ℕ := ((Grid.columnsLive t).filter (·.live)).map (·.height)
+def headHeights : List ℕ := ((columnsLive t).filter (·.live)).map (·.height)
 
 /-- A tree is headed when it has a unique head terminal. -/
-def IsHeaded : Prop := (Grid.headHeights t).length = 1
+def IsHeaded : Prop := (headHeights t).length = 1
 
 instance : Decidable (IsHeaded t) := by unfold IsHeaded; infer_instance
 
 /-- `leaf` is a head terminal of `t`, reached from the root by an all-head descent. -/
-inductive Grid.IsHeadTerminal : Tree → Tree → Prop
-  | leaf (wt hd) : Grid.IsHeadTerminal (.node (.syl wt hd) []) (.node (.syl wt hd) [])
+inductive IsHeadTerminal : Tree → Tree → Prop
+  | leaf (wt hd) : IsHeadTerminal (.node (.syl wt hd) []) (.node (.syl wt hd) [])
   | head {a cs c leaf} : c ∈ cs → c.label.isHead →
-      Grid.IsHeadTerminal c leaf → Grid.IsHeadTerminal (.node a cs) leaf
+      IsHeadTerminal c leaf → IsHeadTerminal (.node a cs) leaf
 
 /-- The **head terminals** (DTEs) — Liberman & Prince's *designated terminal elements*: the
     σ-leaves reached from the root by an all-head descent. The head-child recursion mirroring
-    `Grid.IsHeadTerminal`, structural (so `decide` computes it) via `Planar.fold`. -/
-def Grid.headTerminals (t : Tree) : List Tree :=
+    `IsHeadTerminal`, structural (so `decide` computes it) via `Planar.fold`. -/
+def headTerminals (t : Tree) : List Tree :=
   t.fold fun a ps =>
     if a.isSyl ∧ ps = [] then [.node a []]
     else (ps.filter (·.1.label.isHead)).flatMap (·.2)
 
 /-- Head terminals recurse through the head children: a σ-leaf is its own; otherwise a non-head
     edge drops a child's terminals while a head edge keeps them. -/
-@[simp] theorem Grid.headTerminals_node (a : Constituent) (cs : List Tree) :
-    Grid.headTerminals (.node a cs)
+@[simp] theorem headTerminals_node (a : Constituent) (cs : List Tree) :
+    headTerminals (.node a cs)
       = if a.isSyl ∧ cs = [] then [.node a []]
-        else (cs.filter (·.label.isHead)).flatMap Grid.headTerminals := by
-  conv_lhs => rw [Grid.headTerminals, RootedTree.Planar.fold_node]
+        else (cs.filter (·.label.isHead)).flatMap headTerminals := by
+  conv_lhs => rw [headTerminals, RootedTree.Planar.fold_node]
   simp only [List.map_eq_nil_iff]
   split
   · rfl
   · rw [List.filter_map, List.flatMap_map]; rfl
 
 /-- The head terminal as a single element, if the tree is headed. -/
-def Grid.headTerminal (t : Tree) : Option Tree := (Grid.headTerminals t).head?
+def headTerminal (t : Tree) : Option Tree := (headTerminals t).head?
 
-/-- The fold `Grid.headTerminals` computes the relation `Grid.IsHeadTerminal`. -/
-theorem Grid.mem_headTerminals_iff {t leaf : Tree} :
-    leaf ∈ Grid.headTerminals t ↔ Grid.IsHeadTerminal t leaf := by
+/-- The fold `headTerminals` computes the relation `IsHeadTerminal`. -/
+theorem mem_headTerminals_iff {t leaf : Tree} :
+    leaf ∈ headTerminals t ↔ IsHeadTerminal t leaf := by
   induction t using Core.Order.Branching.inductionOn with
   | ih t IH =>
     obtain ⟨a, cs⟩ := t
-    rw [Grid.headTerminals_node]
+    rw [headTerminals_node]
     split
     · rename_i hσ; obtain ⟨hσ, rfl⟩ := hσ
       obtain ⟨w, hd, rfl⟩ : ∃ w hd, a = .syl w hd := by cases a <;> simp_all [Constituent.isSyl]
@@ -164,46 +166,46 @@ private theorem List.filter_flatMap_eq {β γ : Type*} (p : β → Bool) (f : β
 
 /-- The structural head terminals are exactly the leaves of the *live* grid columns: the all-head
     descent and `columnsLive`'s `live` bit pick out the same σ-leaves. -/
-private theorem Grid.headTerminals_eq_live :
-    Grid.headTerminals t = ((Grid.columnsLive t).filter (·.live)).map (·.leaf) := by
+private theorem headTerminals_eq_live :
+    headTerminals t = ((columnsLive t).filter (·.live)).map (·.leaf) := by
   induction t using Core.Order.Branching.inductionOn with
   | ih t IH =>
     obtain ⟨a, cs⟩ := t
-    rw [Grid.headTerminals_node, Grid.columnsLive_node]
+    rw [headTerminals_node, columnsLive_node]
     by_cases h : a.isSyl = true ∧ cs = []
     · obtain ⟨hσ, rfl⟩ := h; simp [hσ]
     · rw [if_neg h, if_neg h, List.filter_flatMap_eq, List.filter_flatMap, List.map_flatMap]
       refine List.flatMap_congr fun c hc => ?_
       rw [List.filter_map, List.map_map]
       cases hh : c.label.isHead <;>
-        simp [Grid.bumpLive, Function.comp_def, IH c (by simpa using hc)]
+        simp [bumpLive, Function.comp_def, IH c (by simpa using hc)]
 
 /-- A tree is headed iff it has a single head terminal. -/
-theorem isHeaded_iff_headTerminals : IsHeaded t ↔ (Grid.headTerminals t).length = 1 := by
-  rw [IsHeaded, Grid.headHeights, List.length_map, Grid.headTerminals_eq_live, List.length_map]
+theorem isHeaded_iff_headTerminals : IsHeaded t ↔ (headTerminals t).length = 1 := by
+  rw [IsHeaded, headHeights, List.length_map, headTerminals_eq_live, List.length_map]
 
 /-- The metrical grid of a tree, as stacked rows. -/
-def Grid.ofTree : Grid :=
-  (List.range (Grid.peak t)).map
-    (fun r => (Grid.columns t).map (fun h => decide (r < h)))
+def ofTree : Grid :=
+  (List.range (peak t)).map
+    (fun r => (columns t).map (fun h => decide (r < h)))
 
 /-! ### The Continuous Column Constraint -/
 
 /-- Whether one row is a submask of the row below. -/
-private def Grid.rowSubmask (upper lower : List Bool) : Bool :=
+private def rowSubmask (upper lower : List Bool) : Bool :=
   (upper.zip lower).all (fun p => !p.1 || p.2)
 
 /-- The Continuous Column Constraint ([prince-1983]; [hayes-1995]): no column has a gap. -/
-def Grid.IsContinuous (g : Grid) : Prop := g.IsChain (fun lower upper => Grid.rowSubmask upper lower = true)
+def IsContinuous (g : Grid) : Prop := g.IsChain (fun lower upper => rowSubmask upper lower = true)
 
-instance (g : Grid) : Decidable (Grid.IsContinuous g) := by unfold Grid.IsContinuous; infer_instance
+instance (g : Grid) : Decidable (IsContinuous g) := by unfold IsContinuous; infer_instance
 
-/-- `Grid.ofTree` always satisfies the Continuous Column Constraint ([prince-1983]; [hayes-1995]). -/
-theorem Grid.ofTree_isContinuous (t : Tree) : Grid.IsContinuous (Grid.ofTree t) := by
-  rw [Grid.IsContinuous, Grid.ofTree, List.isChain_map, List.isChain_iff_getElem]
+/-- `ofTree` always satisfies the Continuous Column Constraint ([prince-1983]; [hayes-1995]). -/
+theorem ofTree_isContinuous (t : Tree) : IsContinuous (ofTree t) := by
+  rw [IsContinuous, ofTree, List.isChain_map, List.isChain_iff_getElem]
   intro i _
   simp only [List.getElem_range]
-  rw [Grid.rowSubmask, List.zip_map', List.all_map, List.all_eq_true]
+  rw [rowSubmask, List.zip_map', List.all_map, List.all_eq_true]
   intro h _
   by_cases hr : i + 1 < h <;> simp [hr]
   omega
@@ -213,48 +215,48 @@ theorem Grid.ofTree_isContinuous (t : Tree) : Grid.IsContinuous (Grid.ofTree t) 
 Re-representing a `Foot` as a tree and reading its grid recovers its head — the depth-1 core. -/
 
 /-- The live fold on a σ-leaf: one live column at height `1`. -/
-private theorem Grid.columnsLive.go_syl (wt : Syllable.Weight) (hd : Bool) :
-    Grid.columnsLive.go (.node (Constituent.syl wt hd) [])
+private theorem columnsLive.go_syl (wt : Syllable.Weight) (hd : Bool) :
+    columnsLive.go (.node (Constituent.syl wt hd) [])
       = [⟨.node (Constituent.syl wt hd) [], 1, true⟩] := rfl
 
 /-- The `goList` fold as a `flatMap` over children. -/
-private theorem Grid.columnsLive.goList_eq (cs : List Tree) :
-    Grid.columnsLive.goList cs
-      = cs.flatMap (fun c => (Grid.columnsLive.go c).map (Grid.bumpLive c.label.isHead)) := by
+private theorem columnsLive.goList_eq (cs : List Tree) :
+    columnsLive.goList cs
+      = cs.flatMap (fun c => (columnsLive.go c).map (bumpLive c.label.isHead)) := by
   induction cs with
   | nil => rfl
-  | cons c cs ih => simp only [Grid.columnsLive.goList, List.flatMap_cons, ih]
+  | cons c cs ih => simp only [columnsLive.goList, List.flatMap_cons, ih]
 
 /-- The live grid of a non-σ node is the bumped concatenation of its children's. -/
-private theorem Grid.columnsLive.node_of_ne_σ {a : Constituent} {cs : List Tree}
+private theorem columnsLive.node_of_ne_σ {a : Constituent} {cs : List Tree}
     (ha : a.isSyl = false) :
-    Grid.columnsLive (.node a cs)
-      = cs.flatMap (fun c => (Grid.columnsLive.go c).map (Grid.bumpLive c.label.isHead)) := by
-  rw [← Grid.columnsLive.goList_eq]
-  simp [Grid.columnsLive, Grid.columnsLive.go, ha]
+    columnsLive (.node a cs)
+      = cs.flatMap (fun c => (columnsLive.go c).map (bumpLive c.label.isHead)) := by
+  rw [← columnsLive.goList_eq]
+  simp [columnsLive, columnsLive.go, ha]
 
 /-- A foot's grid is `2` at the head σ, `1` elsewhere. -/
-theorem Grid.columns_toProsTree {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
-    Grid.columns (f.toProsTree w) = (Foot.toGrid f).map (fun b => if b then 2 else 1) := by
-  rw [Grid.columns, Foot.toProsTree,
-      Grid.columnsLive.node_of_ne_σ (a := Constituent.ft false) (by decide), List.flatMap_map]
-  simp only [Grid.columnsLive.go_syl, RootedTree.Planar.label_node, Constituent.isHead,
-    List.map_cons, List.map_nil, Grid.bumpLive]
+theorem columns_toProsTree {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
+    columns (f.toProsTree w) = (Foot.toGrid f).map (fun b => if b then 2 else 1) := by
+  rw [columns, Foot.toProsTree,
+      columnsLive.node_of_ne_σ (a := Constituent.ft false) (by decide), List.flatMap_map]
+  simp only [columnsLive.go_syl, RootedTree.Planar.label_node, Constituent.isHead,
+    List.map_cons, List.map_nil, bumpLive]
   rw [← List.map_eq_flatMap, Foot.toGrid, List.map_map, List.map_map]
   refine List.map_congr_left fun i _ => ?_
   by_cases hi : i = f.head <;> simp [hi]
 
 /-- The grid's head row recovers `Foot.toGrid`. -/
-theorem Grid.foot_headRow {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
-    (Grid.columns (f.toProsTree w)).map (fun h => decide (1 < h)) = Foot.toGrid f := by
-  rw [Grid.columns_toProsTree, List.map_map]
+theorem foot_headRow {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
+    (columns (f.toProsTree w)).map (fun h => decide (1 < h)) = Foot.toGrid f := by
+  rw [columns_toProsTree, List.map_map]
   refine List.map_id'' (fun b => ?_) _
   cases b <;> rfl
 
 /-- A foot's grid peaks at `2`. -/
-theorem Grid.peak_toProsTree {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
-    Grid.peak (f.toProsTree w) = 2 := by
-  rw [Grid.peak, Grid.columns_toProsTree]
+theorem peak_toProsTree {S : Type*} (w : S → Syllable.Weight) (f : Foot S) :
+    peak (f.toProsTree w) = 2 := by
+  rw [peak, columns_toProsTree]
   refine Nat.le_antisymm (List.max_le_of_forall_le _ 2 ?_) (List.le_max_of_le' 0 ?_ le_rfl)
   · rintro x hx
     obtain ⟨b, _, rfl⟩ := List.mem_map.mp hx
@@ -264,12 +266,12 @@ theorem Grid.peak_toProsTree {S : Type*} (w : S → Syllable.Weight) (f : Foot S
 
 /-! ### What the grid forgets
 
-The projection is one-way: it drops constituency (`Grid.ofTree_not_injective`) and, under recursion,
-[liberman-prince-1977]'s order-invariant culminativity (`Grid.not_culminative_under_recursion`). -/
+The projection is one-way: it drops constituency (`ofTree_not_injective`) and, under recursion,
+[liberman-prince-1977]'s order-invariant culminativity (`not_culminative_under_recursion`). -/
 
-/-- `Grid.ofTree` is not injective: the grid forgets constituency. -/
-theorem Grid.ofTree_not_injective :
-    ∃ t₁ t₂ : Tree, t₁ ≠ t₂ ∧ Grid.ofTree t₁ = Grid.ofTree t₂ :=
+/-- `ofTree` is not injective: the grid forgets constituency. -/
+theorem ofTree_not_injective :
+    ∃ t₁ t₂ : Tree, t₁ ≠ t₂ ∧ ofTree t₁ = ofTree t₂ :=
   ⟨.node .om [.node .ft [.node (.syl 1) []]], .node .om [.node (.syl 1) []],
     by decide, by decide⟩
 
@@ -281,22 +283,22 @@ instance (cols : List ℕ) : Decidable (IsCulminative cols) := by
   unfold IsCulminative; infer_instance
 
 /-- Recursion can break culminativity. -/
-theorem Grid.not_culminative_under_recursion :
-    ∃ t : Tree, IsWord t ∧ ¬ IsCulminative (Grid.columns t) :=
+theorem not_culminative_under_recursion :
+    ∃ t : Tree, IsWord t ∧ ¬ IsCulminative (columns t) :=
   ⟨.node .om
       [ .node (.ft true) [.node (.syl 1 true) []],
         .node .om [.node (.ft true) [.node (.syl 1 true) []]] ],
     by decide, by decide⟩
 
 /-- A flat word stays culminative. -/
-theorem Grid.culminative_flat :
-    IsCulminative (Grid.columns
+theorem culminative_flat :
+    IsCulminative (columns
       (.node .om [ .node (.ft true)  [.node (.syl 1 true) []],
                    .node (.ft false) [.node (.syl 1 true) []] ])) := by decide
 
 /-! ### The word peak and the head terminal
 
-The ω analogue of `Grid.peak_toProsTree`: on a non-recursive headed word the grid peak *is* the
+The ω analogue of `peak_toProsTree`: on a non-recursive headed word the grid peak *is* the
 head terminal (Liberman & Prince's designated terminal element) — primary stress reads off the
 grid. Recursion is the sole obstruction, and (unlike the foot) culminativity alone is not enough. -/
 
@@ -346,18 +348,18 @@ private theorem isWord_children {a : Constituent} {cs : List Tree}
   · exact Or.inr h
 
 /-- The live fold on any σ-leaf: one live column at height `1`. -/
-private theorem Grid.columnsLive.go_leaf {sb : Constituent} (h : sb.isSyl = true) :
-    Grid.columnsLive.go (.node sb []) = [⟨.node sb [], 1, true⟩] := by
-  simp [Grid.columnsLive.go, h]
+private theorem columnsLive.go_leaf {sb : Constituent} (h : sb.isSyl = true) :
+    columnsLive.go (.node sb []) = [⟨.node sb [], 1, true⟩] := by
+  simp [columnsLive.go, h]
 
 /-- Column-height bounds for a non-recursive word: `≤ 3`, live `≥ 2`, and height `3` ⇒ live. -/
-private theorem Grid.columnsLive_bounded {t : Tree} (hw : IsWord t) (hr : noRec t = 0) :
-    ∀ col ∈ Grid.columnsLive t,
+private theorem columnsLive_bounded {t : Tree} (hw : IsWord t) (hr : noRec t = 0) :
+    ∀ col ∈ columnsLive t,
       col.height ≤ 3 ∧ (col.live = true → 2 ≤ col.height) ∧ (col.height = 3 → col.live = true) := by
   obtain ⟨a, cs⟩ := t
   obtain ⟨ha, hchild⟩ := isWord_children hw hr
   intro col hcol
-  rw [Grid.columnsLive.node_of_ne_σ (a := a) (Constituent.isSyl_eq_false_of_isOm ha),
+  rw [columnsLive.node_of_ne_σ (a := a) (Constituent.isSyl_eq_false_of_isOm ha),
     List.mem_flatMap] at hcol
   obtain ⟨c, hc, hcol⟩ := hcol
   rw [List.mem_map] at hcol
@@ -366,9 +368,9 @@ private theorem Grid.columnsLive_bounded {t : Tree} (hw : IsWord t) (hr : noRec 
   · obtain ⟨cl, ccs⟩ := c
     simp only [isFootTree, Bool.and_eq_true] at hfoot
     obtain ⟨⟨hclf, _⟩, hleaves⟩ := hfoot
-    have hgoc : Grid.columnsLive.go (.node cl ccs)
-        = ccs.flatMap (fun s => (Grid.columnsLive.go s).map (Grid.bumpLive s.label.isHead)) :=
-      Grid.columnsLive.node_of_ne_σ (a := cl) (Constituent.isSyl_eq_false_of_isFt hclf)
+    have hgoc : columnsLive.go (.node cl ccs)
+        = ccs.flatMap (fun s => (columnsLive.go s).map (bumpLive s.label.isHead)) :=
+      columnsLive.node_of_ne_σ (a := cl) (Constituent.isSyl_eq_false_of_isFt hclf)
     rw [hgoc, List.mem_flatMap] at hcol0
     obtain ⟨s, hs, hcol0⟩ := hcol0
     have hsleaf := List.all_eq_true.mp hleaves s hs
@@ -376,30 +378,30 @@ private theorem Grid.columnsLive_bounded {t : Tree} (hw : IsWord t) (hr : noRec 
     simp only [Bool.and_eq_true, List.isEmpty_iff] at hsleaf
     obtain ⟨hsσ, hsds⟩ := hsleaf
     subst hsds
-    rw [Grid.columnsLive.go_leaf hsσ, List.map_cons, List.map_nil, List.mem_singleton] at hcol0
+    rw [columnsLive.go_leaf hsσ, List.map_cons, List.map_nil, List.mem_singleton] at hcol0
     subst hcol0
     cases hclh : cl.isHead <;> cases hsbh : sb.isHead <;>
-      simp [Grid.bumpLive, RootedTree.Planar.label_node, hclh, hsbh]
+      simp [bumpLive, RootedTree.Planar.label_node, hclh, hsbh]
   · obtain ⟨cb, cbs⟩ := c
     simp only [RootedTree.Planar.label_node] at hlev
     simp only [RootedTree.Planar.children_node] at hchildren
     subst hchildren
-    rw [Grid.columnsLive.go_leaf hlev, List.mem_singleton] at hcol0
+    rw [columnsLive.go_leaf hlev, List.mem_singleton] at hcol0
     subst hcol0
     cases hcbh : cb.isHead <;>
-      simp [Grid.bumpLive, RootedTree.Planar.label_node, hcbh]
+      simp [bumpLive, RootedTree.Planar.label_node, hcbh]
 
 /-- On a non-recursive headed word, the head terminal is the grid peak ([liberman-prince-1977]). -/
-theorem Grid.headHeights_eq_peak {t : Tree} (hw : IsWord t) (hh : IsHeaded t) (hr : noRec t = 0) :
-    Grid.headHeights t = [Grid.peak t] := by
-  have facts := Grid.columnsLive_bounded hw hr
-  rw [IsHeaded, Grid.headHeights, List.length_map] at hh
+theorem headHeights_eq_peak {t : Tree} (hw : IsWord t) (hh : IsHeaded t) (hr : noRec t = 0) :
+    headHeights t = [peak t] := by
+  have facts := columnsLive_bounded hw hr
+  rw [IsHeaded, headHeights, List.length_map] at hh
   obtain ⟨c0, hc0⟩ := List.length_eq_one_iff.mp hh
-  have hc0mf : c0 ∈ (Grid.columnsLive t).filter (·.live) := by rw [hc0]; simp
+  have hc0mf : c0 ∈ (columnsLive t).filter (·.live) := by rw [hc0]; simp
   rw [List.mem_filter] at hc0mf
   obtain ⟨hc0mem, hc0live⟩ := hc0mf
-  have hpeak : c0.height = Grid.peak t := by
-    rw [Grid.peak, Grid.columns]
+  have hpeak : c0.height = peak t := by
+    rw [peak, columns]
     refine le_antisymm
       (List.le_max_of_le' 0 (List.mem_map.mpr ⟨c0, hc0mem, rfl⟩) (le_refl c0.height))
       (List.max_le_of_forall_le _ c0.height fun x hx => ?_)
@@ -409,24 +411,24 @@ theorem Grid.headHeights_eq_peak {t : Tree} (hw : IsWord t) (hh : IsHeaded t) (h
     obtain ⟨hle3, _, h3⟩ := facts col hcm
     rcases (show col.height ≤ 2 ∨ col.height = 3 by omega) with h2 | h3eq
     · exact le_trans h2 (hc0ge2 hc0live)
-    · have hmem : col ∈ (Grid.columnsLive t).filter (·.live) :=
+    · have hmem : col ∈ (columnsLive t).filter (·.live) :=
         List.mem_filter.mpr ⟨hcm, h3 h3eq⟩
       rw [hc0, List.mem_singleton] at hmem
-      exact le_of_eq (congrArg Grid.Column.height hmem)
-  rw [Grid.headHeights, hc0]; simp [hpeak]
+      exact le_of_eq (congrArg Column.height hmem)
+  rw [headHeights, hc0]; simp [hpeak]
 
 /-- Under recursion the peak can desert the head terminal, even when culminative
     ([ito-mester-2009]). -/
-theorem Grid.head_below_peak_under_recursion :
-    ∃ t : Tree, IsWord t ∧ IsHeaded t ∧ IsCulminative (Grid.columns t)
-      ∧ Grid.headHeights t ≠ [Grid.peak t] :=
+theorem head_below_peak_under_recursion :
+    ∃ t : Tree, IsWord t ∧ IsHeaded t ∧ IsCulminative (columns t)
+      ∧ headHeights t ≠ [peak t] :=
   ⟨.node .om [ .node (.syl 1 true) [],
                .node .om [.node (.ft true) [.node (.syl 1 true) []]] ],
     by decide, by decide, by decide, by decide⟩
 
 /-- Without Layeredness the peak can desert the head terminal too. -/
-theorem Grid.head_below_peak_unlayered :
-    ∃ t : Tree, IsHeaded t ∧ noRec t = 0 ∧ ¬ IsWord t ∧ Grid.headHeights t ≠ [Grid.peak t] :=
+theorem head_below_peak_unlayered :
+    ∃ t : Tree, IsHeaded t ∧ noRec t = 0 ∧ ¬ IsWord t ∧ headHeights t ≠ [peak t] :=
   ⟨.node .om [ .node Constituent.ph [.node (.ft true) [.node (.syl 1 true) []]],
                .node (.syl 1 true) [] ],
     by decide, by decide, by decide, by decide⟩
@@ -442,10 +444,12 @@ private def exWord : Tree :=
       .node (.ft false) [.node (.syl 1 true) []],
       .node (.syl 1 false) [] ]
 
-example : Grid.columns exWord = [3, 2, 1] := by decide
-example : Grid.peak exWord = 3 := by decide
-example : Grid.ofTree exWord =
+example : columns exWord = [3, 2, 1] := by decide
+example : peak exWord = 3 := by decide
+example : ofTree exWord =
     [[true, true, true], [true, true, false], [true, false, false]] := by decide
-example : Grid.IsContinuous (Grid.ofTree exWord) := by decide
+example : IsContinuous (ofTree exWord) := by decide
+
+end Grid
 
 end Prosody

--- a/Linglib/Studies/BeckerEtAl2025.lean
+++ b/Linglib/Studies/BeckerEtAl2025.lean
@@ -10,7 +10,7 @@ reversal**: when an iamb would leave a phrase-final long vowel, the last two syl
 trochee instead ([becker-etal-2025] §3.1; [hayes-1995] §5.3b). The **last foot is the head foot**
 of the word, and the **primary stress is the head of the head foot** ([becker-etal-2025] p. 2365)
 — i.e. the syllable reached from the word ω by an all-head descent: the **head terminal**
-(Liberman & Prince's *designated terminal element*, `Prosody.headTerminals`).
+(Liberman & Prince's *designated terminal element*, `Prosody.Grid.headTerminals`).
 
 The paper's title result — *incoherent* stress ([gordon-2016]) — is that the default High tone does
 **not** dock on this head terminal but surfaces displaced, on the last syllable of a tone domain
@@ -63,12 +63,12 @@ def annatto : Tree :=
 
 /-! ### The grid: secondary stress on every foot head, primary on the head foot's
 
-Reading `gridColumns ∘` the footing recovers the stress profile: `1` unstressed, `2` a secondary
+Reading `Grid.columns ∘` the footing recovers the stress profile: `1` unstressed, `2` a secondary
 (a non-head foot's head), `3` the primary (the head foot's head). -/
 
-theorem gridColumns_fell    : gridColumns fell    = [1, 2, 1, 3, 1] := by decide
-theorem gridColumns_weFell  : gridColumns weFell  = [1, 2, 1, 2, 3, 1] := by decide
-theorem gridColumns_annatto : gridColumns annatto = [1, 3, 1] := by decide
+theorem gridColumns_fell    : Grid.columns fell    = [1, 2, 1, 3, 1] := by decide
+theorem gridColumns_weFell  : Grid.columns weFell  = [1, 2, 1, 2, 3, 1] := by decide
+theorem gridColumns_annatto : Grid.columns annatto = [1, 3, 1] := by decide
 
 /-! ### Primary stress is the head terminal ([becker-etal-2025] p. 2365)
 
@@ -82,19 +82,19 @@ theorem isHeaded_weFell  : IsHeaded weFell  := by decide
 theorem isHeaded_annatto : IsHeaded annatto := by decide
 
 /-- 's/he fell': the head terminal is the long `kí:` (head of the rightmost iamb). -/
-theorem headTerminals_fell : headTerminals fell = [.node (.syl 2 true) []] := by decide
+theorem headTerminals_fell : Grid.headTerminals fell = [.node (.syl 2 true) []] := by decide
 
 /-- 'we fell': the head terminal is the reversed trochee's initial short `kí`. -/
-theorem headTerminals_weFell : headTerminals weFell = [.node (.syl 1 true) []] := by decide
+theorem headTerminals_weFell : Grid.headTerminals weFell = [.node (.syl 1 true) []] := by decide
 
 /-- 'annatto': the head terminal is the long `mí:`. -/
-theorem headTerminals_annatto : headTerminals annatto = [.node (.syl 2 true) []] := by decide
+theorem headTerminals_annatto : Grid.headTerminals annatto = [.node (.syl 2 true) []] := by decide
 
 /-- The same fact **declaratively** ([liberman-prince-1977]): `kí:` is the head terminal of `fell`
-    — reached from ω by an all-head descent (ω → head foot → head σ), `IsHeadTerminal` — via the
-    spec↔fold bridge `mem_headTerminals_iff`, not just by computing the list. -/
-theorem isHeadTerminal_fell : IsHeadTerminal fell (.node (.syl 2 true) []) :=
-  mem_headTerminals_iff.mp (by decide)
+    — reached from ω by an all-head descent (ω → head foot → head σ), `Grid.IsHeadTerminal` — via the
+    spec↔fold bridge `Grid.mem_headTerminals_iff`, not just by computing the list. -/
+theorem isHeadTerminal_fell : Grid.IsHeadTerminal fell (.node (.syl 2 true) []) :=
+  Grid.mem_headTerminals_iff.mp (by decide)
 
 /-! ### The trochaic reversal is OT-optimal ([becker-etal-2025] §3.1, Table 2)
 
@@ -134,7 +134,7 @@ def cIamb : Constraint FootingCand := fun c => match c.toTree with
 /-- **`*V:]φ`** ([becker-etal-2025] (3)): one mark for a long vowel in the **phrase**-final σ (for a
     one-word phrase, the word-final σ). -/
 def cStarV : Constraint FootingCand := fun c =>
-  match (gridColumnsLive c.toTree).getLast? with
+  match (Grid.columnsLive c.toTree).getLast? with
   | some col => if decide (col.leaf.label.weight? = some 2) then 1 else 0
   | none     => 0
 

--- a/Linglib/Studies/BeckerEtAl2025.lean
+++ b/Linglib/Studies/BeckerEtAl2025.lean
@@ -20,7 +20,7 @@ The metrically most prominent syllable is thereby dissociated from the high-tone
 This file formalizes the **default-length metrical spine** the tonal analysis is anchored to: the
 left-to-right iambic footing (with final trochaic reversal) of words in isolation, and the
 certification that the primary stress is exactly the grid's head terminal. That a word has a
-*unique* head terminal (`Prosody.IsHeaded`) is metrical culminativity — Liberman & Prince's DTE
+*unique* head terminal (`Prosody.Grid.IsHeaded`) is metrical culminativity — Liberman & Prince's DTE
 uniqueness ([hyman-2006]). The paper's `Culminativity-H` (§4.2) is a *distinct, tonal* constraint
 ("one violation per High tone domain with more than one foot head"), part of the deferred tone
 layer. Also deferred alongside tone: lexical long vowels (Max-μ, monosyllabic feet, §3.1), word
@@ -72,14 +72,14 @@ theorem gridColumns_annatto : Grid.columns annatto = [1, 3, 1] := by decide
 
 /-! ### Primary stress is the head terminal ([becker-etal-2025] p. 2365)
 
-Each word has a **unique head terminal** (`IsHeaded` — metrical culminativity, Liberman & Prince's
+Each word has a **unique head terminal** (`Grid.IsHeaded` — metrical culminativity, Liberman & Prince's
 DTE uniqueness; cf. [hyman-2006]), and it is exactly the head syllable of the head foot — the long
 `kí:`/`mí:`, or the reversed-trochee's initial `kí`. The primary stress is read off the grid's live
 column as an *element*. -/
 
-theorem isHeaded_fell    : IsHeaded fell    := by decide
-theorem isHeaded_weFell  : IsHeaded weFell  := by decide
-theorem isHeaded_annatto : IsHeaded annatto := by decide
+theorem isHeaded_fell    : Grid.IsHeaded fell    := by decide
+theorem isHeaded_weFell  : Grid.IsHeaded weFell  := by decide
+theorem isHeaded_annatto : Grid.IsHeaded annatto := by decide
 
 /-- 's/he fell': the head terminal is the long `kí:` (head of the rightmost iamb). -/
 theorem headTerminals_fell : Grid.headTerminals fell = [.node (.syl 2 true) []] := by decide

--- a/Linglib/Studies/Hayes1995.lean
+++ b/Linglib/Studies/Hayes1995.lean
@@ -13,14 +13,14 @@ foot — independently supported by the absence of CV(C) content words in the la
 (unfooted).
 
 `parse` is that algorithm on the weight string; reading the stress off the result with the
-metrical grid (`Prosody.gridColumns`) recovers the attested prominences — primary `3`,
+metrical grid (`Prosody.Grid.columns`) recovers the attested prominences — primary `3`,
 secondary `2`, unstressed `1`. Quantity moves the peak: all-light `kataba` is stressed on the
 **antepenult**, but a heavy penult (`mudarris`) draws stress to the **penult**. (The forms
 `kataba` and `ʔinkasara` are Cairene *Classical*; [hayes-1995] shows these take the same
 stressing as colloquial Cairene, so the analysis is label-independent.)
 
 The grid stress-test turns on the **Continuous Column Constraint** ([prince-1983]; [hayes-1995]
-§3.4.2 (9), formalised as `Prosody.toGrid_isContinuous`): End Rule Right cannot promote the stray
+§3.4.2 (9), formalised as `Prosody.Grid.ofTree_isContinuous`): End Rule Right cannot promote the stray
 final light syllable, because a column raised over an unfooted syllable would have a *gap* —
 a mark on a higher layer with none below — and the grid forbids that. So the peak retracts
 *inward* off the right edge, unlike the uniform words of [prince-1983] whose peak sits at the
@@ -76,7 +76,7 @@ def parse (y : Yield) : Tree := .node .om (markHeadFoot (parseCells y))
 /-! ### Quantity-sensitive stress
 
 The forms are [hayes-1995]'s, given as their post-extrametricality weight profiles
-(`1` = light CV, `2` = heavy CVC/CVV). Reading `gridColumns ∘ parse` recovers the attested
+(`1` = light CV, `2` = heavy CVC/CVV). Reading `Grid.columns ∘ parse` recovers the attested
 stress: the column of `3` is the primary, `2` a secondary, `1` unstressed. -/
 
 /-- *kataba* `ka.ta.ba` 'he wrote' — all light (Cairene Classical). -/
@@ -88,23 +88,23 @@ def Pinkasara : Yield := [2, 1, 1, 1]
 
 /-- **Antepenultimate stress** ([hayes-1995] (15d), (16d)): all-light `kataba` parses as
     `(ká.ta)ba`, the rightmost foot heading the antepenult; the final light is stray. -/
-theorem gridColumns_kataba : gridColumns (parse kataba) = [3, 1, 1] := by decide
+theorem gridColumns_kataba : Grid.columns (parse kataba) = [3, 1, 1] := by decide
 
 /-- **Penultimate stress** ([hayes-1995] (12b), (15b)): with a heavy penult, `mudarris` parses
     as `mu(dár)ri` — the heavy is its own foot, rightmost, so quantity pulls the peak one
     syllable rightward off the antepenult. -/
-theorem gridColumns_mudarris : gridColumns (parse mudarris) = [1, 3, 1] := by decide
+theorem gridColumns_mudarris : Grid.columns (parse mudarris) = [1, 3, 1] := by decide
 
 /-- **Restarting the count after a heavy, with secondary stress** ([hayes-1995] (15d), (16d)):
     `ʔinkasara` parses as `(ʔìn)(ká.sa)ra` — the heavy initial is its own foot (secondary `2`),
     the count restarts, the next two lights foot, and the antepenult `ka` takes primary `3`. -/
-theorem gridColumns_Pinkasara : gridColumns (parse Pinkasara) = [2, 3, 1, 1] := by decide
+theorem gridColumns_Pinkasara : Grid.columns (parse Pinkasara) = [2, 3, 1, 1] := by decide
 
 /-- **The head terminal is the antepenult head σ** ([liberman-prince-1977]): `kataba`'s head
     terminal — its primary stress, Liberman & Prince's designated terminal element — is the head
     syllable of the rightmost (head) foot, read off the grid's live column as an *element*, not
     just a height (cf. `gridColumns_kataba`'s `[3, 1, 1]`). -/
-theorem headTerminals_kataba : headTerminals (parse kataba) = [.node (.syl 1 true) []] := by decide
+theorem headTerminals_kataba : Grid.headTerminals (parse kataba) = [.node (.syl 1 true) []] := by decide
 
 /-! ### The Continuous Column Constraint blocks final promotion
 
@@ -113,18 +113,18 @@ Why the peak does not sit at the right edge. End Rule Right would, naively, mark
 a word-layer mark over it leaves the foot layer empty beneath, a gapped column the
 **Continuous Column Constraint** rules out ([hayes-1995] §3.4.2 (9), §4.1.3 (17)). So the mark retracts to the
 rightmost foot head, and the peak lands inward. The attested grid is continuous *by
-construction* (`Prosody.toGrid_isContinuous`); the promotion is not. -/
+construction* (`Prosody.Grid.ofTree_isContinuous`); the promotion is not. -/
 
 /-- The attested grid of `kataba`: a continuous staircase, the primary column of three on the
     antepenult, the foot layer (`true` row 1) supporting it, the stray final light flat. -/
 theorem toGrid_kataba :
-    toGrid (parse kataba) = [[true, true, true], [true, false, false], [true, false, false]] := by
+    Grid.ofTree (parse kataba) = [[true, true, true], [true, false, false], [true, false, false]] := by
   decide
 
 /-- **The grid is well-formed** ([hayes-1995] §3.4.2 (9)): `kataba`'s grid satisfies the Continuous
-    Column Constraint — a consumer of the derived `Prosody.toGrid_isContinuous`, here doing the
+    Column Constraint — a consumer of the derived `Prosody.Grid.ofTree_isContinuous`, here doing the
     work that makes the inward peak the *only* legal reading. -/
-theorem cairene_grid_continuous : IsContinuous (toGrid (parse kataba)) := toGrid_isContinuous _
+theorem cairene_grid_continuous : Grid.IsContinuous (Grid.ofTree (parse kataba)) := Grid.ofTree_isContinuous _
 
 /-- The grid `kataba` would have if End Rule Right promoted the stray final light: a word-layer
     mark on the final column (`[hayes-1995] (17)`, *(x)(x.)*) with no foot-layer mark beneath. -/
@@ -133,13 +133,13 @@ def promotedKataba : Grid := [[true, true, true], [true, false, false], [false, 
 /-- **Promoting the final light violates the CCC** ([hayes-1995] (16d), (17)): the final
     column of `promotedKataba` is marked on layer 2 with nothing on layer 1 — a gap. This is
     exactly why End Rule Right cannot reach the edge, and the peak retracts inward. -/
-theorem promotedKataba_not_continuous : ¬ IsContinuous promotedKataba := by decide
+theorem promotedKataba_not_continuous : ¬ Grid.IsContinuous promotedKataba := by decide
 
 /-- **The peak retracts off the right edge** ([hayes-1995] (16d)): the final stray light of
     `kataba` is strictly weaker than the primary — unlike a uniform right-strong word
     ([prince-1983]), whose grid peaks at the edge. The blocked promotion above is why. -/
 theorem kataba_final_below_peak :
-    (gridColumns (parse kataba)).getLast?.getD 0 < gridPeak (parse kataba) := by
+    (Grid.columns (parse kataba)).getLast?.getD 0 < Grid.peak (parse kataba) := by
   decide
 
 end Hayes1995

--- a/Linglib/Studies/Prince1983.lean
+++ b/Linglib/Studies/Prince1983.lean
@@ -5,16 +5,16 @@ import Linglib.Phonology.Prosody.Grid
 
 [prince-1983]'s *Relating to the Grid* reads a metrical **grid** off a prosodic tree by the
 Relative Prominence Projection Rule ([liberman-prince-1977]) — formalised as
-`Prosody.gridColumns` — and observes that a **uniform** metrical tree (every constituent
+`Prosody.Grid.columns` — and observes that a **uniform** metrical tree (every constituent
 strong on the same side) projects to a grid whose single strongest column sits at one **end**:
 the *End Rule*.
 
 This file stress-tests the grid projection against that prediction. A uniformly right-strong
 (iambic) word and a uniformly left-strong (trochaic) word project, by `decide`, to staircase
 column profiles whose strict maximum is the rightmost (resp. leftmost) syllable — the End Rule,
-recovered through `Prosody.gridColumns`. It also leans on the projection's information loss:
+recovered through `Prosody.Grid.columns`. It also leans on the projection's information loss:
 the grid records *where* the prominence peak is, not the bracketing that produced it
-(`Prosody.toGrid_not_injective`).
+(`Prosody.Grid.ofTree_not_injective`).
 -/
 
 namespace Prince1983
@@ -50,22 +50,22 @@ def leftStrong : Tree := om [ftH [σh, σw], ftW [σh, σw]]
 /-- **End Rule, right** ([prince-1983]): the rightmost grid column strictly dominates every
     other — the prominence peak is at the right edge. -/
 def EndRuleRight (t : Tree) : Prop :=
-  ∀ h ∈ (gridColumns t).dropLast, h < (gridColumns t).getLast?.getD 0
+  ∀ h ∈ (Grid.columns t).dropLast, h < (Grid.columns t).getLast?.getD 0
 instance (t : Tree) : Decidable (EndRuleRight t) := by unfold EndRuleRight; infer_instance
 
 /-- **End Rule, left** ([prince-1983]): the leftmost grid column strictly dominates every
     other — the prominence peak is at the left edge. -/
 def EndRuleLeft (t : Tree) : Prop :=
-  ∀ h ∈ (gridColumns t).tail, h < (gridColumns t).headD 0
+  ∀ h ∈ (Grid.columns t).tail, h < (Grid.columns t).headD 0
 instance (t : Tree) : Decidable (EndRuleLeft t) := by unfold EndRuleLeft; infer_instance
 
 /-! ### The RPPR projects uniform trees to End-Rule grids -/
 
 /-- The right-strong word projects to a staircase peaking at the right edge. -/
-theorem gridColumns_rightStrong : gridColumns rightStrong = [1, 2, 1, 3] := by decide
+theorem gridColumns_rightStrong : Grid.columns rightStrong = [1, 2, 1, 3] := by decide
 
 /-- The left-strong word projects to a staircase peaking at the left edge. -/
-theorem gridColumns_leftStrong : gridColumns leftStrong = [3, 1, 2, 1] := by decide
+theorem gridColumns_leftStrong : Grid.columns leftStrong = [3, 1, 2, 1] := by decide
 
 /-- **End Rule (right):** a uniformly right-strong word is strongest at its right edge. -/
 theorem endRuleRight_rightStrong : EndRuleRight rightStrong := by decide
@@ -76,10 +76,10 @@ theorem endRuleLeft_leftStrong : EndRuleLeft leftStrong := by decide
 /-- **The End-Rule peak IS the head terminal** ([prince-1983]; [liberman-prince-1977]): the
     rightmost column End Rule Right promotes is the head foot's head σ — the head terminal
     (Liberman & Prince's designated terminal element) as a *node*, not just the tallest height. -/
-theorem headTerminals_rightStrong : headTerminals rightStrong = [σh] := by decide
+theorem headTerminals_rightStrong : Grid.headTerminals rightStrong = [σh] := by decide
 
 /-- And its prominence is the grid peak: on a uniform (non-recursive headed) word the head
-    terminal's height is the peak — the concrete instance of `Prosody.headHeights_eq_peak`. -/
-theorem endRulePeak_is_head : headHeights rightStrong = [gridPeak rightStrong] := by decide
+    terminal's height is the peak — the concrete instance of `Prosody.Grid.headHeights_eq_peak`. -/
+theorem endRulePeak_is_head : Grid.headHeights rightStrong = [Grid.peak rightStrong] := by decide
 
 end Prince1983


### PR DESCRIPTION
## Summary

Started as docstring polish for `Grid.lean` (post-#1021); became a real architectural fix once the head-terminal proofs kept being janky. Two layers:

**`Core/Combinatorics/RootedTree/Planar.lean` — add `Planar.fold`.**
The codebase hand-rolls a `mutual go/goList` pair for *every* rose-tree fold (`map`, `leafCount`, …) — there's no general combinator. `Planar.fold` is the missing **paramorphism**: `f` receives the root label and each child *paired with its own fold*, so downstream functions can branch on child labels (follow a distinguished child) with no `zip`. It's `mutual` with the same result/label universe, so it stays **structural and reduces under `decide`/`rfl`**. Downstream rose-tree folds become one-liners instead of bespoke `mutual` blocks.

**`Phonology/Prosody/Grid.lean` — decouple head terminals, then polish.**
`headTerminals` was routed through the height-carrying `columnsLive` fold, which conflates two unrelated things: head-edge *heights* (the grid) and all-head-descent *liveness* (the spine). The head terminals only need the latter — a pure structural recursion mirroring `IsHeadTerminal`. Now:
- `Grid.headTerminals` is a one-liner `t.fold …`;
- `headTerminals_node` / `mem_headTerminals_iff` are clean inductions (`mem` no longer pulls in `Classical.choice`);
- the lone `columnsLive` bridge (`headTerminals_eq_live`) is isolated and only feeds `isHeaded_iff_headTerminals`.

Plus the polish that motivated the session: plain mathlib-style one-liner docstrings (no bold lead-ins), the `Prosody.Grid` namespace (`Grid.columns` / `peak` / `ofTree` / `headHeights` / …), a `variable (t : Tree)` lift, and a golfed `IsHeadTerminal` inductive.

**Studies** (`BeckerEtAl2025`, `Hayes1995`, `Prince1983`) track the `Prosody.Grid` namespace.

## Test plan

- `lake build` green (6588 jobs); no new `sorry`/`axiom`.
- Axioms: `Planar.fold` — none; `Grid.mem_headTerminals_iff` — `[propext, Quot.sound]` (no `Classical.choice`); `Grid.headTerminals_node` — `[propext]`.
- Studies' `decide` certs on `headTerminals` still compute (structural fold reduces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)