### PR TITLE
refactor(Semantics/Degree): move Degree/Threshold types to Defs

### DIFF
--- a/Linglib/Semantics/Degree/Defs.lean
+++ b/Linglib/Semantics/Degree/Defs.lean
@@ -1,28 +1,113 @@
-import Linglib.Core.Order.Boundedness
-import Linglib.Semantics.Degree.DirectedMeasure
-import Linglib.Semantics.Degree.HasMeasure
+import Mathlib.Order.Basic
+import Mathlib.Order.BoundedOrder.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Card
+import Mathlib.Order.Fin.Basic
+import Mathlib.Tactic.NormNum
 
 /-!
-# Degree Semantics: Type Definitions
+# Degree semantics: core types and classification carriers
 
-Pure type definitions for degree-based analyses of gradable expressions
-[heim-2001] [kennedy-2007] [schwarzschild-2008] [beltrama-2025].
-Positive-form semantics is in `Basic.lean`; Kennedy 2007's interpretive
-economy classification is in `Kennedy.lean`. Klein-style delineation
-[klein-1980] has no measure function and lives in
-`Semantics/Gradability/Delineation.lean`.
+Foundational definitions for degree-based analyses of gradable expressions
+[heim-2001] [kennedy-2007] [schwarzschild-2008] [beltrama-2025]:
+
+* the discrete scale types `Degree max` / `Threshold max` (the finite carriers used
+  by the RSA fragment), and
+* the Kennedy-style classification enums (`PositiveStandard`, `AdjectiveClass`, …).
+
+Positive-form semantics is in `Basic.lean`; Kennedy 2007's interpretive economy is in
+`Kennedy.lean`; the abstract `μ : E → α` measure typeclass is in `HasMeasure.lean`.
+Klein-style delineation [klein-1980] has no measure function and lives in
+`Gradability/Delineation.lean`.
 
 ## Main definitions
 
-* `DegPType`, `StandardType` — DegP compositional taxonomy
-* `ModifierDirection` — amplifier / downtoner axis
-* `AdjectivalConstruction` — surface-construction type for evaluativity
-* `PositiveStandard`, `AdjectiveClass` — Kennedy-style classification carriers
+* `Degree max`, `Threshold max` — discrete bounded scale types (`Fin`-backed).
+* `DegPType`, `StandardType` — DegP compositional taxonomy.
+* `ModifierDirection` — amplifier / downtoner axis.
+* `AdjectivalConstruction` — surface-construction type for evaluativity.
+* `PositiveStandard`, `AdjectiveClass` — Kennedy-style classification carriers.
 -/
 
 namespace Semantics.Degree
 
