### PR TITLE
refactor(Features): retire requiresComparisonClass; Dimension→enum

### DIFF
--- a/Linglib/Features/PropertyDomain.lean
+++ b/Linglib/Features/PropertyDomain.lean
@@ -22,7 +22,6 @@ temperature, ...) and projects to a `PropertyDomain` via
 
 * `PropertyDomain` — the broad perceptual/cognitive channel.
 * `PerceptualDimension` — a named scalar dimension, with a `domain` view.
-* `PropertyDomain.requiresComparisonClass` — coarse relative/absolute tag.
 -/
 
 namespace Features
@@ -41,41 +40,6 @@ inductive PropertyDomain where
   | psychological
   | state
   deriving Repr, DecidableEq, Inhabited
-
-/-- Whether adjectives in this domain are typically **relative** gradable
-    adjectives, whose standard is fixed against a contextual comparison
-    class ([kennedy-2007], [kennedy-mcnally-2005]). Size, evaluative,
-    psychological, and sensory domains are relative; color, material,
-    orientation, and state are absolute — the standard sits at a scale
-    endpoint, or the adjective is non-gradable.
-
-    This is a coarse domain-keyed heuristic. The principled classification
-    runs off scale structure, not perceptual domain:
-    `Semantics.Degree.PositiveStandard.RequiresComparisonClass` derives the
-    same distinction from an adjective's `Boundedness`, and the two can
-    diverge (mildly-positive adjectives such as *decent* receive a
-    functional standard the domain heuristic misses). The heuristic also
-    collapses the maximum-standard, minimum-standard, and non-gradable
-    distinctions ([rotstein-winter-2004]) into a single `False`. -/
-def PropertyDomain.requiresComparisonClass : PropertyDomain → Prop
-  | .size          => True   -- tall, short, big, wide, ...
-  | .evaluative    => True   -- expensive, good, ...
-  | .psychological => True   -- smart, ...
-  | .sensory       => True   -- hot, cold, ...
-  | .color         => False  -- yellow, red, ...
-  | .material      => False  -- wooden, metal, ...
-  | .orientation   => False  -- vertical, horizontal, ...
-  | .state         => False  -- full, wet, dead, ...
-
-instance : DecidablePred PropertyDomain.requiresComparisonClass
-  | .size          => inferInstanceAs (Decidable True)
-  | .evaluative    => inferInstanceAs (Decidable True)
-  | .psychological => inferInstanceAs (Decidable True)
-  | .sensory       => inferInstanceAs (Decidable True)
-  | .color         => inferInstanceAs (Decidable False)
-  | .material      => inferInstanceAs (Decidable False)
-  | .orientation   => inferInstanceAs (Decidable False)
-  | .state         => inferInstanceAs (Decidable False)
 
 /-- A named scalar dimension that a gradable adjective measures along.
     Used via leading-dot syntax in adjective entries

--- a/Linglib/Features/PropertyDomain.lean
+++ b/Linglib/Features/PropertyDomain.lean
@@ -4,23 +4,33 @@
 [giles-etal-2026] [wolfe-horowitz-2017]
 
 A taxonomy of perceptual and cognitive channels that classify the
-dimension a gradable adjective measures along. The first four domains
-(`color`, `size`, `material`, `orientation`) have established perceptual-
-discriminability profiles in the visual-search literature; the rest are
-inventoried for typological completeness.
+dimension a gradable adjective measures along. `color`, `material`, and
+`orientation` are features known to guide visual search
+([wolfe-horowitz-2017]); [giles-etal-2026] manipulates their perceptual
+discriminability and finds colour resists reduction to discriminability
+alone. These channels, together with `size`, carry the noise parameters
+used by the RSA reference model; the remaining domains are inventoried
+for typological completeness.
 
-`Dimension` pairs a human-readable name with a `PropertyDomain` and is
-populated by the smart constructors below; the bridge to noise
-parameters (`Features.PropertyDomain.noiseDiscrimination`) lives in
+`PerceptualDimension` names the individual dimensions (height, cost,
+temperature, ...) and projects to a `PropertyDomain` via
+`PerceptualDimension.domain`. The bridge to noise parameters
+(`Features.PropertyDomain.noiseDiscrimination`) lives in
 `Pragmatics/RSA/Channel.lean`.
+
+## Main definitions
+
+* `PropertyDomain` — the broad perceptual/cognitive channel.
+* `PerceptualDimension` — a named scalar dimension, with a `domain` view.
+* `PropertyDomain.requiresComparisonClass` — coarse relative/absolute tag.
 -/
 
 namespace Features
 
 /-- Broad perceptual/cognitive domain that a gradable dimension belongs to.
-    The first four (`color`, `size`, `material`, `orientation`) have
-    established noise parameters in `RSA.Noise`; the rest are classified
-    but not yet parameterised. -/
+    `color`, `size`, `material`, and `orientation` carry noise parameters
+    in `RSA.Noise` (via `noiseDiscrimination`); the rest are classified but
+    not parameterised. -/
 inductive PropertyDomain where
   | color
   | size
@@ -32,92 +42,76 @@ inductive PropertyDomain where
   | state
   deriving Repr, DecidableEq, Inhabited
 
