### PR TITLE
feat(Syntax/Adjective): lexical API core; migrate Latin fragment

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2751,6 +2751,7 @@ import Linglib.Studies.Zimmermann2026
 import Linglib.Studies.Zuraw2010
 import Linglib.Studies.ZurawHayes2017
 import Linglib.Studies.ZwickyPullum1983
+import Linglib.Syntax.Adjective.Basic
 import Linglib.Syntax.Adposition.Basic
 import Linglib.Syntax.Adposition.Order
 import Linglib.Syntax.Adposition.Spatial

--- a/Linglib/Fragments/Latin/Adjectives.lean
+++ b/Linglib/Fragments/Latin/Adjectives.lean
@@ -1,12 +1,14 @@
-import Linglib.Morphology.DegreeContainment
+import Linglib.Syntax.Adjective.Basic
 
 /-!
 # Latin Adjective Degree Forms
 [bobaljik-2012]
 
 Latin comparative and superlative morphology, used for cross-linguistic
-verification of [bobaljik-2012]'s *ABA constraint and pattern
-inventory.
+verification of [bobaljik-2012]'s *ABA constraint and pattern inventory. Latin
+adjectives instantiate the general `Adjective` object (`Syntax/Adjective/Basic.lean`),
+carrying their morphology in the `comparison` facet; the data here is purely
+morphological (no scale `dimension`).
 
 Latin exhibits all three attested degree suppletion patterns:
 
@@ -19,80 +21,69 @@ No Latin adjective shows an *ABA pattern.
 
 namespace Latin.Adjectives
 
-open Morphology.DegreeContainment
+open Morphology.DegreeContainment (DegreePattern aaa abb abc)
 
 -- ============================================================================
