### PR TITLE
refactor(Semantics/Degree): recut Defs, re-home AdjectivalConstruction

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1695,6 +1695,7 @@ import Linglib.Semantics.Degree.Gradability.Antonymy
 import Linglib.Semantics.Degree.Gradability.Basic
 import Linglib.Semantics.Degree.Gradability.Classification
 import Linglib.Semantics.Degree.Gradability.ClauseEmbedding
+import Linglib.Semantics.Degree.Gradability.Construction
 import Linglib.Semantics.Degree.Gradability.Delineation
 import Linglib.Semantics.Degree.Gradability.Dimension
 import Linglib.Semantics.Degree.Gradability.GradableNouns

--- a/Linglib/Pragmatics/Implicature/Markedness.lean
+++ b/Linglib/Pragmatics/Implicature/Markedness.lean
@@ -23,6 +23,7 @@ The key point: these are objective, measurable properties. Different theories
 -/
 
 import Linglib.Semantics.Degree.Gradability.Basic
+import Linglib.Semantics.Degree.Gradability.Construction
 import Linglib.Fragments.English.Predicates.Adjectival
 import Mathlib.Data.Rat.Defs
 

--- a/Linglib/Semantics/Degree/Defs.lean
+++ b/Linglib/Semantics/Degree/Defs.lean
@@ -23,10 +23,11 @@ Klein-style delineation [klein-1980] has no measure function and lives in
 ## Main definitions
 
 * `Degree max`, `Threshold max` — discrete bounded scale types (`Fin`-backed).
-* `DegPType`, `StandardType` — DegP compositional taxonomy.
-* `ModifierDirection` — amplifier / downtoner axis.
-* `AdjectivalConstruction` — surface-construction type for evaluativity.
+* `DegPType` — DegP compositional taxonomy.
 * `PositiveStandard`, `AdjectiveClass` — Kennedy-style classification carriers.
+
+Adjectival surface-construction types (`AdjectivalConstruction`) live in
+`Gradability/Construction.lean`.
 -/
 
 namespace Degree
@@ -128,53 +129,6 @@ inductive DegPType where
   /-- *enough*. -/
   | sufficiency
   deriving DecidableEq, Repr
-
-/-- The standard of comparison: what the degree is compared to. -/
-inductive StandardType where
-  /-- "taller than Bill" — explicit standard. -/
-  | explicit
-  /-- "tall" — contextually determined standard. -/
-  | contextual
-  /-- "full" — scale endpoint as standard. -/
-  | absolute
-  deriving DecidableEq, Repr
-
-/-- Degree modifier direction — the same axis as NPI scalar direction.
-Lexical instantiations of named modifiers (*slightly*, *very*, *quite*,
-etc.) live in consuming Studies files. -/
-inductive ModifierDirection where
-  /-- *very*, *extremely* — raises the threshold. -/
-  | amplifier
-  /-- *slightly*, *kind of* — lowers the threshold. -/
-  | downtoner
-  deriving DecidableEq, Repr
-
-/-- Degree construction type. Used by evaluativity analyses to track which
-surface constructions trigger evaluative readings. -/
-inductive AdjectivalConstruction where
-  /-- "Kim is tall" — unmarked form. -/
-  | positive
-  /-- "Kim is taller than Sam". -/
-  | comparative
-  /-- "Kim is as tall as Sam". -/
-  | equative
-  /-- "Kim is 6 feet tall" — explicit measure phrase. -/
-  | measurePhrase
-  /-- "How tall is Kim?". -/
-  | degreeQuestion
-  deriving Repr, DecidableEq
-
-/-- User-facing rendering, distinct from `Repr` (which prefixes the
-namespace). Consumed by Studies files that string-interpolate construction
-names into diagnostic messages — see e.g.
-`Studies/Rett2015Implicature.lean`. -/
-instance : ToString AdjectivalConstruction where
-  toString
-    | .positive => "positive"
-    | .comparative => "comparative"
-    | .equative => "equative"
-    | .measurePhrase => "measurePhrase"
-    | .degreeQuestion => "degreeQuestion"
 
 /-! ### Kennedy-style classification carriers -/
 