-/-- A named dimension classified by its perceptual domain. -/
-structure Dimension where
-  name : String
-  domain : PropertyDomain
+/-- Whether adjectives in this domain are typically **relative** gradable
+    adjectives, whose standard is fixed against a contextual comparison
+    class ([kennedy-2007], [kennedy-mcnally-2005]). Size, evaluative,
+    psychological, and sensory domains are relative; color, material,
+    orientation, and state are absolute — the standard sits at a scale
+    endpoint, or the adjective is non-gradable.
+
+    This is a coarse domain-keyed heuristic. The principled classification
+    runs off scale structure, not perceptual domain:
+    `Semantics.Degree.PositiveStandard.RequiresComparisonClass` derives the
+    same distinction from an adjective's `Boundedness`, and the two can
+    diverge (mildly-positive adjectives such as *decent* receive a
+    functional standard the domain heuristic misses). The heuristic also
+    collapses the maximum-standard, minimum-standard, and non-gradable
+    distinctions ([rotstein-winter-2004]) into a single `False`. -/
+def PropertyDomain.requiresComparisonClass : PropertyDomain → Prop
+  | .size          => True   -- tall, short, big, wide, ...
+  | .evaluative    => True   -- expensive, good, ...
+  | .psychological => True   -- smart, ...
+  | .sensory       => True   -- hot, cold, ...
+  | .color         => False  -- yellow, red, ...
+  | .material      => False  -- wooden, metal, ...
+  | .orientation   => False  -- vertical, horizontal, ...
+  | .state         => False  -- full, wet, dead, ...
+
+instance : DecidablePred PropertyDomain.requiresComparisonClass
+  | .size          => inferInstanceAs (Decidable True)
+  | .evaluative    => inferInstanceAs (Decidable True)
+  | .psychological => inferInstanceAs (Decidable True)
+  | .sensory       => inferInstanceAs (Decidable True)
+  | .color         => inferInstanceAs (Decidable False)
+  | .material      => inferInstanceAs (Decidable False)
+  | .orientation   => inferInstanceAs (Decidable False)
+  | .state         => inferInstanceAs (Decidable False)
+
+/-- A named scalar dimension that a gradable adjective measures along.
+    Used via leading-dot syntax in adjective entries
+    (`{ ..., dimension := .height, ... }`); its perceptual channel is
+    recovered with `PerceptualDimension.domain`. -/
+inductive PerceptualDimension where
+  -- Size
+  | height | width | length | weight | thickness | depth | speed
+  | strength | age | generalSize
+  -- Sensory
+  | temperature | brightness | volume
+  -- Evaluative
+  | happiness | cost | price | quality | value | danger | beauty
+  | importance | safety
+  -- Psychological
+  | intelligence | expectation | possibility | confidence
+  -- State
+  | fullness | wetness | cleanliness | straightness | flatness | openness
+  | freedom | tightness | alive | pregnancy | hardness | smoothness | purity
+  | cracking | denting | scratching | shattering
+  -- Perceptual (RSA noise connection)
+  | color
   deriving Repr, DecidableEq, Inhabited
 
