### PR TITLE
refactor(Gradability): one GradableAdjective, semantics off Syntax

### DIFF
--- a/Linglib/Fragments/English/Predicates/Adjectival.lean
+++ b/Linglib/Fragments/English/Predicates/Adjectival.lean
@@ -2,18 +2,19 @@ import Linglib.Semantics.Gradability.Basic
 
 /-! # Adjectival Predicate Lexicon Fragment
 
-Gradable adjective entries following [kennedy-2007]. Each entry stores its surface
-form, scalar `dimension`, lexicalized pole (`isLowerEndpoint`) or `standardOverride`,
-and antonym data; the scale shape (`scaleType`), positive `standard`, and Kennedy
-`adjectiveClass` are *derived* views of the `Syntax/Adjective` API (`GradableAdjEntry
-extends GradableAdjective`), not stored — the fix for the old `scaleType` field that
-conflated scale shape with pole (`wet`/`dry` share one closed `.wetness` scale). The
-derived Kennedy classification is exercised at the end of this file.
+Gradable adjective entries following [kennedy-2007], typed with
+`Semantics.Gradability.GradableAdjective` (the syntactic `Syntax/Adjective` lexeme
+refined with the degree-semantic layer). Each entry stores its surface form, scalar
+`dimension`, lexicalized pole (`isLowerEndpoint`) or `standardOverride`, and antonym
+data; the scale shape (`scaleType`), positive `standard`, and Kennedy `adjectiveClass`
+are *derived* views, not stored — the fix for the old `scaleType` field that conflated
+scale shape with pole (`wet`/`dry` share one closed `.wetness` scale). The derived
+Kennedy classification is exercised at the end of this file.
 -/
 
 namespace English.Predicates.Adjectival
 
-open Semantics.Gradability (AntonymRelation GradableAdjEntry)
+open Semantics.Gradability (AntonymRelation GradableAdjective)
 open Core.Order (Boundedness)
 open Features (EvaluativeValence)
 open Features (NegationType)
@@ -22,10 +23,10 @@ open Features (NegationType)
 /-- [kennedy-2007]
 An adjectival predicate entry.
 
-This is an alias for `GradableAdjEntry` from the Theory module, re-exported
+This is an alias for `GradableAdjective` from the Theory module, re-exported
 here for the Fragments organization.
 -/
-abbrev AdjectivalPredicateEntry := GradableAdjEntry
+abbrev AdjectivalPredicateEntry := GradableAdjective
 
 
 /-- "tall" — open scale, contrary to "short" -/

--- a/Linglib/Pragmatics/Implicature/Markedness.lean
+++ b/Linglib/Pragmatics/Implicature/Markedness.lean
@@ -74,11 +74,11 @@ def prefixedMorphology (form : String) (pfx : String := "un") : Morphology :=
 /--
 Extended gradable adjective entry with morphological information.
 
-Extends `GradableAdjEntry` with:
+Extends `GradableAdjective` with:
 - Morphological structure for markedness computation
 - Polarity indicator (positive vs negative pole)
 -/
-structure GradableAdjWithMorphology extends GradableAdjEntry where
+structure GradableAdjWithMorphology extends GradableAdjective where
   /-- Morphological structure -/
   morphology : Morphology
   /-- Is this the positive pole of the scale? -/
@@ -226,7 +226,7 @@ def costDifference : ℚ := 1
 "tall" with morphology: simple, positive pole
 -/
 def tall_with_morphology : GradableAdjWithMorphology where
-  toGradableAdjEntry := tall
+  toGradableAdjective := tall
   morphology := simpleMorphology "tall"
   isPositivePole := true
 
@@ -234,7 +234,7 @@ def tall_with_morphology : GradableAdjWithMorphology where
 "short" with morphology: simple, negative pole
 -/
 def short_with_morphology : GradableAdjWithMorphology where
-  toGradableAdjEntry := short
+  toGradableAdjective := short
   morphology := simpleMorphology "short"
   isPositivePole := false
 
@@ -242,7 +242,7 @@ def short_with_morphology : GradableAdjWithMorphology where
 "happy" with morphology: simple, positive pole
 -/
 def happy_with_morphology : GradableAdjWithMorphology where
-  toGradableAdjEntry := happy
+  toGradableAdjective := happy
   morphology := simpleMorphology "happy"
   isPositivePole := true
 
