### PR TITLE
feat(Phonology): OCP monoidal quotient + destutter presented monoid

### DIFF
--- a/Linglib/Core/Algebra/FreeMonoid/Destutter.lean
+++ b/Linglib/Core/Algebra/FreeMonoid/Destutter.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.Algebra.BigOperators.Group.List.Basic
 import Mathlib.Algebra.FreeMonoid.Basic
+import Mathlib.Algebra.PresentedMonoid.Basic
 import Mathlib.GroupTheory.Congruence.Basic
 import Linglib.Core.Data.List.Destutter
 
@@ -16,20 +18,35 @@ adjacent elements equal). Under **append-then-destutter** these form a monoid, a
 `List.destutter (· ≠ ·)` is the quotient homomorphism out of the free monoid:
 `{l // l.IsChain (· ≠ ·)} ≃* FreeMonoid α ⧸ ker`.
 
+Abstractly this is the monoid **presented by idempotent generators** `⟨α | a · a = a⟩`: the
+defining relations `destutterRel` make each generator absorb its own repeat, the rewriting
+system `a · a → a` is confluent and terminating, and `destutter (· ≠ ·)` computes its normal
+forms — the stutter-free words. `presentedMonoidEquiv` packages this as a `MulEquiv`
+`PresentedMonoid (destutterRel α) ≃* {l // l.IsChain (· ≠ ·)}`, identifying the abstract
+presentation with the concrete normal-form model.
+
 ## Main definitions
 
-* `List.destutterConcat` — append, then `destutter (· ≠ ·)`; the monoid multiplication.
-* `Monoid {l : List α // l.IsChain (· ≠ ·)}` — the destutter quotient monoid.
+* `Monoid {l : List α // l.IsChain (· ≠ ·)}` — the destutter quotient monoid, with
+  multiplication `List.destutterConcat` (from `Core.Data.List.Destutter`).
 * `FreeMonoid.destutterHom` — the quotient map `FreeMonoid α →* {l // l.IsChain (· ≠ ·)}`.
-* `FreeMonoid.destutterCon` — its kernel congruence on the free monoid.
+* `FreeMonoid.destutterRel` — the presentation `⟨α | a · a = a⟩`: each generator is idempotent.
 * `FreeMonoid.destutterQuotientEquiv` — first isomorphism `FreeMonoid α ⧸ ker ≃* {l // …}`.
+* `FreeMonoid.presentedMonoidEquiv` — the concrete model is the presented monoid
+  `PresentedMonoid (destutterRel α) ≃* {l // l.IsChain (· ≠ ·)}`.
+* `FreeMonoid.destutterLift` — the **universal property**: the destutter monoid is the free
+  monoid on idempotent generators; any `f : α → M` with `f a * f a = f a` extends uniquely
+  (`destutterLift_unique`) to a monoid hom `l ↦ (l.map f).prod`.
 
 ## Implementation notes
 
 The `destutter`-vs-`++` congruence lemmas live in `Core.Data.List.Destutter` (candidates
-for `Mathlib.Data.List.Destutter`); this file adds the monoid/quotient layer (candidate for
-`Mathlib.Algebra.FreeMonoid`). Nothing here is specific to any application; the phonological
-Obligatory Contour Principle (`Phonology.OCP`) is one consumer, reading this as
+for `Mathlib.Data.List.Destutter`); this file adds the monoid/presentation layer (candidate
+for `Mathlib.Algebra.FreeMonoid`). The monoid multiplication is associative because
+`destutter (· ≠ ·)` is a `++`-congruence (`destutter_append_left`/`_right` from that file);
+the presentation is identified with the concrete model by the normalization lemma
+`conGen_destutterRel_destutter`. Nothing here is specific to any application; the phonological
+Obligatory Contour Principle (`Phonology.OCP`) is one consumer, reading the presentation as
 autosegmental tier fusion.
 -/
 
@@ -37,32 +54,10 @@ namespace List
 
 variable {α : Type*} [DecidableEq α]
 
-/-- **Append then destutter**: concatenate, then collapse the single run that may form at
-the seam. The multiplication of the destutter quotient monoid. -/
-def destutterConcat (x y : List α) : List α := (x ++ y).destutter (· ≠ ·)
+/-! ### The bundled quotient monoid
 