-/-- Whether adjectives in this domain typically require comparison-class
-    computation for interpretation. Size, evaluative, psychological, and
-    sensory domains contain relative gradable adjectives (RGAs) interpreted
-    relative to a contextually-determined standard. Color, material,
-    orientation, and state domains contain adjectives with more stable
-    meanings.
-
-    [sedivy-etal-1999] showed that comparison-class-dependent
-    (scalar) adjectives trigger contrastive inferences in referential
-    contexts, while non-dependent (color) adjectives do not. -/
-def PropertyDomain.requiresComparisonClass : PropertyDomain → Bool
-  | .size          => true   -- tall, short, big, wide, ...
-  | .evaluative    => true   -- expensive, good, ...
-  | .psychological => true   -- smart, ...
-  | .sensory       => true   -- hot, cold, ...
-  | .color         => false  -- yellow, red, ...
-  | .material      => false  -- wooden, metal, ...
-  | .orientation   => false  -- vertical, horizontal, ...
-  | .state         => false  -- full, wet, dead, ...
-
--- Smart constructors for `Dimension`, organised by domain.
--- Used via anonymous-constructor syntax in adjective entries:
---   `{ ..., dimension := .height, ... } : GradableAdjEntry`
-
--- Size domain
-def Dimension.height      : Dimension := ⟨"height",      .size⟩
-def Dimension.width       : Dimension := ⟨"width",       .size⟩
-def Dimension.length      : Dimension := ⟨"length",      .size⟩
-def Dimension.weight      : Dimension := ⟨"weight",      .size⟩
-def Dimension.thickness   : Dimension := ⟨"thickness",   .size⟩
-def Dimension.depth       : Dimension := ⟨"depth",       .size⟩
-def Dimension.speed       : Dimension := ⟨"speed",       .size⟩
-def Dimension.strength    : Dimension := ⟨"strength",    .size⟩
-def Dimension.age         : Dimension := ⟨"age",         .size⟩
-def Dimension.generalSize : Dimension := ⟨"size",        .size⟩
-
--- Sensory domain
-def Dimension.temperature : Dimension := ⟨"temperature", .sensory⟩
-def Dimension.brightness  : Dimension := ⟨"brightness",  .sensory⟩
-def Dimension.volume      : Dimension := ⟨"volume",      .sensory⟩
-
--- Evaluative domain
-def Dimension.happiness   : Dimension := ⟨"happiness",   .evaluative⟩
-def Dimension.cost        : Dimension := ⟨"cost",        .evaluative⟩
-def Dimension.price       : Dimension := ⟨"price",       .evaluative⟩
-def Dimension.quality     : Dimension := ⟨"quality",     .evaluative⟩
-def Dimension.value       : Dimension := ⟨"value",       .evaluative⟩
-def Dimension.danger      : Dimension := ⟨"danger",      .evaluative⟩
-def Dimension.beauty      : Dimension := ⟨"beauty",      .evaluative⟩
-def Dimension.importance  : Dimension := ⟨"importance",  .evaluative⟩
-def Dimension.safety      : Dimension := ⟨"safety",      .evaluative⟩
-
--- Psychological domain
-def Dimension.intelligence : Dimension := ⟨"intelligence", .psychological⟩
-def Dimension.expectation  : Dimension := ⟨"expectation",  .psychological⟩
-def Dimension.possibility  : Dimension := ⟨"possibility",  .psychological⟩
-def Dimension.confidence   : Dimension := ⟨"confidence",   .psychological⟩
-
--- State domain
-def Dimension.fullness      : Dimension := ⟨"fullness",      .state⟩
-def Dimension.wetness       : Dimension := ⟨"wetness",       .state⟩
-def Dimension.cleanliness   : Dimension := ⟨"cleanliness",   .state⟩
-def Dimension.straightness  : Dimension := ⟨"straightness",  .state⟩
-def Dimension.flatness      : Dimension := ⟨"flatness",      .state⟩
-def Dimension.openness      : Dimension := ⟨"openness",      .state⟩
-def Dimension.freedom       : Dimension := ⟨"freedom",       .state⟩
-def Dimension.tightness     : Dimension := ⟨"tightness",     .state⟩
-def Dimension.alive         : Dimension := ⟨"alive",         .state⟩
-def Dimension.pregnancy     : Dimension := ⟨"pregnancy",     .state⟩
-def Dimension.hardness      : Dimension := ⟨"hardness",      .state⟩
-def Dimension.smoothness    : Dimension := ⟨"smoothness",    .state⟩
-def Dimension.purity        : Dimension := ⟨"purity",        .state⟩
-def Dimension.cracking      : Dimension := ⟨"cracking",      .state⟩
-def Dimension.denting       : Dimension := ⟨"denting",       .state⟩
-def Dimension.scratching    : Dimension := ⟨"scratching",    .state⟩
-def Dimension.shattering    : Dimension := ⟨"shattering",    .state⟩
-
--- Perceptual domain (RSA noise connection)
-def Dimension.color       : Dimension := ⟨"color",       .color⟩
-def Dimension.material    : Dimension := ⟨"material",    .material⟩
-def Dimension.orientation : Dimension := ⟨"orientation", .orientation⟩
+/-- The perceptual/cognitive channel a dimension belongs to. -/
+def PerceptualDimension.domain : PerceptualDimension → PropertyDomain
+  | .height | .width | .length | .weight | .thickness | .depth | .speed
+  | .strength | .age | .generalSize => .size
+  | .temperature | .brightness | .volume => .sensory
+  | .happiness | .cost | .price | .quality | .value | .danger | .beauty
+  | .importance | .safety => .evaluative
+  | .intelligence | .expectation | .possibility | .confidence => .psychological
+  | .fullness | .wetness | .cleanliness | .straightness | .flatness
+  | .openness | .freedom | .tightness | .alive | .pregnancy | .hardness
+  | .smoothness | .purity | .cracking | .denting | .scratching
+  | .shattering => .state
+  | .color => .color
 
 end Features

--- a/Linglib/Fragments/English/Modifiers/Adjectives.lean
+++ b/Linglib/Fragments/English/Modifiers/Adjectives.lean
@@ -51,7 +51,7 @@ structure AdjModifierEntry where
   /-- Scale boundedness (from [kennedy-2007]) -/
   scaleType : Boundedness := .open_
   /-- What dimension is being measured? -/
-  dimension : Features.Dimension
+  dimension : Features.PerceptualDimension
   /-- Antonym form (if any) -/
   antonymForm : Option String := none
   /-- Antonym relation: contrary (gap) vs contradictory (no gap) -/

--- a/Linglib/Pragmatics/Implicature/Markedness.lean
+++ b/Linglib/Pragmatics/Implicature/Markedness.lean
@@ -358,7 +358,7 @@ structure MAlternativeSet where
   /-- The unmarked (cheaper) form -/
   unmarked : String
   /-- The dimension they share (e.g., .height) -/
-  dimension : Features.Dimension
+  dimension : Features.PerceptualDimension
   /-- The cost difference between forms -/
   costDifference : ℚ
   /-- Construction where they're equivalent -/

--- a/Linglib/Semantics/Gradability/Basic.lean
+++ b/Linglib/Semantics/Gradability/Basic.lean
@@ -159,7 +159,7 @@ inductive SpatialConfigType where
 structure GradableAdjEntry where
   form : String
   scaleType : Boundedness
-  dimension : Features.Dimension
+  dimension : Features.PerceptualDimension
   antonymForm : Option String := none
   antonymRelation : Option AntonymRelation := none
   spatialConfigType : Option SpatialConfigType := none

