### PR TITLE
feat(Syntax/Adjective): lexical API core; migrate Latin fragment

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2751,6 +2751,7 @@ import Linglib.Studies.Zimmermann2026
 import Linglib.Studies.Zuraw2010
 import Linglib.Studies.ZurawHayes2017
 import Linglib.Studies.ZwickyPullum1983
+import Linglib.Syntax.Adjective.Basic
 import Linglib.Syntax.Adposition.Basic
 import Linglib.Syntax.Adposition.Order
 import Linglib.Syntax.Adposition.Spatial

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -748,6 +748,7 @@ import Linglib.Fragments.English.Distributives
 import Linglib.Fragments.English.Evidentiality
 import Linglib.Fragments.English.FocusParticles
 import Linglib.Fragments.English.FunctionWords
+import Linglib.Fragments.English.GradableAdjectives
 import Linglib.Fragments.English.Indefinites
 import Linglib.Fragments.English.MeasurePhrases
 import Linglib.Fragments.English.Modifiers.Adjectives

--- a/Linglib/Fragments/English/GradableAdjectives.lean
+++ b/Linglib/Fragments/English/GradableAdjectives.lean
@@ -1,0 +1,94 @@
+import Linglib.Syntax.Adjective.Basic
+import Linglib.Semantics.Gradability.Dimension
+import Linglib.Semantics.Degree.Defs
+
+/-!
+# English gradable adjectives (`GradableAdjective`)
+
+Canonical gradable adjectives typed with the `Syntax/Adjective` API, exercising the
+derived Kennedy classification ([kennedy-2007], [kennedy-mcnally-2005]). Each entry
+stores only its scalar `dimension` (and, for a min/max-standard adjective, the
+lexicalized pole `isLowerEndpoint`, or a `standardOverride` for a mildly-positive
+adjective); the scale shape, the positive standard, and the relative/absolute class
+are **derived**, not stored — the fix for the old `scaleType` field that conflated
+scale shape with pole and contradicted `Dimension.boundedness` (`wet`/`dry` share one
+closed `.wetness` scale, differing only in pole).
+
+This is the seed of the unified English adjective fragment; the
+`Predicates/Adjectival.lean` `GradableAdjEntry` set folds in here as the migration
+proceeds.
+-/
+
+open Semantics.Gradability (Dimension)
+open Semantics.Degree (AdjectiveClass PositiveStandard)
+
+namespace English.GradableAdjectives
+
+/-! ### Entries — only the dimension + pole/override are lexical; the rest is derived -/
+
+/-- *tall* — open height scale ⇒ relative. -/
+def tall : GradableAdjective := { form := "tall", dimension := some .height }
+
+/-- *full* — closed fullness scale, upper pole ⇒ maximum-standard. -/
+def full : GradableAdjective := { form := "full", dimension := some .fullness }
+
+/-- *empty* — closed fullness scale, lower pole ⇒ minimum-standard. -/
+def empty : GradableAdjective :=
+  { form := "empty", dimension := some .fullness, isLowerEndpoint := true }
+
+/-- *wet* — closed wetness scale, lower pole ⇒ minimum-standard. -/
+def wet : GradableAdjective :=
+  { form := "wet", dimension := some .wetness, isLowerEndpoint := true }
+
+/-- *dry* — closed wetness scale, upper pole ⇒ maximum-standard. -/
+def dry : GradableAdjective := { form := "dry", dimension := some .wetness }
+
+/-- *straight* — closed straightness scale, upper pole ⇒ maximum-standard. -/
+def straight : GradableAdjective := { form := "straight", dimension := some .straightness }
+
+/-- *bent* — closed straightness scale, lower pole ⇒ minimum-standard. -/
+def bent : GradableAdjective :=
+  { form := "bent", dimension := some .straightness, isLowerEndpoint := true }
+
+/-- *good* — open value scale ⇒ relative. -/
+def good : GradableAdjective := { form := "good", dimension := some .value }
+
+/-- *decent* — a mildly-positive adjective: open shape but a functional standard
+    ([beltrama-2025]), recorded via `standardOverride`. -/
+def decent : GradableAdjective :=
+  { form := "decent", dimension := some .value, standardOverride := some .functional }
+
+/-! ### The derived classification (the API's payoff — all by `rfl`/`decide`) -/
+
+-- scale *shape* is the dimension's; `wet`/`dry` no longer disagree on it:
+theorem tall_open : tall.scaleType = .open_ := rfl
+theorem wet_closed : wet.scaleType = .closed := rfl
+theorem dry_closed : dry.scaleType = .closed := rfl
+
+-- the pole the old `scaleType` conflated, now recovered:
+theorem wet_min : wet.standard = .minEndpoint := rfl
+theorem dry_max : dry.standard = .maxEndpoint := rfl
+
+-- every Kennedy class, derived from (dimension, pole, override):
+theorem tall_relative     : tall.adjectiveClass = .relativeGradable := rfl
+theorem good_relative     : good.adjectiveClass = .relativeGradable := rfl
+theorem full_absMax       : full.adjectiveClass = .absoluteMaximum := rfl
+theorem straight_absMax   : straight.adjectiveClass = .absoluteMaximum := rfl
+theorem dry_absMax        : dry.adjectiveClass = .absoluteMaximum := rfl
+theorem empty_absMin      : empty.adjectiveClass = .absoluteMinimum := rfl
+theorem wet_absMin        : wet.adjectiveClass = .absoluteMinimum := rfl
+theorem bent_absMin       : bent.adjectiveClass = .absoluteMinimum := rfl
+theorem decent_mildlyPos  : decent.adjectiveClass = .mildlyPositive := rfl
+
+-- comparison-class dependence: only the open-scale relatives require one:
+theorem tall_requires_cc  : tall.IsRelative := by decide
+theorem good_requires_cc  : good.IsRelative := by decide
+theorem wet_no_cc         : ¬ wet.IsRelative := by decide
+theorem full_no_cc        : ¬ full.IsRelative := by decide
+theorem decent_no_cc      : ¬ decent.IsRelative := by decide
+
+/-- All these adjectives are gradable (carry a dimension). -/
+theorem all_gradable :
+    tall.IsGradable ∧ full.IsGradable ∧ wet.IsGradable ∧ good.IsGradable := by decide
+
+end English.GradableAdjectives