-/-- `destutterConcat` outputs are stutter-free. -/
-theorem isChain_destutterConcat (x y : List α) :
-    (destutterConcat x y).IsChain (· ≠ ·) := isChain_destutter (· ≠ ·) (x ++ y)
-
-/-- `destutterConcat` is associative — inherited from `++` through `destutter`. -/
-theorem destutterConcat_assoc (x y z : List α) :
-    destutterConcat (destutterConcat x y) z = destutterConcat x (destutterConcat y z) := by
-  simp only [destutterConcat, destutter_append_left, destutter_append_right, List.append_assoc]
-
-theorem nil_destutterConcat (x : List α) :
-    destutterConcat [] x = x.destutter (· ≠ ·) := by simp [destutterConcat]
-
-theorem destutterConcat_nil (x : List α) :
-    destutterConcat x [] = x.destutter (· ≠ ·) := by simp [destutterConcat]
-
-/-- `destutter (· ≠ ·)` carries `(List α, ++)` onto `(·, destutterConcat)`. -/
-theorem destutter_append_eq_destutterConcat (x y : List α) :
-    (x ++ y).destutter (· ≠ ·)
-      = destutterConcat (x.destutter (· ≠ ·)) (y.destutter (· ≠ ·)) := by
-  rw [destutterConcat, ← destutter_append_destutter]
-
-/-! ### The bundled quotient monoid -/
+The multiplication `List.destutterConcat` (append then destutter) and its `List`-level laws
+live in `Core.Data.List.Destutter`; here they are bundled into the monoid structure. -/
 
 instance : Mul {l : List α // l.IsChain (· ≠ ·)} :=
   ⟨fun a b => ⟨destutterConcat a b, isChain_destutterConcat _ _⟩⟩
@@ -78,8 +73,8 @@ omit [DecidableEq α] in
 
 /-- The destutter quotient monoid: `destutterConcat` multiplication, `[]` unit. -/
 instance : Monoid {l : List α // l.IsChain (· ≠ ·)} where
-  mul_assoc a b c := Subtype.ext <| by simp [destutterConcat_assoc]
-  one_mul a := Subtype.ext <| by simp [nil_destutterConcat, destutter_of_isChain _ _ a.2]
+  mul_assoc a b c := Subtype.ext (destutterConcat_assoc _ _ _)
+  one_mul a := Subtype.ext (destutter_of_isChain _ _ a.2)
   mul_one a := Subtype.ext <| by simp [destutterConcat_nil, destutter_of_isChain _ _ a.2]
 
 end List
@@ -98,19 +93,144 @@ def destutterHom : FreeMonoid α →* {l : List α // l.IsChain (· ≠ ·)} whe
   map_mul' x y := Subtype.ext <| by
     simp [FreeMonoid.toList_mul, List.destutter_append_eq_destutterConcat]
 
+/-- `ofList` of a stutter-free list is a right inverse of `destutterHom`: a chain is its own
+destutter normal form. -/
+@[simp] theorem destutterHom_ofList (c : {l : List α // l.IsChain (· ≠ ·)}) :
+    destutterHom (FreeMonoid.ofList c.1) = c :=
+  Subtype.ext <| by
+    simp only [destutterHom, MonoidHom.coe_mk, OneHom.coe_mk, FreeMonoid.toList_ofList]
+    exact destutter_of_isChain _ _ c.2
+
 theorem destutterHom_surjective :
     Function.Surjective (destutterHom : FreeMonoid α →* {l : List α // l.IsChain (· ≠ ·)}) :=
-  fun c => ⟨FreeMonoid.ofList c.1, Subtype.ext <| by
-    simp only [destutterHom, MonoidHom.coe_mk, OneHom.coe_mk, FreeMonoid.toList_ofList]
-    exact destutter_of_isChain _ _ c.2⟩
+  fun c => ⟨FreeMonoid.ofList c.1, destutterHom_ofList c⟩
 
 /-- The destutter congruence on the free monoid: the kernel of `destutterHom`. -/
 def destutterCon : Con (FreeMonoid α) := Con.ker destutterHom
 
 /-- **First isomorphism theorem** for the destutter quotient: the abstract quotient
-`FreeMonoid α ⧸ ker` is the concrete stutter-free model `{l // l.IsChain (· ≠ ·)}`. -/
-noncomputable def destutterQuotientEquiv :
+`FreeMonoid α ⧸ ker` is the concrete stutter-free model `{l // l.IsChain (· ≠ ·)}`.
+Computable: `ofList` on chains is the right inverse. -/
+def destutterQuotientEquiv :
     (destutterCon (α := α)).Quotient ≃* {l : List α // l.IsChain (· ≠ ·)} :=
-  Con.quotientKerEquivOfSurjective destutterHom destutterHom_surjective
+  Con.quotientKerEquivOfRightInverse destutterHom (fun c => FreeMonoid.ofList c.1)
+    destutterHom_ofList
+
+/-! ### The monoid presentation `⟨α | a · a = a⟩` -/
+
+/-- The defining relations of the destutter monoid: every generator is **idempotent**
+(`a · a = a`). The presented monoid `PresentedMonoid (destutterRel α)` is `⟨α | a · a = a⟩`. -/
+def destutterRel (α : Type*) : FreeMonoid α → FreeMonoid α → Prop :=
+  fun x y => ∃ a : α, x = of a * of a ∧ y = of a
+
+/-- `destutterHom` collapses each defining relation: `destutter [a, a] = [a]`. -/
+theorem destutterHom_destutterRel {x y : FreeMonoid α} (h : destutterRel α x y) :
+    destutterHom x = destutterHom y := by
+  obtain ⟨a, rfl, rfl⟩ := h
+  exact Subtype.ext (by simp [destutterHom, FreeMonoid.toList_mul, FreeMonoid.toList_of])
+
+/-- Running-element form of the normalization lemma: prepending the running element `a`,
+the word `a :: l` is congruent to its `destutter'`. -/
+private theorem conGen_destutterRel_destutter' (a : α) (l : List α) :
+    (conGen (destutterRel α)) (of a * ofList l) (ofList (l.destutter' (· ≠ ·) a)) := by
+  induction l generalizing a with
+  | nil => simpa [destutter'_nil, ofList_cons] using (conGen (destutterRel α)).refl (of a)
+  | cons b l ih =>
+    by_cases h : a ≠ b
+    · rw [destutter'_cons_pos (h := h), ofList_cons, ofList_cons]
+      exact (conGen (destutterRel α)).mul ((conGen (destutterRel α)).refl (of a)) (ih b)
+    · obtain rfl : a = b := not_not.mp h
+      have hbase : (conGen (destutterRel α)) (of a * of a) (of a) :=
+        ConGen.Rel.of _ _ ⟨a, rfl, rfl⟩
+      rw [destutter'_cons_neg (h := by simp), ofList_cons, ← mul_assoc]
+      exact (conGen (destutterRel α)).trans
+        ((conGen (destutterRel α)).mul hbase ((conGen (destutterRel α)).refl (ofList l))) (ih a)
+
+/-- **Normalization**: every free-monoid word is congruent, modulo the idempotent-generator
+relations, to its `destutter (· ≠ ·)` normal form. The rewriting system `a · a → a` reduces
+each word to a stutter-free one. -/
+theorem conGen_destutterRel_destutter (l : List α) :
+    (conGen (destutterRel α)) (ofList l) (ofList (l.destutter (· ≠ ·))) := by
+  cases l with
+  | nil => exact (conGen (destutterRel α)).refl _
+  | cons a l => rw [destutter_cons']; exact conGen_destutterRel_destutter' a l
+
+/-- The destutter congruence **is** the presentation `⟨α | a · a = a⟩`: two words have the
+same destutter exactly when the idempotent-generator relations identify them. -/
+theorem destutterCon_eq_conGen : destutterCon (α := α) = conGen (destutterRel α) := by
+  refine le_antisymm (fun x y hxy => ?_) (Con.conGen_le.2 ?_)
+  · have hxy' : destutterHom x = destutterHom y := hxy
+    have hval : x.toList.destutter (· ≠ ·) = y.toList.destutter (· ≠ ·) :=
+      congrArg Subtype.val hxy'
+    have nx := conGen_destutterRel_destutter (α := α) x.toList
+    have ny := conGen_destutterRel_destutter (α := α) y.toList
+    rw [hval] at nx
+    exact (conGen (destutterRel α)).trans nx ((conGen (destutterRel α)).symm ny)
+  · intro x y h
+    exact destutterHom_destutterRel h
+
+/-- The concrete stutter-free model **is** the monoid presented by idempotent generators
+`⟨α | a · a = a⟩`, with `destutter (· ≠ ·)` computing normal forms. -/
+def presentedMonoidEquiv :
+    PresentedMonoid (destutterRel α) ≃* {l : List α // l.IsChain (· ≠ ·)} :=
+  (Con.congr destutterCon_eq_conGen.symm).trans destutterQuotientEquiv
+
+/-! ### Universal property: the free monoid on idempotent generators -/
+
+variable {M : Type*} [Monoid M]
+
+/-- `(· .map f).prod` is invariant under `destutter (· ≠ ·)` when each `f a` is idempotent:
+collapsing an adjacent run replaces `f a * f a` by `f a`. The engine of `destutterLift`,
+read off the normalization lemma `conGen_destutterRel_destutter`. -/
+theorem destutter_map_prod (f : α → M) (hf : ∀ a, f a * f a = f a) (xs : List α) :
+    ((xs.destutter (· ≠ ·)).map f).prod = (xs.map f).prod := by
+  have hle : conGen (destutterRel α) ≤ Con.ker (FreeMonoid.lift f) :=
+    Con.conGen_le.2 fun x y h => by obtain ⟨a, rfl, rfl⟩ := h; simp [hf]
+  have h := hle (conGen_destutterRel_destutter xs)
+  rw [Con.ker_apply, FreeMonoid.lift_ofList, FreeMonoid.lift_ofList] at h
+  exact h.symm
+
+/-- **Universal property** — the destutter monoid is the *free monoid on idempotent
+generators*: any `f : α → M` sending each generator to an idempotent element of `M` extends
+to the monoid hom `l ↦ (l.map f).prod` out of the stutter-free model. This realizes
+`PresentedMonoid.lift`'s universal property for the presentation `⟨α | a · a = a⟩` (via
+`presentedMonoidEquiv`) in concrete computable form — the destutter-monoid analogue of
+`FreeMonoid.lift`. -/
+def destutterLift (f : α → M) (hf : ∀ a, f a * f a = f a) :
+    {l : List α // l.IsChain (· ≠ ·)} →* M where
+  toFun l := (l.1.map f).prod
+  map_one' := rfl
+  map_mul' a b := by
+    show ((destutterConcat a.1 b.1).map f).prod = (a.1.map f).prod * (b.1.map f).prod
+    rw [← List.prod_append, ← List.map_append]
+    exact destutter_map_prod f hf (a.1 ++ b.1)
+
+@[simp] theorem destutterLift_singleton (f : α → M) (hf : ∀ a, f a * f a = f a) (a : α) :
+    destutterLift f hf ⟨[a], isChain_singleton a⟩ = f a := by
+  simp [destutterLift]
+
+/-- A stutter-free list is the product of its single-element generators (no fusion occurs,
+since it is already a chain): the generators generate. -/
+theorem eq_prod_map_singleton {l : List α} (hl : l.IsChain (· ≠ ·)) :
+    (⟨l, hl⟩ : {l : List α // l.IsChain (· ≠ ·)})
+      = (l.map fun a => ⟨[a], isChain_singleton a⟩).prod := by
+  induction l with
+  | nil => rfl
+  | cons a t ih =>
+    have ht : t.IsChain (· ≠ ·) := hl.tail
+    rw [List.map_cons, List.prod_cons, ← ih ht]
+    exact Subtype.ext (destutter_of_isChain _ _ hl).symm
+
+/-- **Uniqueness** for the universal property: any monoid hom agreeing with `f` on the
+single-autosegment generators is `destutterLift f hf`. -/
+theorem destutterLift_unique (f : α → M) (hf : ∀ a, f a * f a = f a)
+    (g : {l : List α // l.IsChain (· ≠ ·)} →* M)
+    (hg : ∀ a, g ⟨[a], isChain_singleton a⟩ = f a) : g = destutterLift f hf := by
+  ext ⟨l, hl⟩
+  have hgprod : g ⟨l, hl⟩ = (l.map f).prod := by
+    conv_lhs => rw [eq_prod_map_singleton hl]
+    rw [g.map_list_prod, List.map_map]
+    exact congrArg List.prod (List.map_congr_left fun a _ => by simpa using hg a)
+  rw [hgprod]; rfl
 
 end FreeMonoid

--- a/Linglib/Core/Data/List/Destutter.lean
+++ b/Linglib/Core/Data/List/Destutter.lean
@@ -23,6 +23,8 @@ proofs go through `destutter'` boundary scaffolding. Candidates for
 * `List.destutter_head?` — `destutter` preserves the head.
 * `List.destutter_append_length_clean` — the clean-clean boundary length: two `(· ≠ ·)`
   chains concatenated and destuttered merge exactly one element iff the seam matches.
+* `List.destutterConcat` — append then destutter; the multiplication of the destutter
+  quotient monoid, with its associativity and unit laws (pure `List` facts).
 -/
 
 namespace List
@@ -185,5 +187,37 @@ theorem destutter_append_length_clean {l m : List α}
     · have := length_pos_of_ne_nil (l := m) (by rintro rfl; simp at h)
       omega
     · omega
+
+/-! ### Append-then-destutter
+
+`destutterConcat` — append, then collapse the single run that may form at the seam — is the
+multiplication of the destutter quotient monoid (built on the free monoid in
+`Mathlib.Algebra.FreeMonoid.Destutter`). Associativity and the unit laws reduce to the
+`++`-congruences above, so they are pure `List` facts and live here. -/
+
+/-- **Append then destutter**: concatenate, then collapse the single run that may form at
+the seam. The multiplication of the destutter quotient monoid. -/
+def destutterConcat (x y : List α) : List α := (x ++ y).destutter (· ≠ ·)
+
+/-- `destutterConcat` outputs are stutter-free. -/
+theorem isChain_destutterConcat (x y : List α) :
+    (destutterConcat x y).IsChain (· ≠ ·) := isChain_destutter (· ≠ ·) (x ++ y)
+
+/-- `destutterConcat` is associative — inherited from `++` through `destutter`. -/
+theorem destutterConcat_assoc (x y z : List α) :
+    destutterConcat (destutterConcat x y) z = destutterConcat x (destutterConcat y z) := by
+  simp only [destutterConcat, destutter_append_left, destutter_append_right, List.append_assoc]
+
+theorem nil_destutterConcat (x : List α) :
+    destutterConcat [] x = x.destutter (· ≠ ·) := rfl
+
+theorem destutterConcat_nil (x : List α) :
+    destutterConcat x [] = x.destutter (· ≠ ·) := by simp [destutterConcat]
+
+/-- `destutter (· ≠ ·)` carries `(List α, ++)` onto `(·, destutterConcat)`. -/
+theorem destutter_append_eq_destutterConcat (x y : List α) :
+    (x ++ y).destutter (· ≠ ·)
+      = destutterConcat (x.destutter (· ≠ ·)) (y.destutter (· ≠ ·)) := by
+  rw [destutterConcat, ← destutter_append_destutter]
 
 end List

--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -536,6 +536,10 @@ open CategoryTheory MonoidalCategory
   leftUnitor X := eqToIso (one_mul X)
   rightUnitor X := eqToIso (mul_one X)
 
+/-- The monoidal product **is** the object-monoid multiplication (both are `concat`): the
+    explicit bridge between the categorical `⊗` and the decategorified `*`. -/
+@[simp] theorem tensorObj_eq_mul (A B : AR α β) : A ⊗ B = A * B := rfl
+
 instance : MonoidalCategory (AR α β) :=
   MonoidalCategory.ofTensorHom
     (id_tensorHom_id := Hom.concatMap_id)
@@ -571,8 +575,8 @@ def isPlanar : ObjectProperty (AR α β) := fun A => A.toGraph.IsPlanar
 
 /-- Planarity is a **monoidal property**: the unit is planar and `concat`
     preserves planarity (using the left factor's in-boundedness via
-    `Graph.isPlanar_concat`). This is the categorical content of the NCC's
-    morpheme-modularity ([bermudez-otero-2012]). -/
+    `Graph.isPlanar_concat`). This is the categorical content of [jardine-heinz-2015]'s
+    NCC-preservation result (their Theorem 4: every concatenation satisfies the NCC). -/
 instance instIsMonoidalIsPlanar : (isPlanar (α := α) (β := β)).IsMonoidal where
   prop_unit := Graph.isPlanar_empty
   prop_tensor X₁ _X₂ h₁ h₂ := Graph.isPlanar_concat X₁.inBounds h₁ h₂
@@ -612,12 +616,15 @@ instance [DecidableEq α] (A : AR α β) : Decidable (upperOCPClean A) :=
     smallest label/backbone pair admitting two equal upper elements. -/
 private def ocpWitness : AR Bool Unit := ⟨⟨.ofList [true], .empty, ∅⟩, by decide⟩
 
-/-- The OCP is **not** morpheme-modular: concatenation can create an adjacent
-    identical autosegment pair at the morpheme boundary — a violation present in
-    neither factor. Witnessed by two single-autosegment reps (`⟨[true], [], ∅⟩`)
-    whose concatenation has upper tier `[true, true]`. The OCP-clean ARs are
-    therefore not closed under `⊗`; the boundary violation is what forces a repair
-    (`OCP.collapse`; see `collapse_repairs_boundary`). -/
+/-- OCP-cleanness is **not** closed under the bare coproduct `⊗` (`concat`): concatenation
+    can abut an identical autosegment pair at the morpheme boundary — a violation present in
+    neither factor. Witnessed by two single-autosegment reps (`⟨[true], [], ∅⟩`) whose
+    concatenation has upper tier `[true, true]`. This is why [jardine-heinz-2015] build the
+    melody-tier *merge* into their concatenation `◦`: the bare coproduct here is `◦` with the
+    merge stripped out, and the merge restores the OCP (their Theorem 5; `OCP.collapse` as the
+    repair, `collapse_repairs_boundary`; `Collapse.isCleanAR_gconcatAR` for closure under `◦`).
+    So the OCP is a monoidal *quotient* (closed under fusion-`◦`), not a monoidal *sub*-object
+    (closed under the coproduct) — the dual situation to the NCC (`ncc_isMonoidal`). -/
 theorem ocp_not_isMonoidal : ¬ (upperOCPClean (α := Bool) (β := Unit)).IsMonoidal := by
   intro h
   haveI := h.toTensorLE
@@ -627,10 +634,11 @@ theorem ocp_not_isMonoidal : ¬ (upperOCPClean (α := Bool) (β := Unit)).IsMono
   revert hc
   decide
 
-/-- The discriminating dichotomy: the monoidal structure of `WellFormedAR` classifies the
-    NCC as morpheme-modular (closed under `⊗`) and the OCP as not
-    (boundary-spanning). The two halves cannot be interchanged — that is what
-    makes the monoidal product load-bearing rather than decorative. -/
+/-- The discriminating dichotomy ([jardine-heinz-2015] Theorems 4 vs 5): under the bare
+    coproduct `⊗` the NCC is preserved (closed, a monoidal *sub*-object) but the OCP is not
+    (boundary-spanning). The OCP is recovered only as a *quotient*, by the fusion merge that
+    `◦` builds in. The two halves cannot be interchanged — that is what makes the monoidal
+    product load-bearing rather than decorative. -/
 theorem ncc_modular_ocp_not :
     (isPlanar (α := Bool) (β := Unit)).IsMonoidal ∧
     ¬ (upperOCPClean (α := Bool) (β := Unit)).IsMonoidal :=

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -3,14 +3,16 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Core.Algebra.FreeMonoid.Destutter
 import Linglib.Phonology.OCP
 import Linglib.Phonology.Autosegmental.Realization
 
 /-!
 # OCP-merging collapse of autosegmental representations
 
-[jardine-2019]'s tone realization `g_T` is **OCP-merging**: `g_T(Hⁿ)` is a *single*
-H node multiply associated to the `n` morae, not `n` separate H nodes. The
+A merging tone realization ([jardine-2019]; the melody-merging naming function of
+[jardine-heinz-2015], Mende example) is **OCP-merging**: a tonal melody `Hⁿ` realizes as a
+*single* H node multiply associated to the `n` morae, not `n` separate H nodes. The
 project's `Autosegmental.realize` (`Realization.lean`) instead uses the bridge-only
 `concat` (the categorical coproduct), which keeps the `n` H nodes apart. This file
 supplies the missing merge as a post-processing retraction on the upper tier:
@@ -20,7 +22,7 @@ supplies the missing merge as a post-processing retraction on the upper tier:
   `(k, j)` is repointed to `(ρ k, j)`, where `ρ` (`runIdx`) sends an upper position to
   the index of its run in the collapsed tier. The lower tier is untouched, so a merged
   node keeps *all* the morae its run was associated with (multiple association).
-* `realizeMerged := collapseAR ∘ realize` — the OCP-merging realization `g_T`.
+* `realizeMerged := collapseAR ∘ realize` — the OCP-merging realization.
 
 The upper-tier collapse is exactly `OCP.collapse` (= `List.destutter (· ≠ ·)`); the
 link pushforward is the `SimpleGraph.map`/`Quiver.Push` idiom
@@ -29,7 +31,7 @@ link pushforward is the `SimpleGraph.map`/`Quiver.Push` idiom
 
 ## The AR-level OCP quotient monoid
 
-`collapseAR` is the AR-level lift of `OCP.collapseHom`: a retraction onto the OCP-clean
+`collapseAR` is the AR-level lift of `FreeMonoid.destutterHom`: a retraction onto the OCP-clean
 ARs that descends to a quotient of the concat monoid `AR α β`. The key congruence is
 `collapseAR_concat` — the AR shadow of `OCP.collapse_append`, whose links half reduces to
 `runIdx` commuting with the collapse-collapse seam (`runIdx_append_collapse_left/right`,
@@ -44,6 +46,14 @@ in turn the boundary-length lemma `List.destutter_append_length_clean`). It bund
 * `collapseAR_id_on_clean` — `collapseAR` retracts onto its OCP-clean fixed points.
 * `instMonoidCleanAR` / `collapseARHom` / `ocpARQuotientEquiv` — the AR-level OCP quotient
   monoid, its bundled hom, and the first-isomorphism equivalence.
+* `upperHom` / `upperHomClean_comp_collapseARHom` — the upper-tier projection and the
+  decategorification square: the AR-level OCP quotient maps onto the tier-level one.
+* `autosegment_mul_self` / `ocpPresentation` — the tier-level OCP-clean monoid is presented
+  by idempotent autosegments `⟨α | a · a = a⟩`; the OCP is a monoidal **quotient**, the
+  counterpart to the No-Crossing Constraint's monoidal **subcategory** (`ncc_isMonoidal`).
+* `collapse_not_reflective` — that quotient does *not* categorify: `collapse` is not a
+  reflector (a morphism can split a geminate), so the OCP quotient lives on the object monoid,
+  not the category — the precise sense in which OCP and NCC differ.
 -/
 
 namespace Autosegmental
@@ -242,7 +252,7 @@ theorem collapseGraph_concat {A B : Graph α β}
 /-! ### Collapse on ARs -/
 
 /-- **OCP-merging collapse** on ARs: `collapseGraph` repackaged with its in-bounds
-    proof. The AR-level lift of `OCP.collapseHom` — the run-collapse carrying the
+    proof. The AR-level lift of `FreeMonoid.destutterHom` — the run-collapse carrying the
     association lines the flat tier-string discards. -/
 def collapseAR (A : AR α β) : AR α β where
   toGraph := collapseGraph A.toGraph
@@ -269,7 +279,7 @@ theorem collapseAR_concat (A B : AR α β) :
 The base object `AR α β` carries the concatenation monoid (`AR.instMonoid`); `collapseAR`
 is the OCP retraction onto its OCP-clean fixed points. `collapseAR_concat` is the
 homomorphism law, so `collapseAR` bundles as `collapseARHom : AR α β →* {A // IsCleanAR A}`
-— the AR-level lift of `OCP.collapseHom`, carrying the association lines the flat
+— the AR-level lift of `FreeMonoid.destutterHom`, carrying the association lines the flat
 tier-string discards. As a mathlib quotient, `{A // IsCleanAR A}` is
 `AR α β ⧸ Con.ker collapseARHom` (`ocpARQuotientEquiv`). -/
 
@@ -355,7 +365,7 @@ instance instMonoidCleanAR : Monoid {A : AR α β // IsCleanAR A} where
     rw [← AR.mul_eq_concat, mul_one, collapseAR_id_on_clean A.2]
 
 /-- The bundled AR-level OCP quotient map. `collapseAR_concat` is its `map_mul`; the AR-level
-    lift of `OCP.collapseHom`. -/
+    lift of `FreeMonoid.destutterHom`. -/
 def collapseARHom : AR α β →* {A : AR α β // IsCleanAR A} where
   toFun A := ⟨collapseAR A, isCleanAR_collapseAR _⟩
   map_one' := Subtype.ext collapseAR_one
@@ -376,18 +386,189 @@ theorem collapseARHom_surjective :
 
 /-- **First isomorphism theorem for the AR-level OCP quotient.** The abstract quotient
     `AR α β ⧸ OCP` is the concrete OCP-clean model `{A // IsCleanAR A}` ([jardine-2019]'s
-    OCP-merging realization, now carrying the association lines). -/
-noncomputable def ocpARQuotientEquiv :
+    OCP-merging realization, now carrying the association lines). Computable: an OCP-clean AR
+    is its own collapse, the right inverse. -/
+def ocpARQuotientEquiv :
     (ocpConAR (α := α) (β := β)).Quotient ≃* {A : AR α β // IsCleanAR A} :=
-  Con.quotientKerEquivOfSurjective collapseARHom collapseARHom_surjective
+  Con.quotientKerEquivOfRightInverse collapseARHom (·.1)
+    (fun C => Subtype.ext (collapseAR_id_on_clean C.2))
+
+/-! ### The decategorification square: the OCP as a monoidal quotient
+
+Forgetting morphisms and the lower tier, the upper-tier projection `upperHom : AR α β →*
+FreeMonoid α` (concatenation appends upper tiers) carries the AR-level OCP quotient down to
+the *tier-level* one, and the square
+
+```
+        (AR α β, concat)  ──collapseARHom──►  {A // IsCleanAR A}
+              │                                      │
+        upperHom │                                   │ upperHomClean
+              ▼                                       ▼
+        FreeMonoid α ──destutterHom──►  {l // IsClean l}  ≃  PresentedMonoid ⟨α | a · a = a⟩
+```
+
+commutes (`upperHomClean_comp_collapseARHom`). The bottom-right model is the monoid
+**presented by idempotent autosegments** `⟨α | a · a = a⟩` (`ocpPresentation`, via
+`FreeMonoid.presentedMonoidEquiv`): each autosegment is idempotent (`autosegment_mul_self`),
+which *is* the OCP. This is the precise sense in which the OCP is "monoidal" — a monoidal
+**quotient**, in contrast to the No-Crossing Constraint, which is a monoidal **subcategory**
+(`ncc_isMonoidal`); the OCP-clean objects are *not* closed under the monoidal product
+(`ocp_not_isMonoidal`), so no sub-object will do. The square is a `MonoidHom` identity in the
+decategorified monoid `(AR α β, concat)`; the `IsMonoidal` facts live one level up, in the
+monoidal category `(AR α β, ⊗ = coproduct)`. -/
+
+/-- The upper tier of a collapse is the tier-level collapse of the upper tier: the engine of
+the decategorification square. -/
+@[simp] theorem upper_collapseAR (A : AR α β) :
+    (collapseAR A).upper.toList = collapse A.upper.toList := by
+  simp [collapseAR, collapseGraph_upper, LabeledTuple.toList_ofList]
+
+/-- **Upper-tier projection** as a monoid hom `AR α β →* FreeMonoid α`: morpheme
+concatenation appends upper tiers (`AR.concat_upper`, `LabeledTuple.toList_concat`). The
+decategorification of an autosegmental representation to its melodic tier string. -/
+def upperHom : AR α β →* FreeMonoid α where
+  toFun A := FreeMonoid.ofList A.upper.toList
+  map_one' := rfl
+  map_mul' A B := by
+    simp only [AR.mul_eq_concat, AR.concat_upper, LabeledTuple.toList_concat,
+      FreeMonoid.ofList_append]
+
+omit [DecidableEq α] in
+@[simp] theorem upperHom_apply (A : AR α β) :
+    upperHom A = FreeMonoid.ofList A.upper.toList := rfl
+
+/-- The projection restricts to OCP-clean representations onto OCP-clean tiers: `IsCleanAR`
+is by definition cleanness of the upper tier. -/
+def upperHomClean : {A : AR α β // IsCleanAR A} →* {l : List α // IsClean l} where
+  toFun A := ⟨A.1.upper.toList, A.2⟩
+  map_one' := rfl
+  map_mul' A B := Subtype.ext <| by
+    show (collapseAR (A.1.concat B.1)).upper.toList =
+      List.destutterConcat A.1.upper.toList B.1.upper.toList
+    rw [upper_collapseAR, AR.concat_upper, LabeledTuple.toList_concat]
+    rfl
+
+/-- **The decategorification square commutes.** Projecting to the upper tier intertwines the
+AR-level OCP quotient map with the tier-level one (`FreeMonoid.destutterHom`): collapse then
+project equals project then collapse. -/
+theorem upperHomClean_comp_collapseARHom :
+    upperHomClean.comp (collapseARHom (α := α) (β := β))
+      = FreeMonoid.destutterHom.comp upperHom := by
+  refine MonoidHom.ext fun A => Subtype.ext ?_
+  show (collapseAR A).upper.toList = (FreeMonoid.ofList A.upper.toList).toList.destutter (· ≠ ·)
+  rw [upper_collapseAR, FreeMonoid.toList_ofList]
+  rfl
+
+/-! #### The OCP-clean tier monoid is presented by idempotent autosegments -/
+
+/-- A single autosegment as a (trivially) OCP-clean tier. -/
+def autosegment (a : α) : {l : List α // IsClean l} := ⟨[a], isClean_singleton a⟩
+
+/-- **The OCP, as a monoid equation.** Fusion-gluing an autosegment to a copy of itself
+returns the one autosegment: each generator is idempotent, `a · a = a`. This is the
+*tier-string* shadow of OCP-driven fusion ([mccarthy-1986]'s gemination); the multiple
+association it creates — one melody node linked to several timing slots — lives at the AR
+level (`collapseARHom`), which the tier-string projection discards. -/
+@[simp] theorem autosegment_mul_self (a : α) :
+    autosegment a * autosegment a = autosegment a :=
+  Subtype.ext (by simp [autosegment, List.coe_mul, List.destutterConcat, List.destutter_pair])
+
+/-- **The OCP-clean tier monoid is the presented monoid `⟨α | a · a = a⟩`**
+(`FreeMonoid.presentedMonoidEquiv`), with `collapse` computing its normal forms — the
+bottom-right corner of the decategorification square. With `ocp_not_isMonoidal`, this is the
+precise content of "the OCP is monoidal": a monoidal *quotient*, the counterpart to the
+No-Crossing Constraint's monoidal *subcategory* (`ncc_isMonoidal`). -/
+def ocpPresentation :
+    {l : List α // IsClean l} ≃* PresentedMonoid (FreeMonoid.destutterRel α) :=
+  FreeMonoid.presentedMonoidEquiv.symm
+
+/-! #### The OCP quotient does not categorify: `collapse` is not a reflector
+
+`collapseAR` is an idempotent retraction on *objects* (`collapseAR_idempotent`,
+`collapseAR_id_on_clean`), so one might hope OCP-clean were a *reflective subcategory* of `AR`
+with `collapseAR` the reflector — the exact categorical dual of `ncc_isMonoidal`. It is
+**not**. An autosegmental morphism is an arbitrary label-preserving position map, so it can
+send a morpheme-internal geminate to two *distinct* like nodes of a clean target; the
+collapse, having already merged the geminate into one node, cannot separate them, so no
+universal factorization exists. The OCP quotient is therefore irreducibly decategorified: it
+lives on the object monoid `(AR, concat)`, not on the category. -/
+
+/-- Source with an upper-tier geminate `[true, true]` (not OCP-clean). -/
+private abbrev gemSrc : AR Bool Unit := ⟨⟨.ofList [true, true], .empty, ∅⟩, by decide⟩
+
+/-- Clean target `[true, false, true]`: the two `true`s are non-adjacent. -/
+private abbrev cleanTgt : AR Bool Unit := ⟨⟨.ofList [true, false, true], .empty, ∅⟩, by decide⟩
+
+/-- The **geminate-splitting morphism** `[true, true] ⟶ [true, false, true]`, sending the two
+`true` nodes to the *distinct* clean positions 0 and 2 — a valid label-preserving morphism. -/
+private abbrev splitHom : gemSrc ⟶ cleanTgt :=
+  { fU := { toFun := fun i => if i.val = 0 then ⟨0, by decide⟩ else ⟨2, by decide⟩
+            label_comp := by decide }
+    fL := { toFun := id, label_comp := rfl }
+    links_preserve := by intro i j _ _ h; simp at h }
+
+/-- **`collapse` is not a reflector.** OCP-clean is not a reflective subcategory of `AR`:
+there is a clean target `B` and a morphism `g : A ⟶ B` injective on the upper tier (it keeps
+a geminate apart) out of a source `A` whose collapse strictly merges that tier. Such a `g`
+cannot factor through the collapse — the dual of `ncc_isMonoidal` fails, and the OCP quotient
+exists only after decategorification. -/
+theorem collapse_not_reflective :
+    ∃ (A B : AR Bool Unit) (g : A ⟶ B),
+      IsCleanAR B ∧ Function.Injective g.fU.toFun ∧
+        (collapseAR A).upper.len < A.upper.len :=
+  ⟨gemSrc, cleanTgt, splitHom, by decide, by decide, by decide⟩
+
+/-! #### J&H Theorem 5 and the tier asymmetry
+
+[jardine-heinz-2015] build the OCP merge *into* their concatenation `◦`, and their **Theorem
+5** is that `◦` preserves the OCP. Here `◦` is `gconcatAR` (collapse after the bare coproduct
+`concat`), and Theorem 5 is `isCleanAR_gconcatAR`: OCP-clean ARs are closed under
+fusion-concatenation, where they are *not* closed under the bare coproduct
+(`ocp_not_isMonoidal`). That is the genuine sub-vs-quotient asymmetry — the NCC survives the
+coproduct (`ncc_isMonoidal`), the OCP needs the merge.
+
+The merge acts on the *upper* (melody) tier only: `collapseAR` leaves the lower (timing) tier
+untouched (`collapseAR_lower`). So the two tier projections carry different algebra — the
+upper is destuttered (`upper_collapseAR`, the OCP quotient), the lower is **free**, invariant
+under collapse (`lowerHom_collapseAR`). This is [jardine-heinz-2015]'s §7 prediction in
+algebraic form: the melody tier fuses, so contour tones are *bounded*; the timing tier does
+not, so spreading is *unbounded*. -/
+
+/-- **[jardine-heinz-2015] Theorem 5.** OCP-clean ARs are closed under fusion-concatenation
+`◦` (`gconcatAR`): the merge built into `◦` preserves the OCP, where the bare coproduct
+`concat` does not (`ocp_not_isMonoidal`). The positive half of the sub-vs-quotient dichotomy. -/
+theorem isCleanAR_gconcatAR (A B : AR α β) : IsCleanAR (gconcatAR A B) :=
+  isCleanAR_collapseAR _
+
+/-- `collapseAR` leaves the lower (timing) tier untouched: the merge is upper-tier only. -/
+@[simp] theorem collapseAR_lower (A : AR α β) : (collapseAR A).lower = A.lower := rfl
+
+/-- **Lower-tier projection** as a monoid hom `AR α β →* FreeMonoid β`: concatenation appends
+lower tiers. The timing-tier decategorification, dual to `upperHom`. -/
+def lowerHom : AR α β →* FreeMonoid β where
+  toFun A := FreeMonoid.ofList A.lower.toList
+  map_one' := rfl
+  map_mul' A B := by
+    simp only [AR.mul_eq_concat, AR.concat_lower, LabeledTuple.toList_concat,
+      FreeMonoid.ofList_append]
+
+omit [DecidableEq α] in
+@[simp] theorem lowerHom_apply (A : AR α β) :
+    lowerHom A = FreeMonoid.ofList A.lower.toList := rfl
+
+/-- **The timing tier is free.** Unlike the melody tier — which `collapse` destutters
+(`upper_collapseAR`) — the lower tier is *invariant* under collapse: it is not quotiented.
+The algebraic form of the spreading/contour asymmetry ([jardine-heinz-2015] §7). -/
+@[simp] theorem lowerHom_collapseAR (A : AR α β) : lowerHom (collapseAR A) = lowerHom A := by
+  simp [lowerHom]
 
 /-! ### The OCP-merging realization -/
 
 variable {S : Type*}
 
-/-- **The OCP-merging realization** `g_T` ([jardine-2019]): realize the string via the
+/-- **The OCP-merging realization** ([jardine-2019]): realize the string via the
     bridge-only `concat`, then fuse adjacent identical upper nodes
-    (`collapseAR ∘ realize`). Unlike `realize`, `realizeMerged gT (Hⁿ)` is a single H
+    (`collapseAR ∘ realize`). Unlike `realize`, `realizeMerged g₀ (Hⁿ)` is a single H
     node multiply associated — the merge that renders unbounded tone plateauing a
     *local* AR pattern. -/
 def realizeMerged (g₀ : S → AR α β) (w : List S) : AR α β := collapseAR (realize g₀ w)

--- a/Linglib/Phonology/OCP.lean
+++ b/Linglib/Phonology/OCP.lean
@@ -3,15 +3,13 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Mathlib.Algebra.FreeMonoid.Basic
-import Mathlib.GroupTheory.Congruence.Basic
-import Linglib.Core.Algebra.FreeMonoid.Destutter
+import Linglib.Core.Data.List.Destutter
 
 /-!
 # The Obligatory Contour Principle
 
 The categorical, strict-identity, single-tier OCP: the ban on two *identical* adjacent
-autosegments on one tier ([mccarthy-1986]), on a projected tier for `IsCleanOn`
+autosegments on one tier ([leben-1973], [mccarthy-1986]), on a projected tier for `IsCleanOn`
 ([chandlee-jardine-2019]). As a stringset the constraint is tier-based strictly local
 (TSL₂, [heinz-rawal-tanner-2011]), characterised in `OCP`. The
 fusion repair `collapse` is mathlib's
@@ -26,10 +24,6 @@ and lives in the thresholded-TSL substrate, not here.
 
 * `OCP.IsClean` / `OCP.IsCleanOn` — OCP-cleanness, flat and on a projected tier.
 * `OCP.collapse` — the fusion repair (OCP-merger normal form).
-* `OCP.gconcat` / `OCP.collapseHom` / `OCP.ocpCon` / `OCP.ocpQuotientEquiv` — the OCP quotient
-  monoid `(OCP-clean, gconcat, [])`, read off the theory-neutral
-  `Core.Algebra.FreeMonoid.Destutter` substrate (the `Monoid {l // IsClean l}` instance is
-  inherited from there).
 * `OCP.block` — the blocking repair (antigemination guard).
 
 ## Main results
@@ -37,8 +31,10 @@ and lives in the thresholded-TSL substrate, not here.
 * `collapse_eq_destutter` — the fusion repair is `List.destutter`.
 * `collapse_clean` / `collapse_eq_self_iff` — `collapse` is the retraction onto `IsClean`.
 * `collapse_sublist` — fusion never adds material.
-* `collapse_append` — `collapse` is the quotient hom: `(OCP-clean, gconcat, [])` is the
-  quotient `(List α, ++)/OCP` (the monoid laws live on the substrate).
+* `collapse_append` — `collapse` is the OCP congruence: collapsing each operand before `++`
+  is harmless, so `collapse` descends to the OCP quotient of `(List α, ++)` (the quotient
+  monoid and its presentation `⟨α | a · a = a⟩` live on the `Core.Algebra.FreeMonoid.Destutter`
+  substrate; the autosegmental reading is in `Autosegmental.Collapse`).
 * `block_eq_self` — antigemination: a rule is blocked when it would violate the OCP.
 -/
 
@@ -50,7 +46,8 @@ variable {α β : Type*}
 
 /-- A tier is **OCP-clean** when no adjacent pair is identical. Adjacency-only, so
 weaker than `List.Nodup` (`[1, 2, 1]` is clean). A reducible alias of the substrate
-predicate, so the `Core.Algebra.FreeMonoid.Destutter` monoid instance transfers. -/
+predicate `List.IsChain (· ≠ ·)`, so the substrate's `Monoid {l // l.IsChain (· ≠ ·)}`
+applies to OCP-clean tiers downstream. -/
 abbrev IsClean (xs : List α) : Prop :=
   List.IsChain (· ≠ ·) xs
 
@@ -125,8 +122,9 @@ theorem mem_collapse {a : α} {xs : List α} (ha : a ∈ collapse xs) : a ∈ xs
 /-! ### The OCP congruence: `collapse` as a quotient homomorphism
 
 `collapse` descends to a homomorphism on the OCP quotient of `(List α, ++)`: collapsing
-each operand before appending is harmless. This is what makes `(OCP-clean, gconcat, [])` the
-quotient `(List α, ++)/OCP`, bundled below as `collapseHom` over the substrate monoid. -/
+each operand before appending is harmless. This is what makes the OCP-clean tiers under
+fusion-concatenation (`List.destutterConcat`) the quotient `(List α, ++)/OCP` — bundled on
+the `Core.Algebra.FreeMonoid.Destutter` substrate as `FreeMonoid.destutterHom`. -/
 
 /-- Collapsing the left operand before appending does not change the result. -/
 theorem collapse_append_left (x y : List α) :
@@ -144,33 +142,16 @@ theorem collapse_append (x y : List α) :
     collapse (x ++ y) = collapse (collapse x ++ collapse y) :=
   List.destutter_append_destutter x y
 
-/-! ### The bundled OCP quotient monoid (read off `Core.Algebra.FreeMonoid.Destutter`)
+/-! ### The blocking repair
 
-The construction is theory-neutral (`List.destutterConcat`, `FreeMonoid.destutterHom`, the
-`Monoid {l // l.IsChain (· ≠ ·)}` instance); the names below read it as autosegmental tier
-fusion. The `Monoid {l // IsClean l}` instance is inherited from the substrate, since
-`IsClean` is a reducible alias of `List.IsChain (· ≠ ·)`. -/
-
-/-- **OCP-gluing concatenation** `∘`: concatenate, then merge the new boundary geminate. The
-multiplication of the OCP quotient monoid (`List.destutterConcat`). -/
-abbrev gconcat (x y : List α) : List α := List.destutterConcat x y
-
-/-- The bundled OCP quotient map `FreeMonoid α →* {l // IsClean l}`
-(`FreeMonoid.destutterHom`), reading destutter normalization as OCP fusion. -/
-abbrev collapseHom : FreeMonoid α →* {l : List α // IsClean l} := FreeMonoid.destutterHom
-
-/-- The **OCP congruence** on the free monoid: the kernel of `collapseHom`
-(`FreeMonoid.destutterCon`). The OCP quotient monoid is `ocpCon.Quotient`. -/
-abbrev ocpCon : Con (FreeMonoid α) := FreeMonoid.destutterCon
-
-/-- **First isomorphism theorem for the OCP quotient** ([mccarthy-1986]). The abstract
-quotient monoid `FreeMonoid α ⧸ OCP` is the concrete OCP-clean model `{l // IsClean l}`
-(`FreeMonoid.destutterQuotientEquiv`). -/
-noncomputable abbrev ocpQuotientEquiv :
-    (ocpCon (α := α)).Quotient ≃* {l : List α // IsClean l} :=
-  FreeMonoid.destutterQuotientEquiv
-
-/-! ### The blocking repair -/
+The substrate provides the OCP quotient monoid (OCP-clean tiers under fusion-concatenation,
+`List.destutterConcat`) and its identification with the monoid presented by idempotent
+autosegments `⟨α | a · a = a⟩`
+(`Core.Algebra.FreeMonoid.Destutter`). The autosegmental reading of that quotient — the
+decategorification square against the categorical representation, contrasting the OCP (a
+monoidal quotient) with the No-Crossing Constraint (a monoidal subcategory) — lives
+downstream in `Autosegmental.Collapse`, which can see both `Autosegmental.ncc_isMonoidal` and
+`Autosegmental.ocp_not_isMonoidal`. -/
 
 variable (rule : List α → List α)
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -141,6 +141,16 @@
   sources   = {Phenomena/Reference/Studies/SikosEtAl2021.lean;Phenomena/Reference/Studies/SikosEtAl2021Bridge.lean}
 }% REF: George, B. R. (2011). Question Embedding and the Semantics of Answers. UCLA PhD dissertation.
 % REF: Pantcheva, M. B. (2011). Decomposing Path: The Nanosyntax of Directional Expressions.
+@phdthesis{leben-1973,
+  author    = {Leben, William Ronald},
+  year      = {1973},
+  title     = {Suprasegmental Phonology},
+  school    = {Massachusetts Institute of Technology},
+  type      = {Ph.D. Dissertation},
+  subfield  = {phonology/autosegmental},
+  role      = {cited},
+  sources   = {Phonology/OCP.lean}
+}
 @phdthesis{pantcheva-2011,
   author    = {Pantcheva, Marina Blagoeva},
   year      = {2011},


### PR DESCRIPTION
The OCP-clean autosegmental tiers form the monoid **presented by idempotent generators** ⟨α | a·a = a⟩ — a monoidal *quotient* (fusion is the quotient map), not a sub-object. Random-file audit of `Core/Algebra/FreeMonoid/Destutter.lean` that grew into the full structure.

- **Core substrate**: the destutter monoid is `PresentedMonoid ⟨α | a·a = a⟩` (`presentedMonoidEquiv`) with a universal property `destutterLift` (free monoid on idempotent generators, the `FreeMonoid.lift` analogue); `destutterConcat` filed under `Data/List`, the algebra under `Algebra/FreeMonoid` (mathlib mirror).
- **Autosegmental**: the decategorification square (upper-tier projection intertwines the AR- and tier-level OCP quotients); J&H 2015 Theorem 5 (`isCleanAR_gconcatAR`); the tier asymmetry (melody quotiented, timing free); and `collapse_not_reflective` — the quotient provably does *not* categorify (a morphism splits a geminate).
- **Faithfulness**: reframed `ocp_not_isMonoidal` (non-closure is the bare coproduct; J&H's `◦` restores the OCP), dropped a misattribution, added `[leben-1973]`.