--- a/Linglib/Studies/Kennedy2007.lean
+++ b/Linglib/Studies/Kennedy2007.lean
@@ -47,8 +47,8 @@ central claims against the degree substrate and the English adjective Fragment.
 * `k2007_matrix_agrees_with_typology`, `k2007_modifier_data_agrees`,
   `pipeline_agrees_with_measure` — the matrix agrees with the per-adjective
   typology data and with the `DirectedMeasure` / `LicensingPipeline` substrate.
-* `tall_cc_convergence` (etc.) — scale-structure and property-domain paths
-  agree on comparison-class sensitivity for each Fragment adjective.
+* `tall_requires_cc`, `full_no_cc` (etc.) — comparison-class sensitivity
+  read off each Fragment adjective's scale structure.
 -/
 
 namespace Kennedy2007
@@ -619,49 +619,31 @@ theorem pipeline_agrees_with_measure {max : Nat} {W : Type*} (μ : W → Degree 
 
 /-! #### Scale structure → comparison-class sensitivity
 
-[kennedy-2007]'s scale structure and `PropertyDomain.requiresComparisonClass`
-are two independent classifications that converge on the same prediction for
-whether an adjective's standard depends on contextual domain information:
+Whether an adjective's standard depends on contextual domain information is
+read off its scale structure ([kennedy-2007]): `scaleType → interpretiveEconomy
+→ PositiveStandard → PositiveStandard.RequiresComparisonClass`. An open scale
+yields a contextual **s** (requires a comparison class); a closed scale fixes
+the standard at an endpoint via Interpretive Economy.
 
-- **Scale-structure path** ([kennedy-2007]): `scaleType → interpretiveEconomy
-  → PositiveStandard → PositiveStandard.RequiresComparisonClass`.
-  Open scale → contextual **s** → requires a comparison class.
-- **Domain path** ([sedivy-etal-1999]): `dimension.domain →
-  PropertyDomain.requiresComparisonClass`.
+Kennedy argues that the comparison class is descriptively real but NOT a
+semantic argument of *pos*; it feeds into **s** contextually rather than as a
+constituent of logical form. -/
 
-Kennedy argues (§2.3) that the comparison class is descriptively real but NOT a
-semantic argument of *pos*; `requiresComparisonClass` tracks whether contextual
-domain information is needed — compatible with that view, since the information
-feeds into **s** contextually rather than as a constituent of logical form. The
-two paths agree on the canonical adjectives sampled below, but the coarse domain
-heuristic can diverge from scale structure — `mpa_ie_exception` exhibits a
-mildly-positive adjective (*decent*) where they disagree. -/
+/-- "tall": open scale ⇒ CC-dependence. -/
+theorem tall_requires_cc :
+    (interpretiveEconomy tall.scaleType).RequiresComparisonClass := trivial
 
-/-- "tall": both paths predict CC-dependence. -/
-theorem tall_cc_convergence :
-    (interpretiveEconomy tall.scaleType).RequiresComparisonClass ∧
-    tall.dimension.domain.requiresComparisonClass :=
-  ⟨trivial, trivial⟩
+/-- "full": maximum-standard (closed scale) ⇒ CC-independence. -/
+theorem full_no_cc :
+    ¬ (interpretiveEconomy full.scaleType).RequiresComparisonClass := id
 
-/-- "full": both paths predict CC-independence. -/
-theorem full_no_cc_convergence :
-    ¬ (interpretiveEconomy full.scaleType).RequiresComparisonClass ∧
-    ¬ full.dimension.domain.requiresComparisonClass :=
-  ⟨id, id⟩
+/-- "wet": lower-bounded ⇒ endpoint standard ⇒ CC-independence. -/
+theorem wet_no_cc :
+    ¬ (interpretiveEconomy wet.scaleType).RequiresComparisonClass := id
 
-/-- "wet": both paths predict CC-independence
-    (lower-bounded → endpoint standard; state domain). -/
-theorem wet_no_cc_convergence :
-    ¬ (interpretiveEconomy wet.scaleType).RequiresComparisonClass ∧
-    ¬ wet.dimension.domain.requiresComparisonClass :=
-  ⟨id, id⟩
-
-/-- "dry": both paths predict CC-independence
-    (upper-bounded → endpoint standard; state domain). -/
-theorem dry_no_cc_convergence :
-    ¬ (interpretiveEconomy dry.scaleType).RequiresComparisonClass ∧
-    ¬ dry.dimension.domain.requiresComparisonClass :=
-  ⟨id, id⟩
+/-- "dry": upper-bounded ⇒ endpoint standard ⇒ CC-independence. -/
+theorem dry_no_cc :
+    ¬ (interpretiveEconomy dry.scaleType).RequiresComparisonClass := id
 
 /-! #### MPA licensing ([beltrama-2025]) -/
 
@@ -685,8 +667,7 @@ theorem mpa_good_same_licensing :
     Economy, distinct from *good*'s exception. -/
 theorem mpa_ie_exception :
     (interpretiveEconomy decent.scaleType) = .minEndpoint ∧
-    ¬ (interpretiveEconomy decent.scaleType).RequiresComparisonClass ∧
-    decent.dimension.domain.requiresComparisonClass := ⟨rfl, id, trivial⟩
+    ¬ (interpretiveEconomy decent.scaleType).RequiresComparisonClass := ⟨rfl, id⟩
 
 /-! #### Modifier-class matrix consistency (eq. (61)) -/
 

--- a/Linglib/Studies/Kennedy2007.lean
+++ b/Linglib/Studies/Kennedy2007.lean
@@ -632,34 +632,36 @@ whether an adjective's standard depends on contextual domain information:
 Kennedy argues (§2.3) that the comparison class is descriptively real but NOT a
 semantic argument of *pos*; `requiresComparisonClass` tracks whether contextual
 domain information is needed — compatible with that view, since the information
-feeds into **s** contextually rather than as a constituent of logical form. For
-every concrete Fragment adjective, the two paths agree. -/
+feeds into **s** contextually rather than as a constituent of logical form. The
+two paths agree on the canonical adjectives sampled below, but the coarse domain
+heuristic can diverge from scale structure — `mpa_ie_exception` exhibits a
+mildly-positive adjective (*decent*) where they disagree. -/
 
 /-- "tall": both paths predict CC-dependence. -/
 theorem tall_cc_convergence :
     (interpretiveEconomy tall.scaleType).RequiresComparisonClass ∧
-    tall.dimension.domain.requiresComparisonClass = true :=
-  ⟨trivial, rfl⟩
+    tall.dimension.domain.requiresComparisonClass :=
+  ⟨trivial, trivial⟩
 
 /-- "full": both paths predict CC-independence. -/
 theorem full_no_cc_convergence :
     ¬ (interpretiveEconomy full.scaleType).RequiresComparisonClass ∧
-    full.dimension.domain.requiresComparisonClass = false :=
-  ⟨id, rfl⟩
+    ¬ full.dimension.domain.requiresComparisonClass :=
+  ⟨id, id⟩
 
 /-- "wet": both paths predict CC-independence
     (lower-bounded → endpoint standard; state domain). -/
 theorem wet_no_cc_convergence :
     ¬ (interpretiveEconomy wet.scaleType).RequiresComparisonClass ∧
-    wet.dimension.domain.requiresComparisonClass = false :=
-  ⟨id, rfl⟩
+    ¬ wet.dimension.domain.requiresComparisonClass :=
+  ⟨id, id⟩
 
 /-- "dry": both paths predict CC-independence
     (upper-bounded → endpoint standard; state domain). -/
 theorem dry_no_cc_convergence :
     ¬ (interpretiveEconomy dry.scaleType).RequiresComparisonClass ∧
-    dry.dimension.domain.requiresComparisonClass = false :=
-  ⟨id, rfl⟩
+    ¬ dry.dimension.domain.requiresComparisonClass :=
+  ⟨id, id⟩
 
 /-! #### MPA licensing ([beltrama-2025]) -/
 
@@ -684,7 +686,7 @@ theorem mpa_good_same_licensing :
 theorem mpa_ie_exception :
     (interpretiveEconomy decent.scaleType) = .minEndpoint ∧
     ¬ (interpretiveEconomy decent.scaleType).RequiresComparisonClass ∧
-    decent.dimension.domain.requiresComparisonClass = true := ⟨rfl, id, rfl⟩
+    decent.dimension.domain.requiresComparisonClass := ⟨rfl, id, trivial⟩
 
 /-! #### Modifier-class matrix consistency (eq. (61)) -/
 

--- a/Linglib/Studies/RonderosEtAl2024.lean
+++ b/Linglib/Studies/RonderosEtAl2024.lean
@@ -433,16 +433,16 @@ infrastructure (`Features.PropertyDomain`, `RSA.Noise`,
 theorem scalar_shares_sedivy_domain :
     AdjType.toDomain .scalar = SedivyEtAl1999.adjDomain ∧
     Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .scalar) = true :=
-  ⟨rfl, rfl⟩
+      (AdjType.toDomain .scalar) :=
+  ⟨rfl, trivial⟩
 
 /-- **Disagreement with the comparison-class-only mechanism on color.**
     Color does *not* require comparison-class binding (so the
     Bierwisch/Sedivy mechanism alone predicts no contrast effect for
     color), yet Ronderos finds a robust color contrast effect. -/
 theorem color_does_not_require_comparison_class :
-    Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .color) = false := rfl
+    ¬ Features.PropertyDomain.requiresComparisonClass
+      (AdjType.toDomain .color) := id
 
 /-- **Material fails the comparison-class route.** Material adjectives,
     like color, do not require comparison-class binding — so the
