### PR TITLE
feat(Core/Order): ground metalinguistic comparative in l-lifting

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -213,6 +213,7 @@ import Linglib.Core.Order.ComparativeProbability.Patterns
 import Linglib.Core.Order.ComparativeProbability.Representability
 import Linglib.Core.Order.ComparativeProbability.Systems
 import Linglib.Core.Order.ComparativeScale
+import Linglib.Core.Order.TotalPreorder
 import Linglib.Core.Order.Comparison
 import Linglib.Core.Order.Flat
 import Linglib.Core.Order.FourierMotzkin

--- a/Linglib/Core/Order/ComparativeProbability/Systems.lean
+++ b/Linglib/Core/Order/ComparativeProbability/Systems.lean
@@ -341,6 +341,27 @@ theorem dominationLift_axiomT (hRefl : ∀ w, ge_w w w) :
 theorem dominationLift_axiomJ : RightUnion (dominationLift ge_w) :=
   fun _ _ _ hAB hAC b hb => hb.elim (hAB b) (hAC b)
 
+/-- Over a **total** relation, the strict l-lifting collapses to Lewis's
+∃∀ comparative possibility: some A-point strictly dominates every B-point.
+This is the form the metalinguistic comparative takes in
+[rudolph-kocurek-2024] (there bounded to the cone below an evaluation index,
+with worlds read as semantic interpretations). -/
+theorem strict_dominationLift_iff (hTotal : ∀ a b, ge_w a b ∨ ge_w b a)
+    (A B : Set W) :
+    ComparativeProbability.Strict (dominationLift ge_w) A B ↔
+    ∃ a ∈ A, ∀ b ∈ B, ge_w a b ∧ ¬ ge_w b a := by
+  constructor
+  · rintro ⟨-, hn⟩
+    unfold dominationLift at hn
+    push Not at hn
+    obtain ⟨a, haA, ha⟩ := hn
+    exact ⟨a, haA, fun b hbB =>
+      ⟨(hTotal a b).resolve_right (ha b hbB), ha b hbB⟩⟩
+  · rintro ⟨a, haA, ha⟩
+    refine ⟨fun b hbB => ⟨a, haA, (ha b hbB).1⟩, fun h => ?_⟩
+    obtain ⟨b, hbB, hba⟩ := h a haA
+    exact (ha b hbB).2 hba
+
 /-- The l-lifting satisfies determination by singletons. -/
 theorem dominationLift_axiomDS : DeterminedBySingletons (dominationLift ge_w) :=
   fun _ b hAb =>