@@ -250,7 +250,7 @@ def happy_with_morphology : GradableAdjWithMorphology where
 "unhappy" with morphology: prefixed, negative pole
 -/
 def unhappy_with_morphology : GradableAdjWithMorphology where
-  toGradableAdjEntry := unhappy
+  toGradableAdjective := unhappy
   morphology := prefixedMorphology "unhappy"
   isPositivePole := false
 

--- a/Linglib/Semantics/Gradability/AntonymPrediction.lean
+++ b/Linglib/Semantics/Gradability/AntonymPrediction.lean
@@ -173,7 +173,7 @@ def predictionForAntonymy : NegationType → Asymmetry
 
 /-- Read prediction off a Fragment lexical entry's `antonymRelation`. Defaults
     to `.symmetric` for entries without an explicit antonymy classification. -/
-def predictionForEntry (e : GradableAdjEntry) : Asymmetry :=
+def predictionForEntry (e : GradableAdjective) : Asymmetry :=
   e.antonymRelation.elim .symmetric predictionForAntonymy
 
 end Semantics.Gradability

--- a/Linglib/Semantics/Gradability/Basic.lean
+++ b/Linglib/Semantics/Gradability/Basic.lean
@@ -7,7 +7,7 @@ Types and operations for gradable adjective semantics (tall, happy, expensive).
 
 - `NegationType`: Contradictory vs. contrary antonyms
 - `ThresholdPair`: Two thresholds for contrary antonyms with gap
-- `GradableAdjEntry`: Lexical entry bundling form + scale structure + antonym
+- `GradableAdjective`: the gradable adjective — syntactic `Adjective` + degree semantics
 - `InformationalStrength`: Weak/strong adjective distinction
 - Negation and gap-region predicates
 
@@ -32,12 +32,14 @@ import Linglib.Features.Antonymy
 import Linglib.Features.Valence
 import Linglib.Semantics.Gradability.MLScale
 import Linglib.Semantics.Degree.Basic
+import Linglib.Semantics.Degree.Kennedy
 import Linglib.Syntax.Adjective.Basic
 
 namespace Semantics.Gradability
 
 open Core.Order (Boundedness)
 open Semantics.Degree (Degree Threshold Degree.toNat Threshold.toNat deg thr allDegrees allThresholds)
+open Semantics.Degree (PositiveStandard AdjectiveClass interpretiveEconomy)
 open Features (NegationType)
 
 -- Two-Threshold Model for Contrary Antonyms
@@ -155,16 +157,22 @@ inductive SpatialConfigType where
   | surfaceOrient   -- flat: orientation relative to reference surface
   deriving DecidableEq, Repr
 
-/-- A gradable adjective lexical entry: the general `GradableAdjective`
-    (`Syntax/Adjective`) extended with the fields specific to this fragment's
-    Kennedy-style entries — the lexical `antonymRelation`, resultative
-    `spatialConfigType` ([levin-2026]), and `evaluativeValence` ([nouwen-2024]).
-    Surface form and the scalar `dimension` are inherited `Adjective` fields; the
-    scale shape (`scaleType`), positive `standard`, and Kennedy `adjectiveClass`
-    are the inherited *derived* views (the old stored `scaleType` conflated shape
-    with pole — see `Syntax/Adjective/Basic.lean`). -/
-structure GradableAdjEntry extends GradableAdjective where
+/-- A **gradable adjective**: the syntactic `Adjective` (`Syntax/Adjective`) refined
+    with the degree-**semantic** layer that becomes relevant in this module — the
+    Kennedy `standardOverride`, and the lexical-semantic facets `antonymRelation`,
+    resultative `spatialConfigType` ([levin-2026]), and `evaluativeValence`
+    ([nouwen-2024]). The scale shape (`scaleType`), positive `standard`, and Kennedy
+    `adjectiveClass` are *derived views* below — the fix for the old stored `scaleType`
+    that conflated scale shape with pole (`wet`/`dry` share one closed `.wetness`
+    scale, differing only in pole). -/
+structure GradableAdjective extends Adjective where
+  /-- Override the Kennedy default standard (the `good`/MPA residual: an open-shape
+      scale that nonetheless takes a functional/contextual standard, [beltrama-2025]).
+      `none` = take the derived default. -/
+  standardOverride : Option PositiveStandard := none
+  /-- Lexical antonym's logical relation (contrary vs contradictory). -/
   antonymRelation : Option AntonymRelation := none