--- § 1: Latin Adjective Entry
--- ============================================================================
-
-/-- A Latin adjective entry with positive, comparative, and superlative
-    forms plus the suppletive pattern. Minimal structure — Latin data
-    here is purely morphological (no scale type, dimension, etc.). -/
-structure LatinAdjEntry where
-  pos  : String
-  cmpr : String
-  sprl : String
-  suppletion : DegreePattern
-  deriving DecidableEq, Repr, BEq
-
--- ============================================================================
--- § 2: Regular Adjectives (AAA)
+-- § 1: Regular Adjectives (AAA)
 -- ============================================================================
 
 /-- *longus – longior – longissimus* ('long'): regular synthetic
     comparative and superlative with productive suffixes *-ior*/*-issimus*. -/
-def longus : LatinAdjEntry :=
-  { pos := "longus", cmpr := "longior", sprl := "longissimus"
-  , suppletion := aaa }
+def longus : Adjective :=
+  { form := "longus"
+  , comparison := { formComp := "longior", formSuper := "longissimus", suppletion := aaa } }
 
 /-- *altus – altior – altissimus* ('tall/high/deep'): regular. -/
-def altus : LatinAdjEntry :=
-  { pos := "altus", cmpr := "altior", sprl := "altissimus"
-  , suppletion := aaa }
+def altus : Adjective :=
+  { form := "altus"
+  , comparison := { formComp := "altior", formSuper := "altissimus", suppletion := aaa } }
 
 /-- *fortis – fortior – fortissimus* ('brave/strong'): regular. -/
-def fortis : LatinAdjEntry :=
-  { pos := "fortis", cmpr := "fortior", sprl := "fortissimus"
-  , suppletion := aaa }
+def fortis : Adjective :=
+  { form := "fortis"
+  , comparison := { formComp := "fortior", formSuper := "fortissimus", suppletion := aaa } }
 
 -- ============================================================================
--- § 3: Suppletive Adjectives
+-- § 2: Suppletive Adjectives
 -- ============================================================================
 
 /-- *bonus – melior – optimus* ('good – better – best'): three distinct
-    roots (ABC). The paradigmatic example of ABC suppletion
-    ([bobaljik-2012]). -/
-def bonus : LatinAdjEntry :=
-  { pos := "bonus", cmpr := "melior", sprl := "optimus"
-  , suppletion := abc }
+    roots (ABC), the paradigmatic ABC example ([bobaljik-2012]). Both grades
+    suppletive. -/
+def bonus : Adjective :=
+  { form := "bonus"
+  , comparison := { formComp := "melior", formSuper := "optimus", suppletion := abc
+                  , comparativeStrategy := .suppletive, superlativeStrategy := .suppletive } }
 
-/-- *malus – peior – pessimus* ('bad – worse – worst'): three distinct
-    roots (ABC). -/
-def malus : LatinAdjEntry :=
-  { pos := "malus", cmpr := "peior", sprl := "pessimus"
-  , suppletion := abc }
+/-- *malus – peior – pessimus* ('bad – worse – worst'): three distinct roots (ABC). -/
+def malus : Adjective :=
+  { form := "malus"
+  , comparison := { formComp := "peior", formSuper := "pessimus", suppletion := abc
+                  , comparativeStrategy := .suppletive, superlativeStrategy := .suppletive } }
 
-/-- *magnus – maior – maximus* ('great – greater – greatest'): ABB.
-    The comparative and superlative share the suppletive root *mai-*/*max-*. -/
-def magnus : LatinAdjEntry :=
-  { pos := "magnus", cmpr := "maior", sprl := "maximus"
-  , suppletion := abb }
+/-- *magnus – maior – maximus* ('great – greater – greatest'): ABB — the
+    comparative and superlative share the suppletive root *mai-*/*max-*. -/
+def magnus : Adjective :=
+  { form := "magnus"
+  , comparison := { formComp := "maior", formSuper := "maximus", suppletion := abb
+                  , comparativeStrategy := .suppletive, superlativeStrategy := .suppletive } }
 
-/-- *parvus – minor – minimus* ('small – smaller – smallest'): ABB.
-    Suppletive root *min-* shared across comparative and superlative. -/
-def parvus : LatinAdjEntry :=
-  { pos := "parvus", cmpr := "minor", sprl := "minimus"
-  , suppletion := abb }
+/-- *parvus – minor – minimus* ('small – smaller – smallest'): ABB, suppletive
+    root *min-* shared across comparative and superlative. -/
+def parvus : Adjective :=
+  { form := "parvus"
+  , comparison := { formComp := "minor", formSuper := "minimus", suppletion := abb
+                  , comparativeStrategy := .suppletive, superlativeStrategy := .suppletive } }
 
 -- ============================================================================
--- § 4: Fragment Inventory
+-- § 3: Fragment Inventory
 -- ============================================================================
 
-def allEntries : List LatinAdjEntry :=
+def allEntries : List Adjective :=
   [longus, altus, fortis, bonus, malus, magnus, parvus]
 
 -- ============================================================================
--- § 5: Contiguity Verification
+-- § 4: Contiguity Verification
 -- ============================================================================
 
 /-- All Latin entries satisfy contiguity (no *ABA). -/

--- a/Linglib/Syntax/Adjective/Basic.lean
+++ b/Linglib/Syntax/Adjective/Basic.lean
@@ -1,0 +1,162 @@
+import Linglib.Semantics.Gradability.Dimension
+import Linglib.Semantics.Degree.Defs
+import Linglib.Semantics.Degree.Kennedy
+import Linglib.Morphology.DegreeContainment
+
+/-!
+# Adjective
+
+Lexical core for the adjective as a grammatical object, modeled on `Syntax/Pronoun/`:
+the general `Adjective` structure (the lexical core every adjective shares) and the
+`GradableAdjective` specialization (which `extends Adjective` with the degree-semantic
+lexical fields). The general concept gets the plain name; specializations `extends` it.
+
+The scale an adjective measures is the `Semantics.Gradability.Dimension` **key**
+(imported as a field, cf. `Pronoun` importing `Person`/`Number`); its boundedness,
+comparison-class dependence, and telicity are *derived views* of that key, not stored.
+The degree **denotation** (`DirectedMeasure`) lives downstream in `Semantics/Gradability`.
+
+## The `scaleType` decomposition
+
+The old `GradableAdjEntry.scaleType : Boundedness` conflated three independent facts and
+contradicted `Dimension.boundedness` (`wet`/`dry` share one closed `.wetness` scale, yet
+stored `.lowerBounded`/`.upperBounded`). They are separated here:
+
+* **shape** — `dimension.boundedness` (derived);
+* **pole** — `isLowerEndpoint` (the *only* thing distinguishing `wet` from `dry`);
+* **standard** — `GradableAdjective.standard`, derived from (shape, pole) with an
+  `Option PositiveStandard` override for the `good`/MPA residual ([kennedy-2007],
+  [kennedy-mcnally-2005]).
+
+## Deferred (earn their consumers, cf. `Pronoun`'s deferred capability tower)
+
+* Agreement φ-features + `toWord` realization — added when an agreeing-language fragment
+  sets them (φ with no setter would be dead fields).
+* Dixon `PCClass` view (`Dimension.pcClass`) — waits on a lightweight `PCClass` home
+  (it currently sits in the heavy `Morphology/RootTypology.lean`).
+* `MultidimAdjective` (Sassoon multidimensionality) and the gradable facets
+  (`evaluativeValence`/`spatialConfigType`/`informationalStrength`/subjectivity).
+* The `Modifier`/`Gradable` capability classes — built at the second-carrier trigger
+  (an `Adverb`/degree-word struct), exactly as `Pronoun` deferred `Proform`.
+
+This is the adjectival realization of a property concept; when a verb- or
+noun-strategy fragment lands, factor a `PropertyConcept` superclass.
+-/
+
+open Semantics.Gradability (Dimension)
+open Semantics.Degree (PositiveStandard AdjectiveClass interpretiveEconomy)
+open Core.Order (Boundedness)
+open Morphology.DegreeContainment (DegreePattern)
+
+set_option autoImplicit false
+
+/-! ### Comparison morphology -/
+
+/-- How a comparative/superlative grade is formed. -/
+inductive Adjective.ComparisonStrategy
+  | synthetic | periphrastic | suppletive
+  deriving DecidableEq, Repr, BEq
+
+/-- Grade-level comparison morphology: the cross-linguistic structure (per-grade
+    formation strategy + the suppletion pattern, whose *ABA constraint lives in
+    `Morphology/DegreeContainment`, [bobaljik-2012]) plus the surface comparative and
+    superlative forms. -/
+structure Adjective.ComparisonFacet where
+  formComp  : Option String := none
+  formSuper : Option String := none
+  comparativeStrategy : Adjective.ComparisonStrategy := .synthetic
+  superlativeStrategy : Adjective.ComparisonStrategy := .synthetic
+  suppletion : DegreePattern := ⟨0, 0, 0⟩
+  /-- Equative strategy, if the language marks it morphologically (not under the
+      comparative/superlative containment). -/
+  equative : Option Adjective.ComparisonStrategy := none
+  deriving DecidableEq, Repr, BEq
+
+/-- No comparison marking (the default). -/
+def Adjective.ComparisonFacet.regular : Adjective.ComparisonFacet := {}
+
+/-! ### The general adjective object -/
+
+/-- The general adjective object: the lexical core every adjective shares — surface
+    form, the scalar `dimension` key + lexicalized pole, comparison morphology, and
+    lexical antonymy. Carries no denotation of its own (cf. `Pronoun`); the degree
+    meaning is derived in `Semantics/Gradability`. Specializations `extends` it.
+    Coexists with `namespace Adjective` (a type and a namespace may share a name). -/
+structure Adjective where
+  /-- Surface form (citation/positive-grade). -/
+  form : String
+  /-- Native script form, when distinct. -/
+  script : Option String := none
+  /-- The scalar dimension measured, as a `Semantics.Gradability.Dimension` key.
+      `none` for classifying/relational adjectives (*wooden*, *former*, *medical*)
+      and other non-gradables. -/
+  dimension : Option Dimension := none
+  /-- Which pole of the scale the adjective lexicalizes (*short*, *empty*, *wet*):
+      the only thing distinguishing polar scale-mates that share one `dimension`. -/
+  isLowerEndpoint : Bool := false
+  /-- Comparative/superlative morphology. -/
+  comparison : Adjective.ComparisonFacet := .regular
+  /-- Lexical antonym's surface form, when it has a stable one. -/
+  antonymForm : Option String := none
+  deriving Repr, DecidableEq, BEq
+
+/-- A gradable adjective: `Adjective` plus the degree-semantic lexical fields
+    (Kennedy). Its well-formedness requires a `dimension`. -/
+structure GradableAdjective extends Adjective where
+  /-- Override the Kennedy default standard (the `good`/MPA residual: an open-shape
+      scale that nonetheless takes a functional/contextual standard, [beltrama-2025]).
+      `none` = take the derived default. -/
+  standardOverride : Option PositiveStandard := none
+  deriving Repr, BEq
+
+namespace Adjective
+
+/-- Gradable iff it carries a scalar dimension — derived (cf. `Pronoun.category`). -/
+def IsGradable (a : Adjective) : Prop := a.dimension.isSome = true
+
+instance (a : Adjective) : Decidable a.IsGradable := by unfold IsGradable; infer_instance
+
+/-- The suppletion pattern of the comparison paradigm — a convenience read of
+    `comparison.suppletion` (the field consumers most often want). -/
+def suppletion (a : Adjective) : DegreePattern := a.comparison.suppletion
+
+end Adjective
+
+namespace GradableAdjective
+
+/-- The scale's intrinsic shape — read off the `dimension` key, not stored. -/
+def scaleType (g : GradableAdjective) : Boundedness :=
+  (g.dimension.map Dimension.boundedness).getD .open_
+
+/-- The effective positive standard: the default from (scale shape, pole),
+    overridable by `standardOverride`. This is the quantity the old `scaleType` field
+    conflated — it separates `wet` (closed + lower ⇒ min) from `dry` (closed + upper ⇒
+    max), and lets `good` (open shape) take a contextual standard rather than a bogus
+    bound. ([kennedy-2007]'s Interpretive Economy on the open/singly-bounded cases.) -/
+def standard (g : GradableAdjective) : PositiveStandard :=
+  g.standardOverride.getD <|
+    match g.dimension.map Dimension.boundedness, g.isLowerEndpoint with
+    | some .closed, true  => .minEndpoint
+    | some .closed, false => .maxEndpoint
+    | some b,       _     => interpretiveEconomy b
+    | none,         _     => .contextual
+
+/-- Kennedy's adjective class — derived from `standard`, not stored
+    ([kennedy-2007], [kennedy-mcnally-2005]). -/
+def adjectiveClass (g : GradableAdjective) : AdjectiveClass :=
+  match g.dimension with
+  | none => .nonGradable
+  | some _ =>
+    match g.standard with
+    | .contextual  => .relativeGradable
+    | .minEndpoint => .absoluteMinimum
+    | .maxEndpoint => .absoluteMaximum
+    | .functional  => .mildlyPositive
+
+/-- Comparison-class dependence — the relative/absolute distinction, derived. -/
+def IsRelative (g : GradableAdjective) : Prop := g.adjectiveClass.IsRelative
+
+instance (g : GradableAdjective) : Decidable g.IsRelative := by
+  unfold IsRelative; infer_instance
+
+end GradableAdjective


### PR DESCRIPTION
Stage 1 of a first-class Adjective API modeled on `Syntax/Pronoun/`.

Depends on #1029 (uses the `Semantics.Gradability.Dimension` carrier).

- New `Syntax/Adjective/Basic.lean`: the general `Adjective` object + `GradableAdjective extends Adjective` (plain name for the general concept, specialization `extends`, Pronoun-style). The `scaleType` category error is fixed by decomposition into derived views: `scaleType` = `dimension.boundedness` (shape), `isLowerEndpoint` (pole), and `GradableAdjective.standard` (derived from shape+pole, overridable) — so `wet`/`dry` (one closed `.wetness` scale, opposite poles) and `good` (open shape, contextual standard) type correctly instead of via a stored field that contradicted `Dimension.boundedness`.
- `Fragments/Latin/Adjectives.lean` migrated to `Adjective` as the first consumer; `Bobaljik2012` unchanged via an `Adjective.suppletion` accessor.
- Deferred (documented, earn-their-consumers, cf. Pronoun's deferred capability tower): agreement φ-features + `toWord`, the Dixon `PCClass` view, `MultidimAdjective`, the gradable facets, and the `Modifier`/`Gradable` capability classes. English unification + the denotation bridge are follow-on stages.