@@ -451,8 +451,8 @@ theorem color_does_not_require_comparison_class :
     is insufficient for color, however; see
     `color_does_not_require_comparison_class`.) -/
 theorem material_does_not_require_comparison_class :
-    Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .material) = false := rfl
+    ¬ Features.PropertyDomain.requiresComparisonClass
+      (AdjType.toDomain .material) := id
 
 /-- **Effect ordering aligns with noise discrimination.** The
     perceptual-discrimination route predicts the cross-category
@@ -489,8 +489,8 @@ theorem adjType_to_noise_discrimination :
     those above the material level produce a contrast effect. The
     baseline-restrictiveness family is keyed off
     `Features.PropertyDomain.requiresComparisonClass` (semantic route):
-    only the scalar (size) domain returns `true`, predicting the
-    no-contrast baseline disadvantage to be uniquely scalar.
+    only the scalar (size) domain requires a comparison class, predicting
+    the no-contrast baseline disadvantage to be uniquely scalar.
 
     This theorem records the two-mechanism factorisation as a typed
     statement: the scalar adjective type is the *unique* one whose
@@ -503,15 +503,15 @@ theorem adjType_to_noise_discrimination :
 theorem two_mechanisms_factorise :
     -- Semantic route: scalar uniquely requires comparison class
     Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .scalar) = true ∧