-open Core.Order (Boundedness)
+/-! ### Discrete bounded scales
+
+`Degree max` wraps `Fin (max + 1)` with `LinearOrder`, `BoundedOrder`, `Fintype`;
+`Threshold max` wraps `Fin max` with a coercion to `Degree max`. These are the
+discretized carriers used by the gradable-adjective RSA fragment. -/
+
+/-- A degree on a scale from 0 to `max` — a discretized continuous value
+    (height, temperature, …). -/
+structure Degree (max : Nat) where
+  value : Fin (max + 1)
+  deriving Repr, DecidableEq
+
+instance {n : Nat} : Inhabited (Degree n) := ⟨⟨0, Nat.zero_lt_succ n⟩⟩
+
+/-- `Degree max` inherits a linear order from `Fin (max + 1)`. -/
+instance {max : Nat} : LinearOrder (Degree max) :=
+  LinearOrder.lift' Degree.value (fun a b h => by cases a; cases b; simp_all)
+
+/-- `Degree max` is bounded: 0 is the minimum, `max` the maximum. -/
+instance {max : Nat} : BoundedOrder (Degree max) where
+  top := ⟨Fin.last max⟩
+  le_top d := Fin.le_last d.value
+  bot := ⟨0, Nat.zero_lt_succ max⟩
+  bot_le d := Fin.zero_le d.value
+
+/-- All degrees from 0 to `max`. -/
+def allDegrees (max : Nat) : List (Degree max) :=
+  List.finRange (max + 1) |>.map (⟨·⟩)
+
+/-- Degree from `Nat` (clamped to `max`). -/
+def Degree.ofNat (max : Nat) (n : Nat) : Degree max :=
+  ⟨⟨min n max, by omega⟩⟩
+
+/-- The numeric value of a degree. -/
+def Degree.toNat {max : Nat} (d : Degree max) : Nat := d.value.val
+
+/-- A threshold for a gradable adjective: `x` is "tall" iff `degree x > threshold`. -/
+structure Threshold (max : Nat) where
+  value : Fin max
+  deriving Repr, DecidableEq
+
+instance {n : Nat} [NeZero n] : Inhabited (Threshold n) :=
+  ⟨⟨0, Nat.pos_of_ne_zero (NeZero.ne n)⟩⟩
+
+/-- `Threshold max` inherits a linear order from `Fin max`. -/
+instance {max : Nat} : LinearOrder (Threshold max) :=
+  LinearOrder.lift' Threshold.value (fun a b h => by cases a; cases b; simp_all)
+
+/-- All thresholds from 0 to `max - 1`. -/
+def allThresholds (max : Nat) (_ : 0 < max := by omega) : List (Threshold max) :=
+  List.finRange max |>.map (⟨·⟩)
+
+/-- The numeric value of a threshold. -/
+def Threshold.toNat {max : Nat} (t : Threshold max) : Nat := t.value.val
+
+instance {max : Nat} : Fintype (Degree max) :=
+  Fintype.ofEquiv (Fin (max + 1)) ⟨Degree.mk, Degree.value, fun _ => rfl, fun ⟨_⟩ => rfl⟩
+
+instance {max : Nat} [NeZero max] : Fintype (Threshold max) :=
+  Fintype.ofEquiv (Fin max) ⟨Threshold.mk, Threshold.value, fun _ => rfl, fun ⟨_⟩ => rfl⟩
+
+/-- Coercion: a `Threshold` embeds into `Degree` via `Fin.castSucc`. -/
+instance {max : Nat} : Coe (Threshold max) (Degree max) where
+  coe t := ⟨t.value.castSucc⟩
+
+theorem coe_threshold_toNat {max : Nat} (t : Threshold max) :
+    (t : Degree max).toNat = t.toNat := rfl
+
+/-- Construct a degree by literal: `deg 5 : Degree 10`. -/
+abbrev deg (n : Nat) {max : Nat} (h : n ≤ max := by omega) : Degree max :=
+  ⟨⟨n, by omega⟩⟩
+
+/-- Construct a threshold by literal: `thr 5 : Threshold 10`. -/
+abbrev thr (n : Nat) {max : Nat} (h : n < max := by omega) : Threshold max :=
+  ⟨⟨n, h⟩⟩
+
+/-! ### DegP compositional taxonomy -/
 
 /-- The compositional structure of a Degree Phrase (DegP).
 
@@ -90,6 +175,8 @@ instance : ToString AdjectivalConstruction where
     | .equative => "equative"
     | .measurePhrase => "measurePhrase"
     | .degreeQuestion => "degreeQuestion"
+
+/-! ### Kennedy-style classification carriers -/
 
 /-- Positive form standard: how the contextual threshold is determined.
 For open scales, the standard is the contextual norm

--- a/Linglib/Semantics/Degree/HasMeasure.lean
+++ b/Linglib/Semantics/Degree/HasMeasure.lean
@@ -1,139 +1,30 @@
-import Mathlib.Order.Basic
-import Mathlib.Order.BoundedOrder.Basic
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Data.Fintype.Card
-import Mathlib.Order.Fin.Basic
-import Mathlib.Tactic.NormNum
+import Linglib.Semantics.Degree.Defs
 
 /-!
-# Core/Scales/HasMeasure.lean — measurement typeclass + finite degree types
+# HasMeasure — the measurement typeclass
 
-`HasMeasure E α` is the formal-semantics "measure function" `μ : E → α`,
-parameterized over both the entity type and the codomain.
+`HasMeasure E α` is the formal-semantics measure function `μ : E → α`, parameterized
+over both the entity type `E` and the codomain scale `α`. This file adds only the
+abstract typeclass; the concrete scale carriers `Degree`/`Threshold` are defined in
+`Defs.lean`, re-exported here (via the import) so both are reachable together.
 