--- a/Linglib/Core/Order/TotalPreorder.lean
+++ b/Linglib/Core/Order/TotalPreorder.lean
@@ -1,0 +1,97 @@
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Order.Defs.Unbundled
+
+/-!
+# Bundled decidable total preorders
+
+A `TotalPreorder α` bundles a relation with mathlib's unbundled relation-class
+laws (`IsPreorder`, `Std.Total`) and decidability. Bundled — unlike a
+`Preorder` instance — because consumers quantify over orderings of a fixed
+carrier: plausibility frames rank worlds ([lewis-1973] comparative
+similarity), and metalinguistic common grounds are *sets* of ordering-world
+pairs ranking semantic interpretations ([rudolph-kocurek-2024]), so orderings
+must be first-class data.
+
+## Main declarations
+
+* `TotalPreorder` — the bundle, with `lt`, `equiv`, and `ofBool` (construction
+  from a Boolean table, for finite models).
+* `IsMaximal`, `AcceptedAt` — top-ranked points, and truth of a predicate
+  throughout them (Stalnaker-style acceptance on a plausibility frame).
+-/
+
+namespace Core.Order
+
+/-- A bundled total preorder with decidability. Laws are carried as mathlib's
+unbundled relation classes, registered as instances. -/
+structure TotalPreorder (α : Type*) where
+  /-- The preorder relation: `le a b` means a is ranked no higher than b. -/
+  le : α → α → Prop
+  /-- Reflexivity and transitivity, as mathlib's unbundled relation class. -/
+  isPreorder : IsPreorder α le
+  /-- Totality, as mathlib's unbundled relation class. -/
+  total : Std.Total le
+  /-- Decidability of the ordering. -/
+  decRel : DecidableRel le
+
+attribute [instance] TotalPreorder.isPreorder TotalPreorder.total
+  TotalPreorder.decRel
+
+namespace TotalPreorder
+
+variable {α : Type*} (ord : TotalPreorder α)
+
+/-- Reflexivity (mathlib's `Std.Refl`, field-style). -/
+theorem le_refl (a : α) : ord.le a a := Std.Refl.refl a
+
+/-- Transitivity (mathlib's `IsTrans`, field-style). -/
+theorem le_trans (a b c : α) : ord.le a b → ord.le b c → ord.le a c :=
+  IsTrans.trans a b c
+
+/-- Totality (mathlib's `Std.Total`, field-style). -/
+theorem le_total (a b : α) : ord.le a b ∨ ord.le b a := Std.Total.total a b
+
+/-- Strict ordering: a is ranked strictly below b. -/
+def lt (a b : α) : Prop := ord.le a b ∧ ¬ ord.le b a
+
+instance decRelLt : DecidableRel ord.lt := fun _ _ =>
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-- Equivalence: a and b are ranked at the same level. -/
+def equiv (a b : α) : Prop := ord.le a b ∧ ord.le b a
+
+instance decRelEquiv : DecidableRel ord.equiv := fun _ _ =>
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-- ¬(a < b) → b ≤ a (by totality). -/
+theorem le_of_not_lt {a b : α} (h : ¬ ord.lt a b) : ord.le b a :=
+  Classical.byContradiction fun hba => h ⟨(ord.le_total a b).resolve_right hba, hba⟩
+
+/-- Construct a `TotalPreorder` from a Bool-valued table — the convenient
+form for concrete finite models defined by pattern matching. -/
+def ofBool {α : Type*} (f : α → α → Bool)
+    (h_refl : ∀ a, f a a = true)
+    (h_trans : ∀ a b c, f a b = true → f b c = true → f a c = true)
+    (h_total : ∀ a b, f a b = true ∨ f b a = true) :
+    TotalPreorder α where
+  le a b := f a b = true
+  isPreorder := { refl := h_refl, trans := h_trans }
+  total := ⟨h_total⟩
+  decRel _ _ := inferInstance
+
+/-- A top-ranked point: no point is ranked strictly above it. -/
+def IsMaximal (x : α) : Prop := ∀ y, ¬ ord.lt x y
+
+instance [Fintype α] (x : α) : Decidable (ord.IsMaximal x) := by
+  unfold IsMaximal; infer_instance
+
+/-- Acceptance: a predicate holds throughout the top-ranked points. -/
+def AcceptedAt (A : α → Prop) : Prop := ∀ x, ord.IsMaximal x → A x
+
+instance [Fintype α] (A : α → Prop) [DecidablePred A] :
+    Decidable (ord.AcceptedAt A) := by
+  unfold AcceptedAt; infer_instance
+
+end TotalPreorder
+
+end Core.Order

--- a/Linglib/Studies/RudolphKocurek2024.lean
+++ b/Linglib/Studies/RudolphKocurek2024.lean
@@ -1,6 +1,8 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Tactic.DeriveFintype
 import Linglib.Discourse.CommonGround
+import Linglib.Core.Order.TotalPreorder
+import Linglib.Core.Order.ComparativeProbability.Systems
 import Linglib.Semantics.Degree.Comparative
 import Linglib.Semantics.Degree.Gradability.Delineation
 
@@ -53,67 +55,13 @@ structure Interpretation (W : Type*) (Pred : Type*) (Entity : Type*) where
   /-- Extension of predicate P at world w: the entities P applies to. -/
   ext : Pred → W → Entity → Bool
 
-/-- A semantic ordering is a total preorder on a set of interpretations,
-representing a speaker's relative interpretive commitments: `le i j` means
-the speaker is at least as committed to j as to i. Bundled with decidability
-so that finite models compute (`decide`). -/
-structure SemanticOrdering (I : Type*) where
-  /-- The preorder relation: `le i j` means i is ranked no higher than j. -/
-  le : I → I → Prop
-  /-- Reflexivity and transitivity, as mathlib's unbundled relation class. -/
-  isPreorder : IsPreorder I le
-  /-- Totality, as mathlib's unbundled relation class. Registered as
-  instances, so the mathlib relation API applies to `ord.le` directly. -/
-  total : Std.Total le
-  /-- Decidability of the ordering relation -/
-  decRel : DecidableRel le
+open Core.Order (TotalPreorder)
 
-attribute [instance] SemanticOrdering.isPreorder SemanticOrdering.total
-  SemanticOrdering.decRel
-
-namespace SemanticOrdering
-
-variable {I : Type*} (ord : SemanticOrdering I)
-
-/-- Reflexivity (mathlib's `Std.Refl`, field-style). -/
-theorem le_refl (i : I) : ord.le i i := Std.Refl.refl i
-
-/-- Transitivity (mathlib's `IsTrans`, field-style). -/
-theorem le_trans (i j k : I) : ord.le i j → ord.le j k → ord.le i k :=
-  IsTrans.trans i j k
-
-/-- Totality (mathlib's `Std.Total`, field-style). -/
-theorem le_total (i j : I) : ord.le i j ∨ ord.le j i := Std.Total.total i j
-
-/-- Strict ordering: i is ranked strictly below j. -/
-def lt (i j : I) : Prop := ord.le i j ∧ ¬ ord.le j i
-
-instance decRelLt : DecidableRel ord.lt := fun _ _ =>
-  inferInstanceAs (Decidable (_ ∧ _))
-
-/-- Equivalence: i and j are ranked at the same level. -/
-def equiv (i j : I) : Prop := ord.le i j ∧ ord.le j i
-
-instance decRelEquiv : DecidableRel ord.equiv := fun _ _ =>
-  inferInstanceAs (Decidable (_ ∧ _))
-
-/-- ¬(a < b) → b ≤ a (by totality). -/
-theorem le_of_not_lt {a b : I} (h : ¬ ord.lt a b) : ord.le b a :=
-  Classical.byContradiction fun hba => h ⟨(ord.le_total a b).resolve_right hba, hba⟩
-
-end SemanticOrdering
-
-/-- Construct a `SemanticOrdering` from a Bool-valued table — the convenient
-form for concrete models defined by pattern matching. -/
-def SemanticOrdering.ofBool {I : Type*} (f : I → I → Bool)
-    (h_refl : ∀ i, f i i = true)
-    (h_trans : ∀ i j k, f i j = true → f j k = true → f i k = true)
-    (h_total : ∀ i j, f i j = true ∨ f j i = true) :
-    SemanticOrdering I where
-  le i j := f i j = true
-  isPreorder := { refl := h_refl, trans := h_trans }
-  total := ⟨h_total⟩
-  decRel _ _ := inferInstance
+/-- A semantic ordering — the paper's ranking of interpretations by strength
+of interpretive commitment ([rudolph-kocurek-2024] §4.2) — IS the substrate's
+bundled decidable total preorder (`Core.Order.TotalPreorder`), the same frame
+object that ranks worlds in Lewisian plausibility semantics. -/
+abbrev SemanticOrdering (I : Type*) := TotalPreorder I
 
 /-! ### Formulas -/
 
@@ -196,6 +144,27 @@ theorem eval_mc_iff (A B : MFormula Pred Entity) (ord : SemanticOrdering I)
         ¬ Eval interpFn A ord i'' w → ord.lt i'' i' :=
   Iff.rfl
 
+/-- **Grounding in the comparative-probability substrate**: the metalinguistic
+comparative is the *strict l-lifting* of the semantic ordering
+([holliday-icard-2013]; Lewis's lifting), applied to the cone at or below the
+evaluation index — ≻ is comparative possibility over interpretations rather
+than worlds, and the ∃∀ clause of the paper's semantics is exactly the
+strict Smyth order via `strict_dominationLift_iff`. -/
+theorem eval_mc_iff_strict_dominationLift (A B : MFormula Pred Entity)
+    (ord : SemanticOrdering I) (i : I) (w : W) :
+    Eval interpFn (.mc A B) ord i w ↔
+    ComparativeProbability.Strict
+      (ComparativeProbability.dominationLift (fun a b => ord.le b a))
+      {x | ord.le x i ∧ Eval interpFn A ord x w ∧ ¬ Eval interpFn B ord x w}
+      {x | ord.le x i ∧ Eval interpFn B ord x w ∧ ¬ Eval interpFn A ord x w} := by
+  rw [eval_mc_iff,
+    ComparativeProbability.strict_dominationLift_iff (fun a b => ord.le_total b a)]
+  constructor
+  · rintro ⟨x, h1, h2, h3, hdom⟩
+    exact ⟨x, ⟨h1, h2, h3⟩, fun b ⟨hb1, hb2, hb3⟩ => hdom b hb1 hb2 hb3⟩
+  · rintro ⟨x, ⟨h1, h2, h3⟩, hdom⟩
+    exact ⟨x, h1, h2, h3, fun b hb1 hb2 hb3 => hdom b ⟨hb1, hb2, hb3⟩⟩
+
 /-! ### General entailment facts
 
 Of the supplement's Fact 3 entailment patterns, those that follow directly from
@@ -223,19 +192,14 @@ theorem eval_me_comm (φ ψ : MFormula Pred Entity) (ord : SemanticOrdering I)
 
 /-! ### Assertoric Content -/
 
-/-- Is interpretation i maximal in the ordering? -/
-def IsMaximal (ord : SemanticOrdering I) (i : I) : Prop := ∀ i', ¬ ord.lt i i'
-
-instance [Fintype I] (ord : SemanticOrdering I) (i : I) :
-    Decidable (IsMaximal ord i) := by unfold IsMaximal; infer_instance
-
-/-- Assertoric content: A is true at all ≤-maximal interpretations. A speaker
-accepts A iff on every ordering-world pair they leave open, A holds at every
-top-ranked interpretation. Acceptance-preservation — entailment at the level
-of assertoric content — is nonclassical (see `mc_disj_not_accepted`). -/
+/-- Assertoric content: A is true at all ≤-maximal interpretations — the
+substrate's `TotalPreorder.AcceptedAt` acceptance operator. A speaker accepts
+A iff on every ordering-world pair they leave open, A holds at every
+top-ranked interpretation. Acceptance-preservation is nonclassical (see
+`mc_disj_not_accepted`). -/
 def AssertoricContent [Fintype I] (φ : MFormula Pred Entity)
     (ord : SemanticOrdering I) (w : W) : Prop :=
-  ∀ i, IsMaximal ord i → Eval interpFn φ ord i w
+  ord.AcceptedAt (fun i => Eval interpFn φ ord i w)
 
 instance [Fintype I] (φ : MFormula Pred Entity) (ord : SemanticOrdering I) (w : W) :
     Decidable (AssertoricContent interpFn φ ord w) := by
@@ -1443,7 +1407,7 @@ inductive I3 | i0 | i1 | i2
 
 /-- Linear ordering: i0 ≤ i1 ≤ i2. -/
 def ord₃ : SemanticOrdering I3 :=
-  SemanticOrdering.ofBool
+  .ofBool
     (λ i j => match i, j with
       | .i0, _ => true
       | .i1, .i0 => false
@@ -1490,7 +1454,7 @@ inductive I2 | j0 | j1
 
 /-- Tied ordering: j0 ≡ j1 (both maximal). -/
 def tiedOrd : SemanticOrdering I2 :=
-  SemanticOrdering.ofBool
+  .ofBool
     (λ _ _ => true)
     (by intro i; cases i <;> rfl)
     (by intro i j k _ _; cases i <;> cases j <;> cases k <;> rfl)
@@ -1744,7 +1708,7 @@ inductive I4 | i | j | k | l
 j and k are tied at the middle level — this is essential for the
 equatives La ≈ Pa and Pa ≈ Ca to hold (witnesses block each other). -/
 def ord₄ : SemanticOrdering I4 :=
-  SemanticOrdering.ofBool
+  .ofBool
     (λ x y => match x, y with
       | .l, _ => true
       | .j, .l => false


### PR DESCRIPTION
The metalinguistic comparative has a logic backing already in the substrate: Holliday–Icard's comparative-probability systems (`Core/Order/ComparativeProbability/`), whose `dominationLift` is Lewis's l-lifting of a world preorder to propositions.

- **`Systems.lean`** gains `strict_dominationLift_iff`: over a *total* relation, the strict l-lift collapses to Lewis's ∃∀ comparative possibility — exactly the shape of [rudolph-kocurek-2024]'s MC clause.
- **New `Core/Order/TotalPreorder.lean`**: the bundled decidable total preorder (laws as mathlib relation classes) with `lt`/`equiv`/`ofBool` + `IsMaximal`/`AcceptedAt` — the frame object shared by Lewisian plausibility semantics and interpretation-ranking; graduated from the study, where it was `SemanticOrdering`.
- **Study**: `SemanticOrdering := TotalPreorder` (paper vocabulary as an abbrev), `AssertoricContent := ord.AcceptedAt …`, and the new grounding theorem `eval_mc_iff_strict_dominationLift`: ≻ IS the strict l-lifting of the semantic ordering on the cone below the index — comparative possibility over interpretations rather than worlds. The paper-faithful ∃∀ recursion stays definitional (it must: inside conditionals the restricted ordering is non-total, where the equivalence fails).