--- a/Linglib/Fragments/Latin/Adjectives.lean
+++ b/Linglib/Fragments/Latin/Adjectives.lean
@@ -1,12 +1,14 @@
-import Linglib.Morphology.DegreeContainment
+import Linglib.Syntax.Adjective.Basic
 
 /-!
 # Latin Adjective Degree Forms
 [bobaljik-2012]
 
 Latin comparative and superlative morphology, used for cross-linguistic
-verification of [bobaljik-2012]'s *ABA constraint and pattern
-inventory.
+verification of [bobaljik-2012]'s *ABA constraint and pattern inventory. Latin
+adjectives instantiate the general `Adjective` object (`Syntax/Adjective/Basic.lean`),
+carrying their morphology in the `comparison` facet; the data here is purely
+morphological (no scale `dimension`).
 
 Latin exhibits all three attested degree suppletion patterns:
 
@@ -19,80 +21,69 @@ No Latin adjective shows an *ABA pattern.
 
 namespace Latin.Adjectives
 
-open Morphology.DegreeContainment
+open Morphology.DegreeContainment (DegreePattern aaa abb abc)
 
 -- ============================================================================
--- § 1: Latin Adjective Entry
--- ============================================================================
-
-/-- A Latin adjective entry with positive, comparative, and superlative
-    forms plus the suppletive pattern. Minimal structure — Latin data
-    here is purely morphological (no scale type, dimension, etc.). -/
-structure LatinAdjEntry where
-  pos  : String
-  cmpr : String
-  sprl : String
-  suppletion : DegreePattern
-  deriving DecidableEq, Repr, BEq
-
--- ============================================================================
--- § 2: Regular Adjectives (AAA)
+-- § 1: Regular Adjectives (AAA)
 -- ============================================================================
 
 /-- *longus – longior – longissimus* ('long'): regular synthetic
     comparative and superlative with productive suffixes *-ior*/*-issimus*. -/
-def longus : LatinAdjEntry :=
-  { pos := "longus", cmpr := "longior", sprl := "longissimus"
-  , suppletion := aaa }
+def longus : Adjective :=
+  { form := "longus"
+  , comparison := { formComp := "longior", formSuper := "longissimus", suppletion := aaa } }
 
 /-- *altus – altior – altissimus* ('tall/high/deep'): regular. -/
-def altus : LatinAdjEntry :=
-  { pos := "altus", cmpr := "altior", sprl := "altissimus"
-  , suppletion := aaa }
+def altus : Adjective :=
+  { form := "altus"
+  , comparison := { formComp := "altior", formSuper := "altissimus", suppletion := aaa } }
 
 /-- *fortis – fortior – fortissimus* ('brave/strong'): regular. -/
-def fortis : LatinAdjEntry :=
-  { pos := "fortis", cmpr := "fortior", sprl := "fortissimus"
-  , suppletion := aaa }
+def fortis : Adjective :=
+  { form := "fortis"
+  , comparison := { formComp := "fortior", formSuper := "fortissimus", suppletion := aaa } }
 
 -- ============================================================================
--- § 3: Suppletive Adjectives
+-- § 2: Suppletive Adjectives
 -- ============================================================================
 
 /-- *bonus – melior – optimus* ('good – better – best'): three distinct
-    roots (ABC). The paradigmatic example of ABC suppletion
-    ([bobaljik-2012]). -/
-def bonus : LatinAdjEntry :=
-  { pos := "bonus", cmpr := "melior", sprl := "optimus"
-  , suppletion := abc }
+    roots (ABC), the paradigmatic ABC example ([bobaljik-2012]). Both grades
+    suppletive. -/
+def bonus : Adjective :=
+  { form := "bonus"
+  , comparison := { formComp := "melior", formSuper := "optimus", suppletion := abc
+                  , comparativeStrategy := .suppletive, superlativeStrategy := .suppletive } }
 
-/-- *malus – peior – pessimus* ('bad – worse – worst'): three distinct
-    roots (ABC). -/
-def malus : LatinAdjEntry :=
-  { pos := "malus", cmpr := "peior", sprl := "pessimus"
-  , suppletion := abc }
+/-- *malus – peior – pessimus* ('bad – worse – worst'): three distinct roots (ABC). -/
+def malus : Adjective :=
+  { form := "malus"
+  , comparison := { formComp := "peior", formSuper := "pessimus", suppletion := abc
+                  , comparativeStrategy := .suppletive, superlativeStrategy := .suppletive } }
 
-/-- *magnus – maior – maximus* ('great – greater – greatest'): ABB.
-    The comparative and superlative share the suppletive root *mai-*/*max-*. -/
-def magnus : LatinAdjEntry :=
-  { pos := "magnus", cmpr := "maior", sprl := "maximus"
-  , suppletion := abb }
+/-- *magnus – maior – maximus* ('great – greater – greatest'): ABB — the
+    comparative and superlative share the suppletive root *mai-*/*max-*. -/
+def magnus : Adjective :=
+  { form := "magnus"
+  , comparison := { formComp := "maior", formSuper := "maximus", suppletion := abb
+                  , comparativeStrategy := .suppletive, superlativeStrategy := .suppletive } }
 
-/-- *parvus – minor – minimus* ('small – smaller – smallest'): ABB.
-    Suppletive root *min-* shared across comparative and superlative. -/
-def parvus : LatinAdjEntry :=
-  { pos := "parvus", cmpr := "minor", sprl := "minimus"
-  , suppletion := abb }
+/-- *parvus – minor – minimus* ('small – smaller – smallest'): ABB, suppletive
+    root *min-* shared across comparative and superlative. -/
+def parvus : Adjective :=
+  { form := "parvus"
+  , comparison := { formComp := "minor", formSuper := "minimus", suppletion := abb
+                  , comparativeStrategy := .suppletive, superlativeStrategy := .suppletive } }
 
 -- ============================================================================
--- § 4: Fragment Inventory
+-- § 3: Fragment Inventory
 -- ============================================================================
 
-def allEntries : List LatinAdjEntry :=
+def allEntries : List Adjective :=
   [longus, altus, fortis, bonus, malus, magnus, parvus]
 
 -- ============================================================================
--- § 5: Contiguity Verification
+-- § 4: Contiguity Verification
 -- ============================================================================
 
 /-- All Latin entries satisfy contiguity (no *ABA). -/

--- a/Linglib/Syntax/Adjective/Basic.lean
+++ b/Linglib/Syntax/Adjective/Basic.lean
@@ -1,0 +1,162 @@
+import Linglib.Semantics.Gradability.Dimension
+import Linglib.Semantics.Degree.Defs
+import Linglib.Semantics.Degree.Kennedy
+import Linglib.Morphology.DegreeContainment
+
+/-!
+# Adjective
+
+Lexical core for the adjective as a grammatical object, modeled on `Syntax/Pronoun/`:
+the general `Adjective` structure (the lexical core every adjective shares) and the
+`GradableAdjective` specialization (which `extends Adjective` with the degree-semantic
+lexical fields). The general concept gets the plain name; specializations `extends` it.
+
+The scale an adjective measures is the `Semantics.Gradability.Dimension` **key**
+(imported as a field, cf. `Pronoun` importing `Person`/`Number`); its boundedness,
+comparison-class dependence, and telicity are *derived views* of that key, not stored.
+The degree **denotation** (`DirectedMeasure`) lives downstream in `Semantics/Gradability`.
+
+## The `scaleType` decomposition
+
+The old `GradableAdjEntry.scaleType : Boundedness` conflated three independent facts and
+contradicted `Dimension.boundedness` (`wet`/`dry` share one closed `.wetness` scale, yet
+stored `.lowerBounded`/`.upperBounded`). They are separated here:
+
+* **shape** — `dimension.boundedness` (derived);
+* **pole** — `isLowerEndpoint` (the *only* thing distinguishing `wet` from `dry`);
+* **standard** — `GradableAdjective.standard`, derived from (shape, pole) with an
+  `Option PositiveStandard` override for the `good`/MPA residual ([kennedy-2007],
+  [kennedy-mcnally-2005]).
+
+## Deferred (earn their consumers, cf. `Pronoun`'s deferred capability tower)
+
+* Agreement φ-features + `toWord` realization — added when an agreeing-language fragment
+  sets them (φ with no setter would be dead fields).
+* Dixon `PCClass` view (`Dimension.pcClass`) — waits on a lightweight `PCClass` home
+  (it currently sits in the heavy `Morphology/RootTypology.lean`).
+* `MultidimAdjective` (Sassoon multidimensionality) and the gradable facets
+  (`evaluativeValence`/`spatialConfigType`/`informationalStrength`/subjectivity).
+* The `Modifier`/`Gradable` capability classes — built at the second-carrier trigger
+  (an `Adverb`/degree-word struct), exactly as `Pronoun` deferred `Proform`.
+
+This is the adjectival realization of a property concept; when a verb- or
+noun-strategy fragment lands, factor a `PropertyConcept` superclass.
+-/
+
+open Semantics.Gradability (Dimension)
+open Semantics.Degree (PositiveStandard AdjectiveClass interpretiveEconomy)
+open Core.Order (Boundedness)
+open Morphology.DegreeContainment (DegreePattern)
+
+set_option autoImplicit false
+
+/-! ### Comparison morphology -/
+
+/-- How a comparative/superlative grade is formed. -/
+inductive Adjective.ComparisonStrategy
+  | synthetic | periphrastic | suppletive
+  deriving DecidableEq, Repr, BEq
+
+/-- Grade-level comparison morphology: the cross-linguistic structure (per-grade
+    formation strategy + the suppletion pattern, whose *ABA constraint lives in
+    `Morphology/DegreeContainment`, [bobaljik-2012]) plus the surface comparative and
+    superlative forms. -/
+structure Adjective.ComparisonFacet where
+  formComp  : Option String := none
+  formSuper : Option String := none
+  comparativeStrategy : Adjective.ComparisonStrategy := .synthetic
+  superlativeStrategy : Adjective.ComparisonStrategy := .synthetic
+  suppletion : DegreePattern := ⟨0, 0, 0⟩
+  /-- Equative strategy, if the language marks it morphologically (not under the
+      comparative/superlative containment). -/
+  equative : Option Adjective.ComparisonStrategy := none
+  deriving DecidableEq, Repr, BEq
+
+/-- No comparison marking (the default). -/
+def Adjective.ComparisonFacet.regular : Adjective.ComparisonFacet := {}
+
+/-! ### The general adjective object -/
+
+/-- The general adjective object: the lexical core every adjective shares — surface
+    form, the scalar `dimension` key + lexicalized pole, comparison morphology, and
+    lexical antonymy. Carries no denotation of its own (cf. `Pronoun`); the degree
+    meaning is derived in `Semantics/Gradability`. Specializations `extends` it.
+    Coexists with `namespace Adjective` (a type and a namespace may share a name). -/
+structure Adjective where
+  /-- Surface form (citation/positive-grade). -/
+  form : String
+  /-- Native script form, when distinct. -/
+  script : Option String := none
+  /-- The scalar dimension measured, as a `Semantics.Gradability.Dimension` key.
+      `none` for classifying/relational adjectives (*wooden*, *former*, *medical*)
+      and other non-gradables. -/
+  dimension : Option Dimension := none
+  /-- Which pole of the scale the adjective lexicalizes (*short*, *empty*, *wet*):
+      the only thing distinguishing polar scale-mates that share one `dimension`. -/
+  isLowerEndpoint : Bool := false
+  /-- Comparative/superlative morphology. -/
+  comparison : Adjective.ComparisonFacet := .regular
+  /-- Lexical antonym's surface form, when it has a stable one. -/
+  antonymForm : Option String := none
+  deriving Repr, DecidableEq, BEq
+
+/-- A gradable adjective: `Adjective` plus the degree-semantic lexical fields
+    (Kennedy). Its well-formedness requires a `dimension`. -/
+structure GradableAdjective extends Adjective where
+  /-- Override the Kennedy default standard (the `good`/MPA residual: an open-shape
+      scale that nonetheless takes a functional/contextual standard, [beltrama-2025]).
+      `none` = take the derived default. -/
+  standardOverride : Option PositiveStandard := none
+  deriving Repr, BEq
+
+namespace Adjective
+
+/-- Gradable iff it carries a scalar dimension — derived (cf. `Pronoun.category`). -/
+def IsGradable (a : Adjective) : Prop := a.dimension.isSome = true
+
+instance (a : Adjective) : Decidable a.IsGradable := by unfold IsGradable; infer_instance
+
+/-- The suppletion pattern of the comparison paradigm — a convenience read of
+    `comparison.suppletion` (the field consumers most often want). -/
+def suppletion (a : Adjective) : DegreePattern := a.comparison.suppletion
+
+end Adjective
+
+namespace GradableAdjective
+
+/-- The scale's intrinsic shape — read off the `dimension` key, not stored. -/
+def scaleType (g : GradableAdjective) : Boundedness :=
+  (g.dimension.map Dimension.boundedness).getD .open_
+
+/-- The effective positive standard: the default from (scale shape, pole),
+    overridable by `standardOverride`. This is the quantity the old `scaleType` field
+    conflated — it separates `wet` (closed + lower ⇒ min) from `dry` (closed + upper ⇒
+    max), and lets `good` (open shape) take a contextual standard rather than a bogus
+    bound. ([kennedy-2007]'s Interpretive Economy on the open/singly-bounded cases.) -/
+def standard (g : GradableAdjective) : PositiveStandard :=
+  g.standardOverride.getD <|
+    match g.dimension.map Dimension.boundedness, g.isLowerEndpoint with
+    | some .closed, true  => .minEndpoint
+    | some .closed, false => .maxEndpoint
+    | some b,       _     => interpretiveEconomy b
+    | none,         _     => .contextual
+
+/-- Kennedy's adjective class — derived from `standard`, not stored
+    ([kennedy-2007], [kennedy-mcnally-2005]). -/
+def adjectiveClass (g : GradableAdjective) : AdjectiveClass :=
+  match g.dimension with
+  | none => .nonGradable
+  | some _ =>
+    match g.standard with
+    | .contextual  => .relativeGradable
+    | .minEndpoint => .absoluteMinimum
+    | .maxEndpoint => .absoluteMaximum
+    | .functional  => .mildlyPositive
+
+/-- Comparison-class dependence — the relative/absolute distinction, derived. -/
+def IsRelative (g : GradableAdjective) : Prop := g.adjectiveClass.IsRelative
+
+instance (g : GradableAdjective) : Decidable g.IsRelative := by
+  unfold IsRelative; infer_instance
+
+end GradableAdjective


### PR DESCRIPTION
Re-lands #1030, whose content was stranded (based on the #1029 branch, so it merged into the defunct base instead of `main`). Cherry-picked onto `main` now that #1029's `Semantics.Gradability.Dimension` carrier is in `main`.

Stage 1 of the Adjective API modeled on `Syntax/Pronoun/`:
- New `Syntax/Adjective/Basic.lean`: general `Adjective` + `GradableAdjective extends`; the `scaleType` category error decomposed into derived `scaleType`/`standard`/`adjectiveClass` (shape from `dimension.boundedness`, pole from `isLowerEndpoint`, standard derived+overridable) so `wet`/`dry`/`good` type correctly.
- `Fragments/Latin/Adjectives.lean` migrated to `Adjective` (non-gradable consumer); `Bobaljik2012` unchanged via an `Adjective.suppletion` accessor.
- `Fragments/English/GradableAdjectives.lean`: canonical gradable adjectives typed with `GradableAdjective`, with `rfl`/`decide` theorems exercising every derived view (`scaleType`/`standard`/`adjectiveClass`/`IsRelative`/`IsGradable`) across all four Kennedy classes — so the gradable half of the API has a real consumer.

Deferred (documented): φ-features/`toWord`, Dixon `PCClass` view, `MultidimAdjective`, the gradable facets, capability tower. The full `GradableAdjEntry` → `GradableAdjective` migration (93 entries) is a later stage.