--- a/Linglib/Semantics/Degree/Gradability/Construction.lean
+++ b/Linglib/Semantics/Degree/Gradability/Construction.lean
@@ -1,0 +1,43 @@
+/-!
+# Adjectival construction types
+
+The surface constructions a gradable adjective participates in — positive,
+comparative, equative, measure phrase, degree question. Evaluativity analyses
+track which constructions trigger evaluative readings ([rett-2015]); markedness
+implicature computes alternatives over them
+(`Pragmatics/Implicature/Markedness.lean`).
+
+The degree-substrate DegP taxonomy (`DegPType`, covering degree *heads* rather
+than adjectival surface constructions) lives in `Semantics/Degree/Defs.lean`.
+-/
+
+namespace Degree
+
+/-- Degree construction type. Used by evaluativity analyses to track which
+surface constructions trigger evaluative readings. -/
+inductive AdjectivalConstruction where
+  /-- "Kim is tall" — unmarked form. -/
+  | positive
+  /-- "Kim is taller than Sam". -/
+  | comparative
+  /-- "Kim is as tall as Sam". -/
+  | equative
+  /-- "Kim is 6 feet tall" — explicit measure phrase. -/
+  | measurePhrase
+  /-- "How tall is Kim?". -/
+  | degreeQuestion
+  deriving Repr, DecidableEq
+
+/-- User-facing rendering, distinct from `Repr` (which prefixes the
+namespace). Consumed by Studies files that string-interpolate construction
+names into diagnostic messages — see e.g.
+`Studies/Rett2015Implicature.lean`. -/
+instance : ToString AdjectivalConstruction where
+  toString
+    | .positive => "positive"
+    | .comparative => "comparative"
+    | .equative => "equative"
+    | .measurePhrase => "measurePhrase"
+    | .degreeQuestion => "degreeQuestion"
+
+end Degree

--- a/Linglib/Studies/BumfordRett2021.lean
+++ b/Linglib/Studies/BumfordRett2021.lean
@@ -1,5 +1,6 @@
 import Linglib.Tactics.RSAPredict
 import Linglib.Pragmatics.RSA.Basic
+import Linglib.Semantics.Degree.Gradability.Construction
 import Linglib.Studies.Rett2015Implicature
 import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Fintype.Prod
@@ -454,7 +455,7 @@ def utterancePolarity : Utterance → Option Polarity
   | .null     => none
 
 /-- Construction labels for each simulation, connecting to the
-    `AdjectivalConstruction` type from `Degree.Defs`. -/
+    `AdjectivalConstruction` type from `Semantics/Degree/Gradability/Construction.lean`. -/
 abbrev posConstruction  : AdjectivalConstruction := .positive
 abbrev eqConstruction   : AdjectivalConstruction := .equative
 abbrev compConstruction : AdjectivalConstruction := .comparative

--- a/Linglib/Studies/DeoThomas2025.lean
+++ b/Linglib/Studies/DeoThomas2025.lean
@@ -31,6 +31,7 @@ import Linglib.Semantics.Questions.Basic
 import Linglib.Semantics.Questions.Granularity
 import Linglib.Semantics.Mood.PartitionAsInquiry
 import Linglib.Semantics.Degree.Granularity
+import Linglib.Semantics.Degree.Gradability.Construction
 import Linglib.Data.Examples.DeoThomas2025
 import Linglib.Studies.ThomasDeo2020
 

--- a/Linglib/Studies/Rett2015.lean
+++ b/Linglib/Studies/Rett2015.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Rat.Defs
 import Linglib.Semantics.Degree.Gradability.Basic
+import Linglib.Semantics.Degree.Gradability.Construction
 
 /-!
 # Evaluativity: Empirical Patterns
@@ -12,7 +13,7 @@ are evaluative, comparatives are not, equatives show asymmetry.
 
 `EvaluativityStatus`, `EvaluativityDatum`, `EvaluativityPrediction`
 
-`AdjectivalConstruction` is defined in `Degree.Defs`.
+`AdjectivalConstruction` is defined in `Semantics/Degree/Gradability/Construction.lean`.
 
 -/
 

--- a/Linglib/Studies/Rett2015Implicature.lean
+++ b/Linglib/Studies/Rett2015Implicature.lean
@@ -2,6 +2,7 @@ import Mathlib.Data.Rat.Defs
 import Linglib.Pragmatics.Implicature.Basic
 import Linglib.Pragmatics.Implicature.Markedness
 import Linglib.Semantics.Degree.Gradability.Basic
+import Linglib.Semantics.Degree.Gradability.Construction
 import Linglib.Studies.Rett2015
 
 /-!

--- a/Linglib/Studies/ThomasDeo2020.lean
+++ b/Linglib/Studies/ThomasDeo2020.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Degree.Granularity
 import Linglib.Semantics.Degree.Basic
+import Linglib.Semantics.Degree.Gradability.Construction
 
 /-!
 # Granularity and *Just*: Degree Morphology [thomas-deo-2020]


### PR DESCRIPTION
Defs.lean audit (#5 of the Degree architecture audit): move `AdjectivalConstruction` to `Gradability/Construction.lean` (its consumers are evaluativity studies + markedness implicature, no core Degree file); delete dead `ModifierDirection` + `StandardType` (zero consumers); `DegPType`/`PositiveStandard`/`AdjectiveClass` stay (degree-general consumers verified).