### PR TITLE
refactor(Semantics/Degree): rename namespace Semantics.Degree → Degree

### DIFF
--- a/Linglib/Pragmatics/Implicature/Markedness.lean
+++ b/Linglib/Pragmatics/Implicature/Markedness.lean
@@ -29,7 +29,7 @@ import Mathlib.Data.Rat.Defs
 namespace Implicature.Markedness
 
 open Semantics.Gradability
-open Semantics.Degree (Degree Threshold Degree.toNat Threshold.toNat deg thr)
+open Degree (Degree Threshold Degree.toNat Threshold.toNat deg thr)
 open Semantics.Gradability (ThresholdPair)
 open Features (NegationType)
 open English.Predicates.Adjectival (tall short happy unhappy)
@@ -334,7 +334,7 @@ Whether antonyms have the same truth conditions depends on the construction:
 - Polar-INVARIANT: "as tall as" = "as short as" → M-alternatives exist
 -/
 
-open Semantics.Degree (AdjectivalConstruction)
+open Degree (AdjectivalConstruction)
 
 /-- Polar variance: do antonyms have the same truth conditions in this construction? -/
 inductive PolarVariance where

--- a/Linglib/Semantics/Attitudes/EpistemicThreshold.lean
+++ b/Linglib/Semantics/Attitudes/EpistemicThreshold.lean
@@ -488,7 +488,7 @@ def epistemicBoundedness : Core.Order.Boundedness := .closed
     (upward monotone: higher credence → more likely to satisfy). Reversed
     entries (`uncertain`, `unlikely`) are negative (downward monotone). -/
 def epistemicAsDirectedMeasure (cr : AgentCredence E W) (_entry : EpistemicEntry)
-    : Semantics.Degree.DirectedMeasure ℚ (E × (W → Bool)) where
+    : Degree.DirectedMeasure ℚ (E × (W → Bool)) where
   μ := fun ⟨a, φ⟩ => cr a φ
   boundedness := epistemicBoundedness
 
@@ -544,7 +544,7 @@ satisfies System FA (and hence all of W ⊂ F ⊂ FA).
 /-- Threshold semantics is upward monotone in the credence ordering:
     if `cr a φ ≥ θ` and `cr a φ ≤ cr a ψ`, then `cr a ψ ≥ θ`.
 
-    This is an instance of `Semantics.Degree.IsUpwardMonotone` applied to the
+    This is an instance of `Degree.IsUpwardMonotone` applied to the
     epistemic scale. The family of propositions `P(θ) = meetsThreshold θ`
     is upward monotone in credence — higher credence always satisfies
     lower thresholds.

--- a/Linglib/Semantics/Degree/Abstraction.lean
+++ b/Linglib/Semantics/Degree/Abstraction.lean
@@ -43,10 +43,10 @@ image `μ '' {x | R x}`, connecting to `gc_sSup_Iic` under
 
 -/
 
-namespace Semantics.Degree.Abstraction
+namespace Degree.Abstraction
 
 open Core.Order
-open Semantics.Degree
+open Degree
 -- ════════════════════════════════════════════════════
 -- § 1. Degree Predicates and Maximality
 -- ════════════════════════════════════════════════════
@@ -281,7 +281,7 @@ theorem negatedDegreePredicate_eq {Entity D : Type*} [LinearOrder D]
 theorem heim_extensional_equivalence {Entity D : Type*} [LinearOrder D]
     (μ : Entity → D) (a b : Entity) :
     heimComparativeWithMeasure μ a b ↔
-      Semantics.Degree.comparativeSem μ a b .positive :=
+      Degree.comparativeSem μ a b .positive :=
   Iff.rfl
 
 -- ─── Galois Connection ────────────────────────────
@@ -306,4 +306,4 @@ theorem heim_kennedy_via_galois {Entity D : Type*} [LinearOrder D]
     posExt μ b ⊂ posExt μ a :=
   (posExt_ssubset_iff μ b a).symm
 
-end Semantics.Degree.Abstraction
+end Degree.Abstraction

--- a/Linglib/Semantics/Degree/Basic.lean
+++ b/Linglib/Semantics/Degree/Basic.lean
@@ -29,9 +29,7 @@ serves the same clients; this module is imported by
 `Studies/` files.
 -/
 
-namespace Semantics.Degree
-
-open Semantics.Degree (Degree Threshold)
+namespace Degree
 
 /-! ### Concrete threshold-based meanings
 