-deprecation alias for one version, then removed in a later refactor.
-
-`Degree max` and `Threshold max` are discretized scale types for gradable
-adjective RSA computations; they participate in the `DirectedMeasure`
-infrastructure via their `LinearOrder`/`BoundedOrder` instances.
-
-This file is part of the Phase A decomposition of the legacy
-`Core/Scales/Scale.lean` dumping ground (master plan v4).
-
-## Multi-dim measurement
-
-No `outParam` on `δ` — multi-dim same-carrier (e.g. `Entity` measured by
-both height and weight) is supported via distinct `(α, δ)` instance
-signatures or newtype wrappers (mathlib `Additive`/`Multiplicative`
-precedent). This is a deliberate design choice per master plan v4.
+**No `outParam` on `α`**: multi-dim same-carrier measurement (e.g. an `Entity`
+measured by BOTH height and weight) is supported by distinct `(E, α)` instances or
+newtype wrappers (mathlib `Additive`/`Multiplicative` precedent). When an `Entity` has
+multiple measures, consumers disambiguate via explicit `(α := …)` or named instances.
 -/
 
 namespace Semantics.Degree
 
--- ════════════════════════════════════════════════════
--- § 11. Discrete Bounded Scales
--- ════════════════════════════════════════════════════
+/-- Typeclass for entities that carry a measurement on some scale — the
+    formal-semantics measure function `μ : E → α`.
 