-    Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .color) = false ∧
-    Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .material) = false ∧
+      (AdjType.toDomain .scalar) ∧
+    ¬ Features.PropertyDomain.requiresComparisonClass
+      (AdjType.toDomain .color) ∧
+    ¬ Features.PropertyDomain.requiresComparisonClass
+      (AdjType.toDomain .material) ∧
     -- Perceptual route: color and scalar strictly above material
     RSA.Noise.colorDiscrimination > RSA.Noise.materialDiscrimination ∧
     RSA.Noise.sizeDiscrimination > RSA.Noise.materialDiscrimination :=
-  ⟨rfl, rfl, rfl,
+  ⟨trivial, id, id,
    lt_trans RSA.Noise.size_gt_material RSA.Noise.color_gt_size,
    RSA.Noise.size_gt_material⟩
 

--- a/Linglib/Studies/RonderosEtAl2024.lean
+++ b/Linglib/Studies/RonderosEtAl2024.lean
@@ -2,6 +2,7 @@ import Mathlib.Data.Rat.Defs
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.DeriveFintype
 import Linglib.Features.PropertyDomain
+import Linglib.Semantics.Degree.Defs
 import Linglib.Processing.VisualWorld
 import Linglib.Pragmatics.RSA.Channel
 import Linglib.Studies.SedivyEtAl1999
@@ -120,9 +121,9 @@ Two prior accounts of the contrastive inference effect:
    [bierwisch-1989]): scalar adjectives carry a free
    comparison-class variable, bound by visual context, which makes
    the contrast pair pragmatically informative. Predicts an effect
-   for scalar but *not* for color or material (color and material do
-   not require a comparison class — see
-   `Features.PropertyDomain.requiresComparisonClass`).
+   for scalar but *not* for color or material (color and material are
+   non-gradable, so require no comparison class — see `AdjType.toClass`
+   and `AdjectiveClass.IsRelative`).
 
 2. **Perceptual discrimination** ([kursat-degen-2021],
    [giles-etal-2026]): high perceptual discriminability makes a
@@ -150,15 +151,13 @@ is observable independent of any contrast manipulation.
   channel) cannot satisfy `SatisfiesRonderosPattern` because it would
   predict equal contrast effects for all adjective types — a useful
   negative result that could itself be a theorem.
-- **Connection to `Semantics/Gradability/`**: Ronderos's
-  semantic factor (scalar = gradable + comparison-class-dependent;
-  color/material = non-gradable) is currently mediated only through
-  `Features.PropertyDomain.requiresComparisonClass`. A deeper bridge
-  would tie `AdjType.scalar` to the
-  `Semantics.Gradability.Classification` subsective/comparison-class
-  hierarchy, so the "scalar requires a comparison class" claim is
-  derivable from gradability theory rather than projected via the
-  domain table.
+- **Connection to `Semantics/Degree/`**: Ronderos's semantic factor
+  (scalar = gradable + comparison-class-dependent; color/material =
+  non-gradable) is derived through `AdjType.toClass`, which maps each
+  adjective type to a Kennedy-style `Semantics.Degree.AdjectiveClass`.
+  The "scalar requires a comparison class" claim then follows from
+  `AdjectiveClass.IsRelative`, grounded in gradability theory rather
+  than projected via a perceptual-domain table.
 -/
 
 namespace RonderosEtAl2024
@@ -195,6 +194,16 @@ def AdjType.toDomain : AdjType → Features.PropertyDomain
   | .color    => .color
   | .scalar   => .size
   | .material => .material
+
+/-- Map an adjective type to its Kennedy-style scale-structure class
+    ([kennedy-2007], [kennedy-mcnally-2005]). Ronderos's semantic factor:
+    scalar adjectives are gradable and interpreted against a comparison
+    class (`relativeGradable`); color and material encode non-gradable
+    properties (`nonGradable`), interpreted in absolute terms. -/
+def AdjType.toClass : AdjType → Semantics.Degree.AdjectiveClass
+  | .scalar   => .relativeGradable
+  | .color    => .nonGradable
+  | .material => .nonGradable
 
 -- ============================================================================
 -- §2. Cell
@@ -428,21 +437,19 @@ infrastructure (`Features.PropertyDomain`, `RSA.Noise`,
 
 /-- **Agreement with [sedivy-etal-1999] on scalar adjectives.**
     Both studies place the scalar contrast effect on the size domain,
-    which `Features.PropertyDomain` flags as requiring comparison-class
-    binding. -/
+    and scalar adjectives are relative gradable adjectives — interpreted
+    against a comparison class ([kennedy-2007]). -/
 theorem scalar_shares_sedivy_domain :
     AdjType.toDomain .scalar = SedivyEtAl1999.adjDomain ∧
-    Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .scalar) :=
-  ⟨rfl, trivial⟩
+    (AdjType.toClass .scalar).IsRelative :=
+  ⟨rfl, rfl⟩
 
 /-- **Disagreement with the comparison-class-only mechanism on color.**
     Color does *not* require comparison-class binding (so the
     Bierwisch/Sedivy mechanism alone predicts no contrast effect for
     color), yet Ronderos finds a robust color contrast effect. -/
 theorem color_does_not_require_comparison_class :