+  /-- Resultative spatial-configuration class ([levin-2026]). -/
   spatialConfigType : Option SpatialConfigType := none
   /-- Evaluative valence of the adjective, when applicable.
       Determines intensifier degree class ([nouwen-2024]):
@@ -172,6 +180,46 @@ structure GradableAdjEntry extends GradableAdjective where
       positive-evaluative bases yield M-degree intensifiers. -/
   evaluativeValence : Option Features.EvaluativeValence := none
   deriving Repr
+
+namespace GradableAdjective
+
+/-- The scale's intrinsic shape — read off the `dimension` key, not stored
+    (`.open_` for a non-gradable, which has no scale). -/
+def scaleType (g : GradableAdjective) : Boundedness :=
+  (g.dimension.map Dimension.boundedness).getD .open_
+
+/-- The effective positive standard: the default from (scale shape, pole),
+    overridable by `standardOverride`. This is the quantity the old `scaleType` field
+    conflated — it separates `wet` (closed + lower ⇒ min) from `dry` (closed + upper ⇒
+    max), and lets `good` (open shape) take a contextual standard rather than a bogus
+    bound. ([kennedy-2007]'s Interpretive Economy on the open/singly-bounded cases.) -/
+def standard (g : GradableAdjective) : PositiveStandard :=
+  g.standardOverride.getD <|
+    match g.dimension.map Dimension.boundedness, g.isLowerEndpoint with
+    | some .closed, true  => .minEndpoint
+    | some .closed, false => .maxEndpoint
+    | some b,       _     => interpretiveEconomy b
+    | none,         _     => .contextual
+
+/-- Kennedy's adjective class — derived from `standard`, not stored; `.nonGradable`
+    exactly when there is no `dimension` ([kennedy-2007], [kennedy-mcnally-2005]). -/
+def adjectiveClass (g : GradableAdjective) : AdjectiveClass :=
+  match g.dimension with
+  | none => .nonGradable
+  | some _ =>
+    match g.standard with
+    | .contextual  => .relativeGradable
+    | .minEndpoint => .absoluteMinimum
+    | .maxEndpoint => .absoluteMaximum
+    | .functional  => .mildlyPositive
+
+/-- Comparison-class dependence — the relative/absolute distinction, derived. -/
+def IsRelative (g : GradableAdjective) : Prop := g.adjectiveClass.IsRelative
+
+instance (g : GradableAdjective) : Decidable g.IsRelative := by
+  unfold IsRelative; infer_instance
+
+end GradableAdjective
 
 -- ════════════════════════════════════════════════════
 -- Multidimensional Adjective Semantics
@@ -283,17 +331,17 @@ so the abstract theorems in `MeasurementScale.lean` apply directly to concrete
 RSA degree computations. -/
 
 def adjMeasure {max : Nat} {W : Type*} (μ : W → Degree max)
-    (entry : GradableAdjEntry) : DirectedMeasure (Degree max) W :=
+    (entry : GradableAdjective) : DirectedMeasure (Degree max) W :=
   DirectedMeasure.adjective μ entry.scaleType
 
 theorem closedAdj_licensed {max : Nat} {W : Type*} (μ : W → Degree max)
-    (entry : GradableAdjEntry) (h : entry.scaleType = .closed) :
+    (entry : GradableAdjective) (h : entry.scaleType = .closed) :
     (adjMeasure μ entry).IsLicensed := by
   simp [adjMeasure, DirectedMeasure.adjective,
         DirectedMeasure.IsLicensed, Boundedness.IsLicensed, h]
 
 theorem openAdj_blocked {max : Nat} {W : Type*} (μ : W → Degree max)
-    (entry : GradableAdjEntry) (h : entry.scaleType = .open_) :
+    (entry : GradableAdjective) (h : entry.scaleType = .open_) :
     ¬ (adjMeasure μ entry).IsLicensed := by
   simp [adjMeasure, DirectedMeasure.adjective,
         DirectedMeasure.IsLicensed, Boundedness.IsLicensed, h]

--- a/Linglib/Studies/AlexandropoulouGotzner2024.lean
+++ b/Linglib/Studies/AlexandropoulouGotzner2024.lean
@@ -61,7 +61,7 @@ namespace AlexandropoulouGotzner2024
 
 open Core.Order (Boundedness)
 open Semantics.Degree (Degree Threshold deg thr)
-open Semantics.Gradability (GradableAdjEntry ThresholdPair inGapRegion
+open Semantics.Gradability (GradableAdjective ThresholdPair inGapRegion
   positiveMeaning' contraryNegMeaning notContraryNegMeaning)
 open Semantics.Degree (positiveMeaning antonymMeaning positiveMeaning_monotone)
 open English.Predicates.Adjectival
@@ -76,10 +76,10 @@ open English.Predicates.Adjectival
     uses size (large/small/gigantic/tiny) as the relative case and cleanliness
     (clean/dirty/pristine/filthy) as the absolute case. -/
 structure AdjQuadruple where
-  weakPos    : GradableAdjEntry
-  weakNeg    : GradableAdjEntry
-  strongPos  : GradableAdjEntry
-  strongNeg  : GradableAdjEntry
+  weakPos    : GradableAdjective
+  weakNeg    : GradableAdjective
+  strongPos  : GradableAdjective
+  strongNeg  : GradableAdjective
   deriving Repr
 
 def sizeQuad : AdjQuadruple where

--- a/Linglib/Studies/AlexandropoulouGotzner2024JoS.lean
+++ b/Linglib/Studies/AlexandropoulouGotzner2024JoS.lean
@@ -81,7 +81,7 @@ namespace AlexandropoulouGotzner2024JoS
 
 open Semantics.Degree (Degree Threshold)
 open Features (NegationType Asymmetry)
-open Semantics.Gradability (GradableAdjEntry ThresholdPair positiveMeaning'
+open Semantics.Gradability (GradableAdjective ThresholdPair positiveMeaning'
   contraryNegMeaning notContraryNegMeaning AntonymForm
   predictionForAntonymy predictionForEntry)
 open Semantics.Degree (antonymMeaning)
@@ -101,7 +101,7 @@ inductive AGCase where
 
 /-! `Asymmetry` (asymmetric/symmetric direction enum), `predictionForAntonymy`
     (NegationType → Asymmetry skeleton), and `predictionForEntry`
-    (GradableAdjEntry → Asymmetry projection) are now substrate, in
+    (GradableAdjective → Asymmetry projection) are now substrate, in
     `Features/Antonymy.lean` and `Semantics/Gradability/AntonymPrediction.lean`
     respectively. The substrate-anchor theorems
     `Semantics.Gradability.contradictoryDenot_synonymy` and
@@ -113,7 +113,7 @@ inductive AGCase where
     prediction signatures below derive their per-case answers by reading
     `antonymRelation` off this representative — the Fragment is the single
     source of truth, not a parallel hardcoded enum in this file. -/
-def AGCase.representative : AGCase → GradableAdjEntry
+def AGCase.representative : AGCase → GradableAdjective
   | .weakRelative   => large
   | .weakAbsolute   => clean
   | .strongGradable => gigantic

--- a/Linglib/Studies/Nouwen2024.lean
+++ b/Linglib/Studies/Nouwen2024.lean
@@ -388,7 +388,7 @@ def unattestedCount : Nat := (allEntries.filter (!·.attested)).length
 
 /-- Look up the Fragment adjective entry for an intensifier's adjectival base. -/
 def IntensifierEntry.fragmentEntry (e : IntensifierEntry) :
-    Option Semantics.Gradability.GradableAdjEntry :=
+    Option Semantics.Gradability.GradableAdjective :=
   English.Predicates.Adjectival.lookup e.adjBase
 
 /-- Bridge: pleasant's Fragment entry has positive evaluative valence,

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -86,7 +86,7 @@ the paper's argument is that disturbance predicates are a uniform class.
 namespace Tham2025
 
 open Core.Order (Boundedness LicensingPipeline)
-open Semantics.Gradability (DimensionBindingType GradableAdjEntry
+open Semantics.Gradability (DimensionBindingType GradableAdjective
   adjMeasure closedAdj_licensed conjunctiveBinding disjunctiveBinding)
 open Semantics.Gradability.Aggregation (weightedScore boolMeasures
   spatialNormalizedScore spatialNormalizedBinding)

--- a/Linglib/Syntax/Adjective/Basic.lean
+++ b/Linglib/Syntax/Adjective/Basic.lean
@@ -1,32 +1,23 @@
 import Linglib.Semantics.Gradability.Dimension
-import Linglib.Semantics.Degree.Defs
-import Linglib.Semantics.Degree.Kennedy
 import Linglib.Morphology.DegreeContainment
 
 /-!
 # Adjective
 
-Lexical core for the adjective as a grammatical object, modeled on `Syntax/Pronoun/`:
-the general `Adjective` structure (the lexical core every adjective shares) and the
-`GradableAdjective` specialization (which `extends Adjective` with the degree-semantic
-lexical fields). The general concept gets the plain name; specializations `extends` it.
+The syntactic core of the adjective as a grammatical object, modeled on
+`Syntax/Pronoun/`: surface form, the scalar `dimension` **key** it measures + the
+lexicalized pole, comparison morphology, and lexical antonymy. The dimension is
+carried as a key (cf. `Pronoun` importing `Person`/`Number`), not interpreted here.
 
-The scale an adjective measures is the `Semantics.Gradability.Dimension` **key**
-(imported as a field, cf. `Pronoun` importing `Person`/`Number`); its boundedness,
-comparison-class dependence, and telicity are *derived views* of that key, not stored.
-The degree **denotation** (`DirectedMeasure`) lives downstream in `Semantics/Gradability`.
+Gradability is **not** a type split — it is the derived predicate `IsGradable`
+(`dimension.isSome`); a non-gradable adjective (*wooden*, *former*, *medical*) is the
+same type with `dimension = none`.
 
-## The `scaleType` decomposition
-
-The old `GradableAdjEntry.scaleType : Boundedness` conflated three independent facts and
-contradicted `Dimension.boundedness` (`wet`/`dry` share one closed `.wetness` scale, yet
-stored `.lowerBounded`/`.upperBounded`). They are separated here:
-
-* **shape** — `dimension.boundedness` (derived);
-* **pole** — `isLowerEndpoint` (the *only* thing distinguishing `wet` from `dry`);
-* **standard** — `GradableAdjective.standard`, derived from (shape, pole) with an
-  `Option PositiveStandard` override for the `good`/MPA residual ([kennedy-2007],
-  [kennedy-mcnally-2005]).
+The **degree-semantic** layer lives one layer up, in `Semantics/Gradability`, where the
+scale's boundedness, positive standard, and Kennedy class *become relevant*: the
+`GradableAdjective` refinement there `extends Adjective` with the `standardOverride`
+and derives `scaleType`/`standard`/`adjectiveClass` from the (shape, pole, override).
+This file deliberately does not depend on the Degree/Kennedy semantics.
 
 ## Deferred (earn their consumers, cf. `Pronoun`'s deferred capability tower)
 
@@ -34,8 +25,6 @@ stored `.lowerBounded`/`.upperBounded`). They are separated here:
   sets them (φ with no setter would be dead fields).
 * Dixon `PCClass` view (`Dimension.pcClass`) — waits on a lightweight `PCClass` home
   (it currently sits in the heavy `Morphology/RootTypology.lean`).
-* `MultidimAdjective` (Sassoon multidimensionality) and the gradable facets
-  (`evaluativeValence`/`spatialConfigType`/`informationalStrength`/subjectivity).
 * The `Modifier`/`Gradable` capability classes — built at the second-carrier trigger
   (an `Adverb`/degree-word struct), exactly as `Pronoun` deferred `Proform`.
 
@@ -44,8 +33,6 @@ noun-strategy fragment lands, factor a `PropertyConcept` superclass.
 -/
 
 open Semantics.Gradability (Dimension)
-open Semantics.Degree (PositiveStandard AdjectiveClass interpretiveEconomy)
-open Core.Order (Boundedness)
 open Morphology.DegreeContainment (DegreePattern)
 
 set_option autoImplicit false
@@ -75,13 +62,18 @@ structure Adjective.ComparisonFacet where
 /-- No comparison marking (the default). -/
 def Adjective.ComparisonFacet.regular : Adjective.ComparisonFacet := {}
 
-/-! ### The general adjective object -/
+/-! ### The adjective object -/
 
-/-- The general adjective object: the lexical core every adjective shares — surface
-    form, the scalar `dimension` key + lexicalized pole, comparison morphology, and
-    lexical antonymy. Carries no denotation of its own (cf. `Pronoun`); the degree
-    meaning is derived in `Semantics/Gradability`. Specializations `extends` it.
-    Coexists with `namespace Adjective` (a type and a namespace may share a name). -/
+/-- The adjective lexeme: the syntactic core every adjective shares — surface form,
+    the scalar `dimension` key + lexicalized pole, comparison morphology, and lexical
+    antonymy. Carries no denotation of its own (cf. `Pronoun`); the degree-semantic
+    interpretation of `dimension`/pole is derived one layer up, on `GradableAdjective`
+    in `Semantics/Gradability`.
+
+    Gradability is **not** a type split: it is the derived predicate `IsGradable`
+    (`dimension.isSome`); a non-gradable adjective is the same type with
+    `dimension = none`. Coexists with `namespace Adjective` (a type and a namespace may
+    share a name). -/
 structure Adjective where
   /-- Surface form (citation/positive-grade). -/
   form : String
@@ -100,15 +92,6 @@ structure Adjective where
   antonymForm : Option String := none
   deriving Repr, DecidableEq, BEq
 
-/-- A gradable adjective: `Adjective` plus the degree-semantic lexical fields
-    (Kennedy). Its well-formedness requires a `dimension`. -/
-structure GradableAdjective extends Adjective where
-  /-- Override the Kennedy default standard (the `good`/MPA residual: an open-shape
-      scale that nonetheless takes a functional/contextual standard, [beltrama-2025]).
-      `none` = take the derived default. -/
-  standardOverride : Option PositiveStandard := none
-  deriving Repr, BEq
-
 namespace Adjective
 
 /-- Gradable iff it carries a scalar dimension — derived (cf. `Pronoun.category`). -/
@@ -121,42 +104,3 @@ instance (a : Adjective) : Decidable a.IsGradable := by unfold IsGradable; infer
 def suppletion (a : Adjective) : DegreePattern := a.comparison.suppletion
 
 end Adjective
-
-namespace GradableAdjective
-
-/-- The scale's intrinsic shape — read off the `dimension` key, not stored. -/
-def scaleType (g : GradableAdjective) : Boundedness :=
-  (g.dimension.map Dimension.boundedness).getD .open_
-
-/-- The effective positive standard: the default from (scale shape, pole),
-    overridable by `standardOverride`. This is the quantity the old `scaleType` field
-    conflated — it separates `wet` (closed + lower ⇒ min) from `dry` (closed + upper ⇒
-    max), and lets `good` (open shape) take a contextual standard rather than a bogus
-    bound. ([kennedy-2007]'s Interpretive Economy on the open/singly-bounded cases.) -/
-def standard (g : GradableAdjective) : PositiveStandard :=
-  g.standardOverride.getD <|
-    match g.dimension.map Dimension.boundedness, g.isLowerEndpoint with
-    | some .closed, true  => .minEndpoint
-    | some .closed, false => .maxEndpoint
-    | some b,       _     => interpretiveEconomy b
-    | none,         _     => .contextual
-
-/-- Kennedy's adjective class — derived from `standard`, not stored
-    ([kennedy-2007], [kennedy-mcnally-2005]). -/
-def adjectiveClass (g : GradableAdjective) : AdjectiveClass :=
-  match g.dimension with
-  | none => .nonGradable
-  | some _ =>
-    match g.standard with
-    | .contextual  => .relativeGradable
-    | .minEndpoint => .absoluteMinimum
-    | .maxEndpoint => .absoluteMaximum
-    | .functional  => .mildlyPositive
-
-/-- Comparison-class dependence — the relative/absolute distinction, derived. -/
-def IsRelative (g : GradableAdjective) : Prop := g.adjectiveClass.IsRelative
-
-instance (g : GradableAdjective) : Decidable g.IsRelative := by
-  unfold IsRelative; infer_instance
-
-end GradableAdjective


### PR DESCRIPTION
Consolidates the adjective API into one gradable type in the right layer. `GradableAdjEntry` folds into a single `GradableAdjective`, which moves to `Semantics/Gradability` (`extends Adjective`) — where the degree semantics become relevant. Gradability stays a derived predicate (`IsGradable := dimension.isSome`), never a type split.

- `Syntax/Adjective` now holds only the syntactic lexeme (form, dimension key, pole, comparison morphology) and no longer imports `Degree`/`Kennedy` — the syntax layer is independent of degree semantics.
- `scaleType`/`standard`/`adjectiveClass`/`standardOverride` + the lexical-semantic facets live on `GradableAdjective` in `Semantics/Gradability`.