-/-! ### Degree and Threshold types for finite scales
-
-`Degree max` wraps `Fin (max + 1)` with `LinearOrder`, `BoundedOrder`, `Fintype`.
-`Threshold max` wraps `Fin max` with coercion to `Degree max`. -/
-
-/-- A degree on a scale from 0 to max. Represents discretized continuous
-    values like height, temperature, etc. -/
-structure Degree (max : Nat) where
-  value : Fin (max + 1)
-  deriving Repr, DecidableEq
-
-instance {n : Nat} : Inhabited (Degree n) := ⟨⟨0, Nat.zero_lt_succ n⟩⟩
-
-/-- `Degree max` inherits a linear order from `Fin (max + 1)`. -/
-instance {max : Nat} : LinearOrder (Degree max) :=
-  LinearOrder.lift' Degree.value (fun a b h => by cases a; cases b; simp_all)
-
-/-- `Degree max` is bounded: 0 is the minimum, `max` is the maximum. -/
-instance {max : Nat} : BoundedOrder (Degree max) where
-  top := ⟨Fin.last max⟩
-  le_top d := Fin.le_last d.value
-  bot := ⟨0, Nat.zero_lt_succ max⟩
-  bot_le d := Fin.zero_le d.value
-
-/-- All degrees from 0 to max -/
-def allDegrees (max : Nat) : List (Degree max) :=
-  List.finRange (max + 1) |>.map (⟨·⟩)
-
-/-- Degree from Nat (clamped) -/
-def Degree.ofNat (max : Nat) (n : Nat) : Degree max :=
-  ⟨⟨min n max, by omega⟩⟩
-
-/-- Get numeric value -/
-def Degree.toNat {max : Nat} (d : Degree max) : Nat := d.value.val
-
-/-- A threshold for a gradable adjective. x is "tall" iff degree(x) > threshold. -/
-structure Threshold (max : Nat) where
-  value : Fin max
-  deriving Repr, DecidableEq
-
-instance {n : Nat} [NeZero n] : Inhabited (Threshold n) :=
-  ⟨⟨0, Nat.pos_of_ne_zero (NeZero.ne n)⟩⟩
-
-/-- `Threshold max` inherits a linear order from `Fin max`. -/
-instance {max : Nat} : LinearOrder (Threshold max) :=
-  LinearOrder.lift' Threshold.value (fun a b h => by cases a; cases b; simp_all)
-
-/-- All thresholds from 0 to max-1 -/
-def allThresholds (max : Nat) (_ : 0 < max := by omega) : List (Threshold max) :=
-  List.finRange max |>.map (⟨·⟩)
-
-/-- Get numeric value -/
-def Threshold.toNat {max : Nat} (t : Threshold max) : Nat := t.value.val
-
-instance {max : Nat} : Fintype (Degree max) :=
-  Fintype.ofEquiv (Fin (max + 1)) ⟨Degree.mk, Degree.value, fun _ => rfl, fun ⟨_⟩ => rfl⟩
-
-instance {max : Nat} [NeZero max] : Fintype (Threshold max) :=
-  Fintype.ofEquiv (Fin max) ⟨Threshold.mk, Threshold.value, fun _ => rfl, fun ⟨_⟩ => rfl⟩
-
-/-- Coercion: Threshold embeds into Degree via Fin.castSucc -/
-instance {max : Nat} : Coe (Threshold max) (Degree max) where
-  coe t := ⟨t.value.castSucc⟩
-
-theorem coe_threshold_toNat {max : Nat} (t : Threshold max) :
-    (t : Degree max).toNat = t.toNat := rfl
-
-/-- Construct a degree by literal: `deg 5 : Degree 10`. -/
-abbrev deg (n : Nat) {max : Nat} (h : n ≤ max := by omega) : Degree max :=
-  ⟨⟨n, by omega⟩⟩
-
-/-- Construct a threshold by literal: `thr 5 : Threshold 10`. -/
-abbrev thr (n : Nat) {max : Nat} (h : n < max := by omega) : Threshold max :=
-  ⟨⟨n, h⟩⟩
-
--- ════════════════════════════════════════════════════
--- § 12. HasMeasure typeclass (renames HasDegree)
--- ════════════════════════════════════════════════════
-
-/-- Typeclass for entities that have a measurement on some scale.
-    The formal semantics "measure function" μ : Entity → α.
-
-    The codomain `α` is polymorphic — heights might use ℚ (cm, exact),
-    physical heights ℝ, durations ℕ (ticks), prices ℚ (USD), etc.
-
-    **No `outParam` on α**: master plan v4 deliberately drops `outParam`
-    to support multi-dim same-carrier (e.g., `Entity` measured by BOTH
-    height and weight). When an `Entity` has multiple measures, consumers
-    disambiguate via explicit `(α := ...)` or named instances; mathlib
-    `Additive`/`Multiplicative` newtype-wrapping is the canonical pattern
-    for type-level disambiguation.
-
-    Renamed from `HasDegree` (legacy name) per master plan v4 Phase A.7.
-    Field name kept as `degree` for one-version migration compatibility;
-    `HasMeasure.measure` is provided as the v4-canonical alias. -/
+    The codomain `α` is polymorphic: heights might use `ℚ` (cm, exact) or `ℝ`,
+    durations `ℕ` (ticks), prices `ℚ` (USD), etc. -/
 class HasMeasure (E : Type*) (α : Type*) where
   degree : E → α
 
-/-- v4-canonical name for the measurement function. Aliased to the
-    legacy field name `degree` for one-version migration. -/
+/-- Readable name for the measurement function, aliased to the field `degree`. -/
 abbrev HasMeasure.measure {E α : Type*} [HasMeasure E α] : E → α :=
   HasMeasure.degree
 

--- a/Linglib/Semantics/Degree/Kennedy.lean
+++ b/Linglib/Semantics/Degree/Kennedy.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Degree.Defs
+import Linglib.Core.Order.Boundedness
 
 /-!
 # Kennedy 2007: Interpretive Economy


### PR DESCRIPTION
First fix from the `Degree/` architectural audit: the fundamental `Degree`/`Threshold` scale types were defined in `HasMeasure.lean` (so "where is `Degree` defined?" answered "the typeclass file", which no one would guess). Moves them into `Defs.lean` where the definitions belong, restoring the `Defs`/`Basic` layering convention.

- `Defs.lean` now holds the core scale types + the classification enums; drops its dead `HasMeasure`/`DirectedMeasure`/`Boundedness` imports.
- `HasMeasure.lean` is now just the abstract `μ : E → α` typeclass (imports `Defs`, re-exporting the types so consumers are unaffected).
- `Kennedy.lean` imports `Core.Order.Boundedness` directly (it was reaching it transitively through `Defs`'s removed import).