@@ -76,4 +74,4 @@ theorem positiveMeaning_monotone (d : Degree max) (θ_weak θ_strong : Threshold
 
 end Concrete
 
-end Semantics.Degree
+end Degree

--- a/Linglib/Semantics/Degree/Bounds.lean
+++ b/Linglib/Semantics/Degree/Bounds.lean
@@ -25,7 +25,7 @@ This file is part of the Phase A decomposition of the legacy
 `Core/Scales/Scale.lean` dumping ground (master plan v4).
 -/
 
-namespace Semantics.Degree
+namespace Degree
 
 open Core.Order
 
@@ -224,4 +224,4 @@ theorem maxOnScale_ge_atMost (b : α) :
     maxOnScale .ge {d | d ≤ b} = {b} :=
   maxOnScale_atLeast_singleton id b
 
-end Semantics.Degree
+end Degree

--- a/Linglib/Semantics/Degree/Comparative.lean
+++ b/Linglib/Semantics/Degree/Comparative.lean
@@ -37,7 +37,7 @@ consumers in `Studies/Hoeksema1983.lean`.
 * `comparative_iff_posExt_ssubset` — comparison as extent inclusion ([kennedy-1999]).
 -/
 
-namespace Semantics.Degree
+namespace Degree
 
 open Core.Order (ScalePolarity Comparison)
 
@@ -248,4 +248,4 @@ theorem negatedEquative_iff_posExt_ssubset [LinearOrder D] (μ : Entity → D) (
 
 end Equative
 
-end Semantics.Degree
+end Degree

--- a/Linglib/Semantics/Degree/Defs.lean
+++ b/Linglib/Semantics/Degree/Defs.lean
@@ -29,7 +29,7 @@ Klein-style delineation [klein-1980] has no measure function and lives in
 * `PositiveStandard`, `AdjectiveClass` — Kennedy-style classification carriers.
 -/
 
-namespace Semantics.Degree
+namespace Degree
 
 /-! ### Discrete bounded scales
 
@@ -240,4 +240,4 @@ def AdjectiveClass.IsRelative (c : AdjectiveClass) : Prop :=
 instance : DecidablePred AdjectiveClass.IsRelative :=
   fun c => decEq c .relativeGradable
 
-end Semantics.Degree
+end Degree

--- a/Linglib/Semantics/Degree/Differential.lean
+++ b/Linglib/Semantics/Degree/Differential.lean
@@ -22,7 +22,7 @@ not just an ordinal or interval scale. Hence "3 inches taller" ✓ but
 
 -/
 
-namespace Semantics.Degree.Differential
+namespace Degree.Differential
 
 -- ════════════════════════════════════════════════════
 -- § 1. Differential Semantics
@@ -148,4 +148,4 @@ def subcomparativeAdmissibility : List SubcomparativeAdmissibilityDatum :=
 #guard subcomparativeAdmissibility.all (λ d =>
   d.acceptable == admitsSubcomparative d.level)
 
-end Semantics.Degree.Differential
+end Degree.Differential

--- a/Linglib/Semantics/Degree/DirectedMeasure.lean
+++ b/Linglib/Semantics/Degree/DirectedMeasure.lean
@@ -37,7 +37,7 @@ Mathlib typeclass instances cannot be stored in record fields; the enum
 and the typeclass system serve different roles and both are real.
 -/
 
-namespace Semantics.Degree
+namespace Degree
 
 open Core.Order
 
@@ -127,4 +127,4 @@ theorem classA_blocked (μ : W → α) :
 
 end DirectedMeasure
 
-end Semantics.Degree
+end Degree

--- a/Linglib/Semantics/Degree/Extent.lean
+++ b/Linglib/Semantics/Degree/Extent.lean
@@ -41,7 +41,7 @@ itself. A faithful sortal formalization (typed `PosExt D` / `NegExt D`
 with a partial DEG) is not provided here.
 -/
 
-namespace Semantics.Degree
+namespace Degree
 
 variable {Entity D : Type*}
 
@@ -101,7 +101,7 @@ theorem compl_posExt [LinearOrder D] (μ : Entity → D) (x : Entity) :
 /-- Order-reversing equivalence between `posExt`- and `negExt`-inclusions.
     The Galois-antitone framing is `compl_subset_compl` specialized at
     `Iic`/`Ioi` via `compl_posExt`. Linglib's
-    `Semantics.Degree.Little.littlePred` defines
+    `Degree.Little.littlePred` defines
     [heim-2006]'s LITTLE as predicate complement; LITTLE is *not*
     this map (it operates on type ⟨d,t⟩, not the powerset lattice),
     but the algebraic shadow of LITTLE *is* this antitone identity. -/
@@ -124,4 +124,4 @@ theorem crossExtent_always_false [LinearOrder D]
     (μ : Entity → D) (a b : Entity) : ¬ crossExtentInclusion μ a b :=
   fun h => absurd (h (min_le_left (μ a) (μ b))) (not_lt.mpr (min_le_right _ _))
 
-end Semantics.Degree
+end Degree

--- a/Linglib/Semantics/Degree/Gradability/AntonymPrediction.lean
+++ b/Linglib/Semantics/Degree/Gradability/AntonymPrediction.lean
@@ -39,9 +39,9 @@ primitives via `Iff.rfl` bridges that survive substrate transparency
 
 namespace Semantics.Gradability
 
-open Semantics.Degree (Degree Threshold)
+open Degree (Degree Threshold)
 open Features (NegationType Asymmetry)
-open Semantics.Degree (positiveMeaning negativeMeaning antonymMeaning)
+open Degree (positiveMeaning negativeMeaning antonymMeaning)
 
 -- ============================================================================
 -- § 1. Two Extensional Denotations
@@ -132,7 +132,7 @@ theorem isContrary_strengthenedDenot {max : Nat} (tp : ThresholdPair max)
   · rw [disjoint_iff]
     funext d
     simp only [AntonymForm.strengthenedDenot, positiveMeaning', contraryNegMeaning,
-      Semantics.Degree.positiveMeaning, Semantics.Degree.negativeMeaning,
+      Degree.positiveMeaning, Degree.negativeMeaning,
       Pi.inf_apply, Pi.bot_apply, inf_Prop_eq]
     exact eq_false (fun ⟨h1, h2⟩ => absurd (h1.trans h2) (lt_asymm h))
   · rw [codisjoint_iff]
@@ -140,7 +140,7 @@ theorem isContrary_strengthenedDenot {max : Nat} (tp : ThresholdPair max)
     intro hco
     have hd := congrFun hco d
     simp only [AntonymForm.strengthenedDenot, positiveMeaning', contraryNegMeaning,
-      notContraryNegMeaning, Semantics.Degree.positiveMeaning, Semantics.Degree.negativeMeaning,
+      notContraryNegMeaning, Degree.positiveMeaning, Degree.negativeMeaning,
       Pi.sup_apply, Pi.top_apply, sup_Prop_eq] at hd hd1 hd2
     rcases of_eq_true hd with hp | hn
     · exact hd2 hp

--- a/Linglib/Semantics/Degree/Gradability/Antonymy.lean
+++ b/Linglib/Semantics/Degree/Gradability/Antonymy.lean
@@ -30,10 +30,10 @@ set_option autoImplicit false
 
 namespace Semantics.Gradability.Antonymy
 
-open Semantics.Degree (Degree Threshold Threshold.toNat)
+open Degree (Degree Threshold Threshold.toNat)
 open Semantics.Gradability (ThresholdPair contradictoryNeg
   positiveMeaning' contraryNegMeaning notContraryNegMeaning inGapRegion)
-open Semantics.Degree (positiveMeaning antonymMeaning)
+open Degree (positiveMeaning antonymMeaning)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Contradictory Negation: Involutory (DNE holds)
@@ -75,7 +75,7 @@ theorem contradictory_exhaustive {max : Nat}
     (d : Degree max) (tp : ThresholdPair max) :
     inGapRegion d tp ↔ notContraryNegMeaning d tp ∧ ¬ positiveMeaning' d tp := by
   simp only [inGapRegion, notContraryNegMeaning, positiveMeaning',
-             Semantics.Degree.positiveMeaning, not_lt]
+             Degree.positiveMeaning, not_lt]
 
 /-- When the gap is strict (θ_neg < θ_pos), there exists a degree that is
     "not unhappy" but NOT "happy" — double negation through contrary fails.
@@ -84,7 +84,7 @@ theorem contrary_gap_exists {max : Nat} (tp : ThresholdPair max)
     (h : (tp.neg : Degree max) < (tp.pos : Degree max)) :
     ∃ d : Degree max, notContraryNegMeaning d tp ∧ ¬ positiveMeaning' d tp := by
   refine ⟨↑tp.neg, le_refl _, ?_⟩
-  simp only [positiveMeaning', Semantics.Degree.positiveMeaning, not_lt]
+  simp only [positiveMeaning', Degree.positiveMeaning, not_lt]
   exact le_of_lt h
 
 /-- The gap region is nonempty when θ_neg < θ_pos. -/

--- a/Linglib/Semantics/Degree/Gradability/Basic.lean
+++ b/Linglib/Semantics/Degree/Gradability/Basic.lean
@@ -35,7 +35,7 @@ The intersective/subsective/privative classification lives in `Classification.le
 namespace Semantics.Gradability
 
 open Core.Order (Boundedness)
-open Semantics.Degree (Degree Threshold Degree.toNat Threshold.toNat deg thr allDegrees allThresholds
+open Degree (Degree Threshold Degree.toNat Threshold.toNat deg thr allDegrees allThresholds
   PositiveStandard AdjectiveClass interpretiveEconomy)
 open Features (NegationType)
 
@@ -60,11 +60,11 @@ through a `ThresholdPair`'s two poles. -/
 section TwoThreshold
 variable {max : Nat} (d : Degree max)
 
-/-- Contradictory negation *not happy* — `d ≤ θ` (`Semantics.Degree.antonymMeaning`). -/
-abbrev contradictoryNeg (θ : Threshold max) : Prop := Semantics.Degree.antonymMeaning d θ
+/-- Contradictory negation *not happy* — `d ≤ θ` (`Degree.antonymMeaning`). -/
+abbrev contradictoryNeg (θ : Threshold max) : Prop := Degree.antonymMeaning d θ
 
-/-- Contrary negation *unhappy* — `d < θ_neg` (`Semantics.Degree.negativeMeaning`). -/
-abbrev contraryNeg (θ_neg : Threshold max) : Prop := Semantics.Degree.negativeMeaning d θ_neg
+/-- Contrary negation *unhappy* — `d < θ_neg` (`Degree.negativeMeaning`). -/
+abbrev contraryNeg (θ_neg : Threshold max) : Prop := Degree.negativeMeaning d θ_neg
 
 /-- The gap region: `d` is neither positive nor negative (`neg ≤ d ≤ pos`). -/
 abbrev inGapRegion (tp : ThresholdPair max) : Prop :=
@@ -72,11 +72,11 @@ abbrev inGapRegion (tp : ThresholdPair max) : Prop :=
 
 /-- Positive form *happy* at the pair's upper threshold — `d > pos`. -/
 abbrev positiveMeaning' (tp : ThresholdPair max) : Prop :=
-  Semantics.Degree.positiveMeaning d tp.pos
+  Degree.positiveMeaning d tp.pos
 
 /-- Negative form *unhappy* at the pair's lower threshold — `d < neg`. -/
 abbrev contraryNegMeaning (tp : ThresholdPair max) : Prop :=
-  Semantics.Degree.negativeMeaning d tp.neg
+  Degree.negativeMeaning d tp.neg
 
 /-- *not unhappy* — the complement of the negative form (`neg ≤ d`). -/
 abbrev notContraryNegMeaning (tp : ThresholdPair max) : Prop :=
@@ -261,7 +261,7 @@ theorem negate_involutive (b : DimensionBindingType) :
 /-- [sassoon-2013] Hypothesis 3: standard type predicts binding type.
     Total (max standard) → conjunctive, partial (min standard) → disjunctive,
     relative (contextual) → mixed. -/
-def predictedBinding : Semantics.Degree.PositiveStandard → DimensionBindingType
+def predictedBinding : Degree.PositiveStandard → DimensionBindingType
   | .maxEndpoint  => .conjunctive
   | .minEndpoint  => .disjunctive
   | .contextual   => .mixed
@@ -270,10 +270,10 @@ def predictedBinding : Semantics.Degree.PositiveStandard → DimensionBindingTyp
 /-! ### Marginality scales ([dinis-jacinto-2026]) -/
 
 -- The tail of the file works with the full `DirectedMeasure`/order API.
-open Core.Order Semantics.Degree
+open Core.Order Degree
 
 structure GradableMLScale (α : Type*) [LinearOrder α] (W : Type*) extends
-    Semantics.Degree.DirectedMeasure α W where
+    Degree.DirectedMeasure α W where
   ml : Semantics.Gradability.MLScale α
 
 def marginalityPositive {α : Type*} [LinearOrder α]

--- a/Linglib/Semantics/Degree/Gradability/Dimension.lean
+++ b/Linglib/Semantics/Degree/Gradability/Dimension.lean
@@ -32,7 +32,7 @@ endpoint-licensing pipeline with `Boundedness`, `MereoTag`, and `EpistemicTag`.
 -/
 
 open Core.Order (Boundedness ScalePolarity LicensingPipeline)
-open Semantics.Degree (HasGreatest hasGreatest_of_orderTop not_hasGreatest_of_noMaxOrder)
+open Degree (HasGreatest hasGreatest_of_orderTop not_hasGreatest_of_noMaxOrder)
 open Features (Telicity VendlerClass)
 
 namespace Semantics.Gradability

--- a/Linglib/Semantics/Degree/Gradability/GradableNouns.lean
+++ b/Linglib/Semantics/Degree/Gradability/GradableNouns.lean
@@ -23,12 +23,12 @@ degree scale. The full denotation is:
 
 namespace Semantics.Gradability.GradableNouns
 
-open Semantics.Degree
+open Degree
 /-- Degree on a 0–10 scale, backed by the canonical `Degree 10` type. -/
-abbrev Degree := Semantics.Degree.Degree 10
+abbrev Degree := Degree.Degree 10
 
 /-- All degrees on the 0–10 scale. -/
-def allDegrees : List Degree := Semantics.Degree.allDegrees 10
+def allDegrees : List Degree := Degree.allDegrees 10
 
 /-- d0 is the minimum degree (from BoundedOrder). -/
 theorem d0_is_minimum : ∀ d : Degree, deg 0 ≤ d := λ d => bot_le (a := d)
@@ -62,7 +62,7 @@ def bigness (d : Degree) : Degree := d
 
 /-- Small: inverted ordering (0 maximally small, 10 minimally small). -/
 def smallness (d : Degree) : Degree :=
-  Semantics.Degree.Degree.ofNat 10 (10 - d.toNat)
+  Degree.Degree.ofNat 10 (10 - d.toNat)
 
 /-- Standard for "big" (contextual, typically middling). -/
 def bigStandard : Degree := deg 5

--- a/Linglib/Semantics/Degree/Gradability/Hierarchy.lean
+++ b/Linglib/Semantics/Degree/Gradability/Hierarchy.lean
@@ -50,7 +50,7 @@ namespace Semantics.Gradability.Hierarchy
 open Semantics.Gradability.Delineation
 open Semantics.Measurement (MeasureFn)
 open Features.Dimension (Dimension)
-open Semantics.Degree (HasMeasure)
+open Degree (HasMeasure)
 -- ════════════════════════════════════════════════════
 -- § 1. Measurement → Degree
 -- ════════════════════════════════════════════════════

--- a/Linglib/Semantics/Degree/Gradability/Intensification.lean
+++ b/Linglib/Semantics/Degree/Gradability/Intensification.lean
@@ -34,8 +34,8 @@ for the RSA pragmatic model.
 namespace Semantics.Gradability.Intensification
 
 open Features (EvaluativeValence)
-open Semantics.Degree (Degree Threshold Degree.toNat Threshold.toNat deg thr)
-open Semantics.Degree (positiveMeaning)
+open Degree (Degree Threshold Degree.toNat Threshold.toNat deg thr)
+open Degree (positiveMeaning)
 
 -- Evaluative Measure Functions
 

--- a/Linglib/Semantics/Degree/Gradability/MLScale.lean
+++ b/Linglib/Semantics/Degree/Gradability/MLScale.lean
@@ -9,7 +9,7 @@ relation M. From R (= `<`) and M one derives L (largely smaller than):
 L(x,y) := x < y ∧ ¬ M x y. Five axioms govern M; Theorem 2.2 derives
 M-TRANSITIVITY and M-BOUNDEDNESS as consequences.
 
-This sits alongside `DirectedMeasure` (in `Semantics.Degree`): a `DirectedMeasure`
+This sits alongside `DirectedMeasure` (in `Degree`): a `DirectedMeasure`
 determines licensing from boundedness, while an `MLScale` adds granularity
 structure (marginal vs. large difference) on the same `LinearOrder`.
 

--- a/Linglib/Semantics/Degree/Gradability/StatesBased.lean
+++ b/Linglib/Semantics/Degree/Gradability/StatesBased.lean
@@ -31,7 +31,7 @@ confidence ordering (CSW observation (72)).
 
 ## Architecture
 
-`StatesBasedEntry` extends `ComparativeScale` (from `Semantics.Degree`) with a
+`StatesBasedEntry` extends `ComparativeScale` (from `Degree`) with a
 contrast point. The background ordering is the ambient `[Preorder S]`.
 This is a competing theory to the standard threshold model in `Theory.lean`; the
 bridge theorem `statesBased_iff_kennedy` shows when they agree.

--- a/Linglib/Semantics/Degree/Granularity.lean
+++ b/Linglib/Semantics/Degree/Granularity.lean
@@ -38,7 +38,7 @@ This reversal explains why approximative *just* yields different readings:
   component derived from the reversal.
 -/
 
-namespace Semantics.Degree.Granularity
+namespace Degree.Granularity
 
 -- ════════════════════════════════════════════════════
 -- § 1. Granularity Intervals (eqs. 43, 45, 49)
@@ -258,4 +258,4 @@ theorem finer_granularity_refines (n ε₁ ε₂ : Nat) (hdvd : ε₁ ∣ ε₂)
 
 end GranularityQuestion
 
-end Semantics.Degree.Granularity
+end Degree.Granularity

--- a/Linglib/Semantics/Degree/HasMeasure.lean
+++ b/Linglib/Semantics/Degree/HasMeasure.lean
@@ -14,7 +14,7 @@ newtype wrappers (mathlib `Additive`/`Multiplicative` precedent). When an `Entit
 multiple measures, consumers disambiguate via explicit `(α := …)` or named instances.
 -/
 
-namespace Semantics.Degree
+namespace Degree
 
 /-- Typeclass for entities that carry a measurement on some scale — the
     formal-semantics measure function `μ : E → α`.
@@ -28,4 +28,4 @@ class HasMeasure (E : Type*) (α : Type*) where
 abbrev HasMeasure.measure {E α : Type*} [HasMeasure E α] : E → α :=
   HasMeasure.degree
 
-end Semantics.Degree
+end Degree

--- a/Linglib/Semantics/Degree/Intervals.lean
+++ b/Linglib/Semantics/Degree/Intervals.lean
@@ -22,9 +22,9 @@ commensurable scales; differentials specify the interval gap.
 * `subcomparative` — cross-dimensional comparison ([schwarzschild-wilkinson-2002]).
 -/
 
-namespace Semantics.Degree.Intervals
+namespace Degree.Intervals
 
-open Semantics.Degree
+open Degree
 
 /-! ### Intervals as degrees -/
 
@@ -103,4 +103,4 @@ theorem negativeInterval_membership {Entity D : Type*} [LinearOrder D] [BoundedO
     (negativeInterval μ x).fst ≤ d ↔ μ x ≤ d :=
   Iff.rfl
 
-end Semantics.Degree.Intervals
+end Degree.Intervals

--- a/Linglib/Semantics/Degree/Kennedy.lean
+++ b/Linglib/Semantics/Degree/Kennedy.lean
@@ -36,7 +36,7 @@ meanings are favoured).
   whenever the scale has an endpoint.
 -/
 
-namespace Semantics.Degree
+namespace Degree
 
 open Core.Order (Boundedness)
 
@@ -109,4 +109,4 @@ def IsClassA (b : Boundedness) : Prop :=
 instance : DecidablePred IsClassA :=
   fun b => inferInstanceAs (Decidable (interpretiveEconomy b).RequiresComparisonClass)
 
-end Semantics.Degree
+end Degree

--- a/Linglib/Semantics/Degree/Little.lean
+++ b/Linglib/Semantics/Degree/Little.lean
@@ -26,9 +26,9 @@ inverts the measured region.
 * `little_reverses_comparison` — LITTLE flips comparison direction
 -/
 
-namespace Semantics.Degree.Little
+namespace Degree.Little
 
-open Semantics.Degree (comparativeSem ScaleDirection taller_shorter_antonymy)
+open _root_.Degree (comparativeSem ScaleDirection taller_shorter_antonymy)
 
 /-- LITTLE on degree predicates: complementation. -/
 def littlePred {D : Type*} (P : D → Prop) : D → Prop :=
@@ -41,8 +41,8 @@ complement of the degree predicate for 'tall', exactly the relation
 between `posExt` and `negExt` from [kennedy-1999]. -/
 theorem little_posExt_eq_negExt {Entity D : Type*} [LinearOrder D]
     (μ : Entity → D) (x : Entity) (d : D) :
-    littlePred (· ∈ Semantics.Degree.posExt μ x) d ↔ d ∈ Semantics.Degree.negExt μ x := by
-  simp [littlePred, Semantics.Degree.posExt, Semantics.Degree.negExt]
+    littlePred (· ∈ Degree.posExt μ x) d ↔ d ∈ Degree.negExt μ x := by
+  simp [littlePred, Degree.posExt, Degree.negExt]
 
 /-- LITTLE is an involution: double degree negation cancels. -/
 theorem little_involution {D : Type*} (P : D → Prop) (d : D) :
@@ -56,4 +56,4 @@ theorem little_reverses_comparison {Entity α : Type*} [LinearOrder α]
     comparativeSem μ a b .positive ↔ comparativeSem μ b a .negative :=
   taller_shorter_antonymy μ a b
 
-end Semantics.Degree.Little
+end Degree.Little

--- a/Linglib/Semantics/Degree/MeasureFunction.lean
+++ b/Linglib/Semantics/Degree/MeasureFunction.lean
@@ -59,7 +59,7 @@ quantify over the scale's maximum (or its absence).
 
 -/
 
-namespace Semantics.Degree.MeasureFunction
+namespace Degree.MeasureFunction
 
 open Semantics.ArgumentStructure.Affectedness
 
@@ -92,7 +92,7 @@ set_option linter.dupNamespace false in
     `[SetLike]` (typeclass) interfaces.
 
     The duplicated `MeasureFunction` namespace (file-level
-    `Semantics.Degree.MeasureFunction` + the type itself) is harmless
+    `Degree.MeasureFunction` + the type itself) is harmless
     here — same pattern as mathlib's `Function` files. The `set_option
     linter.dupNamespace false in` immediately above silences the
     namespace-duplication warning for this single declaration. -/
@@ -273,4 +273,4 @@ def HasLatentScale.ofHasMeasureFunction
     HasLatentScale α (Event Time) where
   latentScale _ _ := True
 
-end Semantics.Degree.MeasureFunction
+end Degree.MeasureFunction

--- a/Linglib/Semantics/Degree/Measurement/Basic.lean
+++ b/Linglib/Semantics/Degree/Measurement/Basic.lean
@@ -188,7 +188,7 @@ per (entity, codomain) pair. For entities with multiple measurable dimensions,
 use `MeasureFn` directly — the typeclass projection is the specialization for
 when a single dimension is contextually salient. -/
 @[reducible]
-def MeasureFn.toHasDegree {E : Type*} (μ : MeasureFn E) : Semantics.Degree.HasMeasure E ℚ :=
+def MeasureFn.toHasDegree {E : Type*} (μ : MeasureFn E) : Degree.HasMeasure E ℚ :=
   { degree := μ.apply }
 
 -- ============================================================================

--- a/Linglib/Semantics/Degree/Predicate.lean
+++ b/Linglib/Semantics/Degree/Predicate.lean
@@ -27,7 +27,7 @@ This file is part of the Phase A decomposition of the legacy
 `Core/Scales/Scale.lean` dumping ground (master plan v4).
 -/
 
-namespace Semantics.Degree
+namespace Degree
 
 open Core.Order
 
@@ -300,4 +300,4 @@ theorem leOver_upMono {W : Type*} (μ : W → α) : IsUpwardMonotone (Comparison
     `isMaxInf_atMost_iff_eq`) live in
     `Semantics/Entailment/Extremum.lean`. -/
 
-end Semantics.Degree
+end Degree

--- a/Linglib/Semantics/Degree/Superlative.lean
+++ b/Linglib/Semantics/Degree/Superlative.lean
@@ -25,7 +25,7 @@ operators: wide scope yields relative, narrow scope yields absolute.
 
 -/
 
-namespace Semantics.Degree.Superlative
+namespace Degree.Superlative
 
 -- ════════════════════════════════════════════════════
 -- § 1. Absolute Superlative
@@ -104,7 +104,7 @@ theorem superlative_iff_universal_comparative {Entity D : Type*} [LinearOrder D]
     (μ : Entity → D) (C : Set Entity) (x : Entity) :
     absoluteSuperlative μ C x ↔
       x ∈ C ∧ ∀ y ∈ C, y ≠ x →
-        Semantics.Degree.comparativeSem μ x y .positive :=
+        Degree.comparativeSem μ x y .positive :=
   Iff.rfl
 
-end Semantics.Degree.Superlative
+end Degree.Superlative

--- a/Linglib/Semantics/Degree/ThanClause.lean
+++ b/Linglib/Semantics/Degree/ThanClause.lean
@@ -23,7 +23,7 @@ the degree set against which the matrix predicate is evaluated.
 
 -/
 
-namespace Semantics.Degree.ThanClause
+namespace Degree.ThanClause
 
 -- ════════════════════════════════════════════════════
 -- § 1. Than-Clause Denotation
@@ -88,7 +88,7 @@ theorem phrasal_clausal_equivalence {Entity D : Type*} [Preorder D]
     and Schwarzschild calls "positive interval". -/
 theorem thanClause_eq_posExt {Entity D : Type*} [Preorder D]
     (μ : Entity → D) (b : Entity) :
-    thanClauseDenotation μ b = Semantics.Degree.posExt μ b :=
+    thanClauseDenotation μ b = Degree.posExt μ b :=
   rfl
 
-end Semantics.Degree.ThanClause
+end Degree.ThanClause

--- a/Linglib/Semantics/Entailment/Extremum.lean
+++ b/Linglib/Semantics/Entailment/Extremum.lean
@@ -59,7 +59,7 @@ not their primary formulation.
 
 namespace Entailment
 
-open Semantics.Degree
+open Degree
 open Core.Order (Comparison)
 variable {α : Type*} [LinearOrder α]
 
@@ -265,7 +265,7 @@ entailment-theoretic MIP layer. -/
 
 /-- The maximally informative degree of a directed measure's derived
     property is the true measure value, whichever the direction. -/
-theorem _root_.Semantics.Degree.DirectedMeasure.isMaxInf_degreeProperty_iff
+theorem _root_.Degree.DirectedMeasure.isMaxInf_degreeProperty_iff
     {W : Type*} (dm : DirectedMeasure α W) (m : α) (w : W)
     (hSurj : Function.Surjective dm.μ) :
     IsMaxInf dm.degreeProperty m w ↔ dm.μ w = m := by
@@ -280,7 +280,7 @@ theorem _root_.Semantics.Degree.DirectedMeasure.isMaxInf_degreeProperty_iff
 /-- Direction-invariance, bundled: two directed measures sharing a measure
     function agree on maximal informativity regardless of direction or
     boundedness — the constructor-level form of `mip_direction_invariant`. -/
-theorem _root_.Semantics.Degree.DirectedMeasure.isMaxInf_degreeProperty_congr
+theorem _root_.Degree.DirectedMeasure.isMaxInf_degreeProperty_congr
     {W : Type*} (dm₁ dm₂ : DirectedMeasure α W) (hμ : dm₁.μ = dm₂.μ)
     (m : α) (w : W) (hSurj : Function.Surjective dm₁.μ) :
     IsMaxInf dm₁.degreeProperty m w ↔ IsMaxInf dm₂.degreeProperty m w := by

--- a/Linglib/Semantics/Numerals/Basic.lean
+++ b/Linglib/Semantics/Numerals/Basic.lean
@@ -232,41 +232,41 @@ theorem classB_includes_bare_world (e : Numeral.Entry) (bare : Nat → Nat → P
   exact h
 
 /-- Bare numeral pointwise entails "at least `m`" — the `id`-specialization
-    of `Semantics.Degree.eqOver_imp_geOver`. -/
+    of `Degree.eqOver_imp_geOver`. -/
 theorem classB_entailed_by_bare (m n : Nat) :
     bareMeaning m n → atLeastMeaning m n :=
-  Semantics.Degree.eqOver_imp_geOver id m n
+  Degree.eqOver_imp_geOver id m n
 
 /-- Exact bare numerals are not upward-monotone: the `id`-specialization of
-    `Semantics.Degree.eqOver_not_upward_monotone` (witness `d = 3`, `d' = 4`). -/
+    `Degree.eqOver_not_upward_monotone` (witness `d = 3`, `d' = 4`). -/
 theorem bare_not_upward_monotone :
     ¬ ∀ m m' n, m ≤ m' → bareMeaning m n → bareMeaning m' n := by
   intro h
-  exact Semantics.Degree.eqOver_not_upward_monotone (W := Nat) id (d := 3) (d' := 4)
+  exact Degree.eqOver_not_upward_monotone (W := Nat) id (d := 3) (d' := 4)
     (by decide) (by decide) (w := 3) rfl
     (fun x y hxy hex => h x y 3 hxy hex)
 
 /-- Bare numerals are not downward-monotone either, so they fail the
     Horn-scale criterion in both directions. The `id`-specialization of
-    `Semantics.Degree.eqOver_not_downward_monotone`. -/
+    `Degree.eqOver_not_downward_monotone`. -/
 theorem bare_not_downward_monotone :
     ¬ ∀ m m' n, m' ≤ m → bareMeaning m n → bareMeaning m' n := by
   intro h
-  exact Semantics.Degree.eqOver_not_downward_monotone (W := Nat) id (d := 3) (d' := 2)
+  exact Degree.eqOver_not_downward_monotone (W := Nat) id (d := 3) (d' := 2)
     (by decide) (by decide) (w := 3) rfl
     (fun x y hyx hex => h x y 3 hyx hex)
 
 /-- "At least `m`" is strictly weaker than "bare `m`" — the `id`-specialization
-    of `Semantics.Degree.geOver_strictly_weaker_than_eqOver` (witness `d' = m+1`). -/
+    of `Degree.geOver_strictly_weaker_than_eqOver` (witness `d' = m+1`). -/
 theorem atLeast_strictly_weaker_than_bare (m : Nat) :
     atLeastMeaning m (m + 1) ∧ ¬ bareMeaning m (m + 1) :=
-  Semantics.Degree.geOver_strictly_weaker_than_eqOver id (Nat.lt_succ_self m) (w := m + 1) rfl
+  Degree.geOver_strictly_weaker_than_eqOver id (Nat.lt_succ_self m) (w := m + 1) rfl
 
 /-- "More than `m`" and "bare `m`" have disjoint denotations — the
-    `id`-specialization of `Semantics.Degree.gtOver_disjoint_eqOver`. -/
+    `id`-specialization of `Degree.gtOver_disjoint_eqOver`. -/
 theorem moreThan_disjoint_from_bare (m n : Nat) :
     ¬ (bareMeaning m n ∧ moreThanMeaning m n) :=
-  Semantics.Degree.gtOver_disjoint_eqOver id m n
+  Degree.gtOver_disjoint_eqOver id m n
 
 -- ============================================================================
 -- Section 6: Type-Shifting ([kennedy-2015] §3.1)
@@ -274,20 +274,20 @@ theorem moreThan_disjoint_from_bare (m n : Nat) :
 
 /-! ## De-Fregean type-shifting: exact → lower-bound
 
-The general operation `Semantics.Degree.typeLower` (`∃ d' ≥ d, exact d' w`) and
+The general operation `Degree.typeLower` (`∃ d' ≥ d, exact d' w`) and
 its collapse `typeLower_eqOver_iff` (existentially lowering `Comparison.eq.over μ`
 yields `Comparison.ge.over μ`) live in `Semantics/Degree/Predicate.lean`.
 Numerals are the `id`-instantiation: `typeLower bareMeaning m n ↔ atLeastMeaning m n`
 follows by definitional unfolding (`bareMeaning ≡ Comparison.eq.over id`,
 `atLeastMeaning ≡ Comparison.ge.over id`).
 
-The general theorem `Semantics.Degree.distinct_no_universal_witness` rules out
+The general theorem `Degree.distinct_no_universal_witness` rules out
 the alternative universal-closure reading of Partee's iota. -/
 
-/-- The numeral instantiation of `Semantics.Degree.typeLower_eqOver_iff`. -/
+/-- The numeral instantiation of `Degree.typeLower_eqOver_iff`. -/
 theorem typeLower_bareMeaning_iff (m n : Nat) :
-    Semantics.Degree.typeLower bareMeaning m n ↔ atLeastMeaning m n :=
-  Semantics.Degree.typeLower_eqOver_iff id m n
+    Degree.typeLower bareMeaning m n ↔ atLeastMeaning m n :=
+  Degree.typeLower_eqOver_iff id m n
 
 -- ============================================================================
 -- Section 7: EXH–Type-Shift Duality ([spector-2013] §6.2 vs [kennedy-2015])

--- a/Linglib/Semantics/Quantification/Binominal.lean
+++ b/Linglib/Semantics/Quantification/Binominal.lean
@@ -154,7 +154,7 @@ property of N₂. -/
 
 section EM
 open Semantics.Gradability.Intensification (EvaluativeMeasure intensifiedMeaning)
-open Semantics.Degree (Degree Threshold Degree.toNat Threshold.toNat)
+open Degree (Degree Threshold Degree.toNat Threshold.toNat)
 /-- EM semantics: N₁ as evaluative modifier of a contextual property of N₂.
 
 "a hell of a game" = the game x such that the contextually-salient
@@ -243,7 +243,7 @@ Uses `muHorrible 10` as the evaluative measure for *hell*:
 
 section EMBIExample
 open Semantics.Gradability.Intensification (muHorrible EvaluativeMeasure)
-open Semantics.Degree (Degree deg thr)
+open Degree (Degree deg thr)
 /-- Quality measure for EM: contextually-determined goodness as a doctor.
 George (9) is an outstanding doctor; Sarah (6) is decent; Floyd (3) is poor. -/
 def doctorQuality : GradableNouns.Person → Degree 10
@@ -263,7 +263,7 @@ def hellEval : EvaluativeMeasure 10 := muHorrible 10
 theorem george_hell_of_doctor :
     emSemantics hellEval doctorQuality (thr 3) isDoctorB .george = true := by
   simp only [emSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
-             Semantics.Degree.Degree.toNat, Semantics.Degree.Threshold.toNat]
+             Degree.Degree.toNat, Degree.Threshold.toNat]
   norm_num
 
 /-- Sarah is not "a hell of a doctor": quality (6) yields
@@ -271,7 +271,7 @@ theorem george_hell_of_doctor :
 theorem sarah_not_hell_of_doctor :
     emSemantics hellEval doctorQuality (thr 3) isDoctorB .sarah = false := by
   simp only [emSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
-             Semantics.Degree.Degree.toNat, Semantics.Degree.Threshold.toNat]
+             Degree.Degree.toNat, Degree.Threshold.toNat]
   norm_num
 
 /-- George is "a hell of a good doctor": good(9 > 5) ✓ AND
@@ -280,8 +280,8 @@ theorem george_hell_of_good_doctor :
     biSemantics hellEval doctorQuality (thr 5) (thr 3) isDoctorB .george = true := by
   simp only [biSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
              Semantics.Gradability.Intensification.intensifiedMeaning,
-             Semantics.Degree.positiveMeaning,
-             Semantics.Degree.Degree.toNat, Semantics.Degree.Threshold.toNat,
+             Degree.positiveMeaning,
+             Degree.Degree.toNat, Degree.Threshold.toNat,
              Bool.and_eq_true, decide_eq_true_eq]
   refine ⟨trivial, ?_, ?_⟩
   · decide
@@ -293,8 +293,8 @@ theorem sarah_not_hell_of_good_doctor :
     biSemantics hellEval doctorQuality (thr 5) (thr 3) isDoctorB .sarah = false := by
   simp only [biSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
              Semantics.Gradability.Intensification.intensifiedMeaning,
-             Semantics.Degree.positiveMeaning,
-             Semantics.Degree.Degree.toNat, Semantics.Degree.Threshold.toNat,
+             Degree.positiveMeaning,
+             Degree.Degree.toNat, Degree.Threshold.toNat,
              Bool.and_eq_false_iff, decide_eq_false_iff_not]
   right
   push Not
@@ -328,7 +328,7 @@ The worked example witnesses both directions of independence:
     idiot-doctor) but fails `emSemantics` (she is not a hell-of-a-doctor). -/
 theorem ebnp_not_entails_em :
     ebnpSemantics exampleIdiot isDoctorB .sarah = true ∧
-    emSemantics hellEval doctorQuality (Semantics.Degree.thr 3) isDoctorB .sarah = false :=
+    emSemantics hellEval doctorQuality (Degree.thr 3) isDoctorB .sarah = false :=
   ⟨by decide, sarah_not_hell_of_doctor⟩
 
 end Quantification.Binominal

--- a/Linglib/Studies/AlexandropoulouGotzner2024.lean
+++ b/Linglib/Studies/AlexandropoulouGotzner2024.lean
@@ -60,10 +60,10 @@ bridge theorem all live in `AlexandropoulouGotzner2024JoS.lean`.
 namespace AlexandropoulouGotzner2024
 
 open Core.Order (Boundedness)
-open Semantics.Degree (Degree Threshold deg thr)
+open Degree (Degree Threshold deg thr)
 open Semantics.Gradability (GradableAdjective ThresholdPair inGapRegion
   positiveMeaning' contraryNegMeaning notContraryNegMeaning)
-open Semantics.Degree (positiveMeaning antonymMeaning positiveMeaning_monotone)
+open Degree (positiveMeaning antonymMeaning positiveMeaning_monotone)
 open English.Predicates.Adjectival
   (large small gigantic tiny clean dirty pristine filthy)
 

--- a/Linglib/Studies/AlexandropoulouGotzner2024JoS.lean
+++ b/Linglib/Studies/AlexandropoulouGotzner2024JoS.lean
@@ -79,12 +79,12 @@ derivation of the predictions from first principles.
 
 namespace AlexandropoulouGotzner2024JoS
 
-open Semantics.Degree (Degree Threshold)
+open Degree (Degree Threshold)
 open Features (NegationType Asymmetry)
 open Semantics.Gradability (GradableAdjective ThresholdPair positiveMeaning'
   contraryNegMeaning notContraryNegMeaning AntonymForm
   predictionForAntonymy predictionForEntry)
-open Semantics.Degree (antonymMeaning)
+open Degree (antonymMeaning)
 open English.Predicates.Adjectival
   (large clean gigantic)
 

--- a/Linglib/Studies/BeaverCondoravdi2003.lean
+++ b/Linglib/Studies/BeaverCondoravdi2003.lean
@@ -46,7 +46,7 @@ across historical alternatives.
 
 namespace Tense.TemporalConnectives.BeaverCondoravdi
 
-open Semantics.Degree (maxOnScale)
+open Degree (maxOnScale)
 variable {W T : Type*} [LinearOrder T]
 
 -- ============================================================================

--- a/Linglib/Studies/Beltrama2025.lean
+++ b/Linglib/Studies/Beltrama2025.lean
@@ -41,8 +41,8 @@ the grammar of adjectival mildness. *Natural Language Semantics* 33, 169--205.
 namespace Beltrama2025
 
 open Core.Order (Boundedness)
-open Semantics.Degree (PositiveStandard interpretiveEconomy positiveMeaning)
-open Semantics.Degree (AdjectiveClass)
+open Degree (PositiveStandard interpretiveEconomy positiveMeaning)
+open Degree (AdjectiveClass)
 
 -- ============================================================================
 -- § 1. Empirical Profile (Table 1)
@@ -414,7 +414,7 @@ theorem mpa_good_same_valence :
 -- § 12. Integration: DegPType.sufficiency (*enough* parallel)
 -- ============================================================================
 
-open Semantics.Degree (DegPType)
+open Degree (DegPType)
 
 /-- MPAs encode the same necessity component as *enough*
     ([beltrama-2025] §5.3; Nadathur 2023): the minimum degree

--- a/Linglib/Studies/BhattPancheva2004.lean
+++ b/Linglib/Studies/BhattPancheva2004.lean
@@ -75,8 +75,8 @@ open Minimalist.DegreeMovement
    isHeimKennedy_no_dependency isHeimKennedy_dependency_requires_high_DegP
    williams_scope_correlation williams_exempt_when_no_binding)
 open Core.Order (Comparison)
-open Semantics.Degree (gtOverSet_eq_singleton_of_isGreatest)
-open Semantics.Degree.ThanClause (thanClauseDenotation thanClauseMax thanClauseMax_isGreatest)
+open Degree (gtOverSet_eq_singleton_of_isGreatest)
+open Degree.ThanClause (thanClauseDenotation thanClauseMax thanClauseMax_isGreatest)
 open Semantics.Polarity (LicensingContext)
 open Semantics.Polarity.Licensing (contextProperties)
 

--- a/Linglib/Studies/Bresnan1973.lean
+++ b/Linglib/Studies/Bresnan1973.lean
@@ -70,9 +70,9 @@ against Fragment `formComp` entries.
 
 namespace Bresnan1973
 
-open Semantics.Degree (DegPType)
-open Semantics.Degree.ThanClause (ThanClauseType)
-open Semantics.Degree (comparativeSem)
+open Degree (DegPType)
+open Degree.ThanClause (ThanClauseType)
+open Degree (comparativeSem)
 open Core.Order (ScalePolarity Boundedness)
 -- ════════════════════════════════════════════════════
 -- § 1. QP Structure (Det + Q)

--- a/Linglib/Studies/BumfordRett2021.lean
+++ b/Linglib/Studies/BumfordRett2021.lean
@@ -73,7 +73,7 @@ namespace BumfordRett2021
 
 open RSA
 open Rett2015Implicature (Polarity)
-open Semantics.Degree (AdjectivalConstruction)
+open Degree (AdjectivalConstruction)
 
 -- ============================================================================
 -- § 1. World Type: Height × CC Center

--- a/Linglib/Studies/Buring2007.lean
+++ b/Linglib/Studies/Buring2007.lean
@@ -52,7 +52,7 @@ disambiguate the two, favoring Analysis 1.
 ## Formal Connections
 
 - **LITTLE as extent complement**: `littlePred` maps `posExt` to `negExt`,
-  connecting to [kennedy-1999]'s extent algebra in `Semantics.Degree`.
+  connecting to [kennedy-1999]'s extent algebra in `Degree`.
 - **Cross-polar anomaly = algebraic impossibility**: same-dimension
   cross-polar comparison requires `crossExtentInclusion`, which
   `crossExtent_always_false` proves is impossible on any linear order.
@@ -64,11 +64,11 @@ disambiguate the two, favoring Analysis 1.
 
 namespace Buring2007
 
-open Semantics.Degree (comparativeSem ScaleDirection taller_shorter_antonymy)
-open Semantics.Degree.Little (littlePred little_posExt_eq_negExt little_involution
+open Degree (comparativeSem ScaleDirection taller_shorter_antonymy)
+open Degree.Little (littlePred little_posExt_eq_negExt little_involution
   little_reverses_comparison)
-open Semantics.Degree.Intervals (subcomparative negativeInterval)
-open Semantics.Degree (posExt negExt crossExtentInclusion crossExtent_always_false)
+open Degree.Intervals (subcomparative negativeInterval)
+open Degree (posExt negExt crossExtentInclusion crossExtent_always_false)
 -- ════════════════════════════════════════════════════
 -- § 1. LITTLE: Degree Negation on Extents
 -- ════════════════════════════════════════════════════
@@ -88,8 +88,8 @@ open Semantics.Degree (posExt negExt crossExtentInclusion crossExtent_always_fal
 theorem little_positive_to_negative {Entity D : Type*}
     [LinearOrder D] [BoundedOrder D]
     (μ : Entity → D) (x : Entity) :
-    (negativeInterval μ x).fst = (Semantics.Degree.Intervals.positiveInterval μ x).snd := by
-  simp [negativeInterval, Semantics.Degree.Intervals.positiveInterval]
+    (negativeInterval μ x).fst = (Degree.Intervals.positiveInterval μ x).snd := by
+  simp [negativeInterval, Degree.Intervals.positiveInterval]
 
 -- ════════════════════════════════════════════════════
 -- § 2. Cross-Polar Anomaly: Algebraic Impossibility

--- a/Linglib/Studies/DeoThomas2025.lean
+++ b/Linglib/Studies/DeoThomas2025.lean
@@ -260,7 +260,7 @@ theorem all_flavors_attested :
 -- E. Construction → Flavor Bridge ([thomas-deo-2020])
 -- ============================================================================
 
-open Semantics.Degree (AdjectivalConstruction)
+open Degree (AdjectivalConstruction)
 
 /-- Derive *just* flavor from adjectival construction type.
     [thomas-deo-2020] predict:
@@ -446,7 +446,7 @@ theorem refinement_implies_wider {W : Type*}
 /-! ### The full chain: finer granularity → wider question
 
 Composes the two independently proved steps:
-1. `finer_granularity_refines` (from `Semantics.Degree.Granularity`):
+1. `finer_granularity_refines` (from `Degree.Granularity`):
    if ε₁ ∣ ε₂, the ε₁-partition refines the ε₂-partition
 2. `refinement_implies_wider` (proved above):
    strict partition refinement → issue width
@@ -455,7 +455,7 @@ This is the formal content of the lexical entry (36): *just* selects
 the widest answerable construal, which — when alternatives vary by
 granularity — is the finest one the speaker can answer. -/
 
-open Semantics.Degree.Granularity (granQUD finer_granularity_refines)
+open Degree.Granularity (granQUD finer_granularity_refines)
 
 /-- The complete granularity–width chain ([deo-thomas-2025] §3.1.2–3.2).
 

--- a/Linglib/Studies/Fine1975.lean
+++ b/Linglib/Studies/Fine1975.lean
@@ -45,7 +45,7 @@ is the existential dual of supervaluation. See
 namespace Fine1975
 
 open Core.Duality (Truth3)
-open Semantics.Degree (Degree Threshold Degree.toNat Threshold.toNat)
+open Degree (Degree Threshold Degree.toNat Threshold.toNat)
 open Semantics.Gradability (ThresholdPair inGapRegion)
 open Semantics.Supervaluation (SpecSpace superTrue definitely indefinite)
 

--- a/Linglib/Studies/FoxHackl2006.lean
+++ b/Linglib/Studies/FoxHackl2006.lean
@@ -34,7 +34,7 @@ dependency: 2006 imports 2001).
 
 namespace FoxHackl2006
 
-open Semantics.Degree.Abstraction (negatedDegreePredicate)
+open Degree.Abstraction (negatedDegreePredicate)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Basic Degree Question Data

--- a/Linglib/Studies/FoxHackl2006Numerals.lean
+++ b/Linglib/Studies/FoxHackl2006Numerals.lean
@@ -33,7 +33,7 @@ construction, no bridge lemma needed.
 
 namespace FoxHackl2006Numerals
 
-open Semantics.Degree
+open Degree
 open Entailment
 open Semantics.Numerals
 open Core.Order (Comparison)

--- a/Linglib/Studies/Gajewski2011.lean
+++ b/Linglib/Studies/Gajewski2011.lean
@@ -616,7 +616,7 @@ theorem bridge_hoeksema_gtOverSet_strawsonAA
     (defined : Set D → Entity → Prop) :
     IsStrawsonAntiAdditive (Core.Order.Comparison.gt.overSet μ) defined :=
   antiAdditive_implies_strawsonAA _
-    (Semantics.Degree.gtOverSet_isAntiAdditive μ) _
+    (Degree.gtOverSet_isAntiAdditive μ) _
 
 /-! ## Strong-NPI registry consistency
 

--- a/Linglib/Studies/Guerrini2026.lean
+++ b/Linglib/Studies/Guerrini2026.lean
@@ -277,7 +277,7 @@ truth conditions are extensional (`DIST` over the actual kind extension), hence
 *stronger* than any threshold generic. Prevalence is the bridge quantity. -/
 
 open TesslerGoodman2019 (genericMeaning GenThreshold)
-open Semantics.Degree (deg thr)
+open Degree (deg thr)
 
 /-- Prevalence of `P` among the atoms of an extension at `w`:
     `|{a ∈ ext | P a w}| / |ext|`. (Generalizes to

--- a/Linglib/Studies/Heim2001.lean
+++ b/Linglib/Studies/Heim2001.lean
@@ -77,11 +77,11 @@ re-exported below.
 namespace Heim2001
 
 open Set
-open Semantics.Degree.Abstraction
+open Degree.Abstraction
   (lowDegP_forall lowDegP_exists highDegP_forall highDegP_exists
    forall_more_high_to_low forall_more_low_to_high exists_more_scope_collapse
    negatedDegreePredicate negatedDegreePredicate_eq)
-open Semantics.Degree (comparativeSem)
+open Degree (comparativeSem)
 open Minimalist.DegreeMovement
   (IsHeimKennedy ScopeBinding not_isHeimKennedy_QP_above_bound_DegP)
 
@@ -306,7 +306,7 @@ theorem verbClass_predicts_highDegPAvailable :
 -- complement `R` twice in the semantic calculation (paper ex. (59)),
 -- giving evidence for DegP-movement independent of VP-ellipsis. The
 -- semantic decomposition `λR. λx. max{d : R(x,d)} > max{d : ∃y ≠ x. R(y,d)}`
--- is formalized as `Semantics.Degree.Superlative.absoluteSuperlative`;
+-- is formalized as `Degree.Superlative.absoluteSuperlative`;
 -- consumers should reference the substrate definition directly.
 --
 -- The contrast "Kim climbed the highest mountain" / "KIM climbed the

--- a/Linglib/Studies/Hoeksema1983.lean
+++ b/Linglib/Studies/Hoeksema1983.lean
@@ -96,7 +96,7 @@ open Semantics.Polarity.Licensing
 
 open Entailment
 open Core.Order (Comparison)
-open Semantics.Degree (gtOverSet_isAntiAdditive gtOverSet_atomic_eq_comparativeSem)
+open Degree (gtOverSet_isAntiAdditive gtOverSet_atomic_eq_comparativeSem)
 open Semantics.Polarity (LicensingContext)
 open Semantics.Polarity.Licensing (contextProperties)
 

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -1025,14 +1025,14 @@ theorem unless_licensing :
 - **Positive**: Q(Z, D) — Z has property Q to degree D
 - **Negative**: ¬Q(Z, D'), D' > D — Z does NOT have Q to degree D'
 
-In the degree semantics of `Semantics.Degree`:
+In the degree semantics of `Degree`:
   comparativeSem μ a b .positive ↔ μ(a) > μ(b)
 
 This entails: ∃D (= μ(b)) such that Q(Z, D), and ∃D' (= μ(a)) > D
 such that ¬Q(Z, D'). The dual predication over distinct degrees is
 what licenses EN in the complement of comparatives. -/
 
-open Semantics.Degree (comparativeSem)
+open Degree (comparativeSem)
 
 /-- A comparative entails dual degree predication: Y exceeds Z on
     the scale, so Q(Z, μ(Z)) holds but ¬Q(Z, μ(Y)) — dual inference
@@ -1048,7 +1048,7 @@ theorem comparative_dual_degrees {Entity : Type*} {α : Type*} [LinearOrder α]
 theorem comparative_antonymy_preserves_dual {Entity : Type*} {α : Type*}
     [LinearOrder α] (μ : Entity → α) (a b : Entity) :
     comparativeSem μ a b .positive ↔ comparativeSem μ b a .negative :=
-  Semantics.Degree.taller_shorter_antonymy μ a b
+  Degree.taller_shorter_antonymy μ a b
 
 /-- Comparatives map to the comparative licensing condition. -/
 theorem comparative_licensing :
@@ -1154,7 +1154,7 @@ theorem zarma_en_determined_by_aspect :
 | logicalOperator         | Modality.Kratzer             | not_impossible_activates_p   |
 |                         | Conditionals.Basic           | unless_modus_ponens          |
 |                         | (conjunction + negation)     | without_entails_not_p        |
-| comparative             | Semantics.Degree           | comparative_dual_degrees     |
+| comparative             | Degree           | comparative_dual_degrees     |
 -/
 
 /-- All four licensing conditions have at least one bridge theorem

--- a/Linglib/Studies/KatzirSingh2015.lean
+++ b/Linglib/Studies/KatzirSingh2015.lean
@@ -248,7 +248,7 @@ grade to all of his students. Kim is a professor."
 The QUD is good (we don't know Kim's grade). But "some" is needlessly
 weak: "all" is equally complex and semantically stronger.
 
-Connects to Semantics.Degree: the ⟦all⟧ ⊆ ⟦some⟧ entailment that drives
+Connects to Degree: the ⟦all⟧ ⊆ ⟦some⟧ entailment that drives
 the Answer Condition is the same relationship captured by
 `Alternatives.Quantifiers.entails.all.some_ = true`. -/
 

--- a/Linglib/Studies/Kennedy1999.lean
+++ b/Linglib/Studies/Kennedy1999.lean
@@ -24,11 +24,11 @@ the degree argument.
 3. **Cross-polar anomaly**: "Kim is as tall as Lee is short" is anomalous
    because the equative tries to compare a positive extent with a negative
    extent — structurally incompatible (proved always-false in
-   `Semantics.Degree.crossExtent_always_false`).
+   `Degree.crossExtent_always_false`).
 
 4. **Antonymy biconditional**: "BK is longer than The Idiot iff The Idiot is
    shorter than BK" is DERIVED from extent complementarity, not stipulated
-   as a lexical property (proved in `Semantics.Degree.antonymy_biconditional`).
+   as a lexical property (proved in `Degree.antonymy_biconditional`).
 
 5. **DegP projection**: Degree morphemes head their own syntactic phrase.
    This has been refined by [heim-2001] (sentential operator approach)
@@ -61,10 +61,10 @@ distribution), [bhatt-pancheva-2004] and [lechner-2004]
 
 namespace Kennedy1999
 
-open Semantics.Degree (comparativeSem equativeSem
+open Degree (comparativeSem equativeSem
   comparative_iff_posExt_ssubset comparative_iff_negExt_ssubset
   equativeSem_iff_posExt_subset)
-open Semantics.Degree (posExt negExt crossExtentInclusion crossExtent_always_false posExt_subset_iff negExt_subset_iff extent_galois_antitone)
+open Degree (posExt negExt crossExtentInclusion crossExtent_always_false posExt_subset_iff negExt_subset_iff extent_galois_antitone)
 -- ════════════════════════════════════════════════════
 -- § 1. Cross-Polar Anomaly Data
 -- ════════════════════════════════════════════════════
@@ -140,7 +140,7 @@ theorem samePolar_equative_welldefined {Entity D : Type*} [LinearOrder D]
 
 /-- "A is taller than B" iff B's positive extent is strictly contained
     in A's. Bridges the consensus comparative to the algebraic
-    `posExt_ssubset_iff` from `Semantics.Degree`. -/
+    `posExt_ssubset_iff` from `Degree`. -/
 theorem comparative_extent_bridge {Entity D : Type*} [LinearOrder D]
     (μ : Entity → D) (a b : Entity) :
     comparativeSem μ a b .positive ↔ posExt μ b ⊂ posExt μ a :=
@@ -187,12 +187,12 @@ theorem equative_antonymy_extent {Entity D : Type*} [LinearOrder D]
     who treats -er as a sentential operator rather than a DegP head.
     Both agree that degree binding is syntactic.
 
-    Note: the degree head inventory matches `Semantics.Degree.DegPType`
+    Note: the degree head inventory matches `Degree.DegPType`
     from `Degree/Defs.lean`, which is the current consensus enumeration.
     This historical structure records Kennedy's specific proposal that
     these heads project a full DegP phrase. -/
 structure HistoricalDegP where
-  head : Semantics.Degree.DegPType
+  head : Degree.DegPType
   adjective : String
   deriving Repr
 

--- a/Linglib/Studies/Kennedy2007.lean
+++ b/Linglib/Studies/Kennedy2007.lean
@@ -53,7 +53,7 @@ central claims against the degree substrate and the English adjective Fragment.
 
 namespace Kennedy2007
 
-open Semantics.Degree
+open Degree
 
 /-! ### Scale structure and Interpretive Economy
 
@@ -297,7 +297,7 @@ structure AdjectiveTypologyDatum where
   /-- The adjective -/
   adjective : String
   /-- Its classification -/
-  classification : Semantics.Degree.AdjectiveClass
+  classification : Degree.AdjectiveClass
   /-- The underlying scale name (e.g., "height", "fullness") -/
   scale : String
   /-- Scale structure (Kennedy 2007's 4-way typology), the canonical

--- a/Linglib/Studies/KennedyLevin2008.lean
+++ b/Linglib/Studies/KennedyLevin2008.lean
@@ -334,7 +334,7 @@ dimensions the K&L verbs measure. -/
 open Semantics.ArgumentStructure.Affectedness
 open Semantics.ArgumentStructure.Affectedness.Hierarchy
 open Semantics.Gradability (Dimension)
-open Semantics.Degree.MeasureFunction
+open Degree.MeasureFunction
 
 /-! #### Telicity from the scale's order structure (order-theoretic K&L thesis)
 

--- a/Linglib/Studies/Krifka2007.lean
+++ b/Linglib/Studies/Krifka2007.lean
@@ -65,12 +65,12 @@ set_option autoImplicit false
 
 namespace Krifka2007
 
-open Semantics.Degree (Degree Threshold deg thr)
+open Degree (Degree Threshold deg thr)
 open Semantics.Gradability (ThresholdPair inGapRegion
   positiveMeaning' contraryNegMeaning notContraryNegMeaning contradictoryNeg
   AntonymForm contradictoryDenot_synonymy strengthenedDenot_breaks_synonymy)
 open Semantics.Gradability.Antonymy
-open Semantics.Degree (positiveMeaning)
+open Degree (positiveMeaning)
 open Data.Examples
 open Features (NegationType)
 open Pragmatics.Bidirectional (superoptimal superoptimalSet

--- a/Linglib/Studies/MacuchSilvaEtAl2024.lean
+++ b/Linglib/Studies/MacuchSilvaEtAl2024.lean
@@ -172,7 +172,7 @@ theorem eighteen_allows_some :
 theorem zero_allows_none :
     strongestTruthfulPositive ⟨0, 60, Nat.zero_le 60⟩ = .none_ := by native_decide
 
-/-- The quantifier ordering matches the Horn scale from `Semantics.Degree` -/
+/-- The quantifier ordering matches the Horn scale from `Degree` -/
 theorem quantifier_ordering_matches_scale :
     Alternatives.Quantifiers.entails .all .most = true ∧
     Alternatives.Quantifiers.entails .most .some_ = true ∧

--- a/Linglib/Studies/Morzycki2009.lean
+++ b/Linglib/Studies/Morzycki2009.lean
@@ -44,7 +44,7 @@ predict the acceptability pattern recorded in the data below.
 namespace Morzycki2009
 
 open Semantics.Gradability.GradableNouns
-open Semantics.Degree (deg)
+open Degree (deg)
 -- ═══════════════════════════════════════════════════════════════
 -- Data: Bigness Generalization (§2.2)
 -- ═══════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Nouwen2024.lean
+++ b/Linglib/Studies/Nouwen2024.lean
@@ -605,13 +605,13 @@ namespace RSA.Nouwen2024
 
 instance : NeZero (6 : Nat) := ⟨by omega⟩
 
-abbrev Height := Semantics.Degree.Degree 6
-abbrev Threshold := Semantics.Degree.Threshold 6
+abbrev Height := Degree.Degree 6
+abbrev Threshold := Degree.Threshold 6
 
-open Semantics.Degree (deg thr)
+open Degree (deg thr)
 open Features (EvaluativeValence)
 open Semantics.Gradability.Intensification (EvaluativeMeasure)
-open Semantics.Degree (positiveMeaning)
+open Degree (positiveMeaning)
 
 /-- ⟦tall⟧(θ)(x) = 1 iff height(x) > θ, specialized to scale 6. -/
 def tallMeaning (θ : Threshold) (h : Height) : Bool :=
@@ -706,7 +706,7 @@ private lemma muHorrible_eq (h : Height) :
     (Semantics.Gradability.Intensification.muHorrible 6).mu h.toNat =
     (muHorrible h : ℚ) := by
   unfold Semantics.Gradability.Intensification.muHorrible muHorrible
-  fin_cases h <;> simp [Semantics.Degree.Degree.toNat] <;> norm_num
+  fin_cases h <;> simp [Degree.Degree.toNat] <;> norm_num
 
 /--
 The local horribly_warm meaning agrees with theory-layer `intensifiedMeaning`
@@ -725,7 +725,7 @@ private lemma muPleasant_eq (h : Height) :
     (Semantics.Gradability.Intensification.muPleasant 6).mu h.toNat =
     (muPleasant h : ℚ) := by
   unfold Semantics.Gradability.Intensification.muPleasant muPleasant
-  fin_cases h <;> simp [Semantics.Degree.Degree.toNat] <;> norm_num
+  fin_cases h <;> simp [Degree.Degree.toNat] <;> norm_num
 
 /--
 The local pleasantly_warm meaning agrees with theory-layer `intensifiedMeaning`

--- a/Linglib/Studies/Nouwen2024PMF.lean
+++ b/Linglib/Studies/Nouwen2024PMF.lean
@@ -125,7 +125,7 @@ namespace RSA.Nouwen2024.PMF
 
 open scoped ENNReal
 open RSA.Nouwen2024
-open Semantics.Degree (deg thr)
+open Degree (deg thr)
 /-! ## §1. Height prior as a PMF -/
 
 /-- Height prior weights as `ℝ≥0∞`. Reuses `heightPrior : Height → ℚ` from

--- a/Linglib/Studies/Rett2015.lean
+++ b/Linglib/Studies/Rett2015.lean
@@ -12,13 +12,13 @@ are evaluative, comparatives are not, equatives show asymmetry.
 
 `EvaluativityStatus`, `EvaluativityDatum`, `EvaluativityPrediction`
 
-`AdjectivalConstruction` is defined in `Semantics.Degree.Defs`.
+`AdjectivalConstruction` is defined in `Degree.Defs`.
 
 -/
 
 namespace Rett2015.Evaluativity
 
-open Semantics.Degree (AdjectivalConstruction)
+open Degree (AdjectivalConstruction)
 
 -- Evaluativity Judgments
 

--- a/Linglib/Studies/Rett2015Implicature.lean
+++ b/Linglib/Studies/Rett2015Implicature.lean
@@ -57,7 +57,7 @@ namespace Rett2015Implicature
 
 open Implicature
 open Implicature.Markedness
-open Semantics.Degree (AdjectivalConstruction)
+open Degree (AdjectivalConstruction)
 open Semantics.Gradability
 
 

--- a/Linglib/Studies/Rett2020.lean
+++ b/Linglib/Studies/Rett2020.lean
@@ -24,7 +24,7 @@ reference point is selected (all of B vs MAX of B).
 ## Level
 
 **Level 2 (interval sets)**: operates on `SentDenotation` directly, using
-`maxOnScale` from `Semantics.Degree` to select the informative bound.
+`maxOnScale` from `Degree` to select the informative bound.
 
 ## Bridges
 
@@ -47,7 +47,7 @@ open Core.Order
 open NonemptyInterval
 open Features
 open Features.ChangeOfState
-open Semantics.Degree (maxOnScale isAmbidirectional maxOnScale_singleton maxOnScale_lt_closedInterval maxOnScale_gt_closedInterval)
+open Degree (maxOnScale isAmbidirectional maxOnScale_singleton maxOnScale_lt_closedInterval maxOnScale_gt_closedInterval)
 variable {Time : Type*} [LinearOrder Time]
 
 -- ============================================================================

--- a/Linglib/Studies/Rett2026.lean
+++ b/Linglib/Studies/Rett2026.lean
@@ -41,7 +41,7 @@ Two types of EN with different syntactic positions and licensing:
 namespace Rett2026
 
 open Core.Order (Boundedness)
-open Semantics.Degree (isAmbidirectional)
+open Degree (isAmbidirectional)
 open English.Modifiers.Adjectives (AdjModifierEntry)
 
 /-- Manner implicature triggered by EN in an ambidirectional construction.
@@ -361,9 +361,9 @@ theorem while_isAmbidirectional_witness :
     ENConstruction.while_.isAmbidirectional = false := rfl
 
 /-- Cross-references `isAmbidirectional .comparative = true` to
-    the boundary singletons `Semantics.Degree.maxOnScale_ge_atMost` /
-    `Semantics.Degree.maxOnScale_atLeast_singleton`, plus
-    `Semantics.Degree.comparative_boundary`. -/
+    the boundary singletons `Degree.maxOnScale_ge_atMost` /
+    `Degree.maxOnScale_atLeast_singleton`, plus
+    `Degree.comparative_boundary`. -/
 theorem comparative_isAmbidirectional_witness :
     ENConstruction.comparative.isAmbidirectional = true := rfl
 

--- a/Linglib/Studies/RonderosEtAl2024.lean
+++ b/Linglib/Studies/RonderosEtAl2024.lean
@@ -154,7 +154,7 @@ is observable independent of any contrast manipulation.
 - **Connection to `Semantics/Degree/`**: Ronderos's semantic factor
   (scalar = gradable + comparison-class-dependent; color/material =
   non-gradable) is derived through `AdjType.toClass`, which maps each
-  adjective type to a Kennedy-style `Semantics.Degree.AdjectiveClass`.
+  adjective type to a Kennedy-style `Degree.AdjectiveClass`.
   The "scalar requires a comparison class" claim then follows from
   `AdjectiveClass.IsRelative`, grounded in gradability theory rather
   than projected via a perceptual-domain table.
@@ -200,7 +200,7 @@ def AdjType.toDomain : AdjType → Features.PropertyDomain
     scalar adjectives are gradable and interpreted against a comparison
     class (`relativeGradable`); color and material encode non-gradable
     properties (`nonGradable`), interpreted in absolute terms. -/
-def AdjType.toClass : AdjType → Semantics.Degree.AdjectiveClass
+def AdjType.toClass : AdjType → Degree.AdjectiveClass
   | .scalar   => .relativeGradable
   | .color    => .nonGradable
   | .material => .nonGradable

--- a/Linglib/Studies/Rouillard2026.lean
+++ b/Linglib/Studies/Rouillard2026.lean
@@ -85,7 +85,7 @@ open Semantics.Aspect
 open Semantics.Aspect.SubintervalProperty
 open Features
 open Core.Order
-open Semantics.Degree
+open Degree
 open Entailment
 open English.TemporalExpressions
 
@@ -326,7 +326,7 @@ theorem gTIAPropertyOpenNeg_downwardMonotone {μ : NonemptyInterval Time → α}
 
 `MIP_Licensed` and `MIP_LicensedDown` are defined in
     `Semantics/Entailment/Extremum.lean` and reused here. They
-    combine `Semantics.Degree.AdmitsOptimum P` (non-constancy: the *atelic*
+    combine `Degree.AdmitsOptimum P` (non-constancy: the *atelic*
     failure mode) with the per-world existence of a `Set.IsLeast` /
     `Set.IsGreatest` (mathlib): a most-informative numeral exists at some
     world. The two conjuncts capture two separate failure modes:

--- a/Linglib/Studies/Sassoon2013.lean
+++ b/Linglib/Studies/Sassoon2013.lean
@@ -65,7 +65,7 @@ namespace Sassoon2013
 open Semantics.Gradability (DimensionBindingType conjunctiveBinding
   disjunctiveBinding deMorgan_conjunctive_disjunctive
   deMorgan_disjunctive_conjunctive predictedBinding)
-open Semantics.Degree (interpretiveEconomy)
+open Degree (interpretiveEconomy)
 open Core.Order (Boundedness)
 -- ════════════════════════════════════════════════════
 -- § 1. Multidimensional Adjective Data

--- a/Linglib/Studies/ScontrasPearl2021Quantification.lean
+++ b/Linglib/Studies/ScontrasPearl2021Quantification.lean
@@ -312,7 +312,7 @@ theorem lowerBound_preserves_negation_scope :
 /-- [kennedy-2015]'s resolution: exact meaning is basic, lower-bound is derived
     via type-shift. Both meanings are grammatically available. -/
 theorem typeshift_resolves_tension :
-    Semantics.Degree.typeLower bareMeaning 2 2 ↔
+    Degree.typeLower bareMeaning 2 2 ↔
     atLeastMeaning 2 2 :=
   Semantics.Numerals.typeLower_bareMeaning_iff 2 2
 

--- a/Linglib/Studies/SedivyEtAl1999.lean
+++ b/Linglib/Studies/SedivyEtAl1999.lean
@@ -136,7 +136,7 @@ def adjDomain : Features.PropertyDomain := .size
     against a comparison class ([kennedy-2007], [kennedy-mcnally-2005]) —
     the structural prerequisite for Bierwisch's lexical account of the
     contrast effect (§5 of [sedivy-etal-1999]). -/
-def adjClass : Semantics.Degree.AdjectiveClass := .relativeGradable
+def adjClass : Degree.AdjectiveClass := .relativeGradable
 
 theorem adjClass_is_relative : adjClass.IsRelative := rfl
 
@@ -291,7 +291,7 @@ theorem trivial_satisfies_pattern :
 adopted in §5 of [sedivy-etal-1999]) places a free comparison-class
 variable in the lexical entry of every scalar adjective. Scalar adjectives
 are relative gradable adjectives ([kennedy-2007]); `adjClass_is_relative`
-records this via `Semantics.Degree.AdjectiveClass.IsRelative`.
+records this via `Degree.AdjectiveClass.IsRelative`.
 
 Note: Exp 1B nonetheless found contrast effects with intersective adjectives,
 attributed to *referential narrowing* rather than comparison-class binding.

--- a/Linglib/Studies/TenWolde2023.lean
+++ b/Linglib/Studies/TenWolde2023.lean
@@ -233,13 +233,13 @@ worked examples from `Semantics/Lexical/Noun/Binominal`. -/
 theorem entailment_summary :
     -- BI entails EM (bi_entails_em instantiated)
     (biSemantics (Semantics.Gradability.Intensification.muHorrible 10)
-      doctorQuality (Semantics.Degree.thr 5) (Semantics.Degree.thr 3) isDoctor .george = true →
+      doctorQuality (Degree.thr 5) (Degree.thr 3) isDoctor .george = true →
      emSemantics (Semantics.Gradability.Intensification.muHorrible 10)
-      doctorQuality (Semantics.Degree.thr 3) isDoctor .george = true) ∧
+      doctorQuality (Degree.thr 3) isDoctor .george = true) ∧
     -- EBNP and EM have different truth conditions
     (ebnpSemantics exampleIdiot isDoctor .sarah = true ∧
      emSemantics (Semantics.Gradability.Intensification.muHorrible 10)
-      doctorQuality (Semantics.Degree.thr 3) isDoctor .sarah = false) := by
+      doctorQuality (Degree.thr 3) isDoctor .sarah = false) := by
   constructor
   · exact bi_entails_em _ _ _ _ _ _
   · constructor <;> native_decide

--- a/Linglib/Studies/TesslerFranke2020PMF.lean
+++ b/Linglib/Studies/TesslerFranke2020PMF.lean
@@ -31,9 +31,9 @@ set_option autoImplicit false
 namespace TesslerFranke2020.PMF
 
 open scoped ENNReal
-open Semantics.Degree (Degree Threshold deg thr)
+open Degree (Degree Threshold deg thr)
 open Features (NegationType)
-open Semantics.Degree (positiveMeaning negativeMeaning)
+open Degree (positiveMeaning negativeMeaning)
 
 /-! ## §0. Domain types -/
 
@@ -60,7 +60,7 @@ abbrev NegLexicon := NegationType
 @[reducible] def LatentState := HThreshold × HThreshold × NegLexicon
 
 /-- Utterance meaning parameterized by thresholds and lexicon, grounded in
-shared `Semantics.Degree` predicates. -/
+shared `Degree` predicates. -/
 def utteranceMeaning (θ₁ θ₂ : HThreshold) (L : NegLexicon)
     (u : Utterance) (d : HappinessDeg) : Bool :=
   match u with

--- a/Linglib/Studies/TesslerGoodman2019.lean
+++ b/Linglib/Studies/TesslerGoodman2019.lean
@@ -19,7 +19,7 @@ as gradable adjectives. The scale is **prevalence** rather than height/degree:
 
     ⟦gen⟧(p, θ) = 1 if prevalence p > threshold θ
 
-This IS `positiveMeaning` from `Semantics.Degree` — the generic meaning is
+This IS `positiveMeaning` from `Degree` — the generic meaning is
 grounded in scalar adjective semantics by construction, not by bridge theorem.
 
 ## Model
@@ -102,11 +102,11 @@ set_option autoImplicit false
 
 namespace TesslerGoodman2019
 
-open Semantics.Degree (Degree Threshold deg thr allDegrees allThresholds Degree.toNat Threshold.toNat)
-open Semantics.Degree (positiveMeaning)
+open Degree (Degree Threshold deg thr allDegrees allThresholds Degree.toNat Threshold.toNat)
+open Degree (positiveMeaning)
 
 -- ============================================================================
--- § 1. Domain Types (reusing Semantics.Degree — same types as LassiterGoodman2017)
+-- § 1. Domain Types (reusing Degree — same types as LassiterGoodman2017)
 -- ============================================================================
 
 /-- Discretized prevalence: 0%, 5%, ..., 100% (21 values).
@@ -149,7 +149,7 @@ inductive Utterance where
 
 /-- ⟦gen⟧(p, θ) = p > θ.
 
-    This IS `positiveMeaning` from `Semantics.Degree` — the generic meaning
+    This IS `positiveMeaning` from `Degree` — the generic meaning
     function is literally the positive scalar adjective meaning applied to the
     prevalence scale. Grounded by construction. -/
 def genericMeaning (θ : GenThreshold) (p : Prevalence) : Bool :=

--- a/Linglib/Studies/TesslerGoodman2022.lean
+++ b/Linglib/Studies/TesslerGoodman2022.lean
@@ -99,8 +99,8 @@ set_option autoImplicit false
 
 namespace TesslerGoodman2022
 
-open Semantics.Degree (Degree Threshold deg thr allDegrees allThresholds Degree.toNat Threshold.toNat)
-open Semantics.Degree (positiveMeaning negativeMeaning)
+open Degree (Degree Threshold deg thr allDegrees allThresholds Degree.toNat Threshold.toNat)
+open Degree (positiveMeaning negativeMeaning)
 
 -- ============================================================================
 -- § 1. Domain Types
@@ -627,11 +627,11 @@ the CC is pragmatic/contextual, not a constituent of the logical form.
     bounded scale → endpoint standard → s fixed by scale → nothing to infer
 
 The chain connects three independent modules:
-1. `Semantics.Degree.interpretiveEconomy` (Theory: scale → standard type)
-2. `Semantics.Degree.PositiveStandard.RequiresComparisonClass` (Theory: standard → domain-dependent?)
+1. `Degree.interpretiveEconomy` (Theory: scale → standard type)
+2. `Degree.PositiveStandard.RequiresComparisonClass` (Theory: standard → domain-dependent?)
 3. `RSAConfig.L1_latent` with `Latent = ComparisonClass` (this file: infer CC) -/
 
-open Semantics.Degree (interpretiveEconomy PositiveStandard IsClassA)
+open Degree (interpretiveEconomy PositiveStandard IsClassA)
 
 /-- Height is an open-scale dimension: "tall" is relative (Class A). -/
 theorem height_is_classA : IsClassA Core.Order.Boundedness.open_ := trivial

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -92,7 +92,7 @@ open Semantics.Gradability.Aggregation (weightedScore boolMeasures
   spatialNormalizedScore spatialNormalizedBinding)
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Semantics.Lexical
-open Semantics.Degree (interpretiveEconomy)
+open Degree (interpretiveEconomy)
 open English.Predicates
 
 -- ════════════════════════════════════════════════════
@@ -487,7 +487,7 @@ theorem scratch_adj_verb_scale_agree :
 
 /-- Disturbance adjectives are licensed for degree modification by the
     Kennedy pipeline, just like *full* and *clean*. -/
-theorem cracked_licensed {max : Nat} {W : Type*} (μ : W → Semantics.Degree.Degree max) :
+theorem cracked_licensed {max : Nat} {W : Type*} (μ : W → Degree.Degree max) :
     (adjMeasure μ Adjectival.cracked).IsLicensed :=
   closedAdj_licensed μ Adjectival.cracked rfl
 theorem cracked_pipeline_licensed :
@@ -624,7 +624,7 @@ theorem crack_refutes_strict_hkl_matrix :
     `Boundedness` level — both are `.closed`, hence both license degree
     modification. -/
 theorem cracked_licensing_converges_with_kennedy2007
-    {max : Nat} {W : Type*} (μ : W → Semantics.Degree.Degree max) :
+    {max : Nat} {W : Type*} (μ : W → Degree.Degree max) :
     (adjMeasure μ Adjectival.cracked).IsLicensed ↔
     (adjMeasure μ Adjectival.full).IsLicensed :=
   iff_of_true (closedAdj_licensed μ Adjectival.cracked rfl)
@@ -999,14 +999,14 @@ theorem solt_tham_share_substrate_bounded_by_one :
     of the closed scale is load-bearing for which prediction. -/
 theorem cracked_ie_max_vs_tham_lower_bound :
     interpretiveEconomy Adjectival.cracked.scaleType =
-      Semantics.Degree.PositiveStandard.maxEndpoint ∧
+      Degree.PositiveStandard.maxEndpoint ∧
     crack.simplePredicationObjective = true ∧
     -- The two endpoints of a closed scale are distinct standards,
     -- yet both are required for different aspects of *cracked*'s
     -- meaning per Tham §3.4 (lower = physical instantiation,
     -- upper = spatial extent).
-    Semantics.Degree.PositiveStandard.maxEndpoint ≠
-      Semantics.Degree.PositiveStandard.minEndpoint := by
+    Degree.PositiveStandard.maxEndpoint ≠
+      Degree.PositiveStandard.minEndpoint := by
   refine ⟨rfl, rfl, ?_⟩; decide
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/ThomasDeo2020.lean
+++ b/Linglib/Studies/ThomasDeo2020.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Degree.Basic
 # Granularity and *Just*: Degree Morphology [thomas-deo-2020]
 
 Grounds the approximative readings of *just* with degree constructions in
-the granularity semantics of `Semantics.Degree.Granularity`: with
+the granularity semantics of `Degree.Granularity`: with
 equatives the negative component of *just* is vacuous (`just_vacuous_iff`,
 "just as tall as" ≈ "exactly"), while with comparatives it forces failure
 at coarser grains (`just_rules_out`, "just taller than" ≈ "barely").
@@ -20,8 +20,8 @@ at coarser grains (`just_rules_out`, "just taller than" ≈ "barely").
 
 namespace ThomasDeo2020
 
-open Semantics.Degree.Granularity
-open Semantics.Degree (AdjectivalConstruction)
+open Degree.Granularity
+open Degree (AdjectivalConstruction)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Formal Grounding

--- a/Linglib/Studies/VonFintel1999.lean
+++ b/Linglib/Studies/VonFintel1999.lean
@@ -491,7 +491,7 @@ theorem bridge_lahiri_glad_settle_overgeneration :
 
 /-- **Hoeksema's S-comparative is anti-additive, hence trivially Strawson-DE.**
     [hoeksema-1983] proves the S-comparative anti-additive
-    (`Semantics.Degree.gtOverSet_isAntiAdditive`); the
+    (`Degree.gtOverSet_isAntiAdditive`); the
     inheritance chain AA → DE → Strawson-DE makes the bridge automatic.
 
     This places the S-comparative in the same Strawson-DE class as
@@ -503,6 +503,6 @@ theorem bridge_hoeksema_gtOverSet_strawsonDE
     (defined : Set D → Entity → Prop) :
     IsStrawsonDE (Core.Order.Comparison.gt.overSet μ) defined :=
   antitone_implies_strawsonDE _
-    (Semantics.Degree.gtOverSet_isAntiAdditive μ).antitone defined
+    (Degree.gtOverSet_isAntiAdditive μ).antitone defined
 
 end VonFintel1999

--- a/Linglib/Studies/VonStechow1984.lean
+++ b/Linglib/Studies/VonStechow1984.lean
@@ -38,9 +38,9 @@ is simpler and better motivated than competing scope-based analyses.
 
 namespace VonStechow1984
 
-open Semantics.Degree (comparativeSem equativeSem ScaleDirection)
-open Semantics.Degree.Abstraction (IsMaxDeg)
-open Semantics.Degree.Differential (differentialComparative factorEquative)
+open Degree (comparativeSem equativeSem ScaleDirection)
+open Degree.Abstraction (IsMaxDeg)
+open Degree.Differential (differentialComparative factorEquative)
 /-! ### Intensional degree semantics
 
 Migrated from `Semantics/Degree/Intensional.lean` (single-paper
@@ -675,7 +675,7 @@ structure TooCounterfactualDatum where
   sentence : String
   differential : String
   counterfactualBase : String
-  degPType : Semantics.Degree.DegPType
+  degPType : Degree.DegPType
   deriving Repr
 
 def tooData : List TooCounterfactualDatum :=

--- a/Linglib/Studies/Wellwood2015.lean
+++ b/Linglib/Studies/Wellwood2015.lean
@@ -573,7 +573,7 @@ theorem max_eq_comparativeSem {Entity Time Measured : Type*} [LinearOrder Time]
     (hb : role b eb ∧ P eb)
     (hb_unique : ∀ e, role b e → P e → e = eb) :
     comparativeTruth role P extract μ a b ↔
-      Semantics.Degree.comparativeSem
+      Degree.comparativeSem
         (μ ∘ extract) ea eb .positive :=
   comparativeTruth_max ha ha_unique hb hb_unique
 


### PR DESCRIPTION
Re-land of #1037, which showed MERGED but stranded into a defunct base (stacked-squash on `degree-core-defs`): its merge commit never reached main, so the rename isn't actually live.

Drops the redundant `Semantics.` prefix so the degree hub uses a bare `Degree` namespace (mathlib-idiomatic — cf. `Filter`, not `Order.Filter`). Namespace references only; the `Linglib.Semantics.Degree.*` import paths (the directory) are unchanged. 76 files, 212 refs.

Two self-opens inside the Degree namespace tree were fixed for the `Degree.Degree` type-dup (`Basic` drops a redundant `open`; `Little` uses `open _root_.Degree`); consumer opens resolve to root fine.