-    ¬ Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .color) := id
+    ¬ (AdjType.toClass .color).IsRelative := by decide
 
 /-- **Material fails the comparison-class route.** Material adjectives,
     like color, do not require comparison-class binding — so the
@@ -451,8 +458,7 @@ theorem color_does_not_require_comparison_class :
     is insufficient for color, however; see
     `color_does_not_require_comparison_class`.) -/
 theorem material_does_not_require_comparison_class :
-    ¬ Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .material) := id
+    ¬ (AdjType.toClass .material).IsRelative := by decide
 
 /-- **Effect ordering aligns with noise discrimination.** The
     perceptual-discrimination route predicts the cross-category
@@ -487,31 +493,28 @@ theorem adjType_to_noise_discrimination :
     `Features.PropertyDomain.noiseDiscrimination` (perceptual route): all
     three adjective types have *some* discrimination value, but only
     those above the material level produce a contrast effect. The
-    baseline-restrictiveness family is keyed off
-    `Features.PropertyDomain.requiresComparisonClass` (semantic route):
-    only the scalar (size) domain requires a comparison class, predicting
+    baseline-restrictiveness family is keyed off `AdjType.toClass` /
+    `AdjectiveClass.IsRelative` (semantic route): only the scalar type is
+    a relative gradable adjective — requiring a comparison class — predicting
     the no-contrast baseline disadvantage to be uniquely scalar.
 
     This theorem records the two-mechanism factorisation as a typed
     statement: the scalar adjective type is the *unique* one whose
-    domain requires a comparison class; color and material are the
+    class is relative gradable; color and material are the
     *two* whose domains have noise discrimination strictly above the
     material baseline (where "above the material baseline" means
     "strictly larger" — material is at the floor). The two
     mechanisms therefore make orthogonal predictions, and Ronderos's
     pattern is the joint envelope. -/
 theorem two_mechanisms_factorise :
-    -- Semantic route: scalar uniquely requires comparison class
-    Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .scalar) ∧
-    ¬ Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .color) ∧
-    ¬ Features.PropertyDomain.requiresComparisonClass
-      (AdjType.toDomain .material) ∧
+    -- Semantic route: scalar uniquely is relative gradable (needs a CC)
+    (AdjType.toClass .scalar).IsRelative ∧
+    ¬ (AdjType.toClass .color).IsRelative ∧
+    ¬ (AdjType.toClass .material).IsRelative ∧
     -- Perceptual route: color and scalar strictly above material
     RSA.Noise.colorDiscrimination > RSA.Noise.materialDiscrimination ∧
     RSA.Noise.sizeDiscrimination > RSA.Noise.materialDiscrimination :=
-  ⟨trivial, id, id,
+  ⟨rfl, by decide, by decide,
    lt_trans RSA.Noise.size_gt_material RSA.Noise.color_gt_size,
    RSA.Noise.size_gt_material⟩
 

--- a/Linglib/Studies/SedivyEtAl1999.lean
+++ b/Linglib/Studies/SedivyEtAl1999.lean
@@ -137,7 +137,7 @@ def adjDomain : Features.PropertyDomain := .size
     stipulation: it follows from `Features.PropertyDomain.requiresComparisonClass`
     by reduction. -/
 theorem adjDomain_requires_comparison_class :
-    Features.PropertyDomain.requiresComparisonClass adjDomain = true := rfl
+    Features.PropertyDomain.requiresComparisonClass adjDomain := trivial
 
 -- ============================================================================
 -- §2. Norming Data (Table 5)

--- a/Linglib/Studies/SedivyEtAl1999.lean
+++ b/Linglib/Studies/SedivyEtAl1999.lean
@@ -3,6 +3,7 @@ import Mathlib.Data.Fintype.Sigma
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.DeriveFintype
 import Linglib.Features.PropertyDomain
+import Linglib.Semantics.Degree.Defs
 import Linglib.Processing.VisualWorld
 
 /-!
@@ -125,19 +126,19 @@ instance : HasDisplayKind Cell where
 
 /-- The perceptual domain targeted by Exps 2 and 3 (scalar size adjectives:
     "tall", "short", "long"). Cross-study bridges use this to connect
-    Sedivy's findings to the comparison-class typology in
+    Sedivy's findings to the perceptual-domain typology in
     `Features.PropertyDomain`. Exp 1's intersective adjectives (color,
     material, shape) live in different domains and are not summarised
     here — see the docstring for the per-experiment breakdown. -/
 def adjDomain : Features.PropertyDomain := .size
 
-/-- The size domain requires comparison-class binding, which is the
-    structural prerequisite for Bierwisch's lexical account of the
-    contrast effect (§5 of [sedivy-etal-1999]). This is not a
-    stipulation: it follows from `Features.PropertyDomain.requiresComparisonClass`
-    by reduction. -/
-theorem adjDomain_requires_comparison_class :
-    Features.PropertyDomain.requiresComparisonClass adjDomain := trivial
+/-- Scalar size adjectives are relative gradable adjectives, interpreted
+    against a comparison class ([kennedy-2007], [kennedy-mcnally-2005]) —
+    the structural prerequisite for Bierwisch's lexical account of the
+    contrast effect (§5 of [sedivy-etal-1999]). -/
+def adjClass : Semantics.Degree.AdjectiveClass := .relativeGradable
+
+theorem adjClass_is_relative : adjClass.IsRelative := rfl
 
 -- ============================================================================
 -- §2. Norming Data (Table 5)
@@ -288,14 +289,13 @@ theorem trivial_satisfies_pattern :
 
 /-! The lexical-semantic account of the contrast effect ([bierwisch-1989],
 adopted in §5 of [sedivy-etal-1999]) places a free comparison-class
-variable in the lexical entry of every scalar adjective. The
-`Features.PropertyDomain` infrastructure flags this with
-`requiresComparisonClass`; the connection is made formal by
-`adjDomain_requires_comparison_class` above.
+variable in the lexical entry of every scalar adjective. Scalar adjectives
+are relative gradable adjectives ([kennedy-2007]); `adjClass_is_relative`
+records this via `Semantics.Degree.AdjectiveClass.IsRelative`.
 
 Note: Exp 1B nonetheless found contrast effects with intersective adjectives,
 attributed to *referential narrowing* rather than comparison-class binding.
-The two mechanisms are theoretically distinct; `requiresComparisonClass`
-captures only the comparison-class route. -/
+The two mechanisms are theoretically distinct; the comparison-class route
+covers only the former. -/
 
 end SedivyEtAl1999

--- a/Linglib/Studies/TesslerGoodman2022.lean
+++ b/Linglib/Studies/TesslerGoodman2022.lean
@@ -582,12 +582,10 @@ Since the weight functions are identical, the § 8 predictions transfer:
 | summer  | warm  | superordinate | `basketball_tall_infers_super` |
 | summer  | cold  | subordinate   | `basketball_short_infers_sub` |
 
-This connects to `Features.PerceptualDimension.temperature`: a `sensory` domain for
-which `requiresComparisonClass` holds ([kennedy-2007]). -/
-
-/-- Temperature is a comparison-class-sensitive dimension. -/
-theorem temperature_requires_cc :
-    Features.PropertyDomain.requiresComparisonClass .sensory := trivial
+This connects to `Features.PerceptualDimension.temperature`: temperature
+adjectives (*warm*/*cold*) are open-scale relative gradable adjectives, so — like
+*tall* — they require a comparison class (`open_scale_requires_cc_inference`;
+[kennedy-2007]). -/
 
 /-- The literal/pragmatic reversal transfers to temperature via the
     winter ↔ jockey mapping. The literal model predicts "warm in winter"

--- a/Linglib/Studies/TesslerGoodman2022.lean
+++ b/Linglib/Studies/TesslerGoodman2022.lean
@@ -582,12 +582,12 @@ Since the weight functions are identical, the § 8 predictions transfer:
 | summer  | warm  | superordinate | `basketball_tall_infers_super` |
 | summer  | cold  | subordinate   | `basketball_short_infers_sub` |
 
-This connects to `Features.Dimension.temperature`: a `sensory` domain with
-`requiresComparisonClass = true` ([sedivy-etal-1999]). -/
+This connects to `Features.PerceptualDimension.temperature`: a `sensory` domain for
+which `requiresComparisonClass` holds ([kennedy-2007]). -/
 
 /-- Temperature is a comparison-class-sensitive dimension. -/
 theorem temperature_requires_cc :
-    Features.PropertyDomain.requiresComparisonClass .sensory = true := rfl
+    Features.PropertyDomain.requiresComparisonClass .sensory := trivial
 
 /-- The literal/pragmatic reversal transfers to temperature via the
     winter ↔ jockey mapping. The literal model predicts "warm in winter"


### PR DESCRIPTION
Recut `Features/PropertyDomain.lean` from a mathlib-quality audit.

- **Retire `PropertyDomain.requiresComparisonClass`** (a stipulated domain-keyed `Bool` table) in favour of scale structure. Comparison-class dependence now derives from `Semantics.Degree`: per-adjective via `interpretiveEconomy ∘ scaleType` (Kennedy2007, TesslerGoodman2022) and per-category via a new `AdjType.toClass → AdjectiveClass.IsRelative` (RonderosEtAl2024, SedivyEtAl1999). Grounded in the same Kennedy/Kennedy–McNally distinction the Ronderos paper's Semantic Factors section invokes (scalar = relative gradable; color/material = non-gradable).
- **`structure Dimension {name, domain}` → `inductive Features.PerceptualDimension`** with a `domain` projection — resolves the `Features.Dimension` struct-vs-namespace clash with the physical `Features.Dimension.Dimension`, drops the never-read `String` field and two dead constructors.
- Fixes the citations (Sedivy 1999 characterization, Wolfe–Horowitz, Giles et al.) and removes the false "the two paths agree" claim in `Kennedy2007` (`mpa_ie_exception` was its own counterexample).